### PR TITLE
convenience library to load all classes stored on our dsts

### DIFF
--- a/offline/packages/PHGeometry/Makefile.am
+++ b/offline/packages/PHGeometry/Makefile.am
@@ -34,17 +34,14 @@ libphgeom_io_la_SOURCES = \
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  `root-config --evelibs`
+  -L$(ROOTSYS)/lib
 
 libphgeom_la_LIBADD = \
-  -lphool \
-  -lfun4all \
-  -lGeom \
+  -lSubsysReco \
   libphgeom_io.la
 
 libphgeom_io_la_LIBADD = \
   -lphool \
-  -lfun4all \
   -lGeom
 
 BUILT_SOURCES = \

--- a/offline/packages/PHGeometry/Makefile.am
+++ b/offline/packages/PHGeometry/Makefile.am
@@ -1,8 +1,5 @@
 AUTOMAKE_OPTIONS = foreign
 
-BUILT_SOURCES = \
-  testexternals.cc
-
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
@@ -11,6 +8,7 @@ AM_CPPFLAGS = \
   -I`root-config --incdir`
 
 lib_LTLIBRARIES = \
+   libphgeom_io.la \
    libphgeom.la
 
 pkginclude_HEADERS = \
@@ -24,28 +22,43 @@ noinst_HEADERS = \
 libphgeom_la_SOURCES = \
   PHGeomTGeo.cc \
   PHGeomTGeo_Dict.cc \
-  PHGeomIOTGeo.cc \
-  PHGeomIOTGeo_Dict.cc \
   PHGeomFileImport.cc \
   PHGeomFileImport_Dict.cc  \
   PHGeomUtility.cc \
   PHGeomUtility_Dict.cc 
 
-libphgeom_la_LDFLAGS = \
+libphgeom_io_la_SOURCES = \
+  PHGeomIOTGeo.cc \
+  PHGeomIOTGeo_Dict.cc
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
   `root-config --evelibs`
 
 libphgeom_la_LIBADD = \
-  -L$(libdir) \
-  -L$(OFFLINE_MAIN)/lib \
+  -lphool \
+  -lfun4all \
+  -lGeom \
+  libphgeom_io.la
+
+libphgeom_io_la_LIBADD = \
   -lphool \
   -lfun4all \
   -lGeom
 
-noinst_PROGRAMS = \
-  testexternals
+BUILT_SOURCES = \
+  testexternals.cc
 
-testexternals_SOURCES = testexternals.cc
-testexternals_LDADD   = libphgeom.la
+noinst_PROGRAMS = \
+  testexternals_libphgeom \
+  testexternals_libphgeom_io
+
+testexternals_libphgeom_SOURCES = testexternals.cc
+testexternals_libphgeom_LDADD   = libphgeom.la
+
+testexternals_libphgeom_io_SOURCES = testexternals.cc
+testexternals_libphgeom_io_LDADD   = libphgeom_io.la
 
 testexternals.cc:
 	echo "//*** this is a generated file. Do not commit, do not edit" > $@
@@ -61,4 +74,4 @@ testexternals.cc:
 
 
 clean-local:
-	rm -f *Dict*
+	rm -f *Dict* $(BUILT_SOURCES)

--- a/offline/packages/PHGeometry/PHGeomIOTGeo.cc
+++ b/offline/packages/PHGeometry/PHGeomIOTGeo.cc
@@ -20,8 +20,6 @@
 
 using namespace std;
 
-ClassImp(PHGeomIOTGeo);
-
 PHGeomIOTGeo::PHGeomIOTGeo() :
     Data(0)
 {

--- a/simulation/g4simulation/g4dst/Makefile.am
+++ b/simulation/g4simulation/g4dst/Makefile.am
@@ -15,7 +15,8 @@ libg4dst_la_LDFLAGS = \
   -lg4hough_io \
   -lcemc_io \
   -lg4vertex_io \
-  -lg4jets_io
+  -lg4jets_io \
+  -lphgeom_io
 
 libg4dst_la_SOURCES = \
    g4dst.C

--- a/simulation/g4simulation/g4dst/Makefile.am
+++ b/simulation/g4simulation/g4dst/Makefile.am
@@ -20,13 +20,17 @@ libg4dst_la_LDFLAGS = \
 libg4dst_la_SOURCES = \
    g4dst.C
 
+g4dst.C:
+	echo "//*** this is a generated empty file. Do not commit, do not edit" > $@
+
 ################################################
 # linking tests
 
 noinst_PROGRAMS = testexternals
 
 BUILT_SOURCES = \
-  testexternals.C
+  testexternals.C \
+  g4dst.C
 
 testexternals_LDADD = \
   libg4dst.la
@@ -39,4 +43,4 @@ testexternals.C:
 	echo "}" >> $@
 
 clean-local:
-	rm -f *Dict*
+	rm -f *Dict* $(BUILT_SOURCES)

--- a/simulation/g4simulation/g4dst/g4dst.C
+++ b/simulation/g4simulation/g4dst/g4dst.C
@@ -1,1 +1,0 @@
-// dummy file to create DST I/O meta-library


### PR DESCRIPTION
This is a meta library which depends on all our io libraries. Loading it resolves all classes stored on our DSTs, so users do not have to figure out what libraries need loading to read in DSTs. Our PHGeometry library was split into an io lib for the dst content and a reco lib. I removed unneeded library dependencies which caused dependencies on e.g. odbc