### PR TITLE
Uniform HepMC Vertex Smearing

### DIFF
--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -99,10 +99,19 @@ HepMCNodeReader::process_event(PHCompositeNode *topNode)
       cout << PHWHERE << " unknown world shape " << worldshape << endl;
       exit(1);
     }
-  double xshift = vertex_pos_x + smeargauss(width_vx);
-  double yshift = vertex_pos_y + smeargauss(width_vy);
-  double zshift = vertex_pos_z + smeargauss(width_vz);
+  double xshift = vertex_pos_x; + smeargauss(width_vx);
+  double yshift = vertex_pos_y; + smeargauss(width_vy);
+  double zshift = vertex_pos_z; + smeargauss(width_vz);
 
+  if (width_vx > 0.0) xshift += smeargauss(width_vx);
+  else                xshift += smearflat(width_vx);
+
+  if (width_vy > 0.0) yshift += smeargauss(width_vy);
+  else                yshift += smearflat(width_vy);
+  
+  if (width_vz > 0.0) zshift += smeargauss(width_vz);
+  else                zshift += smearflat(width_vz);
+  
   PHHepMCGenEvent *genevt = findNode::getClass<PHHepMCGenEvent>(topNode,"PHHepMCGenEvent");
   
   HepMC::GenEvent *evt = genevt->getEvent();
@@ -210,6 +219,16 @@ HepMCNodeReader::smeargauss(const double width)
       return 0;
     }
   return gsl_ran_gaussian(RandomGenerator,width);
+}
+
+double
+HepMCNodeReader::smearflat(const double width)
+{
+  if (width == 0)
+    {
+      return 0;
+    }
+  return width*(gsl_rng_uniform_pos(RandomGenerator) - 0.5);
 }
 
 void

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -29,6 +29,7 @@ class HepMCNodeReader : public SubsysReco
 
 private:
   double smeargauss(const double width);
+  double smearflat(const double width);
   int _embed_flag;
   double vertex_pos_x;
   double vertex_pos_y;


### PR DESCRIPTION
Previously only a Gaussian smearing could be applied. I overloaded negative values of smearing into access to a uniform distribution. This is a simple one, but Chris should approve that I have selected the appropriate GSL implementations.