### PR TITLE
configuring PHPythia to use a logical OR of triggers should disable t…

### DIFF
--- a/generators/PHPythia8/PHPythia8.h
+++ b/generators/PHPythia8/PHPythia8.h
@@ -50,8 +50,8 @@ public:
 
   /// set event selection criteria
   void register_trigger(PHPy8GenTrigger *theTrigger);
-  void set_trigger_OR() { _triggersOR = true; } // default true
-  void set_trigger_AND() { _triggersAND = true; }
+  void set_trigger_OR() { _triggersOR = true; _triggersAND = false; } // default true
+  void set_trigger_AND() { _triggersAND = true; _triggersOR = false; }
 
   /// pass commands directly to PYTHIA8
   void process_string(std::string s) {_commands.push_back(s);}


### PR DESCRIPTION
…he logical AND evaluation (and vice versa). 

Without this bug fix, since the logical OR is checked first in the evaluation of the PHPythia triggers, it is impossible to actually configure and use a logical AND of triggers in practice. (For example, requiring both an electron and a positron from an Upsilon decay in the sPHENIX acceptance using the logical AND of two single particle triggers).