### PR TITLE
add at rest condition to saving hits

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,90 @@
+---
+Language:        Cpp
+# BasedOnStyle:  sphenix
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -23,11 +23,10 @@
 using namespace std;
 
 //_______________________________________________________________
-//note this inactive thickness is ~1.5% of a radiation length
 PHG4CylinderDetector::PHG4CylinderDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam, const int lyr ): 
   PHG4Detector(Node,dnam),
   params(parameters),
-  cylinder_physi(NULL),
+  cylinder_physi(nullptr),
   layer(lyr)
 {}
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -11,8 +11,8 @@
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
-#include <Geant4/G4PhysicalConstants.hh>
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4PhysicalConstants.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4VisAttributes.hh>
@@ -23,65 +23,64 @@
 using namespace std;
 
 //_______________________________________________________________
-PHG4CylinderDetector::PHG4CylinderDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam, const int lyr ): 
-  PHG4Detector(Node,dnam),
-  params(parameters),
-  cylinder_physi(nullptr),
-  layer(lyr)
-{}
+PHG4CylinderDetector::PHG4CylinderDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam, const int lyr) : PHG4Detector(Node, dnam),
+                                                                                                                                        params(parameters),
+                                                                                                                                        cylinder_physi(nullptr),
+                                                                                                                                        layer(lyr)
+{
+}
 
 //_______________________________________________________________
-bool PHG4CylinderDetector::IsInCylinder(const G4VPhysicalVolume * volume) const
+bool PHG4CylinderDetector::IsInCylinder(const G4VPhysicalVolume *volume) const
 {
   if (volume == cylinder_physi)
-    {
-      return true;
-    }
+  {
+    return true;
+  }
   return false;
 }
 
-
 //_______________________________________________________________
-void PHG4CylinderDetector::Construct( G4LogicalVolume* logicWorld )
+void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
 {
   G4Material *TrackerMaterial = G4Material::GetMaterial(params->get_string_param("material"));
 
-  if ( ! TrackerMaterial)
-    {
-      std::cout << "Error: Can not set material" << std::endl;
-      exit(-1);
-    }
+  if (!TrackerMaterial)
+  {
+    std::cout << "Error: Can not set material" << std::endl;
+    exit(-1);
+  }
 
-  G4VisAttributes* siliconVis= new G4VisAttributes();
+  G4VisAttributes *siliconVis = new G4VisAttributes();
   if (params->get_int_param("blackhole"))
-    {
-      PHG4Utils::SetColour(siliconVis, "BlackHole");
-      siliconVis->SetVisibility(false);
-      siliconVis->SetForceSolid(false);
-    }
+  {
+    PHG4Utils::SetColour(siliconVis, "BlackHole");
+    siliconVis->SetVisibility(false);
+    siliconVis->SetForceSolid(false);
+  }
   else
-    {
-      PHG4Utils::SetColour(siliconVis, params->get_string_param("material"));
-      siliconVis->SetVisibility(true);
-      siliconVis->SetForceSolid(true);
-    }
+  {
+    PHG4Utils::SetColour(siliconVis, params->get_string_param("material"));
+    siliconVis->SetVisibility(true);
+    siliconVis->SetForceSolid(true);
+  }
 
   // determine length of cylinder using PHENIX's rapidity coverage if flag is true
-  double radius = params->get_double_param("radius")*cm;
-  double thickness = params->get_double_param("thickness")*cm;
+  double radius = params->get_double_param("radius") * cm;
+  double thickness = params->get_double_param("thickness") * cm;
   G4VSolid *cylinder_solid = new G4Tubs(G4String(GetName().c_str()),
-			      radius,
-			      radius + thickness, 
-			      params->get_double_param("length")*cm/2. ,0,twopi);
-  G4LogicalVolume *cylinder_logic = new G4LogicalVolume(cylinder_solid, 
-				       TrackerMaterial, 
-				       G4String(GetName().c_str()),
-				       0,0,0);
+                                        radius,
+                                        radius + thickness,
+                                        params->get_double_param("length") * cm / 2., 0, twopi);
+  G4LogicalVolume *cylinder_logic = new G4LogicalVolume(cylinder_solid,
+                                                        TrackerMaterial,
+                                                        G4String(GetName().c_str()),
+                                                        0, 0, 0);
   cylinder_logic->SetVisAttributes(siliconVis);
-  cylinder_physi = new G4PVPlacement(0, G4ThreeVector(params->get_double_param("place_x")*cm,
-                                                      params->get_double_param("place_y")*cm,
-						      params->get_double_param("place_z")*cm), 
-				     cylinder_logic, 
-				     G4String(GetName().c_str()), 
-				     logicWorld, 0, false, overlapcheck);
+  cylinder_physi = new G4PVPlacement(0, G4ThreeVector(params->get_double_param("place_x") * cm,
+                                                      params->get_double_param("place_y") * cm,
+                                                      params->get_double_param("place_z") * cm),
+                                     cylinder_logic,
+                                     G4String(GetName().c_str()),
+                                     logicWorld, 0, false, overlapcheck);
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
@@ -9,32 +9,28 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHG4Parameters;
 
-class PHG4CylinderDetector: public PHG4Detector
+class PHG4CylinderDetector : public PHG4Detector
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4CylinderDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam, const int layer = 0 );
+  PHG4CylinderDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam, const int layer = 0);
 
   //! destructor
-  virtual ~PHG4CylinderDetector( void )
-  {}
+  virtual ~PHG4CylinderDetector(void)
+  {
+  }
 
   //! construct
-  void Construct( G4LogicalVolume* world );
+  void Construct(G4LogicalVolume *world);
 
-  bool IsInCylinder(const G4VPhysicalVolume*) const;
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return layer;}
-
-  private:
-
+  bool IsInCylinder(const G4VPhysicalVolume *) const;
+  void SuperDetector(const std::string &name) { superdetector = name; }
+  const std::string SuperDetector() const { return superdetector; }
+  int get_Layer() const { return layer; }
+ private:
   PHG4Parameters *params;
 
-  G4VPhysicalVolume* cylinder_physi;
-
+  G4VPhysicalVolume *cylinder_physi;
 
   int layer;
   std::string superdetector;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -126,7 +126,7 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       savetrackid = aTrack->GetTrackID();
       //set the initial energy deposit
       hit->set_edep(0);
-      if (!geantino)
+      if (!geantino && !IsBlackHole)
       {
         hit->set_eion(0);
       }
@@ -201,8 +201,11 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     }
     else
     {
-      double eion = edep - aStep->GetNonIonizingEnergyDeposit() / GeV;
-      hit->set_eion(hit->get_eion() + eion);
+      if (!IsBlackHole)
+      {
+        double eion = edep - aStep->GetNonIonizingEnergyDeposit() / GeV;
+        hit->set_eion(hit->get_eion() + eion);
+      }
     }
     if (save_light_yield)
     {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -2,8 +2,8 @@
 #include "PHG4CylinderDetector.h"
 #include "PHG4Parameters.h"
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
 
@@ -19,25 +19,24 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4CylinderSteppingAction::PHG4CylinderSteppingAction( PHG4CylinderDetector* detector, const PHG4Parameters *parameters ):
-  detector_( detector ),
-  params(parameters),
-  hits_(nullptr),
-  hit(nullptr),
-  saveshower(nullptr),
-  save_light_yield(params->get_int_param("lightyield")),
-  savetrackid(-1),
-  savepoststepstatus(-1),
-  active(params->get_int_param("active")),
-  IsBlackHole(params->get_int_param("blackhole")),
-  zmin(params->get_double_param("place_z")*cm-params->get_double_param("length")*cm/2.),
-  zmax(params->get_double_param("place_z")*cm+params->get_double_param("length")*cm/2.),
-  tmin(params->get_double_param("tmin")*ns),
-  tmax(params->get_double_param("tmax")*ns)
+PHG4CylinderSteppingAction::PHG4CylinderSteppingAction(PHG4CylinderDetector* detector, const PHG4Parameters* parameters) : detector_(detector),
+                                                                                                                           params(parameters),
+                                                                                                                           hits_(nullptr),
+                                                                                                                           hit(nullptr),
+                                                                                                                           saveshower(nullptr),
+                                                                                                                           save_light_yield(params->get_int_param("lightyield")),
+                                                                                                                           savetrackid(-1),
+                                                                                                                           savepoststepstatus(-1),
+                                                                                                                           active(params->get_int_param("active")),
+                                                                                                                           IsBlackHole(params->get_int_param("blackhole")),
+                                                                                                                           zmin(params->get_double_param("place_z") * cm - params->get_double_param("length") * cm / 2.),
+                                                                                                                           zmax(params->get_double_param("place_z") * cm + params->get_double_param("length") * cm / 2.),
+                                                                                                                           tmin(params->get_double_param("tmin") * ns),
+                                                                                                                           tmax(params->get_double_param("tmax") * ns)
 {
   // G4 seems to have issues in the um range
-  zmin -= copysign(zmin,1./1e6*cm);
-  zmax += copysign(zmax,1./1e6*cm);
+  zmin -= copysign(zmin, 1. / 1e6 * cm);
+  zmax += copysign(zmax, 1. / 1e6 * cm);
 }
 
 PHG4CylinderSteppingAction::~PHG4CylinderSteppingAction()
@@ -50,16 +49,16 @@ PHG4CylinderSteppingAction::~PHG4CylinderSteppingAction()
 }
 
 //____________________________________________________________________________..
-bool PHG4CylinderSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
+bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
   // get volume of the current step
   G4VPhysicalVolume* volume = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
   // G4 just calls  UserSteppingAction for every step (and we loop then over all our
   // steppingactions. First we have to check if we are actually in our volume
   if (!detector_->IsInCylinder(volume))
-    {
-      return false;
-    }
+  {
+    return false;
+  }
 
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
@@ -68,219 +67,219 @@ bool PHG4CylinderSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
 
   // if this cylinder stops everything, just put all kinetic energy into edep
   if (IsBlackHole)
+  {
+    if ((!isfinite(tmin) && !isfinite(tmax)) ||
+        aTrack->GetGlobalTime() < tmin ||
+        aTrack->GetGlobalTime() > tmax)
     {
-      if ( (!isfinite(tmin) && !isfinite(tmax)) ||
-           aTrack->GetGlobalTime() < tmin ||
-	   aTrack->GetGlobalTime() > tmax)
-	{
-	  edep = aTrack->GetKineticEnergy()/GeV;
-	  G4Track* killtrack = const_cast<G4Track *> (aTrack);
-	  killtrack->SetTrackStatus(fStopAndKill);
-	}
+      edep = aTrack->GetKineticEnergy() / GeV;
+      G4Track* killtrack = const_cast<G4Track*>(aTrack);
+      killtrack->SetTrackStatus(fStopAndKill);
     }
+  }
 
   int layer_id = detector_->get_Layer();
   // test if we are active
-  if ( active )
+  if (active)
+  {
+    bool geantino = false;
+    // the check for the pdg code speeds things up, I do not want to make
+    // an expensive string compare for every track when we know
+    // geantino or chargedgeantino has pid=0
+    if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
+        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
     {
-      bool geantino = false;
-      // the check for the pdg code speeds things up, I do not want to make 
-      // an expensive string compare for every track when we know
-      // geantino or chargedgeantino has pid=0
-      if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
-          aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
-	{
-          geantino = true;
-	}
-      G4StepPoint * prePoint = aStep->GetPreStepPoint();
-      G4StepPoint * postPoint = aStep->GetPostStepPoint();
-      //        cout << "time prepoint: " << prePoint->GetGlobalTime()/ns << endl;
-      //        cout << "time postpoint: " << postPoint->GetGlobalTime()/ns << endl;
-      //        cout << "kinetic energy: " <<  aTrack->GetKineticEnergy()/GeV << endl;
-      //       G4ParticleDefinition* def = aTrack->GetDefinition();
-      //       cout << "Particle: " << def->GetParticleName() << endl;
-      switch (prePoint->GetStepStatus())
+      geantino = true;
+    }
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    //        cout << "time prepoint: " << prePoint->GetGlobalTime()/ns << endl;
+    //        cout << "time postpoint: " << postPoint->GetGlobalTime()/ns << endl;
+    //        cout << "kinetic energy: " <<  aTrack->GetKineticEnergy()/GeV << endl;
+    //       G4ParticleDefinition* def = aTrack->GetDefinition();
+    //       cout << "Particle: " << def->GetParticleName() << endl;
+    switch (prePoint->GetStepStatus())
+    {
+    case fWorldBoundary:
+    case fGeomBoundary:
+    case fUndefined:
+      if (!hit)
+      {
+        hit = new PHG4Hitv1();
+      }
+
+      hit->set_layer((unsigned int) layer_id);
+
+      //here we set the entrance values in cm
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
+
+      hit->set_px(0, prePoint->GetMomentum().x() / GeV);
+      hit->set_py(0, prePoint->GetMomentum().y() / GeV);
+      hit->set_pz(0, prePoint->GetMomentum().z() / GeV);
+
+      // time in ns
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      //set and save the track ID
+      hit->set_trkid(aTrack->GetTrackID());
+      savetrackid = aTrack->GetTrackID();
+      //set the initial energy deposit
+      hit->set_edep(0);
+      if (!geantino)
+      {
+        hit->set_eion(0);
+      }
+      if (save_light_yield)
+      {
+        hit->set_light_yield(0);
+      }
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
-	case fWorldBoundary:
-        case fGeomBoundary:
-        case fUndefined:
-	  if (! hit)
-	    {
-              hit = new PHG4Hitv1();
-	    }
-
-	  hit->set_layer((unsigned int)layer_id);
-
-          //here we set the entrance values in cm
-          hit->set_x( 0, prePoint->GetPosition().x() / cm );
-          hit->set_y( 0, prePoint->GetPosition().y() / cm );
-          hit->set_z( 0, prePoint->GetPosition().z() / cm );
-
-	  hit->set_px( 0, prePoint->GetMomentum().x() / GeV );
-	  hit->set_py( 0, prePoint->GetMomentum().y() / GeV );
-	  hit->set_pz( 0, prePoint->GetMomentum().z() / GeV );
-
-	  // time in ns
-          hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
-	  //set and save the track ID
-	  hit->set_trkid(aTrack->GetTrackID());
-	  savetrackid = aTrack->GetTrackID();
-          //set the initial energy deposit
-          hit->set_edep(0);
-	  if (!geantino)
-	    {
-	      hit->set_eion(0);
-	    }
-	  if (save_light_yield)
-	    {
-	      hit->set_light_yield(0);
-	    }
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  hit->set_trkid(pp->GetUserTrackId());
-		  hit->set_shower_id(pp->GetShower()->get_id());
-		  saveshower = pp->GetShower();
-		}
-	    }
-
-	  if (hit->get_z(0)*cm > zmax || hit->get_z(0)*cm < zmin)
-	    {
-	      cout << detector_->SuperDetector()  << std::setprecision(9)
-		   << "PHG4CylinderSteppingAction: Entry hit z " << hit->get_z(0)*cm 
-                   << " outside acceptance,  zmin " << zmin 
-                   << ", zmax " << zmax << ", layer: " << layer_id << endl;
-	    }
-          break;
-        default:
-          break;
+          hit->set_trkid(pp->GetUserTrackId());
+          hit->set_shower_id(pp->GetShower()->get_id());
+          saveshower = pp->GetShower();
         }
