### PR TITLE
check input manager list file for size and being a regular file

### DIFF
--- a/offline/framework/fun4all/Fun4AllInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllInputManager.cc
@@ -1,7 +1,7 @@
 #include "Fun4AllInputManager.h"
+#include <phool/phool.h>
 #include "Fun4AllServer.h"
 #include "SubsysReco.h"
-#include <phool/phool.h>
 
 #include <boost/filesystem.hpp>
 
@@ -10,48 +10,46 @@
 
 using namespace std;
 
-Fun4AllInputManager::Fun4AllInputManager(const string &name, const string &nodename, const string &topnodename):
-  Fun4AllBase(name),
-  InputNode(nodename),
-  topNodeName(topnodename),
-  mySyncManager(NULL),
-  repeat(0),
-  myrunnumber(0),
-  initrun(0)
-{ 
+Fun4AllInputManager::Fun4AllInputManager(const string &name, const string &nodename, const string &topnodename)
+  : Fun4AllBase(name)
+  , InputNode(nodename)
+  , topNodeName(topnodename)
+  , mySyncManager(NULL)
+  , repeat(0)
+  , myrunnumber(0)
+  , initrun(0)
+{
   return;
 }
 
 Fun4AllInputManager::~Fun4AllInputManager()
 {
   while (Subsystems.begin() != Subsystems.end())
+  {
+    if (verbosity)
     {
-      if (verbosity)
-        {
-          Subsystems.back()->Verbosity(verbosity);
-        }
-      delete Subsystems.back();
-      Subsystems.pop_back();
+      Subsystems.back()->Verbosity(verbosity);
     }
+    delete Subsystems.back();
+    Subsystems.pop_back();
+  }
 }
 
-int
-Fun4AllInputManager::AddFile(const string &filename)
+int Fun4AllInputManager::AddFile(const string &filename)
 {
   if (verbosity > 0)
-    {
-      cout << "Adding " << filename << " to list of input files for "
-	   << Name() << endl;
-    }
+  {
+    cout << "Adding " << filename << " to list of input files for "
+         << Name() << endl;
+  }
   filelist.push_back(filename);
   filelist_copy.push_back(filename);
   return 0;
 }
 
-int
-Fun4AllInputManager::AddListFile(const string &filename, const int do_it)
+int Fun4AllInputManager::AddListFile(const string &filename, const int do_it)
 {
-// checking filesize to see if we have a text file
+  // checking filesize to see if we have a text file
   if (boost::filesystem::exists(filename.c_str()))
   {
     if (boost::filesystem::is_regular_file(filename.c_str()))
@@ -59,13 +57,13 @@ Fun4AllInputManager::AddListFile(const string &filename, const int do_it)
       uintmax_t fsize = boost::filesystem::file_size(filename.c_str());
       if (fsize > 1000000 && !do_it)
       {
-	cout << "size of " << filename
+        cout << "size of " << filename
              << " is suspiciously large for a text file: "
              << fsize << " bytes" << endl;
-      cout << "if you really want to use " << filename
-           << " as list file (it will be used as a text file containing a list of input files), use AddListFile(\""
-           << filename << "\",1)" << endl;
-      return -1;
+        cout << "if you really want to use " << filename
+             << " as list file (it will be used as a text file containing a list of input files), use AddListFile(\""
+             << filename << "\",1)" << endl;
+        return -1;
       }
     }
     else
@@ -76,123 +74,120 @@ Fun4AllInputManager::AddListFile(const string &filename, const int do_it)
   }
   else
   {
-cout << PHWHERE << "Could not open " << filename << endl;
-return -1;
+    cout << PHWHERE << "Could not open " << filename << endl;
+    return -1;
   }
   ifstream infile;
   infile.open(filename.c_str(), ios_base::in);
   if (!infile)
-    {
-      cout << PHWHERE << "Could not open " << filename << endl;
-      return -1;
-    }
+  {
+    cout << PHWHERE << "Could not open " << filename << endl;
+    return -1;
+  }
   string FullLine;
   getline(infile, FullLine);
-  while ( !infile.eof())
+  while (!infile.eof())
+  {
+    if (FullLine.size() && FullLine[0] != '#')  // remove comments
     {
-      if (FullLine.size() && FullLine[0] != '#') // remove comments
-        {
-          AddFile(FullLine);
-        }
-      else if( FullLine.size() )
-        {
-          if (verbosity > 0)
-            {
-              cout << "Found Comment: " << FullLine << endl;
-            }
-        }
-				
-      getline( infile, FullLine );
+      AddFile(FullLine);
     }
+    else if (FullLine.size())
+    {
+      if (verbosity > 0)
+      {
+        cout << "Found Comment: " << FullLine << endl;
+      }
+    }
+
+    getline(infile, FullLine);
+  }
   infile.close();
   return 0;
 }
 
