### PR TITLE
SvtxTrack storage and interface revision

### DIFF
--- a/simulation/g4simulation/g4eval/JetRecoEval.C
+++ b/simulation/g4simulation/g4eval/JetRecoEval.C
@@ -408,7 +408,7 @@ float JetRecoEval::get_energy_contribution(Jet* recojet, Jet* truthjet) {
 	SvtxTrack* track = _trackmap->get(index);
 	PHG4Particle* maxtruthparticle = get_svtx_eval_stack()->get_track_eval()->max_truth_particle_by_nclusters(track);
 	if (maxtruthparticle->get_track_id() == truthparticle->get_track_id()) { 
-	  energy = track->getMomentum();
+	  energy = track->get_p();
 	}
       } else if (source == Jet::CEMC_TOWER) {
 	RawTower* tower = _cemctowers->getTower(index);

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -461,7 +461,7 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode *topNode) {
 	    float pz = track->get3Momentum(2);
 
 	    cout << "===Created-SvtxTrack==========================================" << endl;
-	    cout << " SvtxTrack id = " << track->getTrackID() << endl;
+	    cout << " SvtxTrack id = " << track->get_id() << endl;
 	    cout << " preco = (";
 	    cout.width(5); cout << px;
 	    cout << ",";
@@ -1078,7 +1078,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float nfromtruth    = NAN;
 
 	if (track) {
-	  trackID   = track->getTrackID();     
+	  trackID   = track->get_id();     
 	  charge    = track->getCharge();
 	  quality   = track->getQuality();
 	  chisq     = track->getChisq();
@@ -1160,7 +1160,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
     
 	SvtxTrack* track         = &iter->second;
 
-	float trackID   = track->getTrackID();     
+	float trackID   = track->get_id();     
 	float charge    = track->getCharge();
 	float quality   = track->getQuality();
 	float chisq     = track->getChisq();

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -1097,9 +1097,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  px        = track->get3Momentum(0);
 	  py        = track->get3Momentum(1);
 	  pz        = track->get3Momentum(2);
-	  pcax      = track->get_d() * sin(track->get_phi());
-	  pcay      = track->get_d() * cos(track->get_phi());
-	  pcaz      = track->get_z0();
+	  pcax      = track->get_x();
+	  pcay      = track->get_y();
+	  pcaz      = track->get_z();
 
 	  nfromtruth = trackeval->get_nclusters_contribution(track,g4particle);
 	}
@@ -1179,9 +1179,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float px        = track->get3Momentum(0);
 	float py        = track->get3Momentum(1);
 	float pz        = track->get3Momentum(2);
-	float pcax      = track->get_d() * sin(track->get_phi());
-	float pcay      = track->get_d() * cos(track->get_phi());
-	float pcaz      = track->get_z0();
+	float pcax      = track->get_x();
+	float pcay      = track->get_y();
+	float pcaz      = track->get_z();
 
 	float presdphi = track->get_cal_dphi(SvtxTrack::PRES);
 	float presdeta = track->get_cal_deta(SvtxTrack::PRES);

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -1097,9 +1097,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  px        = track->get3Momentum(0);
 	  py        = track->get3Momentum(1);
 	  pz        = track->get3Momentum(2);
-	  pcax      = track->d * sin(track->phi);
-	  pcay      = track->d * cos(track->phi);
-	  pcaz      = track->z0;
+	  pcax      = track->get_d() * sin(track->get_phi());
+	  pcay      = track->get_d() * cos(track->get_phi());
+	  pcaz      = track->get_z0();
 
 	  nfromtruth = trackeval->get_nclusters_contribution(track,g4particle);
 	}
@@ -1179,9 +1179,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float px        = track->get3Momentum(0);
 	float py        = track->get3Momentum(1);
 	float pz        = track->get3Momentum(2);
-	float pcax      = track->d * sin(track->phi);
-	float pcay      = track->d * cos(track->phi);
-	float pcaz      = track->z0;
+	float pcax      = track->get_d() * sin(track->get_phi());
+	float pcay      = track->get_d() * cos(track->get_phi());
+	float pcaz      = track->get_z0();
 
 	float presdphi = track->get_cal_dphi(SvtxTrack::PRES);
 	float presdeta = track->get_cal_deta(SvtxTrack::PRES);

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -456,9 +456,9 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode *topNode) {
 	  
 	    SvtxTrack *track = *jter;
 
-	    float px = track->get3Momentum(0);
-	    float py = track->get3Momentum(1);
-	    float pz = track->get3Momentum(2);
+	    float px = track->get_px();
+	    float py = track->get_py();
+	    float pz = track->get_pz();
 
 	    cout << "===Created-SvtxTrack==========================================" << endl;
 	    cout << " SvtxTrack id = " << track->get_id() << endl;
@@ -469,7 +469,7 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode *topNode) {
 	    cout << ",";
 	    cout.width(5); cout << pz;
 	    cout << ")" << endl;
-	    cout << " quality = " << track->getQuality() << endl;
+	    cout << " quality = " << track->get_quality() << endl;
 	    cout << " nfromtruth = " << trackeval->get_nclusters_contribution(track,particle) << endl;
 
 	    cout << " ---Associated-SvtxClusters-to-PHG4Hits-------------------------" << endl;    
@@ -1079,10 +1079,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
 	if (track) {
 	  trackID   = track->get_id();     
-	  charge    = track->getCharge();
-	  quality   = track->getQuality();
-	  chisq     = track->getChisq();
-	  ndf       = track->getNDF();
+	  charge    = track->get_charge();
+	  quality   = track->get_quality();
+	  chisq     = track->get_chisq();
+	  ndf       = track->get_ndf();
 	  nhits     = track->getNhits();
 
 	  for (unsigned int i = 0; i < 32; ++i){ // only 32 bits available	
@@ -1091,12 +1091,12 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	    }
 	  }
 
-	  dca       = track->getDCA();
-	  dca2d     = track->getDCA2D();
-	  dca2dsigma = track->getDCA2Dsigma();
-	  px        = track->get3Momentum(0);
-	  py        = track->get3Momentum(1);
-	  pz        = track->get3Momentum(2);
+	  dca       = track->get_dca();
+	  dca2d     = track->get_dca2d();
+	  dca2dsigma = track->get_dca2d_error();
+	  px        = track->get_px();
+	  py        = track->get_py();
+	  pz        = track->get_pz();
 	  pcax      = track->get_x();
 	  pcay      = track->get_y();
 	  pcaz      = track->get_z();
@@ -1161,10 +1161,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	SvtxTrack* track         = &iter->second;
 
 	float trackID   = track->get_id();     
-	float charge    = track->getCharge();
-	float quality   = track->getQuality();
-	float chisq     = track->getChisq();
-	float ndf       = track->getNDF();
+	float charge    = track->get_charge();
+	float quality   = track->get_quality();
+	float chisq     = track->get_chisq();
+	float ndf       = track->get_ndf();
 	float nhits     = track->getNhits();
 
 	unsigned int layers = 0x0;
@@ -1174,11 +1174,11 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  }
 	}
       
