### PR TITLE
scintillation light collection in SPACAL

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
@@ -214,7 +214,7 @@ PHG4CylinderGeom_Spacalv3::geom_tower::get_position_fraction_x_in_sub_tower(int 
   assert(index_x >= 0);
 
   const double sub_tower_width_x = (double) NFiberX / NSubtowerX;
-  const double x_in_sub_tower = fmod(index_x,  sub_tower_width_x); //! x is negative azimuthal direction
+  const double x_in_sub_tower = (fmod(index_x,  sub_tower_width_x)+0.5)/sub_tower_width_x ; //! x is negative azimuthal direction
   assert(x_in_sub_tower <=1 );
   assert(x_in_sub_tower >= 0);
 
@@ -230,7 +230,7 @@ PHG4CylinderGeom_Spacalv3::geom_tower::get_position_fraction_y_in_sub_tower(int 
   const double sub_tower_width_y = (double) NFiberY / NSubtowerY;
 
   assert(pRotationAngleX < 0);
-  const double y_in_sub_tower = fmod(index_y ,  sub_tower_width_y); //! y is negative polar direction
+  const double y_in_sub_tower = (fmod(index_y ,  sub_tower_width_y) + 0.5)/sub_tower_width_y; //! y is negative polar direction
   assert(y_in_sub_tower <=1 );
   assert(y_in_sub_tower >= 0);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
@@ -206,6 +206,37 @@ PHG4CylinderGeom_Spacalv3::geom_tower::get_sub_tower_ID_y(int fiber_id) const
   return tower_ID_y;
 }
 
+double
+PHG4CylinderGeom_Spacalv3::geom_tower::get_position_fraction_x_in_sub_tower(int fiber_id) const
+{
+  const int index_x = fiber_id / NFiberY;
+  assert(index_x < NFiberX);
+  assert(index_x >= 0);
+
+  const double sub_tower_width_x = (double) NFiberX / NSubtowerX;
+  const double x_in_sub_tower = fmod(index_x,  sub_tower_width_x); //! x is negative azimuthal direction
+  assert(x_in_sub_tower <=1 );
+  assert(x_in_sub_tower >= 0);
+
+  return x_in_sub_tower;
+}
+
+double
+PHG4CylinderGeom_Spacalv3::geom_tower::get_position_fraction_y_in_sub_tower(int fiber_id) const
+{
+  assert(fiber_id >= 0);
+  const int index_y = fiber_id % NFiberY;
+
+  const double sub_tower_width_y = (double) NFiberY / NSubtowerY;
+
+  assert(pRotationAngleX < 0);
+  const double y_in_sub_tower = fmod(index_y ,  sub_tower_width_y); //! y is negative polar direction
+  assert(y_in_sub_tower <=1 );
+  assert(y_in_sub_tower >= 0);
+
+  return y_in_sub_tower;
+}
+
 void
 PHG4CylinderGeom_Spacalv3::geom_tower::identify(std::ostream& os) const
 {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
@@ -128,12 +128,19 @@ public:
     //! fiber layout (2D index of 0...NFiberX/NFiberY) -> fiber_id
     int
     compose_fiber_id(int index_x, int index_y) const;
-    //! fiber_id -> sub tower ID x.azimuthal direction: 0 ... NSubtowerX -1
+    //! fiber_id -> sub tower ID x/azimuthal direction: 0 ... NSubtowerX -1
     int
     get_sub_tower_ID_x(int fiber_id) const;
     //! fiber_id -> sub tower ID y/polar direction: 0 ... NSubtowerY -1
     int
     get_sub_tower_ID_y(int fiber_id) const;
+    //! fiber_id -> fraction position in sub tower ID in the x/azimuthal direction, [0-1]
+    double
+    get_position_fraction_x_in_sub_tower(int fiber_id) const;
+    //! fiber_id -> fraction position in sub tower ID in the y/polar direction, [0-1]
+    double
+    get_position_fraction_y_in_sub_tower(int fiber_id) const;
+
 
     //! height of light guide
     double LightguideHeight;

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -39,7 +39,8 @@ PHG4FullProjSpacalCellReco::PHG4FullProjSpacalCellReco(const string &name) :
         0),
     tmin_default(0.0),  // ns
     tmax_default(60.0), // ns
-    tmin_max()
+    tmin_max(), //
+    light_collection_model()
 {
 }
 
@@ -371,22 +372,23 @@ PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
           // hit loop
           int scint_id = hiter->second->get_scint_id();
 
+          // decode scint_id
+          PHG4CylinderGeom_Spacalv3::scint_id_coder decoder(scint_id);
+
+          // convert to z_ID, phi_ID
+          std::pair<int, int> tower_z_phi_ID =
+              layergeom->get_tower_z_phi_ID(decoder.tower_ID,
+                  decoder.sector_ID);
+          const int & tower_ID_z = tower_z_phi_ID.first;
+          const int & tower_ID_phi = tower_z_phi_ID.second;
+
+          PHG4CylinderGeom_Spacalv3::tower_map_t::const_iterator it_tower =
+              layergeom->get_sector_tower_map().find(decoder.tower_ID);
+          assert(it_tower != layergeom->get_sector_tower_map().end());
+
           unsigned int key = static_cast<unsigned int>(scint_id);
           if (celllist.find(key) == celllist.end())
             {
-              // decode scint_id
-              PHG4CylinderGeom_Spacalv3::scint_id_coder decoder(scint_id);
-
-              // convert to z_ID, phi_ID
-              std::pair<int, int> tower_z_phi_ID =
-                  layergeom->get_tower_z_phi_ID(decoder.tower_ID,
-                      decoder.sector_ID);
-              const int & tower_ID_z = tower_z_phi_ID.first;
-              const int & tower_ID_phi = tower_z_phi_ID.second;
-
-              PHG4CylinderGeom_Spacalv3::tower_map_t::const_iterator it_tower =
-                  layergeom->get_sector_tower_map().find(decoder.tower_ID);
-              assert(it_tower != layergeom->get_sector_tower_map().end());
 
               // convert tower_ID_z to to eta bin number
               int etabin = -1;
@@ -422,8 +424,34 @@ PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
               celllist[key]->set_fiber_ID(decoder.fiber_ID);
             }
 
+          double light_yield = hiter->second->get_light_yield();
+
+          // light yield correction from fiber attenuation:
+          if (light_collection_model.use_fiber_model())
+            {
+              const double z = 0.5
+                  * (hiter->second->get_local_z(0)
+                      + hiter->second->get_local_z(1));
+              assert(not std::isnan(z));
+
+              light_yield *= light_collection_model.get_fiber_transmission(z);
+            }
+
+          // light yield correction from light guide collection efficiency:
+          if (light_collection_model.use_fiber_model())
+            {
+              const double x =
+                  it_tower->second.get_position_fraction_x_in_sub_tower(
+                      decoder.fiber_ID);
+              const double y =
+                  it_tower->second.get_position_fraction_y_in_sub_tower(
+                      decoder.fiber_ID);
+
+              light_yield *= light_collection_model.get_light_guide_efficiency(x, y);
+            }
+
           celllist[key]->add_edep(hiter->first, hiter->second->get_edep(),
-              hiter->second->get_light_yield());
+              light_yield);
           celllist[key]->add_shower_edep(hiter->second->get_shower_id(),
               hiter->second->get_edep());
 
