### PR TITLE
New truth matching conditions to handle truth table copies during embedding

### DIFF
--- a/simulation/g4simulation/g4eval/BaseTruthEval.C
+++ b/simulation/g4simulation/g4eval/BaseTruthEval.C
@@ -1,0 +1,226 @@
+
+#include "BaseTruthEval.h"
+
+#include <fun4all/getClass.h>
+#include <phool/PHCompositeNode.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4Hit.h>
+
+#include <cstdlib>
+#include <float.h>
+#include <cassert>
+#include <iostream>
+
+using namespace std;
+
+BaseTruthEval::BaseTruthEval(PHCompositeNode* topNode)
+  : _truthinfo(NULL),
+    _strict(true) {
+  get_node_pointers(topNode);
+}
+
+void BaseTruthEval::next_event(PHCompositeNode* topNode) {
+  get_node_pointers(topNode);
+}
+      
+PHG4Particle* BaseTruthEval::get_particle(PHG4Hit* g4hit) {
+
+  if (_strict) assert(g4hit);
+  else if (!g4hit) return NULL;
+  
+  PHG4Particle* particle = _truthinfo->GetHit( g4hit->get_trkid() );
+  if (_strict) assert(particle); 
+
+  return particle;
+}
+
+int BaseTruthEval::get_embed(PHG4Particle* particle) {
+
+  if (_strict) assert(particle);
+  else if (!particle) return 0;
+
+  if (!is_primary(particle)) return 0;
+
+  PHG4Particle* primary = get_primary(particle);
+  if (_strict) assert(primary);
+  else if (!primary) return 0;
+  
+  return _truthinfo->isEmbeded(primary->get_track_id());
+}
+
+PHG4VtxPoint* BaseTruthEval::get_vertex(PHG4Particle* particle) {
+
+  if (_strict) assert(particle);
+  else if (!particle) return NULL;
+
+  if (particle->get_primary_id() == -1) {
+    return _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );  
+  }
+
+  PHG4VtxPoint* vtx = _truthinfo->GetVtx( particle->get_vtx_id() );
+  if (_strict) assert(vtx);
+ 
+  return vtx;
+}
+
+bool BaseTruthEval::is_primary(PHG4Particle* particle) {
+
+  if (_strict) assert(particle);
+  else if (!particle) return false;
+  
+  bool is_primary = false;
+  if (particle->get_parent_id() == 0) {
+    is_primary = true;
+  }
+  
+  return is_primary;
+}
+
+PHG4Particle* BaseTruthEval::get_primary(PHG4Hit* g4hit) {
+
+  if (_strict) assert(g4hit);
+  else if (!g4hit) return NULL;
+
+  PHG4Particle* particle = get_particle(g4hit);
+  PHG4Particle* primary = get_primary(particle);
+
+  if (_strict) assert(primary);
+  
+  return primary;
+}
+
+PHG4Particle* BaseTruthEval::get_primary(PHG4Particle* particle) {
+
+  if (_strict) assert(particle);
+  else if (!particle) return NULL;
+
+  // always report the primary from the Primary Map regardless if a
+  // primary from the full Map was the argument
+  PHG4Particle* returnval = NULL;
+  if (particle->get_primary_id() != -1) {
+    returnval = _truthinfo->GetPrimaryHit( particle->get_primary_id() );
+  } else {
+    returnval = _truthinfo->GetPrimaryHit( particle->get_track_id() );
+  }
+
+  if (_strict) assert(returnval);
+  
+  return returnval;
+}
+
+ bool BaseTruthEval::is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle) {
+
+  if (_strict) {
+    assert(g4hit);
+    assert(particle);
+  } else if (!g4hit||!particle) {
+    return false;
+  }
+
+  bool is_from_particle = false;
+
+  PHG4Particle* candidate = get_particle(g4hit);
+  if (_strict) assert(candidate);
+
+  if (candidate) {
+    if (are_same_particle(candidate,particle)) {
+      is_from_particle = true;
+    }
+  }
+
+  return is_from_particle;
+}
+
+bool BaseTruthEval::are_same_particle(PHG4Particle* p1, PHG4Particle* p2) {
+
+  if (_strict) {
+    assert(p1);
+    assert(p2);
+  } else if (!p1||!p2) {
+    return false;
+  }
+
+  bool are_same_particle = false;
+
+  // get ready for some insanity... I have to deal with the case where
+  // the primary particles are copied between the two truth containers
+  // but have different track ids
+  
+  if ((p1->get_primary_id() == -1) &&
+      (p2->get_primary_id() == -1)) {
+    // both particles are from the primary truth map, use track ids
+    if (p1->get_track_id() == p2->get_track_id()) {
+      are_same_particle = true;
+    }
+  } else if ((p1->get_primary_id() != -1) &&
+	     (p2->get_primary_id() != -1)) {
+    // both particles are from the total truth map, use track ids
+    if (p1->get_track_id() == p2->get_track_id()) {
+      are_same_particle = true;
+    }
+  } else if (is_primary(p1) && is_primary(p2)) {
+    // both particles are primary
+    if ((p1->get_primary_id() == -1) &&
+	(p2->get_primary_id() != -1)) {
+      // only the first particle is from the primary truth map, use one track id and one primary id
+      if (p1->get_track_id() == p2->get_primary_id()) {
+	are_same_particle = true;
+      }
+    } else if ((p1->get_primary_id() != -1) &&
+	       (p2->get_primary_id() == -1)) {
+      // only the second particle is from the primary truth map, use one track id and one primary id
+      if (p1->get_primary_id() == p2->get_track_id()) {
+	are_same_particle = true;
+      }
+    }
+  }
+ 
+  return are_same_particle;
+}
+
+bool BaseTruthEval::are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2) {
+
+  if (_strict) {
+    assert(vtx1);
+    assert(vtx2);
+  } else if (!vtx1||!vtx2) {
+    return false;
+  }
+
+  bool are_same_vertex = false;
+
+  // I will need to deal with copies of vertex points too, argh!
+  // Here I have very few options, we can either match the vertexes by
+  // id or by position there is no ancestry to utilize
+
+  // in the embedded dst it is 100% sure the first method will fail
+  // since I can't trace between vertexes and the vertex ids have changed
+  // I guess I will have to resort to the second method, which means there
+  // is some possiblity of having a position collision between two vertexes
+  // that are in fact different in terms of content
+  
+  //  if (vtx1->get_id() == vtx2->get_id()) {
+  //    are_same_vertex = true;
+  //  }
+
+  if ((vtx1->get_x() == vtx2->get_x()) &&
+      (vtx1->get_y() == vtx2->get_y()) &&
+      (vtx1->get_z() == vtx2->get_z()) &&
+      (vtx1->get_t() == vtx2->get_t())) {
+    are_same_vertex = true;
+  }
+ 
+  return are_same_vertex;
+}
+  
+void BaseTruthEval::get_node_pointers(PHCompositeNode* topNode) {
+
+  _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
+  if (!_truthinfo) {
+    cerr << PHWHERE << " ERROR: Can't find G4TruthInfo" << endl;
+    exit(-1);
+  }
+  
+  return;
+}

