### PR TITLE
Truth Pattern Recognition for Tracking

### DIFF
--- a/simulation/g4simulation/g4hough/Makefile.am
+++ b/simulation/g4simulation/g4hough/Makefile.am
@@ -144,6 +144,7 @@ libg4hough_la_SOURCES = \
   PHG4TruthPatRec.C \
   PHG4TrackFastSim.C \
   PHG4TrackKalmanFitter_Dict.C \
+  PHG4TruthPatRec_Dict.C \
   PHG4TrackFastSim_Dict.C \
   PHG4SvtxMomentumRecal.C \
   PHG4SvtxMomentumRecal_Dict.C \

--- a/simulation/g4simulation/g4hough/Makefile.am
+++ b/simulation/g4simulation/g4hough/Makefile.am
@@ -69,6 +69,7 @@ pkginclude_HEADERS = \
   PHG4HoughTransformTPC.h \
   PHG4TrackGhostRejection.h \
   PHG4TrackKalmanFitter.h \
+  PHG4TruthPatRec.h \
   PHG4TrackFastSim.h \
   PHG4SvtxMomentumRecal.h \
   PHG4SvtxTrackProjection.h \
@@ -140,6 +141,7 @@ libg4hough_la_SOURCES = \
   PHG4TrackGhostRejection.C \
   PHG4TrackGhostRejection_Dict.C \
   PHG4TrackKalmanFitter.C \
+  PHG4TruthPatRec.C \
   PHG4TrackFastSim.C \
   PHG4TrackKalmanFitter_Dict.C \
   PHG4TrackFastSim_Dict.C \

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
@@ -489,10 +489,11 @@ void PHG4TrackKalmanFitter::fill_eval_tree(PHCompositeNode *topNode) {
 				*dynamic_cast<SvtxTrack_v1*>(itr->second));
 
 	i = 0;
