### PR TITLE
Use same memory saving hit caching as in spacal and inner/outer hcal, make more use of forward declarations

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4BlockRegionSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockRegionSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>

--- a/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.cc
@@ -4,7 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
-
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
@@ -4,7 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
-
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>

--- a/simulation/g4simulation/g4detectors/PHG4ConeRegionSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeRegionSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>

--- a/simulation/g4simulation/g4detectors/PHG4ConeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSteppingAction.cc
@@ -4,7 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
-
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderRegionSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderRegionSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -1,12 +1,14 @@
-#ifndef PHG4VCylinderSteppingAction_h
-#define PHG4VCylinderSteppingAction_h
+#ifndef PHG4CylinderSteppingAction_h
+#define PHG4CylinderSteppingAction_h
 
-#include "g4main/PHG4SteppingAction.h"
+#include <g4main/PHG4SteppingAction.h>
+
 #include <string>
 
 class PHG4CylinderDetector;
 class PHG4Hit;
 class PHG4HitContainer;
+class PHG4Shower;
 
 class PHG4CylinderSteppingAction : public PHG4SteppingAction
 {
@@ -29,7 +31,11 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
   void set_zmin(const float z) {zmin = z;}
   void set_zmax(const float z) {zmax = z;}
 
+  void flush_cached_values();
+
   private:
+
+  void save_previous_g4hit();
 
   //! pointer to the detector
   PHG4CylinderDetector* detector_;
@@ -37,9 +43,12 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
   //! pointer to hit container
   PHG4HitContainer * hits_;
   PHG4Hit *hit;
+  PHG4HitContainer *savehitcontainer;
+  PHG4Shower *saveshower;
+  int save_layer_id;
   float zmin;
   float zmax;
 };
 
 
-#endif //__G4PHPHYTHIAREADER_H__
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -1,17 +1,15 @@
-
-
 #include "PHG4CylinderSubsystem.h"
 #include "PHG4CylinderDetector.h"
 #include "PHG4CylinderGeomv1.h"
 #include "PHG4CylinderGeomContainer.h"
 #include "PHG4CylinderSteppingAction.h"
 #include "PHG4EventActionClearZeroEdep.h"
-//#include "PHG4CylinderEventAction.h"
+#include "PHG4FlushStepTrackingAction.h"
 #include "PHG4CylinderRegionSteppingAction.h"
-#include <g4main/PHG4Utils.h>
 
-#include <g4main/PHG4PhenixDetector.h>
 #include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4PhenixDetector.h>
+#include <g4main/PHG4Utils.h>
 
 #include <phool/getClass.h>
 
@@ -25,6 +23,7 @@ using namespace std;
 PHG4CylinderSubsystem::PHG4CylinderSubsystem( const std::string &na, const int lyr):
   detector_( NULL ),
   steppingAction_( NULL ),
+  trackingAction_(NULL),
   eventAction_(NULL),
   radius(100),
   length(100),
@@ -112,6 +111,10 @@ int PHG4CylinderSubsystem::InitRun( PHCompositeNode* topNode )
       steppingAction_->set_zmin(zpos-detlength/2.);
       steppingAction_->set_zmax(zpos + detlength/2.);
     }
+  if (steppingAction_)
+    {
+      trackingAction_ = new PHG4FlushStepTrackingAction(steppingAction_);
+    }
   return 0;
 
 }
@@ -141,4 +144,8 @@ PHG4SteppingAction* PHG4CylinderSubsystem::GetSteppingAction( void ) const
   return steppingAction_;
 }
 
-
+PHG4TrackingAction*
+PHG4CylinderSubsystem::GetTrackingAction( void ) const
+{
+  return trackingAction_; 
+}

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -1,7 +1,7 @@
 #ifndef PHG4CylinderSubsystem_h
 #define PHG4CylinderSubsystem_h
 
-#include "g4main/PHG4Subsystem.h"
+#include <g4main/PHG4Subsystem.h>
 
 #include <Geant4/G4Types.hh>
 #include <Geant4/G4String.hh>
@@ -9,6 +9,7 @@
 class PHG4CylinderDetector;
 class PHG4CylinderSteppingAction;
 class PHG4EventAction;
