### PR TITLE
Keep track of number of hits for fast sim track

### DIFF
--- a/generators/PHPythia6/PHPy6ForwardElectronTrig.C
+++ b/generators/PHPythia6/PHPy6ForwardElectronTrig.C
@@ -20,7 +20,7 @@ PHPy6ForwardElectronTrig::PHPy6ForwardElectronTrig(const std::string &name): PHP
   n_em_required = 1; 
   n_ep_required = 1; 
   n_comb_required = 1; 
-  ptot_required = 1.0; 
+  pt_required = 0.5; 
   eta_low = 1.0; 
   eta_high = 5.0; 
 
@@ -37,9 +37,9 @@ void PHPy6ForwardElectronTrig::PrintConfig()
   cout << endl; 
   cout << "PHPy6ForwardElectronTrig Configuration: " << endl; 
   cout << " >=" << n_ep_required << " e+ required" << endl; 
-  cout << " >=" << n_em_required << " em required" << endl; 
+  cout << " >=" << n_em_required << " e- required" << endl; 
   cout << " >=" << n_comb_required << " combined required" << endl; 
-  cout << " Electron total momentum > " << ptot_required << " GeV required" << endl; 
+  cout << " Electron transverse momentum > " << pt_required << " GeV required" << endl; 
   cout << " " << eta_low << " < eta < " << eta_high << endl; 
 
   if(RequireElectron) cout << " RequireElectron is set" << endl;
