### PR TITLE
Use packed storage for Global Vertex

### DIFF
--- a/simulation/g4simulation/g4hough/SvtxVertex.h
+++ b/simulation/g4simulation/g4hough/SvtxVertex.h
@@ -50,11 +50,11 @@ public:
   virtual unsigned int get_ndof() const                      {return UINT_MAX;}
   virtual void         set_ndof(float ndof)                  {}
   
-  virtual float        get_position(int coor) const          {return NAN;}
-  virtual void         set_position(int coor, float xi)      {}
+  virtual float        get_position(unsigned int coor) const          {return NAN;}
+  virtual void         set_position(unsigned int coor, float xi)      {}
 
-  virtual float        get_error(int i, int j) const         {return NAN;}
-  virtual void         set_error(int i, int j, float value)  {}
+  virtual float        get_error(unsigned int i, unsigned int j) const         {return NAN;}
+  virtual void         set_error(unsigned int i, unsigned int j, float value)  {}
 
   //
   // associated track ids methods

--- a/simulation/g4simulation/g4hough/SvtxVertex_v1.C
+++ b/simulation/g4simulation/g4hough/SvtxVertex_v1.C
@@ -78,12 +78,12 @@ int SvtxVertex_v1::IsValid() const {
   return 1;
 }
 
-void SvtxVertex_v1::set_error(int i, int j, float value) {
+void SvtxVertex_v1::set_error(unsigned int i, unsigned int j, float value) {
   _err[covar_index(i,j)] = value;
   return;
 }
 
-float SvtxVertex_v1::get_error(int i, int j) const {
+float SvtxVertex_v1::get_error(unsigned int i, unsigned int j) const {
   return _err[covar_index(i,j)];
 }
 

--- a/simulation/g4simulation/g4hough/SvtxVertex_v1.h
+++ b/simulation/g4simulation/g4hough/SvtxVertex_v1.h
@@ -45,11 +45,11 @@ public:
   unsigned int get_ndof() const                      {return _ndof;}
   void         set_ndof(float ndof)                  {_ndof = ndof;}
   
-  float        get_position(int coor) const          {return _pos[coor];}
-  void         set_position(int coor, float xi)      {_pos[coor] = xi;}
+  float        get_position(unsigned int coor) const          {return _pos[coor];}
+  void         set_position(unsigned int coor, float xi)      {_pos[coor] = xi;}
 
-  float        get_error(int i, int j) const;        //< get vertex error covar
-  void         set_error(int i, int j, float value); //< set vertex error covar
+  float        get_error(unsigned int i, unsigned int j) const;        //< get vertex error covar
+  void         set_error(unsigned int i, unsigned int j, float value); //< set vertex error covar
 
   //
   // associated track ids methods

--- a/simulation/g4simulation/g4vertex/GlobalVertex.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertex.h
@@ -49,11 +49,11 @@ public:
   virtual unsigned int get_ndof() const                      {return 0xFFFFFFFF;}
   virtual void         set_ndof(float ndof)                  {}
   
-  virtual float        get_position(int coor) const          {return NAN;}
-  virtual void         set_position(int coor, float xi)      {}
+  virtual float        get_position(unsigned int coor) const          {return NAN;}
+  virtual void         set_position(unsigned int coor, float xi)      {}
 
-  virtual float        get_error(int i, int j) const         {return NAN;}
-  virtual void         set_error(int i, int j, float value)  {}
+  virtual float        get_error(unsigned int i, unsigned int j) const         {return NAN;}
+  virtual void         set_error(unsigned int i, unsigned int j, float value)  {}
 
   //
   // associated vertex ids methods

--- a/simulation/g4simulation/g4vertex/GlobalVertex_v1.C
+++ b/simulation/g4simulation/g4vertex/GlobalVertex_v1.C
@@ -13,11 +13,10 @@ GlobalVertex_v1::GlobalVertex_v1()
     _pos(),
     _chisq(NAN),
     _ndof(0xFFFFFFFF),
-    _err(3),
+    _err(),
     _vtx_ids() {
   
   for (int i = 0; i < 3; ++i) _pos[i] = NAN;  
-  for (int i = 0; i < 3; ++i) _err[i] = std::vector<float>(i+1);
 
   for (int j = 0; j < 3; ++j) {
     for (int i = j; i < 3; ++i) {
@@ -98,13 +97,16 @@ int GlobalVertex_v1::isValid() const {
   return 1;
 }
 
-void GlobalVertex_v1::set_error(int i, int j, float value) {
-  if (j > i) set_error(j,i,value);
-  else _err[i][j] = value;
+void GlobalVertex_v1::set_error(unsigned int i, unsigned int j, float value) {
+  _err[covar_index(i,j)] = value;
   return;
 }
 
-float GlobalVertex_v1::get_error(int i, int j) const {
-  if (j > i) return get_error(j,i);
-  return _err[i][j];
+float GlobalVertex_v1::get_error(unsigned int i, unsigned int j) const {
+  return _err[covar_index(i,j)];
+}
+
+unsigned int GlobalVertex_v1::covar_index(unsigned int i, unsigned int j) const {
+  if (i>j) std::swap(i,j);
+  return i+1+(j+1)*(j)/2-1;
 }

--- a/simulation/g4simulation/g4vertex/GlobalVertex_v1.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertex_v1.h
@@ -47,11 +47,11 @@ public:
   unsigned int get_ndof() const                      {return _ndof;}
   void         set_ndof(float ndof)                  {_ndof = ndof;}
   
-  float        get_position(int coor) const          {return _pos[coor];}
-  void         set_position(int coor, float xi)      {_pos[coor] = xi;}
+  float        get_position(unsigned int coor) const          {return _pos[coor];}
+  void         set_position(unsigned int coor, float xi)      {_pos[coor] = xi;}
 
-  float        get_error(int i, int j) const;        //< get vertex error covar
-  void         set_error(int i, int j, float value); //< set vertex error covar
+  float        get_error(unsigned int i, unsigned int j) const;        //< get vertex error covar
+  void         set_error(unsigned int i, unsigned int j, float value); //< set vertex error covar
 
   //
   // associated vertex ids methods
@@ -76,6 +76,8 @@ public:
   GlobalVertex::VtxIter end_vtxids()                            {return _vtx_ids.end();}
     
 private:
+
+  unsigned int covar_index(unsigned int i, unsigned int j) const;
   
   unsigned int                                 _id;      //< unique identifier within container
   float                                        _t;       //< collision time
@@ -83,7 +85,7 @@ private:
   float                                        _pos[3];  //< collision position x,y,z
   float                                        _chisq;   //< vertex fit chisq 
   unsigned int                                 _ndof;    //< degrees of freedom
-  std::vector<std::vector<float> >             _err;     //< error covariance matrix (+/- cm^2)
+  float                                        _err[6];  //< error covariance matrix (+/- cm^2)
   std::map<GlobalVertex::VTXTYPE,unsigned int> _vtx_ids; //< list of vtx ids
   
   ClassDef(GlobalVertex_v1, 1);


### PR DESCRIPTION
Borrow the implementation for space efficient packed storage for the covariance as was done in g4hough.