### PR TITLE
Calorimeter Digitalization and Calibration

### DIFF
--- a/simulation/g4simulation/g4cemc/Makefile.am
+++ b/simulation/g4simulation/g4cemc/Makefile.am
@@ -52,6 +52,10 @@ libcemc_la_SOURCES = \
   RawClusterBuilderv1_Dict.cc \
   RawTowerBuilder.cc \
   RawTowerBuilder_Dict.cc \
+  RawTowerCalibration.cc \
+  RawTowerCalibration_Dict.cc \
+  RawTowerDigitizer.cc \
+  RawTowerDigitizer_Dict.cc \
   RawTowerBuilderCone.cc \
   RawTowerBuilderCone_Dict.cc \
   RawTowerCombiner.cc \

--- a/simulation/g4simulation/g4cemc/RawClusterBuilder.cc
+++ b/simulation/g4simulation/g4cemc/RawClusterBuilder.cc
@@ -346,8 +346,15 @@ void RawClusterBuilder::CreateNodes(PHCompositeNode *topNode)
       throw std::runtime_error("Failed to find DST node in EmcRawTowerBuilder::CreateNodes");
     }
 
+  PHNodeIterator dstiter(dstNode);
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",detector ));
+  if(!DetNode){
+      DetNode = new PHCompositeNode(detector);
+      dstNode->addNode(DetNode);
+   }
+
   _clusters = new RawClusterContainer();
   ClusterNodeName = "CLUSTER_" + detector;
   PHIODataNode<PHObject> *clusterNode = new PHIODataNode<PHObject>(_clusters, ClusterNodeName.c_str(), "PHObject");
-  dstNode->addNode(clusterNode);
+  DetNode->addNode(clusterNode);
 }

--- a/simulation/g4simulation/g4cemc/RawClusterBuilder.cc
+++ b/simulation/g4simulation/g4cemc/RawClusterBuilder.cc
@@ -126,7 +126,7 @@ int RawClusterBuilder::InitRun(PHCompositeNode *topNode)
 int RawClusterBuilder::process_event(PHCompositeNode *topNode)
 {
 
-  string towernodename = "TOWER_" + detector;
+  string towernodename = "TOWER_CALIB_" + detector;
   // Grab the towers
   RawTowerContainer* towers = findNode::getClass<RawTowerContainer>(topNode, towernodename.c_str());
   if (!towers)

--- a/simulation/g4simulation/g4cemc/RawClusterBuilderv1.cc
+++ b/simulation/g4simulation/g4cemc/RawClusterBuilderv1.cc
@@ -67,7 +67,7 @@ int RawClusterBuilderv1::InitRun(PHCompositeNode *topNode)
 int RawClusterBuilderv1::process_event(PHCompositeNode *topNode)
 {
 
-  string towernodename = "TOWER_" + detector;
+  string towernodename = "TOWER_CALIB_" + detector;
   // Grab the towers
   RawTowerContainer* towers = findNode::getClass<RawTowerContainer>(topNode, towernodename.c_str());
   if (!towers)

--- a/simulation/g4simulation/g4cemc/RawTower.h
+++ b/simulation/g4simulation/g4cemc/RawTower.h
@@ -27,9 +27,11 @@ class RawTower : public PHObject {
   virtual RawTowerDefs::keytype get_id() const { PHOOL_VIRTUAL_WARN("get_id()"); return 0; }
   virtual int get_bineta() const { PHOOL_VIRTUAL_WARN("get_ieta()"); return -1; }
   virtual int get_binphi() const { PHOOL_VIRTUAL_WARN("get_iphi()"); return -1; }
+
+  //! energy assigned to the tower. Depending on stage of process and DST node name, it could be energy deposition, light yield or calibrated energies
   virtual double get_energy() const { PHOOL_VIRTUAL_WARN("get_energy()"); return 0.0; }
-  virtual void set_light_yield(const float l)  { PHOOL_VIRTUAL_WARN("set_light_yield()"); return ; }
-  virtual float get_light_yield() const { PHOOL_VIRTUAL_WARN("get_light_yield()"); return 0.0; }
+  //! energy assigned to the tower. Depending on stage of process and DST node name, it could be energy deposition, light yield or calibrated energies
+  virtual void set_energy (const double ) { PHOOL_VIRTUAL_WARN("set_energy()"); return  ; }
 
   virtual CellConstRange get_g4cells()
   {

--- a/simulation/g4simulation/g4cemc/RawTower.h
+++ b/simulation/g4simulation/g4cemc/RawTower.h
@@ -33,7 +33,7 @@ class RawTower : public PHObject {
   //! energy assigned to the tower. Depending on stage of process and DST node name, it could be energy deposition, light yield or calibrated energies
   virtual void set_energy (const double ) { PHOOL_VIRTUAL_WARN("set_energy()"); return  ; }
 
-  virtual CellConstRange get_g4cells()
+  virtual CellConstRange get_g4cells() const
   {
     PHOOL_VIRTUAL_WARN("get_g4cells()");
     CellMap dummy;

--- a/simulation/g4simulation/g4cemc/RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerBuilder.cc
@@ -382,7 +382,7 @@ RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
 
   // Create the tower nodes on the tree
   _towers = new RawTowerContainer();
-  TowerNodeName = "TOWER_" + detector;
+  TowerNodeName = "TOWER_SIM_" + detector;
   PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers, TowerNodeName.c_str(), "PHObject");
   dstNode->addNode(towerNode);
 

--- a/simulation/g4simulation/g4cemc/RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerBuilder.cc
@@ -396,11 +396,19 @@ RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
       throw std::runtime_error("Failed to find DST node in RawTowerBuilder::CreateNodes");
     }
 
+
+  PHNodeIterator dstiter(dstNode);
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",detector ));
+  if(!DetNode){
+      DetNode = new PHCompositeNode(detector);
+      dstNode->addNode(DetNode);
+   }
+
   // Create the tower nodes on the tree
   _towers = new RawTowerContainer();
   TowerNodeName = "TOWER_SIM_" + detector;
   PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers, TowerNodeName.c_str(), "PHObject");
-  dstNode->addNode(towerNode);
+  DetNode->addNode(towerNode);
 
   return;
 }

--- a/simulation/g4simulation/g4cemc/RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerBuilder.cc
@@ -34,7 +34,7 @@ RawTowerBuilder::RawTowerBuilder(const std::string& name):
   _phimin(NAN),
   _etastep(NAN),
   _phistep(NAN),
-  _tower_energy_src(kEnergyDeposition),
+  _tower_energy_src(kLightYield),
   _timer( PHTimeServer::get()->insert_new(name) )
 {}
 
@@ -406,7 +406,15 @@ RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
 
   // Create the tower nodes on the tree
   _towers = new RawTowerContainer();
-  TowerNodeName = "TOWER_SIM_" + detector;
+  if (_sim_tower_node_prefix.length() == 0)
+    {
+      // no prefix, consistent with older convension
+      TowerNodeName = "TOWER_" + detector;
+    }
+  else
+    {
+      TowerNodeName = "TOWER_" + _sim_tower_node_prefix + "_" + detector;
+    }
   PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers, TowerNodeName.c_str(), "PHObject");
   DetNode->addNode(towerNode);
 

--- a/simulation/g4simulation/g4cemc/RawTowerBuilder.h
+++ b/simulation/g4simulation/g4cemc/RawTowerBuilder.h
@@ -33,6 +33,18 @@ class RawTowerBuilder : public SubsysReco {
 
   };
 
+  enu_tower_energy_src
+  get_tower_energy_src() const
+  {
+    return _tower_energy_src;
+  }
+
+  void
+  set_tower_energy_src(enu_tower_energy_src towerEnergySrc)
+  {
+    _tower_energy_src = towerEnergySrc;
+  }
+
 
  protected:
   void CreateNodes(PHCompositeNode *topNode);

--- a/simulation/g4simulation/g4cemc/RawTowerBuilder.h
+++ b/simulation/g4simulation/g4cemc/RawTowerBuilder.h
@@ -23,6 +23,17 @@ class RawTowerBuilder : public SubsysReco {
   void EminCut(const double e) {emin = e;}
   void checkenergy(const int i = 1) {chkenergyconservation = i;}
 
+  enum enu_tower_energy_src
+  {
+    //! save Geant4 energy deposition as the weight of the cells
+      kEnergyDeposition,
+
+      //! save light yield as the weight of the cells
+      kLightYield
+
+  };
+
+
  protected:
   void CreateNodes(PHCompositeNode *topNode);
 
@@ -43,6 +54,7 @@ class RawTowerBuilder : public SubsysReco {
   double _phimin;
   double _etastep;
   double _phistep;
+  enu_tower_energy_src _tower_energy_src;
 
   PHTimeServer::timer _timer;
 

--- a/simulation/g4simulation/g4cemc/RawTowerBuilder.h
+++ b/simulation/g4simulation/g4cemc/RawTowerBuilder.h
@@ -46,6 +46,18 @@ class RawTowerBuilder : public SubsysReco {
   }
 
 
+  std::string
+  get_sim_tower_node_prefix() const
+  {
+    return _sim_tower_node_prefix;
+  }
+
+  void
+  set_sim_tower_node_prefix(std::string simTowerNodePrefix)
+  {
+    _sim_tower_node_prefix = simTowerNodePrefix;
+  }
+
  protected:
   void CreateNodes(PHCompositeNode *topNode);
 
@@ -55,6 +67,7 @@ class RawTowerBuilder : public SubsysReco {
   std::string detector;
   std::string TowerNodeName;
   std::string TowerGeomNodeName;
+  std::string _sim_tower_node_prefix;
 
   int _cell_binning;
   double emin;	

--- a/simulation/g4simulation/g4cemc/RawTowerCalibration.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerCalibration.cc
@@ -16,53 +16,40 @@
 #include <iostream>
 #include <stdexcept>
 #include <map>
+#include <cassert>
 
 using namespace std;
 
-RawTowerCalibration::RawTowerCalibration(const std::string& name):
-  SubsysReco(name),
-  _towers(NULL),
-  rawtowergeom(NULL),
-  detector("NONE"),
-  _cell_binning(PHG4CylinderCellDefs::undefined),
-  emin(1e-6),
-  chkenergyconservation(0),
-  _nlayers(-1),
-  _nphibins(-1),
-  _netabins(-1),
-  _etamin(NAN),
-  _phimin(NAN),
-  _etastep(NAN),
-  _phistep(NAN),
-  _timer( PHTimeServer::get()->insert_new(name) )
-{}
+RawTowerCalibration::RawTowerCalibration(const std::string& name) :
+    SubsysReco(name), _calib_algorithm(kNo_calibration), //
+    _calib_towers(NULL), _raw_towers(NULL), //
+    rawtowergeom(NULL), //
+    detector("NONE"), //
+    _calib_tower_node_prefix("CALIB"), _raw_tower_node_prefix("RAW"), //
+    //! pedstal in unit of ADC
+    _pedstal_ADC(NAN),
+    //! calibration constant in unit of GeV per ADC
+    _calib_const_GeV_ADC(NAN), //
+    _zero_suppression_GeV(0), //
+    _timer(PHTimeServer::get()->insert_new(name))
+{
+}
 
-int 
+int
 RawTowerCalibration::InitRun(PHCompositeNode *topNode)
 {
-  std::string geonodename = "CYLINDERCELLGEOM_" + detector;
-  PHG4CylinderCellGeomContainer* cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, geonodename.c_str());
-  if (!cellgeos)
-    {
-      std::cerr << PHWHERE << " " << geonodename << " Node missing, doing nothing." << std::endl;
-      throw std::runtime_error("Failed to find " + geonodename + " node in RawTowerCalibration::CreateNodes");
-    }
-
-  // fill the number of layers in the calorimeter
-  _nlayers = cellgeos->get_NLayers();
-
-
   PHNodeIterator iter(topNode);
 
   // Looking for the DST node
   PHCompositeNode *dstNode;
-  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",
+      "DST"));
   if (!dstNode)
     {
-      std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << "DST Node missing, doing nothing." << std::endl;
       exit(1);
     }
-
 
   try
     {
@@ -71,237 +58,99 @@ RawTowerCalibration::InitRun(PHCompositeNode *topNode)
   catch (std::exception& e)
     {
       std::cout << e.what() << std::endl;
-      //exit(1);
+      return Fun4AllReturnCodes::ABORTRUN;
     }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int 
+int
 RawTowerCalibration::process_event(PHCompositeNode *topNode)
 {
   if (verbosity)
     {
-      std::cout << PHWHERE << "Process event entered" << std::endl;
+      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__<< "Process event entered" << std::endl;
     }
 
+  RawTowerContainer::ConstRange begin_end = _raw_towers->getTowers();
+  RawTowerContainer::ConstIterator rtiter;
+  for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
+    {
+      const RawTowerDefs::keytype key = rtiter->first;
+      const RawTower *raw_tower = rtiter->second;
+      assert(raw_tower);
 
+      if (_calib_algorithm == kNo_calibration)
+        {
+          if (raw_tower->get_energy() > _zero_suppression_GeV)
+            {
+              _calib_towers->AddTower(key, new RawTowerv1(*raw_tower));
+            }
+        }
+      else if (_calib_algorithm == kSimple_linear_calibration)
+        {
+          const double raw_energy = raw_tower->get_energy();
+          const double calib_energy = (raw_energy - _pedstal_ADC)
+              * _calib_const_GeV_ADC;
 
+          if (calib_energy > _zero_suppression_GeV)
+            {
+              RawTower *calib_tower = new RawTowerv1(*raw_tower);
+              calib_tower->set_energy(calib_energy);
+              _calib_towers->AddTower(key, calib_tower);
+            }
+        }
+      else
+        {
+          std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+              << " invalid calibration algorithm #" << _calib_algorithm
+              << std::endl;
+
+          return Fun4AllReturnCodes::ABORTRUN;
+        }
+    } //  for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
+
+  if (verbosity)
+    {
+      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << "input sum energy = " << _raw_towers->getTotalEdep()
+          << ", output sum digitalized value = " << _calib_towers->getTotalEdep()
+          << std::endl;
+    }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int 
+int
 RawTowerCalibration::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void 
+void
 RawTowerCalibration::CreateNodes(PHCompositeNode *topNode)
 {
 
   PHNodeIterator iter(topNode);
-  PHCompositeNode *runNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
+  PHCompositeNode *runNode = static_cast<PHCompositeNode*>(iter.findFirst(
+      "PHCompositeNode", "RUN"));
   if (!runNode)
     {
-      std::cerr << PHWHERE << "Run Node missing, doing nothing." << std::endl;
-      throw std::runtime_error("Failed to find Run node in RawTowerCalibration::CreateNodes");
+      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << "Run Node missing, doing nothing." << std::endl;
+      throw std::runtime_error(
+          "Failed to find Run node in RawTowerCalibration::CreateNodes");
     }
 
-  // get the cell geometry and build up the tower geometry object
-  std::string geonodename = "CYLINDERCELLGEOM_" + detector;
-  PHG4CylinderCellGeomContainer* cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, geonodename.c_str());
-  if (!cellgeos)
-    {
-      std::cerr << PHWHERE << " " << geonodename << " Node missing, doing nothing." << std::endl;
-      throw std::runtime_error("Failed to find " + geonodename + " node in RawTowerCalibration::CreateNodes");
-    }
   TowerGeomNodeName = "TOWERGEOM_" + detector;
-  rawtowergeom =  findNode::getClass<RawTowerGeom>(topNode, TowerGeomNodeName.c_str());
-  if (! rawtowergeom)
+  rawtowergeom = findNode::getClass<RawTowerGeom>(topNode,
+      TowerGeomNodeName.c_str());
+  if (!rawtowergeom)
     {
-
-      rawtowergeom = new RawTowerGeomv2();
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom, TowerGeomNodeName.c_str(), "PHObject");
-      runNode->addNode(newNode);
-    }
-  // fill the number of layers in the calorimeter
-  _nlayers = cellgeos->get_NLayers();
-
-  // Create the tower nodes on the tree
-  std::map<int, PHG4CylinderCellGeom *>::const_iterator miter;
-  std::pair <std::map<int, PHG4CylinderCellGeom *>::const_iterator, std::map<int, PHG4CylinderCellGeom *>::const_iterator> begin_end = cellgeos->get_begin_end();
-  int ifirst = 1;
-  int first_layer = -1;
-  PHG4CylinderCellGeom * first_cellgeo = NULL;
-  double inner_radius = 0;
-  double thickness = 0;
-  for (miter = begin_end.first; miter != begin_end.second; ++miter)
-    {
-      PHG4CylinderCellGeom *cellgeo = miter->second;
-      first_cellgeo = miter->second;
-
-      if (verbosity)
-	{
-	  cellgeo->identify();
-	}
-      thickness += cellgeo->get_thickness();
-      if (ifirst)
-	{
-	  _cell_binning = cellgeo->get_binning();
-	  _nphibins = cellgeo->get_phibins();
-	  _phimin = cellgeo->get_phimin();
-	  _phistep = cellgeo->get_phistep();
-          if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
-              or _cell_binning == PHG4CylinderCellDefs::etaslatbinning)
-            {
-              _netabins = cellgeo->get_etabins();
-              _etamin = cellgeo->get_etamin();
-              _etastep = cellgeo->get_etastep();
-            }
-          else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
-            {
-              _netabins = cellgeo->get_zbins();// bin eta in the same number of z bins
-            }
-          else if (_cell_binning == PHG4CylinderCellDefs::spacalbinning)
-            {
-              // use eta definiton for each row of towers
-              _netabins = cellgeo->get_etabins();
-            }
-          else
-            {
-              cout <<"RawTowerCalibration::CreateNodes::"<<Name()
-		   <<" - Fatal Error - unsupported cell binning method "<<_cell_binning<<endl;
-            }
-	  inner_radius = cellgeo->get_radius();
-	  first_layer = cellgeo->get_layer();
-	  ifirst = 0;
-	}
-      else
-	{
-          if (_cell_binning != cellgeo->get_binning())
-            {
-              cout << "inconsistent binning method from " << _cell_binning
-             << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_binning()
-             << endl;
-              exit(1);
-            }
-	  if (inner_radius > cellgeo->get_radius())
-	    {
-	      cout << "radius of layer " << cellgeo->get_layer() 
-		   << " is " << cellgeo->get_radius()
-		   << " which smaller than radius " << inner_radius
-		   << " of first layer in list " << first_layer
-		   << endl;
-	    }
-	  if (_nphibins != cellgeo->get_phibins())
-	    {
-	      cout << "mixing number of phibins, fisrt layer: " << _nphibins
-		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phibins()
-		   << endl;
-	      exit(1);
-	    }
-	  if ( _phimin != cellgeo->get_phimin())
-	    {
-	      cout << "mixing number of phimin, fisrt layer: " << _phimin
-		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phimin()
-		   << endl;
-	      exit(1);
-	    }
-	  if (_phistep != cellgeo->get_phistep())
-	    {
-	      cout << "mixing phisteps first layer: " << _phistep
-		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phistep()
-		   << " diff: " << _phistep - cellgeo->get_phistep()
-		   << endl;
-	      exit(1);
-	    }
-          if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
-              or _cell_binning == PHG4CylinderCellDefs::etaslatbinning)
-            {
-              if (_netabins != cellgeo->get_etabins())
-                {
-                  cout << "mixing number of_netabins , fisrt layer: " << _netabins
-                 << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_etabins()
-                 << endl;
-                  exit(1);
-                }
-              if (fabs(_etamin - cellgeo->get_etamin()) > 1e-9)
-                {
-                  cout << "mixing etamin, fisrt layer: " << _etamin << " layer "
-                      << cellgeo->get_layer() << ": " << cellgeo->get_etamin()
-                      << " diff: " << _etamin - cellgeo->get_etamin() << endl;
-                  exit(1);
-                }
-              if (fabs(_etastep - cellgeo->get_etastep()) > 1e-9)
-                {
-                  cout << "mixing eta steps first layer: " << _etastep
-                      << " layer " << cellgeo->get_layer() << ": "
-                      << cellgeo->get_etastep() << " diff: "
-                      << _etastep - cellgeo->get_etastep() << endl;
-                  exit(1);
-                }
-            }
-
-          else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
-            {
-
-              if (_netabins != cellgeo->get_zbins())
-                {
-                  cout << "mixing number of z bins , fisrt layer: " << _netabins
-                 << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_zbins()
-                 << endl;
-                  exit(1);
-                }
-            }
-	}
-    }
-  rawtowergeom->set_radius(inner_radius);
-  rawtowergeom->set_thickness(thickness);
-  rawtowergeom->set_phibins(_nphibins);
-  rawtowergeom->set_phistep(_phistep);
-  rawtowergeom->set_phimin(_phimin);
-  rawtowergeom->set_etabins(_netabins);
-
-  if (first_cellgeo == NULL)
-    {
-      cout <<"RawTowerCalibration::CreateNodes - ERROR - can not find first layer of cells "<<endl;
-
-      exit(1);
-    }
-
-  if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
-      or _cell_binning == PHG4CylinderCellDefs::etaslatbinning
-      or _cell_binning == PHG4CylinderCellDefs::spacalbinning
-      )
-    {
-//  rawtowergeom->set_etamin(_etamin);
-//  rawtowergeom->set_etastep(_etastep);
-      for (int ibin = 0; ibin<first_cellgeo->get_etabins(); ibin++)
-        {
-
-          const pair<double, double> range = first_cellgeo -> get_etabounds(ibin);
-
-          rawtowergeom->set_etabounds(ibin, range);
-        }
-
-    }
-  else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
-    {
-      for (int ibin = 0; ibin<first_cellgeo->get_zbins(); ibin++)
-        {
-
-          const pair<double, double> z_range = first_cellgeo -> get_zbounds(ibin);
-          const double r = first_cellgeo->get_radius();
-          const double eta1 = -log (tan(atan2(r, z_range.first)/2.) );
-          const double eta2 = -log (tan(atan2(r, z_range.second)/2.) );
-          rawtowergeom->set_etabounds(ibin, make_pair(eta1, eta2));
-        }
-
-    }
-  else
-    {
-      cout <<"RawTowerCalibration::CreateNodes - ERROR - unsupported cell geometry "<<_cell_binning<<endl;
-      exit(1);
+      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << " " << TowerGeomNodeName << " Node missing, doing bail out!"
+          << std::endl;
+      throw std::runtime_error(
+          "Failed to find " + TowerGeomNodeName
+              + " node in RawTowerCalibration::CreateNodes");
     }
 
   if (verbosity >= 1)