@@ -74,7 +74,7 @@ bool PHPy6ForwardElectronTrig::Apply( const HepMC::GenEvent* evt )
 	  = evt->particles_begin(); p != evt->particles_end(); ++p ){
     if ( (abs((*p)->pdg_id()) == 11) && ((*p)->status()==1) && 
 	 ((*p)->momentum().pseudoRapidity() > eta_low) && ((*p)->momentum().pseudoRapidity() < eta_high) && 
-	 (sqrt(pow((*p)->momentum().px(),2) + pow((*p)->momentum().py(),2) + pow((*p)->momentum().pz(),2))>ptot_required) ) {
+	 (sqrt(pow((*p)->momentum().px(),2) + pow((*p)->momentum().py(),2))>pt_required) ) {
       if(((*p)->pdg_id()) == 11) n_em_found++;
       if(((*p)->pdg_id()) == -11) n_ep_found++;
     }

--- a/generators/PHPythia6/PHPy6ForwardElectronTrig.h
+++ b/generators/PHPythia6/PHPy6ForwardElectronTrig.h
@@ -26,7 +26,7 @@ class PHPy6ForwardElectronTrig: public PHPy6GenTrigger
   void set_electrons_required(int n){n_ep_required = n;}
   void set_positrons_required(int n){n_em_required = n;}
   void set_combined_required(int n){n_comb_required = n;}
-  void set_ptot_required(float set_ptot){ptot_required = set_ptot;}
+  void set_pt_required(float set_pt){pt_required = set_pt;}
   void set_eta_range(float set_eta_low, float set_eta_high){eta_low = set_eta_low; eta_high = set_eta_high;}
 
   void PrintConfig(); 
@@ -51,7 +51,7 @@ class PHPy6ForwardElectronTrig: public PHPy6GenTrigger
   unsigned int n_ep_required; 
   unsigned int n_em_required; 
   unsigned int n_comb_required; 
-  float ptot_required; 
+  float pt_required; 
   float eta_low; 
   float eta_high; 
   

--- a/generators/PHPythia6/PHPythia6.C
+++ b/generators/PHPythia6/PHPythia6.C
@@ -50,8 +50,7 @@ PHPythia6::PHPythia6(const std::string &name):
   _filename_ascii("pythia_hepmc.dat"),
   _registeredTriggers(),
   _triggersOR(true),
-  _triggersAND(false),
-  fSeed(-1){
+  _triggersAND(false){
 
   //RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
 }
@@ -77,39 +76,10 @@ int PHPythia6::Init(PHCompositeNode *topNode) {
   HepMC::HEPEVT_Wrapper::set_max_number_entries(4000);
   HepMC::HEPEVT_Wrapper::set_sizeof_real(8);
 
-  /* set pythia random number seed (mandatory!) */
-
-  if ( fSeed < 0 ){
-    // first try getting seed from /dev/random
-    ifstream devrandom;
-    devrandom.open("/dev/random",ios::binary);
-    devrandom.read((char*)&fSeed,sizeof(fSeed));
-    devrandom.close();
-	    
-    if ( fSeed != -1 )
-      {
-	cout << PHWHERE << " Got seed from /dev/random" << endl;
-	fSeed = abs(fSeed)%900000000;
-      }
-    else
-      {
-	// /dev/random failed, get the random seed from the time of day, to the microsecond
-	//fSeed = (Int_t)(time(NULL)/3);
-	cout << PHWHERE << " Getting seed from gettimeofday()" << endl;
-	timeval xtime;
-	int status = gettimeofday(&xtime,NULL);
-	if ( status==0 )
-	  {
-	    fSeed = ((xtime.tv_sec << 12) + (xtime.tv_usec&0xfff))%900000000;
-	  }
-	else
-	  {
-	    cout << PHWHERE << " something wrong with gettimeofday()" << endl;
-	  }
-      }
-  }
-	  
-	  
+  /* set pythia random number seed (mandatory!) */  
+  int fSeed = PHRandomSeed(); 
+  fSeed = abs(fSeed)%900000000;
+	    	  	  
   if ( (fSeed>=0) && (fSeed<=900000000) ) {
     pydatr.mrpy[0] = fSeed;                   // set seed
     pydatr.mrpy[1] = 0;                       // use new seed

--- a/generators/PHPythia6/PHPythia6.h
+++ b/generators/PHPythia6/PHPythia6.h
@@ -50,9 +50,6 @@ public:
   void set_trigger_OR() { _triggersOR = true; } // default true
   void set_trigger_AND() { _triggersAND = true; }
 
-  //! Set Seed of random number generator
-  void SetSeed(const int s) { fSeed = s; }
-
 private:
 
   int ReadConfig(const std::string cfg_file = "");
@@ -90,9 +87,6 @@ private:
   std::vector<PHPy6GenTrigger*> _registeredTriggers;
   bool _triggersOR;
   bool _triggersAND;
-
-  // Seed selection
-  int fSeed; 
  
   /**
    * definition needed to use pythia wrapper headers from HepMC

--- a/generators/PHPythia6/PHPythia6.h
+++ b/generators/PHPythia6/PHPythia6.h
@@ -50,6 +50,9 @@ public:
   void set_trigger_OR() { _triggersOR = true; } // default true
   void set_trigger_AND() { _triggersAND = true; }
 
+  //! Set Seed of random number generator
+  void SetSeed(const int s) { fSeed = s; }
+
 private:
 
   int ReadConfig(const std::string cfg_file = "");
@@ -87,6 +90,9 @@ private:
   std::vector<PHPy6GenTrigger*> _registeredTriggers;
   bool _triggersOR;
   bool _triggersAND;
+
+  // Seed selection
+  int fSeed; 
  
   /**
    * definition needed to use pythia wrapper headers from HepMC

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -280,7 +280,8 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 	  }
 
 	  SvtxTrack* svtx_track_out = MakeSvtxTrack(track,
-						    particle->get_track_id());
+						    particle->get_track_id(),
+						    measurements.size());
 
 	  if(svtx_track_out) _trackmap_out->insert(svtx_track_out);
 
@@ -474,7 +475,8 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
 }
 
 SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
-		const unsigned int truth_track_id) {
+					   const unsigned int truth_track_id, 
+					   const unsigned int nmeas) {
 
 	double chi2 = phgf_track->get_chi2();
 	double ndf = phgf_track->get_ndf();
@@ -506,7 +508,7 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 //	SvtxTrack_v1* out_track = new SvtxTrack_v1(*static_cast<const SvtxTrack_v1*> (svtx_track));
 //	SvtxTrack_v1* out_track = new SvtxTrack_v1();
 
-	SvtxTrack* out_track = new SvtxTrack_FastSim();
+	SvtxTrack_FastSim *out_track = new SvtxTrack_FastSim();
 	out_track->set_truth_track_id(truth_track_id);
 	/*!
 	 * TODO: check the definition
@@ -526,6 +528,9 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 	out_track->set_charge(
 			(_reverse_mag_field) ?
 					-1. * phgf_track->get_charge() : phgf_track->get_charge());
+
+	out_track->set_num_measurements(nmeas); 
+
 	out_track->set_px(mom.Px());
 	out_track->set_py(mom.Py());
 	out_track->set_pz(mom.Pz());
@@ -582,7 +587,7 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 	  out_track->insert_state(state);
 	}
 
-	return out_track;
+	return (SvtxTrack *)out_track;
 }
 
 PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementVerticalPlane(

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -275,7 +275,9 @@ private:
 	/*!
 	 * Make SvtxTrack from PHGenFit::Track
 	 */
-	SvtxTrack* MakeSvtxTrack(const PHGenFit::Track* phgf_track_in, const unsigned int truth_track_id = UINT_MAX);
+	SvtxTrack* MakeSvtxTrack(const PHGenFit::Track* phgf_track_in, 
+				 const unsigned int truth_track_id = UINT_MAX,
+				 const unsigned int nmeas = 0);
 
 	//! Event counter
 	int _event;

--- a/simulation/g4simulation/g4hough/SvtxTrack_FastSim.C
+++ b/simulation/g4simulation/g4hough/SvtxTrack_FastSim.C
@@ -14,7 +14,7 @@ ClassImp(SvtxTrack_FastSim)
 using namespace std;
 
 SvtxTrack_FastSim::SvtxTrack_FastSim() :
-		_truth_track_id(UINT_MAX) {
+  _truth_track_id(UINT_MAX),_nmeas(0) {
 }
 
 SvtxTrack_FastSim::~SvtxTrack_FastSim() {

--- a/simulation/g4simulation/g4hough/SvtxTrack_FastSim.h
+++ b/simulation/g4simulation/g4hough/SvtxTrack_FastSim.h
@@ -30,9 +30,13 @@ public:
 	int  isValid() const;
 	SvtxTrack* Clone() const {return new SvtxTrack_FastSim(*this);}
 
+	void set_num_measurements(int nmeas) {_nmeas = nmeas;} 
+	unsigned int get_num_measurements() {return _nmeas;} 
+
 private:
 
 	unsigned int _truth_track_id;
+	unsigned int _nmeas; 
 
 
 	ClassDef(SvtxTrack_FastSim,1)


### PR DESCRIPTION
Submitted for your consideration - it would be very useful to keep track of *at least* the number of hits on a FastSim track, especially when looking at all tracks and not just primary tracks.  The evaluation software from Haiwang uses the "size_clusters()" method to extract the number of hits on the track, but in SvtxTrack this is meant to keep track of the number of calorimeter clusters attached to the track, and in any case PHG4TrackFastSim does nothing to fill it. 

The attached patch just adds the ability to store the number of measurements along the track in SvtxTrack_FastSim and adds the code to PHG4TrackFastSim to initialize it.  

It might be nice to store an id/pointer to the detector-specific hits instead, but this should be done in a more general way that will ultimately interface with the TPC, etc.  I thought about this but decided I don't really know enough to do this in a general way at this point. 
