### PR TITLE
Add PHG4BeamlineMagnetSubsystem

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -131,6 +131,9 @@ libg4detectors_io_la_SOURCES = \
   PHG4ScintillatorSlatContainer_Dict.cc
 
 libg4detectors_la_SOURCES = \
+  PHG4BeamlineMagnetDetector.cc \
+  PHG4BeamlineMagnetSubsystem.cc \
+  PHG4BeamlineMagnetSubsystem_Dict.cc \
   PHG4BlockCellReco.cc \
   PHG4BlockCellReco_Dict.cc \
   PHG4BlockDetector.cc \

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
@@ -17,6 +17,7 @@
 #include <Geant4/G4QuadrupoleMagField.hh>
 #include <Geant4/G4PhysicalConstants.hh>
 #include <Geant4/G4PVPlacement.hh>
+//#include <Geant4/G4RotationMatrix.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4VisAttributes.hh>
@@ -125,10 +126,16 @@ void PHG4BeamlineMagnetDetector::Construct( G4LogicalVolume* logicWorld )
   G4bool allLocal = false;
   magnet_logic->SetFieldManager(fieldMgr,allLocal);
 
-  magnet_physi = new G4PVPlacement(0, G4ThreeVector(params->get_double_param("place_x")*cm,
-                                                    params->get_double_param("place_y")*cm,
-                                                    params->get_double_param("place_z")*cm),
-                                   magnet_logic,
+  G4RotationMatrix rotm;
+  rotm.rotateX(params->get_double_param("rot_x")*deg);
+  rotm.rotateY(params->get_double_param("rot_y")*deg);
+  rotm.rotateZ(params->get_double_param("rot_z")*deg);
+
+  magnet_physi = new G4PVPlacement(G4Transform3D(rotm,
+						 G4ThreeVector(params->get_double_param("place_x")*cm,
+							       params->get_double_param("place_y")*cm,
+							       params->get_double_param("place_z")*cm) ),
+				   magnet_logic,
                                    G4String(GetName().c_str()),
                                    logicWorld, 0, false, overlapcheck);
 

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
@@ -84,14 +84,14 @@ void PHG4BeamlineMagnetDetector::Construct( G4LogicalVolume* logicWorld )
   string magnettype = params->get_string_param("magtype");
   if ( magnettype == "dipole" )
     {
-      double fieldValue = params->get_double_param("field_y");
+      G4double fieldValue = params->get_double_param("field_y")*tesla;
       magField = new G4UniformMagField(G4ThreeVector(0.,fieldValue,0.));
       //  magField = new G4UniformMagField (G4double vField, G4double vTheta, G4double vPhi);
       cout << "Creating DIPOLE with field " << fieldValue << " and name " << GetName() << endl;
     }
   else if ( magnettype == "quadrupole" )
     {
-      double fieldGradient = params->get_double_param("fieldgradient");
+      G4double fieldGradient = params->get_double_param("fieldgradient")*tesla/meter;
       magField = new G4QuadrupoleMagField (fieldGradient);
       //  magField = new G4QuadrupoleMagField (G4double pGradient, G4ThreeVector pOrigin, G4RotationMatrix *pMatrix);
       cout << "Creating QUADRUPOLE with gradient " << fieldGradient << " and name " << GetName() << endl;

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
@@ -1,0 +1,152 @@
+#include "PHG4BeamlineMagnetDetector.h"
+#include "PHG4Parameters.h"
+
+#include <g4main/PHG4PhenixDetector.h>
+#include <g4main/PHG4Utils.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+
+#include <Geant4/G4Colour.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
+#include <Geant4/G4FieldManager.hh>
+#include <Geant4/G4MagneticField.hh>
+#include <Geant4/G4UniformMagField.hh>
+#include <Geant4/G4QuadrupoleMagField.hh>
+#include <Geant4/G4PhysicalConstants.hh>
+#include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4Tubs.hh>
+#include <Geant4/G4VisAttributes.hh>
+
+#include <cmath>
+#include <sstream>
+
+using namespace std;
+
+//_______________________________________________________________
+//note this inactive thickness is ~1.5% of a radiation length
+PHG4BeamlineMagnetDetector::PHG4BeamlineMagnetDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam, const int lyr ):
+  PHG4Detector(Node,dnam),
+  params(parameters),
+  magnet_physi(NULL),
+  cylinder_physi(NULL),
+  layer(lyr)
+{}
+
+//_______________________________________________________________
+bool PHG4BeamlineMagnetDetector::IsInBeamlineMagnet(const G4VPhysicalVolume * volume) const
+{
+  if (volume == magnet_physi)
+    {
+      return true;
+    }
+  return false;
+}
+
+
+//_______________________________________________________________
+void PHG4BeamlineMagnetDetector::Construct( G4LogicalVolume* logicWorld )
+{
+  G4Material *TrackerMaterial = G4Material::GetMaterial(params->get_string_param("material"));
+
+  if ( ! TrackerMaterial)
+    {
+      std::cout << "Error: Can not set material" << std::endl;
+      exit(-1);
+    }
+
+  G4VisAttributes* fieldVis= new G4VisAttributes();
+  PHG4Utils::SetColour(fieldVis, "BlackHole");
+  fieldVis->SetVisibility(false);
+  fieldVis->SetForceSolid(false);
+
+  G4VisAttributes* siliconVis= new G4VisAttributes();
+  if (params->get_int_param("blackhole"))
+    {
+      PHG4Utils::SetColour(siliconVis, "BlackHole");
+      siliconVis->SetVisibility(false);
+      siliconVis->SetForceSolid(false);
+    }
+  else
+    {
+      PHG4Utils::SetColour(siliconVis, params->get_string_param("material"));
+      siliconVis->SetVisibility(true);
+      siliconVis->SetForceSolid(true);
+    }
+
+  /* Creating a magnetic field */
+  G4MagneticField* magField = NULL;
+
+  string magnettype = params->get_string_param("magtype");
+  if ( magnettype == "dipole" )
+    {
+      double fieldValue = params->get_double_param("field_y");
+      magField = new G4UniformMagField(G4ThreeVector(0.,fieldValue,0.));
+      //  magField = new G4UniformMagField (G4double vField, G4double vTheta, G4double vPhi);
+      cout << "Creating DIPOLE with field " << fieldValue << " and name " << GetName() << endl;
+    }
+  else if ( magnettype == "quadrupole" )
+    {
+      double fieldGradient = params->get_double_param("fieldgradient");
+      magField = new G4QuadrupoleMagField (fieldGradient);
+      //  magField = new G4QuadrupoleMagField (G4double pGradient, G4ThreeVector pOrigin, G4RotationMatrix *pMatrix);
+      cout << "Creating QUADRUPOLE with gradient " << fieldGradient << " and name " << GetName() << endl;
+    }
+
+  if ( !magField )
+    {
+      cout << PHWHERE << " Aborting, no magnetic field specified for " << GetName() << endl;
+      exit(1);
+    }
+
+  /* Set up Geant4 field manager */
+  G4FieldManager* fieldMgr = new G4FieldManager();
+  fieldMgr->SetDetectorField(magField);
+  fieldMgr->CreateChordFinder(magField);
+
+  /* Add volume with magnetic field */
+  double radius = params->get_double_param("radius")*cm;
+  double thickness = params->get_double_param("thickness")*cm;
+
+  G4VSolid *magnet_solid = new G4Tubs(G4String(GetName().c_str()),
+                                      0,
+                                      radius+thickness,
+                                      params->get_double_param("length")*cm/2. ,0,twopi);
+
+  G4LogicalVolume *magnet_logic = new G4LogicalVolume(magnet_solid,
+                                                      G4Material::GetMaterial("G4_Galactic"),
+                                                      G4String(GetName().c_str()),
+                                                      0,0,0);
+  magnet_logic->SetVisAttributes(fieldVis);
+
+  G4bool allLocal = false;
+  magnet_logic->SetFieldManager(fieldMgr,allLocal);
+
+  magnet_physi = new G4PVPlacement(0, G4ThreeVector(params->get_double_param("place_x")*cm,
+                                                    params->get_double_param("place_y")*cm,
+                                                    params->get_double_param("place_z")*cm),
+                                   magnet_logic,
+                                   G4String(GetName().c_str()),
+                                   logicWorld, 0, false, overlapcheck);
+
+
+  /* Add volume with solid magnet material */
+  G4VSolid *cylinder_solid = new G4Tubs(G4String(GetName().append("_Solid").c_str()),
+                                        radius,
+                                        radius + thickness,
+                                        params->get_double_param("length")*cm/2. ,0,twopi);
+  G4LogicalVolume *cylinder_logic = new G4LogicalVolume(cylinder_solid,
+                                                        TrackerMaterial,
+                                                        G4String(GetName().c_str()),
+                                                        0,0,0);
+  cylinder_logic->SetVisAttributes(siliconVis);
+
+  cylinder_physi = new G4PVPlacement(0, G4ThreeVector(0,0,0),
+                                     cylinder_logic,
+                                     G4String(GetName().append("_Solid").c_str()),
+                                     magnet_logic, 0, false, overlapcheck);
+
+}

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
@@ -5,8 +5,6 @@
 #include <g4main/PHG4Utils.h>
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>
-#include <phool/getClass.h>
 
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4LogicalVolume.hh>
@@ -17,18 +15,14 @@
 #include <Geant4/G4QuadrupoleMagField.hh>
 #include <Geant4/G4PhysicalConstants.hh>
 #include <Geant4/G4PVPlacement.hh>
-//#include <Geant4/G4RotationMatrix.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#include <cmath>
-#include <sstream>
 
 using namespace std;
 
 //_______________________________________________________________
-//note this inactive thickness is ~1.5% of a radiation length
 PHG4BeamlineMagnetDetector::PHG4BeamlineMagnetDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam, const int lyr ):
   PHG4Detector(Node,dnam),
   params(parameters),
