### PR TITLE
Support timing cut in Cell reco

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <limits>       // std::numeric_limits
 
 using namespace std;
 
@@ -33,7 +34,7 @@ static vector<PHG4CylinderCell*> cellptarray;
 PHG4BlockCellReco::PHG4BlockCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new("PHG4BlockCellReco")),
-  chkenergyconservation(0)
+  chkenergyconservation(0), timing_window_size(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));
 }
@@ -271,6 +272,10 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
     {
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
       {
+          // checking ADC timing integration window cut
+          if (hiter->second->get_t(0)>timing_window_size)
+            continue;
+
         pair<double, double> etax[2];
         double xbin[2];
         double etabin[2];

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
@@ -34,6 +34,11 @@ class PHG4BlockCellReco : public SubsysReco
   void etaxsize(const int i, const double deltaeta, const double deltax);
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
+  //! get timing window size in ns.
+  double get_timing_window_size() const {return timing_window_size;}
+  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  void set_timing_window_size(const double s) {timing_window_size = s;}
+
  protected:
   void set_size(const int i, const double sizeA, const double sizeB, const int what);
   int CheckEnergy(PHCompositeNode *topNode);
@@ -56,6 +61,9 @@ class PHG4BlockCellReco : public SubsysReco
   PHTimeServer::timer _timer;
   int nbins[2];
   int chkenergyconservation;
+
+  //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  double timing_window_size;
 
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -22,13 +22,15 @@
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <limits>       // std::numeric_limits
+
 
 using namespace std;
 
 PHG4CylinderCellReco::PHG4CylinderCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new("PHG4CylinderCellReco")),
-  chkenergyconservation(0)
+  chkenergyconservation(0), timing_window_size(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));
 }
@@ -321,6 +323,10 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
         {
           for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
             {
+              // checking ADC timing integration window cut
+              if (hiter->second->get_t(0)>timing_window_size)
+                continue;
+
               pair<double, double> etaphi[2];
               double phibin[2];
               double etabin[2];
@@ -516,6 +522,10 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 
           for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
             {
+              // checking ADC timing integration window cut
+              if (hiter->second->get_t(0)>timing_window_size)
+                continue;
+
               double xinout[2];
               double yinout[2];
               double px[2];

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
@@ -35,6 +35,11 @@ class PHG4CylinderCellReco : public SubsysReco
   void checkenergy(const int i=1) {chkenergyconservation = i;}
   void OutputDetector(const std::string &d) {outdetector = d;}
 
+  //! get timing window size in ns.
+  double get_timing_window_size() const {return timing_window_size;}
+  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  void set_timing_window_size(const double s) {timing_window_size = s;}
+
  protected:
   void set_size(const int i, const double sizeA, const double sizeB, const int what);
   int CheckEnergy(PHCompositeNode *topNode);
@@ -62,6 +67,8 @@ class PHG4CylinderCellReco : public SubsysReco
   int nbins[2];
   int chkenergyconservation;
 
+  //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  double timing_window_size;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -25,12 +25,13 @@
 #include <cassert>
 #include <boost/foreach.hpp>
 #include <exception>
+#include <limits>       // std::numeric_limits
 
 using namespace std;
 
 PHG4FullProjSpacalCellReco::PHG4FullProjSpacalCellReco(const string &name) :
     SubsysReco(name), _timer(PHTimeServer::get()->insert_new(name.c_str())), chkenergyconservation(
-        0)
+        0), timing_window_size(numeric_limits<double>::max())
 {
 }
 
@@ -321,6 +322,10 @@ PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
 
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
         {
+          // checking ADC timing integration window cut
+          if (hiter->second->get_t(0)>timing_window_size)
+            continue;
+
           // hit loop
           int scint_id = hiter->second->get_scint_id();
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
@@ -31,6 +31,11 @@ class PHG4FullProjSpacalCellReco : public SubsysReco
 
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
+  //! get timing window size in ns.
+  double get_timing_window_size() const {return timing_window_size;}
+  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  void set_timing_window_size(const double s) {timing_window_size = s;}
+
  protected:
 
   int CheckEnergy(PHCompositeNode *topNode);
@@ -45,6 +50,10 @@ class PHG4FullProjSpacalCellReco : public SubsysReco
   PHTimeServer::timer _timer;
   int chkenergyconservation;
   std::map<unsigned int, PHG4CylinderCell *> celllist;
+
+  //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  double timing_window_size;
+
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <limits>       // std::numeric_limits
 
 using namespace std;
 
@@ -29,7 +30,7 @@ PHG4HcalCellReco::PHG4HcalCellReco(const string &name) :
   _timer(PHTimeServer::get()->insert_new(name.c_str())),
   nslatscombined(1),
   netabins(24), // that is our default
-  chkenergyconservation(0)
+  chkenergyconservation(0), timing_window_size(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));  
 }
@@ -178,6 +179,10 @@ PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
       int nslatbins = geo->get_phibins();
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
 	{
+          // checking ADC timing integration window cut
+          if (hiter->second->get_t(0)>timing_window_size)
+            continue;
+
 	  int slatno = hiter->second->get_scint_id();
 	  int slatbin;
 	  slatbin = hiter->second->get_layer() / nslatscombined;

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
@@ -32,6 +32,11 @@ class PHG4HcalCellReco : public SubsysReco
   void checkenergy(const int i=1) {chkenergyconservation = i;}
   void set_etabins(const int nbins=24) {netabins = nbins;}
 
+  //! get timing window size in ns.
+  double get_timing_window_size() const {return timing_window_size;}
+  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  void set_timing_window_size(const double s) {timing_window_size = s;}
+
  protected:
   void set_size(const int i, const double sizeA, const int sizeB, const int what);
   int CheckEnergy(PHCompositeNode *topNode);
@@ -54,6 +59,10 @@ class PHG4HcalCellReco : public SubsysReco
   int netabins;
   int chkenergyconservation;
   std::map<unsigned int, PHG4CylinderCell *> celllist;
+
+  //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  double timing_window_size;
+
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <limits>       // std::numeric_limits
 
 using namespace std;
 
@@ -34,7 +35,7 @@ PHG4SlatCellReco::PHG4SlatCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new(name.c_str())),
   nslatscombined(1),
-  chkenergyconservation(0)
+  chkenergyconservation(0), timing_window_size(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));
   memset(cellptarray, 0, sizeof(cellptarray));
