### PR TITLE
Use PHG4Parameters to store/retrieve all the hardcoded silicon tracker numbers

### DIFF
--- a/offline/packages/NodeDump/DumpPHG4CylinderGeomContainer.cc
+++ b/offline/packages/NodeDump/DumpPHG4CylinderGeomContainer.cc
@@ -36,6 +36,17 @@ int DumpPHG4CylinderGeomContainer::process_Node(PHNode *myNode)
           *fout << "thickness: " << hiter->second->get_thickness() << endl;
           *fout << "zmin: " << hiter->second->get_zmin() << endl;
           *fout << "zmax: " << hiter->second->get_zmax() << endl;
+	  *fout << "nscint: " << hiter->second->get_nscint() << endl;
+	  *fout << "tiltangle: " << hiter->second->get_tiltangle() << endl;
+	  *fout << "strip_y_spacing: " << hiter->second->get_strip_y_spacing() << endl;
+	  *fout << "strip_z_spacing: " << hiter->second->get_strip_z_spacing() << endl;
+	  *fout << "strip_tilt: " << hiter->second->get_strip_tilt() << endl;
+	  *fout << "N_strip_columns: " << hiter->second->get_N_strip_columns()  << endl;
+	  *fout << "N_strips_per_column: " << hiter->second->get_N_strips_per_column() << endl;
+	  *fout << "N_sensors_in_layer: " << hiter->second->get_N_sensors_in_layer() << endl;
+	  *fout << "pixel_z: " << hiter->second->get_pixel_z() << endl;
+	  *fout << "pixel_x: " << hiter->second->get_pixel_x() << endl;
+	  *fout << "pixel_thickness: " << hiter->second->get_pixel_thickness() << endl;
         }
     }
   return 0;

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -403,7 +403,7 @@ void PHG4DetectorGroupSubsystem::InitializeParameters()
   {
     set_default_int_param(*iter, "absorberactive", 0);
     set_default_int_param(*iter, "absorbertruth", 0);
-    set_default_int_param(*iter, "active", 1);
+    set_default_int_param(*iter, "active", 0);
     set_default_int_param(*iter, "blackhole", 0);
   }
   SetDefaultParameters();  // call method from specific subsystem

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -137,8 +137,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
     double fphx_x  = params->get_double_param("fphx_x")*cm;
     double fphx_y  = params->get_double_param("fphx_y")*cm;
     double fphx_z  = params->get_double_param("fphx_z")*cm;
- double pgs_x = params->get_double_param("pgs_x")*mm;
-//    double stave_x = params->get_double_param("stave_x")*cm;
+    double pgs_x = params->get_double_param("pgs_x")*mm;
+    double stave_x = params->get_double_param("stave_x")*mm;
+    double halfladder_z = params->get_double_param("halfladder_z")*cm;
     for (int itype = 0; itype < 2; ++itype)
     {
       if (!(itype >= 0 && itype <= 1))
@@ -186,11 +187,11 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Si-sensor active area
          */
-      const double siactive_x = (strip_x/2.);                        // 0.24mm/2
-      const double siactive_y = strip_y/2. * 2. * nstrips_phi_cell;  // (0.078mm * 2*128)/2 = 0.078mm * 128
+      const double siactive_x = strip_x;                        // 0.24mm/2
+      const double siactive_y = strip_y * nstrips_phi_cell;  // (0.078mm * 2*128)/2 = 0.078mm * 128
       const double siactive_z = strip_z/2. * nstrips_z_sensor;       // (20mm * 5or8)/2 = 10mm * 5or8
 
-      G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x, siactive_y, siactive_z);
+      G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x/2., siactive_y, siactive_z);
       G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 
       G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, (strip_y/2.) *2., (strip_z/2.) *2.);
@@ -199,7 +200,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Si-sensor full (active+inactive) area
          */
-      const double sifull_x = siactive_x;                    // 0.24mm/2
+      const double sifull_x = siactive_x/2.;                    // 0.24mm/2
       const double sifull_y = siactive_y + params->get_double_param("sensor_edge_phi")*cm;  // (1.305mm  + 0.078mm * 2*128 + 1.305mm)/2 = 0.078mm * 128 + 1.305mm
       const double sifull_z = siactive_z + params->get_double_param("sensor_edge_z")*cm;    // (0.98mm + 20mm * 5 + 0.98mm)/2 = 10mm * 5 + 0.98mm
 
@@ -228,7 +229,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4LogicalVolume *hdi_volume = new G4LogicalVolume(hdi_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(hdi_volume);
 
-      const G4double hdi_ext_z = (itype == 0) ? 0.000001 : arr_halfladder_z[ilayer] - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
+      const G4double hdi_ext_z = (itype == 0) ? 0.000001 : halfladder_z/2. - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
       G4VSolid *hdi_ext_box = new G4Box(boost::str(boost::format("hdi_ext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x/2., hdi_y/2., hdi_ext_z);
       G4LogicalVolume *hdi_ext_volume = new G4LogicalVolume(hdi_ext_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdi_ext_box_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(hdi_ext_volume);
@@ -301,11 +302,11 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       const double stave_y = pgs_y;
       const double stave_z = hdi_z;
 
-      G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % sphxlayer % itype).c_str(), stave_x, stave_y, stave_z);
+      G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % sphxlayer % itype).c_str(), stave_x/2., stave_y, stave_z);
       //G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, Copper, boost::str(boost::format("stave_volume_%d_%d") %sphxlayer %itype).c_str(), 0, 0, 0);
       G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(stave_volume);
-      G4VSolid *stave_ext_box = new G4Box(boost::str(boost::format("stave_ext_box_%d_%s") % sphxlayer % itype).c_str(), stave_x, stave_y, hdi_ext_z);
+      G4VSolid *stave_ext_box = new G4Box(boost::str(boost::format("stave_ext_box_%d_%s") % sphxlayer % itype).c_str(), stave_x/2., stave_y, hdi_ext_z);
       //G4LogicalVolume *stave_ext_volume = new G4LogicalVolume(stave_ext_box,  Copper, boost::str(boost::format("stave_ext_volume_%d_%s") %sphxlayer %itype).c_str(), 0, 0, 0);
       G4LogicalVolume *stave_ext_volume = new G4LogicalVolume(stave_ext_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(stave_ext_volume);
@@ -318,7 +319,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Ladder
          */
-      const double ladder_x = stave_x + pgs_x/2. + hdi_x/2. + fphx_x/2.;
+      const double ladder_x = stave_x/2. + pgs_x/2. + hdi_x/2. + fphx_x/2.;
       const double ladder_y = hdi_y;
       const double ladder_z = hdi_z;
       G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x, ladder_y/2., ladder_z);
@@ -341,14 +342,14 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Carbon stave
          */
-      const double TVstave_x = -ladder_x + stave_x;
+      const double TVstave_x = -ladder_x + stave_x/2.;
       new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), stave_volume, boost::str(boost::format("stave_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
       new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), stave_ext_volume, boost::str(boost::format("stave_ext_%d_%s") % sphxlayer % itype).c_str(), ladder_ext_volume, false, 0, overlapcheck);
 
       /*
          * PGS
          */
-      const double TVpgs_x = TVstave_x + stave_x + pgs_x/2.;
+      const double TVpgs_x = TVstave_x + stave_x/2. + pgs_x/2.;
       new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgs_volume, boost::str(boost::format("pgs_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
       new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgs_ext_volume, boost::str(boost::format("pgs_ext_%d_%s") % sphxlayer % itype).c_str(), ladder_ext_volume, false, 0, overlapcheck);
 
@@ -362,7 +363,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Si-sensor
          */
-      const double TVSi_x = TVhdi_x + hdi_x/2. + siactive_x;
+      const double TVSi_x = TVhdi_x + hdi_x/2. + siactive_x/2.;
       new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siinactive_volume, boost::str(boost::format("siinactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
       new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siactive_volume, boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -119,7 +119,6 @@ void PHG4SiliconTrackerDetector::Construct(G4LogicalVolume *logicWorld)
 int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *trackerenvelope)
 {
   double hdi_z_[nlayer_][2];
-
   for (unsigned int ilayer = 0; ilayer < nlayer_; ++ilayer)
   {
     const int sphxlayer = layerconfig_[ilayer].first;
@@ -197,8 +196,8 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
          * Si-sensor full (active+inactive) area
          */
       const double sifull_x = siactive_x;                    // 0.24mm/2
-      const double sifull_y = siactive_y + sensor_edge_phi;  // (1.305mm  + 0.078mm * 2*128 + 1.305mm)/2 = 0.078mm * 128 + 1.305mm
-      const double sifull_z = siactive_z + sensor_edge_z;    // (0.98mm + 20mm * 5 + 0.98mm)/2 = 10mm * 5 + 0.98mm
+      const double sifull_y = siactive_y + params->get_double_param("sensor_edge_phi")*cm;  // (1.305mm  + 0.078mm * 2*128 + 1.305mm)/2 = 0.078mm * 128 + 1.305mm
+      const double sifull_z = siactive_z + params->get_double_param("sensor_edge_z")*cm;    // (0.98mm + 20mm * 5 + 0.98mm)/2 = 10mm * 5 + 0.98mm
 
       G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % sphxlayer % itype).c_str(), sifull_x, sifull_y, sifull_z);
 
@@ -218,7 +217,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * HDI
          */
-      const G4double hdi_z = sifull_z + hdi_edge_z;  // hdi_edge_z = 100micron
+      const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z")*cm;  // hdi_edge_z = 100micron
       hdi_z_[ilayer][itype] = hdi_z;
 
       G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x, hdi_y, hdi_z);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -133,8 +133,12 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
     const G4double offsetphi = params->get_double_param("offsetphi")*deg;
     const G4double offsetrot =  params->get_double_param("offsetrot")*deg;
     const G4double hdi_y = params->get_double_param("hdi_y")*cm;
-
-
+    double hdi_x = params->get_double_param("hdi_x")*cm;
+    double fphx_x  = params->get_double_param("fphx_x")*cm;
+    double fphx_y  = params->get_double_param("fphx_y")*cm;
+    double fphx_z  = params->get_double_param("fphx_z")*cm;
+ double pgs_x = params->get_double_param("pgs_x")*mm;
+//    double stave_x = params->get_double_param("stave_x")*cm;
     for (int itype = 0; itype < 2; ++itype)
     {
       if (!(itype >= 0 && itype <= 1))
@@ -220,12 +224,12 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z")*cm;  // hdi_edge_z = 100micron
       hdi_z_[ilayer][itype] = hdi_z;
 
-      G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x, hdi_y/2., hdi_z);
+      G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x/2., hdi_y/2., hdi_z);
       G4LogicalVolume *hdi_volume = new G4LogicalVolume(hdi_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(hdi_volume);
 
       const G4double hdi_ext_z = (itype == 0) ? 0.000001 : arr_halfladder_z[ilayer] - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
-      G4VSolid *hdi_ext_box = new G4Box(boost::str(boost::format("hdi_ext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x, hdi_y/2., hdi_ext_z);
+      G4VSolid *hdi_ext_box = new G4Box(boost::str(boost::format("hdi_ext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x/2., hdi_y/2., hdi_ext_z);
       G4LogicalVolume *hdi_ext_volume = new G4LogicalVolume(hdi_ext_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdi_ext_box_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(hdi_ext_volume);
       G4VisAttributes *hdi_vis = new G4VisAttributes();
@@ -237,7 +241,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * FPHX
          */
-      G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % sphxlayer % itype).c_str(), fphx_x, fphx_y, fphx_z);
+      G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % sphxlayer % itype).c_str(), fphx_x/2., fphx_y/2., fphx_z/2.);
       G4LogicalVolume *fphx_volume = new G4LogicalVolume(fphx_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("fphx_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(fphx_volume);
       G4VisAttributes *fphx_vis = new G4VisAttributes();
@@ -251,8 +255,8 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * FPHX Container
          */
-      const double fphxcontainer_x = fphx_x;
-      const double fphxcontainer_y = fphx_y;
+      const double fphxcontainer_x = fphx_x/2.;
+      const double fphxcontainer_y = fphx_y/2.;
       const double fphxcontainer_z = hdi_z;
 
       G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % sphxlayer % itype).c_str(), fphxcontainer_x, fphxcontainer_y, fphxcontainer_z);
@@ -274,14 +278,14 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * PGS
          */
-      const double pgs_y = sifull_y + gap_sensor_fphx + 2. * fphx_y;  // between FPHX's outer edges
+      const double pgs_y = sifull_y + gap_sensor_fphx + 2. * fphx_y/2.;  // between FPHX's outer edges
       const double pgs_z = hdi_z;
 
-      G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % sphxlayer % itype).c_str(), pgs_x, pgs_y, pgs_z);
+      G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % sphxlayer % itype).c_str(), pgs_x/2., pgs_y, pgs_z);
       //G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, Copper, boost::str(boost::format("pgs_volume_%d_%d") %sphxlayer %itype).c_str(), 0, 0, 0);
       G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgs_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(pgs_volume);