+class PHG4FlushStepTrackingAction;
 
 class PHG4CylinderSubsystem: public PHG4Subsystem
 {
@@ -38,8 +39,9 @@ class PHG4CylinderSubsystem: public PHG4Subsystem
   int process_event(PHCompositeNode *);
 
   //! accessors (reimplemented)
-  virtual PHG4Detector* GetDetector( void ) const;
-  virtual PHG4SteppingAction* GetSteppingAction( void ) const;
+  PHG4Detector* GetDetector( void ) const;
+  PHG4SteppingAction* GetSteppingAction( void ) const;
+  PHG4TrackingAction* GetTrackingAction( void ) const;
   PHG4EventAction* GetEventAction() const {return eventAction_;}
 
   void SetRadius(const G4double dbl) {radius = dbl;}
@@ -69,6 +71,9 @@ class PHG4CylinderSubsystem: public PHG4Subsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
   PHG4CylinderSteppingAction* steppingAction_;
+
+  PHG4FlushStepTrackingAction *trackingAction_;
+
   PHG4EventAction *eventAction_;
   G4double radius;
   G4double length;

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4FCalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FCalSteppingAction.cc
@@ -3,6 +3,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>

--- a/simulation/g4simulation/g4detectors/PHG4FPbScRegionSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScRegionSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSteppingAction.cc
@@ -3,6 +3,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSteppingAction.cc
@@ -7,6 +7,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4HitDefs.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -5,6 +5,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -10,6 +10,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
@@ -5,6 +5,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
@@ -5,6 +5,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4RICHSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHSteppingAction.cc
@@ -13,6 +13,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include "Geant4/G4ProcessManager.hh"

--- a/simulation/g4simulation/g4detectors/PHG4SectorSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSteppingAction.cc
@@ -12,6 +12,7 @@
 
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4HitDefs.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
@@ -13,6 +13,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4HitDefs.h>
+#include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4main/PHG4EventAction.h
+++ b/simulation/g4simulation/g4main/PHG4EventAction.h
@@ -1,9 +1,8 @@
 #ifndef PHG4EventAction_h
 #define PHG4EventAction_h
 
-#include <phool/PHCompositeNode.h>
-
 class G4Event;
+class PHCompositeNode;
 
 class PHG4EventAction
 {

--- a/simulation/g4simulation/g4main/PHG4Shower.h
+++ b/simulation/g4simulation/g4main/PHG4Shower.h
@@ -1,14 +1,13 @@
-#ifndef __PHG4SHOWER_H__
-#define __PHG4SHOWER_H__
+#ifndef PHG4SHOWER_H__
+#define PHG4SHOWER_H__
 
 #include "PHG4HitDefs.h"
 
 #include <phool/PHObject.h>
-#include <cmath>
+#include <cmath> // for NAN def
 #include <set>
 #include <map>
 #include <iostream>
-#include <string>
 
 class PHG4Shower : public PHObject {
 
@@ -118,4 +117,3 @@ private:
 };
 
 #endif
-

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
@@ -1,9 +1,9 @@
-#ifndef __PHG4TrackUserInfoV1_H__
-#define __PHG4TrackUserInfoV1_H__
+#ifndef PHG4TrackUserInfoV1_H__
+#define PHG4TrackUserInfoV1_H__
 
 #include <Geant4/G4VUserTrackInformation.hh>
 
-#include "PHG4Shower.h"
+class PHG4Shower;
 
 // Made this with "V1" in the name in case we ever want to inherit from
 // it with other versions...

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -4,6 +4,8 @@
 #include "PHG4UserPrimaryParticleInformation.h"
 
 #include "PHG4VtxPoint.h"
+#include "PHG4Shower.h"
+
 #include "PHG4TruthInfoContainer.h"
 #include "PHG4HitContainer.h"
 #include "PHG4Hit.h"

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.h
@@ -3,17 +3,15 @@
 
 #include "PHG4EventAction.h"
 
-#include "PHG4HitContainer.h"
-
-#include <phool/PHCompositeNode.h>
-
 #include <Geant4/G4ThreeVector.hh>
 #include <Geant4/globals.hh>
 
 #include <set>
 #include <map>
 
+class PHG4HitContainer;
 class PHG4TruthInfoContainer;
+class PHCompositeNode;
 
 class PHG4TruthEventAction: public PHG4EventAction
 {

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -1,5 +1,7 @@
 #include "PHG4TruthInfoContainer.h"
-#include "PHG4Particlev1.h"
+
+#include "PHG4Particle.h"
+#include "PHG4Shower.h"
 #include "PHG4VtxPointv1.h"
 
 #include <phool/phool.h>
@@ -290,4 +292,16 @@ int PHG4TruthInfoContainer::isEmbededVtx(const int vtxid) const {
   }
   
   return iter->second;
+}
+
+bool
+PHG4TruthInfoContainer::is_primary_vtx(const PHG4VtxPoint* v) const
+{
+  return (v->get_id() > 0);
+}
+
+bool
+PHG4TruthInfoContainer::is_primary(const PHG4Particle* p) const
+{
+  return (p->get_track_id() > 0);
 }

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -1,13 +1,14 @@
-#ifndef __PHG4TRUTHINFOCONTAINER_H__
-#define __PHG4TRUTHINFOCONTAINER_H__
+#ifndef PHG4TRUTHINFOCONTAINER_H__
+#define PHG4TRUTHINFOCONTAINER_H__
 
 #include <phool/PHObject.h>
+
 #include <map>
 #include <set>
 
-#include "PHG4Particle.h"
-#include "PHG4VtxPoint.h"
-#include "PHG4Shower.h"
+class PHG4Shower;
+class PHG4Particle;
+class PHG4VtxPoint;
 
 class PHG4TruthInfoContainer: public PHObject {
   
@@ -46,7 +47,7 @@ public:
   PHG4Particle* GetParticle(const int particleid);
   PHG4Particle* GetPrimaryParticle(const int particleid);
 
-  bool is_primary(const PHG4Particle* p) const {return (p->get_track_id() > 0);}
+  bool is_primary(const PHG4Particle* p) const;
   
   //! Get a range of iterators covering the entire container
   Range GetParticleRange() {return Range(particlemap.begin(),particlemap.end());}
@@ -89,7 +90,7 @@ public:
   PHG4VtxPoint* GetVtx(const int vtxid);
   PHG4VtxPoint* GetPrimaryVtx(const int vtxid);
 
-  bool is_primary_vtx(const PHG4VtxPoint* v) const {return (v->get_id() > 0);}
+  bool is_primary_vtx(const PHG4VtxPoint* v) const;
   
   //! Get a range of iterators covering the entire vertex container
   VtxRange GetVtxRange() {return VtxRange(vtxmap.begin(),vtxmap.end());}


### PR DESCRIPTION
I propagated the caching of hits to the cylinder subsystem. Saved hits before and after are identical. Also cleanup of include files. We don't want to drag around includes in include files which are not used and lead to sloppy programming downstream where code relies on some unrelated include to provide includes.