### PR TITLE
Truth tracking2

### DIFF
--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
@@ -84,18 +84,29 @@ Fitter::~Fitter()
 int Fitter::processTrack(PHGenFit::Track* track, const bool save_to_evt_disp) {
 	genfit::Track* fitTrack = track->getGenFitTrack();
 	if(!fitTrack->checkConsistency()){
-		if(verbosity >= 1) LogWARNING("genfit::Track::checkConsistency() failed!") ;
+		if(verbosity >= 2) LogWARNING("genfit::Track::checkConsistency() failed!") ;
 		return -1;
 	}
-	_fitter->processTrack(fitTrack);
+
+	try {
+		_fitter->processTrack(fitTrack);
+	} catch (genfit::Exception& e) {
+		if (verbosity >= 1) {
+			std::cerr << "PHGenFit::Exception: \n";
+			std::cerr << e.what();
+			std::cerr << "Exception, next track" << std::endl;
+		}
+		return -1;
+	}
+
 	if(!fitTrack->checkConsistency()){
-		if(verbosity >= 1) LogWARNING("genfit::Track::checkConsistency() failed!") ;
+		if(verbosity >= 2) LogWARNING("genfit::Track::checkConsistency() failed!") ;
 		return -1;
 	}
 
 	genfit::AbsTrackRep* rep = fitTrack->getCardinalRep();
 	if (!fitTrack->getFitStatus(rep)->isFitConverged()) {
-		if(verbosity >= 1) LogWARNING("Track could not be fitted successfully! Fit is not converged!");
+		if(verbosity >= 2) LogWARNING("Track could not be fitted successfully! Fit is not converged!");
 		return -1;
 	}
 

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
@@ -20,6 +20,7 @@
 #include <GenFit/AbsKalmanFitter.h>
 #include <GenFit/KalmanFitter.h>
 #include <GenFit/KalmanFitterRefTrack.h>
+#include <GenFit/DAF.h>
 #include <GenFit/RKTrackRep.h>
 
 //GenFitExp
@@ -66,8 +67,14 @@ Fitter::Fitter(
 		_fitter = new genfit::KalmanFitterRefTrack();
 	else if(fitter_choice.compare("KalmanFitter")==0)
 		_fitter = new genfit::KalmanFitter();
+	else if(fitter_choice.compare("DafSimple")==0)
+		_fitter = new genfit::DAF(false);
+	else if(fitter_choice.compare("DafRef")==0)
+		_fitter = new genfit::DAF(true);
 	else
 		_fitter = new genfit::KalmanFitter();
+
+	genfit::Exception::quiet(true);
 }
 
 Fitter::~Fitter()

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
@@ -83,7 +83,7 @@ Fitter::~Fitter()
 		delete _fitter;
 	if(_tgeo_manager)
 		//delete _tgeo_manager;
-		_tgeo_manager->Delete();
+		//_tgeo_manager->Delete();
 	if(_display)
 		delete _display;
 }
