### PR TITLE
Module to support ganging EMCal readout

### DIFF
--- a/simulation/g4simulation/g4cemc/Makefile.am
+++ b/simulation/g4simulation/g4cemc/Makefile.am
@@ -57,6 +57,8 @@ libcemc_la_SOURCES = \
   RawClusterBuilderFwd_Dict.cc \
   RawTowerBuilder.cc \
   RawTowerBuilder_Dict.cc \
+  RawTowerCombiner.cc \
+  RawTowerCombiner_Dict.cc \
   RawTowerBuilderByHitIndex.cc \
   RawTowerBuilderByHitIndex_Dict.cc \
   RawTowerCalibration.cc \

--- a/simulation/g4simulation/g4cemc/RawTowerCalibration.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerCalibration.cc
@@ -212,8 +212,7 @@ RawTowerCalibration::CreateNodes(PHCompositeNode *topNode)
       CaliTowerNodeName.c_str());
   if (!_calib_towers)
     {
-      _calib_towers = new RawTowerContainer(
-          RawTowerDefs::convert_name_to_caloid(detector));
+      _calib_towers = new RawTowerContainer(_raw_towers -> getCalorimeterID());
       PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(
           _calib_towers, CaliTowerNodeName.c_str(), "PHObject");
       DetNode->addNode(towerNode);

--- a/simulation/g4simulation/g4cemc/RawTowerCombiner.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerCombiner.cc
@@ -82,6 +82,7 @@ RawTowerCombiner::process_event(PHCompositeNode *topNode)
   assert(_towers);
 
   const double input_e_sum = _towers->getTotalEdep();
+  const double input_n_tower = _towers->size();
 
   if (verbosity)
     {
@@ -180,8 +181,9 @@ RawTowerCombiner::process_event(PHCompositeNode *topNode)
   if (verbosity)
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << "input sum energy = " << input_e_sum << ", merged sum energy = "
-          << _towers->getTotalEdep() << std::endl;
+          << "input sum energy = " << input_e_sum <<" from "<<input_n_tower<< " towers, merged sum energy = "
+          << _towers->getTotalEdep()<<" from "<<_towers->size()<<" towers" << std::endl;
+      assert(input_e_sum ==  _towers->getTotalEdep());
     }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/simulation/g4simulation/g4cemc/RawTowerCombiner.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerCombiner.cc
@@ -25,11 +25,9 @@ using namespace std;
 RawTowerCombiner::RawTowerCombiner(const std::string& name) :
     SubsysReco(name), //
     /*std::string*/_tower_node_prefix("SIM"),
-    /*std::string*/_output_node_suffix(""), // empty suffix will be automatically assigned later
     /*unsigned int*/_n_combine_eta(2),
     /*unsigned int*/_n_combine_phi(2),
-    /*RawTowerContainer**/_intput_towers(NULL),
-    /*RawTowerContainer**/_output_towers(NULL),
+    /*RawTowerContainer**/_towers(NULL),
     /*std::string*/detector("NONE")
 {
 
@@ -50,15 +48,6 @@ RawTowerCombiner::InitRun(PHCompositeNode *topNode)
       cout << __PRETTY_FUNCTION__ << " Fatal error _n_combine_phi==0" << endl;
 
       exit(1243);
-    }
-
-  if (_output_node_suffix.length() == 0)
-    {
-      // automatic suffix
-
-      stringstream suffix;
-      suffix << _n_combine_eta << "x" << _n_combine_phi;
-      _output_node_suffix = suffix.str();
     }
 
   PHNodeIterator iter(topNode);
@@ -90,15 +79,20 @@ RawTowerCombiner::InitRun(PHCompositeNode *topNode)
 int
 RawTowerCombiner::process_event(PHCompositeNode *topNode)
 {
-  assert(_intput_towers);
-  assert(_output_towers);
+  assert(_towers);
+
+  const double input_e_sum = _towers->getTotalEdep();
 
   if (verbosity)
     {
       std::cout << __PRETTY_FUNCTION__ << "Process event entered" << std::endl;
     }
 
-  RawTowerContainer::ConstRange all_towers = _intput_towers->getTowers();
+  typedef pair<int, int> tower_id_t;
+  typedef map<tower_id_t, RawTower *> new_tower_map_t;
+  new_tower_map_t new_tower_map;
+
+  RawTowerContainer::ConstRange all_towers = _towers->getTowers();
   for (RawTowerContainer::ConstIterator it = all_towers.first;
       it != all_towers.second; ++it)
     {
@@ -110,21 +104,27 @@ RawTowerCombiner::process_event(PHCompositeNode *topNode)
       const int output_eta = get_output_bin_eta(intput_eta);
       const int output_phi = get_output_bin_phi(intput_phi);
 
-      RawTower *output_tower = _output_towers->getTower(output_eta, output_phi);
+      RawTower *output_tower = NULL;
+      new_tower_map_t::iterator it_new = new_tower_map.find(
+          make_pair(output_eta, output_phi));
 
-      if (not output_tower)
+      if (it_new == new_tower_map.end())
         {
           output_tower = new RawTowerv1(*input_tower);
-          _output_towers->AddTower(intput_eta, intput_phi, output_tower);
+          assert(output_tower);
+          new_tower_map[make_pair(output_eta, output_phi)] = output_tower;
+
           if (verbosity >= VERBOSITY_MORE)
             {
               std::cout << __PRETTY_FUNCTION__ << "::" << detector << "::"
-                  << " new output tower " << std::endl;
-              _output_towers->identify();
+                  << " new output tower (prior to tower ID assignment): ";
+              output_tower->identify();
             }
         }
       else
         {
+          output_tower = it_new->second;
+
           output_tower->set_energy(
               output_tower->get_energy() + input_tower->get_energy());
 
@@ -156,19 +156,32 @@ RawTowerCombiner::process_event(PHCompositeNode *topNode)
           if (verbosity >= VERBOSITY_MORE)
             {
               std::cout << __PRETTY_FUNCTION__ << "::" << detector << "::"
-                  << " merget into output tower " << std::endl;
-              _output_towers->identify();
+                  << " merget into output tower (prior to tower ID assignment) : ";
+              output_tower->identify();
             }
         }
 
     }
 
+  // replace content in tower container
+  _towers->Reset();
+
+  for (new_tower_map_t::iterator it = new_tower_map.begin();
+      it != new_tower_map.end(); ++it)
+    {
+
+      const int eta = it->first.first;
+      const int phi = it->first.second;
+      RawTower * tower = it->second;
+
+      _towers->AddTower(eta, phi, tower);
+    }
+
   if (verbosity)
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << "input sum energy = " << _intput_towers->getTotalEdep()
-          << ", output sum digitalized value = "
-          << _output_towers->getTotalEdep() << std::endl;
+          << "input sum energy = " << input_e_sum << ", merged sum energy = "
+          << _towers->getTotalEdep() << std::endl;
     }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -183,7 +196,6 @@ RawTowerCombiner::End(PHCompositeNode *topNode)
 void
 RawTowerCombiner::CreateNodes(PHCompositeNode *topNode)
 {
-  assert(_output_node_suffix.length() > 0);
 
   PHNodeIterator iter(topNode);
   PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
@@ -200,101 +212,105 @@ RawTowerCombiner::CreateNodes(PHCompositeNode *topNode)
       RawTowerDefs::convert_name_to_caloid(detector);
 
   const string iTowerGeomNodeName = "TOWERGEOM_" + detector;
-  RawTowerGeomContainer *input_towergeom = findNode::getClass<
+  RawTowerGeomContainer *towergeom = findNode::getClass<
       RawTowerGeomContainer>(topNode, iTowerGeomNodeName.c_str());
-  if (!input_towergeom)
+  if (!towergeom)
     {
       std::cerr << __PRETTY_FUNCTION__ << " - " << iTowerGeomNodeName
           << " Node missing, doing nothing." << std::endl;
       throw std::runtime_error(
           "Failed to find input tower geometry node in RawTowerCombiner::CreateNodes");
     }
+  assert(towergeom);
 
-  const string oTowerGeomNodeName = "TOWERGEOM_" + detector
-      + _output_node_suffix;
-  RawTowerGeomContainer *output_towergeom = findNode::getClass<
-      RawTowerGeomContainer>(topNode, oTowerGeomNodeName.c_str());
-  if (!output_towergeom)
-    {
-      output_towergeom = new RawTowerGeomContainer_Cylinderv1(caloid);
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(
-          output_towergeom, oTowerGeomNodeName.c_str(), "PHObject");
-      runNode->addNode(newNode);
-    }
+  const double r = towergeom->get_radius();
 
-  assert(output_towergeom);
+  const int new_phibins = ceil(
+      double(towergeom->get_phibins()) / double(_n_combine_phi));
+  const int new_etabins = ceil(
+      double(towergeom->get_etabins()) / double(_n_combine_eta));
 
-  const double r = input_towergeom->get_radius();
-  output_towergeom->set_radius(r);
-  output_towergeom->set_thickness(input_towergeom->get_thickness());
-  output_towergeom->set_phibins(
-      ceil(double(input_towergeom->get_phibins()) / double(_n_combine_phi)));
-  output_towergeom->set_etabins(
-      ceil(double(input_towergeom->get_etabins()) / double(_n_combine_eta)));
+  typedef std::pair<double, double> bound_t;
+  typedef std::vector<bound_t> bound_map_t;
 
-  for (int ibin = 0; ibin < output_towergeom->get_phibins(); ibin++)
+  bound_map_t eta_bound_map;
+  bound_map_t phi_bound_map;
+
+  for (int ibin = 0; ibin < new_phibins; ibin++)
     {
       const int first_bin = ibin * _n_combine_phi;
-      assert(first_bin >= 0 && first_bin < input_towergeom->get_phibins());
+      assert(first_bin >= 0 && first_bin < towergeom->get_phibins());
 
       int last_bin = (ibin + 1) * _n_combine_phi - 1;
-      if (last_bin >= input_towergeom->get_phibins())
-        last_bin = input_towergeom->get_phibins();
+      if (last_bin >= towergeom->get_phibins())
+        last_bin = towergeom->get_phibins();
 
-      const pair<double, double> range1 = input_towergeom->get_phibounds(
+      const pair<double, double> range1 = towergeom->get_phibounds(
           first_bin);
-      const pair<double, double> range2 = input_towergeom->get_phibounds(
+      const pair<double, double> range2 = towergeom->get_phibounds(
           last_bin);
 
-      output_towergeom->set_phibounds(ibin,
-          make_pair(range1.first, range2.second));
+      phi_bound_map.push_back(make_pair(range1.first, range2.second));
     }
 
-  for (int ibin = 0; ibin < output_towergeom->get_etabins(); ibin++)
+  for (int ibin = 0; ibin < new_etabins; ibin++)
     {
       const int first_bin = ibin * _n_combine_eta;
-      assert(first_bin >= 0 && first_bin < input_towergeom->get_etabins());
+      assert(first_bin >= 0 && first_bin < towergeom->get_etabins());
 
       int last_bin = (ibin + 1) * _n_combine_eta - 1;
-      if (last_bin >= input_towergeom->get_etabins())
-        last_bin = input_towergeom->get_etabins();
+      if (last_bin >= towergeom->get_etabins())
+        last_bin = towergeom->get_etabins();
 
-      const pair<double, double> range1 = input_towergeom->get_etabounds(
+      const pair<double, double> range1 = towergeom->get_etabounds(
           first_bin);
-      const pair<double, double> range2 = input_towergeom->get_etabounds(
+      const pair<double, double> range2 = towergeom->get_etabounds(
           last_bin);
 
-      output_towergeom->set_etabounds(ibin,
-          make_pair(range1.first, range2.second));
+      eta_bound_map.push_back(make_pair(range1.first, range2.second));
+    }
 
+  // now update the tower geometry object with the new tower structure.
+  towergeom->Reset();
+
+  towergeom->set_phibins(new_phibins);
+  towergeom->set_etabins(new_etabins);
+
+  for (int ibin = 0; ibin < new_phibins; ibin++)
+    {
+      towergeom->set_phibounds(ibin, phi_bound_map[ibin]);
+    }
+  for (int ibin = 0; ibin < new_etabins; ibin++)
+    {
+      towergeom->set_etabounds(ibin, eta_bound_map[ibin]);
     }
 
   // setup location of all towers
-  for (int iphi = 0; iphi < output_towergeom->get_phibins(); iphi++)
-    for (int ieta = 0; ieta < output_towergeom->get_etabins(); ieta++)
+  for (int iphi = 0; iphi < towergeom->get_phibins(); iphi++)
+    for (int ieta = 0; ieta < towergeom->get_etabins(); ieta++)
       {
         RawTowerGeomv1 * tg = new RawTowerGeomv1(
             RawTowerDefs::encode_towerid(caloid, ieta, iphi));
 
-        tg->set_center_x(r * cos(output_towergeom->get_phicenter(iphi)));
-        tg->set_center_y(r * sin(output_towergeom->get_phicenter(iphi)));
+        tg->set_center_x(r * cos(towergeom->get_phicenter(iphi)));
+        tg->set_center_y(r * sin(towergeom->get_phicenter(iphi)));
         tg->set_center_z(
             r
                 / tan(
                     PHG4Utils::get_theta(
-                        output_towergeom->get_etacenter(ieta))));
-        output_towergeom->add_tower_geometry(tg);
+                        towergeom->get_etacenter(ieta))));
+        towergeom->add_tower_geometry(tg);
       }
   if (verbosity >= VERBOSITY_SOME)
     {
-      output_towergeom->identify();
+      towergeom->identify();
     }
 
   const string input_TowerNodeName = "TOWER_" + _tower_node_prefix + "_"
       + detector;
-  _intput_towers = findNode::getClass<RawTowerContainer>(topNode,
+  _towers = findNode::getClass<RawTowerContainer>(topNode,
       input_TowerNodeName.c_str());
-  if (!_intput_towers)
+  if (!_towers)
     {
       std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
           << " " << input_TowerNodeName << " Node missing, doing bail out!"
@@ -312,34 +328,6 @@ RawTowerCombiner::CreateNodes(PHCompositeNode *topNode)
           << std::endl;
       throw std::runtime_error(
           "Failed to find DST node in RawTowerCombiner::CreateNodes");
-    }
-
-  PHNodeIterator dstiter(dstNode);
-  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst(
-      "PHCompositeNode", detector));
-  if (!DetNode)
-    {
-      DetNode = new PHCompositeNode(detector);
-      dstNode->addNode(DetNode);
-    }
-
-  // Create the tower nodes on the tree
-  _output_towers = new RawTowerContainer(caloid);
-  stringstream soutput_towers;
-  soutput_towers << "TOWER_";
-  if (_tower_node_prefix.length() > 0)
-    {
-      soutput_towers << _tower_node_prefix << "_";
-    }
-  soutput_towers << detector << _output_node_suffix;
-  PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_output_towers,
-      soutput_towers.str(), "PHObject");
-  DetNode->addNode(towerNode);
-
-  if (verbosity)
-    {
-      cout << __PRETTY_FUNCTION__ << ": output to " << soutput_towers.str()
-          << endl;
     }
 
   return;

--- a/simulation/g4simulation/g4cemc/RawTowerCombiner.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerCombiner.cc
@@ -1,0 +1,477 @@
+#include "RawTowerCombiner.h"
+#include "RawTowerContainer.h"
+#include "RawTowerGeomContainer_Cylinderv1.h"
+#include "RawTowerGeomv1.h"
+#include "RawTowerv1.h"
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellContainer.h>
+#include <g4detectors/PHG4CylinderCell.h>
+#include <g4detectors/PHG4CylinderCellDefs.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <g4main/PHG4Utils.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/getClass.h>
+
+#include <iostream>
+#include <stdexcept>
+#include <map>
+
+using namespace std;
+
+RawTowerCombiner::RawTowerCombiner(const std::string& name) :
+    SubsysReco(name), //
+    /*std::string*/_tower_node_prefix("SIM"),
+    /*std::string*/_output_node_suffix(""), // empty suffix will be automatically assigned later
+    /*unsigned int*/_n_combine_eta(2),
+    /*unsigned int*/_n_combine_phi(2),
+    /*RawTowerContainer**/_output_towers(NULL),
+    /*RawTowerContainer**/_input_towers(NULL),
+    /*RawTowerGeomContainer **/rawtowergeom(NULL),
+    /*std::string*/detector("NONE")
+{
+
+}
+
+int
+RawTowerCombiner::InitRun(PHCompositeNode *topNode)
+{
+  if (_n_combine_eta == 0)
+    {
+      cout << __PRETTY_FUNCTION__ << " Fatal error _n_combine_eta==0" << endl;
+
+      exit(1243);
+    }
+
+  if (_n_combine_phi == 0)
+    {
+      cout << __PRETTY_FUNCTION__ << " Fatal error _n_combine_phi==0" << endl;
+
+      exit(1243);
+    }
+
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode;
+  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",
+      "DST"));
+  if (!dstNode)
+    {
+      std::cout << __PRETTY_FUNCTION__ << "DST Node missing, doing nothing."
+          << std::endl;
+      exit(1);
+    }
+
+  try
+    {
+      CreateNodes(topNode);
+    }
+  catch (std::exception& e)
+    {
+      std::cout << e.what() << std::endl;
+      //exit(1);
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int
+RawTowerCombiner::process_event(PHCompositeNode *topNode)
+{
+  if (verbosity)
+    {
+      std::cout << __PRETTY_FUNCTION__ << "Process event entered" << std::endl;
+    }
+
+  RawTowerContainer::ConstRange all_towers = _intput_towers->getTowers();
+  for (RawTowerContainer::ConstIterator it = all_towers.first;
+      it != all_towers.second; ++it)
+    {
+      const RawTower *input_tower = it->second;
+      assert(input_tower);
+
+      const int intput_eta = input_tower->get_bineta();
+      const int intput_phi = input_tower->get_binphi();
+      const int output_eta = get_output_bin_eta(intput_eta);
+      const int output_phi = get_output_bin_phi(intput_phi);
+
+      RawTower *output_tower = _output_towers->getTower(output_eta, output_phi);
+
+      if (not output_tower)
+        {
+          output_tower = new RawTowerv1(*input_tower);
+          _output_towers->AddTower(intput_eta, intput_phi, output_tower);
+          if (verbosity >= VERBOSITY_MORE)
+            {
+              std::cout << __PRETTY_FUNCTION__ << "::" << detector << "::"
+                  << " new output tower " << _output_towers->identify()
+                  << std::endl;
+            }
+        }
+      else
+        {
+          output_tower->set_energy(
+              output_tower->get_energy() + input_tower->get_energy());
+
+          output_tower->set_time(
+              (abs(output_tower->get_energy()) * output_tower->get_time()
+                  + abs(input_tower->get_energy()) * input_tower->get_time()) //
+                  / (abs(output_tower->get_energy())
+                      + abs(input_tower->get_energy()) + 1e-9) //avoid devide 0
+                  );
+
+
+          RawTower::CellConstRange cell_range = input_tower->get_g4cells();
+
+          for (RawTower::CellConstIterator cell_iter = cell_range.first;
+              cell_iter != cell_range.second; ++cell_iter)
+            {
+              output_tower->add_ecell(cell_iter->first, cell_iter->second);
+            }
+
+          RawTower::ShowerConstRange shower_range = input_tower->get_g4showers();
+
+          for (RawTower::ShowerConstIterator shower_iter = shower_range.first;
+              shower_iter != shower_range.second; ++shower_iter)
+            {
+              output_tower->add_eshower(shower_iter->first, shower_iter->second);
+            }
+
+          if (verbosity >= VERBOSITY_MORE)
+            {
+              std::cout << __PRETTY_FUNCTION__ << "::" << detector << "::"
+                  << " merget into output tower " << _output_towers->identify()
+                  << std::endl;
+            }
+        }
+
+    }
+
+  if (verbosity)
+    {
+      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << "input sum energy = " << _sim_towers->getTotalEdep()
+          << ", output sum digitalized value = " << _raw_towers->getTotalEdep()
+          << std::endl;
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int
+RawTowerCombiner::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void
+RawTowerCombiner::CreateNodes(PHCompositeNode *topNode)
+{
+
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+      "PHCompositeNode", "RUN"));
+  if (!runNode)
+    {
+      std::cerr << __PRETTY_FUNCTION__ << "Run Node missing, doing nothing."
+          << std::endl;
+      throw std::runtime_error(
+          "Failed to find Run node in RawTowerCombiner::CreateNodes");
+    }
+
+  const RawTowerDefs::CalorimeterId caloid =
+      RawTowerDefs::convert_name_to_caloid(detector);
+
+  // get the cell geometry and build up the tower geometry object
+  std::string geonodename = "CYLINDERCELLGEOM_" + detector;
+  PHG4CylinderCellGeomContainer* cellgeos = findNode::getClass<
+      PHG4CylinderCellGeomContainer>(topNode, geonodename.c_str());
+  if (!cellgeos)
+    {
+      std::cerr << __PRETTY_FUNCTION__ << " " << geonodename
+          << " Node missing, doing nothing." << std::endl;
+      throw std::runtime_error(
+          "Failed to find " + geonodename
+              + " node in RawTowerCombiner::CreateNodes");
+    }
+  TowerGeomNodeName = "TOWERGEOM_" + detector;
+  RawTowerGeomContainer *rawtowergeom =
+      findNode::getClass<RawTowerGeomContainer>(topNode,
+          TowerGeomNodeName.c_str());
+  if (!rawtowergeom)
+    {
+
+      rawtowergeom = new RawTowerGeomContainer_Cylinderv1(caloid);
+      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom,
+          TowerGeomNodeName.c_str(), "PHObject");
+      runNode->addNode(newNode);
+    }
+  // fill the number of layers in the calorimeter
+  _nlayers = cellgeos->get_NLayers();
+
+  // Create the tower nodes on the tree
+  std::map<int, PHG4CylinderCellGeom *>::const_iterator miter;
+  std::pair<std::map<int, PHG4CylinderCellGeom *>::const_iterator,
+      std::map<int, PHG4CylinderCellGeom *>::const_iterator> begin_end =
+      cellgeos->get_begin_end();
+  int ifirst = 1;
+  int first_layer = -1;
+  PHG4CylinderCellGeom * first_cellgeo = NULL;
+  double inner_radius = 0;
+  double thickness = 0;
+  for (miter = begin_end.first; miter != begin_end.second; ++miter)
+    {
+      PHG4CylinderCellGeom *cellgeo = miter->second;
+      first_cellgeo = miter->second;
+
+      if (verbosity)
+        {
+          cellgeo->identify();
+        }
+      thickness += cellgeo->get_thickness();
+      if (ifirst)
+        {
+          _cell_binning = cellgeo->get_binning();
+          _nphibins = cellgeo->get_phibins();
+          _phimin = cellgeo->get_phimin();
+          _phistep = cellgeo->get_phistep();
+          if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
+              or _cell_binning == PHG4CylinderCellDefs::etaslatbinning)
+            {
+              _netabins = cellgeo->get_etabins();
+              _etamin = cellgeo->get_etamin();
+              _etastep = cellgeo->get_etastep();
+            }
+          else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
+            {
+              _netabins = cellgeo->get_zbins(); // bin eta in the same number of z bins
+            }
+          else if (_cell_binning == PHG4CylinderCellDefs::spacalbinning)
+            {
+              // use eta definiton for each row of towers
+              _netabins = cellgeo->get_etabins();
+            }
+          else
+            {
+              cout << "RawTowerCombiner::CreateNodes::" << Name()
+                  << " - Fatal Error - unsupported cell binning method "
+                  << _cell_binning << endl;
+            }
+          inner_radius = cellgeo->get_radius();
+          first_layer = cellgeo->get_layer();
+          ifirst = 0;
+        }
+      else
+        {
+          if (_cell_binning != cellgeo->get_binning())
+            {
+              cout << "inconsistent binning method from " << _cell_binning
+                  << " layer " << cellgeo->get_layer() << ": "
+                  << cellgeo->get_binning() << endl;
+              exit(1);
+            }
+          if (inner_radius > cellgeo->get_radius())
+            {
+              cout << "radius of layer " << cellgeo->get_layer() << " is "
+                  << cellgeo->get_radius() << " which smaller than radius "
+                  << inner_radius << " of first layer in list " << first_layer
+                  << endl;
+            }
+          if (_nphibins != cellgeo->get_phibins())
+            {
+              cout << "mixing number of phibins, fisrt layer: " << _nphibins
+                  << " layer " << cellgeo->get_layer() << ": "
+                  << cellgeo->get_phibins() << endl;
+              exit(1);
+            }
+          if (_phimin != cellgeo->get_phimin())
+            {
+              cout << "mixing number of phimin, fisrt layer: " << _phimin
+                  << " layer " << cellgeo->get_layer() << ": "
+                  << cellgeo->get_phimin() << endl;
+              exit(1);
+            }
+          if (_phistep != cellgeo->get_phistep())
+            {
+              cout << "mixing phisteps first layer: " << _phistep << " layer "
+                  << cellgeo->get_layer() << ": " << cellgeo->get_phistep()
+                  << " diff: " << _phistep - cellgeo->get_phistep() << endl;
+              exit(1);
+            }
+          if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
+              or _cell_binning == PHG4CylinderCellDefs::etaslatbinning)
+            {
+              if (_netabins != cellgeo->get_etabins())
+                {
+                  cout << "mixing number of_netabins , fisrt layer: "
+                      << _netabins << " layer " << cellgeo->get_layer() << ": "
+                      << cellgeo->get_etabins() << endl;
+                  exit(1);
+                }
+              if (fabs(_etamin - cellgeo->get_etamin()) > 1e-9)
+                {
+                  cout << "mixing etamin, fisrt layer: " << _etamin << " layer "
+                      << cellgeo->get_layer() << ": " << cellgeo->get_etamin()
+                      << " diff: " << _etamin - cellgeo->get_etamin() << endl;
+                  exit(1);
+                }
+              if (fabs(_etastep - cellgeo->get_etastep()) > 1e-9)
+                {
+                  cout << "mixing eta steps first layer: " << _etastep
+                      << " layer " << cellgeo->get_layer() << ": "
+                      << cellgeo->get_etastep() << " diff: "
+                      << _etastep - cellgeo->get_etastep() << endl;
+                  exit(1);
+                }
+            }
+
+          else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
+            {
+
+              if (_netabins != cellgeo->get_zbins())
+                {
+                  cout << "mixing number of z bins , fisrt layer: " << _netabins
+                      << " layer " << cellgeo->get_layer() << ": "
+                      << cellgeo->get_zbins() << endl;
+                  exit(1);
+                }
+            }
+        }
+    }
+  rawtowergeom->set_radius(inner_radius);
+  rawtowergeom->set_thickness(thickness);
+  rawtowergeom->set_phibins(_nphibins);
+//  rawtowergeom->set_phistep(_phistep);
+//  rawtowergeom->set_phimin(_phimin);
+  rawtowergeom->set_etabins(_netabins);
+
+  if (first_cellgeo == NULL)
+    {
+      cout
+          << "RawTowerCombiner::CreateNodes - ERROR - can not find first layer of cells "
+          << endl;
+
+      exit(1);
+    }
+
+  for (int ibin = 0; ibin < first_cellgeo->get_phibins(); ibin++)
+    {
+
+      const pair<double, double> range = first_cellgeo->get_phibounds(ibin);
+
+      rawtowergeom->set_phibounds(ibin, range);
+    }
+
+  if (_cell_binning == PHG4CylinderCellDefs::etaphibinning
+      or _cell_binning == PHG4CylinderCellDefs::etaslatbinning
+      or _cell_binning == PHG4CylinderCellDefs::spacalbinning)
+    {
+      const double r = inner_radius + thickness / 2.;
+
+      for (int ibin = 0; ibin < first_cellgeo->get_etabins(); ibin++)
+        {
+
+          const pair<double, double> range = first_cellgeo->get_etabounds(ibin);
+
+          rawtowergeom->set_etabounds(ibin, range);
+        }
+
+      // setup location of all towers
+      for (int iphi = 0; iphi < rawtowergeom->get_phibins(); iphi++)
+        for (int ieta = 0; ieta < rawtowergeom->get_etabins(); ieta++)
+          {
+            RawTowerGeomv1 * tg = new RawTowerGeomv1(
+                RawTowerDefs::encode_towerid(caloid, ieta, iphi));
+
+            tg->set_center_x(r * cos(rawtowergeom->get_phicenter(iphi)));
+            tg->set_center_y(r * sin(rawtowergeom->get_phicenter(iphi)));
+            tg->set_center_z(
+                r
+                    / tan(
+                        PHG4Utils::get_theta(
+                            rawtowergeom->get_etacenter(ieta))));
+            rawtowergeom->add_tower_geometry(tg);
+          }
+
+    }
+  else if (_cell_binning == PHG4CylinderCellDefs::sizebinning)
+    {
+      const double r = inner_radius + thickness / 2.;
+
+      for (int ibin = 0; ibin < first_cellgeo->get_zbins(); ibin++)
+        {
+
+          const pair<double, double> z_range = first_cellgeo->get_zbounds(ibin);
+//          const double r = first_cellgeo->get_radius();
+          const double eta1 = -log(tan(atan2(r, z_range.first) / 2.));
+          const double eta2 = -log(tan(atan2(r, z_range.second) / 2.));
+          rawtowergeom->set_etabounds(ibin, make_pair(eta1, eta2));
+        }
+
+      // setup location of all towers
+      for (int iphi = 0; iphi < rawtowergeom->get_phibins(); iphi++)
+        for (int ibin = 0; ibin < first_cellgeo->get_zbins(); ibin++)
+          {
+            RawTowerGeomv1 * tg = new RawTowerGeomv1(
+                RawTowerDefs::encode_towerid(caloid, ibin, iphi));
+
+            tg->set_center_x(r * cos(rawtowergeom->get_phicenter(iphi)));
+            tg->set_center_y(r * sin(rawtowergeom->get_phicenter(iphi)));
+            tg->set_center_z(first_cellgeo->get_zcenter(ibin));
+
+            rawtowergeom->add_tower_geometry(tg);
+          }
+    }
+  else
+    {
+      cout
+          << "RawTowerCombiner::CreateNodes - ERROR - unsupported cell geometry "
+          << _cell_binning << endl;
+      exit(1);
+    }
+
+  if (verbosity >= 1)
+    {
+      rawtowergeom->identify();
+    }
+
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+      "PHCompositeNode", "DST"));
+  if (!dstNode)
+    {
+      std::cerr << __PRETTY_FUNCTION__ << "DST Node missing, doing nothing."
+          << std::endl;
+      throw std::runtime_error(
+          "Failed to find DST node in RawTowerCombiner::CreateNodes");
+    }
+
+  PHNodeIterator dstiter(dstNode);
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst(
+      "PHCompositeNode", detector));
+  if (!DetNode)
+    {
+      DetNode = new PHCompositeNode(detector);
+      dstNode->addNode(DetNode);
+    }
+
+  // Create the tower nodes on the tree
+  _towers = new RawTowerContainer(caloid);
+  if (_sim_tower_node_prefix.length() == 0)
+    {
+      // no prefix, consistent with older convension
+      TowerNodeName = "TOWER_" + detector;
+    }
+  else
+    {
+      TowerNodeName = "TOWER_" + _sim_tower_node_prefix + "_" + detector;
+    }
+  PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers,
+      TowerNodeName.c_str(), "PHObject");
+  DetNode->addNode(towerNode);
+
+  return;
+}
+

