### PR TITLE
Saturation Correction

### DIFF
--- a/offline/packages/Prototype2/PROTOTYPE2_FEM.C
+++ b/offline/packages/Prototype2/PROTOTYPE2_FEM.C
@@ -136,6 +136,15 @@ PROTOTYPE2_FEM::SampleFit_PowerLawExp(//
   fits.SetParLimits(4, pedestal - abs(peakval), pedestal + abs(peakval));
 //  fits.SetParLimits(5, - abs(peakval),  + abs(peakval));
   fits.FixParameter(5, 0);
+
+  //Saturation correction - Abhisek
+   for(int ipoint=0; ipoint<gpulse.GetN(); ipoint++)
+    if((gpulse.GetY())[ipoint]==0)
+     {
+      gpulse.RemovePoint(ipoint);
+      ipoint--;
+     }
+
   gpulse.Fit(&fits, "MQRN0", "goff", 0., (double) NSAMPLES);
 
   if (verbosity)


### PR DESCRIPTION
Saturation correction to the ADC timing samples. After discussing in the HCAL workfest we decided to redo the signal fits without the saturation points. This would potentially improve nonlinearity observed in HCAL test beam performance. Below is an example:
Fit with saturated points:
![before_corr](https://cloud.githubusercontent.com/assets/10897950/19695769/70f26ae8-9ab2-11e6-9294-c73a2cbf42be.png)

Fit without saturation points:
![after_corr](https://cloud.githubusercontent.com/assets/10897950/19695805/98f60388-9ab2-11e6-818d-9daa173936fb.png)

