### PR TITLE
add option to run truth jet reco only over embedded particles

### DIFF
--- a/simulation/g4simulation/g4jets/TruthJetInput.C
+++ b/simulation/g4simulation/g4jets/TruthJetInput.C
@@ -19,6 +19,8 @@
 #include <iostream>
 #include <vector>
 #include <cstdlib>
+#include <algorithm>    // std::find
+
 
 using namespace std;
 
@@ -64,7 +66,7 @@ std::vector<Jet*> TruthJetInput::get_input(PHCompositeNode *topNode) {
       {
         const int this_embed_id = truthinfo->isEmbeded(part->get_track_id());
 
-        if (_embed_id.find( this_embed_id ) ==  it != _embed_id.end())
+        if ( std::find(_embed_id.begin(), _embed_id.end(), this_embed_id) == _embed_id.end() )
           {
             continue; // reject particle as it is not in the interested embedding stream.
           }

--- a/simulation/g4simulation/g4jets/TruthJetInput.C
+++ b/simulation/g4simulation/g4jets/TruthJetInput.C
@@ -30,7 +30,16 @@ TruthJetInput::TruthJetInput(Jet::SRC input)
 }
 
 void TruthJetInput::identify(std::ostream& os) {
-  os << "   TruthJetInput: G4TruthInfo to Jet::PARTICLE" << endl;
+  os << "   TruthJetInput: G4TruthInfo to Jet::PARTICLE";
+  if ( use_embed_stream())
+    {
+      os<<". Processing embedded streams: ";
+      for (std::vector<int>::const_iterator it = _embed_id.begin(); it != _embed_id.end(); ++it)
+        {
+          os << (*it)<<", ";
+        }
+    }
+  os << endl;
 }
 
 std::vector<Jet*> TruthJetInput::get_input(PHCompositeNode *topNode) {
@@ -50,6 +59,16 @@ std::vector<Jet*> TruthJetInput::get_input(PHCompositeNode *topNode) {
        iter != range.second; 
        ++iter) {
     PHG4Particle *part = iter->second;
+
+    if (use_embed_stream())
+      {
+        const int this_embed_id = truthinfo->isEmbeded(part->get_track_id());
+
+        if (_embed_id.find( this_embed_id ) ==  it != _embed_id.end())
+          {
+            continue; // reject particle as it is not in the interested embedding stream.
+          }
+      }
 
     // remove some particles (muons, taus, neutrinos)...
     // 12 == nu_e

--- a/simulation/g4simulation/g4jets/TruthJetInput.h
+++ b/simulation/g4simulation/g4jets/TruthJetInput.h
@@ -15,6 +15,13 @@ public:
   TruthJetInput(Jet::SRC input);
   virtual ~TruthJetInput() {}
 
+  //! by default, TruthJetInput process all truth primary particle.
+  //! However, it can be configured to read only one or more embedded stream via add_embedding_flag()
+  //! It can be useful for reconstruct truth jet for embedded pythia jets only, etc.
+  //! Call add_embedding_flag() multiple times to add multiple embed stream
+  void add_embedding_flag(const int embed_stream_id)
+  {_embed_id.push_back(embed_stream_id);}
+
   void identify(std::ostream& os = std::cout);
   
   Jet::SRC get_src() {return _input;}
@@ -31,6 +38,12 @@ private:
   Jet::SRC _input;
   float _eta_min;
   float _eta_max;
+
+  //! if empty: process all primary particles
+  //! if non-empty: only process primary particles in the selected embed stream.
+  std::vector<int> _embed_id;
+
+  bool use_embed_stream() {return _embed_id.size()>0;}
 };
 
 #endif


### PR DESCRIPTION
This modification adds support for restricting truth jet reconstruction to only run over particles with an embedded id given by user. This is needed for studies of jet performance after embedding into HIJING. We tested this code at the sPHENIX MAPS workfest: it correctly recovers the "PYTHIA only" truth jet kinematics for PYTHIA events embedded into HIJING events. 

For example, if the embedded event is being read in with a HepMCNodeReader and assigned a given embedded ID:

```c++
      HepMCNodeReader *hr = new HepMCNodeReader();
      hr->Embed( 17 );
      se->registerSubsystem(hr);
```

Truth jet reconstruction can be specified to run only over particles with that embedded ID:

```c++
  TruthJetInput *tji = new TruthJetInput(Jet::PARTICLE);
  tji->add_embedding_flag( 17 );
  JetReco *truthjetreco = new JetReco();
  truthjetreco->add_input( tji );
```