### PR TITLE
replace zero energy hit removal in afterburner by properly saving hits which contain energy

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4MapsDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsDetector.cc
@@ -3,8 +3,6 @@
 #include "PHG4CylinderGeom_MAPS.h"
 #include "PHG4Parameters.h"
 
-#include "TMath.h"
-
 #include <g4main/PHG4Utils.h>
 
 #include <phool/PHCompositeNode.h>

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
@@ -1,9 +1,9 @@
 #include "PHG4Prototype2InnerHcalSteppingAction.h"
-#include "PHG4Prototype2InnerHcalDetector.h"
 #include "PHG4Parameters.h"
+#include "PHG4Prototype2InnerHcalDetector.h"
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
 
@@ -11,16 +11,16 @@
 
 #include <phool/getClass.h>
 
-#include <Geant4/G4Step.hh>
 #include <Geant4/G4MaterialCutsCouple.hh>
+#include <Geant4/G4Step.hh>
 
 #include <boost/foreach.hpp>
 #include <boost/tokenizer.hpp>
 // this is an ugly hack, the gcc optimizer has a bug which
 // triggers the uninitialized variable warning which
-// stops compilation because of our -Werror 
-#include <boost/version.hpp> // to get BOOST_VERSION
-#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700 )
+// stops compilation because of our -Werror
+#include <boost/version.hpp>  // to get BOOST_VERSION
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700)
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #pragma message "ignoring bogus gcc warning in boost header lexical_cast.hpp"
 #include <boost/lexical_cast.hpp>
@@ -33,34 +33,34 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4Prototype2InnerHcalSteppingAction::PHG4Prototype2InnerHcalSteppingAction( PHG4Prototype2InnerHcalDetector* detector, PHG4Parameters *parameters):
-  detector_( detector ),
-  hits_(nullptr),
-  absorberhits_(nullptr),
-  hit(nullptr),
-  params(parameters),
-  savehitcontainer(nullptr),
-  saveshower(nullptr),
-  absorbertruth(params->get_int_param("absorbertruth")),
-  IsActive(params->get_int_param("active")),
-  IsBlackHole(params->get_int_param("blackhole")),
-  light_scint_model(params->get_int_param("light_scint_model")),
-  light_balance_inner_corr(params->get_double_param("light_balance_inner_corr")),
-  light_balance_inner_radius(params->get_double_param("light_balance_inner_radius")*cm),
-  light_balance_outer_corr(params->get_double_param("light_balance_outer_corr")),
-  light_balance_outer_radius(params->get_double_param("light_balance_outer_radius")*cm)
-{}
+PHG4Prototype2InnerHcalSteppingAction::PHG4Prototype2InnerHcalSteppingAction(PHG4Prototype2InnerHcalDetector* detector, PHG4Parameters* parameters)
+  : detector_(detector)
+  , hits_(nullptr)
+  , absorberhits_(nullptr)
+  , hit(nullptr)
+  , params(parameters)
+  , savehitcontainer(nullptr)
+  , saveshower(nullptr)
+  , absorbertruth(params->get_int_param("absorbertruth"))
+  , IsActive(params->get_int_param("active"))
+  , IsBlackHole(params->get_int_param("blackhole"))
+  , light_scint_model(params->get_int_param("light_scint_model"))
+  , light_balance_inner_corr(params->get_double_param("light_balance_inner_corr"))
+  , light_balance_inner_radius(params->get_double_param("light_balance_inner_radius") * cm)
+  , light_balance_outer_corr(params->get_double_param("light_balance_outer_corr"))
+  , light_balance_outer_radius(params->get_double_param("light_balance_outer_radius") * cm)
+{
+}
 
 //____________________________________________________________________________..
-bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
+bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
-
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   // get volume of the current step
   G4VPhysicalVolume* volume = touch->GetVolume();
 
   // detector_->IsInPrototype2InnerHcal(volume)
-  // returns 
+  // returns
   //  0 is outside of Prototype2InnerHcal
   //  1 is inside scintillator
   // -1 is steel absorber
@@ -68,67 +68,67 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aS
   int whichactive = detector_->IsInPrototype2InnerHcal(volume);
 
   if (!whichactive)
-    {
-      return false;
-    }
+  {
+    return false;
+  }
   int row_id = -1;
   int slat_id = -1;
-  if (whichactive > 0) // scintillator
-    {
-      // first extract the scintillator id (0-3) from the volume name (OuterScinti_0,1,2,3)
-      boost::char_separator<char> sep("_");
-      boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
-      boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter =  tok.begin();
-      ++tokeniter;
-      slat_id = boost::lexical_cast<int>(*tokeniter);
-      // G4AssemblyVolumes naming convention:
-      //     av_WWW_impr_XXX_YYY_ZZZ
-      // where:
+  if (whichactive > 0)  // scintillator
+  {
+    // first extract the scintillator id (0-3) from the volume name (OuterScinti_0,1,2,3)
+    boost::char_separator<char> sep("_");
+    boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
+    boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter = tok.begin();
+    ++tokeniter;
+    slat_id = boost::lexical_cast<int>(*tokeniter);
+    // G4AssemblyVolumes naming convention:
+    //     av_WWW_impr_XXX_YYY_ZZZ
+    // where:
 
-      //     WWW - assembly volume instance number
-      //     XXX - assembly volume imprint number
-      //     YYY - the name of the placed logical volume
-      //     ZZZ - the logical volume index inside the assembly volume
-      // e.g. av_1_impr_2_InnerHcalScintiMother_pv_11
-      // 2 the number of the scintillator mother volume
-      // InnerHcalScintiMother_11: name of scintillator slat
-      // 11: number of scintillator slat logical volume
-      // use boost tokenizer to separate the _, then take value
-      // after "impr" for mother volume and after "pv" for scintillator slat
-      // use boost lexical cast for string -> int conversion
-      G4VPhysicalVolume* mothervolume = touch->GetVolume(1);
-      boost::tokenizer<boost::char_separator<char> > tokm(mothervolume->GetName(), sep);
-      for (tokeniter = tokm.begin(); tokeniter != tokm.end(); ++tokeniter)
-       	{
-       	  if (*tokeniter == "pv")
-       	    {
-       	      ++tokeniter;
-       	      if (tokeniter != tokm.end())
-       		{
-		  row_id = boost::lexical_cast<int>(*tokeniter);
-// from the construction via assembly volumes, the mother id starts 
-// at 2 and is incremented by 2 for each new row of slats
-// this maps it back to 0-nslats
-		  row_id -= 2;  
-		  row_id /= 2;
-		}
-       	      else
-       		{
-       		  cout << PHWHERE << " Error parsing " << mothervolume->GetName()
-       		       << " for mother scinti slat id " << endl;
-		  exit(1);
-       		}
-	      break;
-	    }
-	}
-      // cout << "mother volume: " <<  mothervolume->GetName() 
-      //      << ", volume name " << volume->GetName() << ", row: " << row_id
-      //  	   << ", column: " << slat_id << endl;
-    }
-  else
+    //     WWW - assembly volume instance number
+    //     XXX - assembly volume imprint number
+    //     YYY - the name of the placed logical volume
+    //     ZZZ - the logical volume index inside the assembly volume
+    // e.g. av_1_impr_2_InnerHcalScintiMother_pv_11
+    // 2 the number of the scintillator mother volume
+    // InnerHcalScintiMother_11: name of scintillator slat
+    // 11: number of scintillator slat logical volume
+    // use boost tokenizer to separate the _, then take value
+    // after "impr" for mother volume and after "pv" for scintillator slat
+    // use boost lexical cast for string -> int conversion
+    G4VPhysicalVolume* mothervolume = touch->GetVolume(1);
+    boost::tokenizer<boost::char_separator<char> > tokm(mothervolume->GetName(), sep);
+    for (tokeniter = tokm.begin(); tokeniter != tokm.end(); ++tokeniter)
     {
-      slat_id = touch->GetCopyNumber(); // steel plate id
+      if (*tokeniter == "pv")
+      {
+        ++tokeniter;
+        if (tokeniter != tokm.end())
+        {
+          row_id = boost::lexical_cast<int>(*tokeniter);
+          // from the construction via assembly volumes, the mother id starts
+          // at 2 and is incremented by 2 for each new row of slats
+          // this maps it back to 0-nslats
+          row_id -= 2;
+          row_id /= 2;
+        }
+        else
+        {
+          cout << PHWHERE << " Error parsing " << mothervolume->GetName()
+               << " for mother scinti slat id " << endl;
+          exit(1);
+        }
+        break;
+      }
     }
+    // cout << "mother volume: " <<  mothervolume->GetName()
+    //      << ", volume name " << volume->GetName() << ", row: " << row_id
+    //  	   << ", column: " << slat_id << endl;
+  }
+  else
+  {
+    slat_id = touch->GetCopyNumber();  // steel plate id
+  }
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
   G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
