### PR TITLE
Evaluator CPU Performance Optimization

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -17,6 +17,9 @@ class SvtxClusterMap;
 class SvtxHitMap;
 class SvtxTruthEval;
 
+using namespace std;
+typedef multimap<float, SvtxCluster*> innerMap;
+
 class SvtxClusterEval {
 
 public:
@@ -64,6 +67,8 @@ public:
 private:
 
   void get_node_pointers(PHCompositeNode* topNode);
+  void fill_cluster_layer_map();
+  //  void fill_g4hit_layer_map();
   bool has_node_pointers();
   
   SvtxHitEval _hiteval;
@@ -85,6 +90,9 @@ private:
   std::map<PHG4Hit*,SvtxCluster* >                      _cache_best_cluster_from_g4hit;
   std::map<std::pair<SvtxCluster*,PHG4Particle*>,float> _cache_get_energy_contribution_g4particle;
   std::map<std::pair<SvtxCluster*,PHG4Hit*>,float>      _cache_get_energy_contribution_g4hit;
+
+  std::multimap<unsigned int, innerMap> _clusters_per_layer;
+  std::multimap<unsigned int, PHG4Hit*> _g4hits_per_layer;
 };
 
 #endif // SVTXCLUSTEREVAL_H__

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -66,7 +66,9 @@ SvtxEvaluator::SvtxEvaluator(const string &name, const string &filename, const s
   _ntp_track(nullptr),
   _filename(filename),
   _trackmapname(trackmapname),
-  _tfile(nullptr) {
+  _tfile(nullptr),
+  _timer(nullptr)
+{
   verbosity = 0;
 }
 

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -5,6 +5,8 @@
 #include <phool/PHCompositeNode.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/getClass.h>
+#include <phool/PHTimeServer.h>
+#include <phool/PHTimer.h>
 
 #include <g4hough/SvtxVertexMap.h>
 #include <g4hough/SvtxVertex.h>
@@ -50,6 +52,7 @@ SvtxEvaluator::SvtxEvaluator(const string &name, const string &filename, const s
   _do_gtrack_eval(true),
   _do_track_eval(true),
   _do_track_match(true),
+  _do_eval_light(true),
   _scan_for_embedded(false),
   _nlayers_maps(nlayers_maps),
   _nlayers_intt(nlayers_intt),
@@ -134,7 +137,10 @@ int SvtxEvaluator::Init(PHCompositeNode *topNode) {
 					       "gvx:gvy:gvz:gvt:"
 					       "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
 					       "gembed:gprimary:nfromtruth:nwrong:ntrumaps:ntruintt:ntrutpc:layersfromtruth");
-  
+
+  _timer = new PHTimer("_eval_timer");
+  _timer->stop();
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -363,8 +369,7 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode *topNode) {
 	++nclusters[cluster->get_layer()];
       }
     }
-
-    for (unsigned int ilayer = 0; ilayer < 100; ++ilayer) {
+    for (unsigned int ilayer = 0; ilayer < _nlayers_maps + _nlayers_intt+ _nlayers_tpc; ++ilayer) {
       cout << "layer " << ilayer << ": nG4hits = " << ng4hits[ilayer]
 	   << " => nHits = " << nhits[ilayer]
 	   << " => nClusters = " << nclusters[ilayer] << endl;
@@ -559,7 +564,7 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode *topNode) {
 
 void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
-  if (verbosity > 1) cout << "SvtxEvaluator::fillOutputNtuples() entered" << endl;
+  if (verbosity > 0) cout << "SvtxEvaluator::fillOutputNtuples() entered" << endl;
 
   SvtxVertexEval*   vertexeval = _svtxevalstack->get_vertex_eval();
   SvtxTrackEval*     trackeval = _svtxevalstack->get_track_eval();
@@ -572,7 +577,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //-----------------------
 
   if (_ntp_vertex) {
-    //cout << "Filling ntp_vertex " << endl;
+    if (verbosity > 0){
+      cout << "Filling ntp_vertex " << endl;
+      _timer->restart();
+    }
     SvtxVertexMap* vertexmap = findNode::getClass<SvtxVertexMap>(topNode,"SvtxVertexMap");
     PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
     if (vertexmap && truthinfo) {
@@ -628,6 +636,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	_ntp_vertex->Fill(vertex_data);      
       }
     }
+    if(verbosity >= 1){
+      _timer->stop();
+      cout << "vertex time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
+    }
   }
   
   //-----------------------
@@ -635,7 +647,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //-----------------------
   
   if (_ntp_gpoint) {
-    //cout << "Filling ntp_gpoint " << endl;    
+    if (verbosity > 0){ cout << "Filling ntp_gpoint " << endl; _timer->restart();}
     SvtxVertexMap* vertexmap = findNode::getClass<SvtxVertexMap>(topNode,"SvtxVertexMap");
     PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
 
@@ -682,6 +694,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	_ntp_gpoint->Fill(gpoint_data);      
       }
     }
+    if(verbosity >= 1){
+      _timer->stop();
+      cout << "gpoint time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
+    }
   }
   
   //---------------------
