### PR TITLE
print out random number seeds for debugging

### DIFF
--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -50,9 +50,11 @@ HepMCNodeReader::HepMCNodeReader(const std::string &name)
       vertex_t0(0.0),
       width_vx(0.0),
       width_vy(0.0),
-      width_vz(0.0) {
+      width_vz(0.0) 
+{
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
   unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
+  cout << Name() << " random seed: " << seed << endl;
   gsl_rng_set(RandomGenerator, seed);
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
@@ -30,6 +30,7 @@ PHG4ParticleGeneratorBase::PHG4ParticleGeneratorBase(const string &name):
 {
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
   seed = PHRandomSeed(); // fixed seed is handled in this funtcion
+  cout << Name() << " random seed: " << seed << endl;
   gsl_rng_set(RandomGenerator,seed);
   return;
 }
@@ -206,6 +207,7 @@ void
 PHG4ParticleGeneratorBase::set_seed(const unsigned int iseed)
 {
   seed = iseed;
+  cout << Name() << " random seed: " << seed << endl;
   gsl_rng_set(RandomGenerator,seed);
 }
 

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
@@ -97,7 +97,9 @@ PHG4ParticleGeneratorD0::set_mass(const double mass_in)
 int
 PHG4ParticleGeneratorD0::InitRun(PHCompositeNode *topNode)
 {
-  gRandom->SetSeed(PHRandomSeed()); // fixed seed handled in PHRandomSeed()
+  unsigned int iseed = PHRandomSeed(); // fixed seed handled in PHRandomSeed()
+  cout << Name() << " random seed: " << iseed << endl;
+  gRandom->SetSeed(iseed);
 
   fsin = new TF1("fsin","sin(x)",0,M_PI);
 

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -152,10 +152,14 @@ PHG4ParticleGeneratorVectorMeson::InitRun(PHCompositeNode *topNode)
   cout << "PHG4ParticleGeneratorVectorMeson::InitRun started." << endl;
 
   trand = new TRandom3();
-  trand->SetSeed(PHRandomSeed()); // fixed seed handles in PHRandomSeed()
+  unsigned int iseed = PHRandomSeed(); // fixed seed handles in PHRandomSeed()
+  cout << Name() << " random seed: " << iseed << endl;
+  trand->SetSeed(iseed);
   if (_histrand_init)
     {
-      gRandom->SetSeed(PHRandomSeed());
+      iseed = PHRandomSeed();
+      cout << Name() << " histrand random seed: " << iseed << endl;
+      gRandom->SetSeed(iseed);
     }
 
   fsin = new TF1("fsin","sin(x)",0,M_PI);

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -152,8 +152,9 @@ int PHG4Reco::Init( PHCompositeNode* topNode )
   if (verbosity > 0) {
     cout << "========================= PHG4Reco::Init() ================================" << endl;
   }
-
-  G4Seed(PHRandomSeed()); // fixed seed handled in PHRandomSeed()
+  unsigned int iseed = PHRandomSeed();
+  cout << Name() << " G4 Random Seed: " << iseed << endl;
+  G4Seed(iseed); // fixed seed handled in PHRandomSeed()
   
   // create GEANT run manager
   if (verbosity > 1) cout << "PHG4Reco::Init - create run manager" << endl;


### PR DESCRIPTION
When running hijing simulations we have very rare crashes which are not reproducible when just rerunning with a different seed. Now the seed is printed out so those crashes can be reproduced