@@ -514,8 +542,23 @@ PHG4FullProjSpacalCellReco::CheckEnergy(PHCompositeNode *topNode)
 }
 
 PHG4FullProjSpacalCellReco::LightCollectionModel::LightCollectionModel() :
-    data_grid_light_guide_efficiency(NULL)
+    data_grid_light_guide_efficiency(NULL), data_grid_fiber_trans(NULL)
 {
+
+  data_grid_light_guide_efficiency_verify = new TH2F("data_grid_light_guide_efficiency_verify",
+      "light collection efficiency as used in PHG4FullProjSpacalCellReco::LightCollectionModel;x positio fraction;y position fraction", //
+      100, 0., 1., 100, 0., 1.);
+
+  data_grid_fiber_trans_verify = new TH1F("data_grid_fiber_trans",
+      "SCSF-78 Fiber Transmission as used in PHG4FullProjSpacalCellReco::LightCollectionModel;position in fiber (cm);Effective transmission",
+      100, -15, 15);
+
+  // register histograms
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  se->registerHisto(data_grid_light_guide_efficiency_verify);
+  se->registerHisto(data_grid_fiber_trans_verify);
+
 }
 
 PHG4FullProjSpacalCellReco::LightCollectionModel::~LightCollectionModel()
@@ -528,19 +571,26 @@ PHG4FullProjSpacalCellReco::LightCollectionModel::~LightCollectionModel()
 
 void
 PHG4FullProjSpacalCellReco::LightCollectionModel::load_data_file(
-    std::string input_file,  std::string histogram_light_guide_model, std::string histogram_fiber_model)
+    const std::string & input_file,
+    const std::string & histogram_light_guide_model,
+    const std::string & histogram_fiber_model)
 {
-  TFile fin(input_file.c_str());
+  TFile * fin = TFile::Open(input_file.c_str());
 
-  assert(fin.IsOpen());
+  assert(fin);
+  assert(fin->IsOpen());
 
-  data_grid_light_guide_efficiency = dynamic_cast<TH2 *>(fin.FindObject(histogram_light_guide_model.c_str()));
+  data_grid_light_guide_efficiency = dynamic_cast<TH2 *>(fin->Get(
+      histogram_light_guide_model.c_str()));
   assert(data_grid_light_guide_efficiency);
   data_grid_light_guide_efficiency->SetDirectory(NULL);
 
-  data_grid_fiber_trans = dynamic_cast<TH1 *>(fin.FindObject(histogram_fiber_model.c_str()));
+  data_grid_fiber_trans = dynamic_cast<TH1 *>(fin->Get(
+      histogram_fiber_model.c_str()));
   assert(data_grid_fiber_trans);
   data_grid_fiber_trans->SetDirectory(NULL);
+
+  delete fin;
 }
 
 double
