### PR TITLE
quick patch to get strips geo back

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -500,9 +500,9 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
       // parameters are in cm, so no conversion needed here to get to cm (*cm/cm)
       PHG4CylinderGeom *mygeom = new PHG4CylinderGeom_Siladders(
           sphxlayer,
-          params->get_double_param("strip_x"),
-          params->get_double_param("strip_y"),
-          params->get_double_param("strip_z_0"),
+          params->get_double_param("strip_x")/2.,
+          params->get_double_param("strip_y")/2.,
+          params->get_double_param("strip_z_0")/2.,
           params->get_double_param("strip_z_1"),
           params->get_int_param("nstrips_z_sensor_0"),
           params->get_int_param("nstrips_z_sensor_1"),


### PR DESCRIPTION
For some reason the intt geo object wants the strip_x, strip_y and strip_z in length/2. This patch is to restore the previous behavior and get Haiwang going again