@@ -689,7 +705,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //---------------------
 
   if (_ntp_g4hit) {
-    //cout << "Filling ntp_g4hit " << endl;
+    if (verbosity > 0) {cout << "Filling ntp_g4hit " << endl;_timer->restart();}
     std::set<PHG4Hit*> g4hits = trutheval->all_truth_hits();
     for (std::set<PHG4Hit*>::iterator iter = g4hits.begin();
 	 iter != g4hits.end();
@@ -717,8 +733,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       float gvy       = NAN;
       float gvz       = NAN;
 
-      float gembed  = NAN;
-      float gprimary = NAN;
+      float gembed    = NAN;
+      float gprimary  = NAN;
 
       float gfpx      = 0.;
       float gfpy      = 0.;
@@ -745,8 +761,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  gvy       = vtx->get_y();
 	  gvz       = vtx->get_z();
 	}
-    
-	PHG4Hit* outerhit = trutheval->get_outermost_truth_hit(g4particle);	
+	PHG4Hit* outerhit = nullptr;
+	if(_do_eval_light == false)
+	  outerhit = trutheval->get_outermost_truth_hit(g4particle);	
+
 	if (outerhit) {
 	  gfpx      = outerhit->get_px(1);
 	  gfpy      = outerhit->get_py(1);
@@ -764,6 +782,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       float nclusters = clusters.size();
 
       // best cluster reco'd
+      //      SvtxCluster* cluster = nullptr;//clustereval->best_cluster_from(g4hit);
       SvtxCluster* cluster = clustereval->best_cluster_from(g4hit);
 
       float clusID     = NAN;
@@ -834,6 +853,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
       _ntp_g4hit->Fill(g4hit_data);
     }
+    if(verbosity >= 1){
+      _timer->stop();
+      cout << "g4hit time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
+    }
   }
   
   //--------------------
@@ -841,7 +864,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //--------------------
 
   if (_ntp_hit) {
-    //cout << "Filling ntp_hit " << endl;
+    if (verbosity > 0){ cout << "Filling ntp_hit " << endl;_timer->restart();}
     // need things off of the DST...
     SvtxHitMap* hitmap = findNode::getClass<SvtxHitMap>(topNode,"SvtxHitMap");
     if (hitmap) {
@@ -970,16 +993,20 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	_ntp_hit->Fill(hit_data);     
       }
     }
+    if(verbosity >= 1){
+      _timer->stop();
+      cout << "hit time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
+    }
   }
   
   //------------------------
   // fill the Cluster NTuple
   //------------------------
 