@@ -137,229 +137,226 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction( const G4Step* aS
 
   // if this block stops everything, just put all kinetic energy into edep
   if (IsBlackHole)
-    {
-      edep = aTrack->GetKineticEnergy() / GeV;
-      G4Track* killtrack = const_cast<G4Track *> (aTrack);
-      killtrack->SetTrackStatus(fStopAndKill);
-    }
+  {
+    edep = aTrack->GetKineticEnergy() / GeV;
+    G4Track* killtrack = const_cast<G4Track*>(aTrack);
+    killtrack->SetTrackStatus(fStopAndKill);
+  }
   int layer_id = detector_->get_Layer();
   // make sure we are in a volume
-  if ( IsActive )
+  if (IsActive)
+  {
+    bool geantino = false;
+
+    // the check for the pdg code speeds things up, I do not want to make
+    // an expensive string compare for every track when we know
+    // geantino or chargedgeantino has pid=0
+    if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
+        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
     {
-      bool geantino = false;
-
-      // the check for the pdg code speeds things up, I do not want to make
-      // an expensive string compare for every track when we know
-      // geantino or chargedgeantino has pid=0
-      if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
-	  aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
-	{
-	  geantino = true;
-	}
-      G4StepPoint * prePoint = aStep->GetPreStepPoint();
-      G4StepPoint * postPoint = aStep->GetPostStepPoint();
-      //       cout << "track id " << aTrack->GetTrackID() << endl;
-      //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
-      //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
-      switch (prePoint->GetStepStatus())
-	{
-	case fGeomBoundary:
-	case fUndefined:
-	if (! hit)
-	  {
-	    hit = new PHG4Hitv1();
-	  }
-	  hit->set_row(row_id);
-	  if (whichactive > 0) // only for scintillators
-	    {
-	       hit->set_scint_id(slat_id); // the slat id in the mother volume (or steel plate id), the column
-	    }
-	  //here we set the entrance values in cm
-	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
-	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
-	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
-	  // time in ns
-	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
-	  //set the track ID
-	  hit->set_trkid(aTrack->GetTrackID());
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  hit->set_trkid(pp->GetUserTrackId());
-		  hit->set_shower_id(pp->GetShower()->get_id());
-		}
-	    }
-
-	  //set the initial energy deposit
-	  hit->set_edep(0);
-
-          hit->set_hit_type(0);
-          if( (aTrack->GetParticleDefinition()->GetParticleName().find("e+") != string::npos) ||
-              (aTrack->GetParticleDefinition()->GetParticleName().find("e-") != string::npos) )
-            hit->set_hit_type(1);
-
-	  if (whichactive > 0) // return of IsInPrototype2InnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
-	    {
-              savehitcontainer = hits_;
-	      hit->set_light_yield(0); // for scintillator only, initialize light yields
-	      hit->set_eion(0);
-	    }
-	  else
-	    {
-	      savehitcontainer = absorberhits_;
-	    }
-
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  hit->set_trkid(pp->GetUserTrackId());
-		  hit->set_shower_id(pp->GetShower()->get_id());
-		  saveshower =  pp->GetShower();
-		}
-	    }
-	  break;
-	default:
-	  break;
-	}
-      // here we just update the exit values, it will be overwritten
-      // for every step until we leave the volume or the particle
-      // ceases to exist
-      hit->set_x( 1, postPoint->GetPosition().x() / cm );
-      hit->set_y( 1, postPoint->GetPosition().y() / cm );
-      hit->set_z( 1, postPoint->GetPosition().z() / cm );
-
-      hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
-
-      if (whichactive > 0) // return of IsInPrototype2InnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
-        {
-          hit->set_eion(hit->get_eion() + eion);
-          light_yield = eion;
-          if (light_scint_model)
-            {
-              light_yield = GetVisibleEnergyDeposition(aStep); // for scintillator only, calculate light yields
-	    }
-          if (isfinite(light_balance_outer_radius) && 
-              isfinite(light_balance_inner_radius) && 
-	      isfinite(light_balance_outer_corr) &&
-	      isfinite(light_balance_inner_corr))
-            {
-              double r = sqrt(postPoint->GetPosition().x()*postPoint->GetPosition().x()
-			    + postPoint->GetPosition().y()*postPoint->GetPosition().y());
-              double cor =  GetLightCorrection(r);
-              light_yield = light_yield * cor;
-            }
-	  hit->set_light_yield(hit->get_light_yield() + light_yield);
-        }
-
-      //sum up the energy to get total deposited
-      hit->set_edep(hit->get_edep() + edep);
-      if (geantino)
-	{
-	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-	  if (whichactive > 0) // add light yield for scintillators
-	    {
-	      hit->set_light_yield(-1);
-              hit->set_eion(-1);
-	    }
-	}
-      if (edep > 0 && (whichactive > 0 || absorbertruth > 0))
-	{
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  pp->SetKeep(1); // we want to keep the track
-		}
-	    }
-	}
-      // if any of these conditions is true this is the last step in
-      // this volume and we need to save the hit
-      // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
-      // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
-      // (happens when your detector goes outside world volume)
-      // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
-      // aTrack->GetTrackStatus() == fStopAndKill is also set)
-      // aTrack->GetTrackStatus() == fStopAndKill: track ends
-      if (postPoint->GetStepStatus() == fGeomBoundary || 
-          postPoint->GetStepStatus() == fWorldBoundary || 
-	  postPoint->GetStepStatus() == fAtRestDoItProc ||
-          aTrack->GetTrackStatus() == fStopAndKill)
+      geantino = true;
+    }
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    //       cout << "track id " << aTrack->GetTrackID() << endl;
+    //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
+    //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
+    switch (prePoint->GetStepStatus())
+    {
+    case fGeomBoundary:
+    case fUndefined:
+      if (!hit)
       {
-          // save only hits with energy deposit (or -1 for geantino)
-	  if (hit->get_edep())
-	    {
-	      savehitcontainer->AddHit(layer_id, hit);
-	      if (saveshower)
-		{
-		  saveshower->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		}
-	      // ownership has been transferred to container, set to null
-	      // so we will create a new hit for the next track
-	      hit = nullptr;
-	    }
-	  else
-	    {
-	      // if this hit has no energy deposit, just reset it for reuse
-	      // this means we have to delete it in the dtor. If this was
-	      // the last hit we processed the memory is still allocated
-	      hit->Reset();
-	    }
- 	}
+        hit = new PHG4Hitv1();
+      }
+      hit->set_row(row_id);
+      if (whichactive > 0)  // only for scintillators
+      {
+        hit->set_scint_id(slat_id);  // the slat id in the mother volume (or steel plate id), the column
+      }
+      //here we set the entrance values in cm
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      // time in ns
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      //set the track ID
+      hit->set_trkid(aTrack->GetTrackID());
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          hit->set_trkid(pp->GetUserTrackId());
+          hit->set_shower_id(pp->GetShower()->get_id());
+        }
+      }
 
-      //       hit->identify();
-      // return true to indicate the hit was used
-      return true;
+      //set the initial energy deposit
+      hit->set_edep(0);
 
+      hit->set_hit_type(0);
+      if ((aTrack->GetParticleDefinition()->GetParticleName().find("e+") != string::npos) ||
+          (aTrack->GetParticleDefinition()->GetParticleName().find("e-") != string::npos))
+        hit->set_hit_type(1);
+
+      if (whichactive > 0)  // return of IsInPrototype2InnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
+      {
+        savehitcontainer = hits_;
+        hit->set_light_yield(0);  // for scintillator only, initialize light yields
+        hit->set_eion(0);
+      }
+      else
+      {
+        savehitcontainer = absorberhits_;
+      }
+
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          hit->set_trkid(pp->GetUserTrackId());
+          hit->set_shower_id(pp->GetShower()->get_id());
+          saveshower = pp->GetShower();
+        }
+      }
+      break;
+    default:
+      break;
     }
-  else
+    // here we just update the exit values, it will be overwritten
+    // for every step until we leave the volume or the particle
+    // ceases to exist
+    hit->set_x(1, postPoint->GetPosition().x() / cm);
+    hit->set_y(1, postPoint->GetPosition().y() / cm);
+    hit->set_z(1, postPoint->GetPosition().z() / cm);
+
+    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+
+    if (whichactive > 0)  // return of IsInPrototype2InnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
     {
-      return false;
+      hit->set_eion(hit->get_eion() + eion);
+      light_yield = eion;
+      if (light_scint_model)
+      {
+        light_yield = GetVisibleEnergyDeposition(aStep);  // for scintillator only, calculate light yields
+      }
+      if (isfinite(light_balance_outer_radius) &&
+          isfinite(light_balance_inner_radius) &&
+          isfinite(light_balance_outer_corr) &&
+          isfinite(light_balance_inner_corr))
+      {
+        double r = sqrt(postPoint->GetPosition().x() * postPoint->GetPosition().x() + postPoint->GetPosition().y() * postPoint->GetPosition().y());
+        double cor = GetLightCorrection(r);
+        light_yield = light_yield * cor;
+      }
+      hit->set_light_yield(hit->get_light_yield() + light_yield);
     }
