### PR TITLE
Copy Performance Mods from CaloEval to SvtxEval and JetEval

### DIFF
--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -123,8 +123,6 @@ bool CaloTruthEval::is_primary(PHG4Particle* particle) {
 
   bool is_primary = true;
   if (!_truthinfo->GetPrimaryHit(particle->get_track_id())) {
-    // does the particle id appear in the primary map?
-    // this way either copy (in Map or Primary Map) will report correctly
     is_primary = false;
   }
   

--- a/simulation/g4simulation/g4eval/JetRecoEval.C
+++ b/simulation/g4simulation/g4eval/JetRecoEval.C
@@ -146,14 +146,12 @@ std::set<PHG4Hit*> JetRecoEval::all_truth_hits(Jet* recojet) {
       RawCluster* cluster = _hcaloutclusters->getCluster(index);
       new_hits = get_hcalout_eval_stack()->get_rawcluster_eval()->all_truth_hits(cluster); 
     }
-    
-    std::set<PHG4Hit*> union_hits;
 
-    std::set_union(truth_hits.begin(),truth_hits.end(),
-		   new_hits.begin(),new_hits.end(),
-		   std::inserter(union_hits,union_hits.begin()));
-
-    std::swap(truth_hits,union_hits); // swap union into truth_particles    
+    for (std::set<PHG4Hit*>::iterator jter = new_hits.begin();
+	 jter != new_hits.end();
+	 ++jter) {
+      truth_hits.insert(*jter);
+    }
   }
 
   if (_do_cache) _cache_all_truth_hits.insert(make_pair(recojet,truth_hits));
@@ -234,14 +232,12 @@ std::set<PHG4Particle*> JetRecoEval::all_truth_particles(Jet* recojet) {
       RawCluster* cluster = _hcaloutclusters->getCluster(index);
       new_particles = get_hcalout_eval_stack()->get_rawcluster_eval()->all_truth_primaries(cluster); 
     }
-    
-    std::set<PHG4Particle*> union_hits;
 
-    std::set_union(truth_particles.begin(),truth_particles.end(),
-		   new_particles.begin(),new_particles.end(),
-		   std::inserter(union_hits,union_hits.begin()));
-
-    std::swap(truth_particles,union_hits); // swap union into truth_particles    
+    for (std::set<PHG4Particle*>::iterator jter = new_particles.begin();
+	 jter != new_particles.end();
+	 ++jter) {
+      truth_particles.insert(*jter);
+    }   
   }
 
   if (_do_cache) _cache_all_truth_particles.insert(make_pair(recojet,truth_particles));

