### PR TITLE
fixing up tower ids

### DIFF
--- a/simulation/g4simulation/g4cemc/RawTowerContainer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerContainer.cc
@@ -19,7 +19,7 @@ RawTowerContainer::genkey(const unsigned int ieta, const unsigned int iphi) cons
       exit(1);
     }
   RawTowerDefs::keytype key = 0;
-  key |= (ieta << RawTowerDefs::tower_idbits);
+  key |= (ieta << RawTowerDefs::eta_idbits);
   key |= iphi;
   return key;
 }

--- a/simulation/g4simulation/g4cemc/RawTowerDefs.h
+++ b/simulation/g4simulation/g4cemc/RawTowerDefs.h
@@ -6,6 +6,7 @@ namespace RawTowerDefs
   typedef unsigned int keytype;
   static unsigned int calo_idbits = 8;
   static unsigned int tower_idbits = sizeof(keytype)*8 - calo_idbits;
+  static unsigned int eta_idbits = tower_idbits/2;
 }
 
 #endif

--- a/simulation/g4simulation/g4cemc/RawTowerv1.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerv1.cc
@@ -1,4 +1,7 @@
 #include "RawTowerv1.h"
+
+#include "RawTowerDefs.h"
+
 #include <iostream>
 #include <algorithm>
 
@@ -25,7 +28,7 @@ RawTowerv1::RawTowerv1(const unsigned int ieta, const unsigned int iphi) :
 {
   if (ieta < 0xFFF && iphi < 0xFFF)
     {
-  towerid = (ieta << 12) + iphi;
+  towerid = (ieta << RawTowerDefs::eta_idbits) + iphi;
     }
   else
     {

--- a/simulation/g4simulation/g4cemc/RawTowerv1.h
+++ b/simulation/g4simulation/g4cemc/RawTowerv1.h
@@ -3,6 +3,8 @@
 
 #include "RawTower.h"
 
+#include "RawTowerDefs.h"
+
 #include <map>
 
 class RawTowerv1 : public RawTower {
@@ -18,7 +20,7 @@ class RawTowerv1 : public RawTower {
   void identify(std::ostream& os=std::cout) const;
 
   RawTowerDefs::keytype get_id() const { return towerid;}
-  int get_bineta() const { return (towerid >> 12)&0xFFF ; }
+  int get_bineta() const { return (towerid >> RawTowerDefs::eta_idbits)&0xFFF ; }
   int get_binphi() const { return towerid&0xFFF; }
   double get_energy() const;
 


### PR DESCRIPTION
Lower 24 bits should be divided into 12 bits for eta and 12 bits for phi. Extend the Defs into other places where 12 bits were hard-coded.