### PR TITLE
Make refitting an official option

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
@@ -690,6 +690,13 @@ int PHG4TrackKalmanFitter::CreateNodes(PHCompositeNode *topNode) {
 		tb_node->addNode(vertexes_node);
 		if (verbosity > 0)
 			cout << "Svtx/SvtxVertexMapRefit node added" << endl;
+	} else if (!findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap")) {
+		_vertexmap = new SvtxVertexMap_v1;
+		PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(
+				_vertexmap, "SvtxVertexMap", "PHObject");
+		tb_node->addNode(vertexes_node);
+		if (verbosity > 0)
+			cout << "Svtx/SvtxVertexMap node added" << endl;
 	}
 
 	return Fun4AllReturnCodes::EVENT_OK;
@@ -728,10 +735,10 @@ int PHG4TrackKalmanFitter::GetNodes(PHCompositeNode * topNode) {
 
 	// Input Svtx Vertices
 	_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
-	if (!_vertexmap && _event < 2 && verbosity >= 1) {
-		cout << PHWHERE << " SvtxVertexrMap node not found on node tree, NOT critical"
+	if (!_vertexmap && _event < 2) {
+		cout << PHWHERE << " SvtxVertexrMap node not found on node tree"
 				<< endl;
-		//return Fun4AllReturnCodes::ABORTEVENT;
+		return Fun4AllReturnCodes::ABORTEVENT;
 	}
 
 	// Output Svtx Tracks

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
@@ -187,14 +187,6 @@ public:
 		_primary_pid_guess = primaryPidGuess;
 	}
 
-	DetectorType get_detector_type() const {
-		return _detector_type;
-	}
-
-	void set_detector_type(DetectorType detectorType) {
-		_detector_type = detectorType;
-	}
-
 	double get_cut_min_p_T() const {
 		return _cut_min_pT;
 	}
@@ -278,9 +270,6 @@ private:
 
 	//!flags
 	unsigned int _flags;
-
-	//!Detector Type
-	DetectorType _detector_type;
 
 	//bool _make_separate_nodes;
 	OutPutMode _output_mode;

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
@@ -203,6 +203,22 @@ public:
 		_cut_min_pT = cutMinPT;
 	}
 
+	bool is_over_write_svtxtrackmap() const {
+		return _over_write_svtxtrackmap;
+	}
+
+	void set_over_write_svtxtrackmap(bool overWriteSvtxtrackmap) {
+		_over_write_svtxtrackmap = overWriteSvtxtrackmap;
+	}
+
+	bool is_over_write_svtxvertexmap() const {
+		return _over_write_svtxvertexmap;
+	}
+
+	void set_over_write_svtxvertexmap(bool overWriteSvtxvertexmap) {
+		_over_write_svtxvertexmap = overWriteSvtxvertexmap;
+	}
+
 private:
 
 	//! Event counter
@@ -268,6 +284,9 @@ private:
 
 	//bool _make_separate_nodes;
 	OutPutMode _output_mode;
+
+	bool _over_write_svtxtrackmap;
+	bool _over_write_svtxvertexmap;
 
 	bool _fit_primary_tracks;
 