@@ -87,14 +81,16 @@ void PHG4BeamlineMagnetDetector::Construct( G4LogicalVolume* logicWorld )
       G4double fieldValue = params->get_double_param("field_y")*tesla;
       magField = new G4UniformMagField(G4ThreeVector(0.,fieldValue,0.));
       //  magField = new G4UniformMagField (G4double vField, G4double vTheta, G4double vPhi);
-      cout << "Creating DIPOLE with field " << fieldValue << " and name " << GetName() << endl;
+      if ( verbosity > 0 )
+	cout << "Creating DIPOLE with field " << fieldValue << " and name " << GetName() << endl;
     }
   else if ( magnettype == "quadrupole" )
     {
       G4double fieldGradient = params->get_double_param("fieldgradient")*tesla/meter;
       magField = new G4QuadrupoleMagField (fieldGradient);
       //  magField = new G4QuadrupoleMagField (G4double pGradient, G4ThreeVector pOrigin, G4RotationMatrix *pMatrix);
-      cout << "Creating QUADRUPOLE with gradient " << fieldGradient << " and name " << GetName() << endl;
+      if ( verbosity > 0 )
+	cout << "Creating QUADRUPOLE with gradient " << fieldGradient << " and name " << GetName() << endl;
     }
 
   if ( !magField )

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.h
@@ -1,0 +1,43 @@
+#ifndef PHG4BeamlineMagnetDetector_h
+#define PHG4BeamlineMagnetDetector_h
+
+#include <g4main/PHG4Detector.h>
+
+#include <string>
+
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+class PHG4Parameters;
+
+class PHG4BeamlineMagnetDetector: public PHG4Detector
+{
+
+  public:
+
+  //! constructor
+  PHG4BeamlineMagnetDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam, const int layer = 0 );
+
+  //! destructor
+  virtual ~PHG4BeamlineMagnetDetector( void )
+  {}
+
+  //! construct
+  void Construct( G4LogicalVolume* world );
+
+  bool IsInBeamlineMagnet(const G4VPhysicalVolume*) const;
+  void SuperDetector(const std::string &name) {superdetector = name;}
+  const std::string SuperDetector() const {return superdetector;}
+  int get_Layer() const {return layer;}
+
+  private:
+
+  PHG4Parameters *params;
+
+  G4VPhysicalVolume* magnet_physi;
+  G4VPhysicalVolume* cylinder_physi;
+
+  int layer;
+  std::string superdetector;
+};
+
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
@@ -1,0 +1,145 @@
+#include "PHG4BeamlineMagnetSubsystem.h"
+#include "PHG4BeamlineMagnetDetector.h"
+#include "PHG4CylinderGeomv1.h"
+#include "PHG4CylinderGeomContainer.h"
+#include "PHG4CylinderSteppingAction.h"
+#include "PHG4EventActionClearZeroEdep.h"
+#include "PHG4Parameters.h"
+
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4PhenixDetector.h>
+#include <g4main/PHG4Utils.h>
+
+#include <phool/getClass.h>
+
+#include <Geant4/globals.hh>
+
+#include <sstream>
+
+using namespace std;
+
+//_______________________________________________________________________
+PHG4BeamlineMagnetSubsystem::PHG4BeamlineMagnetSubsystem( const std::string &na, const int lyr):
+  PHG4DetectorSubsystem(na,lyr),
+  detector_( NULL ),
+  steppingAction_( NULL ),
+  eventAction_(NULL)
+{
+  InitializeParameters();
+}
+
+//_______________________________________________________________________
+int PHG4BeamlineMagnetSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
+{
+  // create hit list only for active layers
+  PHNodeIterator iter( topNode );
+  //  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+  if (GetParams()->get_int_param("lengthviarapidity"))
+    {
+      GetParams()->set_double_param("length",PHG4Utils::GetLengthForRapidityCoverage( GetParams()->get_double_param("radius") + GetParams()->get_double_param("thickness"))*2);
+    }
+  // create detector
+  detector_ = new PHG4BeamlineMagnetDetector(topNode, GetParams(), Name(), GetLayer());
+//  G4double detlength = GetParams()->get_double_param("length");
+//  detector_->SuperDetector(SuperDetector());
+//  detector_->OverlapCheck(CheckOverlap());
+//  if (GetParams()->get_int_param("active"))
+//    {
+//      ostringstream nodename;
+//      ostringstream geonode;
+//      if (SuperDetector() != "NONE")
+//        {
+//          nodename <<  "G4HIT_" << SuperDetector();
+//          geonode << "CYLINDERGEOM_" << SuperDetector();
+//        }
+//      else
+//        {
+//          nodename <<  "G4HIT_" << Name();
+//          geonode << "CYLINDERGEOM_" << Name();
+//        }
+//      PHG4HitContainer* cylinder_hits =  findNode::getClass<PHG4HitContainer>( topNode , nodename.str().c_str() );
+//      if ( !cylinder_hits )
+//        {
+//          dstNode->addNode( new PHIODataNode<PHObject>( cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject" ));
+//        }
+//      cylinder_hits->AddLayer(GetLayer());
+//      PHG4CylinderGeomContainer *geo =  findNode::getClass<PHG4CylinderGeomContainer>(topNode , geonode.str().c_str());
+//      if (!geo)
+//        {
+//          geo = new PHG4CylinderGeomContainer();
+//          PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN" ));
+//          PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geo, geonode.str().c_str(), "PHObject");
+//          runNode->addNode(newNode);
+//        }
+//      PHG4CylinderGeom *mygeom = new PHG4CylinderGeomv1(GetParams()->get_double_param("radius"), GetParams()->get_double_param("place_z")-detlength/2., GetParams()->get_double_param("place_z") + detlength/2.,GetParams()->get_double_param("thickness"));
+//      geo->AddLayerGeom(GetLayer(), mygeom);
+//      eventAction_ = new PHG4EventActionClearZeroEdep(topNode, nodename.str());
+//      steppingAction_ = new PHG4CylinderSteppingAction(detector_, GetParams());
+//    }
+//  if (GetParams()->get_int_param("blackhole"))
+//    {
+//      steppingAction_ = new PHG4CylinderSteppingAction(detector_, GetParams());
+//    }
+  return 0;
+
+}
+
+//_______________________________________________________________________
+int PHG4BeamlineMagnetSubsystem::process_event( PHCompositeNode* topNode )
+{
+  // pass top node to stepping action so that it gets
+  // relevant nodes needed internally
+  if (steppingAction_)
+    {
+      steppingAction_->SetInterfacePointers( topNode );
+    }
+  return 0;
+
+}
+
+//_______________________________________________________________________
+PHG4Detector* PHG4BeamlineMagnetSubsystem::GetDetector( void ) const
+{
+  return detector_;
+}
+
+void
+PHG4BeamlineMagnetSubsystem::SetDefaultParameters()
+{
+  set_default_string_param("magtype", "");
+
+  set_default_double_param("field_y", NAN);
+  set_default_double_param("fieldgradient", NAN);
+
+  set_default_double_param("length",100);
+  set_default_double_param("place_x", 0.);
+  set_default_double_param("place_y", 0.);
+  set_default_double_param("place_z", 0.);
+  set_default_double_param("radius", 100);
+  set_default_double_param("thickness",100);
+  set_default_double_param("tmin",NAN);
+  set_default_double_param("tmax",NAN);
+
+  set_default_int_param("lengthviarapidity",1);
+
+  set_default_string_param("material", "G4_Galactic");
+}
+
+void
+PHG4BeamlineMagnetSubsystem::Print(const string &what) const
+{
+  cout << Name() << " Parameters: " << endl;
+  if (! BeginRunExecuted())
+    {
+      cout << "Need to execute BeginRun() before parameter printout is meaningful" << endl;
+      cout << "To do so either run one or more events or on the command line execute: " << endl;
+      cout << "Fun4AllServer *se = Fun4AllServer::instance();" << endl;
+      cout << "PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");" << endl;
+      cout << "g4->InitRun(se->topNode());" << endl;
+      cout << "PHG4BeamlineMagnetSubsystem *cyl = (PHG4BeamlineMagnetSubsystem *) g4->getSubsystem(\"" << Name() << "\");" << endl;
+      cout << "cyl->Print()" << endl;
+      return;
+    }
+  GetParams()->Print();
+  return;
+}

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
@@ -1,29 +1,17 @@
 #include "PHG4BeamlineMagnetSubsystem.h"
 #include "PHG4BeamlineMagnetDetector.h"
