### PR TITLE
mlp -- changed the default for the number of samples in teh HBD packets from 12 to 24.

### DIFF
--- a/online_distribution/newbasic/packet_hbd_fpga.cc
+++ b/online_distribution/newbasic/packet_hbd_fpga.cc
@@ -13,7 +13,7 @@ Packet_hbd_fpga::Packet_hbd_fpga(PACKET_ptr data)
     }
   else
     {
-      HBD_NSAMPLES = 12;
+      HBD_NSAMPLES = 24;
     }
   std::cout << "Samples = " << HBD_NSAMPLES << std::endl;
 }

--- a/online_distribution/newbasic/packet_hbd_fpgashort.cc
+++ b/online_distribution/newbasic/packet_hbd_fpgashort.cc
@@ -8,7 +8,7 @@ Packet_hbd_fpgashort::Packet_hbd_fpgashort(PACKET_ptr data)
   : Packet_w4 (data)
 {
   nr_modules = 0;
-  HBD_NSAMPLES = 12;
+  HBD_NSAMPLES = 24;
   hbd_parity=0;
 }
   


### PR DESCRIPTION
The HBD packet is the only one that needs some external information to decode properly, as the number of samples it was configured for is not part of the packet payload - a stupid oversight. 
The default for the HBD was 12, while in sPHENIX, where the old HBD electronics is used extensively, we virtually always write 24 samples. This is not an optimal situation, as our packets are normally required to be autonomously decodable. But in the sPHENIX context, this is better than each user having to manually set the number of samples, and always get it right. 