### PR TITLE
fixed up PHG4CylinderCellTPCReco

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -10,6 +10,7 @@
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
+
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
 
@@ -19,8 +20,14 @@
 #include <phool/PHNodeIterator.h>
 #include <phool/PHRandomSeed.h>
 
+#include <TH1F.h>
+#include <TProfile2D.h>
+#include <TROOT.h>
+
 #include <CLHEP/Units/PhysicalConstants.h>
 #include <CLHEP/Units/SystemOfUnits.h>
+
+#include <gsl/gsl_randist.h>
 
 #include <cmath>
 #include <cstdlib>
@@ -28,9 +35,6 @@
 #include <sstream>
 #include <limits>
 
-#include "TH1F.h"
-#include "TProfile2D.h"
-#include "TStopwatch.h"
 
 using namespace std;
 
@@ -56,16 +60,18 @@ PHG4CylinderCellTPCReco::PHG4CylinderCellTPCReco(int n_pixel,
       fHErrorRPhi(NULL),
       fHErrorZ(NULL),
       fFractRPsm(0.0),
-      fFractZZsm(0.0),
-      fSW(NULL),
-      fHTime(NULL)
+      fFractZZsm(0.0)
 {
   memset(nbins,0,sizeof(nbins));
-  rand.SetSeed(PHRandomSeed());
+  unsigned int seed = PHRandomSeed(); // fixed seed is handled in this funtcion
+  cout << Name() << " random seed: " << seed << endl;
+  RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
+  gsl_rng_set(RandomGenerator, seed);
 }
 
 PHG4CylinderCellTPCReco::~PHG4CylinderCellTPCReco()
 {
+  gsl_rng_free(RandomGenerator);
   delete distortion;
 }
 
@@ -105,10 +111,8 @@ int PHG4CylinderCellTPCReco::Init(PHCompositeNode* top_node)
     se->registerHisto( fHErrorRPhi );
     fHErrorZ = new TProfile2D("TPCGEO_CloudSizeZ","TPCGEO_CloudSizeZ",50,-0.5,49.5,220,-110,+110);
     se->registerHisto( fHErrorZ );
-    fSW = new TStopwatch();
-    fHTime = new TH1F("TIME_TPCGEO","TPCGEO_TIME;sec per event",1000,0,60);
-    se->registerHisto( fHTime );
   }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -152,7 +156,6 @@ int PHG4CylinderCellTPCReco::InitRun(PHCompositeNode *topNode)
     layerseggeo->set_radius(layergeom->get_radius());
     layerseggeo->set_thickness(layergeom->get_thickness());
     
-    zmin_max[layer] = make_pair(layergeom->get_zmin(), layergeom->get_zmax());
     double size_z = (sizeiter->second).second;
     double size_r = (sizeiter->second).first;
     double bins_r;