@@ -309,22 +158,45 @@ RawTowerCalibration::CreateNodes(PHCompositeNode *topNode)
       rawtowergeom->identify();
     }
 
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+      "PHCompositeNode", "DST"));
   if (!dstNode)
     {
-      std::cerr << PHWHERE << "DST Node missing, doing nothing." << std::endl;
-      throw std::runtime_error("Failed to find DST node in RawTowerCalibration::CreateNodes");
+      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << "DST Node missing, doing nothing." << std::endl;
+      throw std::runtime_error(
+          "Failed to find DST node in RawTowerCalibration::CreateNodes");
+    }
+
+  RawTowerNodeName = "TOWER_" + _raw_tower_node_prefix + "_" + detector;
+  _raw_towers = findNode::getClass<RawTowerContainer>(dstNode,
+      RawTowerNodeName.c_str());
+  if (!_raw_towers)
+    {
+      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << " " << RawTowerNodeName << " Node missing, doing bail out!"
+          << std::endl;
+      throw std::runtime_error(
+          "Failed to find " + RawTowerNodeName
+              + " node in RawTowerCalibration::CreateNodes");
     }
 
   // Create the tower nodes on the tree
-  _towers = new RawTowerContainer();
-  CaliTowerNodeName = "TOWER_SIM_" + detector;
-  PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers, CaliTowerNodeName.c_str(), "PHObject");
-  dstNode->addNode(towerNode);
+  PHNodeIterator dstiter(dstNode);
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst(
+      "PHCompositeNode", detector));
+  if (!DetNode)
+    {
+      DetNode = new PHCompositeNode(detector);
+      dstNode->addNode(DetNode);
+    }
+
+  _calib_towers = new RawTowerContainer();
+  CaliTowerNodeName = "TOWER_" + _calib_tower_node_prefix + "_" + detector;
+  PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_calib_towers,
+      CaliTowerNodeName.c_str(), "PHObject");
+  DetNode->addNode(towerNode);
 
   return;
 }
-
-
-
 