-  //cout << "check for ntp_cluster" << endl;
+  if (verbosity > 0){ cout << "check for ntp_cluster" << endl;_timer->restart();}
 
   if (_ntp_cluster && !_scan_for_embedded) {
-    //cout << "Filling ntp_cluster 1 " << endl;
+    if (verbosity > 0) cout << "Filling ntp_cluster (all of them) " << endl;
     // need things off of the DST...
     SvtxClusterMap* clustermap = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
     if (clustermap) {
@@ -989,9 +1016,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	   ++iter) {
     
 	SvtxCluster* cluster     = iter->second;   
-	SvtxTrack* track = trackeval->best_track_from(cluster);
-	
-	PHG4Hit *g4hit           = clustereval->max_truth_hit_by_energy(cluster); 
+	SvtxTrack* track         = trackeval->best_track_from(cluster);
+       	PHG4Hit *g4hit           = clustereval->max_truth_hit_by_energy(cluster); 
 	PHG4Particle *g4particle = trutheval->get_particle(g4hit);
     
 	float hitID    = cluster->get_id();
@@ -1053,15 +1079,17 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	    gpx      = g4particle->get_px();
 	    gpy      = g4particle->get_py();
 	    gpz      = g4particle->get_pz();
-
+	    
 	    PHG4VtxPoint* vtx = trutheval->get_vertex(g4particle);
 	    if (vtx) {
 	      gvx      = vtx->get_x();
 	      gvy      = vtx->get_y();
 	      gvz      = vtx->get_z();
 	    }
-
-	    PHG4Hit* outerhit = trutheval->get_outermost_truth_hit(g4particle);	
+	    
+	    PHG4Hit* outerhit = nullptr;
+	    if(_do_eval_light == false)
+	      outerhit = trutheval->get_outermost_truth_hit(g4particle);	
 	    if (outerhit) {
 	      gfpx     = outerhit->get_px(1);
 	      gfpy     = outerhit->get_py(1);
@@ -1073,6 +1101,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	    
 	    gembed   = trutheval->get_embed(g4particle);
 	    gprimary = trutheval->is_primary(g4particle);
+	    
 	  }      //   if (g4particle){
 	} //  if (g4hit) {
 
@@ -1129,7 +1158,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
     
   } else if (_ntp_cluster && _scan_for_embedded) {
 
-    //cout << "Filling ntp_cluster 2 " << endl;
+    if (verbosity > 0) cout << "Filling ntp_cluster (embedded only) " << endl;
 
     // if only scanning embedded signals, loop over all the tracks from
     // embedded particles and report all of their clusters, including those
@@ -1226,8 +1255,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 		gvy      = vtx->get_y();
 		gvz      = vtx->get_z();
 	      }
-
-	      PHG4Hit* outerhit = trutheval->get_outermost_truth_hit(g4particle);	
+	      PHG4Hit* outerhit = nullptr;
+	      if(_do_eval_light == false)
+		outerhit = trutheval->get_outermost_truth_hit(g4particle);	
 	      if (outerhit) {
 		gfpx     = outerhit->get_px(1);
 		gfpy     = outerhit->get_py(1);
@@ -1294,7 +1324,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       }
     }
   }
-    
+  if(verbosity >= 1){
+    _timer->stop();
+    cout << "cluster time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
+  }
   //------------------------
   // fill the Gtrack NTuple
   //------------------------
@@ -1304,7 +1337,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //cout << "check for ntp_gtrack" << endl;
 
   if (_ntp_gtrack) {
-    //cout << "Filling ntp_gtrack " << endl;
+    if (verbosity > 0){ cout << "Filling ntp_gtrack " << endl;_timer->restart();}
 
     PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");   
     SvtxClusterMap* clustermap = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
@@ -1369,11 +1402,15 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gpx      = g4particle->get_px();
 	float gpy      = g4particle->get_py();
 	float gpz      = g4particle->get_pz();
-	TVector3 gv(gpx,gpy,gpz);
-	float gpt  = gv.Pt();
-	float geta = gv.Eta();
-	float gphi = gv.Phi();
-
+	float gpt      = NAN;
+	float geta     = NAN;
+	float gphi     = NAN;
+	if(gpx!=0&&gpy!=0){
+	  TVector3 gv(gpx,gpy,gpz);
+	  gpt  = gv.Pt();
+	  geta = gv.Eta();
+	  gphi = gv.Phi();
+	}
 	PHG4VtxPoint* vtx = trutheval->get_vertex(g4particle);	
 	float gvx      = vtx->get_x();
 	float gvy      = vtx->get_y();
@@ -1387,7 +1424,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gfy       = 0.;
 	float gfz       = 0.;
     
-	PHG4Hit* outerhit = trutheval->get_outermost_truth_hit(g4particle);	
+	PHG4Hit* outerhit = nullptr;
+	if(_do_eval_light == false)
+	  outerhit = trutheval->get_outermost_truth_hit(g4particle);	
+
 	if (outerhit) {
 	  gfpx      = outerhit->get_px(1);
 	  gfpy      = outerhit->get_py(1);
@@ -1579,6 +1619,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
       }	     
     }
+    if(verbosity >= 1){
+      _timer->stop();
+      cout << "gtrack time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
+    }
   }
   
   //------------------------