@@ -219,10 +222,6 @@ int PHG4CylinderCellTPCReco::InitRun(PHCompositeNode *topNode)
 
 int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
 {
-  if(verbosity>1) {
-    fSW->Reset();
-    fSW->Start();
-  }
   _timer.get()->restart();
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hit){cout << "Could not locate g4 hit node " << hitnodename << endl;exit(1);}
@@ -336,21 +335,21 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
 	if(hiter->second->has_property(PHG4Hit::prop_eion)) cell->add_eion(hiter->second->get_eion());
       } else { // TPC
 	// converting Edep to Total Number Of Electrons
-        double nelec = rand.PoissonD( elec_per_kev*1e6*edep );
+        double nelec = gsl_ran_poisson(RandomGenerator,elec_per_kev*1e6*edep);
 	if(verbosity>1) {
 	  fHElectrons->Fill( nelec );
 	}
 	double sigmaT = 0.010; //100um
 	double sigmaL = 0.010; //100um
-        double cloud_sig_rp = sqrt( fDiffusionT*fDiffusionT*(fHalfLength - TMath::Abs(hiter->second->get_avg_z())) + sigmaT*sigmaT );
-        double cloud_sig_zz = sqrt( fDiffusionL*fDiffusionL*(fHalfLength - TMath::Abs(hiter->second->get_avg_z())) + sigmaL*sigmaL );
+        double cloud_sig_rp = sqrt( fDiffusionT*fDiffusionT*(fHalfLength - fabs(hiter->second->get_avg_z())) + sigmaT*sigmaT );
+        double cloud_sig_zz = sqrt( fDiffusionL*fDiffusionL*(fHalfLength - fabs(hiter->second->get_avg_z())) + sigmaL*sigmaL );
 
 	//===============
 	// adding a random displacement to effectively deal with cellularisation
-	phi += fFractRPsm*rand.Gaus(0,cloud_sig_rp)/r;
+	phi += fFractRPsm*gsl_ran_gaussian(RandomGenerator, cloud_sig_rp)/r;
 	if(phi>+pi) phi -= 2*pi;
 	if(phi<-pi) phi += 2*pi;
-	z += fFractZZsm*rand.Gaus(0,cloud_sig_zz);
+	z += fFractZZsm*gsl_ran_gaussian(RandomGenerator, cloud_sig_zz);
 	// moving center
 	phibin = geo->get_phibin( phi );
 	zbin = geo->get_zbin( z );
@@ -437,9 +436,6 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
   }
   if(verbosity>1000) std::cout<<"PHG4CylinderCellTPCReco end" << std::endl;
   _timer.get()->stop();
