### PR TITLE
Signal peak fit for calorimeter prototype2 analysis

### DIFF
--- a/offline/packages/Prototype2/PROTOTYPE2_FEM.C
+++ b/offline/packages/Prototype2/PROTOTYPE2_FEM.C
@@ -157,8 +157,14 @@ PROTOTYPE2_FEM::SampleFit_PowerLawExp(//
       sleep(1);
     }
 
-  peak = fits.GetParameter(0);
-  peak_sample = fits.GetParameter(1);
+//  peak = fits.GetParameter(0); // not exactly peak height
+  peak = (fits.GetParameter(0)*pow(fits.GetParameter(2)/fits.GetParameter(3),fits.GetParameter(2)))/exp(fits.GetParameter(2));// exact peak height is (p0*Power(p2/p3,p2))/Power(E,p2)
+
+//  peak_sample = fits.GetParameter(1); // signal start time
+  peak_sample = fits.GetParameter(1) + fits.GetParameter(2)/fits.GetParameter(3); // signal peak time
+
+  // peak integral = p0*Power(p3,-1 - p2)*Gamma(1 + p2). Note yet used in output
+
   pedstal = fits.GetParameter(4);
 
   return true;


### PR DESCRIPTION
Following #204 , in which @sen1 suggest ignore saturated ADC sample in prototype2 signal fit, we found the fit result in tower energy still suffers from saturation. The problem trace to the choice of fit parameter that is output as energy in ```PROTOTYPE2_FEM.C```. In the current version, the scale constant in front of the signal shape function is returned as tower energy. However, as signal saturates, the shape changes and the scale constant does not represents the energy anymore. 

Therefore, this pull request change the fit to return true ADC-VS-time peak height as energy in a tower, which is calculated analytically in 	3126ef5 . Test production show improved HCal linearity and slightly improved EMCal resolution after this change. 

## HCal Tests

See Hcal test in Abhisek's talk in HCal meeting https://indico.bnl.gov/conferenceDisplay.py?confId=2498

## EMCal Tests

Here is comparison for production QA plot for 8 GeV EMCal 5x5 energy resolution with inclusive hodoscope cut (accept all 8x8 fingers) in run 2609
 
Last production before this change in 
```/gpfs/mnt/gpfs02/sphenix/data/data01/t1044-2016a/production/Production_0715_EMCalSet2_HCalPR12```
![image](https://cloud.githubusercontent.com/assets/7947083/19941142/5dc8762a-a105-11e6-8fc0-699c4692da0e.png)

New production with this change in 
```/gpfs/mnt/gpfs02/sphenix/data/data01/t1044-2016a/production/Production_1101_EMCalSet2_HCalPR12```
![image](https://cloud.githubusercontent.com/assets/7947083/19941489/a96aa034-a106-11e6-90b6-3f8dcc315afe.png)

New code improved resolution for 8 GeV electron by 4% relatively. New production are being produced at 
```/gpfs/mnt/gpfs02/sphenix/data/data01/t1044-2016a/production/Production_1101_EMCalSet2_HCalPR12```