### PR TITLE
Add Birk's law and update light collection model

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.h
@@ -38,6 +38,11 @@ class PHG4HcalSteppingAction : public PHG4SteppingAction
     light_balance_outer_radius_ = outer_radius;
     light_balance_outer_corr_ = outer_corr;
   }
+
+  void SetLightScintModel(const bool b = true)
+  {
+    light_scint_model_ = b;
+  }
   
   private:
 
@@ -51,6 +56,7 @@ class PHG4HcalSteppingAction : public PHG4SteppingAction
   float zmin;
   float zmax;
 
+  bool  light_scint_model_;
   bool  light_balance_;
   float light_balance_inner_radius_;
   float light_balance_inner_corr_;

--- a/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
@@ -39,6 +39,7 @@ PHG4HcalSubsystem::PHG4HcalSubsystem( const std::string &na, const int lyr):
   layer(lyr),
   detector_type(na),
   superdetector("NONE"),
+  light_scint_model_(true),
   light_balance_(false),
   light_balance_inner_radius_(0.0),
   light_balance_inner_corr_(1.0),
@@ -124,6 +125,7 @@ int PHG4HcalSubsystem::InitRun( PHCompositeNode* topNode )
 					    light_balance_inner_corr_,
 					    light_balance_outer_radius_,
 					    light_balance_outer_corr_);
+	steppingAction_->SetLightScintModel(light_scint_model_);
       }
     }
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.h
@@ -71,6 +71,10 @@ class PHG4HcalSubsystem: public PHG4Subsystem
     light_balance_outer_radius_ = outer_radius;
     light_balance_outer_corr_ = outer_corr;
   }
+  void SetLightScintModel(const bool b = true)
+  {
+    light_scint_model_ = b;
+  }
   
   void Print(const std::string &what = "ALL") const;
 
@@ -100,6 +104,7 @@ class PHG4HcalSubsystem: public PHG4Subsystem
   std::string detector_type;
   std::string superdetector;
 
+  bool  light_scint_model_;
   bool  light_balance_;
   float light_balance_inner_radius_;
   float light_balance_inner_corr_;

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
@@ -34,6 +34,11 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
     light_balance_outer_radius_ = outer_radius;
     light_balance_outer_corr_ = outer_corr;
   }
+
+  void SetLightScintModel(const bool b = true)
+  {
+    light_scint_model_ = b;
+  }
   
   private:
 
@@ -45,6 +50,7 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
   PHG4HitContainer * absorberhits_;
   PHG4Hit *hit;
 
+  bool  light_scint_model_;
   bool  light_balance_;
   float light_balance_inner_radius_;
   float light_balance_inner_corr_;

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -31,6 +31,7 @@ PHG4OuterHcalSubsystem::PHG4OuterHcalSubsystem( const std::string &name, const i
   blackhole(0),
   detector_type(name),
   superdetector("NONE"),
+  light_scint_model_(true),
   light_balance_(false),
   light_balance_inner_radius_(0.0),
   light_balance_inner_corr_(1.0),
@@ -115,6 +116,7 @@ int PHG4OuterHcalSubsystem::Init( PHCompositeNode* topNode )
 					    light_balance_outer_radius_,
 					    light_balance_outer_corr_);
       }
+      steppingAction_->SetLightScintModel(light_scint_model_);
     }
   if (blackhole && !active)
     {

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
@@ -67,7 +67,10 @@ class PHG4OuterHcalSubsystem: public PHG4Subsystem
     light_balance_outer_radius_ = outer_radius;
     light_balance_outer_corr_ = outer_corr;
   }
-  
+  void SetLightScintModel(const bool b = true)
+   {
+     light_scint_model_ = b;
+   }
 
   void BlackHole(const int i=1) {blackhole = i;}
 
@@ -97,6 +100,7 @@ class PHG4OuterHcalSubsystem: public PHG4Subsystem
   std::string detector_type;
   std::string superdetector;
 
+  bool  light_scint_model_;
   bool  light_balance_;
   float light_balance_inner_radius_;
   float light_balance_inner_corr_;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
@@ -22,6 +22,7 @@
 #include <fun4all/getClass.h>
 
 #include <Geant4/G4Step.hh>
+#include <Geant4/G4MaterialCutsCouple.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 
 #include <iostream>
@@ -154,8 +155,32 @@ PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       hit->set_edep(hit->get_edep() + edep);
       hit->set_eion(hit->get_eion() + eion);
 
