### PR TITLE
move the hi eta scintillator tiles of the outer hcal to the front edge of the steel plates

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -1,30 +1,20 @@
 #include "PHG4Prototype2InnerHcalDetector.h"
-#include "PHG4CylinderGeomContainer.h"
-#include "PHG4CylinderGeomv3.h"
 
 #include <g4main/PHG4Utils.h>
-
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
 
 #include <Geant4/G4AssemblyVolume.hh>
-#include <Geant4/G4IntersectionSolid.hh>
-#include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/G4Material.hh>
 #include <Geant4/G4Box.hh>
-#include <Geant4/G4Cons.hh>
+#include <Geant4/G4Colour.hh>
 #include <Geant4/G4ExtrudedSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4TwoVector.hh>
-#include <Geant4/G4Trap.hh>
-#include <Geant4/G4Tubs.hh>
-#include <Geant4/G4UserLimits.hh>
-
 #include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4Colour.hh>
 
 #include <cmath>
 #include <sstream>

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -1,44 +1,23 @@
 #include "PHG4Prototype2OuterHcalDetector.h"
-#include "PHG4CylinderGeomContainer.h"
-#include "PHG4CylinderGeomv3.h"
 
 #include <g4main/PHG4Utils.h>
-
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
 
 #include <Geant4/G4AssemblyVolume.hh>
-#include <Geant4/G4IntersectionSolid.hh>
-#include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/G4Material.hh>
 #include <Geant4/G4Box.hh>
-#include <Geant4/G4Cons.hh>
+#include <Geant4/G4Colour.hh>
 #include <Geant4/G4ExtrudedSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4TwoVector.hh>
-#include <Geant4/G4Trap.hh>
-#include <Geant4/G4Tubs.hh>
-#include <Geant4/G4UserLimits.hh>
-
 #include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4Colour.hh>
-
-#include <CGAL/Exact_circular_kernel_2.h>
-#include <CGAL/point_generators_2.h>
-#include <CGAL/Object.h>
-#include <CGAL/Circular_kernel_intersections.h>
-
-#include <boost/math/special_functions/sign.hpp>
 
 #include <cmath>
 #include <sstream>
-
-typedef CGAL::Exact_circular_kernel_2             Circular_k;
-typedef CGAL::Point_2<Circular_k>                 Point_2;
-typedef CGAL::Line_2<Circular_k>                Line_2;
 
 using namespace std;
 
@@ -89,7 +68,7 @@ PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNod
   scinti_t12_corner_lower_left(0*mm,-scinti_t12_front_size),
 
   scinti_x(828.9),
-  scinti_x_hi_eta(697.4*mm-121.09*mm),
+  scinti_x_hi_eta(697.4*mm+121.09*mm),
   steel_z(1600.*mm),
   size_z(steel_z),
   scinti_tile_z(steel_z),