--- a/simulation/g4simulation/g4cemc/RawTowerCalibration.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerCalibration.cc
@@ -1,0 +1,394 @@
+#include "RawTowerCalibration.h"
+#include "RawTowerContainer.h"
+#include "RawTowerGeomv2.h"
+#include "RawTowerv1.h"
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellContainer.h>
+#include <g4detectors/PHG4CylinderCell.h>
+#include <g4detectors/PHG4CylinderCellDefs.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/getClass.h>
+
+#include <iostream>
+#include <stdexcept>
+#include <map>
+
+using namespace std;
+
+RawTowerCalibration::RawTowerCalibration(const std::string& name):
+  SubsysReco(name),
+  _towers(NULL),
+  rawtowergeom(NULL),
+  detector("NONE"),
+  _cell_binning(PHG4CylinderCellDefs::undefined),
+  emin(1e-6),
+  chkenergyconservation(0),
+  _nlayers(-1),
+  _nphibins(-1),
+  _netabins(-1),
+  _etamin(NAN),
+  _phimin(NAN),
+  _etastep(NAN),
+  _phistep(NAN),
+  _timer( PHTimeServer::get()->insert_new(name) )
+{}
+
+int 
+RawTowerCalibration::InitRun(PHCompositeNode *topNode)
+{
+  std::string geonodename = "CYLINDERCELLGEOM_" + detector;
+  PHG4CylinderCellGeomContainer* cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, geonodename.c_str());
+  if (!cellgeos)
+    {
+      std::cerr << PHWHERE << " " << geonodename << " Node missing, doing nothing." << std::endl;
+      throw std::runtime_error("Failed to find " + geonodename + " node in RawTowerCalibration::CreateNodes");
+    }
+
+  // fill the number of layers in the calorimeter
+  _nlayers = cellgeos->get_NLayers();
+
+
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode;
+  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+    {
+      std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+      exit(1);
+    }
+
+
+  try
+    {
+      CreateNodes(topNode);
+    }
+  catch (std::exception& e)
+    {
+      std::cout << e.what() << std::endl;
+      //exit(1);
+    }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int 
+RawTowerCalibration::process_event(PHCompositeNode *topNode)
+{
+  if (verbosity)
+    {
+      std::cout << PHWHERE << "Process event entered" << std::endl;
+    }
+
+  // get cells
+  std::string cellnodename = "G4CELL_" + detector;
+  PHG4CylinderCellContainer* cells = findNode::getClass<PHG4CylinderCellContainer>(topNode, cellnodename.c_str());
+  if (!cells)
+    {
+      std::cerr << PHWHERE << " " << cellnodename << " Node missing, doing nothing." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+  // loop over all cells in an event
+  PHG4CylinderCellContainer::ConstIterator cell_iter;
+  PHG4CylinderCellContainer::ConstRange cell_range = cells->getCylinderCells();
+  for (cell_iter = cell_range.first; cell_iter != cell_range.second; ++cell_iter)
+    {
+      PHG4CylinderCell *cell = cell_iter->second;
+
+      if (verbosity > 2)
+        {
+          std::cout << PHWHERE << " print out the cell:" << std::endl;
+          cell->identify();
+        }
+
+      // add the energy to the corresponding tower
+       RawTower *tower = _towers->getTower(cell->get_binz(),cell->get_binphi());
+       if (! tower)
+	 {
+	   tower = new RawTowerv1(cell->get_binz(), cell->get_binphi());
+	   _towers->AddTower(cell->get_binz(), cell->get_binphi(), tower);
+	 }
+       tower->add_ecell(cell->get_cell_id(), cell->get_edep());
+       tower->set_light_yield( tower->get_light_yield() +  cell->get_light_yield()  );
+       rawtowergeom =  findNode::getClass<RawTowerGeom>(topNode, TowerGeomNodeName.c_str());
+       if (verbosity > 2)
+	 {
+           tower->identify();
+	 }
+    }
+  double towerE = 0;
+  if (chkenergyconservation)
+    {
+      double cellE = cells->getTotalEdep();
+      towerE = _towers->getTotalEdep();
+      if (fabs(cellE - towerE) / cellE > 1e-5)
+	{
+	  cout << "towerE: " << towerE << ", cellE: " << cellE << ", delta: " << cellE - towerE << endl;
+	}
+    }
+  if (verbosity)
+    {
+      towerE = _towers->getTotalEdep();
+    }
+
+  _towers->compress(emin);
+  if (verbosity)
+    {
+      cout << "Energy lost by dropping towers with less than "
+	   << emin << " energy, lost energy: "  << towerE - _towers->getTotalEdep() << endl;
+      _towers->identify();
+      RawTowerContainer::ConstRange begin_end = _towers->getTowers();
+      RawTowerContainer::ConstIterator iter;
+      for (iter =  begin_end.first; iter != begin_end.second; ++iter)
+	{
+	  iter->second->identify();
+        }
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int 
+RawTowerCalibration::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void 
+RawTowerCalibration::CreateNodes(PHCompositeNode *topNode)
+{
+
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *runNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
+  if (!runNode)
+    {
+      std::cerr << PHWHERE << "Run Node missing, doing nothing." << std::endl;
+      throw std::runtime_error("Failed to find Run node in RawTowerCalibration::CreateNodes");
+    }
+
+  // get the cell geometry and build up the tower geometry object
+  std::string geonodename = "CYLINDERCELLGEOM_" + detector;
+  PHG4CylinderCellGeomContainer* cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, geonodename.c_str());
+  if (!cellgeos)
+    {
+      std::cerr << PHWHERE << " " << geonodename << " Node missing, doing nothing." << std::endl;
+      throw std::runtime_error("Failed to find " + geonodename + " node in RawTowerCalibration::CreateNodes");
+    }
+  TowerGeomNodeName = "TOWERGEOM_" + detector;
+  rawtowergeom =  findNode::getClass<RawTowerGeom>(topNode, TowerGeomNodeName.c_str());
+  if (! rawtowergeom)
+    {
+
+      rawtowergeom = new RawTowerGeomv2();
+      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom, TowerGeomNodeName.c_str(), "PHObject");
+      runNode->addNode(newNode);
+    }
+  // fill the number of layers in the calorimeter
+  _nlayers = cellgeos->get_NLayers();
+
+  // Create the tower nodes on the tree
+  std::map<int, PHG4CylinderCellGeom *>::const_iterator miter;
+  std::pair <std::map<int, PHG4CylinderCellGeom *>::const_iterator, std::map<int, PHG4CylinderCellGeom *>::const_iterator> begin_end = cellgeos->get_begin_end();
+  int ifirst = 1;
+  int first_layer = -1;
+  PHG4CylinderCellGeom * first_cellgeo = NULL;
+  double inner_radius = 0;
+  double thickness = 0;
+  for (miter = begin_end.first; miter != begin_end.second; ++miter)
+    {
+      PHG4CylinderCellGeom *cellgeo = miter->second;
+      first_cellgeo = miter->second;
+
+      if (verbosity)
+	{
+	  cellgeo->identify();
+	}
+      thickness += cellgeo->get_thickness();
+      if (ifirst)
+	{
+	  _cell_binning = cellgeo->get_binning();
+	  _nphibins = cellgeo->get_phibins();
+	  _phimin = cellgeo->get_phimin();
+	  _phistep = cellgeo->get_phistep();
+          if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
+              or _cell_binning == PHG4CylinderCellDefs::etaslatbinning)
+            {
+              _netabins = cellgeo->get_etabins();
+              _etamin = cellgeo->get_etamin();
+              _etastep = cellgeo->get_etastep();
+            }
+          else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
+            {
+              _netabins = cellgeo->get_zbins();// bin eta in the same number of z bins
+            }
+          else if (_cell_binning == PHG4CylinderCellDefs::spacalbinning)
+            {
+              // use eta definiton for each row of towers
+              _netabins = cellgeo->get_etabins();
+            }
+          else
+            {
+              cout <<"RawTowerCalibration::CreateNodes::"<<Name()
+		   <<" - Fatal Error - unsupported cell binning method "<<_cell_binning<<endl;
+            }
+	  inner_radius = cellgeo->get_radius();
+	  first_layer = cellgeo->get_layer();
+	  ifirst = 0;
+	}
+      else
+	{
+          if (_cell_binning != cellgeo->get_binning())
+            {
+              cout << "inconsistent binning method from " << _cell_binning
+             << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_binning()
+             << endl;
+              exit(1);
+            }
+	  if (inner_radius > cellgeo->get_radius())
+	    {
+	      cout << "radius of layer " << cellgeo->get_layer() 
+		   << " is " << cellgeo->get_radius()
+		   << " which smaller than radius " << inner_radius
+		   << " of first layer in list " << first_layer
+		   << endl;
+	    }
+	  if (_nphibins != cellgeo->get_phibins())
+	    {
+	      cout << "mixing number of phibins, fisrt layer: " << _nphibins
+		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phibins()
+		   << endl;
+	      exit(1);
+	    }
+	  if ( _phimin != cellgeo->get_phimin())
+	    {
+	      cout << "mixing number of phimin, fisrt layer: " << _phimin
+		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phimin()
+		   << endl;
+	      exit(1);
+	    }
+	  if (_phistep != cellgeo->get_phistep())
+	    {
+	      cout << "mixing phisteps first layer: " << _phistep
+		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phistep()
+		   << " diff: " << _phistep - cellgeo->get_phistep()
+		   << endl;
+	      exit(1);
+	    }
+          if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
+              or _cell_binning == PHG4CylinderCellDefs::etaslatbinning)
+            {
+              if (_netabins != cellgeo->get_etabins())
+                {
+                  cout << "mixing number of_netabins , fisrt layer: " << _netabins
+                 << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_etabins()
+                 << endl;
+                  exit(1);
+                }
+              if (fabs(_etamin - cellgeo->get_etamin()) > 1e-9)
+                {
+                  cout << "mixing etamin, fisrt layer: " << _etamin << " layer "
+                      << cellgeo->get_layer() << ": " << cellgeo->get_etamin()
+                      << " diff: " << _etamin - cellgeo->get_etamin() << endl;
+                  exit(1);
+                }
+              if (fabs(_etastep - cellgeo->get_etastep()) > 1e-9)
+                {
+                  cout << "mixing eta steps first layer: " << _etastep
+                      << " layer " << cellgeo->get_layer() << ": "
+                      << cellgeo->get_etastep() << " diff: "
+                      << _etastep - cellgeo->get_etastep() << endl;
+                  exit(1);
+                }
+            }
+
+          else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
+            {
+
+              if (_netabins != cellgeo->get_zbins())
+                {
+                  cout << "mixing number of z bins , fisrt layer: " << _netabins
+                 << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_zbins()
+                 << endl;
+                  exit(1);
+                }
+            }
+	}
+    }
+  rawtowergeom->set_radius(inner_radius);
+  rawtowergeom->set_thickness(thickness);
+  rawtowergeom->set_phibins(_nphibins);
+  rawtowergeom->set_phistep(_phistep);
+  rawtowergeom->set_phimin(_phimin);
+  rawtowergeom->set_etabins(_netabins);
+
+  if (first_cellgeo == NULL)
+    {
+      cout <<"RawTowerCalibration::CreateNodes - ERROR - can not find first layer of cells "<<endl;
+
+      exit(1);
+    }
+
+  if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
+      or _cell_binning == PHG4CylinderCellDefs::etaslatbinning
+      or _cell_binning == PHG4CylinderCellDefs::spacalbinning
+      )
+    {
+//  rawtowergeom->set_etamin(_etamin);
+//  rawtowergeom->set_etastep(_etastep);
+      for (int ibin = 0; ibin<first_cellgeo->get_etabins(); ibin++)
+        {
+
+          const pair<double, double> range = first_cellgeo -> get_etabounds(ibin);
+
+          rawtowergeom->set_etabounds(ibin, range);
+        }
+
+    }
+  else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
+    {
+      for (int ibin = 0; ibin<first_cellgeo->get_zbins(); ibin++)
+        {
+
+          const pair<double, double> z_range = first_cellgeo -> get_zbounds(ibin);
+          const double r = first_cellgeo->get_radius();
+          const double eta1 = -log (tan(atan2(r, z_range.first)/2.) );
+          const double eta2 = -log (tan(atan2(r, z_range.second)/2.) );
+          rawtowergeom->set_etabounds(ibin, make_pair(eta1, eta2));
+        }
+
+    }
+  else
+    {
+      cout <<"RawTowerCalibration::CreateNodes - ERROR - unsupported cell geometry "<<_cell_binning<<endl;
+      exit(1);
+    }
+
+  if (verbosity >= 1)
+    {
+      rawtowergeom->identify();
+    }
+
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+    {
+      std::cerr << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+      throw std::runtime_error("Failed to find DST node in RawTowerCalibration::CreateNodes");
+    }
+
+  // Create the tower nodes on the tree
+  _towers = new RawTowerContainer();
+  TowerNodeName = "TOWER_SIM_" + detector;
+  PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers, TowerNodeName.c_str(), "PHObject");
+  dstNode->addNode(towerNode);
+
+  return;
+}
+
+
+
+