-  if(verbosity>1) {
-    fHTime->Fill( fSW->RealTime() );
-  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -22,7 +22,7 @@ class PHG4CylinderCellTPCReco : public SubsysReco
 {
 public:
   
-  PHG4CylinderCellTPCReco( int n_pixel=2, const std::string &name = "CYLINDERTPCRECO");
+  PHG4CylinderCellTPCReco( const int n_pixel=2, const std::string &name = "CYLINDERTPCRECO");
   
   virtual ~PHG4CylinderCellTPCReco();
   
@@ -33,23 +33,18 @@ public:
   //! event processing
   int process_event(PHCompositeNode *topNode);
   
-  //! end of process
-  int End(PHCompositeNode *topNode);
-  
   void Detector(const std::string &d);
   void cellsize(const int i, const double sr, const double sz);
-//   void etaphisize(const int i, const double deltaeta, const double deltaphi);
   void OutputDetector(const std::string &d) {outdetector = d;}
 
-  void setHalfLength( double hz ){fHalfLength = hz;}
-  void setDiffusionL( double diff ){fDiffusionL = diff;}
-  void setDiffusionT( double diff ){fDiffusionT = diff;}
-  void setDiffusion( double diff ){setDiffusionL(diff); setDiffusionT(diff);} //deprecated
-  void setElectronsPerKeV( double epk ){elec_per_kev = epk;}
-  void set_drift_velocity( const double cm_per_ns) { driftv = cm_per_ns;}
+  void setHalfLength(const double hz){fHalfLength = hz;}
+  void setDiffusionL(const double diff){fDiffusionL = diff;}
+  void setDiffusionT(const double diff){fDiffusionT = diff;}
+  void setElectronsPerKeV(const double epk){elec_per_kev = epk;}
+  void set_drift_velocity(const double cm_per_ns) { driftv = cm_per_ns;}
 
-  void setSmearRPhi( double v ) {fFractRPsm=v;}
-  void setSmearZ( double v ) {fFractZZsm=v;}
+  void setSmearRPhi(const double v) {fFractRPsm=v;}
+  void setSmearZ(const double v) {fFractZZsm=v;}
   
   double get_timing_window_min(const int i) {return tmin_max[i].first;}
   double get_timing_window_max(const int i) {return tmin_max[i].second;}
@@ -64,8 +59,8 @@ public:
   void setDistortion (PHG4TPCDistortion * d) {distortion = d;}
 
 protected:
-  std::map<int, int>  binning;
-  std::map<int, std::pair <double,double> > cell_size; // cell size in phi/z
+  std::map<int, int> binning;
+  std::map<int, std::pair<double,double>> cell_size; // cell size in phi/z
   std::map<int, double> phistep;
   std::map<int, double> etastep;
   std::string detector;
@@ -74,7 +69,7 @@ protected:
   std::string cellnodename;
   std::string geonodename;
   std::string seggeonodename;
-  std::map<int, std::pair<int, int> > n_phi_z_bins;
+  std::map<int, std::pair<int, int>> n_phi_z_bins;
   PHTimeServer::timer _timer;
   int nbins[2];
   
@@ -88,7 +83,7 @@ protected:
 
   double tmin_default;
   double tmax_default;
-  std::map<int, std::pair<double,double> > tmin_max;
+  std::map<int,std::pair<double,double>> tmin_max;
   
   //! distortion to the primary ionization if not NULL
   PHG4TPCDistortion * distortion;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -40,7 +40,7 @@ public:
   void setHalfLength(const double hz){fHalfLength = hz;}
   void setDiffusionL(const double diff){fDiffusionL = diff;}
   void setDiffusionT(const double diff){fDiffusionT = diff;}
-  void setElectronsPerKeV(const double epk){elec_per_kev = epk;}
+  void setElectronsPerKeV(const double epk){elec_per_gev = epk*1e6;}
   void set_drift_velocity(const double cm_per_ns) { driftv = cm_per_ns;}
 
   void setSmearRPhi(const double v) {fFractRPsm=v;}
@@ -76,7 +76,7 @@ protected:
   double fHalfLength;
   double fDiffusionT;
   double fDiffusionL;
-  double elec_per_kev;
+  double elec_per_gev;
   double driftv;
 
   int num_pixel_layers;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -4,16 +4,19 @@
 #include <fun4all/SubsysReco.h>
 #include <phool/PHTimeServer.h>
 
-#include <TRandom3.h>
+// rootcint barfs with this header so we need to hide it
+#ifndef __CINT__
+#include <gsl/gsl_rng.h>
+#endif
+
 
 #include <string>
 #include <map>
 
 class PHCompositeNode;
 class PHG4TPCDistortion;
-class TH1F;
+class TH1;
 class TProfile2D;
-class TStopwatch;
 
 class PHG4CylinderCellTPCReco : public SubsysReco
 {
@@ -63,7 +66,6 @@ public:
 protected:
   std::map<int, int>  binning;
   std::map<int, std::pair <double,double> > cell_size; // cell size in phi/z
-  std::map<int, std::pair <double,double> > zmin_max; // zmin/zmax for each layer for faster lookup
   std::map<int, double> phistep;
   std::map<int, double> etastep;
   std::string detector;
@@ -76,8 +78,6 @@ protected:
   PHTimeServer::timer _timer;
   int nbins[2];
   
-  TRandom3 rand;
-
   double fHalfLength;
   double fDiffusionT;
   double fDiffusionL;
@@ -92,7 +92,7 @@ protected:
   
   //! distortion to the primary ionization if not NULL
   PHG4TPCDistortion * distortion;
-  TH1F *fHElectrons;
+  TH1 *fHElectrons;
   TProfile2D *fHWindowP;
   TProfile2D *fHWindowZ;
   TProfile2D *fHMeanEDepPerCell;
@@ -101,8 +101,11 @@ protected:
   TProfile2D *fHErrorZ;
   double fFractRPsm;
   double fFractZZsm;
-  TStopwatch *fSW;
-  TH1F *fHTime;
+#ifndef __CINT__
+  //! random generator that conform with sPHENIX standard
+  gsl_rng *RandomGenerator;
+#endif
+
 };
 
 #endif


### PR DESCRIPTION
it was still using the root random number generators, replaced by gsl. Removed TMath::Abs(), use defines from cmath (M_PI instead of acos(0) and SQRT2 instead of sqrt(2)). Replaced bad unsigned long key by the previous unsigned long long. Nota bene on 64 bits long is 64 bits like long long but on 32 bit architectures long is 32 bits (long long is 64 bits on 32 bit archs)- which is why the long type should never be used.
I am puzzled about the 60ns time window which looks like a leftover from the calorimeters.