### PR TITLE
consistent 64 bit keys and hit ids, fixed hit properties

### DIFF
--- a/offline/packages/NodeDump/DumpPHG4HitContainer.cc
+++ b/offline/packages/NodeDump/DumpPHG4HitContainer.cc
@@ -6,6 +6,7 @@
 #include <g4main/PHG4Hit.h>
 
 #include <string>
+#include <stdint.h>
 
 using namespace std;
 
@@ -32,7 +33,7 @@ int DumpPHG4HitContainer::process_Node(PHNode *myNode)
       *fout << "num layers: " << phg4hitcontainer->num_layers() << endl;
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
         {
-          *fout << "id: " << hiter->second->get_hit_id() << endl;
+	  *fout << "id: 0x" << hex << hiter->second->get_hit_id() << dec << endl;
           *fout << "layer: " << hiter->second->get_layer() << endl;
           *fout << "trkid: " << hiter->second->get_trkid() << endl;
           *fout << "edep: " << hiter->second->get_edep() << endl;
@@ -43,7 +44,32 @@ int DumpPHG4HitContainer::process_Node(PHNode *myNode)
               *fout << "z(" << i << "): " << hiter->second->get_z(i) << endl;
               *fout << "t(" << i << "): " << hiter->second->get_t(i) << endl;
             }
-        }
+	   for (unsigned char ic = 0; ic < UCHAR_MAX; ic++)
+	     {
+	       PHG4Hit::PROPERTY prop_id = static_cast<PHG4Hit::PROPERTY> (ic);
+	       if (hiter->second->has_property(prop_id))
+		 {
+		   *fout << "prop id: " << static_cast<unsigned int> (ic);
+		   pair<const string, PHG4Hit::PROPERTY_TYPE> property_info = PHG4Hit::get_property_info(prop_id);
+		   *fout << ", name " << property_info.first << " value ";
+		   switch(property_info.second)
+		     {
+		     case PHG4Hit::type_int:
+		       *fout << hiter->second->get_property_int(prop_id);
+		       break;
+		     case PHG4Hit::type_uint:
+		       *fout << hiter->second->get_property_uint(prop_id);
+		       break;
+		     case PHG4Hit::type_float:
+		       *fout << hiter->second->get_property_float(prop_id);
+		       break;
+		     default:
+		       *fout << " unknown type ";
+		     }
+		   *fout <<endl;
+		 }
+	     }
+	}
     }
   return 0;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
