### PR TITLE
Add event header for test beam analysis produciton

### DIFF
--- a/offline/packages/Prototype2/EventHeader_Prototype2.C
+++ b/offline/packages/Prototype2/EventHeader_Prototype2.C
@@ -1,0 +1,38 @@
+#include "EventHeader_Prototype2.h"
+
+using namespace std;
+
+ClassImp(EventHeader_Prototype2)
+
+EventHeader_Prototype2::EventHeader_Prototype2()
+{
+  Reset();
+  return;
+}
+
+void 
+EventHeader_Prototype2::Reset()
+{
+  TimeStamp = 0;
+  EvtSequence = -999999;
+  EvtType = -999999;
+  return;
+}
+
+void 
+EventHeader_Prototype2::identify(ostream& out) const
+{
+  out << "identify yourself: I am an EventHeader_Prototype2 Object" << endl;
+  out << "Event no: " << EvtSequence 
+      << ", Type: " << EvtType 
+      << ", RCDAQ arrival time: " << ctime(&TimeStamp)
+      << endl;
+
+  return;
+}
+
+int 
+EventHeader_Prototype2::isValid() const
+{
+  return((TimeStamp) ? 1:0); // return 1 if TimeStamp is not zero
+}

--- a/offline/packages/Prototype2/EventHeader_Prototype2.h
+++ b/offline/packages/Prototype2/EventHeader_Prototype2.h
@@ -1,0 +1,58 @@
+#ifndef EventHeader_Prototype2_H
+#define EventHeader_Prototype2_H
+
+#include <phool/PHObject.h>
+
+#include <ctime>
+#include <iostream>
+
+//! EventHeader specific for prototype2 beam tests
+class EventHeader_Prototype2: public PHObject
+{
+ public:
+
+  /// ctor
+  EventHeader_Prototype2();
+  /// dtor
+  virtual ~EventHeader_Prototype2() {}
+
+  EventHeader_Prototype2 * clone() const { return new EventHeader_Prototype2(*this); }
+
+  ///  Clear Event
+  void Reset();
+
+
+  /** identify Function from PHObject
+      @param os Output Stream 
+   */
+  void identify(std::ostream& os = std::cout) const;
+
+  /// isValid returns non zero if object contains valid data
+  int isValid() const;
+
+  /// get Event Number
+  int get_EvtSequence() const {return EvtSequence;}
+  /// set Event Number
+  void set_EvtSequence(const int evtno) {EvtSequence=evtno; return;}
+
+  /// get Event Type (Data,rejected,EOR,BOR,...)
+  int get_EvtType() const {return EvtType;}
+  /// set Event Type (Data,rejected,EOR,BOR,...)
+  void set_EvtType(const int ival) {EvtType = ival; return;}
+
+  /// get ATP TimeStamp (unix time, convert with ctime() to date string 
+  time_t  get_TimeStamp() const {return TimeStamp;}
+  /// set ATP TimeStamp
+  void set_TimeStamp(const time_t evttime) {TimeStamp = evttime; return;}
+
+ protected:
+
+  int EvtSequence;  // Event number
+  int EvtType;      // Data type (Data,Rejected,Scaler,PPG ...)
+  time_t TimeStamp;  // TimeStamp of Evt
+
+ private: // prevent doc++ from showing ClassDef
+  ClassDef(EventHeader_Prototype2,1)
+};
+
+#endif

--- a/offline/packages/Prototype2/EventHeader_Prototype2LinkDef.h
+++ b/offline/packages/Prototype2/EventHeader_Prototype2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class EventHeader_Prototype2+;
+
+#endif /* __CINT__ */

--- a/offline/packages/Prototype2/Makefile.am
+++ b/offline/packages/Prototype2/Makefile.am
@@ -17,7 +17,8 @@ lib_LTLIBRARIES = \
 pkginclude_HEADERS = \
   RawTower_Prototype2.h \
   RawTower_Temperature.h \
-  EventHeader_Prototype2.h
+  EventHeader_Prototype2.h \
+  PROTOTYPE2_FEM.h
 
 libPrototype2_la_SOURCES = \
   RawTower_Prototype2.cc \

--- a/offline/packages/Prototype2/Makefile.am
+++ b/offline/packages/Prototype2/Makefile.am
@@ -16,7 +16,8 @@ lib_LTLIBRARIES = \
 
 pkginclude_HEADERS = \
   RawTower_Prototype2.h \
-  RawTower_Temperature.h 
+  RawTower_Temperature.h \
+  EventHeader_Prototype2.h
 
 libPrototype2_la_SOURCES = \
   RawTower_Prototype2.cc \
@@ -36,7 +37,9 @@ libPrototype2_la_SOURCES = \
   PROTOTYPE2_FEM.C \
   PROTOTYPE2_FEMDict.cc \
   RawTower_Temperature.cc \
-  RawTower_TemperatureDict.cc
+  RawTower_TemperatureDict.cc \
+  EventHeader_Prototype2.cc \
+  EventHeader_Prototype2Dict.cc
 
 libPrototype2_la_LIBADD = \
   -lSubsysReco \