-void
-Fun4AllInputManager:: Print(const string &what) const
+void Fun4AllInputManager::Print(const string &what) const
 {
   if (what == "ALL" || what == "FILELIST")
-    {
-      cout << "--------------------------------------" << endl << endl;
-      cout << "List of input files in Fun4AllInputManager " << Name() << ":" << endl;
+  {
+    cout << "--------------------------------------" << endl
+         << endl;
+    cout << "List of input files in Fun4AllInputManager " << Name() << ":" << endl;
 
-      list<string>::const_iterator iter;
-      for (iter = filelist.begin(); iter != filelist.end(); ++iter)
-	{
-	  cout << *iter << endl;
-	}
+    list<string>::const_iterator iter;
+    for (iter = filelist.begin(); iter != filelist.end(); ++iter)
+    {
+      cout << *iter << endl;
     }
+  }
   if (what == "ALL" || what == "SUBSYSTEMS")
+  {
+    // loop over the map and print out the content (name and location in memory)
+    cout << "--------------------------------------" << endl
+         << endl;
+    cout << "List of SubsysRecos in Fun4AllInputManager " << Name() << ":" << endl;
+
+    vector<SubsysReco *>::const_iterator miter;
+    for (miter = Subsystems.begin(); miter != Subsystems.end(); ++miter)
     {
-      // loop over the map and print out the content (name and location in memory)
-      cout << "--------------------------------------" << endl << endl;
-      cout << "List of SubsysRecos in Fun4AllInputManager " << Name() << ":" << endl;
-
-      vector<SubsysReco *>::const_iterator miter;
-      for (miter = Subsystems.begin(); miter != Subsystems.end(); ++miter)
-	{
-	  cout << (*miter)->Name() << endl;
-	}
-      cout << endl;
-
+      cout << (*miter)->Name() << endl;
     }
+    cout << endl;
+  }
   return;
 }
 
-int 
-Fun4AllInputManager::registerSubsystem(SubsysReco *subsystem)
+int Fun4AllInputManager::registerSubsystem(SubsysReco *subsystem)
 {
   Fun4AllServer *se = Fun4AllServer::instance();
   int iret = subsystem->Init(se->topNode(topNodeName));
   if (iret)
-    {
-      cout << PHWHERE << " Error initializing subsystem "
-	   << subsystem->Name() << ", return code: " << iret << endl;
-      return iret;
-    }
+  {
+    cout << PHWHERE << " Error initializing subsystem "
+         << subsystem->Name() << ", return code: " << iret << endl;
+    return iret;
+  }
   if (verbosity > 0)
-    {
-      cout << "Registering Subsystem " << subsystem->Name() << endl;
-    }
+  {
+    cout << "Registering Subsystem " << subsystem->Name() << endl;
+  }
   Subsystems.push_back(subsystem);
   return 0;
 }
 
-int
-Fun4AllInputManager::RejectEvent()
+int Fun4AllInputManager::RejectEvent()
 {
   if (!Subsystems.empty())
+  {
+    Fun4AllServer *se = Fun4AllServer::instance();
+    vector<SubsysReco *>::iterator iter;
+    for (iter = Subsystems.begin(); iter != Subsystems.end(); ++iter)
     {
-      Fun4AllServer *se = Fun4AllServer::instance();
-      vector<SubsysReco *>::iterator iter;
-      for (iter = Subsystems.begin(); iter != Subsystems.end(); ++iter)
-        {
-	  if (!initrun)
-	    {
-	      (*iter)->InitRun(se->topNode(topNodeName));
-	      initrun = 1;
-	    }
-	  if (verbosity > 0)
-            {
-              cout << Name() << ": Fun4AllInpuManager::EventReject processing " << (*iter)->Name() << endl;
-            }
-          if ((*iter)->process_event(se->topNode(topNodeName)) != Fun4AllReturnCodes::EVENT_OK )
-            {
-              return Fun4AllReturnCodes::DISCARDEVENT;
-            }
-        }
+      if (!initrun)
+      {
+        (*iter)->InitRun(se->topNode(topNodeName));
+        initrun = 1;
+      }
+      if (verbosity > 0)
+      {
+        cout << Name() << ": Fun4AllInpuManager::EventReject processing " << (*iter)->Name() << endl;
+      }
+      if ((*iter)->process_event(se->topNode(topNodeName)) != Fun4AllReturnCodes::EVENT_OK)
+      {
+        return Fun4AllReturnCodes::DISCARDEVENT;
+      }
     }
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int
-Fun4AllInputManager::ResetFileList()
+int Fun4AllInputManager::ResetFileList()
 {
   if (filelist_copy.empty())
-    {
-      cout << Name() << ": ResetFileList can only be used with filelists" << endl;
-      return -1;
-    }
+  {
+    cout << Name() << ": ResetFileList can only be used with filelists" << endl;
+    return -1;
+  }
   filelist.clear();
   filelist = filelist_copy;
   return 0;

--- a/offline/framework/fun4all/Fun4AllInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllInputManager.cc
@@ -3,6 +3,8 @@
 #include "SubsysReco.h"
 #include <phool/phool.h>
 
+#include <boost/filesystem.hpp>
+
 #include <fstream>
 #include <iostream>
 
@@ -47,8 +49,36 @@ Fun4AllInputManager::AddFile(const string &filename)
 }
 
 int
-Fun4AllInputManager::AddListFile(const string &filename)
+Fun4AllInputManager::AddListFile(const string &filename, const int do_it)
 {
+// checking filesize to see if we have a text file
+  if (boost::filesystem::exists(filename.c_str()))
+  {
+    if (boost::filesystem::is_regular_file(filename.c_str()))
+    {
+      uintmax_t fsize = boost::filesystem::file_size(filename.c_str());
+      if (fsize > 1000000 && !do_it)
+      {
+	cout << "size of " << filename
+             << " is suspiciously large for a text file: "
+             << fsize << " bytes" << endl;
+      cout << "if you really want to use " << filename
+           << " as list file (it will be used as a text file containing a list of input files), use AddListFile(\""
+           << filename << "\",1)" << endl;
+      return -1;
+      }
+    }
+    else
+    {
+      cout << filename << " is not a regular file" << endl;
+      return -1;
+    }
+  }
+  else
+  {
+cout << PHWHERE << "Could not open " << filename << endl;
+return -1;
+  }
   ifstream infile;
   infile.open(filename.c_str(), ios_base::in);
   if (!infile)

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -35,7 +35,7 @@ class Fun4AllInputManager: public Fun4AllBase
   virtual int skip(const int nevt) {return PushBackEvents(-nevt);}
   virtual int NoSyncPushBackEvents(const int /*nevt*/) {return -1;}
   int AddFile(const std::string &filename);
-  int AddListFile(const std::string &filename);
+  int AddListFile(const std::string &filename, const int do_it = 0);
   int registerSubsystem(SubsysReco *subsystem);
   virtual int RejectEvent();
   void Repeat(const int i=-1) {repeat = i;}

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -13,50 +13,48 @@ class SubsysReco;
 class SyncObject;
 class Fun4AllSyncManager;
 
-class Fun4AllInputManager: public Fun4AllBase
+class Fun4AllInputManager : public Fun4AllBase
 {
  public:
-
   virtual ~Fun4AllInputManager();
-  virtual int fileopen(const std::string& /*filename*/) {return -1;}
-  virtual int fileclose() {return -1;}
-  virtual int isOpen() {return 0;}
-  virtual int run(const int /*nevents=0*/) {return -1;}
-  virtual int ReadInRunNode(PHCompositeNode* /*RunNode*/) {return -1;}
-  virtual std::string Filename() {return filename;}
-  virtual int GetSyncObject(SyncObject** /*mastersync*/) {return 0;}
-  virtual int SyncIt(const SyncObject* /*mastersync*/) {return Fun4AllReturnCodes::SYNC_FAIL;}
-  virtual int BranchSelect(const std::string& /*branch*/, const int /*iflag*/) {return -1;}
-  virtual int setBranches() {return -1;}
+  virtual int fileopen(const std::string & /*filename*/) { return -1; }
+  virtual int fileclose() { return -1; }
+  virtual int isOpen() { return 0; }
+  virtual int run(const int /*nevents=0*/) { return -1; }
+  virtual int ReadInRunNode(PHCompositeNode * /*RunNode*/) { return -1; }
+  virtual std::string Filename() { return filename; }
+  virtual int GetSyncObject(SyncObject ** /*mastersync*/) { return 0; }
+  virtual int SyncIt(const SyncObject * /*mastersync*/) { return Fun4AllReturnCodes::SYNC_FAIL; }
+  virtual int BranchSelect(const std::string & /*branch*/, const int /*iflag*/) { return -1; }
+  virtual int setBranches() { return -1; }
   virtual void Print(const std::string &what = "ALL") const;
-  virtual int PushBackEvents(const int /*nevt*/) {return -1;}
+  virtual int PushBackEvents(const int /*nevt*/) { return -1; }
   // so people can use the skip they are used to instead of PushBackEvents
   // with negative arg
-  virtual int skip(const int nevt) {return PushBackEvents(-nevt);}
-  virtual int NoSyncPushBackEvents(const int /*nevt*/) {return -1;}
+  virtual int skip(const int nevt) { return PushBackEvents(-nevt); }
+  virtual int NoSyncPushBackEvents(const int /*nevt*/) { return -1; }
   int AddFile(const std::string &filename);
   int AddListFile(const std::string &filename, const int do_it = 0);
   int registerSubsystem(SubsysReco *subsystem);
   virtual int RejectEvent();
-  void Repeat(const int i=-1) {repeat = i;}
-  virtual void setSyncManager(Fun4AllSyncManager *master) {mySyncManager = master;}
+  void Repeat(const int i = -1) { repeat = i; }
+  virtual void setSyncManager(Fun4AllSyncManager *master) { mySyncManager = master; }
   int ResetFileList();
-  virtual int ResetEvent() {return 0;}
-  virtual void SetRunNumber(const int runno) {myrunnumber = runno;}
-  virtual int RunNumber() const {return myrunnumber;}
-  void AddToFileOpened(const std::string &filename) {filelist_opened.push_back(filename);}
-  const std::list<std::string> GetFileList() const {return filelist_copy;}
-  const std::list<std::string> GetFileOpenedList() const {return filelist_opened;}
-
+  virtual int ResetEvent() { return 0; }
+  virtual void SetRunNumber(const int runno) { myrunnumber = runno; }
+  virtual int RunNumber() const { return myrunnumber; }
+  void AddToFileOpened(const std::string &filename) { filelist_opened.push_back(filename); }
+  const std::list<std::string> GetFileList() const { return filelist_copy; }
+  const std::list<std::string> GetFileOpenedList() const { return filelist_opened; }
  protected:
   Fun4AllInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
   std::vector<SubsysReco *> Subsystems;
   std::string InputNode;
   std::string filename;
   std::string topNodeName;
-  std::list<std::string>filelist;
-  std::list<std::string>filelist_copy;
-  std::list<std::string>filelist_opened;  // all files which were opened during running
+  std::list<std::string> filelist;
+  std::list<std::string> filelist_copy;
+  std::list<std::string> filelist_opened;  // all files which were opened during running
   Fun4AllSyncManager *mySyncManager;
   int repeat;
   int myrunnumber;

--- a/offline/framework/fun4all/Makefile.am
+++ b/offline/framework/fun4all/Makefile.am
@@ -72,6 +72,7 @@ libfun4all_la_LIBADD = \
   -L$(OFFLINE_MAIN)/lib \
   libSubsysReco.la \
   libTDirectoryHelper.la \
+  -lboost_filesystem \
   -lEvent \
   -lFROG \
   -lffaobjects \


### PR DESCRIPTION
Someone accidentally added a root file as list file with AddListFile(). The code interprets this as an ascii list and started filling the characters into an stl vector until the memory blew apart with 50GB. This change adds a check for the size. If it exceeds 1MB (which is a pretty large list) it returns with an error. It can be overridden if needed. Even if a binary file is used now it won't overflow the memory making this easier for the user to recognize - nice crash when running the job