### PR TITLE
Option to remove non-embedded particle and vertex from the truth table

### DIFF
--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.C
@@ -252,9 +252,11 @@ float CaloRawClusterEval::get_energy_contribution(RawCluster* cluster, PHG4Parti
 	 ++iter) {
       PHG4Hit* g4hit = *iter;
       PHG4Particle* candidate = get_truth_eval()->get_primary_particle(g4hit);
-      if (candidate->get_track_id() == primary->get_track_id()) {
-	energy += g4hit->get_edep();
-      }
+
+      if (candidate)
+        if (candidate->get_track_id() == primary->get_track_id()) {
+    energy += g4hit->get_edep();
+        }
     }
     
   }

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -106,7 +106,8 @@ std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
        ++iter) {
     PHG4Hit* g4hit = *iter;
     PHG4Particle* primary = get_truth_eval()->get_primary_particle( g4hit );    
-    truth_primaries.insert(primary);
+    if (primary)
+      truth_primaries.insert(primary);
   }
 
   if (_do_cache) _cache_all_truth_primaries.insert(make_pair(tower,truth_primaries));
@@ -250,9 +251,10 @@ float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* p
 	 ++iter) {
       PHG4Hit* g4hit = *iter;
       PHG4Particle* candidate = get_truth_eval()->get_primary_particle(g4hit);
-      if (candidate->get_track_id() == primary->get_track_id()) {
-	energy += g4hit->get_edep();
-      }
+      if (candidate)
+        if (candidate->get_track_id() == primary->get_track_id()) {
+    energy += g4hit->get_edep();
+        }
     }
     
   }

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -13,6 +13,7 @@
 #include <map>
 #include <float.h>
 #include <iostream>
+#include <cassert>
 
 using namespace std;
 
@@ -99,11 +100,17 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Hit* g4hit) {
   }
   
   PHG4Particle* particle = get_parent_particle(g4hit);
+
+  if (particle)
+    {
   PHG4Particle* primary = get_primary_particle(particle);
+  assert(primary);
   
   if (_do_cache) _cache_get_primary_particle_g4hit.insert(make_pair(g4hit,primary));
-  
   return primary;
+    }
+  else
+    return NULL;
 }
 
 int CaloTruthEval::get_embed(PHG4Particle* particle) {
@@ -158,8 +165,8 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
     PHG4Hit* g4hit = g4iter->second;
     PHG4Particle* candidate = get_primary_particle(g4hit);
     if (!candidate) {
-        cout <<__PRETTY_FUNCTION__<<" - Error - can not find the primary particle for g4hit: "<<endl;
-        g4hit->identify();
+//        cout <<__PRETTY_FUNCTION__<<" - Error - can not find the primary particle for g4hit: "<<endl;
+//        g4hit->identify();
         continue;
     }
     if (candidate->get_track_id() != primary->get_track_id()) continue;

--- a/simulation/g4simulation/g4eval/JetTruthEval.C
+++ b/simulation/g4simulation/g4eval/JetTruthEval.C
@@ -71,7 +71,8 @@ std::set<PHG4Particle*> JetTruthEval::all_truth_particles(Jet* truthjet) {
     }
 
     PHG4Particle* truth_particle = _truthinfo->GetHit(index);
-    truth_particles.insert(truth_particle);
+    if (truth_particle)
+      truth_particles.insert(truth_particle);
   }
 
   if (_do_cache) _cache_all_truth_particles.insert(make_pair(truthjet,truth_particles));

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.C
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.C
@@ -21,6 +21,7 @@
 #include <map>
 #include <float.h>
 #include <algorithm>
+#include <cassert>
 
 using namespace std;
 
