### PR TITLE
All ladders

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
@@ -55,9 +55,9 @@ void PHG4CylinderGeom_Siladders::find_segment_center(const int segment_z_bin, co
 
   // Ladder
   const double phi  = offsetphi + dphi_ * (double)segment_phi_bin;
-  location[0] = eff_radius * cos(phi);
-  location[1] = eff_radius * sin(phi);
-  location[2] = ladder_z_[itype];
+  location[0] = eff_radius  * cos(phi);
+  location[1] = eff_radius  * sin(phi);
+  location[2] = ladder_z_[itype] ;
 }
 
 void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[])

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -86,17 +86,19 @@ int PHG4SiliconTrackerCellReco::InitRun(PHCompositeNode *topNode)
   if (verbosity > 0)
     geo->identify();
 
-  binning.insert(std::make_pair(2, 0));
-  binning.insert(std::make_pair(3, 1));
-  binning.insert(std::make_pair(4, 2));
-  binning.insert(std::make_pair(5, 3));
-  for (std::map<int,int>::iterator iter = binning.begin(); iter != binning.end(); ++iter)
-    {
-      // if the user doesn't set an integration window, set the default
-      tmin_max.insert(std::make_pair(/*layer*/iter->first, std::make_pair(tmin_default, tmax_default)));
-    }
+  // ADF: removed this because it hard-codes the layer numbers!
+  // binning.insert(std::make_pair(2, 0));
+  // binning.insert(std::make_pair(3, 1));
+  // binning.insert(std::make_pair(4, 2));
+  // binning.insert(std::make_pair(5, 3));
+  // for (std::map<int,int>::iterator iter = binning.begin(); iter != binning.end(); ++iter)
+  //   {
+  //     // if the user doesn't set an integration window, set the default
+  //     tmin_max.insert(std::make_pair(/*layer*/iter->first, std::make_pair(tmin_default, tmax_default)));
+  //   }
 
-  return Fun4AllReturnCodes::EVENT_OK;
+
+return Fun4AllReturnCodes::EVENT_OK;
 }
 
 
