### PR TITLE
Cumulative memory bug fixes

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -165,7 +165,6 @@ libg4detectors_la_SOURCES = \
   PHG4FCalSubsystem.cc \
   PHG4FCalSubsystem_Dict.cc \
   PHG4ForwardEcalDetector.cc \
-  PHG4FlushStepTrackingAction.cc \
   PHG4EICForwardEcalDetector.cc \
   PHG4ForwardEcalSteppingAction.cc \
   PHG4ForwardEcalSubsystem.cc \

--- a/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.cc
@@ -19,7 +19,7 @@ using namespace std;
 //____________________________________________________________________________..
 PHG4BlockSteppingAction::PHG4BlockSteppingAction( PHG4BlockDetector* detector, const PHG4Parameters *parameters ):
   detector_( detector ),
-  params(parameters),
+  params(parameters), hits_(NULL), hit(NULL),
   active(params->get_int_param("active")),
   IsBlackHole(params->get_int_param("blackhole")),
   use_g4_steps(params->get_int_param("use_g4steps"))

--- a/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
@@ -25,6 +25,11 @@ using namespace std;
 //note this inactive thickness is ~1.5% of a radiation length
 PHG4ConeDetector::PHG4ConeDetector( PHCompositeNode *Node, const std::string &dnam,const int lyr  ):
   PHG4Detector(Node, dnam),
+  TrackerMaterial(NULL),
+  InactiveMaterial(NULL),
+  block_solid(NULL),
+  block_logic(NULL),
+  block_physi(NULL),
   place_in_x(0*cm),
   place_in_y(0*cm),
   place_in_z(300*cm),

--- a/simulation/g4simulation/g4detectors/PHG4ConeRegionSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeRegionSteppingAction.cc
@@ -16,7 +16,7 @@
 using namespace std;
 //____________________________________________________________________________..
 PHG4ConeRegionSteppingAction::PHG4ConeRegionSteppingAction( PHG4ConeDetector* detector ):
