### PR TITLE
Add a36 and 1006 steel and use for prototype (a36) and outer hcal (1006)

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -191,7 +191,7 @@ PHG4OuterHcalSubsystem::SetDefaultParameters()
   set_default_int_param("n_scinti_plates", 5*64);
   set_default_int_param("n_scinti_tiles", 12);
 
-  set_default_string_param("material", "G4_Fe");
+  set_default_string_param("material", "Steel_1006");
 }
 
 PHG4TrackingAction*

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -140,7 +140,7 @@ PHG4Prototype2InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
 					 zero, 1.0);
 
       volume_steel = steel_plate->GetCubicVolume()*n_steel_plates;
-      innerhcalsteelplate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("SS310"),"InnerHcalSteelPlate", 0, 0, 0);
+      innerhcalsteelplate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("Steel_A36"),"InnerHcalSteelPlate", 0, 0, 0);
       G4VisAttributes* visattchk = new G4VisAttributes();
       visattchk->SetVisibility(true);
       visattchk->SetForceSolid(false);

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -143,7 +143,7 @@ PHG4Prototype2OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
 					 zero, 1.0);
 
       volume_steel = steel_plate->GetCubicVolume()*n_steel_plates;
-      outerhcalsteelplate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("SS310"),"OuterHcalSteelPlate", 0, 0, 0);
+      outerhcalsteelplate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("Steel_A36"),"OuterHcalSteelPlate", 0, 0, 0);
       G4VisAttributes* visattchk = new G4VisAttributes();
       visattchk->SetVisibility(true);
       visattchk->SetForceSolid(false);

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -672,6 +672,7 @@ PHG4Reco::DefineMaterials()
   G4Element *C  = nist->FindOrBuildElement("C");
   G4Element *Cr  = nist->FindOrBuildElement("Cr");
   G4Element *Cs  = nist->FindOrBuildElement("Cs");
+  G4Element *Cu  = nist->FindOrBuildElement("Cu");
   G4Element *F  = nist->FindOrBuildElement("F");
   G4Element *Fe  = nist->FindOrBuildElement("Fe");
   G4Element *H  = nist->FindOrBuildElement("H");
@@ -740,6 +741,19 @@ PHG4Reco::DefineMaterials()
   Steel->AddElement(C, 0.0017);
   Steel->AddElement(S, 0.00045);
   Steel->AddElement(P, 0.00045);
+
+  // a36 steel from http://www.matweb.com
+  G4Material *a36 = new G4Material("Steel_A36",density = 7.85*g/cm3,ncomponents = 5);
+  a36->AddElement(Fe, 0.9824);
+  a36->AddElement(Cu,0.002);
+  a36->AddElement(C,0.0025);
+  a36->AddElement(Mn,0.0103);
+  a36->AddElement(Si,0.0028);
+
+  // 1006 steel from http://www.matweb.com
+  G4Material *steel_1006 = new G4Material("Steel_1006",density = 7.872*g/cm3,ncomponents = 2);
+  steel_1006->AddElement(Fe, 0.996);
+  steel_1006->AddElement(Mn,0.004);
 
   // from www.aalco.co.uk
   G4Material *Al5083 = new G4Material("Al5083", density = 2.65*g/cm3, ncomponents = 3);


### PR DESCRIPTION
Up to now we used SS310 for the hcal prototype steel and G4_Fe for the outer hcal. The prototypes are made of a36 and the outer hcal will use 1006. Those materials were added (from the compositions as listed in http://www.matweb.com) and are now the defaults for the prototypes and outer hcal