### PR TITLE
Eval modifications + new random numbers for PHPythia8

### DIFF
--- a/generators/PHPythia8/Makefile.am
+++ b/generators/PHPythia8/Makefile.am
@@ -23,6 +23,8 @@ libPHPythia8_la_LDFLAGS = \
   `root-config --libs`
 
 libPHPythia8_la_LIBADD = \
+  -lgsl \
+  -lgslcblas \
   -lphool \
   -lSubsysReco \
   -lfun4all \

--- a/generators/PHPythia8/PHPythia8.h
+++ b/generators/PHPythia8/PHPythia8.h
@@ -10,6 +10,10 @@
 
 #include <Rtypes.h>
 
+#ifndef __CINT__
+#include <gsl/gsl_rng.h>
+#endif
+
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -51,8 +55,6 @@ public:
 
   void print_config() const;
 
-  void set_seed(const int s) { _seed = s; }
-
   /// set event selection criteria
   void register_trigger(PHPy8GenTrigger *theTrigger);
   void set_trigger_OR() { _triggersOR = true; } // default true
@@ -90,7 +92,6 @@ private:
   std::string _node_name;
 
   // vertex placement
-  TRandom *_rand;
   bool _useBeamVtx;
   double _beamX, _beamXsigma;
   double _beamY, _beamYsigma;
@@ -108,11 +109,14 @@ private:
 
   std::string _configFile;
   std::vector<std::string> _commands;
-  long int _seed;		
   
   // HepMC
   HepMC::Pythia8ToHepMC *_pythiaToHepMC;
   PHHepMCGenEvent *_phhepmcevt;
+
+#ifndef __CINT__
+  gsl_rng *RandomGenerator;
+#endif
 };
 
 #endif	/* __PHPYTHIA8_H__ */

--- a/generators/PHPythia8/README
+++ b/generators/PHPythia8/README
@@ -1,0 +1,8 @@
+to get started
+
+add to .cshrc
+ setenv PYTHIA8 ${OFFLINE_MAIN}/share/Pythia8
+ setenv PYTHIA8DATA ${PYTHIA8}/xmldoc
+
+login in a new window
+cp the phpythia8.cfg to working area

--- a/generators/PHPythia8/README
+++ b/generators/PHPythia8/README
@@ -6,3 +6,6 @@ add to .cshrc
 
 login in a new window
 cp the phpythia8.cfg to working area
+
+you will need to add the HepMC node reader after the PHPythia8
+to feed the hepmc node into GEANT4

--- a/generators/PHPythia8/phpythia8.cfg
+++ b/generators/PHPythia8/phpythia8.cfg
@@ -1,7 +1,7 @@
 ! Beam settings
 Beams:idA = 2212   ! first beam, p = 2212, pbar = -2212
 Beams:idB = 2212   ! second beam, p = 2212, pbar = -2212
-Beams:eCM = 510.   ! CM energy of collision
+Beams:eCM = 200.   ! CM energy of collision
 
 ! Settings related to output in init(), next() and stat()
 Init:showChangedSettings = on
@@ -21,9 +21,9 @@ Next:numberShowInfo = 0            ! print event information n times
 #HardQCD:hardbbbar = on
 HardQCD:all = on
 #Charmonium:all = on
-SoftQCD:nonDiffractive = on
+#SoftQCD:nonDiffractive = on
 
 
 ! Cuts
-PhaseSpace:pTHatMin = 1.0
+PhaseSpace:pTHatMin = 25.0
 

--- a/generators/PHPythia8/phpythia8.cfg
+++ b/generators/PHPythia8/phpythia8.cfg
@@ -1,0 +1,29 @@
+! Beam settings
+Beams:idA = 2212   ! first beam, p = 2212, pbar = -2212
+Beams:idB = 2212   ! second beam, p = 2212, pbar = -2212
+Beams:eCM = 510.   ! CM energy of collision
+
+! Settings related to output in init(), next() and stat()
+Init:showChangedSettings = on
+#Next:numberCount = 0          ! print message every n events
+Next:numberShowInfo = 0            ! print event information n times
+#Next:numberShowProcess = 1         ! print process record n times
+#Next:numberShowEvent = 1           ! print event record n times
+
+! PDF
+#PDF:useLHAPDF = on
+#PDF:LHAPDFset = CT10.LHgrid
+#PDF:pSet = 7 ! CTEQ6L
+
+
+! Process
+#HardQCD:hardccbar = on
+#HardQCD:hardbbbar = on
+HardQCD:all = on
+#Charmonium:all = on
+SoftQCD:nonDiffractive = on
+
+
+! Cuts
+PhaseSpace:pTHatMin = 1.0
+

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -497,63 +497,58 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
       float efromtruth = NAN;
 
