### PR TITLE
add tower by tower calibration for EMCal

### DIFF
--- a/simulation/g4simulation/g4cemc/RawTowerCalibration.h
+++ b/simulation/g4simulation/g4cemc/RawTowerCalibration.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include <phool/PHTimeServer.h>
+#include <g4detectors/PHG4Parameters.h>
 
 class PHCompositeNode;
 class RawTowerContainer;
@@ -33,6 +34,7 @@ public:
   Detector(const std::string &d)
   {
     detector = d;
+    _tower_calib_params.set_name(d);
   }
   void
   TowerType(const int type)
@@ -46,7 +48,10 @@ public:
     kNo_calibration = 0,
 
     //! simple calibration with pedstal subtraction and a global energy scale (sampling fraction) correction
-    kSimple_linear_calibration = 1
+    kSimple_linear_calibration = 1,
+
+    //! input calibration file for tower by tower calibration. Use GetCalibrationParameters() to set the calibration parameters
+    kTower_by_tower_calibration = 2
   };
 
   enu_calib_algorithm
@@ -121,6 +126,12 @@ public:
     _zero_suppression_GeV = zeroSuppressionGeV;
   }
 
+  //! Get the parameters for update. Useful fields are listed in SetDefaultParameters();
+  PHG4Parameters &
+  GetCalibrationParameters()
+  {
+    return _tower_calib_params;
+  }
 protected:
   void
   CreateNodes(PHCompositeNode *topNode);
@@ -152,6 +163,9 @@ protected:
   int _tower_type; 
 
   PHTimeServer::timer _timer;
+
+  //! Tower by tower calibration parameters
+  PHG4Parameters _tower_calib_params;
 
 };
 


### PR DESCRIPTION
## Introduction

In the 2017 SPACAL design (https://github.com/sPHENIX-Collaboration/coresoftware/pull/300), the fiber density various slightly from block to block, with an up to 10% relative variation. 

To get energy scale consistent between all blocks, a tower-by-tower calibration is introduced, similar to that used in the test beam reconstruction. 

The tower by tower calibration constant is the inverse of the average sampling fraction for 4-GeV photons in the corresponding SPACAL 2x2 block:
![emcalana root_drawecal_blockcalibration](https://user-images.githubusercontent.com/7947083/27928382-fc5772dc-625c-11e7-95ba-16a9ef756fbd.png)

## Related pull request. 
- Calibration file: https://github.com/sPHENIX-Collaboration/calibrations/pull/25 
- Macros: https://github.com/sPHENIX-Collaboration/macros/pull/69 

## Calibration checks

Check cluster energy response of 4-GeV photon in the EMCal is studied in two case as following. Note the lower energy response around eta=0 is related to the assembly gap and enclosure between two EMCal half sectors. 

### Current build: use a common calibration constant
The center few blocks has higher sampling or response due to they are 1-D protective blocks which has higher fiber density than other 2-D projective blocks. On the higher rapidity blocks, the fiber density is relatively higher at shower-max too. 
![spacalresponse1](https://user-images.githubusercontent.com/7947083/27928317-b64467e6-625c-11e7-9ef2-4fb4cffef4ed.png)

### Use the new tower-by-tower calibration
The response is now flat cross all etas. 
![spacalresponse2](https://user-images.githubusercontent.com/7947083/27928324-ba5510b0-625c-11e7-8113-8a1635f1fa95.png)

## Check

@jdosbo  could you test it out once in nightly build? 
