### PR TITLE
port to gcc 4.8.2

### DIFF
--- a/generators/flowAfterburner/Makefile.am
+++ b/generators/flowAfterburner/Makefile.am
@@ -7,7 +7,7 @@ AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
    `geant4-config --libs-without-gui` \
-  -lHepMC -lgsl -lgslcblas
+  -lHepMC -lgsl -lgslcblas -lpthread
 
 INCLUDES = \
   -I$(includedir) \

--- a/generators/sHijing/Makefile.am
+++ b/generators/sHijing/Makefile.am
@@ -4,7 +4,7 @@ AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
    `geant4-config --libs-without-gui` \
-  -lHepMC -lhijing -lhijing_dummy -lfastjet -lCGAL -lgfortran
+  -lHepMC -lhijing -lhijing_dummy -lfastjet -lCGAL -lgfortran -lpthread
 
 INCLUDES = \
   -I$(includedir) \

--- a/offline/framework/fun4all/Fun4AllEventOutStream.h
+++ b/offline/framework/fun4all/Fun4AllEventOutStream.h
@@ -8,7 +8,14 @@
 #include <Event/phenixTypes.h>
 
 #ifndef __CINT__
+#include <boost/version.hpp> // to get BOOST_VERSION
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && (BOOST_VERSION == 105700 || BOOST_VERSION == 106000) )
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #include <boost/numeric/interval.hpp>
+#pragma GCC diagnostic warning "-Wunused-local-typedefs"
+#else
+#include <boost/numeric/interval.hpp>
+#endif
 #endif
 
 #include <map>

--- a/offline/packages/HelixHough/helix_hough/HelixHough.h
+++ b/offline/packages/HelixHough/helix_hough/HelixHough.h
@@ -1,10 +1,6 @@
 #ifndef __HELIX_HOUGH_H__
 #define __HELIX_HOUGH_H__
 
-#include <cmath>
-#include <vector>
-#include <set>
-#include <map>
 #include "fastvec.h"
 #include "HelixRange.h"
 #include "HelixResolution.h"
@@ -13,6 +9,10 @@
 #include "HelixKalmanState.h"
 #include <xmmintrin.h>
 #include <emmintrin.h>
+#include <cmath>
+#include <vector>
+#include <set>
+#include <map>
 
 #ifndef M_PI
 #define M_PI           3.14159265358979323846
@@ -120,7 +120,7 @@ class HelixHough
   public:
     HelixHough(unsigned int n_phi, unsigned int n_d, unsigned int n_k, unsigned int n_dzdl, unsigned int n_z0, HelixResolution& min_resolution, HelixResolution& max_resolution, HelixRange& range);
     HelixHough(std::vector<std::vector<unsigned int> >& zoom_profile, unsigned int minzoom, HelixRange& range);
-    ~HelixHough();
+    virtual ~HelixHough();
     
     void initHelixHough(unsigned int n_phi, unsigned int n_d, unsigned int n_k, unsigned int n_dzdl, unsigned int n_z0, HelixResolution& min_resolution, HelixResolution& max_resolution, HelixRange& range);
     

--- a/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTracker.h
+++ b/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTracker.h
@@ -202,7 +202,7 @@ class sPHENIXTracker : public HelixHough
 public:
   sPHENIXTracker(unsigned int n_phi, unsigned int n_d, unsigned int n_k, unsigned int n_dzdl, unsigned int n_z0, HelixResolution& min_resolution, HelixResolution& max_resolution, HelixRange& range, std::vector<float>& material, std::vector<float>& radius, float Bfield);
   sPHENIXTracker(std::vector<std::vector<unsigned int> >& zoom_profile, unsigned int minzoom, HelixRange& range, std::vector<float>& material, std::vector<float>& radius, float Bfield, bool parallel=false, unsigned int num_threads=1);