+
+    //sum up the energy to get total deposited
+    hit->set_edep(hit->get_edep() + edep);
+    if (geantino)
+    {
+      hit->set_edep(-1);    // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      if (whichactive > 0)  // add light yield for scintillators
+      {
+        hit->set_light_yield(-1);
+        hit->set_eion(-1);
+      }
+    }
+    if (edep > 0 && (whichactive > 0 || absorbertruth > 0))
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
+      }
+    }
+    // if any of these conditions is true this is the last step in
+    // this volume and we need to save the hit
+    // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
+    // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
+    // (happens when your detector goes outside world volume)
+    // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
+    // aTrack->GetTrackStatus() == fStopAndKill is also set)
+    // aTrack->GetTrackStatus() == fStopAndKill: track ends
+    if (postPoint->GetStepStatus() == fGeomBoundary ||
+        postPoint->GetStepStatus() == fWorldBoundary ||
+        postPoint->GetStepStatus() == fAtRestDoItProc ||
+        aTrack->GetTrackStatus() == fStopAndKill)
+    {
+      // save only hits with energy deposit (or -1 for geantino)
+      if (hit->get_edep())
+      {
+        savehitcontainer->AddHit(layer_id, hit);
+        if (saveshower)
+        {
+          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+        }
+        // ownership has been transferred to container, set to null
+        // so we will create a new hit for the next track
+        hit = nullptr;
+      }
+      else
+      {
+        // if this hit has no energy deposit, just reset it for reuse
+        // this means we have to delete it in the dtor. If this was
+        // the last hit we processed the memory is still allocated
+        hit->Reset();
+      }
+    }
+
+    //       hit->identify();
+    // return true to indicate the hit was used
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 //____________________________________________________________________________..
-void PHG4Prototype2InnerHcalSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+void PHG4Prototype2InnerHcalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
-
   string hitnodename;
   string absorbernodename;
   if (detector_->SuperDetector() != "NONE")
-    {
-      hitnodename = "G4HIT_" + detector_->SuperDetector();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->SuperDetector();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->SuperDetector();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->SuperDetector();
+  }
   else
-    {
-      hitnodename = "G4HIT_" + detector_->GetName();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->GetName();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->GetName();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->GetName();
+  }
 
   //now look for the map and grab a pointer to it.
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
-  absorberhits_ =  findNode::getClass<PHG4HitContainer>( topNode , absorbernodename.c_str() );
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
 
   // if we do not find the node it's messed up.
-  if ( ! hits_ )
+  if (!hits_)
+  {
+    std::cout << "PHG4Prototype2InnerHcalSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+  }
+  if (!absorberhits_)
+  {
+    if (verbosity > 1)
     {
-      std::cout << "PHG4Prototype2InnerHcalSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+      cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
     }
-  if ( ! absorberhits_)
-    {
-      if (verbosity > 1)
-	{
-	  cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
-	}
-    }
+  }
 }
 
 double
 PHG4Prototype2InnerHcalSteppingAction::GetLightCorrection(const double r) const
 {
-  double m = (light_balance_outer_corr - light_balance_inner_corr)/(light_balance_outer_radius - light_balance_inner_radius);
-  double b = light_balance_inner_corr - m*light_balance_inner_radius;
-  double value = m*r+b;  
+  double m = (light_balance_outer_corr - light_balance_inner_corr) / (light_balance_outer_radius - light_balance_inner_radius);
+  double b = light_balance_inner_corr - m * light_balance_inner_radius;
+  double value = m * r + b;
   if (value > 1.0) return 1.0;
   if (value < 0.0) return 0.0;
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
@@ -11,32 +11,30 @@ class PHG4Shower;
 
 class PHG4Prototype2InnerHcalSteppingAction : public PHG4SteppingAction
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4Prototype2InnerHcalSteppingAction( PHG4Prototype2InnerHcalDetector*, PHG4Parameters *parameters );
+  PHG4Prototype2InnerHcalSteppingAction(PHG4Prototype2InnerHcalDetector *, PHG4Parameters *parameters);
 
   //! destroctor
   virtual ~PHG4Prototype2InnerHcalSteppingAction()
-  {}
+  {
+  }
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  virtual bool UserSteppingAction(const G4Step *, bool);
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers( PHCompositeNode* );
+  virtual void SetInterfacePointers(PHCompositeNode *);
 
   double GetLightCorrection(const double r) const;
 
-  private:
-
+ private:
   //! pointer to the detector
-  PHG4Prototype2InnerHcalDetector* detector_;
+  PHG4Prototype2InnerHcalDetector *detector_;
 
   //! pointer to hit container
-  PHG4HitContainer * hits_;
-  PHG4HitContainer * absorberhits_;
+  PHG4HitContainer *hits_;
+  PHG4HitContainer *absorberhits_;
   PHG4Hit *hit;
   PHG4Parameters *params;
   PHG4HitContainer *savehitcontainer;
@@ -48,12 +46,11 @@ class PHG4Prototype2InnerHcalSteppingAction : public PHG4SteppingAction
   int IsActive;
   int IsBlackHole;
   int light_scint_model;
-  
+
   double light_balance_inner_corr;
   double light_balance_inner_radius;
   double light_balance_outer_corr;
   double light_balance_outer_radius;
 };
 
-
-#endif // PHG4Prototype2InnerHcalSteppingAction_h
+#endif  // PHG4Prototype2InnerHcalSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
@@ -3,10 +3,11 @@
 
 #include <g4main/PHG4SteppingAction.h>
 
-class PHG4Prototype2InnerHcalDetector;
-class PHG4Parameters;
 class PHG4Hit;
 class PHG4HitContainer;
+class PHG4Parameters;
+class PHG4Prototype2InnerHcalDetector;
+class PHG4Shower;
 
 class PHG4Prototype2InnerHcalSteppingAction : public PHG4SteppingAction
 {
@@ -38,6 +39,8 @@ class PHG4Prototype2InnerHcalSteppingAction : public PHG4SteppingAction
   PHG4HitContainer * absorberhits_;
   PHG4Hit *hit;
   PHG4Parameters *params;
+  PHG4HitContainer *savehitcontainer;
+  PHG4Shower *saveshower;
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -1,6 +1,5 @@
 #include "PHG4Prototype2InnerHcalSubsystem.h"
 #include "PHG4Prototype2InnerHcalDetector.h"
-#include "PHG4EventActionClearZeroEdep.h"
 #include "PHG4Prototype2InnerHcalSteppingAction.h"
 #include "PHG4Parameters.h"
 
@@ -20,9 +19,8 @@ using namespace std;
 //_______________________________________________________________________
 PHG4Prototype2InnerHcalSubsystem::PHG4Prototype2InnerHcalSubsystem( const std::string &name, const int lyr ):
   PHG4DetectorSubsystem( name, lyr ),
-  detector_(NULL),
-  steppingAction_( NULL ),
-  eventAction_(NULL)
+  detector_(nullptr),
+  steppingAction_( nullptr )
 {
   InitializeParameters();
 }
@@ -80,16 +78,6 @@ PHG4Prototype2InnerHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 	      g4_hits = new PHG4HitContainer(node);
               DetNode->addNode( new PHIODataNode<PHObject>( g4_hits, node.c_str(), "PHObject" ));
 	    }
-	  if (! eventAction_)
-	    {
-	      eventAction_ = new PHG4EventActionClearZeroEdep(topNode, node);
-	    }
-	  else
-	    {
-	      PHG4EventActionClearZeroEdep *evtact = dynamic_cast<PHG4EventActionClearZeroEdep *>(eventAction_);
-
-	      evtact->AddNode(node);
-	    }
 	}
 
       // create stepping action
@@ -130,6 +118,10 @@ PHG4Prototype2InnerHcalSubsystem::Print(const string &what) const
   if (detector_)
     {
       detector_->Print(what);
+    }
+  if (steppingAction_)
+    {
+      steppingAction_->Print(what);
     }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -1,7 +1,7 @@
 #include "PHG4Prototype2InnerHcalSubsystem.h"
+#include "PHG4Parameters.h"
 #include "PHG4Prototype2InnerHcalDetector.h"
 #include "PHG4Prototype2InnerHcalSteppingAction.h"
-#include "PHG4Parameters.h"
 
 #include <g4main/PHG4HitContainer.h>
 
@@ -17,20 +17,19 @@
 using namespace std;
 
 //_______________________________________________________________________
-PHG4Prototype2InnerHcalSubsystem::PHG4Prototype2InnerHcalSubsystem( const std::string &name, const int lyr ):
-  PHG4DetectorSubsystem( name, lyr ),
-  detector_(nullptr),
-  steppingAction_( nullptr )
+PHG4Prototype2InnerHcalSubsystem::PHG4Prototype2InnerHcalSubsystem(const std::string &name, const int lyr)
+  : PHG4DetectorSubsystem(name, lyr)
+  , detector_(nullptr)
+  , steppingAction_(nullptr)
 {
   InitializeParameters();
 }
 
 //_______________________________________________________________________
-int 
-PHG4Prototype2InnerHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
+int PHG4Prototype2InnerHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
-  PHNodeIterator iter( topNode );
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
   detector_ = new PHG4Prototype2InnerHcalDetector(topNode, GetParams(), Name());
@@ -38,102 +37,96 @@ PHG4Prototype2InnerHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
   detector_->OverlapCheck(CheckOverlap());
   set<string> nodes;
   if (GetParams()->get_int_param("active"))
