### PR TITLE
New version for the inner hcal - the scintillators were too short in the previous version

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -47,7 +47,8 @@ typedef CGAL::Segment_2<Circular_k>                Segment_2;
 
 using namespace std;
 
-static double no_overlap = 0.000;// added safety margin against overlaps by using same boundary between volumes
+static double no_overlap = 0.0*mm;// added safety margin against overlaps by using same boundary between volumes
+static double subtract_from_scinit_length = 0.02*mm;
 PHG4InnerHcalDetector::PHG4InnerHcalDetector( PHCompositeNode *Node, PHG4InnerHcalParameters *parameters, const std::string &dnam  ):
   PHG4Detector(Node, dnam),
   params(parameters),
@@ -179,14 +180,17 @@ PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
 	    }
 	}
     }
+  scinti_tile_x  = scinti_tile_x_upper + scinti_tile_x_lower;// - subtract_from_scinit_length - fabs(sin(params->tilt_angle/rad)*1*mm);// - 0.5*mm;
   cout << "lower instersect: " << CGAL::to_double(lowerleft.x())/cm
        << ", " << CGAL::to_double(lowerleft.y())/cm << endl;
   cout << "scintitile_x_upper: " << scinti_tile_x_upper
        << ", scintitile_x_lower: " << scinti_tile_x_lower
+       << ", scinti_tile_x: " << scinti_tile_x;
+  //    scinti_tile_x -= 1*mm;
+    cout << " new scinti_tile_x: " << scinti_tile_x
        << endl;
-  scinti_tile_x  = scinti_tile_x_upper + scinti_tile_x_lower;
-  //  scinti_tile_x  = 2*scinti_tile_x_upper;
-
+    //    scinti_tile_x  = 2*scinti_tile_x_upper;
+    scinti_tile_x  -= scinti_tile_x/1000.;
   G4VSolid* scintibox =  new G4Box("ScintiTile", scinti_tile_x / 2., params->scinti_tile_thickness / 2., scinti_tile_z / 2.);
 
   return scintibox;
@@ -420,25 +424,34 @@ PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelope)
   visattchk->SetColour(G4Colour::Cyan());
   steel_logical->SetVisAttributes(visattchk);
   G4AssemblyVolume *scinti_mother_logical = ConstructHcalScintillatorAssembly(hcalenvelope);
+  // G4VSolid *scintilatorbox = ConstructScintillatorBox(hcalenvelope);
+  // G4LogicalVolume *scintilatorbox_logical = new  G4LogicalVolume(scintilatorbox, G4Material::GetMaterial("G4_POLYSTYRENE"),"HCalScinti", 0, 0, 0);
   double phi = 0;
   double deltaphi = 2 * M_PI / params->n_scinti_plates;
   ostringstream name;
   double middlerad = params->outer_radius - (params->outer_radius - params->inner_radius) / 2.;
   //  middlerad = params->inner_radius +  (params->outer_radius - params->inner_radius)*(scinti_tile_x_lower-scinti_tile_x_upper)/(scinti_tile_x_lower+scinti_tile_x_upper) / 2.;
-  //  for (int i = 0; i < params->n_scinti_plates; i++)
-  cout << "middlerad : " << middlerad << endl;
+  cout << "old middlerad : " << middlerad;
+  //  middlerad = middlerad - (scinti_tile_x/2.)*sin(fabs(params->tilt_angle)/rad);
   double shiftslat = fabs(scinti_tile_x_lower - scinti_tile_x_upper)/2.;
-  for (int i = 0; i < 3; i++)
+double newypos = 0*middlerad + sin(fabs(params->tilt_angle/rad))*shiftslat;
+double newxpos = 1*middlerad - cos(fabs(params->tilt_angle/rad))*shiftslat;
+ double newrad = sqrt(newxpos*newxpos + newypos*newypos);
+  cout << " new: " << newrad << endl;
+  //  middlerad = newrad;
+  for (int i = 0; i < params->n_scinti_plates; i++)
     {
       G4RotationMatrix *Rot = new G4RotationMatrix();
       double ypos = sin(phi) * middlerad;
       double xpos = cos(phi) * middlerad;
-      ypos += sin(fabs(params->tilt_angle)/rad)*shiftslat;
-       xpos -= cos(fabs(params->tilt_angle)/rad)*shiftslat;
-      cout << "xypos: " << xpos/cm << ", " << ypos/cm << endl;
+       cout << "old xypos: " << xpos/cm << ", " << ypos/cm << ", rad: " << sqrt(xpos/cm*xpos/cm + ypos/cm*ypos/cm) << endl;
+       ypos += sin((-params->tilt_angle)/rad - phi)*shiftslat;
+        xpos -= cos((-params->tilt_angle)/rad - phi)*shiftslat;
+       cout << "xypos: " << xpos/cm << ", " << ypos/cm << ", rad: " << sqrt(xpos/cm*xpos/cm + ypos/cm*ypos/cm) << endl;
       Rot->rotateZ(phi * rad + params->tilt_angle);
       G4ThreeVector g4vec(xpos, ypos, 0);
-      scinti_mother_logical->MakeImprint(hcalenvelope, g4vec, Rot, i, overlapcheck);
+      //      new G4PVPlacement(Rot, g4vec, scintilatorbox_logical, "HCalScint", hcalenvelope, 0, i, overlapcheck);
+            scinti_mother_logical->MakeImprint(hcalenvelope, g4vec, Rot, i, overlapcheck);
       Rot = new G4RotationMatrix();
       Rot->rotateZ(-phi * rad);
       name.str("");

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -67,6 +67,8 @@ typedef CGAL::Point_2<Circular_k>                 Point_2;
   G4double x_at_y(Point_2 &p0, Point_2 &p1, G4double yin);
   PHG4InnerHcalParameters *params;
   G4double scinti_tile_x;
+  G4double scinti_tile_x_lower;
+  G4double scinti_tile_x_upper;
   G4double scinti_tile_z;
   G4double envelope_inner_radius;
   G4double envelope_outer_radius;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.cc
@@ -9,7 +9,7 @@ PHG4InnerHcalParameters::PHG4InnerHcalParameters():
   scinti_gap(0.85 * cm),
   tilt_angle(32.5 * deg),
   n_scinti_plates(5 * 64),
-  n_scinti_tiles(11),
+  n_scinti_tiles(12),
   scinti_tile_thickness(0.7*cm),
   scinti_gap_neighbor(0.1*cm),
   scinti_eta_coverage(1.1),


### PR DESCRIPTION
I changed the default number of scintilator tiles from 22 to 24 (to match it to the electronics channels which go in groups of 8).

I went over the geometry again. In the old version you can see gaps between the left inner hcal envelope and the beginning of the scintilators (red):
![old_inner_hcal](https://cloud.githubusercontent.com/assets/7316141/9914956/6b11f9f0-5c82-11e5-851d-304bf3fe620f.png)
In the new version those are gone:
![new_inner_hcal](https://cloud.githubusercontent.com/assets/7316141/9914991/a02b2f9e-5c82-11e5-93b9-64b689e91a2b.png)
There is still a minute issue at low tilt angles (where the scintilator face touches the envelope instead of the corner) which requires subtracting 0.1mm from the scintilator length to avoid overlaps with the envelope. Given the precision of cutting scintillators I don't think I'll go through that math.
