### PR TITLE
New SVTX tracking layer energy threshold defaults

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
@@ -21,7 +21,9 @@ using namespace std;
 
 PHG4SvtxThresholds::PHG4SvtxThresholds(const string &name) :
   SubsysReco(name),
-  _fraction_of_mip(0.5),
+  _fraction_of_mip(),
+  _thresholds_by_layer(),
+  _use_thickness_mip(),
   _hits(NULL),
   _timer(PHTimeServer::get()->insert_new(name)) {
 }
@@ -40,7 +42,13 @@ int PHG4SvtxThresholds::InitRun(PHCompositeNode* topNode) {
   
   if (verbosity > 0) {
     cout << "====================== PHG4SvtxThresholds::InitRun() ======================" << endl;
-    cout << " Fraction of expected MIP energy = " << _fraction_of_mip << endl;
+    for (std::map<int,float>::iterator iter = _fraction_of_mip.begin();
+	 iter != _fraction_of_mip.end();
+	 ++iter) {
+      cout << " Fraction of expected MIP energy for Layer #" << iter->first << ": ";
+      cout << iter->second << endl;
+      cout << endl;
+    }
     for (std::map<int,float>::iterator iter = _thresholds_by_layer.begin();
 	 iter != _thresholds_by_layer.end();
 	 ++iter) {
@@ -70,7 +78,7 @@ int PHG4SvtxThresholds::process_event(PHCompositeNode *topNode)
        iter != _hits->end();
        ++iter) {
     SvtxHit* hit = iter->second;
-
+   
     if (hit->get_e() < get_threshold_by_layer(hit->get_layer())) {
       remove_hits.push_back(hit->get_id());
     }
@@ -108,7 +116,10 @@ void PHG4SvtxThresholds::CalculateCylinderThresholds(PHCompositeNode* topNode) {
 
     if (get_use_thickness_mip(layer)) {
       // Si MIP energy = 3.876 MeV / cm
-      float threshold = _fraction_of_mip*0.003876*thickness;
+      float threshold = 0.0;      
+      if (_fraction_of_mip.find(layer) != _fraction_of_mip.end()) {	
+	threshold = _fraction_of_mip[layer]*0.003876*thickness;
+      }	  
       _thresholds_by_layer.insert(std::make_pair(layer,threshold));
     } else {
       float minpath = pitch;
@@ -116,7 +127,10 @@ void PHG4SvtxThresholds::CalculateCylinderThresholds(PHCompositeNode* topNode) {
       if (thickness < minpath) minpath = thickness;
 	
       // Si MIP energy = 3.876 MeV / cm
-      float threshold = _fraction_of_mip*0.003876*minpath;  
+      float threshold = 0.0;      
+      if (_fraction_of_mip.find(layer) != _fraction_of_mip.end()) {	
+	threshold = _fraction_of_mip[layer]*0.003876*minpath;  
+      }	      
       _thresholds_by_layer.insert(std::make_pair(layer,threshold));
     }
   }
@@ -143,7 +157,10 @@ void PHG4SvtxThresholds::CalculateLadderThresholds(PHCompositeNode* topNode) {
 
     if (get_use_thickness_mip(layer)) {
       // Si MIP energy = 3.876 MeV / cm
-      float threshold = _fraction_of_mip*0.003876*thickness;
+      float threshold = 0.0;
+      if (_fraction_of_mip.find(layer) != _fraction_of_mip.end()) {
+	threshold = _fraction_of_mip[layer]*0.003876*thickness;
+      }
       _thresholds_by_layer.insert(std::make_pair(layer,threshold));
     } else {
       float minpath = pitch;
@@ -151,7 +168,10 @@ void PHG4SvtxThresholds::CalculateLadderThresholds(PHCompositeNode* topNode) {
       if (thickness < minpath) minpath = thickness;
       
       // Si MIP energy = 3.876 MeV / cm
-      float threshold = _fraction_of_mip*0.003876*minpath;  
+      float threshold = 0.0;
+      if (_fraction_of_mip.find(layer) != _fraction_of_mip.end()) {
+	threshold = _fraction_of_mip[layer]*0.003876*minpath;
+      }
       _thresholds_by_layer.insert(std::make_pair(layer,threshold));
     }
   }

--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
@@ -39,14 +39,14 @@ int PHG4SvtxThresholds::InitRun(PHCompositeNode* topNode) {
   
   CalculateCylinderThresholds(topNode);
   CalculateLadderThresholds(topNode);
-  
+
   if (verbosity > 0) {
     cout << "====================== PHG4SvtxThresholds::InitRun() ======================" << endl;
     for (std::map<int,float>::iterator iter = _fraction_of_mip.begin();
 	 iter != _fraction_of_mip.end();
 	 ++iter) {
       cout << " Fraction of expected MIP energy for Layer #" << iter->first << ": ";
-      cout << iter->second << endl;
+      cout << iter->second;
       cout << endl;
     }
     for (std::map<int,float>::iterator iter = _thresholds_by_layer.begin();

--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
@@ -29,8 +29,8 @@ class PHG4SvtxThresholds : public SubsysReco
   int End(PHCompositeNode *topNode);
   
   //! set an energy requirement relative to the short-axis MIP expectation
-  void set_threshold(const float fraction_of_mip) {
-    _fraction_of_mip = fraction_of_mip;
+  void set_threshold(const int layer, const float fraction_of_mip) {
+    _fraction_of_mip.insert(std::make_pair(layer,fraction_of_mip));
   }
   float get_threshold_by_layer(const int layer) const {
     if (_thresholds_by_layer.find(layer) == _thresholds_by_layer.end()) return 0.0;
@@ -53,9 +53,9 @@ class PHG4SvtxThresholds : public SubsysReco
   void CalculateLadderThresholds(PHCompositeNode *topNode);
 
   // settings
-  float _fraction_of_mip;
+  std::map<int,float> _fraction_of_mip;
   std::map<int,float> _thresholds_by_layer;
-  std::map<int,bool> _use_thickness_mip;
+  std::map<int,bool>  _use_thickness_mip;
 
   SvtxHitMap* _hits;
   

--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
@@ -33,6 +33,7 @@ class PHG4SvtxThresholds : public SubsysReco
     std::cout << "PHG4SvtxThresholds use is out of date. "
 	      << "Continuing with assumption of tracker with <9 layers. "
 	      << "Please update your macros with the latest from GitHub" << std::endl;
+    // remove this function eventually
     _fraction_of_mip[0] = fraction_of_mip;
     _fraction_of_mip[1] = fraction_of_mip;
     _fraction_of_mip[2] = fraction_of_mip;

--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
@@ -1,7 +1,8 @@
 #ifndef __PHG4SVTXTHRESHOLDS__
 #define __PHG4SVTXTHRESHOLDS__
 
-#include <vector>
+#include <map>
+#include <iostream>
 
 #include <fun4all/SubsysReco.h>
 #include <phool/PHTimeServer.h>
@@ -27,6 +28,20 @@ class PHG4SvtxThresholds : public SubsysReco
   
   //! end of process
   int End(PHCompositeNode *topNode);
+
+  void set_threshold(const float fraction_of_mip) {
+    std::cout << "PHG4SvtxThresholds use is out of date. "
+	      << "Continuing with assumption of tracker with <9 layers. "
+	      << "Please update your macros with the latest from GitHub" << std::endl;
+    _fraction_of_mip[0] = fraction_of_mip;
+    _fraction_of_mip[1] = fraction_of_mip;
+    _fraction_of_mip[2] = fraction_of_mip;
+    _fraction_of_mip[3] = fraction_of_mip;
+    _fraction_of_mip[4] = fraction_of_mip;
+    _fraction_of_mip[5] = fraction_of_mip;
+    _fraction_of_mip[6] = fraction_of_mip;
+    _fraction_of_mip[7] = fraction_of_mip;
+  }
   
   //! set an energy requirement relative to the short-axis MIP expectation
   void set_threshold(const int layer, const float fraction_of_mip) {


### PR DESCRIPTION
The old threshold module used a single value for all layers which will clobber the TPC since it is inside the same cylinder cell container. So I changed the default to 0.0 and require individual setting of each layer threshold. I've updated the SVTX macros and will generate a separate pull request on that side. The old interface will work with a warning message to update the macros from GitHub.

I'm pretty sure this is the last change needed to make the behavior of the silicon the same in the silicon+tpc and silicon-only macros.