### PR TITLE
read back parametermapcontainer from dst to restore setting used during production

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -115,11 +115,12 @@ int PHG4DetectorGroupSubsystem::InitRun(PHCompositeNode *topNode)
   else
   {
     // if not filled from file or DB, check if we have a node containing those calibrations
-    // on the node tree and load them (unlikely - this code is for future use)
+    // on the node tree and load them (the embedding wants to use the 
+    // parameters saved on the previous pass)
     PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode, paramnodename);
     if (nodeparams)
     {
-      //	  params->FillFrom(nodeparams, layer);
+      paramscontainer->FillFrom(nodeparams);
     }
   }
   // parameters set in the macro always override whatever is read from
@@ -403,7 +404,6 @@ void PHG4DetectorGroupSubsystem::InitializeParameters()
   {
     set_default_int_param(*iter, "absorberactive", 0);
     set_default_int_param(*iter, "absorbertruth", 0);
-    set_default_int_param(*iter, "active", 0);
     set_default_int_param(*iter, "blackhole", 0);
   }
   SetDefaultParameters();  // call method from specific subsystem

--- a/simulation/g4simulation/g4detectors/PHG4ParametersContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ParametersContainer.cc
@@ -37,6 +37,24 @@ PHG4ParametersContainer::~PHG4ParametersContainer()
 }
 
 void
+PHG4ParametersContainer::FillFrom(const PdbParameterMapContainer *saveparamcontainer)
+{
+// this fill only existing detids - no new ones are created (if the PdbParameterMapContainer contains
+// entries from another detector)
+  PdbParameterMapContainer::parConstRange begin_end =  saveparamcontainer->get_ParameterMaps();
+  for (PdbParameterMapContainer::parIter iter = begin_end.first; iter != begin_end.second; ++iter)
+  {
+    Iterator pariter = parametermap.find(iter->first);
+    if (pariter != parametermap.end())
+    {
+      PHG4Parameters *params = pariter->second;
+      params->FillFrom(iter->second);
+    }
+  }
+  return;
+}
+
+void
 PHG4ParametersContainer::AddPHG4Parameters(const int layer, PHG4Parameters *params)
 {
   if (parametermap.find(layer) != parametermap.end())

--- a/simulation/g4simulation/g4detectors/PHG4ParametersContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4ParametersContainer.h
@@ -36,6 +36,8 @@ class PHG4ParametersContainer : public PHObject
   void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename);
   int ExistDetid(const int detid) const;
   void clear() { parametermap.clear(); }
+  void FillFrom(const PdbParameterMapContainer *saveparamcontainer);
+
  protected:
   void CopyToPdbParameterMapContainer(PdbParameterMapContainer *myparm);
   std::string superdetectorname;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -198,7 +198,7 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> begin_end = GetDetIds();
   for (set<int>::const_iterator it = begin_end.first; it != begin_end.second; ++it)
   {
-    set_int_param(*it, "active", 1);
+    set_default_int_param(*it, "active", 1);
   }
 
   return;


### PR DESCRIPTION
This just follows the scheme of the parametermap handling. During sim step of the embedding we want to use the same parameters as during the production of the input DST. This is normally the case - as long as the default setting ins the code are not changed (and recompiled) so this is just a safeguard. I verified that the parameters used by the embedding don't change and are now stable even if the default parameters are changed in the code. The parameters can still be overridden in the macro or via reading from a DB or file (actually useful if you want to change the active setting)