### PR TITLE
fix tower digitization (put old scheme to loop over all possible towers back in)

### DIFF
--- a/simulation/g4simulation/g4cemc/RawClusterContainer.cc
+++ b/simulation/g4simulation/g4cemc/RawClusterContainer.cc
@@ -4,8 +4,6 @@
 #include <cstdlib>
 #include <iostream>
 
-ClassImp(RawClusterContainer)
-
 using namespace std;
 
 RawClusterContainer::ConstRange

--- a/simulation/g4simulation/g4cemc/RawClusterv1.cc
+++ b/simulation/g4simulation/g4cemc/RawClusterv1.cc
@@ -2,10 +2,8 @@
 
 using namespace std;
 
-ClassImp(RawClusterv1)
-
-RawClusterv1::RawClusterv1()
-: RawCluster(),
+RawClusterv1::RawClusterv1():
+  RawCluster(),
   clusterid(0),
   _eta(0.0),
   _phi(0.0),

--- a/simulation/g4simulation/g4cemc/RawTowerContainer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerContainer.cc
@@ -4,8 +4,6 @@
 #include <cstdlib>
 #include <iostream>
 
-ClassImp(RawTowerContainer)
-
 using namespace std;
 
 void 

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.cc
@@ -3,11 +3,13 @@
 #include "RawTowerGeomContainer.h"
 #include "RawTowerGeom.h"
 #include "RawTowerv1.h"
+
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
 #include <g4detectors/PHG4CylinderCellGeom.h>
 #include <g4detectors/PHG4CylinderCellContainer.h>
 #include <g4detectors/PHG4CylinderCell.h>
 #include <g4detectors/PHG4CylinderCellDefs.h>
+
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHIODataNode.h>
@@ -16,31 +18,36 @@
 #include <phool/getClass.h>
 #include <phool/recoConsts.h>
 
-#include <iostream>
-#include <stdexcept>
-#include <map>
-#include <cmath>
-
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
+
+#include <cmath>
+#include <iostream>
+#include <map>
+#include <stdexcept>
 
 using namespace std;
 
 RawTowerDigitizer::RawTowerDigitizer(const std::string& name) :
-    SubsysReco(name), _digi_algorithm(kNo_digitization), //
-    _sim_towers(NULL), _raw_towers(NULL), rawtowergeom(NULL), //
-    detector("NONE"), //
-    _sim_tower_node_prefix("SIM"), _raw_tower_node_prefix("RAW"), //
-    _photonelec_yield_visible_GeV(NAN), //default to invalid
-    _photonelec_ADC(NAN), //default to invalid
-    _pedstal_central_ADC(NAN), //default to invalid
-    _pedstal_width_ADC(NAN), //default to invalid
-    _zero_suppression_ADC(0), //default to apply no zero suppression
-    _tower_type(-1),
-    _timer(PHTimeServer::get()->insert_new(name))
+  SubsysReco(name), 
+  _digi_algorithm(kNo_digitization), 
+  _sim_towers(nullptr), 
+  _raw_towers(nullptr), 
+  rawtowergeom(nullptr),
+  detector("NONE"),
+  _sim_tower_node_prefix("SIM"), 
+  _raw_tower_node_prefix("RAW"), //
+  _photonelec_yield_visible_GeV(NAN), //default to invalid
+  _photonelec_ADC(NAN), //default to invalid
+  _pedstal_central_ADC(NAN), //default to invalid
+  _pedstal_width_ADC(NAN), //default to invalid
+  _zero_suppression_ADC(0), //default to apply no zero suppression
+  _tower_type(-1),
+  _timer(PHTimeServer::get()->insert_new(name))
 {
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
   seed = PHRandomSeed(); // fixed seed handled in PHRandomSeed()
+  cout << Name() << " Random Seed: " << seed << endl;
   gsl_rng_set(RandomGenerator, seed);
 }
 
@@ -64,12 +71,11 @@ RawTowerDigitizer::InitRun(PHCompositeNode *topNode)
 
   // Looking for the DST node
   PHCompositeNode *dstNode;