-      G4VSolid *pgs_ext_box = new G4Box(boost::str(boost::format("pgs_ext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x, pgs_y, hdi_ext_z);
+      G4VSolid *pgs_ext_box = new G4Box(boost::str(boost::format("pgs_ext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x/2., pgs_y, hdi_ext_z);
       //G4LogicalVolume *pgs_ext_volume = new G4LogicalVolume(pgs_ext_box, Copper, boost::str(boost::format("pgs_ext_volume_%d_%s") %sphxlayer %itype).c_str(), 0, 0, 0);
       G4LogicalVolume *pgs_ext_volume = new G4LogicalVolume(pgs_ext_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgs_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
 
@@ -314,13 +318,13 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Ladder
          */
-      const double ladder_x = stave_x + pgs_x + hdi_x + fphx_x;
-      const double ladder_y = hdi_y/2.;
+      const double ladder_x = stave_x + pgs_x/2. + hdi_x/2. + fphx_x/2.;
+      const double ladder_y = hdi_y;
       const double ladder_z = hdi_z;
-      G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x, ladder_y, ladder_z);
+      G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x, ladder_y/2., ladder_z);
       G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(ladder_volume);
-      G4VSolid *ladder_ext_box = new G4Box(boost::str(boost::format("ladder_ext_box_%d_%s") % sphxlayer % itype).c_str(), ladder_x, ladder_y, hdi_ext_z);
+      G4VSolid *ladder_ext_box = new G4Box(boost::str(boost::format("ladder_ext_box_%d_%s") % sphxlayer % itype).c_str(), ladder_x, ladder_y/2., hdi_ext_z);
       G4LogicalVolume *ladder_ext_volume = new G4LogicalVolume(ladder_ext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(ladder_ext_volume);
       G4VisAttributes *ladder_vis = new G4VisAttributes();
@@ -344,29 +348,29 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * PGS
          */
-      const double TVpgs_x = TVstave_x + stave_x + pgs_x;
+      const double TVpgs_x = TVstave_x + stave_x + pgs_x/2.;
       new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgs_volume, boost::str(boost::format("pgs_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
       new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgs_ext_volume, boost::str(boost::format("pgs_ext_%d_%s") % sphxlayer % itype).c_str(), ladder_ext_volume, false, 0, overlapcheck);
 
       /*
          * HDI
          */
-      const double TVhdi_x = TVpgs_x + pgs_x + hdi_x;
+      const double TVhdi_x = TVpgs_x + pgs_x/2. + hdi_x/2.;
       new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdi_volume, boost::str(boost::format("hdi_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
       new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdi_ext_volume, boost::str(boost::format("hdi_ext_%d_%s") % sphxlayer % itype).c_str(), ladder_ext_volume, false, 0, overlapcheck);
 
       /*
          * Si-sensor
          */
-      const double TVSi_x = TVhdi_x + hdi_x + siactive_x;
+      const double TVSi_x = TVhdi_x + hdi_x/2. + siactive_x;
       new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siinactive_volume, boost::str(boost::format("siinactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
       new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siactive_volume, boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
 
       /*
          * FPHX
          */
-      const double TVfphx_x = TVhdi_x + hdi_x + fphx_x;
-      const double TVfphx_y = sifull_y + gap_sensor_fphx + fphx_y;
+      const double TVfphx_x = TVhdi_x + hdi_x/2. + fphx_x/2.;
+      const double TVfphx_y = sifull_y + gap_sensor_fphx + fphx_y/2.;
       new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
 
       new G4PVPlacement(0, G4ThreeVector(TVfphx_x, -TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerm_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
@@ -380,9 +384,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
          * Ladder
          */
       const double dphi = CLHEP::twopi / (double) nladders_layer;
-      eff_radius[ilayer] = radius + ladder_x - 2. * (fphx_x - strip_x/2.);
+      eff_radius[ilayer] = radius + ladder_x - 2. * (fphx_x/2. - strip_x/2.);
       posz[ilayer][itype] = (itype == 0) ? hdi_z : 2. * hdi_z_[ilayer][0] + hdi_z;
-      strip_x_offset[ilayer] = ladder_x - 2. * (fphx_x - strip_x/2.) - strip_x/2.;
+      strip_x_offset[ilayer] = ladder_x - 2. * (fphx_x/2. - strip_x/2.) - strip_x/2.;
 
       for (G4int icopy = 0; icopy < nladders_layer; icopy++)
       {

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -67,9 +67,9 @@ int PHG4SiliconTrackerDetector::IsInSiliconTracker(G4VPhysicalVolume *volume) co
   // to their volumes
   G4LogicalVolume *logvol = volume->GetLogicalVolume();
   if (!absorberlogvols.empty() && absorberlogvols.find(logvol) != absorberlogvols.end())
-    {
-      return -1;
-    }
+  {
+    return -1;
+  }
   if (activelogvols.find(logvol) != activelogvols.end())
   {
     return 1;
@@ -187,7 +187,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4LogicalVolume *siinactive_volume = new G4LogicalVolume(siinactive_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("siinactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
-      absorberlogvols.insert(siinactive_volume);
+        absorberlogvols.insert(siinactive_volume);
       }
       G4VisAttributes *siinactive_vis = new G4VisAttributes();
       siinactive_vis->SetVisibility(true);
@@ -205,14 +205,14 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4LogicalVolume *hdi_volume = new G4LogicalVolume(hdi_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
-      absorberlogvols.insert(hdi_volume);
+        absorberlogvols.insert(hdi_volume);
       }
       const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z / 2. - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
       G4VSolid *hdiext_box = new G4Box(boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdiext_z);
       G4LogicalVolume *hdiext_volume = new G4LogicalVolume(hdiext_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
-      absorberlogvols.insert(hdiext_volume);
+        absorberlogvols.insert(hdiext_volume);
       }
       G4VisAttributes *hdi_vis = new G4VisAttributes();
       hdi_vis->SetVisibility(true);
@@ -227,7 +227,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4LogicalVolume *fphx_volume = new G4LogicalVolume(fphx_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("fphx_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
-      absorberlogvols.insert(fphx_volume);
+        absorberlogvols.insert(fphx_volume);
       }
       G4VisAttributes *fphx_vis = new G4VisAttributes();
       fphx_vis->SetVisibility(true);
@@ -248,7 +248,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4LogicalVolume *fphxcontainer_volume = new G4LogicalVolume(fphxcontainer_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("fphxcontainer_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
-      absorberlogvols.insert(fphxcontainer_volume);
+        absorberlogvols.insert(fphxcontainer_volume);
       }
       G4VisAttributes *fphxcontainer_vis = new G4VisAttributes();
       fphxcontainer_vis->SetVisibility(false);
@@ -273,7 +273,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgs_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
-      absorberlogvols.insert(pgs_volume);
+        absorberlogvols.insert(pgs_volume);
       }
       G4VSolid *pgsext_box = new G4Box(boost::str(boost::format("pgsext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y, hdiext_z);
       G4LogicalVolume *pgsext_volume = new G4LogicalVolume(pgsext_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgsext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
@@ -294,13 +294,13 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
-      absorberlogvols.insert(stave_volume);
+        absorberlogvols.insert(stave_volume);
       }
       G4VSolid *staveext_box = new G4Box(boost::str(boost::format("staveext_box_%d_%s") % sphxlayer % itype).c_str(), stave_x / 2., stave_y, hdiext_z);
       G4LogicalVolume *staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("staveext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
-      absorberlogvols.insert(staveext_volume);
+        absorberlogvols.insert(staveext_volume);
       }
       G4VisAttributes *stave_vis = new G4VisAttributes();
       stave_vis->SetVisibility(true);
@@ -318,13 +318,13 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
-      absorberlogvols.insert(ladder_volume);
+        absorberlogvols.insert(ladder_volume);
       }
       G4VSolid *ladderext_box = new G4Box(boost::str(boost::format("ladderext_box_%d_%s") % sphxlayer % itype).c_str(), ladder_x, ladder_y / 2., hdiext_z);
       G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladderext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
-      absorberlogvols.insert(ladderext_volume);
+        absorberlogvols.insert(ladderext_volume);
       }
       G4VisAttributes *ladder_vis = new G4VisAttributes();
       ladder_vis->SetVisibility(true);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -112,8 +112,8 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
     double fphx_x = params->get_double_param("fphx_x") * cm;
     double fphx_y = params->get_double_param("fphx_y") * cm;
     double fphx_z = params->get_double_param("fphx_z") * cm;
-    double pgs_x = params->get_double_param("pgs_x") * mm;
-    double stave_x = params->get_double_param("stave_x") * mm;
+    double pgs_x = params->get_double_param("pgs_x") * cm;
+    double stave_x = params->get_double_param("stave_x") * cm;
     double halfladder_z = params->get_double_param("halfladder_z") * cm;
     for (int itype = 0; itype < 2; ++itype)
     {

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -127,12 +127,12 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
     const PHG4Parameters *params = paramscontainer->GetParameters(inttlayer);
   const G4double strip_x = params->get_double_param("strip_x")*cm;
     const G4double strip_y =  params->get_double_param("strip_y")*cm;
-    const int nstrips_phi_cell = arr_nstrips_phi_cell[inttlayer];
+    const int nstrips_phi_cell = params->get_int_param("nstrips_phi_cell");
 
     const int nladders_layer = params->get_int_param("nladder");
     const G4double radius = params->get_double_param("radius")*cm;
-    const G4double offsetphi = arr_offsetphi[inttlayer];
-    const G4double offsetrot = arr_offsetrot[inttlayer];
+    const G4double offsetphi = params->get_double_param("offsetphi")*deg;
+    const G4double offsetrot =  params->get_double_param("offsetrot")*deg;
     const G4double hdi_y = arr_hdi_y[inttlayer];
 
 
@@ -144,19 +144,21 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       std::cout << " PHG4SiliconTrackerDetector::ConstrctSiliconTracker:  sphxlayer " << sphxlayer << " inttlayer " << inttlayer << std::endl;
 
       G4double strip_z;
+      int nstrips_z_sensor;
       switch(itype)
       {
       case 0:
 	strip_z =  params->get_double_param("strip_z_0")*cm;
+	nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_0");
 	break;
       case 1:
 	strip_z =  params->get_double_param("strip_z_1")*cm;
+	nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_1");
 	break;
       default:
 	cout << "invalid itype " << itype << endl;
 	exit(1);
       }
-      const int nstrips_z_sensor = (inttlayer == 0) ? arr_nstrips_z_sensor[0][itype] : arr_nstrips_z_sensor[1][itype];
 
       /*----- Step 1 -----
        * We make volume for Si-sensor, FPHX, HDI, PGS sheet, and stave.
@@ -492,9 +494,6 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
       const int sphxlayer = layerconfig_[ilayer].first;
       const int inttlayer = layerconfig_[ilayer].second;
 
-      const int nstrips_z_sensor0 = (ilayer == 0) ? arr_nstrips_z_sensor[0][0] : arr_nstrips_z_sensor[1][0];
-      const int nstrips_z_sensor1 = (ilayer == 0) ? arr_nstrips_z_sensor[0][1] : arr_nstrips_z_sensor[1][1];
-
       const PHG4Parameters *params = paramscontainer->GetParameters(inttlayer);
 // parameters are in cm, so no conversion needed here to get to cm (*cm/cm)
       PHG4CylinderGeom *mygeom = new PHG4CylinderGeom_Siladders(
@@ -503,16 +502,16 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
           params->get_double_param("strip_y"),
           params->get_double_param("strip_z_0"),
           params->get_double_param("strip_z_1"),
-          nstrips_z_sensor0,
-          nstrips_z_sensor1,
-          arr_nstrips_phi_cell[inttlayer],
+	  params->get_int_param("nstrips_z_sensor_0"),//nstrips_z_sensor0,
+          params->get_int_param("nstrips_z_sensor_1"),//nstrips_z_sensor1,
+	  params->get_int_param("nstrips_phi_cell"),
           params->get_int_param("nladder"),
           posz[ilayer][0] / cm,
           posz[ilayer][1] / cm,
           eff_radius[ilayer] / cm,
           strip_x_offset[ilayer] / cm,
-          arr_offsetphi[inttlayer] / rad,
-          arr_offsetrot[inttlayer] / rad);
+          params->get_double_param("offsetphi")*deg/rad,//arr_offsetphi[inttlayer] / rad,
+          params->get_double_param("offsetrot")*deg/rad);//arr_offsetrot[inttlayer] / rad);
       geo->AddLayerGeom(sphxlayer, mygeom);
       if (verbosity > 0)
         geo->identify();

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -132,7 +132,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
     const G4double radius = params->get_double_param("radius")*cm;
     const G4double offsetphi = params->get_double_param("offsetphi")*deg;
     const G4double offsetrot =  params->get_double_param("offsetrot")*deg;
-    const G4double hdi_y = arr_hdi_y[inttlayer];
+    const G4double hdi_y = params->get_double_param("hdi_y")*cm;
 
 
     for (int itype = 0; itype < 2; ++itype)
@@ -220,12 +220,12 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z")*cm;  // hdi_edge_z = 100micron
       hdi_z_[ilayer][itype] = hdi_z;
 
-      G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x, hdi_y, hdi_z);
+      G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x, hdi_y/2., hdi_z);
       G4LogicalVolume *hdi_volume = new G4LogicalVolume(hdi_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(hdi_volume);
 
       const G4double hdi_ext_z = (itype == 0) ? 0.000001 : arr_halfladder_z[ilayer] - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
-      G4VSolid *hdi_ext_box = new G4Box(boost::str(boost::format("hdi_ext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x, hdi_y, hdi_ext_z);
+      G4VSolid *hdi_ext_box = new G4Box(boost::str(boost::format("hdi_ext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x, hdi_y/2., hdi_ext_z);
       G4LogicalVolume *hdi_ext_volume = new G4LogicalVolume(hdi_ext_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdi_ext_box_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(hdi_ext_volume);
       G4VisAttributes *hdi_vis = new G4VisAttributes();
@@ -315,7 +315,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
          * Ladder
          */
       const double ladder_x = stave_x + pgs_x + hdi_x + fphx_x;
-      const double ladder_y = hdi_y;
+      const double ladder_y = hdi_y/2.;
       const double ladder_z = hdi_z;
       G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x, ladder_y, ladder_z);
       G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -124,22 +124,22 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
     const int sphxlayer = layerconfig_[ilayer].first;
     const int inttlayer = layerconfig_[ilayer].second;
     const PHG4Parameters *params = paramscontainer->GetParameters(inttlayer);
-  const G4double strip_x = params->get_double_param("strip_x")*cm;
-    const G4double strip_y =  params->get_double_param("strip_y")*cm;
+    const G4double strip_x = params->get_double_param("strip_x") * cm;
+    const G4double strip_y = params->get_double_param("strip_y") * cm;
     const int nstrips_phi_cell = params->get_int_param("nstrips_phi_cell");
 
     const int nladders_layer = params->get_int_param("nladder");
-    const G4double radius = params->get_double_param("radius")*cm;
-    const G4double offsetphi = params->get_double_param("offsetphi")*deg;
-    const G4double offsetrot =  params->get_double_param("offsetrot")*deg;
-    const G4double hdi_y = params->get_double_param("hdi_y")*cm;
-    double hdi_x = params->get_double_param("hdi_x")*cm;
-    double fphx_x  = params->get_double_param("fphx_x")*cm;
-    double fphx_y  = params->get_double_param("fphx_y")*cm;
-    double fphx_z  = params->get_double_param("fphx_z")*cm;
-    double pgs_x = params->get_double_param("pgs_x")*mm;
-    double stave_x = params->get_double_param("stave_x")*mm;
-    double halfladder_z = params->get_double_param("halfladder_z")*cm;
+    const G4double radius = params->get_double_param("radius") * cm;
+    const G4double offsetphi = params->get_double_param("offsetphi") * deg;
+    const G4double offsetrot = params->get_double_param("offsetrot") * deg;
+    const G4double hdi_y = params->get_double_param("hdi_y") * cm;
+    double hdi_x = params->get_double_param("hdi_x") * cm;
+    double fphx_x = params->get_double_param("fphx_x") * cm;
+    double fphx_y = params->get_double_param("fphx_y") * cm;
+    double fphx_z = params->get_double_param("fphx_z") * cm;
+    double pgs_x = params->get_double_param("pgs_x") * mm;
+    double stave_x = params->get_double_param("stave_x") * mm;
+    double halfladder_z = params->get_double_param("halfladder_z") * cm;
     for (int itype = 0; itype < 2; ++itype)
     {
       if (!(itype >= 0 && itype <= 1))
@@ -149,19 +149,19 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
       G4double strip_z;
       int nstrips_z_sensor;
-      switch(itype)
+      switch (itype)
       {
       case 0:
-	strip_z =  params->get_double_param("strip_z_0")*cm;
-	nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_0");
-	break;
+        strip_z = params->get_double_param("strip_z_0") * cm;
+        nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_0");
+        break;
       case 1:
-	strip_z =  params->get_double_param("strip_z_1")*cm;
-	nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_1");
-	break;
+        strip_z = params->get_double_param("strip_z_1") * cm;
+        nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_1");
+        break;
       default:
-	cout << "invalid itype " << itype << endl;
-	exit(1);
+        cout << "invalid itype " << itype << endl;
+        exit(1);
       }
 
       /*----- Step 1 -----
@@ -172,7 +172,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Si-strip
          */
-      G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % sphxlayer % itype).c_str(), strip_x/2., strip_y/2. - strip_y/ 20000., strip_z/2. - strip_z/2. / 10000.);
+      G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % sphxlayer % itype).c_str(), strip_x / 2., strip_y / 2. - strip_y / 20000., strip_z / 2. - strip_z / 2. / 10000.);
       G4LogicalVolume *strip_volume = new G4LogicalVolume(strip_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("strip_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsActive.find(inttlayer))->second > 0)
       {
@@ -187,11 +187,11 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Si-sensor active area
          */
-      const double siactive_x = strip_x;                        // 0.24mm/2
-      const double siactive_y = strip_y * nstrips_phi_cell;  // (0.078mm * 2*128)/2 = 0.078mm * 128
-      const double siactive_z = strip_z/2. * nstrips_z_sensor;       // (20mm * 5or8)/2 = 10mm * 5or8
+      const double siactive_x = strip_x;                          // 0.24mm/2
+      const double siactive_y = strip_y * nstrips_phi_cell;       // (0.078mm * 2*128)/2 = 0.078mm * 128
+      const double siactive_z = strip_z / 2. * nstrips_z_sensor;  // (20mm * 5or8)/2 = 10mm * 5or8
 
-      G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x/2., siactive_y, siactive_z);
+      G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x / 2., siactive_y, siactive_z);
       G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 
       G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, strip_y, strip_z);
@@ -200,11 +200,11 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Si-sensor full (active+inactive) area
          */
-      const double sifull_x = siactive_x;                    // 0.24mm/2
-      const double sifull_y = siactive_y + params->get_double_param("sensor_edge_phi")*cm;  // (1.305mm  + 0.078mm * 2*128 + 1.305mm)/2 = 0.078mm * 128 + 1.305mm
-      const double sifull_z = siactive_z + params->get_double_param("sensor_edge_z")*cm;    // (0.98mm + 20mm * 5 + 0.98mm)/2 = 10mm * 5 + 0.98mm
+      const double sifull_x = siactive_x;                                                     // 0.24mm/2
+      const double sifull_y = siactive_y + params->get_double_param("sensor_edge_phi") * cm;  // (1.305mm  + 0.078mm * 2*128 + 1.305mm)/2 = 0.078mm * 128 + 1.305mm
+      const double sifull_z = siactive_z + params->get_double_param("sensor_edge_z") * cm;    // (0.98mm + 20mm * 5 + 0.98mm)/2 = 10mm * 5 + 0.98mm
 
-      G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % sphxlayer % itype).c_str(), sifull_x/2., sifull_y, sifull_z);
+      G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % sphxlayer % itype).c_str(), sifull_x / 2., sifull_y, sifull_z);
 
       /*
          * Si-sensor inactive area
@@ -222,15 +222,15 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * HDI
          */
-      const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z")*cm;  // hdi_edge_z = 100micron
+      const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z") * cm;  // hdi_edge_z = 100micron
       hdi_z_[ilayer][itype] = hdi_z;
 
-      G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x/2., hdi_y/2., hdi_z);
+      G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdi_z);
       G4LogicalVolume *hdi_volume = new G4LogicalVolume(hdi_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(hdi_volume);
 
-      const G4double hdi_ext_z = (itype == 0) ? 0.000001 : halfladder_z/2. - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
-      G4VSolid *hdi_ext_box = new G4Box(boost::str(boost::format("hdi_ext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x/2., hdi_y/2., hdi_ext_z);
+      const G4double hdi_ext_z = (itype == 0) ? 0.000001 : halfladder_z / 2. - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
+      G4VSolid *hdi_ext_box = new G4Box(boost::str(boost::format("hdi_ext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdi_ext_z);
       G4LogicalVolume *hdi_ext_volume = new G4LogicalVolume(hdi_ext_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdi_ext_box_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(hdi_ext_volume);
       G4VisAttributes *hdi_vis = new G4VisAttributes();
@@ -242,7 +242,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * FPHX
          */
-      G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % sphxlayer % itype).c_str(), fphx_x/2., fphx_y/2., fphx_z/2.);
+      G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % sphxlayer % itype).c_str(), fphx_x / 2., fphx_y / 2., fphx_z / 2.);
       G4LogicalVolume *fphx_volume = new G4LogicalVolume(fphx_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("fphx_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(fphx_volume);
       G4VisAttributes *fphx_vis = new G4VisAttributes();
@@ -251,13 +251,13 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       fphx_vis->SetColour(G4Colour::Gray());
       fphx_volume->SetVisAttributes(fphx_vis);
 
-      const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx")*cm;
+      const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx") * cm;
 
       /*
          * FPHX Container
          */
-      const double fphxcontainer_x = fphx_x/2.;
-      const double fphxcontainer_y = fphx_y/2.;
+      const double fphxcontainer_x = fphx_x / 2.;
+      const double fphxcontainer_y = fphx_y / 2.;
       const double fphxcontainer_z = hdi_z;
 
       G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % sphxlayer % itype).c_str(), fphxcontainer_x, fphxcontainer_y, fphxcontainer_z);
@@ -271,22 +271,22 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       const int ncopy = nstrips_z_sensor;
       const double offsetx = 0.;
       const double offsety = 0.;
-      const double offsetz = (ncopy % 2 == 0) ? -2. * strip_z/2. * double(ncopy / 2) + strip_z/2. : -2. * strip_z/2. * double(ncopy / 2);
+      const double offsetz = (ncopy % 2 == 0) ? -2. * strip_z / 2. * double(ncopy / 2) + strip_z / 2. : -2. * strip_z / 2. * double(ncopy / 2);
 
-      G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * strip_z/2., ncopy);
+      G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * strip_z / 2., ncopy);
       new G4PVParameterised(boost::str(boost::format("fphxcontainer_%d_%d") % sphxlayer % itype).c_str(), fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, overlapcheck);
 
       /*
          * PGS
          */
-      const double pgs_y = sifull_y + gap_sensor_fphx + 2. * fphx_y/2.;  // between FPHX's outer edges
+      const double pgs_y = sifull_y + gap_sensor_fphx + 2. * fphx_y / 2.;  // between FPHX's outer edges
       const double pgs_z = hdi_z;
 
-      G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % sphxlayer % itype).c_str(), pgs_x/2., pgs_y, pgs_z);
+      G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y, pgs_z);
       //G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, Copper, boost::str(boost::format("pgs_volume_%d_%d") %sphxlayer %itype).c_str(), 0, 0, 0);
       G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgs_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(pgs_volume);
-      G4VSolid *pgs_ext_box = new G4Box(boost::str(boost::format("pgs_ext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x/2., pgs_y, hdi_ext_z);
+      G4VSolid *pgs_ext_box = new G4Box(boost::str(boost::format("pgs_ext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y, hdi_ext_z);
       //G4LogicalVolume *pgs_ext_volume = new G4LogicalVolume(pgs_ext_box, Copper, boost::str(boost::format("pgs_ext_volume_%d_%s") %sphxlayer %itype).c_str(), 0, 0, 0);
       G4LogicalVolume *pgs_ext_volume = new G4LogicalVolume(pgs_ext_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgs_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
 
@@ -302,11 +302,11 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       const double stave_y = pgs_y;
       const double stave_z = hdi_z;
 
-      G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % sphxlayer % itype).c_str(), stave_x/2., stave_y, stave_z);
+      G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % sphxlayer % itype).c_str(), stave_x / 2., stave_y, stave_z);
       //G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, Copper, boost::str(boost::format("stave_volume_%d_%d") %sphxlayer %itype).c_str(), 0, 0, 0);
       G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(stave_volume);
-      G4VSolid *stave_ext_box = new G4Box(boost::str(boost::format("stave_ext_box_%d_%s") % sphxlayer % itype).c_str(), stave_x/2., stave_y, hdi_ext_z);
+      G4VSolid *stave_ext_box = new G4Box(boost::str(boost::format("stave_ext_box_%d_%s") % sphxlayer % itype).c_str(), stave_x / 2., stave_y, hdi_ext_z);
       //G4LogicalVolume *stave_ext_volume = new G4LogicalVolume(stave_ext_box,  Copper, boost::str(boost::format("stave_ext_volume_%d_%s") %sphxlayer %itype).c_str(), 0, 0, 0);
       G4LogicalVolume *stave_ext_volume = new G4LogicalVolume(stave_ext_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(stave_ext_volume);
@@ -319,13 +319,13 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Ladder
          */
-      const double ladder_x = stave_x/2. + pgs_x/2. + hdi_x/2. + fphx_x/2.;
+      const double ladder_x = stave_x / 2. + pgs_x / 2. + hdi_x / 2. + fphx_x / 2.;
       const double ladder_y = hdi_y;
       const double ladder_z = hdi_z;
-      G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x, ladder_y/2., ladder_z);
+      G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x, ladder_y / 2., ladder_z);
       G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(ladder_volume);
-      G4VSolid *ladder_ext_box = new G4Box(boost::str(boost::format("ladder_ext_box_%d_%s") % sphxlayer % itype).c_str(), ladder_x, ladder_y/2., hdi_ext_z);
+      G4VSolid *ladder_ext_box = new G4Box(boost::str(boost::format("ladder_ext_box_%d_%s") % sphxlayer % itype).c_str(), ladder_x, ladder_y / 2., hdi_ext_z);
       G4LogicalVolume *ladder_ext_volume = new G4LogicalVolume(ladder_ext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       absorberlogvols.insert(ladder_ext_volume);
       G4VisAttributes *ladder_vis = new G4VisAttributes();
@@ -342,36 +342,36 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Carbon stave
          */
-      const double TVstave_x = -ladder_x + stave_x/2.;
+      const double TVstave_x = -ladder_x + stave_x / 2.;
       new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), stave_volume, boost::str(boost::format("stave_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
       new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), stave_ext_volume, boost::str(boost::format("stave_ext_%d_%s") % sphxlayer % itype).c_str(), ladder_ext_volume, false, 0, overlapcheck);
 
       /*
          * PGS
          */
-      const double TVpgs_x = TVstave_x + stave_x/2. + pgs_x/2.;
+      const double TVpgs_x = TVstave_x + stave_x / 2. + pgs_x / 2.;
       new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgs_volume, boost::str(boost::format("pgs_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
       new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgs_ext_volume, boost::str(boost::format("pgs_ext_%d_%s") % sphxlayer % itype).c_str(), ladder_ext_volume, false, 0, overlapcheck);
 
       /*
          * HDI
          */
-      const double TVhdi_x = TVpgs_x + pgs_x/2. + hdi_x/2.;
+      const double TVhdi_x = TVpgs_x + pgs_x / 2. + hdi_x / 2.;
       new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdi_volume, boost::str(boost::format("hdi_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
       new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdi_ext_volume, boost::str(boost::format("hdi_ext_%d_%s") % sphxlayer % itype).c_str(), ladder_ext_volume, false, 0, overlapcheck);
 
       /*
          * Si-sensor
          */
-      const double TVSi_x = TVhdi_x + hdi_x/2. + siactive_x/2.;
+      const double TVSi_x = TVhdi_x + hdi_x / 2. + siactive_x / 2.;
       new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siinactive_volume, boost::str(boost::format("siinactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
       new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siactive_volume, boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
 
       /*
          * FPHX
          */
-      const double TVfphx_x = TVhdi_x + hdi_x/2. + fphx_x/2.;
-      const double TVfphx_y = sifull_y + gap_sensor_fphx + fphx_y/2.;
+      const double TVfphx_x = TVhdi_x + hdi_x / 2. + fphx_x / 2.;
+      const double TVfphx_y = sifull_y + gap_sensor_fphx + fphx_y / 2.;
       new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
 
       new G4PVPlacement(0, G4ThreeVector(TVfphx_x, -TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerm_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, overlapcheck);
@@ -384,10 +384,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Ladder
          */
-      const double dphi = 2*M_PI / nladders_layer;
-      eff_radius[ilayer] = radius + ladder_x - 2. * (fphx_x/2. - strip_x/2.);
+      const double dphi = 2 * M_PI / nladders_layer;
+      eff_radius[ilayer] = radius + ladder_x - 2. * (fphx_x / 2. - strip_x / 2.);
       posz[ilayer][itype] = (itype == 0) ? hdi_z : 2. * hdi_z_[ilayer][0] + hdi_z;
-      strip_x_offset[ilayer] = ladder_x - 2. * (fphx_x/2. - strip_x/2.) - strip_x/2.;
+      strip_x_offset[ilayer] = ladder_x - 2. * (fphx_x / 2. - strip_x / 2.) - strip_x / 2.;
 
       for (G4int icopy = 0; icopy < nladders_layer; icopy++)
       {
@@ -499,23 +499,23 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
       const int inttlayer = layerconfig_[ilayer].second;
 
       const PHG4Parameters *params = paramscontainer->GetParameters(inttlayer);
-// parameters are in cm, so no conversion needed here to get to cm (*cm/cm)
+      // parameters are in cm, so no conversion needed here to get to cm (*cm/cm)
       PHG4CylinderGeom *mygeom = new PHG4CylinderGeom_Siladders(
           sphxlayer,
-	  params->get_double_param("strip_x"),
+          params->get_double_param("strip_x"),
           params->get_double_param("strip_y"),
           params->get_double_param("strip_z_0"),
           params->get_double_param("strip_z_1"),
-	  params->get_int_param("nstrips_z_sensor_0"),//nstrips_z_sensor0,
-          params->get_int_param("nstrips_z_sensor_1"),//nstrips_z_sensor1,
-	  params->get_int_param("nstrips_phi_cell"),
+          params->get_int_param("nstrips_z_sensor_0"),  //nstrips_z_sensor0,
+          params->get_int_param("nstrips_z_sensor_1"),  //nstrips_z_sensor1,
+          params->get_int_param("nstrips_phi_cell"),
           params->get_int_param("nladder"),
           posz[ilayer][0] / cm,
           posz[ilayer][1] / cm,
           eff_radius[ilayer] / cm,
           strip_x_offset[ilayer] / cm,
-          params->get_double_param("offsetphi")*deg/rad,//arr_offsetphi[inttlayer] / rad,
-          params->get_double_param("offsetrot")*deg/rad);//arr_offsetrot[inttlayer] / rad);
+          params->get_double_param("offsetphi") * deg / rad,   //arr_offsetphi[inttlayer] / rad,
+          params->get_double_param("offsetrot") * deg / rad);  //arr_offsetrot[inttlayer] / rad);
       geo->AddLayerGeom(sphxlayer, mygeom);
       if (verbosity > 0)
         geo->identify();

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -129,8 +129,8 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
     const G4double strip_y =  params->get_double_param("strip_y")*cm;
     const int nstrips_phi_cell = arr_nstrips_phi_cell[inttlayer];
 
-    const int nladders_layer = arr_nladders_layer[inttlayer];
-    const G4double radius = arr_radius[inttlayer];
+    const int nladders_layer = params->get_int_param("nladder");
+    const G4double radius = params->get_double_param("radius")*cm;
     const G4double offsetphi = arr_offsetphi[inttlayer];
     const G4double offsetrot = arr_offsetrot[inttlayer];
     const G4double hdi_y = arr_hdi_y[inttlayer];
@@ -143,18 +143,30 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
       std::cout << " PHG4SiliconTrackerDetector::ConstrctSiliconTracker:  sphxlayer " << sphxlayer << " inttlayer " << inttlayer << std::endl;
 
-      const G4double strip_z = (inttlayer == 0) ? arr_strip_z[0][itype] : arr_strip_z[1][itype];
+      G4double strip_z;
+      switch(itype)
+      {
+      case 0:
+	strip_z =  params->get_double_param("strip_z_0")*cm;
+	break;
+      case 1:
+	strip_z =  params->get_double_param("strip_z_1")*cm;
+	break;
+      default:
+	cout << "invalid itype " << itype << endl;
+	exit(1);
+      }
       const int nstrips_z_sensor = (inttlayer == 0) ? arr_nstrips_z_sensor[0][itype] : arr_nstrips_z_sensor[1][itype];
 
       /*----- Step 1 -----
-         * We make volume for Si-sensor, FPHX, HDI, PGS sheet, and stave.
+       * We make volume for Si-sensor, FPHX, HDI, PGS sheet, and stave.
          * Then we make ladder volume large enough to enclose the above volume.
          */
 
       /*
          * Si-strip
          */
-      G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % sphxlayer % itype).c_str(), strip_x/2., strip_y/2. - strip_y/ 20000., strip_z - strip_z / 10000.);
+      G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % sphxlayer % itype).c_str(), strip_x/2., strip_y/2. - strip_y/ 20000., strip_z/2. - strip_z/2. / 10000.);
       G4LogicalVolume *strip_volume = new G4LogicalVolume(strip_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("strip_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsActive.find(inttlayer))->second > 0)
       {
@@ -171,12 +183,12 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
          */
       const double siactive_x = (strip_x/2.);                        // 0.24mm/2
       const double siactive_y = strip_y/2. * 2. * nstrips_phi_cell;  // (0.078mm * 2*128)/2 = 0.078mm * 128
-      const double siactive_z = strip_z * nstrips_z_sensor;       // (20mm * 5or8)/2 = 10mm * 5or8
+      const double siactive_z = strip_z/2. * nstrips_z_sensor;       // (20mm * 5or8)/2 = 10mm * 5or8
 
       G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x, siactive_y, siactive_z);
       G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 
-      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, (strip_y/2.) *2., (strip_z) *2.);
+      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, (strip_y/2.) *2., (strip_z/2.) *2.);
       new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), strip_volume, siactive_volume, kZAxis, nstrips_phi_cell * 2 * nstrips_z_sensor, stripparam, false);  // overlap check too long.
 
       /*
@@ -253,9 +265,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       const int ncopy = nstrips_z_sensor;
       const double offsetx = 0.;
       const double offsety = 0.;
-      const double offsetz = (ncopy % 2 == 0) ? -2. * strip_z * double(ncopy / 2) + strip_z : -2. * strip_z * double(ncopy / 2);
+      const double offsetz = (ncopy % 2 == 0) ? -2. * strip_z/2. * double(ncopy / 2) + strip_z/2. : -2. * strip_z/2. * double(ncopy / 2);
 
-      G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * strip_z, ncopy);
+      G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * strip_z/2., ncopy);
       new G4PVParameterised(boost::str(boost::format("fphxcontainer_%d_%d") % sphxlayer % itype).c_str(), fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, overlapcheck);
 
       /*
@@ -480,8 +492,6 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
       const int sphxlayer = layerconfig_[ilayer].first;
       const int inttlayer = layerconfig_[ilayer].second;
 
-      const double strip_z0 = (ilayer == 0) ? arr_strip_z[0][0] : arr_strip_z[1][0];
-      const double strip_z1 = (ilayer == 0) ? arr_strip_z[0][1] : arr_strip_z[1][1];
       const int nstrips_z_sensor0 = (ilayer == 0) ? arr_nstrips_z_sensor[0][0] : arr_nstrips_z_sensor[1][0];
       const int nstrips_z_sensor1 = (ilayer == 0) ? arr_nstrips_z_sensor[0][1] : arr_nstrips_z_sensor[1][1];
 
@@ -491,12 +501,12 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
           sphxlayer,
 	  params->get_double_param("strip_x"),
           params->get_double_param("strip_y"),
-          strip_z0 / cm,
-          strip_z1 / cm,
+          params->get_double_param("strip_z_0"),
+          params->get_double_param("strip_z_1"),
           nstrips_z_sensor0,
           nstrips_z_sensor1,
           arr_nstrips_phi_cell[inttlayer],
-          arr_nladders_layer[inttlayer],
+          params->get_int_param("nladder"),
           posz[ilayer][0] / cm,
           posz[ilayer][1] / cm,
           eff_radius[ilayer] / cm,

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -194,17 +194,17 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x/2., siactive_y, siactive_z);
       G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 
-      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, (strip_y/2.) *2., (strip_z/2.) *2.);
+      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, strip_y, strip_z);
       new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), strip_volume, siactive_volume, kZAxis, nstrips_phi_cell * 2 * nstrips_z_sensor, stripparam, false);  // overlap check too long.
 
       /*
          * Si-sensor full (active+inactive) area
          */
-      const double sifull_x = siactive_x/2.;                    // 0.24mm/2
+      const double sifull_x = siactive_x;                    // 0.24mm/2
       const double sifull_y = siactive_y + params->get_double_param("sensor_edge_phi")*cm;  // (1.305mm  + 0.078mm * 2*128 + 1.305mm)/2 = 0.078mm * 128 + 1.305mm
       const double sifull_z = siactive_z + params->get_double_param("sensor_edge_z")*cm;    // (0.98mm + 20mm * 5 + 0.98mm)/2 = 10mm * 5 + 0.98mm
 
-      G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % sphxlayer % itype).c_str(), sifull_x, sifull_y, sifull_z);
+      G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % sphxlayer % itype).c_str(), sifull_x/2., sifull_y, sifull_z);
 
       /*
          * Si-sensor inactive area
@@ -251,7 +251,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       fphx_vis->SetColour(G4Colour::Gray());
       fphx_volume->SetVisAttributes(fphx_vis);
 
-      const double gap_sensor_fphx = 1.0 * mm;
+      const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx")*cm;
 
       /*
          * FPHX Container
@@ -384,7 +384,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       /*
          * Ladder
          */
-      const double dphi = CLHEP::twopi / (double) nladders_layer;
+      const double dphi = 2*M_PI / nladders_layer;
       eff_radius[ilayer] = radius + ladder_x - 2. * (fphx_x/2. - strip_x/2.);
       posz[ilayer][itype] = (itype == 0) ? hdi_z : 2. * hdi_z_[ilayer][0] + hdi_z;
       strip_x_offset[ilayer] = ladder_x - 2. * (fphx_x/2. - strip_x/2.) - strip_x/2.;
@@ -394,7 +394,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
         const double phi = offsetphi + dphi * (double) icopy;
         const double posx = eff_radius[ilayer] * cos(phi);
         const double posy = eff_radius[ilayer] * sin(phi);
-        const double fRotate = phi + offsetrot + CLHEP::pi;
+        const double fRotate = phi + offsetrot + M_PI;
 
         G4RotationMatrix *ladderrotation = new G4RotationMatrix();
         ladderrotation->rotateZ(-fRotate);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -86,7 +86,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   const double pgs_x = 0.21 * mm * 0.5;    // 70micron * 3layers
   const double stave_x = 0.23 * mm * 0.5;  // too thick? TODO
 
-  const G4double arr_hdi_y[4] = {38. * mm * 0.5, 43. * mm * 0.5, 43. * mm * 0.5, 43. * mm * 0.5};
+//  const G4double arr_hdi_y[4] = {38. * mm * 0.5, 43. * mm * 0.5, 43. * mm * 0.5, 43. * mm * 0.5};
   const G4double arr_halfladder_z[4] = {220. * mm * 0.5, 268. * mm * 0.5, 268. * mm * 0.5, 268. * mm * 0.5};
   std::set<G4LogicalVolume *> absorberlogvols;
   std::set<G4LogicalVolume *> activelogvols;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -78,7 +78,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
 
   //const double pgs_x = 0.35*mm * 0.5; // 70micron * 5layers
 //  const double pgs_x = 0.21 * mm * 0.5;    // 70micron * 3layers 
-  const double stave_x = 0.23 * mm * 0.5;  // too thick? TODO 
+//  const double stave_x = 0.23 * mm * 0.5;  // too thick? TODO 
 
   const G4double arr_halfladder_z[4] = {220. * mm * 0.5, 268. * mm * 0.5, 268. * mm * 0.5, 268. * mm * 0.5};
   std::set<G4LogicalVolume *> absorberlogvols;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -77,8 +77,8 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   G4double strip_x_offset[4];
 
   //const double pgs_x = 0.35*mm * 0.5; // 70micron * 5layers
-//  const double pgs_x = 0.21 * mm * 0.5;    // 70micron * 3layers 
-//  const double stave_x = 0.23 * mm * 0.5;  // too thick? TODO 
+  //  const double pgs_x = 0.21 * mm * 0.5;    // 70micron * 3layers
+  //  const double stave_x = 0.23 * mm * 0.5;  // too thick? TODO
 
   const G4double arr_halfladder_z[4] = {220. * mm * 0.5, 268. * mm * 0.5, 268. * mm * 0.5, 268. * mm * 0.5};
   std::set<G4LogicalVolume *> absorberlogvols;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -57,7 +57,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
  private:
   void AddGeometryNode();
   int ConstructSiliconTracker(G4LogicalVolume *sandwich);
-  int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = NULL);
+  int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = nullptr);
 
   PHG4ParametersContainer *paramscontainer;
   int absorberactive;
@@ -76,17 +76,10 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   G4double posz[4][2];
   G4double strip_x_offset[4];
 
-  //const double hdi_x  = 0.473*mm * 0.5;
-  const double hdi_x = 0.38626 * mm * 0.5;  // updated design
-  const double fphx_x = 0.32 * mm * 0.5;
-  const double fphx_y = 2.7 * mm * 0.5;
-  const double fphx_z = 9.0 * mm * 0.5;
-
   //const double pgs_x = 0.35*mm * 0.5; // 70micron * 5layers
-  const double pgs_x = 0.21 * mm * 0.5;    // 70micron * 3layers
-  const double stave_x = 0.23 * mm * 0.5;  // too thick? TODO
+//  const double pgs_x = 0.21 * mm * 0.5;    // 70micron * 3layers 
+  const double stave_x = 0.23 * mm * 0.5;  // too thick? TODO 
 
-//  const G4double arr_hdi_y[4] = {38. * mm * 0.5, 43. * mm * 0.5, 43. * mm * 0.5, 43. * mm * 0.5};
   const G4double arr_halfladder_z[4] = {220. * mm * 0.5, 268. * mm * 0.5, 268. * mm * 0.5, 268. * mm * 0.5};
   std::set<G4LogicalVolume *> absorberlogvols;
   std::set<G4LogicalVolume *> activelogvols;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -27,8 +27,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHG4ParametersContainer *parameters, const std::string &dnam = "SILICON_TRACKER", const vpair &layerconfig = vpair(0));
 
   //! destructor
-  virtual ~PHG4SiliconTrackerDetector(){}
-
+  virtual ~PHG4SiliconTrackerDetector() {}
   //! construct
   virtual void Construct(G4LogicalVolume *world);
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -54,9 +54,6 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
     return detector_type;
   }
 