@@ -548,18 +598,36 @@ PHG4FullProjSpacalCellReco::LightCollectionModel::get_light_guide_efficiency(
     const double x_fraction, const double y_fraction)
 {
   assert(data_grid_light_guide_efficiency);
-  assert(x_fraction >=0);
-  assert(x_fraction <=1);
-  assert(y_fraction >=0);
-  assert(y_fraction <=1);
+  assert(x_fraction >= 0);
+  assert(x_fraction <= 1);
+  assert(y_fraction >= 0);
+  assert(y_fraction <= 1);
 
-  return data_grid_light_guide_efficiency->Interpolate(x_fraction, y_fraction);
+  const double eff = data_grid_light_guide_efficiency->Interpolate(x_fraction,
+      y_fraction);
+
+  data_grid_light_guide_efficiency_verify->SetBinContent( //
+      data_grid_light_guide_efficiency_verify->GetXaxis()->FindBin(x_fraction), //
+      data_grid_light_guide_efficiency_verify->GetYaxis()->FindBin(y_fraction), //
+      eff //
+      );
+
+  return eff;
 }
 
 double
-PHG4FullProjSpacalCellReco::LightCollectionModel::get_fiber_transmission(const double z_distance)
+PHG4FullProjSpacalCellReco::LightCollectionModel::get_fiber_transmission(
+    const double z_distance)
 {
-  assert(data_grid_light_guide_efficiency);
-  return data_grid_light_guide_efficiency->Interpolate(z_distance);
+  assert(data_grid_fiber_trans);
+
+  const double eff = data_grid_fiber_trans->Interpolate(z_distance);
+
+  data_grid_fiber_trans_verify->SetBinContent( //
+      data_grid_fiber_trans_verify->GetXaxis()->FindBin(z_distance), //
+      eff //
+      );
+
+  return eff;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
@@ -41,7 +41,42 @@ class PHG4FullProjSpacalCellReco : public SubsysReco
   void   set_timing_window_defaults(const double tmin, const double tmax) {
     tmin_default = tmin; tmax_default = tmax;
   }
-  
+
+  class LightCollectionModel
+  {
+  public:
+    LightCollectionModel();
+    virtual ~LightCollectionModel();
+
+    //! input data file
+    void load_data_file(const std::string & input_file, const std::string & histogram_light_guide_model, const std::string & histogram_fiber_model);
+
+    //! Whether use light collection model
+    bool use_light_guide_model() {return data_grid_light_guide_efficiency != NULL;}
+
+    //! Whether use Light Transmission Efficiency model for the fiber
+    bool use_fiber_model() {return data_grid_fiber_trans != NULL;}
+
+    //! get Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
+    double get_light_guide_efficiency(const double x_fraction, const double y_fraction);
+
+    //! get Light Transmission Efficiency for the fiber as function of z position (cm) in the fiber. Z=0 is at the middle of the fiber
+    double get_fiber_transmission(const double z_distance);
+
+  private:
+    //! 2-D data grid for Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
+    TH2 * data_grid_light_guide_efficiency;
+
+    //! 1-D data grid for the light transmission efficiency in the fiber as function of distance to location in the fiber. Z=0 is at the middle of the fiber
+    TH1 * data_grid_fiber_trans;
+
+    TH2 * data_grid_light_guide_efficiency_verify;
+    TH1 * data_grid_fiber_trans_verify;
+
+  };
+
+  LightCollectionModel & get_light_collection_model () {return light_collection_model;}
+
  protected:
 
   int CheckEnergy(PHCompositeNode *topNode);
@@ -60,35 +95,6 @@ class PHG4FullProjSpacalCellReco : public SubsysReco
   double tmin_default;
   double tmax_default;
   std::map<int, std::pair<double,double> > tmin_max;
-
-  class LightCollectionModel
-  {
-  public:
-    LightCollectionModel();
-    virtual ~LightCollectionModel();
-
-    //! input data file
-    void load_data_file(std::string input_file, std::string histogram_light_guide_model, std::string histogram_fiber_model);
-
-    //! Whether use light collection model
-    bool use_light_guide_model() {return data_grid_light_guide_efficiency != NULL;}
-
-    //! Whether use Light Transmission Efficiency model for the fiber
-    bool use_fiber_model() {return data_grid_fiber_trans != NULL;}
-
-    //! get Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
-    double get_light_guide_efficiency(const double x_fraction, const double y_fraction);
-
-    //! get Light Transmission Efficiency for the fiber as function of z position (cm) in the fiber away from the readout end
-    double get_fiber_transmission(const double z_distance);
-
-  private:
-    //! 2-D data grid for Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
-    TH2 * data_grid_light_guide_efficiency;
-
-//    //! 1-D data grid for the light transmission efficiency in the fiber as function of distance to the readout end
-    TH1 * data_grid_fiber_trans;
-  };
 
   LightCollectionModel light_collection_model;
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
@@ -9,6 +9,8 @@
 
 class PHCompositeNode;
 class PHG4CylinderCell;
+class TH2;
+class TH1;
 
 class PHG4FullProjSpacalCellReco : public SubsysReco
 {
@@ -58,6 +60,38 @@ class PHG4FullProjSpacalCellReco : public SubsysReco
   double tmin_default;
   double tmax_default;
   std::map<int, std::pair<double,double> > tmin_max;
+
+  class LightCollectionModel
+  {
+  public:
+    LightCollectionModel();
+    virtual ~LightCollectionModel();
+
+    //! input data file
+    void load_data_file(std::string input_file, std::string histogram_light_guide_model, std::string histogram_fiber_model);
+
+    //! Whether use light collection model
+    bool use_light_guide_model() {return data_grid_light_guide_efficiency != NULL;}
+
+    //! Whether use Light Transmission Efficiency model for the fiber
+    bool use_fiber_model() {return data_grid_fiber_trans != NULL;}
+
+    //! get Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
+    double get_light_guide_efficiency(const double x_fraction, const double y_fraction);
+
+    //! get Light Transmission Efficiency for the fiber as function of z position (cm) in the fiber away from the readout end
+    double get_fiber_transmission(const double z_distance);
+
+  private:
+    //! 2-D data grid for Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
+    TH2 * data_grid_light_guide_efficiency;
+
+//    //! 1-D data grid for the light transmission efficiency in the fiber as function of distance to the readout end
+    TH1 * data_grid_fiber_trans;
+  };
+
+  LightCollectionModel light_collection_model;
+
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellRecoLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellRecoLinkDef.h
@@ -1,5 +1,6 @@
 #ifdef __CINT__
 
 #pragma link C++ class PHG4FullProjSpacalCellReco-!;
+#pragma link C++ class PHG4FullProjSpacalCellReco::LightCollectionModel-!;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSteppingAction.cc
@@ -137,6 +137,13 @@ PHG4SpacalPrototypeSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
         // time in ns
         hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+
+        if (isactive == PHG4SpacalPrototypeDetector::FIBER_CORE) // only for active areas
+          {
+            // store all pre local coordinates
+            StoreLocalCoorindate(hit, aStep, true, false);
+          }
+
 	//set the track ID
 	{
 	  hit->set_trkid(aTrack->GetTrackID());
@@ -206,6 +213,13 @@ PHG4SpacalPrototypeSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       hit->set_z(1, postPoint->GetPosition().z() / cm);
 
       hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+
+      if (isactive == PHG4SpacalPrototypeDetector::FIBER_CORE) // only for active areas
+        {
+          // store all pre local coordinates
+          StoreLocalCoorindate(hit, aStep, false, true);
+        }
+
       //sum up the energy to get total deposited
       hit->set_edep(hit->get_edep() + edep);
 

--- a/simulation/g4simulation/g4main/PHG4Hit.cc
+++ b/simulation/g4simulation/g4main/PHG4Hit.cc
@@ -76,6 +76,18 @@ PHG4Hit::get_property_info(const PROPERTY prop_id)
     return make_pair("pz in",PHG4Hit::type_float);
   case   prop_pz_1:
     return make_pair("pz out",PHG4Hit::type_float);
+  case   prop_local_x_0:
+    return make_pair("local x in",PHG4Hit::type_float);
+  case   prop_local_x_1:
+    return make_pair("local x out",PHG4Hit::type_float);
+  case   prop_local_y_0:
+    return make_pair("local y in",PHG4Hit::type_float);
+  case   prop_local_y_1:
+    return make_pair("local y out",PHG4Hit::type_float);
+  case   prop_local_z_0:
+    return make_pair("local z in",PHG4Hit::type_float);
+  case   prop_local_z_1:
+    return make_pair("local z out",PHG4Hit::type_float);
   case   prop_path_length:
     return make_pair("pathlength",PHG4Hit::type_float);
   case   prop_layer:
@@ -101,7 +113,7 @@ PHG4Hit::get_property_info(const PROPERTY prop_id)
   case   prop_index_l:
     return make_pair("generic index l",PHG4Hit::type_int);
   default:
-    cout << "unknown index " << prop_id << endl;
+    cout << "PHG4Hit::get_property_info - Fatal Error - unknown index " << prop_id << endl;
     exit(1);
   }
 }

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -23,6 +23,9 @@ class PHG4Hit: public PHObject
   virtual float get_px(const int i) const {return NAN;}
   virtual float get_py(const int i) const {return NAN;}
   virtual float get_pz(const int i) const {return NAN;}
+  virtual float get_local_x(const int i) const {return NAN;}
+  virtual float get_local_y(const int i) const {return NAN;}
+  virtual float get_local_z(const int i) const {return NAN;}
   virtual float get_t(const int i) const {return NAN;}
   virtual float get_edep() const {return NAN;}
   virtual float get_eion() const {return NAN;}
@@ -49,6 +52,9 @@ class PHG4Hit: public PHObject
   virtual void set_px(const int i, const float f) {return;}
   virtual void set_py(const int i, const float f) {return;}
   virtual void set_pz(const int i, const float f) {return;}
+  virtual void set_local_x(const int i, const float f) {return;}
+  virtual void set_local_y(const int i, const float f) {return;}
+  virtual void set_local_z(const int i, const float f) {return;}
   virtual void set_t(const int i, const float f) {return;}
   virtual void set_edep(const float f) {return;}
   virtual void set_eion(const float f) {return;}
@@ -77,7 +83,9 @@ class PHG4Hit: public PHObject
   virtual void print() const {std::cout<<"PHG4Hit base class - print() not implemented"<<std::endl;}
 
 
-  //! add a short name to PHG4Hit::get_property_name
+  //! Procedure to add a new PROPERTY tag:
+  //! 1.add new tag below with unique value,
+  //! 2.add a short name to PHG4Hit::get_property_info
   enum PROPERTY 
   {//
 
@@ -100,6 +108,14 @@ class PHG4Hit: public PHObject
 
     //! pathlength
     prop_path_length = 16,
+
+    //! local coordinate
+    prop_local_x_0 = 20,
+    prop_local_x_1 = 21,
+    prop_local_y_0 = 22,
+    prop_local_y_1 = 23,
+    prop_local_z_0 = 24,
+    prop_local_z_1 = 25,
 
     //-- detector specific IDs: 100+ --
 

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -268,3 +268,100 @@ PHG4Hitv1::set_pz(const int i, const float f)
       exit(1);
     }
 }