-  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",
-      "DST"));
+  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
     {
-      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << "DST Node missing, doing nothing." << std::endl;
+      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+	   << "DST Node missing, doing nothing." << endl;
       exit(1);
     }
 
@@ -79,7 +85,7 @@ RawTowerDigitizer::InitRun(PHCompositeNode *topNode)
     }
   catch (std::exception& e)
     {
-      std::cout << e.what() << std::endl;
+      cout << e.what() << endl;
       return Fun4AllReturnCodes::ABORTRUN;
     }
   return Fun4AllReturnCodes::EVENT_OK;
@@ -90,79 +96,82 @@ RawTowerDigitizer::process_event(PHCompositeNode *topNode)
 {
   if (verbosity)
     {
-      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << "Process event entered. " << "Digitalization method: ";
+      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+	   << "Process event entered. " << "Digitalization method: ";
 
       if (kNo_digitization)
-        cout << "directly pass the energy of sim tower to digitalized tower";
+	{
+	  cout << "directly pass the energy of sim tower to digitalized tower";
+	}
       else if (kSimple_photon_digitization)
-        cout
-            << "simple digitization with photon statistics, ADC conversion and pedstal";
-
-      std::cout << std::endl;
+	{
+	  cout << "simple digitization with photon statistics, ADC conversion and pedstal";
+	}
+      cout << endl;
     }
-
+  // loop over all possible towers, even empty ones. The digitization can add towers containing
+  // pedestals
   RawTowerGeomContainer::ConstRange all_towers = rawtowergeom->get_tower_geometries();
 
   for (RawTowerGeomContainer::ConstIterator it = all_towers.first;
-      it != all_towers.second; ++it)
+       it != all_towers.second; ++it)
     {
       const RawTowerDefs::keytype key = it->second->get_id();
-      if(_tower_type>=0)
+      if(_tower_type >= 0)
 	{
 	  // Skip towers that don't match the type we are supposed to digitize
-	  if(_tower_type != it->second->get_tower_type()) 
+	  if(_tower_type != it->second->get_tower_type())
 	    {
-	      continue; 
+	      continue;
 	    }
 	}
 
       RawTower *sim_tower = _sim_towers->getTower(key);
+      RawTower *digi_tower = nullptr;
 
-
-      if (sim_tower)
+      if (_digi_algorithm == kNo_digitization)
 	{
-	  RawTower *digi_tower = NULL;
-	  if (_digi_algorithm == kNo_digitization)
+	  // for no digitization just copy existing towers
+	  if (sim_tower)
 	    {
-              digi_tower = new RawTowerv1(*sim_tower);
+	      digi_tower = new RawTowerv1(*sim_tower);
 	    }
-	  else if (_digi_algorithm == kSimple_photon_digitization)
+	}
+      else if (_digi_algorithm == kSimple_photon_digitization)
+	{
+	  // for photon digitization towers can be created if sim_tower is null pointer
+	  digi_tower = simple_photon_digitization(sim_tower);
+	}
+      else
+	{
+	  cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+	       << " invalid digitization algorithm #" << _digi_algorithm
+	       << endl;
+
+	  return Fun4AllReturnCodes::ABORTRUN;
+	}
+      if (digi_tower)
+	{
+	  _raw_towers->AddTower(key, digi_tower);
+
+	  if (verbosity)
 	    {
-	      digi_tower = simple_photon_digitization(sim_tower);
+	      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+		   << " output tower:"
+		   << endl;
+	      digi_tower->identify();
 	    }
-	  else
-	    {
-
-	      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-			<< " invalid digitization algorithm #" << _digi_algorithm
-			<< std::endl;
-
-	      return Fun4AllReturnCodes::ABORTRUN;
-	    }
-	  if (digi_tower)
-	    {
-	      //	digi_tower->set_tower_type(_tower_type);
-	      _raw_towers->AddTower(key, digi_tower);
-
-	      if (verbosity)
-		{
-		  std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-			    << " output tower:"
-			    << std::endl;
-		  digi_tower->identify();
-		}
-	    }
-
 	}
 
     }