-  ~sPHENIXTracker();
+  virtual ~sPHENIXTracker();
 
   void finalize(std::vector<SimpleTrack3D>& input, std::vector<SimpleTrack3D>& output);
   void findTracks(std::vector<SimpleHit3D>& hits, std::vector<SimpleTrack3D>& tracks, const HelixRange& range);

--- a/simulation/g4simulation/g4cemc/BEmcCluster.cc
+++ b/simulation/g4simulation/g4cemc/BEmcCluster.cc
@@ -945,7 +945,7 @@ float EmcPeakarea::GetChi2()
 // Returns Hi2 after its minimization fluctuating CG position 
 // (i.e. after shower profile fit)
 {
-    float chi, chi0, chicorr;
+    float chi, chi0;
     float e1, x1, y1, e2, x2, y2;
     int nh;
     EmcModule *phit, *vv;
@@ -966,8 +966,6 @@ float EmcPeakarea::GetChi2()
     int ndf; // Gamma parameter list changed MV 28.01.00
     fOwner->Gamma(nh, phit, &chi, &chi0, &e1, &x1, &y1, &e2, &x2, &y2, ndf);
     fNdf=ndf;
-    chicorr = fOwner->Chi2Correct(chi0, ndf); // nh->ndf MV 28.01.00
-
     delete [] phit;
     return chi0;
 }
@@ -1160,7 +1158,7 @@ int EmcPeakarea::GetGammas( EmcEmshower* ShList)
   // in Chi2Limit(Number_of_Hits) function, 1-photon hypothesis is 
   // accepted, otherwise the 2-shower hypothesis is checked
   
-  float chi, chi0, e1, x1, y1, e2, x2, y2, chicorr;
+  float chi, chi0, e1, x1, y1, e2, x2, y2;
   int nh, ig;
   EmcModule *phit, *vv;
   EmcEmshower sh1(fOwner), sh2(fOwner);
@@ -1181,7 +1179,6 @@ int EmcPeakarea::GetGammas( EmcEmshower* ShList)
                              // beforehand
   int ndf; // Gamma parameter list changed MV 28.01.00
   fOwner->Gamma(nh, phit, &chi, &chi0, &e1, &x1, &y1, &e2, &x2, &y2, ndf);
-  chicorr = fOwner->Chi2Correct(chi, ndf); // nh->ndf MV 28.01.00
   if(e1>0)
     sh1.ReInitialize(e1, x1*fOwner->GetModSizex(), y1*fOwner->GetModSizey(),
 		     chi, ndf);

