### PR TITLE
Modify Evaluator Error Handling for Missing Nodes

### DIFF
--- a/simulation/g4simulation/g4eval/BaseTruthEval.C
+++ b/simulation/g4simulation/g4eval/BaseTruthEval.C
@@ -36,6 +36,8 @@ void BaseTruthEval::next_event(PHCompositeNode* topNode) {
       
 PHG4Particle* BaseTruthEval::get_particle(PHG4Hit* g4hit) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(g4hit);}
   else if (!g4hit) {++_errors; return NULL;}
   
@@ -48,6 +50,8 @@ PHG4Particle* BaseTruthEval::get_particle(PHG4Hit* g4hit) {
 
 int BaseTruthEval::get_embed(PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return 0;}
+  
   if (_strict) {assert(particle);}
   else if (!particle) {++_errors; return 0;}
 
@@ -62,6 +66,8 @@ int BaseTruthEval::get_embed(PHG4Particle* particle) {
 
 PHG4VtxPoint* BaseTruthEval::get_vertex(PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;} 
+  
   if (_strict) {assert(particle);}
   else if (!particle) {++_errors; return NULL;}
 
@@ -74,8 +80,10 @@ PHG4VtxPoint* BaseTruthEval::get_vertex(PHG4Particle* particle) {
 
 bool BaseTruthEval::is_primary(PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return false;}
+  
   if (_strict) {assert(particle);}
-  else if (!particle) {return false;}
+  else if (!particle) {++_errors; return false;}
   
   bool is_primary = false;
   if (particle->get_parent_id() == 0) {
@@ -87,6 +95,8 @@ bool BaseTruthEval::is_primary(PHG4Particle* particle) {
 
 PHG4Particle* BaseTruthEval::get_primary(PHG4Hit* g4hit) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(g4hit);}
   else if (!g4hit) {++_errors; return NULL;}
 
@@ -101,6 +111,8 @@ PHG4Particle* BaseTruthEval::get_primary(PHG4Hit* g4hit) {
 
 PHG4Particle* BaseTruthEval::get_primary(PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(particle);}
   else if (!particle) {++_errors; return NULL;}
 
@@ -114,8 +126,10 @@ PHG4Particle* BaseTruthEval::get_primary(PHG4Particle* particle) {
   return returnval;
 }
 
- bool BaseTruthEval::is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle) {
+bool BaseTruthEval::is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return false;}
+   
   if (_strict) {
     assert(g4hit);
     assert(particle);
@@ -133,6 +147,8 @@ PHG4Particle* BaseTruthEval::get_primary(PHG4Particle* particle) {
 
 bool BaseTruthEval::are_same_particle(PHG4Particle* p1, PHG4Particle* p2) {
 
+  if (!has_node_pointers()) {++_errors; return false;}
+  
   if (_strict) {
     assert(p1);
     assert(p2);
@@ -147,6 +163,8 @@ bool BaseTruthEval::are_same_particle(PHG4Particle* p1, PHG4Particle* p2) {
 
 bool BaseTruthEval::are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2) {
 
+  if (!has_node_pointers()) {++_errors; return false;}
+  
   if (_strict) {
     assert(vtx1);
     assert(vtx2);
@@ -168,4 +186,12 @@ void BaseTruthEval::get_node_pointers(PHCompositeNode* topNode) {
   }
   
   return;
+}
+
+bool BaseTruthEval::has_node_pointers() {
+
+  if (_strict) assert(_truthinfo);
+  else if (!_truthinfo) return false;
+  
+  return true;
 }

--- a/simulation/g4simulation/g4eval/BaseTruthEval.h
+++ b/simulation/g4simulation/g4eval/BaseTruthEval.h
@@ -36,6 +36,7 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode* topNode);
+  bool has_node_pointers();
   
   PHG4TruthInfoContainer* _truthinfo;
 

--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.C
@@ -67,6 +67,8 @@ void CaloRawClusterEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Hit*> CaloRawClusterEval::all_truth_hits(RawCluster* cluster) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Hit*>();}
+  
   if (_strict) {assert(cluster);}
   else if (!cluster) {++_errors; return std::set<PHG4Hit*>();}
   
@@ -113,6 +115,8 @@ std::set<PHG4Hit*> CaloRawClusterEval::all_truth_hits(RawCluster* cluster) {
   
 std::set<PHG4Particle*> CaloRawClusterEval::all_truth_primaries(RawCluster* cluster) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Particle*>();}
+  
   if (_strict) {assert(cluster);}
   else if (!cluster) {++_errors; return std::set<PHG4Particle*>();}
   
@@ -158,6 +162,8 @@ std::set<PHG4Particle*> CaloRawClusterEval::all_truth_primaries(RawCluster* clus
 
 PHG4Particle* CaloRawClusterEval::max_truth_primary_by_energy(RawCluster* cluster) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(cluster);}
   else if (!cluster) {++_errors; return NULL;}
   
@@ -198,6 +204,8 @@ PHG4Particle* CaloRawClusterEval::max_truth_primary_by_energy(RawCluster* cluste
 
 std::set<RawCluster*> CaloRawClusterEval::all_clusters_from(PHG4Particle* primary) { 
 
+  if (!has_node_pointers()) {++_errors; return std::set<RawCluster*>();}
+  
   if (_strict) {assert(primary);}
   else if (!primary) {++_errors; return std::set<RawCluster*>();}
   
@@ -248,6 +256,8 @@ std::set<RawCluster*> CaloRawClusterEval::all_clusters_from(PHG4Particle* primar
 
 RawCluster* CaloRawClusterEval::best_cluster_from(PHG4Particle* primary) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(primary);}
   else if (!primary) {++_errors; return NULL;}
   
@@ -293,6 +303,8 @@ RawCluster* CaloRawClusterEval::best_cluster_from(PHG4Particle* primary) {
 // overlap calculations
 float CaloRawClusterEval::get_energy_contribution(RawCluster* cluster, PHG4Particle* primary) {
 
+  if (!has_node_pointers()) {++_errors; return NAN;}
+  
   if (_strict) {
     assert(cluster);
     assert(primary);
@@ -348,17 +360,20 @@ void CaloRawClusterEval::get_node_pointers(PHCompositeNode* topNode) {
   // need things off of the DST...
   std::string nodename = "CLUSTER_" + _caloname;
   _clusters = findNode::getClass<RawClusterContainer>(topNode,nodename.c_str());
-  if (!_clusters) {
-    cerr << PHWHERE << " ERROR: Can't find " << nodename << endl;
-    exit(-1);
-  }
 
   std::string towername = "TOWER_CALIB_" + _caloname;
   _towers = findNode::getClass<RawTowerContainer>(topNode,towername.c_str());
-  if (!_towers) {
-    cerr << PHWHERE << " ERROR: Can't find " << towername << endl;
-    exit(-1);
-  }
   
   return;
+}
+
+bool CaloRawClusterEval::has_node_pointers() {
+
+  if (_strict) assert(_clusters);
+  else if (!_clusters) return false;
+
+  if (_strict) assert(_towers);
+  else if (!_towers) return false;
+  
+  return true;
 }

--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.h
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.h
@@ -60,6 +60,7 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode *topNode);
+  bool has_node_pointers();
   
   std::string _caloname;  
   CaloRawTowerEval _towereval;

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.C
@@ -66,6 +66,8 @@ void CaloRawTowerEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Hit*> CaloRawTowerEval::all_truth_hits(RawTower* tower) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Hit*>();}
+  
   if (_strict) {assert(tower);}
   else if (!tower) {++_errors; return std::set<PHG4Hit*>();}
   
@@ -111,6 +113,8 @@ std::set<PHG4Hit*> CaloRawTowerEval::all_truth_hits(RawTower* tower) {
   
 std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Particle*>();}
+  
   if (_strict) {assert(tower);}
   else if (!tower) {++_errors; return std::set<PHG4Particle*>();}
   
@@ -145,6 +149,8 @@ std::set<PHG4Particle*> CaloRawTowerEval::all_truth_primaries(RawTower* tower) {
 
 PHG4Particle* CaloRawTowerEval::max_truth_primary_by_energy(RawTower* tower) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(tower);}
   else if (!tower) {++_errors; return NULL;}
   
@@ -186,6 +192,8 @@ PHG4Particle* CaloRawTowerEval::max_truth_primary_by_energy(RawTower* tower) {
 
 std::set<RawTower*> CaloRawTowerEval::all_towers_from(PHG4Particle* primary) { 
 
+  if (!has_node_pointers()) {++_errors; return std::set<RawTower*>();}
+  
   if (_strict) {assert(primary);}
   else if (!primary) {++_errors; return std::set<RawTower*>();}
   
@@ -237,6 +245,8 @@ std::set<RawTower*> CaloRawTowerEval::all_towers_from(PHG4Particle* primary) {
 
 RawTower* CaloRawTowerEval::best_tower_from(PHG4Particle* primary) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(primary);}
   else if (!primary) {++_errors; return NULL;}
   
@@ -282,6 +292,8 @@ RawTower* CaloRawTowerEval::best_tower_from(PHG4Particle* primary) {
 // overlap calculations
 float CaloRawTowerEval::get_energy_contribution(RawTower* tower, PHG4Particle* primary) {
 
+  if (!has_node_pointers()) {++_errors; return NAN;}
+  
   if (_strict) {
     assert(tower);
     assert(primary);
@@ -337,30 +349,31 @@ void CaloRawTowerEval::get_node_pointers(PHCompositeNode *topNode) {
   // need things off of the DST...
   std::string towername = "TOWER_CALIB_" + _caloname;
   _towers = findNode::getClass<RawTowerContainer>(topNode,towername.c_str());
-  if (!_towers) {
-    cerr << PHWHERE << " ERROR: Can't find " << towername << endl;
-    exit(-1);
-  }
   
   std::string cellname = "G4CELL_" + _caloname;
   _g4cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,cellname.c_str());
-  if (!_g4cells) {
-    cerr << PHWHERE << " ERROR: Can't find " << cellname << endl;
-    exit(-1);
-  }
 
   std::string hitname = "G4HIT_" + _caloname;  
   _g4hits = findNode::getClass<PHG4HitContainer>(topNode,hitname.c_str());
-  if (!_g4hits){ 
-    cerr << PHWHERE << " ERROR: Can't find " << hitname << endl;
-    exit(-1);
-  }
 
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
-  if (!_truthinfo) {
-    cerr << PHWHERE << " ERROR: Can't find G4TruthInfo" << endl;
-    exit(-1);
-  }
 
   return;
+}
+
+bool CaloRawTowerEval::has_node_pointers() {
+
+  if (_strict) assert(_towers);
+  else if (!_towers) return false;
+
+  if (_strict) assert(_g4cells);
+  else if (!_g4cells) return false; 
+
+  if (_strict) assert(_g4hits);
+  else if (!_g4hits) return false; 
+
+  if (_strict) assert(_truthinfo);
+  else if (!_truthinfo) return false;
+
+  return true;
 }

--- a/simulation/g4simulation/g4eval/CaloRawTowerEval.h
+++ b/simulation/g4simulation/g4eval/CaloRawTowerEval.h
@@ -60,6 +60,7 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode *topNode);
+  bool has_node_pointers();
 
   std::string _caloname;
   CaloTruthEval _trutheval;  

--- a/simulation/g4simulation/g4eval/CaloTruthEval.C
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.C
@@ -59,6 +59,8 @@ void CaloTruthEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Hit*> CaloTruthEval::all_truth_hits(PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Hit*>();}
+  
   if (_strict) {assert(particle);}
   else if (!particle) {++_errors; return std::set<PHG4Hit*>();}
   
@@ -97,6 +99,8 @@ PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Particle* particle) {
 
 PHG4Particle* CaloTruthEval::get_primary_particle(PHG4Hit* g4hit) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(g4hit);}
   else if (!g4hit) {++_errors; return NULL;}
   
@@ -132,6 +136,8 @@ bool CaloTruthEval::is_primary(PHG4Particle* particle) {
 
 std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Hit*>();}
+  
   if (_strict) {assert(primary);}
   else if (!primary) {++_errors; return std::set<PHG4Hit*>();}
   
@@ -175,6 +181,8 @@ std::set<PHG4Hit*> CaloTruthEval::get_shower_from_primary(PHG4Particle* primary)
 // moliere (90% containment) radius of scintilator hits
 float CaloTruthEval::get_shower_moliere_radius(PHG4Particle* primary) {
 
+  if (!has_node_pointers()) {++_errors; return NAN;}
+  
   if (_strict) {assert(primary);}
   else if (!primary) {++_errors; return NAN;}
   
@@ -256,6 +264,8 @@ float CaloTruthEval::get_shower_moliere_radius(PHG4Particle* primary) {
 
 float CaloTruthEval::get_shower_energy_deposit(PHG4Particle* primary) {
 
+  if (!has_node_pointers()) {++_errors; return NAN;}
+  
   if (_strict) {assert(primary);}
   else if (!primary) {++_errors; return NAN;}
   
@@ -305,17 +315,20 @@ void CaloTruthEval::get_node_pointers(PHCompositeNode *topNode) {
 
   // need things off of the DST...
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
-  if (!_truthinfo) {
-    cerr << PHWHERE << " ERROR: Can't find G4TruthInfo" << endl;
-    exit(-1);
-  }
-  
+ 
   std::string name = "G4HIT_" + _caloname;
   _g4hits = findNode::getClass<PHG4HitContainer>(topNode,name.c_str());
-  if (!_g4hits) {
-    cerr << PHWHERE << " ERROR: Can't find " << name << endl;
-    exit(-1);
-  }
   
   return;
+}
+
+bool CaloTruthEval::has_node_pointers() {
+
+  if (_strict) assert(_truthinfo);
+  else if (!_truthinfo) return false;
+
+  if (_strict) assert(_g4hits);
+  if (!_g4hits) return false;
+
+  return true;
 }

--- a/simulation/g4simulation/g4eval/CaloTruthEval.h
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.h
@@ -55,6 +55,7 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode *topNode);
+  bool has_node_pointers();
 
   BaseTruthEval _basetrutheval;
   

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.C
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.C
@@ -73,6 +73,8 @@ void SvtxClusterEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(SvtxCluster* cluster) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Hit*>();}
+  
   if (_strict) {assert(cluster);}
   else if (!cluster) {++_errors; return std::set<PHG4Hit*>();}
   
@@ -112,6 +114,8 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(SvtxCluster* cluster) {
 
 PHG4Hit* SvtxClusterEval::max_truth_hit_by_energy(SvtxCluster* cluster) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(cluster);}
   else if (!cluster) {++_errors; return NULL;}
   
@@ -143,6 +147,8 @@ PHG4Hit* SvtxClusterEval::max_truth_hit_by_energy(SvtxCluster* cluster) {
   
 std::set<PHG4Particle*> SvtxClusterEval::all_truth_particles(SvtxCluster* cluster) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Particle*>();}
+  
   if (_strict) {assert(cluster);}
   else if (!cluster) {++_errors; return std::set<PHG4Particle*>();}
   
@@ -177,6 +183,8 @@ std::set<PHG4Particle*> SvtxClusterEval::all_truth_particles(SvtxCluster* cluste
 
 PHG4Particle* SvtxClusterEval::max_truth_particle_by_energy(SvtxCluster* cluster) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(cluster);}
   else if (!cluster) {++_errors; return NULL;}
   
@@ -212,6 +220,8 @@ PHG4Particle* SvtxClusterEval::max_truth_particle_by_energy(SvtxCluster* cluster
 
 std::set<SvtxCluster*> SvtxClusterEval::all_clusters_from(PHG4Particle* truthparticle) { 
 
+  if (!has_node_pointers()) {++_errors; return std::set<SvtxCluster*>();}
+  
   if (_strict) {assert(truthparticle);}
   else if (!truthparticle) {++_errors; return std::set<SvtxCluster*>();}
   
@@ -251,6 +261,8 @@ std::set<SvtxCluster*> SvtxClusterEval::all_clusters_from(PHG4Particle* truthpar
 
 std::set<SvtxCluster*> SvtxClusterEval::all_clusters_from(PHG4Hit* truthhit) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<SvtxCluster*>();}
+  
   if (_strict) {assert(truthhit);}
   else if (!truthhit) {++_errors; return std::set<SvtxCluster*>();}
   
@@ -294,6 +306,8 @@ std::set<SvtxCluster*> SvtxClusterEval::all_clusters_from(PHG4Hit* truthhit) {
 
 SvtxCluster* SvtxClusterEval::best_cluster_from(PHG4Hit* truthhit) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(truthhit);}
   else if (!truthhit) {++_errors; return NULL;}
   
@@ -327,6 +341,8 @@ SvtxCluster* SvtxClusterEval::best_cluster_from(PHG4Hit* truthhit) {
 // overlap calculations
 float SvtxClusterEval::get_energy_contribution(SvtxCluster* cluster, PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return NAN;}
+  
   if (_strict) {
     assert(cluster);
     assert(particle);
@@ -361,6 +377,8 @@ float SvtxClusterEval::get_energy_contribution(SvtxCluster* cluster, PHG4Particl
 
 float SvtxClusterEval::get_energy_contribution(SvtxCluster* cluster, PHG4Hit* g4hit) {
 
+  if (!has_node_pointers()) {++_errors; return NAN;}
+  
   if (_strict) {
     assert(cluster);
     assert(g4hit);
@@ -397,22 +415,24 @@ void SvtxClusterEval::get_node_pointers(PHCompositeNode *topNode) {
 
   // need things off of the DST...
   _clustermap = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
-  if (!_clustermap) {
-    cerr << PHWHERE << " ERROR: Can't find SvtxClusterMap" << endl;
-    exit(-1);
-  }
 
   _hitmap = findNode::getClass<SvtxHitMap>(topNode,"SvtxHitMap");
-  if (!_hitmap) {
-    cerr << PHWHERE << " ERROR: Can't find SvtxHitMap" << endl;
-    exit(-1);
-  }
 
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
-  if (!_truthinfo) {
-    cerr << PHWHERE << " ERROR: Can't find G4TruthInfo" << endl;
-    exit(-1);
-  }
   
   return;
+}
+
+bool SvtxClusterEval::has_node_pointers() {
+
+  if (_strict) assert(_clustermap);
+  else if (!_clustermap) return false;
+
+  if (_strict) assert(_hitmap);
+  else if (!_hitmap) return false;
+
+  if (_strict) assert(_truthinfo);
+  else if (!_truthinfo) return false;
+  
+  return true;
 }

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -63,6 +63,7 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode* topNode);
+  bool has_node_pointers();
   
   SvtxHitEval _hiteval;
   SvtxClusterMap* _clustermap;

--- a/simulation/g4simulation/g4eval/SvtxHitEval.C
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.C
@@ -71,6 +71,8 @@ void SvtxHitEval::next_event(PHCompositeNode* topNode) {
 
 PHG4CylinderCell* SvtxHitEval::get_cell(SvtxHit* hit) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(hit);}
   else if (!hit) {++_errors; return NULL;}
   
@@ -88,6 +90,8 @@ PHG4CylinderCell* SvtxHitEval::get_cell(SvtxHit* hit) {
 
 std::set<PHG4Hit*> SvtxHitEval::all_truth_hits(SvtxHit* hit) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Hit*>();}
+  
   if (_strict) {assert(hit);}
   else if (!hit) {++_errors; return std::set<PHG4Hit*>();}
   
@@ -133,6 +137,8 @@ std::set<PHG4Hit*> SvtxHitEval::all_truth_hits(SvtxHit* hit) {
 
 PHG4Hit* SvtxHitEval::max_truth_hit_by_energy(SvtxHit* hit) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(hit);}
   else if (!hit) {++_errors; return NULL;}
   
@@ -164,6 +170,8 @@ PHG4Hit* SvtxHitEval::max_truth_hit_by_energy(SvtxHit* hit) {
   
 std::set<PHG4Particle*> SvtxHitEval::all_truth_particles(SvtxHit* hit) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Particle*>();}
+  
   if (_strict) {assert(hit);}
   else if (!hit) {++_errors; return std::set<PHG4Particle*>();}
   
@@ -198,6 +206,8 @@ std::set<PHG4Particle*> SvtxHitEval::all_truth_particles(SvtxHit* hit) {
 
 PHG4Particle* SvtxHitEval::max_truth_particle_by_energy(SvtxHit* hit) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(hit);}
   else if (!hit) {++_errors; return NULL;}
   
@@ -233,6 +243,8 @@ PHG4Particle* SvtxHitEval::max_truth_particle_by_energy(SvtxHit* hit) {
 
 std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Particle* g4particle) { 
 
+  if (!has_node_pointers()) {++_errors; return std::set<SvtxHit*>();}
+  
   if (_strict) {assert(g4particle);}
   else if (!g4particle) {++_errors; return std::set<SvtxHit*>();}
   
@@ -272,6 +284,8 @@ std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Particle* g4particle) {
 
 std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Hit* g4hit) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<SvtxHit*>();}
+  
   if (_strict) {assert(g4hit);}
   else if (!g4hit) {++_errors; return std::set<SvtxHit*>();}
   
@@ -315,6 +329,8 @@ std::set<SvtxHit*> SvtxHitEval::all_hits_from(PHG4Hit* g4hit) {
 
 SvtxHit* SvtxHitEval::best_hit_from(PHG4Hit* g4hit) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(g4hit);}
   else if (!g4hit) {++_errors; return NULL;}
   
@@ -348,6 +364,8 @@ SvtxHit* SvtxHitEval::best_hit_from(PHG4Hit* g4hit) {
 // overlap calculations
 float SvtxHitEval::get_energy_contribution(SvtxHit* hit, PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return NAN;}
+  
   if (_strict) {
     assert(hit);
     assert(particle);
@@ -382,6 +400,8 @@ float SvtxHitEval::get_energy_contribution(SvtxHit* hit, PHG4Particle* particle)
 
 float SvtxHitEval::get_energy_contribution(SvtxHit* hit, PHG4Hit* g4hit) {
 
+  if (!has_node_pointers()) {++_errors; return NAN;}
+  
   if (_strict) {
     assert(hit);
     assert(g4hit);
@@ -420,31 +440,32 @@ void SvtxHitEval::get_node_pointers(PHCompositeNode* topNode) {
 
   // need things off of the DST...
   _hitmap = findNode::getClass<SvtxHitMap>(topNode,"SvtxHitMap");
-  if (!_hitmap) {
-    cerr << PHWHERE << " ERROR: Can't find SvtxHitMap" << endl;
-    exit(-1);
-  }
 
   // need things off of the DST...
   _g4cells_svtx    = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SVTX");
   _g4cells_tracker = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SILICON_TRACKER");
-  if (!_g4cells_svtx && !_g4cells_tracker) {
-    cerr << PHWHERE << " ERROR: Can't find G4CELL_SVTX or G4CELL_SILICON_TRACKER" << endl;
-    exit(-1);
-  }
     
   _g4hits_svtx    = findNode::getClass<PHG4HitContainer>(topNode,"G4HIT_SVTX");
   _g4hits_tracker = findNode::getClass<PHG4HitContainer>(topNode,"G4HIT_SILICON_TRACKER");
-  if (!_g4hits_svtx && !_g4hits_tracker) {
-    cerr << PHWHERE << " ERROR: Can't find G4HIT_SVTX or G4HIT_SILICON_TRACKER" << endl;
-    exit(-1);
-  }
   
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
-  if (!_truthinfo) {
-    cerr << PHWHERE << " ERROR: Can't find G4TruthInfo" << endl;
-    exit(-1);
-  }
   
   return;
+}
+
+bool SvtxHitEval::has_node_pointers() {
+
+  if (_strict) assert(_hitmap);
+  else if (!_hitmap) return false;
+
+  if (_strict) assert(_g4cells_svtx || _g4cells_tracker);
+  else if (!_g4cells_svtx && !_g4cells_tracker) return false;
+
+  if (_strict) assert(_g4hits_svtx || _g4hits_tracker);
+  else if (!_g4hits_svtx && !_g4hits_tracker) return false;
+
+  if (_strict) assert(_truthinfo);
+  else if (!_truthinfo) return false;
+  
+  return true;
 }

--- a/simulation/g4simulation/g4eval/SvtxHitEval.h
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.h
@@ -65,6 +65,7 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode *topNode);
+  bool has_node_pointers();
 
   SvtxTruthEval _trutheval;
   SvtxHitMap* _hitmap;

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.C
@@ -63,6 +63,8 @@ void SvtxTrackEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Hit*> SvtxTrackEval::all_truth_hits(SvtxTrack* track) {
 
+  if (!has_node_pointers()) return std::set<PHG4Hit*>();
+  
   if (_strict) {assert(track);}
   else if (!track) {++_errors; return std::set<PHG4Hit*>();}
   
@@ -102,6 +104,8 @@ std::set<PHG4Hit*> SvtxTrackEval::all_truth_hits(SvtxTrack* track) {
   
 std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track) {
 
+  if (!has_node_pointers()) return std::set<PHG4Particle*>();
+  
   if (_strict) {assert(track);}
   else if (!track) {++_errors; return std::set<PHG4Particle*>();}
   
@@ -141,6 +145,8 @@ std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track) {
 
 PHG4Particle* SvtxTrackEval::max_truth_particle_by_nclusters(SvtxTrack* track) {
 
+  if (!has_node_pointers()) return NULL;
+  
   if (_strict) {assert(track);}
   else if (!track) {++_errors; return NULL;}
   
@@ -175,6 +181,8 @@ PHG4Particle* SvtxTrackEval::max_truth_particle_by_nclusters(SvtxTrack* track) {
 
 std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle) { 
 
+  if (!has_node_pointers()) return std::set<SvtxTrack*>();
+  
   if (_strict) {assert(truthparticle);}
   else if (!truthparticle) {++_errors; return std::set<SvtxTrack*>();}
   
@@ -223,6 +231,8 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
 
 std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Hit* truthhit) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<SvtxTrack*>();}
+  
   if (_strict) {assert(truthhit);}
   else if (!truthhit) {++_errors; return std::set<SvtxTrack*>();}
   
@@ -273,6 +283,8 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Hit* truthhit) {
 
 SvtxTrack* SvtxTrackEval::best_track_from(PHG4Particle* truthparticle) { 
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(truthparticle);}
   else if (!truthparticle) {++_errors; return NULL;}
   
@@ -306,6 +318,8 @@ SvtxTrack* SvtxTrackEval::best_track_from(PHG4Particle* truthparticle) {
 // overlap calculations
 unsigned int SvtxTrackEval::get_nclusters_contribution(SvtxTrack* track, PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return 0;}
+  
   if (_strict) {
     assert(track);
     assert(particle);
@@ -355,16 +369,20 @@ void SvtxTrackEval::get_node_pointers(PHCompositeNode *topNode) {
 
   // need things off of the DST...
   _trackmap = findNode::getClass<SvtxTrackMap>(topNode,"SvtxTrackMap");
-  if (!_trackmap) {
-    cerr << PHWHERE << " ERROR: Can't find SvtxTrackMap" << endl;
-    exit(-1);
-  }
   
   _clustermap = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
-  if (!_clustermap) {
-    cerr << PHWHERE << " ERROR: Can't find SvtxClusterMap" << endl;
-    exit(-1);
-  }
 
   return;
+}
+
+bool SvtxTrackEval::has_node_pointers() {
+
+  // need things off of the DST...
+  if (_strict) assert(_trackmap);
+  else if (!_trackmap) return false;
+
+  if (_strict) assert(_clustermap);
+  else if (!_clustermap) return false;
+
+  return true;
 }

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -62,6 +62,7 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode* topNode);
+  bool has_node_pointers();
   
   SvtxClusterEval _clustereval;
   SvtxTrackMap* _trackmap;

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -60,6 +60,8 @@ void SvtxTruthEval::next_event(PHCompositeNode* topNode) {
 /// \todo this copy may be too expensive to call a lot...
 std::set<PHG4Hit*> SvtxTruthEval::all_truth_hits() {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Hit*>();}
+  
   if (_do_cache) {
     if (!_cache_all_truth_hits.empty()) {
       return _cache_all_truth_hits;
@@ -100,6 +102,8 @@ std::set<PHG4Hit*> SvtxTruthEval::all_truth_hits() {
 
 std::set<PHG4Hit*> SvtxTruthEval::all_truth_hits(PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Hit*>();}
+  
   if (_strict) {assert(particle);}
   else if (!particle) {++_errors; return std::set<PHG4Hit*>();}
   
@@ -144,6 +148,8 @@ std::set<PHG4Hit*> SvtxTruthEval::all_truth_hits(PHG4Particle* particle) {
 
 PHG4Hit* SvtxTruthEval::get_innermost_truth_hit(PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(particle);}
   else if (!particle) {++_errors; return NULL;}
   
@@ -169,6 +175,8 @@ PHG4Hit* SvtxTruthEval::get_innermost_truth_hit(PHG4Particle* particle) {
 
 PHG4Hit* SvtxTruthEval::get_outermost_truth_hit(PHG4Particle* particle) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(particle);}
   else if (!particle) {++_errors; return NULL;}
   
@@ -210,6 +218,8 @@ bool SvtxTruthEval::is_primary(PHG4Particle* particle) {
 
 PHG4Particle* SvtxTruthEval::get_primary(PHG4Hit* g4hit) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(g4hit);}
   else if (!g4hit) {++_errors; return NULL;}
 
@@ -250,17 +260,20 @@ bool SvtxTruthEval::are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2) {
 void SvtxTruthEval::get_node_pointers(PHCompositeNode* topNode) {
   
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
-  if (!_truthinfo) {
-    cerr << PHWHERE << " ERROR: Can't find G4TruthInfo" << endl;
-    exit(-1);
-  }
 
   _g4hits_svtx    = findNode::getClass<PHG4HitContainer>(topNode,"G4HIT_SVTX");
   _g4hits_tracker = findNode::getClass<PHG4HitContainer>(topNode,"G4HIT_SILICON_TRACKER");
-  if (!_g4hits_svtx && !_g4hits_tracker) {
-    cerr << PHWHERE << " ERROR: Can't find G4HIT_SVTX or G4HIT_SILICON_TRACKER" << endl;
-    exit(-1);
-  }
   
   return;
+}
+
+bool SvtxTruthEval::has_node_pointers() {
+
+  if (_strict) assert(_truthinfo);
+  else if (!_truthinfo) return false;
+
+  if (_strict) assert(_g4hits_svtx || _g4hits_tracker);
+  else if (!_g4hits_svtx && !_g4hits_tracker) return false;
+  
+  return true;
 }

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -53,6 +53,7 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode* topNode);
+  bool has_node_pointers();
 
   BaseTruthEval _basetrutheval;
   

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.C
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.C
@@ -63,6 +63,8 @@ void SvtxVertexEval::next_event(PHCompositeNode* topNode) {
 
 std::set<PHG4Particle*> SvtxVertexEval::all_truth_particles(SvtxVertex* vertex) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4Particle*>();}
+  
   if (_strict) {assert(vertex);}
   else if (!vertex) {++_errors; return std::set<PHG4Particle*>();}
   
@@ -101,6 +103,8 @@ std::set<PHG4Particle*> SvtxVertexEval::all_truth_particles(SvtxVertex* vertex) 
 
 std::set<PHG4VtxPoint*> SvtxVertexEval::all_truth_points(SvtxVertex* vertex) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<PHG4VtxPoint*>();}
+  
   if (_strict) {assert(vertex);}
   else if (!vertex) {++_errors; return std::set<PHG4VtxPoint*>();}
   
@@ -134,6 +138,8 @@ std::set<PHG4VtxPoint*> SvtxVertexEval::all_truth_points(SvtxVertex* vertex) {
 
 PHG4VtxPoint* SvtxVertexEval::max_truth_point_by_ntracks(SvtxVertex* vertex) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(vertex);}
   else if (!vertex) {++_errors; return NULL;}
   
@@ -168,6 +174,8 @@ PHG4VtxPoint* SvtxVertexEval::max_truth_point_by_ntracks(SvtxVertex* vertex) {
    
 std::set<SvtxVertex*> SvtxVertexEval::all_vertexes_from(PHG4VtxPoint* truthpoint) {
 
+  if (!has_node_pointers()) {++_errors; return std::set<SvtxVertex*>();}
+  
   if (_strict) {assert(truthpoint);}
   else if (!truthpoint) {++_errors; return std::set<SvtxVertex*>();}
 
@@ -204,6 +212,8 @@ std::set<SvtxVertex*> SvtxVertexEval::all_vertexes_from(PHG4VtxPoint* truthpoint
 
 SvtxVertex* SvtxVertexEval::best_vertex_from(PHG4VtxPoint* truthpoint) {
 
+  if (!has_node_pointers()) {++_errors; return NULL;}
+  
   if (_strict) {assert(truthpoint);}
   else if (!truthpoint) {++_errors; return NULL;}
 
@@ -237,6 +247,8 @@ SvtxVertex* SvtxVertexEval::best_vertex_from(PHG4VtxPoint* truthpoint) {
 // overlap calculations
 unsigned int SvtxVertexEval::get_ntracks_contribution(SvtxVertex* vertex, PHG4VtxPoint* truthpoint) {
 
+  if (!has_node_pointers()) {++_errors; return 0;}
+  
   if (_strict) {
     assert(vertex);
     assert(truthpoint);
@@ -281,22 +293,24 @@ void SvtxVertexEval::get_node_pointers(PHCompositeNode* topNode) {
 
   // need things off the DST...
   _vertexmap = findNode::getClass<SvtxVertexMap>(topNode,"SvtxVertexMap");
-  if (!_vertexmap) {
-    cerr << PHWHERE << " ERROR: Can't find SvtxVertexMap" << endl;
-    exit(-1);
-  }
   
   _trackmap = findNode::getClass<SvtxTrackMap>(topNode,"SvtxTrackMap");
-  if (!_trackmap) {
-    cerr << PHWHERE << " ERROR: Can't find SvtxTrackMap" << endl;
-    exit(-1);
-  }
 
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
-  if (!_truthinfo) {
-    cerr << PHWHERE << " ERROR: Can't find G4TruthInfo" << endl;
-    exit(-1);
-  }
   
   return;
+}
+
+bool SvtxVertexEval::has_node_pointers() {
+
+  if (_strict) assert(_vertexmap);
+  else if (!_vertexmap) return false;
+  
+  if (_strict) assert(_trackmap);
+  else if (!_trackmap) return false;
+
+  if (_strict) assert(_truthinfo);
+  else if (!_truthinfo) return false;
+  
+  return true;
 }

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.h
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.h
@@ -65,6 +65,7 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode* topNode);
+  bool has_node_pointers();
   
   SvtxTrackEval _trackeval;
   SvtxVertexMap* _vertexmap;


### PR DESCRIPTION
The evaluator hierarchy has the jet truth evaluation owning evaluator stacks for each detector subsystem. Previously when a subsystem was missing the detector evaluator stack would notice the missing node and throw an error. However, with the jet evaluator we'd like it to not care if say, the forward calorimeters were not run and those nodes are not missing, so long as we never ask for information from those nodes.

So I've moved the crash stop error into the public methods so that the missing nodes are only queried on usage and not at setup. I've also changed this check from a crash stop error into the standard error handling of the evaluation that does best it can during processing and reports errors at the end.

This should allow @johnlajoie to keep making good progress on forward jets and their evaluation.