-      // here we just update the exit values, it will be overwritten
-      // for every step until we leave the volume or the particle
-      // ceases to exist
-      // some sanity checks for inconsistencies
-      // check if this hit was created, if not print out last post step status
-      if (! hit || ! isfinite(hit->get_x(0)))
-	{
-	  cout << "hit was not created" << endl;
-	  cout << "prestep status: " << prePoint->GetStepStatus()
-	       << ", last post step status: " << savepoststepstatus << endl;
-	  exit(1);
-	}
-      savepoststepstatus = postPoint->GetStepStatus();
-      // check if track id matches the initial one when the hit was created
-      if (aTrack->GetTrackID() != savetrackid)
-	{
-	  cout << "hits do not belong to the same track" << endl;
-	  cout << "saved track: " << savetrackid
-	       << ", current trackid: " << aTrack->GetTrackID()
-	       << endl;
-	  exit(1);
-	}
-      hit->set_x( 1, postPoint->GetPosition().x() / cm );
-      hit->set_y( 1, postPoint->GetPosition().y() / cm );
-      hit->set_z( 1, postPoint->GetPosition().z() / cm );
+      }
 
-      hit->set_px(1, postPoint->GetMomentum().x() / GeV );
-      hit->set_py(1, postPoint->GetMomentum().y() / GeV );
-      hit->set_pz(1, postPoint->GetMomentum().z() / GeV );
-
-      hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
-      //sum up the energy to get total deposited
-      hit->set_edep(hit->get_edep() + edep);
-      if (hit->get_z(1)*cm > zmax || hit->get_z(1)*cm < zmin)
-	{
-	  cout << detector_->SuperDetector() << std::setprecision(9)
-	       << " PHG4CylinderSteppingAction: Exit hit z " << hit->get_z(1)*cm 
-               << " outside acceptance zmin " << zmin 
-               << ", zmax " << zmax << ", layer: " << layer_id << endl;
-	}
-      if (geantino)
-	{
-	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-	}
-      else
-	{
-	  double eion = edep - aStep->GetNonIonizingEnergyDeposit()/GeV;
-	  hit->set_eion(hit->get_eion() + eion);
-	}
-	  if (save_light_yield)
-	    {
-double light_yield = GetVisibleEnergyDeposition(aStep);
-	      hit->set_light_yield(hit->get_light_yield() + light_yield);
-	    }
-      if (edep > 0)
-	{
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  pp->SetKeep(1); // we want to keep the track
-		}
-	    }
-	}
-      // if any of these conditions is true this is the last step in
-      // this volume and we need to save the hit
-      // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
-      // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
-      // (happens when your detector goes outside world volume)
-      // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
-      // aTrack->GetTrackStatus() == fStopAndKill is also set)
-      // aTrack->GetTrackStatus() == fStopAndKill: track ends
-      if (postPoint->GetStepStatus() == fGeomBoundary || 
-          postPoint->GetStepStatus() == fWorldBoundary || 
-          postPoint->GetStepStatus() == fAtRestDoItProc ||
-          aTrack->GetTrackStatus() == fStopAndKill)
-	{
-          // save only hits with energy deposit (or -1 for geantino)
-	  if (hit->get_edep())
-	    {
-	      hits_->AddHit(layer_id, hit);
-	      if (saveshower)
-		{
-		  saveshower->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		}
-	      // ownership has been transferred to container, set to null
-	      // so we will create a new hit for the next track
-	      hit = nullptr;
-	    }
-	  else
-	    {
-	      // if this hit has no energy deposit, just reset it for reuse
-	      // this means we have to delete it in the dtor. If this was
-	      // the last hit we processed the memory is still allocated
-	      hit->Reset();
-	    }
- 	}
-      // return true to indicate the hit was used
-      return true;
+      if (hit->get_z(0) * cm > zmax || hit->get_z(0) * cm < zmin)
+      {
+        cout << detector_->SuperDetector() << std::setprecision(9)
+             << "PHG4CylinderSteppingAction: Entry hit z " << hit->get_z(0) * cm
+             << " outside acceptance,  zmin " << zmin
+             << ", zmax " << zmax << ", layer: " << layer_id << endl;
+      }
+      break;
+    default:
+      break;
     }
-  else
+    // here we just update the exit values, it will be overwritten
+    // for every step until we leave the volume or the particle
+    // ceases to exist
+    // some sanity checks for inconsistencies
+    // check if this hit was created, if not print out last post step status
+    if (!hit || !isfinite(hit->get_x(0)))
     {
-      return false;
+      cout << "hit was not created" << endl;
+      cout << "prestep status: " << prePoint->GetStepStatus()
+           << ", last post step status: " << savepoststepstatus << endl;
+      exit(1);
     }
+    savepoststepstatus = postPoint->GetStepStatus();
+    // check if track id matches the initial one when the hit was created
+    if (aTrack->GetTrackID() != savetrackid)
+    {
+      cout << "hits do not belong to the same track" << endl;
+      cout << "saved track: " << savetrackid
+           << ", current trackid: " << aTrack->GetTrackID()
+           << endl;
+      exit(1);
+    }
+    hit->set_x(1, postPoint->GetPosition().x() / cm);
+    hit->set_y(1, postPoint->GetPosition().y() / cm);
+    hit->set_z(1, postPoint->GetPosition().z() / cm);
+
+    hit->set_px(1, postPoint->GetMomentum().x() / GeV);
+    hit->set_py(1, postPoint->GetMomentum().y() / GeV);
+    hit->set_pz(1, postPoint->GetMomentum().z() / GeV);
+
+    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+    //sum up the energy to get total deposited
+    hit->set_edep(hit->get_edep() + edep);
+    if (hit->get_z(1) * cm > zmax || hit->get_z(1) * cm < zmin)
+    {
+      cout << detector_->SuperDetector() << std::setprecision(9)
+           << " PHG4CylinderSteppingAction: Exit hit z " << hit->get_z(1) * cm
+           << " outside acceptance zmin " << zmin
+           << ", zmax " << zmax << ", layer: " << layer_id << endl;
+    }
+    if (geantino)
+    {
+      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+    }
+    else
+    {
+      double eion = edep - aStep->GetNonIonizingEnergyDeposit() / GeV;
+      hit->set_eion(hit->get_eion() + eion);
+    }
+    if (save_light_yield)
+    {
+      double light_yield = GetVisibleEnergyDeposition(aStep);
+      hit->set_light_yield(hit->get_light_yield() + light_yield);
+    }
+    if (edep > 0)
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
+      }
+    }
+    // if any of these conditions is true this is the last step in
+    // this volume and we need to save the hit
+    // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
+    // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
+    // (happens when your detector goes outside world volume)
+    // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
+    // aTrack->GetTrackStatus() == fStopAndKill is also set)
+    // aTrack->GetTrackStatus() == fStopAndKill: track ends
+    if (postPoint->GetStepStatus() == fGeomBoundary ||
+        postPoint->GetStepStatus() == fWorldBoundary ||
+        postPoint->GetStepStatus() == fAtRestDoItProc ||
+        aTrack->GetTrackStatus() == fStopAndKill)
+    {
+      // save only hits with energy deposit (or -1 for geantino)
+      if (hit->get_edep())
+      {
+        hits_->AddHit(layer_id, hit);
+        if (saveshower)
+        {
+          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+        }
+        // ownership has been transferred to container, set to null
+        // so we will create a new hit for the next track
+        hit = nullptr;
+      }
+      else
+      {
+        // if this hit has no energy deposit, just reset it for reuse
+        // this means we have to delete it in the dtor. If this was
+        // the last hit we processed the memory is still allocated
+        hit->Reset();
+      }
+    }
+    // return true to indicate the hit was used
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 //____________________________________________________________________________..
-void PHG4CylinderSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+void PHG4CylinderSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
-
   string hitnodename;
   if (detector_->SuperDetector() != "NONE")
-    {
-      hitnodename = "G4HIT_" + detector_->SuperDetector();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->SuperDetector();
+  }
   else
-    {
-      hitnodename = "G4HIT_" + detector_->GetName();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->GetName();
+  }
 
   //now look for the map and grab a pointer to it.
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
 
   // if we do not find the node we need to make it.
-  if ( ! hits_  && !IsBlackHole)
-    { std::cout << "PHG4CylinderSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl; }
-
+  if (!hits_ && !IsBlackHole)
+  {
+    std::cout << "PHG4CylinderSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+  }
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -13,33 +13,28 @@ class PHG4Parameters;
 
 class PHG4CylinderSteppingAction : public PHG4SteppingAction
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4CylinderSteppingAction( PHG4CylinderDetector*, const PHG4Parameters *parameters );
+  PHG4CylinderSteppingAction(PHG4CylinderDetector *, const PHG4Parameters *parameters);
 
   //! destructor
   virtual ~PHG4CylinderSteppingAction();
 
-
   //! stepping action
-  bool UserSteppingAction(const G4Step*, bool);
+  bool UserSteppingAction(const G4Step *, bool);
 
   //! reimplemented from base class
-  void SetInterfacePointers( PHCompositeNode* );
+  void SetInterfacePointers(PHCompositeNode *);
 
-  void SaveLightYield(const int i = 1) {save_light_yield = i;}
-
-  private:
-
+  void SaveLightYield(const int i = 1) { save_light_yield = i; }
+ private:
   //! pointer to the detector
-  PHG4CylinderDetector* detector_;
+  PHG4CylinderDetector *detector_;
 
   const PHG4Parameters *params;
 
   //! pointer to hit container
-  PHG4HitContainer * hits_;
+  PHG4HitContainer *hits_;
   PHG4Hit *hit;
   PHG4Shower *saveshower;
   int save_light_yield;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -24,10 +24,12 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
 
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  bool UserSteppingAction(const G4Step*, bool);
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers( PHCompositeNode* );
+  void SetInterfacePointers( PHCompositeNode* );
+
+  void SaveLightYield(const int i = 1) {save_light_yield = i;}
 
   private:
 
@@ -40,6 +42,9 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
   PHG4HitContainer * hits_;
   PHG4Hit *hit;
   PHG4Shower *saveshower;
+  int save_light_yield;
+  int savetrackid;
+  int savepoststepstatus;
   int active;
   int IsBlackHole;
   double zmin;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -1,7 +1,7 @@
 #include "PHG4CylinderSubsystem.h"
 #include "PHG4CylinderDetector.h"
-#include "PHG4CylinderGeomv1.h"
 #include "PHG4CylinderGeomContainer.h"
+#include "PHG4CylinderGeomv1.h"
 #include "PHG4CylinderSteppingAction.h"
 #include "PHG4Parameters.h"
 
@@ -18,144 +18,140 @@
 using namespace std;
 
 //_______________________________________________________________________
-PHG4CylinderSubsystem::PHG4CylinderSubsystem( const std::string &na, const int lyr):
-  PHG4DetectorSubsystem(na,lyr),
-  detector_( nullptr ),
-  steppingAction_( nullptr )
+PHG4CylinderSubsystem::PHG4CylinderSubsystem(const std::string &na, const int lyr) : PHG4DetectorSubsystem(na, lyr),
+                                                                                     detector_(nullptr),
+                                                                                     steppingAction_(nullptr)
 {
   InitializeParameters();
 }
 
 //_______________________________________________________________________
-int PHG4CylinderSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
+int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
   // create hit list only for active layers
   if (GetParams()->get_int_param("lengthviarapidity"))
-    {
-      GetParams()->set_double_param("length",PHG4Utils::GetLengthForRapidityCoverage( GetParams()->get_double_param("radius") + GetParams()->get_double_param("thickness"))*2);
-    }
+  {
+    GetParams()->set_double_param("length", PHG4Utils::GetLengthForRapidityCoverage(GetParams()->get_double_param("radius") + GetParams()->get_double_param("thickness")) * 2);
+  }
   // create detector
   detector_ = new PHG4CylinderDetector(topNode, GetParams(), Name(), GetLayer());
   G4double detlength = GetParams()->get_double_param("length");
   detector_->SuperDetector(SuperDetector());
   detector_->OverlapCheck(CheckOverlap());
   if (GetParams()->get_int_param("active"))
-    {
-  PHNodeIterator iter( topNode );
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
-  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN" ));
+  {
+    PHNodeIterator iter(topNode);
+    PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+    PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
 
-  ostringstream nodename;
-  ostringstream geonode;
-  if (SuperDetector() != "NONE")
+    ostringstream nodename;
+    ostringstream geonode;
+    if (SuperDetector() != "NONE")
     {
       // create super detector subnodes
       PHNodeIterator iter_dst(dstNode);
-      PHCompositeNode *superSubNode =  dynamic_cast<PHCompositeNode*>(iter_dst.findFirst("PHCompositeNode", SuperDetector()));
-      if (! superSubNode)
-	{
-	  superSubNode = new PHCompositeNode(SuperDetector());
-	  dstNode->addNode(superSubNode);
-	}
+      PHCompositeNode *superSubNode = dynamic_cast<PHCompositeNode *>(iter_dst.findFirst("PHCompositeNode", SuperDetector()));
+      if (!superSubNode)
+      {
+        superSubNode = new PHCompositeNode(SuperDetector());
+        dstNode->addNode(superSubNode);
+      }
       dstNode = superSubNode;
       PHNodeIterator iter_run(runNode);
-      superSubNode = dynamic_cast<PHCompositeNode*>(iter_run.findFirst("PHCompositeNode", SuperDetector()));
-      if (! superSubNode)
-	{
-	  superSubNode = new PHCompositeNode(SuperDetector());
-	  runNode->addNode(superSubNode);
-	}
+      superSubNode = dynamic_cast<PHCompositeNode *>(iter_run.findFirst("PHCompositeNode", SuperDetector()));
+      if (!superSubNode)
+      {
+        superSubNode = new PHCompositeNode(SuperDetector());
+        runNode->addNode(superSubNode);
+      }
       runNode = superSubNode;
 
-          nodename <<  "G4HIT_" << SuperDetector();
-          geonode << "CYLINDERGEOM_" << SuperDetector();
-       }
-
-      else
-        {
-          nodename <<  "G4HIT_" << Name();
-          geonode << "CYLINDERGEOM_" << Name();
-        }
-      PHG4HitContainer* cylinder_hits =  findNode::getClass<PHG4HitContainer>( topNode , nodename.str().c_str() );
-      if ( !cylinder_hits )
-        {
-          dstNode->addNode( new PHIODataNode<PHObject>( cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject" ));
-        }
-      cylinder_hits->AddLayer(GetLayer());
-      PHG4CylinderGeomContainer *geo =  findNode::getClass<PHG4CylinderGeomContainer>(topNode , geonode.str().c_str());
-      if (!geo)
-        {
-          geo = new PHG4CylinderGeomContainer();
-          PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geo, geonode.str().c_str(), "PHObject");
-          runNode->addNode(newNode);
-        }
-      PHG4CylinderGeom *mygeom = new PHG4CylinderGeomv1(GetParams()->get_double_param("radius"), GetParams()->get_double_param("place_z")-detlength/2., GetParams()->get_double_param("place_z") + detlength/2.,GetParams()->get_double_param("thickness"));
-      geo->AddLayerGeom(GetLayer(), mygeom);
-      steppingAction_ = new PHG4CylinderSteppingAction(detector_, GetParams());
+      nodename << "G4HIT_" << SuperDetector();
+      geonode << "CYLINDERGEOM_" << SuperDetector();
     }
-  if (GetParams()->get_int_param("blackhole"))
+
+    else
     {
-      steppingAction_ = new PHG4CylinderSteppingAction(detector_, GetParams());
+      nodename << "G4HIT_" << Name();
+      geonode << "CYLINDERGEOM_" << Name();
     }
+    PHG4HitContainer *cylinder_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+    if (!cylinder_hits)
+    {
+      dstNode->addNode(new PHIODataNode<PHObject>(cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject"));
+    }
+    cylinder_hits->AddLayer(GetLayer());
+    PHG4CylinderGeomContainer *geo = findNode::getClass<PHG4CylinderGeomContainer>(topNode, geonode.str().c_str());
+    if (!geo)
+    {
+      geo = new PHG4CylinderGeomContainer();
+      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geo, geonode.str().c_str(), "PHObject");
+      runNode->addNode(newNode);
+    }
+    PHG4CylinderGeom *mygeom = new PHG4CylinderGeomv1(GetParams()->get_double_param("radius"), GetParams()->get_double_param("place_z") - detlength / 2., GetParams()->get_double_param("place_z") + detlength / 2., GetParams()->get_double_param("thickness"));
+    geo->AddLayerGeom(GetLayer(), mygeom);
+    steppingAction_ = new PHG4CylinderSteppingAction(detector_, GetParams());
+  }
+  if (GetParams()->get_int_param("blackhole"))
+  {
+    steppingAction_ = new PHG4CylinderSteppingAction(detector_, GetParams());
+  }
   return 0;
-
 }
 
 //_______________________________________________________________________
-int PHG4CylinderSubsystem::process_event( PHCompositeNode* topNode )
+int PHG4CylinderSubsystem::process_event(PHCompositeNode *topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
   if (steppingAction_)
-    {
-      steppingAction_->SetInterfacePointers( topNode );
-    }
+  {
+    steppingAction_->SetInterfacePointers(topNode);
+  }
   return 0;
 }
 
-void
-PHG4CylinderSubsystem::SetDefaultParameters()
+void PHG4CylinderSubsystem::SetDefaultParameters()
 {
-  set_default_double_param("length",100);
+  set_default_double_param("length", 100);
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);
   set_default_double_param("place_z", 0.);
   set_default_double_param("radius", 100);
-  set_default_double_param("thickness",100);
-  set_default_double_param("tmin",NAN);
-  set_default_double_param("tmax",NAN);
+  set_default_double_param("thickness", 100);
+  set_default_double_param("tmin", NAN);
+  set_default_double_param("tmax", NAN);
 
-  set_default_int_param("lengthviarapidity",1);
-  set_default_int_param("lightyield",0);
+  set_default_int_param("lengthviarapidity", 1);
+  set_default_int_param("lightyield", 0);
 
   set_default_string_param("material", "G4_Galactic");
 }
 
-PHG4Detector*
-PHG4CylinderSubsystem::GetDetector( void ) const
+PHG4Detector *
+PHG4CylinderSubsystem::GetDetector(void) const
 {
   return detector_;
 }
 
-void
-PHG4CylinderSubsystem::Print(const string &what) const
+void PHG4CylinderSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
-  if (! BeginRunExecuted())
-    {
-      cout << "Need to execute BeginRun() before parameter printout is meaningful" << endl;
-      cout << "To do so either run one or more events or on the command line execute: " << endl;
-      cout << "Fun4AllServer *se = Fun4AllServer::instance();" << endl;
-      cout << "PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");" << endl;
-      cout << "g4->InitRun(se->topNode());" << endl;
-      cout << "PHG4CylinderSubsystem *cyl = (PHG4CylinderSubsystem *) g4->getSubsystem(\"" << Name() << "\");" << endl;
-      cout << "cyl->Print()" << endl;
-      return;
-    }
+  if (!BeginRunExecuted())
+  {
+    cout << "Need to execute BeginRun() before parameter printout is meaningful" << endl;
+    cout << "To do so either run one or more events or on the command line execute: " << endl;
+    cout << "Fun4AllServer *se = Fun4AllServer::instance();" << endl;
+    cout << "PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");" << endl;
+    cout << "g4->InitRun(se->topNode());" << endl;
+    cout << "PHG4CylinderSubsystem *cyl = (PHG4CylinderSubsystem *) g4->getSubsystem(\"" << Name() << "\");" << endl;
+    cout << "cyl->Print()" << endl;
+    return;
+  }
   GetParams()->Print();
   if (steppingAction_)
