### PR TITLE
Bug fix on local coordinate calculation

### DIFF
--- a/simulation/g4simulation/g4main/PHG4SteppingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4SteppingAction.cc
@@ -122,11 +122,12 @@ PHG4SteppingAction::StoreLocalCoorindate(PHG4Hit * hit, const G4Step* aStep,
   assert(hit);
   assert(aStep);
 
+  G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
+  G4TouchableHandle theTouchable = preStepPoint->GetTouchableHandle();
+
   if (do_prepoint)
     {
-      G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
 
-      G4TouchableHandle theTouchable = preStepPoint->GetTouchableHandle();
       G4ThreeVector worldPosition = preStepPoint->GetPosition();
       G4ThreeVector localPosition =
           theTouchable->GetHistory()->GetTopTransform().TransformPoint(
@@ -140,7 +141,6 @@ PHG4SteppingAction::StoreLocalCoorindate(PHG4Hit * hit, const G4Step* aStep,
     {
       G4StepPoint * postPoint = aStep->GetPostStepPoint();
 
-      G4TouchableHandle theTouchable = postPoint->GetTouchableHandle();
       G4ThreeVector worldPosition = postPoint->GetPosition();
       G4ThreeVector localPosition =
           theTouchable->GetHistory()->GetTopTransform().TransformPoint(


### PR DESCRIPTION
This pull request introduce a bug fix for local coordinate calculation utility.

## What's fixed

Local coordinate calculation was introduced in #173 to the base class of ```PHG4SteppingAction```. Tony @adfrawley  reported the exit point calculation is wrong for the on-going MAPS detector development. This problem was traced down to the translation matrix for the exit point of PHG4Hit used the next logical volume passing the sensitive volume. Fix was straight forward: use the pre-step's translation matrix for glocal-to-local transformation of both pre- and post-points. 

## Verification

Currently two subsystem uses this local coordinates translation. Both are checked:

### Scintillation model in SPACAL fiber 

Local x-y coordinate of exit point is plotted here for PHG4Hits in SPACAL fibers in one electron shower. It shows a nice circular shell for at the radius of fiber core. This check did not reveal this bug before the fix because the next volume pass the fiber core is fiber cladding, which share the identical glocal-to-local transform matrix as the core.

<img width="317" alt="2016-07-20 23_54_03-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/17026943/e3ca82ea-4f2f-11e6-8ac3-2798c18607c9.png">

### MAPS digitization in sensor

@adfrawley uses local coordinate in MAPS sensor to determine pixel hit. After this fix, the entry (black) and exit (red) points show up at the front and back surface of the sensor volume (y = +/- 10 um), except for very few secondary production in the sensor. The local x-y location nicely cover the surface of a sensor, which will be converted to pixel number. 

<img width="491" alt="2016-07-21 10_40_44-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/17027104/92d208b2-4f30-11e6-91ea-e0e9f151b23c.png">

