### PR TITLE
patch to solve ambiguity in error_rphi for cluster

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -992,7 +992,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float ey       = sqrt(cluster->get_error(1,1));
 	float ez       = cluster->get_z_error();
 
-	float ephi     = cluster->get_phi_error();
+	float ephi     = cluster->get_rphi_error();
 	
 	float e        = cluster->get_e();
 	float adc      = cluster->get_adc();
@@ -1154,7 +1154,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  float ey       = sqrt(cluster->get_error(1,1));
 	  float ez       = cluster->get_z_error();
 
-	  float ephi     = cluster->get_phi_error();
+	  float ephi     = cluster->get_rphi_error();
 	  
 	  float e        = cluster->get_e();
 	  float adc      = cluster->get_adc();

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -403,7 +403,7 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
 	  ERR[0][1] = 0.0;
 	  ERR[0][2] = 0.0;
 	  ERR[1][0] = 0.0;
-	  ERR[1][1] = pp_err/radius*pp_err/radius; //cluster_v1 expects polar coordinates covariance
+	  ERR[1][1] = pp_err*pp_err; //cluster_v1 expects rad, arc, z as elementsof covariance
 	  ERR[1][2] = 0.0;
 	  ERR[2][0] = 0.0;
 	  ERR[2][1] = 0.0;

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
@@ -1067,7 +1067,7 @@ std::shared_ptr<PHGenFit::Track> PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNo
 		}
 
 		PHGenFit::Measurement* meas = new PHGenFit::PlanarMeasurement(pos, n,
-				cluster->get_phi_error(), cluster->get_z_error());
+				cluster->get_rphi_error(), cluster->get_z_error());
 
 //		TMatrixF cov_uvn(3,3);
 //		TMatrixF cov_xyz(3,3);
@@ -1081,7 +1081,7 @@ std::shared_ptr<PHGenFit::Track> PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNo
 //		cov_uvn[0][2] = 0.;
 //
 //		cov_uvn[1][0] = 0.;
-//		cov_uvn[1][1] = cluster->get_phi_error()*cluster->get_phi_error();
+//		cov_uvn[1][1] = cluster->get_rphi_error()*cluster->get_rphi_error();
 //		cov_uvn[1][2] = 0.;
 //
 //		cov_uvn[2][0] = 0.;

--- a/simulation/g4simulation/g4hough/SvtxCluster.h
+++ b/simulation/g4simulation/g4hough/SvtxCluster.h
@@ -80,6 +80,7 @@ public:
   virtual float        get_z_size() const {return NAN;}
 
   virtual float        get_phi_error() const {return NAN;}
+  virtual float        get_rphi_error() const {return NAN;}
   virtual float        get_z_error() const {return NAN;}
 
 protected:

--- a/simulation/g4simulation/g4hough/SvtxCluster_v1.C
+++ b/simulation/g4simulation/g4hough/SvtxCluster_v1.C
@@ -151,6 +151,12 @@ float SvtxCluster_v1::get_z_size() const {
 }
 
 float SvtxCluster_v1::get_phi_error() const {
+  float rad = sqrt(_pos[0]*_pos[0] + _pos[1]*_pos[1]);
+  if(rad>0) return get_rphi_error()/rad;
+  return 0;
+}
+
+float SvtxCluster_v1::get_rphi_error() const {
 
   TMatrixF COVAR(3,3);
   for (unsigned int i=0; i<3; ++i) {

--- a/simulation/g4simulation/g4hough/SvtxCluster_v1.h
+++ b/simulation/g4simulation/g4hough/SvtxCluster_v1.h
@@ -74,6 +74,7 @@ public:
   float        get_phi_size() const;
   float        get_z_size() const;
 
+  float        get_rphi_error() const;
   float        get_phi_error() const;
   float        get_z_error() const;
   
@@ -87,7 +88,7 @@ private:
   float _e;                        //< cluster energy
   unsigned int _adc;               //< cluster sum adc
   float _size[6];                  //< size covariance matrix (packed storage) (+/- cm^2)
-  float _err[6];                   //< size covariance matrix (packed storage) (+/- cm^2)
+  float _err[6];                   //< covariance matrix: rad, arc and z
   std::set<unsigned int> _hit_ids; //< list of cell hit ids 
   
   ClassDef(SvtxCluster_v1, 1);


### PR DESCRIPTION
Creating new function get_rphi_error() to return error in rphi measurement.

Changing get_phi_error() to get_rphi_error() for evaluator and kalmanFitter, since the intention in that code is to use the error of rphi and not the error of phi.

TPCClusterer now returns rphi as element of covariance (previously was phi).
