### PR TITLE
push temporary fix to get correct strip y indices

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -171,6 +171,8 @@ libg4detectors_la_SOURCES = \
   PHG4CylinderCellReco.cc \
   PHG4CylinderCellReco_Dict.cc \
   PHG4CylinderSteppingAction.cc \
+  PHG4DetectorGroupSubsystem.cc \
+  PHG4DetectorGroupSubsystem_Dict.cc \
   PHG4DetectorSubsystem.cc \
   PHG4DetectorSubsystem_Dict.cc \
   PHG4EnvelopeDetector.cc \

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -1,0 +1,563 @@
+#include "PHG4DetectorGroupSubsystem.h"
+#include "PHG4Parameters.h"
+#include "PHG4ParametersContainer.h"
+
+#include <pdbcalbase/PdbParameterMap.h>
+#include <pdbcalbase/PdbParameterMapContainer.h>
+
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+
+#include <boost/format.hpp>
+
+#include <iostream>
+#include <sstream>
+
+using namespace std;
+
+PHG4DetectorGroupSubsystem::PHG4DetectorGroupSubsystem(const std::string &name, const int lyr): 
+  PHG4Subsystem(name),
+  params(new PHG4Parameters(Name())),
+  paramscontainer(new PHG4ParametersContainer(Name())),
+  savetopNode(NULL),
+  overlapcheck(false),
+  layer(lyr),
+  usedb(0),
+  beginrunexecuted(0),
+  filetype(PHG4DetectorGroupSubsystem::none),
+  superdetector("NONE"),
+  calibfiledir("./")
+{
+  // put the layer into the name so we get unique names
+  // for multiple layers
+  ostringstream nam;
+  nam << name << "_" << lyr;
+  Name(nam.str().c_str());
+  paramsmap[lyr] = new PHG4Parameters(Name());
+}
+
+int 
+PHG4DetectorGroupSubsystem::Init(PHCompositeNode* topNode)
+{
+
+  savetopNode = topNode;
+  cout << "setting param name to " << Name() << endl;
+  params->set_name(Name());
+  int iret = InitSubsystem(topNode);
+  return iret;
+}
+
+int 
+PHG4DetectorGroupSubsystem::InitRun( PHCompositeNode* topNode )
+{
+  PHNodeIterator iter( topNode );
+  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "PAR" ));
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN" ));
+
+  string g4geonodename = "G4GEO_";
+  string paramnodename = "G4GEOPARAM_";
+  string calibdetname;
+  int isSuperDetector = 0;
+  if (superdetector != "NONE")
+    {
+      g4geonodename += SuperDetector();
+      paramscontainer = findNode::getClass<PHG4ParametersContainer>(parNode,g4geonodename);
+      if (! paramscontainer)
+	{
+	  PHNodeIterator parIter(parNode);
+          PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(parIter.findFirst("PHCompositeNode",SuperDetector()));
+	  if (! DetNode)
+	    {
+	      DetNode = new PHCompositeNode(SuperDetector());
+	      parNode->addNode(DetNode);
+	    }
+	  paramscontainer = new PHG4ParametersContainer(superdetector);
+	  DetNode->addNode(new PHDataNode<PHG4ParametersContainer>(paramscontainer,g4geonodename));
+	}
+      paramscontainer->AddPHG4Parameters(layer,params);
+      paramnodename += superdetector;
+      calibdetname = superdetector;
+      isSuperDetector = 1;
+    }
+  else
+    {
+      g4geonodename += params->Name();
+      parNode->addNode(new PHDataNode<PHG4Parameters>(params,g4geonodename));
+      paramnodename += params->Name();
+      calibdetname = params->Name();
+    }
+
+
+
+  // ASSUMPTION: if we read from DB and/or file we don't want the stuff from
+  // the node tree
+  // We leave the defaults intact in case there is no entry for
+  // those in the object read from the DB or file
+  // Order: read first DB, then calib file if both are enabled
+  if (ReadDB() || get_filetype() != PHG4DetectorGroupSubsystem::none)
+    {
+      if (ReadDB())
+	{
+	   ReadParamsFromDB(calibdetname,isSuperDetector);
+	}
+      if (get_filetype() != PHG4DetectorGroupSubsystem::none)
+	{
+	  ReadParamsFromFile(calibdetname, get_filetype(),isSuperDetector );
+	}
+    }
+  else
+    {
+      PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,paramnodename);
+      if (nodeparams)
+	{
+	  params->FillFrom(nodeparams, layer);
+	}
+    }
+  // parameters set in the macro always override whatever is read from
+  // the node tree, DB or file
+  UpdateParametersWithMacro();
+  // save updated persistant copy on node tree
+  PHCompositeNode *RunDetNode = runNode;
+  if (superdetector != "NONE")
+    {
+      PHNodeIterator runIter(runNode);
+      RunDetNode = dynamic_cast<PHCompositeNode*>(runIter.findFirst("PHCompositeNode",SuperDetector()));
+      if (! RunDetNode)
+	{
+	  RunDetNode = new PHCompositeNode(SuperDetector());
+	  runNode->addNode(RunDetNode);
+	}
+    }
+  params->SaveToNodeTree(RunDetNode,paramnodename,layer);
+  int iret = InitRunSubsystem(topNode);
+  if (Verbosity() > 0)
+    {
+      PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,paramnodename);
+      cout << Name() << endl;
+      nodeparams->print();
+    }
+  beginrunexecuted = 1;
+  return iret;
+}
+
+void
+PHG4DetectorGroupSubsystem::SuperDetector(const std::string &name)
+{
+  superdetector = name;
+  return;
+}
+
+void
+PHG4DetectorGroupSubsystem::set_double_param(const int detid, const std::string &name, const double dval)
+{
+  map<int, map<const std::string, double>>::const_iterator iter = default_double.find(detid);
+  if (iter == default_double.end())
+  {
+    cout << "detid " << detid << " not implemented" << endl;
+    cout << "implemented detector ids: " << endl;
+    for (map<int, map<const std::string, double>>::const_iterator iter2 = default_double.begin(); iter2 != default_double.end(); ++iter2)
+    {
+      cout << "detid: " << iter2->first << endl;
+    }
+    return;
+  }
+  if (iter->second.find(name) == iter->second.end())
+  {
+      cout << "double parameter " << name << " not implemented" << endl;
+      cout << "implemented double parameters are:" << endl;
+      for (map<const string, double>::const_iterator iter3 = iter->second.begin(); iter3 != iter->second.end(); ++iter3)
+      {
+	cout << iter3->first << endl;
+      }
+      return;
+  }
+// here we know we have entries for the detector id and the variable name exists
+// in the defaults, so now lets set it
+//  iter->second[name] = dval;
+  return;
+}
+/*
+  if (default_double.find(name) == default_double.end())
+    {
+      cout << "double parameter " << name << " not implemented" << endl;
+      cout << "implemented double parameters are:" << endl;
+      for (map<const string, double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
+	{
+	  cout << iter->first << endl;
+	}
+      return;
+    }
+  dparams[name] = dval;
+*/
+
+
+double
+PHG4DetectorGroupSubsystem::get_double_param(const int detid, const std::string &name) const
+{
+  return params->get_double_param(name);
+}
+
+void
+PHG4DetectorGroupSubsystem::set_int_param(const std::string &name, const int ival)
+{
+/*
+  if (default_int.find(name) == default_int.end())
+    {
+      cout << "integer parameter " << name << " not implemented" << endl;
+      cout << "implemented integer parameters are:" << endl;
+      for (map<const string, int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
+	{
+	  cout << iter->first << endl;
+	}
+      return;
+    }
+  iparams[name] = ival;
+*/
+}
+
+int
+PHG4DetectorGroupSubsystem::get_int_param(const std::string &name) const
+{
+  return params->get_int_param(name);
+}
+
+void
+PHG4DetectorGroupSubsystem::set_string_param(const std::string &name, const string &sval)
+{
+/*
+  if (default_string.find(name) == default_string.end())
+    {
+      cout << "string parameter " << name << " not implemented" << endl;
+      cout << "implemented string parameters are:" << endl;
+      for (map<const string, string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
+	{
+	  cout << iter->first << endl;
+	}
+      return;
+    }
+  cparams[name] = sval;
+*/
+}
+
+string
+PHG4DetectorGroupSubsystem::get_string_param(const std::string &name) const
+{
+  return params->get_string_param(name);
+}
+
+void
+PHG4DetectorGroupSubsystem::UpdateParametersWithMacro()
+{
+  for (map<const string,double>::const_iterator iter = dparams.begin(); iter != dparams.end(); ++iter)
+    {
+      params->set_double_param(iter->first,iter->second);
+    }
+  for (map<const string,int>::const_iterator iter = iparams.begin(); iter != iparams.end(); ++iter)
+    {
+      params->set_int_param(iter->first,iter->second);
+    }
+  for (map<const string,string>::const_iterator iter = cparams.begin(); iter != cparams.end(); ++iter)
+    {
+      params->set_string_param(iter->first,iter->second);
+    }
+  return;
+}
+
+void
+PHG4DetectorGroupSubsystem::set_default_double_param(const int detid, const std::string &name, const double dval)
+{
+  map<int, map<const std::string, double>>::iterator dmapiter = default_double.find(detid);
+  if (dmapiter == default_double.end())
+  {
+    map<const std::string, double> newdmap;
+    newdmap[name] = dval;
+    default_double[detid] = newdmap;
+  }
+  else
+  {
+    if (dmapiter->second.find(name) != dmapiter->second.end())
+    {
+      cout << "trying to overwrite default double " << name << " " 
+	   << dmapiter->second.find(name)->second << " with " << dval << endl;
+      exit(1);
+    }
+    else
+    {
+      dmapiter->second[name] = dval;
+    }
+  }
+  return;
+}
+
+void
+PHG4DetectorGroupSubsystem::set_default_int_param(const int detid, const std::string &name, const int ival)
+{
+  map<int, map<const std::string, int>>::iterator imapiter = default_int.find(detid);
+  if (imapiter == default_int.end())
+  {
+    map<const std::string, int> newimap;
+    newimap[name] = ival;
+    default_int[detid] = newimap;
+  }
+  else
+  {
+    if (imapiter->second.find(name) != imapiter->second.end())
+    {
+      cout << "trying to overwrite default int " << name << " " 
+	   << imapiter->second.find(name)->second << " with " << ival << endl;
+      exit(1);
+    }
+    else
+    {
+      imapiter->second[name] = ival;
+    }
+  }
+  return;
+}
+
+void
+PHG4DetectorGroupSubsystem::set_default_string_param(const int detid, const std::string &name, const string &sval)
+{
+  map<int, map<const std::string, string>>::iterator smapiter = default_string.find(detid);
+  if (smapiter == default_string.end())
+  {
+    map<const std::string, string> newsmap;
+    newsmap[name] = sval;
+    default_string[detid] = newsmap;
+  }
+  else
+  {
+    if (smapiter->second.find(name) != smapiter->second.end())
+    {
+      cout << "trying to overwrite default string " << name << " " 
+	   << smapiter->second.find(name)->second << " with " << sval << endl;
+      exit(1);
+    }
+    else
+    {
+      smapiter->second[name] = sval;
+    }
+  }
+  return;
+}
+
+void
+PHG4DetectorGroupSubsystem::InitializeParameters()
+{
+  for (set<int>::const_iterator iter=layers.begin(); iter != layers.end(); ++iter)
+  {
+    set_default_int_param(*iter, "absorberactive", 0);
+  set_default_int_param(*iter, "absorbertruth", 0);
+  set_default_int_param(*iter, "active", 0);
+  set_default_int_param(*iter, "blackhole", 0);
+  }
+  SetDefaultParameters(); // call method from specific subsystem
+  // now load those parameters to our params class
+  map<int, map<const string, double>>::const_iterator diter;
+  for (diter = default_double.begin(); diter != default_double.end(); ++diter)
+  {
+    PHG4Parameters *detidparams = paramscontainer->GetParametersToModify(diter->first);
+    if (!detidparams)
+    {
+      detidparams = new PHG4Parameters(boost::str(boost::format("%s_%d") %Name() %diter->first));
+      paramscontainer->AddPHG4Parameters(diter->first,detidparams);
+    }
+    map<const string, double>::const_iterator diter2;
+    for (diter2 = diter->second.begin(); diter2 != diter->second.end(); ++diter2)
+    {
+      detidparams->set_double_param(diter2->first, diter2->second);
+    }
+  }
+
+  map<int, map<const string, int>>::const_iterator iiter;
+  for (iiter = default_int.begin(); iiter != default_int.end(); ++iiter)
+  {
+    PHG4Parameters *detidparams = paramscontainer->GetParametersToModify(iiter->first);
+    if (!detidparams)
+    {
+      detidparams = new PHG4Parameters(boost::str(boost::format("%s_%d") %Name() %iiter->first));
+      paramscontainer->AddPHG4Parameters(iiter->first,detidparams);
+    }
+    map<const string, int>::const_iterator iiter2;
+    for (iiter2 = iiter->second.begin(); iiter2 != iiter->second.end(); ++iiter2)
+    {
+      detidparams->set_int_param(iiter2->first, iiter2->second);
+    }
+  }
+
+  map<int, map<const string, string>>::const_iterator siter;
+  for (siter = default_string.begin(); siter != default_string.end(); ++siter)
+  {
+    PHG4Parameters *detidparams = paramscontainer->GetParametersToModify(siter->first);
+    if (!detidparams)
+    {
+      detidparams = new PHG4Parameters(boost::str(boost::format("%s_%d") %Name() %siter->first));
+      paramscontainer->AddPHG4Parameters(siter->first,detidparams);
+    }
+    map<const string, string>::const_iterator siter2;
+    for (siter2 = siter->second.begin(); siter2 != siter->second.end(); ++siter2)
+    {
+      detidparams->set_string_param(siter2->first, siter2->second);
+    }
+  }
+}
+
+int
+PHG4DetectorGroupSubsystem::SaveParamsToDB()
+{
+  int iret = 0;
+  if (paramscontainer)
+    {
+      iret = paramscontainer->WriteToDB();
+    }
+  else
+    {
+      iret = params->WriteToDB();
+    }
+  if (iret)
+    {
+      cout << "problem committing to DB" << endl;
+    }
+  return iret;
+}
+
+int
+PHG4DetectorGroupSubsystem::ReadParamsFromDB(const string &name, const int issuper)
+{
+  int iret = 0;
+  if (issuper)
+    {
+      iret = params->ReadFromDB(name,layer);
+    }
+  else
+    {
+      iret = params->ReadFromDB();
+    }
+  if (iret)
+    {
+      cout << "problem reading from DB" << endl;
+    }
+  return iret;
+}
+
+int
+PHG4DetectorGroupSubsystem::SaveParamsToFile(const PHG4DetectorGroupSubsystem::FILE_TYPE ftyp)
+{
+  string extension;
+  switch(ftyp)
+    {
+    case xml:
+      extension = "xml";
+      break;
+    case root:
+      extension = "root";
+      break;
+    default:
+      cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
+      exit(1);
+    }
+  int iret = 0;
+  if (paramscontainer)
+    {
+      iret = paramscontainer->WriteToFile(extension,calibfiledir);
+    }
+  else
+    {
+      iret = params->WriteToFile(extension,calibfiledir);
+    }
+  if (iret)
+    {
+      cout << "problem saving to " << extension << " file " << endl;
+    }
+  return iret;
+}
+
+int
+PHG4DetectorGroupSubsystem::ReadParamsFromFile(const string &name, const PHG4DetectorGroupSubsystem::FILE_TYPE ftyp, const int issuper)
+{
+  string extension;
+  switch(ftyp)
+    {
+    case xml:
+      extension = "xml";
+      break;
+    case root:
+      extension = "root";
+      break;
+    default:
+      cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
+      exit(1);
+    }
+  int iret = params->ReadFromFile(name, extension, layer, issuper, calibfiledir);
+  if (iret)
+    {
+      cout << "problem reading from " << extension << " file " << endl;
+    }
+  return iret;
+}
+
+void
+PHG4DetectorGroupSubsystem::SetActive(const int detid, const int i)
+{
+  iparams["active"] = i;
+}
+
+void
+PHG4DetectorGroupSubsystem::SetAbsorberActive(const int detid, const int i)
+{
+  iparams["absorberactive"] = i;
+}
+
+void
+PHG4DetectorGroupSubsystem::BlackHole(const int detid, const int i)
+{
+  iparams["blackhole"] = i;
+}
+
+void
+PHG4DetectorGroupSubsystem::SetAbsorberTruth(const int detid, const int i)
+{
+  iparams["absorbertruth"] = i;
+}
+
+void PHG4DetectorGroupSubsystem::PrintDefaultParams() const
+{
+  cout << "int values: " << endl;
+  map<int, map<const std::string, int>>::const_iterator iiter;
+  for (iiter = default_int.begin(); iiter != default_int.end(); ++iiter)
+  {
+    cout << "Detector id: " << iiter->first << endl;
+    map<const string, int>::const_iterator iiter2;
+    for (iiter2 = iiter->second.begin(); iiter2 != iiter->second.end(); ++iiter2)
+    {
+      cout << iiter2->first << ": " << iiter2->second << endl;
+    }
+  }
+  cout << "double values: " << endl;
+  map<int, map<const std::string, double>>::const_iterator diter;
+  for (diter = default_double.begin(); diter != default_double.end(); ++diter)
+  {
+    cout << "Detector id: " << diter->first << endl;
+    map<const string, double>::const_iterator diter2;
+    for (diter2 = diter->second.begin(); diter2 != diter->second.end(); ++diter2)
+    {
+      cout << diter2->first << ": " << diter2->second << endl;
+    }
+  }
+  cout << "string values: " << endl;
+  map<int, map<const std::string, string>>::const_iterator siter;
+  for (siter = default_string.begin(); siter != default_string.end(); ++siter)
+  {
+    cout << "Detector id: " << siter->first << endl;
+    map<const string, string>::const_iterator siter2;
+    for (siter2 = siter->second.begin(); siter2 != siter->second.end(); ++siter2)
+    {
+      cout << siter2->first << ": " << siter2->second << endl;
+    }
+  }
+  return;
+}

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.h
@@ -1,0 +1,116 @@
+#ifndef PHG4DetectorGroupSubsystem_h
+#define PHG4DetectorGroupSubsystem_h
+
+#include <g4main/PHG4Subsystem.h>
+
+#include <map>
+#include <string>
+#include <set>
+
+class PHG4Parameters;
+class PHG4ParametersContainer;
+
+class PHG4DetectorGroupSubsystem : public PHG4Subsystem
+{
+ public:
+
+  enum FILE_TYPE {none = 0, xml = 1, root = 2};
+
+  virtual ~PHG4DetectorGroupSubsystem() {}
+
+  // stupid rootcint does not support final keyword
+#ifndef __CINT__
+  int Init(PHCompositeNode *) final;
+  int InitRun(PHCompositeNode *) final;
+#else
+  int Init(PHCompositeNode *);
+  int InitRun(PHCompositeNode *);
+#endif
+
+  virtual int InitRunSubsystem(PHCompositeNode *) {return 0;}
+  virtual int InitSubsystem(PHCompositeNode *) {return 0;}
+
+  void OverlapCheck(const bool chk = true) {overlapcheck = chk;}
+  bool CheckOverlap() const {return overlapcheck;}
+
+  PHG4Parameters *GetParams() const {return params;} 
+  PHG4ParametersContainer *GetParamsContainer() const {return paramscontainer;} 
+
+ // Get/Set parameters from macro
+  void set_double_param(const int detid, const std::string &name, const double dval);
+  double get_double_param(const int detid, const std::string &name) const;
+  void set_int_param(const std::string &name, const int ival);
+  int get_int_param(const std::string &name) const;
+  void set_string_param(const std::string &name, const std::string &sval);
+  std::string get_string_param(const std::string &name) const;
+
+  void UseDB(const int i = 1) {usedb = i;}
+  int ReadDB() const {return usedb;}
+  FILE_TYPE get_filetype() const {return filetype;}
+
+  void UseCalibFiles(const FILE_TYPE ftyp) {filetype = ftyp;}
+  int SaveParamsToDB();
+  int ReadParamsFromDB(const std::string &name, const int issuper);
+  int SaveParamsToFile(const FILE_TYPE ftyp);
+  int ReadParamsFromFile(const std::string &name, const FILE_TYPE ftyp, const int issuper);
+  void SetCalibrationFileDir(const std::string &calibdir) {calibfiledir = calibdir;}
+
+  void UpdateParametersWithMacro();
+
+  void SetActive(const int detid, const int i = 1);
+  void SetAbsorberActive(const int detid, const int i = 1);
+  void SetAbsorberTruth(const int detid, const int i = 1);
+  void BlackHole(const int detid, const int i=1);
+  void SuperDetector(const std::string &name);
+  const std::string SuperDetector() const {return superdetector;}
+
+  int GetLayer() const {return layer;}
+  virtual void SetDefaultParameters() = 0; // this one has to be implemented by the daughter
+ protected: // those cannot be executed on the cmd line 
+
+  PHG4DetectorGroupSubsystem(const std::string &name = "GenericSubsystem", const int lyr = 0);
+  // these initialize the defaults and add new entries to the
+  // list of variables. This should not be possible from the macro to
+  // prevent abuse (this makes the list of possible parameters deterministic)
+  void InitializeParameters();
+  void AddDetId(const int i) {layers.insert(i);}
+
+  void set_default_double_param(const int detid,  const std::string &name, const double dval);
+  void set_default_int_param(const int detid, const std::string &name, const int ival); 
+  void set_default_string_param(const int detid, const std::string &name, const std::string &sval);
+  //void set_default_int_param(const std::string &name, const int ival);
+  //void set_default_string_param(const std::string &name, const std::string &sval);
+  int BeginRunExecuted() const {return beginrunexecuted;}
+  void PrintDefaultParams() const;
+
+ private:
+  PHG4Parameters *params;
+  PHG4ParametersContainer *paramscontainer;
+  PHCompositeNode *savetopNode;
+  bool overlapcheck;
+  int layer;
+  int usedb;
+  int beginrunexecuted;
+  FILE_TYPE filetype;
+  std::string superdetector;
+  std::string calibfiledir;
+
+  std::set<int> layers;
+
+  std::map<int, PHG4Parameters *> paramsmap;
+
+  /* std::map<int, std::map<const std::string, double>> dparams; */
+  /* std::map<int, std::map<const std::string, int>> iparams; */
+  /* std::map<int, std::map<const std::string, std::string>> cparams; */
+
+  std::map<const std::string, double> dparams;
+  std::map<const std::string, int> iparams;
+  std::map<const std::string, std::string> cparams;
+
+   std::map<int, std::map<const std::string, double>> default_double;
+   std::map<int, std::map<const std::string, int>> default_int;
+   std::map<int, std::map<const std::string, std::string>> default_string;
+
+};
+
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystemLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4DetectorGroupSubsystem-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -1,7 +1,7 @@
 #include "PHG4SiliconTrackerDetector.h"
 #include "PHG4CylinderGeomContainer.h"
 #include "PHG4CylinderGeom_Siladders.h"