--- a/simulation/g4simulation/g4cemc/RawTowerCombiner.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCombiner.h
@@ -106,8 +106,6 @@ protected:
   RawTowerContainer* _output_towers;
 
   std::string detector;
-  std::string TowerNodeName;
-  std::string TowerGeomNodeName;
 
 };
 

--- a/simulation/g4simulation/g4cemc/RawTowerCombiner.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCombiner.h
@@ -79,29 +79,10 @@ public:
     _n_combine_phi = combinePhi;
   }
 
-  //! suffix added to the calorimeter detector name
-  //! if empty, suffix will be automatically assigned, e.g. "2x2"
-  std::string
-  get_output_node_suffix() const
-  {
-    return _output_node_suffix;
-  }
-
-  //! suffix added to the calorimeter detector name
-  //! if empty, suffix will be automatically assigned, e.g. "2x2"
-  void
-  set_output_node_suffix(std::string outputNodeSuffix)
-  {
-    _output_node_suffix = outputNodeSuffix;
-  }
 protected:
 
   //! prefix to the tower node
   std::string _tower_node_prefix;
-
-  //! suffix added to the calorimeter detector name
-  //! if empty, suffix will be automatically assigned, e.g. "2x2"
-  std::string _output_node_suffix;
 
   //! number of eta towers to be merged into a new tower
   unsigned int _n_combine_eta;
