### PR TITLE
Evaluator set_strict(true/false) option

### DIFF
--- a/simulation/g4simulation/g4eval/CaloEvalStack.h
+++ b/simulation/g4simulation/g4eval/CaloEvalStack.h
@@ -24,7 +24,9 @@ public:
   virtual ~CaloEvalStack() {}
 
   void next_event(PHCompositeNode *topNode);
-
+  void do_caching(bool do_cache) {_clustereval.do_caching(do_cache);}
+  void set_strict(bool strict) {_clustereval.set_strict(strict);}
+  
   CaloRawClusterEval* get_rawcluster_eval() {return &_clustereval;}
   CaloRawTowerEval*   get_rawtower_eval() {return _clustereval.get_rawtower_eval();}
   CaloTruthEval*      get_truth_eval() {return _clustereval.get_truth_eval();}

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -34,6 +34,7 @@ CaloEvaluator::CaloEvaluator(const string &name, const string &caloname, const s
     _truth_trace_embed_flags(),
     _truth_e_threshold(0.0), // 0 GeV before reco is traced
     _reco_e_threshold(0.0), // 0 GeV before reco is traced
+    _strict(true),
     _do_gpoint_eval(true),
     _do_gshower_eval(true),
     _do_tower_eval(true),
@@ -167,6 +168,8 @@ void CaloEvaluator::printOutputInfo(PHCompositeNode *topNode) {
   if (verbosity > 2) cout << "CaloEvaluator::printOutputInfo() entered" << endl;
 
   CaloEvalStack caloevalstack(topNode,_caloname); 
+  caloevalstack.set_strict(_strict);
+
   CaloRawClusterEval* clustereval = caloevalstack.get_rawcluster_eval();
   CaloTruthEval*        trutheval = caloevalstack.get_truth_eval();
   
@@ -303,6 +306,8 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   if (verbosity > 2) cout << "CaloEvaluator::fillOutputNtuples() entered" << endl;
 
   CaloEvalStack caloevalstack(topNode,_caloname); 
+  caloevalstack.set_strict(_strict);
+
   CaloRawClusterEval* clustereval = caloevalstack.get_rawcluster_eval();
   CaloRawTowerEval*     towereval = caloevalstack.get_rawtower_eval();
   CaloTruthEval*        trutheval = caloevalstack.get_truth_eval();

--- a/simulation/g4simulation/g4eval/CaloEvaluator.h
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.h
@@ -37,6 +37,8 @@ class CaloEvaluator : public SubsysReco {
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
+  void set_strict(bool b) {_strict = b;}
+  
   // funtions to limit the tracing to only part of the event ---------
   // and speed up the evaluation
 
@@ -85,6 +87,8 @@ class CaloEvaluator : public SubsysReco {
   //----------------------------------
   // evaluator output ntuples
 
+  bool _strict;
+  
   bool _do_gpoint_eval;
   bool _do_gshower_eval;
   bool _do_tower_eval;

--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.C
@@ -21,6 +21,7 @@
 #include <map>
 #include <float.h>
 #include <algorithm>
+#include <cassert>
 
 using namespace std;
 
@@ -29,6 +30,7 @@ CaloRawClusterEval::CaloRawClusterEval(PHCompositeNode* topNode, std::string cal
     _towereval(topNode,caloname),
     _clusters(NULL),
     _towers(NULL),
+    _strict(true),
     _do_cache(true),
     _cache_all_truth_hits(),
     _cache_all_truth_primaries(),
@@ -55,6 +57,9 @@ void CaloRawClusterEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Hit*> CaloRawClusterEval::all_truth_hits(RawCluster* cluster) {
 
+  if (_strict) assert(cluster);
+  else if (!cluster) return std::set<PHG4Hit*>();
+  
   if (_do_cache) {
     std::map<RawCluster*,std::set<PHG4Hit*> >::iterator iter =
       _cache_all_truth_hits.find(cluster);
@@ -67,17 +72,27 @@ std::set<PHG4Hit*> CaloRawClusterEval::all_truth_hits(RawCluster* cluster) {
   
   // loop over all the clustered towers
   RawCluster::TowerConstRange begin_end = cluster->get_towers();
-  RawCluster::TowerConstIterator iter;
-  for (iter = begin_end.first; iter != begin_end.second; ++iter)
-    { 
+  for (RawCluster::TowerConstIterator iter = begin_end.first;
+       iter != begin_end.second;
+       ++iter) { 
+
     RawTower* tower = _towers->getTower(iter->first);
+
+    if (_strict) assert(tower);
+    else if (!tower) continue;
     
     std::set<PHG4Hit*> new_hits = get_rawtower_eval()->all_truth_hits(tower);
 
     for (std::set<PHG4Hit*>::iterator iter = new_hits.begin();
 	 iter != new_hits.end();
 	 ++iter) {
-      truth_hits.insert(*iter);
+
+      PHG4Hit* g4hit = *iter;
+
+      if (_strict) assert(g4hit);
+      else if (!g4hit) continue;
+      
+      truth_hits.insert(g4hit);
     }
   }
 
@@ -88,6 +103,9 @@ std::set<PHG4Hit*> CaloRawClusterEval::all_truth_hits(RawCluster* cluster) {
   
 std::set<PHG4Particle*> CaloRawClusterEval::all_truth_primaries(RawCluster* cluster) {
 
+  if (_strict) assert(cluster);
+  else if (!cluster) return std::set<PHG4Particle*>();
+  
   if (_do_cache) {
     std::map<RawCluster*,std::set<PHG4Particle*> >::iterator iter =
       _cache_all_truth_primaries.find(cluster);
@@ -100,16 +118,26 @@ std::set<PHG4Particle*> CaloRawClusterEval::all_truth_primaries(RawCluster* clus
   
   // loop over all the clustered towers
   RawCluster::TowerConstRange begin_end = cluster->get_towers();
-  RawCluster::TowerConstIterator iter;
-  for (iter = begin_end.first; iter != begin_end.second; ++iter)
-    { 
+  for (RawCluster::TowerConstIterator iter = begin_end.first;
+       iter != begin_end.second;
+       ++iter) {
+    
     RawTower* tower = _towers->getTower(iter->first);
+
+    if (_strict) assert(tower);
+    else if (!tower) continue;
+        
     std::set<PHG4Particle*> new_primaries = _towereval.all_truth_primaries(tower);
 
     for (std::set<PHG4Particle*>::iterator iter = new_primaries.begin();
 	 iter != new_primaries.end();
 	 ++iter) {
-      truth_primaries.insert(*iter);
+      PHG4Particle* particle = *iter;
+
+      if (_strict) assert(particle);
+      else if (!particle) continue;
+      
+      truth_primaries.insert(particle);
     }
   }
 
@@ -120,6 +148,9 @@ std::set<PHG4Particle*> CaloRawClusterEval::all_truth_primaries(RawCluster* clus
 
 PHG4Particle* CaloRawClusterEval::max_truth_primary_by_energy(RawCluster* cluster) {
 
+  if (_strict) assert(cluster);
+  else if (!cluster) return NULL;
+  
   if (_do_cache) {
     std::map<RawCluster*,PHG4Particle*>::iterator iter =
       _cache_max_truth_primary_by_energy.find(cluster);
@@ -138,6 +169,10 @@ PHG4Particle* CaloRawClusterEval::max_truth_primary_by_energy(RawCluster* cluste
        ++iter) {
 
     PHG4Particle* primary = *iter;
+
+    if (_strict) assert(primary);
+    else if (!primary) continue;
+    
     float e = get_energy_contribution(cluster,primary);
     if (isnan(e)) continue;
     if (e > max_e) {
@@ -153,10 +188,16 @@ PHG4Particle* CaloRawClusterEval::max_truth_primary_by_energy(RawCluster* cluste
 
 std::set<RawCluster*> CaloRawClusterEval::all_clusters_from(PHG4Particle* primary) { 
 
+  if (_strict) assert(primary);
+  else if (!primary) return std::set<RawCluster*>();
+  
   if (!get_truth_eval()->is_primary(primary)) return std::set<RawCluster*>();
 
   primary = get_truth_eval()->get_primary_particle(primary);
 
+  if (_strict) assert(primary);
+  else if (!primary) return std::set<RawCluster*>();
+  
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<RawCluster*> >::iterator iter =
       _cache_all_clusters_from_primary.find(primary);
@@ -180,6 +221,10 @@ std::set<RawCluster*> CaloRawClusterEval::all_clusters_from(PHG4Particle* primar
 	 jter != primaries.end();
 	 ++jter) {
       PHG4Particle* candidate = *jter;
+
+      if (_strict) assert(candidate);
+      else if (!candidate) continue;
+      
       if (candidate->get_track_id() == primary->get_track_id()) {
 	clusters.insert(cluster);
       }    
@@ -193,10 +238,16 @@ std::set<RawCluster*> CaloRawClusterEval::all_clusters_from(PHG4Particle* primar
 
 RawCluster* CaloRawClusterEval::best_cluster_from(PHG4Particle* primary) {
 
+  if (_strict) assert(primary);
+  else if (!primary) return NULL;
+  
   if (!get_truth_eval()->is_primary(primary)) return NULL;
 
   primary = get_truth_eval()->get_primary_particle(primary);
-      
+
+  if (_strict) assert(primary);
+  else if (!primary) return NULL;
+  
   if (_do_cache) {
     std::map<PHG4Particle*,RawCluster*>::iterator iter =
       _cache_best_cluster_from_primary.find(primary);
@@ -212,6 +263,10 @@ RawCluster* CaloRawClusterEval::best_cluster_from(PHG4Particle* primary) {
        iter != clusters.end();
        ++iter) {
     RawCluster* cluster = *iter;
+
+    if (_strict) assert(cluster);
+    else if (!cluster) continue;
+    
     float energy = get_energy_contribution(cluster,primary);
     if(isnan(energy)) continue;
     if (energy > best_energy) {
@@ -228,10 +283,20 @@ RawCluster* CaloRawClusterEval::best_cluster_from(PHG4Particle* primary) {
 // overlap calculations
 float CaloRawClusterEval::get_energy_contribution(RawCluster* cluster, PHG4Particle* primary) {
 
+  if (_strict) {
+    assert(cluster);
+    assert(primary);
+  } else if (!cluster||!primary) {
+    return NAN;
+  }
+  
   if (!get_truth_eval()->is_primary(primary)) return NAN;
 
   // reduce cache misses by using only pointer from PrimaryMap
   primary = get_truth_eval()->get_primary_particle(primary);
+
+  if (_strict) assert(primary);
+  else if (!primary) return NULL;
   
   if (_do_cache) {
     std::map<std::pair<RawCluster*,PHG4Particle*>,float>::iterator iter =
@@ -253,12 +318,13 @@ float CaloRawClusterEval::get_energy_contribution(RawCluster* cluster, PHG4Parti
       PHG4Hit* g4hit = *iter;
       PHG4Particle* candidate = get_truth_eval()->get_primary_particle(g4hit);
 
-      if (candidate)
-        if (candidate->get_track_id() == primary->get_track_id()) {
-    energy += g4hit->get_edep();
-        }
-    }
-    
+      if (_strict) assert(candidate);
+      else if (!candidate) continue;
+      
+      if (candidate->get_track_id() == primary->get_track_id()) {
+	energy += g4hit->get_edep();
+      }
+    }    
   }
   
   if (_do_cache) _cache_get_energy_contribution_primary.insert(make_pair(make_pair(cluster,primary),energy));

--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.h
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.h
@@ -25,7 +25,15 @@ public:
   virtual ~CaloRawClusterEval() {}
 
   void next_event(PHCompositeNode *topNode);
-  void do_caching(bool do_cache) {_do_cache = do_cache;}
+  void do_caching(bool do_cache) {
+    _do_cache = do_cache;
+    _towereval.do_caching(do_cache);
+  }
+  void set_strict(bool strict) {
+    _strict = strict;
+    _towereval.set_strict(strict);
+  }
+  
   CaloTruthEval* get_truth_eval() {return _towereval.get_truth_eval();}
   CaloRawTowerEval* get_rawtower_eval() {return &_towereval;}
 
@@ -51,6 +59,8 @@ private:
   CaloRawTowerEval _towereval;
   RawClusterContainer* _clusters;
   RawTowerContainer* _towers;
+
+  bool _strict;
   
   bool                                                 _do_cache;
   std::map<RawCluster*,std::set<PHG4Hit*> >            _cache_all_truth_hits;

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -157,6 +157,10 @@ PHG4Particle* CaloRawTowerEval::max_truth_primary_by_energy(RawTower* tower) {
        ++iter) {
 
     PHG4Particle* primary = *iter;
+
+    if (_strict) assert(primary);
+    else if (!primary) continue;
+    
     float e = get_energy_contribution(tower,primary);
     if (isnan(e)) continue;
     if (e > max_e) {
@@ -179,6 +183,9 @@ std::set<RawTower*> CaloRawTowerEval::all_towers_from(PHG4Particle* primary) {
 
   // use primary map pointer
   primary = get_truth_eval()->get_primary_particle(primary);
+
+  if (_strict) assert(primary);
+  else if (!primary) return std::set<RawTower*>();
   
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<RawTower*> >::iterator iter =
@@ -226,6 +233,9 @@ RawTower* CaloRawTowerEval::best_tower_from(PHG4Particle* primary) {
   if (!_trutheval.is_primary(primary)) return NULL;
 
   primary = get_truth_eval()->get_primary_particle(primary);
+
+  if (_strict) assert(primary);
+  else if (!primary) return NULL;
   
   if (_do_cache) {
     std::map<PHG4Particle*,RawTower*>::iterator iter =
@@ -242,6 +252,10 @@ RawTower* CaloRawTowerEval::best_tower_from(PHG4Particle* primary) {
        iter != towers.end();
        ++iter) {
     RawTower* tower = *iter;
+
+    if (_strict) assert(tower);
+    else if (!tower) continue;
+    
     float energy = get_energy_contribution(tower,primary);
     if (isnan(energy)) continue;
     if (energy > best_energy) {
@@ -269,6 +283,9 @@ float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* p
 
   // reduce cache misses by using only pointer from PrimaryMap
   primary = get_truth_eval()->get_primary_particle(primary);
+
+  if (_strict) assert(primary);
+  else if (!primary) return NAN;
   
   if (_do_cache) {
     std::map<std::pair<RawTower*,PHG4Particle*>, float>::iterator iter =

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -18,6 +18,7 @@
 #include <set>
 #include <map>
 #include <float.h>
+#include <cassert>
 
 using namespace std;
 
@@ -28,6 +29,7 @@ CaloRawTowerEval::CaloRawTowerEval(PHCompositeNode* topNode, std::string calonam
     _g4cells(NULL),
     _g4hits(NULL),
     _truthinfo(NULL),
+    _strict(true),
     _do_cache(true),
     _cache_all_truth_hits(),
     _cache_all_truth_primaries(),
@@ -54,6 +56,9 @@ void CaloRawTowerEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Hit*> CaloRawTowerEval::all_truth_hits(RawTower* tower) {
 
+  if (_strict) assert(tower);
+  else if (!tower) return std::set<PHG4Hit*>();
+  
   if (_do_cache) {
     std::map<RawTower*,std::set<PHG4Hit*> >::iterator iter =
       _cache_all_truth_hits.find(tower);
@@ -72,11 +77,18 @@ std::set<PHG4Hit*> CaloRawTowerEval::all_truth_hits(RawTower* tower) {
     unsigned int cell_id = cell_iter->first;
     PHG4CylinderCell *cell = _g4cells->findCylinderCell(cell_id);
 
+    if (_strict) assert(cell);
+    else if (!cell) continue;
+    
     // loop over all the g4hits in this cell
     for (PHG4CylinderCell::EdepConstIterator hit_iter = cell->get_g4hits().first;
 	 hit_iter != cell->get_g4hits().second;
 	 ++hit_iter) {      
-      PHG4Hit* g4hit = _g4hits->findHit(hit_iter->first);   
+      PHG4Hit* g4hit = _g4hits->findHit(hit_iter->first);
+
+      if (_strict) assert(g4hit);
+      else if (!g4hit) continue;
+      
       // fill output set
       truth_hits.insert(g4hit);
     }
@@ -89,6 +101,9 @@ std::set<PHG4Hit*> CaloRawTowerEval::all_truth_hits(RawTower* tower) {
   
 std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
 
+  if (_strict) assert(tower);
+  else if (!tower) return std::set<PHG4Particle*>();
+  
   if (_do_cache) {
     std::map<RawTower*,std::set<PHG4Particle*> >::iterator iter =
       _cache_all_truth_primaries.find(tower);
@@ -105,9 +120,12 @@ std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
        iter != g4hits.end();
        ++iter) {
     PHG4Hit* g4hit = *iter;
-    PHG4Particle* primary = get_truth_eval()->get_primary_particle( g4hit );    
-    if (primary)
-      truth_primaries.insert(primary);
+    PHG4Particle* primary = get_truth_eval()->get_primary_particle( g4hit );
+
+    if (_strict) assert(primary);
+    else if (!primary) continue;
+
+    truth_primaries.insert(primary);
   }
 
   if (_do_cache) _cache_all_truth_primaries.insert(make_pair(tower,truth_primaries));
@@ -117,6 +135,9 @@ std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
 
 PHG4Particle* CaloRawTowerEval::max_truth_primary_by_energy(RawTower* tower) {
 
+  if (_strict) assert(tower);
+  else if (!tower) return NULL;
+  
   if (_do_cache) {
     std::map<RawTower*,PHG4Particle*>::iterator iter =
       _cache_max_truth_primary_by_energy.find(tower);
@@ -151,6 +172,9 @@ PHG4Particle* CaloRawTowerEval::max_truth_primary_by_energy(RawTower* tower) {
 
 std::set<RawTower*> CaloRawTowerEval::all_towers_from(PHG4Particle* primary) { 
 
+  if (_strict) assert(primary);
+  else if (!primary) return std::set<RawTower*>();
+  
   if (!_trutheval.is_primary(primary)) return std::set<RawTower*>();
 
   // use primary map pointer
@@ -179,6 +203,10 @@ std::set<RawTower*> CaloRawTowerEval::all_towers_from(PHG4Particle* primary) {
 	 jter != primaries.end();
 	 ++jter) {
       PHG4Particle* candidate = *jter;
+
+      if (_strict) assert(candidate);
+      else if (!candidate) continue;
+      
       if (candidate->get_track_id() == primary->get_track_id()) {
 	towers.insert(tower);
       }    
@@ -192,6 +220,9 @@ std::set<RawTower*> CaloRawTowerEval::all_towers_from(PHG4Particle* primary) {
 
 RawTower* CaloRawTowerEval::best_tower_from(PHG4Particle* primary) {
 
+  if (_strict) assert(primary);
+  else if (!primary) return NULL;
+  
   if (!_trutheval.is_primary(primary)) return NULL;
 
   primary = get_truth_eval()->get_primary_particle(primary);
@@ -227,6 +258,13 @@ RawTower* CaloRawTowerEval::best_tower_from(PHG4Particle* primary) {
 // overlap calculations
 float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* primary) {
 
+  if (_strict) {
+    assert(tower);
+    assert(primary);
+  } else if (!tower||!primary) {
+    return NAN;
+  }
+  
   if (!_trutheval.is_primary(primary)) return NAN;
 
   // reduce cache misses by using only pointer from PrimaryMap
@@ -251,12 +289,14 @@ float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* p
 	 ++iter) {
       PHG4Hit* g4hit = *iter;
       PHG4Particle* candidate = get_truth_eval()->get_primary_particle(g4hit);
-      if (candidate)
-        if (candidate->get_track_id() == primary->get_track_id()) {
-    energy += g4hit->get_edep();
-        }
+
+      if (_strict) assert(candidate);
+      else if (!candidate) continue;
+
+      if (candidate->get_track_id() == primary->get_track_id()) {
+	energy += g4hit->get_edep();
+      }
     }
-    
   }
 
   if (_do_cache) _cache_get_energy_contribution_primary.insert(make_pair(make_pair(tower,primary),energy));

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.h
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.h
@@ -26,7 +26,15 @@ public:
   virtual ~CaloRawTowerEval() {}
 
   void next_event(PHCompositeNode *topNode);
-  void do_caching(bool do_cache) {_do_cache = do_cache;}
+  void do_caching(bool do_cache) {
+    _do_cache = do_cache;
+    _trutheval.do_caching(do_cache);
+  }
+  void set_strict(bool strict) {
+    _strict = strict;
+    _trutheval.set_strict(strict);
+  }
+
   CaloTruthEval* get_truth_eval() {return &_trutheval;}
 
   // backtrace through to PHG4Hits
@@ -54,6 +62,8 @@ private:
   PHG4HitContainer* _g4hits;
   PHG4TruthInfoContainer* _truthinfo;
 
+  bool _strict;
+  
   bool                                               _do_cache;
   std::map<RawTower*,std::set<PHG4Hit*> >            _cache_all_truth_hits;
   std::map<RawTower*,std::set<PHG4Particle*> >       _cache_all_truth_primaries;

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -121,6 +121,8 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Hit* g4hit) {
 
   if (_do_cache) _cache_get_primary_particle_g4hit.insert(make_pair(g4hit,primary));
 
+  if (_strict) assert(primary);
+  
   return primary;
 }
 
@@ -169,6 +171,9 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
 
   primary = get_primary_particle(primary);
 
+  if (_strict) assert(primary);
+  else if (!primary) return std::set<PHG4Hit*>();
+  
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<PHG4Hit*> >::iterator iter =
       _cache_get_shower_from_primary.find(primary);
@@ -208,6 +213,9 @@ float CaloTruthEval::get_shower_moliere_radius(PHG4Particle* primary) {
   if (!is_primary(primary)) return NAN;
 
   primary = get_primary_particle(primary);
+
+  if (_strict) assert(primary);
+  else if (!primary) return NAN;
   
   if (_do_cache) {
     std::map<PHG4Particle*,float>::iterator iter =
@@ -286,6 +294,9 @@ float CaloTruthEval::get_shower_energy_deposit(PHG4Particle* primary) {
   if (!is_primary(primary)) return NAN;
 
   primary = get_primary_particle(primary);
+
+  if (_strict) assert(primary);
+  else if (!primary) return NAN;
   
   if (_do_cache) {
     std::map<PHG4Particle*,float>::iterator iter =

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -21,6 +21,7 @@ CaloTruthEval::CaloTruthEval(PHCompositeNode* topNode,std::string caloname)
   : _caloname(caloname),
     _truthinfo(NULL),
     _g4hits(NULL),
+    _strict(true),
     _do_cache(true),
     _cache_all_truth_hits_g4particle(),
     _cache_get_primary_particle_g4hit(),
@@ -43,6 +44,9 @@ void CaloTruthEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Hit*> CaloTruthEval::all_truth_hits(PHG4Particle* particle) {
 
+  if (_strict) assert(particle);
+  else if (!particle) return std::set<PHG4Hit*>();
+  
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<PHG4Hit*> >::iterator iter =
       _cache_all_truth_hits_g4particle.find(particle);
@@ -70,12 +74,20 @@ std::set<PHG4Hit*> CaloTruthEval::all_truth_hits(PHG4Particle* particle) {
 
 PHG4Particle* CaloTruthEval::get_parent_particle(PHG4Hit* g4hit) {
 
+  if (_strict) assert(g4hit);
+  else if (!g4hit) return NULL;
+  
   PHG4Particle* particle = _truthinfo->GetHit( g4hit->get_trkid() );
+  if (_strict) assert(particle);
+  
   return particle;
 }
 
 PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Particle* particle) {
 
+  if (_strict) assert(particle);
+  else if (!particle) return NULL;
+  
   // always report the primary from the Primary Map regardless if a
   // primary from the full Map was the argument
   PHG4Particle* returnval = NULL;
@@ -85,12 +97,17 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Particle* particle) {
     returnval = _truthinfo->GetPrimaryHit( particle->get_track_id() );
   }
 
+  if (_strict) assert(returnval);
+  
   return returnval;
 }
 
 
 PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Hit* g4hit) {
 
+  if (_strict) assert(g4hit);
+  else if (!g4hit) return NULL;
+  
   if (_do_cache) {
     std::map<PHG4Hit*,PHG4Particle*>::iterator iter =
       _cache_get_primary_particle_g4hit.find(g4hit);
@@ -100,17 +117,11 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Hit* g4hit) {
   }
   
   PHG4Particle* particle = get_parent_particle(g4hit);
-
-  if (particle)
-    {
   PHG4Particle* primary = get_primary_particle(particle);
-  assert(primary);
-  
+
   if (_do_cache) _cache_get_primary_particle_g4hit.insert(make_pair(g4hit,primary));
+
   return primary;
-    }
-  else
-    return NULL;
 }
 
 int CaloTruthEval::get_embed(PHG4Particle* particle) {
@@ -120,15 +131,27 @@ int CaloTruthEval::get_embed(PHG4Particle* particle) {
 
 PHG4VtxPoint* CaloTruthEval::get_vertex(PHG4Particle* particle) {
 
+  if (_strict) assert(particle);
+  else if (!particle) return NULL;
+
+  PHG4VtxPoint* point = NULL;
+  
   if (particle->get_primary_id() == -1) {
-    return _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );  
+    point = _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );  
+  } else {
+    point = _truthinfo->GetVtx( particle->get_vtx_id() ); 
   }
 
-  return _truthinfo->GetVtx( particle->get_vtx_id() );  
+  if (_strict) assert(point);
+  
+  return point;
 }
 
 bool CaloTruthEval::is_primary(PHG4Particle* particle) {
 
+  if (_strict) assert(particle);
+  else if (!particle) return false;
+  
   bool is_primary = true;
   if (!_truthinfo->GetPrimaryHit(particle->get_track_id())) {
     is_primary = false;
@@ -139,13 +162,12 @@ bool CaloTruthEval::is_primary(PHG4Particle* particle) {
 
 std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary) {
 
+  if (_strict) assert(primary);
+  else if (!primary) return std::set<PHG4Hit*>();
+  
   if (!is_primary(primary)) return std::set<PHG4Hit*>();
 
   primary = get_primary_particle(primary);
-  if (!primary){
-      cout <<__PRETTY_FUNCTION__<<" - Error - encountered invalid primary as input. "<<endl;
-      return std::set<PHG4Hit*>();
-  }
 
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<PHG4Hit*> >::iterator iter =
@@ -164,11 +186,10 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
 
     PHG4Hit* g4hit = g4iter->second;
     PHG4Particle* candidate = get_primary_particle(g4hit);
-    if (!candidate) {
-//        cout <<__PRETTY_FUNCTION__<<" - Error - can not find the primary particle for g4hit: "<<endl;
-//        g4hit->identify();
-        continue;
-    }
+
+    if (_strict) assert(candidate);
+    else if (!candidate) continue;
+
     if (candidate->get_track_id() != primary->get_track_id()) continue;
     truth_hits.insert(g4hit);
   }
@@ -181,6 +202,9 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
 // moliere (90% containment) radius of scintilator hits
 float CaloTruthEval::get_shower_moliere_radius(PHG4Particle* primary) {
 
+  if (_strict) assert(primary);
+  else if (!primary) return NAN;
+  
   if (!is_primary(primary)) return NAN;
 
   primary = get_primary_particle(primary);
@@ -256,6 +280,9 @@ float CaloTruthEval::get_shower_moliere_radius(PHG4Particle* primary) {
 
 float CaloTruthEval::get_shower_energy_deposit(PHG4Particle* primary) {
 
+  if (_strict) assert(primary);
+  else if (!primary) return NAN;
+  
   if (!is_primary(primary)) return NAN;
 
   primary = get_primary_particle(primary);

--- a/simulation/g4simulation/g4eval/CaloTruthEval.h
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.h
@@ -23,6 +23,7 @@ public:
 
   void next_event(PHCompositeNode *topNode);
   void do_caching(bool do_cache) {_do_cache = do_cache;}
+  void set_strict(bool strict) {_strict = strict;}
 
   std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);  
   PHG4Particle*      get_parent_particle(PHG4Hit* g4hit);
@@ -44,6 +45,8 @@ private:
   PHG4TruthInfoContainer* _truthinfo;
   PHG4HitContainer* _g4hits;
 
+  bool _strict;
+  
   bool                                        _do_cache;
   std::map<PHG4Particle*,std::set<PHG4Hit*> > _cache_all_truth_hits_g4particle;
   std::map<PHG4Hit*,PHG4Particle*>            _cache_get_primary_particle_g4hit;

--- a/simulation/g4simulation/g4eval/JetEvalStack.h
+++ b/simulation/g4simulation/g4eval/JetEvalStack.h
@@ -26,7 +26,9 @@ public:
   virtual ~JetEvalStack() {}
 
   void next_event(PHCompositeNode *topNode);
-
+  void do_caching(bool do_cache) {_recoeval.do_caching(do_cache);}
+  void set_strict(bool strict) {_recoeval.set_strict(strict);}
+  
   JetRecoEval*   get_reco_eval() {return &_recoeval;}
   JetTruthEval*  get_truth_eval() {return _recoeval.get_truth_eval();}
 

--- a/simulation/g4simulation/g4eval/JetEvaluator.C
+++ b/simulation/g4simulation/g4eval/JetEvaluator.C
@@ -27,6 +27,7 @@ JetEvaluator::JetEvaluator(const string &name,
     _recojetname(recojetname),
     _truthjetname(truthjetname),
     _ievent(0),
+    _strict(true),
     _do_recojet_eval(true),
     _do_truthjet_eval(true),
     _ntp_recojet(NULL),
@@ -115,6 +116,8 @@ void JetEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   if (verbosity > 2) cout << "JetEvaluator::fillOutputNtuples() entered" << endl;
 
   JetEvalStack jetevalstack(topNode,_recojetname,_truthjetname); 
+  jetevalstack.set_strict(_strict);
+
   JetRecoEval*   recoeval = jetevalstack.get_reco_eval();
   //JetTruthEval* trutheval = jetevalstack.get_truth_eval();
  

--- a/simulation/g4simulation/g4eval/JetEvaluator.h
+++ b/simulation/g4simulation/g4eval/JetEvaluator.h
@@ -37,6 +37,8 @@ class JetEvaluator : public SubsysReco {
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
+  void set_strict(bool b) {_strict = b;}
+  
  private:
 
   std::string _recojetname;
@@ -47,6 +49,8 @@ class JetEvaluator : public SubsysReco {
   //----------------------------------
   // evaluator output ntuples
 
+  bool _strict;
+  
   bool _do_recojet_eval;
   bool _do_truthjet_eval;
   

--- a/simulation/g4simulation/g4eval/JetRecoEval.C
+++ b/simulation/g4simulation/g4eval/JetRecoEval.C
@@ -29,6 +29,7 @@
 #include <map>
 #include <float.h>
 #include <algorithm>
+#include <cassert>
 
 using namespace std;
 
@@ -47,6 +48,7 @@ JetRecoEval::JetRecoEval(PHCompositeNode* topNode,
     _hcalinclusters(NULL),
     _hcalouttowers(NULL),
     _hcaloutclusters(NULL),
+    _strict(true),
     _do_cache(true),
     _cache_all_truth_hits(),
     _cache_all_truth_jets(),
@@ -75,6 +77,9 @@ void JetRecoEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Hit*> JetRecoEval::all_truth_hits(Jet* recojet) {
 
+  if (_strict) assert(recojet);
+  else if (!recojet) return std::set<PHG4Hit*>();
+  
   if (_do_cache) {
     std::map<Jet*,std::set<PHG4Hit*> >::iterator iter =
       _cache_all_truth_hits.find(recojet);
@@ -97,59 +102,107 @@ std::set<PHG4Hit*> JetRecoEval::all_truth_hits(Jet* recojet) {
     std::set<PHG4Hit*> new_hits;
     
     if (source == Jet::TRACK) {
+
       if (!_trackmap) {
 	cout << PHWHERE << "ERROR: can't find SvtxTrackMap" << endl;
 	exit(-1);
       }
-      SvtxTrack* track = _trackmap->get(index);     
+
+      SvtxTrack* track = _trackmap->get(index);
+
+      if (_strict) assert(track);
+      else if (!track) continue;
+      
       new_hits = get_svtx_eval_stack()->get_track_eval()->all_truth_hits(track);      
+
     } else if (source == Jet::CEMC_TOWER) {
+
       if (!_cemctowers) {
 	cout << PHWHERE << "ERROR: can't find TOWER_CEMC" << endl;
 	exit(-1);
       }
+      
       RawTower* tower = _cemctowers->getTower(index);
+
+      if (_strict) assert(tower);
+      else if (!tower) continue;
+      
       new_hits = get_cemc_eval_stack()->get_rawtower_eval()->all_truth_hits(tower);      
+
     } else if (source == Jet::CEMC_CLUSTER) {
+
       if (!_cemcclusters) {
 	cout << PHWHERE << "ERROR: can't find CLUSTER_CEMC" << endl;
 	exit(-1);
       }
+
       RawCluster* cluster = _cemcclusters->getCluster(index);
+
+      if (_strict) assert(cluster);
+      else if (!cluster) continue;
+      
       new_hits = get_cemc_eval_stack()->get_rawcluster_eval()->all_truth_hits(cluster);      
+
     } else if (source == Jet::HCALIN_TOWER) {
+
       if (!_hcalintowers) {
 	cout << PHWHERE << "ERROR: can't find TOWER_HCALIN" << endl;
 	exit(-1);
       }
+
       RawTower* tower = _hcalintowers->getTower(index);
+
+      if (_strict) assert(tower);
+      else if (!tower) continue;
+      
       new_hits = get_hcalin_eval_stack()->get_rawtower_eval()->all_truth_hits(tower); 
+
     } else if (source == Jet::HCALIN_CLUSTER) {
+
       if (!_hcalinclusters) {
 	cout << PHWHERE << "ERROR: can't find CLUSTER_HCALIN" << endl;
 	exit(-1);
       }
+
       RawCluster* cluster = _hcalinclusters->getCluster(index);
+
+      if (_strict) assert(cluster);
+      else if (!cluster) continue;
+      
       new_hits = get_hcalin_eval_stack()->get_rawcluster_eval()->all_truth_hits(cluster); 
+
     } else if (source == Jet::HCALOUT_TOWER) {
+
       if (!_hcalouttowers) {
 	cout << PHWHERE << "ERROR: can't find TOWER_HCALOUT" << endl;
 	exit(-1);
       }
+
       RawTower* tower = _hcalouttowers->getTower(index);
+
+      if (_strict) assert(tower);
+      else if (!tower) continue;
+      
       new_hits = get_hcalout_eval_stack()->get_rawtower_eval()->all_truth_hits(tower); 
+
     } else if (source == Jet::HCALOUT_CLUSTER) {
+
       if (!_hcaloutclusters) {
 	cout << PHWHERE << "ERROR: can't find CLUSTER_HCALOUT" << endl;
 	exit(-1);
       }
+
       RawCluster* cluster = _hcaloutclusters->getCluster(index);
+
+      if (_strict) assert(cluster);
+      else if (!cluster) continue;
+      
       new_hits = get_hcalout_eval_stack()->get_rawcluster_eval()->all_truth_hits(cluster); 
     }
 
     for (std::set<PHG4Hit*>::iterator jter = new_hits.begin();
 	 jter != new_hits.end();
-	 ++jter) {
+	 ++jter) {      
       truth_hits.insert(*jter);
     }
   }
@@ -160,7 +213,10 @@ std::set<PHG4Hit*> JetRecoEval::all_truth_hits(Jet* recojet) {
 }
 
 std::set<PHG4Particle*> JetRecoEval::all_truth_particles(Jet* recojet) {
- 
+
+  if (_strict) assert(recojet);
+  else if (!recojet) return std::set<PHG4Particle*>();
+  
   if (_do_cache) {
     std::map<Jet*,std::set<PHG4Particle*> >::iterator iter =
       _cache_all_truth_particles.find(recojet);
@@ -183,53 +239,101 @@ std::set<PHG4Particle*> JetRecoEval::all_truth_particles(Jet* recojet) {
     std::set<PHG4Particle*> new_particles;
     
     if (source == Jet::TRACK) {
+      
       if (!_trackmap) {
 	cout << PHWHERE << "ERROR: can't find SvtxTrackMap" << endl;
 	exit(-1);
       }
-      SvtxTrack* track = _trackmap->get(index);     
+
+      SvtxTrack* track = _trackmap->get(index);
+
+      if (_strict) assert(track);
+      else if (!track) continue;
+
       new_particles = get_svtx_eval_stack()->get_track_eval()->all_truth_particles(track);      
+
     } else if (source == Jet::CEMC_TOWER) {
+
       if (!_cemctowers) {
 	cout << PHWHERE << "ERROR: can't find TOWER_CEMC" << endl;
 	exit(-1);
       }
+      
       RawTower* tower = _cemctowers->getTower(index);
+
+      if (_strict) assert(tower);
+      else if (!tower) continue;
+      
       new_particles = get_cemc_eval_stack()->get_rawtower_eval()->all_truth_primaries(tower);      
+
     } else if (source == Jet::CEMC_CLUSTER) {
+
       if (!_cemcclusters) {
 	cout << PHWHERE << "ERROR: can't find CLUSTER_CEMC" << endl;
 	exit(-1);
       }
+
       RawCluster* cluster = _cemcclusters->getCluster(index);
+
+      if (_strict) assert(cluster);
+      else if (!cluster) continue;
+      
       new_particles = get_cemc_eval_stack()->get_rawcluster_eval()->all_truth_primaries(cluster); 
+
     } else if (source == Jet::HCALIN_TOWER) {
+
       if (!_hcalintowers) {
 	cout << PHWHERE << "ERROR: can't find TOWER_HCALIN" << endl;
 	exit(-1);
       }
+
       RawTower* tower = _hcalintowers->getTower(index);
+
+      if (_strict) assert(tower);
+      else if (!tower) continue;
+      
       new_particles = get_hcalin_eval_stack()->get_rawtower_eval()->all_truth_primaries(tower); 
+
     } else if (source == Jet::HCALIN_CLUSTER) {
+
       if (!_hcalinclusters) {
 	cout << PHWHERE << "ERROR: can't find CLUSTER_HCALIN" << endl;
 	exit(-1);
       }
+
       RawCluster* cluster = _hcalinclusters->getCluster(index);
+
+      if (_strict) assert(cluster);
+      else if (!cluster) continue;
+
       new_particles = get_hcalin_eval_stack()->get_rawcluster_eval()->all_truth_primaries(cluster); 
+
     } else if (source == Jet::HCALOUT_TOWER) {
+
       if (!_hcalouttowers) {
 	cout << PHWHERE << "ERROR: can't find TOWER_HCALOUT" << endl;
 	exit(-1);
       }
+
       RawTower* tower = _hcalouttowers->getTower(index);
+
+      if (_strict) assert(tower);
+      else if (!tower) continue;
+      
       new_particles = get_hcalout_eval_stack()->get_rawtower_eval()->all_truth_primaries(tower); 
+
     } else if (source == Jet::HCALOUT_CLUSTER) {
+
       if (!_hcaloutclusters) {
 	cout << PHWHERE << "ERROR: can't find CLUSTER_HCALOUT" << endl;
 	exit(-1);
       }
+
       RawCluster* cluster = _hcaloutclusters->getCluster(index);
+
+      if (_strict) assert(cluster);
+      else if (!cluster) continue;
+
       new_particles = get_hcalout_eval_stack()->get_rawcluster_eval()->all_truth_primaries(cluster); 
     }
 
@@ -247,6 +351,9 @@ std::set<PHG4Particle*> JetRecoEval::all_truth_particles(Jet* recojet) {
 
 std::set<Jet*> JetRecoEval::all_truth_jets(Jet* recojet) {
 
+  if (_strict) assert(recojet);
+  else if (!recojet) return std::set<Jet*>();
+  
   if (_do_cache) {
     std::map<Jet*,std::set<Jet*> >::iterator iter =
       _cache_all_truth_jets.find(recojet);
@@ -265,6 +372,9 @@ std::set<Jet*> JetRecoEval::all_truth_jets(Jet* recojet) {
        iter != particles.end();
        ++iter) {
     PHG4Particle* particle = *iter;
+
+    if (_strict) assert(particle);
+    else if (!particle) continue;
     
     Jet* truth_jet = _jettrutheval.get_truth_jet(particle);
     if (!truth_jet) continue;
@@ -278,6 +388,9 @@ std::set<Jet*> JetRecoEval::all_truth_jets(Jet* recojet) {
 }
 
 Jet* JetRecoEval::max_truth_jet_by_energy(Jet* recojet) {
+
+  if (_strict) assert(recojet);
+  else if (!recojet) return NULL;
   
   if (_do_cache) {
     std::map<Jet*,Jet*>::iterator iter =
@@ -295,6 +408,10 @@ Jet* JetRecoEval::max_truth_jet_by_energy(Jet* recojet) {
        iter != truthjets.end();
        ++iter) {
     Jet* candidate = *iter;
+
+    if (_strict) assert(candidate);
+    else if (!candidate) continue;
+    
     float energy = get_energy_contribution(recojet,candidate);
     if (energy > max_energy) {
       truthjet = candidate;
@@ -309,6 +426,9 @@ Jet* JetRecoEval::max_truth_jet_by_energy(Jet* recojet) {
 
 std::set<Jet*> JetRecoEval::all_jets_from(Jet* truthjet) {
 
+   if (_strict) assert(truthjet);
+   else if (!truthjet) return std::set<Jet*>();
+  
   if (_do_cache) {
     std::map<Jet*,std::set<Jet*> >::iterator iter =
       _cache_all_jets_from.find(truthjet);
@@ -330,7 +450,11 @@ std::set<Jet*> JetRecoEval::all_jets_from(Jet* truthjet) {
     for (std::set<Jet*>::iterator jter = truthcandidates.begin();
 	 jter != truthcandidates.end();
 	 ++jter) {
-      Jet* truthcandidate = *jter;     
+      Jet* truthcandidate = *jter;
+
+      if (_strict) assert(truthcandidate);
+      else if (!truthcandidate) continue;
+      
       if (truthcandidate->get_id() == truthjet->get_id()) {
 	recojets.insert(recojet);
       }
@@ -344,6 +468,9 @@ std::set<Jet*> JetRecoEval::all_jets_from(Jet* truthjet) {
 
 Jet* JetRecoEval::best_jet_from(Jet* truthjet) {
 
+   if (_strict) assert(truthjet);
+   else if (!truthjet) return NULL;
+  
   if (_do_cache) {
     std::map<Jet*,Jet*>::iterator iter =
       _cache_best_jet_from.find(truthjet);
@@ -359,7 +486,11 @@ Jet* JetRecoEval::best_jet_from(Jet* truthjet) {
   for (std::set<Jet*>::iterator iter = recojets.begin();
        iter != recojets.end();
        ++iter) {
-    Jet* recojet = *iter;    
+    Jet* recojet = *iter;
+
+   if (_strict) assert(recojet);
+   else if (!recojet) continue;
+    
     float energy = get_energy_contribution(recojet,truthjet);
     if (energy > max_energy) {
       bestrecojet = recojet;
@@ -375,6 +506,13 @@ Jet* JetRecoEval::best_jet_from(Jet* truthjet) {
 // overlap calculations
 float JetRecoEval::get_energy_contribution(Jet* recojet, Jet* truthjet) {
 
+  if (_strict) {
+    assert(recojet);
+    assert(truthjet);
+  } else if (!recojet||!truthjet) {
+    return NAN;
+  }
+  
   if (_do_cache) {
     std::map<std::pair<Jet*,Jet*>,float>::iterator iter =
       _cache_get_energy_contribution.find(make_pair(recojet,truthjet));
@@ -392,6 +530,9 @@ float JetRecoEval::get_energy_contribution(Jet* recojet, Jet* truthjet) {
        iter != truthjetcomp.end();
        ++iter) {
     PHG4Particle* truthparticle = *iter;
+
+    if (_strict) assert(truthparticle);
+    else if (!truthparticle) continue;
     
     // loop over all recojet constituents
     for (Jet::ConstIter jter = recojet->begin_comp();
@@ -403,28 +544,70 @@ float JetRecoEval::get_energy_contribution(Jet* recojet, Jet* truthjet) {
       float energy = 0.0;
     
       if (source == Jet::TRACK) {
+	
 	SvtxTrack* track = _trackmap->get(index);
+
+	if (_strict) assert(track);
+	else if (!track) continue;
+	
 	PHG4Particle* maxtruthparticle = get_svtx_eval_stack()->get_track_eval()->max_truth_particle_by_nclusters(track);
+
+	if (_strict) assert(maxtruthparticle);
+	else if (!maxtruthparticle) continue;
+
 	if (maxtruthparticle->get_track_id() == truthparticle->get_track_id()) { 
 	  energy = track->get_p();
 	}
       } else if (source == Jet::CEMC_TOWER) {
+	
 	RawTower* tower = _cemctowers->getTower(index);
+
+	if (_strict) assert(tower);
+	else if (!tower) continue;
+
 	energy = get_cemc_eval_stack()->get_rawtower_eval()->get_energy_contribution(tower,truthparticle);
+
       } else if (source == Jet::CEMC_CLUSTER) {
+	
 	RawCluster* cluster = _cemcclusters->getCluster(index);
+
+	if (_strict) assert(cluster);
+	else if (!cluster) continue;
+	
 	energy = get_cemc_eval_stack()->get_rawcluster_eval()->get_energy_contribution(cluster,truthparticle);
+
       } else if (source == Jet::HCALIN_TOWER) {
+
 	RawTower* tower = _hcalintowers->getTower(index);
+
+	if (_strict) assert(tower);
+	else if (!tower) continue;
+	
 	energy = get_hcalin_eval_stack()->get_rawtower_eval()->get_energy_contribution(tower,truthparticle);
+
       } else if (source == Jet::HCALIN_CLUSTER) {
+	
 	RawCluster* cluster = _hcalinclusters->getCluster(index);
+
+	if (_strict) assert(cluster);
+	else if (!cluster) continue;
+	
 	energy = get_hcalin_eval_stack()->get_rawcluster_eval()->get_energy_contribution(cluster,truthparticle);
+
       } else if (source == Jet::HCALOUT_TOWER) {
 	RawTower* tower = _hcalouttowers->getTower(index);
+
+	if (_strict) assert(tower);
+	else if (!tower) continue;
+	
 	energy = get_hcalout_eval_stack()->get_rawtower_eval()->get_energy_contribution(tower,truthparticle);
       } else if (source == Jet::HCALOUT_CLUSTER) {
+
 	RawCluster* cluster = _hcaloutclusters->getCluster(index);
+
+	if (_strict) assert(cluster);
+	else if (!cluster) continue;
+	
 	energy = get_hcalout_eval_stack()->get_rawcluster_eval()->get_energy_contribution(cluster,truthparticle);
       }
 

--- a/simulation/g4simulation/g4eval/JetRecoEval.h
+++ b/simulation/g4simulation/g4eval/JetRecoEval.h
@@ -30,7 +30,14 @@ public:
   virtual ~JetRecoEval() {}
 
   void next_event(PHCompositeNode *topNode);
-  void do_caching(bool do_cache) {_do_cache = do_cache;}
+  void do_caching(bool do_cache) {
+    _do_cache = do_cache;
+    _jettrutheval.do_caching(do_cache);
+  }
+  void set_strict(bool strict) {
+    _strict = strict;
+    _jettrutheval.set_strict(strict);
+  }
 
   JetTruthEval*     get_truth_eval()         {return &_jettrutheval;}
   SvtxEvalStack*    get_svtx_eval_stack()    {return _jettrutheval.get_svtx_eval_stack();}
@@ -73,6 +80,8 @@ private:
   RawClusterContainer* _hcalinclusters;
   RawTowerContainer*   _hcalouttowers;
   RawClusterContainer* _hcaloutclusters;
+
+  bool _strict;
   
   bool                                    _do_cache;
   std::map<Jet*,std::set<PHG4Hit*> >      _cache_all_truth_hits;

--- a/simulation/g4simulation/g4eval/JetTruthEval.C
+++ b/simulation/g4simulation/g4eval/JetTruthEval.C
@@ -14,6 +14,7 @@
 #include <map>
 #include <float.h>
 #include <algorithm>
+#include <cassert>
 
 using namespace std;
 
@@ -26,6 +27,7 @@ JetTruthEval::JetTruthEval(PHCompositeNode* topNode,
     _hcaloutevalstack(topNode,"HCALOUT"),
     _truthinfo(NULL),
     _truthjets(NULL),
+    _strict(true),
     _do_cache(true),
     _cache_all_truth_particles(),
     _cache_all_truth_hits(),
@@ -49,6 +51,9 @@ void JetTruthEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Particle*> JetTruthEval::all_truth_particles(Jet* truthjet) {
 
+  if (_strict) assert(truthjet);
+  else if (!truthjet) return std::set<PHG4Particle*>();
+  
   if (_do_cache) {
     std::map<Jet*,std::set<PHG4Particle*> >::iterator iter =
       _cache_all_truth_particles.find(truthjet);
@@ -71,8 +76,11 @@ std::set<PHG4Particle*> JetTruthEval::all_truth_particles(Jet* truthjet) {
     }
 
     PHG4Particle* truth_particle = _truthinfo->GetHit(index);
-    if (truth_particle)
-      truth_particles.insert(truth_particle);
+    
+    if (_strict) assert(truth_particle);
+    else if (!truth_particle) continue;
+    
+    truth_particles.insert(truth_particle);
   }
 
   if (_do_cache) _cache_all_truth_particles.insert(make_pair(truthjet,truth_particles));
@@ -82,6 +90,9 @@ std::set<PHG4Particle*> JetTruthEval::all_truth_particles(Jet* truthjet) {
 
 std::set<PHG4Hit*> JetTruthEval::all_truth_hits(Jet* truthjet) {
 
+  if (_strict) assert(truthjet);
+  else if (!truthjet) return std::set<PHG4Hit*>();
+  
   if (_do_cache) {
     std::map<Jet*,std::set<PHG4Hit*> >::iterator iter =
       _cache_all_truth_hits.find(truthjet);
@@ -100,6 +111,9 @@ std::set<PHG4Hit*> JetTruthEval::all_truth_hits(Jet* truthjet) {
        ++iter) {
     PHG4Particle* particle = *iter;
 
+    if (_strict) assert(particle);
+    else if (!particle) continue;
+    
     // ask the svtx truth eval to backtrack the particles to g4hits
     SvtxTruthEval* svtx_truth_eval = _svtxevalstack.get_truth_eval(); 
     std::set<PHG4Hit*> svtx_g4hits = svtx_truth_eval->all_truth_hits(particle);
@@ -107,7 +121,13 @@ std::set<PHG4Hit*> JetTruthEval::all_truth_hits(Jet* truthjet) {
     for (std::set<PHG4Hit*>::iterator jter = svtx_g4hits.begin();
 	 jter != svtx_g4hits.end();
 	 ++jter) {
-      truth_hits.insert(*jter);
+
+      PHG4Hit* g4hit = *jter;
+
+      if (_strict) assert(g4hit);
+      else if (!g4hit) continue;
+      
+      truth_hits.insert(g4hit);
     }
     
     // ask the cemc truth eval to backtrack the primary to g4hits
@@ -117,7 +137,13 @@ std::set<PHG4Hit*> JetTruthEval::all_truth_hits(Jet* truthjet) {
     for (std::set<PHG4Hit*>::iterator jter = cemc_g4hits.begin();
 	 jter != cemc_g4hits.end();
 	 ++jter) {
-      truth_hits.insert(*jter);
+      
+      PHG4Hit* g4hit = *jter;
+
+      if (_strict) assert(g4hit);
+      else if (!g4hit) continue;
+      
+      truth_hits.insert(g4hit);
     }
     
     // ask the hcalin truth eval to backtrack the primary to g4hits
@@ -127,7 +153,13 @@ std::set<PHG4Hit*> JetTruthEval::all_truth_hits(Jet* truthjet) {
     for (std::set<PHG4Hit*>::iterator jter = hcalin_g4hits.begin();
 	 jter != hcalin_g4hits.end();
 	 ++jter) {
-      truth_hits.insert(*jter);
+
+      PHG4Hit* g4hit = *jter;
+
+      if (_strict) assert(g4hit);
+      else if (!g4hit) continue;
+      
+      truth_hits.insert(g4hit);
     }
     
     // ask the hcalout truth eval to backtrack the primary to g4hits
@@ -137,7 +169,13 @@ std::set<PHG4Hit*> JetTruthEval::all_truth_hits(Jet* truthjet) {
     for (std::set<PHG4Hit*>::iterator jter = hcalout_g4hits.begin();
 	 jter != hcalout_g4hits.end();
 	 ++jter) {
-      truth_hits.insert(*jter);
+
+      PHG4Hit* g4hit = *jter;
+
+      if (_strict) assert(g4hit);
+      else if (!g4hit) continue;
+      
+      truth_hits.insert(g4hit);      
     }    
   }
   
@@ -148,6 +186,9 @@ std::set<PHG4Hit*> JetTruthEval::all_truth_hits(Jet* truthjet) {
 
 Jet* JetTruthEval::get_truth_jet(PHG4Particle* particle) {
 
+  if (_strict) assert(particle);
+  else if (!particle) return NULL;
+  
   if (_do_cache) {
     std::map<PHG4Particle*,Jet*>::iterator iter =
       _cache_get_truth_jet.find(particle);

--- a/simulation/g4simulation/g4eval/JetTruthEval.h
+++ b/simulation/g4simulation/g4eval/JetTruthEval.h
@@ -24,8 +24,21 @@ public:
   virtual ~JetTruthEval() {}
 
   void next_event(PHCompositeNode* topNode);
-  void do_caching(bool do_cache) {_do_cache = do_cache;}
-
+  void do_caching(bool do_cache) {
+    _do_cache = do_cache;
+    _svtxevalstack.do_caching(do_cache);
+    _cemcevalstack.do_caching(do_cache);
+    _hcalinevalstack.do_caching(do_cache);
+    _hcaloutevalstack.do_caching(do_cache);
+  }
+  void set_strict(bool strict) {
+    _strict = strict;
+    _svtxevalstack.set_strict(strict);
+    _cemcevalstack.set_strict(strict);
+    _hcalinevalstack.set_strict(strict);
+    _hcaloutevalstack.set_strict(strict); 
+  }  
+  
   SvtxEvalStack* get_svtx_eval_stack() {return &_svtxevalstack;}
   CaloEvalStack* get_cemc_eval_stack() {return &_cemcevalstack;}
   CaloEvalStack* get_hcalin_eval_stack() {return &_hcalinevalstack;}
@@ -48,6 +61,8 @@ private:
 
   PHG4TruthInfoContainer* _truthinfo;
   JetMap* _truthjets;
+
+  bool _strict;
   
   bool                                    _do_cache;
   std::map<Jet*,std::set<PHG4Particle*> > _cache_all_truth_particles;

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -24,7 +24,14 @@ public:
   virtual ~SvtxClusterEval() {}
 
   void next_event(PHCompositeNode *topNode);
-  void do_caching(bool do_cache) {_do_cache = do_cache;}
+  void do_caching(bool do_cache) {
+    _do_cache = do_cache;
+    _hiteval.do_caching(do_cache);
+  }
+  void set_strict(bool strict) {
+    _strict = strict;
+    _hiteval.set_strict(strict);
+  }
   
   // access the clustereval (and its cached values)
   SvtxHitEval* get_hit_eval() {return &_hiteval;}
@@ -55,6 +62,8 @@ private:
   SvtxClusterMap* _clustermap;
   SvtxHitMap* _hitmap;
   PHG4TruthInfoContainer* _truthinfo;
+
+  bool _strict;
   
   bool                                                  _do_cache;
   std::map<SvtxCluster*,std::set<PHG4Hit*> >            _cache_all_truth_hits;

--- a/simulation/g4simulation/g4eval/SvtxEvalStack.h
+++ b/simulation/g4simulation/g4eval/SvtxEvalStack.h
@@ -24,6 +24,8 @@ public:
   virtual ~SvtxEvalStack() {}
 
   void next_event(PHCompositeNode *topNode);
+  void do_caching(bool do_cache) {_vertexeval.do_caching(do_cache);}
+  void set_strict(bool strict) {_vertexeval.set_strict(strict);}
 
   SvtxVertexEval*  get_vertex_eval() {return &_vertexeval;}
   SvtxTrackEval*   get_track_eval() {return _vertexeval.get_track_eval();}

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -38,6 +38,7 @@ using namespace std;
 SvtxEvaluator::SvtxEvaluator(const string &name, const string &filename) :
   SubsysReco("SvtxEvaluator"),
   _ievent(0),
+  _strict(true),
   _do_vertex_eval(true),
   _do_gpoint_eval(true),
   _do_g4hit_eval(true),
@@ -195,6 +196,7 @@ void SvtxEvaluator::printInputInfo(PHCompositeNode *topNode) {
     cout << endl;
     cout << "---PHG4HITS-------------" << endl;
     SvtxTruthEval trutheval(topNode);
+    trutheval.set_strict(_strict);
     std::set<PHG4Hit*> g4hits = trutheval.all_truth_hits();
     unsigned int ig4hit = 0;
     for(std::set<PHG4Hit*>::iterator iter = g4hits.begin();
@@ -265,6 +267,7 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode *topNode) {
   //==========================================
 
   SvtxEvalStack svtxevalstack(topNode);
+  svtxevalstack.set_strict(_strict);
 
   SvtxTrackEval*     trackeval = svtxevalstack.get_track_eval();
   SvtxClusterEval* clustereval = svtxevalstack.get_cluster_eval();
@@ -531,6 +534,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   if (verbosity > 1) cout << "SvtxEvaluator::fillOutputNtuples() entered" << endl;
 
   SvtxEvalStack svtxevalstack(topNode);
+  svtxevalstack.set_strict(_strict);
 
   SvtxVertexEval*   vertexeval = svtxevalstack.get_vertex_eval();
   SvtxTrackEval*     trackeval = svtxevalstack.get_track_eval();

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -38,6 +38,8 @@ public:
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
+  void set_strict(bool b) {_strict = b;}
+  
   void do_vertex_eval(bool b) {_do_vertex_eval = b;}
   void do_gpoint_eval(bool b) {_do_gpoint_eval = b;}
   void do_g4hit_eval(bool b) {_do_g4hit_eval = b;}
@@ -53,6 +55,8 @@ public:
   //----------------------------------
   // evaluator output ntuples
 
+  bool _strict;
+  
   bool _do_vertex_eval;
   bool _do_gpoint_eval;
   bool _do_g4hit_eval;

--- a/simulation/g4simulation/g4eval/SvtxHitEval.C
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.C
@@ -16,6 +16,7 @@
 #include <set>
 #include <map>
 #include <float.h>
+#include <cassert>
 
 using namespace std;
 
@@ -27,6 +28,7 @@ SvtxHitEval::SvtxHitEval(PHCompositeNode* topNode)
     _g4hits_svtx(NULL),
     _g4hits_tracker(NULL),
     _truthinfo(NULL),
+    _strict(true),
     _do_cache(true),
     _cache_all_truth_hits(),
     _cache_max_truth_hit_by_energy(),
@@ -58,16 +60,24 @@ void SvtxHitEval::next_event(PHCompositeNode* topNode) {
 }
 
 PHG4CylinderCell* SvtxHitEval::get_cell(SvtxHit* hit) {
+
+  if (_strict) assert(hit);
+  else if (!hit) return NULL;
   
   // hop from reco hit to g4cell
   PHG4CylinderCell* cell = NULL;
   if (!cell&&_g4cells_svtx)    cell = _g4cells_svtx->findCylinderCell(hit->get_cellid());
-  if (!cell&&_g4cells_tracker) cell = _g4cells_tracker->findCylinderCell(hit->get_cellid()); 
+  if (!cell&&_g4cells_tracker) cell = _g4cells_tracker->findCylinderCell(hit->get_cellid());
+  // no assert as some hits may be noise
+  
   return cell;
 }
 
 std::set<PHG4Hit*> SvtxHitEval::all_truth_hits(SvtxHit* hit) {
 
+  if (_strict) assert(hit);
+  else if (!hit) return std::set<PHG4Hit*>();
+  
   if (_do_cache) {
     std::map<SvtxHit*,std::set<PHG4Hit*> >::iterator iter =
       _cache_all_truth_hits.find(hit);
@@ -92,7 +102,9 @@ std::set<PHG4Hit*> SvtxHitEval::all_truth_hits(SvtxHit* hit) {
     PHG4Hit* g4hit = NULL;
     if (!g4hit&&_g4hits_svtx)    g4hit = _g4hits_svtx->findHit(g4iter->first);
     if (!g4hit&&_g4hits_tracker) g4hit = _g4hits_tracker->findHit(g4iter->first);
-    if (!g4hit) continue;
+
+    if (_strict) assert(g4hit);
+    else if (!g4hit) continue;
     
     // fill output set
     truth_hits.insert(g4hit);
@@ -104,6 +116,9 @@ std::set<PHG4Hit*> SvtxHitEval::all_truth_hits(SvtxHit* hit) {
 }
 
 PHG4Hit* SvtxHitEval::max_truth_hit_by_energy(SvtxHit* hit) {
+
+  if (_strict) assert(hit);
+  else if (!hit) return NULL;
   
   if (_do_cache) {
     std::map<SvtxHit*,PHG4Hit*>::iterator iter =
@@ -133,6 +148,9 @@ PHG4Hit* SvtxHitEval::max_truth_hit_by_energy(SvtxHit* hit) {
   
 std::set<PHG4Particle*> SvtxHitEval::all_truth_particles(SvtxHit* hit) {
 
+  if (_strict) assert(hit);
+  else if (!hit) return std::set<PHG4Particle*>();
+  
   if (_do_cache) {
     std::map<SvtxHit*,std::set<PHG4Particle*> >::iterator iter =
       _cache_all_truth_particles.find(hit);
@@ -144,14 +162,16 @@ std::set<PHG4Particle*> SvtxHitEval::all_truth_particles(SvtxHit* hit) {
   std::set<PHG4Particle*> truth_particles;
   
   std::set<PHG4Hit*> g4hits = all_truth_hits(hit);
-  if (g4hits.empty()) return truth_particles;
 
   for (std::set<PHG4Hit*>::iterator iter = g4hits.begin();
        iter != g4hits.end();
        ++iter) {
     PHG4Hit* g4hit = *iter;
     PHG4Particle* particle = _truthinfo->GetHit( g4hit->get_trkid() );
-    if (!particle) continue;
+
+    if (_strict) assert(particle);
+    else if (!particle) continue;
+
     truth_particles.insert(particle);
   }
 
@@ -162,6 +182,9 @@ std::set<PHG4Particle*> SvtxHitEval::all_truth_particles(SvtxHit* hit) {
 
 PHG4Particle* SvtxHitEval::max_truth_particle_by_energy(SvtxHit* hit) {
 
+  if (_strict) assert(hit);
+  else if (!hit) return NULL;
+  
   if (_do_cache) {
     std::map<SvtxHit*,PHG4Particle*>::iterator iter =
       _cache_max_truth_particle_by_energy.find(hit);
@@ -194,6 +217,9 @@ PHG4Particle* SvtxHitEval::max_truth_particle_by_energy(SvtxHit* hit) {
 
 std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Particle* g4particle) { 
 
+  if (_strict) assert(g4particle);
+  else if (!g4particle) return std::set<SvtxHit*>();
+  
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<SvtxHit*> >::iterator iter =
       _cache_all_hits_from_particle.find(g4particle);
@@ -230,6 +256,9 @@ std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Particle* g4particle) {
 
 std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Hit* g4hit) {
 
+  if (_strict) assert(g4hit);
+  else if (!g4hit) return std::set<SvtxHit*>();
+  
   if (_do_cache) {
     std::map<PHG4Hit*,std::set<SvtxHit*> >::iterator iter =
       _cache_all_hits_from_g4hit.find(g4hit);
@@ -266,6 +295,9 @@ std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Hit* g4hit) {
 
 SvtxHit* SvtxHitEval::best_hit_from(PHG4Hit* g4hit) {
 
+  if (_strict) assert(g4hit);
+  else if (!g4hit) return NULL;
+  
   if (_do_cache) {
     std::map<PHG4Hit*,SvtxHit*>::iterator iter =
       _cache_best_hit_from_g4hit.find(g4hit);
@@ -296,6 +328,13 @@ SvtxHit* SvtxHitEval::best_hit_from(PHG4Hit* g4hit) {
 // overlap calculations
 float SvtxHitEval::get_energy_contribution(SvtxHit* hit, PHG4Particle* particle) {
 
+  if (_strict) {
+    assert(hit);
+    assert(particle);
+  } else if (!hit||!particle) {
+    return NAN;
+  }
+  
   if (_do_cache) {
     std::map<std::pair<SvtxHit*,PHG4Particle*>,float>::iterator iter =
       _cache_get_energy_contribution_g4particle.find(make_pair(hit,particle));
@@ -322,6 +361,13 @@ float SvtxHitEval::get_energy_contribution(SvtxHit* hit, PHG4Particle* particle)
 
 float SvtxHitEval::get_energy_contribution(SvtxHit* hit, PHG4Hit* g4hit) {
 
+  if (_strict) {
+    assert(hit);
+    assert(g4hit);
+  } else if (!hit||!g4hit) {
+    return NAN;
+  }
+  
   if (_do_cache) {
     std::map<std::pair<SvtxHit*,PHG4Hit*>,float>::iterator iter =
       _cache_get_energy_contribution_g4hit.find(make_pair(hit,g4hit));

--- a/simulation/g4simulation/g4eval/SvtxHitEval.C
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.C
@@ -68,7 +68,9 @@ PHG4CylinderCell* SvtxHitEval::get_cell(SvtxHit* hit) {
   PHG4CylinderCell* cell = NULL;
   if (!cell&&_g4cells_svtx)    cell = _g4cells_svtx->findCylinderCell(hit->get_cellid());
   if (!cell&&_g4cells_tracker) cell = _g4cells_tracker->findCylinderCell(hit->get_cellid());
-  // no assert as some hits may be noise
+
+  // only noise hits (cellid left at default value) should not trace
+  if ((_strict) && (hit->get_cellid() != 0xFFFFFFFF)) assert(cell);
   
   return cell;
 }
@@ -92,7 +94,10 @@ std::set<PHG4Hit*> SvtxHitEval::all_truth_hits(SvtxHit* hit) {
   PHG4CylinderCell *cell = NULL;
   if (!cell&&_g4cells_svtx)    cell = _g4cells_svtx->findCylinderCell(hit->get_cellid());
   if (!cell&&_g4cells_tracker) cell = _g4cells_tracker->findCylinderCell(hit->get_cellid());
-  if (!cell) return truth_hits;
+
+  // only noise hits (cellid left at default value) should not trace
+  if ((_strict) && (hit->get_cellid() != 0xFFFFFFFF)) assert(cell);
+  else if (!cell) return truth_hits;
 
   // loop over all the g4hits in this cell
   for (PHG4CylinderCell::EdepConstIterator g4iter = cell->get_g4hits().first;

--- a/simulation/g4simulation/g4eval/SvtxHitEval.h
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.h
@@ -25,8 +25,15 @@ public:
   virtual ~SvtxHitEval() {}
 
   void next_event(PHCompositeNode *topNode);
-  void do_caching(bool do_cache) {_do_cache = do_cache;}
-
+  void do_caching(bool do_cache) {
+    _do_cache = do_cache;
+    _trutheval.do_caching(do_cache);
+  }
+  void set_strict(bool strict) {
+    _strict = strict;
+    _trutheval.set_strict(strict);
+  }
+  
   // access the clustereval (and its cached values)
   SvtxTruthEval* get_truth_eval() {return &_trutheval;}
   
@@ -61,6 +68,8 @@ private:
   PHG4HitContainer* _g4hits_tracker;
   PHG4TruthInfoContainer* _truthinfo;
 
+  bool _strict;
+  
   bool                                              _do_cache;
   std::map<SvtxHit*,std::set<PHG4Hit*> >            _cache_all_truth_hits;
   std::map<SvtxHit*,PHG4Hit*>                       _cache_max_truth_hit_by_energy;

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.C
@@ -16,6 +16,7 @@
 #include <set>
 #include <float.h>
 #include <algorithm>
+#include <cassert>
 
 using namespace std;
 
@@ -23,6 +24,7 @@ SvtxTrackEval::SvtxTrackEval(PHCompositeNode* topNode)
   : _clustereval(topNode),
     _trackmap(NULL),
     _clustermap(NULL),
+    _strict(true),
     _do_cache(true),
     _cache_all_truth_hits(),
     _cache_all_truth_particles(),
@@ -52,6 +54,9 @@ void SvtxTrackEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Hit*> SvtxTrackEval::all_truth_hits(SvtxTrack* track) {
 
+  if (_strict) assert(track);
+  else if (!track) return std::set<PHG4Hit*>();
+  
   if (_do_cache) {
     std::map<SvtxTrack*,std::set<PHG4Hit*> >::iterator iter =
       _cache_all_truth_hits.find(track);
@@ -69,6 +74,9 @@ std::set<PHG4Hit*> SvtxTrackEval::all_truth_hits(SvtxTrack* track) {
     unsigned int cluster_id = *iter;  
     SvtxCluster* cluster = _clustermap->get(cluster_id);
 
+    if (_strict) assert(cluster);
+    else if (!cluster) continue;
+    
     std::set<PHG4Hit*> new_hits = _clustereval.all_truth_hits(cluster);
 
     for (std::set<PHG4Hit*>::iterator jter = new_hits.begin();
@@ -85,6 +93,9 @@ std::set<PHG4Hit*> SvtxTrackEval::all_truth_hits(SvtxTrack* track) {
   
 std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track) {
 
+  if (_strict) assert(track);
+  else if (!track) return std::set<PHG4Particle*>();
+  
   if (_do_cache) {
     std::map<SvtxTrack*,std::set<PHG4Particle*> >::iterator iter =
       _cache_all_truth_particles.find(track);
@@ -102,6 +113,9 @@ std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track) {
     unsigned int cluster_id = *iter;
     SvtxCluster* cluster = _clustermap->get(cluster_id);
 
+    if (_strict) assert(cluster);
+    else if (!cluster) continue;
+    
     std::set<PHG4Particle*> new_particles = _clustereval.all_truth_particles(cluster);
 
     for (std::set<PHG4Particle*>::iterator jter = new_particles.begin();
@@ -118,6 +132,9 @@ std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track) {
 
 PHG4Particle* SvtxTrackEval::max_truth_particle_by_nclusters(SvtxTrack* track) {
 
+  if (_strict) assert(track);
+  else if (!track) return NULL;
+  
   if (_do_cache) {
     std::map<SvtxTrack*,PHG4Particle*>::iterator iter =
       _cache_max_truth_particle_by_nclusters.find(track);
@@ -149,6 +166,9 @@ PHG4Particle* SvtxTrackEval::max_truth_particle_by_nclusters(SvtxTrack* track) {
 
 std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle) { 
 
+  if (_strict) assert(truthparticle);
+  else if (!truthparticle) return std::set<SvtxTrack*>();
+  
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<SvtxTrack*> >::iterator iter =
       _cache_all_tracks_from_particle.find(truthparticle);
@@ -171,6 +191,9 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
       unsigned int cluster_id = *iter;
       SvtxCluster* cluster = _clustermap->get(cluster_id);
 
+      if (_strict) assert(cluster);
+      else if (!cluster) continue;
+      
       // loop over all particles
       std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster);
       for (std::set<PHG4Particle*>::iterator jter = particles.begin();
@@ -192,6 +215,9 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
 
 std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Hit* truthhit) {
 
+  if (_strict) assert(truthhit);
+  else if (!truthhit) return std::set<SvtxTrack*>();
+  
   if (_do_cache) {
     std::map<PHG4Hit*,std::set<SvtxTrack*> >::iterator iter =
       _cache_all_tracks_from_g4hit.find(truthhit);
@@ -215,6 +241,9 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Hit* truthhit) {
       unsigned int cluster_id = *iter;
       SvtxCluster* cluster = _clustermap->get(cluster_id);
 
+      if (_strict) assert(cluster);
+      else if (!cluster) continue;
+      
       // loop over all hits
       std::set<PHG4Hit*> hits = _clustereval.all_truth_hits(cluster);
       for (std::set<PHG4Hit*>::iterator jter = hits.begin();
@@ -236,6 +265,9 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Hit* truthhit) {
 
 SvtxTrack* SvtxTrackEval::best_track_from(PHG4Particle* truthparticle) { 
 
+  if (_strict) assert(truthparticle);
+  else if (!truthparticle) return NULL;
+  
   if (_do_cache) {
     std::map<PHG4Particle*,SvtxTrack*>::iterator iter =
       _cache_best_track_from_particle.find(truthparticle);
@@ -266,6 +298,13 @@ SvtxTrack* SvtxTrackEval::best_track_from(PHG4Particle* truthparticle) {
 // overlap calculations
 unsigned int SvtxTrackEval::get_nclusters_contribution(SvtxTrack* track, PHG4Particle* particle) {
 
+  if (_strict) {
+    assert(track);
+    assert(particle);
+  } else if (!track||!particle) {
+    return 0;
+  }
+  
   if (_do_cache) {
     std::map<std::pair<SvtxTrack*,PHG4Particle*>, unsigned int>::iterator iter =
       _cache_get_nclusters_contribution.find(make_pair(track,particle));
@@ -283,6 +322,9 @@ unsigned int SvtxTrackEval::get_nclusters_contribution(SvtxTrack* track, PHG4Par
     unsigned int cluster_id = *iter;
     SvtxCluster* cluster = _clustermap->get(cluster_id);
 
+    if (_strict) assert(cluster);
+    else if (!cluster) continue;     
+    
     // loop over all particles
     std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster);
     for (std::set<PHG4Particle*>::iterator jter = particles.begin();

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -24,7 +24,14 @@ public:
   virtual ~SvtxTrackEval() {}
 
   void next_event(PHCompositeNode *topNode);
-  void do_caching(bool do_cache) {_do_cache = do_cache;}
+  void do_caching(bool do_cache) {
+    _do_cache = do_cache;
+    _clustereval.do_caching(do_cache);
+  }
+  void set_strict(bool strict) {
+    _strict = strict;
+    _clustereval.set_strict(strict);
+  }
   
   // access the clustereval (and its cached values)
   SvtxClusterEval* get_cluster_eval() {return &_clustereval;}
@@ -54,6 +61,8 @@ private:
   SvtxTrackMap* _trackmap;
   SvtxClusterMap* _clustermap;
 
+  bool _strict;
+  
   bool                                                        _do_cache;
   std::map<SvtxTrack*,std::set<PHG4Hit*> >                    _cache_all_truth_hits;
   std::map<SvtxTrack*,std::set<PHG4Particle*> >               _cache_all_truth_particles;

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -21,6 +21,7 @@ SvtxTruthEval::SvtxTruthEval(PHCompositeNode* topNode)
   : _truthinfo(NULL),
     _g4hits_svtx(NULL),
     _g4hits_tracker(NULL),
+    _strict(true),
     _do_cache(true),
     _cache_all_truth_hits(),
     _cache_all_truth_hits_g4particle(),
@@ -82,6 +83,9 @@ std::set<PHG4Hit*> SvtxTruthEval::all_truth_hits() {
 
 std::set<PHG4Hit*> SvtxTruthEval::all_truth_hits(PHG4Particle* particle) {
 
+  if (_strict) assert(particle);
+  else if (!particle) return std::set<PHG4Hit*>();
+  
   if (_do_cache) {
     std::map<PHG4Particle*,std::set<PHG4Hit*> >::iterator iter =
       _cache_all_truth_hits_g4particle.find(particle);
@@ -123,6 +127,9 @@ std::set<PHG4Hit*> SvtxTruthEval::all_truth_hits(PHG4Particle* particle) {
 
 PHG4Hit* SvtxTruthEval::get_innermost_truth_hit(PHG4Particle* particle) {
 
+  if (_strict) assert(particle);
+  else if (!particle) return NULL;
+  
   PHG4Hit* innermost_hit = NULL;
   float innermost_radius = FLT_MAX;
   
@@ -145,6 +152,9 @@ PHG4Hit* SvtxTruthEval::get_innermost_truth_hit(PHG4Particle* particle) {
 
 PHG4Hit* SvtxTruthEval::get_outermost_truth_hit(PHG4Particle* particle) {
 
+  if (_strict) assert(particle);
+  else if (!particle) return NULL;
+  
   PHG4Hit* outermost_hit = NULL;
   float outermost_radius = FLT_MAX*-1.0;
   
@@ -167,17 +177,28 @@ PHG4Hit* SvtxTruthEval::get_outermost_truth_hit(PHG4Particle* particle) {
 
 PHG4Particle* SvtxTruthEval::get_particle(PHG4Hit* g4hit) {
 
+  if (_strict) assert(g4hit);
+  else if (!g4hit) return NULL;
+  
   PHG4Particle* particle = _truthinfo->GetHit( g4hit->get_trkid() );
+  if (_strict) assert(particle); 
+
   return particle;
 }
 
 int SvtxTruthEval::get_embed(PHG4Particle* particle) {
+
+  if (_strict) assert(particle);
+  else if (!particle) return 0;
 
   return _truthinfo->isEmbeded(particle->get_track_id());
 }
 
 bool SvtxTruthEval::is_primary(PHG4Particle* particle) {
 
+  if (_strict) assert(particle);
+  else if (!particle) return false;
+  
   bool is_primary = true;
   if (!_truthinfo->GetPrimaryHit(particle->get_track_id())) {
     is_primary = false;
@@ -188,20 +209,16 @@ bool SvtxTruthEval::is_primary(PHG4Particle* particle) {
 
 PHG4VtxPoint* SvtxTruthEval::get_vertex(PHG4Particle* particle) {
 
-  assert(particle);
+  if (_strict) assert(particle);
+  else if (!particle) return NULL;
 
   if (particle->get_primary_id() == -1) {
     return _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );  
   }
 
   PHG4VtxPoint* vtx = _truthinfo->GetVtx( particle->get_vtx_id() );
-
-  if (!vtx)
-    {
-      cout<<__PRETTY_FUNCTION__<<" - Error - missing vertex for G4 track:"<<endl;
-      particle->identify();
-    }
-
+  if (_strict) assert(vtx);
+ 
   return vtx;
 }
 

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -21,6 +21,7 @@ public:
 
   void next_event(PHCompositeNode *topNode);
   void do_caching(bool do_cache) {_do_cache = do_cache;}
+  void set_strict(bool strict) {_strict = strict;}
   
   std::set<PHG4Hit*> all_truth_hits();
   std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);
@@ -40,6 +41,8 @@ private:
   PHG4HitContainer* _g4hits_svtx;
   PHG4HitContainer* _g4hits_tracker;
 
+  bool _strict;
+  
   bool                                        _do_cache;
   std::set<PHG4Hit*>                          _cache_all_truth_hits;
   std::map<PHG4Particle*,std::set<PHG4Hit*> > _cache_all_truth_hits_g4particle;

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.h
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.h
@@ -27,6 +27,14 @@ public:
   virtual ~SvtxVertexEval() {}
 
   void next_event(PHCompositeNode *topNode);
+  void do_caching(bool do_cache) {
+    _do_cache = do_cache;
+    _trackeval.do_caching(do_cache);
+  }
+  void set_strict(bool strict) {
+    _strict = strict;
+    _trackeval.set_strict(strict);
+  }
   
   // access the sub evals (and the cached values)
   SvtxTrackEval*   get_track_eval() {return &_trackeval;}
@@ -57,6 +65,8 @@ private:
   SvtxTrackMap* _trackmap;
   PHG4TruthInfoContainer* _truthinfo;
 
+  bool _strict;
+  
   bool _do_cache;
   std::map<SvtxVertex*,std::set<PHG4Particle*> >               _cache_all_truth_particles;
   std::map<SvtxVertex*,std::set<PHG4VtxPoint*> >               _cache_all_truth_points;


### PR DESCRIPTION
@blackcathj Here is the option for adding defensive depth to the evaluation. Can you try this on the gutted embedding macro? You will need to call eval->set_strict(false) in the detector macros. It adds lookup protection pretty much everywhere and specifically in the spots you were modifying previously, but it is possible I let something slip through.