--- a/simulation/g4simulation/g4hough/PHG4TruthPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4TruthPatRec.C
@@ -62,12 +62,15 @@ int PHG4TruthPatRec::process_event(PHCompositeNode* topNode) {
 	PHG4HitContainer* phg4hits_svtx = findNode::getClass<PHG4HitContainer>(
 			topNode, "G4HIT_SVTX");
 
+	PHG4HitContainer* phg4hits_intt = findNode::getClass<PHG4HitContainer>(
+			topNode, "G4HIT_SILICON_TRACKER");
+
 	PHG4HitContainer* phg4hits_maps = findNode::getClass<PHG4HitContainer>(
 			topNode, "G4HIT_MAPS");
 
-	if (!phg4hits_svtx and !phg4hits_maps) {
+	if (!phg4hits_svtx and phg4hits_intt and !phg4hits_maps) {
 		if (verbosity >= 0) {
-			LogError("!phg4hits_svtx and !phg4hits_maps");
+			LogError("No PHG4HitContainer found!");
 		}
 		return Fun4AllReturnCodes::ABORTRUN;
 	}
@@ -80,15 +83,18 @@ int PHG4TruthPatRec::process_event(PHCompositeNode* topNode) {
 		return Fun4AllReturnCodes::ABORTRUN;
 	}
 
-	PHG4CellContainer* cells_svtx = findNode::getClass<
-			PHG4CellContainer>(topNode, "G4CELL_SVTX");
+	PHG4CellContainer* cells_svtx = findNode::getClass<PHG4CellContainer>(
+			topNode, "G4CELL_SVTX");
 
-	PHG4CellContainer* cells_maps = findNode::getClass<
-			PHG4CellContainer>(topNode, "G4CELL_MAPS");
+	PHG4CellContainer* cells_intt = findNode::getClass<PHG4CellContainer>(
+			topNode, "G4CELL_SILICON_TRACKER");
 
-	if (!cells_svtx and !cells_maps) {
+	PHG4CellContainer* cells_maps = findNode::getClass<PHG4CellContainer>(
+			topNode, "G4CELL_MAPS");
+
+	if (!cells_svtx and !cells_intt and !cells_maps) {
 		if (verbosity >= 0) {
-			LogError("!cells_svtx and !cells_maps");
+			LogError("No PHG4CellContainer found!");
 		}
 		return Fun4AllReturnCodes::ABORTRUN;
 	}
@@ -103,6 +109,7 @@ int PHG4TruthPatRec::process_event(PHCompositeNode* topNode) {
 		PHG4Cell* cell = nullptr;
 
 		if(!cell and cells_svtx) cell = cells_svtx->findCell(svtxhit->get_cellid());
+		if(!cell and cells_intt) cell = cells_intt->findCell(svtxhit->get_cellid());
 		if(!cell and cells_maps) cell = cells_maps->findCell(svtxhit->get_cellid());
 
 		if(!cell){
@@ -119,6 +126,7 @@ int PHG4TruthPatRec::process_event(PHCompositeNode* topNode) {
 
 			PHG4Hit *phg4hit = nullptr;
 			if(!phg4hit and phg4hits_svtx) phg4hit = phg4hits_svtx->findHit(hits_it->first);
+			if(!phg4hit and phg4hits_intt) phg4hit = phg4hits_intt->findHit(hits_it->first);
 			if(!phg4hit and phg4hits_maps) phg4hit = phg4hits_maps->findHit(hits_it->first);
 
 			if(!phg4hit){

--- a/simulation/g4simulation/g4hough/PHG4TruthPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4TruthPatRec.C
@@ -103,7 +103,7 @@ int PHG4TruthPatRec::process_event(PHCompositeNode* topNode) {
 	TrkClustersMap m_trackID_clusters;
 
 	for (SvtxClusterMap::ConstIter cluster_itr = _clustermap->begin();
-			cluster_itr != _clustermap->end(); cluster_itr++) {
+			cluster_itr != _clustermap->end(); ++cluster_itr) {
 		SvtxCluster *cluster = cluster_itr->second;
 		SvtxHit* svtxhit = hitsmap->find(*cluster->begin_hits())->second;
 		PHG4Cell* cell = nullptr;
@@ -153,7 +153,7 @@ int PHG4TruthPatRec::process_event(PHCompositeNode* topNode) {
 	}
 
 	for (TrkClustersMap::const_iterator trk_clusers_itr = m_trackID_clusters.begin();
-			trk_clusers_itr!=m_trackID_clusters.end(); trk_clusers_itr++) {
+			trk_clusers_itr!=m_trackID_clusters.end(); ++trk_clusers_itr) {
 		if(trk_clusers_itr->second.size() > _min_clusters_per_track) {
 			std::unique_ptr<SvtxTrack_FastSim> svtx_track(new SvtxTrack_FastSim());
 			//SvtxTrack_FastSim* svtx_track = new SvtxTrack_FastSim();

--- a/simulation/g4simulation/g4hough/PHG4TruthPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4TruthPatRec.C
@@ -32,11 +32,9 @@
 #include <set>
 
 
-#define LogDebug(exp)		std::cout<<"DEBUG: "  <<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
-#define LogError(exp)		std::cout<<"ERROR: "  <<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
-#define LogWarning(exp)	std::cout<<"WARNING: "<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
-
-#define WILD_FLOAT -9999.
+#define LogDebug(exp)		std::cout<<"DEBUG: "  <<__FILE__<<": "<<__LINE__<<": "<< exp <<std::endl
+#define LogError(exp)		std::cout<<"ERROR: "  <<__FILE__<<": "<<__LINE__<<": "<< exp <<std::endl
+#define LogWarning(exp)	std::cout<<"WARNING: "<<__FILE__<<": "<<__LINE__<<": "<< exp <<std::endl
 
 using namespace std;
 

--- a/simulation/g4simulation/g4hough/SvtxTrackState.h
+++ b/simulation/g4simulation/g4hough/SvtxTrackState.h
@@ -50,7 +50,7 @@ public:
   virtual void  set_error(unsigned int i, unsigned int j, float value) {}
 
   virtual std::string get_name(){return "";}
-  virtual void set_name(std::string name){}
+  virtual void set_name(std::string &name){}
 
 protected:
   SvtxTrackState(float pathlength = 0.0) {}

--- a/simulation/g4simulation/g4hough/SvtxTrackState_v1.h
+++ b/simulation/g4simulation/g4hough/SvtxTrackState_v1.h
@@ -56,7 +56,7 @@ public:
   void  set_error(unsigned int i, unsigned int j, float value);
 
   std::string get_name(){return state_name;}
-  void set_name(std::string name){state_name = name;}
+  void set_name(std::string &name){state_name = name;}
   
 private:
 


### PR DESCRIPTION
Updated both GenFit( [`PHG4TrackKalmanFitter `](https://github.com/HaiwangYu/coresoftware/blob/master/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C) ) and ideal pattern recognition ( [`PHG4TruthPatRec `](https://github.com/HaiwangYu/coresoftware/blob/master/simulation/g4simulation/g4hough/PHG4TruthPatRec.C) )modules.

Basically made them more automatic and woking with different Fun4All steering macro options.
Also some bugs were fixed for the ideal pattern recognition module.

I also made some example macros:
https://github.com/HaiwangYu/macros/tree/MakeRefitFormal

Now there are two easy-to-use switches:
 - [use_truth_pat_rec](https://github.com/HaiwangYu/macros/blob/MakeRefitFormal/macros/g4simulations/Fun4All_single_particle.C#L50) : use ideal pattern recgnition instead of Hough transformation, in this case, [`PHG4TrackKalmanFitter `](https://github.com/HaiwangYu/coresoftware/blob/master/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C) will be also called for track fitting and vertexing.
 - [do_refit](https://github.com/HaiwangYu/macros/blob/MakeRefitFormal/macros/g4simulations/Fun4All_single_particle.C#L51) do refitting using [`PHG4TrackKalmanFitter `](https://github.com/HaiwangYu/coresoftware/blob/master/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C)

An event display for ladder tracker looks like this:
![image](https://cloud.githubusercontent.com/assets/10383186/24522957/57810a6a-155f-11e7-9fb1-a5a28229d156.png)
