### PR TITLE
Standardized Calorimetry QA - part 1/3

### DIFF
--- a/offline/QA/macros/QA_Draw_CEMC_G4Hit.C
+++ b/offline/QA/macros/QA_Draw_CEMC_G4Hit.C
@@ -54,6 +54,7 @@ QA_Draw_CEMC_G4Hit(const char * qa_file_name_new =
   TH2F * h_QAG4Sim_CEMC_G4Hit_XY = (TH2F *) qa_file_new->GetObjectChecked(
       "h_QAG4Sim_CEMC_G4Hit_XY", "TH2F");
   assert(h_QAG4Sim_CEMC_G4Hit_XY);
+  h_QAG4Sim_CEMC_G4Hit_XY->GetYaxis()->SetTitleOffset(1.5);
   h_QAG4Sim_CEMC_G4Hit_XY->Draw("COLZ");
 
   p = (TPad *) c1->cd(idx++);
@@ -63,6 +64,7 @@ QA_Draw_CEMC_G4Hit(const char * qa_file_name_new =
   TH2F * h_QAG4Sim_CEMC_G4Hit_RZ = (TH2F *) qa_file_new->GetObjectChecked(
       "h_QAG4Sim_CEMC_G4Hit_RZ", "TH2F");
   assert(h_QAG4Sim_CEMC_G4Hit_RZ);
+  h_QAG4Sim_CEMC_G4Hit_RZ->GetYaxis()->SetTitleOffset(1.5);
   h_QAG4Sim_CEMC_G4Hit_RZ->Draw("COLZ");
 
   p = (TPad *) c1->cd(idx++);
@@ -275,7 +277,7 @@ QA_Draw_CEMC_G4Hit(const char * qa_file_name_new =
         }
 
 
-  SaveCanvas(c1, TString(qa_file_name_new) + TString(c1->GetName()), kFALSE);
+  SaveCanvas(c1, TString(qa_file_name_new) + TString(c1->GetName()), true);
 }
 
 void

--- a/offline/QA/macros/QA_Draw_CEMC_G4Hit.C
+++ b/offline/QA/macros/QA_Draw_CEMC_G4Hit.C
@@ -1,0 +1,306 @@
+// $Id: $
+
+/*!
+ * \file QA_Draw_CEMC_G4Hit.C
+ * \brief
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include <cmath>
+#include <TFile.h>
+#include <TString.h>
+#include <TLine.h>
+#include <TTree.h>
+#include <cassert>
+
+//some common style files
+#include "SaveCanvas.C"
+#include "SetOKStyle.C"
+using namespace std;
+
+void
+QA_Draw_CEMC_G4Hit(const char * qa_file_name_new =
+    "G4sPHENIXCells_1000pi24GeV.root_qa.root", const char * qa_file_name_ref =
+    "G4sPHENIXCells_100e24GeV.root_qa.root")
+{
+
+  SetOKStyle();
+  gStyle->SetOptStat(0);
+  gStyle->SetOptFit(1111);
+  TVirtualFitter::SetDefaultFitter("Minuit2");
+
+  TFile * qa_file_new = new TFile(qa_file_name_new);
+  assert(qa_file_new->IsOpen());
+
+  TFile * qa_file_ref = NULL;
+  if (qa_file_name_ref)
+    {
+      qa_file_ref = new TFile(qa_file_name_ref);
+      assert(qa_file_ref->IsOpen());
+    }
+
+  TCanvas *c1 = new TCanvas("QA_Draw_CEMC_G4Hit", "QA_Draw_CEMC_G4Hit", 1800,
+      900);
+  c1->Divide(4, 2);
+  int idx = 1;
+  TPad * p;
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogz();
+
+  TH2F * h_QAG4Sim_CEMC_G4Hit_XY = (TH2F *) qa_file_new->GetObjectChecked(
+      "h_QAG4Sim_CEMC_G4Hit_XY", "TH2F");
+  assert(h_QAG4Sim_CEMC_G4Hit_XY);
+  h_QAG4Sim_CEMC_G4Hit_XY->Draw("COLZ");
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogz();
+
+  TH2F * h_QAG4Sim_CEMC_G4Hit_RZ = (TH2F *) qa_file_new->GetObjectChecked(
+      "h_QAG4Sim_CEMC_G4Hit_RZ", "TH2F");
+  assert(h_QAG4Sim_CEMC_G4Hit_RZ);
+  h_QAG4Sim_CEMC_G4Hit_RZ->Draw("COLZ");
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+//  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection->ProjectionX(
+              "qa_file_new_h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection_px");
+
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection);
+
+          proj_ref = h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection->ProjectionX(
+              "qa_file_ref_h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection_px");
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection->ProjectionY(
+              "qa_file_new_h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection_py");
+
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection);
+
+          proj_ref = h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection->ProjectionY(
+              "qa_file_ref_h_QAG4Sim_CEMC_G4Hit_LateralTruthProjection_py");
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogx();
+  p->SetLogy();
+
+    {
+
+      TH1F * h_new =
+          (TH1F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_CEMC_G4Hit_HitTime", "TH1F");
+      assert(h_new);
+
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref =
+              (TH1F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_CEMC_G4Hit_HitTime", "TH1F");
+          assert(h_ref);
+
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized energy per bin");
+//      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+
+    p = (TPad *) c1->cd(idx++);
+    c1->Update();
+//    p->SetLogx();
+//    p->SetLogy();
+
+      {
+
+        TH1F * h_new =
+            (TH1F *) qa_file_new->GetObjectChecked(
+                "h_QAG4Sim_CEMC_G4Hit_FractionTruthEnergy", "TH1F");
+        assert(h_new);
+
+        h_new->Rebin(20);
+        h_new->Sumw2();
+        h_new->Scale(1. / h_new->GetSum());
+
+        TH1F * h_ref = NULL;
+        if (qa_file_ref)
+          {
+            TH1F * h_ref =
+                (TH1F *) qa_file_ref->GetObjectChecked(
+                    "h_QAG4Sim_CEMC_G4Hit_FractionTruthEnergy", "TH1F");
+            assert(h_ref);
+
+            h_ref->Rebin(20);
+            h_ref->Scale(1. / h_ref->GetSum());
+          }
+
+        h_new->GetYaxis()->SetTitleOffset(1.5);
+        h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+  //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+        DrawReference(h_new, h_ref);
+      }
+
+    p = (TPad *) c1->cd(idx++);
+    c1->Update();
+    //  p->SetLogz();
+
+      {
+
+        TH1F * h_new =
+            (TH1F *) qa_file_new->GetObjectChecked(
+                "h_QAG4Sim_CEMC_G4Hit_VSF", "TH1F");
+        assert(h_new);
+
+//        h_new->Rebin(2);
+//        h_new->Sumw2();
+        h_new->Scale(1. / h_new->GetSum());
+
+        TH1F * h_ref = NULL;
+        if (qa_file_ref)
+          {
+            TH1F * h_ref =
+                (TH1F *) qa_file_ref->GetObjectChecked(
+                    "h_QAG4Sim_CEMC_G4Hit_VSF", "TH1F");
+            assert(h_ref);
+
+            h_ref->Scale(1. / h_ref->GetSum());
+          }
+
+        h_new->GetYaxis()->SetTitleOffset(1.5);
+        h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+        h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+        DrawReference(h_new, h_ref);
+      }
+
+      p = (TPad *) c1->cd(idx++);
+      c1->Update();
+      //  p->SetLogz();
+
+        {
+
+          TH1F * h_new =
+              (TH1F *) qa_file_new->GetObjectChecked(
+                  "h_QAG4Sim_CEMC_G4Hit_FractionEMVisibleEnergy", "TH1F");
+          assert(h_new);
+
+          h_new->Rebin(4);
+          h_new->Sumw2();
+          h_new->Scale(1. / h_new->GetSum());
+
+          TH1F * h_ref = NULL;
+          if (qa_file_ref)
+            {
+              TH1F * h_ref =
+                  (TH1F *) qa_file_ref->GetObjectChecked(
+                      "h_QAG4Sim_CEMC_G4Hit_FractionEMVisibleEnergy", "TH1F");
+              assert(h_ref);
+
+              h_ref->Rebin(4);
+              h_ref->Scale(1. / h_ref->GetSum());
+            }
+
+          h_new->GetYaxis()->SetTitleOffset(1.5);
+          h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+//          h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+          DrawReference(h_new, h_ref);
+        }
+
+
+  SaveCanvas(c1, TString(qa_file_name_new) + TString(c1->GetName()), kFALSE);
+}
+
+void
+DrawReference(TH1 * hnew, TH1 * href)
+{
+
+  hnew->SetLineColor(kBlue + 3);
+  hnew->SetMarkerColor(kBlue + 3);
+  hnew->SetLineWidth(2);
+  hnew->SetMarkerStyle(kFullCircle);
+  hnew->SetMarkerSize(1);
+
+  href->SetLineColor(kGreen + 1);
+  href->SetFillColor(kGreen + 1);
+  href->SetLineStyle(0);
+  href->SetMarkerColor(kGreen + 1);
+  href->SetLineWidth(0);
+  href->SetMarkerStyle(kDot);
+  href->SetMarkerSize(0);
+
+  hnew->Draw(); // set scale
+
+  if (href)
+    {
+      href->Draw("HIST same");
+      hnew->Draw("same"); // over lay data points
+    }
+}

--- a/offline/QA/macros/QA_Draw_CEMC_G4Hit.C
+++ b/offline/QA/macros/QA_Draw_CEMC_G4Hit.C
@@ -177,7 +177,7 @@ QA_Draw_CEMC_G4Hit(const char * qa_file_name_new =
     p = (TPad *) c1->cd(idx++);
     c1->Update();
 //    p->SetLogx();
-//    p->SetLogy();
+    p->SetLogy();
 
       {
 
@@ -203,7 +203,7 @@ QA_Draw_CEMC_G4Hit(const char * qa_file_name_new =
           }
 
         h_new->GetYaxis()->SetTitleOffset(1.5);
-        h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+        h_new->GetYaxis()->SetTitle("Probability per bin");
   //      h_new->GetXaxis()->SetRangeUser(-0, .1);
 
         DrawReference(h_new, h_ref);
@@ -236,7 +236,7 @@ QA_Draw_CEMC_G4Hit(const char * qa_file_name_new =
           }
 
         h_new->GetYaxis()->SetTitleOffset(1.5);
-        h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+        h_new->GetYaxis()->SetTitle("Probability per bin");
         h_new->GetXaxis()->SetRangeUser(-0, .1);
 
         DrawReference(h_new, h_ref);
@@ -270,7 +270,7 @@ QA_Draw_CEMC_G4Hit(const char * qa_file_name_new =
             }
 
           h_new->GetYaxis()->SetTitleOffset(1.5);
-          h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+          h_new->GetYaxis()->SetTitle("Probability per bin");
 //          h_new->GetXaxis()->SetRangeUser(-0, .1);
 
           DrawReference(h_new, h_ref);

--- a/offline/QA/macros/QA_Draw_CEMC_TowerCluster.C
+++ b/offline/QA/macros/QA_Draw_CEMC_TowerCluster.C
@@ -132,7 +132,7 @@ QA_Draw_CEMC_TowerCluster(const char * qa_file_name_new =
         }
 
       h_new->GetYaxis()->SetTitleOffset(1.5);
-      h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+      h_new->GetYaxis()->SetTitle("Probability per bin");
       //      h_new->GetXaxis()->SetRangeUser(-0, .1);
 
       DrawReference(h_new, h_ref);
@@ -166,7 +166,7 @@ QA_Draw_CEMC_TowerCluster(const char * qa_file_name_new =
           }
 
         h_new->GetYaxis()->SetTitleOffset(1.5);
-        h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+        h_new->GetYaxis()->SetTitle("Probability per bin");
         //      h_new->GetXaxis()->SetRangeUser(-0, .1);
 
         DrawReference(h_new, h_ref);
@@ -292,7 +292,7 @@ QA_Draw_CEMC_TowerCluster(const char * qa_file_name_new =
         }
 
       h_new->GetYaxis()->SetTitleOffset(1.5);
-      h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+      h_new->GetYaxis()->SetTitle("Probability per bin");
       //          h_new->GetXaxis()->SetRangeUser(-0, .1);
 
       DrawReference(h_new, h_ref);

--- a/offline/QA/macros/QA_Draw_CEMC_TowerCluster.C
+++ b/offline/QA/macros/QA_Draw_CEMC_TowerCluster.C
@@ -1,0 +1,329 @@
+// $Id: $
+
+/*!
+ * \file QA_Draw_CEMC_TowerCluster.C
+ * \brief
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include <cmath>
+#include <TFile.h>
+#include <TString.h>
+#include <TLine.h>
+#include <TTree.h>
+#include <cassert>
+
+//some common style files
+#include "SaveCanvas.C"
+#include "SetOKStyle.C"
+using namespace std;
+
+void
+QA_Draw_CEMC_TowerCluster(const char * qa_file_name_new =
+    "G4sPHENIXCells_1000pi24GeV.root_qa.root", const char * qa_file_name_ref =
+    "G4sPHENIXCells_100e24GeV.root_qa.root")
+{
+
+  SetOKStyle();
+  gStyle->SetOptStat(0);
+  gStyle->SetOptFit(1111);
+  TVirtualFitter::SetDefaultFitter("Minuit2");
+
+  TFile * qa_file_new = new TFile(qa_file_name_new);
+  assert(qa_file_new->IsOpen());
+
+  TFile * qa_file_ref = NULL;
+  if (qa_file_name_ref)
+    {
+      qa_file_ref = new TFile(qa_file_name_ref);
+      assert(qa_file_ref->IsOpen());
+    }
+
+  TCanvas *c1 = new TCanvas("QA_Draw_CEMC_G4Hit", "QA_Draw_CEMC_G4Hit", 1800,
+      900);
+  c1->Divide(4, 2);
+  int idx = 1;
+  TPad * p;
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogx();
+  p->SetLogy();
+
+    {
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_CEMC_Tower_1x1", "TH1F");
+      assert(h_new);
+
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_CEMC_Tower_1x1", "TH1F");
+          assert(h_ref);
+
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized tower count per bin");
+//      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogx();
+  p->SetLogy();
+
+    {
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_CEMC_Tower_3x3", "TH1F");
+      assert(h_new);
+
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_CEMC_Tower_3x3", "TH1F");
+          assert(h_ref);
+
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized tower count per bin");
+      //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //    p->SetLogx();
+      p->SetLogy();
+
+    {
+
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_CEMC_Tower_1x1_max", "TH1F");
+      assert(h_new);
+
+      h_new->Rebin(40);
+      h_new->Sumw2();
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_CEMC_Tower_1x1_max", "TH1F");
+          assert(h_ref);
+
+          h_ref->Rebin(40);
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+      //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+
+    p = (TPad *) c1->cd(idx++);
+    c1->Update();
+    //    p->SetLogx();
+        p->SetLogy();
+
+      {
+
+        TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+            "h_QAG4Sim_CEMC_Tower_4x4_max", "TH1F");
+        assert(h_new);
+
+        h_new->Rebin(40);
+        h_new->Sumw2();
+        h_new->Scale(1. / h_new->GetSum());
+
+        TH1F * h_ref = NULL;
+        if (qa_file_ref)
+          {
+            TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+                "h_QAG4Sim_CEMC_Tower_4x4_max", "TH1F");
+            assert(h_ref);
+
+            h_ref->Rebin(40);
+            h_ref->Scale(1. / h_ref->GetSum());
+          }
+
+        h_new->GetYaxis()->SetTitleOffset(1.5);
+        h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+        //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+        DrawReference(h_new, h_ref);
+      }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogz();
+
+  TH2F * h_QAG4Sim_CEMC_Cluster_LateralTruthProjection =
+      (TH2F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_CEMC_Cluster_LateralTruthProjection", "TH2F");
+  assert(h_QAG4Sim_CEMC_Cluster_LateralTruthProjection);
+  h_QAG4Sim_CEMC_Cluster_LateralTruthProjection->GetYaxis()->SetTitleOffset(
+      1.5);
+  h_QAG4Sim_CEMC_Cluster_LateralTruthProjection->GetXaxis()->SetRangeUser(-5,
+      5);
+  h_QAG4Sim_CEMC_Cluster_LateralTruthProjection->GetYaxis()->SetRangeUser(-5,
+      5);
+  h_QAG4Sim_CEMC_Cluster_LateralTruthProjection->Draw("COLZ");
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_CEMC_Cluster_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_CEMC_Cluster_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_CEMC_Cluster_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_CEMC_Cluster_LateralTruthProjection->ProjectionX(
+              "qa_file_new_h_QAG4Sim_CEMC_Cluster_LateralTruthProjection_px");
+
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_CEMC_Cluster_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_CEMC_Cluster_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_CEMC_Cluster_LateralTruthProjection);
+
+          proj_ref = h_QAG4Sim_CEMC_Cluster_LateralTruthProjection->ProjectionX(
+              "qa_file_ref_h_QAG4Sim_CEMC_Cluster_LateralTruthProjection_px");
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitleOffset(1.);
+      proj_new->GetXaxis()->SetTitleOffset(1.);
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_CEMC_Cluster_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_CEMC_Cluster_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_CEMC_Cluster_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_CEMC_Cluster_LateralTruthProjection->ProjectionY(
+              "qa_file_new_h_QAG4Sim_CEMC_Cluster_LateralTruthProjection_py");
+
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_CEMC_Cluster_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_CEMC_Cluster_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_CEMC_Cluster_LateralTruthProjection);
+
+          proj_ref = h_QAG4Sim_CEMC_Cluster_LateralTruthProjection->ProjectionY(
+              "qa_file_ref_h_QAG4Sim_CEMC_Cluster_LateralTruthProjection_py");
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitleOffset(1.);
+      proj_new->GetXaxis()->SetTitleOffset(1.);
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_CEMC_Cluster_BestMatchERatio", "TH1F");
+      assert(h_new);
+
+      h_new->Rebin(2);
+      h_new->Sumw2();
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_CEMC_Cluster_BestMatchERatio", "TH1F");
+          assert(h_ref);
+
+          h_ref->Rebin(2);
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+      //          h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  SaveCanvas(c1, TString(qa_file_name_new) + TString(c1->GetName()), true);
+}
+
+void
+DrawReference(TH1 * hnew, TH1 * href)
+{
+
+  hnew->SetLineColor(kBlue + 3);
+  hnew->SetMarkerColor(kBlue + 3);
+  hnew->SetLineWidth(2);
+  hnew->SetMarkerStyle(kFullCircle);
+  hnew->SetMarkerSize(1);
+
+  href->SetLineColor(kGreen + 1);
+  href->SetFillColor(kGreen + 1);
+  href->SetLineStyle(0);
+  href->SetMarkerColor(kGreen + 1);
+  href->SetLineWidth(0);
+  href->SetMarkerStyle(kDot);
+  href->SetMarkerSize(0);
+
+  hnew->Draw(); // set scale
+
+  if (href)
+    {
+      href->Draw("HIST same");
+      hnew->Draw("same"); // over lay data points
+    }
+}

--- a/offline/QA/macros/QA_Draw_CEMC_TowerCluster.C
+++ b/offline/QA/macros/QA_Draw_CEMC_TowerCluster.C
@@ -41,7 +41,7 @@ QA_Draw_CEMC_TowerCluster(const char * qa_file_name_new =
       assert(qa_file_ref->IsOpen());
     }
 
-  TCanvas *c1 = new TCanvas("QA_Draw_CEMC_G4Hit", "QA_Draw_CEMC_G4Hit", 1800,
+  TCanvas *c1 = new TCanvas("QA_Draw_CEMC_", "QA_Draw_CEMC_", 1800,
       900);
   c1->Divide(4, 2);
   int idx = 1;

--- a/offline/QA/macros/QA_Draw_HCALIN_G4Hit.C
+++ b/offline/QA/macros/QA_Draw_HCALIN_G4Hit.C
@@ -177,7 +177,7 @@ QA_Draw_HCALIN_G4Hit(const char * qa_file_name_new =
     p = (TPad *) c1->cd(idx++);
     c1->Update();
 //    p->SetLogx();
-//    p->SetLogy();
+    p->SetLogy();
 
       {
 
@@ -203,7 +203,7 @@ QA_Draw_HCALIN_G4Hit(const char * qa_file_name_new =
           }
 
         h_new->GetYaxis()->SetTitleOffset(1.5);
-        h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+        h_new->GetYaxis()->SetTitle("Probability per bin");
   //      h_new->GetXaxis()->SetRangeUser(-0, .1);
 
         DrawReference(h_new, h_ref);
@@ -220,7 +220,7 @@ QA_Draw_HCALIN_G4Hit(const char * qa_file_name_new =
                 "h_QAG4Sim_HCALIN_G4Hit_VSF", "TH1F");
         assert(h_new);
 
-//        h_new->Rebin(2);
+        h_new->Rebin(2);
 //        h_new->Sumw2();
         h_new->Scale(1. / h_new->GetSum());
 
@@ -232,11 +232,12 @@ QA_Draw_HCALIN_G4Hit(const char * qa_file_name_new =
                     "h_QAG4Sim_HCALIN_G4Hit_VSF", "TH1F");
             assert(h_ref);
 
+            h_ref->Rebin(2);
             h_ref->Scale(1. / h_ref->GetSum());
           }
 
         h_new->GetYaxis()->SetTitleOffset(1.5);
-        h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+        h_new->GetYaxis()->SetTitle("Probability per bin");
         h_new->GetXaxis()->SetRangeUser(-0, .2);
 
         DrawReference(h_new, h_ref);
@@ -270,7 +271,7 @@ QA_Draw_HCALIN_G4Hit(const char * qa_file_name_new =
             }
 
           h_new->GetYaxis()->SetTitleOffset(1.5);
-          h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+          h_new->GetYaxis()->SetTitle("Probability per bin");
 //          h_new->GetXaxis()->SetRangeUser(-0, .1);
 
           DrawReference(h_new, h_ref);

--- a/offline/QA/macros/QA_Draw_HCALIN_G4Hit.C
+++ b/offline/QA/macros/QA_Draw_HCALIN_G4Hit.C
@@ -1,0 +1,308 @@
+// $Id: $
+
+/*!
+ * \file QA_Draw_HCALIN_G4Hit.C
+ * \brief
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include <cmath>
+#include <TFile.h>
+#include <TString.h>
+#include <TLine.h>
+#include <TTree.h>
+#include <cassert>
+
+//some common style files
+#include "SaveCanvas.C"
+#include "SetOKStyle.C"
+using namespace std;
+
+void
+QA_Draw_HCALIN_G4Hit(const char * qa_file_name_new =
+    "G4sPHENIXCells_1000pi24GeV.root_qa.root", const char * qa_file_name_ref =
+    "G4sPHENIXCells_100e24GeV.root_qa.root")
+{
+
+  SetOKStyle();
+  gStyle->SetOptStat(0);
+  gStyle->SetOptFit(1111);
+  TVirtualFitter::SetDefaultFitter("Minuit2");
+
+  TFile * qa_file_new = new TFile(qa_file_name_new);
+  assert(qa_file_new->IsOpen());
+
+  TFile * qa_file_ref = NULL;
+  if (qa_file_name_ref)
+    {
+      qa_file_ref = new TFile(qa_file_name_ref);
+      assert(qa_file_ref->IsOpen());
+    }
+
+  TCanvas *c1 = new TCanvas("QA_Draw_HCALIN_G4Hit", "QA_Draw_HCALIN_G4Hit", 1800,
+      900);
+  c1->Divide(4, 2);
+  int idx = 1;
+  TPad * p;
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogz();
+
+  TH2F * h_QAG4Sim_HCALIN_G4Hit_XY = (TH2F *) qa_file_new->GetObjectChecked(
+      "h_QAG4Sim_HCALIN_G4Hit_XY", "TH2F");
+  assert(h_QAG4Sim_HCALIN_G4Hit_XY);
+  h_QAG4Sim_HCALIN_G4Hit_XY->GetYaxis()->SetTitleOffset(1.5);
+  h_QAG4Sim_HCALIN_G4Hit_XY->Draw("COLZ");
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogz();
+
+  TH2F * h_QAG4Sim_HCALIN_G4Hit_RZ = (TH2F *) qa_file_new->GetObjectChecked(
+      "h_QAG4Sim_HCALIN_G4Hit_RZ", "TH2F");
+  assert(h_QAG4Sim_HCALIN_G4Hit_RZ);
+  h_QAG4Sim_HCALIN_G4Hit_RZ->GetYaxis()->SetTitleOffset(1.5);
+  h_QAG4Sim_HCALIN_G4Hit_RZ->Draw("COLZ");
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+//  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection->ProjectionX(
+              "qa_file_new_h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection_px");
+
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection);
+
+          proj_ref = h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection->ProjectionX(
+              "qa_file_ref_h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection_px");
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+//      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection->ProjectionY(
+              "qa_file_new_h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection_py");
+
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection);
+
+          proj_ref = h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection->ProjectionY(
+              "qa_file_ref_h_QAG4Sim_HCALIN_G4Hit_LateralTruthProjection_py");
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+//      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogx();
+  p->SetLogy();
+
+    {
+
+      TH1F * h_new =
+          (TH1F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_HCALIN_G4Hit_HitTime", "TH1F");
+      assert(h_new);
+
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref =
+              (TH1F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_HCALIN_G4Hit_HitTime", "TH1F");
+          assert(h_ref);
+
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized energy per bin");
+//      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+
+    p = (TPad *) c1->cd(idx++);
+    c1->Update();
+//    p->SetLogx();
+//    p->SetLogy();
+
+      {
+
+        TH1F * h_new =
+            (TH1F *) qa_file_new->GetObjectChecked(
+                "h_QAG4Sim_HCALIN_G4Hit_FractionTruthEnergy", "TH1F");
+        assert(h_new);
+
+        h_new->Rebin(20);
+        h_new->Sumw2();
+        h_new->Scale(1. / h_new->GetSum());
+
+        TH1F * h_ref = NULL;
+        if (qa_file_ref)
+          {
+            TH1F * h_ref =
+                (TH1F *) qa_file_ref->GetObjectChecked(
+                    "h_QAG4Sim_HCALIN_G4Hit_FractionTruthEnergy", "TH1F");
+            assert(h_ref);
+
+            h_ref->Rebin(20);
+            h_ref->Scale(1. / h_ref->GetSum());
+          }
+
+        h_new->GetYaxis()->SetTitleOffset(1.5);
+        h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+  //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+        DrawReference(h_new, h_ref);
+      }
+
+    p = (TPad *) c1->cd(idx++);
+    c1->Update();
+    //  p->SetLogz();
+
+      {
+
+        TH1F * h_new =
+            (TH1F *) qa_file_new->GetObjectChecked(
+                "h_QAG4Sim_HCALIN_G4Hit_VSF", "TH1F");
+        assert(h_new);
+
+//        h_new->Rebin(2);
+//        h_new->Sumw2();
+        h_new->Scale(1. / h_new->GetSum());
+
+        TH1F * h_ref = NULL;
+        if (qa_file_ref)
+          {
+            TH1F * h_ref =
+                (TH1F *) qa_file_ref->GetObjectChecked(
+                    "h_QAG4Sim_HCALIN_G4Hit_VSF", "TH1F");
+            assert(h_ref);
+
+            h_ref->Scale(1. / h_ref->GetSum());
+          }
+
+        h_new->GetYaxis()->SetTitleOffset(1.5);
+        h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+        h_new->GetXaxis()->SetRangeUser(-0, .2);
+
+        DrawReference(h_new, h_ref);
+      }
+
+      p = (TPad *) c1->cd(idx++);
+      c1->Update();
+      //  p->SetLogz();
+
+        {
+
+          TH1F * h_new =
+              (TH1F *) qa_file_new->GetObjectChecked(
+                  "h_QAG4Sim_HCALIN_G4Hit_FractionEMVisibleEnergy", "TH1F");
+          assert(h_new);
+
+          h_new->Rebin(4);
+          h_new->Sumw2();
+          h_new->Scale(1. / h_new->GetSum());
+
+          TH1F * h_ref = NULL;
+          if (qa_file_ref)
+            {
+              TH1F * h_ref =
+                  (TH1F *) qa_file_ref->GetObjectChecked(
+                      "h_QAG4Sim_HCALIN_G4Hit_FractionEMVisibleEnergy", "TH1F");
+              assert(h_ref);
+
+              h_ref->Rebin(4);
+              h_ref->Scale(1. / h_ref->GetSum());
+            }
+
+          h_new->GetYaxis()->SetTitleOffset(1.5);
+          h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+//          h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+          DrawReference(h_new, h_ref);
+        }
+
+
+  SaveCanvas(c1, TString(qa_file_name_new) + TString(c1->GetName()), true);
+}
+
+void
+DrawReference(TH1 * hnew, TH1 * href)
+{
+
+  hnew->SetLineColor(kBlue + 3);
+  hnew->SetMarkerColor(kBlue + 3);
+  hnew->SetLineWidth(2);
+  hnew->SetMarkerStyle(kFullCircle);
+  hnew->SetMarkerSize(1);
+
+  href->SetLineColor(kGreen + 1);
+  href->SetFillColor(kGreen + 1);
+  href->SetLineStyle(0);
+  href->SetMarkerColor(kGreen + 1);
+  href->SetLineWidth(0);
+  href->SetMarkerStyle(kDot);
+  href->SetMarkerSize(0);
+
+  hnew->Draw(); // set scale
+
+  if (href)
+    {
+      href->Draw("HIST same");
+      hnew->Draw("same"); // over lay data points
+    }
+}

--- a/offline/QA/macros/QA_Draw_HCALIN_TowerCluster.C
+++ b/offline/QA/macros/QA_Draw_HCALIN_TowerCluster.C
@@ -1,0 +1,334 @@
+// $Id: $
+
+/*!
+ * \file QA_Draw_HCALIN_TowerCluster.C
+ * \brief
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include <cmath>
+#include <TFile.h>
+#include <TString.h>
+#include <TLine.h>
+#include <TTree.h>
+#include <cassert>
+
+//some common style files
+#include "SaveCanvas.C"
+#include "SetOKStyle.C"
+using namespace std;
+
+void
+QA_Draw_HCALIN_TowerCluster(const char * qa_file_name_new =
+    "G4sPHENIXCells_1000pi24GeV.root_qa.root", const char * qa_file_name_ref =
+    "G4sPHENIXCells_100e24GeV.root_qa.root")
+{
+
+  SetOKStyle();
+  gStyle->SetOptStat(0);
+  gStyle->SetOptFit(1111);
+  TVirtualFitter::SetDefaultFitter("Minuit2");
+
+  TFile * qa_file_new = new TFile(qa_file_name_new);
+  assert(qa_file_new->IsOpen());
+
+  TFile * qa_file_ref = NULL;
+  if (qa_file_name_ref)
+    {
+      qa_file_ref = new TFile(qa_file_name_ref);
+      assert(qa_file_ref->IsOpen());
+    }
+
+  TCanvas *c1 = new TCanvas("QA_Draw_HCALIN_G4Hit", "QA_Draw_HCALIN_G4Hit",
+      1800, 900);
+  c1->Divide(4, 2);
+  int idx = 1;
+  TPad * p;
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogx();
+  p->SetLogy();
+
+    {
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALIN_Tower_1x1", "TH1F");
+      assert(h_new);
+
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_HCALIN_Tower_1x1", "TH1F");
+          assert(h_ref);
+
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized tower count per bin");
+//      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogx();
+  p->SetLogy();
+
+    {
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALIN_Tower_3x3", "TH1F");
+      assert(h_new);
+
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_HCALIN_Tower_3x3", "TH1F");
+          assert(h_ref);
+
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized tower count per bin");
+      //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //    p->SetLogx();
+  p->SetLogy();
+
+    {
+
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALIN_Tower_1x1_max", "TH1F");
+      assert(h_new);
+
+      h_new->Rebin(40);
+      h_new->Sumw2();
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_HCALIN_Tower_1x1_max", "TH1F");
+          assert(h_ref);
+
+          h_ref->Rebin(40);
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+      //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //    p->SetLogx();
+  p->SetLogy();
+
+    {
+
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALIN_Tower_4x4_max", "TH1F");
+      assert(h_new);
+
+      h_new->Rebin(40);
+      h_new->Sumw2();
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_HCALIN_Tower_4x4_max", "TH1F");
+          assert(h_ref);
+
+          h_ref->Rebin(40);
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+      //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogz();
+
+  TH2F * h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection =
+      (TH2F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection", "TH2F");
+  assert(h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection);
+  h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection->GetYaxis()->SetTitleOffset(
+      1.5);
+//  h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection->GetXaxis()->SetRangeUser(-5,
+//      5);
+//  h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection->GetYaxis()->SetRangeUser(-5,
+//      5);
+  h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection->Draw("COLZ");
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection->ProjectionX(
+              "qa_file_new_h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection_px");
+      proj_new->Rebin(4);
+
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection);
+
+          proj_ref =
+              h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection->ProjectionX(
+                  "qa_file_ref_h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection_px");
+          proj_ref->Rebin(4);
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitleOffset(1.);
+      proj_new->GetXaxis()->SetTitleOffset(1.);
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+//      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection->ProjectionY(
+              "qa_file_new_h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection_py");
+
+      proj_new->Rebin(4);
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection);
+
+          proj_ref =
+              h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection->ProjectionY(
+                  "qa_file_ref_h_QAG4Sim_HCALIN_Cluster_LateralTruthProjection_py");
+          proj_ref->Rebin(4);
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitleOffset(1.);
+      proj_new->GetXaxis()->SetTitleOffset(1.);
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+//      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALIN_Cluster_BestMatchERatio", "TH1F");
+      assert(h_new);
+
+      h_new->Rebin(2);
+      h_new->Sumw2();
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_HCALIN_Cluster_BestMatchERatio", "TH1F");
+          assert(h_ref);
+
+          h_ref->Rebin(2);
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+      //          h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  SaveCanvas(c1, TString(qa_file_name_new) + TString(c1->GetName()), true);
+}
+
+void
+DrawReference(TH1 * hnew, TH1 * href)
+{
+
+  hnew->SetLineColor(kBlue + 3);
+  hnew->SetMarkerColor(kBlue + 3);
+  hnew->SetLineWidth(2);
+  hnew->SetMarkerStyle(kFullCircle);
+  hnew->SetMarkerSize(1);
+
+  href->SetLineColor(kGreen + 1);
+  href->SetFillColor(kGreen + 1);
+  href->SetLineStyle(0);
+  href->SetMarkerColor(kGreen + 1);
+  href->SetLineWidth(0);
+  href->SetMarkerStyle(kDot);
+  href->SetMarkerSize(0);
+
+  hnew->Draw(); // set scale
+
+  if (href)
+    {
+      href->Draw("HIST same");
+      hnew->Draw("same"); // over lay data points
+    }
+}

--- a/offline/QA/macros/QA_Draw_HCALIN_TowerCluster.C
+++ b/offline/QA/macros/QA_Draw_HCALIN_TowerCluster.C
@@ -132,7 +132,7 @@ QA_Draw_HCALIN_TowerCluster(const char * qa_file_name_new =
         }
 
       h_new->GetYaxis()->SetTitleOffset(1.5);
-      h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+      h_new->GetYaxis()->SetTitle("Probability per bin");
       //      h_new->GetXaxis()->SetRangeUser(-0, .1);
 
       DrawReference(h_new, h_ref);
@@ -165,7 +165,7 @@ QA_Draw_HCALIN_TowerCluster(const char * qa_file_name_new =
         }
 
       h_new->GetYaxis()->SetTitleOffset(1.5);
-      h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+      h_new->GetYaxis()->SetTitle("Probability per bin");
       //      h_new->GetXaxis()->SetRangeUser(-0, .1);
 
       DrawReference(h_new, h_ref);
@@ -297,7 +297,7 @@ QA_Draw_HCALIN_TowerCluster(const char * qa_file_name_new =
         }
 
       h_new->GetYaxis()->SetTitleOffset(1.5);
-      h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+      h_new->GetYaxis()->SetTitle("Probability per bin");
       //          h_new->GetXaxis()->SetRangeUser(-0, .1);
 
       DrawReference(h_new, h_ref);

--- a/offline/QA/macros/QA_Draw_HCALIN_TowerCluster.C
+++ b/offline/QA/macros/QA_Draw_HCALIN_TowerCluster.C
@@ -41,7 +41,7 @@ QA_Draw_HCALIN_TowerCluster(const char * qa_file_name_new =
       assert(qa_file_ref->IsOpen());
     }
 
-  TCanvas *c1 = new TCanvas("QA_Draw_HCALIN_G4Hit", "QA_Draw_HCALIN_G4Hit",
+  TCanvas *c1 = new TCanvas("QA_Draw_HCALIN_TowerCluster", "QA_Draw_HCALIN_TowerCluster",
       1800, 900);
   c1->Divide(4, 2);
   int idx = 1;

--- a/offline/QA/macros/QA_Draw_HCALOUT_G4Hit.C
+++ b/offline/QA/macros/QA_Draw_HCALOUT_G4Hit.C
@@ -177,7 +177,7 @@ QA_Draw_HCALOUT_G4Hit(const char * qa_file_name_new =
     p = (TPad *) c1->cd(idx++);
     c1->Update();
 //    p->SetLogx();
-//    p->SetLogy();
+    p->SetLogy();
 
       {
 
@@ -203,7 +203,7 @@ QA_Draw_HCALOUT_G4Hit(const char * qa_file_name_new =
           }
 
         h_new->GetYaxis()->SetTitleOffset(1.5);
-        h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+        h_new->GetYaxis()->SetTitle("Probability per bin");
   //      h_new->GetXaxis()->SetRangeUser(-0, .1);
 
         DrawReference(h_new, h_ref);
@@ -236,7 +236,7 @@ QA_Draw_HCALOUT_G4Hit(const char * qa_file_name_new =
           }
 
         h_new->GetYaxis()->SetTitleOffset(1.5);
-        h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+        h_new->GetYaxis()->SetTitle("Probability per bin");
         h_new->GetXaxis()->SetRangeUser(-0, .1);
 
         DrawReference(h_new, h_ref);
@@ -270,7 +270,7 @@ QA_Draw_HCALOUT_G4Hit(const char * qa_file_name_new =
             }
 
           h_new->GetYaxis()->SetTitleOffset(1.5);
-          h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+          h_new->GetYaxis()->SetTitle("Probability per bin");
 //          h_new->GetXaxis()->SetRangeUser(-0, .1);
 
           DrawReference(h_new, h_ref);

--- a/offline/QA/macros/QA_Draw_HCALOUT_G4Hit.C
+++ b/offline/QA/macros/QA_Draw_HCALOUT_G4Hit.C
@@ -1,0 +1,308 @@
+// $Id: $
+
+/*!
+ * \file QA_Draw_HCALOUT_G4Hit.C
+ * \brief
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include <cmath>
+#include <TFile.h>
+#include <TString.h>
+#include <TLine.h>
+#include <TTree.h>
+#include <cassert>
+
+//some common style files
+#include "SaveCanvas.C"
+#include "SetOKStyle.C"
+using namespace std;
+
+void
+QA_Draw_HCALOUT_G4Hit(const char * qa_file_name_new =
+    "G4sPHENIXCells_1000pi24GeV.root_qa.root", const char * qa_file_name_ref =
+    "G4sPHENIXCells_100e24GeV.root_qa.root")
+{
+
+  SetOKStyle();
+  gStyle->SetOptStat(0);
+  gStyle->SetOptFit(1111);
+  TVirtualFitter::SetDefaultFitter("Minuit2");
+
+  TFile * qa_file_new = new TFile(qa_file_name_new);
+  assert(qa_file_new->IsOpen());
+
+  TFile * qa_file_ref = NULL;
+  if (qa_file_name_ref)
+    {
+      qa_file_ref = new TFile(qa_file_name_ref);
+      assert(qa_file_ref->IsOpen());
+    }
+
+  TCanvas *c1 = new TCanvas("QA_Draw_HCALOUT_G4Hit", "QA_Draw_HCALOUT_G4Hit", 1800,
+      900);
+  c1->Divide(4, 2);
+  int idx = 1;
+  TPad * p;
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogz();
+
+  TH2F * h_QAG4Sim_HCALOUT_G4Hit_XY = (TH2F *) qa_file_new->GetObjectChecked(
+      "h_QAG4Sim_HCALOUT_G4Hit_XY", "TH2F");
+  assert(h_QAG4Sim_HCALOUT_G4Hit_XY);
+  h_QAG4Sim_HCALOUT_G4Hit_XY->GetYaxis()->SetTitleOffset(1.5);
+  h_QAG4Sim_HCALOUT_G4Hit_XY->Draw("COLZ");
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogz();
+
+  TH2F * h_QAG4Sim_HCALOUT_G4Hit_RZ = (TH2F *) qa_file_new->GetObjectChecked(
+      "h_QAG4Sim_HCALOUT_G4Hit_RZ", "TH2F");
+  assert(h_QAG4Sim_HCALOUT_G4Hit_RZ);
+  h_QAG4Sim_HCALOUT_G4Hit_RZ->GetYaxis()->SetTitleOffset(1.5);
+  h_QAG4Sim_HCALOUT_G4Hit_RZ->Draw("COLZ");
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+//  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection->ProjectionX(
+              "qa_file_new_h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection_px");
+
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection);
+
+          proj_ref = h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection->ProjectionX(
+              "qa_file_ref_h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection_px");
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+//      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection->ProjectionY(
+              "qa_file_new_h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection_py");
+
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection);
+
+          proj_ref = h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection->ProjectionY(
+              "qa_file_ref_h_QAG4Sim_HCALOUT_G4Hit_LateralTruthProjection_py");
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+//      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogx();
+  p->SetLogy();
+
+    {
+
+      TH1F * h_new =
+          (TH1F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_HCALOUT_G4Hit_HitTime", "TH1F");
+      assert(h_new);
+
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref =
+              (TH1F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_HCALOUT_G4Hit_HitTime", "TH1F");
+          assert(h_ref);
+
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized energy per bin");
+//      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+
+    p = (TPad *) c1->cd(idx++);
+    c1->Update();
+//    p->SetLogx();
+//    p->SetLogy();
+
+      {
+
+        TH1F * h_new =
+            (TH1F *) qa_file_new->GetObjectChecked(
+                "h_QAG4Sim_HCALOUT_G4Hit_FractionTruthEnergy", "TH1F");
+        assert(h_new);
+
+        h_new->Rebin(20);
+        h_new->Sumw2();
+        h_new->Scale(1. / h_new->GetSum());
+
+        TH1F * h_ref = NULL;
+        if (qa_file_ref)
+          {
+            TH1F * h_ref =
+                (TH1F *) qa_file_ref->GetObjectChecked(
+                    "h_QAG4Sim_HCALOUT_G4Hit_FractionTruthEnergy", "TH1F");
+            assert(h_ref);
+
+            h_ref->Rebin(20);
+            h_ref->Scale(1. / h_ref->GetSum());
+          }
+
+        h_new->GetYaxis()->SetTitleOffset(1.5);
+        h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+  //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+        DrawReference(h_new, h_ref);
+      }
+
+    p = (TPad *) c1->cd(idx++);
+    c1->Update();
+    //  p->SetLogz();
+
+      {
+
+        TH1F * h_new =
+            (TH1F *) qa_file_new->GetObjectChecked(
+                "h_QAG4Sim_HCALOUT_G4Hit_VSF", "TH1F");
+        assert(h_new);
+
+//        h_new->Rebin(2);
+//        h_new->Sumw2();
+        h_new->Scale(1. / h_new->GetSum());
+
+        TH1F * h_ref = NULL;
+        if (qa_file_ref)
+          {
+            TH1F * h_ref =
+                (TH1F *) qa_file_ref->GetObjectChecked(
+                    "h_QAG4Sim_HCALOUT_G4Hit_VSF", "TH1F");
+            assert(h_ref);
+
+            h_ref->Scale(1. / h_ref->GetSum());
+          }
+
+        h_new->GetYaxis()->SetTitleOffset(1.5);
+        h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+        h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+        DrawReference(h_new, h_ref);
+      }
+
+      p = (TPad *) c1->cd(idx++);
+      c1->Update();
+      //  p->SetLogz();
+
+        {
+
+          TH1F * h_new =
+              (TH1F *) qa_file_new->GetObjectChecked(
+                  "h_QAG4Sim_HCALOUT_G4Hit_FractionEMVisibleEnergy", "TH1F");
+          assert(h_new);
+
+          h_new->Rebin(4);
+          h_new->Sumw2();
+          h_new->Scale(1. / h_new->GetSum());
+
+          TH1F * h_ref = NULL;
+          if (qa_file_ref)
+            {
+              TH1F * h_ref =
+                  (TH1F *) qa_file_ref->GetObjectChecked(
+                      "h_QAG4Sim_HCALOUT_G4Hit_FractionEMVisibleEnergy", "TH1F");
+              assert(h_ref);
+
+              h_ref->Rebin(4);
+              h_ref->Scale(1. / h_ref->GetSum());
+            }
+
+          h_new->GetYaxis()->SetTitleOffset(1.5);
+          h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+//          h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+          DrawReference(h_new, h_ref);
+        }
+
+
+  SaveCanvas(c1, TString(qa_file_name_new) + TString(c1->GetName()), true);
+}
+
+void
+DrawReference(TH1 * hnew, TH1 * href)
+{
+
+  hnew->SetLineColor(kBlue + 3);
+  hnew->SetMarkerColor(kBlue + 3);
+  hnew->SetLineWidth(2);
+  hnew->SetMarkerStyle(kFullCircle);
+  hnew->SetMarkerSize(1);
+
+  href->SetLineColor(kGreen + 1);
+  href->SetFillColor(kGreen + 1);
+  href->SetLineStyle(0);
+  href->SetMarkerColor(kGreen + 1);
+  href->SetLineWidth(0);
+  href->SetMarkerStyle(kDot);
+  href->SetMarkerSize(0);
+
+  hnew->Draw(); // set scale
+
+  if (href)
+    {
+      href->Draw("HIST same");
+      hnew->Draw("same"); // over lay data points
+    }
+}

--- a/offline/QA/macros/QA_Draw_HCALOUT_TowerCluster.C
+++ b/offline/QA/macros/QA_Draw_HCALOUT_TowerCluster.C
@@ -1,0 +1,334 @@
+// $Id: $
+
+/*!
+ * \file QA_Draw_HCALOUT_TowerCluster.C
+ * \brief
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include <cmath>
+#include <TFile.h>
+#include <TString.h>
+#include <TLine.h>
+#include <TTree.h>
+#include <cassert>
+
+//some common style files
+#include "SaveCanvas.C"
+#include "SetOKStyle.C"
+using namespace std;
+
+void
+QA_Draw_HCALOUT_TowerCluster(const char * qa_file_name_new =
+    "G4sPHENIXCells_1000pi24GeV.root_qa.root", const char * qa_file_name_ref =
+    "G4sPHENIXCells_100e24GeV.root_qa.root")
+{
+
+  SetOKStyle();
+  gStyle->SetOptStat(0);
+  gStyle->SetOptFit(1111);
+  TVirtualFitter::SetDefaultFitter("Minuit2");
+
+  TFile * qa_file_new = new TFile(qa_file_name_new);
+  assert(qa_file_new->IsOpen());
+
+  TFile * qa_file_ref = NULL;
+  if (qa_file_name_ref)
+    {
+      qa_file_ref = new TFile(qa_file_name_ref);
+      assert(qa_file_ref->IsOpen());
+    }
+
+  TCanvas *c1 = new TCanvas("QA_Draw_HCALOUT_G4Hit", "QA_Draw_HCALOUT_G4Hit",
+      1800, 900);
+  c1->Divide(4, 2);
+  int idx = 1;
+  TPad * p;
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogx();
+  p->SetLogy();
+
+    {
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALOUT_Tower_1x1", "TH1F");
+      assert(h_new);
+
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_HCALOUT_Tower_1x1", "TH1F");
+          assert(h_ref);
+
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized tower count per bin");
+//      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogx();
+  p->SetLogy();
+
+    {
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALOUT_Tower_3x3", "TH1F");
+      assert(h_new);
+
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_HCALOUT_Tower_3x3", "TH1F");
+          assert(h_ref);
+
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized tower count per bin");
+      //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //    p->SetLogx();
+  p->SetLogy();
+
+    {
+
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALOUT_Tower_1x1_max", "TH1F");
+      assert(h_new);
+
+      h_new->Rebin(40);
+      h_new->Sumw2();
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_HCALOUT_Tower_1x1_max", "TH1F");
+          assert(h_ref);
+
+          h_ref->Rebin(40);
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+      //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //    p->SetLogx();
+  p->SetLogy();
+
+    {
+
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALOUT_Tower_4x4_max", "TH1F");
+      assert(h_new);
+
+      h_new->Rebin(40);
+      h_new->Sumw2();
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_HCALOUT_Tower_4x4_max", "TH1F");
+          assert(h_ref);
+
+          h_ref->Rebin(40);
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+      //      h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  p->SetLogz();
+
+  TH2F * h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection =
+      (TH2F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection", "TH2F");
+  assert(h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection);
+  h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection->GetYaxis()->SetTitleOffset(
+      1.5);
+//  h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection->GetXaxis()->SetRangeUser(-5,
+//      5);
+//  h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection->GetYaxis()->SetRangeUser(-5,
+//      5);
+  h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection->Draw("COLZ");
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection->ProjectionX(
+              "qa_file_new_h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection_px");
+      proj_new->Rebin(4);
+
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection);
+
+          proj_ref =
+              h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection->ProjectionX(
+                  "qa_file_ref_h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection_px");
+          proj_ref->Rebin(4);
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitleOffset(1.);
+      proj_new->GetXaxis()->SetTitleOffset(1.);
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+//      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH2F * h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection =
+          (TH2F *) qa_file_new->GetObjectChecked(
+              "h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection", "TH2F");
+      assert(h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection);
+
+      TH1D * proj_new =
+          h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection->ProjectionY(
+              "qa_file_new_h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection_py");
+
+      proj_new->Rebin(4);
+      proj_new->Scale(1. / proj_new->GetSum());
+
+      TH1D * proj_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH2F * h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection =
+              (TH2F *) qa_file_ref->GetObjectChecked(
+                  "h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection", "TH2F");
+          assert(h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection);
+
+          proj_ref =
+              h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection->ProjectionY(
+                  "qa_file_ref_h_QAG4Sim_HCALOUT_Cluster_LateralTruthProjection_py");
+          proj_ref->Rebin(4);
+          proj_ref->Scale(1. / proj_ref->GetSum());
+
+        }
+
+      proj_new->GetYaxis()->SetTitleOffset(1.);
+      proj_new->GetXaxis()->SetTitleOffset(1.);
+      proj_new->GetYaxis()->SetTitle("Normalized energy distribution");
+//      proj_new->GetXaxis()->SetRangeUser(-10, 10);
+
+      DrawReference(proj_new, proj_ref);
+    }
+
+  p = (TPad *) c1->cd(idx++);
+  c1->Update();
+  //  p->SetLogz();
+
+    {
+
+      TH1F * h_new = (TH1F *) qa_file_new->GetObjectChecked(
+          "h_QAG4Sim_HCALOUT_Cluster_BestMatchERatio", "TH1F");
+      assert(h_new);
+
+      h_new->Rebin(2);
+      h_new->Sumw2();
+      h_new->Scale(1. / h_new->GetSum());
+
+      TH1F * h_ref = NULL;
+      if (qa_file_ref)
+        {
+          TH1F * h_ref = (TH1F *) qa_file_ref->GetObjectChecked(
+              "h_QAG4Sim_HCALOUT_Cluster_BestMatchERatio", "TH1F");
+          assert(h_ref);
+
+          h_ref->Rebin(2);
+          h_ref->Scale(1. / h_ref->GetSum());
+        }
+
+      h_new->GetYaxis()->SetTitleOffset(1.5);
+      h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+      //          h_new->GetXaxis()->SetRangeUser(-0, .1);
+
+      DrawReference(h_new, h_ref);
+    }
+
+  SaveCanvas(c1, TString(qa_file_name_new) + TString(c1->GetName()), true);
+}
+
+void
+DrawReference(TH1 * hnew, TH1 * href)
+{
+
+  hnew->SetLineColor(kBlue + 3);
+  hnew->SetMarkerColor(kBlue + 3);
+  hnew->SetLineWidth(2);
+  hnew->SetMarkerStyle(kFullCircle);
+  hnew->SetMarkerSize(1);
+
+  href->SetLineColor(kGreen + 1);
+  href->SetFillColor(kGreen + 1);
+  href->SetLineStyle(0);
+  href->SetMarkerColor(kGreen + 1);
+  href->SetLineWidth(0);
+  href->SetMarkerStyle(kDot);
+  href->SetMarkerSize(0);
+
+  hnew->Draw(); // set scale
+
+  if (href)
+    {
+      href->Draw("HIST same");
+      hnew->Draw("same"); // over lay data points
+    }
+}

--- a/offline/QA/macros/QA_Draw_HCALOUT_TowerCluster.C
+++ b/offline/QA/macros/QA_Draw_HCALOUT_TowerCluster.C
@@ -41,7 +41,7 @@ QA_Draw_HCALOUT_TowerCluster(const char * qa_file_name_new =
       assert(qa_file_ref->IsOpen());
     }
 
-  TCanvas *c1 = new TCanvas("QA_Draw_HCALOUT_G4Hit", "QA_Draw_HCALOUT_G4Hit",
+  TCanvas *c1 = new TCanvas("QA_Draw_HCALOUT_", "QA_Draw_HCALOUT_",
       1800, 900);
   c1->Divide(4, 2);
   int idx = 1;

--- a/offline/QA/macros/QA_Draw_HCALOUT_TowerCluster.C
+++ b/offline/QA/macros/QA_Draw_HCALOUT_TowerCluster.C
@@ -132,7 +132,7 @@ QA_Draw_HCALOUT_TowerCluster(const char * qa_file_name_new =
         }
 
       h_new->GetYaxis()->SetTitleOffset(1.5);
-      h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+      h_new->GetYaxis()->SetTitle("Probability per bin");
       //      h_new->GetXaxis()->SetRangeUser(-0, .1);
 
       DrawReference(h_new, h_ref);
@@ -165,7 +165,7 @@ QA_Draw_HCALOUT_TowerCluster(const char * qa_file_name_new =
         }
 
       h_new->GetYaxis()->SetTitleOffset(1.5);
-      h_new->GetYaxis()->SetTitle("Normalized probability per bin");
+      h_new->GetYaxis()->SetTitle("Probability per bin");
       //      h_new->GetXaxis()->SetRangeUser(-0, .1);
 
       DrawReference(h_new, h_ref);
@@ -297,7 +297,7 @@ QA_Draw_HCALOUT_TowerCluster(const char * qa_file_name_new =
         }
 
       h_new->GetYaxis()->SetTitleOffset(1.5);
-      h_new->GetYaxis()->SetTitle("Normalized Probability per bin");
+      h_new->GetYaxis()->SetTitle("Probability per bin");
       //          h_new->GetXaxis()->SetRangeUser(-0, .1);
 
       DrawReference(h_new, h_ref);

--- a/offline/QA/macros/SaveCanvas.C
+++ b/offline/QA/macros/SaveCanvas.C
@@ -1,0 +1,145 @@
+// $Id: $
+
+/*!
+ * \file SaveCanvas.C
+ * \brief Save canvas as png, eps, cxx, root, etc.
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef SaveCanvas_C
+
+#define SaveCanvas_C
+
+#include <TList.h>
+#include <TClass.h>
+#include <TCanvas.h>
+#include <TPad.h>
+#include <TString.h>
+#include <TDirectory.h>
+#include <TFile.h>
+#include <TStyle.h>
+#include <TObject.h>
+#include <TH1F.h>
+
+#include <iostream>
+
+using namespace std;
+
+//! Service function to SaveCanvas()
+void
+SavePad(TPad * p)
+{
+  if (!p)
+    return;
+
+  TList * l = p->GetListOfPrimitives();
+//  l->Print();
+
+  TIter next(l);
+  TObject *obj = NULL;
+  while ((obj = next()))
+    {
+
+      if (obj->IsA()->GetBaseClassOffset(TClass::GetClass("TPad")) >= 0)
+        {
+          if ((TPad *) obj != p)
+            SavePad((TPad *) obj);
+        }
+      else if (obj->IsA()->GetBaseClassOffset(TClass::GetClass("TH1")) >= 0)
+        {
+          cout << "Save TH1 " << obj->GetName() << endl;
+          obj->Clone()->Write(obj->GetName(), TObject::kOverwrite);
+        }
+      else if (obj->IsA()->GetBaseClassOffset(TClass::GetClass("TF1")) >= 0)
+        {
+          cout << "Save TF1 " << obj->GetName() << endl;
+          obj->Clone()->Write(obj->GetName(), TObject::kOverwrite);
+        }
+      else if (obj->IsA()->GetBaseClassOffset(TClass::GetClass("TGraph")) >= 0)
+        {
+          cout << "Save TGraph " << obj->GetName() << endl;
+          obj->Clone()->Write(obj->GetName(), TObject::kOverwrite);
+        }
+    }
+}
+
+//! Save canvas to multiple formats
+/*!
+ *  @param[in] c    pointer to the canvas
+ *  @param[in] name Base of the file name. The default is the name of the cavas
+ *  @param[in] bEPS true = save .eps and .pdf format too.
+ */
+void
+SaveCanvas(TCanvas * c, TString name = "", Bool_t bEPS = kTRUE)
+{
+  if (name.Length() == 0)
+    name = c->GetName();
+
+  c->Print(name + ".png");
+
+  TDirectory * oldd = gDirectory;
+
+  TString rootfilename;
+
+  c->Print(rootfilename = name + ".root");
+
+  TFile f(rootfilename, "update");
+
+  SavePad(c);
+
+  f.Close();
+
+  oldd->cd();
+
+  if (bEPS)
+    {
+//      c->Print(name + ".pdf");
+
+      float x = 20;
+      float y = 20;
+      gStyle->GetPaperSize(x, y);
+
+      gStyle->SetPaperSize(c->GetWindowWidth() / 72 * 2.54,
+          c->GetWindowHeight() / 72 * 2.54);
+//      c->Print(name + ".eps");
+      c->Print(name + ".svg");
+      gSystem->Exec("rsvg-convert -f pdf -o "+name + ".pdf " + name + ".svg");
+
+      gStyle->SetPaperSize(x, y);
+    }
+  //      c->Print(name+".C");
+}
+
+//! example to use this SaveCanvas()
+/*!
+ *  Output:
+ *  The canvas data will be saved to RootFileName.root, as well as
+ *  RootFileName.png for presentation and RootFileName.eps for Latex
+ *
+ *  How to use RootFileName.root
+ *  open RootFileName.root with root.
+ *  It contains the canvas object "CanvasTest", which can be redraw with CanvasTest -> Draw()
+ *  It also contains a copy of the histograms and graphs data for use in root again, e.g.
+ *  root [3]  h1->GetBinContent(30)
+ *
+ */
+void
+example_save_canvas()
+{
+
+  TCanvas *c1 = new TCanvas("CanvasTest", "CanvasTest", 800, 900);
+
+  TH1F * h1 = new TH1F("h1", "histo from a gaussian", 100, -3, 3);
+  h1->FillRandom("gaus", 10000);
+
+  h1->Draw();
+
+  // single call to save c1 to file RootFileName.*
+  SaveCanvas(c1, "RootFileName");
+
+}
+
+#endif
+

--- a/offline/QA/macros/SetOKStyle.C
+++ b/offline/QA/macros/SetOKStyle.C
@@ -1,0 +1,100 @@
+void
+SetOKStyle()
+{
+  TStyle* OKStyle = new TStyle("OKStyle", "OK Default Style");
+
+  // Colors
+
+  //set the background color to white
+  OKStyle->SetFillColor(10);
+  OKStyle->SetFrameFillColor(kWhite);
+  OKStyle->SetFrameFillStyle(0);
+  OKStyle->SetFillStyle(0);
+  OKStyle->SetCanvasColor(kWhite);
+  OKStyle->SetPadColor(kWhite);
+  OKStyle->SetTitleFillColor(0);
+  OKStyle->SetStatColor(kWhite);
+
+  // Get rid of drop shadow on legends
+  // This doesn't seem to work.  Call SetBorderSize(1) directly on your TLegends
+  OKStyle->SetLegendBorderSize(1);
+
+  //don't put a colored frame around the plots
+  OKStyle->SetFrameBorderMode(0);
+  OKStyle->SetCanvasBorderMode(0);
+  OKStyle->SetPadBorderMode(0);
+
+  //use the primary color palette
+  OKStyle->SetPalette(1, 0);
+
+  //set the default line color for a histogram to be black
+  OKStyle->SetHistLineColor(kBlack);
+
+  //set the default line color for a fit function to be red
+  OKStyle->SetFuncColor(kBlue);
+
+  //make the axis labels black
+  OKStyle->SetLabelColor(kBlack, "xyz");
+
+  //set the default title color to be black
+  OKStyle->SetTitleColor(kBlack);
+
+  //set the margins
+  OKStyle->SetPadBottomMargin(0.15);
+  OKStyle->SetPadLeftMargin(0.1);
+  OKStyle->SetPadTopMargin(0.075);
+  OKStyle->SetPadRightMargin(0.1);
+
+  //set axis label and title text sizes
+  OKStyle->SetLabelSize(0.035, "xyz");
+  OKStyle->SetTitleSize(0.05, "xyz");
+  OKStyle->SetTitleOffset(0.9, "xyz");
+  OKStyle->SetStatFontSize(0.035);
+  OKStyle->SetTextSize(0.05);
+  OKStyle->SetTitleBorderSize(0);
+  OKStyle->SetTitleStyle(0);
+
+  OKStyle->SetLegendBorderSize(0);
+
+  //set line widths
+  OKStyle->SetHistLineWidth(1);
+  OKStyle->SetFrameLineWidth(2);
+  OKStyle->SetFuncWidth(2);
+
+  // Misc
+
+  //align the titles to be centered
+  //OKStyle->SetTextAlign(22);
+
+  //turn off xy grids
+  OKStyle->SetPadGridX(1);
+  OKStyle->SetPadGridY(1);
+
+  //set the tick mark style
+  OKStyle->SetPadTickX(1);
+  OKStyle->SetPadTickY(1);
+
+  //don't show the fit parameters in a box
+  OKStyle->SetOptFit(0);
+
+  //set the default stats shown
+  OKStyle->SetOptStat(1);
+
+  //marker settings
+// 	OKStyle->SetMarkerStyle(8);
+// 	OKStyle->SetMarkerSize(0.7);
+
+  // Fonts
+  OKStyle->SetStatFont(42);
+  OKStyle->SetLabelFont(42, "xyz");
+  OKStyle->SetTitleFont(42, "xyz");
+  OKStyle->SetTextFont(42);
+
+  // Set the paper size for output
+  OKStyle->SetPaperSize(TStyle::kUSLetter);
+
+  //done
+  OKStyle->cd();
+
+  cout << "Using Jin's Style" << endl;
+}

--- a/offline/QA/modules/Makefile.am
+++ b/offline/QA/modules/Makefile.am
@@ -1,0 +1,63 @@
+AUTOMAKE_OPTIONS = foreign
+
+INCLUDES = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -I`root-config --incdir`
+
+lib_LTLIBRARIES = \
+   libqa_modules.la
+
+AM_CXXFLAGS = -Wall -Werror -msse2
+
+libqa_modules_la_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib
+
+libqa_modules_la_LIBADD = \
+  -lfun4all \
+  -lphg4hit \
+  -lg4detectors_io \
+  -lg4hough_io \
+  -lg4hough \
+  -lcemc_io \
+  -lg4jets_io \
+  -lg4eval
+
+pkginclude_HEADERS = 
+
+#pkginclude_HEADERS = $(include_HEADERS)
+
+libqa_modules_la_SOURCES = \
+  QAG4SimulationCalorimeter.C \
+  QAG4SimulationCalorimeter_Dict.C \
+  QAHistManagerDef.C \
+  QAHistManagerDef_Dict.C
+
+# Rule for generating table CINT dictionaries.
+%_Dict.C: %.h %LinkDef.h
+	rootcint -f $@ -c $(DEFAULT_INCLUDES) $(INCLUDES) $^
+
+%_Dict.cpp: %.h %LinkDef.h
+	rootcint -f $@ -c $(DEFAULT_INCLUDES) $(INCLUDES) $^
+
+################################################
+# linking tests
+
+noinst_PROGRAMS = testexternals
+
+BUILT_SOURCES = \
+  testexternals.C
+
+testexternals_LDADD = \
+  libqa_modules.la
+
+testexternals.C:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f *Dict* testexternals.C

--- a/offline/QA/modules/QAG4SimulationCalorimeter.C
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.C
@@ -1,0 +1,594 @@
+#include "QAG4SimulationCalorimeter.h"
+
+#include <fun4all/SubsysReco.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/PHTFileServer.h>
+#include <phool/PHCompositeNode.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/getClass.h>
+
+#include <phool/PHCompositeNode.h>
+
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4VtxPoint.h>
+#include <g4main/PHG4Particle.h>
+
+//#include <g4hough/SvtxVertexMap.h>
+//#include <g4hough/PHG4HoughTransform.h>
+
+#include <g4cemc/RawTowerContainer.h>
+#include <g4cemc/RawTowerGeomContainer.h>
+#include <g4cemc/RawTower.h>
+#include <g4cemc/RawClusterContainer.h>
+#include <g4cemc/RawCluster.h>
+
+#include <g4eval/CaloEvalStack.h>
+#include <g4eval/CaloRawClusterEval.h>
+#include <g4eval/CaloRawTowerEval.h>
+#include <g4eval/CaloTruthEval.h>
+#include <g4eval/SvtxEvalStack.h>
+
+#include <TNtuple.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TVector3.h>
+#include <TLorentzVector.h>
+
+#include <exception>
+#include <stdexcept>
+#include <iostream>
+#include <vector>
+#include <set>
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+
+#include "QAHistManagerDef.h"
+
+using namespace std;
+
+QAG4SimulationCalorimeter::QAG4SimulationCalorimeter( QAG4SimulationCalorimeter::enu_flags flags) :
+    SubsysReco("QAG4SimulationCalorimeter"), _eval_stack(NULL),
+    _magfield(1.5),  _flags(flags), _ievent(0)
+{
+
+  verbosity = 1;
+
+  _hcalout_hit_container = NULL;
+  _hcalin_hit_container = NULL;
+  _cemc_hit_container = NULL;
+  _hcalout_abs_hit_container = NULL;
+  _hcalin_abs_hit_container = NULL;
+  _cemc_abs_hit_container = NULL;
+  _magnet_hit_container = NULL;
+  _bh_hit_container = NULL;
+  _bh_plus_hit_container = NULL;
+  _bh_minus_hit_container = NULL;
+  _cemc_electronics_hit_container = NULL;
+  _hcalin_spt_hit_container = NULL;
+  _svtx_hit_container = NULL;
+  _svtx_support_hit_container = NULL;
+
+}
+
+QAG4SimulationCalorimeter::~QAG4SimulationCalorimeter()
+{
+  if (_eval_stack)
+    {
+      delete _eval_stack;
+    }
+}
+
+int
+QAG4SimulationCalorimeter::InitRun(PHCompositeNode *topNode)
+{
+  _ievent = 0;
+
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *dstNode = static_cast<PHCompositeNode*>(iter.findFirst(
+      "PHCompositeNode", "DST"));
+  if (!dstNode)
+    {
+      std::cerr << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+      throw runtime_error(
+          "Failed to find DST node in EmcRawTowerBuilder::CreateNodes");
+    }
+
+  // get DST objects
+  _hcalout_hit_container = findNode::getClass<PHG4HitContainer>(topNode,
+      "G4HIT_HCALOUT");
+  _hcalin_hit_container = findNode::getClass<PHG4HitContainer>(topNode,
+      "G4HIT_HCALIN");
+
+  _cemc_hit_container = findNode::getClass<PHG4HitContainer>(topNode,
+      "G4HIT_CEMC");
+
+  _hcalout_abs_hit_container = findNode::getClass<PHG4HitContainer>(topNode,
+      "G4HIT_ABSORBER_HCALOUT");
+
+  _hcalin_abs_hit_container = findNode::getClass<PHG4HitContainer>(topNode,
+      "G4HIT_ABSORBER_HCALIN");
+
+  _cemc_abs_hit_container = findNode::getClass<PHG4HitContainer>(topNode,
+      "G4HIT_ABSORBER_CEMC");
+
+
+
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int
+QAG4SimulationCalorimeter::End(PHCompositeNode *topNode)
+{
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int
+QAG4SimulationCalorimeter::Init(PHCompositeNode *topNode)
+{
+
+  _ievent = 0;
+
+  if (flag(kProcessSF))
+    {
+      cout << "QAG4SimulationCalorimeter::Init - Process sampling fraction" << endl;
+      Init_SF(topNode);
+    }
+  if (flag(kProcessTower))
+    {
+      cout << "QAG4SimulationCalorimeter::Init - Process tower occupancies" << endl;
+      Init_Tower(topNode);
+    }
+  if (flag(kProcessMCPhoton))
+    {
+      cout << "QAG4SimulationCalorimeter::Init - Process trakcs" << endl;
+//      Init_MCPhoton(topNode);
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int
+QAG4SimulationCalorimeter::process_event(PHCompositeNode *topNode)
+{
+
+  if (verbosity > 2)
+    cout << "QAG4SimulationCalorimeter::process_event() entered" << endl;
+
+  if (_eval_stack)
+    _eval_stack->next_event(topNode);
+
+  if (flag(kProcessSF))
+    process_event_SF(topNode);
+  if (flag(kProcessTower))
+    process_event_Tower(topNode);
+//  if (flag(kProcessMCPhoton))
+//    process_event_MCPhoton(topNode);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+
+int
+QAG4SimulationCalorimeter::Init_SF(PHCompositeNode *topNode)
+{
+
+  Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_SF", //
+      "_h_CEMC_SF", 1000, 0, .2));
+  hm->registerHisto(new TH1F("EMCalAna_h_HCALIN_SF", //
+      "_h_HCALIN_SF", 1000, 0, .2));
+  hm->registerHisto(new TH1F("EMCalAna_h_HCALOUT_SF", //
+      "_h_HCALOUT_SF", 1000, 0, .2));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_VSF", //
+      "_h_CEMC_VSF", 1000, 0, .2));
+  hm->registerHisto(new TH1F("EMCalAna_h_HCALIN_VSF", //
+      "_h_HCALIN_VSF", 1000, 0, .2));
+  hm->registerHisto(new TH1F("EMCalAna_h_HCALOUT_VSF", //
+      "_h_HCALOUT_VSF", 1000, 0, .2));
+
+  hm->registerHisto(new TH2F("EMCalAna_h_CEMC_RZ", //
+      "EMCalAna_h_CEMC_RZ;Z (cm);R (cm)", 1200, -300, 300, 600, -000, 300));
+  hm->registerHisto(new TH2F("EMCalAna_h_HCALIN_RZ", //
+      "EMCalAna_h_HCALIN_RZ;Z (cm);R (cm)", 1200, -300, 300, 600, -000, 300));
+  hm->registerHisto(new TH2F("EMCalAna_h_HCALOUT_RZ", //
+      "EMCalAna_h_HCALOUT_RZ;Z (cm);R (cm)", 1200, -300, 300, 600, -000, 300));
+
+  hm->registerHisto(new TH2F("EMCalAna_h_CEMC_XY", //
+      "EMCalAna_h_CEMC_XY;X (cm);Y (cm)", 1200, -300, 300, 1200, -300, 300));
+  hm->registerHisto(new TH2F("EMCalAna_h_HCALIN_XY", //
+      "EMCalAna_h_HCALIN_XY;X (cm);Y (cm)", 1200, -300, 300, 1200, -300, 300));
+  hm->registerHisto(new TH2F("EMCalAna_h_HCALOUT_XY", //
+      "EMCalAna_h_HCALOUT_XY;X (cm);Y (cm)", 1200, -300, 300, 1200, -300, 300));
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int
+QAG4SimulationCalorimeter::process_event_SF(PHCompositeNode *topNode)
+{
+
+  if (verbosity > 2)
+    cout << "QAG4SimulationCalorimeter::process_event_SF() entered" << endl;
+
+  TH1F* h = NULL;
+
+  Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  double e_hcin = 0.0, e_hcout = 0.0, e_cemc = 0.0;
+  double ev_hcin = 0.0, ev_hcout = 0.0, ev_cemc = 0.0;
+  double ea_hcin = 0.0, ea_hcout = 0.0, ea_cemc = 0.0;
+
+  if (_hcalout_hit_container)
+    {
+      TH2F * hrz = (TH2F*) hm->getHisto("EMCalAna_h_HCALOUT_RZ");
+      assert(hrz);
+      TH2F * hxy = (TH2F*) hm->getHisto("EMCalAna_h_HCALOUT_XY");
+      assert(hxy);
+
+      PHG4HitContainer::ConstRange hcalout_hit_range =
+          _hcalout_hit_container->getHits();
+      for (PHG4HitContainer::ConstIterator hit_iter = hcalout_hit_range.first;
+          hit_iter != hcalout_hit_range.second; hit_iter++)
+        {
+
+          PHG4Hit *this_hit = hit_iter->second;
+          assert(this_hit);
+
+          e_hcout += this_hit->get_edep();
+          ev_hcout += this_hit->get_light_yield();
+
+          const TVector3 hit(this_hit->get_avg_x(), this_hit->get_avg_y(),
+              this_hit->get_avg_z());
+          hrz->Fill(hit.Z(), hit.Perp(), this_hit->get_light_yield());
+          hxy->Fill(hit.X(), hit.Y(), this_hit->get_light_yield());
+        }
+    }
+
+  if (_hcalin_hit_container)
+    {
+      TH2F * hrz = (TH2F*) hm->getHisto("EMCalAna_h_HCALIN_RZ");
+      assert(hrz);
+      TH2F * hxy = (TH2F*) hm->getHisto("EMCalAna_h_HCALIN_XY");
+      assert(hxy);
+
+      PHG4HitContainer::ConstRange hcalin_hit_range =
+          _hcalin_hit_container->getHits();
+      for (PHG4HitContainer::ConstIterator hit_iter = hcalin_hit_range.first;
+          hit_iter != hcalin_hit_range.second; hit_iter++)
+        {
+
+          PHG4Hit *this_hit = hit_iter->second;
+          assert(this_hit);
+
+          e_hcin += this_hit->get_edep();
+          ev_hcin += this_hit->get_light_yield();
+
+          const TVector3 hit(this_hit->get_avg_x(), this_hit->get_avg_y(),
+              this_hit->get_avg_z());
+          hrz->Fill(hit.Z(), hit.Perp(), this_hit->get_light_yield());
+          hxy->Fill(hit.X(), hit.Y(), this_hit->get_light_yield());
+
+        }
+    }
+
+  if (_cemc_hit_container)
+    {
+      TH2F * hrz = (TH2F*) hm->getHisto("EMCalAna_h_CEMC_RZ");
+      assert(hrz);
+      TH2F * hxy = (TH2F*) hm->getHisto("EMCalAna_h_CEMC_XY");
+      assert(hxy);
+
+      PHG4HitContainer::ConstRange cemc_hit_range =
+          _cemc_hit_container->getHits();
+      for (PHG4HitContainer::ConstIterator hit_iter = cemc_hit_range.first;
+          hit_iter != cemc_hit_range.second; hit_iter++)
+        {
+
+          PHG4Hit *this_hit = hit_iter->second;
+          assert(this_hit);
+
+          e_cemc += this_hit->get_edep();
+          ev_cemc += this_hit->get_light_yield();
+
+          const TVector3 hit(this_hit->get_avg_x(), this_hit->get_avg_y(),
+              this_hit->get_avg_z());
+          hrz->Fill(hit.Z(), hit.Perp(), this_hit->get_light_yield());
+          hxy->Fill(hit.X(), hit.Y(), this_hit->get_light_yield());
+        }
+    }
+
+  if (_hcalout_abs_hit_container)
+    {
+      PHG4HitContainer::ConstRange hcalout_abs_hit_range =
+          _hcalout_abs_hit_container->getHits();
+      for (PHG4HitContainer::ConstIterator hit_iter =
+          hcalout_abs_hit_range.first; hit_iter != hcalout_abs_hit_range.second;
+          hit_iter++)
+        {
+
+          PHG4Hit *this_hit = hit_iter->second;
+          assert(this_hit);
+
+          ea_hcout += this_hit->get_edep();
+
+        }
+    }
+
+  if (_hcalin_abs_hit_container)
+    {
+      PHG4HitContainer::ConstRange hcalin_abs_hit_range =
+          _hcalin_abs_hit_container->getHits();
+      for (PHG4HitContainer::ConstIterator hit_iter = hcalin_abs_hit_range.first;
+          hit_iter != hcalin_abs_hit_range.second; hit_iter++)
+        {
+
+          PHG4Hit *this_hit = hit_iter->second;
+          assert(this_hit);
+
+          ea_hcin += this_hit->get_edep();
+        }
+    }
+
+  if (_cemc_abs_hit_container)
+    {
+      PHG4HitContainer::ConstRange cemc_abs_hit_range =
+          _cemc_abs_hit_container->getHits();
+      for (PHG4HitContainer::ConstIterator hit_iter = cemc_abs_hit_range.first;
+          hit_iter != cemc_abs_hit_range.second; hit_iter++)
+        {
+
+          PHG4Hit *this_hit = hit_iter->second;
+          assert(this_hit);
+
+          ea_cemc += this_hit->get_edep();
+
+        }
+    }
+
+  h = (TH1F*) hm->getHisto("EMCalAna_h_CEMC_SF");
+  assert(h);
+  h->Fill(e_cemc / (e_cemc + ea_cemc) + 1e-9);
+  h = (TH1F*) hm->getHisto("EMCalAna_h_CEMC_VSF");
+  assert(h);
+  h->Fill(ev_cemc / (e_cemc + ea_cemc) + 1e-9);
+
+  h = (TH1F*) hm->getHisto("EMCalAna_h_HCALOUT_SF");
+  assert(h);
+  h->Fill(e_hcout / (e_hcout + ea_hcout) + 1e-9);
+  h = (TH1F*) hm->getHisto("EMCalAna_h_HCALOUT_VSF");
+  assert(h);
+  h->Fill(ev_hcout / (e_hcout + ea_hcout) + 1e-9);
+
+  h = (TH1F*) hm->getHisto("EMCalAna_h_HCALIN_SF");
+  assert(h);
+  h->Fill(e_hcin / (e_hcin + ea_hcin) + 1e-9);
+  h = (TH1F*) hm->getHisto("EMCalAna_h_HCALIN_VSF");
+  assert(h);
+  h->Fill(ev_hcin / (e_hcin + ea_hcin) + 1e-9);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int
+QAG4SimulationCalorimeter::Init_Tower(PHCompositeNode *topNode)
+{
+
+  Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_1x1", //
+      "h_CEMC_TOWER_1x1", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_1x1_max", //
+      "EMCalAna_h_CEMC_TOWER_1x1_max", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_1x1_max_trigger_ADC", //
+      "EMCalAna_h_CEMC_TOWER_1x1_max_trigger_ADC", 5000, 0, 50));
+
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_2x2", //
+      "h_CEMC_TOWER_2x2", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_2x2_max", //
+      "EMCalAna_h_CEMC_TOWER_2x2_max", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_2x2_max_trigger_ADC", //
+      "EMCalAna_h_CEMC_TOWER_2x2_max_trigger_ADC", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_2x2_slide2_max_trigger_ADC", //
+      "EMCalAna_h_CEMC_TOWER_2x2_slide2_max_trigger_ADC", 5000, 0, 50));
+
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_3x3", //
+      "h_CEMC_TOWER_3x3", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_3x3_max", //
+      "EMCalAna_h_CEMC_TOWER_3x3_max", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_3x3_max_trigger_ADC", //
+      "EMCalAna_h_CEMC_TOWER_3x3_max_trigger_ADC", 5000, 0, 50));
+
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_4x4", //
+      "h_CEMC_TOWER_4x4", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_4x4_max", //
+      "EMCalAna_h_CEMC_TOWER_4x4_max", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_4x4_max_trigger_ADC", //
+      "EMCalAna_h_CEMC_TOWER_4x4_max_trigger_ADC", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_4x4_slide2_max_trigger_ADC", //
+      "EMCalAna_h_CEMC_TOWER_4x4_slide2_max_trigger_ADC", 5000, 0, 50));
+
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_5x5", //
+      "h_CEMC_TOWER_4x4", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_5x5_max", //
+      "EMCalAna_h_CEMC_TOWER_5x5_max", 5000, 0, 50));
+  hm->registerHisto(new TH1F("EMCalAna_h_CEMC_TOWER_5x5_max_trigger_ADC", //
+      "EMCalAna_h_CEMC_TOWER_5x5_max_trigger_ADC", 5000, 0, 50));
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int
+QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
+{
+  const string detector("CEMC");
+
+  if (verbosity > 2)
+    cout << "QAG4SimulationCalorimeter::process_event_SF() entered" << endl;
+
+  string towernodename = "TOWER_CALIB_" + detector;
+  // Grab the towers
+  RawTowerContainer* towers = findNode::getClass<RawTowerContainer>(topNode,
+      towernodename.c_str());
+  if (!towers)
+    {
+      std::cout << PHWHERE << ": Could not find node " << towernodename.c_str()
+          << std::endl;
+      return Fun4AllReturnCodes::DISCARDEVENT;
+    }
+  string towergeomnodename = "TOWERGEOM_" + detector;
+  RawTowerGeomContainer *towergeom = findNode::getClass<RawTowerGeomContainer>(
+      topNode, towergeomnodename.c_str());
+  if (!towergeom)
+    {
+      cout << PHWHERE << ": Could not find node " << towergeomnodename.c_str()
+          << endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+  static const double trigger_ADC_bin = 45. / 256.; //8-bit ADC max to 45 GeV
+  static const int max_size = 5;
+  map<int, string> size_label;
+  size_label[1] = "1x1";
+  size_label[2] = "2x2";
+  size_label[3] = "3x3";
+  size_label[4] = "4x4";
+  size_label[5] = "5x5";
+  map<int, double> max_energy;
+  map<int, double> max_energy_trigger_ADC;
+  map<int, double> slide2_max_energy_trigger_ADC;
+  map<int, TH1F*> energy_hist_list;
+  map<int, TH1F*> max_energy_hist_list;
+  map<int, TH1F*> max_energy_trigger_ADC_hist_list;
+  map<int, TH1F*> slide2_max_energy_trigger_ADC_hist_list;
+
+  Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+  for (int size = 1; size <= max_size; ++size)
+    {
+      max_energy[size] = 0;
+      max_energy_trigger_ADC[size] = 0;
+
+      TH1F* h = NULL;
+
+      h = (TH1F*) hm->getHisto("EMCalAna_h_CEMC_TOWER_" + size_label[size]);
+      assert(h);
+      energy_hist_list[size] = h;
+      h = (TH1F*) hm->getHisto(
+          "EMCalAna_h_CEMC_TOWER_" + size_label[size] + "_max");
+      assert(h);
+      max_energy_hist_list[size] = h;
+
+      h = (TH1F*) hm->getHisto(
+          "EMCalAna_h_CEMC_TOWER_" + size_label[size] + "_max_trigger_ADC");
+      assert(h);
+      max_energy_trigger_ADC_hist_list[size] = h;
+
+      if (size == 2 or size == 4)
+        {
+          // sliding window made from 2x2 sums
+          slide2_max_energy_trigger_ADC[size] = 0;
+
+          h = (TH1F*) hm->getHisto(
+              "EMCalAna_h_CEMC_TOWER_" + size_label[size]
+                  + "_slide2_max_trigger_ADC");
+          assert(h);
+          slide2_max_energy_trigger_ADC_hist_list[size] = h;
+
+        }
+
+    }
+
+  for (int binphi = 0; binphi < towergeom->get_phibins(); ++binphi)
+    {
+      for (int bineta = 0; bineta < towergeom->get_etabins(); ++bineta)
+        {
+          for (int size = 1; size <= max_size; ++size)
+            {
+              double energy = 0;
+              double energy_trigger_ADC = 0;
+              double slide2_energy_trigger_ADC = 0;
+
+              for (int iphi = binphi; iphi < binphi + size; ++iphi)
+                {
+                  for (int ieta = bineta; ieta < bineta + size; ++ieta)
+                    {
+                      if (ieta > towergeom->get_etabins())
+                        continue;
+
+                      // wrap around
+                      int wrapphi = iphi;
+                      assert(wrapphi >= 0);
+                      if (wrapphi >= towergeom->get_phibins())
+                        {
+                          wrapphi = wrapphi - towergeom->get_phibins();
+                        }
+
+                      RawTower* tower = towers->getTower(ieta, wrapphi);
+
+                      if (tower)
+                        {
+                          const double e_intput = tower->get_energy();
+
+                          const double e_trigger_ADC = round(
+                              e_intput / trigger_ADC_bin) * trigger_ADC_bin;
+
+                          energy += e_intput;
+                          energy_trigger_ADC += e_trigger_ADC;
+
+                          if ((size == 2 or size == 4) and (binphi % 2 == 0)
+                              and (bineta % 2 == 0))
+                            {
+                              // sliding window made from 2x2 sums
+
+                              slide2_energy_trigger_ADC += e_trigger_ADC;
+                            }
+                        }
+                    }
+                }
+
+              energy_hist_list[size]->Fill(energy);
+
+              if (energy > max_energy[size])
+                max_energy[size] = energy;
+              if (energy_trigger_ADC > max_energy_trigger_ADC[size])
+                max_energy_trigger_ADC[size] = energy_trigger_ADC;
+
+              if ((size == 2 or size == 4) and (binphi % 2 == 0)
+                  and (bineta % 2 == 0))
+                {
+                  // sliding window made from 2x2 sums
+
+                  if (slide2_energy_trigger_ADC
+                      > slide2_max_energy_trigger_ADC[size])
+                    slide2_max_energy_trigger_ADC[size] =
+                        slide2_energy_trigger_ADC;
+                }
+
+            } //          for (int size = 1; size <= 4; ++size)
+        }
+    }
+
+  for (int size = 1; size <= max_size; ++size)
+    {
+      max_energy_hist_list[size]->Fill(max_energy[size]);
+      max_energy_trigger_ADC_hist_list[size]->Fill(
+          max_energy_trigger_ADC[size]);
+
+      if (size == 2 or size == 4)
+        {
+          // sliding window made from 2x2 sums
+          slide2_max_energy_trigger_ADC_hist_list[size]->Fill(
+              slide2_max_energy_trigger_ADC[size]);
+        }
+    }
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/QA/modules/QAG4SimulationCalorimeter.C
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.C
@@ -197,32 +197,32 @@ QAG4SimulationCalorimeter::Init_G4Hit(PHCompositeNode *topNode)
   assert(hm);
 
   hm->registerHisto(
-      new TH2F(TString(get_histo_prefix()) + "_RZ", //
+      new TH2F(TString(get_histo_prefix()) + "_G4Hit_RZ", //
       TString(_calo_name) + " RZ projection;Z (cm);R (cm)", 1200, -300, 300,
           600, -000, 300));
 
   hm->registerHisto(
-      new TH2F(TString(get_histo_prefix()) + "_XY", //
+      new TH2F(TString(get_histo_prefix()) + "_G4Hit_XY", //
       TString(_calo_name) + " XY projection;X (cm);Y (cm)", 1200, -300, 300,
           1200, -300, 300));
 
   hm->registerHisto(
-      new TH2F(TString(get_histo_prefix()) + "_LateralTruthProjection", //
+      new TH2F(TString(get_histo_prefix()) + "_G4Hit_LateralTruthProjection", //
           TString(_calo_name)
               + " shower lateral projection (last primary);Polar direction (cm);Azimuthal direction (cm)",
           200, -30, 30, 200, -30, 30));
 
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_SF", //
+  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_G4Hit_SF", //
   TString(_calo_name) + " sampling fraction;Sampling fraction", 1000, 0, .2));
 
   hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_VSF", //
+      new TH1F(TString(get_histo_prefix()) + "_G4Hit_VSF", //
           TString(_calo_name)
               + " visible sampling fraction;Visible sampling fraction", 1000, 0,
           .2));
 
   TH1F * h =
-      new TH1F(TString(get_histo_prefix()) + "_HitTime", //
+      new TH1F(TString(get_histo_prefix()) + "_G4Hit_HitTime", //
           TString(_calo_name)
               + " hit time (edep weighting);Hit time - T0 (ns);Geant4 energy density",
           1000, 0.5, 10000);
@@ -230,7 +230,7 @@ QAG4SimulationCalorimeter::Init_G4Hit(PHCompositeNode *topNode)
   hm->registerHisto(h);
 
   hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_FractionEnergy", //
+      new TH1F(TString(get_histo_prefix()) + "_G4Hit_FractionEnergy", //
           TString(_calo_name)
               + " fraction truth energy ;G4 energy (active + absorber) / total truth energy",
           1000, 0, 1));
@@ -314,14 +314,14 @@ QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
 
   if (_calo_hit_container)
     {
-      TH2F * hrz = (TH2F*) hm->getHisto(get_histo_prefix() + "_RZ");
+      TH2F * hrz = (TH2F*) hm->getHisto(get_histo_prefix() + "_G4Hit_RZ");
       assert(hrz);
-      TH2F * hxy = (TH2F*) hm->getHisto(get_histo_prefix() + "_XY");
+      TH2F * hxy = (TH2F*) hm->getHisto(get_histo_prefix() + "_G4Hit_XY");
       assert(hxy);
-      TH2F * ht = (TH2F*) hm->getHisto(get_histo_prefix() + "_HitTime");
+      TH2F * ht = (TH2F*) hm->getHisto(get_histo_prefix() + "_G4Hit_HitTime");
       assert(ht);
       TH2F * hlat = (TH2F*) hm->getHisto(
-          get_histo_prefix() + "_LateralTruthProjection");
+          get_histo_prefix() + "_G4Hit_LateralTruthProjection");
       assert(hlat);
 
       PHG4HitContainer::ConstRange calo_hit_range =
@@ -370,15 +370,15 @@ QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
         << " - SF = " << e_calo / (e_calo + ea_calo + 1e-9) << ", VSF = "
         << ev_calo / (e_calo + ea_calo + 1e-9) << endl;
 
-  h = (TH1F*) hm->getHisto(get_histo_prefix() + "_SF");
+  h = (TH1F*) hm->getHisto(get_histo_prefix() + "_G4Hit_SF");
   assert(h);
   h->Fill(e_calo / (e_calo + ea_calo + 1e-9));
 
-  h = (TH1F*) hm->getHisto(get_histo_prefix() + "_VSF");
+  h = (TH1F*) hm->getHisto(get_histo_prefix() + "_G4Hit_VSF");
   assert(h);
   h->Fill(ev_calo / (e_calo + ea_calo + 1e-9));
 
-  h = (TH1F*) hm->getHisto(get_histo_prefix() + "_FractionEnergy");
+  h = (TH1F*) hm->getHisto(get_histo_prefix() + "_G4Hit_FractionEnergy");
   assert(h);
   h->Fill((e_calo + ea_calo) / total_primary_energy);
 
@@ -399,53 +399,53 @@ QAG4SimulationCalorimeter::Init_Tower(PHCompositeNode *topNode)
 
   TH1F * h = NULL;
 
-  h = new TH1F(TString(get_histo_prefix()) + "_TOWER_1x1", //
+  h = new TH1F(TString(get_histo_prefix()) + "_Tower_1x1", //
   TString(_calo_name) + " 1x1 tower;1x1 TOWER Energy (GeV)", 100, 9e-4, 100);
   QAHistManagerDef::useLogBins(h->GetXaxis());
   hm->registerHisto(h);
 
   hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_TOWER_1x1_max", //
+      new TH1F(TString(get_histo_prefix()) + "_Tower_1x1_max", //
           TString(_calo_name)
               + " 1x1 tower max per event;1x1 tower max per event (GeV)", 5000,
           0, 50));
 
-  h = new TH1F(TString(get_histo_prefix()) + "_TOWER_2x2", //
+  h = new TH1F(TString(get_histo_prefix()) + "_Tower_2x2", //
   TString(_calo_name) + " 2x2 tower;2x2 TOWER Energy (GeV)", 100, 9e-4, 100);
   QAHistManagerDef::useLogBins(h->GetXaxis());
   hm->registerHisto(h);
   hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_TOWER_2x2_max", //
+      new TH1F(TString(get_histo_prefix()) + "_Tower_2x2_max", //
           TString(_calo_name)
               + " 2x2 tower max per event;2x2 tower max per event (GeV)", 5000,
           0, 50));
 
-  h = new TH1F(TString(get_histo_prefix()) + "_TOWER_3x3", //
+  h = new TH1F(TString(get_histo_prefix()) + "_Tower_3x3", //
   TString(_calo_name) + " 3x3 tower;3x3 TOWER Energy (GeV)", 100, 9e-4, 100);
   QAHistManagerDef::useLogBins(h->GetXaxis());
   hm->registerHisto(h);
   hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_TOWER_3x3_max", //
+      new TH1F(TString(get_histo_prefix()) + "_Tower_3x3_max", //
           TString(_calo_name)
               + " 3x3 tower max per event;3x3 tower max per event (GeV)", 5000,
           0, 50));
 
-  h = new TH1F(TString(get_histo_prefix()) + "_TOWER_4x4", //
+  h = new TH1F(TString(get_histo_prefix()) + "_Tower_4x4", //
   TString(_calo_name) + " 4x4 tower;4x4 TOWER Energy (GeV)", 100, 9e-4, 100);
   QAHistManagerDef::useLogBins(h->GetXaxis());
   hm->registerHisto(h);
   hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_TOWER_4x4_max", //
+      new TH1F(TString(get_histo_prefix()) + "_Tower_4x4_max", //
           TString(_calo_name)
               + " 4x4 tower max per event;4x4 tower max per event (GeV)", 5000,
           0, 50));
 
-  h = new TH1F(TString(get_histo_prefix()) + "_TOWER_5x5", //
+  h = new TH1F(TString(get_histo_prefix()) + "_Tower_5x5", //
   TString(_calo_name) + " 5x5 tower;5x5 TOWER Energy (GeV)", 100, 9e-4, 100);
   QAHistManagerDef::useLogBins(h->GetXaxis());
   hm->registerHisto(h);
   hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_TOWER_5x5_max", //
+      new TH1F(TString(get_histo_prefix()) + "_Tower_5x5_max", //
           TString(_calo_name)
               + " 5x5 tower max per event;5x5 tower max per event (GeV)", 5000,
           0, 50));
@@ -501,11 +501,11 @@ QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
       TH1F* h = NULL;
 
       h = (TH1F*) hm->getHisto(
-          get_histo_prefix() + "_TOWER_" + size_label[size]);
+          get_histo_prefix() + "_Tower_" + size_label[size]);
       assert(h);
       energy_hist_list[size] = h;
       h = (TH1F*) hm->getHisto(
-          get_histo_prefix() + "_TOWER_" + size_label[size] + "_max");
+          get_histo_prefix() + "_Tower_" + size_label[size] + "_max");
       assert(h);
       max_energy_hist_list[size] = h;
 