@@ -117,8 +98,7 @@ protected:
   void
   CreateNodes(PHCompositeNode *topNode);
 
-  RawTowerContainer* _intput_towers;
-  RawTowerContainer* _output_towers;
+  RawTowerContainer* _towers;
 
   std::string detector;
 

--- a/simulation/g4simulation/g4cemc/RawTowerCombiner.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCombiner.h
@@ -30,54 +30,65 @@ public:
   process_event(PHCompositeNode *topNode);
   int
   End(PHCompositeNode *topNode);
+
   void
   Detector(const std::string &d)
   {
     detector = d;
   }
 
+  //! prefix to the tower node
   std::string
   get_tower_node_prefix() const
   {
     return _tower_node_prefix;
   }
 
+  //! prefix to the tower node
   void
-  set_tower_node_prefix(std::string simTowerNodePrefix)
+  set_tower_node_prefix(const std::string & simTowerNodePrefix)
   {
     _tower_node_prefix = simTowerNodePrefix;
   }
 
+  //! number of eta towers to be merged into a new tower
   unsigned int
   get_combine_eta() const
   {
     return _n_combine_eta;
   }
 
+  //! number of eta towers to be merged into a new tower
   void
   set_combine_eta(unsigned int combineEta)
   {
     _n_combine_eta = combineEta;
   }
 