@@ -82,9 +82,6 @@ bool PHG4CEmcTestBeamSteppingAction::UserSteppingAction( const G4Step* aStep, bo
 	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
 	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
 	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
-	  hit->set_px( 0, prePoint->GetMomentum().x() / GeV );
-	  hit->set_py( 0, prePoint->GetMomentum().y() / GeV );
-	  hit->set_pz( 0, prePoint->GetMomentum().z() / GeV );
 	  // time in ns
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
@@ -123,10 +120,6 @@ bool PHG4CEmcTestBeamSteppingAction::UserSteppingAction( const G4Step* aStep, bo
       hit->set_x( 1, postPoint->GetPosition().x() / cm );
       hit->set_y( 1, postPoint->GetPosition().y() / cm );
       hit->set_z( 1, postPoint->GetPosition().z() / cm );
-
-      hit->set_px(1, postPoint->GetMomentum().x() / GeV );
-      hit->set_py(1, postPoint->GetMomentum().y() / GeV );
-      hit->set_pz(1, postPoint->GetMomentum().z() / GeV );
 
       hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
       //sum up the energy to get total deposited

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
@@ -180,10 +180,6 @@ bool PHG4CrystalCalorimeterSteppingAction::UserSteppingAction( const G4Step* aSt
       hit->set_y( 1, postPoint->GetPosition().y() / cm );
       hit->set_z( 1, postPoint->GetPosition().z() / cm );
 
-      hit->set_px(1, postPoint->GetMomentum().x() / GeV );
-      hit->set_py(1, postPoint->GetMomentum().y() / GeV );
-      hit->set_pz(1, postPoint->GetMomentum().z() / GeV );
-
       hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
 
       /* sum up the energy to get total deposited */

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.cc
@@ -140,10 +140,6 @@ bool PHG4EnvelopeSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
 		hit->set_y( 1, postPoint->GetPosition().y() / cm );
 		hit->set_z( 1, postPoint->GetPosition().z() / cm );
 
-		hit->set_px(1, postPoint->GetMomentum().x() / GeV );
-		hit->set_py(1, postPoint->GetMomentum().y() / GeV );
-		hit->set_pz(1, postPoint->GetMomentum().z() / GeV );
-
 		hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
 
 		/* sum up the energy to get total deposited */

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
@@ -173,10 +173,6 @@ bool PHG4ForwardHcalSteppingAction::UserSteppingAction( const G4Step* aStep, boo
       hit->set_y( 1, postPoint->GetPosition().y() / cm );
       hit->set_z( 1, postPoint->GetPosition().z() / cm );
 
-      hit->set_px(1, postPoint->GetMomentum().x() / GeV );
-      hit->set_py(1, postPoint->GetMomentum().y() / GeV );
-      hit->set_pz(1, postPoint->GetMomentum().z() / GeV );
-
       hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
 
       /* sum up the energy to get total deposited */

--- a/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSteppingAction.cc
@@ -147,9 +147,6 @@ bool PHG4HcalPrototypeSteppingAction::UserSteppingAction( const G4Step* aStep, b
 	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
 	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
 	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
-	  hit->set_px( 0, prePoint->GetMomentum().x() / GeV );
-	  hit->set_py( 0, prePoint->GetMomentum().y() / GeV );
-	  hit->set_pz( 0, prePoint->GetMomentum().z() / GeV );
 	  // time in ns
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
@@ -188,10 +185,6 @@ bool PHG4HcalPrototypeSteppingAction::UserSteppingAction( const G4Step* aStep, b
       hit->set_x( 1, postPoint->GetPosition().x() / cm );
       hit->set_y( 1, postPoint->GetPosition().y() / cm );
       hit->set_z( 1, postPoint->GetPosition().z() / cm );
-
-      hit->set_px(1, postPoint->GetMomentum().x() / GeV );
-      hit->set_py(1, postPoint->GetMomentum().y() / GeV );
-      hit->set_pz(1, postPoint->GetMomentum().z() / GeV );
 
       hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
       //sum up the energy to get total deposited

--- a/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
@@ -83,10 +83,6 @@ bool PHG4HcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
           hit->set_y( 0, prePoint->GetPosition().y() / cm );
           hit->set_z( 0, prePoint->GetPosition().z() / cm );
 
-	  hit->set_px( 0, prePoint->GetMomentum().x() / GeV );
-	  hit->set_py( 0, prePoint->GetMomentum().y() / GeV );
-	  hit->set_pz( 0, prePoint->GetMomentum().z() / GeV );
-
 	  // time in ns
           hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
@@ -132,10 +128,6 @@ bool PHG4HcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
       hit->set_x( 1, postPoint->GetPosition().x() / cm );
       hit->set_y( 1, postPoint->GetPosition().y() / cm );
       hit->set_z( 1, postPoint->GetPosition().z() / cm );
-
-      hit->set_px(1, postPoint->GetMomentum().x() / GeV );
-      hit->set_py(1, postPoint->GetMomentum().y() / GeV );
-      hit->set_pz(1, postPoint->GetMomentum().z() / GeV );
 
       hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -166,9 +166,6 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
 	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
 	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
-	  hit->set_px( 0, prePoint->GetMomentum().x() / GeV );
-	  hit->set_py( 0, prePoint->GetMomentum().y() / GeV );
-	  hit->set_pz( 0, prePoint->GetMomentum().z() / GeV );
 	  // time in ns
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
@@ -208,10 +205,6 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
       hit->set_x( 1, postPoint->GetPosition().x() / cm );
       hit->set_y( 1, postPoint->GetPosition().y() / cm );
       hit->set_z( 1, postPoint->GetPosition().z() / cm );
-
-      hit->set_px(1, postPoint->GetMomentum().x() / GeV );
-      hit->set_py(1, postPoint->GetMomentum().y() / GeV );
-      hit->set_pz(1, postPoint->GetMomentum().z() / GeV );
 
       hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
       //sum up the energy to get total deposited

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -168,9 +168,6 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
 	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
 	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
-	  hit->set_px( 0, prePoint->GetMomentum().x() / GeV );
-	  hit->set_py( 0, prePoint->GetMomentum().y() / GeV );
-	  hit->set_pz( 0, prePoint->GetMomentum().z() / GeV );
 	  // time in ns
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
@@ -209,10 +206,6 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
       hit->set_x( 1, postPoint->GetPosition().x() / cm );
       hit->set_y( 1, postPoint->GetPosition().y() / cm );
       hit->set_z( 1, postPoint->GetPosition().z() / cm );
-
-      hit->set_px(1, postPoint->GetMomentum().x() / GeV );
-      hit->set_py(1, postPoint->GetMomentum().y() / GeV );
-      hit->set_pz(1, postPoint->GetMomentum().z() / GeV );
 
       hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
 

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
@@ -1,5 +1,3 @@
-// $$Id: PHG4SpacalSteppingAction.cc,v 1.6 2015/01/07 23:50:05 jinhuang Exp $$
-
 /*!
  * \file ${file_name}
  * \brief
@@ -92,10 +90,6 @@ PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         hit->set_y(0, prePoint->GetPosition().y() / cm);
         hit->set_z(0, prePoint->GetPosition().z() / cm);
 
-        hit->set_px(0, prePoint->GetMomentum().x() / GeV);
-        hit->set_py(0, prePoint->GetMomentum().y() / GeV);
-        hit->set_pz(0, prePoint->GetMomentum().z() / GeV);
-
         // time in ns
         hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
         //set the track ID
@@ -146,10 +140,6 @@ PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       hit->set_x(1, postPoint->GetPosition().x() / cm);
       hit->set_y(1, postPoint->GetPosition().y() / cm);
       hit->set_z(1, postPoint->GetPosition().z() / cm);
-
-      hit->set_px(1, postPoint->GetMomentum().x() / GeV);
-      hit->set_py(1, postPoint->GetMomentum().y() / GeV);
-      hit->set_pz(1, postPoint->GetMomentum().z() / GeV);
 
       hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
       //sum up the energy to get total deposited

--- a/simulation/g4simulation/g4main/PHG4Hit.cc
+++ b/simulation/g4simulation/g4main/PHG4Hit.cc
@@ -16,6 +16,9 @@ PHG4Hit::Copy(PHG4Hit const &g4hit)
       set_z(i,g4hit.get_z(i));
       set_t(i,g4hit.get_t(i));
     }
+  set_hit_id(g4hit.get_hit_id());
+  set_trkid(g4hit.get_trkid());
+  set_edep(g4hit.get_edep());
   for (unsigned char ic = 0; ic < UCHAR_MAX; ic++)
     {
       PROPERTY prop_id = static_cast<PHG4Hit::PROPERTY> (ic);

--- a/simulation/g4simulation/g4main/PHG4Hit.cc
+++ b/simulation/g4simulation/g4main/PHG4Hit.cc
@@ -1,5 +1,7 @@
 #include "PHG4Hit.h"
 
+#include <cstdlib>
+
 using namespace std;
 
 ClassImp(PHG4Hit)
@@ -57,3 +59,71 @@ ostream& operator<<(ostream& stream, const PHG4Hit * hit){
   return stream;
 }
 
+std::pair<const std::string,PHG4Hit::PROPERTY_TYPE> 
+PHG4Hit::get_property_info(const PROPERTY prop_id) 
+{
+  switch (prop_id)
+  {
+  case  prop_eion:
+    return make_pair("ionizing energy loss",PHG4Hit::type_float);
+  case   prop_light_yield:
+    return make_pair("light yield",PHG4Hit::type_float);
+  case   prop_px:
+    return make_pair("px",PHG4Hit::type_float);
+  case   prop_py:
+    return make_pair("py",PHG4Hit::type_float);
+  case   prop_pz:
+    return make_pair("pz",PHG4Hit::type_float);
+  case   prop_path_length:
+    return make_pair("pathlength",PHG4Hit::type_float);
+  case   prop_layer:
+    return make_pair("layer ID",PHG4Hit::type_uint);
+  case   prop_scint_id:
+    return make_pair("scintillator ID",PHG4Hit::type_int);
+  case   prop_strip_z_index:
+    return make_pair("strip z index",PHG4Hit::type_int);
+  case   prop_strip_y_index:
+    return make_pair("strip y index",PHG4Hit::type_int);
+  case   prop_ladder_z_index:
+    return make_pair("ladder z index",PHG4Hit::type_int);
+  case   prop_ladder_phi_index:
+    return make_pair("ladder phi index",PHG4Hit::type_int);
+  case   prop_index_i:
+    return make_pair("generic index i",PHG4Hit::type_int);
+  case   prop_index_j:
+    return make_pair("generic index j",PHG4Hit::type_int);
+  case   prop_index_k:
+    return make_pair("generic index k",PHG4Hit::type_int);
+  default:
+    cout << "unknown index " << prop_id << endl;
+    exit(1);
+  }
+}
+
+
+bool
+PHG4Hit::check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type)
+{
+  pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id);
+  if (property_info.second != prop_type)
+    {
+      return false;
+    }
+  return true;
+}
+
+string
+PHG4Hit::get_property_type(const PROPERTY_TYPE prop_type)
+{
+  switch(prop_type)
+    {
+    case type_int:
+      return "int";
+    case type_uint:
+      return "unsigned int";
+    case type_float:
+      return "float";
+    default:
+      return "unkown";
+    }
+}

--- a/simulation/g4simulation/g4main/PHG4Hit.cc
+++ b/simulation/g4simulation/g4main/PHG4Hit.cc
@@ -14,23 +14,16 @@ PHG4Hit::Copy(PHG4Hit const &g4hit)
       set_x(i,g4hit.get_x(i));
       set_y(i,g4hit.get_y(i));
       set_z(i,g4hit.get_z(i));
-      set_px(i,g4hit.get_px(i));
-      set_py(i,g4hit.get_py(i));
-      set_pz(i,g4hit.get_pz(i));
       set_t(i,g4hit.get_t(i));
     }
-  set_edep(g4hit.get_edep());
-  set_eion(g4hit.get_eion());
-  set_path_length(g4hit.get_path_length());
-  set_light_yield(g4hit.get_light_yield());
-  set_layer(g4hit.get_layer());
-  set_hit_id(g4hit.get_hit_id());
-  set_scint_id(g4hit.get_scint_id());
-  set_trkid(g4hit.get_trkid());
-  set_strip_z_index(g4hit.get_strip_z_index());
-  set_strip_y_index(g4hit.get_strip_y_index());
-  set_ladder_z_index(g4hit.get_ladder_z_index());
-  set_ladder_phi_index(g4hit.get_ladder_phi_index());
+  for (unsigned char ic = 0; ic < UCHAR_MAX; ic++)
+    {
+      PROPERTY prop_id = static_cast<PHG4Hit::PROPERTY> (ic);
+      if (g4hit.has_property(prop_id))
+        {
+	  set_property_nocheck(prop_id,g4hit.get_property_nocheck(prop_id));
+	}
+    }
 }
 
 

--- a/simulation/g4simulation/g4main/PHG4Hit.cc
+++ b/simulation/g4simulation/g4main/PHG4Hit.cc
@@ -64,12 +64,18 @@ PHG4Hit::get_property_info(const PROPERTY prop_id)
     return make_pair("ionizing energy loss",PHG4Hit::type_float);
   case   prop_light_yield:
     return make_pair("light yield",PHG4Hit::type_float);
-  case   prop_px:
-    return make_pair("px",PHG4Hit::type_float);
-  case   prop_py:
-    return make_pair("py",PHG4Hit::type_float);
-  case   prop_pz:
-    return make_pair("pz",PHG4Hit::type_float);
+  case   prop_px_0:
+    return make_pair("px in",PHG4Hit::type_float);
+  case   prop_px_1:
+    return make_pair("px out",PHG4Hit::type_float);
+  case   prop_py_0:
+    return make_pair("py in",PHG4Hit::type_float);
+  case   prop_py_1:
+    return make_pair("py out",PHG4Hit::type_float);
+  case   prop_pz_0:
+    return make_pair("pz in",PHG4Hit::type_float);
+  case   prop_pz_1:
+    return make_pair("pz out",PHG4Hit::type_float);
   case   prop_path_length:
     return make_pair("pathlength",PHG4Hit::type_float);
   case   prop_layer:

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -49,8 +49,8 @@ class PHG4Hit: public PHObject
   virtual void set_t(const int i, const float f) {return;}
   virtual void set_edep(const float f) {return;}
   virtual void set_eion(const float f) {return;}
-  virtual void set_light_yield(float lightYield){return;}
-  virtual void set_path_length(float pathLength){return;}
+  virtual void set_light_yield(const float lightYield){return;}
+  virtual void set_path_length(const float pathLength){return;}
   virtual void set_layer(const unsigned int i) {return;}
   virtual void set_hit_id(const unsigned long long i) {return;}
   virtual void set_scint_id(const int i) {return;}
@@ -116,68 +116,31 @@ class PHG4Hit: public PHObject
     //! max limit in order to fit into 8 bit unsigned number
     prop_MAX_NUMBER = UCHAR_MAX
   };
-  enum PROPERTY_TYPE {//
+
+  enum PROPERTY_TYPE 
+{//
     type_int = 1,
     type_uint = 2,
     type_float = 3,
-    type_unknown = -1};
+    type_unknown = -1
+};
 
-  virtual bool  has_property(PROPERTY prop_id) const {return false;}
-  virtual float get_property_float(PROPERTY prop_id) const {return NAN;}
-  virtual int   get_property_int(PROPERTY prop_id) const {return INT_MIN;}
-  virtual unsigned int   get_property_uint(PROPERTY prop_id) const {return UINT_MAX;}
-  virtual void  set_property(PROPERTY prop_id, float value) {return;}
-  virtual void  set_property(PROPERTY prop_id, int value) {return;}
-  virtual void  set_property(PROPERTY prop_id, unsigned int value) {return;}
-  static std::pair<const std::string,PROPERTY_TYPE> get_property_name(PROPERTY prop_id);
-  //  static const std::string get_property_type(PROPERTY prop_id);
+  virtual bool  has_property(const PROPERTY prop_id) const {return false;}
+  virtual float get_property_float(const PROPERTY prop_id) const {return NAN;}
+  virtual int   get_property_int(const PROPERTY prop_id) const {return INT_MIN;}
+  virtual unsigned int   get_property_uint(const PROPERTY prop_id) const {return UINT_MAX;}
+  virtual void  set_property(const PROPERTY prop_id, const float value) {return;}
+  virtual void  set_property(const PROPERTY prop_id, const int value) {return;}
+  virtual void  set_property(const PROPERTY prop_id, const unsigned int value) {return;}
+  static std::pair<const std::string,PROPERTY_TYPE> get_property_info(PROPERTY prop_id);
+  static bool check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type);
+  static std::string get_property_type(const PROPERTY_TYPE prop_type);
+
  protected:
   ClassDef(PHG4Hit,1)
 };
 
 
-inline std::pair<const std::string,PHG4Hit::PROPERTY_TYPE> PHG4Hit::get_property_name(const PROPERTY prop_id) 
-{
-  switch (prop_id)
-  {
-  case  prop_eion:
-    return std::make_pair("ionizing energy loss",PHG4Hit::type_float);
-    /*
-  case   prop_light_yield:
-    return "light yield";
-
-  case   prop_px:
-    return "px";
-  case   prop_py:
-    return "py";
-  case   prop_pz:
-    return "pz";
-  case   prop_path_length:
-    return "pathlength";
-
-  case   prop_layer:
-    return "layer ID";
-  case   prop_scint_id:
-    return "scintillator ID";
-  case   prop_strip_z_index:
-    return "strip z index";
-  case   prop_strip_y_index:
-    return "strip y index";
-  case   prop_ladder_z_index:
-    return "ladder z index";
-  case   prop_ladder_phi_index:
-    return "ladder phi index";
-  case   prop_index_i:
-    return "generic index i";
-  case   prop_index_j:
-    return "generic index j";
-  case   prop_index_k:
-    return "generic index k";
-    */
-  default:
-    return std::make_pair("invalid property",PHG4Hit::type_unknown);
-  }
-}
 inline float PHG4Hit::get_avg_x() const { return 0.5*(get_x(0)+get_x(1)); }
 inline float PHG4Hit::get_avg_y() const { return 0.5*(get_y(0)+get_y(1)); }
 inline float PHG4Hit::get_avg_z() const { return 0.5*(get_z(0)+get_z(1)); }

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -137,6 +137,8 @@ class PHG4Hit: public PHObject
   static std::string get_property_type(const PROPERTY_TYPE prop_type);
 
  protected:
+  virtual unsigned int get_property_nocheck(const PROPERTY prop_id) const {return UINT_MAX;}
+  virtual void set_property_nocheck(const PROPERTY prop_id,const unsigned int) {return;}
   ClassDef(PHG4Hit,1)
 };
 

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -28,7 +28,7 @@ class PHG4Hit: public PHObject
   virtual float get_light_yield() const {return NAN;}
   virtual float get_path_length() const {return NAN;}
   virtual unsigned int get_layer() const {return UINT_MAX;}
-  virtual unsigned int get_hit_id() const {return UINT_MAX;}
+  virtual unsigned long long get_hit_id() const {return ULONG_LONG_MAX;}
   virtual int get_scint_id() const {return INT_MIN;}
   virtual int get_trkid() const {return INT_MIN;}
   virtual int get_strip_z_index() const {return INT_MIN;}
@@ -52,7 +52,7 @@ class PHG4Hit: public PHObject
   virtual void set_light_yield(float lightYield){return;}
   virtual void set_path_length(float pathLength){return;}
   virtual void set_layer(const unsigned int i) {return;}
-  virtual void set_hit_id(const unsigned int i) {return;}
+  virtual void set_hit_id(const unsigned long long i) {return;}
   virtual void set_scint_id(const int i) {return;}
   virtual void set_trkid(const int i) {return;}
   virtual void set_strip_z_index(const int i) {return;}
@@ -116,6 +116,11 @@ class PHG4Hit: public PHObject
     //! max limit in order to fit into 8 bit unsigned number
     prop_MAX_NUMBER = UCHAR_MAX
   };
+  enum PROPERTY_TYPE {//
+    type_int = 1,
+    type_uint = 2,
+    type_float = 3,
+    type_unknown = -1};
 
   virtual bool  has_property(PROPERTY prop_id) const {return false;}
   virtual float get_property_float(PROPERTY prop_id) const {return NAN;}
@@ -124,18 +129,20 @@ class PHG4Hit: public PHObject
   virtual void  set_property(PROPERTY prop_id, float value) {return;}
   virtual void  set_property(PROPERTY prop_id, int value) {return;}
   virtual void  set_property(PROPERTY prop_id, unsigned int value) {return;}
-  static const char * get_property_name(PROPERTY prop_id);
-
+  static std::pair<const std::string,PROPERTY_TYPE> get_property_name(PROPERTY prop_id);
+  //  static const std::string get_property_type(PROPERTY prop_id);
  protected:
   ClassDef(PHG4Hit,1)
 };
 
-inline const char * PHG4Hit::get_property_name(const PROPERTY prop_id)
+
+inline std::pair<const std::string,PHG4Hit::PROPERTY_TYPE> PHG4Hit::get_property_name(const PROPERTY prop_id) 
 {
   switch (prop_id)
   {
   case  prop_eion:
-    return "ioning energy loss";
+    return std::make_pair("ionizing energy loss",PHG4Hit::type_float);
+    /*
   case   prop_light_yield:
     return "light yield";
 
@@ -166,9 +173,9 @@ inline const char * PHG4Hit::get_property_name(const PROPERTY prop_id)
     return "generic index j";
   case   prop_index_k:
     return "generic index k";
-
+    */
   default:
-    return "invalid property";
+    return std::make_pair("invalid property",PHG4Hit::type_unknown);
   }
 }
 inline float PHG4Hit::get_avg_x() const { return 0.5*(get_x(0)+get_x(1)); }

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -73,7 +73,8 @@ class PHG4Hit: public PHObject
 
 
   //! add a short name to PHG4Hit::get_property_name
-  enum PROPERTY {//
+  enum PROPERTY 
+  {//
 
     //-- hit properties: 1 - 10  --
     //! ionizing energy loss
@@ -82,15 +83,18 @@ class PHG4Hit: public PHObject
     //! for scintillation detectors, the amount of light produced
     prop_light_yield = 2,
 
-    //-- event properties: 10 - 20  --
+    //-- track properties: 10 - 20  --
 
     //! momentum
-    prop_px = 10,
-    prop_py ,
-    prop_pz ,
+    prop_px_0 = 10,
+    prop_px_1 = 11,
+    prop_py_0 = 12,
+    prop_py_1 = 13,
+    prop_pz_0 = 14,
+    prop_pz_1 = 15,
 
     //! pathlength
-    prop_path_length = 15,
+    prop_path_length = 16,
 
     //-- detector specific IDs: 100+ --
 
@@ -101,15 +105,15 @@ class PHG4Hit: public PHObject
 
     //! SVX stuff
     prop_strip_z_index = 110,
-    prop_strip_y_index,
-    prop_ladder_z_index,
-    prop_ladder_phi_index,
+    prop_strip_y_index = 111,
+    prop_ladder_z_index = 112,
+    prop_ladder_phi_index = 113,
 
     //! generic indexes
     prop_index_i = 121,
-    prop_index_j ,
-    prop_index_k ,
-    prop_index_l ,
+    prop_index_j = 122,
+    prop_index_k = 123,
+    prop_index_l = 124,
 
 
 
@@ -118,12 +122,12 @@ class PHG4Hit: public PHObject
   };
 
   enum PROPERTY_TYPE 
-{//
+  {//
     type_int = 1,
     type_uint = 2,
     type_float = 3,
     type_unknown = -1
-};
+  };
 
   virtual bool  has_property(const PROPERTY prop_id) const {return false;}
   virtual float get_property_float(const PROPERTY prop_id) const {return NAN;}

--- a/simulation/g4simulation/g4main/PHG4HitContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4HitContainer.cc
@@ -97,6 +97,22 @@ PHG4HitContainer::genkey(const unsigned int detid)
 }
 
 PHG4HitContainer::ConstIterator
+PHG4HitContainer::AddHit(PHG4Hit *newhit)
+{
+  unsigned long long key = newhit->get_hit_id();
+  if (hitmap.find(key) != hitmap.end())
+    {
+      cout << "hit with id  0x" << hex << key << " exists already" << endl;
+      return hitmap.find(key);
+    }
+  unsigned long long detidlong = key >>  phg4hitdefs::hit_idbits;
+  unsigned int detid = detidlong;
+  layers.insert(detid);
+  hitmap[key] = newhit;
+  return hitmap.find(key);
+}
+
+PHG4HitContainer::ConstIterator
 PHG4HitContainer::AddHit(const unsigned int detid, PHG4Hit *newhit)
 {
   unsigned long long key = genkey(detid);

--- a/simulation/g4simulation/g4main/PHG4HitContainer.h
+++ b/simulation/g4simulation/g4main/PHG4HitContainer.h
@@ -26,6 +26,8 @@ class PHG4HitContainer: public PHObject
 
   void identify(std::ostream& os = std::cout) const;
 
+  ConstIterator AddHit(PHG4Hit *newhit);
+
   ConstIterator AddHit(const unsigned int detid, PHG4Hit *newhit);
   
   Iterator findOrAddHit(unsigned long long key);

--- a/simulation/g4simulation/g4main/PHG4HitContainer.h
+++ b/simulation/g4simulation/g4main/PHG4HitContainer.h
@@ -1,5 +1,5 @@
-#ifndef __PHG4HITCONTAINER_H__
-#define __PHG4HITCONTAINER_H__
+#ifndef PHG4HITCONTAINER_H__
+#define PHG4HITCONTAINER_H__
 
 
 #include <phool/PHObject.h>
@@ -16,7 +16,7 @@ class PHG4HitContainer: public PHObject
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
-  typedef std::set<int>::const_iterator LayerIter;
+  typedef std::set<unsigned int>::const_iterator LayerIter;
 
   PHG4HitContainer();
 
@@ -26,16 +26,16 @@ class PHG4HitContainer: public PHObject
 
   void identify(std::ostream& os = std::cout) const;
 
-  ConstIterator AddHit(const int detid, PHG4Hit *newhit);
+  ConstIterator AddHit(const unsigned int detid, PHG4Hit *newhit);
   
   Iterator findOrAddHit(unsigned long long key);
 
   PHG4Hit* findHit( unsigned long long key );
 
-  unsigned long long genkey(const int detid);
+  unsigned long long genkey(const unsigned int detid);
 
   //! return all hits matching a given detid
-  ConstRange getHits(const int detid) const;
+  ConstRange getHits(const unsigned int detid) const;
 
   //! return all hist
   ConstRange getHits( void ) const;
@@ -45,14 +45,14 @@ class PHG4HitContainer: public PHObject
   unsigned int num_layers(void) const
   { return layers.size(); }
   std::pair<LayerIter, LayerIter> getLayers() const
-    { return make_pair(layers.begin(), layers.end());}
-  void AddLayer(const int ilayer) {layers.insert(ilayer);}
+     { return make_pair(layers.begin(), layers.end());} 
+  void AddLayer(const unsigned int ilayer) {layers.insert(ilayer);}
   void RemoveZeroEDep();
-  unsigned long long getmaxkey(const int detid);
+  unsigned long long getmaxkey(const unsigned int detid);
 
  protected:
   Map hitmap;
-  std::set<int> layers; // layers is not reset since layers must not change event by event
+  std::set<unsigned int> layers; // layers is not reset since layers must not change event by event
 
   ClassDef(PHG4HitContainer,1)
 };

--- a/simulation/g4simulation/g4main/PHG4HitDefs.h
+++ b/simulation/g4simulation/g4main/PHG4HitDefs.h
@@ -3,8 +3,8 @@
 
 namespace phg4hitdefs
 {
-static int keybits = 8;
-static int hit_idbits = 32-keybits;
+  static int keybits = 8;
+  static int hit_idbits = 64-keybits;
 }
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -1,14 +1,18 @@
 #include "PHG4Hitv1.h"
 #include "PHG4HitDefs.h"
 
+#include <phool/phool.h>
+
+#include <cstdlib>
+
 using namespace std;
 
 ClassImp(PHG4Hitv1)
 
 PHG4Hitv1::PHG4Hitv1():
- hitid(ULONG_LONG_MAX),
- trackid(INT_MIN),
- edep(NAN)
+hitid(ULONG_LONG_MAX),
+  trackid(INT_MIN),
+  edep(NAN)
 {
   for (int i = 0; i<2;i++)
     {
@@ -35,57 +39,105 @@ PHG4Hitv1::print() const {
     {
       u_property p( i->second);
 
-      std::cout <<"\t" << static_cast<const int>(i->first) <<":\t" <<get_property_name(static_cast<PROPERTY>(i->first)).first<<" = "
-          <<"\t"<<p.fdata<<" (float)"
-          <<"\t"<<p.idata<<" (int)"
-          <<"\t"<<p.uidata<<" (uint)"
-          <<"\t"<<sizeof(u_property)<<" (memory size)"
-          <<endl;
+      std::cout <<"\t" << static_cast<const int>(i->first) <<":\t" <<get_property_info(static_cast<PROPERTY>(i->first)).first<<" = "
+		<<"\t"<<p.fdata<<" (float)"
+		<<"\t"<<p.idata<<" (int)"
+		<<"\t"<<p.uidata<<" (uint)"
+		<<"\t"<<sizeof(u_property)<<" (memory size)"
+		<<endl;
     }
 }
 
 bool
-PHG4Hitv1::has_property(PHG4Hitv1::PROPERTY prop_id) const
+PHG4Hitv1::has_property(const PROPERTY prop_id) const
 {
   prop_map_t::const_iterator i = prop_map.find(prop_id);
   return i!=prop_map.end();
 }
 
 float
-PHG4Hitv1::get_property_float(PHG4Hitv1::PROPERTY prop_id) const
+PHG4Hitv1::get_property_float(const PROPERTY prop_id) const
 {
+  if (!check_property(prop_id,type_float))
+    {
+      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_float) << endl; 
+      exit(1);
+    }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
   return (i==prop_map.end())? NAN : u_property(i->second).fdata ;
 }
 
 int
-PHG4Hitv1::get_property_int(PHG4Hitv1::PROPERTY prop_id) const
+PHG4Hitv1::get_property_int(const PROPERTY prop_id) const
 {
+  if (!check_property(prop_id,type_int))
+    {
+      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_int) << endl; 
+      exit(1);
+    }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
   return (i==prop_map.end())? NAN : u_property(i->second).idata ;
 }
 
 unsigned int
-PHG4Hitv1::get_property_uint(PHG4Hitv1::PROPERTY prop_id) const
+PHG4Hitv1::get_property_uint(const PROPERTY prop_id) const
 {
+  if (!check_property(prop_id,type_uint))
+    {
+      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_uint) << endl; 
+      exit(1);
+    }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
   return (i==prop_map.end())? NAN : u_property(i->second).uidata ;
 }
 
 void
