### PR TITLE
add option to save hcal absorber hits in truth info

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -42,12 +42,12 @@ bool PHG4CylinderSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
   const G4Track* aTrack = aStep->GetTrack();
 
   // if this cylinder stops everything, just put all kinetic energy into edep
-   if (detector_->IsBlackHole())
-     {
-        edep = aTrack->GetKineticEnergy()/GeV;
-        G4Track* killtrack = const_cast<G4Track *> (aTrack);
-        killtrack->SetTrackStatus(fStopAndKill);
-     }
+  if (detector_->IsBlackHole())
+    {
+      edep = aTrack->GetKineticEnergy()/GeV;
+      G4Track* killtrack = const_cast<G4Track *> (aTrack);
+      killtrack->SetTrackStatus(fStopAndKill);
+    }
 
   int layer_id = detector_->get_Layer();
   // test if we are active
@@ -64,11 +64,11 @@ bool PHG4CylinderSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
 	}
       G4StepPoint * prePoint = aStep->GetPreStepPoint();
       G4StepPoint * postPoint = aStep->GetPostStepPoint();
-//        cout << "time prepoint: " << prePoint->GetGlobalTime()/ns << endl;
-//        cout << "time postpoint: " << postPoint->GetGlobalTime()/ns << endl;
-//        cout << "kinetic energy: " <<  aTrack->GetKineticEnergy()/GeV << endl;
-//       G4ParticleDefinition* def = aTrack->GetDefinition();
-//       cout << "Particle: " << def->GetParticleName() << endl;
+      //        cout << "time prepoint: " << prePoint->GetGlobalTime()/ns << endl;
+      //        cout << "time postpoint: " << postPoint->GetGlobalTime()/ns << endl;
+      //        cout << "kinetic energy: " <<  aTrack->GetKineticEnergy()/GeV << endl;
+      //       G4ParticleDefinition* def = aTrack->GetDefinition();
+      //       cout << "Particle: " << def->GetParticleName() << endl;
       switch (prePoint->GetStepStatus())
         {
         case fGeomBoundary:
@@ -141,13 +141,13 @@ bool PHG4CylinderSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
 	}
       if (edep > 0)
 	{
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	      {
-		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		  {
-		    pp->SetKeep(1); // we want to keep the track
-		  }
-	      }
+	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+	    {
+	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		{
+		  pp->SetKeep(1); // we want to keep the track
+		}
+	    }
 	}
       //    hit->identify();
       // return true to indicate the hit was used

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.cc
@@ -28,7 +28,8 @@ PHG4InnerHcalParameters::PHG4InnerHcalParameters():
   ncross(4),
   blackhole(0),
   material("SS310"),
-  steplimits(NAN)
+  steplimits(NAN),
+  absorbertruth(0)
 {}
 
 void

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.cc
@@ -25,7 +25,7 @@ PHG4InnerHcalParameters::PHG4InnerHcalParameters():
   z_rot(0*deg),
   active(0),
   absorberactive(0),
-  ncross(0),
+  ncross(4),
   blackhole(0),
   material("SS310"),
   steplimits(NAN)

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.h
@@ -33,6 +33,7 @@ class PHG4InnerHcalParameters
   G4int blackhole;
   G4String material;
   G4double steplimits;
+  G4int absorbertruth;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -1,5 +1,6 @@
 #include "PHG4InnerHcalSteppingAction.h"
 #include "PHG4InnerHcalDetector.h"
+#include "PHG4InnerHcalParameters.h"
 
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
@@ -31,12 +32,13 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction( PHG4InnerHcalDetector* detector ):
+PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction( PHG4InnerHcalDetector* detector, PHG4InnerHcalParameters *parameters):
   PHG4SteppingAction(NULL),
   detector_( detector ),
   hits_(NULL),
   absorberhits_(NULL),
   hit(NULL),
+  params(parameters),
   light_balance_(false),
   light_balance_inner_radius_(NAN),
   light_balance_inner_corr_(NAN),
