### PR TITLE
Patch for Cut and Paste Bug in Cluster v1

### DIFF
--- a/simulation/g4simulation/g4hough/SvtxCluster_v1.C
+++ b/simulation/g4simulation/g4hough/SvtxCluster_v1.C
@@ -112,7 +112,7 @@ void SvtxCluster_v1::set_error(unsigned int i, unsigned int j, float value) {
 }
 
 float SvtxCluster_v1::get_error(unsigned int i, unsigned int j) const {
-  return _size[covar_index(i,j)];
+  return _err[covar_index(i,j)];
 }
 
 float SvtxCluster_v1::get_phi_size() const {


### PR DESCRIPTION
Veronica found a cut and paste bug in the get_error() method on the SvtxCluster object. I fix the bug and check the resulting tracking performance delta for a MAPS tracker:
![crosscheck_maps](https://cloud.githubusercontent.com/assets/12105552/16572578/43a56ee8-4227-11e6-9d93-5820da58823d.png)

and for the MAPS+TPC tracker:
![crosscheck_tpc](https://cloud.githubusercontent.com/assets/12105552/16572582/4e3ad924-4227-11e6-8637-f72b1c442334.png)

This will get us started on simplifying the cluster error handling. I'll go ahead and merge this right away since it is tested.