--- a/simulation/g4simulation/g4cemc/RawTowerCalibration.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCalibration.h
@@ -30,7 +30,8 @@ class RawTowerCalibration : public SubsysReco {
   RawTowerGeom *rawtowergeom;
 
   std::string detector;
-  std::string TowerNodeName;
+  std::string RawTowerNodeName;
+  std::string CaliTowerNodeName;
   std::string TowerGeomNodeName;
 
   int _cell_binning;

--- a/simulation/g4simulation/g4cemc/RawTowerCalibration.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCalibration.h
@@ -10,24 +10,120 @@ class PHCompositeNode;
 class RawTowerContainer;
 class RawTowerGeom;
 
-//! simple calibration for a linear scale and pedstal calibration cross all channels
-class RawTowerCalibration : public SubsysReco {
+//! calibrate ADC value to measured energy deposition in calorimeter towers
+//! default input DST node is TOWER_RAW_DETECTOR
+//! default output DST node is TOWER_CALIB_DETECTOR
+class RawTowerCalibration : public SubsysReco
+{
 
- public:
-  RawTowerCalibration(const std::string& name="RawTowerCalibration");
-  virtual ~RawTowerCalibration(){}
+public:
+  RawTowerCalibration(const std::string& name = "RawTowerCalibration");
+  virtual
+  ~RawTowerCalibration()
+  {
+  }
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
-  void Detector(const std::string &d) {detector = d;}
-  void EminCut(const double e) {emin = e;}
-  void checkenergy(const int i = 1) {chkenergyconservation = i;}
+  int
+  InitRun(PHCompositeNode *topNode);
+  int
+  process_event(PHCompositeNode *topNode);
+  int
+  End(PHCompositeNode *topNode);
+  void
+  Detector(const std::string &d)
+  {
+    detector = d;
+  }
 
- protected:
-  void CreateNodes(PHCompositeNode *topNode);
+  enum enu_calib_algorithm
+  {
+    //! directly pass the energy of raw tower to calibrated tower. Zero suppression is applied
+    kNo_calibration = 0,
 
-  RawTowerContainer* _towers;
+    //! simple digitalization with photon statistics, ADC conversion and pedstal
+    kSimple_linear_calibration = 1
+  };
+
+  enu_calib_algorithm
+  get_calib_algorithm() const
+  {
+    return _calib_algorithm;
+  }
+
+  void
+  set_calib_algorithm(enu_calib_algorithm calibAlgorithm)
+  {
+    _calib_algorithm = calibAlgorithm;
+  }
+
+  double
+  get_calib_const_GeV_ADC() const
+  {
+    return _calib_const_GeV_ADC;
+  }
+
+  void
+  set_calib_const_GeV_ADC(double calibConstGeVAdc)
+  {
+    _calib_const_GeV_ADC = calibConstGeVAdc;
+  }
+
+  std::string
+  get_calib_tower_node_prefix() const
+  {
+    return _calib_tower_node_prefix;
+  }
+
+  void
+  set_calib_tower_node_prefix(std::string calibTowerNodePrefix)
+  {
+    _calib_tower_node_prefix = calibTowerNodePrefix;
+  }
+
+  double
+  get_pedstal_ADC() const
+  {
+    return _pedstal_ADC;
+  }
+
+  void
+  set_pedstal_ADC(double pedstalAdc)
+  {
+    _pedstal_ADC = pedstalAdc;
+  }
+
+  std::string
+  get_raw_tower_node_prefix() const
+  {
+    return _raw_tower_node_prefix;
+  }
+
+  void
+  set_raw_tower_node_prefix(std::string rawTowerNodePrefix)
+  {
+    _raw_tower_node_prefix = rawTowerNodePrefix;
+  }
+
+  double
+  get_zero_suppression_GeV() const
+  {
+    return _zero_suppression_GeV;
+  }
+
+  void
+  set_zero_suppression_GeV(double zeroSuppressionGeV)
+  {
+    _zero_suppression_GeV = zeroSuppressionGeV;
+  }
+
+protected:
+  void
+  CreateNodes(PHCompositeNode *topNode);
+
+  enu_calib_algorithm _calib_algorithm;
+
+  RawTowerContainer* _calib_towers;
+  RawTowerContainer* _raw_towers;
   RawTowerGeom *rawtowergeom;
 
   std::string detector;
@@ -35,16 +131,17 @@ class RawTowerCalibration : public SubsysReco {
   std::string CaliTowerNodeName;
   std::string TowerGeomNodeName;
 
-  int _cell_binning;
-  double emin;	
-  int chkenergyconservation;
-  int _nlayers;
-  int _nphibins;
-  int _netabins;
-  double _etamin;
-  double _phimin;
-  double _etastep;
-  double _phistep;
+  std::string _calib_tower_node_prefix;
+  std::string _raw_tower_node_prefix;
+
+  //! pedstal in unit of ADC
+  double _pedstal_ADC;
+
+  //! calibration constant in unit of GeV per ADC
+  double _calib_const_GeV_ADC;
+
+  //! zero suppression in unit of GeV
+  double _zero_suppression_GeV;
 
   PHTimeServer::timer _timer;
 

--- a/simulation/g4simulation/g4cemc/RawTowerCalibration.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCalibration.h
@@ -1,0 +1,51 @@
+#ifndef RawTowerCalibration_H__
+#define RawTowerCalibration_H__
+
+#include <fun4all/SubsysReco.h>
+#include <string>
+
+#include <phool/PHTimeServer.h>
+
+class PHCompositeNode;
+class RawTowerContainer;
+class RawTowerGeom;
+
+class RawTowerCalibration : public SubsysReco {
+
+ public:
+  RawTowerCalibration(const std::string& name="RawTowerCalibration");
+  virtual ~RawTowerCalibration(){}
+
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+  void Detector(const std::string &d) {detector = d;}
+  void EminCut(const double e) {emin = e;}
+  void checkenergy(const int i = 1) {chkenergyconservation = i;}
+
+ protected:
+  void CreateNodes(PHCompositeNode *topNode);
+
+  RawTowerContainer* _towers;
+  RawTowerGeom *rawtowergeom;
+
+  std::string detector;
+  std::string TowerNodeName;
+  std::string TowerGeomNodeName;
+
+  int _cell_binning;
+  double emin;	
+  int chkenergyconservation;
+  int _nlayers;
+  int _nphibins;
+  int _netabins;
+  double _etamin;
+  double _phimin;
+  double _etastep;
+  double _phistep;
+
+  PHTimeServer::timer _timer;
+
+};
+
+#endif /* RawTowerCalibration_H__ */

--- a/simulation/g4simulation/g4cemc/RawTowerCalibration.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCalibration.h
@@ -40,7 +40,7 @@ public:
     //! directly pass the energy of raw tower to calibrated tower. Zero suppression is applied
     kNo_calibration = 0,
 
-    //! simple digitalization with photon statistics, ADC conversion and pedstal
+    //! simple calibration with pedstal subtraction and a global energy scale (sampling fraction) correction
     kSimple_linear_calibration = 1
   };
 

--- a/simulation/g4simulation/g4cemc/RawTowerCalibration.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCalibration.h
@@ -10,6 +10,7 @@ class PHCompositeNode;
 class RawTowerContainer;
 class RawTowerGeom;
 
+//! simple calibration for a linear scale and pedstal calibration cross all channels
 class RawTowerCalibration : public SubsysReco {
 
  public:

--- a/simulation/g4simulation/g4cemc/RawTowerCalibrationLinkDef.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCalibrationLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RawTowerCalibration-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4cemc/RawTowerContainer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerContainer.cc
@@ -70,6 +70,13 @@ RawTowerContainer::AddTower(const unsigned int ieta, const int unsigned iphi, Ra
   return _towers.find(key);
 }
 
+RawTowerContainer::ConstIterator
+RawTowerContainer::AddTower(RawTowerDefs::keytype key, RawTower *twr)
+{
+  _towers[key] = twr;
+  return _towers.find(key);
+}
+
 RawTower *
 RawTowerContainer::getTower(RawTowerDefs::keytype key)
 {

--- a/simulation/g4simulation/g4cemc/RawTowerContainer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerContainer.h
@@ -27,6 +27,7 @@ class RawTowerContainer : public PHObject
   int isValid() const;
   void identify(std::ostream& os=std::cout) const;
   ConstIterator AddTower(const unsigned int ieta, const unsigned int iphi, RawTower *twr);
+  ConstIterator AddTower(RawTowerDefs::keytype key, RawTower *twr);
   RawTower *getTower(RawTowerDefs::keytype key);
   RawTower *getTower(const unsigned int ieta, const unsigned int iphi);
   //! return all towers

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
@@ -19,50 +19,27 @@
 
 using namespace std;
 
-RawTowerDigitizer::RawTowerDigitizer(const std::string& name):
-  SubsysReco(name),
-  _towers(NULL),
-  rawtowergeom(NULL),
-  detector("NONE"),
-  _cell_binning(PHG4CylinderCellDefs::undefined),
-  emin(1e-6),
-  chkenergyconservation(0),
-  _nlayers(-1),
-  _nphibins(-1),
-  _netabins(-1),
-  _etamin(NAN),
-  _phimin(NAN),
-  _etastep(NAN),
-  _phistep(NAN),
-  _timer( PHTimeServer::get()->insert_new(name) )
-{}
+RawTowerDigitizer::RawTowerDigitizer(const std::string& name) :
+    SubsysReco(name), _sim_towers(NULL), _raw_towers(NULL), rawtowergeom(NULL), detector(
+        "NONE"), emin(1e-6), _timer(PHTimeServer::get()->insert_new(name))
+{
+}
 
-int 
+int
 RawTowerDigitizer::InitRun(PHCompositeNode *topNode)
 {
-  std::string geonodename = "CYLINDERCELLGEOM_" + detector;
-  PHG4CylinderCellGeomContainer* cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, geonodename.c_str());
-  if (!cellgeos)
-    {
-      std::cerr << PHWHERE << " " << geonodename << " Node missing, doing nothing." << std::endl;
-      throw std::runtime_error("Failed to find " + geonodename + " node in RawTowerDigitizer::CreateNodes");
-    }
-
-  // fill the number of layers in the calorimeter
-  _nlayers = cellgeos->get_NLayers();
-
 
   PHNodeIterator iter(topNode);
 
   // Looking for the DST node
   PHCompositeNode *dstNode;
-  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",
+      "DST"));
   if (!dstNode)
     {
       std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
       exit(1);
     }
-
 
   try
     {
@@ -71,12 +48,12 @@ RawTowerDigitizer::InitRun(PHCompositeNode *topNode)
   catch (std::exception& e)
     {
       std::cout << e.what() << std::endl;
-      //exit(1);
+      return Fun4AllReturnCodes::ABORTRUN;
     }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int 
+int
 RawTowerDigitizer::process_event(PHCompositeNode *topNode)
 {
   if (verbosity)
@@ -84,288 +61,47 @@ RawTowerDigitizer::process_event(PHCompositeNode *topNode)
       std::cout << PHWHERE << "Process event entered" << std::endl;
     }
 
-  // get cells
-  std::string cellnodename = "G4CELL_" + detector;
-  PHG4CylinderCellContainer* cells = findNode::getClass<PHG4CylinderCellContainer>(topNode, cellnodename.c_str());
-  if (!cells)
-    {
-      std::cerr << PHWHERE << " " << cellnodename << " Node missing, doing nothing." << std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
-
-  // loop over all cells in an event
-  PHG4CylinderCellContainer::ConstIterator cell_iter;
-  PHG4CylinderCellContainer::ConstRange cell_range = cells->getCylinderCells();
-  for (cell_iter = cell_range.first; cell_iter != cell_range.second; ++cell_iter)
-    {
-      PHG4CylinderCell *cell = cell_iter->second;
-
-      if (verbosity > 2)
-        {
-          std::cout << PHWHERE << " print out the cell:" << std::endl;
-          cell->identify();
-        }
-
-      // add the energy to the corresponding tower
-       RawTower *tower = _towers->getTower(cell->get_binz(),cell->get_binphi());
-       if (! tower)
-	 {
-	   tower = new RawTowerv1(cell->get_binz(), cell->get_binphi());
-	   _towers->AddTower(cell->get_binz(), cell->get_binphi(), tower);
-	 }
-       tower->add_ecell(cell->get_cell_id(), cell->get_edep());
-       tower->set_light_yield( tower->get_light_yield() +  cell->get_light_yield()  );
-       rawtowergeom =  findNode::getClass<RawTowerGeom>(topNode, TowerGeomNodeName.c_str());
-       if (verbosity > 2)
-	 {
-           tower->identify();
-	 }
-    }
   double towerE = 0;
-  if (chkenergyconservation)
-    {
-      double cellE = cells->getTotalEdep();
-      towerE = _towers->getTotalEdep();
-      if (fabs(cellE - towerE) / cellE > 1e-5)
-	{
-	  cout << "towerE: " << towerE << ", cellE: " << cellE << ", delta: " << cellE - towerE << endl;
-	}
-    }
   if (verbosity)
     {
-      towerE = _towers->getTotalEdep();
+      towerE = _raw_towers->getTotalEdep();
     }
 
-  _towers->compress(emin);
-  if (verbosity)
-    {
-      cout << "Energy lost by dropping towers with less than "
-	   << emin << " energy, lost energy: "  << towerE - _towers->getTotalEdep() << endl;
-      _towers->identify();
-      RawTowerContainer::ConstRange begin_end = _towers->getTowers();
-      RawTowerContainer::ConstIterator iter;
-      for (iter =  begin_end.first; iter != begin_end.second; ++iter)
-	{
-	  iter->second->identify();
-        }
-    }
+  _raw_towers->compress(emin);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int 
+int
 RawTowerDigitizer::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void 
+void
 RawTowerDigitizer::CreateNodes(PHCompositeNode *topNode)
 {
 
   PHNodeIterator iter(topNode);
-  PHCompositeNode *runNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
+  PHCompositeNode *runNode = static_cast<PHCompositeNode*>(iter.findFirst(
+      "PHCompositeNode", "RUN"));
   if (!runNode)
     {
       std::cerr << PHWHERE << "Run Node missing, doing nothing." << std::endl;
-      throw std::runtime_error("Failed to find Run node in RawTowerDigitizer::CreateNodes");
+      throw std::runtime_error(
+          "Failed to find Run node in RawTowerDigitizer::CreateNodes");
     }
 
-  // get the cell geometry and build up the tower geometry object
-  std::string geonodename = "CYLINDERCELLGEOM_" + detector;
-  PHG4CylinderCellGeomContainer* cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, geonodename.c_str());
-  if (!cellgeos)
-    {
-      std::cerr << PHWHERE << " " << geonodename << " Node missing, doing nothing." << std::endl;
-      throw std::runtime_error("Failed to find " + geonodename + " node in RawTowerDigitizer::CreateNodes");
-    }
   TowerGeomNodeName = "TOWERGEOM_" + detector;
-  rawtowergeom =  findNode::getClass<RawTowerGeom>(topNode, TowerGeomNodeName.c_str());
-  if (! rawtowergeom)
+  rawtowergeom = findNode::getClass<RawTowerGeom>(topNode,
+      TowerGeomNodeName.c_str());
+  if (!rawtowergeom)
     {
-
-      rawtowergeom = new RawTowerGeomv2();
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom, TowerGeomNodeName.c_str(), "PHObject");
-      runNode->addNode(newNode);
-    }
-  // fill the number of layers in the calorimeter
-  _nlayers = cellgeos->get_NLayers();
-
-  // Create the tower nodes on the tree
-  std::map<int, PHG4CylinderCellGeom *>::const_iterator miter;
-  std::pair <std::map<int, PHG4CylinderCellGeom *>::const_iterator, std::map<int, PHG4CylinderCellGeom *>::const_iterator> begin_end = cellgeos->get_begin_end();
-  int ifirst = 1;
-  int first_layer = -1;
-  PHG4CylinderCellGeom * first_cellgeo = NULL;
-  double inner_radius = 0;
-  double thickness = 0;
-  for (miter = begin_end.first; miter != begin_end.second; ++miter)
-    {
-      PHG4CylinderCellGeom *cellgeo = miter->second;
-      first_cellgeo = miter->second;
-
-      if (verbosity)
-	{
-	  cellgeo->identify();
-	}
-      thickness += cellgeo->get_thickness();
-      if (ifirst)
-	{
-	  _cell_binning = cellgeo->get_binning();
-	  _nphibins = cellgeo->get_phibins();
-	  _phimin = cellgeo->get_phimin();
-	  _phistep = cellgeo->get_phistep();
-          if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
-              or _cell_binning == PHG4CylinderCellDefs::etaslatbinning)
-            {
-              _netabins = cellgeo->get_etabins();
-              _etamin = cellgeo->get_etamin();
-              _etastep = cellgeo->get_etastep();
-            }
-          else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
-            {
-              _netabins = cellgeo->get_zbins();// bin eta in the same number of z bins
-            }
-          else if (_cell_binning == PHG4CylinderCellDefs::spacalbinning)
-            {
-              // use eta definiton for each row of towers
-              _netabins = cellgeo->get_etabins();
-            }
-          else
-            {
-              cout <<"RawTowerDigitizer::CreateNodes::"<<Name()
-		   <<" - Fatal Error - unsupported cell binning method "<<_cell_binning<<endl;
-            }
-	  inner_radius = cellgeo->get_radius();
-	  first_layer = cellgeo->get_layer();
-	  ifirst = 0;
-	}
-      else
-	{
-          if (_cell_binning != cellgeo->get_binning())
-            {
-              cout << "inconsistent binning method from " << _cell_binning
-             << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_binning()
-             << endl;
-              exit(1);
-            }
-	  if (inner_radius > cellgeo->get_radius())
-	    {
-	      cout << "radius of layer " << cellgeo->get_layer() 
-		   << " is " << cellgeo->get_radius()
-		   << " which smaller than radius " << inner_radius
-		   << " of first layer in list " << first_layer
-		   << endl;
-	    }
-	  if (_nphibins != cellgeo->get_phibins())
-	    {
-	      cout << "mixing number of phibins, fisrt layer: " << _nphibins
-		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phibins()
-		   << endl;
-	      exit(1);
-	    }
-	  if ( _phimin != cellgeo->get_phimin())
-	    {
-	      cout << "mixing number of phimin, fisrt layer: " << _phimin
-		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phimin()
-		   << endl;
-	      exit(1);
-	    }
-	  if (_phistep != cellgeo->get_phistep())
-	    {
-	      cout << "mixing phisteps first layer: " << _phistep
-		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phistep()
-		   << " diff: " << _phistep - cellgeo->get_phistep()
-		   << endl;
-	      exit(1);
-	    }
-          if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
-              or _cell_binning == PHG4CylinderCellDefs::etaslatbinning)
-            {
-              if (_netabins != cellgeo->get_etabins())
-                {
-                  cout << "mixing number of_netabins , fisrt layer: " << _netabins
-                 << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_etabins()
-                 << endl;
-                  exit(1);
-                }
-              if (fabs(_etamin - cellgeo->get_etamin()) > 1e-9)
-                {
-                  cout << "mixing etamin, fisrt layer: " << _etamin << " layer "
-                      << cellgeo->get_layer() << ": " << cellgeo->get_etamin()
-                      << " diff: " << _etamin - cellgeo->get_etamin() << endl;
-                  exit(1);
-                }
-              if (fabs(_etastep - cellgeo->get_etastep()) > 1e-9)
-                {
-                  cout << "mixing eta steps first layer: " << _etastep
-                      << " layer " << cellgeo->get_layer() << ": "
-                      << cellgeo->get_etastep() << " diff: "
-                      << _etastep - cellgeo->get_etastep() << endl;
-                  exit(1);
-                }
-            }
-
-          else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
-            {
-
-              if (_netabins != cellgeo->get_zbins())
-                {
-                  cout << "mixing number of z bins , fisrt layer: " << _netabins
-                 << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_zbins()
-                 << endl;
-                  exit(1);
-                }
-            }
-	}
-    }
-  rawtowergeom->set_radius(inner_radius);
-  rawtowergeom->set_thickness(thickness);
-  rawtowergeom->set_phibins(_nphibins);
-  rawtowergeom->set_phistep(_phistep);
-  rawtowergeom->set_phimin(_phimin);
-  rawtowergeom->set_etabins(_netabins);
-
-  if (first_cellgeo == NULL)
-    {
-      cout <<"RawTowerDigitizer::CreateNodes - ERROR - can not find first layer of cells "<<endl;
-
-      exit(1);
-    }
-
-  if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
-      or _cell_binning == PHG4CylinderCellDefs::etaslatbinning
-      or _cell_binning == PHG4CylinderCellDefs::spacalbinning
-      )
-    {
-//  rawtowergeom->set_etamin(_etamin);
-//  rawtowergeom->set_etastep(_etastep);
-      for (int ibin = 0; ibin<first_cellgeo->get_etabins(); ibin++)
-        {
-
-          const pair<double, double> range = first_cellgeo -> get_etabounds(ibin);
-
-          rawtowergeom->set_etabounds(ibin, range);
-        }
-
-    }
-  else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
-    {
-      for (int ibin = 0; ibin<first_cellgeo->get_zbins(); ibin++)
-        {
-
-          const pair<double, double> z_range = first_cellgeo -> get_zbounds(ibin);
-          const double r = first_cellgeo->get_radius();
-          const double eta1 = -log (tan(atan2(r, z_range.first)/2.) );
-          const double eta2 = -log (tan(atan2(r, z_range.second)/2.) );
-          rawtowergeom->set_etabounds(ibin, make_pair(eta1, eta2));
-        }
-
-    }
-  else
-    {
-      cout <<"RawTowerDigitizer::CreateNodes - ERROR - unsupported cell geometry "<<_cell_binning<<endl;
-      exit(1);
+      std::cerr << PHWHERE << " " << TowerGeomNodeName
+          << " Node missing, doing bail out!" << std::endl;
+      throw std::runtime_error(
+          "Failed to find " + TowerGeomNodeName
+              + " node in RawTowerDigitizer::CreateNodes");
     }
 
   if (verbosity >= 1)
@@ -373,22 +109,34 @@ RawTowerDigitizer::CreateNodes(PHCompositeNode *topNode)
       rawtowergeom->identify();
     }
 
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+      "PHCompositeNode", "DST"));
   if (!dstNode)
     {
       std::cerr << PHWHERE << "DST Node missing, doing nothing." << std::endl;
-      throw std::runtime_error("Failed to find DST node in RawTowerDigitizer::CreateNodes");
+      throw std::runtime_error(
+          "Failed to find DST node in RawTowerDigitizer::CreateNodes");
+    }
+
+  SimTowerNodeName = "TOWER_SIM_" + detector;
+  _raw_towers = findNode::getClass<RawTowerContainer>(dstNode,
+      SimTowerNodeName.c_str());
+  if (!_raw_towers)
+    {
+      std::cerr << PHWHERE << " " << SimTowerNodeName
+          << " Node missing, doing bail out!" << std::endl;
+      throw std::runtime_error(
+          "Failed to find " + SimTowerNodeName
+              + " node in RawTowerDigitizer::CreateNodes");
     }
 
   // Create the tower nodes on the tree
