### PR TITLE
shift hcal tiles so their phi coverage does not change with tilt angle or number of tiles

### DIFF
--- a/generators/PHPythia8/PHPy8GenTrigger.C
+++ b/generators/PHPythia8/PHPy8GenTrigger.C
@@ -8,7 +8,9 @@ using namespace std;
 
 //__________________________________________________________
 PHPy8GenTrigger::PHPy8GenTrigger(const std::string &name):
-_name(name) {}
+  _verbosity(0),
+  _name(name)
+ {}
 
 //__________________________________________________________
 PHPy8GenTrigger::~PHPy8GenTrigger() {}

--- a/generators/PHPythia8/PHPy8JetTrigger.C
+++ b/generators/PHPythia8/PHPy8JetTrigger.C
@@ -13,18 +13,12 @@ using namespace std;
 
 //__________________________________________________________
 PHPy8JetTrigger::PHPy8JetTrigger(const std::string &name):
-  PHPy8GenTrigger(name) {
-  
-  _verbosity = 0;
-  
-  _theEtaLow = 1.0;
-  _theEtaHigh = 4.0; 
-  
-  _minPt = 10.0; 
-
-  _R = 1.0; 
- 
-}
+  PHPy8GenTrigger(name),
+  _theEtaHigh(4.0),
+  _theEtaLow(1.0),
+  _minPt(10.0),
+  _R(1.0)
+ {}
 
 PHPy8JetTrigger::~PHPy8JetTrigger() {
   if (_verbosity > 0) PrintConfig();

--- a/generators/PHPythia8/PHPy8ParticleTrigger.C
+++ b/generators/PHPythia8/PHPy8ParticleTrigger.C
@@ -6,39 +6,36 @@ using namespace std;
 
 //__________________________________________________________
 PHPy8ParticleTrigger::PHPy8ParticleTrigger(const std::string &name):
-  PHPy8GenTrigger(name) {
-  
-  _verbosity = 0;
-  
-  _theEtaHigh = 999.9;
-  _theEtaLow = -999.9;
-  _thePtHigh = 999.9;
-  _thePtLow = -999.9;
-  _thePHigh = 999.9;
-  _thePLow = -999.9;
-  _thePzHigh = 999.9;
-  _thePzLow = -999.9;
-  
-  _doEtaHighCut = false;
-  _doEtaLowCut = false;
-  _doBothEtaCut = false;
+  PHPy8GenTrigger(name),
+  _theEtaHigh(-999.9),
+  _theEtaLow(-999.9),
+  _thePtHigh(999.9),
+  _thePtLow(-999.9),
+  _thePHigh(999.9),
+  _thePLow(-999.9),
+  _thePzHigh(999.9),
+  _thePzLow(-999.9),
 
-  _doAbsEtaHighCut = false;
-  _doAbsEtaLowCut = false;
-  _doBothAbsEtaCut = false;
+  _doEtaHighCut(false),
+  _doEtaLowCut(false),
+  _doBothEtaCut(false),
 
-  _doPtHighCut = false;
-  _doPtLowCut = false;
-  _doBothPtCut = false;
+  _doAbsEtaHighCut(false),
+  _doAbsEtaLowCut(false),
+  _doBothAbsEtaCut(false),
 
-  _doPHighCut = false;
-  _doPLowCut = false;
-  _doBothPCut = false;
+  _doPtHighCut(false),
+  _doPtLowCut(false),
+  _doBothPtCut(false),
 
-  _doPzHighCut = false;
-  _doPzLowCut = false;
-  _doBothPzCut = false;
-}
+  _doPHighCut(false),
+  _doPLowCut(false),
+  _doBothPCut(false),
+
+  _doPzHighCut(false),
+  _doPzLowCut(false),
+  _doBothPzCut(false)
+{}
 
 PHPy8ParticleTrigger::~PHPy8ParticleTrigger() {
   if (_verbosity > 0) PrintConfig();

--- a/generators/PHPythia8/PHPythia8.C
+++ b/generators/PHPythia8/PHPythia8.C
@@ -5,25 +5,11 @@
 #include <phhepmc/PHHepMCGenEvent.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/getClass.h>
-#include <phool/recoConsts.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHDataNode.h>
-#include <phool/PHObject.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>
-#include <phool/PHNodeReset.h>
-#include <phool/PHTimeStamp.h>
 #include <phool/PHRandomSeed.h>
 
-#include <TMCParticle.h>
-#include <TClonesArray.h>
-#include <TFile.h>
-#include <TTree.h>
-#include <TDirectory.h>
-#include <TObjArray.h>
-#include <TParticle.h>
-#include <TRandom.h>
 
 #include <Pythia8/Pythia.h>
 #include <Pythia8Plugins/HepMC2.h>
@@ -31,16 +17,7 @@
 
 #include <gsl/gsl_randist.h>
 
-#include <iostream>
-#include <iomanip>
-#include <fstream>
-#include <sstream>
-#include <cstdlib>
-#include <stdlib.h>
-#include <ctime>
-#include <sys/time.h>
-#include <algorithm>
-#include <cctype>
+#include <TString.h> // needed for Form()
 
 using namespace std;
 
@@ -88,7 +65,7 @@ PHPythia8::PHPythia8(const std::string &name):
 
 PHPythia8::~PHPythia8() {
   gsl_rng_free (RandomGenerator);
-  if (_pythia) delete _pythia;  
+  delete _pythia;  
 }
 
 int PHPythia8::Init(PHCompositeNode *topNode) {
@@ -107,13 +84,7 @@ int PHPythia8::Init(PHCompositeNode *topNode) {
   // I map the designated unique seed from recoconst into something
   // acceptable for PYTHIA8
 
-  recoConsts *rc = recoConsts::instance();
-  unsigned int seed = 0;
-  if (rc->FlagExist("RANDOMSEED")) {
-    seed = std::abs(rc->get_IntFlag("RANDOMSEED"));
-  } else {
-    seed = PHRandomSeed();
-  }
+  unsigned int seed = PHRandomSeed();
 
   if (seed > 900000000) {
     seed = seed % 900000000;
@@ -180,7 +151,6 @@ int PHPythia8::process_event(PHCompositeNode *topNode) {
   
   bool passedGen = false;
   bool passedTrigger = false;
-  std::vector<bool> theTriggerResults;
   int genCounter = 0;
 
   while (!passedTrigger) {

--- a/generators/PHPythia8/PHPythia8.h
+++ b/generators/PHPythia8/PHPythia8.h
@@ -8,23 +8,16 @@
 #include <Pythia8/Pythia.h>
 #endif
 
-#include <Rtypes.h>
-
 #ifndef __CINT__
 #include <gsl/gsl_rng.h>
 #endif
 
 #include <iostream>
-#include <fstream>
 #include <string>
-#include <cmath>
 
 class PHCompositeNode;
 class PHHepMCGenEvent;
 class PHHepMCFilter;
-class TTree;
-class TFile;
-class TRandom;
 
 class PHPy8GenTrigger;
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -12,10 +12,12 @@
 #include <g4main/PHG4HitContainer.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
-#include <phool/PHNodeIterator.h>
+
+#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/getClass.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHRandomSeed.h>
 
 #include <TROOT.h>
 #include <TMath.h>
@@ -38,12 +40,15 @@ PHG4CylinderCellTPCReco::PHG4CylinderCellTPCReco(int n_pixel,
       tmin_default(0.0),  // ns
       tmax_default(60.0), // ns
       tmin_max(),
-      distortion(NULL) {}
+      distortion(NULL) 
+{
+  memset(nbins,0,sizeof(nbins));
+  rand.SetSeed(PHRandomSeed());
+}
 
 PHG4CylinderCellTPCReco::~PHG4CylinderCellTPCReco()
 {
-  if (distortion)
-    delete distortion;
+  delete distortion;
 }
 
 void PHG4CylinderCellTPCReco::Detector(const std::string &d)

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -3,12 +3,13 @@
 
 #include <fun4all/SubsysReco.h>
 #include <phool/PHTimeServer.h>
+
+#include <TRandom3.h>
+
 #include <string>
 #include <map>
-#include "TRandom3.h"
 
 class PHCompositeNode;
-class PHG4CylinderCell;
 class PHG4TPCDistortion;
 
 class PHG4CylinderCellTPCReco : public SubsysReco
@@ -53,12 +54,6 @@ public:
   void setDistortion (PHG4TPCDistortion * d) {distortion = d;}
 
 protected:
-//   void set_size(const int i, const double sizeA, const double sizeB, const int what);
-//   int CheckEnergy(PHCompositeNode *topNode);
-//   static std::pair<double, double> get_etaphi(const double x, const double y, const double z);
-//   static double get_eta(const double radius, const double z);
-//   bool lines_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy, double* rx, double* ry);
-//   bool line_and_rectangle_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy, double* rr);
   
   std::map<int, int>  binning;
   std::map<int, std::pair <double,double> > cell_size; // cell size in phi/z

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -27,6 +27,7 @@ using namespace std;
 PHG4CylinderDetector::PHG4CylinderDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam, const int lyr ): 
   PHG4Detector(Node,dnam),
   params(parameters),
+  cylinder_physi(NULL),
   layer(lyr)
 {}
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
@@ -5,8 +5,6 @@
 
 #include <string>
 
-class G4Material;
-class G4Tubs;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHG4Parameters;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -446,6 +446,33 @@ PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelope)
   ostringstream name;
   double middlerad = outer_radius - (outer_radius - inner_radius) / 2.;
   double shiftslat = fabs(scinti_tile_x_lower - scinti_tile_x_upper)/2.;
+  // calculate phi offset (copied from code inside following loop): 
+  // first get the center point (phi=0) so it's middlerad/0
+  // then shift the scintillator center as documented in loop
+  // then 
+  // for positive tilt angles we need the lower left corner of the scintillator
+  // for negative tilt angles we nee the upper right corner of the scintillator
+  // as it turns out the code uses the middle of the face of the scintillator
+  // as reference, if this is a problem the code needs to be modified to
+  // actually calculate the corner (but the math of the construction is that 
+  // the middle of the scintillator sits at zero)
+  double xp = cos(phi) * middlerad;
+  double yp = sin(phi) * middlerad;
+  xp -= cos((-tilt_angle)/rad - phi)*shiftslat;
+  yp +=  sin((-tilt_angle)/rad - phi)*shiftslat;
+  if (tilt_angle >0)
+    {
+      double xo = xp - (scinti_tile_x/2.)*cos(tilt_angle/rad);
+      double yo = yp - (scinti_tile_x/2.)*sin(tilt_angle/rad);
+      phi = -atan(yo/xo);
+    }
+  else if (tilt_angle < 0)
+    {
+      double xo = xp + (scinti_tile_x/2.)*cos(tilt_angle/rad);
+      double yo = yp + (scinti_tile_x/2.)*sin(tilt_angle/rad);
+      phi = -atan(yo/xo);
+    }
+  // else (for tilt_angle = 0) phi stays zero
   for (int i = 0; i < n_scinti_plates; i++)
     {
       G4RotationMatrix *Rot = new G4RotationMatrix();

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -457,8 +457,34 @@ PHG4OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelope)
   ostringstream name;
   double middlerad = outer_radius - (outer_radius - inner_radius) / 2.;
   double shiftslat = fabs(scinti_tile_x_lower - scinti_tile_x_upper)/2.;
+  // calculate phi offset (copied from code inside following loop): 
+  // first get the center point (phi=0) so it's middlerad/0
+  // then shift the scintillator center as documented in loop
+  // then 
+  // for positive tilt angles we need the lower left corner of the scintillator
+  // for negative tilt angles we nee the upper right corner of the scintillator
+  // as it turns out the code uses the middle of the face of the scintillator
+  // as reference, if this is a problem the code needs to be modified to
+  // actually calculate the corner (but the math of the construction is that 
+  // the middle of the scintillator sits at zero)
+  double xp = cos(phi) * middlerad;
+  double yp = sin(phi) * middlerad;
+  xp -= cos((-tilt_angle)/rad - phi)*shiftslat;
+  yp +=  sin((-tilt_angle)/rad - phi)*shiftslat;
+  if (tilt_angle >0)
+    {
+      double xo = xp - (scinti_tile_x/2.)*cos(tilt_angle/rad);
+      double yo = yp - (scinti_tile_x/2.)*sin(tilt_angle/rad);
+      phi = -atan(yo/xo);
+    }
+  else if (tilt_angle < 0)
+    {
+      double xo = xp + (scinti_tile_x/2.)*cos(tilt_angle/rad);
+      double yo = yp + (scinti_tile_x/2.)*sin(tilt_angle/rad);
+      phi = -atan(yo/xo);
+    }
+  // else (for tilt_angle = 0) phi stays zero
   for (int i = 0; i < n_scinti_plates; i++)
-    //  for (int i = 0; i < 1; i++)
     {
       G4RotationMatrix *Rot = new G4RotationMatrix();
       double ypos = sin(phi) * middlerad;

--- a/simulation/g4simulation/g4detectors/PHG4RICHDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHDetector.cc
@@ -9,7 +9,7 @@
  */
 
 #include "PHG4RICHDetector.h"
-#include <PHG4RICHSteppingAction.h>
+#include "PHG4RICHSteppingAction.h"
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Colour.hh>
@@ -29,16 +29,18 @@ using namespace std;
 using namespace ePHENIXRICH;
 
 PHG4RICHDetector::PHG4RICHDetector(PHCompositeNode *Node, const RICH_Geometry & g) :
-    PHG4Detector(Node), ePHENIXRICHConstruction(g)
-{
-
-}
+  PHG4Detector(Node),
+  ePHENIXRICHConstruction(g),
+  stepping_action(NULL),
+  _region(NULL)
+{}
 
 PHG4RICHDetector::PHG4RICHDetector(PHCompositeNode *Node) :
-    PHG4Detector(Node), ePHENIXRICHConstruction()
-{
-
-}
+  PHG4Detector(Node),
+  ePHENIXRICHConstruction(),
+  stepping_action(NULL),
+  _region(NULL)
+{}
 
 void
 PHG4RICHDetector::Construct(G4LogicalVolume* logicWorld)

--- a/simulation/g4simulation/g4detectors/PHG4RICHDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4RICHDetector.h
@@ -11,13 +11,14 @@
 #ifndef PHG4RICHDetector_h
 #define PHG4RICHDetector_h
 
-#include "g4main/PHG4Detector.h"
+#include "ePHENIXRICHConstruction.h"
+
+#include <g4main/PHG4Detector.h>
 
 #include <Geant4/G4Region.hh>
 #include <Geant4/G4Types.hh>
 #include <Geant4/globals.hh>
 
-#include "ePHENIXRICHConstruction.h"
 
 #include <map>
 

--- a/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.cc
+++ b/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.cc
@@ -25,16 +25,12 @@
 #include <Geant4/G4VisAttributes.hh>
 #include <Geant4/G4Colour.hh>
 
-#include <Geant4/G4NistManager.hh>
-
 #include <Geant4/G4Ellipsoid.hh>
 #include <Geant4/G4Sphere.hh>
 #include <Geant4/G4Orb.hh>
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4DisplacedSolid.hh>
-#include <Geant4/G4ExtrudedSolid.hh>
 #include <Geant4/G4IntersectionSolid.hh>
-#include <Geant4/G4UnionSolid.hh>
 #include <Geant4/G4SubtractionSolid.hh>
 
 #include <Geant4/G4LogicalBorderSurface.hh>
@@ -44,29 +40,18 @@
 #include <cmath>
 #include <iostream>
 #include <sstream>
+
 using namespace std;
 using namespace ePHENIXRICH;
 
-ePHENIXRICHConstruction::~ePHENIXRICHConstruction()
-{
-  // TODO Auto-generated destructor stub
-}
+ePHENIXRICHConstruction::ePHENIXRICHConstruction():
+  overlapcheck_rich(false)
 
-ePHENIXRICHConstruction::ePHENIXRICHConstruction()
-{
-  // TODO Auto-generated constructor stub
-
-  overlapcheck_rich = false;
-}
-ePHENIXRICHConstruction::ePHENIXRICHConstruction(const RICH_Geometry & g)
-{
-  // TODO Auto-generated constructor stub
-
-  geom = g;
-
-  overlapcheck_rich = false;
-
-}
+{}
+ePHENIXRICHConstruction::ePHENIXRICHConstruction(const RICH_Geometry & g):
+  geom(g),
+  overlapcheck_rich(false)
+{}
 
 G4LogicalVolume * ePHENIXRICHConstruction::RegisterLogicalVolume(
                                                                  G4LogicalVolume * v)

--- a/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.h
+++ b/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.h
@@ -384,8 +384,7 @@ namespace ePHENIXRICH
   class ePHENIXRICHConstruction
   {
   public:
-    virtual
-    ~ePHENIXRICHConstruction();
+    virtual ~ePHENIXRICHConstruction(){}
     ePHENIXRICHConstruction();
     ePHENIXRICHConstruction(const RICH_Geometry & g);
 


### PR DESCRIPTION
The offset of the front (positive tilt) or back (negative tilt) corners of the first tile respect to phi=0 is calculated and used to align the towers independent of the tilt angle or the number of tiles. This still needs to be propagated to the cell/tower geometry but at least we do not need tilt angle dependent calibrations in the analysis anymore.
PHPythia8 now uses PHRandomSeed() as sole source for random seed (the recoConsts was removed, this is handled inside PHRandomSeed()).
A handful of cppcheck warnings and the usual mixup of includes with quotes vs includes with <> were fixed  