@@ -576,7 +576,7 @@ QAG4SimulationCalorimeter::Init_Cluster(PHCompositeNode *topNode)
   assert(hm);
 
   hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_MaxClusterE", //
+      new TH1F(TString(get_histo_prefix()) + "_Cluster_BestMatchERatio", //
           TString(_calo_name)
               + " best matched cluster E/E_{Truth};E_{Cluster}/E_{Truth}", 150,
           0, 1.5));
@@ -613,7 +613,7 @@ QAG4SimulationCalorimeter::process_event_Cluster(PHCompositeNode *topNode)
   CaloRawClusterEval* clustereval = _caloevalstack->get_rawcluster_eval();
   assert(clustereval);
 
-  TH1F* h = (TH1F*) hm->getHisto(get_histo_prefix() + "_MaxClusterE");
+  TH1F* h = (TH1F*) hm->getHisto(get_histo_prefix() + "_Cluster_BestMatchERatio");
   assert(h);
 
   RawCluster* cluster = clustereval->best_cluster_from(last_primary);
@@ -622,11 +622,10 @@ QAG4SimulationCalorimeter::process_event_Cluster(PHCompositeNode *topNode)
 
       if (verbosity > 3)
       cout << "QAG4SimulationCalorimeter::process_event_Cluster::" << _calo_name
