### PR TITLE
fix crashed caused by a rare combination of step status's

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -38,27 +38,28 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector* detector, const PHG4Parameters* parameters) : detector_(detector),
-                                                                                                                              hits_(nullptr),
-                                                                                                                              absorberhits_(nullptr),
-                                                                                                                              hit(nullptr),
-                                                                                                                              params(parameters),
-                                                                                                                              savehitcontainer(nullptr),
-                                                                                                                              saveshower(nullptr),
-															      savevolpre(nullptr),
-															      savevolpost(nullptr),
-                                                                                                                              savetrackid(-1),
-                                                                                                                              saveprestepstatus(-1),
-                                                                                                                              savepoststepstatus(-1),
-                                                                                                                              absorbertruth(params->get_int_param("absorbertruth")),
-                                                                                                                              IsActive(params->get_int_param("active")),
-                                                                                                                              IsBlackHole(params->get_int_param("blackhole")),
-                                                                                                                              n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr) * params->get_int_param("n_towers")),
-                                                                                                                              light_scint_model(params->get_int_param("light_scint_model")),
-                                                                                                                              light_balance_inner_corr(params->get_double_param("light_balance_inner_corr")),
-                                                                                                                              light_balance_inner_radius(params->get_double_param("light_balance_inner_radius") * cm),
-                                                                                                                              light_balance_outer_corr(params->get_double_param("light_balance_outer_corr")),
-                                                                                                                              light_balance_outer_radius(params->get_double_param("light_balance_outer_radius") * cm)
+PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector* detector, const PHG4Parameters* parameters)
+  : detector_(detector)
+  , hits_(nullptr)
+  , absorberhits_(nullptr)
+  , hit(nullptr)
+  , params(parameters)
+  , savehitcontainer(nullptr)
+  , saveshower(nullptr)
+  , savevolpre(nullptr)
+  , savevolpost(nullptr)
+  , savetrackid(-1)
+  , saveprestepstatus(-1)
+  , savepoststepstatus(-1)
+  , absorbertruth(params->get_int_param("absorbertruth"))
+  , IsActive(params->get_int_param("active"))
+  , IsBlackHole(params->get_int_param("blackhole"))
+  , n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr) * params->get_int_param("n_towers"))
+  , light_scint_model(params->get_int_param("light_scint_model"))
+  , light_balance_inner_corr(params->get_double_param("light_balance_inner_corr"))
+  , light_balance_inner_radius(params->get_double_param("light_balance_inner_radius") * cm)
+  , light_balance_outer_corr(params->get_double_param("light_balance_outer_corr"))
+  , light_balance_outer_radius(params->get_double_param("light_balance_outer_radius") * cm)
 {
   name = detector_->GetName();
 }
@@ -199,7 +200,7 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     case fPostStepDoItProc:
       if (savepoststepstatus != fGeomBoundary)
       {
-	break;
+        break;
       }
     case fGeomBoundary:
     case fUndefined:
@@ -223,7 +224,7 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       hit->set_edep(0);
       if (whichactive > 0)  // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
       {
-        hit->set_eion(0);     // only implemented for v5 otherwise empty
+        hit->set_eion(0);         // only implemented for v5 otherwise empty
         hit->set_light_yield(0);  // for scintillator only, initialize light yields
         // Now save the container we want to add this hit to
         savehitcontainer = hits_;
@@ -256,11 +257,11 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
            << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
       cout << "last track: " << savetrackid
            << ", current trackid: " << aTrack->GetTrackID() << endl;
-      cout << "phys pre vol: " << volume->GetName() 
-	   << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+      cout << "phys pre vol: " << volume->GetName()
+           << " post vol : " << touchpost->GetVolume()->GetName() << endl;
       cout << " previous phys pre vol: " << savevolpre->GetName()
            << " previous phys post vol: " << savevolpost->GetName() << endl;
-     exit(1);
+      exit(1);
     }
     // check if track id matches the initial one when the hit was created
     if (aTrack->GetTrackID() != savetrackid)

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -3,6 +3,7 @@
 
 #include <g4main/PHG4SteppingAction.h>
 