-  _towers = new RawTowerContainer();
-  TowerNodeName = "TOWER_SIM_" + detector;
-  PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers, TowerNodeName.c_str(), "PHObject");
+  _raw_towers = new RawTowerContainer();
+  RawTowerNodeName = "TOWER_RAW_" + detector;
+  PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_raw_towers,
+      RawTowerNodeName.c_str(), "PHObject");
   dstNode->addNode(towerNode);
 
   return;
 }
-
-
-
 

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
@@ -265,11 +265,18 @@ RawTowerDigitizer::CreateNodes(PHCompositeNode *topNode)
     }
 
   // Create the tower nodes on the tree
+  PHNodeIterator dstiter(dstNode);
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",detector ));
+  if(!DetNode){
+      DetNode = new PHCompositeNode(detector);
+      dstNode->addNode(DetNode);
+   }
+
   _raw_towers = new RawTowerContainer();
   RawTowerNodeName = "TOWER_RAW_" + detector;
   PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_raw_towers,
       RawTowerNodeName.c_str(), "PHObject");
-  dstNode->addNode(towerNode);
+  DetNode->addNode(towerNode);
 
   return;
 }

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
@@ -10,12 +10,16 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHIODataNode.h>
+#include <phool/PHRandomSeed.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/getClass.h>
+#include <fun4all/recoConsts.h>
 
 #include <iostream>
 #include <stdexcept>
 #include <map>
+
+#include <gsl/gsl_rng.h>
 
 using namespace std;
 
@@ -23,6 +27,29 @@ RawTowerDigitizer::RawTowerDigitizer(const std::string& name) :
     SubsysReco(name), _sim_towers(NULL), _raw_towers(NULL), rawtowergeom(NULL), detector(
         "NONE"), emin(1e-6), _timer(PHTimeServer::get()->insert_new(name))
 {
+  RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
+  recoConsts *rc = recoConsts::instance();
+  if (rc->FlagExist("RANDOMSEED"))
+    {
+      seed = rc->get_IntFlag("RANDOMSEED");
+    }
+  else
+    {
+      seed = PHRandomSeed();
+    }
+  gsl_rng_set(RandomGenerator, seed);
+}
+
+RawTowerDigitizer::~RawTowerDigitizer()
+{
+  gsl_rng_free(RandomGenerator);
+}
+
+void
+RawTowerDigitizer::set_seed(const unsigned int iseed)
+{
+  seed = iseed;
+  gsl_rng_set(RandomGenerator,seed);
 }
 
 int

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
@@ -1,0 +1,394 @@
+#include "RawTowerDigitizer.h"
+#include "RawTowerContainer.h"
+#include "RawTowerGeomv2.h"
+#include "RawTowerv1.h"
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellContainer.h>
+#include <g4detectors/PHG4CylinderCell.h>
+#include <g4detectors/PHG4CylinderCellDefs.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/getClass.h>
+
+#include <iostream>
+#include <stdexcept>
+#include <map>
+
+using namespace std;
+
+RawTowerDigitizer::RawTowerDigitizer(const std::string& name):
+  SubsysReco(name),
+  _towers(NULL),
+  rawtowergeom(NULL),
+  detector("NONE"),
+  _cell_binning(PHG4CylinderCellDefs::undefined),
+  emin(1e-6),
+  chkenergyconservation(0),
+  _nlayers(-1),
+  _nphibins(-1),
+  _netabins(-1),
+  _etamin(NAN),
+  _phimin(NAN),
+  _etastep(NAN),
+  _phistep(NAN),
+  _timer( PHTimeServer::get()->insert_new(name) )
+{}
+
+int 
+RawTowerDigitizer::InitRun(PHCompositeNode *topNode)
+{
+  std::string geonodename = "CYLINDERCELLGEOM_" + detector;
+  PHG4CylinderCellGeomContainer* cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, geonodename.c_str());
+  if (!cellgeos)
+    {
+      std::cerr << PHWHERE << " " << geonodename << " Node missing, doing nothing." << std::endl;
+      throw std::runtime_error("Failed to find " + geonodename + " node in RawTowerDigitizer::CreateNodes");
+    }
+
+  // fill the number of layers in the calorimeter
+  _nlayers = cellgeos->get_NLayers();
+
+
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode;
+  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+    {
+      std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+      exit(1);
+    }
+
+
+  try
+    {
+      CreateNodes(topNode);
+    }
+  catch (std::exception& e)
+    {
+      std::cout << e.what() << std::endl;
+      //exit(1);
+    }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int 
+RawTowerDigitizer::process_event(PHCompositeNode *topNode)
+{
+  if (verbosity)
+    {
+      std::cout << PHWHERE << "Process event entered" << std::endl;
+    }
+
+  // get cells
+  std::string cellnodename = "G4CELL_" + detector;
+  PHG4CylinderCellContainer* cells = findNode::getClass<PHG4CylinderCellContainer>(topNode, cellnodename.c_str());
+  if (!cells)
+    {
+      std::cerr << PHWHERE << " " << cellnodename << " Node missing, doing nothing." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+  // loop over all cells in an event
+  PHG4CylinderCellContainer::ConstIterator cell_iter;
+  PHG4CylinderCellContainer::ConstRange cell_range = cells->getCylinderCells();
+  for (cell_iter = cell_range.first; cell_iter != cell_range.second; ++cell_iter)
+    {
+      PHG4CylinderCell *cell = cell_iter->second;
+
+      if (verbosity > 2)
+        {
+          std::cout << PHWHERE << " print out the cell:" << std::endl;
+          cell->identify();
+        }
+
+      // add the energy to the corresponding tower
+       RawTower *tower = _towers->getTower(cell->get_binz(),cell->get_binphi());
+       if (! tower)
+	 {
+	   tower = new RawTowerv1(cell->get_binz(), cell->get_binphi());
+	   _towers->AddTower(cell->get_binz(), cell->get_binphi(), tower);
+	 }
+       tower->add_ecell(cell->get_cell_id(), cell->get_edep());
+       tower->set_light_yield( tower->get_light_yield() +  cell->get_light_yield()  );
+       rawtowergeom =  findNode::getClass<RawTowerGeom>(topNode, TowerGeomNodeName.c_str());
+       if (verbosity > 2)
+	 {
+           tower->identify();
+	 }
+    }
+  double towerE = 0;
+  if (chkenergyconservation)
+    {
+      double cellE = cells->getTotalEdep();
+      towerE = _towers->getTotalEdep();
+      if (fabs(cellE - towerE) / cellE > 1e-5)
+	{
+	  cout << "towerE: " << towerE << ", cellE: " << cellE << ", delta: " << cellE - towerE << endl;
+	}
+    }
+  if (verbosity)
+    {
+      towerE = _towers->getTotalEdep();
+    }
+
+  _towers->compress(emin);
+  if (verbosity)
+    {
+      cout << "Energy lost by dropping towers with less than "
+	   << emin << " energy, lost energy: "  << towerE - _towers->getTotalEdep() << endl;
+      _towers->identify();
+      RawTowerContainer::ConstRange begin_end = _towers->getTowers();
+      RawTowerContainer::ConstIterator iter;
+      for (iter =  begin_end.first; iter != begin_end.second; ++iter)
+	{
+	  iter->second->identify();
+        }
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int 
+RawTowerDigitizer::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void 
+RawTowerDigitizer::CreateNodes(PHCompositeNode *topNode)
+{
+
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *runNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
+  if (!runNode)
+    {
+      std::cerr << PHWHERE << "Run Node missing, doing nothing." << std::endl;
+      throw std::runtime_error("Failed to find Run node in RawTowerDigitizer::CreateNodes");
+    }
+
+  // get the cell geometry and build up the tower geometry object
+  std::string geonodename = "CYLINDERCELLGEOM_" + detector;
+  PHG4CylinderCellGeomContainer* cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, geonodename.c_str());
+  if (!cellgeos)
+    {
+      std::cerr << PHWHERE << " " << geonodename << " Node missing, doing nothing." << std::endl;
+      throw std::runtime_error("Failed to find " + geonodename + " node in RawTowerDigitizer::CreateNodes");
+    }
+  TowerGeomNodeName = "TOWERGEOM_" + detector;
+  rawtowergeom =  findNode::getClass<RawTowerGeom>(topNode, TowerGeomNodeName.c_str());
+  if (! rawtowergeom)
+    {
+
+      rawtowergeom = new RawTowerGeomv2();
+      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom, TowerGeomNodeName.c_str(), "PHObject");
+      runNode->addNode(newNode);
+    }
+  // fill the number of layers in the calorimeter
+  _nlayers = cellgeos->get_NLayers();
+
+  // Create the tower nodes on the tree
+  std::map<int, PHG4CylinderCellGeom *>::const_iterator miter;
+  std::pair <std::map<int, PHG4CylinderCellGeom *>::const_iterator, std::map<int, PHG4CylinderCellGeom *>::const_iterator> begin_end = cellgeos->get_begin_end();
+  int ifirst = 1;
+  int first_layer = -1;
+  PHG4CylinderCellGeom * first_cellgeo = NULL;
+  double inner_radius = 0;
+  double thickness = 0;
+  for (miter = begin_end.first; miter != begin_end.second; ++miter)
+    {
+      PHG4CylinderCellGeom *cellgeo = miter->second;
+      first_cellgeo = miter->second;
+
+      if (verbosity)
+	{
+	  cellgeo->identify();
+	}
+      thickness += cellgeo->get_thickness();
+      if (ifirst)
+	{
+	  _cell_binning = cellgeo->get_binning();
+	  _nphibins = cellgeo->get_phibins();
+	  _phimin = cellgeo->get_phimin();
+	  _phistep = cellgeo->get_phistep();
+          if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
+              or _cell_binning == PHG4CylinderCellDefs::etaslatbinning)
+            {
+              _netabins = cellgeo->get_etabins();
+              _etamin = cellgeo->get_etamin();
+              _etastep = cellgeo->get_etastep();
+            }
+          else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
+            {
+              _netabins = cellgeo->get_zbins();// bin eta in the same number of z bins
+            }
+          else if (_cell_binning == PHG4CylinderCellDefs::spacalbinning)
+            {
+              // use eta definiton for each row of towers
+              _netabins = cellgeo->get_etabins();
+            }
+          else
+            {
+              cout <<"RawTowerDigitizer::CreateNodes::"<<Name()
+		   <<" - Fatal Error - unsupported cell binning method "<<_cell_binning<<endl;
+            }
+	  inner_radius = cellgeo->get_radius();
+	  first_layer = cellgeo->get_layer();
+	  ifirst = 0;
+	}
+      else
+	{
+          if (_cell_binning != cellgeo->get_binning())
+            {
+              cout << "inconsistent binning method from " << _cell_binning
+             << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_binning()
+             << endl;
+              exit(1);
+            }
+	  if (inner_radius > cellgeo->get_radius())
+	    {
+	      cout << "radius of layer " << cellgeo->get_layer() 
+		   << " is " << cellgeo->get_radius()
+		   << " which smaller than radius " << inner_radius
+		   << " of first layer in list " << first_layer
+		   << endl;
+	    }
+	  if (_nphibins != cellgeo->get_phibins())
+	    {
+	      cout << "mixing number of phibins, fisrt layer: " << _nphibins
+		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phibins()
+		   << endl;
+	      exit(1);
+	    }
+	  if ( _phimin != cellgeo->get_phimin())
+	    {
+	      cout << "mixing number of phimin, fisrt layer: " << _phimin
+		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phimin()
+		   << endl;
+	      exit(1);
+	    }
+	  if (_phistep != cellgeo->get_phistep())
+	    {
+	      cout << "mixing phisteps first layer: " << _phistep
+		   << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_phistep()
+		   << " diff: " << _phistep - cellgeo->get_phistep()
+		   << endl;
+	      exit(1);
+	    }
+          if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
+              or _cell_binning == PHG4CylinderCellDefs::etaslatbinning)
+            {
+              if (_netabins != cellgeo->get_etabins())
+                {
+                  cout << "mixing number of_netabins , fisrt layer: " << _netabins
+                 << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_etabins()
+                 << endl;
+                  exit(1);
+                }
+              if (fabs(_etamin - cellgeo->get_etamin()) > 1e-9)
+                {
+                  cout << "mixing etamin, fisrt layer: " << _etamin << " layer "
+                      << cellgeo->get_layer() << ": " << cellgeo->get_etamin()
+                      << " diff: " << _etamin - cellgeo->get_etamin() << endl;
+                  exit(1);
+                }
+              if (fabs(_etastep - cellgeo->get_etastep()) > 1e-9)
+                {
+                  cout << "mixing eta steps first layer: " << _etastep
+                      << " layer " << cellgeo->get_layer() << ": "
+                      << cellgeo->get_etastep() << " diff: "
+                      << _etastep - cellgeo->get_etastep() << endl;
+                  exit(1);
+                }
+            }
+
+          else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
+            {
+
+              if (_netabins != cellgeo->get_zbins())
+                {
+                  cout << "mixing number of z bins , fisrt layer: " << _netabins
+                 << " layer " << cellgeo->get_layer() << ": " << cellgeo->get_zbins()
+                 << endl;
+                  exit(1);
+                }
+            }
+	}
+    }
+  rawtowergeom->set_radius(inner_radius);
+  rawtowergeom->set_thickness(thickness);
+  rawtowergeom->set_phibins(_nphibins);
+  rawtowergeom->set_phistep(_phistep);
+  rawtowergeom->set_phimin(_phimin);
+  rawtowergeom->set_etabins(_netabins);
+
+  if (first_cellgeo == NULL)
+    {
+      cout <<"RawTowerDigitizer::CreateNodes - ERROR - can not find first layer of cells "<<endl;
+
+      exit(1);
+    }
+
+  if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
+      or _cell_binning == PHG4CylinderCellDefs::etaslatbinning
+      or _cell_binning == PHG4CylinderCellDefs::spacalbinning
+      )
+    {
+//  rawtowergeom->set_etamin(_etamin);
+//  rawtowergeom->set_etastep(_etastep);
+      for (int ibin = 0; ibin<first_cellgeo->get_etabins(); ibin++)
+        {
+
+          const pair<double, double> range = first_cellgeo -> get_etabounds(ibin);
+
+          rawtowergeom->set_etabounds(ibin, range);
+        }
+
+    }
+  else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
+    {
+      for (int ibin = 0; ibin<first_cellgeo->get_zbins(); ibin++)
+        {
+
+          const pair<double, double> z_range = first_cellgeo -> get_zbounds(ibin);
+          const double r = first_cellgeo->get_radius();
+          const double eta1 = -log (tan(atan2(r, z_range.first)/2.) );
+          const double eta2 = -log (tan(atan2(r, z_range.second)/2.) );
+          rawtowergeom->set_etabounds(ibin, make_pair(eta1, eta2));
+        }
+
+    }
+  else
+    {
+      cout <<"RawTowerDigitizer::CreateNodes - ERROR - unsupported cell geometry "<<_cell_binning<<endl;
+      exit(1);
+    }
+
+  if (verbosity >= 1)
+    {
+      rawtowergeom->identify();
+    }
+
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+    {
+      std::cerr << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+      throw std::runtime_error("Failed to find DST node in RawTowerDigitizer::CreateNodes");
+    }
+
+  // Create the tower nodes on the tree
+  _towers = new RawTowerContainer();
+  TowerNodeName = "TOWER_SIM_" + detector;
+  PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers, TowerNodeName.c_str(), "PHObject");
+  dstNode->addNode(towerNode);
+
+  return;
+}
+
+
+
+

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
@@ -119,9 +119,11 @@ RawTowerDigitizer::process_event(PHCompositeNode *topNode)
         RawTower *digi_tower = NULL;
 
         if (_digi_algorithm == kNo_digitalization)