+
+
+float
+PHG4Hitv1::get_local_x(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_local_x_0);
+    case 1:
+      return  get_property_float(prop_local_x_1);
+    default:
+      cout << "Invalid index in get_local_x: " << i << endl;
+      exit(1);
+    }
+}
+
+float
+PHG4Hitv1::get_local_y(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_local_y_0);
+    case 1:
+      return  get_property_float(prop_local_y_1);
+    default:
+      cout << "Invalid index in get_local_y: " << i << endl;
+      exit(1);
+    }
+}
+
+float
+PHG4Hitv1::get_local_z(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_local_z_0);
+    case 1:
+      return  get_property_float(prop_local_z_1);
+    default:
+      cout << "Invalid index in get_local_z: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+PHG4Hitv1::set_local_x(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_local_x_0,f);
+      return;
+    case 1:
+      set_property(prop_local_x_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_local_x: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+PHG4Hitv1::set_local_y(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_local_y_0,f);
+      return;
+    case 1:
+      set_property(prop_local_y_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_local_y: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+PHG4Hitv1::set_local_z(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_local_z_0,f);
+      return;
+    case 1:
+      set_property(prop_local_z_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_local_z: " << i << endl;
+      exit(1);
+    }
+}

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -50,6 +50,9 @@ class PHG4Hitv1 : public PHG4Hit
   virtual float get_px(const int i) const;
   virtual float get_py(const int i) const;
   virtual float get_pz(const int i) const;
+  virtual float get_local_x(const int i) const;
+  virtual float get_local_y(const int i) const;
+  virtual float get_local_z(const int i) const;
   virtual float get_eion() const          {return  get_property_float(prop_eion);}
   virtual float get_light_yield() const   {return  get_property_float(prop_light_yield);}
   virtual float get_path_length() const {return  get_property_float(prop_path_length);}
@@ -68,6 +71,9 @@ class PHG4Hitv1 : public PHG4Hit
   virtual void set_px(const int i, const float f);
   virtual void set_py(const int i, const float f);
   virtual void set_pz(const int i, const float f);
+  virtual void set_local_x(const int i, const float f);
+  virtual void set_local_y(const int i, const float f);
+  virtual void set_local_z(const int i, const float f);
   virtual void set_eion(const float f)            {set_property(prop_eion,f);}
   virtual void set_light_yield(const float f)           {set_property(prop_light_yield,f);}
   virtual void set_path_length(const float f)           {set_property(prop_path_length,f);}

--- a/simulation/g4simulation/g4main/PHG4SteppingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4SteppingAction.cc
@@ -14,8 +14,16 @@
 #include <Geant4/G4Track.hh>
 #include <Geant4/G4LossTableManager.hh>
 #include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4StepPoint.hh>
+#include <Geant4/G4TouchableHandle.hh>
+#include <Geant4/G4ThreeVector.hh>
+#include <Geant4/G4NavigationHistory.hh>
+
+
+#include <g4main/PHG4Hit.h>
 
 #include <iostream>
+#include <cassert>
 
 using namespace std;
 
@@ -105,6 +113,44 @@ PHG4SteppingAction::GetVisibleEnergyDeposition(const G4Step* step)
 
       return 0;
     }