+  //! number of eta towers to be merged into a new tower
   unsigned int
   get_combine_phi() const
   {
     return _n_combine_phi;
   }
 
+  //! number of eta towers to be merged into a new tower
   void
   set_combine_phi(unsigned int combinePhi)
   {
     _n_combine_phi = combinePhi;
   }
 
+  //! suffix added to the calorimeter detector name
+  //! if empty, suffix will be automatically assigned, e.g. "2x2"
   std::string
   get_output_node_suffix() const
   {
     return _output_node_suffix;
   }
 
+  //! suffix added to the calorimeter detector name
+  //! if empty, suffix will be automatically assigned, e.g. "2x2"
   void
   set_output_node_suffix(std::string outputNodeSuffix)
   {
@@ -85,12 +96,16 @@ public:
   }
 protected:
 
+  //! prefix to the tower node
   std::string _tower_node_prefix;
 
-  //! if empty, suffix will be automatically assigned
+  //! suffix added to the calorimeter detector name
+  //! if empty, suffix will be automatically assigned, e.g. "2x2"
   std::string _output_node_suffix;
 
+  //! number of eta towers to be merged into a new tower
   unsigned int _n_combine_eta;
+  //! number of phi towers to be merged into a new tower
   unsigned int _n_combine_phi;
 
   //! get the new ieta from the old

