### PR TITLE
Fix various tracking code so that tracking IO object always use the DST node

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -425,10 +425,11 @@ int PHG4HoughTransform::CreateNodes(PHCompositeNode* topNode) {
     cerr << PHWHERE << "DST Node missing, doing nothing." << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
+  PHNodeIterator iter_dst(dstNode);
 
   // Create the SVTX node
   PHCompositeNode* tb_node =
-    dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "SVTX"));
+    dynamic_cast<PHCompositeNode*>(iter_dst.findFirst("PHCompositeNode", "SVTX"));
   if (!tb_node) {
     tb_node = new PHCompositeNode("SVTX");
     dstNode->addNode(tb_node);

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -474,9 +474,10 @@ int PHG4HoughTransformTPC::CreateNodes(PHCompositeNode *topNode)
   cerr << PHWHERE << "DST Node missing, doing nothing." << endl;
   return Fun4AllReturnCodes::ABORTEVENT;
   }
+  PHNodeIterator iter_dst(dstNode);
 
   // Create the SVTX node
-  PHCompositeNode* tb_node = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "SVTX"));
+  PHCompositeNode* tb_node = dynamic_cast<PHCompositeNode*>(iter_dst.findFirst("PHCompositeNode", "SVTX"));
   if (!tb_node)
   {
   tb_node = new PHCompositeNode("SVTX");

--- a/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
@@ -188,10 +188,11 @@ int PHG4SvtxClusterizer::InitRun(PHCompositeNode* topNode) {
     cout << PHWHERE << "DST Node missing, doing nothing." << endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
+  PHNodeIterator iter_dst(dstNode);
     
   // Create the SVX node if required
   PHCompositeNode* svxNode 
-    = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","SVTX"));
+    = dynamic_cast<PHCompositeNode*>(iter_dst.findFirst("PHCompositeNode","SVTX"));
   if (!svxNode) {
     svxNode = new PHCompositeNode("SVTX");
     dstNode->addNode(svxNode);
@@ -199,7 +200,7 @@ int PHG4SvtxClusterizer::InitRun(PHCompositeNode* topNode) {
   
   // Create the Cluster node if required
   SvtxClusterMap *svxclusters 
-    = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
+    = findNode::getClass<SvtxClusterMap>(dstNode,"SvtxClusterMap");
   if (!svxclusters) {
     svxclusters = new SvtxClusterMap_v1();
     PHIODataNode<PHObject> *SvtxClusterMapNode =

--- a/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.C
@@ -36,7 +36,6 @@ int PHG4SvtxDigitizer::InitRun(PHCompositeNode* topNode) {
   //-------------
   // Add Hit Node
   //-------------
-
   PHNodeIterator iter(topNode);
 
   // Looking for the DST node
@@ -46,17 +45,18 @@ int PHG4SvtxDigitizer::InitRun(PHCompositeNode* topNode) {
     cout << PHWHERE << "DST Node missing, doing nothing." << endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
+  PHNodeIterator iter_dst(dstNode);
     
   // Create the SVX node if required
   PHCompositeNode* svxNode 
-    = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","SVTX"));
+    = dynamic_cast<PHCompositeNode*>(iter_dst.findFirst("PHCompositeNode","SVTX"));
   if (!svxNode) {
     svxNode = new PHCompositeNode("SVTX");
     dstNode->addNode(svxNode);
   }
   
   // Create the Hit node if required
-  SvtxHitMap *svxhits = findNode::getClass<SvtxHitMap>(topNode,"SvtxHitMap");
+  SvtxHitMap *svxhits = findNode::getClass<SvtxHitMap>(dstNode,"SvtxHitMap");
   if (!svxhits) {
     svxhits = new SvtxHitMap_v1();
     PHIODataNode<PHObject> *SvtxHitMapNode =

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -134,7 +134,7 @@ int PHG4TPCClusterizer::InitRun(PHCompositeNode* topNode) {
 void PHG4TPCClusterizer::reset() {}
 
 int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
-  
+
   PHNodeIterator iter(topNode);
 
   PHCompositeNode* dstNode =
@@ -143,22 +143,23 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
     cout << PHWHERE << "DST Node missing, doing nothing." << endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
+  PHNodeIterator iter_dst(dstNode);
 
-  SvtxHitMap* hits = findNode::getClass<SvtxHitMap>(topNode, "SvtxHitMap");
+  SvtxHitMap* hits = findNode::getClass<SvtxHitMap>(dstNode, "SvtxHitMap");
   if (!hits) {
     cout << PHWHERE << "ERROR: Can't find node SvtxHitMap" << endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
   PHCompositeNode* svxNode =
-      dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "SVTX"));
+      dynamic_cast<PHCompositeNode*>(iter_dst.findFirst("PHCompositeNode", "SVTX"));
   if (!svxNode) {
     svxNode = new PHCompositeNode("SVTX");
     dstNode->addNode(svxNode);
   }
 
   SvtxClusterMap* svxclusters =
-      findNode::getClass<SvtxClusterMap>(topNode, "SvtxClusterMap");
+      findNode::getClass<SvtxClusterMap>(dstNode, "SvtxClusterMap");
   if (!svxclusters) {
     svxclusters = new SvtxClusterMap_v1();
     PHIODataNode<PHObject>* SvtxClusterMapNode =
@@ -170,7 +171,7 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
     findNode::getClass<PHG4CylinderCellGeomContainer>(topNode,"CYLINDERCELLGEOM_SVTX");
   if (!geom_container) return Fun4AllReturnCodes::ABORTRUN;
 
-  PHG4CylinderCellContainer* cells =  findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SVTX");
+  PHG4CylinderCellContainer* cells =  findNode::getClass<PHG4CylinderCellContainer>(dstNode,"G4CELL_SVTX");
   if (!cells) return Fun4AllReturnCodes::ABORTRUN;
 
   std::vector<std::vector<const SvtxHit*> > layer_sorted;

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -313,9 +313,10 @@ int PHG4TrackFastSim::CreateNodes(PHCompositeNode *topNode) {
 		cerr << PHWHERE << "DST Node missing, doing nothing." << endl;
 		return Fun4AllReturnCodes::ABORTEVENT;
 	}
+  PHNodeIterator iter_dst(dstNode);
 
 	// Create the FGEM node
-	PHCompositeNode* tb_node = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+	PHCompositeNode* tb_node = dynamic_cast<PHCompositeNode*>(iter_dst.findFirst(
 			"PHCompositeNode", _sub_top_node_name.c_str()));
 	if (!tb_node) {
 		tb_node = new PHCompositeNode(_sub_top_node_name.c_str());

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
@@ -468,9 +468,10 @@ int PHG4TrackKalmanFitter::CreateNodes(PHCompositeNode *topNode) {
 		cerr << PHWHERE << "DST Node missing, doing nothing." << endl;
 		return Fun4AllReturnCodes::ABORTEVENT;
 	}
+  PHNodeIterator iter_dst(dstNode);
 
 	// Create the SVTX node
-	PHCompositeNode* tb_node = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+	PHCompositeNode* tb_node = dynamic_cast<PHCompositeNode*>(iter_dst.findFirst(
 			"PHCompositeNode", "SVTX"));
 	if (!tb_node) {
 		tb_node = new PHCompositeNode("SVTX");


### PR DESCRIPTION
Thanks for @SashaLebedev for reporting a crash for TPC simulation after a few recent software changes. The problem trace to multiple tracking subsystem code built IO nodes onto the RUN node instead of the DST node, which is not reset after each event and not written to DST files. This problem only acted now as the geometry parameter are now saved to a composite SVTX node on the RUN node. 

This problem should be fixed after nightly build. 