### PR TITLE
Add SvtxTrackState to SvtxTrack for requested detector projections to SvtxTrack_FastSim

### DIFF
--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
@@ -23,6 +23,8 @@
 #define LogError(exp)		std::cout<<"ERROR: "<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
 #define LogWarning(exp)	std::cout<<"WARNING: "<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
 
+#define WILD_DOUBLE -999999
+
 
 namespace PHGenFit {
 
@@ -61,8 +63,10 @@ Track::~Track()
 	delete _track;
 }
 
-genfit::MeasuredStateOnPlane* Track::extrapolateToPlane(TVector3 O, TVector3 n, const int tr_point_id) const
+double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O, TVector3 n, const int tr_point_id) const
 {
+	double pathlenth = WILD_DOUBLE;
+
 	genfit::SharedPlanePtr destPlane(new genfit::DetPlane(O, n));
 
 	genfit::AbsTrackRep* rep = _track->getCardinalRep();
@@ -70,90 +74,143 @@ genfit::MeasuredStateOnPlane* Track::extrapolateToPlane(TVector3 O, TVector3 n, 
 			tr_point_id, rep);
 	if (tp == NULL) {
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
+		return WILD_DOUBLE;
+	}
+	genfit::KalmanFittedStateOnPlane *kfsop  = new genfit::KalmanFittedStateOnPlane(
+			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
+	// extrapolate back to reference plane.
+	try {
+		pathlenth = rep->extrapolateToPlane(*kfsop, destPlane);
+	} catch (genfit::Exception& e) {
+		std::cerr << "Exception, next track" << std::endl;
+		std::cerr << e.what();
+		return WILD_DOUBLE;
+	}
+
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
+
+	return pathlenth;
+}
+
+genfit::MeasuredStateOnPlane* Track::extrapolateToPlane(TVector3 O, TVector3 n, const int tr_point_id) const
+{
+	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+	double pathlenth = this->extrapolateToPlane(*state, O, n, tr_point_id);
+	if(pathlenth <= WILD_DOUBLE)
 		return NULL;
+	else
+		return state;
+}
+
+double Track::extrapolateToLine(genfit::MeasuredStateOnPlane& state, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
+{
+	double pathlenth = WILD_DOUBLE;
+
+	genfit::AbsTrackRep* rep = _track->getCardinalRep();
+	genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
+			tr_point_id, rep);
+	if (tp == NULL) {
+		std::cout << "Track has no TrackPoint with fitterInfo! \n";
+		return WILD_DOUBLE;
 	}
 	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
 			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
 	// extrapolate back to reference plane.
 	try {
-		rep->extrapolateToPlane(*kfsop, destPlane);
+		pathlenth = rep->extrapolateToLine(*kfsop, line_point, line_direction);
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
-		return NULL;
+		return WILD_DOUBLE;
 	}
 
-	return kfsop;
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
+
+
+	return pathlenth;
 }
 
 genfit::MeasuredStateOnPlane* Track::extrapolateToLine(TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
 {
-	genfit::AbsTrackRep* rep = _track->getCardinalRep();
-	genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
-			tr_point_id, rep);
-	if (tp == NULL) {
-		std::cout << "Track has no TrackPoint with fitterInfo! \n";
+	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+	double pathlenth = this->extrapolateToLine(*state, line_point, line_direction, tr_point_id);
+	if(pathlenth <= WILD_DOUBLE)
 		return NULL;
-	}
-	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
-			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
-	// extrapolate back to reference plane.
-	try {
-		rep->extrapolateToLine(*kfsop, line_point, line_direction);
-	} catch (genfit::Exception& e) {
-		std::cerr << "Exception, next track" << std::endl;
-		std::cerr << e.what();
-		return NULL;
-	}
-
-	return kfsop;
+	else
+		return state;
 }
 
-genfit::MeasuredStateOnPlane* Track::extrapolateToCylinder(double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
+double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
 {
+	double pathlenth = WILD_DOUBLE;
+
 	genfit::AbsTrackRep* rep = _track->getCardinalRep();
 	genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
 			tr_point_id, rep);
 	if (tp == NULL) {
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
-		return NULL;
+		return WILD_DOUBLE;
 	}
 	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
 			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getForwardUpdate()));
 	// extrapolate back to reference plane.
 	try {
 		//rep->extrapolateToLine(*kfsop, line_point, line_direction);
-		rep->extrapolateToCylinder(*kfsop, radius, line_point, line_direction);
+		pathlenth = rep->extrapolateToCylinder(*kfsop, radius, line_point, line_direction);
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
-		return NULL;
+		return WILD_DOUBLE;
 	}
 