-          if (sim_tower)
-            digi_tower = new RawTowerv1(*sim_tower);
-        if (_digi_algorithm == kSimple_photon_digitalization)
+          {
+            if (sim_tower)
+              digi_tower = new RawTowerv1(*sim_tower);
+          }
+        else if (_digi_algorithm == kSimple_photon_digitalization)
           digi_tower = simple_photon_digitalization(ieta, iphi, sim_tower);
         else
           {

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
@@ -10,6 +10,8 @@ class PHCompositeNode;
 class RawTowerContainer;
 class RawTowerGeom;
 
+class RawTower;
+
 // rootcint barfs with this header so we need to hide it
 #ifndef __CINT__
 #include <gsl/gsl_rng.h>
@@ -35,11 +37,6 @@ public:
   {
     detector = d;
   }
-  void
-  EminCut(const double e)
-  {
-    emin = e;
-  }
 
   void
   set_seed(const unsigned int iseed);
@@ -49,9 +46,96 @@ public:
     return seed;
   }
 
+  enum enu_digi_algorithm
+  {
+    //! simple digitalization with photon statistics, ADC conversion and pedstal
+    ksimple_photon_digitalization
+
+  };
+
+  enu_digi_algorithm
+  get_digi_algorithm() const
+  {
+    return _digi_algorithm;
+  }
+
+  void
+  set_digi_algorithm(enu_digi_algorithm digiAlgorithm)
+  {
+    _digi_algorithm = digiAlgorithm;
+  }
+
+  double
+  get_pedstal_central_ADC() const
+  {
+    return _pedstal_central_ADC;
+  }
+
+  void
+  set_pedstal_central_ADC(double pedstalCentralAdc)
+  {
+    _pedstal_central_ADC = pedstalCentralAdc;
+  }
+
+  double
+  get_pedstal_width_ADC() const
+  {
+    return _pedstal_width_ADC;
+  }
+
+  void
+  set_pedstal_width_ADC(double pedstalWidthAdc)
+  {
+    _pedstal_width_ADC = pedstalWidthAdc;
+  }
+
+  double
+  get_photonelec_ADC() const
+  {
+    return _photonelec_ADC;
+  }
+
+  void
+  set_photonelec_ADC(double photonelecAdc)
+  {
+    _photonelec_ADC = photonelecAdc;
+  }
+
+  double
+  get_photonelec_yield_visible_Ge_V() const
+  {
+    return _photonelec_yield_visible_GeV;
+  }
+
+  void
+  set_photonelec_yield_visible_Ge_V(double photonelecYieldVisibleGeV)
+  {
+    _photonelec_yield_visible_GeV = photonelecYieldVisibleGeV;
+  }
+
+  double
+  get_zero_suppression_ADC() const
+  {
+    return _zero_suppression_ADC;
+  }
+
+  void
+  set_zero_suppression_ADC(double zeroSuppressionAdc)
+  {
+    _zero_suppression_ADC = zeroSuppressionAdc;
+  }
+
 protected:
   void
   CreateNodes(PHCompositeNode *topNode);
+
+  enu_digi_algorithm _digi_algorithm;
+
+  //! simple digitalization with photon statistics, ADC conversion and pedstal
+  //! \param  sim_tower simulation tower input
+  //! \return a new RawTower object contain digitalized value of ADC output in RawTower::get_energy()
+  RawTower *
+  simple_photon_digitalization(RawTower * sim_tower);
 
   RawTowerContainer* _sim_towers;
   RawTowerContainer* _raw_towers;
@@ -62,8 +146,20 @@ protected:
   std::string RawTowerNodeName;
   std::string TowerGeomNodeName;
 
-  int _cell_binning;
-  double emin;
+  //! photon electron yield per GeV of visible energy
+  double _photonelec_yield_visible_GeV;
+
+  //! photon electron per ADC unit
+  double _photonelec_ADC;
+
+  //! pedstal central in unit of ADC
+  double _pedstal_central_ADC;
+
+  //! pedstal width in unit of ADC
+  double _pedstal_width_ADC;
+
+  //! zero suppression in unit of ADC
+  double _zero_suppression_ADC;
 
   PHTimeServer::timer _timer;
 

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
@@ -10,15 +10,19 @@ class PHCompositeNode;
 class RawTowerContainer;
 class RawTowerGeom;
 
+// rootcint barfs with this header so we need to hide it
+#ifndef __CINT__
+#include <gsl/gsl_rng.h>
+#endif
+
+//! simple tower digitizer which sum all cell to produce photon yield and pedstal noises
 class RawTowerDigitizer : public SubsysReco
 {
 
 public:
   RawTowerDigitizer(const std::string& name = "RawTowerDigitizer");
   virtual
-  ~RawTowerDigitizer()
-  {
-  }
+  ~RawTowerDigitizer();
 
   int
   InitRun(PHCompositeNode *topNode);
@@ -37,6 +41,14 @@ public:
     emin = e;
   }
 
+  void
+  set_seed(const unsigned int iseed);
+  unsigned int
+  get_seed() const
+  {
+    return seed;
+  }
+
 protected:
   void
   CreateNodes(PHCompositeNode *topNode);
@@ -53,9 +65,12 @@ protected:
   int _cell_binning;
   double emin;
 
-
   PHTimeServer::timer _timer;
 
+  unsigned int seed;
+#ifndef __CINT__
+  gsl_rng *RandomGenerator;
+#endif
 };
 
 #endif /* RawTowerDigitizer_H__ */

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
@@ -18,6 +18,8 @@ class RawTower;
 #endif
 
 //! simple tower digitizer which sum all cell to produce photon yield and pedstal noises
+//! default input DST node is TOWER_SIM_DETECTOR
+//! default output DST node is TOWER_RAW_DETECTOR
 class RawTowerDigitizer : public SubsysReco
 {
 
@@ -127,6 +129,29 @@ public:
     _zero_suppression_ADC = zeroSuppressionAdc;
   }
 
+  std::string
+  get_raw_tower_node_prefix() const
+  {
+    return _raw_tower_node_prefix;
+  }
+
+  void
+  set_raw_tower_node_prefix(std::string rawTowerNodePrefix)
+  {
+    _raw_tower_node_prefix = rawTowerNodePrefix;
+  }
+
+  std::string
+  get_sim_tower_node_prefix() const
+  {
+    return _sim_tower_node_prefix;
+  }
+
+  void
+  set_sim_tower_node_prefix(std::string simTowerNodePrefix)
+  {
+    _sim_tower_node_prefix = simTowerNodePrefix;
+  }
 protected:
   void
   CreateNodes(PHCompositeNode *topNode);
@@ -147,6 +172,9 @@ protected:
   std::string SimTowerNodeName;
   std::string RawTowerNodeName;
   std::string TowerGeomNodeName;
+
+  std::string _sim_tower_node_prefix;
+  std::string _raw_tower_node_prefix;
 
   //! photon electron yield per GeV of visible energy
   double _photonelec_yield_visible_GeV;

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
@@ -1,0 +1,51 @@
+#ifndef RawTowerDigitizer_H__
+#define RawTowerDigitizer_H__
+
+#include <fun4all/SubsysReco.h>
+#include <string>
+
+#include <phool/PHTimeServer.h>
+
+class PHCompositeNode;
+class RawTowerContainer;
+class RawTowerGeom;
+
+class RawTowerDigitizer : public SubsysReco {
+
+ public:
+  RawTowerDigitizer(const std::string& name="RawTowerDigitizer");
+  virtual ~RawTowerDigitizer(){}
+
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+  void Detector(const std::string &d) {detector = d;}
+  void EminCut(const double e) {emin = e;}
+  void checkenergy(const int i = 1) {chkenergyconservation = i;}
+
+ protected:
+  void CreateNodes(PHCompositeNode *topNode);
+
+  RawTowerContainer* _towers;
+  RawTowerGeom *rawtowergeom;
+
+  std::string detector;
+  std::string TowerNodeName;
+  std::string TowerGeomNodeName;
+
+  int _cell_binning;
+  double emin;	
+  int chkenergyconservation;
+  int _nlayers;
+  int _nphibins;
+  int _netabins;
+  double _etamin;
+  double _phimin;
+  double _etastep;
+  double _phistep;
+
+  PHTimeServer::timer _timer;
+
+};
+
+#endif /* RawTowerDigitizer_H__ */

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
@@ -48,8 +48,11 @@ public:
 
   enum enu_digi_algorithm
   {
+    //! directly pass the energy of sim tower to digitalized tower
+    kNo_digitalization = 0,
+
     //! simple digitalization with photon statistics, ADC conversion and pedstal
-    ksimple_photon_digitalization
+    kSimple_photon_digitalization = 1
 
   };
 
