### PR TITLE
replace eta/phi bin based tower key in cluster by towerid from towers, store tower energy for easier access

### DIFF
--- a/simulation/g4simulation/g4cemc/Makefile.am
+++ b/simulation/g4simulation/g4cemc/Makefile.am
@@ -87,6 +87,7 @@ libcemc_la_LIBADD = \
 
 pkginclude_HEADERS = \
   RawCluster.h \
+  RawClusterDefs.h \
   RawClusterContainer.h \
   RawTower.h \
   RawTowerDefs.h \

--- a/simulation/g4simulation/g4cemc/RawCluster.h
+++ b/simulation/g4simulation/g4cemc/RawCluster.h
@@ -1,6 +1,9 @@
 #ifndef RAWCLUSTER_H__
 #define RAWCLUSTER_H__
 
+#include "RawClusterDefs.h"
+#include "RawTowerDefs.h"
+
 #include <phool/PHObject.h>
 #include <phool/phool.h>
 #include <cmath> // def of NAN
@@ -12,26 +15,41 @@ class RawTower;
 class RawCluster : public PHObject {
 
  public:
-  RawCluster() {}
+
+  typedef std::map<RawTowerDefs::keytype, float> TowerMap;
+  typedef TowerMap::iterator TowerIterator;
+  typedef TowerMap::const_iterator TowerConstIterator;
+  typedef std::pair<TowerIterator, TowerIterator> TowerRange;
+  typedef std::pair<TowerConstIterator, TowerConstIterator> TowerConstRange;
+
+
   virtual ~RawCluster() {}
 
   virtual void Reset() { PHOOL_VIRTUAL_WARNING; }
   virtual int isValid() const { PHOOL_VIRTUAL_WARNING; return 0; }
   virtual void identify(std::ostream& os=std::cout) const { PHOOL_VIRTUAL_WARNING; }
 
-  virtual unsigned int get_id() const { PHOOL_VIRTUAL_WARN("get_id()"); return 0; }
+  virtual RawClusterDefs::keytype get_id() const { PHOOL_VIRTUAL_WARN("get_id()"); return 0; }
   virtual float get_eta() const { PHOOL_VIRTUAL_WARN("get_eta()"); return NAN; }
   virtual float get_phi() const { PHOOL_VIRTUAL_WARN("get_phi()"); return NAN; }
   virtual float get_energy() const { PHOOL_VIRTUAL_WARN("get_energy()"); return NAN; }
 
-  virtual void set_id(const unsigned int id) { PHOOL_VIRTUAL_WARN("set_id(const unsigned int id)");}
+  virtual void set_id(const RawClusterDefs::keytype id) { PHOOL_VIRTUAL_WARN("set_id(const unsigned int id)");}
   virtual void set_eta(const float eta) { PHOOL_VIRTUAL_WARN("set_eta(const float eta)");}
   virtual void set_phi(const float phi) { PHOOL_VIRTUAL_WARN("set_phi(const float phi)");}
   virtual void set_energy(const float energy) { PHOOL_VIRTUAL_WARN("set_energy(const float energy)");}
 
-  virtual void addTower(const int ieta, const int iphi) { PHOOL_VIRTUAL_WARNING; }
+  virtual void addTower(const RawClusterDefs::keytype twrid, const float etower) { PHOOL_VIRTUAL_WARNING; }
   virtual size_t getNTowers() const { PHOOL_VIRTUAL_WARNING; return 0;}
-  virtual std::pair<int,int> getTowerBin(const unsigned int itower) const { PHOOL_VIRTUAL_WARNING; return std::make_pair(0,0);}
+  virtual TowerConstRange get_towers()
+  {
+    PHOOL_VIRTUAL_WARN("get_towers()");
+    TowerMap dummy;
+    return make_pair(dummy.begin(), dummy.end());
+  }
+
+ protected:
+  RawCluster() {} // make sure nobody calls ctor of base class
 
   ClassDef(RawCluster,1)
 

--- a/simulation/g4simulation/g4cemc/RawClusterBuilderv1.h
+++ b/simulation/g4simulation/g4cemc/RawClusterBuilderv1.h
@@ -15,7 +15,7 @@ class RawClusterBuilderv1 : public SubsysReco {
 
  public:
   RawClusterBuilderv1(const std::string& name = "RawClusterBuilder"); 
-  ~RawClusterBuilderv1();
+  virtual ~RawClusterBuilderv1();
 
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);

--- a/simulation/g4simulation/g4cemc/RawClusterContainer.h
+++ b/simulation/g4simulation/g4cemc/RawClusterContainer.h
@@ -1,6 +1,8 @@
 #ifndef RAWCLUSTERCONTAINER_H__
 #define RAWCLUSTERCONTAINER_H__
 
+#include "RawClusterDefs.h"
+
 #include <phool/PHObject.h>
 #include <phool/phool.h>
 #include <iostream>
@@ -13,7 +15,7 @@ class RawClusterContainer : public PHObject
 
  public:
 
-  typedef std::map<unsigned int,RawCluster *> Map;
+  typedef std::map<RawClusterDefs::keytype, RawCluster *> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
@@ -26,7 +28,7 @@ class RawClusterContainer : public PHObject
   int isValid() const;
   void identify(std::ostream& os=std::cout) const;
   ConstIterator AddCluster(RawCluster *clus);
-  RawCluster *getCluster(const unsigned int id);
+  RawCluster *getCluster(const RawClusterDefs::keytype id);
   //! return all clusters
   ConstRange getClusters( void ) const;
   Range getClusters( void );

--- a/simulation/g4simulation/g4cemc/RawClusterDefs.h
+++ b/simulation/g4simulation/g4cemc/RawClusterDefs.h
@@ -1,0 +1,9 @@
+#ifndef RAWCLUSTERDEFS_H
+#define RAWCLUSTERDEFS_H
+
+namespace RawClusterDefs
+{
+  typedef unsigned int keytype;
+}
+
+#endif

--- a/simulation/g4simulation/g4cemc/RawClusterv1.cc
+++ b/simulation/g4simulation/g4cemc/RawClusterv1.cc
@@ -6,7 +6,7 @@ ClassImp(RawClusterv1)
 
 RawClusterv1::RawClusterv1()
 : RawCluster(),
-  _id(0),
+  clusterid(0),
   _eta(0.0),
   _phi(0.0),
   _energy(0.0)
@@ -15,20 +15,21 @@ RawClusterv1::RawClusterv1()
 void
 RawClusterv1::Reset()
 {
-  _id = 0;
+  clusterid = 0;
   _eta = 0.0;
   _phi = 0.0;
   _energy = 0.0;
-  _towers.clear();
+  towermap.clear();
 }
 
-std::pair<int,int>
-RawClusterv1::getTowerBin(const unsigned int itower) const
+void
+RawClusterv1::addTower(const RawClusterDefs::keytype twrid, const float etower)
 {
-  if (itower < _towers.size())
+  if (towermap.find(twrid) != towermap.end())
     {
-      return  _towers[itower];
+      cout << "tower 0x" << hex << twrid << ", dec: " << dec
+	   << twrid << " already exists, that is bad" << endl;
+      exit(1);
     }
-  return make_pair(-9999,-9999);
+  towermap[twrid] = etower;
 }
-

--- a/simulation/g4simulation/g4cemc/RawClusterv1.h
+++ b/simulation/g4simulation/g4cemc/RawClusterv1.h
@@ -12,35 +12,37 @@ class RawClusterv1 : public RawCluster {
   virtual ~RawClusterv1() {}
 
   void Reset();
-  int isValid() const { return _towers.size() > 0; }
+  int isValid() const { return towermap.size() > 0; }
   void identify(std::ostream& os=std::cout) const {
     os << "This is the RawClusterv1 object" << std::endl;
   }
 
-  unsigned int get_id() const { return _id; }
+  RawClusterDefs::keytype get_id() const { return clusterid; }
   float get_eta() const { return _eta; }
   float get_phi() const { return _phi; }
   float get_energy() const { return _energy; }
 
-  void set_id(const unsigned int id) {_id = id;}
+  void set_id(const RawClusterDefs::keytype id) {clusterid = id;}
   void set_eta(const float eta) { _eta = eta; }
   void set_phi(const float phi) { _phi = phi; }
   void set_energy(const float energy) { _energy = energy; }
 
-  void addTower(const int ieta, const int iphi)
-  {
-    _towers.push_back(std::make_pair(ieta,iphi));
-  }
-  size_t getNTowers() const { return _towers.size();}
-  std::pair<int,int> getTowerBin(const unsigned int itower) const;
+  void addTower(const RawClusterDefs::keytype twrid, const float etower);
+  size_t getNTowers() const { return towermap.size();}
+
+  RawCluster::TowerConstRange get_towers()
+    {
+      return make_pair(towermap.begin(),towermap.end());
+    }
 
  private:
-  unsigned int _id;
+  RawClusterDefs::keytype clusterid;
   float _eta;
   float _phi;
   float _energy;
-
   std::vector<std::pair<int,int> > _towers;
+
+  TowerMap towermap;
 
   ClassDef(RawClusterv1,1)
 

--- a/simulation/g4simulation/g4cemc/RawClusterv1LinkDef.h
+++ b/simulation/g4simulation/g4cemc/RawClusterv1LinkDef.h
@@ -1,5 +1,6 @@
 #ifdef __CINT__
 
+#pragma link C++ namespace RawClusterDefs;
 #pragma link C++ class RawClusterv1+;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.C
@@ -66,12 +66,11 @@ std::set<PHG4Hit*> CaloRawClusterEval::all_truth_hits(RawCluster* cluster) {
   std::set<PHG4Hit*> truth_hits;
 
   // loop over all the clustered towers
-  for (unsigned int itower = 0; itower < cluster->getNTowers(); ++itower) {
-
-    int ieta = cluster->getTowerBin(itower).first;
-    int iphi = cluster->getTowerBin(itower).second;
-    
-    RawTower* tower = _towers->getTower(ieta,iphi);
+  RawCluster::TowerConstRange begin_end = cluster->get_towers();
+  RawCluster::TowerConstIterator iter;
+  for (iter = begin_end.first; iter != begin_end.second; ++iter)
+    { 
+    RawTower* tower = _towers->getTower(iter->first);
     
     std::set<PHG4Hit*> new_hits = _towereval.all_truth_hits(tower);
     std::set<PHG4Hit*> union_hits;
@@ -101,13 +100,11 @@ std::set<PHG4Particle*> CaloRawClusterEval::all_truth_primaries(RawCluster* clus
   std::set<PHG4Particle*> truth_primaries;
   
   // loop over all the clustered towers
-  for (unsigned int itower = 0; itower < cluster->getNTowers(); ++itower) {
-
-    int ieta = cluster->getTowerBin(itower).first;
-    int iphi = cluster->getTowerBin(itower).second;
-    
-    RawTower* tower = _towers->getTower(ieta,iphi);
-    
+  RawCluster::TowerConstRange begin_end = cluster->get_towers();
+  RawCluster::TowerConstIterator iter;
+  for (iter = begin_end.first; iter != begin_end.second; ++iter)
+    { 
+    RawTower* tower = _towers->getTower(iter->first);
     std::set<PHG4Particle*> new_primaries = _towereval.all_truth_primaries(tower);
     std::set<PHG4Particle*> union_primaries;
 


### PR DESCRIPTION
Now the clusters follow the same scheme as our hits, cells and towers. No change in the clusters themselves. This made a small change in the evaluator necessary.