### PR TITLE
Add support of prototype3 EMCal

### DIFF
--- a/offline/QA/modules/QAG4SimulationCalorimeter.C
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.C
@@ -384,6 +384,11 @@ QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
           // EM visible energy that is only associated with electron energy deposition
           PHG4Particle* particle = _truth_container->GetParticle(
               this_hit->get_trkid());
+          if (!particle)
+            {
+              cout <<__PRETTY_FUNCTION__<<" - Error - this PHG4hit missing particle: "; this_hit -> identify();
+            }
+          assert(particle);
           if (abs(particle->get_pid()) == 11)
             ev_calo_em += this_hit->get_light_yield();
 

--- a/offline/database/pdbcal/base/Makefile.am
+++ b/offline/database/pdbcal/base/Makefile.am
@@ -13,7 +13,8 @@ ROOTIFY  = perl $(srcdir)/PdbRootify.pl
 libpdbcalBase_la_LDFLAGS = \
   `root-config --evelibs`
 libpdbcalBase_la_LIBADD = \
-  -L$(libdir) -L$(OFFLINE_MAIN)/lib -lphool 
+  -L$(libdir) -L$(OFFLINE_MAIN)/lib -lphool \
+  -lXMLIO
 
 #please add new classes sorted according to the roman alphabet
 libpdbcalBase_la_SOURCES = \

--- a/offline/database/pdbcal/base/PdbParameterMap.cc
+++ b/offline/database/pdbcal/base/PdbParameterMap.cc
@@ -1,5 +1,6 @@
 #include "PdbParameterMap.h"
 
+#include  <boost/functional/hash.hpp>
 #include <iostream>
 
 using namespace std;
@@ -7,6 +8,8 @@ using namespace std;
 void
 PdbParameterMap::print() const
 {
+  cout <<"PdbParameterMap::print - Hash 0x"<<std::hex << get_hash()<<std::dec<<endl;
+
   cout << "double parameters: " << endl;
   for (map<const string, double>::const_iterator iter = dparams.begin(); iter != dparams.end(); ++iter)
     {
@@ -51,3 +54,40 @@ PdbParameterMap::set_string_param(const std::string &name, const string &str)
   cparams[name] = str;
 }
 
+
+size_t
+PdbParameterMap::get_hash() const
+{
+  size_t seed = 0;
+
+  for (dMap::const_iterator iter = dparams.begin();
+      iter != dparams.end(); ++iter)
+    {
+//      size_t seed = 0;
+      boost::hash_combine(seed, iter->first );
+      boost::hash_combine(seed, iter->second );
+//      cout << iter->first << ": " << iter->second <<" -> "<<seed<< endl;
+    }
+
+  for (iMap::const_iterator iter = iparams.begin();
+      iter != iparams.end(); ++iter)
+    {
+//      size_t seed = 0;
+      boost::hash_combine(seed, iter->first );
+      boost::hash_combine(seed, iter->second );
+//      cout << iter->first << ": " << iter->second <<" -> "<<seed<< endl;
+    }
+
+  for (strMap::const_iterator iter = cparams.begin();
+      iter != cparams.end(); ++iter)
+    {
+//      size_t seed = 0;
+      boost::hash_combine(seed, iter->first );
+      boost::hash_combine(seed, iter->second );
+//      cout << iter->first << ": " << iter->second <<" -> "<<seed<< endl;
+    }
+
+
+  return seed;
+
+}

--- a/offline/database/pdbcal/base/PdbParameterMap.h
+++ b/offline/database/pdbcal/base/PdbParameterMap.h
@@ -25,6 +25,9 @@ class PdbParameterMap: public PdbCalChan
   void print() const;
   void Reset(); // from PHObject - clear content
 
+  //! hash of binary information for checking purpose
+  size_t get_hash() const;
+
   dConstRange get_dparam_iters() const 
     {return make_pair(dparams.begin(),dparams.end());}
 

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.cc
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.cc
@@ -1,11 +1,20 @@
 #include "PdbParameterMapContainer.h"
 #include "PdbParameterMap.h"
+#include "PdbBankID.h"
 
 #include <phool/phool.h>
+#include <phool/PHTimeStamp.h>
 
+#include <TBufferXML.h>
+#include <TFile.h>
 #include <TSystem.h>
 
+#include <cassert>
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
 #include <iostream>
+#include <sstream>
 
 using namespace std;
 
@@ -62,4 +71,54 @@ PdbParameterMapContainer::GetParametersToModify(const int layer)
       return NULL;
     }
   return iter->second;