+
+
   if (verbosity)
     {
-      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-		<< "input sum energy = " << _sim_towers->getTotalEdep()
-		<< ", output sum digitalized value = " << _raw_towers->getTotalEdep()
-		<< std::endl;
+      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+	   << "input sum energy = " << _sim_towers->getTotalEdep()
+	   << ", output sum digitalized value = " << _raw_towers->getTotalEdep()
+	   << endl;
     }
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -170,58 +179,61 @@ RawTowerDigitizer::process_event(PHCompositeNode *topNode)
 RawTower *
 RawTowerDigitizer::simple_photon_digitization(RawTower * sim_tower)
 {
-  RawTower *digi_tower = NULL;
+  RawTower *digi_tower = nullptr;
 
   double energy = 0;
   if (sim_tower)
-    energy = sim_tower->get_energy();
-
+    {
+      energy = sim_tower->get_energy();
+    }
   const double photon_count_mean = energy * _photonelec_yield_visible_GeV;
   const int photon_count = gsl_ran_poisson(RandomGenerator, photon_count_mean);
   const int signal_ADC = floor(photon_count / _photonelec_ADC);
 
-  const double pedstal = _pedstal_central_ADC
-      + ((_pedstal_width_ADC > 0) ?
-          gsl_ran_gaussian(RandomGenerator, _pedstal_width_ADC) : 0);
+  const double pedstal = _pedstal_central_ADC + ((_pedstal_width_ADC > 0) ? gsl_ran_gaussian(RandomGenerator, _pedstal_width_ADC) : 0);
   const int sum_ADC = signal_ADC + (int) pedstal;
 
   if (sum_ADC > _zero_suppression_ADC)
     {
       // create new digitalizaed tower
       if (sim_tower)
-        digi_tower = new RawTowerv1(*sim_tower);
+	{
+	  digi_tower = new RawTowerv1(*sim_tower);
+	}
       else
-        digi_tower = new RawTowerv1();
-
+	{
+	  digi_tower = new RawTowerv1();
+	}
       digi_tower->set_energy((double) sum_ADC);
     }
 
   if (verbosity >= 2)
     {
-      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << std::endl;
+      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+	   << endl;
 
       cout << "input: ";
       if (sim_tower)
-        sim_tower->identify();
+	{
+	  sim_tower->identify();
+	}
       else
-        cout << "None" << endl;
+	{
+	  cout << "None" << endl;
+	}
       cout << "output based on " << "sum_ADC = " << sum_ADC << ", zero_sup = "
-          << _zero_suppression_ADC << " : ";
+	   << _zero_suppression_ADC << " : ";
       if (digi_tower)
-        digi_tower->identify();
+	{
+	  digi_tower->identify();
+	}
       else
-        cout << "None" << endl;
-
+	{
+	  cout << "None" << endl;
+	}
     }
 
   return digi_tower;
-}
-
-int
-RawTowerDigitizer::End(PHCompositeNode *topNode)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 void
@@ -229,27 +241,24 @@ RawTowerDigitizer::CreateNodes(PHCompositeNode *topNode)
 {
 
   PHNodeIterator iter(topNode);
-  PHCompositeNode *runNode = static_cast<PHCompositeNode*>(iter.findFirst(
-      "PHCompositeNode", "RUN"));
+  PHCompositeNode *runNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
   if (!runNode)
     {
-      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << "Run Node missing, doing nothing." << std::endl;
+      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+	   << "Run Node missing, doing nothing." << endl;
       throw std::runtime_error(
-          "Failed to find Run node in RawTowerDigitizer::CreateNodes");
+			       "Failed to find Run node in RawTowerDigitizer::CreateNodes");
     }
 
   TowerGeomNodeName = "TOWERGEOM_" + detector;
