### PR TITLE
add forward rapidity test setup to hcal prototypes

### DIFF
--- a/offline/packages/Prototype2/CaloCalibration.C
+++ b/offline/packages/Prototype2/CaloCalibration.C
@@ -1,19 +1,18 @@
 #include "CaloCalibration.h"
-
+#include "PROTOTYPE2_FEM.h"
 #include "RawTower_Prototype2.h"
+
 #include <g4cemc/RawTowerContainer.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/phool.h>
 #include <phool/getClass.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include "PROTOTYPE2_FEM.h"
 #include <iostream>
 #include <TString.h>
 #include <cmath>
 #include <string>
 #include <cassert>
 #include <cfloat>
-#include "PROTOTYPE2_FEM.h"
 
 using namespace std;
 

--- a/offline/packages/Prototype2/CaloUnpackPRDF.C
+++ b/offline/packages/Prototype2/CaloUnpackPRDF.C
@@ -1,19 +1,20 @@
+#include "RawTower_Prototype2.h"
+#include "PROTOTYPE2_FEM.h"
+#include "CaloUnpackPRDF.h"
+
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
 #include <Event/packetConstants.h>
 #include <Event/packet.h>
 #include <Event/packet_hbd_fpgashort.h>
-#include "RawTower_Prototype2.h"
 #include <g4cemc/RawTowerContainer.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/phool.h>
 #include <phool/getClass.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include "PROTOTYPE2_FEM.h"
 #include <iostream>
 #include <string>
 #include <cassert>
-#include "CaloUnpackPRDF.h"
 
 using namespace std;
 

--- a/offline/packages/Prototype2/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype2/GenericUnpackPRDF.C
@@ -1,19 +1,20 @@
+#include "RawTower_Prototype2.h"
+#include "PROTOTYPE2_FEM.h"
+#include "GenericUnpackPRDF.h"
+
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
 #include <Event/packetConstants.h>
 #include <Event/packet.h>
 #include <Event/packet_hbd_fpgashort.h>
-#include "RawTower_Prototype2.h"
 #include <g4cemc/RawTowerContainer.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/phool.h>
 #include <phool/getClass.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include "PROTOTYPE2_FEM.h"
 #include <iostream>
 #include <string>
 #include <cassert>
-#include "GenericUnpackPRDF.h"
 
 using namespace std;
 

--- a/offline/packages/Prototype2/Prototype2DSTReader.h
+++ b/offline/packages/Prototype2/Prototype2DSTReader.h
@@ -11,6 +11,9 @@
 #ifndef Prototype2DSTReader_H_
 #define Prototype2DSTReader_H_
 
+#include "RawTower_Prototype2.h"
+#include "RawTower_Temperature.h"
+
 #include <HepMC/GenEvent.h>
 #include <HepMC/SimpleVector.h>
 #include <fun4all/SubsysReco.h>
@@ -18,8 +21,6 @@
 #include <iostream>
 #include <vector>
 #include <TClonesArray.h>
-#include "RawTower_Prototype2.h"
-#include "RawTower_Temperature.h"
 
 class TTree;
 

--- a/offline/packages/Prototype2/RunInfoUnpackPRDF.C
+++ b/offline/packages/Prototype2/RunInfoUnpackPRDF.C
@@ -1,18 +1,19 @@
 #include "RunInfoUnpackPRDF.h"
+#include "RawTower_Prototype2.h"
+#include "PROTOTYPE2_FEM.h"
 
 #include <ffaobjects/EventHeaderv1.h>
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
 #include <Event/packetConstants.h>
 #include <Event/packet.h>
-#include "RawTower_Prototype2.h"
 #include <pdbcalbase/PdbParameterMap.h>
 #include <g4detectors/PHG4Parameters.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/phool.h>
 #include <phool/getClass.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include "PROTOTYPE2_FEM.h"
+
 #include <iostream>
 #include <string>
 #include <cassert>

--- a/offline/packages/Prototype2/TempInfoUnpackPRDF.C
+++ b/offline/packages/Prototype2/TempInfoUnpackPRDF.C
@@ -1,20 +1,21 @@
+#include "RawTower_Temperature.h"
+#include "PROTOTYPE2_FEM.h"
+#include "TempInfoUnpackPRDF.h"
+
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
 #include <Event/packetConstants.h>
 #include <Event/packet.h>
 #include <g4cemc/RawTowerContainer.h>
-#include "RawTower_Temperature.h"
 #include <pdbcalbase/PdbParameterMap.h>
 #include <g4detectors/PHG4Parameters.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/phool.h>
 #include <phool/getClass.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include "PROTOTYPE2_FEM.h"
 #include <iostream>
 #include <string>
 #include <cassert>
-#include "TempInfoUnpackPRDF.h"
 
 using namespace std;
 

--- a/offline/packages/Prototype2/TempInfoUnpackPRDF.h
+++ b/offline/packages/Prototype2/TempInfoUnpackPRDF.h
@@ -16,7 +16,7 @@ class TempInfoUnpackPRDF : public SubsysReco
 {
 public:
   TempInfoUnpackPRDF();
-  ~TempInfoUnpackPRDF() {};
+  virtual ~TempInfoUnpackPRDF() {};
 
   int
   Init(PHCompositeNode *topNode);

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -40,11 +40,13 @@ PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNod
   steel_plate_corner_upper_right(1308.5*mm,-286.96*mm), 
   steel_plate_corner_lower_right(1298.8*mm,-297.39*mm),
   steel_plate_corner_lower_left(1155.8*mm,-163.92*mm),
+
   scinti_u1_front_size(105.9*mm),
   scinti_u1_corner_upper_left(0*mm,0*mm),
   scinti_u1_corner_upper_right(198.1*mm,0*mm),
   scinti_u1_corner_lower_right(198.1*mm,-121.3*mm),
   scinti_u1_corner_lower_left(0*mm,-scinti_u1_front_size),
+
   scinti_u2_corner_upper_left(0*mm,0*mm),
   scinti_u2_corner_upper_right(198.1*mm,-15.4*mm),
   scinti_u2_corner_lower_right(198.1*mm,-141.5*mm),
@@ -92,8 +94,7 @@ PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNod
   n_steel_plates(n_scinti_plates+1),
   active(params->get_int_param("active")),
   absorberactive(params->get_int_param("absorberactive")),
-  layer(0),
-  scintilogicnameprefix("InnerHcalScintiMother")
+  layer(0)
 {
   cout << "upper left: " << scinti_t9_corner_upper_left << endl;
   cout << "upper right: " << scinti_t9_corner_upper_right << endl;
@@ -249,10 +250,6 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
   Rot->rotateX(-90*deg);
   new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-scinti_u1_front_size-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,"InnerScinti_0", scintiboxlogical, false, 0, overlapcheck);
 
-    DisplayVolume(scintiboxlogical,hcalenvelope);
-    return scintiboxlogical;
-
-
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
   new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-gap_between_tiles/2.),scintiu1_logic,"InnerScinti_1", scintiboxlogical, false, 0, overlapcheck);
@@ -284,7 +281,7 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTileU1(G4LogicalVolume* hcalenve
 					    zero, 1.0);
 
   G4LogicalVolume *scintiu1_logic = new G4LogicalVolume(scintiu1,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiU1", NULL, NULL, NULL);
-     DisplayVolume(scintiu1,hcalenvelope);
+  //     DisplayVolume(scintiu1,hcalenvelope);
   return scintiu1_logic;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -49,18 +49,42 @@ PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNod
   scinti_u2_corner_upper_right(198.1*mm,-15.4*mm),
   scinti_u2_corner_lower_right(198.1*mm,-141.5*mm),
   scinti_u2_corner_lower_left(0*mm,-110.59*mm),
-  inner_radius(1830*mm),
-  outer_radius(2685*mm),
+
+  scinti_t9_distance_to_corner(26.44*mm),
+  scinti_t9_front_size(140.3*mm),
+  scinti_t9_corner_upper_left(0*mm,0*mm),
+  scinti_t9_corner_upper_right(198.1*mm,-134.4*mm),
+  scinti_t9_corner_lower_right(198.1*mm,-198.1*mm/tan(52.02/180.*M_PI)-scinti_t9_front_size),
+  scinti_t9_corner_lower_left(0*mm,-scinti_t9_front_size),
+
+  scinti_t10_front_size(149.2*mm),
+  scinti_t10_corner_upper_left(0*mm,0*mm),
+  scinti_t10_corner_upper_right(198.1*mm,-154.6*mm),
+  scinti_t10_corner_lower_right(198.1*mm,-198.1*mm/tan(48.34/180.*M_PI)-scinti_t10_front_size),
+  scinti_t10_corner_lower_left(0*mm,-scinti_t10_front_size),
+
+
+  scinti_t11_front_size(144.3*mm),
+  scinti_t11_corner_upper_left(0*mm,0*mm),
+  scinti_t11_corner_upper_right(198.1*mm,-176.2*mm),
+  scinti_t11_corner_lower_right(198.1*mm,-198.1*mm/tan(45.14/180.*M_PI)-scinti_t11_front_size),
+  scinti_t11_corner_lower_left(0*mm,-scinti_t11_front_size),
+
+  scinti_t12_front_size(186.6*mm),
+  scinti_t12_corner_upper_left(0*mm,0*mm),
+  scinti_t12_corner_upper_right(198.1*mm,-197.11*mm),
+  scinti_t12_corner_lower_right(198.1*mm,-198.1*mm/tan(41.47/180.*M_PI)-scinti_t12_front_size),
+  scinti_t12_corner_lower_left(0*mm,-scinti_t12_front_size),
+
   scinti_x(198.1),
   steel_x(823.*mm),
   steel_z(901.7*mm),
   size_z(steel_z),
   scinti_tile_z(steel_z),
   scinti_tile_thickness(7*mm),
-  scinti_box_smaller(0.02*mm), // blargh - off by 20 microns bc scitni tilt angle, need to revisit at some point
+  scinti_box_smaller(0.02*mm), // blargh - off by 20 microns bc scinti tilt angle, need to revisit at some point
   gap_between_tiles(1*mm),
   scinti_gap(8.5*mm),
-  tilt_angle(-32*deg),
   deltaphi(2*M_PI/320.),
   volume_steel(NAN),
   volume_scintillator(NAN),
@@ -71,6 +95,10 @@ PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNod
   layer(0),
   scintilogicnameprefix("InnerHcalScintiMother")
 {
+  cout << "upper left: " << scinti_t9_corner_upper_left << endl;
+  cout << "upper right: " << scinti_t9_corner_upper_right << endl;
+  cout << "lower right: " << scinti_t9_corner_lower_right << endl;
+  cout << "lower left: " << scinti_t9_corner_lower_left << endl;
 }
 
 //_______________________________________________________________
@@ -138,10 +166,70 @@ PHG4Prototype2InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
 }
 
 G4LogicalVolume*
+PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope)
+{
+  G4VSolid* scintiboxsolid = new G4Box("InnerHcalScintiMother",scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
+  //  DisplayVolume(scintiboxsolid,hcalenvelope);
+
+  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String("InnerHcalScintiMother"), 0, 0, 0);
+  G4VisAttributes* hcalVisAtt = new G4VisAttributes();
+  hcalVisAtt->SetVisibility(true);
+  hcalVisAtt->SetForceSolid(false);
+  hcalVisAtt->SetColour(G4Colour::Magenta());
+  G4LogicalVolume *scintit9_logic = ConstructScintiTile9(hcalenvelope);
+  scintit9_logic->SetVisAttributes(hcalVisAtt);
+
+  double distance_to_corner = -size_z/2.+scinti_t9_distance_to_corner;
+  G4RotationMatrix *Rot;  
+  Rot = new G4RotationMatrix();  
+  Rot->rotateX(90*deg);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit9_logic,"InnerScinti_9", scintiboxlogical, false, 0, overlapcheck);
+
+  hcalVisAtt = new G4VisAttributes();
+  hcalVisAtt->SetVisibility(true);
+  hcalVisAtt->SetForceSolid(false);
+  hcalVisAtt->SetColour(G4Colour::Blue());
+  G4LogicalVolume *scintit10_logic = ConstructScintiTile10(hcalenvelope);
+  scintit10_logic->SetVisAttributes(hcalVisAtt);
+
+  distance_to_corner += scinti_t9_front_size + gap_between_tiles;
+  Rot = new G4RotationMatrix();  
+  Rot->rotateX(90*deg);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit10_logic,"InnerScinti_0", scintiboxlogical, false, 0, overlapcheck);
+
+  hcalVisAtt = new G4VisAttributes();
+  hcalVisAtt->SetVisibility(true);
+  hcalVisAtt->SetForceSolid(false);
+  hcalVisAtt->SetColour(G4Colour::Yellow());
+  G4LogicalVolume *scintit11_logic = ConstructScintiTile11(hcalenvelope);
+  scintit11_logic->SetVisAttributes(hcalVisAtt);
+
+  distance_to_corner += scinti_t10_front_size + gap_between_tiles;
+  Rot = new G4RotationMatrix();  
+  Rot->rotateX(90*deg);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit11_logic,"InnerScinti_0", scintiboxlogical, false, 0, overlapcheck);
+
+  hcalVisAtt = new G4VisAttributes();
+  hcalVisAtt->SetVisibility(true);
+  hcalVisAtt->SetForceSolid(false);
+  hcalVisAtt->SetColour(G4Colour::Cyan());
+  G4LogicalVolume *scintit12_logic = ConstructScintiTile12(hcalenvelope);
+  scintit12_logic->SetVisAttributes(hcalVisAtt);
+
+  distance_to_corner += scinti_t11_front_size + gap_between_tiles;
+  Rot = new G4RotationMatrix();  
+  Rot->rotateX(90*deg);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit12_logic,"InnerScinti_0", scintiboxlogical, false, 0, overlapcheck);
+
+    DisplayVolume(scintiboxlogical,hcalenvelope);
+  return scintiboxlogical;
+}
+
+G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
 { 
   G4VSolid* scintiboxsolid = new G4Box("InnerHcalScintiMother",scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
-  //  DisplayVolume(scintiboxsolid,hcalenvelope);
+  //    DisplayVolume(scintiboxsolid,hcalenvelope);
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String("InnerHcalScintiMother"), 0, 0, 0);
   G4VisAttributes* hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -161,6 +249,10 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
   Rot->rotateX(-90*deg);
   new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-scinti_u1_front_size-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,"InnerScinti_0", scintiboxlogical, false, 0, overlapcheck);
 
+    DisplayVolume(scintiboxlogical,hcalenvelope);
+    return scintiboxlogical;
+
+
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
   new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-gap_between_tiles/2.),scintiu1_logic,"InnerScinti_1", scintiboxlogical, false, 0, overlapcheck);
@@ -172,8 +264,7 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
   new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,scinti_u1_front_size+gap_between_tiles/2.+gap_between_tiles),scintiu2_logic,"InnerScinti_3", scintiboxlogical, false, 0, overlapcheck);
-
-
+  //  DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
 }
 
@@ -193,7 +284,7 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTileU1(G4LogicalVolume* hcalenve
 					    zero, 1.0);
 
   G4LogicalVolume *scintiu1_logic = new G4LogicalVolume(scintiu1,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiU1", NULL, NULL, NULL);
-  //   DisplayVolume(scintiu1,hcalenvelope);
+     DisplayVolume(scintiu1,hcalenvelope);
   return scintiu1_logic;
 }
 
@@ -217,6 +308,86 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenve
   return scintiu2_logic;
 }
 
+G4LogicalVolume*
+PHG4Prototype2InnerHcalDetector::ConstructScintiTile9(G4LogicalVolume* hcalenvelope)
+{
+  std::vector<G4TwoVector> vertexes;
+  vertexes.push_back(scinti_t9_corner_upper_left);
+  vertexes.push_back(scinti_t9_corner_upper_right);
+  vertexes.push_back(scinti_t9_corner_lower_right);
+  vertexes.push_back(scinti_t9_corner_lower_left);
+  G4TwoVector zero(0, 0);
+  G4VSolid *scintit9 =  new G4ExtrudedSolid("InnerHcalScintiT9",
+					    vertexes,
+					    scinti_tile_thickness  / 2.0,
+					    zero, 1.0,
+					    zero, 1.0);
+
+  G4LogicalVolume *scintit9_logic = new G4LogicalVolume(scintit9,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT9", NULL, NULL, NULL);
+  //     DisplayVolume(scintit9,hcalenvelope);
+  return scintit9_logic;
+}
+
+G4LogicalVolume*
+PHG4Prototype2InnerHcalDetector::ConstructScintiTile10(G4LogicalVolume* hcalenvelope)
+{
+  std::vector<G4TwoVector> vertexes;
+  vertexes.push_back(scinti_t10_corner_upper_left);
+  vertexes.push_back(scinti_t10_corner_upper_right);
+  vertexes.push_back(scinti_t10_corner_lower_right);
+  vertexes.push_back(scinti_t10_corner_lower_left);
+  G4TwoVector zero(0, 0);
+  G4VSolid *scintit10 =  new G4ExtrudedSolid("InnerHcalScintiT10",
+					    vertexes,
+					    scinti_tile_thickness  / 2.0,
+					    zero, 1.0,
+					    zero, 1.0);
+
+  G4LogicalVolume *scintit10_logic = new G4LogicalVolume(scintit10,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT10", NULL, NULL, NULL);
+  //     DisplayVolume(scintit10,hcalenvelope);
+  return scintit10_logic;
+}
+
+G4LogicalVolume*
+PHG4Prototype2InnerHcalDetector::ConstructScintiTile11(G4LogicalVolume* hcalenvelope)
+{
+  std::vector<G4TwoVector> vertexes;
+  vertexes.push_back(scinti_t11_corner_upper_left);
+  vertexes.push_back(scinti_t11_corner_upper_right);
+  vertexes.push_back(scinti_t11_corner_lower_right);
+  vertexes.push_back(scinti_t11_corner_lower_left);
+  G4TwoVector zero(0, 0);
+  G4VSolid *scintit11 =  new G4ExtrudedSolid("InnerHcalScintiT11",
+					    vertexes,
+					    scinti_tile_thickness  / 2.0,
+					    zero, 1.0,
+					    zero, 1.0);
+
+  G4LogicalVolume *scintit11_logic = new G4LogicalVolume(scintit11,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT11", NULL, NULL, NULL);
+  //     DisplayVolume(scintit11,hcalenvelope);
+  return scintit11_logic;
+}
+
+G4LogicalVolume*
+PHG4Prototype2InnerHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenvelope)
+{
+  std::vector<G4TwoVector> vertexes;
+  vertexes.push_back(scinti_t12_corner_upper_left);
+  vertexes.push_back(scinti_t12_corner_upper_right);
+  vertexes.push_back(scinti_t12_corner_lower_right);
+  vertexes.push_back(scinti_t12_corner_lower_left);
+  G4TwoVector zero(0, 0);
+  G4VSolid *scintit12 =  new G4ExtrudedSolid("InnerHcalScintiT12",
+					    vertexes,
+					    scinti_tile_thickness  / 2.0,
+					    zero, 1.0,
+					    zero, 1.0);
+
+  G4LogicalVolume *scintit12_logic = new G4LogicalVolume(scintit12,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT12", NULL, NULL, NULL);
+  //     DisplayVolume(scintit12,hcalenvelope);
+  return scintit12_logic;
+}
+
 // Construct the envelope and the call the
 // actual inner hcal construction
 void
@@ -227,6 +398,10 @@ PHG4Prototype2InnerHcalDetector::Construct( G4LogicalVolume* logicWorld )
   Rot->rotateX(params->get_double_param("rot_x")*deg);
   Rot->rotateY(params->get_double_param("rot_y")*deg);
   Rot->rotateZ(params->get_double_param("rot_z")*deg);
+  //  ConstructScintiTile9(logicWorld);
+    ConstructScintillatorBoxHiEta(logicWorld);
+  //ConstructScintillatorBox(logicWorld);
+  return;
   innerhcalassembly = new G4AssemblyVolume();
   //ConstructSteelPlate(hcal_envelope_log);
   // return;
@@ -263,11 +438,6 @@ PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelop
 	{
 	  double ypos = sin(phi+philow) * middlerad;
 	  double xpos = cos(phi+philow) * middlerad;
-	  // the center of the scintillator is not the center of the inner hcal
-	  // but depends on the tilt angle. Therefore we need to shift
-	  // the center from the mid point
-	  // ypos += sin((-tilt_angle)/rad - phi)*scinti_box_shift;
-	  // xpos -= cos((-tilt_angle)/rad - phi)*scinti_box_shift;
 	  name.str("");
 	  name << "InnerHcalScintiBox_" << i;
 	  Rot = new G4RotationMatrix();
@@ -297,6 +467,47 @@ PHG4Prototype2InnerHcalDetector::DisplayVolume(G4VSolid *volume,  G4LogicalVolum
 {
   static int i = 0;
   G4LogicalVolume* checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), "DISPLAYLOGICAL", 0, 0, 0);
+  G4VisAttributes* visattchk = new G4VisAttributes();
+  visattchk->SetVisibility(true);
+  visattchk->SetForceSolid(false);
+  switch(i)
+    {
+    case 0:
+      visattchk->SetColour(G4Colour::Red());
+      i++;
+      break;
+    case 1:
+      visattchk->SetColour(G4Colour::Magenta());
+      i++;
+      break;
+    case 2:
+      visattchk->SetColour(G4Colour::Yellow());
+      i++;
+      break;
+    case 3:
+      visattchk->SetColour(G4Colour::Blue());
+      i++;
+      break;
+    case 4:
+      visattchk->SetColour(G4Colour::Cyan());
+      i++;
+      break;
+    default:
+      visattchk->SetColour(G4Colour::Green());
+      i = 0;
+      break;
+    }
+
+  checksolid->SetVisAttributes(visattchk);
+  new G4PVPlacement(rotm, G4ThreeVector(0, 0, 0), checksolid, "DISPLAYVOL", logvol, 0, false, overlapcheck);
+  //  new G4PVPlacement(rotm, G4ThreeVector(0, -460.3, 0), checksolid, "DISPLAYVOL", logvol, 0, false, overlapcheck);
+  return 0;
+}
+
+int
+PHG4Prototype2InnerHcalDetector::DisplayVolume(G4LogicalVolume *checksolid,  G4LogicalVolume* logvol, G4RotationMatrix *rotm )
+{
+  static int i = 0;
   G4VisAttributes* visattchk = new G4VisAttributes();
   visattchk->SetVisibility(true);
   visattchk->SetForceSolid(false);

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -95,12 +95,7 @@ PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNod
   active(params->get_int_param("active")),
   absorberactive(params->get_int_param("absorberactive")),
   layer(0)
-{
-  cout << "upper left: " << scinti_t9_corner_upper_left << endl;
-  cout << "upper right: " << scinti_t9_corner_upper_right << endl;
-  cout << "lower right: " << scinti_t9_corner_lower_right << endl;
-  cout << "lower left: " << scinti_t9_corner_lower_left << endl;
-}
+{}
 
 //_______________________________________________________________
 //_______________________________________________________________
@@ -470,42 +465,8 @@ PHG4Prototype2InnerHcalDetector::GetScintiAngle()
 int
 PHG4Prototype2InnerHcalDetector::DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix *rotm )
 {
-  static int i = 0;
   G4LogicalVolume* checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), "DISPLAYLOGICAL", 0, 0, 0);
-  G4VisAttributes* visattchk = new G4VisAttributes();
-  visattchk->SetVisibility(true);
-  visattchk->SetForceSolid(false);
-  switch(i)
-    {
-    case 0:
-      visattchk->SetColour(G4Colour::Red());
-      i++;
-      break;
-    case 1:
-      visattchk->SetColour(G4Colour::Magenta());
-      i++;
-      break;
-    case 2:
-      visattchk->SetColour(G4Colour::Yellow());
-      i++;
-      break;
-    case 3:
-      visattchk->SetColour(G4Colour::Blue());
-      i++;
-      break;
-    case 4:
-      visattchk->SetColour(G4Colour::Cyan());
-      i++;
-      break;
-    default:
-      visattchk->SetColour(G4Colour::Green());
-      i = 0;
-      break;
-    }
-
-  checksolid->SetVisAttributes(visattchk);
-  new G4PVPlacement(rotm, G4ThreeVector(0, 0, 0), checksolid, "DISPLAYVOL", logvol, 0, false, overlapcheck);
-  //  new G4PVPlacement(rotm, G4ThreeVector(0, -460.3, 0), checksolid, "DISPLAYVOL", logvol, 0, false, overlapcheck);
+  DisplayVolume(checksolid, logvol, rotm);
   return 0;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -79,7 +79,6 @@ PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNod
   scinti_t12_corner_lower_left(0*mm,-scinti_t12_front_size),
 
   scinti_x(198.1),
-  steel_x(823.*mm),
   steel_z(901.7*mm),
   size_z(steel_z),
   scinti_tile_z(steel_z),
@@ -385,7 +384,9 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
 void
 PHG4Prototype2InnerHcalDetector::Construct( G4LogicalVolume* logicWorld )
 {
-  G4ThreeVector g4vec(0,0,0);
+  G4ThreeVector g4vec(params->get_double_param("place_x")*cm,
+                      params->get_double_param("place_y")*cm,
+		      params->get_double_param("place_z")*cm);
   G4RotationMatrix *Rot = new G4RotationMatrix();
   Rot->rotateX(params->get_double_param("rot_x")*deg);
   Rot->rotateY(params->get_double_param("rot_y")*deg);

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -195,7 +195,7 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   distance_to_corner += scinti_t9_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit10_logic,"InnerScinti_0", scintiboxlogical, false, 0, overlapcheck);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit10_logic,"InnerScinti_10", scintiboxlogical, false, 0, overlapcheck);
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -207,7 +207,7 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   distance_to_corner += scinti_t10_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit11_logic,"InnerScinti_0", scintiboxlogical, false, 0, overlapcheck);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit11_logic,"InnerScinti_11", scintiboxlogical, false, 0, overlapcheck);
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -219,9 +219,9 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   distance_to_corner += scinti_t11_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit12_logic,"InnerScinti_0", scintiboxlogical, false, 0, overlapcheck);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit12_logic,"InnerScinti_12", scintiboxlogical, false, 0, overlapcheck);
 