-    {
-      steppingAction_->Print(what);
-    }
+  {
+    steppingAction_->Print(what);
+  }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -3,23 +3,22 @@
 
 #include "PHG4DetectorSubsystem.h"
 
-#include <Geant4/G4Types.hh>
 #include <Geant4/G4String.hh>
+#include <Geant4/G4Types.hh>
 
 class PHG4CylinderDetector;
 class PHG4SteppingAction;
 
-class PHG4CylinderSubsystem: public PHG4DetectorSubsystem
+class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4CylinderSubsystem( const std::string &name = "CYLINDER", const int layer = 0 );
+  PHG4CylinderSubsystem(const std::string& name = "CYLINDER", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4CylinderSubsystem( void )
-  {}
+  virtual ~PHG4CylinderSubsystem(void)
+  {
+  }
 
   //! init runwise stuff
   /*!
@@ -27,22 +26,21 @@ class PHG4CylinderSubsystem: public PHG4DetectorSubsystem
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode*);
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode*);
 
   //! Print info (from SubsysReco)
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string& what = "ALL") const;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector( void ) const;
-  PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
-
+  PHG4Detector* GetDetector(void) const;
+  PHG4SteppingAction* GetSteppingAction(void) const { return steppingAction_; }
  private:
   void SetDefaultParameters();
 
@@ -53,7 +51,6 @@ class PHG4CylinderSubsystem: public PHG4DetectorSubsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
   PHG4SteppingAction* steppingAction_;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -8,7 +8,6 @@
 
 class PHG4CylinderDetector;
 class PHG4SteppingAction;
-class PHG4EventAction;
 
 class PHG4CylinderSubsystem: public PHG4DetectorSubsystem
 {
@@ -43,7 +42,6 @@ class PHG4CylinderSubsystem: public PHG4DetectorSubsystem
   //! accessors (reimplemented)
   PHG4Detector* GetDetector( void ) const;
   PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
-  PHG4EventAction* GetEventAction() const {return eventAction_;}
 
  private:
   void SetDefaultParameters();
@@ -56,7 +54,6 @@ class PHG4CylinderSubsystem: public PHG4DetectorSubsystem
   /*! derives from PHG4SteppingActions */
   PHG4SteppingAction* steppingAction_;
 
-  PHG4EventAction *eventAction_;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystemLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderSubsystem-!;
+#pragma link C++ class PHG4CylinderSubsystem - !;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -1,10 +1,10 @@
 #include "PHG4InnerHcalSteppingAction.h"
-#include "PHG4InnerHcalDetector.h"
 #include "PHG4HcalDefs.h"
+#include "PHG4InnerHcalDetector.h"
 #include "PHG4Parameters.h"
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
 
@@ -14,17 +14,17 @@
 
 #include <TSystem.h>
 
-#include <Geant4/G4Step.hh>
 #include <Geant4/G4MaterialCutsCouple.hh>
+#include <Geant4/G4Step.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 
 #include <boost/foreach.hpp>
 #include <boost/tokenizer.hpp>
 // this is an ugly hack, the gcc optimizer has a bug which
 // triggers the uninitialized variable warning which
-// stops compilation because of our -Werror 
-#include <boost/version.hpp> // to get BOOST_VERSION
-#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700 )
+// stops compilation because of our -Werror
+#include <boost/version.hpp>  // to get BOOST_VERSION
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700)
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #pragma message "ignoring bogus gcc warning in boost header lexical_cast.hpp"
 #include <boost/lexical_cast.hpp>
@@ -37,26 +37,26 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction( PHG4InnerHcalDetector* detector, const PHG4Parameters *parameters):
-  detector_( detector ),
-  hits_(nullptr),
-  absorberhits_(nullptr),
-  hit(nullptr),
-  params(parameters),
-  savehitcontainer(nullptr),
-  saveshower(nullptr),
-  savetrackid(-1),
-  savepoststepstatus(-1),
-  absorbertruth(params->get_int_param("absorbertruth")),
-  IsActive(params->get_int_param("active")),
-  IsBlackHole(params->get_int_param("blackhole")),
-  n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr)*params->get_int_param("n_towers")),
-  light_scint_model(params->get_int_param("light_scint_model")),
-  light_balance_inner_corr(params->get_double_param("light_balance_inner_corr")),
-  light_balance_inner_radius(params->get_double_param("light_balance_inner_radius")*cm),
-  light_balance_outer_corr(params->get_double_param("light_balance_outer_corr")),
-  light_balance_outer_radius(params->get_double_param("light_balance_outer_radius")*cm)
-{}
+PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector* detector, const PHG4Parameters* parameters) : detector_(detector),
+                                                                                                                              hits_(nullptr),
+                                                                                                                              absorberhits_(nullptr),
+                                                                                                                              hit(nullptr),
+                                                                                                                              params(parameters),
+                                                                                                                              savehitcontainer(nullptr),
+                                                                                                                              saveshower(nullptr),
+                                                                                                                              savetrackid(-1),
+                                                                                                                              savepoststepstatus(-1),
+                                                                                                                              absorbertruth(params->get_int_param("absorbertruth")),
+                                                                                                                              IsActive(params->get_int_param("active")),
+                                                                                                                              IsBlackHole(params->get_int_param("blackhole")),
+                                                                                                                              n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr) * params->get_int_param("n_towers")),
+                                                                                                                              light_scint_model(params->get_int_param("light_scint_model")),
+                                                                                                                              light_balance_inner_corr(params->get_double_param("light_balance_inner_corr")),
+                                                                                                                              light_balance_inner_radius(params->get_double_param("light_balance_inner_radius") * cm),
+                                                                                                                              light_balance_outer_corr(params->get_double_param("light_balance_outer_corr")),
+                                                                                                                              light_balance_outer_radius(params->get_double_param("light_balance_outer_radius") * cm)
+{
+}
 
 PHG4InnerHcalSteppingAction::~PHG4InnerHcalSteppingAction()
 {
@@ -67,15 +67,14 @@ PHG4InnerHcalSteppingAction::~PHG4InnerHcalSteppingAction()
   delete hit;
 }
 //____________________________________________________________________________..
-bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
+bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
-
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   // get volume of the current step
   G4VPhysicalVolume* volume = touch->GetVolume();
 
   // detector_->IsInInnerHcal(volume)
-  // returns 
+  // returns
   //  0 is outside of InnerHcal
   //  1 is inside scintillator
   // -1 is steel absorber
@@ -83,80 +82,80 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
   int whichactive = detector_->IsInInnerHcal(volume);
 
   if (!whichactive)
-    {
-      return false;
-    }
+  {
+    return false;
+  }
   int layer_id = -1;
   int tower_id = -1;
-  if (whichactive > 0) // scintillator
-    {
-      // G4AssemblyVolumes naming convention:
-      //     av_WWW_impr_XXX_YYY_ZZZ
-      // where:
+  if (whichactive > 0)  // scintillator
+  {
+    // G4AssemblyVolumes naming convention:
+    //     av_WWW_impr_XXX_YYY_ZZZ
+    // where:
 
-      //     WWW - assembly volume instance number
-      //     XXX - assembly volume imprint number
-      //     YYY - the name of the placed logical volume
-      //     ZZZ - the logical volume index inside the assembly volume
-      // e.g. av_1_impr_82_HcalInnerScinti_11_pv_11
-      // 82 the number of the scintillator mother volume
-      // HcalInnerScinti_11: name of scintillator slat
-      // 11: number of scintillator slat logical volume
-      // use boost tokenizer to separate the _, then take value
-      // after "impr" for mother volume and after "pv" for scintillator slat
-      // use boost lexical cast for string -> int conversion
-      boost::char_separator<char> sep("_");
-      boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
-      boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
-      for (tokeniter = tok.begin(); tokeniter != tok.end(); ++tokeniter)
-	{
-	  if (*tokeniter == "impr")
-	    {
-	      ++tokeniter;
-	      if (tokeniter != tok.end())
-		{
-		  layer_id = boost::lexical_cast<int>(*tokeniter);
-		  // check detector description, for assemblyvolumes it is not possible
-		  // to give the first volume id=0, so they go from id=1 to id=n. 
-		  // I am not going to start with fortran again - our indices start 
-		  // at zero, id=0 to id=n-1. So subtract one here
-		  layer_id--;
-		  if (layer_id < 0 || layer_id >= n_scinti_plates)
-		    {
-		      cout << "invalid scintillator row " << layer_id
-			   << ", valid range 0 < row < " << n_scinti_plates << endl;
-		      gSystem->Exit(1);
-		    }
-		}
-	      else
-		{
-		  cout << PHWHERE << " Error parsing " << volume->GetName()
-		       << " for mother volume number " << endl;
-		  gSystem->Exit(1);
-		}
-	    }
-	  else if (*tokeniter == "pv")
-	    {
-	      ++tokeniter;
-	      if (tokeniter != tok.end())
-		{
-		  tower_id = boost::lexical_cast<int>(*tokeniter);
-		}
-	      else
-		{
-		  cout << PHWHERE << " Error parsing " << volume->GetName()
-		       << " for mother scinti slat id " << endl;
-	          gSystem->Exit(1);
-		}
-	    }
-	}
-      // cout << "name " << volume->GetName() << ", mid: " << layer_id
-      //  	   << ", twr: " << tower_id << endl;
-    }
-  else
+    //     WWW - assembly volume instance number
+    //     XXX - assembly volume imprint number
+    //     YYY - the name of the placed logical volume
+    //     ZZZ - the logical volume index inside the assembly volume
+    // e.g. av_1_impr_82_HcalInnerScinti_11_pv_11
+    // 82 the number of the scintillator mother volume
+    // HcalInnerScinti_11: name of scintillator slat
+    // 11: number of scintillator slat logical volume
+    // use boost tokenizer to separate the _, then take value
+    // after "impr" for mother volume and after "pv" for scintillator slat
+    // use boost lexical cast for string -> int conversion
+    boost::char_separator<char> sep("_");
+    boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
+    boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
+    for (tokeniter = tok.begin(); tokeniter != tok.end(); ++tokeniter)
     {
-      layer_id = touch->GetCopyNumber(); // steel plate id
+      if (*tokeniter == "impr")
+      {
+        ++tokeniter;
+        if (tokeniter != tok.end())
+        {
+          layer_id = boost::lexical_cast<int>(*tokeniter);
+          // check detector description, for assemblyvolumes it is not possible
+          // to give the first volume id=0, so they go from id=1 to id=n.
+          // I am not going to start with fortran again - our indices start
+          // at zero, id=0 to id=n-1. So subtract one here
+          layer_id--;
+          if (layer_id < 0 || layer_id >= n_scinti_plates)
+          {
+            cout << "invalid scintillator row " << layer_id
+                 << ", valid range 0 < row < " << n_scinti_plates << endl;
+            gSystem->Exit(1);
+          }
+        }
+        else
+        {
+          cout << PHWHERE << " Error parsing " << volume->GetName()
+               << " for mother volume number " << endl;
+          gSystem->Exit(1);
+        }
+      }
+      else if (*tokeniter == "pv")
+      {
+        ++tokeniter;
+        if (tokeniter != tok.end())
+        {
+          tower_id = boost::lexical_cast<int>(*tokeniter);
+        }
+        else
+        {
+          cout << PHWHERE << " Error parsing " << volume->GetName()
+               << " for mother scinti slat id " << endl;
+          gSystem->Exit(1);
+        }
+      }
     }
+    // cout << "name " << volume->GetName() << ", mid: " << layer_id
+    //  	   << ", twr: " << tower_id << endl;
+  }
+  else
+  {
+    layer_id = touch->GetCopyNumber();  // steel plate id
+  }
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
   G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
