### PR TITLE
fill the raw tower geom properly - second attempt

### DIFF
--- a/simulation/g4simulation/g4cemc/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/HcalRawTowerBuilder.cc
@@ -123,20 +123,20 @@ HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
   rawtowergeom->set_thickness(get_double_param(PHG4HcalDefs::outerrad)-get_double_param(PHG4HcalDefs::innerrad));
   rawtowergeom->set_phibins(get_int_param(PHG4HcalDefs::n_towers));
   rawtowergeom->set_etabins(get_int_param("etabins"));
-  for (int i=0; i<64; i++)
+  for (int i=0; i<get_int_param(PHG4HcalDefs::n_towers); i++)
     {
-      pair<double, double> range = make_pair(i*360./64.,(i+1)*360./64.);
+      pair<double, double> range = make_pair(i*360./get_int_param(PHG4HcalDefs::n_towers),(i+1)*360./get_int_param(PHG4HcalDefs::n_towers));
       rawtowergeom->set_phibounds(i,range);
     }
   double etalowbound = -1.1;
-  for (int i = 0; i < 24; i++)
+  for (int i = 0; i < get_int_param("etabins"); i++)
     {
-      double etahibound = etalowbound + 2.2 / 24.;
+      double etahibound = etalowbound + 2.2 / get_int_param("etabins");
       pair<double, double> range = make_pair(etalowbound, etahibound);
       rawtowergeom->set_etabounds(i, range);
       etalowbound = etahibound;
     }
-  if (verbosity > 0)
+	 //  if (verbosity > 0)
     {
       rawtowergeom->identify();
     }

--- a/simulation/g4simulation/g4cemc/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/HcalRawTowerBuilder.cc
@@ -109,6 +109,37 @@ HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
 	  cout << "unknown energy source" << endl;
 	}
     }
+  TowerGeomNodeName = "TOWERGEOM_" + detector;
+  rawtowergeom = findNode::getClass<RawTowerGeomContainer>(topNode,
+      TowerGeomNodeName.c_str());
+  if (!rawtowergeom)
+    {
+      rawtowergeom = new RawTowerGeomContainer_Cylinderv1(RawTowerDefs::convert_name_to_caloid(detector));
+      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom,
+          TowerGeomNodeName.c_str(), "PHObject");
+      RunDetNode->addNode(newNode);
+    }
+  rawtowergeom->set_radius(get_double_param(PHG4HcalDefs::innerrad));
+  rawtowergeom->set_thickness(get_double_param(PHG4HcalDefs::outerrad)-get_double_param(PHG4HcalDefs::innerrad));
+  rawtowergeom->set_phibins(get_int_param(PHG4HcalDefs::n_towers));
+  rawtowergeom->set_etabins(get_int_param("etabins"));
+  for (int i=0; i<64; i++)
+    {
+      pair<double, double> range = make_pair(i*360./64.,(i+1)*360./64.);
+      rawtowergeom->set_phibounds(i,range);
+    }
+  double etalowbound = -1.1;
+  for (int i = 0; i < 24; i++)
+    {
+      double etahibound = etalowbound + 2.2 / 24.;
+      pair<double, double> range = make_pair(etalowbound, etahibound);
+      rawtowergeom->set_etabounds(i, range);
+      etalowbound = etahibound;
+    }
+  if (verbosity > 0)
+    {
+      rawtowergeom->identify();
+    }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -225,28 +256,6 @@ HcalRawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
       throw std::runtime_error(
           "Failed to find Run node in HcalRawTowerBuilder::CreateNodes");
     }
-  PHNodeIterator runIter(runNode);
-  PHCompositeNode *RunDetNode =  dynamic_cast<PHCompositeNode*>(runIter.findFirst("PHCompositeNode",detector));
-  if (! RunDetNode)
-    {
-      RunDetNode = new PHCompositeNode(detector);
-      runNode->addNode(RunDetNode);
-    }
-  TowerGeomNodeName = "TOWERGEOM_" + detector;
-  rawtowergeom = findNode::getClass<RawTowerGeomContainer>(topNode,
-      TowerGeomNodeName.c_str());
-  if (!rawtowergeom)
-    {
-      rawtowergeom = new RawTowerGeomContainer_Cylinderv1(RawTowerDefs::convert_name_to_caloid(detector));
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom,
-          TowerGeomNodeName.c_str(), "PHObject");
-      RunDetNode->addNode(newNode);
-    }
-  rawtowergeom->set_radius(get_double_param(PHG4HcalDefs::innerrad));
-  rawtowergeom->set_thickness(get_double_param(PHG4HcalDefs::outerrad)-get_double_param(PHG4HcalDefs::innerrad));
-  rawtowergeom->set_phibins(get_int_param(PHG4HcalDefs::n_towers));
-  rawtowergeom->set_etabins(get_int_param("etabins"));
-	     	     
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
       "PHCompositeNode", "DST"));
   if (!dstNode)