-	return kfsop;
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
+
+	return pathlenth;
 }
 
-genfit::MeasuredStateOnPlane* Track::extrapolateToPoint(TVector3 P, const int tr_point_id) const
+genfit::MeasuredStateOnPlane*  Track::extrapolateToCylinder(double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
 {
+	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+	double pathlenth = this->extrapolateToCylinder(*state, radius, line_point, line_direction);
+	if(pathlenth <= WILD_DOUBLE)
+		return NULL;
+	else
+		return state;
+}
+
+double Track::extrapolateToPoint(genfit::MeasuredStateOnPlane& state, TVector3 P, const int tr_point_id) const
+{
+	double pathlenth = WILD_DOUBLE;
 	genfit::AbsTrackRep* rep = _track->getCardinalRep();
 	genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
 			tr_point_id, rep);
 	if (tp == NULL) {
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
-		return NULL;
+		return WILD_DOUBLE;
 	}
 	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
 			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
 	// extrapolate back to reference plane.
 	try {
-		rep->extrapolateToPoint(*kfsop, P);
+		pathlenth = rep->extrapolateToPoint(*kfsop, P);
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
-		return NULL;
+		return WILD_DOUBLE;
 	}
 
-	return kfsop;
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
+
+	return pathlenth;
 }
 
+genfit::MeasuredStateOnPlane*  Track::extrapolateToPoint(TVector3 P, const int tr_point_id) const
+{
+	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+	double pathlenth = this->extrapolateToPoint(*state, P, tr_point_id);
+	if(pathlenth <= WILD_DOUBLE)
+		return NULL;
+	else
+		return state;
+}
 } //End of PHGenFit namespace

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.h
@@ -44,18 +44,25 @@ public:
 	//! Add measurement
 	int addMeasurements(std::vector<PHGenFit::Measurement*> measurements);
 
+	/*!
+	 * track_point 0 is the first one, and -1 is the last one
+	 */
+	double extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O, TVector3 n, const int tr_point_id = 0) const;
 	//!
-	genfit::MeasuredStateOnPlane* extrapolateToPlane(TVector3 O, TVector3 n, const int tr_point_id = -1) const;
+	double extrapolateToLine(genfit::MeasuredStateOnPlane& state, TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
+	//!
+	double extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
+	//!
+	double extrapolateToPoint(genfit::MeasuredStateOnPlane& state, TVector3 P, const int tr_point_id = 0) const;
 
+	//!
+	genfit::MeasuredStateOnPlane* extrapolateToPlane(TVector3 O, TVector3 n, const int tr_point_id = 0) const;
 	//!
 	genfit::MeasuredStateOnPlane* extrapolateToLine(TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
-
 	//!
-	genfit::MeasuredStateOnPlane* extrapolateToCylinder(double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id = -1) const;
-
+	genfit::MeasuredStateOnPlane* extrapolateToCylinder(double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
 	//!
 	genfit::MeasuredStateOnPlane* extrapolateToPoint(TVector3 P, const int tr_point_id = 0) const;
-
 	//!
 	genfit::Track* getGenFitTrack() {return _track;}
 

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -273,6 +273,7 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 				particle->get_track_id());
 
 		if(svtx_track_out) _trackmap_out->insert(svtx_track_out);
+
 	} // Loop all primary particles
 
 	//! add tracks to event display
@@ -562,6 +563,8 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 	  state->set_px(gf_state->getMom().x());
 	  state->set_py(gf_state->getMom().y());
 	  state->set_pz(gf_state->getMom().z());
+
+	  state->set_name(_state_names[i]); 
 
 	  for(int i=0;i<6;i++)
 	    {

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -272,7 +272,7 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 		SvtxTrack* svtx_track_out = MakeSvtxTrack(track,
 				particle->get_track_id());
 
-		_trackmap_out->insert(svtx_track_out);
+		if(svtx_track_out) _trackmap_out->insert(svtx_track_out);
 	} // Loop all primary particles
 
 	//! add tracks to event display
@@ -550,6 +550,9 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 	    LogError("Unrecognized detector name for state projection"); 
 	    continue; 
 	  }
+	  
+	  // if projection fails, bail out
+	  if(!gf_state) continue;
 
 	  SvtxTrackState* state = new SvtxTrackState_v1(_state_location[i]);
 	  state->set_x(gf_state->getPos().x());

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -25,10 +25,6 @@
 #include <TMatrixF.h>
 #include <TRandom.h>
 #include <TString.h>
