### PR TITLE
carry HepMC barcode information through truth tracking

### DIFF
--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -199,6 +199,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode) {
         particle->set_px((*fiter)->momentum().px() * mom_factor);
         particle->set_py((*fiter)->momentum().py() * mom_factor);
         particle->set_pz((*fiter)->momentum().pz() * mom_factor);
+	particle->set_barcode((*fiter)->barcode()); 
         ineve->AddParticle((*v)->barcode(), particle);
 
         if (_embed_flag != 0) ineve->AddEmbeddedParticle(particle, _embed_flag);

--- a/simulation/g4simulation/g4main/PHG4Particle.h
+++ b/simulation/g4simulation/g4main/PHG4Particle.h
@@ -23,6 +23,8 @@ class PHG4Particle: public PHObject
   virtual int get_parent_id() const {return -9999;}
   virtual int get_primary_id() const {return 0xFFFFFFFF;}
 
+  virtual int get_barcode() const {return 0xFFFFFFFF;}
+
   virtual void set_track_id(const int i) {return;}
   virtual void set_vtx_id(const int i) {return;}
   virtual void set_parent_id(const int i) {return;}
@@ -33,6 +35,8 @@ class PHG4Particle: public PHObject
   virtual void set_py(const double x) {return;}
   virtual void set_pz(const double x) {return;}
   virtual void set_e(const double e) {return;}
+
+  virtual void set_barcode(const int barcode) {return;}
 
   void identify(std::ostream& os = std::cout) const;
 

--- a/simulation/g4simulation/g4main/PHG4Particlev1.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev1.cc
@@ -9,7 +9,8 @@ PHG4Particlev1::PHG4Particlev1():
   fpid(0),
   fpx(0),
   fpy(0),
-  fpz(0)
+  fpz(0),
+  barcode(-1)
 {}
 
 PHG4Particlev1::PHG4Particlev1(const string &name, const int pid, const double px, const double py, const double pz):
@@ -17,7 +18,8 @@ PHG4Particlev1::PHG4Particlev1(const string &name, const int pid, const double p
   fpid(pid),
   fpx(px),
   fpy(py),
-  fpz(pz)
+  fpz(pz),
+  barcode(-1)
 {}
   
 PHG4Particlev1::PHG4Particlev1(const PHG4Particle *in):
@@ -25,7 +27,8 @@ PHG4Particlev1::PHG4Particlev1(const PHG4Particle *in):
   fpid(in->get_pid()),
   fpx(in->get_px()),
   fpy(in->get_py()),
-  fpz(in->get_pz())
+  fpz(in->get_pz()),
+  barcode(in->get_barcode())
 {}
 
 void
@@ -42,6 +45,7 @@ PHG4Particlev1::identify(ostream& os) const
 	os << ", pid: " << fpid
          << ", px: " << fpx 
          << ", py: " << fpy 
-         << ", pz: " << fpz << endl;
+         << ", pz: " << fpz 
+	 << ", barcode: " << barcode << endl;
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4Particlev1.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev1.h
@@ -17,6 +17,8 @@ class PHG4Particlev1: public PHG4Particle
   double get_px() const {return fpx;}
   double get_py() const {return fpy;}
   double get_pz() const {return fpz;}
+  
+  int get_barcode() const {return barcode;}
 
   void set_name(const std::string &name) {fname=name;}
   void set_pid(const int i) {fpid=i;}
@@ -24,12 +26,16 @@ class PHG4Particlev1: public PHG4Particle
   void set_py(const double x) {fpy = x;}
   void set_pz(const double x) {fpz = x;}
 
+  void set_barcode(const int bcd) {barcode = bcd;}
+
   void identify(std::ostream& os = std::cout) const;
 
  protected:
   std::string fname;
   int fpid;
   double fpx,fpy,fpz;
+  int barcode; 
+
   ClassDef(PHG4Particlev1,1)
 };
 

--- a/simulation/g4simulation/g4main/PHG4Particlev2.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.cc
@@ -10,7 +10,8 @@ PHG4Particlev2::PHG4Particlev2():
   vtxid(0),
   parentid(0),
   primaryid(0xFFFFFFFF),
-  fe(0.0)
+  fe(0.0),
+  barcode(-1)
 {}
 
 PHG4Particlev2::PHG4Particlev2(const string &name, const int pid, const double px, const double py, const double pz):
@@ -19,7 +20,8 @@ PHG4Particlev2::PHG4Particlev2(const string &name, const int pid, const double p
   vtxid(0),
   parentid(0),
   primaryid(0xFFFFFFFF),
-  fe(0.0)
+  fe(0.0),
+  barcode(-1)
 {}
   
 PHG4Particlev2::PHG4Particlev2(const PHG4Particle *in):
@@ -28,7 +30,8 @@ PHG4Particlev2::PHG4Particlev2(const PHG4Particle *in):
   vtxid(0),
   parentid(0),
   primaryid(0xFFFFFFFF),
-  fe(0.0)
+  fe(0.0),
+  barcode(-1)
 {}
 
 void

--- a/simulation/g4simulation/g4main/PHG4Particlev2.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.h
@@ -18,11 +18,15 @@ class PHG4Particlev2: public PHG4Particlev1
   int get_primary_id() const {return primaryid;}
   double get_e() const {return fe;}
 
+  int get_barcode() const {return barcode;}
+
   void set_track_id(const int i) {trkid = i;}
   void set_vtx_id(const int i) {vtxid = i;}
   void set_parent_id(const int i) {parentid = i;}
   void set_primary_id(const int i) {primaryid = i;}
   void set_e(const double e) {fe = e;}
+
+  void set_barcode(const int bcd) {barcode = bcd;}
 
   void identify(std::ostream& os = std::cout) const;
 
@@ -32,6 +36,7 @@ class PHG4Particlev2: public PHG4Particlev1
   int parentid;
   int primaryid;
   double fe;
+  int barcode; 
 
   ClassDef(PHG4Particlev2,1)
 };

--- a/simulation/g4simulation/g4main/PHG4PrimaryGeneratorAction.cc
+++ b/simulation/g4simulation/g4main/PHG4PrimaryGeneratorAction.cc
@@ -110,11 +110,14 @@ PHG4PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
                                              (*particle_iter->second).get_py()*GeV,
                                              (*particle_iter->second).get_pz()*GeV);
             }
