### PR TITLE
small fixes to compile under root 6

### DIFF
--- a/offline/packages/trigger/CaloTriggerInfo.C
+++ b/offline/packages/trigger/CaloTriggerInfo.C
@@ -1,3 +1,0 @@
-#include "CaloTriggerInfo.h"
-
-ClassImp(CaloTriggerInfo)

--- a/offline/packages/trigger/CaloTriggerInfo_v1.C
+++ b/offline/packages/trigger/CaloTriggerInfo_v1.C
@@ -1,6 +1,7 @@
 #include "CaloTriggerInfo_v1.h"
 
-ClassImp(CaloTriggerInfo_v1)
+
+using namespace std;
 
 CaloTriggerInfo_v1::CaloTriggerInfo_v1()
 {

--- a/offline/packages/trigger/Makefile.am
+++ b/offline/packages/trigger/Makefile.am
@@ -33,7 +33,6 @@ pkginclude_HEADERS = \
   CaloTriggerInfo_v1.h
 
 libcalotrigger_io_la_SOURCES = \
-  CaloTriggerInfo.C \
   CaloTriggerInfo_Dict.C \
   CaloTriggerInfo_v1.C \
   CaloTriggerInfo_v1_Dict.C

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -316,7 +316,8 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
 	fHMeanEDepPerCell->Fill( float(*layer), z, edep );
       }
       if( (*layer) < (unsigned int)num_pixel_layers ) { // MAPS + ITT
-        unsigned long long key = zbin*nphibins + phibin;
+	unsigned long long longphibins = nphibins;
+        unsigned long long key = zbin*longphibins + phibin;
 	std::map<unsigned long long, PHG4Cell*>::iterator it = cellptmap.find(key);
 	PHG4Cell *cell;
 	if(it != cellptmap.end()) {

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -18,7 +18,7 @@ class PHG4Hitv1 : public PHG4Hit
   PHG4Hitv1();
   explicit PHG4Hitv1(const PHG4Hit &g4hit);
   virtual ~PHG4Hitv1() {}
-  void identify(ostream& os) const;
+  void identify(std::ostream& os  = std::cout) const;
   void Reset();
 
   // The indices here represent the entry and exit points of the particle


### PR DESCRIPTION
While compiling with root6 I came across a missing std:: in the PHG4Hitv1.h and a missing using namespace std in CaloTriggerInfo_v1.C for ostream which were probably resolved by root5. Coverity complained about inconsistent handling of int vs long long when generating the long long key.
ClassImps are obsolete (that macro was needed to generate the THtml documentation which has been phased out a long time ago in favour of doxygen)