### PR TITLE
add PDF info to to HepMC::GenEvent

### DIFF
--- a/generators/PHPythia6/PHPythia6.C
+++ b/generators/PHPythia6/PHPythia6.C
@@ -373,6 +373,15 @@ int PHPythia6::process_event(PHCompositeNode *topNode) {
     // set cross section information
     evt->set_cross_section( HepMC::getPythiaCrossSection() );
 
+    // Set the PDF information
+    HepMC::PdfInfo pdfinfo;
+    pdfinfo.set_x1(pypars.pari[33-1]); 
+    pdfinfo.set_x2(pypars.pari[34-1]); 
+    pdfinfo.set_scalePDF(pypars.pari[22-1]);
+    pdfinfo.set_id1(pypars.msti[15-1]); 
+    pdfinfo.set_id2(pypars.msti[16-1]);  
+    evt->set_pdf_info(pdfinfo); 
+
     // test trigger logic
     
     bool andScoreKeeper = true;


### PR DESCRIPTION
Adds a PdfInfo structure to the HEPMC GenEvent so the x1, x2, Q2 and parton id's for the event are saved. 