@@ -165,233 +164,228 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 
   // if this block stops everything, just put all kinetic energy into edep
   if (IsBlackHole)
-    {
-      edep = aTrack->GetKineticEnergy() / GeV;
-      G4Track* killtrack = const_cast<G4Track *> (aTrack);
-      killtrack->SetTrackStatus(fStopAndKill);
-    }
+  {
+    edep = aTrack->GetKineticEnergy() / GeV;
+    G4Track* killtrack = const_cast<G4Track*>(aTrack);
+    killtrack->SetTrackStatus(fStopAndKill);
+  }
 
   // make sure we are in a volume
-  if ( IsActive )
+  if (IsActive)
+  {
+    bool geantino = false;
+
+    // the check for the pdg code speeds things up, I do not want to make
+    // an expensive string compare for every track when we know
+    // geantino or chargedgeantino has pid=0
+    if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
+        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
     {
-      bool geantino = false;
-
-      // the check for the pdg code speeds things up, I do not want to make
-      // an expensive string compare for every track when we know
-      // geantino or chargedgeantino has pid=0
-      if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
-	  aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
-	{
-	  geantino = true;
-	}
-      G4StepPoint * prePoint = aStep->GetPreStepPoint();
-      G4StepPoint * postPoint = aStep->GetPostStepPoint();
-      //       cout << "track id " << aTrack->GetTrackID() << endl;
-      //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
-      //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
-      switch (prePoint->GetStepStatus())
-	{
-	case fGeomBoundary:
-	case fUndefined:
-	  // if previous hit was saved, hit pointer was set to nullptr 
-	  // and we have to make a new one
-	  if (! hit)
-	    {
-	      hit = new PHG4Hitv1();
-	    }
-	  hit->set_scint_id(tower_id); // the slat id (or steel plate id)
-	  //here we set the entrance values in cm
-	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
-	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
-	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
-	  // time in ns
-	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
-	  //set the track ID
-	  hit->set_trkid(aTrack->GetTrackID());
-	  //set the initial energy deposit
-	  hit->set_edep(0);
-	  hit->set_eion(0); // only implemented for v5 otherwise empty
-	  if (whichactive > 0) // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
-	    {
-	      hit->set_light_yield(0); // for scintillator only, initialize light yields
-	      // Now save the container we want to add this hit to
-	      savehitcontainer = hits_;
-	    }
-	  else
-	    {
-	      savehitcontainer = absorberhits_;
-	    }
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  hit->set_trkid(pp->GetUserTrackId());
-		  hit->set_shower_id(pp->GetShower()->get_id());
-		  saveshower =  pp->GetShower();
-		}
-	    }
-	  break;
-	default:
-	  break;
-	}
-      // some sanity checks for inconsistencies
-      // check if this hit was created, if not print out last post step status
-      if (! hit || ! isfinite(hit->get_x(0)))
-	{
-	  cout << GetName() << ": hit was not created" << endl;
-	  cout << "prestep status: " << prePoint->GetStepStatus()
-	       << ", last post step status: " << savepoststepstatus << endl;
-	  exit(1);
-	}
-      savepoststepstatus = postPoint->GetStepStatus();
-      // check if track id matches the initial one when the hit was created
-      if (aTrack->GetTrackID() != savetrackid)
-	{
-	  cout << GetName() << ": hits do not belong to the same track" << endl;
-	  cout << "saved track: " << savetrackid
-	       << ", current trackid: " << aTrack->GetTrackID()
-	       << endl;
-	  exit(1);
-	}
-      // here we just update the exit values, it will be overwritten
-      // for every step until we leave the volume or the particle
-      // ceases to exist
-      hit->set_x( 1, postPoint->GetPosition().x() / cm );
-      hit->set_y( 1, postPoint->GetPosition().y() / cm );
-      hit->set_z( 1, postPoint->GetPosition().z() / cm );
-
-      hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
-
-      if (whichactive > 0) // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
+      geantino = true;
+    }
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    //       cout << "track id " << aTrack->GetTrackID() << endl;
+    //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
+    //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
+    switch (prePoint->GetStepStatus())
+    {
+    case fGeomBoundary:
+    case fUndefined:
+      // if previous hit was saved, hit pointer was set to nullptr
+      // and we have to make a new one
+      if (!hit)
+      {
+        hit = new PHG4Hitv1();
+      }
+      hit->set_scint_id(tower_id);  // the slat id (or steel plate id)
+      //here we set the entrance values in cm
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      // time in ns
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      //set the track ID
+      hit->set_trkid(aTrack->GetTrackID());
+      //set the initial energy deposit
+      hit->set_edep(0);
+      hit->set_eion(0);     // only implemented for v5 otherwise empty
+      if (whichactive > 0)  // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
+      {
+        hit->set_light_yield(0);  // for scintillator only, initialize light yields
+        // Now save the container we want to add this hit to
+        savehitcontainer = hits_;
+      }
+      else
+      {
+        savehitcontainer = absorberhits_;
+      }
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
-          if (light_scint_model)
-            {
-              light_yield = GetVisibleEnergyDeposition(aStep); // for scintillator only, calculate light yields
-	    }
-	  else
-            {
-              light_yield = eion;
-            }
-          if (isfinite(light_balance_outer_radius) && 
-              isfinite(light_balance_inner_radius) && 
-	      isfinite(light_balance_outer_corr) &&
-	      isfinite(light_balance_inner_corr))
-            {
-              double r = sqrt(postPoint->GetPosition().x()*postPoint->GetPosition().x()
-			    + postPoint->GetPosition().y()*postPoint->GetPosition().y());
-              double cor =  GetLightCorrection(r);
-              light_yield = light_yield * cor;
-
-            }
+          hit->set_trkid(pp->GetUserTrackId());
+          hit->set_shower_id(pp->GetShower()->get_id());
+          saveshower = pp->GetShower();
         }
-
-      //sum up the energy to get total deposited
-      hit->set_edep(hit->get_edep() + edep);
-      hit->set_eion(hit->get_eion() + eion);
-      if (whichactive > 0)
-	{
-	  hit->set_light_yield(hit->get_light_yield() + light_yield);
-	}
-      if (geantino)
-	{
-	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-          hit->set_eion(-1);
-	}
-      if (edep > 0)
-	{
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  pp->SetKeep(1); // we want to keep the track
-		}
-
-
-	    }
-	}
-
-      // if any of these conditions is true this is the last step in
-      // this volume and we need to save the hit
-      // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
-      // (happens when your detector goes outside world volume)
-      // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
-      // aTrack->GetTrackStatus() == fStopAndKill is also set)
-      // aTrack->GetTrackStatus() == fStopAndKill: track ends
-      if (postPoint->GetStepStatus() == fGeomBoundary || 
-          postPoint->GetStepStatus() == fWorldBoundary || 
-          postPoint->GetStepStatus() == fAtRestDoItProc ||
-          aTrack->GetTrackStatus() == fStopAndKill)
-	{
-          // save only hits with energy deposit (or -1 for geantino)
-	  if (hit->get_edep())
-	    {
-	      savehitcontainer->AddHit(layer_id, hit);
-	      if (saveshower)
-		{
-		  saveshower->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		}
-	      // ownership has been transferred to container, set to null
-	      // so we will create a new hit for the next track
-	      hit = nullptr;
-	    }
-	  else
-	    {
-	      // if this hit has no energy deposit, just reset it for reuse
-	      // this means we have to delete it in the dtor. If this was
-	      // the last hit we processed the memory is still allocated
-	      hit->Reset();
-	    }
- 	}
-      // return true to indicate the hit was used
-      return true;
+      }
+      break;
+    default:
+      break;
     }
-  else
+    // some sanity checks for inconsistencies
+    // check if this hit was created, if not print out last post step status
+    if (!hit || !isfinite(hit->get_x(0)))
     {
-      return false;
+      cout << GetName() << ": hit was not created" << endl;
+      cout << "prestep status: " << prePoint->GetStepStatus()
+           << ", last post step status: " << savepoststepstatus << endl;
+      exit(1);
     }
+    savepoststepstatus = postPoint->GetStepStatus();
+    // check if track id matches the initial one when the hit was created
+    if (aTrack->GetTrackID() != savetrackid)
+    {
+      cout << GetName() << ": hits do not belong to the same track" << endl;
+      cout << "saved track: " << savetrackid
+           << ", current trackid: " << aTrack->GetTrackID()
+           << endl;
+      exit(1);
+    }
+    // here we just update the exit values, it will be overwritten
+    // for every step until we leave the volume or the particle
+    // ceases to exist
+    hit->set_x(1, postPoint->GetPosition().x() / cm);
+    hit->set_y(1, postPoint->GetPosition().y() / cm);
+    hit->set_z(1, postPoint->GetPosition().z() / cm);
+
+    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+
+    if (whichactive > 0)  // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
+    {
+      if (light_scint_model)
+      {
+        light_yield = GetVisibleEnergyDeposition(aStep);  // for scintillator only, calculate light yields
+      }
+      else
+      {
+        light_yield = eion;
+      }
+      if (isfinite(light_balance_outer_radius) &&
+          isfinite(light_balance_inner_radius) &&
+          isfinite(light_balance_outer_corr) &&
+          isfinite(light_balance_inner_corr))
+      {
+        double r = sqrt(postPoint->GetPosition().x() * postPoint->GetPosition().x() + postPoint->GetPosition().y() * postPoint->GetPosition().y());
+        double cor = GetLightCorrection(r);
+        light_yield = light_yield * cor;
+      }
+    }
+
+    //sum up the energy to get total deposited
+    hit->set_edep(hit->get_edep() + edep);
+    hit->set_eion(hit->get_eion() + eion);
+    if (whichactive > 0)
+    {
+      hit->set_light_yield(hit->get_light_yield() + light_yield);
+    }
+    if (geantino)
+    {
+      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      hit->set_eion(-1);
+    }
+    if (edep > 0)
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
+      }
+    }
+
+    // if any of these conditions is true this is the last step in
+    // this volume and we need to save the hit
+    // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
+    // (happens when your detector goes outside world volume)
+    // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
+    // aTrack->GetTrackStatus() == fStopAndKill is also set)
+    // aTrack->GetTrackStatus() == fStopAndKill: track ends
+    if (postPoint->GetStepStatus() == fGeomBoundary ||
+        postPoint->GetStepStatus() == fWorldBoundary ||
+        postPoint->GetStepStatus() == fAtRestDoItProc ||
+        aTrack->GetTrackStatus() == fStopAndKill)
+    {
+      // save only hits with energy deposit (or -1 for geantino)
+      if (hit->get_edep())
+      {
+        savehitcontainer->AddHit(layer_id, hit);
+        if (saveshower)
+        {
+          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+        }
+        // ownership has been transferred to container, set to null
+        // so we will create a new hit for the next track
+        hit = nullptr;
+      }
+      else
+      {
+        // if this hit has no energy deposit, just reset it for reuse
+        // this means we have to delete it in the dtor. If this was
+        // the last hit we processed the memory is still allocated
+        hit->Reset();
+      }
+    }
+    // return true to indicate the hit was used
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 //____________________________________________________________________________..
-void PHG4InnerHcalSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+void PHG4InnerHcalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
-
   string hitnodename;
   string absorbernodename;
   if (detector_->SuperDetector() != "NONE")
-    {
-      hitnodename = "G4HIT_" + detector_->SuperDetector();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->SuperDetector();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->SuperDetector();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->SuperDetector();
+  }
   else
-    {
-      hitnodename = "G4HIT_" + detector_->GetName();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->GetName();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->GetName();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->GetName();
+  }
 
   //now look for the map and grab a pointer to it.
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
-  absorberhits_ =  findNode::getClass<PHG4HitContainer>( topNode , absorbernodename.c_str() );
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
 
   // if we do not find the node it's messed up.