@@ -102,13 +105,13 @@ public:
   }
 
   double
-  get_photonelec_yield_visible_Ge_V() const
+  get_photonelec_yield_visible_GeV() const
   {
     return _photonelec_yield_visible_GeV;
   }
 
   void
-  set_photonelec_yield_visible_Ge_V(double photonelecYieldVisibleGeV)
+  set_photonelec_yield_visible_GeV(double photonelecYieldVisibleGeV)
   {
     _photonelec_yield_visible_GeV = photonelecYieldVisibleGeV;
   }

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
@@ -53,7 +53,6 @@ public:
 
     //! simple digitalization with photon statistics, ADC conversion and pedstal
     kSimple_photon_digitalization = 1
-
   };
 
   enu_digi_algorithm

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
@@ -10,39 +10,49 @@ class PHCompositeNode;
 class RawTowerContainer;
 class RawTowerGeom;
 
-class RawTowerDigitizer : public SubsysReco {
+class RawTowerDigitizer : public SubsysReco
+{
 
- public:
-  RawTowerDigitizer(const std::string& name="RawTowerDigitizer");
-  virtual ~RawTowerDigitizer(){}
+public:
+  RawTowerDigitizer(const std::string& name = "RawTowerDigitizer");
+  virtual
+  ~RawTowerDigitizer()
+  {
+  }
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
-  void Detector(const std::string &d) {detector = d;}
-  void EminCut(const double e) {emin = e;}
-  void checkenergy(const int i = 1) {chkenergyconservation = i;}
+  int
+  InitRun(PHCompositeNode *topNode);
+  int
+  process_event(PHCompositeNode *topNode);
+  int
+  End(PHCompositeNode *topNode);
+  void
+  Detector(const std::string &d)
+  {
+    detector = d;
+  }
+  void
+  EminCut(const double e)
+  {
+    emin = e;
+  }
 
- protected:
-  void CreateNodes(PHCompositeNode *topNode);
+protected:
+  void
+  CreateNodes(PHCompositeNode *topNode);
 
-  RawTowerContainer* _towers;
+  RawTowerContainer* _sim_towers;
+  RawTowerContainer* _raw_towers;
   RawTowerGeom *rawtowergeom;
 
   std::string detector;
-  std::string TowerNodeName;
+  std::string SimTowerNodeName;
+  std::string RawTowerNodeName;
   std::string TowerGeomNodeName;
 
   int _cell_binning;
-  double emin;	
-  int chkenergyconservation;
-  int _nlayers;
-  int _nphibins;
-  int _netabins;
-  double _etamin;
-  double _phimin;
-  double _etastep;
-  double _phistep;
+  double emin;
+
 
   PHTimeServer::timer _timer;
 

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
@@ -135,7 +135,7 @@ protected:
   //! \param  sim_tower simulation tower input
   //! \return a new RawTower object contain digitalized value of ADC output in RawTower::get_energy()
   RawTower *
-  simple_photon_digitalization(RawTower * sim_tower);
+  simple_photon_digitalization(int ieta, int iphi, RawTower * sim_tower);
 
   RawTowerContainer* _sim_towers;
   RawTowerContainer* _raw_towers;

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizerLinkDef.h
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RawTowerDigitizer-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4cemc/RawTowerv1.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerv1.cc
@@ -17,6 +17,20 @@ RawTowerv1::RawTowerv1() :
   energy(0)
 {}
 
+RawTowerv1::RawTowerv1(const RawTower & tower)
+{
+  towerid = (tower.get_id());
+  energy = (tower.get_energy());
+
+  CellConstRange cell_range = tower.get_g4cells();
+
+  for (CellConstIterator cell_iter = cell_range.first;
+      cell_iter != cell_range.second; ++cell_iter)
+    {
+      add_ecell(cell_iter->first, cell_iter->second);
+    }
+}
+
 RawTowerv1::RawTowerv1(RawTowerDefs::keytype id) : 
   towerid(id),
   energy(0)

--- a/simulation/g4simulation/g4cemc/RawTowerv1.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerv1.cc
@@ -14,17 +14,17 @@ ClassImp(RawTowerv1)
 
 RawTowerv1::RawTowerv1() : 
   towerid(~0), // initialize all bits on
-  light_yield(NAN)
+  energy(0)
 {}
 
 RawTowerv1::RawTowerv1(RawTowerDefs::keytype id) : 
   towerid(id),
-  light_yield(NAN)
+  energy(0)
 {}
 
 RawTowerv1::RawTowerv1(const unsigned int ieta, const unsigned int iphi) :
   towerid(0),
-  light_yield(NAN)
+  energy(0)
 {
   if (ieta < 0xFFF && iphi < 0xFFF)
     {
@@ -70,15 +70,4 @@ RawTowerv1::add_ecell(const PHG4CylinderCellDefs::keytype g4cellid, const float 
     }
 }
 
-double 
-RawTowerv1::get_energy() const
-{
-  RawTower::CellConstIterator iter;
-  double esum = 0;
-  for (iter = ecells.begin(); iter != ecells.end(); ++iter)
-    {
-      esum += iter->second;
-    }
-  return esum;
-}
 

--- a/simulation/g4simulation/g4cemc/RawTowerv1.h
+++ b/simulation/g4simulation/g4cemc/RawTowerv1.h
@@ -11,6 +11,7 @@ class RawTowerv1 : public RawTower {
 
  public:
   RawTowerv1();
+  RawTowerv1(const RawTower & tower);
   RawTowerv1(RawTowerDefs::keytype id);
   RawTowerv1(const unsigned int ieta, const unsigned int iphi);
   virtual ~RawTowerv1();
@@ -25,7 +26,7 @@ class RawTowerv1 : public RawTower {
   double get_energy() const {return energy;}
   void set_energy(const double e) {energy = e;}
 
-  RawTower::CellConstRange get_g4cells()
+  RawTower::CellConstRange get_g4cells() const
   {return make_pair(ecells.begin(), ecells.end());}
   void add_ecell(const PHG4CylinderCellDefs::keytype g4cellid, const float ecell);
 

--- a/simulation/g4simulation/g4cemc/RawTowerv1.h
+++ b/simulation/g4simulation/g4cemc/RawTowerv1.h
@@ -22,10 +22,8 @@ class RawTowerv1 : public RawTower {
   RawTowerDefs::keytype get_id() const { return towerid;}
   int get_bineta() const { return (towerid >> RawTowerDefs::eta_idbits)&0xFFF ; }
   int get_binphi() const { return towerid&0xFFF; }
-  double get_energy() const;
-
-  void set_light_yield(const float l)  { light_yield = l; }
-  float get_light_yield() const { return light_yield; };
+  double get_energy() const {return energy;}
+  void set_energy(const double e) {energy = e;}
 
   RawTower::CellConstRange get_g4cells()
   {return make_pair(ecells.begin(), ecells.end());}
@@ -33,11 +31,13 @@ class RawTowerv1 : public RawTower {
 
  protected:
   RawTowerDefs::keytype towerid;
-  float light_yield;
+
+  //! energy assigned to the tower. Depending on stage of process and DST node name, it could be energy deposition, light yield or calibrated energies
+  double energy;
 
   CellMap ecells;
 
-  ClassDef(RawTowerv1,2)
+  ClassDef(RawTowerv1,3)
 };
 
 #endif /* RAWTOWERV1_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -62,10 +62,20 @@ int PHG4BlockCellReco::InitRun(PHCompositeNode *topNode)
   cellnodename = "G4CELL_" + detector;
   PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode , cellnodename);
   if (!cells)
-  {
+    {
+      PHNodeIterator dstiter(dstNode);
+      PHCompositeNode *DetNode =
+          dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",
+              detector));
+      if (!DetNode)
+        {
+          DetNode = new PHCompositeNode(detector);
+          dstNode->addNode(DetNode);
+        }
+
     cells = new PHG4CylinderCellContainer();
     PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str() , "PHObject");
-    dstNode->addNode(newNode);
+    DetNode->addNode(newNode);
   }
 
   geonodename = "BLOCKGEOM_" + detector;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -56,9 +56,18 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
   PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode , cellnodename);
   if (!cells)
     {
+      PHNodeIterator dstiter(dstNode);
+      PHCompositeNode *DetNode =
+          dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",
+              detector));
+      if (!DetNode)
+        {
+          DetNode = new PHCompositeNode(detector);
+          dstNode->addNode(DetNode);
+        }
       cells = new PHG4CylinderCellContainer();
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str() , "PHObject");
-      dstNode->addNode(newNode);
+      DetNode->addNode(newNode);
     }
 
   geonodename = "CYLINDERGEOM_" + detector;

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -61,10 +61,19 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
       PHG4CylinderCellContainer>(topNode, cellnodename);
   if (!cells)
     {
+      PHNodeIterator dstiter(dstNode);
+      PHCompositeNode *DetNode =
+          dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",
+              detector));
+      if (!DetNode)
+        {
+          DetNode = new PHCompositeNode(detector);
+          dstNode->addNode(DetNode);
+        }
       cells = new PHG4CylinderCellContainer();
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells,
           cellnodename.c_str(), "PHObject");
-      dstNode->addNode(newNode);
+      DetNode->addNode(newNode);
     }
 
   geonodename = "CYLINDERGEOM_" + detector;

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -56,9 +56,18 @@ int PHG4HcalCellReco::InitRun(PHCompositeNode *topNode)
   PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode , cellnodename);
   if (!cells)
     {
+      PHNodeIterator dstiter(dstNode);
+      PHCompositeNode *DetNode =
+          dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",
+              detector));
+      if (!DetNode)
+        {
+          DetNode = new PHCompositeNode(detector);
+          dstNode->addNode(DetNode);
+        }
       cells = new PHG4CylinderCellContainer();
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str() , "PHObject");
-      dstNode->addNode(newNode);
+      DetNode->addNode(newNode);
     }
 
   geonodename = "CYLINDERGEOM_" + detector;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -57,9 +57,18 @@ int PHG4SiliconTrackerCellReco::InitRun(PHCompositeNode *topNode)
   PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode , cellnodename);
   if (!cells)
     {
+      PHNodeIterator dstiter(dstNode);
+      PHCompositeNode *DetNode =
+          dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",
+              detector));
+      if (!DetNode)
+        {
+          DetNode = new PHCompositeNode(detector);
+          dstNode->addNode(DetNode);
+        }
       cells = new PHG4CylinderCellContainer();
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str() , "PHObject");
-      dstNode->addNode(newNode);
+      DetNode->addNode(newNode);
     
     }
 

--- a/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
@@ -63,9 +63,18 @@ int PHG4SlatCellReco::InitRun(PHCompositeNode *topNode)
   PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode , cellnodename);
   if (!cells)
     {
+      PHNodeIterator dstiter(dstNode);
+      PHCompositeNode *DetNode =
+          dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",
+              detector));
+      if (!DetNode)
+        {
+          DetNode = new PHCompositeNode(detector);
+          dstNode->addNode(DetNode);
+        }
       cells = new PHG4CylinderCellContainer();
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str() , "PHObject");
-      dstNode->addNode(newNode);
+      DetNode->addNode(newNode);
     }
 
   geonodename = "CYLINDERGEOM_" + detector;

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -447,7 +447,7 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
     if (verbosity > 1) cout << "CaloEvaluator::filling tower ntuple..." << endl;
     