-PHG4Hitv1::set_property(PHG4Hitv1::PROPERTY prop_id, float value)
+PHG4Hitv1::set_property(const PROPERTY prop_id, const float value)
 {
+  if (!check_property(prop_id,type_float))
+    {
+      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_float) << endl; 
+      exit(1);
+    }
   prop_map[prop_id] = u_property(value).get_storage();
 }
 
 void
-PHG4Hitv1::set_property(PHG4Hitv1::PROPERTY prop_id, int value)
+PHG4Hitv1::set_property(const PROPERTY prop_id, const int value)
 {
+  if (!check_property(prop_id,type_int))
+    {
+      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_int) << endl; 
+      exit(1);
+    }
   prop_map[prop_id] = u_property(value).get_storage();
 }
 
 void
-PHG4Hitv1::set_property(PHG4Hitv1::PROPERTY prop_id, unsigned int value)
+PHG4Hitv1::set_property(const PROPERTY prop_id, const unsigned int value)
 {
+  if (!check_property(prop_id,type_uint))
+    {
+      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_uint) << endl; 
+      exit(1);
+    }
   prop_map[prop_id] = u_property(value).get_storage();
 }

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -3,12 +3,10 @@
 
 using namespace std;
 
-//G4Allocator<PHG4Hitv1> PHG4Hitv1Allocator;
-
 ClassImp(PHG4Hitv1)
 
 PHG4Hitv1::PHG4Hitv1():