@@ -284,6 +285,9 @@ SvtxCluster* SvtxClusterEval::best_cluster_from(PHG4Hit* truthhit) {
   
 // overlap calculations
 float SvtxClusterEval::get_energy_contribution(SvtxCluster* cluster, PHG4Particle* particle) {
+
+  assert(cluster);
+  assert(particle);
 
   if (_do_cache) {
     std::map<std::pair<SvtxCluster*,PHG4Particle*>, float>::iterator iter =

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -12,6 +12,8 @@
 #include <set>
 #include <map>
 #include <float.h>
+#include <cassert>
+#include <iostream>
 
 using namespace std;
 
@@ -186,11 +188,21 @@ bool SvtxTruthEval::is_primary(PHG4Particle* particle) {
 
 PHG4VtxPoint* SvtxTruthEval::get_vertex(PHG4Particle* particle) {
 
+  assert(particle);
+
   if (particle->get_primary_id() == -1) {
     return _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );  
   }
 
-  return _truthinfo->GetVtx( particle->get_vtx_id() );  
+  PHG4VtxPoint* vtx = _truthinfo->GetVtx( particle->get_vtx_id() );
+
+  if (!vtx)
+    {
+      cout<<__PRETTY_FUNCTION__<<" - Error - missing vertex for G4 track:"<<endl;
+      particle->identify();
+    }
+
+  return vtx;
 }
 
 void SvtxTruthEval::get_node_pointers(PHCompositeNode* topNode) {

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.C
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.C
@@ -17,6 +17,7 @@
 #include <set>
 #include <float.h>
 #include <algorithm>
+#include <cassert>
 
 using namespace std;
 
@@ -68,7 +69,10 @@ std::set<PHG4Particle*> SvtxVertexEval::all_truth_particles(SvtxVertex* vertex) 
        ++iter) {
     
     SvtxTrack* track = _trackmap->get(*iter);    
-    all_particles.insert(_trackeval.max_truth_particle_by_nclusters(track));
+    PHG4Particle* max_particle = _trackeval.max_truth_particle_by_nclusters(track);
+
+    if (max_particle)
+    all_particles.insert(max_particle);
   }
 
   if (_do_cache) _cache_all_truth_particles.insert(make_pair(vertex,all_particles));
@@ -93,7 +97,9 @@ std::set<PHG4VtxPoint*> SvtxVertexEval::all_truth_points(SvtxVertex* vertex) {
        iter != particles.end();
        ++iter) {
     PHG4Particle* particle = *iter;
+    assert(particle);
     PHG4VtxPoint* point = get_truth_eval()->get_vertex(particle);
+    assert (point);
     points.insert(point);
   }
 
@@ -135,6 +141,8 @@ PHG4VtxPoint* SvtxVertexEval::max_truth_point_by_ntracks(SvtxVertex* vertex) {
    
 std::set<SvtxVertex*> SvtxVertexEval::all_vertexes_from(PHG4VtxPoint* truthpoint) {
 
+  assert(truthpoint);
+
   if (_do_cache) {
     std::map<PHG4VtxPoint*,std::set<SvtxVertex*> >::iterator iter =
       _cache_all_vertexes_from_point.find(truthpoint);
@@ -155,6 +163,7 @@ std::set<SvtxVertex*> SvtxVertexEval::all_vertexes_from(PHG4VtxPoint* truthpoint
 	 jter != points.end();
 	 ++jter) {
       PHG4VtxPoint* point = *jter;
+      assert(point);
       if (point->get_id() == truthpoint->get_id()) {
 	all_vertexes.insert(vertex);
       }
@@ -168,6 +177,8 @@ std::set<SvtxVertex*> SvtxVertexEval::all_vertexes_from(PHG4VtxPoint* truthpoint
 
 SvtxVertex* SvtxVertexEval::best_vertex_from(PHG4VtxPoint* truthpoint) {
  
+  assert(truthpoint);
+
   if (_do_cache) {
     std::map<PHG4VtxPoint*,SvtxVertex*>::iterator iter =
       _cache_best_vertex_from_point.find(truthpoint);
@@ -215,8 +226,13 @@ unsigned int SvtxVertexEval::get_ntracks_contribution(SvtxVertex* vertex, PHG4Vt
     SvtxTrack* track = _trackmap->get(*iter);
     PHG4Particle* particle = _trackeval.max_truth_particle_by_nclusters(track);
 
+    if (particle)
+      {
     PHG4VtxPoint* candidate = get_truth_eval()->get_vertex(particle);
+    assert(candidate);
+
     if (candidate->get_id() == truthpoint->get_id()) ++ntracks;
+      }
   }
   
   if (_do_cache) _cache_get_ntracks_contribution.insert(make_pair(make_pair(vertex,truthpoint),ntracks));

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
@@ -18,6 +18,9 @@
 #include <Geant4/G4ParticleDefinition.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 
+#include <cassert>
+#include <iostream>
+
 using namespace std;
 
 //_______________________________________________________________________
@@ -25,7 +28,8 @@ PHG4TruthSubsystem::PHG4TruthSubsystem( const string &name ):
   PHG4Subsystem( name ),
   eventAction_( 0 ),
   steppingAction_( 0 ),
-  trackingAction_( 0 )
+  trackingAction_( 0 ),
+  saveOnlyEmbeded_(false)
 {}
 
 //_______________________________________________________________________
@@ -135,6 +139,60 @@ PHG4TruthSubsystem::process_event( PHCompositeNode* topNode )
 
     }
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4TruthSubsystem::process_after_geant(PHCompositeNode * topNode)
+{
+  if (saveOnlyEmbeded_)
+    {
+      if (Verbosity()>1)
+        {
+          cout <<__PRETTY_FUNCTION__<<" - INFO - only save the G4 truth information that is associated with the embedded particle"<<endl;
+        }
+
+      PHG4TruthInfoContainer* truthInfoList =  findNode::getClass<PHG4TruthInfoContainer>( topNode , "G4TruthInfo" );
+      assert(truthInfoList);
+
+      set<int> savevtxlist;
+
+      // remove particle that is not embedd associated
+      PHG4TruthInfoContainer::Range truth_range = truthInfoList->GetHitRange();
+      PHG4TruthInfoContainer::Iterator truthiter = truth_range.first;
+      while (truthiter != truth_range.second)
+        {
+          const int primary_id = (truthiter->second)->get_primary_id();
+          if (truthInfoList->isEmbeded(primary_id) == 0)
+            {
+              // not a embed associated particle
+
+              truthInfoList->delete_hit(truthiter++);
+            }
+          else
+            {
+              // save vertex id for primary particle which leaves no hit
+              // in active area
+              savevtxlist.insert((truthiter->second)->get_vtx_id());
+              ++truthiter;
+            }
+        }
+
+      // remove vertex that is not embedd associated
+      PHG4TruthInfoContainer::VtxRange vtxrange = truthInfoList->GetVtxRange();
+      PHG4TruthInfoContainer::VtxIterator vtxiter = vtxrange.first;
+      while (vtxiter != vtxrange.second)
+        {
+          if (savevtxlist.find(vtxiter->first) == savevtxlist.end())
+            {
+              truthInfoList->delete_vtx(vtxiter++);
+            }
+          else
+            {
+              ++vtxiter;
+            }
+        }
+    }
+
+  return 0;
 }
 
 int

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.h
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.h
@@ -26,6 +26,9 @@ class PHG4TruthSubsystem: public PHG4Subsystem
   //! event processing
   int process_event(PHCompositeNode *);
 
+  //! event processing
+  virtual int process_after_geant(PHCompositeNode *);
+
   //! Clean up after each event.
   int ResetEvent(PHCompositeNode *);
 
@@ -34,11 +37,17 @@ class PHG4TruthSubsystem: public PHG4Subsystem
   virtual PHG4SteppingAction* GetSteppingAction( void ) const;
   virtual PHG4TrackingAction* GetTrackingAction( void ) const;
 
+  //! only save the G4 truth information that is associated with the embedded particle
+  void SetSaveOnlyEmbeded(bool b = true){saveOnlyEmbeded_ = b;};
+
   private:
 
   PHG4TruthEventAction* eventAction_;
   PHG4TruthSteppingAction* steppingAction_;
   PHG4TruthTrackingAction* trackingAction_;
+
+  //! only save the G4 truth information that is associated with the embedded particle
+  bool saveOnlyEmbeded_;
 
 };
 


### PR DESCRIPTION
As advertised in pull request #65 , one remaining problem to kick off the embedding production is that the output DST file size is large, even after excluding the absorber G4Hits (~250MB/event). 

One solution to this problem is proposed in this pull request: an option (PHG4TruthSubsystem::SetSaveOnlyEmbeded() ) to drop off the truth G4 particle and vertex which is not associated with embedded particle. This option is by-default off, and can be activated via macro during the embedding production. This is driven by the analysis need for embedding production, for which hijing background are noise-like hits and the only embedded particle need to be traced via truth table. Meanwhile, the evaluator was updated in order to handle the missing truth info for the higjing particles. 

An example production macro using this feature is on this branch: 
https://github.com/blackcathj/macros/blob/SinglePart_master_embed_prod/macros/g4simulations/Fun4All_G4_sPHENIX.C 

With this option activated, the output size is reduced by ~x10, about 30MB/event (w/24GeV EM Shower embedded). The leading space consumers are as following, half of which is in hits of EMCal fibers:
```
******************************************************************************
*Tree    :T         : titled by PHOOL                                        *
*Entries :        2 : Total =       150750366 bytes  File  Size =   63266626 *
*        :          : Tree compression factor =   2.25                       *
******************************************************************************
*Br    2 :DST.G4HIT_HCALIN.hitmap : map<unsigned long long,PHG4Hit*>         *
*Entries :        2 : Total  Size=   30116732 bytes  File Size  =   12173537 *
*Baskets :        2 : Basket Size=      32000 bytes  Compression=   2.47     *
*............................................................................*
*Br    6 :DST.G4HIT_HCALOUT.hitmap : map<unsigned long long,PHG4Hit*>        *
*Entries :        2 : Total  Size=   16851408 bytes  File Size  =    7039598 *
*Baskets :        2 : Basket Size=      32000 bytes  Compression=   2.39     *
*............................................................................*
*Br   10 :DST.G4HIT_PIPE.hitmap : map<unsigned long long,PHG4Hit*>           *
*Entries :        2 : Total  Size=    4438069 bytes  File Size  =    2398833 *
*Baskets :        2 : Basket Size=      32000 bytes  Compression=   1.85     *
*............................................................................*
*Br   14 :DST.G4HIT_SVTX.hitmap : map<unsigned long long,PHG4Hit*>           *
*Entries :        2 : Total  Size=    5805603 bytes  File Size  =    3235109 *
*Baskets :        2 : Basket Size=      32000 bytes  Compression=   1.79     *
*............................................................................*
*Br   18 :DST.G4HIT_CEMC.hitmap : map<unsigned long long,PHG4Hit*>           *
*Entries :        2 : Total  Size=   66139416 bytes  File Size  =   30633112 *
*Baskets :        2 : Basket Size=      32000 bytes  Compression=   2.16     *
*............................................................................*
*Br   22 :DST.G4TruthInfo.hitmap : map<int,PHG4Particle*>                    *
*Entries :        2 : Total  Size=   12411081 bytes  File Size  =    3393135 *
*Baskets :        2 : Basket Size=      32000 bytes  Compression=   2.41     *
*............................................................................*
*Br   23 :DST.G4TruthInfo.vtxmap : map<int,PHG4VtxPoint*>                    *
*Entries :        2 : Total  Size=    8222009 bytes  File Size  =    2645347 *
*Baskets :        2 : Basket Size=      32000 bytes  Compression=   2.04     *
*............................................................................*
*Br   24 :DST.G4TruthInfo.primary_particle_map : map<int,PHG4Particle*>      *
*Entries :        2 : Total  Size=    2896191 bytes  File Size  =     625294 *
*Baskets :        2 : Basket Size=      32000 bytes  Compression=   3.03     *
*Br   29 :DST.PHHepMCGenEvent._theEvt : HepMC::GenEvent*                     *
*Entries :        2 : Total  Size=    3836883 bytes  File Size  =    1113638 *
*Baskets :        2 : Basket Size=      32000 bytes  Compression=   3.44     *
*............................................................................*
```