--- a/simulation/g4simulation/g4eval/BaseTruthEval.h
+++ b/simulation/g4simulation/g4eval/BaseTruthEval.h
@@ -1,0 +1,42 @@
+
+#ifndef __BASETRUTHEVAL_H__
+#define __BASETRUTHEVAL_H__
+
+#include <phool/PHCompositeNode.h>
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4VtxPoint.h>
+
+class BaseTruthEval {
+
+public:
+
+  BaseTruthEval(PHCompositeNode *topNode);
+  virtual ~BaseTruthEval() {}
+
+  void next_event(PHCompositeNode *topNode);
+  void set_strict(bool strict) {_strict = strict;}
+  
+  PHG4Particle*      get_particle(PHG4Hit* g4hit);  
+  int                get_embed(PHG4Particle* particle);
+  PHG4VtxPoint*      get_vertex(PHG4Particle* particle);
+
+  bool               is_primary(PHG4Particle* particle);
+  PHG4Particle*      get_primary(PHG4Hit* g4hit);
+  PHG4Particle*      get_primary(PHG4Particle* particle);  
+
+  bool               is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle);
+  bool               are_same_particle(PHG4Particle* p1, PHG4Particle* p2);
+  bool               are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2);
+    
+private:
+
+  void get_node_pointers(PHCompositeNode* topNode);
+  
+  PHG4TruthInfoContainer* _truthinfo;
+
+  bool _strict;
+};
+
+#endif // __BASETRUTHEVAL_H__