-          << " - get cluster :";
-
-      cluster->identify();
+          << " - get cluster with energy "<<cluster->get_energy() <<" VS primary energy "<< last_primary->get_e() <<endl;
 
       h->Fill(cluster->get_energy() / (last_primary->get_e() + 1e-9)); //avoids divide zero
+
     }
   else
     {

--- a/offline/QA/modules/QAG4SimulationCalorimeter.C
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.C
@@ -244,7 +244,8 @@ QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
     }
 
   assert(not _truth_container->GetMap().empty());
-  const PHG4Particle * last_primary = _truth_container->GetMap().rbegin()->second;
+  const PHG4Particle * last_primary =
+      _truth_container->GetMap().rbegin()->second;
   assert(last_primary);
 
   if (verbosity > 2)
@@ -376,55 +377,58 @@ QAG4SimulationCalorimeter::Init_Tower(PHCompositeNode *topNode)
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);
 
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_TOWER_1x1", //
-  "h_" + TString(_calo_name) + "_TOWER_1x1", 5000, 0, 50));
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_TOWER_1x1_max", //
-  TString(get_histo_prefix()) + "_TOWER_1x1_max", 5000, 0, 50));
-  hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_TOWER_1x1_max_trigger_ADC", //
-      TString(get_histo_prefix()) + "_TOWER_1x1_max_trigger_ADC", 5000, 0, 50));
+  TH1F * h = NULL;
 
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_TOWER_2x2", //
-  "h_" + TString(_calo_name) + "_TOWER_2x2", 5000, 0, 50));
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_TOWER_2x2_max", //
-  TString(get_histo_prefix()) + "_TOWER_2x2_max", 5000, 0, 50));
-  hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_TOWER_2x2_max_trigger_ADC", //
-      TString(get_histo_prefix()) + "_TOWER_2x2_max_trigger_ADC", 5000, 0, 50));
-  hm->registerHisto(
-      new TH1F(
-          TString(get_histo_prefix()) + "_TOWER_2x2_slide2_max_trigger_ADC", //
-          TString(get_histo_prefix()) + "_TOWER_2x2_slide2_max_trigger_ADC",
-          5000, 0, 50));
+  h = new TH1F(TString(get_histo_prefix()) + "_TOWER_1x1", //
+  TString(_calo_name) + " 1x1 tower;1x1 TOWER Energy (GeV)", 100, 9e-4, 100);
+  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
 
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_TOWER_3x3", //
-  "h_" + TString(_calo_name) + "_TOWER_3x3", 5000, 0, 50));
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_TOWER_3x3_max", //
-  TString(get_histo_prefix()) + "_TOWER_3x3_max", 5000, 0, 50));
   hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_TOWER_3x3_max_trigger_ADC", //
