### PR TITLE
Bugfix in treatment of new tower container nodes

### DIFF
--- a/offline/packages/jetbackground/RetowerCEMC.h
+++ b/offline/packages/jetbackground/RetowerCEMC.h
@@ -41,7 +41,8 @@ class RetowerCEMC : public SubsysReco
  private:
   int CreateNode(PHCompositeNode *topNode);
 
-  RawTowerContainer* _emcal_retower;
+  int _NETA;
+  int _NPHI;
   std::vector< std::vector<float> > _EMCAL_RETOWER_E;
 
 };

--- a/offline/packages/jetbackground/SubtractTowers.C
+++ b/offline/packages/jetbackground/SubtractTowers.C
@@ -27,7 +27,7 @@
 #include <vector>
 
 SubtractTowers::SubtractTowers(const std::string &name)
-  : SubsysReco(name), _emcal_towers(nullptr), _ihcal_towers(nullptr), _ohcal_towers(nullptr)
+  : SubsysReco(name)
 {
   _background_iteration = 0;
 }
@@ -46,6 +46,8 @@ int SubtractTowers::Init(PHCompositeNode *topNode)
 
 int SubtractTowers::InitRun(PHCompositeNode *topNode)
 {
+
+  CreateNode(topNode);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -68,10 +70,17 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
     std::cout << "SubtractTowers::process_event: " << towersIH3->size() << " TOWER_CALIB_HCALIN towers" << std::endl;
     std::cout << "SubtractTowers::process_event: " << towersOH3->size() << " TOWER_CALIB_HCALOUT towers" << std::endl;
   }
+
+  // these should have already been created during InitRun()
+  RawTowerContainer* emcal_towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_CEMC_RETOWER_SUB1");
+  RawTowerContainer* ihcal_towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALIN_SUB1");
+  RawTowerContainer* ohcal_towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALOUT_SUB1");
   
-  _emcal_towers = new RawTowerContainer( RawTowerDefs::CalorimeterId::HCALIN );
-  _ihcal_towers = new RawTowerContainer( RawTowerDefs::CalorimeterId::HCALIN );
-  _ohcal_towers = new RawTowerContainer( RawTowerDefs::CalorimeterId::HCALOUT );
+  if (verbosity > 0) {
+    std::cout << "SubtractTowers::process_event: starting with " << emcal_towers->size() << " TOWER_CALIB_CEMC_RETOWER_SUB1 towers" << std::endl;
+    std::cout << "SubtractTowers::process_event: starting with " << ihcal_towers->size() << " TOWER_CALIB_HCALIN_SUB1 towers" << std::endl;
+    std::cout << "SubtractTowers::process_event: starting with " << ohcal_towers->size() << " TOWER_CALIB_HCALOUT_SUB1 towers" << std::endl;
+  }
 
   TowerBackground* towerbackground = findNode::getClass<TowerBackground>(topNode,"TowerBackground_Sub1");
 
@@ -88,7 +97,7 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 
     RawTower *new_tower = new RawTowerv1();
     new_tower->set_energy( this_E );
-    _emcal_towers->AddTower( this_etabin, this_phibin, new_tower );
+    emcal_towers->AddTower( this_etabin, this_phibin, new_tower );
     
   }
 
