### PR TITLE
Adding FullCalo (jet patch) trigger simulator capability

### DIFF
--- a/offline/packages/trigger/CaloTriggerInfo.h
+++ b/offline/packages/trigger/CaloTriggerInfo.h
@@ -11,18 +11,69 @@ class CaloTriggerInfo : public PHObject
   virtual void identify(std::ostream &os = std::cout) const { os << "CaloTriggerInfo base class" << std::endl; };
   virtual void Reset() {}
   virtual int isValid() const { return 0; }
-  virtual void set_best_2x2_E(float E) {}
-  virtual void set_best_2x2_eta(float eta) {}
-  virtual void set_best_2x2_phi(float phi) {}
-  virtual float get_best_2x2_E() { return 0; }
-  virtual float get_best_2x2_eta() { return 0; }
-  virtual float get_best_2x2_phi() { return 0; }
-  virtual void set_best_4x4_E(float E) {}
-  virtual void set_best_4x4_eta(float eta) {}
-  virtual void set_best_4x4_phi(float phi) {}
-  virtual float get_best_4x4_E() { return 0; }
-  virtual float get_best_4x4_eta() { return 0; }
-  virtual float get_best_4x4_phi() { return 0; }
+
+  // EMCal 2x2
+  virtual void set_best_EMCal_2x2_E(float E) {}
+  virtual void set_best_EMCal_2x2_eta(float eta) {}
+  virtual void set_best_EMCal_2x2_phi(float phi) {}
+
+  virtual float get_best_EMCal_2x2_E() { return 0; }
+  virtual float get_best_EMCal_2x2_eta() { return 0; }
+  virtual float get_best_EMCal_2x2_phi() { return 0; }
+
+  // EMCal 4x4
+  virtual void set_best_EMCal_4x4_E(float E) {}
+  virtual void set_best_EMCal_4x4_eta(float eta) {}
+  virtual void set_best_EMCal_4x4_phi(float phi) {}
+
+  virtual float get_best_EMCal_4x4_E() { return 0; }
+  virtual float get_best_EMCal_4x4_eta() { return 0; }
+  virtual float get_best_EMCal_4x4_phi() { return 0; }
+
+  // FullCalo 0.2x0.2
+  virtual void set_best_FullCalo_0p2x0p2_E(float E) {}
+  virtual void set_best_FullCalo_0p2x0p2_eta(float eta) {}
+  virtual void set_best_FullCalo_0p2x0p2_phi(float phi) {}
+
+  virtual float get_best_FullCalo_0p2x0p2_E() { return 0; }
+  virtual float get_best_FullCalo_0p2x0p2_eta() { return 0; }
+  virtual float get_best_FullCalo_0p2x0p2_phi() { return 0; }
+
+  // FullCalo 0.4x0.4
+  virtual void set_best_FullCalo_0p4x0p4_E(float E) {}
+  virtual void set_best_FullCalo_0p4x0p4_eta(float eta) {}
+  virtual void set_best_FullCalo_0p4x0p4_phi(float phi) {}
+
+  virtual float get_best_FullCalo_0p4x0p4_E() { return 0; }
+  virtual float get_best_FullCalo_0p4x0p4_eta() { return 0; }
+  virtual float get_best_FullCalo_0p4x0p4_phi() { return 0; }
+
+  // FullCalo 0.6x0.6
+  virtual void set_best_FullCalo_0p6x0p6_E(float E) {}
+  virtual void set_best_FullCalo_0p6x0p6_eta(float eta) {}
+  virtual void set_best_FullCalo_0p6x0p6_phi(float phi) {}
+
+  virtual float get_best_FullCalo_0p6x0p6_E() { return 0; }
+  virtual float get_best_FullCalo_0p6x0p6_eta() { return 0; }
+  virtual float get_best_FullCalo_0p6x0p6_phi() { return 0; }
+
+  // FullCalo 0.8x0.8
+  virtual void set_best_FullCalo_0p8x0p8_E(float E) {}
+  virtual void set_best_FullCalo_0p8x0p8_eta(float eta) {}
+  virtual void set_best_FullCalo_0p8x0p8_phi(float phi) {}
+
+  virtual float get_best_FullCalo_0p8x0p8_E() { return 0; }
+  virtual float get_best_FullCalo_0p8x0p8_eta() { return 0; }
+  virtual float get_best_FullCalo_0p8x0p8_phi() { return 0; }
+
+  // FullCalo 1.0x1.0
+  virtual void set_best_FullCalo_1p0x1p0_E(float E) {}
+  virtual void set_best_FullCalo_1p0x1p0_eta(float eta) {}
+  virtual void set_best_FullCalo_1p0x1p0_phi(float phi) {}
+
+  virtual float get_best_FullCalo_1p0x1p0_E() { return 0; }
+  virtual float get_best_FullCalo_1p0x1p0_eta() { return 0; }
+  virtual float get_best_FullCalo_1p0x1p0_phi() { return 0; }
 
  protected:
   CaloTriggerInfo() {}

--- a/offline/packages/trigger/CaloTriggerInfo_v1.C
+++ b/offline/packages/trigger/CaloTriggerInfo_v1.C
@@ -4,9 +4,34 @@ ClassImp(CaloTriggerInfo_v1)
 
 CaloTriggerInfo_v1::CaloTriggerInfo_v1()
 {
+  _EMCAL_2x2_BEST_E = 0;
+  _EMCAL_2x2_BEST_ETA = 0;
+  _EMCAL_2x2_BEST_PHI = 0;
+
   _EMCAL_4x4_BEST_E = 0;
   _EMCAL_4x4_BEST_ETA = 0;
   _EMCAL_4x4_BEST_PHI = 0;
+
+  _FULLCALO_0p2x0p2_BEST_E = 0;
+  _FULLCALO_0p2x0p2_BEST_ETA = 0;
+  _FULLCALO_0p2x0p2_BEST_PHI = 0;
+
+  _FULLCALO_0p4x0p4_BEST_E = 0;
+  _FULLCALO_0p4x0p4_BEST_ETA = 0;
+  _FULLCALO_0p4x0p4_BEST_PHI = 0;
+
+  _FULLCALO_0p6x0p6_BEST_E = 0;
+  _FULLCALO_0p6x0p6_BEST_ETA = 0;
+  _FULLCALO_0p6x0p6_BEST_PHI = 0;
+
+  _FULLCALO_0p8x0p8_BEST_E = 0;
+  _FULLCALO_0p8x0p8_BEST_ETA = 0;
+  _FULLCALO_0p8x0p8_BEST_PHI = 0;
+
+  _FULLCALO_1p0x1p0_BEST_E = 0;
+  _FULLCALO_1p0x1p0_BEST_ETA = 0;
+  _FULLCALO_1p0x1p0_BEST_PHI = 0;
+
 }
 
 CaloTriggerInfo_v1::~CaloTriggerInfo_v1()