+class G4VPhysicalVolume;
 class PHG4InnerHcalDetector;
 class PHG4Parameters;
 class PHG4Hit;
@@ -37,7 +38,10 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   const PHG4Parameters *params;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
+  G4VPhysicalVolume *savevolpre;
+  G4VPhysicalVolume *savevolpost;
   int savetrackid;
+  int saveprestepstatus;
   int savepoststepstatus;
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -3,6 +3,7 @@
 #include "PHG4HcalDefs.h"
 #include "PHG4OuterHcalDetector.h"
 #include "PHG4Parameters.h"
+#include "PHG4StepStatusDecode.h"
 
 // our own headers in alphabetical order
 
@@ -60,7 +61,10 @@ PHG4OuterHcalSteppingAction::PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector* 
                                                                                                                               params(parameters),
                                                                                                                               savehitcontainer(nullptr),
                                                                                                                               saveshower(nullptr),
+															      savevolpre(nullptr),
+															      savevolpost(nullptr),
                                                                                                                               savetrackid(-1),
+                                                                                                                              saveprestepstatus(-1),
                                                                                                                               savepoststepstatus(-1),
                                                                                                                               enable_field_checker(0),
                                                                                                                               absorbertruth(params->get_int_param("absorbertruth")),
@@ -95,6 +99,7 @@ int PHG4OuterHcalSteppingAction::Init()
 bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
+  G4TouchableHandle touchpost = aStep->GetPostStepPoint()->GetTouchableHandle();
   // get volume of the current step
   G4VPhysicalVolume* volume = touch->GetVolume();
 
@@ -220,6 +225,11 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
     switch (prePoint->GetStepStatus())
     {
+    case fPostStepDoItProc:
+      if (savepoststepstatus != fGeomBoundary)
+      {
+	break;
+      }
     case fGeomBoundary:
     case fUndefined:
       if (!hit)
@@ -267,8 +277,16 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     if (!hit || !isfinite(hit->get_x(0)))
     {
       cout << GetName() << ": hit was not created" << endl;
-      cout << "prestep status: " << prePoint->GetStepStatus()
-           << ", last post step status: " << savepoststepstatus << endl;
+      cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+           << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
+      cout << "last track: " << savetrackid
+           << ", current trackid: " << aTrack->GetTrackID() << endl;
+      cout << "phys pre vol: " << volume->GetName() 
+	   << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+      cout << " previous phys pre vol: " << savevolpre->GetName()
+           << " previous phys post vol: " << savevolpost->GetName() << endl;
       exit(1);
     }
     savepoststepstatus = postPoint->GetStepStatus();
@@ -281,7 +299,11 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
            << endl;
       exit(1);
     }
-    // here we just update the exit values, it will be overwritten
+    saveprestepstatus = prePoint->GetStepStatus();
+    savepoststepstatus = postPoint->GetStepStatus();
+    savevolpre = volume;
+    savevolpost = touchpost->GetVolume();
+     // here we just update the exit values, it will be overwritten
     // for every step until we leave the volume or the particle
     // ceases to exist
     hit->set_x(1, postPoint->GetPosition().x() / cm);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -54,28 +54,29 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4OuterHcalSteppingAction::PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector* detector, const PHG4Parameters* parameters) : detector_(detector),
