### PR TITLE
Implementation of fsPHENIX Dual EMCal (reuse PbGL and MPC)

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -140,6 +140,7 @@ libg4detectors_la_SOURCES = \
   PHG4FCalSubsystem.cc \
   PHG4FCalSubsystem_Dict.cc \
   PHG4ForwardEcalDetector.cc \
+  PHG4EICForwardEcalDetector.cc \
   PHG4ForwardEcalSteppingAction.cc \
   PHG4ForwardEcalSubsystem.cc \
   PHG4ForwardEcalSubsystem_Dict.cc \

--- a/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.cc
@@ -140,15 +140,15 @@ PHG4EICForwardEcalDetector::ConstructTower()
 						      0, 0, 0);
 
   /* create geometry volumes for scintillator and absorber plates to place inside single_tower */
-  //G4int nlayers = 60;
-  //G4double thickness_layer = _tower_dz/(float)nlayers;
-  //G4double thickness_absorber = thickness_layer / 3.0 * 2.0; // 2/3rd absorber
-  //G4double thickness_scintillator = thickness_layer / 3.0 * 1.0; // 1/3rd scintillator
-  // PHENIX EMCal JGL 12/27/2015
-  G4int nlayers = 66;
+  G4int nlayers = 60;
   G4double thickness_layer = _tower_dz/(float)nlayers;
-  G4double thickness_absorber = thickness_layer*0.23; // 27% absorber by length
-  G4double thickness_scintillator = thickness_layer*0.73; // 73% scintillator by length
+  G4double thickness_absorber = thickness_layer / 3.0 * 2.0; // 2/3rd absorber
+  G4double thickness_scintillator = thickness_layer / 3.0 * 1.0; // 1/3rd scintillator
+  // PHENIX EMCal JGL 12/27/2015
+  // G4int nlayers = 66;
+  // G4double thickness_layer = _tower_dz/(float)nlayers;
+  // G4double thickness_absorber = thickness_layer*0.23; // 27% absorber by length
+  // G4double thickness_scintillator = thickness_layer*0.73; // 73% scintillator by length
 
   G4VSolid* solid_absorber = new G4Box( G4String("single_plate_absorber_solid"),
 				   _tower_dx / 2.0,

--- a/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.h
@@ -1,0 +1,76 @@
+#ifndef PHG4EICForwardEcalDetector_h
+#define PHG4EICForwardEcalDetector_h
+
+#include <g4main/PHG4Detector.h>
+#include <PHG4ForwardEcalDetector.h>
+
+#include <Geant4/globals.hh>
+#include <Geant4/G4Types.hh>
+#include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4RotationMatrix.hh>
+#include <Geant4/G4Material.hh>
+
+#include <string>
+#include <map>
+#include <vector>
+#include <set>
+
+class G4AssemblyVolume;
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+class G4VSolid;
+
+/**
+ * \file ${file_name}
+ * \brief Module to build forward sampling Hadron calorimeterr (endcap) in Geant4
+ * \author Nils Feege <nils.feege@stonybrook.edu>
+ */
+
+class PHG4EICForwardEcalDetector: public PHG4ForwardEcalDetector
+{
+
+public:
+
+  //! constructor
+  PHG4EICForwardEcalDetector( PHCompositeNode *Node, const std::string &dnam="BLOCK" );
+
+  //! destructor
+  virtual ~PHG4EICForwardEcalDetector();
+
+  //! construct
+  virtual void Construct( G4LogicalVolume* world );
+
+  virtual void SetTowerDimensions(G4double dx, G4double dy, G4double dz) {
+  _tower_dx = dx;
+  _tower_dy = dy;
+  _tower_dz = dz;
+  }
+
+  void SetMaterialScintillator( G4String material ) { _materialScintillator = material; }
+  void SetMaterialAbsorber( G4String material ) { _materialAbsorber = material; }
+
+private:
+
+  G4LogicalVolume* ConstructTower();
+  int PlaceTower(G4LogicalVolume* envelope , G4LogicalVolume* tower);
+  int ParseParametersFromTable();
+
+  struct towerposition {
+    G4double x;
+    G4double y;
+    G4double z;
+  } ;
+
+  std::map< std::string, towerposition > _map_tower;
+
+  /* ECAL tower geometry */
+  G4double _tower_dx;
+  G4double _tower_dy;
+  G4double _tower_dz;
+
+  G4String _materialScintillator;
+  G4String _materialAbsorber;
+
+};
+
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
@@ -22,6 +22,7 @@
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Trd.hh>
+#include <Geant4/G4NistManager.hh>
 
 #include <Geant4/G4VisAttributes.hh>
 #include <Geant4/G4Colour.hh>
@@ -53,11 +54,12 @@ PHG4ForwardEcalDetector::PHG4ForwardEcalDetector( PHCompositeNode *Node, const s
   _dZ(170*mm),
   _sPhi(0),
   _dPhi(2*M_PI),
-  _tower_dx(30*mm),
-  _tower_dy(30*mm),
-  _tower_dz(170.0*mm),
-  _materialScintillator( "G4_POLYSTYRENE" ),
-  _materialAbsorber( "G4_Pb" ),
+  _tower0_dx(30*mm),
+  _tower0_dy(30*mm),
+  _tower0_dz(170.0*mm),
+  _tower1_dx(30*mm),
+  _tower1_dy(30*mm),
+  _tower1_dz(170.0*mm),
   _active(1),
   _absorberactive(0),
   _layer(0),
@@ -159,10 +161,11 @@ PHG4ForwardEcalDetector::Construct( G4LogicalVolume* logicWorld )
 		     ecal_envelope_log, name_envelope.str().c_str(), logicWorld, 0, false, overlapcheck);
 
   /* Construct single calorimeter tower */
-  G4LogicalVolume* singletower = ConstructTower();
+  G4LogicalVolume* singletower0 = ConstructTower(0);
+  G4LogicalVolume* singletower1 = ConstructTower(1);
 
-  /* Place calorimeter tower within envelope */
-  PlaceTower( ecal_envelope_log , singletower );
+  /* Place calorimeter towers within envelope */
+  PlaceTower( ecal_envelope_log , singletower0, singletower1 );
 
   return;
 }
