### PR TITLE
KalmanPatRec - day one patch

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
@@ -2783,7 +2783,9 @@ int PHG4KalmanPatRec::SimpleTrack3DToPHGenFitTracks(PHCompositeNode* topNode, un
 		cov(1, 1) = _vertex_error[1]*_vertex_error[1];
 		cov(2, 2) = _vertex_error[2]*_vertex_error[2];
 		PHGenFit::Measurement* meas = new PHGenFit::SpacepointMeasurement(v, cov);
-		meas->set_cluster_ID(0);
+		//FIXME re-use the first cluster id
+		unsigned int id = m_r_clusterID.begin()->second;
+		meas->set_cluster_ID(id);
 		measurements.push_back(meas);
 	}
 

--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.h
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.h
@@ -31,6 +31,7 @@
 
 // PHGenFit
 #include <phgenfit/Fitter.h>
+//#include <phgenfit/Measurement.h>
 
 // g4hough includes
 #include "SvtxTrackState.h"
@@ -38,15 +39,21 @@
 // forward declarations
 class PHCompositeNode;
 class SvtxClusterMap;
+class SvtxCluster;
 class SvtxTrackMap;
 class SvtxTrack;
 class SvtxVertexMap;
 class SvtxVertex;
+class SvtxHitMap;
+class PHG4CellContainer;
+class PHG4CylinderGeomContainer;
+
 class PHG4HitContainer;
 
 namespace PHGenFit {
 class Fitter;
 class Track;
+class Measurement;
 } /* namespace PHGenFit */
 
 namespace genfit {
@@ -561,6 +568,9 @@ private:
 			const unsigned int init_layer = 0, const unsigned int end_layer = 66,
 			const bool use_fitted_state_once = false);
 
+	//!
+	PHGenFit::Measurement* SvtxClusterToPHGenFitMeasurement(const SvtxCluster* cluster);
+
 	//! TrackPropPatRec Call.
 	std::vector<unsigned int> SearchHitsNearBy (const unsigned int layer, const float z_center, const float phi_center, const float z_window, const float phi_window);
 
@@ -672,6 +682,16 @@ private:
 	SvtxClusterMap* _g4clusters;
 	SvtxTrackMap* _g4tracks;
 	SvtxVertexMap* _g4vertexes;
+
+	//nodes to get norm vector
+	SvtxHitMap* _svtxhitsmap;
+
+	PHG4CellContainer* _cells_svtx;
+	PHG4CellContainer* _cells_intt;
+	PHG4CellContainer* _cells_maps;
+
+	PHG4CylinderGeomContainer* _geom_container_intt;
+	PHG4CylinderGeomContainer* _geom_container_maps;
 
 
 	bool _seeding_only_mode;


### PR DESCRIPTION
Previously didn't rotate the norm vector when track propagated to silicon detectors.
This reduced the hit finding eff. in the silicon layers.
Fixed it in this patch.

Quickly tested with 5GeV and 30GeV pions embedded into central Hijing events.
Resolution for pT and DCA improved significantly:

5GeV:
![image](https://cloud.githubusercontent.com/assets/10383186/26421370/d66ea102-4093-11e7-8f86-06de2d59e96f.png)


30GeV:
![image](https://cloud.githubusercontent.com/assets/10383186/26421343/c0eeb8c6-4093-11e7-88c7-d058476cd02d.png)