--- a/simulation/g4simulation/g4cemc/RawTowerCombiner.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCombiner.h
@@ -1,0 +1,114 @@
+#ifndef RawTowerCombiner_H__
+#define RawTowerCombiner_H__
+
+#include <fun4all/SubsysReco.h>
+#include <string>
+
+#include <phool/PHTimeServer.h>
+
+class PHCompositeNode;
+class RawTowerContainer;
+class RawTowerGeomContainer;
+
+//! RawTowerCombiner module that joints multiple RawTower together to form a single readout in a separate node
+//! Use this class to simulate ganged readout or trigger channels that combined multiple towers
+//! Should be called after RawTowerBuilder but before RawTowerDigitizer
+class RawTowerCombiner : public SubsysReco
+{
+
+public:
+  RawTowerCombiner(const std::string& name = "RawTowerCombiner");
+
+  virtual
+  ~RawTowerCombiner()
+  {
+  }
+
+  int
+  InitRun(PHCompositeNode *topNode);
+  int
+  process_event(PHCompositeNode *topNode);
+  int
+  End(PHCompositeNode *topNode);
+  void
+  Detector(const std::string &d)
+  {
+    detector = d;
+  }
+
+  std::string
+  get_tower_node_prefix() const
+  {
+    return _tower_node_prefix;
+  }
+
+  void
+  set_tower_node_prefix(std::string simTowerNodePrefix)
+  {
+    _tower_node_prefix = simTowerNodePrefix;
+  }
+
+  unsigned int
+  get_combine_eta() const
+  {
+    return _n_combine_eta;
+  }
+
+  void
+  set_combine_eta(unsigned int combineEta)
+  {
+    _n_combine_eta = combineEta;
+  }
+
+  unsigned int
+  get_combine_phi() const
+  {
+    return _n_combine_phi;
+  }
+
+  void
+  set_combine_phi(unsigned int combinePhi)
+  {
+    _n_combine_phi = combinePhi;
+  }
+
+  std::string
+  get_output_node_suffix() const
+  {
+    return _output_node_suffix;
+  }
+
+  void
+  set_output_node_suffix(std::string outputNodeSuffix)
+  {
+    _output_node_suffix = outputNodeSuffix;
+  }
+protected:
+
+  std::string _tower_node_prefix;
+
+  //! if empty, suffix will be automatically assigned
+  std::string _output_node_suffix;
+
+  unsigned int _n_combine_eta;
+  unsigned int _n_combine_phi;
+
+  //! get the new ieta from the old
+  inline int get_output_bin_eta(int input_bin) const {return input_bin/_n_combine_eta;}
+  //! get the new iphi from the old
+  inline int get_output_bin_phi(int input_bin) const {return input_bin/_n_combine_phi;}
+
+
+  void
+  CreateNodes(PHCompositeNode *topNode);
+
+  RawTowerContainer* _intput_towers;
+  RawTowerContainer* _output_towers;
+
+  std::string detector;
+  std::string TowerNodeName;
+  std::string TowerGeomNodeName;
+
+};
+
+#endif /* RawTowerCombiner_H__ */