-                                                                                                                              hits_(nullptr),
-                                                                                                                              absorberhits_(nullptr),
-                                                                                                                              hit(nullptr),
-                                                                                                                              params(parameters),
-                                                                                                                              savehitcontainer(nullptr),
-                                                                                                                              saveshower(nullptr),
-															      savevolpre(nullptr),
-															      savevolpost(nullptr),
-                                                                                                                              savetrackid(-1),
-                                                                                                                              saveprestepstatus(-1),
-                                                                                                                              savepoststepstatus(-1),
-                                                                                                                              enable_field_checker(0),
-                                                                                                                              absorbertruth(params->get_int_param("absorbertruth")),
-                                                                                                                              IsActive(params->get_int_param("active")),
-                                                                                                                              IsBlackHole(params->get_int_param("blackhole")),
-                                                                                                                              n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr) * params->get_int_param("n_towers")),
-                                                                                                                              light_scint_model(params->get_int_param("light_scint_model")),
-                                                                                                                              light_balance_inner_corr(params->get_double_param("light_balance_inner_corr")),
-                                                                                                                              light_balance_inner_radius(params->get_double_param("light_balance_inner_radius") * cm),
-                                                                                                                              light_balance_outer_corr(params->get_double_param("light_balance_outer_corr")),
-                                                                                                                              light_balance_outer_radius(params->get_double_param("light_balance_outer_radius") * cm)
+PHG4OuterHcalSteppingAction::PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector* detector, const PHG4Parameters* parameters)
+  : detector_(detector)
+  , hits_(nullptr)
+  , absorberhits_(nullptr)
+  , hit(nullptr)
+  , params(parameters)
+  , savehitcontainer(nullptr)
+  , saveshower(nullptr)
+  , savevolpre(nullptr)
+  , savevolpost(nullptr)
+  , savetrackid(-1)
+  , saveprestepstatus(-1)
+  , savepoststepstatus(-1)
+  , enable_field_checker(0)
+  , absorbertruth(params->get_int_param("absorbertruth"))
+  , IsActive(params->get_int_param("active"))
+  , IsBlackHole(params->get_int_param("blackhole"))
+  , n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr) * params->get_int_param("n_towers"))
+  , light_scint_model(params->get_int_param("light_scint_model"))
+  , light_balance_inner_corr(params->get_double_param("light_balance_inner_corr"))
+  , light_balance_inner_radius(params->get_double_param("light_balance_inner_radius") * cm)
+  , light_balance_outer_corr(params->get_double_param("light_balance_outer_corr"))
+  , light_balance_outer_radius(params->get_double_param("light_balance_outer_radius") * cm)
 {
   name = detector_->GetName();
 }
@@ -228,7 +229,7 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     case fPostStepDoItProc:
       if (savepoststepstatus != fGeomBoundary)
       {
-	break;
+        break;
       }
     case fGeomBoundary:
     case fUndefined:
@@ -283,8 +284,8 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
            << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
       cout << "last track: " << savetrackid
            << ", current trackid: " << aTrack->GetTrackID() << endl;
-      cout << "phys pre vol: " << volume->GetName() 
-	   << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+      cout << "phys pre vol: " << volume->GetName()
+           << " post vol : " << touchpost->GetVolume()->GetName() << endl;
       cout << " previous phys pre vol: " << savevolpre->GetName()
            << " previous phys post vol: " << savevolpost->GetName() << endl;
       exit(1);
@@ -303,7 +304,7 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     savepoststepstatus = postPoint->GetStepStatus();
     savevolpre = volume;
     savevolpost = touchpost->GetVolume();
-     // here we just update the exit values, it will be overwritten
+    // here we just update the exit values, it will be overwritten
     // for every step until we leave the volume or the particle
     // ceases to exist
     hit->set_x(1, postPoint->GetPosition().x() / cm);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
@@ -3,6 +3,7 @@
 
 #include <g4main/PHG4SteppingAction.h>
 
+class G4VPhysicalVolume;
 class PHG4OuterHcalDetector;
 class PHG4Parameters;
 class PHG4Hit;
@@ -41,7 +42,10 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
   const PHG4Parameters *params;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
+  G4VPhysicalVolume *savevolpre;
+  G4VPhysicalVolume *savevolpost;
   int savetrackid;
+  int saveprestepstatus;
   int savepoststepstatus;
   int enable_field_checker;
 


### PR DESCRIPTION
It's something which shouldn't happen - after a post step status of fGeomboundary one would expect a pre step status of fGeomboundary which starts a new hit. Instead the next pre step status is fPostStepDoItProc and it's back in the previous pre step volume. This fix catches this condition and will create a new hit in this case. The printouts in case the hit is a null ptr (which means the previous hit was saved and deleted but no new hit was created in this step) contain a lot more info now to track these cases down