### PR TITLE
cleanup of g4hough code

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -23,6 +23,7 @@
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
 #include <fun4all/getClass.h>
 
 // Geant4 includes

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -21,8 +21,6 @@
 
 // PHENIX includes
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHTypedNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <fun4all/getClass.h>
@@ -41,13 +39,11 @@
 #include <VertexFinder.h>
 
 // ROOT includes
-#include <TVector3.h>
 #include <TH1D.h>
 
 // standard includes
 #include <cmath>
 #include <iostream>
-#include <float.h>
 
 using findNode::getClass;
 using namespace std;

--- a/simulation/g4simulation/g4hough/PHG4SvtxAddConnectedCells.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxAddConnectedCells.C
@@ -1,7 +1,5 @@
 #include "PHG4SvtxAddConnectedCells.h"
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHTypedNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <fun4all/getClass.h>

--- a/simulation/g4simulation/g4hough/PHG4SvtxAddConnectedCells.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxAddConnectedCells.h
@@ -14,8 +14,8 @@ class PHG4SvtxAddConnectedCells : public SubsysReco {
 
 public:
 
-  PHG4SvtxAddConnectedCells(const char * name = "PHG4SvtxAddConnectedCells");
-  ~PHG4SvtxAddConnectedCells(){}
+  PHG4SvtxAddConnectedCells(const std::string &name = "PHG4SvtxAddConnectedCells");
+  virtual ~PHG4SvtxAddConnectedCells(){}
   
   //! module initialization
   int Init(PHCompositeNode *topNode){return 0;}
@@ -30,12 +30,12 @@ public:
   int End(PHCompositeNode *topNode){return 0;}
 
 
-  void set_phi_offset(int offset) {
+  void set_phi_offset(const int offset) {
     connected_phi_offset = offset;
     std::cout << " PHG4SvtxAddConnectedCells: phi bins offset for connected cells set to " << connected_phi_offset << std::endl;
   }
   
-  void set_ncells_connected(int layer, int connected) {
+  void set_ncells_connected(const int layer, const int connected) {
     if(layer < 19)
       {
 	ncells_connected[layer] = connected;

--- a/simulation/g4simulation/g4hough/PHG4SvtxBeamSpotReco.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxBeamSpotReco.C
@@ -1,13 +1,12 @@
 #include "PHG4SvtxBeamSpotReco.h"
-
+#include "SvtxBeamSpot.h"
 #include "SvtxVertexMap.h"
 #include "SvtxVertex.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHTypedNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
 #include <fun4all/getClass.h>
 #include <fun4all/recoConsts.h>
 
@@ -17,13 +16,12 @@
 
 using namespace std;
 
-PHG4SvtxBeamSpotReco::PHG4SvtxBeamSpotReco(const char* name) :
+PHG4SvtxBeamSpotReco::PHG4SvtxBeamSpotReco(const string &name) :
   SubsysReco(name),
   _pca(2),
   _vertexes(NULL),
   _beamspot(NULL),
   _timer(PHTimeServer::get()->insert_new(name)) {
-  verbosity = 0;
 }
 
 int PHG4SvtxBeamSpotReco::InitRun(PHCompositeNode* topNode) {
@@ -35,7 +33,7 @@ int PHG4SvtxBeamSpotReco::InitRun(PHCompositeNode* topNode) {
   PHNodeIterator iter(topNode);
   
   PHCompositeNode *parNode 
-    = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","PAR"));
+    = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","PAR"));
   if (!parNode) {
     cout << PHWHERE << "PAR Node missing, doing nothing." << endl;
     return Fun4AllReturnCodes::ABORTRUN;

--- a/simulation/g4simulation/g4hough/PHG4SvtxBeamSpotReco.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxBeamSpotReco.h
@@ -1,19 +1,20 @@
 #ifndef __PHG4SVTXBEAMSPOTRECO__
 #define __PHG4SVTXBEAMSPOTRECO__
 
-#include "SvtxVertexMap.h"
-#include "SvtxBeamSpot.h"
 
 #include <fun4all/SubsysReco.h>
 #include <phool/PHTimeServer.h>
 
 #include <TPrincipal.h>
 
+class SvtxBeamSpot;
+class SvtxVertexMap;
+
 class PHG4SvtxBeamSpotReco : public SubsysReco {
   
 public:
 
-  PHG4SvtxBeamSpotReco(const char * name = "PHG4SvtxBeamSpotReco");
+  PHG4SvtxBeamSpotReco(const std::string &name = "PHG4SvtxBeamSpotReco");
   virtual ~PHG4SvtxBeamSpotReco(){}
   
   //! module initialization

--- a/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
@@ -8,8 +8,6 @@
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHTypedNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <fun4all/getClass.h>
@@ -123,14 +121,11 @@ bool PHG4SvtxClusterizer::ladder_are_adjacent(const PHG4CylinderCell* lhs,
   return false;
 }
 
-PHG4SvtxClusterizer::PHG4SvtxClusterizer(const char* name) :
+PHG4SvtxClusterizer::PHG4SvtxClusterizer(const string &name) :
   SubsysReco(name),
   _hits(NULL),
   _clusterlist(NULL),
   _fraction_of_mip(0.5),
-  _thresholds_by_layer(),
-  _make_z_clustering(),
-  _make_e_weights(),
   _timer(PHTimeServer::get()->insert_new(name)) {
 }
 
@@ -215,16 +210,12 @@ int PHG4SvtxClusterizer::process_event(PHCompositeNode *topNode) {
 
   _timer.get()->restart();
   
-  _clusterlist = 0;
-  PHTypedNodeIterator<SvtxClusterMap> clusteriter(topNode);
-  PHIODataNode<SvtxClusterMap> *SvtxClusterMapNode = clusteriter.find("SvtxClusterMap");
-  if (!SvtxClusterMapNode) {
-    cout << PHWHERE << " ERROR: Can't find SvtxClusterMap." << endl;
-    return Fun4AllReturnCodes::ABORTRUN;
-  } else {
-    _clusterlist = (SvtxClusterMap*)SvtxClusterMapNode->getData();
-  }
-
+  _clusterlist = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
+  if (!_clusterlist) 
+    {
+      cout << PHWHERE << " ERROR: Can't find SvtxClusterMap." << endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
   _clusterlist->Reset();
   
   ClusterCylinderCells(topNode);
@@ -239,12 +230,7 @@ int PHG4SvtxClusterizer::process_event(PHCompositeNode *topNode) {
 void PHG4SvtxClusterizer::CalculateCylinderThresholds(PHCompositeNode *topNode) {
 
   // get the SVX geometry object
-  PHG4CylinderCellGeomContainer* geom_container = 0;
-  PHTypedNodeIterator<PHG4CylinderCellGeomContainer> geomiter(topNode);
-  PHIODataNode<PHG4CylinderCellGeomContainer>* PHG4CylinderCellGeomContainerNode = geomiter.find("CYLINDERCELLGEOM_SVTX");
-  if(PHG4CylinderCellGeomContainerNode) {
-    geom_container = (PHG4CylinderCellGeomContainer*) PHG4CylinderCellGeomContainerNode->getData();
-  }
+  PHG4CylinderCellGeomContainer* geom_container = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode,"CYLINDERCELLGEOM_SVTX");
   if (!geom_container) return;
   
   // determine cluster thresholds and layer index mapping
@@ -276,21 +262,10 @@ void PHG4SvtxClusterizer::CalculateCylinderThresholds(PHCompositeNode *topNode) 
 
 void PHG4SvtxClusterizer::CalculateLadderThresholds(PHCompositeNode *topNode) {
 
-  PHG4CylinderCellContainer *cells = NULL;
-  PHG4CylinderGeomContainer *geom_container = NULL;
-    
-  PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-  PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SILICON_TRACKER");
-  if (cell_container_node) {
-    cells = (PHG4CylinderCellContainer*) cell_container_node->getData();
-  }
+  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SILICON_TRACKER");
   if (!cells) return;
-  
-  PHTypedNodeIterator<PHG4CylinderGeomContainer> geomiter(topNode);
-  PHIODataNode<PHG4CylinderGeomContainer>* PHG4CylinderGeomContainerNode = geomiter.find("CYLINDERGEOM_SILICON_TRACKER");
-  if (PHG4CylinderGeomContainerNode) {
-    geom_container = (PHG4CylinderGeomContainer*) PHG4CylinderGeomContainerNode->getData();
-  }
+
+  PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_SILICON_TRACKER");
   if (!geom_container) return;
   
   PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
@@ -326,28 +301,13 @@ void PHG4SvtxClusterizer::ClusterCylinderCells(PHCompositeNode *topNode) {
   //----------
 
   // get the SVX geometry object
-  PHG4CylinderCellGeomContainer* geom_container = 0;
-  PHTypedNodeIterator<PHG4CylinderCellGeomContainer> geomiter(topNode);
-  PHIODataNode<PHG4CylinderCellGeomContainer>* PHG4CylinderCellGeomContainerNode = geomiter.find("CYLINDERCELLGEOM_SVTX");
-  if(PHG4CylinderCellGeomContainerNode) {
-    geom_container = (PHG4CylinderCellGeomContainer*) PHG4CylinderCellGeomContainerNode->getData();
-  }
+  PHG4CylinderCellGeomContainer* geom_container = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode,"CYLINDERCELLGEOM_SVTX");
   if (!geom_container) return;
   
-  PHG4HitContainer* g4hits = 0;
-  PHTypedNodeIterator<PHG4HitContainer> g4hititer(topNode);
-  PHIODataNode<PHG4HitContainer> *PHG4HitContainerNode = g4hititer.find("G4HIT_SVTX");
-  if (PHG4HitContainerNode) {
-    g4hits = (PHG4HitContainer*)PHG4HitContainerNode->getData();
-  }
+  PHG4HitContainer* g4hits = findNode::getClass<PHG4HitContainer>(topNode,"G4HIT_SVTX");
   if (!g4hits) return;
   
-  PHG4CylinderCellContainer* cells = 0;
-  PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-  PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SVTX");
-  if (cell_container_node) {
-    cells = (PHG4CylinderCellContainer*) cell_container_node->getData();
-  }
+  PHG4CylinderCellContainer* cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SVTX");
   if (!cells) return; 
   
   //-----------
@@ -612,28 +572,13 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
   //----------
 
   // get the SVX geometry object
-  PHG4CylinderGeomContainer* geom_container = 0;
-  PHTypedNodeIterator<PHG4CylinderGeomContainer> geomiter(topNode);
-  PHIODataNode<PHG4CylinderGeomContainer>* PHG4CylinderGeomContainerNode = geomiter.find("CYLINDERGEOM_SILICON_TRACKER");
-  if(PHG4CylinderGeomContainerNode) {
-    geom_container = (PHG4CylinderGeomContainer*) PHG4CylinderGeomContainerNode->getData();
-  }
+  PHG4CylinderGeomContainer* geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_SILICON_TRACKER");
   if (!geom_container) return;
   
-  PHG4HitContainer* g4hits = 0;
-  PHTypedNodeIterator<PHG4HitContainer> g4hititer(topNode);
-  PHIODataNode<PHG4HitContainer> *PHG4HitContainerNode = g4hititer.find("G4HIT_SILICON_TRACKER");
-  if (PHG4HitContainerNode) {
-    g4hits = (PHG4HitContainer*)PHG4HitContainerNode->getData();
-  }
+  PHG4HitContainer* g4hits =  findNode::getClass<PHG4HitContainer>(topNode,"G4HIT_SILICON_TRACKER");
   if (!g4hits) return;
   
-  PHG4CylinderCellContainer* cells = 0;
-  PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-  PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SILICON_TRACKER");
-  if (cell_container_node) {
-    cells = (PHG4CylinderCellContainer*) cell_container_node->getData();
-  }
+  PHG4CylinderCellContainer* cells =  findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SILICON_TRACKER");
   if (!cells) return; 
  
   //-----------
@@ -921,13 +866,11 @@ void PHG4SvtxClusterizer::PrintClusters(PHCompositeNode *topNode) {
 
   if (verbosity >= 1) {
 
-    PHTypedNodeIterator<SvtxClusterMap> clusteriter(topNode);
-    PHIODataNode<SvtxClusterMap> *SvtxClusterMapNode = clusteriter.find("SvtxClusterMap");
-    if (!SvtxClusterMapNode) return;
+    SvtxClusterMap *clusterlist = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
+    if (!clusterlist) return;
     
     cout << "================= PHG4SvtxClusterizer::process_event() ====================" << endl;
   
-    SvtxClusterMap *clusterlist = (SvtxClusterMap*)SvtxClusterMapNode->getData();
 
     cout << " Found and recorded the following " << clusterlist->size() << " clusters: " << endl;
 

--- a/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
@@ -10,6 +10,7 @@
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
 #include <fun4all/getClass.h>
 #include <g4detectors/PHG4CylinderCellContainer.h>
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
@@ -146,7 +147,7 @@ int PHG4SvtxClusterizer::InitRun(PHCompositeNode* topNode) {
 
   // Looking for the DST node
   PHCompositeNode *dstNode 
-    = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","DST"));
+    = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","DST"));
   if (!dstNode) {
     cout << PHWHERE << "DST Node missing, doing nothing." << endl;
     return Fun4AllReturnCodes::ABORTRUN;

--- a/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.h
@@ -13,8 +13,8 @@ class PHG4SvtxClusterizer : public SubsysReco {
 
 public:
 
-  PHG4SvtxClusterizer(const char * name = "PHG4SvtxClusterizer");
-  ~PHG4SvtxClusterizer(){}
+  PHG4SvtxClusterizer(const std::string &name = "PHG4SvtxClusterizer");
+  virtual ~PHG4SvtxClusterizer(){}
   
   //! module initialization
   int Init(PHCompositeNode *topNode){return 0;}
@@ -29,30 +29,30 @@ public:
   int End(PHCompositeNode *topNode){return 0;}
   
   //! set an energy requirement relative to the thickness MIP expectation
-  void set_threshold(float fraction_of_mip) {
+  void set_threshold(const float fraction_of_mip) {
     _fraction_of_mip = fraction_of_mip;
   }
-  float get_threshold_by_layer(int layer) {
+  float get_threshold_by_layer(const int layer) const {
     if (_thresholds_by_layer.find(layer) == _thresholds_by_layer.end()) return 0.0;
-    return _thresholds_by_layer[layer];
+    return _thresholds_by_layer.find(layer)->second;
   }
   
   //! option to turn off z-dimension clustering
-  void set_z_clustering(int layer, bool make_z_clustering) {
+  void set_z_clustering(const int layer, const bool make_z_clustering) {
     _make_z_clustering.insert(std::make_pair(layer,make_z_clustering));
   }
-  bool get_z_clustering(int layer) {
+  bool get_z_clustering(const int layer) const {
     if (_make_z_clustering.find(layer) == _make_z_clustering.end()) return true;
-    return _make_z_clustering[layer];
+    return _make_z_clustering.find(layer)->second;
   }
 
   //! option to turn on/off energy weighted clustering
-  void set_energy_weighting(int layer, bool make_e_weights) {
+  void set_energy_weighting(const int layer, const bool make_e_weights) {
     _make_e_weights.insert(std::make_pair(layer,make_e_weights));
   }
-  bool get_energy_weighting(int layer) {
+  bool get_energy_weighting(const int layer) const {
     if (_make_e_weights.find(layer) == _make_e_weights.end()) return false;
-    return _make_e_weights[layer];
+    return _make_e_weights.find(layer)->second;
   }  
 
 private:

--- a/simulation/g4simulation/g4hough/PHG4SvtxDeadArea.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDeadArea.C
@@ -4,8 +4,6 @@
 #include "SvtxHit.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHTypedNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <fun4all/getClass.h>
@@ -18,16 +16,22 @@
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
 #include <g4detectors/PHG4CylinderCellGeom.h>
 
+#include <TRandom3.h>
+
 #include <iostream>
 
 using namespace std;
 
-PHG4SvtxDeadArea::PHG4SvtxDeadArea(const char* name) :
+PHG4SvtxDeadArea::PHG4SvtxDeadArea(const string &name) :
   SubsysReco(name),
-  _eff_by_layer(),
   _hits(NULL),
   _rand(NULL),
   _timer(PHTimeServer::get()->insert_new(name)) {
+}
+
+PHG4SvtxDeadArea::~PHG4SvtxDeadArea()
+{
+  delete _rand;
 }
 
 int PHG4SvtxDeadArea::InitRun(PHCompositeNode* topNode) {
@@ -92,20 +96,9 @@ int PHG4SvtxDeadArea::End(PHCompositeNode* topNode) {
 
 void PHG4SvtxDeadArea::FillCylinderDeadAreaMap(PHCompositeNode* topNode) {
 
-  PHG4CylinderCellContainer *cells = NULL;
-  PHG4CylinderCellGeomContainer *geom_container = NULL;
+  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SVTX");
+  PHG4CylinderCellGeomContainer *geom_container = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode,"CYLINDERCELLGEOM_SVTX");
     
-  PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-  PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SVTX");
-  if (cell_container_node) {
-    cells = (PHG4CylinderCellContainer*) cell_container_node->getData();
-  }
-
-  PHTypedNodeIterator<PHG4CylinderCellGeomContainer> geomiter(topNode);
-  PHIODataNode<PHG4CylinderCellGeomContainer>* PHG4CylinderCellGeomContainerNode = geomiter.find("CYLINDERCELLGEOM_SVTX");
-  if (PHG4CylinderCellGeomContainerNode) {
-    geom_container = (PHG4CylinderCellGeomContainer*) PHG4CylinderCellGeomContainerNode->getData();
-  }
 
   if (!geom_container || !cells) return;
   
@@ -125,21 +118,9 @@ void PHG4SvtxDeadArea::FillCylinderDeadAreaMap(PHCompositeNode* topNode) {
 
 void PHG4SvtxDeadArea::FillLadderDeadAreaMap(PHCompositeNode* topNode) {
 
-  PHG4CylinderCellContainer *cells = NULL;
-  PHG4CylinderGeomContainer *geom_container = NULL;
+  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SILICON_TRACKER");
+  PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_SILICON_TRACKER");
     
-  PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-  PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SILICON_TRACKER");
-  if (cell_container_node) {
-    cells = (PHG4CylinderCellContainer*) cell_container_node->getData();
-  }
-
-  PHTypedNodeIterator<PHG4CylinderGeomContainer> geomiter(topNode);
-  PHIODataNode<PHG4CylinderGeomContainer>* PHG4CylinderGeomContainerNode = geomiter.find("CYLINDERGEOM_SILICON_TRACKER");
-  if (PHG4CylinderGeomContainerNode) {
-    geom_container = (PHG4CylinderGeomContainer*) PHG4CylinderGeomContainerNode->getData();
-  }
-  
   if (!geom_container || !cells) return;
 
   PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();

--- a/simulation/g4simulation/g4hough/PHG4SvtxDeadArea.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDeadArea.h
@@ -1,22 +1,20 @@
 #ifndef __PHG4SVTXDEADAREA_H__
 #define __PHG4SVTXDEADAREA_H__
 
-#include "SvtxHitMap.h"
-
 #include <fun4all/SubsysReco.h>
 #include <phool/PHTimeServer.h>
-#include <TRandom3.h>
 
 #include <map>
+
+class SvtxHitMap;
+class TRandom3;
 
 class PHG4SvtxDeadArea : public SubsysReco {
 
 public:
 
-  PHG4SvtxDeadArea(const char * name = "PHG4SvtxDeadArea");
-  ~PHG4SvtxDeadArea(){
-    if (_rand) delete _rand;
-  }
+  PHG4SvtxDeadArea(const std::string &name = "PHG4SvtxDeadArea");
+  virtual ~PHG4SvtxDeadArea();
   
   //! module initialization
   int Init(PHCompositeNode *topNode){return 0;}
@@ -31,12 +29,12 @@ public:
   int End(PHCompositeNode *topNode);
   
   //! kill random hits in this layer with fractional eff efficiency
-  void set_hit_efficiency(int ilayer, float eff) {
+  void set_hit_efficiency(const int ilayer, const float eff) {
     _eff_by_layer.insert(std::make_pair(ilayer,eff));
   }
-  float get_hit_efficiency(int ilayer) {
+  float get_hit_efficiency(const int ilayer) const {
     if (_eff_by_layer.find(ilayer) == _eff_by_layer.end()) return 1.0;
-    return _eff_by_layer[ilayer];
+    return _eff_by_layer.find(ilayer)->second;
   }
 
  private:

--- a/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.C
@@ -3,10 +3,9 @@
 #include "SvtxHitMap.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHTypedNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
 #include <fun4all/getClass.h>
 #include <g4detectors/PHG4CylinderCellContainer.h>
 #include <g4detectors/PHG4CylinderCell.h>
@@ -20,10 +19,8 @@
 
 using namespace std;
 
-PHG4SvtxDigitizer::PHG4SvtxDigitizer(const char* name) :
+PHG4SvtxDigitizer::PHG4SvtxDigitizer(const string &name) :
   SubsysReco(name),
-  _max_adc(),
-  _energy_scale(),
   _hitmap(NULL),
   _timer(PHTimeServer::get()->insert_new(name)) {
 }
@@ -38,7 +35,7 @@ int PHG4SvtxDigitizer::InitRun(PHCompositeNode* topNode) {
 
   // Looking for the DST node
   PHCompositeNode *dstNode 
-    = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","DST"));
+    = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","DST"));
   if (!dstNode) {
     cout << PHWHERE << "DST Node missing, doing nothing." << endl;
     return Fun4AllReturnCodes::ABORTRUN;
@@ -91,15 +88,12 @@ int PHG4SvtxDigitizer::process_event(PHCompositeNode *topNode) {
 
   _timer.get()->restart();
 
-  _hitmap = NULL;
-  PHTypedNodeIterator<SvtxHitMap> iter(topNode);
-  PHIODataNode<SvtxHitMap> *SvtxHitMapNode = iter.find("SvtxHitMap");
-  if (!SvtxHitMapNode) {
-    cout << PHWHERE << " ERROR: Can't find SvtxHitMap." << endl;
-    return Fun4AllReturnCodes::ABORTRUN;
-  } else {
-    _hitmap = (SvtxHitMap*)SvtxHitMapNode->getData();
-  }
+  _hitmap = findNode::getClass<SvtxHitMap>(topNode,"SvtxHitMap");
+  if (!_hitmap) 
+    {
+      cout << PHWHERE << " ERROR: Can't find SvtxHitMap." << endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
 
   _hitmap->Reset();
   
@@ -116,20 +110,9 @@ void PHG4SvtxDigitizer::CalculateCylinderCellADCScale(PHCompositeNode *topNode) 
 
   // defaults to 8-bit ADC, short-axis MIP placed at 1/4 dynamic range
 
-  PHG4CylinderCellContainer *cells = NULL;
-  PHG4CylinderCellGeomContainer *geom_container = NULL;
+  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SVTX");
+  PHG4CylinderCellGeomContainer *geom_container = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode,"CYLINDERCELLGEOM_SVTX");
     
-  PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-  PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SVTX");
-  if (cell_container_node) {
-    cells = (PHG4CylinderCellContainer*) cell_container_node->getData();
-  }
-
-  PHTypedNodeIterator<PHG4CylinderCellGeomContainer> geomiter(topNode);
-  PHIODataNode<PHG4CylinderCellGeomContainer>* PHG4CylinderCellGeomContainerNode = geomiter.find("CYLINDERCELLGEOM_SVTX");
-  if (PHG4CylinderCellGeomContainerNode) {
-    geom_container = (PHG4CylinderCellGeomContainer*) PHG4CylinderCellGeomContainerNode->getData();
-  }
 
   if (!geom_container || !cells) return;
   
@@ -161,21 +144,9 @@ void PHG4SvtxDigitizer::CalculateLadderCellADCScale(PHCompositeNode *topNode) {
 
   // defaults to 8-bit ADC, short-axis MIP placed at 1/4 dynamic range
 
-  PHG4CylinderCellContainer *cells = NULL;
-  PHG4CylinderGeomContainer *geom_container = NULL;
+  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SILICON_TRACKER");
+  PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_SILICON_TRACKER");
     
-  PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-  PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SILICON_TRACKER");
-  if (cell_container_node) {
-    cells = (PHG4CylinderCellContainer*) cell_container_node->getData();
-  }
-
-  PHTypedNodeIterator<PHG4CylinderGeomContainer> geomiter(topNode);
-  PHIODataNode<PHG4CylinderGeomContainer>* PHG4CylinderGeomContainerNode = geomiter.find("CYLINDERGEOM_SILICON_TRACKER");
-  if (PHG4CylinderGeomContainerNode) {
-    geom_container = (PHG4CylinderGeomContainer*) PHG4CylinderGeomContainerNode->getData();
-  }
-
   if (!geom_container || !cells) return;
   
   PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
@@ -208,12 +179,7 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
   // Get Nodes
   //----------
  
-  PHG4CylinderCellContainer* cells = 0;
-  PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-  PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SVTX");
-  if (cell_container_node) {
-    cells = (PHG4CylinderCellContainer*) cell_container_node->getData();
-  }
+  PHG4CylinderCellContainer* cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SVTX");
   if (!cells) return; 
   
   //-------------
@@ -259,12 +225,7 @@ void PHG4SvtxDigitizer::DigitizeLadderCells(PHCompositeNode *topNode) {
   // Get Nodes
   //----------
  
-  PHG4CylinderCellContainer* cells = 0;
-  PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-  PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SILICON_TRACKER");
-  if (cell_container_node) {
-    cells = (PHG4CylinderCellContainer*) cell_container_node->getData();
-  }
+  PHG4CylinderCellContainer* cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SILICON_TRACKER");
   if (!cells) return; 
   
   //-------------
@@ -309,13 +270,11 @@ void PHG4SvtxDigitizer::PrintHits(PHCompositeNode *topNode) {
 
   if (verbosity >= 1) {
 
-    PHTypedNodeIterator<SvtxHitMap> hititer(topNode);
-    PHIODataNode<SvtxHitMap> *SvtxHitMapNode = hititer.find("SvtxHitMap");
-    if (!SvtxHitMapNode) return;
+    SvtxHitMap *hitlist = findNode::getClass<SvtxHitMap>(topNode,"SvtxHitMap");
+    if (!hitlist) return;
     
     cout << "================= PHG4SvtxDigitizer::process_event() ====================" << endl;
   
-    SvtxHitMap *hitlist = (SvtxHitMap*)SvtxHitMapNode->getData();
 
     cout << " Found and recorded the following " << hitlist->size() << " hits: " << endl;
 

--- a/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.h
@@ -1,19 +1,19 @@
 #ifndef __PHG4SVTXDIGITIZER__
 #define __PHG4SVTXDIGITIZER__
 
-#include "SvtxHitMap.h"
+#include <fun4all/SubsysReco.h>
+#include <phool/PHTimeServer.h>
 
 #include <vector>
 
-#include <fun4all/SubsysReco.h>
-#include <phool/PHTimeServer.h>
+class SvtxHitMap;
 
 class PHG4SvtxDigitizer : public SubsysReco
 {
  public:
 
-  PHG4SvtxDigitizer(const char * name = "PHG4SvtxDigitizer");
-  ~PHG4SvtxDigitizer(){}
+  PHG4SvtxDigitizer(const std::string &name = "PHG4SvtxDigitizer");
+  virtual ~PHG4SvtxDigitizer(){}
   
   //! module initialization
   int Init(PHCompositeNode *topNode){return 0;}
@@ -27,7 +27,7 @@ class PHG4SvtxDigitizer : public SubsysReco
   //! end of process
   int End(PHCompositeNode *topNode) {return 0;}
   
-  void set_adc_scale(int layer, unsigned int max_adc, float energy_per_adc) {
+  void set_adc_scale(const int layer, const unsigned int max_adc, const float energy_per_adc) {
     _max_adc.insert(std::make_pair(layer,max_adc));
     _energy_scale.insert(std::make_pair(layer,energy_per_adc));
   }

--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
@@ -4,8 +4,6 @@
 #include "SvtxHit.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHTypedNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <fun4all/getClass.h>
@@ -21,11 +19,9 @@
 
 using namespace std;
 
-PHG4SvtxThresholds::PHG4SvtxThresholds(const char* name) :
+PHG4SvtxThresholds::PHG4SvtxThresholds(const string &name) :
   SubsysReco(name),
   _fraction_of_mip(0.5),
-  _thresholds_by_layer(),
-  _use_thickness_mip(),
   _hits(NULL),
   _timer(PHTimeServer::get()->insert_new(name)) {
 }
@@ -96,21 +92,9 @@ int PHG4SvtxThresholds::End(PHCompositeNode* topNode) {
 
 void PHG4SvtxThresholds::CalculateCylinderThresholds(PHCompositeNode* topNode) {
 
-  PHG4CylinderCellContainer *cells = NULL;
-  PHG4CylinderCellGeomContainer *geom_container = NULL;
+  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SVTX");
+  PHG4CylinderCellGeomContainer *geom_container = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode,"CYLINDERCELLGEOM_SVTX");
     
-  PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-  PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SVTX");
-  if (cell_container_node) {
-    cells = (PHG4CylinderCellContainer*) cell_container_node->getData();
-  }
-
-  PHTypedNodeIterator<PHG4CylinderCellGeomContainer> geomiter(topNode);
-  PHIODataNode<PHG4CylinderCellGeomContainer>* PHG4CylinderCellGeomContainerNode = geomiter.find("CYLINDERCELLGEOM_SVTX");
-  if (PHG4CylinderCellGeomContainerNode) {
-    geom_container = (PHG4CylinderCellGeomContainer*) PHG4CylinderCellGeomContainerNode->getData();
-  }
-
   if (!geom_container || !cells) return;
   
   PHG4CylinderCellGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
@@ -143,20 +127,8 @@ void PHG4SvtxThresholds::CalculateCylinderThresholds(PHCompositeNode* topNode) {
 
 void PHG4SvtxThresholds::CalculateLadderThresholds(PHCompositeNode* topNode) {
 
-  PHG4CylinderCellContainer *cells = NULL;
-  PHG4CylinderGeomContainer *geom_container = NULL;
-    
-  PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-  PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SILICON_TRACKER");
-  if (cell_container_node) {
-    cells = (PHG4CylinderCellContainer*) cell_container_node->getData();
-  }
-
-  PHTypedNodeIterator<PHG4CylinderGeomContainer> geomiter(topNode);
-  PHIODataNode<PHG4CylinderGeomContainer>* PHG4CylinderGeomContainerNode = geomiter.find("CYLINDERGEOM_SILICON_TRACKER");
-  if (PHG4CylinderGeomContainerNode) {
-    geom_container = (PHG4CylinderGeomContainer*) PHG4CylinderGeomContainerNode->getData();
-  }
+  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SILICON_TRACKER");
+  PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_SILICON_TRACKER");
 
   if (!geom_container || !cells) return;
   

--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
@@ -1,12 +1,12 @@
 #ifndef __PHG4SVTXTHRESHOLDS__
 #define __PHG4SVTXTHRESHOLDS__
 
-#include "SvtxHitMap.h"
-
 #include <vector>
 
 #include <fun4all/SubsysReco.h>
 #include <phool/PHTimeServer.h>
+
+class SvtxHitMap;
 
 class PHG4SvtxThresholds : public SubsysReco
 {
@@ -29,20 +29,20 @@ class PHG4SvtxThresholds : public SubsysReco
   int End(PHCompositeNode *topNode);
   
   //! set an energy requirement relative to the short-axis MIP expectation
-  void set_threshold(float fraction_of_mip) {
+  void set_threshold(const float fraction_of_mip) {
     _fraction_of_mip = fraction_of_mip;
   }
-  float get_threshold_by_layer(int layer) {
+  float get_threshold_by_layer(const int layer) const {
     if (_thresholds_by_layer.find(layer) == _thresholds_by_layer.end()) return 0.0;
-    return _thresholds_by_layer[layer];
+    return _thresholds_by_layer.find(layer)->second;
   }
 
   //! decide if the MIP should use the layer thickness instead of the short-axis
   //! thickness setting in outer layers will kill bending lower pT tracks
-  void set_use_thickness_mip(int layer, bool use_thickness_mip) {
+  void set_use_thickness_mip(const int layer, const bool use_thickness_mip) {
     _use_thickness_mip.insert(std::make_pair(layer,use_thickness_mip));
   }
-  bool get_use_thickness_mip(int layer) {
+  bool get_use_thickness_mip(const int layer) {
     if (_use_thickness_mip.find(layer) == _use_thickness_mip.end()) return false;
     return _use_thickness_mip[layer];
   }

--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
@@ -12,9 +12,9 @@ class PHG4SvtxThresholds : public SubsysReco
 {
  public:
 
-  PHG4SvtxThresholds(const char * name = "PHG4SvtxThresholds");
+  PHG4SvtxThresholds(const std::string &name = "PHG4SvtxThresholds");
 
-  ~PHG4SvtxThresholds(){}
+  virtual ~PHG4SvtxThresholds(){}
   
   //! module initialization
   int Init(PHCompositeNode *topNode){return 0;}

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
@@ -1,4 +1,7 @@
-#include <PHG4SvtxTrackProjection.h>
+#include "PHG4SvtxTrackProjection.h"
+#include "SvtxTrackMap.h"
+#include "SvtxTrack.h"
+#include "PHG4HoughTransform.h"
 
 // PHENIX includes
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -9,36 +12,28 @@
 #include <fun4all/getClass.h>
 
 // PHENIX Geant4 includes
-#include <SvtxTrackMap.h>
-#include <SvtxTrack.h>
-#include <PHG4HoughTransform.h>
 #include <g4cemc/RawTowerGeom.h>
 #include <g4cemc/RawTowerContainer.h>
 #include <g4cemc/RawTower.h>
 #include <g4cemc/RawClusterContainer.h>
 #include <g4cemc/RawCluster.h>
 
-// ROOT includes
-#include <TMath.h>
-
 // standard includes
 #include <iostream>
 #include <vector>
-#include <float.h>
 
 using namespace std;
 
 PHG4SvtxTrackProjection::PHG4SvtxTrackProjection(const string &name) :
-SubsysReco(name)
+  SubsysReco(name),
+  _num_cal_layers(4),
+  _mag_extent(156.5) // middle of Babar magent
 {
-  verbosity = 0;
-  _num_cal_layers = 4;
   _cal_radii.assign(_num_cal_layers,NAN);
   _cal_names.push_back("PRES"); // PRES not yet in G4
   _cal_names.push_back("CEMC");
   _cal_names.push_back("HCALIN");
   _cal_names.push_back("HCALOUT");
-  _mag_extent = 156.5; // middle of Babar magent
 }
 
 int PHG4SvtxTrackProjection::Init(PHCompositeNode *topNode) 

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
@@ -5,8 +5,6 @@
 
 // PHENIX includes
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHTypedNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <fun4all/getClass.h>

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.h
@@ -7,11 +7,10 @@
 /// \author Mike McCumber
 //===========================================================
 
+#include "PHG4HoughTransform.h"
+
 // PHENIX includes
 #include <fun4all/SubsysReco.h>
-
-// PHG4 includes
-#include <PHG4HoughTransform.h>
 
 // std includes
 #include <vector>

--- a/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.C
@@ -6,8 +6,6 @@
 #include "SvtxTrack.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHTypedNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <fun4all/getClass.h>
@@ -17,14 +15,14 @@
 
 using namespace std;
 
-bool hit_sort(unsigned int i, unsigned int j) { return (i < j);}
+bool hit_sort(const unsigned int i, const unsigned int j) { return (i < j);}
 
-PHG4TrackGhostRejection::PHG4TrackGhostRejection(int nlayers, const string &name) :
-SubsysReco(name)
+PHG4TrackGhostRejection::PHG4TrackGhostRejection(const int nlayers, const string &name) :
+  SubsysReco(name),
+  _g4tracks(NULL),
+  _nlayers(nlayers),
+  _max_shared_hits(_nlayers)
 {
-  verbosity = 0;
-  _nlayers = nlayers;
-  _max_shared_hits = _nlayers;
   _layer_enabled.assign(_nlayers,true);
   _overlapping.clear();
   _candidates.clear();

--- a/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.h
@@ -48,7 +48,7 @@ class PHG4TrackGhostRejection : public SubsysReco
 
  public:
  
-  PHG4TrackGhostRejection(int nlayers, const std::string &name = "PHG4TrackGhostRejection");
+  PHG4TrackGhostRejection(const int nlayers, const std::string &name = "PHG4TrackGhostRejection");
   virtual ~PHG4TrackGhostRejection() {}
 		
   int Init(PHCompositeNode *topNode);
@@ -56,11 +56,11 @@ class PHG4TrackGhostRejection : public SubsysReco
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
   
-  void set_max_shared_hits(unsigned int nhits) { _max_shared_hits = nhits; }
+  void set_max_shared_hits(const unsigned int nhits) { _max_shared_hits = nhits; }
   unsigned int get_max_shared_hits() { return _max_shared_hits; }
 
-  void set_layer_enabled(int layer, bool enabled) {_layer_enabled[layer] = enabled;}
-  bool get_layer_enabled(int layer) {return _layer_enabled[layer];}
+  void set_layer_enabled(const int layer, const bool enabled) {_layer_enabled[layer] = enabled;}
+  bool get_layer_enabled(const int layer) const {return _layer_enabled[layer];}
 
  private:
 


### PR DESCRIPTION
A lot of reco modules still used the PHTypedNodeIterator which was replaced by getClass<> about 10 years ago. I really do not want this to propagate again from here. Insure claimed a string problem in a dictionary which might be caused by using const chars as module name (replaced by strings many years ago), so I replaced const chars by std::strings in the ctors of the classes I looked at. Also a lot of arguments were not const even if they could be and using maps like return map[...] is not const while map.find(...)->second is.