### PR TITLE
 add support for pmas setting

### DIFF
--- a/generators/PHPythia6/PHPythia6.C
+++ b/generators/PHPythia6/PHPythia6.C
@@ -291,7 +291,15 @@ int PHPythia6::ReadConfig(const string cfg_file) {
       pydat3.mdme[index-1][idc-1] = value; 
       cout << "mdme\t" << idc << " " << index << " " << value << endl;
     }
-    else
+    else if ( label == "pmas" )
+    {
+      int idc = 0;          
+      line >> idc >> index >> value;
+      
+      pydat2.pmas[index-1][idc-1] = value; 
+      cout << "pmas\t" << idc << " " << index << " " << value << endl;
+    }
+     else
       {
 	// label was not understood
 	cout << "************************************************************" << endl;


### PR DESCRIPTION
Added support for the pmas setting; we use this to set the charm and bottom quark mass when it's important to match to data....