-  /* const int arr_nstrips_z_sensor[2][2] = {/\*Layer0*\/ {5, 5}, /\*Layer1-3*\/ {8, 5}}; */
-  /* const int arr_nstrips_phi_cell[4] = {128, 128, 128, 128}; */
-
  private:
   void AddGeometryNode();
   int ConstructSiliconTracker(G4LogicalVolume *sandwich);
@@ -74,10 +71,6 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
 
   std::string detector_type;
   std::string superdetector;
-
-  const G4double sensor_edge_phi = 1.305 * mm;
-  const G4double sensor_edge_z = 0.98 * mm;
-  const G4double hdi_edge_z = 0.10 * mm;
 
   G4double eff_radius[4];
   G4double posz[4][2];

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -54,10 +54,8 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
     return detector_type;
   }
 
-  const G4double arr_offsetphi[4] = {0.0 / 180. * CLHEP::pi, 0.0 / 180. * CLHEP::pi, 0.0 / 180. * CLHEP::pi, 0.0 / 180. * CLHEP::pi};
-  const G4double arr_offsetrot[4] = {14.0 / 180. * CLHEP::pi, 14.0 / 180. * CLHEP::pi, 12.0 / 180. * CLHEP::pi, 11.5 / 180. * CLHEP::pi};
-  const int arr_nstrips_z_sensor[2][2] = {/*Layer0*/ {5, 5}, /*Layer1-3*/ {8, 5}};
-  const int arr_nstrips_phi_cell[4] = {128, 128, 128, 128};
+  /* const int arr_nstrips_z_sensor[2][2] = {/\*Layer0*\/ {5, 5}, /\*Layer1-3*\/ {8, 5}}; */
+  /* const int arr_nstrips_phi_cell[4] = {128, 128, 128, 128}; */
 
  private:
   void AddGeometryNode();

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -60,10 +60,10 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   const G4double arr_offsetrot[4] = {14.0 / 180. * CLHEP::pi, 14.0 / 180. * CLHEP::pi, 12.0 / 180. * CLHEP::pi, 11.5 / 180. * CLHEP::pi};
   const int arr_nstrips_z_sensor[2][2] = {/*Layer0*/ {5, 5}, /*Layer1-3*/ {8, 5}};
   const int arr_nstrips_phi_cell[4] = {128, 128, 128, 128};
