### PR TITLE
Add Pythia6 particle trigger

### DIFF
--- a/generators/PHPythia6/Makefile.am
+++ b/generators/PHPythia6/Makefile.am
@@ -10,7 +10,8 @@ lib_LTLIBRARIES = libPHPythia6.la
 pkginclude_HEADERS = \
   PHPythia6.h \
   PHPy6GenTrigger.h \
-  PHPy6ForwardElectronTrig.h 
+  PHPy6ForwardElectronTrig.h \
+  PHPy6ParticleTrigger.h
 
 libPHPythia6_la_LDFLAGS = ${AM_LDFLAGS} `root-config --libs`
 
@@ -24,7 +25,10 @@ libPHPythia6_la_SOURCES = \
   PHPy6GenTrigger.C \
   PHPy6GenTrigger.h \
   PHPy6ForwardElectronTrig.C \
-  PHPy6ForwardElectronTrig.h 
+  PHPy6ForwardElectronTrig.h \
+  PHPy6ParticleTrigger.C \
+  PHPy6ParticleTrigger.h
+
 
 BUILT_SOURCES = \
   testexternals.C
@@ -46,6 +50,7 @@ PHPythia6_Dict.C: \
   PHPythia6.h \
   PHPy6GenTrigger.h \
   PHPy6ForwardElectronTrig.h \
+  PHPy6ParticleTrigger.h \
   PHPythia6LinkDef.h
 	rootcint -f $@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
 

--- a/generators/PHPythia6/PHPy6GenTrigger.C
+++ b/generators/PHPythia6/PHPy6GenTrigger.C
@@ -6,7 +6,8 @@ using namespace std;
 
 //__________________________________________________________
 PHPy6GenTrigger::PHPy6GenTrigger(const std::string &name):
-_name(name) {}
+  _verbosity(0),
+  _name(name) {}
 
 //__________________________________________________________
 PHPy6GenTrigger::~PHPy6GenTrigger() {}