@@ -96,16 +105,16 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
   // but note: after retowering, all of these should already exist...
   for (int eta = 0; eta < geomIH->get_etabins(); eta++) {
     for (int phi = 0; phi < geomIH->get_phibins(); phi++) {
-      if ( ! _emcal_towers->getTower( eta, phi ) ) {
+      if ( ! emcal_towers->getTower( eta, phi ) ) {
 	RawTower *new_tower = new RawTowerv1();
 	new_tower->set_energy( 0 );
-	_emcal_towers->AddTower( eta, phi, new_tower );
+	emcal_towers->AddTower( eta, phi, new_tower );
       }
     }
   }
 
   // update towers for background subtraction...
-  for (RawTowerContainer::ConstIterator rtiter = _emcal_towers->getTowers().first; rtiter != _emcal_towers->getTowers().second; ++rtiter) {
+  for (RawTowerContainer::ConstIterator rtiter = emcal_towers->getTowers().first; rtiter != emcal_towers->getTowers().second; ++rtiter) {
     RawTower *tower = rtiter->second;
     float raw_energy = tower->get_energy();
     float UE = towerbackground->get_UE( 0 ).at( tower->get_bineta() );
@@ -129,23 +138,23 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 
     RawTower *new_tower = new RawTowerv1();
     new_tower->set_energy( this_E );
-    _ihcal_towers->AddTower( this_etabin, this_phibin, new_tower );
+    ihcal_towers->AddTower( this_etabin, this_phibin, new_tower );
     
   }
 
   // now fill in additional towers with zero energy to fill out the full grid
   for (int eta = 0; eta < geomIH->get_etabins(); eta++) {
     for (int phi = 0; phi < geomIH->get_phibins(); phi++) {
-      if ( ! _ihcal_towers->getTower( eta, phi ) ) {
+      if ( ! ihcal_towers->getTower( eta, phi ) ) {
 	RawTower *new_tower = new RawTowerv1();
 	new_tower->set_energy( 0 );
-	_ihcal_towers->AddTower( eta, phi, new_tower );
+	ihcal_towers->AddTower( eta, phi, new_tower );
       }
     }
   }
 
   // update towers for background subtraction...
-  for (RawTowerContainer::ConstIterator rtiter = _ihcal_towers->getTowers().first; rtiter != _ihcal_towers->getTowers().second; ++rtiter) {
+  for (RawTowerContainer::ConstIterator rtiter = ihcal_towers->getTowers().first; rtiter != ihcal_towers->getTowers().second; ++rtiter) {
     RawTower *tower = rtiter->second;
     float raw_energy = tower->get_energy();
     float UE = towerbackground->get_UE( 1 ).at( tower->get_bineta() );
@@ -167,23 +176,23 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 
     RawTower *new_tower = new RawTowerv1();
     new_tower->set_energy( this_E );
-    _ohcal_towers->AddTower( this_etabin, this_phibin, new_tower );
+    ohcal_towers->AddTower( this_etabin, this_phibin, new_tower );
     
   }
 
   // now fill in additional towers with zero energy to fill out the full grid
   for (int eta = 0; eta < geomOH->get_etabins(); eta++) {
     for (int phi = 0; phi < geomOH->get_phibins(); phi++) {
-      if ( ! _ohcal_towers->getTower( eta, phi ) ) {
+      if ( ! ohcal_towers->getTower( eta, phi ) ) {
 	RawTower *new_tower = new RawTowerv1();
 	new_tower->set_energy( 0 );
-	_ohcal_towers->AddTower( eta, phi, new_tower );
+	ohcal_towers->AddTower( eta, phi, new_tower );
       }
     }
   }
 
   // update towers for background subtraction...
-  for (RawTowerContainer::ConstIterator rtiter = _ohcal_towers->getTowers().first; rtiter != _ohcal_towers->getTowers().second; ++rtiter) {
+  for (RawTowerContainer::ConstIterator rtiter = ohcal_towers->getTowers().first; rtiter != ohcal_towers->getTowers().second; ++rtiter) {
     RawTower *tower = rtiter->second;
     float raw_energy = tower->get_energy();
     float UE = towerbackground->get_UE( 2 ).at( tower->get_bineta() );
@@ -192,12 +201,10 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
   }
 
   if (verbosity > 0) {
-    std::cout << "SubtractTowers::process_event: " << _emcal_towers->size() << " TOWER_CALIB_CEMC_RETOWER_SUB1 towers" << std::endl;
-    std::cout << "SubtractTowers::process_event: " << _ihcal_towers->size() << " TOWER_CALIB_HCALIN_SUB1 towers" << std::endl;
-    std::cout << "SubtractTowers::process_event: " << _ohcal_towers->size() << " TOWER_CALIB_HCALOUT_SUB1 towers" << std::endl;
+    std::cout << "SubtractTowers::process_event: ending with " << emcal_towers->size() << " TOWER_CALIB_CEMC_RETOWER_SUB1 towers" << std::endl;
+    std::cout << "SubtractTowers::process_event: ending with " << ihcal_towers->size() << " TOWER_CALIB_HCALIN_SUB1 towers" << std::endl;
+    std::cout << "SubtractTowers::process_event: ending with " << ohcal_towers->size() << " TOWER_CALIB_HCALOUT_SUB1 towers" << std::endl;
   }
-
-  CreateNode(topNode);
 
   if (verbosity > 0) std::cout << "SubtractTowers::process_event: exiting" << std::endl;
 
@@ -226,17 +233,37 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
     std::cout << PHWHERE << "EMCal Node note found, doing nothing." << std::endl;
   }
   
-  PHIODataNode<PHObject> *emcalTowerNode = new PHIODataNode<PHObject>(_emcal_towers, "TOWER_CALIB_CEMC_RETOWER_SUB1", "PHObject");
-  emcalNode->addNode(emcalTowerNode);
+  RawTowerContainer* test_emcal_tower = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_CEMC_RETOWER_SUB1");
+  if ( !test_emcal_tower ) {
+
+    if (verbosity > 0) std::cout << "SubtractTowers::CreateNode : creating TOWER_CALIB_CEMC_RETOWER_SUB1 node " << std::endl;
+
+    RawTowerContainer* emcal_towers = new RawTowerContainer( RawTowerDefs::CalorimeterId::HCALIN );
+    PHIODataNode<PHObject> *emcalTowerNode = new PHIODataNode<PHObject>(emcal_towers, "TOWER_CALIB_CEMC_RETOWER_SUB1", "PHObject");
+    emcalNode->addNode(emcalTowerNode);
+    
+  } else {
+    std::cout << "SubtractTowers::CreateNode : TOWER_CALIB_CEMC_RETOWER_SUB1 already exists! " << std::endl;
+  }
 
   // store the new IHCal towers
   PHCompositeNode *ihcalNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "HCALIN"));
   if (!ihcalNode) {
     std::cout << PHWHERE << "IHCal Node note found, doing nothing." << std::endl;
   }
-  
-  PHIODataNode<PHObject> *ihcalTowerNode = new PHIODataNode<PHObject>(_ihcal_towers, "TOWER_CALIB_HCALIN_SUB1", "PHObject");
-  ihcalNode->addNode(ihcalTowerNode);
+
+  RawTowerContainer* test_ihcal_tower = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALIN_SUB1");
+  if ( !test_ihcal_tower ) {
+
+    if (verbosity > 0) std::cout << "SubtractTowers::CreateNode : creating TOWER_CALIB_HCALIN_SUB1 node " << std::endl;
+
+    RawTowerContainer* ihcal_towers = new RawTowerContainer( RawTowerDefs::CalorimeterId::HCALIN );
+    PHIODataNode<PHObject> *ihcalTowerNode = new PHIODataNode<PHObject>(ihcal_towers, "TOWER_CALIB_HCALIN_SUB1", "PHObject");
+    ihcalNode->addNode(ihcalTowerNode);
+    
+  } else {
+    std::cout << "SubtractTowers::CreateNode : TOWER_CALIB_HCALIN_SUB1 already exists! " << std::endl;
+  }
 
   // store the new OHCal towers
   PHCompositeNode *ohcalNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "HCALOUT"));
@@ -244,8 +271,18 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
     std::cout << PHWHERE << "OHCal Node note found, doing nothing." << std::endl;
   }
 