@@ -279,7 +288,6 @@ HcalRawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
   PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers,
       TowerNodeName.c_str(), "PHObject");
   DetNode->addNode(towerNode);
-
   return;
 }
 

--- a/simulation/g4simulation/g4cemc/RawTowerContainer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerContainer.h
@@ -20,10 +20,10 @@ class RawTowerContainer : public PHObject
   typedef std::pair<Iterator, Iterator> Range;
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
 
-  RawTowerContainer( RawTowerDefs::CalorimeterId caloid = RawTowerDefs::NONE )
-  {
-    _caloid = caloid;
-  }
+ RawTowerContainer( RawTowerDefs::CalorimeterId caloid = RawTowerDefs::NONE ):
+  _caloid(caloid)
+  {}
+
   virtual ~RawTowerContainer() {}
 
   void Reset();

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -12,7 +12,7 @@
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4PVPlacement.hh>
-
+#include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4VisAttributes.hh>
 #include <Geant4/G4Colour.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
@@ -1,22 +1,10 @@
 #ifndef PHG4BlockDetector_h
 #define PHG4BlockDetector_h
 
-#include "PHG4Parameters.h"
-
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/globals.hh>
-#include <Geant4/G4Region.hh>
-#include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4Types.hh>
-
-#include <map>
-
-
-class G4Material;
-class G4Box;
 class G4LogicalVolume;
-class G4Region;
+class PHG4Parameters;
 class G4VPhysicalVolume;
 
 class PHG4BlockDetector: public PHG4Detector

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
@@ -1,5 +1,6 @@
 #include "PHG4BlockSubsystem.h"
 #include "PHG4BlockDetector.h"
+#include "PHG4Parameters.h"
 #include "PHG4EventActionClearZeroEdep.h"
 #include "PHG4BlockSteppingAction.h"
 #include "PHG4BlockGeomv1.h"

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.cc
@@ -11,14 +11,15 @@
 #include "PHG4CylinderCellGeom_Spacalv1.h"
 #include "PHG4CylinderCellDefs.h"
 
-#include <stdexcept>
-#include <sstream>
-#include <cassert>
 #include <boost/foreach.hpp>
+
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <stdexcept>
 #include <sstream>
+
 ClassImp(PHG4CylinderCellGeom_Spacalv1);
 
 using namespace std;

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
@@ -9,30 +9,24 @@
 #include <phool/getClass.h>
 
 #include <Geant4/G4AssemblyVolume.hh>
-#include <Geant4/G4IntersectionSolid.hh>
-#include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/G4Material.hh>
 #include <Geant4/G4Box.hh>
-#include <Geant4/G4ExtrudedSolid.hh>
-#include <Geant4/G4LogicalVolume.hh>
-#include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4TwoVector.hh>
-#include <Geant4/G4Trap.hh>
-#include <Geant4/G4GenericTrap.hh>
+#include <Geant4/G4Colour.hh>
 #include <Geant4/G4Cons.hh>
-#include <Geant4/G4Box.hh>
+#include <Geant4/G4ExtrudedSolid.hh>
+#include <Geant4/G4GenericTrap.hh>
+#include <Geant4/G4IntersectionSolid.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
+#include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4SubtractionSolid.hh>
+#include <Geant4/G4Trap.hh>
 #include <Geant4/G4Trd.hh>
 #include <Geant4/G4Tubs.hh>
-
+#include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4Colour.hh>
 
-#include <cmath>
-#include <sstream>
 
 #include <iostream>
-#include <fstream>
-#include <cstdlib>
 
 using namespace std;
 
@@ -170,5 +164,3 @@ PHG4EnvelopeDetector::Construct( G4LogicalVolume* logicWorld )
 		overlapcheck);
 	
 }
-
-

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.h
@@ -6,70 +6,63 @@
 #include <Geant4/globals.hh>
 #include <Geant4/G4Types.hh>
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4RotationMatrix.hh>
-#include <Geant4/G4Material.hh>
 
 #include <string>
-#include <map>
-#include <vector>
-#include <set>
 
