### PR TITLE
Some Initial Pileup Capabilities

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -35,8 +35,9 @@ PHG4BlockCellReco::PHG4BlockCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new("PHG4BlockCellReco")),
   chkenergyconservation(0),
-  timing_min(0.0),
-  timing_max(numeric_limits<double>::max())
+  tmin_default(-0.0),  // ns
+  tmax_default(100.0), // ns
+  tmin_max()
 {
   memset(nbins, 0, sizeof(nbins));
 }
@@ -204,6 +205,14 @@ int PHG4BlockCellReco::InitRun(PHCompositeNode *topNode)
       layerseggeo->identify();
     }
   }
+
+  for (std::map<int,int>::iterator iter = binning.begin(); 
+       iter != binning.end(); ++iter) {
+    int layer = iter->first;
+    // if the user doesn't set an integration window, set the default
+    tmin_max.insert(std::make_pair(layer,std::make_pair(tmin_default,tmax_default)));    
+  }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -275,8 +284,8 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
       {
 	// checking ADC timing integration window cut
-	if (hiter->second->get_t(0)>timing_max) continue;
-	if (hiter->second->get_t(1)<timing_min) continue;
+	if (hiter->second->get_t(0)>tmin_max[*layer].second) continue;
+	if (hiter->second->get_t(1)<tmin_max[*layer].first) continue;	      
 
         pair<double, double> etax[2];
         double xbin[2];

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -35,8 +35,8 @@ PHG4BlockCellReco::PHG4BlockCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new("PHG4BlockCellReco")),
   chkenergyconservation(0),
-  tmin_default(-0.0),  // ns
-  tmax_default(100.0), // ns
+  tmin_default(0.0),  // ns
+  tmax_default(60.0), // ns
   tmin_max()
 {
   memset(nbins, 0, sizeof(nbins));

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -34,7 +34,9 @@ static vector<PHG4CylinderCell*> cellptarray;
 PHG4BlockCellReco::PHG4BlockCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new("PHG4BlockCellReco")),
-  chkenergyconservation(0), timing_window_size(numeric_limits<double>::max())
+  chkenergyconservation(0),
+  timing_min(0.0),
+  timing_max(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));
 }
@@ -272,9 +274,9 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
     {
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
       {
-          // checking ADC timing integration window cut
-          if (hiter->second->get_t(0)>timing_window_size)
-            continue;
+	// checking ADC timing integration window cut
+	if (hiter->second->get_t(0)>timing_max) continue;
+	if (hiter->second->get_t(1)<timing_min) continue;
 
         pair<double, double> etax[2];
         double xbin[2];

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
@@ -33,11 +33,17 @@ class PHG4BlockCellReco : public SubsysReco
   void cellsize(const int i, const double sr, const double sz);
   void etaxsize(const int i, const double deltaeta, const double deltax);
   void checkenergy(const int i=1) {chkenergyconservation = i;}
-
+  
+  double get_timing_window_min() {return timing_min;}
+  double get_timing_window_max() {return timing_max;}
+  void set_timing_window(const double tmin, const double tmax) {
+    timing_min = tmin; timing_max = tmax;
+  }
+  
   //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_window_size;}
+  double get_timing_window_size() const {return timing_max - timing_min;}
   //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {timing_window_size = s;}
+  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
 
  protected:
   void set_size(const int i, const double sizeA, const double sizeB, const int what);
@@ -63,7 +69,8 @@ class PHG4BlockCellReco : public SubsysReco
   int chkenergyconservation;
 
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_window_size;
+  double timing_min;
+  double timing_max;
 
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
@@ -39,7 +39,10 @@ class PHG4BlockCellReco : public SubsysReco
   void   set_timing_window(const int i, const double tmin, const double tmax) {
     tmin_max[i] = std::make_pair(tmin,tmax);
   }
-
+  void   set_timing_window_defaults(const double tmin, const double tmax) {
+    tmin_default = tmin; tmax_default = tmax;
+  }
+  
  protected:
   void set_size(const int i, const double sizeA, const double sizeB, const int what);
   int CheckEnergy(PHCompositeNode *topNode);

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
@@ -34,16 +34,11 @@ class PHG4BlockCellReco : public SubsysReco
   void etaxsize(const int i, const double deltaeta, const double deltax);
   void checkenergy(const int i=1) {chkenergyconservation = i;}
   
-  double get_timing_window_min() {return timing_min;}
-  double get_timing_window_max() {return timing_max;}
-  void set_timing_window(const double tmin, const double tmax) {
-    timing_min = tmin; timing_max = tmax;
+  double get_timing_window_min(const int i) {return tmin_max[i].first;}
+  double get_timing_window_max(const int i) {return tmin_max[i].second;}
+  void   set_timing_window(const int i, const double tmin, const double tmax) {
+    tmin_max[i] = std::make_pair(tmin,tmax);
   }
-  
-  //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_max - timing_min;}
-  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
 
  protected:
   void set_size(const int i, const double sizeA, const double sizeB, const int what);
@@ -69,9 +64,9 @@ class PHG4BlockCellReco : public SubsysReco
   int chkenergyconservation;
 
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_min;
-  double timing_max;
-
+  double tmin_default;
+  double tmax_default;
+  std::map<int, std::pair<double,double> > tmin_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -30,8 +30,8 @@ PHG4CylinderCellReco::PHG4CylinderCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new("PHG4CylinderCellReco")),
   chkenergyconservation(0),
-  tmin_default(-0.0),  // ns
-  tmax_default(100.0), // ns
+  tmin_default(0.0),  // ns
+  tmax_default(60.0), // ns
   tmin_max()
 {
   memset(nbins, 0, sizeof(nbins));

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -16,7 +16,7 @@
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
 
-#include<TROOT.h>
+#include <TROOT.h>
 
 #include <cmath>
 #include <cstdlib>
@@ -30,7 +30,9 @@ using namespace std;
 PHG4CylinderCellReco::PHG4CylinderCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new("PHG4CylinderCellReco")),
-  chkenergyconservation(0), timing_window_size(numeric_limits<double>::max())
+  chkenergyconservation(0),
+  timing_min(0.0),
+  timing_max(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));
 }
@@ -324,9 +326,9 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
           for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
             {
               // checking ADC timing integration window cut
-              if (hiter->second->get_t(0)>timing_window_size)
-                continue;
-
+              if (hiter->second->get_t(0)>timing_max) continue;
+	      if (hiter->second->get_t(1)<timing_min) continue;
+	      
               pair<double, double> etaphi[2];
               double phibin[2];
               double etabin[2];
@@ -525,8 +527,8 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
           for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
             {
               // checking ADC timing integration window cut
-              if (hiter->second->get_t(0)>timing_window_size)
-                continue;
+              if (hiter->second->get_t(0)>timing_max) continue;
+	      if (hiter->second->get_t(1)<timing_min) continue;
 
               double xinout[2];
               double yinout[2];

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -31,8 +31,9 @@ PHG4CylinderCellReco::PHG4CylinderCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new("PHG4CylinderCellReco")),
   chkenergyconservation(0),
-  timing_min(0.0),
-  timing_max(numeric_limits<double>::max())
+  tmin_default(-0.0),  // ns
+  tmax_default(100.0), // ns
+  tmin_max()
 {
   memset(nbins, 0, sizeof(nbins));
 }
@@ -250,6 +251,13 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
 	}
     }
 
