### PR TITLE
Extend parameter class to handle multiple layers

### DIFF
--- a/offline/database/pdbcal/base/Makefile.am
+++ b/offline/database/pdbcal/base/Makefile.am
@@ -43,6 +43,8 @@ libpdbcalBase_la_SOURCES = \
   PdbParameterError_dict.C \
   PdbParameterMap.cc \
   PdbParameterMap_dict.C \
+  PdbParameterMapContainer.cc \
+  PdbParameterMapContainer_dict.C \
   PHGenericFactoryT.C \
   RunToTime.cc \
   RunToTime_dict.C
@@ -65,6 +67,7 @@ pkginclude_HEADERS = \
   PdbParameter.h \
   PdbParameterError.h \
   PdbParameterMap.h \
+  PdbParameterMapContainer.h \
   PHGenericFactoryT.h \
   RunToTime.h
 

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.cc
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.cc
@@ -1,0 +1,65 @@
+#include "PdbParameterMapContainer.h"
+#include "PdbParameterMap.h"
+
+#include <phool/phool.h>
+
+#include <TSystem.h>
+
+#include <iostream>
+
+using namespace std;
+
+PdbParameterMapContainer::~PdbParameterMapContainer()
+{
+  while(parametermap.begin() != parametermap.end())
+    {
+      delete parametermap.begin()->second;
+      parametermap.erase(parametermap.begin());
+    }
+  return;
+}
+
+void
+PdbParameterMapContainer::print() const
+{
+  for (map<int, PdbParameterMap *>::const_iterator iter = parametermap.begin(); 
+       iter != parametermap.end(); ++iter)
+    {
+      cout << "layer " << iter->first << endl;
+      iter->second->print();
+    }
+  return;
+}
+
+void
+PdbParameterMapContainer::AddPdbParameterMap(const int layer, PdbParameterMap *params)
+{
+  if (parametermap.find(layer) != parametermap.end())
+    {
+      cout << PHWHERE << " layer " << layer << " already exists" << endl; 
+      gSystem->Exit(1);
+    }
+  parametermap[layer] = params;
+}
+
+const PdbParameterMap *
+PdbParameterMapContainer::GetParameters(const int layer) const
+{
+  map<int, PdbParameterMap *>::const_iterator iter = parametermap.find(layer);
+if (iter == parametermap.end())
+  {
+    return NULL;
+  }
+ return iter->second;
+}
+
+PdbParameterMap *
+PdbParameterMapContainer::GetParametersToModify(const int layer)
+{
+  map<int, PdbParameterMap *>::iterator iter = parametermap.find(layer);
+  if (iter == parametermap.end())
+    {
+      return NULL;
+    }
+  return iter->second;
+}

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.cc
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.cc
@@ -46,11 +46,11 @@ const PdbParameterMap *
 PdbParameterMapContainer::GetParameters(const int layer) const
 {
   map<int, PdbParameterMap *>::const_iterator iter = parametermap.find(layer);
-if (iter == parametermap.end())
-  {
-    return NULL;
-  }
- return iter->second;
+  if (iter == parametermap.end())
+    {
+      return NULL;
+    }
+  return iter->second;
 }
 
 PdbParameterMap *

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.h
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.h
@@ -1,0 +1,28 @@
+#ifndef PdbParameterMapContainer__h
+#define PdbParameterMapContainer__h
+
+#include "PdbCalChan.h"
+
+#include <map>
+
+class PdbParameterMap;
+
+class PdbParameterMapContainer: public PdbCalChan
+{
+ public:
+  PdbParameterMapContainer() {}
+  virtual ~PdbParameterMapContainer();
+
+  void print() const;
+
+  void AddPdbParameterMap(const int layer, PdbParameterMap *params);
+  const PdbParameterMap *GetParameters(const int layer) const;
+  PdbParameterMap *GetParametersToModify(const int layer);
+
+ protected:
+  std::map<int, PdbParameterMap *> parametermap;
+
+  ClassDef(PdbParameterMapContainer,1)
+};
+
+#endif

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.h
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.h
@@ -10,6 +10,11 @@ class PdbParameterMap;
 class PdbParameterMapContainer: public PdbCalChan
 {
  public:
+
+  typedef std::map<int, PdbParameterMap *> parMap;
+  typedef parMap::const_iterator parIter;
+  typedef std::pair<parIter, parIter> parConstRange;
+
   PdbParameterMapContainer() {}
   virtual ~PdbParameterMapContainer();
 
@@ -18,6 +23,7 @@ class PdbParameterMapContainer: public PdbCalChan
   void AddPdbParameterMap(const int layer, PdbParameterMap *params);
   const PdbParameterMap *GetParameters(const int layer) const;
   PdbParameterMap *GetParametersToModify(const int layer);
+  parConstRange get_ParameterMaps() const {return make_pair(parametermap.begin(), parametermap.end());}
 
  protected:
   std::map<int, PdbParameterMap *> parametermap;

--- a/offline/database/pdbcal/pg/Makefile.am
+++ b/offline/database/pdbcal/pg/Makefile.am
@@ -55,6 +55,8 @@ libPgCal_la_SOURCES = \
   PgPostParameterErrorBank_dict.C \
   PgPostParameterMapBank.cc \
   PgPostParameterMapBank_dict.C \
+  PgPostParameterMapContainerBank.cc \
+  PgPostParameterMapContainerBank_dict.C \
   RunToTimePg.cc \
   RunToTimePg_dict.C
 

--- a/offline/database/pdbcal/pg/PgPostApplication.cc
+++ b/offline/database/pdbcal/pg/PgPostApplication.cc
@@ -56,11 +56,10 @@ int PgPostApplication::releaseConnection()
   return 0;
 }
 
-PgPostApplication::PgPostApplication(const string &dbname)
-{
-  dsn = dbname;
-  readOnly = 1;
-}
+PgPostApplication::PgPostApplication(const string &dbname):
+  readOnly(1),
+  dsn(dbname)
+{}
 
 PgPostApplication::~PgPostApplication()
 {

--- a/offline/database/pdbcal/pg/RunToTimePg.cc
+++ b/offline/database/pdbcal/pg/RunToTimePg.cc
@@ -133,7 +133,7 @@ RunToTimePg::getTime(const int runNumber, const string &what)
           // this picks the last run
           map<const int, PHTimeStamp *>::reverse_iterator iter = beginruntimes.rbegin();
           // go to the run before
-          iter++;
+          ++iter;
           int delrun = iter->first;
           delete iter->second;
           beginruntimes.erase(delrun);

--- a/offline/packages/NodeDump/DumpPdbParameterMap.cc
+++ b/offline/packages/NodeDump/DumpPdbParameterMap.cc
@@ -31,6 +31,18 @@ int DumpPdbParameterMap::process_Node(PHNode *myNode)
         {
           *fout << "name: " << diter->first << ": value " << diter->second << endl;
         }
+      PdbParameterMap::iIter iiter;
+      PdbParameterMap::iConstRange ibegin_end = pdbparams->get_iparam_iters();
+      for (iiter=ibegin_end.first; iiter != ibegin_end.second; ++iiter)
+        {
+          *fout << "name: " << iiter->first << ": value " << iiter->second << endl;
+        }
+      PdbParameterMap::strIter striter;
+      PdbParameterMap::strConstRange strbegin_end = pdbparams->get_cparam_iters();
+      for (striter=strbegin_end.first; striter != strbegin_end.second; ++striter)
+        {
+          *fout << "name: " << striter->first << ": value " << striter->second << endl;
+        }
     }
   return 0;
 }

