### PR TITLE
mlp -- removed the "PROTOTYPE2_FEM.h" include from the header. 

### DIFF
--- a/offline/packages/Prototype2/RawTower_Temperature.h
+++ b/offline/packages/Prototype2/RawTower_Temperature.h
@@ -5,7 +5,6 @@
 #include <g4cemc/RawTowerDefs.h>
 #include <vector>
 #include <stdint.h>
-#include "PROTOTYPE2_FEM.h"
 
 class RawTower_Temperature : public RawTower {
  public:


### PR DESCRIPTION
When you want to use it in a non-production environment, it fails since
we are not installing this header.
This will not affect the existing DSTs. After the next rebuild all will be fine.