+  {
+    PHNodeIterator dstiter(dstNode);
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", SuperDetector()));
+    if (!DetNode)
     {
-      PHNodeIterator dstiter( dstNode );
-      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",SuperDetector()));
-      if (! DetNode)
-	{
-          DetNode = new PHCompositeNode(SuperDetector());
-          dstNode->addNode(DetNode);
-        }
+      DetNode = new PHCompositeNode(SuperDetector());
+      dstNode->addNode(DetNode);
+    }
 
-      ostringstream nodename;
+    ostringstream nodename;
+    if (SuperDetector() != "NONE")
+    {
+      nodename << "G4HIT_" << SuperDetector();
+    }
+    else
+    {
+      nodename << "G4HIT_" << Name();
+    }
+    nodes.insert(nodename.str());
+    if (GetParams()->get_int_param("absorberactive"))
+    {
+      nodename.str("");
       if (SuperDetector() != "NONE")
-	{
-	  nodename <<  "G4HIT_" << SuperDetector();
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << SuperDetector();
+      }
       else
-	{
-	  nodename <<  "G4HIT_" <<  Name();
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << Name();
+      }
       nodes.insert(nodename.str());
-      if (GetParams()->get_int_param("absorberactive"))
-	{
-	  nodename.str("");
-	  if (SuperDetector() != "NONE")
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << SuperDetector();
-	    }
-	  else
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" <<  Name();
-	    }
-          nodes.insert(nodename.str());
-	}
-      BOOST_FOREACH(string node, nodes)
-	{
-	  PHG4HitContainer* g4_hits =  findNode::getClass<PHG4HitContainer>( topNode , node.c_str());
-	  if ( !g4_hits )
-	    {
-	      g4_hits = new PHG4HitContainer(node);
-              DetNode->addNode( new PHIODataNode<PHObject>( g4_hits, node.c_str(), "PHObject" ));
-	    }
-	}
-
-      // create stepping action
-      steppingAction_ = new PHG4Prototype2InnerHcalSteppingAction(detector_, GetParams());
-
     }
-  else
+    BOOST_FOREACH (string node, nodes)
     {
-      // if this is a black hole it does not have to be active
-      if (GetParams()->get_int_param("blackhole"))
-	{
-	  steppingAction_ = new PHG4Prototype2InnerHcalSteppingAction(detector_, GetParams());
-	}
+      PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, node.c_str());
+      if (!g4_hits)
+      {
+        g4_hits = new PHG4HitContainer(node);
+        DetNode->addNode(new PHIODataNode<PHObject>(g4_hits, node.c_str(), "PHObject"));
+      }
     }
-  return 0;
 
+    // create stepping action
+    steppingAction_ = new PHG4Prototype2InnerHcalSteppingAction(detector_, GetParams());
+  }
+  else
+  {
+    // if this is a black hole it does not have to be active
+    if (GetParams()->get_int_param("blackhole"))
+    {
+      steppingAction_ = new PHG4Prototype2InnerHcalSteppingAction(detector_, GetParams());
+    }
+  }
+  return 0;
 }
 
 //_______________________________________________________________________
-int
-PHG4Prototype2InnerHcalSubsystem::process_event( PHCompositeNode * topNode )
+int PHG4Prototype2InnerHcalSubsystem::process_event(PHCompositeNode *topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
   if (steppingAction_)
-    {
-      steppingAction_->SetInterfacePointers( topNode );
-    }
+  {
+    steppingAction_->SetInterfacePointers(topNode);
+  }
   return 0;
 }
 
-
-void
-PHG4Prototype2InnerHcalSubsystem::Print(const string &what) const
+void PHG4Prototype2InnerHcalSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
   GetParams()->Print();
   if (detector_)
-    {
-      detector_->Print(what);
-    }
+  {
+    detector_->Print(what);
+  }
   if (steppingAction_)
-    {
-      steppingAction_->Print(what);
-    }
+  {
+    steppingAction_->Print(what);
+  }
   return;
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4Prototype2InnerHcalSubsystem::GetDetector( void ) const
+PHG4Detector *PHG4Prototype2InnerHcalSubsystem::GetDetector(void) const
 {
   return detector_;
 }
 
-void
-PHG4Prototype2InnerHcalSubsystem::SetDefaultParameters()
+void PHG4Prototype2InnerHcalSubsystem::SetDefaultParameters()
 {
   // all in cm
   set_default_double_param("light_balance_inner_corr", NAN);
@@ -154,9 +147,7 @@ PHG4Prototype2InnerHcalSubsystem::SetDefaultParameters()
   set_default_string_param("material", "SS310");
 }
 
-
-void
-PHG4Prototype2InnerHcalSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr)
+void PHG4Prototype2InnerHcalSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr)
 {
   set_double_param("light_balance_inner_corr", inner_corr);
   set_double_param("light_balance_inner_radius", inner_radius);

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.h
@@ -5,7 +5,6 @@
 
 #include <string>
 
-class PHG4EventAction;
 class PHG4Prototype2InnerHcalDetector;
 class PHG4SteppingAction;
 
@@ -42,8 +41,6 @@ class PHG4Prototype2InnerHcalSubsystem: public PHG4DetectorSubsystem
   virtual PHG4Detector* GetDetector( void ) const;
   virtual PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
 
-  PHG4EventAction* GetEventAction() const {return eventAction_;}
-
   void SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr);
   protected:
 
@@ -56,10 +53,6 @@ class PHG4Prototype2InnerHcalSubsystem: public PHG4DetectorSubsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingAction */
   PHG4SteppingAction* steppingAction_;
-
-  //! particle tracking "stepping" action
-  /*! derives from PHG4EventAction */
-  PHG4EventAction *eventAction_;
 
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.h
@@ -8,42 +8,40 @@
 class PHG4Prototype2InnerHcalDetector;
 class PHG4SteppingAction;
 
-class PHG4Prototype2InnerHcalSubsystem: public PHG4DetectorSubsystem
+class PHG4Prototype2InnerHcalSubsystem : public PHG4DetectorSubsystem
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4Prototype2InnerHcalSubsystem( const std::string &name = "HCALIN", const int layer = 0 );
+  PHG4Prototype2InnerHcalSubsystem(const std::string& name = "HCALIN", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4Prototype2InnerHcalSubsystem( void )
-  {}
+  virtual ~PHG4Prototype2InnerHcalSubsystem(void)
+  {
+  }
 
   /*!
   creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode*);
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode*);
 
   //! Print info (from SubsysReco)
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string& what = "ALL") const;
 
   //! accessors (reimplemented)
-  virtual PHG4Detector* GetDetector( void ) const;
-  virtual PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
+  virtual PHG4Detector* GetDetector(void) const;
+  virtual PHG4SteppingAction* GetSteppingAction(void) const { return steppingAction_; }
+  void SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr);
 
-  void SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr);
-  protected:
-
+ protected:
   void SetDefaultParameters();
 
   //! detector geometry
@@ -53,7 +51,6 @@ class PHG4Prototype2InnerHcalSubsystem: public PHG4DetectorSubsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingAction */
   PHG4SteppingAction* steppingAction_;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
@@ -1,9 +1,9 @@
 #include "PHG4Prototype2OuterHcalSteppingAction.h"
-#include "PHG4Prototype2OuterHcalDetector.h"
 #include "PHG4Parameters.h"
+#include "PHG4Prototype2OuterHcalDetector.h"
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
 
@@ -11,16 +11,16 @@
 
 #include <phool/getClass.h>
 
-#include <Geant4/G4Step.hh>
 #include <Geant4/G4MaterialCutsCouple.hh>
+#include <Geant4/G4Step.hh>
 
 #include <boost/foreach.hpp>
 #include <boost/tokenizer.hpp>
 // this is an ugly hack, the gcc optimizer has a bug which
 // triggers the uninitialized variable warning which
-// stops compilation because of our -Werror 
-#include <boost/version.hpp> // to get BOOST_VERSION
-#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700 )
+// stops compilation because of our -Werror
+#include <boost/version.hpp>  // to get BOOST_VERSION
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700)
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #pragma message "ignoring bogus gcc warning in boost header lexical_cast.hpp"
 #include <boost/lexical_cast.hpp>
