### PR TITLE
encode the caloid to RawTowerContainer, consistent with RawTowerGeomC…

### DIFF
--- a/simulation/g4simulation/g4cemc/Prototype2RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/Prototype2RawTowerBuilder.cc
@@ -221,7 +221,7 @@ Prototype2RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
     }
 
   // Create the tower nodes on the tree
-  _towers = new RawTowerContainer();
+  _towers = new RawTowerContainer(RawTowerDefs::convert_name_to_caloid(detector));
   if (_sim_tower_node_prefix.length() == 0)
     {
       // no prefix, consistent with older convension


### PR DESCRIPTION
One quick fix to sync ID between RawTowerContainer and RawTowerGeomContainer for Prototype2RawTowerBuilder