-  if ( ! hits_ )
+  if (!hits_)
+  {
+    std::cout << "PHG4InnerHcalSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+  }
+  if (!absorberhits_)
+  {
+    if (verbosity > 1)
     {
-      std::cout << "PHG4InnerHcalSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+      cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
     }
-  if ( ! absorberhits_)
-    {
-      if (verbosity > 1)
-	{
-	  cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
-	}
-    }
+  }
 }
 
 double
 PHG4InnerHcalSteppingAction::GetLightCorrection(const double r) const
 {
-  double m = (light_balance_outer_corr - light_balance_inner_corr)/(light_balance_outer_radius - light_balance_inner_radius);
-  double b = light_balance_inner_corr - m*light_balance_inner_radius;
-  double value = m*r+b;  
+  double m = (light_balance_outer_corr - light_balance_inner_corr) / (light_balance_outer_radius - light_balance_inner_radius);
+  double b = light_balance_inner_corr - m * light_balance_inner_radius;
+  double value = m * r + b;
   if (value > 1.0) return 1.0;
   if (value < 0.0) return 0.0;
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -211,9 +211,9 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       savetrackid = aTrack->GetTrackID();
       //set the initial energy deposit
       hit->set_edep(0);
-      hit->set_eion(0);     // only implemented for v5 otherwise empty
       if (whichactive > 0)  // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
       {
+        hit->set_eion(0);     // only implemented for v5 otherwise empty
         hit->set_light_yield(0);  // for scintillator only, initialize light yields
         // Now save the container we want to add this hit to
         savehitcontainer = hits_;
@@ -289,9 +289,9 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
     //sum up the energy to get total deposited
     hit->set_edep(hit->get_edep() + edep);
-    hit->set_eion(hit->get_eion() + eion);
     if (whichactive > 0)
     {
+      hit->set_eion(hit->get_eion() + eion);
       hit->set_light_yield(hit->get_light_yield() + light_yield);
     }
     if (geantino)

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -41,6 +41,8 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   const PHG4Parameters *params;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
+  int savetrackid;
+  int savepoststepstatus;
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -11,28 +11,24 @@ class PHG4Shower;
 
 class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4InnerHcalSteppingAction( PHG4InnerHcalDetector*, const PHG4Parameters *parameters );
+  PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector *, const PHG4Parameters *parameters);
 
   //! destructor
   virtual ~PHG4InnerHcalSteppingAction();
 
-
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  virtual bool UserSteppingAction(const G4Step *, bool);
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers( PHCompositeNode* );
+  virtual void SetInterfacePointers(PHCompositeNode *);
 
   double GetLightCorrection(const double r) const;
 
-  private:
-
+ private:
   //! pointer to the detector
-  PHG4InnerHcalDetector* detector_;
+  PHG4InnerHcalDetector *detector_;
 
   //! pointer to hit container
   PHG4HitContainer *hits_;
@@ -51,12 +47,11 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   int IsBlackHole;
   int n_scinti_plates;
   int light_scint_model;
-  
+
   double light_balance_inner_corr;
   double light_balance_inner_radius;
   double light_balance_outer_corr;
   double light_balance_outer_radius;
 };
 
-
-#endif // PHG4InnerHcalSteppingAction_h
+#endif  // PHG4InnerHcalSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -133,6 +133,11 @@ PHG4InnerHcalSubsystem::Print(const string &what) const
     {
       detector_->Print(what);
     }
+  if (steppingAction_)
+    {
+      steppingAction_->Print(what);
+    }
+
   return;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4MapsSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsSteppingAction.cc
@@ -209,8 +209,7 @@ bool PHG4MapsSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
 	  */
 
 	  // Store the local coordinates for the entry point 
-	  // Note the typo in Coordinate is needed!
-	  StoreLocalCoorindate(hit, aStep, true, false);
+	  StoreLocalCoordinate(hit, aStep, true, false);
 	  
 	  // Store the entrance values in cm in world coordinates
 	  hit->set_x( 0, prePoint->GetPosition().x() / cm );
@@ -296,7 +295,7 @@ bool PHG4MapsSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
       */
 
       // Store the local coordinates for the exit point
-      StoreLocalCoorindate(hit, aStep, false, true);
+      StoreLocalCoordinate(hit, aStep, false, true);
 
        // Store world coordinates for the exit point
       hit->set_x( 1, postPoint->GetPosition().x() / cm );

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -238,9 +238,9 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       savetrackid = aTrack->GetTrackID();
       //set the initial energy deposit
       hit->set_edep(0);
-      hit->set_eion(0);
       if (whichactive > 0)  // return of IsInOuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
       {
+        hit->set_eion(0);
         hit->set_light_yield(0);  //  for scintillator only, initialize light yields
         // Now save the container we want to add this hit to
         savehitcontainer = hits_;
@@ -314,9 +314,9 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
     //sum up the energy to get total deposited
     hit->set_edep(hit->get_edep() + edep);
-    hit->set_eion(hit->get_eion() + eion);
     if (whichactive > 0)
     {
+      hit->set_eion(hit->get_eion() + eion);
       hit->set_light_yield(hit->get_light_yield() + light_yield);
     }
     if (geantino)

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -1,7 +1,7 @@
 // local headers in quotes (that is important when using include subdirs!)
 #include "PHG4OuterHcalSteppingAction.h"
-#include "PHG4OuterHcalDetector.h"
 #include "PHG4HcalDefs.h"
+#include "PHG4OuterHcalDetector.h"
 #include "PHG4Parameters.h"
 
 // our own headers in alphabetical order
@@ -9,8 +9,8 @@
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllServer.h>
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
@@ -36,9 +36,9 @@
 #include <boost/tokenizer.hpp>
 // this is an ugly hack, the gcc optimizer has a bug which
 // triggers the uninitialized variable warning which
-// stops compilation because of our -Werror 
-#include <boost/version.hpp> // to get BOOST_VERSION
-#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700 )
+// stops compilation because of our -Werror
+#include <boost/version.hpp>  // to get BOOST_VERSION
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700)
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #pragma message "ignoring bogus gcc warning in boost header lexical_cast.hpp"
 #include <boost/lexical_cast.hpp>
@@ -53,26 +53,25 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4OuterHcalSteppingAction::PHG4OuterHcalSteppingAction( PHG4OuterHcalDetector* detector,  const PHG4Parameters *parameters):
-  detector_( detector ),
-  hits_(nullptr),
-  absorberhits_(nullptr),
-  hit(nullptr),
-  params(parameters),
-  savehitcontainer(nullptr),
-  saveshower(nullptr),
-savetrackid(-1),
-savepoststepstatus(-1),
-  enable_field_checker(0),
-  absorbertruth(params->get_int_param("absorbertruth")),
-  IsActive(params->get_int_param("active")),
-  IsBlackHole(params->get_int_param("blackhole")),
-  n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr)*params->get_int_param("n_towers")),
-  light_scint_model(params->get_int_param("light_scint_model")),
-  light_balance_inner_corr(params->get_double_param("light_balance_inner_corr")),
-  light_balance_inner_radius(params->get_double_param("light_balance_inner_radius")*cm),
-  light_balance_outer_corr(params->get_double_param("light_balance_outer_corr")),
-  light_balance_outer_radius(params->get_double_param("light_balance_outer_radius")*cm)
+PHG4OuterHcalSteppingAction::PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector* detector, const PHG4Parameters* parameters) : detector_(detector),
+                                                                                                                              hits_(nullptr),
+                                                                                                                              absorberhits_(nullptr),
+                                                                                                                              hit(nullptr),
+                                                                                                                              params(parameters),
+                                                                                                                              savehitcontainer(nullptr),
+                                                                                                                              saveshower(nullptr),
+                                                                                                                              savetrackid(-1),
+                                                                                                                              savepoststepstatus(-1),
+                                                                                                                              enable_field_checker(0),
+                                                                                                                              absorbertruth(params->get_int_param("absorbertruth")),
+                                                                                                                              IsActive(params->get_int_param("active")),
+                                                                                                                              IsBlackHole(params->get_int_param("blackhole")),
+                                                                                                                              n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr) * params->get_int_param("n_towers")),
+                                                                                                                              light_scint_model(params->get_int_param("light_scint_model")),
+                                                                                                                              light_balance_inner_corr(params->get_double_param("light_balance_inner_corr")),
+                                                                                                                              light_balance_inner_radius(params->get_double_param("light_balance_inner_radius") * cm),
+                                                                                                                              light_balance_outer_corr(params->get_double_param("light_balance_outer_corr")),
+                                                                                                                              light_balance_outer_radius(params->get_double_param("light_balance_outer_radius") * cm)
 {
   name = detector_->GetName();
 }
@@ -86,109 +85,106 @@ PHG4OuterHcalSteppingAction::~PHG4OuterHcalSteppingAction()
   delete hit;
 }
 
-int
-PHG4OuterHcalSteppingAction::Init()
+int PHG4OuterHcalSteppingAction::Init()
 {
   enable_field_checker = GetIntOpt("FieldChecker");
   return 0;
 }
 
 //____________________________________________________________________________..
-bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
+bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
-
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   // get volume of the current step
   G4VPhysicalVolume* volume = touch->GetVolume();
 
   // detector_->IsInOuterHcal(volume)
-  // returns 
+  // returns
   //  0 is outside of OuterHcal
   //  1 is inside scintillator
   // -1 is steel absorber (if absorber set to active)
 
-  int whichactive = detector_->IsInOuterHcal(volume); 
+  int whichactive = detector_->IsInOuterHcal(volume);
 
   if (!whichactive)
-    {
-      return false;
-    }
+  {
+    return false;
+  }
 
   if (enable_field_checker)
-    {
-      FieldChecker(aStep);
-    }
-
+  {
+    FieldChecker(aStep);
+  }
 
   int layer_id = -1;
   int tower_id = -1;
-  if (whichactive > 0) // scintillator
-    {
-      // G4AssemblyVolumes naming convention:
-      //     av_WWW_impr_XXX_YYY_ZZZ
-      // where:
+  if (whichactive > 0)  // scintillator
+  {
+    // G4AssemblyVolumes naming convention:
+    //     av_WWW_impr_XXX_YYY_ZZZ
+    // where:
 
-      //     WWW - assembly volume instance number
-      //     XXX - assembly volume imprint number
-      //     YYY - the name of the placed logical volume
-      //     ZZZ - the logical volume index inside the assembly volume
-      // e.g. av_1_impr_82_HcalOuterScinti_11_pv_11
-      // 82 the number of the scintillator mother volume
-      // HcalOuterScinti_11: name of scintillator slat
-      // 11: number of scintillator slat logical volume
-      // use boost tokenizer to separate the _, then take value
-      // after "impr" for mother volume and after "pv" for scintillator slat
-      // use boost lexical cast for string -> int conversion
-      boost::char_separator<char> sep("_");
-      boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
-      boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
-      for (tokeniter = tok.begin(); tokeniter != tok.end(); ++tokeniter)
-	{
-	  if (*tokeniter == "impr")
-	    {
-	      ++tokeniter;
-	      if (tokeniter != tok.end())
-		{
-		  layer_id = boost::lexical_cast<int>(*tokeniter);
-		  // check detector description, for assemblyvolumes it is not possible
-		  // to give the first volume id=0, so they go from id=1 to id=n. 
-		  // I am not going to start with fortran again - our indices start 
-		  // at zero, id=0 to id=n-1. So subtract one here
-		  layer_id--;
-		  if (layer_id < 0 || layer_id >= n_scinti_plates)
-		    {
-		      cout << "invalid scintillator row " << layer_id
-			   << ", valid range 0 < row < " << n_scinti_plates << endl;
-		      gSystem->Exit(1);
-		    }
-		}
-	      else
-		{
-		  cout << PHWHERE << " Error parsing " << volume->GetName()
-		       << " for mother volume number " << endl;
-		  gSystem->Exit(1);
-		}
-	    }
-	  else if (*tokeniter == "pv")
-	    {
-	      ++tokeniter;
-	      if (tokeniter != tok.end())
-		{
-		  tower_id = boost::lexical_cast<int>(*tokeniter);
-		}
-	      else
-		{
-		  cout << PHWHERE << " Error parsing " << volume->GetName()
-		       << " for mother scinti slat id " << endl;
-	          gSystem->Exit(1);
-		}
-	    }
-	}
-    }
-  else
+    //     WWW - assembly volume instance number
+    //     XXX - assembly volume imprint number
+    //     YYY - the name of the placed logical volume
+    //     ZZZ - the logical volume index inside the assembly volume
+    // e.g. av_1_impr_82_HcalOuterScinti_11_pv_11
+    // 82 the number of the scintillator mother volume
+    // HcalOuterScinti_11: name of scintillator slat
+    // 11: number of scintillator slat logical volume
+    // use boost tokenizer to separate the _, then take value
+    // after "impr" for mother volume and after "pv" for scintillator slat
+    // use boost lexical cast for string -> int conversion
+    boost::char_separator<char> sep("_");
+    boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
+    boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
+    for (tokeniter = tok.begin(); tokeniter != tok.end(); ++tokeniter)
     {
-      layer_id = touch->GetCopyNumber(); // steel plate id
+      if (*tokeniter == "impr")
+      {
+        ++tokeniter;
+        if (tokeniter != tok.end())
+        {
+          layer_id = boost::lexical_cast<int>(*tokeniter);
+          // check detector description, for assemblyvolumes it is not possible
+          // to give the first volume id=0, so they go from id=1 to id=n.
+          // I am not going to start with fortran again - our indices start
+          // at zero, id=0 to id=n-1. So subtract one here
+          layer_id--;
+          if (layer_id < 0 || layer_id >= n_scinti_plates)
+          {
+            cout << "invalid scintillator row " << layer_id
+                 << ", valid range 0 < row < " << n_scinti_plates << endl;
+            gSystem->Exit(1);
+          }
+        }
+        else
+        {
+          cout << PHWHERE << " Error parsing " << volume->GetName()
+               << " for mother volume number " << endl;
+          gSystem->Exit(1);
+        }
+      }
+      else if (*tokeniter == "pv")
+      {
+        ++tokeniter;
+        if (tokeniter != tok.end())
+        {
+          tower_id = boost::lexical_cast<int>(*tokeniter);
+        }
+        else
+        {
+          cout << PHWHERE << " Error parsing " << volume->GetName()
+               << " for mother scinti slat id " << endl;
+          gSystem->Exit(1);
+        }
+      }
     }
+  }
+  else
+  {
+    layer_id = touch->GetCopyNumber();  // steel plate id
+  }
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
   G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
@@ -198,74 +194,74 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
 
   // if this block stops everything, just put all kinetic energy into edep
   if (IsBlackHole)
-    {
-      edep = aTrack->GetKineticEnergy() / GeV;
-      G4Track* killtrack = const_cast<G4Track *> (aTrack);
-      killtrack->SetTrackStatus(fStopAndKill);
-    }
+  {
+    edep = aTrack->GetKineticEnergy() / GeV;
+    G4Track* killtrack = const_cast<G4Track*>(aTrack);
+    killtrack->SetTrackStatus(fStopAndKill);
+  }
 
   // make sure we are in a volume
