### PR TITLE
mlp -- changed behavior of the "empty" rcdaqEveniterator constructor

### DIFF
--- a/online_distribution/newbasic/rcdaqEventiterator.cc
+++ b/online_distribution/newbasic/rcdaqEventiterator.cc
@@ -8,6 +8,7 @@
 #include "rcdaqEventiterator.h"
 #include <stdio.h>
 #include <iostream>
+#include <stdlib.h>
 
 #include "oncsBuffer.h"
 #include "gzbuffer.h"
@@ -42,6 +43,19 @@ rcdaqEventiterator::~rcdaqEventiterator()
      if (bptr != NULL ) delete bptr;
 }  
 
+
+rcdaqEventiterator::rcdaqEventiterator()
+{
+  string host = "localhost";
+    
+  if ( getenv("RCDAQHOST")  )
+    {
+      host = getenv("RCDAQHOST");
+    }
+
+  int status;
+  setup (host.c_str(), status);
+}  
 
 rcdaqEventiterator::rcdaqEventiterator(const char *ip)
 {

--- a/online_distribution/newbasic/rcdaqEventiterator.h
+++ b/online_distribution/newbasic/rcdaqEventiterator.h
@@ -22,7 +22,8 @@ class  rcdaqEventiterator : public Eventiterator {
 public:
 
   virtual ~rcdaqEventiterator();
-  rcdaqEventiterator(const char *ip = "127.0.0.1");
+  rcdaqEventiterator();
+  rcdaqEventiterator(const char *ip );
   rcdaqEventiterator(const char *ip, int &status);
 
   const char * getIdTag() const;


### PR DESCRIPTION
If the env. variable $RCDAQHOST - the same you define to interact with a remote rcdaq_server - is defined, it will default to that host. The assumption is that if you want to control that remote server, you will also want to get your monitoring data from there.
If that is not defined, you get "localhost" as the default.