--- a/generators/PHPythia6/PHPy6ParticleTrigger.C
+++ b/generators/PHPythia6/PHPy6ParticleTrigger.C
@@ -126,11 +126,11 @@ bool PHPy6ParticleTrigger::Apply( const HepMC::GenEvent* evt )
         // loop over all partents to this particle
         for (int k = 0; k < int(_theParents.size()); k++) {
           // check Mothers
-	  for ( HepMC::GenVertex::particles_out_const_iterator p_mom = (*p)->end_vertex()->particles_out_const_begin();
-		p_mom != (*p)->end_vertex()->particles_out_const_end();
-		++p_mom )
+	  for ( HepMC::GenVertex::particles_in_const_iterator p_parent = (*p)->production_vertex()->particles_in_const_begin();
+		p_parent != (*p)->production_vertex()->particles_in_const_end();
+		++p_parent )
 	    {
-	      if (abs( (*p_mom)->pdg_id() ) == abs(_theParents[k]))
+	      if (abs( (*p_parent)->pdg_id() ) == abs(_theParents[k]))
 		{
 		  passedParents = true;
 		  if (_verbosity > 5) cout << "found parent!" << endl;

--- a/generators/PHPythia6/PHPy6ParticleTrigger.C
+++ b/generators/PHPythia6/PHPy6ParticleTrigger.C
@@ -1,0 +1,349 @@
+#include "PHPy6GenTrigger.h"
+#include "PHPy6ParticleTrigger.h"
+#include <phool/PHCompositeNode.h>
+#include <phool/phool.h>
+#include <phool/getClass.h>
+
+#include <phhepmc/PHHepMCGenEvent.h>
+#include <HepMC/GenEvent.h>
+
+#include <cstdlib>
+#include <iostream>
+using namespace std;
+
+//___________________________________________________________________________
+PHPy6ParticleTrigger::PHPy6ParticleTrigger(const std::string &name):
+  PHPy6GenTrigger(name),
+
+  _theEtaHigh(-999.9),
+  _theEtaLow(-999.9),
+  _thePtHigh(999.9),
+  _thePtLow(-999.9),
+  _thePHigh(999.9),
+  _thePLow(-999.9),
+  _thePzHigh(999.9),
+  _thePzLow(-999.9),
+
+  _doEtaHighCut(false),
+  _doEtaLowCut(false),
+  _doBothEtaCut(false),
+
+  _doAbsEtaHighCut(false),
+  _doAbsEtaLowCut(false),
+  _doBothAbsEtaCut(false),
+
+  _doPtHighCut(false),
+  _doPtLowCut(false),
+  _doBothPtCut(false),
+
+  _doPHighCut(false),
+  _doPLowCut(false),
+  _doBothPCut(false),
+
+  _doPzHighCut(false),
+  _doPzLowCut(false),
+  _doBothPzCut(false)
+{}
+
+
+bool PHPy6ParticleTrigger::Apply( const HepMC::GenEvent* evt )
+{
+
+  // Print Out Trigger Information Once, for Posterity
+  static int trig_info_printed = 0;
+  if ( trig_info_printed==0 )
+    {
+      PrintConfig();
+      trig_info_printed = 1;
+    }
+
+  //  for ( HepMC::GenEvent::particle_const_iterator p
+  //          = evt->particles_begin(); p != evt->particles_end(); ++p ){
+  //    if ( (abs((*p)->pdg_id()) == 11) && ((*p)->status()==1) &&
+  //         ((*p)->momentum().pseudoRapidity() > eta_low) && ((*p)->momentum().pseudoRapidity() < eta_high) &&
+  //         ( ) {
+  //      if(((*p)->pdg_id()) == 11) n_em_found++;
+  //      if(((*p)->pdg_id()) == -11) n_ep_found++;
+  //    }
+  //  }
+  //
+  //  if( (RequireOR && ((n_em_found>=n_em_required)||(n_ep_found>=n_ep_required)) ) ||
+  //      (RequireElectron && (n_em_found>=n_em_required)) ||
+  //      (RequirePositron && (n_ep_found>=n_ep_required)) ||
+  //      (RequireAND && (n_em_found>=n_em_required) && (n_ep_found>=n_ep_required)) ||
+  //      (RequireCOMBO && (n_em_found+n_ep_found)>=n_comb_required) )
+  //    {
+  //      ++ntriggered_forward_electron;
+  //      return true;
+  //    }
+
+  // Loop over all particles in the event
+  for ( HepMC::GenEvent::particle_const_iterator p
+          = evt->particles_begin(); p != evt->particles_end(); ++p ){
+
+    // loop over all the trigger particle criteria
+    for (int j = 0; j < int(_theParticles.size()); j++) {
+
+      bool passedParents = false;
+      double p_pT = sqrt(pow((*p)->momentum().px(),2) + pow((*p)->momentum().py(),2));
+      double p_pAbs = sqrt(pow((*p)->momentum().px(),2) + pow((*p)->momentum().py(),2) + pow((*p)->momentum().pz(),2));
+      if ( (*p)->pdg_id() == _theParticles[j] &&
+           (*p)->status() == 1 ) { //only stable particles
+
+        if (_doBothEtaCut && ((*p)->momentum().eta() < _theEtaLow ||
+                              (*p)->momentum().eta() > _theEtaHigh)) continue;
+        if (_doEtaLowCut && (*p)->momentum().eta() < _theEtaLow) continue;
+        if (_doEtaHighCut && (*p)->momentum().eta() > _theEtaHigh) continue;
+
+        if (_doBothAbsEtaCut && (abs((*p)->momentum().eta()) < _theEtaLow ||
+                                 abs((*p)->momentum().eta()) > _theEtaHigh)) continue;
+        if (_doAbsEtaLowCut && abs((*p)->momentum().eta()) < _theEtaLow) continue;
+        if (_doAbsEtaHighCut && abs((*p)->momentum().eta()) > _theEtaHigh) continue;
+
+        if (_doBothPtCut && (p_pT < _thePtLow ||
+                             p_pT > _thePtHigh)) continue;
+        if (_doPtHighCut && p_pT > _thePtHigh ) continue;
+        if (_doPtLowCut && p_pT < _thePtLow) continue;
+
+        if (_doBothPCut && (p_pAbs < _thePLow ||
+                            p_pAbs > _thePHigh)) continue;
+        if (_doPHighCut && p_pAbs > _thePHigh ) continue;
+        if (_doPLowCut && p_pAbs < _thePLow) continue;
+
+        if (_doBothPzCut && ((*p)->momentum().pz() < _thePzLow ||
+                             (*p)->momentum().pz() > _thePzHigh)) continue;
+        if (_doPzHighCut && (*p)->momentum().pz() > _thePzHigh ) continue;
+        if (_doPzLowCut && (*p)->momentum().pz() < _thePzLow) continue;
+
+        if (_verbosity > 5) {
+          cout << "stable " << (*p)->pdg_id()
+               << "  pt: " << p_pT
+               << " pz: " << (*p)->momentum().pz()
+               << " p: " << p_pAbs
+               << " eta: " << (*p)->momentum().eta() << endl;
+        }
+
+        // loop over all partents to this particle
+        for (int k = 0; k < int(_theParents.size()); k++) {
+          // check Mothers
+	  for ( HepMC::GenVertex::particles_out_const_iterator p_mom = (*p)->end_vertex()->particles_out_const_begin();
+		p_mom != (*p)->end_vertex()->particles_out_const_end();
+		++p_mom )
+	    {
+	      if (abs( (*p_mom)->pdg_id() ) == abs(_theParents[k]))
+		{
+		  passedParents = true;
+		  if (_verbosity > 5) cout << "found parent!" << endl;
+		  break;
+		}
+	    }//moms for loop
+          if (passedParents) break;
+        }//parents for loop
+
+        //If we made it here and it passes parents, success!
+        if (_theParents.size() == 0 || passedParents) return true;
+
+      }//if _theParticles
+    }//_theParticles for loop
+
+  }//pythia event for loop
+
+  return false;
+
+}
+
+void PHPy6ParticleTrigger::AddParticles(std::string particles) {
+  std::vector<int> addedParts = convertToInts(particles);
+  _theParticles.insert(_theParticles.end(),addedParts.begin(),addedParts.end());
+}
+
+void PHPy6ParticleTrigger::AddParticles(int particle) {
+  _theParticles.push_back(particle);
+}
+
+void PHPy6ParticleTrigger::AddParticles(std::vector<int> particles) {
+  _theParticles.insert(_theParticles.end(),particles.begin(),particles.end());
+}
+
+void PHPy6ParticleTrigger::AddParents(std::string parents) {
+  std::vector<int> addedParents = convertToInts(parents);
+  _theParents.insert(_theParents.end(),addedParents.begin(),addedParents.end());
+}
+
+void PHPy6ParticleTrigger::AddParents(int parent) {
+  _theParents.push_back(parent);
+}
+
+void PHPy6ParticleTrigger::AddParents(std::vector<int> parents) {
+  _theParents.insert(_theParents.end(),parents.begin(),parents.end());
+}
+
+void PHPy6ParticleTrigger::SetPtHigh(double pt) {
+  _thePtHigh = pt;
+  if (_doPtLowCut) _doBothPtCut = true;
+  else _doPtHighCut = true;
+}
+
+void PHPy6ParticleTrigger::SetPtLow(double pt) {
+  _thePtLow = pt;
+  if (_doPtHighCut) _doBothPtCut = true;
+  else _doPtLowCut = true;
+}
+
+void PHPy6ParticleTrigger::SetPtHighLow(double ptHigh, double ptLow) {
+  if (ptHigh < ptLow) {
+    _thePtHigh = ptLow;
+    _thePtLow = ptHigh;
+  } else {
+    _thePtHigh = ptHigh;
+    _thePtLow = ptLow;
+  }
+  _doBothPtCut = true;
+  _doPtLowCut = false;
+  _doPtHighCut = false;
+}
+
+void PHPy6ParticleTrigger::SetPHigh(double p) {
+  _thePHigh = p;
+  if (_doPLowCut) {
+    _doBothPCut = true;
+    _doPLowCut = false;
+  } else {
+    _doPHighCut = true;
+  }
+}
+
+void PHPy6ParticleTrigger::SetPLow(double p) {
+  _thePLow = p;
+  if (_doPHighCut) {
+    _doBothPCut = true;
+    _doPHighCut = false;
+  } else {
+    _doPLowCut = true;
+  }
+}
+
+void PHPy6ParticleTrigger::SetPHighLow(double pHigh, double pLow) {
+  if (pHigh < pLow) {
+    _thePHigh = pLow;
+    _thePLow= pHigh;
+  } else {
+    _thePHigh = pHigh;
+    _thePLow = pLow;
+  }
+  _doBothPCut = true;
+  _doPLowCut = false;
+  _doPHighCut = false;
+}
+
+void PHPy6ParticleTrigger::SetEtaHigh(double eta) {
+  _theEtaHigh = eta;
+  if (_doEtaLowCut) {
+    _doBothEtaCut = true;
+    _doEtaLowCut = false;
+  } else {
+    _doEtaHighCut = true;
+  }
+}
+
+void PHPy6ParticleTrigger::SetEtaLow(double eta) {
+  _theEtaLow = eta;
+  if (_doEtaHighCut) {
+    _doBothEtaCut = true;
+    _doEtaHighCut = false;
+  } else {
+    _doEtaLowCut = true;
+  }
+}
+
+void PHPy6ParticleTrigger::SetEtaHighLow(double etaHigh, double etaLow) {
+  _theEtaHigh = etaHigh;
+  _theEtaLow = etaLow;
+  _doBothEtaCut = true;
+  _doEtaHighCut = false;
+  _doEtaLowCut = false;
+}
+
+void PHPy6ParticleTrigger::SetAbsEtaHigh(double eta) {
+  _theEtaHigh = eta;
+  if (_doAbsEtaLowCut) {
+    _doBothAbsEtaCut = true;
+    _doAbsEtaLowCut = false;
+  } else {
+    _doAbsEtaHighCut = true;
+  }
+}
+
+void PHPy6ParticleTrigger::SetAbsEtaLow(double eta) {
+  _theEtaLow = eta;
+  if (_doAbsEtaHighCut) {
+    _doBothAbsEtaCut = true;
+    _doAbsEtaHighCut = false;
+  } else {
+    _doAbsEtaLowCut = true;
+  }
+}
+
+void PHPy6ParticleTrigger::SetAbsEtaHighLow(double etaHigh, double etaLow) {
+  _theEtaHigh = etaHigh;
+  _theEtaLow = etaLow;
+  _doBothAbsEtaCut = true;
+  _doAbsEtaLowCut = false;
+  _doAbsEtaHighCut = false;
+}
+
+void PHPy6ParticleTrigger::SetPzHigh(double pz) {
+  _thePzHigh = pz;
+  if (_doPzLowCut) {
+    _doBothPzCut = true;
+    _doPzLowCut = false;
+  } else {
+    _doPzHighCut = true;
+  }
+}
+
+void PHPy6ParticleTrigger::SetPzLow(double pz) {
+  _thePzLow = pz;
+  if (_doPzHighCut) {
+    _doBothPzCut = true;
+    _doPzHighCut = false;
+  } else {
+    _doPzLowCut = true;
+  }
+}
+
+void PHPy6ParticleTrigger::SetPzHighLow(double pzHigh, double pzLow) {
+  if (pzHigh < pzLow) {
+    _thePzHigh = pzLow;
+    _thePzLow= pzHigh;
+  } else {
+    _thePzHigh = pzHigh;
+    _thePzLow = pzLow;
+  }
+  _doBothPzCut = true;
+  _doPzLowCut = false;
+  _doPzHighCut = false;
+}
+
+void PHPy6ParticleTrigger::PrintConfig() {
+  cout << "---------------- PHPy6ParticleTrigger::PrintConfig --------------------" << endl;
+  cout << "   Particles: ";
+  for (int i = 0; i < int(_theParticles.size()); i++) cout << _theParticles[i] << "  ";
+  cout << endl;
+
+  cout << "   Parents: ";
+  for (int i = 0; i < int(_theParents.size()); i++) cout << _theParents[i] << "  ";
+  cout << endl;
+
+  if (_doEtaHighCut||_doEtaLowCut||_doBothEtaCut)
+    cout << "   doEtaCut:  " << _theEtaLow << " < eta < " << _theEtaHigh << endl;
+  if (_doAbsEtaHighCut||_doAbsEtaLowCut||_doBothAbsEtaCut)
+    cout << "   doAbsEtaCut:  " << _theEtaLow << " < |eta| < " << _theEtaHigh << endl;
+  if (_doPtHighCut||_doPtLowCut||_doBothPtCut)
+    cout << "   doPtCut:  " << _thePtLow << " < pT < " << _thePtHigh << endl;
+  if (_doPHighCut||_doPLowCut||_doBothPCut)
+    cout << "   doPCut:  " << _thePLow << " < p < " << _thePHigh << endl;
+  if (_doPzHighCut||_doPzLowCut||_doBothPzCut)
+    cout << "   doPzCut:  " << _thePzLow << " < pz < " << _thePzHigh << endl;
+  cout << "-----------------------------------------------------------------------" << endl;
+}

--- a/generators/PHPythia6/PHPy6ParticleTrigger.h
+++ b/generators/PHPythia6/PHPy6ParticleTrigger.h
@@ -1,0 +1,83 @@
+#ifndef PHPy6ParticleTrigger_h
+#define PHPy6ParticleTrigger_h
+
+#include "PHPy6GenTrigger.h"
+#include <HepMC/GenEvent.h>
+
+namespace HepMC
+{
+  class GenEvent;
+};
+
+/**
+ * Fun4All module based in PHPythia8/PHPy8ParticleTrigger
+ *
+ * Provides trigger for events gerenated by PHPythia6 event generator (Pythia6 wrapper for Fun4All).
+ *
+ * This trigger makes use of the conversion of Pythia6 events to HepMC format done in PHPythia6.
+ *
+ */
+class PHPy6ParticleTrigger: public PHPy6GenTrigger
+{
+public:
+
+  //! constructor
+  PHPy6ParticleTrigger(const std::string &name = "PHPy6ParticleTriggerger");
+
+  //! destructor
+  ~PHPy6ParticleTrigger( void ){}
+
+#ifndef __CINT__
+  bool Apply(const HepMC::GenEvent* evt);
+#endif
+
+  void AddParticles(std::string particles);
+  void AddParticles(int particle);
+  void AddParticles(std::vector<int> particles);
+
+  void AddParents(std::string parents);
+  void AddParents(int parent);
+  void AddParents(std::vector<int> parents);
+
+  void SetPtHigh(double pt);
+  void SetPtLow(double pt);
+  void SetPtHighLow(double ptHigh, double ptLow);
+
+  void SetPHigh(double p);
+  void SetPLow(double p);
+  void SetPHighLow(double pHigh, double pLow);
+
+  void SetEtaHigh(double eta);
+  void SetEtaLow(double eta);
+  void SetEtaHighLow(double etaHigh, double etaLow);
+
+  void SetAbsEtaHigh(double eta);
+  void SetAbsEtaLow(double eta);
+  void SetAbsEtaHighLow(double etaHigh, double etaLow);
+
+  void SetPzHigh(double pz);
+  void SetPzLow(double pz);
+  void SetPzHighLow(double pzHigh, double pzLow);
+
+  void PrintConfig();
+
+protected:
+
+  // trigger variables
+  std::vector<int> _theParents;
+  std::vector<int> _theParticles;
+
+  double _theEtaHigh, _theEtaLow;
+  double _thePtHigh, _thePtLow;
+  double _thePHigh, _thePLow;
+  double _thePzHigh, _thePzLow;
+
+  bool _doEtaHighCut, _doEtaLowCut, _doBothEtaCut;
+  bool _doAbsEtaHighCut, _doAbsEtaLowCut, _doBothAbsEtaCut;
+  bool _doPtHighCut, _doPtLowCut, _doBothPtCut;
+  bool _doPHighCut, _doPLowCut, _doBothPCut;
+  bool _doPzHighCut, _doPzLowCut, _doBothPzCut;
+
+};
+
+#endif

--- a/generators/PHPythia6/PHPythia6LinkDef.h
+++ b/generators/PHPythia6/PHPythia6LinkDef.h
@@ -3,6 +3,7 @@
 #pragma link C++ class PHPythia6-!;
 #pragma link C++ class PHPy6GenTrigger-!;
 #pragma link C++ class PHPy6ForwardElectronTrig-!;
+#pragma link C++ class PHPy6ParticleTrigger-!;
 
 #endif
 


### PR DESCRIPTION
Copied the PHPythia8/PHPy8ParticleTrigger module to PHPythia6/PHPy6ParticleTrigger and made changes to make it work with Pythia6-HepMC events. The trigger uses the Pythia6 event and particle information stored in HepMC format.

Here's a screenshot that shows it does what it is supposed to, i.e. reject Pythia6 events that do not match the particle trigger requirement:

![screen shot 2017-01-09 at 3 51 20 pm](https://cloud.githubusercontent.com/assets/9557412/21783133/17882444-d684-11e6-93d5-052dc3eb81a8.png)
