### PR TITLE
Enable saving visible energy in more cell builders

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -397,7 +397,7 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
             cellptarray[ibin]->set_phibin(ixbin);
             cellptarray[ibin]->set_etabin(ietabin);
           }
-          cellptarray[ibin]->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1]);
+          cellptarray[ibin]->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1], hiter->second->get_light_yield()*vdedx[i1]);
           // just a sanity check - we don't want to mess up by having Nan's or Infs in our energy deposition
           if (! isfinite(hiter->second->get_edep()*vdedx[i1]))
           {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -451,7 +451,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		      if(verbosity > 1)
 			cout << "  add energy to existing cell " << endl;
 
-		      cellptmap.find(key)->second->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1]);
+		      cellptmap.find(key)->second->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1], hiter->second->get_light_yield()*vdedx[i1]);
 		    }
 		  else
 		    {
@@ -463,7 +463,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
                       it->second->set_layer(*layer);
                       it->second->set_phibin(iphibin);
                       it->second->set_etabin(ietabin);		      
-		      it->second->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1], hiter->second->get_light_yield());
+		      it->second->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1], hiter->second->get_light_yield()*vdedx[i1]);
 		    }
 
 		  // just a sanity check - we don't want to mess up by having Nan's or Infs in our energy deposition
@@ -659,7 +659,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		      if(verbosity > 1)
 			cout << "  add energy to existing cell for key = " << cellptmap.find(key)->first << endl;
 
-		      cellptmap.find(key)->second->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1]);
+		      cellptmap.find(key)->second->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1], hiter->second->get_light_yield()*vdedx[i1]);
 		    }
 		  else
 		    {
@@ -671,7 +671,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		      it->second->set_layer(*layer);
                       it->second->set_phibin(iphibin);
                       it->second->set_zbin(izbin);
-		      it->second->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1]);
+		      it->second->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1], hiter->second->get_light_yield()*vdedx[i1]);
 		    }
 		}
               vphi.clear();

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -595,6 +595,16 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
                 }
 
               double trklen = sqrt((ax - bx) * (ax - bx) + (ay - by) * (ay - by));
+              // if entry and exit hit are the same (seems to happen rarely), trklen = 0
+              // which leads to a 0/0 and an NaN in edep later on
+              // this code does for particles in the same cell a trklen/trklen (vdedx[ii]/trklen)
+              // so setting this to any non zero number will do just fine
+              // I just pick -1 here to flag those strange hits in case I want t oanalyze them
+              // later on
+              if (trklen == 0)
+          {
+            trklen = -1.;
+          }
               vector<int> vphi;
               vector<int> vz;
               vector<double> vdedx;
@@ -660,6 +670,14 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 			cout << "  add energy to existing cell for key = " << cellptmap.find(key)->first << endl;
 
 		      cellptmap.find(key)->second->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1], hiter->second->get_light_yield()*vdedx[i1]);
+
+          if(verbosity > 1 and isnan(hiter->second->get_light_yield()*vdedx[i1]))
+            {
+
+              cout << "    NAN lighy yield with vdedx[i1] = "<<vdedx[i1]
+              <<" and hiter->second->get_light_yield() = "<<hiter->second->get_light_yield() << endl;
+
+            }
 		    }
 		  else
 		    {
@@ -672,6 +690,15 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
                       it->second->set_phibin(iphibin);
                       it->second->set_zbin(izbin);
 		      it->second->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1], hiter->second->get_light_yield()*vdedx[i1]);
+
+          if(verbosity > 1 and isnan(hiter->second->get_light_yield()*vdedx[i1]))
+            {
+
+              cout << "    NAN lighy yield with vdedx[i1] = "<<vdedx[i1]
+              <<" and hiter->second->get_light_yield() = "<<hiter->second->get_light_yield() << endl;
+
+            }
+
 		    }
 		}
               vphi.clear();

--- a/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
@@ -329,7 +329,7 @@ PHG4SlatCellReco::process_event(PHCompositeNode *topNode)
 			  cellptarray[slatbin][intetabin]->set_phibin(slatbin);
 			  cellptarray[slatbin][intetabin]->set_etabin(intetabin);
 			}
-		      cellptarray[slatbin][intetabin]->add_edep(hiter->first, hiter->second->get_edep()*bins_fraction.back().get<2>());
+		      cellptarray[slatbin][intetabin]->add_edep(hiter->first, hiter->second->get_edep()*bins_fraction.back().get<2>(), hiter->second->get_light_yield()*bins_fraction.back().get<2>());
 		      bins_fraction.pop_back();
 		    }
 		}
@@ -342,7 +342,7 @@ PHG4SlatCellReco::process_event(PHCompositeNode *topNode)
 		      cellptarray[slatbin][intetabin]->set_phibin(slatbin);
 		      cellptarray[slatbin][intetabin]->set_etabin(intetabin);
 		    }
-		  cellptarray[slatbin][intetabin]->add_edep(hiter->first, hiter->second->get_edep());
+		  cellptarray[slatbin][intetabin]->add_edep(hiter->first, hiter->second->get_edep(), hiter->second->get_light_yield());
 		}
 	    } // end loop over g4hits
           int numcells = 0;


### PR DESCRIPTION
PHG4CylinderCell is capable of storing visible energy sum from PHG4Hit. However, this has not yet propagated to all Cell reco code. This pull request is intended to do so. 

BTW, also fix a bug in z-bin cell builder, that a zero-pathlength hit would induce a divide-zero error. 