@@ -170,7 +173,7 @@ PHG4ForwardEcalDetector::Construct( G4LogicalVolume* logicWorld )
 
 //_______________________________________________________________________
 G4LogicalVolume*
-PHG4ForwardEcalDetector::ConstructTower()
+PHG4ForwardEcalDetector::ConstructTower( int type )
 {
   if ( verbosity > 0 )
     {
@@ -180,90 +183,83 @@ PHG4ForwardEcalDetector::ConstructTower()
   /* create logical volume for single tower */
   G4Material* material_air = G4Material::GetMaterial( "G4_AIR" );
 
-  G4VSolid* single_tower_solid = new G4Box( G4String("single_tower_solid"),
+  G4double _tower_dx = 0.0;
+  G4double _tower_dy = 0.0;
+  G4double _tower_dz = 0.0;
+
+  G4NistManager* manager = G4NistManager::Instance();
+  G4Material* material_scintillator;
+
+  if(type==0){
+    _tower_dx = _tower0_dx; 
+    _tower_dy = _tower0_dy; 
+    _tower_dz = _tower0_dz;
+    material_scintillator = manager->FindOrBuildMaterial("G4_LEAD_OXIDE"); 
+  }
+  else if(type==1){
+    _tower_dx = _tower1_dx; 
+    _tower_dy = _tower1_dy; 
+    _tower_dz = _tower1_dz; 
+    material_scintillator = manager->FindOrBuildMaterial("G4_PbWO4"); 
+  }
+  else{
+    cout << "PHG4ForwardEcalDetector: invalid type = " << type << endl;
+    material_scintillator = NULL; 
+  }
+
+  ostringstream single_tower_solid_name;
+  single_tower_solid_name.str("");
+  single_tower_solid_name << _towerlogicnameprefix << "_single_scintillator_type" << type << endl;
+
+  G4VSolid* single_tower_solid = new G4Box( G4String(single_tower_solid_name.str().c_str()),
                                        _tower_dx / 2.0,
                                        _tower_dy / 2.0,
                                        _tower_dz / 2.0 );
 
+  ostringstream single_tower_logic_name;
+  single_tower_logic_name.str("");
+  single_tower_logic_name << "single_tower_logic_type" << type << endl;
+
   G4LogicalVolume *single_tower_logic = new G4LogicalVolume( single_tower_solid,
-						      material_air,
-						      "single_tower_logic",
-						      0, 0, 0);
+							     material_air,
+							     single_tower_logic_name.str().c_str(),
+							     0, 0, 0);
 
-  /* create geometry volumes for scintillator and absorber plates to place inside single_tower */
-  //G4int nlayers = 60;
-  //G4double thickness_layer = _tower_dz/(float)nlayers;
-  //G4double thickness_absorber = thickness_layer / 3.0 * 2.0; // 2/3rd absorber
-  //G4double thickness_scintillator = thickness_layer / 3.0 * 1.0; // 1/3rd scintillator
-  // PHENIX EMCal JGL 12/27/2015
-  G4int nlayers = 66;
-  G4double thickness_layer = _tower_dz/(float)nlayers;
-  G4double thickness_absorber = thickness_layer*0.23; // 27% absorber by length
-  G4double thickness_scintillator = thickness_layer*0.73; // 73% scintillator by length
+  ostringstream single_scintillator_name;
+  single_scintillator_name.str("");
+  single_scintillator_name << "single_scintillator_type" << type << endl;
 
-  G4VSolid* solid_absorber = new G4Box( G4String("single_plate_absorber_solid"),
+  G4VSolid* solid_scintillator = new G4Box( G4String(single_scintillator_name.str().c_str()),
 				   _tower_dx / 2.0,
 				   _tower_dy / 2.0,
-				   thickness_absorber / 2.0 );
+				   _tower_dz / 2.0 );
 
-  G4VSolid* solid_scintillator = new G4Box( G4String("single_plate_scintillator"),
-				   _tower_dx / 2.0,
-				   _tower_dy / 2.0,
-				   thickness_scintillator / 2.0 );
-
-  /* create logical volumes for scintillator and absorber plates to place inside single_tower */
-  G4Material* material_scintillator = G4Material::GetMaterial( _materialScintillator.c_str() );
-  G4Material* material_absorber = G4Material::GetMaterial( _materialAbsorber.c_str() );
-
-  G4LogicalVolume *logic_absorber = new G4LogicalVolume( solid_absorber,
-						    material_absorber,
-						    "single_plate_absorber_logic",
-						    0, 0, 0);
+  ostringstream hEcal_scintillator_plate_logic_name;
+  hEcal_scintillator_plate_logic_name.str("");
+  hEcal_scintillator_plate_logic_name << "hEcal_scintillator_plate_logic_type" << type << endl;
 
   G4LogicalVolume *logic_scint = new G4LogicalVolume( solid_scintillator,
-						    material_scintillator,
-						    "hEcal_scintillator_plate_logic",
-						    0, 0, 0);
+						      material_scintillator,
+						      hEcal_scintillator_plate_logic_name.str().c_str(),
+						      0, 0, 0);
 
   G4VisAttributes *visattscint = new G4VisAttributes();
   visattscint->SetVisibility(true);
   visattscint->SetForceSolid(true);
   visattscint->SetColour(G4Colour::Cyan());
-  logic_absorber->SetVisAttributes(visattscint);
   logic_scint->SetVisAttributes(visattscint);
 
-  /* place physical volumes for absorber and scintillator plates */
-  G4double xpos_i = 0;
-  G4double ypos_i = 0;
-  G4double zpos_i = ( -1 * _tower_dz / 2.0 ) + thickness_absorber / 2.0;
-
-  ostringstream name_absorber;
-  name_absorber.str("");
-  name_absorber << _towerlogicnameprefix << "_single_plate_absorber" << endl;
+  /* place physical volumes for scintillator */
 
   ostringstream name_scintillator;
   name_scintillator.str("");
   name_scintillator << _towerlogicnameprefix << "_single_plate_scintillator" << endl;
 
-  for (int i = 1; i <= nlayers; i++)
-    {
-      new G4PVPlacement( 0, G4ThreeVector(xpos_i , ypos_i, zpos_i),
-			 logic_absorber,
-			 name_absorber.str().c_str(),
-			 single_tower_logic,
-			 0, 0, overlapcheck);
-
-      zpos_i += ( thickness_absorber/2. + thickness_scintillator/2. );
-
-      new G4PVPlacement( 0, G4ThreeVector(xpos_i , ypos_i, zpos_i),
-			 logic_scint,
-			 name_scintillator.str().c_str(),
-			 single_tower_logic,
-			 0, 0, overlapcheck);
-
-      zpos_i += ( thickness_absorber/2. + thickness_scintillator/2. );
-    }
-
+  new G4PVPlacement( 0, G4ThreeVector(0.0, 0.0, 0.0),
+		     logic_scint,
+		     name_scintillator.str().c_str(),
+		     single_tower_logic,
+		     0, 0, overlapcheck);
 
   G4VisAttributes *visattchk = new G4VisAttributes();
   visattchk->SetVisibility(true);
@@ -280,7 +276,7 @@ PHG4ForwardEcalDetector::ConstructTower()
 }
 
 int