-  rawtowergeom = findNode::getClass<RawTowerGeomContainer>(topNode,
-      TowerGeomNodeName.c_str());
+  rawtowergeom = findNode::getClass<RawTowerGeomContainer>(topNode, TowerGeomNodeName.c_str());
   if (!rawtowergeom)
     {
-      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << " " << TowerGeomNodeName << " Node missing, doing bail out!"
-          << std::endl;
-      throw std::runtime_error(
-          "Failed to find " + TowerGeomNodeName
-              + " node in RawTowerDigitizer::CreateNodes");
+      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+	   << " " << TowerGeomNodeName << " Node missing, doing bail out!"
+	   << endl;
+      throw std::runtime_error("Failed to find " + TowerGeomNodeName
+			       + " node in RawTowerDigitizer::CreateNodes");
     }
 
   if (verbosity >= 1)
@@ -257,33 +266,28 @@ RawTowerDigitizer::CreateNodes(PHCompositeNode *topNode)
       rawtowergeom->identify();
     }
 
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
-      "PHCompositeNode", "DST"));
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
     {
-      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << "DST Node missing, doing nothing." << std::endl;
-      throw std::runtime_error(
-          "Failed to find DST node in RawTowerDigitizer::CreateNodes");
+      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+	   << "DST Node missing, doing nothing." << endl;
+      throw std::runtime_error("Failed to find DST node in RawTowerDigitizer::CreateNodes");
     }
 
   SimTowerNodeName = "TOWER_" + _sim_tower_node_prefix + "_" + detector;
-  _sim_towers = findNode::getClass<RawTowerContainer>(dstNode,
-      SimTowerNodeName.c_str());
+  _sim_towers = findNode::getClass<RawTowerContainer>(dstNode, SimTowerNodeName.c_str());
   if (!_sim_towers)
     {
-      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << " " << SimTowerNodeName << " Node missing, doing bail out!"
-          << std::endl;
-      throw std::runtime_error(
-          "Failed to find " + SimTowerNodeName
-              + " node in RawTowerDigitizer::CreateNodes");
+      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+	   << " " << SimTowerNodeName << " Node missing, doing bail out!"
+	   << endl;
+      throw std::runtime_error("Failed to find " + SimTowerNodeName
+			       + " node in RawTowerDigitizer::CreateNodes");
     }
 
   // Create the tower nodes on the tree
   PHNodeIterator dstiter(dstNode);
-  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst(
-      "PHCompositeNode", detector));
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode", detector));
   if (!DetNode)
     {
       DetNode = new PHCompositeNode(detector);
@@ -292,13 +296,14 @@ RawTowerDigitizer::CreateNodes(PHCompositeNode *topNode)
 
   // Be careful as a previous digitizer may have been registered for this detector
   RawTowerNodeName = "TOWER_" + _raw_tower_node_prefix + "_" + detector;
-  _raw_towers = findNode::getClass<RawTowerContainer>(DetNode,RawTowerNodeName.c_str());
-  if (!_raw_towers){
-    _raw_towers = new RawTowerContainer( _sim_towers -> getCalorimeterID()  );
-    PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_raw_towers,
-								   RawTowerNodeName.c_str(), "PHObject");
-    DetNode->addNode(towerNode);
-  }
+  _raw_towers = findNode::getClass<RawTowerContainer>(DetNode, RawTowerNodeName.c_str());
+  if (!_raw_towers)
+    {
+      _raw_towers = new RawTowerContainer( _sim_towers -> getCalorimeterID()  );
+      PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_raw_towers,
+								     RawTowerNodeName.c_str(), "PHObject");
+      DetNode->addNode(towerNode);
+    }
 
   return;
 }

--- a/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4cemc/RawTowerDigitizer.h
@@ -2,9 +2,9 @@
 #define RawTowerDigitizer_H__
 
 #include <fun4all/SubsysReco.h>
-#include <string>
-
 #include <phool/PHTimeServer.h>
+
+#include <string>
 
 class PHCompositeNode;
 class RawTowerContainer;
