### PR TITLE
CaloTruthEval::get_shower_from_primary() logic was backward

### DIFF
--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -163,7 +163,7 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
     if (_strict) {assert(candidate);}
     else if (!candidate) {++_errors; continue;}
 
-    if (are_same_particle(candidate,primary)) continue;
+    if (!are_same_particle(candidate,primary)) continue;
     truth_hits.insert(g4hit);
   }
 


### PR DESCRIPTION
When I rewrote the CaloTruthEval object to account for the id mismatches in the truth tables, I inserted are_same_particle(p1,p2) in many places. In this particular spot I reverse the logic by accident by not typing a '!'. Apologies for not seeing this sooner.