-          if (primary)
-            {
+      if (primary) {
 
-              gparticleID = primary->get_track_id();
-              gflavor = primary->get_pid();
+	gparticleID = primary->get_track_id();
+	gflavor = primary->get_pid();
 
-              std::set<PHG4Hit*> g4hits = trutheval->get_shower_from_primary(
-                  primary);
-              gnhits = g4hits.size();
-              gpx = primary->get_px();
-              gpy = primary->get_py();
-              gpz = primary->get_pz();
-              ge = primary->get_e();
+	std::set<PHG4Hit*> g4hits = trutheval->get_shower_from_primary(primary);
+	gnhits = g4hits.size();
+	gpx = primary->get_px();
+	gpy = primary->get_py();
+	gpz = primary->get_pz();
+	ge = primary->get_e();
 
-              gpt = sqrt(gpx * gpx + gpy * gpy);
-              if (gpt != 0.0)
-                geta = asinh(gpz / gpt);
-              gphi = atan2(gpy, gpx);
+	gpt = sqrt(gpx * gpx + gpy * gpy);
+	if (gpt != 0.0) geta = asinh(gpz / gpt);
+	gphi = atan2(gpy, gpx);
 
-              PHG4VtxPoint* vtx = trutheval->get_vertex(primary);
+	PHG4VtxPoint* vtx = trutheval->get_vertex(primary);
 
-              if (vtx)
-                {
-                  gvx = vtx->get_x();
-                  gvy = vtx->get_y();
-                  gvz = vtx->get_z();
-                }
+	if (vtx) {
+	  gvx = vtx->get_x();
+	  gvy = vtx->get_y();
+	  gvz = vtx->get_z();
+	}
 
-              gembed = trutheval->get_embed(primary);
-              gedep = trutheval->get_shower_energy_deposit(primary);
-              gmrad = trutheval->get_shower_moliere_radius(primary);
+	gembed = trutheval->get_embed(primary);
+	gedep = trutheval->get_shower_energy_deposit(primary);
+	gmrad = trutheval->get_shower_moliere_radius(primary);
 
-              efromtruth = towereval->get_energy_contribution(tower, primary);
-
-            }
+	efromtruth = towereval->get_energy_contribution(tower, primary);
+      }
 
       float tower_data[21] = {_ievent,
-            towerid,
-            ieta,
-            iphi,
-            eta,
-            phi,
-            e,
-            gparticleID,
-            gflavor,
-            gnhits,
-            geta,
-            gphi,
-            ge,
-            gpt,
-            gvx,
-            gvy,
-            gvz,
-            gembed,
-            gedep,
-            gmrad,
-            efromtruth
+			      towerid,
+			      ieta,
+			      iphi,
+			      eta,
+			      phi,
+			      e,
+			      gparticleID,
+			      gflavor,
+			      gnhits,
+			      geta,
+			      gphi,
+			      ge,
+			      gpt,
+			      gvx,
+			      gvy,
+			      gvz,
+			      gembed,
+			      gedep,
+			      gmrad,
+			      efromtruth
       };
       
       _ntp_tower->Fill(tower_data);
@@ -609,41 +604,36 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
       float efromtruth = NAN;
 
