### PR TITLE
PHG4TrackFastSim leaks like a sieve!

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -318,9 +318,9 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 	  _fitter->getEventDisplay()->addEvent(rf_gf_tracks);
 	}
 	else{
-	  //for (std::vector<PHGenFit::Track*>::iterator it = rf_tracks.begin() ; it != rf_tracks.end(); ++it)
-	  //  delete (*it);
-	  //rf_tracks.clear();
+	  for (std::vector<PHGenFit::Track*>::iterator it = rf_tracks.begin() ; it != rf_tracks.end(); ++it)
+	    delete (*it);
+	  rf_tracks.clear();
 	}
 
 //	if(_trackmap_out->get(0)) {

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -596,10 +596,12 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 	    {
 	      for(int j=i;j<6;j++)
 		{
-		  out_track->set_error(i,j, gf_state->get6DCov()[i][j]);
+		  state->set_error(i,j, gf_state->get6DCov()[i][j]);
 		}
 	    }
 	  out_track->insert_state(state);
+	  // the state is cloned on insert_state, so delete this copy here!
+	  delete state; 
 	}
 
 	return (SvtxTrack *)out_track;

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -482,6 +482,8 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
 						meas_out.push_back(meas);
 						//meas->getMeasurement()->Print(); //DEBUG
 					}
+					else
+					  delete meas; 
 				}
 			}
 		} /*Loop layers within one detector layer*/


### PR DESCRIPTION
PHG4TrackFastSim was leaking like crazy, making it impossible to run forward jet simulations.  Several of these were simple, just neglecting to delete things that were unused or that a subsequent object makes a copy of.  The main problem, however, has to do with the PHGenFit interface to GenFit.  PHGenFit creates a number of interface objects that themselves create underlying GenFit objects. The top level of this is the PHEGenFit::Track object that owns its measurements in a parallel fashion to the way the GenFit::Track object owns its measurements.  However, the code was keeping track of the underlying GenFit::Track objects and deleting them.  This left all the PHGenFit wrapper objects lying around consuming memory like crazy.

Valgrind is happy now, and doesn't show PHG4FastTrackSim as responsible for leaking anything.  There are a lot of jumps on uninitialized variables in GenFit itself; however. That will have to be an investigation for another day