### PR TITLE
Initial commit of calo trigger emulator and info node.

### DIFF
--- a/offline/packages/trigger/CaloTriggerInfo.C
+++ b/offline/packages/trigger/CaloTriggerInfo.C
@@ -1,0 +1,21 @@
+#include "CaloTriggerInfo.h"
+
+ClassImp(CaloTriggerInfo)
+
+CaloTriggerInfo::CaloTriggerInfo()
+{
+  _EMCAL_4x4_BEST_E = 0;
+  _EMCAL_4x4_BEST_ETA = 0;
+  _EMCAL_4x4_BEST_PHI = 0;
+}
+
+CaloTriggerInfo::~CaloTriggerInfo()
+{
+}
+
+void CaloTriggerInfo::identify(ostream& os) const
+{
+  os << "CaloTriggerInfo: highest 2x2 eta/phi = " << _EMCAL_4x4_BEST_ETA << " / " << _EMCAL_4x4_BEST_PHI << ", E = " << _EMCAL_4x4_BEST_E << std::endl;
+
+  return;
+}

--- a/offline/packages/trigger/CaloTriggerInfo.h
+++ b/offline/packages/trigger/CaloTriggerInfo.h
@@ -2,8 +2,6 @@
 #define __CALOTRIGGERINFO_H__
 
 #include <phool/PHObject.h>
