### PR TITLE
Memory leak fix for PHGenFit and PHG4TrackKalmanFitter

### DIFF
--- a/offline/packages/PHGenFitPkg/Example/Makefile
+++ b/offline/packages/PHGenFitPkg/Example/Makefile
@@ -9,8 +9,8 @@ G4CONFIG     := geant4-config
 G4CFLAGS     := $(shell $(G4CONFIG) --cflags) 
 G4LDFLAGS    := $(shell $(G4CONFIG) --libs)
 
-GENFITCFLAGS	:=	-I$(GENFIT)/include
-GENFITLDFLAGS	:=	-L$(GENFIT)/lib -lgenfit2
+#GENFITCFLAGS	:=	-I$(GENFIT)/include
+#GENFITLDFLAGS	:=	-L$(GENFIT)/lib -lgenfit2
 
 CXX           = c++ -g
 CXXFLAGS      = -O3 -Wall -fPIC
@@ -28,11 +28,11 @@ LDFLAGS      += $(ROOTLDFLAGS) $(ROOTGLIBS) ${ROOTLIBS}
 #CXXFLAGS     += $(GENFITCFLAGS)
 #LDFLAGS      += $(GENFITLDFLAGS)
 
-CXXFLAGS	+=	-I$(OFFLINE_MAIN)/include
-LDFLAGS		+=	-L$(OFFLINE_MAIN)/lib -lgenfit2exp -lPHGenFit
-
 CXXFLAGS	+=	-I$(MY_INSTALL)/include
 LDFLAGS		+=	-L$(MY_INSTALL)/lib -lgenfit2exp -lPHGenFit
+
+CXXFLAGS	+=	-I$(OFFLINE_MAIN)/include
+LDFLAGS		+=	-L$(OFFLINE_MAIN)/lib -lgenfit2exp -lPHGenFit
 
 TESTO         = testPHGenFit.o
 TEST	        = testPHGenFit