-  if ( IsActive )
-    {
-      bool geantino = false;
+  if (IsActive)
+  {
+    bool geantino = false;
 
-      // the check for the pdg code speeds things up, I do not want to make
-      // an expensive string compare for every track when we know
-      // geantino or chargedgeantino has pid=0
-      if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
-	  aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
-	{
-	  geantino = true;
-	}
-      G4StepPoint * prePoint = aStep->GetPreStepPoint();
-      G4StepPoint * postPoint = aStep->GetPostStepPoint();
-      //       cout << "track id " << aTrack->GetTrackID() << endl;
-      //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
-      //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
-      switch (prePoint->GetStepStatus())
-	{
-	case fGeomBoundary:
-	case fUndefined:
-	  if (! hit)
-	    {
-	      hit = new PHG4Hitv1();
-	    }
-	  hit->set_scint_id(tower_id); // the slat id (or steel plate id)
-	  //here we set the entrance values in cm
-	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
-	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
-	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
-	  // time in ns
-	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
-	  //set the track ID
-            hit->set_trkid(aTrack->GetTrackID());
-           savetrackid = aTrack->GetTrackID();
-	  //set the initial energy deposit
-	  hit->set_edep(0);
-	  hit->set_eion(0); 
-	  if (whichactive > 0) // return of IsInOuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
-	    {
-	      hit->set_light_yield(0); //  for scintillator only, initialize light yields
-	      // Now save the container we want to add this hit to
-	      savehitcontainer = hits_;
-	    }
-	  else
-	    {
-	      savehitcontainer = absorberhits_;
-	    }
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  hit->set_trkid(pp->GetUserTrackId());
-		  hit->set_shower_id(pp->GetShower()->get_id());
-		  saveshower =  pp->GetShower();
-		}
-	    }
-	  break;
-	default:
-	  break;
-	}
+    // the check for the pdg code speeds things up, I do not want to make
+    // an expensive string compare for every track when we know
+    // geantino or chargedgeantino has pid=0
+    if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
+        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
+    {
+      geantino = true;
+    }
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    //       cout << "track id " << aTrack->GetTrackID() << endl;
+    //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
+    //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
+    switch (prePoint->GetStepStatus())
+    {
+    case fGeomBoundary:
+    case fUndefined:
+      if (!hit)
+      {
+        hit = new PHG4Hitv1();
+      }
+      hit->set_scint_id(tower_id);  // the slat id (or steel plate id)
+      //here we set the entrance values in cm
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      // time in ns
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      //set the track ID
+      hit->set_trkid(aTrack->GetTrackID());
+      savetrackid = aTrack->GetTrackID();
+      //set the initial energy deposit
+      hit->set_edep(0);
+      hit->set_eion(0);
+      if (whichactive > 0)  // return of IsInOuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
+      {
+        hit->set_light_yield(0);  //  for scintillator only, initialize light yields
+        // Now save the container we want to add this hit to
+        savehitcontainer = hits_;
+      }
+      else
+      {
+        savehitcontainer = absorberhits_;
+      }
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          hit->set_trkid(pp->GetUserTrackId());
+          hit->set_shower_id(pp->GetShower()->get_id());
+          saveshower = pp->GetShower();
+        }
+      }
+      break;
+    default:
+      break;
+    }
     // some sanity checks for inconsistencies
     // check if this hit was created, if not print out last post step status
     if (!hit || !isfinite(hit->get_x(0)))
@@ -285,153 +281,149 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool 
            << endl;
       exit(1);
     }
-       // here we just update the exit values, it will be overwritten
-      // for every step until we leave the volume or the particle
-      // ceases to exist
-      hit->set_x( 1, postPoint->GetPosition().x() / cm );
-      hit->set_y( 1, postPoint->GetPosition().y() / cm );
-      hit->set_z( 1, postPoint->GetPosition().z() / cm );
+    // here we just update the exit values, it will be overwritten
+    // for every step until we leave the volume or the particle
+    // ceases to exist
+    hit->set_x(1, postPoint->GetPosition().x() / cm);
+    hit->set_y(1, postPoint->GetPosition().y() / cm);
+    hit->set_z(1, postPoint->GetPosition().z() / cm);
 
-      hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
+    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
 
-      if (whichactive > 0)
+    if (whichactive > 0)
+    {
+      if (light_scint_model)
+      {
+        light_yield = GetVisibleEnergyDeposition(aStep);
+      }
+      else
+      {
+        light_yield = eion;
+      }
+
+      if (isfinite(light_balance_outer_radius) &&
+          isfinite(light_balance_inner_radius) &&
+          isfinite(light_balance_outer_corr) &&
+          isfinite(light_balance_inner_corr))
+      {
+        double r = sqrt(postPoint->GetPosition().x() * postPoint->GetPosition().x() + postPoint->GetPosition().y() * postPoint->GetPosition().y());
+        double cor = GetLightCorrection(r);
+        light_yield = light_yield * cor;
+      }
+    }
+
+    //sum up the energy to get total deposited
+    hit->set_edep(hit->get_edep() + edep);
+    hit->set_eion(hit->get_eion() + eion);
+    if (whichactive > 0)
+    {
+      hit->set_light_yield(hit->get_light_yield() + light_yield);
+    }
+    if (geantino)
+    {
+      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      hit->set_eion(-1);
+    }
+    if (edep > 0)
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
-          if (light_scint_model)
-            {
-              light_yield = GetVisibleEnergyDeposition(aStep);
-            }
-          else
-            {
-              light_yield = eion;
-            }
-
-          if (isfinite(light_balance_outer_radius) && 
-              isfinite(light_balance_inner_radius) && 
-	      isfinite(light_balance_outer_corr) &&
-	      isfinite(light_balance_inner_corr))
-            {
-              double r = sqrt(postPoint->GetPosition().x()*postPoint->GetPosition().x()
-			    + postPoint->GetPosition().y()*postPoint->GetPosition().y());
-              double cor = GetLightCorrection(r);
-              light_yield = light_yield * cor;
-            }
+          pp->SetKeep(1);  // we want to keep the track
         }
+      }
+    }
 
-      //sum up the energy to get total deposited
-      hit->set_edep(hit->get_edep() + edep);
-      hit->set_eion(hit->get_eion() + eion);
-      if (whichactive > 0)
-	{
-	  hit->set_light_yield(hit->get_light_yield() + light_yield);
-	}
-      if (geantino)
-	{
-	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-          hit->set_eion(-1);
-	}
-      if (edep > 0)
-	{
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  pp->SetKeep(1); // we want to keep the track
-		}
-	    }
-	}
-
-      // if any of these conditions is true this is the last step in
-      // this volume and we need to save the hit
-      // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
+    // if any of these conditions is true this is the last step in
+    // this volume and we need to save the hit
+    // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
     // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
     // (happens when your detector goes outside world volume)
     // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
     // aTrack->GetTrackStatus() == fStopAndKill is also set)
     // aTrack->GetTrackStatus() == fStopAndKill: track ends
-      if (postPoint->GetStepStatus() == fGeomBoundary || 
-          postPoint->GetStepStatus() == fWorldBoundary || 
-          postPoint->GetStepStatus() == fAtRestDoItProc ||
-          aTrack->GetTrackStatus() == fStopAndKill)
-	{
-          // save only hits with energy deposit (or -1 for geantino)
-	  if (hit->get_edep())
-	    {
-	      savehitcontainer->AddHit(layer_id, hit);
-	      if (saveshower)
-		{
-		  saveshower->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		}
-	      // ownership has been transferred to container, set to null
-	      // so we will create a new hit for the next track
-	      hit = nullptr;
-	    }
-	  else
-	    {
-	      // if this hit has no energy deposit, just reset it for reuse
-	      // this means we have to delete it in the dtor. If this was
-	      // the last hit we processed the memory is still allocated
-	      hit->Reset();
-	    }
- 	}
-      // return true to indicate the hit was used
-      return true;
-
-    }
-  else
+    if (postPoint->GetStepStatus() == fGeomBoundary ||
+        postPoint->GetStepStatus() == fWorldBoundary ||
+        postPoint->GetStepStatus() == fAtRestDoItProc ||
+        aTrack->GetTrackStatus() == fStopAndKill)
     {
-      return false;
+      // save only hits with energy deposit (or -1 for geantino)
+      if (hit->get_edep())
+      {
+        savehitcontainer->AddHit(layer_id, hit);
+        if (saveshower)
+        {
+          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+        }
+        // ownership has been transferred to container, set to null
+        // so we will create a new hit for the next track
+        hit = nullptr;
+      }
+      else
+      {
+        // if this hit has no energy deposit, just reset it for reuse
+        // this means we have to delete it in the dtor. If this was
+        // the last hit we processed the memory is still allocated
+        hit->Reset();
+      }
     }
+    // return true to indicate the hit was used
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 //____________________________________________________________________________..
-void PHG4OuterHcalSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+void PHG4OuterHcalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
-
   string hitnodename;
   string absorbernodename;
   if (detector_->SuperDetector() != "NONE")
-    {
-      hitnodename = "G4HIT_" + detector_->SuperDetector();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->SuperDetector();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->SuperDetector();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->SuperDetector();
+  }
   else
-    {
-      hitnodename = "G4HIT_" + detector_->GetName();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->GetName();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->GetName();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->GetName();
+  }
 
   //now look for the map and grab a pointer to it.
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
-  absorberhits_ =  findNode::getClass<PHG4HitContainer>( topNode , absorbernodename.c_str() );
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
 
   // if we do not find the node it's messed up.
-  if ( ! hits_ )
+  if (!hits_)
+  {
+    std::cout << "PHG4OuterHcalSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+  }
+  if (!absorberhits_)
+  {
+    if (Verbosity() > 1)
     {
-      std::cout << "PHG4OuterHcalSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+      cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
     }
-  if ( ! absorberhits_)
-    {
-      if (Verbosity() > 1)
-	{
-	  cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
-	}
-    }
+  }
 }
 
-double 
+double
 PHG4OuterHcalSteppingAction::GetLightCorrection(const double r) const
 {
-  double m = (light_balance_outer_corr - light_balance_inner_corr)/(light_balance_outer_radius - light_balance_inner_radius);
-  double b = light_balance_inner_corr - m*light_balance_inner_radius;
-  double value = m*r+b;  
+  double m = (light_balance_outer_corr - light_balance_inner_corr) / (light_balance_outer_radius - light_balance_inner_radius);
+  double b = light_balance_inner_corr - m * light_balance_inner_radius;
+  double value = m * r + b;
   if (value > 1.0) return 1.0;
   if (value < 0.0) return 0.0;
 
   return value;
 }
 
-void
-PHG4OuterHcalSteppingAction::FieldChecker(const G4Step* aStep)
+void PHG4OuterHcalSteppingAction::FieldChecker(const G4Step* aStep)
 {
   Fun4AllServer* se = Fun4AllServer::instance();
   assert(se);
@@ -439,17 +431,17 @@ PHG4OuterHcalSteppingAction::FieldChecker(const G4Step* aStep)
   static const string h_field_name = "hOuterHcalField";
 
   if (not se->isHistoRegistered(h_field_name))
-    {
-      TH2F * h = new TH2F(h_field_name.c_str(), "Magnetic field (Tesla) in HCal;X (cm);Y (cm)", 2400,
-			  -300, 300, 2400, -300, 300);
+  {
+    TH2F* h = new TH2F(h_field_name.c_str(), "Magnetic field (Tesla) in HCal;X (cm);Y (cm)", 2400,
+                       -300, 300, 2400, -300, 300);
 
-      se->registerHisto(h, 1);
+    se->registerHisto(h, 1);
 
-      cout <<"PHG4OuterHcalSteppingAction::FieldChecker - make a histograme to check outer Hcal field map."<<
-	" Saved to Fun4AllServer Histo with name "<<h_field_name<<endl;
-    }
+    cout << "PHG4OuterHcalSteppingAction::FieldChecker - make a histograme to check outer Hcal field map."
+         << " Saved to Fun4AllServer Histo with name " << h_field_name << endl;
+  }
 
-  TH2F * h = dynamic_cast<TH2F *>(se->getHisto(h_field_name));
+  TH2F* h = dynamic_cast<TH2F*>(se->getHisto(h_field_name));
   assert(h);
 
   assert(aStep);
@@ -461,46 +453,46 @@ PHG4OuterHcalSteppingAction::FieldChecker(const G4Step* aStep)
 
   G4ThreeVector globPosition = aStep->GetPreStepPoint()->GetPosition();
 
-  G4double globPosVec[4] = { 0 };
-  G4double FieldValueVec[6] = { 0 };
+  G4double globPosVec[4] = {0};
+  G4double FieldValueVec[6] = {0};
 
   globPosVec[0] = globPosition.x();
   globPosVec[1] = globPosition.y();
   globPosVec[2] = globPosition.z();
   globPosVec[3] = aStep->GetPreStepPoint()->GetGlobalTime();
 
-  const Int_t binx = h->GetXaxis()->FindBin(globPosVec[0]/cm);
-  const Int_t biny = h->GetYaxis()->FindBin(globPosVec[1]/cm);
+  const Int_t binx = h->GetXaxis()->FindBin(globPosVec[0] / cm);
+  const Int_t biny = h->GetYaxis()->FindBin(globPosVec[1] / cm);
 
   if (h->GetBinContent(binx, binx) == 0)
-    { // only fille unfilled bins
+  {  // only fille unfilled bins
 
-      G4TransportationManager* transportMgr =
-	G4TransportationManager::GetTransportationManager();
-      assert(transportMgr);
+    G4TransportationManager* transportMgr =
+        G4TransportationManager::GetTransportationManager();
+    assert(transportMgr);
 
-      G4PropagatorInField* fFieldPropagator =
-	transportMgr->GetPropagatorInField();
-      assert(fFieldPropagator);
+    G4PropagatorInField* fFieldPropagator =
+        transportMgr->GetPropagatorInField();
+    assert(fFieldPropagator);
 
-      G4FieldManager* fieldMgr = fFieldPropagator->FindAndSetFieldManager(volume);
-      assert(fieldMgr);
+    G4FieldManager* fieldMgr = fFieldPropagator->FindAndSetFieldManager(volume);
+    assert(fieldMgr);
 
-      const G4Field* pField = fieldMgr->GetDetectorField();
-      assert(pField);
+    const G4Field* pField = fieldMgr->GetDetectorField();
+    assert(pField);
 
-      pField->GetFieldValue(globPosVec, FieldValueVec);
+    pField->GetFieldValue(globPosVec, FieldValueVec);
 
-      G4ThreeVector FieldValue = G4ThreeVector(FieldValueVec[0],
-					       FieldValueVec[1], FieldValueVec[2]);
+    G4ThreeVector FieldValue = G4ThreeVector(FieldValueVec[0],
+                                             FieldValueVec[1], FieldValueVec[2]);
 
-      const double B = FieldValue.mag() / tesla;
+    const double B = FieldValue.mag() / tesla;
 
-      h->SetBinContent(binx, biny, B);
+    h->SetBinContent(binx, biny, B);
 
-      cout << "PHG4OuterHcalSteppingAction::FieldChecker - " << "bin " << binx
-	   << ", " << biny << " := " << B << " Tesla @ x,y = " << globPosVec[0] / cm
-	   << "," << globPosVec[1] / cm << " cm"<<endl;
-    }
-
+    cout << "PHG4OuterHcalSteppingAction::FieldChecker - "
+         << "bin " << binx
+         << ", " << biny << " := " << B << " Tesla @ x,y = " << globPosVec[0] / cm
+         << "," << globPosVec[1] / cm << " cm" << endl;
+  }
 }

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
@@ -11,36 +11,32 @@ class PHG4Shower;
 
 class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4OuterHcalSteppingAction( PHG4OuterHcalDetector* , const PHG4Parameters *parameters);