--- a/simulation/g4simulation/g4eval/JetTruthEval.C
+++ b/simulation/g4simulation/g4eval/JetTruthEval.C
@@ -103,47 +103,41 @@ std::set<PHG4Hit*> JetTruthEval::all_truth_hits(Jet* truthjet) {
     SvtxTruthEval* svtx_truth_eval = _svtxevalstack.get_truth_eval(); 
     std::set<PHG4Hit*> svtx_g4hits = svtx_truth_eval->all_truth_hits(particle);
 
-    std::set<PHG4Hit*> union_g4hits;
-    
-    std::set_union(truth_hits.begin(),truth_hits.end(),
-		   svtx_g4hits.begin(),svtx_g4hits.end(),
-		   std::inserter(union_g4hits,union_g4hits.begin()));
-    
-    std::swap(truth_hits,union_g4hits); // swap union into truth_hits
-    union_g4hits.clear();
+    for (std::set<PHG4Hit*>::iterator jter = svtx_g4hits.begin();
+	 jter != svtx_g4hits.end();
+	 ++jter) {
+      truth_hits.insert(*jter);
+    }
     
     // ask the cemc truth eval to backtrack the primary to g4hits
     CaloTruthEval* cemc_truth_eval = _cemcevalstack.get_truth_eval(); 
     std::set<PHG4Hit*> cemc_g4hits = cemc_truth_eval->get_shower_from_primary(particle);
 
-    std::set_union(truth_hits.begin(),truth_hits.end(),
-		   cemc_g4hits.begin(),cemc_g4hits.end(),
-		   std::inserter(union_g4hits,union_g4hits.begin()));
-    
-    std::swap(truth_hits,union_g4hits); // swap union into truth_hits
-    union_g4hits.clear();
+    for (std::set<PHG4Hit*>::iterator jter = cemc_g4hits.begin();
+	 jter != cemc_g4hits.end();
+	 ++jter) {
+      truth_hits.insert(*jter);
+    }
     
     // ask the hcalin truth eval to backtrack the primary to g4hits
     CaloTruthEval* hcalin_truth_eval = _hcalinevalstack.get_truth_eval(); 
     std::set<PHG4Hit*> hcalin_g4hits = hcalin_truth_eval->get_shower_from_primary(particle);
 
-    std::set_union(truth_hits.begin(),truth_hits.end(),
-		   hcalin_g4hits.begin(),hcalin_g4hits.end(),
-		   std::inserter(union_g4hits,union_g4hits.begin()));
-    
-    std::swap(truth_hits,union_g4hits); // swap union into truth_hits
-    union_g4hits.clear();
+    for (std::set<PHG4Hit*>::iterator jter = hcalin_g4hits.begin();
+	 jter != hcalin_g4hits.end();
+	 ++jter) {
+      truth_hits.insert(*jter);
+    }
     
     // ask the hcalout truth eval to backtrack the primary to g4hits
     CaloTruthEval* hcalout_truth_eval = _hcaloutevalstack.get_truth_eval(); 
     std::set<PHG4Hit*> hcalout_g4hits = hcalout_truth_eval->get_shower_from_primary(particle);
 
-    std::set_union(truth_hits.begin(),truth_hits.end(),
-		   hcalout_g4hits.begin(),hcalout_g4hits.end(),
-		   std::inserter(union_g4hits,union_g4hits.begin()));
-    
-    std::swap(truth_hits,union_g4hits); // swap union into truth_hits
-    union_g4hits.clear();    
+    for (std::set<PHG4Hit*>::iterator jter = hcalout_g4hits.begin();
+	 jter != hcalout_g4hits.end();
+	 ++jter) {
+      truth_hits.insert(*jter);
+    }    
   }
   
   if (_do_cache) _cache_all_truth_hits.insert(make_pair(truthjet,truth_hits));

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.C
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.C
@@ -79,13 +79,12 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(SvtxCluster* cluster) {
 
     std::set<PHG4Hit*> new_g4hits = _hiteval.all_truth_hits(hit);
 
-    std::set<PHG4Hit*> union_g4hits;
+    for (std::set<PHG4Hit*>::iterator iter = new_g4hits.begin();
+	 iter != new_g4hits.end();
+	 ++iter) {
 
-    std::set_union(truth_hits.begin(),truth_hits.end(),
-		   new_g4hits.begin(),new_g4hits.end(),
-		   std::inserter(union_g4hits,union_g4hits.begin()));
-    
-    std::swap(truth_hits,union_g4hits); // swap union into truth_hits
+      truth_hits.insert(*iter);
+    }
   }
 
   if (_do_cache) _cache_all_truth_hits.insert(make_pair(cluster,truth_hits));

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.C
@@ -71,13 +71,11 @@ std::set<PHG4Hit*> SvtxTrackEval::all_truth_hits(SvtxTrack* track) {
 
     std::set<PHG4Hit*> new_hits = _clustereval.all_truth_hits(cluster);
 
-    std::set<PHG4Hit*> union_hits; // placeholder for union of new hits and truth hits
-
-    std::set_union(truth_hits.begin(),truth_hits.end(),
-		   new_hits.begin(),new_hits.end(),
-		   std::inserter(union_hits,union_hits.begin()));
-
-    std::swap(truth_hits,union_hits); // swap union into truth_hits
+    for (std::set<PHG4Hit*>::iterator jter = new_hits.begin();
+	 jter != new_hits.end();
+	 ++jter) {      
+      truth_hits.insert(*jter);
+    }
   }
 
   if (_do_cache) _cache_all_truth_hits.insert(make_pair(track,truth_hits));
@@ -106,13 +104,11 @@ std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track) {
 
     std::set<PHG4Particle*> new_particles = _clustereval.all_truth_particles(cluster);
 
-    std::set<PHG4Particle*> union_particles; // placeholder for union of new particles and truth particles
-
-    std::set_union(truth_particles.begin(),truth_particles.end(),
-		   new_particles.begin(),new_particles.end(),
-		   std::inserter(union_particles,union_particles.begin()));
-
-    std::swap(truth_particles,union_particles); // swap union into truth_particles
+    for (std::set<PHG4Particle*>::iterator jter = new_particles.begin();
+	 jter != new_particles.end();
+	 ++jter) {
+      truth_particles.insert(*jter);
+    }
   }
 
   if (_do_cache) _cache_all_truth_particles.insert(make_pair(track,truth_particles));

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -176,13 +176,12 @@ int SvtxTruthEval::get_embed(PHG4Particle* particle) {
 
 bool SvtxTruthEval::is_primary(PHG4Particle* particle) {
 
-  if (particle->get_primary_id() == particle->get_track_id()) {
-    return true;
-  } else if (particle->get_primary_id() == -1) {
-    return true;
+  bool is_primary = true;
+  if (!_truthinfo->GetPrimaryHit(particle->get_track_id())) {
+    is_primary = false;
   }
   
-  return false;
+  return is_primary;
 }
 
 PHG4VtxPoint* SvtxTruthEval::get_vertex(PHG4Particle* particle) {


### PR DESCRIPTION
Remove some of the poor occupancy scaling calls from the other evals. Just in case these get worse under occupancy load some day. SVTX performance:

![crosscheck](https://cloud.githubusercontent.com/assets/12105552/10091324/d074dac6-6374-11e5-963e-dd9dfb5f3138.png)