+  for (std::map<int,int>::iterator iter = binning.begin(); 
+       iter != binning.end(); ++iter) {
+    int layer = iter->first;
+    // if the user doesn't set an integration window, set the default
+    tmin_max.insert(std::make_pair(layer,std::make_pair(tmin_default,tmax_default)));    
+  }
+  
   // print out settings
   if (verbosity > 0) {
     cout << "===================== PHG4CylinderCellReco::InitRun() =====================" << endl;
@@ -326,8 +334,8 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
           for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
             {
               // checking ADC timing integration window cut
-              if (hiter->second->get_t(0)>timing_max) continue;
-	      if (hiter->second->get_t(1)<timing_min) continue;
+              if (hiter->second->get_t(0)>tmin_max[*layer].second) continue;
+	      if (hiter->second->get_t(1)<tmin_max[*layer].first) continue;
 	      
               pair<double, double> etaphi[2];
               double phibin[2];
@@ -527,8 +535,8 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
           for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
             {
               // checking ADC timing integration window cut
-              if (hiter->second->get_t(0)>timing_max) continue;
-	      if (hiter->second->get_t(1)<timing_min) continue;
+              if (hiter->second->get_t(0)>tmin_max[*layer].second) continue;
+	      if (hiter->second->get_t(1)<tmin_max[*layer].first) continue;
 
               double xinout[2];
               double yinout[2];

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -24,7 +24,6 @@
 #include <sstream>
 #include <limits>       // std::numeric_limits
 
-
 using namespace std;
 
 PHG4CylinderCellReco::PHG4CylinderCellReco(const string &name) :

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
@@ -35,10 +35,16 @@ class PHG4CylinderCellReco : public SubsysReco
   void checkenergy(const int i=1) {chkenergyconservation = i;}
   void OutputDetector(const std::string &d) {outdetector = d;}
 
+  double get_timing_window_min() {return timing_min;}
+  double get_timing_window_max() {return timing_max;}
+  void set_timing_window(const double tmin, const double tmax) {
+    timing_min = tmin; timing_max = tmax;
+  }
+  
   //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_window_size;}
+  double get_timing_window_size() const {return timing_max - timing_min;}
   //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {timing_window_size = s;}
+  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
 
  protected:
   void set_size(const int i, const double sizeA, const double sizeB, const int what);
@@ -68,7 +74,8 @@ class PHG4CylinderCellReco : public SubsysReco
   int chkenergyconservation;
 
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_window_size;
+  double timing_min;
+  double timing_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
@@ -35,16 +35,11 @@ class PHG4CylinderCellReco : public SubsysReco
   void checkenergy(const int i=1) {chkenergyconservation = i;}
   void OutputDetector(const std::string &d) {outdetector = d;}
 
-  double get_timing_window_min() {return timing_min;}
-  double get_timing_window_max() {return timing_max;}
-  void set_timing_window(const double tmin, const double tmax) {
-    timing_min = tmin; timing_max = tmax;
+  double get_timing_window_min(const int i) {return tmin_max[i].first;}
+  double get_timing_window_max(const int i) {return tmin_max[i].second;}
+  void   set_timing_window(const int i, const double tmin, const double tmax) {
+    tmin_max[i] = std::make_pair(tmin,tmax);
   }
-  
-  //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_max - timing_min;}
-  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
 
  protected:
   void set_size(const int i, const double sizeA, const double sizeB, const int what);
@@ -74,8 +69,9 @@ class PHG4CylinderCellReco : public SubsysReco
   int chkenergyconservation;
 
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_min;
-  double timing_max;
+  double tmin_default;
+  double tmax_default;
+  std::map<int, std::pair<double,double> > tmin_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
@@ -40,6 +40,9 @@ class PHG4CylinderCellReco : public SubsysReco
   void   set_timing_window(const int i, const double tmin, const double tmax) {
     tmin_max[i] = std::make_pair(tmin,tmax);
   }
+  void   set_timing_window_defaults(const double tmin, const double tmax) {
+    tmin_default = tmin; tmax_default = tmax;
+  }
 
  protected:
   void set_size(const int i, const double sizeA, const double sizeB, const int what);

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -23,12 +23,15 @@
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <limits>
 
 using namespace std;
 
 
 PHG4CylinderCellTPCReco::PHG4CylinderCellTPCReco(const string &name) :
-SubsysReco(name), diffusion(0.0057), elec_per_kev(38.)
+  SubsysReco(name), diffusion(0.0057), elec_per_kev(38.),
+  timing_min(0.0),
+  timing_max(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));
 }
@@ -188,6 +191,10 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
     double phistepsize = phistep[*layer];
     for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
     {
+      // checking ADC timing integration window cut
+      if (hiter->second->get_t(0)>timing_max) continue;
+      if (hiter->second->get_t(1)<timing_min) continue;
+      
       double xinout;
       double yinout;
       double phi;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -36,8 +36,8 @@ PHG4CylinderCellTPCReco::PHG4CylinderCellTPCReco(int n_pixel,
       diffusion(0.0057),
       elec_per_kev(38.),
       num_pixel_layers(n_pixel),
-      tmin_default(-0.0),  // ns
-      tmax_default(100.0), // ns
+      tmin_default(0.0),  // ns
+      tmax_default(60.0), // ns
       tmin_max(),
       distortion(NULL) {}
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -35,9 +35,10 @@ PHG4CylinderCellTPCReco::PHG4CylinderCellTPCReco(int n_pixel,
     : SubsysReco(name),
       diffusion(0.0057),
       elec_per_kev(38.),
-      timing_min(0.0),
-      timing_max(numeric_limits<double>::max()),
       num_pixel_layers(n_pixel),
+      tmin_default(-0.0),  // ns
+      tmax_default(100.0), // ns
+      tmin_max(),
       distortion(NULL) {}
 
 PHG4CylinderCellTPCReco::~PHG4CylinderCellTPCReco()
@@ -154,6 +155,14 @@ int PHG4CylinderCellTPCReco::InitRun(PHCompositeNode *topNode)
     
     seggeo->AddLayerCellGeom(layerseggeo);
   }
+
+  for (std::map<int,int>::iterator iter = binning.begin(); 
+       iter != binning.end(); ++iter) {
+    int layer = iter->first;
+    // if the user doesn't set an integration window, set the default
+    tmin_max.insert(std::make_pair(layer,std::make_pair(tmin_default,tmax_default)));    
+  }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -188,8 +197,8 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
     for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
     {
       // checking ADC timing integration window cut
-      if (hiter->second->get_t(0)>timing_max) continue;
-      if (hiter->second->get_t(1)<timing_min) continue;
+      if (hiter->second->get_t(0)>tmin_max[*layer].second) continue;
+      if (hiter->second->get_t(1)<tmin_max[*layer].first) continue;
       
       double xinout;
       double yinout;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -39,17 +39,12 @@ public:
   void setDiffusion( double diff ){diffusion = diff;}
   void setElectronsPerKeV( double epk ){elec_per_kev = epk;}
 
-  double get_timing_window_min() {return timing_min;}
-  double get_timing_window_max() {return timing_max;}
-  void set_timing_window(const double tmin, const double tmax) {
-    timing_min = tmin; timing_max = tmax;
+  double get_timing_window_min(const int i) {return tmin_max[i].first;}
+  double get_timing_window_max(const int i) {return tmin_max[i].second;}
+  void   set_timing_window(const int i, const double tmin, const double tmax) {
+    tmin_max[i] = std::make_pair(tmin,tmax);
   }
-  
-  //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_max - timing_min;}
-  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
-  
+
   //! distortion to the primary ionization
   void setDistortion (PHG4TPCDistortion * d) {distortion = d;}
 
@@ -85,6 +80,10 @@ protected:
   double timing_max;
 
   int num_pixel_layers;
+
+  double tmin_default;
+  double tmax_default;
+  std::map<int, std::pair<double,double> > tmin_max;
   
   //! distortion to the primary ionization if not NULL
   PHG4TPCDistortion * distortion;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -44,6 +44,9 @@ public:
   void   set_timing_window(const int i, const double tmin, const double tmax) {
     tmin_max[i] = std::make_pair(tmin,tmax);
   }
+  void   set_timing_window_defaults(const double tmin, const double tmax) {
+    tmin_default = tmin; tmax_default = tmax;
+  }
 
   //! distortion to the primary ionization
   void setDistortion (PHG4TPCDistortion * d) {distortion = d;}

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -38,6 +38,17 @@ public:
 
   void setDiffusion( double diff ){diffusion = diff;}
   void setElectronsPerKeV( double epk ){elec_per_kev = epk;}
+
+  double get_timing_window_min() {return timing_min;}
+  double get_timing_window_max() {return timing_max;}
+  void set_timing_window(const double tmin, const double tmax) {
+    timing_min = tmin; timing_max = tmax;
+  }
+  
+  //! get timing window size in ns.
+  double get_timing_window_size() const {return timing_max - timing_min;}
+  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
   
 protected:
 //   void set_size(const int i, const double sizeA, const double sizeB, const int what);
@@ -67,7 +78,9 @@ protected:
 
   double diffusion;
   double elec_per_kev;
-  
+
+  double timing_min;
+  double timing_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -76,9 +76,6 @@ protected:
   double diffusion;
   double elec_per_kev;
 
-  double timing_min;
-  double timing_max;
-
   int num_pixel_layers;
 
   double tmin_default;

--- a/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.cc
@@ -24,8 +24,9 @@ PHG4ForwardCalCellReco::PHG4ForwardCalCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new(name.c_str())),
   chkenergyconservation(0),
-  timing_min(0.0),
-  timing_max(numeric_limits<double>::max())
+  tmin_default(0.0),  // ns
+  tmax_default(60.0), // ns
+  tmin_max()
 {
   memset(nbins, 0, sizeof(nbins));  
 }
@@ -66,7 +67,7 @@ int PHG4ForwardCalCellReco::InitRun(PHCompositeNode *topNode)
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str() , "PHObject");
       DetNode->addNode(newNode);
     }
-
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -97,8 +98,8 @@ PHG4ForwardCalCellReco::process_event(PHCompositeNode *topNode)
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
 	{
 	  // checking ADC timing integration window cut
-	  if (hiter->second->get_t(0)>timing_max) continue;
-	  if (hiter->second->get_t(1)<timing_min) continue;
+	  if (hiter->second->get_t(0)>tmax_default) continue;
+	  if (hiter->second->get_t(1)<tmin_default) continue;
 
           // only hits that deposited energy (or geantinos)
           if (hiter->second->get_edep()<=0)

--- a/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.cc
@@ -23,7 +23,9 @@ using namespace std;
 PHG4ForwardCalCellReco::PHG4ForwardCalCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new(name.c_str())),
-  chkenergyconservation(0), timing_window_size(numeric_limits<double>::max())
+  chkenergyconservation(0),
+  timing_min(0.0),
+  timing_max(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));  
 }
@@ -94,9 +96,9 @@ PHG4ForwardCalCellReco::process_event(PHCompositeNode *topNode)
       PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits(*layer);
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
 	{
-          // checking ADC timing integration window cut
-          if (hiter->second->get_t(0)>timing_window_size)
-            continue;
+	  // checking ADC timing integration window cut
+	  if (hiter->second->get_t(0)>timing_max) continue;
+	  if (hiter->second->get_t(1)<timing_min) continue;
 
           // only hits that deposited energy (or geantinos)
           if (hiter->second->get_edep()<=0)

--- a/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.h
@@ -30,16 +30,14 @@ class PHG4ForwardCalCellReco : public SubsysReco
   void Detector(const std::string &d) {detector = d;}
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
-  double get_timing_window_min() {return timing_min;}
-  double get_timing_window_max() {return timing_max;}
-  void set_timing_window(const double tmin, const double tmax) {
-    timing_min = tmin; timing_max = tmax;
+  double get_timing_window_min(const int i) {return tmin_default;}
+  double get_timing_window_max(const int i) {return tmax_default;}
+  void   set_timing_window(const int i, const double tmin, const double tmax) {
+    tmin_default = tmin; tmax_default = tmax;
   }
-  
-  //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_max - timing_min;}
-  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
+  void   set_timing_window_defaults(const double tmin, const double tmax) {
+    tmin_default = tmin; tmax_default = tmax;
+  }
 
  protected:
   int CheckEnergy(PHCompositeNode *topNode);
@@ -52,8 +50,9 @@ class PHG4ForwardCalCellReco : public SubsysReco
   std::map<unsigned int, PHG4CylinderCell *> celllist;
 
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_min;
-  double timing_max;
+  double tmin_default;
+  double tmax_default;
+  std::map<int, std::pair<double,double> > tmin_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.h
@@ -30,10 +30,16 @@ class PHG4ForwardCalCellReco : public SubsysReco
   void Detector(const std::string &d) {detector = d;}
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
+  double get_timing_window_min() {return timing_min;}
+  double get_timing_window_max() {return timing_max;}
+  void set_timing_window(const double tmin, const double tmax) {
+    timing_min = tmin; timing_max = tmax;
+  }
+  
   //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_window_size;}
+  double get_timing_window_size() const {return timing_max - timing_min;}
   //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {timing_window_size = s;}
+  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
 
  protected:
   int CheckEnergy(PHCompositeNode *topNode);
@@ -46,8 +52,8 @@ class PHG4ForwardCalCellReco : public SubsysReco
   std::map<unsigned int, PHG4CylinderCell *> celllist;
 
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_window_size;
-
+  double timing_min;
+  double timing_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -31,8 +31,9 @@ using namespace std;
 PHG4FullProjSpacalCellReco::PHG4FullProjSpacalCellReco(const string &name) :
     SubsysReco(name), _timer(PHTimeServer::get()->insert_new(name.c_str())), chkenergyconservation(
         0),
-    timing_min(0.0),
-    timing_max(numeric_limits<double>::max())
+    tmin_default(0.0),  // ns
+    tmax_default(60.0), // ns
+    tmin_max()
 {
 }
 
@@ -287,6 +288,7 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
           layerseggeo->identify();
         }
     }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -357,8 +359,8 @@ PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
         {
 	  // checking ADC timing integration window cut
-	  if (hiter->second->get_t(0)>timing_max) continue;
-	  if (hiter->second->get_t(1)<timing_min) continue;
+	  if (hiter->second->get_t(0)>tmax_default) continue;
+	  if (hiter->second->get_t(1)<tmin_default) continue;
 
           // hit loop
           int scint_id = hiter->second->get_scint_id();

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -30,7 +30,9 @@ using namespace std;
 
 PHG4FullProjSpacalCellReco::PHG4FullProjSpacalCellReco(const string &name) :
     SubsysReco(name), _timer(PHTimeServer::get()->insert_new(name.c_str())), chkenergyconservation(
-        0), timing_window_size(numeric_limits<double>::max())
+        0),
+    timing_min(0.0),
+    timing_max(numeric_limits<double>::max())
 {
 }
 
@@ -354,9 +356,9 @@ PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
 
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
         {
-          // checking ADC timing integration window cut
-          if (hiter->second->get_t(0) > timing_window_size)
-            continue;
+	  // checking ADC timing integration window cut
+	  if (hiter->second->get_t(0)>timing_max) continue;
+	  if (hiter->second->get_t(1)<timing_min) continue;
 
           // hit loop
           int scint_id = hiter->second->get_scint_id();

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
@@ -31,21 +31,18 @@ class PHG4FullProjSpacalCellReco : public SubsysReco
 
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
-  double get_timing_window_min() {return timing_min;}
-  double get_timing_window_max() {return timing_max;}
-  void set_timing_window(const double tmin, const double tmax) {
-    timing_min = tmin; timing_max = tmax;
+  double get_timing_window_min(const int i) {return tmin_default;}
+  double get_timing_window_max(const int i) {return tmax_default;}
+  void   set_timing_window(const int i, const double tmin, const double tmax) {
+    tmin_default = tmin; tmax_default = tmax;
+  }
+  void   set_timing_window_defaults(const double tmin, const double tmax) {
+    tmin_default = tmin; tmax_default = tmax;
   }
   
-  //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_max - timing_min;}
-  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
-
  protected:
 
   int CheckEnergy(PHCompositeNode *topNode);
-
 
   std::string detector;
   std::string hitnodename;
@@ -58,9 +55,9 @@ class PHG4FullProjSpacalCellReco : public SubsysReco
   std::map<unsigned int, PHG4CylinderCell *> celllist;
 
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_min;
-  double timing_max;
-
+  double tmin_default;
+  double tmax_default;
+  std::map<int, std::pair<double,double> > tmin_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
@@ -31,10 +31,16 @@ class PHG4FullProjSpacalCellReco : public SubsysReco
 
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
+  double get_timing_window_min() {return timing_min;}
+  double get_timing_window_max() {return timing_max;}
+  void set_timing_window(const double tmin, const double tmax) {
+    timing_min = tmin; timing_max = tmax;
+  }
+  
   //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_window_size;}
+  double get_timing_window_size() const {return timing_max - timing_min;}
   //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {timing_window_size = s;}
+  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
 
  protected:
 
@@ -52,7 +58,8 @@ class PHG4FullProjSpacalCellReco : public SubsysReco
   std::map<unsigned int, PHG4CylinderCell *> celllist;
 
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_window_size;
+  double timing_min;
+  double timing_max;
 
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -30,7 +30,9 @@ PHG4HcalCellReco::PHG4HcalCellReco(const string &name) :
   _timer(PHTimeServer::get()->insert_new(name.c_str())),
   nslatscombined(1),
   netabins(24), // that is our default
-  chkenergyconservation(0), timing_window_size(numeric_limits<double>::max())
+  chkenergyconservation(0),
+  timing_min(0.0),
+  timing_max(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));  
 }
@@ -179,9 +181,9 @@ PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
       int nslatbins = geo->get_phibins();
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
 	{
-          // checking ADC timing integration window cut
-          if (hiter->second->get_t(0)>timing_window_size)
-            continue;
+	  // checking ADC timing integration window cut
+	  if (hiter->second->get_t(0)>timing_max) continue;
+	  if (hiter->second->get_t(1)<timing_min) continue;
 
 	  int slatno = hiter->second->get_scint_id();
 	  int slatbin;

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -31,8 +31,9 @@ PHG4HcalCellReco::PHG4HcalCellReco(const string &name) :
   nslatscombined(1),
   netabins(24), // that is our default
   chkenergyconservation(0),
-  timing_min(0.0),
-  timing_max(numeric_limits<double>::max())
+  tmin_default(0.0),  // ns
+  tmax_default(60.0), // ns
+  tmin_max()
 {
   memset(nbins, 0, sizeof(nbins));  
 }
@@ -143,6 +144,14 @@ int PHG4HcalCellReco::InitRun(PHCompositeNode *topNode)
 	  layerseggeo->identify();
 	}
     }