@@ -33,34 +33,34 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4Prototype2OuterHcalSteppingAction::PHG4Prototype2OuterHcalSteppingAction( PHG4Prototype2OuterHcalDetector* detector, PHG4Parameters *parameters):
-  detector_( detector ),
-  hits_(nullptr),
-  absorberhits_(nullptr),
-  hit(nullptr),
-  params(parameters),
-  savehitcontainer(nullptr),
-  saveshower(nullptr),
-  absorbertruth(params->get_int_param("absorbertruth")),
-  IsActive(params->get_int_param("active")),
-  IsBlackHole(params->get_int_param("blackhole")),
-  light_scint_model(params->get_int_param("light_scint_model")),
-  light_balance_inner_corr(params->get_double_param("light_balance_inner_corr")),
-  light_balance_inner_radius(params->get_double_param("light_balance_inner_radius")*cm),
-  light_balance_outer_corr(params->get_double_param("light_balance_outer_corr")),
-  light_balance_outer_radius(params->get_double_param("light_balance_outer_radius")*cm)
-{}
+PHG4Prototype2OuterHcalSteppingAction::PHG4Prototype2OuterHcalSteppingAction(PHG4Prototype2OuterHcalDetector* detector, PHG4Parameters* parameters)
+  : detector_(detector)
+  , hits_(nullptr)
+  , absorberhits_(nullptr)
+  , hit(nullptr)
+  , params(parameters)
+  , savehitcontainer(nullptr)
+  , saveshower(nullptr)
+  , absorbertruth(params->get_int_param("absorbertruth"))
+  , IsActive(params->get_int_param("active"))
+  , IsBlackHole(params->get_int_param("blackhole"))
+  , light_scint_model(params->get_int_param("light_scint_model"))
+  , light_balance_inner_corr(params->get_double_param("light_balance_inner_corr"))
+  , light_balance_inner_radius(params->get_double_param("light_balance_inner_radius") * cm)
+  , light_balance_outer_corr(params->get_double_param("light_balance_outer_corr"))
+  , light_balance_outer_radius(params->get_double_param("light_balance_outer_radius") * cm)
+{
+}
 
 //____________________________________________________________________________..
-bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
+bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
-
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   // get volume of the current step
   G4VPhysicalVolume* volume = touch->GetVolume();
 
   // detector_->IsInPrototype2OuterHcal(volume)
-  // returns 
+  // returns
   //  0 is outside of Prototype2OuterHcal
   //  1 is inside scintillator
   // -1 is steel absorber
@@ -68,67 +68,67 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
   int whichactive = detector_->IsInPrototype2OuterHcal(volume);
 
   if (!whichactive)
-    {
-      return false;
-    }
+  {
+    return false;
+  }
   int row_id = -1;
   int slat_id = -1;
-  if (whichactive > 0) // scintillator
-    {
-      // first extract the scintillator id (0-3) from the volume name (OuterScinti_0,1,2,3)
-      boost::char_separator<char> sep("_");
-      boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
-      boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter =  tok.begin();
-      ++tokeniter;
-      slat_id = boost::lexical_cast<int>(*tokeniter);
-      // G4AssemblyVolumes naming convention:
-      //     av_WWW_impr_XXX_YYY_ZZZ
-      // where:
+  if (whichactive > 0)  // scintillator
+  {
+    // first extract the scintillator id (0-3) from the volume name (OuterScinti_0,1,2,3)
+    boost::char_separator<char> sep("_");
+    boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
+    boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter = tok.begin();
+    ++tokeniter;
+    slat_id = boost::lexical_cast<int>(*tokeniter);
+    // G4AssemblyVolumes naming convention:
+    //     av_WWW_impr_XXX_YYY_ZZZ
+    // where:
 
-      //     WWW - assembly volume instance number
-      //     XXX - assembly volume imprint number
-      //     YYY - the name of the placed logical volume
-      //     ZZZ - the logical volume index inside the assembly volume
-      // e.g. av_1_impr_1_OuterHcalScintiMother_pv_11
-      // 82 the number of the scintillator mother volume
-      // OuterHcalScintiMother_11: name of scintillator slat
-      // 11: number of scintillator slat logical volume
-      // use boost tokenizer to separate the _, then take value
-      // after "impr" for mother volume and after "pv" for scintillator slat
-      // use boost lexical cast for string -> int conversion
-      G4VPhysicalVolume* mothervolume = touch->GetVolume(1);
-      boost::tokenizer<boost::char_separator<char> > tokm(mothervolume->GetName(), sep);
-      for (tokeniter = tokm.begin(); tokeniter != tokm.end(); ++tokeniter)
-       	{
-       	  if (*tokeniter == "pv")
-       	    {
-       	      ++tokeniter;
-       	      if (tokeniter != tokm.end())
-       		{
-		  row_id = boost::lexical_cast<int>(*tokeniter);
-// from the construction via assembly volumes, the mother id starts 
-// at 2 and is incremented by 2 for each new row of slats
-// this maps it back to 0-nslats
-		  row_id -= 2;  
-		  row_id /= 2;
-		}
-       	      else
-       		{
-       		  cout << PHWHERE << " Error parsing " << mothervolume->GetName()
-       		       << " for mother scinti slat id " << endl;
-		  exit(1);
-       		}
-	      break;
-	    }
-	}
-      // cout << "mother volume: " <<  mothervolume->GetName() 
-      //      << ", volume name " << volume->GetName() << ", row: " << row_id
-      //  	   << ", column: " << slat_id << endl;
-    }
-  else
+    //     WWW - assembly volume instance number
+    //     XXX - assembly volume imprint number
+    //     YYY - the name of the placed logical volume
+    //     ZZZ - the logical volume index inside the assembly volume
+    // e.g. av_1_impr_1_OuterHcalScintiMother_pv_11
+    // 82 the number of the scintillator mother volume
+    // OuterHcalScintiMother_11: name of scintillator slat
+    // 11: number of scintillator slat logical volume
+    // use boost tokenizer to separate the _, then take value
+    // after "impr" for mother volume and after "pv" for scintillator slat
+    // use boost lexical cast for string -> int conversion
+    G4VPhysicalVolume* mothervolume = touch->GetVolume(1);
+    boost::tokenizer<boost::char_separator<char> > tokm(mothervolume->GetName(), sep);
+    for (tokeniter = tokm.begin(); tokeniter != tokm.end(); ++tokeniter)
     {
-      row_id = touch->GetCopyNumber(); // steel plate id
+      if (*tokeniter == "pv")
+      {
+        ++tokeniter;
+        if (tokeniter != tokm.end())
+        {
+          row_id = boost::lexical_cast<int>(*tokeniter);
+          // from the construction via assembly volumes, the mother id starts
+          // at 2 and is incremented by 2 for each new row of slats
+          // this maps it back to 0-nslats
+          row_id -= 2;
+          row_id /= 2;
+        }
+        else
+        {
+          cout << PHWHERE << " Error parsing " << mothervolume->GetName()
+               << " for mother scinti slat id " << endl;
+          exit(1);
+        }
+        break;
+      }
     }
+    // cout << "mother volume: " <<  mothervolume->GetName()
+    //      << ", volume name " << volume->GetName() << ", row: " << row_id
+    //  	   << ", column: " << slat_id << endl;
+  }
+  else
+  {
+    row_id = touch->GetCopyNumber();  // steel plate id
+  }
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
   G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
@@ -137,232 +137,227 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 
   // if this block stops everything, just put all kinetic energy into edep
   if (IsBlackHole)
-    {
-      edep = aTrack->GetKineticEnergy() / GeV;
-      G4Track* killtrack = const_cast<G4Track *> (aTrack);
-      killtrack->SetTrackStatus(fStopAndKill);
-    }
+  {
+    edep = aTrack->GetKineticEnergy() / GeV;
+    G4Track* killtrack = const_cast<G4Track*>(aTrack);
+    killtrack->SetTrackStatus(fStopAndKill);
+  }
   int layer_id = detector_->get_Layer();
 
   // make sure we are in a volume