--- a/offline/packages/PHGenFitPkg/Example/minimumTestPHGenFit.cc
+++ b/offline/packages/PHGenFitPkg/Example/minimumTestPHGenFit.cc
@@ -44,7 +44,7 @@ std::vector<TVector3> get_raw_measurements()
 
 int main(int argc, char**argv) {
 	//! Initiallize Geometry, Field, Fitter
-	PHGenFit::Fitter* fitter = new PHGenFit::Fitter("sPHENIX_Geo.root","sPHENIX.2d.root", 1.4 / 1.5,"KalmanFitter","RKTrackRep",true);
+	PHGenFit::Fitter* fitter = new PHGenFit::Fitter("sPHENIX_Geo.root","sPHENIX.2d.root", 1.4 / 1.5,"KalmanFitter","RKTrackRep",false);
 
 	//! Build TrackRep from particle assumption
 	int pid = -13; //mu+
@@ -75,16 +75,28 @@ int main(int argc, char**argv) {
 	track->addMeasurements(measurements);
 
 	//! Fit the track
-	fitter->processTrack(track, true);
+	fitter->processTrack(track, false);
+
+	for(int i=0;i<measurements.size();i++) {
+		delete measurements[i];
+		measurements[i] = NULL;
+	}
+	measurements.clear();
 
 	//! Extrapolate to beam line
-	genfit::MeasuredStateOnPlane* state_at_beam_line = track->extrapolateToLine(TVector3(0, 0, 0), TVector3(0, 0, 1));
-	state_at_beam_line->Print();
+	//genfit::MeasuredStateOnPlane* state = track->extrapolateToLine(TVector3(0, 0, 0), TVector3(0, 0, 1));
+	//genfit::MeasuredStateOnPlane* state = track->extrapolateToPoint(TVector3(0, 0, 0));
+	genfit::MeasuredStateOnPlane* state = track->extrapolateToCylinder(1.,TVector3(0, 0, 0), TVector3(0, 0, 1));
+	state->Print();
+	delete state;
 
 	//! Event display, uncomment to use
 	//fitter->displayEvent();
 
 	//! Comment off if want to keep event display.
+
+	delete track;
+
 	delete fitter;
 
 	return 0;

--- a/offline/packages/PHGenFitPkg/Example/minimumTestPHGenFit.cc
+++ b/offline/packages/PHGenFitPkg/Example/minimumTestPHGenFit.cc
@@ -77,12 +77,6 @@ int main(int argc, char**argv) {
 	//! Fit the track
 	fitter->processTrack(track, false);
 
-	for(int i=0;i<measurements.size();i++) {
-		delete measurements[i];
-		measurements[i] = NULL;
-	}
-	measurements.clear();
-
 	//! Extrapolate to beam line
 	//genfit::MeasuredStateOnPlane* state = track->extrapolateToLine(TVector3(0, 0, 0), TVector3(0, 0, 1));
 	//genfit::MeasuredStateOnPlane* state = track->extrapolateToPoint(TVector3(0, 0, 0));

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
@@ -37,11 +37,11 @@
 namespace PHGenFit {
 
 Fitter::Fitter(
-		const std::string tgeo_file_name,
-		const std::string field_file_name,
+		const std::string &tgeo_file_name,
+		const std::string &field_file_name,
 		const double field_scaling_factor,
-		const std::string fitter_choice,
-		const std::string track_rep_choice,
+		const std::string &fitter_choice,
+		const std::string &track_rep_choice,
 		const bool doEventDisplay
 ) : verbosity(0), _doEventDisplay(doEventDisplay)
 {
@@ -123,9 +123,9 @@ int Fitter::processTrack(PHGenFit::Track* track, const bool save_to_evt_disp) {
 	return 0;
 }
 
-Fitter* Fitter::getInstance(const std::string tgeo_file_name,
-		const std::string field_file_name, const double field_scaling_factor,
-		const std::string fitter_choice, const std::string track_rep_choice,
+Fitter* Fitter::getInstance(const std::string &tgeo_file_name,
+		const std::string &field_file_name, const double field_scaling_factor,
+		const std::string &fitter_choice, const std::string &track_rep_choice,
 		const bool doEventDisplay) {
 
 	TGeoManager* tgeo_manager = TGeoManager::Import(tgeo_file_name.data(), "Default");
@@ -148,8 +148,8 @@ Fitter* Fitter::getInstance(const std::string tgeo_file_name,
 }
 
 Fitter* Fitter::getInstance(TGeoManager* tgeo_manager,
-		const std::string field_file_name, const double field_scaling_factor,
-		const std::string fitter_choice, const std::string track_rep_choice,
+		const std::string &field_file_name, const double field_scaling_factor,
+		const std::string &fitter_choice, const std::string &track_rep_choice,
 		const bool doEventDisplay) {
 
 	if(!tgeo_manager)
@@ -171,7 +171,7 @@ Fitter* Fitter::getInstance(TGeoManager* tgeo_manager,
 }
 
 Fitter::Fitter(TGeoManager* tgeo_manager, genfit::AbsBField* fieldMap,
-		const std::string fitter_choice, const std::string track_rep_choice,
+		const std::string &fitter_choice, const std::string &track_rep_choice,
 		const bool doEventDisplay): verbosity(0), _tgeo_manager(tgeo_manager), _doEventDisplay(doEventDisplay)
 {
 

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
@@ -37,34 +37,34 @@ class Fitter
 {
 public:
 	//! Default constructor
-	Fitter(const std::string tgeo_file_name,
-			const std::string field_file_name,
+	Fitter(const std::string &tgeo_file_name,
+			const std::string &field_file_name,
 			const double field_scaling_factor = 1.4/1.5,
-			const std::string fitter_choice = "KalmanFitterRefTrack",
-			const std::string track_rep_choice = "RKTrackRep",
+			const std::string &fitter_choice = "KalmanFitterRefTrack",
+			const std::string &track_rep_choice = "RKTrackRep",
 			const bool doEventDisplay = false);
 
 	Fitter(TGeoManager* tgeo_manager,
 			genfit::AbsBField* fieldMap,
-			const std::string fitter_choice = "KalmanFitterRefTrack",
-			const std::string track_rep_choice = "RKTrackRep",
+			const std::string &fitter_choice = "KalmanFitterRefTrack",
+			const std::string &track_rep_choice = "RKTrackRep",
 			const bool doEventDisplay = false);
 
 	//! Default destructor
 	~Fitter();
 
-	static Fitter* getInstance(const std::string tgeo_file_name,
-			const std::string field_file_name,
+	static Fitter* getInstance(const std::string &tgeo_file_name,
+			const std::string &field_file_name,
 			const double field_scaling_factor = 1.4/1.5,
-			const std::string fitter_choice = "KalmanFitterRefTrack",
-			const std::string track_rep_choice = "RKTrackRep",
+			const std::string &fitter_choice = "KalmanFitterRefTrack",
+			const std::string &track_rep_choice = "RKTrackRep",
 			const bool doEventDisplay = false);
 
 	static Fitter* getInstance(TGeoManager* tgeo_manager,
-			const std::string field_file_name,
+			const std::string &field_file_name,
 			const double field_scaling_factor = 1.4/1.5,
-			const std::string fitter_choice = "KalmanFitterRefTrack",
-			const std::string track_rep_choice = "RKTrackRep",
+			const std::string &fitter_choice = "KalmanFitterRefTrack",
+			const std::string &track_rep_choice = "RKTrackRep",
 			const bool doEventDisplay = false);
 
 	int processTrack(PHGenFit::Track* track, const bool save_to_evt_disp = false);

--- a/offline/packages/PHGenFitPkg/PHGenFit/Measurement.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Measurement.cc
@@ -10,7 +10,8 @@ namespace PHGenFit {
 
 Measurement::~Measurement()
 {
-	delete _measurement;
-	_measurement = NULL;
+//	if(_measurement) {
+//		delete _measurement;
+//	}
 }
 } //End of PHGenFit namespace

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
@@ -45,7 +45,7 @@ Track::Track(genfit::AbsTrackRep *rep, TVector3 seed_pos, TVector3 seed_mom, TMa
 	//_track = NEW(genfit::Track)(rep, seedState, seedCov);
 }
 
-int Track::addMeasurements(std::vector<PHGenFit::Measurement*> measurements)
+int Track::addMeasurements(std::vector<PHGenFit::Measurement*> &measurements)
 {
 	BOOST_FOREACH(PHGenFit::Measurement* measurement, measurements)
 	{
@@ -53,7 +53,11 @@ int Track::addMeasurements(std::vector<PHGenFit::Measurement*> measurements)
 		msmts.push_back(measurement->getMeasurement());
 		_track->insertPoint(
 				new genfit::TrackPoint(msmts, _track));
+
+		_measurements.push_back(measurement);
 	}
+
+	//measurements.clear();
 
 	return 0;
 }
@@ -61,6 +65,12 @@ int Track::addMeasurements(std::vector<PHGenFit::Measurement*> measurements)
 Track::~Track()
 {
 	delete _track;
+
+	BOOST_FOREACH(PHGenFit::Measurement* measurement, _measurements)
+	{
+		delete measurement;
+	}
+	_measurements.clear();
 }
 
 double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O, TVector3 n, const int tr_point_id) const

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
@@ -90,6 +90,8 @@ double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O
 
 	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
 
+	delete kfsop;
+
 	return pathlenth;
 }
 
@@ -130,6 +132,7 @@ double Track::extrapolateToLine(genfit::MeasuredStateOnPlane& state, TVector3 li
 
 	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
 
+	delete kfsop;
 
 	return pathlenth;
 }
@@ -172,6 +175,8 @@ double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double 
 
 	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
 
+	delete kfsop;
+
 	return pathlenth;
 }
 
@@ -210,6 +215,8 @@ double Track::extrapolateToPoint(genfit::MeasuredStateOnPlane& state, TVector3 P
 	}
 
 	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
+
+	delete kfsop;
 
 	return pathlenth;
 }

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
@@ -86,21 +86,21 @@ double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
 		return WILD_DOUBLE;
 	}
-	genfit::KalmanFittedStateOnPlane *kfsop  = new genfit::KalmanFittedStateOnPlane(
-			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
+	std::unique_ptr<genfit::KalmanFittedStateOnPlane> kfsop (new genfit::KalmanFittedStateOnPlane(
+			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate())));
 	// extrapolate back to reference plane.
 	try {
 		pathlenth = rep->extrapolateToPlane(*kfsop, destPlane);
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
-		delete kfsop;
+		//delete kfsop;
 		return WILD_DOUBLE;
 	}
 
-	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop.get());
 
-	delete kfsop;
+	//delete kfsop;
 
 	return pathlenth;
 }
@@ -128,21 +128,21 @@ double Track::extrapolateToLine(genfit::MeasuredStateOnPlane& state, TVector3 li
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
 		return WILD_DOUBLE;
 	}
-	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
-			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
+	std::unique_ptr<genfit::KalmanFittedStateOnPlane> kfsop (new genfit::KalmanFittedStateOnPlane(
+			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate())));
 	// extrapolate back to reference plane.
 	try {
 		pathlenth = rep->extrapolateToLine(*kfsop, line_point, line_direction);
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
-		delete kfsop;
+		//delete kfsop;
 		return WILD_DOUBLE;
 	}
 
-	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop.get());
 
-	delete kfsop;
+	//delete kfsop;
 
 	return pathlenth;
 }
@@ -170,8 +170,8 @@ double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double 
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
 		return WILD_DOUBLE;
 	}
-	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
-			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getForwardUpdate()));
+	std::unique_ptr<genfit::KalmanFittedStateOnPlane> kfsop (new genfit::KalmanFittedStateOnPlane(
+			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate())));
 	// extrapolate back to reference plane.
 	try {
 		//rep->extrapolateToLine(*kfsop, line_point, line_direction);
@@ -179,13 +179,13 @@ double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double 
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
-		delete kfsop;
+		//delete kfsop;
 		return WILD_DOUBLE;
 	}
 