-  const G4double arr_strip_x[4] = {0.200 * mm * 0.5, 0.200 * mm * 0.5, 0.200 * mm * 0.5, 0.200 * mm * 0.5};  // 200 micron
+//  const G4double arr_strip_x[4] = {0.200 * mm * 0.5, 0.200 * mm * 0.5, 0.200 * mm * 0.5, 0.200 * mm * 0.5};  // 200 micron
   //const G4double arr_strip_x[4] = {0.240*mm*0.5, 0.240*mm*0.5, 0.240*mm*0.5, 0.240*mm*0.5}; // 240 micron
   //const G4double arr_strip_x[4] = {0.320*mm*0.5, 0.320*mm*0.5, 0.320*mm*0.5, 0.320*mm*0.5}; // 320 micron
-  const G4double arr_strip_y[4] = {0.078 * mm * 0.5, 0.086 * mm * 0.5, 0.086 * mm * 0.5, 0.086 * mm * 0.5};
+//  const G4double arr_strip_y[4] = {0.078 * mm * 0.5, 0.086 * mm * 0.5, 0.086 * mm * 0.5, 0.086 * mm * 0.5};
   const G4double arr_strip_z[2][2] = {/*Layer0*/ {18.0 * mm * 0.5, 18.0 * mm * 0.5}, /*Layer1-3*/ {16.0 * mm * 0.5, 20.0 * mm * 0.5}};
 
  private:

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -54,17 +54,10 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
     return detector_type;
   }
 
