### PR TITLE
Incoming

### DIFF
--- a/online_distribution/newbasic/prdfBuffer.cc
+++ b/online_distribution/newbasic/prdfBuffer.cc
@@ -62,7 +62,7 @@ int prdfBuffer::buffer_swap()
 
   while (evtindex*4  < bptr->Length - BUFFERHEADERLENGTH)
     {
-      COUT << "evt index " << evtindex << "  buffer length = " <<   bptr->Length << std::endl;
+      //      COUT << "evt index " << evtindex << "  buffer length = " <<   bptr->Length << std::endl;
 
       // map event header on data
       evtptr = (  evtdata_ptr ) &bptr->data[evtindex];


### PR DESCRIPTION
This implements a rather substantial change in the protocol that the rcdaqEventiterator uses to obtain monitoring data from rcdaq. 
Before, there was a way to get a race condition (and to stop rcdaq from acquiring data) if one would just kill the monitoring client requesting data in mid-stream. Conversely, if the rcdaq_server got restarted, one had to restart the monitoring. Also, due to a regression I put in with an attempt to get a quick fix, it was impossible to have more than one client requesting data. 
Now all is rock-solid. No killed client can interfere with the data taking, and the monitoring resumes gracefully if one shuts down (or just kills) the server and restarts it. And an arbitrary number of clients can connect again. 