### PR TITLE
Prototype3 production code update

### DIFF
--- a/offline/packages/Prototype3/EventInfoSummary.C
+++ b/offline/packages/Prototype3/EventInfoSummary.C
@@ -1,0 +1,296 @@
+#include "EventInfoSummary.h"
+#include "RawTower_Prototype3.h"
+#include "PROTOTYPE3_FEM.h"
+
+#include <g4cemc/RawTowerContainer.h>
+#include <ffaobjects/EventHeaderv1.h>
+#include <Event/Event.h>
+#include <Event/EventTypes.h>
+#include <Event/packetConstants.h>
+#include <Event/packet.h>
+#include <pdbcalbase/PdbParameterMap.h>
+#include <g4detectors/PHG4Parameters.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics.hpp>
+
+#include <iostream>
+#include <string>
+#include <cassert>
+
+using namespace std;
+using namespace boost::accumulators;
+
+typedef PHIODataNode<PHObject> PHObjectNode_t;
+
+//____________________________________
+EventInfoSummary::EventInfoSummary() :
+    SubsysReco("EventInfoSummary"), eventinfo_node_name("EVENT_INFO")
+{
+}
+
+//____________________________________
+int
+EventInfoSummary::Init(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________
+int
+EventInfoSummary::InitRun(PHCompositeNode *topNode)
+{
+  CreateNodeTree(topNode);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________
+int
+EventInfoSummary::process_event(PHCompositeNode *topNode)
+{
+  Event* event = findNode::getClass<Event>(topNode, "PRDF");
+  if (event == NULL)
+    {
+      if (Verbosity() >= VERBOSITY_SOME)
+        cout << "EventInfoSummary::Process_Event - Event not found" << endl;
+      return Fun4AllReturnCodes::DISCARDEVENT;
+    }
+
+  // search for run info
+  if (event->getEvtType() != DATAEVENT)
+    return Fun4AllReturnCodes::EVENT_OK;
+  else // DATAEVENT
+    {
+      if (verbosity >= VERBOSITY_SOME)
+        {
+          cout << "EventInfoSummary::process_event - with DATAEVENT events ";
+          event->identify();
+        }
+
+      map<int, Packet*> packet_list;
+
+      PHG4Parameters Params("EventInfo");
+
+      // spill indicator
+        {
+          RawTowerContainer* TOWER_RAW_SPILL_WARBLER = findNode::getClass<
+              RawTowerContainer>(topNode, "TOWER_RAW_SPILL_WARBLER");
+          assert(TOWER_RAW_SPILL_WARBLER);
+
+          RawTower_Prototype3 *raw_tower =
+              dynamic_cast<RawTower_Prototype3 *>(TOWER_RAW_SPILL_WARBLER->getTower(0));
+          assert(raw_tower);
+
+          accumulator_set<double, features<tag::variance>> acc;
+
+          vector<double> vec_signal_samples;
+          for (int i = 0; i < RawTower_Prototype3::NSAMPLES; i++)
+            {
+              acc(raw_tower->get_signal_samples(i));
+            }
+
+          const double warbler_rms = variance(acc);
+          const bool is_in_spill = warbler_rms > (1000*1000);
+          Params.set_double_param("beam_SPILL_WARBLER_RMS", warbler_rms);
+          Params.set_double_param("beam_Is_In_Spill", is_in_spill);
+          Params.set_int_param("beam_Is_In_Spill", is_in_spill);
+        }
+
+      // energy sums
+        {
+          RawTowerContainer* TOWER_CALIB_CEMC = findNode::getClass<
+              RawTowerContainer>(topNode, "TOWER_CALIB_CEMC");
+          assert(TOWER_CALIB_CEMC);
+
+          RawTowerContainer* TOWER_CALIB_LG_HCALIN = findNode::getClass<
+              RawTowerContainer>(topNode, "TOWER_CALIB_LG_HCALIN");
+
+          RawTowerContainer* TOWER_CALIB_LG_HCALOUT = findNode::getClass<
+              RawTowerContainer>(topNode, "TOWER_CALIB_LG_HCALOUT");
+
+          // process inner HCAL
+          if (TOWER_CALIB_CEMC)
+            {
+              double sum_energy_calib = 0;
+
+              auto range = TOWER_CALIB_CEMC->getTowers();
+              for (auto it = range.first; it != range.second; ++it)
+                {
+
+                  RawTower* tower = it->second;
+                  assert(tower);
+
+                  const int col = tower->get_bineta();
+                  const int row = tower->get_binphi();
+
+                  if (col < 0 or col >= 8)
+                    continue;
+                  if (row < 0 or row >= 8)
+                    continue;
+
+                  const double energy_calib = tower->get_energy();
+                  sum_energy_calib += energy_calib;
+
+                } //       for (auto it = range.first; it != range.second; ++it)
+              Params.set_double_param("CALIB_CEMC_Sum", sum_energy_calib);
+            } // process inner HCAL
+
+          // process inner HCAL
+          if (TOWER_CALIB_LG_HCALIN)
+            {
+              double sum_energy_calib = 0;
+
+              auto range = TOWER_CALIB_LG_HCALIN->getTowers();
+              for (auto it = range.first; it != range.second; ++it)
+                {
+
+                  RawTower* tower = it->second;
+                  assert(tower);
+
+                  const int col = tower->get_bineta();
+                  const int row = tower->get_binphi();
+
+                  if (col < 0 or col >= 4)
+                    continue;
+                  if (row < 0 or row >= 4)
+                    continue;
+
+                  const double energy_calib = tower->get_energy();
+                  sum_energy_calib += energy_calib;
+
+                } //       for (auto it = range.first; it != range.second; ++it)
+              Params.set_double_param("CALIB_LG_HCALIN_Sum", sum_energy_calib);
+            } // process inner HCAL
+
+          // process outer HCAL
+          if (TOWER_CALIB_LG_HCALOUT)
+            {
+              double sum_energy_calib = 0;
+
+              auto range = TOWER_CALIB_LG_HCALOUT->getTowers();
+              for (auto it = range.first; it != range.second; ++it)
+                {
+
+                  RawTower* tower = it->second;
+                  assert(tower);
+
+                  const int col = tower->get_bineta();
+                  const int row = tower->get_binphi();
+
+                  if (col < 0 or col >= 4)
+                    continue;
+                  if (row < 0 or row >= 4)
+                    continue;
+
+                  const double energy_calib = tower->get_energy();
+                  sum_energy_calib += energy_calib;
+
+                } //       for (auto it = range.first; it != range.second; ++it)
+
+              Params.set_double_param("CALIB_LG_HCALOUT_Sum", sum_energy_calib);
+            } // process outer HCAL
+
+        }
+
+      // generic packets
+      for (typ_channel_map::const_iterator it = channel_map.begin();
+          it != channel_map.end(); ++it)
+        {
+          const string & name = it->first;
+          const channel_info & info = it->second;
+
+          if (packet_list.find(info.packet_id) == packet_list.end())
+            {
+              packet_list[info.packet_id] = event->getPacket(info.packet_id);
+            }
+
+          Packet * packet = packet_list[info.packet_id];
+
+          if (!packet)
+            {
+//          if (Verbosity() >= VERBOSITY_SOME)
+              cout
+                  << "EventInfoSummary::process_event - failed to locate packet "
+                  << info.packet_id << " from ";
+              event->identify();
+
+              Params.set_double_param(name, NAN);
+              continue;
+            }
+
+          const int ivalue = packet->iValue(info.offset);
+
+          const double dvalue = ivalue * info.calibration_const;
+
+          if (verbosity >= VERBOSITY_SOME)
+            {
+              cout << "EventInfoSummary::process_event - " << name << " = "
+                  << dvalue << ", raw = " << ivalue << " @ packet "
+                  << info.packet_id << ", offset " << info.offset << endl;
+            }
+
+          Params.set_double_param(name, dvalue);
+        }
+
+      for (map<int, Packet*>::iterator it = packet_list.begin();
+          it != packet_list.end(); ++it)
+        {
+          if (it->second)
+            delete it->second;
+        }
+
+      Params.SaveToNodeTree(topNode, eventinfo_node_name);
+
+      if (verbosity >= VERBOSITY_SOME)
+        Params.Print();
+    }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_______________________________________
+void
+EventInfoSummary::CreateNodeTree(PHCompositeNode *topNode)
+{
+  PHNodeIterator nodeItr(topNode);
+
+  PHNodeIterator iter(topNode);
+
+  //DST node
+  PHCompositeNode* dst_node =
+      static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dst_node)
+    {
+      cout << "PHComposite node created: DST" << endl;
+      dst_node = new PHCompositeNode("DST");
+      topNode->addNode(dst_node);
+    }
+
+  PdbParameterMap *nodeparams =
+      findNode::getClass<PdbParameterMap>(dst_node, eventinfo_node_name);
+  if (not nodeparams)
+    {
+      dst_node->addNode(new PHIODataNode<PdbParameterMap>(new PdbParameterMap(), eventinfo_node_name));
+    }
+
+}
+
+//___________________________________
+int
+EventInfoSummary::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void
+EventInfoSummary::add_channel(const std::string & name, //! name of the channel
+    const int packet_id, //! packet id
+    const unsigned int offset, //! offset in packet data
+    const double calibration_const //! conversion constant from integer to meaningful value
+    )
+{
+  channel_map.insert(make_pair(name, channel_info(packet_id, offset, calibration_const)));
+}

--- a/offline/packages/Prototype3/EventInfoSummary.h
+++ b/offline/packages/Prototype3/EventInfoSummary.h
@@ -1,0 +1,66 @@
+#ifndef __CaloUnpackPRDFF__
+#define __CaloUnpackPRDFF__
+
+#include <fun4all/SubsysReco.h>
+#include <phool/PHObject.h>
+#include <string>
+#include <map>
+#include <utility>
+
+class Event;
+class Packet;
+class RawTowerContainer;
+class RawTower;
+
+class EventInfoSummary : public SubsysReco
+{
+public:
+  EventInfoSummary();
+
+  int
+  Init(PHCompositeNode *topNode);
+
+  int
+  InitRun(PHCompositeNode *topNode);
+
+  int
+  process_event(PHCompositeNode *topNode);
+
+  int
+  End(PHCompositeNode *topNode);
+
+  void
+  CreateNodeTree(PHCompositeNode *topNode);
+
+  //! add stuff to be unpacked
+  void
+  add_channel(const std::string & name, //! name of the channel
+      const int packet_id, //! packet id
+      const unsigned int offset, //! offset in packet data
+      const double calibration_const = +1 //! conversion constant from integer to meaningful value
+      );
+
+private:
+
+  class channel_info
+  {
+  public:
+    channel_info(int p, unsigned int o, double c) :
+        packet_id(p), offset(o), calibration_const(c)
+    {
+    }
+
+    int packet_id;
+    unsigned offset;
+    double calibration_const;
+  };
+
+  //! list of channel name -> channel info
+  typedef std::map<std::string, channel_info> typ_channel_map;
+
+  typ_channel_map channel_map;
+
+  std::string eventinfo_node_name;
+};
+
+#endif //**CaloUnpackPRDFF**//

--- a/offline/packages/Prototype3/EventInfoSummaryLinkDef.h
+++ b/offline/packages/Prototype3/EventInfoSummaryLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class EventInfoSummary-!;
+
+#endif

--- a/offline/packages/Prototype3/Makefile.am
+++ b/offline/packages/Prototype3/Makefile.am
@@ -30,6 +30,8 @@ libPrototype3_la_SOURCES = \
   TempInfoUnpackPRDFDict.C \
   RunInfoUnpackPRDF.C \
   RunInfoUnpackPRDFDict.C \
+  EventInfoSummary.C \
+  EventInfoSummaryDict.C \
   CaloCalibration.C \
   CaloCalibrationDict.C \
   GenericUnpackPRDF.C \

--- a/offline/packages/Prototype3/PROTOTYPE3_FEM.C
+++ b/offline/packages/Prototype3/PROTOTYPE3_FEM.C
@@ -178,7 +178,7 @@ PROTOTYPE3_FEM::SampleFit_PowerLawExp(//
 
   //Saturation correction - Abhisek
    for(int ipoint=0; ipoint<gpulse.GetN(); ipoint++)
-    if((gpulse.GetY())[ipoint]==0)
+    if((gpulse.GetY())[ipoint]==0 or (gpulse.GetY())[ipoint]>=4090) // drop point if touching max or low limit on ADCs
      {
       gpulse.RemovePoint(ipoint);
       ipoint--;

--- a/offline/packages/Prototype3/Prototype3DSTReader.cc
+++ b/offline/packages/Prototype3/Prototype3DSTReader.cc
@@ -82,6 +82,23 @@ Prototype3DSTReader::Init(PHCompositeNode*)
 
       nblocks++;
     }
+  for (vector<string>::const_iterator it = _eventinfo_list.begin();
+      it != _eventinfo_list.end(); ++it)
+    {
+      const string & nodenam = *it;
+
+      record rec;
+      rec._cnt = 0;
+      rec._name = nodenam;
+      rec._arr = NULL;
+      rec._arr_ptr = NULL;
+      rec._dvalue = 0;
+      rec._type = record::typ_eventinfo;
+
+      _records.push_back(rec);
+
+      nblocks++;
+    }
 
   for (vector<string>::const_iterator it = _tower_postfix.begin();
       it != _tower_postfix.end(); ++it)
@@ -158,6 +175,14 @@ Prototype3DSTReader::build_tree()
       cout << "Prototype3DSTReader::build_tree - Add " << rec._name << endl;
 
       if (rec._type == record::typ_runinfo)
+        {
+
+          const string name_cnt = rec._name;
+          const string name_cnt_desc = name_cnt + "/D";
+          _T->Branch(name_cnt.c_str(), &(rec._dvalue), name_cnt_desc.c_str(),
+              BUFFER_SIZE);
+        }
+      if (rec._type == record::typ_eventinfo)
         {
 
           const string name_cnt = rec._name;
@@ -347,6 +372,20 @@ Prototype3DSTReader::process_event(PHCompositeNode* topNode)
           run_info_copy.FillFrom(info);
 
           rec._dvalue = run_info_copy.get_double_param(rec._name);
+
+        } //
+      else if (rec._type == record::typ_eventinfo)
+        {
+
+          PdbParameterMap *info = findNode::getClass<PdbParameterMap>(topNode,
+              "EVENT_INFO");
+
+          assert(info);
+
+          PHG4Parameters event_info_copy("EVENT_INFO");
+          event_info_copy.FillFrom(info);
+
+          rec._dvalue = event_info_copy.get_double_param(rec._name);
 
         } //      if (rec._type == record::typ_hit)
       else if (rec._type == record::typ_part)

--- a/offline/packages/Prototype3/Prototype3DSTReader.h
+++ b/offline/packages/Prototype3/Prototype3DSTReader.h
@@ -69,6 +69,11 @@ public:
   {
     _runinfo_list.push_back(name);
   }
+  void
+  AddEventInfo(const std::string &name)
+  {
+    _eventinfo_list.push_back(name);
+  }
 
   //! zero suppression for all calorimeters
   double
@@ -93,6 +98,7 @@ protected:
 //  std::vector<std::string> _jet_postfix;
 //  std::vector<std::string> _node_name;
   std::vector<std::string> _runinfo_list;
+  std::vector<std::string> _eventinfo_list;
 
   int nblocks;
 
@@ -110,7 +116,7 @@ protected:
 
     enum enu_type
     {
-      typ_hit, typ_part, typ_vertex, typ_tower, typ_jets, typ_runinfo, typ_towertemp
+      typ_hit, typ_part, typ_vertex, typ_tower, typ_jets, typ_runinfo, typ_eventinfo, typ_towertemp
     };
     enu_type _type;
   };


### PR DESCRIPTION
Prototype3 production code update:

1. This year, the calorimeter signals are positive pulses. Adjust the ADC-time fitting code to allow overflow-ADC samples in the positive directions. 
2. Thanks for Martin pointing out a new signal this year encode the spill indicator. Added a module to interpret the spill indicator and place results in a new event information ''DST/EVENT_INFO'' node, as well as in the DST-reader TTrees as variable ''beam_Is_In_Spill''. 

Will start a new series of data production and update on wiki: https://wiki.bnl.gov/sPHENIX/index.php/2017_calorimeter_beam_test/Data_Production_and_Analysis#Production_output 