+}
+
+void
+PHG4SteppingAction::StoreLocalCoorindate(PHG4Hit * hit, const G4Step* aStep,
+    bool do_prepoint, bool do_postpoint)
+{
+  assert(hit);
+  assert(aStep);
+
+  if (do_prepoint)
+    {
+      G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
+
+      G4TouchableHandle theTouchable = preStepPoint->GetTouchableHandle();
+      G4ThreeVector worldPosition = preStepPoint->GetPosition();
+      G4ThreeVector localPosition =
+          theTouchable->GetHistory()->GetTopTransform().TransformPoint(
+              worldPosition);
+
+      hit->set_local_x(0, localPosition.x() / cm);
+      hit->set_local_y(0, localPosition.y() / cm);
+      hit->set_local_z(0, localPosition.z() / cm);
+    }
+  if (do_postpoint)
+    {
+      G4StepPoint * postPoint = aStep->GetPostStepPoint();
+
+      G4TouchableHandle theTouchable = postPoint->GetTouchableHandle();
+      G4ThreeVector worldPosition = postPoint->GetPosition();
+      G4ThreeVector localPosition =
+          theTouchable->GetHistory()->GetTopTransform().TransformPoint(
+              worldPosition);
+
+      hit->set_local_x(1, localPosition.x() / cm);
+      hit->set_local_y(1, localPosition.y() / cm);
+      hit->set_local_z(1, localPosition.z() / cm);
+    }
+
 }
 
 bool