+}
+
+int
+PdbParameterMapContainer::WriteToFile(const std::string &detector_name,
+    const string &extension, const string &dir)
+{
+  //Note the naming convention should be consistent with PHG4Parameters::WriteToFile
+
+  ostringstream fullpath;
+  ostringstream fnamestream;
+  PdbBankID bankID(0); // lets start at zero
+  PHTimeStamp TStart(0);
+  PHTimeStamp TStop(0xffffffff);
+  fullpath << dir;
+  // add / if directory lacks ending /
+  if (*(dir.rbegin()) != '/')
+    {
+      fullpath << "/";
+    }
+  fnamestream << detector_name << "_geoparams" << "-"
+      << bankID.getInternalValue() << "-" << TStart.getTics() << "-"
+      << TStop.getTics() << "-" << time(0) << "." << extension;
+  string fname = fnamestream.str();
+  std::transform(fname.begin(), fname.end(), fname.begin(), ::tolower);
+  fullpath << fname;
+
+  cout << "PdbParameterMapContainer::WriteToFile - save to " << fullpath.str()
+      << endl;
+
+  TFile *f = TFile::Open(fullpath.str().c_str(), "recreate");
+
+  PdbParameterMapContainer * container = new PdbParameterMapContainer();
+  for (std::map<int, PdbParameterMap *>::const_iterator it =
+      parametermap.begin(); it != parametermap.end(); ++it)
+    {
+      PdbParameterMap *myparm = static_cast<PdbParameterMap *> (it->second->Clone());
+      container->AddPdbParameterMap(it->first, myparm);
+    }
+
+  // force xml file writing to use extended precision shown experimentally
+  // to not modify input parameters (.15e)
+  string floatformat = TBufferXML::GetFloatFormat();
+  TBufferXML::SetFloatFormat("%.15e");
+  container->Write("PdbParameterMapContainer");
+  delete f;
+  // restore previous xml float format
+  TBufferXML::SetFloatFormat(floatformat.c_str());
+  cout << "sleeping 1 second to prevent duplicate inserttimes" << endl;
+  sleep(1);
+  return 0;
 }

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.cc
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.cc
@@ -113,7 +113,7 @@ PdbParameterMapContainer::WriteToFile(const std::string &detector_name,
   // force xml file writing to use extended precision shown experimentally
   // to not modify input parameters (.15e)
   string floatformat = TBufferXML::GetFloatFormat();
-  TBufferXML::SetFloatFormat("%.15e");
+  TBufferXML::SetFloatFormat("%.17g"); // for IEEE 754 double
   container->Write("PdbParameterMapContainer");
   delete f;
   // restore previous xml float format

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.h
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.h
@@ -25,6 +25,9 @@ class PdbParameterMapContainer: public PdbCalChan
   PdbParameterMap *GetParametersToModify(const int layer);
   parConstRange get_ParameterMaps() const {return make_pair(parametermap.begin(), parametermap.end());}
 
+  //! write PdbParameterMapContainer to an external file with root or xml extension.
+  int WriteToFile(const std::string &detector_name, const std::string &extension, const std::string &dir = ".");
+
  protected:
   std::map<int, PdbParameterMap *> parametermap;
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
@@ -223,9 +223,9 @@ public:
     int tower_ID;
     int fiber_ID;
 
-    static const int kfiber_bit = 12;
-    static const int ktower_bit = 12;
-    static const int ksector_bit = 8;
+    static const int kfiber_bit = 13; // max 8192 fiber per tower
+    static const int ktower_bit = 11; // max 2048 towers per sector
+    static const int ksector_bit = 8; // max 256 sectors
 
   ClassDef(PHG4CylinderGeom_Spacalv3::scint_id_coder,1)
   };