--- a/offline/packages/NodeDump/DumpPdbParameterMapContainer.cc
+++ b/offline/packages/NodeDump/DumpPdbParameterMapContainer.cc
@@ -1,0 +1,56 @@
+#include "DumpPdbParameterMapContainer.h"
+
+#include <phool/PHIODataNode.h>
+
+#include <pdbcalbase/PdbParameterMapContainer.h>
+#include <pdbcalbase/PdbParameterMap.h>
+
+#include <string>
+
+using namespace std;
+
+typedef PHIODataNode<PdbParameterMapContainer> MyNode_t;
+
+DumpPdbParameterMapContainer::DumpPdbParameterMapContainer(const string &NodeName): DumpObject(NodeName)
+{
+  return ;
+}
+
+int DumpPdbParameterMapContainer::process_Node(PHNode *myNode)
+{
+  PdbParameterMapContainer *pdbparams = NULL;
+  MyNode_t *thisNode = static_cast <MyNode_t *> (myNode);
+  if (thisNode)
+    {
+      pdbparams = thisNode->getData();
+    }
+  if (pdbparams)
+    {
+      PdbParameterMapContainer::parIter piter;
+      PdbParameterMapContainer::parConstRange pbegin_end = pdbparams->get_ParameterMaps();
+      for (piter=pbegin_end.first; piter != pbegin_end.second; ++piter)
+        {
+	  *fout << "PdbParameterMap no " << piter->first << endl;
+          PdbParameterMap::dIter diter;
+	  PdbParameterMap::dConstRange dbegin_end = piter->second->get_dparam_iters();
+	  for (diter=dbegin_end.first; diter != dbegin_end.second; ++diter)
+	    {
+	      *fout << "name: " << diter->first << ": value " << diter->second << endl;
+	    }
+	  PdbParameterMap::iIter iiter;
+	  PdbParameterMap::iConstRange ibegin_end = piter->second->get_iparam_iters();
+	  for (iiter=ibegin_end.first; iiter != ibegin_end.second; ++iiter)
+	    {
+	      *fout << "name: " << iiter->first << ": value " << iiter->second << endl;
+	    }
+	  PdbParameterMap::strIter striter;
+	  PdbParameterMap::strConstRange strbegin_end = piter->second->get_cparam_iters();
+	  for (striter=strbegin_end.first; striter != strbegin_end.second; ++striter)
+	    {
+	      *fout << "name: " << striter->first << ": value " << striter->second << endl;
+	    }
+        }
+    }
+  return 0;
+}
+