-#include "PHG4Parameters.h"
+#include "PHG4ParametersContainer.h"
 #include "PHG4SiliconTrackerParameterisation.h"
 
 #include <g4main/PHG4Utils.h>
@@ -27,12 +27,12 @@
 
 using namespace std;
 
-PHG4SiliconTrackerDetector::PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam, const vpair &layerconfig)
+PHG4SiliconTrackerDetector::PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHG4ParametersContainer *parameters, const std::string &dnam, const vpair &layerconfig)
   : PHG4Detector(Node, dnam)
-  , params(parameters)
-  , active(params->get_int_param("active"))
-  , absorberactive(params->get_int_param("absorberactive"))
-  , blackhole(params->get_int_param("blackhole"))
+  , paramscontainer(parameters)
+  , active(1)
+  , absorberactive(0)
+  , blackhole(0)
 {
   layerconfig_ = layerconfig;
 
@@ -162,7 +162,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Si-sensor active area
          */
-      const double siactive_x = strip_x;                                               // 0.24mm/2
+      const double siactive_x = (strip_x);                                               // 0.24mm/2
       const double siactive_y = (strip_y + strip_y / 10000.) * 2. * nstrips_phi_cell;  // (0.078mm * 2*128)/2 = 0.078mm * 128
       const double siactive_z = (strip_z + strip_z / 10000.) * nstrips_z_sensor;       // (20mm * 5or8)/2 = 10mm * 5or8
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -163,15 +163,18 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
          * Si-sensor active area
          */
       const double siactive_x = (strip_x);                                               // 0.24mm/2
-      const double siactive_y = (strip_y + strip_y / 10000.) * 2. * nstrips_phi_cell;  // (0.078mm * 2*128)/2 = 0.078mm * 128
-      const double siactive_z = (strip_z + strip_z / 10000.) * nstrips_z_sensor;       // (20mm * 5or8)/2 = 10mm * 5or8
+//      const double siactive_y = (strip_y + strip_y / 10000.) * 2. * nstrips_phi_cell;  // (0.078mm * 2*128)/2 = 0.078mm * 128
+//      const double siactive_z = (strip_z + strip_z / 10000.) * nstrips_z_sensor;       // (20mm * 5or8)/2 = 10mm * 5or8
+      const double siactive_y = strip_y * 2. * nstrips_phi_cell;  // (0.078mm * 2*128)/2 = 0.078mm * 128
+      const double siactive_z = strip_z * nstrips_z_sensor;       // (20mm * 5or8)/2 = 10mm * 5or8
 
       G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x, siactive_y, siactive_z);
       G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       //	activelogvols.insert(siactive_volume);
 