@@ -25,33 +25,16 @@ class RawTowerDigitizer : public SubsysReco
 
 public:
   RawTowerDigitizer(const std::string& name = "RawTowerDigitizer");
-  virtual
-  ~RawTowerDigitizer();
+  virtual ~RawTowerDigitizer();
 
-  int
-  InitRun(PHCompositeNode *topNode);
-  int
-  process_event(PHCompositeNode *topNode);
-  int
-  End(PHCompositeNode *topNode);
-  void
-  Detector(const std::string &d)
-  {
-    detector = d;
-  }
-  void
-  TowerType(const int type)
-  {
-    _tower_type = type; 
-  } 
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  void Detector(const std::string &d) {detector = d;}
 
-  void
-  set_seed(const unsigned int iseed);
-  unsigned int
-  get_seed() const
-  {
-    return seed;
-  }
+  void TowerType(const int type) {_tower_type = type;} 
+
+  void set_seed(const unsigned int iseed);
+  unsigned int get_seed() const {return seed;}
 
   enum enu_digi_algorithm
   {
@@ -85,7 +68,7 @@ public:
   }
 
   void
-  set_pedstal_central_ADC(double pedstalCentralAdc)
+  set_pedstal_central_ADC(const double pedstalCentralAdc)
   {
     _pedstal_central_ADC = pedstalCentralAdc;
   }
@@ -97,7 +80,7 @@ public:
   }
 
   void
-  set_pedstal_width_ADC(double pedstalWidthAdc)
+  set_pedstal_width_ADC(const double pedstalWidthAdc)
   {
     _pedstal_width_ADC = pedstalWidthAdc;
   }
@@ -109,7 +92,7 @@ public:
   }
 
   void
-  set_photonelec_ADC(double photonelecAdc)
+  set_photonelec_ADC(const double photonelecAdc)
   {
     _photonelec_ADC = photonelecAdc;
   }
@@ -121,7 +104,7 @@ public:
   }
 
   void
-  set_photonelec_yield_visible_GeV(double photonelecYieldVisibleGeV)
+  set_photonelec_yield_visible_GeV(const double photonelecYieldVisibleGeV)
   {
     _photonelec_yield_visible_GeV = photonelecYieldVisibleGeV;
   }
@@ -133,7 +116,7 @@ public:
   }
 
   void
-  set_zero_suppression_ADC(double zeroSuppressionAdc)
+  set_zero_suppression_ADC(const double zeroSuppressionAdc)
   {
     _zero_suppression_ADC = zeroSuppressionAdc;
   }
@@ -145,7 +128,7 @@ public:
   }
 
   void
-  set_raw_tower_node_prefix(std::string rawTowerNodePrefix)
+  set_raw_tower_node_prefix(const std::string &rawTowerNodePrefix)
   {
     _raw_tower_node_prefix = rawTowerNodePrefix;
   }
@@ -157,21 +140,19 @@ public:
   }
 
   void
-  set_sim_tower_node_prefix(std::string simTowerNodePrefix)
+  set_sim_tower_node_prefix(const std::string &simTowerNodePrefix)
   {
     _sim_tower_node_prefix = simTowerNodePrefix;
   }
 protected:
-  void
-  CreateNodes(PHCompositeNode *topNode);
+  void CreateNodes(PHCompositeNode *topNode);
 
   enu_digi_algorithm _digi_algorithm;
 
   //! simple digitization with photon statistics, ADC conversion and pedstal
   //! \param  sim_tower simulation tower input
   //! \return a new RawTower object contain digitalized value of ADC output in RawTower::get_energy()
-  RawTower *
-  simple_photon_digitization(RawTower * sim_tower);
+  RawTower *simple_photon_digitization(RawTower * sim_tower);
 
   RawTowerContainer* _sim_towers;
   RawTowerContainer* _raw_towers;

--- a/simulation/g4simulation/g4cemc/RawTowerGeom.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerGeom.cc
@@ -3,8 +3,6 @@
 #include <cmath>
 #include <cstdlib>
 