--- a/offline/packages/Prototype2/RawTower_Prototype2.h
+++ b/offline/packages/Prototype2/RawTower_Prototype2.h
@@ -5,7 +5,8 @@
 #include <g4cemc/RawTowerDefs.h>
 #include <map>
 #include <stdint.h>
-#include "PROTOTYPE2_FEM.h"
+
+#include <prototype2/PROTOTYPE2_FEM.h>
 
 class RawTower_Prototype2 : public RawTower {
  public:

--- a/offline/packages/Prototype2/RunInfoUnpackPRDF.C
+++ b/offline/packages/Prototype2/RunInfoUnpackPRDF.C
@@ -1,4 +1,5 @@
 #include "RunInfoUnpackPRDF.h"
+#include "EventHeader_Prototype2.h"
 
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
@@ -17,6 +18,8 @@
 #include <cassert>
 
 using namespace std;
+
+typedef PHIODataNode <PHObject> PHObjectNode_t;
 
 //____________________________________
 RunInfoUnpackPRDF::RunInfoUnpackPRDF() :
@@ -51,69 +54,86 @@ RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::DISCARDEVENT;
     }
 
+  // construct event info
+  EventHeader_Prototype2* eventheader = findNode::getClass<
+      EventHeader_Prototype2>(topNode, "EventHeader_Prototype2");
+  if (eventheader)
+    {
+      eventheader->set_EvtSequence(event->getEvtSequence());
+      eventheader->set_EvtType(event->getEvtType());
+      eventheader->set_TimeStamp(event->getTime());
+      if (verbosity)
+        {
+          eventheader->identify();
+        }
+    }
+
+  // search for run info
   if (event->getEvtType() != BEGRUNEVENT)
     return Fun4AllReturnCodes::EVENT_OK;
-
-  if (verbosity >= VERBOSITY_SOME)
+  else
     {
-
-      cout << "RunInfoUnpackPRDF::process_event - ";
-      event->identify();
-    }
-
-  map<int, Packet*> packet_list;
-
-  PHG4Parameters Params("RunInfo");
-
-  for (typ_channel_map::const_iterator it = channel_map.begin();
-      it != channel_map.end(); ++it)
-    {
-      const string & name = it->first;
-      const channel_info & info = it->second;
-
-      if (packet_list.find(info.packet_id) == packet_list.end())
-        {
-          packet_list[info.packet_id] = event->getPacket(info.packet_id);
-        }
-
-      Packet * packet = packet_list[info.packet_id];
-
-      if (!packet)
-        {
-//          if (Verbosity() >= VERBOSITY_SOME)
-          cout << "RunInfoUnpackPRDF::process_event - failed to locate packet "
-              << info.packet_id << " from ";
-          event->identify();
-
-          Params.set_double_param(name, NAN);
-          continue;
-        }
-
-      const int ivalue = packet->iValue(info.offset);
-
-      const double dvalue = ivalue * info.calibration_const;
-
       if (verbosity >= VERBOSITY_SOME)
         {
-          cout << "RunInfoUnpackPRDF::process_event - " << name << " = "
-              << dvalue << ", raw = " << ivalue << " @ packet "
-              << info.packet_id << ", offset " << info.offset << endl;
+          cout << "RunInfoUnpackPRDF::process_event - with BEGRUNEVENT events ";
+          event->identify();
         }
 
-      Params.set_double_param(name, dvalue);
+      map<int, Packet*> packet_list;
+
+      PHG4Parameters Params("RunInfo");
+
+      for (typ_channel_map::const_iterator it = channel_map.begin();
+          it != channel_map.end(); ++it)
+        {
+          const string & name = it->first;
+          const channel_info & info = it->second;
+
+          if (packet_list.find(info.packet_id) == packet_list.end())
+            {
+              packet_list[info.packet_id] = event->getPacket(info.packet_id);
+            }
+
+          Packet * packet = packet_list[info.packet_id];
+
+          if (!packet)
+            {
+//          if (Verbosity() >= VERBOSITY_SOME)
+              cout
+                  << "RunInfoUnpackPRDF::process_event - failed to locate packet "
+                  << info.packet_id << " from ";
+              event->identify();
+
+              Params.set_double_param(name, NAN);
+              continue;
+            }
+
+          const int ivalue = packet->iValue(info.offset);
+
+          const double dvalue = ivalue * info.calibration_const;
+
+          if (verbosity >= VERBOSITY_SOME)
+            {
+              cout << "RunInfoUnpackPRDF::process_event - " << name << " = "
+                  << dvalue << ", raw = " << ivalue << " @ packet "
+                  << info.packet_id << ", offset " << info.offset << endl;
+            }
+
+          Params.set_double_param(name, dvalue);
+        }
+
+      for (map<int, Packet*>::iterator it = packet_list.begin();
+          it != packet_list.end(); ++it)
+        {
+          if (it->second)
+            delete it->second;
+        }
+
+      Params.SaveToNodeTree(topNode, runinfo_node_name);
+
+      if (verbosity >= VERBOSITY_SOME)
+        Params.Print();
     }