@@ -15,7 +40,13 @@ CaloTriggerInfo_v1::~CaloTriggerInfo_v1()
 
 void CaloTriggerInfo_v1::identify(ostream& os) const
 {
-  os << "CaloTriggerInfo: highest 2x2 eta/phi = " << _EMCAL_4x4_BEST_ETA << " / " << _EMCAL_4x4_BEST_PHI << ", E = " << _EMCAL_4x4_BEST_E << std::endl;
+  os << "CaloTriggerInfo: highest EMCal 2x2 eta/phi = " << _EMCAL_2x2_BEST_ETA << " / " << _EMCAL_2x2_BEST_PHI << ", E = " << _EMCAL_2x2_BEST_E << std::endl;
+  os << "CaloTriggerInfo: highest EMCal 4x4 eta/phi = " << _EMCAL_4x4_BEST_ETA << " / " << _EMCAL_4x4_BEST_PHI << ", E = " << _EMCAL_4x4_BEST_E << std::endl;
+  os << "CaloTriggerInfo: highest FullCalo 0.2x0.2 eta/phi = " << _FULLCALO_0p2x0p2_BEST_ETA << " / " << _FULLCALO_0p2x0p2_BEST_PHI << ", E = " << _FULLCALO_0p2x0p2_BEST_E << std::endl;
+  os << "CaloTriggerInfo: highest FullCalo 0.4x0.4 eta/phi = " << _FULLCALO_0p4x0p4_BEST_ETA << " / " << _FULLCALO_0p4x0p4_BEST_PHI << ", E = " << _FULLCALO_0p4x0p4_BEST_E << std::endl;
+  os << "CaloTriggerInfo: highest FullCalo 0.6x0.6 eta/phi = " << _FULLCALO_0p6x0p6_BEST_ETA << " / " << _FULLCALO_0p6x0p6_BEST_PHI << ", E = " << _FULLCALO_0p6x0p6_BEST_E << std::endl;
+  os << "CaloTriggerInfo: highest FullCalo 0.8x0.8 eta/phi = " << _FULLCALO_0p8x0p8_BEST_ETA << " / " << _FULLCALO_0p8x0p8_BEST_PHI << ", E = " << _FULLCALO_0p8x0p8_BEST_E << std::endl;
+  os << "CaloTriggerInfo: highest FullCalo 1.0x1.0 eta/phi = " << _FULLCALO_1p0x1p0_BEST_ETA << " / " << _FULLCALO_1p0x1p0_BEST_PHI << ", E = " << _FULLCALO_1p0x1p0_BEST_E << std::endl;
 
   return;
 }

--- a/offline/packages/trigger/CaloTriggerInfo_v1.h
+++ b/offline/packages/trigger/CaloTriggerInfo_v1.h
@@ -14,18 +14,70 @@ class CaloTriggerInfo_v1 : public CaloTriggerInfo
   void identify(std::ostream &os = std::cout) const;
   void Reset() {}
   int isValid() const { return 1; }
-  void set_best_2x2_E(float E) { _EMCAL_2x2_BEST_E = E; }
-  void set_best_2x2_eta(float eta) { _EMCAL_2x2_BEST_ETA = eta; }
-  void set_best_2x2_phi(float phi) { _EMCAL_2x2_BEST_PHI = phi; }
-  float get_best_2x2_E() { return _EMCAL_2x2_BEST_E; }
-  float get_best_2x2_eta() { return _EMCAL_2x2_BEST_ETA; }
-  float get_best_2x2_phi() { return _EMCAL_2x2_BEST_PHI; }
-  void set_best_4x4_E(float E) { _EMCAL_4x4_BEST_E = E; }
-  void set_best_4x4_eta(float eta) { _EMCAL_4x4_BEST_ETA = eta; }
-  void set_best_4x4_phi(float phi) { _EMCAL_4x4_BEST_PHI = phi; }
-  float get_best_4x4_E() { return _EMCAL_4x4_BEST_E; }
-  float get_best_4x4_eta() { return _EMCAL_4x4_BEST_ETA; }
-  float get_best_4x4_phi() { return _EMCAL_4x4_BEST_PHI; }
+
+  // EMCal 2x2
+  void set_best_EMCal_2x2_E(float E) { _EMCAL_2x2_BEST_E = E; }
+  void set_best_EMCal_2x2_eta(float eta) { _EMCAL_2x2_BEST_ETA = eta; }
+  void set_best_EMCal_2x2_phi(float phi) { _EMCAL_2x2_BEST_PHI = phi; }
+
+  float get_best_EMCal_2x2_E() { return _EMCAL_2x2_BEST_E; }
+  float get_best_EMCal_2x2_eta() { return _EMCAL_2x2_BEST_ETA; }
+  float get_best_EMCal_2x2_phi() { return _EMCAL_2x2_BEST_PHI; }
+
+  // EMCal 4x4
+  void set_best_EMCal_4x4_E(float E) { _EMCAL_4x4_BEST_E = E; }
+  void set_best_EMCal_4x4_eta(float eta) { _EMCAL_4x4_BEST_ETA = eta; }
+  void set_best_EMCal_4x4_phi(float phi) { _EMCAL_4x4_BEST_PHI = phi; }
+
+  float get_best_EMCal_4x4_E() { return _EMCAL_4x4_BEST_E; }
+  float get_best_EMCal_4x4_eta() { return _EMCAL_4x4_BEST_ETA; }
+  float get_best_EMCal_4x4_phi() { return _EMCAL_4x4_BEST_PHI; }
+
+  // FullCalo 0.2x0.2
+  void set_best_FullCalo_0p2x0p2_E(float E) { _FULLCALO_0p2x0p2_BEST_E = E; }
+  void set_best_FullCalo_0p2x0p2_eta(float eta) { _FULLCALO_0p2x0p2_BEST_ETA = eta; }
+  void set_best_FullCalo_0p2x0p2_phi(float phi) { _FULLCALO_0p2x0p2_BEST_PHI = phi; }
+
+  float get_best_FullCalo_0p2x0p2_E() { return _FULLCALO_0p2x0p2_BEST_E; }
+  float get_best_FullCalo_0p2x0p2_eta() { return _FULLCALO_0p2x0p2_BEST_ETA; }
+  float get_best_FullCalo_0p2x0p2_phi() { return _FULLCALO_0p2x0p2_BEST_PHI; }
+
+  // FullCalo 0.4x0.4
+  void set_best_FullCalo_0p4x0p4_E(float E) { _FULLCALO_0p4x0p4_BEST_E = E; }
+  void set_best_FullCalo_0p4x0p4_eta(float eta) { _FULLCALO_0p4x0p4_BEST_ETA = eta; }
+  void set_best_FullCalo_0p4x0p4_phi(float phi) { _FULLCALO_0p4x0p4_BEST_PHI = phi; }
+
+  float get_best_FullCalo_0p4x0p4_E() { return _FULLCALO_0p4x0p4_BEST_E; }
+  float get_best_FullCalo_0p4x0p4_eta() { return _FULLCALO_0p4x0p4_BEST_ETA; }
+  float get_best_FullCalo_0p4x0p4_phi() { return _FULLCALO_0p4x0p4_BEST_PHI; }
+
+  // FullCalo 0.6x0.6
+  void set_best_FullCalo_0p6x0p6_E(float E) { _FULLCALO_0p6x0p6_BEST_E = E; }
+  void set_best_FullCalo_0p6x0p6_eta(float eta) { _FULLCALO_0p6x0p6_BEST_ETA = eta; }
+  void set_best_FullCalo_0p6x0p6_phi(float phi) { _FULLCALO_0p6x0p6_BEST_PHI = phi; }
+
+  float get_best_FullCalo_0p6x0p6_E() { return _FULLCALO_0p6x0p6_BEST_E; }
+  float get_best_FullCalo_0p6x0p6_eta() { return _FULLCALO_0p6x0p6_BEST_ETA; }
+  float get_best_FullCalo_0p6x0p6_phi() { return _FULLCALO_0p6x0p6_BEST_PHI; }
+
+  // FullCalo 0.8x0.8
+  void set_best_FullCalo_0p8x0p8_E(float E) { _FULLCALO_0p8x0p8_BEST_E = E; }
+  void set_best_FullCalo_0p8x0p8_eta(float eta) { _FULLCALO_0p8x0p8_BEST_ETA = eta; }
+  void set_best_FullCalo_0p8x0p8_phi(float phi) { _FULLCALO_0p8x0p8_BEST_PHI = phi; }
+
+  float get_best_FullCalo_0p8x0p8_E() { return _FULLCALO_0p8x0p8_BEST_E; }
+  float get_best_FullCalo_0p8x0p8_eta() { return _FULLCALO_0p8x0p8_BEST_ETA; }
+  float get_best_FullCalo_0p8x0p8_phi() { return _FULLCALO_0p8x0p8_BEST_PHI; }
+
+  // FullCalo 1.0x1.0
+  void set_best_FullCalo_1p0x1p0_E(float E) { _FULLCALO_1p0x1p0_BEST_E = E; }
+  void set_best_FullCalo_1p0x1p0_eta(float eta) { _FULLCALO_1p0x1p0_BEST_ETA = eta; }
+  void set_best_FullCalo_1p0x1p0_phi(float phi) { _FULLCALO_1p0x1p0_BEST_PHI = phi; }
+
+  float get_best_FullCalo_1p0x1p0_E() { return _FULLCALO_1p0x1p0_BEST_E; }
+  float get_best_FullCalo_1p0x1p0_eta() { return _FULLCALO_1p0x1p0_BEST_ETA; }
+  float get_best_FullCalo_1p0x1p0_phi() { return _FULLCALO_1p0x1p0_BEST_PHI; }
+
  private:
   float _EMCAL_2x2_BEST_E;
   float _EMCAL_2x2_BEST_ETA;