--- a/simulation/g4simulation/g4cemc/RawTowerCombinerLinkDef.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCombinerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RawTowerCombiner-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
@@ -291,7 +291,7 @@ RawTowerDigitizer::CreateNodes(PHCompositeNode *topNode)
   RawTowerNodeName = "TOWER_" + _raw_tower_node_prefix + "_" + detector;
   _raw_towers = findNode::getClass<RawTowerContainer>(DetNode,RawTowerNodeName.c_str());
   if (!_raw_towers){
-    _raw_towers = new RawTowerContainer(RawTowerDefs::convert_name_to_caloid(detector));
+    _raw_towers = new RawTowerContainer( _sim_towers -> getCalorimeterID()  );
     PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_raw_towers,
 								   RawTowerNodeName.c_str(), "PHObject");
     DetNode->addNode(towerNode);

--- a/simulation/g4simulation/g4cemc/RawTowerGeomContainer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomContainer.h
@@ -27,7 +27,7 @@ class RawTowerGeomContainer : public PHObject
   //! default constructor for ROOT IO
   virtual ~RawTowerGeomContainer() {}
 
-  void identify(std::ostream& os=std::cout) const;
+  virtual void identify(std::ostream& os=std::cout) const;
 
   //! 8-bit calorimeter ID
   virtual void set_calorimeter_id( RawTowerDefs::CalorimeterId  ) { PHOOL_VIRTUAL_WARN("set_calorimeter_id()");}

