### PR TITLE
Additional CaloEvalStack Optimization

### DIFF
--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -35,6 +35,7 @@ CaloEvaluator::CaloEvaluator(const string &name, const string &caloname, const s
     _caloname(caloname),
     _ievent(0),
     _truth_trace_embed_flags(),
+    _truth_e_threshold(0.0), // 0 GeV before reco is traced
     _reco_e_threshold(0.0), // 0 GeV before reco is traced
     _do_gpoint_eval(true),
     _do_gshower_eval(true),
@@ -388,6 +389,8 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	 ++iter) {
       PHG4Particle* primary = iter->second;
 
+      if (primary->get_e() < _truth_e_threshold) continue;
+      
       if (!_truth_trace_embed_flags.empty()) {
 	if (_truth_trace_embed_flags.find(trutheval->get_embed(primary)) ==
 	    _truth_trace_embed_flags.end()) continue;

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -25,9 +25,6 @@
 //#include <algorithm>
 #include <cmath>
 
-#include </opt/sphenix/utils/include/valgrind/callgrind.h>
-#include <sys/time.h>
-
 using namespace std;
 
 CaloEvaluator::CaloEvaluator(const string &name, const string &caloname, const string &filename) 
@@ -95,21 +92,7 @@ int CaloEvaluator::process_event(PHCompositeNode *topNode) {
   // fill the Evaluator NTuples
   //---------------------------
 
-  struct timeval start, end;
-  long mtime, seconds, useconds;    
-  gettimeofday(&start, NULL);
-  CALLGRIND_START_INSTRUMENTATION;
-  
   fillOutputNtuples(topNode);
-
-  CALLGRIND_STOP_INSTRUMENTATION;
-  gettimeofday(&end, NULL);
-
-  seconds  = end.tv_sec  - start.tv_sec;
-  useconds = end.tv_usec - start.tv_usec;
-  mtime = ((seconds) * 1000 + useconds/1000.0) + 0.5;
-
-  cout << "mike timer (usec): " << mtime << endl; 
   
   //--------------------------------------------------
   // Print out the ancestry information for this event

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -25,6 +25,9 @@
 //#include <algorithm>
 #include <cmath>
 
+#include </opt/sphenix/utils/include/valgrind/callgrind.h>
+#include <sys/time.h>
+
 using namespace std;
 
 CaloEvaluator::CaloEvaluator(const string &name, const string &caloname, const string &filename) 
@@ -91,7 +94,21 @@ int CaloEvaluator::process_event(PHCompositeNode *topNode) {
   // fill the Evaluator NTuples
   //---------------------------
 
+  struct timeval start, end;
+  long mtime, seconds, useconds;    
+  gettimeofday(&start, NULL);
+  CALLGRIND_START_INSTRUMENTATION;
+  
   fillOutputNtuples(topNode);
+
+  CALLGRIND_STOP_INSTRUMENTATION;
+  gettimeofday(&end, NULL);
+
+  seconds  = end.tv_sec  - start.tv_sec;
+  useconds = end.tv_usec - start.tv_usec;
+  mtime = ((seconds) * 1000 + useconds/1000.0) + 0.5;
+
+  cout << "mike timer (usec): " << mtime << endl; 
   
   //--------------------------------------------------
   // Print out the ancestry information for this event

--- a/simulation/g4simulation/g4eval/CaloEvaluator.h
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.h
@@ -41,6 +41,10 @@ class CaloEvaluator : public SubsysReco {
   void add_truth_tracing_embed_flag(int flag) {
     _truth_trace_embed_flags.insert(flag);
   }
+  
+  void set_truth_tracing_energy_threshold(float thresh) {
+    _truth_e_threshold = thresh;
+  }
 
   // backward trace only if reco meets an energy threshold requirement
   void set_reco_tracing_energy_threshold(float thresh) {
@@ -59,6 +63,7 @@ class CaloEvaluator : public SubsysReco {
   unsigned long _ievent;
 
   std::set<int> _truth_trace_embed_flags;
+  float _truth_e_threshold;
   float _reco_e_threshold;
 
   //----------------------------------

--- a/simulation/g4simulation/g4eval/CaloEvaluator.h
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.h
@@ -37,20 +37,36 @@ class CaloEvaluator : public SubsysReco {
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
-  // forward trace only off of primaries with embed flags set
+  // funtions to limit the tracing to only part of the event ---------
+  // and speed up the evaluation
+
+  // when tracing truth showers limit the trace to showers
+  // that result from truth particles with a particular embed flag set
+  // useful if you only want to know about that electron you
+  // embedded into a central hijing event
+  // (evaluation for truth objects with matching embed flag set unaffected)
   void add_truth_tracing_embed_flag(int flag) {
     _truth_trace_embed_flags.insert(flag);
   }
   
+  // limit the tracing of truth particles to those above some
+  // theshold energy. useful for tracing only high energy particles
+  // and ignoring low energy truth particles from a hijing event
+  // (evaluation for objects above threshold unaffected)
   void set_truth_tracing_energy_threshold(float thresh) {
     _truth_e_threshold = thresh;
   }
 
-  // backward trace only if reco meets an energy threshold requirement
+  // limit the tracing of towers and clusters back to the truth particles
+  // to only those reconstructed objects above a particular energy
+  // threshold (evaluation for objects above threshold unaffected)
   void set_reco_tracing_energy_threshold(float thresh) {
     _reco_e_threshold = thresh;
   }
 
+  // functions to limit the output size ------------------
+  // will no evaluate or write out these particular ntuples
+  // mostly intended for size savings, but some time savings will result
   void set_do_gpoint_eval(bool b) {_do_gpoint_eval = b;}
   void set_do_gshower_eval(bool b) {_do_gshower_eval = b;}
   void set_do_tower_eval(bool b) {_do_tower_eval = b;}

--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.C
@@ -240,19 +240,25 @@ float CaloRawClusterEval::get_energy_contribution(RawCluster* cluster, PHG4Parti
       return iter->second;
     }
   }
-  
-  float energy = 0.0;
-  std::set<PHG4Hit*> g4hits = all_truth_hits(cluster);
-  for (std::set<PHG4Hit*>::iterator iter = g4hits.begin();
-       iter != g4hits.end();
-       ++iter) {
-    PHG4Hit* g4hit = *iter;
-    PHG4Particle* candidate = get_truth_eval()->get_primary_particle(g4hit);
-    if (candidate->get_track_id() == primary->get_track_id()) {
-      energy += g4hit->get_edep();
-    }
-  }
 
+  float energy = 0.0;
+  
+  std::set<PHG4Particle*> g4particles = all_truth_primaries(cluster);
+  if (g4particles.find(primary) != g4particles.end()) {
+
+    std::set<PHG4Hit*> g4hits = all_truth_hits(cluster);
+    for (std::set<PHG4Hit*>::iterator iter = g4hits.begin();
+	 iter != g4hits.end();
+	 ++iter) {
+      PHG4Hit* g4hit = *iter;
+      PHG4Particle* candidate = get_truth_eval()->get_primary_particle(g4hit);
+      if (candidate->get_track_id() == primary->get_track_id()) {
+	energy += g4hit->get_edep();
+      }
+    }
+    
+  }
+  
   if (_do_cache) _cache_get_energy_contribution_primary.insert(make_pair(make_pair(cluster,primary),energy));
   
   return energy;

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -240,15 +240,21 @@ float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* p
   }
   
   float energy = 0.0;
-  std::set<PHG4Hit*> g4hits = all_truth_hits(tower);
-  for (std::set<PHG4Hit*>::iterator iter = g4hits.begin();
-       iter != g4hits.end();
-       ++iter) {
-    PHG4Hit* g4hit = *iter;
-    PHG4Particle* candidate = get_truth_eval()->get_primary_particle(g4hit);
-    if (candidate->get_track_id() == primary->get_track_id()) {
-      energy += g4hit->get_edep();
+
+  std::set<PHG4Particle*> g4particles = all_truth_primaries(tower);
+  if (g4particles.find(primary) != g4particles.end()) {
+  
+    std::set<PHG4Hit*> g4hits = all_truth_hits(tower);
+    for (std::set<PHG4Hit*>::iterator iter = g4hits.begin();
+	 iter != g4hits.end();
+	 ++iter) {
+      PHG4Hit* g4hit = *iter;
+      PHG4Particle* candidate = get_truth_eval()->get_primary_particle(g4hit);
+      if (candidate->get_track_id() == primary->get_track_id()) {
+	energy += g4hit->get_edep();
+      }
     }
+    
   }
 
   if (_do_cache) _cache_get_energy_contribution_primary.insert(make_pair(make_pair(tower,primary),energy));

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -21,7 +21,7 @@ CaloTruthEval::CaloTruthEval(PHCompositeNode* topNode,std::string caloname)
     _g4hits(NULL),
     _do_cache(true),
     _cache_all_truth_hits_g4particle(),
-    _cache_get_primary_particle_g4particle(),
+    //_cache_get_primary_particle_g4particle(),
     _cache_get_primary_particle_g4hit(),
     _cache_get_shower_from_primary(),
     _cache_get_shower_moliere_radius(),
@@ -32,7 +32,7 @@ CaloTruthEval::CaloTruthEval(PHCompositeNode* topNode,std::string caloname)
 void CaloTruthEval::next_event(PHCompositeNode* topNode) {
 
   _cache_all_truth_hits_g4particle.clear();
-  _cache_get_primary_particle_g4particle.clear();
+  //_cache_get_primary_particle_g4particle.clear();
   _cache_get_primary_particle_g4hit.clear();
   _cache_get_shower_from_primary.clear();
   _cache_get_shower_moliere_radius.clear();
@@ -76,14 +76,6 @@ PHG4Particle* CaloTruthEval::get_parent_particle(PHG4Hit* g4hit) {
 
 PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Particle* particle) {
 
-  if (_do_cache) {
-    std::map<PHG4Particle*,PHG4Particle*>::iterator iter =
-      _cache_get_primary_particle_g4particle.find(particle);
-    if (iter != _cache_get_primary_particle_g4particle.end()) {
-      return iter->second;
-    }
-  }
-
   // always report the primary from the Primary Map regardless if a
   // primary from the full Map was the argument
   PHG4Particle* returnval = NULL;
@@ -93,8 +85,6 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Particle* particle) {
     returnval = _truthinfo->GetPrimaryHit( particle->get_track_id() );
   }
 
-  if (_do_cache) _cache_get_primary_particle_g4particle.insert(make_pair(particle,returnval));
-  
   return returnval;
 }
 

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -89,7 +89,7 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Particle* particle) {
 
 PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Hit* g4hit) {
 
-  if (_do_cache) { // 35% savings
+  if (_do_cache) {
     std::map<PHG4Hit*,PHG4Particle*>::iterator iter =
       _cache_get_primary_particle_g4hit.find(g4hit);
     if (iter != _cache_get_primary_particle_g4hit.end()) {

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -21,7 +21,6 @@ CaloTruthEval::CaloTruthEval(PHCompositeNode* topNode,std::string caloname)
     _g4hits(NULL),
     _do_cache(true),
     _cache_all_truth_hits_g4particle(),
-    //_cache_get_primary_particle_g4particle(),
     _cache_get_primary_particle_g4hit(),
     _cache_get_shower_from_primary(),
     _cache_get_shower_moliere_radius(),
@@ -32,7 +31,6 @@ CaloTruthEval::CaloTruthEval(PHCompositeNode* topNode,std::string caloname)
 void CaloTruthEval::next_event(PHCompositeNode* topNode) {
 
   _cache_all_truth_hits_g4particle.clear();
-  //_cache_get_primary_particle_g4particle.clear();
   _cache_get_primary_particle_g4hit.clear();
   _cache_get_shower_from_primary.clear();
   _cache_get_shower_moliere_radius.clear();
@@ -91,15 +89,15 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Particle* particle) {
 
 PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Hit* g4hit) {
 
-  if (_do_cache) {
+  if (_do_cache) { // 35% savings
     std::map<PHG4Hit*,PHG4Particle*>::iterator iter =
       _cache_get_primary_particle_g4hit.find(g4hit);
-     if (iter != _cache_get_primary_particle_g4hit.end()) {
-       return iter->second;
-     }
+    if (iter != _cache_get_primary_particle_g4hit.end()) {
+      return iter->second;
+    }
   }
   
-  PHG4Particle* particle = _truthinfo->GetHit( g4hit->get_trkid() );
+  PHG4Particle* particle = get_parent_particle(g4hit);
   PHG4Particle* primary = get_primary_particle(particle);
   
   if (_do_cache) _cache_get_primary_particle_g4hit.insert(make_pair(g4hit,primary));
@@ -137,6 +135,8 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
 
   if (!is_primary(primary)) return std::set<PHG4Hit*>();
 
+  primary = get_primary_particle(primary);
+  
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<PHG4Hit*> >::iterator iter =
       _cache_get_shower_from_primary.find(primary);
@@ -168,6 +168,8 @@ float CaloTruthEval::get_shower_moliere_radius(PHG4Particle* primary) {
 
   if (!is_primary(primary)) return NAN;
 
+  primary = get_primary_particle(primary);
+  
   if (_do_cache) {
     std::map<PHG4Particle*,float>::iterator iter =
       _cache_get_shower_moliere_radius.find(primary);
@@ -241,6 +243,8 @@ float CaloTruthEval::get_shower_energy_deposit(PHG4Particle* primary) {
 
   if (!is_primary(primary)) return NAN;
 
+  primary = get_primary_particle(primary);
+  
   if (_do_cache) {
     std::map<PHG4Particle*,float>::iterator iter =
       _cache_get_shower_energy_deposit.find(primary);

--- a/simulation/g4simulation/g4eval/CaloTruthEval.h
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.h
@@ -46,7 +46,6 @@ private:
 
   bool                                        _do_cache;
   std::map<PHG4Particle*,std::set<PHG4Hit*> > _cache_all_truth_hits_g4particle;
-  std::map<PHG4Particle*,PHG4Particle*>       _cache_get_primary_particle_g4particle;
   std::map<PHG4Hit*,PHG4Particle*>            _cache_get_primary_particle_g4hit;
   std::map<PHG4Particle*,std::set<PHG4Hit*> > _cache_get_shower_from_primary;
   std::map<PHG4Particle*,float>               _cache_get_shower_moliere_radius;


### PR DESCRIPTION
I've leaned a bit more on the caching for an additional minor speed improvement. I also provide an energy cutoff for the truth eval tracing. I suggest setting both truth and reco tracing to >2.0 GeV/c for the calorimeter macros. That should run at about half time of a full event.

Most of the time now is spent tracing the between g4hits and g4particles with lots of calls going to the truthinfocontainer. Short of storing the primary truth id on the g4hit id itself (which would explode memory) it is pretty tough to go faster than this now.