### PR TITLE
Sort out row/column business for prototype

### DIFF
--- a/simulation/g4simulation/g4cemc/Prototype2RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/Prototype2RawTowerBuilder.cc
@@ -70,7 +70,7 @@ Prototype2RawTowerBuilder::InitRun(PHCompositeNode *topNode)
 int
 Prototype2RawTowerBuilder::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity)
+  if (verbosity>3)
     {
       std::cout << PHWHERE << "Process event entered" << std::endl;
     }

--- a/simulation/g4simulation/g4cemc/Prototype2RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/Prototype2RawTowerBuilder.cc
@@ -100,12 +100,13 @@ Prototype2RawTowerBuilder::process_event(PHCompositeNode *topNode)
         }
       short twrrow = get_tower_row(cell->get_row());
       // add the energy to the corresponding tower
-      RawTower *tower = _towers->getTower(twrrow, cell->get_column());
+      // towers are addressed column/row to make the mapping more intuitive
+      RawTower *tower = _towers->getTower(cell->get_column(), twrrow);
       if (!tower)
         {
           tower = new RawTowerv1();
           tower->set_energy(0);
-          _towers->AddTower(twrrow, cell->get_column(), tower);
+          _towers->AddTower(cell->get_column(), twrrow, tower);
         }
       double cell_weight = 0;
       if (_tower_energy_src == kEnergyDeposition)

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2HcalCellReco.cc
@@ -106,9 +106,9 @@ PHG4Prototype2HcalCellReco::process_event(PHCompositeNode *topNode)
 	    {
 	      continue;
 	    }
-	  short irow = hiter->second->get_layer();
 	  short icolumn = hiter->second->get_scint_id();
-	  if ( irow >= ROWDIM)
+	  short irow = hiter->second->get_row();
+	  if ( irow >= ROWDIM || irow < 0)
 	    {
 	      cout << "row " << irow
 		   << " exceed array size: " << ROWDIM
@@ -116,7 +116,7 @@ PHG4Prototype2HcalCellReco::process_event(PHCompositeNode *topNode)
 	      exit(1);
 	    }
 
-	  if (icolumn >= COLUMNDIM)
+	  if (icolumn >= COLUMNDIM || icolumn < 0)
 	    {
 	      cout << "column: " << icolumn
 		   << " exceed array size: " << COLUMNDIM
@@ -133,7 +133,7 @@ PHG4Prototype2HcalCellReco::process_event(PHCompositeNode *topNode)
 					     hiter->second->get_eion(),
 					     hiter->second->get_light_yield());
 	  slatarray[irow][icolumn]->add_hit_key(hiter->first);
-	  // cout << "row: " << hiter->second->get_layer() 
+	  // cout << "row: " << hiter->second->get_row() 
 	  // 	   << ", column: " << hiter->second->get_scint_id() << endl;
 	  // checking ADC timing integration window cut
 	} // end loop over g4hits

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
@@ -303,6 +303,10 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	{
 	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
           hit->set_eion(-1);
+	  if (whichactive > 0) // add light yield for scintillators
+	    {
+	      hit->set_light_yield(-1);
+	    }
 	}
       if (edep > 0)
 	{

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
@@ -68,8 +68,8 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aS
     {
       return false;
     }
-  unsigned int motherid = ~0x0; // initialize to 0xFFFFFF using the correct bitness
-  int tower_id = -1;
+  int row_id = -1;
+  int slat_id = -1;
   if (whichactive > 0) // scintillator
     {
       // first extract the scintillator id (0-3) from the volume name (OuterScinti_0,1,2,3)
@@ -77,7 +77,7 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aS
       boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
       boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter =  tok.begin();
       ++tokeniter;
-      tower_id = boost::lexical_cast<int>(*tokeniter);
+      slat_id = boost::lexical_cast<int>(*tokeniter);
       // G4AssemblyVolumes naming convention:
       //     av_WWW_impr_XXX_YYY_ZZZ
       // where:
@@ -102,12 +102,12 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aS
        	      ++tokeniter;
        	      if (tokeniter != tokm.end())
        		{
-		  motherid = boost::lexical_cast<int>(*tokeniter);
+		  row_id = boost::lexical_cast<int>(*tokeniter);
 // from the construction via assembly volumes, the mother id starts 
 // at 2 and is incremented by 2 for each new row of slats
 // this maps it back to 0-nslats
-		  motherid -= 2;  
-		  motherid /= 2;
+		  row_id -= 2;  
+		  row_id /= 2;
 		}
        	      else
        		{
@@ -118,12 +118,13 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	      break;
 	    }
 	}
-      // cout << "name " << volume->GetName() << ", mid: " << motherid
-      // 	   << ", twr: " << tower_id << endl;
+      // cout << "mother volume: " <<  mothervolume->GetName() 
+      //      << ", volume name " << volume->GetName() << ", row: " << row_id
+      //  	   << ", column: " << slat_id << endl;
     }
   else
     {
-      tower_id = touch->GetCopyNumber(); // steel plate id
+      slat_id = touch->GetCopyNumber(); // steel plate id
     }
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
@@ -163,8 +164,11 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	case fGeomBoundary:
 	case fUndefined:
 	  hit = new PHG4Hitv1();