-	for (SvtxVertexMap::ConstIter itr = _vertexmap->begin();
-			itr != _vertexmap->end(); ++itr)
-		new ((*_tca_vertexmap)[i++]) (SvtxVertex_v1)(
-				*dynamic_cast<SvtxVertex_v1*>(itr->second));
+	if (_vertexmap)
+		for (SvtxVertexMap::ConstIter itr = _vertexmap->begin();
+				itr != _vertexmap->end(); ++itr)
+			new ((*_tca_vertexmap)[i++]) (SvtxVertex_v1)(
+					*dynamic_cast<SvtxVertex_v1*>(itr->second));
 
 	if (_trackmap_refit) {
 		i = 0;
@@ -674,10 +675,10 @@ int PHG4TrackKalmanFitter::GetNodes(PHCompositeNode * topNode) {
 
 	// Input Svtx Vertices
 	_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
-	if (!_vertexmap && _event < 2) {
-		cout << PHWHERE << " SvtxVertexrMap node not found on node tree"
+	if (!_vertexmap && _event < 2 && verbosity >= 1) {
+		cout << PHWHERE << " SvtxVertexrMap node not found on node tree, NOT critical"
 				<< endl;
-		return Fun4AllReturnCodes::ABORTEVENT;
+		//return Fun4AllReturnCodes::ABORTEVENT;
 	}
 
 	// Output Svtx Tracks

--- a/simulation/g4simulation/g4hough/PHG4TruthPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4TruthPatRec.C
@@ -1,0 +1,69 @@
+/*!
+ *  \file		PHG4TruthPatRec.C
+ *  \brief		Truth Pattern Recognition
+ *  \details	Using generate, GEANT level information to mimic ideal pattern recognition
+ *  \author		Haiwang Yu <yuhw@nmsu.edu>
+ */
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/PHTFileServer.h>
+#include <g4detectors/PHG4CylinderCellContainer.h>
+#include <g4detectors/PHG4CylinderGeomContainer.h>
+#include <g4detectors/PHG4CylinderCell_MAPS.h>
+#include <g4detectors/PHG4CylinderGeom_MAPS.h>
+#include <g4detectors/PHG4CylinderGeom_Siladders.h>
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4Particlev2.h>
+#include <g4main/PHG4VtxPointv1.h>
+#include <GenFit/FieldManager.h>
+#include <GenFit/GFRaveVertex.h>
+#include <GenFit/GFRaveVertexFactory.h>
+#include <GenFit/MeasuredStateOnPlane.h>
+#include <GenFit/RKTrackRep.h>
+#include <GenFit/StateOnPlane.h>
+#include <GenFit/Track.h>
+#include <phgenfit/Fitter.h>
+#include <phgenfit/PlanarMeasurement.h>
+#include <phgenfit/SpacepointMeasurement.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phgeom/PHGeomUtility.h>
+#include <iostream>
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "TClonesArray.h"
+#include "TMatrixDSym.h"
+#include "TTree.h"
+#include "TVector3.h"
+#include "TRandom3.h"
+#include "TRotation.h"
+
+#include "SvtxCluster.h"
+#include "SvtxClusterMap.h"
+#include "SvtxTrackState_v1.h"
+#include "SvtxHit_v1.h"
+#include "SvtxHitMap.h"
+#include "SvtxTrack.h"
+#include "SvtxTrack_v1.h"
+#include "SvtxVertex_v1.h"
+#include "SvtxTrackMap.h"
+#include "SvtxTrackMap_v1.h"
+#include "SvtxVertexMap_v1.h"
+#include "PHG4TruthPatRec.h"
+
+#define LogDebug(exp)		std::cout<<"DEBUG: "  <<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
+#define LogError(exp)		std::cout<<"ERROR: "  <<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
+#define LogWarning(exp)	std::cout<<"WARNING: "<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
+
+#define WILD_FLOAT -9999.
+
+using namespace std;
+

--- a/simulation/g4simulation/g4hough/PHG4TruthPatRec.h
+++ b/simulation/g4simulation/g4hough/PHG4TruthPatRec.h
@@ -56,21 +56,21 @@ public:
 		verbosity = verb; // SubsysReco verbosity
 	}
 
-	bool is_use_ladder_intt() const {
-		return _use_ladder_intt;
-	}
-
-	void set_use_ladder_intt(bool useLadderIntt) {
-		_use_ladder_intt = useLadderIntt;
-	}
-
-	bool is_use_ladder_maps() const {
-		return _use_ladder_maps;
-	}
-
-	void set_use_ladder_maps(bool useLadderMaps) {
-		_use_ladder_maps = useLadderMaps;
-	}
+//	bool is_use_ladder_intt() const {
+//		return _use_ladder_intt;
+//	}
+//
+//	void set_use_ladder_intt(bool useLadderIntt) {
+//		_use_ladder_intt = useLadderIntt;
+//	}
+//
+//	bool is_use_ladder_maps() const {
+//		return _use_ladder_maps;
+//	}
+//
+//	void set_use_ladder_maps(bool useLadderMaps) {
+//		_use_ladder_maps = useLadderMaps;
+//	}
 
 //
 //	DetectorType get_detector_type() const {
@@ -89,8 +89,8 @@ private:
 	//!Detector Type
 //	DetectorType _detector_type;
 
-	bool _use_ladder_maps;
-	bool _use_ladder_intt;
+//	bool _use_ladder_maps;
+//	bool _use_ladder_intt;
 
 
 	//! Get all the nodes

--- a/simulation/g4simulation/g4hough/PHG4TruthPatRec.h
+++ b/simulation/g4simulation/g4hough/PHG4TruthPatRec.h
@@ -1,0 +1,77 @@
+/*!
+ *  \file		PHG4TruthPatRec.h
+ *  \brief		Truth Pattern Recognition
+ *  \details	Using generate, GEANT level information to mimic ideal pattern recognition
+ *  \author		Haiwang Yu <yuhw@nmsu.edu>
+ */
+
+#ifndef __PHG4TruthPatRec_H__
+#define __PHG4TruthPatRec_H__
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+#include <vector>
+
+
+class SvtxTrack;
+
+class SvtxTrackMap;
+class SvtxVertexMap;
+class SvtxVertex;
+class PHCompositeNode;
+class PHG4TruthInfoContainer;
+class SvtxClusterMap;
+class SvtxEvalStack;
+class TFile;
+class TTree;
+
+
+//! \brief		Refit SvtxTracks with PHGenFit.
+class PHG4TruthPatRec: public SubsysReco {
+public:
+
+	//! Default constructor
+	PHG4TruthPatRec(const std::string &name = "PHG4TruthPatRec");
+
+	//! dtor
+	~PHG4TruthPatRec();
+
+	//!Initialization, called for initialization
+	int Init(PHCompositeNode *);
+
+	//!Initialization Run, called for initialization of a run
+	int InitRun(PHCompositeNode *);
+
+	//!Process Event, called for each event
+	int process_event(PHCompositeNode *);
+
+	//!End, write and close files
+	int End(PHCompositeNode *);
+
+	/// set verbosity
+	void Verbosity(int verb) {
+		verbosity = verb; // SubsysReco verbosity
+	}
+
+
+private:
+
+	//! Event counter
+	int _event;
+
+	//! Get all the nodes
+	int GetNodes(PHCompositeNode *);
+
+	//!Create New nodes
+	int CreateNodes(PHCompositeNode *);
+
+	//! Input Node pointers
+	PHG4TruthInfoContainer* _truth_container;
+	SvtxClusterMap* _clustermap;
+
+	//! Output Node poniters
+	SvtxTrackMap* _trackmap;
+};
+
+#endif //* __PHG4TruthPatRec_H__ *//

--- a/simulation/g4simulation/g4hough/PHG4TruthPatRec.h
+++ b/simulation/g4simulation/g4hough/PHG4TruthPatRec.h
@@ -31,6 +31,8 @@ class TTree;
 class PHG4TruthPatRec: public SubsysReco {
 public:
 
+//	enum DetectorType {MIE, MAPS_TPC, MAPS_IT_TPC, LADDER_MAPS_TPC, LADDER_MAPS_IT_TPC, LADDER_MAPS_LADDER_IT_TPC, MAPS_LADDER_IT_TPC};
+
 	//! Default constructor
 	PHG4TruthPatRec(const std::string &name = "PHG4TruthPatRec");
 
@@ -54,11 +56,42 @@ public:
 		verbosity = verb; // SubsysReco verbosity
 	}
 
+	bool is_use_ladder_intt() const {
+		return _use_ladder_intt;
+	}
+
+	void set_use_ladder_intt(bool useLadderIntt) {
+		_use_ladder_intt = useLadderIntt;
+	}
+
+	bool is_use_ladder_maps() const {
+		return _use_ladder_maps;
+	}
+
+	void set_use_ladder_maps(bool useLadderMaps) {
+		_use_ladder_maps = useLadderMaps;
+	}
+
+//
+//	DetectorType get_detector_type() const {
+//		return _detector_type;
+//	}
+//
+//	void set_detector_type(DetectorType detectorType) {
+//		_detector_type = detectorType;
+//	}
 
 private:
 
 	//! Event counter
 	int _event;
+
+	//!Detector Type
+//	DetectorType _detector_type;
+
+	bool _use_ladder_maps;
+	bool _use_ladder_intt;
+
 
 	//! Get all the nodes
 	int GetNodes(PHCompositeNode *topNode);

--- a/simulation/g4simulation/g4hough/PHG4TruthPatRec.h
+++ b/simulation/g4simulation/g4hough/PHG4TruthPatRec.h
@@ -27,7 +27,7 @@ class TFile;
 class TTree;
 
 
-//! \brief		Refit SvtxTracks with PHGenFit.
+//! \brief		Truth Pattern Recognition.
 class PHG4TruthPatRec: public SubsysReco {
 public:
 
@@ -38,16 +38,16 @@ public:
 	~PHG4TruthPatRec();
 
 	//!Initialization, called for initialization
-	int Init(PHCompositeNode *);
+	int Init(PHCompositeNode *topNode);
 
 	//!Initialization Run, called for initialization of a run
-	int InitRun(PHCompositeNode *);
+	int InitRun(PHCompositeNode *topNode);
 
 	//!Process Event, called for each event
-	int process_event(PHCompositeNode *);
+	int process_event(PHCompositeNode *topNode);
 
 	//!End, write and close files
-	int End(PHCompositeNode *);
+	int End(PHCompositeNode *topNode);
 
 	/// set verbosity
 	void Verbosity(int verb) {
@@ -61,10 +61,12 @@ private:
 	int _event;
 
 	//! Get all the nodes
-	int GetNodes(PHCompositeNode *);
+	int GetNodes(PHCompositeNode *topNode);
 
 	//!Create New nodes
-	int CreateNodes(PHCompositeNode *);
+	int CreateNodes(PHCompositeNode *topNode);
+
+	unsigned int _min_clusters_per_track;
 
 	//! Input Node pointers
 	PHG4TruthInfoContainer* _truth_container;

--- a/simulation/g4simulation/g4hough/PHG4TruthPatRecLinkDef.h
+++ b/simulation/g4simulation/g4hough/PHG4TruthPatRecLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4TruthPatRec-!;
+
+#endif


### PR DESCRIPTION
Tracking pattern recognition by grouping clusters associated with a truth `PHG4Particle`.
Introduction:
[2017-02-28 talk](https://indico.bnl.gov/getFile.py/access?contribId=1&resId=0&materialId=slides&confId=2682)
[2017-03-07 talk](https://indico.bnl.gov/conferenceDisplay.py?confId=2683)

Example macro:
[line 376, 377 of G4_Svtx_maps_ladders+intt_ladders+tpc_TruthPatRec.C ](https://github.com/HaiwangYu/macros/blob/TruthPatRec/macros/g4simulations/G4_Svtx_maps_ladders%2Bintt_ladders%2Btpc_TruthPatRec.C#L376)
As this module only do the pattern recognition, a kalman filter is needed to fit the track.