-
-  for (map<int, Packet*>::iterator it = packet_list.begin();
-      it != packet_list.end(); ++it)
-    {
-      if (it->second)
-        delete it->second;
-    }
-
-  Params.SaveToNodeTree(topNode, runinfo_node_name);
-
-  if (verbosity >= VERBOSITY_SOME) Params.Print();
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -140,6 +160,19 @@ RunInfoUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
           new PHIODataNode<PdbParameterMap>(new PdbParameterMap(),
               runinfo_node_name));
     }
+
+  //DST node
+  PHCompositeNode* dst_node = static_cast<PHCompositeNode*>( nodeItr.findFirst("PHCompositeNode", "DST" ));
+  if(!dst_node)
+  {
+    cout << "PHComposite node created: DST" << endl;
+    dst_node  = new PHCompositeNode( "DST" );
+    topNode->addNode( dst_node );
+  }
+
+  EventHeader_Prototype2* eventheader = new EventHeader_Prototype2();
+  PHObjectNode_t *EventHeaderNode = new PHObjectNode_t(eventheader, "EventHeader_Prototype2", "PHObject"); // contain PHObject
+  dst_node->addNode(EventHeaderNode);
 
 }
 

--- a/offline/packages/Prototype2/RunInfoUnpackPRDF.C
+++ b/offline/packages/Prototype2/RunInfoUnpackPRDF.C
@@ -56,7 +56,7 @@ RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
 
   // construct event info
   EventHeader_Prototype2* eventheader = findNode::getClass<
-      EventHeader_Prototype2>(topNode, "EventHeader_Prototype2");
+      EventHeader_Prototype2>(topNode, "EventHeader");
   if (eventheader)
     {
       eventheader->set_EvtSequence(event->getEvtSequence());
@@ -171,7 +171,7 @@ RunInfoUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
   }
 
   EventHeader_Prototype2* eventheader = new EventHeader_Prototype2();
-  PHObjectNode_t *EventHeaderNode = new PHObjectNode_t(eventheader, "EventHeader_Prototype2", "PHObject"); // contain PHObject
+  PHObjectNode_t *EventHeaderNode = new PHObjectNode_t(eventheader, "EventHeader", "PHObject"); // contain PHObject
   dst_node->addNode(EventHeaderNode);
 
 }

--- a/offline/packages/Prototype2/RunInfoUnpackPRDF.C
+++ b/offline/packages/Prototype2/RunInfoUnpackPRDF.C
@@ -1,3 +1,5 @@
+#include "RunInfoUnpackPRDF.h"
+
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
 #include <Event/packetConstants.h>
@@ -13,7 +15,6 @@
 #include <iostream>
 #include <string>
 #include <cassert>
-#include "RunInfoUnpackPRDF.h"
 
 using namespace std;
 

--- a/offline/packages/Prototype2/configure.in
+++ b/offline/packages/Prototype2/configure.in
@@ -1,4 +1,4 @@
-AC_INIT(hcal_dst,[1.00])
+AC_INIT(prototype2,[1.00])
 AC_CONFIG_SRCDIR([configure.in])
 AM_INIT_AUTOMAKE
 


### PR DESCRIPTION
From Test Beam workfest, adding event header to DST which store event number, type and timestampe. The immediate goals is to allow analysis code etrieve event time for use in temperature correction. 

Also the header installation location is updated to prototype2, e.g. inclusion of the EventHeader uses #include <prototype2/EventHeader_Prototype2.h>

## Example check

An example DST production from PRDF can be run using the default macro on RCF: 
https://github.com/sPHENIX-Collaboration/macros/blob/master/macros/prototype2/Fun4All_TestBeam.C 

From the DST output (./data/beam_00002609.root), the event header could be interactively printed via 
```
[jinhuang@rcas2073 macros]$ root
root [0]   gSystem->Load("libPrototype2.so");
root [2] TFile *_file0 = TFile::Open("data/beam_00002609.root")
root [3] T->Scan("DST.EventHeader.identify()")
************************
*    Row   * DST.Event *
************************
identify yourself: I am an EventHeader_Prototype2 Object
Event no: 2, Type: 1, RCDAQ arrival time: Wed Apr 27 19:21:33 2016
*        0 *         0 *
identify yourself: I am an EventHeader_Prototype2 Object
Event no: 3, Type: 1, RCDAQ arrival time: Wed Apr 27 19:21:33 2016
...
```

Or it can be plotted interactively:
```
T->Draw("DST.EventHeader.TimeStamp:DST.EventHeader.EvtSequence>>h2")
```

For formal analysis, a Fun4All analysis module is suggested. The event header can be fetched via DST node DST.EventHeader, like the standard PHENIX event headers.
```c++
#include <prototype2/EventHeader_Prototype2.h>
process_event(PHCompositeNode *topNode)
{
...
EventHeader_Prototype2 *eventheader = getClass<EventHeader_Prototype2> (topNode, "EventHeader");
...
}
```