+
+  for (std::map<int,int>::iterator iter = binning.begin(); 
+       iter != binning.end(); ++iter) {
+    int layer = iter->first;
+    // if the user doesn't set an integration window, set the default
+    tmin_max.insert(std::make_pair(layer,std::make_pair(tmin_default,tmax_default)));    
+  }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -182,8 +191,8 @@ PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
 	{
 	  // checking ADC timing integration window cut
-	  if (hiter->second->get_t(0)>timing_max) continue;
-	  if (hiter->second->get_t(1)<timing_min) continue;
+	  if (hiter->second->get_t(0)>tmin_max[*layer].second) continue;
+	  if (hiter->second->get_t(1)<tmin_max[*layer].first) continue;
 
 	  int slatno = hiter->second->get_scint_id();
 	  int slatbin;

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
@@ -32,17 +32,15 @@ class PHG4HcalCellReco : public SubsysReco
   void checkenergy(const int i=1) {chkenergyconservation = i;}
   void set_etabins(const int nbins=24) {netabins = nbins;}
 
-  double get_timing_window_min() {return timing_min;}
-  double get_timing_window_max() {return timing_max;}
-  void set_timing_window(const double tmin, const double tmax) {
-    timing_min = tmin; timing_max = tmax;
+  double get_timing_window_min(const int i) {return tmin_max[i].first;}
+  double get_timing_window_max(const int i) {return tmin_max[i].second;}
+  void   set_timing_window(const int i, const double tmin, const double tmax) {
+    tmin_max[i] = std::make_pair(tmin,tmax);
+  }
+  void   set_timing_window_defaults(const double tmin, const double tmax) {
+    tmin_default = tmin; tmax_default = tmax;
   }
   
-  //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_max - timing_min;}
-  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
-
  protected:
   void set_size(const int i, const double sizeA, const int sizeB, const int what);
   int CheckEnergy(PHCompositeNode *topNode);
@@ -66,10 +64,9 @@ class PHG4HcalCellReco : public SubsysReco
   int chkenergyconservation;
   std::map<unsigned int, PHG4CylinderCell *> celllist;
 
-  //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_min;
-  double timing_max;
-
+  double tmin_default;
+  double tmax_default;
+  std::map<int, std::pair<double,double> > tmin_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
@@ -32,10 +32,16 @@ class PHG4HcalCellReco : public SubsysReco
   void checkenergy(const int i=1) {chkenergyconservation = i;}
   void set_etabins(const int nbins=24) {netabins = nbins;}
 
+  double get_timing_window_min() {return timing_min;}
+  double get_timing_window_max() {return timing_max;}
+  void set_timing_window(const double tmin, const double tmax) {
+    timing_min = tmin; timing_max = tmax;
+  }
+  
   //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_window_size;}
+  double get_timing_window_size() const {return timing_max - timing_min;}
   //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {timing_window_size = s;}
+  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
 
  protected:
   void set_size(const int i, const double sizeA, const int sizeB, const int what);
@@ -61,7 +67,8 @@ class PHG4HcalCellReco : public SubsysReco
   std::map<unsigned int, PHG4CylinderCell *> celllist;
 
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_window_size;
+  double timing_min;
+  double timing_max;
 
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2HcalCellReco.cc
@@ -30,7 +30,9 @@ PHG4Prototype2HcalCellReco::PHG4Prototype2HcalCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new(name.c_str())),
   nslatscombined(1),
-  chkenergyconservation(0), timing_window_size(numeric_limits<double>::max())
+  chkenergyconservation(0),
+  timing_min(0.0),
+  timing_max(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));
   memset(slatarray, 0, sizeof(slatarray));