-      double light_yield = GetVisibleEnergyDeposition(aStep);
+      double light_yield = 0;
+      if (isactive == PHG4SpacalDetector::FIBER_CORE) // the slat ids start with zero
+        {
+          light_yield = GetVisibleEnergyDeposition(aStep);
+
+          static bool once = true;
+          if (once and edep>0)
+            {
+              once = false;
+
+              cout << "PHG4SpacalSteppingAction::UserSteppingAction::"
+                  //
+                  << detector_->GetName() << " - "
+                  << " use scintillating light model at each Geant4 steps. "
+                  <<"First step: "
+                  <<"Material = "<<aTrack->GetMaterialCutsCouple()->GetMaterial()->GetName()<<", "
+                  <<"Birk Constant = "<<aTrack->GetMaterialCutsCouple()->GetMaterial()->GetIonisation()->GetBirksConstant()<<","
+                  <<"edep = " <<edep<<", "
+                  <<"eion = " <<eion<<", "
+                  <<"light_yield = " <<light_yield
+                  << endl;
+            }
+
+        }
       hit->set_light_yield(hit->get_light_yield() + light_yield);
+
       if (hit->get_z(1) > get_zmax() || hit->get_z(1) < get_zmin())
         {
           cout << "PHG4SpacalSteppingAction: hit outside acceptance get_zmin() "


### PR DESCRIPTION
To get the branch: 
https://github.com/sPHENIX-Collaboration/coresoftware/tree/HCalWithCorrection 
To check the proposed update:
https://github.com/sPHENIX-Collaboration/coresoftware/compare/HCalWithCorrection 
To try it out in compiled binary:
You can use my local build at /phenix/u/jinhuang/work/sPHENIX/simulation//install/lib
To try it out with a DST reader:
Run /direct/phenix+sim02/phnxreco/ePHENIX/jinhuang/simulation/test/SPACAL_test/Fun4All_G4_sPHENIX.C
One example output file in ROOT readable format:
/direct/phenix+sim02/phnxreco/ePHENIX/jinhuang/simulation/test/SPACAL_test/G4sPHENIXCells.root_DSTReader.root

The changes are:

Change 1: Besides saving raw Geant4 energy deposition in the original edep variable, now we also save another variable proportional to the visible energy deposition or light yield as PHG4Hitv6:: set_light_yield()

Change 2: by default, Birk’s correction is applied to all three calorimeter systems. It can be switched off in macro with something like PHG4OuterHcalSubsystem:: SetLightScintModel(false); 
You can compare the total energy deposition VS ionization energy loss VS visible energy, by directly inspect the above ROOT file:
[jinhuang@rcas2077 SPACAL_test]$ root G4sPHENIXCells.root_DSTReader.root
root [0] 
root [1] T->Scan("Sum$(G4HIT_CEMC.edep):Sum$(G4HIT_CEMC.eion):Sum$(G4HIT_CEMC.light_yield)")
************************************************
*    Row   * Sum$(G4HI * Sum$(G4HI * Sum$(G4HI *
************************************************
*        0 * 0.0148168 * 0.0146101 * 0.0101124 *
*        1 * 0.0139606 * 0.0135287 * 0.0060525 *
************************************************
(Long64_t)2
root [2] T->Scan("Sum$(G4HIT_HCALIN.edep):Sum$(G4HIT_HCALIN.eion):Sum$(G4HIT_HCALIN.light_yield)")
************************************************
*    Row   * Sum$(G4HI * Sum$(G4HI * Sum$(G4HI *
************************************************
*        0 * 0.1916093 * 0.1894691 * 0.1337106 *
*        1 * 0.1126987 * 0.1103420 * 0.0859741 *
************************************************
(Long64_t)2
root [3] T->Scan("Sum$(G4HIT_HCALOUT.edep):Sum$(G4HIT_HCALOUT.eion):Sum$(G4HIT_HCALOUT.light_yield)")
************************************************
*    Row   * Sum$(G4HI * Sum$(G4HI * Sum$(G4HI *
************************************************
*        0 * 0.2190678 * 0.2135585 * 0.1441620 *
*        1 * 0.1744929 * 0.1720843 * 0.1596879 *
************************************************

Change 3: The hit position dependent light collection correction is now applied to light_yield, on top of birk’s corrected energy deposition. This correction is by default OFF. But it can be turned ON with macro like, PHG4HcalSubsystem:: SetLightCorrection(float inner_radius, float inner_corr,   float outer_radius, float outer_corr) ; <- This is Chris’ code

Please give it a try and let me know if there is any comment. If it runs well, I will do the merge. 
