### PR TITLE
mlp - the padding in prdf was never properly implemented. 

### DIFF
--- a/online_distribution/newbasic/CpacketV1.h
+++ b/online_distribution/newbasic/CpacketV1.h
@@ -37,6 +37,7 @@ extern "C" {
 #include "packetV1Public.h"
 #include "packetHdrV1.h"
 #include "formatError.h"
+#include "dataBlock.h"
 
 VALUE_ret makePacketV1Hdr (PACKET_ptr, UINT);
 
@@ -86,7 +87,24 @@ INLINE_D LOGIC_ret emptyPacketV1 (PACKET_ptr packet_ptr)
 
 INLINE_D VALUE_ret getPacketV1DataLength (PACKET_ptr packet_ptr)
 {
-  PHDWORD dataLength = getPacketLength(packet_ptr) - getPacketHdrLength(packet_ptr) -
+
+  PHDWORD dataLength;
+  if (getPacketStructure(packet_ptr) == Unstructured)
+    {
+
+      int factor = 4 / getUnstructPacketWordSize(packet_ptr);
+
+      dataLength = factor * ( getPacketLength(packet_ptr)
+			      - getPacketHdrLength(packet_ptr)
+			      - getPacketErrorLength(packet_ptr)
+			      - getPacketDebugLength(packet_ptr) )
+	- getPacketPadding(packet_ptr);
+
+      return dataLength;
+
+    }
+  
+  dataLength = getPacketLength(packet_ptr) - getPacketHdrLength(packet_ptr) -
                      getPacketErrorLength(packet_ptr) - getPacketDebugLength(packet_ptr) -
                      getPacketPadding(packet_ptr);
   return dataLength;


### PR DESCRIPTION
We rarely saw this because the DCMs tend to give 32bit-based data, which works ok.
The padding is in units of the packet data size. So if that size is 1
(byte-based), and we store just one character, the padding will
be 7 so that we fill up to the next 64bit boundary. (Note that the
ONCS format is 128bit-aligned). Similarly, if the data size is 2, and we store
one value, we get a padding value of 3.
The routine here simply subtracted paddingsize 32bit-values, which was wrong.