@@ -242,7 +244,7 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
           hit->set_eion(-1);
 	}
-      if (edep > 0)
+      if (edep > 0 && (whichactive > 0 || params->absorbertruth > 0))
 	{
 	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	    {

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -4,6 +4,7 @@
 #include "g4main/PHG4SteppingAction.h"
 
 class PHG4InnerHcalDetector;
+class PHG4InnerHcalParameters;
 class PHG4Hit;
 class PHG4HitContainer;
 
@@ -13,7 +14,7 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   public:
 
   //! constructor
-  PHG4InnerHcalSteppingAction( PHG4InnerHcalDetector* );
+  PHG4InnerHcalSteppingAction( PHG4InnerHcalDetector*, PHG4InnerHcalParameters *parameters );
 
   //! destroctor
   virtual ~PHG4InnerHcalSteppingAction()
@@ -44,6 +45,7 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   PHG4HitContainer * hits_;
   PHG4HitContainer * absorberhits_;
   PHG4Hit *hit;
+  PHG4InnerHcalParameters *params;
 
   bool  light_balance_;
   float light_balance_inner_radius_;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -92,7 +92,7 @@ int PHG4InnerHcalSubsystem::InitRun( PHCompositeNode* topNode )
 	}
 
       // create stepping action
-      steppingAction_ = new PHG4InnerHcalSteppingAction(detector_);
+      steppingAction_ = new PHG4InnerHcalSteppingAction(detector_, params);
 
     }
   else
@@ -100,7 +100,7 @@ int PHG4InnerHcalSubsystem::InitRun( PHCompositeNode* topNode )
       // if this is a black hole it does not have to be active
       if (params->blackhole)
 	{
-	  steppingAction_ = new PHG4InnerHcalSteppingAction(detector_);
+	  steppingAction_ = new PHG4InnerHcalSteppingAction(detector_, params);
 	}
     }
   return 0;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -145,6 +145,7 @@ void
 PHG4InnerHcalSubsystem::SetTiltAngle(const double tilt)
 {
   params->tilt_angle = tilt * deg;
+  params->ncross = 0;
 }
 
 double

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalParameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalParameters.cc
@@ -25,7 +25,7 @@ PHG4OuterHcalParameters::PHG4OuterHcalParameters():
   z_rot(0*deg),
   active(0),
   absorberactive(0),
-  ncross(0),
+  ncross(-4),
   blackhole(0),
   material("G4_Fe"),
   steplimits(NAN),

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalParameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalParameters.cc
@@ -37,7 +37,8 @@ PHG4OuterHcalParameters::PHG4OuterHcalParameters():
   light_balance_outer_radius(10.0),
   light_balance_outer_corr(1.0),
   magnet_cutout(12.*cm),
-  magnet_cutout_first_scinti(8) // tile start at 0, drawing tile starts at 1
+  magnet_cutout_first_scinti(8), // tile start at 0, drawing tile starts at 1
+  absorbertruth(0)
 {}
 
 void

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalParameters.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalParameters.h
@@ -41,6 +41,7 @@ class PHG4OuterHcalParameters
   G4double light_balance_outer_corr;
   G4double magnet_cutout;
   G4int magnet_cutout_first_scinti;
+  G4int absorbertruth;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -2,8 +2,6 @@
 #include "PHG4OuterHcalDetector.h"
 #include "PHG4OuterHcalParameters.h"
 
-
-#include <TH2F.h>
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllServer.h>
 #include <Geant4/G4TransportationManager.hh>
@@ -18,6 +16,8 @@
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <fun4all/getClass.h>
+
+#include <TH2F.h>
 
 #include <Geant4/G4Step.hh>
 #include <Geant4/G4MaterialCutsCouple.hh>
@@ -63,9 +63,9 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
   // returns 
   //  0 is outside of OuterHcal
   //  1 is inside scintillator
-  // -1 is steel absorber
+  // -1 is steel absorber (if absorber set to active)
 