-      TString(get_histo_prefix()) + "_TOWER_3x3_max_trigger_ADC", 5000, 0, 50));
+      new TH1F(TString(get_histo_prefix()) + "_TOWER_1x1_max", //
+          TString(_calo_name)
+              + " 1x1 tower max per event;1x1 tower max per event (GeV)", 5000,
+          0, 50));
 
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_TOWER_4x4", //
-  "h_" + TString(_calo_name) + "_TOWER_4x4", 5000, 0, 50));
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_TOWER_4x4_max", //
-  TString(get_histo_prefix()) + "_TOWER_4x4_max", 5000, 0, 50));
+  h = new TH1F(TString(get_histo_prefix()) + "_TOWER_2x2", //
+  TString(_calo_name) + " 2x2 tower;2x2 TOWER Energy (GeV)", 100, 9e-4, 100);
+  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
   hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_TOWER_4x4_max_trigger_ADC", //
-      TString(get_histo_prefix()) + "_TOWER_4x4_max_trigger_ADC", 5000, 0, 50));
-  hm->registerHisto(
-      new TH1F(
-          TString(get_histo_prefix()) + "_TOWER_4x4_slide2_max_trigger_ADC", //
-          TString(get_histo_prefix()) + "_TOWER_4x4_slide2_max_trigger_ADC",
-          5000, 0, 50));
+      new TH1F(TString(get_histo_prefix()) + "_TOWER_2x2_max", //
+          TString(_calo_name)
+              + " 2x2 tower max per event;2x2 tower max per event (GeV)", 5000,
+          0, 50));
 
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_TOWER_5x5", //
-  "h_" + TString(_calo_name) + "_TOWER_4x4", 5000, 0, 50));
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "_TOWER_5x5_max", //
-  TString(get_histo_prefix()) + "_TOWER_5x5_max", 5000, 0, 50));
+  h = new TH1F(TString(get_histo_prefix()) + "_TOWER_3x3", //
+  TString(_calo_name) + " 3x3 tower;3x3 TOWER Energy (GeV)", 100, 9e-4, 100);
+  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
   hm->registerHisto(
-      new TH1F(TString(get_histo_prefix()) + "_TOWER_5x5_max_trigger_ADC", //
-      TString(get_histo_prefix()) + "_TOWER_5x5_max_trigger_ADC", 5000, 0, 50));
+      new TH1F(TString(get_histo_prefix()) + "_TOWER_3x3_max", //
+          TString(_calo_name)
+              + " 3x3 tower max per event;3x3 tower max per event (GeV)", 5000,
+          0, 50));
+
+  h = new TH1F(TString(get_histo_prefix()) + "_TOWER_4x4", //
+  TString(_calo_name) + " 4x4 tower;4x4 TOWER Energy (GeV)", 100, 9e-4, 100);
+  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
+  hm->registerHisto(
+      new TH1F(TString(get_histo_prefix()) + "_TOWER_4x4_max", //
+          TString(_calo_name)
+              + " 4x4 tower max per event;4x4 tower max per event (GeV)", 5000,
+          0, 50));
+
+  h = new TH1F(TString(get_histo_prefix()) + "_TOWER_5x5", //
+  TString(_calo_name) + " 5x5 tower;5x5 TOWER Energy (GeV)", 100, 9e-4, 100);
+  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
+  hm->registerHisto(
+      new TH1F(TString(get_histo_prefix()) + "_TOWER_5x5_max", //
+          TString(_calo_name)
+              + " 5x5 tower max per event;5x5 tower max per event (GeV)", 5000,
+          0, 50));
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -457,7 +461,6 @@ QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-  static const double trigger_ADC_bin = 45. / 256.; //8-bit ADC max to 45 GeV
   static const int max_size = 5;
   map<int, string> size_label;
   size_label[1] = "1x1";