@@ -34,6 +86,26 @@ class CaloTriggerInfo_v1 : public CaloTriggerInfo
   float _EMCAL_4x4_BEST_E;
   float _EMCAL_4x4_BEST_ETA;
   float _EMCAL_4x4_BEST_PHI;
+
+  float _FULLCALO_0p2x0p2_BEST_E;
+  float _FULLCALO_0p2x0p2_BEST_ETA;
+  float _FULLCALO_0p2x0p2_BEST_PHI;
+
+  float _FULLCALO_0p4x0p4_BEST_E;
+  float _FULLCALO_0p4x0p4_BEST_ETA;
+  float _FULLCALO_0p4x0p4_BEST_PHI;
+
+  float _FULLCALO_0p6x0p6_BEST_E;
+  float _FULLCALO_0p6x0p6_BEST_ETA;
+  float _FULLCALO_0p6x0p6_BEST_PHI;
+
+  float _FULLCALO_0p8x0p8_BEST_E;
+  float _FULLCALO_0p8x0p8_BEST_ETA;
+  float _FULLCALO_0p8x0p8_BEST_PHI;
+
+  float _FULLCALO_1p0x1p0_BEST_E;
+  float _FULLCALO_1p0x1p0_BEST_ETA;
+  float _FULLCALO_1p0x1p0_BEST_PHI;
 
   ClassDef(CaloTriggerInfo_v1, 1);
 };

--- a/offline/packages/trigger/CaloTriggerSim.C
+++ b/offline/packages/trigger/CaloTriggerSim.C
@@ -12,6 +12,7 @@
 #include <g4cemc/RawTower.h>
 #include <g4cemc/RawTowerContainer.h>
 #include <g4cemc/RawTowerGeom.h>
+#include <g4cemc/RawTowerGeomContainer.h>
 #include <g4cemc/RawTowerGeomContainer_Cylinderv1.h>
 
 #include "CaloTriggerInfo_v1.h"
@@ -36,6 +37,28 @@ CaloTriggerSim::CaloTriggerSim(const std::string &name)
   _EMCAL_4x4_NETA = -1;
   _EMCAL_4x4_NPHI = -1;
 
+  // do the same for full calo
+  _FULLCALO_PHI_START = 0;
+  _FULLCALO_PHI_END = 2*3.14159;
+  
+  _FULLCALO_0p1x0p1_NETA = -1;
+  _FULLCALO_0p1x0p1_NPHI = -1;
+
+  _FULLCALO_0p2x0p2_NETA = -1;
+  _FULLCALO_0p2x0p2_NPHI = -1;
+
+  _FULLCALO_0p4x0p4_NETA = -1;
+  _FULLCALO_0p4x0p4_NPHI = -1;
+
+  _FULLCALO_0p6x0p6_NETA = -1;
+  _FULLCALO_0p6x0p6_NPHI = -1;
+
+  _FULLCALO_0p8x0p8_NETA = -1;
+  _FULLCALO_0p8x0p8_NPHI = -1;
+
+  _FULLCALO_1p0x1p0_NETA = -1;
+  _FULLCALO_1p0x1p0_NPHI = -1;
+
   // these get cleared every event, but clear them at the
   // initiatlization step just in case
 
@@ -46,6 +69,27 @@ CaloTriggerSim::CaloTriggerSim(const std::string &name)
   _EMCAL_4x4_BEST_E = 0;
   _EMCAL_4x4_BEST_PHI = 0;
   _EMCAL_4x4_BEST_ETA = 0;
+
+  _FULLCALO_0p2x0p2_BEST_E = 0;
+  _FULLCALO_0p2x0p2_BEST_PHI = 0;
+  _FULLCALO_0p2x0p2_BEST_ETA = 0;
+
+  _FULLCALO_0p4x0p4_BEST_E = 0;
+  _FULLCALO_0p4x0p4_BEST_PHI = 0;
+  _FULLCALO_0p4x0p4_BEST_ETA = 0;
+
+  _FULLCALO_0p6x0p6_BEST_E = 0;
+  _FULLCALO_0p6x0p6_BEST_PHI = 0;
+  _FULLCALO_0p6x0p6_BEST_ETA = 0;
+
+  _FULLCALO_0p8x0p8_BEST_E = 0;
+  _FULLCALO_0p8x0p8_BEST_PHI = 0;
+  _FULLCALO_0p8x0p8_BEST_ETA = 0;
+
+  _FULLCALO_1p0x1p0_BEST_E = 0;
+  _FULLCALO_1p0x1p0_BEST_PHI = 0;
+  _FULLCALO_1p0x1p0_BEST_ETA = 0;
+
 }
 
 CaloTriggerSim::~CaloTriggerSim()
@@ -70,12 +114,21 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
   if (verbosity > 0)
     std::cout << "CaloTriggerSim::process_event: entering" << std::endl;
 
+  // pull out the tower containers and geometry objects at the start
   RawTowerContainer *towersEM3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC");
-  if (verbosity > 0)
+  RawTowerContainer *towersIH3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALIN");
+  RawTowerContainer *towersOH3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALOUT");
+  if (verbosity > 0) {
     std::cout << "CaloTriggerSim::process_event: " << towersEM3->size() << " TOWER_CALIB_CEMC towers" << std::endl;
+    std::cout << "CaloTriggerSim::process_event: " << towersIH3->size() << " TOWER_CALIB_HCALIN towers" << std::endl;
+    std::cout << "CaloTriggerSim::process_event: " << towersOH3->size() << " TOWER_CALIB_HCALOUT towers" << std::endl;
+  }
+
+  RawTowerGeomContainer_Cylinderv1 *geomEM = findNode::getClass<RawTowerGeomContainer_Cylinderv1>(topNode, "TOWERGEOM_CEMC");
+  RawTowerGeomContainer *geomIH = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
+  RawTowerGeomContainer *geomOH = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
 
   // get the binning from the geometry (different for 1D vs 2D...)