+  PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector *, const PHG4Parameters *parameters);
 
   //! destructor
   virtual ~PHG4OuterHcalSteppingAction();
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  virtual bool UserSteppingAction(const G4Step *, bool);
 
   virtual int Init();
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers( PHCompositeNode* );
+  virtual void SetInterfacePointers(PHCompositeNode *);
 
   double GetLightCorrection(const double r) const;
 
-  void FieldChecker (const G4Step*);
-  void EnableFieldChecker(const int i=1) {enable_field_checker = i;}
-
-  private:
-
+  void FieldChecker(const G4Step *);
+  void EnableFieldChecker(const int i = 1) { enable_field_checker = i; }
+ private:
   //! pointer to the detector
-  PHG4OuterHcalDetector* detector_;
+  PHG4OuterHcalDetector *detector_;
 
   //! pointer to hit container
-  PHG4HitContainer * hits_;
-  PHG4HitContainer * absorberhits_;
+  PHG4HitContainer *hits_;
+  PHG4HitContainer *absorberhits_;
   PHG4Hit *hit;
   const PHG4Parameters *params;
   PHG4HitContainer *savehitcontainer;
@@ -57,12 +53,11 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
   int IsBlackHole;
   int n_scinti_plates;
   int light_scint_model;
-  
+
   double light_balance_inner_corr;
   double light_balance_inner_radius;
   double light_balance_outer_corr;
   double light_balance_outer_radius;
 };
 
-
-#endif // PHG4OuterHcalSteppingAction_h
+#endif  // PHG4OuterHcalSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
@@ -1,5 +1,5 @@
-#ifndef PHG4VOuterHcalSteppingAction_h
-#define PHG4VOuterHcalSteppingAction_h
+#ifndef PHG4OuterHcalSteppingAction_h
+#define PHG4OuterHcalSteppingAction_h
 
 #include <g4main/PHG4SteppingAction.h>
 
@@ -45,7 +45,8 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
   const PHG4Parameters *params;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
-
+  int savetrackid;
+  int savepoststepstatus;
   int enable_field_checker;
 
   // since getting parameters is a map search we do not want to

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
@@ -7,37 +7,37 @@
  */
 
 #include "PHG4SpacalSteppingAction.h"
-#include "PHG4SpacalDetector.h"
 #include "PHG4CylinderGeom_Spacalv3.h"
+#include "PHG4SpacalDetector.h"
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4HitDefs.h>
+#include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
 
-#include <Geant4/G4Step.hh>
 #include <Geant4/G4MaterialCutsCouple.hh>
+#include <Geant4/G4Step.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 
 #include <iostream>
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4SpacalSteppingAction::PHG4SpacalSteppingAction(PHG4SpacalDetector* detector) :
-  PHG4SteppingAction(0), 
-  detector_(detector), 
-  hits_(nullptr), 
-  absorberhits_(nullptr), 
-  hit(nullptr),
-  savehitcontainer(nullptr),
-  saveshower(nullptr),
-savetrackid(-1),
-savepoststepstatus(-1)
-{}
+PHG4SpacalSteppingAction::PHG4SpacalSteppingAction(PHG4SpacalDetector* detector) : PHG4SteppingAction(0),
+                                                                                   detector_(detector),
+                                                                                   hits_(nullptr),
+                                                                                   absorberhits_(nullptr),
+                                                                                   hit(nullptr),
+                                                                                   savehitcontainer(nullptr),
+                                                                                   saveshower(nullptr),
+                                                                                   savetrackid(-1),
+                                                                                   savepoststepstatus(-1)
+{
+}
 
 PHG4SpacalSteppingAction::~PHG4SpacalSteppingAction()
 {
@@ -49,148 +49,140 @@ PHG4SpacalSteppingAction::~PHG4SpacalSteppingAction()
 }
 
 //____________________________________________________________________________..
-bool
-PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
+bool PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
-
   // get volume of the current step
   G4VPhysicalVolume* volume =
       aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
 
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
-  G4double eion = (aStep->GetTotalEnergyDeposit()
-      - aStep->GetNonIonizingEnergyDeposit()) / GeV;
+  G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
 
   const G4Track* aTrack = aStep->GetTrack();
 
   int layer_id = detector_->get_Layer();
   // make sure we are in a volume
-  // IsInCylinderActive returns the number of the scintillator 
+  // IsInCylinderActive returns the number of the scintillator
   // slat which has fired
   int isactive = detector_->IsInCylinderActive(volume);
   if (isactive > PHG4SpacalDetector::INACTIVE)
+  {
+    bool geantino = false;
+    // the check for the pdg code speeds things up, I do not want to make
+    // an expensive string compare for every track when we know
+    // geantino or chargedgeantino has pid=0
+    if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 && aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
     {
-      bool geantino = false;
-      // the check for the pdg code speeds things up, I do not want to make 
-      // an expensive string compare for every track when we know
-      // geantino or chargedgeantino has pid=0
-      if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0
-          && aTrack->GetParticleDefinition()->GetParticleName().find("geantino")
-              != string::npos)
-        {
-          geantino = true;
-        }
-      G4StepPoint * prePoint = aStep->GetPreStepPoint();
-      G4StepPoint * postPoint = aStep->GetPostStepPoint();
-      int scint_id = -1;
+      geantino = true;
+    }
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    int scint_id = -1;
 
-      if (//
-          detector_->get_geom()->get_config() == PHG4SpacalDetector::SpacalGeom_t::kFullProjective_2DTaper //
-          or //
-      detector_->get_geom()->get_config() == PHG4SpacalDetector::SpacalGeom_t::kFullProjective_2DTaper_SameLengthFiberPerTower//
-      )
-        {
-          //SPACAL ID that is associated with towers
-          int sector_ID =0;
-          int tower_ID = 0;
-          int fiber_ID = 0;
+    if (                                                                                                                          //
+        detector_->get_geom()->get_config() == PHG4SpacalDetector::SpacalGeom_t::kFullProjective_2DTaper                          //
+        or                                                                                                                        //
+        detector_->get_geom()->get_config() == PHG4SpacalDetector::SpacalGeom_t::kFullProjective_2DTaper_SameLengthFiberPerTower  //
+        )
+    {
+      //SPACAL ID that is associated with towers
+      int sector_ID = 0;
+      int tower_ID = 0;
+      int fiber_ID = 0;
 
-          if (isactive == PHG4SpacalDetector::FIBER_CORE)
-            {
+      if (isactive == PHG4SpacalDetector::FIBER_CORE)
+      {
+        fiber_ID = prePoint->GetTouchable()->GetReplicaNumber(1);
+        tower_ID = prePoint->GetTouchable()->GetReplicaNumber(2);
+        sector_ID = prePoint->GetTouchable()->GetReplicaNumber(3);
+      }
 
-              fiber_ID = prePoint->GetTouchable()->GetReplicaNumber(1);
-              tower_ID = prePoint->GetTouchable()->GetReplicaNumber(2);
-              sector_ID  = prePoint->GetTouchable()->GetReplicaNumber(3);
+      else if (isactive == PHG4SpacalDetector::FIBER_CLADING)
+      {
+        fiber_ID = prePoint->GetTouchable()->GetReplicaNumber(0);
+        tower_ID = prePoint->GetTouchable()->GetReplicaNumber(1);
+        sector_ID = prePoint->GetTouchable()->GetReplicaNumber(2);
+      }
 
-            }
+      else if (isactive == PHG4SpacalDetector::ABSORBER)
+      {
+        tower_ID = prePoint->GetTouchable()->GetReplicaNumber(0);
+        sector_ID = prePoint->GetTouchable()->GetReplicaNumber(1);
+      }
 
-          else if (isactive == PHG4SpacalDetector::FIBER_CLADING)
-            {
-              fiber_ID = prePoint->GetTouchable()->GetReplicaNumber(0);
-              tower_ID = prePoint->GetTouchable()->GetReplicaNumber(1);
-              sector_ID  = prePoint->GetTouchable()->GetReplicaNumber(2);
-            }
-
-          else if (isactive == PHG4SpacalDetector::ABSORBER)
-            {
-              tower_ID = prePoint->GetTouchable()->GetReplicaNumber(0);
-              sector_ID  = prePoint->GetTouchable()->GetReplicaNumber(1);
-            }
-
-          // compact the tower/sector/fiber ID into 32 bit scint_id, so we could save some space for SPACAL hits
-          scint_id = PHG4CylinderGeom_Spacalv3::scint_id_coder(sector_ID, tower_ID, fiber_ID).scint_ID;
-
-        }
+      // compact the tower/sector/fiber ID into 32 bit scint_id, so we could save some space for SPACAL hits
+      scint_id = PHG4CylinderGeom_Spacalv3::scint_id_coder(sector_ID, tower_ID, fiber_ID).scint_ID;
+    }
+    else
+    {
+      // other configuraitons
+      if (isactive == PHG4SpacalDetector::FIBER_CORE)
+        scint_id = prePoint->GetTouchable()->GetReplicaNumber(2);
+      else if (isactive == PHG4SpacalDetector::FIBER_CLADING)
+        scint_id = prePoint->GetTouchable()->GetReplicaNumber(1);
       else
+        scint_id = prePoint->GetTouchable()->GetReplicaNumber(0);
+    }
+
+    //       cout << "track id " << aTrack->GetTrackID() << endl;
+    //        cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
+    //        cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
+    switch (prePoint->GetStepStatus())
+    {
+    case fGeomBoundary:
+    case fUndefined:
+      // if previous hit was saved, hit pointer was set to nullptr
+      // and we have to make a new one
+      if (!hit)
+      {
+        hit = new PHG4Hitv1();
+      }
+      hit->set_layer((unsigned int) layer_id);
+      hit->set_scint_id(scint_id);  // isactive contains the scintillator slat id
+      //here we set the entrance values in cm
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
+
+      // time in ns
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      //set the track ID
+      hit->set_trkid(aTrack->GetTrackID());
+      savetrackid = aTrack->GetTrackID();
+      //set the initial energy deposit
+      hit->set_edep(0);
+      // Now add the hit
+      if (isactive == PHG4SpacalDetector::FIBER_CORE)  // the slat ids start with zero
+      {
+        hit->set_eion(0);  // only implemented for v5 otherwise empty
+        hit->set_light_yield(0);
+        savehitcontainer = hits_;
+      }
+      else
+      {
+        savehitcontainer = absorberhits_;
+      }
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
-          // other configuraitons
-          if (isactive == PHG4SpacalDetector::FIBER_CORE)
-            scint_id = prePoint->GetTouchable()->GetReplicaNumber(2);
-          else if (isactive == PHG4SpacalDetector::FIBER_CLADING)
-            scint_id = prePoint->GetTouchable()->GetReplicaNumber(1);
-          else
-            scint_id = prePoint->GetTouchable()->GetReplicaNumber(0);
+          hit->set_trkid(pp->GetUserTrackId());
+          hit->set_shower_id(pp->GetShower()->get_id());
+          saveshower = pp->GetShower();
         }
+      }
 
-      //       cout << "track id " << aTrack->GetTrackID() << endl;
-      //        cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
-      //        cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
-      switch (prePoint->GetStepStatus())
-        {
-      case fGeomBoundary:
-      case fUndefined:
-	  // if previous hit was saved, hit pointer was set to nullptr 
-	  // and we have to make a new one
-	  if (! hit)
-	    {
-	      hit = new PHG4Hitv1();
-	    }
-        hit->set_layer((unsigned int) layer_id);
-        hit->set_scint_id(scint_id); // isactive contains the scintillator slat id
-        //here we set the entrance values in cm
-        hit->set_x(0, prePoint->GetPosition().x() / cm);
-        hit->set_y(0, prePoint->GetPosition().y() / cm);
-        hit->set_z(0, prePoint->GetPosition().z() / cm);
-
-        // time in ns
-        hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
-	//set the track ID
-	hit->set_trkid(aTrack->GetTrackID());
-           savetrackid = aTrack->GetTrackID();
-        //set the initial energy deposit
-        hit->set_edep(0);
-        // Now add the hit
-        if (isactive == PHG4SpacalDetector::FIBER_CORE) // the slat ids start with zero
-          {
-            hit->set_eion(0); // only implemented for v5 otherwise empty
-            hit->set_light_yield(0);
-	    savehitcontainer = hits_;	    
-          }
-        else
-          {
-            savehitcontainer = absorberhits_;
-          }
-	if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	  {
-	    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-	      {
-		hit->set_trkid(pp->GetUserTrackId());
-		hit->set_shower_id(pp->GetShower()->get_id());
-                saveshower =  pp->GetShower();
-	      }
-	  }
-
-        if (hit->get_z(0) > get_zmax() || hit->get_z(0) < get_zmin())
-          {
-            cout << "PHG4SpacalSteppingAction: hit outside acceptance, layer: "
-                << layer_id << endl;
-            hit->identify();
-          }
-        break;
-      default:
-        break;
-        }
+      if (hit->get_z(0) > get_zmax() || hit->get_z(0) < get_zmin())
+      {
+        cout << "PHG4SpacalSteppingAction: hit outside acceptance, layer: "
+             << layer_id << endl;
+        hit->identify();
+      }
+      break;
+    default:
+      break;
+    }
     // some sanity checks for inconsistencies
     // check if this hit was created, if not print out last post step status
     if (!hit || !isfinite(hit->get_x(0)))
@@ -210,145 +202,147 @@ PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
            << endl;
       exit(1);
     }
-       // here we just update the exit values, it will be overwritten
-      // for every step until we leave the volume or the particle
-      // ceases to exist
-      hit->set_x(1, postPoint->GetPosition().x() / cm);
-      hit->set_y(1, postPoint->GetPosition().y() / cm);
-      hit->set_z(1, postPoint->GetPosition().z() / cm);
+    // here we just update the exit values, it will be overwritten
+    // for every step until we leave the volume or the particle
+    // ceases to exist
+    hit->set_x(1, postPoint->GetPosition().x() / cm);
+    hit->set_y(1, postPoint->GetPosition().y() / cm);
+    hit->set_z(1, postPoint->GetPosition().z() / cm);
 