-#include "PHG4CylinderGeomv1.h"
-#include "PHG4CylinderGeomContainer.h"
-#include "PHG4CylinderSteppingAction.h"
-#include "PHG4EventActionClearZeroEdep.h"
 #include "PHG4Parameters.h"
 
-#include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4PhenixDetector.h>
 #include <g4main/PHG4Utils.h>
 
-#include <phool/getClass.h>
-
 #include <Geant4/globals.hh>
-
-#include <sstream>
 
 using namespace std;
 
 //_______________________________________________________________________
 PHG4BeamlineMagnetSubsystem::PHG4BeamlineMagnetSubsystem( const std::string &na, const int lyr):
   PHG4DetectorSubsystem(na,lyr),
-  detector_( NULL ),
-  steppingAction_( NULL ),
-  eventAction_(NULL)
+  detector_( NULL )
 {
   InitializeParameters();
 }
@@ -31,55 +19,10 @@ PHG4BeamlineMagnetSubsystem::PHG4BeamlineMagnetSubsystem( const std::string &na,
 //_______________________________________________________________________
 int PHG4BeamlineMagnetSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 {
-  // create hit list only for active layers
-  PHNodeIterator iter( topNode );
-  //  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
-  if (GetParams()->get_int_param("lengthviarapidity"))
-    {
-      GetParams()->set_double_param("length",PHG4Utils::GetLengthForRapidityCoverage( GetParams()->get_double_param("radius") + GetParams()->get_double_param("thickness"))*2);
-    }
-  // create detector
+
+  /* create magnet */
   detector_ = new PHG4BeamlineMagnetDetector(topNode, GetParams(), Name(), GetLayer());
-//  G4double detlength = GetParams()->get_double_param("length");
-//  detector_->SuperDetector(SuperDetector());
-//  detector_->OverlapCheck(CheckOverlap());
-//  if (GetParams()->get_int_param("active"))
-//    {
-//      ostringstream nodename;
-//      ostringstream geonode;
-//      if (SuperDetector() != "NONE")
-//        {
-//          nodename <<  "G4HIT_" << SuperDetector();
-//          geonode << "CYLINDERGEOM_" << SuperDetector();
-//        }
-//      else
-//        {
-//          nodename <<  "G4HIT_" << Name();
-//          geonode << "CYLINDERGEOM_" << Name();
-//        }
-//      PHG4HitContainer* cylinder_hits =  findNode::getClass<PHG4HitContainer>( topNode , nodename.str().c_str() );
-//      if ( !cylinder_hits )
-//        {
-//          dstNode->addNode( new PHIODataNode<PHObject>( cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject" ));
-//        }
-//      cylinder_hits->AddLayer(GetLayer());
-//      PHG4CylinderGeomContainer *geo =  findNode::getClass<PHG4CylinderGeomContainer>(topNode , geonode.str().c_str());
-//      if (!geo)
-//        {
-//          geo = new PHG4CylinderGeomContainer();
-//          PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN" ));
-//          PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geo, geonode.str().c_str(), "PHObject");
-//          runNode->addNode(newNode);
-//        }
-//      PHG4CylinderGeom *mygeom = new PHG4CylinderGeomv1(GetParams()->get_double_param("radius"), GetParams()->get_double_param("place_z")-detlength/2., GetParams()->get_double_param("place_z") + detlength/2.,GetParams()->get_double_param("thickness"));
-//      geo->AddLayerGeom(GetLayer(), mygeom);
-//      eventAction_ = new PHG4EventActionClearZeroEdep(topNode, nodename.str());
-//      steppingAction_ = new PHG4CylinderSteppingAction(detector_, GetParams());
-//    }
-//  if (GetParams()->get_int_param("blackhole"))
-//    {
-//      steppingAction_ = new PHG4CylinderSteppingAction(detector_, GetParams());
-//    }
+
   return 0;
 
 }
@@ -87,14 +30,7 @@ int PHG4BeamlineMagnetSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 //_______________________________________________________________________
 int PHG4BeamlineMagnetSubsystem::process_event( PHCompositeNode* topNode )
 {
-  // pass top node to stepping action so that it gets
-  // relevant nodes needed internally
-  if (steppingAction_)
-    {
-      steppingAction_->SetInterfacePointers( topNode );
-    }
   return 0;
-
 }
 
 //_______________________________________________________________________

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
@@ -115,6 +115,9 @@ PHG4BeamlineMagnetSubsystem::SetDefaultParameters()
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);
   set_default_double_param("place_z", 0.);