@@ -242,6 +243,10 @@ PHG4SlatCellReco::process_event(PHCompositeNode *topNode)
         {
           for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
             {
+              // checking ADC timing integration window cut
+              if (hiter->second->get_t(0)>timing_window_size)
+                continue;
+
               double etaphi[2];
               int slatbin;
               double etabin[2];

--- a/simulation/g4simulation/g4detectors/PHG4SlatCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SlatCellReco.h
@@ -33,6 +33,11 @@ class PHG4SlatCellReco : public SubsysReco
   void etasize_nslat(const int i, const double deltaeta, const int nslat);
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
+  //! get timing window size in ns.
+  double get_timing_window_size() const {return timing_window_size;}
+  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  void set_timing_window_size(const double s) {timing_window_size = s;}
+
  protected:
   void set_size(const int i, const double sizeA, const int sizeB, const int what);
   int CheckEnergy(PHCompositeNode *topNode);
@@ -54,6 +59,10 @@ class PHG4SlatCellReco : public SubsysReco
   int nbins[2];
   int nslatscombined;
   int chkenergyconservation;
+
+  //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  double timing_window_size;
+
 };
 
 #endif


### PR DESCRIPTION
As an action item from the last simulation meeting, this pull request introduces a timing cut in the cell reco to the mimic the effective ADC integration window for sPHENIX calorimeters.  

The idea is to apply this cut after PHG4Hit stage, since the timing span for each hit is small and it would allow us to tune the timing window post Geant production of hits. Also only a simple max-timing cut was applied, since at length scale of 100ns the start time variation is effectively negligible. The cut value can be changed via macro inputs. However, in near future, we plan to read it via the parameter node, after Chris finish building the parameter database infrastructure.

The default timing window is 0 to infinity, i.e. consistent with no timing cut as used in previous analysis. The timing cut can be activated for all calorimeters via macro such as this example: 
https://github.com/sPHENIX-Collaboration/macros/commit/1da9e30e9f21f63057b3ade72b401154645a3285 

Here is a comparison between three different timing window cut
1. No cut as default and consistent as previous analysis
2. 100ns timing cut to mimic 0-100ns ADC integration window we plan to use
3. 30ns timing cut to mimic fit for the amplitude the ADC-timing peak. 
For this fast test, 100 40 GeV pi- from the pre-CDR production was used. The change in the distribution for the total cluster energy is obvious between no-cut and timing cut applied:
![image](https://cloud.githubusercontent.com/assets/7947083/11320361/67dcfe90-9064-11e5-8f79-7947c76be0db.png)