-    string towernode = "TOWER_" + _caloname;
+    string towernode = "TOWER_CALIB_" + _caloname;
     RawTowerContainer* towers = findNode::getClass<RawTowerContainer>(topNode,towernode.c_str());
     if (!towers) {
       cerr << PHWHERE << " ERROR: Can't find " << towernode << endl;
@@ -474,54 +474,86 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       float e       = tower->get_energy();
 
       PHG4Particle* primary = towereval->max_truth_primary_by_energy(tower);
-    
-      float gparticleID = primary->get_track_id();
-      float gflavor     = primary->get_pid();
-      
-      std::set<PHG4Hit*> g4hits = trutheval->get_shower_from_primary(primary);     
-      float gnhits   = g4hits.size();	
-      float gpx      = primary->get_px();
-      float gpy      = primary->get_py();
-      float gpz      = primary->get_pz();
-      float ge       = primary->get_e();
 
-      float gpt = sqrt(gpx*gpx+gpy*gpy);
+      float gparticleID = NAN;
+      float gflavor     = NAN;
+      float gnhits   = NAN;
+      float gpx      = NAN;
+      float gpy      = NAN;
+      float gpz      = NAN;
+      float ge       = NAN;
+
+      float gpt = NAN;
       float geta = NAN;
-      if (gpt != 0.0) geta = asinh(gpz/gpt);
-      float gphi = atan2(gpy,gpx);
-      
-      PHG4VtxPoint* vtx = trutheval->get_vertex(primary);	
-      float gvx      = vtx->get_x();
-      float gvy      = vtx->get_y();
-      float gvz      = vtx->get_z();
-      
-      float gembed   = trutheval->get_embed(primary);
-      float gedep    = trutheval->get_shower_energy_deposit(primary);
-      float gmrad    = trutheval->get_shower_moliere_radius(primary);
+      float gphi = NAN;
 
-      float efromtruth = towereval->get_energy_contribution(tower,primary);
+      float gvx      = NAN;
+      float gvy      = NAN;
+      float gvz      = NAN;
+
+      float gembed   = NAN;
+      float gedep    = NAN;
+      float gmrad    = NAN;
+
+      float efromtruth = NAN;
+
+          if (primary)
+            {
+
+              gparticleID = primary->get_track_id();
+              gflavor = primary->get_pid();
+
+              std::set<PHG4Hit*> g4hits = trutheval->get_shower_from_primary(
+                  primary);
+              gnhits = g4hits.size();
+              gpx = primary->get_px();
+              gpy = primary->get_py();
+              gpz = primary->get_pz();
+              ge = primary->get_e();
+
+              gpt = sqrt(gpx * gpx + gpy * gpy);
+              if (gpt != 0.0)
+                geta = asinh(gpz / gpt);
+              gphi = atan2(gpy, gpx);
+
+              PHG4VtxPoint* vtx = trutheval->get_vertex(primary);
+
+              if (vtx)
+                {
+                  gvx = vtx->get_x();
+                  gvy = vtx->get_y();
+                  gvz = vtx->get_z();
+                }
+
+              gembed = trutheval->get_embed(primary);
+              gedep = trutheval->get_shower_energy_deposit(primary);
+              gmrad = trutheval->get_shower_moliere_radius(primary);
+
+              efromtruth = towereval->get_energy_contribution(tower, primary);
+
+            }
 
       float tower_data[21] = {_ievent,
-			      towerid,
-			      ieta,
-			      iphi,
-			      eta,
-			      phi,
-			      e,
-			      gparticleID,
-			      gflavor,
-			      gnhits,
-			      geta,
-			      gphi,
-			      ge,
-			      gpt,
-			      gvx,
-			      gvy,
-			      gvz,
-			      gembed,
-			      gedep,
-			      gmrad,
-			      efromtruth
+            towerid,
+            ieta,
+            iphi,
+            eta,
+            phi,
+            e,
+            gparticleID,
+            gflavor,
+            gnhits,
+            geta,
+            gphi,
+            ge,
+            gpt,
+            gvx,
+            gvy,
+            gvz,
+            gembed,
+            gedep,
+            gmrad,
+            efromtruth
       };
       
       _ntp_tower->Fill(tower_data);
@@ -553,32 +585,65 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       float e         = cluster->get_energy();
       
       PHG4Particle* primary = clustereval->max_truth_primary_by_energy(cluster);
-    
-      float gparticleID = primary->get_track_id();
-      float gflavor     = primary->get_pid();
-      
-      std::set<PHG4Hit*> g4hits = trutheval->get_shower_from_primary(primary);     
-      float gnhits   = g4hits.size();	
-      float gpx      = primary->get_px();
-      float gpy      = primary->get_py();
-      float gpz      = primary->get_pz();
-      float ge       = primary->get_e();
 
-      float gpt = sqrt(gpx*gpx+gpy*gpy);
+      float gparticleID = NAN;
+      float gflavor     = NAN;
+
+      float gnhits   = NAN;
+      float gpx      = NAN;
+      float gpy      = NAN;
+      float gpz      = NAN;
+      float ge       = NAN;
+
+      float gpt = NAN;
       float geta = NAN;
-      if (gpt != 0.0) geta = asinh(gpz/gpt);
-      float gphi = atan2(gpy,gpx);
+      float gphi = NAN;
       
-      PHG4VtxPoint* vtx = trutheval->get_vertex(primary);	
-      float gvx      = vtx->get_x();
-      float gvy      = vtx->get_y();
-      float gvz      = vtx->get_z();
+      float gvx      = NAN;
+      float gvy      = NAN;
+      float gvz      = NAN;
       
-      float gembed   = trutheval->get_embed(primary);
-      float gedep    = trutheval->get_shower_energy_deposit(primary);
-      float gmrad    = trutheval->get_shower_moliere_radius(primary);
+      float gembed   = NAN;
+      float gedep    = NAN;
+      float gmrad    = NAN;
 
-      float efromtruth = clustereval->get_energy_contribution(cluster,primary);
+      float efromtruth = NAN;
+
+          if (primary)
+            {
+              gparticleID = primary->get_track_id();
+              gflavor = primary->get_pid();
+
+              std::set<PHG4Hit*> g4hits = trutheval->get_shower_from_primary(
+                  primary);
+              gnhits = g4hits.size();
+              gpx = primary->get_px();
+              gpy = primary->get_py();
+              gpz = primary->get_pz();
+              ge = primary->get_e();
+
+              gpt = sqrt(gpx * gpx + gpy * gpy);
+              if (gpt != 0.0)
+                geta = asinh(gpz / gpt);
+              gphi = atan2(gpy, gpx);
+
+              PHG4VtxPoint* vtx = trutheval->get_vertex(primary);
+
+              if (vtx)
+                {
+                  ;
+                  gvx = vtx->get_x();
+                  gvy = vtx->get_y();
+                  gvz = vtx->get_z();
+                }
+
+              gembed = trutheval->get_embed(primary);
+              gedep = trutheval->get_shower_energy_deposit(primary);
+              gmrad = trutheval->get_shower_moliere_radius(primary);
+
+              efromtruth = clustereval->get_energy_contribution(cluster,
+                  primary);
+            }
       
       float cluster_data[20] = {_ievent,
 				clusterID,

--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.C
@@ -261,7 +261,7 @@ void CaloRawClusterEval::get_node_pointers(PHCompositeNode* topNode) {
     exit(-1);
   }
 
-  std::string towername = "TOWER_" + _caloname;
+  std::string towername = "TOWER_CALIB_" + _caloname;
   _towers = findNode::getClass<RawTowerContainer>(topNode,towername.c_str());
   if (!_towers) {
     cerr << PHWHERE << " ERROR: Can't find " << towername << endl;

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -250,7 +250,7 @@ float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* p
 void CaloRawTowerEval::get_node_pointers(PHCompositeNode *topNode) {
 
   // need things off of the DST...
-  std::string towername = "TOWER_" + _caloname;
+  std::string towername = "TOWER_CALIB_" + _caloname;
   _towers = findNode::getClass<RawTowerContainer>(topNode,towername.c_str());
   if (!_towers) {
     cerr << PHWHERE << " ERROR: Can't find " << towername << endl;

--- a/simulation/g4simulation/g4eval/JetRecoEval.C
+++ b/simulation/g4simulation/g4eval/JetRecoEval.C
@@ -455,9 +455,9 @@ void JetRecoEval::get_node_pointers(PHCompositeNode* topNode) {
   }
 
   _trackmap = findNode::getClass<SvtxTrackMap>(topNode,"SvtxTrackMap");
-  _cemctowers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CEMC");
-  _hcalintowers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_HCALIN");
-  _hcalouttowers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_HCALOUT");
+  _cemctowers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_CEMC");
+  _hcalintowers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALIN");
+  _hcalouttowers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALOUT");
   _cemcclusters = findNode::getClass<RawClusterContainer>(topNode,"CLUSTER_CEMC");
   _hcalinclusters = findNode::getClass<RawClusterContainer>(topNode,"CLUSTER_HCALIN");
   _hcaloutclusters = findNode::getClass<RawClusterContainer>(topNode,"CLUSTER_HCALOUT");

--- a/simulation/g4simulation/g4histos/G4RawTowerTTree.cc
+++ b/simulation/g4simulation/g4histos/G4RawTowerTTree.cc
@@ -94,7 +94,7 @@ G4RawTowerTTree::Detector(const std::string &det)
 {
   _detector = det;
   _outnodename = "G4RootRawTower_" + det;
-  _towernodename = "TOWER_" + det;
+  _towernodename = "TOWER_CALIB_" + det;
   _towergeomnodename = "TOWERGEOM_" + det;
   if (!_histofilename.size())
     {

--- a/simulation/g4simulation/g4histos/G4TowerNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4TowerNtuple.cc
@@ -61,7 +61,7 @@ G4TowerNtuple::process_event( PHCompositeNode* topNode )
     {
       int detid = (_detid.find(*iter))->second;
       nodename.str("");
-      nodename << "TOWER_" << *iter;
+      nodename << "TOWER_CALIB_" << *iter;
       geonodename.str("");
       geonodename << "TOWERGEOM_" << *iter;
       RawTowerGeom* towergeom = findNode::getClass<RawTowerGeom>(topNode, geonodename.str().c_str());

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
@@ -93,7 +93,7 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
     }
 
     // pull the towers
-    string towernodename = "TOWER_" + _cal_names[i];
+    string towernodename = "TOWER_CALIB_" + _cal_names[i];
     RawTowerContainer *towerList = findNode::getClass<RawTowerContainer>(topNode,towernodename.c_str());
     if (!towerList) {
       cerr << PHWHERE << " ERROR: Can't find node " << towernodename << endl;

--- a/simulation/g4simulation/g4jets/TowerJetInput.C
+++ b/simulation/g4simulation/g4jets/TowerJetInput.C
@@ -48,19 +48,19 @@ std::vector<Jet*> TowerJetInput::get_input(PHCompositeNode *topNode) {
   RawTowerContainer *towers = NULL;
   RawTowerGeom *geom = NULL;
   if (_input == Jet::CEMC_TOWER) {
-    towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CEMC");
+    towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_CEMC");
     geom = findNode::getClass<RawTowerGeom>(topNode,"TOWERGEOM_CEMC");
     if (!towers||!geom) {
       return std::vector<Jet*>();
     }
   } else if (_input == Jet::HCALIN_TOWER) {
-    towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_HCALIN");
+    towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALIN");
     geom = findNode::getClass<RawTowerGeom>(topNode,"TOWERGEOM_HCALIN");
     if (!towers||!geom) {
       return std::vector<Jet*>();
     }
   } else if (_input == Jet::HCALOUT_TOWER) {
-    towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_HCALOUT");
+    towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALOUT");
     geom = findNode::getClass<RawTowerGeom>(topNode,"TOWERGEOM_HCALOUT");
     if (!towers||!geom) {
       return std::vector<Jet*>();

--- a/simulation/g4simulation/g4picoDst/mFillG4SnglHTCContainer.cc
+++ b/simulation/g4simulation/g4picoDst/mFillG4SnglHTCContainer.cc
@@ -122,7 +122,7 @@ mFillG4SnglHTCContainer::process_event( PHCompositeNode* top_node )
 	   string tmpstr(*iter);
 	   if( !(tmpstr.compare(0,8,"ABSORBER")==0) ){ 
 	   towernode.str("");
-	   towernode << "TOWER_" << *iter;
+	   towernode << "TOWER_CALIB_" << *iter;
 	   RawTowerContainer *twrs = findNode::getClass<RawTowerContainer>(top_node, towernode.str().c_str());
 	   towergeomnode.str("");
 	   towergeomnode << "TOWERGEOM_" << *iter;


### PR DESCRIPTION
As discussed in the last simulation meeting, digitalization and calibration modules are introduced. Specific changes are:

## Tower and Tower Builder

RawTowerBuilder now output light yield (previously G4 energy deposition) to DSTNodes of RawTowerv1 objects. RawTowerv1 now support save of a single double precision total energy value, which could be later interpreted as digitized/calibrated value, depending on the DSTNode name.

## Digitalization

RawTowerDigitizer is introduced to convert G4 light yield into digitalized ADC values. Two options supported right now through set_digi_algorithm():
* kNo_digitalization (default for compatibility): directly pass the energy of sim tower to digitalized tower
* kSimple_photon_digitalization: digitalization with Poission photon statistics, ADC conversion and pedstal

## Calibration

RawTowerCalibration further convert ADC value into the measured and calibrated value for use in downstream analysis of clustering and evaluation. Also two options supported right now through set_calib_algorithm():
* kNo_calibration: directly pass the energy of raw tower to calibrated tower. Zero suppression is applied
* simple digitalization with photon statistics, ADC conversion and pedstal

## Reorganize calorimeter related nodes

Now the information flow on the node structure is 
G4CELL_* -> tower ->  TOWER_SIM_* -> digitalization ->  TOWER_RAW_* -> calibration -> TOWER_CALIB_* -> clusterizer -> CLUSTER_*. 
The TOWER_CALIB_* node represents measured value in total energy deposition in GeV, which should be used in downstream analysis of clustering and evaluation. 

Also the DST nodes are organized in PHCompositeNode of the subsystem names 
```
      BBC (PHCompositeNode)/
         BbcVertexMap (PHIODataNode)
      SVTX (PHCompositeNode)/
         G4CELL_SVTX (PHIODataNode)
         SvtxHitMap (PHIODataNode)
         SvtxClusterMap (PHIODataNode)
         SvtxTrackMap (PHIODataNode)
         SvtxVertexMap (PHIODataNode)
      CEMC (PHCompositeNode)/
         G4CELL_CEMC (PHIODataNode)
         TOWER_SIM_CEMC (PHIODataNode)
         TOWER_RAW_CEMC (PHIODataNode)
         TOWER_CALIB_CEMC (PHIODataNode)
         CLUSTER_CEMC (PHIODataNode)
      HCALIN (PHCompositeNode)/
         G4CELL_HCALIN (PHIODataNode)
         TOWER_SIM_HCALIN (PHIODataNode)
         TOWER_RAW_HCALIN (PHIODataNode)
         TOWER_CALIB_HCALIN (PHIODataNode)
         CLUSTER_HCALIN (PHIODataNode)
      HCALOUT (PHCompositeNode)/
         G4CELL_HCALOUT (PHIODataNode)
         TOWER_SIM_HCALOUT (PHIODataNode)
         TOWER_RAW_HCALOUT (PHIODataNode)
         TOWER_CALIB_HCALOUT (PHIODataNode)
         CLUSTER_HCALOUT (PHIODataNode)
```

## Update on evaluator

Since pedstal is introduced to digitized and calibrated towers, cluster and tower evaluator are updated to support Towers with no association to truth particle (i.e. energy from pedstal fluctuation). In that case, truth energy is saved as NAN. 

## How to proceed

I used my private build to make energy resolution plots. So most bugs should be hashed out. Nevertheless, I will appreciate crosschecks. 

If @mccumbermike , @sen1 and @pinkenburg  think this approach is fine, then I can 
1. merge it 
2. kick off a build
3. merge a related pull request in the macro repository  (https://github.com/sPHENIX-Collaboration/macros/pull/4)