- hitid(UINT_MAX),
+ hitid(ULONG_LONG_MAX),
  trackid(INT_MIN),
  edep(NAN)
 {
@@ -37,7 +35,7 @@ PHG4Hitv1::print() const {
     {
       u_property p( i->second);
 
-      std::cout <<"\t" << static_cast<const int>(i->first) <<":\t" <<get_property_name(static_cast<PROPERTY>(i->first))<<" = "
+      std::cout <<"\t" << static_cast<const int>(i->first) <<":\t" <<get_property_name(static_cast<PROPERTY>(i->first)).first<<" = "
           <<"\t"<<p.fdata<<" (float)"
           <<"\t"<<p.idata<<" (int)"
           <<"\t"<<p.uidata<<" (uint)"

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -10,9 +10,9 @@ using namespace std;
 ClassImp(PHG4Hitv1)
 
 PHG4Hitv1::PHG4Hitv1():
-hitid(ULONG_LONG_MAX),
-  trackid(INT_MIN),
-  edep(NAN)
+ hitid(ULONG_LONG_MAX),
+ trackid(INT_MIN),
+ edep(NAN)
 {
   for (int i = 0; i<2;i++)
     {
@@ -37,14 +37,24 @@ PHG4Hitv1::print() const {
 
   for (prop_map_t::const_iterator i = prop_map.begin(); i!= prop_map.end(); ++i)
     {
-      u_property p( i->second);
-
-      std::cout <<"\t" << static_cast<const int>(i->first) <<":\t" <<get_property_info(static_cast<PROPERTY>(i->first)).first<<" = "
-		<<"\t"<<p.fdata<<" (float)"
-		<<"\t"<<p.idata<<" (int)"
-		<<"\t"<<p.uidata<<" (uint)"
-		<<"\t"<<sizeof(u_property)<<" (memory size)"
-		<<endl;
+      PROPERTY prop_id = static_cast<PROPERTY>(i->first);
+      pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+      cout << "\t" << i->first << ":\t" << property_info.first << " = \t";
+      switch(property_info.second)
+	{
+	case type_int:
+	  cout << get_property_int(prop_id);
+	  break;
+	case type_uint:
+	  cout << get_property_uint(prop_id);
+	  break;
+	case type_float:
+	  cout << get_property_float(prop_id);
+	  break;
+	default:
+	  cout << " unknown type ";
+	}
+      cout <<endl;
     }
 }
 

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -162,3 +162,99 @@ PHG4Hitv1::get_property_nocheck(const PROPERTY prop_id) const
     }
   return UINT_MAX;
 }
+
+float
+PHG4Hitv1::get_px(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_px_0);
+    case 1:
+      return  get_property_float(prop_px_1);
+    default:
+      cout << "Invalid index in get_px: " << i << endl;
+      exit(1);
+    }
+}
+
+float
+PHG4Hitv1::get_py(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_py_0);
+    case 1:
+      return  get_property_float(prop_py_1);
+    default:
+      cout << "Invalid index in get_py: " << i << endl;
+      exit(1);
+    }
+}
+
+float
+PHG4Hitv1::get_pz(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_pz_0);
+    case 1:
+      return  get_property_float(prop_pz_1);
+    default:
+      cout << "Invalid index in get_pz: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+PHG4Hitv1::set_px(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_px_0,f);
+      return;
+    case 1:
+      set_property(prop_px_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_px: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+PHG4Hitv1::set_py(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_py_0,f);
+      return;
+    case 1:
+      set_property(prop_py_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_py: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+PHG4Hitv1::set_pz(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_pz_0,f);
+      return;
+    case 1:
+      set_property(prop_pz_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_pz: " << i << endl;
+      exit(1);
+    }
+}

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -151,3 +151,14 @@ PHG4Hitv1::set_property(const PROPERTY prop_id, const unsigned int value)
     }
   prop_map[prop_id] = u_property(value).get_storage();
 }
