### PR TITLE
fixes for 32-64 bit g4hit id, use typedefs for key types

### DIFF
--- a/offline/packages/NodeDump/DumpPHG4CylinderCellContainer.cc
+++ b/offline/packages/NodeDump/DumpPHG4CylinderCellContainer.cc
@@ -32,7 +32,7 @@ int DumpPHG4CylinderCellContainer::process_Node(PHNode *myNode)
       *fout << "num layers: " << phg4cellcontainer->num_layers() << endl;
       for (hiter = cell_begin_end.first; hiter != cell_begin_end.second; hiter++)
         {
-          *fout << "id: " << hiter->second->get_cell_id() << endl;
+          *fout << "id: 0x" << hex << hiter->second->get_cell_id() << dec << endl;
           *fout << "layer: " << hiter->second->get_layer() << endl;
           *fout << "edep: " << hiter->second->get_edep() << endl;
           *fout << "binz: " << hiter->second->get_binz() << endl;

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellGeom.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellGeom.cc
@@ -24,42 +24,42 @@ PHG4BlockCellGeom::PHG4BlockCellGeom():
 void
 PHG4BlockCellGeom::set_zbins(const int i)
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   _nzbins = i;
 }
 
 void
 PHG4BlockCellGeom::set_zmin(const double z)
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   _zmin = z;
 }
 
 int
 PHG4BlockCellGeom::get_zbins() const
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return _nzbins;
 }
 
 double
 PHG4BlockCellGeom::get_zmin() const
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return _zmin;
 }
 
 double
 PHG4BlockCellGeom::get_zstep() const
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return _zstep;
 }
 
 void
 PHG4BlockCellGeom::set_zstep(const double z)
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   _zstep = z;
 }
 
@@ -154,19 +154,19 @@ PHG4BlockCellGeom::identify(std::ostream& os) const
      << ", thickness: " << _thickness;
   switch (_binning)
   {
-  case phg4cylindercelldefs::sizebinning:
+  case PHG4CylinderCellDefs::sizebinning:
     os << ", zbins: " << _nzbins
        << ", zmin: " << _zmin
        << ", zstepsize: " << _zstep;
     break;
 
-  case phg4cylindercelldefs::etaphibinning:
+  case PHG4CylinderCellDefs::etaphibinning:
     os << ", etabins: " << _nzbins
        << ", etamin: " << _zmin
        << ", etastepsize: " << _zstep;
     break;
 
-  case phg4cylindercelldefs::etaslatbinning:
+  case PHG4CylinderCellDefs::etaslatbinning:
     os << ", etabins: " << _nzbins
        << ", etamin: " << _zmin
        << ", etastepsize: " << _zstep;
@@ -193,7 +193,7 @@ PHG4BlockCellGeom::get_zbounds(const int ibin) const
       cout << "Asking for invalid bin in z: " << ibin << endl;
       exit(1);
     }
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   double zlow = _zmin + ibin * _zstep;
   double zhigh = zlow + _zstep;
   return make_pair(zlow, zhigh);
@@ -208,7 +208,7 @@ PHG4BlockCellGeom::get_etabounds(const int ibin) const
       exit(1);
     }
   check_binning_method_eta("PHG4BlockCellGeom::get_etabounds");
-  //  check_binning_method(phg4cylindercelldefs::etaphibinning);
+  //  check_binning_method(PHG4CylinderCellDefs::etaphibinning);
   double zlow = _zmin + ibin * _zstep;
   double zhigh = zlow + _zstep;
   return make_pair(zlow, zhigh);
@@ -238,7 +238,7 @@ PHG4BlockCellGeom::get_zbin(const double z) const
     return -1;
   }
   
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return floor( (z-_zmin)/_zstep );
 }
 
@@ -275,7 +275,7 @@ PHG4BlockCellGeom::get_zcenter(const int ibin) const
     cout << "Asking for invalid bin in z: " << ibin << endl;
     exit(1);
   }
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return _zmin + (ibin + 0.5)*_zstep;
 }
 