-  const int arr_nladders_layer[4] = {20, 26, 32, 38};
-  const G4double arr_radius[4] = {60.0 * mm, 80.0 * mm, 100.0 * mm, 120.0 * mm};
   const G4double arr_offsetphi[4] = {0.0 / 180. * CLHEP::pi, 0.0 / 180. * CLHEP::pi, 0.0 / 180. * CLHEP::pi, 0.0 / 180. * CLHEP::pi};
   const G4double arr_offsetrot[4] = {14.0 / 180. * CLHEP::pi, 14.0 / 180. * CLHEP::pi, 12.0 / 180. * CLHEP::pi, 11.5 / 180. * CLHEP::pi};
   const int arr_nstrips_z_sensor[2][2] = {/*Layer0*/ {5, 5}, /*Layer1-3*/ {8, 5}};
   const int arr_nstrips_phi_cell[4] = {128, 128, 128, 128};
-//  const G4double arr_strip_x[4] = {0.200 * mm * 0.5, 0.200 * mm * 0.5, 0.200 * mm * 0.5, 0.200 * mm * 0.5};  // 200 micron
-  //const G4double arr_strip_x[4] = {0.240*mm*0.5, 0.240*mm*0.5, 0.240*mm*0.5, 0.240*mm*0.5}; // 240 micron
-  //const G4double arr_strip_x[4] = {0.320*mm*0.5, 0.320*mm*0.5, 0.320*mm*0.5, 0.320*mm*0.5}; // 320 micron
-//  const G4double arr_strip_y[4] = {0.078 * mm * 0.5, 0.086 * mm * 0.5, 0.086 * mm * 0.5, 0.086 * mm * 0.5};
-  const G4double arr_strip_z[2][2] = {/*Layer0*/ {18.0 * mm * 0.5, 18.0 * mm * 0.5}, /*Layer1-3*/ {16.0 * mm * 0.5, 20.0 * mm * 0.5}};
 
  private:
   void AddGeometryNode();

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -27,7 +27,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHG4ParametersContainer *parameters, const std::string &dnam = "SILICON_TRACKER", const vpair &layerconfig = vpair(0));
 
   //! destructor
-  virtual ~PHG4SiliconTrackerDetector();
+  virtual ~PHG4SiliconTrackerDetector(){}
 
   //! construct
   virtual void Construct(G4LogicalVolume *world);
@@ -60,8 +60,6 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = nullptr);
 
   PHG4ParametersContainer *paramscontainer;
-  int absorberactive;
-
   vpair layerconfig_;
   unsigned int nlayer_;
   int layermin_;
@@ -76,14 +74,10 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   G4double posz[4][2];
   G4double strip_x_offset[4];
 
-  //const double pgs_x = 0.35*mm * 0.5; // 70micron * 5layers
-  //  const double pgs_x = 0.21 * mm * 0.5;    // 70micron * 3layers
-  //  const double stave_x = 0.23 * mm * 0.5;  // too thick? TODO
-
-  const G4double arr_halfladder_z[4] = {220. * mm * 0.5, 268. * mm * 0.5, 268. * mm * 0.5, 268. * mm * 0.5};
   std::set<G4LogicalVolume *> absorberlogvols;
   std::set<G4LogicalVolume *> activelogvols;
   std::map<int, int> IsActive;