--- a/simulation/g4simulation/g4detectors/PHG4Parameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Parameters.cc
@@ -15,6 +15,7 @@
 #include <TBufferXML.h>
 #include <TFile.h>
 #include <TSystem.h>
+#include <TBufferFile.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
@@ -116,11 +117,24 @@ PHG4Parameters::exist_double_param(const std::string &name) const
 void
 PHG4Parameters::Print() const
 {
-  cout << "Parameters for " << detname << endl;
+  cout << "Parameters for " << detname << " (Hash = 0x"<< std::hex << get_hash() << std::dec <<")" << endl;
   printint();
   printdouble();
   printstring();
   return;
+}
+
+unsigned long
+PHG4Parameters::get_hash() const
+{
+
+  const TObject *ptr = dynamic_cast<const TObject *>(this);
+  assert(ptr);
+  std::unique_ptr<TBuffer> b(new TBufferFile(TBuffer::kWrite));
+
+  b->WriteObject(ptr);
+
+  return TString::Hash(b->Buffer(), b->Length());
 }
 
 void

--- a/simulation/g4simulation/g4detectors/PHG4Parameters.h
+++ b/simulation/g4simulation/g4detectors/PHG4Parameters.h
@@ -30,7 +30,7 @@ class PHG4Parameters: public PHObject
   void Print() const;
 
   //! hash of binary information for checking purpose
-  unsigned long get_hash() const;
+  size_t get_hash() const;
 
   void set_int_param(const std::string &name, const int ival);
   int get_int_param(const std::string &name) const;

--- a/simulation/g4simulation/g4detectors/PHG4Parameters.h
+++ b/simulation/g4simulation/g4detectors/PHG4Parameters.h
@@ -29,6 +29,9 @@ class PHG4Parameters: public PHObject
 
   void Print() const;
 
+  //! hash of binary information for checking purpose
+  unsigned long get_hash() const;
+
   void set_int_param(const std::string &name, const int ival);
   int get_int_param(const std::string &name) const;
   bool exist_int_param(const std::string &name) const;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.cc