@@ -310,13 +310,13 @@ PHG4BlockCellGeom::methodname(const int i) const
 {
   switch (i)
   {
-  case phg4cylindercelldefs::sizebinning:
+  case PHG4CylinderCellDefs::sizebinning:
     return "Bins in cm";
     break;
-  case phg4cylindercelldefs::etaphibinning:
+  case PHG4CylinderCellDefs::etaphibinning:
     return "Eta/Phi bins";
     break;
-  case phg4cylindercelldefs::etaslatbinning:
+  case PHG4CylinderCellDefs::etaslatbinning:
     return "Eta/numslat bins";
     break;
   default:
@@ -341,15 +341,15 @@ PHG4BlockCellGeom::check_binning_method(const int i) const
 void
 PHG4BlockCellGeom::check_binning_method_eta(const std::string & src) const
 {
-  if (_binning != phg4cylindercelldefs::etaphibinning && 
-      _binning != phg4cylindercelldefs::etaslatbinning)
+  if (_binning != PHG4CylinderCellDefs::etaphibinning && 
+      _binning != PHG4CylinderCellDefs::etaslatbinning)
   {
     if (src.size())
       cout << src<<" : ";
     
     cout << "different binning method used " << methodname(_binning)
-         << ", not : " << methodname(phg4cylindercelldefs::etaphibinning)
-         << " or " << methodname(phg4cylindercelldefs::etaslatbinning)
+         << ", not : " << methodname(PHG4CylinderCellDefs::etaphibinning)
+         << " or " << methodname(PHG4CylinderCellDefs::etaslatbinning)
          << endl;
     exit(1);
   }
@@ -359,16 +359,16 @@ PHG4BlockCellGeom::check_binning_method_eta(const std::string & src) const
 void
 PHG4BlockCellGeom::check_binning_method_x(const std::string & src) const
 {
-  if (_binning != phg4cylindercelldefs::etaphibinning && 
-      _binning != phg4cylindercelldefs::sizebinning &&
-      _binning != phg4cylindercelldefs::etaslatbinning)
+  if (_binning != PHG4CylinderCellDefs::etaphibinning && 
+      _binning != PHG4CylinderCellDefs::sizebinning &&
+      _binning != PHG4CylinderCellDefs::etaslatbinning)
   {
     if (src.size())
       cout << src<<" : ";
     
     cout << "different binning method used " << methodname(_binning)
-         << ", not : " << methodname(phg4cylindercelldefs::etaphibinning)
-         << " or " << methodname(phg4cylindercelldefs::sizebinning)
+         << ", not : " << methodname(PHG4CylinderCellDefs::etaphibinning)
+         << " or " << methodname(PHG4CylinderCellDefs::sizebinning)
          << endl;
     exit(1);
   }

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -118,7 +118,7 @@ int PHG4BlockCellReco::InitRun(PHCompositeNode *topNode)
     // layerseggeo->set_radius(layergeom->get_radius());
     // layerseggeo->set_thickness(layergeom->get_thickness());
 
-    if (binning[layer] == phg4cylindercelldefs::etaphibinning)
+    if (binning[layer] == PHG4CylinderCellDefs::etaphibinning)
     {
       // calculate eta at radius+ thickness (outer radius)
       // length via eta coverage is calculated using the outer radius
@@ -173,7 +173,7 @@ int PHG4BlockCellReco::InitRun(PHCompositeNode *topNode)
 
       pair<int, int> x_z_bin = make_pair(xbins, etabins);
       n_x_z_bins[layer] = x_z_bin;
-      layerseggeo->set_binning(phg4cylindercelldefs::etaphibinning);
+      layerseggeo->set_binning(PHG4CylinderCellDefs::etaphibinning);
       layerseggeo->set_etabins(etabins);
       layerseggeo->set_etamin(etamin);
       layerseggeo->set_etastep(etastepsize);
@@ -257,7 +257,7 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
 
 
     // ------- eta/x binning ------------------------------------------------------------------------
-    if (binning[*layer] == phg4cylindercelldefs::etaphibinning)
+    if (binning[*layer] == PHG4CylinderCellDefs::etaphibinning)
     {
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
       {
@@ -452,13 +452,13 @@ PHG4BlockCellReco::End(PHCompositeNode *topNode)
 void
 PHG4BlockCellReco::cellsize(const int i, const double sr, const double sz)
 {
-  set_size(i, sr, sz, phg4cylindercelldefs::sizebinning);
+  set_size(i, sr, sz, PHG4CylinderCellDefs::sizebinning);
 }
 
 void
 PHG4BlockCellReco::etaxsize(const int i, const double deltaeta, const double deltax)
 {
-  set_size(i, deltaeta, deltax, phg4cylindercelldefs::etaphibinning);
+  set_size(i, deltaeta, deltax, PHG4CylinderCellDefs::etaphibinning);
   return;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCell.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCell.h
@@ -1,6 +1,8 @@
 #ifndef PHG4CYLINDERCELL_H
 #define PHG4CYLINDERCELL_H
 
+#include "PHG4CylinderCellDefs.h"
+#include <g4main/PHG4HitDefs.h>
 #include <phool/PHObject.h>
 #include <cmath>
 #include <map>
@@ -8,6 +10,11 @@
 class PHG4CylinderCell : public PHObject
 {
  public:
+  typedef std::map<PHG4HitDefs::keytype, float> EdepMap;
+  typedef EdepMap::iterator EdepIterator;
+  typedef EdepMap::const_iterator EdepConstIterator;
+  typedef std::pair<EdepIterator, EdepIterator> EdepRange;
+  typedef std::pair<EdepConstIterator, EdepConstIterator> EdepConstRange;
 
   virtual ~PHG4CylinderCell(){}
 
@@ -15,18 +22,18 @@ class PHG4CylinderCell : public PHObject
     os << "PHG4CylinderCell base class" << std::endl;
   }
   
-  virtual std::pair< std::map<unsigned int,float>::const_iterator, std::map<unsigned int,float>::const_iterator > get_g4hits() {
-    std::map <unsigned int, float> dummy;
+  virtual EdepConstRange get_g4hits() {
+    std::map <PHG4HitDefs::keytype, float> dummy;
     return std::make_pair(dummy.begin(), dummy.end());
   }
   
-  virtual void add_edep(const unsigned int g4hitid, const float edep) {return;}
-  virtual void set_cell_id(const unsigned int id) {return;}
+  virtual void add_edep(const PHG4HitDefs::keytype g4hitid, const float edep) {return;}
+  virtual void set_cell_id(const PHG4CylinderCellDefs::keytype id) {return;}
   virtual void set_layer(const unsigned int i) {return;}
  
   virtual double get_edep() const {return NAN;}
   virtual unsigned int get_layer() const {return 0xFFFFFFFF;}
-  virtual unsigned int get_cell_id() const {return 0xFFFFFFFF;}
+  virtual PHG4CylinderCellDefs::keytype get_cell_id() const {return 0xFFFFFFFF;}
   virtual int get_binz() const {return -1;}
   virtual int get_binphi() const {return -1;}
   virtual int get_bineta() const {return -1;}
@@ -37,9 +44,9 @@ class PHG4CylinderCell : public PHObject
 
   virtual void set_sensor_index(const std::string &si) {return;}
   virtual std::string get_sensor_index() const {return "";}
-  virtual void set_ladder_phi_index(int i) {return;}
+  virtual void set_ladder_phi_index(const int i) {return;}
   virtual int get_ladder_phi_index() const {return -9999;}
-  virtual void set_ladder_z_index(int i) {return;}
+  virtual void set_ladder_z_index(const int i) {return;}
   virtual int get_ladder_z_index() const {return -9999;}
   
  protected:

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.cc
@@ -43,18 +43,19 @@ PHG4CylinderCellContainer::identify(ostream& os) const
   return;
 }
 
-unsigned int
-PHG4CylinderCellContainer::genkey(const int detid)
+
+PHG4CylinderCellDefs::keytype
+PHG4CylinderCellContainer::genkey(const unsigned int detid)
 {
-  if ((detid >> phg4cylindercelldefs::keybits) > 0)
+  if ((detid >> PHG4CylinderCellDefs::keybits) > 0)
     {
       cout << " detector id too large: " << detid << endl;
       exit(1);
     }
-  int shiftval = detid << phg4cylindercelldefs::cell_idbits;
-  int cellid = cellmap.size();
+  unsigned int shiftval = detid << PHG4CylinderCellDefs::cell_idbits;
+  unsigned int cellid = cellmap.size();
   cellid++;
-  int newkey = cellid | shiftval;
+  PHG4CylinderCellDefs::keytype newkey = cellid | shiftval;
   if (cellmap.find(newkey) != cellmap.end())
     {
       cout << " duplicate key: " << newkey << " exiting now" << endl;
@@ -63,26 +64,27 @@ PHG4CylinderCellContainer::genkey(const int detid)
   return newkey;
 }
 
-std::map<unsigned int,PHG4CylinderCell *>::const_iterator
-PHG4CylinderCellContainer::AddCylinderCell(const int detid, PHG4CylinderCell *newcell)
+PHG4CylinderCellContainer::ConstIterator
+PHG4CylinderCellContainer::AddCylinderCell(const unsigned int detid, PHG4CylinderCell *newcell)
 {
-  unsigned int key = genkey(detid);
+  PHG4CylinderCellDefs::keytype key = genkey(detid);
   layers.insert(newcell->get_layer());
   newcell->set_cell_id(key);
   cellmap[key] = newcell;
   return cellmap.find(key);
 }
 
-PHG4CylinderCellContainer::ConstRange PHG4CylinderCellContainer::getCylinderCells(const int detid) const
+PHG4CylinderCellContainer::ConstRange 
+PHG4CylinderCellContainer::getCylinderCells(const unsigned int detid) const
 {
-  if ((detid >> phg4cylindercelldefs::keybits) > 0)
+  if ((detid >> PHG4CylinderCellDefs::keybits) > 0)
     {
       cout << " detector id too large: " << detid << endl;
       exit(1);
     }
   //  unsigned int shiftval = detid << cell_idbits;
-  unsigned int keylow = detid << phg4cylindercelldefs::cell_idbits;
-  unsigned int keyup = ((detid + 1)<< phg4cylindercelldefs::cell_idbits) -1 ;
+  PHG4CylinderCellDefs::keytype keylow = detid << PHG4CylinderCellDefs::cell_idbits;
+  PHG4CylinderCellDefs::keytype keyup = ((detid + 1)<< PHG4CylinderCellDefs::cell_idbits) -1 ;
 //   cout << "keylow: 0x" << hex << keylow << dec << endl;
 //   cout << "keyup: 0x" << hex << keyup << dec << endl;
   ConstRange retpair;
@@ -91,11 +93,13 @@ PHG4CylinderCellContainer::ConstRange PHG4CylinderCellContainer::getCylinderCell
   return retpair;
 }
 
-PHG4CylinderCellContainer::ConstRange PHG4CylinderCellContainer::getCylinderCells( void ) const
+PHG4CylinderCellContainer::ConstRange 
+PHG4CylinderCellContainer::getCylinderCells( void ) const
 { return std::make_pair( cellmap.begin(), cellmap.end() ); }
 
 
-PHG4CylinderCellContainer::Iterator PHG4CylinderCellContainer::findOrAddCylinderCell(unsigned int key)
+PHG4CylinderCellContainer::Iterator 
+PHG4CylinderCellContainer::findOrAddCylinderCell(PHG4CylinderCellDefs::keytype key)
 {
   PHG4CylinderCellContainer::Iterator it = cellmap.find(key);
   if(it == cellmap.end())
@@ -109,7 +113,8 @@ PHG4CylinderCellContainer::Iterator PHG4CylinderCellContainer::findOrAddCylinder
   return it;
 }
 
-PHG4CylinderCell* PHG4CylinderCellContainer::findCylinderCell(unsigned int key)
+PHG4CylinderCell* 
+PHG4CylinderCellContainer::findCylinderCell(PHG4CylinderCellDefs::keytype key)
 {
   PHG4CylinderCellContainer::ConstIterator it = cellmap.find(key);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.h
@@ -12,7 +12,7 @@ class PHG4CylinderCellContainer: public PHObject
 {
 
   public:
-  typedef std::map<unsigned int,PHG4CylinderCell *> Map;
+  typedef std::map<PHG4CylinderCellDefs::keytype,PHG4CylinderCell *> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
@@ -28,10 +28,10 @@ class PHG4CylinderCellContainer: public PHObject
 
   void identify(std::ostream& os = std::cout) const;
 
-  ConstIterator AddCylinderCell(const int detid, PHG4CylinderCell *newcylinderCell);
+  ConstIterator AddCylinderCell(const unsigned int detid, PHG4CylinderCell *newcylinderCell);
   
   //! preferred removal method, key is currently the cell id
-  void RemoveCylinderCell(unsigned int key) {
+  void RemoveCylinderCell(PHG4CylinderCellDefs::keytype key) {
     cellmap.erase(key);
   }
 
@@ -54,17 +54,17 @@ class PHG4CylinderCellContainer: public PHObject
   }
 
 
-  Iterator findOrAddCylinderCell(unsigned int key);
+  Iterator findOrAddCylinderCell(PHG4CylinderCellDefs::keytype key);
 
-  unsigned int genkey(const int detid);
+  PHG4CylinderCellDefs::keytype genkey(const unsigned int detid);
 
   //! return all cylinderCells matching a given detid
-  ConstRange getCylinderCells(const int detid) const;
+  ConstRange getCylinderCells(const unsigned int detid) const;
 
   //! return all hist
   ConstRange getCylinderCells( void ) const;
 
-  PHG4CylinderCell* findCylinderCell(unsigned int key);
+  PHG4CylinderCell* findCylinderCell(PHG4CylinderCellDefs::keytype key);
 
   unsigned int size( void ) const
   { return cellmap.size(); }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellDefs.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellDefs.h
@@ -1,8 +1,9 @@
 #ifndef PHG4CYLINDERCELLGEFS_H
 #define PHG4CYLINDERCELLGEFS_H
 
-namespace phg4cylindercelldefs
+namespace PHG4CylinderCellDefs
 {
+  typedef unsigned int keytype;
   static int keybits = 8;
   static int cell_idbits = 32 - keybits;
   enum {undefined = 0, sizebinning = 1, etaphibinning = 2, etaslatbinning = 3};

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom.cc
@@ -26,42 +26,42 @@ PHG4CylinderCellGeom::PHG4CylinderCellGeom():
 void
 PHG4CylinderCellGeom::set_zbins(const int i)
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   nzbins = i;
 }
 
 void
 PHG4CylinderCellGeom::set_zmin(const double z)
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   zmin = z;
 }
 
 int
 PHG4CylinderCellGeom::get_zbins() const
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return nzbins;
 }
 
 double
 PHG4CylinderCellGeom::get_zmin() const
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return zmin;
 }
 
 double
 PHG4CylinderCellGeom::get_zstep() const
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return zstep;
 }
 
 void
 PHG4CylinderCellGeom::set_zstep(const double z)
 {
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   zstep = z;
 }
 
@@ -156,17 +156,17 @@ PHG4CylinderCellGeom::identify(std::ostream& os) const
      << ", thickness: " << thickness;
   switch (binning)
     {
-    case phg4cylindercelldefs::sizebinning:
+    case PHG4CylinderCellDefs::sizebinning:
       os << ", zbins: " << nzbins
 	 << ", zmin: " << zmin
 	 << ", zstepsize: " << zstep;
       break;
-    case phg4cylindercelldefs::etaphibinning:
+    case PHG4CylinderCellDefs::etaphibinning:
       os << ", etabins: " << nzbins
 	 << ", etamin: " << zmin
 	 << ", etastepsize: " << zstep;
       break;
-    case phg4cylindercelldefs::etaslatbinning:
+    case PHG4CylinderCellDefs::etaslatbinning:
       os << ", etabins: " << nzbins
 	 << ", etamin: " << zmin
 	 << ", etastepsize: " << zstep;
@@ -191,7 +191,7 @@ PHG4CylinderCellGeom::get_zbounds(const int ibin) const
       cout << "Asking for invalid bin in z: " << ibin << endl;
       exit(1);
     }
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   double zlow = zmin + ibin * zstep;
   double zhigh = zlow + zstep;
   return make_pair(zlow, zhigh);
@@ -206,7 +206,7 @@ PHG4CylinderCellGeom::get_etabounds(const int ibin) const
       exit(1);
     }
   check_binning_method_eta("PHG4CylinderCellGeom::get_etabounds");
-//  check_binning_method(phg4cylindercelldefs::etaphibinning);
+//  check_binning_method(PHG4CylinderCellDefs::etaphibinning);
   double zlow = zmin + ibin * zstep;
   double zhigh = zlow + zstep;
   return make_pair(zlow, zhigh);
@@ -236,7 +236,7 @@ PHG4CylinderCellGeom::get_zbin(const double z) const
     return -1;
   }
   
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return floor( (z-zmin)/zstep );
 }
 
@@ -273,7 +273,7 @@ PHG4CylinderCellGeom::get_zcenter(const int ibin) const
       cout << "Asking for invalid bin in z: " << ibin << endl;
       exit(1);
     }
-  check_binning_method(phg4cylindercelldefs::sizebinning);
+  check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return zmin + (ibin + 0.5)*zstep;
 }
 
@@ -308,13 +308,13 @@ PHG4CylinderCellGeom::methodname(const int i) const
 {
   switch (i)
     {
-    case phg4cylindercelldefs::sizebinning:
+    case PHG4CylinderCellDefs::sizebinning:
       return "Bins in cm";
       break;
-    case phg4cylindercelldefs::etaphibinning:
+    case PHG4CylinderCellDefs::etaphibinning:
       return "Eta/Phi bins";
       break;
-    case phg4cylindercelldefs::etaslatbinning:
+    case PHG4CylinderCellDefs::etaslatbinning:
       return "Eta/numslat bins";
       break;
     default:
@@ -339,15 +339,15 @@ PHG4CylinderCellGeom::check_binning_method(const int i) const
 void
 PHG4CylinderCellGeom::check_binning_method_eta(const std::string & src) const
 {
-  if (binning != phg4cylindercelldefs::etaphibinning && 
-      binning != phg4cylindercelldefs::etaslatbinning)
+  if (binning != PHG4CylinderCellDefs::etaphibinning && 
+      binning != PHG4CylinderCellDefs::etaslatbinning)
     {
       if (src.size())
         cout << src<<" : ";
 
       cout << "different binning method used " << methodname(binning)
-           << ", not : " << methodname(phg4cylindercelldefs::etaphibinning)
-	   << " or " << methodname(phg4cylindercelldefs::etaslatbinning)
+           << ", not : " << methodname(PHG4CylinderCellDefs::etaphibinning)
+	   << " or " << methodname(PHG4CylinderCellDefs::etaslatbinning)
            << endl;
       exit(1);
     }
@@ -357,16 +357,16 @@ PHG4CylinderCellGeom::check_binning_method_eta(const std::string & src) const
 void
 PHG4CylinderCellGeom::check_binning_method_phi(const std::string & src) const
 {
-  if (binning != phg4cylindercelldefs::etaphibinning && 
-      binning != phg4cylindercelldefs::sizebinning &&
-      binning != phg4cylindercelldefs::etaslatbinning)
+  if (binning != PHG4CylinderCellDefs::etaphibinning && 
+      binning != PHG4CylinderCellDefs::sizebinning &&
+      binning != PHG4CylinderCellDefs::etaslatbinning)
     {
       if (src.size())
         cout << src<<" : ";
 
       cout << "different binning method used " << methodname(binning)
-           << ", not : " << methodname(phg4cylindercelldefs::etaphibinning)
-	   << " or " << methodname(phg4cylindercelldefs::sizebinning)
+           << ", not : " << methodname(PHG4CylinderCellDefs::etaphibinning)
+	   << " or " << methodname(PHG4CylinderCellDefs::sizebinning)
            << endl;
       exit(1);
     }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -103,7 +103,7 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
       layerseggeo->set_layer(layergeom->get_layer());
       layerseggeo->set_radius(layergeom->get_radius());
       layerseggeo->set_thickness(layergeom->get_thickness());
-      if (binning[layer] == phg4cylindercelldefs::etaphibinning)
+      if (binning[layer] == PHG4CylinderCellDefs::etaphibinning)
         {
           // calculate eta at radius+ thickness (outer radius)
           // length via eta coverage is calculated using the outer radius
@@ -155,7 +155,7 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
             }
           pair<int, int> phi_z_bin = make_pair(phibins, etabins);
           n_phi_z_bins[layer] = phi_z_bin;
-          layerseggeo->set_binning(phg4cylindercelldefs::etaphibinning);
+          layerseggeo->set_binning(PHG4CylinderCellDefs::etaphibinning);
           layerseggeo->set_etabins(etabins);
           layerseggeo->set_etamin(etamin);
           layerseggeo->set_etastep(etastepsize);
@@ -165,7 +165,7 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
           phistep[layer] = phistepsize;
           etastep[layer] = etastepsize;
         }
-      else if (binning[layer] == phg4cylindercelldefs::sizebinning)
+      else if (binning[layer] == PHG4CylinderCellDefs::sizebinning)
         {
           zmin_max[layer] = make_pair(layergeom->get_zmin(), layergeom->get_zmax());
           double size_z = (sizeiter->second).second;
@@ -222,7 +222,7 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
                 }
               zhigh += size_z;
             }
-          layerseggeo->set_binning(phg4cylindercelldefs::sizebinning);
+          layerseggeo->set_binning(PHG4CylinderCellDefs::sizebinning);
           layerseggeo->set_zbins(nbins[1]);
           layerseggeo->set_zmin(layergeom->get_zmin());
           layerseggeo->set_zstep(size_z);
@@ -245,14 +245,14 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
 	 iter != binning.end(); ++iter) {
       int layer = iter->first;
 
-      if (binning[layer] == phg4cylindercelldefs::etaphibinning) {
+      if (binning[layer] == PHG4CylinderCellDefs::etaphibinning) {
 	// phi & eta bin is usually used to make projective towers
 	// so just print the first layer
 	cout << " Layer #" << binning.begin()->first << "-" << binning.rbegin()->first << endl;
 	cout << "   Nbins (phi,eta): (" << n_phi_z_bins[layer].first << ", " << n_phi_z_bins[layer].second << ")" << endl;
 	cout << "   Cell Size (phi,eta): (" << cell_size[layer].first << " rad, " << cell_size[layer].second << " units)" << endl;
 	break;
-      } else if (binning[layer] == phg4cylindercelldefs::sizebinning) {	
+      } else if (binning[layer] == PHG4CylinderCellDefs::sizebinning) {	
 	cout << " Layer #" << layer << endl;
 	cout << "   Nbins (phi,z): (" << n_phi_z_bins[layer].first << ", " << n_phi_z_bins[layer].second << ")" << endl;
 	cout << "   Cell Size (phi,z): (" << cell_size[layer].first << " cm, " << cell_size[layer].second << " cm)" << endl;
@@ -308,7 +308,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
       int nzbins = n_phi_z_bins[*layer].second;
 
       // ------- eta/phi binning ------------------------------------------------------------------------
-      if (binning[*layer] == phg4cylindercelldefs::etaphibinning)
+      if (binning[*layer] == PHG4CylinderCellDefs::etaphibinning)
         {
           for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
             {
@@ -722,13 +722,13 @@ PHG4CylinderCellReco::End(PHCompositeNode *topNode)
 void
 PHG4CylinderCellReco::cellsize(const int i, const double sr, const double sz)
 {
-  set_size(i, sr, sz, phg4cylindercelldefs::sizebinning);
+  set_size(i, sr, sz, PHG4CylinderCellDefs::sizebinning);
 }
 
 void
 PHG4CylinderCellReco::etaphisize(const int i, const double deltaeta, const double deltaphi)
 {
-  set_size(i, deltaeta, deltaphi, phg4cylindercelldefs::etaphibinning);
+  set_size(i, deltaeta, deltaphi, PHG4CylinderCellDefs::etaphibinning);
   return;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.cc
@@ -13,7 +13,7 @@ PHG4CylinderCellv1::PHG4CylinderCellv1():
 {}
 
 void
-PHG4CylinderCellv1::add_edep(const unsigned int g4hitid, const float edep)
+PHG4CylinderCellv1::add_edep(const unsigned long long g4hitid, const float edep)
 {
   if (edeps.find(g4hitid) == edeps.end())
     {
@@ -28,7 +28,7 @@ PHG4CylinderCellv1::add_edep(const unsigned int g4hitid, const float edep)
 double PHG4CylinderCellv1::get_edep() const {
   
   double esum = 0.0;
-  map<unsigned int,float>::const_iterator iter;
+  map<unsigned long long,float>::const_iterator iter;
   for (iter = edeps.begin(); iter != edeps.end(); ++iter) {
     esum += iter->second;
   }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.cc
@@ -1,4 +1,5 @@
 #include "PHG4CylinderCellv1.h"
+#include "PHG4CylinderCellDefs.h"
 
 using namespace std;
 
@@ -13,7 +14,7 @@ PHG4CylinderCellv1::PHG4CylinderCellv1():
 {}
 
 void
-PHG4CylinderCellv1::add_edep(const unsigned long long g4hitid, const float edep)
+PHG4CylinderCellv1::add_edep(const PHG4HitDefs::keytype g4hitid, const float edep)
 {
   if (edeps.find(g4hitid) == edeps.end())
     {
@@ -28,7 +29,7 @@ PHG4CylinderCellv1::add_edep(const unsigned long long g4hitid, const float edep)
 double PHG4CylinderCellv1::get_edep() const {
   
   double esum = 0.0;
-  map<unsigned long long,float>::const_iterator iter;
+  EdepConstIterator iter;
   for (iter = edeps.begin(); iter != edeps.end(); ++iter) {
     esum += iter->second;
   }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.h
@@ -2,6 +2,8 @@
 #define PHG4CYLINDERCELLV1_H
 
 #include "PHG4CylinderCell.h"
+#include <g4main/PHG4HitDefs.h>
+
 #include <cmath>
 #include <map>
 
@@ -14,14 +16,14 @@ class PHG4CylinderCellv1 : public PHG4CylinderCell
 
   void identify(std::ostream& os = std::cout) const;
 
-  std::pair< std::map<unsigned int,float>::const_iterator, std::map<unsigned int,float>::const_iterator > get_g4hits()
+   EdepConstRange get_g4hits()
     {return make_pair(edeps.begin(), edeps.end());}
-  void add_edep(const unsigned int g4hitid, const float edep);
-  void set_cell_id(const unsigned int id) {cellid = id;}
+  void add_edep(const PHG4HitDefs::keytype g4hitid, const float edep);
+  void set_cell_id(const PHG4CylinderCellDefs::keytype id) {cellid = id;}
   void set_layer(const unsigned int i) {layer = i;}
   double get_edep() const;
   unsigned int get_layer() const {return layer;}
-  unsigned int get_cell_id() const {return cellid;}
+  PHG4CylinderCellDefs::keytype get_cell_id() const {return cellid;}
   int get_binz() const {return binz;}
   int get_binphi() const {return binphi;}
   int get_bineta() const {return get_binz();}
@@ -33,10 +35,10 @@ class PHG4CylinderCellv1 : public PHG4CylinderCell
  protected:
 
   unsigned int layer;
-  unsigned int cellid;
+  PHG4CylinderCellDefs::keytype cellid;
   int binz;
   int binphi;
-  std::map<unsigned int, float> edeps;
+  EdepMap edeps;
    
   ClassDef(PHG4CylinderCellv1,1)
 };

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv2.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv2.h
@@ -18,10 +18,10 @@ class PHG4CylinderCellv2 : public PHG4CylinderCellv1
   void set_sensor_index(const std::string &si) {sensor_index = si;}
   std::string get_sensor_index() const  {return sensor_index;}
 
-  void set_ladder_phi_index(int i) {ladder_phi_index = i;}
+  void set_ladder_phi_index(const int i) {ladder_phi_index = i;}
   int get_ladder_phi_index() const {return ladder_phi_index;}
 
-  void set_ladder_z_index(int i) {ladder_z_index = i;}
+  void set_ladder_z_index(const int i) {ladder_z_index = i;}
   int get_ladder_z_index() const {return ladder_z_index;}
   
  protected:

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -114,7 +114,7 @@ int PHG4HcalCellReco::InitRun(PHCompositeNode *topNode)
 	    {
 	      layergeom->identify();
 	    }
-          layerseggeo->set_binning(phg4cylindercelldefs::etaslatbinning);
+          layerseggeo->set_binning(PHG4CylinderCellDefs::etaslatbinning);
           layerseggeo->set_etabins(22);
           layerseggeo->set_etamin(-1.1);
           layerseggeo->set_etastep((1.1+1.1)/22.);
@@ -241,7 +241,7 @@ PHG4HcalCellReco::etasize_nslat(const int i, const double deltaeta, const int ns
   if (nslat >= 1)
     {
       nslatscombined = nslat;
-      set_size(i, deltaeta, nslat, phg4cylindercelldefs::etaslatbinning);
+      set_size(i, deltaeta, nslat, PHG4CylinderCellDefs::etaslatbinning);
     }
   else
     {

--- a/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
@@ -111,7 +111,7 @@ int PHG4SlatCellReco::InitRun(PHCompositeNode *topNode)
       layerseggeo->set_layer(layergeom->get_layer());
       layerseggeo->set_radius(layergeom->get_radius());
       layerseggeo->set_thickness(layergeom->get_thickness());
-      if (binning[layer] == phg4cylindercelldefs::etaslatbinning)
+      if (binning[layer] == PHG4CylinderCellDefs::etaslatbinning)
         {
           // calculate eta at radius+ thickness (outer radius)
           // length via eta coverage is calculated using the outer radius
@@ -157,7 +157,7 @@ int PHG4SlatCellReco::InitRun(PHCompositeNode *topNode)
 	    {
 	      layergeom->identify();
 	    }
-          layerseggeo->set_binning(phg4cylindercelldefs::etaslatbinning);
+          layerseggeo->set_binning(PHG4CylinderCellDefs::etaslatbinning);
           layerseggeo->set_etabins(etabins);
           layerseggeo->set_etamin(etamin);
           layerseggeo->set_etastep(etastepsize);
@@ -229,7 +229,7 @@ PHG4SlatCellReco::process_event(PHCompositeNode *topNode)
 
 
       // ------- eta/phi binning ------------------------------------------------------------------------
-      if (binning[*layer] == phg4cylindercelldefs::etaslatbinning)
+      if (binning[*layer] == PHG4CylinderCellDefs::etaslatbinning)
         {
           for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
             {
@@ -384,13 +384,13 @@ PHG4SlatCellReco::End(PHCompositeNode *topNode)
 void
 PHG4SlatCellReco::cellsize(const int i, const double sr, const double sz)
 {
-  set_size(i, sr, sz, phg4cylindercelldefs::sizebinning);
+  set_size(i, sr, sz, PHG4CylinderCellDefs::sizebinning);
 }
 
 void
 PHG4SlatCellReco::etaphisize(const int i, const double deltaeta, const double deltaphi)
 {
-  set_size(i, deltaeta, deltaphi, phg4cylindercelldefs::etaphibinning);
+  set_size(i, deltaeta, deltaphi, PHG4CylinderCellDefs::etaphibinning);
   return;
 }
 
@@ -400,7 +400,7 @@ PHG4SlatCellReco::etasize_nslat(const int i, const double deltaeta, const int ns
   if (nslat >= 1)
     {
       nslatscombined = nslat;
-      set_size(i, deltaeta, nslat, phg4cylindercelldefs::etaslatbinning);
+      set_size(i, deltaeta, nslat, PHG4CylinderCellDefs::etaslatbinning);
     }
   else
     {

--- a/simulation/g4simulation/g4eval/PHG4CalEvaluator.C
+++ b/simulation/g4simulation/g4eval/PHG4CalEvaluator.C
@@ -12,11 +12,13 @@
 #include <g4detectors/PHG4CylinderCellContainer.h>
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitDefs.h>
 #include <g4main/PHG4VtxPoint.h>
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <g4main/PHG4VtxPoint.h>
 #include <g4detectors/PHG4CylinderCell.h>
+#include <g4detectors/PHG4CylinderCellDefs.h>
 #include <g4cemc/RawTower.h>
 #include <g4cemc/RawTowerContainer.h>
 #include <g4cemc/RawTowerGeom.h>
@@ -580,13 +582,12 @@ void PHG4CalEvaluator::fillTowerToGshowerMap()
 		}
 
 	      // loop over all ghits within those cells
-	      std::pair< std::map<unsigned int, float>::const_iterator, 
-			 std::map<unsigned int, float>::const_iterator > g4hits = cell->get_g4hits();
-	      std::map<unsigned int, float>::const_iterator g4iter = g4hits.first;
+	      PHG4CylinderCell::EdepConstRange g4hits = cell->get_g4hits();
+	      PHG4CylinderCell::EdepConstIterator g4iter = g4hits.first;
 	      for (g4iter = g4hits.first; g4iter != g4hits.second; g4iter++)
 		{
 		  // ask each ghit how much energy it deposited and where that energy came from
-		  int g4hit_id = g4iter->first;
+		  PHG4HitDefs::keytype g4hit_id = g4iter->first;
 		  float g4hit_energy = g4iter->second;
 		  CalGshower *gshower = _g4hitid_gshower_map[g4hit_id];
 		  PHG4Hit *ghit = _g4hitList->findHit( g4hit_id );

--- a/simulation/g4simulation/g4eval/PHG4CalEvaluator.h
+++ b/simulation/g4simulation/g4eval/PHG4CalEvaluator.h
@@ -8,6 +8,8 @@
 /// \author Richard Hollis (translated to sPHENIX CAL simulations)
 //===============================================
 
+#include <g4main/PHG4HitDefs.h>
+
 // PHENIX includes
 #include <fun4all/SubsysReco.h>
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -149,8 +151,6 @@ class PHG4CalEvaluator : public SubsysReco
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
-  void Verbosity(int verb){verbosity = verb;}
-
   void set_trace_truth(bool b) {_trace_truth = false;}
 
   void Detector(const std::string &name) {detector = name;}
@@ -191,7 +191,7 @@ class PHG4CalEvaluator : public SubsysReco
   std::string detector;
   std::vector<CalGshower> _gshower_list;              ///< holds a list of truth particles (convenience storage)
   std::map <PHG4Hit*,CalGshower*> _g4hit_gshower_map; ///< reverse g4hit->gshower lookup
-  std::map <int,CalGshower*> _g4hitid_gshower_map;    ///< reverse g4hit->gshower lookup (uses id)
+  std::map <PHG4HitDefs::keytype,CalGshower*> _g4hitid_gshower_map;    ///< reverse g4hit->gshower lookup (uses id)
   
   std::map <RawTower*, CalGshower*> _tower_gshower_map;     ///< holds the greatest truth contributor map to a particular tower
   std::map <RawTower*, float> _tower_epurity_map;            ///< holds the greatest truth contributor map to a particular tower

--- a/simulation/g4simulation/g4eval/PHG4Evaluator.h
+++ b/simulation/g4simulation/g4eval/PHG4Evaluator.h
@@ -27,6 +27,8 @@
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitDefs.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Particle.h>
 
 // ROOT includes
@@ -207,7 +209,7 @@ class SvxGtrack : public PHObject
 ///
 class PHG4Evaluator : public SubsysReco
 {
-  typedef std::map<unsigned int, PHG4Hit*> HitMap;
+  typedef PHG4HitContainer::Map HitMap;
 
  public:
  
@@ -234,7 +236,7 @@ class PHG4Evaluator : public SubsysReco
 
   enum LayerType {CylinderLayer, LadderLayer};
   
-  unsigned long _ievent;
+  unsigned int _ievent;
   PHTimeServer::timer _timer;   ///< Timer
   std::vector<PHTimeServer::timer> _internal_timer;
 
@@ -272,6 +274,7 @@ class PHG4Evaluator : public SubsysReco
   SvtxHitMap *_hitList;
   PHG4CylinderCellContainer *_cellList;
   PHG4CylinderCellGeomContainer *_cellGeos;
+  // typedefed from PHG4HitContainer::Map
   HitMap _g4hitList;
   PHG4TruthInfoContainer* _truth_info_container;
   
@@ -302,7 +305,7 @@ class PHG4Evaluator : public SubsysReco
   std::map <SvtxTrack*, unsigned int> _track_purity_map;
 
 
-  std::multimap <int, unsigned int> _particleid_g4hitid_mmap; ///< forward look up between a truth particle id and a g4hit id
+  std::multimap <int, PHG4HitDefs::keytype> _particleid_g4hitid_mmap; ///< forward look up between a truth particle id and a g4hit id
   EvalLinks* _cluster_g4hit_svtx_links;
   EvalLinks* _cluster_g4hit_silicon_tracker_links;
   EvalLinks* _track_particle_links;

--- a/simulation/g4simulation/g4hough/PHG4SvtxAddConnectedCells.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxAddConnectedCells.C
@@ -7,6 +7,7 @@
 #include <fun4all/getClass.h>
 #include <g4detectors/PHG4CylinderCellContainer.h>
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderCell.h>
 #include <g4detectors/PHG4CylinderCellv1.h>
 #include <g4detectors/PHG4CylinderCellGeom.h>
 
@@ -147,17 +148,18 @@ int PHG4SvtxAddConnectedCells::process_event(PHCompositeNode *topNode) {
 	int ibinz = cell_list[i]->get_binz();
 	int ibinphi = cell_list[i]->get_binphi();
 
-	int g4hitid = -1;
-	typedef map<unsigned int,float>::const_iterator hitmapiterator;
-	pair<hitmapiterator,hitmapiterator> maprange = cell_list[i]->get_g4hits();
-	for (hitmapiterator hititer = maprange.first;
+	PHG4HitDefs::keytype g4hitid = ~0;
+	int foundit = 0;
+	PHG4CylinderCell::EdepConstRange maprange = cell_list[i]->get_g4hits();
+	for (PHG4CylinderCell::EdepConstIterator hititer = maprange.first;
 	     hititer != maprange.second;
 	     hititer++) {
 	  g4hitid = hititer->first;
+	  foundit = 1;
 	}
 
 	// Should be impossible
-	if(g4hitid == -1)
+	if(!foundit)
 	  {
 	    cout << "Oops! G4 hitid not found" << endl;
 	    continue;
@@ -212,10 +214,9 @@ int PHG4SvtxAddConnectedCells::process_event(PHCompositeNode *topNode) {
 	  PHG4CylinderCell* cell = celliter->second;
 	  
 	  // Get the G4 hitid
-	  int g4hitid = -1;
-	  typedef map<unsigned int,float>::const_iterator hitmapiterator;
-	  pair<hitmapiterator,hitmapiterator> maprange = cell->get_g4hits();
-	  for (hitmapiterator hititer = maprange.first;
+	  PHG4HitDefs::keytype g4hitid = ~0;
+	  PHG4CylinderCell::EdepConstRange maprange = cell->get_g4hits();
+	  for (PHG4CylinderCell::EdepConstIterator hititer = maprange.first;
 	       hititer != maprange.second;
 	       hititer++) {
 	    g4hitid = hititer->first;

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -1,6 +1,7 @@
 #ifndef PHG4Hit_H__
 #define PHG4Hit_H__
 
+#include "PHG4HitDefs.h"
 #include <phool/PHObject.h>
 #include <cmath>
 #include <climits>
@@ -28,7 +29,7 @@ class PHG4Hit: public PHObject
   virtual float get_light_yield() const {return NAN;}
   virtual float get_path_length() const {return NAN;}
   virtual unsigned int get_layer() const {return UINT_MAX;}
-  virtual unsigned long long get_hit_id() const {return ULONG_LONG_MAX;}
+  virtual PHG4HitDefs::keytype get_hit_id() const {return ULONG_LONG_MAX;}
   virtual int get_scint_id() const {return INT_MIN;}
   virtual int get_trkid() const {return INT_MIN;}
   virtual int get_strip_z_index() const {return INT_MIN;}
@@ -52,7 +53,7 @@ class PHG4Hit: public PHObject
   virtual void set_light_yield(const float lightYield){return;}
   virtual void set_path_length(const float pathLength){return;}
   virtual void set_layer(const unsigned int i) {return;}
-  virtual void set_hit_id(const unsigned long long i) {return;}
+  virtual void set_hit_id(const PHG4HitDefs::keytype i) {return;}
   virtual void set_scint_id(const int i) {return;}
   virtual void set_trkid(const int i) {return;}
   virtual void set_strip_z_index(const int i) {return;}

--- a/simulation/g4simulation/g4main/PHG4HitContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4HitContainer.cc
@@ -43,7 +43,7 @@ PHG4HitContainer::identify(ostream& os) const
   return;
 }
 
-unsigned long long 
+PHG4HitDefs::keytype
 PHG4HitContainer::getmaxkey(const unsigned int detid)
 {
   ConstRange miter = getHits(detid);
@@ -58,32 +58,32 @@ PHG4HitContainer::getmaxkey(const unsigned int detid)
     {
       return  0;
     }
-  unsigned long long detidlong = detid;
-  unsigned long long shiftval = detidlong << phg4hitdefs::hit_idbits;
+  PHG4HitDefs::keytype detidlong = detid;
+  PHG4HitDefs::keytype shiftval = detidlong << PHG4HitDefs::hit_idbits;
   ConstIterator lastlayerentry = miter.second;
   --lastlayerentry;
-  unsigned long long iret = lastlayerentry->first - shiftval; // subtract layer mask
+  PHG4HitDefs::keytype iret = lastlayerentry->first - shiftval; // subtract layer mask
   return iret;
 }
 
 
-unsigned long long
+PHG4HitDefs::keytype
 PHG4HitContainer::genkey(const unsigned int detid)
 {
-  if ((detid >> phg4hitdefs::keybits) > 0)
+  if ((detid >> PHG4HitDefs::keybits) > 0)
     {
       cout << " detector id too large: " << detid << endl;
       exit(1);
     }
-  unsigned long long detidlong = detid;
-  unsigned long long shiftval = detidlong << phg4hitdefs::hit_idbits;
+  PHG4HitDefs::keytype detidlong = detid;
+  PHG4HitDefs::keytype shiftval = detidlong << PHG4HitDefs::hit_idbits;
   //  cout << "max index: " << (detminmax->second)->first << endl;
   // after removing hits with no energy deposition, we have holes
   // in our hit ranges. This construct will get us the last hit in
   // a layer and return it's hit id. Adding 1 will put us at the end of this layer
-  unsigned long long hitid = getmaxkey(detid);
+  PHG4HitDefs::keytype hitid = getmaxkey(detid);
   hitid++;
-  unsigned long long newkey = hitid | shiftval;
+  PHG4HitDefs::keytype newkey = hitid | shiftval;
   if (hitmap.find(newkey) != hitmap.end())
     {
       cout << PHWHERE << " duplicate key: 0x" 
@@ -99,13 +99,13 @@ PHG4HitContainer::genkey(const unsigned int detid)
 PHG4HitContainer::ConstIterator
 PHG4HitContainer::AddHit(PHG4Hit *newhit)
 {
-  unsigned long long key = newhit->get_hit_id();
+  PHG4HitDefs::keytype key = newhit->get_hit_id();
   if (hitmap.find(key) != hitmap.end())
     {
       cout << "hit with id  0x" << hex << key << " exists already" << endl;
       return hitmap.find(key);
     }
-  unsigned long long detidlong = key >>  phg4hitdefs::hit_idbits;
+  PHG4HitDefs::keytype detidlong = key >>  PHG4HitDefs::hit_idbits;
   unsigned int detid = detidlong;
   layers.insert(detid);
   hitmap[key] = newhit;
@@ -115,7 +115,7 @@ PHG4HitContainer::AddHit(PHG4Hit *newhit)
 PHG4HitContainer::ConstIterator
 PHG4HitContainer::AddHit(const unsigned int detid, PHG4Hit *newhit)
 {
-  unsigned long long key = genkey(detid);
+  PHG4HitDefs::keytype key = genkey(detid);
   layers.insert(detid);
   newhit->set_hit_id(key);
   hitmap[key] = newhit;
@@ -124,14 +124,14 @@ PHG4HitContainer::AddHit(const unsigned int detid, PHG4Hit *newhit)
 
 PHG4HitContainer::ConstRange PHG4HitContainer::getHits(const unsigned int detid) const
 {
-  if ((detid >> phg4hitdefs::keybits) > 0)
+  if ((detid >> PHG4HitDefs::keybits) > 0)
     {
       cout << " detector id too large: " << detid << endl;
       exit(1);
     }
-  unsigned long long detidlong = detid;
-  unsigned long long  keylow = detidlong << phg4hitdefs::hit_idbits;
-  unsigned long long  keyup = ((detidlong + 1) << phg4hitdefs::hit_idbits) -1 ;
+  PHG4HitDefs::keytype detidlong = detid;
+  PHG4HitDefs::keytype keylow = detidlong << PHG4HitDefs::hit_idbits;
+  PHG4HitDefs::keytype keyup = ((detidlong + 1) << PHG4HitDefs::hit_idbits) -1 ;
   ConstRange retpair;
   retpair.first = hitmap.lower_bound(keylow);
   retpair.second = hitmap.upper_bound(keyup);
@@ -142,7 +142,7 @@ PHG4HitContainer::ConstRange PHG4HitContainer::getHits( void ) const
 { return std::make_pair( hitmap.begin(), hitmap.end() ); }
 
 
-PHG4HitContainer::Iterator PHG4HitContainer::findOrAddHit(unsigned long long key)
+PHG4HitContainer::Iterator PHG4HitContainer::findOrAddHit(PHG4HitDefs::keytype key)
 {
   PHG4HitContainer::Iterator it = hitmap.find(key);
   if(it == hitmap.end())
@@ -157,7 +157,7 @@ PHG4HitContainer::Iterator PHG4HitContainer::findOrAddHit(unsigned long long key
   return it;
 }
 
-PHG4Hit* PHG4HitContainer::findHit(unsigned long long key)
+PHG4Hit* PHG4HitContainer::findHit(PHG4HitDefs::keytype key)
 {
   PHG4HitContainer::ConstIterator it = hitmap.find(key);
   if(it != hitmap.end())

--- a/simulation/g4simulation/g4main/PHG4HitContainer.h
+++ b/simulation/g4simulation/g4main/PHG4HitContainer.h
@@ -1,6 +1,7 @@
 #ifndef PHG4HITCONTAINER_H__
 #define PHG4HITCONTAINER_H__
 
+#include "PHG4HitDefs.h"
 
 #include <phool/PHObject.h>
 #include <map>
@@ -11,7 +12,7 @@ class PHG4HitContainer: public PHObject
 {
 
   public:
-  typedef std::map<unsigned long long,PHG4Hit *> Map;
+  typedef std::map<PHG4HitDefs::keytype, PHG4Hit *> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
@@ -30,11 +31,11 @@ class PHG4HitContainer: public PHObject
 
   ConstIterator AddHit(const unsigned int detid, PHG4Hit *newhit);
   
-  Iterator findOrAddHit(unsigned long long key);
+  Iterator findOrAddHit(PHG4HitDefs::keytype key);
 
-  PHG4Hit* findHit( unsigned long long key );
+  PHG4Hit* findHit(PHG4HitDefs::keytype key );
 
-  unsigned long long genkey(const unsigned int detid);
+  PHG4HitDefs::keytype genkey(const unsigned int detid);
 
   //! return all hits matching a given detid
   ConstRange getHits(const unsigned int detid) const;
@@ -50,7 +51,7 @@ class PHG4HitContainer: public PHObject
      { return make_pair(layers.begin(), layers.end());} 
   void AddLayer(const unsigned int ilayer) {layers.insert(ilayer);}
   void RemoveZeroEDep();
-  unsigned long long getmaxkey(const unsigned int detid);
+  PHG4HitDefs::keytype getmaxkey(const unsigned int detid);
 
  protected:
   Map hitmap;

--- a/simulation/g4simulation/g4main/PHG4HitDefs.h
+++ b/simulation/g4simulation/g4main/PHG4HitDefs.h
@@ -1,8 +1,9 @@
 #ifndef PHG4HITGEFS_H
 #define PHG4HITGEFS_H
 
-namespace phg4hitdefs
+namespace PHG4HitDefs
 {
+  typedef unsigned long long keytype;
   static int keybits = 8;
   static int hit_idbits = 64-keybits;
 }

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -31,7 +31,8 @@ PHG4Hitv1::PHG4Hitv1(PHG4Hit const &g4hit)
 
 void
 PHG4Hitv1::print() const {
-  std::cout<<"New Hitv1   "<<hitid<<"  on track "<<trackid<<" EDep "<<edep<<std::endl;
+  std::cout<<"New Hitv1  0x"<< hex << hitid 
+	   << dec << "  on track "<<trackid<<" EDep "<<edep<<std::endl;
   std::cout<<"Location: X "<<x[0]<<"/"<<x[1]<<"  Y "<<y[0]<<"/"<<y[1]<<"  Z "<<z[0]<<"/"<<z[1]<<std::endl;
   std::cout<<"Time        "<<t[0]<<"/"<<t[1]<<std::endl;
 

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -2,6 +2,7 @@
 #define PHG4Hitv1_H__
 
 #include "PHG4Hit.h"
+#include "PHG4HitDefs.h"
 
 #include <map>
 #include <stdint.h>
@@ -17,7 +18,7 @@ class PHG4Hitv1 : public PHG4Hit
   float get_z(const int i) const {return z[i];}
   float get_t(const int i) const {return t[i];}
   float get_edep() const {return edep;}
-  unsigned long long get_hit_id() const {return hitid;}
+  PHG4HitDefs::keytype get_hit_id() const {return hitid;}
   int get_trkid() const {return trackid;}
   
   void set_x(const int i, const float f) {x[i]=f;}
@@ -25,7 +26,7 @@ class PHG4Hitv1 : public PHG4Hit
   void set_z(const int i, const float f) {z[i]=f;}
   void set_t(const int i, const float f) {t[i]=f;}
   void set_edep(const float f) {edep = f;}
-  void set_hit_id(const unsigned long long i) {hitid=i;}
+  void set_hit_id(const PHG4HitDefs::keytype i) {hitid=i;}
   void set_trkid(const int i) {trackid=i;}
 
   virtual void print() const;
@@ -81,7 +82,7 @@ class PHG4Hitv1 : public PHG4Hit
   float y[2];
   float z[2];
   float t[2];
-  unsigned long long hitid;
+  PHG4HitDefs::keytype hitid;
   int trackid;
   float edep;
 


### PR DESCRIPTION
Fixed all hitid issues I could find - the eval links in the evaluator might still not be happy but the code passes valgrind