@@ -466,19 +469,14 @@ QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
   size_label[4] = "4x4";
   size_label[5] = "5x5";
   map<int, double> max_energy;
-  map<int, double> max_energy_trigger_ADC;
-  map<int, double> slide2_max_energy_trigger_ADC;
   map<int, TH1F*> energy_hist_list;
   map<int, TH1F*> max_energy_hist_list;
-  map<int, TH1F*> max_energy_trigger_ADC_hist_list;
-  map<int, TH1F*> slide2_max_energy_trigger_ADC_hist_list;
 
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);
   for (int size = 1; size <= max_size; ++size)
     {
       max_energy[size] = 0;
-      max_energy_trigger_ADC[size] = 0;
 
       TH1F* h = NULL;
 
@@ -491,25 +489,6 @@ QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
       assert(h);
       max_energy_hist_list[size] = h;
 
-      h = (TH1F*) hm->getHisto(
-          get_histo_prefix() + "_TOWER_" + size_label[size]
-              + "_max_trigger_ADC");
-      assert(h);
-      max_energy_trigger_ADC_hist_list[size] = h;
-
-      if (size == 2 or size == 4)
-        {
-          // sliding window made from 2x2 sums
-          slide2_max_energy_trigger_ADC[size] = 0;
-
-          h = (TH1F*) hm->getHisto(
-              get_histo_prefix() + "_TOWER_" + size_label[size]
-                  + "_slide2_max_trigger_ADC");
-          assert(h);
-          slide2_max_energy_trigger_ADC_hist_list[size] = h;
-
-        }
-
     }
 
   for (int binphi = 0; binphi < towergeom->get_phibins(); ++binphi)
