### PR TITLE
better fix for parametrized volume overlaps

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -150,7 +150,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Si-strip
          */
-      G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % sphxlayer % itype).c_str(), strip_x, strip_y, strip_z);
+      G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % sphxlayer % itype).c_str(), strip_x, strip_y-strip_y/10000., strip_z-strip_z/10000.);
       G4LogicalVolume *strip_volume = new G4LogicalVolume(strip_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("strip_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       activelogvols.insert(strip_volume);
       G4VisAttributes *strip_vis = new G4VisAttributes();
@@ -163,8 +163,6 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
          * Si-sensor active area
          */
       const double siactive_x = (strip_x);                                               // 0.24mm/2
-//      const double siactive_y = (strip_y + strip_y / 10000.) * 2. * nstrips_phi_cell;  // (0.078mm * 2*128)/2 = 0.078mm * 128
-//      const double siactive_z = (strip_z + strip_z / 10000.) * nstrips_z_sensor;       // (20mm * 5or8)/2 = 10mm * 5or8
       const double siactive_y = strip_y * 2. * nstrips_phi_cell;  // (0.078mm * 2*128)/2 = 0.078mm * 128
       const double siactive_z = strip_z * nstrips_z_sensor;       // (20mm * 5or8)/2 = 10mm * 5or8
 
@@ -172,7 +170,6 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       //	activelogvols.insert(siactive_volume);
 
-//      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, (strip_y + strip_y / 10000.) * 2., (strip_z + strip_z / 10000.) * 2.);
       G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, (strip_y) * 2., (strip_z) * 2.); 
      new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), strip_volume, siactive_volume, kZAxis, nstrips_phi_cell * 2 * nstrips_z_sensor, stripparam, false);  // overlap check too long.
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -137,14 +137,18 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       G4VPhysicalVolume* volume_post = postPoint->GetTouchableHandle()->GetVolume();
       G4LogicalVolume* logvolpre = volume->GetLogicalVolume();
       G4LogicalVolume* logvolpost = volume_post->GetLogicalVolume();
+// this is just failsafe - I tested with 1000000 pions and did not hit this once
       if (logvolpre == logvolpost)
       {
         if (volume->GetCopyNo() == volume_post->GetCopyNo())
         {
-//          cout << "Overlap detected in volume " << volume->GetName() << " where post volume " << volume_post->GetName() << " has same copy no."
-//               << "- pre and post step point of same volume for step status fGeomBoundary" << endl;
+          cout << "Overlap detected in volume " << volume->GetName() << " where post volume " 
+               << volume_post->GetName() << " has same copy no." << volume->GetCopyNo() 
+               << " pre and post step point of same volume for step status fGeomBoundary" << endl;
+	  cout << "logvol name " << logvolpre->GetName() << ", post: " << logvolpost->GetName() << endl;
           // we need a hack to replace the values above with the correct strip index values
           // the transform of the world coordinates into the sensor frame will work correctly, so we determine the strip indices from the hit position
+	  cout << "strip y bef: " << strip_y_index << ", strip z: " << strip_z_index;
 
           G4ThreeVector preworldPos = prePoint->GetPosition();
           G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
@@ -168,9 +172,11 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
               strip_y_index = i;
               if (verbosity > 1) std::cout << "                            revised strip y position = " << strip_y_index << std::endl;
             }
+
           }
+	  cout << " strip y aft: " << strip_y_index << ", strip z: " << strip_z_index << endl;
+
         }
-        // cout << "copy no " << volume->GetCopyNo() << ", strip_y_index: " << strip_y_index << " div.quot: " << copydiv.quot << ", strip_z_index: " << strip_z_index  << ", div.rem: " << copydiv.rem << endl;
       }
     }
   }


### PR DESCRIPTION
It turns out that reducing the strip sizes by 1/10000th of their size takes care of the overlaps. I guess the approach to increase the size of the mother volume and adjusting the parametrization wasn't consistent. The code needed an additional check besides the copy number which can be identical for different logical volumes (copy = 0 is all over the place)