--- a/simulation/g4simulation/g4main/PHG4SteppingAction.h
+++ b/simulation/g4simulation/g4main/PHG4SteppingAction.h
@@ -7,6 +7,7 @@
 
 class G4Step;
 class PHCompositeNode;
+class PHG4Hit;
 
 class PHG4SteppingAction
 {
@@ -37,6 +38,9 @@ class PHG4SteppingAction
 
   //! get amount of energy that can make scintillation light, in Unit of GeV.
   virtual double GetVisibleEnergyDeposition(const G4Step* step);
+
+  //! Extract local coordinate of the hit and save to PHG4Hit
+  virtual void StoreLocalCoorindate(PHG4Hit * hit, const G4Step* step, bool do_prepoint, bool do_postpoint);
 
   virtual void flush_cached_values() {return;}
 


### PR DESCRIPTION
## What's new

As preparation to the coming test beam workfest, this pull request puts SPACAL simulation to a near final shape by introducing scintillation light collection model that handles both fiber attenuation and light guide position dependent efficiency.

Also as a general service, this pull request introduce calculation and storage of local coordinates via commit ac9ae806aaa29d3c774830a16dfd4b0c3e694a91, which would be useful for light collection efficiency calculation for HCal and Digitization for MAPS tracker. 

## Inputs

### Light attenuation in fiber

Sean Stoll (BNL) extracted effective light attenuation for SCSF-78 scintillation fiber from manufacture spec curves to be 105 cm. To be confirmed with our measurements. The reflection at the non-readout end is ~30%. Together, the relative light collection efficiency along length position on the fiber is as plotted below and saved to calibration database:
![loadscsf78fiber](https://cloud.githubusercontent.com/assets/7947083/16697415/8ba973d6-4517-11e6-9946-57802e7f3522.png)

### Light collection in light guide 

Mike Phillips simulated light collection efficiency in test beam light guide in Geant4 as function of input location (left). It is converted to relative collection efficiency via re-binning and smoothing (middle). And the spread from bin-to-bin is histogrammed on the right.

![loadmikephippslightguideeffupdated](https://cloud.githubusercontent.com/assets/7947083/16697496/e5acdab2-4517-11e6-9eeb-59a7ebebb7e0.png)

## Results

By using the light collection variation and use a wider beam spot as observed in test beam, the reference energy resolution from simulation gets a bit worse for both constant and statistical term. It is now more closer to that observed in data too (https://wiki.bnl.gov/sPHENIX/index.php/T-1044/EMCal_good_run_note#Energy_scans). 

![drawemcaltower_resolution_compare](https://cloud.githubusercontent.com/assets/7947083/16697286/f39f89d6-4516-11e6-84d8-caf0c5df7673.png)

## Related pull requests
* Calibration repository: histogram containing the relative light collection efficiency 
* Macro repository: enable use of light collection. If not updated, by default these light collection model is not used to be consistent with before. 

## Plan

Plan is that if there is objection in the next few days, this pull request will be merged and ready to use in test beam workfest. 