### PR TITLE
clean up memory before deleting track vector in PHG4TrackFastSim

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -291,8 +291,11 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 	//! add tracks to event display
 	if (_do_evt_display)
 		_fitter->getEventDisplay()->addEvent(rf_gf_tracks);
-	else
-		rf_gf_tracks.clear();
+	else{
+	  for (std::vector<genfit::Track*>::iterator it = rf_gf_tracks.begin() ; it != rf_gf_tracks.end(); ++it)
+	    delete (*it);
+	  rf_gf_tracks.clear();
+	}
 
 //	if(_trackmap_out->get(0)) {
 //		_trackmap_out->get(0)->identify();


### PR DESCRIPTION
Fix memory leak by cleaning up new'd tracks before clearing list. 