-  RawTowerGeomContainer_Cylinderv1 *geomEM = findNode::getClass<RawTowerGeomContainer_Cylinderv1>(topNode, "TOWERGEOM_CEMC");
   int geom_etabins = geomEM->get_etabins();
   int geom_phibins = geomEM->get_phibins();
 
@@ -134,7 +187,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
     _EMCAL_1x1_MAP[this_etabin][this_phibin] += this_E;
 
-    if (verbosity > 0 && tower->get_energy() > 1)
+    if (verbosity > 1 && tower->get_energy() > 1)
     {
       std::cout << "CaloTriggerSim::process_event: EMCal 1x1 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << this_etabin << " ) / " << this_phi << " ( " << this_phibin << " ) / " << this_E << std::endl;
     }
@@ -175,7 +228,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
       if (this_phi > 3.14159) this_phi -= 2 * 3.14159;
       if (this_phi < -3.14159) this_phi += 2 * 3.14159;
 
-      if (verbosity > 0 && this_sum > 1)
+      if (verbosity > 1 && this_sum > 1)
       {
         std::cout << "CaloTriggerSim::process_event: EMCal 2x2 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
       }
@@ -225,7 +278,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
       float this_sum = 0;
 
       this_sum += _EMCAL_2x2_MAP[ieta][iphi];