-class G4AssemblyVolume;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
-class G4VSolid;
 
 class PHG4EnvelopeDetector: public PHG4Detector
 {
-	public:
-		//Constructor
-		PHG4EnvelopeDetector(  PHCompositeNode *Node, const std::string &dnam="BLOCK" );
+ public:
+  //Constructor
+  PHG4EnvelopeDetector(  PHCompositeNode *Node, const std::string &dnam="BLOCK" );
 	
-		//Destructor
-		virtual ~PHG4EnvelopeDetector();
+  //Destructor
+  virtual ~PHG4EnvelopeDetector();
 	
-		//Construct
-		virtual void Construct( G4LogicalVolume* world );
+  //Construct
+  virtual void Construct( G4LogicalVolume* world );
 	
-		//Volume accessors
-		bool IsInEnvelope(G4VPhysicalVolume*) const;
+  //Volume accessors
+  bool IsInEnvelope(G4VPhysicalVolume*) const;
 	
-		void SetPlace( G4double place_in_x, G4double place_in_y, G4double place_in_z) 
-		{
-			_placeInX = place_in_x;
-			_placeInY = place_in_y;
-			_placeInZ = place_in_z;
-		}
+  void SetPlace( G4double place_in_x, G4double place_in_y, G4double place_in_z) 
+  {
+    _placeInX = place_in_x;
+    _placeInY = place_in_y;
+    _placeInZ = place_in_z;
+  }
 	
-		void SetInnerRadius( G4double radius ) { _innerRadius = radius; }
-		void SetOuterRadius( G4double radius ) { _outerRadius = radius; }
-		void SetCylinderLength (G4double length) {_dZ_cyl = length; }
+  void SetInnerRadius( G4double radius ) { _innerRadius = radius; }
+  void SetOuterRadius( G4double radius ) { _outerRadius = radius; }
+  void SetCylinderLength (G4double length) {_dZ_cyl = length; }
 
-		void SetActive(const int i = 1) {_active = i;}
-		int IsActive() const {return _active;}
+  void SetActive(const int i = 1) {_active = i;}
+  int IsActive() const {return _active;}
 
-		void SuperDetector(const std::string &name) {_superdetector = name;}
-		const std::string SuperDetector() const {return _superdetector;}
+  void SuperDetector(const std::string &name) {_superdetector = name;}
+  const std::string SuperDetector() const {return _superdetector;}
 
-		int get_Layer() const {return _layer;}
+  int get_Layer() const {return _layer;}
 	
-	private:
-		G4double _placeInX;
-		G4double _placeInY;
-		G4double _placeInZ;
-		G4double _innerRadius;
-		G4double _outerRadius;
-		G4double _dZ;
-		G4double _dZ_cyl;
-		G4double _sPhi;
-		G4double _dPhi;
+ private:
+  G4double _placeInX;
+  G4double _placeInY;
+  G4double _placeInZ;
+  G4double _innerRadius;
+  G4double _outerRadius;
+  G4double _dZ;
+  G4double _dZ_cyl;
+  G4double _sPhi;
+  G4double _dPhi;
 		
-		G4String _materialCrystal;
+  G4String _materialCrystal;
 		
-		int _active;
-		int _layer;	
+  int _active;
+  int _layer;	
 	
-		std::string _superdetector;
+  std::string _superdetector;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlat.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlat.h
@@ -7,6 +7,7 @@
 #include <phool/PHObject.h>
 #include <cmath>
 #include <map>
+#include <set>
 
 class PHG4ScintillatorSlat : public PHObject
 {
@@ -30,7 +31,7 @@ class PHG4ScintillatorSlat : public PHObject
   virtual double get_edep() const {return NAN;}
   virtual double get_eion() const {return NAN;}
   virtual double get_light_yield() const  {return NAN;}
-
+  virtual std::pair<std::set<PHG4HitDefs::keytype>::const_iterator, std::set<PHG4HitDefs::keytype>::const_iterator> get_hit_ids() const = 0;
 
   
  protected:

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.h
@@ -29,7 +29,7 @@ class PHG4ScintillatorSlatv1 : public PHG4ScintillatorSlat
   double get_edep() const {return edep;}
   double get_eion() const {return eion;}
   double get_light_yield() const {return light_yield;}
-
+  std::pair<std::set<PHG4HitDefs::keytype>::const_iterator, std::set<PHG4HitDefs::keytype>::const_iterator> get_hit_ids() const {return std::make_pair(hit_id.begin(),hit_id.end());}
 
 
  protected:


### PR DESCRIPTION
The raw tower geometry was set during Init() while the parameters were only read from the node tree during the InitRun(), that lead to invalid radii and thickness's. Also missing was the loop which sets the eta/phi ranges. They are now filled generically from info added by the g4 detector implementation
Also some cleanup of include files and forward declaration