### PR TITLE
Add PHSartre Diffractive/UPC Event Generator

### DIFF
--- a/generators/PHSartre/Makefile.am
+++ b/generators/PHSartre/Makefile.am
@@ -1,0 +1,70 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -I/opt/sphenix/core/include \
+  -I`root-config --incdir` 
+
+AM_CXXFLAGS = -Werror
+
+lib_LTLIBRARIES = libPHSartre.la 
+
+pkginclude_HEADERS = \
+  PHSartre.h \
+  PHSartreGenTrigger.h \
+  PHSartreParticleTrigger.h 
+
+libPHSartre_la_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L/opt/sphenix/core/lib \
+  `root-config --libs`
+
+libPHSartre_la_LIBADD = \
+  -lsartre \
+  -lgemini \
+  -lgsl \
+  -lgslcblas \
+  -lphool \
+  -lSubsysReco \
+  -lfun4all \
+  -lboost_iostreams \
+  -lphhepmc \
+  -lHepMC \
+  -lUnuran \
+  -lEG \
+  -lMathMore
+
+libPHSartre_la_SOURCES = \
+  PHSartre.C \
+  PHSartreGenTrigger.C \
+  PHSartreParticleTrigger.C \
+  PHSartre_Dict.C
+
+BUILT_SOURCES = \
+  testexternals.C
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_LDADD = \
+  libPHSartre.la
+
+testexternals.C:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+PHSartre_Dict.C: \
+  PHSartre.h \
+  PHSartreGenTrigger.h \
+  PHSartreParticleTrigger.h \
+  PHSartreLinkDef.h
+	rootcint -f $@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+
+clean-local:
+	rm -f *Dict*
+	rm -f testexternals*