@@ -518,10 +497,15 @@ QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
         {
           for (int size = 1; size <= max_size; ++size)
             {
-              double energy = 0;
-              double energy_trigger_ADC = 0;
-              double slide2_energy_trigger_ADC = 0;
 
+              // for 2x2 and 4x4 use slide-2 window as implimented in DAQ
+              if ((size == 2 or size == 4)
+                  and ((binphi % 2 != 0) and (bineta % 2 != 0)))
+                continue;
+
+              double energy = 0;
+
+              // sliding window made from 2x2 sums
               for (int iphi = binphi; iphi < binphi + size; ++iphi)
                 {
                   for (int ieta = bineta; ieta < bineta + size; ++ieta)
@@ -543,40 +527,15 @@ QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
                         {
                           const double e_intput = tower->get_energy();
 
-                          const double e_trigger_ADC = round(
-                              e_intput / trigger_ADC_bin) * trigger_ADC_bin;
-
                           energy += e_intput;
-                          energy_trigger_ADC += e_trigger_ADC;
-
-                          if ((size == 2 or size == 4) and (binphi % 2 == 0)
-                              and (bineta % 2 == 0))
-                            {
-                              // sliding window made from 2x2 sums
-
-                              slide2_energy_trigger_ADC += e_trigger_ADC;
-                            }
                         }
                     }
                 }
 
-              energy_hist_list[size]->Fill(energy);
+              energy_hist_list[size]->Fill(energy == 0 ? 9.1e-4 : energy); // trick to fill 0 energy tower to the first bin
 
               if (energy > max_energy[size])
                 max_energy[size] = energy;
-              if (energy_trigger_ADC > max_energy_trigger_ADC[size])
-                max_energy_trigger_ADC[size] = energy_trigger_ADC;
-
-              if ((size == 2 or size == 4) and (binphi % 2 == 0)
-                  and (bineta % 2 == 0))
-                {
-                  // sliding window made from 2x2 sums
-
-                  if (slide2_energy_trigger_ADC
-                      > slide2_max_energy_trigger_ADC[size])
-                    slide2_max_energy_trigger_ADC[size] =
-                        slide2_energy_trigger_ADC;
-                }
 
             } //          for (int size = 1; size <= 4; ++size)
         }