--- a/simulation/g4simulation/g4cemc/RawTowerGeomContainer_Cylinderv1.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomContainer_Cylinderv1.cc
@@ -15,6 +15,19 @@ RawTowerGeomContainer_Cylinderv1::RawTowerGeomContainer_Cylinderv1(
   return;
 }
 
+
+void
+RawTowerGeomContainer_Cylinderv1::Reset()
+{
+  eta_bound_map.clear();
+
+  phi_bound_map.clear();
+
+  RawTowerGeomContainerv1::Reset();
+}
+
+
+
 void
 RawTowerGeomContainer_Cylinderv1::set_etabins(const int i)
 {

--- a/simulation/g4simulation/g4cemc/RawTowerGeomContainer_Cylinderv1.h
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomContainer_Cylinderv1.h
@@ -12,9 +12,12 @@ class RawTowerGeomContainer_Cylinderv1 : public RawTowerGeomContainerv1
 public:
   RawTowerGeomContainer_Cylinderv1(
       RawTowerDefs::CalorimeterId caloid);
+  virtual ~RawTowerGeomContainer_Cylinderv1() {Reset();}
 
-  void
+  virtual void
   identify(std::ostream& os = std::cout) const;
+
+  virtual void Reset();
 
   double
   get_radius() const

--- a/simulation/g4simulation/g4cemc/RawTowerGeomContainerv1.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomContainerv1.cc
@@ -91,7 +91,6 @@ RawTowerGeomContainerv1::Reset()
       _geoms.erase(_geoms.begin());
     }
 
