### PR TITLE
bug fixed on the INTT ladder z position; segment_z_bin<=1 means negat…

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
@@ -51,13 +51,14 @@ bool PHG4CylinderGeom_Siladders::load_geometry()
 
 void PHG4CylinderGeom_Siladders::find_segment_center(const int segment_z_bin, const int segment_phi_bin, double location[])
 {
-  const int itype = (segment_z_bin==1 || segment_z_bin==2) ? 0 : 1;
+  const int itype    = (segment_z_bin==1 || segment_z_bin==2) ? 0 : 1;
+  const double signz = (segment_z_bin<=1) ? -1. : 1.;
 
   // Ladder
   const double phi  = offsetphi + dphi_ * (double)segment_phi_bin;
   location[0] = eff_radius  * cos(phi);
   location[1] = eff_radius  * sin(phi);
-  location[2] = ladder_z_[itype] ;
+  location[2] = signz * ladder_z_[itype];
 }
 
 void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[])


### PR DESCRIPTION
…ive rapidity, thus the |z| must be multiplied by signz=-1.
I forgot to commit this code yesterday.