@@ -585,15 +544,6 @@ QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
   for (int size = 1; size <= max_size; ++size)
     {
       max_energy_hist_list[size]->Fill(max_energy[size]);
-      max_energy_trigger_ADC_hist_list[size]->Fill(
-          max_energy_trigger_ADC[size]);
-
-      if (size == 2 or size == 4)
-        {
-          // sliding window made from 2x2 sums
-          slide2_max_energy_trigger_ADC_hist_list[size]->Fill(
-              slide2_max_energy_trigger_ADC[size]);
-        }
     }
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/QA/modules/QAG4SimulationCalorimeter.C
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.C
@@ -314,14 +314,14 @@ QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
 
   if (_calo_hit_container)
     {
-      TH2F * hrz = (TH2F*) hm->getHisto(get_histo_prefix() + "_G4Hit_RZ");
+      TH2F * hrz = dynamic_cast<TH2F*>( hm->getHisto(get_histo_prefix() + "_G4Hit_RZ"));
       assert(hrz);
-      TH2F * hxy = (TH2F*) hm->getHisto(get_histo_prefix() + "_G4Hit_XY");
+      TH2F * hxy = dynamic_cast<TH2F*>( hm->getHisto(get_histo_prefix() + "_G4Hit_XY"));
       assert(hxy);
-      TH2F * ht = (TH2F*) hm->getHisto(get_histo_prefix() + "_G4Hit_HitTime");
+      TH2F * ht = dynamic_cast<TH2F*>( hm->getHisto(get_histo_prefix() + "_G4Hit_HitTime"));
       assert(ht);
-      TH2F * hlat = (TH2F*) hm->getHisto(
-          get_histo_prefix() + "_G4Hit_LateralTruthProjection");
+      TH2F * hlat = dynamic_cast<TH2F*>( hm->getHisto(
+          get_histo_prefix() + "_G4Hit_LateralTruthProjection"));
       assert(hlat);
 
       PHG4HitContainer::ConstRange calo_hit_range =
@@ -370,15 +370,15 @@ QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
         << " - SF = " << e_calo / (e_calo + ea_calo + 1e-9) << ", VSF = "
         << ev_calo / (e_calo + ea_calo + 1e-9) << endl;
 
-  h = (TH1F*) hm->getHisto(get_histo_prefix() + "_G4Hit_SF");
+  h = dynamic_cast<TH1F*>( hm->getHisto(get_histo_prefix() + "_G4Hit_SF"));
   assert(h);
   h->Fill(e_calo / (e_calo + ea_calo + 1e-9));
 
-  h = (TH1F*) hm->getHisto(get_histo_prefix() + "_G4Hit_VSF");
+  h = dynamic_cast<TH1F*>( hm->getHisto(get_histo_prefix() + "_G4Hit_VSF"));
   assert(h);
   h->Fill(ev_calo / (e_calo + ea_calo + 1e-9));
 
-  h = (TH1F*) hm->getHisto(get_histo_prefix() + "_G4Hit_FractionEnergy");
+  h = dynamic_cast<TH1F*>( hm->getHisto(get_histo_prefix() + "_G4Hit_FractionEnergy"));
   assert(h);
   h->Fill((e_calo + ea_calo) / total_primary_energy);
 
@@ -500,12 +500,12 @@ QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
 
       TH1F* h = NULL;
 
-      h = (TH1F*) hm->getHisto(
-          get_histo_prefix() + "_Tower_" + size_label[size]);
+      h = dynamic_cast<TH1F*>( hm->getHisto(
+          get_histo_prefix() + "_Tower_" + size_label[size]));
       assert(h);
       energy_hist_list[size] = h;
-      h = (TH1F*) hm->getHisto(
-          get_histo_prefix() + "_Tower_" + size_label[size] + "_max");
+      h = dynamic_cast<TH1F*>( hm->getHisto(
+          get_histo_prefix() + "_Tower_" + size_label[size] + "_max"));
       assert(h);
       max_energy_hist_list[size] = h;
 
@@ -630,7 +630,7 @@ QAG4SimulationCalorimeter::process_event_Cluster(PHCompositeNode *topNode)
   CaloRawClusterEval* clustereval = _caloevalstack->get_rawcluster_eval();
   assert(clustereval);
 
-  TH1F* h = (TH1F*) hm->getHisto(get_histo_prefix() + "_Cluster_BestMatchERatio");
+  TH1F* h = dynamic_cast<TH1F*>( hm->getHisto(get_histo_prefix() + "_Cluster_BestMatchERatio"));
   assert(h);
 
   RawCluster* cluster = clustereval->best_cluster_from(last_primary);
@@ -682,8 +682,8 @@ QAG4SimulationCalorimeter::process_event_Cluster(PHCompositeNode *topNode)
       assert(axis_polar.Mag() >0);
       axis_polar = axis_polar.Unit();
 
-      TH2F * hlat = (TH2F*) hm->getHisto(
-          get_histo_prefix() + "_Cluster_LateralTruthProjection");
+      TH2F * hlat = dynamic_cast<TH2F*>( hm->getHisto(
+          get_histo_prefix() + "_Cluster_LateralTruthProjection"));
       assert(hlat);
 
       const double hit_azimuth = axis_azimuth.Dot(hit - vertex);

--- a/offline/QA/modules/QAG4SimulationCalorimeter.C
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.C
@@ -386,23 +386,29 @@ QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
         << " - SF = " << e_calo / (e_calo + ea_calo + 1e-9) << ", VSF = "
         << ev_calo / (e_calo + ea_calo + 1e-9) << endl;
 
-  h = dynamic_cast<TH1F*>(hm->getHisto(get_histo_prefix() + "_G4Hit_SF"));
-  assert(h);
-  h->Fill(e_calo / (e_calo + ea_calo + 1e-9));
+  if (e_calo + ea_calo > 0)
+    {
+      h = dynamic_cast<TH1F*>(hm->getHisto(get_histo_prefix() + "_G4Hit_SF"));
+      assert(h);
+      h->Fill(e_calo / (e_calo + ea_calo));
 
-  h = dynamic_cast<TH1F*>(hm->getHisto(get_histo_prefix() + "_G4Hit_VSF"));
-  assert(h);
-  h->Fill(ev_calo / (e_calo + ea_calo + 1e-9));
+      h = dynamic_cast<TH1F*>(hm->getHisto(get_histo_prefix() + "_G4Hit_VSF"));
+      assert(h);
+      h->Fill(ev_calo / (e_calo + ea_calo));
+    }
 
   h = dynamic_cast<TH1F*>(hm->getHisto(
       get_histo_prefix() + "_G4Hit_FractionTruthEnergy"));
   assert(h);
   h->Fill((e_calo + ea_calo) / total_primary_energy);
 
-  h = dynamic_cast<TH1F*>(hm->getHisto(
-      get_histo_prefix() + "_G4Hit_FractionEMVisibleEnergy"));
-  assert(h);
-  h->Fill(ev_calo_em / (ev_calo + 1e-9));
+  if (ev_calo > 0)
+    {
+      h = dynamic_cast<TH1F*>(hm->getHisto(
+          get_histo_prefix() + "_G4Hit_FractionEMVisibleEnergy"));
+      assert(h);
+      h->Fill(ev_calo_em / (ev_calo));
+    }
 
   if (verbosity > 3)
     cout << "QAG4SimulationCalorimeter::process_event_G4Hit::" << _calo_name

--- a/offline/QA/modules/QAG4SimulationCalorimeter.h
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.h
@@ -31,7 +31,7 @@ public:
     kDefaultFlag = kProcessSF | kProcessTower
   };
 
-  QAG4SimulationCalorimeter(enu_flags flags = kDefaultFlag);
+  QAG4SimulationCalorimeter(std::string calo_name, enu_flags flags = kDefaultFlag);
   virtual
   ~QAG4SimulationCalorimeter();
 
@@ -102,32 +102,18 @@ private:
 //  int
 //  process_event_MCPhoton(PHCompositeNode *topNode);
 
-  enum enu_calo
-  {
-    kCEMC, kHCALIN, kHCALOUT
-  };
 
   SvtxEvalStack * _eval_stack;
 
+  //! to be retired with system interface
   double _magfield;
 
+  std::string _calo_name;
   uint32_t _flags;
   unsigned long _ievent;
 
-  PHG4HitContainer* _hcalout_hit_container;
-  PHG4HitContainer* _hcalin_hit_container;
-  PHG4HitContainer* _cemc_hit_container;
-  PHG4HitContainer* _hcalout_abs_hit_container;
-  PHG4HitContainer* _hcalin_abs_hit_container;
-  PHG4HitContainer* _cemc_abs_hit_container;
-  PHG4HitContainer* _magnet_hit_container;
-  PHG4HitContainer* _bh_hit_container;
-  PHG4HitContainer* _bh_plus_hit_container;
-  PHG4HitContainer* _bh_minus_hit_container;
-  PHG4HitContainer* _cemc_electronics_hit_container;
-  PHG4HitContainer* _hcalin_spt_hit_container;
-  PHG4HitContainer* _svtx_hit_container;
-  PHG4HitContainer* _svtx_support_hit_container;
+  PHG4HitContainer* _calo_hit_container;
+  PHG4HitContainer* _calo_abs_hit_container;
 };
 
 #endif // __CALOEVALUATOR_H__

