### PR TITLE
mlp - added the class to maintain the temperatures for a given module.

### DIFF
--- a/offline/packages/Prototype2/Makefile.am
+++ b/offline/packages/Prototype2/Makefile.am
@@ -15,7 +15,8 @@ lib_LTLIBRARIES = \
   libPrototype2.la
 
 pkginclude_HEADERS = \
-  RawTower_Prototype2.h 
+  RawTower_Prototype2.h \
+  RawTower_Temperature.h 
 
 libPrototype2_la_SOURCES = \
   RawTower_Prototype2.cc \
@@ -31,7 +32,9 @@ libPrototype2_la_SOURCES = \
   GenericUnpackPRDF.C \
   GenericUnpackPRDFDict.C \
   PROTOTYPE2_FEM.C \
-  PROTOTYPE2_FEMDict.cc
+  PROTOTYPE2_FEMDict.cc \
+  RawTower_Temperature.cc \
+  RawTower_TemperatureDict.cc
 
 libPrototype2_la_LIBADD = \
   -lSubsysReco \

--- a/offline/packages/Prototype2/RawTower_Temperature.cc
+++ b/offline/packages/Prototype2/RawTower_Temperature.cc
@@ -1,0 +1,114 @@
+#include "RawTower_Temperature.h"
+#include <g4cemc/RawTowerDefs.h>
+#include <iostream>
+#include <iomanip>
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <cassert>
+
+#include "PROTOTYPE2_FEM.h"
+
+using namespace std;
+
+ClassImp(RawTower_Temperature)
+
+RawTower_Temperature::RawTower_Temperature() :
+    towerid(~0) // initialize all bits on
+{}
+
+// we can copy only from another  RawTower_Temperature, not a generic tower
+RawTower_Temperature::RawTower_Temperature(const RawTower_Temperature & tower)
+{
+  towerid = tower.get_id();
+
+  for ( int i = 0; i < tower.get_nr_entries(); i++)
+    {
+      add_entry( tower.get_eventnumber_from_entry(i)
+		 ,tower.get_time_from_entry(i)
+		 ,tower.get_temperature_from_entry(i) );
+    }
+}
+
+RawTower_Temperature::RawTower_Temperature(RawTowerDefs::keytype id) :
+    towerid(id)
+{
+
+}
+
+RawTower_Temperature::RawTower_Temperature(const unsigned int icol, const unsigned int irow)
+{
+  towerid = RawTowerDefs::encode_towerid(RawTowerDefs::NONE, icol, irow);
+}
+
+
+RawTower_Temperature::~RawTower_Temperature()
+{
+}
+
+void
+RawTower_Temperature::Reset()
+{
+  eventnumbers.clear();
+  times.clear();
+  temperatures.clear();
+}
+
+float  RawTower_Temperature::get_temperature_from_time(const time_t t) const
+{
+  if ( !isValid() ) return -1;
+
+  if ( t < get_time_from_entry(0) ) // if we ask for a time before the start time, we return the first reading
+    {
+      return get_temperature_from_entry( 0);
+    }
+
+
+  int lowest_entry=0;
+  int above_entry=0;
+
+  for ( int i = 0; i < get_nr_entries() ; i++)
+    {
+      if ( get_time_from_entry(i) < t )
+	{
+	  lowest_entry = i;
+	}
+      else
+	{
+	  if ( !above_entry) above_entry = i;
+	}
+    }
+
+  if ( !above_entry  ) // we didn't find a entry later than this
+    {
+      return get_temperature_from_entry( lowest_entry);
+    }
+
+  double m = ( get_temperature_from_entry(above_entry) - get_temperature_from_entry(lowest_entry)) /
+    ( get_time_from_entry(above_entry) - get_time_from_entry(lowest_entry));
+
+  return get_temperature_from_entry(lowest_entry) + m * ( t-get_time_from_entry(lowest_entry) );
+
+}
+void
+RawTower_Temperature::identify(std::ostream& os) const
+{
+  os << "RawTower_Temperature col=" << get_column() << " row=" << get_row() << ":  " << temperatures.size() << " entries"  << std::endl;
+}
+
+void
+RawTower_Temperature::print(std::ostream& os) const
+{
+  identify(os);
+
+  cout << "entry    event     time        T" << endl;
+  for ( int i = 0; i < get_nr_entries(); i++)
+    {
+      os << setw( 4) << i << "  " 
+	 << setw(7) <<  get_eventnumber_from_entry(i) << "  "
+	 << setw(7) <<  get_time_from_entry(i)        << "  "
+	 << setw(5) <<  get_temperature_from_entry(i) 
+	 << endl;
+    }
+}
+

