### PR TITLE
mlp -- based on some googling, remove -fkeep-inline to see if this

### DIFF
--- a/online_distribution/newbasic/configure.in
+++ b/online_distribution/newbasic/configure.in
@@ -62,7 +62,7 @@ AC_PROG_LIBTOOL
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -fkeep-inline-functions"
+  CXXFLAGS="$CXXFLAGS -Wall"
 fi
 
 AC_HEADER_STDC


### PR DESCRIPTION
at long last, I was able to nail down the difference between a standard and the nightly rebuild. It activates a switch that effectively adds -fkeep-inline-functions to the link flags. Google finds a reference to thsi as the culprit that results in a failure to instantiate a number of STL and boost classes. We'll see what this gives.  