-	  hit->set_layer(motherid);
-	  hit->set_scint_id(tower_id); // the slat id (or steel plate id)
+	  hit->set_row(row_id);
+	  if (whichactive > 0) // only for scintillators
+	    {
+	       hit->set_scint_id(slat_id); // the slat id in the mother volume (or steel plate id), the column
+	    }
 	  //here we set the entrance values in cm
 	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
 	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
@@ -172,50 +176,37 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	  // time in ns
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
-	  {
-            hit->set_trkid(aTrack->GetTrackID());
-            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	      {
-		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		  {
-		    hit->set_trkid(pp->GetUserTrackId());
-		    hit->set_shower_id(pp->GetShower()->get_id());
-		  }
-	      }
-	  }
+	  hit->set_trkid(aTrack->GetTrackID());
+	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+	    {
+	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		{
+		  hit->set_trkid(pp->GetUserTrackId());
+		  hit->set_shower_id(pp->GetShower()->get_id());
+		}
+	    }
 
 	  //set the initial energy deposit
 	  hit->set_edep(0);
 	  hit->set_eion(0); // only implemented for v5 otherwise empty
+          PHG4HitContainer *hitcontainer;
 	  if (whichactive > 0) // return of IsInPrototype2InnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
 	    {
+              hitcontainer = hits_;
 	      hit->set_light_yield(0); // for scintillator only, initialize light yields
-	      // Now add the hit
-	      hits_->AddHit(layer_id, hit);
-	      
-	      {
-		if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-		  {
-		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		      {
-			pp->GetShower()->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		      }
-		  }
-	      }
 	    }
 	  else
 	    {
-	      absorberhits_->AddHit(layer_id, hit);
-	      
-	      {
-		if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-		  {
-		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		      {
-			pp->GetShower()->add_g4hit_id(absorberhits_->GetID(),hit->get_hit_id());
-		      }
-		  }
-	      }
+	      hitcontainer = absorberhits_;
+	    }
+	  // here we set what is common for scintillator and absorber hits
+	  hitcontainer->AddHit(layer_id, hit);
+	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+	    {
+	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		{
+		  pp->GetShower()->add_g4hit_id(hitcontainer->GetID(),hit->get_hit_id());
+		}
 	    }
 	  break;
 	default:
@@ -232,73 +223,27 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aS
 
       if (whichactive > 0) // return of IsInPrototype2InnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
         {
+          light_yield = eion;
           if (light_scint_model)
             {
               light_yield = GetVisibleEnergyDeposition(aStep); // for scintillator only, calculate light yields
-	      static bool once = true;
-	      if (once && edep > 0)
-		{
-		  once = false;
-
-		  if (verbosity > 0) 
-		    {
-		      cout << "PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction::"
-			//
-			   << detector_->GetName() << " - "
-			   << " use scintillating light model at each Geant4 steps. "
-			   << "First step: " << "Material = "
-			   << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetName()
-			   << ", " << "Birk Constant = "
-			   << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetIonisation()->GetBirksConstant()
-			   << "," << "edep = " << edep << ", " << "eion = " << eion
-			   << ", " << "light_yield = " << light_yield << endl;
-		    }
-		}
 	    }
-	  else
-            {
-              light_yield = eion;
-            }
           if (isfinite(light_balance_outer_radius) && 
               isfinite(light_balance_inner_radius) && 
 	      isfinite(light_balance_outer_corr) &&
 	      isfinite(light_balance_inner_corr))
             {
-              double r = sqrt(
-			      postPoint->GetPosition().x()*postPoint->GetPosition().x()
-			      + postPoint->GetPosition().y()*postPoint->GetPosition().y());
+              double r = sqrt(postPoint->GetPosition().x()*postPoint->GetPosition().x()
+			    + postPoint->GetPosition().y()*postPoint->GetPosition().y());
               double cor =  GetLightCorrection(r);
               light_yield = light_yield * cor;
-
-              static bool once = true;
-              if (once && light_yield>0)
-                {
-                  once = false;
-
-		  if (verbosity > 1) 
-		    {
-		      cout << "PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction::"
-			//
-			   << detector_->GetName() << " - "
-			   << " use a simple light collection model with linear radial dependence. "
-			   <<"First step: "
-			   <<"r = " <<r/cm<<", "
-			   <<"correction ratio = " <<cor<<", "
-			   <<"light_yield after cor. = " <<light_yield
-			   << endl;
-		    }
-                }
-
             }
+	  hit->set_light_yield(hit->get_light_yield() + light_yield);
         }
 
       //sum up the energy to get total deposited
       hit->set_edep(hit->get_edep() + edep);
       hit->set_eion(hit->get_eion() + eion);
