### PR TITLE
some improvements of sHijing

### DIFF
--- a/generators/sHijing/Hijing.cxx
+++ b/generators/sHijing/Hijing.cxx
@@ -96,22 +96,26 @@ int iap;
 int iat;
 int izp;
 int izt;
-int events;
 int spec;
 double m_vertexOffsetCut = 1.0E-7;
 bool keepSpectators;
 
 int
-main ()
+main (int argc, char **argv)
 {
+  string config_filename = "sHijing.xml";
+  if (argc > 1)
+    {
+      config_filename = argv[1];
+    }
+  cout << "using config file: " << config_filename << endl;
   char frame[] = "        ";
   char proj[]  = "        ";
   char targ[]  = "        ";
 
   using boost::property_tree::ptree;
   iptree pt, null;
-
-  std::ifstream config_file("sHijing.xml");
+  std::ifstream config_file(config_filename);
 
   if (config_file)
     {
@@ -133,7 +137,8 @@ main ()
   keepSpectators = pt.get("HIJING.KEEP_SPECTATORS", 1);
   std::string output = pt.get("HIJING.OUTPUT", "sHijing.dat");
 
-  long randomSeed = pt.get ("HIJING.RANDOM.SEED", 11793);
+  std::random_device rdev;
+  long randomSeed = pt.get ("HIJING.RANDOM.SEED", rdev());
   engine = new CLHEP::MTwistEngine (randomSeed);
 
   // See if there are any sections for HIPR1, IHPR2
@@ -176,7 +181,7 @@ main ()
 
   HIJSET (efrm, frame, proj, targ, iap, izp, iat, izt);
 
-  int status;
+  //  int status;
   HepMC::IO_GenEvent ascii_io (output.c_str(), std::ios::out);
   int events = 0;
   do 

--- a/generators/sHijing/Makefile.am
+++ b/generators/sHijing/Makefile.am
@@ -3,16 +3,22 @@ AUTOMAKE_OPTIONS = foreign
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-   `geant4-config --libs-without-gui` \
-  -lHepMC -lhijing -lhijing_dummy -lfastjet -lCGAL -lgfortran -lpthread
+  `geant4-config --libs-without-gui` \
+  -lHepMC \
+  -lhijing \
+  -lhijing_dummy \
+  -lfastjet \
+  -lCGAL \
+  -lgfortran \
+  -lpthread
 
 INCLUDES = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
-  `geant4-config --cflags-without-gui`
+  -isystem$(OFFLINE_MAIN)/include 
 
 AM_FFLAGS="-DFVOIDP=INTEGER*8"
-
+# turn off warnings about unused functions in cfortran.h
+AM_CXXFLAGS=-Wno-unused-function -Wall -Werror
 noinst_HEADERS = \
   HijCrdn.h \
   HijJet1.h \

--- a/generators/sHijing/configure.ac
+++ b/generators/sHijing/configure.ac
@@ -1,10 +1,11 @@
-AC_INIT(Hijing.cxx)
+AC_INIT(configure.ac)
 
 AM_INIT_AUTOMAKE(sHijing, 1.00)
 
-AC_PROG_CXX
+AC_PROG_CXX(CC g++)
 AC_PROG_F77(gfortran)
 AC_ENABLE_STATIC(no)
-AC_PROG_LIBTOOL
+LT_INIT
 
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/generators/sHijing/sHijing.xml
+++ b/generators/sHijing/sHijing.xml
@@ -8,14 +8,17 @@
   <IZP>79</IZP>
   <IAT>197</IAT>
   <IZT>79</IZT>
+  <!-- number of events -->
   <N>20</N>
   <BMIN>0</BMIN>
   <BMAX>4</BMAX>
   <KEEP_SPECTATORS>1</KEEP_SPECTATORS>
   <OUTPUT>sHijing.dat</OUTPUT>
+<!-- random number seed if we want to fix it, default is random
   <RANDOM>
     <SEED>11793</SEED>
   </RANDOM>
+-->
   <HIPR1>
     <5>5.0</5>
   </HIPR1>

--- a/generators/sHijing/sHijing.xml
+++ b/generators/sHijing/sHijing.xml
@@ -9,6 +9,8 @@
   <IAT>197</IAT>
   <IZT>79</IZT>
   <N>20</N>
+  <BMIN>0</BMIN>
+  <BMAX>4</BMAX>
   <KEEP_SPECTATORS>1</KEEP_SPECTATORS>
   <OUTPUT>sHijing.dat</OUTPUT>
   <RANDOM>


### PR DESCRIPTION
The config file can now be given as cmd line argument (clunky - should be replaced by boost program_options) so we can use this in batch. Default is now a random random seed, rather than hardcoded 11793. Can still be overridden by setting in config file. Some cleanups (cppcheck) took care of warnings, now -Werror enabled