-  detector_( detector )
+  detector_( detector ), hits_(NULL), hit(NULL)
 {}
 
 //____________________________________________________________________________..

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
@@ -339,11 +339,13 @@ PHG4CrystalCalorimeterSteppingAction::ParseG4VolumeName( G4VPhysicalVolume* volu
 		if (*tokeniter == "j")
 		{
 			++tokeniter;
+			if (tokeniter == tok.end()) break;
 			j = boost::lexical_cast<int>(*tokeniter);
 		}
 		else if (*tokeniter == "k")
 		{
 			++tokeniter;
+      if (tokeniter == tok.end()) break;
 			k = boost::lexical_cast<int>(*tokeniter);
 		}
 	}

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
@@ -50,6 +50,7 @@ PHG4EnvelopeDetector::PHG4EnvelopeDetector(  PHCompositeNode *Node, const std::s
 	_dPhi(2*M_PI),
 	_materialCrystal( "G4_PbWO4" ),
 	_active(1),
+	_layer(0),
 	_superdetector("NONE")
 {
 	

--- a/simulation/g4simulation/g4detectors/PHG4FCalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FCalDetector.cc
@@ -30,7 +30,11 @@ PHG4FCalDetector::PHG4FCalDetector( PHCompositeNode *Node ) :
   segment_length(length/((double)(segments_per_column))),
   segment_thickness(scintillator_thickness/((double)(segments_per_thickness))),
   z_position(100.0 * cm),
-  layer_separation(1.0 * mm)
+  layer_separation(1.0 * mm),
+  AbsorberMaterial(NULL),
+  ScintillatorMaterial(NULL),
+  stepping_action(NULL),
+  _region(NULL)
 {
   
 }

--- a/simulation/g4simulation/g4detectors/PHG4FCalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FCalSteppingAction.cc
@@ -14,7 +14,8 @@
 using namespace std;
 
 
-PHG4FCalSteppingAction::PHG4FCalSteppingAction( PHG4FCalDetector* detector ) : detector_( detector )
+PHG4FCalSteppingAction::PHG4FCalSteppingAction( PHG4FCalDetector* detector ) :
+    detector_( detector ), hits_(NULL), hit(NULL)
 {
   
 }

--- a/simulation/g4simulation/g4detectors/PHG4FPbScDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScDetector.cc
@@ -28,7 +28,11 @@ PHG4FPbScDetector::PHG4FPbScDetector( PHCompositeNode *Node, const std::string &
   x_position(0.0 * cm),
   y_position(0.0 * cm),
   z_position(400.0 * cm),
-  layer_separation(0.0)
+  layer_separation(0.0),
+  AbsorberMaterial(NULL),
+  ScintillatorMaterial(NULL),
+  stepping_action(NULL),
+  _region(NULL)
 {
   
 }

--- a/simulation/g4simulation/g4detectors/PHG4FPbScRegionSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScRegionSteppingAction.cc
@@ -16,7 +16,7 @@
 using namespace std;
 //____________________________________________________________________________..
 PHG4FPbScRegionSteppingAction::PHG4FPbScRegionSteppingAction( PHG4FPbScDetector* detector ):
-  detector_( detector )
+  detector_( detector ), hits_(NULL), hit(NULL)
 {}
 
 //____________________________________________________________________________..

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSteppingAction.cc
@@ -13,7 +13,8 @@
 using namespace std;
 
 
-PHG4FPbScSteppingAction::PHG4FPbScSteppingAction( PHG4FPbScDetector* detector) : detector_( detector )
+PHG4FPbScSteppingAction::PHG4FPbScSteppingAction( PHG4FPbScDetector* detector) :
+    detector_( detector ), hits_(NULL), hit(NULL)
 {
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
@@ -16,7 +16,7 @@ using namespace std;
 //_______________________________________________________________________
 PHG4FPbScSubsystem::PHG4FPbScSubsystem( const string &name ):
 PHG4Subsystem( name ),
-detector_( NULL )
+detector_( NULL ), steppingAction_(NULL), eventAction_(NULL), x_position(0), y_position(0), z_position(0)
 {
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
@@ -339,11 +339,13 @@ PHG4ForwardEcalSteppingAction::ParseG4VolumeName( G4VPhysicalVolume* volume, int
 		if (*tokeniter == "j")
 		{
 			++tokeniter;
+			if ( tokeniter == tok.end()) break;
 			j = boost::lexical_cast<int>(*tokeniter);
 		}
 		else if (*tokeniter == "k")
 		{
 			++tokeniter;
+      if ( tokeniter == tok.end()) break;
 			k = boost::lexical_cast<int>(*tokeniter);
 		}
 	}

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
@@ -342,11 +342,13 @@ PHG4ForwardHcalSteppingAction::ParseG4VolumeName( G4VPhysicalVolume* volume, int
 		if (*tokeniter == "j")
 		{
 			++tokeniter;
+      if ( tokeniter == tok.end()) break;
 			j = boost::lexical_cast<int>(*tokeniter);
 		}
 		else if (*tokeniter == "k")
 		{
 			++tokeniter;
+      if ( tokeniter == tok.end()) break;
 			k = boost::lexical_cast<int>(*tokeniter);
 		}
 	}

--- a/simulation/g4simulation/g4detectors/PHG4MapsDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsDetector.cc
@@ -30,6 +30,7 @@
 
 #include <cmath>
 #include <sstream>
+#include <memory>
 
 using namespace std;
 
@@ -137,8 +138,8 @@ PHG4MapsDetector::ConstructMaps(G4LogicalVolume* trackerenvelope)
   //===================================
 
   // import the staves from the gemetry file
-  G4GDMLReadStructure * reader = new G4GDMLReadStructure();
-  G4GDMLParser gdmlParser(reader);
+  std::unique_ptr<G4GDMLReadStructure>  reader (new G4GDMLReadStructure());
+  G4GDMLParser gdmlParser(reader.get());
   gdmlParser.Read(stave_geometry_file);
   
   // figure out which assembly we want
@@ -148,6 +149,8 @@ PHG4MapsDetector::ConstructMaps(G4LogicalVolume* trackerenvelope)
   if (Verbosity())
     cout << "Geting the stave assembly named " << assemblyname << endl;
   G4AssemblyVolume* av_ITSUStave = reader->GetAssembly(assemblyname);
+
+//  if (reader) delete reader;
 
   //=========================================
   // Now we populate the whole layer with the staves

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -1173,6 +1173,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  float gx       = NAN;
 	  float gy       = NAN;
 	  float gz       = NAN;
+	  float gt       = NAN;
 	  float gtrackID = NAN;
 	  float gflavor  = NAN;
 	  float gpx      = NAN;
@@ -1196,7 +1197,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	    g4hitID  = g4hit->get_hit_id();
 	    gx       = g4hit->get_avg_x();
 	    gy       = g4hit->get_avg_y();
-	    gz       = g4hit->get_avg_z();
+      gz       = g4hit->get_avg_z();
+      gt       = g4hit->get_avg_t();
 
 	    if (g4particle) {
 	    
@@ -1232,7 +1234,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	    efromtruth = clustereval->get_energy_contribution(cluster,g4particle);
 	  }
 
-	  float cluster_data[37] = {(float) _ievent,
+	  float cluster_data[38] = {(float) _ievent,
 				    hitID,
 				    x,
 				    y,
@@ -1252,6 +1254,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				    gx,
 				    gy,
 				    gz,
+				    gt,
 				    gtrackID,
 				    gflavor,
 				    gpx,

--- a/simulation/g4simulation/g4main/PHG4Particlev2.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.cc
@@ -20,8 +20,8 @@ PHG4Particlev2::PHG4Particlev2(const string &name, const int pid, const double p
   vtxid(0),
   parentid(0),
   primaryid(0xFFFFFFFF),
-  fe(0.0),
-  barcode(-1)
+  fe(0.0)//,
+//  barcode(-1)
 {}
   
 PHG4Particlev2::PHG4Particlev2(const PHG4Particle *in):
@@ -30,12 +30,12 @@ PHG4Particlev2::PHG4Particlev2(const PHG4Particle *in):
   vtxid(0),
   parentid(0),
   primaryid(0xFFFFFFFF),
-  fe(0.0),
-  barcode(-1)
+  fe(0.0)//,
+  //barcode(-1)
 {}
 
 void
-PHG4Particlev2::identify(ostream& os) const
+PHG4Particlev2::identify(std::ostream& os) const
 {
   if(fname.size() > 0) {
     os << "PHG4Particlev2 name: " << fname << ", ";

--- a/simulation/g4simulation/g4main/PHG4Particlev2.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.cc
@@ -10,8 +10,8 @@ PHG4Particlev2::PHG4Particlev2():
   vtxid(0),
   parentid(0),
   primaryid(0xFFFFFFFF),
-  fe(0.0),
-  barcode(-1)
+  fe(0.0)//,
+//  barcode(-1)
 {}
 
 PHG4Particlev2::PHG4Particlev2(const string &name, const int pid, const double px, const double py, const double pz):

--- a/simulation/g4simulation/g4main/PHG4Particlev2.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.h
@@ -18,7 +18,8 @@ class PHG4Particlev2: public PHG4Particlev1
   int get_primary_id() const {return primaryid;}
   double get_e() const {return fe;}
 
-  int get_barcode() const {return barcode;}
+  // this function was implimented in PHG4Particlev1
+//  int get_barcode() const {return barcode;}
 
   void set_track_id(const int i) {trkid = i;}
   void set_vtx_id(const int i) {vtxid = i;}
@@ -26,7 +27,8 @@ class PHG4Particlev2: public PHG4Particlev1
   void set_primary_id(const int i) {primaryid = i;}
   void set_e(const double e) {fe = e;}
 
-  void set_barcode(const int bcd) {barcode = bcd;}
+  // this function was implimented in PHG4Particlev1
+//  void set_barcode(const int bcd) {barcode = bcd;}
 
   void identify(std::ostream& os = std::cout) const;
 
@@ -36,9 +38,10 @@ class PHG4Particlev2: public PHG4Particlev1
   int parentid;
   int primaryid;
   double fe;
-  int barcode; 
+  // this variable was implimented in PHG4Particlev1
+//  int barcode;
 
-  ClassDef(PHG4Particlev2,1)
+  ClassDef(PHG4Particlev2,2)
 };
 
 


### PR DESCRIPTION
During cross check of #218 and #219, valgrind and cppcheck tests were run on the tracker simulation which revealed a few historical problems. This pull request try to fix some of them:

1. duplicated ```PHG4Particlev2::barcode``` and its interface functions that shadow that of  PHG4Particlev1
2. inconsistent NTuple data length in ```SvtxEvaluator.C```
3. uninitialized variables in variable code
4. unchecked iterator in various code 

Propose to merge after merging #218 and #219