### PR TITLE
Shift TPC cluster centers to the corresponding PHG4Hit center

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -205,11 +205,11 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
       double z;
       int phibin;
       int zbin;
-      xinout = hiter->second->get_x(0);
-      yinout = hiter->second->get_y(0);
+      xinout = hiter->second->get_avg_x();
+      yinout = hiter->second->get_avg_y();
       double r = sqrt( xinout*xinout + yinout*yinout );
-      phi = atan2(hiter->second->get_y(0), hiter->second->get_x(0));
-      z =  hiter->second->get_z(0);
+      phi = atan2(hiter->second->get_avg_y(), hiter->second->get_avg_x());
+      z =  hiter->second->get_avg_z();
       
       // apply primary charge distortion
       if( (*layer) >= (unsigned int)num_pixel_layers )
@@ -237,7 +237,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
       if(phibin < 0 || phibin >= nphibins){continue;}
       double phidisp = phi - geo->get_phicenter(phibin);
       
-      zbin = geo->get_zbin( hiter->second->get_z(0) );
+      zbin = geo->get_zbin( hiter->second->get_avg_z() );
       if(zbin < 0 || zbin >= nzbins){continue;}
       double zdisp = z - geo->get_zcenter(zbin);
       
@@ -268,8 +268,8 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
       {
         double nelec = elec_per_kev*1.0e6*edep;
 
-        double cloud_sig_x = 1.5*sqrt( diffusion*diffusion*(100. - TMath::Abs(hiter->second->get_z(0))) + 0.03*0.03 );
-        double cloud_sig_z = 1.5*sqrt((1.+2.2*2.2)*diffusion*diffusion*(100. - TMath::Abs(hiter->second->get_z(0))) + 0.01*0.01 );
+        double cloud_sig_x = 1.5*sqrt( diffusion*diffusion*(100. - TMath::Abs(hiter->second->get_avg_z())) + 0.03*0.03 );
+        double cloud_sig_z = 1.5*sqrt((1.+2.2*2.2)*diffusion*diffusion*(100. - TMath::Abs(hiter->second->get_avg_z())) + 0.01*0.01 );
         
         int n_phi = (int)(3.*( cloud_sig_x/(r*phistepsize) )) + 3;
         int n_z = (int)(3.*( cloud_sig_z/zstepsize )) + 3;

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -250,7 +250,7 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
           SvtxCluster_v1 clus;
           clus.set_layer(layer);
           clus.set_e(e);
-          double radius = geo->get_radius();
+          double radius = geo->get_radius() + 0.5*geo->get_thickness();
           clus.set_position(0, radius * cos(phi));
           clus.set_position(1, radius * sin(phi));
           clus.set_position(2, z);


### PR DESCRIPTION
Changes made to PHG4CylinderCellTPCReco and PHG4TPCClusterizer.
With this change, also when the space charge distortion in PHG4CylinderCellTPCReco turned off.
The TPC cluster pulldistribution w.r.t PHG4Hit looks almost perfect:
![image](https://cloud.githubusercontent.com/assets/10383186/20284348/b28b4082-aa8a-11e6-907c-be4bc98c2d94.png)


Related to [this talk](https://indico.bnl.gov/getFile.py/access?contribId=2&resId=0&materialId=slides&confId=1935)