-  if ( IsActive )
+  if (IsActive)
+  {
+    bool geantino = false;
+
+    // the check for the pdg code speeds things up, I do not want to make
+    // an expensive string compare for every track when we know
+    // geantino or chargedgeantino has pid=0
+    if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
+        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
     {
-      bool geantino = false;
-
-      // the check for the pdg code speeds things up, I do not want to make
-      // an expensive string compare for every track when we know
-      // geantino or chargedgeantino has pid=0
-      if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
-	  aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
-	{
-	  geantino = true;
-	}
-      G4StepPoint * prePoint = aStep->GetPreStepPoint();
-      G4StepPoint * postPoint = aStep->GetPostStepPoint();
-      //       cout << "track id " << aTrack->GetTrackID() << endl;
-      //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
-      //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
-      switch (prePoint->GetStepStatus())
-	{
-	case fGeomBoundary:
-	case fUndefined:
-	if (! hit)
-	  {
-	    hit = new PHG4Hitv1();
-	  }
-	  hit->set_row(row_id); // this is the row
-	  if (whichactive > 0) // only for scintillators
-	    {
-	       hit->set_scint_id(slat_id); // the slat id in the mother volume (or steel plate id), the column
-	    }
-	  //here we set the entrance values in cm
-	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
-	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
-	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
-	  // time in ns
-	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
-	  //set the track ID
-	  hit->set_trkid(aTrack->GetTrackID());
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  hit->set_trkid(pp->GetUserTrackId());
-		  hit->set_shower_id(pp->GetShower()->get_id());
-		}
-	    }
-
-	  //set the initial energy deposit
-	  hit->set_edep(0);
-
-          hit->set_hit_type(0);
-          if( (aTrack->GetParticleDefinition()->GetParticleName().find("e+") != string::npos) ||
-              (aTrack->GetParticleDefinition()->GetParticleName().find("e-") != string::npos) )
-            hit->set_hit_type(1);
-
-	  // here we do things which are different between scintillator and absorber hits
-	  if (whichactive > 0) // return of IsInPrototype2OuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
-	    {
-              savehitcontainer = hits_;
-	      hit->set_light_yield(0); // for scintillator only, initialize light yields
-	      hit->set_eion(0);
-	    }
-	  else
-	    {
-	      savehitcontainer = absorberhits_;
-	    }
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  hit->set_trkid(pp->GetUserTrackId());
-		  hit->set_shower_id(pp->GetShower()->get_id());
-		  saveshower =  pp->GetShower();
-		}
-	    }
-	  break;
-	default:
-	  break;
-	}
-      // here we just update the exit values, it will be overwritten
-      // for every step until we leave the volume or the particle
-      // ceases to exist
-      hit->set_x( 1, postPoint->GetPosition().x() / cm );
-      hit->set_y( 1, postPoint->GetPosition().y() / cm );
-      hit->set_z( 1, postPoint->GetPosition().z() / cm );
-
-      hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
-
-      if (whichactive > 0) // return of IsInPrototype2OuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
+      geantino = true;
+    }
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    //       cout << "track id " << aTrack->GetTrackID() << endl;
+    //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
+    //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
+    switch (prePoint->GetStepStatus())
+    {
+    case fGeomBoundary:
+    case fUndefined:
+      if (!hit)
+      {
+        hit = new PHG4Hitv1();
+      }
+      hit->set_row(row_id);  // this is the row
+      if (whichactive > 0)   // only for scintillators
+      {
+        hit->set_scint_id(slat_id);  // the slat id in the mother volume (or steel plate id), the column
+      }
+      //here we set the entrance values in cm
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      // time in ns
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      //set the track ID
+      hit->set_trkid(aTrack->GetTrackID());
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
-          hit->set_eion(hit->get_eion() + eion);
-          light_yield = eion;
-          if (light_scint_model)
-            {
-              light_yield = GetVisibleEnergyDeposition(aStep); // for scintillator only, calculate light yields
-	    }
-          if (isfinite(light_balance_outer_radius) && 
-              isfinite(light_balance_inner_radius) && 
-	      isfinite(light_balance_outer_corr) &&
-	      isfinite(light_balance_inner_corr))
-            {
-              double r = sqrt(postPoint->GetPosition().x()*postPoint->GetPosition().x()
-			    + postPoint->GetPosition().y()*postPoint->GetPosition().y());
-              double cor =  GetLightCorrection(r);
-              light_yield = light_yield * cor;
-            }
-	  hit->set_light_yield(hit->get_light_yield() + light_yield);
+          hit->set_trkid(pp->GetUserTrackId());
+          hit->set_shower_id(pp->GetShower()->get_id());
         }
+      }
 
-      //sum up the energy to get total deposited
-      hit->set_edep(hit->get_edep() + edep);
-      if (geantino)
-	{
-	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-	  if (whichactive > 0)
-	    {
-	      hit->set_light_yield(-1);
-              hit->set_eion(-1);
-	    }
-	}
-      if (edep > 0 && (whichactive > 0 || absorbertruth > 0))
-	{
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  pp->SetKeep(1); // we want to keep the track
-		}
+      //set the initial energy deposit
+      hit->set_edep(0);
 
+      hit->set_hit_type(0);
+      if ((aTrack->GetParticleDefinition()->GetParticleName().find("e+") != string::npos) ||
+          (aTrack->GetParticleDefinition()->GetParticleName().find("e-") != string::npos))
+        hit->set_hit_type(1);
 
-	    }
-	}
-
-      // if any of these conditions is true this is the last step in
-      // this volume and we need to save the hit
-      // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
-      // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
-      // (happens when your detector goes outside world volume)
-      // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
-      // aTrack->GetTrackStatus() == fStopAndKill is also set)
-      // aTrack->GetTrackStatus() == fStopAndKill: track ends
-      if (postPoint->GetStepStatus() == fGeomBoundary || 
-          postPoint->GetStepStatus() == fWorldBoundary || 
-	  postPoint->GetStepStatus() == fAtRestDoItProc ||
-          aTrack->GetTrackStatus() == fStopAndKill)
-	{
-          // save only hits with energy deposit (or -1 for geantino)
-	  if (hit->get_edep())
-	    {
-	      savehitcontainer->AddHit(layer_id, hit);
-	      if (saveshower)
-		{
-		  saveshower->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		}
-	      // ownership has been transferred to container, set to null
-	      // so we will create a new hit for the next track
-	      hit = nullptr;
-	    }
-	  else
-	    {
-	      // if this hit has no energy deposit, just reset it for reuse
-	      // this means we have to delete it in the dtor. If this was
-	      // the last hit we processed the memory is still allocated
-	      hit->Reset();
-	    }
- 	}
-      //       hit->identify();
-      // return true to indicate the hit was used
-      return true;
-
+      // here we do things which are different between scintillator and absorber hits
+      if (whichactive > 0)  // return of IsInPrototype2OuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
+      {
+        savehitcontainer = hits_;
+        hit->set_light_yield(0);  // for scintillator only, initialize light yields
+        hit->set_eion(0);
+      }
+      else
+      {
+        savehitcontainer = absorberhits_;
+      }
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          hit->set_trkid(pp->GetUserTrackId());
+          hit->set_shower_id(pp->GetShower()->get_id());
+          saveshower = pp->GetShower();
+        }
+      }
+      break;
+    default:
+      break;
     }
-  else
+    // here we just update the exit values, it will be overwritten
+    // for every step until we leave the volume or the particle
+    // ceases to exist
+    hit->set_x(1, postPoint->GetPosition().x() / cm);
+    hit->set_y(1, postPoint->GetPosition().y() / cm);
+    hit->set_z(1, postPoint->GetPosition().z() / cm);
+
+    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+
+    if (whichactive > 0)  // return of IsInPrototype2OuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
     {
-      return false;
+      hit->set_eion(hit->get_eion() + eion);
+      light_yield = eion;
+      if (light_scint_model)
+      {
+        light_yield = GetVisibleEnergyDeposition(aStep);  // for scintillator only, calculate light yields
+      }
+      if (isfinite(light_balance_outer_radius) &&
+          isfinite(light_balance_inner_radius) &&
+          isfinite(light_balance_outer_corr) &&
+          isfinite(light_balance_inner_corr))
+      {
+        double r = sqrt(postPoint->GetPosition().x() * postPoint->GetPosition().x() + postPoint->GetPosition().y() * postPoint->GetPosition().y());
+        double cor = GetLightCorrection(r);
+        light_yield = light_yield * cor;
+      }
+      hit->set_light_yield(hit->get_light_yield() + light_yield);
     }
+
+    //sum up the energy to get total deposited
+    hit->set_edep(hit->get_edep() + edep);
+    if (geantino)
+    {
+      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      if (whichactive > 0)
+      {
+        hit->set_light_yield(-1);
+        hit->set_eion(-1);
+      }
+    }
+    if (edep > 0 && (whichactive > 0 || absorbertruth > 0))
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
+      }
+    }
+
+    // if any of these conditions is true this is the last step in
+    // this volume and we need to save the hit
+    // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
+    // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
+    // (happens when your detector goes outside world volume)
+    // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
+    // aTrack->GetTrackStatus() == fStopAndKill is also set)
+    // aTrack->GetTrackStatus() == fStopAndKill: track ends
+    if (postPoint->GetStepStatus() == fGeomBoundary ||
+        postPoint->GetStepStatus() == fWorldBoundary ||
+        postPoint->GetStepStatus() == fAtRestDoItProc ||
+        aTrack->GetTrackStatus() == fStopAndKill)
+    {
+      // save only hits with energy deposit (or -1 for geantino)
+      if (hit->get_edep())
+      {
+        savehitcontainer->AddHit(layer_id, hit);
+        if (saveshower)
+        {
+          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+        }
+        // ownership has been transferred to container, set to null
+        // so we will create a new hit for the next track
+        hit = nullptr;
+      }
+      else
+      {
+        // if this hit has no energy deposit, just reset it for reuse
+        // this means we have to delete it in the dtor. If this was
+        // the last hit we processed the memory is still allocated
+        hit->Reset();
+      }
+    }
+    //       hit->identify();
+    // return true to indicate the hit was used
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 //____________________________________________________________________________..
-void PHG4Prototype2OuterHcalSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+void PHG4Prototype2OuterHcalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
-
   string hitnodename;
   string absorbernodename;
   if (detector_->SuperDetector() != "NONE")
-    {
-      hitnodename = "G4HIT_" + detector_->SuperDetector();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->SuperDetector();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->SuperDetector();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->SuperDetector();
+  }
   else
-    {
-      hitnodename = "G4HIT_" + detector_->GetName();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->GetName();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->GetName();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->GetName();
+  }
 
   //now look for the map and grab a pointer to it.
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
-  absorberhits_ =  findNode::getClass<PHG4HitContainer>( topNode , absorbernodename.c_str() );
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
 
   // if we do not find the node it's messed up.
