### PR TITLE
okay - put the old PHG4SvtxThresholds back

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
@@ -10,6 +10,8 @@
 
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4detectors/PHG4CylinderGeom.h>
+#include <g4detectors/PHG4CylinderCellContainer.h>
+#include <g4detectors/PHG4CylinderCell.h>
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
 #include <g4detectors/PHG4CylinderCellGeom.h>
 
@@ -22,7 +24,7 @@ PHG4SvtxThresholds::PHG4SvtxThresholds(const string &name) :
   _fraction_of_mip(),
   _thresholds_by_layer(),
   _use_thickness_mip(),
-  _hits(nullptr),
+  _hits(NULL),
   _timer(PHTimeServer::get()->insert_new(name)) {
 }
 
@@ -35,9 +37,9 @@ int PHG4SvtxThresholds::InitRun(PHCompositeNode* topNode) {
     return Fun4AllReturnCodes::ABORTRUN;
   }
   
-  CalculateGenericThresholds(topNode,"MAPS");
-  CalculateGenericThresholds(topNode,"SVTX");
-  CalculateGenericThresholds(topNode,"SILICON_TRACKER");
+  CalculateCylinderThresholds(topNode);
+  CalculateLadderThresholds(topNode);
+  CalculateMapsLadderThresholds(topNode);
 
   if (verbosity > 0) {
     cout << "====================== PHG4SvtxThresholds::InitRun() ======================" << endl;
@@ -93,14 +95,103 @@ int PHG4SvtxThresholds::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+int PHG4SvtxThresholds::End(PHCompositeNode* topNode) {
 
-void 
-PHG4SvtxThresholds::CalculateGenericThresholds(PHCompositeNode* topNode, const string &detector) 
-{
-  string nodename = "CYLINDERGEOM_" + detector;
-  PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,nodename);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
 
-  if (!geom_container) return;
+void PHG4SvtxThresholds::CalculateCylinderThresholds(PHCompositeNode* topNode) {
+
+  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SVTX");
+  PHG4CylinderCellGeomContainer *geom_container = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode,"CYLINDERCELLGEOM_SVTX");
+    
+  if (!geom_container || !cells) return;
+  
+  PHG4CylinderCellGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
+  for(PHG4CylinderCellGeomContainer::ConstIterator layeriter = layerrange.first;
+      layeriter != layerrange.second;
+      ++layeriter) {
+    
+    int layer = layeriter->second->get_layer();
+    float thickness = (layeriter->second)->get_thickness();
+    float pitch = (layeriter->second)->get_phistep()*(layeriter->second)->get_radius();
+    float length = (layeriter->second)->get_zstep();
+
+    if (get_use_thickness_mip(layer)) {
+      // Si MIP energy = 3.876 MeV / cm
+      float threshold = 0.0;      
+      if (_fraction_of_mip.find(layer) != _fraction_of_mip.end()) {	
+	threshold = _fraction_of_mip[layer]*0.003876*thickness;
+	if(verbosity >2) 
+	  cout << " using thickness: threshold = " << threshold << " thickness = " << thickness << " fraction of mip = " << _fraction_of_mip[layer] << " layer " << layer << endl;
+      }	  
+      _thresholds_by_layer.insert(std::make_pair(layer,threshold));
+    } else {
+      float minpath = pitch;
+      if (length < minpath) minpath = length;
+      if (thickness < minpath) minpath = thickness;
+	
+      // Si MIP energy = 3.876 MeV / cm
+      float threshold = 0.0;      
+      if (_fraction_of_mip.find(layer) != _fraction_of_mip.end()) {	
+	threshold = _fraction_of_mip[layer]*0.003876*minpath;  
+      }	      
+      _thresholds_by_layer.insert(std::make_pair(layer,threshold));
+      if(verbosity >2) 
+	cout << " not using thickness: threshold = " << threshold << " thickness = " << thickness << " fraction of mip = " << _fraction_of_mip[layer] << " layer " << layer << endl;
+    }
+  }
+  
+  return;
+}
+
+void PHG4SvtxThresholds::CalculateLadderThresholds(PHCompositeNode* topNode) {
+
+  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SILICON_TRACKER");
+  PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_SILICON_TRACKER");
+
+  if (!geom_container || !cells) return;
+  
+  PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
+  for(PHG4CylinderGeomContainer::ConstIterator layeriter = layerrange.first;
+      layeriter != layerrange.second;
+      ++layeriter) {
+
+    int layer = layeriter->second->get_layer();
+    float thickness = (layeriter->second)->get_thickness();
+    float pitch = (layeriter->second)->get_strip_y_spacing();
+    float length = (layeriter->second)->get_strip_z_spacing();
+
+    if (get_use_thickness_mip(layer)) {
+      // Si MIP energy = 3.876 MeV / cm
+      float threshold = 0.0;
+      if (_fraction_of_mip.find(layer) != _fraction_of_mip.end()) {
+	threshold = _fraction_of_mip[layer]*0.003876*thickness;
+      }
+      _thresholds_by_layer.insert(std::make_pair(layer,threshold));
+    } else {
+      float minpath = pitch;
+      if (length < minpath) minpath = length;
+      if (thickness < minpath) minpath = thickness;
+      
+      // Si MIP energy = 3.876 MeV / cm
+      float threshold = 0.0;
+      if (_fraction_of_mip.find(layer) != _fraction_of_mip.end()) {
+	threshold = _fraction_of_mip[layer]*0.003876*minpath;
+      }
+      _thresholds_by_layer.insert(std::make_pair(layer,threshold));
+    }
+  }
+  
+  return;
+}
+
+void PHG4SvtxThresholds::CalculateMapsLadderThresholds(PHCompositeNode* topNode) {
+
+  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_MAPS");
+  PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_MAPS");
+
+  if (!geom_container || !cells) return;
   
   PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
   for(PHG4CylinderGeomContainer::ConstIterator layeriter = layerrange.first;

--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
@@ -10,8 +10,6 @@
 
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4detectors/PHG4CylinderGeom.h>
-#include <g4detectors/PHG4CylinderCellContainer.h>
-#include <g4detectors/PHG4CylinderCell.h>
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
 #include <g4detectors/PHG4CylinderCellGeom.h>
 
@@ -102,10 +100,9 @@ int PHG4SvtxThresholds::End(PHCompositeNode* topNode) {
 
 void PHG4SvtxThresholds::CalculateCylinderThresholds(PHCompositeNode* topNode) {
 
-  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SVTX");
   PHG4CylinderCellGeomContainer *geom_container = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode,"CYLINDERCELLGEOM_SVTX");
     
-  if (!geom_container || !cells) return;
+  if (!geom_container) return;
   
   PHG4CylinderCellGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
   for(PHG4CylinderCellGeomContainer::ConstIterator layeriter = layerrange.first;
@@ -147,10 +144,9 @@ void PHG4SvtxThresholds::CalculateCylinderThresholds(PHCompositeNode* topNode) {
 
 void PHG4SvtxThresholds::CalculateLadderThresholds(PHCompositeNode* topNode) {
 
-  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_SILICON_TRACKER");
   PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_SILICON_TRACKER");
 
-  if (!geom_container || !cells) return;
+  if (!geom_container) return;
   
   PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
   for(PHG4CylinderGeomContainer::ConstIterator layeriter = layerrange.first;
@@ -188,10 +184,9 @@ void PHG4SvtxThresholds::CalculateLadderThresholds(PHCompositeNode* topNode) {
 
 void PHG4SvtxThresholds::CalculateMapsLadderThresholds(PHCompositeNode* topNode) {
 
-  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode,"G4CELL_MAPS");
   PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_MAPS");
 
-  if (!geom_container || !cells) return;
+  if (!geom_container) return;
   
   PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
   for(PHG4CylinderGeomContainer::ConstIterator layeriter = layerrange.first;

--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.h
@@ -1,12 +1,11 @@
-#ifndef PHG4SVTXTHRESHOLDS__H
-#define PHG4SVTXTHRESHOLDS__H
-
-
-#include <fun4all/SubsysReco.h>
-#include <phool/PHTimeServer.h>
+#ifndef __PHG4SVTXTHRESHOLDS__
+#define __PHG4SVTXTHRESHOLDS__
 
 #include <map>
 #include <iostream>
+
+#include <fun4all/SubsysReco.h>
+#include <phool/PHTimeServer.h>
 
 class SvtxHitMap;
 
@@ -18,12 +17,18 @@ class PHG4SvtxThresholds : public SubsysReco
 
   virtual ~PHG4SvtxThresholds(){}
   
+  //! module initialization
+  int Init(PHCompositeNode *topNode){return 0;}
+  
   //! run initialization
   int InitRun(PHCompositeNode *topNode);
   
     //! event processing
   int process_event(PHCompositeNode *topNode);
   
+  //! end of process
+  int End(PHCompositeNode *topNode);
+
   void set_threshold(const float fraction_of_mip) {
     std::cout << "PHG4SvtxThresholds use is out of date. "
 	      << "Continuing with assumption of tracker with <9 layers. "
@@ -60,7 +65,9 @@ class PHG4SvtxThresholds : public SubsysReco
 
  private:
 
-  void CalculateGenericThresholds(PHCompositeNode *topNode, const std::string &detector);
+  void CalculateCylinderThresholds(PHCompositeNode *topNode);
+  void CalculateLadderThresholds(PHCompositeNode *topNode);
+  void CalculateMapsLadderThresholds(PHCompositeNode *topNode);
 
   // settings
   std::map<int,float> _fraction_of_mip;


### PR DESCRIPTION
this code will bite us again, it loops over the cylindergeom container for one detector, over cylindercellgeoms in others, extracting pitch,length,thickness via different methods but then calling the same cut and pasted code