+  set_default_double_param("rot_x", 0.);
+  set_default_double_param("rot_y", 0.);
+  set_default_double_param("rot_z", 0.);
   set_default_double_param("radius", 100);
   set_default_double_param("thickness",100);
   set_default_double_param("tmin",NAN);

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.h
@@ -1,0 +1,62 @@
+#ifndef PHG4BeamlineMagnetSubsystem_h
+#define PHG4BeamlineMagnetSubsystem_h
+
+#include "PHG4DetectorSubsystem.h"
+
+#include <Geant4/G4Types.hh>
+#include <Geant4/G4String.hh>
+
+class PHG4BeamlineMagnetDetector;
+class PHG4SteppingAction;
+class PHG4EventAction;
+
+class PHG4BeamlineMagnetSubsystem: public PHG4DetectorSubsystem
+{
+
+  public:
+
+  //! constructor
+  PHG4BeamlineMagnetSubsystem( const std::string &name = "CYLINDER", const int layer = 0 );
+
+  //! destructor
+  virtual ~PHG4BeamlineMagnetSubsystem( void )
+  {}
+
+  //! init runwise stuff
+  /*!
+  creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
+  reates the stepping action and place it on the node tree, under "ACTIONS" node
+  creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
+  */
+  int InitRunSubsystem(PHCompositeNode *);
+
+  //! event processing
+  /*!
+  get all relevant nodes from top nodes (namely hit list)
+  and pass that to the stepping action
+  */
+  int process_event(PHCompositeNode *);
+
+  //! Print info (from SubsysReco)
+  void Print(const std::string &what = "ALL") const;
+
+  //! accessors (reimplemented)
+  PHG4Detector* GetDetector( void ) const;
+  PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
+  PHG4EventAction* GetEventAction() const {return eventAction_;}
+
+ private:
+  void SetDefaultParameters();
+
+  //! detector geometry
+  /*! defives from PHG4Detector */
+  PHG4BeamlineMagnetDetector* detector_;
+
+  //! particle tracking "stepping" action
+  /*! derives from PHG4SteppingActions */
+  PHG4SteppingAction* steppingAction_;
+
+  PHG4EventAction *eventAction_;
+};
+
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.h
@@ -3,12 +3,7 @@
 
 #include "PHG4DetectorSubsystem.h"
 