-  RawTowerGeomContainer::Reset();
 }
 
 void

--- a/simulation/g4simulation/g4cemc/RawTowerGeomContainerv1.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomContainerv1.cc
@@ -84,11 +84,14 @@ RawTowerGeomContainerv1::isValid() const
 void
 RawTowerGeomContainerv1::Reset()
 {
+
   while (_geoms.begin() != _geoms.end())
     {
       delete _geoms.begin()->second;
       _geoms.erase(_geoms.begin());
     }
+
+  RawTowerGeomContainer::Reset();
 }
 
 void

--- a/simulation/g4simulation/g4cemc/RawTowerGeomContainerv1.h
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomContainerv1.h
@@ -15,9 +15,9 @@ class RawTowerGeomContainerv1 : public RawTowerGeomContainer
   RawTowerGeomContainerv1( RawTowerDefs::CalorimeterId caloid );
   virtual ~RawTowerGeomContainerv1();
 
-  void Reset();
-  int isValid() const;
-  void identify(std::ostream& os=std::cout) const;
+  virtual void Reset();
+  virtual int isValid() const;
+  virtual void identify(std::ostream& os=std::cout) const;
 
   void set_calorimeter_id( RawTowerDefs::CalorimeterId caloid ) { _caloid = caloid; }
   RawTowerDefs::CalorimeterId get_calorimeter_id( ) const { return _caloid; }


### PR DESCRIPTION
## Introduction

Adding a new tower analysis module to enable analysis of sPHENIX simulation to use multi-tower ganging of EMCal readout. For example 2x2-ganging as proposed for some CEMC de-scoping options. 

Technically, a new module ```RawTowerCombiner``` is introduced to combine MxN towers into one readout channel on an eta-phi tower grid exiting on the DST tree. Therefore, it needs to be called after ```RawTowerBuilder``` and before ```RawTowerDigitizer```. During the merging, truth structure (Cells and showers) is maintained. In the default mode, both RawTower and RawTowerGeometry are edited on the DST tree, rather than introducing a new node for combined towers. I found this is least intrusive to our analysis code base. 

If one need to use this module for ALD charge (e.g. photon position resolution, jet finding, etc.), please contact me directly, in order to speed up verification and feedback.

## Verification

The single particle simulation in the 2016-02-01 Geant4 production (```/sphenix/sim/sim01/production/2016-02-01```) was used for testing. 

One example is distance between best CEMC cluster from the trajectory projection of 24 GeV/c electrons. Green reference plot is default towering and blue curve is after 2x2 ganging. The ganged distribution is roughly twice wider while the central value remain zeroed.
<img width="194" alt="2x2test" src="https://cloud.githubusercontent.com/assets/7947083/15116941/546e3fd2-15d3-11e6-8a19-3e720c302ddd.png">

## Example macros

By default, this new module is NOT used in analysis and no ganging is applied. 

Example macro to enabling 2x2 ganging as proposed for some de-scoping otpions: https://github.com/blackcathj/macros/blob/EMCal2x2/macros/g4simulations/G4_CEmc_Spacal.C 
Or specifically these lines added:
```c++
void CEMC_Towers(int verbosity = 0) {
 ...
  // TowerBuilder
 ...

  // Make ganged output for CEMC
  if (combin_CEMC_tower_2x2)
  {
    // group CEMC RawTower to CEMC2x2
    RawTowerCombiner * TowerCombiner = new RawTowerCombiner("RawTowerCombiner_CEMC");
    TowerCombiner->Detector("CEMC");
    TowerCombiner->set_combine_eta(2);
    TowerCombiner->set_combine_phi(2);
//    TowerCombiner->Verbosity(RawTowerCombiner::VERBOSITY_SOME);
    se->registerSubsystem( TowerCombiner );
  }

 // TowerDigitizer
 ...
```