### PR TITLE
move use of existing vertex into generator base class

### DIFF
--- a/simulation/g4simulation/g4main/PHG4ParticleGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGenerator.cc
@@ -75,7 +75,10 @@ PHG4ParticleGenerator::process_event(PHCompositeNode *topNode)
 {
   PHG4InEvent *ineve = findNode::getClass<PHG4InEvent>(topNode,"PHG4INEVENT");
 
-  vtx_z = (z_max-z_min)*gsl_rng_uniform_pos(RandomGenerator) + z_min;
+  if (! ReuseExistingVertex(topNode))
+    {
+      vtx_z = (z_max-z_min)*gsl_rng_uniform_pos(RandomGenerator) + z_min;
+    }
   int vtxindex = ineve->AddVtx(vtx_x,vtx_y,vtx_z,t0);
 
   vector<PHG4Particle *>::const_iterator iter;

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
@@ -27,10 +27,19 @@ class PHG4ParticleGeneratorBase: public SubsysReco
   virtual void set_vtx(const double x, const double y, const double z);
   virtual void set_t0(const double t) {t0 = t;}
 
+  virtual double get_vtx_x() const {return vtx_x;}
+  virtual double get_vtx_y() const {return vtx_y;}
+  virtual double get_vtx_z() const {return vtx_z;}
+  virtual double get_t0() const {return t0;}
+
   virtual void Print(const std::string &what = "ALL") const;
   virtual void AddParticle(const std::string &particle, const double x, const double y, const double z);
   virtual void AddParticle(const int pid, const double x, const double y, const double z);
   virtual void Embed(const int i=1) {embedflag = i;}
+  virtual int ReuseExistingVertex(PHCompositeNode *topNode);
+
+  int get_reuse_existing_vertex() const {return reuse_existing_vertex;}
+  void set_reuse_existing_vertex(const int i = 1) {reuse_existing_vertex = i;}
   void set_seed(const unsigned int iseed);
   unsigned int get_seed() const {return seed;}
 
@@ -42,6 +51,7 @@ class PHG4ParticleGeneratorBase: public SubsysReco
   void CheckAndCreateParticleVector();
   void SetParticleId(PHG4Particle *particle, PHG4InEvent *ineve);
   int embedflag;
+  int reuse_existing_vertex;
   double vtx_x;
   double vtx_y;
   double vtx_z;

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
@@ -131,17 +131,19 @@ PHG4ParticleGeneratorD0::process_event(PHCompositeNode *topNode)
   double cc = GSL_CONST_CGSM_SPEED_OF_LIGHT; // speed of light cm/sec
   double ctau = tau*cc*1.0e+04;  // ctau in micrometers
 
-  // Randomly generate vertex position in z 
-
-  if (vtx_zmax != vtx_zmin)
+  // If not reusing existing vertex Randomly generate vertex position in z 
+  if (! ReuseExistingVertex(topNode))
     {
-      vtx_z = (vtx_zmax - vtx_zmin) * gsl_rng_uniform_pos(RandomGenerator) + vtx_zmin;
-    }
-  else
-    {
-      vtx_z = vtx_zmin;
-    }
 
+      if (vtx_zmax != vtx_zmin)
+	{
+	  vtx_z = (vtx_zmax - vtx_zmin) * gsl_rng_uniform_pos(RandomGenerator) + vtx_zmin;
+	}
+      else
+	{
+	  vtx_z = vtx_zmin;
+	}
+    }
   // taken randomly from a fitted pT distribution to Pythia Upsilons
 
   double pt = 0.0;

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -189,15 +189,17 @@ PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
 {
   PHG4InEvent *ineve = findNode::getClass<PHG4InEvent>(topNode,"PHG4INEVENT");
 
-  // Randomly generate vertex position in z 
-
-  if (vtx_zmax != vtx_zmin)
+  // If not reusing existing vertex Randomly generate vertex position in z 
+  if (! ReuseExistingVertex(topNode))
     {
-      vtx_z = (vtx_zmax - vtx_zmin) * gsl_rng_uniform_pos(RandomGenerator) + vtx_zmin;
-    }
-  else
-    {
-      vtx_z = vtx_zmin;
+      if (vtx_zmax != vtx_zmin)
+	{
+	  vtx_z = (vtx_zmax - vtx_zmin) * gsl_rng_uniform_pos(RandomGenerator) + vtx_zmin;
+	}
+      else
+	{
+	  vtx_z = vtx_zmin;
+	}
     }
   int vtxindex = ineve->AddVtx(vtx_x,vtx_y,vtx_z,t0);
 

--- a/simulation/g4simulation/g4main/PHG4ParticleGun.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGun.cc
@@ -28,6 +28,7 @@ int
 PHG4ParticleGun::process_event(PHCompositeNode *topNode)
 {
   PHG4InEvent *ineve = findNode::getClass<PHG4InEvent>(topNode,"PHG4INEVENT");
+  ReuseExistingVertex(topNode); // checks if we should reuse existing vertex
   int vtxindex = ineve->AddVtx(vtx_x,vtx_y,vtx_z,t0);
   vector<PHG4Particle *>::const_iterator iter;
   for (iter = particlelist.begin(); iter != particlelist.end(); ++iter)

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
@@ -226,27 +226,20 @@ int PHG4SimpleEventGenerator::InitRun(PHCompositeNode *topNode) {
 
 int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
 
-  double vertex_x = 0.0;
-  double vertex_y = 0.0;
-  double vertex_z = 0.0;
-
-  if (ReuseExistingVertex(topNode))
-    {
-      vertex_x = get_vtx_x();
-      vertex_y = get_vtx_y();
-      vertex_z = get_vtx_z();
-    }
-  else
+  // vtx_x, vtx_y and vtx_z are doubles from the base class
+  // common methods modify those, please no private copies
+  // at some point we might rely on them being up to date
+  if (!ReuseExistingVertex(topNode))
     {
       // generate a new vertex point
-      vertex_x = smearvtx(_vertex_x,_vertex_width_x,_vertex_func_x);
-      vertex_y = smearvtx(_vertex_y,_vertex_width_y,_vertex_func_y);
-      vertex_z = smearvtx(_vertex_z,_vertex_width_z,_vertex_func_z);
+      vtx_x = smearvtx(_vertex_x,_vertex_width_x,_vertex_func_x);
+      vtx_y = smearvtx(_vertex_y,_vertex_width_y,_vertex_func_y);
+      vtx_z = smearvtx(_vertex_z,_vertex_width_z,_vertex_func_z);
     } 
 
-  vertex_x += _vertex_offset_x;
-  vertex_y += _vertex_offset_y;
-  vertex_z += _vertex_offset_z;
+  vtx_x += _vertex_offset_x;
+  vtx_y += _vertex_offset_y;
+  vtx_z += _vertex_offset_z;
 
   int vtxindex = -1;
   int trackid = -1;
@@ -270,9 +263,9 @@ int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
         y *= r;
         z *= r;
 
-	vtxindex = _ineve->AddVtx(vertex_x+x,vertex_y+y,vertex_z+z,0.0);
+	vtxindex = _ineve->AddVtx(vtx_x+x,vtx_y+y,vtx_z+z,0.0);
       } else if ((i==0)&&(j==0)) {
-	vtxindex = _ineve->AddVtx(vertex_x,vertex_y,vertex_z,0.0);
+	vtxindex = _ineve->AddVtx(vtx_x,vtx_y,vtx_z,0.0);
       }
 
       ++trackid;

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.h
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.h
@@ -49,9 +49,6 @@ public:
   //! set the width of the vertex distribution function about the mean
   void set_vertex_distribution_width(const double x, const double y, const double z);
 
-  //! reuse the first existing vertex found
-  void set_reuse_existing_vertex(const bool b) {_reuse_existing_vertex = b;}
-
   //! set an offset vector from the existing vertex
   void set_existing_vertex_offset_vector(const double x, const double y, const double z);
   
@@ -68,7 +65,6 @@ private:
   // can be translated using the GEANT4 lookup
   std::vector<std::pair<int, unsigned int> > _particle_codes; // <pdgcode, count>
   std::vector<std::pair<std::string, unsigned int> > _particle_names; // <names, count>
-  bool _reuse_existing_vertex;
   FUNCTION _vertex_func_x;
   FUNCTION _vertex_func_y;
   FUNCTION _vertex_func_z;


### PR DESCRIPTION
I moved that code from the simple event generator into the PHG4ParticleGeneratorBase class and added a call to it to the other single particle generators. It works as before - please in the future put common functionality like this into the base class. Less work for everyone else