### PR TITLE
TPC Memory Reduction

### DIFF
--- a/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTrackerTPC_findTracksBySegments.cpp
+++ b/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTrackerTPC_findTracksBySegments.cpp
@@ -851,7 +851,7 @@ static bool fit_all(vector<SimpleHit3D>& hits, vector<vector<int> >& layer_index
 
 void sPHENIXTrackerTPC::findTracksByCombinatorialKalman(vector<SimpleHit3D>& hits, vector<SimpleTrack3D>& tracks, const HelixRange& range)
 {
-  cout<<"findTracksByCombinatorialKalman "<<hits.size()<<" "<<tracks.size()<<endl;
+  //cout<<"findTracksByCombinatorialKalman "<<hits.size()<<" "<<tracks.size()<<endl;
 
   timeval t1,t2;
   double time1=0.;

--- a/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
@@ -124,7 +124,9 @@ bool PHG4SvtxClusterizer::ladder_are_adjacent(const PHG4CylinderCell* lhs,
   return false;
 }
 
-PHG4SvtxClusterizer::PHG4SvtxClusterizer(const string &name) :
+PHG4SvtxClusterizer::PHG4SvtxClusterizer(const string &name,
+					 unsigned int min_layer,
+					 unsigned int max_layer) :
   SubsysReco(name),
   _hits(NULL),
   _clusterlist(NULL),
@@ -132,6 +134,8 @@ PHG4SvtxClusterizer::PHG4SvtxClusterizer(const string &name) :
   _thresholds_by_layer(),
   _make_z_clustering(),
   _make_e_weights(),
+  _min_layer(min_layer),
+  _max_layer(max_layer),
   _timer(PHTimeServer::get()->insert_new(name)) {}
 
 int PHG4SvtxClusterizer::InitRun(PHCompositeNode* topNode) {
@@ -334,6 +338,10 @@ void PHG4SvtxClusterizer::ClusterCylinderCells(PHCompositeNode *topNode) {
       ++layeriter) {
 
     int layer = layeriter->second->get_layer();
+
+    if ((unsigned int)layer < _min_layer) continue;
+    if ((unsigned int)layer > _max_layer) continue;
+    
     int nphibins = layeriter->second->get_phibins();
 
     // loop over all hits/cells in this layer
@@ -604,6 +612,9 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 
     int layer = layeriter->second->get_layer();
 
+    if ((unsigned int)layer < _min_layer) continue;
+    if ((unsigned int)layer > _max_layer) continue;
+    
     std::map<PHG4CylinderCell*,SvtxHit*> cell_hit_map;
     vector<PHG4CylinderCell*> cell_list;
     for (std::multimap<int,SvtxHit*>::iterator hiter = layer_hits_mmap.lower_bound(layer);

--- a/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.h
@@ -4,6 +4,7 @@
 #include <fun4all/SubsysReco.h>
 #include <phool/PHTimeServer.h>
 #include <map>
+#include <limits.h>
 
 class SvtxHitMap;
 class SvtxClusterMap;
@@ -13,7 +14,8 @@ class PHG4SvtxClusterizer : public SubsysReco {
 
 public:
 
-  PHG4SvtxClusterizer(const std::string &name = "PHG4SvtxClusterizer");
+  PHG4SvtxClusterizer(const std::string &name = "PHG4SvtxClusterizer",
+		      unsigned int min_layer = 0, unsigned int max_layer = UINT_MAX);
   virtual ~PHG4SvtxClusterizer(){}
   
   //! module initialization
@@ -84,6 +86,9 @@ private:
   std::map<int,float> _thresholds_by_layer; // layer->threshold
   std::map<int,bool> _make_z_clustering;    // layer->z_clustering_option
   std::map<int,bool> _make_e_weights;       // layer->energy_weighting_option
+
+  unsigned int _min_layer;
+  unsigned int _max_layer;
   
   PHTimeServer::timer _timer;
 };

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -163,7 +163,6 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
         new PHIODataNode<PHObject>(svxclusters, "SvtxClusterMap", "PHObject");
     svxNode->addNode(SvtxClusterMapNode);
   }
-  svxclusters->Reset();
 
   PHG4CylinderCellGeomContainer* geom_container =
     findNode::getClass<PHG4CylinderCellGeomContainer>(topNode,"CYLINDERCELLGEOM_SVTX");
@@ -197,8 +196,6 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
     PHG4CylinderCellGeom* geo = geom_container->GetLayerCellGeom(layer);
     nphibins = layeriter->second->get_phibins();
     nzbins = layeriter->second->get_zbins();
-
-    cout << nphibins*nzbins << endl;
 
     nhits.clear();
     nhits.assign(nzbins, 0);
@@ -263,8 +260,6 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
     }
   }
 
-  cout << "clusters = " << svxclusters->size() << endl;
-  
   reset();
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -1,32 +1,32 @@
 #include "PHG4TPCClusterizer.h"
-#include "SvtxHitMap.h"
-#include "SvtxHit.h"
+#include "SvtxCluster.h"
 #include "SvtxClusterMap.h"
 #include "SvtxClusterMap_v1.h"
-#include "SvtxCluster.h"
 #include "SvtxCluster_v1.h"
+#include "SvtxHit.h"
+#include "SvtxHitMap.h"
 
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <g4detectors/PHG4CylinderCell.h>
+#include <g4detectors/PHG4CylinderCellContainer.h>
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderGeom.h>
+#include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
-#include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHTypedNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHTypedNodeIterator.h>
 #include <phool/getClass.h>
-#include <g4detectors/PHG4CylinderCellContainer.h>
-#include <g4detectors/PHG4CylinderCellGeomContainer.h>
-#include <g4detectors/PHG4CylinderGeomContainer.h>
-#include <g4detectors/PHG4CylinderGeom.h>
-#include <g4detectors/PHG4CylinderCell.h>
-#include <g4detectors/PHG4CylinderCellGeom.h>
 
 #include <TMath.h>
 
-#include <TH1D.h>
+#include <TF1.h>
 #include <TFitResult.h>
 #include <TFitResultPtr.h>
-#include <TF1.h>
+#include <TH1D.h>
 
 #include <cassert>
 #include <cstdlib>
@@ -35,225 +35,235 @@
 
 using namespace std;
 
-static int phi_span=10;
-static int z_span=10;
+static int phi_span = 10;
+static int z_span = 10;
 
-
-static inline int wrap_bin( int bin, int nbins )
-{
-	if(bin<0){bin+=nbins;}
-	if(bin>=nbins){bin-=nbins;}
-	return bin;
+static int wrap_bin(int bin, int nbins) {
+  if (bin < 0) {
+    bin += nbins;
+  }
+  if (bin >= nbins) {
+    bin -= nbins;
+  }
+  return bin;
 }
 
-static bool is_local_maximum( vector<float> const& amps, int nphibins, int nzbins, int phi, int z )
-{
-	int max_width = 32;
-	if( amps[z*nphibins + phi] <= 0. ){return false;}
-	float cent_val = amps[z*nphibins + phi];
-	bool is_max = true;
-	for( int iz=-max_width;iz<=max_width;++iz )
-	{
-		int cz = z+iz;if(cz<0){continue;}if(cz>=(int)(nzbins)){continue;}
-		for( int ip=-max_width;ip<=max_width;++ip )
-		{
-			if( (iz==0) && (ip==0) ){continue;}
-			int cp = wrap_bin( phi+ip, nphibins );
-			assert (cp >= 0);
-			if( amps[cz*nphibins+cp] > cent_val ){is_max=false;break;}
-		}
-		if(is_max==false){break;}
-	}
-	return is_max;
+static bool is_local_maximum(const std::vector<float>& amps, int nphibins,
+                             int nzbins, int phi, int z) {
+  int max_width = 32;
+  if (amps[z * nphibins + phi] <= 0.) {
+    return false;
+  }
+  float cent_val = amps[z * nphibins + phi];
+  bool is_max = true;
+  for (int iz = -max_width; iz <= max_width; ++iz) {
+    int cz = z + iz;
+    if (cz < 0) {
+      continue;
+    }
+    if (cz >= (int)(nzbins)) {
+      continue;
+    }
+    for (int ip = -max_width; ip <= max_width; ++ip) {
+      if ((iz == 0) && (ip == 0)) {
+        continue;
+      }
+      int cp = wrap_bin(phi + ip, nphibins);
+      assert(cp >= 0);
+      if (amps[cz * nphibins + cp] > cent_val) {
+        is_max = false;
+        break;
+      }
+    }
+    if (is_max == false) {
+      break;
+    }
+  }
+  return is_max;
 }
 
+static void fit_cluster(std::vector<float>& amps, int nphibins, int nzbins,
+                        int& nhits_tot, std::vector<int>& nhits, int phibin,
+                        int zbin, PHG4CylinderCellGeom* geo, float& phi,
+                        float& z, float& e) {
+  e = 0.;
+  phi = 0.;
+  z = 0.;
+  
+  float prop_cut = 0.05;
+  float peak = amps[zbin * nphibins + phibin];
 
-static void fit_cluster( vector<float>& amps, int nphibins, int nzbins, int& nhits_tot, vector<int>& nhits, int phibin, int zbin, PHG4CylinderCellGeom* geo, float& phi, float& z, float& e )
-{
-	e = 0.;
-	phi = 0.;
-	z = 0.;
-	float prop_cut = 0.05;
-	float peak = amps[zbin*nphibins+phibin];
+  for (int iz = -z_span; iz <= z_span; ++iz) {
+    int cz = zbin + iz;
+    if (cz < 0) {
+      continue;
+    }
+    if (cz >= (int)(nzbins)) {
+      continue;
+    }
+    for (int ip = -phi_span; ip <= phi_span; ++ip) {
+      int cp = wrap_bin(phibin + ip, nphibins);
+      assert(cp >= 0);
+      if (amps[cz * nphibins + cp] <= 0.) {
+        continue;
+      }
+      if (amps[cz * nphibins + cp] < prop_cut * peak) {
+        continue;
+      }
+      e += amps[cz * nphibins + cp];
+      phi += amps[cz * nphibins + cp] * geo->get_phicenter(cp);
+      z += amps[cz * nphibins + cp] * geo->get_zcenter(cz);
+      nhits_tot -= 1;
+      nhits[cz] -= 1;
+      amps[cz * nphibins + cp] = 0.;
+    }
+  }
 
-
-	for( int iz=-z_span;iz<=z_span;++iz )
-	{
-		int cz = zbin+iz;if(cz<0){continue;}if(cz>=(int)(nzbins)){continue;}
-		for( int ip=-phi_span;ip<=phi_span;++ip )
-		{
-			int cp = wrap_bin( phibin+ip, nphibins );
-			assert (cp >= 0);
-			if(amps[cz*nphibins+cp] <= 0.)
-			{
-				continue;
-			}
-			if( amps[cz*nphibins+cp] < prop_cut*peak )
-			{
-				continue;
-			}
-			e += amps[cz*nphibins+cp];
-			phi += amps[cz*nphibins+cp]*geo->get_phicenter(cp);
-			z += amps[cz*nphibins+cp]*geo->get_zcenter(cz);
-			nhits_tot -= 1;
-			nhits[cz] -= 1;
-			amps[cz*nphibins+cp] = 0.;
-		}
-	}
-
-	phi /= e;
-	z /= e;
+  phi /= e;
+  z /= e;
 }
 
-int PHG4TPCClusterizer::InitRun(PHCompositeNode *topNode)
-{
-	phi_span = _phi_span;
-	z_span = _z_span;
-	return Fun4AllReturnCodes::EVENT_OK;
+int PHG4TPCClusterizer::InitRun(PHCompositeNode* topNode) {
+  phi_span = _phi_span;
+  z_span = _z_span;
+  return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void PHG4TPCClusterizer::reset()
-{
+void PHG4TPCClusterizer::reset() {}
 
+int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
+  
+  PHNodeIterator iter(topNode);
+
+  PHCompositeNode* dstNode =
+      static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode) {
+    cout << PHWHERE << "DST Node missing, doing nothing." << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  SvtxHitMap* hits = findNode::getClass<SvtxHitMap>(topNode, "SvtxHitMap");
+  if (!hits) {
+    cout << PHWHERE << "ERROR: Can't find node SvtxHitMap" << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  PHCompositeNode* svxNode =
+      dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "SVTX"));
+  if (!svxNode) {
+    svxNode = new PHCompositeNode("SVTX");
+    dstNode->addNode(svxNode);
+  }
+
+  SvtxClusterMap* svxclusters =
+      findNode::getClass<SvtxClusterMap>(topNode, "SvtxClusterMap");
+  if (!svxclusters) {
+    svxclusters = new SvtxClusterMap_v1();
+    PHIODataNode<PHObject>* SvtxClusterMapNode =
+        new PHIODataNode<PHObject>(svxclusters, "SvtxClusterMap", "PHObject");
+    svxNode->addNode(SvtxClusterMapNode);
+  }
+  svxclusters->Reset();
+
+  PHG4CylinderCellGeomContainer* geom_container =
+    findNode::getClass<PHG4CylinderCellGeomContainer>(topNode,"CYLINDERCELLGEOM_SVTX");
+  if (!geom_container) return Fun4AllReturnCodes::ABORTRUN;
+
+  PHG4CylinderCellContainer* cells =  findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SVTX");
+  if (!cells) return Fun4AllReturnCodes::ABORTRUN;
+
+  std::vector<std::vector<const SvtxHit*> > layer_sorted;
+  PHG4CylinderCellGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
+  for (PHG4CylinderCellGeomContainer::ConstIterator layeriter = layerrange.first;
+       layeriter != layerrange.second;
+       ++layeriter) {
+    layer_sorted.push_back(std::vector<const SvtxHit*>());
+  }
+  for (SvtxHitMap::Iter iter = hits->begin(); iter != hits->end(); ++iter) {
+    SvtxHit* hit = iter->second;
+    layer_sorted[hit->get_layer()].push_back(hit);
+  }
+
+  unsigned int layer = 0;
+  for (PHG4CylinderCellGeomContainer::ConstIterator layeriter =
+           layerrange.first;
+       layeriter != layerrange.second; ++layeriter) {
+
+    // exit on the MAPS layers...
+    
+    PHG4CylinderCellGeom* geo = geom_container->GetLayerCellGeom(layer);
+    nphibins = layeriter->second->get_phibins();
+    nzbins = layeriter->second->get_zbins();
+
+    cout << nphibins*nzbins << endl;
+
+    nhits.clear();
+    nhits.assign(nzbins, 0);
+    amps.clear();
+    amps.assign(nphibins * nzbins, 0.);
+    cellids.clear();
+    cellids.assign(nphibins * nzbins, 0);
+
+    for (unsigned int i = 0; i < layer_sorted[layer].size(); ++i) {
+
+      const SvtxHit* hit = layer_sorted[layer][i];
+      if (hit->get_e() <= 0.) continue;
+      
+      PHG4CylinderCell* cell = cells->findCylinderCell(hit->get_cellid());
+      int phibin = cell->get_binphi();
+      int zbin = cell->get_binz();
+      nhits[zbin] += 1;
+      amps[zbin * nphibins + phibin] += hit->get_e();
+      cellids[zbin * nphibins + phibin] = hit->get_id();
+    }
+
+    int nhits_tot = 0;
+    for (int zbin = 0; zbin < nzbins; ++zbin) {
+      nhits_tot += nhits[zbin];
+    }
+
+    while (nhits_tot > 0) {
+
+      for (int zbin = 0; zbin < nzbins; ++zbin) {
+
+        if (nhits[zbin] <= 0) continue;
+
+        for (int phibin = 0; phibin < nphibins; ++phibin) {
+
+          if (is_local_maximum(amps, nphibins, nzbins, phibin, zbin) == false) {
+            continue;
+          }
+
+          float phi = 0.;
+          float z = 0.;
+          float e = 0.;
+
+          fit_cluster(amps, nphibins, nzbins, nhits_tot, nhits, phibin, zbin,
+                      geo, phi, z, e);
+
+          if ((layer > 2) && (e < energy_cut)) {
+            continue;
+          }
+
+          SvtxCluster_v1 clus;
+          clus.set_layer(layer);
+          clus.set_e(e);
+          double radius = geo->get_radius();
+          clus.set_position(0, radius * cos(phi));
+          clus.set_position(1, radius * sin(phi));
+          clus.set_position(2, z);
+          clus.insert_hit(cellids[zbin * nphibins + phibin]);
+
+          svxclusters->insert(&clus);
+        }
+      }
+    }
+
+    layer += 1;
+  }
+
+  cout << "clusters = " << svxclusters->size() << endl;
+  
+  reset();
+  return Fun4AllReturnCodes::EVENT_OK;
 }
-
-
-int PHG4TPCClusterizer::process_event(PHCompositeNode *topNode)
-{
-	PHNodeIterator iter(topNode);
-
-	PHCompositeNode *dstNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","DST"));
-	if (!dstNode) {
-		cout << PHWHERE << "DST Node missing, doing nothing." << endl;
-		return Fun4AllReturnCodes::ABORTRUN;}
-
-	SvtxHitMap* hits = findNode::getClass<SvtxHitMap>(topNode,"SvtxHitMap");
-	if (!hits) {
-    	cout << PHWHERE << "ERROR: Can't find node SvtxHitMap" << endl;
-    	return Fun4AllReturnCodes::ABORTRUN;}
-
-	PHCompositeNode* svxNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","SVTX"));
-	if (!svxNode){
-		svxNode = new PHCompositeNode("SVTX");
-		dstNode->addNode(svxNode);}
-
-	SvtxClusterMap *svxclusters = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
-	if (!svxclusters){
-		svxclusters = new SvtxClusterMap_v1();
-		PHIODataNode<PHObject> *SvtxClusterMapNode = new PHIODataNode<PHObject>(svxclusters, "SvtxClusterMap", "PHObject");
-		svxNode->addNode(SvtxClusterMapNode);}
-
-	PHG4CylinderCellGeomContainer* geom_container = 0;
-	PHTypedNodeIterator<PHG4CylinderCellGeomContainer> geomiter(topNode);
-	PHIODataNode<PHG4CylinderCellGeomContainer>* PHG4CylinderCellGeomContainerNode = geomiter.find("CYLINDERCELLGEOM_SVTX");
-	if(PHG4CylinderCellGeomContainerNode){geom_container = (PHG4CylinderCellGeomContainer*) PHG4CylinderCellGeomContainerNode->getData();}
-	if (!geom_container) return Fun4AllReturnCodes::ABORTRUN;
-
-	PHG4HitContainer* g4hits = 0;
-	PHTypedNodeIterator<PHG4HitContainer> g4hititer(topNode);
-	PHIODataNode<PHG4HitContainer> *PHG4HitContainerNode = g4hititer.find("G4HIT_SVTX");
-	if (PHG4HitContainerNode) {g4hits = (PHG4HitContainer*)PHG4HitContainerNode->getData();}
-	if (!g4hits) return Fun4AllReturnCodes::ABORTRUN;;
-	
-	PHG4CylinderCellContainer* cells = 0;
-	PHTypedNodeIterator<PHG4CylinderCellContainer> celliter(topNode);
-	PHIODataNode<PHG4CylinderCellContainer>* cell_container_node = celliter.find("G4CELL_SVTX");
-	if (cell_container_node) {cells = (PHG4CylinderCellContainer*) cell_container_node->getData();}
-	if (!cells) return Fun4AllReturnCodes::ABORTRUN;;
-
-	SvtxClusterMap* clusterlist = 0;
-	PHTypedNodeIterator<SvtxClusterMap> clusteriter(topNode);
-	PHIODataNode<SvtxClusterMap> *SvtxClusterMapNode = clusteriter.find("SvtxClusterMap");
-	if (!SvtxClusterMapNode) {
-		cout << PHWHERE << " ERROR: Can't find SvtxClusterMap." << endl;
-		return Fun4AllReturnCodes::ABORTRUN;}
-		else {clusterlist = (SvtxClusterMap*)SvtxClusterMapNode->getData();}
-	clusterlist->Reset();
-
-	vector<vector<SvtxHit*> > layer_sorted;
-	PHG4CylinderCellGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
-	for(PHG4CylinderCellGeomContainer::ConstIterator layeriter = layerrange.first;layeriter != layerrange.second;++layeriter)
-	{
-		layer_sorted.push_back( vector<SvtxHit*>() );
-	}
-	for(SvtxHitMap::Iter iter = hits->begin();iter != hits->end();++iter)
-	{
-		SvtxHit* hit = iter->second;
-		layer_sorted[ hit->get_layer() ].push_back( hit->Clone() );
-	}
-
-	unsigned int layer = 0;
-	for(PHG4CylinderCellGeomContainer::ConstIterator layeriter = layerrange.first;layeriter != layerrange.second;++layeriter)
-	{
-
-		PHG4CylinderCellGeom* geo = geom_container->GetLayerCellGeom(layer);
-		nphibins = layeriter->second->get_phibins();
-		nzbins =  layeriter->second->get_zbins();
-
-
-		nhits.clear();nhits.assign( nzbins, 0 );
-		amps.clear();amps.assign( nphibins*nzbins, 0. );
-		cellids.clear();cellids.assign( nphibins*nzbins, 0 );
-		for(unsigned int i=0;i<layer_sorted[layer].size();++i)
-		{
-			SvtxHit* hit = layer_sorted[layer][i];
-			if(hit->get_e() <= 0.){continue;}
-			PHG4CylinderCell* cell = cells->findCylinderCell(hit->get_cellid());
-			int phibin = cell->get_binphi();
-			int zbin = cell->get_binz();
-			nhits[zbin] += 1;
-			amps[ zbin*nphibins + phibin ] += hit->get_e();
-			cellids[ zbin*nphibins + phibin ] = hit->get_id();
-		}
-		int nhits_tot = 0;
-		for(int zbin=0;zbin<nzbins;++zbin)
-		{
-			nhits_tot += nhits[zbin];
-		}
-		while( nhits_tot > 0 )
-		{
-			for(int zbin=0;zbin<nzbins;++zbin)
-			{
-				if(nhits[zbin] <= 0){continue;}
-				for( int phibin=0;phibin<nphibins;++phibin )
-				{
-					if( is_local_maximum( amps, nphibins, nzbins, phibin, zbin ) == false ){continue;}
-
-					float phi=0.;float z=0.;float e=0.;
-					fit_cluster( amps, nphibins, nzbins, nhits_tot, nhits, phibin, zbin, geo, phi, z, e );
-					
-
-					if( (layer>2) && (e<energy_cut) ){continue;}
-
-					SvtxCluster_v1 clus;
-					clus.set_layer( layer );
-					clus.set_e(e);
-					double radius = geo->get_radius();
-					clus.set_position( 0, radius*cos(phi) );
-					clus.set_position( 1, radius*sin(phi) );
-					clus.set_position( 2, z );
-					clus.insert_hit( cellids[ zbin*nphibins + phibin ] );
-					clusterlist->insert(&clus);
-				}
-			}
-		}
-
-
-		layer += 1;
-	}
-
-	for( unsigned int l=0;l<layer_sorted.size();++l )
-	{
-		for(unsigned int i=0;i<layer_sorted[l].size();++i)
-		{
-			delete layer_sorted[l][i];
-		}
-	}
-
-	reset();
-	return Fun4AllReturnCodes::EVENT_OK;
-}
-
-
-
-

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -190,6 +190,8 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
        layeriter != layerrange.second; ++layeriter) {
 
     // exit on the MAPS layers...
+    if (layer < _min_layer) continue;
+    if (layer > _max_layer) continue;
     
     PHG4CylinderCellGeom* geo = geom_container->GetLayerCellGeom(layer);
     nphibins = layeriter->second->get_phibins();

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -184,11 +184,12 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
     layer_sorted[hit->get_layer()].push_back(hit);
   }
 
-  unsigned int layer = 0;
   for (PHG4CylinderCellGeomContainer::ConstIterator layeriter =
            layerrange.first;
        layeriter != layerrange.second; ++layeriter) {
 
+    unsigned int layer = (unsigned int)layeriter->second->get_layer();
+    
     // exit on the MAPS layers...
     if (layer < _min_layer) continue;
     if (layer > _max_layer) continue;
@@ -260,8 +261,6 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
         }
       }
     }
-
-    layer += 1;
   }
 
   cout << "clusters = " << svxclusters->size() << endl;

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.h
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.h
@@ -3,12 +3,15 @@
 
 #include <fun4all/SubsysReco.h>
 #include <vector>
+#include <limits.h>
 
 class PHG4TPCClusterizer : public SubsysReco {
  public:
   PHG4TPCClusterizer(const char *name = "PHG4SvtxClusterizer",
-                     unsigned int phi_s = 10, unsigned int z_s = 5)
-      : SubsysReco(name), _phi_span(phi_s), _z_span(z_s), energy_cut(-1.) {}
+                     unsigned int phi_s = 10, unsigned int z_s = 5,
+		     unsigned int min_layer = 0, unsigned int max_layer = UINT_MAX)
+    : SubsysReco(name), _phi_span(phi_s), _z_span(z_s), energy_cut(-1.),
+      _min_layer(min_layer), _max_layer(max_layer) {}
   ~PHG4TPCClusterizer() {}
 
   //! module initialization
@@ -38,6 +41,8 @@ class PHG4TPCClusterizer : public SubsysReco {
   unsigned int _phi_span;
   unsigned int _z_span;
   double energy_cut;
+  unsigned int _min_layer;
+  unsigned int _max_layer;
 };
 
 #endif

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.h
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.h
@@ -4,44 +4,40 @@
 #include <fun4all/SubsysReco.h>
 #include <vector>
 
-class PHG4TPCClusterizer : public SubsysReco
-{
-	public:
-		PHG4TPCClusterizer(const char * name = "PHG4SvtxClusterizer", unsigned int phi_s=10,unsigned int z_s=5) : SubsysReco(name), _phi_span(phi_s), _z_span(z_s), energy_cut(-1.) {}
-		~PHG4TPCClusterizer(){}
+class PHG4TPCClusterizer : public SubsysReco {
+ public:
+  PHG4TPCClusterizer(const char *name = "PHG4SvtxClusterizer",
+                     unsigned int phi_s = 10, unsigned int z_s = 5)
+      : SubsysReco(name), _phi_span(phi_s), _z_span(z_s), energy_cut(-1.) {}
+  ~PHG4TPCClusterizer() {}
 
-		//! module initialization
-		int Init(PHCompositeNode *topNode){return 0;}
+  //! module initialization
+  int Init(PHCompositeNode *topNode) { return 0; }
 
-		//! run initialization
-		int InitRun(PHCompositeNode *topNode);
+  //! run initialization
+  int InitRun(PHCompositeNode *topNode);
 
-		//! event processing
-		int process_event(PHCompositeNode *topNode);
+  //! event processing
+  int process_event(PHCompositeNode *topNode);
 
-		//! end of process
-		int End(PHCompositeNode *topNode){return 0;}
+  //! end of process
+  int End(PHCompositeNode *topNode) { return 0; }
 
-		void setEnergyCut(double ecut){energy_cut=ecut;}
+  void setEnergyCut(double ecut) { energy_cut = ecut; }
 
+ private:
 
-	private:
-		// std::vector<std::vector<std::vector<float> > > amps;
-		// std::vector<std::vector<std::vector<int> > > cellids;
-		// std::vector<std::vector<int> > nhits;
+  std::vector<int> nhits;
+  std::vector<float> amps;
+  std::vector<int> cellids;
+  int nphibins;
+  int nzbins;
 
-		std::vector<int> nhits;
-		std::vector<float> amps;
-		std::vector<int> cellids;
-		int nphibins;
-		int nzbins;
+  void reset();
 
-		void reset();
-
-		unsigned int _phi_span;
-		unsigned int _z_span;
-		double energy_cut;
+  unsigned int _phi_span;
+  unsigned int _z_span;
+  double energy_cut;
 };
-
 
 #endif


### PR DESCRIPTION
The TPC was using fixed size arrays to cluster both the MAPS and the TPC layers. In the MAPS layers, due to the fine pitch pixels, this is a particularly wasteful approach. So I've rewritten both the MAPS and the TPC clusterizer to work over just those subsystems individually. The peak memory footprint is now 1.2 GB smaller and things will run on the normal condor queue for the TPC simulations.

I will need to push changes to the MAPS+TPC macro as well with this merge.

Here is the full MAPS performance cross check:
![maps_memory](https://cloud.githubusercontent.com/assets/12105552/16265869/c6335aa0-384f-11e6-983e-233b5599ccd7.png)

And here is the MAPS+TPC performance cross check:
![tpc_memory](https://cloud.githubusercontent.com/assets/12105552/16265855/af751da8-384f-11e6-9525-114fda4321a5.png)

Some small changes in this one since the MAPS clusters are now made differently.