+
+unsigned int
+PHG4Hitv1::get_property_nocheck(const PROPERTY prop_id) const
+{
+  prop_map_t::const_iterator iter = prop_map.find(prop_id);
+  if (iter != prop_map.end())
+    {
+      return iter->second;
+    }
+  return UINT_MAX;
+}

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -1,28 +1,23 @@
-#ifndef __PHG4Hitv1_H__
-#define __PHG4Hitv1_H__
+#ifndef PHG4Hitv1_H__
+#define PHG4Hitv1_H__
 
 #include "PHG4Hit.h"
-//#include <Geant4/G4Allocator.hh>
+
 #include <map>
 #include <stdint.h>
-
-//#ifndef __CINT__
-//class PHG4Hitv1;
-//extern G4Allocator<PHG4Hitv1> PHG4Hitv1Allocator;
-//#endif
 
 class PHG4Hitv1 : public PHG4Hit
 {
  public:
   PHG4Hitv1();
-  PHG4Hitv1(PHG4Hit const &g4hit);
+  explicit PHG4Hitv1(const PHG4Hit &g4hit);
   // The indices here represent the entry and exit points of the particle
   float get_x(const int i) const {return x[i];}
   float get_y(const int i) const {return y[i];}
   float get_z(const int i) const {return z[i];}
   float get_t(const int i) const {return t[i];}
   float get_edep() const {return edep;}
-  unsigned int get_hit_id() const {return hitid;}
+  unsigned long long get_hit_id() const {return hitid;}
   int get_trkid() const {return trackid;}
   
   void set_x(const int i, const float f) {x[i]=f;}
@@ -30,7 +25,7 @@ class PHG4Hitv1 : public PHG4Hit
   void set_z(const int i, const float f) {z[i]=f;}
   void set_t(const int i, const float f) {t[i]=f;}
   void set_edep(const float f) {edep = f;}
-  void set_hit_id(const unsigned int i) {hitid=i;}
+  void set_hit_id(const unsigned long long i) {hitid=i;}
   void set_trkid(const int i) {trackid=i;}
 
   virtual void print() const;
@@ -53,7 +48,7 @@ class PHG4Hitv1 : public PHG4Hit
   virtual int get_scint_id() const        {return  get_property_int(prop_scint_id);}
   virtual int get_strip_z_index() const   {return  get_property_int(prop_strip_z_index);}
   virtual int get_strip_y_index() const   {return  get_property_int(prop_strip_y_index);}
-  virtual int get_ladder_z_index() const  {return  get_property_int(prop_ladder_z_index);}
+  virtual int get_ladder_z_index() const  {return  get_property_int(prop_ladder_phi_index);}
   virtual int get_ladder_phi_index() const{return  get_property_int(prop_ladder_phi_index);}
   virtual int get_index_i() const{return  get_property_int(prop_index_i);}
   virtual int get_index_j() const{return  get_property_int(prop_index_j);}
@@ -70,7 +65,7 @@ class PHG4Hitv1 : public PHG4Hit
   virtual void set_scint_id(const int i)          {set_property(prop_scint_id,i);}
   virtual void set_strip_z_index(const int i)     {set_property(prop_strip_z_index,i);}
   virtual void set_strip_y_index(const int i)     {set_property(prop_strip_y_index,i);}
-  virtual void set_ladder_z_index(const int i)    {set_property(prop_ladder_z_index,i);}
+  virtual void set_ladder_z_index(const int i)    {set_property(prop_ladder_phi_index,i);}
   virtual void set_ladder_phi_index(const int i)  {set_property(prop_ladder_phi_index,i);}
   virtual void set_index_i(const int i)  {set_property(prop_index_i,i);}
   virtual void set_index_j(const int i)  {set_property(prop_index_j,i);}
@@ -84,7 +79,7 @@ class PHG4Hitv1 : public PHG4Hit
   float y[2];
   float z[2];
   float t[2];
-  unsigned int hitid;
+  unsigned long long hitid;
   int trackid;
   float edep;
 

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -38,9 +38,9 @@ class PHG4Hitv1 : public PHG4Hit
   void  set_property(const PROPERTY prop_id, const int value);
   void  set_property(const PROPERTY prop_id, const unsigned int value);
 
-  virtual float get_px(const int i) const {return  get_property_float(prop_px);}
-  virtual float get_py(const int i) const {return  get_property_float(prop_py);}
-  virtual float get_pz(const int i) const {return  get_property_float(prop_pz);}
+  virtual float get_px(const int i) const;
+  virtual float get_py(const int i) const;
+  virtual float get_pz(const int i) const;
   virtual float get_eion() const          {return  get_property_float(prop_eion);}
   virtual float get_light_yield() const   {return  get_property_float(prop_light_yield);}
   virtual float get_path_length() const {return  get_property_float(prop_path_length);}
@@ -55,9 +55,9 @@ class PHG4Hitv1 : public PHG4Hit
   virtual int get_index_k() const {return  get_property_int(prop_index_k);}
   virtual int get_index_l() const {return  get_property_int(prop_index_l);}
 
-  virtual void set_px(const int i, const float f) {set_property(prop_px,f);}
-  virtual void set_py(const int i, const float f) {set_property(prop_py,f);}
-  virtual void set_pz(const int i, const float f) {set_property(prop_pz,f);}
+  virtual void set_px(const int i, const float f);
+  virtual void set_py(const int i, const float f);
+  virtual void set_pz(const int i, const float f);
   virtual void set_eion(const float f)            {set_property(prop_eion,f);}
   virtual void set_light_yield(const float f)           {set_property(prop_light_yield,f);}
   virtual void set_path_length(const float f)           {set_property(prop_path_length,f);}

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -43,7 +43,7 @@ class PHG4Hitv1 : public PHG4Hit
   virtual float get_pz(const int i) const {return  get_property_float(prop_pz);}
   virtual float get_eion() const          {return  get_property_float(prop_eion);}
   virtual float get_light_yield() const   {return  get_property_float(prop_light_yield);}
-  virtual float    get_path_length() const {return  get_property_float(prop_path_length);}
+  virtual float get_path_length() const {return  get_property_float(prop_path_length);}
   virtual unsigned int get_layer() const  {return  get_property_uint(prop_layer);}
   virtual int get_scint_id() const        {return  get_property_int(prop_scint_id);}
   virtual int get_strip_z_index() const   {return  get_property_int(prop_strip_z_index);}
@@ -104,9 +104,6 @@ class PHG4Hitv1 : public PHG4Hit
 
   //! container for additional property
   prop_map_t prop_map;
-
-//  u_property t1;
-//  u_property t2;
 
   ClassDef(PHG4Hitv1,2)
 };

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -30,37 +30,37 @@ class PHG4Hitv1 : public PHG4Hit
 
   virtual void print() const;
 
