### PR TITLE
Storage Revision for PHG4TruthInfoContainer

### DIFF
--- a/offline/packages/NodeDump/DumpPHG4TruthInfoContainer.cc
+++ b/offline/packages/NodeDump/DumpPHG4TruthInfoContainer.cc
@@ -40,7 +40,7 @@ int DumpPHG4TruthInfoContainer::process_Node(PHNode *myNode)
           (*vtxiter->second).identify(*fout);
 	}
       PHG4TruthInfoContainer::ConstIterator particle_iter;
-      PHG4TruthInfoContainer::ConstRange particlebegin_end = truthcontainer->GetHitRange();
+      PHG4TruthInfoContainer::ConstRange particlebegin_end = truthcontainer->GetParticleRange();
           for (particle_iter = particlebegin_end.first; particle_iter != particlebegin_end.second; particle_iter++)
             {
 	      *fout << "particle number: " << particle_iter->first << endl;

--- a/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.cc
@@ -85,15 +85,14 @@ bool PHG4BlockSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
 	  {
-            int trkoffset = 0;
+            hit->set_trkid(aTrack->GetTrackID());
             if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-            hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
 
 	  //set the initial energy deposit
@@ -118,15 +117,14 @@ bool PHG4BlockSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
 	      hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	      //set the track ID
 	      {
-		int trkoffset = 0;
+		hit->set_trkid(aTrack->GetTrackID());
 		if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 		  {
 		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		      {
-			trkoffset = pp->GetTrackIdOffset();
+			hit->set_trkid(pp->GetUserTrackId());
 		      }
 		  }
-		hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	      }
 
 	      //set the initial energy deposit

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
@@ -86,15 +86,14 @@ bool PHG4CEmcTestBeamSteppingAction::UserSteppingAction( const G4Step* aStep, bo
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
 	  {
-	    int trkoffset = 0;
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+            hit->set_trkid(aTrack->GetTrackID());
+            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-	    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
 
 	  //set the initial energy deposit

--- a/simulation/g4simulation/g4detectors/PHG4ConeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSteppingAction.cc
@@ -60,17 +60,16 @@ bool PHG4ConeSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
           hit->set_z( 0, prePoint->GetPosition().z() / cm );
 	  // time in ns
           hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
-          //set the track ID
+ 	  //set the track ID
 	  {
-	    int trkoffset = 0;
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+            hit->set_trkid(aTrack->GetTrackID());
+            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-	    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
 
           //set the initial energy deposit

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
@@ -144,15 +144,14 @@ bool PHG4CrystalCalorimeterSteppingAction::UserSteppingAction( const G4Step* aSt
 
 	  /* set the track ID */
 	  {
-	    int trkoffset = 0;
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+            hit->set_trkid(aTrack->GetTrackID());
+            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-	    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
 
 	  /* set intial energy deposit */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -91,15 +91,14 @@ bool PHG4CylinderSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
           hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
 	  {
-	    int trkoffset = 0;
+	    hit->set_trkid(aTrack->GetTrackID());
 	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-	    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
           //set the initial energy deposit
           hit->set_edep(0);

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.cc
@@ -113,15 +113,14 @@ bool PHG4EnvelopeSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
 
 				/* set the track ID */
 				{
-					int trkoffset = 0;
-					if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+				  hit->set_trkid(aTrack->GetTrackID());
+				  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+				    {
+				      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 					{
-						if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-						{
-							trkoffset = pp->GetTrackIdOffset();
-						}
+					  hit->set_trkid(pp->GetUserTrackId());
 					}
-					hit->set_trkid(aTrack->GetTrackID() + trkoffset);
+				    }
 				}
 
 				/* set intial energy deposit */

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
@@ -129,17 +129,16 @@ bool PHG4ForwardEcalSteppingAction::UserSteppingAction( const G4Step* aStep, boo
 	  /* Set hit time */
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 
-	  /* set the track ID */
+	  //set the track ID
 	  {
-	    int trkoffset = 0;
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+            hit->set_trkid(aTrack->GetTrackID());
+            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-	    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
 
 	  /* set intial energy deposit */

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
@@ -129,17 +129,16 @@ bool PHG4ForwardHcalSteppingAction::UserSteppingAction( const G4Step* aStep, boo
 	  /* Set hit time */
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 
-	  /* set the track ID */
+	  //set the track ID
 	  {
-	    int trkoffset = 0;
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+            hit->set_trkid(aTrack->GetTrackID());
+            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-	    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
 
 	  /* set intial energy deposit */

--- a/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSteppingAction.cc
@@ -151,15 +151,14 @@ bool PHG4HcalPrototypeSteppingAction::UserSteppingAction( const G4Step* aStep, b
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
 	  {
-	    int trkoffset = 0;
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+            hit->set_trkid(aTrack->GetTrackID());
+            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-	    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
 	  
 	  //set the initial energy deposit

--- a/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
@@ -87,15 +87,14 @@ bool PHG4HcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
           hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
 	  {
-	    int trkoffset = 0;
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+            hit->set_trkid(aTrack->GetTrackID());
+            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-	    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
           //set the initial energy deposit
           hit->set_edep(0);

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -167,15 +167,14 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
 	  {
-	    int trkoffset = 0;
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+            hit->set_trkid(aTrack->GetTrackID());
+            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-	    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
 
 	  //set the initial energy deposit

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -166,15 +166,14 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
 	  {
-	    int trkoffset = 0;
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+            hit->set_trkid(aTrack->GetTrackID());
+            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-	    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
 
 	  //set the initial energy deposit

--- a/simulation/g4simulation/g4detectors/PHG4RICHSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHSteppingAction.cc
@@ -145,15 +145,14 @@ bool PHG4RICHSteppingAction::MakeHit(const G4Step* aStep){
 
   //set the track ID
   {
-    int trkoffset = 0;
+    hit->set_trkid(aTrack->GetTrackID());
     if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
       {
-        if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-          {
-            trkoffset = pp->GetTrackIdOffset();
-          }
+	if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+	  {
+	    hit->set_trkid(pp->GetUserTrackId());
+	  }
       }
-    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
   }
 
   // set optical photon energy deposition to 0

--- a/simulation/g4simulation/g4detectors/PHG4SectorSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSteppingAction.cc
@@ -65,19 +65,17 @@ PHG4SectorSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         hit->set_z(0, prePoint->GetPosition().z() / cm);
         // time in ns
         hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
-        //set the track ID
-          {
-            int trkoffset = 0;
-            if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
-              {
-                if (PHG4TrackUserInfoV1* pp =
-                    dynamic_cast<PHG4TrackUserInfoV1*>(p))
-                  {
-                    trkoffset = pp->GetTrackIdOffset();
-                  }
-              }
-            hit->set_trkid(aTrack->GetTrackID() + trkoffset);
-          }
+	//set the track ID
+	{
+	  hit->set_trkid(aTrack->GetTrackID());
+	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+	    {
+	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		{
+		  hit->set_trkid(pp->GetUserTrackId());
+		}
+	    }
+	}
 
         //set the initial energy deposit
         hit->set_edep(0);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -189,15 +189,14 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction( const G4Step* aStep, 
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
 	  {
-	    int trkoffset = 0;
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+            hit->set_trkid(aTrack->GetTrackID());
+            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	      {
 		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		  {
-		    trkoffset = pp->GetTrackIdOffset();
+		    hit->set_trkid(pp->GetUserTrackId());
 		  }
 	      }
-	    hit->set_trkid(aTrack->GetTrackID() + trkoffset);
 	  }
 	  //set the initial energy deposit
 	  hit->set_edep(0);

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
@@ -136,19 +136,17 @@ PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
         // time in ns
         hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
-        //set the track ID
-          {
-            int trkoffset = 0;
-            if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
-              {
-                if (PHG4TrackUserInfoV1* pp =
-                    dynamic_cast<PHG4TrackUserInfoV1*>(p))
-                  {
-                    trkoffset = pp->GetTrackIdOffset();
-                  }
-              }
-            hit->set_trkid(aTrack->GetTrackID() + trkoffset);
-          }
+	//set the track ID
+	{
+	  hit->set_trkid(aTrack->GetTrackID());
+	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+	    {
+	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		{
+		  hit->set_trkid(pp->GetUserTrackId());
+		}
+	    }
+	}
         //set the initial energy deposit
         hit->set_edep(0);
         if (isactive == PHG4SpacalDetector::FIBER_CORE) // only for active areas

--- a/simulation/g4simulation/g4eval/BaseTruthEval.C
+++ b/simulation/g4simulation/g4eval/BaseTruthEval.C
@@ -39,7 +39,7 @@ PHG4Particle* BaseTruthEval::get_particle(PHG4Hit* g4hit) {
   if (_strict) {assert(g4hit);}
   else if (!g4hit) {++_errors; return NULL;}
   
-  PHG4Particle* particle = _truthinfo->GetHit( g4hit->get_trkid() );
+  PHG4Particle* particle = _truthinfo->GetParticle( g4hit->get_trkid() );
   if (_strict) {assert(particle);}
   else if (!particle) {++_errors;}
   
@@ -112,9 +112,9 @@ PHG4Particle* BaseTruthEval::get_primary(PHG4Particle* particle) {
   // primary from the full Map was the argument
   PHG4Particle* returnval = NULL;
   if (particle->get_primary_id() != -1) {
-    returnval = _truthinfo->GetPrimaryHit( particle->get_primary_id() );
+    returnval = _truthinfo->GetPrimaryParticle( particle->get_primary_id() );
   } else {
-    returnval = _truthinfo->GetPrimaryHit( particle->get_track_id() );
+    returnval = _truthinfo->GetPrimaryParticle( particle->get_track_id() );
   }
 
   if (_strict) {assert(returnval);}

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -223,9 +223,9 @@ void CaloEvaluator::printOutputInfo(PHCompositeNode *topNode) {
 
     cout << "vtrue = (" << gvx << "," << gvy << "," << gvz << ") => vreco = (" << vx << "," << vy << "," << vz << ")" << endl;
 
-    PHG4TruthInfoContainer::Map map = truthinfo->GetPrimaryMap();
-    for (PHG4TruthInfoContainer::ConstIterator iter = map.begin(); 
-	 iter != map.end(); 
+    PHG4TruthInfoContainer::ConstRange range = truthinfo->GetPrimaryParticleRange();
+    for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
+	 iter != range.second; 
 	 ++iter) {
       PHG4Particle* primary = iter->second;
       
@@ -376,11 +376,12 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       cerr << PHWHERE << " ERROR: Can't find G4TruthInfo" << endl;
       exit(-1);
     }
-    
-    PHG4TruthInfoContainer::Map map = truthinfo->GetPrimaryMap();
-    for (PHG4TruthInfoContainer::ConstIterator iter = map.begin(); 
-	 iter != map.end(); 
+
+    PHG4TruthInfoContainer::ConstRange range = truthinfo->GetPrimaryParticleRange();
+    for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
+	 iter != range.second; 
 	 ++iter) {
+    
       PHG4Particle* primary = iter->second;
 
       if (primary->get_e() < _truth_e_threshold) continue;

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -161,7 +161,7 @@ void CaloEvaluator::printInputInfo(PHCompositeNode *topNode) {
     
     cout << "PHG4TruthInfoContainer contents: " << endl; 
 
-    PHG4TruthInfoContainer::Range truthrange = truthinfo->GetHitRange();
+    PHG4TruthInfoContainer::Range truthrange = truthinfo->GetParticleRange();
     for(PHG4TruthInfoContainer::Iterator truthiter = truthrange.first;
 	truthiter != truthrange.second;
 	++truthiter) {

--- a/simulation/g4simulation/g4eval/JetTruthEval.C
+++ b/simulation/g4simulation/g4eval/JetTruthEval.C
@@ -85,7 +85,7 @@ std::set<PHG4Particle*> JetTruthEval::all_truth_particles(Jet* truthjet) {
       exit(-1);
     }
 
-    PHG4Particle* truth_particle = _truthinfo->GetHit(index);
+    PHG4Particle* truth_particle = _truthinfo->GetParticle(index);
     
     if (_strict) {assert(truth_particle);}
     else if (!truth_particle) {++_errors; continue;}
@@ -221,7 +221,7 @@ Jet* JetTruthEval::get_truth_jet(PHG4Particle* particle) {
 	 ++jter) {
       unsigned int index = jter->second;
       
-      PHG4Particle* constituent = _truthinfo->GetHit( index );
+      PHG4Particle* constituent = _truthinfo->GetParticle( index );
       if (_strict) {assert(constituent);}
       else if (!constituent) {++_errors; continue;}
 

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.C
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.C
@@ -162,7 +162,7 @@ std::set<PHG4Particle*> SvtxClusterEval::all_truth_particles(SvtxCluster* cluste
        iter != g4hits.end();
        ++iter) {
     PHG4Hit* hit = *iter;
-    PHG4Particle* particle = _truthinfo->GetHit( hit->get_trkid() );
+    PHG4Particle* particle = get_truth_eval()->get_particle(hit);
 
     if (_strict) {assert(particle);}
     else if (!particle) {++_errors; continue;}

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -363,7 +363,8 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode *topNode) {
 
     SvtxTrackMap* trackmap = findNode::getClass<SvtxTrackMap>(topNode,"SvtxTrackMap");
     
-    cout << "nGtracks = " << truthinfo->GetPrimaryMap().size();
+    cout << "nGtracks = " << std::distance(truthinfo->GetPrimaryParticleRange().first,
+					  truthinfo->GetPrimaryParticleRange().second);
     cout << " => nTracks = ";
     if (trackmap) cout << trackmap->size() << endl;
     else cout << 0 << endl;
@@ -391,11 +392,11 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode *topNode) {
 	}
       }
 
-      PHG4TruthInfoContainer::Map primarymap = truthinfo->GetPrimaryMap();
-      for (PHG4TruthInfoContainer::Iterator iter = primarymap.begin();
-	   iter != primarymap.end();
+      PHG4TruthInfoContainer::ConstRange range = truthinfo->GetPrimaryParticleRange();
+      for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
+	   iter != range.second; 
 	   ++iter) {
-      
+	
 	PHG4Particle *particle = iter->second;
 
 	// track-wise information
@@ -1078,10 +1079,12 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
     PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");   
     SvtxClusterMap* clustermap = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
     if (truthinfo) {
-      PHG4TruthInfoContainer::Map map = truthinfo->GetPrimaryMap();
-      for (PHG4TruthInfoContainer::ConstIterator iter = map.begin(); 
-	   iter != map.end(); 
-	   ++iter) {
+
+      PHG4TruthInfoContainer::ConstRange range = truthinfo->GetPrimaryParticleRange();
+      for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
+	   iter != range.second; 
+	 ++iter) {
+	
 	PHG4Particle* g4particle = iter->second;
     
 	float gtrackID = g4particle->get_track_id();

--- a/simulation/g4simulation/g4eval/SvtxHitEval.C
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.C
@@ -183,7 +183,7 @@ std::set<PHG4Particle*> SvtxHitEval::all_truth_particles(SvtxHit* hit) {
        iter != g4hits.end();
        ++iter) {
     PHG4Hit* g4hit = *iter;
-    PHG4Particle* particle = _truthinfo->GetHit( g4hit->get_trkid() );
+    PHG4Particle* particle = get_truth_eval()->get_particle( g4hit );
 
     if (_strict) assert(particle);
     else if (!particle) {++_errors; continue;}

--- a/simulation/g4simulation/g4histos/G4SnglNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4SnglNtuple.cc
@@ -59,11 +59,11 @@ G4SnglNtuple::process_event( PHCompositeNode* topNode )
   PHG4TruthInfoContainer* truthInfoList 
     =  findNode::getClass<PHG4TruthInfoContainer>(topNode , "G4TruthInfo" );
 
-  const PHG4TruthInfoContainer::Map primMap = truthInfoList->GetPrimaryMap();
-  double px = primMap.begin()->second->get_px();
-  double py = primMap.begin()->second->get_py();
-  double pz = primMap.begin()->second->get_pz();
-  double e = primMap.begin()->second->get_e();
+  const PHG4TruthInfoContainer::Range primRange = truthInfoList->GetPrimaryParticleRange();
+  double px = primRange.first->second->get_px();
+  double py = primRange.first->second->get_py();
+  double pz = primRange.first->second->get_pz();
+  double e = primRange.first->second->get_e();
   double pt = sqrt(px * px + py * py);
   double phi = atan2(py, px);
   double theta = atan2(pt, pz);

--- a/simulation/g4simulation/g4histos/G4SnglTree.cc
+++ b/simulation/g4simulation/g4histos/G4SnglTree.cc
@@ -84,11 +84,11 @@ G4SnglTree::process_event( PHCompositeNode* topNode )
 	PHG4TruthInfoContainer* truthInfoList 
 		=  findNode::getClass<PHG4TruthInfoContainer>(topNode , "G4TruthInfo" );
 
-	const PHG4TruthInfoContainer::Map primMap = truthInfoList->GetPrimaryMap();
-	double px = primMap.begin()->second->get_px();
-	double py = primMap.begin()->second->get_py();
-	double pz = primMap.begin()->second->get_pz();
-	double e = primMap.begin()->second->get_e();
+	const PHG4TruthInfoContainer::Range primRange = truthInfoList->GetPrimaryParticleRange();
+	double px = primRange.first->second->get_px();
+	double py = primRange.first->second->get_py();
+	double pz = primRange.first->second->get_pz();
+	double e = primRange.first->second->get_e();
 	double pt = sqrt(px * px + py * py);
 	double phi = atan2(py, px);
 	double theta = atan2(pt, pz);

--- a/simulation/g4simulation/g4jets/TruthJetInput.C
+++ b/simulation/g4simulation/g4jets/TruthJetInput.C
@@ -45,9 +45,9 @@ std::vector<Jet*> TruthJetInput::get_input(PHCompositeNode *topNode) {
   }
 
   std::vector<Jet*> pseudojets;
-  PHG4TruthInfoContainer::Map primary_map = truthinfo->GetPrimaryMap();
-  for (PHG4TruthInfoContainer::ConstIterator iter = primary_map.begin(); 
-       iter != primary_map.end(); 
+  PHG4TruthInfoContainer::ConstRange range = truthinfo->GetPrimaryParticleRange();
+  for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
+       iter != range.second; 
        ++iter) {
     PHG4Particle *part = iter->second;
 

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -191,7 +191,7 @@ HepMCNodeReader::process_event(PHCompositeNode *topNode)
 	      particle->set_py((*fiter)->momentum().py()*mom_factor);
 	      particle->set_pz((*fiter)->momentum().pz()*mom_factor);
 	      ineve->AddParticle((*v)->barcode(), particle);
-	      if (_embed_flag != 0) ineve->AddEmbeddedParticle(particle);
+	      if (_embed_flag != 0) ineve->AddEmbeddedParticle(particle,_embed_flag);
 	    }
 	}
     }

--- a/simulation/g4simulation/g4main/PHG4ConsistencyCheck.cc
+++ b/simulation/g4simulation/g4main/PHG4ConsistencyCheck.cc
@@ -29,7 +29,7 @@ PHG4ConsistencyCheck::process_event(PHCompositeNode *topNode)
     {
       return 0;
     }
-  PHG4TruthInfoContainer::ConstRange trange = truthcont->GetHitRange();
+  PHG4TruthInfoContainer::ConstRange trange = truthcont->GetParticleRange();
   PHG4TruthInfoContainer::ConstIterator titer;
   int imax = 1000000;
   for (titer = trange.first; titer != trange.second; titer++)
@@ -56,7 +56,7 @@ PHG4ConsistencyCheck::process_event(PHCompositeNode *topNode)
         {
 
           int trkid = hit->second->get_trkid();
-          PHG4Particle* part = truthcont->GetHit(trkid);
+          PHG4Particle* part = truthcont->GetParticle(trkid);
           if (!part)
             {
               hit->second->identify();
@@ -72,7 +72,7 @@ PHG4ConsistencyCheck::process_event(PHCompositeNode *topNode)
                     {
                       cout << "primary id " << primary_id << " is embedded" << endl;
                       printpart.insert(primary_id);
-                      PHG4Particle* parta = truthcont->GetHit(primary_id);
+                      PHG4Particle* parta = truthcont->GetParticle(primary_id);
                       parta->identify();
                     }
                 }
@@ -87,7 +87,7 @@ PHG4ConsistencyCheck::process_event(PHCompositeNode *topNode)
       for (hit = hit_begin_end.first; hit != hit_begin_end.second; hit++)
         {
           int trkid = hit->second->get_trkid();
-          PHG4Particle* part = truthcont->GetHit(trkid);
+          PHG4Particle* part = truthcont->GetParticle(trkid);
           if (!part)
             {
               cout << "could not locate geant particle " << trkid << " in G4HIT_SVTX" << endl;

--- a/simulation/g4simulation/g4main/PHG4ConsistencyCheck.cc
+++ b/simulation/g4simulation/g4main/PHG4ConsistencyCheck.cc
@@ -40,11 +40,11 @@ PHG4ConsistencyCheck::process_event(PHCompositeNode *topNode)
         }
     }
   cout << "min index: " << imax << endl;
-  std::pair< std::set<int>::const_iterator, std::set<int>::const_iterator > embtrk_b_e = truthcont->GetEmbeddedTrkIds();
-  std::set<int>::const_iterator embiter;
+  std::pair< std::map<int,int>::const_iterator, std::map<int,int>::const_iterator > embtrk_b_e = truthcont->GetEmbeddedTrkIds();
+  std::map<int,int>::const_iterator embiter;
   for (embiter = embtrk_b_e.first; embiter != embtrk_b_e.second; embiter++)
     {
-      cout << "embedded trkid: " << *embiter << endl;
+      cout << "embedded trkid: " << embiter->first << endl;
     }
   PHG4HitContainer *ghit = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_CEMC_E");
   if (ghit)

--- a/simulation/g4simulation/g4main/PHG4InEvent.cc
+++ b/simulation/g4simulation/g4main/PHG4InEvent.cc
@@ -149,9 +149,9 @@ PHG4InEvent::identify(ostream& os) const
   if (!embedded_particlelist.empty())
     {
       os << "embedded particles:" << endl;
-      for (set<PHG4Particle *>::const_iterator iter = embedded_particlelist.begin(); iter != embedded_particlelist.end(); ++iter)
+      for (map<PHG4Particle *,int>::const_iterator iter = embedded_particlelist.begin(); iter != embedded_particlelist.end(); ++iter)
 	{
-	  (*iter)->identify(os);
+	  (iter->first)->identify(os);
 	}
     }
   else
@@ -164,11 +164,12 @@ PHG4InEvent::identify(ostream& os) const
 int
 PHG4InEvent::isEmbeded(PHG4Particle *p) const
 {
-  if (embedded_particlelist.find(p) != embedded_particlelist.end())
-    {
-      return true;
-    }
-  return false;
+  std::map<PHG4Particle*,int>::const_iterator iter = embedded_particlelist.find(p);
+  if (iter == embedded_particlelist.end()) {
+    return 0;
+  }
+
+  return iter->second;
 }
 
 void

--- a/simulation/g4simulation/g4main/PHG4InEvent.h
+++ b/simulation/g4simulation/g4main/PHG4InEvent.h
@@ -22,14 +22,14 @@ class PHG4InEvent: public PHObject
   int AddVtx(const double x, const double y, const double z, const double t);
   int AddVtx(const int id,const PHG4VtxPoint &);
   int AddParticle(const int vtxid, PHG4Particle *particle);
-  void AddEmbeddedParticle(PHG4Particle *particle) {embedded_particlelist.insert(particle);}
+  void AddEmbeddedParticle(PHG4Particle *particle, int flag) {embedded_particlelist.insert(std::make_pair(particle,flag));}
 
   //  PHG4VtxPoint *GetVtx() {return vtxlist.begin()->second;}
   std::pair< std::map<int, PHG4VtxPoint *>::const_iterator, std::map<int, PHG4VtxPoint *>::const_iterator > GetVertices() const;
   std::pair< std::multimap<int,PHG4Particle *>::const_iterator, std::multimap<int,PHG4Particle *>::const_iterator > GetParticles(const int vtxid) const;
   std::pair< std::multimap<int,PHG4Particle *>::const_iterator, std::multimap<int,PHG4Particle *>::const_iterator > GetParticles() const;
   std::pair< std::multimap<int,PHG4Particle *>::iterator, std::multimap<int,PHG4Particle *>::iterator > GetParticles_Modify();
-  std::pair< std::set<PHG4Particle *>::const_iterator, std::set<PHG4Particle *>::const_iterator> GetEmbeddedParticles() const
+  std::pair< std::map<PHG4Particle *,int>::const_iterator, std::map<PHG4Particle *,int>::const_iterator> GetEmbeddedParticles() const
     {return std::make_pair(embedded_particlelist.begin(), embedded_particlelist.end());}
   int isEmbeded(PHG4Particle *) const;
   int GetNEmbedded() const {return embedded_particlelist.size();}
@@ -41,7 +41,7 @@ class PHG4InEvent: public PHObject
   int AddVtxCommon(PHG4VtxPoint *newvtx);
   std::map<int,PHG4VtxPoint *> vtxlist;
   std::multimap<int,PHG4Particle *> particlelist;
-  std::set<PHG4Particle *> embedded_particlelist;
+  std::map<PHG4Particle *,int> embedded_particlelist;
 
   ClassDef(PHG4InEvent,1)
 };

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
@@ -196,7 +196,7 @@ PHG4ParticleGeneratorBase::SetParticleId(PHG4Particle * particle, PHG4InEvent *i
     }
   if (embedflag)
     {
-      ineve->AddEmbeddedParticle(particle);
+      ineve->AddEmbeddedParticle(particle,embedflag);
     }
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
@@ -239,7 +239,7 @@ PHG4ParticleGeneratorD0::process_event(PHCompositeNode *topNode)
       PHG4Particle *particle = new PHG4Particlev1(*iter);
       SetParticleId(particle,ineve);
       ineve->AddParticle(vtxindex, particle);
-      if(_embedflag!=0) { ineve->AddEmbeddedParticle(particle); }
+      if(_embedflag!=0) { ineve->AddEmbeddedParticle(particle,embedflag); }
     }
 
   // List what has been put into ineve for this event

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -280,7 +280,7 @@ PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
       PHG4Particle *particle = new PHG4Particlev1(*iter);
       SetParticleId(particle,ineve);
       ineve->AddParticle(vtxindex, particle);
-      if(_embedflag!=0) { ineve->AddEmbeddedParticle(particle); }
+      if(_embedflag!=0) { ineve->AddEmbeddedParticle(particle,embedflag); }
     }
 
   // List what has been put into ineve for this event

--- a/simulation/g4simulation/g4main/PHG4PrimaryGeneratorAction.cc
+++ b/simulation/g4simulation/g4main/PHG4PrimaryGeneratorAction.cc
@@ -112,7 +112,7 @@ PHG4PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
             }
           if (inEvent->isEmbeded(particle_iter->second))
             {
-              PHG4UserPrimaryParticleInformation *userdata = new PHG4UserPrimaryParticleInformation(1);
+              PHG4UserPrimaryParticleInformation *userdata = new PHG4UserPrimaryParticleInformation(inEvent->isEmbeded(particle_iter->second));
               g4part->SetUserInformation(userdata);
             }
           vertex->SetPrimary(g4part);

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -5,6 +5,7 @@
 #include "PHG4PhenixDetector.h"
 #include "PHG4PhenixSteppingAction.h"
 #include "PHG4PhenixTrackingAction.h"
+#include "PHG4TrackingAction.h"
 #include "PHG4PhenixEventAction.h"
 #include "PHG4Subsystem.h"
 #include "PHG4InEvent.h"
@@ -327,9 +328,20 @@ PHG4Reco::InitRun( PHCompositeNode* topNode )
   BOOST_FOREACH( PHG4Subsystem * g4sub, subsystems_)
     {
       trackingAction_->AddAction( g4sub->GetTrackingAction() );
-    }
-  runManager_->SetUserAction(trackingAction_ );
 
+      // not all subsystems define a user tracking action
+      if (g4sub->GetTrackingAction())
+	{
+	  // make tracking manager accessible within user tracking action if defined
+	  if( G4TrackingManager* trackingManager = G4EventManager::GetEventManager()->GetTrackingManager() )
+	    {
+	      g4sub->GetTrackingAction()->SetTrackingManagerPointer(trackingManager);
+	    }
+	}
+    }
+
+  runManager_->SetUserAction(trackingAction_ );
+  
   // initialize
   runManager_->Initialize();
 
@@ -391,9 +403,9 @@ PHG4Reco::InitRun( PHCompositeNode* topNode )
 
   // needs large amount of memory which kills central hijing events
   // store generated trajectories
-  //   if( G4TrackingManager* trackingManager = G4EventManager::GetEventManager()->GetTrackingManager() ){
-  //     trackingManager->SetStoreTrajectory( true );
-  //   }
+  //if( G4TrackingManager* trackingManager = G4EventManager::GetEventManager()->GetTrackingManager() ){
+  //  trackingManager->SetStoreTrajectory( true );
+  //}
 
   // quiet some G4 print-outs (EM and Hadronic settings during first event)
   G4HadronicProcessStore::Instance()->SetVerbose(0);

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
@@ -301,7 +301,7 @@ int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
       particle->set_e(e);
 
       _ineve->AddParticle(vtxindex, particle);
-      if (embedflag != 0) _ineve->AddEmbeddedParticle(particle);
+      if (embedflag != 0) _ineve->AddEmbeddedParticle(particle,embedflag);
     }
   }
 

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
@@ -3,56 +3,46 @@
 #include <Geant4/G4Track.hh>
 #include <boost/lexical_cast.hpp>
 
-namespace PHG4TrackUserInfo
-{
-  // void SetTrackIdOffset(G4Track* track, const int trkidoffset)
-  // {
-  //   if ( G4VUserTrackInformation* p = track->GetUserInformation() )
-  //     {
-  // 	// User info exists, test it for something valid
-  // 	if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-  // 	  {
-  // 	    pp->SetTrackIdOffset(trkidoffset);
-  // 	  }
-  // 	else
-  // 	  {
-  // 	    std::cout << "Unknown UserTrackInformation stored in track number "
-  // 		      << boost::lexical_cast<std::string>(track->GetTrackID())
-  // 		      << std::endl;
-  // 	  }
-  //     }
-  //   else
-  //     {
-  // 	// User info does not exist, add it.
-  // 	PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
-  // 	pp->SetTrackIdOffset(trkidoffset);
-  // 	track->SetUserInformation(pp);
-  //     }
-  // }
-  void SetUserTrackId(G4Track* track, const int usertrackid)
-  {
-    if ( G4VUserTrackInformation* p = track->GetUserInformation() )
-      {
-	// User info exists, test it for something valid
-	if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-	  {
-	    pp->SetUserTrackId(usertrackid);
-	  }
-	else
-	  {
-	    std::cout << "Unknown UserTrackInformation stored in track number "
-		      << boost::lexical_cast<std::string>(track->GetTrackID())
-		      << std::endl;
-	  }
-      }
-    else
-      {
-	// User info does not exist, add it.
-	PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
+namespace PHG4TrackUserInfo {
+  
+  void SetUserTrackId(G4Track* track, const int usertrackid) {
+
+    if ( G4VUserTrackInformation* p = track->GetUserInformation() ) {
+      // User info exists, test it for something valid
+      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) ) {
 	pp->SetUserTrackId(usertrackid);
-	track->SetUserInformation(pp);
+      } else {
+	std::cout << "Unknown UserTrackInformation stored in track number "
+		  << boost::lexical_cast<std::string>(track->GetTrackID())
+		  << std::endl;
       }
+    } else {
+      // User info does not exist, add it.
+      PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
+      pp->SetUserTrackId(usertrackid);
+      track->SetUserInformation(pp);
+    }
   }
+
+  void SetUserParentId(G4Track* track, const int usertrackid) {
+
+    if ( G4VUserTrackInformation* p = track->GetUserInformation() ) {
+      // User info exists, test it for something valid
+      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) ) {
+	pp->SetUserParentId(usertrackid);
+      } else {
+	std::cout << "Unknown UserTrackInformation stored in track number "
+		  << boost::lexical_cast<std::string>(track->GetTrackID())
+		  << std::endl;
+      }
+    } else {
+      // User info does not exist, add it.
+      PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
+      pp->SetUserParentId(usertrackid);
+      track->SetUserInformation(pp);
+    }
+  }
+  
   void SetWanted(G4Track* track, const int trkid)
   {
     if ( G4VUserTrackInformation* p = track->GetUserInformation() )

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
@@ -29,6 +29,30 @@ namespace PHG4TrackUserInfo
 	track->SetUserInformation(pp);
       }
   }
+  void SetUserTrackId(G4Track* track, const int usertrackid)
+  {
+    if ( G4VUserTrackInformation* p = track->GetUserInformation() )
+      {
+	// User info exists, test it for something valid
+	if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+	  {
+	    pp->SetUserTrackId(usertrackid);
+	  }
+	else
+	  {
+	    std::cout << "Unknown UserTrackInformation stored in track number "
+		      << boost::lexical_cast<std::string>(track->GetTrackID())
+		      << std::endl;
+	  }
+      }
+    else
+      {
+	// User info does not exist, add it.
+	PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
+	pp->SetUserTrackId(usertrackid);
+	track->SetUserInformation(pp);
+      }
+  }
   void SetWanted(G4Track* track, const int trkid)
   {
     if ( G4VUserTrackInformation* p = track->GetUserInformation() )

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
@@ -3,7 +3,7 @@
 #include <Geant4/G4Track.hh>
 #include <boost/lexical_cast.hpp>
 
-namespace PHG4TrackUserInfo {
+namespace PHG4TrackUserInfo { 
   
   void SetUserTrackId(G4Track* track, const int usertrackid) {
 
@@ -23,7 +23,7 @@ namespace PHG4TrackUserInfo {
       track->SetUserInformation(pp);
     }
   }
-
+  
   void SetUserParentId(G4Track* track, const int userparentid) {
 
     if ( G4VUserTrackInformation* p = track->GetUserInformation() ) {

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
@@ -24,12 +24,12 @@ namespace PHG4TrackUserInfo {
     }
   }
 
-  void SetUserParentId(G4Track* track, const int usertrackid) {
+  void SetUserParentId(G4Track* track, const int userparentid) {
 
     if ( G4VUserTrackInformation* p = track->GetUserInformation() ) {
       // User info exists, test it for something valid
       if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) ) {
-	pp->SetUserParentId(usertrackid);
+	pp->SetUserParentId(userparentid);
       } else {
 	std::cout << "Unknown UserTrackInformation stored in track number "
 		  << boost::lexical_cast<std::string>(track->GetTrackID())
@@ -38,7 +38,26 @@ namespace PHG4TrackUserInfo {
     } else {
       // User info does not exist, add it.
       PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
-      pp->SetUserParentId(usertrackid);
+      pp->SetUserParentId(userparentid);
+      track->SetUserInformation(pp);
+    }
+  }
+
+  void SetUserPrimaryId(G4Track* track, const int userprimaryid) {
+    
+    if ( G4VUserTrackInformation* p = track->GetUserInformation() ) {
+      // User info exists, test it for something valid
+      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) ) {
+	pp->SetUserPrimaryId(userprimaryid);
+      } else {
+	std::cout << "Unknown UserTrackInformation stored in track number "
+		  << boost::lexical_cast<std::string>(track->GetTrackID())
+		  << std::endl;
+      }
+    } else {
+      // User info does not exist, add it.
+      PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
+      pp->SetUserPrimaryId(userprimaryid);
       track->SetUserInformation(pp);
     }
   }

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
@@ -5,30 +5,30 @@
 
 namespace PHG4TrackUserInfo
 {
-  void SetTrackIdOffset(G4Track* track, const int trkidoffset)
-  {
-    if ( G4VUserTrackInformation* p = track->GetUserInformation() )
-      {
-	// User info exists, test it for something valid
-	if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-	  {
-	    pp->SetTrackIdOffset(trkidoffset);
-	  }
-	else
-	  {
-	    std::cout << "Unknown UserTrackInformation stored in track number "
-		      << boost::lexical_cast<std::string>(track->GetTrackID())
-		      << std::endl;
-	  }
-      }
-    else
-      {
-	// User info does not exist, add it.
-	PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
-	pp->SetTrackIdOffset(trkidoffset);
-	track->SetUserInformation(pp);
-      }
-  }
+  // void SetTrackIdOffset(G4Track* track, const int trkidoffset)
+  // {
+  //   if ( G4VUserTrackInformation* p = track->GetUserInformation() )
+  //     {
+  // 	// User info exists, test it for something valid
+  // 	if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+  // 	  {
+  // 	    pp->SetTrackIdOffset(trkidoffset);
+  // 	  }
+  // 	else
+  // 	  {
+  // 	    std::cout << "Unknown UserTrackInformation stored in track number "
+  // 		      << boost::lexical_cast<std::string>(track->GetTrackID())
+  // 		      << std::endl;
+  // 	  }
+  //     }
+  //   else
+  //     {
+  // 	// User info does not exist, add it.
+  // 	PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
+  // 	pp->SetTrackIdOffset(trkidoffset);
+  // 	track->SetUserInformation(pp);
+  //     }
+  // }
   void SetUserTrackId(G4Track* track, const int usertrackid)
   {
     if ( G4VUserTrackInformation* p = track->GetUserInformation() )

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
@@ -14,28 +14,28 @@ class PHG4TrackUserInfoV1 : public G4VUserTrackInformation
 {
 public:
   PHG4TrackUserInfoV1() : G4VUserTrackInformation("TrackUserInfoV1"),
-			  usertrackid(0), wanted(0), keep(0) {}
+			  usertrackid(0), userparentid(0), wanted(0), keep(0) {}
   virtual ~PHG4TrackUserInfoV1() {}
   void Print() const 
   {
     G4cout << "PHG4TrackUserInfoV1: " << std::endl;
-    //G4cout << "   TrackIdOffset = " << trackidoffset << std::endl;
     G4cout << "   UserTrackId = " << usertrackid << std::endl;
+    G4cout << "   UserParentId = " << userparentid << std::endl;
     G4cout << "   Wanted = " << wanted << std::endl;
     G4cout << "   Keep = " << keep << std::endl;
   }
-  //void SetTrackIdOffset (const int val) { trackidoffset = val; }
-  //int GetTrackIdOffset() const {return trackidoffset;}
   void SetUserTrackId(const int val) {usertrackid = val;}
   int GetUserTrackId() const {return usertrackid;}
+  void SetUserParentId(const int val) {userparentid = val;}
+  int GetUserParentId() const {return userparentid;}
   void SetWanted(const int val) {wanted = val;}
   int GetWanted() const {return wanted;}
   void SetKeep(const int val) {keep = val;}
   int GetKeep() const {return keep;}
 
 private:
-  //int trackidoffset;
   int usertrackid;
+  int userparentid;
   int wanted;
   int keep;
 };
@@ -46,8 +46,8 @@ class G4Track;
 
 namespace PHG4TrackUserInfo 
 {
-  //void SetTrackIdOffset(G4Track* track, const int trkidoffset);
   void SetUserTrackId(G4Track* track, const int usertrackid);
+  void SetUserParentId(G4Track* track, const int userparentid);
   void SetWanted(G4Track* track, const int wanted);
   void SetKeep(G4Track* track, const int keep);
 };

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
@@ -13,17 +13,21 @@
 class PHG4TrackUserInfoV1 : public G4VUserTrackInformation
 {
 public:
-  PHG4TrackUserInfoV1() : G4VUserTrackInformation("TrackUserInfoV1"), trackidoffset(0), wanted(0), keep(0) {}
+  PHG4TrackUserInfoV1() : G4VUserTrackInformation("TrackUserInfoV1"),
+			  trackidoffset(0), usertrackid(0), wanted(0), keep(0) {}
   virtual ~PHG4TrackUserInfoV1() {}
   void Print() const 
   {
     G4cout << "PHG4TrackUserInfoV1: " << std::endl;
     G4cout << "   TrackIdOffset = " << trackidoffset << std::endl;
+    G4cout << "   UserTrackId = " << usertrackid << std::endl;
     G4cout << "   Wanted = " << wanted << std::endl;
     G4cout << "   Keep = " << keep << std::endl;
   }
   void SetTrackIdOffset (const int val) { trackidoffset = val; }
   int GetTrackIdOffset() const {return trackidoffset;}
+  void SetUserTrackId(const int val) {usertrackid = val;}
+  int GetUserTrackId() const {return usertrackid;}
   void SetWanted(const int val) {wanted = val;}
   int GetWanted() const {return wanted;}
   void SetKeep(const int val) {keep = val;}
@@ -31,6 +35,7 @@ public:
 
 private:
   int trackidoffset;
+  int usertrackid;
   int wanted;
   int keep;
 };
@@ -42,6 +47,7 @@ class G4Track;
 namespace PHG4TrackUserInfo 
 {
   void SetTrackIdOffset(G4Track* track, const int trkidoffset);
+  void SetUserTrackId(G4Track* track, const int usertrackid);
   void SetWanted(G4Track* track, const int wanted);
   void SetKeep(G4Track* track, const int keep);
 };

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
@@ -25,7 +25,7 @@ public:
     G4cout << "   Keep = " << keep << std::endl;
   }
   void SetTrackIdOffset (const int val) { trackidoffset = val; }
-  int GetTrackIdOffset() const {return trackidoffset;}
+  //int GetTrackIdOffset() const {return trackidoffset;}
   void SetUserTrackId(const int val) {usertrackid = val;}
   int GetUserTrackId() const {return usertrackid;}
   void SetWanted(const int val) {wanted = val;}

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
@@ -14,13 +14,14 @@ class PHG4TrackUserInfoV1 : public G4VUserTrackInformation
 {
 public:
   PHG4TrackUserInfoV1() : G4VUserTrackInformation("TrackUserInfoV1"),
-			  usertrackid(0), userparentid(0), wanted(0), keep(0) {}
+			  usertrackid(0), userparentid(0), userprimaryid(0), wanted(0), keep(0) {}
   virtual ~PHG4TrackUserInfoV1() {}
   void Print() const 
   {
     G4cout << "PHG4TrackUserInfoV1: " << std::endl;
     G4cout << "   UserTrackId = " << usertrackid << std::endl;
     G4cout << "   UserParentId = " << userparentid << std::endl;
+    G4cout << "   UserPrimaryId = " << userprimaryid << std::endl;
     G4cout << "   Wanted = " << wanted << std::endl;
     G4cout << "   Keep = " << keep << std::endl;
   }
@@ -28,6 +29,8 @@ public:
   int GetUserTrackId() const {return usertrackid;}
   void SetUserParentId(const int val) {userparentid = val;}
   int GetUserParentId() const {return userparentid;}
+  void SetUserPrimaryId(const int val) {userprimaryid = val;}
+  int GetUserPrimaryId() const {return userprimaryid;}
   void SetWanted(const int val) {wanted = val;}
   int GetWanted() const {return wanted;}
   void SetKeep(const int val) {keep = val;}
@@ -36,6 +39,7 @@ public:
 private:
   int usertrackid;
   int userparentid;
+  int userprimaryid;
   int wanted;
   int keep;
 };
@@ -48,6 +52,7 @@ namespace PHG4TrackUserInfo
 {
   void SetUserTrackId(G4Track* track, const int usertrackid);
   void SetUserParentId(G4Track* track, const int userparentid);
+  void SetUserPrimaryId(G4Track* track, const int userprimaryid);
   void SetWanted(G4Track* track, const int wanted);
   void SetKeep(G4Track* track, const int keep);
 };

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
@@ -14,17 +14,17 @@ class PHG4TrackUserInfoV1 : public G4VUserTrackInformation
 {
 public:
   PHG4TrackUserInfoV1() : G4VUserTrackInformation("TrackUserInfoV1"),
-			  trackidoffset(0), usertrackid(0), wanted(0), keep(0) {}
+			  usertrackid(0), wanted(0), keep(0) {}
   virtual ~PHG4TrackUserInfoV1() {}
   void Print() const 
   {
     G4cout << "PHG4TrackUserInfoV1: " << std::endl;
-    G4cout << "   TrackIdOffset = " << trackidoffset << std::endl;
+    //G4cout << "   TrackIdOffset = " << trackidoffset << std::endl;
     G4cout << "   UserTrackId = " << usertrackid << std::endl;
     G4cout << "   Wanted = " << wanted << std::endl;
     G4cout << "   Keep = " << keep << std::endl;
   }
-  void SetTrackIdOffset (const int val) { trackidoffset = val; }
+  //void SetTrackIdOffset (const int val) { trackidoffset = val; }
   //int GetTrackIdOffset() const {return trackidoffset;}
   void SetUserTrackId(const int val) {usertrackid = val;}
   int GetUserTrackId() const {return usertrackid;}
@@ -34,7 +34,7 @@ public:
   int GetKeep() const {return keep;}
 
 private:
-  int trackidoffset;
+  //int trackidoffset;
   int usertrackid;
   int wanted;
   int keep;
@@ -46,7 +46,7 @@ class G4Track;
 
 namespace PHG4TrackUserInfo 
 {
-  void SetTrackIdOffset(G4Track* track, const int trkidoffset);
+  //void SetTrackIdOffset(G4Track* track, const int trkidoffset);
   void SetUserTrackId(G4Track* track, const int usertrackid);
   void SetWanted(G4Track* track, const int wanted);
   void SetKeep(G4Track* track, const int keep);

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
@@ -14,10 +14,11 @@ class PHG4TrackUserInfoV1 : public G4VUserTrackInformation
 {
 public:
   PHG4TrackUserInfoV1() : G4VUserTrackInformation("TrackUserInfoV1"),
-			  usertrackid(0), userparentid(0), userprimaryid(0), wanted(0), keep(0) {}
+			  usertrackid(0), userparentid(0), userprimaryid(0),
+			  wanted(0), keep(0) {}
   virtual ~PHG4TrackUserInfoV1() {}
-  void Print() const 
-  {
+
+  void Print() const {
     G4cout << "PHG4TrackUserInfoV1: " << std::endl;
     G4cout << "   UserTrackId = " << usertrackid << std::endl;
     G4cout << "   UserParentId = " << userparentid << std::endl;
@@ -25,14 +26,19 @@ public:
     G4cout << "   Wanted = " << wanted << std::endl;
     G4cout << "   Keep = " << keep << std::endl;
   }
+
   void SetUserTrackId(const int val) {usertrackid = val;}
   int GetUserTrackId() const {return usertrackid;}
+  
   void SetUserParentId(const int val) {userparentid = val;}
   int GetUserParentId() const {return userparentid;}
+
   void SetUserPrimaryId(const int val) {userprimaryid = val;}
   int GetUserPrimaryId() const {return userprimaryid;}
+
   void SetWanted(const int val) {wanted = val;}
   int GetWanted() const {return wanted;}
+
   void SetKeep(const int val) {keep = val;}
   int GetKeep() const {return keep;}
 

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -26,6 +26,7 @@ PHG4TruthEventAction::PHG4TruthEventAction( void ):
   truthInfoList_( 0 ),
   primarytrackidoffset(0),
   secondarytrackidoffset(0),
+  primarymaptrackidoffset(0),
   vertexid_(0)
 {}
 
@@ -170,7 +171,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
               primaryid = particle->get_track_id(); // this particle is the primary truth
               assert (primaryid > secondarytrackidoffset);
               primaryid -= secondarytrackidoffset; // recovery the Geant4 track ID = inEvent track ID
-              primaryid += primarytrackidoffset; // ID for the primary track in truth container
+              primaryid += primarymaptrackidoffset; // ID for the primary track in truth container
 
               break;
             }
@@ -208,7 +209,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
 	if (userdata->get_embed())
 	  {
 //      truthInfoList_->AddEmbededTrkId(part->GetTrackID()+ trackidoffset); // use G4 particle list ID for the embedded list
-      truthInfoList_->AddEmbededTrkId(part->GetTrackID()+ primarytrackidoffset); // use primary ID for the embedded list
+      truthInfoList_->AddEmbededTrkId(part->GetTrackID()+ primarymaptrackidoffset); // use primary ID for the embedded list
 	  }
       }
       part = part->GetNext();

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -52,7 +52,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
   for (write_iter = writeList_.begin(); write_iter != writeList_.end(); ++write_iter)
     {
       G4int mytrkid = *write_iter;
-      PHG4Particle *particle = truthInfoList_->GetHit(mytrkid);
+      PHG4Particle *particle = truthInfoList_->GetParticle(mytrkid);
       // if track is already in save list, nothing needs to be done
       if (savelist.find(mytrkid) != savelist.end())
         {
@@ -68,7 +68,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
       G4int parentid = particle->get_parent_id();
       while (savelist.find(parentid) == savelist.end() && parentid > 0)
         {
-          particle = truthInfoList_->GetHit(parentid);
+          particle = truthInfoList_->GetParticle(parentid);
           wrttracks.push_back(parentid);
           wrtvtx.push_back(particle->get_vtx_id());
           parentid = particle->get_parent_id();
@@ -90,7 +90,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
   // loop over particles in truth list and remove them if they are not
   // in the save list andare not primary particles (parent_id == 0)
   int removed[4] = {0};
-  PHG4TruthInfoContainer::Range truth_range = truthInfoList_->GetHitRange();
+  PHG4TruthInfoContainer::Range truth_range = truthInfoList_->GetParticleRange();
   PHG4TruthInfoContainer::Iterator truthiter = truth_range.first;
   while (truthiter != truth_range.second)
     {
@@ -105,7 +105,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
 	  // for regular sims, trackidoffset is zero
           if ((truthiter->second)->get_parent_id() != 0 && truthiter->first > trackidoffset)
             {
-              truthInfoList_->delete_hit(truthiter++);
+              truthInfoList_->delete_particle(truthiter++);
               removed[1]++;
             }
           else
@@ -144,7 +144,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
   // --- fill primary truth fields --------------------------
 
   // loop over all truth entries now that those entries are full
-  truth_range = truthInfoList_->GetHitRange();
+  truth_range = truthInfoList_->GetParticleRange();
   for (truthiter = truth_range.first; truthiter != truth_range.second; ++truthiter)
     {
       // do not handle primary particle which are stored with negative track ids
@@ -176,7 +176,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
             }
 
           // otherwise advance to the next particle in the ancestry
-          particle = truthInfoList_->GetHit(particle->get_parent_id());
+          particle = truthInfoList_->GetParticle(particle->get_parent_id());
 
           // the last parent seen will know the primary truth particle
           primaryid = particle->get_primary_id();

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -52,6 +52,9 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt) {
     std::cout << "PHG4TruthEventAction::EndOfEventAction - unable to find G4TruthInfo node" << std::endl;
     return;
   }
+
+  // construct a list of track ids to preserve in the the output that includes any
+  // track designated in the writeList_ during processing or its ancestry chain
   
   std::set<G4int> savelist;
   std::set<int> savevtxlist;
@@ -78,7 +81,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt) {
     // now crawl up the truth info and add parents until we hit
     // a track which is already being saved
     G4int parentid = particle->get_parent_id();
-    while (savelist.find(parentid) == savelist.end() && parentid > 0) {
+    while (savelist.find(parentid) == savelist.end() && parentid != 0) {
       particle = truthInfoList_->GetParticle(parentid);
       wrttracks.push_back(parentid);
       wrtvtx.push_back(particle->get_vtx_id());
@@ -100,6 +103,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt) {
   
   // the save lists are filled now, except primary track which never
   // made it into any active volume and their vertex
+  
   // loop over particles in truth list and remove them if they are not
   // in the save list and are not primary particles (parent_id == 0)
   

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -23,15 +23,11 @@ using namespace std;
 
 //___________________________________________________
 PHG4TruthEventAction::PHG4TruthEventAction( void ):
-  truthInfoList_( 0 ),
-  vertexid_(0)
+  truthInfoList_( 0 )
 {}
 
 //___________________________________________________
-void PHG4TruthEventAction::BeginOfEventAction(const G4Event* evt)
-{
-  vertexid_ = 0;
-}
+void PHG4TruthEventAction::BeginOfEventAction(const G4Event* evt) {}
 
 //___________________________________________________
 void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
@@ -103,7 +99,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
 	  // for embedding: particles from initial sim do not have their keep flag set, we want to keep particles with trkid <= trackidoffset
 	  // trackidoffset is the geantid of the last particle
 	  // for regular sims, trackidoffset is zero
-          if ((truthiter->second)->get_parent_id() != 0 && truthiter->first > 0)
+          if ((truthiter->second)->get_parent_id() != 0 && truthiter->first > 0) // MPM I'll need to revise this section
             {
               truthInfoList_->delete_particle(truthiter++);
               removed[1]++;
@@ -160,39 +156,23 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
 }
 
 //___________________________________________________
-void PHG4TruthEventAction::AddTrackidToWritelist( const G4int trackid)
-{
-  writeList_.insert(trackid);
+void PHG4TruthEventAction::AddTrackidToWritelist(const G4int trackid) {
+   writeList_.insert(trackid);
 }
 
 //___________________________________________________
-void PHG4TruthEventAction::SetInterfacePointers( PHCompositeNode* topNode )
-{
+void PHG4TruthEventAction::SetInterfacePointers(PHCompositeNode* topNode) {
+  
   //now look for the map and grab a pointer to it.
   truthInfoList_ =  findNode::getClass<PHG4TruthInfoContainer>( topNode , "G4TruthInfo" );
 
   // if we do not find the node we need to make it.
-  if ( !truthInfoList_ )
-    {
-      std::cout << "PHG4TruthEventAction::SetInterfacePointers - unable to find G4TruthInfo" << std::endl;
-    }
-
+  if ( !truthInfoList_ ) {
+    std::cout << "PHG4TruthEventAction::SetInterfacePointers - unable to find G4TruthInfo" << std::endl;
+  }
 }
 
-PHG4TruthEventAction::bimap_type::iterator
-PHG4TruthEventAction::AddVertex(G4ThreeVector& v)
-{
-  bimap_type::iterator it;
-  bool inserted = false;
-  boost::tie(it, inserted) = vertexIdMap_.insert(bimap_type::value_type(vertexid_, v));
-  if ( inserted ) vertexid_++;
-  return it;
-}
-
-int
-PHG4TruthEventAction::ResetEvent(PHCompositeNode *)
-{
+int PHG4TruthEventAction::ResetEvent(PHCompositeNode *) {
   writeList_.clear();
-  vertexIdMap_.clear();
   return 0;
 }

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -24,8 +24,8 @@ using namespace std;
 //___________________________________________________
 PHG4TruthEventAction::PHG4TruthEventAction( void ):
   truthInfoList_( 0 ),
-  trackidoffset(0),
-  parimarytrackidoffset(0),
+  primarytrackidoffset(0),
+  secondarytrackidoffset(0),
   vertexid_(0)
 {}
 
@@ -103,7 +103,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
 	  // for embedding: particles from initial sim do not have their keep flag set, we want to keep particles with trkid <= trackidoffset
 	  // trackidoffset is the geantid of the last particle
 	  // for regular sims, trackidoffset is zero
-          if ((truthiter->second)->get_parent_id() != 0 && truthiter->first > trackidoffset)
+          if ((truthiter->second)->get_parent_id() != 0 && truthiter->first > secondarytrackidoffset)
             {
               truthInfoList_->delete_particle(truthiter++);
               removed[1]++;
@@ -168,9 +168,9 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
           if (particle->get_parent_id() <= 0)
             {
               primaryid = particle->get_track_id(); // this particle is the primary truth
-              assert (primaryid > trackidoffset);
-              primaryid -= trackidoffset; // recovery the Geant4 track ID = inEvent track ID
-              primaryid += parimarytrackidoffset; // ID for the primary track in truth container
+              assert (primaryid > secondarytrackidoffset);
+              primaryid -= secondarytrackidoffset; // recovery the Geant4 track ID = inEvent track ID
+              primaryid += primarytrackidoffset; // ID for the primary track in truth container
 
               break;
             }
@@ -208,7 +208,7 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
 	if (userdata->get_embed())
 	  {
 //      truthInfoList_->AddEmbededTrkId(part->GetTrackID()+ trackidoffset); // use G4 particle list ID for the embedded list
-      truthInfoList_->AddEmbededTrkId(part->GetTrackID()+ parimarytrackidoffset); // use primary ID for the embedded list
+      truthInfoList_->AddEmbededTrkId(part->GetTrackID()+ primarytrackidoffset); // use primary ID for the embedded list
 	  }
       }
       part = part->GetNext();

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -149,7 +149,8 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt) {
       PHG4UserPrimaryParticleInformation *userdata = dynamic_cast<PHG4UserPrimaryParticleInformation *> (part->GetUserInformation());
       if (userdata) {
 	if (userdata->get_embed()) {
-	  truthInfoList_->AddEmbededTrkId(userdata->get_user_track_id()); // use primary ID for the embedded list
+	  truthInfoList_->AddEmbededTrkId(userdata->get_user_track_id(),userdata->get_embed());
+	  truthInfoList_->AddEmbededVtxId(userdata->get_user_vtx_id(),userdata->get_embed());
 	}
       }
       part = part->GetNext();

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.h
@@ -42,6 +42,8 @@ public:
   void PrimaryTrackIdOffset(const int i) {primarytrackidoffset = i;}
   void SecondaryTrackIdOffset(const int i) {secondarytrackidoffset = i;}
 
+  void PrimaryMapTrackIdOffset(const int i) {primarymaptrackidoffset = i;}
+  
   bimap_type::iterator AddVertex(G4ThreeVector& v);
   
  private:
@@ -55,7 +57,8 @@ public:
 
   int primarytrackidoffset;
   int secondarytrackidoffset;
-
+  int primarymaptrackidoffset;
+  
   // TESTING
   // Bidirectional map of vertexid <-> vertex position
   int vertexid_;

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.h
@@ -39,15 +39,13 @@ public:
   //! add id into track list
   void AddTrackidToWritelist( const G4int trackid);
 
-  void TrackIdOffset(const int i) {trackidoffset = i;}
-  void PrimaryTrackIdOffset(const int i) {parimarytrackidoffset = i;}
-
+  void PrimaryTrackIdOffset(const int i) {primarytrackidoffset = i;}
+  void SecondaryTrackIdOffset(const int i) {secondarytrackidoffset = i;}
 
   bimap_type::iterator AddVertex(G4ThreeVector& v);
   
  private:
-  
-  
+    
   //! set of track ids to be written out
 
   std::set<G4int> writeList_;
@@ -55,9 +53,9 @@ public:
   //! pointer to truth information container
   PHG4TruthInfoContainer* truthInfoList_;
 
-  int trackidoffset;
-  int parimarytrackidoffset;
-  
+  int primarytrackidoffset;
+  int secondarytrackidoffset;
+
   // TESTING
   // Bidirectional map of vertexid <-> vertex position
   int vertexid_;

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.h
@@ -42,6 +42,9 @@ public:
 
   //! pointer to truth information container
   PHG4TruthInfoContainer* truthInfoList_;
+
+  int prev_existing_lower_key;
+  int prev_existing_upper_key;
 };
 
 

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.h
@@ -8,8 +8,6 @@
 #include <Geant4/G4ThreeVector.hh>
 #include <Geant4/globals.hh>
 
-#include <boost/bimap.hpp>
-
 #include <set>
 
 class PHG4TruthInfoContainer;
@@ -18,14 +16,12 @@ class PHG4TruthEventAction: public PHG4EventAction
 {
 
 public:
-  typedef boost::bimap<int,G4ThreeVector> bimap_type;
 
   //! constructor
   PHG4TruthEventAction( void );
 
   //! destuctor
-  virtual ~PHG4TruthEventAction( void )
-  {}
+  virtual ~PHG4TruthEventAction( void ) {}
 
   void BeginOfEventAction(const G4Event*);
 
@@ -39,21 +35,13 @@ public:
   //! add id into track list
   void AddTrackidToWritelist( const G4int trackid);
 
-  bimap_type::iterator AddVertex(G4ThreeVector& v);
-  
  private:
     
   //! set of track ids to be written out
-
   std::set<G4int> writeList_;
 
   //! pointer to truth information container
   PHG4TruthInfoContainer* truthInfoList_;
-
-  // TESTING
-  // Bidirectional map of vertexid <-> vertex position
-  int vertexid_;
-  bimap_type vertexIdMap_;  
 };
 
 

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.h
@@ -39,11 +39,6 @@ public:
   //! add id into track list
   void AddTrackidToWritelist( const G4int trackid);
 
-  void PrimaryTrackIdOffset(const int i) {primarytrackidoffset = i;}
-  void SecondaryTrackIdOffset(const int i) {secondarytrackidoffset = i;}
-
-  void PrimaryMapTrackIdOffset(const int i) {primarymaptrackidoffset = i;}
-  
   bimap_type::iterator AddVertex(G4ThreeVector& v);
   
  private:
@@ -55,10 +50,6 @@ public:
   //! pointer to truth information container
   PHG4TruthInfoContainer* truthInfoList_;
 
-  int primarytrackidoffset;
-  int secondarytrackidoffset;
-  int primarymaptrackidoffset;
-  
   // TESTING
   // Bidirectional map of vertexid <-> vertex position
   int vertexid_;

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -22,13 +22,6 @@ PHG4TruthInfoContainer::PHG4TruthInfoContainer() :
 
 PHG4TruthInfoContainer::~PHG4TruthInfoContainer() {}
 
-// Deleter object to that takes a pair and deletes the second member
-template<class T>
-struct SecondDeleter : std::unary_function<T,void>
-{
-  void operator()(T v) { delete v.second; }
-};
-
 void
 PHG4TruthInfoContainer::Reset()
 {
@@ -48,36 +41,32 @@ PHG4TruthInfoContainer::Reset()
   return;
 }
 
-void
-PHG4TruthInfoContainer::identify(ostream& os) const
-{
-   ConstIterator iter;
-   cout << "---particlemap--------------------------" << endl;
-   for (iter = particlemap.begin(); iter != particlemap.end(); ++iter)
-     {
-       cout << "particle key " <<  iter->first << endl;
-       (iter->second)->identify();
-     }
-   ConstVtxIterator vter;
-   cout << "---vtxmap-------------------------------" << endl;
-   for (vter = vtxmap.begin(); vter != vtxmap.end(); ++vter)
-     {
-       cout << "vtx id: " << vter ->first << endl;
-       (vter ->second)->identify();
-     }
+void PHG4TruthInfoContainer::identify(ostream& os) const {
+
+  cout << "---particlemap--------------------------" << endl;
+  for (ConstIterator iter = particlemap.begin(); iter != particlemap.end(); ++iter) {
+    cout << "particle id " <<  iter->first << endl;
+    (iter->second)->identify();
+  }
+
+  cout << "---vtxmap-------------------------------" << endl;
+  for (ConstVtxIterator vter = vtxmap.begin(); vter != vtxmap.end(); ++vter) {
+    cout << "vtx id: " << vter ->first << endl;
+    (vter ->second)->identify();
+  }
    
-   cout << "---list of embeded track flags-------------------" << endl;
-   for (std::map<int,int>::const_iterator eter = particle_embed_flags.begin();
-	eter != particle_embed_flags.end();
-	++eter) {
-     cout << "embeded track id: " << eter->first << " flag: " << eter->second << endl;
-   }
-   cout << "---list of embeded vtx flags-------------------" << endl;
-   for (std::map<int,int>::const_iterator eter = vertex_embed_flags.begin();
-	eter != vertex_embed_flags.end();
-	++eter) {
-     cout << "embeded vertex id: " << eter->first << " flag: " << eter->second << endl;
-   }
+  cout << "---list of embeded track flags-------------------" << endl;
+  for (std::map<int,int>::const_iterator eter = particle_embed_flags.begin();
+       eter != particle_embed_flags.end();
+       ++eter) {
+    cout << "embeded track id: " << eter->first << " flag: " << eter->second << endl;
+  }
+  cout << "---list of embeded vtx flags-------------------" << endl;
+  for (std::map<int,int>::const_iterator eter = vertex_embed_flags.begin();
+       eter != vertex_embed_flags.end();
+       ++eter) {
+    cout << "embeded vertex id: " << eter->first << " flag: " << eter->second << endl;
+  }
    
   return;
 }
@@ -98,24 +87,6 @@ PHG4TruthInfoContainer::AddParticle(const int trackid, PHG4Particle *newparticle
       << std::endl;
   return particlemap.end();
 }
-
-// PHG4TruthInfoContainer::ConstIterator
-// PHG4TruthInfoContainer::AddPrimaryParticle(PHG4Particle *newparticle)
-// {
-//   int key = primary_particle_map.size()+1;
-//   if ( primary_particle_map.find(key) !=  primary_particle_map.end())
-//     {
-//       cout << PHWHERE << "particle with id " << key << " already inserted, fix indexing" << endl;
-//       exit(1);
-//     }
-
-//   ConstIterator it;
-//   bool added = false;
-//   boost::tie(it,added) = primary_particle_map.insert(std::make_pair(key,newparticle));
-//   if ( added ) return it;
-//   cerr << "PHG4TruthInfoContainer::AddParticle - Attempt to add particle with existing trackid " << key << std::endl;
-//   return particlemap.end();
-// }
 
 PHG4Particle*
 PHG4TruthInfoContainer::GetParticle(const int trackid)
@@ -156,33 +127,6 @@ PHG4TruthInfoContainer::GetPrimaryVtx(const int vtxid)
   return NULL;
 }
 
-PHG4TruthInfoContainer::VtxRange
-PHG4TruthInfoContainer::GetVtxRange()
-{
-  return VtxRange(vtxmap.begin(),vtxmap.end());
-}
-
-PHG4TruthInfoContainer::ConstVtxRange
-PHG4TruthInfoContainer::GetVtxRange() const
-{
-  return ConstVtxRange(vtxmap.begin(),vtxmap.end());
-}
-
-PHG4TruthInfoContainer::VtxIterator
-PHG4TruthInfoContainer::AddVertex(const int id)
-{
-  int key = id;
-  VtxIterator it = vtxmap.find(key);
-  if ( it != vtxmap.end() ) 
-    {
-      std::cerr << "PHG4TruthInfoContainer::AddVertex - Attempt to add vertex with existing id " << id << std::endl;
-      exit(2);
-    }
-  bool tmp = false;
-  boost::tie(it,tmp) = vtxmap.insert( std::make_pair(key,new PHG4VtxPointv1(NAN,NAN,NAN,NAN,key)) );
-  return it;
-}
-
 PHG4TruthInfoContainer::ConstVtxIterator
 PHG4TruthInfoContainer::AddVertex(const int id, PHG4VtxPoint *newvtx)
 {
@@ -205,68 +149,6 @@ PHG4TruthInfoContainer::AddVertex(const int id, PHG4VtxPoint *newvtx)
   cerr << "PHG4TruthInfoContainer::AddVertex - Attempt to add vertex with existing id " << id << std::endl;
   return vtxmap.end();
 }
-
-// int
-// PHG4TruthInfoContainer::AddPrimaryVertex(PHG4VtxPoint *newvtx)
-// {
-// // initial guess of key, if we are the first index (map.size() == 0)
-// //  no need to check anything just add the vertex
-//   int key = primary_vtxmap.size()+1;  
-//   if (key == 1)
-//     {
-//       primary_vtxmap.insert(make_pair(key,newvtx));
-//       newvtx->set_id(key);
-//     }
-//   else
-//     {
-//       // we already have a vertex, check if the newly added vertex is identical to existing vertex
-//       ConstVtxIterator vtxiter;
-//       for (vtxiter = primary_vtxmap.begin(); vtxiter != primary_vtxmap.end(); ++vtxiter)
-// 	{
-// 	  PHG4VtxPoint *savedvtx = vtxiter->second;
-// 	  if (*savedvtx == *newvtx)
-// 	    {
-// 	      key = vtxiter->first;
-// 	      delete newvtx; // since we do not store it we have to delete it here
-// 	      return key;
-// 	    }
-// 	}
-//       // if not found among existing vertices, add it
-//        primary_vtxmap.insert(make_pair(key,newvtx));
-//        newvtx->set_id(key);
-//     }
-//   return key;
-// }
-
-// int
-// PHG4TruthInfoContainer::maxprimarytrkindex() const
-// {
-//   int key = 0;
-//   if (!primary_particle_map.empty())
-//     {
-//       key = primary_particle_map.rbegin()->first;
-//     }
-//   if (key < 0)
-//     {
-//       key = 0;
-//     }
-//   return key;
-// }
-
-// int
-// PHG4TruthInfoContainer::minprimarytrkindex() const
-// {
-//   int key = 0;
-//   if (!primary_particle_map.empty())
-//     {
-//        key = primary_particle_map.begin()->first;
-//     }
-//   if (key > 0)
-//     {
-//       key = 0;
-//     }
-//   return key;
-// }
 
 int
 PHG4TruthInfoContainer::maxtrkindex() const

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -22,9 +22,8 @@ PHG4TruthInfoContainer::PHG4TruthInfoContainer() :
 
 PHG4TruthInfoContainer::~PHG4TruthInfoContainer() {}
 
-void
-PHG4TruthInfoContainer::Reset()
-{
+void PHG4TruthInfoContainer::Reset() {
+  
   for (Iterator iter = particlemap.begin(); iter != particlemap.end(); ++iter) {
     delete iter->second;
   }
@@ -59,68 +58,68 @@ void PHG4TruthInfoContainer::identify(ostream& os) const {
   for (std::map<int,int>::const_iterator eter = particle_embed_flags.begin();
        eter != particle_embed_flags.end();
        ++eter) {
-    cout << "embeded track id: " << eter->first << " flag: " << eter->second << endl;
+    cout << "embeded track id: " << eter->first
+	 << " flag: " << eter->second << endl;
   }
+  
   cout << "---list of embeded vtx flags-------------------" << endl;
   for (std::map<int,int>::const_iterator eter = vertex_embed_flags.begin();
        eter != vertex_embed_flags.end();
        ++eter) {
-    cout << "embeded vertex id: " << eter->first << " flag: " << eter->second << endl;
+    cout << "embeded vertex id: " << eter->first
+	 << " flag: " << eter->second << endl;
   }
    
   return;
 }
 
 PHG4TruthInfoContainer::ConstIterator
-PHG4TruthInfoContainer::AddParticle(const int trackid, PHG4Particle *newparticle)
-{
+PHG4TruthInfoContainer::AddParticle(const int trackid, PHG4Particle *newparticle) {
+  
   int key = trackid;
   ConstIterator it;
   bool added = false;
   boost::tie(it,added) = particlemap.insert(std::make_pair(key,newparticle));
   if ( added ) return it;
-  cerr << "PHG4TruthInfoContainer::AddParticle - Attempt to add particle with existing trackid "
-      << trackid <<": "<<newparticle ->get_name()<<" id "
-      << newparticle->get_track_id()
-      <<", p = ["<<newparticle->get_px()<<", "<<newparticle->get_py()<<", "<<newparticle->get_pz()<<"], "
-      <<" parent ID "<<newparticle->get_parent_id()
-      << std::endl;
+  
+  cerr << "PHG4TruthInfoContainer::AddParticle"
+       << " - Attempt to add particle with existing trackid "
+       << trackid <<": "<<newparticle ->get_name()<<" id "
+       << newparticle->get_track_id()
+       <<", p = ["<<newparticle->get_px()
+       <<", "<<newparticle->get_py()
+       <<", "<<newparticle->get_pz()<<"], "
+       <<" parent ID "<<newparticle->get_parent_id()
+       << std::endl;
   return particlemap.end();
 }
 
-PHG4Particle*
-PHG4TruthInfoContainer::GetParticle(const int trackid)
-{
+PHG4Particle* PHG4TruthInfoContainer::GetParticle(const int trackid) {
+  
   int key = trackid;
   Iterator it = particlemap.find(key);
   if ( it != particlemap.end() ) return it->second;
   return NULL;
 }
 
-PHG4Particle*
-PHG4TruthInfoContainer::GetPrimaryParticle(const int trackid)
-{
+PHG4Particle* PHG4TruthInfoContainer::GetPrimaryParticle(const int trackid) {
+  
   if (trackid <= 0) return NULL;
   Iterator it = particlemap.find(trackid);
   if ( it != particlemap.end() ) return it->second;
   return NULL;
 }
 
-PHG4VtxPoint*
-PHG4TruthInfoContainer::GetVtx(const int vtxid)
-{
+PHG4VtxPoint* PHG4TruthInfoContainer::GetVtx(const int vtxid) {
+  
   int key = vtxid;
   VtxIterator it = vtxmap.find(key);
-  if ( it != vtxmap.end() )
-    {
-      return it->second;
-    }
+  if ( it != vtxmap.end() ) return it->second;
   return NULL;
 }
 
-PHG4VtxPoint*
-PHG4TruthInfoContainer::GetPrimaryVtx(const int vtxid)
-{
+PHG4VtxPoint* PHG4TruthInfoContainer::GetPrimaryVtx(const int vtxid) {
+
   if (vtxid <= 0) return NULL;
   VtxIterator it = vtxmap.find(vtxid);
   if ( it != vtxmap.end() ) return it->second;
@@ -128,99 +127,71 @@ PHG4TruthInfoContainer::GetPrimaryVtx(const int vtxid)
 }
 
 PHG4TruthInfoContainer::ConstVtxIterator
-PHG4TruthInfoContainer::AddVertex(const int id, PHG4VtxPoint *newvtx)
-{
+PHG4TruthInfoContainer::AddVertex(const int id, PHG4VtxPoint *newvtx) {
+
   int key = id;
   ConstVtxIterator it;
   bool added = false;
-  if (vtxmap.find(id) != vtxmap.end())
-    {
-      //PHG4VtxPoint *pt = 
-      cout << "trying to add existing vtx " << id 
-	   << " vtx pos: " << endl;
- (vtxmap.find(id)->second)->identify();
- identify();
-    }
+
+  if (vtxmap.find(id) != vtxmap.end()) {
+    cout << "trying to add existing vtx " << id 
+	 << " vtx pos: " << endl;
+    (vtxmap.find(id)->second)->identify();
+    identify();
+  }
+  
   boost::tie(it,added) = vtxmap.insert(std::make_pair(key,newvtx));
   if ( added ) {
-      newvtx->set_id(key);
-      return it;
+    newvtx->set_id(key);
+    return it;
   }
-  cerr << "PHG4TruthInfoContainer::AddVertex - Attempt to add vertex with existing id " << id << std::endl;
+
+  cerr << "PHG4TruthInfoContainer::AddVertex"
+       << " - Attempt to add vertex with existing id " << id << std::endl;
   return vtxmap.end();
 }
 
-int
-PHG4TruthInfoContainer::maxtrkindex() const
-{
+int PHG4TruthInfoContainer::maxtrkindex() const {
+  
   int key = 0;
-  if (!particlemap.empty())
-    {
-      key = particlemap.rbegin()->first;
-    }
-  if (key < 0)
-    {
-      key = 0;
-    }
+  if (!particlemap.empty()) key = particlemap.rbegin()->first;
+  if (key < 0) key = 0;
   return key;
 }
 
-int
-PHG4TruthInfoContainer::mintrkindex() const
-{
+int PHG4TruthInfoContainer::mintrkindex() const {
+  
   int key = 0;
-  if (!particlemap.empty())
-    {
-       key = particlemap.begin()->first;
-    }
-  if (key > 0)
-    {
-      key = 0;
-    }
+  if (!particlemap.empty()) key = particlemap.begin()->first;
+  if (key > 0) key = 0;
   return key;
 }
 
-int
-PHG4TruthInfoContainer::maxvtxindex() const
-{
+int PHG4TruthInfoContainer::maxvtxindex() const {
+  
   int key = 0;
-  if (!vtxmap.empty())
-    {
-      key = vtxmap.rbegin()->first;
-    }
-  if (key < 0)
-    {
-      key = 0;
-    }
+  if (!vtxmap.empty()) key = vtxmap.rbegin()->first;
+  if (key < 0) key = 0;
   return key;
 }
 
-int
-PHG4TruthInfoContainer::minvtxindex() const
-{
+int PHG4TruthInfoContainer::minvtxindex() const {
+  
   int key = 0;
-  if (!vtxmap.empty())
-    {
-       key = vtxmap.begin()->first;
-    }
-  if (key > 0)
-    {
-      key = 0;
-    }
+  if (!vtxmap.empty()) key = vtxmap.begin()->first;
+  if (key > 0) key = 0;
   return key;
 }
 
-void
-PHG4TruthInfoContainer::delete_particle(Iterator piter)
-{
+void PHG4TruthInfoContainer::delete_particle(Iterator piter) {
+  
   delete piter->second;
   particlemap.erase(piter);
   return;
 }
 
-void
-PHG4TruthInfoContainer::delete_vtx(VtxIterator viter)
-{
+void PHG4TruthInfoContainer::delete_vtx(VtxIterator viter) {
+  
   delete viter->second;
   vtxmap.erase(viter);
   return;

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -17,8 +17,8 @@ PHG4TruthInfoContainer::PHG4TruthInfoContainer() :
   particlemap(),
   vtxmap(),
   primary_particle_map(),
-  primary_vtxmap(),
-  embedded_trkid() {  
+  primary_vtxmap() {
+  //embedded_trkid() {  
 }
 
 PHG4TruthInfoContainer::~PHG4TruthInfoContainer() {}
@@ -39,13 +39,19 @@ PHG4TruthInfoContainer::Reset()
   std::for_each(vtxmap.begin(),vtxmap.end(),SecondDeleter<VtxMap::value_type>());
   vtxmap.clear();
 
+  particle_subevents.clear();
+  vertex_subevents.clear();
+  particle_embed_flags.clear();
+  vertex_embed_flags.clear();
+
+
   std::for_each(primary_particle_map.begin(),primary_particle_map.end(),SecondDeleter<Map::value_type>());
   primary_particle_map.clear();
 
   std::for_each(primary_vtxmap.begin(),primary_vtxmap.end(),SecondDeleter<VtxMap::value_type>());
   primary_vtxmap.clear();
-
-  embedded_trkid.clear();
+  
+  //embedded_trkid.clear();
 
   return;
 }
@@ -67,6 +73,7 @@ PHG4TruthInfoContainer::identify(ostream& os) const
        cout << "vtx id: " << vter ->first << endl;
        (vter ->second)->identify();
      }
+   
    cout << "---primaryparticlemap-------------------" << endl;
    for (iter = primary_particle_map.begin(); iter != primary_particle_map.end(); ++iter)
      {
@@ -79,11 +86,19 @@ PHG4TruthInfoContainer::identify(ostream& os) const
        cout << "vtx id: " << vter ->first << endl;
        (vter ->second)->identify();
      }
-   cout << "---list of embeded tracks-------------------" << endl;
-   for (std::set<int>::const_iterator eter = embedded_trkid.begin(); eter != embedded_trkid.end(); ++eter)
-     {
-       cout << "embeded track ID " << *eter << endl;
-     }
+   
+   cout << "---list of embeded track flags-------------------" << endl;
+   for (std::map<int,int>::const_iterator eter = particle_embed_flags.begin();
+	eter != particle_embed_flags.end();
+	++eter) {
+     cout << "embeded track id: " << eter->first << " flag: " << eter->second << endl;
+   }
+   cout << "---list of embeded vtx flags-------------------" << endl;
+   for (std::map<int,int>::const_iterator eter = vertex_embed_flags.begin();
+	eter != vertex_embed_flags.end();
+	++eter) {
+     cout << "embeded vertex id: " << eter->first << " flag: " << eter->second << endl;
+   }
    
   return;
 }
@@ -365,14 +380,24 @@ PHG4TruthInfoContainer::delete_vtx(VtxIterator viter)
   return;
 }
 
-int
-PHG4TruthInfoContainer::isEmbeded(const int trackid) const
-{
-  if (embedded_trkid.find(trackid) != embedded_trkid.end())
-    {
-      return true;
-    }
-  return false;
+int PHG4TruthInfoContainer::isEmbeded(const int trackid) const {
+
+  std::map<int,int>::const_iterator iter = particle_embed_flags.find(trackid);
+  if (iter == particle_embed_flags.end()) {
+    return 0;
+  }
+  
+  return iter->second;
+}
+
+int PHG4TruthInfoContainer::isEmbededVtx(const int vtxid) const {
+
+  std::map<int,int>::const_iterator iter = vertex_embed_flags.find(vtxid);
+  if (iter == vertex_embed_flags.end()) {
+    return 0;
+  }
+  
+  return iter->second;
 }
 
 std::set<int> PHG4TruthInfoContainer::GetSubEventIds() const {

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -13,21 +13,15 @@
 
 using namespace std;
 
-int 
-PHG4TruthInfoContainer::get_key(const int detid)
-{
-  return detid;
+PHG4TruthInfoContainer::PHG4TruthInfoContainer() :
+  particlemap(),
+  vtxmap(),
+  primary_particle_map(),
+  primary_vtxmap(),
+  embedded_trkid() {
 }
 
-PHG4TruthInfoContainer::PHG4TruthInfoContainer()
-{
-  //std::cout << __PRETTY_FUNCTION__ << std::endl;
-}
-
-PHG4TruthInfoContainer::~PHG4TruthInfoContainer()
-{
-  //std::cout << __PRETTY_FUNCTION__ << std::endl;
-}
+PHG4TruthInfoContainer::~PHG4TruthInfoContainer() {}
 
 // Deleter object to that takes a pair and deletes the second member
 template<class T>
@@ -97,7 +91,7 @@ PHG4TruthInfoContainer::identify(ostream& os) const
 PHG4TruthInfoContainer::ConstIterator
 PHG4TruthInfoContainer::AddParticle(const int trackid, PHG4Particle *newparticle)
 {
-  int key = get_key(trackid);
+  int key = trackid;
   ConstIterator it;
   bool added = false;
   boost::tie(it,added) = particlemap.insert(std::make_pair(key,newparticle));
@@ -132,7 +126,7 @@ PHG4TruthInfoContainer::AddPrimaryParticle(PHG4Particle *newparticle)
 PHG4Particle*
 PHG4TruthInfoContainer::GetParticle(const int trackid)
 {
-  int key = get_key(trackid);
+  int key = trackid;
   Iterator it = particlemap.find(key);
   if ( it != particlemap.end() ) return it->second;
   return 0;
@@ -141,7 +135,7 @@ PHG4TruthInfoContainer::GetParticle(const int trackid)
 PHG4Particle*
 PHG4TruthInfoContainer::GetPrimaryParticle(const int trackid)
 {
-  int key = get_key(trackid);
+  int key = trackid;
   Iterator it = primary_particle_map.find(key);
   if ( it != primary_particle_map.end() ) return it->second;
   return 0;
@@ -162,7 +156,7 @@ PHG4TruthInfoContainer::GetParticleRange() const
 PHG4VtxPoint*
 PHG4TruthInfoContainer::GetVtx(const int vtxid)
 {
-  int key = get_key(vtxid);
+  int key = vtxid;
   VtxIterator it = vtxmap.find(key);
   if ( it != vtxmap.end() )
     {
@@ -174,7 +168,7 @@ PHG4TruthInfoContainer::GetVtx(const int vtxid)
 PHG4VtxPoint*
 PHG4TruthInfoContainer::GetPrimaryVtx(const int vtxid)
 {
-  int key = get_key(vtxid);
+  int key = vtxid;
   VtxIterator it = primary_vtxmap.find(key);
   if ( it != primary_vtxmap.end() )
     {
@@ -198,7 +192,7 @@ PHG4TruthInfoContainer::GetVtxRange() const
 PHG4TruthInfoContainer::VtxIterator
 PHG4TruthInfoContainer::AddVertex(const int id)
 {
-  int key = get_key(id);
+  int key = id;
   VtxIterator it = vtxmap.find(key);
   if ( it != vtxmap.end() ) 
     {
@@ -213,7 +207,7 @@ PHG4TruthInfoContainer::AddVertex(const int id)
 PHG4TruthInfoContainer::ConstVtxIterator
 PHG4TruthInfoContainer::AddVertex(const int id, PHG4VtxPoint *newvtx)
 {
-  int key = get_key(id);
+  int key = id;
   ConstVtxIterator it;
   bool added = false;
   if (vtxmap.find(id) != vtxmap.end())

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -16,8 +16,6 @@ using namespace std;
 PHG4TruthInfoContainer::PHG4TruthInfoContainer() :
   particlemap(),
   vtxmap(),
-  particle_subevents(),
-  vertex_subevents(),
   particle_embed_flags(),
   vertex_embed_flags() {
 }
@@ -44,8 +42,6 @@ PHG4TruthInfoContainer::Reset()
   }
   vtxmap.clear();
 
-  particle_subevents.clear();
-  vertex_subevents.clear();
   particle_embed_flags.clear();
   vertex_embed_flags.clear();
   
@@ -366,105 +362,4 @@ int PHG4TruthInfoContainer::isEmbededVtx(const int vtxid) const {
   }
   
   return iter->second;
-}
-
-std::set<int> PHG4TruthInfoContainer::GetSubEventIds() const {
-
-  std::set<int> subevent_ids;
-
-  for (std::map< int, std::pair<int,int> >::const_iterator iter = particle_subevents.begin();
-       iter != particle_subevents.end();
-       ++iter) {
-    int subevent_id = iter->first;
-    subevent_ids.insert(subevent_id);
-  }
-  
-  return subevent_ids;
-}
-
-PHG4TruthInfoContainer::Range PHG4TruthInfoContainer::GetSubEventPrimaryParticleRange(int subevent) {
-
-  std::map<int, std::pair<int,int> >::iterator iter = particle_subevents.find(subevent);
-  if (iter == particle_subevents.end()) {
-    return make_pair(particlemap.end(),particlemap.end());
-  }
-
-  int lowerkey = 0;
-  if (subevent > 1) {
-    lowerkey = particle_subevents.find(subevent-1)->second.second;
-  }
-  int upperkey = iter->second.second;
-
-  Iterator loweriter = particlemap.upper_bound(lowerkey);
-  Iterator upperiter = particlemap.upper_bound(upperkey);
-    
-  return make_pair(loweriter,upperiter);
-}
-
-PHG4TruthInfoContainer::Range PHG4TruthInfoContainer::GetSubEventSecondaryParticleRange(int subevent) {
-
-  std::map<int, std::pair<int,int> >::iterator iter = particle_subevents.find(subevent);
-  if (iter == particle_subevents.end()) {
-    return make_pair(particlemap.end(),particlemap.end());
-  }
-
-  int lowerkey = iter->second.first;
-  int upperkey = 0;
-  if (subevent > 1) {
-    upperkey = particle_subevents.find(subevent-1)->second.first;
-  }
-
-  Iterator loweriter = particlemap.lower_bound(lowerkey);
-  Iterator upperiter = particlemap.lower_bound(upperkey);
-    
-  return make_pair(loweriter,upperiter);
-}
-
-PHG4TruthInfoContainer::VtxRange PHG4TruthInfoContainer::GetSubEventPrimaryVertexRange(int subevent) {
-
-  std::map<int, std::pair<int,int> >::iterator iter = vertex_subevents.find(subevent);
-  if (iter == vertex_subevents.end()) {
-    return make_pair(vtxmap.end(),vtxmap.end());
-  }
-
-  int lowerkey = 0;
-  if (subevent > 1) {
-    lowerkey = vertex_subevents.find(subevent-1)->second.second;
-  }
-  int upperkey = iter->second.second; 
-
-  VtxIterator loweriter = vtxmap.upper_bound(lowerkey);
-  VtxIterator upperiter = vtxmap.upper_bound(upperkey);
-    
-  return make_pair(loweriter,upperiter);
-}
-
-PHG4TruthInfoContainer::VtxRange PHG4TruthInfoContainer::GetSubEventSecondaryVertexRange(int subevent) {
-
-  std::map<int, std::pair<int,int> >::iterator iter = vertex_subevents.find(subevent);
-  if (iter == vertex_subevents.end()) {
-    return make_pair(vtxmap.end(),vtxmap.end());
-  }
-
-  int lowerkey = iter->second.first;
-  int upperkey = 0;
-  if (subevent > 1) {
-    upperkey = vertex_subevents.find(subevent-1)->second.first;
-  }
-
-  VtxIterator loweriter = vtxmap.lower_bound(lowerkey);
-  VtxIterator upperiter = vtxmap.lower_bound(upperkey);
-    
-  return make_pair(loweriter,upperiter);
-}
-
-void PHG4TruthInfoContainer::MarkSubEventBoundary() {
-
-  int subevent = 1;
-  if (!particle_subevents.empty()) {
-    subevent = particle_subevents.rbegin()->first + 1;
-  }
-  
-  particle_subevents.insert(make_pair(subevent,make_pair(mintrkindex(),maxtrkindex())));
-  vertex_subevents.insert(make_pair(subevent,make_pair(minvtxindex(),maxvtxindex())));  
 }

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -18,7 +18,7 @@ PHG4TruthInfoContainer::PHG4TruthInfoContainer() :
   vtxmap(),
   primary_particle_map(),
   primary_vtxmap(),
-  embedded_trkid() {
+  embedded_trkid() {  
 }
 
 PHG4TruthInfoContainer::~PHG4TruthInfoContainer() {}
@@ -373,4 +373,105 @@ PHG4TruthInfoContainer::isEmbeded(const int trackid) const
       return true;
     }
   return false;
+}
+
+std::set<int> PHG4TruthInfoContainer::GetSubEventIds() const {
+
+  std::set<int> subevent_ids;
+
+  for (std::map< int, std::pair<int,int> >::const_iterator iter = particle_subevents.begin();
+       iter != particle_subevents.end();
+       ++iter) {
+    int subevent_id = iter->first;
+    subevent_ids.insert(subevent_id);
+  }
+  
+  return subevent_ids;
+}
+
+PHG4TruthInfoContainer::Range PHG4TruthInfoContainer::GetSubEventPrimaryParticleRange(int subevent) {
+
+  std::map<int, std::pair<int,int> >::iterator iter = particle_subevents.find(subevent);
+  if (iter == particle_subevents.end()) {
+    return make_pair(particlemap.end(),particlemap.end());
+  }
+
+  int lowerkey = 0;
+  if (subevent > 1) {
+    lowerkey = particle_subevents.find(subevent-1)->second.second;
+  }
+  int upperkey = iter->second.second;
+
+  Iterator loweriter = particlemap.upper_bound(lowerkey);
+  Iterator upperiter = particlemap.upper_bound(upperkey);
+    
+  return make_pair(loweriter,upperiter);
+}
+
+PHG4TruthInfoContainer::Range PHG4TruthInfoContainer::GetSubEventSecondaryParticleRange(int subevent) {
+
+  std::map<int, std::pair<int,int> >::iterator iter = particle_subevents.find(subevent);
+  if (iter == particle_subevents.end()) {
+    return make_pair(particlemap.end(),particlemap.end());
+  }
+
+  int lowerkey = iter->second.first;
+  int upperkey = 0;
+  if (subevent > 1) {
+    upperkey = particle_subevents.find(subevent-1)->second.first;
+  }
+
+  Iterator loweriter = particlemap.lower_bound(lowerkey);
+  Iterator upperiter = particlemap.lower_bound(upperkey);
+    
+  return make_pair(loweriter,upperiter);
+}
+
+PHG4TruthInfoContainer::VtxRange PHG4TruthInfoContainer::GetSubEventPrimaryVertexRange(int subevent) {
+
+  std::map<int, std::pair<int,int> >::iterator iter = vertex_subevents.find(subevent);
+  if (iter == vertex_subevents.end()) {
+    return make_pair(vtxmap.end(),vtxmap.end());
+  }
+
+  int lowerkey = 0;
+  if (subevent > 1) {
+    lowerkey = vertex_subevents.find(subevent-1)->second.second;
+  }
+  int upperkey = iter->second.second; 
+
+  VtxIterator loweriter = vtxmap.upper_bound(lowerkey);
+  VtxIterator upperiter = vtxmap.upper_bound(upperkey);
+    
+  return make_pair(loweriter,upperiter);
+}
+
+PHG4TruthInfoContainer::VtxRange PHG4TruthInfoContainer::GetSubEventSecondaryVertexRange(int subevent) {
+
+  std::map<int, std::pair<int,int> >::iterator iter = vertex_subevents.find(subevent);
+  if (iter == vertex_subevents.end()) {
+    return make_pair(vtxmap.end(),vtxmap.end());
+  }
+
+  int lowerkey = iter->second.first;
+  int upperkey = 0;
+  if (subevent > 1) {
+    upperkey = vertex_subevents.find(subevent-1)->second.first;
+  }
+
+  VtxIterator loweriter = vtxmap.lower_bound(lowerkey);
+  VtxIterator upperiter = vtxmap.lower_bound(upperkey);
+    
+  return make_pair(loweriter,upperiter);
+}
+
+void PHG4TruthInfoContainer::MarkSubEventBoundary() {
+
+  int subevent = 1;
+  if (!particle_subevents.empty()) {
+    subevent = particle_subevents.rbegin()->first + 1;
+  }
+  
+  particle_subevents.insert(make_pair(subevent,make_pair(mintrkindex(),maxtrkindex())));
+  vertex_subevents.insert(make_pair(subevent,make_pair(minvtxindex(),maxvtxindex())));  
 }

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -39,8 +39,8 @@ struct SecondDeleter : std::unary_function<T,void>
 void
 PHG4TruthInfoContainer::Reset()
 {
-  std::for_each(hitmap.begin(),hitmap.end(),SecondDeleter<Map::value_type>());
-  hitmap.clear();
+  std::for_each(particlemap.begin(),particlemap.end(),SecondDeleter<Map::value_type>());
+  particlemap.clear();
 
   std::for_each(vtxmap.begin(),vtxmap.end(),SecondDeleter<VtxMap::value_type>());
   vtxmap.clear();
@@ -61,9 +61,9 @@ PHG4TruthInfoContainer::identify(ostream& os) const
 {
    ConstIterator iter;
    cout << "---particlemap--------------------------" << endl;
-   for (iter = hitmap.begin(); iter != hitmap.end(); ++iter)
+   for (iter = particlemap.begin(); iter != particlemap.end(); ++iter)
      {
-       cout << "hit key " <<  iter->first << endl;
+       cout << "particle key " <<  iter->first << endl;
        (iter->second)->identify();
      }
    ConstVtxIterator vter;
@@ -95,24 +95,24 @@ PHG4TruthInfoContainer::identify(ostream& os) const
 }
 
 PHG4TruthInfoContainer::ConstIterator
-PHG4TruthInfoContainer::AddHit(const int trackid, PHG4Particle *newhit)
+PHG4TruthInfoContainer::AddParticle(const int trackid, PHG4Particle *newparticle)
 {
   int key = get_key(trackid);
   ConstIterator it;
   bool added = false;
-  boost::tie(it,added) = hitmap.insert(std::make_pair(key,newhit));
+  boost::tie(it,added) = particlemap.insert(std::make_pair(key,newparticle));
   if ( added ) return it;
-  cerr << "PHG4TruthInfoContainer::AddHit - Attempt to add hit with existing trackid "
-      << trackid <<": "<<newhit ->get_name()<<" id "
-      << newhit->get_track_id()
-      <<", p = ["<<newhit->get_px()<<", "<<newhit->get_py()<<", "<<newhit->get_pz()<<"], "
-      <<" parent ID "<<newhit->get_parent_id()
+  cerr << "PHG4TruthInfoContainer::AddParticle - Attempt to add particle with existing trackid "
+      << trackid <<": "<<newparticle ->get_name()<<" id "
+      << newparticle->get_track_id()
+      <<", p = ["<<newparticle->get_px()<<", "<<newparticle->get_py()<<", "<<newparticle->get_pz()<<"], "
+      <<" parent ID "<<newparticle->get_parent_id()
       << std::endl;
-  return hitmap.end();
+  return particlemap.end();
 }
 
 PHG4TruthInfoContainer::ConstIterator
-PHG4TruthInfoContainer::AddPrimaryParticle(PHG4Particle *newhit)
+PHG4TruthInfoContainer::AddPrimaryParticle(PHG4Particle *newparticle)
 {
   int key = primary_particle_map.size()+1;
   if ( primary_particle_map.find(key) !=  primary_particle_map.end())
@@ -123,23 +123,23 @@ PHG4TruthInfoContainer::AddPrimaryParticle(PHG4Particle *newhit)
 
   ConstIterator it;
   bool added = false;
-  boost::tie(it,added) = primary_particle_map.insert(std::make_pair(key,newhit));
+  boost::tie(it,added) = primary_particle_map.insert(std::make_pair(key,newparticle));
   if ( added ) return it;
-  cerr << "PHG4TruthInfoContainer::AddHit - Attempt to add hit with existing trackid " << key << std::endl;
-  return hitmap.end();
+  cerr << "PHG4TruthInfoContainer::AddParticle - Attempt to add particle with existing trackid " << key << std::endl;
+  return particlemap.end();
 }
 
 PHG4Particle*
-PHG4TruthInfoContainer::GetHit(const int trackid)
+PHG4TruthInfoContainer::GetParticle(const int trackid)
 {
   int key = get_key(trackid);
-  Iterator it = hitmap.find(key);
-  if ( it != hitmap.end() ) return it->second;
+  Iterator it = particlemap.find(key);
+  if ( it != particlemap.end() ) return it->second;
   return 0;
 }
 
 PHG4Particle*
-PHG4TruthInfoContainer::GetPrimaryHit(const int trackid)
+PHG4TruthInfoContainer::GetPrimaryParticle(const int trackid)
 {
   int key = get_key(trackid);
   Iterator it = primary_particle_map.find(key);
@@ -148,15 +148,15 @@ PHG4TruthInfoContainer::GetPrimaryHit(const int trackid)
 }
 
 PHG4TruthInfoContainer::Range
-PHG4TruthInfoContainer::GetHitRange()
+PHG4TruthInfoContainer::GetParticleRange()
 {
-  return Range(hitmap.begin(),hitmap.end());
+  return Range(particlemap.begin(),particlemap.end());
 }
 
 PHG4TruthInfoContainer::ConstRange
-PHG4TruthInfoContainer::GetHitRange() const
+PHG4TruthInfoContainer::GetParticleRange() const
 {
-  return ConstRange(hitmap.begin(),hitmap.end());
+  return ConstRange(particlemap.begin(),particlemap.end());
 }
 
 PHG4VtxPoint*
@@ -299,9 +299,9 @@ int
 PHG4TruthInfoContainer::maxtrkindex() const
 {
   int key = 0;
-  if (!hitmap.empty())
+  if (!particlemap.empty())
     {
-      key = hitmap.rbegin()->first;
+      key = particlemap.rbegin()->first;
     }
   if (key < 0)
     {
@@ -314,9 +314,9 @@ int
 PHG4TruthInfoContainer::mintrkindex() const
 {
   int key = 0;
-  if (!hitmap.empty())
+  if (!particlemap.empty())
     {
-       key = hitmap.begin()->first;
+       key = particlemap.begin()->first;
     }
   if (key > 0)
     {
@@ -356,10 +356,10 @@ PHG4TruthInfoContainer::minvtxindex() const
 }
 
 void
-PHG4TruthInfoContainer::delete_hit(Iterator hiter)
+PHG4TruthInfoContainer::delete_particle(Iterator piter)
 {
-  delete hiter->second;
-  hitmap.erase(hiter);
+  delete piter->second;
+  particlemap.erase(piter);
   return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -74,9 +74,6 @@ public:
   //! Add a vertex and return an iterator to the user
   ConstVtxIterator AddVertex(const int vtxid, PHG4VtxPoint* vertex);
 
-  //! Add a primary vertex and return index to the user
-  //int AddPrimaryVertex(PHG4VtxPoint *);
-  
   PHG4VtxPoint* GetVtx(const int vtxid);
   PHG4VtxPoint* GetPrimaryVtx(const int vtxid);
   

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -120,18 +120,10 @@ public:
   // +N   primary particle id => particle*
   // +N-1 
   // ...
-  // +J+1 subevent #2
-  // +J   subevent #1 boundary (last particle flagged in particle_subevents)
-  // +J-1 subevent #1
-  // ..
   // +1   primary particle id => particle*
   // 0    no entry
   // -1   secondary particle id => particle*
   // ...
-  // -K+1 subevent #1
-  // -K   subevent #1 boundary (last particle flagged in particle_subevents)
-  // -K-1 subevent #2
-  // ..
   // -M+1
   // -M   secondary particle id => particle*
   

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -34,7 +34,8 @@ public:
  
   //! Add a particle that the user has created
   ConstIterator AddParticle(const int particleid, PHG4Particle* newparticle);
-
+  void delete_particle(Iterator piter);
+  
   PHG4Particle* GetParticle(const int particleid);
   PHG4Particle* GetPrimaryParticle(const int particleid);
 
@@ -54,48 +55,60 @@ public:
     return std::distance(particlemap.upper_bound(0),particlemap.end());
   }
   
-  //! Get the map itself
+  //! Get the Particle Map storage
   const Map& GetMap() const {return particlemap;}
   
   int maxtrkindex() const;
   int mintrkindex() const;
 
-  void delete_particle(Iterator piter);
-
-  std::pair< std::map<int,int>::const_iterator, std::map<int,int>::const_iterator > GetEmbeddedTrkIds() const {return std::make_pair(particle_embed_flags.begin(), particle_embed_flags.end());}
-  void AddEmbededTrkId(const int id, const int flag) {particle_embed_flags.insert(std::make_pair(id,flag));}
+  std::pair< std::map<int,int>::const_iterator,
+	     std::map<int,int>::const_iterator > GetEmbeddedTrkIds() const {
+    return std::make_pair(particle_embed_flags.begin(), particle_embed_flags.end());
+  }
+  void AddEmbededTrkId(const int id, const int flag) {
+    particle_embed_flags.insert(std::make_pair(id,flag));
+  }
 
   int isEmbeded(const int trackid) const;
    
   // --- vertex storage --------------------------------------------------------
   
   //! Add a vertex and return an iterator to the user
-  VtxIterator AddVertex(const int vtxid);
-  //! Add a vertex and return an iterator to the user
   ConstVtxIterator AddVertex(const int vtxid, PHG4VtxPoint* vertex);
-
+  void delete_vtx(VtxIterator viter);
+  
   PHG4VtxPoint* GetVtx(const int vtxid);
   PHG4VtxPoint* GetPrimaryVtx(const int vtxid);
   
   //! Get a range of iterators covering the entire vertex container
-  VtxRange GetVtxRange();
-  ConstVtxRange GetVtxRange() const;
+  VtxRange GetVtxRange() {return VtxRange(vtxmap.begin(),vtxmap.end());}
+  ConstVtxRange GetVtxRange() const {return ConstVtxRange(vtxmap.begin(),vtxmap.end());}
 
+  VtxRange GetPrimaryVtxRange() {return VtxRange(vtxmap.upper_bound(0),vtxmap.end());}
+  ConstVtxRange GetPrimaryVtxRange() const {return ConstVtxRange(vtxmap.upper_bound(0),vtxmap.end());}
+
+  VtxRange GetSecondaryVtxRange() {return VtxRange(vtxmap.begin(),vtxmap.upper_bound(0));}
+  ConstVtxRange GetSecondaryVtxRange() const {return ConstVtxRange(vtxmap.begin(),vtxmap.upper_bound(0));}
+  
   //! Get the number of vertices stored
   unsigned int GetNumVertices() const {return vtxmap.size();}
 
+  //! Get the Vertex Map storage
   const VtxMap& GetVtxMap() const {return vtxmap;}
 
   int maxvtxindex() const;
   int minvtxindex() const;
- 
-  void delete_vtx(VtxIterator viter);
 
   // returns the first primary vertex that was processed by Geant4
   int GetPrimaryVertexIndex() {return (vtxmap.lower_bound(1))->first;}
 
-  std::pair< std::map<int,int>::const_iterator, std::map<int,int>::const_iterator > GetEmbeddedVtxIds() const {return std::make_pair(vertex_embed_flags.begin(), vertex_embed_flags.end());}
-  void AddEmbededVtxId(const int id, const int flag) {vertex_embed_flags.insert(std::make_pair(id,flag));}
+  std::pair< std::map<int,int>::const_iterator,
+	     std::map<int,int>::const_iterator > GetEmbeddedVtxIds() const {
+    return std::make_pair(vertex_embed_flags.begin(), vertex_embed_flags.end());
+  }
+  void AddEmbededVtxId(const int id, const int flag) {
+    vertex_embed_flags.insert(std::make_pair(id,flag));
+  }
 
   int isEmbededVtx(const int vtxid) const;
   
@@ -127,14 +140,14 @@ public:
   // -M+1
   // -M   secondary particle id => particle*
   
-  Map particlemap;
+  Map particlemap; //< particle => particle*
 
   // vertex storage map format is similar to the above particle map
-  VtxMap vtxmap;
+  VtxMap vtxmap; //< vertex id => vertex*
 
   // embed flag storage, will typically be set for only a few entries or none at all
-  std::map< int, int> particle_embed_flags;               // trackid => embed flag
-  std::map< int, int> vertex_embed_flags;                 // vtxid => embed flag
+  std::map< int, int> particle_embed_flags; //< trackid => embed flag
+  std::map< int, int> vertex_embed_flags;   //< vtxid => embed flag
 
   ClassDef(PHG4TruthInfoContainer,1)
 };

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -38,29 +38,34 @@ public:
   PHG4Particle* GetParticle(const int particleid);
   PHG4Particle* GetPrimaryParticle(const int particleid);
 
-  ConstIterator AddPrimaryParticle(PHG4Particle *newparticle);
+  //ConstIterator AddPrimaryParticle(PHG4Particle *newparticle);
   
   //! Get a range of iterators covering the entire container
-  Range GetParticleRange();
-  ConstRange GetParticleRange() const;
+  Range GetParticleRange() {return Range(particlemap.begin(),particlemap.end());}
+  ConstRange GetParticleRange() const {return ConstRange(particlemap.begin(),particlemap.end());}
 
+  Range GetPrimaryParticleRange() {return Range(particlemap.upper_bound(0),particlemap.end());}
+  ConstRange GetPrimaryParticleRange() const {return ConstRange(particlemap.upper_bound(0),particlemap.end());}
+
+  Range GetSecondaryParticleRange() {return Range(particlemap.begin(),particlemap.upper_bound(0));}
+  ConstRange GetSecondaryParticleRange() const {return ConstRange(particlemap.begin(),particlemap.upper_bound(0));}
+  
   //! particle size
   unsigned int size( void ) const {return particlemap.size();}
-  int GetNumPrimaryVertexParticles() {return primary_particle_map.size();}
+  int GetNumPrimaryVertexParticles() {
+    return std::distance(particlemap.upper_bound(0),particlemap.end());
+  }
   
   //! Get the map itself
   const Map& GetMap() const {return particlemap;}
-  const Map& GetPrimaryMap() const {return primary_particle_map;}
-
+  //const Map& GetPrimaryMap() const {return primary_particle_map;}
+  
   int maxtrkindex() const;
   int mintrkindex() const;
 
-  int maxprimarytrkindex() const;
-  int minprimarytrkindex() const;
-
   void delete_particle(Iterator piter);
 
-  int GetLastParticleIndex() {return (primary_particle_map.rbegin())->first;}
+  //int GetLastParticleIndex() {return (primary_particle_map.rbegin())->first;}
 
   std::pair< std::map<int,int>::const_iterator, std::map<int,int>::const_iterator > GetEmbeddedTrkIds() const {return std::make_pair(particle_embed_flags.begin(), particle_embed_flags.end());}
   void AddEmbededTrkId(const int id, const int flag) {particle_embed_flags.insert(std::make_pair(id,flag));}
@@ -75,7 +80,7 @@ public:
   ConstVtxIterator AddVertex(const int vtxid, PHG4VtxPoint* vertex);
 
   //! Add a primary vertex and return index to the user
-  int AddPrimaryVertex(PHG4VtxPoint *);
+  //int AddPrimaryVertex(PHG4VtxPoint *);
   
   PHG4VtxPoint* GetVtx(const int vtxid);
   PHG4VtxPoint* GetPrimaryVtx(const int vtxid);
@@ -159,10 +164,6 @@ public:
   std::map< int, std::pair<int,int> > vertex_subevents;   // subevent index => lower key and upper key
   std::map< int, int> particle_embed_flags;               // trackid => embed flag
   std::map< int, int> vertex_embed_flags;                 // trackid => embed flag
-
-  // --- deprecated storage ----------
-  Map primary_particle_map;
-  VtxMap primary_vtxmap;
 
   ClassDef(PHG4TruthInfoContainer,1)
 };

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -62,12 +62,11 @@ public:
 
   int GetLastParticleIndex() {return (primary_particle_map.rbegin())->first;}
 
-  std::pair< std::set<int>::const_iterator, std::set<int>::const_iterator > GetEmbeddedTrkIds() const
-    {return std::make_pair(embedded_trkid.begin(), embedded_trkid.end());}
-  void AddEmbededTrkId(const int i) {embedded_trkid.insert(i);}
+  std::pair< std::map<int,int>::const_iterator, std::map<int,int>::const_iterator > GetEmbeddedTrkIds() const {return std::make_pair(particle_embed_flags.begin(), particle_embed_flags.end());}
+  void AddEmbededTrkId(const int id, const int flag) {particle_embed_flags.insert(std::make_pair(id,flag));}
 
   int isEmbeded(const int trackid) const;
-  
+   
   // --- vertex storage --------------------------------------------------------
   
   //! Add a vertex and return an iterator to the user
@@ -98,6 +97,13 @@ public:
   // returns the first primary vertex that was processed by Geant4
   int GetPrimaryVertexIndex() {return (vtxmap.lower_bound(1))->first;}
 
+  std::pair< std::map<int,int>::const_iterator, std::map<int,int>::const_iterator > GetEmbeddedVtxIds() const {return std::make_pair(vertex_embed_flags.begin(), vertex_embed_flags.end());}
+  void AddEmbededVtxId(const int id, const int flag) {vertex_embed_flags.insert(std::make_pair(id,flag));}
+
+  int isEmbededVtx(const int vtxid) const;
+  
+  // --- subevent boundary storage ---------------------------------------------
+  
   std::set<int> GetSubEventIds() const;
   Range         GetSubEventPrimaryParticleRange(int subevent);
   Range         GetSubEventSecondaryParticleRange(int subevent);
@@ -116,11 +122,9 @@ public:
   ConstRange GetHitRange() const {return GetParticleRange();}
   void delete_hit(Iterator piter) {delete_particle(piter);}
 
-  // end deprecated interface, confusingly named -------------------------------
-  
  private:
 
-  // map format description:
+  // particle storage map format description:
   // primary particles are appended in the positive direction
   // secondary particles are appended in the negative direction
   // subevent boundaries between geant runs are stored in the subevent markers
@@ -144,8 +148,13 @@ public:
   // -M   secondary particle id => particle*
   
   Map particlemap;
+
+  // vertex storage map format is similar to the above particle map
   VtxMap vtxmap;
 
+  // these items will be set only rarely and so it doesn't make sense to put
+  // this information directly on the objects themselves so I will store them
+  // here individually by lookup id
   std::map< int, std::pair<int,int> > particle_subevents; // subevent index => lower key and upper key
   std::map< int, std::pair<int,int> > vertex_subevents;   // subevent index => lower key and upper key
   std::map< int, int> particle_embed_flags;               // trackid => embed flag
@@ -154,8 +163,6 @@ public:
   // --- deprecated storage ----------
   Map primary_particle_map;
   VtxMap primary_vtxmap;
-  // track ids of embedded particles
-  std::set<int> embedded_trkid;
 
   ClassDef(PHG4TruthInfoContainer,1)
 };

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -38,8 +38,6 @@ public:
   PHG4Particle* GetParticle(const int particleid);
   PHG4Particle* GetPrimaryParticle(const int particleid);
 
-  //ConstIterator AddPrimaryParticle(PHG4Particle *newparticle);
-  
   //! Get a range of iterators covering the entire container
   Range GetParticleRange() {return Range(particlemap.begin(),particlemap.end());}
   ConstRange GetParticleRange() const {return ConstRange(particlemap.begin(),particlemap.end());}
@@ -58,14 +56,11 @@ public:
   
   //! Get the map itself
   const Map& GetMap() const {return particlemap;}
-  //const Map& GetPrimaryMap() const {return primary_particle_map;}
   
   int maxtrkindex() const;
   int mintrkindex() const;
 
   void delete_particle(Iterator piter);
-
-  //int GetLastParticleIndex() {return (primary_particle_map.rbegin())->first;}
 
   std::pair< std::map<int,int>::const_iterator, std::map<int,int>::const_iterator > GetEmbeddedTrkIds() const {return std::make_pair(particle_embed_flags.begin(), particle_embed_flags.end());}
   void AddEmbededTrkId(const int id, const int flag) {particle_embed_flags.insert(std::make_pair(id,flag));}
@@ -106,15 +101,6 @@ public:
   void AddEmbededVtxId(const int id, const int flag) {vertex_embed_flags.insert(std::make_pair(id,flag));}
 
   int isEmbededVtx(const int vtxid) const;
-  
-  // --- subevent boundary storage ---------------------------------------------
-  
-  std::set<int> GetSubEventIds() const;
-  Range         GetSubEventPrimaryParticleRange(int subevent);
-  Range         GetSubEventSecondaryParticleRange(int subevent);
-  VtxRange      GetSubEventPrimaryVertexRange(int subevent);
-  VtxRange      GetSubEventSecondaryVertexRange(int subevent); 
-  void          MarkSubEventBoundary();
   
   // deprecated interface, confusingly named as we store particles not hits ----
   // do not call these functions in new code, i'm leaving these for now for
@@ -157,13 +143,9 @@ public:
   // vertex storage map format is similar to the above particle map
   VtxMap vtxmap;
 
-  // these items will be set only rarely and so it doesn't make sense to put
-  // this information directly on the objects themselves so I will store them
-  // here individually by lookup id
-  std::map< int, std::pair<int,int> > particle_subevents; // subevent index => lower key and upper key
-  std::map< int, std::pair<int,int> > vertex_subevents;   // subevent index => lower key and upper key
+  // embed flag storage, will typically be set for only a few entries or none at all
   std::map< int, int> particle_embed_flags;               // trackid => embed flag
-  std::map< int, int> vertex_embed_flags;                 // trackid => embed flag
+  std::map< int, int> vertex_embed_flags;                 // vtxid => embed flag
 
   ClassDef(PHG4TruthInfoContainer,1)
 };

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -1,7 +1,6 @@
 #ifndef __PHG4TRUTHINFOCONTAINER_H__
 #define __PHG4TRUTHINFOCONTAINER_H__
 
-
 #include <phool/PHObject.h>
 #include <map>
 #include <set>
@@ -9,9 +8,10 @@
 class PHG4Particle;
 class PHG4VtxPoint;
 
-class PHG4TruthInfoContainer: public PHObject
-{
-  public:
+class PHG4TruthInfoContainer: public PHObject {
+  
+public:
+
   typedef std::map<int,PHG4Particle *> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
@@ -25,72 +25,42 @@ class PHG4TruthInfoContainer: public PHObject
   typedef std::pair<ConstVtxIterator, ConstVtxIterator> ConstVtxRange;
 
   PHG4TruthInfoContainer();
-
   virtual ~PHG4TruthInfoContainer();
 
   void Reset();
 
   void identify(std::ostream& os = std::cout) const;
 
-  //! Add a hit that the user has created (use with caution)
-  ConstIterator AddHit(const int detid, PHG4Particle *newhit);
+  // --- particle storage ------------------------------------------------------
+  
+  //! Add a particle that the user has created
+  ConstIterator AddParticle(const int particleid, PHG4Particle* newparticle);
 
-  //! Add a hit and return an iterator to the user
-  //  Iterator AddHit(const int detid);
-
-  PHG4Particle* GetHit(const int detid);
-  PHG4Particle* GetPrimaryHit(const int detid);
-
-  //! Add a vertex and return an iterator to the user
-  VtxIterator AddVertex(const int detid);
-
-  //! Add a vertex and return an iterator to the user
-  ConstVtxIterator AddVertex(const int detid, PHG4VtxPoint *);
-
-  //! Add a primary vertex and return index to the user
-  int AddPrimaryVertex(PHG4VtxPoint *);
+  PHG4Particle* GetParticle(const int particleid);
+  PHG4Particle* GetPrimaryParticle(const int particleid);
 
   ConstIterator AddPrimaryParticle(PHG4Particle *newparticle);
-
-  PHG4VtxPoint* GetVtx(const int detid);
-
-  PHG4VtxPoint* GetPrimaryVtx(const int vtxid);
-
-  //! Get a range of iterators covering the entire container
-  Range GetHitRange();
-  ConstRange GetHitRange() const;
   
-  //! Get a range of iterators covering the entire vertex container
-  VtxRange GetVtxRange();
-  ConstVtxRange GetVtxRange() const;
+  //! Get a range of iterators covering the entire container
+  Range GetParticleRange();
+  ConstRange GetParticleRange() const;
 
-  //! hit size
-  unsigned int size( void ) const
-  { return hitmap.size(); }
-
-  //! Get the number of vertices stored
-  unsigned int GetNumVertices() const { return vtxmap.size(); }
-
+  //! particle size
+  unsigned int size( void ) const {return particlemap.size();}
+  int GetNumPrimaryVertexParticles() {return primary_particle_map.size();}
+  
   //! Get the map itself
-  const Map& GetMap() const { return hitmap; }
-  const Map& GetPrimaryMap() const { return primary_particle_map; }
-  const VtxMap& GetVtxMap() const { return vtxmap; }
+  const Map& GetMap() const {return particlemap;}
+  const Map& GetPrimaryMap() const {return primary_particle_map;}
 
   int maxtrkindex() const;
   int mintrkindex() const;
 
-  int maxvtxindex() const;
-  int minvtxindex() const;
- 
   int maxprimarytrkindex() const;
   int minprimarytrkindex() const;
 
-  void delete_hit(Iterator hiter);
-  void delete_vtx(VtxIterator viter);
+  void delete_particle(Iterator piter);
 
-  int GetPrimaryVertexIndex() {return (primary_vtxmap.begin())->first;}
-  int GetNumPrimaryVertexParticles() {return primary_particle_map.size();}
-  
   int GetLastParticleIndex() {return (primary_particle_map.rbegin())->first;}
 
   std::pair< std::set<int>::const_iterator, std::set<int>::const_iterator > GetEmbeddedTrkIds() const
@@ -98,13 +68,55 @@ class PHG4TruthInfoContainer: public PHObject
   void AddEmbededTrkId(const int i) {embedded_trkid.insert(i);}
 
   int isEmbeded(const int trackid) const;
+  
+  // --- vertex storage --------------------------------------------------------
+  
+  //! Add a vertex and return an iterator to the user
+  VtxIterator AddVertex(const int vtxid);
+  //! Add a vertex and return an iterator to the user
+  ConstVtxIterator AddVertex(const int vtxid, PHG4VtxPoint* vertex);
 
+  //! Add a primary vertex and return index to the user
+  int AddPrimaryVertex(PHG4VtxPoint *);
+  
+  PHG4VtxPoint* GetVtx(const int vtxid);
+  PHG4VtxPoint* GetPrimaryVtx(const int vtxid);
+  
+  //! Get a range of iterators covering the entire vertex container
+  VtxRange GetVtxRange();
+  ConstVtxRange GetVtxRange() const;
+
+  //! Get the number of vertices stored
+  unsigned int GetNumVertices() const {return vtxmap.size();}
+
+  const VtxMap& GetVtxMap() const {return vtxmap;}
+
+  int maxvtxindex() const;
+  int minvtxindex() const;
+ 
+  void delete_vtx(VtxIterator viter);
+
+  int GetPrimaryVertexIndex() {return (primary_vtxmap.begin())->first;}
+
+  // deprecated interface, confusingly named as we store particles not hits ----
+  // do not call these functions in new code, i'm leaving these for now for
+  // build compatibility outside of coresoftware
+  
+  //ConstIterator AddHit(const int particleid, PHG4Particle *newparticle) {return AddParticle(particleid,newparticle);}
+  //PHG4Particle* GetHit(const int particleid) {return GetParticle(particleid);}
+  //PHG4Particle* GetPrimaryHit(const int particleid) {return GetPrimaryParticle(particleid);}
+  //Range GetHitRange() {return GetParticleRange();}
+  //ConstRange GetHitRange() const {return GetParticleRange();}
+  //void delete_hit(Iterator piter) {delete_particle(piter);}
+
+  // end deprecated interface, confusingly named -------------------------------
+  
  protected:
 
   //! generate a key
   static int get_key(const int detid);
 
-  Map hitmap;
+  Map particlemap;
   VtxMap vtxmap;
 
   Map primary_particle_map;

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -28,11 +28,10 @@ public:
   virtual ~PHG4TruthInfoContainer();
 
   void Reset();
-
   void identify(std::ostream& os = std::cout) const;
 
   // --- particle storage ------------------------------------------------------
-  
+ 
   //! Add a particle that the user has created
   ConstIterator AddParticle(const int particleid, PHG4Particle* newparticle);
 
@@ -102,19 +101,16 @@ public:
   // do not call these functions in new code, i'm leaving these for now for
   // build compatibility outside of coresoftware
   
-  //ConstIterator AddHit(const int particleid, PHG4Particle *newparticle) {return AddParticle(particleid,newparticle);}
-  //PHG4Particle* GetHit(const int particleid) {return GetParticle(particleid);}
-  //PHG4Particle* GetPrimaryHit(const int particleid) {return GetPrimaryParticle(particleid);}
-  //Range GetHitRange() {return GetParticleRange();}
-  //ConstRange GetHitRange() const {return GetParticleRange();}
-  //void delete_hit(Iterator piter) {delete_particle(piter);}
+  ConstIterator AddHit(const int particleid, PHG4Particle *newparticle) {return AddParticle(particleid,newparticle);}
+  PHG4Particle* GetHit(const int particleid) {return GetParticle(particleid);}
+  PHG4Particle* GetPrimaryHit(const int particleid) {return GetPrimaryParticle(particleid);}
+  Range GetHitRange() {return GetParticleRange();}
+  ConstRange GetHitRange() const {return GetParticleRange();}
+  void delete_hit(Iterator piter) {delete_particle(piter);}
 
   // end deprecated interface, confusingly named -------------------------------
   
- protected:
-
-  //! generate a key
-  static int get_key(const int detid);
+ private:
 
   Map particlemap;
   VtxMap vtxmap;

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -5,8 +5,8 @@
 #include <map>
 #include <set>
 
-class PHG4Particle;
-class PHG4VtxPoint;
+#include "PHG4Particle.h"
+#include "PHG4VtxPoint.h"
 
 class PHG4TruthInfoContainer: public PHObject {
   
@@ -34,11 +34,13 @@ public:
  
   //! Add a particle that the user has created
   ConstIterator AddParticle(const int particleid, PHG4Particle* newparticle);
-  void delete_particle(Iterator piter);
+  void delete_particle(Iterator piter); 
   
   PHG4Particle* GetParticle(const int particleid);
   PHG4Particle* GetPrimaryParticle(const int particleid);
 
+  bool is_primary(const PHG4Particle* p) const {return (p->get_track_id() > 0);}
+  
   //! Get a range of iterators covering the entire container
   Range GetParticleRange() {return Range(particlemap.begin(),particlemap.end());}
   ConstRange GetParticleRange() const {return ConstRange(particlemap.begin(),particlemap.end());}
@@ -48,7 +50,7 @@ public:
 
   Range GetSecondaryParticleRange() {return Range(particlemap.begin(),particlemap.upper_bound(0));}
   ConstRange GetSecondaryParticleRange() const {return ConstRange(particlemap.begin(),particlemap.upper_bound(0));}
-  
+
   //! particle size
   unsigned int size( void ) const {return particlemap.size();}
   int GetNumPrimaryVertexParticles() {
@@ -79,6 +81,8 @@ public:
   
   PHG4VtxPoint* GetVtx(const int vtxid);
   PHG4VtxPoint* GetPrimaryVtx(const int vtxid);
+
+  bool is_primary_vtx(const PHG4VtxPoint* v) const {return (v->get_id() > 0);}
   
   //! Get a range of iterators covering the entire vertex container
   VtxRange GetVtxRange() {return VtxRange(vtxmap.begin(),vtxmap.end());}
@@ -114,25 +118,35 @@ public:
 
  private:
 
-  // particle storage map format description:
-  // primary particles are appended in the positive direction
-  // secondary particles are appended in the negative direction
-  // subevent boundaries between geant runs are stored in the subevent markers
+  /// particle storage map format description:
+  /// primary particles are appended in the positive direction
+  /// secondary particles are appended in the negative direction
+  /// subevent boundaries between geant runs are stored in the subevent markers
+  /// +N   primary particle id => particle*
+  /// +N-1 
+  /// ...
+  /// +1   primary particle id => particle*
+  /// 0    no entry
+  /// -1   secondary particle id => particle*
+  /// ...
+  /// -M+1
+  /// -M   secondary particle id => particle*  
+  Map particlemap;
 
-  // +N   primary particle id => particle*
-  // +N-1 
-  // ...
-  // +1   primary particle id => particle*
-  // 0    no entry
-  // -1   secondary particle id => particle*
-  // ...
-  // -M+1
-  // -M   secondary particle id => particle*
-  
-  Map particlemap; //< particle => particle*
-
-  // vertex storage map format is similar to the above particle map
-  VtxMap vtxmap; //< vertex id => vertex*
+  /// vertex storage map format description:
+  /// primary vertexes are appended in the positive direction
+  /// secondary vertexes are appended in the negative direction
+  /// subevent boundaries between geant runs are stored in the subevent markers
+  /// +N   primary vertex id => vertex*
+  /// +N-1 
+  /// ...
+  /// +1   primary vertex id => vertex*
+  /// 0    no entry
+  /// -1   secondary vertex id => vertex*
+  /// ...
+  /// -M+1
+  /// -M   secondary vertex id => vertex*  
+  VtxMap vtxmap;
 
   // embed flag storage, will typically be set for only a few entries or none at all
   std::map< int, int> particle_embed_flags; //< trackid => embed flag

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -121,7 +121,6 @@ public:
   /// particle storage map format description:
   /// primary particles are appended in the positive direction
   /// secondary particles are appended in the negative direction
-  /// subevent boundaries between geant runs are stored in the subevent markers
   /// +N   primary particle id => particle*
   /// +N-1 
   /// ...
@@ -136,7 +135,6 @@ public:
   /// vertex storage map format description:
   /// primary vertexes are appended in the positive direction
   /// secondary vertexes are appended in the negative direction
-  /// subevent boundaries between geant runs are stored in the subevent markers
   /// +N   primary vertex id => vertex*
   /// +N-1 
   /// ...

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -111,17 +111,6 @@ public:
   }
 
   int isEmbededVtx(const int vtxid) const;
-  
-  // deprecated interface, confusingly named as we store particles not hits ----
-  // do not call these functions in new code, i'm leaving these for now for
-  // build compatibility outside of coresoftware
-  
-  ConstIterator AddHit(const int particleid, PHG4Particle *newparticle) {return AddParticle(particleid,newparticle);}
-  PHG4Particle* GetHit(const int particleid) {return GetParticle(particleid);}
-  PHG4Particle* GetPrimaryHit(const int particleid) {return GetPrimaryParticle(particleid);}
-  Range GetHitRange() {return GetParticleRange();}
-  ConstRange GetHitRange() const {return GetParticleRange();}
-  void delete_hit(Iterator piter) {delete_particle(piter);}
 
  private:
 

--- a/simulation/g4simulation/g4main/PHG4TruthSteppingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSteppingAction.cc
@@ -15,42 +15,5 @@ PHG4TruthSteppingAction::PHG4TruthSteppingAction( PHG4TruthEventAction* eventAct
 //________________________________________________________
 bool PHG4TruthSteppingAction::UserSteppingAction( const G4Step* step, bool hitWasUsed )
 {
-//   if ( VERBOSE>0 )
-//     {
-//       G4VPhysicalVolume* volume = step->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
-//       std::cout << "PHG4TruthSteppingAction::UserSteppingAction: Stepping in volume " << volume->GetName()
-// 		<< " = " << volume;
-//       if ( volume->IsParameterised() ) std::cout << " copyNo " << volume->GetCopyNo();
-//       std::cout << " " << (hitWasUsed?"hit was used":"hit was not used") << std::endl;
-//     }
-
-//   bool addid = false;
-
-//   const G4Track* track=step->GetTrack();
-//   if ( ! track ) return false;
-
-//   //  if( !hitWasUsed ) return false;
-
-//   // hitWasUsed being true means that the hit corresponds to at least
-//   // one of the previously defined subsystem, in which case one adds its
-//   // corresponding track id to the eventAction
-//   // We have to check both hitused and the user data stored with the track, since 
-//   // region stepping routines will be called outside the master stepping action.
-
-//   if ( hitWasUsed ) addid = true;
-//   else if ( PHG4TrackUserInfoV1* p = dynamic_cast<PHG4TrackUserInfoV1*>(track->GetUserInformation()) )
-//     {
-//       if ( p->GetWanted() ) addid = true;
-//     }
-
-//   if ( ! addid ) return false;
-
-//   if( track )
-//   {
-//     eventAction_->AddTrackidToWritelist( track->GetTrackID() );
-//     return true;
-
-//   } else return false;
   return false;
-
 }

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
@@ -87,12 +87,17 @@ PHG4TruthSubsystem::process_event( PHCompositeNode* topNode )
 
   // this is called before G4 is kicked into gear. So we can fill in the information of the
   // G4 input particles from the InEvent Node.
+
+  //----------------------------------------------------------------------------
+  // to be removed when we deprecate the primary map storage
+  
   PHG4InEvent *inEvent = findNode::getClass<PHG4InEvent>(topNode, "PHG4INEVENT");
   if (!inEvent) // if this node doesn't exist, they get the particles from somewhere else (not good)
     {
       cout << "Could not locate PHG4INEVENT node, where do you get your Geant 4 input from???" << endl;
       return Fun4AllReturnCodes::EVENT_OK;
     }
+  
   PHG4TruthInfoContainer* truthInfoList =  findNode::getClass<PHG4TruthInfoContainer>( topNode , "G4TruthInfo" );
 
   map<int, PHG4VtxPoint *>::const_iterator vtxiter;
@@ -129,6 +134,9 @@ PHG4TruthSubsystem::process_event( PHCompositeNode* topNode )
 	}
 
     }
+
+  //----------------------------------------------------------------------------
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -183,10 +191,10 @@ int PHG4TruthSubsystem::process_after_geant(PHCompositeNode * topNode)
         }
     }
 
-
- {
-  PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
-  truthinfo->identify();
+  // MPM I'll need to remove this before merging
+  {
+    PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
+    truthinfo->identify();
   } 
   
   return 0;

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
@@ -139,12 +139,6 @@ int PHG4TruthSubsystem::process_after_geant(PHCompositeNode * topNode)
         }
     }
 
-  // MPM I'll need to remove this before merging
-  {
-    PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
-    truthinfo->identify();
-  } 
-  
   return 0;
 }
 

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
@@ -57,7 +57,6 @@ int PHG4TruthSubsystem::InitRun( PHCompositeNode* topNode )
   trackingAction_ = new PHG4TruthTrackingAction( eventAction_ );
 
   return 0;
-
 }
 
 //_______________________________________________________________________
@@ -102,9 +101,10 @@ PHG4TruthSubsystem::process_event( PHCompositeNode* topNode )
 //     cout << "truthInfoList maxkey: " << truthInfoList->maxindex() << endl;
 //     cout << "truthInfoList minkey: " << truthInfoList->minindex() << endl;
   trackingAction_->PrimaryTrackIdOffset(truthInfoList->maxtrkindex());
-  trackingAction_->SecondaryTrackIdOffset(truthInfoList->maxtrkindex());
-  eventAction_->PrimaryTrackIdOffset(truthInfoList->maxprimarytrkindex());
-  eventAction_->SecondaryTrackIdOffset(truthInfoList->maxtrkindex());
+  trackingAction_->SecondaryTrackIdOffset(truthInfoList->mintrkindex());
+  eventAction_->PrimaryTrackIdOffset(truthInfoList->maxtrkindex());
+  eventAction_->SecondaryTrackIdOffset(truthInfoList->mintrkindex());
+  eventAction_->PrimaryMapTrackIdOffset(truthInfoList->maxprimarytrkindex());
   map<int, PHG4VtxPoint *>::const_iterator vtxiter;
   multimap<int, PHG4Particle *>::const_iterator particle_iter;
   std::pair< std::map<int, PHG4VtxPoint *>::const_iterator, std::map<int, PHG4VtxPoint *>::const_iterator > vtxbegin_end = inEvent->GetVertices();

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
@@ -156,7 +156,7 @@ int PHG4TruthSubsystem::process_after_geant(PHCompositeNode * topNode)
       set<int> savevtxlist;
 
       // remove particle that is not embedd associated
-      PHG4TruthInfoContainer::Range truth_range = truthInfoList->GetHitRange();
+      PHG4TruthInfoContainer::Range truth_range = truthInfoList->GetParticleRange();
       PHG4TruthInfoContainer::Iterator truthiter = truth_range.first;
       while (truthiter != truth_range.second)
         {
@@ -165,7 +165,7 @@ int PHG4TruthSubsystem::process_after_geant(PHCompositeNode * topNode)
             {
               // not a embed associated particle
 
-              truthInfoList->delete_hit(truthiter++);
+              truthInfoList->delete_particle(truthiter++);
             }
           else
             {

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
@@ -95,16 +95,6 @@ PHG4TruthSubsystem::process_event( PHCompositeNode* topNode )
     }
   PHG4TruthInfoContainer* truthInfoList =  findNode::getClass<PHG4TruthInfoContainer>( topNode , "G4TruthInfo" );
 
-//     cout << "truthInfoList identify" << endl;
-//     truthInfoList->identify();
-//     cout << "truthInfoList identify done" << endl;
-//     cout << "truthInfoList maxkey: " << truthInfoList->maxindex() << endl;
-//     cout << "truthInfoList minkey: " << truthInfoList->minindex() << endl;
-  trackingAction_->PrimaryTrackIdOffset(truthInfoList->maxtrkindex());
-  trackingAction_->SecondaryTrackIdOffset(truthInfoList->mintrkindex());
-  eventAction_->PrimaryTrackIdOffset(truthInfoList->maxtrkindex());
-  eventAction_->SecondaryTrackIdOffset(truthInfoList->mintrkindex());
-  eventAction_->PrimaryMapTrackIdOffset(truthInfoList->maxprimarytrkindex());
   map<int, PHG4VtxPoint *>::const_iterator vtxiter;
   multimap<int, PHG4Particle *>::const_iterator particle_iter;
   std::pair< std::map<int, PHG4VtxPoint *>::const_iterator, std::map<int, PHG4VtxPoint *>::const_iterator > vtxbegin_end = inEvent->GetVertices();

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
@@ -85,58 +85,6 @@ PHG4TruthSubsystem::process_event( PHCompositeNode* topNode )
       exit(1);
     }
 
-  // this is called before G4 is kicked into gear. So we can fill in the information of the
-  // G4 input particles from the InEvent Node.
-
-  //----------------------------------------------------------------------------
-  // to be removed when we deprecate the primary map storage
-  
-  PHG4InEvent *inEvent = findNode::getClass<PHG4InEvent>(topNode, "PHG4INEVENT");
-  if (!inEvent) // if this node doesn't exist, they get the particles from somewhere else (not good)
-    {
-      cout << "Could not locate PHG4INEVENT node, where do you get your Geant 4 input from???" << endl;
-      return Fun4AllReturnCodes::EVENT_OK;
-    }
-  
-  PHG4TruthInfoContainer* truthInfoList =  findNode::getClass<PHG4TruthInfoContainer>( topNode , "G4TruthInfo" );
-
-  map<int, PHG4VtxPoint *>::const_iterator vtxiter;
-  multimap<int, PHG4Particle *>::const_iterator particle_iter;
-  std::pair< std::map<int, PHG4VtxPoint *>::const_iterator, std::map<int, PHG4VtxPoint *>::const_iterator > vtxbegin_end = inEvent->GetVertices();
-  for (vtxiter = vtxbegin_end.first; vtxiter != vtxbegin_end.second; ++vtxiter)
-    {
-      PHG4VtxPoint *vtx = new PHG4VtxPointv1(vtxiter->second);
-      int my_vtx_id = truthInfoList->AddPrimaryVertex(vtx);
-	   
-      pair<multimap<int, PHG4Particle *>::const_iterator, multimap<int, PHG4Particle *>::const_iterator > particlebegin_end = inEvent->GetParticles(vtxiter->first);
-      for (particle_iter = particlebegin_end.first; particle_iter != particlebegin_end.second; ++particle_iter)
-	{
-	  PHG4Particle *particle = new PHG4Particlev2(particle_iter->second);
-	  particle->set_vtx_id(my_vtx_id);
-	  G4ParticleTable* particleTable( G4ParticleTable::GetParticleTable() );
-	  G4ParticleDefinition* g4particle( particleTable->FindParticle( particle->get_pid() ) );
-	  if ( !g4particle && (particle->get_name()).find("geantino") == string::npos ) // keep geantinos
-	    {
-	      std::cout << PHWHERE << ": unable to find particle properties for "
-			<< particle->get_name() << " with PDG id "
-			<< particle->get_pid() << std::endl;
-	    }
-	  double mass = 0;
-	  if (g4particle)
-	    {
-	      mass = ( g4particle->GetPDGMass() / GeV );
-	    }
-	  double energy = sqrt( pow(mass, 2) + pow(particle->get_px(), 2) + pow(particle->get_py(), 2) + pow(particle->get_pz(), 2) );
-	  particle->set_e( energy );
-
-	  PHG4TruthInfoContainer::ConstIterator piter = truthInfoList->AddPrimaryParticle(particle);
-	  particle->set_track_id(piter->first); // update track id with returned id from insert
-	}
-
-    }
-
-  //----------------------------------------------------------------------------
-  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
@@ -101,9 +101,10 @@ PHG4TruthSubsystem::process_event( PHCompositeNode* topNode )
 //     cout << "truthInfoList identify done" << endl;
 //     cout << "truthInfoList maxkey: " << truthInfoList->maxindex() << endl;
 //     cout << "truthInfoList minkey: " << truthInfoList->minindex() << endl;
-  trackingAction_->TrackIdOffset(truthInfoList->maxtrkindex());
-  eventAction_->TrackIdOffset(truthInfoList->maxtrkindex());
+  trackingAction_->PrimaryTrackIdOffset(truthInfoList->maxtrkindex());
+  trackingAction_->SecondaryTrackIdOffset(truthInfoList->maxtrkindex());
   eventAction_->PrimaryTrackIdOffset(truthInfoList->maxprimarytrkindex());
+  eventAction_->SecondaryTrackIdOffset(truthInfoList->maxtrkindex());
   map<int, PHG4VtxPoint *>::const_iterator vtxiter;
   multimap<int, PHG4Particle *>::const_iterator particle_iter;
   std::pair< std::map<int, PHG4VtxPoint *>::const_iterator, std::map<int, PHG4VtxPoint *>::const_iterator > vtxbegin_end = inEvent->GetVertices();

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
@@ -192,6 +192,12 @@ int PHG4TruthSubsystem::process_after_geant(PHCompositeNode * topNode)
         }
     }
 
+
+ {
+  PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
+  truthinfo->identify();
+  } 
+  
   return 0;
 }
 

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.h
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.h
@@ -48,7 +48,6 @@ class PHG4TruthSubsystem: public PHG4Subsystem
 
   //! only save the G4 truth information that is associated with the embedded particle
   bool saveOnlyEmbeded_;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -83,7 +83,7 @@ PHG4TruthTrackingAction::PostUserTrackingAction( const G4Track* track)
      {
        if ( p->GetKeep() )
  	{
-	  int trackid = p->GetTrackIdOffset() + track->GetTrackID();
+	  int trackid = p->GetUserTrackId();
  	  eventAction_->AddTrackidToWritelist( trackid );
  	}
      }

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -17,7 +17,8 @@ const int VERBOSE = 0;
 
 //________________________________________________________
 PHG4TruthTrackingAction::PHG4TruthTrackingAction( PHG4TruthEventAction* eventAction ) :
-  trackidoffset(0),
+  primarytrackidoffset(0),
+  secondarytrackidoffset(0),
   eventAction_( eventAction ), 
   truthInfoList_( NULL )
 {}
@@ -27,7 +28,7 @@ PHG4TruthTrackingAction::PreUserTrackingAction( const G4Track* track)
 {
   G4ThreeVector v = track->GetVertexPosition();
   G4ThreeVector pdir = track->GetVertexMomentumDirection();
-  int trackid = track->GetTrackID() + trackidoffset;
+  int trackid = track->GetTrackID() + primarytrackidoffset;
   PHG4TrackUserInfo::SetUserTrackId(const_cast<G4Track *> (track), trackid);
   //  PHG4TrackUserInfo::SetTrackIdOffset(const_cast<G4Track *> (track), trackidoffset); // adding info to G4Track -> non const
   G4ParticleDefinition* def = track->GetDefinition();
@@ -44,7 +45,7 @@ PHG4TruthTrackingAction::PreUserTrackingAction( const G4Track* track)
   ti->set_track_id( trackid );
   if (track->GetParentID()) // primary particle -> parent ID = 0
     {
-      ti->set_parent_id( track->GetParentID() + trackidoffset );
+      ti->set_parent_id( track->GetParentID() + primarytrackidoffset );
     }
   else
     {

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -39,12 +39,6 @@ void PHG4TruthTrackingAction::PreUserTrackingAction( const G4Track* track) {
 
   // add the user id to the geant4 user info
   PHG4TrackUserInfo::SetUserTrackId(const_cast<G4Track *> (track), trackid);
-
-  // tell the primary particle copy where this output will be stored
-  if (!track->GetParentID()) {
-    PHG4UserPrimaryParticleInformation* userdata = (PHG4UserPrimaryParticleInformation*)track->GetDynamicParticle()->GetPrimaryParticle()->GetUserInformation();
-    if (userdata) userdata->set_user_track_id(trackid);
-  }
   
   // determine the momentum vector
   G4ParticleDefinition* def = track->GetDefinition();
@@ -108,6 +102,15 @@ void PHG4TruthTrackingAction::PreUserTrackingAction( const G4Track* track) {
   // insert particle into the output
   truthInfoList_->AddParticle(trackid, ti);
 
+  // tell the primary particle copy in G4 where this output will be stored
+  if (!track->GetParentID()) {
+    PHG4UserPrimaryParticleInformation* userdata = (PHG4UserPrimaryParticleInformation*)track->GetDynamicParticle()->GetPrimaryParticle()->GetUserInformation();
+    if (userdata) {
+      userdata->set_user_track_id(trackid);
+      userdata->set_user_vtx_id(vtxindex);
+    }
+  }
+  
   return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -28,6 +28,7 @@ PHG4TruthTrackingAction::PreUserTrackingAction( const G4Track* track)
   G4ThreeVector v = track->GetVertexPosition();
   G4ThreeVector pdir = track->GetVertexMomentumDirection();
   int trackid = track->GetTrackID() + trackidoffset;
+  PHG4TrackUserInfo::SetUserTrackId(const_cast<G4Track *> (track), trackid);
   PHG4TrackUserInfo::SetTrackIdOffset(const_cast<G4Track *> (track), trackidoffset); // adding info to G4Track -> non const
   G4ParticleDefinition* def = track->GetDefinition();
   int pdgid = def->GetPDGEncoding();

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -71,7 +71,7 @@ PHG4TruthTrackingAction::PreUserTrackingAction( const G4Track* track)
   ti->set_vtx_id(vtxindex);
   //       cout << "Adding particle trkid: " << trackid << endl;
   //       ti->identify();
-  truthInfoList_->AddHit(trackid, ti);
+  truthInfoList_->AddParticle(trackid, ti);
   return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -29,7 +29,7 @@ PHG4TruthTrackingAction::PreUserTrackingAction( const G4Track* track)
   G4ThreeVector pdir = track->GetVertexMomentumDirection();
   int trackid = track->GetTrackID() + trackidoffset;
   PHG4TrackUserInfo::SetUserTrackId(const_cast<G4Track *> (track), trackid);
-  PHG4TrackUserInfo::SetTrackIdOffset(const_cast<G4Track *> (track), trackidoffset); // adding info to G4Track -> non const
+  //  PHG4TrackUserInfo::SetTrackIdOffset(const_cast<G4Track *> (track), trackidoffset); // adding info to G4Track -> non const
   G4ParticleDefinition* def = track->GetDefinition();
   int pdgid = def->GetPDGEncoding();
   //   double charge = def->GetPDGCharge();

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
@@ -28,7 +28,8 @@ public:
   //! Set pointers to the i/o nodes
   virtual void SetInterfacePointers( PHCompositeNode* );
 
-  void TrackIdOffset(const int i) {trackidoffset = i;}
+  void PrimaryTrackIdOffset(const int i) {primarytrackidoffset = i;}
+  void SecondaryTrackIdOffset(const int i) {secondarytrackidoffset = i;}
 
   int ResetEvent(PHCompositeNode *);
 
@@ -36,8 +37,9 @@ private:
 
   std::map<G4ThreeVector,int> VertexMap;
 
-  int trackidoffset;
-
+  int primarytrackidoffset;
+  int secondarytrackidoffset;
+  
   //! pointer to the "owning" event action
   PHG4TruthEventAction* eventAction_;
 

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
@@ -28,24 +28,17 @@ public:
   //! Set pointers to the i/o nodes
   virtual void SetInterfacePointers( PHCompositeNode* );
 
-  void PrimaryTrackIdOffset(const int i) {primarytrackidoffset = i;}
-  void SecondaryTrackIdOffset(const int i) {secondarytrackidoffset = i;}
-
   int ResetEvent(PHCompositeNode *);
 
 private:
 
   std::map<G4ThreeVector,int> VertexMap;
 
-  int primarytrackidoffset;
-  int secondarytrackidoffset;
-  
   //! pointer to the "owning" event action
   PHG4TruthEventAction* eventAction_;
 
   //! pointer to truth information container
   PHG4TruthInfoContainer* truthInfoList_;
-
 };
 
 

--- a/simulation/g4simulation/g4main/PHG4UserPrimaryParticleInformation.h
+++ b/simulation/g4simulation/g4main/PHG4UserPrimaryParticleInformation.h
@@ -13,15 +13,20 @@ public:
   {
     std::cout << "Embedding = " << embed << std::endl;
     std::cout << "User Track ID = " << usertrackid << std::endl;
+    std::cout << "User Vertex ID = " << uservtxid << std::endl;
   }
   int get_embed() const {return embed;}
 
   void set_user_track_id(int val) {usertrackid = val;}
   int get_user_track_id() const {return usertrackid;}
+
+  void set_user_vtx_id(int val) {uservtxid = val;}
+  int get_user_vtx_id() const {return uservtxid;}
   
 private:
   int embed;
   int usertrackid;
+  int uservtxid;
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4UserPrimaryParticleInformation.h
+++ b/simulation/g4simulation/g4main/PHG4UserPrimaryParticleInformation.h
@@ -7,15 +7,21 @@
 class PHG4UserPrimaryParticleInformation : public G4VUserPrimaryParticleInformation
 {
 public:
-  PHG4UserPrimaryParticleInformation(const int emb) : embed(emb) {}
+  PHG4UserPrimaryParticleInformation(const int emb) : embed(emb),
+						      usertrackid(0) {}
   void Print() const 
   {
     std::cout << "Embedding = " << embed << std::endl;
+    std::cout << "User Track ID = " << usertrackid << std::endl;
   }
   int get_embed() const {return embed;}
 
+  void set_user_track_id(int val) {usertrackid = val;}
+  int get_user_track_id() const {return usertrackid;}
+  
 private:
   int embed;
+  int usertrackid;
 };
 
 #endif

--- a/simulation/g4simulation/g4picoDst/mFillG4SnglHTCContainer.cc
+++ b/simulation/g4simulation/g4picoDst/mFillG4SnglHTCContainer.cc
@@ -92,15 +92,15 @@ mFillG4SnglHTCContainer::process_event( PHCompositeNode* top_node )
    PHG4TruthInfoContainer* truthInfoList 
 	=  findNode::getClass<PHG4TruthInfoContainer>(top_node , "G4TruthInfo" );
 
-   const PHG4TruthInfoContainer::Map primMap = truthInfoList->GetPrimaryMap();
+   const PHG4TruthInfoContainer::Range primRange = truthInfoList->GetPrimaryParticleRange();
 
-   snglhtcs->set_PID( primMap.begin()->second->get_pid() );
-   snglhtcs->set_Energy( primMap.begin()->second->get_e() );
-   snglhtcs->set_Theta( atan2(sqrt(pow(primMap.begin()->second->get_px(),2) + pow(primMap.begin()->second->get_py(),2)), primMap.begin()->second->get_pz()) );
-   snglhtcs->set_Phi( atan2(primMap.begin()->second->get_py(), primMap.begin()->second->get_px()) );
-   snglhtcs->set_Px( primMap.begin()->second->get_px() );
-   snglhtcs->set_Py( primMap.begin()->second->get_py() );
-   snglhtcs->set_Pz( primMap.begin()->second->get_pz() );
+   snglhtcs->set_PID( primRange.first->second->get_pid() );
+   snglhtcs->set_Energy( primRange.first->second->get_e() );
+   snglhtcs->set_Theta( atan2(sqrt(pow(primRange.first->second->get_px(),2) + pow(primRange.first->second->get_py(),2)), primRange.first->second->get_pz()) );
+   snglhtcs->set_Phi( atan2(primRange.first->second->get_py(), primRange.first->second->get_px()) );
+   snglhtcs->set_Px( primRange.first->second->get_px() );
+   snglhtcs->set_Py( primRange.first->second->get_py() );
+   snglhtcs->set_Pz( primRange.first->second->get_pz() );
 
    ostringstream hitnode, towernode, towergeomnode, clusternode;
    set<string>::const_iterator iter;


### PR DESCRIPTION
We should discuss this in a simulation meeting prior to merge, so I'm submitting this now for early review.

I've completed and tested the revision of the truth info container in this branch. The new code contains a single storage map for particles and a single storage map for vertexes (no more comparisons between primary copies needed---there can be only one). Primaries and secondaries are segregated to positive and negative key identifiers respectively. Thus the primary ids in the first round of G4 processing are not modified, preserving look up to the generator level. We can add a barcode based lookup in another round of revision to do that even better. There is a new set of range functions for iterating over the primaries and secondaries independently which have been used to replace parts of the core library where the deprecated primary map was returned. Additional runs of G4 append either to the top of the map for primaries or the bottom for secondaries. Primary vertexes can be identified by the sign of the id, something not possible previously without searching through the particle list. Information about primary ancestry is now passed down during processing instead of a tree-spanning trace at the end of the event, so the module should also consume less CPU now. Other revisions were made to pass the embed flag integer value all the way through the simulation and into the output. I envision this as a way to test the fidelity of multiple vertex algorithms (each pythia event gets a different embed flag), but there are lots of things that tool could be utilized to do. This merge as currently coded will break backwards DST compatibility---no versioning has been implemented on this object and the interface is still evolving anyway.

The evaluator chews happily on the new format as no assumptions on trackid values were made in the initial design. The new code doesn't interfere with the proper evaluation of the data as demonstrated here:

![crosscheck](https://cloud.githubusercontent.com/assets/12105552/11320323/91109a36-9052-11e5-88d1-0e78c83bce9c.png)

I haven't yet optimized the evaluation for the new format, but that will be a next step. That goal will alleviate some of the issue in the TPC evaluation where we were spending >50% of CPU trying to decide if two particle pointers were in fact the same particle under the different maps. Some of the speed issue might partially resolve already since this version of the truth info will send that code down the faster side of the evaluation, but the plan is to update the evaluator to strip those if-statements.

One big interface change is the removal of the GetPrimaryMap() function. Users should instead use the GetPrimaryParticleRange() which will result in the same basic functionality. I also rename the *Hit* methods to *Particle* methods to reflect the actual container contents as this was really very confusing when I first started using this object in the evaluation.

Jin, I've tried this code in an embedded event and I see it appending correctly, but if it is easy for you to try it out with a DST created with the branch in a real-world scenario, that would give me more confidence this revision is working as expected.