### PR TITLE
Overlap in 1-D projective SPACAL

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.cc
@@ -144,7 +144,7 @@ PHG4CylinderGeom_Spacalv1::SetDefault()
   virualize_fiber = false;
   construction_verbose = 0;
 
-  init_default_sector_map();
+//  init_default_sector_map();
 }
 
 void

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.cc
@@ -76,7 +76,7 @@ PHG4CylinderGeom_Spacalv2::SetDefault()
   polar_taper_ratio = 1 + 1.1 / 42.;
   assembly_spacing = 0.0001; // order ~1um clearance around all structures
 
-  init_default_sector_map();
+//  init_default_sector_map();
 
 }
 
@@ -145,7 +145,7 @@ PHG4CylinderGeom_Spacalv2::set_azimuthal_n_sec(int azimuthalNSec)
     }
 
   azimuthal_n_sec = azimuthalNSec;
-  init_default_sector_map();
+//  init_default_sector_map();
 }
 
 bool

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
@@ -344,7 +344,7 @@ PHG4CylinderGeom_Spacalv3::get_tower_z_phi_ID(const int tower_ID,
 void
 PHG4CylinderGeom_Spacalv3::subtower_consistency_check() const
 {
-  assert(sector_tower_map.begin() != sector_tower_map.end());
+  if (sector_tower_map.begin() == sector_tower_map.end()) return;
 
   for (tower_map_t::const_iterator it = sector_tower_map.begin();
       it != sector_tower_map.end(); ++it)
@@ -365,6 +365,7 @@ PHG4CylinderGeom_Spacalv3::subtower_consistency_check() const
 int
 PHG4CylinderGeom_Spacalv3::get_n_subtower_eta() const
 {
+  if (sector_tower_map.begin() == sector_tower_map.end()) return 0;
   assert(sector_tower_map.begin() != sector_tower_map.end());
   return sector_tower_map.begin()->second.NSubtowerY;
 }
@@ -372,6 +373,7 @@ PHG4CylinderGeom_Spacalv3::get_n_subtower_eta() const
 int
 PHG4CylinderGeom_Spacalv3::get_n_subtower_phi() const
 {
+  if (sector_tower_map.begin() == sector_tower_map.end()) return 0;
   assert(sector_tower_map.begin() != sector_tower_map.end());
   return sector_tower_map.begin()->second.NSubtowerX;
 }

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -144,6 +144,9 @@ PHG4SpacalDetector::Construct(G4LogicalVolume* logicWorld)
 
 
   // install sectors
+  if (_geom->get_sector_map().size() == 0)
+    _geom->init_default_sector_map();
+
   std::pair<G4LogicalVolume *,G4Transform3D> psec = Construct_AzimuthalSeg();
   G4LogicalVolume *sec_logic = psec.first;
   const G4Transform3D & sec_trans = psec.second;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -60,6 +60,8 @@ PHG4SpacalDetector::PHG4SpacalDetector(PHCompositeNode *Node,
 
   fiber_core_step_limits = new G4UserLimits(
       _geom->get_fiber_core_step_size() * cm);
+
+  Verbosity(_geom->get_construction_verbose());
 }
 
 PHG4SpacalDetector::~PHG4SpacalDetector(void)
@@ -226,7 +228,7 @@ PHG4SpacalDetector::Construct(G4LogicalVolume* logicWorld)
       //    geo->identify();
     }
 
-  if ((verbosity > 0) && (_geom->get_construction_verbose() >= 1))
+  if ((verbosity > 0))
     {
       cout << "PHG4SpacalDetector::Construct::" << GetName()
           << " - Completed. Print Geometry:" << endl;
@@ -347,7 +349,7 @@ PHG4SpacalDetector::Construct_Fiber(const G4double length, const string & id)
     }
 
     const bool overlapcheck_fiber = overlapcheck
-        and (_geom->get_construction_verbose() >= 3);
+        and (verbosity >= 3);
   G4PVPlacement * core_physi = new G4PVPlacement(0, G4ThreeVector(), core_logic,
       G4String(G4String(GetName() + string("_fiber_core") + id)), fiber_logic,
       false, 0, overlapcheck_fiber);


### PR DESCRIPTION
In https://github.com/sPHENIX-Collaboration/macros/pull/34, @nfeege reported an overlap error in central EMCal. That trace to an overlap problem introduce to 1-D projective SPACAL  ( ~30um overlap between sectors) in a past commit (cfb339e64a3fcfbdf0df35ed0b10a75a8a52ac76). 2-D projective SPACAL is NOT affected. 

This pull request carries the patch fixing this problem.

## Checks

Both 1-D and 2-D projective SPACAL do not has overlap after this fix. Nevertheless, I also invite @nfeege to check again in the full macro. 

For 1-D projective SPACAL, this bug lead to ~30um overlap between sectors. Fixing this problem slightly changed the visible sampling fraction from 2.33% in the nightly-build to 2.28% with this patch. The full comparison is checked with calorimeter QA using 24 GeV electrons: 

![qa_draw_cemc_g4hit](https://cloud.githubusercontent.com/assets/7947083/17380017/eabe94f2-5992-11e6-8fe0-0c6331a1fccb.png)
![g4sphenixcells root_qa_new rootqa_draw_cemc_towercluster](https://cloud.githubusercontent.com/assets/7947083/17380064/2bd74308-5993-11e6-94e5-42060179d2cb.png)

The 2-D projective SPACAL remain unchanged.
