### PR TITLE
Modify PHG4Cylinder to accomodate TPC, add step size limit, add FR4 and sPHENIX tpc gas

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -238,7 +238,7 @@ libg4detectors_la_SOURCES = \
   PHG4Prototype2OuterHcalDetector.cc \
   PHG4Prototype2OuterHcalSteppingAction.cc \
   PHG4Prototype2OuterHcalSubsystem.cc \
-  PHG4Prototype2OuterHcalSubsystem_Dict.C \
+  PHG4Prototype2OuterHcalSubsystem_Dict.cc \
   PHG4RICHDetector.cc \
   PHG4RICHSteppingAction.cc \
   PHG4RICHSubsystem.cc \

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -15,6 +15,7 @@
 #include <Geant4/G4PhysicalConstants.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Tubs.hh>
+#include <Geant4/G4UserLimits.hh>
 #include <Geant4/G4VisAttributes.hh>
 
 #include <cmath>
@@ -72,10 +73,17 @@ void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
                                         radius,
                                         radius + thickness,
                                         params->get_double_param("length") * cm / 2., 0, twopi);
+  double steplimits = params->get_double_param("steplimits")*cm;
+  G4UserLimits *g4userlimits = nullptr;
+  if (isfinite(steplimits))
+  {
+    g4userlimits = new G4UserLimits(steplimits);
+  }
+  
   G4LogicalVolume *cylinder_logic = new G4LogicalVolume(cylinder_solid,
                                                         TrackerMaterial,
                                                         G4String(GetName().c_str()),
-                                                        0, 0, 0);
+                                                        nullptr, nullptr, g4userlimits);
   cylinder_logic->SetVisAttributes(siliconVis);
   cylinder_physi = new G4PVPlacement(0, G4ThreeVector(params->get_double_param("place_x") * cm,
                                                       params->get_double_param("place_y") * cm,

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -24,10 +24,11 @@
 using namespace std;
 
 //_______________________________________________________________
-PHG4CylinderDetector::PHG4CylinderDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam, const int lyr) : PHG4Detector(Node, dnam),
-                                                                                                                                        params(parameters),
-                                                                                                                                        cylinder_physi(nullptr),
-                                                                                                                                        layer(lyr)
+PHG4CylinderDetector::PHG4CylinderDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam, const int lyr)
+  : PHG4Detector(Node, dnam)
+  , params(parameters)
+  , cylinder_physi(nullptr)
+  , layer(lyr)
 {
 }
 
@@ -73,13 +74,13 @@ void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
                                         radius,
                                         radius + thickness,
                                         params->get_double_param("length") * cm / 2., 0, twopi);
-  double steplimits = params->get_double_param("steplimits")*cm;
+  double steplimits = params->get_double_param("steplimits") * cm;
   G4UserLimits *g4userlimits = nullptr;
   if (isfinite(steplimits))
   {
     g4userlimits = new G4UserLimits(steplimits);
   }