@@ -888,10 +888,10 @@ PHG4SpacalPrototypeDetector::Construct_LightGuide(
   assert(weight_x2 >=0 and weight_x2<=1);
   assert(weight_xcenter >=0 and weight_xcenter<=1);
 
-  const double lg_pDx1 = g_tower.pDx1 * weight_x1 //
-  + g_tower.pDx2 * (1 - weight_x1) / g_tower.NSubtowerX;
-  const double lg_pDx2 = g_tower.pDx1 * weight_x2 //
-  + g_tower.pDx2 * (1 - weight_x2) / g_tower.NSubtowerX;
+  const double lg_pDx1 =( g_tower.pDx1 * weight_x1 //
+  + g_tower.pDx2 * (1 - weight_x1) )/ g_tower.NSubtowerX;
+  const double lg_pDx2 =( g_tower.pDx1 * weight_x2 //
+  + g_tower.pDx2 * (1 - weight_x2) )/ g_tower.NSubtowerX;
   const double lg_pDy1 = g_tower.pDy1 / g_tower.NSubtowerY;
   const double lg_Alp1 = atan(
       (g_tower.pDx2 - g_tower.pDx1) * (-g_tower.NSubtowerX + 1. + 2 * index_x)

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
@@ -156,8 +156,9 @@ PHG4SpacalPrototypeSubsystem::Print(const std::string &what) const
 void
 PHG4SpacalPrototypeSubsystem::SetDefaultParameters()
 {
-  set_default_double_param("xpos", 0.);
-  set_default_double_param("ypos", 0.);
-  set_default_double_param("zpos", 0.);
+  set_default_double_param("xpos", 0.); // translation in 3D
+  set_default_double_param("ypos", 0.); // translation in 3D
+  set_default_double_param("zpos", 0.); // translation in 3D
+  set_default_double_param("z_rotation_degree", 0.); // roation in the vertical plane
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
@@ -160,5 +160,6 @@ PHG4SpacalPrototypeSubsystem::SetDefaultParameters()
   set_default_double_param("ypos", 0.); // translation in 3D
   set_default_double_param("zpos", 0.); // translation in 3D
   set_default_double_param("z_rotation_degree", 0.); // roation in the vertical plane
+  set_default_int_param("construction_verbose", 0.); // roation in the vertical plane
   return;
 }


### PR DESCRIPTION
A few update on the core software to support the prototype3 EMCal simulation: 

- Support save PdbParameterMapContainer to files
- To address #199, add hash check to PdbParameterMap and expanded the XML output decimal precision from ```%15e``` to ```%18g``` (required precision for loss-less save of IEEE 754 double). Confirmed the read back reproduce the initial binary hash
- Update SPACAL 32-bit scintillator ID assignment to support higher fiber count in 2x2 blocks. This will **break the backward compatibility with previously simulated EMCal DSTs in both sPHENIX and prototypes.** 
- Minor: allow user to set the rotation of EMCal around the (sphenix) z axis 
- Minor: add G4hit->G4particle consistency check on the truth container in the calorimetry QA module. 

## Event display

32 GeV pion in prototype3 calorimetry system:
![prototypethree14](https://cloud.githubusercontent.com/assets/7947083/21614372/36d9cf6e-d1a7-11e6-93f5-3b49d606e460.png)
![prototypethree15](https://cloud.githubusercontent.com/assets/7947083/21614409/5aaf551c-d1a7-11e6-8d66-b224f89178cc.png)

32 GeV electron in prototype3 EMCal (with 10 degree tilt vertically) at center of one tower
![prototypethree23](https://cloud.githubusercontent.com/assets/7947083/21614384/45da2fcc-d1a7-11e6-89b1-82b6ffca5d00.png)
![prototypethree24](https://cloud.githubusercontent.com/assets/7947083/21614399/55beb0f2-d1a7-11e6-8861-860a12e91d32.png)


## Performance check for prototype3 EMCal

Standard calorimetry QA: 
**Note**: comparing to pre-CDR simulation of sPHENIX 2-D projective calorimeter, this prototype has 15% relatively less fibers density. (pre-CDR simulation has 2880 fibers in 2x2 block and prototype3 has 2444 fibers), this leads to significantly lower sampling fraction.
![prototypethree19](https://cloud.githubusercontent.com/assets/7947083/21614657/4f9e0244-d1a8-11e6-854d-c30ef5030048.png)

Resolution comparison with calorimeter tilted by 10 degree and shooting in the center of one tower:
**Note**: worse statistical term is expected from reduced fiber density. Higher constant term is expected from higher variation of sampling fraction VS depth with 2-D projective geometry. 
![prototypethree25](https://cloud.githubusercontent.com/assets/7947083/21614680/6390401e-d1a8-11e6-9d4e-c50f5f3450c9.png)


## Performance consistency check for 24 GeV electron with |eta|<0.1 in sPHENIX 2-D projective SPACAL

G4-hit check, which is consistent: 
![prototypethree19](https://cloud.githubusercontent.com/assets/7947083/21614796/0259adc0-d1a9-11e6-9353-f6286df77afd.png)

Tower check
**Note**: the pedestal peak in the tower response is gone! The problem trace to previous pull request #226, in which towers without Geant4 hit was not digitized. Digitization of non-Geant4-hit tower is necessary in order to produce the SiPM noise which adds to ~20GeV per event in the whole EMCal.
![prototypethree27](https://cloud.githubusercontent.com/assets/7947083/21614775/efed3ca6-d1a8-11e6-98e0-05239fb29462.png)


