### PR TITLE
Set deposited energy for RICH photon hits to energy deposit from G4 step

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4RICHSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHSteppingAction.cc
@@ -120,6 +120,8 @@ PHG4RICHSteppingAction::UserSteppingAction(const G4Step* aStep)
 
 bool PHG4RICHSteppingAction::MakeHit(const G4Step* aStep){
 
+  // collect energy and track
+  G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
   const G4Track* aTrack = aStep->GetTrack();
   G4StepPoint* postPoint = aStep->GetPostStepPoint();
 
@@ -157,8 +159,8 @@ bool PHG4RICHSteppingAction::MakeHit(const G4Step* aStep){
       }
   }
 
-  // set optical photon energy deposition to 0
-  hit->set_edep(0);
+  // set optical photon energy deposition
+  hit->set_edep(edep);
 
   // Now add the hit
   hits_->AddHit(layer_id, hit);


### PR DESCRIPTION
As Chris pointed out in today's software meetings, G4Hits with exactly '0' energy may get discarded by following modules. Therefore, the energies of hits from optical Cerenkov photons are now set to the energy that these photons deposit according to Geant4 (which is a few eV per photon).