### PR TITLE
Ph pythia6 update

### DIFF
--- a/generators/PHPythia6/Makefile.am
+++ b/generators/PHPythia6/Makefile.am
@@ -18,7 +18,11 @@ libPHPythia6_la_LIBADD = \
 
 libPHPythia6_la_SOURCES = \
   PHPythia6.C \
-  PHPythia6_Dict.C
+  PHPythia6_Dict.C \
+  PHPy6GenTrigger.C \
+  PHPy6GenTrigger.h \
+  PHPy6ForwardElectronTrig.C \
+  PHPy6ForwardElectronTrig.h 
 
 BUILT_SOURCES = \
   testexternals.C
@@ -38,6 +42,8 @@ testexternals.C:
 
 PHPythia6_Dict.C: \
   PHPythia6.h \
+  PHPy6GenTrigger.h \
+  PHPy6ForwardElectronTrig.h \
   PHPythia6LinkDef.h
 	rootcint -f $@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
 

--- a/generators/PHPythia6/PHPy6ForwardElectronTrig.C
+++ b/generators/PHPythia6/PHPy6ForwardElectronTrig.C
@@ -1,0 +1,49 @@
+#include <PHPy6GenTrigger.h>
+#include <PHPy6ForwardElectronTrig.h>
+#include "phool/PHCompositeNode.h"
+#include "phool/phool.h"
+#include "phool/getClass.h"
+
+#include <phhepmc/PHHepMCGenEvent.h>
+#include <HepMC/GenEvent.h>
+
+#include <cstdlib>
+#include <iostream>
+using namespace std;
+
+//___________________________________________________________________________
+PHPy6ForwardElectronTrig::PHPy6ForwardElectronTrig(const std::string &name): PHPy6GenTrigger(name) 
+{
+  ntriggered_forward_electron = 0;
+  nconsidered_forward_electron = 0;
+}
+	
+bool PHPy6ForwardElectronTrig::Apply( const HepMC::GenEvent* evt )
+{
+
+  // increment counter
+  ++nconsidered_forward_electron;
+	
+  // Print Out Trigger Information Once, for Posterity
+  static int trig_info_printed = 0;
+  if ( trig_info_printed==0 )
+    {
+      cout << "PyForwardElectronTrig -- triggering on: Electron, 1.0 < |pseudorapidity| < 5.0" << endl;
+      trig_info_printed = 1;
+    }
+
+  // Check the HepMC particle list - 
+  // final state e+/- within 1.0 < eta < 5.0 
+	
+  for ( HepMC::GenEvent::particle_const_iterator p 
+	  = evt->particles_begin(); p != evt->particles_end(); ++p ){
+    if ( (abs((*p)->pdg_id()) == 11) && ((*p)->status()==1) && 
+	 ((*p)->momentum().eta() > 1.0) && ((*p)->momentum().eta() < 5.0) ) {
+      ++ntriggered_forward_electron;
+      return true;
+    }
+  }
+
+  return false;
+  
+}

--- a/generators/PHPythia6/PHPy6ForwardElectronTrig.h
+++ b/generators/PHPythia6/PHPy6ForwardElectronTrig.h
@@ -1,0 +1,33 @@
+#ifndef PHPy6ForwardElectronTrig_h
+#define PHPy6ForwardElectronTrig_h
+
+#include <PHPy6GenTrigger.h>
+#include <HepMC/GenEvent.h>
+
+namespace HepMC
+{
+  class GenEvent;
+};
+
+class PHPy6ForwardElectronTrig: public PHPy6GenTrigger
+{
+  public:
+  
+  //! constructor
+  PHPy6ForwardElectronTrig(const std::string &name = "PHPy6ForwardElectronTrigger");
+  
+  //! destructor 
+  ~PHPy6ForwardElectronTrig( void ){}
+ 
+  #ifndef __CINT__ 
+  bool Apply(const HepMC::GenEvent* evt);
+  #endif
+ 
+  protected:
+	
+  int ntriggered_forward_electron;
+  int nconsidered_forward_electron;
+  
+};
+
+#endif	

