### PR TITLE
Fix PHPythia6 random seed, set electron trigger to use pT (not ptot)

### DIFF
--- a/generators/PHPythia6/PHPy6ForwardElectronTrig.C
+++ b/generators/PHPythia6/PHPy6ForwardElectronTrig.C
@@ -20,7 +20,7 @@ PHPy6ForwardElectronTrig::PHPy6ForwardElectronTrig(const std::string &name): PHP
   n_em_required = 1; 
   n_ep_required = 1; 
   n_comb_required = 1; 
-  ptot_required = 1.0; 
+  pt_required = 0.5; 
   eta_low = 1.0; 
   eta_high = 5.0; 
 
@@ -37,9 +37,9 @@ void PHPy6ForwardElectronTrig::PrintConfig()
   cout << endl; 
   cout << "PHPy6ForwardElectronTrig Configuration: " << endl; 
   cout << " >=" << n_ep_required << " e+ required" << endl; 
-  cout << " >=" << n_em_required << " em required" << endl; 
+  cout << " >=" << n_em_required << " e- required" << endl; 
   cout << " >=" << n_comb_required << " combined required" << endl; 
-  cout << " Electron total momentum > " << ptot_required << " GeV required" << endl; 
+  cout << " Electron transverse momentum > " << pt_required << " GeV required" << endl; 
   cout << " " << eta_low << " < eta < " << eta_high << endl; 
 
   if(RequireElectron) cout << " RequireElectron is set" << endl;
@@ -74,7 +74,7 @@ bool PHPy6ForwardElectronTrig::Apply( const HepMC::GenEvent* evt )
 	  = evt->particles_begin(); p != evt->particles_end(); ++p ){
     if ( (abs((*p)->pdg_id()) == 11) && ((*p)->status()==1) && 
 	 ((*p)->momentum().pseudoRapidity() > eta_low) && ((*p)->momentum().pseudoRapidity() < eta_high) && 
-	 (sqrt(pow((*p)->momentum().px(),2) + pow((*p)->momentum().py(),2) + pow((*p)->momentum().pz(),2))>ptot_required) ) {
+	 (sqrt(pow((*p)->momentum().px(),2) + pow((*p)->momentum().py(),2))>pt_required) ) {
       if(((*p)->pdg_id()) == 11) n_em_found++;
       if(((*p)->pdg_id()) == -11) n_ep_found++;
     }

--- a/generators/PHPythia6/PHPy6ForwardElectronTrig.h
+++ b/generators/PHPythia6/PHPy6ForwardElectronTrig.h
@@ -26,7 +26,7 @@ class PHPy6ForwardElectronTrig: public PHPy6GenTrigger
   void set_electrons_required(int n){n_ep_required = n;}
   void set_positrons_required(int n){n_em_required = n;}
   void set_combined_required(int n){n_comb_required = n;}
-  void set_ptot_required(float set_ptot){ptot_required = set_ptot;}
+  void set_pt_required(float set_pt){pt_required = set_pt;}
   void set_eta_range(float set_eta_low, float set_eta_high){eta_low = set_eta_low; eta_high = set_eta_high;}
 
   void PrintConfig(); 
@@ -51,7 +51,7 @@ class PHPy6ForwardElectronTrig: public PHPy6GenTrigger
   unsigned int n_ep_required; 
   unsigned int n_em_required; 
   unsigned int n_comb_required; 
-  float ptot_required; 
+  float pt_required; 
   float eta_low; 
   float eta_high; 
   

--- a/generators/PHPythia6/PHPythia6.C
+++ b/generators/PHPythia6/PHPythia6.C
@@ -50,8 +50,7 @@ PHPythia6::PHPythia6(const std::string &name):
   _filename_ascii("pythia_hepmc.dat"),
   _registeredTriggers(),
   _triggersOR(true),
-  _triggersAND(false),
-  fSeed(-1){
+  _triggersAND(false){
 
   //RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
 }
@@ -77,39 +76,10 @@ int PHPythia6::Init(PHCompositeNode *topNode) {
   HepMC::HEPEVT_Wrapper::set_max_number_entries(4000);
   HepMC::HEPEVT_Wrapper::set_sizeof_real(8);
 
-  /* set pythia random number seed (mandatory!) */
-
-  if ( fSeed < 0 ){
-    // first try getting seed from /dev/random
-    ifstream devrandom;
-    devrandom.open("/dev/random",ios::binary);
-    devrandom.read((char*)&fSeed,sizeof(fSeed));
-    devrandom.close();
-	    
-    if ( fSeed != -1 )
-      {
-	cout << PHWHERE << " Got seed from /dev/random" << endl;
-	fSeed = abs(fSeed)%900000000;
-      }
-    else
-      {
-	// /dev/random failed, get the random seed from the time of day, to the microsecond
-	//fSeed = (Int_t)(time(NULL)/3);
-	cout << PHWHERE << " Getting seed from gettimeofday()" << endl;
-	timeval xtime;
-	int status = gettimeofday(&xtime,NULL);
-	if ( status==0 )
-	  {
-	    fSeed = ((xtime.tv_sec << 12) + (xtime.tv_usec&0xfff))%900000000;
-	  }
-	else
-	  {
-	    cout << PHWHERE << " something wrong with gettimeofday()" << endl;
-	  }
-      }
-  }
-	  
-	  
+  /* set pythia random number seed (mandatory!) */  
+  int fSeed = PHRandomSeed(); 
+  fSeed = abs(fSeed)%900000000;
+	    	  	  
   if ( (fSeed>=0) && (fSeed<=900000000) ) {
     pydatr.mrpy[0] = fSeed;                   // set seed
     pydatr.mrpy[1] = 0;                       // use new seed

--- a/generators/PHPythia6/PHPythia6.h
+++ b/generators/PHPythia6/PHPythia6.h
@@ -50,9 +50,6 @@ public:
   void set_trigger_OR() { _triggersOR = true; } // default true
   void set_trigger_AND() { _triggersAND = true; }
 
-  //! Set Seed of random number generator
-  void SetSeed(const int s) { fSeed = s; }
-
 private:
 
   int ReadConfig(const std::string cfg_file = "");
@@ -90,9 +87,6 @@ private:
   std::vector<PHPy6GenTrigger*> _registeredTriggers;
   bool _triggersOR;
   bool _triggersAND;
-
-  // Seed selection
-  int fSeed; 
  
   /**
    * definition needed to use pythia wrapper headers from HepMC

--- a/generators/PHPythia6/PHPythia6.h
+++ b/generators/PHPythia6/PHPythia6.h
@@ -50,6 +50,9 @@ public:
   void set_trigger_OR() { _triggersOR = true; } // default true
   void set_trigger_AND() { _triggersAND = true; }
 
+  //! Set Seed of random number generator
+  void SetSeed(const int s) { fSeed = s; }
+
 private:
 
   int ReadConfig(const std::string cfg_file = "");
@@ -87,6 +90,9 @@ private:
   std::vector<PHPy6GenTrigger*> _registeredTriggers;
   bool _triggersOR;
   bool _triggersAND;
+
+  // Seed selection
+  int fSeed; 
  
   /**
    * definition needed to use pythia wrapper headers from HepMC


### PR DESCRIPTION
PHPYthia6 in the sPHENIX repositories was configured to use a hard-coded random seed. Guess how I found this. Guess how much time it wasted. 

This commit modifies PHPythia6 to use the same method to set the random see used in the PHENIX version of PHPythia6, and adds a function to allow the user to set the seed manually. 

This commit also changes the example electron trigger to use PT instead of ptot - this just makes more sense for forward physics.  