### PR TITLE
TPC branch was storing truth cell ids on clusters not reco hit ids.

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -179,7 +179,7 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode *topNode)
 		int zbin = cell->get_binz();
 		nhits[layer][zbin] += 1;
 		amps[layer][zbin][phibin] += hit->get_e();
-		cellids[layer][zbin][phibin] = hit->get_cellid();
+		cellids[layer][zbin][phibin] = hit->get_id();
 	}
 	for(unsigned int layer=0;layer<amps.size();++layer)
 	{


### PR DESCRIPTION
Clusters should store SvtxHit reco ids not cylinder cell truth ids. This was interfering with the evaluator tracing on the TPC configuration. There could be other problems, but I suspect this was the key barrier to getting the new eval working on the TPC.