### PR TITLE
Add preliminary geometry object to prototype towers for digitizer, fix coverity problems

### DIFF
--- a/simulation/g4simulation/g4cemc/Prototype2RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/Prototype2RawTowerBuilder.cc
@@ -1,5 +1,7 @@
 #include "Prototype2RawTowerBuilder.h"
 #include "RawTowerContainer.h"
+#include "RawTowerGeomContainer_Cylinderv1.h"
+#include "RawTowerGeomv1.h"
 #include "RawTowerv1.h"
 #include <g4detectors/PHG4ScintillatorSlat.h>
 #include <g4detectors/PHG4ScintillatorSlatContainer.h>
@@ -172,7 +174,34 @@ Prototype2RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
 {
 
   PHNodeIterator iter(topNode);
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+      "PHCompositeNode", "RUN"));
+  if (!runNode)
+    {
+      std::cerr << PHWHERE << "Run Node missing, doing nothing." << std::endl;
+      throw std::runtime_error(
+          "Failed to find Run node in Prototype2RawTowerBuilder::CreateNodes");
+    }
+  TowerGeomNodeName = "TOWERGEOM_" + detector;
+  rawtowergeom = findNode::getClass<RawTowerGeomContainer>(topNode,
+      TowerGeomNodeName.c_str());
+  if (!rawtowergeom)
+    {
 
+      rawtowergeom = new RawTowerGeomContainer_Cylinderv1(RawTowerDefs::convert_name_to_caloid(detector));
+      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom,
+          TowerGeomNodeName.c_str(), "PHObject");
+      runNode->addNode(newNode);
+    }
+  for (int irow = 0; irow < 4; irow++)
+    {
+      for (int icolumn=0; icolumn<4; icolumn++)
+	{
+	  RawTowerGeomv1 * tg = new RawTowerGeomv1(RawTowerDefs::encode_towerid(RawTowerDefs::convert_name_to_caloid(detector), icolumn, irow));
+            rawtowergeom->add_tower_geometry(tg);
+	}
+    }
+	     	     
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
       "PHCompositeNode", "DST"));
   if (!dstNode)

