### PR TITLE
Verbosity tune for fun4all server

### DIFF
--- a/offline/framework/fun4all/Fun4AllBase.cc
+++ b/offline/framework/fun4all/Fun4AllBase.cc
@@ -6,14 +6,14 @@ using namespace std;
 
 Fun4AllBase::Fun4AllBase(const string &name):
   ThisName(name),
-  verbosity(0)
+  verbosity(VERBOSITY_QUIET)
 {
   return;
 }
 
 Fun4AllBase::~Fun4AllBase()
 {
-  if (verbosity > 0)
+  if (verbosity >= VERBOSITY_MORE)
     {
       cout << "Deleting " << Name () << endl;
     }

--- a/offline/framework/fun4all/Fun4AllBase.h
+++ b/offline/framework/fun4all/Fun4AllBase.h
@@ -2,6 +2,7 @@
 #define __FUN4ALLBASE_H__
 
 #include <string>
+#include <climits>       // std::numeric_limits
 
 /** Base class for all Fun4All Classes
  *
@@ -29,8 +30,35 @@ class Fun4AllBase
   */
   virtual void Print(const std::string &what = "ALL") const;
 
+  enum enu_Verbosity{
+
+    //! Quiet mode. Only output critical messages. Intended for batch production mode.
+    VERBOSITY_QUIET = 0,
+
+    //! Output some useful messages during manual command line running
+    VERBOSITY_SOME = 1,
+
+    //! Output more messages
+    VERBOSITY_MORE = 2,
+
+    //! Output even more messages
+    VERBOSITY_EVEN_MORE = 3,
+
+    //! Output a lot of messages
+    VERBOSITY_A_LOT = 4,
+
+    // ... use your imagination ...
+
+    //! Show all messages. Useful for step-by-step debugging
+    VERBOSITY_MAX =  INT_MAX
+
+  } ;
+
   /// Sets the verbosity of this module (0 by default=quiet).
-  virtual void Verbosity(const int ival) {verbosity = ival;}
+  virtual void Verbosity(const int ival) {verbosity = static_cast<enu_Verbosity>(ival);}
+
+  /// Sets the verbosity of this module (0 by default=quiet).
+  virtual void Verbosity(enu_Verbosity ival) {verbosity = ival;}
 
   /// Gets the verbosity of this module.
   virtual int Verbosity() const {return verbosity;}

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -71,7 +71,7 @@ Fun4AllServer::~Fun4AllServer()
   delete beginruntimestamp;
   while (Subsystems.begin() != Subsystems.end())
     {
-      if (verbosity)
+      if (verbosity>=VERBOSITY_MORE)
         {
           Subsystems.back().first->Verbosity(verbosity);
         }
@@ -80,7 +80,7 @@ Fun4AllServer::~Fun4AllServer()
     }
   while (HistoManager.begin() != HistoManager.end())
     {
-      if (verbosity)
+      if (verbosity>=VERBOSITY_MORE)
         {
           HistoManager.back()->Verbosity(verbosity);
         }
@@ -90,7 +90,7 @@ Fun4AllServer::~Fun4AllServer()
     }
   while (OutputManager.begin() != OutputManager.end())
     {
-      if (verbosity)
+      if (verbosity>=VERBOSITY_MORE)
         {
           OutputManager.back()->Verbosity(verbosity);
         }
@@ -105,7 +105,7 @@ Fun4AllServer::~Fun4AllServer()
     }
   while (topnodemap.begin() != topnodemap.end())
     {
-      if (verbosity)
+      if (verbosity>=VERBOSITY_MORE)
         {
           topnodemap.begin()->second->print();
         }
@@ -246,7 +246,7 @@ Fun4AllServer::registerSubsystem(SubsysReco *subsystem, const string &topnodenam
     {
       if (iret == Fun4AllReturnCodes::DONOTREGISTERSUBSYSTEM)
         {
-          if (verbosity > 0)
+          if (verbosity >= VERBOSITY_SOME)
             {
               cout << "Not Registering Subsystem " << subsystem->Name() << endl;
             }
@@ -256,7 +256,7 @@ Fun4AllServer::registerSubsystem(SubsysReco *subsystem, const string &topnodenam
            << subsystem->Name() << ", return code: " << iret << endl;
       return iret;
     }
-  if (verbosity > 0)
+  if (verbosity >= VERBOSITY_SOME)
     {
       cout << "Registering Subsystem " << subsystem->Name() << endl;
     }
@@ -302,7 +302,7 @@ Fun4AllServer::unregisterSubsystemsNow()
           delete (*removeiter).first;
           continue;
         }
-      if (verbosity)
+      if (verbosity >= VERBOSITY_MORE)
         {
           cout << "Removing Subsystem: " << (*removeiter).first->Name()
                << " at index " << index << endl;
@@ -330,7 +330,7 @@ Fun4AllServer::getSubsysReco(const string &name)
     {
       if ( (*sysiter).first->Name() == name )
         {
-          if (verbosity > 0)
+          if (verbosity >= VERBOSITY_EVEN_MORE)
             {
               cout << "Found Subsystem " << name << endl;
             }
@@ -371,7 +371,7 @@ Fun4AllServer::registerOutputManager(Fun4AllOutputManager *manager)
           return -1;
         }
     }
-  if (verbosity > 0)
+  if (verbosity >= VERBOSITY_SOME)
     {
       cout << "Registering OutputManager " << manager->Name() << endl;
     }
@@ -390,7 +390,7 @@ Fun4AllServer::UpdateEventSelector(Fun4AllOutputManager *manager)
   manager->RecoModuleIndex()->clear();
   for (striter = manager->EventSelector()->begin();striter != manager->EventSelector()->end(); ++striter)
     {
-      if (verbosity > 0)
+      if (verbosity >= VERBOSITY_EVEN_MORE)
         {
           cout << PHWHERE << "striter: " << *striter << endl;
         }
@@ -401,7 +401,7 @@ Fun4AllServer::UpdateEventSelector(Fun4AllOutputManager *manager)
           if ( *striter == (*subsysiter).first->Name() )
             {
               manager->RecoModuleIndex()->push_back(index);
-              if (verbosity > 0)
+              if (verbosity  >= VERBOSITY_EVEN_MORE)
                 {
                   cout << PHWHERE << "setting RecoModuleIndex to " << index << endl;
                 }
@@ -429,7 +429,7 @@ Fun4AllServer::getOutputManager(const string &name)
     {
       if ( name == (*iter)->Name())
         {
-          if (verbosity > 0)
+          if (verbosity  >= VERBOSITY_EVEN_MORE)
             {
               cout << "Found OutputManager " << name << endl;
             }
@@ -448,14 +448,14 @@ Fun4AllServer::getHistoManager(const string &name)
     {
       if ( (*iter)->Name() == name)
         {
-          if (verbosity > 0)
+          if (verbosity  >= VERBOSITY_EVEN_MORE)
             {
               cout << "Found HistoManager " << name << endl;
             }
           return *iter;
         }
     }
-  if (verbosity > 0)
+  if (verbosity >= VERBOSITY_MORE)
     {
       cout << "Could not find HistoManager " << name << endl;
     }
@@ -474,7 +474,7 @@ Fun4AllServer::registerHistoManager(Fun4AllHistoManager *manager)
           return -1;
         }
     }
-  if (verbosity > 0)
+  if (verbosity >= VERBOSITY_SOME)
     {
       cout << "Registering HistoManager " << manager->Name() << endl;
     }
@@ -536,7 +536,7 @@ Fun4AllServer::process_event()
   string currdir = gDirectory->GetPath();
   for (iter = Subsystems.begin(); iter != Subsystems.end(); ++iter)
     {
-      if (verbosity > 0)
+      if (verbosity >= VERBOSITY_MORE)
         {
           cout << "Fun4AllServer::process_event processing " << (*iter).first->Name() << endl;
         }
@@ -551,7 +551,7 @@ Fun4AllServer::process_event()
         }
       else
         {
-          if (verbosity > 2)
+          if (verbosity >= VERBOSITY_EVEN_MORE)
             {
               cout << "process_event: cded to " << newdirname.str().c_str() << endl;
             }
@@ -578,7 +578,7 @@ Fun4AllServer::process_event()
         {
           if (RetCodes[icnt] == Fun4AllReturnCodes::DISCARDEVENT)
             {
-              if (verbosity > 0)
+              if (verbosity >= VERBOSITY_EVEN_MORE)
                 {
                   cout << "Fun4AllServer::Discard Event by " << (*iter).first->Name() << endl;
                 }
@@ -587,7 +587,7 @@ Fun4AllServer::process_event()
             {
               retcodesmap[Fun4AllReturnCodes::ABORTEVENT]++;
               eventbad = 1;
-              if (verbosity > 0)
+              if (verbosity >= VERBOSITY_MORE)
                 {
                   cout << "Fun4AllServer::Abort Event by " << (*iter).first->Name() << endl;
                 }
@@ -652,7 +652,7 @@ Fun4AllServer::process_event()
             {
               if (!(*iterOutMan)->DoNotWriteEvent(&RetCodes))
                 {
-                  if (verbosity)
+                  if (verbosity >= VERBOSITY_MORE)
                     {
                       cout << "Writing Event for " << (*iterOutMan)->Name() << endl;
                     }
@@ -660,7 +660,7 @@ Fun4AllServer::process_event()
                 }
               else
                 {
-                  if (verbosity)
+                  if (verbosity >= VERBOSITY_MORE)
                     {
                       cout << "Not Writing Event for " << (*iterOutMan)->Name() << endl;
                     }
@@ -671,7 +671,7 @@ Fun4AllServer::process_event()
     }
   for (iter = Subsystems.begin(); iter != Subsystems.end(); ++iter)
     {
-      if (verbosity > 0)
+      if (verbosity >= VERBOSITY_EVEN_MORE)
         {
           cout << "Fun4AllServer::process_event Resetting Event " << (*iter).first->Name() << endl;
         }
@@ -679,7 +679,7 @@ Fun4AllServer::process_event()
     }
   BOOST_FOREACH(Fun4AllSyncManager *syncman, SyncManagers)
     {
-      if (verbosity > 0)
+      if (verbosity >= VERBOSITY_EVEN_MORE)
         {
           cout << "Fun4AllServer::process_event Resetting Event for Sync Manager " << syncman->Name() << endl;
         }
@@ -718,7 +718,7 @@ int Fun4AllServer::Reset()
   vector<pair<SubsysReco *, PHCompositeNode *> >::iterator iter;
   for (iter = Subsystems.begin(); iter != Subsystems.end(); ++iter)
     {
-      if (verbosity > 0)
+      if (verbosity >= VERBOSITY_EVEN_MORE)
         {
           cout << "Fun4AllServer::Reset Resetting " << (*iter).first->Name() << endl;
         }
@@ -760,7 +760,7 @@ int Fun4AllServer::BeginRun(const int runno)
       cout << endl;
       //rc->set_TimeStamp(*beginruntimestamp);
     }
-  if (verbosity > 0)
+  if (verbosity >= VERBOSITY_SOME)
     {
       cout << "Fun4AllServer::BeginRun: Run number " << runno << " uses RECO TIMESTAMP: ";
       beginruntimestamp->print();
@@ -795,13 +795,13 @@ int Fun4AllServer::BeginRun(const int runno)
         }
       else
         {
-          if (verbosity > 2)
+          if (verbosity >= VERBOSITY_EVEN_MORE)
             {
               cout << "BeginRun: cded to " <<  newdirname.str().c_str() << endl;
             }
         }
 
-      if (verbosity > 0)
+      if (verbosity >= VERBOSITY_SOME)
         {
           cout << "Fun4AllServer::BeginRun: InitRun for " << (*iter).first->Name() << endl;
         }
@@ -880,7 +880,7 @@ Fun4AllServer::CountOutNodesRecursive(PHCompositeNode *startNode, const int icou
       else
         {
           icnt++;
-          if (verbosity > 2)
+          if (verbosity >= VERBOSITY_EVEN_MORE)
             {
               cout << thisNode->getName() << ", Node Count: " << icnt << endl;
             }
@@ -935,7 +935,7 @@ int Fun4AllServer::EndRun(const int runno)
   string currdir = gDirectory->GetPath();
   for (iter = Subsystems.begin(); iter != Subsystems.end(); ++iter)
     {
-      if (verbosity > 0)
+      if (verbosity >= VERBOSITY_MORE)
         {
           cout << "Fun4AllServer::EndRun: EndRun("
                << runno << ") for " << (*iter).first->Name() << endl;
@@ -951,7 +951,7 @@ int Fun4AllServer::EndRun(const int runno)
         }
       else
         {
-          if (verbosity > 2)
+          if (verbosity >= VERBOSITY_EVEN_MORE)
             {
               cout << "EndRun: cded to " <<  newdirname.str().c_str() << endl;
             }
@@ -990,7 +990,7 @@ Fun4AllServer::End()
   string currdir = gDirectory->GetPath();
   for (iter = Subsystems.begin(); iter != Subsystems.end(); ++iter)
     {
-      if (verbosity > 0)
+      if (verbosity >= VERBOSITY_SOME)
         {
           cout << "Fun4AllServer::End: End for " << (*iter).first->Name() << endl;
         }
@@ -1005,7 +1005,7 @@ Fun4AllServer::End()
         }
       else
         {
-          if (verbosity > 2)
+          if (verbosity >= VERBOSITY_EVEN_MORE)
             {
               cout << "End: cded to " << newdirname.str().c_str() << endl;
             }
@@ -1176,7 +1176,7 @@ int Fun4AllServer::outfileclose()
 {
   while (!OutputManager.empty())
     {
-      if (verbosity > 0)
+      if (verbosity >= VERBOSITY_MORE)
         {
           cout << "Erasing OutputManager "
                << (*OutputManager.begin())->Name()
@@ -1306,7 +1306,7 @@ Fun4AllServer::run(const int nevnts, const bool require_nevents)
       int resetnodetree = 0;
       for (iter = SyncManagers.begin(); iter != SyncManagers.end(); ++iter)
         {
-          if (verbosity > 1)
+          if (verbosity >= VERBOSITY_MORE)
             {
               cout << "executing run for input master " << (*iter)->Name() << endl;
 
@@ -1563,7 +1563,7 @@ Fun4AllServer::registerSyncManager(Fun4AllSyncManager *newmaster)
 	  return -1;
         }
     }
-  if (verbosity > 0)
+  if (verbosity >= VERBOSITY_SOME)
     {
       cout << "Registering Input Master " << newmaster->Name() << endl;
     }

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -30,6 +30,7 @@
 #include <boost/foreach.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
@@ -1394,7 +1395,38 @@ Fun4AllServer::run(const int nevnts, const bool require_nevents)
 	      BeginRun(runnumber);
 	    }
 	}
+
+      if (verbosity>=VERBOSITY_SOME)
+        {
+          // print event cycle counter in log scale if VERBOSITY_SOME
+
+          const double significand = icnt / pow(10, (int) (log10(icnt)));
+
+          if ((fmod(significand, 1.0) == 0 && significand <= 10) or icnt == 0)
+            {
+              cout << "Fun4AllServer::run - process_event cycle "
+              << icnt << "\t for run " << runnumber ;
+              if (require_nevents)
+                cout <<", "<<icnt_good <<" good event so far";
+              cout << endl;
+            }
+        }
+
+
+      if (icnt == 0 and verbosity>VERBOSITY_QUIET)
+        {
+          // increase verbosity for the first event in verbose modes
+          ++verbosity;
+        }
+
       iret = process_event();      
+
+      if (icnt == 0 and verbosity>VERBOSITY_QUIET)
+        {
+          // increase verbosity for the first event in verbose modes
+          --verbosity;
+        }
+
       if (require_nevents)
         {
           if (std::find(RetCodes.begin(),

--- a/simulation/g4simulation/g4eval/PHG4DSTReader.cc
+++ b/simulation/g4simulation/g4eval/PHG4DSTReader.cc
@@ -227,10 +227,10 @@ int
 PHG4DSTReader::process_event(PHCompositeNode* topNode)
 {
 
-  const double significand = _event / TMath::Power(10, (int) (log10(_event)));
-
-  if (fmod(significand, 1.0) == 0 && significand <= 10)
-    cout << "PHG4DSTReader::process_event - " << _event << endl;
+//  const double significand = _event / TMath::Power(10, (int) (log10(_event)));
+//
+//  if (fmod(significand, 1.0) == 0 && significand <= 10)
+//    cout << "PHG4DSTReader::process_event - " << _event << endl;
   _event++;
 
   //clean ups


### PR DESCRIPTION
Two light touches on the framework code, which should not change be default behavior: 

1. Introduce an enum name for each level of verbosity for ```Fun4AllBase::verbosity``` (without breaking compatibility of using it as integer). 

Therefore, instead of writing 
```c++
if (verbosity > 1) cout <"some debug message"; 
```
one can choose to write as 
```
if (verbosity >= VERBOSITY_SOME) cout <"some debug message"; 
```
Similar user can choose verbosity levels in macro with enum tags instead of number now. More in ```Fun4AllBase::enu_Verbosity```, which will be compiled to searchable documentation in doxygen once merged.

2. Sort out levels of verbosity messages in ```Fun4AllServer```. Default is still quiet mode (suitable for batch condor jobs), although I advertise for verbosity level ```VERBOSITY_SOME``` during interactive running. 

If set this line in the macro: 
```c++
  Fun4AllServer *se = Fun4AllServer::instance();
  se->Verbosity(Fun4AllServer::VERBOSITY_SOME); // In interactive root running, print some useful info to show progress, including log-scale event counter
```
Fun4AllServer will output some useful info to show progress, including log-scale event counter and module progress for the first event. In my experience, this is usually useful when developing your own analysis module to indicate show how many event processed or to ID a module caused a crash in first event. 

An example output is
```
Processing Fun4All_G4_sPHENIX.C...
Registering Subsystem CYLINDERRECO
.....
Registering Subsystem QAG4SimulationCalorimeterSum
Fun4AllServer: Runnumber forced to 0 by RUNNUMBER IntFlag
Fun4AllServer::setRun(): could not get timestamp for run  0, using tics(0) timestamp: Wed Dec 31 19:00:00 1969
Fun4AllServer::BeginRun: Run number 0 uses RECO TIMESTAMP: Sat Mar  5 16:53:31 2016
Fun4AllServer::BeginRun: InitRun for CYLINDERRECO
...
Fun4AllServer::BeginRun: InitRun for QAG4SimulationCalorimeter_HCALOUT
Fun4AllServer::BeginRun: InitRun for QAG4SimulationCalorimeterSum
--------------------------------------

List of Nodes in Fun4AllServer:
Node Tree under TopNode TOP
TOP (PHCompositeNode)/
   DST (PHCompositeNode)/
      G4HIT_PIPE (PHIODataNode)
      G4HIT_SVTX (PHIODataNode)
      G4HIT_SVTXSUPPORT (PHIODataNode)
....
   PAR (PHCompositeNode)/
      SVTX (PHCompositeNode)/
         SvtxBeamSpot (PHIODataNode)


Fun4AllServer::run - process_event cycle 0	 for run 0
Fun4AllServer::process_event processing CYLINDERRECO
Fun4AllServer::process_event processing CEMCCYLCELLRECO
Fun4AllServer::process_event processing HCALCELLRECO
...
Fun4AllServer::process_event processing QAG4SimulationCalorimeter_HCALOUT
Fun4AllServer::process_event processing QAG4SimulationCalorimeterSum
Fun4AllServer::run - process_event cycle 1	 for run 0
Fun4AllServer::run - process_event cycle 2	 for run 0
Fun4AllServer::run - process_event cycle 3	 for run 0
Fun4AllServer::run - process_event cycle 4	 for run 0
Fun4AllServer::run - process_event cycle 5	 for run 0
Fun4AllServer::run - process_event cycle 6	 for run 0
Fun4AllServer::run - process_event cycle 7	 for run 0
Fun4AllServer::run - process_event cycle 8	 for run 0
Fun4AllServer::run - process_event cycle 9	 for run 0
Fun4AllServer::run - process_event cycle 10	 for run 0
Fun4AllServer::run - process_event cycle 20	 for run 0
Fun4AllServer::run - process_event cycle 30	 for run 0
Fun4AllServer::run - process_event cycle 40	 for run 0
Fun4AllServer::run - process_event cycle 50	 for run 0
Fun4AllServer::run - process_event cycle 60	 for run 0
Fun4AllServer::run - process_event cycle 70	 for run 0
Fun4AllServer::run - process_event cycle 80	 for run 0
Fun4AllServer::run - process_event cycle 90	 for run 0
Fun4AllServer::run - process_event cycle 100	 for run 0
Fun4AllServer::End: End for CYLINDERRECO
Fun4AllServer::End: End for CEMCCYLCELLRECO
Fun4AllServer::End: End for HCALCELLRECO
Fun4AllServer::End: End for HCALCELLRECO
...
Fun4AllServer::End: End for QAG4SimulationCalorimeter_HCALIN
Fun4AllServer::End: End for QAG4SimulationCalorimeter_HCALOUT
Fun4AllServer::End: End for QAG4SimulationCalorimeterSum
All done

```