--- a/generators/PHPythia6/PHPy6GenTrigger.C
+++ b/generators/PHPythia6/PHPy6GenTrigger.C
@@ -1,0 +1,28 @@
+#include "PHPy6GenTrigger.h"
+
+#include <iterator>
+
+using namespace std;
+
+//__________________________________________________________
+PHPy6GenTrigger::PHPy6GenTrigger(const std::string &name):
+_name(name) {}
+
+//__________________________________________________________
+PHPy6GenTrigger::~PHPy6GenTrigger() {}
+
+std::vector<int> PHPy6GenTrigger::convertToInts(std::string s) {
+  
+  vector<int> theVec;
+  stringstream ss(s);
+  int i;  
+  while (ss >> i) {
+    theVec.push_back(i);
+    if (ss.peek() == ',' ||
+	ss.peek() == ' ' ||
+	ss.peek() == ':' ||
+	ss.peek() == ';') ss.ignore();
+  }
+
+  return theVec;
+}

--- a/generators/PHPythia6/PHPy6GenTrigger.h
+++ b/generators/PHPythia6/PHPy6GenTrigger.h
@@ -1,0 +1,46 @@
+#ifndef __PHPY6GENTRIGGER_H__
+#define __PHPY6GENTRIGGER_H__
+
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <vector>
+
+#include <HepMC/GenEvent.h>
+
+namespace HepMC
+{
+  class GenEvent;
+};
+
+class PHPy6GenTrigger {
+
+ protected:  
+  //! constructor
+  PHPy6GenTrigger(const std::string &name = "PHPy6GenTrigger");
+
+ public:
+  virtual ~PHPy6GenTrigger();
+
+  #ifndef __CINT__
+  virtual bool Apply(const HepMC::GenEvent* evt) {
+    std::cout << "PHPy8GenTrigger::Apply - in virtual function" << std::endl;
+    return false;
+  }
+  #endif
+
+  virtual std::string GetName() { return _name; }
+  
+  std::vector<int> convertToInts(std::string s);
+
+  void Verbosity(int v) { _verbosity = v; }
+
+protected:
+  int _verbosity;  
+  
+private:
+  std::string _name;
+};
+
+#endif	
+