@@ -102,10 +104,9 @@ PHG4Prototype2HcalCellReco::process_event(PHCompositeNode *topNode)
       PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits(*layer);
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
 	{
-	  if (hiter->second->get_t(0)>timing_window_size)
-	    {
-	      continue;
-	    }
+	  if (hiter->second->get_t(0)>timing_max) continue;
+	  if (hiter->second->get_t(1)<timing_min) continue;
+	  
 	  short icolumn = hiter->second->get_scint_id();
 	  short irow = hiter->second->get_row();
 	  if ( irow >= ROWDIM || irow < 0)

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2HcalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2HcalCellReco.h
@@ -30,10 +30,16 @@ class PHG4Prototype2HcalCellReco : public SubsysReco
   void Detector(const std::string &d) {detector = d;}
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
+  double get_timing_window_min() {return timing_min;}
+  double get_timing_window_max() {return timing_max;}
+  void set_timing_window(const double tmin, const double tmax) {
+    timing_min = tmin; timing_max = tmax;
+  }
+
   //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_window_size;}
+  double get_timing_window_size() const {return timing_max - timing_min;}
   //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {timing_window_size = s;}
+  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
 
  protected:
   int CheckEnergy(PHCompositeNode *topNode);
@@ -53,7 +59,8 @@ class PHG4Prototype2HcalCellReco : public SubsysReco
   int chkenergyconservation;
 
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_window_size;
+  double timing_min;
+  double timing_max;
 
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2HcalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2HcalCellReco.h
@@ -30,17 +30,15 @@ class PHG4Prototype2HcalCellReco : public SubsysReco
   void Detector(const std::string &d) {detector = d;}
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
-  double get_timing_window_min() {return timing_min;}
-  double get_timing_window_max() {return timing_max;}
-  void set_timing_window(const double tmin, const double tmax) {
-    timing_min = tmin; timing_max = tmax;
+  double get_timing_window_min(const int i) {return tmin_max[i].first;}
+  double get_timing_window_max(const int i) {return tmin_max[i].second;}
+  void   set_timing_window(const int i, const double tmin, const double tmax) {
+    tmin_max[i] = std::make_pair(tmin,tmax);
   }
-
-  //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_max - timing_min;}
-  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
-
+  void   set_timing_window_defaults(const double tmin, const double tmax) {
+    tmin_default = tmin; tmax_default = tmax;
+  }
+  
  protected:
   int CheckEnergy(PHCompositeNode *topNode);
   std::map<int, int>  binning;
@@ -58,10 +56,9 @@ class PHG4Prototype2HcalCellReco : public SubsysReco
   int nslatscombined;
   int chkenergyconservation;
 
-  //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_min;
-  double timing_max;
-
+  double tmin_default;
+  double tmax_default;
+  std::map<int, std::pair<double,double> > tmin_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -29,8 +29,9 @@ PHG4SiliconTrackerCellReco::PHG4SiliconTrackerCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new(name.c_str())),
   chkenergyconservation(0),
-  timing_min(0.0),
-  timing_max(numeric_limits<double>::max())
+  tmin_default(0.0),  // ns
+  tmax_default(60.0), // ns
+  tmin_max()
 {
   memset(nbins, 0, sizeof(nbins));
   Detector(name);
@@ -147,6 +148,13 @@ int PHG4SiliconTrackerCellReco::InitRun(PHCompositeNode *topNode)
     }
   */
 
+  for (std::map<int,int>::iterator iter = binning.begin(); 
+       iter != binning.end(); ++iter) {
+    int layer = iter->first;
+    // if the user doesn't set an integration window, set the default
+    tmin_max.insert(std::make_pair(layer,std::make_pair(tmin_default,tmax_default)));    
+  }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -195,8 +203,9 @@ PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
 
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
 	{
-	  if (hiter->second->get_t(0)>timing_max) continue;
-	  if (hiter->second->get_t(1)<timing_min) continue;
+	  // checking ADC timing integration window cut
+	  if (hiter->second->get_t(0)>tmin_max[*layer].second) continue;
+	  if (hiter->second->get_t(1)<tmin_max[*layer].first) continue;
 	  
 	  int ladder_z_index = hiter->second->get_ladder_z_index();
 	  int ladder_phi_index = hiter->second->get_ladder_phi_index();

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -28,7 +28,9 @@ using namespace std;
 PHG4SiliconTrackerCellReco::PHG4SiliconTrackerCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new(name.c_str())),
-  chkenergyconservation(0)
+  chkenergyconservation(0),
+  timing_min(0.0),
+  timing_max(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));
   Detector(name);