--- a/offline/packages/NodeDump/DumpPdbParameterMapContainer.cc
+++ b/offline/packages/NodeDump/DumpPdbParameterMapContainer.cc
@@ -30,7 +30,7 @@ int DumpPdbParameterMapContainer::process_Node(PHNode *myNode)
       PdbParameterMapContainer::parConstRange pbegin_end = pdbparams->get_ParameterMaps();
       for (piter=pbegin_end.first; piter != pbegin_end.second; ++piter)
         {
-	  *fout << "PdbParameterMap no " << piter->first << endl;
+	  *fout << "PdbParameterMap # " << piter->first << endl;
           PdbParameterMap::dIter diter;
 	  PdbParameterMap::dConstRange dbegin_end = piter->second->get_dparam_iters();
 	  for (diter=dbegin_end.first; diter != dbegin_end.second; ++diter)

--- a/offline/packages/NodeDump/DumpPdbParameterMapContainer.h
+++ b/offline/packages/NodeDump/DumpPdbParameterMapContainer.h
@@ -1,0 +1,21 @@
+#ifndef DUMPPdbParameterMapContainer_H__
+#define DUMPPdbParameterMapContainer_H__
+
+#include "DumpObject.h"
+
+#include <string>
+
+class PHNode;
+
+class DumpPdbParameterMapContainer : public DumpObject
+{
+ public:
+  DumpPdbParameterMapContainer(const std::string &NodeName);
+  virtual ~DumpPdbParameterMapContainer() {}
+
+ protected:
+   int process_Node(PHNode *mynode);
+};
+
+#endif /* DUMPPdbParameterMapContainer_H__ */
+

--- a/offline/packages/NodeDump/Makefile.am
+++ b/offline/packages/NodeDump/Makefile.am
@@ -14,6 +14,7 @@ pkginclude_HEADERS = \
 libphnodedump_la_SOURCES = \
   Dumper.cc \
   DumpPdbParameterMap.cc \
+  DumpPdbParameterMapContainer.cc \
   DumpPHG4BlockGeomContainer.cc \
   DumpPHG4CylinderCellContainer.cc \
   DumpPHG4CylinderCellGeomContainer.cc \

--- a/offline/packages/NodeDump/PHNodeDump.cc
+++ b/offline/packages/NodeDump/PHNodeDump.cc
@@ -2,6 +2,7 @@
 #include "DumpObject.h"
 
 #include "DumpPdbParameterMap.h"
+#include "DumpPdbParameterMapContainer.h"
 #include "DumpPHG4BlockGeomContainer.h"
 #include "DumpPHG4CylinderCellContainer.h"
 #include "DumpPHG4CylinderCellGeomContainer.h"
@@ -158,6 +159,10 @@ int PHNodeDump::AddDumpObject(const string &NodeName, PHNode *node)
           if (tmp->InheritsFrom("PdbParameterMap"))
             {
               newdump = new DumpPdbParameterMap(NodeName);
+            }
+          else if (tmp->InheritsFrom("PdbParameterMapContainer"))
+            {
+              newdump = new DumpPdbParameterMapContainer(NodeName);
             }
           else if (tmp->InheritsFrom("PHG4BlockGeomContainer"))
             {

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -38,6 +38,7 @@ libg4detectors_la_LIBADD = \
 
 pkginclude_HEADERS = \
   PHG4Parameters.h \
+  PHG4ParametersContainer.h \
   PHG4BlockGeom.h \
   PHG4BlockGeomContainer.h \
   PHG4CylinderCell.h \
@@ -62,6 +63,8 @@ pkginclude_HEADERS = \
 libg4detectors_io_la_SOURCES = \
   PHG4Parameters.cc \
   PHG4Parameters_Dict.cc \
+  PHG4ParametersContainer.cc \
+  PHG4ParametersContainer_Dict.cc \
   PHG4BlockCellGeom.cc \
   PHG4BlockCellGeom_Dict.cc \
   PHG4BlockCellGeomContainer.cc \

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -24,10 +24,12 @@ INCLUDES = \
     -I${G4_MAIN}/include/Geant4
 
 libg4detectors_io_la_LIBADD = \
+  -L$(ROOTSYS)/lib \
   -lphool \
   -lboost_filesystem \
   -lboost_system \
-  -lpdbcalBase
+  -lpdbcalBase \
+  -lXMLIO
 
 libg4detectors_la_LIBADD = \
   libg4detectors_io.la \

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -24,6 +24,7 @@ using namespace std;
 PHG4BlockDetector::PHG4BlockDetector( PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam, const int lyr):
   PHG4Detector(Node, dnam),
   params(parameters),
+  block_physi(NULL),
   layer(lyr)
 {}
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4.cc
@@ -58,8 +58,7 @@ void PHG4CylinderGeomv4::find_segment_center(int segment_z_bin, int segment_phi_
   
   // We need to stagger the radii at alternate phi values by radius_stagger, since the ladders overlap in phi
   // The number of staggers is an input number, since it has to be the same for both parts of a double layer!
-  double R_layer = 0.0;
-  R_layer = layer_radius + (double) istagger * radius_stagger;
+  double R_layer = layer_radius + (double) istagger * radius_stagger;
   
   // Place the ladder segment envelopes at the correct z and phi
   double phi  = (double) segment_phi_bin * segment_phi_step;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -130,6 +130,17 @@ void
 PHG4CylinderSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
+  if (! BeginRunExecuted())
+    {
+      cout << "Need to execute BeginRun() before parameter printout is meaningful" << endl;
+      cout << "To do so either run one or more events or on the command line execute: " << endl;
+      cout << "Fun4AllServer *se = Fun4AllServer::instance();" << endl;
+      cout << "PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");" << endl;
+      cout << "g4->InitRun(se->topNode());" << endl;
+      cout << "PHG4CylinderSubsystem *cyl = (PHG4CylinderSubsystem *) g4->getSubsystem(\"" << Name() << "\");" << endl;
+      cout << "cyl->Print()" << endl;
+      return;
+    }
   GetParams()->Print();
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -31,15 +31,6 @@ PHG4CylinderSubsystem::PHG4CylinderSubsystem( const std::string &na, const int l
 }
 
 //_______________________________________________________________________
-int
-PHG4CylinderSubsystem::InitSubsystem( PHCompositeNode* topNode )
-{
-  // kludge until the phg4parameters are sorted out (adding layers)
-  GetParams()->set_name(Name());
-  return 0;
-}
-
-//_______________________________________________________________________
 int PHG4CylinderSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 {
   // create hit list only for active layers

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -23,9 +23,6 @@ class PHG4CylinderSubsystem: public PHG4DetectorSubsystem
   virtual ~PHG4CylinderSubsystem( void )
   {}
 
-  //! init
-  int InitSubsystem(PHCompositeNode *);
-
   //! init runwise stuff
   /*!
   creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
@@ -25,6 +25,7 @@ PHG4DetectorSubsystem::PHG4DetectorSubsystem(const std::string &name, const int 
   overlapcheck(false),
   layer(lyr),
   usedb(0),
+  beginrunexecuted(0),
   filetype(PHG4DetectorSubsystem::none),
   superdetector("NONE"),
   calibfiledir("./")
@@ -110,9 +111,13 @@ PHG4DetectorSubsystem::InitRun( PHCompositeNode* topNode )
   // save updated persistant copy on node tree
   params->SaveToNodeTree(runNode,paramnodename,layer);
   int iret = InitRunSubsystem(topNode);
-PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,paramnodename);
- cout << Name() << endl;
- nodeparams->print();
+  if (Verbosity() > 0)
+    {
+      PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,paramnodename);
+      cout << Name() << endl;
+      nodeparams->print();
+    }
+  beginrunexecuted = 1;
   return iret;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
@@ -55,6 +55,7 @@ PHG4DetectorSubsystem::InitRun( PHCompositeNode* topNode )
   string g4geonodename = "G4GEO_";
   string paramnodename = "G4GEOPARAM_";
   string calibdetname;
+  int isSuperDetector = 0;
   if (superdetector != "NONE")
     {
       g4geonodename += SuperDetector();
@@ -67,6 +68,7 @@ PHG4DetectorSubsystem::InitRun( PHCompositeNode* topNode )
       paramscontainer->AddPHG4Parameters(layer,params);
       paramnodename += superdetector;
       calibdetname = superdetector;
+      isSuperDetector = 1;
     }
   else
     {
@@ -87,11 +89,11 @@ PHG4DetectorSubsystem::InitRun( PHCompositeNode* topNode )
     {
       if (ReadDB())
 	{
-          ReadParamsFromDB(calibdetname);
+	   ReadParamsFromDB(calibdetname,isSuperDetector);
 	}
       if (get_filetype() != PHG4DetectorSubsystem::none)
 	{
-	  ReadParamsFromFile(calibdetname, get_filetype());
+	  ReadParamsFromFile(calibdetname, get_filetype(),isSuperDetector );
 	}
     }
   else
@@ -289,9 +291,17 @@ PHG4DetectorSubsystem::SaveParamsToDB()
 }
 
 int
-PHG4DetectorSubsystem::ReadParamsFromDB(const string &name)
+PHG4DetectorSubsystem::ReadParamsFromDB(const string &name, const int issuper)
 {
-  int iret = params->ReadFromDB(name,layer);
+  int iret = 0;
+  if (issuper)
+    {
+      iret = params->ReadFromDB(name,layer);
+    }
+  else
+    {
+      iret = params->ReadFromDB();
+    }
   if (iret)
     {
       cout << "problem reading from DB" << endl;
@@ -332,7 +342,7 @@ PHG4DetectorSubsystem::SaveParamsToFile(const PHG4DetectorSubsystem::FILE_TYPE f
 }
 
 int
-PHG4DetectorSubsystem::ReadParamsFromFile(const string &name, const PHG4DetectorSubsystem::FILE_TYPE ftyp)
+PHG4DetectorSubsystem::ReadParamsFromFile(const string &name, const PHG4DetectorSubsystem::FILE_TYPE ftyp, const int issuper)
 {
   string extension;
   switch(ftyp)
@@ -347,7 +357,7 @@ PHG4DetectorSubsystem::ReadParamsFromFile(const string &name, const PHG4Detector
       cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
       exit(1);
     }
-  int iret = params->ReadFromFile(name, extension, layer, calibfiledir);
+  int iret = params->ReadFromFile(name, extension, layer, issuper, calibfiledir);
   if (iret)
     {
       cout << "problem reading from " << extension << " file " << endl;

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
@@ -282,7 +282,15 @@ PHG4DetectorSubsystem::InitializeParameters()
 int
 PHG4DetectorSubsystem::SaveParamsToDB()
 {
-  int iret = params->WriteToDB();
+  int iret = 0;
+  if (paramscontainer)
+    {
+      iret = paramscontainer->WriteToDB();
+    }
+  else
+    {
+      iret = params->WriteToDB();
+    }
   if (iret)
     {
       cout << "problem committing to DB" << endl;

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
@@ -74,6 +74,7 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
   void set_default_double_param( const std::string &name, const double dval);
   void set_default_int_param( const std::string &name, const int ival);
   void set_default_string_param( const std::string &name, const std::string &sval);
+  int BeginRunExecuted() const {return beginrunexecuted;}
 
  private:
   PHG4Parameters *params;
@@ -82,6 +83,7 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
   bool overlapcheck;
   int layer;
   int usedb;
+  int beginrunexecuted;
   FILE_TYPE filetype;
   std::string superdetector;
   std::string calibfiledir;

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
@@ -7,6 +7,7 @@
 #include <string>
 
 class PHG4Parameters;
+class PHG4ParametersContainer;
 
 class PHG4DetectorSubsystem : public PHG4Subsystem
 {
@@ -47,9 +48,9 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
 
   void UseCalibFiles(const FILE_TYPE ftyp) {filetype = ftyp;}
   int SaveParamsToDB();
-  int ReadParamsFromDB();
+  int ReadParamsFromDB(const std::string &name);
   int SaveParamsToFile(const FILE_TYPE ftyp);
-  int ReadParamsFromFile(const FILE_TYPE ftyp);
+  int ReadParamsFromFile(const std::string &name, const FILE_TYPE ftyp);
   void SetCalibrationFileDir(const std::string &calibdir) {calibfiledir = calibdir;}
 
   void UpdateParametersWithMacro();
@@ -76,6 +77,8 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
 
  private:
   PHG4Parameters *params;
+  PHG4ParametersContainer *paramscontainer;
+  PHCompositeNode *savetopNode;
   bool overlapcheck;
   int layer;
   int usedb;

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
@@ -48,9 +48,9 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
 
   void UseCalibFiles(const FILE_TYPE ftyp) {filetype = ftyp;}
   int SaveParamsToDB();
-  int ReadParamsFromDB(const std::string &name);
+  int ReadParamsFromDB(const std::string &name, const int issuper);
   int SaveParamsToFile(const FILE_TYPE ftyp);
-  int ReadParamsFromFile(const std::string &name, const FILE_TYPE ftyp);
+  int ReadParamsFromFile(const std::string &name, const FILE_TYPE ftyp, const int issuper);
   void SetCalibrationFileDir(const std::string &calibdir) {calibfiledir = calibdir;}
 
   void UpdateParametersWithMacro();

--- a/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.cc
@@ -233,7 +233,7 @@ PHG4EICForwardEcalDetector::PlaceTower(G4LogicalVolume* ecalenvelope, G4LogicalV
   /* Loop over all tower positions in vector and place tower */
   typedef std::map< std::string, towerposition>::iterator it_type;
 
-  for(it_type iterator = _map_tower.begin(); iterator != _map_tower.end(); iterator++) {
+  for(it_type iterator = _map_tower.begin(); iterator != _map_tower.end(); ++iterator) {
 
       if ( verbosity > 0 )
 	{

--- a/simulation/g4simulation/g4detectors/PHG4Parameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Parameters.cc
@@ -177,7 +177,7 @@ PHG4Parameters::printstring() const
 void
 PHG4Parameters::FillFrom(const PdbParameterMapContainer *saveparamcontainer, const int layer)
 {
-  assert(saveparamcontainer);
+  //  assert(saveparamcontainer != NULL);
 
   const PdbParameterMap *saveparams = saveparamcontainer->GetParameters(layer);
   if (! saveparams)
@@ -297,7 +297,7 @@ PHG4Parameters::WriteToDB()
 }
 
 int
-PHG4Parameters::ReadFromDB(const int layer)
+PHG4Parameters::ReadFromDB(const string &name, const int layer)
 {
   PdbBankManager* bankManager = PdbBankManager::instance();
   PdbApplication *application = bankManager->getApplication();
@@ -312,10 +312,10 @@ PHG4Parameters::ReadFromDB(const int layer)
   PdbBankID bankID(0); // lets start at zero
   PHTimeStamp TSearch(10);
 
-  string tablename = detname + "_geoparams";
+  string tablename = name + "_geoparams";
   std::transform(tablename.begin(), tablename.end(), tablename.begin(),
       ::tolower);
-  PdbCalBank *NewBank = bankManager->fetchBank("PdbParameterMapBank", bankID,
+  PdbCalBank *NewBank = bankManager->fetchBank("PdbParameterMapContainerBank", bankID,
       tablename, TSearch);
   if (NewBank)
     {
@@ -365,12 +365,12 @@ PHG4Parameters::WriteToFile(const string &extension, const string &dir)
 }
 
 int
-PHG4Parameters::ReadFromFile(const string &extension, const int layer, const string &dir)
+PHG4Parameters::ReadFromFile(const string &name, const string &extension, const int layer, const string &dir)
 {
   PHTimeStamp TSearch(10);
   PdbBankID bankID(0);
   ostringstream fnamestream;
-  fnamestream << detname << "_geoparams" << "-" << bankID.getInternalValue();
+  fnamestream << name << "_geoparams" << "-" << bankID.getInternalValue();
   string fileprefix = fnamestream.str();
   std::transform(fileprefix.begin(), fileprefix.end(), fileprefix.begin(),
       ::tolower);

--- a/simulation/g4simulation/g4detectors/PHG4Parameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Parameters.cc
@@ -506,13 +506,13 @@ PHG4Parameters::ReadFromFile(const string &name, const string &extension, const 
   TFile *f = TFile::Open(fname.c_str());
   if (issuper)
     {
-      PdbParameterMapContainer *myparm = (PdbParameterMapContainer *) f->Get("PdbParameterMapContainer");
+      PdbParameterMapContainer *myparm = static_cast<PdbParameterMapContainer *> (f->Get("PdbParameterMapContainer"));
       FillFrom(myparm, layer);
       delete myparm;
     }
   else
     {
-      PdbParameterMap *myparm = (PdbParameterMap *) f->Get("PdbParameterMap");
+      PdbParameterMap *myparm = static_cast<PdbParameterMap *> (f->Get("PdbParameterMap"));
       FillFrom(myparm);
       delete myparm;
     }

--- a/simulation/g4simulation/g4detectors/PHG4Parameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Parameters.cc
@@ -13,6 +13,7 @@
 #include <phool/PHTimeStamp.h>
 
 #include <TFile.h>
+#include <TSystem.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
@@ -490,8 +491,8 @@ PHG4Parameters::ReadFromFile(const string &name, const string &extension, const 
     }
   if (calibfiles.empty())
     {
-      cout << "No calibration file found" << endl;
-      return -1;
+      cout << "No calibration file like " << dir << "/" << fileprefix << " found" << endl;
+      gSystem->Exit(1);
     }
   cout << "Reading from File: " << (calibfiles.rbegin())->second << endl;
   string fname = (calibfiles.rbegin())->second;

--- a/simulation/g4simulation/g4detectors/PHG4Parameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Parameters.cc
@@ -12,6 +12,7 @@
 #include <phool/PHIODataNode.h>
 #include <phool/PHTimeStamp.h>
 
+#include <TBufferXML.h>
 #include <TFile.h>
 #include <TSystem.h>
 
@@ -426,8 +427,14 @@ PHG4Parameters::WriteToFile(const string &extension, const string &dir)
   PdbParameterMap *myparm = new PdbParameterMap();
   CopyToPdbParameterMap(myparm);
   TFile *f = TFile::Open(fullpath.str().c_str(), "recreate");
+  // force xml file writing to use extended precision shown experimentally
+  // to not modify input parameters (.15e)
+  string floatformat = TBufferXML::GetFloatFormat();
+  TBufferXML::SetFloatFormat("%.15e");
   myparm->Write();
   delete f;
+  // restore previous xml float format
+  TBufferXML::SetFloatFormat(floatformat.c_str());
   cout << "sleeping 1 second to prevent duplicate inserttimes" << endl;
   sleep(1);
   return 0;

--- a/simulation/g4simulation/g4detectors/PHG4Parameters.h
+++ b/simulation/g4simulation/g4detectors/PHG4Parameters.h
@@ -7,6 +7,7 @@
 #include <string>
 
 class PdbParameterMap;
+class PdbParameterMapContainer;
 class PHCompositeNode;
 
 // contains parameters in our units,
@@ -40,13 +41,13 @@ class PHG4Parameters: public PHObject
   void set_name(const std::string &name) {detname = name;}
   std::string Name() const {return detname;}
 
-  void FillFrom(const PdbParameterMap *saveparams);
+  void FillFrom(const PdbParameterMapContainer *saveparamcontainer, const int layer);
   void FillFrom(const PHG4Parameters *saveparams);
-  void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename);
+  void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename, const int layer);
   int WriteToDB();
-  int ReadFromDB();
+  int ReadFromDB(const int layer);
   int WriteToFile(const std::string &extension, const std::string &dir = ".");
-  int ReadFromFile(const std::string &extension, const std::string &dir = ".");
+  int ReadFromFile(const std::string &extension, const int layer, const std::string &dir = ".");
 
  protected:
   void printint() const;

--- a/simulation/g4simulation/g4detectors/PHG4Parameters.h
+++ b/simulation/g4simulation/g4detectors/PHG4Parameters.h
@@ -45,15 +45,15 @@ class PHG4Parameters: public PHObject
   void FillFrom(const PHG4Parameters *saveparams);
   void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename, const int layer);
   int WriteToDB();
-  int ReadFromDB(const int layer);
+  int ReadFromDB(const std::string &name, const int layer);
   int WriteToFile(const std::string &extension, const std::string &dir = ".");
-  int ReadFromFile(const std::string &extension, const int layer, const std::string &dir = ".");
+  int ReadFromFile(const std::string &name, const std::string &extension, const int layer, const std::string &dir = ".");
+  void CopyToPdbParameterMap(PdbParameterMap *myparm);
 
  protected:
   void printint() const;
   void printdouble() const;
   void printstring() const;
-  void CopyToPdbParameterMap(PdbParameterMap *myparm);
   unsigned int ConvertStringToUint(const std::string &str) const;
   PdbParameterMap *pdbparam;
   std::string detname;

--- a/simulation/g4simulation/g4detectors/PHG4Parameters.h
+++ b/simulation/g4simulation/g4detectors/PHG4Parameters.h
@@ -41,13 +41,15 @@ class PHG4Parameters: public PHObject
   void set_name(const std::string &name) {detname = name;}
   std::string Name() const {return detname;}
 
+  void FillFrom(const PdbParameterMap *saveparams);
   void FillFrom(const PdbParameterMapContainer *saveparamcontainer, const int layer);
   void FillFrom(const PHG4Parameters *saveparams);
   void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename, const int layer);
   int WriteToDB();
+  int ReadFromDB();
   int ReadFromDB(const std::string &name, const int layer);
   int WriteToFile(const std::string &extension, const std::string &dir = ".");
-  int ReadFromFile(const std::string &name, const std::string &extension, const int layer, const std::string &dir = ".");
+  int ReadFromFile(const std::string &name, const std::string &extension, const int layer, const int issuper, const std::string &dir = ".");
   void CopyToPdbParameterMap(PdbParameterMap *myparm);
 
  protected:

--- a/simulation/g4simulation/g4detectors/PHG4ParametersContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ParametersContainer.cc
@@ -104,6 +104,44 @@ PHG4ParametersContainer::WriteToFile(const string &extension, const string &dir)
   return 0;
 }
 
+int
+PHG4ParametersContainer::WriteToDB()
+{
+  PdbBankManager* bankManager = PdbBankManager::instance();
+  PdbApplication *application = bankManager->getApplication();
+  if (!application->startUpdate())
+    {
+      cout << PHWHERE << " Aborting, Database not writable" << endl;
+      application->abort();
+      exit(1);
+    }
+
+  //  Make a bank ID...
+  PdbBankID bankID(0); // lets start at zero
+  PHTimeStamp TStart(0);
+  PHTimeStamp TStop(0xffffffff);
+
+  string tablename = superdetectorname + "_geoparams";
+  std::transform(tablename.begin(), tablename.end(), tablename.begin(),
+      ::tolower);
+  PdbCalBank *NewBank = bankManager->createBank("PdbParameterMapContainerBank", bankID,
+      "Geometry Parameters", TStart, TStop, tablename);
+  if (NewBank)
+    {
+      NewBank->setLength(1);
+      PdbParameterMapContainer *myparm = (PdbParameterMapContainer*) &NewBank->getEntry(0);
+      CopyToPdbParameterMapContainer(myparm);
+      application->commit(NewBank);
+      delete NewBank;
+    }
+  else
+    {
+      cout << PHWHERE " Committing to DB failed" << endl;
+      return -1;
+    }
+  return 0;
+}
+
 void
 PHG4ParametersContainer::CopyToPdbParameterMapContainer(PdbParameterMapContainer *myparmap)
 {

--- a/simulation/g4simulation/g4detectors/PHG4ParametersContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ParametersContainer.cc
@@ -10,6 +10,7 @@
 
 #include <phool/phool.h>
 
+#include <TBufferXML.h>
 #include <TFile.h>
 #include <TSystem.h>
 
@@ -97,8 +98,14 @@ PHG4ParametersContainer::WriteToFile(const string &extension, const string &dir)
   PdbParameterMapContainer *myparm = new PdbParameterMapContainer();
   CopyToPdbParameterMapContainer(myparm);
   TFile *f = TFile::Open(fullpath.str().c_str(), "recreate");
+  // force xml file writing to use extended precision shown experimentally
+  // to not modify input parameters (.15e)
+  string floatformat = TBufferXML::GetFloatFormat();
+  TBufferXML::SetFloatFormat("%.15e");
   myparm->Write();
   delete f;
+  // restore previous xml float format
+  TBufferXML::SetFloatFormat(floatformat.c_str());
   cout << "sleeping 1 second to prevent duplicate inserttimes" << endl;
   sleep(1);
   return 0;

--- a/simulation/g4simulation/g4detectors/PHG4ParametersContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ParametersContainer.cc
@@ -1,0 +1,58 @@
+#include "PHG4ParametersContainer.h"
+#include "PHG4Parameters.h"
+
+#include <phool/phool.h>
+
+#include <TSystem.h>
+
+#include <iostream>
+
+using namespace std;
+
+PHG4ParametersContainer::~PHG4ParametersContainer()
+{
+  while(parametermap.begin() != parametermap.end())
+    {
+      delete parametermap.begin()->second;
+      parametermap.erase(parametermap.begin());
+    }
+
+}
+
+void
+PHG4ParametersContainer::AddPHG4Parameters(const int layer, PHG4Parameters *params)
+{
+  if (parametermap.find(layer) != parametermap.end())
+    {
+      cout << PHWHERE << " layer " << layer << " already exists for " 
+	   << (parametermap.find(layer))->second->Name() << endl;
+      gSystem->Exit(1);
+    }
+  parametermap[layer] = params;
+}
+
+const PHG4Parameters *
+PHG4ParametersContainer::GetParameters(const int layer) const
+{
+  map<int, PHG4Parameters *>::const_iterator iter = parametermap.find(layer);
+if (iter == parametermap.end())
+  {
+    cout << "could not find parameters for layer " << layer
+	 << endl;
+    return NULL;
+  }
+ return iter->second;
+}
+
+PHG4Parameters *
+PHG4ParametersContainer::GetParametersToModify(const int layer)
+{
+  map<int, PHG4Parameters *>::iterator iter = parametermap.find(layer);
+  if (iter == parametermap.end())
+    {
+      cout << "could not find parameters for layer " << layer
+	   << endl;
+      return NULL;
+    }
+  return iter->second;
+}

--- a/simulation/g4simulation/g4detectors/PHG4ParametersContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4ParametersContainer.h
@@ -1,0 +1,30 @@
+#ifndef PHG4ParametersContainer__h
+#define PHG4ParametersContainer__h
+
+#include <phool/PHObject.h>
+
+#include <map>
+#include <string>
+
+class PHG4Parameters;
+
+class PHG4ParametersContainer: public PHObject
+{
+ public:
+  PHG4ParametersContainer() {}
+  virtual ~PHG4ParametersContainer();
+
+  void AddPHG4Parameters(const int layer, PHG4Parameters *params);
+  const PHG4Parameters *GetParameters(const int layer) const;
+  PHG4Parameters *GetParametersToModify(const int layer);
+
+  void set_name(const std::string &name) {superdetectorname = name;}
+  std::string Name() const {return superdetectorname;}
+
+ protected:
+  std::string superdetectorname;
+  std::map<int, PHG4Parameters *> parametermap;
+
+};
+
+#endif //PHG4ParametersContainer__h

--- a/simulation/g4simulation/g4detectors/PHG4ParametersContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4ParametersContainer.h
@@ -7,21 +7,24 @@
 #include <string>
 
 class PHG4Parameters;
+class PdbParameterMapContainer;
 
 class PHG4ParametersContainer: public PHObject
 {
  public:
-  PHG4ParametersContainer() {}
+  PHG4ParametersContainer(const std::string &name = "NONE");
   virtual ~PHG4ParametersContainer();
 
   void AddPHG4Parameters(const int layer, PHG4Parameters *params);
   const PHG4Parameters *GetParameters(const int layer) const;
   PHG4Parameters *GetParametersToModify(const int layer);
+  int WriteToFile(const std::string &extension, const std::string &dir);
 
   void set_name(const std::string &name) {superdetectorname = name;}
   std::string Name() const {return superdetectorname;}
 
  protected:
+  void CopyToPdbParameterMapContainer(PdbParameterMapContainer *myparm);
   std::string superdetectorname;
   std::map<int, PHG4Parameters *> parametermap;
 

--- a/simulation/g4simulation/g4detectors/PHG4ParametersContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4ParametersContainer.h
@@ -19,7 +19,8 @@ class PHG4ParametersContainer: public PHObject
   const PHG4Parameters *GetParameters(const int layer) const;
   PHG4Parameters *GetParametersToModify(const int layer);
   int WriteToFile(const std::string &extension, const std::string &dir);
-
+  int WriteToDB();
+  
   void set_name(const std::string &name) {superdetectorname = name;}
   std::string Name() const {return superdetectorname;}
 

--- a/simulation/g4simulation/g4detectors/PHG4ParametersContainerLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4ParametersContainerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4ParametersContainer-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -413,15 +413,17 @@ PHG4Prototype2InnerHcalSubsystem::ReadParamsFromFile(const PHG4Prototype2InnerHc
       exit(1);
     }
   string name;
+  int issuper = 0;
   if (superdetector != "NONE")
     {
       name = superdetector;
+      issuper = 1;
     }
   else
     {
       name = params->Name();
     }
-  int iret = params->ReadFromFile(name, extension, layer, calibfiledir);
+  int iret = params->ReadFromFile(name, extension, layer, issuper, calibfiledir);
   if (iret)
     {
       cout << "problem reading from " << extension << " file " << endl;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -363,7 +363,7 @@ PHG4Prototype2InnerHcalSubsystem::SaveParamsToDB()
 int
 PHG4Prototype2InnerHcalSubsystem::ReadParamsFromDB()
 {
-  int iret = params->ReadFromDB(layer);
+  int iret = params->ReadFromDB(superdetector,layer);
   if (iret)
     {
       cout << "problem reading from DB" << endl;
@@ -412,7 +412,16 @@ PHG4Prototype2InnerHcalSubsystem::ReadParamsFromFile(const PHG4Prototype2InnerHc
       cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
       exit(1);
     }
-  int iret = params->ReadFromFile(extension,layer, calibfiledir);
+  string name;
+  if (superdetector != "NONE")
+    {
+      name = superdetector;
+    }
+  else
+    {
+      name = params->Name();
+    }
+  int iret = params->ReadFromFile(name, extension, layer, calibfiledir);
   if (iret)
     {
       cout << "problem reading from " << extension << " file " << endl;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -7,6 +7,7 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <pdbcalbase/PdbParameterMap.h>
+#include <pdbcalbase/PdbParameterMapContainer.h>
 
 #include <phool/getClass.h>
 
@@ -88,17 +89,17 @@ PHG4Prototype2InnerHcalSubsystem::InitRun( PHCompositeNode* topNode )
     }
   else
     {
-      PdbParameterMap *nodeparams = findNode::getClass<PdbParameterMap>(topNode,paramnodename);
+      PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,paramnodename);
       if (nodeparams)
 	{
-	  params->FillFrom(nodeparams);
+	  params->FillFrom(nodeparams, layer);
 	}
     }
   // parameters set in the macro always override whatever is read from
   // the node tree, DB or file
   UpdateParametersWithMacro();
   // save updated persistant copy on node tree
-  params->SaveToNodeTree(parNode,paramnodename);
+  params->SaveToNodeTree(parNode,paramnodename, layer);
   // create detector
   detector_ = new PHG4Prototype2InnerHcalDetector(topNode, params, Name());
   detector_->SuperDetector(superdetector);
@@ -362,7 +363,7 @@ PHG4Prototype2InnerHcalSubsystem::SaveParamsToDB()
 int
 PHG4Prototype2InnerHcalSubsystem::ReadParamsFromDB()
 {
-  int iret = params->ReadFromDB();
+  int iret = params->ReadFromDB(layer);
   if (iret)
     {
       cout << "problem reading from DB" << endl;
@@ -411,7 +412,7 @@ PHG4Prototype2InnerHcalSubsystem::ReadParamsFromFile(const PHG4Prototype2InnerHc
       cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
       exit(1);
     }
-  int iret = params->ReadFromFile(extension,calibfiledir);
+  int iret = params->ReadFromFile(extension,layer, calibfiledir);
   if (iret)
     {
       cout << "problem reading from " << extension << " file " << endl;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
@@ -413,15 +413,17 @@ PHG4Prototype2OuterHcalSubsystem::ReadParamsFromFile(const PHG4Prototype2OuterHc
       exit(1);
     }
   string name;
+  int issuper = 0;
   if (superdetector != "NONE")
     {
       name = superdetector;
+      issuper = 1;
     }
   else
     {
       name = params->Name();
     }
-  int iret = params->ReadFromFile(name, extension, layer, calibfiledir);
+  int iret = params->ReadFromFile(name, extension, layer, issuper, calibfiledir);
   if (iret)
     {
       cout << "problem reading from " << extension << " file " << endl;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
@@ -363,7 +363,7 @@ PHG4Prototype2OuterHcalSubsystem::SaveParamsToDB()
 int
 PHG4Prototype2OuterHcalSubsystem::ReadParamsFromDB()
 {
-  int iret = params->ReadFromDB(layer);
+  int iret = params->ReadFromDB(superdetector,layer);
   if (iret)
     {
       cout << "problem reading from DB" << endl;
@@ -412,7 +412,16 @@ PHG4Prototype2OuterHcalSubsystem::ReadParamsFromFile(const PHG4Prototype2OuterHc
       cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
       exit(1);
     }
-  int iret = params->ReadFromFile(extension,layer, calibfiledir);
+  string name;
+  if (superdetector != "NONE")
+    {
+      name = superdetector;
+    }
+  else
+    {
+      name = params->Name();
+    }
+  int iret = params->ReadFromFile(name, extension, layer, calibfiledir);
   if (iret)
     {
       cout << "problem reading from " << extension << " file " << endl;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
@@ -7,6 +7,7 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <pdbcalbase/PdbParameterMap.h>
+#include <pdbcalbase/PdbParameterMapContainer.h>
 
 #include <phool/getClass.h>
 
@@ -88,17 +89,17 @@ PHG4Prototype2OuterHcalSubsystem::InitRun( PHCompositeNode* topNode )
     }
   else
     {
-      PdbParameterMap *nodeparams = findNode::getClass<PdbParameterMap>(topNode,paramnodename);
+      PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,paramnodename);
       if (nodeparams)
 	{
-	  params->FillFrom(nodeparams);
+	  params->FillFrom(nodeparams, layer);
 	}
     }
   // parameters set in the macro always override whatever is read from
   // the node tree, DB or file
   UpdateParametersWithMacro();
   // save updated persistant copy on node tree
-  params->SaveToNodeTree(parNode,paramnodename);
+  params->SaveToNodeTree(parNode,paramnodename,layer);
   // create detector
   detector_ = new PHG4Prototype2OuterHcalDetector(topNode, params, Name());
   detector_->SuperDetector(superdetector);
@@ -362,7 +363,7 @@ PHG4Prototype2OuterHcalSubsystem::SaveParamsToDB()
 int
 PHG4Prototype2OuterHcalSubsystem::ReadParamsFromDB()
 {
-  int iret = params->ReadFromDB();
+  int iret = params->ReadFromDB(layer);
   if (iret)
     {
       cout << "problem reading from DB" << endl;
@@ -411,7 +412,7 @@ PHG4Prototype2OuterHcalSubsystem::ReadParamsFromFile(const PHG4Prototype2OuterHc
       cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
       exit(1);
     }
-  int iret = params->ReadFromFile(extension,calibfiledir);
+  int iret = params->ReadFromFile(extension,layer, calibfiledir);
   if (iret)
     {
       cout << "problem reading from " << extension << " file " << endl;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.cc
@@ -106,7 +106,6 @@ PHG4SpacalPrototypeDetector::Construct(G4LogicalVolume* logicWorld)
   PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
       "PHCompositeNode", "RUN"));
   assert(parNode);
-  string g4geonodename = "G4GEO_" + superdetector;
 
   if (!_geom)
     {

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.cc
@@ -1,12 +1,3 @@
-// $$Id: PHG4SpacalPrototypeDetector.cc,v 1.7 2015/02/10 15:39:26 pinkenbu Exp $$
-
-/*!
- * \file ${file_name}
- * \brief
- * \author Jin Huang <jhuang@bnl.gov>
- * \version $$Revision: 1.7 $$
- * \date $$Date: 2015/02/10 15:39:26 $$
- */
 #include "PHG4SpacalPrototypeDetector.h"
 #include "PHG4CylinderGeomContainer.h"
 #include "PHG4Parameters.h"
@@ -52,15 +43,19 @@ using namespace std;
 
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4SpacalPrototypeDetector::PHG4SpacalPrototypeDetector(PHCompositeNode *Node,
-    const std::string &dnam) :
-    PHG4Detector(Node, dnam), _region(NULL), //
-    cylinder_solid(NULL), cylinder_logic(NULL), cylinder_physi(NULL), //
-    active(0), absorberactive(0), //
-    step_limits(NULL), clading_step_limits(NULL), fiber_core_step_limits(NULL), //
+PHG4SpacalPrototypeDetector::PHG4SpacalPrototypeDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam) :
+    PHG4Detector(Node, dnam), 
+    construction_params(parameters),
+    cylinder_solid(NULL), 
+    cylinder_logic(NULL), 
+    cylinder_physi(NULL), //
+    active(0), 
+    absorberactive(0), //
+    step_limits(NULL), 
+    clading_step_limits(NULL), 
+    fiber_core_step_limits(NULL), //
     _geom(NULL)
-{
-}
+{}
 
 PHG4SpacalPrototypeDetector::~PHG4SpacalPrototypeDetector(void)
 {
@@ -112,9 +107,6 @@ PHG4SpacalPrototypeDetector::Construct(G4LogicalVolume* logicWorld)
       "PHCompositeNode", "RUN"));
   assert(parNode);
   string g4geonodename = "G4GEO_" + superdetector;
-  PHG4Parameters *construction_params = findNode::getClass<PHG4Parameters>(
-      parNode, g4geonodename);
-  assert(construction_params);
 
   if (!_geom)
     {

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.h
@@ -1,18 +1,9 @@
-// $$Id: PHG4SpacalPrototypeDetector.h,v 1.2 2014/08/12 03:49:12 jinhuang Exp $$
-
-/*!
- * \file ${file_name}
- * \brief
- * \author Jin Huang <jhuang@bnl.gov>
- * \version $$Revision: 1.2 $$
- * \date $$Date: 2014/08/12 03:49:12 $$
- */
-
 #ifndef PHG4SpacalPrototypeDetector_h
 #define PHG4SpacalPrototypeDetector_h
 
-#include "g4main/PHG4Detector.h"
 #include "PHG4CylinderGeom_Spacalv3.h"
+
+#include <g4main/PHG4Detector.h>
 
 #include <Geant4/globals.hh>
 #include <Geant4/G4Region.hh>
@@ -23,11 +14,12 @@
 #include <set>
 #include <utility>
 
-class G4Material;
-class G4VSolid;
 class G4LogicalVolume;
-class G4VPhysicalVolume;
+class G4Material;
 class G4UserLimits;
+class G4VPhysicalVolume;
+class G4VSolid;
+class PHG4Parameters;
 
 class PHG4SpacalPrototypeDetector : public PHG4Detector
 {
@@ -35,7 +27,7 @@ class PHG4SpacalPrototypeDetector : public PHG4Detector
 public:
   typedef PHG4CylinderGeom_Spacalv3 SpacalGeom_t;
 
-  PHG4SpacalPrototypeDetector(PHCompositeNode* Node, const std::string& dnam);
+  PHG4SpacalPrototypeDetector(PHCompositeNode* Node, PHG4Parameters *parameters, const std::string& dnam);
 
   virtual
   ~PHG4SpacalPrototypeDetector(void);
@@ -96,15 +88,6 @@ public:
     return superdetector;
   }
 
-  G4UserSteppingAction*
-  GetSteppingAction()
-  {
-    if (_region)
-      return _region->GetRegionalSteppingAction();
-    else
-      return 0;
-  }
-
   virtual void
   Print(const std::string& what = "ALL") const;
 
@@ -125,7 +108,8 @@ public:
 
 protected:
 
-  G4Region* _region;
+  PHG4Parameters *construction_params;
+
   G4VSolid* cylinder_solid;
   G4LogicalVolume* cylinder_logic;
   G4VPhysicalVolume* cylinder_physi;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
@@ -9,6 +9,8 @@
  */
 #include "PHG4SpacalPrototypeSubsystem.h"
 
+#include "PHG4ParametersContainer.h"
+
 #include "PHG4SpacalPrototypeDetector.h"
 #include "PHG4ProjSpacalDetector.h"
 #include "PHG4FullProjSpacalDetector.h"
@@ -25,6 +27,8 @@
 #include <phool/getClass.h>
 
 #include <pdbcalbase/PdbParameterMap.h>
+#include <pdbcalbase/PdbParameterMapContainer.h>
+
 #include <Geant4/globals.hh>
 
 #include <sstream>
@@ -55,8 +59,12 @@ PHG4SpacalPrototypeSubsystem::InitRun(PHCompositeNode* topNode)
   // update the parameters on the node tree
   PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
       "PHCompositeNode", "RUN"));
-  string g4geonodename = "G4GEO_" + superdetector;
-  parNode->addNode(new PHDataNode<PHG4Parameters>(new PHG4Parameters(superdetector), g4geonodename));
+  string g4geonodename = "G4GEO_";
+  if (superdetector != "NONE")
+    {
+      g4geonodename += superdetector;
+    }
+  parNode->addNode(new PHDataNode<PHG4ParametersContainer>(new PHG4ParametersContainer(), g4geonodename));
 
   PHG4Parameters *construction_params = findNode::getClass<PHG4Parameters>(
       parNode, g4geonodename);
@@ -72,7 +80,7 @@ PHG4SpacalPrototypeSubsystem::InitRun(PHCompositeNode* topNode)
     {
       // use DB
 
-      int iret = construction_params->ReadFromDB();
+      int iret = construction_params->ReadFromDB(0);
       if (iret)
         {
           cout
@@ -84,11 +92,11 @@ PHG4SpacalPrototypeSubsystem::InitRun(PHCompositeNode* topNode)
     }
   else
     {
-      PdbParameterMap *nodeparams = findNode::getClass<PdbParameterMap>(topNode,
+      PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,
           paramnodename);
       if (nodeparams)
         {
-          construction_params->FillFrom(nodeparams);
+          construction_params->FillFrom(nodeparams,0);
         }
     }
 
@@ -97,7 +105,7 @@ PHG4SpacalPrototypeSubsystem::InitRun(PHCompositeNode* topNode)
 
 //   this step is moved to after detector construction
 //   save updated persistant copy on node tree
-  construction_params->SaveToNodeTree(parNode, paramnodename);
+  construction_params->SaveToNodeTree(parNode, paramnodename, 0);
 
   if (verbosity > 0)
     cout

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
@@ -80,7 +80,7 @@ PHG4SpacalPrototypeSubsystem::InitRun(PHCompositeNode* topNode)
     {
       // use DB
 
-      int iret = construction_params->ReadFromDB(0);
+      int iret = construction_params->ReadFromDB(superdetector,0);
       if (iret)
         {
           cout

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.h
@@ -11,8 +11,9 @@
 #ifndef PHG4SpacalPrototypeSubsystem_h
 #define PHG4SpacalPrototypeSubsystem_h
 
-#include "g4main/PHG4Subsystem.h"
 #include "PHG4Parameters.h"
+
+#include <g4main/PHG4Subsystem.h>
 
 #include <Geant4/G4Types.hh>
 #include <Geant4/G4String.hh>

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.h
@@ -1,41 +1,22 @@
-// $$Id: PHG4SpacalPrototypeSubsystem.h,v 1.2 2014/08/12 03:49:12 jinhuang Exp $$
-
-/*!
- * \file ${file_name}
- * \brief
- * \author Jin Huang <jhuang@bnl.gov>
- * \version $$Revision: 1.2 $$
- * \date $$Date: 2014/08/12 03:49:12 $$
- */
-
 #ifndef PHG4SpacalPrototypeSubsystem_h
 #define PHG4SpacalPrototypeSubsystem_h
 
-#include "PHG4Parameters.h"
-
-#include <g4main/PHG4Subsystem.h>
-
-#include <Geant4/G4Types.hh>
-#include <Geant4/G4String.hh>
+#include "PHG4DetectorSubsystem.h"
 
 class PHG4SpacalPrototypeDetector;
-class PHG4SpacalPrototypeSteppingAction;
+class PHG4SteppingAction;
 class PHG4EventAction;
 
-class PHG4SpacalPrototypeSubsystem : public PHG4Subsystem
+class PHG4SpacalPrototypeSubsystem : public PHG4DetectorSubsystem
 {
 
 public:
 
   //! constructor
-  PHG4SpacalPrototypeSubsystem(const std::string &name =
-      "CEMC");
+  PHG4SpacalPrototypeSubsystem(const std::string &name = "CEMC");
 
   //! destructor
-  virtual
-  ~PHG4SpacalPrototypeSubsystem(void)
-  {
-  }
+  virtual ~PHG4SpacalPrototypeSubsystem(void) {}
 
   //! init
   /*!
@@ -43,103 +24,37 @@ public:
    reates the stepping action and place it on the node tree, under "ACTIONS" node
    creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
    */
-  int
-  InitRun(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode *);
 
   //! event processing
   /*!
    get all relevant nodes from top nodes (namely hit list)
    and pass that to the stepping action
    */
-  int
-  process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *);
 
   //! accessors (reimplemented)
-  virtual PHG4Detector*
-  GetDetector(void) const;
-  virtual PHG4SteppingAction*
-  GetSteppingAction(void) const;
-  PHG4EventAction*
-  GetEventAction() const
-  {
-    return eventAction_;
-  }
+  virtual PHG4Detector* GetDetector(void) const;
+  PHG4SteppingAction* GetSteppingAction(void) const {return steppingAction_;}
+  PHG4EventAction* GetEventAction() const {return eventAction_;}
 
-  void
-  SetActive(const int i = 1)
-  {
-    active = i;
-  }
-  void
-  SetAbsorberActive(const int i = 1)
-  {
-    absorberactive = i;
-  }
-  void
-  SuperDetector(const std::string &name)
-  {
-    superdetector = name;
-    Params.set_name(superdetector);
-  }
-  const std::string
-  SuperDetector()
-  {
-    return superdetector;
-  }
 
   void
   Print(const std::string &what = "ALL") const;
 
-  //! load the default parameter to param
-  void
-  SetDefaultParameters(PHG4Parameters * param);
-
-  //! Get the parameters for readonly
-  const PHG4Parameters &
-  GetParameters() const
-  {
-    return Params;
-  }
-
-  //! Get the parameters for update. Useful fields are listed in SetDefaultParameters();
-  PHG4Parameters &
-  GetParameters()
-  {
-    return Params;
-  }
-
-  //! Overwrite the parameter. Useful fields are listed in SetDefaultParameters();
-  void
-  SetParameters(const PHG4Parameters & geom)
-  {
-    Params = geom;
-  }
-
-  //! use database?
-  void
-  UseDB(const bool b = true)
-  {
-    useDB = b;
-  }
-
 private:
+  //! load the default parameter to param
+  void SetDefaultParameters();
+
 
   //! detector geometry
-  /*! defives from PHG4Detector */
+  /*! derives from PHG4Detector */
   PHG4SpacalPrototypeDetector* detector_;
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
-  PHG4SpacalPrototypeSteppingAction* steppingAction_;
+  PHG4SteppingAction* steppingAction_;
   PHG4EventAction *eventAction_;
-
-  int active;
-  int absorberactive;
-  std::string detector_type;
-  std::string superdetector;
-
-  int useDB;
-  PHG4Parameters Params;
 };
 
 #endif


### PR DESCRIPTION
The tracker needs parameters on a layer by layer basis. Previously this was done by giving each layer its own parameter class instance leading to a large number of nodes (also DB table and/or calibration files). This pull request introduces a container where multiple parameter instances can be handled as a single entity. Those parameters do not have to describe the same detector type, it is possible to merge e.g. a tilted plate hcal with a surrounding cylinder for the electronics into one calibration object. The previous standalone parameter class is still available (for e.g. single layer cylinders).
Since this change only deals with the handling of parameters but not their value, it doesn't change the simulations results (which was verified). This only affects subsystems inheriting from PHG4DetectorSubsystem which handles the parameters (and parameter containers) in a general way.
One peculiarity I came across is how root deals with saving objects to xml files. One has to set the precision for float/doubles by hand (the default gives float precision which is not good enough for our double parameters). It currently uses %.15e to write out the parameters which seems to give the most accurate description when looking at the resulting xml file. The xml file which is used by the prototype spacal was written with %.18e to be compatible with the existing one. The readback results in differences in the sims - basically DO NOT USE ROOT PRODUCED XML calibration files for serious endeavours.  