+  std::map<int, int> IsAbsorberActive;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -58,9 +58,9 @@ PHG4SiliconTrackerSteppingAction::PHG4SiliconTrackerSteppingAction(PHG4SiliconTr
     PHG4Parameters* par = iter->second;
     IsActive[iter->first] = par->get_int_param("active");
     IsBlackHole[iter->first] = par->get_int_param("blackhole");
-    strip_y[iter->first] =  par->get_double_param("strip_y")*cm;
-    strip_z[iter->first][0] = par->get_double_param("strip_z_0")*cm;
-    strip_z[iter->first][1] = par->get_double_param("strip_z_1")*cm;
+    strip_y[iter->first] = par->get_double_param("strip_y") * cm;
+    strip_z[iter->first][0] = par->get_double_param("strip_z_0") * cm;
+    strip_z[iter->first][1] = par->get_double_param("strip_z_1") * cm;
     nstrips_z_sensor[iter->first][0] = par->get_int_param("nstrips_z_sensor_0");
     nstrips_z_sensor[iter->first][1] = par->get_int_param("nstrips_z_sensor_1");
     nstrips_phi_cell[iter->first] = par->get_int_param("nstrips_phi_cell");
@@ -177,8 +177,8 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
           strip_z_index = 0;
           for (int i = 0; i < nstrips_z_sensor[inttlayer][laddertype]; ++i)
           {
-            const double zmin = strip_z[inttlayer][laddertype] * (double) (i) -strip_z[inttlayer][laddertype]/2. * (double) nstrips_z_sensor[inttlayer][laddertype];
-            const double zmax = strip_z[inttlayer][laddertype] * (double) (i + 1) - strip_z[inttlayer][laddertype]/2. * (double) nstrips_z_sensor[inttlayer][laddertype];
+            const double zmin = strip_z[inttlayer][laddertype] * (double) (i) -strip_z[inttlayer][laddertype] / 2. * (double) nstrips_z_sensor[inttlayer][laddertype];
+            const double zmax = strip_z[inttlayer][laddertype] * (double) (i + 1) - strip_z[inttlayer][laddertype] / 2. * (double) nstrips_z_sensor[inttlayer][laddertype];
             if (strip_pos.z() / mm > zmin && strip_pos.z() / mm <= zmax)
             {
               cout << "zmin: " << zmin << ", zmax: " << zmax << endl;
@@ -190,7 +190,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
           strip_y_index = 0;
           for (int i = 0; i < 2 * nstrips_phi_cell[inttlayer]; ++i)
           {
-            const double ymin = strip_y[inttlayer] * (double) (i) - strip_y[inttlayer] * (double) nstrips_phi_cell[inttlayer];
+            const double ymin = strip_y[inttlayer] * (double) (i) -strip_y[inttlayer] * (double) nstrips_phi_cell[inttlayer];
             const double ymax = strip_y[inttlayer] * (double) (i + 1) - strip_y[inttlayer] * (double) nstrips_phi_cell[inttlayer];
             if (strip_pos.y() / mm > ymin && strip_pos.y() / mm <= ymax)
             {

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -59,6 +59,8 @@ PHG4SiliconTrackerSteppingAction::PHG4SiliconTrackerSteppingAction(PHG4SiliconTr
     IsActive[iter->first] = par->get_int_param("active");
     IsBlackHole[iter->first] = par->get_int_param("blackhole");
     strip_y[iter->first] =  par->get_double_param("strip_y")*cm;
+    strip_z[iter->first][0] = par->get_double_param("strip_z_0")*cm;
+    strip_z[iter->first][1] = par->get_double_param("strip_z_1")*cm;
   }
 }
 
@@ -138,7 +140,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     }
     // convert ladder type [0-3] to silicon sensor type [0-1]
     const int laddertype = (ladderz == 1 || ladderz == 2) ? 0 : 1;
-    const double strip_z = (inttlayer == 0) ? detector_->arr_strip_z[0][laddertype] : detector_->arr_strip_z[1][laddertype];
+//    const double strip_z = (inttlayer == 0) ? detector_->arr_strip_z[0][laddertype] : detector_->arr_strip_z[1][laddertype];
     const int nstrips_z_sensor = (inttlayer == 0) ? detector_->arr_nstrips_z_sensor[0][laddertype] : detector_->arr_nstrips_z_sensor[1][laddertype];
     const int nstrips_phi_cell = detector_->arr_nstrips_phi_cell[inttlayer];
 //    const double strip_y = detector_->arr_strip_y[inttlayer];
@@ -176,8 +178,8 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
           strip_z_index = 0;
           for (int i = 0; i < nstrips_z_sensor; ++i)
           {
-            const double zmin = 2. * strip_z * (double) (i) -strip_z * (double) nstrips_z_sensor;
-            const double zmax = 2. * strip_z * (double) (i + 1) - strip_z * (double) nstrips_z_sensor;
+            const double zmin = strip_z[inttlayer][laddertype] * (double) (i) -strip_z[inttlayer][laddertype]/2. * (double) nstrips_z_sensor;
+            const double zmax = strip_z[inttlayer][laddertype] * (double) (i + 1) - strip_z[inttlayer][laddertype]/2. * (double) nstrips_z_sensor;
             if (strip_pos.z() / mm > zmin && strip_pos.z() / mm <= zmax)
             {
               cout << "zmin: " << zmin << ", zmax: " << zmax << endl;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -61,6 +61,9 @@ PHG4SiliconTrackerSteppingAction::PHG4SiliconTrackerSteppingAction(PHG4SiliconTr
     strip_y[iter->first] =  par->get_double_param("strip_y")*cm;
     strip_z[iter->first][0] = par->get_double_param("strip_z_0")*cm;
     strip_z[iter->first][1] = par->get_double_param("strip_z_1")*cm;
+    nstrips_z_sensor[iter->first][0] = par->get_int_param("nstrips_z_sensor_0");
+    nstrips_z_sensor[iter->first][1] = par->get_int_param("nstrips_z_sensor_1");
+    nstrips_phi_cell[iter->first] = par->get_int_param("nstrips_phi_cell");
   }
 }
 
@@ -140,13 +143,9 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     }
     // convert ladder type [0-3] to silicon sensor type [0-1]
     const int laddertype = (ladderz == 1 || ladderz == 2) ? 0 : 1;
-//    const double strip_z = (inttlayer == 0) ? detector_->arr_strip_z[0][laddertype] : detector_->arr_strip_z[1][laddertype];
-    const int nstrips_z_sensor = (inttlayer == 0) ? detector_->arr_nstrips_z_sensor[0][laddertype] : detector_->arr_nstrips_z_sensor[1][laddertype];
-    const int nstrips_phi_cell = detector_->arr_nstrips_phi_cell[inttlayer];
-//    const double strip_y = detector_->arr_strip_y[inttlayer];
 
     // Find the strip y and z index values from the copy number (integer division, quotient is strip_y, remainder is strip_z)
-    div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor);
+    div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor[inttlayer][laddertype]);
     strip_y_index = copydiv.quot;
     strip_z_index = copydiv.rem;
     G4ThreeVector strip_pos = volume->GetTranslation();
@@ -176,10 +175,10 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
           G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
 
           strip_z_index = 0;
-          for (int i = 0; i < nstrips_z_sensor; ++i)
+          for (int i = 0; i < nstrips_z_sensor[inttlayer][laddertype]; ++i)
           {
-            const double zmin = strip_z[inttlayer][laddertype] * (double) (i) -strip_z[inttlayer][laddertype]/2. * (double) nstrips_z_sensor;
-            const double zmax = strip_z[inttlayer][laddertype] * (double) (i + 1) - strip_z[inttlayer][laddertype]/2. * (double) nstrips_z_sensor;
+            const double zmin = strip_z[inttlayer][laddertype] * (double) (i) -strip_z[inttlayer][laddertype]/2. * (double) nstrips_z_sensor[inttlayer][laddertype];
+            const double zmax = strip_z[inttlayer][laddertype] * (double) (i + 1) - strip_z[inttlayer][laddertype]/2. * (double) nstrips_z_sensor[inttlayer][laddertype];
             if (strip_pos.z() / mm > zmin && strip_pos.z() / mm <= zmax)
             {
               cout << "zmin: " << zmin << ", zmax: " << zmax << endl;
@@ -189,10 +188,10 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
           }
 
           strip_y_index = 0;
-          for (int i = 0; i < 2 * nstrips_phi_cell; ++i)
+          for (int i = 0; i < 2 * nstrips_phi_cell[inttlayer]; ++i)
           {
-            const double ymin = strip_y[inttlayer] * (double) (i) - strip_y[inttlayer] * (double) nstrips_phi_cell;
-            const double ymax = strip_y[inttlayer] * (double) (i + 1) - strip_y[inttlayer] * (double) nstrips_phi_cell;
+            const double ymin = strip_y[inttlayer] * (double) (i) - strip_y[inttlayer] * (double) nstrips_phi_cell[inttlayer];
+            const double ymax = strip_y[inttlayer] * (double) (i + 1) - strip_y[inttlayer] * (double) nstrips_phi_cell[inttlayer];
             if (strip_pos.y() / mm > ymin && strip_pos.y() / mm <= ymax)
             {
               cout << "ymin: " << ymin << ", ymax: " << ymax << endl;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -58,6 +58,7 @@ PHG4SiliconTrackerSteppingAction::PHG4SiliconTrackerSteppingAction(PHG4SiliconTr
     PHG4Parameters* par = iter->second;
     IsActive[iter->first] = par->get_int_param("active");
     IsBlackHole[iter->first] = par->get_int_param("blackhole");
+    strip_y[iter->first] =  par->get_double_param("strip_y")*cm;
   }
 }
 
@@ -140,7 +141,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     const double strip_z = (inttlayer == 0) ? detector_->arr_strip_z[0][laddertype] : detector_->arr_strip_z[1][laddertype];
     const int nstrips_z_sensor = (inttlayer == 0) ? detector_->arr_nstrips_z_sensor[0][laddertype] : detector_->arr_nstrips_z_sensor[1][laddertype];
     const int nstrips_phi_cell = detector_->arr_nstrips_phi_cell[inttlayer];
-    const double strip_y = detector_->arr_strip_y[inttlayer];
+//    const double strip_y = detector_->arr_strip_y[inttlayer];
 
     // Find the strip y and z index values from the copy number (integer division, quotient is strip_y, remainder is strip_z)
     div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor);
@@ -188,8 +189,8 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
           strip_y_index = 0;
           for (int i = 0; i < 2 * nstrips_phi_cell; ++i)
           {
-            const double ymin = 2. * strip_y * (double) (i) -2. * strip_y * (double) nstrips_phi_cell;
-            const double ymax = 2. * strip_y * (double) (i + 1) - 2. * strip_y * (double) nstrips_phi_cell;
+            const double ymin = strip_y[inttlayer] * (double) (i) - strip_y[inttlayer] * (double) nstrips_phi_cell;
+            const double ymax = strip_y[inttlayer] * (double) (i + 1) - strip_y[inttlayer] * (double) nstrips_phi_cell;
             if (strip_pos.y() / mm > ymin && strip_pos.y() / mm <= ymax)
             {
               cout << "ymin: " << ymin << ", ymax: " << ymax << endl;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -65,6 +65,17 @@ PHG4SiliconTrackerSteppingAction::PHG4SiliconTrackerSteppingAction(PHG4SiliconTr
     nstrips_z_sensor[iter->first][1] = par->get_int_param("nstrips_z_sensor_1");
     nstrips_phi_cell[iter->first] = par->get_int_param("nstrips_phi_cell");
   }
+  AbsorberIndex["ladder"] = -1;
+  AbsorberIndex["stave"] = -2;
+  AbsorberIndex["pgs"] = -3;
+  AbsorberIndex["siinactive"] = -4;
+  AbsorberIndex["hdi"] = -5;
+  AbsorberIndex["fphxcontainer"] = -6;
+  AbsorberIndex["fphxcontainerm"] = -7;
+  AbsorberIndex["fphxcontainerp"] = -8;
+  AbsorberIndex["ladderext"] = -9;
+  AbsorberIndex["hdiext"] = -10;
+  AbsorberIndex["staveext"] = -11;
 }
 
 PHG4SiliconTrackerSteppingAction::~PHG4SiliconTrackerSteppingAction()
@@ -74,6 +85,10 @@ PHG4SiliconTrackerSteppingAction::~PHG4SiliconTrackerSteppingAction()
   // if the last hit was saved, hit is a nullptr pointer which are
   // legal to delete (it results in a no operation)
   delete hit;
+  BOOST_FOREACH(string absname, missingabsorbers)
+  {
+    cout << "PHG4SiliconTrackerSteppingAction: need to implement absorber " << absname << endl;
+  }
 }
 
 //____________________________________________________________________________..
@@ -156,19 +171,21 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       G4VPhysicalVolume* volume_post = postPoint->GetTouchableHandle()->GetVolume();
       G4LogicalVolume* logvolpre = volume->GetLogicalVolume();
       G4LogicalVolume* logvolpost = volume_post->GetLogicalVolume();
-      // this is just failsafe - I tested with 1000000 pions and did not hit this once
+      // this is just failsafe - we still have those impossible hits where pre and poststep
+      // are in the same volume with status fGeomBoundary
+      // but the extraction of the strip index above works for those
+      // my assumption is that the end of a physics step coincides with the boundary and 
+      // the physics step size is taken rather the geometric step size
       if (logvolpre == logvolpost)
       {
         if (volume->GetCopyNo() == volume_post->GetCopyNo())
         {
-          cout << "Overlap detected in volume " << volume->GetName() << " where post volume "
-               << volume_post->GetName() << " has same copy no." << volume->GetCopyNo()
-               << " pre and post step point of same volume for step status fGeomBoundary" << endl;
-          cout << "logvol name " << logvolpre->GetName() << ", post: " << logvolpost->GetName() << endl;
-          // we need a hack to replace the values above with the correct strip index values
-          // the transform of the world coordinates into the sensor frame will work correctly, so we determine the strip indices from the hit position
-          cout << "strip y bef: " << strip_y_index << ", strip z: " << strip_z_index << endl;
+	  int strip_y_index_old = strip_y_index;
+	  int strip_z_index_old = strip_z_index;
 
+          // we need a hack to compare the values above with the correct strip index values
+          // the transform of the world coordinates into the sensor frame will work correctly, 
+          // so we determine the strip indices from the hit position
           G4ThreeVector preworldPos = prePoint->GetPosition();
           G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
           G4ThreeVector postworldPos = postPoint->GetPosition();
@@ -181,7 +198,6 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
             const double zmax = strip_z[inttlayer][laddertype] * (double) (i + 1) - strip_z[inttlayer][laddertype] / 2. * (double) nstrips_z_sensor[inttlayer][laddertype];
             if (strip_pos.z() / mm > zmin && strip_pos.z() / mm <= zmax)
             {
-              cout << "zmin: " << zmin << ", zmax: " << zmax << endl;
               strip_z_index = i;
               break;
             }
@@ -194,30 +210,59 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
             const double ymax = strip_y[inttlayer] * (double) (i + 1) - strip_y[inttlayer] * (double) nstrips_phi_cell[inttlayer];
             if (strip_pos.y() / mm > ymin && strip_pos.y() / mm <= ymax)
             {
-              cout << "ymin: " << ymin << ", ymax: " << ymax << endl;
               strip_y_index = i;
               if (verbosity > 1) std::cout << "                            revised strip y position = " << strip_y_index << std::endl;
               break;
             }
           }
+	  if (strip_y_index_old != strip_y_index || strip_z_index_old != strip_z_index)
+	  {
+          cout << "Overlap detected in volume " << volume->GetName() << " where post volume "
+               << volume_post->GetName() << " has same copy no." << volume->GetCopyNo()
+               << " pre and post step point of same volume for step status fGeomBoundary" << endl;
+          cout << "logvol name " << logvolpre->GetName() << ", post: " << logvolpost->GetName() << endl;
+          cout << "strip y bef: " << strip_y_index_old << ", strip z: " << strip_z_index_old << endl;
           cout << " strip y aft: " << strip_y_index << ", strip z: " << strip_z_index << endl;
           cout << "pre hitpos x: " << strip_pos.x() << ", y: " << strip_pos.y() << ", z: "
                << strip_pos.z() << endl;
           cout << "posthitpos x: " << poststrip_pos.x() << ", y: " << poststrip_pos.y() << ", z: "
                << poststrip_pos.z() << endl;
           cout << "eloss: " << aStep->GetTotalEnergyDeposit() / GeV << " GeV" << endl;
+	  cout << "safety prestep: " << prePoint->GetSafety() 
+	       << ", poststep: " << postPoint->GetSafety() << endl;
+	  }
         }
       }
     }
   }
   else  // silicon inactive area, FPHX, stabe etc. as absorbers
   {
-    sphxlayer = -1;
-    inttlayer = -1;
-    ladderz = -1;
-    ladderphi = -1;
-    strip_z_index = -1;
-    strip_y_index = -1;
+try
+{
+    boost::char_separator<char> sep("_");
+    boost::tokenizer<boost::char_separator<char> > tok(touch->GetVolume(0)->GetName(), sep);
+    boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
+    tokeniter = tok.begin();
+    map<string, int>::const_iterator iter = AbsorberIndex.find(*tokeniter);
+    if (iter == AbsorberIndex.end())
+    {
+      cout << "Absorber " << *tokeniter << " not in list" << endl;
+      missingabsorbers.insert(*tokeniter);
+      ladderz = -AbsorberIndex.size();
+      AbsorberIndex[*tokeniter] = ladderz;
+    }
+    else
+    {
+      ladderz = iter->second;
+    }
+      sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
+      inttlayer = boost::lexical_cast<int>(*(++tokeniter));
+}
+catch (...)
+{
+  cout << " that did not work for " << touch->GetVolume(0)->GetName() << endl;
+  missingabsorbers.insert(touch->GetVolume(0)->GetName());
+}
   }
 
   // collect energy and track length step by step
@@ -257,10 +302,13 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     hit->set_layer((unsigned int) sphxlayer);
 
     // set the index values needed to locate the sensor strip
+    hit->set_ladder_z_index(ladderz);
+    if (whichactive > 0)
+    {
     hit->set_strip_z_index(strip_z_index);
     hit->set_strip_y_index(strip_y_index);
-    hit->set_ladder_z_index(ladderz);
     hit->set_ladder_phi_index(ladderphi);
+    }
 
     //here we set the entrance values in cm
     hit->set_x(0, prePoint->GetPosition().x() / cm);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -85,7 +85,7 @@ PHG4SiliconTrackerSteppingAction::~PHG4SiliconTrackerSteppingAction()
   // if the last hit was saved, hit is a nullptr pointer which are
   // legal to delete (it results in a no operation)
   delete hit;
-  BOOST_FOREACH(string absname, missingabsorbers)
+  BOOST_FOREACH (string absname, missingabsorbers)
   {
     cout << "PHG4SiliconTrackerSteppingAction: need to implement absorber " << absname << endl;
   }
@@ -174,17 +174,17 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       // this is just failsafe - we still have those impossible hits where pre and poststep
       // are in the same volume with status fGeomBoundary
       // but the extraction of the strip index above works for those
-      // my assumption is that the end of a physics step coincides with the boundary and 
+      // my assumption is that the end of a physics step coincides with the boundary and
       // the physics step size is taken rather the geometric step size
       if (logvolpre == logvolpost)
       {
         if (volume->GetCopyNo() == volume_post->GetCopyNo())
         {
-	  int strip_y_index_old = strip_y_index;
-	  int strip_z_index_old = strip_z_index;
+          int strip_y_index_old = strip_y_index;
+          int strip_z_index_old = strip_z_index;
 
           // we need a hack to compare the values above with the correct strip index values
-          // the transform of the world coordinates into the sensor frame will work correctly, 
+          // the transform of the world coordinates into the sensor frame will work correctly,
           // so we determine the strip indices from the hit position
           G4ThreeVector preworldPos = prePoint->GetPosition();
           G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
@@ -215,54 +215,54 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
               break;
             }
           }