-      hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
-      //sum up the energy to get total deposited
-      hit->set_edep(hit->get_edep() + edep);
+    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+    //sum up the energy to get total deposited
+    hit->set_edep(hit->get_edep() + edep);
 
-      if (isactive == PHG4SpacalDetector::FIBER_CORE) // only for active areas
+    if (isactive == PHG4SpacalDetector::FIBER_CORE)  // only for active areas
+    {
+      hit->set_eion(hit->get_eion() + eion);
+
+      double light_yield = GetVisibleEnergyDeposition(aStep);
+
+      static bool once = true;
+      if (once and edep > 0)
+      {
+        once = false;
+
+        if (verbosity > 0)
         {
-          hit->set_eion(hit->get_eion() + eion);
-
-          double light_yield = GetVisibleEnergyDeposition(aStep);
-
-          static bool once = true;
-          if (once and edep > 0)
-            {
-              once = false;
-
-	      if (verbosity > 0) {
-		cout << "PHG4SpacalSteppingAction::UserSteppingAction::"
-                  //
-		     << detector_->GetName() << " - "
-		     << " use scintillating light model at each Geant4 steps. "
-		     << "First step: " << "Material = "
-		     << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetName()
-		     << ", " << "Birk Constant = "
-		     << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetIonisation()->GetBirksConstant()
-		     << "," << "edep = " << edep << ", " << "eion = " << eion
-		     << ", " << "light_yield = " << light_yield << endl;
-	      }
-	    }
-
-          hit->set_light_yield(hit->get_light_yield() + light_yield);
+          cout << "PHG4SpacalSteppingAction::UserSteppingAction::"
+               //
+               << detector_->GetName() << " - "
+               << " use scintillating light model at each Geant4 steps. "
+               << "First step: "
+               << "Material = "
+               << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetName()
+               << ", "
+               << "Birk Constant = "
+               << aTrack->GetMaterialCutsCouple()->GetMaterial()->GetIonisation()->GetBirksConstant()
+               << ","
+               << "edep = " << edep << ", "
+               << "eion = " << eion
+               << ", "
+               << "light_yield = " << light_yield << endl;
         }
+      }
 
-      if (hit->get_z(1) > get_zmax() || hit->get_z(1) < get_zmin())
+      hit->set_light_yield(hit->get_light_yield() + light_yield);
+    }
+
+    if (hit->get_z(1) > get_zmax() || hit->get_z(1) < get_zmin())
+    {
+      cout << "PHG4SpacalSteppingAction: hit outside acceptance get_zmin() "
+           << get_zmin() << ", get_zmax() " << get_zmax() << " at exit"
+           << endl;
+      hit->identify();
+    }
+    if (geantino)
+    {
+      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+                          //          hit->set_eion(-1);
+    }
+    if (edep > 0)
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
-          cout << "PHG4SpacalSteppingAction: hit outside acceptance get_zmin() "
-              << get_zmin() << ", get_zmax() " << get_zmax() << " at exit"
-              << endl;
-          hit->identify();
+          pp->SetKeep(1);  // we want to keep the track
         }
-      if (geantino)
-        {
-          hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-//          hit->set_eion(-1);
-        }
-      if (edep > 0)
-        {
-          if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
-            {
-              if (PHG4TrackUserInfoV1* pp =
-                  dynamic_cast<PHG4TrackUserInfoV1*>(p))
-                {
-                  pp->SetKeep(1); // we want to keep the track
-                }
-            }
-        }
-      // if any of these conditions is true this is the last step in
-      // this volume and we need to save the hit
-      // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
+      }
+    }
+    // if any of these conditions is true this is the last step in
+    // this volume and we need to save the hit
+    // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
     // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
     // (happens when your detector goes outside world volume)
-      // aTrack->GetTrackStatus() == fStopAndKill: track ends
-      if (postPoint->GetStepStatus() == fGeomBoundary || 
-          postPoint->GetStepStatus() == fWorldBoundary || 
-          postPoint->GetStepStatus() == fAtRestDoItProc ||
-          aTrack->GetTrackStatus() == fStopAndKill)
-	{
-          // save only hits with energy deposit (or -1 for geantino)
-	  if (hit->get_edep())
-	    {
-	      savehitcontainer->AddHit(layer_id, hit);
-	      if (saveshower)
-		{
-		  saveshower->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		}
-	      // ownership has been transferred to container, set to null
-	      // so we will create a new hit for the next track
-	      hit = nullptr;
-	    }
-	  else
-	    {
-	      // if this hit has no energy deposit, just reset it for reuse
-	      // this means we have to delete it in the dtor. If this was
-	      // the last hit we processed the memory is still allocated
-	      hit->Reset();
-	    }
- 	}
-      // return true to indicate the hit was used
-      return true;
-
-    }
-  else
+    // aTrack->GetTrackStatus() == fStopAndKill: track ends
+    if (postPoint->GetStepStatus() == fGeomBoundary ||
+        postPoint->GetStepStatus() == fWorldBoundary ||
+        postPoint->GetStepStatus() == fAtRestDoItProc ||
+        aTrack->GetTrackStatus() == fStopAndKill)
     {
-      return false;
+      // save only hits with energy deposit (or -1 for geantino)
+      if (hit->get_edep())
+      {
+        savehitcontainer->AddHit(layer_id, hit);
+        if (saveshower)
+        {
+          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+        }
+        // ownership has been transferred to container, set to null
+        // so we will create a new hit for the next track
+        hit = nullptr;
+      }
+      else
+      {
+        // if this hit has no energy deposit, just reset it for reuse
+        // this means we have to delete it in the dtor. If this was
+        // the last hit we processed the memory is still allocated
+        hit->Reset();
+      }
     }
+    // return true to indicate the hit was used
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 //____________________________________________________________________________..
-void
-PHG4SpacalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
+void PHG4SpacalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
-
   string hitnodename;
   string absorbernodename;
   if (detector_->SuperDetector() != "NONE")
-    {
-      hitnodename = "G4HIT_" + detector_->SuperDetector();
-      absorbernodename = "G4HIT_ABSORBER_" + detector_->SuperDetector();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->SuperDetector();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->SuperDetector();
+  }
   else
-    {
-      hitnodename = "G4HIT_" + detector_->GetName();
-      absorbernodename = "G4HIT_ABSORBER_" + detector_->GetName();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->GetName();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->GetName();
+  }
 
   //now look for the map and grab a pointer to it.
   hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode,
-      absorbernodename.c_str());
+                                                       absorbernodename.c_str());
   // if we do not find the node we need to make it.
   if (!hits_)
+  {
+    std::cout << "PHG4SpacalSteppingAction::SetTopNode - unable to find "
+              << hitnodename << std::endl;
+  }
+  if (!absorberhits_)
+  {
+    if (verbosity > 1)
     {
       std::cout << "PHG4SpacalSteppingAction::SetTopNode - unable to find "
-          << hitnodename << std::endl;
+                << absorbernodename << std::endl;
     }
-  if (!absorberhits_)
-    {
-      if (verbosity > 1)
-        {
-          std::cout << "PHG4SpacalSteppingAction::SetTopNode - unable to find "
-              << absorbernodename << std::endl;
-        }
-    }
+  }
 }
 
 double

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
@@ -20,22 +20,20 @@ class PHG4Shower;
 
 class PHG4SpacalSteppingAction : public PHG4SteppingAction
 {
-
-public:
-
+ public:
   //! constructor
-  PHG4SpacalSteppingAction(PHG4SpacalDetector*);
+  PHG4SpacalSteppingAction(PHG4SpacalDetector *);
 
   //! destroctor
   virtual ~PHG4SpacalSteppingAction();
 
   //! stepping action
   virtual bool
-  UserSteppingAction(const G4Step*, bool);
+  UserSteppingAction(const G4Step *, bool);
 
   //! reimplemented from base class
   virtual void
-  SetInterfacePointers(PHCompositeNode*);
+  SetInterfacePointers(PHCompositeNode *);
 
   double
   get_zmin();
@@ -43,20 +41,18 @@ public:
   double
   get_zmax();
 
-private:
-
+ private:
   //! pointer to the detector
-  PHG4SpacalDetector* detector_;
+  PHG4SpacalDetector *detector_;
 
-//! pointer to hit container
-  PHG4HitContainer * hits_;
-  PHG4HitContainer * absorberhits_;
+  //! pointer to hit container
+  PHG4HitContainer *hits_;
+  PHG4HitContainer *absorberhits_;
   PHG4Hit *hit;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
   int savetrackid;
   int savepoststepstatus;
-
 };
 
-#endif // PHG4VHcalSteppingAction_h
+#endif  // PHG4VHcalSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
@@ -54,6 +54,8 @@ private:
   PHG4Hit *hit;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
+  int savetrackid;
+  int savepoststepstatus;
 
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -13,7 +13,6 @@
 #include "PHG4CylinderGeom.h"
 #include "PHG4CylinderGeomContainer.h"
 #include "PHG4SpacalSteppingAction.h"
-#include "PHG4EventActionClearZeroEdep.h"
 
 #include <g4main/PHG4Utils.h>
 #include <g4main/PHG4PhenixDetector.h>
@@ -29,9 +28,8 @@ using namespace std;
 
 //_______________________________________________________________________
 PHG4SpacalSubsystem::PHG4SpacalSubsystem( const std::string &na, const int lyr):
-  detector_( NULL ),
-  steppingAction_( NULL ),
-  eventAction_(NULL),
+  detector_( nullptr ),
+  steppingAction_( nullptr ),
   active(0),
   absorberactive(0),
   layer(lyr),
@@ -111,7 +109,6 @@ int PHG4SpacalSubsystem::InitRun( PHCompositeNode* topNode )
           dstNode->addNode( new PHIODataNode<PHObject>( cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject" ));
         }
       cylinder_hits->AddLayer(layer);
-      PHG4EventActionClearZeroEdep *evtac = new PHG4EventActionClearZeroEdep(topNode, nodename.str());
       if (absorberactive)
         {
           nodename.str("");
@@ -129,9 +126,7 @@ int PHG4SpacalSubsystem::InitRun( PHCompositeNode* topNode )
               dstNode->addNode( new PHIODataNode<PHObject>( cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject" ));
             }
           cylinder_hits->AddLayer(layer);
-          evtac->AddNode(nodename.str());
         }
-      eventAction_ = evtac;
       steppingAction_ = new PHG4SpacalSteppingAction(detector_);
     }
    return 0;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.h
@@ -18,7 +18,6 @@
 
 class PHG4SpacalDetector;
 class PHG4SpacalSteppingAction;
-class PHG4EventAction;
 
 class PHG4SpacalSubsystem : public PHG4Subsystem
 {
@@ -58,11 +57,6 @@ public:
   virtual PHG4SteppingAction*
   GetSteppingAction(void) const;
 
-  PHG4EventAction*
-  GetEventAction() const
-  {
-    return eventAction_;
-  }
   void
   SetLengthViaRapidityCoverage(const G4bool bl)
   {
@@ -123,8 +117,6 @@ private:
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
   PHG4SpacalSteppingAction* steppingAction_;
-
-  PHG4EventAction *eventAction_;
 
   int active;
   int absorberactive;

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -819,22 +819,6 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   CF4->AddElement(C, natoms = 1);
   CF4->AddElement(F, natoms = 4);
 
-  // radiation length Al = 8.897cm, magnet diameter 20cm
-  // this is 1 radlen of al spread over the magnet by
-  // weighting its density
-  G4double z;
-  G4double a;
-  G4Material *almag =
-    new G4Material("AL_MAG", z = 13., a = 26.98 * g / mole, density = (2.7 * g / cm3) * 8.897 / 20);
-  // Babar magnet thickness, still 1X0
-  G4Material *albabarmag =
-    new G4Material("AL_BABAR_MAG", z = 13., a = 26.98 * g / mole, density = (2.7 * g / cm3) * 8.897 / 33);
-  if (verbosity > 1)
-    {
-      cout << "adding " << almag->GetName() << endl;
-      cout << "adding " << albabarmag->GetName() << endl;
-    }
-
     {
       //! ePHENIX TPC - Jin Huang <jhuang@bnl.gov>
       //! Ref: B. Yu et al. A gem based tpc for the legs experiment. In Nuclear Science Symposium

--- a/simulation/g4simulation/g4main/PHG4SteppingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4SteppingAction.cc
@@ -116,8 +116,8 @@ PHG4SteppingAction::GetVisibleEnergyDeposition(const G4Step* step)
 }
 
 void
-PHG4SteppingAction::StoreLocalCoorindate(PHG4Hit * hit, const G4Step* aStep,
-    bool do_prepoint, bool do_postpoint)
+PHG4SteppingAction::StoreLocalCoordinate(PHG4Hit * hit, const G4Step* aStep,
+    const bool do_prepoint, const bool do_postpoint)
 {
   assert(hit);
   assert(aStep);

--- a/simulation/g4simulation/g4main/PHG4SteppingAction.h
+++ b/simulation/g4simulation/g4main/PHG4SteppingAction.h
@@ -14,7 +14,8 @@ class PHG4SteppingAction
 
   public:
   PHG4SteppingAction( const int i = 0 ):
-    verbosity(i)
+    verbosity(i),
+    name("NONAME")
   {}
 
   virtual ~PHG4SteppingAction()
@@ -40,7 +41,7 @@ class PHG4SteppingAction
   virtual double GetVisibleEnergyDeposition(const G4Step* step);
 
   //! Extract local coordinate of the hit and save to PHG4Hit
-  virtual void StoreLocalCoorindate(PHG4Hit * hit, const G4Step* step, bool do_prepoint, bool do_postpoint);
+  virtual void StoreLocalCoordinate(PHG4Hit * hit, const G4Step* step, const bool do_prepoint, const bool do_postpoint);
 
   virtual void SetInterfacePointers( PHCompositeNode* ) {return;}
 
@@ -49,11 +50,12 @@ class PHG4SteppingAction
   void SetOpt(const std::string &name, const int i) {opt_int[name] = i;}
   bool IntOptExist(const std::string &name);
   int GetIntOpt(const std::string &name);
+  std::string GetName() const {return name;}
  protected:
   int verbosity;
+  std::string name;
 
  private:
-
   std::set<std::string> _ScintLightYieldMissingMaterial;
   std::map<std::string, int> opt_int;
 


### PR DESCRIPTION
This should not make a difference, the track status seems to be stopandkill which is another condition for saving a hit. Add some sanity checks if the hits are not scrambled (track id does not change, hit is initialized when it is updated). Try new formatting using clang-format, added .clang-format in top dir so 
clang-format -style=file -i <file>
reformats the file using our style conventions
Now for cylinders the deposited ionization energy is also stored (and optional with flag the light yield). For the hcals the deposited ionization is not saved anymore for the absorber which should lead to some space saving