### PR TITLE
Added ability to use Pythia6 Tunes, Jet trigger for comparison with Pythia8

### DIFF
--- a/generators/PHPythia6/Makefile.am
+++ b/generators/PHPythia6/Makefile.am
@@ -17,13 +17,17 @@ libPHPythia6_la_LDFLAGS = ${AM_LDFLAGS} `root-config --libs`
 
 libPHPythia6_la_LIBADD = \
   -lphool -lSubsysReco -lfun4all -lPythia6 -lEG -lEGPythia6 \
-  -lphhepmc -lHepMC -lHepMCfio -lgsl -lgslcblas
+  -lphhepmc -lHepMC -lHepMCfio -lgsl -lgslcblas -lfastjet \
+  -lCGAL
+
 
 libPHPythia6_la_SOURCES = \
   PHPythia6.C \
   PHPythia6_Dict.C \
   PHPy6GenTrigger.C \
   PHPy6GenTrigger.h \
+  PHPy6JetTrigger.C \
+  PHPy6JetTrigger.h \
   PHPy6ForwardElectronTrig.C \
   PHPy6ForwardElectronTrig.h \
   PHPy6ParticleTrigger.C \
@@ -49,6 +53,7 @@ testexternals.C:
 PHPythia6_Dict.C: \
   PHPythia6.h \
   PHPy6GenTrigger.h \
+  PHPy6JetTrigger.h \
   PHPy6ForwardElectronTrig.h \
   PHPy6ParticleTrigger.h \
   PHPythia6LinkDef.h

--- a/generators/PHPythia6/PHPy6JetTrigger.C
+++ b/generators/PHPythia6/PHPy6JetTrigger.C
@@ -1,0 +1,123 @@
+
+#include "PHPy6GenTrigger.h"
+#include "PHPy6JetTrigger.h"
+#include <phool/PHCompositeNode.h>
+#include <phool/phool.h>
+#include <phool/getClass.h>
+
+#include <phhepmc/PHHepMCGenEvent.h>
+#include <HepMC/GenEvent.h>
+
+// fastjet includes
+#include <fastjet/JetDefinition.hh>
+#include <fastjet/PseudoJet.hh>
+#include <fastjet/ClusterSequence.hh>
+#include <fastjet/SISConePlugin.hh>
+#include <cassert>
+
+using namespace std;
+
+//__________________________________________________________
+PHPy6JetTrigger::PHPy6JetTrigger(const std::string &name):
+  PHPy6GenTrigger(name),
+  _theEtaHigh(4.0),
+  _theEtaLow(1.0),
+  _minPt(10.0),
+  _R(1.0)
+ {}
+
+PHPy6JetTrigger::~PHPy6JetTrigger() {
+  if (_verbosity > 0) PrintConfig();
+}
+
+bool PHPy6JetTrigger::Apply(const HepMC::GenEvent* evt) {
+
+  
+  // Loop over all particles in the event
+  int idx = 0; 
+  std::vector<fastjet::PseudoJet> pseudojets;
+  for ( HepMC::GenEvent::particle_const_iterator p 
+	  = evt->particles_begin(); p != evt->particles_end(); ++p ){
+	
+    idx++; 
+    if ( ((*p)->status()!=1) != 0) continue; 
+      
+    // remove some particles (muons, taus, neutrinos)...
+    // 12 == nu_e
+    // 13 == muons
+    // 14 == nu_mu
+    // 15 == taus
+    // 16 == nu_tau
+    if ((abs(((*p)->pdg_id())) >= 12) && (abs(((*p)->pdg_id())) <= 16)) continue;
+    
+    // acceptance... _etamin,_etamax
+    if (((*p)->momentum().px() == 0.0) && ((*p)->momentum().py() == 0.0)) continue; // avoid pt=0
+    if ( (((*p)->momentum().pseudoRapidity()) < _theEtaLow) ||
+	  (((*p)->momentum().pseudoRapidity()) > _theEtaHigh)) continue;
+
+
+    fastjet::PseudoJet pseudojet ((*p)->momentum().px(),
+				  (*p)->momentum().py(),
+				  (*p)->momentum().pz(),
+				  (*p)->momentum().e());
+    pseudojet.set_user_index(idx);
+    pseudojets.push_back(pseudojet);
+
+  }
+
+  // Call FastJet
+
+  fastjet::JetDefinition *jetdef = new fastjet::JetDefinition(fastjet::antikt_algorithm,_R, fastjet::E_scheme,fastjet::Best);
+  fastjet::ClusterSequence jetFinder(pseudojets,*jetdef);
+  std::vector<fastjet::PseudoJet> fastjets = jetFinder.inclusive_jets();
+  delete jetdef;
+
+  bool jetFound = false; 
+  double max_pt = -1;
+  for (unsigned int ijet = 0; ijet < fastjets.size(); ++ijet) {
+
+      const double pt =  sqrt(pow(fastjets[ijet].px(),2) + pow(fastjets[ijet].py(),2));
+
+      if (pt > max_pt) max_pt = pt;
+
+    if(pt > _minPt){
+      jetFound = true; 
+      break; 
+    }
+  }
+
+  if (_verbosity > 2) {
+    cout << "PHPy6JetTrigger::Apply - max_pt = "<<max_pt<<", and jetFound = "<<jetFound<<endl;
+  }
+
+  return jetFound;
+}
+  
+void PHPy6JetTrigger::SetEtaHighLow(double etaHigh, double etaLow) {
+
+  _theEtaHigh = etaHigh;
+  _theEtaLow = etaLow;
+
+  if (_theEtaHigh<_theEtaLow)
+    {
+      swap(_theEtaHigh, _theEtaLow);
+    }
+
+}
+
+void PHPy6JetTrigger::SetMinJetPt(double minPt) {
+  _minPt = minPt; 
+}
+
+void PHPy6JetTrigger::SetJetR(double R) {
+  _R = R; 
+}
+
+void PHPy6JetTrigger::PrintConfig() {
+  cout << "---------------- PHPy6JetTrigger::PrintConfig --------------------" << endl;
+
+  cout << "   Particles EtaCut:  " << _theEtaLow << " < eta < " << _theEtaHigh << endl; 
+  cout << "   Minimum Jet pT: " << _minPt << " GeV/c" << endl; 
+  cout << "   Anti-kT Radius: " << _R << endl; 
+  cout << "-----------------------------------------------------------------------" << endl;
+}

