### PR TITLE
Remove error message from Pythia8

### DIFF
--- a/generators/PHPythia8/PHPythia8.C
+++ b/generators/PHPythia8/PHPythia8.C
@@ -129,11 +129,9 @@ int PHPythia8::Init(PHCompositeNode *topNode) {
 
   _pythia->init();
 
-  print_config();
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
-
+  
 int PHPythia8::End(PHCompositeNode *topNode) {
   //-* dump out closing info (cross-sections, etc)
   _pythia->stat();
@@ -173,7 +171,7 @@ int PHPythia8::read_config(const char *cfg_file) {
 
 //-* print pythia config info
 void PHPythia8::print_config() const {
-  _pythia->info.list();
+  //_pythia->info.list();
 }
 
 int PHPythia8::process_event(PHCompositeNode *topNode) {

--- a/generators/PHPythia8/PHPythia8.h
+++ b/generators/PHPythia8/PHPythia8.h
@@ -44,7 +44,7 @@ public:
   PHPythia8(const std::string &name = "PHPythia8");
   virtual ~PHPythia8();
 
-  int Init(PHCompositeNode *topNode);  
+  int Init(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode); 
   int ResetEvent(PHCompositeNode *topNode); 
   int End(PHCompositeNode *topNode);


### PR DESCRIPTION
Info List print in Init() was called before event variables (x1,x2,QQ,etc) were filled. Pythia8 produces an error message that will confuse users, so I'm removing this print.