-      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, (strip_y + strip_y / 10000.) * 2., (strip_z + strip_z / 10000.) * 2.);
-      new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), strip_volume, siactive_volume, kZAxis, nstrips_phi_cell * 2 * nstrips_z_sensor, stripparam, false);  // overlap check too long.
+//      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, (strip_y + strip_y / 10000.) * 2., (strip_z + strip_z / 10000.) * 2.);
+      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, (strip_y) * 2., (strip_z) * 2.); 
+     new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), strip_volume, siactive_volume, kZAxis, nstrips_phi_cell * 2 * nstrips_z_sensor, stripparam, false);  // overlap check too long.
 
       /*
          * Si-sensor full (active+inactive) area

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -15,7 +15,7 @@
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4VSolid;
-class PHG4Parameters;
+class PHG4ParametersContainer;
 
 class PHG4SiliconTrackerDetector : public PHG4Detector
 {
@@ -23,7 +23,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   typedef std::vector<std::pair<int, int>> vpair;
 
   //! constructor
-  PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam = "BLOCK", const vpair &layerconfig = vpair(0));
+  PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHG4ParametersContainer *parameters, const std::string &dnam = "SILICON_TRACKER", const vpair &layerconfig = vpair(0));
 
   //! destructor
   virtual ~PHG4SiliconTrackerDetector();
@@ -70,7 +70,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   int ConstructSiliconTracker(G4LogicalVolume *sandwich);
   int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = NULL);
 
-  PHG4Parameters *params;
+  PHG4ParametersContainer *paramscontainer;
   int active;
   int absorberactive;
   int blackhole;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -34,6 +34,7 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
 
   int IsActive;
   int IsBlackHole;
+  int toggle;
 };
 
 #endif  // PHG4SiliconTrackerSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -34,7 +34,6 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
 
   int IsActive;
   int IsBlackHole;
-  int toggle;
 };
 
 #endif  // PHG4SiliconTrackerSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -17,7 +17,7 @@ using namespace std;
 
 //_______________________________________________________________________
 PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &detectorname, const vpair &layerconfig)
-  : PHG4DetectorSubsystem(detectorname)
+  : PHG4DetectorGroupSubsystem(detectorname)
   , detector_(0)
   , steppingAction_(nullptr)
   , eventAction_(nullptr)
@@ -25,6 +25,10 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &dete
   , detector_type(detectorname)
   , superdetector(detectorname)
 {
+  for (vector<pair<int, int>>::const_iterator piter = layerconfig.begin(); piter != layerconfig.end(); ++piter)
+  {
+    AddDetId((*piter).second);
+  }
   InitializeParameters();
   // put the layer into the name so we get unique names
   // for multiple layers
@@ -41,7 +45,7 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  detector_ = new PHG4SiliconTrackerDetector(topNode, GetParams(), Name(), layerconfig_);
+  detector_ = new PHG4SiliconTrackerDetector(topNode, GetParamsContainer(), Name(), layerconfig_);
   detector_->SuperDetector(superdetector);
   detector_->Detector(detector_type);
   detector_->OverlapCheck(CheckOverlap());
@@ -59,7 +63,8 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
       dstNode->addNode(new PHIODataNode<PHObject>(block_hits = new PHG4HitContainer(nodename), nodename.c_str(), "PHObject"));
 
     PHG4EventActionClearZeroEdep *eventaction = new PHG4EventActionClearZeroEdep(topNode, nodename);
-    if (GetParams()->get_int_param("absorberactive"))
+//    if (GetParams()->get_int_param("absorberactive"))
+    if (0)
     {
       nodename = (superdetector != "NONE") ? boost::str(boost::format("G4HIT_ABSORBER_%s") % superdetector) : boost::str(boost::format("G4HIT_ABSORBER_%s_%d_%d") % detector_type % sphxlayermin % sphxlayermax);
 
@@ -105,5 +110,14 @@ PHG4Detector *PHG4SiliconTrackerSubsystem::GetDetector(void) const
 
 void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
 {
+  set_default_double_param(0,"Radius",6.);
+  set_default_double_param(1,"Radius",8.);
+  set_default_double_param(2,"Radius",10.);
+  set_default_double_param(3,"Radius",12.);
   return;
+}
+
+void PHG4SiliconTrackerSubsystem::Print(const string &what) const
+{
+  PrintDefaultParams();
 }

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
@@ -1,7 +1,7 @@
 #ifndef PHG4SiliconTrackerSubsystem_h
 #define PHG4SiliconTrackerSubsystem_h
 
-#include "PHG4DetectorSubsystem.h"
+#include "PHG4DetectorGroupSubsystem.h"
 
 #include <Geant4/G4String.hh>
 #include <Geant4/G4Types.hh>
@@ -13,7 +13,7 @@ class PHG4SiliconTrackerDetector;
 class PHG4SiliconTrackerSteppingAction;
 class PHG4EventAction;
 
-class PHG4SiliconTrackerSubsystem : public PHG4DetectorSubsystem
+class PHG4SiliconTrackerSubsystem : public PHG4DetectorGroupSubsystem
 {
  public:
   typedef std::vector<std::pair<int, int>> vpair;
@@ -47,6 +47,8 @@ class PHG4SiliconTrackerSubsystem : public PHG4DetectorSubsystem
   PHG4EventAction *GetEventAction() const { return eventAction_; }
   void SuperDetector(const std::string &name) { superdetector = name; }
   const std::string SuperDetector() { return superdetector; }
+  void Print(const std::string &what = "ALL") const;
+
  private:
   void SetDefaultParameters();
 


### PR DESCRIPTION
use copy number to decode unproblematic strips rather than the complicated and cpu intensive check for the y/z range.Also start with the PHG4DetectorGroupSubsystem base class for subsystems containing multiple layers/detector ids