### PR TITLE
Some changes to make dlist and ddump honor a $RCDAQHOST env. variable

### DIFF
--- a/online_distribution/newbasic/ddump.cc
+++ b/online_distribution/newbasic/ddump.cc
@@ -1,15 +1,15 @@
 #include <stdlib.h>
 #include <signal.h>
+#include <string>
 
 #include "fileEventiterator.h"
 #include "testEventiterator.h"
 #include "rcdaqEventiterator.h"
 #include "oncsEventiterator.h"
-
 #include <stdio.h>
 
 #ifdef HAVE_GETOPT_H
-#include <getopt.h>
+#include "getopt.h"
 #endif
 
 #include<vector>
@@ -130,6 +130,7 @@ void sig_handler(int i)
   void sig_handler(...)
 #endif
 {
+  COUT << "sig_handler: signal seen " << std::endl;
   if (it) delete it;
   exit(0);
 }
@@ -325,7 +326,15 @@ main(int argc, char *argv[])
     case RCDAQEVENTITERATOR:
       if ( optind+1>argc) 
 	{
-	  it = new rcdaqEventiterator("localhost", status);
+	  std::string host = "localhost";
+    
+	  if ( getenv("RCDAQHOST")  )
+	    {
+	      host = getenv("RCDAQHOST");
+	    }
+	  
+	  it = new rcdaqEventiterator(host.c_str(), status);
+
 	}
       else
 	{

--- a/online_distribution/newbasic/dlist.cc
+++ b/online_distribution/newbasic/dlist.cc
@@ -2,6 +2,8 @@
 
 #include <stdlib.h>
 #include <signal.h>
+#include <string>
+
 #include "fileEventiterator.h"
 #include "rcdaqEventiterator.h"
 #include "testEventiterator.h"
@@ -9,6 +11,7 @@
 
 
 #include <stdio.h>
+#include <signal>
 
 #ifdef HAVE_GETOPT_H
 #include "getopt.h"
@@ -228,7 +231,14 @@ main(int argc, char *argv[])
     case RCDAQEVENTITERATOR:
       if ( optind+1>argc) 
 	{
-	  it = new rcdaqEventiterator("localhost", status);
+	  std::string host = "localhost";
+    
+	  if ( getenv("RCDAQHOST")  )
+	    {
+	      host = getenv("RCDAQHOST");
+	    }
+	  
+	  it = new rcdaqEventiterator(host.c_str(), status);
 	}
       else
 	{


### PR DESCRIPTION
Some changes to make dlist and ddump honor a $RCDAQHOST env. variable definitions if one just says "dlist -r". The idea is that in that case it defaults to "localhost" in the absence of variable, or its value else.
The RCDAQHOST env. variable is set if one controls a remote rcdaq_server, and it is a reasonable assumption that one will also get monitoring data from there.
