### PR TITLE
Add property tag to SvtxTrack

### DIFF
--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -6,7 +6,7 @@ ClassImp(SvtxTrack)
 
 using namespace std;
 
-SvtxTrack::SvtxTrack() : phi(0.),d(0.),kappa(0.),z0(0.),dzdl(0.), x(0.), y(0.), z(0.), covariance(6,6)
+SvtxTrack::SvtxTrack() : phi(0.),d(0.),kappa(0.),z0(0.),dzdl(0.), covariance(6,6)
 {
   Reset();
 }
@@ -29,22 +29,22 @@ SvtxTrack::SvtxTrack(SvtxTrack *track) : covariance( *(track->getCovariance()) )
   }
   
   trackID = track->getTrackID();
-  momentum = track->getMomentum();
+//  momentum = track->getMomentum();
   for(int j=0;j<3;j++){
     mom3[j] = track->get3Momentum(j);
   }
 
-  charge = track->getCharge();
+//  charge = track->getCharge();
   isprimary = track->getPrimary();
   ispositive = track->getPositive();
-  quality = track->getQuality();
+//  quality = track->getQuality();
   
-  DCA = track->getDCA();
-  DCA2D = track->getDCA2D();
-
-  chisq = track->getChisq();
-  chisqv = track->getChisqv();
-  ndf = track->getNDF();
+//  DCA = track->getDCA();
+//  DCA2D = track->getDCA2D();
+//
+//  chisq = track->getChisq();
+//  chisqv = track->getChisqv();
+//  ndf = track->getNDF();
   
   for(int i=0;i<9;i++){
     scatter[i] = track->getScatter(i);
@@ -84,22 +84,22 @@ SvtxTrack::SvtxTrack(const SvtxTrack& track) : covariance( *(track.getCovariance
   }
   
   trackID = track.getTrackID();
-  momentum = track.getMomentum();
+//  momentum = track.getMomentum();
   for(int j=0;j<3;j++){
     mom3[j] = track.get3Momentum(j);
   }
 
-  charge = track.getCharge();
+//  charge = track.getCharge();
   isprimary = track.getPrimary();
   ispositive = track.getPositive();
-  quality = track.getQuality();
+//  quality = track.getQuality();
   
-  DCA = track.getDCA();
-  DCA2D = track.getDCA2D();
+//  DCA = track.getDCA();
+//  DCA2D = track.getDCA2D();
 
-  chisq = track.getChisq();
-  chisqv = track.getChisqv();
-  ndf = track.getNDF();
+//  chisq = track.getChisq();
+//  chisqv = track.getChisqv();
+//  ndf = track.getNDF();
   
   for(int i=0;i<9;i++){
     scatter[i] = track.getScatter(i);
@@ -113,9 +113,10 @@ SvtxTrack::SvtxTrack(const SvtxTrack& track) : covariance( *(track.getCovariance
     cal_cluster_e[i] = track.get_cal_cluster_e(i);
   }
 
-  x = track.get_x();
-  y = track.get_y();
-  z = track.get_z();
+  //! TODO delete these lines. They are now part of property map
+//  x = track.get_x();
+//  y = track.get_y();
+//  z = track.get_z();
 
 
   for (prop_map_t::const_iterator i = track.prop_map.begin();
@@ -155,7 +156,7 @@ void SvtxTrack::identify(ostream& os) const
     {
       PROPERTY prop_id = static_cast<PROPERTY>(i->first);
       pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-      cout << "\t" << i->first << ":\t" << property_info.first << " = \t";
+      cout << "\t" << property_info.first << " = \t";
       switch(property_info.second)
   {
   case type_int:
@@ -187,22 +188,24 @@ void SvtxTrack::Reset()
   }
 
   trackID = -1;
-  momentum=NAN;
+//  momentum=NAN;
   for(int j=0;j<3;j++){
     mom3[j]=NAN;
   }
 
-  charge=1;
+//  charge=1;
+  setCharge(1);
   isprimary=false;
   ispositive=false;
-  quality=NAN;
+//  quality=NAN;
   
-  DCA=NAN;
-  DCA2D=NAN;
-
-  chisq = NAN;
-  chisqv = NAN;
-  ndf = 0;
+//  DCA=NAN;
+//  DCA2D=NAN;
+//
+//  chisq = NAN;
+//  chisqv = NAN;
+//  ndf = 0;
+  setNDF(0);
   
   for(int i=0;i<9;i++){
     scatter[i]=NAN;
@@ -217,6 +220,13 @@ void SvtxTrack::Reset()
   }
 
   prop_map.clear();
+
+  //! TODO: these init are set so that they produce consistent result as before (init x/y/z to 0).
+  //! But it seems redundant.
+  //! I would suggest remove these three lines, which is equavlent to init them to NAN.
+  set_x(0);
+  set_y(0);
+  set_z(0);
 
   return;
 }
@@ -260,6 +270,35 @@ SvtxTrack::get_property_info(const PROPERTY prop_id)
   {
   case  prop_FastSim_TruthID:
     return make_pair("Truth ID (available for fast sim track only)",SvtxTrack::type_int);
+
+  case  prop_momentum:
+    return make_pair("Momentum",SvtxTrack::type_float);
+  case  prop_charge:
+    return make_pair("Charge",SvtxTrack::type_int);
+  case  prop_quality:
+    return make_pair("Quality",SvtxTrack::type_float);
+  case  prop_chisq:
+    return make_pair("Chi Square",SvtxTrack::type_float);
+  case  prop_chisqv:
+    return make_pair("Chi Square @ vertex",SvtxTrack::type_float);
+  case  prop_ndf:
+    return make_pair("NDF",SvtxTrack::type_int);
+
+  case  prop_DCA:
+    return make_pair("DCA",SvtxTrack::type_float);
+  case  prop_DCA2D:
+    return make_pair("DCA 2D",SvtxTrack::type_float);
+  case  prop_DCA2Dsigma:
+    return make_pair("DCA 2D Sigma",SvtxTrack::type_float);
+
+  case  prop_x:
+    return make_pair("Vertex x",SvtxTrack::type_float);
+  case  prop_y:
+    return make_pair("Vertex y",SvtxTrack::type_float);
+  case  prop_z:
+    return make_pair("Vertex z",SvtxTrack::type_float);
+
+
   default:
     cout << "unknown index " << prop_id << endl;
     exit(1);

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -18,7 +18,7 @@ SvtxTrack::SvtxTrack(SvtxTrack *track) : covariance( *(track->getCovariance()) )
   kappa = track->kappa ;
   z0    = track->z0    ;
   dzdl  = track->dzdl  ;
-  setDCA2Dsigma(track->getDCA2Dsigma());
+  //setDCA2Dsigma(track->getDCA2Dsigma());
   
   for(int i=0;i<100;i++)
   {
@@ -73,7 +73,7 @@ SvtxTrack::SvtxTrack(const SvtxTrack& track) : covariance( *(track.getCovariance
   kappa = track.kappa ;
   z0    = track.z0    ;
   dzdl  = track.dzdl  ;
-  setDCA2Dsigma(track.getDCA2Dsigma());
+ // setDCA2Dsigma(track.getDCA2Dsigma());
   
   for(int i=0;i<100;i++)
   {

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -179,6 +179,8 @@ void SvtxTrack::identify(ostream& os) const
 
 void SvtxTrack::Reset()
 {
+  prop_map.clear();
+
   for(int i=0;i<100;i++)
   {
     clusterID[i]=-9999;
@@ -218,8 +220,6 @@ void SvtxTrack::Reset()
     cal_cluster_id[i] = -9999;
     cal_cluster_e[i] = NAN;
   }
-
-  prop_map.clear();
 
   //! TODO: these init are set so that they produce consistent result as before (init x/y/z to 0).
   //! But it seems redundant.

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <stdint.h>
 #include <climits>
+#include <string>
 
 class SvtxTrack : public PHObject
 {
@@ -102,12 +103,12 @@ class SvtxTrack : public PHObject
   void set_cal_cluster_e(int layer, float e) {cal_cluster_e[layer] = e;}
   float get_cal_cluster_e(int layer) const {return cal_cluster_e[layer];}
 
-  float get_x() const{return x;}
-  void set_x(float val){x = val;}
-  float get_y() const{return y;}
-  void set_y(float val){y = val;}
-  float get_z() const{return z;}
-  void set_z(float val){z = val;}
+  float get_x() const{return get_property_float(prop_x);}
+  void set_x(float val){set_property(prop_x, val);}
+  float get_y() const{return get_property_float(prop_y);}
+  void set_y(float val){set_property(prop_y, val);}
+  float get_z() const{return get_property_float(prop_z);}
+  void set_z(float val){set_property(prop_z, val);}
 
   
 
@@ -118,19 +119,17 @@ class SvtxTrack : public PHObject
   {//
     //! Truth ID
     prop_FastSim_TruthID = 0,
-    prop_isprimary =1,
 
     //!Track properties
     prop_momentum = 10,
     prop_charge,
-    prop_ispositive,
     prop_quality,
     prop_chisq,
     prop_chisqv,
     prop_ndf,
 
     //! vertex properties
-    prop_DCA = 20,
+    prop_DCA = 30,
     prop_DCA2D,
     prop_DCA2Dsigma,
     prop_x,prop_y,prop_z,
@@ -194,20 +193,20 @@ class SvtxTrack : public PHObject
   int     clusterID[100];
   int     trackID;
   float   position[100][3];
-  float   momentum;
+//  float   momentum;
   float   mom3[3];
-  int     charge;
+//  int     charge;
   bool    isprimary;
   bool    ispositive;
-  float   quality;
-  float   chisq;
-  float   chisqv;
-  int     ndf;
-  float   DCA;
-  float   DCA2D;
-  float   DCA2Dsigma;
+//  float   quality;
+//  float   chisq;
+//  float   chisqv;
+//  int     ndf;
+//  float   DCA;
+//  float   DCA2D;
+//  float   DCA2Dsigma;
   float   scatter[100];
-  float   x,y,z;
+//  float   x,y,z;
 
   TMatrix covariance;
 
@@ -227,7 +226,7 @@ class SvtxTrack : public PHObject
 
 
 
-  ClassDef(SvtxTrack,1)
+  ClassDef(SvtxTrack,2)
 };
 
 
@@ -238,27 +237,27 @@ inline bool SvtxTrack::hasCluster(int layer) const {return (clusterID[layer]>-99
 inline void SvtxTrack::setScatter(int layer, float sct){scatter[layer]=sct;}
 inline float SvtxTrack::getScatter(int layer) const {return scatter[layer];}
 
-inline void SvtxTrack::setDCA(float d){DCA=d;}
-inline float SvtxTrack::getDCA() const {return DCA;}
-inline void SvtxTrack::setDCA2D(float d){DCA2D=d;}
-inline float SvtxTrack::getDCA2D() const {return DCA2D;}
-inline void SvtxTrack::setDCA2Dsigma(float s){DCA2Dsigma=s;}
-inline float SvtxTrack::getDCA2Dsigma() const {return DCA2Dsigma;}
+inline void SvtxTrack::setDCA(float d){set_property(prop_DCA, d);}
+inline float SvtxTrack::getDCA() const {return get_property_float(prop_DCA);}
+inline void SvtxTrack::setDCA2D(float d){set_property(prop_DCA2D, d);}
+inline float SvtxTrack::getDCA2D() const{return get_property_float(prop_DCA2D);}
+inline void SvtxTrack::setDCA2Dsigma(float s){set_property(prop_DCA2Dsigma, s);}
+inline float SvtxTrack::getDCA2Dsigma() const {return get_property_float(prop_DCA2Dsigma);}
 
-inline void SvtxTrack::setMomentum(float p){momentum=p;}
-inline float SvtxTrack::getMomentum() const {return momentum;}
+inline void SvtxTrack::setMomentum(float p){set_property(prop_momentum, p);}
+inline float SvtxTrack::getMomentum() const {return get_property_float(prop_momentum);}
 
-inline void SvtxTrack::setQuality(float q){quality=q;}
-inline float SvtxTrack::getQuality() const {return quality;}
+inline void SvtxTrack::setQuality(float q){set_property(prop_quality, q);}
+inline float SvtxTrack::getQuality() const {return get_property_float(prop_quality);}
 
-inline void SvtxTrack::setChisq(float q){chisq=q;}
-inline float SvtxTrack::getChisq() const {return chisq;}
+inline void SvtxTrack::setChisq(float q){set_property(prop_chisq, q);}
+inline float SvtxTrack::getChisq() const{return get_property_float(prop_chisq);}
 
-inline void SvtxTrack::setChisqv(float q){chisqv=q;}
-inline float SvtxTrack::getChisqv() const {return chisqv;}
+inline void SvtxTrack::setChisqv(float q){set_property(prop_chisqv, q);}
+inline float SvtxTrack::getChisqv() const {return get_property_float(prop_chisqv);}
 
-inline void SvtxTrack::setNDF(int q){ndf=q;}
-inline int SvtxTrack::getNDF() const {return ndf;}
+inline void SvtxTrack::setNDF(int q){set_property(prop_ndf, q);}
+inline int SvtxTrack::getNDF() const{return get_property_int(prop_ndf);}
 
 
 inline void SvtxTrack::set3Momentum(float px, float py, float pz)
@@ -269,8 +268,8 @@ inline void SvtxTrack::set3Momentum(float px, float py, float pz)
 }
 inline float SvtxTrack::get3Momentum(int coor) const {return mom3[coor];}
 
-inline void SvtxTrack::setCharge(int c){charge=c;}
-inline int SvtxTrack::getCharge() const {return charge;}
+inline void SvtxTrack::setCharge(int c){set_property(prop_charge, c);}
+inline int SvtxTrack::getCharge() const {return get_property_int(prop_charge);}
 
 inline void SvtxTrack::setPrimary(bool prim){isprimary=prim;}
 inline bool SvtxTrack::getPrimary() const {return isprimary;}

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -5,6 +5,10 @@
 #include <TMatrix.h>
 #include <iostream>
 
+#include <map>
+#include <stdint.h>
+#include <climits>
+
 class SvtxTrack : public PHObject
 {
   
@@ -105,6 +109,86 @@ class SvtxTrack : public PHObject
   float get_z() const{return z;}
   void set_z(float val){z = val;}
 
+  
+
+ public:
+
+  //! In order to add a new property, please add a short desc. to SvtxTrack::get_property_info()
+  enum PROPERTY
+  {//
+    //! Truth ID
+    prop_FastSim_TruthID = 0,
+    prop_isprimary =1,
+
+    //!Track properties
+    prop_momentum = 10,
+    prop_charge,
+    prop_ispositive,
+    prop_quality,
+    prop_chisq,
+    prop_chisqv,
+    prop_ndf,
+
+    //! vertex properties
+    prop_DCA = 20,
+    prop_DCA2D,
+    prop_DCA2Dsigma,
+    prop_x,prop_y,prop_z,
+
+    //! max limit in order to fit into 8 bit unsigned number
+    prop_MAX_NUMBER = UCHAR_MAX
+  };
+
+  enum PROPERTY_TYPE
+  {//
+    type_int = 1,
+    type_uint = 2,
+    type_float = 3,
+    type_unknown = -1
+  };
+
+  virtual bool  has_property(const PROPERTY prop_id) const ;
+  virtual float get_property_float(const PROPERTY prop_id) const;
+  virtual int   get_property_int(const PROPERTY prop_id) const;
+  virtual unsigned int   get_property_uint(const PROPERTY prop_id) const;
+  virtual void  set_property(const PROPERTY prop_id, const float value) ;
+  virtual void  set_property(const PROPERTY prop_id, const int value) ;
+  virtual void  set_property(const PROPERTY prop_id, const unsigned int value) ;
+  static std::pair<const std::string,PROPERTY_TYPE> get_property_info(PROPERTY prop_id);
+  static bool check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type);
+  static std::string get_property_type(const PROPERTY_TYPE prop_type);
+
+ protected:
+
+  virtual unsigned int get_property_nocheck(const PROPERTY prop_id) const ;
+  void set_property_nocheck(const PROPERTY prop_id,const unsigned int ui) {prop_map[prop_id]=ui;}
+
+  //! storage types for additional property
+  typedef uint8_t prop_id_t;
+  typedef uint32_t prop_storage_t;
+  typedef std::map<prop_id_t, prop_storage_t> prop_map_t;
+
+  //! convert between 32bit inputs and storage type prop_storage_t
+  union u_property{
+    float fdata;
+    int32_t idata;
+    uint32_t uidata;
+
+    u_property(int32_t in): idata(in) {}
+    u_property(uint32_t in): uidata(in) {}
+    u_property(float in): fdata(in) {}
+    u_property(): uidata(0) {}
+
+    prop_storage_t get_storage() const {return uidata;}
+  };
+
+  //! container for additional property
+  prop_map_t prop_map;
+
+  ///@}
+
+
+
  protected:
 
   int     clusterID[100];
@@ -124,15 +208,24 @@ class SvtxTrack : public PHObject
   float   DCA2Dsigma;
   float   scatter[100];
   float   x,y,z;
-  
+
   TMatrix covariance;
-  
+
   // calorimeter matches
   float   cal_dphi[4];
   float   cal_deta[4];
   float   cal_energy_3x3[4];
   int     cal_cluster_id[4];
   float   cal_cluster_e[4];
+
+
+  /** @name Property Tags
+   *  Support a variable size propery tags
+   */
+  ///@{
+
+
+
 
   ClassDef(SvtxTrack,1)
 };


### PR DESCRIPTION
Attn: @mccumbermike 

Following Mike's request, I have added the property tagging capability to the SvtxTrack object. The goal would be avoiding multi-versioning of this object, while flexibly support adding more property tags onto the track. These new code are based on our experience of property map on PHG4Hit. 

This pull request only proposes the changes. I will leave it up to tracking expert to decide whether merge it or continue the development based on this branch (blackcathj/coresoftware:PropertyTagOnTrack). 

I moved a few scalar variable to the property map as a start. It will be trickier to move arrays into the property map. However we should be able to do so, if we define the interface function right and keep it transparent to the users. Again I will leave it to tracking experts to decide. 

If I did it right, these change should be transparent to users of SvtxTrack. First test looks good, which is easy to do in the ROOT command lines: 

```
[jinhuang@rcas2066 macro]$ root
root [0]   gSystem->Load("libg4hough.so");
root [1]  SvtxTrack tr
root [2] tr.identify()
SvtxTrack Object id: -1 
	Charge = 	1
	NDF = 	0
	Vertex x = 	0
	Vertex y = 	0
	Vertex z = 	0

# OK, init looks good. Go on to add more properties:
root [3] tr.setMomentum(23)
root [4] tr.setCharge(-1)
root [5] tr.setQuality(1)
root [6] tr.setChisq(2)
root [7] tr.setChisqv(3)
root [8] tr.setNDF(4)
root [9] tr.setDCA(5)
root [10] tr.setDCA2D(6)
root [11] tr.setDCA2Dsigma(7)
root [12] tr.set_x(8)
root [13] tr.set_y(9)
root [14] tr.set_z(10)
root [15] tr.identify()
SvtxTrack Object id: -1 chisq/dof: 0.5 
	Momentum = 	23
	Charge = 	-1
	Quality = 	1
	Chi Square = 	2
	Chi Square @ vertex = 	3
	NDF = 	4
	DCA = 	5
	DCA 2D = 	6
	DCA 2D Sigma = 	7
	Vertex x = 	8
	Vertex y = 	9
	Vertex z = 	10

```