@@ -1588,7 +1632,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
 
   if (_ntp_track) {
-    //cout << "Filling ntp_track " << endl;
+    if (verbosity > 0){ cout << "Filling ntp_track " << endl;_timer->restart();}
 
     // need things off of the DST...
     SvtxTrackMap* trackmap = findNode::getClass<SvtxTrackMap>(topNode,_trackmapname.c_str());
@@ -1772,8 +1816,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	    gvy      = vtx->get_y();
 	    gvz      = vtx->get_z();
 	    gvt      = vtx->get_t();
-	    
-	    PHG4Hit* outerhit = trutheval->get_outermost_truth_hit(g4particle);	      
+
+	    PHG4Hit* outerhit = nullptr;
+	    if(_do_eval_light == false)
+	      outerhit = trutheval->get_outermost_truth_hit(g4particle);	
 	    if (outerhit) {
 	      gfpx     = outerhit->get_px(1);
 	      gfpy     = outerhit->get_py(1);
@@ -1885,6 +1931,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	*/
 	_ntp_track->Fill(track_data);
       }
+    }
+    if(verbosity >= 1){
+      _timer->stop();
+      cout << "track time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
     }
   }
   

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -9,7 +9,8 @@
 
 
 #include <fun4all/SubsysReco.h>
-
+#include <phool/PHTimeServer.h>
+#include <phool/PHTimer.h>
 #include <string>
 
 class PHCompositeNode;
@@ -54,6 +55,7 @@ public:
   void do_track_eval(bool b) {_do_track_eval = b;}
 
   void do_track_match(bool b) {_do_track_match = b;}
+  void do_eval_light(bool b) {_do_eval_light = b;}
   void scan_for_embedded(bool b) {_scan_for_embedded = b;}
   
  private:
@@ -78,6 +80,7 @@ public:
   bool _do_track_eval;
 
   bool _do_track_match;
+  bool _do_eval_light;
   bool _scan_for_embedded;
 
   unsigned int _nlayers_maps = 3;
@@ -97,6 +100,8 @@ public:
   //Track map name
   std::string _trackmapname;
   TFile *_tfile;
+
+  PHTimer *_timer;
 
   // output subroutines
   void fillOutputNtuples(PHCompositeNode* topNode); ///< dump the evaluator information into ntuple for external analysis

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -66,6 +66,7 @@ public:
   std::set<SvtxTrack*> all_tracks_from(PHG4Hit* truthhit);
   std::set<SvtxTrack*> all_tracks_from(SvtxCluster* cluster);
   SvtxTrack*           best_track_from(SvtxCluster* cluster);
+  void                 create_cache_track_from_cluster();
   
   // overlap calculations
   void         calc_cluster_contribution(SvtxTrack* svtxtrack, PHG4Particle* truthparticle);  
@@ -89,6 +90,7 @@ private:
   unsigned int _errors;
   
   bool                                                        _do_cache;
+  bool                                                        _cache_track_from_cluster_exists;
   std::map<SvtxTrack*,std::set<PHG4Hit*> >                    _cache_all_truth_hits;
   std::map<SvtxTrack*,std::set<PHG4Particle*> >               _cache_all_truth_particles;
   std::map<SvtxTrack*,PHG4Particle*>                          _cache_max_truth_particle_by_nclusters;

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.C
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.C
@@ -206,6 +206,14 @@ PHG4Hit* SvtxTruthEval::get_outermost_truth_hit(PHG4Particle* particle) {
   PHG4Hit* outermost_hit = nullptr;
   float outermost_radius = FLT_MAX*-1.0;
   
+  if (_do_cache) {
+    std::map<PHG4Particle*,PHG4Hit*>::iterator iter =
+      _cache_get_outermost_truth_hit.find(particle);
+    if (iter != _cache_get_outermost_truth_hit.end()) {
+      return iter->second;
+    }
+  }
+
   std::set<PHG4Hit*> truth_hits = all_truth_hits(particle);
   for (std::set<PHG4Hit*>::iterator iter = truth_hits.begin();
        iter != truth_hits.end();
@@ -219,6 +227,7 @@ PHG4Hit* SvtxTruthEval::get_outermost_truth_hit(PHG4Particle* particle) {
       outermost_hit = candidate;      
     }
   }
+  if (_do_cache) _cache_get_outermost_truth_hit.insert(make_pair(particle,outermost_hit));
 
   return outermost_hit;
 }


### PR DESCRIPTION
Full matching (not just embedded) now works in central Hijing events.
g4hit + Cluster + track matching executes in 1200 seconds
including the hit matching (not optimized yet) increases the budget to 3800seconds.

In semi central events the CPU usage decreased from 2700sec to 465sec.

Most performance inceases were obtained by presorting the clustermap
in layer and z to reduce the search range and by caching matching results.
A lot of time is spent accessing the clustermap. Access to clusters in the large 
clustermap is apparently quite inefficient.