-PHG4ForwardEcalDetector::PlaceTower(G4LogicalVolume* ecalenvelope, G4LogicalVolume* singletower)
+PHG4ForwardEcalDetector::PlaceTower(G4LogicalVolume* ecalenvelope, G4LogicalVolume* singletower0, G4LogicalVolume* singletower1)
 {
   /* Loop over all tower positions in vector and place tower */
   typedef std::map< std::string, towerposition>::iterator it_type;
@@ -292,6 +288,14 @@ PHG4ForwardEcalDetector::PlaceTower(G4LogicalVolume* ecalenvelope, G4LogicalVolu
 	  cout << "PHG4ForwardEcalDetector: Place tower " << iterator->first
 	       << " at x = " << iterator->second.x << " , y = " << iterator->second.y << " , z = " << iterator->second.z << endl;
 	}
+
+      G4LogicalVolume* singletower = NULL;
+      if(iterator->second.type==0)
+	singletower = singletower0; 
+      else if(iterator->second.type==1)
+	singletower = singletower1; 
+      else
+	cout << "PHG4ForwardEcalDetector: invalid type =  " << iterator->second.type << endl; 
 
       new G4PVPlacement( 0, G4ThreeVector(iterator->second.x, iterator->second.y, iterator->second.z),
 			 singletower,
@@ -343,11 +347,11 @@ PHG4ForwardEcalDetector::ParseParametersFromTable()
 	  G4double pos_x, pos_y, pos_z;
 	  G4double size_x, size_y, size_z;
 	  G4double rot_x, rot_y, rot_z;
-	  G4double dummy;
+	  G4double type;
 	  string dummys;
 
 	  /* read string- break if error */
-	  if ( !( iss >> dummys >> dummy >> idx_j >> idx_k >> idx_l >> pos_x >> pos_y >> pos_z >> size_x >> size_y >> size_z >> rot_x >> rot_y >> rot_z ) )
+	  if ( !( iss >> dummys >> type >> idx_j >> idx_k >> idx_l >> pos_x >> pos_y >> pos_z >> size_x >> size_y >> size_z >> rot_x >> rot_y >> rot_z ) )
 	    {
 	      cerr << "ERROR in PHG4ForwardEcalDetector: Failed to read line in mapping file " << _mapping_tower_file << endl;
 	      exit(1);
@@ -357,7 +361,7 @@ PHG4ForwardEcalDetector::ParseParametersFromTable()
 	  /* Mapping file uses cm, this class uses mm for length */
 	  ostringstream towername;
 	  towername.str("");
-	  towername << _towerlogicnameprefix << "_j_" << idx_j << "_k_" << idx_k;
+	  towername << _towerlogicnameprefix << "_t_" << type << "_j_" << idx_j << "_k_" << idx_k;
 
 	  /* Add Geant4 units */
 	  pos_x = pos_x * cm;
@@ -369,6 +373,7 @@ PHG4ForwardEcalDetector::ParseParametersFromTable()
 	  tower_new.x = pos_x;
 	  tower_new.y = pos_y;
 	  tower_new.z = pos_z;
+	  tower_new.type = type; 
 	  _map_tower.insert( make_pair( towername.str() , tower_new ) );
 
 	}
@@ -393,17 +398,29 @@ PHG4ForwardEcalDetector::ParseParametersFromTable()
   /* Update member variables for global parameters based on parsed parameter file */
   std::map<string,G4double>::iterator parit;
 
-  parit = _map_global_parameter.find("Gtower_dx");
+  parit = _map_global_parameter.find("Gtower0_dx");
   if (parit != _map_global_parameter.end())
-    _tower_dx = parit->second * cm;
+    _tower0_dx = parit->second * cm;
 
-  parit = _map_global_parameter.find("Gtower_dy");
+  parit = _map_global_parameter.find("Gtower0_dy");
   if (parit != _map_global_parameter.end())
-    _tower_dy = parit->second * cm;
+    _tower0_dy = parit->second * cm;
 
-  parit = _map_global_parameter.find("Gtower_dz");
+  parit = _map_global_parameter.find("Gtower0_dz");
   if (parit != _map_global_parameter.end())
-    _tower_dz = parit->second * cm;
+    _tower0_dz = parit->second * cm;
+
+  parit = _map_global_parameter.find("Gtower1_dx");
+  if (parit != _map_global_parameter.end())
+    _tower1_dx = parit->second * cm;
+
+  parit = _map_global_parameter.find("Gtower1_dy");
+  if (parit != _map_global_parameter.end())
+    _tower1_dy = parit->second * cm;
+
+  parit = _map_global_parameter.find("Gtower1_dz");
+  if (parit != _map_global_parameter.end())
+    _tower1_dz = parit->second * cm;
 
   parit = _map_global_parameter.find("Gr1_inner");
   if (parit != _map_global_parameter.end())

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
@@ -49,10 +49,17 @@ public:
   }
 
 
-  void SetTowerDimensions(G4double dx, G4double dy, G4double dz) {
-  _tower_dx = dx;
-  _tower_dy = dy;
-  _tower_dz = dz;
+  void SetTowerDimensions(G4double dx, G4double dy, G4double dz, G4double type) {
+    if(type==0){
+      _tower0_dx = dx;
+      _tower0_dy = dy;
+      _tower0_dz = dz;
+    }
+    else{
+      _tower1_dx = dx;
+      _tower1_dy = dy;
+      _tower1_dz = dz;
+    }
   }
 
   void SetPlace( G4double place_in_x, G4double place_in_y, G4double place_in_z) {
@@ -64,9 +71,6 @@ public:
   void SetXRot( G4double rot_in_x ) { _rot_in_x = rot_in_x; }
   void SetYRot( G4double rot_in_y ) { _rot_in_y = rot_in_y; }
   void SetZRot( G4double rot_in_z ) { _rot_in_z = rot_in_z; }
-
-  void SetMaterialScintillator( G4String material ) { _materialScintillator = material; }
-  void SetMaterialAbsorber( G4String material ) { _materialAbsorber = material; }
 
   void SetActive(const int i = 1) {_active = i;}
   void SetAbsorberActive(const int i = 1) {_absorberactive = i;}
@@ -83,14 +87,15 @@ public:
 
 private:
 
-  G4LogicalVolume* ConstructTower();
-  int PlaceTower(G4LogicalVolume* envelope , G4LogicalVolume* tower);
+  G4LogicalVolume* ConstructTower( int type );
+  int PlaceTower(G4LogicalVolume* envelope , G4LogicalVolume* tower0, G4LogicalVolume* tower1 );
   int ParseParametersFromTable();
 
   struct towerposition {
     G4double x;
     G4double y;
     G4double z;
+    G4double type; 
   } ;
 
   /* Calorimeter envelope geometry */
@@ -112,12 +117,13 @@ private:
   G4double _dPhi;
 
   /* ECAL tower geometry */
-  G4double _tower_dx;
-  G4double _tower_dy;
-  G4double _tower_dz;
+  G4double _tower0_dx;
+  G4double _tower0_dy;
+  G4double _tower0_dz;
 
-  G4String _materialScintillator;
-  G4String _materialAbsorber;
+  G4double _tower1_dx;
+  G4double _tower1_dy;
+  G4double _tower1_dz;
 
   int _active;
   int _absorberactive;

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
@@ -42,14 +42,12 @@ public:
   //!@name volume accessors
   int IsInForwardEcal(G4VPhysicalVolume*) const;
 
-
   //! Select mapping file for calorimeter tower
   void SetTowerMappingFile( std::string filename ) {
     _mapping_tower_file = filename;
   }
 
-
-  void SetTowerDimensions(G4double dx, G4double dy, G4double dz, G4double type) {
+  virtual void SetTowerDimensions(G4double dx, G4double dy, G4double dz, G4double type) {
     if(type==0){
       _tower0_dx = dx;
       _tower0_dy = dy;
@@ -98,6 +96,19 @@ private:
     G4double type; 
   } ;
 
+  std::map< std::string, towerposition > _map_tower;
+
+  /* ECAL tower geometry */
+  G4double _tower0_dx;
+  G4double _tower0_dy;
+  G4double _tower0_dz;
+
+  G4double _tower1_dx;
+  G4double _tower1_dy;
+  G4double _tower1_dz;
+
+protected:
+
   /* Calorimeter envelope geometry */
   G4double _place_in_x;
   G4double _place_in_y;
@@ -116,15 +127,6 @@ private:
   G4double _sPhi;
   G4double _dPhi;
 
-  /* ECAL tower geometry */
-  G4double _tower0_dx;
-  G4double _tower0_dy;
-  G4double _tower0_dz;
-
-  G4double _tower1_dx;
-  G4double _tower1_dy;
-  G4double _tower1_dz;
-
   int _active;
   int _absorberactive;
   int _layer;
@@ -135,7 +137,7 @@ private:
   std::string _mapping_tower_file;
 
   std::map< std::string, G4double > _map_global_parameter;
-  std::map< std::string, towerposition > _map_tower;
+
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.cc
@@ -1,5 +1,6 @@
 #include "PHG4ForwardEcalSubsystem.h"
 #include "PHG4ForwardEcalDetector.h"
+#include "PHG4EICForwardEcalDetector.h"
 #include "PHG4ForwardEcalSteppingAction.h"
 #include "PHG4EventActionClearZeroEdep.h"
 
@@ -24,7 +25,8 @@ PHG4ForwardEcalSubsystem::PHG4ForwardEcalSubsystem( const std::string &name, con
   absorber_active(0),
   blackhole(0),
   detector_type(name),
-  mappingfile_("")
+  mappingfile_(""),
+  EICDetector(0)
 {
 
 }
@@ -37,7 +39,11 @@ int PHG4ForwardEcalSubsystem::Init( PHCompositeNode* topNode )
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
 
   // create detector
-  detector_ = new PHG4ForwardEcalDetector(topNode, Name());
+  if(EICDetector)
+    detector_ = new PHG4EICForwardEcalDetector(topNode, Name());
+  else
+    detector_ = new PHG4ForwardEcalDetector(topNode, Name());
+
   detector_->SetActive(active);
   detector_->SetAbsorberActive(absorber_active);
   detector_->BlackHole(blackhole);

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.h
@@ -52,6 +52,9 @@ public:
   void SetAbsorberActive(const int i = 1){absorber_active = i;}
   void BlackHole(const int i=1){blackhole = i;}
 
+  void SetEICDetector(){EICDetector = 1;}
+  void SetfsPHENIXDetector(){EICDetector = 0;}
+
 private:
 
   /** Pointer to the Geant4 implementation of the detector
@@ -69,6 +72,8 @@ private:
 
   std::string detector_type;
   std::string mappingfile_;
+
+  int EICDetector; 
 
 };
 


### PR DESCRIPTION
This commit implements the fsPHENIX dual EMCal, comprised of re-used elements of the PHENIX PbGl and MPC. This can be easily switched between the EIC EMCal and the fsPHENIX EMCal at the macro level; PHG4ForwardEcalSubsystem can use different detector classes (derived from a base class), selectable at the macro level.  This allow fsPHENIX to move forward with the new implementation without breaking compatibility with the EIC detector simulations.  

Some pretty plots - the EIC EMCal (Pb/Sc sandwich): 
<img width="775" alt="eic_emcal" src="https://cloud.githubusercontent.com/assets/3042746/13790167/122a7bb6-eab5-11e5-8012-704553a00ffa.png">

and the brand new fsPHENIX dual EMCal:
<img width="812" alt="new_fsphenix_emcal" src="https://cloud.githubusercontent.com/assets/3042746/13790176/1da0621c-eab5-11e5-83c9-ab9666b7ea9c.png">