-	  if (strip_y_index_old != strip_y_index || strip_z_index_old != strip_z_index)
-	  {
-          cout << "Overlap detected in volume " << volume->GetName() << " where post volume "
-               << volume_post->GetName() << " has same copy no." << volume->GetCopyNo()
-               << " pre and post step point of same volume for step status fGeomBoundary" << endl;
-          cout << "logvol name " << logvolpre->GetName() << ", post: " << logvolpost->GetName() << endl;
-          cout << "strip y bef: " << strip_y_index_old << ", strip z: " << strip_z_index_old << endl;
-          cout << " strip y aft: " << strip_y_index << ", strip z: " << strip_z_index << endl;
-          cout << "pre hitpos x: " << strip_pos.x() << ", y: " << strip_pos.y() << ", z: "
-               << strip_pos.z() << endl;
-          cout << "posthitpos x: " << poststrip_pos.x() << ", y: " << poststrip_pos.y() << ", z: "
-               << poststrip_pos.z() << endl;
-          cout << "eloss: " << aStep->GetTotalEnergyDeposit() / GeV << " GeV" << endl;
-	  cout << "safety prestep: " << prePoint->GetSafety() 
-	       << ", poststep: " << postPoint->GetSafety() << endl;
-	  }
+          if (strip_y_index_old != strip_y_index || strip_z_index_old != strip_z_index)
+          {
+            cout << "Overlap detected in volume " << volume->GetName() << " where post volume "
+                 << volume_post->GetName() << " has same copy no." << volume->GetCopyNo()
+                 << " pre and post step point of same volume for step status fGeomBoundary" << endl;
+            cout << "logvol name " << logvolpre->GetName() << ", post: " << logvolpost->GetName() << endl;
+            cout << "strip y bef: " << strip_y_index_old << ", strip z: " << strip_z_index_old << endl;
+            cout << " strip y aft: " << strip_y_index << ", strip z: " << strip_z_index << endl;
+            cout << "pre hitpos x: " << strip_pos.x() << ", y: " << strip_pos.y() << ", z: "
+                 << strip_pos.z() << endl;
+            cout << "posthitpos x: " << poststrip_pos.x() << ", y: " << poststrip_pos.y() << ", z: "
+                 << poststrip_pos.z() << endl;
+            cout << "eloss: " << aStep->GetTotalEnergyDeposit() / GeV << " GeV" << endl;
+            cout << "safety prestep: " << prePoint->GetSafety()
+                 << ", poststep: " << postPoint->GetSafety() << endl;
+          }
         }
       }
     }
   }
   else  // silicon inactive area, FPHX, stabe etc. as absorbers
   {
-try
-{
-    boost::char_separator<char> sep("_");
-    boost::tokenizer<boost::char_separator<char> > tok(touch->GetVolume(0)->GetName(), sep);
-    boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
-    tokeniter = tok.begin();
-    map<string, int>::const_iterator iter = AbsorberIndex.find(*tokeniter);
-    if (iter == AbsorberIndex.end())
+    try
     {
-      cout << "Absorber " << *tokeniter << " not in list" << endl;
-      missingabsorbers.insert(*tokeniter);
-      ladderz = -AbsorberIndex.size();
-      AbsorberIndex[*tokeniter] = ladderz;
-    }
-    else
-    {
-      ladderz = iter->second;
-    }
+      boost::char_separator<char> sep("_");
+      boost::tokenizer<boost::char_separator<char> > tok(touch->GetVolume(0)->GetName(), sep);
+      boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
+      tokeniter = tok.begin();
+      map<string, int>::const_iterator iter = AbsorberIndex.find(*tokeniter);
+      if (iter == AbsorberIndex.end())
+      {
+        cout << "Absorber " << *tokeniter << " not in list" << endl;
+        missingabsorbers.insert(*tokeniter);
+        ladderz = -AbsorberIndex.size();
+        AbsorberIndex[*tokeniter] = ladderz;
+      }
+      else
+      {
+        ladderz = iter->second;
+      }
       sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
       inttlayer = boost::lexical_cast<int>(*(++tokeniter));
-}
-catch (...)
-{
-  cout << " that did not work for " << touch->GetVolume(0)->GetName() << endl;
-  missingabsorbers.insert(touch->GetVolume(0)->GetName());
-}
+    }
+    catch (...)
+    {
+      cout << " that did not work for " << touch->GetVolume(0)->GetName() << endl;
+      missingabsorbers.insert(touch->GetVolume(0)->GetName());
+    }
   }
 
   // collect energy and track length step by step
@@ -305,9 +305,9 @@ catch (...)
     hit->set_ladder_z_index(ladderz);
     if (whichactive > 0)
     {
-    hit->set_strip_z_index(strip_z_index);
-    hit->set_strip_y_index(strip_y_index);
-    hit->set_ladder_phi_index(ladderphi);
+      hit->set_strip_z_index(strip_z_index);
+      hit->set_strip_y_index(strip_y_index);
+      hit->set_ladder_phi_index(ladderphi);
     }
 
     //here we set the entrance values in cm

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -32,6 +32,7 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
   PHG4Shower *saveshower;
   const PHG4ParametersContainer *paramscontainer;
 
+  double strip_y[4];
   std::map<int, int> IsActive;
   std::map<int, int> IsBlackHole;
 };

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -34,8 +34,8 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
 
   double strip_y[4];
   double strip_z[4][2];
-int nstrips_z_sensor[4][2];
-int nstrips_phi_cell[4];
+  int nstrips_z_sensor[4][2];
+  int nstrips_phi_cell[4];
   std::map<int, int> IsActive;
   std::map<int, int> IsBlackHole;
 };

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -33,6 +33,7 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
   const PHG4ParametersContainer *paramscontainer;
 
   double strip_y[4];
+  double strip_z[4][2];
   std::map<int, int> IsActive;
   std::map<int, int> IsBlackHole;
 };

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -34,6 +34,8 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
 
   double strip_y[4];
   double strip_z[4][2];
+int nstrips_z_sensor[4][2];
+int nstrips_phi_cell[4];
   std::map<int, int> IsActive;
   std::map<int, int> IsBlackHole;
 };

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -38,6 +38,8 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
   int nstrips_phi_cell[4];
   std::map<int, int> IsActive;
   std::map<int, int> IsBlackHole;
+  std::map<std::string, int> AbsorberIndex;
+  std::set<std::string> missingabsorbers;
 };
 
 #endif  // PHG4SiliconTrackerSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -138,10 +138,10 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
     set_default_double_param(i, "hdi_x", 0.038626);
     set_default_double_param(i, "hdi_edge_z", 0.01);
     set_default_double_param(i, "offsetphi", 0.);
-    set_default_double_param(i, "pgs_x", 0.21);
+    set_default_double_param(i, "pgs_x", 0.021);
     set_default_double_param(i, "sensor_edge_phi", 0.1305);
     set_default_double_param(i, "sensor_edge_z", 0.098);
-    set_default_double_param(i, "stave_x", 0.23);
+    set_default_double_param(i, "stave_x", 0.023);
     set_default_double_param(i, "strip_x", 0.02);
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -128,15 +128,25 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   set_default_int_param(2,"nladder",32);
   set_default_int_param(3,"nladder",38);
 
-  set_default_double_param(0, "Radius", 6.);
-  set_default_double_param(1, "Radius", 8.);
-  set_default_double_param(2, "Radius", 10.);
-  set_default_double_param(3, "Radius", 12.);
+  set_default_double_param(0, "radius", 6.);
+  set_default_double_param(1, "radius", 8.);
+  set_default_double_param(2, "radius", 10.);
+  set_default_double_param(3, "radius", 12.);
 
   set_default_double_param(0, "strip_y",0.0078);
   set_default_double_param(1, "strip_y",0.0086);
   set_default_double_param(2, "strip_y",0.0086);
   set_default_double_param(3, "strip_y",0.0086);
