### PR TITLE
Enable tracking for all tracks, not just primaries

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -66,7 +66,7 @@ PHG4TrackFastSim::PHG4TrackFastSim(const std::string &name) :
 				false), _use_vertex_in_fitting(true), _vertex_xy_resolution(
 				50E-4), _vertex_z_resolution(50E-4), _phi_resolution(50E-4), _r_resolution(
 				1.), _z_resolution(50E-4), _pat_rec_hit_finding_eff(1.), _pat_rec_noise_prob(0.), 
-		                _N_DETECTOR_LAYER(5), _N_STATES(0) {
+		                _N_DETECTOR_LAYER(5), _primary_tracking(1), _N_STATES(0) {
 
 	_event = -1;
 
@@ -197,85 +197,95 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 
 	vector<genfit::Track*> rf_gf_tracks;
 
-	for (PHG4TruthInfoContainer::ConstIterator itr =
-			_truth_container->GetPrimaryParticleRange().first;
-			itr != _truth_container->GetPrimaryParticleRange().second; ++itr) {
-		PHG4Particle* particle = itr->second;
+	PHG4TruthInfoContainer::ConstRange itr_range; 
+	if(_primary_tracking){
+	  // Tracking for primaries only
+	  itr_range = _truth_container->GetPrimaryParticleRange();
+	}
+	else{
+	  // Check ALL particles
+	  itr_range = _truth_container->GetParticleRange();
+	}
+	
+	for (PHG4TruthInfoContainer::ConstIterator itr = itr_range.first;
+	     itr != itr_range.second; ++itr) {
+	  PHG4Particle* particle = itr->second;
 
-		TVector3 seed_pos(0, 0, 0);
-		TVector3 seed_mom(0, 0, 0);
-		TMatrixDSym seed_cov(6);
+	  TVector3 seed_pos(0, 0, 0);
+	  TVector3 seed_mom(0, 0, 0);
+	  TMatrixDSym seed_cov(6);
 
-		//! Create measurements
-		std::vector<PHGenFit::Measurement*> measurements;
+	  //! Create measurements
+	  std::vector<PHGenFit::Measurement*> measurements;
 
-//		_use_vertex_in_fitting = true;
+	  //		_use_vertex_in_fitting = true;
 
-		PHGenFit::Measurement* vtx_meas = NULL;
+	  PHGenFit::Measurement* vtx_meas = NULL;
 
-		if (_use_vertex_in_fitting) {
-			vtx_meas = VertexMeasurement(TVector3(0, 0, 0),
-					_vertex_xy_resolution, _vertex_z_resolution);
-			measurements.push_back(vtx_meas);
-		}
+	  if (_use_vertex_in_fitting) {
+	    vtx_meas = VertexMeasurement(TVector3(0, 0, 0),
+					 _vertex_xy_resolution, _vertex_z_resolution);
+	    measurements.push_back(vtx_meas);
+	  }
 
-		PseudoPatternRecognition(particle, measurements, seed_pos, seed_mom,
-				seed_cov);
+	  PseudoPatternRecognition(particle, measurements, seed_pos, seed_mom,
+				   seed_cov);
 
-		if (measurements.size() < 3) {
-			if (verbosity >= 2) {
-				//LogWarning("measurements.size() < 3");
-				std::cout << "event: " << _event << " : measurements.size() < 3"
-						<< "\n";
-			}
-			continue;
-		}
+	  if (measurements.size() < 3) {
+	    if (verbosity >= 2) {
+	      //LogWarning("measurements.size() < 3");
+	      std::cout << "event: " << _event << " : measurements.size() < 3"
+			<< "\n";
+	    }
+	    continue;
+	  }
 
-		//! Build TrackRep from particle assumption
-		/*!
-		 * mu+:	-13
-		 * mu-:	13
-		 * pi+:	211
-		 * pi-:	-211
-		 * e-:	11
-		 * e+:	-11
-		 */
-		//int pid = 13; //
-		//SMART(genfit::AbsTrackRep) rep = NEW(genfit::RKTrackRep)(pid);
-		genfit::AbsTrackRep* rep = new genfit::RKTrackRep(
-				_primary_assumption_pid);
+	  //! Build TrackRep from particle assumption
+	  /*!
+	   * mu+:	-13
+	   * mu-:	13
+	   * pi+:	211
+	   * pi-:	-211
+	   * e-:	11
+	   * e+:	-11
+	   */
+	  //int pid = 13; //
+	  //SMART(genfit::AbsTrackRep) rep = NEW(genfit::RKTrackRep)(pid);
+	  genfit::AbsTrackRep* rep = new genfit::RKTrackRep(
+							    _primary_assumption_pid);
 
-		//rep->setDebugLvl(1); //DEBUG
+	  //rep->setDebugLvl(1); //DEBUG
 
-		//! Initiallize track with seed from pattern recognition
-		PHGenFit::Track* track = new PHGenFit::Track(rep, seed_pos, seed_mom,
-				seed_cov);
+	  //! Initiallize track with seed from pattern recognition
+	  PHGenFit::Track* track = new PHGenFit::Track(rep, seed_pos, seed_mom,
+						       seed_cov);
 
-		rf_gf_tracks.push_back(track->getGenFitTrack());
+	  rf_gf_tracks.push_back(track->getGenFitTrack());
 
-		//LogDEBUG;
-		//! Add measurements to track
-		track->addMeasurements(measurements);
+	  //LogDEBUG;
+	  //! Add measurements to track
+	  track->addMeasurements(measurements);
 
-		//LogDEBUG;
-		//! Fit the track
-		int fitting_err = _fitter->processTrack(track, false);
+	  //LogDEBUG;
+	  //! Fit the track
+	  int fitting_err = _fitter->processTrack(track, false);
 
-		if (fitting_err != 0) {
-			if (verbosity >= 2) {
-				//LogWarning("measurements.size() < 3");
-				std::cout << "event: " << _event
-						<< " : fitting_err != 0, next track." << "\n";
-			}
-			continue;
-		}
+	  if (fitting_err != 0) {
+	    if (verbosity >= 2) {
+	      //LogWarning("measurements.size() < 3");
+	      std::cout << "event: " << _event
+			<< " : fitting_err != 0, next track." << "\n";
+	    }
+	    continue;
+	  }
 
-		SvtxTrack* svtx_track_out = MakeSvtxTrack(track,
-				particle->get_track_id());
+	  SvtxTrack* svtx_track_out = MakeSvtxTrack(track,
+						    particle->get_track_id());
 
-		if(svtx_track_out) _trackmap_out->insert(svtx_track_out);
+	  if(svtx_track_out) _trackmap_out->insert(svtx_track_out);
 
 	} // Loop all primary particles
+
 
 	//! add tracks to event display
 	if (_do_evt_display)

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -242,6 +242,10 @@ public:
 		_primary_assumption_pid = primaryAssumptionPid;
 	}
 
+	void set_primary_tracking(int pTrk) {
+	        _primary_tracking = pTrk; 
+	}
+
 private:
 
 	/*!
@@ -346,9 +350,11 @@ private:
 	//!
 	double _pat_rec_noise_prob;
 
-
 	//!
 	int _N_DETECTOR_LAYER;
+
+	//! 
+	int _primary_tracking; 
 
 	//!
 	int _N_STATES;


### PR DESCRIPTION
Submitted for consideration, although I am sure this is not the last word.  Currently PHG4TrackFastSim only checks primary tracks for fast tracking. This modification leaves primary tracks as the default, but enables a switch to search all tracks  (set in G4_FGEM_fsPHENIX.C:FGEM_FastSim_Reco): 

  kalman->set_primary_tracking(0); // 0=all tracks, >0 = primaries only

I could use some advice here - it seems that PHG4TruthInfoContainer makes some distinction between tracks and showers, so this isn't horribly inefficient in the sense that it searches over all tracks in an EM shower, but I am uncertain how the truth tracking is done so this interpretation may not be correct. Another way to do this would be to just combine hits in the FGEM's from the same tracks, but that is more complicated and potentially biased if you are not careful. 

I ran tests with this using single e-, pi- as well as DY and MB events and although the time per event did not increase by huge factors, although I didn't time it closely.  The output is seeing tracks found that do not match up to primaries in my evaluator code. 

Finally, when running over all tracks there are more messages in the err files like: 

Error in <TDecompChol::Decompose()>: matrix not positive definite
genfit::Exception thrown with excString:
KalmanFitterInfo::calcAverageState: ill-conditioned covariance matrix.
in line: 149 in file: /phenix/u/phnxbld/workarea/sPHENIX/genfit/genfit/core/src/MeasuredStateOnPlane.cc
with fatal flag 0

or

genfit::Exception thrown with excString:
MaterialEffects::getMomGammaBeta - Energy <= mass
in line: 362 in file: /phenix/u/phnxbld/workarea/sPHENIX/genfit/genfit/trackReps/src/MaterialEffects.cc
with fatal flag 0

which I think makes perfect sense - we are now handing GenFit some pretty ragged tracks from secondaries, and things like the initial momenta and particle type choice may not be valid. 

