### PR TITLE
Initial z-vtxing for MAPS+TPC configuration

### DIFF
--- a/offline/packages/HelixHough/helix_hough/HelixHough.h
+++ b/offline/packages/HelixHough/helix_hough/HelixHough.h
@@ -291,6 +291,8 @@ class HelixHough
     std::vector<HelixKalmanState> seed_states;
     
     unsigned int n_layers;
+    int layer_start;
+    int layer_end;
     bool smooth_back;
     bool cull_input_hits;
     bool iterate_clustering;

--- a/offline/packages/HelixHough/helix_hough/HelixHough_findHelices.cpp
+++ b/offline/packages/HelixHough/helix_hough/HelixHough_findHelices.cpp
@@ -87,7 +87,7 @@ static inline void setClusterRange(HelixRange& range1, HelixRange& range2,
   range2.max_z0 = range1.min_z0 + z0_size * ((float)(prange.max_z0 + 1));
 }
 
-void HelixHough::findHelices(vector<SimpleHit3D>& hits, unsigned int min_hits,
+void HelixHough::findHelices(vector<SimpleHit3D>& hits_init, unsigned int min_hits,
                              unsigned int max_hits,
                              vector<SimpleTrack3D>& tracks,
                              unsigned int maxtracks) {
@@ -95,6 +95,30 @@ void HelixHough::findHelices(vector<SimpleHit3D>& hits, unsigned int min_hits,
   xy_vote_time = 0.;
   z_vote_time = 0.;
   cluster_time = 0.;
+
+  vector<SimpleHit3D> hits;
+
+  if (layer_end > 0 && layer_start > 0){
+    for (unsigned int in = 0; in < hits_init.size(); in++) {
+    if(hits_init[in].get_layer() > layer_start-1 && hits_init[in].get_layer() < layer_end+1 )
+    hits.push_back(hits_init[in]);
+    }
+  } else if ( layer_end < 0 && layer_start > 0) {
+    for (unsigned int in = 0; in < hits_init.size(); in++) {
+    if(hits_init[in].get_layer() > layer_start-1)
+    hits.push_back(hits_init[in]);
+    }
+  } else if ( layer_end > 0 && layer_start < 0) {
+    for (unsigned int in = 0; in < hits_init.size(); in++) {
+    if( hits_init[in].get_layer() < layer_end+1 )
+    hits.push_back(hits_init[in]);
+    }
+  } else {
+    for (unsigned int in = 0; in < hits_init.size(); in++) {
+    hits.push_back(hits_init[in]);
+    }
+  }
+
 
   index_mapping.clear();
   index_mapping.resize(hits.size(), 0);

--- a/offline/packages/HelixHough/helix_hough/HelixHough_init.cpp
+++ b/offline/packages/HelixHough/helix_hough/HelixHough_init.cpp
@@ -12,7 +12,7 @@ HelixHough::HelixHough(unsigned int n_phi, unsigned int n_d, unsigned int n_k, u
 }
 
 
-HelixHough::HelixHough(vector<vector<unsigned int> >& zoom_profile, unsigned int minzoom, HelixRange& range) : vote_time(0.), xy_vote_time(0.), z_vote_time(0.), print_timings(false), separate_by_helicity(true), helicity(false), check_layers(false), req_layers(0), bin_scale(1.), z_bin_scale(1.), remove_hits(false), only_one_helicity(false), start_zoom(0), max_hits_pairs(0), cluster_start_bin(2), layers_at_a_time(4), n_layers(6), smooth_back(false), cull_input_hits(false), iterate_clustering(false)
+HelixHough::HelixHough(vector<vector<unsigned int> >& zoom_profile, unsigned int minzoom, HelixRange& range) : vote_time(0.), xy_vote_time(0.), z_vote_time(0.), print_timings(false), separate_by_helicity(true), helicity(false), check_layers(false), req_layers(0), bin_scale(1.), z_bin_scale(1.), remove_hits(false), only_one_helicity(false), start_zoom(0), max_hits_pairs(0), cluster_start_bin(2), layers_at_a_time(4), n_layers(6), layer_start(-1), layer_end(-1), smooth_back(false), cull_input_hits(false), iterate_clustering(false)
 {
   for(unsigned int i=0;i<hits_vec.size();i++){delete hits_vec[i];}
   hits_vec.clear();

--- a/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTrackerTPC.h
+++ b/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTrackerTPC.h
@@ -209,6 +209,7 @@ class sPHENIXTrackerTPC : public HelixHough {
                             std::vector<SimpleTrack3D>& tracks,
                             const HelixRange& range);  
   void initEvent(std::vector<SimpleHit3D>& hits, unsigned int min_hits) {
+
     int min_layer = 999999;
     int max_layer = 0;
     for (unsigned int i = 0; i < hits.size(); ++i) {
@@ -221,6 +222,7 @@ class sPHENIXTrackerTPC : public HelixHough {
     }
     setSeedLayer(min_layer);
     setNLayers(max_layer + 1);
+
 
     nfits = 0;
     combos.clear();
@@ -277,6 +279,24 @@ class sPHENIXTrackerTPC : public HelixHough {
   void setRejectGhosts(bool rg) { reject_ghosts = rg; }
 
   std::vector<float>& getIsolation() { return isolation_variable; }
+
+  static void calculateKappaTangents(
+      float* x1_a, float* y1_a, float* z1_a, float* x2_a, float* y2_a,
+      float* z2_a, float* x3_a, float* y3_a, float* z3_a, float* dx1_a,
+      float* dy1_a, float* dz1_a, float* dx2_a, float* dy2_a, float* dz2_a,
+      float* dx3_a, float* dy3_a, float* dz3_a, float* kappa_a, float* dkappa_a,
+      float* ux_mid_a, float* uy_mid_a, float* ux_end_a, float* uy_end_a,
+      float* dzdl_1_a, float* dzdl_2_a, float* ddzdl_1_a, float* ddzdl_2_a);
+  void calculateKappaTangents(
+      float* x1_a, float* y1_a, float* z1_a, float* x2_a, float* y2_a,
+      float* z2_a, float* x3_a, float* y3_a, float* z3_a, float* dx1_a,
+      float* dy1_a, float* dz1_a, float* dx2_a, float* dy2_a, float* dz2_a,
+      float* dx3_a, float* dy3_a, float* dz3_a, float* kappa_a, float* dkappa_a,
+      float* ux_mid_a, float* uy_mid_a, float* ux_end_a, float* uy_end_a,
+      float* dzdl_1_a, float* dzdl_2_a, float* ddzdl_1_a, float* ddzdl_2_a,
+      float sinang_cut, float cosang_diff_inv, float* cur_kappa_a,
+      float* cur_dkappa_a, float* cur_ux_a, float* cur_uy_a, float* cur_chi2_a,
+      float* chi2_a);
 
   void pairRejection(std::vector<SimpleTrack3D>& input,
                      std::vector<SimpleTrack3D>& output,
@@ -340,6 +360,15 @@ class sPHENIXTrackerTPC : public HelixHough {
         thread_trackers[i]->setRemoveHits(rh);
       }
     }
+  }
+
+
+  void setStartLayer(int start) {
+    layer_start = start;
+  }
+ 
+  void setEndLayer(int end) {
+    layer_end = end;
   }
 
   void setSeedLayer(int sl) {
@@ -432,7 +461,10 @@ class sPHENIXTrackerTPC : public HelixHough {
 
   void setRequirePixels(bool rp){require_pixels = rp;}
 
+
  private:
+  float kappaToPt(float kappa);
+  float ptToKappa(float pt);
   void findTracksByCombinatorialKalman(std::vector<SimpleHit3D>& hits,
                                        std::vector<SimpleTrack3D>& tracks,
                                        const HelixRange& range);
@@ -510,6 +542,7 @@ class sPHENIXTrackerTPC : public HelixHough {
   std::vector<float> hit_error_scale;
 
   bool require_pixels;
+
 };
 
 

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -70,6 +70,7 @@ PHG4HoughTransformTPC::PHG4HoughTransformTPC(unsigned int seed_layers, unsigned 
   _material(),
   _user_material(),
   _magField(1.5), ///< in Tesla
+  _use_bbc(true),
   _reject_ghosts(true), 
   _remove_hits(true), 
   _use_cell_size(false),
@@ -205,14 +206,14 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
   int code = translate_input();
   if (code != Fun4AllReturnCodes::EVENT_OK) return code;  
 
-  if (verbosity>0){
-  fast_vertex_from_bbc();
-  _vertex[2]=0.0;
-  }
-
   //------------------------------------
   // Find an initial z-vertex position
   //------------------------------------
+
+  if (verbosity>0 || _use_bbc){
+    fast_vertex_from_bbc();
+    if(!_use_bbc)  _vertex[2]=0.0;
+  }
 
   code = initial_zvertex_finding();
   if (code != Fun4AllReturnCodes::EVENT_OK) return code;

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -84,7 +84,8 @@ PHG4HoughTransformTPC::PHG4HoughTransformTPC(unsigned int seed_layers, unsigned 
   _chi2_cut_fast_par0(16.0),
   _chi2_cut_fast_par1(0.0),
   _chi2_cut_fast_max(FLT_MAX),
-  _chi2_cut_full(4.0),
+  _chi2_cut_init(3.0),
+  _chi2_cut_full(2.0),
   _ca_chi2_cut(4.0),
   _cos_angle_cut(0.985),
   _bin_scale(0.8), 
@@ -104,7 +105,6 @@ PHG4HoughTransformTPC::PHG4HoughTransformTPC(unsigned int seed_layers, unsigned 
   _track_covars(),
   _vertex(),
   _tracker(NULL),
-  _tracker_vertex(NULL),
   _tracker_etap_seed(NULL),
   _tracker_etam_seed(NULL),
   _vertexFinder(),
@@ -155,7 +155,9 @@ int PHG4HoughTransformTPC::InitRun(PHCompositeNode *topNode)
     cout << " Fast fit chisq cut min(par0+par1/pt,max): min( "
 	 << _chi2_cut_fast_par0 << " + " << _chi2_cut_fast_par1 << " / pt, "
 	 << _chi2_cut_fast_max << " )" << endl;
+    cout << " Initial vertex maximum chisq: " << _chi2_cut_init << endl;
     cout << " Maximum chisq (kalman fit): " << _chi2_cut_full << endl;
+
     cout << " Cell automaton chisq: " << _ca_chi2_cut << endl;
     cout << " Cos Angle Cut: " << _cos_angle_cut << endl;
     cout << " Ghost rejection: " << boolalpha << _reject_ghosts << noboolalpha << endl;
@@ -203,8 +205,10 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
   int code = translate_input();
   if (code != Fun4AllReturnCodes::EVENT_OK) return code;  
 
-//  fast_vertex_from_bbc();
-//  _vertex[2]=0.0;
+  if (verbosity>0){
+  fast_vertex_from_bbc();
+  _vertex[2]=0.0;
+  }
 
   //------------------------------------
   // Find an initial z-vertex position
@@ -239,7 +243,6 @@ int PHG4HoughTransformTPC::End(PHCompositeNode *topNode) {
   
   delete _tracker_etap_seed; _tracker_etap_seed = NULL;
   delete _tracker_etam_seed; _tracker_etam_seed = NULL;
-  delete _tracker_vertex; _tracker_vertex = NULL;
   delete _tracker; _tracker = NULL;
 
   if(_write_reco_tree==true)

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -62,293 +62,60 @@ using namespace std;
 using namespace Eigen;
 
 
-static void convertHelixCovarianceToEuclideanCovariance( float B, float phi, float d, float kappa, float z0, float dzdl, Eigen::Matrix<float,5,5> const& input, Eigen::Matrix<float,6,6>& output )
-{
-  Matrix<float,6,5> J = Matrix<float,6,5>::Zero(6,5);
-  // phi,d,nu,z0,dzdl
-  // -->
-  // x,y,z,px,py,pz
-  float nu = sqrt(kappa);
-  float dk_dnu = 2*nu;
-
-  float cosphi = cos(phi);
-  float sinphi = sin(phi);
-
-  J( 0, 0 ) = -sinphi*d;
-  J( 0, 1 ) = cosphi;
-  J( 1, 0 ) = d*cosphi;
-  J( 1, 1 ) = sinphi;
-  J( 2, 3 ) = 1;
-
-  float pt = 0.003*B/kappa;
-  float dpt_dk = -0.003*B/(kappa*kappa);
-
-  J( 3, 0 ) = -cosphi*pt;
-  J( 3, 2 ) = -sinphi*dpt_dk*dk_dnu;
-  J( 4, 0 ) = -sinphi*pt;
-  J( 4, 2 ) = cosphi*dpt_dk*dk_dnu;
-
-  float alpha = 1./(1. - dzdl*dzdl);
-  float alpha_half = pow( alpha, 0.5 );
-  float alpha_3_half = alpha*alpha_half;
-
-  J( 5, 2 ) = dpt_dk*dzdl*alpha_half*dk_dnu;
-  J( 5, 4 ) = pt*( alpha_half + dzdl*dzdl*alpha_3_half )*dk_dnu;
-
-  output = J*input*(J.transpose());
-}
-
-
-static inline double sign(double x)
-{
-  return ((double)(x > 0.)) - ((double)(x < 0.));
-}
-
-
-void PHG4HoughTransformTPC::projectToRadius(const SvtxTrack* track,
-					    double B,
-					    double radius,
-					    std::vector<double>& intersection) {
-  intersection.clear();
-  intersection.assign(3,NAN);
-
-  // start from the inner most state vector
-  const SvtxTrackState* state = track->get_state(0.0);
-  projectToRadius(state,track->get_charge(),B,radius,intersection);
-  
-  // iterate once to see if there is a state vector closer to the intersection
-  if (track->size_states() == 1) return;
-
-  const SvtxTrackState* closest = NULL;  
-  float min_dist = FLT_MAX;
-  for (SvtxTrack::ConstStateIter iter = track->begin_states();
-       iter != track->end_states();
-       ++iter) {
-    const SvtxTrackState* candidate = iter->second;
-    float dist = sqrt(pow(candidate->get_x()-intersection[0],2) +
-		      pow(candidate->get_y()-intersection[1],2) +
-		      pow(candidate->get_z()-intersection[2],2));
-
-    if (dist < min_dist) {
-      closest = candidate;
-      min_dist = dist;
-    }
-  }
-
-  // if we just got back the previous case, bail
-  if (closest->get_pathlength() == 0.0) return;
-
-  // recompute using the closer state vector
-  projectToRadius(closest,track->get_charge(),B,radius,intersection);
-
-  return;
-}
-
-void PHG4HoughTransformTPC::projectToRadius(const SvtxTrackState* state,
-					    int charge,
-					    double B,
-					    double radius,
-					    std::vector<double>& intersection) {
-  intersection.clear();
-  intersection.assign(3,NAN);
-  
-  // find 2d intersections in x,y plane
-  std::set<std::vector<double> > intersections;
-  if (B != 0.0) {
-    // magentic field present, project track as a circle leaving the state position
-    
-    // compute the center of rotation and the helix parameters
-    // x(u) = r*cos(q*u+cphi) + cx
-    // y(u) = r*sin(q*u+cphi) + cy
-    // z(u) = b*u + posz;
-    
-    double cr = state->get_pt() * 333.6 / B;                                  // radius of curvature
-    double cx = state->get_x() - (state->get_py()*cr)/charge/state->get_pt(); // center of rotation, x
-    double cy = (state->get_px()*cr)/charge/state->get_pt() + state->get_y(); // center of rotation, y
-    double cphi = atan2(state->get_y()-cy,state->get_x()-cx);                 // phase of state position
-    double b = state->get_pz()/state->get_pt()*cr;                            // pitch along z
-
-    if (!circle_circle_intersections(0.0,0.0,radius,
-				    cx,cy,cr,
-				    &intersections)) {
-      return;
-    }
-
-    if (intersections.empty()) return;
-    
-    // downselect solutions based on track direction
-    // we want the solution where the state vector would exit the cylinder
-    // this can be determined by the direction that the track circulates in
-
-    // rotate the px,py to the postion of the solution
-    // then ask if the dot product of the displacement vector between the solution
-    // and the cylinder center with the rotated momentum vector is positive
-    std::set<std::vector<double> >::iterator remove_iter = intersections.end();
-    double intersection_z = 0.0;
-    for (std::set<std::vector<double> >::iterator iter = intersections.begin();
-	 iter != intersections.end();
-	 ++iter) {
-      double x = iter->at(0);
-      double y = iter->at(1);
-
-      // find the azimuthal rotation about the center of rotation between the state vector and the solution
-
-      // displacement between center of rotation and solution
-      double dx = x - cx;
-      double dy = y - cy;
-      double dphi = atan2(dy,dx);
-       
-      // displacement between center of rotation and state position
-      double state_dx = state->get_x() - cx;
-      double state_dy = state->get_y() - cy;
-      double state_dphi = atan2(state_dy,state_dx);
-
-      // relative rotation angle
-      double rotphi = (dphi-state_dphi);
-        
-      // rotated momentum at the solution
-      double rotpx = cos(rotphi)*state->get_px() - sin(rotphi)*state->get_py();
-      double rotpy = sin(rotphi)*state->get_px() + cos(rotphi)*state->get_py();
-    
-      // assumes cylinder is centered at 0,0
-      double dot = rotpx*x + rotpy*y;
-
-      // our solution will have a momentum vector leaving the cylinder surface
-      if (dot >= 0.0) {
-	// find the solution for z
-	double u = (dphi - cphi)/charge;
-	
-	// look only along the projection (not backward)
-	if (u > 2.0*M_PI) {
-	  u = u - 2.0*M_PI;
-	} else if (u < 0.0) {
-	  u = u + 2.0*M_PI;
-	}
-
-	intersection_z = b*u+state->get_z();      
-      } else {
-	remove_iter = iter;
-      }
-    }
-
-    if (remove_iter != intersections.end()) {
-      intersections.erase(remove_iter);
-    }
-
-    if (intersections.empty()) return;
-    
-    intersection[0] = intersections.begin()->at(0);
-    intersection[1] = intersections.begin()->at(1);
-    intersection[2] = intersection_z;
-
-    return;
-    
-  } else {
-    // no magnetic field project track as a line
-    
-    circle_line_intersections(0.0,0.0,radius,
-     			      state->get_x(),state->get_y(),state->get_px(),state->get_py(),
-     			      &intersections);
-
-    if (intersections.empty()) return;
-    
-    // downselect solutions based on track direction
-    // we want the solution where the state vector would point outward
-    // since the track doesn't bend this will be the solution where
-    // the dot product of the displacement between the solution and the cylinder center
-    // and the momentum vector is positive
-    std::set<std::vector<double> >::iterator remove_iter = intersections.end();
-    double intersection_z = 0.0;
-    for (std::set<std::vector<double> >::iterator iter = intersections.begin();
-      	 iter != intersections.end();
-      	 ++iter) {
-       double x = iter->at(0);
-       double y = iter->at(1);
-
-      // assumes cylinder is centered at 0,0
-      double dot = state->get_px()*x + state->get_py()*y;
-      if (dot >= 0.0) {
-
-	// x(u) = px*u + x1
-	// y(u) = py*u + y1
-	// z(u) = pz*u + z1
-	
-	double u = NAN;
-	if (state->get_px() != 0) {
-	  u = (intersection[0] - state->get_x()) / state->get_px();
-	} else if (state->get_py() != 0) {
-	  u = (intersection[1] - state->get_y()) / state->get_py();      
-	}
-
-	intersection_z = state->get_pz()*u+state->get_z();    
-      } else {
-	remove_iter = iter;
-      }
-    }
-
-    if (remove_iter != intersections.end()) {
-      intersections.erase(remove_iter);
-    }
-
-    if (intersections.empty()) return;
-
-    intersection[0] = intersections.begin()->at(0);
-    intersection[1] = intersections.begin()->at(1);
-    intersection[2] = intersection_z;
-
-    return;
-  }
-  
-  return;
-}
-
-float PHG4HoughTransformTPC::kappaToPt(float kappa) {  
-  return _pt_rescale * _magField / 333.6 / kappa;
-}
-
-float PHG4HoughTransformTPC::ptToKappa(float pt) {  
-  return _pt_rescale * _magField / 333.6 / pt;
-}
-
 PHG4HoughTransformTPC::PHG4HoughTransformTPC(unsigned int seed_layers, unsigned int req_seed, const string &name) :
   SubsysReco(name),
-  _timer(PHTimeServer::get()->insert_new("PHG4HoughTransformTPC")),
-  _timer_initial_hough(PHTimeServer::get()->insert_new("PHG4HoughTransformTPC::track finding")),
-  _min_pT(0.2), 
-  _min_pT_init(0.2), 
   _seed_layers(seed_layers), 
   _req_seed(req_seed), 
+  _radii(),
+  _material(),
+  _user_material(),
+  _magField(1.5), ///< in Tesla
   _reject_ghosts(true), 
   _remove_hits(true), 
   _use_cell_size(false),
   _max_cluster_error(3.0),
+  _min_pt(0.2),
+  _min_z0(-14.0),
+  _max_z0(+14.0),
+  _max_d(1.0),
+  _cut_on_dca(false),
+  _dcaxy_cut(0.1),
+  _dcaz_cut(0.2),
+  _chi2_cut_fast_par0(16.0),
+  _chi2_cut_fast_par1(0.0),
+  _chi2_cut_fast_max(FLT_MAX),
+  _chi2_cut_full(4.0),
+  _ca_chi2_cut(4.0),
+  _cos_angle_cut(0.985),
   _bin_scale(0.8), 
   _z_bin_scale(0.8), 
-  _cut_on_dca(false), 
-  _dca_cut(0.1),
-  _dcaz_cut(0.2),
+  _min_combo_hits(req_seed),
+  _max_combo_hits(3/2*seed_layers),
+  _min_vtx_hits(3),
+  _max_vtx_hits(14),
+  _pt_rescale(1.0),
+  _fit_error_scale(_seed_layers,1.0/sqrt(12.0)),
+  _vote_error_scale(_seed_layers,1.0),
+  _layer_ilayer_map(),
+  _clusters_init(),
+  _clusters(),
+  _tracks(),
+  _track_errors(),
+  _track_covars(),
+  _vertex(),
+  _tracker(NULL),
+  _tracker_vertex(NULL),
+  _tracker_etap_seed(NULL),
+  _tracker_etam_seed(NULL),
+  _vertexFinder(),
+  _bbc_vertexes(NULL),
+  _g4clusters(NULL),
+  _g4tracks(NULL),
+  _g4vertexes(NULL),
+  _timer(PHTimeServer::get()->insert_new("PHG4HoughTransformTPC")),
+  _timer_initial_hough(PHTimeServer::get()->insert_new("PHG4HoughTransformTPC::track finding")),
   _write_reco_tree(false)
 {
-  _bbc_vertexes = NULL;
-  _magField = 1.5; // Tesla
-  _use_vertex = true;
-  _chi2_cut_init = 4.0;
-  _chi2_cut_fast_par0 = 16.0;
-  _chi2_cut_fast_par1 = 0.0;
-  _chi2_cut_fast_max = FLT_MAX;
-  _chi2_cut_full = 4.0;
-  _ca_chi2_cut = 4.0;
-  _cos_angle_cut = 0.985;
-
-  _beta = 1;
-  _lambda = 1;
-
-  _pt_rescale = 1.0;
-  
-  _vote_error_scale.assign(_seed_layers, 1.0);
-  _fit_error_scale.assign(_seed_layers, 1.0/sqrt(12.));
-
-  _layer_ilayer_map.clear();
 }
 
 int PHG4HoughTransformTPC::Init(PHCompositeNode *topNode)
@@ -371,7 +138,6 @@ int PHG4HoughTransformTPC::InitRun(PHCompositeNode *topNode)
 
   if (verbosity > 0) {
     cout << "====================== PHG4HoughTransformTPC::InitRun() ======================" << endl;
-    cout << " CVS Version: $Id: PHG4HoughTransformTPC.C,v 1.101 2015/04/21 23:47:09 pinkenbu Exp $" << endl;
     cout << " Magnetic field set to: " << _magField << " Tesla" << endl;
     cout << " Number of tracking layers: " << _nlayers << endl;
     for (int i=0; i<_nlayers; ++i) {
@@ -385,7 +151,7 @@ int PHG4HoughTransformTPC::InitRun(PHCompositeNode *topNode)
 	   << endl;
     }
     cout << " Required hits: " << _req_seed << endl;
-    cout << " Minimum pT: " << _min_pT << endl;
+    cout << " Minimum pt: " << _min_pt << endl;
     cout << " Fast fit chisq cut min(par0+par1/pt,max): min( "
 	 << _chi2_cut_fast_par0 << " + " << _chi2_cut_fast_par1 << " / pt, "
 	 << _chi2_cut_fast_max << " )" << endl;
@@ -398,16 +164,11 @@ int PHG4HoughTransformTPC::InitRun(PHCompositeNode *topNode)
     if (!_use_cell_size) cout << " Max cluster size error = " << _max_cluster_error << endl;
     cout << " Maximum DCA: " << boolalpha << _cut_on_dca << noboolalpha << endl;
     if (_cut_on_dca) {
-      cout << "   Maximum DCA cut: " << _dca_cut << endl;
+      cout << "   Maximum DCA cut: " << _dcaxy_cut << endl;
     }
     cout << "   Maximum DCAZ cut: " << _dcaz_cut << endl;
     cout << " Phi bin scale: " << _bin_scale << endl;
     cout << " Z bin scale: " << _z_bin_scale << endl;
-    cout << " Produce an initial vertex for tracking: " << boolalpha << _use_vertex << noboolalpha << endl;
-    if (_use_vertex) {
-      cout << "   Initial vertex minimum pT: " << _min_pT_init << endl;
-      cout << "   Initial vertex maximum chisq: " << _chi2_cut_init << endl;
-    }
     cout << " Momentum rescale factor: " << _pt_rescale << endl; 
     cout << "===========================================================================" << endl;
   }
@@ -422,424 +183,64 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
 
   if(verbosity > 0) cout << "PHG4HoughTransformTPC::process_event -- entered" << endl;
 
-  // moving clearing to the beginning of event or we will have
-  // return bugs from early exits!
   _clusters_init.clear();
   _clusters.clear();
   _tracks.clear();
-  
+  _track_errors.clear();
+  _vertex.clear();
+  _vertex.assign(3,0.0); 
+ 
   //---------------------------------
   // Get Objects off of the Node Tree
   //---------------------------------
   
   GetNodes(topNode);
   
+  //----------------------------------
   // Translate into Helix_Hough objects
   //-----------------------------------
-  //wrap_clusters_timer.get()->restart();
 
-  for (SvtxClusterMap::Iter iter = _g4clusters->begin();
-       iter != _g4clusters->end();
-       ++iter) {
-    SvtxCluster* cluster = iter->second;
+  int code = translate_input();
+  if (code != Fun4AllReturnCodes::EVENT_OK) return code;  
 
-    //cluster->identify();
-    
-    //float phi = atan2(cluster->get_position(1),cluster->get_position(0));
-     unsigned int ilayer = _layer_ilayer_map[cluster->get_layer()];
-    
-    // float xy_error=0.;float z_error=0.;
-    // if (_use_cell_size) {
-    //   xy_error = _smear_xy_layer[ilayer] * _vote_error_scale[ilayer];
-    //   z_error  = _smear_z_layer[ilayer] * _vote_error_scale[ilayer];
-      
-    // }
-    // else {
-    //   if( cluster->get_phi_size() <= _max_cluster_error*_smear_xy_layer[ilayer] ){xy_error = cluster->get_phi_size() * _vote_error_scale[ilayer];}
-    //   else{xy_error = _max_cluster_error*_smear_xy_layer[ilayer] * _vote_error_scale[ilayer];}
-    //   if(cluster->get_z_size() <= _max_cluster_error*_smear_z_layer[ilayer]){z_error  = cluster->get_z_size() * _vote_error_scale[ilayer];}
-    //   else{z_error  = _max_cluster_error*_smear_z_layer[ilayer] * _vote_error_scale[ilayer];}
-    // }
+//  fast_vertex_from_bbc();
+//  _vertex[2]=0.0;
 
-    // cout<<"layer : "<<ilayer<<" , xy_error : "<<xy_error<<" , z_error : "<<z_error<<endl;
-
-    // if(ilayer < 3)
-    // {
-    //   xy_error = 0.002;
-    //   z_error = 0.002;
-    // }
-    // else
-    // {
-    //   xy_error = 0.011;
-    //   z_error = 0.03;
-    // }
-
-
-    vector<SimpleHit3D>* which_vec = &_clusters;
-    if (ilayer<_seed_layers) {which_vec=&_clusters_init;}
-
-    SimpleHit3D hit3d;
-
-    hit3d.set_id(cluster->get_id());
-    hit3d.set_layer(ilayer);
-    
-    hit3d.set_x(cluster->get_x());
-    hit3d.set_y(cluster->get_y());
-    hit3d.set_z(cluster->get_z());
-
-    // hit3d.set_ex(fabs(xy_error*sin(phi)));
-    // hit3d.set_ey(fabs(xy_error*cos(phi)));
-    // hit3d.set_ez(z_error);
-    
-    // copy covariance over
-    for (int i=0; i<3; ++i) {
-      for (int j=i; j<3; ++j) {
-	hit3d.set_error(i,j,cluster->get_error(i,j));
-	hit3d.set_size(i,j,cluster->get_size(i,j));
-      }
-    }
-
-    which_vec->push_back(hit3d);
-  }
-
-  if (verbosity > 20) {
-    cout << "-------------------------------------------------------------------" << endl;
-    cout << "PHG4HoughTransformTPC::process_event has the following input clusters:" << endl;
-
-    if (!_clusters_init.empty()) {
-      for (unsigned int i = 0; i < _clusters_init.size(); ++i) {
-	cout << "n init clusters = "<<_clusters_init.size() << endl;
-	_clusters_init[i].print();
-      }
-    } else {
-      for (unsigned int i = 0; i < _clusters.size(); ++i) {
-	cout << "n clusters = "<<_clusters.size() << endl;
-	_clusters[i].print();
-      }
-    }
-    
-    cout << "-------------------------------------------------------------------" << endl;
-  }
-  
   //------------------------------------
-  // Perform the initial zvertex finding
+  // Find an initial z-vertex position
   //------------------------------------
 
+  code = initial_zvertex_finding();
+  if (code != Fun4AllReturnCodes::EVENT_OK) return code;
   
+  //---------------------------------------------------------
+  // Preform the track finding and final vertex determination
+  //---------------------------------------------------------
 
-  // Grab some initial tracks for initial z-vertex finding
-  _tracks.clear();
-
-  _vertex.clear();
-  _vertex.push_back(0.0); // x guess
-  _vertex.push_back(0.0); // y guess
-  _vertex.push_back(0.0); // z guess
-
-  //  if(_use_vertex) {
-  fast_vertex_from_bbc();            
-  //}  // if(_use_vertex)
-
-  // shift the vertex to the origin
-  for(unsigned int ht=0;ht<_clusters_init.size();++ht)
-    {
-      _clusters_init[ht].set_x( _clusters_init[ht].get_x() - _vertex[0]);
-      _clusters_init[ht].set_y( _clusters_init[ht].get_y() - _vertex[1]);
-      _clusters_init[ht].set_z( _clusters_init[ht].get_z() - _vertex[2]);
-    }
-  for(unsigned int ht=0;ht<_clusters.size();++ht)
-    {
-      _clusters[ht].set_x( _clusters[ht].get_x() - _vertex[0]);
-      _clusters[ht].set_y( _clusters[ht].get_y() - _vertex[1]);
-      _clusters[ht].set_z( _clusters[ht].get_z() - _vertex[2]);
-    }
-    
-  
-  //----------------------------------
-  // Preform the track finding
-  //----------------------------------
-  _tracker->clear();
-  _tracks.clear();
-  _timer_initial_hough.get()->restart();
-  _tracker->findHelices(_clusters_init, _min_hits_init, _max_hits_init, _tracks);
-
-  vector<SimpleHit3D> remaining_hits;
-  vector<int> used( _clusters_init.size(), 0 );
-  for(unsigned int tr=0;tr<_tracks.size();++tr)
-  {
-    for(unsigned int h=0;h<_tracks[tr].hits.size();++h)
-    {
-      used[_tracks[tr].hits[h].get_id()] = 1;
-    }
-  }
-  for(unsigned int i=0;i<_clusters_init.size();++i)
-  {
-    if( used[i] == 0 )
-    {
-      remaining_hits.push_back( _clusters_init[i] );
-    }
-  }
-  vector<SimpleTrack3D> append_tracks;
-  _tracker->findHelices(remaining_hits, _min_hits_init, _max_hits_init, append_tracks);
-  for(unsigned int tr=0;tr<append_tracks.size();++tr)
-  {
-    _tracks.push_back(append_tracks[tr]);
-  }
-
-
-  _timer_initial_hough.get()->stop();
-  
-  
-
-  if(verbosity > 0)
-  {
-    cout << "PHG4HoughTransformTPC::process_event -- full track finding pass found: " << _tracks.size() << " tracks" << endl;
-  }    
-   
-  //----------------------------
-  // Re-center event on detector
-  //----------------------------
-
-  if (verbosity > 0)
-    cout << "PHG4HoughTransformTPC::process_event -- recentering event on "
-            "detector..."
-         << endl;
-  vector<double> chi_squareds;
-  for (unsigned int tt = 0; tt < _tracks.size(); tt++) {
-    // move the hits in the track back to their original position
-    for (unsigned int hh = 0; hh < _tracks[tt].hits.size(); hh++) {
-      _tracks[tt].hits[hh].set_x(_tracks[tt].hits[hh].get_x() + _vertex[0]);
-      _tracks[tt].hits[hh].set_y(_tracks[tt].hits[hh].get_y() + _vertex[1]);
-      _tracks[tt].hits[hh].set_z(_tracks[tt].hits[hh].get_z() + _vertex[2]);
-      // _tracks[tt].z0 += _vertex[2];
-    }
-    chi_squareds.push_back(_tracker->getKalmanStates()[tt].chi2);
-  }
-
-  if (verbosity > 0) {
-    cout << "PHG4HoughTransformTPC::process_event -- final track count: "
-         << _tracks.size() << endl;
-  }
-
-  //---------------------------
-  // Final vertex determination
-  //---------------------------
-  
-  // final best guess of the primary vertex position here...
-  if(verbosity > 0)
-  {
-    cout<< "PHG4HoughTransformTPC::process_event -- calculating final vertex" << endl;
-  }
-  
-  // sort the tracks by pT
-  vector<vector<double> > pTmap;
-  for(unsigned int i=0;i<_tracks.size();++i)
-  {
-    double pT = kappaToPt(_tracks[i].kappa);
-    pTmap.push_back(vector<double>());
-    pTmap.back().push_back(pT);
-    pTmap.back().push_back((double)i);
-  }
-  sort(pTmap.begin(), pTmap.end());
-  vector<SimpleTrack3D> vtxtracks;
-  vector<Matrix<float,5,5> > vtxcovariances;
-  unsigned int maxvtxtracks=100;
-  if(_tracks.size() < maxvtxtracks){vtxtracks = _tracks;}
-  else
-  {
-    for(unsigned int i=0;i<maxvtxtracks;++i)
-    {
-      vtxtracks.push_back(_tracks[ (int)(pTmap[pTmap.size()-1-i][1]) ]);
-      vtxcovariances.push_back( (_tracker->getKalmanStates())[ (int)(pTmap[pTmap.size()-1-i][1]) ].C );
-    }
-  }
-  
-  double vx = _vertex[0];
-  double vy = _vertex[1];
-  double vz = _vertex[2];
-  
-  _vertex[0] = 0.;
-  _vertex[1] = 0.;
-  _vertex[2] = 0.;
-  
-  _vertexFinder.findVertex(vtxtracks, vtxcovariances, _vertex, 0.3, false);
-  _vertexFinder.findVertex(vtxtracks, vtxcovariances, _vertex, 0.1, false);
-  _vertexFinder.findVertex(vtxtracks, vtxcovariances, _vertex, 0.02, false);
-  _vertexFinder.findVertex(vtxtracks, vtxcovariances, _vertex, 0.005, false);
-  
-  _vertex[0] += vx;
-  _vertex[1] += vy;
-  _vertex[2] += vz;
-  
-  if(verbosity > 0)
-  {
-    cout << "PHG4HoughTransformTPC::process_event -- final vertex: " << _vertex[0] << " " << _vertex[1] << " " << _vertex[2] << endl;
-  }
+  code = full_tracking_and_vertexing();
+  if (code != Fun4AllReturnCodes::EVENT_OK) return code;
 
   //--------------------------------
-  // Translate back into PHG4 objects
+  // Translate back into SVTX objects
   //--------------------------------
 
-  if(verbosity > 0)
-  {
-    cout << "PHG4HoughTransformTPC::process_event -- producing PHG4Track objects..." << endl;
+  code = export_output(); 
+  if (code != Fun4AllReturnCodes::EVENT_OK) return code;
+
+  if(_write_reco_tree==true) {
+    _reco_tree->Fill(); 
   }
-
-  SvtxVertex_v1 vertex;
-  vertex.set_t0(0.0);
-  for (int i=0;i<3;++i) vertex.set_position(i,_vertex[i]);
-  vertex.set_chisq(0.0);
-  vertex.set_ndof(0); 
-  vertex.set_error(0,0,0.0);
-  vertex.set_error(0,1,0.0);
-  vertex.set_error(0,2,0.0);
-  vertex.set_error(1,0,0.0);
-  vertex.set_error(1,1,0.0);
-  vertex.set_error(1,2,0.0);
-  vertex.set_error(2,0,0.0);
-  vertex.set_error(2,1,0.0);
-  vertex.set_error(2,2,0.0);
-  
-  // copy out the reconstructed vertex position
-  //_g4tracks->setVertex(_vertex[0],_vertex[1],_vertex[2]);
-  //_g4tracks->setVertexError(0.0,0.0,0.0);
- 
-  // at this point we should already have an initial pt and pz guess...
-  // need to translate this into the PHG4Track object...
-
-  vector<SimpleHit3D> track_hits;
-  int clusterID;
-  int clusterLayer;
-
-  for(unsigned int itrack=0; itrack<_tracks.size();itrack++)
-  {
-    SvtxTrack_v1 track;
-    track.set_id(itrack);
-    track_hits.clear();
-    track_hits = _tracks.at(itrack).hits;
-    
-    for(unsigned int ihit = 0; ihit<track_hits.size();ihit++)
-    {
-      //      dEdx1=0;
-      //      dEdx2=0;
-      if( (track_hits.at(ihit).get_id()) >= _g4clusters->size()){continue;}
-      SvtxCluster *cluster = _g4clusters->get(track_hits.at(ihit).get_id());
-      clusterID = cluster->get_id();
-      clusterLayer = cluster->get_layer();
-      if( (clusterLayer < (int)_seed_layers) && (clusterLayer >= 0) )
-      {
-        track.insert_cluster(clusterID);
-      }
-    }
-    float kappa = _tracks.at(itrack).kappa;
-    float d = _tracks.at(itrack).d;
-    float phi = _tracks.at(itrack).phi;
-
-    float dzdl = _tracks.at(itrack).dzdl;
-    float z0 = _tracks.at(itrack).z0;
-    
-    // track.set_helix_phi(phi);
-    // track.set_helix_kappa(kappa);
-    // track.set_helix_d(d);
-    // track.set_helix_z0(z0);
-    // track.set_helix_dzdl(dzdl);
-    
-    float pT = kappaToPt(kappa);
-
-    float x_center = cos(phi)*(d+1/kappa); // x coordinate of circle center
-    float y_center = sin(phi)*(d+1/kappa); // y    "      "     "      "
-
-    // find helicity from cross product sign
-    short int helicity;
-    if((track_hits[0].get_x()-x_center)*(track_hits[track_hits.size()-1].get_y()-y_center) -
-       (track_hits[0].get_y()-y_center)*(track_hits[track_hits.size()-1].get_x()-x_center) > 0)
-    {
-      helicity = 1;
-    }
-    else
-    { 
-      helicity = -1;
-    }
-    float pZ = 0;
-    if(dzdl != 1)
-    {
-      pZ = pT * dzdl / sqrt(1.0 - dzdl*dzdl);
-    }
-    int ndf = 2*_tracks.at(itrack).hits.size() - 5;
-    track.set_chisq(chi_squareds[itrack]);
-    track.set_ndf(ndf);
-    track.set_px( pT*cos(phi-helicity*M_PI/2) );
-    track.set_py( pT*sin(phi-helicity*M_PI/2) );
-    track.set_pz( pZ );
-
-    track.set_dca2d( d );
-    track.set_dca2d_error(sqrt(_tracker->getKalmanStates()[itrack].C(1,1)));  
-
-    if(_write_reco_tree==true)
-    {
-      _recoevent->tracks.push_back( SimpleRecoTrack() );
-      _recoevent->tracks.back().px = pT*cos(phi-helicity*M_PI/2);
-      _recoevent->tracks.back().py = pT*sin(phi-helicity*M_PI/2);
-      _recoevent->tracks.back().pz = pZ;
-      _recoevent->tracks.back().d = d;
-      _recoevent->tracks.back().z0 = z0;
-      _recoevent->tracks.back().quality = chi_squareds[itrack]/((float)ndf);
-      _recoevent->tracks.back().charge = (-1*helicity);
-    }
-    
-
-    if(_magField > 0)
-    {
-      track.set_charge( helicity );
-    }
-    else
-    {
-      track.set_charge( -1.0*helicity );
-    }
-
-    Matrix<float,6,6> euclidean_cov = Matrix<float,6,6>::Zero(6,6);
-    convertHelixCovarianceToEuclideanCovariance( _magField, phi, d, kappa, z0, dzdl, _tracker->getKalmanStates()[itrack].C, euclidean_cov );
-    
-    for(unsigned int row=0;row<6;++row)
-    {
-      for(unsigned int col=0;col<6;++col)
-      {
-	track.set_error(row,col,euclidean_cov(row,col));
-      }
-    }
-
-    track.set_x( vertex.get_x() + d*cos(phi) );
-    track.set_y( vertex.get_y() + d*sin(phi) );
-    track.set_z( vertex.get_z() + z0 );
-    
-    _g4tracks->insert(&track);
-    vertex.insert_track(track.get_id());
-
-    if (verbosity > 5) {
-      cout << "track " << itrack << " quality = "
-           << track.get_quality() << endl;
-      cout << "px = " << track.get_px()
-           << " py = " << track.get_py()
-           << " pz = " << track.get_pz() << endl;
-    }
-  } // track loop
-
-  SvtxVertex *vtxptr = _g4vertexes->insert(&vertex);
-  if (verbosity > 5) vtxptr->identify();
-  
-  if(verbosity > 0)
-  {
-    cout << "PHG4HoughTransformTPC::process_event -- leaving process_event" << endl;
-  }
-
-  if(_write_reco_tree==true){ _reco_tree->Fill(); }
 
   _timer.get()->stop();
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int PHG4HoughTransformTPC::End(PHCompositeNode *topNode) {
-  delete _tracker_vertex;
-  delete _tracker;
+  
+  delete _tracker_etap_seed; _tracker_etap_seed = NULL;
+  delete _tracker_etam_seed; _tracker_etam_seed = NULL;
+  delete _tracker_vertex; _tracker_vertex = NULL;
+  delete _tracker; _tracker = NULL;
 
   if(_write_reco_tree==true)
   {
@@ -853,6 +254,241 @@ int PHG4HoughTransformTPC::End(PHCompositeNode *topNode) {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+void PHG4HoughTransformTPC::projectToRadius(const SvtxTrack* track,
+                                            double B,
+                                            double radius,
+                                            std::vector<double>& intersection) {
+  intersection.clear();
+  intersection.assign(3,NAN);
+
+
+  // start from the inner most state vector
+  const SvtxTrackState* state = track->get_state(0.0);
+  projectToRadius(state,track->get_charge(),B,radius,intersection);
+
+  // iterate once to see if there is a state vector closer to the intersection
+  if (track->size_states() == 1) return;
+
+  const SvtxTrackState* closest = NULL;
+  float min_dist = FLT_MAX;
+  for (SvtxTrack::ConstStateIter iter = track->begin_states();
+       iter != track->end_states();
+       ++iter) {
+    const SvtxTrackState* candidate = iter->second;
+    float dist = sqrt(pow(candidate->get_x()-intersection[0],2) +
+                      pow(candidate->get_y()-intersection[1],2) +
+                      pow(candidate->get_z()-intersection[2],2));
+
+    if (dist < min_dist) {
+      closest = candidate;
+      min_dist = dist;
+    }
+  }
+
+  // if we just got back the previous case, bail
+  if (closest->get_pathlength() == 0.0) return;
+
+  // recompute using the closer state vector
+  projectToRadius(closest,track->get_charge(),B,radius,intersection);
+  
+  return;
+}
+
+void PHG4HoughTransformTPC::projectToRadius(const SvtxTrackState* state,
+                                            int charge,
+                                            double B,
+                                            double radius,
+                                            std::vector<double>& intersection) {
+  intersection.clear();
+  intersection.assign(3,NAN);
+
+  // find 2d intersections in x,y plane
+  std::set<std::vector<double> > intersections;
+  if (B != 0.0) {
+  // magentic field present, project track as a circle leaving the state position
+
+  // compute the center of rotation and the helix parameters
+  // x(u) = r*cos(q*u+cphi) + cx
+  // y(u) = r*sin(q*u+cphi) + cy
+  // z(u) = b*u + posz;
+
+    double cr = state->get_pt() * 333.6 / B;                                  // radius of curvature
+    double cx = state->get_x() - (state->get_py()*cr)/charge/state->get_pt(); // center of rotation, x
+    double cy = (state->get_px()*cr)/charge/state->get_pt() + state->get_y(); // center of rotation, y
+    double cphi = atan2(state->get_y()-cy,state->get_x()-cx);                 // phase of state position
+    double b = state->get_pz()/state->get_pt()*cr;                            // pitch along z
+
+    if (!circle_circle_intersections(0.0,0.0,radius,
+                                    cx,cy,cr,
+                                    &intersections)) {
+      return;
+    }
+
+    if (intersections.empty()) return;
+    // downselect solutions based on track direction
+    // we want the solution where the state vector would exit the cylinder
+    // this can be determined by the direction that the track circulates in
+
+    // rotate the px,py to the postion of the solution
+    // then ask if the dot product of the displacement vector between the solution
+    // and the cylinder center with the rotated momentum vector is positive
+
+    std::set<std::vector<double> >::iterator remove_iter = intersections.end();
+    double intersection_z = 0.0;
+    for (std::set<std::vector<double> >::iterator iter = intersections.begin();
+         iter != intersections.end();
+         ++iter) {
+      double x = iter->at(0);
+      double y = iter->at(1);
+
+      // find the azimuthal rotation about the center of rotation between the state vector and the solution
+      // displacement between center of rotation and solution
+      double dx = x - cx;
+      double dy = y - cy;
+      double dphi = atan2(dy,dx);
+
+      // displacement between center of rotation and state position
+      double state_dx = state->get_x() - cx;
+      double state_dy = state->get_y() - cy;
+      double state_dphi = atan2(state_dy,state_dx);
+     
+      // relative rotation angle
+      double rotphi = (dphi-state_dphi);
+      
+      // rotated momentum at the solution
+      double rotpx = cos(rotphi)*state->get_px() - sin(rotphi)*state->get_py();
+      double rotpy = sin(rotphi)*state->get_px() + cos(rotphi)*state->get_py();
+    
+      // assumes cylinder is centered at 0,0
+      double dot = rotpx*x + rotpy*y;
+  
+      // our solution will have a momentum vector leaving the cylinder surface
+      if (dot >= 0.0) {
+        // find the solution for z
+        double u = (dphi - cphi)/charge;
+  
+        // look only along the projection (not backward)                          
+        if (u > 2.0*M_PI) {
+          u = u - 2.0*M_PI;
+        } else if (u < 0.0) {
+          u = u + 2.0*M_PI;
+        }
+
+        intersection_z = b*u+state->get_z();
+      } else {
+        remove_iter = iter;
+      }
+    }
+
+    if (remove_iter != intersections.end()) {
+      intersections.erase(remove_iter);
+    }
+
+    if (intersections.empty()) return;
+
+    intersection[0] = intersections.begin()->at(0);
+    intersection[1] = intersections.begin()->at(1);
+    intersection[2] = intersection_z;
+
+    return;
+
+  } else {
+    // no magnetic field project track as a line
+    
+    circle_line_intersections(0.0,0.0,radius,
+                              state->get_x(),state->get_y(),state->get_px(),state->get_py(),
+                              &intersections);
+
+    if (intersections.empty()) return;
+
+    // downselect solutions based on track direction
+    // we want the solution where the state vector would point outward
+    // since the track doesn't bend this will be the solution where
+    // the dot product of the displacement between the solution and the cylinder center
+    // and the momentum vector is positive
+    std::set<std::vector<double> >::iterator remove_iter = intersections.end();
+    double intersection_z = 0.0;
+    for (std::set<std::vector<double> >::iterator iter = intersections.begin();
+         iter != intersections.end();
+         ++iter) {
+       double x = iter->at(0);
+       double y = iter->at(1);
+
+      // assumes cylinder is centered at 0,0
+      double dot = state->get_px()*x + state->get_py()*y;
+      if (dot >= 0.0) {
+        // x(u) = px*u + x1
+        // y(u) = py*u + y1
+        // z(u) = pz*u + z1
+
+        double u = NAN;
+        if (state->get_px() != 0) {
+          u = (intersection[0] - state->get_x()) / state->get_px();
+        } else if (state->get_py() != 0) {
+          u = (intersection[1] - state->get_y()) / state->get_py();
+        }
+
+        intersection_z = state->get_pz()*u+state->get_z();
+      } else {
+        remove_iter = iter;
+      }
+    }
+
+    if (remove_iter != intersections.end()) {
+      intersections.erase(remove_iter);
+    }
+
+    if (intersections.empty()) return;
+
+    intersection[0] = intersections.begin()->at(0);
+    intersection[1] = intersections.begin()->at(1);
+    intersection[2] = intersection_z;
+
+    return;
+  }
+
+  return;
+}
+
+void PHG4HoughTransformTPC::set_material(int layer, float value)
+{
+  _user_material[layer] = value;
+}
+
+int PHG4HoughTransformTPC::CreateNodes(PHCompositeNode *topNode)
+{
+  // create nodes...
+  PHNodeIterator iter(topNode);
+
+  PHCompositeNode *dstNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if(!dstNode)
+  {
+  cerr << PHWHERE << "DST Node missing, doing nothing." << endl;
+  return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  // Create the SVTX node
+  PHCompositeNode* tb_node = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "SVTX"));
+  if (!tb_node)
+  {
+  tb_node = new PHCompositeNode("SVTX");
+  dstNode->addNode(tb_node);
+  if (verbosity>0) cout << "SVTX node added" << endl;
+  }
+
+  _g4tracks = new SvtxTrackMap_v1;
+  PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(_g4tracks,"SvtxTrackMap","PHObject");
+  tb_node->addNode(tracks_node);
+  if (verbosity>0) cout << "Svtx/SvtxTrackMap node added" << endl;
+  
+  _g4vertexes = new SvtxVertexMap_v1;
+  PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(_g4vertexes,"SvtxVertexMap","PHObject");
+  tb_node->addNode(vertexes_node);
+  if (verbosity>0) cout << "Svtx/SvtxVertexMap node added" << endl;
+
+  return InitializeGeometry(topNode);
+}
+
 int PHG4HoughTransformTPC::InitializeGeometry(PHCompositeNode *topNode) {
 
   //---------------------------------------------------------
@@ -861,9 +497,12 @@ int PHG4HoughTransformTPC::InitializeGeometry(PHCompositeNode *topNode) {
 
   bool default_geo = false;
   
-  PHG4CylinderCellGeomContainer* cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode,"CYLINDERCELLGEOM_SVTX");
-  PHG4CylinderGeomContainer* laddergeos = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_SILICON_TRACKER");
-  //PHG4CylinderCellContainer* cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SVTX");
+  PHG4CylinderCellGeomContainer* cellgeos = 
+      findNode::getClass<PHG4CylinderCellGeomContainer>(
+          topNode,"CYLINDERCELLGEOM_SVTX");
+  PHG4CylinderGeomContainer* laddergeos = 
+      findNode::getClass<PHG4CylinderGeomContainer>(
+          topNode,"CYLINDERGEOM_SILICON_TRACKER");
   
   if (cellgeos||laddergeos) {
     unsigned int ncelllayers = 0;
@@ -874,15 +513,16 @@ int PHG4HoughTransformTPC::InitializeGeometry(PHCompositeNode *topNode) {
     default_geo = false;
   } else {
     cerr << PHWHERE
-	 << "Neither CYLINDERCELLGEOM_SVTX nor CYLINDERGEOM_SILICON_TRACKER available, reverting to a default geometry"
+	 << "Neither CYLINDERCELLGEOM_SVTX nor CYLINDERGEOM_SILICON_TRACKER "
+            "available, reverting to a default geometry"
 	 << std::endl;    
     _nlayers = 6;
     default_geo = true;
   }
 
-  //=================================================//                                                                                                      
-  //  Initializing HelixHough objects                //                                                                                                      
-  //=================================================//                                                                                            
+  //=================================================
+  //  Initializing HelixHough objects
+  //=================================================//                                                                              
 
   _radii.assign(_nlayers, 0.0);
   _smear_xy_layer.assign(_nlayers, 0.0);
@@ -1002,77 +642,180 @@ int PHG4HoughTransformTPC::InitializeGeometry(PHCompositeNode *topNode) {
     _material[_layer_ilayer_map[iter->first]] = iter->second;
   }
 
-  float kappa_max = ptToKappa(_min_pT);
+  // initialize the pattern recognition tools
+  setup_seed_tracker_objects();
+  setup_tracker_object();
 
-  HelixRange top_range( 0.0, 2.*M_PI,
-		       -0.1, 0.1,
-			0.0, kappa_max,
-		       -0.9, 0.9,
-		       -1.0*_dcaz_cut, 1.0*_dcaz_cut);
-  if (!_use_vertex) {
-    top_range.min_z0 = -10.;
-    top_range.max_z0 = 10.;
-  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
 
-  top_range.min_z0 = -0.1;
-  top_range.max_z0 = 0.1;
-  
-  vector<unsigned int> onezoom(5,0);
-  vector<vector<unsigned int> > zoomprofile;
+int PHG4HoughTransformTPC::setup_seed_tracker_objects() {
+
+  float kappa_max = ptToKappa(_min_pt);
+
+  std::vector<unsigned int> onezoom(5,0);
+  std::vector<vector<unsigned int> > zoomprofile;
   zoomprofile.assign(5,onezoom);
-  zoomprofile[0][0] = 8;
+  zoomprofile[0][0] = 16;
   zoomprofile[0][1] = 1;
   zoomprofile[0][2] = 8;
   zoomprofile[0][3] = 8;
-  zoomprofile[0][4] = 1;
-  
+  zoomprofile[0][4] = 2;
+
   zoomprofile[1][0] = 8;
   zoomprofile[1][1] = 1;
-  zoomprofile[1][2] = 8;
-  zoomprofile[1][3] = 8;
-  zoomprofile[1][4] = 1;
-  
-  zoomprofile[2][0] = 8;
-  zoomprofile[2][1] = 1;
-  zoomprofile[2][2] = 8;
-  zoomprofile[2][3] = 8;
-  zoomprofile[2][4] = 1;
+  zoomprofile[1][2] = 4;
+  zoomprofile[1][3] = 4;
+  zoomprofile[1][4] = 2;
 
-  zoomprofile[3][0] = 8;
-  zoomprofile[3][1] = 3;
-  zoomprofile[3][2] = 8;
-  zoomprofile[3][3] = 2;
-  zoomprofile[3][4] = 3;
+  zoomprofile[2][0] = 4;
+  zoomprofile[2][1] = 3;
+  zoomprofile[2][2] = 2;
+  zoomprofile[2][3] = 2;
+  zoomprofile[2][4] = 3;
 
-  zoomprofile[4][0] = 8;
-  zoomprofile[4][1] = 3;
-  zoomprofile[4][2] = 8;
-  zoomprofile[4][3] = 2;
-  zoomprofile[4][4] = 3;
-  
+  for (unsigned int i = 3; i <= 4; ++i) {
+    zoomprofile[i][0] = 3;
+    zoomprofile[i][1] = 3;
+    zoomprofile[i][2] = 3;
+    zoomprofile[i][3] = 3;
+    zoomprofile[i][4] = 3;
+  }
+
+
+  HelixRange pos_range( 0.0, 2.*M_PI,      // center of rotation azimuthal angles
+                        -0.1, 0.1,   // 2d dca range
+                        0.0, kappa_max,    // curvature range
+                        0.0, 0.9,          // dzdl range
+                        _min_z0, _max_z0); // dca_z range
+
+  _tracker_etap_seed = new sPHENIXTrackerTPC(zoomprofile, 1, pos_range, _material, _radii, _magField);
+  _tracker_etap_seed->setEndLayer(4); // layers numbered from 0 towards outside
+  _tracker_etap_seed->requireLayers(5);
+  _tracker_etap_seed->setClusterStartBin(1);
+  _tracker_etap_seed->setRejectGhosts(_reject_ghosts);
+  _tracker_etap_seed->setFastChi2Cut(_chi2_cut_fast_par0,
+                                     _chi2_cut_fast_par1,
+                                     _chi2_cut_fast_max);
+  _tracker_etap_seed->setChi2Cut(_chi2_cut_full);
+  _tracker_etap_seed->setChi2RemovalCut(_chi2_cut_full*0.5);
+  _tracker_etap_seed->setCellularAutomatonChi2Cut(_ca_chi2_cut);
+  _tracker_etap_seed->setPrintTimings(false);
+  _tracker_etap_seed->setCutOnDca(false);
+  _tracker_etap_seed->setSmoothBack(true);
+  _tracker_etap_seed->setBinScale(_bin_scale);
+  _tracker_etap_seed->setZBinScale(_z_bin_scale);
+  _tracker_etap_seed->setRemoveHits(_remove_hits);
+  _tracker_etap_seed->setSeparateByHelicity(true);
+  _tracker_etap_seed->setMaxHitsPairs(0);
+  _tracker_etap_seed->setCosAngleCut(_cos_angle_cut);
+  _tracker_etap_seed->setRequirePixels(true);
+
+  for(unsigned int ilayer = 0; ilayer < _fit_error_scale.size(); ++ilayer) {
+    float scale1 = _fit_error_scale[ilayer];
+    float scale2 = _vote_error_scale[ilayer];
+    float scale = scale1/scale2;
+    _tracker_etap_seed->setHitErrorScale(ilayer, scale);
+  }
+
+  HelixRange neg_range( 0.0, 2.*M_PI,      // center of rotation azimuthal angles
+                        -0.1, 0.1,   // 2d dca range
+                        0.0, kappa_max,    // curvature range
+                        -0.9, 0.0,         // dzdl range
+                        _min_z0, _max_z0); // dca_z range
+
+  _tracker_etam_seed = new sPHENIXTrackerTPC(zoomprofile, 1, neg_range, _material, _radii, _magField);
+  _tracker_etam_seed->setEndLayer(4);
+  _tracker_etam_seed->requireLayers(5);
+  _tracker_etam_seed->setClusterStartBin(1);
+  _tracker_etam_seed->setRejectGhosts(_reject_ghosts);
+  _tracker_etam_seed->setFastChi2Cut(_chi2_cut_fast_par0,
+                                     _chi2_cut_fast_par1,
+                                     _chi2_cut_fast_max);
+  _tracker_etam_seed->setChi2Cut(_chi2_cut_full);
+  _tracker_etam_seed->setChi2RemovalCut(_chi2_cut_full*0.5);
+  _tracker_etam_seed->setCellularAutomatonChi2Cut(_ca_chi2_cut);
+  _tracker_etam_seed->setPrintTimings(false);
+  _tracker_etam_seed->setCutOnDca(false);
+  _tracker_etam_seed->setSmoothBack(true);
+  _tracker_etam_seed->setBinScale(_bin_scale);
+  _tracker_etam_seed->setZBinScale(_z_bin_scale);
+  _tracker_etam_seed->setRemoveHits(_remove_hits);
+  _tracker_etam_seed->setSeparateByHelicity(true);
+  _tracker_etam_seed->setMaxHitsPairs(0);
+  _tracker_etam_seed->setCosAngleCut(_cos_angle_cut);
+  _tracker_etam_seed->setRequirePixels(true);
+
+  for(unsigned int ilayer = 0; ilayer < _fit_error_scale.size(); ++ilayer) {
+    float scale1 = _fit_error_scale[ilayer];
+    float scale2 = _vote_error_scale[ilayer];
+    float scale = scale1/scale2;
+    _tracker_etam_seed->setHitErrorScale(ilayer, scale);
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+int PHG4HoughTransformTPC::setup_tracker_object() {
+
+  float kappa_max = ptToKappa(_min_pt);
+
+  HelixRange top_range( 0.0, 2.*M_PI,             // center of rotation azimuthal angles
+                        -0.1, 0.1,  // 2d dca range
+                        0.0, kappa_max,           // curvature range
+                        -0.9, 0.9,                // dzdl range
+                        -0.1, 0.1);   // dca_z range
+
+    vector<unsigned int> onezoom(5,0);
+    vector<vector<unsigned int> > zoomprofile;
+    zoomprofile.assign(5,onezoom);
+    zoomprofile[0][0] = 8;
+    zoomprofile[0][1] = 1;
+    zoomprofile[0][2] = 8;
+    zoomprofile[0][3] = 8;
+    zoomprofile[0][4] = 1;
     
+    zoomprofile[1][0] = 8;
+    zoomprofile[1][1] = 1;
+    zoomprofile[1][2] = 8;
+    zoomprofile[1][3] = 8;
+    zoomprofile[1][4] = 1;
+    
+    zoomprofile[2][0] = 8;
+    zoomprofile[2][1] = 1;
+    zoomprofile[2][2] = 8;
+    zoomprofile[2][3] = 8;
+    zoomprofile[2][4] = 1;
+
+    zoomprofile[3][0] = 8;
+    zoomprofile[3][1] = 3;
+    zoomprofile[3][2] = 8;
+    zoomprofile[3][3] = 2;
+    zoomprofile[3][4] = 3;
+
+    zoomprofile[4][0] = 8;
+    zoomprofile[4][1] = 3;
+    zoomprofile[4][2] = 8;
+    zoomprofile[4][3] = 2;
+    zoomprofile[4][4] = 3;
+
   _tracker = new sPHENIXTrackerTPC(zoomprofile, 3, top_range, _material, _radii, _magField);
-  _tracker->setIterateClustering(true);
+  _tracker->setIterateClustering(true); 
   _tracker->setNLayers(_seed_layers);
   _tracker->requireLayers(_req_seed);
-  _max_hits_init = (_seed_layers*3)/2;
-  if(_seed_layers >= 10){_max_hits_init = _seed_layers;}
-  _min_hits_init = _req_seed;
+  if(_seed_layers >= 10){_max_combo_hits = _seed_layers;}
   _tracker->setClusterStartBin(3);
-  // if(_seed_layers < 10){ _tracker->setClusterStartBin(1); }
-  // else{ _tracker->setClusterStartBin(10); }
   _tracker->setRejectGhosts(_reject_ghosts);
   _tracker->setFastChi2Cut(_chi2_cut_fast_par0,
-			   _chi2_cut_fast_par1,
-			   _chi2_cut_fast_max);
+                           _chi2_cut_fast_par1,
+                           _chi2_cut_fast_max);
   _tracker->setChi2Cut(_chi2_cut_full);
   _tracker->setChi2RemovalCut(_chi2_cut_full*0.5);
   _tracker->setCellularAutomatonChi2Cut(_ca_chi2_cut);
   _tracker->setPrintTimings(false);
-  if(verbosity > 3){_tracker->setPrintTimings(true);}
-  _tracker->setVerbosity(verbosity);
   _tracker->setCutOnDca(_cut_on_dca);
-  _tracker->setDcaCut(_dca_cut);
+  _tracker->setDcaCut(_dcaxy_cut);
   _tracker->setSmoothBack(true);
   _tracker->setBinScale(_bin_scale);
   _tracker->setZBinScale(_z_bin_scale);
@@ -1081,126 +824,15 @@ int PHG4HoughTransformTPC::InitializeGeometry(PHCompositeNode *topNode) {
   _tracker->setMaxHitsPairs(0);
   _tracker->setCosAngleCut(_cos_angle_cut);
   _tracker->setRequirePixels(true);
-  
-    vector<vector<unsigned int> > zoomprofile2;
-    zoomprofile2.assign(4,onezoom);
-    zoomprofile2[0][0] = 8;
-    zoomprofile2[0][1] = 1;
-    zoomprofile2[0][2] = 4;
-    zoomprofile2[0][3] = 8;
-    zoomprofile2[0][4] = 4;
-    
-    zoomprofile2[1][0] = 8;
-    zoomprofile2[1][1] = 1;
-    zoomprofile2[1][2] = 4;
-    zoomprofile2[1][3] = 8;
-    zoomprofile2[1][4] = 4;
-    
-    zoomprofile2[2][0] = 8;
-    zoomprofile2[2][1] = 1;
-    zoomprofile2[2][2] = 4;
-    zoomprofile2[2][3] = 4;
-    zoomprofile2[2][4] = 4;
 
-    zoomprofile2[3][0] = 8;
-    zoomprofile2[3][1] = 3;
-    zoomprofile2[3][2] = 3;
-    zoomprofile2[3][3] = 4;
-    zoomprofile2[3][4] = 3;
-
-      HelixRange top_range2( 0.0, 2.*M_PI,
-               -0.2, 0.2,
-          0.0, kappa_max,
-               -0.9, 0.9,
-               -10., 10.);
-      
-    _tracker_vertex = new sPHENIXTrackerTPC(zoomprofile2, 3, top_range2, _material, _radii, _magField);
-    _tracker_vertex->setIterateClustering(true);
-    _tracker_vertex->setNLayers(_seed_layers);
-    _tracker_vertex->requireLayers(_req_seed);
-    _max_hits_init = _seed_layers*4;
-    if(_seed_layers >= 10){_max_hits_init = _seed_layers*1;}
-    _min_hits_init = _req_seed;
-    _tracker_vertex->setClusterStartBin(2);
-    // if(_seed_layers < 10){ _tracker_vertex->setClusterStartBin(1); }
-    // else{ _tracker_vertex->setClusterStartBin(10); }
-    _tracker_vertex->setRejectGhosts(_reject_ghosts);
-    _tracker_vertex->setFastChi2Cut(_chi2_cut_fast_par0,
-           _chi2_cut_fast_par1,
-           _chi2_cut_fast_max);
-    _tracker_vertex->setChi2Cut(_chi2_cut_full);
-    _tracker_vertex->setChi2RemovalCut(_chi2_cut_full*0.5);
-    _tracker_vertex->setCellularAutomatonChi2Cut(_ca_chi2_cut);
-    _tracker_vertex->setPrintTimings(false);
-    if(verbosity > 3){_tracker_vertex->setPrintTimings(true);}
-    _tracker_vertex->setVerbosity(verbosity);
-    _tracker_vertex->setCutOnDca(_cut_on_dca);
-    _tracker_vertex->setDcaCut(_dca_cut);
-    _tracker_vertex->setSmoothBack(true);
-    _tracker_vertex->setBinScale(_bin_scale);
-    _tracker_vertex->setZBinScale(_z_bin_scale);
-    _tracker_vertex->setRemoveHits(_remove_hits);
-    _tracker_vertex->setSeparateByHelicity(true);
-    _tracker_vertex->setMaxHitsPairs(0);
-    _tracker_vertex->setCosAngleCut(_cos_angle_cut);
-    _tracker_vertex->setRequirePixels(true);
-
-    
   for(unsigned int ilayer = 0; ilayer < _fit_error_scale.size(); ++ilayer) {
     float scale1 = _fit_error_scale[ilayer];
     float scale2 = _vote_error_scale[ilayer];
     float scale = scale1/scale2;
     _tracker->setHitErrorScale(ilayer, scale);
-    _tracker_vertex->setHitErrorScale(ilayer, scale);
   }
-  
+
   return Fun4AllReturnCodes::EVENT_OK;
-}
-
-void PHG4HoughTransformTPC::set_material(int layer, float value)
-{
-  _user_material[layer] = value;
-}
-
-int PHG4HoughTransformTPC::CreateNodes(PHCompositeNode *topNode)
-{
-  // create nodes...
-  PHNodeIterator iter(topNode);
-  
-  PHCompositeNode *dstNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
-  if(!dstNode)
-  {
-    cerr << PHWHERE << "DST Node missing, doing nothing." << endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-      
-  // Create the SVTX node
-  PHCompositeNode* tb_node = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "SVTX"));
-  if (!tb_node) 
-  {
-    tb_node = new PHCompositeNode("SVTX");
-    dstNode->addNode(tb_node);
-    if (verbosity>0) cout << "SVTX node added" << endl;
-  }
- 	
-  _g4tracks = new SvtxTrackMap_v1;
-  PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(_g4tracks,"SvtxTrackMap","PHObject");
-  tb_node->addNode(tracks_node);
-  if (verbosity>0) cout << "Svtx/SvtxTrackMap node added" << endl;
-
-  _g4vertexes = new SvtxVertexMap_v1;
-  PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(_g4vertexes,"SvtxVertexMap","PHObject");
-  tb_node->addNode(vertexes_node);
-  if (verbosity>0) cout << "Svtx/SvtxVertexMap node added" << endl;
-  
-  //PHG4CylinderGeomContainer* geoms = getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_SVTX");
-  //if(!geoms) 
-  //{
-  //  cerr << PHWHERE << " ERROR: Can't find CYLINDERGEOM_SVTX Node." << endl;
-  //  return Fun4AllReturnCodes::ABORTEVENT;
-  //}
-
-  return InitializeGeometry(topNode);
 }
 
 int PHG4HoughTransformTPC::GetNodes(PHCompositeNode *topNode)
@@ -1211,12 +843,6 @@ int PHG4HoughTransformTPC::GetNodes(PHCompositeNode *topNode)
 
   _bbc_vertexes = getClass<BbcVertexMap>(topNode, "BbcVertexMap");
   
-  _ghitlist = getClass<PHG4HitContainer>(topNode,"G4HIT_SVTX");
-  if(!_ghitlist) 
-  {
-    cerr << PHWHERE << " ERROR: Can't find node PHG4HitContainer" << endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
   
   _g4clusters = getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
   if(!_g4clusters) 
@@ -1244,6 +870,567 @@ int PHG4HoughTransformTPC::GetNodes(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+int PHG4HoughTransformTPC::translate_input(){
+
+  for (SvtxClusterMap::Iter iter = _g4clusters->begin();
+       iter != _g4clusters->end();
+       ++iter) {
+    SvtxCluster* cluster = iter->second;
+
+//    float phi = atan2(cluster->get_position(1),cluster->get_position(0));
+    unsigned int ilayer = _layer_ilayer_map[cluster->get_layer()];
+
+//    float xy_error=0.;float z_error=0.;
+//    if (_use_cell_size) {
+//      xy_error = _smear_xy_layer[ilayer] * _vote_error_scale[ilayer];
+//      z_error  = _smear_z_layer[ilayer] * _vote_error_scale[ilayer];
+
+//    }
+//    else {
+//      if( cluster->get_phi_size() <= _max_cluster_error*_smear_xy_layer[ilayer] ){xy_error = cluster->get_phi_size() * _vote_error_scale[ilayer];}
+//      else{xy_error = _max_cluster_error*_smear_xy_layer[ilayer] * _vote_error_scale[ilayer];}
+//      if(cluster->get_z_size() <= _max_cluster_error*_smear_z_layer[ilayer]){z_error  = cluster->get_z_size() * _vote_error_scale[ilayer];}
+//      else{z_error  = _max_cluster_error*_smear_z_layer[ilayer] * _vote_error_scale[ilayer];}
+//    }
+
+    // cout<<"layer : "<<ilayer<<" , xy_error : "<<xy_error<<" , z_error : "<<z_error<<endl;
+
+//    if(ilayer < 3)
+//    {
+//      xy_error = 0.002;
+//      z_error = 0.002;
+//    }
+//    else
+//    {
+//      xy_error = 0.011;
+//      z_error = 0.03;
+//    }
+
+    vector<SimpleHit3D>* which_vec = &_clusters;
+    if (ilayer<_seed_layers) {which_vec=&_clusters_init;}
+
+    SimpleHit3D hit3d;
+
+    hit3d.set_id(cluster->get_id());
+    hit3d.set_layer(ilayer);
+
+    hit3d.set_x(cluster->get_x());
+    hit3d.set_y(cluster->get_y());
+    hit3d.set_z(cluster->get_z());
+
+//    hit3d.set_ex(fabs(xy_error*sin(phi)));
+//    hit3d.set_ey(fabs(xy_error*cos(phi)));
+//    hit3d.set_ez(z_error);
+
+    // copy covariance over
+    for (int i=0; i<3; ++i) {
+      for (int j=i; j<3; ++j) {
+        hit3d.set_error(i,j,cluster->get_error(i,j));
+        hit3d.set_size(i,j,cluster->get_size(i,j));
+      }
+    }
+
+    which_vec->push_back(hit3d);
+  }
+
+  if (verbosity > 20) {
+    cout << "-------------------------------------------------------------------" << endl;
+    cout << "PHG4HoughTransformTPC::process_event has the following input clusters:" << endl;
+
+    if (!_clusters_init.empty()) {
+      for (unsigned int i = 0; i < _clusters_init.size(); ++i) {
+        cout << "n init clusters = "<<_clusters_init.size() << endl;
+        _clusters_init[i].print();
+      }
+    } else {
+      for (unsigned int i = 0; i < _clusters.size(); ++i) {
+        cout << "n clusters = "<<_clusters.size() << endl;
+        _clusters[i].print();
+      }
+    }
+
+    cout << "-------------------------------------------------------------------" << endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4HoughTransformTPC::initial_zvertex_finding() {
+
+  // fast vertex guessing uses two tracker objects
+  // one looks for postive going eta tracks, the other for negative going tracks
+  // it asks for just a handful of each, but searches
+  // over the broadest possible phase space for the vertex origin
+
+  // limit each window to no more than N tracks
+  unsigned int maxtracks = 250;
+
+  _tracks.clear();
+  _track_errors.clear();
+  _track_covars.clear();
+
+  // loop over initial tracking windows
+  std::vector<SimpleTrack3D> newtracks;
+
+  if(verbosity) std::cout <<" positive eta seeded track finding.. "<< std::endl;
+  _tracker_etap_seed->clear();
+  _tracker_etap_seed->findHelices(_clusters_init, _min_vtx_hits, _max_vtx_hits,
+                                  newtracks, maxtracks);
+
+  if (verbosity) cout << " seed track finding count: " << newtracks.size() << endl;
+  for (unsigned int t = 0; t < newtracks.size(); ++t) {
+    if(newtracks[t].z0 < _min_z0 || newtracks[t].z0 > _max_z0 
+				|| (newtracks[t].z0)!=newtracks[t].z0){
+      if (verbosity) cout << " z0 out of bound: " << newtracks[t].z0 << endl;
+      continue;
+    }
+    if (verbosity) cout << " z0: " << newtracks[t].z0 << endl;
+    _tracks.push_back(newtracks[t]);
+    _track_covars.push_back( (_tracker_etap_seed->getKalmanStates())[t].C );
+  }
+
+  _tracker_etap_seed->clear();
+  newtracks.clear();
+
+  if(verbosity) std::cout <<" negative eta seeded track finding.. "<< std::endl;
+  _tracker_etam_seed->clear();
+  _tracker_etam_seed->findHelices(_clusters_init, _min_vtx_hits, _max_vtx_hits,
+                                  newtracks, maxtracks);
+
+  if (verbosity) cout << " seed track finding count: " << newtracks.size() << endl;
+  for (unsigned int t = 0; t < newtracks.size(); ++t) {
+    if(newtracks[t].z0 < _min_z0 || newtracks[t].z0 > _max_z0 
+				|| (newtracks[t].z0)!=newtracks[t].z0){
+      if (verbosity) cout << " z0 out of bound: " << newtracks[t].z0 << endl;
+      continue;
+    }
+    if (verbosity) cout << " z0: " << newtracks[t].z0 << endl;
+    _tracks.push_back(newtracks[t]);
+    _track_covars.push_back( (_tracker_etam_seed->getKalmanStates())[t].C );
+  }
+
+  _tracker_etam_seed->clear();
+  newtracks.clear();
+
+  _vertex.clear();
+  _vertex.assign(3,0.0);
+
+
+  if (verbosity) cout << " seed track used count: " << _tracks.size() << endl;
+
+  if (!_tracks.empty()) {
+
+    // --- compute seed vertex from initial track finding --------------------
+
+    double zsum = 0.0;
+    double zmse = 0.0;
+
+    for (unsigned int i = 0; i < _tracks.size(); ++i) {
+	zsum += _tracks[i].z0;
+    }
+
+    _vertex[2] = zsum / _tracks.size();
+
+    for(unsigned int i = 0; i< _tracks.size(); ++i) {	
+	zmse += pow(_vertex[2]-_tracks[i].z0, 2);
+    }
+    zmse /= (_tracks.size()-1);
+    zmse = sqrt(zmse);
+
+    if (verbosity > 0) {
+	cout << " seed track vertex pre-fit: "
+           << _vertex[0] << " "
+           << _vertex[1] << " "
+           << _vertex[2] << "+-" << zmse << endl;
+    }
+
+    // start with the average position and converge from there
+    _vertexFinder.findVertex( _tracks, _track_covars, _vertex, 3.00, true);
+    _vertexFinder.findVertex( _tracks, _track_covars, _vertex, 0.10, true);
+    _vertexFinder.findVertex( _tracks, _track_covars, _vertex, 0.02, true);
+  }
+
+  if (verbosity > 0) {
+    cout << " seed track vertex post-fit: "
+         << _vertex[0] << " " << _vertex[1] << " " << _vertex[2] << endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4HoughTransformTPC::full_tracking_and_vertexing() {
+
+  float shift_dx = -_vertex[0];
+  float shift_dy = -_vertex[1];
+  float shift_dz = -_vertex[2];
+
+  // shift to initial vertex position  
+  shift_coordinate_system(shift_dx,shift_dy,shift_dz);
+
+  // reset track storage and tracker
+  _tracks.clear();
+  _track_errors.clear();
+  _track_covars.clear();
+
+  _tracker->clear();
+  _timer_initial_hough.get()->restart();
+
+  // final track finding
+  if(verbosity) std::cout <<" final track finding.. "<< std::endl;
+  _tracker->findHelices(_clusters_init, _min_combo_hits, _max_combo_hits, _tracks);
+
+  if (verbosity > 0){
+    cout << " final track count, 1st pass: " << _tracks.size() << endl;
+  }
+
+
+  vector<SimpleHit3D> remaining_hits;
+  vector<int> used( _clusters_init.size(), 0 );
+  for(unsigned int tr=0;tr<_tracks.size();++tr)
+  {
+    for(unsigned int h=0;h<_tracks[tr].hits.size();++h)
+    {
+      used[_tracks[tr].hits[h].get_id()] = 1;
+    }
+  }
+  for(unsigned int i=0;i<_clusters_init.size();++i)
+  {
+    if( used[i] == 0 )
+    {
+      remaining_hits.push_back( _clusters_init[i] );
+    }
+  }
+  vector<SimpleTrack3D> append_tracks;
+  _tracker->findHelices(remaining_hits, _min_combo_hits, _max_combo_hits, append_tracks);
+  for(unsigned int tr=0;tr<append_tracks.size();++tr)
+  {
+    _tracks.push_back(append_tracks[tr]);
+  }
+  
+  _timer_initial_hough.get()->stop();
+
+  for (unsigned int tt = 0; tt < _tracks.size(); ++tt) {
+    _track_covars.push_back( (_tracker->getKalmanStates())[tt].C );
+    _track_errors.push_back( _tracker->getKalmanStates()[tt].chi2 );
+  }
+
+  // we will need the tracker object below to refit the tracks... so we won't
+  // reset it here
+  if (verbosity > 0){ 
+    cout << " final track count, 2nd pass: " << _tracks.size() << endl;
+    cout<< "PHG4HoughTransformTPC::process_event -- calculating final vertex" << endl;
+  }
+
+  if (!_tracks.empty()) {
+
+    // sort the tracks by pT
+    vector<vector<double> > pTmap;
+    for(unsigned int i=0;i<_tracks.size();++i)
+    {
+      double pT = kappaToPt(_tracks[i].kappa);
+      pTmap.push_back(vector<double>());
+      pTmap.back().push_back(pT);
+      pTmap.back().push_back((double)i);
+    }
+    sort(pTmap.begin(), pTmap.end());
+    vector<SimpleTrack3D> vtx_tracks;
+    vector<Matrix<float,5,5> > vtx_covars;
+    unsigned int maxtracks=100;
+    if(_tracks.size() < maxtracks){vtx_tracks = _tracks;}
+    else
+    {
+      for(unsigned int i=0;i<maxtracks;++i)
+      {
+        vtx_tracks.push_back(_tracks[ (int)(pTmap[pTmap.size()-1-i][1]) ]);
+        vtx_covars.push_back( (_tracker->getKalmanStates())[ (int)(pTmap[pTmap.size()-1-i][1]) ].C );
+      }
+    }
+
+    if (verbosity > 0) {
+      cout << " final vertex pre-fit: "
+           << _vertex[0] - shift_dx << " "
+           << _vertex[1] - shift_dy << " "
+           << _vertex[2] - shift_dz << endl;
+    }
+
+    _vertexFinder.findVertex( vtx_tracks, vtx_covars, _vertex, 0.300, false );
+    _vertexFinder.findVertex( vtx_tracks, vtx_covars, _vertex, 0.100, false );
+    _vertexFinder.findVertex( vtx_tracks, vtx_covars, _vertex, 0.020, false );
+    _vertexFinder.findVertex( vtx_tracks, vtx_covars, _vertex, 0.005, false );
+
+    if (verbosity > 0) {
+      cout << " final vertex post-fit: "
+           << _vertex[0] - shift_dx << " "
+           << _vertex[1] - shift_dy << " "
+           << _vertex[2] - shift_dz << endl;
+    }
+  }
+
+  // shift back to global coordinates
+  shift_coordinate_system(-shift_dx,-shift_dy,-shift_dz);
+
+  if(verbosity > 0)
+  {
+    cout << "PHG4HoughTransformTPC::process_event -- final vertex: " 
+	 << _vertex[0] << " " << _vertex[1] << " " << _vertex[2] << endl;
+  }
+
+/*
+  // we still need to update the track fields for DCA and PCA
+  // we can do that from the final vertex position
+  shift_dx = -_vertex[0];
+  shift_dy = -_vertex[1];
+  shift_dz = -_vertex[2];
+
+  // shift to precision final vertex
+  shift_coordinate_system(shift_dx,shift_dy,shift_dz);
+
+  // recompute track fits to fill dca and pca + error fields
+  std::vector<SimpleTrack3D> refit_tracks;
+  std::vector<double> refit_errors;
+  std::vector<Eigen::Matrix<float,5,5> > refit_covars;
+
+  _tracker->finalize(_tracks,refit_tracks);
+
+  for (unsigned int tt = 0; tt < refit_tracks.size(); ++tt) {
+    refit_errors.push_back( _tracker->getKalmanStates()[tt].chi2);
+    refit_covars.push_back( _tracker->getKalmanStates()[tt].C );
+  }
+
+  // okay now we are done with the tracker
+  _tracker->clear();
+
+  _tracks = refit_tracks;
+  _track_errors = refit_errors;
+  _track_covars = refit_covars;
+  // shift back to global coordinates
+  shift_coordinate_system(-shift_dx,-shift_dy,-shift_dz);
+*/
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4HoughTransformTPC::export_output() {
+
+  if(verbosity > 0)
+  {
+    cout << "PHG4HoughTransformTPC::process_event -- producing PHG4Track objects..." << endl;
+  }
+  SvtxVertex_v1 vertex;
+  vertex.set_t0(0.0);
+  for (int i=0;i<3;++i) vertex.set_position(i,_vertex[i]);
+  vertex.set_chisq(0.0);
+  vertex.set_ndof(0);
+  vertex.set_error(0,0,0.0);
+  vertex.set_error(0,1,0.0);
+  vertex.set_error(0,2,0.0);
+  vertex.set_error(1,0,0.0);
+  vertex.set_error(1,1,0.0);
+  vertex.set_error(1,2,0.0);
+  vertex.set_error(2,0,0.0);
+  vertex.set_error(2,1,0.0);
+  vertex.set_error(2,2,0.0);
+
+  // copy out the reconstructed vertex position
+  //_g4tracks->setVertex(_vertex[0],_vertex[1],_vertex[2]);
+  //_g4tracks->setVertexError(0.0,0.0,0.0);
+  
+  // at this point we should already have an initial pt and pz guess...
+  // need to translate this into the PHG4Track object...
+
+  vector<SimpleHit3D> track_hits;
+  int clusterID;
+  int clusterLayer;
+  for(unsigned int itrack=0; itrack<_tracks.size();itrack++)
+  {
+    SvtxTrack_v1 track;
+    track.set_id(itrack);
+    track_hits.clear();
+    track_hits = _tracks.at(itrack).hits;
+
+    for(unsigned int ihit = 0; ihit<track_hits.size();ihit++)
+    {
+      //      dEdx1=0;
+      //      dEdx2=0;
+      if( (track_hits.at(ihit).get_id()) >= _g4clusters->size()){continue;}
+      SvtxCluster *cluster = _g4clusters->get(track_hits.at(ihit).get_id());
+      clusterID = cluster->get_id();
+      clusterLayer = cluster->get_layer();
+      if( (clusterLayer < (int)_seed_layers) && (clusterLayer >= 0) )
+      {
+        track.insert_cluster(clusterID);
+      }
+    }
+    float kappa = _tracks.at(itrack).kappa;
+    float d = _tracks.at(itrack).d;
+    float phi = _tracks.at(itrack).phi;
+
+    float dzdl = _tracks.at(itrack).dzdl;
+    float z0 = _tracks.at(itrack).z0;
+    
+    float pT = kappaToPt(kappa);
+
+    float x_center = cos(phi)*(d+1/kappa); // x coordinate of circle center
+    float y_center = sin(phi)*(d+1/kappa); // y    "      "     "      "
+  
+    // find helicity from cross product sign
+    short int helicity;
+    if ((track_hits[0].get_x()-x_center) * 
+        (track_hits[track_hits.size()-1].get_y()-y_center) -
+        (track_hits[0].get_y()-y_center) * 
+        (track_hits[track_hits.size()-1].get_x()-x_center) > 0){
+      helicity = 1;
+    } else {
+      helicity = -1;
+    }
+    float pZ = 0;
+    if(dzdl != 1)
+    {
+      pZ = pT * dzdl / sqrt(1.0 - dzdl*dzdl);
+    }
+    int ndf = 2*_tracks.at(itrack).hits.size() - 5;
+    track.set_chisq(_track_errors[itrack]);
+    track.set_ndf(ndf);
+    track.set_px( pT*cos(phi-helicity*M_PI/2) );
+    track.set_py( pT*sin(phi-helicity*M_PI/2) );
+    track.set_pz( pZ );
+
+    track.set_dca2d( d );
+    track.set_dca2d_error(sqrt(_track_covars[itrack](1,1)));
+
+    if(_write_reco_tree==true) {
+      _recoevent->tracks.push_back( SimpleRecoTrack() );
+      _recoevent->tracks.back().px = pT*cos(phi-helicity*M_PI/2);
+      _recoevent->tracks.back().py = pT*sin(phi-helicity*M_PI/2);
+      _recoevent->tracks.back().pz = pZ;
+      _recoevent->tracks.back().d = d;
+      _recoevent->tracks.back().z0 = z0;
+      _recoevent->tracks.back().quality = _track_errors[itrack]/((float)ndf);
+      _recoevent->tracks.back().charge = (-1*helicity);
+    }
+
+    if(_magField > 0) {
+      track.set_charge( helicity );
+    } else {
+      track.set_charge( -1.0*helicity );
+    }
+
+    Eigen::Matrix<float,6,6> euclidean_cov = Matrix<float,6,6>::Zero(6,6);
+    convertHelixCovarianceToEuclideanCovariance( 
+        _magField, phi, d, kappa, z0, dzdl, 
+        _track_covars[itrack], euclidean_cov );
+
+    for(unsigned int row=0;row<6;++row) {
+      for(unsigned int col=0;col<6;++col) {
+        track.set_error(row,col,euclidean_cov(row,col));
+      }
+    }
+
+    track.set_x(vertex.get_x() + d * cos(phi));
+    track.set_y(vertex.get_y() + d * sin(phi));
+    track.set_z(vertex.get_z() + z0);
+
+    _g4tracks->insert(&track);
+    vertex.insert_track(track.get_id());
+
+    if (verbosity > 5) {
+      cout << "track " << itrack << " quality = " << track.get_quality()
+           << endl;
+      cout << "px = " << track.get_px() << " py = " << track.get_py()
+           << " pz = " << track.get_pz() << endl;
+    }
+  }  // track loop
+
+  SvtxVertex *vtxptr = _g4vertexes->insert(&vertex);
+  if (verbosity > 5) vtxptr->identify();
+
+  if (verbosity > 0) {
+    cout << "PHG4HoughTransform::process_event -- leaving process_event"
+         << endl;
+  }
+
+  _clusters.clear();
+  _tracks.clear();
+  _track_errors.clear();
+  _track_covars.clear();
+  _vertex.clear();
+  _vertex.assign(3,0.0);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+float PHG4HoughTransformTPC::kappaToPt(float kappa) {
+  return _pt_rescale * _magField / 333.6 / kappa;
+}
+
+float PHG4HoughTransformTPC::ptToKappa(float pt) {
+  return _pt_rescale * _magField / 333.6 / pt;
+}
+
+void PHG4HoughTransformTPC::convertHelixCovarianceToEuclideanCovariance( 
+     float B, float phi, float d, float kappa, float z0, float dzdl, 
+     Eigen::Matrix<float,5,5> const& input, 
+     Eigen::Matrix<float,6,6>& output ){
+
+  Eigen::Matrix<float,6,5> J = Matrix<float,6,5>::Zero(6,5);
+
+  // phi,d,nu,z0,dzdl
+  //--> 
+  // x,y,z,px,py,pz
+
+  float nu = sqrt(kappa);
+  float dk_dnu = 2*nu;
+
+  float cosphi = cos(phi);
+  float sinphi = sin(phi);
+
+  J( 0, 0 ) = -sinphi*d;
+  J( 0, 1 ) = cosphi;
+  J( 1, 0 ) = d*cosphi;
+  J( 1, 1 ) = sinphi;
+  J( 2, 3 ) = 1;
+
+  float pt = 0.003*B/kappa;
+  float dpt_dk = -0.003*B/(kappa*kappa);
+
+  J( 3, 0 ) = -cosphi*pt;
+  J( 3, 2 ) = -sinphi*dpt_dk*dk_dnu;
+  J( 4, 0 ) = -sinphi*pt;
+  J( 4, 2 ) = cosphi*dpt_dk*dk_dnu;
+
+  float alpha = 1./(1. - dzdl*dzdl);
+  float alpha_half = pow( alpha, 0.5 );
+  float alpha_3_half = alpha*alpha_half;
+
+  J( 5, 2 ) = dpt_dk*dzdl*alpha_half*dk_dnu;
+  J( 5, 4 ) = pt*( alpha_half + dzdl*dzdl*alpha_3_half )*dk_dnu;
+
+  output = J*input*(J.transpose());
+}
+
+void PHG4HoughTransformTPC::shift_coordinate_system(double dx,
+                                                 double dy,
+                                                 double dz) {
+
+  for (unsigned int ht = 0; ht < _clusters_init.size(); ++ht) {
+    _clusters_init[ht].set_x( _clusters_init[ht].get_x() + dx);
+    _clusters_init[ht].set_y( _clusters_init[ht].get_y() + dy);
+    _clusters_init[ht].set_z( _clusters_init[ht].get_z() + dz);
+  }
+
+  for (unsigned int tt = 0; tt < _tracks.size(); ++tt) {
+    for (unsigned int hh = 0; hh < _tracks[tt].hits.size(); ++hh) {
+      _tracks[tt].hits[hh].set_x( _tracks[tt].hits[hh].get_x() + dx);
+      _tracks[tt].hits[hh].set_y( _tracks[tt].hits[hh].get_y() + dy);
+      _tracks[tt].hits[hh].set_z( _tracks[tt].hits[hh].get_z() + dz);
+    }
+  }
+
+  _vertex[0] += dx;
+  _vertex[1] += dy;
+  _vertex[2] += dz;
+
+  return;
+}
 
 bool PHG4HoughTransformTPC::circle_line_intersections(double x0, double y0, double r0,
 						      double x1, double y1, double vx1, double vy1,
@@ -1350,7 +1537,7 @@ int PHG4HoughTransformTPC::fast_vertex_from_bbc() {
       _vertex[0] = 0.0;
       _vertex[1] = 0.0;
       _vertex[2] = vertex->get_z();
-
+     
       if (verbosity) cout << " initial bbc vertex guess: "
 			  << _vertex[0] << " "
 			  << _vertex[1] << " "

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -693,15 +693,15 @@ int PHG4HoughTransformTPC::setup_seed_tracker_objects() {
                         _min_z0, _max_z0); // dca_z range
 
   _tracker_etap_seed = new sPHENIXTrackerTPC(zoomprofile, 1, pos_range, _material, _radii, _magField);
-  _tracker_etap_seed->setEndLayer(4); // layers numbered from 0 towards outside
-  _tracker_etap_seed->requireLayers(5);
+  _tracker_etap_seed->setEndLayer(3); // layers numbered from 0 towards outside
+  _tracker_etap_seed->requireLayers(4);
   _tracker_etap_seed->setClusterStartBin(1);
   _tracker_etap_seed->setRejectGhosts(_reject_ghosts);
   _tracker_etap_seed->setFastChi2Cut(_chi2_cut_fast_par0,
                                      _chi2_cut_fast_par1,
                                      _chi2_cut_fast_max);
-  _tracker_etap_seed->setChi2Cut(_chi2_cut_full);
-  _tracker_etap_seed->setChi2RemovalCut(_chi2_cut_full*0.5);
+  _tracker_etap_seed->setChi2Cut(_chi2_cut_init);
+  _tracker_etap_seed->setChi2RemovalCut(_chi2_cut_init*0.5);
   _tracker_etap_seed->setCellularAutomatonChi2Cut(_ca_chi2_cut);
   _tracker_etap_seed->setPrintTimings(false);
   _tracker_etap_seed->setCutOnDca(false);
@@ -728,15 +728,15 @@ int PHG4HoughTransformTPC::setup_seed_tracker_objects() {
                         _min_z0, _max_z0); // dca_z range
 
   _tracker_etam_seed = new sPHENIXTrackerTPC(zoomprofile, 1, neg_range, _material, _radii, _magField);
-  _tracker_etam_seed->setEndLayer(4);
-  _tracker_etam_seed->requireLayers(5);
+  _tracker_etam_seed->setEndLayer(3);
+  _tracker_etam_seed->requireLayers(4);
   _tracker_etam_seed->setClusterStartBin(1);
   _tracker_etam_seed->setRejectGhosts(_reject_ghosts);
   _tracker_etam_seed->setFastChi2Cut(_chi2_cut_fast_par0,
                                      _chi2_cut_fast_par1,
                                      _chi2_cut_fast_max);
-  _tracker_etam_seed->setChi2Cut(_chi2_cut_full);
-  _tracker_etam_seed->setChi2RemovalCut(_chi2_cut_full*0.5);
+  _tracker_etam_seed->setChi2Cut(_chi2_cut_init);
+  _tracker_etam_seed->setChi2RemovalCut(_chi2_cut_init*0.5);
   _tracker_etam_seed->setCellularAutomatonChi2Cut(_ca_chi2_cut);
   _tracker_etam_seed->setPrintTimings(false);
   _tracker_etam_seed->setCutOnDca(false);

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -64,6 +64,7 @@ using namespace Eigen;
 
 PHG4HoughTransformTPC::PHG4HoughTransformTPC(unsigned int seed_layers, unsigned int req_seed, const string &name) :
   SubsysReco(name),
+  _nlayers(0),
   _seed_layers(seed_layers), 
   _req_seed(req_seed), 
   _radii(),
@@ -115,8 +116,10 @@ PHG4HoughTransformTPC::PHG4HoughTransformTPC(unsigned int seed_layers, unsigned 
   _g4vertexes(NULL),
   _timer(PHTimeServer::get()->insert_new("PHG4HoughTransformTPC")),
   _timer_initial_hough(PHTimeServer::get()->insert_new("PHG4HoughTransformTPC::track finding")),
-  _write_reco_tree(false)
-{
+  _write_reco_tree(false),
+  _reco_tree(NULL),
+  _recoevent(NULL)
+{  
 }
 
 int PHG4HoughTransformTPC::Init(PHCompositeNode *topNode)

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.h
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.h
@@ -94,6 +94,10 @@ public:
     _chi2_cut_fast_max = cut_max;
   }
 
+  /// set the initial tracking chi2 cut
+  void set_chi2_cut_init(double chi2_cut_init) {_chi2_cut_init = chi2_cut_init;}
+  /// get the initial tracking chi2 cut
+  double get_chi2_cut_init() { return _chi2_cut_init;}
   /// set the tracking chi2 cut for full fit 
   void set_chi2_cut_full(double chi2_cut) { _chi2_cut_full = chi2_cut;}
   /// get the tracking chi2 cut for full fit
@@ -297,6 +301,7 @@ public:
   double _chi2_cut_fast_par0;       ///< fit quality chisq/dof for fast fit track fitting
   double _chi2_cut_fast_par1;       ///< fit quality chisq/dof for fast fit track fitting
   double _chi2_cut_fast_max;        ///< fit quality chisq/dof for fast fit track fitting
+  double _chi2_cut_init;	    ///< fil quality chisq/dof for initial track fitting
   double _chi2_cut_full;            ///< fit quality chisq/dof for kalman track fitting
   double _ca_chi2_cut;
   double _cos_angle_cut;

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.h
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.h
@@ -40,8 +40,6 @@ class SvtxClusterMap;
 class SvtxTrackMap;
 class SvtxTrack;
 class SvtxVertexMap;
-class PHG4InEvent;
-class PHG4HitContainer;
 class SimpleRecoEvent;
 class TTree;
 
@@ -70,8 +68,6 @@ public:
   /// set verbosity
   void Verbosity(int verb) {
     verbosity = verb; // SubsysReco verbosity
-    //if(_tracker_init) _tracker_init->setVerbosity(verb);
-    //if(_tracker) _tracker->setVerbosity(verb);
   }
 
   /// external handle for projecting tracks into the calorimetry
@@ -88,16 +84,6 @@ public:
 
   float get_mag_field() const          {return _magField;}
   void  set_mag_field(float magField) {_magField = magField;}
-  
-  /// set option to produce initial vertex for further tracking
-  void set_use_vertex(bool b) {_use_vertex = b;}
-  /// fetch option to produce initial vertex for further tracking
-  bool get_use_vertex() {return _use_vertex;}
-
-  /// set the tracking chi2 for initial vertex finding
-  void set_chi2_cut_init(double chi2_cut) { _chi2_cut_init = chi2_cut;}
-  /// get the tracking chi2 cut for initial vertex finding
-  double get_chi2_cut_init() { return _chi2_cut_init;}
 
   /// set the tracking pt-dependent chi2 cut for fast fit, cut = min(par0 + par1 / pt, max)
   void set_chi2_cut_fast(double cut_par0,
@@ -122,15 +108,18 @@ public:
   void set_cos_angle_cut(double cos_angle_cut) { _cos_angle_cut = cos_angle_cut;}
   /// get early curvature cut between hits, lower values are more open
   double get_cos_angle_cut() { return _cos_angle_cut;}
+  
+  /// set the minimum pt to try to find during full tracking
+  void set_min_pT(float pt){_min_pt=pt;}
 
-  void setInitialResMultiplier(int beta){ _beta = beta;}
-  void setFullResMultiplier(int lambda){ _lambda = lambda;}
-  
-  /// set the minimum pT to try to find during full tracking
-  void set_min_pT(float PT){_min_pT=PT;}
-  /// set the minimum pT to try to find during initial vertex finding tracking
-  void set_min_pT_init(float PT){_min_pT_init=PT;}
-  
+  /// set the z0 search window 
+  void set_z0_range(float min_z0, float max_z0) {
+    _min_z0 = min_z0; _max_z0 = max_z0;
+  }
+
+  /// set the d search window
+  void set_d_max(float max_d) {_max_d = max_d;}
+
   /// radiation length per layer, sequential layer indexes required here
   void set_material(int layer, float value);
 
@@ -143,7 +132,7 @@ public:
   void setUseCellSize(bool use_cell_size) {_use_cell_size = use_cell_size;}
 
   /// limit the maximum error reported by cluster (in number of cell units)
-  void setMaxClusterError(float max_cluster_error) {_max_cluster_error = max_cluster_error;}
+  void setMaxClusterError(float max_cluster_error) {_max_cluster_error = max_cluster_error;} 
 
   /// adjusts the rate of zooming
   void setBinScale(float scale){_bin_scale = scale;}
@@ -153,7 +142,7 @@ public:
   /// turn on DCA limitation
   void setCutOnDCA(bool cod){_cut_on_dca = cod;}
   /// sets an upper limit on X-Y DCA
-  void setDCACut(float dcut){_dca_cut = dcut;}
+  void setDCACut(float dcut){_dcaxy_cut = dcut;}
   /// sets an upper limit on Z DCA
   void setDCAZCut(float dzcut){_dcaz_cut = dzcut;}
 
@@ -162,31 +151,114 @@ public:
 
   /// adjust the relative voting error scale w.r.t. the cluster size
   void setVoteErrorScale(unsigned int layer, float scale) {
-    if(scale > 0.0){_vote_error_scale.at(layer) = scale;}
-    else{std::cout<<"PHG4HoughTransformTPC::setVoteErrorScale : scale must be greater than zero ... doing nothing"<<std::endl;}
+    if (scale > 0.0) {
+      _vote_error_scale.at(layer) = scale;
+    } else{
+      std::cout << "PHG4HoughTransformTPC::setVoteErrorScale : scale must be "
+                   "greater than zero ... doing nothing"
+		<< std::endl;
+    }
   }
   /// adjust the relative fit error scale w.r.t. the cluster size
   void setFitErrorScale(unsigned int layer, float scale) {
-    if(scale > 0.0){_fit_error_scale.at(layer) = scale;}
-    else{std::cout<<"PHG4HoughTransformTPC::setFitErrorScale : scale must be greater than zero ... doing nothing"<<std::endl;}
+    if(scale > 0.0) {
+      _fit_error_scale.at(layer) = scale;
+    } else{
+      std::cout << "PHG4HoughTransformTPC::setFitErrorScale : scale must be "
+                   "greater than zero ... doing nothing"
+                << std::endl;
+    }
   }
 
   void setWriteRecoTree(bool flag){_write_reco_tree=flag;}
 
+  //---deprecated---------------------------------------------------------------
+/*
+  /// set option to produce initial vertex for further tracking
+  void set_use_vertex(bool b) {_use_vertex = b;}
+  /// fetch option to produce initial vertex for further tracking
+  bool get_use_vertex() {return _use_vertex;}
+
+  /// set the tracking chi2 for initial vertex finding
+  void set_chi2_cut_init(double chi2_cut) { _chi2_cut_init = chi2_cut;}
+  /// get the tracking chi2 cut for initial vertex finding
+  double get_chi2_cut_init() { return _chi2_cut_init;}
+  
+  void setInitialResMultiplier(int beta){ _beta = beta;}
+  void setFullResMultiplier(int lambda){ _lambda = lambda;}
+  /// set the minimum pT to try to find during initial vertex finding tracking
+  void set_min_pT_init(float PT){_min_pT_init=PT;}
+
+  bool _use_vertex;
+  double _chi2_cut_init; ///< fit quality chisq/dof for initial track finding
+  int _beta, _lambda; ///< resolution tuning parameters 
+  float _min_pT_init;
+*/
+
 #ifndef __CINT__
  private:
-  bool new_dca_nbin, new_z_z0, new_circle_dca, new_circle_kappa;
+
+  //--------------
+  // InitRun Calls
+  //--------------
+
+  /// create new node output pointers
   int CreateNodes(PHCompositeNode *topNode);
-  int GetNodes(PHCompositeNode *topNode);
+
+  /// scan tracker geometry objects
   int InitializeGeometry(PHCompositeNode *topNode);
 
-  /// code to seed vertex from bbc
+  /// setup seed tracking objects
+  int setup_seed_tracker_objects();
+
+  /// setup initial vertexing tracker
+  int setup_initial_tracker_object();
+
+  /// code to setup full tracking object
+  int setup_tracker_object();
+
+  //--------------------
+  // Process Event Calls
+  //--------------------
+
+  /// fetch node pointers
+  int GetNodes(PHCompositeNode *topNode);
+
+  /// translate into the HelixHough universe
+  int translate_input();
+
+  /// combine seed tracking vertex with BBCZ if available
+  int fast_composite_seed();
+   
+  /// seed vertex from bbc
   int fast_vertex_from_bbc();
-  
+
+  /// seed vertex from initial tracking using a broad search window
+  int initial_zvertex_finding();
+ 
+  /// perform the final tracking and vertexing
+  int full_tracking_and_vertexing();
+
+  /// translate back to the SVTX universe
+  int export_output();
+
+  //------------------
+  // Subfunction Calls
+  //------------------
+ 
   /// convert from inverse curvature to momentum
   float kappaToPt(float kappa);
   /// convert from momentum to inverse curvature
   float ptToKappa(float pt);
+
+  /// convert the covariance from HelixHough coords to x,y,z,px,py,pz
+  void convertHelixCovarianceToEuclideanCovariance(
+      float B, float phi, float d, float kappa, float z0, float dzdl,
+      Eigen::Matrix<float, 5, 5> const& input,
+      Eigen::Matrix<float, 6, 6>& output);
+
+  /// translate the clusters, tracks, and vertex from one origin to another
+  void shift_coordinate_system(double dx, double dy, double dz);
 
   /// helper function for projection code
   static bool circle_line_intersections(double x0, double y0, double r0,
@@ -197,89 +269,79 @@ public:
 					  double x1, double y1, double r1,
 					  std::set<std::vector<double> >* points);
   
-  bool _use_vertex;
-  int _beta, _lambda; ///< resolution tuning parameters 
+  int _nlayers;              ///< number of detector layers                                                         
+  unsigned int _seed_layers, _req_seed;
+  std::vector<float> _radii;          ///< radial distance of each layer (cm)                                           
+  std::vector<float> _smear_xy_layer; ///< detector hit resolution in phi (cm)                                          
+  std::vector<float> _smear_z_layer;  ///< detector hit resolution in z (cm)                 
+  std::vector<float> _material;  ///< material at each layer in rad. lengths
+  std::map<int, float> _user_material;
 
-  double _chi2_cut_init;            ///< fit quality chisq/dof for initial track finding
+  float _magField; ///< in Tesla
+  static float _cmToGeV;  ///< radius of curvature conversion (radius of curvature for a 1 GeV/c particle in 1 Tesla is 333.6 cm)
+
+  bool _reject_ghosts;
+  bool _remove_hits;
+  bool _use_cell_size;
+  float _max_cluster_error;
+
+  float _min_pt;
+  float _min_z0;
+  float _max_z0;
+  float _max_d;
+
+  bool _cut_on_dca;
+  float _dcaxy_cut;
+  float _dcaz_cut;
+
   double _chi2_cut_fast_par0;       ///< fit quality chisq/dof for fast fit track fitting
   double _chi2_cut_fast_par1;       ///< fit quality chisq/dof for fast fit track fitting
   double _chi2_cut_fast_max;        ///< fit quality chisq/dof for fast fit track fitting
   double _chi2_cut_full;            ///< fit quality chisq/dof for kalman track fitting
   double _ca_chi2_cut;
   double _cos_angle_cut;
-  unsigned int _max_hits_init;
-  unsigned int _min_hits_init;
-  unsigned int _maxtracks;
-  unsigned int _max_hits;
-  unsigned int _min_hits;
-  
-  int _nlayers;                  ///< number of detector layers                                                         
-  std::vector<float> _radii;          ///< radial distance of each layer (cm)                                           
-  std::vector<float> _smear_xy_layer; ///< detector hit resolution in phi (cm)                                          
-  std::vector<float> _smear_z_layer;  ///< detector hit resolution in z (cm)                 
-  std::vector<float> _material;  ///< material at each layer in rad. lengths
 
-  // object storage                                                                                                     
-  std::vector<SimpleHit3D> _clusters_init; ///< working array of clusters                                                    
-  std::vector<SimpleHit3D> _clusters;
-  std::vector<SimpleTrack3D> _tracks; ///< working array of tracks                                                      
-  std::vector<float> _vertex;         ///< working array for collision vertex                                           
-
-  // track finding routines                                                                                             
-  sPHENIXTrackerTPC *_tracker;    // finds full tracks  
-  sPHENIXTrackerTPC* _tracker_vertex; // finds a subset of tracks for initial vertex-finding
-  
-  
-  VertexFinder _vertexFinder; ///< vertex finding object
-
-  float _magField; ///< in Tesla
-  static float _cmToGeV;  ///< radius of curvature conversion (radius of curvature for a 1 GeV/c particle in 1 Tesla is 333.6 cm)
-
-  std::vector<double> _radius_vec;
-  
-  SvtxClusterMap* _g4clusters;
-  SvtxTrackMap* _g4tracks;
-  SvtxVertexMap* _g4vertexes;
-  PHG4InEvent* _inevent;
-
-  PHTimeServer::timer _timer;
-  PHTimeServer::timer _timer_initial_hough;
-  
-  float _min_pT;
-  float _min_pT_init;
-  
-  PHG4HitContainer* _ghitlist;
-  
-  unsigned int _seed_layers, _req_seed;
-  
-  std::map<int, float> _user_material;
-  
-  bool _reject_ghosts;
-  bool _remove_hits;
-  bool _use_cell_size;
-
-  float _max_cluster_error;
-  
   float _bin_scale;
   float _z_bin_scale;
-  
-  bool _cut_on_dca;
-  float _dca_cut;
-  float _dcaz_cut;
+
+  unsigned int _min_combo_hits;
+  unsigned int _max_combo_hits;
+
+  unsigned int _min_vtx_hits;
+  unsigned int _max_vtx_hits;
 
   float _pt_rescale;
-  
   std::vector<float> _fit_error_scale;
   std::vector<float> _vote_error_scale;
 
   /// recorded layer indexes to internal sequential indexes
-  std::map<int,unsigned int> _layer_ilayer_map; 
+  std::map<int,unsigned int> _layer_ilayer_map;
 
+  // object storage                                                                                                     
+  std::vector<SimpleHit3D> _clusters_init; ///< working array of clusters                                                    
+  std::vector<SimpleHit3D> _clusters;
+  std::vector<SimpleTrack3D> _tracks; ///< working array of tracks
+  std::vector<double> _track_errors;     ///< working array of track chisq                                                      
+  std::vector<Eigen::Matrix<float,5,5> > _track_covars; ///< working array of track covariances
+  std::vector<float> _vertex;         ///< working array for collision vertex                                           
+
+  // track finding routines                                                                                             
+  sPHENIXTrackerTPC *_tracker;    // finds full tracks  
+  sPHENIXTrackerTPC* _tracker_etap_seed; ///< finds a subset of tracks for the vertex guess
+  sPHENIXTrackerTPC* _tracker_etam_seed; ///< finds a subset of tracks for the vertex guess
+  VertexFinder _vertexFinder; ///< vertex finding object
+
+  BbcVertexMap* _bbc_vertexes; 
+  SvtxClusterMap* _g4clusters;
+  SvtxTrackMap* _g4tracks;
+  SvtxVertexMap* _g4vertexes;
+
+  PHTimeServer::timer _timer;
+  PHTimeServer::timer _timer_initial_hough;
+  
   bool _write_reco_tree;
   TTree* _reco_tree;
   SimpleRecoEvent* _recoevent;
-
-  BbcVertexMap* _bbc_vertexes;
 
 #endif // __CINT__
 };

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.h
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.h
@@ -127,6 +127,9 @@ public:
   /// radiation length per layer, sequential layer indexes required here
   void set_material(int layer, float value);
 
+  /// set use bbc
+  void set_use_vertex(bool ub){_use_bbc = ub;}  
+
   /// set internal ghost rejection
   void setRejectGhosts(bool rg){_reject_ghosts = rg;}
   /// set for internal hit rejection
@@ -193,7 +196,6 @@ public:
   /// set the minimum pT to try to find during initial vertex finding tracking
   void set_min_pT_init(float PT){_min_pT_init=PT;}
 
-  bool _use_vertex;
   double _chi2_cut_init; ///< fit quality chisq/dof for initial track finding
   int _beta, _lambda; ///< resolution tuning parameters 
   float _min_pT_init;
@@ -283,7 +285,8 @@ public:
 
   float _magField; ///< in Tesla
   static float _cmToGeV;  ///< radius of curvature conversion (radius of curvature for a 1 GeV/c particle in 1 Tesla is 333.6 cm)
-
+  
+  bool _use_bbc;
   bool _reject_ghosts;
   bool _remove_hits;
   bool _use_cell_size;


### PR DESCRIPTION
This pull request is to replace the current initial z-vertexing (from BBC with no smearing) with the realistic initial z-vertexing with MAPS+TPC.

The changes made:

offline/package/HelixHough/helix_hough/* 
: add a switch to use selective range of layers. 
: revive findTrackBySegments for initial z-vertexing. 

simulation/g4simulation/g4hough/PHG4HoughTransformTPC.*
: general makeover (modularization) 
: add seeded-tracking steps for initial z-vertexing

Here is an example of performance plot. 
(the std of z-vertex offset ~10um.)

[maps+tpc_L4_chisq2_3.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/397612/maps.tpc_L4_chisq2_3.pdf)