--- a/simulation/g4simulation/g4cemc/RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerBuilder.cc
@@ -193,7 +193,7 @@ RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
 {
 
   PHNodeIterator iter(topNode);
-  PHCompositeNode *runNode = static_cast<PHCompositeNode*>(iter.findFirst(
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
       "PHCompositeNode", "RUN"));
   if (!runNode)
     {
@@ -407,12 +407,7 @@ RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
 
             tg->set_center_x(r * cos(rawtowergeom->get_phicenter(iphi)));
             tg->set_center_y(r * sin(rawtowergeom->get_phicenter(iphi)));
-            tg->set_center_z(
-                r
-                    / tan(
-                        PHG4Utils::get_theta(
-                            rawtowergeom->get_etacenter(ieta))));
-
+            tg->set_center_z(r / tan(PHG4Utils::get_theta(rawtowergeom->get_etacenter(ieta))));
             rawtowergeom->add_tower_geometry(tg);
           }
 

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
@@ -108,7 +108,6 @@ RawTowerDigitizer::process_event(PHCompositeNode *topNode)
       it != all_towers.second; ++it)
     {
       const RawTowerDefs::keytype key = it->second->get_id();
-     
       if(_tower_type>=0){
 	// Skip towers that don't match the type we are supposed to digitize
 	if(_tower_type != it->second->get_tower_type()) continue; 
@@ -121,19 +120,20 @@ RawTowerDigitizer::process_event(PHCompositeNode *topNode)
       if (_digi_algorithm == kNo_digitization)
         {
           if (sim_tower)
+	    {
             digi_tower = new RawTowerv1(*sim_tower);
+	    }
         }
       else if (_digi_algorithm == kSimple_photon_digitization)
+	{
         digi_tower = simple_photon_digitization(sim_tower);
+	}
       else
         {
 
           std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
               << " invalid digitization algorithm #" << _digi_algorithm
               << std::endl;
-
-          if (digi_tower)
-            delete digi_tower;
 
           return Fun4AllReturnCodes::ABORTRUN;
         }

--- a/simulation/g4simulation/g4cemc/RawTowerGeomContainer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomContainer.h
@@ -1,5 +1,5 @@
-#ifndef NEWGEOMCONTAINER_H__
-#define NEWGEOMCONTAINER_H__
+#ifndef RawTowerGeomContainer_H__
+#define RawTowerGeomContainer_H__
 
 #include "RawTowerDefs.h"
 #include <phool/PHObject.h>
@@ -88,4 +88,4 @@ class RawTowerGeomContainer : public PHObject
   ClassDef(RawTowerGeomContainer,2)
 };
 
-#endif /* NEWGEOMCONTAINER_H__ */
+#endif /* RawTowerGeomContainer_H__ */

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
@@ -110,7 +110,7 @@ bool PHG4CEmcTestBeamSteppingAction::UserSteppingAction( const G4Step* aStep, bo
 	      hitcontainer = absorberhits_;
 	    }
 	  // here we set what is common for scintillator and absorber hits
-	  hitcontainer->AddHit(layer_id, hit);
+	  hitcontainer->AddHit(tower_id, hit);
 	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	    {
 	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
@@ -99,34 +99,24 @@ bool PHG4CEmcTestBeamSteppingAction::UserSteppingAction( const G4Step* aStep, bo
 	  //set the initial energy deposit
 	  hit->set_edep(0);
 	  hit->set_eion(0); // only implemented for v5 otherwise empty
-
+          PHG4HitContainer *hitcontainer;
+	  // here we do things which are different between scintillator and absorber hits
 	  if (whichactive > 0) // return of isinCEmcTestDetector, > 0 hit in scintillator, < 0 hit in absorber
 	    {
-	      // Now add the hit
-	      hits_->AddHit(tower_id, hit);
-
-	      {
-		if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-		  {
-		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		      {
-			pp->GetShower()->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		      }
-		  }
-	      }
+              hitcontainer = hits_;
 	    }
 	  else
 	    {
-	      absorberhits_->AddHit(tower_id, hit);
-	      {
-		if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-		  {
-		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		      {
-			pp->GetShower()->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		      }
-		  }
-	      }
+	      hitcontainer = absorberhits_;
+	    }
+	  // here we set what is common for scintillator and absorber hits
+	  hitcontainer->AddHit(layer_id, hit);
+	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+	    {
+	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+		{
+		  pp->GetShower()->add_g4hit_id(hitcontainer->GetID(),hit->get_hit_id());
+		}
 	    }
 	  break;
 	default:

--- a/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSteppingAction.cc
@@ -188,7 +188,7 @@ bool PHG4HcalPrototypeSteppingAction::UserSteppingAction( const G4Step* aStep, b
 		  {
 		    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		      {
-			pp->GetShower()->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
+			pp->GetShower()->add_g4hit_id(absorberhits_->GetID(),hit->get_hit_id());
 		      }
 		  }
 	      }

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -557,6 +557,7 @@ PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume* hcalenv
   // here, this is why the indices are seemingly mixed up
   double xsteelcut[4];
   double zsteelcut[4];
+  fill_n(zsteelcut,4,NAN);
   xsteelcut[0] = x_inner + magnet_cutout_x;
   xsteelcut[1] = xsteelcut[0];
   xsteelcut[2] = inner_radius - offset;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
@@ -254,7 +254,7 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	      hit->set_light_yield(-1);
 	    }
 	}
-      if (edep > 0)
+      if (edep > 0 && (whichactive > 0 || absorbertruth > 0))
 	{
 	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	    {

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -199,7 +199,7 @@ int SvtxEvaluator::End(PHCompositeNode *topNode) {
     }
   }
   
-  if (_svtxevalstack) delete _svtxevalstack;
+  delete _svtxevalstack;
   
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -1,5 +1,4 @@
 #include "PHG4TPCClusterizer.h"
-#include <vector>
 #include "SvtxHitMap.h"
 #include "SvtxHit.h"
 #include "SvtxClusterMap.h"
@@ -22,11 +21,12 @@
 #include <g4detectors/PHG4CylinderCell.h>
 #include <g4detectors/PHG4CylinderCellGeom.h>
 
-#include "TMath.h"
+#include <TMath.h>
 
-#include <iostream>
-
+#include <cassert>
 #include <cstdlib>
+#include <iostream>
+#include <vector>
 
 using namespace std;
 
@@ -53,6 +53,7 @@ static bool is_local_maximum( std::vector<std::vector<float> > const& amps, int 
 		{
 			if( (iz==0) && (ip==0) ){continue;}
 			int cp = wrap_bin( phi+ip, amps[cz].size() );
+			assert (cp >= 0);
 			if( amps[cz][cp] > cent_val ){is_max=false;break;}
 		}
 		if(is_max==false){break;}
@@ -111,6 +112,7 @@ static void fit_cluster( std::vector<std::vector<float> >& amps, int& nhits_tot,
 		for( int ip=1;ip<=phi_span;++ip )
 		{
 			int cp = wrap_bin( phibin-ip, amps[cz].size() );
+			assert(cp >= 0);
 			if(amps[cz][cp] <= 0.){break;}
 			if( amps[cz][cp] < prop_cut*peak ){break;}
 			e += amps[cz][cp];


### PR DESCRIPTION
Using the empty geometry object (which basically only contains the number of towers) the output of the prototype tower builder can now be fed into the digitizer. Coverity found issues in many stepping actions where the new shower objects wasn't filled properly for absorber hits (cut and paste error). Fixed some other benign warnings (like possible use of negative indices) which probably never happened.