--- a/generators/PHPythia6/PHPy6JetTrigger.h
+++ b/generators/PHPythia6/PHPy6JetTrigger.h
@@ -1,0 +1,40 @@
+#ifndef __PHPY6JETTRIGGER_H__
+#define __PHPY6JETTRIGGER_H__
+
+#include "PHPy6GenTrigger.h"
+#include <HepMC/GenEvent.h>
+#include <string>
+
+namespace HepMC
+{
+  class GenEvent;
+};
+
+
+class PHPy6JetTrigger : public PHPy6GenTrigger {
+
+ public:
+
+  PHPy6JetTrigger(const std::string &name = "PHPy6JetTrigger");
+  virtual ~PHPy6JetTrigger();
+
+  #ifndef __CINT__
+  bool Apply(const HepMC::GenEvent* evt);
+  #endif
+
+  void SetEtaHighLow(double etaHigh, double etaLow);
+  void SetMinJetPt(double minPt);
+  void SetJetR(double R);
+
+  void PrintConfig();
+
+ private:
+
+  double _theEtaHigh;
+  double _theEtaLow;
+  double _minPt; 
+  double _R; 
+
+};
+
+#endif	

--- a/generators/PHPythia6/PHPythia6.C
+++ b/generators/PHPythia6/PHPythia6.C
@@ -35,6 +35,9 @@
 #include <algorithm>
 #include <cctype>
 
+#define pytune pytune_
+extern "C" int  pytune(int *itune);
+
 using namespace std;
 
 typedef PHIODataNode<PHObject> PHObjectNode_t;
@@ -307,6 +310,13 @@ int PHPythia6::ReadConfig(const string cfg_file) {
       
       pydat2.pmas[index-1][idc-1] = value; 
       cout << "pmas\t" << idc << " " << index << " " << value << endl;
+    }
+    else if ( label == "pytune" )
+    {
+      int ivalue; 
+      line >> ivalue;
+      pytune(&ivalue);
+      cout << "pytune\t" << ivalue << endl;
     }
      else
       {

--- a/generators/PHPythia6/PHPythia6LinkDef.h
+++ b/generators/PHPythia6/PHPythia6LinkDef.h
@@ -2,6 +2,7 @@
 
 #pragma link C++ class PHPythia6-!;
 #pragma link C++ class PHPy6GenTrigger-!;
+#pragma link C++ class PHPy6JetTrigger-!;
 #pragma link C++ class PHPy6ForwardElectronTrig-!;
 #pragma link C++ class PHPy6ParticleTrigger-!;
 


### PR DESCRIPTION
Added the ability to use the "pytune" card in the pythia6 configuration file.  This allows use to run TuneA, which is a fair match at RHIC kinematics. 

Added a jet trigger which is the same functionality at the jet trigger in the PhPythia8 repository.  This will allow Pythia8 and Pythia6 comparisons on an equal footing. 
