### PR TITLE
add hit flag for shower studies in prototype

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
@@ -190,6 +190,12 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	  //set the initial energy deposit
 	  hit->set_edep(0);
 	  hit->set_eion(0); // only implemented for v5 otherwise empty
+
+          hit->set_hit_type(0);
+          if( (aTrack->GetParticleDefinition()->GetParticleName().find("e+") != string::npos) ||
+              (aTrack->GetParticleDefinition()->GetParticleName().find("e-") != string::npos) )
+            hit->set_hit_type(1);
+
           PHG4HitContainer *hitcontainer;
 	  if (whichactive > 0) // return of IsInPrototype2InnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
 	    {

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
@@ -190,6 +190,12 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	  //set the initial energy deposit
 	  hit->set_edep(0);
 	  hit->set_eion(0); // only implemented for v5 otherwise empty
+
+          hit->set_hit_type(0);
+          if( (aTrack->GetParticleDefinition()->GetParticleName().find("e+") != string::npos) ||
+              (aTrack->GetParticleDefinition()->GetParticleName().find("e-") != string::npos) )
+            hit->set_hit_type(1);
+
           PHG4HitContainer *hitcontainer;
 	  // here we do things which are different between scintillator and absorber hits
 	  if (whichactive > 0) // return of IsInPrototype2OuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber

--- a/simulation/g4simulation/g4main/PHG4Hit.cc
+++ b/simulation/g4simulation/g4main/PHG4Hit.cc
@@ -27,6 +27,7 @@ PHG4Hit::Copy(PHG4Hit const &g4hit)
 	  set_property_nocheck(prop_id,g4hit.get_property_nocheck(prop_id));
 	}
     }
+  set_hit_type(g4hit.get_hit_type()); 
 }
 
 
@@ -46,6 +47,7 @@ PHG4Hit::identify(ostream& os) const
   cout     << "strip_z_index: " << get_strip_z_index() << ", strip_y_index: " << get_strip_y_index() << endl;
   cout     << "ladder_z_index: " << get_ladder_z_index() << ", ladder_phi_index: " << get_ladder_phi_index() << endl;
   cout << "layer id: " << get_layer() << ", scint_id: " << get_scint_id() << endl;
+  cout << "hit type: " << get_hit_type() << endl; 
   return;
 }
 
@@ -112,6 +114,8 @@ PHG4Hit::get_property_info(const PROPERTY prop_id)
     return make_pair("generic index k",PHG4Hit::type_int);
   case   prop_index_l:
     return make_pair("generic index l",PHG4Hit::type_int);
+  case   prop_hit_type:
+    return make_pair("hit type",PHG4Hit::type_int);    
   default:
     cout << "PHG4Hit::get_property_info - Fatal Error - unknown index " << prop_id << endl;
     exit(1);

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -45,6 +45,7 @@ class PHG4Hit: public PHObject
   virtual int get_index_j() const {return INT_MIN;}
   virtual int get_index_k() const {return INT_MIN;}
   virtual int get_index_l() const {return INT_MIN;}
+  virtual int get_hit_type() const {return INT_MIN;}
 
   virtual void set_x(const int i, const float f) {return;}
   virtual void set_y(const int i, const float f) {return;}
@@ -74,6 +75,7 @@ class PHG4Hit: public PHObject
   virtual void set_index_j(const int i) {return;}
   virtual void set_index_k(const int i) {return;}
   virtual void set_index_l(const int i) {return;}
+  virtual void set_hit_type(const int i) {return;}
 
   virtual float get_avg_x() const;
   virtual float get_avg_y() const;
@@ -138,6 +140,8 @@ class PHG4Hit: public PHObject
     prop_index_k = 123,
     prop_index_l = 124,
 
+    //! hit type
+    prop_hit_type = 125,
 
 
     //! max limit in order to fit into 8 bit unsigned number

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -67,6 +67,7 @@ class PHG4Hitv1 : public PHG4Hit
   virtual int get_index_j() const {return  get_property_int(prop_index_j);}
   virtual int get_index_k() const {return  get_property_int(prop_index_k);}
   virtual int get_index_l() const {return  get_property_int(prop_index_l);}
+  virtual int get_hit_type() const {return  get_property_int(prop_hit_type);}
 
   virtual void set_px(const int i, const float f);
   virtual void set_py(const int i, const float f);
@@ -88,6 +89,7 @@ class PHG4Hitv1 : public PHG4Hit
   virtual void set_index_j(const int i)  {set_property(prop_index_j,i);}
   virtual void set_index_k(const int i)  {set_property(prop_index_k,i);}
   virtual void set_index_l(const int i)  {set_property(prop_index_l,i);}
+  virtual void set_hit_type(const int i) {set_property(prop_hit_type,i);}
 
  protected:
   unsigned int get_property_nocheck(const PROPERTY prop_id) const;


### PR DESCRIPTION
This patch adds a hit_type property to PHG4Hit and makes use of it in the inner and outer HCAL prototype stepping actions. This allows one to flag hits that have an EM (e+/e-) or hadronic (all others) origin very easily at the hist stage to facilitate studies of the HCAL signal shapes and the correlations with fluctuations in the EM fraction of the showers. 