### PR TITLE
proper use of vertex for z!=0 in PHG4TrackFastSim

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -200,6 +200,10 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 	vector<genfit::Track*> rf_gf_tracks;
 
 	PHG4VtxPoint *vtxPoint = _truth_container->GetPrimaryVtx(_truth_container->GetPrimaryVertexIndex());
+	// Smear the vertex ONCE for all particles in the event
+	vtxPoint->set_x(vtxPoint->get_x()+ gRandom->Gaus(0, _vertex_xy_resolution)); 
+	vtxPoint->set_y(vtxPoint->get_y()+ gRandom->Gaus(0, _vertex_xy_resolution)); 
+	vtxPoint->set_z(vtxPoint->get_z()+ gRandom->Gaus(0, _vertex_z_resolution)); 
 
 	PHG4TruthInfoContainer::ConstRange itr_range; 
 	if(_primary_tracking){
@@ -224,13 +228,14 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 	  //! Create measurements
 	  std::vector<PHGenFit::Measurement*> measurements;
 
-	  //		_use_vertex_in_fitting = true;
-
 	  PHGenFit::Measurement* vtx_meas = NULL;
 
 	  if (_use_vertex_in_fitting) {
-	    vtx_meas = VertexMeasurement(TVector3(vtxPoint->get_x(), vtxPoint->get_y(), vtxPoint->get_z()),
-					 _vertex_xy_resolution, _vertex_z_resolution);
+	    vtx_meas = VertexMeasurement(TVector3(vtxPoint->get_x(), 
+						  vtxPoint->get_y(), 
+						  vtxPoint->get_z()),
+					 _vertex_xy_resolution, 
+					 _vertex_z_resolution);
 	    measurements.push_back(vtx_meas);
 	  }
 
@@ -263,8 +268,8 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 	  //rep->setDebugLvl(1); //DEBUG
 
 	  //! Initiallize track with seed from pattern recognition
-	  PHGenFit::Track* track = new PHGenFit::Track(rep, seed_pos, seed_mom,
-						       seed_cov);
+ 
+	  PHGenFit::Track* track = new PHGenFit::Track(rep, seed_pos, seed_mom, seed_cov);
 
 	  rf_gf_tracks.push_back(track->getGenFitTrack());
 
@@ -285,9 +290,10 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 	    continue;
 	  }
 
+	  TVector3 vtx(vtxPoint->get_x(), vtxPoint->get_y(), vtxPoint->get_z()); 
 	  SvtxTrack* svtx_track_out = MakeSvtxTrack(track,
 						    particle->get_track_id(),
-						    measurements.size());
+						    measurements.size(), vtx);
 
 	  if(svtx_track_out) _trackmap_out->insert(svtx_track_out);
 
@@ -486,7 +492,8 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
 
 SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 					   const unsigned int truth_track_id, 
-					   const unsigned int nmeas) {
+					   const unsigned int nmeas,
+					   const TVector3 &vtx) {
 
 	double chi2 = phgf_track->get_chi2();
 	double ndf = phgf_track->get_ndf();
@@ -496,11 +503,11 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 	unique_ptr<genfit::MeasuredStateOnPlane> gf_state(new genfit::MeasuredStateOnPlane());
 
 	if (_detector_type == Vertical_Plane) {
-		pathlenth_orig_from_first_meas = phgf_track->extrapolateToPlane(*gf_state, TVector3(0., 0., 0.),
+		pathlenth_orig_from_first_meas = phgf_track->extrapolateToPlane(*gf_state, vtx,
 				TVector3(0., 0., 1.), 0);
 	}
 	else if (_detector_type == Cylinder)
-		pathlenth_orig_from_first_meas = phgf_track->extrapolateToLine(*gf_state, TVector3(0., 0., 0.),
+		pathlenth_orig_from_first_meas = phgf_track->extrapolateToLine(*gf_state, vtx,
 				TVector3(0., 0., 1.));
 	else {
 		LogError("Detector Type NOT implemented!");
@@ -515,8 +522,6 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 	TVector3 mom = gf_state->getMom();
 	TVector3 pos = gf_state->getPos();
 	TMatrixDSym cov = gf_state->get6DCov();
-//	SvtxTrack_v1* out_track = new SvtxTrack_v1(*static_cast<const SvtxTrack_v1*> (svtx_track));
-//	SvtxTrack_v1* out_track = new SvtxTrack_v1();
 
 	SvtxTrack_FastSim *out_track = new SvtxTrack_FastSim();
 	out_track->set_truth_track_id(truth_track_id);
@@ -666,8 +671,7 @@ PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementCylinder(
 	return meas;
 }
 
-PHGenFit::Measurement* PHG4TrackFastSim::VertexMeasurement(const TVector3 &vtx,
-		const double dxy, const double dz) {
+PHGenFit::Measurement* PHG4TrackFastSim::VertexMeasurement(const TVector3 &vtx, double dxy, double dz) {
 	PHGenFit::Measurement* meas = NULL;
 
 	TMatrixDSym cov(3);
@@ -677,12 +681,9 @@ PHGenFit::Measurement* PHG4TrackFastSim::VertexMeasurement(const TVector3 &vtx,
 	cov(2, 2) = dz * dz;
 
 	TVector3 pos = vtx;
-
-	double xy_smear = gRandom->Gaus(0, dxy);
-	double z_smear = gRandom->Gaus(0, dz);
-	pos.SetX(vtx.X() + xy_smear);
-	pos.SetY(vtx.Y() + xy_smear);
-	pos.SetZ(vtx.Z() + z_smear);
+	pos.SetX(vtx.X());
+	pos.SetY(vtx.Y());
+	pos.SetZ(vtx.Z());
 
 	meas = new PHGenFit::SpacepointMeasurement(pos, cov);
 

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -269,15 +269,14 @@ private:
 
 	PHGenFit::PlanarMeasurement* PHG4HitToMeasurementCylinder(const PHG4Hit* g4hit, const double phi_resolution, const double z_resolution);
 
-	PHGenFit::Measurement* VertexMeasurement(const TVector3 &vtx, const double dxy,
-			const double dz);
+	PHGenFit::Measurement* VertexMeasurement(const TVector3 &vtx, double dxy, double dz);
 
 	/*!
 	 * Make SvtxTrack from PHGenFit::Track
 	 */
 	SvtxTrack* MakeSvtxTrack(const PHGenFit::Track* phgf_track_in, 
 				 const unsigned int truth_track_id = UINT_MAX,
-				 const unsigned int nmeas = 0);
+				 const unsigned int nmeas = 0, const TVector3 &vtx = TVector3(0.0,0.0,0.0));
 
 	//! Event counter
 	int _event;


### PR DESCRIPTION
These changes allow for the vertex to be treated properly in the track fitting. The vertex is smeared *once* for a given even, and the projections have been modified so they are to the vertex and not (0,0,0) so that the DCA's are calculated correctly. 

Here's the 2D DCA as a function of vertex, not showing NO vertex dependence

![dca2d_vs_zvtx](https://cloud.githubusercontent.com/assets/3042746/23383445/06670910-fd0c-11e6-9177-df6aa61385f0.png)