-  int whichactive = detector_->IsInOuterHcal(volume);
+  int whichactive = detector_->IsInOuterHcal(volume); 
 
   if (!whichactive)
     {
@@ -73,27 +73,29 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
     }
 
   if (params->enable_field_checker)
-    FieldChecker(aStep);
+    {
+      FieldChecker(aStep);
+    }
 
   unsigned int motherid = ~0x0; // initialize to 0xFFFFFF using the correct bitness
   int tower_id = -1;
   if (whichactive > 0) // scintillator
     {
-// G4AssemblyVolumes naming convention:
-//     av_WWW_impr_XXX_YYY_ZZZ
-// where:
+      // G4AssemblyVolumes naming convention:
+      //     av_WWW_impr_XXX_YYY_ZZZ
+      // where:
 
-//     WWW - assembly volume instance number
-//     XXX - assembly volume imprint number
-//     YYY - the name of the placed logical volume
-//     ZZZ - the logical volume index inside the assembly volume
-// e.g. av_1_impr_82_HcalOuterScinti_11_pv_11
-// 82 the number of the scintillator mother volume
-// HcalOuterScinti_11: name of scintillator slat
-// 11: number of scintillator slat logical volume
-// use boost tokenizer to separate the _, then take value
-// after "impr" for mother volume and after "pv" for scintillator slat
-// use boost lexical cast for string -> int conversion
+      //     WWW - assembly volume instance number
+      //     XXX - assembly volume imprint number
+      //     YYY - the name of the placed logical volume
+      //     ZZZ - the logical volume index inside the assembly volume
+      // e.g. av_1_impr_82_HcalOuterScinti_11_pv_11
+      // 82 the number of the scintillator mother volume
+      // HcalOuterScinti_11: name of scintillator slat
+      // 11: number of scintillator slat logical volume
+      // use boost tokenizer to separate the _, then take value
+      // after "impr" for mother volume and after "pv" for scintillator slat
+      // use boost lexical cast for string -> int conversion
       boost::char_separator<char> sep("_");
       boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
       boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
@@ -153,7 +155,7 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 	{
 	case fGeomBoundary:
 	case fUndefined:
-    hit = new PHG4Hitv1();
+	  hit = new PHG4Hitv1();
 	  hit->set_layer(motherid);
 	  hit->set_scint_id(tower_id); // the slat id (or steel plate id)
 	  //here we set the entrance values in cm
@@ -178,7 +180,7 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 	  //set the initial energy deposit
 	  hit->set_edep(0);
 	  hit->set_eion(0); // only implemented for v5 otherwise empty
-    hit->set_light_yield(0);
+	  hit->set_light_yield(0);
 	  if (whichactive > 0) // return of IsInOuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
 	    {
 	      // Now add the hit
@@ -237,8 +239,8 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
           if (params->light_balance)
             {
               float r = sqrt(
-                  pow(postPoint->GetPosition().x() / cm, 2)
-                      + pow(postPoint->GetPosition().y() / cm, 2));
+			     pow(postPoint->GetPosition().x() / cm, 2)
+			     + pow(postPoint->GetPosition().y() / cm, 2));
               const float cor = GetLightCorrection(r);
               light_yield = light_yield * cor;
 
@@ -273,7 +275,7 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
           hit->set_eion(-1);
 	}
-      if (edep > 0)
+      if (edep > 0 && (whichactive > 0 || params->absorbertruth > 0))
 	{
 	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	    {

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -134,6 +134,7 @@ void
 PHG4OuterHcalSubsystem::SetTiltAngle(const double tilt)
 {
   params->tilt_angle = tilt * deg;
+  params->ncross = 0;
 }
 
 double


### PR DESCRIPTION
To save space by default absorber hits are not added to particles which are added to the truth table. Minor change: default is now 4 crossings for inner and -4 for outer hcal like what is in the preCDR. One does not need to set any options in the macro to get the correct default