### PR TITLE
added method to generate particles of fixed total momentum

### DIFF
--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
@@ -48,6 +48,7 @@ PHG4SimpleEventGenerator::PHG4SimpleEventGenerator(const string &name):
   _phi_max(M_PI),
   _pt_min(0.0),
   _pt_max(10.0),
+  _p_fixed(-1.0),
   _embedflag(0),
   _ineve(NULL) {
   return;
@@ -89,6 +90,11 @@ void PHG4SimpleEventGenerator::set_phi_range(double min, double max) {
 void PHG4SimpleEventGenerator::set_pt_range(double min, double max) {
   _pt_min = min;
   _pt_max = max;
+  return;
+}
+
+void PHG4SimpleEventGenerator::set_p_fixed(double momentum) {
+  _p_fixed = momentum; 
   return;
 }
 
@@ -292,7 +298,13 @@ int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
    
       double eta = _rand->Uniform(_eta_min,_eta_max);
       double phi = _rand->Uniform(_phi_min,_phi_max);
-      double pt  = _rand->Uniform(_pt_min,_pt_max);   
+
+      double pt;   
+      if(_p_fixed > 0.0)
+	pt = _p_fixed/cosh(eta);    
+      else
+	pt = _rand->Uniform(_pt_min,_pt_max);   
+
       double px = pt*cos(phi);
       double py = pt*sin(phi);
       double pz = pt*sinh(eta);

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.h
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.h
@@ -41,6 +41,9 @@ public:
   //! range of randomized pt values
   void set_pt_range(double pt_min, double mom_max);
 
+  //! set fixed momentum for particle
+  void set_p_fixed(double momentum);
+
   //! toss a new vertex according to a Uniform or Gaus distribution
   void set_vertex_distribution_function(FUNCTION x, FUNCTION y, FUNCTION z);
 
@@ -103,6 +106,7 @@ private:
   double _phi_max;
   double _pt_min;
   double _pt_max;
+  double _p_fixed; 
   int _embedflag;
 
   PHG4InEvent* _ineve;


### PR DESCRIPTION
Simple changes to add the ability to generate particles of fixed momentum.  Calling set_p_fixed() with a positive values will generate particles of fixed momentum rather than pT between a min and max range.  Default value for _p_fixed is -1.0 so default behavior will be as before. 