-          if (inEvent->isEmbeded(particle_iter->second))
-            {
+          //if (inEvent->isEmbeded(particle_iter->second))
+	  // Do this for all primaries, not just the embedded particle, so that 
+	  // we can carry the barcode information forward. 
+          //  {
               PHG4UserPrimaryParticleInformation *userdata = new PHG4UserPrimaryParticleInformation(inEvent->isEmbeded(particle_iter->second));
+	      userdata->set_user_barcode((*particle_iter->second).get_barcode()); 
               g4part->SetUserInformation(userdata);
-            }
+	  //  }
           vertex->SetPrimary(g4part);
         }
       //      vertex->Print();

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -79,6 +79,13 @@ void PHG4TruthTrackingAction::PreUserTrackingAction( const G4Track* track) {
   ti->set_name(def->GetParticleName());
   ti->set_e(track->GetTotalEnergy() / GeV);
 
+  if (!track->GetParentID()) {
+    // primary track - propagate the barcode information
+    PHG4UserPrimaryParticleInformation* userdata = (PHG4UserPrimaryParticleInformation*)track->GetDynamicParticle()->GetPrimaryParticle()->GetUserInformation();
+    if(userdata) ti->set_barcode( userdata->get_user_barcode() );
+  }
+
+
   // create a new vertex object ------------------------------------------------
   G4ThreeVector v = track->GetVertexPosition();
   map<G4ThreeVector, int>::const_iterator viter = VertexMap.find(v);

--- a/simulation/g4simulation/g4main/PHG4UserPrimaryParticleInformation.h
+++ b/simulation/g4simulation/g4main/PHG4UserPrimaryParticleInformation.h
@@ -10,7 +10,8 @@ public:
   PHG4UserPrimaryParticleInformation(const int emb) : 
     embed(emb),
     usertrackid(0),
-    uservtxid(0) {}
+    uservtxid(0),
+    barcode(-1)   {}
 
   void Print() const 
   {
@@ -25,11 +26,15 @@ public:
 
   void set_user_vtx_id(int val) {uservtxid = val;}
   int get_user_vtx_id() const {return uservtxid;}
+
+  void set_user_barcode(int bcd) {barcode = bcd;}
+  int get_user_barcode() const {return barcode;}
   
 private:
   int embed;
   int usertrackid;
   int uservtxid;
+  int barcode; 
 };
 
 #endif


### PR DESCRIPTION
This set of modifications will carry the HepMC barcode through to the truth information for primary particles, allowing you to connect a PHG4Particle from PHG4TruthInfoContainer back to the HepMC event record, which then allows you to track back the true origin of a primary in the HepMC event record. For example: 

`         PHHepMCGenEvent *genevent = findNode::getClass<PHHepMCGenEvent>(topNode,"PHHepMCGenEvent");
          HepMC::GenEvent *evt = genevent->getEvent();

	  PHG4TruthInfoContainer::ConstRange range =
			_truth_container->GetParticleRange();

	  for (PHG4TruthInfoContainer::ConstIterator truth_itr = range.first;
			truth_itr != range.second; ++truth_itr) {

	    PHG4Particle* g4particle = truth_itr->second;

            if(_truth_container->is_primary(g4particle)){
	      HepMC::GenParticle *ptcle = evt->barcode_to_particle(g4particle->get_barcode()); 
              ....
	    }
            ...
          }
`

The cost of doing this is the addition of the barcode integer to PHG4Particle and the addition of PHG4UserPrimaryParticleInformation to every primary G4 track to allow the barcode information to carry forward; previously this was only added to embedded tracks.