-    DisplayVolume(scintiboxlogical,hcalenvelope);
+  //    DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
 }
 
@@ -399,9 +399,9 @@ PHG4Prototype2InnerHcalDetector::Construct( G4LogicalVolume* logicWorld )
   Rot->rotateY(params->get_double_param("rot_y")*deg);
   Rot->rotateZ(params->get_double_param("rot_z")*deg);
   //  ConstructScintiTile9(logicWorld);
-    ConstructScintillatorBoxHiEta(logicWorld);
+  //    ConstructScintillatorBoxHiEta(logicWorld);
   //ConstructScintillatorBox(logicWorld);
-  return;
+  //  return;
   innerhcalassembly = new G4AssemblyVolume();
   //ConstructSteelPlate(hcal_envelope_log);
   // return;
@@ -414,7 +414,15 @@ int
 PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelope)
 {
   G4LogicalVolume* steel_plate = ConstructSteelPlate(hcalenvelope); // bottom steel plate
-  G4LogicalVolume* scintibox = ConstructScintillatorBox(hcalenvelope);
+  G4LogicalVolume* scintibox = NULL;
+  if (params->get_int_param("hi_eta"))
+    {
+      scintibox = ConstructScintillatorBoxHiEta(hcalenvelope);
+    }
+  else
+    {
+      scintibox = ConstructScintillatorBox(hcalenvelope);
+    }
   double phi = 0.;
   double phislat = 0.;
   ostringstream name;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
@@ -125,7 +125,6 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   int layer;
   std::string detector_type;
   std::string superdetector;
-  std::string scintilogicnameprefix;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
@@ -104,7 +104,6 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   G4TwoVector scinti_t12_corner_lower_left;
 
   double scinti_x;
-  double steel_x;
   double steel_z;
   double size_z;
   double scinti_tile_z;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
@@ -47,13 +47,19 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
 
   G4LogicalVolume* ConstructSteelPlate(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintillatorBox(G4LogicalVolume* hcalenvelope);
+  G4LogicalVolume* ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintiTileU1(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintiTileU2(G4LogicalVolume* hcalenvelope);
+  G4LogicalVolume* ConstructScintiTile9(G4LogicalVolume* hcalenvelope);
+  G4LogicalVolume* ConstructScintiTile10(G4LogicalVolume* hcalenvelope);
+  G4LogicalVolume* ConstructScintiTile11(G4LogicalVolume* hcalenvelope);
+  G4LogicalVolume* ConstructScintiTile12(G4LogicalVolume* hcalenvelope);
   double GetScintiAngle();
 
   protected:
   int ConstructInnerHcal(G4LogicalVolume* sandwich);
   int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
+  int DisplayVolume(G4LogicalVolume *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
   PHG4Parameters *params;
   G4LogicalVolume *innerhcalsteelplate;
   G4AssemblyVolume *innerhcalassembly;
@@ -66,12 +72,37 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   G4TwoVector scinti_u1_corner_upper_right;
   G4TwoVector scinti_u1_corner_lower_right;
   G4TwoVector scinti_u1_corner_lower_left;
+
   G4TwoVector scinti_u2_corner_upper_left;
   G4TwoVector scinti_u2_corner_upper_right;
   G4TwoVector scinti_u2_corner_lower_right;
   G4TwoVector scinti_u2_corner_lower_left;
-  double inner_radius;
-  double outer_radius;
+
+  double scinti_t9_distance_to_corner;
+  double scinti_t9_front_size;
+  G4TwoVector scinti_t9_corner_upper_left;
+  G4TwoVector scinti_t9_corner_upper_right;
+  G4TwoVector scinti_t9_corner_lower_right;
+  G4TwoVector scinti_t9_corner_lower_left;
+
+  double scinti_t10_front_size;
+  G4TwoVector scinti_t10_corner_upper_left;
+  G4TwoVector scinti_t10_corner_upper_right;
+  G4TwoVector scinti_t10_corner_lower_right;
+  G4TwoVector scinti_t10_corner_lower_left;
+
+  double scinti_t11_front_size;
+  G4TwoVector scinti_t11_corner_upper_left;
+  G4TwoVector scinti_t11_corner_upper_right;
+  G4TwoVector scinti_t11_corner_lower_right;
+  G4TwoVector scinti_t11_corner_lower_left;
+
+  double scinti_t12_front_size;
+  G4TwoVector scinti_t12_corner_upper_left;
+  G4TwoVector scinti_t12_corner_upper_right;
+  G4TwoVector scinti_t12_corner_lower_right;
+  G4TwoVector scinti_t12_corner_lower_left;
+
   double scinti_x;
   double steel_x;
   double steel_z;
@@ -81,7 +112,6 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   double scinti_box_smaller;
   double gap_between_tiles;
   double scinti_gap;
-  double tilt_angle;
   double deltaphi;
   double volume_steel;
   double volume_scintillator;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -22,118 +22,55 @@ using namespace std;
 
 //_______________________________________________________________________
 PHG4Prototype2InnerHcalSubsystem::PHG4Prototype2InnerHcalSubsystem( const std::string &name, const int lyr ):
-  PHG4Subsystem( name ),
+  PHG4DetectorSubsystem( name, lyr ),
   detector_(NULL),
   steppingAction_( NULL ),
-  eventAction_(NULL),
-  layer(lyr),
-  usedb(0),
-  filetype(PHG4Prototype2InnerHcalSubsystem::none),
-  detector_type(name),
-  superdetector("NONE"),
-  calibfiledir("./")
+  eventAction_(NULL)
 {
-
-  // put the layer into the name so we get unique names
-  // for multiple layers
-  ostringstream nam;
-  nam << name << "_" << lyr;
-  Name(nam.str().c_str());
-  params = new PHG4Parameters(Name()); // temporary name till the init is called
-  SetDefaultParameters();
-}
-
-void
-PHG4Prototype2InnerHcalSubsystem::SuperDetector(const std::string &name)
-{
-  superdetector = name;
-  Name(name);
-  return;
-}
-
-int 
-PHG4Prototype2InnerHcalSubsystem::Init(PHCompositeNode* topNode)
-{
-  params->set_name(superdetector);
-  return 0;
+  InitializeParameters();
 }
 
 //_______________________________________________________________________
 int 
-PHG4Prototype2InnerHcalSubsystem::InitRun( PHCompositeNode* topNode )
+PHG4Prototype2InnerHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 {
   PHNodeIterator iter( topNode );
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
 
-  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN" ));
-  string g4geonodename = "G4GEO_" + superdetector;
-  parNode->addNode(new PHDataNode<PHG4Parameters>(params,g4geonodename));
-
-
-  string paramnodename = "G4GEOPARAM_" + superdetector;
-  // ASSUMPTION: if we read from DB and/or file we don't want the stuff from
-  // the node tree
-  // We leave the defaults intact in case there is no entry for
-  // those in the object read from the DB or file
-  // Order: read first DB, then calib file if both are enabled
-  if (usedb || filetype != PHG4Prototype2InnerHcalSubsystem::none)
-    {
-      if (usedb)
-	{
-          ReadParamsFromDB();
-	}
-      if (filetype != PHG4Prototype2InnerHcalSubsystem::none)
-	{
-	  ReadParamsFromFile(filetype);
-	}
-    }
-  else
-    {
-      PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,paramnodename);
-      if (nodeparams)
-	{
-	  params->FillFrom(nodeparams, layer);
-	}
-    }
-  // parameters set in the macro always override whatever is read from
-  // the node tree, DB or file
-  UpdateParametersWithMacro();
-  // save updated persistant copy on node tree
-  params->SaveToNodeTree(parNode,paramnodename, layer);
   // create detector
-  detector_ = new PHG4Prototype2InnerHcalDetector(topNode, params, Name());
-  detector_->SuperDetector(superdetector);
-  detector_->OverlapCheck(overlapcheck);
+  detector_ = new PHG4Prototype2InnerHcalDetector(topNode, GetParams(), Name());
+  detector_->SuperDetector(SuperDetector());
+  detector_->OverlapCheck(CheckOverlap());
   set<string> nodes;
-  if (params->get_int_param("active"))
+  if (GetParams()->get_int_param("active"))
     {
-      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",superdetector));
+      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",SuperDetector()));
       if (! DetNode)
 	{
-          DetNode = new PHCompositeNode(superdetector);
+          DetNode = new PHCompositeNode(SuperDetector());
           dstNode->addNode(DetNode);
         }
 
       ostringstream nodename;
-      if (superdetector != "NONE")
+      if (SuperDetector() != "NONE")
 	{
-	  nodename <<  "G4HIT_" << superdetector;
+	  nodename <<  "G4HIT_" << SuperDetector();
 	}
       else
 	{
-	  nodename <<  "G4HIT_" << detector_type << "_" << layer;
+	  nodename <<  "G4HIT_" <<  Name();
 	}
       nodes.insert(nodename.str());
-      if (params->get_int_param("absorberactive"))
+      if (GetParams()->get_int_param("absorberactive"))
 	{
 	  nodename.str("");
-	  if (superdetector != "NONE")
+	  if (SuperDetector() != "NONE")
 	    {
-	      nodename <<  "G4HIT_ABSORBER_" << superdetector;
+	      nodename <<  "G4HIT_ABSORBER_" << SuperDetector();
 	    }
 	  else
 	    {
-	      nodename <<  "G4HIT_ABSORBER_" << detector_type << "_" << layer;
+	      nodename <<  "G4HIT_ABSORBER_" <<  Name();
 	    }
           nodes.insert(nodename.str());
 	}
@@ -158,15 +95,15 @@ PHG4Prototype2InnerHcalSubsystem::InitRun( PHCompositeNode* topNode )
 	}
 
       // create stepping action
-      steppingAction_ = new PHG4Prototype2InnerHcalSteppingAction(detector_, params);
+      steppingAction_ = new PHG4Prototype2InnerHcalSteppingAction(detector_, GetParams());
 
     }
   else
     {
       // if this is a black hole it does not have to be active
-      if (params->get_int_param("blackhole"))
+      if (GetParams()->get_int_param("blackhole"))
 	{
-	  steppingAction_ = new PHG4Prototype2InnerHcalSteppingAction(detector_, params);
+	  steppingAction_ = new PHG4Prototype2InnerHcalSteppingAction(detector_, GetParams());
 	}
     }
   return 0;
@@ -191,7 +128,7 @@ void
 PHG4Prototype2InnerHcalSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
-  params->Print();
+  GetParams()->Print();
   if (detector_)
     {
       detector_->Print(what);
@@ -205,247 +142,34 @@ PHG4Detector* PHG4Prototype2InnerHcalSubsystem::GetDetector( void ) const
   return detector_;
 }
 
-//_______________________________________________________________________
-PHG4SteppingAction* PHG4Prototype2InnerHcalSubsystem::GetSteppingAction( void ) const
-{
-  return steppingAction_;
-}
-
-void
-PHG4Prototype2InnerHcalSubsystem::SetActive(const int i)
-{
-  iparams["active"] = i;
-}
-
-void
-PHG4Prototype2InnerHcalSubsystem::SetAbsorberActive(const int i)
-{
-  iparams["absorberactive"] = i;
-}
-
-void
-PHG4Prototype2InnerHcalSubsystem::BlackHole(const int i)
-{
-  iparams["blackhole"] = i;
-}
-
-void
-PHG4Prototype2InnerHcalSubsystem::set_double_param(const std::string &name, const double dval)
-{
-  if (default_double.find(name) == default_double.end())
-    {
-      cout << "double parameter " << name << " not implemented" << endl;
-      cout << "implemented double parameters are:" << endl;
-      for (map<const string, double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
-	{
-	  cout << iter->first << endl;
-	}
-      return;
-    }
-  dparams[name] = dval;
-}
-
-void
-PHG4Prototype2InnerHcalSubsystem::set_int_param(const std::string &name, const int ival)
-{
-  if (default_int.find(name) == default_int.end())
-    {
-      cout << "integer parameter " << name << " not implemented" << endl;
-      cout << "implemented integer parameters are:" << endl;
-      for (map<const string, int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
-	{
-	  cout << iter->first << endl;
-	}
-      return;
-    }
-  iparams[name] = ival;
-}
-
-void
-PHG4Prototype2InnerHcalSubsystem::SetAbsorberTruth(const int i)
-{
-  iparams["absorbertruth"] = i;
-}
-
-void
-PHG4Prototype2InnerHcalSubsystem::set_string_param(const std::string &name, const string &sval)
-{
-  if (default_string.find(name) == default_string.end())
-    {
-      cout << "string parameter " << name << " not implemented" << endl;
-      cout << "implemented string parameters are:" << endl;
-      for (map<const string, string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
-	{
-	  cout << iter->first << endl;
-	}
-      return;
-    }
-  cparams[name] = sval;
-}
-
 void
 PHG4Prototype2InnerHcalSubsystem::SetDefaultParameters()
 {
   // all in cm
-  default_double["light_balance_inner_corr"] = NAN;
-  default_double["light_balance_inner_radius"] = NAN;
-  default_double["light_balance_outer_corr"] = NAN;
-  default_double["light_balance_outer_radius"] = NAN;
-  default_double["place_x"] = 0.;
-  default_double["place_y"] = 0.;
-  default_double["place_z"] = 0.;
-  default_double["rot_x"] = 0.;
-  default_double["rot_y"] = 0.;
-  default_double["rot_z"] = 0.;
-  default_double["steplimits"] = NAN;
+  set_default_double_param("light_balance_inner_corr", NAN);
+  set_default_double_param("light_balance_inner_radius", NAN);
+  set_default_double_param("light_balance_outer_corr", NAN);
+  set_default_double_param("light_balance_outer_radius", NAN);
+  set_default_double_param("place_x", 0.);
+  set_default_double_param("place_y", 0.);
+  set_default_double_param("place_z", 0.);
+  set_default_double_param("rot_x", 0.);
+  set_default_double_param("rot_y", 0.);
+  set_default_double_param("rot_z", 0.);
+  set_default_double_param("steplimits", NAN);
 
-  default_int["absorberactive"] = 0;
-  default_int["absorbertruth"] = 1;
-  default_int["active"] = 0;
-  default_int["blackhole"] = 0;
-  default_int["light_scint_model"] = 1;
+  set_default_int_param("light_scint_model", 1);
 
-  default_string["material"] = "SS310";
-  for (map<const string,double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
-    {
-      params->set_double_param(iter->first,iter->second);
-    }
-  for (map<const string,int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
-    {
-      params->set_int_param(iter->first,iter->second);
-    }
-  for (map<const string,string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
-    {
-      params->set_string_param(iter->first,iter->second);
-    }
-
+  set_default_string_param("material", "SS310");
 }
 
-void
-PHG4Prototype2InnerHcalSubsystem::UpdateParametersWithMacro()
-{
-  for (map<const string,double>::const_iterator iter = dparams.begin(); iter != dparams.end(); ++iter)
-    {
-      params->set_double_param(iter->first,iter->second);
-    }
-  for (map<const string,int>::const_iterator iter = iparams.begin(); iter != iparams.end(); ++iter)
-    {
-      params->set_int_param(iter->first,iter->second);
-    }
-  for (map<const string,string>::const_iterator iter = cparams.begin(); iter != cparams.end(); ++iter)
-    {
-      params->set_string_param(iter->first,iter->second);
-    }
-  return;
-}
 
 void
 PHG4Prototype2InnerHcalSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr)
 {
-  dparams["light_balance_inner_corr"] = inner_corr;
-  dparams["light_balance_inner_radius"] = inner_radius;
-  dparams["light_balance_outer_corr"] = outer_corr;
-  dparams["light_balance_outer_radius"] = outer_radius;
+  set_double_param("light_balance_inner_corr", inner_corr);
+  set_double_param("light_balance_inner_radius", inner_radius);
+  set_double_param("light_balance_outer_corr", outer_corr);
+  set_double_param("light_balance_outer_radius", outer_radius);
   return;
 }
-
-int
-PHG4Prototype2InnerHcalSubsystem::SaveParamsToDB()
-{
-  int iret = params->WriteToDB();
-  if (iret)
-    {
-      cout << "problem committing to DB" << endl;
-    }
-  return iret;
-}
-
-int
-PHG4Prototype2InnerHcalSubsystem::ReadParamsFromDB()
-{
-  int iret = params->ReadFromDB(superdetector,layer);
-  if (iret)
-    {
-      cout << "problem reading from DB" << endl;
-    }
-  return iret;
-}
-
-int
-PHG4Prototype2InnerHcalSubsystem::SaveParamsToFile(const PHG4Prototype2InnerHcalSubsystem::FILE_TYPE ftyp)
-{
-  string extension;
-  switch(ftyp)
-    {
-    case xml:
-      extension = "xml";
-      break;
-    case root:
-      extension = "root";
-      break;
-    default:
-      cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
-      exit(1);
-    }
-
-  int iret = params->WriteToFile(extension,calibfiledir);
-  if (iret)
-    {
-      cout << "problem saving to " << extension << " file " << endl;
-    }
-  return iret;
-}
-
-int
-PHG4Prototype2InnerHcalSubsystem::ReadParamsFromFile(const PHG4Prototype2InnerHcalSubsystem::FILE_TYPE ftyp)
-{
-  string extension;
-  switch(ftyp)
-    {
-    case xml:
-      extension = "xml";
-      break;
-    case root:
-      extension = "root";
-      break;
-    default:
-      cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
-      exit(1);
-    }
-  string name;
-  int issuper = 0;
-  if (superdetector != "NONE")
-    {
-      name = superdetector;
-      issuper = 1;
-    }
-  else
-    {
-      name = params->Name();
-    }
-  int iret = params->ReadFromFile(name, extension, layer, issuper, calibfiledir);
-  if (iret)
-    {
-      cout << "problem reading from " << extension << " file " << endl;
-    }
-  return iret;
-}
-
-double
-PHG4Prototype2InnerHcalSubsystem::get_double_param(const std::string &name) const
-{
-  return params->get_double_param(name);
-}
-
-int
-PHG4Prototype2InnerHcalSubsystem::get_int_param(const std::string &name) const
-{
-  return params->get_int_param(name);
-}
-
-string
-PHG4Prototype2InnerHcalSubsystem::get_string_param(const std::string &name) const
-{
-  return params->get_string_param(name);
-}
-

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -6,9 +6,6 @@
 
 #include <g4main/PHG4HitContainer.h>
 
-#include <pdbcalbase/PdbParameterMap.h>
-#include <pdbcalbase/PdbParameterMapContainer.h>
-
 #include <phool/getClass.h>
 
 #include <Geant4/globals.hh>

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -159,6 +159,7 @@ PHG4Prototype2InnerHcalSubsystem::SetDefaultParameters()
   set_default_double_param("steplimits", NAN);
 
   set_default_int_param("light_scint_model", 1);
+  set_default_int_param("hi_eta", 0);
 
   set_default_string_param("material", "SS310");
 }

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.h
@@ -3,24 +3,16 @@
 
 #include "PHG4DetectorSubsystem.h"
 
-#include <Geant4/G4Types.hh>
-#include <Geant4/G4String.hh>
-
-#include <map>
-#include <set>
 #include <string>
 
-class PHG4Prototype2InnerHcalDetector;
-class PHG4Parameters;
-class PHG4Prototype2InnerHcalSteppingAction;
 class PHG4EventAction;
+class PHG4Prototype2InnerHcalDetector;
+class PHG4SteppingAction;
 
 class PHG4Prototype2InnerHcalSubsystem: public PHG4DetectorSubsystem
 {
 
   public:
-
-  enum FILE_TYPE {none = 0, xml = 1, root = 2};
 
   //! constructor
   PHG4Prototype2InnerHcalSubsystem( const std::string &name = "HCALIN", const int layer = 0 );

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.h
@@ -1,7 +1,7 @@
 #ifndef PHG4Prototype2InnerHcalSubsystem_h
 #define PHG4Prototype2InnerHcalSubsystem_h
 
-#include <g4main/PHG4Subsystem.h>
+#include "PHG4DetectorSubsystem.h"
 
 #include <Geant4/G4Types.hh>
 #include <Geant4/G4String.hh>
@@ -15,7 +15,7 @@ class PHG4Parameters;
 class PHG4Prototype2InnerHcalSteppingAction;
 class PHG4EventAction;
 
-class PHG4Prototype2InnerHcalSubsystem: public PHG4Subsystem
+class PHG4Prototype2InnerHcalSubsystem: public PHG4DetectorSubsystem
 {
 
   public:
@@ -29,15 +29,12 @@ class PHG4Prototype2InnerHcalSubsystem: public PHG4Subsystem
   virtual ~PHG4Prototype2InnerHcalSubsystem( void )
   {}
 
-  //! init
-  int Init(PHCompositeNode *);
-
   /*!
   creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRun(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode *);
 
   //! event processing
   /*!
@@ -51,34 +48,14 @@ class PHG4Prototype2InnerHcalSubsystem: public PHG4Subsystem
 
   //! accessors (reimplemented)
   virtual PHG4Detector* GetDetector( void ) const;
-  virtual PHG4SteppingAction* GetSteppingAction( void ) const;
+  virtual PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
 
   PHG4EventAction* GetEventAction() const {return eventAction_;}
-  void SetActive(const int i = 1);
-  void SetAbsorberActive(const int i = 1);
-  void SetAbsorberTruth(const int i = 1);
-  void SuperDetector(const std::string &name);
-  const std::string SuperDetector() {return superdetector;}
 
-  void BlackHole(const int i=1);
   void SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr);
-  void set_double_param(const std::string &name, const double dval);
-  double get_double_param(const std::string &name) const;
-  void set_int_param(const std::string &name, const int ival);
-  int get_int_param(const std::string &name) const;
-  void set_string_param(const std::string &name, const std::string &sval);
-  std::string get_string_param(const std::string &name) const;
-  void SetDefaultParameters();
-  void UpdateParametersWithMacro();
-  void UseDB(const int i = 1) {usedb = i;}
-  void UseCalibFiles(const FILE_TYPE ftyp) {filetype = ftyp;}
-  int SaveParamsToDB();
-  int ReadParamsFromDB();
-  int SaveParamsToFile(const FILE_TYPE ftyp);
-  int ReadParamsFromFile(const FILE_TYPE ftyp);
-  void SetCalibrationFileDir(const std::string &calibdir) {calibfiledir = calibdir;}
-
   protected:
+
+  void SetDefaultParameters();
 
   //! detector geometry
   /*! derives from PHG4Detector */
@@ -86,27 +63,11 @@ class PHG4Prototype2InnerHcalSubsystem: public PHG4Subsystem
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingAction */
-  PHG4Prototype2InnerHcalSteppingAction* steppingAction_;
+  PHG4SteppingAction* steppingAction_;
 
   //! particle tracking "stepping" action
   /*! derives from PHG4EventAction */
   PHG4EventAction *eventAction_;
-
-  PHG4Parameters *params;
-
-  int layer;
-
-  int usedb;
-  FILE_TYPE filetype;
-  std::string detector_type;
-  std::string superdetector;
-  std::string calibfiledir;
-  std::map<const std::string, double> dparams;
-  std::map<const std::string, int> iparams;
-  std::map<const std::string, std::string> cparams;
-  std::map<const std::string, double> default_double;
-  std::map<const std::string, int> default_int;
-  std::map<const std::string, std::string> default_string;
 
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -51,24 +51,51 @@ PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNod
   steel_plate_corner_upper_right(2600.4*mm,-417.4*mm), 
   steel_plate_corner_lower_right(2601.2*mm,-459.8*mm),
   steel_plate_corner_lower_left(1770.9*mm,-459.8*mm),
+
   scinti_u1_front_size(166.2*mm),
   scinti_u1_corner_upper_left(0*mm,0*mm),
   scinti_u1_corner_upper_right(828.9*mm,0*mm),
   scinti_u1_corner_lower_right(828.9*mm,-240.54*mm),
   scinti_u1_corner_lower_left(0*mm,-scinti_u1_front_size),
+
   scinti_u2_corner_upper_left(0*mm,0*mm),
   scinti_u2_corner_upper_right(828.9*mm,-74.3*mm),
   scinti_u2_corner_lower_right(828.9*mm,-320.44*mm),
   scinti_u2_corner_lower_left(0*mm,-171.0*mm),
-  inner_radius(1830*mm),
-  outer_radius(2685*mm),
+
+  scinti_t9_distance_to_corner(0.86*mm),
+  scinti_t9_front_size(241.5*mm),
+  scinti_t9_corner_upper_left(0*mm,0*mm),
+  scinti_t9_corner_upper_right(697.4*mm,-552.2*mm),
+  scinti_t9_corner_lower_right(697.4*mm,-697.4*mm/tan(47.94/180.*M_PI)-scinti_t9_front_size),
+  scinti_t9_corner_lower_left(0*mm,-scinti_t9_front_size),
+
+  scinti_t10_front_size(241.4*mm),
+  scinti_t10_corner_upper_left(0*mm,0*mm),
+  scinti_t10_corner_upper_right(697.4*mm,-629.3*mm),
+  scinti_t10_corner_lower_right(697.4*mm,-697.4*mm/tan(44.2/180.*M_PI)-scinti_t10_front_size),
+  scinti_t10_corner_lower_left(0*mm,-scinti_t10_front_size),
+
+  scinti_t11_front_size(241.4*mm),
+  scinti_t11_corner_upper_left(0*mm,0*mm),
+  scinti_t11_corner_upper_right(697.4*mm,-717.1*mm),
+  scinti_t11_corner_lower_right(697.4*mm,-697.4*mm/tan(42.47/180.*M_PI)-scinti_t11_front_size),
+  scinti_t11_corner_lower_left(0*mm,-scinti_t11_front_size),
+
+  scinti_t12_front_size(312.7*mm),
+  scinti_t12_corner_upper_left(0*mm,0*mm),
+  scinti_t12_corner_upper_right(697.4*mm,-761.8*mm),
+  scinti_t12_corner_lower_right(392.9*mm,-827.7),
+  scinti_t12_corner_lower_left(0*mm,-scinti_t12_front_size),
+
   scinti_x(828.9),
+  scinti_x_hi_eta(697.4*mm-121.09*mm),
   steel_x(823.*mm),
   steel_z(1600.*mm),
   size_z(steel_z),
   scinti_tile_z(steel_z),
   scinti_tile_thickness(7*mm),
-  scinti_box_shift(1.09*mm), // that was found experimetnally by removing overlaps
+  scinti_box_shift(1.09*mm), // that was found experimentally by removing overlaps
   gap_between_tiles(1*mm),
   scinti_gap(8.5*mm),
   tilt_angle(12*deg),
@@ -79,10 +106,8 @@ PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNod
   n_steel_plates(n_scinti_plates+1),
   active(params->get_int_param("active")),
   absorberactive(params->get_int_param("absorberactive")),
-  layer(0),
-  scintilogicnameprefix("OuterHcalScintiMother")
-{
-}
+  layer(0)
+{}
 
 //_______________________________________________________________
 //_______________________________________________________________
@@ -228,8 +253,146 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenve
   return scintiu2_logic;
 }
 
+G4LogicalVolume*
+PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope)
+{ 
+  G4VSolid* scintiboxsolid = new G4Box("OuterHcalScintiMother",scinti_x/2.,scinti_gap/2.,scinti_tile_z/2.);
+  //  DisplayVolume(scintiboxsolid,hcalenvelope);
+  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String("OuterHcalScintiMother"), 0, 0, 0);
+
+  G4VisAttributes* hcalVisAtt = new G4VisAttributes();
+  hcalVisAtt->SetVisibility(true);
+  hcalVisAtt->SetForceSolid(false);
+  hcalVisAtt->SetColour(G4Colour::Magenta());
+  G4LogicalVolume *scintit9_logic = ConstructScintiTile9(hcalenvelope);
+  scintit9_logic->SetVisAttributes(hcalVisAtt);
+
+  double distance_to_corner = -size_z/2.+scinti_t9_distance_to_corner;
+  G4RotationMatrix *Rot;  
+  Rot = new G4RotationMatrix();  
+  Rot->rotateX(90*deg);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit9_logic,"OuterScinti_9", scintiboxlogical, false, 0, overlapcheck);
+
+  hcalVisAtt = new G4VisAttributes();
+  hcalVisAtt->SetVisibility(true);
+  hcalVisAtt->SetForceSolid(false);
+  hcalVisAtt->SetColour(G4Colour::Blue());
+  G4LogicalVolume *scintit10_logic = ConstructScintiTile10(hcalenvelope);
+  scintit10_logic->SetVisAttributes(hcalVisAtt);
+
+  distance_to_corner += scinti_t9_front_size + gap_between_tiles;
+  Rot = new G4RotationMatrix();  
+  Rot->rotateX(90*deg);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit10_logic,"OuterScinti_10", scintiboxlogical, false, 0, overlapcheck);
+
+  hcalVisAtt = new G4VisAttributes();
+  hcalVisAtt->SetVisibility(true);
+  hcalVisAtt->SetForceSolid(false);
+  hcalVisAtt->SetColour(G4Colour::Yellow());
+  G4LogicalVolume *scintit11_logic = ConstructScintiTile11(hcalenvelope);
+  scintit11_logic->SetVisAttributes(hcalVisAtt);
+
+  distance_to_corner += scinti_t10_front_size + gap_between_tiles;
+  Rot = new G4RotationMatrix();  
+  Rot->rotateX(90*deg);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit11_logic,"OuterScinti_11", scintiboxlogical, false, 0, overlapcheck);
+
+  hcalVisAtt = new G4VisAttributes();
+  hcalVisAtt->SetVisibility(true);
+  hcalVisAtt->SetForceSolid(false);
+  hcalVisAtt->SetColour(G4Colour::Cyan());
+  G4LogicalVolume *scintit12_logic = ConstructScintiTile12(hcalenvelope);
+  scintit12_logic->SetVisAttributes(hcalVisAtt);
+
+  distance_to_corner += scinti_t11_front_size + gap_between_tiles;
+  Rot = new G4RotationMatrix();  
+  Rot->rotateX(90*deg);
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit12_logic,"OuterScinti_12", scintiboxlogical, false, 0, overlapcheck);
+  //DisplayVolume(scintiboxlogical,hcalenvelope);
+  return scintiboxlogical;
+}
+G4LogicalVolume*
+PHG4Prototype2OuterHcalDetector::ConstructScintiTile9(G4LogicalVolume* hcalenvelope)
+{
+  std::vector<G4TwoVector> vertexes;
+  vertexes.push_back(scinti_t9_corner_upper_left);
+  vertexes.push_back(scinti_t9_corner_upper_right);
+  vertexes.push_back(scinti_t9_corner_lower_right);
+  vertexes.push_back(scinti_t9_corner_lower_left);
+  G4TwoVector zero(0, 0);
+  G4VSolid *scintit9 =  new G4ExtrudedSolid("OuterHcalScintiT9",
+					    vertexes,
+					    scinti_tile_thickness  / 2.0,
+					    zero, 1.0,
+					    zero, 1.0);
+
+  G4LogicalVolume *scintit9_logic = new G4LogicalVolume(scintit9,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT9", NULL, NULL, NULL);
+  //     DisplayVolume(scintit9,hcalenvelope);
+  return scintit9_logic;
+}
+
+G4LogicalVolume*
+PHG4Prototype2OuterHcalDetector::ConstructScintiTile10(G4LogicalVolume* hcalenvelope)
+{
+  std::vector<G4TwoVector> vertexes;
+  vertexes.push_back(scinti_t10_corner_upper_left);
+  vertexes.push_back(scinti_t10_corner_upper_right);
+  vertexes.push_back(scinti_t10_corner_lower_right);
+  vertexes.push_back(scinti_t10_corner_lower_left);
+  G4TwoVector zero(0, 0);
+  G4VSolid *scintit10 =  new G4ExtrudedSolid("OuterHcalScintiT10",
+					    vertexes,
+					    scinti_tile_thickness  / 2.0,
+					    zero, 1.0,
+					    zero, 1.0);
+
+  G4LogicalVolume *scintit10_logic = new G4LogicalVolume(scintit10,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT10", NULL, NULL, NULL);
+  //     DisplayVolume(scintit10,hcalenvelope);
+  return scintit10_logic;
+}
+
+G4LogicalVolume*
+PHG4Prototype2OuterHcalDetector::ConstructScintiTile11(G4LogicalVolume* hcalenvelope)
+{
+  std::vector<G4TwoVector> vertexes;
+  vertexes.push_back(scinti_t11_corner_upper_left);
+  vertexes.push_back(scinti_t11_corner_upper_right);
+  vertexes.push_back(scinti_t11_corner_lower_right);
+  vertexes.push_back(scinti_t11_corner_lower_left);
+  G4TwoVector zero(0, 0);
+  G4VSolid *scintit11 =  new G4ExtrudedSolid("OuterHcalScintiT11",
+					    vertexes,
+					    scinti_tile_thickness  / 2.0,
+					    zero, 1.0,
+					    zero, 1.0);
+
+  G4LogicalVolume *scintit11_logic = new G4LogicalVolume(scintit11,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT11", NULL, NULL, NULL);
+  //     DisplayVolume(scintit11,hcalenvelope);
+  return scintit11_logic;
+}
+
+G4LogicalVolume*
+PHG4Prototype2OuterHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenvelope)
+{
+  std::vector<G4TwoVector> vertexes;
+  vertexes.push_back(scinti_t12_corner_upper_left);
+  vertexes.push_back(scinti_t12_corner_upper_right);
+  vertexes.push_back(scinti_t12_corner_lower_right);
+  vertexes.push_back(scinti_t12_corner_lower_left);
+  G4TwoVector zero(0, 0);
+  G4VSolid *scintit12 =  new G4ExtrudedSolid("OuterHcalScintiT12",
+					    vertexes,
+					    scinti_tile_thickness  / 2.0,
+					    zero, 1.0,
+					    zero, 1.0);
+
+  G4LogicalVolume *scintit12_logic = new G4LogicalVolume(scintit12,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT12", NULL, NULL, NULL);
+  //     DisplayVolume(scintit12,hcalenvelope);
+  return scintit12_logic;
+}
+
 // Construct the envelope and the call the
-// actual inner hcal construction
+// actual outer hcal construction
 void
 PHG4Prototype2OuterHcalDetector::Construct( G4LogicalVolume* logicWorld )
 {
@@ -238,6 +401,7 @@ PHG4Prototype2OuterHcalDetector::Construct( G4LogicalVolume* logicWorld )
   Rot->rotateX(params->get_double_param("rot_x")*deg);
   Rot->rotateY(params->get_double_param("rot_y")*deg);
   Rot->rotateZ(params->get_double_param("rot_z")*deg);
+  //  ConstructScintillatorBoxHiEta(logicWorld);
   outerhcalassembly = new G4AssemblyVolume();
   //ConstructSteelPlate(hcal_envelope_log);
   // return;
@@ -250,7 +414,15 @@ int
 PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelope)
 {
   G4LogicalVolume* steel_plate = ConstructSteelPlate(hcalenvelope); // bottom steel plate
-  G4LogicalVolume* scintibox = ConstructScintillatorBox(hcalenvelope);
+  G4LogicalVolume* scintibox = NULL;
+  if (params->get_int_param("hi_eta"))
+    {
+      scintibox = ConstructScintillatorBoxHiEta(hcalenvelope);
+    }
+  else
+    {
+      scintibox = ConstructScintillatorBox(hcalenvelope);
+    }
   double phi = 0.;
   double phislat = 0.;
   ostringstream name;
@@ -330,8 +502,15 @@ PHG4Prototype2OuterHcalDetector::GetScintiAngle()
 int
 PHG4Prototype2OuterHcalDetector::DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix *rotm )
 {
-  static int i = 0;
   G4LogicalVolume* checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), "DISPLAYLOGICAL", 0, 0, 0);
+  DisplayVolume(checksolid,logvol,rotm);
+  return 0;
+}
+
+int
+PHG4Prototype2OuterHcalDetector::DisplayVolume(G4LogicalVolume *checksolid,  G4LogicalVolume* logvol, G4RotationMatrix *rotm )
+{
+  static int i = 0;
   G4VisAttributes* visattchk = new G4VisAttributes();
   visattchk->SetVisibility(true);
   visattchk->SetForceSolid(false);
@@ -369,6 +548,7 @@ PHG4Prototype2OuterHcalDetector::DisplayVolume(G4VSolid *volume,  G4LogicalVolum
   return 0;
 }
 
+
 void
 PHG4Prototype2OuterHcalDetector::Print(const string &what) const
 {
@@ -380,3 +560,4 @@ PHG4Prototype2OuterHcalDetector::Print(const string &what) const
     }
   return;
 }
+

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -90,7 +90,6 @@ PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNod
 
   scinti_x(828.9),
   scinti_x_hi_eta(697.4*mm-121.09*mm),
-  steel_x(823.*mm),
   steel_z(1600.*mm),
   size_z(steel_z),
   scinti_tile_z(steel_z),
@@ -396,7 +395,9 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
 void
 PHG4Prototype2OuterHcalDetector::Construct( G4LogicalVolume* logicWorld )
 {
-  G4ThreeVector g4vec(0,0,0);
+  G4ThreeVector g4vec(params->get_double_param("place_x")*cm,
+                      params->get_double_param("place_y")*cm,
+		      params->get_double_param("place_z")*cm);
   G4RotationMatrix *Rot = new G4RotationMatrix();
   Rot->rotateX(params->get_double_param("rot_x")*deg);
   Rot->rotateY(params->get_double_param("rot_y")*deg);

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
@@ -47,13 +47,19 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
 
   G4LogicalVolume* ConstructSteelPlate(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintillatorBox(G4LogicalVolume* hcalenvelope);
+  G4LogicalVolume* ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintiTileU1(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintiTileU2(G4LogicalVolume* hcalenvelope);
-  double GetScintiAngle();
+  G4LogicalVolume* ConstructScintiTile9(G4LogicalVolume* hcalenvelope);
+  G4LogicalVolume* ConstructScintiTile10(G4LogicalVolume* hcalenvelope);
+  G4LogicalVolume* ConstructScintiTile11(G4LogicalVolume* hcalenvelope);
+  G4LogicalVolume* ConstructScintiTile12(G4LogicalVolume* hcalenvelope);
+   double GetScintiAngle();
 
   protected:
   int ConstructOuterHcal(G4LogicalVolume* sandwich);
   int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
+  int DisplayVolume(G4LogicalVolume *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
   PHG4Parameters *params;
   G4LogicalVolume *outerhcalsteelplate;
   G4AssemblyVolume *outerhcalassembly;
@@ -61,18 +67,44 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
   G4TwoVector steel_plate_corner_upper_right;
   G4TwoVector steel_plate_corner_lower_right;
   G4TwoVector steel_plate_corner_lower_left;
+
   double scinti_u1_front_size;
   G4TwoVector scinti_u1_corner_upper_left;
   G4TwoVector scinti_u1_corner_upper_right;
   G4TwoVector scinti_u1_corner_lower_right;
   G4TwoVector scinti_u1_corner_lower_left;
+
   G4TwoVector scinti_u2_corner_upper_left;
   G4TwoVector scinti_u2_corner_upper_right;
   G4TwoVector scinti_u2_corner_lower_right;
   G4TwoVector scinti_u2_corner_lower_left;
-  double inner_radius;
-  double outer_radius;
+  double scinti_t9_distance_to_corner;
+  double scinti_t9_front_size;
+  G4TwoVector scinti_t9_corner_upper_left;
+  G4TwoVector scinti_t9_corner_upper_right;
+  G4TwoVector scinti_t9_corner_lower_right;
+  G4TwoVector scinti_t9_corner_lower_left;
+
+  double scinti_t10_front_size;
+  G4TwoVector scinti_t10_corner_upper_left;
+  G4TwoVector scinti_t10_corner_upper_right;
+  G4TwoVector scinti_t10_corner_lower_right;
+  G4TwoVector scinti_t10_corner_lower_left;
+
+  double scinti_t11_front_size;
+  G4TwoVector scinti_t11_corner_upper_left;
+  G4TwoVector scinti_t11_corner_upper_right;
+  G4TwoVector scinti_t11_corner_lower_right;
+  G4TwoVector scinti_t11_corner_lower_left;
+
+  double scinti_t12_front_size;
+  G4TwoVector scinti_t12_corner_upper_left;
+  G4TwoVector scinti_t12_corner_upper_right;
+  G4TwoVector scinti_t12_corner_lower_right;
+  G4TwoVector scinti_t12_corner_lower_left;
+
   double scinti_x;
+  double scinti_x_hi_eta;
   double steel_x;
   double steel_z;
   double size_z;
@@ -95,7 +127,6 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
   int layer;
   std::string detector_type;
   std::string superdetector;
-  std::string scintilogicnameprefix;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
@@ -105,7 +105,6 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
 
   double scinti_x;
   double scinti_x_hi_eta;
-  double steel_x;
   double steel_z;
   double size_z;
   double scinti_tile_z;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
@@ -6,9 +6,6 @@
 
 #include <g4main/PHG4HitContainer.h>
 
-#include <pdbcalbase/PdbParameterMap.h>
-#include <pdbcalbase/PdbParameterMapContainer.h>
-
 #include <phool/getClass.h>
 
 #include <Geant4/globals.hh>
@@ -22,118 +19,55 @@ using namespace std;
 
 //_______________________________________________________________________
 PHG4Prototype2OuterHcalSubsystem::PHG4Prototype2OuterHcalSubsystem( const std::string &name, const int lyr ):
-  PHG4Subsystem( name ),
+  PHG4DetectorSubsystem( name, lyr ),
   detector_(NULL),
   steppingAction_( NULL ),
-  eventAction_(NULL),
-  layer(lyr),
-  usedb(0),
-  filetype(PHG4Prototype2OuterHcalSubsystem::none),
-  detector_type(name),
-  superdetector("NONE"),
-  calibfiledir("./")
+  eventAction_(NULL)
 {
-
-  // put the layer into the name so we get unique names
-  // for multiple layers
-  ostringstream nam;
-  nam << name << "_" << lyr;
-  Name(nam.str().c_str());
-  params = new PHG4Parameters(Name()); // temporary name till the init is called
-  SetDefaultParameters();
-}
-
-void
-PHG4Prototype2OuterHcalSubsystem::SuperDetector(const std::string &name)
-{
-  superdetector = name;
-  Name(name);
-  return;
-}
-
-int 
-PHG4Prototype2OuterHcalSubsystem::Init(PHCompositeNode* topNode)
-{
-  params->set_name(superdetector);
-  return 0;
+  InitializeParameters();
 }
 
 //_______________________________________________________________________
 int 
-PHG4Prototype2OuterHcalSubsystem::InitRun( PHCompositeNode* topNode )
+PHG4Prototype2OuterHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 {
   PHNodeIterator iter( topNode );
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
 
-  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN" ));
-  string g4geonodename = "G4GEO_" + superdetector;
-  parNode->addNode(new PHDataNode<PHG4Parameters>(params,g4geonodename));
-
-
-  string paramnodename = "G4GEOPARAM_" + superdetector;
-  // ASSUMPTION: if we read from DB and/or file we don't want the stuff from
-  // the node tree
-  // We leave the defaults intact in case there is no entry for
-  // those in the object read from the DB or file
-  // Order: read first DB, then calib file if both are enabled
-  if (usedb || filetype != PHG4Prototype2OuterHcalSubsystem::none)
-    {
-      if (usedb)
-	{
-          ReadParamsFromDB();
-	}
-      if (filetype != PHG4Prototype2OuterHcalSubsystem::none)
-	{
-	  ReadParamsFromFile(filetype);
-	}
-    }
-  else
-    {
-      PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,paramnodename);
-      if (nodeparams)
-	{
-	  params->FillFrom(nodeparams, layer);
-	}
-    }
-  // parameters set in the macro always override whatever is read from
-  // the node tree, DB or file
-  UpdateParametersWithMacro();
-  // save updated persistant copy on node tree
-  params->SaveToNodeTree(parNode,paramnodename,layer);
   // create detector
-  detector_ = new PHG4Prototype2OuterHcalDetector(topNode, params, Name());
-  detector_->SuperDetector(superdetector);
-  detector_->OverlapCheck(overlapcheck);
+  detector_ = new PHG4Prototype2OuterHcalDetector(topNode, GetParams(), Name());
+  detector_->SuperDetector(SuperDetector());
+  detector_->OverlapCheck(CheckOverlap());
   set<string> nodes;
-  if (params->get_int_param("active"))
+  if (GetParams()->get_int_param("active"))
     {
-      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",superdetector));
+      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",SuperDetector()));
       if (! DetNode)
 	{
-          DetNode = new PHCompositeNode(superdetector);
+          DetNode = new PHCompositeNode(SuperDetector());
           dstNode->addNode(DetNode);
         }
 
       ostringstream nodename;
-      if (superdetector != "NONE")
+      if (SuperDetector() != "NONE")
 	{
-	  nodename <<  "G4HIT_" << superdetector;
+	  nodename <<  "G4HIT_" << SuperDetector();
 	}
       else
 	{
-	  nodename <<  "G4HIT_" << detector_type << "_" << layer;
+	  nodename <<  "G4HIT_" << Name();
 	}
       nodes.insert(nodename.str());
-      if (params->get_int_param("absorberactive"))
+      if (GetParams()->get_int_param("absorberactive"))
 	{
 	  nodename.str("");
-	  if (superdetector != "NONE")
+	  if (SuperDetector() != "NONE")
 	    {
-	      nodename <<  "G4HIT_ABSORBER_" << superdetector;
+	      nodename <<  "G4HIT_ABSORBER_" << SuperDetector();
 	    }
 	  else
 	    {
-	      nodename <<  "G4HIT_ABSORBER_" << detector_type << "_" << layer;
+	      nodename <<  "G4HIT_ABSORBER_" << Name();
 	    }
           nodes.insert(nodename.str());
 	}
@@ -158,15 +92,15 @@ PHG4Prototype2OuterHcalSubsystem::InitRun( PHCompositeNode* topNode )
 	}
 
       // create stepping action
-      steppingAction_ = new PHG4Prototype2OuterHcalSteppingAction(detector_, params);
+      steppingAction_ = new PHG4Prototype2OuterHcalSteppingAction(detector_, GetParams());
 
     }
   else
     {
       // if this is a black hole it does not have to be active
-      if (params->get_int_param("blackhole"))
+      if (GetParams()->get_int_param("blackhole"))
 	{
-	  steppingAction_ = new PHG4Prototype2OuterHcalSteppingAction(detector_, params);
+	  steppingAction_ = new PHG4Prototype2OuterHcalSteppingAction(detector_, GetParams());
 	}
     }
   return 0;
@@ -191,7 +125,7 @@ void
 PHG4Prototype2OuterHcalSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
-  params->Print();
+  GetParams()->Print();
   if (detector_)
     {
       detector_->Print(what);
@@ -205,247 +139,35 @@ PHG4Detector* PHG4Prototype2OuterHcalSubsystem::GetDetector( void ) const
   return detector_;
 }
 
-//_______________________________________________________________________
-PHG4SteppingAction* PHG4Prototype2OuterHcalSubsystem::GetSteppingAction( void ) const
-{
-  return steppingAction_;
-}
-
-void
-PHG4Prototype2OuterHcalSubsystem::SetActive(const int i)
-{
-  iparams["active"] = i;
-}
-
-void
-PHG4Prototype2OuterHcalSubsystem::SetAbsorberActive(const int i)
-{
-  iparams["absorberactive"] = i;
-}
-
-void
-PHG4Prototype2OuterHcalSubsystem::BlackHole(const int i)
-{
-  iparams["blackhole"] = i;
-}
-
-void
-PHG4Prototype2OuterHcalSubsystem::set_double_param(const std::string &name, const double dval)
-{
-  if (default_double.find(name) == default_double.end())
-    {
-      cout << "double parameter " << name << " not implemented" << endl;
-      cout << "implemented double parameters are:" << endl;
-      for (map<const string, double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
-	{
-	  cout << iter->first << endl;
-	}
-      return;
-    }
-  dparams[name] = dval;
-}
-
-void
-PHG4Prototype2OuterHcalSubsystem::set_int_param(const std::string &name, const int ival)
-{
-  if (default_int.find(name) == default_int.end())
-    {
-      cout << "integer parameter " << name << " not implemented" << endl;
-      cout << "implemented integer parameters are:" << endl;
-      for (map<const string, int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
-	{
-	  cout << iter->first << endl;
-	}
-      return;
-    }
-  iparams[name] = ival;
-}
-
-void
-PHG4Prototype2OuterHcalSubsystem::SetAbsorberTruth(const int i)
-{
-  iparams["absorbertruth"] = i;
-}
-
-void
-PHG4Prototype2OuterHcalSubsystem::set_string_param(const std::string &name, const string &sval)
-{
-  if (default_string.find(name) == default_string.end())
-    {
-      cout << "string parameter " << name << " not implemented" << endl;
-      cout << "implemented string parameters are:" << endl;
-      for (map<const string, string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
-	{
-	  cout << iter->first << endl;
-	}
-      return;
-    }
-  cparams[name] = sval;
-}
-
 void
 PHG4Prototype2OuterHcalSubsystem::SetDefaultParameters()
 {
   // all in cm
-  default_double["light_balance_inner_corr"] = NAN;
-  default_double["light_balance_inner_radius"] = NAN;
-  default_double["light_balance_outer_corr"] = NAN;
-  default_double["light_balance_outer_radius"] = NAN;
-  default_double["place_x"] = 0.;
-  default_double["place_y"] = 0.;
-  default_double["place_z"] = 0.;
-  default_double["rot_x"] = 0.;
-  default_double["rot_y"] = 0.;
-  default_double["rot_z"] = 0.;
-  default_double["steplimits"] = NAN;
+  set_default_double_param("light_balance_inner_corr", NAN);
+  set_default_double_param("light_balance_inner_radius", NAN);
+  set_default_double_param("light_balance_outer_corr", NAN);
+  set_default_double_param("light_balance_outer_radius", NAN);
+  set_default_double_param("place_x", 0.);
+  set_default_double_param("place_y", 0.);
+  set_default_double_param("place_z", 0.);
+  set_default_double_param("rot_x", 0.);
+  set_default_double_param("rot_y", 0.);
+  set_default_double_param("rot_z", 0.);
+  set_default_double_param("steplimits", NAN);
 
-  default_int["absorberactive"] = 0;
-  default_int["absorbertruth"] = 1;
-  default_int["active"] = 0;
-  default_int["blackhole"] = 0;
-  default_int["light_scint_model"] = 1;
+  set_default_int_param("light_scint_model", 1);
+  set_default_int_param("hi_eta", 0);
 
-  default_string["material"] = "SS310";
-  for (map<const string,double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
-    {
-      params->set_double_param(iter->first,iter->second);
-    }
-  for (map<const string,int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
-    {
-      params->set_int_param(iter->first,iter->second);
-    }
-  for (map<const string,string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
-    {
-      params->set_string_param(iter->first,iter->second);
-    }
+  set_default_string_param("material", "SS310");
 
-}
-
-void
-PHG4Prototype2OuterHcalSubsystem::UpdateParametersWithMacro()
-{
-  for (map<const string,double>::const_iterator iter = dparams.begin(); iter != dparams.end(); ++iter)
-    {
-      params->set_double_param(iter->first,iter->second);
-    }
-  for (map<const string,int>::const_iterator iter = iparams.begin(); iter != iparams.end(); ++iter)
-    {
-      params->set_int_param(iter->first,iter->second);
-    }
-  for (map<const string,string>::const_iterator iter = cparams.begin(); iter != cparams.end(); ++iter)
-    {
-      params->set_string_param(iter->first,iter->second);
-    }
-  return;
 }
 
 void
 PHG4Prototype2OuterHcalSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr)
 {
-  dparams["light_balance_inner_corr"] = inner_corr;
-  dparams["light_balance_inner_radius"] = inner_radius;
-  dparams["light_balance_outer_corr"] = outer_corr;
-  dparams["light_balance_outer_radius"] = outer_radius;
+  set_double_param("light_balance_inner_corr", inner_corr);
+  set_double_param("light_balance_inner_radius", inner_radius);
+  set_double_param("light_balance_outer_corr", outer_corr);
+  set_double_param("light_balance_outer_radius", outer_radius);
   return;
 }
-
-int
-PHG4Prototype2OuterHcalSubsystem::SaveParamsToDB()
-{
-  int iret = params->WriteToDB();
-  if (iret)
-    {
-      cout << "problem committing to DB" << endl;
-    }
-  return iret;
-}
-
-int
-PHG4Prototype2OuterHcalSubsystem::ReadParamsFromDB()
-{
-  int iret = params->ReadFromDB(superdetector,layer);
-  if (iret)
-    {
-      cout << "problem reading from DB" << endl;
-    }
-  return iret;
-}
-
-int
-PHG4Prototype2OuterHcalSubsystem::SaveParamsToFile(const PHG4Prototype2OuterHcalSubsystem::FILE_TYPE ftyp)
-{
-  string extension;
-  switch(ftyp)
-    {
-    case xml:
-      extension = "xml";
-      break;
-    case root:
-      extension = "root";
-      break;
-    default:
-      cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
-      exit(1);
-    }
-
-  int iret = params->WriteToFile(extension,calibfiledir);
-  if (iret)
-    {
-      cout << "problem saving to " << extension << " file " << endl;
-    }
-  return iret;
-}
-
-int
-PHG4Prototype2OuterHcalSubsystem::ReadParamsFromFile(const PHG4Prototype2OuterHcalSubsystem::FILE_TYPE ftyp)
-{
-  string extension;
-  switch(ftyp)
-    {
-    case xml:
-      extension = "xml";
-      break;
-    case root:
-      extension = "root";
-      break;
-    default:
-      cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
-      exit(1);
-    }
-  string name;
-  int issuper = 0;
-  if (superdetector != "NONE")
-    {
-      name = superdetector;
-      issuper = 1;
-    }
-  else
-    {
-      name = params->Name();
-    }
-  int iret = params->ReadFromFile(name, extension, layer, issuper, calibfiledir);
-  if (iret)
-    {
-      cout << "problem reading from " << extension << " file " << endl;
-    }
-  return iret;
-}
-
-double
-PHG4Prototype2OuterHcalSubsystem::get_double_param(const std::string &name) const
-{
-  return params->get_double_param(name);
-}
-
-int
-PHG4Prototype2OuterHcalSubsystem::get_int_param(const std::string &name) const
-{
-  return params->get_int_param(name);
-}
-
-string
-PHG4Prototype2OuterHcalSubsystem::get_string_param(const std::string &name) const
-{
-  return params->get_string_param(name);
-}
-

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.h
@@ -1,26 +1,20 @@
 #ifndef PHG4Prototype2OuterHcalSubsystem_h
 #define PHG4Prototype2OuterHcalSubsystem_h
 
-#include <g4main/PHG4Subsystem.h>
-
-#include <Geant4/G4Types.hh>
-#include <Geant4/G4String.hh>
+#include "PHG4DetectorSubsystem.h"
 
 #include <map>
 #include <set>
 #include <string>
 
-class PHG4Prototype2OuterHcalDetector;
-class PHG4Parameters;
-class PHG4Prototype2OuterHcalSteppingAction;
 class PHG4EventAction;
+class PHG4Prototype2OuterHcalDetector;
+class PHG4SteppingAction;
 
-class PHG4Prototype2OuterHcalSubsystem: public PHG4Subsystem
+class PHG4Prototype2OuterHcalSubsystem: public PHG4DetectorSubsystem
 {
 
   public:
-
-  enum FILE_TYPE {none = 0, xml = 1, root = 2};
 
   //! constructor
   PHG4Prototype2OuterHcalSubsystem( const std::string &name = "HCALIN", const int layer = 0 );
@@ -29,15 +23,12 @@ class PHG4Prototype2OuterHcalSubsystem: public PHG4Subsystem
   virtual ~PHG4Prototype2OuterHcalSubsystem( void )
   {}
 
-  //! init
-  int Init(PHCompositeNode *);
-
   /*!
   creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRun(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode *);
 
   //! event processing
   /*!
@@ -51,34 +42,15 @@ class PHG4Prototype2OuterHcalSubsystem: public PHG4Subsystem
 
   //! accessors (reimplemented)
   virtual PHG4Detector* GetDetector( void ) const;
-  virtual PHG4SteppingAction* GetSteppingAction( void ) const;
+  virtual PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
 
   PHG4EventAction* GetEventAction() const {return eventAction_;}
-  void SetActive(const int i = 1);
-  void SetAbsorberActive(const int i = 1);
-  void SetAbsorberTruth(const int i = 1);
-  void SuperDetector(const std::string &name);
-  const std::string SuperDetector() {return superdetector;}
 
-  void BlackHole(const int i=1);
   void SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr);
-  void set_double_param(const std::string &name, const double dval);
-  double get_double_param(const std::string &name) const;
-  void set_int_param(const std::string &name, const int ival);
-  int get_int_param(const std::string &name) const;
-  void set_string_param(const std::string &name, const std::string &sval);
-  std::string get_string_param(const std::string &name) const;
-  void SetDefaultParameters();
-  void UpdateParametersWithMacro();
-  void UseDB(const int i = 1) {usedb = i;}
-  void UseCalibFiles(const FILE_TYPE ftyp) {filetype = ftyp;}
-  int SaveParamsToDB();
-  int ReadParamsFromDB();
-  int SaveParamsToFile(const FILE_TYPE ftyp);
-  int ReadParamsFromFile(const FILE_TYPE ftyp);
-  void SetCalibrationFileDir(const std::string &calibdir) {calibfiledir = calibdir;}
 
   protected:
+
+  void SetDefaultParameters();
 
   //! detector geometry
   /*! derives from PHG4Detector */
@@ -86,27 +58,11 @@ class PHG4Prototype2OuterHcalSubsystem: public PHG4Subsystem
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingAction */
-  PHG4Prototype2OuterHcalSteppingAction* steppingAction_;
+  PHG4SteppingAction* steppingAction_;
 
   //! particle tracking "stepping" action
   /*! derives from PHG4EventAction */
   PHG4EventAction *eventAction_;
-
-  PHG4Parameters *params;
-
-  int layer;
-
-  int usedb;
-  FILE_TYPE filetype;
-  std::string detector_type;
-  std::string superdetector;
-  std::string calibfiledir;
-  std::map<const std::string, double> dparams;
-  std::map<const std::string, int> iparams;
-  std::map<const std::string, std::string> cparams;
-  std::map<const std::string, double> default_double;
-  std::map<const std::string, int> default_int;
-  std::map<const std::string, std::string> default_string;
 
 };
 


### PR DESCRIPTION
The inner/outer hcal prototypes now inherit from PHG4DetectorSubsystem which simplifies the code tremendously. The high rapidity test setup only differs in the shape of the scintillators, an option (hi_eta) can be used to switch between them. The placement on the platform also differs but that can be accomplished by changing the placement of the hcals in the macro. The code was verified for midrapidity, the hits are identical compared to the previous implementation.

Some cosmetic change for the beam prototype code: We should really watch out that includes using quotes are before include using brackets. Mixing this can lead to really strange behaviour since includes can be picked up from the wrong place on a case by case basis. 