### PR TITLE
Change Flat Smearing from Full Width to Half Width in HepMCNodeReader

### DIFF
--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -228,7 +228,7 @@ HepMCNodeReader::smearflat(const double width)
     {
       return 0;
     }
-  return width*(gsl_rng_uniform_pos(RandomGenerator) - 0.5);
+  return 2.0*width*(gsl_rng_uniform_pos(RandomGenerator) - 0.5);
 }
 
 void


### PR DESCRIPTION
I realize now that most people would expect this to be a half width function not full width. Adding a factor two to switch to the half width definition.