-  if ( ! hits_ )
+  if (!hits_)
+  {
+    std::cout << "PHG4Prototype2OuterHcalSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+  }
+  if (!absorberhits_)
+  {
+    if (verbosity > 1)
     {
-      std::cout << "PHG4Prototype2OuterHcalSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+      cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
     }
-  if ( ! absorberhits_)
-    {
-      if (verbosity > 1)
-	{
-	  cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
-	}
-    }
+  }
 }
 
 double
 PHG4Prototype2OuterHcalSteppingAction::GetLightCorrection(const double r) const
 {
-  double m = (light_balance_outer_corr - light_balance_inner_corr)/(light_balance_outer_radius - light_balance_inner_radius);
-  double b = light_balance_inner_corr - m*light_balance_inner_radius;
-  double value = m*r+b;  
+  double m = (light_balance_outer_corr - light_balance_inner_corr) / (light_balance_outer_radius - light_balance_inner_radius);
+  double b = light_balance_inner_corr - m * light_balance_inner_radius;
+  double value = m * r + b;
   if (value > 1.0) return 1.0;
   if (value < 0.0) return 0.0;
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
@@ -35,10 +35,12 @@ using namespace std;
 //____________________________________________________________________________..
 PHG4Prototype2OuterHcalSteppingAction::PHG4Prototype2OuterHcalSteppingAction( PHG4Prototype2OuterHcalDetector* detector, PHG4Parameters *parameters):
   detector_( detector ),
-  hits_(NULL),
-  absorberhits_(NULL),
-  hit(NULL),
+  hits_(nullptr),
+  absorberhits_(nullptr),
+  hit(nullptr),
   params(parameters),
+  savehitcontainer(nullptr),
+  saveshower(nullptr),
   absorbertruth(params->get_int_param("absorbertruth")),
   IsActive(params->get_int_param("active")),
   IsBlackHole(params->get_int_param("blackhole")),
@@ -164,7 +166,10 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	{
 	case fGeomBoundary:
 	case fUndefined:
-	  hit = new PHG4Hitv1();
+	if (! hit)
+	  {
+	    hit = new PHG4Hitv1();
+	  }
 	  hit->set_row(row_id); // this is the row
 	  if (whichactive > 0) // only for scintillators
 	    {
@@ -189,31 +194,30 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 
 	  //set the initial energy deposit
 	  hit->set_edep(0);
-	  hit->set_eion(0); // only implemented for v5 otherwise empty
 
           hit->set_hit_type(0);
           if( (aTrack->GetParticleDefinition()->GetParticleName().find("e+") != string::npos) ||
               (aTrack->GetParticleDefinition()->GetParticleName().find("e-") != string::npos) )
             hit->set_hit_type(1);
 
-          PHG4HitContainer *hitcontainer;
 	  // here we do things which are different between scintillator and absorber hits
 	  if (whichactive > 0) // return of IsInPrototype2OuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
 	    {
-              hitcontainer = hits_;
+              savehitcontainer = hits_;
 	      hit->set_light_yield(0); // for scintillator only, initialize light yields
+	      hit->set_eion(0);
 	    }
 	  else
 	    {
-	      hitcontainer = absorberhits_;
+	      savehitcontainer = absorberhits_;
 	    }
-	  // here we set what is common for scintillator and absorber hits
-	  hitcontainer->AddHit(layer_id, hit);
 	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
 	    {
 	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
 		{
-		  pp->GetShower()->add_g4hit_id(hitcontainer->GetID(),hit->get_hit_id());
+		  hit->set_trkid(pp->GetUserTrackId());
+		  hit->set_shower_id(pp->GetShower()->get_id());
+		  saveshower =  pp->GetShower();
 		}
 	    }
 	  break;
@@ -231,6 +235,7 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 
       if (whichactive > 0) // return of IsInPrototype2OuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
         {
+          hit->set_eion(hit->get_eion() + eion);
           light_yield = eion;
           if (light_scint_model)
             {
@@ -251,14 +256,13 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 
       //sum up the energy to get total deposited
       hit->set_edep(hit->get_edep() + edep);
-      hit->set_eion(hit->get_eion() + eion);
       if (geantino)
 	{
 	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-          hit->set_eion(-1);
 	  if (whichactive > 0)
 	    {
 	      hit->set_light_yield(-1);
+              hit->set_eion(-1);
 	    }
 	}
       if (edep > 0 && (whichactive > 0 || absorbertruth > 0))
@@ -274,6 +278,39 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction( const G4Step* aS
 	    }
 	}
 
+      // if any of these conditions is true this is the last step in
+      // this volume and we need to save the hit
+      // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
+      // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
+      // (happens when your detector goes outside world volume)
+      // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
+      // aTrack->GetTrackStatus() == fStopAndKill is also set)
+      // aTrack->GetTrackStatus() == fStopAndKill: track ends
+      if (postPoint->GetStepStatus() == fGeomBoundary || 
+          postPoint->GetStepStatus() == fWorldBoundary || 
+	  postPoint->GetStepStatus() == fAtRestDoItProc ||
+          aTrack->GetTrackStatus() == fStopAndKill)
+	{
+          // save only hits with energy deposit (or -1 for geantino)
+	  if (hit->get_edep())
+	    {
+	      savehitcontainer->AddHit(layer_id, hit);
+	      if (saveshower)
+		{
+		  saveshower->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
+		}
+	      // ownership has been transferred to container, set to null
+	      // so we will create a new hit for the next track
+	      hit = nullptr;
+	    }
+	  else
+	    {
+	      // if this hit has no energy deposit, just reset it for reuse
+	      // this means we have to delete it in the dtor. If this was
+	      // the last hit we processed the memory is still allocated
+	      hit->Reset();
+	    }
+ 	}
       //       hit->identify();
       // return true to indicate the hit was used
       return true;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.h
@@ -7,6 +7,7 @@ class PHG4Prototype2OuterHcalDetector;
 class PHG4Parameters;
 class PHG4Hit;
 class PHG4HitContainer;
+class PHG4Shower;
 
 class PHG4Prototype2OuterHcalSteppingAction : public PHG4SteppingAction
 {
@@ -38,6 +39,8 @@ class PHG4Prototype2OuterHcalSteppingAction : public PHG4SteppingAction
   PHG4HitContainer * absorberhits_;
   PHG4Hit *hit;
   PHG4Parameters *params;
+  PHG4HitContainer *savehitcontainer;
+  PHG4Shower *saveshower;
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.h
@@ -11,32 +11,30 @@ class PHG4Shower;
 
 class PHG4Prototype2OuterHcalSteppingAction : public PHG4SteppingAction
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4Prototype2OuterHcalSteppingAction( PHG4Prototype2OuterHcalDetector*, PHG4Parameters *parameters );
+  PHG4Prototype2OuterHcalSteppingAction(PHG4Prototype2OuterHcalDetector *, PHG4Parameters *parameters);
 
   //! destroctor
   virtual ~PHG4Prototype2OuterHcalSteppingAction()
-  {}
+  {
+  }
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  virtual bool UserSteppingAction(const G4Step *, bool);
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers( PHCompositeNode* );
+  virtual void SetInterfacePointers(PHCompositeNode *);
 
   double GetLightCorrection(const double r) const;
 
-  private:
-
+ private:
   //! pointer to the detector
-  PHG4Prototype2OuterHcalDetector* detector_;
+  PHG4Prototype2OuterHcalDetector *detector_;
 
   //! pointer to hit container
-  PHG4HitContainer * hits_;
-  PHG4HitContainer * absorberhits_;
+  PHG4HitContainer *hits_;
+  PHG4HitContainer *absorberhits_;
   PHG4Hit *hit;
   PHG4Parameters *params;
   PHG4HitContainer *savehitcontainer;
@@ -48,12 +46,11 @@ class PHG4Prototype2OuterHcalSteppingAction : public PHG4SteppingAction
   int IsActive;
   int IsBlackHole;
   int light_scint_model;
-  
+
   double light_balance_inner_corr;
   double light_balance_inner_radius;
   double light_balance_outer_corr;
   double light_balance_outer_radius;
 };
 
-
-#endif // PHG4Prototype2OuterHcalSteppingAction_h
+#endif  // PHG4Prototype2OuterHcalSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
@@ -1,6 +1,5 @@
 #include "PHG4Prototype2OuterHcalSubsystem.h"
 #include "PHG4Prototype2OuterHcalDetector.h"
-#include "PHG4EventActionClearZeroEdep.h"
 #include "PHG4Prototype2OuterHcalSteppingAction.h"
 #include "PHG4Parameters.h"
 
@@ -20,9 +19,8 @@ using namespace std;
 //_______________________________________________________________________
 PHG4Prototype2OuterHcalSubsystem::PHG4Prototype2OuterHcalSubsystem( const std::string &name, const int lyr ):
   PHG4DetectorSubsystem( name, lyr ),
-  detector_(NULL),
-  steppingAction_( NULL ),
-  eventAction_(NULL)
+  detector_(nullptr),
+  steppingAction_( nullptr )
 {
   InitializeParameters();
 }
@@ -79,16 +77,6 @@ PHG4Prototype2OuterHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 	    {
 	      g4_hits = new PHG4HitContainer(node);
               DetNode->addNode( new PHIODataNode<PHObject>( g4_hits, node.c_str(), "PHObject" ));
-	    }
-	  if (! eventAction_)
-	    {
-	      eventAction_ = new PHG4EventActionClearZeroEdep(topNode, node);
-	    }
-	  else
-	    {
-	      PHG4EventActionClearZeroEdep *evtact = dynamic_cast<PHG4EventActionClearZeroEdep *>(eventAction_);
-
-	      evtact->AddNode(node);
 	    }
 	}
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
@@ -1,7 +1,7 @@
 #include "PHG4Prototype2OuterHcalSubsystem.h"
+#include "PHG4Parameters.h"
 #include "PHG4Prototype2OuterHcalDetector.h"
 #include "PHG4Prototype2OuterHcalSteppingAction.h"
-#include "PHG4Parameters.h"
 
 #include <g4main/PHG4HitContainer.h>
 
@@ -17,20 +17,19 @@
 using namespace std;
 
 //_______________________________________________________________________
-PHG4Prototype2OuterHcalSubsystem::PHG4Prototype2OuterHcalSubsystem( const std::string &name, const int lyr ):
-  PHG4DetectorSubsystem( name, lyr ),
-  detector_(nullptr),
-  steppingAction_( nullptr )
+PHG4Prototype2OuterHcalSubsystem::PHG4Prototype2OuterHcalSubsystem(const std::string &name, const int lyr)
+  : PHG4DetectorSubsystem(name, lyr)
+  , detector_(nullptr)
+  , steppingAction_(nullptr)
 {
   InitializeParameters();
 }
 
 //_______________________________________________________________________
-int 
-PHG4Prototype2OuterHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
+int PHG4Prototype2OuterHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
-  PHNodeIterator iter( topNode );
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
   detector_ = new PHG4Prototype2OuterHcalDetector(topNode, GetParams(), Name());
@@ -38,98 +37,92 @@ PHG4Prototype2OuterHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
   detector_->OverlapCheck(CheckOverlap());
   set<string> nodes;
   if (GetParams()->get_int_param("active"))
+  {
+    PHNodeIterator dstiter(dstNode);
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", SuperDetector()));
+    if (!DetNode)
     {
-      PHNodeIterator dstiter(dstNode);
-      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",SuperDetector()));
-      if (! DetNode)
-	{
-          DetNode = new PHCompositeNode(SuperDetector());
-          dstNode->addNode(DetNode);
-        }
+      DetNode = new PHCompositeNode(SuperDetector());
+      dstNode->addNode(DetNode);
+    }
 
-      ostringstream nodename;
+    ostringstream nodename;
+    if (SuperDetector() != "NONE")
+    {
+      nodename << "G4HIT_" << SuperDetector();
+    }
+    else
+    {
+      nodename << "G4HIT_" << Name();
+    }
+    nodes.insert(nodename.str());
+    if (GetParams()->get_int_param("absorberactive"))
+    {
+      nodename.str("");
       if (SuperDetector() != "NONE")
-	{
-	  nodename <<  "G4HIT_" << SuperDetector();
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << SuperDetector();
+      }
       else
-	{
-	  nodename <<  "G4HIT_" << Name();
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << Name();
+      }
       nodes.insert(nodename.str());
-      if (GetParams()->get_int_param("absorberactive"))
-	{
-	  nodename.str("");
-	  if (SuperDetector() != "NONE")
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << SuperDetector();
-	    }
-	  else
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << Name();
-	    }
-          nodes.insert(nodename.str());
-	}
-      BOOST_FOREACH(string node, nodes)
-	{
-	  PHG4HitContainer* g4_hits =  findNode::getClass<PHG4HitContainer>( topNode , node.c_str());
-	  if ( !g4_hits )
-	    {
-	      g4_hits = new PHG4HitContainer(node);
-              DetNode->addNode( new PHIODataNode<PHObject>( g4_hits, node.c_str(), "PHObject" ));
-	    }
-	}
-
-      // create stepping action
-      steppingAction_ = new PHG4Prototype2OuterHcalSteppingAction(detector_, GetParams());
-
     }
-  else
+    BOOST_FOREACH (string node, nodes)
     {
-      // if this is a black hole it does not have to be active
-      if (GetParams()->get_int_param("blackhole"))
-	{
-	  steppingAction_ = new PHG4Prototype2OuterHcalSteppingAction(detector_, GetParams());
-	}
+      PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, node.c_str());
+      if (!g4_hits)
+      {
+        g4_hits = new PHG4HitContainer(node);
+        DetNode->addNode(new PHIODataNode<PHObject>(g4_hits, node.c_str(), "PHObject"));
+      }
     }
-  return 0;
 
+    // create stepping action
+    steppingAction_ = new PHG4Prototype2OuterHcalSteppingAction(detector_, GetParams());
+  }
+  else
+  {
+    // if this is a black hole it does not have to be active
+    if (GetParams()->get_int_param("blackhole"))
+    {
+      steppingAction_ = new PHG4Prototype2OuterHcalSteppingAction(detector_, GetParams());
+    }
+  }
+  return 0;
 }
 
 //_______________________________________________________________________