-      this_sum += _EMCAL_2x2_MAP[ieta + 1][iphi];  // 2 * ieta + 1 is safe, since _EMCAL_4x4_NETA = _EMCAL_2x2_NETA - 1
+      this_sum += _EMCAL_2x2_MAP[ieta + 1][iphi];  // ieta + 1 is safe, since _EMCAL_4x4_NETA = _EMCAL_2x2_NETA - 1
 
       if (iphi != _EMCAL_4x4_NPHI - 1)
       {
@@ -242,7 +295,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
       _EMCAL_4x4_MAP[ieta][iphi] = this_sum;
 
-      if (verbosity > 0 && this_sum > 1)
+      if (verbosity > 1 && this_sum > 1)
       {
         std::cout << "CaloTriggerSim::process_event: EMCal 4x4 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
       }
@@ -260,6 +313,472 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
   {
     std::cout << "CaloTriggerSim::process_event: best EMCal 4x4 window is at eta / phi = " << _EMCAL_4x4_BEST_ETA << " / " << _EMCAL_4x4_BEST_PHI << " and E = " << _EMCAL_4x4_BEST_E << std::endl;
   }
+
+  // begin full calo sim
+
+  // get the 0.1x0.1 binning from the OHCal geometry
+  int geomOH_etabins = geomOH->get_etabins();
+  int geomOH_phibins = geomOH->get_phibins();
+
+  // if internal knowledge of geometry is unset, set it now
+  if (_FULLCALO_0p1x0p1_NETA < 0)
+  {
+    _FULLCALO_PHI_START = geomOH->get_phibounds( 0 ).first;
+    _FULLCALO_PHI_END = geomOH->get_phibounds( geomOH_phibins - 1 ).second;
+
+    _FULLCALO_0p1x0p1_NETA = geomOH_etabins;
+    _FULLCALO_0p1x0p1_NPHI = geomOH_phibins;
+
+    // half as many 0.2x0.2 windows along each axis as 0.1x0.1
+    _FULLCALO_0p2x0p2_NETA = geomOH_etabins / 2;
+    _FULLCALO_0p2x0p2_NPHI = geomOH_phibins / 2;
+
+    // each 0.2x0.2 window defines a 0.4x0.4 window for which that
+    // 0.2x0.2 window is the upper-left corner, so there are as many
+    // 0.4x0.4's as 0.2x0.2's (except in eta, where the edge effect
+    // means there is 1 fewer)
+    _FULLCALO_0p4x0p4_NETA = geomOH_etabins / 2 - 1;
+    _FULLCALO_0p4x0p4_NPHI = geomOH_phibins / 2;
+
+    // for 0.6x0.6 windows, the above logic applies, except that the
+    // edge effect causes there to be 2 fewer less in eta
+    _FULLCALO_0p6x0p6_NETA = geomOH_etabins / 2 - 2;
+    _FULLCALO_0p6x0p6_NPHI = geomOH_phibins / 2;
+
+    // for 0.8x0.8 windows, the above logic applies, except that the
+    // edge effect causes there to be 3 fewer less in eta
+    _FULLCALO_0p8x0p8_NETA = geomOH_etabins / 2 - 3;
+    _FULLCALO_0p8x0p8_NPHI = geomOH_phibins / 2;
+
+    // for 1.0x1.0 windows, the above logic applies, except that the
+    // edge effect causes there to be 4 fewer less in eta
+    _FULLCALO_1p0x1p0_NETA = geomOH_etabins / 2 - 4;
+    _FULLCALO_1p0x1p0_NPHI = geomOH_phibins / 2;
+
+    // reset all maps
+    _FULLCALO_0p1x0p1_MAP.resize(_FULLCALO_0p1x0p1_NETA, std::vector<float>(_FULLCALO_0p1x0p1_NPHI, 0));
+    _FULLCALO_0p2x0p2_MAP.resize(_FULLCALO_0p2x0p2_NETA, std::vector<float>(_FULLCALO_0p2x0p2_NPHI, 0));
+    _FULLCALO_0p4x0p4_MAP.resize(_FULLCALO_0p4x0p4_NETA, std::vector<float>(_FULLCALO_0p4x0p4_NPHI, 0));
+    _FULLCALO_0p6x0p6_MAP.resize(_FULLCALO_0p6x0p6_NETA, std::vector<float>(_FULLCALO_0p6x0p6_NPHI, 0));
+    _FULLCALO_0p8x0p8_MAP.resize(_FULLCALO_0p8x0p8_NETA, std::vector<float>(_FULLCALO_0p8x0p8_NPHI, 0));
+    _FULLCALO_1p0x1p0_MAP.resize(_FULLCALO_1p0x1p0_NETA, std::vector<float>(_FULLCALO_1p0x1p0_NPHI, 0));
+
+    if (verbosity > 0)
+    {
+      std::cout << "CaloTriggerSim::process_event: determining phi range for 0.1x0.1 full calo map: " << _FULLCALO_PHI_START << " to " << _FULLCALO_PHI_END << std::endl;
+      std::cout << "CaloTriggerSim::process_event: setting number of full calo window in eta / phi:" << std::endl;
+      std::cout << "  0.1x0.1 are " << _FULLCALO_0p1x0p1_NETA << " / " << _FULLCALO_0p1x0p1_NPHI << ", ";
+      std::cout << "0.2x0.2 are " << _FULLCALO_0p2x0p2_NETA << " / " << _FULLCALO_0p2x0p2_NPHI << ", ";
+      std::cout << "0.4x0.4 are " << _FULLCALO_0p4x0p4_NETA << " / " << _FULLCALO_0p4x0p4_NPHI << ", ";
+      std::cout << "0.6x0.6 are " << _FULLCALO_0p6x0p6_NETA << " / " << _FULLCALO_0p6x0p6_NPHI << ", ";
+      std::cout << "0.8x0.8 are " << _FULLCALO_0p8x0p8_NETA << " / " << _FULLCALO_0p8x0p8_NPHI << ", ";
+      std::cout << "1.0x1.0 are " << _FULLCALO_1p0x1p0_NETA << " / " << _FULLCALO_1p0x1p0_NPHI << std::endl;
+    }
+  }
+
+  // reset 0.1x0.1 map
+  for (int ieta = 0; ieta < _FULLCALO_0p1x0p1_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _FULLCALO_0p1x0p1_NPHI; iphi++)
+    {
+      _FULLCALO_0p1x0p1_MAP[ieta][iphi] = 0;
+    }
+  }
+
+  // iterate over EMCal towers, filling in the 0.1x0.1 region they contribute to
+  RawTowerContainer::ConstRange begin_end_EM = towersEM3->getTowers();
+  for (RawTowerContainer::ConstIterator rtiter = begin_end_EM.first; rtiter != begin_end_EM.second; ++rtiter)
+  {
+    RawTower *tower = rtiter->second;
+    RawTowerGeom *tower_geom = geomEM->get_tower_geometry(tower->get_key());
+
+    float this_eta = tower_geom->get_eta();
+    float this_phi = tower_geom->get_phi();
+    if (this_phi < _FULLCALO_PHI_START) this_phi += 2*3.14159;
+    if (this_phi > _FULLCALO_PHI_END) this_phi -= 2*3.14159;
+ 
+    // note: look up eta/phi index based on OHCal geometry, since this
+    // defines the 0.1x0.1 regions
+    int this_etabin = geomOH->get_etabin( this_eta );
+    int this_phibin = geomOH->get_phibin( this_phi );
+    float this_E = tower->get_energy();
+
+    _FULLCALO_0p1x0p1_MAP[ this_etabin ][ this_phibin ] += this_E;
+
+    if (verbosity > 1 && tower->get_energy() > 1)
+    {
+      std::cout << "CaloTriggerSim::process_event: EMCal tower at eta / phi (added to fullcalo map with etabin / phibin ) / E = " << std::setprecision(6) << this_eta << " / " << this_phi << " ( " << this_etabin << " / " << this_phibin << " ) / " << this_E << std::endl;
+    }
+  }
+
+  // iterate over IHCal towers, filling in the 0.1x0.1 region they contribute to
+  RawTowerContainer::ConstRange begin_end_IH = towersIH3->getTowers();
+  for (RawTowerContainer::ConstIterator rtiter = begin_end_IH.first; rtiter != begin_end_IH.second; ++rtiter)
+  {
+    RawTower *tower = rtiter->second;
+    RawTowerGeom *tower_geom = geomIH->get_tower_geometry(tower->get_key());
+
+    float this_eta = tower_geom->get_eta();
+    float this_phi = tower_geom->get_phi();
+    if (this_phi < _FULLCALO_PHI_START) this_phi += 2*3.14159;
+    if (this_phi > _FULLCALO_PHI_END) this_phi -= 2*3.14159;
+ 
+    // note: look up eta/phi index based on OHCal geometry, even though I
+    // think it is by construction the same as the IHCal geometry...
+    int this_etabin = geomOH->get_etabin( this_eta );
+    int this_phibin = geomOH->get_phibin( this_phi );
+    float this_E = tower->get_energy();
+
+    _FULLCALO_0p1x0p1_MAP[ this_etabin ][ this_phibin ] += this_E;
+
+    if (verbosity > 1 && tower->get_energy() > 0.5)
+    {
+      std::cout << "CaloTriggerSim::process_event: IHCal tower at eta / phi (added to fullcalo map with etabin / phibin ) / E = " << std::setprecision(6) << this_eta << " / " << this_phi << " ( " << this_etabin << " / " << this_phibin << " ) / " << this_E << std::endl;
+    }
+  }
+
+  // iterate over OHCal towers, filling in the 0.1x0.1 region they contribute to
+  RawTowerContainer::ConstRange begin_end_OH = towersOH3->getTowers();
+  for (RawTowerContainer::ConstIterator rtiter = begin_end_OH.first; rtiter != begin_end_OH.second; ++rtiter)
+  {
+    RawTower *tower = rtiter->second;
+    RawTowerGeom *tower_geom = geomOH->get_tower_geometry(tower->get_key());
+
+    float this_eta = tower_geom->get_eta();
+    float this_phi = tower_geom->get_phi();
+    if (this_phi < _FULLCALO_PHI_START) this_phi += 2*3.14159;
+    if (this_phi > _FULLCALO_PHI_END) this_phi -= 2*3.14159;
+ 
+    // note: use the nominal eta/phi index, since the fullcalo 0.1x0.1
+    // map is defined by the OHCal geometry itself
+    int this_etabin = geomOH->get_etabin( this_eta );
+    int this_phibin = geomOH->get_phibin( this_phi );
+    float this_E = tower->get_energy();
+
+    _FULLCALO_0p1x0p1_MAP[ this_etabin ][ this_phibin ] += this_E;
+
+    if (verbosity > 1 && tower->get_energy() > 0.5)
+    {
+      std::cout << "CaloTriggerSim::process_event: OHCal tower at eta / phi (added to fullcalo map with etabin / phibin ) / E = " << std::setprecision(6) << this_eta << " / " << this_phi << " ( " << this_etabin << " / " << this_phibin << " ) / " << this_E << std::endl;
+    }
+  }
+
+  // reset 0.2x0.2 map and best
+  for (int ieta = 0; ieta < _FULLCALO_0p2x0p2_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _FULLCALO_0p2x0p2_NPHI; iphi++)
+    {
+      _FULLCALO_0p2x0p2_MAP[ ieta ][ iphi ] = 0;
+    }
+  }
+
+  _FULLCALO_0p2x0p2_BEST_E = 0;
+  _FULLCALO_0p2x0p2_BEST_PHI = 0;
+  _FULLCALO_0p2x0p2_BEST_ETA = 0;
+
+  // now reconstruct (non-sliding) 0.2x0.2 map from 0.1x0.1 map
+  for (int ieta = 0; ieta < _FULLCALO_0p2x0p2_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _FULLCALO_0p2x0p2_NPHI; iphi++)
+    {
+      float this_sum = 0;
+
+      this_sum += _FULLCALO_0p1x0p1_MAP[2 * ieta][2 * iphi];
+      this_sum += _FULLCALO_0p1x0p1_MAP[2 * ieta][2 * iphi + 1];  // 2 * iphi + 1 is safe, since _FULLCALO_0p2x0p2_NPHI = _FULLCALO_0p1x0p1_NPHI / 2
+      this_sum += _FULLCALO_0p1x0p1_MAP[2 * ieta + 1][2 * iphi];  // 2 * ieta + 1 is safe, since _FULLCALO_0p2x0p2_NETA = _FULLCALO_0p1x0p1_NETA / 2
+      this_sum += _FULLCALO_0p1x0p1_MAP[2 * ieta + 1][2 * iphi + 1];
+
+      // populate 0.2x0.2 map
+      _FULLCALO_0p2x0p2_MAP[ieta][iphi] = this_sum;
+
+      // to calculate the eta, phi position, take the average of that
+      // of the contributing 0.1x0.1's (which are defined by the OHCal geometry)
+      float this_eta = 0.5 * (geomOH->get_etacenter(2 * ieta) + geomOH->get_etacenter(2 * ieta + 1));
+      float this_phi = 0.5 * (geomOH->get_phicenter(2 * iphi) + geomOH->get_phicenter(2 * iphi + 1));
+
+      if (verbosity > 1 && this_sum > 1)
+      {
+        std::cout << "CaloTriggerSim::process_event: FullCalo 0.2x0.2 window eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
+      }
+
+      if (this_sum > _FULLCALO_0p2x0p2_BEST_E)
+      {
+        _FULLCALO_0p2x0p2_BEST_E = this_sum;
+        _FULLCALO_0p2x0p2_BEST_PHI = this_phi;
+        _FULLCALO_0p2x0p2_BEST_ETA = this_eta;
+      }
+    }
+  }
+
+  if (verbosity > 0)
+  {
+    std::cout << "CaloTriggerSim::process_event: best FullCalo 0.2x0.2 window is at eta / phi = " << _FULLCALO_0p2x0p2_BEST_ETA << " / " << _FULLCALO_0p2x0p2_BEST_PHI << " and E = " << _FULLCALO_0p2x0p2_BEST_E << std::endl;
+  }
+
+  // reset fullcalo 0.4x0.4 map & best
+  for (int ieta = 0; ieta < _FULLCALO_0p4x0p4_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _FULLCALO_0p4x0p4_NPHI; iphi++)
+    {
+      _FULLCALO_0p4x0p4_MAP[ ieta ][ iphi ] = 0;
+    }
+  }
+
+  _FULLCALO_0p4x0p4_BEST_E = 0;
+  _FULLCALO_0p4x0p4_BEST_PHI = 0;
+  _FULLCALO_0p4x0p4_BEST_ETA = 0;
+
+  // now reconstruct (sliding) 0.4x0.4 map from 0.2x0.2 map
+  for (int ieta = 0; ieta < _FULLCALO_0p4x0p4_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _FULLCALO_0p4x0p4_NPHI; iphi++)
+    {
+      // for eta calculation, use position of corner tower and add 1.5
+      // tower widths
+      float this_eta = geomOH->get_etacenter(2 * ieta) + 1.5 * ( geomOH->get_etacenter( 1 ) - geomOH->get_etacenter( 0 ) );
+      // for phi calculation, use position of corner tower and add 1.5
+      // tower widths
+      float this_phi = geomOH->get_phicenter(2 * iphi) + 1.5 * (geomOH->get_phicenter( 1 ) - geomOH->get_phicenter( 0 ) );
+
+      float this_sum = 0;
+
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][iphi];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][iphi];  // 2 * ieta + 1 is safe, since _FULLCALO_0p4x0p4_NETA = _FULLCALO_0p4x0p4_NETA - 1
+
+      // add 1 to phi, but take modulus w.r.t. _FULLCALO_0p2x0p2_NPHI
+      // in case we have wrapped back around
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+
+      _FULLCALO_0p4x0p4_MAP[ieta][iphi] = this_sum;
+
+      if (verbosity > 1 && this_sum > 2)
+      {
+        std::cout << "CaloTriggerSim::process_event: FullCalo  0.4x0.4 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
+      }
+
+      if (this_sum > _FULLCALO_0p4x0p4_BEST_E)
+      {
+        _FULLCALO_0p4x0p4_BEST_E = this_sum;
+        _FULLCALO_0p4x0p4_BEST_PHI = this_phi;
+        _FULLCALO_0p4x0p4_BEST_ETA = this_eta;
+      }
+    }
+  }
+
+  if (verbosity > 0)
+  {
+    std::cout << "CaloTriggerSim::process_event: best FullCalo 0.4x0.4 window is at eta / phi = " << _FULLCALO_0p4x0p4_BEST_ETA << " / " << _FULLCALO_0p4x0p4_BEST_PHI << " and E = " << _FULLCALO_0p4x0p4_BEST_E << std::endl;
+  }
+
+  // reset fullcalo 0.6x0.6 map & best
+  for (int ieta = 0; ieta < _FULLCALO_0p6x0p6_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _FULLCALO_0p6x0p6_NPHI; iphi++)
+    {
+      _FULLCALO_0p6x0p6_MAP[ ieta ][ iphi ] = 0;
+    }
+  }
+
+  _FULLCALO_0p6x0p6_BEST_E = 0;
+  _FULLCALO_0p6x0p6_BEST_PHI = 0;
+  _FULLCALO_0p6x0p6_BEST_ETA = 0;
+
+  // now reconstruct (sliding) 0.6x0.6 map from 0.2x0.2 map
+  for (int ieta = 0; ieta < _FULLCALO_0p6x0p6_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _FULLCALO_0p6x0p6_NPHI; iphi++)
+    {
+      // for eta calculation, use position of corner tower and add 2.5
+      // tower widths
+      float this_eta = geomOH->get_etacenter(2 * ieta) + 2.5 * ( geomOH->get_etacenter( 1 ) - geomOH->get_etacenter( 0 ) );
+      // for phi calculation, use position of corner tower and add 2.5
+      // tower widths
+      float this_phi = geomOH->get_phicenter(2 * iphi) + 2.5 * (geomOH->get_phicenter( 1 ) - geomOH->get_phicenter( 0 ) );
+
+      float this_sum = 0;
+
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][iphi];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][iphi];  // ieta + 1 is safe, since _FULLCALO_0p6x0p6_NETA = _FULLCALO_0p2x0p2_NETA - 2
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 2][iphi];  // ieta + 2 is safe, since _FULLCALO_0p6x0p6_NETA = _FULLCALO_0p2x0p2_NETA - 2
+
+      // add 1 to phi, but take modulus w.r.t. _FULLCALO_0p2x0p2_NPHI
+      // in case we have wrapped back around
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 2][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      // add 2 to phi, but take modulus w.r.t. _FULLCALO_0p2x0p2_NPHI
+      // in case we have wrapped back around
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][ ( iphi + 2 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][ ( iphi + 2 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 2][ ( iphi + 2 ) % _FULLCALO_0p2x0p2_NPHI ];
+
+      _FULLCALO_0p6x0p6_MAP[ieta][iphi] = this_sum;
+
+      if (verbosity > 1 && this_sum > 3)
+      {
+        std::cout << "CaloTriggerSim::process_event: FullCalo  0.6x0.6 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
+      }
+
+      if (this_sum > _FULLCALO_0p6x0p6_BEST_E)
+      {
+        _FULLCALO_0p6x0p6_BEST_E = this_sum;
+        _FULLCALO_0p6x0p6_BEST_PHI = this_phi;
+        _FULLCALO_0p6x0p6_BEST_ETA = this_eta;
+      }
+    }
+  }
+
+  if (verbosity > 0)
+  {
+    std::cout << "CaloTriggerSim::process_event: best FullCalo 0.6x0.6 window is at eta / phi = " << _FULLCALO_0p6x0p6_BEST_ETA << " / " << _FULLCALO_0p6x0p6_BEST_PHI << " and E = " << _FULLCALO_0p6x0p6_BEST_E << std::endl;
+  }
+
+  // reset fullcalo 0.8x0.8 map & best
+  for (int ieta = 0; ieta < _FULLCALO_0p8x0p8_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _FULLCALO_0p8x0p8_NPHI; iphi++)
+    {
+      _FULLCALO_0p8x0p8_MAP[ ieta ][ iphi ] = 0;
+    }
+  }
+
+  _FULLCALO_0p8x0p8_BEST_E = 0;
+  _FULLCALO_0p8x0p8_BEST_PHI = 0;
+  _FULLCALO_0p8x0p8_BEST_ETA = 0;
+
+  // now reconstruct (sliding) 0.8x0.8 map from 0.2x0.2 map
+  for (int ieta = 0; ieta < _FULLCALO_0p8x0p8_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _FULLCALO_0p8x0p8_NPHI; iphi++)
+    {
+      // for eta calculation, use position of corner tower and add 3.5
+      // tower widths
+      float this_eta = geomOH->get_etacenter(2 * ieta) + 3.5 * ( geomOH->get_etacenter( 1 ) - geomOH->get_etacenter( 0 ) );
+      // for phi calculation, use position of corner tower and add 3.5
+      // tower widths
+      float this_phi = geomOH->get_phicenter(2 * iphi) + 3.5 * (geomOH->get_phicenter( 1 ) - geomOH->get_phicenter( 0 ) );
+
+      float this_sum = 0;
+
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][iphi];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][iphi];  // ieta + 1 is safe, since _FULLCALO_0p8x0p8_NETA = _FULLCALO_0p2x0p2_NETA - 3
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 2][iphi];  // ieta + 2 is safe, since _FULLCALO_0p8x0p8_NETA = _FULLCALO_0p2x0p2_NETA - 3
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 3][iphi];  // ieta + 3 is safe, since _FULLCALO_0p8x0p8_NETA = _FULLCALO_0p2x0p2_NETA - 3
+
+      // add 1 to phi, but take modulus w.r.t. _FULLCALO_0p2x0p2_NPHI
+      // in case we have wrapped back around
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 2][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 3][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      // add 2 to phi, but take modulus w.r.t. _FULLCALO_0p2x0p2_NPHI
+      // in case we have wrapped back around
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][ ( iphi + 2 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][ ( iphi + 2 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 2][ ( iphi + 2 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 3][ ( iphi + 2 ) % _FULLCALO_0p2x0p2_NPHI ];
+      // add 3 to phi, but take modulus w.r.t. _FULLCALO_0p2x0p2_NPHI
+      // in case we have wrapped back around
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][ ( iphi + 3 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][ ( iphi + 3 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 2][ ( iphi + 3 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 3][ ( iphi + 3 ) % _FULLCALO_0p2x0p2_NPHI ];
+
+      _FULLCALO_0p8x0p8_MAP[ieta][iphi] = this_sum;
+
+      if (verbosity > 1 && this_sum > 4)
+      {
+        std::cout << "CaloTriggerSim::process_event: FullCalo  0.8x0.8 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
+      }
+
+      if (this_sum > _FULLCALO_0p8x0p8_BEST_E)
+      {
+        _FULLCALO_0p8x0p8_BEST_E = this_sum;
+        _FULLCALO_0p8x0p8_BEST_PHI = this_phi;
+        _FULLCALO_0p8x0p8_BEST_ETA = this_eta;
+      }
+    }
+  }
+
+  if (verbosity > 0)
+  {
+    std::cout << "CaloTriggerSim::process_event: best FullCalo 0.8x0.8 window is at eta / phi = " << _FULLCALO_0p8x0p8_BEST_ETA << " / " << _FULLCALO_0p8x0p8_BEST_PHI << " and E = " << _FULLCALO_0p8x0p8_BEST_E << std::endl;
+  }
+
+  // reset fullcalo 1.0x1.0 map & best
+  for (int ieta = 0; ieta < _FULLCALO_1p0x1p0_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _FULLCALO_1p0x1p0_NPHI; iphi++)
+    {
+      _FULLCALO_1p0x1p0_MAP[ ieta ][ iphi ] = 0;
+    }
+  }
+
+  _FULLCALO_1p0x1p0_BEST_E = 0;
+  _FULLCALO_1p0x1p0_BEST_PHI = 0;
+  _FULLCALO_1p0x1p0_BEST_ETA = 0;
+
+  // now reconstruct (sliding) 1.0x1.0 map from 0.2x0.2 map
+  for (int ieta = 0; ieta < _FULLCALO_1p0x1p0_NETA; ieta++)
+  {
+    for (int iphi = 0; iphi < _FULLCALO_1p0x1p0_NPHI; iphi++)
+    {
+      // for eta calculation, use position of corner tower and add 4.5
+      // tower widths
+      float this_eta = geomOH->get_etacenter(2 * ieta) + 4.5 * ( geomOH->get_etacenter( 1 ) - geomOH->get_etacenter( 0 ) );
+      // for phi calculation, use position of corner tower and add 4.5
+      // tower widths
+      float this_phi = geomOH->get_phicenter(2 * iphi) + 4.5 * (geomOH->get_phicenter( 1 ) - geomOH->get_phicenter( 0 ) );
+
+      float this_sum = 0;
+
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][iphi];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][iphi];  // ieta + 1 is safe, since _FULLCALO_1p0x1p0_NETA = _FULLCALO_0p2x0p2_NETA - 3
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 2][iphi];  // ieta + 2 is safe, since _FULLCALO_1p0x1p0_NETA = _FULLCALO_0p2x0p2_NETA - 3
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 3][iphi];  // ieta + 3 is safe, since _FULLCALO_1p0x1p0_NETA = _FULLCALO_0p2x0p2_NETA - 3
+
+      // add 1 to phi, but take modulus w.r.t. _FULLCALO_0p2x0p2_NPHI
+      // in case we have wrapped back around
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 2][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 3][ ( iphi + 1 ) % _FULLCALO_0p2x0p2_NPHI ];
+      // add 2 to phi, but take modulus w.r.t. _FULLCALO_0p2x0p2_NPHI
+      // in case we have wrapped back around
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][ ( iphi + 2 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][ ( iphi + 2 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 2][ ( iphi + 2 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 3][ ( iphi + 2 ) % _FULLCALO_0p2x0p2_NPHI ];
+      // add 3 to phi, but take modulus w.r.t. _FULLCALO_0p2x0p2_NPHI
+      // in case we have wrapped back around
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta][ ( iphi + 3 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 1][ ( iphi + 3 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 2][ ( iphi + 3 ) % _FULLCALO_0p2x0p2_NPHI ];
+      this_sum += _FULLCALO_0p2x0p2_MAP[ieta + 3][ ( iphi + 3 ) % _FULLCALO_0p2x0p2_NPHI ];
+
+      _FULLCALO_1p0x1p0_MAP[ieta][iphi] = this_sum;
+
+      if (verbosity > 1 && this_sum > 5)
+      {
+        std::cout << "CaloTriggerSim::process_event: FullCalo  1.0x1.0 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
+      }
+
+      if (this_sum > _FULLCALO_1p0x1p0_BEST_E)
+      {
+        _FULLCALO_1p0x1p0_BEST_E = this_sum;
+        _FULLCALO_1p0x1p0_BEST_PHI = this_phi;
+        _FULLCALO_1p0x1p0_BEST_ETA = this_eta;
+      }
+    }
+  }
+
+  if (verbosity > 0)
+  {
+    std::cout << "CaloTriggerSim::process_event: best FullCalo 1.0x1.0 window is at eta / phi = " << _FULLCALO_1p0x1p0_BEST_ETA << " / " << _FULLCALO_1p0x1p0_BEST_PHI << " and E = " << _FULLCALO_1p0x1p0_BEST_E << std::endl;
+  }
+
+
 
   FillNode(topNode);
 
@@ -320,13 +839,34 @@ void CaloTriggerSim::FillNode(PHCompositeNode *topNode)
   }
   else
   {
-    triggerinfo->set_best_2x2_E(_EMCAL_2x2_BEST_E);
-    triggerinfo->set_best_2x2_eta(_EMCAL_2x2_BEST_ETA);
-    triggerinfo->set_best_2x2_phi(_EMCAL_2x2_BEST_PHI);
+    triggerinfo->set_best_EMCal_2x2_E(_EMCAL_2x2_BEST_E);
+    triggerinfo->set_best_EMCal_2x2_eta(_EMCAL_2x2_BEST_ETA);
+    triggerinfo->set_best_EMCal_2x2_phi(_EMCAL_2x2_BEST_PHI);
 
-    triggerinfo->set_best_4x4_E(_EMCAL_4x4_BEST_E);
-    triggerinfo->set_best_4x4_eta(_EMCAL_4x4_BEST_ETA);
-    triggerinfo->set_best_4x4_phi(_EMCAL_4x4_BEST_PHI);
+    triggerinfo->set_best_EMCal_4x4_E(_EMCAL_4x4_BEST_E);
+    triggerinfo->set_best_EMCal_4x4_eta(_EMCAL_4x4_BEST_ETA);
+    triggerinfo->set_best_EMCal_4x4_phi(_EMCAL_4x4_BEST_PHI);
+
+    triggerinfo->set_best_FullCalo_0p2x0p2_E(_FULLCALO_0p2x0p2_BEST_E);
+    triggerinfo->set_best_FullCalo_0p2x0p2_eta(_FULLCALO_0p2x0p2_BEST_ETA);
+    triggerinfo->set_best_FullCalo_0p2x0p2_phi(_FULLCALO_0p2x0p2_BEST_PHI);
+
+    triggerinfo->set_best_FullCalo_0p4x0p4_E(_FULLCALO_0p4x0p4_BEST_E);
+    triggerinfo->set_best_FullCalo_0p4x0p4_eta(_FULLCALO_0p4x0p4_BEST_ETA);
+    triggerinfo->set_best_FullCalo_0p4x0p4_phi(_FULLCALO_0p4x0p4_BEST_PHI);
+
+    triggerinfo->set_best_FullCalo_0p6x0p6_E(_FULLCALO_0p6x0p6_BEST_E);
+    triggerinfo->set_best_FullCalo_0p6x0p6_eta(_FULLCALO_0p6x0p6_BEST_ETA);
+    triggerinfo->set_best_FullCalo_0p6x0p6_phi(_FULLCALO_0p6x0p6_BEST_PHI);
+
+    triggerinfo->set_best_FullCalo_0p8x0p8_E(_FULLCALO_0p8x0p8_BEST_E);
+    triggerinfo->set_best_FullCalo_0p8x0p8_eta(_FULLCALO_0p8x0p8_BEST_ETA);
+    triggerinfo->set_best_FullCalo_0p8x0p8_phi(_FULLCALO_0p8x0p8_BEST_PHI);
+
+    triggerinfo->set_best_FullCalo_1p0x1p0_E(_FULLCALO_1p0x1p0_BEST_E);
+    triggerinfo->set_best_FullCalo_1p0x1p0_eta(_FULLCALO_1p0x1p0_BEST_ETA);
+    triggerinfo->set_best_FullCalo_1p0x1p0_phi(_FULLCALO_1p0x1p0_BEST_PHI);
+
   }
 
   return;

--- a/offline/packages/trigger/CaloTriggerSim.h
+++ b/offline/packages/trigger/CaloTriggerSim.h
@@ -59,6 +59,56 @@ class CaloTriggerSim : public SubsysReco
   float _EMCAL_4x4_BEST_PHI;
   float _EMCAL_4x4_BEST_ETA;
 
+  // needed since phi ranges are potentially different in EMCal vs. HCal
+  float _FULLCALO_PHI_START;
+  float _FULLCALO_PHI_END;
+
+  // full calo (based on 0.1x0.1 HCal towers) limits and maps
+  int _FULLCALO_0p1x0p1_NETA;
+  int _FULLCALO_0p1x0p1_NPHI;
+  std::vector<std::vector<float> > _FULLCALO_0p1x0p1_MAP;
+
+  int _FULLCALO_0p2x0p2_NETA;
+  int _FULLCALO_0p2x0p2_NPHI;
+  std::vector<std::vector<float> > _FULLCALO_0p2x0p2_MAP;
+
+  int _FULLCALO_0p4x0p4_NETA;
+  int _FULLCALO_0p4x0p4_NPHI;
+  std::vector<std::vector<float> > _FULLCALO_0p4x0p4_MAP;
+
+  int _FULLCALO_0p6x0p6_NETA;
+  int _FULLCALO_0p6x0p6_NPHI;
+  std::vector<std::vector<float> > _FULLCALO_0p6x0p6_MAP;
+
+  int _FULLCALO_0p8x0p8_NETA;
+  int _FULLCALO_0p8x0p8_NPHI;
+  std::vector<std::vector<float> > _FULLCALO_0p8x0p8_MAP;
+
+  int _FULLCALO_1p0x1p0_NETA;
+  int _FULLCALO_1p0x1p0_NPHI;
+  std::vector<std::vector<float> > _FULLCALO_1p0x1p0_MAP;
+  
+  // highest full calo window energies
+  float _FULLCALO_0p2x0p2_BEST_E;
+  float _FULLCALO_0p2x0p2_BEST_PHI;
+  float _FULLCALO_0p2x0p2_BEST_ETA;
+
+  float _FULLCALO_0p4x0p4_BEST_E;
+  float _FULLCALO_0p4x0p4_BEST_PHI;
+  float _FULLCALO_0p4x0p4_BEST_ETA;
+
+  float _FULLCALO_0p6x0p6_BEST_E;
+  float _FULLCALO_0p6x0p6_BEST_PHI;
+  float _FULLCALO_0p6x0p6_BEST_ETA;
+
+  float _FULLCALO_0p8x0p8_BEST_E;
+  float _FULLCALO_0p8x0p8_BEST_PHI;
+  float _FULLCALO_0p8x0p8_BEST_ETA;
+
+  float _FULLCALO_1p0x1p0_BEST_E;
+  float _FULLCALO_1p0x1p0_BEST_PHI;
+  float _FULLCALO_1p0x1p0_BEST_ETA;
+
   //int verbosity;
 };
 