@@ -471,32 +450,9 @@ PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelop
 double
 PHG4Prototype2OuterHcalDetector::GetScintiAngle()
 {
-  Point_2 upleft(steel_plate_corner_upper_left.x(),steel_plate_corner_upper_left.y());
-  // we just need a horizontal line from the upper left corner for the intersection
-  // with the rear end of the steel plate
-  Point_2 lefttmp(steel_plate_corner_upper_left.x()+200*mm,steel_plate_corner_upper_left.y());
-  Point_2 upright(steel_plate_corner_upper_right.x(),steel_plate_corner_upper_right.y());
-  Point_2 downright(steel_plate_corner_lower_right.x(),steel_plate_corner_lower_right.y());
-  Line_2 rightside(upright,downright);
-  Line_2 horiz(upleft,lefttmp);
-  CGAL::Object result = CGAL::intersection(rightside, horiz);
-  // this point is the intersection of the horizontal line going through the
-  // upper left steel plate cornet with the rear edge of the steel plate
-  Point_2 intersect;
-  if (const Point_2 *ipoint = CGAL::object_cast<Point_2>(&result))
-    {
-      intersect = *ipoint;
-    }
-  // length of rear edge of steel plate from upper right corner to intersection point
-  double lenshort = sqrt((steel_plate_corner_upper_right.x()-CGAL::to_double(intersect.x()))
-                        *(steel_plate_corner_upper_right.x()-CGAL::to_double(intersect.x()))
-		       + (steel_plate_corner_upper_right.y()-CGAL::to_double(intersect.y()))
-                        *(steel_plate_corner_upper_right.y()-CGAL::to_double(intersect.y())));
-  double lenup = sqrt((steel_plate_corner_upper_right.x() - steel_plate_corner_upper_left.x())
-                     *(steel_plate_corner_upper_right.x() - steel_plate_corner_upper_left.x())
-		    + (steel_plate_corner_upper_right.y() - steel_plate_corner_upper_left.y())
-		      *(steel_plate_corner_upper_right.y() - steel_plate_corner_upper_left.y()));
-  double angle = asin(lenshort/lenup);
+  double xlen = steel_plate_corner_upper_right.x() - steel_plate_corner_upper_left.x();
+  double ylen = steel_plate_corner_upper_right.y() - steel_plate_corner_upper_left.y();
+  double angle =  atan(ylen/xlen);
   return angle;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -21,6 +21,8 @@
 
 using namespace std;
 
+double scinti_box_smaller = 0.02*mm;
+
 PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam  ):
   PHG4Detector(Node, dnam),
   params(parameters),
@@ -73,7 +75,7 @@ PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNod
   size_z(steel_z),
   scinti_tile_z(steel_z),
   scinti_tile_thickness(7*mm),
-  scinti_box_shift(1.09*mm), // that was found experimentally by removing overlaps
+scinti_box_smaller(0.02*mm), // blargh - off by 20 microns bc scinti tilt angle, need to revisit at some point
   gap_between_tiles(1*mm),
   scinti_gap(8.5*mm),
   tilt_angle(12*deg),
@@ -154,7 +156,7 @@ PHG4Prototype2OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
 G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
 { 
-  G4VSolid* scintiboxsolid = new G4Box("OuterHcalScintiMother",scinti_x/2.,scinti_gap/2.,scinti_tile_z/2.);
+  G4VSolid* scintiboxsolid = new G4Box("OuterHcalScintiMother",scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String("OuterHcalScintiMother"), 0, 0, 0);
   G4VisAttributes* hcalVisAtt = new G4VisAttributes();
@@ -234,7 +236,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenve
 G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope)
 { 
-  G4VSolid* scintiboxsolid = new G4Box("OuterHcalScintiMother",scinti_x/2.,scinti_gap/2.,scinti_tile_z/2.);
+  G4VSolid* scintiboxsolid = new G4Box("OuterHcalScintiMother",scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String("OuterHcalScintiMother"), 0, 0, 0);
 
@@ -429,8 +431,8 @@ PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelop
 	  // the center of the scintillator is not the center of the inner hcal
 	  // but depends on the tilt angle. Therefore we need to shift
 	  // the center from the mid point
-	  ypos += sin((-tilt_angle)/rad - phi)*scinti_box_shift;
-	  xpos -= cos((-tilt_angle)/rad - phi)*scinti_box_shift;
+	  ypos += sin((-tilt_angle)/rad - phi);
+	  xpos -= cos((-tilt_angle)/rad - phi);
 	  name.str("");
 	  name << "OuterHcalScintiBox_" << i;
 	  Rot = new G4RotationMatrix();

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
@@ -109,7 +109,7 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
   double size_z;
   double scinti_tile_z;
   double scinti_tile_thickness;
-  double scinti_box_shift;
+  double scinti_box_smaller;
   double gap_between_tiles;
   double scinti_gap;
   double tilt_angle;


### PR DESCRIPTION
The most recent design change was to move the scintillator tiles to the front of the steel plates. Also some code cleanup (use of CGAL was not needed), code now very similar to inner hcal prototype but given that the sizes are very different merging them would result in very confusing setups.