-          if (primary)
-            {
-              gparticleID = primary->get_track_id();
-              gflavor = primary->get_pid();
+      if (primary) {
+	gparticleID = primary->get_track_id();
+	gflavor = primary->get_pid();
+	
+	std::set<PHG4Hit*> g4hits = trutheval->get_shower_from_primary(primary);
+	gnhits = g4hits.size();
+	gpx = primary->get_px();
+	gpy = primary->get_py();
+	gpz = primary->get_pz();
+	ge = primary->get_e();
 
-              std::set<PHG4Hit*> g4hits = trutheval->get_shower_from_primary(
-                  primary);
-              gnhits = g4hits.size();
-              gpx = primary->get_px();
-              gpy = primary->get_py();
-              gpz = primary->get_pz();
-              ge = primary->get_e();
+	gpt = sqrt(gpx * gpx + gpy * gpy);
+	if (gpt != 0.0) geta = asinh(gpz / gpt);
+	gphi = atan2(gpy, gpx);
 
-              gpt = sqrt(gpx * gpx + gpy * gpy);
-              if (gpt != 0.0)
-                geta = asinh(gpz / gpt);
-              gphi = atan2(gpy, gpx);
+	PHG4VtxPoint* vtx = trutheval->get_vertex(primary);
 
-              PHG4VtxPoint* vtx = trutheval->get_vertex(primary);
+	if (vtx) {
+	  gvx = vtx->get_x();
+	  gvy = vtx->get_y();
+	  gvz = vtx->get_z();
+	}
+	
+	gembed = trutheval->get_embed(primary);
+	gedep = trutheval->get_shower_energy_deposit(primary);
+	gmrad = trutheval->get_shower_moliere_radius(primary);
 
-              if (vtx)
-                {
-                  ;
-                  gvx = vtx->get_x();
-                  gvy = vtx->get_y();
-                  gvz = vtx->get_z();
-                }
-
-              gembed = trutheval->get_embed(primary);
-              gedep = trutheval->get_shower_energy_deposit(primary);
-              gmrad = trutheval->get_shower_moliere_radius(primary);
-
-              efromtruth = clustereval->get_energy_contribution(cluster,
-                  primary);
-            }
+	efromtruth = clustereval->get_energy_contribution(cluster,
+							  primary);
+      }
       
       float cluster_data[20] = {_ievent,
 				clusterID,

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -100,7 +100,6 @@ std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
   std::set<PHG4Particle*> truth_primaries;
   
   std::set<PHG4Hit*> g4hits = all_truth_hits(tower);
-  if (g4hits.empty()) return truth_primaries;
 
   for (std::set<PHG4Hit*>::iterator iter = g4hits.begin();
        iter != g4hits.end();

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -88,7 +88,8 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Particle* particle) {
   }
   
   PHG4Particle* returnval = particle;
-  if (returnval->get_primary_id() != (int)(0xFFFFFFFF)) {
+  if ((returnval->get_primary_id() != returnval->get_track_id()) ||
+      (returnval->get_primary_id() != -1)) {
     returnval = _truthinfo->GetHit( particle->get_primary_id() );
   }
 
@@ -110,7 +111,7 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Hit* g4hit) {
   
   PHG4Particle* particle = _truthinfo->GetHit( g4hit->get_trkid() );
   PHG4Particle* primary = get_primary_particle(particle);
-
+  
   if (_do_cache) _cache_get_primary_particle_g4hit.insert(make_pair(g4hit,primary));
   
   return primary;
@@ -141,7 +142,9 @@ bool CaloTruthEval::is_primary(PHG4Particle* particle) {
   }
 
   bool is_primary = false;
-  if (particle->get_primary_id() == -1) {
+  if (particle->get_primary_id() == particle->get_track_id()) {
+    is_primary = true;
+  } else if (particle->get_primary_id() == -1) {
     is_primary = true;
   }
   

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -123,7 +123,11 @@ int CaloTruthEval::get_embed(PHG4Particle* particle) {
 
 PHG4VtxPoint* CaloTruthEval::get_vertex(PHG4Particle* particle) {
 
-  return _truthinfo->GetVtx( particle->get_vtx_id() );
+  if (is_primary(particle)) {
+    return _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );
+  }
+
+  return _truthinfo->GetVtx( particle->get_vtx_id() ); 
 }
 
 bool CaloTruthEval::is_primary(PHG4Particle* particle) {
@@ -135,22 +139,12 @@ bool CaloTruthEval::is_primary(PHG4Particle* particle) {
       return iter->second;
     }
   }
-  
-  bool is_primary = false;  
-  PHG4TruthInfoContainer::Map primary_map = _truthinfo->GetPrimaryMap();
-  if (primary_map.find(particle->get_track_id()) != primary_map.end()) {
+
+  bool is_primary = false;
+  if (particle->get_primary_id() == -1) {
     is_primary = true;
   }
-
-  // old lookup used values instead of key which is equivalent to track_id
-  // for (PHG4TruthInfoContainer::ConstIterator iter = primary_map.begin(); 
-  //      iter != primary_map.end(); 
-  //      ++iter) {
-  //   if (iter->second->get_track_id() == particle->get_track_id() ) {
-  //     is_primary = true;
-  //   }
-  // }
-
+  
   if (_do_cache) _cache_is_primary.insert(make_pair(particle,is_primary));
   
   return is_primary;

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -124,11 +124,11 @@ int CaloTruthEval::get_embed(PHG4Particle* particle) {
 
 PHG4VtxPoint* CaloTruthEval::get_vertex(PHG4Particle* particle) {
 
-  if (is_primary(particle)) {
-    return _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );
+  if (particle->get_primary_id() == -1) {
+    return _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );  
   }
 
-  return _truthinfo->GetVtx( particle->get_vtx_id() ); 
+  return _truthinfo->GetVtx( particle->get_vtx_id() );  
 }
 
 bool CaloTruthEval::is_primary(PHG4Particle* particle) {

--- a/simulation/g4simulation/g4eval/JetRecoEval.C
+++ b/simulation/g4simulation/g4eval/JetRecoEval.C
@@ -261,7 +261,7 @@ std::set<Jet*> JetRecoEval::all_truth_jets(Jet* recojet) {
   
   std::set<Jet*> truth_jets;
   
-  // get all truth particles...
+  // get all truth particles (this can include muons and other truth excludes)...
   std::set<PHG4Particle*> particles = all_truth_particles(recojet);
   
   // backtrack from the truth particles to the truth jets...
@@ -269,8 +269,10 @@ std::set<Jet*> JetRecoEval::all_truth_jets(Jet* recojet) {
        iter != particles.end();
        ++iter) {
     PHG4Particle* particle = *iter;
-
+    
     Jet* truth_jet = _jettrutheval.get_truth_jet(particle);
+    if (!truth_jet) continue;
+
     truth_jets.insert(truth_jet);
   }
 

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -3,6 +3,7 @@
 #define __SVTXCLUSTEREVAL_H__
 
 #include "SvtxHitEval.h"
+#include "SvtxTruthEval.h"
 
 #include <phool/PHCompositeNode.h>
 #include <g4hough/SvtxClusterMap.h>
@@ -27,6 +28,7 @@ public:
   
   // access the clustereval (and its cached values)
   SvtxHitEval* get_hit_eval() {return &_hiteval;}
+  SvtxTruthEval* get_truth_eval() {return _hiteval.get_truth_eval();}
   
   // backtrace through to PHG4Hits
   std::set<PHG4Hit*> all_truth_hits          (SvtxCluster* cluster);

--- a/simulation/g4simulation/g4eval/SvtxEvalStack.C
+++ b/simulation/g4simulation/g4eval/SvtxEvalStack.C
@@ -2,7 +2,6 @@
 #include "SvtxEvalStack.h"
 
 #include "SvtxVertexEval.h"
-#include "SvtxTruthEval.h"
 
 #include <fun4all/getClass.h>
 #include <phool/PHCompositeNode.h>
@@ -12,12 +11,10 @@
 using namespace std;
 
 SvtxEvalStack::SvtxEvalStack(PHCompositeNode* topNode)
-  : _vertexeval(topNode),
-    _trutheval(topNode) {
+  : _vertexeval(topNode) {
 }
 
 void SvtxEvalStack::next_event(PHCompositeNode* topNode) {
   _vertexeval.next_event(topNode);
-  _trutheval.next_event(topNode);
 }
 

--- a/simulation/g4simulation/g4eval/SvtxEvalStack.h
+++ b/simulation/g4simulation/g4eval/SvtxEvalStack.h
@@ -29,11 +29,10 @@ public:
   SvtxTrackEval*   get_track_eval() {return _vertexeval.get_track_eval();}
   SvtxClusterEval* get_cluster_eval() {return _vertexeval.get_cluster_eval();}
   SvtxHitEval*     get_hit_eval() {return _vertexeval.get_hit_eval();}
-  SvtxTruthEval*   get_truth_eval() {return &_trutheval;}
+  SvtxTruthEval*   get_truth_eval() {return _vertexeval.get_truth_eval();}
   
 private:
-  SvtxVertexEval _vertexeval; // right now this is the top-level eval, other evals nest underneath
-  SvtxTruthEval  _trutheval;  // except this one
+  SvtxVertexEval _vertexeval; // right now this is the top-level eval
 };
 
 #endif // __SVTXEVALSTACK_H__

--- a/simulation/g4simulation/g4eval/SvtxHitEval.C
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.C
@@ -20,7 +20,8 @@
 using namespace std;
 
 SvtxHitEval::SvtxHitEval(PHCompositeNode* topNode)
-  : _hitmap(NULL),
+  : _trutheval(topNode),
+    _hitmap(NULL),
     _g4cells_svtx(NULL),
     _g4cells_tracker(NULL),
     _g4hits_svtx(NULL),
@@ -51,6 +52,8 @@ void SvtxHitEval::next_event(PHCompositeNode* topNode) {
   _cache_get_energy_contribution_g4particle.clear();
   _cache_get_energy_contribution_g4hit.clear();
 
+  _trutheval.next_event(topNode);
+  
   get_node_pointers(topNode);
 }
 

--- a/simulation/g4simulation/g4eval/SvtxHitEval.h
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.h
@@ -2,6 +2,8 @@
 #ifndef __SVTXHITEVAL_H__
 #define __SVTXHITEVAL_H__
 
+#include "SvtxTruthEval.h"
+
 #include <phool/PHCompositeNode.h>
 #include <g4hough/SvtxHitMap.h>
 #include <g4hough/SvtxHit.h>
@@ -25,6 +27,9 @@ public:
   void next_event(PHCompositeNode *topNode);
   void do_caching(bool do_cache) {_do_cache = do_cache;}
 
+  // access the clustereval (and its cached values)
+  SvtxTruthEval* get_truth_eval() {return &_trutheval;}
+  
   PHG4CylinderCell* get_cell(SvtxHit* hit);
   
   // backtrace through to PHG4Hits
@@ -47,7 +52,8 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode *topNode);
-  
+
+  SvtxTruthEval _trutheval;
   SvtxHitMap* _hitmap;
   PHG4CylinderCellContainer* _g4cells_svtx;
   PHG4CylinderCellContainer* _g4cells_tracker;

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -4,6 +4,7 @@
 
 #include "SvtxClusterEval.h"
 #include "SvtxHitEval.h"
+#include "SvtxTruthEval.h"
 
 #include <phool/PHCompositeNode.h>
 #include <g4hough/SvtxTrackMap.h>
@@ -28,6 +29,7 @@ public:
   // access the clustereval (and its cached values)
   SvtxClusterEval* get_cluster_eval() {return &_clustereval;}
   SvtxHitEval*     get_hit_eval() {return _clustereval.get_hit_eval();}
+  SvtxTruthEval* get_truth_eval() {return _clustereval.get_truth_eval();}
   
   // backtrace through to PHG4Hits
   std::set<PHG4Hit*>  all_truth_hits (SvtxTrack* track);

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -176,13 +176,11 @@ int SvtxTruthEval::get_embed(PHG4Particle* particle) {
 
 bool SvtxTruthEval::is_primary(PHG4Particle* particle) {
 
-  bool is_primary = false;  
-  PHG4TruthInfoContainer::Map primary_map = _truthinfo->GetPrimaryMap();
-  if (primary_map.find(particle->get_track_id()) != primary_map.end()) {
-    is_primary = true;
+  if (particle->get_primary_id() == -1) {
+    return true;
   }
   
-  return is_primary;
+  return false;
 }
 
 PHG4VtxPoint* SvtxTruthEval::get_vertex(PHG4Particle* particle) {

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -187,7 +187,11 @@ bool SvtxTruthEval::is_primary(PHG4Particle* particle) {
 
 PHG4VtxPoint* SvtxTruthEval::get_vertex(PHG4Particle* particle) {
 
-  return _truthinfo->GetVtx( particle->get_vtx_id() );
+  if (is_primary(particle)) {
+    return _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );
+  }
+
+  return _truthinfo->GetVtx( particle->get_vtx_id() );  
 }
 
 void SvtxTruthEval::get_node_pointers(PHCompositeNode* topNode) {

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -176,7 +176,9 @@ int SvtxTruthEval::get_embed(PHG4Particle* particle) {
 
 bool SvtxTruthEval::is_primary(PHG4Particle* particle) {
 
-  if (particle->get_primary_id() == -1) {
+  if (particle->get_primary_id() == particle->get_track_id()) {
+    return true;
+  } else if (particle->get_primary_id() == -1) {
     return true;
   }
   

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -187,8 +187,8 @@ bool SvtxTruthEval::is_primary(PHG4Particle* particle) {
 
 PHG4VtxPoint* SvtxTruthEval::get_vertex(PHG4Particle* particle) {
 
-  if (is_primary(particle)) {
-    return _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );
+  if (particle->get_primary_id() == -1) {
+    return _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );  
   }
 
   return _truthinfo->GetVtx( particle->get_vtx_id() );  

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.C
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.C
@@ -93,12 +93,8 @@ std::set<PHG4VtxPoint*> SvtxVertexEval::all_truth_points(SvtxVertex* vertex) {
        iter != particles.end();
        ++iter) {
     PHG4Particle* particle = *iter;
-
-    // only consider primary particles
-    PHG4TruthInfoContainer::Map primarymap = _truthinfo->GetPrimaryMap();
-    if (primarymap.find(particle->get_track_id()) == primarymap.end()) continue;
-        
-    points.insert(_truthinfo->GetPrimaryVtx(particle->get_vtx_id()));
+    PHG4VtxPoint* point = get_truth_eval()->get_vertex(particle);
+    points.insert(point);
   }
 
   if (_do_cache) _cache_all_truth_points.insert(make_pair(vertex,points));
@@ -219,11 +215,7 @@ unsigned int SvtxVertexEval::get_ntracks_contribution(SvtxVertex* vertex, PHG4Vt
     SvtxTrack* track = _trackmap->get(*iter);
     PHG4Particle* particle = _trackeval.max_truth_particle_by_nclusters(track);
 
-    // only consider primary particles
-    PHG4TruthInfoContainer::Map primarymap = _truthinfo->GetPrimaryMap();
-    if (primarymap.find(particle->get_track_id()) == primarymap.end()) continue;
-
-    PHG4VtxPoint* candidate = _truthinfo->GetPrimaryVtx(particle->get_vtx_id());
+    PHG4VtxPoint* candidate = get_truth_eval()->get_vertex(particle);
     if (candidate->get_id() == truthpoint->get_id()) ++ntracks;
   }
   

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.h
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.h
@@ -5,6 +5,7 @@
 #include "SvtxTrackEval.h"
 #include "SvtxClusterEval.h"
 #include "SvtxHitEval.h"
+#include "SvtxTruthEval.h"
 
 #include <phool/PHCompositeNode.h>
 #include <g4hough/SvtxVertexMap.h>
@@ -31,6 +32,7 @@ public:
   SvtxTrackEval*   get_track_eval() {return &_trackeval;}
   SvtxClusterEval* get_cluster_eval() {return _trackeval.get_cluster_eval();}
   SvtxHitEval*     get_hit_eval() {return _trackeval.get_hit_eval();}
+  SvtxTruthEval* get_truth_eval() {return _trackeval.get_truth_eval();}
   
   // backtrace through to PHG4Hits
   std::set<PHG4Particle*>  all_truth_particles (SvtxVertex* vertex);

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -60,17 +60,32 @@ void
 PHG4TruthInfoContainer::identify(ostream& os) const
 {
    ConstIterator iter;
+   cout << "---particlemap--------------------------" << endl;
    for (iter = hitmap.begin(); iter != hitmap.end(); ++iter)
      {
        cout << "hit key " <<  iter->first << endl;
        (iter->second)->identify();
      }
    ConstVtxIterator vter;
+   cout << "---vtxmap-------------------------------" << endl;
    for (vter = vtxmap.begin(); vter != vtxmap.end(); ++vter)
      {
        cout << "vtx id: " << vter ->first << endl;
        (vter ->second)->identify();
      }
+   cout << "---primaryparticlemap-------------------" << endl;
+   for (iter = primary_particle_map.begin(); iter != primary_particle_map.end(); ++iter)
+     {
+       cout << "primary_particle_ key " <<  iter->first << endl;
+       (iter->second)->identify();
+     }
+   cout << "---primaryparticlemap-------------------" << endl;
+   for (vter = primary_vtxmap.begin(); vter != primary_vtxmap.end(); ++vter)
+     {
+       cout << "vtx id: " << vter ->first << endl;
+       (vter ->second)->identify();
+     }
+   
   return;
 }
 


### PR DESCRIPTION
This merge will bring in the modifications to PHPythia8 to get it read for use (random number seeding mostly). In testing PHPythia8, I discovered all the ways the copied primaries & primary vertexes are not equivalent to the input primary storage and modified the eval to route around this issues. I also solved the problem in issue #44 where the truth eval expected a truth particle to always be in a truth jet, but this won't always be the case given eta acceptance and jet definitions.

Jin I'm assigning this to you. I think having a second runtime check would be helpful. I did see some reco jets being traced back to similar kinematic truth jets in the eval ntuple---that's an encouraging sign.