-#include <g4hough/SvtxTrackMap.h>
-#include <g4hough/SvtxTrackMap_v1.h>
-#include <g4hough/SvtxTrackState.h>
-#include <g4hough/SvtxTrackState_v1.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
@@ -39,6 +35,11 @@
 #include <phgenfit/SpacepointMeasurement.h>
 #include <g4cemc/RawTowerGeom.h>
 #include <g4cemc/RawTowerGeomContainer.h>
+
+#include "SvtxTrackMap.h"
+#include "SvtxTrackMap_v1.h"
+#include "SvtxTrackState.h"
+#include "SvtxTrackState_v1.h"
 #include "SvtxTrack.h"
 #include "SvtxTrack_FastSim.h"
 
@@ -468,38 +469,37 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 	double chi2 = phgf_track->get_chi2();
 	double ndf = phgf_track->get_ndf();
 
-	genfit::MeasuredStateOnPlane* gf_state = NULL;
+	double pathlenth_from_first_meas = -999999;
+	double pathlenth_orig_from_first_meas = -999999;
+	genfit::MeasuredStateOnPlane* gf_state = new genfit::MeasuredStateOnPlane();
 
-	if (_detector_type == Vertical_Plane)
-		gf_state = phgf_track->extrapolateToPlane(TVector3(0., 0., 0.),
-				TVector3(0., 0., 1.));
+	if (_detector_type == Vertical_Plane) {
+		pathlenth_orig_from_first_meas = phgf_track->extrapolateToPlane(*gf_state, TVector3(0., 0., 0.),
+				TVector3(0., 0., 1.), 0);
+	}
 	else if (_detector_type == Cylinder)