-      if (whichactive > 0)
-	{
-	  hit->set_light_yield(hit->get_light_yield() + light_yield);
-	}
       if (geantino)
 	{
 	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
@@ -303,6 +303,10 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	{
 	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
           hit->set_eion(-1);
+	  if (whichactive > 0)
+	    {
+	      hit->set_light_yield(-1);
+	    }
 	}
       if (edep > 0)
 	{

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
@@ -68,8 +68,8 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
     {
       return false;
     }
-  unsigned int motherid = ~0x0; // initialize to 0xFFFFFF using the correct bitness
-  int tower_id = -1;
+  int row_id = -1;
+  int slat_id = -1;
   if (whichactive > 0) // scintillator
     {
       // first extract the scintillator id (0-3) from the volume name (OuterScinti_0,1,2,3)
@@ -77,7 +77,7 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
       boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
       boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter =  tok.begin();
       ++tokeniter;
-      tower_id = boost::lexical_cast<int>(*tokeniter);
+      slat_id = boost::lexical_cast<int>(*tokeniter);
       // G4AssemblyVolumes naming convention:
       //     av_WWW_impr_XXX_YYY_ZZZ
       // where:
@@ -102,12 +102,12 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
        	      ++tokeniter;
        	      if (tokeniter != tokm.end())
        		{
-		  motherid = boost::lexical_cast<int>(*tokeniter);
+		  row_id = boost::lexical_cast<int>(*tokeniter);
 // from the construction via assembly volumes, the mother id starts 
 // at 2 and is incremented by 2 for each new row of slats
 // this maps it back to 0-nslats
-		  motherid -= 2;  
-		  motherid /= 2;
+		  row_id -= 2;  
+		  row_id /= 2;
 		}
        	      else
        		{
@@ -118,12 +118,13 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	      break;
 	    }
 	}
-      // cout << "name " << volume->GetName() << ", mid: " << motherid
-      // 	   << ", twr: " << tower_id << endl;
+      // cout << "mother volume: " <<  mothervolume->GetName() 
+      //      << ", volume name " << volume->GetName() << ", row: " << row_id
+      //  	   << ", column: " << slat_id << endl;
     }
   else
     {
-      tower_id = touch->GetCopyNumber(); // steel plate id
+      row_id = touch->GetCopyNumber(); // steel plate id
     }
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
@@ -163,8 +164,11 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	case fGeomBoundary:
 	case fUndefined:
 	  hit = new PHG4Hitv1();
-	  hit->set_layer(motherid);
-	  hit->set_scint_id(tower_id); // the slat id (or steel plate id)
+	  hit->set_row(row_id); // this is the row
+	  if (whichactive > 0) // only for scintillators
+	    {
+	       hit->set_scint_id(slat_id); // the slat id in the mother volume (or steel plate id), the column
+	    }
 	  //here we set the entrance values in cm
 	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
 	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
@@ -172,50 +176,38 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	  // time in ns
 	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
 	  //set the track ID
-	  {
-            hit->set_trkid(aTrack->GetTrackID());
-            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	      {
-		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		  {
-		    hit->set_trkid(pp->GetUserTrackId());
-		    hit->set_shower_id(pp->GetShower()->get_id());
-		  }
-	      }
-	  }
+	  hit->set_trkid(aTrack->GetTrackID());
+	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+	    {
+	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		{
+		  hit->set_trkid(pp->GetUserTrackId());
+		  hit->set_shower_id(pp->GetShower()->get_id());
+		}
+	    }
 
 	  //set the initial energy deposit
 	  hit->set_edep(0);
 	  hit->set_eion(0); // only implemented for v5 otherwise empty
+          PHG4HitContainer *hitcontainer;
+	  // here we do things which are different between scintillator and absorber hits
 	  if (whichactive > 0) // return of IsInPrototype2OuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
 	    {
+              hitcontainer = hits_;
 	      hit->set_light_yield(0); // for scintillator only, initialize light yields
-	      // Now add the hit
-	      hits_->AddHit(layer_id, hit);
-	      
-	      {
-		if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-		  {
-		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		      {
-			pp->GetShower()->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		      }
-		  }
-	      }
 	    }
 	  else
 	    {
-	      absorberhits_->AddHit(layer_id, hit);
-	      
-	      {
-		if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-		  {
-		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		      {
-			pp->GetShower()->add_g4hit_id(absorberhits_->GetID(),hit->get_hit_id());
-		      }
-		  }
-	      }
+	      hitcontainer = absorberhits_;
+	    }
+	  // here we set what is common for scintillator and absorber hits
+	  hitcontainer->AddHit(layer_id, hit);
+	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+	    {
+	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		{
+		  pp->GetShower()->add_g4hit_id(hitcontainer->GetID(),hit->get_hit_id());
+		}
 	    }
 	  break;
 	default:
@@ -232,73 +224,27 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 
       if (whichactive > 0) // return of IsInPrototype2OuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
         {
+          light_yield = eion;
           if (light_scint_model)
             {
               light_yield = GetVisibleEnergyDeposition(aStep); // for scintillator only, calculate light yields
-	      static bool once = true;
-	      if (once && edep > 0)
-		{
-		  once = false;
-
-		  if (verbosity > 0) 
-		    {
-		      cout << "PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction::"
-			//
-			   << detector_->GetName() << " - "
-			   << " use scintillating light model at each Geant4 steps. "
-			   << "First step: " << "Material = "
-			   << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetName()
-			   << ", " << "Birk Constant = "
-			   << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetIonisation()->GetBirksConstant()
-			   << "," << "edep = " << edep << ", " << "eion = " << eion
-			   << ", " << "light_yield = " << light_yield << endl;
-		    }
-		}
 	    }
-	  else
-            {
-              light_yield = eion;
-            }
           if (isfinite(light_balance_outer_radius) && 
               isfinite(light_balance_inner_radius) && 
 	      isfinite(light_balance_outer_corr) &&
 	      isfinite(light_balance_inner_corr))
             {
-              double r = sqrt(
-			      postPoint->GetPosition().x()*postPoint->GetPosition().x()
-			      + postPoint->GetPosition().y()*postPoint->GetPosition().y());
+              double r = sqrt(postPoint->GetPosition().x()*postPoint->GetPosition().x()
+			    + postPoint->GetPosition().y()*postPoint->GetPosition().y());
               double cor =  GetLightCorrection(r);
               light_yield = light_yield * cor;
-
-              static bool once = true;
-              if (once && light_yield>0)
-                {
-                  once = false;
-
-		  if (verbosity > 1) 
-		    {
-		      cout << "PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction::"
-			//
-			   << detector_->GetName() << " - "
-			   << " use a simple light collection model with linear radial dependence. "
-			   <<"First step: "
-			   <<"r = " <<r/cm<<", "
-			   <<"correction ratio = " <<cor<<", "
-			   <<"light_yield after cor. = " <<light_yield
-			   << endl;
-		    }
-                }
-
             }
+	  hit->set_light_yield(hit->get_light_yield() + light_yield);
         }
 
       //sum up the energy to get total deposited
       hit->set_edep(hit->get_edep() + edep);
       hit->set_eion(hit->get_eion() + eion);
-      if (whichactive > 0)
-	{
-	  hit->set_light_yield(hit->get_light_yield() + light_yield);
-	}
       if (geantino)
 	{
 	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression

--- a/simulation/g4simulation/g4main/PHG4Hit.cc
+++ b/simulation/g4simulation/g4main/PHG4Hit.cc
@@ -82,6 +82,8 @@ PHG4Hit::get_property_info(const PROPERTY prop_id)
     return make_pair("layer ID",PHG4Hit::type_uint);
   case   prop_scint_id:
     return make_pair("scintillator ID",PHG4Hit::type_int);
+  case   prop_row:
+    return make_pair("row",PHG4Hit::type_int);
   case   prop_strip_z_index:
     return make_pair("strip z index",PHG4Hit::type_int);
   case   prop_strip_y_index:

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -32,6 +32,7 @@ class PHG4Hit: public PHObject
   virtual PHG4HitDefs::keytype get_hit_id() const {return ULONG_LONG_MAX;}
   virtual int get_shower_id() const {return INT_MIN;}
   virtual int get_scint_id() const {return INT_MIN;}
+  virtual int get_row() const {return INT_MIN;}
   virtual int get_trkid() const {return INT_MIN;}
   virtual int get_strip_z_index() const {return INT_MIN;}
   virtual int get_strip_y_index() const {return INT_MIN;}
@@ -57,6 +58,7 @@ class PHG4Hit: public PHObject
   virtual void set_hit_id(const PHG4HitDefs::keytype i) {return;}
   virtual void set_shower_id(const int i) {return;}
   virtual void set_scint_id(const int i) {return;}
+  virtual void set_row(const int i) {return;}
   virtual void set_trkid(const int i) {return;}
   virtual void set_strip_z_index(const int i) {return;}
   virtual void set_strip_y_index(const int i) {return;}
@@ -105,6 +107,8 @@ class PHG4Hit: public PHObject
     prop_layer = 101,
     //! scintillator ID
     prop_scint_id = 102,
+    //! row (mother volume or steel plate id)
+    prop_row = 103,
 
     //! SVX stuff
     prop_strip_z_index = 110,

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -4,10 +4,13 @@
 #include "PHG4Hit.h"
 #include "PHG4HitDefs.h"
 
-#include <map>
+#ifdef __CINT__
 #include <stdint.h>
-
+#else
+#include <cstdint>
+#endif
 #include <iostream>
+#include <map>
 
 class PHG4Hitv1 : public PHG4Hit
 {
@@ -52,6 +55,7 @@ class PHG4Hitv1 : public PHG4Hit
   virtual float get_path_length() const {return  get_property_float(prop_path_length);}
   virtual unsigned int get_layer() const  {return  get_property_uint(prop_layer);}
   virtual int get_scint_id() const        {return  get_property_int(prop_scint_id);}
+  virtual int get_row() const {return  get_property_int(prop_row);}
   virtual int get_strip_z_index() const   {return  get_property_int(prop_strip_z_index);}
   virtual int get_strip_y_index() const   {return  get_property_int(prop_strip_y_index);}
   virtual int get_ladder_z_index() const  {return  get_property_int(prop_ladder_phi_index);}
@@ -69,6 +73,7 @@ class PHG4Hitv1 : public PHG4Hit
   virtual void set_path_length(const float f)           {set_property(prop_path_length,f);}
   virtual void set_layer(const unsigned int i)    {set_property(prop_layer,i);}
   virtual void set_scint_id(const int i)          {set_property(prop_scint_id,i);}
+  virtual void set_row(const int i)          {set_property(prop_row,i);}
   virtual void set_strip_z_index(const int i)     {set_property(prop_strip_z_index,i);}
   virtual void set_strip_y_index(const int i)     {set_property(prop_strip_y_index,i);}
   virtual void set_ladder_z_index(const int i)    {set_property(prop_ladder_phi_index,i);}


### PR DESCRIPTION
The columns are now mapped more intuitively onto eta bins, the rows onto phi bins. Add new property prop_row so we don't have to hijack the layers anymore which really have a different meaning