--- a/simulation/g4simulation/g4cemc/PHMakeGroups.h
+++ b/simulation/g4simulation/g4cemc/PHMakeGroups.h
@@ -24,7 +24,6 @@ PHMakeGroups(std::vector<Hit>& hits,
 
   using namespace boost;
   typedef adjacency_list <vecS, vecS, undirectedS> Graph;
-  typedef graph_traits<Graph>::vertex_descriptor Vertex;
   
   Graph G;
   

--- a/simulation/g4simulation/g4cemc/RawClusterBuilderv1.cc
+++ b/simulation/g4simulation/g4cemc/RawClusterBuilderv1.cc
@@ -122,7 +122,7 @@ int RawClusterBuilderv1::process_event(PHCompositeNode *topNode)
   std::vector<EmcCluster> *ClusterList = bemc->GetClusters();
   std::vector<EmcCluster>::iterator pc;
 
-  float ecl, e9, ecore, xcg, ycg, xx, xy, yy;
+  float ecl, xcg, ycg, xx, xy, yy;
   int npk;
   EmcPeakarea pPList[MaxNofPeaks];
   EmcPeakarea *pp;
@@ -154,9 +154,9 @@ int RawClusterBuilderv1::process_event(PHCompositeNode *topNode)
       // Cluster energy
       ecl = pp->GetTotalEnergy();
       // 3x3 energy around center of gravity
-      e9 = pp->GetE9();
+      //e9 = pp->GetE9();
       // Ecore (basically near 2x2 energy around center of gravity)
-      ecore = pp->GetECore();
+      //ecore = pp->GetECore();
       // Center of Gravity etc.
       pp->GetMoments( &xcg, &ycg, &xx, &xy, &yy );
       // Tower with max energy

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
@@ -17,7 +17,6 @@
 using namespace std;
 //____________________________________________________________________________..
 PHG4CEmcTestBeamSteppingAction::PHG4CEmcTestBeamSteppingAction( PHG4CEmcTestBeamDetector* detector ):
-  PHG4SteppingAction(NULL),
   detector_( detector ),
   hits_(NULL),
   absorberhits_(NULL),

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
@@ -33,7 +33,6 @@ using namespace std;
 
 //____________________________________________________________________________..
 PHG4CrystalCalorimeterSteppingAction::PHG4CrystalCalorimeterSteppingAction( PHG4CrystalCalorimeterDetector* detector ):
-  PHG4SteppingAction(NULL),
   detector_( detector ),
   hits_(NULL),
   absorberhits_(NULL),

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -188,12 +188,15 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
     double phistepsize = phistep[*layer];
     for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
     {
-      double xinout;double yinout;double px;double py;double phi;double z;int phibin;int zbin;
+      double xinout;
+      double yinout;
+      double phi;
+      double z;
+      int phibin;
+      int zbin;
       xinout = hiter->second->get_x(0);
       yinout = hiter->second->get_y(0);
       double r = sqrt( xinout*xinout + yinout*yinout );
-      px = hiter->second->get_px(0);
-      py = hiter->second->get_py(0);
       phi = atan2(hiter->second->get_y(0), hiter->second->get_x(0));
       z =  hiter->second->get_z(0);
       phibin = geo->get_phibin( phi );

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
@@ -110,6 +110,7 @@ public:
     int NFiberY;
 
     geom_tower();
+    virtual ~geom_tower(){}
 
     virtual void
     identify(std::ostream& os = std::cout) const;

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.cc
@@ -32,7 +32,6 @@ using namespace std;
 
 //______________________________________________________________
 PHG4EnvelopeSteppingAction::PHG4EnvelopeSteppingAction( PHG4EnvelopeDetector* detector ):
-  PHG4SteppingAction(NULL),
   detector_( detector ),
   hits_(NULL),
   hit(NULL)

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
@@ -34,7 +34,6 @@ using namespace std;
 
 //____________________________________________________________________________..
 PHG4ForwardEcalSteppingAction::PHG4ForwardEcalSteppingAction( PHG4ForwardEcalDetector* detector ):
-  PHG4SteppingAction(NULL),
   detector_( detector ),
   hits_(NULL),
   absorberhits_(NULL),

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
@@ -34,7 +34,6 @@ using namespace std;
 
 //____________________________________________________________________________..
 PHG4ForwardHcalSteppingAction::PHG4ForwardHcalSteppingAction( PHG4ForwardHcalDetector* detector ):
-  PHG4SteppingAction(NULL),
   detector_( detector ),
   hits_(NULL),
   absorberhits_(NULL),

--- a/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSteppingAction.cc
@@ -19,7 +19,6 @@
 using namespace std;
 //____________________________________________________________________________..
 PHG4HcalPrototypeSteppingAction::PHG4HcalPrototypeSteppingAction( PHG4HcalPrototypeDetector* detector ):
-  PHG4SteppingAction(NULL),
   detector_( detector ),
   hits_(NULL),
   absorberhits_(NULL),

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -33,7 +33,6 @@
 using namespace std;
 //____________________________________________________________________________..
 PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction( PHG4InnerHcalDetector* detector, PHG4Parameters *parameters):
-  PHG4SteppingAction(NULL),
   detector_( detector ),
   hits_(NULL),
   absorberhits_(NULL),

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -669,11 +669,8 @@ PHG4OuterHcalDetector::x_at_y(Point_2 &p0, Point_2 &p1, G4double yin)
 {
   double xret = NAN;
   double x[2];
-  double y[2];
   x[0] = CGAL::to_double(p0.x());
-  y[0] = CGAL::to_double(p0.y());
   x[1] = CGAL::to_double(p1.x());
-  y[1] = CGAL::to_double(p1.y());
   Line_2 l(p0, p1);
   double newx = fabs(x[0]) + fabs(x[1]);
   Point_2 p0new(-newx, yin);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -42,7 +42,6 @@
 using namespace std;
 //____________________________________________________________________________..
 PHG4OuterHcalSteppingAction::PHG4OuterHcalSteppingAction( PHG4OuterHcalDetector* detector,  PHG4Parameters *parameters):
-  PHG4SteppingAction(NULL),
   detector_( detector ),
   hits_(NULL),
   absorberhits_(NULL),

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
@@ -1052,7 +1052,6 @@ PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal_log
 		z_cent = 0.00;
 		G4double rot_x = 0.020928529;
 		G4double rot_y = -1.0*rot_x;
-		G4double rot_z = 0.00;
 
 		G4ThreeVector Crystal_Center = G4ThreeVector(x_cent*mm, y_cent*mm, z_cent*mm);
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -31,7 +31,6 @@
 using namespace std;
 //____________________________________________________________________________..
 PHG4SiliconTrackerSteppingAction::PHG4SiliconTrackerSteppingAction( PHG4SiliconTrackerDetector* detector ):
-  PHG4SteppingAction(NULL),
   detector_( detector ),
   hits_(NULL),
   absorberhits_(NULL),

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -351,7 +351,7 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       }
     }
 	
-    float gpoint_data[7] = {_ievent,
+    float gpoint_data[7] = { (float) _ievent,
 			    gvx,
 			    gvy,
 			    gvz,
@@ -435,7 +435,7 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	efromtruth     = clustereval->get_energy_contribution(cluster, primary);
       }
       
-      float shower_data[20] = {_ievent,
+      float shower_data[20] = {(float)_ievent,
 			       gparticleID,
 			       gflavor,
 			       gnhits,
@@ -552,7 +552,7 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	efromtruth = towereval->get_energy_contribution(tower, primary);
       }
 
-      float tower_data[21] = {_ievent,
+      float tower_data[21] = {(float) _ievent,
 			      towerid,
 			      ieta,
 			      iphi,
@@ -661,7 +661,7 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 							  primary);
       }
       
-      float cluster_data[20] = {_ievent,
+      float cluster_data[20] = {(float) _ievent,
 				clusterID,
 				ntowers,
 				eta,

--- a/simulation/g4simulation/g4eval/CaloEvaluator.h
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.h
@@ -80,7 +80,7 @@ class CaloEvaluator : public SubsysReco {
 
   std::string _caloname;
   
-  unsigned long _ievent;
+  unsigned int _ievent;
 
   std::set<int> _truth_trace_embed_flags;
   float _truth_e_threshold;

--- a/simulation/g4simulation/g4eval/CaloRawClusterEval.C
+++ b/simulation/g4simulation/g4eval/CaloRawClusterEval.C
@@ -319,7 +319,7 @@ float CaloRawClusterEval::get_energy_contribution(RawCluster* cluster, PHG4Parti
   primary = get_truth_eval()->get_primary_particle(primary);
 
   if (_strict) {assert(primary);}
-  else if (!primary) {++_errors; return NULL;}
+  else if (!primary) {++_errors; return 0.;}
   
   if (_do_cache) {
     std::map<std::pair<RawCluster*,PHG4Particle*>,float>::iterator iter =

--- a/simulation/g4simulation/g4eval/JetEvaluator.C
+++ b/simulation/g4simulation/g4eval/JetEvaluator.C
@@ -175,7 +175,7 @@ void JetEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	efromtruth = recoeval->get_energy_contribution(recojet,truthjet);
       }
       
-      float recojet_data[14] = {_ievent,
+      float recojet_data[14] = {(float) _ievent,
 				id,
 				ncomp,
 				eta,
@@ -240,7 +240,7 @@ void JetEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	efromtruth = recoeval->get_energy_contribution(recojet,truthjet);
       }
       
-      float truthjet_data[14] = {_ievent,
+      float truthjet_data[14] = {(float) _ievent,
 				 gid,
 				 gncomp,
 				 geta,

--- a/simulation/g4simulation/g4eval/MomentumEvaluator.C
+++ b/simulation/g4simulation/g4eval/MomentumEvaluator.C
@@ -385,12 +385,12 @@ int MomentumEvaluator::process_event( PHCompositeNode *topNode )
    			}
    		}
    		
-   		float ntp_data[14] = { event_counter, t_track->px, t_track->py, t_track->pz, t_track->dcax, t_track->dcay, t_track->dcaz, pointer_list[best_ind]->px, pointer_list[best_ind]->py, pointer_list[best_ind]->pz, pointer_list[best_ind]->dcax, pointer_list[best_ind]->dcay, pointer_list[best_ind]->dcaz, pointer_list[best_ind]->quality };
+   		float ntp_data[14] = { (float) event_counter, t_track->px, t_track->py, t_track->pz, t_track->dcax, t_track->dcay, t_track->dcaz, pointer_list[best_ind]->px, pointer_list[best_ind]->py, pointer_list[best_ind]->pz, pointer_list[best_ind]->dcax, pointer_list[best_ind]->dcay, pointer_list[best_ind]->dcaz, pointer_list[best_ind]->quality };
    		ntp_true->Fill(ntp_data);
    	}
    	else
    	{
-   		float ntp_data[14] = { event_counter, t_track->px, t_track->py, t_track->pz, t_track->dcax, t_track->dcay, t_track->dcaz, -9999.,-9999.,-9999.,-9999.,-9999.,-9999., -9999. };
+   		float ntp_data[14] = { (float) event_counter, t_track->px, t_track->py, t_track->pz, t_track->dcax, t_track->dcay, t_track->dcaz, -9999.,-9999.,-9999.,-9999.,-9999.,-9999., -9999. };
    		ntp_true->Fill(ntp_data);
    	}
 
@@ -430,12 +430,12 @@ int MomentumEvaluator::process_event( PHCompositeNode *topNode )
    			}
    		}
    		
-   		float ntp_data[14] = { event_counter, r_track->px, r_track->py, r_track->pz, r_track->dcax, r_track->dcay, r_track->dcaz, pointer_list[best_ind]->px, pointer_list[best_ind]->py, pointer_list[best_ind]->pz, pointer_list[best_ind]->dcax, pointer_list[best_ind]->dcay, pointer_list[best_ind]->dcaz, r_track->quality };
+   		float ntp_data[14] = { (float) event_counter, r_track->px, r_track->py, r_track->pz, r_track->dcax, r_track->dcay, r_track->dcaz, pointer_list[best_ind]->px, pointer_list[best_ind]->py, pointer_list[best_ind]->pz, pointer_list[best_ind]->dcax, pointer_list[best_ind]->dcay, pointer_list[best_ind]->dcaz, r_track->quality };
    		ntp_reco->Fill(ntp_data);
    	}
    	else
    	{
-   		float ntp_data[14] = { event_counter, r_track->px, r_track->py, r_track->pz, r_track->dcax, r_track->dcay, r_track->dcaz, -9999.,-9999.,-9999.,-9999.,-9999.,-9999., r_track->quality };
+   		float ntp_data[14] = { (float) event_counter, r_track->px, r_track->py, r_track->pz, r_track->dcax, r_track->dcay, r_track->dcaz, -9999.,-9999.,-9999.,-9999.,-9999.,-9999., r_track->quality };
    		ntp_reco->Fill(ntp_data);
    	}
 

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -591,7 +591,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  nfromtruth = vertexeval->get_ntracks_contribution(vertex,point);
 	}
 	  
-	float vertex_data[10] = {_ievent,
+	float vertex_data[10] = {(float) _ievent,
 				 vx,
 				 vy,
 				 vz,
@@ -638,7 +638,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	nfromtruth = vertexeval->get_ntracks_contribution(vertex,point);
       }
 	
-      float gpoint_data[10] = {_ievent,
+      float gpoint_data[10] = {(float) _ievent,
 			       gvx,
 			       gvy,
 			       gvz,
@@ -689,12 +689,12 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       float gembed  = NAN;
       float gprimary = NAN;
 
-      float gfpx      = NULL;
-      float gfpy      = NULL;
-      float gfpz      = NULL;
-      float gfx       = NULL;
-      float gfy       = NULL;
-      float gfz       = NULL;
+      float gfpx      = 0.;
+      float gfpy      = 0.;
+      float gfpz      = 0.;
+      float gfx       = 0.;
+      float gfy       = 0.;
+      float gfz       = 0.;
 
       if (g4particle) {
 
@@ -759,7 +759,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	}
       }
 
-      float g4hit_data[35] = {_ievent,
+      float g4hit_data[35] = {(float) _ievent,
 			      g4hitID,
 			      gx,
 			      gy,
@@ -845,7 +845,6 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gfx      = NAN;
 	float gfy      = NAN;
 	float gfz      = NAN;
-	float glast    = NAN;
 	float gembed   = NAN;
 	float gprimary = NAN;
       
@@ -886,7 +885,6 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	      gfy      = outerhit->get_y(1);
 	      gfz      = outerhit->get_z(1);
 	    }
-	    glast    = NAN;
 	    gembed   = trutheval->get_embed(g4particle);
 	    gprimary = trutheval->is_primary(g4particle);
 	  } //   if (g4particle){
@@ -979,7 +977,6 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gfx      = NAN;
 	float gfy      = NAN;
 	float gfz      = NAN;
-	float glast    = NAN;
 	float gembed   = NAN;
 	float gprimary = NAN;
     
@@ -1020,7 +1017,6 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	      gfz      = outerhit->get_z(1);
 	    }
 	    
-	    glast    = NAN;
 	    gembed   = trutheval->get_embed(g4particle);
 	    gprimary = trutheval->is_primary(g4particle);
 	  }      //   if (g4particle){
@@ -1030,7 +1026,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  efromtruth = clustereval->get_energy_contribution(cluster,g4particle);
 	}
 
-	float cluster_data[33] = {_ievent,
+	float cluster_data[33] = {(float) _ievent,
 				  hitID,
 				  x,
 				  y,
@@ -1101,12 +1097,12 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gvy      = vtx->get_y();
 	float gvz      = vtx->get_z();
 
-	float gfpx      = NULL;
-	float gfpy      = NULL;
-	float gfpz      = NULL;
-	float gfx       = NULL;
-	float gfy       = NULL;
-	float gfz       = NULL;
+	float gfpx      = 0.;
+	float gfpy      = 0.;
+	float gfpz      = 0.;
+	float gfx       = 0.;
+	float gfy       = 0.;
+	float gfz       = 0.;
     
 	PHG4Hit* outerhit = trutheval->get_outermost_truth_hit(g4particle);	
 	if (outerhit) {
@@ -1130,7 +1126,6 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float ndf           = NAN;
 	float nhits         = NAN;
 	unsigned int layers = 0x0;
-	float dca           = NAN;
 	float dca2d         = NAN;
 	float dca2dsigma    = NAN;
 	float px            = NAN;
@@ -1159,7 +1154,6 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	    if (layer < 32) layers |= (0x1 << layer);
 	  }
 
-	  dca       = track->get_dca();
 	  dca2d     = track->get_dca2d();
 	  dca2dsigma = track->get_dca2d_error();
 	  px        = track->get_px();
@@ -1172,7 +1166,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  nfromtruth = trackeval->get_nclusters_contribution(track,g4particle);
 	}
       
-	float gtrack_data[34] = {_ievent,
+	float gtrack_data[34] = {(float) _ievent,
 				 gtrackID,
 				 gflavor,
 				 ng4hits,
@@ -1199,7 +1193,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				 chisq,      
 				 ndf,        
 				 nhits,      
-				 layers,     
+				 (float) layers,     
 				 dca2d,      
 				 dca2dsigma, 			       
 				 pcax,       
@@ -1327,7 +1321,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  nfromtruth = trackeval->get_nclusters_contribution(track,g4particle);
 	}
       
-	float track_data[50] = {_ievent,
+	float track_data[50] = {(float) _ievent,
 				trackID, 
 				px,        
 				py,        
@@ -1337,7 +1331,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				chisq,   
 				ndf,     
 				nhits,   
-				layers,
+				(float) layers,
 				dca2d,     
 				dca2dsigma,      
 				pcax,      

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -133,22 +133,22 @@ public:
   //
   // calo projection methods ---------------------------------------------------
   //
-  virtual float get_cal_dphi(CAL_LAYER layer) const       {return NULL;}
+  virtual float get_cal_dphi(CAL_LAYER layer) const       {return 0.;}
   virtual void  set_cal_dphi(CAL_LAYER layer, float dphi) {}
 
-  virtual float get_cal_deta(CAL_LAYER layer) const       {return NULL;}
+  virtual float get_cal_deta(CAL_LAYER layer) const       {return 0.;}
   virtual void  set_cal_deta(CAL_LAYER layer, float deta) {}
 
-  virtual float get_cal_energy_3x3(CAL_LAYER layer) const             {return NULL;}
+  virtual float get_cal_energy_3x3(CAL_LAYER layer) const             {return 0.;}
   virtual void  set_cal_energy_3x3(CAL_LAYER layer, float energy_3x3) {}
 
-  virtual float get_cal_energy_5x5(CAL_LAYER layer) const             {return NULL;}
+  virtual float get_cal_energy_5x5(CAL_LAYER layer) const             {return 0.;}
   virtual void  set_cal_energy_5x5(CAL_LAYER layer, float energy_5x5) {}
 
-  virtual unsigned int get_cal_cluster_id(CAL_LAYER layer) const            {return NULL;}
+  virtual unsigned int get_cal_cluster_id(CAL_LAYER layer) const            {return 0;}
   virtual void         set_cal_cluster_id(CAL_LAYER layer, unsigned int id) {}
 
-  virtual float get_cal_cluster_e(CAL_LAYER layer) const    {return NULL;}
+  virtual float get_cal_cluster_e(CAL_LAYER layer) const    {return 0.;}
   virtual void  set_cal_cluster_e(CAL_LAYER layer, float e) {}
 
 protected:

--- a/simulation/g4simulation/g4main/PHG4InEvent.cc
+++ b/simulation/g4simulation/g4main/PHG4InEvent.cc
@@ -67,9 +67,9 @@ PHG4InEvent::AddParticle(const int vtxid, PHG4Particle *particle)
       cout << "cannot add particle to non existing vertex, id: " << vtxid << endl;
       exit(1);
     }
-  std::pair< std::multimap<int,PHG4Particle *>::const_iterator, std::multimap<int,PHG4Particle *>::const_iterator > particles = GetParticles(vtxid);
-
   // checking for duplicate particles - sometimes interesting
+  //  std::pair< std::multimap<int,PHG4Particle *>::const_iterator, std::multimap<int,PHG4Particle *>::const_iterator > particles = GetParticles(vtxid);
+
 //   for (multimap<int,PHG4Particle *>::const_iterator piter = particles.first; piter != particles.second; piter++)
 //     {
 //       if (*particle == *(piter->second))


### PR DESCRIPTION
We need to upgrade our compiler ASAP since G4 does not compile anymore with the our installed  4.4.7. We have gcc 4.8.2 as alternative under /opt/gcc, it is set up in a way that the binaries also work on a normal SL6 box. No major changes but the new compiler traces unused variables more aggressively. It also does not accept NULL as numerical int/float value (that shouldn't have been used like this in the first place) and pushing unsigned ints into a float. The changes should be backward compatible, the code should still compile under gcc 4.4.7