--- a/offline/packages/Prototype2/RawTower_Temperature.h
+++ b/offline/packages/Prototype2/RawTower_Temperature.h
@@ -1,0 +1,79 @@
+#ifndef RAWTOWER_TEMPERATURE_H_
+#define RAWTOWER_TEMPERATURE_H_
+
+#include <g4cemc/RawTower.h>
+#include <g4cemc/RawTowerDefs.h>
+#include <vector>
+#include <stdint.h>
+#include "PROTOTYPE2_FEM.h"
+
+class RawTower_Temperature : public RawTower {
+ public:
+  RawTower_Temperature();
+  RawTower_Temperature(const RawTower_Temperature & tower);
+  RawTower_Temperature(const unsigned int icol, const unsigned int irow);
+  RawTower_Temperature(RawTowerDefs::keytype id);
+  virtual ~RawTower_Temperature();
+
+  //  void set_id(RawTowerDefs::keytype id) { towerid = id; }
+
+  void Reset();
+  int isValid() const { return get_nr_entries(); }
+  void identify(std::ostream& os = std::cout) const;
+  void print(std::ostream& os = std::cout) const;
+
+  int get_column() const { return RawTowerDefs::decode_index1(towerid); }
+  int get_row() const { return RawTowerDefs::decode_index2(towerid); }
+
+  void set_id(RawTowerDefs::keytype id) { towerid = id; }
+  RawTowerDefs::keytype get_id() const { return towerid; }
+
+  int get_nr_entries() const { return temperatures.size(); }
+
+  int add_entry( const int eventnr, const time_t t, const float temp)
+  {
+    eventnumbers.push_back(eventnr);
+    times.push_back(t);
+    temperatures.push_back(temp);
+    return get_nr_entries();
+  }
+
+  float  get_temperature_from_entry(const unsigned int entry) const 
+  { 
+    if ( entry >= temperatures.size() ) return -1; 
+    return temperatures[entry];
+  }
+
+  time_t  get_time_from_entry(const unsigned int entry) const 
+  { 
+    if ( entry >=  times.size() ) return 0;   //1970...
+    return times[entry];
+  }
+
+  int  get_eventnumber_from_entry(const unsigned int entry) const 
+  { 
+    if ( entry >= eventnumbers.size() ) return -1; 
+    return eventnumbers[entry];
+  }
+
+  float  get_temperature_from_time(const time_t t) const;
+  
+
+  //---Raw data access------------------------------------------------------------
+
+ protected:
+  RawTowerDefs::keytype towerid;
+
+  //! Temperature readings 
+  //! since we do not have more than 100 entries per run typically,
+  //! we trade efficiency for some simplicity and just use some vectors.
+  //! 
+  std::vector<int> eventnumbers;  
+  std::vector<time_t> times;  
+  std::vector<float> temperatures;  
+
+  ClassDef(RawTower_Temperature, 1)
+};
+
+#endif /* RAWTOWER_PROTOTYPE2_H_ */
+

--- a/offline/packages/Prototype2/RawTower_TemperatureLinkDef.h
+++ b/offline/packages/Prototype2/RawTower_TemperatureLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RawTower_Temperature+;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
This is a class to store the temperature readings for the SiPMs on a tower by tower basis. This allows to structure the container in the same coordinate space as the real SiPM signals, and get the right temperature.
Since we are reading the temperature only every minute or so, we interpolate between readings for event times in between two measurements linearly in time.
One can also ask for the reading from a given entry if one wants to make more sophisticated interpolations.   