### PR TITLE
Prototype cryostat added

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -172,6 +172,10 @@ libg4detectors_la_SOURCES = \
   PHG4InnerHcalSteppingAction.cc \
   PHG4InnerHcalSubsystem.cc \
   PHG4InnerHcal_Dict.C \
+  PHG4Prototype2CryostatDetector.cc \
+  PHG4Prototype2CryostatSteppingAction.cc \
+  PHG4Prototype2CryostatSubsystem.cc \
+  PHG4Prototype2CryostatSubsystem_Dict.C \
   PHG4Prototype2OuterHcalDetector.cc \
   PHG4Prototype2OuterHcalSteppingAction.cc \
   PHG4Prototype2OuterHcalSubsystem.cc \

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatDetector.cc
@@ -1,0 +1,229 @@
+#include "PHG4Prototype2CryostatDetector.h"
+#include "PHG4Parameters.h"
+#include "PHG4CylinderGeomContainer.h"
+#include "PHG4CylinderGeomv3.h"
+
+#include <g4main/PHG4Utils.h>
+
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+
+#include <Geant4/G4AssemblyVolume.hh>
+#include <Geant4/G4IntersectionSolid.hh>
+#include <Geant4/G4SubtractionSolid.hh>
+#include <Geant4/G4Material.hh>
+#include <Geant4/G4Box.hh>
+#include <Geant4/G4Cons.hh>
+#include <Geant4/G4ExtrudedSolid.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4TwoVector.hh>
+#include <Geant4/G4Trap.hh>
+#include <Geant4/G4Tubs.hh>
+#include <Geant4/G4UserLimits.hh>
+
+#include <Geant4/G4VisAttributes.hh>
+#include <Geant4/G4Colour.hh>
+
+#include <cmath>
+#include <sstream>
+
+using namespace std;
+
+PHG4Prototype2CryostatDetector::PHG4Prototype2CryostatDetector( PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam  ):
+  PHG4Detector(Node, dnam),
+  params(parameters),
+  cryostatassembly(NULL),
+  alu_z(609.6*mm),
+  n_alu_plates(3),
+  active(params->get_int_param("active")),
+  absorberactive(params->get_int_param("absorberactive")),
+  layer(0)
+{
+  for (int i=0; i<3; i++)
+    {
+      volume_alu[i] = NAN;
+    }
+  double y_up = alu_z/2.; // it is a square in z/y
+  double y_down = -alu_z/2.;
+  alu_plate_corner_upper_left[0] = G4TwoVector(1419.6*mm,y_up);
+  alu_plate_corner_upper_right[0] = G4TwoVector(1419.6*mm+9.5*mm,y_up);
+  alu_plate_corner_lower_right[0] = G4TwoVector(1419.6*mm+9.5*mm,y_down);
+  alu_plate_corner_lower_left[0] = G4TwoVector(1419.6*mm,y_down);
+
+  alu_plate_corner_upper_left[1] = G4TwoVector(1507.2*mm,y_up);
+  alu_plate_corner_upper_right[1] = G4TwoVector(1507.2*mm+88.9*mm,y_up);
+  alu_plate_corner_lower_right[1] = G4TwoVector(1507.2*mm+88.9*mm,y_down);
+  alu_plate_corner_lower_left[1] = G4TwoVector(1507.2*mm,y_down);
+
+  alu_plate_corner_upper_left[2] = G4TwoVector(1739.3*mm,y_up);
+  alu_plate_corner_upper_right[2] = G4TwoVector(1739.3*mm+25.4*mm,y_up);
+  alu_plate_corner_lower_right[2] = G4TwoVector(1739.3*mm+25.4*mm,y_down);
+  alu_plate_corner_lower_left[2] = G4TwoVector(1739.3*mm,y_down);
+
+}
+
+//_______________________________________________________________
+//_______________________________________________________________
+int
+PHG4Prototype2CryostatDetector::IsInPrototype2Cryostat(G4VPhysicalVolume * volume) const
+{
+  // G4AssemblyVolumes naming convention:
+  //     av_WWW_impr_XXX_YYY_ZZZ
+
+  // where:
+
+  //     WWW - assembly volume instance number
+  //     XXX - assembly volume imprint number
+  //     YYY - the name of the placed logical volume
+  //     ZZZ - the logical volume index inside the assembly volume
+  // e.g. av_1_impr_82_HcalInnerScinti_11_pv_11
+  // 82 the number of the scintillator mother volume
+  // HcalInnerScinti_11: name of scintillator slat
+  // 11: number of scintillator slat logical volume
+  if (absorberactive)
+    {
+      if (volume->GetName().find("CryostatAluPlate") != string::npos)
+	{
+	  return -1;
+	}
+    }
+  if (active)
+    {
+      if (volume->GetName().find("InnerScinti") != string::npos)
+	{
+	  return 1;
+	}
+    }
+  return 0;
+}
+
+G4LogicalVolume*
+PHG4Prototype2CryostatDetector::ConstructAluPlate(G4LogicalVolume* hcalenvelope, const int n)
+{
+  if (n < 0 || n >= n_alu_plates)
+    {
+      cout << "invalid alu plate number " << n << endl;
+      exit(1);
+    }
+  ostringstream name;
+  G4VSolid* alu_plate;
+  std::vector<G4TwoVector> vertexes;
+  vertexes.push_back(alu_plate_corner_upper_left[n]);
+  vertexes.push_back(alu_plate_corner_upper_right[n]);
+  vertexes.push_back(alu_plate_corner_lower_right[n]);
+  vertexes.push_back(alu_plate_corner_lower_left[n]);
+  G4TwoVector zero(0, 0);
+  name.str("");
+  name << "CryostatAluPlateSolid_" << n;
+  alu_plate =  new G4ExtrudedSolid(name.str(),
+				     vertexes,
+				     alu_z  / 2.0,
+				     zero, 1.0,
+				     zero, 1.0);
+
+  volume_alu[n] = alu_plate->GetCubicVolume()*n_alu_plates;
+  name.str("");
+  name << "CryostatAluPlate_" << n;
+  G4LogicalVolume *cryostataluplate = new G4LogicalVolume(alu_plate,G4Material::GetMaterial("G4_AL"),"CryostatAluPlate", 0, 0, 0);
+  G4VisAttributes* visattchk = new G4VisAttributes();
+  visattchk->SetVisibility(true);
+  visattchk->SetForceSolid(false);
+  visattchk->SetColour(G4Colour::Grey());
+  cryostataluplate->SetVisAttributes(visattchk);
+  return cryostataluplate;
+}
+
+
+// Construct the envelope and the call the
+// actual inner hcal construction
+void
+PHG4Prototype2CryostatDetector::Construct( G4LogicalVolume* logicWorld )
+{
+  G4ThreeVector g4vec(0,0,0);
+  G4RotationMatrix *Rot = new G4RotationMatrix();
+  Rot->rotateX(params->get_double_param("rot_x")*deg);
+  Rot->rotateY(params->get_double_param("rot_y")*deg);
+  Rot->rotateZ(params->get_double_param("rot_z")*deg);
+  cryostatassembly = new G4AssemblyVolume();
+  ConstructCryostat(logicWorld);
+  cryostatassembly->MakeImprint(logicWorld,g4vec,Rot,0,overlapcheck);
+  return;
+}
+
+int
+PHG4Prototype2CryostatDetector::ConstructCryostat(G4LogicalVolume* hcalenvelope)
+{
+  ostringstream name;
+  for (int i = 0; i < n_alu_plates; i++)
+    //      for (int i = 0; i < 2; i++)
+    {
+      G4LogicalVolume* alu_plate = ConstructAluPlate(hcalenvelope,i); // bottom alu plate
+      name.str("");
+      name << "CryostatAlu_" << i;
+      G4RotationMatrix *Rot = new G4RotationMatrix();
+      G4ThreeVector g4vec(0,0,0);
+      cryostatassembly->AddPlacedVolume(alu_plate,g4vec,Rot);
+    }
+  return 0;
+}
+
+
+int
+PHG4Prototype2CryostatDetector::DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix *rotm )
+{
+  static int i = 0;
+  G4LogicalVolume* checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), "DISPLAYLOGICAL", 0, 0, 0);
+  G4VisAttributes* visattchk = new G4VisAttributes();
+  visattchk->SetVisibility(true);
+  visattchk->SetForceSolid(false);
+  switch(i)
+    {
+    case 0:
+      visattchk->SetColour(G4Colour::Red());
+      i++;
+      break;
+    case 1:
+      visattchk->SetColour(G4Colour::Magenta());
+      i++;
+      break;
+    case 2:
+      visattchk->SetColour(G4Colour::Yellow());
+      i++;
+      break;
+    case 3:
+      visattchk->SetColour(G4Colour::Blue());
+      i++;
+      break;
+    case 4:
+      visattchk->SetColour(G4Colour::Cyan());
+      i++;
+      break;
+    default:
+      visattchk->SetColour(G4Colour::Green());
+      i = 0;
+      break;
+    }
+
+  checksolid->SetVisAttributes(visattchk);
+  new G4PVPlacement(rotm, G4ThreeVector(0, 0, 0), checksolid, "DISPLAYVOL", logvol, 0, false, overlapcheck);
+  //  new G4PVPlacement(rotm, G4ThreeVector(0, -460.3, 0), checksolid, "DISPLAYVOL", logvol, 0, false, overlapcheck);
+  return 0;
+}
+
+
+void
+PHG4Prototype2CryostatDetector::Print(const string &what) const
+{
+  cout << "Cryostat:" << endl;
+  if (what == "ALL" || what == "VOLUME")
+    {
+      for (int i=0; i<3; i++)
+	{
+	  cout << "Volume Alu " << i << ": " << volume_alu[i]/cm/cm/cm << " cm^3" << endl;
+	}
+    }
+  return;
+}

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatDetector.cc
@@ -90,13 +90,6 @@ PHG4Prototype2CryostatDetector::IsInPrototype2Cryostat(G4VPhysicalVolume * volum
 	  return -1;
 	}
     }