-  
+
   G4LogicalVolume *cylinder_logic = new G4LogicalVolume(cylinder_solid,
                                                         TrackerMaterial,
                                                         G4String(GetName().c_str()),

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -20,21 +20,22 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4CylinderSteppingAction::PHG4CylinderSteppingAction(PHG4CylinderDetector* detector, const PHG4Parameters* parameters) : detector_(detector),
-                                                                                                                           params(parameters),
-                                                                                                                           hits_(nullptr),
-                                                                                                                           hit(nullptr),
-                                                                                                                           saveshower(nullptr),
-                                                                                                                           save_light_yield(params->get_int_param("lightyield")),
-                                                                                                                           savetrackid(-1),
-                                                                                                                           savepoststepstatus(-1),
-                                                                                                                           active(params->get_int_param("active")),
-                                                                                                                           IsBlackHole(params->get_int_param("blackhole")),
-															   use_g4_steps(params->get_int_param("use_g4steps")),
-                                                                                                                           zmin(params->get_double_param("place_z") * cm - params->get_double_param("length") * cm / 2.),
-                                                                                                                           zmax(params->get_double_param("place_z") * cm + params->get_double_param("length") * cm / 2.),
-                                                                                                                           tmin(params->get_double_param("tmin") * ns),
-                                                                                                                           tmax(params->get_double_param("tmax") * ns)
+PHG4CylinderSteppingAction::PHG4CylinderSteppingAction(PHG4CylinderDetector* detector, const PHG4Parameters* parameters)
+  : detector_(detector)
+  , params(parameters)
+  , hits_(nullptr)
+  , hit(nullptr)
+  , saveshower(nullptr)
+  , save_light_yield(params->get_int_param("lightyield"))
+  , savetrackid(-1)
+  , savepoststepstatus(-1)
+  , active(params->get_int_param("active"))
+  , IsBlackHole(params->get_int_param("blackhole"))
+  , use_g4_steps(params->get_int_param("use_g4steps"))
+  , zmin(params->get_double_param("place_z") * cm - params->get_double_param("length") * cm / 2.)
+  , zmax(params->get_double_param("place_z") * cm + params->get_double_param("length") * cm / 2.)
+  , tmin(params->get_double_param("tmin") * ns)
+  , tmax(params->get_double_param("tmax") * ns)
 {
   // G4 seems to have issues in the um range
   zmin -= copysign(zmin, 1. / 1e6 * cm);
@@ -102,7 +103,7 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     //       cout << "Particle: " << def->GetParticleName() << endl;
     int prepointstatus = prePoint->GetStepStatus();
     if (prepointstatus == fGeomBoundary ||
-	prepointstatus == fUndefined ||
+        prepointstatus == fUndefined ||
         use_g4_steps > 0)
     {
       if (!hit)

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -13,6 +13,7 @@
 
 #include <Geant4/G4Step.hh>
 #include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4UserLimits.hh>
 
 #include <iomanip>
 #include <iostream>
@@ -99,13 +100,11 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     //        cout << "kinetic energy: " <<  aTrack->GetKineticEnergy()/GeV << endl;
     //       G4ParticleDefinition* def = aTrack->GetDefinition();
     //       cout << "Particle: " << def->GetParticleName() << endl;
-    cout << "in stepping action" << endl;
     int prepointstatus = prePoint->GetStepStatus();
     if (prepointstatus == fGeomBoundary ||
 	prepointstatus == fUndefined ||
         use_g4_steps > 0)
     {
-      cout << "Creating new hit" << endl;
       if (!hit)
       {
         hit = new PHG4Hitv1();
@@ -236,7 +235,6 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         aTrack->GetTrackStatus() == fStopAndKill ||
         use_g4_steps > 0)
     {
-      cout << "terminating hit" << endl;
       // save only hits with energy deposit (or -1 for geantino)
       if (hit->get_edep())
       {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -42,6 +42,7 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
   int savepoststepstatus;
   int active;
   int IsBlackHole;
+  int use_g4_steps;
   double zmin;
   double zmax;
   double tmin;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -124,6 +124,7 @@ void PHG4CylinderSubsystem::SetDefaultParameters()
 
   set_default_int_param("lengthviarapidity", 1);
   set_default_int_param("lightyield", 0);
+  set_default_int_param("use_g4steps",0);
 
   set_default_string_param("material", "G4_Galactic");
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -18,9 +18,10 @@
 using namespace std;
 
 //_______________________________________________________________________
-PHG4CylinderSubsystem::PHG4CylinderSubsystem(const std::string &na, const int lyr) : PHG4DetectorSubsystem(na, lyr),
-                                                                                     detector_(nullptr),
-                                                                                     steppingAction_(nullptr)
+PHG4CylinderSubsystem::PHG4CylinderSubsystem(const std::string &na, const int lyr)
+  : PHG4DetectorSubsystem(na, lyr)
+  , detector_(nullptr)
+  , steppingAction_(nullptr)
 {
   InitializeParameters();
 }
@@ -118,14 +119,14 @@ void PHG4CylinderSubsystem::SetDefaultParameters()
   set_default_double_param("place_y", 0.);
   set_default_double_param("place_z", 0.);
   set_default_double_param("radius", 100);
-  set_default_double_param("steplimits",NAN);
+  set_default_double_param("steplimits", NAN);
   set_default_double_param("thickness", 100);
   set_default_double_param("tmin", NAN);
   set_default_double_param("tmax", NAN);
 
   set_default_int_param("lengthviarapidity", 1);
   set_default_int_param("lightyield", 0);
-  set_default_int_param("use_g4steps",0);
+  set_default_int_param("use_g4steps", 0);
 
   set_default_string_param("material", "G4_Galactic");
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -118,6 +118,7 @@ void PHG4CylinderSubsystem::SetDefaultParameters()
   set_default_double_param("place_y", 0.);
   set_default_double_param("place_z", 0.);
   set_default_double_param("radius", 100);
+  set_default_double_param("steplimits",NAN);
   set_default_double_param("thickness", 100);
   set_default_double_param("tmin", NAN);
   set_default_double_param("tmax", NAN);

--- a/simulation/g4simulation/g4main/HepMCCompress.cc
+++ b/simulation/g4simulation/g4main/HepMCCompress.cc
@@ -74,10 +74,8 @@ HepMCCompress::process_event(PHCompositeNode *topNode)
     }
 
   vector<short> shepmcvtxvec;
-  vector<short> shepmcparticlevec;
 
   std::list<HepMC::GenParticle*> finalstateparticles;
-  std::list<HepMC::GenParticle*>::const_iterator  fiter;
   // units in G4 interface are GeV and CM
   //  const double mom_factor = HepMC::Units::conversion_factor( evt->momentum_unit(), HepMC::Units::GEV );
   const double length_factor = HepMC::Units::conversion_factor( evt->length_unit(), HepMC::Units::CM );

--- a/simulation/g4simulation/g4main/PHG4HitContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4HitContainer.cc
@@ -15,7 +15,7 @@ PHG4HitContainer::PHG4HitContainer()
 {
 }
 
-PHG4HitContainer::PHG4HitContainer(std::string nodename)
+PHG4HitContainer::PHG4HitContainer(const std::string &nodename)
   : id(PHG4HitDefs::get_volume_id(nodename)), hitmap(), layers()
 {
 }

--- a/simulation/g4simulation/g4main/PHG4HitContainer.h
+++ b/simulation/g4simulation/g4main/PHG4HitContainer.h
@@ -21,7 +21,7 @@ class PHG4HitContainer: public PHObject
   typedef std::set<unsigned int>::const_iterator LayerIter;
 
   PHG4HitContainer(); //< used only by ROOT for DST readback
-  PHG4HitContainer(std::string nodename);
+  PHG4HitContainer(const std::string &nodename);
 
   virtual ~PHG4HitContainer() {}
 

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -33,6 +33,7 @@
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4NistManager.hh>
 #include <Geant4/G4OpenGLImmediateX.hh>
+#include <Geant4/G4StepLimiterPhysics.hh>
 #include <Geant4/G4UIExecutive.hh>
 #include <Geant4/G4UImanager.hh>
 #include <Geant4/G4VisExecutive.hh>
@@ -239,6 +240,8 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
     if (active_force_decay_) decayer->SetForceDecay(force_decay_type_);
     myphysicslist->RegisterPhysics(decayer);
   }
+
+  myphysicslist->RegisterPhysics(new G4StepLimiterPhysics());
   runManager_->SetUserInitialization(myphysicslist);
 
   // initialize registered subsystems

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -98,29 +98,30 @@ G4UImanager *UImanager = nullptr;
 void g4guithread(void *ptr);
 
 //_________________________________________________________________
-PHG4Reco::PHG4Reco(const string &name) : SubsysReco(name),
-                                         magfield(2),
-                                         magfield_rescale(1.0),
-                                         field_(nullptr),
-                                         runManager_(nullptr),
-                                         uisession_(nullptr),
-                                         detector_(nullptr),
-                                         eventAction_(nullptr),
-                                         steppingAction_(nullptr),
-                                         trackingAction_(nullptr),
-                                         generatorAction_(nullptr),
-                                         visManager(nullptr),
-                                         _eta_coverage(1.0),
-                                         mapdim(0),
-                                         fieldmapfile("NONE"),
-                                         worldshape("G4Tubs"),
-                                         worldmaterial("G4_AIR"),
-                                         physicslist("QGSP_BERT"),
-                                         active_decayer_(true),
-                                         active_force_decay_(false),
-                                         force_decay_type_(kAll),
-                                         save_DST_geometry_(false),
-                                         _timer(PHTimeServer::get()->insert_new(name))
+PHG4Reco::PHG4Reco(const string &name)
+  : SubsysReco(name)
+  , magfield(2)
+  , magfield_rescale(1.0)
+  , field_(nullptr)
+  , runManager_(nullptr)
+  , uisession_(nullptr)
+  , detector_(nullptr)
+  , eventAction_(nullptr)
+  , steppingAction_(nullptr)
+  , trackingAction_(nullptr)
+  , generatorAction_(nullptr)
+  , visManager(nullptr)
+  , _eta_coverage(1.0)
+  , mapdim(0)
+  , fieldmapfile("NONE")
+  , worldshape("G4Tubs")
+  , worldmaterial("G4_AIR")
+  , physicslist("QGSP_BERT")
+  , active_decayer_(true)
+  , active_force_decay_(false)
+  , force_decay_type_(kAll)
+  , save_DST_geometry_(false)
+  , _timer(PHTimeServer::get()->insert_new(name))
 {
   for (int i = 0; i < 3; i++)
   {
@@ -680,7 +681,6 @@ void PHG4Reco::DefineMaterials()
   MuIDgas->AddMaterial(IsoButane, fractionmass = 0.08);
   MuIDgas->AddMaterial(G4Material::GetMaterial("G4_CARBON_DIOXIDE"), fractionmass = 0.92);
 
-
   // that seems to be the composition of 304 Stainless steel
   G4Material *StainlessSteel =
       new G4Material("SS304", density = 7.9 * g / cm3, ncomponents = 8);
@@ -731,7 +731,7 @@ void PHG4Reco::DefineMaterials()
   Al5083->AddElement(G4Element::GetElement("Mg"), 0.04);
   Al5083->AddElement(G4Element::GetElement("Al"), 0.956);
 
-  G4Material *FPC = new G4Material("FPC", 1.542*g/cm3, 2);
+  G4Material *FPC = new G4Material("FPC", 1.542 * g / cm3, 2);
   FPC->AddMaterial(G4Material::GetMaterial("G4_Cu"), 0.0162);
   FPC->AddMaterial(G4Material::GetMaterial("G4_KAPTON"), 0.9838);
 
@@ -740,18 +740,18 @@ void PHG4Reco::DefineMaterials()
   W_Epoxy->AddMaterial(G4Material::GetMaterial("G4_W"), fractionmass = 0.5);
   W_Epoxy->AddMaterial(G4Material::GetMaterial("G4_POLYSTYRENE"), fractionmass = 0.5);
 
-//from http://www.physi.uni-heidelberg.de/~adler/TRD/TRDunterlagen/RadiatonLength/tgc2.htm
-//Epoxy (for FR4 )
-//density = 1.2*g/cm3;
-G4Material* Epoxy = new G4Material("Epoxy" , 1.2*g/cm3, ncomponents=2);
-Epoxy->AddElement(G4Element::GetElement("H"), natoms=2);
-Epoxy->AddElement(G4Element::GetElement("C"), natoms=2);
-  
-//FR4 (Glass + Epoxy)
-density = 1.86*g/cm3;
-G4Material* FR4 = new G4Material("FR4"  , density, ncomponents=2);
-FR4->AddMaterial(quartz, fractionmass=0.528);
-FR4->AddMaterial(Epoxy, fractionmass=0.472);
+  //from http://www.physi.uni-heidelberg.de/~adler/TRD/TRDunterlagen/RadiatonLength/tgc2.htm
+  //Epoxy (for FR4 )
+  //density = 1.2*g/cm3;
+  G4Material *Epoxy = new G4Material("Epoxy", 1.2 * g / cm3, ncomponents = 2);
+  Epoxy->AddElement(G4Element::GetElement("H"), natoms = 2);
+  Epoxy->AddElement(G4Element::GetElement("C"), natoms = 2);
+
+  //FR4 (Glass + Epoxy)
+  density = 1.86 * g / cm3;
+  G4Material *FR4 = new G4Material("FR4", density, ncomponents = 2);
+  FR4->AddMaterial(quartz, fractionmass = 0.528);
+  FR4->AddMaterial(Epoxy, fractionmass = 0.472);
   // spacal material. Source : EICROOT/A. Kiselev
   /*
   WEpoxyMix          3  12.011 1.008 183.85  6.  1.  74.  12.18  0.029 0.002 0.969
@@ -811,16 +811,16 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   ePHEINX_TPC_Gas->AddMaterial(G4Material::GetMaterial("G4_Ar"), den_G4_Ar / den);
   ePHEINX_TPC_Gas->AddMaterial(G4Material::GetMaterial("G4_CARBON_DIOXIDE"),
                                den_G4_CARBON_DIOXIDE / den);
-// cross checked with original implementation made up of Ne,C,F
-// this here is very close but makes more sense since it uses Ne and CF4
+  // cross checked with original implementation made up of Ne,C,F
+  // this here is very close but makes more sense since it uses Ne and CF4
   double G4_Ne_frac = 0.9;
   double CF4_frac = 0.1;
-  const double den_G4_Ne =  G4Material::GetMaterial("G4_Ne")->GetDensity();
+  const double den_G4_Ne = G4Material::GetMaterial("G4_Ne")->GetDensity();
   const double den_CF4_2 = CF4->GetDensity();
   const double den_sphenix_tpc_gas = den_G4_Ne * G4_Ne_frac + den_CF4_2 * CF4_frac;
   G4Material *sPHENIX_tpc_gas = new G4Material("sPHENIX_TPC_Gas", den_sphenix_tpc_gas, ncomponents = 2, kStateGas);
-  sPHENIX_tpc_gas->AddMaterial(CF4,den_CF4_2*CF4_frac/den_sphenix_tpc_gas);
-  sPHENIX_tpc_gas->AddMaterial(G4Material::GetMaterial("G4_Ne"), den_G4_Ne*G4_Ne_frac/den_sphenix_tpc_gas);
+  sPHENIX_tpc_gas->AddMaterial(CF4, den_CF4_2 * CF4_frac / den_sphenix_tpc_gas);
+  sPHENIX_tpc_gas->AddMaterial(G4Material::GetMaterial("G4_Ne"), den_G4_Ne * G4_Ne_frac / den_sphenix_tpc_gas);
   //
   // CF4
   //

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -740,6 +740,18 @@ void PHG4Reco::DefineMaterials()
   W_Epoxy->AddMaterial(G4Material::GetMaterial("G4_W"), fractionmass = 0.5);
   W_Epoxy->AddMaterial(G4Material::GetMaterial("G4_POLYSTYRENE"), fractionmass = 0.5);
 
+//from http://www.physi.uni-heidelberg.de/~adler/TRD/TRDunterlagen/RadiatonLength/tgc2.htm
+//Epoxy (for FR4 )
+//density = 1.2*g/cm3;
+G4Material* Epoxy = new G4Material("Epoxy" , 1.2*g/cm3, ncomponents=2);
+Epoxy->AddElement(G4Element::GetElement("H"), natoms=2);
+Epoxy->AddElement(G4Element::GetElement("C"), natoms=2);
+  
+//FR4 (Glass + Epoxy)
+density = 1.86*g/cm3;
+G4Material* FR4 = new G4Material("FR4"  , density, ncomponents=2);
+FR4->AddMaterial(quartz, fractionmass=0.528);
+FR4->AddMaterial(Epoxy, fractionmass=0.472);
   // spacal material. Source : EICROOT/A. Kiselev
   /*
   WEpoxyMix          3  12.011 1.008 183.85  6.  1.  74.  12.18  0.029 0.002 0.969

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -676,12 +676,7 @@ void PHG4Reco::DefineMaterials()
   G4Material *MuIDgas = new G4Material("MuIDgas", density = (1.977e-3 * 0.92 + 0.00265 * 0.08) * g / cm3, ncomponents = 2);
   MuIDgas->AddMaterial(IsoButane, fractionmass = 0.08);
   MuIDgas->AddMaterial(G4Material::GetMaterial("G4_CARBON_DIOXIDE"), fractionmass = 0.92);
-  //----
 
-  // G4Material* Sci =
-  //   new G4Material("Scintillator", density = 1.032 * g / cm3, ncomponents = 2);
-  // Sci->AddElement(C, natoms = 9);
-  // Sci->AddElement(H, natoms = 10);
 
   // that seems to be the composition of 304 Stainless steel
   G4Material *StainlessSteel =
@@ -801,7 +796,16 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   ePHEINX_TPC_Gas->AddMaterial(G4Material::GetMaterial("G4_Ar"), den_G4_Ar / den);
   ePHEINX_TPC_Gas->AddMaterial(G4Material::GetMaterial("G4_CARBON_DIOXIDE"),
                                den_G4_CARBON_DIOXIDE / den);
-
+// cross checked with original implementation made up of Ne,C,F
+// this here is very close but makes more sense since it uses Ne and CF4
+  double G4_Ne_frac = 0.9;
+  double CF4_frac = 0.1;
+  const double den_G4_Ne =  G4Material::GetMaterial("G4_Ne")->GetDensity();
+  const double den_CF4_2 = CF4->GetDensity();
+  const double den_sphenix_tpc_gas = den_G4_Ne * G4_Ne_frac + den_CF4_2 * CF4_frac;
+  G4Material *sPHENIX_tpc_gas = new G4Material("sPHENIX_TPC_Gas", den_sphenix_tpc_gas, ncomponents = 2, kStateGas);
+  sPHENIX_tpc_gas->AddMaterial(CF4,den_CF4_2*CF4_frac/den_sphenix_tpc_gas);
+  sPHENIX_tpc_gas->AddMaterial(G4Material::GetMaterial("G4_Ne"), den_G4_Ne*G4_Ne_frac/den_sphenix_tpc_gas);
   //
   // CF4
   //

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -81,7 +81,7 @@ void PHG4TruthTrackingAction::PreUserTrackingAction( const G4Track* track) {
 
   if (!track->GetParentID()) {
     // primary track - propagate the barcode information
-    PHG4UserPrimaryParticleInformation* userdata = (PHG4UserPrimaryParticleInformation*)track->GetDynamicParticle()->GetPrimaryParticle()->GetUserInformation();
+    PHG4UserPrimaryParticleInformation* userdata = static_cast<PHG4UserPrimaryParticleInformation*> (track->GetDynamicParticle()->GetPrimaryParticle()->GetUserInformation());
     if(userdata) ti->set_barcode( userdata->get_user_barcode() );
   }
 
@@ -136,7 +136,7 @@ void PHG4TruthTrackingAction::PreUserTrackingAction( const G4Track* track) {
     
   // tell the primary particle copy in G4 where this output will be stored
   if (!track->GetParentID()) {
-    PHG4UserPrimaryParticleInformation* userdata = (PHG4UserPrimaryParticleInformation*)track->GetDynamicParticle()->GetPrimaryParticle()->GetUserInformation();
+    PHG4UserPrimaryParticleInformation* userdata = static_cast<PHG4UserPrimaryParticleInformation*>(track->GetDynamicParticle()->GetPrimaryParticle()->GetUserInformation());
     if (userdata) {
       userdata->set_user_track_id(trackid);
       userdata->set_user_vtx_id(vtxindex);


### PR DESCRIPTION
The Cylinders can now save hits after each step with adjustable step size (that did not work before - Thanks Carlos for figuring this out). FR4 was added - found in ncc code by Andrey Sukhanov and the sPHENIX tpc gas (90% Ne, 10%CF4). Fixed some cppcheck warnings on the way