### PR TITLE
Calorimeter evaluator modifications

### DIFF
--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -33,6 +33,8 @@ CaloEvaluator::CaloEvaluator(const string &name, const string &caloname, const s
   : SubsysReco(name),
     _caloname(caloname),
     _ievent(0),
+    _truth_trace_embed_flag(0), // truth => reco trace all primaries
+    _reco_e_threshold(0.0), // 0 GeV before reco is traced
     _do_gpoint_eval(true),
     _do_gshower_eval(true),
     _do_tower_eval(true),
@@ -375,6 +377,10 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	 iter != map.end(); 
 	 ++iter) {
       PHG4Particle* primary = iter->second;
+
+      if (_truth_trace_embed_flag) {
+	if (trutheval->get_embed(primary) != _truth_trace_embed_flag) continue;
+      }
       
       float gparticleID = primary->get_track_id();
       float gflavor     = primary->get_pid();
@@ -473,6 +479,8 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
     for (rtiter = begin_end.first; rtiter !=  begin_end.second; ++rtiter) {
       RawTower *tower = rtiter->second;
 
+      if (tower->get_energy() < _reco_e_threshold) continue;
+      
       float towerid = tower->get_id();
       float ieta    = tower->get_bineta();
       float iphi    = tower->get_binphi();
@@ -580,6 +588,8 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
     for (unsigned int icluster = 0; icluster < clusters->size(); icluster++) {
       RawCluster *cluster = clusters->getCluster(icluster);
 
+      if (cluster->get_energy() < _reco_e_threshold) continue;
+      
       float clusterID = cluster->get_id();
       float ntowers   = cluster->getNTowers();
       float eta       = cluster->get_eta();

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -25,8 +25,6 @@
 //#include <algorithm>
 #include <cmath>
 
-#include </opt/sphenix/utils/include/valgrind/callgrind.h>
-
 using namespace std;
 
 CaloEvaluator::CaloEvaluator(const string &name, const string &caloname, const string &filename) 
@@ -93,12 +91,7 @@ int CaloEvaluator::process_event(PHCompositeNode *topNode) {
   // fill the Evaluator NTuples
   //---------------------------
 
-  CALLGRIND_START_INSTRUMENTATION;
-  
   fillOutputNtuples(topNode);
-
-  CALLGRIND_STOP_INSTRUMENTATION;
-  CALLGRIND_DUMP_STATS;
   
   //--------------------------------------------------
   // Print out the ancestry information for this event

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -21,7 +21,7 @@
 #include <TFile.h>
 
 #include <iostream>
-//#include <vector>
+#include <set>
 //#include <algorithm>
 #include <cmath>
 
@@ -33,7 +33,7 @@ CaloEvaluator::CaloEvaluator(const string &name, const string &caloname, const s
   : SubsysReco(name),
     _caloname(caloname),
     _ievent(0),
-    _truth_trace_embed_flag(0), // truth => reco trace all primaries
+    _truth_trace_embed_flags(),
     _reco_e_threshold(0.0), // 0 GeV before reco is traced
     _do_gpoint_eval(true),
     _do_gshower_eval(true),
@@ -378,8 +378,9 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	 ++iter) {
       PHG4Particle* primary = iter->second;
 
-      if (_truth_trace_embed_flag) {
-	if (trutheval->get_embed(primary) != _truth_trace_embed_flag) continue;
+      if (!_truth_trace_embed_flags.empty()) {
+	if (_truth_trace_embed_flags.find(trutheval->get_embed(primary)) ==
+	    _truth_trace_embed_flags.end()) continue;
       }
       
       float gparticleID = primary->get_track_id();

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -25,6 +25,8 @@
 //#include <algorithm>
 #include <cmath>
 
+#include </opt/sphenix/utils/include/valgrind/callgrind.h>
+
 using namespace std;
 
 CaloEvaluator::CaloEvaluator(const string &name, const string &caloname, const string &filename) 
@@ -89,8 +91,13 @@ int CaloEvaluator::process_event(PHCompositeNode *topNode) {
   // fill the Evaluator NTuples
   //---------------------------
 
+  CALLGRIND_START_INSTRUMENTATION;
+  
   fillOutputNtuples(topNode);
 
+  CALLGRIND_STOP_INSTRUMENTATION;
+  CALLGRIND_DUMP_STATS;
+  
   //--------------------------------------------------
   // Print out the ancestry information for this event
   //--------------------------------------------------

--- a/simulation/g4simulation/g4eval/CaloEvaluator.h
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.h
@@ -13,6 +13,7 @@
 #include <TNtuple.h>
 #include <TFile.h>
 
+#include <set>
 #include <string>
 
 /// \class CaloEvaluator
@@ -37,8 +38,8 @@ class CaloEvaluator : public SubsysReco {
   int End(PHCompositeNode *topNode);
 
   // forward trace only off of primaries with embed flags set
-  void set_truth_tracing_embed_flag(int flag) {
-    _truth_trace_embed_flag = flag;
+  void add_truth_tracing_embed_flag(int flag) {
+    _truth_trace_embed_flags.insert(flag);
   }
 
   // backward trace only if reco meets an energy threshold requirement
@@ -52,7 +53,7 @@ class CaloEvaluator : public SubsysReco {
   
   unsigned long _ievent;
 
-  int _truth_trace_embed_flag;
+  std::set<int> _truth_trace_embed_flags;
   float _reco_e_threshold;
 
   //----------------------------------

--- a/simulation/g4simulation/g4eval/CaloEvaluator.h
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.h
@@ -47,6 +47,11 @@ class CaloEvaluator : public SubsysReco {
     _reco_e_threshold = thresh;
   }
 
+  void set_do_gpoint_eval(bool b) {_do_gpoint_eval = b;}
+  void set_do_gshower_eval(bool b) {_do_gshower_eval = b;}
+  void set_do_tower_eval(bool b) {_do_tower_eval = b;}
+  void set_do_cluster_eval(bool b) {_do_cluster_eval = b;}
+  
  private:
 
   std::string _caloname;

--- a/simulation/g4simulation/g4eval/CaloEvaluator.h
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.h
@@ -36,11 +36,24 @@ class CaloEvaluator : public SubsysReco {
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
+  // forward trace only off of primaries with embed flags set
+  void set_truth_tracing_embed_flag(int flag) {
+    _truth_trace_embed_flag = flag;
+  }
+
+  // backward trace only if reco meets an energy threshold requirement
+  void set_reco_tracing_energy_threshold(float thresh) {
+    _reco_e_threshold = thresh;
+  }
+
  private:
 
   std::string _caloname;
   
   unsigned long _ievent;
+
+  int _truth_trace_embed_flag;
+  float _reco_e_threshold;
 
   //----------------------------------
   // evaluator output ntuples

--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.C
@@ -64,7 +64,7 @@ std::set<PHG4Hit*> CaloRawClusterEval::all_truth_hits(RawCluster* cluster) {
   }
   
   std::set<PHG4Hit*> truth_hits;
-
+  
   // loop over all the clustered towers
   RawCluster::TowerConstRange begin_end = cluster->get_towers();
   RawCluster::TowerConstIterator iter;
@@ -73,13 +73,12 @@ std::set<PHG4Hit*> CaloRawClusterEval::all_truth_hits(RawCluster* cluster) {
     RawTower* tower = _towers->getTower(iter->first);
     
     std::set<PHG4Hit*> new_hits = get_rawtower_eval()->all_truth_hits(tower);
-    std::set<PHG4Hit*> union_hits;
 
-    std::set_union(truth_hits.begin(),truth_hits.end(),
-		   new_hits.begin(),new_hits.end(),
-		   std::inserter(union_hits,union_hits.begin()));
-
-    std::swap(truth_hits,union_hits); // swap union into truth_particles    
+    for (std::set<PHG4Hit*>::iterator iter = new_hits.begin();
+	 iter != new_hits.end();
+	 ++iter) {
+      truth_hits.insert(*iter);
+    }
   }
 
   if (_do_cache) _cache_all_truth_hits.insert(make_pair(cluster,truth_hits));
@@ -106,13 +105,12 @@ std::set<PHG4Particle*> CaloRawClusterEval::all_truth_primaries(RawCluster* clus
     { 
     RawTower* tower = _towers->getTower(iter->first);
     std::set<PHG4Particle*> new_primaries = _towereval.all_truth_primaries(tower);
-    std::set<PHG4Particle*> union_primaries;
 
-    std::set_union(truth_primaries.begin(),truth_primaries.end(),
-		   new_primaries.begin(),new_primaries.end(),
-		   std::inserter(union_primaries,union_primaries.begin()));
-
-    std::swap(truth_primaries,union_primaries); // swap union into truth_particles    
+    for (std::set<PHG4Particle*>::iterator iter = new_primaries.begin();
+	 iter != new_primaries.end();
+	 ++iter) {
+      truth_primaries.insert(*iter);
+    }
   }
 
   if (_do_cache) _cache_all_truth_primaries.insert(make_pair(cluster,truth_primaries));

--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.C
@@ -241,7 +241,8 @@ float CaloRawClusterEval::get_energy_contribution(RawCluster* cluster, PHG4Parti
        iter != g4hits.end();
        ++iter) {
     PHG4Hit* g4hit = *iter;
-    if (g4hit->get_trkid() == primary->get_track_id()) {
+    PHG4Particle* candidate = get_truth_eval()->get_primary_particle(g4hit);
+    if (candidate->get_track_id() == primary->get_track_id()) {
       energy += g4hit->get_edep();
     }
   }

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -106,7 +106,7 @@ std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
        ++iter) {
     PHG4Hit* g4hit = *iter;
     PHG4Particle* primary = get_truth_eval()->get_primary_particle( g4hit );
-
+    
     static bool first0 = true;
     if (first0) {
       cout << PHWHERE << "mike: come back and check why this primary if-statement is here" << endl;
@@ -137,11 +137,16 @@ PHG4Particle* CaloRawTowerEval::max_truth_primary_by_energy(RawTower* tower) {
   PHG4Particle* max_primary = NULL;
   float max_e = FLT_MAX*-1.0;
   std::set<PHG4Particle*> primaries = all_truth_primaries(tower);
+
+  cout << "size: " << primaries.size() << endl;
+  
   for (std::set<PHG4Particle*>::iterator iter = primaries.begin();
        iter != primaries.end();
        ++iter) {
 
     PHG4Particle* primary = *iter;
+    cout << "primary: " << primary << endl;
+
     float e = get_energy_contribution(tower,primary);
     if (isnan(e)) continue;
     if (e > max_e) {
@@ -150,6 +155,8 @@ PHG4Particle* CaloRawTowerEval::max_truth_primary_by_energy(RawTower* tower) {
     }
   }
 
+  cout << "max primary: " << max_primary << endl;
+  
   if (_do_cache) _cache_max_truth_primary_by_energy.insert(make_pair(tower,max_primary));
   
   return max_primary;
@@ -235,10 +242,12 @@ float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* p
 
   if (!_trutheval.is_primary(primary)) return NAN;
 
-  // ensure that the primary is from the primary map and not the full map
-  // important for caching the pointer, but since the track ids are the same
-  // the functional logic below remains the same
+  // reduce cache misses by using only pointer from PrimaryMap
+  cout << "old primary pointer: " << primary << endl;
+  primary->identify();
   primary = get_truth_eval()->get_primary_particle(primary);
+  cout << "updated primary pointer: " << primary << endl;
+  primary->identify();
   
   if (_do_cache) {
     std::map<std::pair<RawTower*,PHG4Particle*>, float>::iterator iter =

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -109,7 +109,8 @@ std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
     
     static bool first0 = true;
     if (first0) {
-      cout << PHWHERE << "mike: come back and check why this primary if-statement is here" << endl;
+      cout << PHWHERE << endl;
+      cout << "\033[31;1m mike: come back and check why this primary if-statement is here \033[0m" << endl;
       first0=false;
     }
     
@@ -138,15 +139,11 @@ PHG4Particle* CaloRawTowerEval::max_truth_primary_by_energy(RawTower* tower) {
   float max_e = FLT_MAX*-1.0;
   std::set<PHG4Particle*> primaries = all_truth_primaries(tower);
 
-  cout << "size: " << primaries.size() << endl;
-  
   for (std::set<PHG4Particle*>::iterator iter = primaries.begin();
        iter != primaries.end();
        ++iter) {
 
     PHG4Particle* primary = *iter;
-    cout << "primary: " << primary << endl;
-
     float e = get_energy_contribution(tower,primary);
     if (isnan(e)) continue;
     if (e > max_e) {
@@ -155,8 +152,6 @@ PHG4Particle* CaloRawTowerEval::max_truth_primary_by_energy(RawTower* tower) {
     }
   }
 
-  cout << "max primary: " << max_primary << endl;
-  
   if (_do_cache) _cache_max_truth_primary_by_energy.insert(make_pair(tower,max_primary));
   
   return max_primary;
@@ -243,11 +238,7 @@ float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* p
   if (!_trutheval.is_primary(primary)) return NAN;
 
   // reduce cache misses by using only pointer from PrimaryMap
-  cout << "old primary pointer: " << primary << endl;
-  primary->identify();
   primary = get_truth_eval()->get_primary_particle(primary);
-  cout << "updated primary pointer: " << primary << endl;
-  primary->identify();
   
   if (_do_cache) {
     std::map<std::pair<RawTower*,PHG4Particle*>, float>::iterator iter =

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -106,7 +106,14 @@ std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
        ++iter) {
     PHG4Hit* g4hit = *iter;
     PHG4Particle* primary = get_truth_eval()->get_primary_particle( g4hit );
-    if (!primary) continue; // why is this here?
+
+    static bool first0 = true;
+    if (first0) {
+      cout << PHWHERE << "mike: come back and check why this primary if-statement is here" << endl;
+      first0=false;
+    }
+    
+    if (!primary) continue; // why is this here? -- noise towers should have zero g4hits and not enter the loop
     truth_primaries.insert(primary);
   }
 

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -105,9 +105,8 @@ std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
        iter != g4hits.end();
        ++iter) {
     PHG4Hit* g4hit = *iter;
-    PHG4Particle* particle = _truthinfo->GetHit( g4hit->get_trkid() );
-    PHG4Particle* primary = _trutheval.get_primary_particle( particle );
-    if (!primary) continue;
+    PHG4Particle* primary = get_truth_eval()->get_primary_particle( g4hit );
+    if (!primary) continue; // why is this here?
     truth_primaries.insert(primary);
   }
 
@@ -137,6 +136,7 @@ PHG4Particle* CaloRawTowerEval::max_truth_primary_by_energy(RawTower* tower) {
 
     PHG4Particle* primary = *iter;
     float e = get_energy_contribution(tower,primary);
+    if (isnan(e)) continue;
     if (e > max_e) {
       max_e = e;
       max_primary = primary;      
@@ -151,6 +151,9 @@ PHG4Particle* CaloRawTowerEval::max_truth_primary_by_energy(RawTower* tower) {
 std::set<RawTower*> CaloRawTowerEval::all_towers_from(PHG4Particle* primary) { 
 
   if (!_trutheval.is_primary(primary)) return std::set<RawTower*>();
+
+  // use primary map pointer
+  primary = get_truth_eval()->get_primary_particle(primary);
   
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<RawTower*> >::iterator iter =
@@ -189,7 +192,9 @@ std::set<RawTower*> CaloRawTowerEval::all_towers_from(PHG4Particle* primary) {
 RawTower* CaloRawTowerEval::best_tower_from(PHG4Particle* primary) {
 
   if (!_trutheval.is_primary(primary)) return NULL;
-      
+
+  primary = get_truth_eval()->get_primary_particle(primary);
+  
   if (_do_cache) {
     std::map<PHG4Particle*,RawTower*>::iterator iter =
       _cache_best_tower_from_primary.find(primary);
@@ -199,13 +204,14 @@ RawTower* CaloRawTowerEval::best_tower_from(PHG4Particle* primary) {
   }
   
   RawTower* best_tower = NULL;
-  float best_energy = 0.0;  
+  float best_energy = FLT_MAX*-1.0;  
   std::set<RawTower*> towers = all_towers_from(primary);
   for (std::set<RawTower*>::iterator iter = towers.begin();
        iter != towers.end();
        ++iter) {
     RawTower* tower = *iter;
     float energy = get_energy_contribution(tower,primary);
+    if (isnan(energy)) continue;
     if (energy > best_energy) {
       best_tower = tower;
       best_energy = energy;

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -105,16 +105,7 @@ std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
        iter != g4hits.end();
        ++iter) {
     PHG4Hit* g4hit = *iter;
-    PHG4Particle* primary = get_truth_eval()->get_primary_particle( g4hit );
-    
-    static bool first0 = true;
-    if (first0) {
-      cout << PHWHERE << endl;
-      cout << "\033[31;1m mike: come back and check why this primary if-statement is here \033[0m" << endl;
-      first0=false;
-    }
-    
-    if (!primary) continue; // why is this here? -- noise towers should have zero g4hits and not enter the loop
+    PHG4Particle* primary = get_truth_eval()->get_primary_particle( g4hit );    
     truth_primaries.insert(primary);
   }
 

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -221,6 +221,11 @@ RawTower* CaloRawTowerEval::best_tower_from(PHG4Particle* primary) {
 float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* primary) {
 
   if (!_trutheval.is_primary(primary)) return NAN;
+
+  // ensure that the primary is from the primary map and not the full map
+  // important for caching the pointer, but since the track ids are the same
+  // the functional logic below remains the same
+  primary = get_truth_eval()->get_primary_particle(primary);
   
   if (_do_cache) {
     std::map<std::pair<RawTower*,PHG4Particle*>, float>::iterator iter =
@@ -236,7 +241,8 @@ float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* p
        iter != g4hits.end();
        ++iter) {
     PHG4Hit* g4hit = *iter;
-    if (g4hit->get_trkid() == primary->get_track_id()) {
+    PHG4Particle* candidate = get_truth_eval()->get_primary_particle(g4hit);
+    if (candidate->get_track_id() == primary->get_track_id()) {
       energy += g4hit->get_edep();
     }
   }

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -86,10 +86,9 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Particle* particle) {
     }
   }
 
-  PHG4Particle* returnval = particle;
-  if (!is_primary(particle)) {
-    returnval = _truthinfo->GetPrimaryHit( particle->get_primary_id() );
-  }
+  // always report the primary from the Primary Map regardless if a
+  // primary from the full Map was the argument
+  PHG4Particle* returnval = _truthinfo->GetPrimaryHit( particle->get_primary_id() );
 
   if (_do_cache) _cache_get_primary_particle_g4particle.insert(make_pair(particle,returnval));
   
@@ -139,10 +138,11 @@ bool CaloTruthEval::is_primary(PHG4Particle* particle) {
     }
   }
 
-  bool is_primary = false;
-  // all particles from the Primary Map have primary id set to -1
-  if (particle->get_primary_id() == -1) {
-    is_primary = true;
+  bool is_primary = true;
+  if (!_truthinfo->GetPrimaryHit(particle->get_track_id())) {
+    // does the particle id appear in the primary map?
+    // this way either copy (in Map or Primary Map) will report correctly
+    is_primary = false;
   }
   
   if (_do_cache) _cache_is_primary.insert(make_pair(particle,is_primary));

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -72,7 +72,6 @@ std::set<PHG4Hit*> CaloTruthEval::all_truth_hits(PHG4Particle* particle) {
 
 PHG4Particle* CaloTruthEval::get_parent_particle(PHG4Hit* g4hit) {
 
-  // expensive call, but only because it gets called a ton (i think)
   PHG4Particle* particle = _truthinfo->GetHit( g4hit->get_trkid() );
   return particle;
 }
@@ -86,11 +85,10 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Particle* particle) {
       return iter->second;
     }
   }
-  
+
   PHG4Particle* returnval = particle;
-  if ((returnval->get_primary_id() != returnval->get_track_id()) ||
-      (returnval->get_primary_id() != -1)) {
-    returnval = _truthinfo->GetHit( particle->get_primary_id() );
+  if (!is_primary(particle)) {
+    returnval = _truthinfo->GetPrimaryHit( particle->get_primary_id() );
   }
 
   if (_do_cache) _cache_get_primary_particle_g4particle.insert(make_pair(particle,returnval));
@@ -142,9 +140,8 @@ bool CaloTruthEval::is_primary(PHG4Particle* particle) {
   }
 
   bool is_primary = false;
-  if (particle->get_primary_id() == particle->get_track_id()) {
-    is_primary = true;
-  } else if (particle->get_primary_id() == -1) {
+  // all particles from the Primary Map have primary id set to -1
+  if (particle->get_primary_id() == -1) {
     is_primary = true;
   }
   

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -23,7 +23,7 @@ CaloTruthEval::CaloTruthEval(PHCompositeNode* topNode,std::string caloname)
     _cache_all_truth_hits_g4particle(),
     _cache_get_primary_particle_g4particle(),
     _cache_get_primary_particle_g4hit(),
-    _cache_is_primary(),
+    //    _cache_is_primary(),
     _cache_get_shower_from_primary(),
     _cache_get_shower_moliere_radius(),
     _cache_get_shower_energy_deposit() {
@@ -35,7 +35,7 @@ void CaloTruthEval::next_event(PHCompositeNode* topNode) {
   _cache_all_truth_hits_g4particle.clear();
   _cache_get_primary_particle_g4particle.clear();
   _cache_get_primary_particle_g4hit.clear();
-  _cache_is_primary.clear();
+  //  _cache_is_primary.clear();
   _cache_get_shower_from_primary.clear();
   _cache_get_shower_moliere_radius.clear();
   _cache_get_shower_energy_deposit.clear();
@@ -135,13 +135,13 @@ PHG4VtxPoint* CaloTruthEval::get_vertex(PHG4Particle* particle) {
 
 bool CaloTruthEval::is_primary(PHG4Particle* particle) {
 
-  if (_do_cache) {
-    std::map<PHG4Particle*,bool>::iterator iter =
-      _cache_is_primary.find(particle);
-    if (iter != _cache_is_primary.end()) {
-      return iter->second;
-    }
-  }
+  //if (_do_cache) {
+  //  std::map<PHG4Particle*,bool>::iterator iter =
+  //    _cache_is_primary.find(particle);
+  //  if (iter != _cache_is_primary.end()) {
+  //    return iter->second;
+  //  }
+  //}
 
   bool is_primary = true;
   if (!_truthinfo->GetPrimaryHit(particle->get_track_id())) {
@@ -150,7 +150,7 @@ bool CaloTruthEval::is_primary(PHG4Particle* particle) {
     is_primary = false;
   }
   
-  if (_do_cache) _cache_is_primary.insert(make_pair(particle,is_primary));
+  //if (_do_cache) _cache_is_primary.insert(make_pair(particle,is_primary));
   
   return is_primary;
 }

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -23,7 +23,6 @@ CaloTruthEval::CaloTruthEval(PHCompositeNode* topNode,std::string caloname)
     _cache_all_truth_hits_g4particle(),
     _cache_get_primary_particle_g4particle(),
     _cache_get_primary_particle_g4hit(),
-    //    _cache_is_primary(),
     _cache_get_shower_from_primary(),
     _cache_get_shower_moliere_radius(),
     _cache_get_shower_energy_deposit() {
@@ -35,7 +34,6 @@ void CaloTruthEval::next_event(PHCompositeNode* topNode) {
   _cache_all_truth_hits_g4particle.clear();
   _cache_get_primary_particle_g4particle.clear();
   _cache_get_primary_particle_g4hit.clear();
-  //  _cache_is_primary.clear();
   _cache_get_shower_from_primary.clear();
   _cache_get_shower_moliere_radius.clear();
   _cache_get_shower_energy_deposit.clear();
@@ -135,22 +133,12 @@ PHG4VtxPoint* CaloTruthEval::get_vertex(PHG4Particle* particle) {
 
 bool CaloTruthEval::is_primary(PHG4Particle* particle) {
 
-  //if (_do_cache) {
-  //  std::map<PHG4Particle*,bool>::iterator iter =
-  //    _cache_is_primary.find(particle);
-  //  if (iter != _cache_is_primary.end()) {
-  //    return iter->second;
-  //  }
-  //}
-
   bool is_primary = true;
   if (!_truthinfo->GetPrimaryHit(particle->get_track_id())) {
     // does the particle id appear in the primary map?
     // this way either copy (in Map or Primary Map) will report correctly
     is_primary = false;
   }
-  
-  //if (_do_cache) _cache_is_primary.insert(make_pair(particle,is_primary));
   
   return is_primary;
 }

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -88,7 +88,12 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Particle* particle) {
 
   // always report the primary from the Primary Map regardless if a
   // primary from the full Map was the argument
-  PHG4Particle* returnval = _truthinfo->GetPrimaryHit( particle->get_primary_id() );
+  PHG4Particle* returnval = NULL;
+  if (particle->get_primary_id() != -1) {
+    returnval = _truthinfo->GetPrimaryHit( particle->get_primary_id() );
+  } else {
+    returnval = _truthinfo->GetPrimaryHit( particle->get_track_id() );
+  }
 
   if (_do_cache) _cache_get_primary_particle_g4particle.insert(make_pair(particle,returnval));
   

--- a/simulation/g4simulation/g4eval/CaloTruthEval.h
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.h
@@ -48,7 +48,6 @@ private:
   std::map<PHG4Particle*,std::set<PHG4Hit*> > _cache_all_truth_hits_g4particle;
   std::map<PHG4Particle*,PHG4Particle*>       _cache_get_primary_particle_g4particle;
   std::map<PHG4Hit*,PHG4Particle*>            _cache_get_primary_particle_g4hit;
-  //std::map<PHG4Particle*,bool>                _cache_is_primary;
   std::map<PHG4Particle*,std::set<PHG4Hit*> > _cache_get_shower_from_primary;
   std::map<PHG4Particle*,float>               _cache_get_shower_moliere_radius;
   std::map<PHG4Particle*,float>               _cache_get_shower_energy_deposit;

--- a/simulation/g4simulation/g4eval/CaloTruthEval.h
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.h
@@ -48,7 +48,7 @@ private:
   std::map<PHG4Particle*,std::set<PHG4Hit*> > _cache_all_truth_hits_g4particle;
   std::map<PHG4Particle*,PHG4Particle*>       _cache_get_primary_particle_g4particle;
   std::map<PHG4Hit*,PHG4Particle*>            _cache_get_primary_particle_g4hit;
-  std::map<PHG4Particle*,bool>                _cache_is_primary;
+  //std::map<PHG4Particle*,bool>                _cache_is_primary;
   std::map<PHG4Particle*,std::set<PHG4Hit*> > _cache_get_shower_from_primary;
   std::map<PHG4Particle*,float>               _cache_get_shower_moliere_radius;
   std::map<PHG4Particle*,float>               _cache_get_shower_energy_deposit;

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -133,6 +133,15 @@ PHG4TruthInfoContainer::GetHit(const int trackid)
   return 0;
 }
 
+PHG4Particle*
+PHG4TruthInfoContainer::GetPrimaryHit(const int trackid)
+{
+  int key = get_key(trackid);
+  Iterator it = primary_particle_map.find(key);
+  if ( it != primary_particle_map.end() ) return it->second;
+  return 0;
+}
+
 PHG4TruthInfoContainer::Range
 PHG4TruthInfoContainer::GetHitRange()
 {

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -39,6 +39,7 @@ class PHG4TruthInfoContainer: public PHObject
   //  Iterator AddHit(const int detid);
 
   PHG4Particle* GetHit(const int detid);
+  PHG4Particle* GetPrimaryHit(const int detid);
 
   //! Add a vertex and return an iterator to the user
   VtxIterator AddVertex(const int detid);


### PR DESCRIPTION
This merge will bring in a couple of things. Most importantly it improves the correctness of the energy contribution calculations. I found these by embedding 40 GeV electrons in central events and watching that the evaluator was not getting confused by the additional trace possibilities.

It also mitigates the speed issues by improving the merging of sets. Full eval of the CEMC in a central event should run 10 minutes or so. For single particle traces within central events these commits resulted in a ~x10 improvement. I've added methods to reduce the forward tracing to particular embed flags and reverse tracing only above some energy threshold. This will buy us some time in many circumstances. 

I need to do more profiling to guide further optimization. One possibility is I might have to swap to unordered_sets, that is a pain to do with tr1, but is still possible if we are still holding off on c++11. I'll let the profiler tell me on Monday at the moment the bottlenecks have moved away from the insert cost / merge cost.

Given the logic repair on the energy contributions and some strides on the optimization, I'm making this pull request available now.

Partially addresses issue #52 