-#include <Geant4/G4Types.hh>
-#include <Geant4/G4String.hh>
-
 class PHG4BeamlineMagnetDetector;
-class PHG4SteppingAction;
-class PHG4EventAction;
 
 class PHG4BeamlineMagnetSubsystem: public PHG4DetectorSubsystem
 {
@@ -42,8 +37,6 @@ class PHG4BeamlineMagnetSubsystem: public PHG4DetectorSubsystem
 
   //! accessors (reimplemented)
   PHG4Detector* GetDetector( void ) const;
-  PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
-  PHG4EventAction* GetEventAction() const {return eventAction_;}
 
  private:
   void SetDefaultParameters();
@@ -52,11 +45,6 @@ class PHG4BeamlineMagnetSubsystem: public PHG4DetectorSubsystem
   /*! defives from PHG4Detector */
   PHG4BeamlineMagnetDetector* detector_;
 
-  //! particle tracking "stepping" action
-  /*! derives from PHG4SteppingActions */
-  PHG4SteppingAction* steppingAction_;
-
-  PHG4EventAction *eventAction_;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystemLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4BeamlineMagnetSubsystem-!;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
Adding a new class g4detectors/PHG4BeamlineMagnetSubsystem. This class represents beam line magnet for studies that need to consider the extended interaction region, for example exclusive processes in ep and eA collisions. The magnets are represented as cylinders with constant dipole or constant gradient quadrupole field within the cylinder volume. The magnet field, field type, position, aperture, outer radius, as well as position and rotation w.r.t. the nominal beam axis can be set via parameters.

This is a screenshot of five magnets in Fun4All (together with the BaBar coil from the default Fun4All macros):

![screen shot 2017-01-18 at 9 14 58 pm](https://cloud.githubusercontent.com/assets/9557412/22091122/4062d184-ddc3-11e6-8431-13955104df35.png)

A rough crosscheck of the deflection of particles in 'x'-direction at z=30 m caused by these magnets agrees reasonably well with calculations by CAD/MagnetDivision for the same configuration of eRHIC magnets:

particle  p(GeV)          angle(mrad)       z(mm)           x_CAD(mm)       x_Geant4(mm)
neutron   250        +4              30000           120.8                      120.0
proton    250        0               30000           279.2                      275.5
proton    250        +5              30000           336.8                      329.8
proton    250*0.8    0               30000           341.6                      333.7

Refining the simulation in the future (e.g. correcting the aperture which is actually not a perfect cylinder) are expected to improve the agreement.