@@ -193,6 +195,9 @@ PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
 
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
 	{
+	  if (hiter->second->get_t(0)>timing_max) continue;
+	  if (hiter->second->get_t(1)<timing_min) continue;
+	  
 	  int ladder_z_index = hiter->second->get_ladder_z_index();
 	  int ladder_phi_index = hiter->second->get_ladder_phi_index();
 	  int strip_z_index = hiter->second->get_strip_z_index();

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
@@ -30,16 +30,14 @@ class PHG4SiliconTrackerCellReco : public SubsysReco
   void Detector(const std::string &d) {detector = d;}
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
-  double get_timing_window_min() {return timing_min;}
-  double get_timing_window_max() {return timing_max;}
-  void set_timing_window(const double tmin, const double tmax) {
-    timing_min = tmin; timing_max = tmax;
+  double get_timing_window_min(const int i) {return tmin_max[i].first;}
+  double get_timing_window_max(const int i) {return tmin_max[i].second;}
+  void   set_timing_window(const int i, const double tmin, const double tmax) {
+    tmin_max[i] = std::make_pair(tmin,tmax);
   }
-  
-  //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_max - timing_min;}
-  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
+  void   set_timing_window_defaults(const double tmin, const double tmax) {
+    tmin_default = tmin; tmax_default = tmax;
+  }
   
  protected:
   //void set_size(const int i, const double sizeA, const int sizeB, const int what);
@@ -65,8 +63,9 @@ class PHG4SiliconTrackerCellReco : public SubsysReco
   //std::map<unsigned int, PHG4CylinderCell *> celllist;
   std::map<std::string, PHG4CylinderCell*> celllist;  // This map holds the hit cells
 
-  double timing_min;
-  double timing_max;
+  double tmin_default;
+  double tmax_default;
+  std::map<int, std::pair<double,double> > tmin_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
@@ -30,6 +30,17 @@ class PHG4SiliconTrackerCellReco : public SubsysReco
   void Detector(const std::string &d) {detector = d;}
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
+  double get_timing_window_min() {return timing_min;}
+  double get_timing_window_max() {return timing_max;}
+  void set_timing_window(const double tmin, const double tmax) {
+    timing_min = tmin; timing_max = tmax;
+  }
+  
+  //! get timing window size in ns.
+  double get_timing_window_size() const {return timing_max - timing_min;}
+  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
+  
  protected:
   //void set_size(const int i, const double sizeA, const int sizeB, const int what);
   int CheckEnergy(PHCompositeNode *topNode);
@@ -53,6 +64,9 @@ class PHG4SiliconTrackerCellReco : public SubsysReco
   int layer;
   //std::map<unsigned int, PHG4CylinderCell *> celllist;
   std::map<std::string, PHG4CylinderCell*> celllist;  // This map holds the hit cells
+
+  double timing_min;
+  double timing_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
@@ -36,8 +36,9 @@ PHG4SlatCellReco::PHG4SlatCellReco(const string &name) :
   _timer(PHTimeServer::get()->insert_new(name.c_str())),
   nslatscombined(1),
   chkenergyconservation(0),
-  timing_min(0.0),
-  timing_max(numeric_limits<double>::max())
+  tmin_default(0.0),  // ns
+  tmax_default(60.0), // ns
+  tmin_max()
 {
   memset(nbins, 0, sizeof(nbins));
   memset(cellptarray, 0, sizeof(cellptarray));
@@ -186,6 +187,14 @@ int PHG4SlatCellReco::InitRun(PHCompositeNode *topNode)
 	  layerseggeo->identify();
 	}
     }
+
+  for (std::map<int,int>::iterator iter = binning.begin(); 
+       iter != binning.end(); ++iter) {
+    int layer = iter->first;
+    // if the user doesn't set an integration window, set the default
+    tmin_max.insert(std::make_pair(layer,std::make_pair(tmin_default,tmax_default)));    
+  }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -246,8 +255,8 @@ PHG4SlatCellReco::process_event(PHCompositeNode *topNode)
           for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
             {
               // checking ADC timing integration window cut
-	      if (hiter->second->get_t(0)>timing_max) continue;
-	      if (hiter->second->get_t(1)<timing_min) continue;
+              if (hiter->second->get_t(0)>tmin_max[*layer].second) continue;
+	      if (hiter->second->get_t(1)<tmin_max[*layer].first) continue;
 
               double etaphi[2];
               int slatbin;

--- a/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SlatCellReco.cc
@@ -35,7 +35,9 @@ PHG4SlatCellReco::PHG4SlatCellReco(const string &name) :
   SubsysReco(name),
   _timer(PHTimeServer::get()->insert_new(name.c_str())),
   nslatscombined(1),
-  chkenergyconservation(0), timing_window_size(numeric_limits<double>::max())
+  chkenergyconservation(0),
+  timing_min(0.0),
+  timing_max(numeric_limits<double>::max())
 {
   memset(nbins, 0, sizeof(nbins));
   memset(cellptarray, 0, sizeof(cellptarray));
@@ -244,8 +246,8 @@ PHG4SlatCellReco::process_event(PHCompositeNode *topNode)
           for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
             {
               // checking ADC timing integration window cut
-              if (hiter->second->get_t(0)>timing_window_size)
-                continue;
+	      if (hiter->second->get_t(0)>timing_max) continue;
+	      if (hiter->second->get_t(1)<timing_min) continue;
 
               double etaphi[2];
               int slatbin;

--- a/simulation/g4simulation/g4detectors/PHG4SlatCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SlatCellReco.h
@@ -33,11 +33,17 @@ class PHG4SlatCellReco : public SubsysReco
   void etasize_nslat(const int i, const double deltaeta, const int nslat);
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
-  //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_window_size;}
-  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {timing_window_size = s;}
+  double get_timing_window_min() {return timing_min;}
+  double get_timing_window_max() {return timing_max;}
+  void set_timing_window(const double tmin, const double tmax) {
+    timing_min = tmin; timing_max = tmax;
+  }
 
+  //! get timing window size in ns.
+  double get_timing_window_size() const {return timing_max - timing_min;}
+  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
+  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
+  
  protected:
   void set_size(const int i, const double sizeA, const int sizeB, const int what);
   int CheckEnergy(PHCompositeNode *topNode);
@@ -61,7 +67,8 @@ class PHG4SlatCellReco : public SubsysReco
   int chkenergyconservation;
 
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_window_size;
+  double timing_min;
+  double timing_max;
 
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4SlatCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SlatCellReco.h
@@ -33,17 +33,15 @@ class PHG4SlatCellReco : public SubsysReco
   void etasize_nslat(const int i, const double deltaeta, const int nslat);
   void checkenergy(const int i=1) {chkenergyconservation = i;}
 
-  double get_timing_window_min() {return timing_min;}
-  double get_timing_window_max() {return timing_max;}
-  void set_timing_window(const double tmin, const double tmax) {
-    timing_min = tmin; timing_max = tmax;
+  double get_timing_window_min(const int i) {return tmin_max[i].first;}
+  double get_timing_window_max(const int i) {return tmin_max[i].second;}
+  void   set_timing_window(const int i, const double tmin, const double tmax) {
+    tmin_max[i] = std::make_pair(tmin,tmax);
+  }
+  void   set_timing_window_defaults(const double tmin, const double tmax) {
+    tmin_default = tmin; tmax_default = tmax;
   }
 
-  //! get timing window size in ns.
-  double get_timing_window_size() const {return timing_max - timing_min;}
-  //! set timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  void set_timing_window_size(const double s) {set_timing_window(0.0,s);}
-  
  protected:
   void set_size(const int i, const double sizeA, const int sizeB, const int what);
   int CheckEnergy(PHCompositeNode *topNode);
@@ -66,9 +64,9 @@ class PHG4SlatCellReco : public SubsysReco
   int nslatscombined;
   int chkenergyconservation;
 
-  //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
-  double timing_min;
-  double timing_max;
+  double tmin_default;
+  double tmax_default;
+  std::map<int, std::pair<double,double> > tmin_max;
 
 };
 

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -68,16 +68,16 @@ int SvtxEvaluator::Init(PHCompositeNode *topNode) {
 
   if (_do_vertex_eval) _ntp_vertex = new TNtuple("ntp_vertex","vertex => max truth",
 						 "event:vx:vy:vz:ntracks:"
-						 "gvx:gvy:gvz:gntracks:"
+						 "gvx:gvy:gvz:gvt:gntracks:"
 						 "nfromtruth");
 
   if (_do_gpoint_eval) _ntp_gpoint = new TNtuple("ntp_gpoint","g4point => best vertex",
-						 "event:gvx:gvy:gvz:gntracks:"
+						 "event:gvx:gvy:gvz:gvt:gntracks:"
 						 "vx:vy:vz:ntracks:"
 						 "nfromtruth");
   
   if (_do_g4hit_eval) _ntp_g4hit = new TNtuple("ntp_g4hit","g4hit => best svtxcluster",
-					       "event:g4hitID:gx:gy:gz:gedep:"
+					       "event:g4hitID:gx:gy:gz:gt:gedep:"
 					       "glayer:gtrackID:gflavor:"
 					       "gpx:gpy:gpz:gvx:gvy:gvz:"
 					       "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
@@ -88,7 +88,7 @@ int SvtxEvaluator::Init(PHCompositeNode *topNode) {
   if (_do_hit_eval) _ntp_hit = new TNtuple("ntp_hit","svtxhit => max truth",
 					   "event:hitID:e:adc:layer:"
 					   "cellID:ecell:"
-					   "g4hitID:gedep:gx:gy:gz:"
+					   "g4hitID:gedep:gx:gy:gz:gt:"
 					   "gtrackID:gflavor:"
 					   "gpx:gpy:gpz:gvx:gvy:gvz:"
 					   "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
@@ -98,7 +98,7 @@ int SvtxEvaluator::Init(PHCompositeNode *topNode) {
 						   "event:hitID:x:y:z:ex:ey:ez:ephi:"
 						   "e:adc:layer:size:phisize:"
 						   "zsize:trackID:g4hitID:gx:"
-						   "gy:gz:gtrackID:gflavor:"
+						   "gy:gz:gt:gtrackID:gflavor:"
 						   "gpx:gpy:gpz:gvx:gvy:gvz:"
 						   "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
 						   "gembed:gprimary:efromtruth");
@@ -580,6 +580,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gvx        = NAN;
 	float gvy        = NAN;
 	float gvz        = NAN;
+	float gvt        = NAN;
 	float gntracks   = truthinfo->GetNumPrimaryVertexParticles();
 	float nfromtruth = NAN;
 	
@@ -587,11 +588,12 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  gvx        = point->get_x();
 	  gvy        = point->get_y();
 	  gvz        = point->get_z();
+	  gvt        = point->get_t();
 	  gntracks   = truthinfo->GetNumPrimaryVertexParticles();
 	  nfromtruth = vertexeval->get_ntracks_contribution(vertex,point);
 	}
 	  
-	float vertex_data[10] = {(float) _ievent,
+	float vertex_data[11] = {(float) _ievent,
 				 vx,
 				 vy,
 				 vz,
@@ -599,6 +601,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				 gvx,
 				 gvy,
 				 gvz,
+				 gvt,
 				 gntracks,
 				 nfromtruth
 	};
@@ -628,6 +631,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gvx        = point->get_x();
 	float gvy        = point->get_y();
 	float gvz        = point->get_z();
+	float gvt        = point->get_t();
 	float gntracks   = truthinfo->GetNumPrimaryVertexParticles();
 	float vx         = NAN;
 	float vy         = NAN;
@@ -643,10 +647,11 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  nfromtruth = vertexeval->get_ntracks_contribution(vertex,point);
 	}
 	
-	float gpoint_data[10] = {(float) _ievent,
+	float gpoint_data[11] = {(float) _ievent,
 				 gvx,
 				 gvy,
 				 gvz,
+				 gvt,
 				 gntracks,
 				 vx,
 				 vy,
@@ -677,11 +682,11 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       float gx        = 0.5*(g4hit->get_x(0)+g4hit->get_x(1));
       float gy        = 0.5*(g4hit->get_y(0)+g4hit->get_y(1));
       float gz        = 0.5*(g4hit->get_z(0)+g4hit->get_z(1));
+      float gt        = 0.5*(g4hit->get_t(0)+g4hit->get_t(1));
       float gedep     = g4hit->get_edep();
       float glayer    = g4hit->get_layer();
   
       float gtrackID  = g4hit->get_trkid();
-
 
       float gflavor   = NAN;
       float gpx       = NAN;
@@ -765,11 +770,12 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	}
       }
 
-      float g4hit_data[35] = {(float) _ievent,
+      float g4hit_data[36] = {(float) _ievent,
 			      g4hitID,
 			      gx,
 			      gy,
 			      gz,
+			      gt,
 			      gedep,
 			      glayer,
 			      gtrackID,
@@ -837,6 +843,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gx       = NAN;
 	float gy       = NAN;
 	float gz       = NAN;
+	float gt       = NAN;
 	float gtrackID = NAN;
 	float gflavor  = NAN;
 	float gpx      = NAN;
@@ -862,6 +869,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  gx       = 0.5*(g4hit->get_x(0)+g4hit->get_x(1));
 	  gy       = 0.5*(g4hit->get_y(0)+g4hit->get_y(1));
 	  gz       = 0.5*(g4hit->get_z(0)+g4hit->get_z(1));
+	  gt       = 0.5*(g4hit->get_t(0)+g4hit->get_t(1));
 	  gx       = g4hit->get_x(0);
 	  gy       = g4hit->get_y(0);
 	  gz       = g4hit->get_z(0);
@@ -900,7 +908,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  efromtruth = hiteval->get_energy_contribution(hit,g4particle);
 	}
 
-	float hit_data[32] = {
+	float hit_data[33] = {
 	  event,
 	  hitID,
 	  e,
@@ -913,6 +921,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  gx,
 	  gy,
 	  gz,
+	  gt,
 	  gtrackID,
 	  gflavor,
 	  gpx,
@@ -980,6 +989,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gx       = NAN;
 	float gy       = NAN;
 	float gz       = NAN;
+	float gt       = NAN;
 	float gtrackID = NAN;
 	float gflavor  = NAN;
 	float gpx      = NAN;
@@ -1004,6 +1014,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  gx       = 0.5*(g4hit->get_x(0)+g4hit->get_x(1));
 	  gy       = 0.5*(g4hit->get_y(0)+g4hit->get_y(1));
 	  gz       = 0.5*(g4hit->get_z(0)+g4hit->get_z(1));
+	  gt       = 0.5*(g4hit->get_t(0)+g4hit->get_t(1));
 	  gx       = g4hit->get_x(0);
 	  gy       = g4hit->get_y(0);
 	  gz       = g4hit->get_z(0);
@@ -1042,7 +1053,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  efromtruth = clustereval->get_energy_contribution(cluster,g4particle);
 	}
 
-	float cluster_data[37] = {(float) _ievent,
+	float cluster_data[38] = {(float) _ievent,
 				  hitID,
 				  x,
 				  y,
@@ -1062,6 +1073,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				  gx,
 				  gy,
 				  gz,
+				  gt,
 				  gtrackID,
 				  gflavor,
 				  gpx,

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -6,8 +6,8 @@
 
 #include <phhepmc/PHHepMCGenEvent.h>
 
-#include <phool/getClass.h>
 #include <phool/PHRandomSeed.h>
+#include <phool/getClass.h>
 #include <phool/recoConsts.h>
 
 #include <HepMC/GenEvent.h>
@@ -23,226 +23,214 @@ using namespace std;
 // All length Units are in cm, no conversion to G4 internal units since
 // this is filled into our objects (PHG4VtxPoint and PHG4Particle)
 
-const double mm_over_c_to_sec = 0.1/GSL_CONST_CGS_SPEED_OF_LIGHT; // pythia vtx time seems to be in mm/c
+// pythia vtx time seems to be in mm/c
+const double mm_over_c_to_sec = 0.1 / GSL_CONST_CGS_SPEED_OF_LIGHT;
+// pythia vtx time seems to be in mm/c
+const double mm_over_c_to_nanosecond = mm_over_c_to_sec * 1e9;
 /// \class  IsStateFinal
 
 /// this predicate returns true if the input has no decay vertex
 class IsStateFinal {
-public:
-    /// returns true if the GenParticle does not decay
-    bool operator()( const HepMC::GenParticle* p ) { 
-	if ( !p->end_vertex() && p->status()==1 ) return 1;
-	return 0;
-    }
+ public:
+  /// returns true if the GenParticle does not decay
+  bool operator()(const HepMC::GenParticle *p) {
+    if (!p->end_vertex() && p->status() == 1) return 1;
+    return 0;
+  }
 };
 
 static IsStateFinal isfinal;
 
-HepMCNodeReader::HepMCNodeReader(const std::string &name):
-  SubsysReco(name),
-  _embed_flag(0),
-  vertex_pos_x(0),
-  vertex_pos_y(0),
-  vertex_pos_z(0),
-  width_vx(0),
-  width_vy(0),
-  width_vz(0)
-{
+HepMCNodeReader::HepMCNodeReader(const std::string &name)
+    : SubsysReco(name),
+      _embed_flag(0),
+      vertex_pos_x(0.0),
+      vertex_pos_y(0.0),
+      vertex_pos_z(0.0),
+      vertex_t0(0.0),
+      width_vx(0.0),
+      width_vy(0.0),
+      width_vz(0.0) {
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
-  unsigned int seed = PHRandomSeed(); // fixed seed is handled in this funtcion
-  gsl_rng_set(RandomGenerator,seed);
+  unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
+  gsl_rng_set(RandomGenerator, seed);
   return;
 }
 
-HepMCNodeReader::~HepMCNodeReader()
-{
-  gsl_rng_free (RandomGenerator);
-}
+HepMCNodeReader::~HepMCNodeReader() { gsl_rng_free(RandomGenerator); }
 
-int
-HepMCNodeReader::Init(PHCompositeNode *topNode)
-{
-  PHG4InEvent *ineve = findNode::getClass<PHG4InEvent>(topNode,"PHG4INEVENT");
-  if (!ineve)
-    {
-      PHNodeIterator iter( topNode );
-      PHCompositeNode *dstNode;
-      dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+int HepMCNodeReader::Init(PHCompositeNode *topNode) {
+  
+  PHG4InEvent *ineve = findNode::getClass<PHG4InEvent>(topNode, "PHG4INEVENT");
+  if (!ineve) {
+    PHNodeIterator iter(topNode);
+    PHCompositeNode *dstNode;
+    dstNode = dynamic_cast<PHCompositeNode *>(
+        iter.findFirst("PHCompositeNode", "DST"));
 
-      ineve = new PHG4InEvent();
-      PHDataNode<PHObject> *newNode = new PHDataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
-      dstNode->addNode(newNode);
-    }
+    ineve = new PHG4InEvent();
+    PHDataNode<PHObject> *newNode =
+        new PHDataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
+    dstNode->addNode(newNode);
+  }
   return 0;
 }
 
-int
-HepMCNodeReader::process_event(PHCompositeNode *topNode)
-{
+int HepMCNodeReader::process_event(PHCompositeNode *topNode) {
+
   recoConsts *rc = recoConsts::instance();
+
   float worldsizex = rc->get_FloatFlag("WorldSizex");
   float worldsizey = rc->get_FloatFlag("WorldSizey");
   float worldsizez = rc->get_FloatFlag("WorldSizez");
   string worldshape = rc->get_CharFlag("WorldShape");
-  enum {ShapeG4Tubs = 0, ShapeG4Box = 1};
+
+  enum { ShapeG4Tubs = 0, ShapeG4Box = 1 };
+
   int ishape;
-  if (worldshape == "G4Tubs")
-    {
-      ishape = ShapeG4Tubs;
-    }
-  else if (worldshape == "G4Box")
-    {
-      ishape = ShapeG4Box;
-    }
-  else
-    {
-      cout << PHWHERE << " unknown world shape " << worldshape << endl;
-      exit(1);
-    }
-  double xshift = vertex_pos_x; + smeargauss(width_vx);
-  double yshift = vertex_pos_y; + smeargauss(width_vy);
-  double zshift = vertex_pos_z; + smeargauss(width_vz);
+  if (worldshape == "G4Tubs") {
+    ishape = ShapeG4Tubs;
+  } else if (worldshape == "G4Box") {
+    ishape = ShapeG4Box;
+  } else {
+    cout << PHWHERE << " unknown world shape " << worldshape << endl;
+    exit(1);
+  }
+  
+  double xshift = vertex_pos_x;
+  double yshift = vertex_pos_y;
+  double zshift = vertex_pos_z;
 
   if (width_vx > 0.0) xshift += smeargauss(width_vx);
   else                xshift += smearflat(width_vx);
 
   if (width_vy > 0.0) yshift += smeargauss(width_vy);
   else                yshift += smearflat(width_vy);
-  
+
   if (width_vz > 0.0) zshift += smeargauss(width_vz);
   else                zshift += smearflat(width_vz);
-  
-  PHHepMCGenEvent *genevt = findNode::getClass<PHHepMCGenEvent>(topNode,"PHHepMCGenEvent");
-  
+
+  PHHepMCGenEvent *genevt =
+    findNode::getClass<PHHepMCGenEvent>(topNode, "PHHepMCGenEvent");
+
   HepMC::GenEvent *evt = genevt->getEvent();
-  if (!evt)
-    {
-      cout << PHWHERE << " no evt pointer under HEPMC Node found" << endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
-  PHG4InEvent *ineve = findNode::getClass<PHG4InEvent>(topNode,"PHG4INEVENT");
-  if (!ineve)
-    {
-      cout << PHWHERE << "no PHG4INEVENT node" << endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
-  std::list<HepMC::GenParticle*> finalstateparticles;
-  std::list<HepMC::GenParticle*>::const_iterator  fiter;
-// units in G4 interface are GeV and CM
-  const double mom_factor = HepMC::Units::conversion_factor( evt->momentum_unit(), (HepMC::Units::MomentumUnit) (genevt->get_momentumunit())); 
-  const double length_factor = HepMC::Units::conversion_factor( evt->length_unit(), (HepMC::Units::LengthUnit) (genevt->get_lengthunit()) );
-  for ( HepMC::GenEvent::vertex_iterator v = evt->vertices_begin();
-	v != evt->vertices_end(); ++v )
-    {
-      finalstateparticles.clear();
-      for (HepMC::GenVertex::particle_iterator p = (*v)->particles_begin(HepMC::children); p != (*v)->particles_end(HepMC::children); ++p)
-	{
-	  if (isfinal(*p))
-	    {
-	      finalstateparticles.push_back(*p);
-	    }
-	}
-      if (!finalstateparticles.empty())
-	{
-	  double xpos = (*v)->position().x()*length_factor + xshift;
-	  double ypos = (*v)->position().y()*length_factor + yshift;
-	  double zpos = (*v)->position().z()*length_factor + zshift;
- 	  if (verbosity > 1)
-	    {
-	      cout << "Vertex : " << endl;
-	      (*v)->print();
-	      cout << "id: " << (*v)->barcode() << endl;
-	      cout << "x: " << xpos << endl;
-	      cout << "y: " << ypos << endl;
-	      cout << "z: " << zpos << endl;
-	      cout << "t: " << (*v)->position().t()*mm_over_c_to_sec << endl;
-	      cout << "Particles" << endl;
-	    }
+  if (!evt) {
+    cout << PHWHERE << " no evt pointer under HEPMC Node found" << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  
+  PHG4InEvent *ineve = findNode::getClass<PHG4InEvent>(topNode, "PHG4INEVENT");
+  if (!ineve) {
+    cout << PHWHERE << "no PHG4INEVENT node" << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  
+  std::list<HepMC::GenParticle *> finalstateparticles;
+  std::list<HepMC::GenParticle *>::const_iterator fiter;
 
-      if (ishape == ShapeG4Tubs)
-        {
-          if (sqrt(xpos*xpos + ypos*ypos) > worldsizey / 2 || fabs(zpos) > worldsizez / 2)
-            {
-              cout << "vertex x/y/z" << xpos << "/" << ypos << "/" << zpos
-                   << " outside world volume radius/z (+-) " << worldsizex / 2 << "/"
-                   << worldsizez / 2
-                   << ", dropping it and its particles" << endl;
-              continue;
-            }
-        }
-      else if (ishape == ShapeG4Box)
-        {
-	  if (fabs(xpos) > worldsizex/2 || fabs(ypos) > worldsizey/2 || fabs(zpos) > worldsizez/2)
-	    {
-	      cout << "Vertex x/y/z " << xpos << "/" << ypos << "/" << zpos
-                   << " outside world volume x/y/z (+-) " << worldsizex/2 << "/"
-                   << worldsizey/2 << "/" << worldsizez/2
-                   << ", dropping it and its particles" << endl;
-	      continue;
-	    }
-        }
-      else
-        {
-          cout << PHWHERE << " shape " << ishape << " not implemented. exiting" << endl;
-          exit(1);
-        }
+  // units in G4 interface are GeV and CM
+  const double mom_factor = HepMC::Units::conversion_factor(evt->momentum_unit(),(HepMC::Units::MomentumUnit)(genevt->get_momentumunit()));  
+  const double length_factor = HepMC::Units::conversion_factor(evt->length_unit(), (HepMC::Units::LengthUnit)(genevt->get_lengthunit()));
+  
+  for (HepMC::GenEvent::vertex_iterator v = evt->vertices_begin();
+       v != evt->vertices_end();
+       ++v) {
 
-	  ineve->AddVtxHepMC((*v)->barcode(), xpos, ypos, zpos, (*v)->position().t()*mm_over_c_to_sec);
-	  for (fiter = finalstateparticles.begin(); fiter != finalstateparticles.end(); ++fiter)
-	    {
-	      if (verbosity > 1)
-		{
-		  (*fiter)->print();
-		}
-	      PHG4Particle *particle = new PHG4Particlev1();
-	      particle->set_pid((*fiter)->pdg_id());
-	      particle->set_px((*fiter)->momentum().px()*mom_factor);
-	      particle->set_py((*fiter)->momentum().py()*mom_factor);
-	      particle->set_pz((*fiter)->momentum().pz()*mom_factor);
-	      ineve->AddParticle((*v)->barcode(), particle);
-	      if (_embed_flag != 0) ineve->AddEmbeddedParticle(particle,_embed_flag);
-	    }
-	}
+    finalstateparticles.clear();
+    for (HepMC::GenVertex::particle_iterator p =
+             (*v)->particles_begin(HepMC::children);
+         p != (*v)->particles_end(HepMC::children); ++p) {
+      if (isfinal(*p)) {
+        finalstateparticles.push_back(*p);
+      }
     }
-  if (verbosity > 0)
-    {
-      ineve->identify();
+    
+    if (!finalstateparticles.empty()) {
+      double xpos = (*v)->position().x() * length_factor + xshift;
+      double ypos = (*v)->position().y() * length_factor + yshift;
+      double zpos = (*v)->position().z() * length_factor + zshift;
+      double time = (*v)->position().t() * mm_over_c_to_nanosecond + vertex_t0;
+
+      if (verbosity > 1) {
+        cout << "Vertex : " << endl;
+        (*v)->print();
+        cout << "id: " << (*v)->barcode() << endl;
+        cout << "x: " << xpos << endl;
+        cout << "y: " << ypos << endl;
+        cout << "z: " << zpos << endl;
+        cout << "t: " << time << endl;
+        cout << "Particles" << endl;
+      }
+
+      if (ishape == ShapeG4Tubs) {
+        if (sqrt(xpos * xpos + ypos * ypos) > worldsizey / 2 ||
+            fabs(zpos) > worldsizez / 2) {
+          cout << "vertex x/y/z" << xpos << "/" << ypos << "/" << zpos
+               << " outside world volume radius/z (+-) " << worldsizex / 2
+               << "/" << worldsizez / 2 << ", dropping it and its particles"
+               << endl;
+          continue;
+        }
+      } else if (ishape == ShapeG4Box) {
+        if (fabs(xpos) > worldsizex / 2 || fabs(ypos) > worldsizey / 2 ||
+            fabs(zpos) > worldsizez / 2) {
+          cout << "Vertex x/y/z " << xpos << "/" << ypos << "/" << zpos
+               << " outside world volume x/y/z (+-) " << worldsizex / 2 << "/"
+               << worldsizey / 2 << "/" << worldsizez / 2
+               << ", dropping it and its particles" << endl;
+          continue;
+        }
+      } else {
+        cout << PHWHERE << " shape " << ishape << " not implemented. exiting"
+             << endl;
+        exit(1);
+      }
+
+      ineve->AddVtxHepMC((*v)->barcode(), xpos, ypos, zpos, time);
+
+      for (fiter = finalstateparticles.begin();
+           fiter != finalstateparticles.end();
+	   ++fiter) {
+
+        if (verbosity > 1) (*fiter)->print();
+        
+        PHG4Particle *particle = new PHG4Particlev1();
+        particle->set_pid((*fiter)->pdg_id());
+        particle->set_px((*fiter)->momentum().px() * mom_factor);
+        particle->set_py((*fiter)->momentum().py() * mom_factor);
+        particle->set_pz((*fiter)->momentum().pz() * mom_factor);
+        ineve->AddParticle((*v)->barcode(), particle);
+
+        if (_embed_flag != 0) ineve->AddEmbeddedParticle(particle, _embed_flag);
+      }
     }
+  }
+  
+  if (verbosity > 0) ineve->identify();
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-double
-HepMCNodeReader::smeargauss(const double width)
-{
-  if (width == 0)
-    {
-      return 0;
-    }
-  return gsl_ran_gaussian(RandomGenerator,width);
+double HepMCNodeReader::smeargauss(const double width) {
+  if (width == 0) return 0;
+  return gsl_ran_gaussian(RandomGenerator, width);
 }
 
-double
-HepMCNodeReader::smearflat(const double width)
-{
-  if (width == 0)
-    {
-      return 0;
-    }
-  return 2.0*width*(gsl_rng_uniform_pos(RandomGenerator) - 0.5);
+double HepMCNodeReader::smearflat(const double width) {
+  if (width == 0) return 0;
+  return 2.0 * width * (gsl_rng_uniform_pos(RandomGenerator) - 0.5);
 }
 
-void
-HepMCNodeReader::VertexPosition(const double v_x, const double v_y, const double v_z)
-{
+void HepMCNodeReader::VertexPosition(const double v_x, const double v_y,
+                                     const double v_z) {
   vertex_pos_x = v_x;
   vertex_pos_y = v_y;
   vertex_pos_z = v_z;
   return;
 }
 
-void
-HepMCNodeReader::SmearVertex(const double s_x, const double s_y, const double s_z)
-{
+void HepMCNodeReader::SmearVertex(const double s_x, const double s_y,
+                                  const double s_z) {
   width_vx = s_x;
   width_vy = s_y;
   width_vz = s_z;

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -26,6 +26,7 @@ class HepMCNodeReader : public SubsysReco
 
 
   void SmearVertex(const double s_x, const double s_y, const double s_z);
+  void SetT0(const double t0) {vertex_t0 = t0;}
 
 private:
   double smeargauss(const double width);
@@ -34,6 +35,7 @@ private:
   double vertex_pos_x;
   double vertex_pos_y;
   double vertex_pos_z;
+  double vertex_t0;
   double width_vx;
   double width_vy;
   double width_vz;

--- a/simulation/g4simulation/g4main/PHG4PrimaryGeneratorAction.cc
+++ b/simulation/g4simulation/g4main/PHG4PrimaryGeneratorAction.cc
@@ -36,7 +36,7 @@ PHG4PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       //       (*vtxiter->second).identify();
       // expected units are cm !
       G4ThreeVector position((*vtxiter->second).get_x()*cm, (*vtxiter->second).get_y()*cm, (*vtxiter->second).get_z()*cm );
-      G4PrimaryVertex* vertex = new G4PrimaryVertex(position, (*vtxiter->second).get_t()*s);
+      G4PrimaryVertex* vertex = new G4PrimaryVertex(position, (*vtxiter->second).get_t()*nanosecond);
       pair<multimap<int, PHG4Particle *>::const_iterator, multimap<int, PHG4Particle *>::const_iterator > particlebegin_end = inEvent->GetParticles(vtxiter->first);
       for (particle_iter = particlebegin_end.first; particle_iter != particlebegin_end.second; ++particle_iter)
         {

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
@@ -29,6 +29,7 @@ PHG4SimpleEventGenerator::PHG4SimpleEventGenerator(const string &name):
   _vertex_func_x(Uniform),
   _vertex_func_y(Uniform),
   _vertex_func_z(Uniform),
+  _t0(0.0),
   _vertex_x(0.0),
   _vertex_y(0.0),
   _vertex_z(0.0),
@@ -63,6 +64,11 @@ void PHG4SimpleEventGenerator::add_particles(const std::string &name, const unsi
 
 void PHG4SimpleEventGenerator::add_particles(const int pid, const unsigned int num) {
   _particle_codes.push_back(std::make_pair(pid,num));
+  return;
+}
+
+void PHG4SimpleEventGenerator::set_t0(const double t0) {
+  _t0 = t0;
   return;
 }
 
@@ -220,6 +226,7 @@ int PHG4SimpleEventGenerator::InitRun(PHCompositeNode *topNode) {
     cout << " Eta range = " << _eta_min << " - " << _eta_max << endl;
     cout << " Phi range = " << _phi_min << " - " << _phi_max << endl;
     cout << " pT range = " << _pt_min << " - " << _pt_max << endl;
+    cout << " t0 = " << _t0 << endl;
     cout << "===========================================================================" << endl;
   }
 
@@ -273,9 +280,9 @@ int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
         y *= r;
         z *= r;
 
-	vtxindex = _ineve->AddVtx(vtx_x+x,vtx_y+y,vtx_z+z,0.0);
+	vtxindex = _ineve->AddVtx(vtx_x+x,vtx_y+y,vtx_z+z,_t0);
       } else if ((i==0)&&(j==0)) {
-	vtxindex = _ineve->AddVtx(vtx_x,vtx_y,vtx_z,0.0);
+	vtxindex = _ineve->AddVtx(vtx_x,vtx_y,vtx_z,_t0);
       }
 
       ++trackid;

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.h
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.h
@@ -28,6 +28,9 @@ public:
   //! interface for adding particle by pid
   void add_particles(const int pid, const unsigned int count);
 
+  //! set the starting time for the event
+  void set_t0(const double t0);
+  
   //! range of randomized eta values
   void set_eta_range(const double eta_min, const double eta_max);
 
@@ -66,10 +69,11 @@ private:
   // these need to be stored separately until run time when the names
   // can be translated using the GEANT4 lookup
   std::vector<std::pair<int, unsigned int> > _particle_codes; // <pdgcode, count>
-  std::vector<std::pair<std::string, unsigned int> > _particle_names; // <names, count>
+  std::vector<std::pair<std::string, unsigned int> > _particle_names; // <names, count>  
   FUNCTION _vertex_func_x;
   FUNCTION _vertex_func_y;
   FUNCTION _vertex_func_z;
+  double _t0;
   double _vertex_x;
   double _vertex_y;
   double _vertex_z;


### PR DESCRIPTION
I'd like to merge some initial changes for treating pileup in G4. I've added a new function to the event generators to place additional events backward in time, lower time limits on the cell reco to add a sense of the integration times (defaults unchanged), a patch for a unit convention bug (sec vs nanosec), and some additional evaluator lines for the g4hit and g4point time to see that everything is exercising correctly. 

EDIT: Here is a look at some g4hit pileup from the new branch.

![screen shot 2016-06-09 at 9 46 54 am](https://cloud.githubusercontent.com/assets/12105552/15931949/cbbdb93e-2e27-11e6-956b-8ce56ae6c91c.png)