-  bool  has_property(PROPERTY prop_id) const;
-  float get_property_float(PROPERTY prop_id) const;
-  int   get_property_int(PROPERTY prop_id) const;
-  unsigned int   get_property_uint(PROPERTY prop_id) const;
-  void  set_property(PROPERTY prop_id, float value);
-  void  set_property(PROPERTY prop_id, int value);
-  void  set_property(PROPERTY prop_id, unsigned int value);
+  bool  has_property(const PROPERTY prop_id) const;
+  float get_property_float(const PROPERTY prop_id) const;
+  int   get_property_int(const PROPERTY prop_id) const;
+  unsigned int   get_property_uint(const PROPERTY prop_id) const;
+  void  set_property(const PROPERTY prop_id, const float value);
+  void  set_property(const PROPERTY prop_id, const int value);
+  void  set_property(const PROPERTY prop_id, const unsigned int value);
 
   virtual float get_px(const int i) const {return  get_property_float(prop_px);}
   virtual float get_py(const int i) const {return  get_property_float(prop_py);}
   virtual float get_pz(const int i) const {return  get_property_float(prop_pz);}
   virtual float get_eion() const          {return  get_property_float(prop_eion);}
   virtual float get_light_yield() const   {return  get_property_float(prop_light_yield);}
-  virtual float    get_path_length() const{return  get_property_float(prop_path_length);}
+  virtual float    get_path_length() const {return  get_property_float(prop_path_length);}
   virtual unsigned int get_layer() const  {return  get_property_uint(prop_layer);}
   virtual int get_scint_id() const        {return  get_property_int(prop_scint_id);}
   virtual int get_strip_z_index() const   {return  get_property_int(prop_strip_z_index);}
   virtual int get_strip_y_index() const   {return  get_property_int(prop_strip_y_index);}
   virtual int get_ladder_z_index() const  {return  get_property_int(prop_ladder_phi_index);}
   virtual int get_ladder_phi_index() const{return  get_property_int(prop_ladder_phi_index);}