+
+  set_default_double_param(0, "strip_z_0",1.8);
+  set_default_double_param(1, "strip_z_0",1.6);
+  set_default_double_param(2, "strip_z_0",1.6);
+  set_default_double_param(3, "strip_z_0",1.6);
+
+  set_default_double_param(0, "strip_z_1",1.8);
+  set_default_double_param(1, "strip_z_1",2.0);
+  set_default_double_param(2, "strip_z_1",2.0);
+  set_default_double_param(3, "strip_z_1",2.0);
 
   std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> begin_end = GetDetIds();
   for (set<int>::const_iterator it = begin_end.first; it != begin_end.second; ++it)

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -122,78 +122,78 @@ PHG4Detector *PHG4SiliconTrackerSubsystem::GetDetector(void) const
 
 void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
 {
-// all values in cm!
-  for (int i=0; i<4; i++)
+  // all values in cm!
+  for (int i = 0; i < 4; i++)
   {
-    set_default_int_param(i,"nstrips_phi_cell",128);
-    set_default_double_param(i,"fphx_x",0.032);
-    set_default_double_param(i,"fphx_y",0.27);
-    set_default_double_param(i,"fphx_z",0.9);
-    set_default_double_param(i,"gap_sensor_fphx",0.1);
-    set_default_double_param(i, "hdi_x",0.038626);
-    set_default_double_param(i,"hdi_edge_z",0.01);
-    set_default_double_param(i, "offsetphi",0.);
-    set_default_double_param(i, "pgs_x",0.21);
-    set_default_double_param(i,"sensor_edge_phi",0.1305);
-    set_default_double_param(i,"sensor_edge_z",0.098);
-    set_default_double_param(i,"stave_x",0.23);
-    set_default_double_param(i,"strip_x",0.02);
+    set_default_int_param(i, "nstrips_phi_cell", 128);
+    set_default_double_param(i, "fphx_x", 0.032);
+    set_default_double_param(i, "fphx_y", 0.27);
+    set_default_double_param(i, "fphx_z", 0.9);
+    set_default_double_param(i, "gap_sensor_fphx", 0.1);
+    set_default_double_param(i, "hdi_x", 0.038626);
+    set_default_double_param(i, "hdi_edge_z", 0.01);
+    set_default_double_param(i, "offsetphi", 0.);
+    set_default_double_param(i, "pgs_x", 0.21);
+    set_default_double_param(i, "sensor_edge_phi", 0.1305);
+    set_default_double_param(i, "sensor_edge_z", 0.098);
+    set_default_double_param(i, "stave_x", 0.23);
+    set_default_double_param(i, "strip_x", 0.02);
   }
 
-  set_default_int_param(0,"nladder",20);
-  set_default_int_param(1,"nladder",26);
-  set_default_int_param(2,"nladder",32);
-  set_default_int_param(3,"nladder",38);
+  set_default_int_param(0, "nladder", 20);
+  set_default_int_param(1, "nladder", 26);
+  set_default_int_param(2, "nladder", 32);
+  set_default_int_param(3, "nladder", 38);
 
-  set_default_int_param(0,"nstrips_z_sensor_0",5);
-  set_default_int_param(1,"nstrips_z_sensor_0",8);
-  set_default_int_param(2,"nstrips_z_sensor_0",8);
-  set_default_int_param(3,"nstrips_z_sensor_0",8);
+  set_default_int_param(0, "nstrips_z_sensor_0", 5);
+  set_default_int_param(1, "nstrips_z_sensor_0", 8);
+  set_default_int_param(2, "nstrips_z_sensor_0", 8);
+  set_default_int_param(3, "nstrips_z_sensor_0", 8);
 
-  set_default_int_param(0,"nstrips_z_sensor_1",5);
-  set_default_int_param(1,"nstrips_z_sensor_1",5);
-  set_default_int_param(2,"nstrips_z_sensor_1",5);
-  set_default_int_param(3,"nstrips_z_sensor_1",5);
+  set_default_int_param(0, "nstrips_z_sensor_1", 5);
+  set_default_int_param(1, "nstrips_z_sensor_1", 5);
+  set_default_int_param(2, "nstrips_z_sensor_1", 5);
+  set_default_int_param(3, "nstrips_z_sensor_1", 5);
 
-  set_default_double_param(0, "halfladder_z",22.);
-  set_default_double_param(1, "halfladder_z",26.8);
-  set_default_double_param(2, "halfladder_z",26.8);
-  set_default_double_param(3, "halfladder_z",26.8);
+  set_default_double_param(0, "halfladder_z", 22.);
+  set_default_double_param(1, "halfladder_z", 26.8);
+  set_default_double_param(2, "halfladder_z", 26.8);
+  set_default_double_param(3, "halfladder_z", 26.8);
 
-  set_default_double_param(0, "hdi_y",3.8);
-  set_default_double_param(1, "hdi_y",4.3);
-  set_default_double_param(2, "hdi_y",4.3);
-  set_default_double_param(3, "hdi_y",4.3);
+  set_default_double_param(0, "hdi_y", 3.8);
+  set_default_double_param(1, "hdi_y", 4.3);
+  set_default_double_param(2, "hdi_y", 4.3);
+  set_default_double_param(3, "hdi_y", 4.3);
 
-  set_default_double_param(0, "offsetrot",14.0);
-  set_default_double_param(1, "offsetrot",14.0);
-  set_default_double_param(2, "offsetrot",12.0);
-  set_default_double_param(3, "offsetrot",11.5);
+  set_default_double_param(0, "offsetrot", 14.0);
+  set_default_double_param(1, "offsetrot", 14.0);
+  set_default_double_param(2, "offsetrot", 12.0);
+  set_default_double_param(3, "offsetrot", 11.5);
 
   set_default_double_param(0, "radius", 6.);
   set_default_double_param(1, "radius", 8.);
   set_default_double_param(2, "radius", 10.);
   set_default_double_param(3, "radius", 12.);
 
-  set_default_double_param(0, "strip_y",0.0078);
-  set_default_double_param(1, "strip_y",0.0086);
-  set_default_double_param(2, "strip_y",0.0086);
-  set_default_double_param(3, "strip_y",0.0086);
+  set_default_double_param(0, "strip_y", 0.0078);
+  set_default_double_param(1, "strip_y", 0.0086);
+  set_default_double_param(2, "strip_y", 0.0086);
+  set_default_double_param(3, "strip_y", 0.0086);
 
-  set_default_double_param(0, "strip_z_0",1.8);
-  set_default_double_param(1, "strip_z_0",1.6);
-  set_default_double_param(2, "strip_z_0",1.6);
-  set_default_double_param(3, "strip_z_0",1.6);
+  set_default_double_param(0, "strip_z_0", 1.8);
+  set_default_double_param(1, "strip_z_0", 1.6);
+  set_default_double_param(2, "strip_z_0", 1.6);
+  set_default_double_param(3, "strip_z_0", 1.6);
 
-  set_default_double_param(0, "strip_z_1",1.8);
-  set_default_double_param(1, "strip_z_1",2.0);
-  set_default_double_param(2, "strip_z_1",2.0);
-  set_default_double_param(3, "strip_z_1",2.0);
+  set_default_double_param(0, "strip_z_1", 1.8);
+  set_default_double_param(1, "strip_z_1", 2.0);
+  set_default_double_param(2, "strip_z_1", 2.0);
+  set_default_double_param(3, "strip_z_1", 2.0);
 
   std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> begin_end = GetDetIds();
   for (set<int>::const_iterator it = begin_end.first; it != begin_end.second; ++it)
-  { 
-    set_int_param(*it,"active",1);
+  {
+    set_int_param(*it, "active", 1);
   }
 
   return;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -22,7 +22,6 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &dete
   , steppingAction_(nullptr)
   , layerconfig_(layerconfig)
   , detector_type(detectorname)
-  , superdetector(detectorname)
 {
   for (vector<pair<int, int>>::const_iterator piter = layerconfig.begin(); piter != layerconfig.end(); ++piter)
   {
@@ -32,6 +31,7 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &dete
   // put the layer into the name so we get unique names
   // for multiple layers
   Name(detectorname);
+  SuperDetector(detectorname);
 }
 
 //_______________________________________________________________________
@@ -45,7 +45,7 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 
   // create detector
   detector_ = new PHG4SiliconTrackerDetector(topNode, GetParamsContainer(), Name(), layerconfig_);
-  detector_->SuperDetector(superdetector);
+  detector_->SuperDetector(SuperDetector());
   detector_->Detector(detector_type);
   detector_->OverlapCheck(CheckOverlap());
 
@@ -76,9 +76,7 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
           DetNode = new PHCompositeNode(SuperDetector());
           dstNode->addNode(DetNode);
         } 
-   cout << "detector: " << detector_type << endl;
-    cout << "superdetector: " << superdetector << endl;
-    std::string nodename = (superdetector != "NONE") ? boost::str(boost::format("G4HIT_%s") % superdetector) : boost::str(boost::format("G4HIT_%s") % detector_type);
+    std::string nodename = (SuperDetector() != "NONE") ? boost::str(boost::format("G4HIT_%s") % SuperDetector()) : boost::str(boost::format("G4HIT_%s") % detector_type);
 
     // create hit list
     PHG4HitContainer *hitcontainer = findNode::getClass<PHG4HitContainer>(topNode, nodename.c_str());
@@ -87,7 +85,7 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 
     if (absorberactive)
     {
-      nodename = (superdetector != "NONE") ? boost::str(boost::format("G4HIT_ABSORBER_%s") % superdetector) : boost::str(boost::format("G4HIT_ABSORBER_%s") % detector_type);
+      nodename = (SuperDetector() != "NONE") ? boost::str(boost::format("G4HIT_ABSORBER_%s") % SuperDetector()) : boost::str(boost::format("G4HIT_ABSORBER_%s") % detector_type);
 
       hitcontainer = findNode::getClass<PHG4HitContainer>(topNode, nodename.c_str());
       if (!hitcontainer)

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -129,6 +129,7 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
     set_default_double_param(i,"fphx_x",0.032);
     set_default_double_param(i,"fphx_y",0.27);
     set_default_double_param(i,"fphx_z",0.9);
+    set_default_double_param(i,"gap_sensor_fphx",0.1);
     set_default_double_param(i, "hdi_x",0.038626);
     set_default_double_param(i,"hdi_edge_z",0.01);
     set_default_double_param(i, "offsetphi",0.);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -123,15 +123,26 @@ PHG4Detector *PHG4SiliconTrackerSubsystem::GetDetector(void) const
 void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
 {
 // all values in cm!
+  for (int i=0; i<4; i++)
+  {
+    set_default_int_param(i,"nstrips_phi_cell",128);
+    set_default_double_param(i,"fphx_x",0.032);
+    set_default_double_param(i,"fphx_y",0.27);
+    set_default_double_param(i,"fphx_z",0.9);
+    set_default_double_param(i, "hdi_x",0.038626);
+    set_default_double_param(i,"hdi_edge_z",0.01);
+    set_default_double_param(i, "offsetphi",0.);
+    set_default_double_param(i, "pgs_x",0.21);
+    set_default_double_param(i,"sensor_edge_phi",0.1305);
+    set_default_double_param(i,"sensor_edge_z",0.098);
+    set_default_double_param(i,"stave_x",0.023);
+    set_default_double_param(i,"strip_x",0.02);
+  }
+
   set_default_int_param(0,"nladder",20);
   set_default_int_param(1,"nladder",26);
   set_default_int_param(2,"nladder",32);
   set_default_int_param(3,"nladder",38);
-
-  set_default_int_param(0,"nstrips_phi_cell",128);
-  set_default_int_param(1,"nstrips_phi_cell",128);
-  set_default_int_param(2,"nstrips_phi_cell",128);
-  set_default_int_param(3,"nstrips_phi_cell",128);
 
   set_default_int_param(0,"nstrips_z_sensor_0",5);
   set_default_int_param(1,"nstrips_z_sensor_0",8);
@@ -143,15 +154,15 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   set_default_int_param(2,"nstrips_z_sensor_1",5);
   set_default_int_param(3,"nstrips_z_sensor_1",5);
 
+  set_default_double_param(0, "halfladder_z",22.);
+  set_default_double_param(1, "halfladder_z",26.8);
+  set_default_double_param(2, "halfladder_z",26.8);
+  set_default_double_param(3, "halfladder_z",26.8);
+
   set_default_double_param(0, "hdi_y",3.8);
   set_default_double_param(1, "hdi_y",4.3);
   set_default_double_param(2, "hdi_y",4.3);
   set_default_double_param(3, "hdi_y",4.3);
-
-  set_default_double_param(0, "offsetphi",0.);
-  set_default_double_param(1, "offsetphi",0.);
-  set_default_double_param(2, "offsetphi",0.);
-  set_default_double_param(3, "offsetphi",0.);
 
   set_default_double_param(0, "offsetrot",14.0);
   set_default_double_param(1, "offsetrot",14.0);
@@ -180,11 +191,7 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
 
   std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> begin_end = GetDetIds();
   for (set<int>::const_iterator it = begin_end.first; it != begin_end.second; ++it)
-  {
-    set_default_double_param(*it,"strip_x",0.02);
-    set_default_double_param(*it,"sensor_edge_phi",0.1305);
-    set_default_double_param(*it,"sensor_edge_z",0.098);
-    set_default_double_param(*it,"hdi_edge_z",0.01);
+  { 
     set_int_param(*it,"active",1);
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -122,15 +122,29 @@ PHG4Detector *PHG4SiliconTrackerSubsystem::GetDetector(void) const
 
 void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
 {
+// all values in cm!
+  set_default_int_param(0,"nladder",20);
+  set_default_int_param(1,"nladder",26);
+  set_default_int_param(2,"nladder",32);
+  set_default_int_param(3,"nladder",38);
+
   set_default_double_param(0, "Radius", 6.);
   set_default_double_param(1, "Radius", 8.);
   set_default_double_param(2, "Radius", 10.);
   set_default_double_param(3, "Radius", 12.);
+
+  set_default_double_param(0, "strip_y",0.0078);
+  set_default_double_param(1, "strip_y",0.0086);
+  set_default_double_param(2, "strip_y",0.0086);
+  set_default_double_param(3, "strip_y",0.0086);
+
   std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> begin_end = GetDetIds();
   for (set<int>::const_iterator it = begin_end.first; it != begin_end.second; ++it)
   {
+    set_default_double_param(*it,"strip_x",0.02);
     set_int_param(*it,"active",1);
   }
+
   return;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -22,7 +22,7 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &dete
   , steppingAction_(nullptr)
   , layerconfig_(layerconfig)
   , detector_type(detectorname)
-  , superdetector("NONE")
+  , superdetector(detectorname)
 {
   for (vector<pair<int, int>>::const_iterator piter = layerconfig.begin(); piter != layerconfig.end(); ++piter)
   {
@@ -69,23 +69,30 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   }
   if (active)
   {
-    cout << "detector: " << detector_type << endl;
+      PHNodeIterator dstIter( dstNode );
+      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstIter.findFirst("PHCompositeNode",SuperDetector()));
+      if (! DetNode)
+	{
+          DetNode = new PHCompositeNode(SuperDetector());
+          dstNode->addNode(DetNode);
+        } 
+   cout << "detector: " << detector_type << endl;
     cout << "superdetector: " << superdetector << endl;
     std::string nodename = (superdetector != "NONE") ? boost::str(boost::format("G4HIT_%s") % superdetector) : boost::str(boost::format("G4HIT_%s") % detector_type);
 
     // create hit list
     PHG4HitContainer *hitcontainer = findNode::getClass<PHG4HitContainer>(topNode, nodename.c_str());
     if (!hitcontainer)
-      dstNode->addNode(new PHIODataNode<PHObject>(hitcontainer = new PHG4HitContainer(nodename), nodename.c_str(), "PHObject"));
+      DetNode->addNode(new PHIODataNode<PHObject>(hitcontainer = new PHG4HitContainer(nodename), nodename.c_str(), "PHObject"));
 
     if (absorberactive)
     {
-      //      nodename = (superdetector != "NONE") ? boost::str(boost::format("G4HIT_ABSORBER_%s") % superdetector) : boost::str(boost::format("G4HIT_ABSORBER_%s") % detector_type);
+      nodename = (superdetector != "NONE") ? boost::str(boost::format("G4HIT_ABSORBER_%s") % superdetector) : boost::str(boost::format("G4HIT_ABSORBER_%s") % detector_type);
 
       hitcontainer = findNode::getClass<PHG4HitContainer>(topNode, nodename.c_str());
       if (!hitcontainer)
       {
-        dstNode->addNode(new PHIODataNode<PHObject>(hitcontainer = new PHG4HitContainer(nodename), nodename.c_str(), "PHObject"));
+        DetNode->addNode(new PHIODataNode<PHObject>(hitcontainer = new PHG4HitContainer(nodename), nodename.c_str(), "PHObject"));
       }
     }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -126,6 +126,11 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   set_default_double_param(1, "Radius", 8.);
   set_default_double_param(2, "Radius", 10.);
   set_default_double_param(3, "Radius", 12.);
+  std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> begin_end = GetDetIds();
+  for (set<int>::const_iterator it = begin_end.first; it != begin_end.second; ++it)
+  {
+    set_int_param(*it,"active",1);
+  }
   return;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -135,7 +135,7 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
     set_default_double_param(i, "pgs_x",0.21);
     set_default_double_param(i,"sensor_edge_phi",0.1305);
     set_default_double_param(i,"sensor_edge_z",0.098);
-    set_default_double_param(i,"stave_x",0.023);
+    set_default_double_param(i,"stave_x",0.23);
     set_default_double_param(i,"strip_x",0.02);
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -128,6 +128,31 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   set_default_int_param(2,"nladder",32);
   set_default_int_param(3,"nladder",38);
 
+  set_default_int_param(0,"nstrips_phi_cell",128);
+  set_default_int_param(1,"nstrips_phi_cell",128);
+  set_default_int_param(2,"nstrips_phi_cell",128);
+  set_default_int_param(3,"nstrips_phi_cell",128);
+
+  set_default_int_param(0,"nstrips_z_sensor_0",5);
+  set_default_int_param(1,"nstrips_z_sensor_0",8);
+  set_default_int_param(2,"nstrips_z_sensor_0",8);
+  set_default_int_param(3,"nstrips_z_sensor_0",8);
+
+  set_default_int_param(0,"nstrips_z_sensor_1",5);
+  set_default_int_param(1,"nstrips_z_sensor_1",5);
+  set_default_int_param(2,"nstrips_z_sensor_1",5);
+  set_default_int_param(3,"nstrips_z_sensor_1",5);
+
+  set_default_double_param(0, "offsetphi",0.);
+  set_default_double_param(1, "offsetphi",0.);
+  set_default_double_param(2, "offsetphi",0.);
+  set_default_double_param(3, "offsetphi",0.);
+
+  set_default_double_param(0, "offsetrot",14.0);
+  set_default_double_param(1, "offsetrot",14.0);
+  set_default_double_param(2, "offsetrot",12.0);
+  set_default_double_param(3, "offsetrot",11.5);
+
   set_default_double_param(0, "radius", 6.);
   set_default_double_param(1, "radius", 8.);
   set_default_double_param(2, "radius", 10.);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -177,6 +177,9 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   for (set<int>::const_iterator it = begin_end.first; it != begin_end.second; ++it)
   {
     set_default_double_param(*it,"strip_x",0.02);
+    set_default_double_param(*it,"sensor_edge_phi",0.1305);
+    set_default_double_param(*it,"sensor_edge_z",0.098);
+    set_default_double_param(*it,"hdi_edge_z",0.01);
     set_int_param(*it,"active",1);
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -69,13 +69,13 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   }
   if (active)
   {
-      PHNodeIterator dstIter( dstNode );
-      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstIter.findFirst("PHCompositeNode",SuperDetector()));
-      if (! DetNode)
-	{
-          DetNode = new PHCompositeNode(SuperDetector());
-          dstNode->addNode(DetNode);
-        } 
+    PHNodeIterator dstIter(dstNode);
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", SuperDetector()));
+    if (!DetNode)
+    {
+      DetNode = new PHCompositeNode(SuperDetector());
+      dstNode->addNode(DetNode);
+    }
     std::string nodename = (SuperDetector() != "NONE") ? boost::str(boost::format("G4HIT_%s") % SuperDetector()) : boost::str(boost::format("G4HIT_%s") % detector_type);
 
     // create hit list

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -143,6 +143,11 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   set_default_int_param(2,"nstrips_z_sensor_1",5);
   set_default_int_param(3,"nstrips_z_sensor_1",5);
 
+  set_default_double_param(0, "hdi_y",3.8);
+  set_default_double_param(1, "hdi_y",4.3);
+  set_default_double_param(2, "hdi_y",4.3);
+  set_default_double_param(3, "hdi_y",4.3);
+
   set_default_double_param(0, "offsetphi",0.);
   set_default_double_param(1, "offsetphi",0.);
   set_default_double_param(2, "offsetphi",0.);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
@@ -43,8 +43,6 @@ class PHG4SiliconTrackerSubsystem : public PHG4DetectorGroupSubsystem
   //! accessors (reimplemented)
   PHG4Detector *GetDetector(void) const;
   PHG4SteppingAction *GetSteppingAction(void) const { return steppingAction_; }
-  void SuperDetector(const std::string &name) { superdetector = name; }
-  const std::string SuperDetector() { return superdetector; }
   void Print(const std::string &what = "ALL") const;
 
  private:
@@ -61,7 +59,6 @@ class PHG4SiliconTrackerSubsystem : public PHG4DetectorGroupSubsystem
   std::vector<std::pair<int, int>> layerconfig_;
 
   std::string detector_type;
-  std::string superdetector;
 };
 
 #endif


### PR DESCRIPTION
Now all parameters are on the node tree. Writing out absorber hits works, the volume is encoded into the ladderz (hokey but this is anyway for testing only). We still have those hits with pre=post step status=fGeomBoundary and pre/post step in the same volume but they result in the same strip index. I assume it's when the stepping length by the physics process and the stepping length to the next geometrical are very close and then the physics process length is chosen. The code will print out a warning if the strip index turns out to be wrong.