### PR TITLE
rollover on G4Seed was still passing a negative seed to CLHEP

### DIFF
--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -539,7 +539,7 @@ PHG4Reco::set_rapidity_coverage(const double eta)
 }
 
 void
-PHG4Reco::G4Seed(const int i)
+PHG4Reco::G4Seed(const unsigned int i)
 {
   CLHEP::HepRandom::setTheSeed(i);
   return;

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -96,7 +96,7 @@ class PHG4Reco: public SubsysReco
 
   int setupInputEventNodeReader(PHCompositeNode *);
 
-  static void G4Seed(const int i);
+  static void G4Seed(const unsigned int i);
 
   // this is an ugly hack to get Au ions working for CAD
   // our particle generators have pdg build in which doesn't work


### PR DESCRIPTION
CLHEP complains when it gets a negative seed:
   Seed for HepJamesRandom must be non-negative
   Seed value supplied was -541589200
   Using its absolute value instead
Even though PHRandomSeed generates a uint the G4Seed interface casts it into an int so overflows can go negative. So I modified G4Seed to pass an uint instead. I thought I had caught this problem on a previous commit but missed this aspect. The logic remains the same, but CLHEP is now quiet. Enjoy.
