### PR TITLE
Fast jet crash fix by avoiding NAN vertex propagation to global vertex

### DIFF
--- a/simulation/g4simulation/g4jets/TowerJetInput.C
+++ b/simulation/g4simulation/g4jets/TowerJetInput.C
@@ -91,6 +91,19 @@ std::vector<Jet*> TowerJetInput::get_input(PHCompositeNode *topNode) {
   if (vtx) vtxz = vtx->get_z();
   else return std::vector<Jet*>();
 
+  if (isnan(vtxz))
+    {
+      static bool once = true;
+      if (once)
+        {
+          once = false;
+
+          cout <<"TowerJetInput::get_input - WARNING - vertex is NAN. Drop all tower inputs (further NAN-vertex warning will be suppressed)."<<endl;
+        }
+
+      return std::vector<Jet*>();
+    }
+
   std::vector<Jet*> pseudojets;
   RawTowerContainer::ConstRange begin_end = towers->getTowers();
   RawTowerContainer::ConstIterator rtiter;

--- a/simulation/g4simulation/g4vertex/GlobalVertexReco.C
+++ b/simulation/g4simulation/g4vertex/GlobalVertexReco.C
@@ -86,6 +86,8 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode) {
   std::set<unsigned int> used_bbc_vtxids;
   
   if (svtxmap && bbcmap) {
+
+      if (verbosity) cout <<"GlobalVertexReco::process_event - svtxmap && bbcmap"<<endl;
     
     for (SvtxVertexMap::ConstIter svtxiter = svtxmap->begin();
 	 svtxiter != svtxmap->end();
@@ -130,6 +132,8 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode) {
       vertex->insert_vtxids(GlobalVertex::BBC,bbc_best->get_id());
       used_bbc_vtxids.insert(bbc_best->get_id());
       
+      if (verbosity) vertex->identify();
+
       globalmap->insert(vertex);
     }
   }
@@ -137,11 +141,14 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode) {
   // okay now loop over all unused SVTX vertexes (2nd class)...
   if (svtxmap) {
 
+      if (verbosity) cout <<"GlobalVertexReco::process_event - svtxmap "<<endl;
     for (SvtxVertexMap::ConstIter svtxiter = svtxmap->begin();
 	 svtxiter != svtxmap->end();
 	 ++svtxiter) {
       const SvtxVertex* svtx = svtxiter->second;
       if (used_svtx_vtxids.find(svtx->get_id()) != used_svtx_vtxids.end()) continue;
+
+      if (isnan(svtx->get_z())) continue;
 
       // we have a standalone SVTX vertex
       GlobalVertex* vertex = new GlobalVertex_v1();
@@ -162,7 +169,8 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode) {
 
       vertex->insert_vtxids(GlobalVertex::SVTX,svtx->get_id());
       used_svtx_vtxids.insert(svtx->get_id());
-      
+
+      if (verbosity) vertex->identify();
       globalmap->insert(vertex);      
     }    
   }
@@ -170,11 +178,14 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode) {
   // okay now loop over all unused BBC vertexes (3rd class)...
   if (bbcmap) {
 
+      if (verbosity) cout <<"GlobalVertexReco::process_event -  bbcmap"<<endl;
     for (BbcVertexMap::ConstIter bbciter = bbcmap->begin();
 	 bbciter != bbcmap->end();
 	 ++bbciter) {
       const BbcVertex* bbc = bbciter->second;      
       if (used_bbc_vtxids.find(bbc->get_id()) != used_bbc_vtxids.end()) continue;
+
+      if (isnan(bbc->get_z())) continue;
 
       GlobalVertex* vertex = new GlobalVertex_v1();
 
@@ -201,7 +212,8 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode) {
 
       vertex->insert_vtxids(GlobalVertex::BBC,bbc->get_id());
       used_bbc_vtxids.insert(bbc->get_id());
-      
+
+      if (verbosity) vertex->identify();
       globalmap->insert(vertex);    
     }
   }


### PR DESCRIPTION
In the past few days the jet finding with calorimeter always crashes within FastJet (for both v3.1 and v3.2).  @pinkenburg , @dvperepelitsa and I traced down the problem to NAN momentum vector passed to FastJet, which stems from an NAN vertex z in the global vertex map. 

Therefore, as a temp fix, all vertex with NAN in z is rejected from filling into the global vertex map. Mike might have a permanent fix later by further trace to its source within the SVX vertex finder or upper stream. 

Checking reconstructing 250 events of 25GeV p+p jets. Blue curves is FastJet 3.2 + this fix. Green reference is FastJet 3.1 as produced on Feb 17.

Calorimeter Tower R=0.7 jet spectrum, which has been stable:
![g4sphenixcells_250jets25gev_test root_qa rootqa_draw_jet_spectrum_h_qag4simjet_antikt_tower_r07](https://cloud.githubusercontent.com/assets/7947083/15203494/64a8fdd2-17d2-11e6-92c4-13a4629e9371.png)

Calorimeter Tower R=0.7 jet truth matching, shows the reconstructed efficiency is slightly lower in the new software:
![g4sphenixcells_250jets25gev_test root_qa rootqa_draw_jet_truthmatching_h_qag4simjet_antikt_truth_r07_antikt_tower_r07](https://cloud.githubusercontent.com/assets/7947083/15203516/950621f8-17d2-11e6-9b2d-6f6f6bb9df63.png)
