### PR TITLE
back-ported a long-standing fix from the PHENIX side

### DIFF
--- a/online_distribution/newbasic/oncsBuffer.cc
+++ b/online_distribution/newbasic/oncsBuffer.cc
@@ -170,10 +170,14 @@ Event * oncsBuffer::getEvent()
   Event *evt;
   evt =  new oncsEvent( &bptr->data[current_index]);
 
+  
+  int l =  evt->getEvtLength();
+  if ( l<= 0) return 0;
   current_index += evt->getEvtLength();
 
   // now is the new index pointing outside the allocated memory?
-  if (current_index < 0 || current_index > BUFFERSIZE)
+  //  if (current_index < 0 || current_index > BUFFERSIZE)
+  if (current_index < 0 || current_index >= buffer_size)
     {
       //COUT << "end of buffer r1" << current_index << std::endl;
       current_index = -1;


### PR DESCRIPTION
that ended the buffer processing prematurely. Don't know why the bug persisted here.
It manifests itself by missing event numbers when one writes "oncs-format" data. The bug had already been fixed in April while we were at Fermilab. It is only at the decoding stage so so data are affected.