-  virtual int get_index_i() const{return  get_property_int(prop_index_i);}
-  virtual int get_index_j() const{return  get_property_int(prop_index_j);}
-  virtual int get_index_k() const{return  get_property_int(prop_index_k);}
-  virtual int get_index_l() const{return  get_property_int(prop_index_l);}
+  virtual int get_index_i() const {return  get_property_int(prop_index_i);}
+  virtual int get_index_j() const {return  get_property_int(prop_index_j);}
+  virtual int get_index_k() const {return  get_property_int(prop_index_k);}
+  virtual int get_index_l() const {return  get_property_int(prop_index_l);}
 
   virtual void set_px(const int i, const float f) {set_property(prop_px,f);}
   virtual void set_py(const int i, const float f) {set_property(prop_py,f);}
   virtual void set_pz(const int i, const float f) {set_property(prop_pz,f);}
   virtual void set_eion(const float f)            {set_property(prop_eion,f);}
-  virtual void set_light_yield(float f)           {set_property(prop_light_yield,f);}
-  virtual void set_path_length(float f)           {set_property(prop_path_length,f);}
+  virtual void set_light_yield(const float f)           {set_property(prop_light_yield,f);}
+  virtual void set_path_length(const float f)           {set_property(prop_path_length,f);}
   virtual void set_layer(const unsigned int i)    {set_property(prop_layer,i);}
   virtual void set_scint_id(const int i)          {set_property(prop_scint_id,i);}
   virtual void set_strip_z_index(const int i)     {set_property(prop_strip_z_index,i);}

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -73,6 +73,8 @@ class PHG4Hitv1 : public PHG4Hit
   virtual void set_index_l(const int i)  {set_property(prop_index_l,i);}
 
  protected:
+  unsigned int get_property_nocheck(const PROPERTY prop_id) const;
+  void set_property_nocheck(const PROPERTY prop_id,const unsigned int ui) {prop_map[prop_id]=ui;}
   // Store both the entry and exit points of the particle
   // Remember, particles do not always enter on the inner edge!
   float x[2];


### PR DESCRIPTION
The 64 bit keys were only partially implemented - The PHG4HitContainer used them but the G4Hits used 32 bit ids. Adding to this was a mixture of implicit conversions of unsigned int -> unsigned long long and vice versa which resulted in rather strange 32 bit keys which we would have noticed in hijing events. Now all is tested and functional (includign the generic G4Hit copy ctor) and the g4 sim results themselves did not change.
Somehow the old distinction between px/py/pz at the entry and exit point got lost - both ended up in the same property and the exit hit always won that. This is important for the tracking evaluation, for non cylinder shaped calorimeters keeping this info does not make sense and it was removed. Updating the properties to include px/py/pz at the exit point made a reshuffling necessary and analysis of the old files will get this wrong but the change for the 64 bit keys breaks backward compatibility anyway. 