-  PHIODataNode<PHObject> *ohcalTowerNode = new PHIODataNode<PHObject>(_ohcal_towers, "TOWER_CALIB_HCALOUT_SUB1", "PHObject");
-  ohcalNode->addNode(ohcalTowerNode);
+  RawTowerContainer* test_ohcal_tower = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALOUT_SUB1");
+  if ( !test_ohcal_tower ) {
+
+    if (verbosity > 0) std::cout << "SubtractTowers::CreateNode : creating TOWER_CALIB_HCALOUT_SUB1 node " << std::endl;
+
+    RawTowerContainer* ohcal_towers = new RawTowerContainer( RawTowerDefs::CalorimeterId::HCALOUT );
+    PHIODataNode<PHObject> *ohcalTowerNode = new PHIODataNode<PHObject>(ohcal_towers, "TOWER_CALIB_HCALOUT_SUB1", "PHObject");
+    ohcalNode->addNode(ohcalTowerNode);
+    
+  } else {
+    std::cout << "SubtractTowers::CreateNode : TOWER_CALIB_HCALOUT_SUB1 already exists! " << std::endl;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/jetbackground/SubtractTowers.h
+++ b/offline/packages/jetbackground/SubtractTowers.h
@@ -43,10 +43,6 @@ class SubtractTowers : public SubsysReco
   int CreateNode(PHCompositeNode *topNode);
 
   int _background_iteration;
-  
-  RawTowerContainer* _emcal_towers;
-  RawTowerContainer* _ihcal_towers;
-  RawTowerContainer* _ohcal_towers;
 
 };
 


### PR DESCRIPTION
The previous version of the RetowerCEMC and SubtractTowers modules attempted to create a new data node (for the retowerized-CEMC and subtracted CEMC/HCALIN/HCALOUT tower containers, respectively) for every event. Now this takes place only during InitRun(), and the containers are accessed from the node tree during process_event(). My initial test did not catch this because I was testing on a single dijet + Hijing background event. The DetermineBackground module has the correct Create/Fill model and does not need a fix.