-		gf_state = phgf_track->extrapolateToLine(TVector3(0., 0., 0.),
+		pathlenth_orig_from_first_meas = phgf_track->extrapolateToLine(*gf_state, TVector3(0., 0., 0.),
 				TVector3(0., 0., 1.));
 	else {
 		LogError("Detector Type NOT implemented!");
 		return NULL;
 	}
 
-	if(!gf_state) {
+	if(pathlenth_orig_from_first_meas<-999990) {
 		LogError("Extraction faild!");
 		return NULL;
 	}
 
-
 	TVector3 mom = gf_state->getMom();
 	TVector3 pos = gf_state->getPos();
 	TMatrixDSym cov = gf_state->get6DCov();
-
 //	SvtxTrack_v1* out_track = new SvtxTrack_v1(*static_cast<const SvtxTrack_v1*> (svtx_track));
 //	SvtxTrack_v1* out_track = new SvtxTrack_v1();
 
 	SvtxTrack* out_track = new SvtxTrack_FastSim();
-
 	out_track->set_truth_track_id(truth_track_id);
-
 	/*!
-	 * FIXME: check the definition
+	 * TODO: check the definition
 	 *  1/p, u'/z', v'/z', u, v
 	 *  u is defined as mom X beam line at POCA
 	 *  so u is the dca2d direction
@@ -516,7 +516,6 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 	out_track->set_charge(
 			(_reverse_mag_field) ?
 					-1. * phgf_track->get_charge() : phgf_track->get_charge());
-
 	out_track->set_px(mom.Px());
 	out_track->set_py(mom.Py());
 	out_track->set_pz(mom.Pz());
@@ -530,22 +529,19 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 			out_track->set_error(i, j, cov[i][j]);
 		}
 	}
-	
 	// State Projections
-
 	for (int i = 0; i < _N_STATES; i++) {
 
 	  if( (_state_names[i]=="FHCAL") || (_state_names[i]=="FEMC") ){
 	    
-	    // Project to a plane at fixed z	  
-	    gf_state = phgf_track->extrapolateToPlane(TVector3(0., 0., _state_location[i]),
-						      TVector3(1., 0., _state_location[i]));
-
+	    // Project to a plane at fixed z
+		  pathlenth_from_first_meas = phgf_track->extrapolateToPlane(*gf_state, TVector3(0., 0., _state_location[i]),
+						      TVector3(1., 0., _state_location[i]), 0);
 	  } else if( (_state_names[i]=="CEMC") || (_state_names[i]=="IHCAL") || (_state_names[i]=="OHCAL")){
 	  
 	    // Project to a cylinder at fixed r	  
-	    gf_state = phgf_track->extrapolateToCylinder(_state_location[i], TVector3(0., 0., 0.),
-						      TVector3(0., 0., 1.));
+		  pathlenth_from_first_meas = phgf_track->extrapolateToCylinder(*gf_state, _state_location[i], TVector3(0., 0., 0.),
+						      TVector3(0., 0., 1.), 0);
 	  }
 	  else{
 	    LogError("Unrecognized detector name for state projection"); 
@@ -553,9 +549,9 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 	  }
 	  
 	  // if projection fails, bail out
-	  if(!gf_state) continue;
+	  if(pathlenth_from_first_meas<-999990) continue;
 
-	  SvtxTrackState* state = new SvtxTrackState_v1(_state_location[i]);
+	  SvtxTrackState* state = new SvtxTrackState_v1(pathlenth_from_first_meas-pathlenth_orig_from_first_meas);
 	  state->set_x(gf_state->getPos().x());
 	  state->set_y(gf_state->getPos().y());
 	  state->set_z(gf_state->getPos().z());
@@ -573,9 +569,7 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 		  out_track->set_error(i,j, gf_state->get6DCov()[i][j]);
 		}
 	    }
-
 	  out_track->insert_state(state);
-
 	}
 
 	return out_track;

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -170,6 +170,14 @@ public:
 		_N_DETECTOR_LAYER = _phg4hits_names.size();
 	}
 
+	void set_state_names(const std::string* stateNames, const int nlayer) {
+		_state_names.clear();
+		for(int i=0;i<nlayer;++i) {
+			_state_names.push_back(stateNames[i]);
+		}
+		_N_STATES = _state_names.size();
+	}
+
 	double get_z_resolution() const {
 		return _z_resolution;
 	}
@@ -342,6 +350,10 @@ private:
 	//!
 	int _N_DETECTOR_LAYER;
 
+	//!
+	int _N_STATES;
+	std::vector<std::string> _state_names;
+	std::vector<double> _state_location;
 
 
 };

--- a/simulation/g4simulation/g4hough/SvtxTrackState.h
+++ b/simulation/g4simulation/g4hough/SvtxTrackState.h
@@ -52,6 +52,9 @@ public:
   virtual float get_error(unsigned int i, unsigned int j) const {return NAN;}
   virtual void  set_error(unsigned int i, unsigned int j, float value) {}
 
+  virtual std::string get_name(){return "";}
+  virtual void set_name(std::string name){}
+
 protected:
   SvtxTrackState(float pathlength = 0.0) {}
 };

--- a/simulation/g4simulation/g4hough/SvtxTrackState_v1.C
+++ b/simulation/g4simulation/g4hough/SvtxTrackState_v1.C
@@ -18,6 +18,7 @@ SvtxTrackState_v1::SvtxTrackState_v1(float pathlength)
       set_error(i,j,0.0);
     }
   } 
+  state_name = "UNKNOWN"; 
 }
 
 void SvtxTrackState_v1::identify(std::ostream &os) const {

--- a/simulation/g4simulation/g4hough/SvtxTrackState_v1.h
+++ b/simulation/g4simulation/g4hough/SvtxTrackState_v1.h
@@ -54,6 +54,9 @@ public:
   
   float get_error(unsigned int i, unsigned int j) const;
   void  set_error(unsigned int i, unsigned int j, float value);
+
+  std::string get_name(){return state_name;}
+  void set_name(std::string name){state_name = name;}
   
 private:
 
@@ -63,6 +66,8 @@ private:
   float _pos[3];
   float _mom[3];
   float _covar[21]; //  6x6 triangular packed storage
+  
+  std::string state_name; 
 
   ClassDef(SvtxTrackState_v1,1)
 };


### PR DESCRIPTION
This patch utilizes the ability of SvtxTrack to save track states to hold projections of track to different detectors - currently the barrel or forward calorimeters.  These projections can then be used in analysis code, etc., to attach calorimeter clusters to the track, etc. 

For the forward calorimeters I have checked this with the FEMC and FHCAL using 30GeV e-/pi- and the projections to attach the closest FEMC and FHCAL clusters.  The E/p for each is plotted below: 

Electrons: 

![femc_e_over_p_30gev_e-](https://cloud.githubusercontent.com/assets/3042746/19324032/3b10417a-9085-11e6-9886-1f1485efcdfb.png)

Negative Pions: 

![e_over_p_30gev_pi-](https://cloud.githubusercontent.com/assets/3042746/19324048/46b50434-9085-11e6-80b0-d2a49660dac7.png)

There are still a few things I might like to add/fix before merging: 

- The constructor for SvtxTrackState takes the pathlength as the argument, but for now this is either the z-location (for the forward calorimeters) or radial position (for the barrel).  The pathlength must come from the fitted track, but it's not clear to me how to get this.  Ideally you could calculate the pathlength between to states?  Suggestions welcome, I don't see how to get this from the PHGenFit::Track object. 

- The only SvtxTrackState identifier seems to be the pathlength. Ideally we could attach a named tag to each state, like "VERTEX", "FEMC", "IHCAL", etc.   This would make it easier to identify the state (projection) instead of just having to sort based on pathlength.   This is a straightforward fit to add.  