-  if (active)
-    {
-      if (volume->GetName().find("InnerScinti") != string::npos)
-	{
-	  return 1;
-	}
-    }
   return 0;
 }
 
@@ -127,7 +120,7 @@ PHG4Prototype2CryostatDetector::ConstructAluPlate(G4LogicalVolume* hcalenvelope,
   volume_alu[n] = alu_plate->GetCubicVolume()*n_alu_plates;
   name.str("");
   name << "CryostatAluPlate_" << n;
-  G4LogicalVolume *cryostataluplate = new G4LogicalVolume(alu_plate,G4Material::GetMaterial("G4_AL"),"CryostatAluPlate", 0, 0, 0);
+  G4LogicalVolume *cryostataluplate = new G4LogicalVolume(alu_plate,G4Material::GetMaterial("G4_Al"),name.str(), 0, 0, 0);
   G4VisAttributes* visattchk = new G4VisAttributes();
   visattchk->SetVisibility(true);
   visattchk->SetForceSolid(false);

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatDetector.h
@@ -1,0 +1,73 @@
+#ifndef PHG4Prototype2CryostatDetector_h
+#define PHG4Prototype2CryostatDetector_h
+
+#include "PHG4Parameters.h"
+
+#include <g4main/PHG4Detector.h>
+
+#include <Geant4/globals.hh>
+#include <Geant4/G4RotationMatrix.hh>
+#include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4TwoVector.hh>
+#include <Geant4/G4Types.hh>
+
+#include <map>
+#include <vector>
+#include <set>
+
+class G4AssemblyVolume;
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+class G4VSolid;
+
+class PHG4Prototype2CryostatDetector: public PHG4Detector
+{
+
+  public:
+
+  //! constructor
+ PHG4Prototype2CryostatDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam);
+
+  //! destructor
+  virtual ~PHG4Prototype2CryostatDetector(){}
+
+  //! construct
+  virtual void Construct( G4LogicalVolume* world );
+
+  virtual void Print(const std::string &what = "ALL") const;
+
+  //!@name volume accessors
+  //@{
+  int IsInPrototype2Cryostat(G4VPhysicalVolume*) const;
+  //@}
+
+  void SuperDetector(const std::string &name) {superdetector = name;}
+  const std::string SuperDetector() const {return superdetector;}
+  int get_Layer() const {return layer;}
+
+  G4LogicalVolume* ConstructAluPlate(G4LogicalVolume* hcalenvelope, const int n);
+
+  protected:
+  void AddGeometryNode();
+  int ConstructCryostat(G4LogicalVolume* sandwich);
+  int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
+  PHG4Parameters *params;
+  G4AssemblyVolume *cryostatassembly;
+  G4TwoVector alu_plate_corner_upper_left[3];
+  G4TwoVector alu_plate_corner_upper_right[3];
+  G4TwoVector alu_plate_corner_lower_right[3];
+  G4TwoVector alu_plate_corner_lower_left[3];
+  double alu_z;
+  double volume_alu[3];
+
+  int n_alu_plates;
+  int active;
+  int absorberactive;
+
+  int layer;
+  std::string detector_type;
+  std::string superdetector;
+  std::string scintilogicnameprefix;
+};
+
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSteppingAction.cc
@@ -68,6 +68,10 @@ bool PHG4Prototype2CryostatSteppingAction::UserSteppingAction( const G4Step* aSt
     {
       return false;
     }
+  if (whichactive > 0)
+    {
+      cout << "hit in " << volume->GetName() << endl;
+    }
   unsigned int motherid = ~0x0; // initialize to 0xFFFFFF using the correct bitness
   int tower_id = -1;
   if (whichactive > 0) // scintillator
@@ -184,6 +188,7 @@ bool PHG4Prototype2CryostatSteppingAction::UserSteppingAction( const G4Step* aSt
 	  hit->set_eion(0); // only implemented for v5 otherwise empty
 	  if (whichactive > 0) // return of IsInPrototype2CryostatDetector, > 0 hit in scintillator, < 0 hit in absorber
 	    {
+	      cout << "found active hit!!!" << endl;
 	      hit->set_light_yield(0); // for scintillator only, initialize light yields
 	      // Now add the hit
 	      hits_->AddHit(layer_id, hit);
@@ -327,28 +332,20 @@ bool PHG4Prototype2CryostatSteppingAction::UserSteppingAction( const G4Step* aSt
 void PHG4Prototype2CryostatSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
 {
 
-  string hitnodename;
   string absorbernodename;
   if (detector_->SuperDetector() != "NONE")
     {
-      hitnodename = "G4HIT_" + detector_->SuperDetector();
       absorbernodename =  "G4HIT_ABSORBER_" + detector_->SuperDetector();
     }
   else
     {
-      hitnodename = "G4HIT_" + detector_->GetName();
       absorbernodename =  "G4HIT_ABSORBER_" + detector_->GetName();
     }
 
   //now look for the map and grab a pointer to it.
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
   absorberhits_ =  findNode::getClass<PHG4HitContainer>( topNode , absorbernodename.c_str() );
 
   // if we do not find the node it's messed up.
-  if ( ! hits_ )
-    {
-      std::cout << "PHG4Prototype2CryostatSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
-    }
   if ( ! absorberhits_)
     {
       if (verbosity > 1)

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSteppingAction.cc
@@ -1,0 +1,371 @@
+#include "PHG4Prototype2CryostatSteppingAction.h"
+#include "PHG4Prototype2CryostatDetector.h"
+#include "PHG4Parameters.h"
+
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Hitv1.h>
+
+#include <g4main/PHG4TrackUserInfoV1.h>
+
+#include <phool/getClass.h>
+
+#include <Geant4/G4Step.hh>
+#include <Geant4/G4MaterialCutsCouple.hh>
+
+#include <boost/foreach.hpp>
+#include <boost/tokenizer.hpp>
+// this is an ugly hack, the gcc optimizer has a bug which
+// triggers the uninitialized variable warning which
+// stops compilation because of our -Werror 
+#include <boost/version.hpp> // to get BOOST_VERSION
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700 )
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma message "ignoring bogus gcc warning in boost header lexical_cast.hpp"
+#include <boost/lexical_cast.hpp>
+#pragma GCC diagnostic warning "-Wuninitialized"
+#else
+#include <boost/lexical_cast.hpp>
+#endif
+
+#include <iostream>
+
+using namespace std;
+//____________________________________________________________________________..
+PHG4Prototype2CryostatSteppingAction::PHG4Prototype2CryostatSteppingAction( PHG4Prototype2CryostatDetector* detector, PHG4Parameters *parameters):
+  detector_( detector ),
+  hits_(NULL),
+  absorberhits_(NULL),
+  hit(NULL),
+  params(parameters),
+  absorbertruth(params->get_int_param("absorbertruth")),
+  IsActive(params->get_int_param("active")),
+  IsBlackHole(params->get_int_param("blackhole")),
+  light_scint_model(params->get_int_param("light_scint_model")),
+  light_balance_inner_corr(params->get_double_param("light_balance_inner_corr")),
+  light_balance_inner_radius(params->get_double_param("light_balance_inner_radius")*cm),
+  light_balance_outer_corr(params->get_double_param("light_balance_outer_corr")),
+  light_balance_outer_radius(params->get_double_param("light_balance_outer_radius")*cm)
+{}
+
+//____________________________________________________________________________..
+bool PHG4Prototype2CryostatSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
+{
+
+  G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
+  // get volume of the current step
+  G4VPhysicalVolume* volume = touch->GetVolume();
+
+  // detector_->IsInPrototype2Cryostat(volume)
+  // returns 
+  //  0 is outside of Prototype2Cryostat
+  //  1 is inside scintillator
+  // -1 is steel absorber
+
+  int whichactive = detector_->IsInPrototype2Cryostat(volume);
+
+  if (!whichactive)
+    {
+      return false;
+    }
+  unsigned int motherid = ~0x0; // initialize to 0xFFFFFF using the correct bitness
+  int tower_id = -1;
+  if (whichactive > 0) // scintillator
+    {
+      // first extract the scintillator id (0-3) from the volume name (OuterScinti_0,1,2,3)
+      boost::char_separator<char> sep("_");
+      boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
+      boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter =  tok.begin();
+      ++tokeniter;
+      tower_id = boost::lexical_cast<int>(*tokeniter);
+      // G4AssemblyVolumes naming convention:
+      //     av_WWW_impr_XXX_YYY_ZZZ
+      // where:
+
+      //     WWW - assembly volume instance number
+      //     XXX - assembly volume imprint number
+      //     YYY - the name of the placed logical volume
+      //     ZZZ - the logical volume index inside the assembly volume
+      // e.g. av_1_impr_1_CryostatScintiMother_pv_11
+      // 82 the number of the scintillator mother volume
+      // CryostatScintiMother_11: name of scintillator slat
+      // 11: number of scintillator slat logical volume
+      // use boost tokenizer to separate the _, then take value
+      // after "impr" for mother volume and after "pv" for scintillator slat
+      // use boost lexical cast for string -> int conversion
+      G4VPhysicalVolume* mothervolume = touch->GetVolume(1);
+      boost::tokenizer<boost::char_separator<char> > tokm(mothervolume->GetName(), sep);
+      for (tokeniter = tokm.begin(); tokeniter != tokm.end(); ++tokeniter)
+       	{
+       	  if (*tokeniter == "pv")
+       	    {
+       	      ++tokeniter;
+       	      if (tokeniter != tokm.end())
+       		{
+		  motherid = boost::lexical_cast<int>(*tokeniter);
+		}
+       	      else
+       		{
+       		  cout << PHWHERE << " Error parsing " << mothervolume->GetName()
+       		       << " for mother scinti slat id " << endl;
+		  exit(1);
+       		}
+	      break;
+	    }
+	}
+      // cout << "name " << volume->GetName() << ", mid: " << motherid
+      // 	   << ", twr: " << tower_id << endl;
+    }
+  else
+    {
+      tower_id = touch->GetCopyNumber(); // steel plate id
+    }
+  // collect energy and track length step by step
+  G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
+  G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
+  G4double light_yield = 0;
+  const G4Track* aTrack = aStep->GetTrack();
+
+  // if this block stops everything, just put all kinetic energy into edep
+  if (IsBlackHole)
+    {
+      edep = aTrack->GetKineticEnergy() / GeV;
+      G4Track* killtrack = const_cast<G4Track *> (aTrack);
+      killtrack->SetTrackStatus(fStopAndKill);
+    }
+  int layer_id = detector_->get_Layer();
+
+  // make sure we are in a volume
+  if ( IsActive )
+    {
+      bool geantino = false;
+
+      // the check for the pdg code speeds things up, I do not want to make
+      // an expensive string compare for every track when we know
+      // geantino or chargedgeantino has pid=0
+      if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
+	  aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
+	{
+	  geantino = true;
+	}
+      G4StepPoint * prePoint = aStep->GetPreStepPoint();
+      G4StepPoint * postPoint = aStep->GetPostStepPoint();
+      //       cout << "track id " << aTrack->GetTrackID() << endl;
+      //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
+      //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
+      switch (prePoint->GetStepStatus())
+	{
+	case fGeomBoundary:
+	case fUndefined:
+	  hit = new PHG4Hitv1();
+	  hit->set_layer(motherid);
+	  hit->set_scint_id(tower_id); // the slat id (or steel plate id)
+	  //here we set the entrance values in cm
+	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
+	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
+	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
+	  // time in ns
+	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
+	  //set the track ID
+	  {
+            hit->set_trkid(aTrack->GetTrackID());
+            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+	      {
+		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		  {
+		    hit->set_trkid(pp->GetUserTrackId());
+		    hit->set_shower_id(pp->GetShower()->get_id());
+		  }
+	      }
+	  }
+
+	  //set the initial energy deposit
+	  hit->set_edep(0);
+	  hit->set_eion(0); // only implemented for v5 otherwise empty
+	  if (whichactive > 0) // return of IsInPrototype2CryostatDetector, > 0 hit in scintillator, < 0 hit in absorber
+	    {
+	      hit->set_light_yield(0); // for scintillator only, initialize light yields
+	      // Now add the hit
+	      hits_->AddHit(layer_id, hit);
+	      
+	      {
+		if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+		  {
+		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		      {
+			pp->GetShower()->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
+		      }
+		  }
+	      }
+	    }
+	  else
+	    {
+	      absorberhits_->AddHit(layer_id, hit);
+	      
+	      {
+		if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+		  {
+		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		      {
+			pp->GetShower()->add_g4hit_id(absorberhits_->GetID(),hit->get_hit_id());
+		      }
+		  }
+	      }
+	    }
+	  break;
+	default:
+	  break;
+	}
+      // here we just update the exit values, it will be overwritten
+      // for every step until we leave the volume or the particle
+      // ceases to exist
+      hit->set_x( 1, postPoint->GetPosition().x() / cm );
+      hit->set_y( 1, postPoint->GetPosition().y() / cm );
+      hit->set_z( 1, postPoint->GetPosition().z() / cm );
+
+      hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
+
+      if (whichactive > 0) // return of IsInPrototype2CryostatDetector, > 0 hit in scintillator, < 0 hit in absorber
+        {
+          if (light_scint_model)
+            {
+              light_yield = GetVisibleEnergyDeposition(aStep); // for scintillator only, calculate light yields
+	      static bool once = true;
+	      if (once && edep > 0)
+		{
+		  once = false;
+
+		  if (verbosity > 0) 
+		    {
+		      cout << "PHG4Prototype2CryostatSteppingAction::UserSteppingAction::"
+			//
+			   << detector_->GetName() << " - "
+			   << " use scintillating light model at each Geant4 steps. "
+			   << "First step: " << "Material = "
+			   << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetName()
+			   << ", " << "Birk Constant = "
+			   << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetIonisation()->GetBirksConstant()
+			   << "," << "edep = " << edep << ", " << "eion = " << eion
+			   << ", " << "light_yield = " << light_yield << endl;
+		    }
+		}
+	    }
+	  else
+            {
+              light_yield = eion;
+            }
+          if (isfinite(light_balance_outer_radius) && 
+              isfinite(light_balance_inner_radius) && 
+	      isfinite(light_balance_outer_corr) &&
+	      isfinite(light_balance_inner_corr))
+            {
+              double r = sqrt(
+			      postPoint->GetPosition().x()*postPoint->GetPosition().x()
+			      + postPoint->GetPosition().y()*postPoint->GetPosition().y());
+              double cor =  GetLightCorrection(r);
+              light_yield = light_yield * cor;
+
+              static bool once = true;
+              if (once && light_yield>0)
+                {
+                  once = false;
+
+		  if (verbosity > 1) 
+		    {
+		      cout << "PHG4Prototype2CryostatSteppingAction::UserSteppingAction::"
+			//
+			   << detector_->GetName() << " - "
+			   << " use a simple light collection model with linear radial dependence. "
+			   <<"First step: "
+			   <<"r = " <<r/cm<<", "
+			   <<"correction ratio = " <<cor<<", "
+			   <<"light_yield after cor. = " <<light_yield
+			   << endl;
+		    }
+                }
+
+            }
+        }
+
+      //sum up the energy to get total deposited
+      hit->set_edep(hit->get_edep() + edep);
+      hit->set_eion(hit->get_eion() + eion);
+      if (whichactive > 0)
+	{
+	  hit->set_light_yield(hit->get_light_yield() + light_yield);
+	}
+      if (geantino)
+	{
+	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+          hit->set_eion(-1);
+	}
+      if (edep > 0)
+	{
+	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+	    {
+	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		{
+		  pp->SetKeep(1); // we want to keep the track
+		}
+
+
+	    }
+	}
+
+      //       hit->identify();
+      // return true to indicate the hit was used
+      return true;
+
+    }
+  else
+    {
+      return false;
+    }
+}
+
+//____________________________________________________________________________..
+void PHG4Prototype2CryostatSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+{
+
+  string hitnodename;
+  string absorbernodename;
+  if (detector_->SuperDetector() != "NONE")
+    {
+      hitnodename = "G4HIT_" + detector_->SuperDetector();
+      absorbernodename =  "G4HIT_ABSORBER_" + detector_->SuperDetector();
+    }
+  else
+    {
+      hitnodename = "G4HIT_" + detector_->GetName();
+      absorbernodename =  "G4HIT_ABSORBER_" + detector_->GetName();
+    }
+
+  //now look for the map and grab a pointer to it.
+  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
+  absorberhits_ =  findNode::getClass<PHG4HitContainer>( topNode , absorbernodename.c_str() );
+
+  // if we do not find the node it's messed up.
+  if ( ! hits_ )
+    {
+      std::cout << "PHG4Prototype2CryostatSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+    }
+  if ( ! absorberhits_)
+    {
+      if (verbosity > 1)
+	{
+	  cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
+	}
+    }
+}
+
+double
+PHG4Prototype2CryostatSteppingAction::GetLightCorrection(const double r) const
+{
+  double m = (light_balance_outer_corr - light_balance_inner_corr)/(light_balance_outer_radius - light_balance_inner_radius);
+  double b = light_balance_inner_corr - m*light_balance_inner_radius;
+  double value = m*r+b;  
+  if (value > 1.0) return 1.0;
+  if (value < 0.0) return 0.0;
+
+  return value;
+}

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSteppingAction.h
@@ -1,0 +1,56 @@
+#ifndef PHG4VPrototype2CryostatSteppingAction_h
+#define PHG4VPrototype2CryostatSteppingAction_h
+
+#include <g4main/PHG4SteppingAction.h>
+
+class PHG4Prototype2CryostatDetector;
+class PHG4Parameters;
+class PHG4Hit;
+class PHG4HitContainer;
+
+class PHG4Prototype2CryostatSteppingAction : public PHG4SteppingAction
+{
+
+  public:
+
+  //! constructor
+  PHG4Prototype2CryostatSteppingAction( PHG4Prototype2CryostatDetector*, PHG4Parameters *parameters );
+
+  //! destroctor
+  virtual ~PHG4Prototype2CryostatSteppingAction()
+  {}
+
+  //! stepping action
+  virtual bool UserSteppingAction(const G4Step*, bool);
+
+  //! reimplemented from base class
+  virtual void SetInterfacePointers( PHCompositeNode* );
+
+  double GetLightCorrection(const double r) const;
+
+  private:
+
+  //! pointer to the detector
+  PHG4Prototype2CryostatDetector* detector_;
+
+  //! pointer to hit container
+  PHG4HitContainer * hits_;
+  PHG4HitContainer * absorberhits_;
+  PHG4Hit *hit;
+  PHG4Parameters *params;
+  // since getting parameters is a map search we do not want to
+  // do this in every step, the parameters used are cached
+  // in the following variables
+  int absorbertruth;
+  int IsActive;
+  int IsBlackHole;
+  int light_scint_model;
+  
+  double light_balance_inner_corr;
+  double light_balance_inner_radius;
+  double light_balance_outer_corr;
+  double light_balance_outer_radius;
+};
+
+
+#endif // PHG4Prototype2CryostatSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSubsystem.cc
@@ -1,0 +1,439 @@
+#include "PHG4Prototype2CryostatSubsystem.h"
+#include "PHG4Prototype2CryostatDetector.h"
+#include "PHG4EventActionClearZeroEdep.h"
+#include "PHG4Prototype2CryostatSteppingAction.h"
+#include "PHG4Parameters.h"
+
+#include <g4main/PHG4HitContainer.h>
+
+#include <pdbcalbase/PdbParameterMap.h>
+
+#include <phool/getClass.h>
+
+#include <Geant4/globals.hh>
+
+#include <boost/foreach.hpp>
+
+#include <set>
+#include <sstream>
+
+using namespace std;
+
+//_______________________________________________________________________
+PHG4Prototype2CryostatSubsystem::PHG4Prototype2CryostatSubsystem( const std::string &name, const int lyr ):
+  PHG4Subsystem( name ),
+  detector_(NULL),
+  steppingAction_( NULL ),
+  eventAction_(NULL),
+  layer(lyr),
+  usedb(0),
+  filetype(PHG4Prototype2CryostatSubsystem::none),
+  detector_type(name),
+  superdetector("NONE"),
+  calibfiledir("./")
+{
+
+  // put the layer into the name so we get unique names
+  // for multiple layers
+  ostringstream nam;
+  nam << name << "_" << lyr;
+  Name(nam.str().c_str());
+  params = new PHG4Parameters(Name()); // temporary name till the init is called
+  SetDefaultParameters();
+}
+
+void
+PHG4Prototype2CryostatSubsystem::SuperDetector(const std::string &name)
+{
+  superdetector = name;
+  Name(name);
+  return;
+}
+
+int 
+PHG4Prototype2CryostatSubsystem::Init(PHCompositeNode* topNode)
+{
+  params->set_name(superdetector);
+  return 0;
+}
+
+//_______________________________________________________________________
+int 
+PHG4Prototype2CryostatSubsystem::InitRun( PHCompositeNode* topNode )
+{
+  PHNodeIterator iter( topNode );
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+
+  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN" ));
+  string g4geonodename = "G4GEO_" + superdetector;
+  parNode->addNode(new PHDataNode<PHG4Parameters>(params,g4geonodename));
+
+
+  string paramnodename = "G4GEOPARAM_" + superdetector;
+  // ASSUMPTION: if we read from DB and/or file we don't want the stuff from
+  // the node tree
+  // We leave the defaults intact in case there is no entry for
+  // those in the object read from the DB or file
+  // Order: read first DB, then calib file if both are enabled
+  if (usedb || filetype != PHG4Prototype2CryostatSubsystem::none)
+    {
+      if (usedb)
+	{
+          ReadParamsFromDB();
+	}
+      if (filetype != PHG4Prototype2CryostatSubsystem::none)
+	{
+	  ReadParamsFromFile(filetype);
+	}
+    }
+  else
+    {
+      PdbParameterMap *nodeparams = findNode::getClass<PdbParameterMap>(topNode,paramnodename);
+      if (nodeparams)
+	{
+	  params->FillFrom(nodeparams);
+	}
+    }
+  // parameters set in the macro always override whatever is read from
+  // the node tree, DB or file
+  UpdateParametersWithMacro();
+  // save updated persistant copy on node tree
+  params->SaveToNodeTree(parNode,paramnodename);
+  // create detector
+  detector_ = new PHG4Prototype2CryostatDetector(topNode, params, Name());
+  detector_->SuperDetector(superdetector);
+  detector_->OverlapCheck(overlapcheck);
+  set<string> nodes;
+  if (params->get_int_param("active"))
+    {
+      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",superdetector));
+      if (! DetNode)
+	{
+          DetNode = new PHCompositeNode(superdetector);
+          dstNode->addNode(DetNode);
+        }
+
+      ostringstream nodename;
+      if (superdetector != "NONE")
+	{
+	  nodename <<  "G4HIT_" << superdetector;
+	}
+      else
+	{
+	  nodename <<  "G4HIT_" << detector_type << "_" << layer;
+	}
+      nodes.insert(nodename.str());
+      if (params->get_int_param("absorberactive"))
+	{
+	  nodename.str("");
+	  if (superdetector != "NONE")
+	    {
+	      nodename <<  "G4HIT_ABSORBER_" << superdetector;
+	    }
+	  else
+	    {
+	      nodename <<  "G4HIT_ABSORBER_" << detector_type << "_" << layer;
+	    }
+          nodes.insert(nodename.str());
+	}
+      BOOST_FOREACH(string node, nodes)
+	{
+	  PHG4HitContainer* g4_hits =  findNode::getClass<PHG4HitContainer>( topNode , node.c_str());
+	  if ( !g4_hits )
+	    {
+	      g4_hits = new PHG4HitContainer(node);
+              DetNode->addNode( new PHIODataNode<PHObject>( g4_hits, node.c_str(), "PHObject" ));
+	    }
+	  if (! eventAction_)
+	    {
+	      eventAction_ = new PHG4EventActionClearZeroEdep(topNode, node);
+	    }
+	  else
+	    {
+	      PHG4EventActionClearZeroEdep *evtact = dynamic_cast<PHG4EventActionClearZeroEdep *>(eventAction_);
+
+	      evtact->AddNode(node);
+	    }
+	}
+
+      // create stepping action
+      steppingAction_ = new PHG4Prototype2CryostatSteppingAction(detector_, params);
+
+    }
+  else
+    {
+      // if this is a black hole it does not have to be active
+      if (params->get_int_param("blackhole"))
+	{
+	  steppingAction_ = new PHG4Prototype2CryostatSteppingAction(detector_, params);
+	}
+    }
+  return 0;
+
+}
+
+//_______________________________________________________________________
+int
+PHG4Prototype2CryostatSubsystem::process_event( PHCompositeNode * topNode )
+{
+  // pass top node to stepping action so that it gets
+  // relevant nodes needed internally
+  if (steppingAction_)
+    {
+      steppingAction_->SetInterfacePointers( topNode );
+    }
+  return 0;
+}
+
+
+void
+PHG4Prototype2CryostatSubsystem::Print(const string &what) const
+{
+  cout << "Inner Hcal Parameters: " << endl;
+  params->print();
+  if (detector_)
+    {
+      detector_->Print(what);
+    }
+  return;
+}
+
+//_______________________________________________________________________
+PHG4Detector* PHG4Prototype2CryostatSubsystem::GetDetector( void ) const
+{
+  return detector_;
+}
+
+//_______________________________________________________________________
+PHG4SteppingAction* PHG4Prototype2CryostatSubsystem::GetSteppingAction( void ) const
+{
+  return steppingAction_;
+}
+
+void
+PHG4Prototype2CryostatSubsystem::SetActive(const int i)
+{
+  iparams["active"] = i;
+}
+
+void
+PHG4Prototype2CryostatSubsystem::SetAbsorberActive(const int i)
+{
+  iparams["absorberactive"] = i;
+}
+
+void
+PHG4Prototype2CryostatSubsystem::BlackHole(const int i)
+{
+  iparams["blackhole"] = i;
+}
+
+void
+PHG4Prototype2CryostatSubsystem::set_double_param(const std::string &name, const double dval)
+{
+  if (default_double.find(name) == default_double.end())
+    {
+      cout << "double parameter " << name << " not implemented" << endl;
+      cout << "implemented double parameters are:" << endl;
+      for (map<const string, double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
+	{
+	  cout << iter->first << endl;
+	}
+      return;
+    }
+  dparams[name] = dval;
+}
+
+void
+PHG4Prototype2CryostatSubsystem::set_int_param(const std::string &name, const int ival)
+{
+  if (default_int.find(name) == default_int.end())
+    {
+      cout << "integer parameter " << name << " not implemented" << endl;
+      cout << "implemented integer parameters are:" << endl;
+      for (map<const string, int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
+	{
+	  cout << iter->first << endl;
+	}
+      return;
+    }
+  iparams[name] = ival;
+}
+
+void
+PHG4Prototype2CryostatSubsystem::SetAbsorberTruth(const int i)
+{
+  iparams["absorbertruth"] = i;
+}
+
+void
+PHG4Prototype2CryostatSubsystem::set_string_param(const std::string &name, const string &sval)
+{
+  if (default_string.find(name) == default_string.end())
+    {
+      cout << "string parameter " << name << " not implemented" << endl;
+      cout << "implemented string parameters are:" << endl;
+      for (map<const string, string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
+	{
+	  cout << iter->first << endl;
+	}
+      return;
+    }
+  cparams[name] = sval;
+}
+
+void
+PHG4Prototype2CryostatSubsystem::SetDefaultParameters()
+{
+  // all in cm
+  default_double["light_balance_inner_corr"] = NAN;
+  default_double["light_balance_inner_radius"] = NAN;
+  default_double["light_balance_outer_corr"] = NAN;
+  default_double["light_balance_outer_radius"] = NAN;
+  default_double["place_x"] = 0.;
+  default_double["place_y"] = 0.;
+  default_double["place_z"] = 0.;
+  default_double["rot_x"] = 0.;
+  default_double["rot_y"] = 0.;
+  default_double["rot_z"] = 0.;
+  default_double["steplimits"] = NAN;
+
+  default_int["absorberactive"] = 0;
+  default_int["absorbertruth"] = 0;
+  default_int["active"] = 0;
+  default_int["blackhole"] = 0;
+  default_int["light_scint_model"] = 1;
+
+  default_string["material"] = "SS310";
+  for (map<const string,double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
+    {
+      params->set_double_param(iter->first,iter->second);
+    }
+  for (map<const string,int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
+    {
+      params->set_int_param(iter->first,iter->second);
+    }
+  for (map<const string,string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
+    {
+      params->set_string_param(iter->first,iter->second);
+    }
+
+}
+
+void
+PHG4Prototype2CryostatSubsystem::UpdateParametersWithMacro()
+{
+  for (map<const string,double>::const_iterator iter = dparams.begin(); iter != dparams.end(); ++iter)
+    {
+      params->set_double_param(iter->first,iter->second);
+    }
+  for (map<const string,int>::const_iterator iter = iparams.begin(); iter != iparams.end(); ++iter)
+    {
+      params->set_int_param(iter->first,iter->second);
+    }
+  for (map<const string,string>::const_iterator iter = cparams.begin(); iter != cparams.end(); ++iter)
+    {
+      params->set_string_param(iter->first,iter->second);
+    }
+  return;
+}
+
+void
+PHG4Prototype2CryostatSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr)
+{
+  dparams["light_balance_inner_corr"] = inner_corr;
+  dparams["light_balance_inner_radius"] = inner_radius;
+  dparams["light_balance_outer_corr"] = outer_corr;
+  dparams["light_balance_outer_radius"] = outer_radius;
+  return;
+}
+
+int
+PHG4Prototype2CryostatSubsystem::SaveParamsToDB()
+{
+  int iret = params->WriteToDB();
+  if (iret)
+    {
+      cout << "problem committing to DB" << endl;
+    }
+  return iret;
+}
+
+int
+PHG4Prototype2CryostatSubsystem::ReadParamsFromDB()
+{
+  int iret = params->ReadFromDB();
+  if (iret)
+    {
+      cout << "problem reading from DB" << endl;
+    }
+  return iret;
+}
+
+int
+PHG4Prototype2CryostatSubsystem::SaveParamsToFile(const PHG4Prototype2CryostatSubsystem::FILE_TYPE ftyp)
+{
+  string extension;
+  switch(ftyp)
+    {
+    case xml:
+      extension = "xml";
+      break;
+    case root:
+      extension = "root";
+      break;
+    default:
+      cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
+      exit(1);
+    }
+
+  int iret = params->WriteToFile(extension,calibfiledir);
+  if (iret)
+    {
+      cout << "problem saving to " << extension << " file " << endl;
+    }
+  return iret;
+}
+
+int
+PHG4Prototype2CryostatSubsystem::ReadParamsFromFile(const PHG4Prototype2CryostatSubsystem::FILE_TYPE ftyp)
+{
+  string extension;
+  switch(ftyp)
+    {
+    case xml:
+      extension = "xml";
+      break;
+    case root:
+      extension = "root";
+      break;
+    default:
+      cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
+      exit(1);
+    }
+  int iret = params->ReadFromFile(extension,calibfiledir);
+  if (iret)
+    {
+      cout << "problem reading from " << extension << " file " << endl;
+    }
+  return iret;
+}
+
+double
+PHG4Prototype2CryostatSubsystem::get_double_param(const std::string &name) const
+{
+  return params->get_double_param(name);
+}
+
+int
+PHG4Prototype2CryostatSubsystem::get_int_param(const std::string &name) const
+{
+  return params->get_int_param(name);
+}
+
+string
+PHG4Prototype2CryostatSubsystem::get_string_param(const std::string &name) const
+{
+  return params->get_string_param(name);
+}
+

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSubsystem.cc
@@ -114,15 +114,15 @@ PHG4Prototype2CryostatSubsystem::InitRun( PHCompositeNode* topNode )
         }
 
       ostringstream nodename;
-      if (superdetector != "NONE")
-	{
-	  nodename <<  "G4HIT_" << superdetector;
-	}
-      else
-	{
-	  nodename <<  "G4HIT_" << detector_type << "_" << layer;
-	}
-      nodes.insert(nodename.str());
+      // if (superdetector != "NONE")
+      // 	{
+      // 	  nodename <<  "G4HIT_" << superdetector;
+      // 	}
+      // else
+      // 	{
+      // 	  nodename <<  "G4HIT_" << detector_type << "_" << layer;
+      // 	}
+      //      nodes.insert(nodename.str());
       if (params->get_int_param("absorberactive"))
 	{
 	  nodename.str("");

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSubsystem.h
@@ -1,0 +1,113 @@
+#ifndef PHG4Prototype2CryostatSubsystem_h
+#define PHG4Prototype2CryostatSubsystem_h
+
+#include <g4main/PHG4Subsystem.h>
+
+#include <Geant4/G4Types.hh>
+#include <Geant4/G4String.hh>
+
+#include <map>
+#include <set>
+#include <string>
+
+class PHG4Prototype2CryostatDetector;
+class PHG4Parameters;
+class PHG4Prototype2CryostatSteppingAction;
+class PHG4EventAction;
+
+class PHG4Prototype2CryostatSubsystem: public PHG4Subsystem
+{
+
+  public:
+
+  enum FILE_TYPE {none = 0, xml = 1, root = 2};
+
+  //! constructor
+  PHG4Prototype2CryostatSubsystem( const std::string &name = "HCALIN", const int layer = 0 );
+
+  //! destructor
+  virtual ~PHG4Prototype2CryostatSubsystem( void )
+  {}
+
+  //! init
+  int Init(PHCompositeNode *);
+
+  /*!
+  creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
+  reates the stepping action and place it on the node tree, under "ACTIONS" node
+  creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
+  */
+  int InitRun(PHCompositeNode *);
+
+  //! event processing
+  /*!
+  get all relevant nodes from top nodes (namely hit list)
+  and pass that to the stepping action
+  */
+  int process_event(PHCompositeNode *);
+
+  //! Print info (from SubsysReco)
+  void Print(const std::string &what = "ALL") const;
+
+  //! accessors (reimplemented)
+  virtual PHG4Detector* GetDetector( void ) const;
+  virtual PHG4SteppingAction* GetSteppingAction( void ) const;
+
+  PHG4EventAction* GetEventAction() const {return eventAction_;}
+  void SetActive(const int i = 1);
+  void SetAbsorberActive(const int i = 1);
+  void SetAbsorberTruth(const int i = 1);
+  void SuperDetector(const std::string &name);
+  const std::string SuperDetector() {return superdetector;}
+
+  void BlackHole(const int i=1);
+  void SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr);
+  void set_double_param(const std::string &name, const double dval);
+  double get_double_param(const std::string &name) const;
+  void set_int_param(const std::string &name, const int ival);
+  int get_int_param(const std::string &name) const;
+  void set_string_param(const std::string &name, const std::string &sval);
+  std::string get_string_param(const std::string &name) const;
+  void SetDefaultParameters();
+  void UpdateParametersWithMacro();
+  void UseDB(const int i = 1) {usedb = i;}
+  void UseCalibFiles(const FILE_TYPE ftyp) {filetype = ftyp;}
+  int SaveParamsToDB();
+  int ReadParamsFromDB();
+  int SaveParamsToFile(const FILE_TYPE ftyp);
+  int ReadParamsFromFile(const FILE_TYPE ftyp);
+  void SetCalibrationFileDir(const std::string &calibdir) {calibfiledir = calibdir;}
+
+  protected:
+
+  //! detector geometry
+  /*! derives from PHG4Detector */
+  PHG4Prototype2CryostatDetector* detector_;
+
+  //! particle tracking "stepping" action
+  /*! derives from PHG4SteppingAction */
+  PHG4Prototype2CryostatSteppingAction* steppingAction_;
+
+  //! particle tracking "stepping" action
+  /*! derives from PHG4EventAction */
+  PHG4EventAction *eventAction_;
+
+  PHG4Parameters *params;
+
+  int layer;
+
+  int usedb;
+  FILE_TYPE filetype;
+  std::string detector_type;
+  std::string superdetector;
+  std::string calibfiledir;
+  std::map<const std::string, double> dparams;
+  std::map<const std::string, int> iparams;
+  std::map<const std::string, std::string> cparams;
+  std::map<const std::string, double> default_double;
+  std::map<const std::string, int> default_int;
+  std::map<const std::string, std::string> default_string;
+
+};
+
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2CryostatSubsystemLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4Prototype2CryostatSubsystem-!;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
A quick implementation of the cryostat mockup of the prototype. It uses extruded volumes right from the corner points from the engineering drawings. The plot shows a geantino scan with the coordinates from the drawings overlaid. The hits visible in the rigth two volumes are from geantinos leaving the sides of the cryostat.
![cryostat](https://cloud.githubusercontent.com/assets/7316141/13932391/3e15c4a6-ef7e-11e5-8b1a-8d0d643cbef3.png)
