### PR TITLE
Maps time window

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4MapsCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4MapsCellReco.h
@@ -1,8 +1,11 @@
 #ifndef PHG4MAPSCELLRECO_H
 #define PHG4MAPSCELLRECO_H
 
+#include "PHG4ParameterContainerInterface.h"
+
 #include <fun4all/SubsysReco.h>
 #include <phool/PHTimeServer.h>
+
 #include <string>
 #include <map>
 #include <vector>
@@ -10,11 +13,11 @@
 class PHCompositeNode;
 class PHG4Cell;
 
-class PHG4MapsCellReco : public SubsysReco
+class PHG4MapsCellReco : public SubsysReco, public PHG4ParameterContainerInterface
 {
  public:
 
-  PHG4MapsCellReco(const std::string &name);
+  explicit PHG4MapsCellReco(const std::string &name = "MAPSRECO");
 
   virtual ~PHG4MapsCellReco(){}
   
@@ -29,6 +32,12 @@ class PHG4MapsCellReco : public SubsysReco
   
   void Detector(const std::string &d) {detector = d;}
   void checkenergy(const int i=1) {chkenergyconservation = i;}
+
+  double get_timing_window_min(const int i) {return tmin_max[i].first;}
+  double get_timing_window_max(const int i) {return tmin_max[i].second;}
+ void   set_timing_window(const int detid, const double tmin, const double tmax);
+
+  void SetDefaultParameters();
 
  protected:
 
@@ -76,7 +85,7 @@ class PHG4MapsCellReco : public SubsysReco
   PHTimeServer::timer _timer;
   int nbins[2];
   int chkenergyconservation;
-
+  std::map<int, std::pair<double,double> > tmin_max;
   std::map<unsigned long long, PHG4Cell*> celllist;  // This map holds the hit cells
 };
 


### PR DESCRIPTION
I modified PHG4MapsCellReco to add a timing cut on the hits. This was requested by Yorito Yamaguchi, who is doing event pileup studies for the INTT. Timing cuts are already implemented for the INTT ladders and for the cylinder cells.

The timing cut for the maps is set at a default value of +/- 2000 ns. The values can be over-written from the macro using the "set_timing_window" method. I checked that the timing cuts are set correctly.