--- a/generators/PHSartre/PHSartre.C
+++ b/generators/PHSartre/PHSartre.C
@@ -1,0 +1,511 @@
+#include "PHSartre.h"
+#include "PHSartreGenTrigger.h"
+
+#include <phhepmc/PHHepMCGenEvent.h>
+#include "CLHEP/Vector/LorentzVector.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHRandomSeed.h>
+
+#include <HepMC/GenEvent.h>
+
+#include <gsl/gsl_randist.h>
+
+#include <TString.h> // needed for Form()
+
+#include <Sartre.h>
+#include <TGenPhaseSpace.h>
+
+using namespace std;
+
+typedef PHIODataNode<PHObject> PHObjectNode_t;
+
+PHSartre::PHSartre(const std::string &name): 
+  SubsysReco(name),
+  _eventcount(0),
+  _gencount(0),
+  _node_name("PHHepMCGenEvent"),
+  _useBeamVtx(false),
+  _beamX(0),
+  _beamXsigma(0),
+  _beamY(0),
+  _beamYsigma(0),
+  _beamZ(0),
+  _beamZsigma(0),
+  _registeredTriggers(),
+  _triggersOR(true),
+  _triggersAND(false),
+  _configFile(""),
+  _commands(),
+  _phhepmcevt(NULL),
+  _sartre(NULL),
+  decay(NULL),
+  daughterID(-1),
+  daughterMasses{0.,0.},
+  doPerformDecay(false) {
+
+  RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
+  
+  char *charPath = getenv("SARTRE_DIR");
+  if (!charPath) {
+    cout << "PHSartre::Could not find $SARTRE_DIR path!" << endl;
+    return;
+  }
+
+  //
+  //  Create the generator and initialize it.
+  //  Once initialized you cannot (should not) change
+  //  the settings w/o re-initialing sartre.
+  //
+  _sartre = new Sartre();
+  
+}
+
+PHSartre::~PHSartre() {
+  gsl_rng_free (RandomGenerator);
+  delete _sartre;  
+}
+
+int PHSartre::Init(PHCompositeNode *topNode) {
+  
+  if (!_configFile.empty()){
+    bool ok = _sartre->init(_configFile);
+    if (!ok) {
+      cerr << "Initialization of sartre failed." << endl;
+      return Fun4AllReturnCodes::ABORTRUN; 
+    }
+  }
+  else{
+      cerr << "Sartre configuration file must be specified" << endl;
+      return Fun4AllReturnCodes::ABORTRUN; 
+  }
+    
+  settings = _sartre->runSettings();
+  settings->list();
+  
+  create_node_tree(topNode);
+
+  // event numbering will start from 1
+  _eventcount = 0;
+
+  decay = new TGenPhaseSpace();  // for VM decays
+  daughterID = settings->userInt();
+  if (daughterID && (settings->vectorMesonId() != 22) ) {
+    doPerformDecay = true;
+    daughterMasses[0] = settings->lookupPDG(daughterID)->Mass();
+    daughterMasses[1] = settings->lookupPDG(-daughterID)->Mass();
+    cout << "PHSartre: " << "Will decay vector meson: ";
+    cout << "PHSartre: " << settings->lookupPDG(settings->vectorMesonId())->GetName();
+    cout << "PHSartre: " << " -> ";
+    cout << "PHSartre: " << settings->lookupPDG(daughterID)->GetName();
+    cout << " ";
+    cout << "PHSartre: " << settings->lookupPDG(-daughterID)->GetName();
+    cout << endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+  
+int PHSartre::End(PHCompositeNode *topNode) {
+  
+  if (verbosity > 1) cout << "PHSartre::End - I'm here!" << endl;
+
+  cout << "PHSartre: " << " Total cross-section: " << _sartre->totalCrossSection() << " nb" << endl;
+  _sartre->listStatus();   
+
+  cout << " *-------  Begin PHSARTRE Trigger Statistics  ----------------------"
+       << "-------------------------------------------------* " << endl;
+  cout << " |                                                                "
+       << "                                                 | " << endl; 
+  cout << "                         PHSartre::End - " << _eventcount
+       << " events passed trigger" << endl;
+  cout << "                         Fraction passed: " << _eventcount
+       << "/" << _gencount
+       << " = " << _eventcount/float(_gencount) << endl;
+  cout << " *-------  End PHSARTRE Trigger Statistics  ------------------------"
+       << "-------------------------------------------------* " << endl;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+//-* print pythia config info
+void PHSartre::print_config() const {
+  settings->list();
+}
+
+int PHSartre::process_event(PHCompositeNode *topNode) {
+
+  if (verbosity > 1) cout << "PHSartre::process_event - event: " << _eventcount << endl;
+  
+  bool passedTrigger = false;
+  Event *event = NULL;
+
+  TLorentzVector *eIn     = NULL;
+  TLorentzVector *pIn     = NULL;
+  TLorentzVector *eOut    = NULL;
+  TLorentzVector *gamma   = NULL;
+  TLorentzVector *vm      = NULL;
+  TLorentzVector *PomOut  = NULL;
+  TLorentzVector *pOut    = NULL;
+  TLorentzVector *vmDecay1 = NULL; 
+  TLorentzVector *vmDecay2 = NULL; 
+  unsigned int preVMDecaySize = 0; 
+
+  while (!passedTrigger) {
+    ++_gencount;
+
+    // Generate a Sartre event
+    event = _sartre->generateEvent();
+        
+    //
+    //  If Sartre is run in UPC mode, half of the events needs to be
+    //  rotated around and axis perpendicular to z:
+    //  (only for symmetric events)
+    //
+    if(settings->UPC() and settings->A()==settings->UPCA()){
+      randomlyReverseBeams(event);
+    }
+	
+    // for sPHENIX/RHIC p+Au
+    // (see comments in ReverseBeams)
+    // reverse when the proton emits the virtual photon
+	
+    if(settings->UPC() and settings->A()==197){
+      ReverseBeams(event);
+    }
+
+    // Set pointers to the parts of the event we will need:
+
+    eIn     = &event->particles[0].p;
+    pIn     = &event->particles[1].p;
+    eOut    = &event->particles[2].p;
+    gamma   = &event->particles[3].p;
+    vm      = &event->particles[4].p;
+    PomOut  = &event->particles[5].p;
+    pOut    = &event->particles[6].p;
+
+    // To allow the triggering to work properly, we need to decay the vector meson here
+
+    preVMDecaySize = event->particles.size(); 
+
+    if(doPerformDecay) {
+
+      if( decay->SetDecay(*vm, 2, daughterMasses) ){
+	double weight = decay->Generate(); // weight is always 1 here
+	if ( (weight-1) > FLT_EPSILON) {
+	  cout << "PHSartre: Warning decay weight != 1, weight = " << weight << endl;
+	}
+	TLorentzVector *vmDaughter1 = decay->GetDecay(0);
+	TLorentzVector *vmDaughter2 = decay->GetDecay(1);
+
+	event->particles[4].status = 2; // set VM status
+
+	Particle vmDC1; 
+	vmDC1.index = event->particles.size(); 
+	vmDC1.pdgId =  daughterID; 
+	vmDC1.status = 1; // final state
+	vmDC1.p = *vmDaughter1; 
+	vmDC1.parents.push_back(4);	
+	event->particles.push_back(vmDC1); 
+	vmDecay1 = &event->particles[event->particles.size()-1].p;
+
+	Particle vmDC2; 
+	vmDC2.index = event->particles.size(); 
+	vmDC2.pdgId =  -daughterID; 
+	vmDC2.status = 1; // final state
+	vmDC2.p = *vmDaughter2; 
+	vmDC2.parents.push_back(4);	
+	event->particles.push_back(vmDC2); 
+	vmDecay2 = &event->particles[event->particles.size()-1].p;
+
+      }
+      else {
+	cout << "PHSartre: WARNING: Kinematics of Vector Meson does not allow decay!" << endl;
+      }
+
+    }
+
+    // test trigger logic
+    
+    bool andScoreKeeper = true;
+    if (verbosity > 2) {
+      cout << "PHSartre::process_event - triggersize: " << _registeredTriggers.size() << endl;
+    }
+
+    for (unsigned int tr = 0; tr < _registeredTriggers.size(); tr++) { 
+      bool trigResult = _registeredTriggers[tr]->Apply(event);
+
+      if (verbosity > 2) {
+	cout << "PHSartre::process_event trigger: "
+	     << _registeredTriggers[tr]->GetName() << "  " << trigResult << endl;
+      }
+
+      if (_triggersOR && trigResult) {
+	passedTrigger = true;
+	break;
+      } else if (_triggersAND) {
+	andScoreKeeper &= trigResult;
+      }
+      
+      if (verbosity > 2 && !passedTrigger) {
+	cout << "PHSartre::process_event - failed trigger: "
+	     << _registeredTriggers[tr]->GetName() <<  endl;
+      }
+    }
+
+    if ((andScoreKeeper && _triggersAND) || (_registeredTriggers.size() == 0)) {
+      passedTrigger = true;
+    }
+
+  }
+
+  // fill HepMC object with event
+  
+  HepMC::GenEvent *genevent = new HepMC::GenEvent(HepMC::Units::GEV, HepMC::Units::MM);
+
+  // add some information to the event
+  genevent->set_event_number(_eventcount);
+
+  // Set the PDF information
+  HepMC::PdfInfo pdfinfo;
+  pdfinfo.set_scalePDF(event->Q2);
+  genevent->set_pdf_info(pdfinfo); 
+
+  // We would also like to save:
+  //
+  // event->t;
+  // event->x;
+  // event->y;
+  // event->s;
+  // event->W;
+  // event->xpom;
+  // (event->polarization == transverse ? 0 : 1);
+  // (event->diffractiveMode == coherent ? 0 : 1);
+  // 
+  // but there doesn't seem to be a good place to do so 
+  // within the HepMC event information?
+  //
+  // t, W and Q^2 form a minial set of good variables for diffractive events
+  // Maybe what I do is record the input particles to the event at the HepMC
+  // vertices and reconstruct the kinematics from there? 
+  
+  // Create HepMC vertices and add final state particles to them
+
+  // First, the emitter(electron)-virtual photon vertex:
+
+  HepMC::GenVertex* egammavtx = new HepMC::GenVertex(CLHEP::HepLorentzVector(0.0,0.0,0.0,0.0));
+  genevent->add_vertex(egammavtx); 
+
+  egammavtx->add_particle_in( 
+			 new HepMC::GenParticle( CLHEP::HepLorentzVector(eIn->Px(),
+									 eIn->Py(),
+									 eIn->Pz(),
+									 eIn->E()), 
+						 event->particles[0].pdgId, 
+						 3 ) 
+			  );
+
+  HepMC::GenParticle *hgamma =  new HepMC::GenParticle( CLHEP::HepLorentzVector(gamma->Px(),
+									 gamma->Py(),
+									 gamma->Pz(),
+									 gamma->E()), 
+						event->particles[3].pdgId, 
+						3 ); 
+
+  egammavtx->add_particle_out(hgamma);
+
+  egammavtx->add_particle_out( 
+			 new HepMC::GenParticle( CLHEP::HepLorentzVector(eOut->Px(),
+									 eOut->Py(),
+									 eOut->Pz(),
+									 eOut->E()), 
+						 event->particles[2].pdgId, 
+						 1 ) 
+			  );
+
+  // Next, the hadron-pomeron vertex:
+
+  HepMC::GenVertex* ppomvtx = new HepMC::GenVertex(CLHEP::HepLorentzVector(0.0,0.0,0.0,0.0));
+  genevent->add_vertex(ppomvtx); 
+
+
+  ppomvtx->add_particle_in( 
+			 new HepMC::GenParticle( CLHEP::HepLorentzVector(pIn->Px(),
+									 pIn->Py(),
+									 pIn->Pz(),
+									 pIn->E()), 
+						 event->particles[1].pdgId, 
+						 3 ) 
+			     );
+
+  HepMC::GenParticle *hPomOut = new HepMC::GenParticle( CLHEP::HepLorentzVector(PomOut->Px(),
+									 PomOut->Py(),
+									 PomOut->Pz(),
+									 PomOut->E()), 
+						 event->particles[5].pdgId, 
+						 3 ); 
+
+  ppomvtx->add_particle_out(hPomOut); 
+
+  // If this is a nuclear breakup, add in the nuclear fragments
+  // Otherwise, add in the outgoing hadron
+        
+  //If the event is incoherent, and nuclear breakup is enabled, fill the remnants to the tree
+  if(settings->enableNuclearBreakup() and event->diffractiveMode == incoherent){
+    for(unsigned int iParticle=7; iParticle < preVMDecaySize; iParticle++){
+      if(event->particles[iParticle].status == 1) {  // Final-state particle
+	const Particle& particle = event->particles[iParticle];	  
+	ppomvtx->add_particle_out( 
+			       new HepMC::GenParticle( CLHEP::HepLorentzVector(particle.p.Px(),
+								 particle.p.Py(),
+								 particle.p.Pz(),
+								 particle.p.E()), 
+						particle.pdgId, 
+						1 ) 
+				);
+      }  
+    }  
+  }
+  else{
+
+    ppomvtx->add_particle_out( 
+			      new HepMC::GenParticle( CLHEP::HepLorentzVector(pOut->Px(),
+									      pOut->Py(),
+									      pOut->Pz(),
+									      pOut->E()), 
+						      event->particles[6].pdgId, 
+						      1 ) 
+			       );
+  }
+
+  // The Pomeron-Photon vertex
+
+  HepMC::GenVertex* gammapomvtx = new HepMC::GenVertex(CLHEP::HepLorentzVector(0.0,0.0,0.0,0.0));
+  genevent->add_vertex(gammapomvtx); 
+  
+  gammapomvtx->add_particle_in(hgamma); 
+  gammapomvtx->add_particle_in(hPomOut); 
+
+  int isVMFinal = 1; 
+  if(doPerformDecay) isVMFinal = 2; 
+
+  HepMC::GenParticle *hvm = new HepMC::GenParticle( CLHEP::HepLorentzVector(vm->Px(),
+									    vm->Py(),
+									    vm->Pz(),
+									    vm->E()), 
+						   event->particles[4].pdgId, 
+						   isVMFinal ) ; 
+
+  gammapomvtx->add_particle_out( hvm );
+ 
+  // Add the VM decay to the event
+
+  if(doPerformDecay) {
+
+    if(vmDecay1 && vmDecay2){
+
+      HepMC::GenVertex* fvtx = new HepMC::GenVertex(CLHEP::HepLorentzVector(0.0,0.0,0.0,0.0));
+      genevent->add_vertex(fvtx); 
+
+      fvtx->add_particle_in( hvm ); 
+
+      fvtx->add_particle_out( 
+			 new HepMC::GenParticle( CLHEP::HepLorentzVector(vmDecay1->Px(),
+							   vmDecay1->Py(),
+							   vmDecay1->Pz(),
+							   vmDecay1->E()), 
+					  daughterID, 
+					  1 ) 
+			  );
+      fvtx->add_particle_out( 
+			 new HepMC::GenParticle( CLHEP::HepLorentzVector(vmDecay2->Px(),
+							   vmDecay2->Py(),
+							   vmDecay2->Pz(),
+							   vmDecay2->E()), 
+					  -daughterID, 
+					  1 ) 
+			  );
+
+    }
+    else {
+      cout << "PHSartre: WARNING: Kinematics of Vector Meson does not allow decay!" << endl;
+    }
+
+  }
+
+  // pass HepMC to PHNode
+  
+  bool success = _phhepmcevt->addEvent(genevent);
+  if (!success) {
+    cout << "PHSartre::process_event - Failed to add event to HepMC record!" << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  // shift node if needed  
+  if (_useBeamVtx) {
+    double mvVtxX = gsl_ran_gaussian(RandomGenerator,_beamXsigma) + _beamX;
+    double mvVtxY = gsl_ran_gaussian(RandomGenerator,_beamYsigma) + _beamY;
+    double mvVtxZ = gsl_ran_gaussian(RandomGenerator,_beamZsigma) + _beamZ;
+    _phhepmcevt->moveVertex(mvVtxX,mvVtxY,mvVtxZ,0.0);
+  }
+
+  // print outs
+  
+  if (verbosity > 2) cout << "PHSartre::process_event - FINISHED WHOLE EVENT" << endl;
+
+  ++_eventcount;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHSartre::create_node_tree(PHCompositeNode *topNode) {
+
+  PHCompositeNode *dstNode;
+  PHNodeIterator iter(topNode);
+
+  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode) {
+    cout << PHWHERE << "DST Node missing doing nothing" << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  _phhepmcevt = new PHHepMCGenEvent();
+  PHObjectNode_t *newNode = new PHObjectNode_t(_phhepmcevt,_node_name.c_str(),"PHObject");
+  dstNode->addNode(newNode);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHSartre::ResetEvent(PHCompositeNode *topNode) {
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void PHSartre::register_trigger(PHSartreGenTrigger *theTrigger) {
+  if(verbosity > 1) cout << "PHSartre::registerTrigger - trigger " << theTrigger->GetName() << " registered" << endl;
+  _registeredTriggers.push_back(theTrigger);
+}
+
+// UPC only
+void PHSartre::randomlyReverseBeams(Event* myEvent){
+        
+    if(gsl_rng_uniform(RandomGenerator) > 0.5){
+        for(unsigned int i=0; i<myEvent->particles.size(); i++)
+            myEvent->particles.at(i).p.RotateX(M_PI);
+    }
+}
+
+// Used to rotate into the sPHENIX/RHIC frame 
+// The photon emitting beam is always pz<0, and in sPHENIX this will be 
+// the ion direction. So what you want to run are two files with:
+// A=1 UPCA=197 (no reversal, Au ion emits photon)
+// A=197 UPCA=1 (reversal required, proton emits photon)
+void PHSartre::ReverseBeams(Event* myEvent){
+    
+  for(unsigned int i=0; i<myEvent->particles.size(); i++)
+    myEvent->particles.at(i).p.RotateX(M_PI);
+
+}
+

--- a/generators/PHSartre/PHSartre.h
+++ b/generators/PHSartre/PHSartre.h
@@ -1,0 +1,120 @@
+#ifndef __PHSARTRE_H__
+#define __PHSARTRE_H__
+
+#include <fun4all/SubsysReco.h>
+#include <phhepmc/PHHepMCGenEvent.h>
+
+#ifndef __CINT__
+#include <Pythia8/Pythia.h>
+#endif
+
+#ifndef __CINT__
+#include <gsl/gsl_rng.h>
+#endif
+
+#include <iostream>
+#include <string>
+
+class PHCompositeNode;
+class PHHepMCGenEvent;
+class PHHepMCFilter;
+
+class Sartre; 
+class Event; 
+class EventGeneratorSettings; 
+class PHSartreGenTrigger;
+class TGenPhaseSpace; 
+
+namespace HepMC {
+  class GenEvent;
+};
+
+class PHSartre: public SubsysReco {
+  
+public:
+  
+  PHSartre(const std::string &name = "PHSartre");
+  virtual ~PHSartre();
+
+  int Init(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode); 
+  int ResetEvent(PHCompositeNode *topNode); 
+  int End(PHCompositeNode *topNode);
+  
+  void set_config_file( const char* cfg_file ) {
+    if ( cfg_file ) _configFile = cfg_file;
+  }
+
+  void print_config() const;
+
+  /// set event selection criteria
+  void register_trigger(PHSartreGenTrigger *theTrigger);
+  void set_trigger_OR() { _triggersOR = true; _triggersAND = false; } // default true
+  void set_trigger_AND() { _triggersAND = true; _triggersOR = false; }
+
+  /// pass commands directly to PYTHIA8
+  void process_string(std::string s) {_commands.push_back(s);}
+  
+  void set_node_name(std::string s) {_node_name = s;}
+
+  void beam_vertex_parameters(double beamX,
+			      double beamY,
+			      double beamZ,
+			      double beamXsigma,
+			      double beamYsigma,
+			      double beamZsigma) {
+    _useBeamVtx = true;
+    _beamX = beamX;
+    _beamY = beamY;
+    _beamZ = beamZ;    
+    _beamXsigma = beamXsigma;
+    _beamYsigma = beamYsigma;
+    _beamZsigma = beamZsigma;
+  }
+
+private:
+
+  int create_node_tree(PHCompositeNode *topNode);
+  double percent_diff(const double a, const double b){return abs((a-b)/a);}
+  void randomlyReverseBeams(Event* myEvent);
+  void ReverseBeams(Event* myEvent);
+  
+  int _eventcount;
+  int _gencount; 
+
+  // output
+  std::string _node_name;
+
+  // vertex placement
+  bool _useBeamVtx;
+  double _beamX, _beamXsigma;
+  double _beamY, _beamYsigma;
+  double _beamZ, _beamZsigma;
+
+  // event selection
+  std::vector<PHSartreGenTrigger*> _registeredTriggers;
+  bool _triggersOR;
+  bool _triggersAND;
+  
+  std::string _configFile;
+  std::vector<std::string> _commands;
+  
+  // HepMC
+  PHHepMCGenEvent *_phhepmcevt;
+
+  // Sartre
+  Sartre *_sartre;
+  EventGeneratorSettings* settings;   
+  TGenPhaseSpace *decay; 
+  int daughterID;
+  double daughterMasses[2];
+  bool doPerformDecay;
+  
+
+#ifndef __CINT__
+  gsl_rng *RandomGenerator;
+#endif
+};
+
+#endif	/* __PHSARTRE_H__ */
+

--- a/generators/PHSartre/PHSartreGenTrigger.C
+++ b/generators/PHSartre/PHSartreGenTrigger.C
@@ -1,0 +1,32 @@
+#include "PHSartreGenTrigger.h"
+
+#include <Sartre.h>
+
+#include <iterator>
+
+using namespace std;
+
+//__________________________________________________________
+PHSartreGenTrigger::PHSartreGenTrigger(const std::string &name):
+  _verbosity(0),
+  _name(name)
+ {}
+
+//__________________________________________________________
+PHSartreGenTrigger::~PHSartreGenTrigger() {}
+
+std::vector<int> PHSartreGenTrigger::convertToInts(std::string s) {
+  
+  vector<int> theVec;
+  stringstream ss(s);
+  int i;  
+  while (ss >> i) {
+    theVec.push_back(i);
+    if (ss.peek() == ',' ||
+	ss.peek() == ' ' ||
+	ss.peek() == ':' ||
+	ss.peek() == ';') ss.ignore();
+  }
+
+  return theVec;
+}

--- a/generators/PHSartre/PHSartreGenTrigger.h
+++ b/generators/PHSartre/PHSartreGenTrigger.h
@@ -1,0 +1,41 @@
+#ifndef __PHSARTREGENTRIGGER_H__
+#define __PHSARTREGENTRIGGER_H__
+
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <vector>
+
+class Event;
+
+class PHSartreGenTrigger {
+
+ protected:  
+  //! constructor
+  PHSartreGenTrigger(const std::string &name = "PHSartreGenTrigger");
+
+ public:
+  virtual ~PHSartreGenTrigger();
+
+  #ifndef __CINT__
+  virtual bool Apply(Event *event) {
+    std::cout << "PHSartreGenTrigger::Apply - in virtual function" << std::endl;
+    return false;
+  }
+  #endif
+
+  virtual std::string GetName() { return _name; }
+  
+  std::vector<int> convertToInts(std::string s);
+
+  void Verbosity(int v) { _verbosity = v; }
+
+protected:
+  int _verbosity;  
+  
+private:
+  std::string _name;
+};
+
+#endif	
+

--- a/generators/PHSartre/PHSartreLinkDef.h
+++ b/generators/PHSartre/PHSartreLinkDef.h
@@ -1,0 +1,7 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHSartre-!;
+#pragma link C++ class PHSartreGenTrigger-!;
+#pragma link C++ class PHSartreParticleTrigger-!;
+
+#endif

--- a/generators/PHSartre/PHSartreParticleTrigger.C
+++ b/generators/PHSartre/PHSartreParticleTrigger.C
@@ -1,0 +1,279 @@
+#include "PHSartreParticleTrigger.h"
+
+#include <Sartre.h>
+
+using namespace std;
+
+//__________________________________________________________
+PHSartreParticleTrigger::PHSartreParticleTrigger(const std::string &name):
+  PHSartreGenTrigger(name),
+  _theEtaHigh(-999.9),
+  _theEtaLow(-999.9),
+  _thePtHigh(999.9),
+  _thePtLow(-999.9),
+  _thePHigh(999.9),
+  _thePLow(-999.9),
+  _thePzHigh(999.9),
+  _thePzLow(-999.9),
+
+  _doEtaHighCut(false),
+  _doEtaLowCut(false),
+  _doBothEtaCut(false),
+
+  _doAbsEtaHighCut(false),
+  _doAbsEtaLowCut(false),
+  _doBothAbsEtaCut(false),
+
+  _doPtHighCut(false),
+  _doPtLowCut(false),
+  _doBothPtCut(false),
+
+  _doPHighCut(false),
+  _doPLowCut(false),
+  _doBothPCut(false),
+
+  _doPzHighCut(false),
+  _doPzLowCut(false),
+  _doBothPzCut(false)
+{}
+
+PHSartreParticleTrigger::~PHSartreParticleTrigger() {
+  if (_verbosity > 0) PrintConfig();
+}
+
+bool PHSartreParticleTrigger::Apply(Event *event) {
+
+  if (_verbosity > 2) {
+    cout << "PHSartreParticleTrigger::Apply - event size: "
+  	 << event->particles.size() << endl;
+  }
+  
+  // Loop over all particles in the event
+  for (unsigned int i = 0; i < event->particles.size(); ++i) {
+    
+    //cout << i << " " << event->particles[i].pdgId << endl; 
+
+    if( (i<7) && (i!=4) ) continue; // only the VM, daughters OR the nuclear remnants 
+
+    const Particle& particle = event->particles[i];	  
+
+    // loop over all the trigger particle criteria
+    for (int j = 0; j < int(_theParticles.size()); j++) {
+	
+      if ( (particle.pdgId == _theParticles[j]) &&
+  	   ((particle.status==1)||(i==4)) ) { //only stable particles OR the vector meson
+	
+  	if (_doBothEtaCut && (particle.p.Eta() < _theEtaLow ||
+  			      particle.p.Eta() > _theEtaHigh)) continue;
+  	if (_doEtaLowCut && particle.p.Eta() < _theEtaLow) continue;
+  	if (_doEtaHighCut && particle.p.Eta() > _theEtaHigh) continue;
+
+  	if (_doBothAbsEtaCut && (abs(particle.p.Eta()) < _theEtaLow ||
+  				 abs(particle.p.Eta()) > _theEtaHigh)) continue;
+  	if (_doAbsEtaLowCut && abs(particle.p.Eta()) < _theEtaLow) continue;
+  	if (_doAbsEtaHighCut && abs(particle.p.Eta()) > _theEtaHigh) continue;
+
+  	if (_doBothPtCut && (particle.p.Pt() < _thePtLow ||
+  			     particle.p.Pt() > _thePtHigh)) continue;
+  	if (_doPtHighCut && particle.p.Pt() > _thePtHigh ) continue;
+  	if (_doPtLowCut && particle.p.Pt() < _thePtLow) continue;
+
+  	if (_doBothPCut && (particle.p.P() < _thePLow ||
+  			    particle.p.P() > _thePHigh)) continue;
+  	if (_doPHighCut && particle.p.P() > _thePHigh ) continue;
+  	if (_doPLowCut && particle.p.P() < _thePLow) continue;
+
+  	if (_doBothPzCut && (particle.p.Pz() < _thePzLow ||
+  			     particle.p.Pz() > _thePzHigh)) continue;
+  	if (_doPzHighCut && particle.p.Pz() > _thePzHigh ) continue;
+  	if (_doPzLowCut && particle.p.Pz() < _thePzLow) continue;
+
+  	//If we made it here, success!
+        return true; 
+	
+      }//if _theParticles
+    }//_theParticles for loop
+    
+  }
+
+  return false;
+}
+
+void PHSartreParticleTrigger::AddParticles(std::string particles) {
+  std::vector<int> addedParts = convertToInts(particles);
+  _theParticles.insert(_theParticles.end(),addedParts.begin(),addedParts.end());
+}
+
+void PHSartreParticleTrigger::AddParticles(int particle) {
+  _theParticles.push_back(particle);
+}
+
+void PHSartreParticleTrigger::AddParticles(std::vector<int> particles) {
+  _theParticles.insert(_theParticles.end(),particles.begin(),particles.end());
+}
+
+void PHSartreParticleTrigger::SetPtHigh(double pt) {
+  _thePtHigh = pt;
+  if (_doPtLowCut) _doBothPtCut = true;
+  else _doPtHighCut = true;
+}
+
+void PHSartreParticleTrigger::SetPtLow(double pt) {
+  _thePtLow = pt;
+  if (_doPtHighCut) _doBothPtCut = true;
+  else _doPtLowCut = true;
+}
+
+void PHSartreParticleTrigger::SetPtHighLow(double ptHigh, double ptLow) {
+  if (ptHigh < ptLow) {
+    _thePtHigh = ptLow;
+    _thePtLow = ptHigh;
+  } else {
+    _thePtHigh = ptHigh;
+    _thePtLow = ptLow;
+  }
+  _doBothPtCut = true;
+  _doPtLowCut = false;
+  _doPtHighCut = false;
+}
+
+void PHSartreParticleTrigger::SetPHigh(double p) {
+  _thePHigh = p;
+  if (_doPLowCut) {
+    _doBothPCut = true;
+    _doPLowCut = false;
+  } else {
+    _doPHighCut = true;
+  }
+}
+
+void PHSartreParticleTrigger::SetPLow(double p) {
+  _thePLow = p;
+  if (_doPHighCut) {
+    _doBothPCut = true;
+    _doPHighCut = false;
+  } else {
+    _doPLowCut = true;
+  }
+}
+
+void PHSartreParticleTrigger::SetPHighLow(double pHigh, double pLow) {
+  if (pHigh < pLow) {
+    _thePHigh = pLow;
+    _thePLow= pHigh;
+  } else {
+    _thePHigh = pHigh;
+    _thePLow = pLow;
+  }
+  _doBothPCut = true;
+  _doPLowCut = false;
+  _doPHighCut = false;
+}
+
+void PHSartreParticleTrigger::SetEtaHigh(double eta) {
+  _theEtaHigh = eta;
+  if (_doEtaLowCut) {
+    _doBothEtaCut = true;
+    _doEtaLowCut = false;
+  } else {
+    _doEtaHighCut = true;
+  }
+}
+  
+void PHSartreParticleTrigger::SetEtaLow(double eta) {
+  _theEtaLow = eta;
+  if (_doEtaHighCut) {
+    _doBothEtaCut = true;
+    _doEtaHighCut = false;
+  } else {
+    _doEtaLowCut = true;
+  }
+}
+  
+void PHSartreParticleTrigger::SetEtaHighLow(double etaHigh, double etaLow) {
+  _theEtaHigh = etaHigh;
+  _theEtaLow = etaLow;
+  _doBothEtaCut = true;
+  _doEtaHighCut = false;
+  _doEtaLowCut = false;
+}
+
+void PHSartreParticleTrigger::SetAbsEtaHigh(double eta) {
+  _theEtaHigh = eta;
+  if (_doAbsEtaLowCut) {
+    _doBothAbsEtaCut = true;
+    _doAbsEtaLowCut = false;
+  } else {
+    _doAbsEtaHighCut = true;
+  }
+}
+
+void PHSartreParticleTrigger::SetAbsEtaLow(double eta) {
+  _theEtaLow = eta;
+  if (_doAbsEtaHighCut) {
+    _doBothAbsEtaCut = true;
+    _doAbsEtaHighCut = false;
+  } else {
+    _doAbsEtaLowCut = true;
+  }
+}
+
+void PHSartreParticleTrigger::SetAbsEtaHighLow(double etaHigh, double etaLow) {
+  _theEtaHigh = etaHigh;
+  _theEtaLow = etaLow;
+  _doBothAbsEtaCut = true;
+  _doAbsEtaLowCut = false;
+  _doAbsEtaHighCut = false;
+}
+
+void PHSartreParticleTrigger::SetPzHigh(double pz) {
+  _thePzHigh = pz;
+  if (_doPzLowCut) {
+    _doBothPzCut = true;
+    _doPzLowCut = false;
+  } else {
+    _doPzHighCut = true;
+  }
+}
+
+void PHSartreParticleTrigger::SetPzLow(double pz) {
+  _thePzLow = pz;
+  if (_doPzHighCut) {
+    _doBothPzCut = true;
+    _doPzHighCut = false;
+  } else {
+    _doPzLowCut = true;
+  }
+}
+
+void PHSartreParticleTrigger::SetPzHighLow(double pzHigh, double pzLow) {
+  if (pzHigh < pzLow) {
+    _thePzHigh = pzLow;
+    _thePzLow= pzHigh;
+  } else {
+    _thePzHigh = pzHigh;
+    _thePzLow = pzLow;
+  }
+  _doBothPzCut = true;
+  _doPzLowCut = false;
+  _doPzHighCut = false;
+}
+
+void PHSartreParticleTrigger::PrintConfig() {
+  cout << "---------------- PHSartreParticleTrigger::PrintConfig --------------------" << endl;
+  cout << "   Particles: ";
+  for (int i = 0; i < int(_theParticles.size()); i++) cout << _theParticles[i] << "  ";
+  cout << endl;
+
+  if (_doEtaHighCut||_doEtaLowCut||_doBothEtaCut)
+    cout << "   doEtaCut:  " << _theEtaLow << " < eta < " << _theEtaHigh << endl; 
+  if (_doAbsEtaHighCut||_doAbsEtaLowCut||_doBothAbsEtaCut)
+    cout << "   doAbsEtaCut:  " << _theEtaLow << " < |eta| < " << _theEtaHigh << endl; 
+  if (_doPtHighCut||_doPtLowCut||_doBothPtCut)
+    cout << "   doPtCut:  " << _thePtLow << " < pT < " << _thePtHigh << endl; 
+  if (_doPHighCut||_doPLowCut||_doBothPCut)
+    cout << "   doPCut:  " << _thePLow << " < p < " << _thePHigh << endl; 
+  if (_doPzHighCut||_doPzLowCut||_doBothPzCut)
+    cout << "   doPzCut:  " << _thePzLow << " < pz < " << _thePzHigh << endl; 
+  cout << "-----------------------------------------------------------------------" << endl;
+}

--- a/generators/PHSartre/PHSartreParticleTrigger.h
+++ b/generators/PHSartre/PHSartreParticleTrigger.h
@@ -1,0 +1,62 @@
+#ifndef __PHSARTREPARTICLETRIGGER_H__
+#define __PHSARTREPARTICLETRIGGER_H__
+
+#include "PHSartreGenTrigger.h"
+#include <string>
+
+class Event;
+
+class PHSartreParticleTrigger : public PHSartreGenTrigger {
+
+ public:
+
+  PHSartreParticleTrigger(const std::string &name = "PHSartreParticleTrigger");
+  virtual ~PHSartreParticleTrigger();
+
+  #ifndef __CINT__
+  bool Apply(Event *event);
+  #endif
+
+  void AddParticles(std::string particles);
+  void AddParticles(int particle);
+  void AddParticles(std::vector<int> particles);
+
+  void SetPtHigh(double pt);
+  void SetPtLow(double pt);
+  void SetPtHighLow(double ptHigh, double ptLow);
+  
+  void SetPHigh(double p);
+  void SetPLow(double p);
+  void SetPHighLow(double pHigh, double pLow);
+
+  void SetEtaHigh(double eta);
+  void SetEtaLow(double eta);
+  void SetEtaHighLow(double etaHigh, double etaLow);
+
+  void SetAbsEtaHigh(double eta);
+  void SetAbsEtaLow(double eta);
+  void SetAbsEtaHighLow(double etaHigh, double etaLow);
+
+  void SetPzHigh(double pz);
+  void SetPzLow(double pz);
+  void SetPzHighLow(double pzHigh, double pzLow);
+
+  void PrintConfig();
+
+ private:
+
+  std::vector<int> _theParticles;
+
+  double _theEtaHigh, _theEtaLow;
+  double _thePtHigh, _thePtLow;
+  double _thePHigh, _thePLow;
+  double _thePzHigh, _thePzLow;
+  
+  bool _doEtaHighCut, _doEtaLowCut, _doBothEtaCut;
+  bool _doAbsEtaHighCut, _doAbsEtaLowCut, _doBothAbsEtaCut;
+  bool _doPtHighCut, _doPtLowCut, _doBothPtCut;
+  bool _doPHighCut, _doPLowCut, _doBothPCut;
+  bool _doPzHighCut, _doPzLowCut, _doBothPzCut;
+};
+
+#endif	

--- a/generators/PHSartre/README
+++ b/generators/PHSartre/README
@@ -1,0 +1,14 @@
+to get started
+
+add to .cshrc
+ setenv SARTRE_DIR /opt/sphenix/core/stow/sartre-1.20
+
+login in a new window
+cp the sartre.cfg to working area
+
+you will need to add the HepMC node reader after the PHSartre
+to feed the hepmc node into GEANT4
+
+for documentation on configuring Sartre, see 
+
+http://sartre.hepforge.org/

--- a/generators/PHSartre/autogen.sh
+++ b/generators/PHSartre/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"
+

--- a/generators/PHSartre/configure.ac
+++ b/generators/PHSartre/configure.ac
@@ -1,0 +1,16 @@
+AC_INIT(PHSartre,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+AM_INIT_AUTOMAKE
+
+AC_PROG_CXX(CC g++)
+LT_INIT([disable-static])
+
+dnl   no point in suppressing warnings people should
+dnl   at least see them, so here we go for g++: -Wall
+dnl   make warnings fatal errors: -Werror
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall"
+fi
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/generators/PHSartre/sartre.cfg
+++ b/generators/PHSartre/sartre.cfg
@@ -1,0 +1,113 @@
+//==============================================================================
+//  sartreRuncard.txt
+//
+//  Copyright (C) 2010-2013 Tobias Toll and Thomas Ullrich 
+//
+//  This file is part of Sartre version: 1.1
+//
+//  This program is free software: you can redistribute it and/or modify 
+//  it under the terms of the GNU General Public License as published by 
+//  the Free Software Foundation.   
+//  This program is distributed in the hope that it will be useful, 
+//  but without any warranty; without even the implied warranty of 
+//  merchantability or fitness for a particular purpose. See the 
+//  GNU General Public License for more details. 
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//  Author: Thomas Ullrich 
+//  Last update: 
+//  $Date: 2015-05-29 13:37:30 -0400 (Fri, 29 May 2015) $
+//  $Author: tobilibob@gmail.com $
+//==============================================================================
+// 
+//  Example Runcard for Sartre Event Generator. 
+// 
+//  Comments start with a # or // 
+// 
+//  Name and value are separated by a "=":  name = value 
+//  (alternatively ":" can be used as well) 
+//==============================================================================  
+# 
+#  Define beams 
+# 
+eBeamEnergy =  100
+hBeamEnergy =  100  
+A           =  197
+
+# 
+# UPC settings, to run in UPC mode set UPC=true and UPCA into the photon emitting species:
+#
+UPC=true
+UPCA=1
+
+# 
+#  Number of events and printout frequency 
+# 
+numberOfEvents =  100000
+timesToShow    =  20
+ 
+# 
+#  Set verbosity 
+# 
+verbose       =  false 
+verboseLevel  =  0
+ 
+# 
+#  Rootfile  
+# 
+rootfile =  example.root 
+ 
+# 
+#  Model parameters 
+# 
+#  vectorMesonID: 22, 113, 333, 443
+#  dipoleModel: bSat or bNonSat
+#
+vectorMesonId =  443
+#dipoleModel =  bSat 
+dipoleModel =  bNonSat 
+ 
+# 
+# User variable used for vector meson decays 
+# PDG: pi+ = 211, K+ = 321, e- = 11, mu- = 13  
+#
+userInt = 11
+
+# 
+#  Kinematic range min > max means no limits (given by table range) 
+# 
+Q2min =  1000000
+Q2max =  0
+Wmin  =  1000000
+Wmax  =  0
+ 
+# 
+#  Corrections 
+# 
+correctForRealAmplitude =  true
+correctSkewedness       =  true
+# maxLambdaUsedInCorrections = 0.65
+ 
+# 
+#  Misc 
+# 
+enableNuclearBreakup = false
+maxNuclearExcitationEnergy = 0.5
+ 
+# 
+#  Random generator seed (if not given current time is used) 
+# 
+#seed =  2011987 
+
+# 
+#  User parameters 
+# 
+# userDouble = 0.
+# userString = "Hello World!"
+# userInt = 0
+
+#
+#  Expert flags
+#
+# applyPhotonFlux = true

--- a/generators/PHSartre/sartreRuncard_pAu_Au_emits.txt
+++ b/generators/PHSartre/sartreRuncard_pAu_Au_emits.txt
@@ -1,0 +1,113 @@
+//==============================================================================
+//  sartreRuncard.txt
+//
+//  Copyright (C) 2010-2013 Tobias Toll and Thomas Ullrich 
+//
+//  This file is part of Sartre version: 1.1
+//
+//  This program is free software: you can redistribute it and/or modify 
+//  it under the terms of the GNU General Public License as published by 
+//  the Free Software Foundation.   
+//  This program is distributed in the hope that it will be useful, 
+//  but without any warranty; without even the implied warranty of 
+//  merchantability or fitness for a particular purpose. See the 
+//  GNU General Public License for more details. 
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//  Author: Thomas Ullrich 
+//  Last update: 
+//  $Date: 2015-05-29 13:37:30 -0400 (Fri, 29 May 2015) $
+//  $Author: tobilibob@gmail.com $
+//==============================================================================
+// 
+//  Example Runcard for Sartre Event Generator. 
+// 
+//  Comments start with a # or // 
+// 
+//  Name and value are separated by a "=":  name = value 
+//  (alternatively ":" can be used as well) 
+//==============================================================================  
+# 
+#  Define beams 
+# 
+eBeamEnergy =  100
+hBeamEnergy =  100  
+A           =  1
+
+# 
+# UPC settings, to run in UPC mode set UPC=true and UPCA into the photon emitting species:
+#
+UPC=true
+UPCA=197
+
+# 
+#  Number of events and printout frequency 
+# 
+numberOfEvents =  100000
+timesToShow    =  20
+ 
+# 
+#  Set verbosity 
+# 
+verbose       =  false 
+verboseLevel  =  0
+ 
+# 
+#  Rootfile  
+# 
+rootfile =  example.root 
+ 
+# 
+#  Model parameters 
+# 
+#  vectorMesonID: 22, 113, 333, 443
+#  dipoleModel: bSat or bNonSat
+#
+vectorMesonId =  443
+#dipoleModel =  bSat 
+dipoleModel =  bNonSat 
+ 
+# 
+# User variable used for vector meson decays 
+# PDG: pi+ = 211, K+ = 321, e- = 11, mu- = 13  
+#
+userInt = 11
+
+# 
+#  Kinematic range min > max means no limits (given by table range) 
+# 
+Q2min =  1000000
+Q2max =  0
+Wmin  =  1000000
+Wmax  =  0
+ 
+# 
+#  Corrections 
+# 
+correctForRealAmplitude =  true
+correctSkewedness       =  true
+# maxLambdaUsedInCorrections = 0.65
+ 
+# 
+#  Misc 
+# 
+enableNuclearBreakup = false
+maxNuclearExcitationEnergy = 0.5
+ 
+# 
+#  Random generator seed (if not given current time is used) 
+# 
+#seed =  2011987 
+
+# 
+#  User parameters 
+# 
+# userDouble = 0.
+# userString = "Hello World!"
+# userInt = 0
+
+#
+#  Expert flags
+#
+# applyPhotonFlux = true

--- a/generators/PHSartre/sartreRuncard_pAu_p_emits.txt
+++ b/generators/PHSartre/sartreRuncard_pAu_p_emits.txt
@@ -1,0 +1,113 @@
+//==============================================================================
+//  sartreRuncard.txt
+//
+//  Copyright (C) 2010-2013 Tobias Toll and Thomas Ullrich 
+//
+//  This file is part of Sartre version: 1.1
+//
+//  This program is free software: you can redistribute it and/or modify 
+//  it under the terms of the GNU General Public License as published by 
+//  the Free Software Foundation.   
+//  This program is distributed in the hope that it will be useful, 
+//  but without any warranty; without even the implied warranty of 
+//  merchantability or fitness for a particular purpose. See the 
+//  GNU General Public License for more details. 
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//  Author: Thomas Ullrich 
+//  Last update: 
+//  $Date: 2015-05-29 13:37:30 -0400 (Fri, 29 May 2015) $
+//  $Author: tobilibob@gmail.com $
+//==============================================================================
+// 
+//  Example Runcard for Sartre Event Generator. 
+// 
+//  Comments start with a # or // 
+// 
+//  Name and value are separated by a "=":  name = value 
+//  (alternatively ":" can be used as well) 
+//==============================================================================  
+# 
+#  Define beams 
+# 
+eBeamEnergy =  100
+hBeamEnergy =  100  
+A           =  197
+
+# 
+# UPC settings, to run in UPC mode set UPC=true and UPCA into the photon emitting species:
+#
+UPC=true
+UPCA=1
+
+# 
+#  Number of events and printout frequency 
+# 
+numberOfEvents =  100000
+timesToShow    =  20
+ 
+# 
+#  Set verbosity 
+# 
+verbose       =  false 
+verboseLevel  =  0
+ 
+# 
+#  Rootfile  
+# 
+rootfile =  example.root 
+ 
+# 
+#  Model parameters 
+# 
+#  vectorMesonID: 22, 113, 333, 443
+#  dipoleModel: bSat or bNonSat
+#
+vectorMesonId =  443
+#dipoleModel =  bSat 
+dipoleModel =  bNonSat 
+ 
+# 
+# User variable used for vector meson decays 
+# PDG: pi+ = 211, K+ = 321, e- = 11, mu- = 13  
+#
+userInt = 11
+
+# 
+#  Kinematic range min > max means no limits (given by table range) 
+# 
+Q2min =  1000000
+Q2max =  0
+Wmin  =  1000000
+Wmax  =  0
+ 
+# 
+#  Corrections 
+# 
+correctForRealAmplitude =  true
+correctSkewedness       =  true
+# maxLambdaUsedInCorrections = 0.65
+ 
+# 
+#  Misc 
+# 
+enableNuclearBreakup = false
+maxNuclearExcitationEnergy = 0.5
+ 
+# 
+#  Random generator seed (if not given current time is used) 
+# 
+#seed =  2011987 
+
+# 
+#  User parameters 
+# 
+# userDouble = 0.
+# userString = "Hello World!"
+# userInt = 0
+
+#
+#  Expert flags
+#
+# applyPhotonFlux = true


### PR DESCRIPTION
PHSartre is a wrapper for the Sartre 1.20 event generator for diffractive and UPC events. It works in much the same way as the PHPythia event generators, and the event output is in HepMC format, suitable for the sPHENIX G4 simulations. The event generator includes a generator level trigger interface and a simple particle trigger. 

(Sartre itself and the root upgrades required have been previously installed by @pinkenburg  - thanks Chris!)