### PR TITLE
fix distance between scinti slats in inner hcal, use parameter for scintillator front face length

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -41,10 +41,11 @@ PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNod
   steel_plate_corner_upper_right(1308.5*mm,-286.96*mm), 
   steel_plate_corner_lower_right(1298.8*mm,-297.39*mm),
   steel_plate_corner_lower_left(1155.8*mm,-163.92*mm),
+  scinti_u1_front_size(105.9*mm),
   scinti_u1_corner_upper_left(0*mm,0*mm),
   scinti_u1_corner_upper_right(198.1*mm,0*mm),
   scinti_u1_corner_lower_right(198.1*mm,-121.3*mm),
-  scinti_u1_corner_lower_left(0*mm,-105.9*mm),
+  scinti_u1_corner_lower_left(0*mm,-scinti_u1_front_size),
   scinti_u2_corner_upper_left(0*mm,0*mm),
   scinti_u2_corner_upper_right(198.1*mm,-15.4*mm),
   scinti_u2_corner_lower_right(198.1*mm,-141.5*mm),
@@ -143,11 +144,6 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
   G4VSolid* scintiboxsolid = new G4Box("InnerHcalScintiMother",scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String("InnerHcalScintiMother"), 0, 0, 0);
-  G4VisAttributes *visattchk = new G4VisAttributes();
-  visattchk->SetVisibility(true);
-  visattchk->SetForceSolid(false);
-  visattchk->SetColour(G4Colour::Yellow());
-  scintiboxlogical->SetVisAttributes(visattchk);
   G4VisAttributes* hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
   hcalVisAtt->SetForceSolid(false);
@@ -164,7 +160,7 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
   G4RotationMatrix *Rot;  
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-166.2*mm-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,"InnerScinti_0", scintiboxlogical, false, 0, overlapcheck);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-scinti_u1_front_size-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,"InnerScinti_0", scintiboxlogical, false, 0, overlapcheck);
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
@@ -176,7 +172,7 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,166.2*mm+gap_between_tiles/2.+gap_between_tiles),scintiu2_logic,"InnerScinti_3", scintiboxlogical, false, 0, overlapcheck);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,scinti_u1_front_size+gap_between_tiles/2.+gap_between_tiles),scintiu2_logic,"InnerScinti_3", scintiboxlogical, false, 0, overlapcheck);
 
 
   return scintiboxlogical;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
@@ -62,6 +62,7 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   G4TwoVector steel_plate_corner_upper_right;
   G4TwoVector steel_plate_corner_lower_right;
   G4TwoVector steel_plate_corner_lower_left;
+  double scinti_u1_front_size;
   G4TwoVector scinti_u1_corner_upper_left;
   G4TwoVector scinti_u1_corner_upper_right;
   G4TwoVector scinti_u1_corner_lower_right;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -52,10 +52,11 @@ PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNod
   steel_plate_corner_upper_right(2600.4*mm,-417.4*mm), 
   steel_plate_corner_lower_right(2601.2*mm,-459.8*mm),
   steel_plate_corner_lower_left(1770.9*mm,-459.8*mm),
+  scinti_u1_front_size(166.2*mm),
   scinti_u1_corner_upper_left(0*mm,0*mm),
   scinti_u1_corner_upper_right(828.9*mm,0*mm),
   scinti_u1_corner_lower_right(828.9*mm,-240.54*mm),
-  scinti_u1_corner_lower_left(0*mm,-166.2*mm),
+  scinti_u1_corner_lower_left(0*mm,-scinti_u1_front_size),
   scinti_u2_corner_upper_left(0*mm,0*mm),
   scinti_u2_corner_upper_right(828.9*mm,-74.3*mm),
   scinti_u2_corner_lower_right(828.9*mm,-320.44*mm),
@@ -154,11 +155,6 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
   G4VSolid* scintiboxsolid = new G4Box("OuterHcalScintiMother",scinti_x/2.,scinti_gap/2.,scinti_tile_z/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String("OuterHcalScintiMother"), 0, 0, 0);
-  G4VisAttributes *visattchk = new G4VisAttributes();
-  visattchk->SetVisibility(true);
-  visattchk->SetForceSolid(false);
-  visattchk->SetColour(G4Colour::Yellow());
-  scintiboxlogical->SetVisAttributes(visattchk);
   G4VisAttributes* hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
   hcalVisAtt->SetForceSolid(false);
@@ -175,7 +171,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
   G4RotationMatrix *Rot;  
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-166.2*mm-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,"OuterScinti_0", scintiboxlogical, false, 0, overlapcheck);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-scinti_u1_front_size-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,"OuterScinti_0", scintiboxlogical, false, 0, overlapcheck);
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
@@ -187,7 +183,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,166.2*mm+gap_between_tiles/2.+gap_between_tiles),scintiu2_logic,"OuterScinti_3", scintiboxlogical, false, 0, overlapcheck);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,scinti_u1_front_size+gap_between_tiles/2.+gap_between_tiles),scintiu2_logic,"OuterScinti_3", scintiboxlogical, false, 0, overlapcheck);
 
 
   return scintiboxlogical;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
@@ -62,6 +62,7 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
   G4TwoVector steel_plate_corner_upper_right;
   G4TwoVector steel_plate_corner_lower_right;
   G4TwoVector steel_plate_corner_lower_left;
+  double scinti_u1_front_size;
   G4TwoVector scinti_u1_corner_upper_left;
   G4TwoVector scinti_u1_corner_upper_right;
   G4TwoVector scinti_u1_corner_lower_right;


### PR DESCRIPTION
Small bugfix. The plots how well the bottom/top coordinates (green triangles) from the drawing match are here, only the bottom coordinates are being used in the construction of the hcals:

![bottominnersteel](https://cloud.githubusercontent.com/assets/7316141/13895913/723cea22-ed51-11e5-903e-3072d19bd096.png)
![bottomoutersteel](https://cloud.githubusercontent.com/assets/7316141/13895912/723cdbd6-ed51-11e5-8218-5c208092d814.png)
![topinnersteel](https://cloud.githubusercontent.com/assets/7316141/13895915/723d39aa-ed51-11e5-91c2-437a4bd3c705.png)
![topoutersteel](https://cloud.githubusercontent.com/assets/7316141/13895914/723ce5fe-ed51-11e5-86d3-87b3974c7505.png)



