### PR TITLE
Changes to the silicon tracker geometry object

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
@@ -70,8 +70,8 @@ void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, cons
   const double strip_z       = strip_z_[itype];
   const int nstrips_z_sensor = nstrips_z_sensor_[itype];
 
-  const double strip_localpos_z = 2.*strip_z*(double)(strip_column%nstrips_z_sensor) -    strip_z*(double)nstrips_z_sensor + strip_z;
-  const double strip_localpos_y = 2.*strip_y*(double)strip_index                     - 2.*strip_y*(double)nstrips_phi_cell + strip_y;
+  const double strip_localpos_z = strip_z*(double)(strip_column%nstrips_z_sensor) -    strip_z/2.*(double)nstrips_z_sensor + strip_z/2.;
+  const double strip_localpos_y = strip_y*(double)strip_index                     - strip_y*(double)nstrips_phi_cell + strip_y/2.;
 
   CLHEP::Hep3Vector strip_localpos(strip_x_offset, strip_localpos_y, strip_localpos_z);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
@@ -1,5 +1,4 @@
 #include "PHG4CylinderGeom_Siladders.h"
-#include <cmath>
 
 #include <g4main/PHG4Detector.h>
 
@@ -8,6 +7,8 @@
 
 #include <CLHEP/Vector/ThreeVector.h>
 #include <CLHEP/Vector/Rotation.h>
+
+#include <cmath>
 
 PHG4CylinderGeom_Siladders::PHG4CylinderGeom_Siladders():
   layer(-1),
@@ -53,7 +54,7 @@ void PHG4CylinderGeom_Siladders::find_segment_center(const int segment_z_bin, co
   const double signz = (segment_z_bin<=1) ? -1. : 1.;
 
   // Ladder
-  const double phi  = offsetphi + dphi_ * (double)segment_phi_bin;
+  const double phi  = offsetphi + dphi_ * segment_phi_bin;
   location[0] = eff_radius  * cos(phi);
   location[1] = eff_radius  * sin(phi);
   location[2] = signz * ladder_z_[itype];
@@ -70,14 +71,14 @@ void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, cons
   const double strip_z       = strip_z_[itype];
   const int nstrips_z_sensor = nstrips_z_sensor_[itype];
 
-  const double strip_localpos_z = strip_z*(double)(strip_column%nstrips_z_sensor) -    strip_z/2.*(double)nstrips_z_sensor + strip_z/2.;
-  const double strip_localpos_y = strip_y*(double)strip_index                     - strip_y*(double)nstrips_phi_cell + strip_y/2.;
+  const double strip_localpos_z = strip_z*(strip_column%nstrips_z_sensor) -    strip_z/2.*nstrips_z_sensor + strip_z/2.;
+  const double strip_localpos_y = strip_y*strip_index                     - strip_y*nstrips_phi_cell + strip_y/2.;
 
   CLHEP::Hep3Vector strip_localpos(strip_x_offset, strip_localpos_y, strip_localpos_z);
 
   // Strip rotation
-  const double phi    = offsetphi + dphi_ * (double)segment_phi_bin;
-  const double rotate = phi + offsetrot + CLHEP::pi;
+  const double phi    = offsetphi + dphi_ * segment_phi_bin;
+  const double rotate = phi + offsetrot + M_PI;
 
   CLHEP::HepRotation rot;
   rot.rotateZ(rotate);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -500,9 +500,9 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
       // parameters are in cm, so no conversion needed here to get to cm (*cm/cm)
       PHG4CylinderGeom *mygeom = new PHG4CylinderGeom_Siladders(
           sphxlayer,
-          params->get_double_param("strip_x")/2.,
-          params->get_double_param("strip_y")/2.,
-          params->get_double_param("strip_z_0")/2.,
+          params->get_double_param("strip_x"),
+          params->get_double_param("strip_y"),
+          params->get_double_param("strip_z_0"),
           params->get_double_param("strip_z_1"),
           params->get_int_param("nstrips_z_sensor_0"),
           params->get_int_param("nstrips_z_sensor_1"),

--- a/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.C
@@ -124,10 +124,10 @@ void PHG4SiliconTrackerDigitizer::CalculateLadderCellADCScale(PHCompositeNode *t
     if (_max_fphx_adc.find(layer)==_max_fphx_adc.end())
       assert(!"Error: _max_fphx_adc is not available.");
 
-    float thickness = (layeriter->second)->get_thickness(); // mm
-    float mip_e     = 0.003876 * 2.*thickness; // GeV
+    float thickness = (layeriter->second)->get_thickness(); // cm
+    float mip_e     = 0.003876 *thickness; // GeV
     _energy_scale.insert(std::make_pair(layer, mip_e));
-  }
+ } 
 
   return;
 }


### PR DESCRIPTION
Initially the strip dimensions were stored as length/2. just what G4 expects for boxes. But looking at the subsequent code it seems that this fact got lost and so in the tracking/clustering everything is off by a factor of 2 (the only method which treated this correctly was the return of the local coordinates). Affected is everything which uses geo->get_thickness(), geo->get_strip_y_spacing() and geo->get_strip_z_spacing(). It doesn't have a big effect but the results after this change are not identical anymore.