### PR TITLE
Apply residual space charge distortion in TPC

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -245,7 +245,11 @@ libg4detectors_la_SOURCES = \
   PHG4SpacalPrototypeSubsystem.cc \
   PHG4SpacalPrototypeSubsystem_Dict.cc \
   PHG4CylinderCellTPCReco.cc \
-  PHG4CylinderCellTPCReco_Dict.cc
+  PHG4CylinderCellTPCReco_Dict.cc\
+  PHG4TPCDistortion.cc \
+  PHG4TPCDistortion_Dict.cc\
+  PHG4TPCSpaceChargeDistortion.cc \
+  PHG4TPCSpaceChargeDistortion_Dict.cc
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -195,20 +195,23 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
       z =  hiter->second->get_z(0);
 
       // apply primary charge distortion
-      if (distortion)
-        {
+      if( (*layer) >= (unsigned int)num_pixel_layers )
+        { // in TPC
+          if (distortion)
+            {
+              // do TPC distortion
 
-          const double dz = distortion ->get_z_distortion(r,phi,z);
-          const double drphi = distortion ->get_rphi_distortion(r,phi,z);
-          //TODO: radial distortion is not applied at the moment,
-          //      because it leads to major change to the structure of this code and it affect the insensitive direction to
-          //      near radial tracks
-          //
-          //          const double dr = distortion ->get_r_distortion(r,phi,z);
-          phi += drphi/r;
-          z += dz;
+              const double dz = distortion ->get_z_distortion(r,phi,z);
+              const double drphi = distortion ->get_rphi_distortion(r,phi,z);
+              //TODO: radial distortion is not applied at the moment,
+              //      because it leads to major change to the structure of this code and it affect the insensitive direction to
+              //      near radial tracks
+              //
+              //          const double dr = distortion ->get_r_distortion(r,phi,z);
+              phi += drphi/r;
+              z += dz;
+            }
         }
-
 
       phibin = geo->get_phibin( phi );
       if(phibin < 0 || phibin >= nphibins){continue;}

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -9,6 +9,7 @@
 
 class PHCompositeNode;
 class PHG4CylinderCell;
+class PHG4TPCDistortion;
 
 class PHG4CylinderCellTPCReco : public SubsysReco
 {
@@ -16,7 +17,7 @@ public:
   
   PHG4CylinderCellTPCReco( int n_pixel=2, const std::string &name = "CYLINDERTPCRECO");
   
-  virtual ~PHG4CylinderCellTPCReco(){}
+  virtual ~PHG4CylinderCellTPCReco();
   
   //! module initialization
   int InitRun(PHCompositeNode *topNode);
@@ -37,7 +38,10 @@ public:
 
   void setDiffusion( double diff ){diffusion = diff;}
   void setElectronsPerKeV( double epk ){elec_per_kev = epk;}
-  
+
+  //! distortion to the primary ionization
+  void set_distortion (PHG4TPCDistortion * d) {distortion = d;}
+
 protected:
 //   void set_size(const int i, const double sizeA, const double sizeB, const int what);
 //   int CheckEnergy(PHCompositeNode *topNode);
@@ -68,6 +72,8 @@ protected:
 
   int num_pixel_layers;
   
+  //! distortion to the primary ionization if not NULL
+  PHG4TPCDistortion * distortion;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -40,7 +40,7 @@ public:
   void setElectronsPerKeV( double epk ){elec_per_kev = epk;}
 
   //! distortion to the primary ionization
-  void set_distortion (PHG4TPCDistortion * d) {distortion = d;}
+  void setDistortion (PHG4TPCDistortion * d) {distortion = d;}
 
 protected:
 //   void set_size(const int i, const double sizeA, const double sizeB, const int what);

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -33,7 +33,6 @@ public:
   void Detector(const std::string &d);
   void cellsize(const int i, const double sr, const double sz);
 //   void etaphisize(const int i, const double deltaeta, const double deltaphi);
-  void checkenergy(const int i=1) {chkenergyconservation = i;}
   void OutputDetector(const std::string &d) {outdetector = d;}
 
   void setDiffusion( double diff ){diffusion = diff;}
@@ -61,7 +60,6 @@ protected:
   std::map<int, std::pair<int, int> > n_phi_z_bins;
   
   int nbins[2];
-  int chkenergyconservation;
   
   TRandom3 rand;
 

--- a/simulation/g4simulation/g4detectors/PHG4TPCDistortion.cc
+++ b/simulation/g4simulation/g4detectors/PHG4TPCDistortion.cc
@@ -1,0 +1,27 @@
+// $Id: $                                                                                             
+
+/*!
+ * \file PHG4TPCDistortion.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "PHG4TPCDistortion.h"
+
+#include <phool/PHRandomSeed.h>
+
+PHG4TPCDistortion::PHG4TPCDistortion(int verbose) :
+    verbosity(verbose)
+{
+  RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
+  unsigned int seed = PHRandomSeed(); // fixed seed is handled in this funtcion
+  gsl_rng_set(RandomGenerator, seed);
+}
+
+PHG4TPCDistortion::~PHG4TPCDistortion()
+{
+  gsl_rng_free(RandomGenerator);
+}
+

--- a/simulation/g4simulation/g4detectors/PHG4TPCDistortion.h
+++ b/simulation/g4simulation/g4detectors/PHG4TPCDistortion.h
@@ -1,0 +1,70 @@
+// $Id: $                                                                                             
+
+/*!
+ * \file PHG4TPCDistortion.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef PHG4TPCDISTORTION_H_
+#define PHG4TPCDISTORTION_H_
+
+// rootcint barfs with this header so we need to hide it
+#ifndef __CINT__
+#include <gsl/gsl_rng.h>
+#endif
+
+/*!
+ * \brief PHG4TPCDistortion is a virtual interface to apply distortion to a primary ionization in TPC
+ *
+ * IO follow PHENIX units (cm)
+ */
+class PHG4TPCDistortion
+{
+public:
+  explicit
+  PHG4TPCDistortion(int verbose = 0);
+
+  virtual
+  ~PHG4TPCDistortion();
+
+  //! radial distortion for a given truth location of the primary ionization
+  virtual double
+  get_r_distortion(double r, double phi, double z) = 0;
+
+  //! r*phi distortion for a given truth location of the primary ionization
+  virtual double
+  get_rphi_distortion(double r, double phi, double z) = 0;
+
+  //! z distortion for a given truth location of the primary ionization
+  virtual double
+  get_z_distortion(double r, double phi, double z) = 0;
+
+  //! Sets the verbosity of this module (0 by default=quiet).
+  virtual void
+  Verbosity(const int ival)
+  {
+    verbosity = ival;
+  }
+
+  //! Gets the verbosity of this module.
+  virtual int
+  Verbosity() const
+  {
+    return verbosity;
+  }
+
+protected:
+  //! The verbosity level. 0 means not verbose at all.
+  int verbosity;
+
+#ifndef __CINT__
+  //! random generator that conform with sPHENIX standard
+  gsl_rng *RandomGenerator;
+#endif
+
+};
+
+#endif /* PHG4TPCDISTORTION_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4TPCDistortionLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4TPCDistortionLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4TPCDistortion-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4TPCSpaceChargeDistortion.cc
+++ b/simulation/g4simulation/g4detectors/PHG4TPCSpaceChargeDistortion.cc
@@ -22,10 +22,10 @@
 using namespace std;
 
 PHG4TPCSpaceChargeDistortion::PHG4TPCSpaceChargeDistortion(
-    const char * distortion_map_file, int verbose) :
+    const std::string & distortion_map_file, int verbose) :
     PHG4TPCDistortion(verbose)
 {
-  TFile file(distortion_map_file);
+  TFile file(distortion_map_file.c_str());
 
   if (not file.IsOpen())
     {
@@ -157,6 +157,10 @@ PHG4TPCSpaceChargeDistortion::get_r_distortion(double r, double phi, double z)
       + gsl_ran_gaussian(RandomGenerator, precisionFactor * dist);
   if (verbosity > 0)
     {
+      cout <<"PHG4TPCSpaceChargeDistortion::get_r_distortion - input"
+          <<" r = "<<r
+          <<" phi = "<<phi
+          <<" z = "<<z<<endl;
       cout << " Uncorrected R Distortion:" << dist;
       cout << " Corrected R Distortion:" << dist2;
       cout << endl;
@@ -180,6 +184,10 @@ PHG4TPCSpaceChargeDistortion::get_rphi_distortion(double r, double phi,
       + gsl_ran_gaussian(RandomGenerator, precisionFactor * dist);
   if (verbosity > 0)
     {
+      cout <<"PHG4TPCSpaceChargeDistortion::get_rphi_distortion - input"
+          <<" r = "<<r
+          <<" phi = "<<phi
+          <<" z = "<<z<<endl;
       cout << " Uncorrected rPHI Distortion:" << dist;
       cout << " Corrected rPHI Distortion:" << dist2;
       cout << endl;

--- a/simulation/g4simulation/g4detectors/PHG4TPCSpaceChargeDistortion.cc
+++ b/simulation/g4simulation/g4detectors/PHG4TPCSpaceChargeDistortion.cc
@@ -1,0 +1,190 @@
+// $Id: $                                                                                             
+
+/*!
+ * \file PHG4TPCSpaceChargeDistortion.cc
+ * \brief From TKH's SpaceChargeDistortion
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "PHG4TPCSpaceChargeDistortion.h"
+
+#include <gsl/gsl_randist.h>
+#include <TH2F.h>
+#include <TH2D.h>
+#include <TH3F.h>
+#include <TFile.h>
+
+#include <iostream>
+#include <cassert>
+
+using namespace std;
+
+PHG4TPCSpaceChargeDistortion::PHG4TPCSpaceChargeDistortion(
+    const char * distortion_map_file, int verbose) :
+    PHG4TPCDistortion(verbose)
+{
+  TFile file(distortion_map_file);
+
+  if (not file.IsOpen())
+    {
+      cout
+          << "PHG4TPCSpaceChargeDistortion::PHG4TPCSpaceChargeDistortion - Fatal Error - "
+          << "Failed to open distortion file " << distortion_map_file << endl;
+
+      exit(13);
+    }
+
+  TH3F *rDistortion = dynamic_cast<TH3F *>(file.Get("mapDeltaR"));
+  if (not rDistortion)
+    {
+      cout
+          << "PHG4TPCSpaceChargeDistortion::PHG4TPCSpaceChargeDistortion - Fatal Error - "
+          << "Failed to find TH3F mapDeltaR in distortion file "
+          << distortion_map_file << endl;
+
+      exit(13);
+    }
+  rDistortion->GetYaxis()->SetRange(1, 1);
+  rDistortion2 = dynamic_cast<TH2D *>(rDistortion->Project3D("xz"));
+  assert(rDistortion2);
+  rDistortion2->SetDirectory(NULL); // make sure to detach from the current TFile
+
+  TH3F *rPhiDistortion = dynamic_cast<TH3F *>(file.Get("mapRDeltaPHI"));
+  if (not rPhiDistortion)
+    {
+      cout
+          << "PHG4TPCSpaceChargeDistortion::PHG4TPCSpaceChargeDistortion - Fatal Error - "
+          << "Failed to find TH3F mapRDeltaPHI in distortion file "
+          << distortion_map_file << endl;
+
+      exit(13);
+    }
+  rPhiDistortion->GetYaxis()->SetRange(1, 1);
+  rPhiDistortion2 = dynamic_cast<TH2D *>(rPhiDistortion->Project3D("xz"));
+  assert(rPhiDistortion2);
+  rPhiDistortion2->SetDirectory(NULL); // make sure to detach from the current TFile
+
+  //  Default to ALICE values...
+  precisionFactor = 0.001;
+  accuracyFactor = 0.005;
+
+  if (verbosity > 1)
+    {
+      cout << "PHG4TPCSpaceChargeDistortion::PHG4TPCSpaceChargeDistortion - "
+          << endl;
+
+      double lowX = rDistortion->GetXaxis()->GetBinCenter(1);
+      double highX = rDistortion->GetXaxis()->GetBinCenter(
+          rDistortion->GetXaxis()->GetNbins());
+      double lowY = rDistortion->GetYaxis()->GetBinCenter(1);
+      double highY = rDistortion->GetYaxis()->GetBinCenter(
+          rDistortion->GetYaxis()->GetNbins());
+      double lowZ = rDistortion->GetZaxis()->GetBinCenter(1);
+      double highZ = rDistortion->GetZaxis()->GetBinCenter(
+          rDistortion->GetZaxis()->GetNbins());
+
+      cout << " " << lowX << " " << highX;
+      cout << " " << lowY << " " << highY;
+      cout << " " << lowZ << " " << highZ;
+      cout << endl;
+
+      double lowX2 = rDistortion2->GetXaxis()->GetBinCenter(1);
+      double highX2 = rDistortion2->GetXaxis()->GetBinCenter(
+          rDistortion2->GetXaxis()->GetNbins());
+      double lowY2 = rDistortion2->GetYaxis()->GetBinCenter(1);
+      double highY2 = rDistortion2->GetYaxis()->GetBinCenter(
+          rDistortion2->GetYaxis()->GetNbins());
+
+      cout << " " << lowX2 << " " << highX2;
+      cout << " " << lowY2 << " " << highY2;
+      cout << endl;
+    }
+
+  if (verbosity > 1)
+    {
+      cout << "PHG4TPCSpaceChargeDistortion::PHG4TPCSpaceChargeDistortion - "
+          << endl;
+
+      double lowX = rPhiDistortion->GetXaxis()->GetBinCenter(1);
+      double highX = rPhiDistortion->GetXaxis()->GetBinCenter(
+          rPhiDistortion->GetXaxis()->GetNbins());
+      double lowY = rPhiDistortion->GetYaxis()->GetBinCenter(1);
+      double highY = rPhiDistortion->GetYaxis()->GetBinCenter(
+          rPhiDistortion->GetYaxis()->GetNbins());
+      double lowZ = rPhiDistortion->GetZaxis()->GetBinCenter(1);
+      double highZ = rPhiDistortion->GetZaxis()->GetBinCenter(
+          rPhiDistortion->GetZaxis()->GetNbins());
+
+      cout << " " << lowX << " " << highX;
+      cout << " " << lowY << " " << highY;
+      cout << " " << lowZ << " " << highZ;
+      cout << endl;
+
+      double lowX2 = rPhiDistortion2->GetXaxis()->GetBinCenter(1);
+      double highX2 = rPhiDistortion2->GetXaxis()->GetBinCenter(
+          rPhiDistortion2->GetXaxis()->GetNbins());
+      double lowY2 = rPhiDistortion2->GetYaxis()->GetBinCenter(1);
+      double highY2 = rPhiDistortion2->GetYaxis()->GetBinCenter(
+          rPhiDistortion2->GetYaxis()->GetNbins());
+
+      cout << " " << lowX2 << " " << highX2;
+      cout << " " << lowY2 << " " << highY2;
+      cout << endl;
+    }
+
+}
+
+PHG4TPCSpaceChargeDistortion::~PHG4TPCSpaceChargeDistortion()
+{
+  if (rDistortion2)
+    delete rDistortion2;
+  if (rPhiDistortion2)
+    delete rPhiDistortion2;
+}
+
+double
+PHG4TPCSpaceChargeDistortion::get_r_distortion(double r, double phi, double z)
+{
+  //  Calculations ONLY for minus z;
+  if (z > 0)
+    z = -z;
+
+  //double dist = rDistortion->Interpolate(r,lowY,z);
+  double dist = rDistortion2->Interpolate(z, r);
+  double dist2 = accuracyFactor * dist
+      + gsl_ran_gaussian(RandomGenerator, precisionFactor * dist);
+  if (verbosity > 0)
+    {
+      cout << " Uncorrected R Distortion:" << dist;
+      cout << " Corrected R Distortion:" << dist2;
+      cout << endl;
+    }
+
+  return dist2;
+}
+
+double
+PHG4TPCSpaceChargeDistortion::get_rphi_distortion(double r, double phi,
+    double z)
+{
+  //  Need to have this histogram in the file...
+  //  Calculations ONLY for minus z;
+  if (z > 0)
+    z = -z;
+
+  //double dist = rPhiDistortion->Interpolate(r,lowY,z);
+  double dist = rPhiDistortion2->Interpolate(z, r);
+  double dist2 = accuracyFactor * dist
+      + gsl_ran_gaussian(RandomGenerator, precisionFactor * dist);
+  if (verbosity > 0)
+    {
+      cout << " Uncorrected rPHI Distortion:" << dist;
+      cout << " Corrected rPHI Distortion:" << dist2;
+      cout << endl;
+    }
+
+  return dist2;
+}
+

--- a/simulation/g4simulation/g4detectors/PHG4TPCSpaceChargeDistortion.h
+++ b/simulation/g4simulation/g4detectors/PHG4TPCSpaceChargeDistortion.h
@@ -15,6 +15,8 @@ class TH2D;
 
 #include "PHG4TPCDistortion.h"
 
+#include <string>
+
 /*!
  * \brief PHG4TPCSpaceChargeDistortion
  */
@@ -44,7 +46,7 @@ class TH2D;
 class PHG4TPCSpaceChargeDistortion : public PHG4TPCDistortion
 {
 public:
-  PHG4TPCSpaceChargeDistortion(const char * distortion_map_file, int verbose = 0);
+  PHG4TPCSpaceChargeDistortion(const std::string & distortion_map_file, int verbose = 0);
 
   virtual
   ~PHG4TPCSpaceChargeDistortion();

--- a/simulation/g4simulation/g4detectors/PHG4TPCSpaceChargeDistortion.h
+++ b/simulation/g4simulation/g4detectors/PHG4TPCSpaceChargeDistortion.h
@@ -1,0 +1,85 @@
+/// $Id: $
+
+/*!
+ * \file PHG4TPCSpaceChargeDistortion.h
+ * \brief From TKH's SpaceChargeDistortion
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef PHG4TPCSPACECHARGEDISTORTION_H_
+#define PHG4TPCSPACECHARGEDISTORTION_H_
+
+class TH2D;
+
+#include "PHG4TPCDistortion.h"
+
+/*!
+ * \brief PHG4TPCSpaceChargeDistortion
+ */
+///
+///  Hello Space Charge DIstortion Fans:
+///
+///    This program is a quick & dirty bootstrap to allow reasonably accurate
+///  space charge calculations to be made with minimal disturbance to our existing
+///  TPC code base in sPHENIX.  Here is the concept of how it works:
+///
+///  To reasonable accuracy, we can model space charge distortions as having two
+///  components, boith stemming dfrom the same original source:
+///
+///    1.  Loss of precision:
+///        We assume that the precision loss is proportional to the DISTORTION
+///        in a manner that is symmetric abouyt zero (after correction).
+///    2.  Loss of accuracy:
+///        Here we assume that we correctly poorly (wrong amount) and thereby
+///        gain a SHIFT that is proportional the distortion itself.
+///
+///  To get a "best estimate" calculation, one uses an external analysis of space charge
+///  distortions to determine the proportionality constants for each one of these.
+///
+///                                                                TKH
+///                                                                5-19-2016
+///
+class PHG4TPCSpaceChargeDistortion : public PHG4TPCDistortion
+{
+public:
+  PHG4TPCSpaceChargeDistortion(const char * distortion_map_file, int verbose = 0);
+
+  virtual
+  ~PHG4TPCSpaceChargeDistortion();
+
+  //! radial distortion for a given truth location of the primary ionization
+  double
+  get_r_distortion(double r, double phi, double z) ;
+
+  //! r*phi distortion for a given truth location of the primary ionization
+  double
+  get_rphi_distortion(double r, double phi, double z) ;
+
+  //! z distortion for a given truth location of the primary ionization
+  double
+  get_z_distortion(double r, double phi, double z) {return 0;}
+
+  TH2D *DRHIST()    {return rDistortion2;}
+  TH2D *DRPHIHIST() {return rPhiDistortion2;}
+
+  ///  NOTE:  ALICE claims that 20 cm deflections are corrected:
+  ///         precision = 200 microns   (precisionFactor = 0.001)
+  ///         accuracy = 1 mm           (accuracy factor = 0.005)
+  ///  These defaults are hard-coded in the constructor, but the user
+  ///  can change them using the routines below...
+  void setPrecision(double p) {precisionFactor = p;}
+  void setAccuracy (double a) { accuracyFactor = a;}
+
+protected:
+
+  TH2D *rDistortion2;
+  TH2D *rPhiDistortion2;
+
+  double precisionFactor;
+  double accuracyFactor;
+
+};
+
+#endif /* PHG4TPCSPACECHARGEDISTORTION_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4TPCSpaceChargeDistortionLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4TPCSpaceChargeDistortionLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4TPCSpaceChargeDistortion-!;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
## Introduction

Tom and Carlos modeled the residual TPC space charge distortion based on the space charge simulation and estimation on the correction residual. This residual distortion is introduced to TPC simulation. 

## Details

A distortion virtual interface class was introduced to apply any distortion to a primary ionization: ```PHG4TPCDistortion```. Later it can be used to apply various full distortion to the primary ionization. But in this pull request, we only apply the residual space charge distortion via prametrization of ```PHG4TPCSpaceChargeDistortion``` (a variation of Tom's code).

The distortion is applied which primary charge drift to the pad in ```PHG4CylinderCellTPCReco```.  At this moment, only r*phi distortion is applied, which is the sensitive direction to a most radial track. Proper application of radial distortion require additional work in the code structure by splitting hit from one TPC readout layer to possibly two different layers. This induce more changes in PHG4CylinderCellTPCReco as well as truth associations (a hit can be associated to multiple cell). Therefore I choose to defer the radial distortion to later stage. 

The necessary data file containing the simulated space charge distortion has already been installed on RCF default calibration folder via this commit:
https://github.com/sPHENIX-Collaboration/calibrations/commit/5a1acc63e424d4ad20dcf45c27f71ec2836b5891 

This pull request do not change default behavior that no distortion is applied unless specified in macro.

## Example TPC macro with distoration

The distortion is loaded to Cell reco. Parameter can be further tuned on macro level before apply in https://github.com/sPHENIX-Collaboration/macros/blob/master/macros/g4simulations/G4_Svtx_maps%2Btpc.C.
```c++
... 
double cage_length = 160.;  // important to use the correct length of TPC. Older version is 400cm,
... 

  PHG4TPCSpaceChargeDistortion * tpc_distortion = new PHG4TPCSpaceChargeDistortion(string(getenv("CALIBRATIONROOT")) + "/Tracking/TPC/SpaceChargeDistortion/sPHENIX20.root");
//  tpc_distortion -> setAccuracy(0); // option to over write default factors
//  tpc_distortion -> setPrecision(1); // option to over write default factors

  PHG4CylinderCellTPCReco *svtx_cells = new PHG4CylinderCellTPCReco(n_svx_layer);
  svtx_cells->setDistortion(tpc_distortion); // load the parametrization
...
```

A working macro set is here: 
https://github.com/blackcathj/macros/tree/tpc_distortion/macros/g4simulations 

## Checks

Tom's distortion code (implimented as ```PHG4TPCSpaceChargeDistortion```) allow adjust accuracy and precision factors. These checks vary these factors my a large amount to make sure the distortion is working. ~100 pT = 4 GeV/c pion- tracks shoot from fixed momentum (pT = 4 GeV/c) and angles (eta = 0.1, phi = 0/pi) are used in this study.

Legend:
* Geant4 truth hit location (red)
* Reconstructed cluster location (black)

1. apply full space charge distortion as shift in r*phi, with accuracy factor = 1 and precision factor = 0. This is as if do not apply space charge correction. The clusters are shifted azimuthally as expected. 
<img width="257" alt="2016-05-25 02_39_29-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/15542819/4dfad52c-2260-11e6-930f-ceb5379906a5.png">


2. apply full space charge distortion as smear in r*phi, with accuracy factor = 0 and precision factor = 1. This is an nonphysical setting for check the precision smearing code. The clusters are smeared around the truth hit  as expected. 
<img width="317" alt="2016-05-25 02_42_00-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/15542825/5171768e-2260-11e6-949d-ef0601b99557.png">

3. apply the default residual distortion, with default accuracy factor and precision factor. As the residual is small, it is very similar to without applying any distortion in this scale of event displays.
<img width="267" alt="2016-05-25 02_39_56-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/15542870/87941dac-2260-11e6-86e5-17182d79e013.png">
 
## Results

Tested with 10k pT=4GeV/c pion tracks of both charges at eta = 0.1. By applying the default residual distortion, changes in the dp/p and reco efficiency is very small for pT=4GeV/c tracks, with 1% +/- 1% relative increase in the width of dp/p.

<img width="330" alt="2016-05-25 10_15_45-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/15543135/ae1caa88-2261-11e6-8f1e-33b2ba233f9a.png">