--- a/generators/PHPythia6/PHPythia6.C
+++ b/generators/PHPythia6/PHPythia6.C
@@ -342,8 +342,8 @@ int PHPythia6::process_event(PHCompositeNode *topNode) {
     // add some information to the event
     evt->set_event_number(_eventcount);
 
-    /* @TODO How to find out correct process ID from pythia? */
-    //  evt->set_signal_process_id(20);
+    /* process ID from pythia */
+    evt->set_signal_process_id(pypars.msti[1-1]);
 
     // set number of multi parton interactions
     evt->set_mpi( pypars.msti[31-1] );

--- a/generators/PHPythia6/PHPythia6.C
+++ b/generators/PHPythia6/PHPythia6.C
@@ -1,4 +1,5 @@
 #include "PHPythia6.h"
+#include "PHPy6GenTrigger.h"
 
 #include <phhepmc/PHHepMCGenEvent.h>
 
@@ -45,7 +46,10 @@ PHPythia6::PHPythia6(const std::string &name):
   _configFile("phpythia6.cfg"),
   _phhepmcevt(NULL),
   _save_ascii( false ),
-  _filename_ascii("pythia_hepmc.dat"){
+  _filename_ascii("pythia_hepmc.dat"),
+  _registeredTriggers(),
+  _triggersOR(true),
+  _triggersAND(false){
 
   //RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
 }
@@ -86,6 +90,14 @@ int PHPythia6::End(PHCompositeNode *topNode) {
   //........................................TERMINATION
   // write out some information from Pythia to the screen
   call_pystat( 1 );
+
+  //match pythia printout
+  cout << " |                                                                "
+       << "                                                 | " << endl; 
+  cout << "                         PHPythia6::End - " << _eventcount
+       << " events passed trigger" << endl;
+  cout << " *-------  End PYTHIA Trigger Statistics  ------------------------"
+       << "-------------------------------------------------* " << endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -266,6 +278,15 @@ int PHPythia6::ReadConfig(const string cfg_file) {
 	pydat2.parf[index-1] = value;
 	cout << "parf\t" << index << " " << value << endl;
       }
+    else if ( label == "mdme" )
+    {
+      int idc = 0;          // decay channel
+      line >> idc >> index >> value;
+      
+      // if (ivalue==1/0) turn on/off decay channel idc
+      pydat3.mdme[index-1][idc-1] = value; 
+      cout << "mdme\t" << idc << " " << index << " " << value << endl;
+    }
     else
       {
 	// label was not understood
@@ -281,6 +302,8 @@ int PHPythia6::ReadConfig(const string cfg_file) {
   // Call pythia initialization
   call_pyinit( _frame.c_str(), _proj.c_str(), _targ.c_str(), _roots );
 
+  //call_pylist(12); 
+
   infile.close();
 
   return _nevents;
@@ -294,40 +317,84 @@ int PHPythia6::process_event(PHCompositeNode *topNode) {
 
   if (verbosity > 1) cout << "PHPythia6::process_event - event: " << _eventcount << endl;
 
+  bool passedTrigger = false;
+  std::vector<bool> theTriggerResults;
+  int genCounter = 0;
+
   /* based on HepMC/example_MyPythia.cc
    *........................................HepMC INITIALIZATIONS
    *
    * Instantiate an IO strategy for reading from HEPEVT. */
   HepMC::IO_HEPEVT hepevtio;
+  HepMC::GenEvent* evt; 
 
-  call_pyevnt();      // generate one event with Pythia
-  // pythia pyhepc routine converts common PYJETS in common HEPEVT
-  call_pyhepc( 1 );
-  HepMC::GenEvent* evt = hepevtio.read_next_event();
+  while (!passedTrigger) {
+    ++genCounter;
 
-  // define the units (Pythia uses GeV and mm)
-  evt->use_units(HepMC::Units::GEV, HepMC::Units::MM);
+    call_pyevnt();      // generate one event with Pythia
+    // pythia pyhepc routine converts common PYJETS in common HEPEVT
+    call_pyhepc( 1 );
+    evt = hepevtio.read_next_event();
 
-  // add some information to the event
-  evt->set_event_number(_eventcount);
+    // define the units (Pythia uses GeV and mm)
+    evt->use_units(HepMC::Units::GEV, HepMC::Units::MM);
 
-  /* @TODO How to find out correct process ID from pythia? */
-  //  evt->set_signal_process_id(20);
+    // add some information to the event
+    evt->set_event_number(_eventcount);
 
-  // set number of multi parton interactions
-  evt->set_mpi( pypars.msti[31-1] );
+    /* @TODO How to find out correct process ID from pythia? */
+    //  evt->set_signal_process_id(20);
 
-  // set cross section information
-  evt->set_cross_section( HepMC::getPythiaCrossSection() );
+    // set number of multi parton interactions
+    evt->set_mpi( pypars.msti[31-1] );
+
+    // set cross section information
+    evt->set_cross_section( HepMC::getPythiaCrossSection() );
+
+    // test trigger logic
+    
+    bool andScoreKeeper = true;
+    if (verbosity > 2) {
+      cout << "PHPythia6::process_event - triggersize: " << _registeredTriggers.size() << endl;
+    }
+
+    for (unsigned int tr = 0; tr < _registeredTriggers.size(); tr++) { 
+      bool trigResult = _registeredTriggers[tr]->Apply(evt);
+
+      if (verbosity > 2) {
+	cout << "PHPythia6::process_event trigger: "
+	     << _registeredTriggers[tr]->GetName() << "  " << trigResult << endl;
+      }
+
+      if (_triggersOR && trigResult) {
+	passedTrigger = true;
+	break;
+      } else if (_triggersAND) {
+	andScoreKeeper &= trigResult;
+      }
+      
+      if (verbosity > 2 && !passedTrigger) {
+	cout << "PHPythia8::process_event - failed trigger: "
+	     << _registeredTriggers[tr]->GetName() <<  endl;
+      }
+    }
+
+    if ((andScoreKeeper && _triggersAND) || (_registeredTriggers.size() == 0)) {
+      passedTrigger = true;
+      genCounter = 0;
+    }
+
+  }
 
   /* write the event out to the ascii files */
   if ( _save_ascii )
-    {
-      HepMC::IO_GenEvent ascii_io(_filename_ascii.c_str(),std::ios::out);
-      ascii_io << evt;
-    }
+  {
+    HepMC::IO_GenEvent ascii_io(_filename_ascii.c_str(),std::ios::out);
+    ascii_io << evt;
+  }
 
   /* pass HepMC to PHNode*/
+
   bool success = _phhepmcevt->addEvent(evt);
   if (!success) {
     cout << "PHPythia6::process_event - Failed to add event to HepMC record!" << endl;
@@ -374,4 +441,9 @@ void PHPythia6::IntegerTest(double number ) {
 
 int PHPythia6::ResetEvent(PHCompositeNode *topNode) {
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void PHPythia6::register_trigger(PHPy6GenTrigger *theTrigger) {
+  if(verbosity > 1) cout << "PHPythia6::registerTrigger - trigger " << theTrigger->GetName() << " registered" << endl;
+  _registeredTriggers.push_back(theTrigger);
 }

--- a/generators/PHPythia6/PHPythia6.h
+++ b/generators/PHPythia6/PHPythia6.h
@@ -12,6 +12,7 @@
 
 class PHCompositeNode;
 class PHHepMCGenEvent;
+class PHPy6GenTrigger; 
 
 namespace HepMC {
   class GenEvent;
@@ -43,6 +44,11 @@ public:
     _save_ascii = true;
     _filename_ascii = fname;
   }
+
+  /// set event selection criteria
+  void register_trigger(PHPy6GenTrigger *theTrigger);
+  void set_trigger_OR() { _triggersOR = true; } // default true
+  void set_trigger_AND() { _triggersAND = true; }
 
 private:
 
@@ -76,6 +82,11 @@ private:
    */
   std::string _filename_ascii;
 
+  // event selection
+  std::vector<PHPy6GenTrigger*> _registeredTriggers;
+  bool _triggersOR;
+  bool _triggersAND;
+ 
   /**
    * definition needed to use pythia wrapper headers from HepMC
    */

--- a/generators/PHPythia6/PHPythia6LinkDef.h
+++ b/generators/PHPythia6/PHPythia6LinkDef.h
@@ -1,6 +1,8 @@
 #ifdef __CINT__
 
 #pragma link C++ class PHPythia6-!;
+#pragma link C++ class PHPy6GenTrigger-!;
+#pragma link C++ class PHPy6ForwardElectronTrig-!;
 
 #endif
 


### PR DESCRIPTION
This branch updates the PHPythia6 package by @nfeege with the following:

-> Added the ability to handle "mdme" settings in the config file (set particle decays)
-> Added triggers and the ability to handle a list of triggers in the event generation
-> Fixed passing the process ID to HepMC event record

All these are needed for the planned fsPHENIX DY simulations. This is an initial package to allow @nfeege and others to have a look and comment. 

As a check, setting the MDME flags in the config file as: 

mdme	174 1 0
mdme	175 1 0
mdme	176 1 0
mdme	177 1 0
mdme	178 1 0
mdme	179 1 0
mdme	180 1 0
mdme	181 1 0
mdme	182 1 1
mdme	183 1 0
mdme	184 1 0
mdme	185 1 0
mdme	186 1 0
mdme	187 1 0
mdme	188 1 0
mdme	189 1 0

results in the following output from a pylist(12):

       23     23    Z0                                  0    0    0     91.18800     2.47813    24.78129   0.00000E+00    1
           174    0   32    0.153995    d               dbar                                                            
           175    0   32    0.119420    u               ubar                                                            
           176    0   32    0.153984    s               sbar                                                            
           177    0   32    0.119259    c               cbar                                                            
           178    0   32    0.152272    b               bbar                                                            
           179    0   32    0.000000    t               tbar                                                            
           180   -1   32    0.000000    b'              b'bar                                                           
           181   -1   32    0.000000    t'              t'bar                                                           
           182    1    0    0.033576    e-              e+                                                              
           183    0    0    0.066806    nu_e            nu_ebar                                                         
           184    0    0    0.033576    mu-             mu+                                                             
           185    0    0    0.066806    nu_mu           nu_mubar                                                        
           186    0    0    0.033500    tau-            tau+                                                            
           187    0    0    0.066806    nu_tau          nu_taubar                                                       
           188   -1    0    0.000000    tau'-           tau'+                                                           
           189   -1    0    0.000000    nu'_tau         nu'_taubar                                                      

Which I think is correct - only decays to electrons will be generated. 

I have two things remaining that I want to do :

-> I need to write a quick module that will allow me to plot some distributions from the generated HepMC events. 

-> For every run, no matter the seed, I always get the message: 

vertex x/y/z6.22641/-2.54406/-4383.3 outside world volume radius/z (+-) 500/500, dropping it and its particles

which I tracked down as coming from HepMcNodeReader, I think on the first event. This seems to indicate some sort of problem with the HepMc node or how the initial event is added to the node. 