--- a/simulation/g4simulation/g4eval/BaseTruthEvalLinkDef.C
+++ b/simulation/g4simulation/g4eval/BaseTruthEvalLinkDef.C
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class BaseTruthEval-;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.C
@@ -224,8 +224,8 @@ std::set<RawCluster*> CaloRawClusterEval::all_clusters_from(PHG4Particle* primar
 
       if (_strict) assert(candidate);
       else if (!candidate) continue;
-      
-      if (candidate->get_track_id() == primary->get_track_id()) {
+
+      if (get_truth_eval()->are_same_particle(candidate,primary)) {
 	clusters.insert(cluster);
       }    
     }
@@ -320,8 +320,8 @@ float CaloRawClusterEval::get_energy_contribution(RawCluster* cluster, PHG4Parti
 
       if (_strict) assert(candidate);
       else if (!candidate) continue;
-      
-      if (candidate->get_track_id() == primary->get_track_id()) {
+
+      if (get_truth_eval()->are_same_particle(candidate,primary)) {
 	energy += g4hit->get_edep();
       }
     }    

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -213,8 +213,8 @@ std::set<RawTower*> CaloRawTowerEval::all_towers_from(PHG4Particle* primary) {
 
       if (_strict) assert(candidate);
       else if (!candidate) continue;
-      
-      if (candidate->get_track_id() == primary->get_track_id()) {
+
+      if (get_truth_eval()->are_same_particle(candidate,primary)) {
 	towers.insert(tower);
       }    
     }
@@ -310,7 +310,7 @@ float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* p
       if (_strict) assert(candidate);
       else if (!candidate) continue;
 
-      if (candidate->get_track_id() == primary->get_track_id()) {
+      if (get_truth_eval()->are_same_particle(candidate,primary)) {
 	energy += g4hit->get_edep();
       }
     }

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -127,8 +127,17 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Hit* g4hit) {
 }
 
 int CaloTruthEval::get_embed(PHG4Particle* particle) {
+
+  if (_strict) assert(particle);
+  else if (!particle) return NULL; 
+
+  if (!is_primary(particle)) return 0;
+
+  PHG4Particle* primary = get_primary_particle(particle);
+  if (_strict) assert(primary);
+  else if (!primary) return 0;
   
-  return _truthinfo->isEmbeded(particle->get_track_id());
+  return _truthinfo->isEmbeded(primary->get_track_id());
 }
 
 PHG4VtxPoint* CaloTruthEval::get_vertex(PHG4Particle* particle) {

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -1,6 +1,8 @@
 
 #include "CaloTruthEval.h"
 
+#include "BaseTruthEval.h"
+
 #include <fun4all/getClass.h>
 #include <phool/PHCompositeNode.h>
 #include <g4main/PHG4TruthInfoContainer.h>
@@ -66,7 +68,7 @@ std::set<PHG4Hit*> CaloTruthEval::all_truth_hits(PHG4Particle* particle) {
        ++g4iter) {
 
     PHG4Hit* g4hit = g4iter->second;
-    if (g4hit->get_trkid() != particle->get_track_id()) continue;
+    if (is_g4hit_from_particle(g4hit,particle)) continue;
     truth_hits.insert(g4hit);
   }
   
@@ -150,7 +152,7 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
     if (_strict) assert(candidate);
     else if (!candidate) continue;
 
-    if (candidate->get_track_id() != primary->get_track_id()) continue;
+    if (are_same_particle(candidate,primary)) continue;
     truth_hits.insert(g4hit);
   }
 
@@ -274,6 +276,18 @@ float CaloTruthEval::get_shower_energy_deposit(PHG4Particle* primary) {
   if (_do_cache) _cache_get_shower_energy_deposit.insert(make_pair(primary,shower_e));
   
   return shower_e;
+}
+
+bool CaloTruthEval::is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle) {
+  return _basetrutheval.is_g4hit_from_particle(g4hit,particle);
+}
+
+bool CaloTruthEval::are_same_particle(PHG4Particle* p1, PHG4Particle* p2) {
+  return _basetrutheval.are_same_particle(p1,p2);
+}
+
+bool CaloTruthEval::are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2) {
+  return _basetrutheval.are_same_vertex(vtx1,vtx2);
 }
 
 void CaloTruthEval::get_node_pointers(PHCompositeNode *topNode) {

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -153,10 +153,10 @@ bool CaloTruthEval::is_primary(PHG4Particle* particle) {
 
   if (_strict) assert(particle);
   else if (!particle) return false;
-  
-  bool is_primary = true;
-  if (!_truthinfo->GetPrimaryHit(particle->get_track_id())) {
-    is_primary = false;
+
+  bool is_primary = false;
+  if (particle->get_parent_id() == 0) {
+    is_primary = true;
   }
   
   return is_primary;

--- a/simulation/g4simulation/g4eval/CaloTruthEval.h
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.h
@@ -34,6 +34,10 @@ public:
   int                get_embed(PHG4Particle* particle);
   PHG4VtxPoint*      get_vertex(PHG4Particle* particle);
 
+  bool               is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle);
+  bool               are_same_particle(PHG4Particle* p1, PHG4Particle* p2);
+  bool               are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2);
+  
   bool               is_primary(PHG4Particle* particle);
   std::set<PHG4Hit*> get_shower_from_primary(PHG4Particle* primary);  
   float              get_shower_moliere_radius(PHG4Particle* primary);

--- a/simulation/g4simulation/g4eval/CaloTruthEval.h
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.h
@@ -25,7 +25,10 @@ public:
 
   void next_event(PHCompositeNode *topNode);
   void do_caching(bool do_cache) {_do_cache = do_cache;}
-  void set_strict(bool strict) {_strict = strict;}
+  void set_strict(bool strict) {
+    _strict = strict;
+    _basetrutheval.set_strict(strict);
+  }
 
   std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);  
   PHG4Particle*      get_parent_particle(PHG4Hit* g4hit);

--- a/simulation/g4simulation/g4eval/CaloTruthEval.h
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.h
@@ -2,6 +2,8 @@
 #ifndef __CALOTRUTHEVAL_H__
 #define __CALOTRUTHEVAL_H__
 