-ClassImp(RawTowerGeom)
-
 using namespace std;
 
 void

--- a/simulation/g4simulation/g4cemc/RawTowerGeomContainer.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomContainer.cc
@@ -1,17 +1,11 @@
 #include "RawTowerGeomContainer.h"
-#include "RawTowerGeom.h"
 
-#include <cstdlib>
 #include <iostream>
-
-ClassImp(RawTowerGeomContainer)
 
 using namespace std;
 
-
-
 void
-RawTowerGeomContainer::identify(std::ostream& os) const
+RawTowerGeomContainer::identify(ostream& os) const
 {
-  os << "Base class RawTowerGeomContainer."<< std::endl;
+  os << "Base class RawTowerGeomContainer."<< endl;
 }

--- a/simulation/g4simulation/g4cemc/RawTowerGeomContainer_Cylinderv1.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomContainer_Cylinderv1.cc
@@ -1,16 +1,16 @@
 #include "RawTowerGeomContainer_Cylinderv1.h"
 
+#include <cassert>
+#include <cmath>
 #include <cstdlib>
 #include <iostream>
-#include <cassert>
-
-ClassImp(RawTowerGeomContainer_Cylinderv1)
 
 using namespace std;
 
-RawTowerGeomContainer_Cylinderv1::RawTowerGeomContainer_Cylinderv1(
-    RawTowerDefs::CalorimeterId caloid) :
-    RawTowerGeomContainerv1(caloid), radius(NAN), thickness(NAN)
+RawTowerGeomContainer_Cylinderv1::RawTowerGeomContainer_Cylinderv1(RawTowerDefs::CalorimeterId caloid) :
+  RawTowerGeomContainerv1(caloid),
+  radius(NAN),
+  thickness(NAN)
 {
   return;
 }
@@ -35,6 +35,7 @@ RawTowerGeomContainer_Cylinderv1::set_etabins(const int i)
   bound_t invalid_bound(NAN, NAN);
   eta_bound_map.resize(i, invalid_bound);
 }