-int
-PHG4Prototype2OuterHcalSubsystem::process_event( PHCompositeNode * topNode )
+int PHG4Prototype2OuterHcalSubsystem::process_event(PHCompositeNode *topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
   if (steppingAction_)
-    {
-      steppingAction_->SetInterfacePointers( topNode );
-    }
+  {
+    steppingAction_->SetInterfacePointers(topNode);
+  }
   return 0;
 }
 
-
-void
-PHG4Prototype2OuterHcalSubsystem::Print(const string &what) const
+void PHG4Prototype2OuterHcalSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
   GetParams()->Print();
   if (detector_)
-    {
-      detector_->Print(what);
-    }
+  {
+    detector_->Print(what);
+  }
   return;
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4Prototype2OuterHcalSubsystem::GetDetector( void ) const
+PHG4Detector *PHG4Prototype2OuterHcalSubsystem::GetDetector(void) const
 {
   return detector_;
 }
 
-void
-PHG4Prototype2OuterHcalSubsystem::SetDefaultParameters()
+void PHG4Prototype2OuterHcalSubsystem::SetDefaultParameters()
 {
   // all in cm
   set_default_double_param("light_balance_inner_corr", NAN);
@@ -148,11 +141,9 @@ PHG4Prototype2OuterHcalSubsystem::SetDefaultParameters()
   set_default_int_param("hi_eta", 0);
 
   set_default_string_param("material", "SS310");
-
 }
 
-void
-PHG4Prototype2OuterHcalSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr)
+void PHG4Prototype2OuterHcalSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr)
 {
   set_double_param("light_balance_inner_corr", inner_corr);
   set_double_param("light_balance_inner_radius", inner_radius);

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.h
@@ -10,43 +10,40 @@
 class PHG4Prototype2OuterHcalDetector;
 class PHG4SteppingAction;
 
-class PHG4Prototype2OuterHcalSubsystem: public PHG4DetectorSubsystem
+class PHG4Prototype2OuterHcalSubsystem : public PHG4DetectorSubsystem
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4Prototype2OuterHcalSubsystem( const std::string &name = "HCALIN", const int layer = 0 );
+  PHG4Prototype2OuterHcalSubsystem(const std::string& name = "HCALIN", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4Prototype2OuterHcalSubsystem( void )
-  {}
+  virtual ~PHG4Prototype2OuterHcalSubsystem(void)
+  {
+  }
 
   /*!
   creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode*);
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode*);
 
   //! Print info (from SubsysReco)
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string& what = "ALL") const;
 
   //! accessors (reimplemented)
-  virtual PHG4Detector* GetDetector( void ) const;
-  virtual PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
+  virtual PHG4Detector* GetDetector(void) const;
+  virtual PHG4SteppingAction* GetSteppingAction(void) const { return steppingAction_; }
+  void SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr);
 
-  void SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr);
-
-  protected:
-
+ protected:
   void SetDefaultParameters();
 
   //! detector geometry
@@ -56,7 +53,6 @@ class PHG4Prototype2OuterHcalSubsystem: public PHG4DetectorSubsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingAction */
   PHG4SteppingAction* steppingAction_;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.h
@@ -7,7 +7,6 @@
 #include <set>
 #include <string>
 
-class PHG4EventAction;
 class PHG4Prototype2OuterHcalDetector;
 class PHG4SteppingAction;
 
@@ -44,8 +43,6 @@ class PHG4Prototype2OuterHcalSubsystem: public PHG4DetectorSubsystem
   virtual PHG4Detector* GetDetector( void ) const;
   virtual PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
 
-  PHG4EventAction* GetEventAction() const {return eventAction_;}
-
   void SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr);
 
   protected:
@@ -59,10 +56,6 @@ class PHG4Prototype2OuterHcalSubsystem: public PHG4DetectorSubsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingAction */
   PHG4SteppingAction* steppingAction_;
-
-  //! particle tracking "stepping" action
-  /*! derives from PHG4EventAction */
-  PHG4EventAction *eventAction_;
 
 };
 


### PR DESCRIPTION
Just bringing the prototype2 hcals to the same level as other detectors. The resulting hits did not change (except the ionization energy is now also saved for the scintillators)