@@ -129,6 +129,29 @@ Fitter* Fitter::getInstance(const std::string tgeo_file_name,
 		const bool doEventDisplay) {
 
 	TGeoManager* tgeo_manager = TGeoManager::Import(tgeo_file_name.data(), "Default");
+	if(!tgeo_manager)
+	{
+		LogERROR("No TGeoManager found!");
+		return NULL;
+	}
+
+	genfit::Field2D *fieldMap = new genfit::Field2D();
+	if(!fieldMap->initialize(field_file_name.data()))
+	{
+		LogERROR("Field map initialization failed!");
+		delete fieldMap;
+		return NULL;
+	}
+	fieldMap->re_scale(field_scaling_factor);// Re-scale to 1.4 T
+
+	return new Fitter(tgeo_manager, fieldMap, fitter_choice, track_rep_choice, doEventDisplay);
+}
+
+Fitter* Fitter::getInstance(TGeoManager* tgeo_manager,
+		const std::string field_file_name, const double field_scaling_factor,
+		const std::string fitter_choice, const std::string track_rep_choice,
+		const bool doEventDisplay) {
+
 	if(!tgeo_manager)
 	{
 		LogERROR("No TGeoManager found!");

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
@@ -85,6 +85,7 @@ public:
 
 	void set_verbosity(int verbosity) {
 		this->verbosity = verbosity;
+		if(verbosity>=1) genfit::Exception::quiet(false);
 	}
 
 private:

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
@@ -60,6 +60,13 @@ public:
 			const std::string track_rep_choice = "RKTrackRep",
 			const bool doEventDisplay = false);
 
+	static Fitter* getInstance(TGeoManager* tgeo_manager,
+			const std::string field_file_name,
+			const double field_scaling_factor = 1.4/1.5,
+			const std::string fitter_choice = "KalmanFitterRefTrack",
+			const std::string track_rep_choice = "RKTrackRep",
+			const bool doEventDisplay = false);
+
 	int processTrack(PHGenFit::Track* track, const bool save_to_evt_disp = false);
 
 	int displayEvent();
@@ -86,6 +93,7 @@ public:
 	void set_verbosity(int verbosity) {
 		this->verbosity = verbosity;
 		if(verbosity>=1) genfit::Exception::quiet(false);
+		else genfit::Exception::quiet(true);
 	}
 
 private:

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
@@ -92,11 +92,11 @@ private:
 	/*!
 	 * Verbose control:
 	 * -1: Silient
-	 * 0: Only Error
-	 * 1: Error + Warning
-	 * 2: DEBUG info
+	 * 0: Minimum
+	 * 1: Errors only
+	 * 2: Errors and Warnings
+	 * 3: Verbose mode, long term debugging
 	 */
-
 	int verbosity;
 
 	TGeoManager* _tgeo_manager;

--- a/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.cc
@@ -11,7 +11,7 @@
 
 namespace PHGenFit {
 
-void SpacepointMeasurement::init(const TVector3& pos, const double resolution)
+void SpacepointMeasurement::init(const TVector3& pos, const TMatrixDSym& cov)
 {
 
 	int nDim = 3;
@@ -22,9 +22,9 @@ void SpacepointMeasurement::init(const TVector3& pos, const double resolution)
 	hitCoords(1) = pos.Y();
 	hitCoords(2) = pos.Z();
 
-	hitCov(0,0) = resolution*resolution;
-	hitCov(1,1) = resolution*resolution;
-	hitCov(2,2) = resolution*resolution;
+	for(int i=0;i<3;i++)
+		for(int j=0;j<3;j++)
+			hitCov(i,j) = cov(i,j);
 
 	int measurementCounter_ = 0;
 	_measurement = new genfit::SpacepointMeasurement(hitCoords, hitCov, -1,
@@ -35,7 +35,22 @@ void SpacepointMeasurement::init(const TVector3& pos, const double resolution)
 
 SpacepointMeasurement::SpacepointMeasurement(const TVector3& pos, const double resolution)
 {
-	init(pos, resolution);
+	TMatrixDSym cov(3);
+	cov.Zero();
+	cov(0, 0) = resolution*resolution;
+	cov(1, 1) = resolution*resolution;
+	cov(2, 2) = resolution*resolution;
+	init(pos, cov);
+}
+
+/*!
+ * Ctor
+ * \param pos measurement position
+ * \param covariance matrix
+ */
+SpacepointMeasurement::SpacepointMeasurement(const TVector3& pos, const TMatrixDSym& cov)
+{
+	init(pos, cov);
 }
 
 SpacepointMeasurement::~SpacepointMeasurement()

--- a/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.h
@@ -17,10 +17,22 @@ namespace PHGenFit {
 class SpacepointMeasurement : public Measurement
 {
 public:
-	//!ctor
+	/*!
+	 * Ctor
+	 * \param pos measurement position
+	 * \param resolution standard dev for diagnal elements of the cov, other elements are zero
+	 */
 	SpacepointMeasurement(const TVector3& pos, const double resolution);
 
-	void init(const TVector3& pos, const double resolution);
+	/*!
+	 * Ctor
+	 * \param pos measurement position
+	 * \param covariance matrix
+	 */
+	SpacepointMeasurement(const TVector3& pos, const TMatrixDSym& cov);
+
+
+	void init(const TVector3& pos, const TMatrixDSym& cov);
 
 	//!dtor
 	~SpacepointMeasurement();

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.h
@@ -11,10 +11,10 @@
 #include <vector>
 
 //BOOST
-#include<boost/make_shared.hpp>
-
-#define SMART(expr) boost::shared_ptr<expr>
-#define NEW(expr) boost::make_shared<expr>
+//#include<boost/make_shared.hpp>
+//
+//#define SMART(expr) boost::shared_ptr<expr>
+//#define NEW(expr) boost::make_shared<expr>
 
 //GenFit
 

--- a/simulation/g4simulation/g4hough/Makefile.am
+++ b/simulation/g4simulation/g4hough/Makefile.am
@@ -60,6 +60,7 @@ pkginclude_HEADERS = \
   SvtxTrackState_v1.h \
   SvtxTrack.h \
   SvtxTrack_v1.h \
+  SvtxTrack_FastSim.h \
   SvtxTrackMap.h \
   SvtxTrackMap_v1.h \
   SvtxBeamSpot.h \
@@ -67,6 +68,7 @@ pkginclude_HEADERS = \
   PHG4HoughTransformTPC.h \
   PHG4TrackGhostRejection.h \
   PHG4TrackKalmanFitter.h \
+  PHG4TrackFastSim.h \
   PHG4SvtxMomentumRecal.h \
   PHG4SvtxTrackProjection.h \
   PHG4SvtxBeamSpotReco.h \
@@ -97,7 +99,9 @@ libg4hough_io_la_SOURCES = \
   SvtxTrack.C \
   SvtxTrack_Dict.C \
   SvtxTrack_v1.C \
+  SvtxTrack_FastSim.C \
   SvtxTrack_v1_Dict.C \
+  SvtxTrack_FastSim_Dict.C \
   SvtxBeamSpot.C \
   SvtxBeamSpot_Dict.C \
   SvtxTrackMap.C \
@@ -133,7 +137,9 @@ libg4hough_la_SOURCES = \
   PHG4TrackGhostRejection.C \
   PHG4TrackGhostRejection_Dict.C \
   PHG4TrackKalmanFitter.C \
+  PHG4TrackFastSim.C \
   PHG4TrackKalmanFitter_Dict.C \
+  PHG4TrackFastSim_Dict.C \
   PHG4SvtxMomentumRecal.C \
   PHG4SvtxMomentumRecal_Dict.C \
   PHG4SvtxTrackProjection.C \

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -61,7 +61,7 @@ PHG4TrackFastSim::PHG4TrackFastSim(const std::string &name) :
 		 _mag_field_re_scaling_factor(1.), _reverse_mag_field(false), _fit_alg_name("KalmanFitterRefTrack"), _do_evt_display(false),
 		 _use_vertex_in_fitting(true), _vertex_xy_resolution(50E-4), _vertex_z_resolution(50E-4),
 		 _phi_resolution(50E-4), _r_resolution(1.), _z_resolution(50E-4),
-		 _pat_rec_hit_finding_eff(1.), _pat_rec_nosise_prob(0.),
+		 _pat_rec_hit_finding_eff(1.), _pat_rec_noise_prob(0.),
 		 _N_DETECTOR_LAYER(5)
 		 {
 
@@ -382,7 +382,7 @@ int PHG4TrackFastSim::PseudoPatternRecognition(
 #endif
 
 				if (hit->get_trkid() == particle->get_track_id()
-						|| gRandom->Uniform(0, 1) < _pat_rec_nosise_prob) {
+						|| gRandom->Uniform(0, 1) < _pat_rec_noise_prob) {
 
 					PHGenFit::Measurement* meas = NULL;
 					if (_detector_type == Vertical_Plane)

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -193,11 +193,11 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 		_trackmap_out->insert(svtx_track_out);
 	}
 
-	if(_trackmap_out->get(0)) {
-		_trackmap_out->get(0)->identify();
-		std::cout<<"DEBUG : "<< _trackmap_out->get(0)->get_px() <<"\n";
-		std::cout<<"DEBUG : "<< _trackmap_out->get(0)->get_truth_track_id() <<"\n";
-	}
+//	if(_trackmap_out->get(0)) {
+//		_trackmap_out->get(0)->identify();
+//		std::cout<<"DEBUG : "<< _trackmap_out->get(0)->get_px() <<"\n";
+//		std::cout<<"DEBUG : "<< _trackmap_out->get(0)->get_truth_track_id() <<"\n";
+//	}
 
 	return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -331,29 +331,33 @@ int PHG4TrackFastSim::PseudoPatternRecognition(
 			continue;
 		}
 
-		for (PHG4HitContainer::ConstIterator itr =
-				_phg4hits[ilayer]->getHits().first;
-				itr != _phg4hits[ilayer]->getHits().second; ++itr) {
-			PHG4Hit * hit = itr->second;
-			if(!hit) {
-				LogDebug("No PHG4Hit Found!");
-				continue;
-			}
-			if (hit->get_trkid() == particle->get_track_id() || gRandom->Uniform(0,1) < _pat_rec_nosise_prob) {
-				PHGenFit::Measurement* meas = NULL;
-				if(_detector_type == Vertical_Plane)
-					meas = PHG4HitToMeasurementVerticalPlane(hit);
-				else if(_detector_type == Cylinder)
-					meas = PHG4HitToMeasurementCylinder(hit);
-				else {
-					LogError("Type not implemented!");
-					return Fun4AllReturnCodes::ABORTEVENT;
-				}
-				if(gRandom->Uniform(0,1) <= _pat_rec_hit_finding_eff)
-					meas_out.push_back(meas);
-			}
-		}
+		LogDebug("");
+		std::cout<< "nlayers: " << _phg4hits[ilayer]->num_layers() <<"\n";
 
+		for(unsigned int isublayer=0; isublayer<_phg4hits[ilayer]->num_layers(); isublayer++) {
+			for (PHG4HitContainer::ConstIterator itr =
+					_phg4hits[ilayer]->getHits(isublayer).first;
+					itr != _phg4hits[ilayer]->getHits(isublayer).second; ++itr) {
+				PHG4Hit * hit = itr->second;
+				if(!hit) {
+					LogDebug("No PHG4Hit Found!");
+					continue;
+				}
+				if (hit->get_trkid() == particle->get_track_id() || gRandom->Uniform(0,1) < _pat_rec_nosise_prob) {
+					PHGenFit::Measurement* meas = NULL;
+					if(_detector_type == Vertical_Plane)
+						meas = PHG4HitToMeasurementVerticalPlane(hit);
+					else if(_detector_type == Cylinder)
+						meas = PHG4HitToMeasurementCylinder(hit);
+					else {
+						LogError("Type not implemented!");
+						return Fun4AllReturnCodes::ABORTEVENT;
+					}
+					if(gRandom->Uniform(0,1) <= _pat_rec_hit_finding_eff)
+						meas_out.push_back(meas);
+				}
+			}
+		} /*Loop layers within one detector layer*/
 	} /*Loop detector layers*/
 
 	return Fun4AllReturnCodes::EVENT_OK;

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -413,8 +413,25 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 	double chi2 = phgf_track->get_chi2();
 	double ndf = phgf_track->get_ndf();
 
-	genfit::MeasuredStateOnPlane* gf_state = phgf_track->extrapolateToPlane(
-			TVector3(0., 0., 0.), TVector3(0., 0., 1.));
+	genfit::MeasuredStateOnPlane* gf_state = NULL;
+
+	if (_detector_type == Vertical_Plane)
+		gf_state = phgf_track->extrapolateToPlane(TVector3(0., 0., 0.),
+				TVector3(0., 0., 1.));
+	else if (_detector_type == Cylinder)
+		gf_state = phgf_track->extrapolateToLine(TVector3(0., 0., 0.),
+				TVector3(0., 0., 1.));
+	else {
+		LogError("Detector Type NOT implemented!");
+		return NULL;
+	}
+
+	if(!gf_state) {
+		LogError("Extraction faild!");
+		return NULL;
+	}
+
+
 	TVector3 mom = gf_state->getMom();
 	TVector3 pos = gf_state->getPos();
 	TMatrixDSym cov = gf_state->get6DCov();

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -40,7 +40,6 @@
 
 #include "PHG4TrackFastSim.h"
 
-
 #define LogDebug(exp)		std::cout<<"DEBUG: "	<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
 #define LogError(exp)		std::cout<<"ERROR: "	<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
 #define LogWarning(exp)	std::cout<<"WARNING: "	<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
@@ -52,23 +51,22 @@
 using namespace std;
 
 PHG4TrackFastSim::PHG4TrackFastSim(const std::string &name) :
-		SubsysReco(name),
-		_detector_type(Vertical_Plane),
-		_truth_container(NULL),
-		_sub_top_node_name("SVTX"), /*_clustermap_out_name("SvtxClusterMap"),*/ _trackmap_out_name("SvtxTrackMap"),
-		/*_clustermap_out(NULL),*/_trackmap_out(NULL),
-		_fitter (NULL),_mag_field_file_name("/phenix/upgrades/decadal/fieldmaps/fsPHENIX.2d.root"),
-		 _mag_field_re_scaling_factor(1.), _reverse_mag_field(false), _fit_alg_name("KalmanFitterRefTrack"), _do_evt_display(false),
-		 _use_vertex_in_fitting(true), _vertex_xy_resolution(50E-4), _vertex_z_resolution(50E-4),
-		 _phi_resolution(50E-4), _r_resolution(1.), _z_resolution(50E-4),
-		 _pat_rec_hit_finding_eff(1.), _pat_rec_noise_prob(0.),
-		 _N_DETECTOR_LAYER(5)
-		 {
+		SubsysReco(name), _detector_type(Vertical_Plane), _truth_container(
+				NULL), _sub_top_node_name("SVTX"), /*_clustermap_out_name("SvtxClusterMap"),*/_trackmap_out_name(
+				"SvtxTrackMap"),
+		/*_clustermap_out(NULL),*/_trackmap_out(NULL), _fitter(NULL), _mag_field_file_name(
+				"/phenix/upgrades/decadal/fieldmaps/fsPHENIX.2d.root"), _mag_field_re_scaling_factor(
+				1.), _reverse_mag_field(false), _fit_alg_name(
+				"KalmanFitterRefTrack"), _primary_assumption_pid(211), _do_evt_display(
+				false), _use_vertex_in_fitting(true), _vertex_xy_resolution(
+				50E-4), _vertex_z_resolution(50E-4), _phi_resolution(50E-4), _r_resolution(
+				1.), _z_resolution(50E-4), _pat_rec_hit_finding_eff(1.), _pat_rec_noise_prob(
+				0.), _N_DETECTOR_LAYER(5) {
 
 	_event = -1;
 
-	for(int i=0;i<_N_DETECTOR_LAYER;i++) {
-		_phg4hits_names.push_back(Form("G4HIT_FGEM_%1d",i));
+	for (int i = 0; i < _N_DETECTOR_LAYER; i++) {
+		_phg4hits_names.push_back(Form("G4HIT_FGEM_%1d", i));
 	}
 }
 
@@ -88,14 +86,16 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode *topNode) {
 
 	_event = -1;
 
-
 	CreateNodes(topNode);
 
 	TGeoManager* tgeo_manager = PHGeomUtility::GetTGeoManager(topNode);
 
 	//_fitter = new PHGenFit::Fitter("sPHENIX_Geo.root","sPHENIX.2d.root", 1.4 / 1.5);
 	_fitter = PHGenFit::Fitter::getInstance(tgeo_manager,
-			_mag_field_file_name.data(), (_reverse_mag_field) ? -1.*_mag_field_re_scaling_factor : _mag_field_re_scaling_factor, "KalmanFitterRefTrack", "RKTrackRep",
+			_mag_field_file_name.data(),
+			(_reverse_mag_field) ?
+					-1. * _mag_field_re_scaling_factor :
+					_mag_field_re_scaling_factor, _fit_alg_name, "RKTrackRep",
 			_do_evt_display);
 
 	if (!_fitter) {
@@ -110,7 +110,7 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode *topNode) {
 
 int PHG4TrackFastSim::End(PHCompositeNode *topNode) {
 
-	if(_do_evt_display) {
+	if (_do_evt_display) {
 		_fitter->displayEvent();
 	}
 
@@ -121,7 +121,8 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 
 	_event++;
 
-	if(verbosity >= 2) std::cout<< "PHG4TrackFastSim::process_event: "<< _event << ".\n";
+	if (verbosity >= 2)
+		std::cout << "PHG4TrackFastSim::process_event: " << _event << ".\n";
 
 	GetNodes(topNode);
 
@@ -132,7 +133,7 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 //		return Fun4AllReturnCodes::ABORTRUN;
 //	}
 
-	if(_trackmap_out)
+	if (_trackmap_out)
 		_trackmap_out->empty();
 	else {
 		LogError("_trackmap_out not found!");
@@ -158,17 +159,19 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 		PHGenFit::Measurement* vtx_meas = NULL;
 
 		if (_use_vertex_in_fitting) {
-			vtx_meas = VertexMeasurement(
-					TVector3(0, 0, 0), _vertex_xy_resolution, _vertex_z_resolution);
+			vtx_meas = VertexMeasurement(TVector3(0, 0, 0),
+					_vertex_xy_resolution, _vertex_z_resolution);
 			measurements.push_back(vtx_meas);
 		}
 
-		PseudoPatternRecognition(particle, measurements, seed_pos, seed_mom, seed_cov);
+		PseudoPatternRecognition(particle, measurements, seed_pos, seed_mom,
+				seed_cov);
 
 		if (measurements.size() < 3) {
-			if(verbosity >= 2) {
+			if (verbosity >= 2) {
 				//LogWarning("measurements.size() < 3");
-				std::cout<<"event: "<< _event << " : measurements.size() < 3" <<"\n";
+				std::cout << "event: " << _event << " : measurements.size() < 3"
+						<< "\n";
 			}
 			continue;
 		}
@@ -182,9 +185,10 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 		 * e-:	11
 		 * e+:	-11
 		 */
-		int pid = 13; //
+		//int pid = 13; //
 		//SMART(genfit::AbsTrackRep) rep = NEW(genfit::RKTrackRep)(pid);
-		genfit::AbsTrackRep* rep = new genfit::RKTrackRep(pid);
+		genfit::AbsTrackRep* rep = new genfit::RKTrackRep(
+				_primary_assumption_pid);
 
 		//rep->setDebugLvl(1); //DEBUG
 
@@ -202,23 +206,23 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 		//! Fit the track
 		int fitting_err = _fitter->processTrack(track, false);
 
-		if(fitting_err != 0)
-		{
-			if(verbosity >= 2) {
+		if (fitting_err != 0) {
+			if (verbosity >= 2) {
 				//LogWarning("measurements.size() < 3");
-				std::cout<<"event: "<< _event << " : fitting_err != 0, next track." <<"\n";
+				std::cout << "event: " << _event
+						<< " : fitting_err != 0, next track." << "\n";
 			}
 			continue;
 		}
 
-		SvtxTrack* svtx_track_out = MakeSvtxTrack(track,particle->get_track_id());
+		SvtxTrack* svtx_track_out = MakeSvtxTrack(track,
+				particle->get_track_id());
 
 		_trackmap_out->insert(svtx_track_out);
 	} // Loop all primary particles
 
-
 	//! add tracks to event display
-	if(_do_evt_display)
+	if (_do_evt_display)
 		_fitter->getEventDisplay()->addEvent(rf_gf_tracks);
 	else
 		rf_gf_tracks.clear();
@@ -250,9 +254,8 @@ int PHG4TrackFastSim::CreateNodes(PHCompositeNode *topNode) {
 		tb_node = new PHCompositeNode(_sub_top_node_name.c_str());
 		dstNode->addNode(tb_node);
 		if (verbosity > 0)
-			cout << _sub_top_node_name.c_str() <<" node added" << endl;
+			cout << _sub_top_node_name.c_str() << " node added" << endl;
 	}
-
 
 //	_clustermap_out = new SvtxClusterMap_v1;
 //
@@ -284,18 +287,17 @@ int PHG4TrackFastSim::GetNodes(PHCompositeNode * topNode) {
 		return Fun4AllReturnCodes::ABORTEVENT;
 	}
 
-	for(int i=0;i<_N_DETECTOR_LAYER;i++) {
-		PHG4HitContainer* phg4hit = findNode::getClass<PHG4HitContainer>(topNode,
-				_phg4hits_names[i].c_str());
+	for (int i = 0; i < _N_DETECTOR_LAYER; i++) {
+		PHG4HitContainer* phg4hit = findNode::getClass<PHG4HitContainer>(
+				topNode, _phg4hits_names[i].c_str());
 		if (!phg4hit && _event < 2) {
-			cout << PHWHERE << _phg4hits_names[i].c_str() <<" node not found on node tree"
-					<< endl;
+			cout << PHWHERE << _phg4hits_names[i].c_str()
+					<< " node not found on node tree" << endl;
 			return Fun4AllReturnCodes::ABORTEVENT;
 		}
 
 		_phg4hits.push_back(phg4hit);
 	}
-
 
 //	_clustermap_out = findNode::getClass<SvtxClusterMap>(topNode,
 //			_clustermap_out_name.c_str());
@@ -308,16 +310,15 @@ int PHG4TrackFastSim::GetNodes(PHCompositeNode * topNode) {
 	_trackmap_out = findNode::getClass<SvtxTrackMap>(topNode,
 			_trackmap_out_name.c_str());
 	if (!_trackmap_out && _event < 2) {
-		cout << PHWHERE << _trackmap_out_name.c_str() << " node not found on node tree"
-				<< endl;
+		cout << PHWHERE << _trackmap_out_name.c_str()
+				<< " node not found on node tree" << endl;
 		return Fun4AllReturnCodes::ABORTEVENT;
 	}
 
 	return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHG4TrackFastSim::PseudoPatternRecognition(
-		const PHG4Particle* particle,
+int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
 		std::vector<PHGenFit::Measurement*>& meas_out, TVector3& seed_pos,
 		TVector3& seed_mom, TMatrixDSym& seed_cov, const bool do_smearing) {
 
@@ -339,8 +340,7 @@ int PHG4TrackFastSim::PseudoPatternRecognition(
 
 		seed_mom.SetXYZ(particle->get_px(), particle->get_py(),
 				particle->get_pz());
-		if(do_smearing)
-		{
+		if (do_smearing) {
 			const double momSmear = 3. / 180. * TMath::Pi();     // rad
 			const double momMagSmear = 0.1;   // relative
 
@@ -407,13 +407,14 @@ int PHG4TrackFastSim::PseudoPatternRecognition(
 	return Fun4AllReturnCodes::EVENT_OK;
 }
 
-SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(
-		const PHGenFit::Track* phgf_track, const unsigned int truth_track_id) {
+SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
+		const unsigned int truth_track_id) {
 
 	double chi2 = phgf_track->get_chi2();
 	double ndf = phgf_track->get_ndf();
 
-	genfit::MeasuredStateOnPlane* gf_state = phgf_track->extrapolateToPlane(TVector3(0.,0.,0.), TVector3(0.,0.,1.));
+	genfit::MeasuredStateOnPlane* gf_state = phgf_track->extrapolateToPlane(
+			TVector3(0., 0., 0.), TVector3(0., 0., 1.));
 	TVector3 mom = gf_state->getMom();
 	TVector3 pos = gf_state->getPos();
 	TMatrixDSym cov = gf_state->get6DCov();
@@ -435,14 +436,14 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(
 	out_track->set_dca2d(dca2d);
 	out_track->set_dca2d_error(gf_state->getCov()[3][3]);
 	double dca3d = sqrt(
-			dca2d*dca2d +
-			gf_state->getState()[4]*gf_state->getState()[4]);
+			dca2d * dca2d + gf_state->getState()[4] * gf_state->getState()[4]);
 	out_track->set_dca(dca3d);
-
 
 	out_track->set_chisq(chi2);
 	out_track->set_ndf(ndf);
-	out_track->set_charge((_reverse_mag_field) ? -1.*phgf_track->get_charge() : phgf_track->get_charge());
+	out_track->set_charge(
+			(_reverse_mag_field) ?
+					-1. * phgf_track->get_charge() : phgf_track->get_charge());
 
 	out_track->set_px(mom.Px());
 	out_track->set_py(mom.Py());
@@ -452,18 +453,14 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(
 	out_track->set_y(pos.Y());
 	out_track->set_z(pos.Z());
 
-	for(int i=0;i<6;i++)
-	{
-		for(int j=i;j<6;j++)
-		{
-			out_track->set_error(i,j,cov[i][j]);
+	for (int i = 0; i < 6; i++) {
+		for (int j = i; j < 6; j++) {
+			out_track->set_error(i, j, cov[i][j]);
 		}
 	}
 
 	return out_track;
 }
-
-
 
 PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementVerticalPlane(
 		const PHG4Hit* g4hit, const double phi_resolution,
@@ -476,16 +473,16 @@ PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementVerticalPlane
 	TVector3 v(pos.X(), pos.Y(), 0);
 	v = 1 / v.Mag() * v;
 
-	TVector3 u = v.Cross(TVector3(0,0,1));
-	u = 1/u.Mag() * u;
+	TVector3 u = v.Cross(TVector3(0, 0, 1));
+	u = 1 / u.Mag() * u;
 
 	double u_smear = gRandom->Gaus(0, phi_resolution);
 	double v_smear = gRandom->Gaus(0, r_resolution);
-	pos.SetX(g4hit->get_avg_x() + u_smear*u.X() + v_smear*v.X());
-	pos.SetY(g4hit->get_avg_y() + u_smear*u.Y() + v_smear*v.Y());
+	pos.SetX(g4hit->get_avg_x() + u_smear * u.X() + v_smear * v.X());
+	pos.SetY(g4hit->get_avg_y() + u_smear * u.Y() + v_smear * v.Y());
 
-
-	meas = new PHGenFit::PlanarMeasurement(pos, u, v, phi_resolution, r_resolution);
+	meas = new PHGenFit::PlanarMeasurement(pos, u, v, phi_resolution,
+			r_resolution);
 
 //	std::cout<<"------------\n";
 //	pos.Print();
@@ -498,30 +495,27 @@ PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementVerticalPlane
 	return meas;
 }
 
-
-PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementCylinder(const PHG4Hit* g4hit, const double phi_resolution, const double z_resolution) {
+PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementCylinder(
+		const PHG4Hit* g4hit, const double phi_resolution,
+		const double z_resolution) {
 
 	PHGenFit::PlanarMeasurement* meas = NULL;
 
-	TVector3 pos(
-			g4hit->get_avg_x(),
-			g4hit->get_avg_y(),
-			g4hit->get_avg_z());
-
+	TVector3 pos(g4hit->get_avg_x(), g4hit->get_avg_y(), g4hit->get_avg_z());
 
 	TVector3 v(0, 0, pos.Z());
-	v = 1/v.Mag() * v;
+	v = 1 / v.Mag() * v;
 
 	TVector3 u = v.Cross(TVector3(pos.X(), pos.Y(), 0));
-	u = 1/u.Mag() * u;
+	u = 1 / u.Mag() * u;
 
 	double u_smear = gRandom->Gaus(0, phi_resolution);
 	double v_smear = gRandom->Gaus(0, z_resolution);
-	pos.SetX(g4hit->get_avg_x() + u_smear*u.X() + v_smear*v.X());
-	pos.SetY(g4hit->get_avg_y() + u_smear*u.Y() + v_smear*v.Y());
+	pos.SetX(g4hit->get_avg_x() + u_smear * u.X() + v_smear * v.X());
+	pos.SetY(g4hit->get_avg_y() + u_smear * u.Y() + v_smear * v.Y());
 
-
-	meas = new PHGenFit::PlanarMeasurement(pos, u, v, phi_resolution, z_resolution);
+	meas = new PHGenFit::PlanarMeasurement(pos, u, v, phi_resolution,
+			z_resolution);
 
 //	std::cout<<"------------\n";
 //	pos.Print();
@@ -534,15 +528,15 @@ PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementCylinder(cons
 	return meas;
 }
 
-PHGenFit::Measurement* PHG4TrackFastSim::VertexMeasurement(const TVector3 &vtx, const double dxy,
-		const double dz) {
+PHGenFit::Measurement* PHG4TrackFastSim::VertexMeasurement(const TVector3 &vtx,
+		const double dxy, const double dz) {
 	PHGenFit::Measurement* meas = NULL;
 
 	TMatrixDSym cov(3);
 	cov.Zero();
-	cov(0, 0) = dxy*dxy;
-	cov(1, 1) = dxy*dxy;
-	cov(2, 2) = dz*dz;
+	cov(0, 0) = dxy * dxy;
+	cov(1, 1) = dxy * dxy;
+	cov(2, 2) = dz * dz;
 
 	TVector3 pos = vtx;
 
@@ -552,25 +546,8 @@ PHGenFit::Measurement* PHG4TrackFastSim::VertexMeasurement(const TVector3 &vtx, 
 	pos.SetY(vtx.Y() + xy_smear);
 	pos.SetZ(vtx.Z() + z_smear);
 
-
 	meas = new PHGenFit::SpacepointMeasurement(pos, cov);
 
 	return meas;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -1,0 +1,525 @@
+/*!
+ *  \file		PHG4TrackFastSim.cc
+ *  \brief		Kalman Filter based on smeared truth PHG4Hit
+ *  \details	Kalman Filter based on smeared truth PHG4Hit
+ *  \author		Haiwang Yu <yuhw@nmsu.edu>
+ */
+
+#include <cmath>
+#include <map>
+#include <utility>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <g4hough/SvtxTrack.h>
+#include <g4hough/SvtxTrackMap.h>
+#include <g4hough/SvtxTrackMap_v1.h>
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <GenFit/MeasuredStateOnPlane.h>
+#include <GenFit/RKTrackRep.h>
+#include <GenFit/StateOnPlane.h>
+#include <phgenfit/Fitter.h>
+#include <phgenfit/PlanarMeasurement.h>
+#include <phgenfit/Track.h>
+#include <phgeom/PHGeomUtility.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+
+#include </afs/rhic.bnl.gov/x8664_sl6/opt/sphenix/core/root-5.34.34/include/TMath.h>
+#include </afs/rhic.bnl.gov/x8664_sl6/opt/sphenix/core/root-5.34.34/include/TRandom.h>
+#include </afs/rhic.bnl.gov/x8664_sl6/opt/sphenix/core/root-5.34.34/include/TString.h>
+#include "SvtxClusterMap.h"
+#include "SvtxClusterMap_v1.h"
+#include "SvtxTrack.h"
+#include "SvtxTrack_FastSim.h"
+
+#include "PHG4TrackFastSim.h"
+
+
+#define LogDebug(exp)		std::cout<<"DEBUG: "	<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
+#define LogError(exp)		std::cout<<"ERROR: "	<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
+#define LogWarning(exp)	std::cout<<"WARNING: "	<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
+
+//#define _N_DETECTOR_LAYER 5
+
+using namespace std;
+
+PHG4TrackFastSim::PHG4TrackFastSim(const std::string &name) :
+		SubsysReco(name),
+		_detector_type(Vertical_Plane),
+		_truth_container(NULL),
+		_sub_top_node_name("SVTX"), _clustermap_out_name("SvtxClusterMap"), _trackmap_out_name("SvtxTrackMap"),
+		_clustermap_out(NULL),_trackmap_out(NULL),
+		_fitter (NULL),_mag_field_file_name("/phenix/upgrades/decadal/fieldmaps/fsPHENIX.2d.root"),
+		 _mag_field_re_scaling_factor(1.), _reverse_mag_field(false), _fit_alg_name("KalmanFitterRefTrack"), _do_evt_display(false),
+		 _phi_resolution(50E-4), //100um
+		 _r_resolution(1.),
+		 _z_resolution(50E-4),
+		 _pat_rec_hit_finding_eff(1.),
+		 _pat_rec_nosise_prob(0.),
+		 _N_DETECTOR_LAYER(5)
+		 {
+
+	_event = 0;
+
+	for(int i=0;i<_N_DETECTOR_LAYER;i++) {
+		_phg4hits_names.push_back(Form("G4HIT_FGEM_%1d",i));
+	}
+}
+
+PHG4TrackFastSim::~PHG4TrackFastSim() {
+	delete _fitter;
+}
+
+/*
+ * Init
+ */
+int PHG4TrackFastSim::Init(PHCompositeNode *topNode) {
+
+	return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4TrackFastSim::InitRun(PHCompositeNode *topNode) {
+
+
+	CreateNodes(topNode);
+
+	TGeoManager* tgeo_manager = PHGeomUtility::GetTGeoManager(topNode);
+
+	//_fitter = new PHGenFit::Fitter("sPHENIX_Geo.root","sPHENIX.2d.root", 1.4 / 1.5);
+	_fitter = PHGenFit::Fitter::getInstance(tgeo_manager,
+			_mag_field_file_name.data(), (_reverse_mag_field) ? -1.*_mag_field_re_scaling_factor : _mag_field_re_scaling_factor, "KalmanFitterRefTrack", "RKTrackRep",
+			_do_evt_display);
+
+	if (!_fitter) {
+		cerr << PHWHERE << endl;
+		return Fun4AllReturnCodes::ABORTRUN;
+	}
+
+	return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4TrackFastSim::End(PHCompositeNode *topNode) {
+
+	return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
+
+	GetNodes(topNode);
+
+	if(_clustermap_out)
+		_clustermap_out->empty();
+	else {
+		LogError("_clustermap_out not found!");
+		return Fun4AllReturnCodes::ABORTRUN;
+	}
+
+	if(_trackmap_out)
+		_trackmap_out->empty();
+	else {
+		LogError("_trackmap_out not found!");
+		return Fun4AllReturnCodes::ABORTRUN;
+	}
+
+	for (PHG4TruthInfoContainer::ConstIterator itr =
+			_truth_container->GetPrimaryParticleRange().first;
+			itr != _truth_container->GetPrimaryParticleRange().second; ++itr) {
+		PHG4Particle* particle = itr->second;
+
+		TVector3 seed_pos(0, 0, 0);
+		TVector3 seed_mom(0, 0, 0);
+		TMatrixDSym seed_cov(6);
+
+		//! Create measurements
+		std::vector<PHGenFit::Measurement*> measurements;
+
+		const bool _use_vertex_in_fitting = true;
+
+		PHGenFit::Measurement* vtx_meas = NULL;
+
+		if (_use_vertex_in_fitting) {
+			vtx_meas = VertexMeasurement(
+					TVector3(0, 0, 0), 0.0050, 0.0050);
+			measurements.push_back(vtx_meas);
+		}
+
+		PseudoPatternRecognition(particle, measurements, seed_pos, seed_mom, seed_cov);
+
+		if (measurements.size() < 3) {
+			if(verbosity >= 2)
+				LogWarning("measurements.size() < 3");
+			continue;
+		}
+
+		//! Build TrackRep from particle assumption
+		/*!
+		 * mu+:	-13
+		 * mu-:	13
+		 * pi+:	211
+		 * pi-:	-211
+		 * e-:	11
+		 * e+:	-11
+		 */
+		int pid = 13; //
+		//SMART(genfit::AbsTrackRep) rep = NEW(genfit::RKTrackRep)(pid);
+		genfit::AbsTrackRep* rep = new genfit::RKTrackRep(pid);
+
+		//! Initiallize track with seed from pattern recognition
+		PHGenFit::Track* track = new PHGenFit::Track(rep, seed_pos, seed_mom,
+				seed_cov);
+
+
+		//LogDEBUG;
+		//! Add measurements to track
+		track->addMeasurements(measurements);
+
+		//LogDEBUG;
+		//! Fit the track
+		int fitting_err = _fitter->processTrack(track, _do_evt_display);
+
+		if(fitting_err != 0)
+		{
+//			LogDEBUG;
+//			std::cout<<"event: "<<ientry<<"\n";
+			continue;
+		}
+
+		SvtxTrack* svtx_track_out = MakeSvtxTrack(track,particle->get_track_id());
+
+		_trackmap_out->insert(svtx_track_out);
+	}
+
+	if(_trackmap_out->get(0)) {
+		_trackmap_out->get(0)->identify();
+		std::cout<<"DEBUG : "<< _trackmap_out->get(0)->get_px() <<"\n";
+		std::cout<<"DEBUG : "<< _trackmap_out->get(0)->get_truth_track_id() <<"\n";
+	}
+
+	return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4TrackFastSim::CreateNodes(PHCompositeNode *topNode) {
+	// create nodes...
+	PHNodeIterator iter(topNode);
+
+	PHCompositeNode *dstNode = static_cast<PHCompositeNode*>(iter.findFirst(
+			"PHCompositeNode", "DST"));
+	if (!dstNode) {
+		cerr << PHWHERE << "DST Node missing, doing nothing." << endl;
+		return Fun4AllReturnCodes::ABORTEVENT;
+	}
+
+	// Create the FGEM node
+	PHCompositeNode* tb_node = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+			"PHCompositeNode", _sub_top_node_name.c_str()));
+	if (!tb_node) {
+		tb_node = new PHCompositeNode(_sub_top_node_name.c_str());
+		dstNode->addNode(tb_node);
+		if (verbosity > 0)
+			cout << _sub_top_node_name.c_str() <<" node added" << endl;
+	}
+
+
+	_clustermap_out = new SvtxClusterMap_v1;
+
+	PHIODataNode<PHObject>* clusters_node = new PHIODataNode<PHObject>(
+			_clustermap_out, _clustermap_out_name.c_str(), "PHObject");
+	tb_node->addNode(clusters_node);
+	if (verbosity > 0)
+		cout << _clustermap_out_name.c_str() <<" node added" << endl;
+
+	_trackmap_out = new SvtxTrackMap_v1;
+
+	PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(
+			_trackmap_out, _trackmap_out_name.c_str(), "PHObject");
+	tb_node->addNode(tracks_node);
+	if (verbosity > 0)
+		cout << _trackmap_out_name.c_str() << " node added" << endl;
+
+	return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4TrackFastSim::GetNodes(PHCompositeNode * topNode) {
+	//DST objects
+	//Truth container
+	_truth_container = findNode::getClass<PHG4TruthInfoContainer>(topNode,
+			"G4TruthInfo");
+	if (!_truth_container && _event < 2) {
+		cout << PHWHERE << " PHG4TruthInfoContainer node not found on node tree"
+				<< endl;
+		return Fun4AllReturnCodes::ABORTEVENT;
+	}
+
+	for(int i=0;i<_N_DETECTOR_LAYER;i++) {
+		PHG4HitContainer* phg4hit = findNode::getClass<PHG4HitContainer>(topNode,
+				_phg4hits_names[i].c_str());
+		if (!phg4hit && _event < 2) {
+			cout << PHWHERE << _phg4hits_names[i].c_str() <<" node not found on node tree"
+					<< endl;
+			return Fun4AllReturnCodes::ABORTEVENT;
+		}
+
+		_phg4hits.push_back(phg4hit);
+	}
+
+
+	_clustermap_out = findNode::getClass<SvtxClusterMap>(topNode,
+			_clustermap_out_name.c_str());
+	if (!_clustermap_out && _event < 2) {
+		cout << PHWHERE << _clustermap_out_name.c_str() << " node not found on node tree"
+				<< endl;
+		return Fun4AllReturnCodes::ABORTEVENT;
+	}
+
+	_trackmap_out = findNode::getClass<SvtxTrackMap>(topNode,
+			_trackmap_out_name.c_str());
+	if (!_trackmap_out && _event < 2) {
+		cout << PHWHERE << _trackmap_out_name.c_str() << " node not found on node tree"
+				<< endl;
+		return Fun4AllReturnCodes::ABORTEVENT;
+	}
+
+	return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4TrackFastSim::PseudoPatternRecognition(
+		const PHG4Particle* particle,
+		std::vector<PHGenFit::Measurement*>& meas_out, TVector3& seed_pos,
+		TVector3& seed_mom, TMatrixDSym& seed_cov, const bool do_smearing) {
+
+	seed_pos.SetXYZ(0, 0, 0);
+	seed_mom.SetXYZ(0, 0, 10);
+	seed_cov.ResizeTo(6, 6);
+
+	for (int i = 0; i < 3; i++) {
+		seed_cov[i][i] = _phi_resolution * _phi_resolution;
+	}
+
+	for (int i = 3; i < 6; i++) {
+		seed_cov[i][i] = 10;
+	}
+
+	if (particle) {
+		TVector3 True_mom(particle->get_px(), particle->get_py(),
+				particle->get_pz());
+
+		seed_mom.SetXYZ(particle->get_px(), particle->get_py(),
+				particle->get_pz());
+		if(do_smearing)
+		{
+			const double momSmear = 3. / 180. * TMath::Pi();     // rad
+			const double momMagSmear = 0.1;   // relative
+
+			seed_mom.SetPhi(gRandom->Gaus(True_mom.Phi(), momSmear));
+			seed_mom.SetTheta(gRandom->Gaus(True_mom.Theta(), momSmear));
+			seed_mom.SetMag(
+					gRandom->Gaus(True_mom.Mag(),
+							momMagSmear * True_mom.Mag()));
+		}
+	}
+
+	meas_out.clear();
+
+	for(int ilayer=0; ilayer<_N_DETECTOR_LAYER; ilayer++) {
+
+		if(!_phg4hits[ilayer]) {
+			LogError("No _phg4hits[i] found!");
+			continue;
+		}
+
+		for (PHG4HitContainer::ConstIterator itr =
+				_phg4hits[ilayer]->getHits().first;
+				itr != _phg4hits[ilayer]->getHits().second; ++itr) {
+			PHG4Hit * hit = itr->second;
+			if(!hit) {
+				LogDebug("No PHG4Hit Found!");
+				continue;
+			}
+			if (hit->get_trkid() == particle->get_track_id() || gRandom->Uniform(0,1) < _pat_rec_nosise_prob) {
+				PHGenFit::Measurement* meas = NULL;
+				if(_detector_type == Vertical_Plane)
+					meas = PHG4HitToMeasurementVerticalPlane(hit);
+				else if(_detector_type == Cylinder)
+					meas = PHG4HitToMeasurementCylinder(hit);
+				else {
+					LogError("Type not implemented!");
+					return Fun4AllReturnCodes::ABORTEVENT;
+				}
+				if(gRandom->Uniform(0,1) <= _pat_rec_hit_finding_eff)
+					meas_out.push_back(meas);
+			}
+		}
+
+	} /*Loop detector layers*/
+
+	return Fun4AllReturnCodes::EVENT_OK;
+}
+
+SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(
+		const PHGenFit::Track* phgf_track, const unsigned int truth_track_id) {
+
+	double chi2 = phgf_track->get_chi2();
+	double ndf = phgf_track->get_ndf();
+
+	genfit::MeasuredStateOnPlane* gf_state = phgf_track->extrapolateToPlane(TVector3(0.,0.,0.), TVector3(0.,0.,1.));
+	TVector3 mom = gf_state->getMom();
+	TVector3 pos = gf_state->getPos();
+	TMatrixDSym cov = gf_state->get6DCov();
+
+//	SvtxTrack_v1* out_track = new SvtxTrack_v1(*static_cast<const SvtxTrack_v1*> (svtx_track));
+//	SvtxTrack_v1* out_track = new SvtxTrack_v1();
+
+	SvtxTrack* out_track = new SvtxTrack_FastSim();
+
+	out_track->set_truth_track_id(truth_track_id);
+
+	/*!
+	 * FIXME: check the definition
+	 *  1/p, u'/z', v'/z', u, v
+	 *  u is defined as mom X beam line at POCA
+	 *  so u is the dca2d direction
+	 */
+	double dca2d = gf_state->getState()[3];
+	out_track->set_dca2d(dca2d);
+	out_track->set_dca2d_error(gf_state->getCov()[3][3]);
+	double dca3d = sqrt(
+			dca2d*dca2d +
+			gf_state->getState()[4]*gf_state->getState()[4]);
+	out_track->set_dca(dca3d);
+
+
+	out_track->set_chisq(chi2);
+	out_track->set_ndf(ndf);
+	out_track->set_charge((_reverse_mag_field) ? -1.*phgf_track->get_charge() : phgf_track->get_charge());
+
+	out_track->set_px(mom.Px());
+	out_track->set_py(mom.Py());
+	out_track->set_pz(mom.Pz());
+
+	out_track->set_x(pos.X());
+	out_track->set_y(pos.Y());
+	out_track->set_z(pos.Z());
+
+	for(int i=0;i<6;i++)
+	{
+		for(int j=i;j<6;j++)
+		{
+			out_track->set_error(i,j,cov[i][j]);
+		}
+	}
+
+	return out_track;
+}
+
+
+
+PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementVerticalPlane(const PHG4Hit* g4hit) {
+
+	PHGenFit::PlanarMeasurement* meas = NULL;
+
+	TVector3 pos(
+			g4hit->get_avg_x(),
+			g4hit->get_avg_y(),
+			g4hit->get_avg_z());
+
+
+	TVector3 v(pos.X(), pos.Y(), 0);
+	v = 1/v.Mag() * v;
+
+	TVector3 u = v.Cross(TVector3(0,0,1));
+	u = 1/u.Mag() * u;
+
+	double u_smear = gRandom->Gaus(0, _phi_resolution);
+	double v_smear = gRandom->Gaus(0, _r_resolution);
+	pos.SetX(g4hit->get_avg_x() + u_smear*u.X() + v_smear*v.X());
+	pos.SetY(g4hit->get_avg_y() + u_smear*u.Y() + v_smear*v.Y());
+
+
+	meas = new PHGenFit::PlanarMeasurement(pos, u, v, _phi_resolution, _r_resolution);
+
+//	std::cout<<"------------\n";
+//	pos.Print();
+//	std::cout<<"at "<<istation<<" station, "<<ioctant << " octant \n";
+//	u.Print();
+//	v.Print();
+
+	//dynamic_cast<PHGenFit::PlanarMeasurement*> (meas)->getMeasurement()->Print();
+
+	return meas;
+}
+
+
+PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementCylinder(const PHG4Hit* g4hit) {
+
+	PHGenFit::PlanarMeasurement* meas = NULL;
+
+	TVector3 pos(
+			g4hit->get_avg_x(),
+			g4hit->get_avg_y(),
+			g4hit->get_avg_z());
+
+
+	TVector3 v(0, 0, pos.Z());
+	v = 1/v.Mag() * v;
+
+	TVector3 u = v.Cross(TVector3(pos.X(), pos.Y(), 0));
+	u = 1/u.Mag() * u;
+
+	double u_smear = gRandom->Gaus(0, _phi_resolution);
+	double v_smear = gRandom->Gaus(0, _z_resolution);
+	pos.SetX(g4hit->get_avg_x() + u_smear*u.X() + v_smear*v.X());
+	pos.SetY(g4hit->get_avg_y() + u_smear*u.Y() + v_smear*v.Y());
+
+
+	meas = new PHGenFit::PlanarMeasurement(pos, u, v, _phi_resolution, _r_resolution);
+
+//	std::cout<<"------------\n";
+//	pos.Print();
+//	std::cout<<"at "<<istation<<" station, "<<ioctant << " octant \n";
+//	u.Print();
+//	v.Print();
+
+	//dynamic_cast<PHGenFit::PlanarMeasurement*> (meas)->getMeasurement()->Print();
+
+	return meas;
+}
+
+PHGenFit::PlanarMeasurement* PHG4TrackFastSim::VertexMeasurement(const TVector3 &vtx, const double dr,
+		const double dphi) {
+	PHGenFit::PlanarMeasurement* meas = NULL;
+
+	TVector3 u(1, 0, 0);
+	TVector3 v(0, 1, 0);
+
+	TVector3 pos = vtx;
+
+	double u_smear = gRandom->Gaus(0, dphi);
+	double v_smear = gRandom->Gaus(0, dr);
+	pos.SetX(vtx.X() + u_smear * u.X() + v_smear * v.X());
+	pos.SetY(vtx.Y() + u_smear * u.Y() + v_smear * v.Y());
+
+	meas = new PHGenFit::PlanarMeasurement(pos, u, v, dr, dphi);
+
+	return meas;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -21,20 +21,20 @@
 #include <phool/PHIODataNode.h>
 #include <phool/PHNodeIterator.h>
 
-#include </afs/rhic.bnl.gov/x8664_sl6/opt/sphenix/core/root-5.34.34/include/TMath.h>
-#include </afs/rhic.bnl.gov/x8664_sl6/opt/sphenix/core/root-5.34.34/include/TMatrixF.h>
-#include </afs/rhic.bnl.gov/x8664_sl6/opt/sphenix/core/root-5.34.34/include/TRandom.h>
-#include </afs/rhic.bnl.gov/x8664_sl6/opt/sphenix/core/root-5.34.34/include/TString.h>
-#include <../../../../install/include/g4hough/SvtxTrackMap.h>
-#include <../../../../install/include/g4hough/SvtxTrackMap_v1.h>
-#include <../../../../install/include/g4main/PHG4Hit.h>
-#include <../../../../install/include/g4main/PHG4Particle.h>
-#include <../../../../install/include/g4main/PHG4TruthInfoContainer.h>
-#include <../../../../install/include/phgenfit/Fitter.h>
-#include <../../../../install/include/phgenfit/PlanarMeasurement.h>
-#include <../../../../install/include/phgenfit/Track.h>
-#include <../../../../install/include/phgeom/PHGeomUtility.h>
-#include "../../../offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.h"
+#include <TMath.h>
+#include <TMatrixF.h>
+#include <TRandom.h>
+#include <TString.h>
+#include <g4hough/SvtxTrackMap.h>
+#include <g4hough/SvtxTrackMap_v1.h>
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <phgenfit/Fitter.h>
+#include <phgenfit/PlanarMeasurement.h>
+#include <phgenfit/Track.h>
+#include <phgeom/PHGeomUtility.h>
+#include <phgenfit/SpacepointMeasurement.h>
 #include "SvtxTrack.h"
 #include "SvtxTrack_FastSim.h"
 

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -15,8 +15,8 @@
 #include <g4main/PHG4HitContainer.h>
 #include <phgenfit/Measurement.h>
 
-#include </afs/rhic.bnl.gov/x8664_sl6/opt/sphenix/core/root-5.34.34/include/TMatrixDSym.h>
-#include </afs/rhic.bnl.gov/x8664_sl6/opt/sphenix/core/root-5.34.34/include/TVector3.h>
+#include <TMatrixDSym.h>
+#include <TVector3.h>
 
 class PHG4Particle;
 namespace PHGenFit {

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -1,0 +1,324 @@
+/*!
+ *  \file		PHG4TrackFastSim.h
+ *  \brief		Kalman Filter based on smeared truth PHG4Hit
+ *  \details	Kalman Filter based on smeared truth PHG4Hit
+ *  \author		Haiwang Yu <yuhw@nmsu.edu>
+ */
+
+#ifndef __PHG4TrackFastSim_H__
+#define __PHG4TrackFastSim_H__
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <fun4all/SubsysReco.h>
+#include <g4main/PHG4HitContainer.h>
+#include <phgenfit/Measurement.h>
+
+#include </afs/rhic.bnl.gov/x8664_sl6/opt/sphenix/core/root-5.34.34/include/TMatrixDSym.h>
+#include </afs/rhic.bnl.gov/x8664_sl6/opt/sphenix/core/root-5.34.34/include/TVector3.h>
+
+class PHG4Particle;
+namespace PHGenFit {
+class PlanarMeasurement;
+} /* namespace PHGenFit */
+
+namespace PHGenFit {
+class Track;
+} /* namespace PHGenFit */
+
+namespace genfit {
+class GFRaveVertexFactory;
+} /* namespace genfit */
+
+class SvtxTrack;
+namespace PHGenFit {
+class Fitter;
+} /* namespace PHGenFit */
+
+class SvtxTrackMap;
+class SvtxVertexMap;
+class SvtxVertex;
+class PHCompositeNode;
+class PHG4TruthInfoContainer;
+class SvtxClusterMap;
+class SvtxEvalStack;
+class TFile;
+class TTree;
+
+class PHG4TrackFastSim: public SubsysReco {
+public:
+
+	enum DETECTOR_TYPE {Vertical_Plane, Cylinder};
+
+	//! Default constructor
+	PHG4TrackFastSim(const std::string &name = "PHG4TrackFastSim");
+
+	//! dtor
+	~PHG4TrackFastSim();
+
+	//!Initialization, called for initialization
+	int Init(PHCompositeNode *);
+
+	//!Initialization Run, called for initialization of a run
+	int InitRun(PHCompositeNode *);
+
+	//!Process Event, called for each event
+	int process_event(PHCompositeNode *);
+
+	//!End, write and close files
+	int End(PHCompositeNode *);
+
+	/// set verbosity
+	void Verbosity(int verb) {
+		verbosity = verb; // SubsysReco verbosity
+	}
+
+	bool is_do_evt_display() const {
+		return _do_evt_display;
+	}
+
+	void set_do_evt_display(bool doEvtDisplay) {
+		_do_evt_display = doEvtDisplay;
+	}
+
+	double get_phi_resolution() const {
+		return _phi_resolution;
+	}
+
+	void set_phi_resolution(double fgemPhiResolution) {
+		_phi_resolution = fgemPhiResolution;
+	}
+
+	double get_r_resolution() const {
+		return _r_resolution;
+	}
+
+	void set_r_resolution(double fgemRResolution) {
+		_r_resolution = fgemRResolution;
+	}
+
+	const std::string& get_fit_alg_name() const {
+		return _fit_alg_name;
+	}
+
+	void set_fit_alg_name(const std::string& fitAlgName) {
+		_fit_alg_name = fitAlgName;
+	}
+
+	const std::string& get_mag_field_file_name() const {
+		return _mag_field_file_name;
+	}
+
+	void set_mag_field_file_name(const std::string& magFieldFileName) {
+		_mag_field_file_name = magFieldFileName;
+	}
+
+	float get_mag_field_re_scaling_factor() const {
+		return _mag_field_re_scaling_factor;
+	}
+
+	void set_mag_field_re_scaling_factor(float magFieldReScalingFactor) {
+		_mag_field_re_scaling_factor = magFieldReScalingFactor;
+	}
+
+	bool is_reverse_mag_field() const {
+		return _reverse_mag_field;
+	}
+
+	void set_reverse_mag_field(bool reverseMagField) {
+		_reverse_mag_field = reverseMagField;
+	}
+
+	double get_pat_rec_hit_finding_eff() const {
+		return _pat_rec_hit_finding_eff;
+	}
+
+	void set_pat_rec_hit_finding_eff(double patRecHitFindingEff) {
+		if(!(patRecHitFindingEff>=0&&patRecHitFindingEff<=1)) {
+			std::cout<<"ERROR: _pat_rec_hit_finding_eff out of range! \n";
+		}
+		_pat_rec_hit_finding_eff = patRecHitFindingEff;
+	}
+
+	double get_pat_rec_nosise_prob() const {
+		return _pat_rec_nosise_prob;
+	}
+
+	void set_pat_rec_nosise_prob(double patRecNosiseProb) {
+		if(!(patRecNosiseProb <= 1. && patRecNosiseProb >= 0)) {
+			std::cout<<"ERROR: _pat_rec_nosise_prob out of range! \n";
+			return;
+		}
+		_pat_rec_nosise_prob = patRecNosiseProb;
+	}
+
+	const std::vector<std::string>& get_phg4hits_names() const {
+		return _phg4hits_names;
+	}
+
+	void set_phg4hits_names(const std::vector<std::string>& phg4hitsNames) {
+		_phg4hits_names = phg4hitsNames;
+		_N_DETECTOR_LAYER = _phg4hits_names.size();
+	}
+
+	void set_phg4hits_names(const std::string* phg4hitsNames, const int nlayer) {
+		_phg4hits_names.clear();
+		for(int i=0;i<nlayer;++i) {
+			_phg4hits_names.push_back(phg4hitsNames[i]);
+		}
+		_N_DETECTOR_LAYER = _phg4hits_names.size();
+	}
+
+	double get_resolution() const {
+		return _z_resolution;
+	}
+
+	void set_resolution(double resolution) {
+		_z_resolution = resolution;
+	}
+
+	DETECTOR_TYPE get_detector_type() const {
+		return _detector_type;
+	}
+
+	void set_detector_type(DETECTOR_TYPE detectorType) {
+		_detector_type = detectorType;
+	}
+
+	const std::string& get_trackmap_out_name() const {
+		return _trackmap_out_name;
+	}
+
+	void set_trackmap_out_name(const std::string& trackmapOutName) {
+		_trackmap_out_name = trackmapOutName;
+	}
+
+	const std::string& get_sub_top_node_name() const {
+		return _sub_top_node_name;
+	}
+
+	void set_sub_top_node_name(const std::string& subTopNodeName) {
+		_sub_top_node_name = subTopNodeName;
+	}
+
+private:
+
+	/*!
+	 * Create needed nodes.
+	 */
+	int CreateNodes(PHCompositeNode *);
+
+	/*!
+	 * Get all the all the required nodes off the node tree.
+	 */
+	int GetNodes(PHCompositeNode *);
+
+	/*!
+	 *
+	 */
+	int PseudoPatternRecognition(const PHG4Particle* particle,
+			std::vector<PHGenFit::Measurement*> & meas_out, TVector3& seed_pos,
+			TVector3& seed_mom, TMatrixDSym& seed_cov, const bool do_smearing = true);
+
+	PHGenFit::PlanarMeasurement* PHG4HitToMeasurementVerticalPlane(const PHG4Hit* g4hit);
+
+	PHGenFit::PlanarMeasurement* PHG4HitToMeasurementCylinder(const PHG4Hit* g4hit);
+
+	PHGenFit::PlanarMeasurement* VertexMeasurement(const TVector3 &vtx, const double dr,
+			const double dphi);
+
+	/*!
+	 * Make SvtxTrack from PHGenFit::Track
+	 */
+	SvtxTrack* MakeSvtxTrack(const PHGenFit::Track* phgf_track_in, const unsigned int truth_track_id = UINT_MAX);
+
+	//! Event counter
+	int _event;
+
+	DETECTOR_TYPE _detector_type;
+
+	//! Input Node pointers
+	PHG4TruthInfoContainer* _truth_container;
+
+	std::vector<PHG4HitContainer*> _phg4hits;
+	std::vector<std::string> _phg4hits_names;
+
+	//! Output Node pointers
+
+	std::string _sub_top_node_name;
+	std::string _clustermap_out_name;
+	std::string _trackmap_out_name;
+
+	SvtxClusterMap* _clustermap_out;
+
+	SvtxTrackMap* _trackmap_out;
+
+
+
+	/*!
+	 *	GenFit fitter interface
+	 */
+	PHGenFit::Fitter* _fitter;
+
+	//!
+	std::string _mag_field_file_name;
+
+	//! rescale mag field, modify the original mag field read in
+	float _mag_field_re_scaling_factor;
+
+	//! Switch to reverse Magnetic field
+	bool _reverse_mag_field;
+
+	//!
+	std::string _fit_alg_name;
+
+	//!
+	bool _do_evt_display;
+
+	/*!
+	 * For PseudoPatternRecognition function.
+	 */
+
+	double _phi_resolution;
+
+	double _r_resolution;
+
+	double _z_resolution;
+
+	//!
+	double _pat_rec_hit_finding_eff;
+
+	//!
+	double _pat_rec_nosise_prob;
+
+
+	//!
+	int _N_DETECTOR_LAYER;
+
+
+
+};
+
+#endif /*__PHG4TrackFastSim_H__*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -141,16 +141,16 @@ public:
 		_pat_rec_hit_finding_eff = patRecHitFindingEff;
 	}
 
-	double get_pat_rec_nosise_prob() const {
-		return _pat_rec_nosise_prob;
+	double get_pat_rec_noise_prob() const {
+		return _pat_rec_noise_prob;
 	}
 
-	void set_pat_rec_nosise_prob(double patRecNosiseProb) {
-		if(!(patRecNosiseProb <= 1. && patRecNosiseProb >= 0)) {
-			std::cout<<"ERROR: _pat_rec_nosise_prob out of range! \n";
+	void set_pat_rec_noise_prob(double patRecNoiseProb) {
+		if(!(patRecNoiseProb <= 1. && patRecNoiseProb >= 0)) {
+			std::cout<<"ERROR: _pat_rec_noise_prob out of range! \n";
 			return;
 		}
-		_pat_rec_nosise_prob = patRecNosiseProb;
+		_pat_rec_noise_prob = patRecNoiseProb;
 	}
 
 	const std::vector<std::string>& get_phg4hits_names() const {
@@ -319,7 +319,7 @@ private:
 	double _pat_rec_hit_finding_eff;
 
 	//!
-	double _pat_rec_nosise_prob;
+	double _pat_rec_noise_prob;
 
 
 	//!

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -226,6 +226,14 @@ public:
 		_vertex_z_resolution = vertexZResolution;
 	}
 
+	int get_primary_assumption_pid() const {
+		return _primary_assumption_pid;
+	}
+
+	void set_primary_assumption_pid(int primaryAssumptionPid) {
+		_primary_assumption_pid = primaryAssumptionPid;
+	}
+
 private:
 
 	/*!
@@ -294,8 +302,17 @@ private:
 	//! Switch to reverse Magnetic field
 	bool _reverse_mag_field;
 
-	//!
+	/*!
+	 * Available choices:
+	 * KalmanFitter
+	 * KalmanFitterRefTrack
+	 * DafSimple
+	 * DafRef
+	 */
 	std::string _fit_alg_name;
+
+	//!
+	int _primary_assumption_pid;
 
 	//!
 	bool _do_evt_display;

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -202,6 +202,30 @@ public:
 		_sub_top_node_name = subTopNodeName;
 	}
 
+	bool is_use_vertex_in_fitting() const {
+		return _use_vertex_in_fitting;
+	}
+
+	void set_use_vertex_in_fitting(bool useVertexInFitting) {
+		_use_vertex_in_fitting = useVertexInFitting;
+	}
+
+	double get_vertex_xy_resolution() const {
+		return _vertex_xy_resolution;
+	}
+
+	void set_vertex_xy_resolution(double vertexXyResolution) {
+		_vertex_xy_resolution = vertexXyResolution;
+	}
+
+	double get_vertex_z_resolution() const {
+		return _vertex_z_resolution;
+	}
+
+	void set_vertex_z_resolution(double vertexZResolution) {
+		_vertex_z_resolution = vertexZResolution;
+	}
+
 private:
 
 	/*!
@@ -279,6 +303,11 @@ private:
 	/*!
 	 * For PseudoPatternRecognition function.
 	 */
+
+	bool _use_vertex_in_fitting;
+
+	double _vertex_xy_resolution;
+	double _vertex_z_resolution;
 
 	double _phi_resolution;
 

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -221,12 +221,12 @@ private:
 			std::vector<PHGenFit::Measurement*> & meas_out, TVector3& seed_pos,
 			TVector3& seed_mom, TMatrixDSym& seed_cov, const bool do_smearing = true);
 
-	PHGenFit::PlanarMeasurement* PHG4HitToMeasurementVerticalPlane(const PHG4Hit* g4hit);
+	PHGenFit::PlanarMeasurement* PHG4HitToMeasurementVerticalPlane(const PHG4Hit* g4hit, const double phi_resolution, const double r_resolution);
 
-	PHGenFit::PlanarMeasurement* PHG4HitToMeasurementCylinder(const PHG4Hit* g4hit);
+	PHGenFit::PlanarMeasurement* PHG4HitToMeasurementCylinder(const PHG4Hit* g4hit, const double phi_resolution, const double z_resolution);
 
-	PHGenFit::PlanarMeasurement* VertexMeasurement(const TVector3 &vtx, const double dr,
-			const double dphi);
+	PHGenFit::Measurement* VertexMeasurement(const TVector3 &vtx, const double dxy,
+			const double dz);
 
 	/*!
 	 * Make SvtxTrack from PHGenFit::Track
@@ -247,10 +247,10 @@ private:
 	//! Output Node pointers
 
 	std::string _sub_top_node_name;
-	std::string _clustermap_out_name;
+//	std::string _clustermap_out_name;
 	std::string _trackmap_out_name;
 
-	SvtxClusterMap* _clustermap_out;
+//	SvtxClusterMap* _clustermap_out;
 
 	SvtxTrackMap* _trackmap_out;
 

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -170,11 +170,11 @@ public:
 		_N_DETECTOR_LAYER = _phg4hits_names.size();
 	}
 
-	double get_resolution() const {
+	double get_z_resolution() const {
 		return _z_resolution;
 	}
 
-	void set_resolution(double resolution) {
+	void set_z_resolution(double resolution) {
 		_z_resolution = resolution;
 	}
 

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSimLinkDef.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSimLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4TrackFastSim-!;
+
+#endif

--- a/simulation/g4simulation/g4hough/SvtxTrack.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack.h
@@ -41,6 +41,9 @@ public:
   virtual unsigned int get_id() const          {return UINT_MAX;}
   virtual void         set_id(unsigned int id) {}
 
+  virtual unsigned int get_truth_track_id() const {return UINT_MAX;}
+  virtual void set_truth_track_id(unsigned int truthTrackId) {}
+
   virtual bool get_positive_charge() const     {return false;}
   virtual void set_positive_charge(bool ispos) {}
 

--- a/simulation/g4simulation/g4hough/SvtxTrack_FastSim.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack_FastSim.C
@@ -7,9 +7,18 @@
 
 #include "SvtxTrack_FastSim.h"
 
-using namespace std;
+#include <limits.h>
 
 ClassImp(SvtxTrack_FastSim)
+
+using namespace std;
+
+SvtxTrack_FastSim::SvtxTrack_FastSim() :
+		_truth_track_id(UINT_MAX) {
+}
+
+SvtxTrack_FastSim::~SvtxTrack_FastSim() {
+}
 
 
 void SvtxTrack_FastSim::identify(std::ostream& os) const {

--- a/simulation/g4simulation/g4hough/SvtxTrack_FastSim.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack_FastSim.C
@@ -1,0 +1,47 @@
+/*
+ * SvtxTrack_FastSim.C
+ *
+ *  Created on: Jul 28, 2016
+ *      Author: yuhw
+ */
+
+#include "SvtxTrack_FastSim.h"
+
+using namespace std;
+
+ClassImp(SvtxTrack_FastSim)
+
+
+void SvtxTrack_FastSim::identify(std::ostream& os) const {
+  os << "SvtxTrack_FastSim Object ";
+  os << "truth_track_id:" << get_truth_track_id() << endl;
+  os << "id: " << get_id() << " ";
+  os << "charge: " << get_charge() << " ";
+  os << "chisq: " << get_chisq() << " ndf:" << get_ndf() << " ";
+  os << endl;
+
+  os << "(px,py,pz) = ("
+     << get_px() << ","
+     << get_py() << ","
+     << get_pz() << ")" << endl;
+
+  os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << endl;
+
+  if (!empty_clusters()) {
+    os << "clusters: ";
+    for (SvtxTrack::ConstClusterIter iter = begin_clusters();
+	 iter != end_clusters();
+	 ++iter) {
+      unsigned int cluster_id = *iter;
+      os << cluster_id << " ";
+    }
+  }
+  os << endl;
+
+  return;
+}
+
+
+int SvtxTrack_FastSim::isValid() const {
+  return 1;
+}

--- a/simulation/g4simulation/g4hough/SvtxTrack_FastSim.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack_FastSim.h
@@ -13,6 +13,9 @@
 class SvtxTrack_FastSim : public SvtxTrack_v1 {
 
 public:
+	SvtxTrack_FastSim();
+	virtual ~SvtxTrack_FastSim();
+
 	unsigned int get_truth_track_id() const {
 		return _truth_track_id;
 	}

--- a/simulation/g4simulation/g4hough/SvtxTrack_FastSim.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack_FastSim.h
@@ -1,0 +1,38 @@
+/*
+ * SvtxTrack_FastSim.h
+ *
+ *  Created on: Jul 28, 2016
+ *      Author: yuhw
+ */
+
+#ifndef __SVTXTRACK_FAST_SIM_H__
+#define __SVTXTRACK_FAST_SIM_H__
+
+#include "SvtxTrack_v1.h"
+
+class SvtxTrack_FastSim : public SvtxTrack_v1 {
+
+public:
+	unsigned int get_truth_track_id() const {
+		return _truth_track_id;
+	}
+
+	void set_truth_track_id(unsigned int truthTrackId) {
+		_truth_track_id = truthTrackId;
+	}
+
+	// The "standard PHObject response" functions...
+	void identify(std::ostream &os=std::cout) const;
+	void Reset() {*this = SvtxTrack_FastSim();}
+	int  isValid() const;
+	SvtxTrack* Clone() const {return new SvtxTrack_FastSim(*this);}
+
+private:
+
+	unsigned int _truth_track_id;
+
+
+	ClassDef(SvtxTrack_FastSim,1)
+};
+
+#endif /* __SVTXTRACK_FAST_SIM_H__ */

--- a/simulation/g4simulation/g4hough/SvtxTrack_FastSimLinkDef.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack_FastSimLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxTrack_FastSim+;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
Introducing a Truth Tracking module into g4hough.
Smearing PHG4Hits form G4 simulations to mimic measurements.
Use truth information to do a pseudo pattern recognition.

Originally designed for the forward tracking. Now generalized to any cylindrical or vertical plane detector setup. Also this module utilized [Jin's PHGeometry offline package](https://github.com/sPHENIX-Collaboration/coresoftware/tree/master/offline/packages/PHGeometry) to handle the G4 => G3 on-the-fly translation, so no need of external G3 root file input. Example event display for FGEM and Maps+TPC:

![image](https://cloud.githubusercontent.com/assets/10383186/17605233/6e257310-5fe7-11e6-8ab3-b88382e490b2.png)
![image](https://cloud.githubusercontent.com/assets/10383186/17605239/72072938-5fe7-11e6-958e-bbe54d114452.png)

Affected code:

- Add a new SvtxTrack derived class SvtxTrack_FastSim:SvtxTrack_v1 and modified the SvtxTrack base class for truth g4particle and phg4hits association.

- PHGenFit package. Compatible with Jin's PHGeometry; Better exception handling; DAF fitting method.

Evaluation code based on the SvtxTrack_FasSim is available at [analysis/Tracking/FastTrackingEval](https://github.com/sPHENIX-Collaboration/analysis/tree/master/Tracking/FastTrackingEval):

![image](https://cloud.githubusercontent.com/assets/10383186/17605370/1d6b160e-5fe8-11e6-93fb-57ba6f000d56.png)

To-do:
- some genfit::Exception std::cerr message is not fully suppressed with PHG4TrackFastSim::Verbosity(0). About 1 message per 1000 track fittings for the FGEM case. May need to modify genfit package.

Related presentations:
[Jul. 27 at SpinFest2016](https://indico2.riken.jp/indico/getFile.py/access?contribId=19&resId=0&materialId=slides&confId=2284)
[Aug. 9 at sPHENIX simulation meeting](https://indico.bnl.gov/getFile.py/access?sessionId=0&resId=0&materialId=0&confId=1922)
[Aug. 9 at fsPHENIX/EIC meeting](https://indico.bnl.gov/getFile.py/access?contribId=2&resId=0&materialId=slides&confId=2316)