-	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop.get());
 
-	delete kfsop;
+	//delete kfsop;
 
 	return pathlenth;
 }
@@ -212,21 +212,21 @@ double Track::extrapolateToPoint(genfit::MeasuredStateOnPlane& state, TVector3 P
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
 		return WILD_DOUBLE;
 	}
-	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
-			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
+	std::unique_ptr<genfit::KalmanFittedStateOnPlane> kfsop (new genfit::KalmanFittedStateOnPlane(
+			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate())));
 	// extrapolate back to reference plane.
 	try {
 		pathlenth = rep->extrapolateToPoint(*kfsop, P);
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
-		delete kfsop;
+		//delete kfsop;
 		return WILD_DOUBLE;
 	}
 
-	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop.get());
 
-	delete kfsop;
+	//delete kfsop;
 
 	return pathlenth;
 }
@@ -248,11 +248,11 @@ double Track::get_charge() const {
 
 	genfit::AbsTrackRep* rep = _track->getCardinalRep();
 	if(rep) {
-		genfit::StateOnPlane* state = this->extrapolateToLine(TVector3(0, 0, 0),
-				TVector3(1, 0, 0));
+		std::unique_ptr<genfit::StateOnPlane> state (this->extrapolateToLine(TVector3(0, 0, 0),
+				TVector3(1, 0, 0)));
 		if (state)
 			charge = rep->getCharge(*state);
-		delete state;
+		//delete state;
 	}
 
 	return charge;

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.h
@@ -42,7 +42,7 @@ public:
 	~Track();
 
 	//! Add measurement
-	int addMeasurements(std::vector<PHGenFit::Measurement*> measurements);
+	int addMeasurements(std::vector<PHGenFit::Measurement*> &measurements);
 
 	/*!
 	 * track_point 0 is the first one, and -1 is the last one
@@ -85,6 +85,7 @@ public:
 private:
 
 	genfit::Track* _track;
+	std::vector<PHGenFit::Measurement*> _measurements;
 	//SMART(genfit::Track) _track;
 };
 } //End of PHGenFit namespace

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
@@ -438,6 +438,9 @@ int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 		}
 	}
 
+	for(genfit::GFRaveVertex *vertex: rave_vertices) {
+		delete vertex;
+	}
 	rave_vertices.clear();
 
 	if (_do_eval) {
@@ -1390,14 +1393,17 @@ bool PHG4TrackKalmanFitter::FillSvtxVertexMap(
 			}
 		}
 
-		if (_vertexmap_refit)
+		if (_vertexmap_refit) {
 			_vertexmap_refit->insert(svtx_vtx);
+		}
 
 		if (verbosity >= 2) {
 			cout << PHWHERE << endl;
 			svtx_vtx->Print();
 			_vertexmap_refit->Print();
 		}
+
+		delete svtx_vtx;
 	}
 
 	return true;

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
@@ -40,6 +40,7 @@
 #include <map>
 #include <utility>
 #include <vector>
+#include <memory>
 
 #include "TClonesArray.h"
 #include "TMatrixDSym.h"
@@ -275,7 +276,7 @@ int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 	vector<genfit::Track*> rf_gf_tracks;
 	rf_gf_tracks.clear();
 
-	vector<PHGenFit::Track*> rf_phgf_tracks;
+	vector< std::shared_ptr<PHGenFit::Track> > rf_phgf_tracks;
 	rf_phgf_tracks.clear();
 
 	map<unsigned int, unsigned int> svtxtrack_genfittrack_map;
@@ -292,7 +293,7 @@ int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 			continue;
 
 		//! stands for Refit_PHGenFit_Track
-		PHGenFit::Track* rf_phgf_track = ReFitTrack(topNode, svtx_track);
+		std::shared_ptr<PHGenFit::Track> rf_phgf_track = ReFitTrack(topNode, svtx_track);
 
 		if (rf_phgf_track) {
 			svtxtrack_genfittrack_map[svtx_track->get_id()] =
@@ -322,7 +323,7 @@ int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 
 	for (SvtxTrackMap::Iter iter = _trackmap->begin(); iter != _trackmap->end();
 			++iter) {
-		PHGenFit::Track* rf_phgf_track = NULL;
+		std::shared_ptr<PHGenFit::Track> rf_phgf_track = NULL;
 
 		if (svtxtrack_genfittrack_map.find(iter->second->get_id())
 				!= svtxtrack_genfittrack_map.end()) {
@@ -361,8 +362,10 @@ int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 //					vertex->set_error(i,j,0);
 			//END DEBUG
 
-			SvtxTrack* rf_track = MakeSvtxTrack(iter->second, rf_phgf_track,
-					vertex);
+//			SvtxTrack* rf_track = MakeSvtxTrack(iter->second, rf_phgf_track,
+//					vertex);
+			std::unique_ptr<SvtxTrack> rf_track(MakeSvtxTrack(iter->second, rf_phgf_track,
+					vertex));
 
 			if(!rf_track) {
 				if (_output_mode == OverwriteOriginalNode)
@@ -376,15 +379,15 @@ int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 
 			if (_output_mode == MakeNewNode || _output_mode == DebugMode)
 				if (_trackmap_refit) {
-					_trackmap_refit->insert(rf_track);
-					delete rf_track;
+					_trackmap_refit->insert(rf_track.get());
+//					delete rf_track;
 				}
 
 			if (_output_mode == OverwriteOriginalNode
 					|| _output_mode == DebugMode) {
 				*(dynamic_cast<SvtxTrack_v1*>(iter->second)) =
-						*(dynamic_cast<SvtxTrack_v1*>(rf_track));
-				delete rf_track;
+						*(dynamic_cast<SvtxTrack_v1*>(rf_track.get()));
+//				delete rf_track;
 			}
 		} else {
 			if (_output_mode == OverwriteOriginalNode)
@@ -395,9 +398,9 @@ int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 
 	// Need to keep tracks if _do_evt_display
 	if(!_do_evt_display) {
-		for(PHGenFit::Track *rf_phgf_track : rf_phgf_tracks) {
-			delete rf_phgf_track;
-		}
+//		for(std::shared_ptr<PHGenFit::Track> rf_phgf_track : rf_phgf_tracks) {
+//			delete rf_phgf_track;
+//		}
 		rf_phgf_tracks.clear();
 	}
 
@@ -420,7 +423,7 @@ int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 				/*!
 				 * rf_phgf_track stands for Refit_PHGenFit_Track
 				 */
-				PHGenFit::Track* rf_phgf_track = ReFitTrack(topNode, svtx_track,
+				std::shared_ptr<PHGenFit::Track> rf_phgf_track = ReFitTrack(topNode, svtx_track,
 						vertex);
 				if (rf_phgf_track) {
 					//FIXME figure out which vertex to use.
@@ -429,7 +432,7 @@ int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 						vertex = _vertexmap_refit->get(0);
 					SvtxTrack* rf_track = MakeSvtxTrack(svtx_track,
 							rf_phgf_track, vertex);
-					delete rf_phgf_track;
+					//delete rf_phgf_track;
 					_primary_trackmap->insert(rf_track);
 				}
 			}
@@ -742,8 +745,12 @@ int PHG4TrackKalmanFitter::GetNodes(PHCompositeNode * topNode) {
  * \param intrack Input SvtxTrack
  * \param invertex Input Vertex, if fit track as a primary vertex
  */
-PHGenFit::Track* PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNode *topNode, const SvtxTrack* intrack,
+//PHGenFit::Track* PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNode *topNode, const SvtxTrack* intrack,
+std::shared_ptr<PHGenFit::Track> PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNode *topNode, const SvtxTrack* intrack,
 		const SvtxVertex* invertex) {
+
+	//std::shared_ptr<PHGenFit::Track> empty_track(NULL);
+
 	if (!intrack) {
 		cerr << PHWHERE << " Input SvtxTrack is NULL!" << endl;
 		return NULL;
@@ -1084,8 +1091,8 @@ PHGenFit::Track* PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNode *topNode, con
 	//TODO Add multiple TrackRep choices.
 	//int pid = 211;
 	genfit::AbsTrackRep* rep = new genfit::RKTrackRep(_primary_pid_guess);
-	PHGenFit::Track* track = new PHGenFit::Track(rep, seed_pos, seed_mom,
-			seed_cov);
+	std::shared_ptr<PHGenFit::Track> track(new PHGenFit::Track(rep, seed_pos, seed_mom,
+			seed_cov));
 
 	//TODO unsorted measurements, should use sorted ones?
 	track->addMeasurements(measurements);
@@ -1094,10 +1101,10 @@ PHGenFit::Track* PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNode *topNode, con
 	 *  Fit the track
 	 *  ret code 0 means 0 error or good status
 	 */
-	if (_fitter->processTrack(track, false) != 0) {
+	if (_fitter->processTrack(track.get(), false) != 0) {
 		if (verbosity >= 1)
 			LogWarning("Track fitting failed");
-		delete track;
+		//delete track;
 		return NULL;
 	}
 
@@ -1108,7 +1115,9 @@ PHGenFit::Track* PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNode *topNode, con
  * Make SvtxTrack from PHGenFit::Track and SvtxTrack
  */
 SvtxTrack* PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack* svtx_track,
-		const PHGenFit::Track* phgf_track, const SvtxVertex* vertex) {
+//std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack* svtx_track,
+		const std::shared_ptr<PHGenFit::Track>& phgf_track, const SvtxVertex* vertex) {
+
 
 	double chi2 = phgf_track->get_chi2();
 	double ndf = phgf_track->get_ndf();
@@ -1129,10 +1138,11 @@ SvtxTrack* PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack* svtx_track,
 				vertex_cov[i][j] = vertex->get_error(i,j);
 	}
 
-	genfit::MeasuredStateOnPlane* gf_state_beam_line_ca = NULL;
+	//genfit::MeasuredStateOnPlane* gf_state_beam_line_ca = NULL;
+	std::shared_ptr<genfit::MeasuredStateOnPlane> gf_state_beam_line_ca = NULL;
 	try {
-		gf_state_beam_line_ca = phgf_track->extrapolateToLine(vertex_position,
-				TVector3(0., 0., 1.));
+		gf_state_beam_line_ca = std::shared_ptr<genfit::MeasuredStateOnPlane>(phgf_track->extrapolateToLine(vertex_position,
+				TVector3(0., 0., 1.)));
 	} catch (...) {
 		if (verbosity >= 2)
 			LogWarning("extrapolateToLine failed!");
@@ -1152,7 +1162,7 @@ SvtxTrack* PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack* svtx_track,
 	double du2 = gf_state_beam_line_ca->getCov()[3][3];
 	double dv2 = gf_state_beam_line_ca->getCov()[4][4];
 
-	delete gf_state_beam_line_ca;
+	//delete gf_state_beam_line_ca;
 
 	//const SvtxTrack_v1* temp_track = static_cast<const SvtxTrack_v1*> (svtx_track);
 	SvtxTrack_v1* out_track = new SvtxTrack_v1(

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
@@ -224,10 +224,10 @@ private:
 	 * \param intrack Input SvtxTrack
 	 * \param invertex Input Vertex, if fit track as a primary vertex
 	 */
-	PHGenFit::Track* ReFitTrack(PHCompositeNode *, const SvtxTrack* intrack, const SvtxVertex* invertex = NULL);
+	std::shared_ptr<PHGenFit::Track> ReFitTrack(PHCompositeNode *, const SvtxTrack* intrack, const SvtxVertex* invertex = NULL);
 
 	//! Make SvtxTrack from PHGenFit::Track and SvtxTrack
-	SvtxTrack* MakeSvtxTrack(const SvtxTrack* svtxtrack, const PHGenFit::Track* genfit_track, const SvtxVertex * vertex = NULL);
+	SvtxTrack* MakeSvtxTrack(const SvtxTrack* svtxtrack, const std::shared_ptr<PHGenFit::Track>& genfit_track, const SvtxVertex * vertex = NULL);
 
 	//! Fill SvtxVertexMap from GFRaveVertexes and Tracks
 	bool FillSvtxVertexMap(

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
@@ -227,7 +227,7 @@ private:
 	std::shared_ptr<PHGenFit::Track> ReFitTrack(PHCompositeNode *, const SvtxTrack* intrack, const SvtxVertex* invertex = NULL);
 
 	//! Make SvtxTrack from PHGenFit::Track and SvtxTrack
-	SvtxTrack* MakeSvtxTrack(const SvtxTrack* svtxtrack, const std::shared_ptr<PHGenFit::Track>& genfit_track, const SvtxVertex * vertex = NULL);
+	std::shared_ptr<SvtxTrack> MakeSvtxTrack(const SvtxTrack* svtxtrack, const std::shared_ptr<PHGenFit::Track>& genfit_track, const SvtxVertex * vertex = NULL);
 
 	//! Fill SvtxVertexMap from GFRaveVertexes and Tracks
 	bool FillSvtxVertexMap(


### PR DESCRIPTION
Fix memory leaks related to PHGenFit and PHG4TrackKalmanFitter.

After this fixing, with DST output turned off, there will be no memory leaks in `PHG4TrackKalmanFitter::process_event`

valgrind log file for one full pp event refitting with DST output turned off; cppcheck log file for PHGenFit and g4hough could be find here:
https://www.phenix.bnl.gov/WWW/p/draft/yuhw/PullRequest/2017-02-27/0/

There are still some one time memory leaks related with TGeo and loading RAVE libraries. But as they are one time leaks, we should be fine for now.