### PR TITLE
Add Truth Layer Record to Eval

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -110,7 +110,7 @@ int SvtxEvaluator::Init(PHCompositeNode *topNode) {
 						  "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
 						  "gembed:gprimary:"
 						  "trackID:px:py:pz:charge:quality:chisq:ndf:nhits:layers:"
-						  "dca2d:dca2dsigma:pcax:pcay:pcaz:nfromtruth");
+						  "dca2d:dca2dsigma:pcax:pcay:pcaz:nfromtruth:layersfromtruth");
   
   if (_do_track_eval) _ntp_track = new TNtuple("ntp_track","svtxtrack => max truth",
 					       "event:trackID:px:py:pz:charge:"
@@ -124,7 +124,7 @@ int SvtxEvaluator::Init(PHCompositeNode *topNode) {
 					       "gpx:gpy:gpz:"
 					       "gvx:gvy:gvz:"
 					       "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
-					       "gembed:gprimary:nfromtruth");
+					       "gembed:gprimary:nfromtruth:layersfromtruth");
   
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -1150,6 +1150,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float pcaz          = NAN;
 
 	float nfromtruth    = NAN;
+	float layersfromtruth = NAN;
 
 	if (track) {
 	  trackID   = track->get_id();     
@@ -1178,9 +1179,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  pcaz      = track->get_z();
 
 	  nfromtruth = trackeval->get_nclusters_contribution(track,g4particle);
+	  layersfromtruth = trackeval->get_nclusters_contribution_by_layer(track,g4particle);
 	}
       
-	float gtrack_data[34] = {(float) _ievent,
+	float gtrack_data[35] = {(float) _ievent,
 				 gtrackID,
 				 gflavor,
 				 ng4hits,
@@ -1213,7 +1215,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				 pcax,       
 				 pcay,       
 				 pcaz,
-				 nfromtruth
+				 nfromtruth,
+				 layersfromtruth
 	};
 
 	_ntp_gtrack->Fill(gtrack_data);
@@ -1302,6 +1305,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gprimary = NAN;
 
 	float nfromtruth = NAN;
+	float layersfromtruth = NAN;
       
 	PHG4Particle* g4particle = trackeval->max_truth_particle_by_nclusters(track);
       
@@ -1333,9 +1337,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  gprimary = trutheval->is_primary(g4particle);
 
 	  nfromtruth = trackeval->get_nclusters_contribution(track,g4particle);
+	  layersfromtruth = trackeval->get_nclusters_contribution_by_layer(track,g4particle);
 	}
       
-	float track_data[50] = {(float) _ievent,
+	float track_data[51] = {(float) _ievent,
 				trackID, 
 				px,        
 				py,        
@@ -1384,7 +1389,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				gfz,
 				gembed,
 				gprimary,
-				nfromtruth
+				nfromtruth,
+				layersfromtruth
 	};
       
 	_ntp_track->Fill(track_data);

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -58,7 +58,8 @@ public:
   
   // overlap calculations
   unsigned int get_nclusters_contribution(SvtxTrack* svtxtrack, PHG4Particle* truthparticle);  
-
+  unsigned int get_nclusters_contribution_by_layer(SvtxTrack* svtxtrack, PHG4Particle* truthparticle);  
+  
   unsigned int get_errors() {return _errors + _clustereval.get_errors();}
 
 private:
@@ -84,6 +85,7 @@ private:
   std::map<SvtxCluster*,std::set<SvtxTrack*> >                _cache_all_tracks_from_cluster;
   std::map<SvtxCluster*,SvtxTrack*>                           _cache_best_track_from_cluster;
   std::map<std::pair<SvtxTrack*,PHG4Particle*>, unsigned int> _cache_get_nclusters_contribution;
+  std::map<std::pair<SvtxTrack*,PHG4Particle*>, unsigned int> _cache_get_nclusters_contribution_by_layer;
 };
 
 #endif // __SVTXTRACKEVAL_H__


### PR DESCRIPTION
I'm adding an entry to the track and gtrack ntuple to record which of the first 30 layers had clusters from the max truth contributor. This will help examine the matching correctness between the MAPS inner tracking and the TPC outer tracking.