+
 void
 RawTowerGeomContainer_Cylinderv1::set_phibins(const int i)
 {

--- a/simulation/g4simulation/g4cemc/RawTowerGeomContainerv1.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomContainerv1.cc
@@ -1,19 +1,15 @@
 #include "RawTowerGeomContainerv1.h"
 #include "RawTowerGeom.h"
 
+#include <cassert>
 #include <cstdlib>
 #include <iostream>
-#include <cassert>
-
-ClassImp(RawTowerGeomContainerv1)
 
 using namespace std;
 
-RawTowerGeomContainerv1::RawTowerGeomContainerv1(
-    RawTowerDefs::CalorimeterId caloid)
-{
-  _caloid = caloid;
-}
+RawTowerGeomContainerv1::RawTowerGeomContainerv1(RawTowerDefs::CalorimeterId caloid):
+  _caloid(caloid)
+{}
 
 RawTowerGeomContainerv1::~RawTowerGeomContainerv1()
 {

--- a/simulation/g4simulation/g4cemc/RawTowerGeomv1.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomv1.cc
@@ -1,15 +1,9 @@
 #include "RawTowerGeomv1.h"
 
-
 #include <iostream>
-#include <algorithm>
-
 #include <cmath>
-#include <map>
 
 using namespace std;
-
-ClassImp(RawTowerGeomv1)
 
 RawTowerGeomv1::RawTowerGeomv1() :
   _towerid(~0),
@@ -24,10 +18,6 @@ RawTowerGeomv1::RawTowerGeomv1(RawTowerDefs::keytype id) :
   _center_y(0),
   _center_z(0)
 {}
-
-RawTowerGeomv1::~RawTowerGeomv1()
-{}
-
 
 double RawTowerGeomv1::get_center_radius() const
 {

--- a/simulation/g4simulation/g4cemc/RawTowerGeomv1.h
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomv1.h
@@ -1,16 +1,14 @@
-#ifndef NEWGEOMV1_H_
-#define NEWGEOMV1_H_
+#ifndef RawTowerGeomv1_h_
+#define RawTowerGeomv1_h_
 
 #include "RawTowerGeom.h"
-
-#include <map>
 
 class RawTowerGeomv1 : public RawTowerGeom {
 
  public:
   RawTowerGeomv1();
   RawTowerGeomv1(RawTowerDefs::keytype id);
-  virtual ~RawTowerGeomv1();
+  virtual ~RawTowerGeomv1(){}
 
   void identify(std::ostream& os=std::cout) const;
 

--- a/simulation/g4simulation/g4cemc/RawTowerGeomv2.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomv2.cc
@@ -1,16 +1,9 @@
 #include "RawTowerGeomv2.h"
 
-#include <g4main/PHG4Utils.h>
-
 #include <iostream>
-#include <algorithm>
-
 #include <cmath>
-#include <map>
 
 using namespace std;
-
-ClassImp(RawTowerGeomv2)
 
 RawTowerGeomv2::RawTowerGeomv2() :
   _towerid(~0),
@@ -31,10 +24,6 @@ RawTowerGeomv2::RawTowerGeomv2(RawTowerDefs::keytype id) :
   _size_z(0)
 {}
 
-RawTowerGeomv2::~RawTowerGeomv2()
-{}
-
-
 double RawTowerGeomv2::get_center_radius() const
 {
   return sqrt( _center_x * _center_x +
@@ -43,8 +32,6 @@ double RawTowerGeomv2::get_center_radius() const
 
 double RawTowerGeomv2::get_eta() const
 {
-
-
   double eta;
   double radius;
   double theta;

--- a/simulation/g4simulation/g4cemc/RawTowerGeomv2.h
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomv2.h
@@ -1,16 +1,14 @@
-#ifndef NEWGEOMV2_H_
-#define NEWGEOMV2_H_
+#ifndef RawTowerGeomv2_h_
+#define RawTowerGeomv2_h_
 
 #include "RawTowerGeom.h"
-
-#include <map>
 
 class RawTowerGeomv2 : public RawTowerGeom {
 
  public:
   RawTowerGeomv2();
   RawTowerGeomv2(RawTowerDefs::keytype id);
-  virtual ~RawTowerGeomv2();
+  virtual ~RawTowerGeomv2(){}
 
   void identify(std::ostream& os=std::cout) const;
 

--- a/simulation/g4simulation/g4cemc/RawTowerGeomv3.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomv3.cc
@@ -1,16 +1,9 @@
 #include "RawTowerGeomv3.h"
 
-#include <g4main/PHG4Utils.h>
-
-#include <iostream>
-#include <algorithm>
-
 #include <cmath>
-#include <map>
+#include <iostream>
 
 using namespace std;
-
-ClassImp(RawTowerGeomv3)
 
 RawTowerGeomv3::RawTowerGeomv3() :
   _towerid(~0),
@@ -22,6 +15,7 @@ RawTowerGeomv3::RawTowerGeomv3() :
   _size_z(0),
   _tower_type(-1)
 {}
+
 RawTowerGeomv3::RawTowerGeomv3(RawTowerDefs::keytype id) :
   _towerid(id),
   _center_x(0),
@@ -33,10 +27,6 @@ RawTowerGeomv3::RawTowerGeomv3(RawTowerDefs::keytype id) :
   _tower_type(-1)
 {}
 
-RawTowerGeomv3::~RawTowerGeomv3()
-{}
-
-
 double RawTowerGeomv3::get_center_radius() const
 {
   return sqrt( _center_x * _center_x +
@@ -45,15 +35,12 @@ double RawTowerGeomv3::get_center_radius() const
 
 double RawTowerGeomv3::get_eta() const
 {
-
-
   double eta;
   double radius;
   double theta;
   radius = sqrt(_center_x * _center_x + _center_y * _center_y);
   theta = atan2(radius, _center_z);
   eta = -log(tan(theta / 2.));
-
   return eta;
 }
 

--- a/simulation/g4simulation/g4cemc/RawTowerGeomv3.h
+++ b/simulation/g4simulation/g4cemc/RawTowerGeomv3.h
@@ -1,16 +1,14 @@
-#ifndef NEWGEOMV3_H_
-#define NEWGEOMV3_H_
+#ifndef RawTowerGeomv3_h_
+#define RawTowerGeomv3_h_
 
 #include "RawTowerGeom.h"
-
-#include <map>
 
 class RawTowerGeomv3 : public RawTowerGeom {
 
  public:
   RawTowerGeomv3();
   RawTowerGeomv3(RawTowerDefs::keytype id);
-  virtual ~RawTowerGeomv3();
+  virtual ~RawTowerGeomv3(){}
 
   void identify(std::ostream& os=std::cout) const;
 
@@ -57,4 +55,4 @@ class RawTowerGeomv3 : public RawTowerGeom {
   ClassDef(RawTowerGeomv3,4)
 };
 
-#endif /* NEWGEOMV3_H_ */
+#endif /* RawTowerGeomv3_h_ */

--- a/simulation/g4simulation/g4cemc/RawTowerv1.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerv1.cc
@@ -1,22 +1,15 @@
 #include "RawTowerv1.h"
 
-#include "RawTowerDefs.h"
-
-#include <iostream>
-#include <algorithm>
-
 #include <cmath>
-#include <map>
+#include <iostream>
 
 using namespace std;
 
-ClassImp(RawTowerv1)
-
 RawTowerv1::RawTowerv1() :
-    towerid(~0), // initialize all bits on
-    energy(0), time(NAN)
-{
-}
+  towerid(~0), // initialize all bits on
+  energy(0),
+  time(NAN)
+{}
 
 RawTowerv1::RawTowerv1(const RawTower & tower)
 {
@@ -42,25 +35,26 @@ RawTowerv1::RawTowerv1(const RawTower & tower)
 }
 
 RawTowerv1::RawTowerv1(RawTowerDefs::keytype id) :
-    towerid(id), energy(0), time(NAN)
-{
-}
+  towerid(id),
+  energy(0),
+  time(NAN)
+{}
 
 RawTowerv1::RawTowerv1(const unsigned int ieta, const unsigned int iphi) :
-    towerid(0), energy(0), time(NAN)
+  towerid(0),
+  energy(0),
+  time(NAN)
 {
   towerid = RawTowerDefs::encode_towerid(RawTowerDefs::NONE, ieta, iphi);
 }
 
 RawTowerv1::RawTowerv1(const RawTowerDefs::CalorimeterId caloid,
-    const unsigned int ieta, const unsigned int iphi) :
-    towerid(0), energy(0), time(NAN)
+                       const unsigned int ieta, const unsigned int iphi) :
+  towerid(0),
+  energy(0),
+  time(NAN)
 {
   towerid = RawTowerDefs::encode_towerid(caloid, ieta, iphi);
-}
-
-RawTowerv1::~RawTowerv1()
-{
 }
 
 void

--- a/simulation/g4simulation/g4cemc/RawTowerv1.h
+++ b/simulation/g4simulation/g4cemc/RawTowerv1.h
@@ -15,7 +15,7 @@ class RawTowerv1 : public RawTower {
   RawTowerv1(const unsigned int ieta, const unsigned int iphi);
   RawTowerv1(const RawTowerDefs::CalorimeterId caloid, const unsigned int ieta,
              const unsigned int iphi);
-  virtual ~RawTowerv1();
+  virtual ~RawTowerv1(){}
 
   void Reset();
   int isValid() const;


### PR DESCRIPTION
I accidentally killed the tower digitization for empty towers, removing pedestals. That's back in with a comment to explain what is being done.
All obsolete ClassImp macros were removed (they are needed for the obsolete THtml machinery in root used for documentation, now superseded by doxygen). unused include files were removed.