### PR TITLE
Allow Geant4 Embedding into existing DSTs (e.g. Hijing)

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -35,7 +35,7 @@ PHG4InnerHcalSubsystem::PHG4InnerHcalSubsystem( const std::string &name, const i
 }
 
 //_______________________________________________________________________
-int PHG4InnerHcalSubsystem::Init( PHCompositeNode* topNode )
+int PHG4InnerHcalSubsystem::InitRun( PHCompositeNode* topNode )
 {
   PHNodeIterator iter( topNode );
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
@@ -29,7 +29,7 @@ class PHG4InnerHcalSubsystem: public PHG4Subsystem
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int Init(PHCompositeNode *);
+  int InitRun(PHCompositeNode *);
 
   //! event processing
   /*!

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -33,7 +33,7 @@ PHG4OuterHcalSubsystem::PHG4OuterHcalSubsystem( const std::string &name, const i
 }
 
 //_______________________________________________________________________
-int PHG4OuterHcalSubsystem::Init( PHCompositeNode* topNode )
+int PHG4OuterHcalSubsystem::InitRun( PHCompositeNode* topNode )
 {
   PHNodeIterator iter( topNode );
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
@@ -29,7 +29,7 @@ class PHG4OuterHcalSubsystem: public PHG4Subsystem
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int Init(PHCompositeNode *);
+  int InitRun(PHCompositeNode *);
 
   //! event processing
   /*!

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -12,6 +12,7 @@
 #include <set>
 #include <map>
 #include <float.h>
+#include <iostream>
 
 using namespace std;
 
@@ -136,7 +137,10 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
   if (!is_primary(primary)) return std::set<PHG4Hit*>();
 
   primary = get_primary_particle(primary);
-  if (!primary) return std::set<PHG4Hit*>();
+  if (!primary){
+      cout <<__PRETTY_FUNCTION__<<" - Error - encountered invalid primary as input. "<<endl;
+      return std::set<PHG4Hit*>();
+  }
 
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<PHG4Hit*> >::iterator iter =
@@ -155,7 +159,11 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
 
     PHG4Hit* g4hit = g4iter->second;
     PHG4Particle* candidate = get_primary_particle(g4hit);
-    if (!candidate) continue;
+    if (!candidate) {
+        cout <<__PRETTY_FUNCTION__<<" - Error - can not find the primary particle for g4hit: "<<endl;
+        g4hit->identify();
+        continue;
+    }
     if (candidate->get_track_id() != primary->get_track_id()) continue;
     truth_hits.insert(g4hit);
   }

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -136,7 +136,8 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
   if (!is_primary(primary)) return std::set<PHG4Hit*>();
 
   primary = get_primary_particle(primary);
-  
+  if (!primary) return std::set<PHG4Hit*>();
+
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<PHG4Hit*> >::iterator iter =
       _cache_get_shower_from_primary.find(primary);
@@ -154,6 +155,7 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
 
     PHG4Hit* g4hit = g4iter->second;
     PHG4Particle* candidate = get_primary_particle(g4hit);
+    if (!candidate) continue;
     if (candidate->get_track_id() != primary->get_track_id()) continue;
     truth_hits.insert(g4hit);
   }

--- a/simulation/g4simulation/g4eval/PHG4DSTReader.cc
+++ b/simulation/g4simulation/g4eval/PHG4DSTReader.cc
@@ -531,12 +531,12 @@ PHG4DSTReader::process_event(PHCompositeNode* topNode)
 //                  add_particle(rec, part);
 //                }
 
-              for (particle_iter = truthInfoList->GetPrimaryMap().begin();
-                  particle_iter != truthInfoList->GetPrimaryMap().end();
+              for (particle_iter = truthInfoList->GetMap().begin();
+                  particle_iter != truthInfoList->GetMap().end();
                   particle_iter++)
                 {
-
-                  _particle_set.insert(particle_iter->first);
+                  if (particle_iter->second->get_parent_id()<=0)
+                    _particle_set.insert(particle_iter->first);
 
 //                  PHG4Particle * part = particle_iter->second;
 //

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -45,6 +45,8 @@ class PHG4Reco: public SubsysReco
   //! full initialization
   int Init(PHCompositeNode *);
 
+  int InitRun( PHCompositeNode* topNode );
+
   //! event processing method
   int process_event(PHCompositeNode *);
 

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
@@ -3,6 +3,7 @@
 #include "PHG4Particlev2.h"
 #include "PHG4InEvent.h"
 #include "PHG4VtxPoint.h"
+#include "PHG4TruthInfoContainer.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/getClass.h>
@@ -238,31 +239,68 @@ int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
     vertex_z = smearvtx(_vertex_z,_vertex_width_z,_vertex_func_z);
   } else {
     
-    if (_ineve->GetNVtx() == 0) {
-      cout << PHWHERE << "::Error - PHG4SimpleEventGenerator expects an existing truth vertex, but none exists" << endl;
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
+    if (_ineve->GetNVtx() > 0) {
+        // embed to vertexes as set by other Geatn4 inputs
 
-    // use the first vertex in the list
-    std::pair< std::map<int, PHG4VtxPoint *>::const_iterator, 
-	       std::map<int, PHG4VtxPoint *>::const_iterator > 
-      range = _ineve->GetVertices();
-    std::map<int, PHG4VtxPoint* >::const_iterator iter = range.first;
-    PHG4VtxPoint* vtx = iter->second;
+        // use the first vertex in the list
+        std::pair< std::map<int, PHG4VtxPoint *>::const_iterator,
+             std::map<int, PHG4VtxPoint *>::const_iterator >
+          range = _ineve->GetVertices();
+        std::map<int, PHG4VtxPoint* >::const_iterator iter = range.first;
+        PHG4VtxPoint* vtx = iter->second;
 
-    if (!vtx) {
-      cout << PHWHERE << "::Error - PHG4SimpleEventGenerator expects an existing truth vertex, but none exists" << endl;
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
+        if (!vtx) {
+          cout << PHWHERE << "::Error - PHG4SimpleEventGenerator expects an existing truth vertex in PHG4InEvent, but none exists" << endl;
+          return Fun4AllReturnCodes::ABORTRUN;
+        }
 
-    vertex_x = vtx->get_x();
-    vertex_y = vtx->get_y();
-    vertex_z = vtx->get_z();
+        vertex_x = vtx->get_x();
+        vertex_y = vtx->get_y();
+        vertex_z = vtx->get_z();
+
+        } // if (_ineve->GetNVtx() > 0) {
+      else
+        {
+          // try the next option for getting primary vertex
+
+          bool vertex_valid = false;
+
+          PHG4TruthInfoContainer* truthInfoList = //
+              findNode::getClass<PHG4TruthInfoContainer>(topNode,
+                  "G4TruthInfo");
+          if (truthInfoList)
+            vertex_valid = truthInfoList->GetPrimaryVtx(0);
+
+          if (vertex_valid)
+            {
+              // embed to vertexes as set by primary vertex from the truth container, e.g. when embedding into DST
+
+              PHG4VtxPoint* vtx = truthInfoList->GetPrimaryVtx(0);
+
+              if (!vtx) {
+                cout << PHWHERE << "::Error - PHG4SimpleEventGenerator expects an existing truth vertex in PHG4TruthInfoContainer, but none exists" << endl;
+                return Fun4AllReturnCodes::ABORTRUN;
+              }
+
+              vertex_x = vtx->get_x();
+              vertex_y = vtx->get_y();
+              vertex_z = vtx->get_z();
+
+            }
+          else
+            {
+              cout << PHWHERE << "::Error - PHG4SimpleEventGenerator expects an existing truth vertex, but none exists"
+                  << endl;
+              return Fun4AllReturnCodes::ABORTRUN;
+            }
+        }
 
     vertex_x += _vertex_offset_x;
     vertex_y += _vertex_offset_y;
     vertex_z += _vertex_offset_z;
-  }
+
+
+    }
 
   int vtxindex = -1;
   int trackid = -1;

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
@@ -263,24 +263,22 @@ int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
         {
           // try the next option for getting primary vertex
 
-          bool vertex_valid = false;
-
           PHG4TruthInfoContainer* truthInfoList = //
               findNode::getClass<PHG4TruthInfoContainer>(topNode,
                   "G4TruthInfo");
           if (truthInfoList)
-            vertex_valid = truthInfoList->GetPrimaryVtx(0);
-
-          if (vertex_valid)
             {
               // embed to vertexes as set by primary vertex from the truth container, e.g. when embedding into DST
 
-              PHG4VtxPoint* vtx = truthInfoList->GetPrimaryVtx(0);
+              PHG4VtxPoint* vtx = truthInfoList->GetPrimaryVtx(1);
 
-              if (!vtx) {
-                cout << PHWHERE << "::Error - PHG4SimpleEventGenerator expects an existing truth vertex in PHG4TruthInfoContainer, but none exists" << endl;
-                return Fun4AllReturnCodes::ABORTRUN;
-              }
+              if (!vtx)
+                {
+                  truthInfoList->identify();
+                  cout << PHWHERE << "::Error - PHG4SimpleEventGenerator expects an existing truth vertex in PHG4TruthInfoContainer, but none exists"
+                      << endl;
+                  return Fun4AllReturnCodes::ABORTRUN;
+                }
 
               vertex_x = vtx->get_x();
               vertex_y = vtx->get_y();

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
@@ -253,6 +253,10 @@ int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
           cout << PHWHERE << "::Error - PHG4SimpleEventGenerator expects an existing truth vertex in PHG4InEvent, but none exists" << endl;
           return Fun4AllReturnCodes::ABORTRUN;
         }
+        if (verbosity > 0) {
+          cout <<PHWHERE<<"::Info - use this primary vertex from PHG4InEvent:"<<endl;
+          vtx->identify();
+        }
 
         vertex_x = vtx->get_x();
         vertex_y = vtx->get_y();
@@ -279,6 +283,11 @@ int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
                       << endl;
                   return Fun4AllReturnCodes::ABORTRUN;
                 }
+
+              if (verbosity > 0) {
+                cout <<PHWHERE<<"::Info - use this primary vertex from PHG4TruthInfoContainer:"<<endl;
+                vtx->identify();
+              }
 
               vertex_x = vtx->get_x();
               vertex_y = vtx->get_y();

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -207,7 +207,8 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
       {
 	if (userdata->get_embed())
 	  {
-            truthInfoList_->AddEmbededTrkId(part->GetTrackID()+ trackidoffset);
+//      truthInfoList_->AddEmbededTrkId(part->GetTrackID()+ trackidoffset); // use G4 particle list ID for the embedded list
+      truthInfoList_->AddEmbededTrkId(part->GetTrackID()+ parimarytrackidoffset); // use primary ID for the embedded list
 	  }
       }
       part = part->GetNext();

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -25,6 +25,7 @@ using namespace std;
 PHG4TruthEventAction::PHG4TruthEventAction( void ):
   truthInfoList_( 0 ),
   trackidoffset(0),
+  parimarytrackidoffset(0),
   vertexid_(0)
 {}
 
@@ -167,6 +168,10 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
           if (particle->get_parent_id() <= 0)
             {
               primaryid = particle->get_track_id(); // this particle is the primary truth
+              assert (primaryid > trackidoffset);
+              primaryid -= trackidoffset; // recovery the Geant4 track ID = inEvent track ID
+              primaryid += parimarytrackidoffset; // ID for the primary track in truth container
+
               break;
             }
 

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.h
@@ -40,6 +40,7 @@ public:
   void AddTrackidToWritelist( const G4int trackid);
 
   void TrackIdOffset(const int i) {trackidoffset = i;}
+  void PrimaryTrackIdOffset(const int i) {parimarytrackidoffset = i;}
 
 
   bimap_type::iterator AddVertex(G4ThreeVector& v);
@@ -55,6 +56,7 @@ public:
   PHG4TruthInfoContainer* truthInfoList_;
 
   int trackidoffset;
+  int parimarytrackidoffset;
   
   // TESTING
   // Bidirectional map of vertexid <-> vertex position

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -79,7 +79,7 @@ PHG4TruthInfoContainer::identify(ostream& os) const
        cout << "primary_particle_ key " <<  iter->first << endl;
        (iter->second)->identify();
      }
-   cout << "---primaryparticlemap-------------------" << endl;
+   cout << "---primary vertex emap-------------------" << endl;
    for (vter = primary_vtxmap.begin(); vter != primary_vtxmap.end(); ++vter)
      {
        cout << "vtx id: " << vter ->first << endl;

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -85,6 +85,11 @@ PHG4TruthInfoContainer::identify(ostream& os) const
        cout << "vtx id: " << vter ->first << endl;
        (vter ->second)->identify();
      }
+   cout << "---list of embeded tracks-------------------" << endl;
+   for (std::set<int>::const_iterator eter = embedded_trkid.begin(); eter != embedded_trkid.end(); ++eter)
+     {
+       cout << "embeded track ID " << *eter << endl;
+     }
    
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -261,6 +261,36 @@ PHG4TruthInfoContainer::AddPrimaryVertex(PHG4VtxPoint *newvtx)
 }
 
 int
+PHG4TruthInfoContainer::maxprimarytrkindex() const
+{
+  int key = 0;
+  if (!primary_vtxmap.empty())
+    {
+      key = primary_vtxmap.rbegin()->first;
+    }
+  if (key < 0)
+    {
+      key = 0;
+    }
+  return key;
+}
+
+int
+PHG4TruthInfoContainer::minprimarytrkindex() const
+{
+  int key = 0;
+  if (!primary_vtxmap.empty())
+    {
+       key = primary_vtxmap.begin()->first;
+    }
+  if (key > 0)
+    {
+      key = 0;
+    }
+  return key;
+}
+
+int
 PHG4TruthInfoContainer::maxtrkindex() const
 {
   int key = 0;

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -82,6 +82,9 @@ class PHG4TruthInfoContainer: public PHObject
   int maxvtxindex() const;
   int minvtxindex() const;
  
+  int maxprimarytrkindex() const;
+  int minprimarytrkindex() const;
+
   void delete_hit(Iterator hiter);
   void delete_vtx(VtxIterator viter);
 

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
@@ -99,6 +99,7 @@ PHG4TruthSubsystem::process_event( PHCompositeNode* topNode )
 //     cout << "truthInfoList minkey: " << truthInfoList->minindex() << endl;
   trackingAction_->TrackIdOffset(truthInfoList->maxtrkindex());
   eventAction_->TrackIdOffset(truthInfoList->maxtrkindex());
+  eventAction_->PrimaryTrackIdOffset(truthInfoList->maxprimarytrkindex());
   map<int, PHG4VtxPoint *>::const_iterator vtxiter;
   multimap<int, PHG4Particle *>::const_iterator particle_iter;
   std::pair< std::map<int, PHG4VtxPoint *>::const_iterator, std::map<int, PHG4VtxPoint *>::const_iterator > vtxbegin_end = inEvent->GetVertices();


### PR DESCRIPTION
It turns out some efforts are required to allow Geant4 events to get embedded to an existing DST stream. This procedure is used to reuse the Hijing production DST and embed more single particles into it via a new Geant4 cycle. 

Example Fun4All_sPHENIX.C macro to drive the embedding production is proposed to a fork of the macro repository:
https://github.com/blackcathj/macros/blob/SinglePart_master_embed_prod/macros/g4simulations/Fun4All_G4_sPHENIX.C

Major changes in coresoftware to allow G4->DST embedding are discussed in this pull request. It will be great if @pinkenburg and @mccumbermike can cross check these updates.  And the proposed changes are open for discussion.

## Add InitRun into PHG4Reco

The most significant change would be in initialization order for PHG4Reco. Previously both InitRun and Init part of the G4 subsystems are called in the Init() function of PHG4Reco (strange to me). That's out-of-order for Fun4All. And it would lead to the G4 subsystem init the node tree prior to loading of the input manager (e.g. DST manager when loading another DST stream). In that case, the DST node from the input manager would get dropped. Also, calling InitRun for G4 subsystem in PHG4Reco::Init() would prevent us from using run number/timestamp based database access in the future too. 

Therefore, I have split PHG4Reco::Init() into two parts of Init() and InitRun(). Only call G4 subsystem InitRun in the later part. 

Most G4 subsystem already use InitRun() for initialization. Two HCal subsystems are not though. Therefore, they were updated to use InitRun().

## Treatment for embedded primary particle. 

When embedding particle into a DST stream containing an existing TruthContainer, TruthContainer would append the new primary particle to a shorter primary particle list and its G4 tracks to the longer particle list. Since the two list sizes are different and the primary particle ID is controlled by TruthContainer, the primary particle's IDs in PHG4TruthInfoContainer::hitmap and in PHG4TruthInfoContainer::primary_particle_map would end up different (which PHG4TruthInfoContainer allows). 

The truth subsystems reco part were updated to support so too, sort out the mapping correctly. 

Now, the truth tracing route is consistent with non-embedding analysis, i.e.:
1. Start with PHG4TruthInfoContainer::hitmap via interface functions
2. locate a PHG4Particle in it 
3. Ask for its primary from with primary_id= PHG4Particle::get_primary_id() 
4. Ask for the primary particle with PHG4TruthInfoContainer::primary_particle_map[primary_id] via interface functions

## Evaluators

@mccumbermike , I think it deserve another round of check to make sure the evaluator is conform to the above standard. Especially that, NO implicit assumption that key->particle would be the same for PHG4TruthInfoContainer::primary_particle_map and PHG4TruthInfoContainer::hitmap, since they are not for newly embedded particles. The right way to go should be via the function CaloTruthEval::get_primary_particle(), which is already used in many part of the evaluator. 

Few minor changes were introduced : 
* CaloTruthEval: pointer protection in CaloTruthEval, in case the primary mapping not working. 
* PHG4DSTReader was updated to conform with the standard on primary particle list. 

## Reuse embedded parimary vertex in PHG4SimpleEventGenerator

Now PHG4SimpleEventGenerator would search for the primary vertex available in both InEvent (e.g. for embed into event generator) and primary vertexes in TruthContainer (e.g. for DST embedding)