--- a/offline/QA/modules/QAG4SimulationCalorimeter.h
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.h
@@ -1,0 +1,133 @@
+#ifndef __CALOEVALUATOR_H__
+#define __CALOEVALUATOR_H__
+
+#include <fun4all/SubsysReco.h>
+#include <phool/PHCompositeNode.h>
+
+#include <string>
+#include <stdint.h>
+
+class PHCompositeNode;
+class PHG4HitContainer;
+class Fun4AllHistoManager;
+class TH1F;
+class TTree;
+class SvtxEvalStack;
+class PHG4Particle;
+class RawTowerGeom;
+class RawTowerContainer;
+class SvtxTrack;
+
+/// \class QAG4SimulationCalorimeter
+class QAG4SimulationCalorimeter : public SubsysReco
+{
+
+public:
+
+  enum enu_flags
+  {
+    kProcessSF = 1 << 1, kProcessTower = 1 << 2, kProcessMCPhoton = 1 << 3,
+
+    kDefaultFlag = kProcessSF | kProcessTower
+  };
+
+  QAG4SimulationCalorimeter(enu_flags flags = kDefaultFlag);
+  virtual
+  ~QAG4SimulationCalorimeter();
+
+  int
+  Init(PHCompositeNode *topNode);
+  int
+  InitRun(PHCompositeNode *topNode);
+  int
+  process_event(PHCompositeNode *topNode);
+  int
+  End(PHCompositeNode *topNode);
+
+  uint32_t
+  get_flags() const
+  {
+    return _flags;
+  }
+
+  void
+  set_flags(enu_flags flags)
+  {
+    _flags = (uint32_t) flags;
+  }
+
+  void
+  set_flag(enu_flags flag)
+  {
+    _flags |= (uint32_t) flag;
+  }
+
+  bool
+  flag(enu_flags flag)
+  {
+    return _flags & flag;
+  }
+
+  void
+  reset_flag(enu_flags flag)
+  {
+    _flags &= ~(uint32_t) flag;
+  }
+
+  float
+  get_mag_field() const
+  {
+    return _magfield;
+  }
+  void
+  set_mag_field(float magfield)
+  {
+    _magfield = magfield;
+  }
+
+private:
+
+  int
+  Init_SF(PHCompositeNode *topNode);
+  int
+  process_event_SF(PHCompositeNode *topNode);
+
+  int
+  Init_Tower(PHCompositeNode *topNode);
+  int
+  process_event_Tower(PHCompositeNode *topNode);
+
+//  int
+//  Init_MCPhoton(PHCompositeNode *topNode);
+//  int
+//  process_event_MCPhoton(PHCompositeNode *topNode);
+
+  enum enu_calo
+  {
+    kCEMC, kHCALIN, kHCALOUT
+  };
+
+  SvtxEvalStack * _eval_stack;
+
+  double _magfield;
+
+  uint32_t _flags;
+  unsigned long _ievent;
+
+  PHG4HitContainer* _hcalout_hit_container;
+  PHG4HitContainer* _hcalin_hit_container;
+  PHG4HitContainer* _cemc_hit_container;
+  PHG4HitContainer* _hcalout_abs_hit_container;
+  PHG4HitContainer* _hcalin_abs_hit_container;
+  PHG4HitContainer* _cemc_abs_hit_container;
+  PHG4HitContainer* _magnet_hit_container;
+  PHG4HitContainer* _bh_hit_container;
+  PHG4HitContainer* _bh_plus_hit_container;
+  PHG4HitContainer* _bh_minus_hit_container;
+  PHG4HitContainer* _cemc_electronics_hit_container;
+  PHG4HitContainer* _hcalin_spt_hit_container;
+  PHG4HitContainer* _svtx_hit_container;
+  PHG4HitContainer* _svtx_support_hit_container;
+};
+
+#endif // __CALOEVALUATOR_H__

--- a/offline/QA/modules/QAG4SimulationCalorimeter.h
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.h
@@ -14,11 +14,10 @@ class PHG4TruthInfoContainer;
 class Fun4AllHistoManager;
 class TH1F;
 class TTree;
-class SvtxEvalStack;
 class PHG4Particle;
 class RawTowerGeom;
 class RawTowerContainer;
-class SvtxTrack;
+class CaloEvalStack;
 
 /// \class QAG4SimulationCalorimeter
 class QAG4SimulationCalorimeter : public SubsysReco
@@ -30,7 +29,7 @@ public:
   {
     kProcessG4Hit = 1 << 1, kProcessTower = 1 << 2, kProcessCluster = 1 << 3,
 
-    kDefaultFlag = kProcessG4Hit | kProcessTower
+    kDefaultFlag = kProcessG4Hit | kProcessTower | kProcessCluster
   };
 
   QAG4SimulationCalorimeter(std::string calo_name, enu_flags flags = kDefaultFlag);
@@ -76,17 +75,6 @@ public:
     _flags &= ~(uint32_t) flag;
   }
 
-  float
-  get_mag_field() const
-  {
-    return _magfield;
-  }
-  void
-  set_mag_field(float magfield)
-  {
-    _magfield = magfield;
-  }
-
   //! common prefix for QA histograms
   std::string get_histo_prefix();
 
@@ -102,15 +90,12 @@ private:
   int
   process_event_Tower(PHCompositeNode *topNode);
 
-//  int
-//  Init_MCPhoton(PHCompositeNode *topNode);
-//  int
-//  process_event_MCPhoton(PHCompositeNode *topNode);
+  int
+  Init_Cluster(PHCompositeNode *topNode);
+  int
+  process_event_Cluster(PHCompositeNode *topNode);
 
-  SvtxEvalStack * _eval_stack;
-
-  //! to be retired with system interface
-  double _magfield;
+  CaloEvalStack* _caloevalstack;
 
   std::string _calo_name;
   uint32_t _flags;

--- a/offline/QA/modules/QAG4SimulationCalorimeter.h
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.h
@@ -6,9 +6,11 @@
 
 #include <string>
 #include <stdint.h>
+#include <TString.h>
 
 class PHCompositeNode;
 class PHG4HitContainer;
+class PHG4TruthInfoContainer;
 class Fun4AllHistoManager;
 class TH1F;
 class TTree;
@@ -26,9 +28,9 @@ public:
 
   enum enu_flags
   {
-    kProcessSF = 1 << 1, kProcessTower = 1 << 2, kProcessMCPhoton = 1 << 3,
+    kProcessG4Hit = 1 << 1, kProcessTower = 1 << 2, kProcessCluster = 1 << 3,
 
-    kDefaultFlag = kProcessSF | kProcessTower
+    kDefaultFlag = kProcessG4Hit | kProcessTower
   };
 
   QAG4SimulationCalorimeter(std::string calo_name, enu_flags flags = kDefaultFlag);
@@ -85,12 +87,15 @@ public:
     _magfield = magfield;
   }
 
+  //! common prefix for QA histograms
+  std::string get_histo_prefix();
+
 private:
 
   int
-  Init_SF(PHCompositeNode *topNode);
+  Init_G4Hit(PHCompositeNode *topNode);
   int
-  process_event_SF(PHCompositeNode *topNode);
+  process_event_G4Hit(PHCompositeNode *topNode);
 
   int
   Init_Tower(PHCompositeNode *topNode);
@@ -101,7 +106,6 @@ private:
 //  Init_MCPhoton(PHCompositeNode *topNode);
 //  int
 //  process_event_MCPhoton(PHCompositeNode *topNode);
-
 
   SvtxEvalStack * _eval_stack;
 
@@ -114,6 +118,7 @@ private:
 
   PHG4HitContainer* _calo_hit_container;
   PHG4HitContainer* _calo_abs_hit_container;
+  PHG4TruthInfoContainer* _truth_container;
 };
 
 #endif // __CALOEVALUATOR_H__

--- a/offline/QA/modules/QAG4SimulationCalorimeterLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationCalorimeterLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class QAG4SimulationCalorimeter-!;
+
+#endif /* __CINT__ */

--- a/offline/QA/modules/QAHistManagerDef.C
+++ b/offline/QA/modules/QAHistManagerDef.C
@@ -1,0 +1,52 @@
+// $Id: $                                                                                             
+ 
+/*!
+ * \file QAHistManagerDef.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "QAHistManagerDef.h"
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllHistoManager.h>
+
+#include <cassert>
+
+using namespace std;
+
+namespace QAHistManagerDef
+{
+
+  //! Get a pointer to the default hist manager for QA modules
+  Fun4AllHistoManager *
+  getHistoManager()
+  {
+
+    Fun4AllServer *se = Fun4AllServer::instance();
+    Fun4AllHistoManager *hm = se->getHistoManager(HistoManagerName);
+
+    if (not hm)
+      {
+//        cout
+//            << "QAHistManagerDef::get_HistoManager - Making Fun4AllHistoManager EMCalAna_HISTOS"
+//            << endl;
+        hm = new Fun4AllHistoManager(HistoManagerName);
+        se->registerHistoManager(hm);
+      }
+
+    assert(hm);
+
+    return hm;
+  }
+
+  //! Save hist to root files
+  void
+  saveQARootFile(const std::string file_name)
+  {
+    getHistoManager()->dumpHistos(file_name);
+  }
+}
+
+

--- a/offline/QA/modules/QAHistManagerDef.C
+++ b/offline/QA/modules/QAHistManagerDef.C
@@ -1,5 +1,5 @@
 // $Id: $                                                                                             
- 
+
 /*!
  * \file QAHistManagerDef.h
  * \brief 
@@ -9,10 +9,15 @@
  */
 
 #include "QAHistManagerDef.h"
+
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllHistoManager.h>
 
+#include <TAxis.h>
+#include <TMath.h>
+
 #include <cassert>
+#include <vector>
 
 using namespace std;
 
@@ -47,6 +52,28 @@ namespace QAHistManagerDef
   {
     getHistoManager()->dumpHistos(file_name);
   }
-}
 
+//! utility function to
+  void
+  useLogBins(TAxis * axis)
+  {
+    assert(axis);
+    assert(axis->GetXmin()>0);
+    assert( axis->GetXmax()>0);
+
+    const int bins = axis->GetNbins();
+
+    Axis_t from = log10(axis->GetXmin());
+    Axis_t to = log10(axis->GetXmax());
+    Axis_t width = (to - from) / bins;
+    vector<Axis_t> new_bins(bins + 1);
+
+    for (int i = 0; i <= bins; i++)
+      {
+        new_bins[i] = TMath::Power(10, from + i * width);
+      }
+    axis->Set(bins, new_bins.data());
+
+  }
+}
 

--- a/offline/QA/modules/QAHistManagerDef.C
+++ b/offline/QA/modules/QAHistManagerDef.C
@@ -48,7 +48,7 @@ namespace QAHistManagerDef
 
   //! Save hist to root files
   void
-  saveQARootFile(const std::string file_name)
+  saveQARootFile(const std::string & file_name)
   {
     getHistoManager()->dumpHistos(file_name);
   }

--- a/offline/QA/modules/QAHistManagerDef.h
+++ b/offline/QA/modules/QAHistManagerDef.h
@@ -12,7 +12,9 @@
 #define QAHISTMANAGERDEF_H_
 
 #include <string>
+
 class Fun4AllHistoManager;
+class TAxis;
 
 namespace QAHistManagerDef
 {
@@ -27,6 +29,9 @@ namespace QAHistManagerDef
 
   //! default name for QA histogram manager
   static const std::string HistoManagerName = "QA_HISTOS";
+
+  //! utility function to convert TAxis to log scale binning (usually for x axis)
+  void useLogBins(TAxis * axis);
 }
 
 #endif /* QAHISTMANAGERDEF_H_ */

--- a/offline/QA/modules/QAHistManagerDef.h
+++ b/offline/QA/modules/QAHistManagerDef.h
@@ -1,0 +1,32 @@
+// $Id: $                                                                                             
+
+/*!
+ * \file QAHistManagerDef.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef QAHISTMANAGERDEF_H_
+#define QAHISTMANAGERDEF_H_
+
+#include <string>
+class Fun4AllHistoManager;
+
+namespace QAHistManagerDef
+{
+
+  //! Get a pointer to the default hist manager for QA modules
+  Fun4AllHistoManager *
+  getHistoManager();
+
+  //! Save hist to root files. It will overwrite the old file if exist
+  void
+  saveQARootFile(const std::string file_name);
+
+  //! default name for QA histogram manager
+  static const std::string HistoManagerName = "QA_HISTOS";
+}
+
+#endif /* QAHISTMANAGERDEF_H_ */

--- a/offline/QA/modules/QAHistManagerDef.h
+++ b/offline/QA/modules/QAHistManagerDef.h
@@ -25,7 +25,7 @@ namespace QAHistManagerDef
 
   //! Save hist to root files. It will overwrite the old file if exist
   void
-  saveQARootFile(const std::string file_name);
+  saveQARootFile(const std::string & file_name);
 
   //! default name for QA histogram manager
   static const std::string HistoManagerName = "QA_HISTOS";

--- a/offline/QA/modules/QAHistManagerDefLinkDef.h
+++ b/offline/QA/modules/QAHistManagerDefLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ namespace QAHistManagerDef-!;
+
+#endif /* __CINT__ */

--- a/offline/QA/modules/autogen.sh
+++ b/offline/QA/modules/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"
+

--- a/offline/QA/modules/configure.in
+++ b/offline/QA/modules/configure.in
@@ -1,0 +1,15 @@
+AC_INIT(configure.in)
+
+AM_INIT_AUTOMAKE(g4eval, 1.00)
+
+AC_PROG_CXX(g++)
+AC_ENABLE_STATIC(no)
+LT_INIT
+
+dnl   no point in suppressing warnings people should 
+dnl   at least see them, so here we go for g++: -Wall
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+fi
+
+AC_OUTPUT(Makefile)

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -403,6 +403,8 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
             cellptarray[ibin]->set_etabin(ietabin);
           }
           cellptarray[ibin]->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1], hiter->second->get_light_yield()*vdedx[i1]);
+          cellptarray[ibin]->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep()*vdedx[i1]);
+
           // just a sanity check - we don't want to mess up by having Nan's or Infs in our energy deposition
           if (! isfinite(hiter->second->get_edep()*vdedx[i1]))
           {

--- a/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.cc
@@ -113,6 +113,7 @@ PHG4ForwardCalCellReco::process_event(PHCompositeNode *topNode)
 	    }
 
 	  celllist[key]->add_edep(hiter->first, hiter->second->get_edep(), hiter->second->get_light_yield());
+	  celllist[key]->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep());
 
 	}
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -370,6 +370,7 @@ PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
 
           celllist[key]->add_edep(hiter->first, hiter->second->get_edep(),
               hiter->second->get_light_yield());
+          celllist[key]->add_shower_edep(hiter->first, hiter->second->get_edep());
 
         } // end loop over g4hits
       int numcells = 0;

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -211,7 +211,8 @@ PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
 	      celllist[key]->set_etabin(slatno);
 	    }
 
-	  celllist[key]->add_edep(hiter->first, hiter->second->get_edep(),hiter->second->get_light_yield());
+    celllist[key]->add_edep(hiter->first, hiter->second->get_edep(),hiter->second->get_light_yield());
+    celllist[key]->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep());
 	} // end loop over g4hits
       int numcells = 0;
       for (map<unsigned int, PHG4CylinderCell *>::const_iterator mapiter = celllist.begin();mapiter != celllist.end() ; ++mapiter)

--- a/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
@@ -347,7 +347,8 @@ PHG4SlatCellReco::process_event(PHCompositeNode *topNode)
 		      cellptarray[slatbin][intetabin]->set_phibin(slatbin);
 		      cellptarray[slatbin][intetabin]->set_etabin(intetabin);
 		    }
-		  cellptarray[slatbin][intetabin]->add_edep(hiter->first, hiter->second->get_edep(), hiter->second->get_light_yield());
+      cellptarray[slatbin][intetabin]->add_edep(hiter->first, hiter->second->get_edep(), hiter->second->get_light_yield());
+      cellptarray[slatbin][intetabin]->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep());
 		}
 	    } // end loop over g4hits
           int numcells = 0;


### PR DESCRIPTION
Implemented first of three planned QA modules. More to be discussed in simulation meeting today. 

Example macros to run: 
https://github.com/blackcathj/macros/tree/SinglePart_master_readhit_calo_eval/macros/g4simulations

Few screen shots, which compare 24GeV pi- shower VS 24GeV e- shower:

* At geant4 production level:
![g4sphenixcells_1000pi24gev root_qa rootqa_draw_cemc_g4hit](https://cloud.githubusercontent.com/assets/7947083/12589268/e27c9c56-c42a-11e5-934c-225e8eae1c1d.png)

* At post-production reconstruction level:
![g4sphenixcells_1000pi24gev root_qa rootqa_draw_cemc_](https://cloud.githubusercontent.com/assets/7947083/12589286/f3c87ba6-c42a-11e5-9dbf-3fe4b7da821f.png)

