### PR TITLE
Additional Evaluator Optimization

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxClusterEval.C
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.C
@@ -263,6 +263,8 @@ std::set<SvtxCluster*> SvtxClusterEval::all_clusters_from(PHG4Hit* truthhit) {
   }
   
   std::set<SvtxCluster*> clusters;
+
+  unsigned int hit_layer = truthhit->get_layer();
   
   // loop over all the clusters
   for (SvtxClusterMap::Iter iter = _clustermap->begin();
@@ -271,7 +273,7 @@ std::set<SvtxCluster*> SvtxClusterEval::all_clusters_from(PHG4Hit* truthhit) {
 
     SvtxCluster* cluster = iter->second;
 
-    if (cluster->get_layer() != truthhit->get_layer()) continue;
+    if (cluster->get_layer() != hit_layer) continue;
 
     // loop over all truth hits connected to this cluster
     std::set<PHG4Hit*> hits = all_truth_hits(cluster);

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.C
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.C
@@ -271,6 +271,8 @@ std::set<SvtxCluster*> SvtxClusterEval::all_clusters_from(PHG4Hit* truthhit) {
 
     SvtxCluster* cluster = iter->second;
 
+    if (cluster->get_layer() != truthhit->get_layer()) continue;
+
     // loop over all truth hits connected to this cluster
     std::set<PHG4Hit*> hits = all_truth_hits(cluster);
     for (std::set<PHG4Hit*>::iterator jter = hits.begin();

--- a/simulation/g4simulation/g4eval/SvtxHitEval.C
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.C
@@ -292,6 +292,8 @@ std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Hit* g4hit) {
 
     SvtxHit* hit = iter->second;
 
+    if (hit->get_layer() != g4hit->get_layer()) continue;
+    
     // loop over all truth hits connected to this hit
     std::set<PHG4Hit*> g4hits = all_truth_hits(hit);
     for (std::set<PHG4Hit*>::iterator jter = g4hits.begin();

--- a/simulation/g4simulation/g4eval/SvtxHitEval.C
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.C
@@ -284,6 +284,8 @@ std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Hit* g4hit) {
   }
   
   std::set<SvtxHit*> hits;
+
+  unsigned int hit_layer = g4hit->get_layer();
   
   // loop over all the hits
   for (SvtxHitMap::Iter iter = _hitmap->begin();
@@ -292,7 +294,7 @@ std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Hit* g4hit) {
 
     SvtxHit* hit = iter->second;
 
-    if (hit->get_layer() != g4hit->get_layer()) continue;
+    if (hit->get_layer() != hit_layer) continue;
     
     // loop over all truth hits connected to this hit
     std::set<PHG4Hit*> g4hits = all_truth_hits(hit);


### PR DESCRIPTION
Before the track evaluator was looping over all clusters and checking the g4hits for a match based on input id, now it bails immediately if the cluster is from the wrong layer which greatly limits the downward search. Look for the change to SvtxClusterEval::all_clusters_from(g4hit) function in the before/after for 4-7 fm impact parameter (for finite callgrind testing) below. The eval is below G4 in these events and comparable to the track finding CPU.

Before:
![before](https://cloud.githubusercontent.com/assets/12105552/11540677/711eaadc-98eb-11e5-9691-cc212945665c.png)

After:
![screen shot 2015-12-02 at 11 51 30 am](https://cloud.githubusercontent.com/assets/12105552/11540679/748a5b9e-98eb-11e5-9640-f3b9902c70a8.png)
