### PR TITLE
Modification to allow fixed number of staves per layer in MVTX, regar…

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4MapsSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsSubsystem.cc
@@ -182,6 +182,7 @@ PHG4MapsSubsystem::SetDefaultParameters()
 //  set_default_double_param("rot_in_z",0);
   set_default_int_param("layer", layer);
   set_default_int_param("stave_type", stave_type);
+  set_default_int_param("N_staves", -1);
 
   set_default_double_param("layer_nominal_radius", NAN);
 


### PR DESCRIPTION
…dless of radius
Modified PHG4MapsSubsystem.cc and PHG4Detector.cc to allow setting a fixed number of staves in each layer, regardless of the layer radius. Previously, the number of staves was automatically calculated using a combination of the radius and the value of the arc length clearance between staves in the ALICE inner barrel. That remains the default behavior, so existing macros will still work.
The arc length clearance between staves was also adjusted to handle better the range of radius values that sPHENIX is interested in.
These changes were made as part of a study of varying the radius of the MVTX layers to give more clearance from the beam pipe.