@@ -132,13 +134,14 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
   for (PHG4HitContainer::ConstIterator hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
     {
       const int sphxlayer = hiter->second->get_layer();
-
       PHG4CylinderGeom *layergeom = geo->GetLayerGeom(sphxlayer);
 
       // checking ADC timing integration window cut
-      if (hiter->second->get_t(0)>tmin_max[sphxlayer].second)
+      // uses default values for now
+      // these should depend on layer radius
+      if (hiter->second->get_t(0)>tmax_default)
         continue;
-      if (hiter->second->get_t(1)<tmin_max[sphxlayer].first)
+      if (hiter->second->get_t(1)<tmin_default)
         continue;
 
       const int ladder_z_index   = hiter->second->get_ladder_z_index();
@@ -151,7 +154,6 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
       layergeom->find_strip_center(ladder_z_index, ladder_phi_index, strip_z_index, strip_y_index, location);
 
       std::string key = boost::str(boost::format("%d-%d_%d_%d") %ladder_z_index %ladder_phi_index %strip_z_index %strip_y_index).c_str();
-
       if (celllist.count(key) > 0)
         {
           celllist[key]->add_edep(hiter->first, hiter->second->get_edep());

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -38,6 +38,7 @@ PHG4SiliconTrackerDetector::PHG4SiliconTrackerDetector(PHCompositeNode *Node, co
   for (unsigned int ilayer=0; ilayer<nlayer_; ++ilayer)
     {
       const int inttlayer = layerconfig_[ilayer].second;
+      std::cout << " PHG4SiliconTrackerDetector constructor: ilayer " << ilayer << " inttlayer " << inttlayer << std::endl;
       if (inttlayer < 0 || inttlayer >= 5)
         assert(!"PHG4SiliconTrackerDetector: check INTT ladder layer.");
     }
@@ -125,6 +126,8 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume* tracker
 
         const int sphxlayer = layerconfig_[ilayer].first;
         const int inttlayer = layerconfig_[ilayer].second;
+
+	std::cout << " PHG4SiliconTrackerDetector::ConstrctSiliconTracker:  sphxlayer " << sphxlayer << " inttlayer " << inttlayer << std::endl;
 
         const G4double strip_x = arr_strip_x[inttlayer];
         const G4double strip_y = arr_strip_y[inttlayer];
@@ -253,10 +256,12 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume* tracker
         const double pgs_z = hdi_z;
 
         G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") %sphxlayer %itype).c_str(), pgs_x, pgs_y, pgs_z);
-        G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, Copper, boost::str(boost::format("pgs_volume_%d_%d") %sphxlayer %itype).c_str(), 0, 0, 0);
+        //G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, Copper, boost::str(boost::format("pgs_volume_%d_%d") %sphxlayer %itype).c_str(), 0, 0, 0);
+	G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box,  G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgs_volume_%d_%d") %sphxlayer %itype).c_str(), 0, 0, 0);
 
         G4VSolid *pgs_ext_box = new G4Box(boost::str(boost::format("pgs_ext_box_%d_%s") %sphxlayer %itype).c_str(), pgs_x, pgs_y, hdi_ext_z);
-        G4LogicalVolume *pgs_ext_volume = new G4LogicalVolume(pgs_ext_box, Copper, boost::str(boost::format("pgs_ext_volume_%d_%s") %sphxlayer %itype).c_str(), 0, 0, 0);
+        //G4LogicalVolume *pgs_ext_volume = new G4LogicalVolume(pgs_ext_box, Copper, boost::str(boost::format("pgs_ext_volume_%d_%s") %sphxlayer %itype).c_str(), 0, 0, 0);
+	G4LogicalVolume *pgs_ext_volume = new G4LogicalVolume(pgs_ext_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgs_ext_volume_%d_%s") %sphxlayer %itype).c_str(), 0, 0, 0);
 
         G4VisAttributes *pgs_vis = new G4VisAttributes();
         pgs_vis->SetVisibility(true);
@@ -271,10 +276,12 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume* tracker
         const double stave_z = hdi_z;
 
         G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") %sphxlayer %itype).c_str(), stave_x, stave_y, stave_z);
-        G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, Copper, boost::str(boost::format("stave_volume_%d_%d") %sphxlayer %itype).c_str(), 0, 0, 0);
+        //G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, Copper, boost::str(boost::format("stave_volume_%d_%d") %sphxlayer %itype).c_str(), 0, 0, 0);
+	G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box,  G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_volume_%d_%d") %sphxlayer %itype).c_str(), 0, 0, 0);
 
         G4VSolid *stave_ext_box = new G4Box(boost::str(boost::format("stave_ext_box_%d_%s") %sphxlayer %itype).c_str(), stave_x, stave_y, hdi_ext_z);
-        G4LogicalVolume *stave_ext_volume = new G4LogicalVolume(stave_ext_box, Copper, boost::str(boost::format("stave_ext_volume_%d_%s") %sphxlayer %itype).c_str(), 0, 0, 0);
+        //G4LogicalVolume *stave_ext_volume = new G4LogicalVolume(stave_ext_box,  Copper, boost::str(boost::format("stave_ext_volume_%d_%s") %sphxlayer %itype).c_str(), 0, 0, 0);
+        G4LogicalVolume *stave_ext_volume = new G4LogicalVolume(stave_ext_box,  G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_ext_volume_%d_%s") %sphxlayer %itype).c_str(), 0, 0, 0);
 
         G4VisAttributes *stave_vis = new G4VisAttributes();
         stave_vis->SetVisibility(true);
@@ -461,20 +468,20 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
 
           PHG4CylinderGeom *mygeom = new PHG4CylinderGeom_Siladders(
 				       sphxlayer,
-                                       arr_strip_x[inttlayer],
-                                       arr_strip_y[inttlayer],
-                                       strip_z0,
-                                       strip_z1,
+                                       arr_strip_x[inttlayer]/cm,
+                                       arr_strip_y[inttlayer]/cm,
+                                       strip_z0/cm,
+                                       strip_z1/cm,
                                        nstrips_z_sensor0,
                                        nstrips_z_sensor1,
-                                       arr_nstrips_phi_cell[inttlayer],
+                                       arr_nstrips_phi_cell[inttlayer]/rad,
                                        arr_nladders_layer[inttlayer],
-                                       posz[ilayer][0],
-                                       posz[ilayer][1],
-                                       eff_radius[ilayer],
-                                       strip_x_offset[ilayer],
-                                       arr_offsetphi[inttlayer],
-                                       arr_offsetrot[inttlayer]
+                                       posz[ilayer][0]/cm,
+                                       posz[ilayer][1]/cm,
+                                       eff_radius[ilayer]/cm,
+                                       strip_x_offset[ilayer]/cm,
+                                       arr_offsetphi[inttlayer]/rad,
+                                       arr_offsetrot[inttlayer]/rad
                                      );
           geo->AddLayerGeom(sphxlayer, mygeom);
 	  if(verbosity>0)

--- a/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.C
@@ -155,6 +155,7 @@ void PHG4SiliconTrackerDigitizer::DigitizeLadderCells(PHCompositeNode *topNode) 
     SvtxHit_v1 hit;
 
     const int layer = cell->get_layer();
+
     hit.set_layer(layer);
     hit.set_cellid(cell->get_cell_id());
 

--- a/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
@@ -669,7 +669,12 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
     SvtxHit* hit = iter->second;
     layer_hits_mmap.insert(make_pair(hit->get_layer(),hit));
   }
-  
+   for (std::multimap<int,SvtxHit*>::iterator it=layer_hits_mmap.begin(); it!=layer_hits_mmap.end(); ++it)
+     {
+       if( (*it).first < (int) _min_layer || (*it).first > (int) _max_layer) 
+     continue;
+     }
+
   PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
   for(PHG4CylinderGeomContainer::ConstIterator layeriter = layerrange.first;
       layeriter != layerrange.second;
@@ -679,7 +684,7 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 
     if ((unsigned int)layer < _min_layer) continue;
     if ((unsigned int)layer > _max_layer) continue;
-    
+
     std::map<PHG4CylinderCell*,SvtxHit*> cell_hit_map;
     vector<PHG4CylinderCell*> cell_list;
     for (std::multimap<int,SvtxHit*>::iterator hiter = layer_hits_mmap.lower_bound(layer);
@@ -690,7 +695,7 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
       cell_list.push_back(cell);
       cell_hit_map.insert(make_pair(cell,hit));
     }
-    
+
     if (cell_list.size() == 0) continue; // if no cells, go to the next layer
     
     // i'm not sure this sorting is ever really used


### PR DESCRIPTION
MAPS ladders + INTT ladders code working now, after fixing a few bugs in INTT ladder code. The changes were to:
g4detectors/PHG4SiliconTrackerDetector 
   -- initialization of geometry object uses cm now, puts layers at correct radius etc.
   -- fixed material bug - copper changed to G4_C
g4hough/PHG4SiliconTrackerCellReco  
   -- fixed hard coding of layer numbers when defining timing cuts, was killing layer 6 hits

Here is a plot of the cluster distribution in the MAPS + INTT ladders:
[maps+intt_clusters_x_vs_y_all_ladders.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/703445/maps.intt_clusters_x_vs_y_all_ladders.pdf)

Here is a plot of the number of hit layers per track in the MAPS and INTT. Where the number of hits is greater than the number of layers, it means more than one sensor was hit in one or more of the layers:
[maps+intt_layers_per_track_all_ladders.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/703448/maps.intt_layers_per_track_all_ladders.pdf)