### PR DESCRIPTION
CaloTriggerSim: A simulation of a"FullCalo" (jet patch) trigger is implemented. The trigger uses both EMCal and HCal tower energies, allowing for experimental triggering on jets of varying sizes and, potentially, on high-pT hadrons. The algorithm first creates a 0.1x0.1 grid in eta and phi as defined by the OHCal geometry. It then fills 0.1x0.1 grid blocks according to the energy in EMCal, IHCal and OHCal towers (for the EMCal, the geometric center of the small towers are used to assign them to the corresponding larger 0.1x0.1 blocks). The 0.1x0.1 blocks are regrouped into 0.2x0.2-sized blocks. Then, sliding windows over these 0.2x0.2 blocks are constructed with total sizes in eta by phi of 0.4x0.4, 0.6x0.6, 0.8x0.8 and 1.0x1.0. The highest-energy windows for each size are calculated, along with their eta and phi position.

CaloTriggerInfo: the virtual base class and "v1" implementation have both been updated to store FullCalo trigger information (largest E and eta, phi position for each window size) on the node. Since we have not yet had a large simulation production with stored trigger information, and since the FullCalo windows are part of the core trigger information, I would like to update the virtual base class at this time.

To briefly demonstrate the performance of the simulated trigger, I attach two plots:
1. Rejection factors as a function of window E for minimum bias p+p collisions, showing different window sizes separately: [h1_trigFull_rej.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/968861/h1_trigFull_rej.pdf)
2. Efficiencies with respect to offline reconstructed tower jets, as a function of pT of the highest-pT jet in the event, in QCD hard scattering p+p collisions. Examples are shown for R=0.2, 0.3 and 0.4 jets with respect to a trigger based on requiring a threshold energy in a 0.4x0.4, 0.6x0.6 and 0.8x0.8 window (respectively for the three cone sizes): [h1_pt_Etrig.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/969105/h1_pt_Etrig.pdf)
