### PR TITLE
Two fixes in silicon simulation code

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -52,6 +52,7 @@ pkginclude_HEADERS = \
   PHG4CylinderGeom.h \
   PHG4CylinderGeom_Spacalv1.h \
   PHG4CylinderGeom_MAPS.h \
+  PHG4CylinderGeom_Siladders.h \
   PHG4CylinderGeom_Spacalv2.h \
   PHG4CylinderGeom_Spacalv3.h \
   PHG4CylinderGeomContainer.h \

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_MAPS.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_MAPS.h
@@ -12,6 +12,20 @@ class PHG4CylinderGeom_MAPS: public PHG4CylinderGeom
 
   PHG4CylinderGeom_MAPS(int layer, int stave_type, int in_Nstaves, double in_layer_nominal_radius, double in_phistep, double in_phitilt, double in_pixel_x, double in_pixel_z, double in_pixel_thickness);
 
+  //! default ctor to allow ROOT stream of this class. Implemented using c++11 feature of delegating constructors
+  PHG4CylinderGeom_MAPS():
+    PHG4CylinderGeom_MAPS(
+        /*int layer*/0,
+        /*int stave_type*/0,
+        /*int in_Nstaves*/0,
+        /*double in_layer_nominal_radius*/3,
+        /*double in_phistep*/0,
+        /*double in_phitilt*/0,
+        /*double in_pixel_x*/20e-4,
+        /*double in_pixel_z*/20e-4,
+        /*double in_pixel_thickness*/18e-4)
+  {  }
+
   virtual ~PHG4CylinderGeom_MAPS() {}
 
   void identify(std::ostream& os = std::cout) const;
@@ -43,19 +57,6 @@ class PHG4CylinderGeom_MAPS: public PHG4CylinderGeom
 
 protected:
 
-  //! default ctor to allow ROOT stream of this class. Implemented using c++11 feature of delegating constructors
-  PHG4CylinderGeom_MAPS():
-    PHG4CylinderGeom_MAPS(
-        /*int layer*/0,
-        /*int stave_type*/0,
-        /*int in_Nstaves*/0,
-        /*double in_layer_nominal_radius*/3,
-        /*double in_phistep*/0,
-        /*double in_phitilt*/0,
-        /*double in_pixel_x*/20e-4,
-        /*double in_pixel_z*/20e-4,
-        /*double in_pixel_thickness*/18e-4)
-  {  }
 
   int layer;
   int stave_type;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_MAPS.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_MAPS.h
@@ -43,6 +43,20 @@ class PHG4CylinderGeom_MAPS: public PHG4CylinderGeom
 
 protected:
 
+  //! default ctor to allow ROOT stream of this class. Implemented using c++11 feature of delegating constructors
+  PHG4CylinderGeom_MAPS():
+    PHG4CylinderGeom_MAPS(
+        /*int layer*/0,
+        /*int stave_type*/0,
+        /*int in_Nstaves*/0,
+        /*double in_layer_nominal_radius*/3,
+        /*double in_phistep*/0,
+        /*double in_phitilt*/0,
+        /*double in_pixel_x*/20e-4,
+        /*double in_pixel_z*/20e-4,
+        /*double in_pixel_thickness*/18e-4)
+  {  }
+
   int layer;
   int stave_type;
   int N_staves;


### PR DESCRIPTION
Two fixes in silicon simulation code
1. As raised by @pinkenburg and @mccumbermike in #232 , ```PHG4CylinderGeom_MAPS``` does not have a public accessible default constructor, which is required for ROOT file IO via the streamer utilities. Adding it. 
Note if the default constructor is put under ```protected``` flag, ROOT still complains on the missing default constructor.  
2. @HaiwangYu raised an issue that the INTT ladder header file ```PHG4CylinderGeom_Siladders.h``` , which is required for downstream analysis. Adding it. 