### PR TITLE
fix problems in clustering caused by unfilled raw tower geometry object

### DIFF
--- a/simulation/g4simulation/g4cemc/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/HcalRawTowerBuilder.cc
@@ -237,20 +237,15 @@ HcalRawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
       TowerGeomNodeName.c_str());
   if (!rawtowergeom)
     {
-
       rawtowergeom = new RawTowerGeomContainer_Cylinderv1(RawTowerDefs::convert_name_to_caloid(detector));
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom,
           TowerGeomNodeName.c_str(), "PHObject");
       RunDetNode->addNode(newNode);
     }
-  for (int irow = 0; irow < 4; irow++)
-    {
-      for (int icolumn=0; icolumn<4; icolumn++)
-	{
-	  RawTowerGeomv1 * tg = new RawTowerGeomv1(RawTowerDefs::encode_towerid(RawTowerDefs::convert_name_to_caloid(detector), icolumn, irow));
-            rawtowergeom->add_tower_geometry(tg);
-	}
-    }
+  rawtowergeom->set_radius(get_double_param(PHG4HcalDefs::innerrad));
+  rawtowergeom->set_thickness(get_double_param(PHG4HcalDefs::outerrad)-get_double_param(PHG4HcalDefs::innerrad));
+  rawtowergeom->set_phibins(get_int_param(PHG4HcalDefs::n_towers));
+  rawtowergeom->set_etabins(get_int_param("etabins"));
 	     	     
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
       "PHCompositeNode", "DST"));
@@ -298,9 +293,14 @@ HcalRawTowerBuilder::get_tower_row(const short cellrow) const
 void
 HcalRawTowerBuilder::SetDefaultParameters()
 {
-  set_default_double_param("emin",1.e-6);
-  set_default_int_param("n_scinti_plates_per_tower",5);
+  set_default_int_param(PHG4HcalDefs::scipertwr,5);
   set_default_int_param("tower_energy_source",kLightYield);
+  set_default_int_param(PHG4HcalDefs::n_towers,64);
+  set_default_int_param("etabins",24);
+
+  set_default_double_param("emin",1.e-6);
+  set_default_double_param(PHG4HcalDefs::outerrad,NAN);
+  set_default_double_param(PHG4HcalDefs::innerrad,NAN);
 }
 
 void
@@ -318,7 +318,11 @@ HcalRawTowerBuilder::ReadParamsFromNodeTree(PHCompositeNode *topNode)
       return;
     }
   pars->FillFrom(saveparams,0);
-  set_int_param(PHG4HcalDefs::scipertwr,get_int_param(PHG4HcalDefs::scipertwr));
+  set_int_param(PHG4HcalDefs::scipertwr,pars->get_int_param(PHG4HcalDefs::scipertwr));
+  set_int_param(PHG4HcalDefs::n_towers,pars->get_int_param(PHG4HcalDefs::n_towers));
+  set_int_param("etabins",2*pars->get_int_param(PHG4HcalDefs::n_scinti_tiles));
+  set_double_param(PHG4HcalDefs::innerrad,pars->get_double_param(PHG4HcalDefs::innerrad));
+  set_double_param(PHG4HcalDefs::outerrad,pars->get_double_param(PHG4HcalDefs::outerrad));
   delete pars;
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4HcalDefs.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDefs.h
@@ -7,6 +7,10 @@ namespace PHG4HcalDefs
 {
   // parameter names used in lookups by other modules
   static const std::string scipertwr = "n_scinti_plates_per_tower";
+  static const std::string innerrad = "inner_radius";
+  static const std::string outerrad = "outer_radius";
+  static const std::string n_towers = "n_towers";
+  static const std::string n_scinti_tiles = "n_scinti_tiles";
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -145,12 +145,12 @@ PHG4Detector* PHG4InnerHcalSubsystem::GetDetector( void ) const
 void
 PHG4InnerHcalSubsystem::SetDefaultParameters()
 {
-  set_default_double_param("inner_radius",116.);
+  set_default_double_param(PHG4HcalDefs::innerrad,116.);
   set_default_double_param("light_balance_inner_corr", NAN);
   set_default_double_param("light_balance_inner_radius", NAN);
   set_default_double_param("light_balance_outer_corr", NAN);
   set_default_double_param("light_balance_outer_radius", NAN);
-  set_default_double_param("outer_radius", 136.);
+  set_default_double_param(PHG4HcalDefs::outerrad, 136.);
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);
   set_default_double_param("place_z", 0.);
@@ -168,9 +168,9 @@ PHG4InnerHcalSubsystem::SetDefaultParameters()
 
   set_default_int_param("light_scint_model", 1);
   set_default_int_param("ncross", 4);
-  set_default_int_param("n_towers", 64);
+  set_default_int_param(PHG4HcalDefs::n_towers, 64);
   set_default_int_param(PHG4HcalDefs::scipertwr, 4);
-  set_default_int_param("n_scinti_tiles", 12);
+  set_default_int_param(PHG4HcalDefs::n_scinti_tiles, 12);
 
   set_default_string_param("material", "SS310");
 }


### PR DESCRIPTION
This is a quick patch which fills the tower geometry object from what is in the detector parameters. Things like the eta binning have changed so I assume the cluster building which used this never really worked in the last months