+#include "BaseTruthEval.h"
+
 #include <phool/PHCompositeNode.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 
@@ -40,6 +42,8 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode *topNode);
+
+  BaseTruthEval _basetrutheval;
   
   std::string _caloname;
   PHG4TruthInfoContainer* _truthinfo;

--- a/simulation/g4simulation/g4eval/JetTruthEval.C
+++ b/simulation/g4simulation/g4eval/JetTruthEval.C
@@ -210,7 +210,12 @@ Jet* JetTruthEval::get_truth_jet(PHG4Particle* particle) {
 	 jter != candidate->end_comp();
 	 ++jter) {
       unsigned int index = jter->second;
-      if (index == (unsigned int)particle->get_track_id()) {
+      
+      PHG4Particle* constituent = _truthinfo->GetHit( index );
+      if (_strict) assert(constituent);
+      else if (!constituent) continue;
+
+      if (get_svtx_eval_stack()->get_truth_eval()->are_same_particle(constituent,particle)) {
 	truth_jet = candidate;
 	break;
       }

--- a/simulation/g4simulation/g4eval/Makefile.am
+++ b/simulation/g4simulation/g4eval/Makefile.am
@@ -26,6 +26,7 @@ libg4eval_la_LIBADD = \
   -lg4jets_io
 
 pkginclude_HEADERS = \
+  BaseTruthEval.h \
   CaloEvalStack.h \
   CaloTruthEval.h \
   CaloRawTowerEval.h \
@@ -46,6 +47,7 @@ pkginclude_HEADERS = \
 #pkginclude_HEADERS = $(include_HEADERS)
 
 libg4eval_la_SOURCES = \
+  BaseTruthEval.C \
   CaloEvalStack.C \
   CaloEvalStack_Dict.C \
   CaloTruthEval.C \

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.C
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.C
@@ -228,7 +228,7 @@ std::set<SvtxCluster*> SvtxClusterEval::all_clusters_from(PHG4Particle* truthpar
 	 jter != particles.end();
 	 ++jter) {
       PHG4Particle* candidate = *jter;
-      if (candidate->get_track_id() == truthparticle->get_track_id()) {
+      if (get_truth_eval()->are_same_particle(candidate,truthparticle)) {
 	clusters.insert(cluster);
       }    
     }
@@ -334,7 +334,7 @@ float SvtxClusterEval::get_energy_contribution(SvtxCluster* cluster, PHG4Particl
        iter != hits.end();
        ++iter) {
     PHG4Hit* hit = *iter;
-    if (hit->get_trkid() == particle->get_track_id()) {
+    if (get_truth_eval()->is_g4hit_from_particle(hit,particle)) {
       energy += hit->get_edep();
     }
   }

--- a/simulation/g4simulation/g4eval/SvtxHitEval.C
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.C
@@ -248,7 +248,7 @@ std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Particle* g4particle) {
 	 jter != g4particles.end();
 	 ++jter) {
       PHG4Particle* candidate = *jter;
-      if (candidate->get_track_id() == g4particle->get_track_id()) {
+      if (get_truth_eval()->are_same_particle(candidate,g4particle)) {
 	hits.insert(hit);
       }    
     }
@@ -354,7 +354,7 @@ float SvtxHitEval::get_energy_contribution(SvtxHit* hit, PHG4Particle* particle)
        iter != g4hits.end();
        ++iter) {
     PHG4Hit* g4hit = *iter;
-    if (g4hit->get_trkid() == particle->get_track_id()) {
+    if (get_truth_eval()->is_g4hit_from_particle(g4hit,particle)) {
       energy += g4hit->get_edep();
     }
   }

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.C
@@ -200,8 +200,7 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
 	   jter != particles.end();
 	   ++jter) {
 	PHG4Particle* candidate = *jter;
-	// if track id matches argument add to output
-	if (candidate->get_track_id() == truthparticle->get_track_id()) {
+	if (get_truth_eval()->are_same_particle(candidate,truthparticle)) {
 	  tracks.insert(track);
 	}
       }
@@ -331,8 +330,7 @@ unsigned int SvtxTrackEval::get_nclusters_contribution(SvtxTrack* track, PHG4Par
 	 jter != particles.end();
 	 ++jter) {
       PHG4Particle* candidate = *jter;
-      // if track id matches argument add to output
-      if (candidate->get_track_id() == particle->get_track_id()) {
+      if (get_truth_eval()->are_same_particle(candidate,particle)) {
 	++nclusters;
       }
     }

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -300,6 +300,10 @@ bool SvtxTruthEval::are_same_particle(PHG4Particle* p1, PHG4Particle* p2) {
 
   bool are_same_particle = false;
 
+  // get ready for some insanity... I have to deal with the case where
+  // the primary particles are copied between the two truth containers
+  // but have different track ids
+  
   if ((p1->get_primary_id() == -1) &&
       (p2->get_primary_id() == -1)) {
     // both particles are from the primary truth map, use track ids
@@ -311,18 +315,21 @@ bool SvtxTruthEval::are_same_particle(PHG4Particle* p1, PHG4Particle* p2) {
     // both particles are from the total truth map, use track ids
     if (p1->get_track_id() == p2->get_track_id()) {
       are_same_particle = true;
-    }   
-  } else if ((p1->get_primary_id() == -1) &&
-	     (p2->get_primary_id() != -1)) {
-    // only the first particle is from the primary truth map, use one track id and one primary id
-    if (p1->get_track_id() == p2->get_primary_id()) {
-      are_same_particle = true;
     }
-  } else if ((p1->get_primary_id() != -1) &&
-	     (p2->get_primary_id() == -1)) {
-    // only the second particle is from the primary truth map, use one track id and one primary id
-    if (p1->get_primary_id() == p2->get_track_id()) {
-      are_same_particle = true;
+  } else if (is_primary(p1) && is_primary(p2)) {
+    // both particles are primary
+    if ((p1->get_primary_id() == -1) &&
+	(p2->get_primary_id() != -1)) {
+      // only the first particle is from the primary truth map, use one track id and one primary id
+      if (p1->get_track_id() == p2->get_primary_id()) {
+	are_same_particle = true;
+      }
+    } else if ((p1->get_primary_id() != -1) &&
+	       (p2->get_primary_id() == -1)) {
+      // only the second particle is from the primary truth map, use one track id and one primary id
+      if (p1->get_primary_id() == p2->get_track_id()) {
+	are_same_particle = true;
+      }
     }
   }
  

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -193,7 +193,13 @@ int SvtxTruthEval::get_embed(PHG4Particle* particle) {
   if (_strict) assert(particle);
   else if (!particle) return 0;
 
-  return _truthinfo->isEmbeded(particle->get_track_id());
+  if (!is_primary(particle)) return 0;
+
+  PHG4Particle* primary = get_primary(particle);
+  if (_strict) assert(primary);
+  else if (!primary) return 0;
+  
+  return _truthinfo->isEmbeded(primary->get_track_id());
 }
 
 PHG4VtxPoint* SvtxTruthEval::get_vertex(PHG4Particle* particle) {

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -348,10 +348,23 @@ bool SvtxTruthEval::are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2) {
   bool are_same_vertex = false;
 
   // I will need to deal with copies of vertex points too, argh!
-  // I'll insert the interface for now, but this will be another headache to
-  // deal with in the near future
+  // Here I have very few options, we can either match the vertexes by
+  // id or by position there is no ancestry to utilize
+
+  // in the embedded dst it is 100% sure the first method will fail
+  // since I can't trace between vertexes and the vertex ids have changed
+  // I guess I will have to resort to the second method, which means there
+  // is some possiblity of having a position collision between two vertexes
+  // that are in fact different in terms of content
   
-  if (vtx1->get_id() == vtx2->get_id()) {
+  //  if (vtx1->get_id() == vtx2->get_id()) {
+  //    are_same_vertex = true;
+  //  }
+
+  if ((vtx1->get_x() == vtx2->get_x()) &&
+      (vtx1->get_y() == vtx2->get_y()) &&
+      (vtx1->get_z() == vtx2->get_z()) &&
+      (vtx1->get_t() == vtx2->get_t())) {
     are_same_vertex = true;
   }
  

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -1,6 +1,8 @@
 
 #include "SvtxTruthEval.h"
 
+#include "BaseTruthEval.h"
+
 #include <fun4all/getClass.h>
 #include <phool/PHCompositeNode.h>
 #include <g4main/PHG4TruthInfoContainer.h>
@@ -18,7 +20,8 @@
 using namespace std;
 
 SvtxTruthEval::SvtxTruthEval(PHCompositeNode* topNode)
-  : _truthinfo(NULL),
+  : _basetrutheval(topNode),
+    _truthinfo(NULL),
     _g4hits_svtx(NULL),
     _g4hits_tracker(NULL),
     _strict(true),
@@ -38,6 +41,8 @@ void SvtxTruthEval::next_event(PHCompositeNode* topNode) {
   _cache_get_innermost_truth_hit.clear();
   _cache_get_outermost_truth_hit.clear();
   _cache_get_primary_g4hit.clear();
+
+  _basetrutheval.next_event(topNode);
   
   get_node_pointers(topNode);
 }
@@ -178,56 +183,19 @@ PHG4Hit* SvtxTruthEval::get_outermost_truth_hit(PHG4Particle* particle) {
 }
 
 PHG4Particle* SvtxTruthEval::get_particle(PHG4Hit* g4hit) {
-
-  if (_strict) assert(g4hit);
-  else if (!g4hit) return NULL;
-  
-  PHG4Particle* particle = _truthinfo->GetHit( g4hit->get_trkid() );
-  if (_strict) assert(particle); 
-
-  return particle;
+  return _basetrutheval.get_particle(g4hit);
 }
 
 int SvtxTruthEval::get_embed(PHG4Particle* particle) {
-
-  if (_strict) assert(particle);
-  else if (!particle) return 0;
-
-  if (!is_primary(particle)) return 0;
-
-  PHG4Particle* primary = get_primary(particle);
-  if (_strict) assert(primary);
-  else if (!primary) return 0;
-  
-  return _truthinfo->isEmbeded(primary->get_track_id());
+  return _basetrutheval.get_embed(particle);
 }
 
 PHG4VtxPoint* SvtxTruthEval::get_vertex(PHG4Particle* particle) {
-
-  if (_strict) assert(particle);
-  else if (!particle) return NULL;
-
-  if (particle->get_primary_id() == -1) {
-    return _truthinfo->GetPrimaryVtx( particle->get_vtx_id() );  
-  }
-
-  PHG4VtxPoint* vtx = _truthinfo->GetVtx( particle->get_vtx_id() );
-  if (_strict) assert(vtx);
- 
-  return vtx;
+  return _basetrutheval.get_vertex(particle);
 }
 
 bool SvtxTruthEval::is_primary(PHG4Particle* particle) {
-
-  if (_strict) assert(particle);
-  else if (!particle) return false;
-  
-  bool is_primary = false;
-  if (particle->get_parent_id() == 0) {
-    is_primary = true;
-  }
-  
-  return is_primary;
+  return _basetrutheval.is_primary(particle);
 }
 
 PHG4Particle* SvtxTruthEval::get_primary(PHG4Hit* g4hit) {
@@ -243,8 +211,7 @@ PHG4Particle* SvtxTruthEval::get_primary(PHG4Hit* g4hit) {
     }
   }
   
-  PHG4Particle* particle = get_particle(g4hit);
-  PHG4Particle* primary = get_primary(particle);
+  PHG4Particle* primary = _basetrutheval.get_primary(g4hit);
 
   if (_do_cache) _cache_get_primary_g4hit.insert(make_pair(g4hit,primary));
   
@@ -254,131 +221,23 @@ PHG4Particle* SvtxTruthEval::get_primary(PHG4Hit* g4hit) {
 }
 
 PHG4Particle* SvtxTruthEval::get_primary(PHG4Particle* particle) {
-
-  if (_strict) assert(particle);
-  else if (!particle) return NULL;
-
-  // always report the primary from the Primary Map regardless if a
-  // primary from the full Map was the argument
-  PHG4Particle* returnval = NULL;
-  if (particle->get_primary_id() != -1) {
-    returnval = _truthinfo->GetPrimaryHit( particle->get_primary_id() );
-  } else {
-    returnval = _truthinfo->GetPrimaryHit( particle->get_track_id() );
-  }
-
-  if (_strict) assert(returnval);
-  
-  return returnval;
+  return _basetrutheval.get_primary(particle);
 }
 
- bool SvtxTruthEval::is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle) {
-
-  if (_strict) {
-    assert(g4hit);
-    assert(particle);
-  } else if (!g4hit||!particle) {
-    return false;
-  }
-
-  bool is_from_particle = false;
-
-  PHG4Particle* candidate = get_particle(g4hit);
-  if (_strict) assert(candidate);
-
-  if (candidate) {
-    if (are_same_particle(candidate,particle)) {
-      is_from_particle = true;
-    }
-  }
-
-  return is_from_particle;
+bool SvtxTruthEval::is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle) {
+  return _basetrutheval.is_g4hit_from_particle(g4hit,particle);
 }
 
 bool SvtxTruthEval::are_same_particle(PHG4Particle* p1, PHG4Particle* p2) {
-
-  if (_strict) {
-    assert(p1);
-    assert(p2);
-  } else if (!p1||!p2) {
-    return false;
-  }
-
-  bool are_same_particle = false;
-
-  // get ready for some insanity... I have to deal with the case where
-  // the primary particles are copied between the two truth containers
-  // but have different track ids
-  
-  if ((p1->get_primary_id() == -1) &&
-      (p2->get_primary_id() == -1)) {
-    // both particles are from the primary truth map, use track ids
-    if (p1->get_track_id() == p2->get_track_id()) {
-      are_same_particle = true;
-    }
-  } else if ((p1->get_primary_id() != -1) &&
-	     (p2->get_primary_id() != -1)) {
-    // both particles are from the total truth map, use track ids
-    if (p1->get_track_id() == p2->get_track_id()) {
-      are_same_particle = true;
-    }
-  } else if (is_primary(p1) && is_primary(p2)) {
-    // both particles are primary
-    if ((p1->get_primary_id() == -1) &&
-	(p2->get_primary_id() != -1)) {
-      // only the first particle is from the primary truth map, use one track id and one primary id
-      if (p1->get_track_id() == p2->get_primary_id()) {
-	are_same_particle = true;
-      }
-    } else if ((p1->get_primary_id() != -1) &&
-	       (p2->get_primary_id() == -1)) {
-      // only the second particle is from the primary truth map, use one track id and one primary id
-      if (p1->get_primary_id() == p2->get_track_id()) {
-	are_same_particle = true;
-      }
-    }
-  }
- 
-  return are_same_particle;
+  return _basetrutheval.are_same_particle(p1,p2);
 }
 
 bool SvtxTruthEval::are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2) {
-
-  if (_strict) {
-    assert(vtx1);
-    assert(vtx2);
-  } else if (!vtx1||!vtx2) {
-    return false;
-  }
-
-  bool are_same_vertex = false;
-
-  // I will need to deal with copies of vertex points too, argh!
-  // Here I have very few options, we can either match the vertexes by
-  // id or by position there is no ancestry to utilize
-
-  // in the embedded dst it is 100% sure the first method will fail
-  // since I can't trace between vertexes and the vertex ids have changed
-  // I guess I will have to resort to the second method, which means there
-  // is some possiblity of having a position collision between two vertexes
-  // that are in fact different in terms of content
-  
-  //  if (vtx1->get_id() == vtx2->get_id()) {
-  //    are_same_vertex = true;
-  //  }
-
-  if ((vtx1->get_x() == vtx2->get_x()) &&
-      (vtx1->get_y() == vtx2->get_y()) &&
-      (vtx1->get_z() == vtx2->get_z()) &&
-      (vtx1->get_t() == vtx2->get_t())) {
-    are_same_vertex = true;
-  }
- 
-  return are_same_vertex;
+  return _basetrutheval.are_same_vertex(vtx1,vtx2);
 }
   
 void SvtxTruthEval::get_node_pointers(PHCompositeNode* topNode) {
-
+  
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
   if (!_truthinfo) {
     cerr << PHWHERE << " ERROR: Can't find G4TruthInfo" << endl;

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -335,6 +335,28 @@ bool SvtxTruthEval::are_same_particle(PHG4Particle* p1, PHG4Particle* p2) {
  
   return are_same_particle;
 }
+
+bool SvtxTruthEval::are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2) {
+
+  if (_strict) {
+    assert(vtx1);
+    assert(vtx2);
+  } else if (!vtx1||!vtx2) {
+    return false;
+  }
+
+  bool are_same_vertex = false;
+
+  // I will need to deal with copies of vertex points too, argh!
+  // I'll insert the interface for now, but this will be another headache to
+  // deal with in the near future
+  
+  if (vtx1->get_id() == vtx2->get_id()) {
+    are_same_vertex = true;
+  }
+ 
+  return are_same_vertex;
+}
   
 void SvtxTruthEval::get_node_pointers(PHCompositeNode* topNode) {
 

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -260,16 +260,16 @@ PHG4Particle* SvtxTruthEval::get_primary(PHG4Particle* particle) {
 
   // always report the primary from the Primary Map regardless if a
   // primary from the full Map was the argument
-  PHG4Particle* primary = NULL;
-  if (particle->get_primary_id() == -1) {
-    primary = _truthinfo->GetPrimaryHit( particle->get_track_id() );
+  PHG4Particle* returnval = NULL;
+  if (particle->get_primary_id() != -1) {
+    returnval = _truthinfo->GetPrimaryHit( particle->get_primary_id() );
   } else {
-    primary = _truthinfo->GetPrimaryHit( particle->get_primary_id() );
+    returnval = _truthinfo->GetPrimaryHit( particle->get_track_id() );
   }
 
-  if (_strict) assert(primary);
+  if (_strict) assert(returnval);
   
-  return primary;
+  return returnval;
 }
 
  bool SvtxTruthEval::is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle) {

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -33,6 +33,7 @@ public:
   PHG4Particle*      get_primary(PHG4Particle* particle);  
 
   bool               is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle);
+  bool               are_same_particle(PHG4Particle* p1, PHG4Particle* p2);
   
   PHG4Hit*           get_innermost_truth_hit(PHG4Particle* particle);
   PHG4Hit*           get_outermost_truth_hit(PHG4Particle* particle);

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -34,6 +34,7 @@ public:
 
   bool               is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle);
   bool               are_same_particle(PHG4Particle* p1, PHG4Particle* p2);
+  bool               are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2);
   
   PHG4Hit*           get_innermost_truth_hit(PHG4Particle* particle);
   PHG4Hit*           get_outermost_truth_hit(PHG4Particle* particle);

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -31,6 +31,8 @@ public:
   bool               is_primary(PHG4Particle* particle);
   PHG4Particle*      get_primary(PHG4Hit* g4hit);
   PHG4Particle*      get_primary(PHG4Particle* particle);  
+
+  bool               is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle);
   
   PHG4Hit*           get_innermost_truth_hit(PHG4Particle* particle);
   PHG4Hit*           get_outermost_truth_hit(PHG4Particle* particle);

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -27,9 +27,11 @@ public:
   std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);
   PHG4Particle*      get_particle(PHG4Hit* g4hit);  
   int                get_embed(PHG4Particle* particle);
-  bool               is_primary(PHG4Particle* particle);
   PHG4VtxPoint*      get_vertex(PHG4Particle* particle);
-
+  bool               is_primary(PHG4Particle* particle);
+  PHG4Particle*      get_primary(PHG4Hit* g4hit);
+  PHG4Particle*      get_primary(PHG4Particle* particle);  
+  
   PHG4Hit*           get_innermost_truth_hit(PHG4Particle* particle);
   PHG4Hit*           get_outermost_truth_hit(PHG4Particle* particle);
   
@@ -48,6 +50,7 @@ private:
   std::map<PHG4Particle*,std::set<PHG4Hit*> > _cache_all_truth_hits_g4particle;
   std::map<PHG4Particle*,PHG4Hit*>            _cache_get_innermost_truth_hit;
   std::map<PHG4Particle*,PHG4Hit*>            _cache_get_outermost_truth_hit;
+  std::map<PHG4Hit*,PHG4Particle*>            _cache_get_primary_g4hit;
 };
 
 #endif // __SVTXTRUTHEVAL_H__

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -2,6 +2,8 @@
 #ifndef __SVTXTRUTHEVAL_H__
 #define __SVTXTRUTHEVAL_H__
 
+#include "BaseTruthEval.h"
+
 #include <phool/PHCompositeNode.h>
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
@@ -42,6 +44,8 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode* topNode);
+
+  BaseTruthEval _basetrutheval;
   
   PHG4TruthInfoContainer* _truthinfo;
   PHG4HitContainer* _g4hits_svtx;

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -23,7 +23,10 @@ public:
 
   void next_event(PHCompositeNode *topNode);
   void do_caching(bool do_cache) {_do_cache = do_cache;}
-  void set_strict(bool strict) {_strict = strict;}
+  void set_strict(bool strict) {
+    _strict = strict;
+    _basetrutheval.set_strict(strict);
+  }
   
   std::set<PHG4Hit*> all_truth_hits();
   std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.C
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.C
@@ -182,7 +182,7 @@ std::set<SvtxVertex*> SvtxVertexEval::all_vertexes_from(PHG4VtxPoint* truthpoint
 	 jter != points.end();
 	 ++jter) {
       PHG4VtxPoint* point = *jter;
-      if (point->get_id() == truthpoint->get_id()) {
+      if (get_truth_eval()->are_same_vertex(point,truthpoint)) {
 	all_vertexes.insert(vertex);
       }
     }
@@ -256,8 +256,10 @@ unsigned int SvtxVertexEval::get_ntracks_contribution(SvtxVertex* vertex, PHG4Vt
 
     if (_strict) assert(candidate);
     else if (!candidate) continue;
-    
-    if (candidate->get_id() == truthpoint->get_id()) ++ntracks;
+
+    if (get_truth_eval()->are_same_vertex(candidate,truthpoint)) {
+      ++ntracks;
+    }
   }
   
   if (_do_cache) _cache_get_ntracks_contribution.insert(make_pair(make_pair(vertex,truthpoint),ntracks));


### PR DESCRIPTION
Okay @blackcathj , I believe I've done it now. I wrote a new class BaseTruthEval to handle common tasks between the SvtxTruthEval and CaloTruthEval. This reduces the duplication of code between the two modules and ensures those portions are always doing the same things. Inside that new class, I have changed the truth id matching criteria to this: 

```
  if ((p1->get_primary_id() == -1) &&
      (p2->get_primary_id() == -1)) {
    // both particles are from the primary truth map, use track ids
    if (p1->get_track_id() == p2->get_track_id()) {
      are_same_particle = true;
    }
  } else if ((p1->get_primary_id() != -1) &&
	     (p2->get_primary_id() != -1)) {
    // both particles are from the total truth map, use track ids
    if (p1->get_track_id() == p2->get_track_id()) {
      are_same_particle = true;
    }
  } else if (is_primary(p1) && is_primary(p2)) {
    // both particles are primary
    if ((p1->get_primary_id() == -1) &&
	(p2->get_primary_id() != -1)) {
      // only the first particle is from the primary truth map, use one track id and one primary id
      if (p1->get_track_id() == p2->get_primary_id()) {
	are_same_particle = true;
      }
    } else if ((p1->get_primary_id() != -1) &&
	       (p2->get_primary_id() == -1)) {
      // only the second particle is from the primary truth map, use one track id and one primary id
      if (p1->get_primary_id() == p2->get_track_id()) {
	are_same_particle = true;
      }
    }
  }
```
This handles the special case where the two primary copies are from separate maps in the 3rd and 4th else-if blocks.

I see that the SVTX and CEMC evaluation is working properly for a handful of electrons thrown near a handful of positrons that were written out to a DST. I have also run the branch through my standard tracking examination (to see I haven't borked anything for the standard tracking eval:
![crosscheck](https://cloud.githubusercontent.com/assets/12105552/10414584/f628649c-6f98-11e5-862b-c4baeb86e0a4.png)

Jin, could you grab the branch and see if it solves your issue with the DST embedded eval as intended?