-	float dca2d     = track->getDCA2D();
-	float dca2dsigma = track->getDCA2Dsigma();
-	float px        = track->get3Momentum(0);
-	float py        = track->get3Momentum(1);
-	float pz        = track->get3Momentum(2);
+	float dca2d     = track->get_dca2d();
+	float dca2dsigma = track->get_dca2d_error();
+	float px        = track->get_px();
+	float py        = track->get_py();
+	float pz        = track->get_pz();
 	float pcax      = track->get_x();
 	float pcay      = track->get_y();
 	float pcaz      = track->get_z();

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.C
@@ -63,10 +63,11 @@ std::set<PHG4Hit*> SvtxTrackEval::all_truth_hits(SvtxTrack* track) {
   std::set<PHG4Hit*> truth_hits;
 
   // loop over all clusters...
-  for (unsigned int ilayer = 0; ilayer < 100; ++ilayer) {
-    if (!track->hasCluster(ilayer)) continue;
-
-    SvtxCluster* cluster = _clustermap->get(track->getClusterID(ilayer));
+  for (SvtxTrack::ConstClusterIter iter = track->begin_clusters();
+       iter != track->end_clusters();
+       ++iter) {
+    unsigned int cluster_id = *iter;  
+    SvtxCluster* cluster = _clustermap->get(cluster_id);
 
     std::set<PHG4Hit*> new_hits = _clustereval.all_truth_hits(cluster);
 
@@ -97,10 +98,11 @@ std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track) {
   std::set<PHG4Particle*> truth_particles;
 
   // loop over all clusters...
-  for (unsigned int ilayer = 0; ilayer < 100; ++ilayer) {
-    if (!track->hasCluster(ilayer)) continue;
-
-    SvtxCluster* cluster = _clustermap->get(track->getClusterID(ilayer));
+  for (SvtxTrack::ConstClusterIter iter = track->begin_clusters();
+       iter != track->end_clusters();
+       ++iter) {
+    unsigned int cluster_id = *iter;
+    SvtxCluster* cluster = _clustermap->get(cluster_id);
 
     std::set<PHG4Particle*> new_particles = _clustereval.all_truth_particles(cluster);
 
@@ -167,11 +169,11 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
        ++iter) {
     SvtxTrack* track = &iter->second;
     
-    // loop over all clusters    
-    for (unsigned int ilayer = 0; ilayer < 100; ++ilayer) {
-      if (!track->hasCluster(ilayer)) continue;
-
-      SvtxCluster* cluster = _clustermap->get(track->getClusterID(ilayer));
+    for (SvtxTrack::ConstClusterIter iter = track->begin_clusters();
+	 iter != track->end_clusters();
+	 ++iter) {
+      unsigned int cluster_id = *iter;
+      SvtxCluster* cluster = _clustermap->get(cluster_id);
 
       // loop over all particles
       std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster);
@@ -210,11 +212,12 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Hit* truthhit) {
        ++iter) {
     SvtxTrack* track = &iter->second;
     
-    // loop over all clusters    
-    for (unsigned int ilayer = 0; ilayer < 100; ++ilayer) {
-      if (!track->hasCluster(ilayer)) continue;
-
-      SvtxCluster* cluster = _clustermap->get(track->getClusterID(ilayer));
+    // loop over all clusters
+    for (SvtxTrack::ConstClusterIter iter = track->begin_clusters();
+	 iter != track->end_clusters();
+	 ++iter) {
+      unsigned int cluster_id = *iter;
+      SvtxCluster* cluster = _clustermap->get(cluster_id);
 
       // loop over all hits
       std::set<PHG4Hit*> hits = _clustereval.all_truth_hits(cluster);
@@ -275,13 +278,14 @@ unsigned int SvtxTrackEval::get_nclusters_contribution(SvtxTrack* track, PHG4Par
     }
   }
   
-  unsigned int nclusters = 0;
+  unsigned int nclusters = 0; 
 
-  // loop over all clusters    
-  for (unsigned int ilayer = 0; ilayer < 100; ++ilayer) {
-    if (!track->hasCluster(ilayer)) continue;
-
-    SvtxCluster* cluster = _clustermap->get(track->getClusterID(ilayer));
+  // loop over all clusters
+  for (SvtxTrack::ConstClusterIter iter = track->begin_clusters();
+       iter != track->end_clusters();
+       ++iter) {
+    unsigned int cluster_id = *iter;
+    SvtxCluster* cluster = _clustermap->get(cluster_id);
 
     // loop over all particles
     std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster);

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -144,7 +144,7 @@ PHG4Hit* SvtxTruthEval::get_innermost_truth_hit(PHG4Particle* particle) {
 PHG4Hit* SvtxTruthEval::get_outermost_truth_hit(PHG4Particle* particle) {
 
   PHG4Hit* outermost_hit = NULL;
-  float outermost_radius = FLT_MAX-1.0;
+  float outermost_radius = FLT_MAX*-1.0;
   
   std::set<PHG4Hit*> truth_hits = all_truth_hits(particle);
   for (std::set<PHG4Hit*>::iterator iter = truth_hits.begin();

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -95,11 +95,11 @@ static inline double sign(double x)
 
 void PHG4HoughTransform::projectToRadius(const SvtxTrack& track, double radius, vector<double>& intersection)
 {
-  float phi = track.get_phi();
-  float d = track.get_d();
-  float k = track.get_kappa();
-  float z0 = track.get_z0();
-  float dzdl = track.get_dzdl();
+  float phi = track.get_helix_phi();
+  float d = track.get_helix_d();
+  float k = track.get_helix_kappa();
+  float z0 = track.get_helix_z0();
+  float dzdl = track.get_helix_dzdl();
   
   intersection.clear();intersection.assign(3,0.);
   double& x = intersection[0];
@@ -672,7 +672,7 @@ int PHG4HoughTransform::process_event(PHCompositeNode *topNode)
   for(unsigned int itrack=0; itrack<_tracks.size();itrack++)
   {
     SvtxTrack track;
-    track.setTrackID(itrack);
+    track.set_id(itrack);
     track_hits.clear();
     track_hits = _tracks.at(itrack).hits;
     
@@ -699,11 +699,11 @@ int PHG4HoughTransform::process_event(PHCompositeNode *topNode)
     float dzdl = _tracks.at(itrack).dzdl;
     float z0 = _tracks.at(itrack).z0;
     
-    track.set_phi(phi);
-    track.set_kappa(kappa);
-    track.set_d(d);
-    track.set_z0(z0);
-    track.set_dzdl(dzdl);
+    track.set_helix_phi(phi);
+    track.set_helix_kappa(kappa);
+    track.set_helix_d(d);
+    track.set_helix_z0(z0);
+    track.set_helix_dzdl(dzdl);
     
     float pT = kappaToPt(kappa);
 
@@ -762,7 +762,7 @@ int PHG4HoughTransform::process_event(PHCompositeNode *topNode)
 
     
     _g4tracks->insert(track);
-    vertex.insert_track(track.getTrackID());
+    vertex.insert_track(track.get_id());
 
     if (verbosity > 5) {
       cout << "track " << itrack << " quality = "

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -93,14 +93,15 @@ static inline double sign(double x)
   return ((double)(x > 0.)) - ((double)(x < 0.));
 }
 
-void PHG4HoughTransform::projectToRadius(const SvtxTrack& track, double radius, vector<double>& intersection)
+void PHG4HoughTransform::projectToRadius(const SvtxTrack& track, double B, double radius, vector<double>& intersection)
 {
-  float phi = track.get_helix_phi();
-  float d = track.get_helix_d();
-  float k = track.get_helix_kappa();
-  float z0 = track.get_helix_z0();
-  float dzdl = track.get_helix_dzdl();
-  
+
+  float phi  = atan2(track.get_y(),track.get_x());
+  float d    = track.get_dca2d();
+  float k    = B / 333.6 / track.get_pt();
+  float z0   = track.get_z();
+  float dzdl = track.get_pz()/track.get_p();
+
   intersection.clear();intersection.assign(3,0.);
   double& x = intersection[0];
   double& y = intersection[1];
@@ -694,11 +695,11 @@ int PHG4HoughTransform::process_event(PHCompositeNode *topNode)
     float dzdl = _tracks.at(itrack).dzdl;
     float z0 = _tracks.at(itrack).z0;
     
-    track.set_helix_phi(phi);
-    track.set_helix_kappa(kappa);
-    track.set_helix_d(d);
-    track.set_helix_z0(z0);
-    track.set_helix_dzdl(dzdl);
+    //    track.set_helix_phi(phi);
+    //    track.set_helix_kappa(kappa);
+    //    track.set_helix_d(d);
+    //    track.set_helix_z0(z0);
+    //    track.set_helix_dzdl(dzdl);
     
     float pT = kappaToPt(kappa);
 

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -95,11 +95,11 @@ static inline double sign(double x)
 
 void PHG4HoughTransform::projectToRadius(const SvtxTrack& track, double radius, vector<double>& intersection)
 {
-  float phi = track.phi;
-  float d = track.d;
-  float k = track.kappa;
-  float z0 = track.z0;
-  float dzdl = track.dzdl;
+  float phi = track.get_phi();
+  float d = track.get_d();
+  float k = track.get_kappa();
+  float z0 = track.get_z0();
+  float dzdl = track.get_dzdl();
   
   intersection.clear();intersection.assign(3,0.);
   double& x = intersection[0];
@@ -696,15 +696,14 @@ int PHG4HoughTransform::process_event(PHCompositeNode *topNode)
     float kappa = _tracks.at(itrack).kappa;
     float d = _tracks.at(itrack).d;
     float phi = _tracks.at(itrack).phi;
-
     float dzdl = _tracks.at(itrack).dzdl;
     float z0 = _tracks.at(itrack).z0;
     
-    track.phi = phi;
-    track.kappa = kappa;
-    track.d = d;
-    track.z0 = z0;
-    track.dzdl = dzdl;
+    track.set_phi(phi);
+    track.set_kappa(kappa);
+    track.set_d(d);
+    track.set_z0(z0);
+    track.set_dzdl(dzdl);
     
     float pT = kappaToPt(kappa);
 

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -727,21 +727,22 @@ int PHG4HoughTransform::process_event(PHCompositeNode *topNode)
       pZ = pT * dzdl / sqrt(1.0 - dzdl*dzdl);
     }
     int ndf = 2*_tracks.at(itrack).hits.size() - 5;
-    track.setQuality(chi_squareds[itrack]/((float)ndf));
-    track.setChisq(chi_squareds[itrack]);
-    track.setNDF(ndf);
-    track.set3Momentum( pT*cos(phi-helicity*M_PI/2), pT*sin(phi-helicity*M_PI/2), pZ);
+    track.set_chisq(chi_squareds[itrack]);
+    track.set_ndf(ndf);
+    track.set_px( pT*cos(phi-helicity*M_PI/2) );
+    track.set_py( pT*sin(phi-helicity*M_PI/2) );
+    track.set_pz( pZ );
 
-    track.setDCA2D( d );
-    track.setDCA2Dsigma(sqrt(_tracker->getKalmanStates()[itrack].C(1,1)));  
+    track.set_dca2d( d );
+    track.set_dca2d_error(sqrt(_tracker->getKalmanStates()[itrack].C(1,1)));  
 
     if(_magField > 0)
     {
-      track.setCharge( -1.0*helicity );
+      track.set_charge( -1.0*helicity );
     }
     else
     {
-      track.setCharge( helicity );
+      track.set_charge( helicity );
     }
 
     Matrix<float,6,6> euclidean_cov = Matrix<float,6,6>::Zero(6,6);
@@ -751,25 +752,23 @@ int PHG4HoughTransform::process_event(PHCompositeNode *topNode)
     {
       for(unsigned int col=0;col<6;++col)
       {
-	track.setCovariance(row,col,euclidean_cov(row,col));
+	track.set_error(row,col,euclidean_cov(row,col));
       }
     }
 
     track.set_x( d*cos(phi) );
     track.set_y( d*sin(phi) );
     track.set_z( z0 );
-
-
     
     _g4tracks->insert(track);
     vertex.insert_track(track.get_id());
 
     if (verbosity > 5) {
       cout << "track " << itrack << " quality = "
-           << track.getQuality() << endl;
-      cout << "px = " << track.get3Momentum(0)
-           << " py = " << track.get3Momentum(1)
-           << " pz = " << track.get3Momentum(2) << endl;
+           << track.get_quality() << endl;
+      cout << "px = " << track.get_px()
+           << " py = " << track.get_py()
+           << " pz = " << track.get_pz() << endl;
     }
   } // track loop
 

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -114,9 +114,13 @@ void PHG4HoughTransform::projectToRadius(const SvtxTrack& track, double radius, 
   // get outer hit
   float hitx = d*cosphi;
   float hity = d*sinphi;
-  if (!track.empty_clusters()) {
-    hitx = track.getOuterMostHitPosition(0);
-    hity = track.getOuterMostHitPosition(1);
+
+  for (SvtxTrack::ConstStateIter iter = track.begin_states();
+       iter != track.end_states();
+       ++iter) {
+    const SvtxTrack::State* state = &iter->second;
+    hitx = state->get_x();
+    hity = state->get_y();
   }
   
   k = fabs(k);
@@ -682,7 +686,6 @@ int PHG4HoughTransform::process_event(PHCompositeNode *topNode)
       if( (clusterLayer < (int)_seed_layers) && (clusterLayer >= 0) )
       {
         track.insert_cluster(clusterID);
-        track.setHitPosition(clusterLayer,cluster_x,cluster_y,cluster_z);
       }
     }
     float kappa = _tracks.at(itrack).kappa;

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -751,7 +751,7 @@ int PHG4HoughTransform::process_event(PHCompositeNode *topNode)
     {
       for(unsigned int col=0;col<6;++col)
       {
-        (*(track.getCovariance()))[row][col] = euclidean_cov(row,col);
+	track.setCovariance(row,col,euclidean_cov(row,col));
       }
     }
 

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -114,18 +114,10 @@ void PHG4HoughTransform::projectToRadius(const SvtxTrack& track, double radius, 
   // get outer hit
   float hitx = d*cosphi;
   float hity = d*sinphi;
-  int nhits = track.getNhits();
-  for(int l=(nhits-1);l>=0;l-=1)
-  {
-    if(track.getClusterID(l) >= 0)
-    {
-      hitx = track.getHitPosition(l, 0);
-      hity = track.getHitPosition(l, 1);
-      break;
-    }
+  if (!track.empty_clusters()) {
+    hitx = track.getOuterMostHitPosition(0);
+    hity = track.getOuterMostHitPosition(1);
   }
-  
-  
   
   k = fabs(k);
   
@@ -689,7 +681,7 @@ int PHG4HoughTransform::process_event(PHCompositeNode *topNode)
       cluster_z = cluster->get_z();
       if( (clusterLayer < (int)_seed_layers) && (clusterLayer >= 0) )
       {
-        track.setClusterID(clusterLayer, clusterID);
+        track.insert_cluster(clusterID);
         track.setHitPosition(clusterLayer,cluster_x,cluster_y,cluster_z);
       }
     }

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -734,11 +734,11 @@ int PHG4HoughTransform::process_event(PHCompositeNode *topNode)
 
     if(_magField > 0)
     {
-      track.set_charge( -1.0*helicity );
+      track.set_charge( helicity );
     }
     else
     {
-      track.set_charge( helicity );
+      track.set_charge( -1.0*helicity );
     }
 
     Matrix<float,6,6> euclidean_cov = Matrix<float,6,6>::Zero(6,6);

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.h
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.h
@@ -71,7 +71,8 @@ public:
 
   /// external handle for projecting tracks into the calorimetry
   static void projectToRadius(const SvtxTrack& track,
-			      double radius,
+			      double magfield, // in Tesla
+			      double radius,   // in cm
 			      std::vector<double>& intersection);
 
   float get_mag_field() const          {return _magField;}

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -745,7 +745,7 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
     {
       for(unsigned int col=0;col<6;++col)
       {
-        (*(track.getCovariance()))[row][col] = euclidean_cov(row,col);
+	track.setCovariance(row,col,euclidean_cov(row,col));
       }
     }
 

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -708,13 +708,14 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
       pZ = pT * dzdl / sqrt(1.0 - dzdl*dzdl);
     }
     int ndf = 2*_tracks.at(itrack).hits.size() - 5;
-    track.setQuality(chi_squareds[itrack]/((float)ndf));
-    track.setChisq(chi_squareds[itrack]);
-    track.setNDF(ndf);
-    track.set3Momentum( pT*cos(phi-helicity*M_PI/2), pT*sin(phi-helicity*M_PI/2), pZ);
+    track.set_chisq(chi_squareds[itrack]);
+    track.set_ndf(ndf);
+    track.set_px( pT*cos(phi-helicity*M_PI/2) );
+    track.set_py( pT*sin(phi-helicity*M_PI/2) );
+    track.set_pz( pZ );
 
-    track.setDCA2D( d );
-    track.setDCA2Dsigma(sqrt(_tracker->getKalmanStates()[itrack].C(1,1)));  
+    track.set_dca2d( d );
+    track.set_dca2d_error(sqrt(_tracker->getKalmanStates()[itrack].C(1,1)));  
 
     if(_write_reco_tree==true)
     {
@@ -731,11 +732,11 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
 
     if(_magField > 0)
     {
-      track.setCharge( -1.0*helicity );
+      track.set_charge( -1.0*helicity );
     }
     else
     {
-      track.setCharge( helicity );
+      track.set_charge( helicity );
     }
 
     Matrix<float,6,6> euclidean_cov = Matrix<float,6,6>::Zero(6,6);
@@ -745,7 +746,7 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
     {
       for(unsigned int col=0;col<6;++col)
       {
-	track.setCovariance(row,col,euclidean_cov(row,col));
+	track.set_error(row,col,euclidean_cov(row,col));
       }
     }
 
@@ -760,10 +761,10 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
 
     if (verbosity > 5) {
       cout << "track " << itrack << " quality = "
-           << track.getQuality() << endl;
-      cout << "px = " << track.get3Momentum(0)
-           << " py = " << track.get3Momentum(1)
-           << " pz = " << track.get3Momentum(2) << endl;
+           << track.get_quality() << endl;
+      cout << "px = " << track.get_px()
+           << " py = " << track.get_py()
+           << " pz = " << track.get_pz() << endl;
     }
   } // track loop
 

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -118,9 +118,13 @@ void PHG4HoughTransformTPC::projectToRadius(const SvtxTrack& track, double radiu
   // get outer hit
   float hitx = d*cosphi;
   float hity = d*sinphi;
-  if (!track.empty_clusters()) {
-    hitx = track.getOuterMostHitPosition(0);
-    hity = track.getOuterMostHitPosition(1);
+
+  for (SvtxTrack::ConstStateIter iter = track.begin_states();
+       iter != track.end_states();
+       ++iter) {
+    const SvtxTrack::State* state = &iter->second;
+    hitx = state->get_x();
+    hity = state->get_y();
   }
   
   k = fabs(k);
@@ -662,7 +666,6 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
       if( (clusterLayer < (int)_seed_layers) && (clusterLayer >= 0) )
       {
         track.insert_cluster(clusterID);
-        track.setHitPosition(clusterLayer,cluster_x,cluster_y,cluster_z);
       }
     }
     float kappa = _tracks.at(itrack).kappa;

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -727,11 +727,11 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
 
     if(_magField > 0)
     {
-      track.set_charge( -1.0*helicity );
+      track.set_charge( helicity );
     }
     else
     {
-      track.set_charge( helicity );
+      track.set_charge( -1.0*helicity );
     }
 
     Matrix<float,6,6> euclidean_cov = Matrix<float,6,6>::Zero(6,6);

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -118,18 +118,10 @@ void PHG4HoughTransformTPC::projectToRadius(const SvtxTrack& track, double radiu
   // get outer hit
   float hitx = d*cosphi;
   float hity = d*sinphi;
-  int nhits = track.getNhits();
-  for(int l=(nhits-1);l>=0;l-=1)
-  {
-    if(track.getClusterID(l) >= 0)
-    {
-      hitx = track.getHitPosition(l, 0);
-      hity = track.getHitPosition(l, 1);
-      break;
-    }
+  if (!track.empty_clusters()) {
+    hitx = track.getOuterMostHitPosition(0);
+    hity = track.getOuterMostHitPosition(1);
   }
-  
-  
   
   k = fabs(k);
   
@@ -669,7 +661,7 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
       cluster_z = cluster->get_z();
       if( (clusterLayer < (int)_seed_layers) && (clusterLayer >= 0) )
       {
-        track.setClusterID(clusterLayer, clusterID);
+        track.insert_cluster(clusterID);
         track.setHitPosition(clusterLayer,cluster_x,cluster_y,cluster_z);
       }
     }

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -99,11 +99,11 @@ static inline double sign(double x)
 
 void PHG4HoughTransformTPC::projectToRadius(const SvtxTrack& track, double radius, vector<double>& intersection)
 {
-  float phi = track.phi;
-  float d = track.d;
-  float k = track.kappa;
-  float z0 = track.z0;
-  float dzdl = track.dzdl;
+  float phi = track.get_phi();
+  float d = track.get_d();
+  float k = track.get_kappa();
+  float z0 = track.get_z0();
+  float dzdl = track.get_dzdl();
   
   intersection.clear();intersection.assign(3,0.);
   double& x = intersection[0];
@@ -680,11 +680,11 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
     float dzdl = _tracks.at(itrack).dzdl;
     float z0 = _tracks.at(itrack).z0;
     
-    track.phi = phi;
-    track.kappa = kappa;
-    track.d = d;
-    track.z0 = z0;
-    track.dzdl = dzdl;
+    track.set_phi(phi);
+    track.set_kappa(kappa);
+    track.set_d(d);
+    track.set_z0(z0);
+    track.set_dzdl(dzdl);
     
     float pT = kappaToPt(kappa);
 

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -97,13 +97,13 @@ static inline double sign(double x)
   return ((double)(x > 0.)) - ((double)(x < 0.));
 }
 
-void PHG4HoughTransformTPC::projectToRadius(const SvtxTrack& track, double radius, vector<double>& intersection)
+void PHG4HoughTransformTPC::projectToRadius(const SvtxTrack& track, double B, double radius, vector<double>& intersection)
 {
-  float phi = track.get_helix_phi();
-  float d = track.get_helix_d();
-  float k = track.get_helix_kappa();
-  float z0 = track.get_helix_z0();
-  float dzdl = track.get_helix_dzdl();
+  float phi  = atan2(track.get_y(),track.get_x());
+  float d    = track.get_dca2d();
+  float k    = B / 333.6 / track.get_pt();
+  float z0   = track.get_z();
+  float dzdl = track.get_pz()/track.get_p();
   
   intersection.clear();intersection.assign(3,0.);
   double& x = intersection[0];
@@ -675,11 +675,11 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
     float dzdl = _tracks.at(itrack).dzdl;
     float z0 = _tracks.at(itrack).z0;
     
-    track.set_helix_phi(phi);
-    track.set_helix_kappa(kappa);
-    track.set_helix_d(d);
-    track.set_helix_z0(z0);
-    track.set_helix_dzdl(dzdl);
+    // track.set_helix_phi(phi);
+    // track.set_helix_kappa(kappa);
+    // track.set_helix_d(d);
+    // track.set_helix_z0(z0);
+    // track.set_helix_dzdl(dzdl);
     
     float pT = kappaToPt(kappa);
 

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -99,11 +99,11 @@ static inline double sign(double x)
 
 void PHG4HoughTransformTPC::projectToRadius(const SvtxTrack& track, double radius, vector<double>& intersection)
 {
-  float phi = track.get_phi();
-  float d = track.get_d();
-  float k = track.get_kappa();
-  float z0 = track.get_z0();
-  float dzdl = track.get_dzdl();
+  float phi = track.get_helix_phi();
+  float d = track.get_helix_d();
+  float k = track.get_helix_kappa();
+  float z0 = track.get_helix_z0();
+  float dzdl = track.get_helix_dzdl();
   
   intersection.clear();intersection.assign(3,0.);
   double& x = intersection[0];
@@ -652,7 +652,7 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
   for(unsigned int itrack=0; itrack<_tracks.size();itrack++)
   {
     SvtxTrack track;
-    track.setTrackID(itrack);
+    track.set_id(itrack);
     track_hits.clear();
     track_hits = _tracks.at(itrack).hits;
     
@@ -680,11 +680,11 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
     float dzdl = _tracks.at(itrack).dzdl;
     float z0 = _tracks.at(itrack).z0;
     
-    track.set_phi(phi);
-    track.set_kappa(kappa);
-    track.set_d(d);
-    track.set_z0(z0);
-    track.set_dzdl(dzdl);
+    track.set_helix_phi(phi);
+    track.set_helix_kappa(kappa);
+    track.set_helix_d(d);
+    track.set_helix_z0(z0);
+    track.set_helix_dzdl(dzdl);
     
     float pT = kappaToPt(kappa);
 
@@ -756,7 +756,7 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
 
     
     _g4tracks->insert(track);
-    vertex.insert_track(track.getTrackID());
+    vertex.insert_track(track.get_id());
 
     if (verbosity > 5) {
       cout << "track " << itrack << " quality = "

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.h
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.h
@@ -73,7 +73,8 @@ public:
 
   /// external handle for projecting tracks into the calorimetry
   static void projectToRadius(const SvtxTrack& track,
-			      double radius,
+			      double magfield, // in Tesla
+			      double radius,   // in cm
 			      std::vector<double>& intersection);
 
   float get_mag_field() const          {return _magField;}

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
@@ -118,7 +118,7 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
 	 ++iter) {
       SvtxTrack *track = &iter->second;
 
-      if (verbosity > 1) cout << "projecting track id " << track->getTrackID() << endl;
+      if (verbosity > 1) cout << "projecting track id " << track->get_id() << endl;
 
       if (verbosity > 1) {
 	cout << " track pt = " << sqrt(pow(track->get3Momentum(0),2) +

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
@@ -121,8 +121,7 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
       if (verbosity > 1) cout << "projecting track id " << track->get_id() << endl;
 
       if (verbosity > 1) {
-	cout << " track pt = " << sqrt(pow(track->get3Momentum(0),2) +
-				       pow(track->get3Momentum(1),2)) << endl;
+	cout << " track pt = " << track->get_pt() << endl;
       }
 
       // curved tracks inside mag field
@@ -163,8 +162,8 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
       double eta = asinh(z/sqrt(x*x+y*y));
 
       if (verbosity > 1) {
-	cout << " initial track phi = " << atan2(track->get3Momentum(1),track->get3Momentum(0));
-	cout << ", eta = " << asinh(track->get3Momentum(2)/sqrt(pow(track->get3Momentum(0),2)+pow(track->get3Momentum(1),2))) << endl;
+	cout << " initial track phi = " << track->get_phi();
+	cout << ", eta = " << track->get_eta() << endl;
 	cout << " calorimeter phi = " << phi << ", eta = " << eta << endl;
       }
 

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
@@ -32,6 +32,10 @@ PHG4SvtxTrackProjection::PHG4SvtxTrackProjection(const string &name) :
   _cal_names.push_back("CEMC");
   _cal_names.push_back("HCALIN");
   _cal_names.push_back("HCALOUT");
+  _cal_types.push_back(SvtxTrack::PRES); // PRES not yet in G4
+  _cal_types.push_back(SvtxTrack::CEMC);
+  _cal_types.push_back(SvtxTrack::HCALIN);
+  _cal_types.push_back(SvtxTrack::HCALOUT);
 }
 
 int PHG4SvtxTrackProjection::Init(PHCompositeNode *topNode) 
@@ -199,7 +203,7 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
       	}
       }
 
-      track->set_cal_energy_3x3(i,energy_3x3);
+      track->set_cal_energy_3x3(_cal_types[i],energy_3x3);
 
       // loop over all clusters and find nearest
       double min_r = DBL_MAX;
@@ -225,10 +229,10 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
       }
 
       if (min_index != -9999) {
-	track->set_cal_dphi(i,min_dphi);
-	track->set_cal_deta(i,min_deta);
-	track->set_cal_cluster_id(i,min_index);
-	track->set_cal_cluster_e(i,min_e);
+	track->set_cal_dphi(_cal_types[i],min_dphi);
+	track->set_cal_deta(_cal_types[i],min_deta);
+	track->set_cal_cluster_id(_cal_types[i],min_index);
+	track->set_cal_cluster_e(_cal_types[i],min_e);
 
 	if (verbosity > 1) {
 	  cout << " nearest cluster dphi = " << min_dphi << " deta = " << min_deta << " e = " << min_e << endl;

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
@@ -25,6 +25,7 @@ using namespace std;
 PHG4SvtxTrackProjection::PHG4SvtxTrackProjection(const string &name) :
   SubsysReco(name),
   _num_cal_layers(4),
+  _magfield(1.5),
   _mag_extent(156.5) // middle of Babar magent
 {
   _cal_radii.assign(_num_cal_layers,NAN);
@@ -130,7 +131,7 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
       point.assign(3,-9999.);
       //if (_cal_radii[i] < _mag_extent) {
       // curved projections inside field
-      _hough.projectToRadius(*track,_cal_radii[i],point);
+      _hough.projectToRadius(*track,_magfield,_cal_radii[i],point);
 
       if (isnan(point[0])) continue;
       if (isnan(point[1])) continue;

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.h
@@ -38,6 +38,9 @@ class PHG4SvtxTrackProjection : public SubsysReco
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
   
+  float get_mag_field() const          {return _magfield;}
+  void  set_mag_field(float magfield) {_magfield = magfield;}
+  
  private:
 
   PHG4HoughTransform _hough;
@@ -45,6 +48,7 @@ class PHG4SvtxTrackProjection : public SubsysReco
   std::vector<SvtxTrack::CAL_LAYER> _cal_types;
   std::vector<std::string> _cal_names;
   std::vector<float> _cal_radii;
+  double _magfield;
   double _mag_extent;
 };
 

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.h
@@ -9,6 +9,8 @@
 
 #include "PHG4HoughTransform.h"
 
+#include "SvtxTrack.h"
+
 // PHENIX includes
 #include <fun4all/SubsysReco.h>
 
@@ -40,6 +42,7 @@ class PHG4SvtxTrackProjection : public SubsysReco
 
   PHG4HoughTransform _hough;
   int _num_cal_layers;
+  std::vector<SvtxTrack::CAL_LAYER> _cal_types;
   std::vector<std::string> _cal_names;
   std::vector<float> _cal_radii;
   double _mag_extent;

--- a/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.C
@@ -98,8 +98,8 @@ int PHG4TrackGhostRejection::process_event(PHCompositeNode *topNode)
       }
     }
 
-    if (track->getNDF() != 0) {
-      combo.chisq = track->getChisq()/track->getNDF();
+    if (track->get_ndf() != 0) {
+      combo.chisq = track->get_chisq()/track->get_ndf();
     }
 
     combo.keep = true;

--- a/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.C
@@ -87,7 +87,7 @@ int PHG4TrackGhostRejection::process_event(PHCompositeNode *topNode)
   
     PHG4TrackCandidate combo;
 
-    combo.trackid = track->getTrackID();
+    combo.trackid = track->get_id();
     combo.nhits = track->getNhits();
 
     for (unsigned int j = 0; j < _nlayers; ++j) {

--- a/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.C
@@ -88,16 +88,15 @@ int PHG4TrackGhostRejection::process_event(PHCompositeNode *topNode)
     PHG4TrackCandidate combo;
 
     combo.trackid = track->get_id();
-    combo.nhits = track->getNhits();
+    combo.nhits = track->size_clusters();
 
-    for (unsigned int j = 0; j < _nlayers; ++j) {
-      if (!_layer_enabled[j]) continue;
-      
-      if (track->hasCluster(j)) {
-	combo.hitids.push_back(track->getClusterID(j));
-      }
+    for (SvtxTrack::ConstClusterIter iter = track->begin_clusters();
+	 iter != track->end_clusters();
+	 ++iter) {
+      unsigned int cluster_id = *iter;
+      combo.hitids.push_back(cluster_id);
     }
-
+      
     if (track->get_ndf() != 0) {
       combo.chisq = track->get_chisq()/track->get_ndf();
     }

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -11,7 +11,6 @@ SvtxTrack::SvtxTrack()
     _is_positive_charge(false),
     _quality(NAN),
     _chisq(NAN),
-    _chisqv(NAN),
     _ndf(0),
     _DCA(NAN),
     _DCA2D(NAN),
@@ -76,7 +75,6 @@ void SvtxTrack::Reset() {
   _DCA2D=NAN;
 
   _chisq = NAN;
-  _chisqv = NAN;
   _ndf = 0;
   
   _cal_dphi.clear();

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -8,6 +8,8 @@ using namespace std;
 
 SvtxTrack::SvtxTrack()
   : _track_id(-1),
+    _charge(1),
+    _ispositive(false),
     _phi(0.0),
     _d(0.0),
     _kappa(0.0),
@@ -72,13 +74,11 @@ void SvtxTrack::Reset() {
   _chisqv = NAN;
   _ndf = 0;
   
-  for(int i=0;i<4;++i){
-    _cal_dphi[i] = NAN;
-    _cal_deta[i] = NAN;
-    _cal_energy_3x3[i] = NAN;
-    _cal_cluster_id[i] = -9999;
-    _cal_cluster_e[i] = NAN;
-  }
+  _cal_dphi.clear();
+  _cal_deta.clear();
+  _cal_energy_3x3.clear();
+  _cal_cluster_id.clear();
+  _cal_cluster_e.clear();
 
   return;
 }
@@ -97,4 +97,34 @@ float SvtxTrack::getInnerMostHitPosition(int coor) const {
 
 short SvtxTrack::getNhits() const {
   return _cluster_ids.size();
+}
+
+float SvtxTrack::get_cal_dphi(SvtxTrack::CAL_LAYER layer) const {
+  std::map<SvtxTrack::CAL_LAYER,float>::const_iterator citer = _cal_dphi.find(layer);
+  if (citer == _cal_dphi.end()) return NAN;
+  return citer->second;
+}
+
+float SvtxTrack::get_cal_deta(SvtxTrack::CAL_LAYER layer) const {
+  std::map<SvtxTrack::CAL_LAYER,float>::const_iterator citer = _cal_deta.find(layer);
+  if (citer == _cal_deta.end()) return NAN;
+  return citer->second;
+}
+
+float SvtxTrack::get_cal_energy_3x3(SvtxTrack::CAL_LAYER layer) const {
+  std::map<SvtxTrack::CAL_LAYER,float>::const_iterator citer = _cal_energy_3x3.find(layer);
+  if (citer == _cal_energy_3x3.end()) return NAN;
+  return citer->second;
+}
+
+int SvtxTrack::get_cal_cluster_id(SvtxTrack::CAL_LAYER layer) const {
+  std::map<SvtxTrack::CAL_LAYER,int>::const_iterator citer = _cal_cluster_id.find(layer);
+  if (citer == _cal_cluster_id.end()) return -9999;
+  return citer->second;
+}
+
+float SvtxTrack::get_cal_cluster_e(SvtxTrack::CAL_LAYER layer) const {
+  std::map<SvtxTrack::CAL_LAYER,float>::const_iterator citer = _cal_cluster_e.find(layer);
+  if (citer == _cal_cluster_e.end()) return NAN;
+  return citer->second;
 }

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -13,11 +13,11 @@ SvtxTrack::SvtxTrack()
     _kappa(0.0),
     _z0(0.0),
     _dzdl(0.0),
-    _clusterID(),
     _x(0.0),
     _y(0.0),
     _z(0.0),
-    _covariance(6,6) {
+    _covariance(6,6),
+    _cluster_ids() {
   Reset();
 }
 
@@ -31,10 +31,9 @@ void SvtxTrack::identify(ostream& os) const
       os << "clusters: ";
       for(unsigned int i = 0; i < 100; i++)
 	{
-	  if(hasCluster(i))
-	    {
-	      os << getClusterID(i) << " ";
-	    }
+	  if (hasCluster(i)) {
+	    os << getClusterID(i) << " ";
+	  }
 	}
     }
     
@@ -49,9 +48,9 @@ void SvtxTrack::identify(ostream& os) const
 void SvtxTrack::Reset() {
 
   _track_id = -1;
-  
+
+  _cluster_ids.clear();
   for (int i=0;i<100;i++) {
-    _clusterID[i]=-9999;
     for(int j=0;j<3;j++){
       _position[i][j]=NAN;
     }
@@ -94,24 +93,12 @@ int SvtxTrack::isValid() const
 }
 
 
-float SvtxTrack::getInnerMostHitPosition(int coor) const
-{
-  int layer=-1;
-  for(int i=0;i<100;i++)
-  {
-    if(_clusterID[i]>=0){layer=i;break;}
-  }
-  if(layer==-1){return NAN;}
+float SvtxTrack::getInnerMostHitPosition(int coor) const {
+  if (_cluster_ids.empty()) return NAN;  
+  int layer = _cluster_ids.begin()->first; 
   return _position[layer][coor];
 }
 
-
-short SvtxTrack::getNhits() const
-{
-  int count = 100;
-  for(unsigned int i = 0; i < 100; i++){	
-    if(_clusterID[i] == -9999)
-      count--;
-  }
-  return count;
+short SvtxTrack::getNhits() const {
+  return _cluster_ids.size();
 }

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -20,105 +20,105 @@ SvtxTrack::SvtxTrack()
   Reset();
 }
 
-SvtxTrack::SvtxTrack(SvtxTrack *track) : covariance( *(track->getCovariance()) )
-{
-  _phi   = track->get_phi();
-  _d     = track->get_d();
-  _kappa = track->get_kappa();
-  _z0    = track->get_z0();
-  _dzdl  = track->get_dzdl();
-  setDCA2Dsigma(track->getDCA2Dsigma());
+// SvtxTrack::SvtxTrack(SvtxTrack *track) : covariance( *(track->getCovariance()) )
+// {
+//   _phi   = track->get_phi();
+//   _d     = track->get_d();
+//   _kappa = track->get_kappa();
+//   _z0    = track->get_z0();
+//   _dzdl  = track->get_dzdl();
+//   setDCA2Dsigma(track->getDCA2Dsigma());
   
-  for(int i=0;i<100;i++)
-  {
-    clusterID[i] = track->getClusterID(i);
-    for(int j=0;j<3;j++){
-      position[i][j] = track->getHitPosition(i,j);
-    }
-  }
+//   for(int i=0;i<100;i++)
+//   {
+//     clusterID[i] = track->getClusterID(i);
+//     for(int j=0;j<3;j++){
+//       position[i][j] = track->getHitPosition(i,j);
+//     }
+//   }
   
-  _track_id = track->getTrackID();
-  momentum = track->getMomentum();
-  for(int j=0;j<3;j++){
-    mom3[j] = track->get3Momentum(j);
-  }
+//   _track_id = track->getTrackID();
+//   momentum = track->getMomentum();
+//   for(int j=0;j<3;j++){
+//     mom3[j] = track->get3Momentum(j);
+//   }
 
-  charge = track->getCharge();
-  isprimary = track->getPrimary();
-  ispositive = track->getPositive();
-  quality = track->getQuality();
+//   charge = track->getCharge();
+//   isprimary = track->getPrimary();
+//   ispositive = track->getPositive();
+//   quality = track->getQuality();
   
-  DCA = track->getDCA();
-  DCA2D = track->getDCA2D();
+//   DCA = track->getDCA();
+//   DCA2D = track->getDCA2D();
 
-  chisq = track->getChisq();
-  chisqv = track->getChisqv();
-  ndf = track->getNDF();
+//   chisq = track->getChisq();
+//   chisqv = track->getChisqv();
+//   ndf = track->getNDF();
   
-  for(int i=0;i<9;i++){
-    scatter[i] = track->getScatter(i);
-  }
+//   for(int i=0;i<9;i++){
+//     scatter[i] = track->getScatter(i);
+//   }
 
-  for(int i=0;i<4;++i) {
-    cal_dphi[i] = track->get_cal_dphi(i);
-    cal_deta[i] = track->get_cal_deta(i);
-    cal_energy_3x3[i] = track->get_cal_energy_3x3(i);
-    cal_cluster_id[i] = track->get_cal_cluster_id(i);
-    cal_cluster_e[i] = track->get_cal_cluster_e(i);
-  }
-}
+//   for(int i=0;i<4;++i) {
+//     cal_dphi[i] = track->get_cal_dphi(i);
+//     cal_deta[i] = track->get_cal_deta(i);
+//     cal_energy_3x3[i] = track->get_cal_energy_3x3(i);
+//     cal_cluster_id[i] = track->get_cal_cluster_id(i);
+//     cal_cluster_e[i] = track->get_cal_cluster_e(i);
+//   }
+// }
 
-SvtxTrack::SvtxTrack(const SvtxTrack& track) : covariance( *(track.getCovariance()) )
-{
-  _phi   = track.get_phi();
-  _d     = track.get_d();
-  _kappa = track.get_kappa();
-  _z0    = track.get_z0();
-  _dzdl  = track.get_dzdl();
-  setDCA2Dsigma(track.getDCA2Dsigma());
+// SvtxTrack::SvtxTrack(const SvtxTrack& track) : covariance( *(track.getCovariance()) )
+// {
+//   _phi   = track.get_phi();
+//   _d     = track.get_d();
+//   _kappa = track.get_kappa();
+//   _z0    = track.get_z0();
+//   _dzdl  = track.get_dzdl();
+//   setDCA2Dsigma(track.getDCA2Dsigma());
   
-  for(int i=0;i<100;i++)
-  {
-    clusterID[i] = track.getClusterID(i);
-    for(int j=0;j<3;j++){
-      position[i][j] = track.getHitPosition(i,j);
-    }
-  }
+//   for(int i=0;i<100;i++)
+//   {
+//     clusterID[i] = track.getClusterID(i);
+//     for(int j=0;j<3;j++){
+//       position[i][j] = track.getHitPosition(i,j);
+//     }
+//   }
   
-  _track_id = track.getTrackID();
-  momentum = track.getMomentum();
-  for(int j=0;j<3;j++){
-    mom3[j] = track.get3Momentum(j);
-  }
+//   _track_id = track.getTrackID();
+//   momentum = track.getMomentum();
+//   for(int j=0;j<3;j++){
+//     mom3[j] = track.get3Momentum(j);
+//   }
 
-  charge = track.getCharge();
-  isprimary = track.getPrimary();
-  ispositive = track.getPositive();
-  quality = track.getQuality();
+//   charge = track.getCharge();
+//   isprimary = track.getPrimary();
+//   ispositive = track.getPositive();
+//   quality = track.getQuality();
   
-  DCA = track.getDCA();
-  DCA2D = track.getDCA2D();
+//   DCA = track.getDCA();
+//   DCA2D = track.getDCA2D();
 
-  chisq = track.getChisq();
-  chisqv = track.getChisqv();
-  ndf = track.getNDF();
+//   chisq = track.getChisq();
+//   chisqv = track.getChisqv();
+//   ndf = track.getNDF();
   
-  for(int i=0;i<9;i++){
-    scatter[i] = track.getScatter(i);
-  }
+//   for(int i=0;i<9;i++){
+//     scatter[i] = track.getScatter(i);
+//   }
 
-  for(int i=0;i<4;++i) {
-    cal_dphi[i] = track.get_cal_dphi(i);
-    cal_deta[i] = track.get_cal_deta(i);
-    cal_energy_3x3[i] = track.get_cal_energy_3x3(i);
-    cal_cluster_id[i] = track.get_cal_cluster_id(i);
-    cal_cluster_e[i] = track.get_cal_cluster_e(i);
-  }
+//   for(int i=0;i<4;++i) {
+//     cal_dphi[i] = track.get_cal_dphi(i);
+//     cal_deta[i] = track.get_cal_deta(i);
+//     cal_energy_3x3[i] = track.get_cal_energy_3x3(i);
+//     cal_cluster_id[i] = track.get_cal_cluster_id(i);
+//     cal_cluster_e[i] = track.get_cal_cluster_e(i);
+//   }
 
-  x = track.get_x();
-  y = track.get_y();
-  z = track.get_z();
-}
+//   x = track.get_x();
+//   y = track.get_y();
+//   z = track.get_z();
+// }
 
 void SvtxTrack::identify(ostream& os) const
 {

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -7,7 +7,7 @@ ClassImp(SvtxTrack)
 using namespace std;
 
 SvtxTrack::SvtxTrack()
-  : trackID(-1),
+  : _track_id(-1),
     _phi(0.0),
     _d(0.0),
     _kappa(0.0),
@@ -37,7 +37,7 @@ SvtxTrack::SvtxTrack(SvtxTrack *track) : covariance( *(track->getCovariance()) )
     }
   }
   
-  trackID = track->getTrackID();
+  _track_id = track->getTrackID();
   momentum = track->getMomentum();
   for(int j=0;j<3;j++){
     mom3[j] = track->get3Momentum(j);
@@ -85,7 +85,7 @@ SvtxTrack::SvtxTrack(const SvtxTrack& track) : covariance( *(track.getCovariance
     }
   }
   
-  trackID = track.getTrackID();
+  _track_id = track.getTrackID();
   momentum = track.getMomentum();
   for(int j=0;j<3;j++){
     mom3[j] = track.get3Momentum(j);
@@ -155,7 +155,7 @@ void SvtxTrack::Reset()
     }
   }
 
-  trackID = -1;
+  _track_id = -1;
   momentum=NAN;
   for(int j=0;j<3;j++){
     mom3[j]=NAN;

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -13,112 +13,13 @@ SvtxTrack::SvtxTrack()
     _kappa(0.0),
     _z0(0.0),
     _dzdl(0.0),
-    x(0.0),
-    y(0.0),
-    z(0.0),
-    covariance(6,6) {
+    _clusterID(),
+    _x(0.0),
+    _y(0.0),
+    _z(0.0),
+    _covariance(6,6) {
   Reset();
 }
-
-// SvtxTrack::SvtxTrack(SvtxTrack *track) : covariance( *(track->getCovariance()) )
-// {
-//   _phi   = track->get_phi();
-//   _d     = track->get_d();
-//   _kappa = track->get_kappa();
-//   _z0    = track->get_z0();
-//   _dzdl  = track->get_dzdl();
-//   setDCA2Dsigma(track->getDCA2Dsigma());
-  
-//   for(int i=0;i<100;i++)
-//   {
-//     clusterID[i] = track->getClusterID(i);
-//     for(int j=0;j<3;j++){
-//       position[i][j] = track->getHitPosition(i,j);
-//     }
-//   }
-  
-//   _track_id = track->getTrackID();
-//   momentum = track->getMomentum();
-//   for(int j=0;j<3;j++){
-//     mom3[j] = track->get3Momentum(j);
-//   }
-
-//   charge = track->getCharge();
-//   isprimary = track->getPrimary();
-//   ispositive = track->getPositive();
-//   quality = track->getQuality();
-  
-//   DCA = track->getDCA();
-//   DCA2D = track->getDCA2D();
-
-//   chisq = track->getChisq();
-//   chisqv = track->getChisqv();
-//   ndf = track->getNDF();
-  
-//   for(int i=0;i<9;i++){
-//     scatter[i] = track->getScatter(i);
-//   }
-
-//   for(int i=0;i<4;++i) {
-//     cal_dphi[i] = track->get_cal_dphi(i);
-//     cal_deta[i] = track->get_cal_deta(i);
-//     cal_energy_3x3[i] = track->get_cal_energy_3x3(i);
-//     cal_cluster_id[i] = track->get_cal_cluster_id(i);
-//     cal_cluster_e[i] = track->get_cal_cluster_e(i);
-//   }
-// }
-
-// SvtxTrack::SvtxTrack(const SvtxTrack& track) : covariance( *(track.getCovariance()) )
-// {
-//   _phi   = track.get_phi();
-//   _d     = track.get_d();
-//   _kappa = track.get_kappa();
-//   _z0    = track.get_z0();
-//   _dzdl  = track.get_dzdl();
-//   setDCA2Dsigma(track.getDCA2Dsigma());
-  
-//   for(int i=0;i<100;i++)
-//   {
-//     clusterID[i] = track.getClusterID(i);
-//     for(int j=0;j<3;j++){
-//       position[i][j] = track.getHitPosition(i,j);
-//     }
-//   }
-  
-//   _track_id = track.getTrackID();
-//   momentum = track.getMomentum();
-//   for(int j=0;j<3;j++){
-//     mom3[j] = track.get3Momentum(j);
-//   }
-
-//   charge = track.getCharge();
-//   isprimary = track.getPrimary();
-//   ispositive = track.getPositive();
-//   quality = track.getQuality();
-  
-//   DCA = track.getDCA();
-//   DCA2D = track.getDCA2D();
-
-//   chisq = track.getChisq();
-//   chisqv = track.getChisqv();
-//   ndf = track.getNDF();
-  
-//   for(int i=0;i<9;i++){
-//     scatter[i] = track.getScatter(i);
-//   }
-
-//   for(int i=0;i<4;++i) {
-//     cal_dphi[i] = track.get_cal_dphi(i);
-//     cal_deta[i] = track.get_cal_deta(i);
-//     cal_energy_3x3[i] = track.get_cal_energy_3x3(i);
-//     cal_cluster_id[i] = track.get_cal_cluster_id(i);
-//     cal_cluster_e[i] = track.get_cal_cluster_e(i);
-//   }
-
-//   x = track.get_x();
-//   y = track.get_y();
-//   z = track.get_z();
-// }
 
 void SvtxTrack::identify(ostream& os) const
 {
@@ -149,40 +50,40 @@ void SvtxTrack::Reset()
 {
   for(int i=0;i<100;i++)
   {
-    clusterID[i]=-9999;
+    _clusterID[i]=-9999;
     for(int j=0;j<3;j++){
-      position[i][j]=NAN;
+      _position[i][j]=NAN;
     }
   }
 
   _track_id = -1;
-  momentum=NAN;
+  _momentum=NAN;
   for(int j=0;j<3;j++){
-    mom3[j]=NAN;
+    _mom3[j]=NAN;
   }
 
-  charge=1;
-  isprimary=false;
-  ispositive=false;
-  quality=NAN;
+  _charge=1;
+  _isprimary=false;
+  _ispositive=false;
+  _quality=NAN;
   
-  DCA=NAN;
-  DCA2D=NAN;
+  _DCA=NAN;
+  _DCA2D=NAN;
 
-  chisq = NAN;
-  chisqv = NAN;
-  ndf = 0;
+  _chisq = NAN;
+  _chisqv = NAN;
+  _ndf = 0;
   
   for(int i=0;i<9;i++){
-    scatter[i]=NAN;
+    _scatter[i]=NAN;
   }
 
   for(int i=0;i<4;++i){
-    cal_dphi[i] = NAN;
-    cal_deta[i] = NAN;
-    cal_energy_3x3[i] = NAN;
-    cal_cluster_id[i] = -9999;
-    cal_cluster_e[i] = NAN;
+    _cal_dphi[i] = NAN;
+    _cal_deta[i] = NAN;
+    _cal_energy_3x3[i] = NAN;
+    _cal_cluster_id[i] = -9999;
+    _cal_cluster_e[i] = NAN;
   }
 
   return;
@@ -199,10 +100,10 @@ float SvtxTrack::getInnerMostHitPosition(int coor) const
   int layer=-1;
   for(int i=0;i<100;i++)
   {
-    if(clusterID[i]>=0){layer=i;break;}
+    if(_clusterID[i]>=0){layer=i;break;}
   }
   if(layer==-1){return NAN;}
-  return position[layer][coor];
+  return _position[layer][coor];
 }
 
 
@@ -210,7 +111,7 @@ short SvtxTrack::getNhits() const
 {
   int count = 100;
   for(unsigned int i = 0; i < 100; i++){	
-    if(clusterID[i] == -9999)
+    if(_clusterID[i] == -9999)
       count--;
   }
   return count;

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -19,7 +19,6 @@ SvtxTrack::SvtxTrack()
     _dca2d_error(NAN),
     _states(),
     _cluster_ids(),
-    _cluster_positions(),
     _calo_matches() {
   // always include the pca point
   _states.insert(make_pair(0.0,State(0.0)));
@@ -60,22 +59,6 @@ void SvtxTrack::Reset() {
 
 int SvtxTrack::isValid() const {
   return 1;
-}
-
-float SvtxTrack::getHitPosition(int layer, int coor) const {
-  std::map<int,std::vector<float> >::const_iterator citer = _cluster_positions.find(layer);
-  if (citer == _cluster_positions.end()) return NAN;
-  return citer->second[coor];
-}
-
-float SvtxTrack::getInnerMostHitPosition(int coor) const {
-  if (_cluster_positions.empty()) return NAN;  
-  return _cluster_positions.begin()->second[coor];
-}
-
-float SvtxTrack::getOuterMostHitPosition(int coor) const {
-  if (_cluster_positions.empty()) return NAN;  
-  return _cluster_positions.rbegin()->second[coor];
 }
 
 const SvtxTrack::State* SvtxTrack::get_state(float pathlength) const {

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -33,7 +33,7 @@ SvtxTrack::SvtxTrack()
     _cal_energy_3x3(),
     _cal_cluster_id(),
     _cal_cluster_e() {
-  Reset();
+  for (int i=0;i<3;++i) _mom3[i] = NAN;
 }
 
 void SvtxTrack::identify(std::ostream& os) const {
@@ -59,24 +59,30 @@ void SvtxTrack::identify(std::ostream& os) const {
 void SvtxTrack::Reset() {
 
   _track_id = -1;
-
-  _cluster_ids.clear();
-  _cluster_positions.clear();
-
-  _momentum=NAN;
-  for(int j=0;j<3;j++){
-    _mom3[j]=NAN;
-  }
-
   _is_positive_charge = false;
-  _quality=NAN;
-  
-  _DCA=NAN;
-  _DCA2D=NAN;
-
+  _quality = NAN;
   _chisq = NAN;
   _ndf = 0;
-  
+  _DCA = NAN;
+  _DCA2D = NAN;
+  _DCA2Dsigma = NAN;
+  _phi = 0.0;
+  _d = 0.0;
+  _kappa = 0.0;
+  _z0 = 0.0;
+  _dzdl = 0.0;
+  _momentum = NAN;
+  for (int i=0;i<3;++i) _mom3[i] = NAN;
+  _x = 0.0;
+  _y = 0.0;
+  _z = 0.0;
+  for (int i=0;i<6;++i) {
+    for (int j=0;j<6;++j) {
+      _covariance[i][j] = 0.0;
+    }
+  }
+  _cluster_ids.clear();
+  _cluster_positions.clear();
   _cal_dphi.clear();
   _cal_deta.clear();
   _cal_energy_3x3.clear();

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -1,13 +1,14 @@
 #include "SvtxTrack.h"
 
 #include <math.h>
+#include <limits.h>
 
 ClassImp(SvtxTrack)
 
 using namespace std;
 
 SvtxTrack::SvtxTrack()
-  : _track_id(-1),
+  : _track_id(UINT_MAX),
     _is_positive_charge(false),
     _quality(NAN),
     _chisq(NAN),
@@ -20,7 +21,6 @@ SvtxTrack::SvtxTrack()
     _kappa(0.0),
     _z0(0.0),
     _dzdl(0.0),
-    //_momentum(NAN),
     _mom(),
     _x(0.0),
     _y(0.0),
@@ -69,7 +69,7 @@ void SvtxTrack::identify(std::ostream& os) const {
 
 void SvtxTrack::Reset() {
 
-  _track_id = -1;
+  _track_id = UINT_MAX;
   _is_positive_charge = false;
   _quality = NAN;
   _chisq = NAN;
@@ -82,7 +82,6 @@ void SvtxTrack::Reset() {
   _kappa = 0.0;
   _z0 = 0.0;
   _dzdl = 0.0;
-  //_momentum = NAN;
   for (int i=0;i<3;++i) _mom[i] = NAN;
   _x = 0.0;
   _y = 0.0;

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -10,7 +10,6 @@ using namespace std;
 SvtxTrack::SvtxTrack()
   : _track_id(UINT_MAX),
     _is_positive_charge(false),
-    //_quality(NAN),
     _chisq(NAN),
     _ndf(0),
     _DCA(NAN),
@@ -53,6 +52,8 @@ void SvtxTrack::identify(std::ostream& os) const {
      << get3Momentum(0) << ","
      << get3Momentum(1) << ","
      << get3Momentum(2) << ")" << endl;
+
+  os << "(x,y,z) = (" << _x << "," << _y << "," << _z << ")" << endl;
   
   if (getNhits() > 0) {
     os << "clusters: ";
@@ -71,7 +72,6 @@ void SvtxTrack::Reset() {
 
   _track_id = UINT_MAX;
   _is_positive_charge = false;
-  //_quality = NAN;
   _chisq = NAN;
   _ndf = 0;
   _DCA = NAN;

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -1,22 +1,32 @@
 #include "SvtxTrack.h"
+
 #include <math.h>
 
 ClassImp(SvtxTrack)
 
 using namespace std;
 
-SvtxTrack::SvtxTrack() : phi(0.),d(0.),kappa(0.),z0(0.),dzdl(0.), x(0.), y(0.), z(0.), covariance(6,6)
-{
+SvtxTrack::SvtxTrack()
+  : trackID(-1),
+    _phi(0.0),
+    _d(0.0),
+    _kappa(0.0),
+    _z0(0.0),
+    _dzdl(0.0),
+    x(0.0),
+    y(0.0),
+    z(0.0),
+    covariance(6,6) {
   Reset();
 }
 
 SvtxTrack::SvtxTrack(SvtxTrack *track) : covariance( *(track->getCovariance()) )
 {
-  phi   = track->phi   ;
-  d     = track->d     ;
-  kappa = track->kappa ;
-  z0    = track->z0    ;
-  dzdl  = track->dzdl  ;
+  _phi   = track->get_phi();
+  _d     = track->get_d();
+  _kappa = track->get_kappa();
+  _z0    = track->get_z0();
+  _dzdl  = track->get_dzdl();
   setDCA2Dsigma(track->getDCA2Dsigma());
   
   for(int i=0;i<100;i++)
@@ -60,11 +70,11 @@ SvtxTrack::SvtxTrack(SvtxTrack *track) : covariance( *(track->getCovariance()) )
 
 SvtxTrack::SvtxTrack(const SvtxTrack& track) : covariance( *(track.getCovariance()) )
 {
-  phi   = track.phi   ;
-  d     = track.d     ;
-  kappa = track.kappa ;
-  z0    = track.z0    ;
-  dzdl  = track.dzdl  ;
+  _phi   = track.get_phi();
+  _d     = track.get_d();
+  _kappa = track.get_kappa();
+  _z0    = track.get_z0();
+  _dzdl  = track.get_dzdl();
   setDCA2Dsigma(track.getDCA2Dsigma());
   
   for(int i=0;i<100;i++)

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -17,16 +17,6 @@ SvtxTrack::SvtxTrack()
     _DCA2D(NAN),
     _DCA2Dsigma(NAN),
     _states(),
-    // _phi(0.0),
-    // _d(0.0),
-    // _kappa(0.0),
-    // _z0(0.0),
-    // _dzdl(0.0),
-    // _mom(),
-    // _x(0.0),
-    // _y(0.0),
-    // _z(0.0),
-    // _covar(6),
     _cluster_ids(),
     _cluster_positions(),
     _cal_dphi(),
@@ -34,16 +24,8 @@ SvtxTrack::SvtxTrack()
     _cal_energy_3x3(),
     _cal_cluster_id(),
     _cal_cluster_e() {
-
+  // always include the pca point
   _states.insert(make_pair(0.0,State()));
-  
-  //  for (int i=0;i<3;++i) _mom[i] = NAN;
-  //  for (int i = 0; i < 6; ++i) _covar[i] = std::vector<float>(i+1);
-  //  for (int i = 0; i < 6; ++i) {
-  //    for (int j = i; j < 6; ++j) {
-  //      set_error(i,j,0.0);
-  //    }
-  //  } 
 }
 
 void SvtxTrack::identify(std::ostream& os) const {
@@ -99,17 +81,6 @@ int SvtxTrack::isValid() const {
   return 1;
 }
 
-// float SvtxTrack::get_error(int i, int j) const {
-//   if (j > i) return get_error(j,i);
-//   return _covar[i][j];
-// }
-
-// void SvtxTrack::set_error(int i, int j, float value) {
-//   if (j > i) set_error(j,i,value);
-//   else _covar[i][j] = value;
-//   return;
-// }
-
 float SvtxTrack::getHitPosition(int layer, int coor) const {
   std::map<int,std::vector<float> >::const_iterator citer = _cluster_positions.find(layer);
   if (citer == _cluster_positions.end()) return NAN;
@@ -154,6 +125,8 @@ float SvtxTrack::get_cal_cluster_e(SvtxTrack::CAL_LAYER layer) const {
   if (citer == _cal_cluster_e.end()) return NAN;
   return citer->second;
 }
+
+// --- innner State class ----------------------------------------------------//
 
 SvtxTrack::State::State()
   : _x(0.0),

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -22,7 +22,7 @@ SvtxTrack::SvtxTrack()
     _cluster_positions(),
     _calo_matches() {
   // always include the pca point
-  _states.insert(make_pair(0.0,State()));
+  _states.insert(make_pair(0.0,State(0.0)));
 }
 
 void SvtxTrack::identify(std::ostream& os) const {

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -39,7 +39,15 @@ SvtxTrack::SvtxTrack()
 void SvtxTrack::identify(std::ostream& os) const {
   os << "SvtxTrack Object ";
   os << "id: " << getTrackID() << " ";
+  os << "charge: " << getCharge() << " ";
+  os << "chisq: " << getChisq() << " ndf:" << getNDF() << " ";
+  os << endl;
 
+  os << "(px,py,pz) = ("
+     << get3Momentum(0) << ","
+     << get3Momentum(1) << ","
+     << get3Momentum(2) << ")" << endl;
+  
   if (getNhits() > 0) {
     os << "clusters: ";
     for (unsigned int i = 0; i < 100; ++i) {
@@ -48,11 +56,8 @@ void SvtxTrack::identify(std::ostream& os) const {
       }
     }
   }
-    
-  if (getNDF() != 0) {
-    os << "chisq/dof: " << getChisq()/getNDF() << " ";
-  }
-  os << endl;
+  os << endl;    
+ 
   return;
 }
 
@@ -92,8 +97,7 @@ void SvtxTrack::Reset() {
   return;
 }
 
-int SvtxTrack::isValid() const
-{
+int SvtxTrack::isValid() const {
   return 1;
 }
 

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -14,9 +14,9 @@ SvtxTrack::SvtxTrack()
     _is_positive_charge(false),
     _chisq(NAN),
     _ndf(0),
-    _DCA(NAN),
-    _DCA2D(NAN),
-    _DCA2Dsigma(NAN),
+    _dca(NAN),
+    _dca2d(NAN),
+    _dca2d_error(NAN),
     _states(),
     _cluster_ids(),
     _cluster_positions(),
@@ -28,14 +28,14 @@ SvtxTrack::SvtxTrack()
 void SvtxTrack::identify(std::ostream& os) const {
   os << "SvtxTrack Object ";
   os << "id: " << get_id() << " ";
-  os << "charge: " << getCharge() << " ";
-  os << "chisq: " << getChisq() << " ndf:" << getNDF() << " ";
+  os << "charge: " << get_charge() << " ";
+  os << "chisq: " << get_chisq() << " ndf:" << get_ndf() << " ";
   os << endl;
 
   os << "(px,py,pz) = ("
-     << get3Momentum(0) << ","
-     << get3Momentum(1) << ","
-     << get3Momentum(2) << ")" << endl;
+     << get_px() << ","
+     << get_py() << ","
+     << get_pz() << ")" << endl;
 
   os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << endl;
   
@@ -78,16 +78,16 @@ short SvtxTrack::getNhits() const {
 
 float SvtxTrack::get_cal_energy_3x3(SvtxTrack::CAL_LAYER layer) const {
   std::map<SvtxTrack::CAL_LAYER,
-	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+	   SvtxTrack::CaloProjection>::const_iterator citer = _calo_matches.find(layer);
   if (citer == _calo_matches.end()) return NAN;
   return citer->second.get_energy_3x3();
 }
 
 void SvtxTrack::set_cal_energy_3x3(SvtxTrack::CAL_LAYER layer, float energy_3x3) {
   std::map<SvtxTrack::CAL_LAYER,
-	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+	   SvtxTrack::CaloProjection>::const_iterator citer = _calo_matches.find(layer);
   if (citer == _calo_matches.end()) {
-    _calo_matches[layer] = SvtxTrack::CaloMatch();
+    _calo_matches[layer] = SvtxTrack::CaloProjection();
   }
   _calo_matches[layer].set_energy_3x3(energy_3x3);
   return;
@@ -95,16 +95,16 @@ void SvtxTrack::set_cal_energy_3x3(SvtxTrack::CAL_LAYER layer, float energy_3x3)
 
 unsigned int SvtxTrack::get_cal_cluster_id(SvtxTrack::CAL_LAYER layer) const {
   std::map<SvtxTrack::CAL_LAYER,
-	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+	   SvtxTrack::CaloProjection>::const_iterator citer = _calo_matches.find(layer);
   if (citer == _calo_matches.end()) return UINT_MAX;
   return citer->second.get_cluster_id();
 }
 
 void SvtxTrack::set_cal_cluster_id(SvtxTrack::CAL_LAYER layer, unsigned int clus_id) {
   std::map<SvtxTrack::CAL_LAYER,
-	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+	   SvtxTrack::CaloProjection>::const_iterator citer = _calo_matches.find(layer);
   if (citer == _calo_matches.end()) {
-    _calo_matches[layer] = SvtxTrack::CaloMatch();
+    _calo_matches[layer] = SvtxTrack::CaloProjection();
   }
   _calo_matches[layer].set_cluster_id(clus_id);
   return;
@@ -112,16 +112,16 @@ void SvtxTrack::set_cal_cluster_id(SvtxTrack::CAL_LAYER layer, unsigned int clus
 
 float SvtxTrack::get_cal_dphi(SvtxTrack::CAL_LAYER layer) const {  
   std::map<SvtxTrack::CAL_LAYER,
-	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+	   SvtxTrack::CaloProjection>::const_iterator citer = _calo_matches.find(layer);
   if (citer == _calo_matches.end()) return NAN;
   return citer->second.get_dphi();
 }
 
 void SvtxTrack::set_cal_dphi(SvtxTrack::CAL_LAYER layer, float dphi) {
   std::map<SvtxTrack::CAL_LAYER,
-	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+	   SvtxTrack::CaloProjection>::const_iterator citer = _calo_matches.find(layer);
   if (citer == _calo_matches.end()) {
-    _calo_matches[layer] = SvtxTrack::CaloMatch();
+    _calo_matches[layer] = SvtxTrack::CaloProjection();
   }
   _calo_matches[layer].set_dphi(dphi);
   return;
@@ -129,16 +129,16 @@ void SvtxTrack::set_cal_dphi(SvtxTrack::CAL_LAYER layer, float dphi) {
 
 float SvtxTrack::get_cal_deta(SvtxTrack::CAL_LAYER layer) const {
   std::map<SvtxTrack::CAL_LAYER,
-	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+	   SvtxTrack::CaloProjection>::const_iterator citer = _calo_matches.find(layer);
   if (citer == _calo_matches.end()) return NAN;
   return citer->second.get_deta();
 }
 
 void SvtxTrack::set_cal_deta(SvtxTrack::CAL_LAYER layer, float deta) {
   std::map<SvtxTrack::CAL_LAYER,
-	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+	   SvtxTrack::CaloProjection>::const_iterator citer = _calo_matches.find(layer);
   if (citer == _calo_matches.end()) {
-    _calo_matches[layer] = SvtxTrack::CaloMatch();
+    _calo_matches[layer] = SvtxTrack::CaloProjection();
   }
   _calo_matches[layer].set_deta(deta);
   return;
@@ -146,16 +146,16 @@ void SvtxTrack::set_cal_deta(SvtxTrack::CAL_LAYER layer, float deta) {
 
 float SvtxTrack::get_cal_cluster_e(SvtxTrack::CAL_LAYER layer) const {
   std::map<SvtxTrack::CAL_LAYER,
-	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+	   SvtxTrack::CaloProjection>::const_iterator citer = _calo_matches.find(layer);
   if (citer == _calo_matches.end()) return NAN;
   return citer->second.get_cluster_energy();
 }
 
 void SvtxTrack::set_cal_cluster_e(SvtxTrack::CAL_LAYER layer, float clus_e) {
   std::map<SvtxTrack::CAL_LAYER,
-	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+	   SvtxTrack::CaloProjection>::const_iterator citer = _calo_matches.find(layer);
   if (citer == _calo_matches.end()) {
-    _calo_matches[layer] = SvtxTrack::CaloMatch();
+    _calo_matches[layer] = SvtxTrack::CaloProjection();
   }
   _calo_matches[layer].set_cluster_energy(clus_e);
   return;
@@ -195,9 +195,9 @@ unsigned int SvtxTrack::State::covar_index(unsigned int i, unsigned int j) const
   return i+1+(j+1)*(j)/2-1;
 }
 
-// --- innner CaloMatch class ------------------------------------------------//
+// --- innner CaloProjection class -------------------------------------------//
 
-SvtxTrack::CaloMatch::CaloMatch()
+SvtxTrack::CaloProjection::CaloProjection()
   : _e3x3(NAN),
     _clus_id(UINT_MAX),
     _deta(NAN),

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -78,6 +78,24 @@ float SvtxTrack::getOuterMostHitPosition(int coor) const {
   return _cluster_positions.rbegin()->second[coor];
 }
 
+const SvtxTrack::State* SvtxTrack::get_state(float pathlength) const {
+  ConstStateIter iter = _states.find(pathlength);
+  if (iter == _states.end()) return NULL;  
+  return &iter->second;
+}
+
+SvtxTrack::State* SvtxTrack::get_state(float pathlength) {
+  StateIter iter = _states.find(pathlength);
+  if (iter == _states.end()) return NULL;
+  return &iter->second;
+}
+
+SvtxTrack::State* SvtxTrack::insert_state(const State &state) {
+  float pathlength = state.get_pathlength();
+  _states.insert(make_pair( pathlength , SvtxTrack::State(state) ));
+  return (&_states[pathlength]);
+}
+
 float SvtxTrack::get_cal_energy_3x3(SvtxTrack::CAL_LAYER layer) const {
   std::map<SvtxTrack::CAL_LAYER,
 	   SvtxTrack::CaloProjection>::const_iterator citer = _calo_matches.find(layer);
@@ -165,8 +183,9 @@ void SvtxTrack::set_cal_cluster_e(SvtxTrack::CAL_LAYER layer, float clus_e) {
 
 // --- innner State class ----------------------------------------------------//
 
-SvtxTrack::State::State()
-  : _pos(),
+SvtxTrack::State::State(float pathlength)
+  : _pathlength(pathlength),
+    _pos(),
     _mom(),
     _covar(),
     _helix_phi(0.0),

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -46,24 +46,23 @@ void SvtxTrack::identify(ostream& os) const
   return;
 }
 
-void SvtxTrack::Reset()
-{
-  for(int i=0;i<100;i++)
-  {
+void SvtxTrack::Reset() {
+
+  _track_id = -1;
+  
+  for (int i=0;i<100;i++) {
     _clusterID[i]=-9999;
     for(int j=0;j<3;j++){
       _position[i][j]=NAN;
     }
   }
 
-  _track_id = -1;
   _momentum=NAN;
   for(int j=0;j<3;j++){
     _mom3[j]=NAN;
   }
 
   _charge=1;
-  _isprimary=false;
   _ispositive=false;
   _quality=NAN;
   

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -10,7 +10,7 @@ using namespace std;
 SvtxTrack::SvtxTrack()
   : _track_id(UINT_MAX),
     _is_positive_charge(false),
-    _quality(NAN),
+    //_quality(NAN),
     _chisq(NAN),
     _ndf(0),
     _DCA(NAN),
@@ -71,7 +71,7 @@ void SvtxTrack::Reset() {
 
   _track_id = UINT_MAX;
   _is_positive_charge = false;
-  _quality = NAN;
+  //_quality = NAN;
   _chisq = NAN;
   _ndf = 0;
   _DCA = NAN;

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -8,42 +8,52 @@ using namespace std;
 
 SvtxTrack::SvtxTrack()
   : _track_id(-1),
-    _charge(1),
-    _ispositive(false),
+    _is_positive_charge(false),
+    _quality(NAN),
+    _chisq(NAN),
+    _chisqv(NAN),
+    _ndf(0),
+    _DCA(NAN),
+    _DCA2D(NAN),
+    _DCA2Dsigma(NAN),
     _phi(0.0),
     _d(0.0),
     _kappa(0.0),
     _z0(0.0),
     _dzdl(0.0),
+    _momentum(NAN),
+    _mom3(),
     _x(0.0),
     _y(0.0),
     _z(0.0),
     _covariance(6,6),
-    _cluster_ids() {
+    _cluster_ids(),
+    _cluster_positions(),
+    _cal_dphi(),
+    _cal_deta(),
+    _cal_energy_3x3(),
+    _cal_cluster_id(),
+    _cal_cluster_e() {
   Reset();
 }
 
-void SvtxTrack::identify(ostream& os) const
-{
+void SvtxTrack::identify(std::ostream& os) const {
   os << "SvtxTrack Object ";
   os << "id: " << getTrackID() << " ";
 
-  if(getNhits() > 0)
-    {
-      os << "clusters: ";
-      for(unsigned int i = 0; i < 100; i++)
-	{
-	  if (hasCluster(i)) {
-	    os << getClusterID(i) << " ";
-	  }
-	}
+  if (getNhits() > 0) {
+    os << "clusters: ";
+    for (unsigned int i = 0; i < 100; ++i) {
+      if (hasCluster(i)) {
+	os << getClusterID(i) << " ";
+      }
     }
+  }
     
-  if(getNDF() != 0)
-    {
-      os << "chisq/dof: " << getChisq()/getNDF() << " ";
-    }
-  os << std::endl;
+  if (getNDF() != 0) {
+    os << "chisq/dof: " << getChisq()/getNDF() << " ";
+  }
+  os << endl;
   return;
 }
 
@@ -59,8 +69,7 @@ void SvtxTrack::Reset() {
     _mom3[j]=NAN;
   }
 
-  _charge=1;
-  _ispositive=false;
+  _is_positive_charge = false;
   _quality=NAN;
   
   _DCA=NAN;

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -72,10 +72,6 @@ void SvtxTrack::Reset() {
   _chisqv = NAN;
   _ndf = 0;
   
-  for(int i=0;i<9;i++){
-    _scatter[i]=NAN;
-  }
-
   for(int i=0;i<4;++i){
     _cal_dphi[i] = NAN;
     _cal_deta[i] = NAN;

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -19,11 +19,7 @@ SvtxTrack::SvtxTrack()
     _states(),
     _cluster_ids(),
     _cluster_positions(),
-    _cal_dphi(),
-    _cal_deta(),
-    _cal_energy_3x3(),
-    _cal_cluster_id(),
-    _cal_cluster_e() {
+    _calo_matches() {
   // always include the pca point
   _states.insert(make_pair(0.0,State()));
 }
@@ -56,24 +52,7 @@ void SvtxTrack::identify(std::ostream& os) const {
 }
 
 void SvtxTrack::Reset() {
-
-  _track_id = UINT_MAX;
-  _is_positive_charge = false;
-  _chisq = NAN;
-  _ndf = 0;
-  _DCA = NAN;
-  _DCA2D = NAN;
-  _DCA2Dsigma = NAN;
-  _states.clear();
-  _states.insert(make_pair(0.0,State()));
-  _cluster_ids.clear();
-  _cluster_positions.clear();
-  _cal_dphi.clear();
-  _cal_deta.clear();
-  _cal_energy_3x3.clear();
-  _cal_cluster_id.clear();
-  _cal_cluster_e.clear();
-
+  *this = SvtxTrack();
   return;
 }
 
@@ -96,34 +75,89 @@ short SvtxTrack::getNhits() const {
   return _cluster_ids.size();
 }
 
-float SvtxTrack::get_cal_dphi(SvtxTrack::CAL_LAYER layer) const {
-  std::map<SvtxTrack::CAL_LAYER,float>::const_iterator citer = _cal_dphi.find(layer);
-  if (citer == _cal_dphi.end()) return NAN;
-  return citer->second;
+float SvtxTrack::get_cal_energy_3x3(SvtxTrack::CAL_LAYER layer) const {
+  std::map<SvtxTrack::CAL_LAYER,
+	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+  if (citer == _calo_matches.end()) return NAN;
+  return citer->second.get_energy_3x3();
+}
+
+void SvtxTrack::set_cal_energy_3x3(SvtxTrack::CAL_LAYER layer, float energy_3x3) {
+  std::map<SvtxTrack::CAL_LAYER,
+	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+  if (citer == _calo_matches.end()) {
+    _calo_matches[layer] = SvtxTrack::CaloMatch();
+  }
+  _calo_matches[layer].set_energy_3x3(energy_3x3);
+  return;
+}
+
+unsigned int SvtxTrack::get_cal_cluster_id(SvtxTrack::CAL_LAYER layer) const {
+  std::map<SvtxTrack::CAL_LAYER,
+	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+  if (citer == _calo_matches.end()) return UINT_MAX;
+  return citer->second.get_cluster_id();
+}
+
+void SvtxTrack::set_cal_cluster_id(SvtxTrack::CAL_LAYER layer, unsigned int clus_id) {
+  std::map<SvtxTrack::CAL_LAYER,
+	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+  if (citer == _calo_matches.end()) {
+    _calo_matches[layer] = SvtxTrack::CaloMatch();
+  }
+  _calo_matches[layer].set_cluster_id(clus_id);
+  return;
+}
+
+float SvtxTrack::get_cal_dphi(SvtxTrack::CAL_LAYER layer) const {  
+  std::map<SvtxTrack::CAL_LAYER,
+	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+  if (citer == _calo_matches.end()) return NAN;
+  return citer->second.get_dphi();
+}
+
+void SvtxTrack::set_cal_dphi(SvtxTrack::CAL_LAYER layer, float dphi) {
+  std::map<SvtxTrack::CAL_LAYER,
+	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+  if (citer == _calo_matches.end()) {
+    _calo_matches[layer] = SvtxTrack::CaloMatch();
+  }
+  _calo_matches[layer].set_dphi(dphi);
+  return;
 }
 
 float SvtxTrack::get_cal_deta(SvtxTrack::CAL_LAYER layer) const {
-  std::map<SvtxTrack::CAL_LAYER,float>::const_iterator citer = _cal_deta.find(layer);
-  if (citer == _cal_deta.end()) return NAN;
-  return citer->second;
+  std::map<SvtxTrack::CAL_LAYER,
+	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+  if (citer == _calo_matches.end()) return NAN;
+  return citer->second.get_deta();
 }
 
-float SvtxTrack::get_cal_energy_3x3(SvtxTrack::CAL_LAYER layer) const {
-  std::map<SvtxTrack::CAL_LAYER,float>::const_iterator citer = _cal_energy_3x3.find(layer);
-  if (citer == _cal_energy_3x3.end()) return NAN;
-  return citer->second;
-}
-
-int SvtxTrack::get_cal_cluster_id(SvtxTrack::CAL_LAYER layer) const {
-  std::map<SvtxTrack::CAL_LAYER,int>::const_iterator citer = _cal_cluster_id.find(layer);
-  if (citer == _cal_cluster_id.end()) return -9999;
-  return citer->second;
+void SvtxTrack::set_cal_deta(SvtxTrack::CAL_LAYER layer, float deta) {
+  std::map<SvtxTrack::CAL_LAYER,
+	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+  if (citer == _calo_matches.end()) {
+    _calo_matches[layer] = SvtxTrack::CaloMatch();
+  }
+  _calo_matches[layer].set_deta(deta);
+  return;
 }
 
 float SvtxTrack::get_cal_cluster_e(SvtxTrack::CAL_LAYER layer) const {
-  std::map<SvtxTrack::CAL_LAYER,float>::const_iterator citer = _cal_cluster_e.find(layer);
-  if (citer == _cal_cluster_e.end()) return NAN;
-  return citer->second;
+  std::map<SvtxTrack::CAL_LAYER,
+	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+  if (citer == _calo_matches.end()) return NAN;
+  return citer->second.get_cluster_energy();
+}
+
+void SvtxTrack::set_cal_cluster_e(SvtxTrack::CAL_LAYER layer, float clus_e) {
+  std::map<SvtxTrack::CAL_LAYER,
+	   SvtxTrack::CaloMatch>::const_iterator citer = _calo_matches.find(layer);
+  if (citer == _calo_matches.end()) {
+    _calo_matches[layer] = SvtxTrack::CaloMatch();
+  }
+  _calo_matches[layer].set_cluster_energy(clus_e);
+  return;
 }
 
 // --- innner State class ----------------------------------------------------//
@@ -157,4 +191,14 @@ void SvtxTrack::State::set_error(int i, int j, float value) {
   if (j > i) set_error(j,i,value);
   else _covar[i][j] = value;
   return;
+}
+
+// --- innner CaloMatch class ------------------------------------------------//
+
+SvtxTrack::CaloMatch::CaloMatch()
+  : _e3x3(NAN),
+    _clus_id(UINT_MAX),
+    _deta(NAN),
+    _dphi(NAN),
+    _clus_e(NAN) {
 }

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -25,7 +25,6 @@ SvtxTrack::SvtxTrack()
     _x(0.0),
     _y(0.0),
     _z(0.0),
-    _covariance(6,6),
     _covar(6),
     _cluster_ids(),
     _cluster_positions(),
@@ -90,7 +89,6 @@ void SvtxTrack::Reset() {
   _z = 0.0;
   for (int i=0;i<6;++i) {
     for (int j=0;j<6;++j) {
-      _covariance[i][j] = 0.0;
       set_error(i,j,0.0);
     }
   }

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -26,6 +26,7 @@ SvtxTrack::SvtxTrack()
     _y(0.0),
     _z(0.0),
     _covariance(6,6),
+    _covar(6),
     _cluster_ids(),
     _cluster_positions(),
     _cal_dphi(),
@@ -34,6 +35,12 @@ SvtxTrack::SvtxTrack()
     _cal_cluster_id(),
     _cal_cluster_e() {
   for (int i=0;i<3;++i) _mom3[i] = NAN;
+  for (int i = 0; i < 6; ++i) _covar[i] = std::vector<float>(i+1);
+  for (int i = 0; i < 6; ++i) {
+    for (int j = i; j < 6; ++j) {
+      set_error(i,j,0.0);
+    }
+  } 
 }
 
 void SvtxTrack::identify(std::ostream& os) const {
@@ -84,6 +91,7 @@ void SvtxTrack::Reset() {
   for (int i=0;i<6;++i) {
     for (int j=0;j<6;++j) {
       _covariance[i][j] = 0.0;
+      set_error(i,j,0.0);
     }
   }
   _cluster_ids.clear();
@@ -99,6 +107,17 @@ void SvtxTrack::Reset() {
 
 int SvtxTrack::isValid() const {
   return 1;
+}
+
+float SvtxTrack::get_error(int i, int j) const {
+  if (j > i) return get_error(j,i);
+  return _covar[i][j];
+}
+
+void SvtxTrack::set_error(int i, int j, float value) {
+  if (j > i) set_error(j,i,value);
+  else _covar[i][j] = value;
+  return;
 }
 
 float SvtxTrack::getHitPosition(int layer, int coor) const {

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -170,12 +170,7 @@ SvtxTrack::State::State(float pathlength)
   : _pathlength(pathlength),
     _pos(),
     _mom(),
-    _covar(),
-    _helix_phi(0.0),
-    _helix_d(0.0),
-    _helix_kappa(0.0),
-    _helix_z0(0.0),
-    _helix_dzdl(0.0) {
+    _covar() {
   for (int i=0;i<3;++i) _pos[i] = 0.0;
   for (int i=0;i<3;++i) _mom[i] = NAN;
   for (int i = 0; i < 6; ++i) {

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -20,8 +20,8 @@ SvtxTrack::SvtxTrack()
     _kappa(0.0),
     _z0(0.0),
     _dzdl(0.0),
-    _momentum(NAN),
-    _mom3(),
+    //_momentum(NAN),
+    _mom(),
     _x(0.0),
     _y(0.0),
     _z(0.0),
@@ -33,7 +33,7 @@ SvtxTrack::SvtxTrack()
     _cal_energy_3x3(),
     _cal_cluster_id(),
     _cal_cluster_e() {
-  for (int i=0;i<3;++i) _mom3[i] = NAN;
+  for (int i=0;i<3;++i) _mom[i] = NAN;
   for (int i = 0; i < 6; ++i) _covar[i] = std::vector<float>(i+1);
   for (int i = 0; i < 6; ++i) {
     for (int j = i; j < 6; ++j) {
@@ -82,8 +82,8 @@ void SvtxTrack::Reset() {
   _kappa = 0.0;
   _z0 = 0.0;
   _dzdl = 0.0;
-  _momentum = NAN;
-  for (int i=0;i<3;++i) _mom3[i] = NAN;
+  //_momentum = NAN;
+  for (int i=0;i<3;++i) _mom[i] = NAN;
   _x = 0.0;
   _y = 0.0;
   _z = 0.0;

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -39,12 +39,13 @@ void SvtxTrack::identify(std::ostream& os) const {
 
   os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << endl;
   
-  if (getNhits() > 0) {
+  if (!empty_clusters()) {
     os << "clusters: ";
-    for (unsigned int i = 0; i < 100; ++i) {
-      if (hasCluster(i)) {
-	os << getClusterID(i) << " ";
-      }
+    for (SvtxTrack::ConstClusterIter iter = begin_clusters();
+	 iter != end_clusters();
+	 ++iter) {
+      unsigned int cluster_id = *iter;
+      os << cluster_id << " ";
     }
   }
   os << endl;    
@@ -72,8 +73,9 @@ float SvtxTrack::getInnerMostHitPosition(int coor) const {
   return _cluster_positions.begin()->second[coor];
 }
 
-short SvtxTrack::getNhits() const {
-  return _cluster_ids.size();
+float SvtxTrack::getOuterMostHitPosition(int coor) const {
+  if (_cluster_positions.empty()) return NAN;  
+  return _cluster_positions.rbegin()->second[coor];
 }
 
 float SvtxTrack::get_cal_energy_3x3(SvtxTrack::CAL_LAYER layer) const {

--- a/simulation/g4simulation/g4hough/SvtxTrack.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack.C
@@ -52,11 +52,7 @@ void SvtxTrack::Reset() {
   _track_id = -1;
 
   _cluster_ids.clear();
-  for (int i=0;i<100;i++) {
-    for(int j=0;j<3;j++){
-      _position[i][j]=NAN;
-    }
-  }
+  _cluster_positions.clear();
 
   _momentum=NAN;
   for(int j=0;j<3;j++){
@@ -88,11 +84,15 @@ int SvtxTrack::isValid() const
   return 1;
 }
 
+float SvtxTrack::getHitPosition(int layer, int coor) const {
+  std::map<int,std::vector<float> >::const_iterator citer = _cluster_positions.find(layer);
+  if (citer == _cluster_positions.end()) return NAN;
+  return citer->second[coor];
+}
 
 float SvtxTrack::getInnerMostHitPosition(int coor) const {
-  if (_cluster_ids.empty()) return NAN;  
-  int layer = _cluster_ids.begin()->first; 
-  return _position[layer][coor];
+  if (_cluster_positions.empty()) return NAN;  
+  return _cluster_positions.begin()->second[coor];
 }
 
 short SvtxTrack::getNhits() const {

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -134,19 +134,19 @@ class SvtxTrack : public PHObject {
   float getCovariance(int i,int j) const {return get_error(i,j);}
   void  setCovariance(int i,int j, float val) {set_error(i,j,val);}
 
-  void  set_cal_dphi(CAL_LAYER layer, float dphi) {_cal_dphi[layer] = dphi;}
-  float get_cal_dphi(CAL_LAYER layer) const;
-
-  void  set_cal_deta(CAL_LAYER layer, float deta) {_cal_deta[layer] = deta;}
-  float get_cal_deta(CAL_LAYER layer) const;
-
-  void  set_cal_energy_3x3(CAL_LAYER layer, float energy_3x3) {_cal_energy_3x3[layer] = energy_3x3;}
+  void  set_cal_energy_3x3(CAL_LAYER layer, float energy_3x3);
   float get_cal_energy_3x3(CAL_LAYER layer) const;
 
-  void  set_cal_cluster_id(CAL_LAYER layer, int id) {_cal_cluster_id[layer] = id;}
-  int   get_cal_cluster_id(CAL_LAYER layer) const;
+  void         set_cal_cluster_id(CAL_LAYER layer, unsigned int id);
+  unsigned int get_cal_cluster_id(CAL_LAYER layer) const;
+  
+  void  set_cal_dphi(CAL_LAYER layer, float dphi);
+  float get_cal_dphi(CAL_LAYER layer) const;
 
-  void  set_cal_cluster_e(CAL_LAYER layer, float e) {_cal_cluster_e[layer] = e;}
+  void  set_cal_deta(CAL_LAYER layer, float deta);
+  float get_cal_deta(CAL_LAYER layer) const;
+
+  void  set_cal_cluster_e(CAL_LAYER layer, float e);
   float get_cal_cluster_e(CAL_LAYER layer) const;
 
   float get_x() const  {return _states.find(0.0)->second.get_x();}
@@ -226,7 +226,35 @@ class SvtxTrack : public PHObject {
   };                                                                          //
   // --- inner State class ---------------------------------------------------//
 
-  // class CaloMatch
+  // --- inner CaloMatch class -----------------------------------------------//
+  class CaloMatch {                                                           //
+  public:                                                                     //
+    CaloMatch();                                                              //
+    virtual ~CaloMatch() {}                                                   //
+                                                                              //
+    float get_energy_3x3() const {return _e3x3;}                              //
+    void  set_energy_3x3(float e3x3) {_e3x3 = e3x3;}                          //
+                                                                              //
+    unsigned int get_cluster_id() const {return _clus_id;}                    //
+    void         set_cluster_id(unsigned int clus_id) {_clus_id = clus_id;}   //
+                                                                              //
+    float get_deta() const {return _deta;}                                    //
+    void  set_deta(float deta) {_deta = deta;}                                //
+                                                                              //
+    float get_dphi() const {return _dphi;}                                    //
+    void  set_dphi(float dphi) {_dphi = dphi;}                                //
+                                                                              //
+    float get_cluster_energy() const {return _clus_e;}                        //
+    void  set_cluster_energy(float clus_e) {_clus_e = clus_e;}                //
+                                                                              //
+  private:                                                                    //
+    float _e3x3;                                                              //
+    unsigned int _clus_id;                                                    //
+    float _deta;                                                              //
+    float _dphi;                                                              //
+    float _clus_e;                                                            //
+  };                                                                          //
+  // --- inner CaloMatch class -----------------------------------------------//
   
   // keep these private for now
   // attempting ~zero interface changes during refactor
@@ -262,11 +290,7 @@ class SvtxTrack : public PHObject {
   std::map<int,std::vector<float> > _cluster_positions; //< layer index => (x,y,z)
   
   // calorimeter matches
-  std::map<CAL_LAYER,float> _cal_dphi;
-  std::map<CAL_LAYER,float> _cal_deta;
-  std::map<CAL_LAYER,float> _cal_energy_3x3;
-  std::map<CAL_LAYER,int>   _cal_cluster_id;
-  std::map<CAL_LAYER,float> _cal_cluster_e;
+  std::map<CAL_LAYER,SvtxTrack::CaloMatch> _calo_matches;
   
   ClassDef(SvtxTrack,1)
 };

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -156,11 +156,11 @@ class SvtxTrack : public PHObject {
   void  set_error(int i, int j, float value);
   
   // track information
-  int     _track_id;
-  bool    _is_positive_charge;
-  float   _quality;
-  float   _chisq;
-  int     _ndf;
+  unsigned int _track_id;
+  bool         _is_positive_charge;
+  float        _quality;
+  float        _chisq;
+  unsigned int _ndf;
 
   // extended track information (non-primary tracks only)
   float   _DCA;
@@ -173,15 +173,16 @@ class SvtxTrack : public PHObject {
   // projection information
   // replace with a set/map of track state vectors
   // x,y,z,px,py,pz + covar
-  
+  // distance along track => state vector
+  // std::map<float,SvtxTrackState*> _states;
+  // float distance = 0.0 will be the default DCA or vertex point value
   float   _phi,_d,_kappa,_z0,_dzdl;
-  //float   _momentum;
   float   _mom[3];
   float   _x,_y,_z;
   std::vector<std::vector<float> > _covar; // 6x6 triangular matrix
   
   // cluster contents
-  std::map<int,int> _cluster_ids; //< layer index => cluster id
+  std::map<int,unsigned int> _cluster_ids; //< layer index => cluster id
 
   // the cluster positions aren't really useful on their own
   // without the cluster uncertainties... maybe we should eliminate

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -168,7 +168,6 @@ class SvtxTrack : public PHObject {
   // track information
   unsigned int _track_id;
   bool         _is_positive_charge;
-  //float        _quality;
   float        _chisq;
   unsigned int _ndf;
 
@@ -186,7 +185,7 @@ class SvtxTrack : public PHObject {
   // distance along track => state vector
   // std::map<float,SvtxTrackState*> _states;
   // float distance = 0.0 will be the default DCA or vertex point value
-  float   _phi,_d,_kappa,_z0,_dzdl;
+  float   _phi,_d,_kappa,_z0,_dzdl; // redundant to x,y,z,px,py,pz & field strength
   float   _mom[3];
   float   _x,_y,_z;
   std::vector<std::vector<float> > _covar; // 6x6 triangular matrix

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -21,14 +21,15 @@ class SvtxTrack : public PHObject {
   void Reset();
   int  isValid() const;
 
-  void set_id(int id) {_track_id = id;}
+  //---old interface-------
+  
   void setTrackID(int index){_track_id = index;}
   int getTrackID() const {return _track_id;}  
-  
+
+  bool hasCluster(int layer) const {return (_cluster_ids.find(layer) != _cluster_ids.end());}
   void setClusterID(int layer, int index) {_cluster_ids[layer] = index;}
   int getClusterID(int layer) const {return _cluster_ids.find(layer)->second;}
-  bool hasCluster(int layer) const {return (_cluster_ids.find(layer) != _cluster_ids.end());}
-  
+    
   void setScatter(int layer, float sct) {
     std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
   }
@@ -116,20 +117,20 @@ class SvtxTrack : public PHObject {
 
   float getInnerMostHitPosition(int coor) const;
 
-  void  set_phi(float phi) {_states[0.0].set_phi(phi);}
-  float get_phi() const {return _states.find(0.0)->second.get_phi();}
+  void  set_helix_phi(float phi) {_states[0.0].set_helix_phi(phi);}
+  float get_helix_phi() const {return _states.find(0.0)->second.get_helix_phi();}
     
-  void  set_d(float d) {_states[0.0].set_d(d);}
-  float get_d() const {return _states.find(0.0)->second.get_d();}
+  void  set_helix_d(float d) {_states[0.0].set_helix_d(d);}
+  float get_helix_d() const {return _states.find(0.0)->second.get_helix_d();}
   
-  void  set_kappa(float kappa) {_states[0.0].set_kappa(kappa);}
-  float get_kappa() const {return _states.find(0.0)->second.get_kappa();}
+  void  set_helix_kappa(float kappa) {_states[0.0].set_helix_kappa(kappa);}
+  float get_helix_kappa() const {return _states.find(0.0)->second.get_helix_kappa();}
     
-  void  set_z0(float z0) {_states[0.0].set_z0(z0);}
-  float get_z0() const {return _states.find(0.0)->second.get_z0();}
+  void  set_helix_z0(float z0) {_states[0.0].set_helix_z0(z0);}
+  float get_helix_z0() const {return _states.find(0.0)->second.get_helix_z0();}
     
-  void  set_dzdl(float dzdl) {_states[0.0].set_dzdl(dzdl);}
-  float get_dzdl() const {return _states.find(0.0)->second.get_dzdl();}
+  void  set_helix_dzdl(float dzdl) {_states[0.0].set_helix_dzdl(dzdl);}
+  float get_helix_dzdl() const {return _states.find(0.0)->second.get_helix_dzdl();}
   
   float getCovariance(int i,int j) const {return get_error(i,j);}
   void  setCovariance(int i,int j, float val) {set_error(i,j,val);}
@@ -149,6 +150,11 @@ class SvtxTrack : public PHObject {
   void  set_cal_cluster_e(CAL_LAYER layer, float e);
   float get_cal_cluster_e(CAL_LAYER layer) const;
 
+  //---new interface------
+
+  unsigned int get_id() const          {return _track_id;}
+  void         set_id(unsigned int id) {_track_id = id;}
+  
   float get_x() const  {return _states.find(0.0)->second.get_x();}
   void  set_x(float x) {_states[0.0].set_x(x);}
   
@@ -158,13 +164,24 @@ class SvtxTrack : public PHObject {
   float get_z() const  {return _states.find(0.0)->second.get_z();}
   void  set_z(float z) {_states[0.0].set_z(z);}
 
-  // add convience calculations
-  //float get_eta() const;
-  //float get_theta() const;
-  //float get_phi() const;
-  //float get_pt() const;
-  //float get_p() const;
+  float get_pos(unsigned int i) const {return _states.find(0.0)->second.get_pos(i);}
 
+  float get_px() const   {return _states.find(0.0)->second.get_px();}
+  void  set_px(float px) {_states[0.0].set_px(px);}
+  
+  float get_py() const   {return _states.find(0.0)->second.get_py();}
+  void  set_py(float py) {_states[0.0].set_py(py);}
+
+  float get_pz() const   {return _states.find(0.0)->second.get_pz();}
+  void  set_pz(float pz) {_states[0.0].set_pz(pz);}
+
+  float get_mom(unsigned int i) const {return _states.find(0.0)->second.get_mom(i);}
+
+  float get_p() const   {return sqrt(pow(get_px(),2) + pow(get_py(),2) + pow(get_pz(),2));}
+  float get_pt() const  {return sqrt(pow(get_px(),2) + pow(get_py(),2));}
+  float get_eta() const {return asinh(get_pz()/get_pt());}
+  //float get_phi() const {return atan2(get_py(),get_px());}
+  
  private: 
 
   // keep it private for now to minimize interface changes
@@ -174,14 +191,16 @@ class SvtxTrack : public PHObject {
     State();                                                                  //
     virtual ~State() {}                                                       //
                                                                               //
-    float get_x() const {return _x;}                                          //
-    void  set_x(float x) {_x = x;}                                            //
+    float get_x() const {return _pos[0];}                                     //
+    void  set_x(float x) {_pos[0] = x;}                                       //
                                                                               //
-    float get_y() const {return _y;}                                          //
-    void  set_y(float y) {_y = y;}                                            //
+    float get_y() const {return _pos[1];}                                     //
+    void  set_y(float y) {_pos[1] = y;}                                       //
                                                                               //
-    float get_z() const {return _z;}                                          //
-    void  set_z(float z) {_z = z;}                                            //
+    float get_z() const {return _pos[2];}                                     //
+    void  set_z(float z) {_pos[2] = z;}                                       //
+                                                                              //
+    float get_pos(unsigned int i) const {return _pos[i];}                     //
                                                                               //
     float get_px() const {return _mom[0];}                                    //
     void  set_px(float px) {_mom[0] = px;}                                    //
@@ -194,35 +213,36 @@ class SvtxTrack : public PHObject {
                                                                               //
     float get_mom(unsigned int i) const {return _mom[i];}                     //
                                                                               //
-    float get_error(int i, int j) const;                                      //
-    void  set_error(int i, int j, float value);                               //
+    float get_error(unsigned int i, unsigned int j) const;                    //
+    void  set_error(unsigned int i, unsigned int j, float value);             //
                                                                               //
-    void  set_phi(float phi) {_phi = phi;}                                    //
-    float get_phi() const {return _phi;}                                      //
+    void  set_helix_phi(float helix_phi) {_helix_phi = helix_phi;}            //
+    float get_helix_phi() const {return _helix_phi;}                          //
                                                                               //
-    void  set_d(float d) {_d = d;}                                            //
-    float get_d() const {return _d;}                                          //
+    void  set_helix_d(float d) {_helix_d = d;}                                //
+    float get_helix_d() const {return _helix_d;}                              //
                                                                               //
-    void  set_kappa(float kappa) {_kappa = kappa;}                            //
-    float get_kappa() const {return _kappa;}                                  //
+    void  set_helix_kappa(float kappa) {_helix_kappa = kappa;}                //
+    float get_helix_kappa() const {return _helix_kappa;}                      //
                                                                               //
-    void  set_z0(float z0) {_z0 = z0;}                                        //
-    float get_z0() const {return _z0;}                                        //
+    void  set_helix_z0(float z0) {_helix_z0 = z0;}                            //
+    float get_helix_z0() const {return _helix_z0;}                            //
                                                                               //
-    void  set_dzdl(float dzdl) {_dzdl = dzdl;}                                //
-    float get_dzdl() const {return _dzdl;}                                    //
+    void  set_helix_dzdl(float dzdl) {_helix_dzdl = dzdl;}                    //
+    float get_helix_dzdl() const {return _helix_dzdl;}                        //
                                                                               //
   private:                                                                    //
-    float _x;                                                                 //
-    float _y;                                                                 //
-    float _z;                                                                 //
+                                                                              //
+    unsigned int covar_index(unsigned int i, unsigned int j) const;           //
+                                                                              //
+    float _pos[3];                                                            //
     float _mom[3];                                                            //
-    std::vector<std::vector<float> > _covar;                                  //
-    float _phi;                                                               //
-    float _d;                                                                 //
-    float _kappa;                                                             //
-    float _z0;                                                                //
-    float _dzdl;                                                              //
+    float _covar[21]; // 6x6 triangular packed storage                        //
+    float _helix_phi;                                                         //
+    float _helix_d;                                                           //
+    float _helix_kappa;                                                       //
+    float _helix_z0;                                                          //
+    float _helix_dzdl;                                                        //
   };                                                                          //
   // --- inner State class ---------------------------------------------------//
 

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -15,9 +15,7 @@ class SvtxTrack : public PHObject {
   enum CAL_LAYER {PRES,CEMC,HCALIN,HCALOUT};
 
   SvtxTrack();
-  //SvtxTrack(SvtxTrack *track);
-  //SvtxTrack(const SvtxTrack& track);
-  virtual ~SvtxTrack() {};
+  virtual ~SvtxTrack() {}
   
   // The "standard PHObject response" functions...
   void identify(std::ostream &os=std::cout) const;
@@ -28,62 +26,62 @@ class SvtxTrack : public PHObject {
   void setTrackID(int index){_track_id = index;}
   int getTrackID() const {return _track_id;}  
   
-  void setClusterID(int layer, int index) {clusterID[layer] = index;}
-  int getClusterID(int layer) const {return clusterID[layer];}
-  bool hasCluster(int layer) const {return (clusterID[layer] >- 9999);}
+  void setClusterID(int layer, int index) {_clusterID[layer] = index;}
+  int getClusterID(int layer) const {return _clusterID[layer];}
+  bool hasCluster(int layer) const {return (_clusterID[layer] >- 9999);}
   
-  void setScatter(int layer, float sct) {scatter[layer] = sct;}
-  float getScatter(int layer) const {return scatter[layer];}
+  void setScatter(int layer, float sct) {_scatter[layer] = sct;}
+  float getScatter(int layer) const {return _scatter[layer];}
   
   void setHitPosition(int layer, float x, float y, float z) {
-    position[layer][0]=x;
-    position[layer][1]=y;
-    position[layer][2]=z;
+    _position[layer][0]=x;
+    _position[layer][1]=y;
+    _position[layer][2]=z;
   }
-  float getHitPosition(int layer, int coor) const {return position[layer][coor];}
+  float getHitPosition(int layer, int coor) const {return _position[layer][coor];}
 
-  void setMomentum(float p) {momentum = p;}
-  float getMomentum() const {return momentum;}
+  void setMomentum(float p) {_momentum = p;}
+  float getMomentum() const {return _momentum;}
   
   void set3Momentum(float px, float py, float pz) {
-    mom3[0] = px;
-    mom3[1] = py;
-    mom3[2] = pz;
+    _mom3[0] = px;
+    _mom3[1] = py;
+    _mom3[2] = pz;
   };
-  float get3Momentum(int coor) const {return mom3[coor];}
+  float get3Momentum(int coor) const {return _mom3[coor];}
   
-  void setCharge(int c) {charge = c;}
-  int getCharge() const {return charge;}
+  void setCharge(int c) {_charge = c;}
+  int getCharge() const {return _charge;}
   
-  void setPrimary(bool prim) {isprimary = prim;}
-  bool getPrimary() const {return isprimary;}
+  void setPrimary(bool prim) {_isprimary = prim;}
+  bool getPrimary() const {return _isprimary;}
   
-  void setPositive(bool prim) {ispositive = prim;}
-  bool getPositive() const {return ispositive;}
+  void setPositive(bool prim) {_ispositive = prim;}
+  bool getPositive() const {return _ispositive;}
   
   //void setNhits(int layer, short n);
   short getNhits() const;
   
-  void setQuality(float q) {quality = q;}
-  float getQuality() const {return quality;}
+  void setQuality(float q) {_quality = q;}
+  float getQuality() const {return _quality;}
 
-  void setChisq(float q) {chisq = q;}
-  float getChisq() const {return chisq;}
+  void setChisq(float q) {_chisq = q;}
+  float getChisq() const {return _chisq;}
 
-  void setChisqv(float q) {chisqv = q;}
-  float getChisqv() const {return chisqv;}
+  void setChisqv(float q) {_chisqv = q;}
+  float getChisqv() const {return _chisqv;}
 
-  void setNDF(int q) {ndf = q;}
-  int getNDF() const {return ndf;}
+  void setNDF(int q) {_ndf = q;}
+  int getNDF() const {return _ndf;}
 
-  void setDCA(float d) {DCA = d;}
-  float getDCA() const {return DCA;}
+  void setDCA(float d) {_DCA = d;}
+  float getDCA() const {return _DCA;}
 
-  void setDCA2D(float d) {DCA2D = d;}
-  float getDCA2D() const {return DCA2D;}
+  void setDCA2D(float d) {_DCA2D = d;}
+  float getDCA2D() const {return _DCA2D;}
   
-  void setDCA2Dsigma(float s) {DCA2Dsigma = s;}
-  float getDCA2Dsigma() const {return DCA2Dsigma;}
+  void setDCA2Dsigma(float s) {_DCA2Dsigma = s;}
+  float getDCA2Dsigma() const {return _DCA2Dsigma;}
 
   float getInnerMostHitPosition(int coor) const;
 
@@ -102,61 +100,61 @@ class SvtxTrack : public PHObject {
   void  set_dzdl(float dzdl) {_dzdl = dzdl;}
   float get_dzdl() const {return _dzdl;}
   
-  const TMatrix* getCovariance() const {return &covariance;}
-  TMatrix* getCovariance() {return &covariance;}
+  const TMatrix* getCovariance() const {return &_covariance;}
+  TMatrix* getCovariance() {return &_covariance;}
   
 
-  void set_cal_dphi(int layer, float dphi) {cal_dphi[layer] = dphi;}
-  float get_cal_dphi(int layer) const {return cal_dphi[layer];}
+  void set_cal_dphi(int layer, float dphi) {_cal_dphi[layer] = dphi;}
+  float get_cal_dphi(int layer) const {return _cal_dphi[layer];}
 
-  void set_cal_deta(int layer, float deta) {cal_deta[layer] = deta;}
-  float get_cal_deta(int layer) const {return cal_deta[layer];}
+  void set_cal_deta(int layer, float deta) {_cal_deta[layer] = deta;}
+  float get_cal_deta(int layer) const {return _cal_deta[layer];}
 
-  void set_cal_energy_3x3(int layer, float energy_3x3) {cal_energy_3x3[layer] = energy_3x3;}
-  float get_cal_energy_3x3(int layer) const {return cal_energy_3x3[layer];}
+  void set_cal_energy_3x3(int layer, float energy_3x3) {_cal_energy_3x3[layer] = energy_3x3;}
+  float get_cal_energy_3x3(int layer) const {return _cal_energy_3x3[layer];}
 
-  void set_cal_cluster_id(int layer, int id) {cal_cluster_id[layer] = id;}
-  float get_cal_cluster_id(int layer) const {return cal_cluster_id[layer];}
+  void set_cal_cluster_id(int layer, int id) {_cal_cluster_id[layer] = id;}
+  float get_cal_cluster_id(int layer) const {return _cal_cluster_id[layer];}
 
-  void set_cal_cluster_e(int layer, float e) {cal_cluster_e[layer] = e;}
-  float get_cal_cluster_e(int layer) const {return cal_cluster_e[layer];}
+  void set_cal_cluster_e(int layer, float e) {_cal_cluster_e[layer] = e;}
+  float get_cal_cluster_e(int layer) const {return _cal_cluster_e[layer];}
 
-  float get_x() const{return x;}
-  void set_x(float val){x = val;}
-  float get_y() const{return y;}
-  void set_y(float val){y = val;}
-  float get_z() const{return z;}
-  void set_z(float val){z = val;}
+  float get_x() const{return _x;}
+  void set_x(float val){_x = val;}
+  float get_y() const{return _y;}
+  void set_y(float val){_y = val;}
+  float get_z() const{return _z;}
+  void set_z(float val){_z = val;}
 
  private: 
 
   int     _track_id;
   float   _phi,_d,_kappa,_z0,_dzdl;
-  int     clusterID[100];
-  float   position[100][3];
-  float   momentum;
-  float   mom3[3];
-  int     charge;
-  bool    isprimary;
-  bool    ispositive;
-  float   quality;
-  float   chisq;
-  float   chisqv;
-  int     ndf;
-  float   DCA;
-  float   DCA2D;
-  float   DCA2Dsigma;
-  float   scatter[100];
-  float   x,y,z;
+  int     _clusterID[100];
+  float   _position[100][3];
+  float   _momentum;
+  float   _mom3[3];
+  int     _charge;
+  bool    _isprimary;
+  bool    _ispositive;
+  float   _quality;
+  float   _chisq;
+  float   _chisqv;
+  int     _ndf;
+  float   _DCA;
+  float   _DCA2D;
+  float   _DCA2Dsigma;
+  float   _scatter[100];
+  float   _x,_y,_z;
   
-  TMatrix covariance;
+  TMatrix _covariance;
   
   // calorimeter matches
-  float   cal_dphi[4];
-  float   cal_deta[4];
-  float   cal_energy_3x3[4];
-  int     cal_cluster_id[4];
-  float   cal_cluster_e[4];
+  float   _cal_dphi[4];
+  float   _cal_deta[4];
+  float   _cal_energy_3x3[4];
+  int     _cal_cluster_id[4];
+  float   _cal_cluster_e[4];
 
   // cluster ids
   //std::multimap<unsigned int,unsigned int> _cluster_ids; //< layer index => cluster id

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -12,7 +12,7 @@ class SvtxTrack : public PHObject {
   
  public:
 
-  enum CAL_LAYER {PRES,CEMC,HCALIN,HCALOUT};
+  enum CAL_LAYER {PRES=0,CEMC=1,HCALIN=2,HCALOUT=3};
 
   SvtxTrack();
   virtual ~SvtxTrack() {}
@@ -32,9 +32,11 @@ class SvtxTrack : public PHObject {
   
   void setScatter(int layer, float sct) {
     std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
-    exit(-1);
   }
-  float getScatter(int layer) const {return NAN;}
+  float getScatter(int layer) const {
+    std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
+    return NAN;
+  }
   
   void setHitPosition(int layer, float x, float y, float z) {
     _position[layer][0]=x;
@@ -106,20 +108,20 @@ class SvtxTrack : public PHObject {
   const TMatrix* getCovariance() const {return &_covariance;}
   TMatrix* getCovariance() {return &_covariance;}  
 
-  void set_cal_dphi(int layer, float dphi) {_cal_dphi[layer] = dphi;}
-  float get_cal_dphi(int layer) const {return _cal_dphi[layer];}
+  void  set_cal_dphi(CAL_LAYER layer, float dphi) {_cal_dphi[layer] = dphi;}
+  float get_cal_dphi(CAL_LAYER layer) const;
 
-  void set_cal_deta(int layer, float deta) {_cal_deta[layer] = deta;}
-  float get_cal_deta(int layer) const {return _cal_deta[layer];}
+  void  set_cal_deta(CAL_LAYER layer, float deta) {_cal_deta[layer] = deta;}
+  float get_cal_deta(CAL_LAYER layer) const;
 
-  void set_cal_energy_3x3(int layer, float energy_3x3) {_cal_energy_3x3[layer] = energy_3x3;}
-  float get_cal_energy_3x3(int layer) const {return _cal_energy_3x3[layer];}
+  void  set_cal_energy_3x3(CAL_LAYER layer, float energy_3x3) {_cal_energy_3x3[layer] = energy_3x3;}
+  float get_cal_energy_3x3(CAL_LAYER layer) const;
 
-  void set_cal_cluster_id(int layer, int id) {_cal_cluster_id[layer] = id;}
-  float get_cal_cluster_id(int layer) const {return _cal_cluster_id[layer];}
+  void  set_cal_cluster_id(CAL_LAYER layer, int id) {_cal_cluster_id[layer] = id;}
+  int   get_cal_cluster_id(CAL_LAYER layer) const;
 
-  void set_cal_cluster_e(int layer, float e) {_cal_cluster_e[layer] = e;}
-  float get_cal_cluster_e(int layer) const {return _cal_cluster_e[layer];}
+  void  set_cal_cluster_e(CAL_LAYER layer, float e) {_cal_cluster_e[layer] = e;}
+  float get_cal_cluster_e(CAL_LAYER layer) const;
 
   float get_x() const{return _x;}
   void set_x(float val){_x = val;}
@@ -131,33 +133,38 @@ class SvtxTrack : public PHObject {
  private: 
 
   int     _track_id;
-  float   _phi,_d,_kappa,_z0,_dzdl;
-  float   _position[100][3];
-  float   _momentum;
-  float   _mom3[3];
+
+  // track information
   int     _charge;
   bool    _ispositive;
   float   _quality;
   float   _chisq;
   float   _chisqv;
   int     _ndf;
+
   float   _DCA;
   float   _DCA2D;
   float   _DCA2Dsigma;
+
+  // projection information
+  float   _phi,_d,_kappa,_z0,_dzdl;
+  float   _position[100][3];
+  float   _momentum;
+  float   _mom3[3];
+
   float   _x,_y,_z;
   
   TMatrix _covariance;
   
-  // calorimeter matches
-  float   _cal_dphi[4];
-  float   _cal_deta[4];
-  float   _cal_energy_3x3[4];
-  int     _cal_cluster_id[4];
-  float   _cal_cluster_e[4];
-
   // cluster ids
-  //int     _clusterID[100];
   std::map<int,int> _cluster_ids; //< layer index => cluster id
+
+  // calorimeter matches
+  std::map<CAL_LAYER,float> _cal_dphi;
+  std::map<CAL_LAYER,float> _cal_deta;
+  std::map<CAL_LAYER,float> _cal_energy_3x3;
+  std::map<CAL_LAYER,int>   _cal_cluster_id;
+  std::map<CAL_LAYER,float> _cal_cluster_e;
   
   ClassDef(SvtxTrack,1)
 };

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -81,8 +81,13 @@ class SvtxTrack : public PHObject {
   void setChisq(float q) {_chisq = q;}
   float getChisq() const {return _chisq;}
 
-  void setChisqv(float q) {_chisqv = q;}
-  float getChisqv() const {return _chisqv;}
+  void setChisqv(float q) {
+    std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
+  }
+  float getChisqv() const {
+    std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
+    return NAN;
+  }
 
   void setNDF(int q) {_ndf = q;}
   int getNDF() const {return _ndf;}
@@ -131,12 +136,14 @@ class SvtxTrack : public PHObject {
   void  set_cal_cluster_e(CAL_LAYER layer, float e) {_cal_cluster_e[layer] = e;}
   float get_cal_cluster_e(CAL_LAYER layer) const;
 
-  float get_x() const{return _x;}
-  void set_x(float val){_x = val;}
-  float get_y() const{return _y;}
-  void set_y(float val){_y = val;}
-  float get_z() const{return _z;}
-  void set_z(float val){_z = val;}
+  float get_x() const  {return _x;}
+  void  set_x(float x) {_x = x;}
+  
+  float get_y() const  {return _y;}
+  void  set_y(float y) {_y = y;}
+
+  float get_z() const  {return _z;}
+  void  set_z(float z) {_z = z;}
 
  private: 
 
@@ -145,7 +152,6 @@ class SvtxTrack : public PHObject {
   bool    _is_positive_charge;
   float   _quality;
   float   _chisq;
-  float   _chisqv;
   int     _ndf;
 
   float   _DCA;

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -47,14 +47,21 @@ class SvtxTrack : public PHObject {
   float getHitPosition(int layer, int coor) const;
 
   void setMomentum(float p) {}
-  float getMomentum() const {return sqrt(pow(_mom[0],2)+pow(_mom[1],2)+pow(_mom[2],2));}
+  float getMomentum() const {
+    float px = _states.find(0.0)->second.get_px();
+    float py = _states.find(0.0)->second.get_py();
+    float pz = _states.find(0.0)->second.get_pz();
+    return sqrt(pow(px,2)+pow(py,2)+pow(pz,2));
+  }
   
   void set3Momentum(float px, float py, float pz) {
-    _mom[0] = px;
-    _mom[1] = py;
-    _mom[2] = pz;
+    _states[0.0].set_px(px);
+    _states[0.0].set_py(py);
+    _states[0.0].set_pz(pz);
   };
-  float get3Momentum(int coor) const {return _mom[coor];}
+  float get3Momentum(int coor) const {
+    return _states.find(0.0)->second.get_mom(coor);
+  }
   
   void setCharge(int c) {
     if (c > 0) setPositive(true);
@@ -109,20 +116,20 @@ class SvtxTrack : public PHObject {
 
   float getInnerMostHitPosition(int coor) const;
 
-  void  set_phi(float phi) {_phi = phi;}
-  float get_phi() const {return _phi;}
-
-  void  set_d(float d) {_d = d;}
-  float get_d() const {return _d;}
-  
-  void  set_kappa(float kappa) {_kappa = kappa;}
-  float get_kappa() const {return _kappa;}
+  void  set_phi(float phi) {_states[0.0].set_phi(phi);}
+  float get_phi() const {return _states.find(0.0)->second.get_phi();}
     
-  void  set_z0(float z0) {_z0 = z0;}
-  float get_z0() const {return _z0;}
-
-  void  set_dzdl(float dzdl) {_dzdl = dzdl;}
-  float get_dzdl() const {return _dzdl;}
+  void  set_d(float d) {_states[0.0].set_d(d);}
+  float get_d() const {return _states.find(0.0)->second.get_d();}
+  
+  void  set_kappa(float kappa) {_states[0.0].set_kappa(kappa);}
+  float get_kappa() const {return _states.find(0.0)->second.get_kappa();}
+    
+  void  set_z0(float z0) {_states[0.0].set_z0(z0);}
+  float get_z0() const {return _states.find(0.0)->second.get_z0();}
+    
+  void  set_dzdl(float dzdl) {_states[0.0].set_dzdl(dzdl);}
+  float get_dzdl() const {return _states.find(0.0)->second.get_dzdl();}
   
   float getCovariance(int i,int j) const {return get_error(i,j);}
   void  setCovariance(int i,int j, float val) {set_error(i,j,val);}
@@ -142,14 +149,14 @@ class SvtxTrack : public PHObject {
   void  set_cal_cluster_e(CAL_LAYER layer, float e) {_cal_cluster_e[layer] = e;}
   float get_cal_cluster_e(CAL_LAYER layer) const;
 
-  float get_x() const  {return _x;}
-  void  set_x(float x) {_x = x;}
+  float get_x() const  {return _states.find(0.0)->second.get_x();}
+  void  set_x(float x) {_states[0.0].set_x(x);}
   
-  float get_y() const  {return _y;}
-  void  set_y(float y) {_y = y;}
+  float get_y() const  {return _states.find(0.0)->second.get_y();}
+  void  set_y(float y) {_states[0.0].set_y(y);}
 
-  float get_z() const  {return _z;}
-  void  set_z(float z) {_z = z;}
+  float get_z() const  {return _states.find(0.0)->second.get_z();}
+  void  set_z(float z) {_states[0.0].set_z(z);}
 
   // add convience calculations
   //float get_eta() const;
@@ -160,10 +167,69 @@ class SvtxTrack : public PHObject {
 
  private: 
 
+  // keep it private for now to minimize interface changes
+  // --- inner State class ---------------------------------------------------//
+  class State {                                                               //
+  public:                                                                     //
+    State();                                                                  //
+    virtual ~State() {}                                                       //
+                                                                              //
+    float get_x() const {return _x;}                                          //
+    void  set_x(float x) {_x = x;}                                            //
+                                                                              //
+    float get_y() const {return _y;}                                          //
+    void  set_y(float y) {_y = y;}                                            //
+                                                                              //
+    float get_z() const {return _z;}                                          //
+    void  set_z(float z) {_z = z;}                                            //
+                                                                              //
+    float get_px() const {return _mom[0];}                                    //
+    void  set_px(float px) {_mom[0] = px;}                                    //
+                                                                              //
+    float get_py() const {return _mom[1];}                                    //
+    void  set_py(float py) {_mom[1] = py;}                                    //
+                                                                              //
+    float get_pz() const {return _mom[2];}                                    //
+    void  set_pz(float pz) {_mom[2] = pz;}                                    //
+                                                                              //
+    float get_mom(unsigned int i) const {return _mom[i];}                     //
+                                                                              //
+    float get_error(int i, int j) const;                                      //
+    void  set_error(int i, int j, float value);                               //
+                                                                              //
+    void  set_phi(float phi) {_phi = phi;}                                    //
+    float get_phi() const {return _phi;}                                      //
+                                                                              //
+    void  set_d(float d) {_d = d;}                                            //
+    float get_d() const {return _d;}                                          //
+                                                                              //
+    void  set_kappa(float kappa) {_kappa = kappa;}                            //
+    float get_kappa() const {return _kappa;}                                  //
+                                                                              //
+    void  set_z0(float z0) {_z0 = z0;}                                        //
+    float get_z0() const {return _z0;}                                        //
+                                                                              //
+    void  set_dzdl(float dzdl) {_dzdl = dzdl;}                                //
+    float get_dzdl() const {return _dzdl;}                                    //
+                                                                              //
+  private:                                                                    //
+    float _x;                                                                 //
+    float _y;                                                                 //
+    float _z;                                                                 //
+    float _mom[3];                                                            //
+    std::vector<std::vector<float> > _covar;                                  //
+    float _phi;                                                               //
+    float _d;                                                                 //
+    float _kappa;                                                             //
+    float _z0;                                                                //
+    float _dzdl;                                                              //
+  };                                                                          //
+  // --- inner State class ---------------------------------------------------//
+  
   // keep these private for now
   // attempting ~zero interface changes during refactor
-  float get_error(int i, int j) const;
-  void  set_error(int i, int j, float value);
+  float get_error(int i, int j) const {return _states.find(0.0)->second.get_error(i,j);}
+  void  set_error(int i, int j, float value) {return _states[0.0].set_error(i,j,value);}
   
   // track information
   unsigned int _track_id;
@@ -183,12 +249,12 @@ class SvtxTrack : public PHObject {
   // replace with a set/map of track state vectors
   // x,y,z,px,py,pz + covar
   // distance along track => state vector
-  // std::map<float,SvtxTrackState*> _states;
+  std::map<float,SvtxTrack::State> _states;
   // float distance = 0.0 will be the default DCA or vertex point value
-  float   _phi,_d,_kappa,_z0,_dzdl; // redundant to x,y,z,px,py,pz & field strength
-  float   _mom[3];
-  float   _x,_y,_z;
-  std::vector<std::vector<float> > _covar; // 6x6 triangular matrix
+  //float   _phi,_d,_kappa,_z0,_dzdl; // redundant to x,y,z,px,py,pz & field strength
+  //float   _mom[3];
+  //float   _x,_y,_z; // point of closest approach assuming vertex is at 0,0,0
+  //std::vector<std::vector<float> > _covar; // 6x6 triangular matrix
   
   // cluster contents
   std::map<int,unsigned int> _cluster_ids; //< layer index => cluster id

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -46,15 +46,15 @@ class SvtxTrack : public PHObject {
   }
   float getHitPosition(int layer, int coor) const;
 
-  void setMomentum(float p) {_momentum = p;}
-  float getMomentum() const {return _momentum;}
+  void setMomentum(float p) {}
+  float getMomentum() const {return sqrt(pow(_mom[0],2)+pow(_mom[1],2)+pow(_mom[2],2));}
   
   void set3Momentum(float px, float py, float pz) {
-    _mom3[0] = px;
-    _mom3[1] = py;
-    _mom3[2] = pz;
+    _mom[0] = px;
+    _mom[1] = py;
+    _mom[2] = pz;
   };
-  float get3Momentum(int coor) const {return _mom3[coor];}
+  float get3Momentum(int coor) const {return _mom[coor];}
   
   void setCharge(int c) {
     if (c > 0) setPositive(true);
@@ -172,9 +172,11 @@ class SvtxTrack : public PHObject {
   
   // projection information
   // replace with a set/map of track state vectors
+  // x,y,z,px,py,pz + covar
+  
   float   _phi,_d,_kappa,_z0,_dzdl;
-  float   _momentum;
-  float   _mom3[3];
+  //float   _momentum;
+  float   _mom[3];
   float   _x,_y,_z;
   std::vector<std::vector<float> > _covar; // 6x6 triangular matrix
   

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -169,12 +169,19 @@ class SvtxTrack : public PHObject {
   bool   empty_states()                 const {return _states.empty();}
   size_t size_states()                  const {return _states.size();}
   size_t count_states(float pathlength) const {return _states.count(pathlength);}
-  void   clear_states()                       {return _states.clear();}
+  void   clear_states() {
+    _states.clear();
+    insert_state(State(0.0));
+  }
   
   const State* get_state(float pathlength) const;
         State* get_state(float pathlength); 
         State* insert_state(const State &state);
-        size_t erase_state(float pathlength) {return _states.erase(pathlength);}
+        size_t erase_state(float pathlength) {
+	  _states.erase(pathlength);
+	  if (pathlength == 0) insert_state(State(0.0));
+	  return _states.size();
+	}
 
   ConstStateIter begin_states()                const {return _states.begin();}
   ConstStateIter  find_state(float pathlength) const {return _states.find(pathlength);}

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -3,10 +3,9 @@
 
 #include <phool/PHObject.h>
 
-#include <TMatrix.h>
-
 #include <iostream>
 #include <map>
+#include <cmath>
 
 class SvtxTrack : public PHObject {
   
@@ -94,15 +93,15 @@ class SvtxTrack : public PHObject {
   }
 
   void setNDF(int q) {_ndf = q;}
-  int getNDF() const {return _ndf;}
+  int  getNDF() const {return _ndf;}
 
-  void setDCA(float d) {_DCA = d;}
+  void  setDCA(float d) {_DCA = d;}
   float getDCA() const {return _DCA;}
 
-  void setDCA2D(float d) {_DCA2D = d;}
+  void  setDCA2D(float d) {_DCA2D = d;}
   float getDCA2D() const {return _DCA2D;}
   
-  void setDCA2Dsigma(float s) {_DCA2Dsigma = s;}
+  void  setDCA2Dsigma(float s) {_DCA2Dsigma = s;}
   float getDCA2Dsigma() const {return _DCA2Dsigma;}
 
   float getInnerMostHitPosition(int coor) const;
@@ -116,14 +115,14 @@ class SvtxTrack : public PHObject {
   void  set_kappa(float kappa) {_kappa = kappa;}
   float get_kappa() const {return _kappa;}
     
-  void set_z0(float z0) {_z0 = z0;}
+  void  set_z0(float z0) {_z0 = z0;}
   float get_z0() const {return _z0;}
 
   void  set_dzdl(float dzdl) {_dzdl = dzdl;}
   float get_dzdl() const {return _dzdl;}
   
-  float getCovariance(int i,int j) const {return _covariance[i][j];}
-  void  setCovariance(int i,int j, float val) {_covariance[i][j] = val;}
+  float getCovariance(int i,int j) const {return get_error(i,j);}
+  void  setCovariance(int i,int j, float val) {set_error(i,j,val);}
 
   void  set_cal_dphi(CAL_LAYER layer, float dphi) {_cal_dphi[layer] = dphi;}
   float get_cal_dphi(CAL_LAYER layer) const;
@@ -177,11 +176,6 @@ class SvtxTrack : public PHObject {
   float   _momentum;
   float   _mom3[3];
   float   _x,_y,_z;
-
-  // ROOT adds a lot of overhead, and will get worse if we store multiple state
-  // vectors, we should replace this with a raw type like a triangular
-  // vector implementation std::vector<std::vector<float> > _covariance;
-  TMatrix _covariance;
   std::vector<std::vector<float> > _covar; // 6x6 triangular matrix
   
   // cluster contents

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -122,9 +122,8 @@ class SvtxTrack : public PHObject {
   void  set_dzdl(float dzdl) {_dzdl = dzdl;}
   float get_dzdl() const {return _dzdl;}
   
-  const TMatrix* getCovariance() const {return &_covariance;}
-  //TMatrix* getCovariance() {return &_covariance;}
-  void setCovariance(int i,int j, float val) {_covariance[i][j] = val;}
+  float getCovariance(int i,int j) const {return _covariance[i][j];}
+  void  setCovariance(int i,int j, float val) {_covariance[i][j] = val;}
 
   void  set_cal_dphi(CAL_LAYER layer, float dphi) {_cal_dphi[layer] = dphi;}
   float get_cal_dphi(CAL_LAYER layer) const;

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -15,8 +15,8 @@ class SvtxTrack : public PHObject {
   enum CAL_LAYER {PRES,CEMC,HCALIN,HCALOUT};
 
   SvtxTrack();
-  SvtxTrack(SvtxTrack *track);
-  SvtxTrack(const SvtxTrack& track);
+  //SvtxTrack(SvtxTrack *track);
+  //SvtxTrack(const SvtxTrack& track);
   virtual ~SvtxTrack() {};
   
   // The "standard PHObject response" functions...

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -5,8 +5,7 @@
 #include <TMatrix.h>
 #include <iostream>
 
-class SvtxTrack : public PHObject
-{
+class SvtxTrack : public PHObject {
   
  public:
 
@@ -76,8 +75,21 @@ class SvtxTrack : public PHObject
   float getDCA2Dsigma() const;
 
   float getInnerMostHitPosition(int coor) const;
+
+  void  set_phi(float phi) {_phi = phi;}
+  float get_phi() const {return _phi;}
+
+  void  set_d(float d) {_d = d;}
+  float get_d() const {return _d;}
   
-  float phi,d,kappa,z0,dzdl;
+  void  set_kappa(float kappa) {_kappa = kappa;}
+  float get_kappa() const {return _kappa;}
+    
+  void set_z0(float z0) {_z0 = z0;}
+  float get_z0() const {return _z0;}
+
+  void  set_dzdl(float dzdl) {_dzdl = dzdl;}
+  float get_dzdl() const {return _dzdl;}
   
   const TMatrix* getCovariance() const {return &covariance;}
   TMatrix* getCovariance() {return &covariance;}
@@ -105,10 +117,11 @@ class SvtxTrack : public PHObject
   float get_z() const{return z;}
   void set_z(float val){z = val;}
 
- protected:
+ private: 
 
-  int     clusterID[100];
   int     trackID;
+  float   _phi,_d,_kappa,_z0,_dzdl;
+  int     clusterID[100];
   float   position[100][3];
   float   momentum;
   float   mom3[3];

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -285,7 +285,7 @@ class SvtxTrack : public PHObject {
   // without the cluster uncertainties... maybe we should eliminate
   // this member for further storage gains (and use the ids to fetch the clusters
   // for remaking the fits)
-  // we will first need to replace the public projection method to use and outer
+  // we will first need to replace the public projection method to use an outer
   // state vector instead of the hit postion
   std::map<int,std::vector<float> > _cluster_positions; //< layer index => (x,y,z)
   

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -79,8 +79,8 @@ class SvtxTrack : public PHObject {
   typedef std::map<float,SvtxTrack::State>::const_iterator ConstStateIter;
   typedef std::map<float,SvtxTrack::State>::iterator       StateIter; 
   
-  typedef std::set<unsigned int>::const_iterator ConstClusterIter;
-  typedef std::set<unsigned int>::iterator       ClusterIter; 
+  typedef std::set<unsigned int>::const_iterator         ConstClusterIter;
+  typedef std::set<unsigned int>::iterator               ClusterIter;
   
   enum CAL_LAYER {PRES=0,CEMC=1,HCALIN=2,HCALOUT=3};
 
@@ -91,22 +91,6 @@ class SvtxTrack : public PHObject {
   void identify(std::ostream &os=std::cout) const;
   void Reset();
   int  isValid() const;
-
-  //---old interface------- 
-
-  void setHitPosition(int layer, float x, float y, float z) {
-    std::vector<float> position(3);
-    position[0] = x;
-    position[1] = y;
-    position[2] = z;
-    _cluster_positions[layer] = position;
-  }
-  float getHitPosition(int layer, int coor) const;
-
-  float getInnerMostHitPosition(int coor) const;
-  float getOuterMostHitPosition(int coor) const;
-  
-  //---revised interface------
 
   unsigned int get_id() const          {return _track_id;}
   void         set_id(unsigned int id) {_track_id = id;}
@@ -192,33 +176,32 @@ class SvtxTrack : public PHObject {
         State* insert_state(const State &state);
         size_t erase_state(float pathlength) {return _states.erase(pathlength);}
 
-  ConstStateIter begin()                 const {return _states.begin();}
-  ConstStateIter  find(float pathlength) const {return _states.find(pathlength);}
-  ConstStateIter   end()                 const {return _states.end();}
+  ConstStateIter begin_states()                const {return _states.begin();}
+  ConstStateIter  find_state(float pathlength) const {return _states.find(pathlength);}
+  ConstStateIter   end_states()                const {return _states.end();}
 
-  StateIter begin()                 {return _states.begin();}
-  StateIter  find(float pathlength) {return _states.find(pathlength);}
-  StateIter   end()                 {return _states.end();}
+  StateIter begin_states()                {return _states.begin();}
+  StateIter  find_state(float pathlength) {return _states.find(pathlength);}
+  StateIter   end_states()                {return _states.end();}
     
   //
   // associated cluster ids methods
   //
-  void             clear_clusters()                           {_cluster_ids.clear();}
-  bool             empty_clusters() const                     {return _cluster_ids.empty();}
-  size_t           size_clusters() const                      {return _cluster_ids.size();}
-  void             insert_cluster(unsigned int clusterid)     {_cluster_ids.insert(clusterid);}
-  size_t           erase_cluster(unsigned int clusterid)      {return _cluster_ids.erase(clusterid);}
-  ConstClusterIter begin_clusters() const                     {return _cluster_ids.begin();}
-  ConstClusterIter find_cluster(unsigned int clusterid) const {return _cluster_ids.find(clusterid);}
-  ConstClusterIter end_clusters() const                       {return _cluster_ids.end();}
-  ClusterIter      begin_clusters()                           {return _cluster_ids.begin();}
-  ClusterIter      find_cluster(unsigned int clusterid)       {return _cluster_ids.find(clusterid);}
-  ClusterIter      end_clusters()                             {return _cluster_ids.end();}
+  void                clear_clusters()                           {_cluster_ids.clear();}
+  bool                empty_clusters() const                     {return _cluster_ids.empty();}
+  size_t              size_clusters() const                      {return _cluster_ids.size();}
+  void                insert_cluster(unsigned int clusterid)     {_cluster_ids.insert(clusterid);}
+  size_t              erase_cluster(unsigned int clusterid)      {return _cluster_ids.erase(clusterid);}
+  ConstClusterIter    begin_clusters() const                     {return _cluster_ids.begin();}
+  ConstClusterIter    find_cluster(unsigned int clusterid) const {return _cluster_ids.find(clusterid);}
+  ConstClusterIter    end_clusters() const                       {return _cluster_ids.end();}
+  ClusterIter         begin_clusters()                           {return _cluster_ids.begin();}
+  ClusterIter         find_cluster(unsigned int clusterid)       {return _cluster_ids.find(clusterid);}
+  ClusterIter         end_clusters()                             {return _cluster_ids.end();}
 
   //
   // calo projection methods
   //
-  
   void  set_cal_energy_3x3(CAL_LAYER layer, float energy_3x3);
   float get_cal_energy_3x3(CAL_LAYER layer) const;
 
@@ -286,14 +269,6 @@ class SvtxTrack : public PHObject {
   
   // cluster contents
   std::set<unsigned int> _cluster_ids;
-  
-  // the cluster positions aren't really useful on their own
-  // without the cluster uncertainties... maybe we should eliminate
-  // this member for further storage gains (and use the ids to fetch the clusters
-  // for remaking the fits)
-  // we will first need to replace the public projection method to use an outer
-  // state vector instead of the hit postion
-  std::map<int,std::vector<float> > _cluster_positions; //< layer index => (x,y,z)
   
   // calorimeter matches
   std::map<CAL_LAYER,SvtxTrack::CaloProjection> _calo_matches;

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -69,8 +69,12 @@ class SvtxTrack : public PHObject {
   void setPositive(bool prim) {_is_positive_charge = prim;}
   bool getPositive() const {return _is_positive_charge;}
 
-  void setPrimary(bool prim) {}
-  bool getPrimary() const {return false;}
+  void setPrimary(bool prim) {
+    std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
+  }
+  bool getPrimary() const {
+    return false;
+  }
   
   //void setNhits(int layer, short n);
   short getNhits() const;
@@ -154,19 +158,33 @@ class SvtxTrack : public PHObject {
   float   _chisq;
   int     _ndf;
 
+  // extended track information (non-primary tracks only)
   float   _DCA;
   float   _DCA2D;
   float   _DCA2Dsigma;
 
+  // extended track information (primary tracks only)
+  // unsigned int _vertex_id;
+  
   // projection information
+  // replace with a set/map of track state vectors
   float   _phi,_d,_kappa,_z0,_dzdl;
   float   _momentum;
   float   _mom3[3];
-  float   _x,_y,_z; 
+  float   _x,_y,_z;
+
+  // ROOT adds a lot of overhead, and will get worse if we store multiple state
+  // vectors, we should replace this with a raw type like a triangular
+  // vector implementation std::vector<std::vector<float> > _covariance;
   TMatrix _covariance;
   
   // cluster contents
-  std::map<int,int> _cluster_ids;                       //< layer index => cluster id
+  std::map<int,int> _cluster_ids; //< layer index => cluster id
+
+  // the cluster positions aren't really useful on their own
+  // without the cluster uncertainties... maybe we should eliminate
+  // this member for further storage gains (and use the ids to fetch the clusters
+  // for remaking the fits)
   std::map<int,std::vector<float> > _cluster_positions; //< layer index => (x,y,z)
   
   // calorimeter matches

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -185,6 +185,8 @@ class SvtxTrack : public PHObject {
   // without the cluster uncertainties... maybe we should eliminate
   // this member for further storage gains (and use the ids to fetch the clusters
   // for remaking the fits)
+  // we will first need to replace the public projection method to use and outer
+  // state vector instead of the hit postion
   std::map<int,std::vector<float> > _cluster_positions; //< layer index => (x,y,z)
   
   // calorimeter matches

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -28,12 +28,13 @@ class SvtxTrack : public PHObject {
   
   void setClusterID(int layer, int index) {_cluster_ids[layer] = index;}
   int getClusterID(int layer) const {return _cluster_ids.find(layer)->second;}
-  bool hasCluster(int layer) const {
-    return (_cluster_ids.find(layer) != _cluster_ids.end());
-  }
+  bool hasCluster(int layer) const {return (_cluster_ids.find(layer) != _cluster_ids.end());}
   
-  void setScatter(int layer, float sct) {_scatter[layer] = sct;}
-  float getScatter(int layer) const {return _scatter[layer];}
+  void setScatter(int layer, float sct) {
+    std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
+    exit(-1);
+  }
+  float getScatter(int layer) const {return NAN;}
   
   void setHitPosition(int layer, float x, float y, float z) {
     _position[layer][0]=x;
@@ -55,11 +56,11 @@ class SvtxTrack : public PHObject {
   void setCharge(int c) {_charge = c;}
   int getCharge() const {return _charge;}
   
-  void setPrimary(bool prim) {}
-  bool getPrimary() const {return false;}
-  
   void setPositive(bool prim) {_ispositive = prim;}
   bool getPositive() const {return _ispositive;}
+
+  void setPrimary(bool prim) {}
+  bool getPrimary() const {return false;}
   
   //void setNhits(int layer, short n);
   short getNhits() const;
@@ -143,7 +144,6 @@ class SvtxTrack : public PHObject {
   float   _DCA;
   float   _DCA2D;
   float   _DCA2Dsigma;
-  float   _scatter[100];
   float   _x,_y,_z;
   
   TMatrix _covariance;

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -45,21 +45,6 @@ class SvtxTrack : public PHObject {
     float get_error(unsigned int i, unsigned int j) const;                    //
     void  set_error(unsigned int i, unsigned int j, float value);             //
                                                                               //
-    float get_helix_phi() const {return _helix_phi;}                          //
-    void  set_helix_phi(float helix_phi) {_helix_phi = helix_phi;}            //
-                                                                              //
-    float get_helix_d() const {return _helix_d;}                              //
-    void  set_helix_d(float d) {_helix_d = d;}                                //
-                                                                              //
-    float get_helix_kappa() const {return _helix_kappa;}                      //
-    void  set_helix_kappa(float kappa) {_helix_kappa = kappa;}                //
-                                                                              //
-    float get_helix_z0() const {return _helix_z0;}                            //
-    void  set_helix_z0(float z0) {_helix_z0 = z0;}                            //
-                                                                              //
-    float get_helix_dzdl() const {return _helix_dzdl;}                        //
-    void  set_helix_dzdl(float dzdl) {_helix_dzdl = dzdl;}                    //
-                                                                              //
   private:                                                                    //
                                                                               //
     unsigned int covar_index(unsigned int i, unsigned int j) const;           //
@@ -68,11 +53,6 @@ class SvtxTrack : public PHObject {
     float _pos[3];                                                            //
     float _mom[3];                                                            //
     float _covar[21]; // 6x6 triangular packed storage                        //
-    float _helix_phi;                                                         //
-    float _helix_d;                                                           //
-    float _helix_kappa;                                                       //
-    float _helix_z0;                                                          //
-    float _helix_dzdl;                                                        //
   };                                                                          //
   // --- inner State class ---------------------------------------------------//
  
@@ -92,6 +72,10 @@ class SvtxTrack : public PHObject {
   void Reset();
   int  isValid() const;
 
+  //
+  // basic track information ---------------------------------------------------
+  //
+  
   unsigned int get_id() const          {return _track_id;}
   void         set_id(unsigned int id) {_track_id = id;}
 
@@ -148,23 +132,8 @@ class SvtxTrack : public PHObject {
   float get_error(int i, int j) const {return _states.find(0.0)->second.get_error(i,j);}
   void  set_error(int i, int j, float value) {return _states[0.0].set_error(i,j,value);}
 
-  float get_helix_phi() const {return _states.find(0.0)->second.get_helix_phi();}  
-  void  set_helix_phi(float phi) {_states[0.0].set_helix_phi(phi);}
-
-  float get_helix_d() const {return _states.find(0.0)->second.get_helix_d();}
-  void  set_helix_d(float d) {_states[0.0].set_helix_d(d);}
-
-  float get_helix_kappa() const {return _states.find(0.0)->second.get_helix_kappa();}  
-  void  set_helix_kappa(float kappa) {_states[0.0].set_helix_kappa(kappa);}
-
-  float get_helix_z0() const {return _states.find(0.0)->second.get_helix_z0();}    
-  void  set_helix_z0(float z0) {_states[0.0].set_helix_z0(z0);}
-
-  float get_helix_dzdl() const {return _states.find(0.0)->second.get_helix_dzdl();}    
-  void  set_helix_dzdl(float dzdl) {_states[0.0].set_helix_dzdl(dzdl);}
-
   //
-  // state methods
+  // state methods -------------------------------------------------------------
   //
   bool   empty_states()                 const {return _states.empty();}
   size_t size_states()                  const {return _states.size();}
@@ -192,7 +161,7 @@ class SvtxTrack : public PHObject {
   StateIter   end_states()                {return _states.end();}
     
   //
-  // associated cluster ids methods
+  // associated cluster ids methods --------------------------------------------
   //
   void                clear_clusters()                           {_cluster_ids.clear();}
   bool                empty_clusters() const                     {return _cluster_ids.empty();}
@@ -207,7 +176,7 @@ class SvtxTrack : public PHObject {
   ClusterIter         end_clusters()                             {return _cluster_ids.end();}
 
   //
-  // calo projection methods
+  // calo projection methods ---------------------------------------------------
   //
   void  set_cal_energy_3x3(CAL_LAYER layer, float energy_3x3);
   float get_cal_energy_3x3(CAL_LAYER layer) const;
@@ -226,7 +195,6 @@ class SvtxTrack : public PHObject {
   
  private: 
 
-  // keep it private for now to minimize interface changes
   // --- inner CaloProjection class ------------------------------------------//
   class CaloProjection {                                                      //
   public:                                                                     //

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -78,8 +78,11 @@ class SvtxTrack : public PHObject {
   //void setNhits(int layer, short n);
   short getNhits() const;
   
-  void setQuality(float q) {_quality = q;}
-  float getQuality() const {return _quality;}
+  void setQuality(float q) {}
+  float getQuality() const {
+    if (_ndf!=0) return _chisq/_ndf;
+    return NAN;
+  }
 
   void setChisq(float q) {_chisq = q;}
   float getChisq() const {return _chisq;}
@@ -148,6 +151,13 @@ class SvtxTrack : public PHObject {
   float get_z() const  {return _z;}
   void  set_z(float z) {_z = z;}
 
+  // add convience calculations
+  //float get_eta() const;
+  //float get_theta() const;
+  //float get_phi() const;
+  //float get_pt() const;
+  //float get_p() const;
+
  private: 
 
   // keep these private for now
@@ -158,7 +168,7 @@ class SvtxTrack : public PHObject {
   // track information
   unsigned int _track_id;
   bool         _is_positive_charge;
-  float        _quality;
+  //float        _quality;
   float        _chisq;
   unsigned int _ndf;
 

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -39,11 +39,13 @@ class SvtxTrack : public PHObject {
   }
   
   void setHitPosition(int layer, float x, float y, float z) {
-    _position[layer][0]=x;
-    _position[layer][1]=y;
-    _position[layer][2]=z;
+    std::vector<float> position(3);
+    position[0] = x;
+    position[1] = y;
+    position[2] = z;
+    _cluster_positions[layer] = position;
   }
-  float getHitPosition(int layer, int coor) const {return _position[layer][coor];}
+  float getHitPosition(int layer, int coor) const;
 
   void setMomentum(float p) {_momentum = p;}
   float getMomentum() const {return _momentum;}
@@ -148,17 +150,15 @@ class SvtxTrack : public PHObject {
 
   // projection information
   float   _phi,_d,_kappa,_z0,_dzdl;
-  float   _position[100][3];
   float   _momentum;
   float   _mom3[3];
-
-  float   _x,_y,_z;
-  
+  float   _x,_y,_z; 
   TMatrix _covariance;
   
-  // cluster ids
-  std::map<int,int> _cluster_ids; //< layer index => cluster id
-
+  // cluster contents
+  std::map<int,int> _cluster_ids;                       //< layer index => cluster id
+  std::map<int,std::vector<float> > _cluster_positions; //< layer index => (x,y,z)
+  
   // calorimeter matches
   std::map<CAL_LAYER,float> _cal_dphi;
   std::map<CAL_LAYER,float> _cal_deta;

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -26,9 +26,11 @@ class SvtxTrack : public PHObject {
   void setTrackID(int index){_track_id = index;}
   int getTrackID() const {return _track_id;}  
   
-  void setClusterID(int layer, int index) {_clusterID[layer] = index;}
-  int getClusterID(int layer) const {return _clusterID[layer];}
-  bool hasCluster(int layer) const {return (_clusterID[layer] >- 9999);}
+  void setClusterID(int layer, int index) {_cluster_ids[layer] = index;}
+  int getClusterID(int layer) const {return _cluster_ids.find(layer)->second;}
+  bool hasCluster(int layer) const {
+    return (_cluster_ids.find(layer) != _cluster_ids.end());
+  }
   
   void setScatter(int layer, float sct) {_scatter[layer] = sct;}
   float getScatter(int layer) const {return _scatter[layer];}
@@ -129,7 +131,6 @@ class SvtxTrack : public PHObject {
 
   int     _track_id;
   float   _phi,_d,_kappa,_z0,_dzdl;
-  int     _clusterID[100];
   float   _position[100][3];
   float   _momentum;
   float   _mom3[3];
@@ -155,7 +156,8 @@ class SvtxTrack : public PHObject {
   float   _cal_cluster_e[4];
 
   // cluster ids
-  //std::multimap<unsigned int,unsigned int> _cluster_ids; //< layer index => cluster id
+  //int     _clusterID[100];
+  std::map<int,int> _cluster_ids; //< layer index => cluster id
   
   ClassDef(SvtxTrack,1)
 };

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -21,15 +21,13 @@ class SvtxTrack : public PHObject {
   void Reset();
   int  isValid() const;
 
-  //---old interface-------
-  
-  void setTrackID(int index){_track_id = index;}
-  int getTrackID() const {return _track_id;}  
+  //---old interface------- 
 
   bool hasCluster(int layer) const {return (_cluster_ids.find(layer) != _cluster_ids.end());}
   void setClusterID(int layer, int index) {_cluster_ids[layer] = index;}
   int getClusterID(int layer) const {return _cluster_ids.find(layer)->second;}
-  
+
+  short getNhits() const;
   void setHitPosition(int layer, float x, float y, float z) {
     std::vector<float> position(3);
     position[0] = x;
@@ -39,64 +37,8 @@ class SvtxTrack : public PHObject {
   }
   float getHitPosition(int layer, int coor) const;
 
-  void setMomentum(float p) {}
-  float getMomentum() const {
-    float px = _states.find(0.0)->second.get_px();
-    float py = _states.find(0.0)->second.get_py();
-    float pz = _states.find(0.0)->second.get_pz();
-    return sqrt(pow(px,2)+pow(py,2)+pow(pz,2));
-  }
-  
-  void set3Momentum(float px, float py, float pz) {
-    _states[0.0].set_px(px);
-    _states[0.0].set_py(py);
-    _states[0.0].set_pz(pz);
-  };
-  float get3Momentum(int coor) const {
-    return _states.find(0.0)->second.get_mom(coor);
-  }
-  
-  void setCharge(int c) {
-    if (c > 0) setPositive(true);
-    else setPositive(false);
-  }
-  int getCharge() const {
-    if (getPositive()) return +1;
-    else return -1;
-  }
-  
-  void setPositive(bool prim) {_is_positive_charge = prim;}
-  bool getPositive() const {return _is_positive_charge;}
-  
-  //void setNhits(int layer, short n);
-  short getNhits() const;
-  
-  void setQuality(float q) {}
-  float getQuality() const {
-    if (_ndf!=0) return _chisq/_ndf;
-    return NAN;
-  }
-
-  void setChisq(float q) {_chisq = q;}
-  float getChisq() const {return _chisq;}
-
-  void setNDF(int q) {_ndf = q;}
-  int  getNDF() const {return _ndf;}
-
-  void  setDCA(float d) {_DCA = d;}
-  float getDCA() const {return _DCA;}
-
-  void  setDCA2D(float d) {_DCA2D = d;}
-  float getDCA2D() const {return _DCA2D;}
-  
-  void  setDCA2Dsigma(float s) {_DCA2Dsigma = s;}
-  float getDCA2Dsigma() const {return _DCA2Dsigma;}
-
   float getInnerMostHitPosition(int coor) const;
-
-  float getCovariance(int i,int j) const {return get_error(i,j);}
-  void  setCovariance(int i,int j, float val) {set_error(i,j,val);}
-
+  
   void  set_cal_energy_3x3(CAL_LAYER layer, float energy_3x3);
   float get_cal_energy_3x3(CAL_LAYER layer) const;
 
@@ -116,7 +58,30 @@ class SvtxTrack : public PHObject {
 
   unsigned int get_id() const          {return _track_id;}
   void         set_id(unsigned int id) {_track_id = id;}
-  
+
+  bool get_positive_charge() const {return _is_positive_charge;}
+  void set_positive_charge(bool ispos) {_is_positive_charge = ispos;}
+
+  int  get_charge() const {return (get_positive_charge()) ? 1 : -1;}
+  void set_charge(int charge) {(charge > 0) ? set_positive_charge(true) : set_positive_charge(false);}
+
+  float get_chisq() const {return _chisq;}  
+  void  set_chisq(float chisq) {_chisq = chisq;}
+
+  unsigned int get_ndf() const {return _ndf;}
+  void         set_ndf(int ndf) {_ndf = ndf;}
+
+  float get_quality() const {return (_ndf != 0) ? _chisq/_ndf : NAN;}
+
+  float get_dca() const {return _dca;}
+  void  set_dca(float dca) {_dca = dca;}
+
+  float get_dca2d() const {return _dca2d;}  
+  void  set_dca2d(float dca2d) {_dca2d = dca2d;}
+
+  float get_dca2d_error() const {return _dca2d_error;}  
+  void  set_dca2d_error(float error) {_dca2d_error = error;}
+
   float get_x() const  {return _states.find(0.0)->second.get_x();}
   void  set_x(float x) {_states[0.0].set_x(x);}
   
@@ -144,20 +109,23 @@ class SvtxTrack : public PHObject {
   float get_eta() const {return asinh(get_pz()/get_pt());}
   float get_phi() const {return atan2(get_py(),get_px());}
 
+  float get_error(int i, int j) const {return _states.find(0.0)->second.get_error(i,j);}
+  void  set_error(int i, int j, float value) {return _states[0.0].set_error(i,j,value);}
+
+  float get_helix_phi() const {return _states.find(0.0)->second.get_helix_phi();}  
   void  set_helix_phi(float phi) {_states[0.0].set_helix_phi(phi);}
-  float get_helix_phi() const {return _states.find(0.0)->second.get_helix_phi();}
-    
-  void  set_helix_d(float d) {_states[0.0].set_helix_d(d);}
+
   float get_helix_d() const {return _states.find(0.0)->second.get_helix_d();}
-  
+  void  set_helix_d(float d) {_states[0.0].set_helix_d(d);}
+
+  float get_helix_kappa() const {return _states.find(0.0)->second.get_helix_kappa();}  
   void  set_helix_kappa(float kappa) {_states[0.0].set_helix_kappa(kappa);}
-  float get_helix_kappa() const {return _states.find(0.0)->second.get_helix_kappa();}
-    
+
+  float get_helix_z0() const {return _states.find(0.0)->second.get_helix_z0();}    
   void  set_helix_z0(float z0) {_states[0.0].set_helix_z0(z0);}
-  float get_helix_z0() const {return _states.find(0.0)->second.get_helix_z0();}
-    
+
+  float get_helix_dzdl() const {return _states.find(0.0)->second.get_helix_dzdl();}    
   void  set_helix_dzdl(float dzdl) {_states[0.0].set_helix_dzdl(dzdl);}
-  float get_helix_dzdl() const {return _states.find(0.0)->second.get_helix_dzdl();}
   
  private: 
 
@@ -193,20 +161,20 @@ class SvtxTrack : public PHObject {
     float get_error(unsigned int i, unsigned int j) const;                    //
     void  set_error(unsigned int i, unsigned int j, float value);             //
                                                                               //
-    void  set_helix_phi(float helix_phi) {_helix_phi = helix_phi;}            //
     float get_helix_phi() const {return _helix_phi;}                          //
+    void  set_helix_phi(float helix_phi) {_helix_phi = helix_phi;}            //
                                                                               //
-    void  set_helix_d(float d) {_helix_d = d;}                                //
     float get_helix_d() const {return _helix_d;}                              //
+    void  set_helix_d(float d) {_helix_d = d;}                                //
                                                                               //
-    void  set_helix_kappa(float kappa) {_helix_kappa = kappa;}                //
     float get_helix_kappa() const {return _helix_kappa;}                      //
+    void  set_helix_kappa(float kappa) {_helix_kappa = kappa;}                //
                                                                               //
-    void  set_helix_z0(float z0) {_helix_z0 = z0;}                            //
     float get_helix_z0() const {return _helix_z0;}                            //
+    void  set_helix_z0(float z0) {_helix_z0 = z0;}                            //
                                                                               //
-    void  set_helix_dzdl(float dzdl) {_helix_dzdl = dzdl;}                    //
     float get_helix_dzdl() const {return _helix_dzdl;}                        //
+    void  set_helix_dzdl(float dzdl) {_helix_dzdl = dzdl;}                    //
                                                                               //
   private:                                                                    //
                                                                               //
@@ -223,11 +191,11 @@ class SvtxTrack : public PHObject {
   };                                                                          //
   // --- inner State class ---------------------------------------------------//
 
-  // --- inner CaloMatch class -----------------------------------------------//
-  class CaloMatch {                                                           //
+  // --- inner CaloProjection class ------------------------------------------//
+  class CaloProjection {                                                      //
   public:                                                                     //
-    CaloMatch();                                                              //
-    virtual ~CaloMatch() {}                                                   //
+    CaloProjection();                                                         //
+    virtual ~CaloProjection() {}                                              //
                                                                               //
     float get_energy_3x3() const {return _e3x3;}                              //
     void  set_energy_3x3(float e3x3) {_e3x3 = e3x3;}                          //
@@ -251,12 +219,7 @@ class SvtxTrack : public PHObject {
     float _dphi;                                                              //
     float _clus_e;                                                            //
   };                                                                          //
-  // --- inner CaloMatch class -----------------------------------------------//
-  
-  // keep these private for now
-  // attempting ~zero interface changes during refactor
-  float get_error(int i, int j) const {return _states.find(0.0)->second.get_error(i,j);}
-  void  set_error(int i, int j, float value) {return _states[0.0].set_error(i,j,value);}
+  // --- inner CaloProjection class ------------------------------------------//
   
   // track information
   unsigned int _track_id;
@@ -265,9 +228,9 @@ class SvtxTrack : public PHObject {
   unsigned int _ndf;
 
   // extended track information (non-primary tracks only)
-  float _DCA;
-  float _DCA2D;
-  float _DCA2Dsigma;
+  float _dca;
+  float _dca2d;
+  float _dca2d_error;
 
   // extended track information (primary tracks only)
   // unsigned int _vertex_id;
@@ -287,7 +250,7 @@ class SvtxTrack : public PHObject {
   std::map<int,std::vector<float> > _cluster_positions; //< layer index => (x,y,z)
   
   // calorimeter matches
-  std::map<CAL_LAYER,SvtxTrack::CaloMatch> _calo_matches;
+  std::map<CAL_LAYER,SvtxTrack::CaloProjection> _calo_matches;
   
   ClassDef(SvtxTrack,1)
 };

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -4,6 +4,7 @@
 #include <phool/PHObject.h>
 
 #include <iostream>
+#include <set>
 #include <map>
 #include <cmath>
 
@@ -11,6 +12,9 @@ class SvtxTrack : public PHObject {
   
  public:
 
+  typedef std::set<unsigned int>::const_iterator ConstClusterIter;
+  typedef std::set<unsigned int>::iterator       ClusterIter; 
+  
   enum CAL_LAYER {PRES=0,CEMC=1,HCALIN=2,HCALOUT=3};
 
   SvtxTrack();
@@ -23,11 +27,12 @@ class SvtxTrack : public PHObject {
 
   //---old interface------- 
 
-  bool hasCluster(int layer) const {return (_cluster_ids.find(layer) != _cluster_ids.end());}
-  void setClusterID(int layer, int index) {_cluster_ids[layer] = index;}
-  int getClusterID(int layer) const {return _cluster_ids.find(layer)->second;}
+  //bool hasCluster(int layer) const {return (_cluster_ids.find(layer) != _cluster_ids.end());}
+  //void setClusterID(int layer, int index) {_cluster_ids[layer] = index;}
+  //int getClusterID(int layer) const {return _cluster_ids.find(layer)->second;}
 
-  short getNhits() const;
+  //unsigned int getNhits() const {return _cluster_ids.size();}
+
   void setHitPosition(int layer, float x, float y, float z) {
     std::vector<float> position(3);
     position[0] = x;
@@ -38,23 +43,9 @@ class SvtxTrack : public PHObject {
   float getHitPosition(int layer, int coor) const;
 
   float getInnerMostHitPosition(int coor) const;
+  float getOuterMostHitPosition(int coor) const;
   
-  void  set_cal_energy_3x3(CAL_LAYER layer, float energy_3x3);
-  float get_cal_energy_3x3(CAL_LAYER layer) const;
-
-  void         set_cal_cluster_id(CAL_LAYER layer, unsigned int id);
-  unsigned int get_cal_cluster_id(CAL_LAYER layer) const;
-  
-  void  set_cal_dphi(CAL_LAYER layer, float dphi);
-  float get_cal_dphi(CAL_LAYER layer) const;
-
-  void  set_cal_deta(CAL_LAYER layer, float deta);
-  float get_cal_deta(CAL_LAYER layer) const;
-
-  void  set_cal_cluster_e(CAL_LAYER layer, float e);
-  float get_cal_cluster_e(CAL_LAYER layer) const;
-
-  //---new interface------
+  //---revised interface------
 
   unsigned int get_id() const          {return _track_id;}
   void         set_id(unsigned int id) {_track_id = id;}
@@ -126,6 +117,44 @@ class SvtxTrack : public PHObject {
 
   float get_helix_dzdl() const {return _states.find(0.0)->second.get_helix_dzdl();}    
   void  set_helix_dzdl(float dzdl) {_states[0.0].set_helix_dzdl(dzdl);}
+
+  //
+  // state methods
+  //
+  
+  //
+  // associated cluster ids methods
+  //
+  void             clear_clusters()                           {_cluster_ids.clear();}
+  bool             empty_clusters() const                     {return _cluster_ids.empty();}
+  size_t           size_clusters() const                      {return _cluster_ids.size();}
+  void             insert_cluster(unsigned int clusterid)     {_cluster_ids.insert(clusterid);}
+  size_t           erase_cluster(unsigned int clusterid)      {return _cluster_ids.erase(clusterid);}
+  ConstClusterIter begin_clusters() const                     {return _cluster_ids.begin();}
+  ConstClusterIter find_cluster(unsigned int clusterid) const {return _cluster_ids.find(clusterid);}
+  ConstClusterIter end_clusters() const                       {return _cluster_ids.end();}
+  ClusterIter      begin_clusters()                           {return _cluster_ids.begin();}
+  ClusterIter      find_cluster(unsigned int clusterid)       {return _cluster_ids.find(clusterid);}
+  ClusterIter      end_clusters()                             {return _cluster_ids.end();}
+
+  //
+  // calo projection methods
+  //
+  
+  void  set_cal_energy_3x3(CAL_LAYER layer, float energy_3x3);
+  float get_cal_energy_3x3(CAL_LAYER layer) const;
+
+  void         set_cal_cluster_id(CAL_LAYER layer, unsigned int id);
+  unsigned int get_cal_cluster_id(CAL_LAYER layer) const;
+  
+  void  set_cal_dphi(CAL_LAYER layer, float dphi);
+  float get_cal_dphi(CAL_LAYER layer) const;
+
+  void  set_cal_deta(CAL_LAYER layer, float deta);
+  float get_cal_deta(CAL_LAYER layer) const;
+
+  void  set_cal_cluster_e(CAL_LAYER layer, float e);
+  float get_cal_cluster_e(CAL_LAYER layer) const;
   
  private: 
 
@@ -239,8 +268,8 @@ class SvtxTrack : public PHObject {
   std::map<float,SvtxTrack::State> _states; //< path length => state object
   
   // cluster contents
-  std::map<int,unsigned int> _cluster_ids; //< layer index => cluster id
-
+  std::set<unsigned int> _cluster_ids;
+  
   // the cluster positions aren't really useful on their own
   // without the cluster uncertainties... maybe we should eliminate
   // this member for further storage gains (and use the ids to fetch the clusters

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -29,14 +29,6 @@ class SvtxTrack : public PHObject {
   bool hasCluster(int layer) const {return (_cluster_ids.find(layer) != _cluster_ids.end());}
   void setClusterID(int layer, int index) {_cluster_ids[layer] = index;}
   int getClusterID(int layer) const {return _cluster_ids.find(layer)->second;}
-    
-  void setScatter(int layer, float sct) {
-    std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
-  }
-  float getScatter(int layer) const {
-    std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
-    return NAN;
-  }
   
   void setHitPosition(int layer, float x, float y, float z) {
     std::vector<float> position(3);
@@ -75,13 +67,6 @@ class SvtxTrack : public PHObject {
   
   void setPositive(bool prim) {_is_positive_charge = prim;}
   bool getPositive() const {return _is_positive_charge;}
-
-  void setPrimary(bool prim) {
-    std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
-  }
-  bool getPrimary() const {
-    return false;
-  }
   
   //void setNhits(int layer, short n);
   short getNhits() const;
@@ -94,14 +79,6 @@ class SvtxTrack : public PHObject {
 
   void setChisq(float q) {_chisq = q;}
   float getChisq() const {return _chisq;}
-
-  void setChisqv(float q) {
-    std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
-  }
-  float getChisqv() const {
-    std::cout << "SvtxTrack:: ERROR - deprecated interface call" << std::endl;
-    return NAN;
-  }
 
   void setNDF(int q) {_ndf = q;}
   int  getNDF() const {return _ndf;}
@@ -117,21 +94,6 @@ class SvtxTrack : public PHObject {
 
   float getInnerMostHitPosition(int coor) const;
 
-  void  set_helix_phi(float phi) {_states[0.0].set_helix_phi(phi);}
-  float get_helix_phi() const {return _states.find(0.0)->second.get_helix_phi();}
-    
-  void  set_helix_d(float d) {_states[0.0].set_helix_d(d);}
-  float get_helix_d() const {return _states.find(0.0)->second.get_helix_d();}
-  
-  void  set_helix_kappa(float kappa) {_states[0.0].set_helix_kappa(kappa);}
-  float get_helix_kappa() const {return _states.find(0.0)->second.get_helix_kappa();}
-    
-  void  set_helix_z0(float z0) {_states[0.0].set_helix_z0(z0);}
-  float get_helix_z0() const {return _states.find(0.0)->second.get_helix_z0();}
-    
-  void  set_helix_dzdl(float dzdl) {_states[0.0].set_helix_dzdl(dzdl);}
-  float get_helix_dzdl() const {return _states.find(0.0)->second.get_helix_dzdl();}
-  
   float getCovariance(int i,int j) const {return get_error(i,j);}
   void  setCovariance(int i,int j, float val) {set_error(i,j,val);}
 
@@ -180,7 +142,22 @@ class SvtxTrack : public PHObject {
   float get_p() const   {return sqrt(pow(get_px(),2) + pow(get_py(),2) + pow(get_pz(),2));}
   float get_pt() const  {return sqrt(pow(get_px(),2) + pow(get_py(),2));}
   float get_eta() const {return asinh(get_pz()/get_pt());}
-  //float get_phi() const {return atan2(get_py(),get_px());}
+  float get_phi() const {return atan2(get_py(),get_px());}
+
+  void  set_helix_phi(float phi) {_states[0.0].set_helix_phi(phi);}
+  float get_helix_phi() const {return _states.find(0.0)->second.get_helix_phi();}
+    
+  void  set_helix_d(float d) {_states[0.0].set_helix_d(d);}
+  float get_helix_d() const {return _states.find(0.0)->second.get_helix_d();}
+  
+  void  set_helix_kappa(float kappa) {_states[0.0].set_helix_kappa(kappa);}
+  float get_helix_kappa() const {return _states.find(0.0)->second.get_helix_kappa();}
+    
+  void  set_helix_z0(float z0) {_states[0.0].set_helix_z0(z0);}
+  float get_helix_z0() const {return _states.find(0.0)->second.get_helix_z0();}
+    
+  void  set_helix_dzdl(float dzdl) {_states[0.0].set_helix_dzdl(dzdl);}
+  float get_helix_dzdl() const {return _states.find(0.0)->second.get_helix_dzdl();}
   
  private: 
 

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -53,8 +53,8 @@ class SvtxTrack : public PHObject {
   void setCharge(int c) {_charge = c;}
   int getCharge() const {return _charge;}
   
-  void setPrimary(bool prim) {_isprimary = prim;}
-  bool getPrimary() const {return _isprimary;}
+  void setPrimary(bool prim) {}
+  bool getPrimary() const {return false;}
   
   void setPositive(bool prim) {_ispositive = prim;}
   bool getPositive() const {return _ispositive;}
@@ -101,8 +101,7 @@ class SvtxTrack : public PHObject {
   float get_dzdl() const {return _dzdl;}
   
   const TMatrix* getCovariance() const {return &_covariance;}
-  TMatrix* getCovariance() {return &_covariance;}
-  
+  TMatrix* getCovariance() {return &_covariance;}  
 
   void set_cal_dphi(int layer, float dphi) {_cal_dphi[layer] = dphi;}
   float get_cal_dphi(int layer) const {return _cal_dphi[layer];}
@@ -135,7 +134,6 @@ class SvtxTrack : public PHObject {
   float   _momentum;
   float   _mom3[3];
   int     _charge;
-  bool    _isprimary;
   bool    _ispositive;
   float   _quality;
   float   _chisq;

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -2,8 +2,11 @@
 #define __SVTXTRACK_H__
 
 #include <phool/PHObject.h>
+
 #include <TMatrix.h>
+
 #include <iostream>
+#include <map>
 
 class SvtxTrack : public PHObject {
   
@@ -21,58 +24,66 @@ class SvtxTrack : public PHObject {
   void Reset();
   int  isValid() const;
 
-  void set_id(int id) {trackID = id;}
-  void setTrackID(int index){trackID = index;}
-  int getTrackID() const {return trackID;}  
+  void set_id(int id) {_track_id = id;}
+  void setTrackID(int index){_track_id = index;}
+  int getTrackID() const {return _track_id;}  
   
-  void setClusterID(int layer, int index);
-  int getClusterID(int layer) const;
-  bool hasCluster(int layer) const;
+  void setClusterID(int layer, int index) {clusterID[layer] = index;}
+  int getClusterID(int layer) const {return clusterID[layer];}
+  bool hasCluster(int layer) const {return (clusterID[layer] >- 9999);}
   
-  void setScatter(int layer, float sct);
-  float getScatter(int layer) const;
+  void setScatter(int layer, float sct) {scatter[layer] = sct;}
+  float getScatter(int layer) const {return scatter[layer];}
   
-  void setHitPosition(int layer, float x, float y, float z);
-  float getHitPosition(int layer, int coor) const;
+  void setHitPosition(int layer, float x, float y, float z) {
+    position[layer][0]=x;
+    position[layer][1]=y;
+    position[layer][2]=z;
+  }
+  float getHitPosition(int layer, int coor) const {return position[layer][coor];}
+
+  void setMomentum(float p) {momentum = p;}
+  float getMomentum() const {return momentum;}
   
-  void setMomentum(float p);
-  float getMomentum() const;
+  void set3Momentum(float px, float py, float pz) {
+    mom3[0] = px;
+    mom3[1] = py;
+    mom3[2] = pz;
+  };
+  float get3Momentum(int coor) const {return mom3[coor];}
   
-  void set3Momentum(float px, float py, float pz);
-  float get3Momentum(int coor) const;
+  void setCharge(int c) {charge = c;}
+  int getCharge() const {return charge;}
   
-  void setCharge(int c);
-  int getCharge() const;
+  void setPrimary(bool prim) {isprimary = prim;}
+  bool getPrimary() const {return isprimary;}
   
-  void setPrimary(bool prim);
-  bool getPrimary() const;
-  
-  void setPositive(bool prim);
-  bool getPositive() const;
+  void setPositive(bool prim) {ispositive = prim;}
+  bool getPositive() const {return ispositive;}
   
   //void setNhits(int layer, short n);
   short getNhits() const;
   
-  void setQuality(float q);
-  float getQuality() const;
+  void setQuality(float q) {quality = q;}
+  float getQuality() const {return quality;}
 
-  void setChisq(float q);
-  float getChisq() const;
+  void setChisq(float q) {chisq = q;}
+  float getChisq() const {return chisq;}
 
-  void setChisqv(float q);
-  float getChisqv() const;
+  void setChisqv(float q) {chisqv = q;}
+  float getChisqv() const {return chisqv;}
 
-  void setNDF(int q);
-  int getNDF() const;
+  void setNDF(int q) {ndf = q;}
+  int getNDF() const {return ndf;}
 
-  void setDCA(float d);
-  float getDCA() const;
+  void setDCA(float d) {DCA = d;}
+  float getDCA() const {return DCA;}
 
-  void setDCA2D(float d);
-  float getDCA2D() const;
+  void setDCA2D(float d) {DCA2D = d;}
+  float getDCA2D() const {return DCA2D;}
   
-  void setDCA2Dsigma(float d);
-  float getDCA2Dsigma() const;
+  void setDCA2Dsigma(float s) {DCA2Dsigma = s;}
+  float getDCA2Dsigma() const {return DCA2Dsigma;}
 
   float getInnerMostHitPosition(int coor) const;
 
@@ -119,7 +130,7 @@ class SvtxTrack : public PHObject {
 
  private: 
 
-  int     trackID;
+  int     _track_id;
   float   _phi,_d,_kappa,_z0,_dzdl;
   int     clusterID[100];
   float   position[100][3];
@@ -147,65 +158,11 @@ class SvtxTrack : public PHObject {
   int     cal_cluster_id[4];
   float   cal_cluster_e[4];
 
+  // cluster ids
+  //std::multimap<unsigned int,unsigned int> _cluster_ids; //< layer index => cluster id
+  
   ClassDef(SvtxTrack,1)
 };
-
-
-inline void SvtxTrack::setClusterID(int layer, int index){clusterID[layer]=index;}
-inline int SvtxTrack::getClusterID(int layer) const {return clusterID[layer];}
-inline bool SvtxTrack::hasCluster(int layer) const {return (clusterID[layer]>-9999);}
-
-inline void SvtxTrack::setScatter(int layer, float sct){scatter[layer]=sct;}
-inline float SvtxTrack::getScatter(int layer) const {return scatter[layer];}
-
-inline void SvtxTrack::setDCA(float d){DCA=d;}
-inline float SvtxTrack::getDCA() const {return DCA;}
-inline void SvtxTrack::setDCA2D(float d){DCA2D=d;}
-inline float SvtxTrack::getDCA2D() const {return DCA2D;}
-inline void SvtxTrack::setDCA2Dsigma(float s){DCA2Dsigma=s;}
-inline float SvtxTrack::getDCA2Dsigma() const {return DCA2Dsigma;}
-
-inline void SvtxTrack::setMomentum(float p){momentum=p;}
-inline float SvtxTrack::getMomentum() const {return momentum;}
-
-inline void SvtxTrack::setQuality(float q){quality=q;}
-inline float SvtxTrack::getQuality() const {return quality;}
-
-inline void SvtxTrack::setChisq(float q){chisq=q;}
-inline float SvtxTrack::getChisq() const {return chisq;}
-
-inline void SvtxTrack::setChisqv(float q){chisqv=q;}
-inline float SvtxTrack::getChisqv() const {return chisqv;}
-
-inline void SvtxTrack::setNDF(int q){ndf=q;}
-inline int SvtxTrack::getNDF() const {return ndf;}
-
-
-inline void SvtxTrack::set3Momentum(float px, float py, float pz)
-{
-  mom3[0] = px;
-  mom3[1] = py;
-  mom3[2] = pz;
-}
-inline float SvtxTrack::get3Momentum(int coor) const {return mom3[coor];}
-
-inline void SvtxTrack::setCharge(int c){charge=c;}
-inline int SvtxTrack::getCharge() const {return charge;}
-
-inline void SvtxTrack::setPrimary(bool prim){isprimary=prim;}
-inline bool SvtxTrack::getPrimary() const {return isprimary;}
-
-inline void SvtxTrack::setPositive(bool p){ispositive=p;}
-inline bool SvtxTrack::getPositive() const {return ispositive;}
-
-inline float SvtxTrack::getHitPosition(int layer, int coor) const {return position[layer][coor];}
-inline void SvtxTrack::setHitPosition(int layer, float x, float y, float z)
-{
-  position[layer][0]=x;
-  position[layer][1]=y;
-  position[layer][2]=z;
-}
-
 
 #endif
 

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -57,11 +57,17 @@ class SvtxTrack : public PHObject {
   };
   float get3Momentum(int coor) const {return _mom3[coor];}
   
-  void setCharge(int c) {_charge = c;}
-  int getCharge() const {return _charge;}
+  void setCharge(int c) {
+    if (c > 0) setPositive(true);
+    else setPositive(false);
+  }
+  int getCharge() const {
+    if (getPositive()) return +1;
+    else return -1;
+  }
   
-  void setPositive(bool prim) {_ispositive = prim;}
-  bool getPositive() const {return _ispositive;}
+  void setPositive(bool prim) {_is_positive_charge = prim;}
+  bool getPositive() const {return _is_positive_charge;}
 
   void setPrimary(bool prim) {}
   bool getPrimary() const {return false;}
@@ -134,11 +140,9 @@ class SvtxTrack : public PHObject {
 
  private: 
 
-  int     _track_id;
-
   // track information
-  int     _charge;
-  bool    _ispositive;
+  int     _track_id;
+  bool    _is_positive_charge;
   float   _quality;
   float   _chisq;
   float   _chisqv;

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -123,7 +123,8 @@ class SvtxTrack : public PHObject {
   float get_dzdl() const {return _dzdl;}
   
   const TMatrix* getCovariance() const {return &_covariance;}
-  TMatrix* getCovariance() {return &_covariance;}  
+  //TMatrix* getCovariance() {return &_covariance;}
+  void setCovariance(int i,int j, float val) {_covariance[i][j] = val;}
 
   void  set_cal_dphi(CAL_LAYER layer, float dphi) {_cal_dphi[layer] = dphi;}
   float get_cal_dphi(CAL_LAYER layer) const;
@@ -151,6 +152,11 @@ class SvtxTrack : public PHObject {
 
  private: 
 
+  // keep these private for now
+  // attempting ~zero interface changes during refactor
+  float get_error(int i, int j) const;
+  void  set_error(int i, int j, float value);
+  
   // track information
   int     _track_id;
   bool    _is_positive_charge;
@@ -177,6 +183,7 @@ class SvtxTrack : public PHObject {
   // vectors, we should replace this with a raw type like a triangular
   // vector implementation std::vector<std::vector<float> > _covariance;
   TMatrix _covariance;
+  std::vector<std::vector<float> > _covar; // 6x6 triangular matrix
   
   // cluster contents
   std::map<int,int> _cluster_ids; //< layer index => cluster id

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -225,6 +225,8 @@ class SvtxTrack : public PHObject {
     float _dzdl;                                                              //
   };                                                                          //
   // --- inner State class ---------------------------------------------------//
+
+  // class CaloMatch
   
   // keep these private for now
   // attempting ~zero interface changes during refactor
@@ -238,23 +240,15 @@ class SvtxTrack : public PHObject {
   unsigned int _ndf;
 
   // extended track information (non-primary tracks only)
-  float   _DCA;
-  float   _DCA2D;
-  float   _DCA2Dsigma;
+  float _DCA;
+  float _DCA2D;
+  float _DCA2Dsigma;
 
   // extended track information (primary tracks only)
   // unsigned int _vertex_id;
   
-  // projection information
-  // replace with a set/map of track state vectors
-  // x,y,z,px,py,pz + covar
-  // distance along track => state vector
-  std::map<float,SvtxTrack::State> _states;
-  // float distance = 0.0 will be the default DCA or vertex point value
-  //float   _phi,_d,_kappa,_z0,_dzdl; // redundant to x,y,z,px,py,pz & field strength
-  //float   _mom[3];
-  //float   _x,_y,_z; // point of closest approach assuming vertex is at 0,0,0
-  //std::vector<std::vector<float> > _covar; // 6x6 triangular matrix
+  // track state information
+  std::map<float,SvtxTrack::State> _states; //< path length => state object
   
   // cluster contents
   std::map<int,unsigned int> _cluster_ids; //< layer index => cluster id

--- a/simulation/g4simulation/g4jets/TrackJetInput.C
+++ b/simulation/g4simulation/g4jets/TrackJetInput.C
@@ -52,7 +52,7 @@ std::vector<Jet*> TrackJetInput::get_input(PHCompositeNode *topNode) {
     jet->set_py(track->get3Momentum(1));
     jet->set_pz(track->get3Momentum(2));
     jet->set_e(track->getMomentum());
-    jet->insert_comp(Jet::TRACK,track->getTrackID());
+    jet->insert_comp(Jet::TRACK,track->get_id());
     pseudojets.push_back(jet);
   }
 

--- a/simulation/g4simulation/g4jets/TrackJetInput.C
+++ b/simulation/g4simulation/g4jets/TrackJetInput.C
@@ -48,10 +48,10 @@ std::vector<Jet*> TrackJetInput::get_input(PHCompositeNode *topNode) {
     const SvtxTrack *track = &iter->second;
 
     Jet *jet = new JetV1();
-    jet->set_px(track->get3Momentum(0));
-    jet->set_py(track->get3Momentum(1));
-    jet->set_pz(track->get3Momentum(2));
-    jet->set_e(track->getMomentum());
+    jet->set_px(track->get_px());
+    jet->set_py(track->get_py());
+    jet->set_pz(track->get_pz());
+    jet->set_e(track->get_p());
     jet->insert_comp(Jet::TRACK,track->get_id());
     pseudojets.push_back(jet);
   }


### PR DESCRIPTION
This merge will rework the SvtxTrack object so that it is suitable for additional modularization of the tracking reconstruction. The track object can now store a projection of the track fit at multiple locations along the path. The default state vector (at the point of closest approach) is exposed through svtxtrack->get_??() methods. Some analysis modules will need minor updates to follow the new interface. I also fix some minor inconsistencies in some method definitions and a bug that swapped the x and y PCA values.

In reworking the object's internal storage I have recovered 2 kilobytes per track for silicon-only tracking. So central event storage is down over 1 MB per event. There is also space savings for the TPC tracks, but not as large a change.

The g4hough's i/o objects will still need to be versioned. My plan is to do that in a future pull request. I have an idea to reduce the storage size of the SvtxHit and SvtxCluster by ~10% as well by utilizing the covariance matrix packed array I have implemented here in SvtxTrack. I believe those changes can hide behind the new interface brought in on this request so further disruption cause by interface changes should now be very minimal. We should pull this new interface while the TPC reconstruction can be fast forwarded with these changes as well. 

I also verified the performance in central events for this merge (solid points) against yesterday's new build (open points):
![crosscheck](https://cloud.githubusercontent.com/assets/12105552/9840673/eb732182-5a52-11e5-9f44-fb30da234ef9.png)