-#include <iostream>
-#include <map>
 
 class CaloTriggerInfo : public PHObject
 {

--- a/offline/packages/trigger/CaloTriggerInfo.h
+++ b/offline/packages/trigger/CaloTriggerInfo.h
@@ -1,0 +1,41 @@
+#ifndef __CALOTRIGGERINFO_H__
+#define __CALOTRIGGERINFO_H__
+
+#include <phool/PHObject.h>
+#include <iostream>
+#include <map>
+
+class CaloTriggerInfo : public PHObject
+{
+ public:
+  CaloTriggerInfo();
+  virtual ~CaloTriggerInfo();
+
+  void identify(std::ostream &os = std::cout) const;
+  void Reset() {}
+  int isValid() const { return 1; }
+  void set_best_2x2_E(float E) { _EMCAL_2x2_BEST_E = E; }
+  void set_best_2x2_eta(float eta) { _EMCAL_2x2_BEST_ETA = eta; }
+  void set_best_2x2_phi(float phi) { _EMCAL_2x2_BEST_PHI = phi; }
+  float get_best_2x2_E() { return _EMCAL_2x2_BEST_E; }
+  float get_best_2x2_eta() { return _EMCAL_2x2_BEST_ETA; }
+  float get_best_2x2_phi() { return _EMCAL_2x2_BEST_PHI; }
+  void set_best_4x4_E(float E) { _EMCAL_4x4_BEST_E = E; }
+  void set_best_4x4_eta(float eta) { _EMCAL_4x4_BEST_ETA = eta; }
+  void set_best_4x4_phi(float phi) { _EMCAL_4x4_BEST_PHI = phi; }
+  float get_best_4x4_E() { return _EMCAL_4x4_BEST_E; }
+  float get_best_4x4_eta() { return _EMCAL_4x4_BEST_ETA; }
+  float get_best_4x4_phi() { return _EMCAL_4x4_BEST_PHI; }
+ private:
+  float _EMCAL_2x2_BEST_E;
+  float _EMCAL_2x2_BEST_ETA;
+  float _EMCAL_2x2_BEST_PHI;
+
+  float _EMCAL_4x4_BEST_E;
+  float _EMCAL_4x4_BEST_ETA;
+  float _EMCAL_4x4_BEST_PHI;
+
+  ClassDef(CaloTriggerInfo, 1);
+};
+
+#endif  // __CALOTRIGGERINFO_H__

--- a/offline/packages/trigger/CaloTriggerInfoLinkDef.h
+++ b/offline/packages/trigger/CaloTriggerInfoLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class CaloTriggerInfo+;
+
+#endif /* __CINT__ */

--- a/offline/packages/trigger/CaloTriggerSim.C
+++ b/offline/packages/trigger/CaloTriggerSim.C
@@ -1,0 +1,333 @@
+#include "CaloTriggerSim.h"
+
+// PHENIX includes
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHTypedNodeIterator.h>
+#include <phool/getClass.h>
+
+// sPHENIX includes
+#include <g4cemc/RawTower.h>
+#include <g4cemc/RawTowerContainer.h>
+#include <g4cemc/RawTowerGeom.h>
+#include <g4cemc/RawTowerGeomContainer_Cylinderv1.h>
+
+#include "CaloTriggerInfo.h"
+
+// standard includes
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+CaloTriggerSim::CaloTriggerSim(const std::string &name)
+  : SubsysReco(name)
+{
+  // initiate sizes as -1 to tell module they can be set when it sees
+  // the EMCal geometry for the first time
+
+  _EMCAL_1x1_NETA = -1;
+  _EMCAL_1x1_NPHI = -1;
+
+  _EMCAL_2x2_NETA = -1;
+  _EMCAL_2x2_NPHI = -1;
+
+  _EMCAL_4x4_NETA = -1;
+  _EMCAL_4x4_NPHI = -1;
+
+  // these get cleared every event, but clear them at the
+  // initiatlization step just in case
+
+  _EMCAL_2x2_BEST_E = 0;
+  _EMCAL_2x2_BEST_PHI = 0;
+  _EMCAL_2x2_BEST_ETA = 0;
+
+  _EMCAL_4x4_BEST_E = 0;
+  _EMCAL_4x4_BEST_PHI = 0;
+  _EMCAL_4x4_BEST_ETA = 0;
+}
+
+CaloTriggerSim::~CaloTriggerSim()
+{
+}
+
+int CaloTriggerSim::Init(PHCompositeNode *topNode)
+{
+  if (verbosity > 0)
+    std::cout << "CaloTriggerSim::Init: initialized" << std::endl;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CaloTriggerSim::InitRun(PHCompositeNode *topNode)
+{
+  return CreateNode(topNode);
+}
+
+int CaloTriggerSim::process_event(PHCompositeNode *topNode)
+{
+  if (verbosity > 0)
+    std::cout << "CaloTriggerSim::process_event: entering" << std::endl;
+
+  RawTowerContainer *towersEM3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC");
+  if (verbosity > 0)
+    std::cout << "CaloTriggerSim::process_event: " << towersEM3->size() << " TOWER_CALIB_CEMC towers" << std::endl;
+
+  // get the binning from the geometry (different for 1D vs 2D...)
+  RawTowerGeomContainer_Cylinderv1 *geomEM = findNode::getClass<RawTowerGeomContainer_Cylinderv1>(topNode, "TOWERGEOM_CEMC");
+  int geom_etabins = geomEM->get_etabins();
+  int geom_phibins = geomEM->get_phibins();
+
+  // if internal knowledge of geometry is unset, set it now (should
+  // only happen once, on the first event)
+  if (_EMCAL_1x1_NETA < 0)
+  {
+    _EMCAL_1x1_NETA = geom_etabins;
+    _EMCAL_1x1_NPHI = geom_phibins;
+
+    // half as many 2x2 windows along each axis as 1x1
+    _EMCAL_2x2_NETA = geom_etabins / 2;
+    _EMCAL_2x2_NPHI = geom_phibins / 2;
+
+    // each 2x2 window defines a 4x4 window for which that 2x2 window
+    // is the upper-left corner, so there are as many 4x4's as 2x2's
+    // (except in eta, where the edge effect means there is 1 fewer)
+    _EMCAL_4x4_NETA = geom_etabins / 2 - 1;
+    _EMCAL_4x4_NPHI = geom_phibins / 2;
+
+    // reset all maps
+    _EMCAL_1x1_MAP.resize(_EMCAL_1x1_NETA, std::vector<float>(_EMCAL_1x1_NPHI, 0));
+    _EMCAL_2x2_MAP.resize(_EMCAL_2x2_NETA, std::vector<float>(_EMCAL_2x2_NPHI, 0));
+    _EMCAL_4x4_MAP.resize(_EMCAL_4x4_NETA, std::vector<float>(_EMCAL_4x4_NPHI, 0));
+
+    if (verbosity > 0)
+    {
+      std::cout << "CaloTriggerSim::process_event: setting number of window in eta / phi,";
+      std::cout << "1x1 are " << _EMCAL_1x1_NETA << " / " << _EMCAL_1x1_NPHI << ", ";
+      std::cout << "2x2 are " << _EMCAL_2x2_NETA << " / " << _EMCAL_2x2_NPHI << ", ";
+      std::cout << "4x4 are " << _EMCAL_4x4_NETA << " / " << _EMCAL_4x4_NPHI << std::endl;
+    }
+  }
+
+  // reset 1x1 map
+  for (int ieta = 0; ieta < _EMCAL_1x1_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _EMCAL_1x1_NPHI; iphi++)
+    {
+      _EMCAL_1x1_MAP[ieta][iphi] = 0;
+    }
+  }
+
+  // iterate over EMCal towers, constructing 1x1's
+  RawTowerContainer::ConstRange begin_end = towersEM3->getTowers();
+  for (RawTowerContainer::ConstIterator rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
+  {
+    RawTower *tower = rtiter->second;
+    RawTowerGeom *tower_geom = geomEM->get_tower_geometry(tower->get_key());
+
+    float this_eta = tower_geom->get_eta();
+    float this_phi = tower_geom->get_phi();
+    int this_etabin = geomEM->get_etabin(this_eta);
+    int this_phibin = geomEM->get_phibin(this_phi);
+    float this_E = tower->get_energy();
+
+    _EMCAL_1x1_MAP[this_etabin][this_phibin] += this_E;
+
+    if (verbosity > 0 && tower->get_energy() > 1)
+    {
+      std::cout << "CaloTriggerSim::process_event: EMCal 1x1 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << this_etabin << " ) / " << this_phi << " ( " << this_phibin << " ) / " << this_E << std::endl;
+    }
+  }
+
+  // reset 2x2 map and best
+  for (int ieta = 0; ieta < _EMCAL_2x2_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _EMCAL_2x2_NPHI; iphi++)
+    {
+      _EMCAL_2x2_MAP[ieta][iphi] = 0;
+    }
+  }
+
+  _EMCAL_2x2_BEST_E = 0;
+  _EMCAL_2x2_BEST_PHI = 0;
+  _EMCAL_2x2_BEST_ETA = 0;
+
+  // now reconstruct 2x2 map from 1x1 map
+  for (int ieta = 0; ieta < _EMCAL_2x2_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _EMCAL_2x2_NPHI; iphi++)
+    {
+      float this_sum = 0;
+
+      this_sum += _EMCAL_1x1_MAP[2 * ieta][2 * iphi];
+      this_sum += _EMCAL_1x1_MAP[2 * ieta][2 * iphi + 1];  // 2 * iphi + 1 is safe, since _EMCAL_2x2_NPHI = _EMCAL_1x1_NPHI / 2
+      this_sum += _EMCAL_1x1_MAP[2 * ieta + 1][2 * iphi];  // 2 * ieta + 1 is safe, since _EMCAL_2x2_NETA = _EMCAL_1x1_NETA / 2
+      this_sum += _EMCAL_1x1_MAP[2 * ieta + 1][2 * iphi + 1];
+
+      // populate 2x2 map
+      _EMCAL_2x2_MAP[ieta][iphi] = this_sum;
+
+      // to calculate the eta, phi position, take the average of that of the 1x1's
+      float this_eta = 0.5 * (geomEM->get_etacenter(2 * ieta) + geomEM->get_etacenter(2 * ieta + 1));
+      float this_phi = 0.5 * (geomEM->get_phicenter(2 * iphi) + geomEM->get_phicenter(2 * iphi + 1));
+      // wrap-around phi (apparently needed for 2D geometry?)
+      if (this_phi > 3.14159) this_phi -= 2 * 3.14159;
+      if (this_phi < -3.14159) this_phi += 2 * 3.14159;
+
+      if (verbosity > 0 && this_sum > 1)
+      {
+        std::cout << "CaloTriggerSim::process_event: EMCal 2x2 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
+      }
+
+      if (this_sum > _EMCAL_2x2_BEST_E)
+      {
+        _EMCAL_2x2_BEST_E = this_sum;
+        _EMCAL_2x2_BEST_PHI = this_phi;
+        _EMCAL_2x2_BEST_ETA = this_eta;
+      }
+    }
+  }
+
+  if (verbosity > 0)
+  {
+    std::cout << "CaloTriggerSim::process_event: best EMCal 2x2 window is at eta / phi = " << _EMCAL_2x2_BEST_ETA << " / " << _EMCAL_2x2_BEST_PHI << " and E = " << _EMCAL_2x2_BEST_E << std::endl;
+  }
+
+  // reset 4x4 map & best
+  for (int ieta = 0; ieta < _EMCAL_4x4_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _EMCAL_4x4_NPHI; iphi++)
+    {
+      _EMCAL_4x4_MAP[ieta][iphi] = 0;
+    }
+  }
+
+  _EMCAL_4x4_BEST_E = 0;
+  _EMCAL_4x4_BEST_PHI = 0;
+  _EMCAL_4x4_BEST_ETA = 0;
+
+  // now reconstruct (sliding) 4x4 map from 2x2 map
+  for (int ieta = 0; ieta < _EMCAL_4x4_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _EMCAL_4x4_NPHI; iphi++)
+    {
+      // for eta calculation (since eta distribution is potentially
+      // non-uniform), average positions of all four towers
+      float this_eta = 0.25 * (geomEM->get_etacenter(2 * ieta) + geomEM->get_etacenter(2 * ieta + 1) + geomEM->get_etacenter(2 * ieta + 2) + geomEM->get_etacenter(2 * ieta + 3));
+      // for phi calculation (since phi distribution is uniform), take
+      // first tower and add 1.5 tower widths
+      float this_phi = geomEM->get_phicenter(2 * iphi) + 1.5 * (geomEM->get_phicenter(2 * iphi + 1) - geomEM->get_phicenter(2 * iphi));
+      // wrap-around phi (apparently needed for 2D geometry?)
+      if (this_phi > 3.14159) this_phi -= 2 * 3.14159;
+      if (this_phi < -3.14159) this_phi += 2 * 3.14159;
+
+      float this_sum = 0;
+
+      this_sum += _EMCAL_2x2_MAP[ieta][iphi];
+      this_sum += _EMCAL_2x2_MAP[ieta + 1][iphi];  // 2 * ieta + 1 is safe, since _EMCAL_4x4_NETA = _EMCAL_2x2_NETA - 1
+
+      if (iphi != _EMCAL_4x4_NPHI - 1)
+      {
+        // if we are not in the last phi row, can safely access 'iphi+1'
+        this_sum += _EMCAL_2x2_MAP[ieta][iphi + 1];
+        this_sum += _EMCAL_2x2_MAP[ieta + 1][iphi + 1];
+      }
+      else
+      {
+        // if we are in the last phi row, wrap back around to zero
+        this_sum += _EMCAL_2x2_MAP[ieta][0];
+        this_sum += _EMCAL_2x2_MAP[ieta + 1][0];
+      }
+
+      _EMCAL_4x4_MAP[ieta][iphi] = this_sum;
+
+      if (verbosity > 0 && this_sum > 1)
+      {
+        std::cout << "CaloTriggerSim::process_event: EMCal 4x4 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
+      }
+
+      if (this_sum > _EMCAL_4x4_BEST_E)
+      {
+        _EMCAL_4x4_BEST_E = this_sum;
+        _EMCAL_4x4_BEST_PHI = this_phi;
+        _EMCAL_4x4_BEST_ETA = this_eta;
+      }
+    }
+  }
+
+  if (verbosity > 0)
+  {
+    std::cout << "CaloTriggerSim::process_event: best EMCal 4x4 window is at eta / phi = " << _EMCAL_4x4_BEST_ETA << " / " << _EMCAL_4x4_BEST_PHI << " and E = " << _EMCAL_4x4_BEST_E << std::endl;
+  }
+
+  FillNode(topNode);
+
+  if (verbosity > 0) std::cout << "CaloTriggerSim::process_event: exiting" << std::endl;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CaloTriggerSim::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CaloTriggerSim::CreateNode(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  // store the trigger stuff under a sub-node directory
+  PHCompositeNode *trigNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "TRIG"));
+  if (!trigNode)
+  {
+    trigNode = new PHCompositeNode("TRIG");
+    dstNode->addNode(trigNode);
+  }
+
+  // create the CaloTriggerInfo
+  CaloTriggerInfo *triggerinfo = findNode::getClass<CaloTriggerInfo>(topNode, "CaloTriggerInfo");
+  if (!triggerinfo)
+  {
+    triggerinfo = new CaloTriggerInfo();
+    PHIODataNode<PHObject> *TriggerNode = new PHIODataNode<PHObject>(triggerinfo, "CaloTriggerInfo", "PHObject");
+    trigNode->addNode(TriggerNode);
+  }
+  else
+  {
+    std::cout << PHWHERE << "::ERROR - CaloTriggerInfo pre-exists, but should not" << std::endl;
+    exit(-1);
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void CaloTriggerSim::FillNode(PHCompositeNode *topNode)
+{
+  CaloTriggerInfo *triggerinfo = findNode::getClass<CaloTriggerInfo>(topNode, "CaloTriggerInfo");
+  if (!triggerinfo)
+  {
+    std::cout << " ERROR -- can't find CaloTriggerInfo node after it should have been created" << std::endl;
+    return;
+  }
+  else
+  {
+    triggerinfo->set_best_2x2_E(_EMCAL_2x2_BEST_E);
+    triggerinfo->set_best_2x2_eta(_EMCAL_2x2_BEST_ETA);
+    triggerinfo->set_best_2x2_phi(_EMCAL_2x2_BEST_PHI);
+
+    triggerinfo->set_best_4x4_E(_EMCAL_4x4_BEST_E);
+    triggerinfo->set_best_4x4_eta(_EMCAL_4x4_BEST_ETA);
+    triggerinfo->set_best_4x4_phi(_EMCAL_4x4_BEST_PHI);
+  }
+
+  return;
+}

--- a/offline/packages/trigger/CaloTriggerSim.h
+++ b/offline/packages/trigger/CaloTriggerSim.h
@@ -1,0 +1,65 @@
+#ifndef __CALOTRIGGERSIM_H__
+#define __CALOTRIGGERSIM_H__
+
+//===========================================================
+/// \file CaloTriggerSim.h
+/// \brief simple trigger emulation
+/// \author Dennis V. Perepelitsa
+//===========================================================
+
+// PHENIX includes
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>
+#include <phool/PHTimeServer.h>
+
+// standard includes
+#include <vector>
+
+// forward declarations
+class PHCompositeNode;
+
+/// \class CaloTriggerSim
+///
+/// \brief simple trigger emulation
+///
+/// This module constructs calo-based trigger signatures
+///
+class CaloTriggerSim : public SubsysReco
+{
+ public:
+  CaloTriggerSim(const std::string &name = "CaloTriggerSim");
+  virtual ~CaloTriggerSim();
+
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+ private:
+  int CreateNode(PHCompositeNode *topNode);
+  void FillNode(PHCompositeNode *topNode);
+
+  int _EMCAL_1x1_NETA;
+  int _EMCAL_1x1_NPHI;
+  std::vector<std::vector<float> > _EMCAL_1x1_MAP;
+
+  int _EMCAL_2x2_NETA;
+  int _EMCAL_2x2_NPHI;
+  std::vector<std::vector<float> > _EMCAL_2x2_MAP;
+
+  int _EMCAL_4x4_NETA;
+  int _EMCAL_4x4_NPHI;
+  std::vector<std::vector<float> > _EMCAL_4x4_MAP;
+
+  float _EMCAL_2x2_BEST_E;
+  float _EMCAL_2x2_BEST_PHI;
+  float _EMCAL_2x2_BEST_ETA;
+
+  float _EMCAL_4x4_BEST_E;
+  float _EMCAL_4x4_BEST_PHI;
+  float _EMCAL_4x4_BEST_ETA;
+
+  //int verbosity;
+};
+
+#endif  // __CALOTRIGGERSIM_H__

--- a/offline/packages/trigger/CaloTriggerSimLinkDef.h
+++ b/offline/packages/trigger/CaloTriggerSimLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class CaloTriggerSim+;
+
+#endif /* __CINT__ */

--- a/offline/packages/trigger/Makefile.am
+++ b/offline/packages/trigger/Makefile.am
@@ -1,0 +1,72 @@
+AUTOMAKE_OPTIONS = foreign
+
+INCLUDES = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include  \
+  -I${G4_MAIN}/include \
+  -I${G4_MAIN}/include/Geant4 \
+  -I`root-config --incdir`
+
+lib_LTLIBRARIES = \
+   libcalotrigger_io.la \
+   libcalotrigger.la
+
+AM_CXXFLAGS = \
+ -Wall -Werror -msse2
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  `geant4-config --libs`
+
+libcalotrigger_io_la_LIBADD = \
+  -lphool
+
+libcalotrigger_la_LIBADD = \
+  -lfun4all \
+  -lcemc_io \
+  -lCGAL \
+  libcalotrigger_io.la
+
+pkginclude_HEADERS = \
+  CaloTriggerSim.h \
+  CaloTriggerInfo.h
+
+#pkginclude_HEADERS = $(include_HEADERS)
+
+libcalotrigger_io_la_SOURCES = \
+  CaloTriggerInfo.C \
+  CaloTriggerInfo_Dict.C
+
+libcalotrigger_la_SOURCES = \
+  CaloTriggerSim.C \
+  CaloTriggerSim_Dict.C
+
+# Rule for generating table CINT dictionaries.
+%_Dict.C: %.h %LinkDef.h
+	rootcint -f $@ -c $(DEFAULT_INCLUDES) $(INCLUDES) $^
+
+%_Dict.cpp: %.h %LinkDef.h
+	rootcint -f $@ -c $(DEFAULT_INCLUDES) $(INCLUDES) $^
+
+################################################
+# linking tests
+
+noinst_PROGRAMS = testexternals
+
+BUILT_SOURCES = \
+  testexternals.C
+
+testexternals_LDADD = \
+  libcalotrigger_io.la \
+  libcalotrigger.la
+
+testexternals.C:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f *Dict* testexternals.C

--- a/offline/packages/trigger/autogen.sh
+++ b/offline/packages/trigger/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"
+

--- a/offline/packages/trigger/configure.in
+++ b/offline/packages/trigger/configure.in
@@ -1,0 +1,16 @@
+AC_INIT(configure.in)
+
+AM_INIT_AUTOMAKE(calotrigger, 1.00)
+
+AC_PROG_CXX(g++)
+AC_ENABLE_STATIC(no)
+LT_INIT
+
+dnl   no point in suppressing warnings people should 
+dnl   at least see them, so here we go for g++: -Wall
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+fi
+
+AC_OUTPUT(Makefile)
+


### PR DESCRIPTION
Initial commit of calo trigger related code. 

There are two major components: (1) a calo trigger simulator module meant to emulate the performance of the Level-1 trigger to be used in sPHENIX data-taking, and (2) a lightweight node which stores calo-trigger information and is to be written to the node tree in simulations.

At the moment, only a photon trigger (or single-electron trigger for Upsilon triggering) is implemented which consists of a 4x4 sliding window (composed of four 2x2 windows) algorithm on the EMCal towers. The simulator is agnostic as to the EMCal geometry (e.g. 1D- or 2D-projective, which differ in their eta structure) and will set up the internal tower map according to what the geometry container object tells it.

This is intended to be the first commit just to get some basic functionality into the framework -- additional functionality (N-bit ADC truncation, jet patch trigger, UE subtraction at Level-1 for Au+Au triggering, potentially di-electron trigger with mass hypothesis, etc.) will follow. I will present a short overview of the module and some first results in the next Simulations meeting. 