### PR TITLE
add light correction to inner hcal stepping action, remove track pathlength from hcal hits, fix cppcheck performance warnings

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4BlockCellGeomContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellGeomContainer.cc
@@ -25,7 +25,7 @@ void
 PHG4BlockCellGeomContainer::identify(std::ostream& os) const
 {
   map<int,PHG4BlockCellGeom *>::const_iterator iter;
-  for (iter=layergeoms.begin(); iter != layergeoms.end(); iter++)
+  for (iter=layergeoms.begin(); iter != layergeoms.end(); ++iter)
     {
       cout << "layer " << iter->first << endl;
       (iter->second)->identify(os);

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeomContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeomContainer.cc
@@ -28,7 +28,7 @@ PHG4BlockGeomContainer::identify(std::ostream& os) const
   os << "mag field: " << _magfield << endl;
   os << "number of layers: " << _layergeoms.size() << endl;
   map<int,PHG4BlockGeom *>::const_iterator iter;
-  for (iter=_layergeoms.begin(); iter != _layergeoms.end(); iter++)
+  for (iter=_layergeoms.begin(); iter != _layergeoms.end(); ++iter)
   {
     (iter->second)->identify(os);
   }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.cc
@@ -29,14 +29,14 @@ PHG4CylinderCellContainer::identify(ostream& os) const
 {
    map<unsigned int,PHG4CylinderCell *>::const_iterator iter;
    os << "Number of cells: " << size() << endl;
-   for (iter = cellmap.begin(); iter != cellmap.end(); iter++)
+   for (iter = cellmap.begin(); iter != cellmap.end(); ++iter)
      {
        os << "cell key 0x" << hex << iter->first << dec << endl;
        (iter->second)->identify();
      }
    set<int>::const_iterator siter;
    os << "Number of layers: " << num_layers() << endl;
-   for (siter = layers.begin(); siter != layers.end(); siter++)
+   for (siter = layers.begin(); siter != layers.end(); ++siter)
      {
        os << "layer : " << *siter << endl;
      }
@@ -131,7 +131,7 @@ PHG4CylinderCellContainer::getTotalEdep() const
 {
   ConstIterator iter;
   double totalenergy = 0;
-  for (iter = cellmap.begin(); iter != cellmap.end(); iter++)
+  for (iter = cellmap.begin(); iter != cellmap.end(); ++iter)
     {
       totalenergy += iter->second->get_edep();
     }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.h
@@ -48,7 +48,7 @@ class PHG4CylinderCellContainer: public PHObject
 	  }
 	else
 	  {
-	    its++;
+	    ++its;
 	  }
       }
   }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomContainer.cc
@@ -25,7 +25,7 @@ void
 PHG4CylinderCellGeomContainer::identify(std::ostream& os) const
 {
   map<int,PHG4CylinderCellGeom *>::const_iterator iter;
-  for (iter=layergeoms.begin(); iter != layergeoms.end(); iter++)
+  for (iter=layergeoms.begin(); iter != layergeoms.end(); ++iter)
     {
       cout << "layer " << iter->first << endl;
       (iter->second)->identify(os);

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -95,7 +95,7 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
   map<int, PHG4CylinderGeom *>::const_iterator miter;
   pair <map<int, PHG4CylinderGeom *>::const_iterator, map<int, PHG4CylinderGeom *>::const_iterator> begin_end = geo->get_begin_end();
   map<int, std::pair <double, double> >::iterator sizeiter;
-  for (miter = begin_end.first; miter != begin_end.second; miter++)
+  for (miter = begin_end.first; miter != begin_end.second; ++miter)
     {
       PHG4CylinderGeom *layergeom = miter->second;
       int layer = layergeom->get_layer();
@@ -981,7 +981,7 @@ PHG4CylinderCellReco::CheckEnergy(PHCompositeNode *topNode)
     }
   PHG4CylinderCellContainer::ConstRange cell_begin_end = cells->getCylinderCells();
   PHG4CylinderCellContainer::ConstIterator citer;
-  for (citer = cell_begin_end.first; citer != cell_begin_end.second; citer++)
+  for (citer = cell_begin_end.first; citer != cell_begin_end.second; ++citer)
     {
       sum_energy_cells += citer->second->get_edep();
     }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -77,7 +77,7 @@ int PHG4CylinderCellTPCReco::InitRun(PHCompositeNode *topNode)
   map<int, PHG4CylinderGeom *>::const_iterator miter;
   pair <map<int, PHG4CylinderGeom *>::const_iterator, map<int, PHG4CylinderGeom *>::const_iterator> begin_end = geo->get_begin_end();
   map<int, std::pair <double, double> >::iterator sizeiter;
-  for(miter = begin_end.first; miter != begin_end.second; miter++)
+  for(miter = begin_end.first; miter != begin_end.second; ++miter)
   {
     PHG4CylinderGeom *layergeom = miter->second;
     int layer = layergeom->get_layer();

--- a/simulation/g4simulation/g4detectors/PHG4FCalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FCalDetector.cc
@@ -147,7 +147,7 @@ bool PHG4FCalDetector::isInScintillator(G4VPhysicalVolume * volume)
 {
   //loop over the physical volumes and see if this is a match
   std::map<unsigned int, G4VPhysicalVolume*>::iterator vol_iter = scintillator_physi_.begin();
-  for ( ; vol_iter != scintillator_physi_.end(); vol_iter ++ )
+  for ( ; vol_iter != scintillator_physi_.end(); ++vol_iter )
   {
     if ( vol_iter->second == volume )
       return true;
@@ -161,7 +161,7 @@ int PHG4FCalDetector::getScintillatorLayer(G4VPhysicalVolume * volume)
 {
   //loop over the physical volumes and see if this is a match
   std::map<unsigned int, G4VPhysicalVolume*>::iterator vol_iter = scintillator_physi_.begin();
-  for ( ; vol_iter != scintillator_physi_.end(); vol_iter ++ )
+  for ( ; vol_iter != scintillator_physi_.end(); ++vol_iter )
   {
     if ( vol_iter->second == volume )
       return vol_iter->first;

--- a/simulation/g4simulation/g4detectors/PHG4FPbScDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScDetector.cc
@@ -160,7 +160,7 @@ bool PHG4FPbScDetector::isInScintillator(G4VPhysicalVolume * volume)
 {
   //loop over the physical volumes and see if this is a match
   std::map<unsigned int, G4VPhysicalVolume*>::iterator vol_iter = scintillator_physi_.begin();
-  for ( ; vol_iter != scintillator_physi_.end(); vol_iter ++ )
+  for ( ; vol_iter != scintillator_physi_.end(); ++vol_iter )
   {
     if ( vol_iter->second == volume )
       {
@@ -175,7 +175,7 @@ int PHG4FPbScDetector::getScintillatorLayer(G4VPhysicalVolume * volume)
 {
   //loop over the physical volumes and see if this is a match
   std::map<unsigned int, G4VPhysicalVolume*>::iterator vol_iter = scintillator_physi_.begin();
-  for ( ; vol_iter != scintillator_physi_.end(); vol_iter ++ )
+  for ( ; vol_iter != scintillator_physi_.end(); ++vol_iter )
   {
     if ( vol_iter->second == volume )
       return vol_iter->first;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.cc
@@ -29,6 +29,12 @@ PHG4InnerHcalParameters::PHG4InnerHcalParameters():
   blackhole(0),
   material("SS310"),
   steplimits(NAN),
+  light_scint_model(true),
+  light_balance(false),
+  light_balance_inner_radius(0.0),
+  light_balance_inner_corr(1.0),
+  light_balance_outer_radius(10.0),
+  light_balance_outer_corr(1.0),
   absorbertruth(0)
 {}
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalParameters.h
@@ -33,6 +33,12 @@ class PHG4InnerHcalParameters
   G4int blackhole;
   G4String material;
   G4double steplimits;
+  bool  light_scint_model;
+  bool light_balance;
+  G4double light_balance_inner_radius;
+  G4double light_balance_inner_corr;
+  G4double light_balance_outer_radius;
+  G4double light_balance_outer_corr;
   G4int absorbertruth;
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -38,12 +38,7 @@ PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction( PHG4InnerHcalDetector*
   hits_(NULL),
   absorberhits_(NULL),
   hit(NULL),
-  params(parameters),
-  light_balance_(false),
-  light_balance_inner_radius_(NAN),
-  light_balance_inner_corr_(NAN),
-  light_balance_outer_radius_(NAN),
-  light_balance_outer_corr_(NAN)
+  params(parameters)
 {}
 
 //____________________________________________________________________________..
@@ -127,7 +122,7 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
   G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
-
+  G4double light_yield = 0;
   const G4Track* aTrack = aStep->GetTrack();
 
   // if this block stops everything, just put all kinetic energy into edep
@@ -188,7 +183,7 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 	  hit->set_eion(0); // only implemented for v5 otherwise empty
 	  if (whichactive > 0) // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
 	    {
-        hit->set_light_yield(0); // for scintillator only, initialize light yields
+	      hit->set_light_yield(0); // for scintillator only, initialize light yields
 
 	      // Now add the hit
 	      hits_->AddHit(layer_id, hit);
@@ -209,36 +204,72 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
       hit->set_z( 1, postPoint->GetPosition().z() / cm );
 
       hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
-      //sum up the energy to get total deposited
-      hit->set_edep(hit->get_edep() + edep);
-      hit->set_eion(hit->get_eion() + eion);
-
 
       if (whichactive > 0) // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
         {
-          double light_yield = GetVisibleEnergyDeposition(aStep); // for scintillator only, calculate light yields
-          hit->set_light_yield(hit->get_light_yield() + light_yield);
-
-          static bool once = true;
-          if (once and edep > 0)
+          if (params->light_scint_model)
             {
-              once = false;
+              light_yield = GetVisibleEnergyDeposition(aStep); // for scintillator only, calculate light yields
+	      static bool once = true;
+	      if (once && edep > 0)
+		{
+		  once = false;
 
-	      if (verbosity > 0) {
-		cout << "PHG4InnerHcalSteppingAction::UserSteppingAction::"
-                  //
-		     << detector_->GetName() << " - "
-		     << " use scintillating light model at each Geant4 steps. "
-		     << "First step: " << "Material = "
-		     << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetName()
-		     << ", " << "Birk Constant = "
-		     << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetIonisation()->GetBirksConstant()
-		     << "," << "edep = " << edep << ", " << "eion = " << eion
-		     << ", " << "light_yield = " << light_yield << endl;
-	      }
+		  if (verbosity > 0) 
+		    {
+		      cout << "PHG4InnerHcalSteppingAction::UserSteppingAction::"
+			//
+			   << detector_->GetName() << " - "
+			   << " use scintillating light model at each Geant4 steps. "
+			   << "First step: " << "Material = "
+			   << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetName()
+			   << ", " << "Birk Constant = "
+			   << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetIonisation()->GetBirksConstant()
+			   << "," << "edep = " << edep << ", " << "eion = " << eion
+			   << ", " << "light_yield = " << light_yield << endl;
+		      cout << "light_balance: " << params->light_balance << endl;
+		    }
+		}
+	    }
+	  else
+            {
+              light_yield = eion;
+            }
+          if (params->light_balance)
+            {
+              float r = sqrt(
+			     pow(postPoint->GetPosition().x() / cm, 2)
+			     + pow(postPoint->GetPosition().y() / cm, 2));
+              const float cor = GetLightCorrection(r);
+              light_yield = light_yield * cor;
+
+              static bool once = true;
+              if (once && light_yield>0)
+                {
+                  once = false;
+
+		  if (verbosity > 1) 
+		    {
+		      cout << "PHG4OuterHcalSteppingAction::UserSteppingAction::"
+			//
+			   << detector_->GetName() << " - "
+			   << " use a simple light collection model with linear radial dependence. "
+			   <<"First step: "
+			   <<"r = " <<r<<", "
+			   <<"correction ratio = " <<cor<<", "
+			   <<"light_yield after cor. = " <<light_yield
+			   << endl;
+		    }
+                }
+
             }
         }
 
+      //sum up the energy to get total deposited
+      hit->set_edep(hit->get_edep() + edep);
+      hit->set_eion(hit->get_eion() + eion);
+      hit->set_light_yield(hit->get_light_yield() + light_yield);
+      hit->set_path_length(aTrack->GetTrackLength() / cm);
       if (geantino)
 	{
 	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
@@ -301,4 +332,16 @@ void PHG4InnerHcalSteppingAction::SetInterfacePointers( PHCompositeNode* topNode
 	  cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
 	}
     }
+}
+
+float 
+PHG4InnerHcalSteppingAction::GetLightCorrection(const float r) const
+{
+  float m = (params->light_balance_outer_corr - params->light_balance_inner_corr)/(params->light_balance_outer_radius - params->light_balance_inner_radius);
+  float b = params->light_balance_inner_corr - m*params->light_balance_inner_radius;
+  float value = m*r+b;  
+  if (value > 1.0) return 1.0;
+  if (value < 0.0) return 0.0;
+
+  return value;
 }

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -184,7 +184,6 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 	  if (whichactive > 0) // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
 	    {
 	      hit->set_light_yield(0); // for scintillator only, initialize light yields
-
 	      // Now add the hit
 	      hits_->AddHit(layer_id, hit);
 	    }
@@ -268,8 +267,10 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
       //sum up the energy to get total deposited
       hit->set_edep(hit->get_edep() + edep);
       hit->set_eion(hit->get_eion() + eion);
-      hit->set_light_yield(hit->get_light_yield() + light_yield);
-      hit->set_path_length(aTrack->GetTrackLength() / cm);
+       if (whichactive > 0)
+	{
+	  hit->set_light_yield(hit->get_light_yield() + light_yield);
+	}
       if (geantino)
 	{
 	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -26,16 +26,8 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   //! reimplemented from base class
   virtual void SetInterfacePointers( PHCompositeNode* );
 
-  float GetLightCorrection(float r);
-  void SetLightCorrection(float inner_radius, float inner_corr,
-			  float outer_radius, float outer_corr) {
-    light_balance_ = true;
-    light_balance_inner_radius_ = inner_radius;
-    light_balance_inner_corr_ = inner_corr;
-    light_balance_outer_radius_ = outer_radius;
-    light_balance_outer_corr_ = outer_corr;
-  }
-  
+  float GetLightCorrection(const float r) const;
+
   private:
 
   //! pointer to the detector
@@ -46,12 +38,6 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   PHG4HitContainer * absorberhits_;
   PHG4Hit *hit;
   PHG4InnerHcalParameters *params;
-
-  bool  light_balance_;
-  float light_balance_inner_radius_;
-  float light_balance_inner_corr_;
-  float light_balance_outer_radius_;
-  float light_balance_outer_corr_;
 };
 
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -271,12 +271,6 @@ PHG4InnerHcalSubsystem::SetScintiGap(const double scgap)
 }
 
 void
-PHG4InnerHcalSubsystem::SetStepLimits(const double slim)
-{
-  params->steplimits = slim*cm;
-}
-
-void
 PHG4InnerHcalSubsystem::SetTiltViaNcross(const int ncross)
 {
   if (ncross == 0)
@@ -290,4 +284,27 @@ PHG4InnerHcalSubsystem::SetTiltViaNcross(const int ncross)
       exit(1);
     }
   params->ncross = ncross;
+}
+
+void
+PHG4InnerHcalSubsystem::SetStepLimits(const double slim)
+{
+  params->steplimits = slim*cm;
+}
+
+void
+PHG4InnerHcalSubsystem::SetLightCorrection(const float inner_radius, const float inner_corr,
+			  const float outer_radius, const float outer_corr) 
+{
+  params->light_balance = true;
+  params->light_balance_inner_radius = inner_radius;
+  params->light_balance_inner_corr = inner_corr;
+  params->light_balance_outer_radius = outer_radius;
+  params->light_balance_outer_corr = outer_corr;
+}
+
+void
+PHG4InnerHcalSubsystem:: SetLightScintModel(const bool b)
+{
+  params->light_scint_model = b;
 }

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
@@ -75,6 +75,11 @@ class PHG4InnerHcalSubsystem: public PHG4Subsystem
   void SetScintiGap(const double scgap);
   void SetStepLimits(const double slim);
 
+  void SetLightCorrection(const float inner_radius, const float inner_corr,
+			  const float outer_radius, const float outer_corr);
+  void SetLightScintModel(const bool b = true);
+
+
   protected:
 
   //! detector geometry

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -334,7 +334,9 @@ void PHG4OuterHcalSteppingAction::SetInterfacePointers( PHCompositeNode* topNode
     }
 }
 
-float PHG4OuterHcalSteppingAction::GetLightCorrection(float r) {
+float 
+PHG4OuterHcalSteppingAction::GetLightCorrection(const float r) const
+{
   float m = (params->light_balance_outer_corr - params->light_balance_inner_corr)/(params->light_balance_outer_radius - params->light_balance_inner_radius);
   float b = params->light_balance_inner_corr - m*params->light_balance_inner_radius;
   float value = m*r+b;  

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -179,10 +179,10 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 
 	  //set the initial energy deposit
 	  hit->set_edep(0);
-	  hit->set_eion(0); // only implemented for v5 otherwise empty
-	  hit->set_light_yield(0);
+	  hit->set_eion(0); 
 	  if (whichactive > 0) // return of IsInOuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
 	    {
+	      hit->set_light_yield(0); //  for scintillator only, initialize light yields
 	      // Now add the hit
 	      hits_->AddHit(layer_id, hit);
 	    }
@@ -268,8 +268,10 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
       //sum up the energy to get total deposited
       hit->set_edep(hit->get_edep() + edep);
       hit->set_eion(hit->get_eion() + eion);
-      hit->set_light_yield(hit->get_light_yield() + light_yield);
-      hit->set_path_length(aTrack->GetTrackLength() / cm);
+      if (whichactive > 0)
+	{
+	  hit->set_light_yield(hit->get_light_yield() + light_yield);
+	}
       if (geantino)
 	{
 	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
@@ -26,7 +26,7 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
   //! reimplemented from base class
   virtual void SetInterfacePointers( PHCompositeNode* );
 
-  float GetLightCorrection(float r);
+  float GetLightCorrection(const float r) const;
 
   void FieldChecker (const G4Step*);
 

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
@@ -167,7 +167,7 @@ PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume* WorldLog)
 
         for (G4MaterialTable::const_iterator it =
             (G4Material::GetMaterialTable())->begin();
-            it != G4Material::GetMaterialTable()->end(); it++)
+            it != G4Material::GetMaterialTable()->end(); ++it)
           {
             cout << (*it) << endl;
           }
@@ -263,7 +263,7 @@ PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume* WorldLog)
 
 G4VSolid *
 PHG4SectorConstructor::Construct_Sectors_Plane( //
-    const std::string name, //
+    const std::string &name, //
     const double start_z, //
     const double thickness, //
     G4VSolid *SecConeBoundary_Det //

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
@@ -239,7 +239,7 @@ namespace PHG4Sector
     {
       int n = 0;
       for (t_layer_list::const_iterator it = layer_list.begin();
-          it != layer_list.end(); it++)
+          it != layer_list.end(); ++it)
         if ((*it).active)
           n++;
       return n;
@@ -380,7 +380,7 @@ namespace PHG4Sector
 
     G4VSolid *
     Construct_Sectors_Plane( //
-        const std::string name, //
+        const std::string &name, //
         const double start_z, //
         const double thickness, //
         G4VSolid *SecConeBoundary_Det //

--- a/simulation/g4simulation/g4detectors/PHG4SectorDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDetector.cc
@@ -35,7 +35,7 @@ bool
 PHG4SectorDetector::IsInSectorActive(G4VPhysicalVolume * volume)
 {
   for (map_phy_vol_t::const_iterator it = map_active_phy_vol.begin();
-      it != map_active_phy_vol.end(); it++)
+      it != map_active_phy_vol.end(); ++it)
     {
       if (volume == (*it).second)
         {
@@ -76,7 +76,7 @@ PHG4SectorDetector::Construct(G4LogicalVolume* logicWorld)
 
 
   for (map_log_vol_t::iterator it = map_log_vol.begin(); it != map_log_vol.end();
-      it++)
+      ++it)
     {
       if ((*it).first != G4String(name_base + "_Log"))
         {


### PR DESCRIPTION
The light correction was only implemented for the outer hcal. This pull request adds it to the inner hcal. While at it I ran cppcheck and fixed all those performance warnings. We should make running cppcheck mandatory before code is being checked in.