### PR TITLE
fixing the ePHENIXRICH

### DIFF
--- a/offline/framework/fun4all/Makefile.am
+++ b/offline/framework/fun4all/Makefile.am
@@ -14,13 +14,20 @@ pkginclude_HEADERS = \
   Fun4AllDstInputManager.h \
   Fun4AllDstOutputManager.h \
   Fun4AllDummyInputManager.h \
+  Fun4AllEventOutStream.h \
+  Fun4AllEventOutputManager.h \
+  Fun4AllFileOutStream.h \
+  Fun4AllHistoBinDefs.h \
   Fun4AllHistoManager.h \
-  Fun4AllSyncManager.h \
   Fun4AllInputManager.h \
   Fun4AllNoSyncDstInputManager.h \
   Fun4AllOutputManager.h \
+  Fun4AllPrdfInputManager.h \
+  Fun4AllPrdfOutputManager.h \
   Fun4AllReturnCodes.h \
+  Fun4AllRolloverFileOutStream.h \
   Fun4AllServer.h \
+  Fun4AllSyncManager.h \
   Fun4AllUtils.h \
   PHTFileServer.h \
   SubsysReco.h \
@@ -28,13 +35,6 @@ pkginclude_HEADERS = \
   TDirectoryHelper.h
 
 noinst_HEADERS = \
-  Fun4AllHistoBinDefs.h \
-  Fun4AllEventOutStream.h \
-  Fun4AllEventOutputManager.h \
-  Fun4AllRolloverFileOutStream.h \
-  Fun4AllFileOutStream.h \
-  Fun4AllPrdfInputManager.h \
-  Fun4AllPrdfOutputManager.h \
   Fun4AllLinkDef.h \
   SubsysRecoLinkDef.h
 

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -47,6 +47,8 @@ libphg4hit_la_LIBADD = \
   -leicsmear
 
 libphg4hit_la_SOURCES = \
+    PHG4EventHeader.cc \
+    PHG4EventHeaderv1.cc \
     PHG4Hit_Dict.cc \
     PHG4HitReadBack.cc \
     PHG4HitDefs.cc \
@@ -54,6 +56,7 @@ libphg4hit_la_SOURCES = \
     PHG4Hitv1.cc \
     PHG4HitEval.cc \
     PHG4HitContainer.cc \
+    PHG4InEvent.cc \
     PHG4Particle.cc \
     PHG4Particlev1.cc \
     PHG4Particlev2.cc \
@@ -67,14 +70,10 @@ libg4testbench_la_SOURCES = \
     G4TBMagneticFieldSetup.cc \
     G4TBFieldMessenger.cc \
     HepMCNodeReader.cc \
-    PHG4_Dict.cc \
     PHG4ConsistencyCheck.cc \
     PHG4EtaParameterization.cc \
     PHG4EtaPhiParameterization.cc \
-    PHG4EventHeader.cc \
-    PHG4EventHeaderv1.cc \
     PHG4HeadReco.cc \
-    PHG4InEvent.cc \
     PHG4InEventCompress.cc \
     PHG4InEventReadBack.cc \
     PHG4InputFilter.cc \
@@ -90,6 +89,7 @@ libg4testbench_la_SOURCES = \
     PHG4PhenixEventAction.cc \
     PHG4PhenixSteppingAction.cc \
     PHG4PhenixTrackingAction.cc \
+    PHG4_Dict.cc \
     PHG4PrimaryGeneratorAction.cc \
     PHG4Reco.cc \
     PHG4RegionInformation.cc \
@@ -124,6 +124,7 @@ libg4testbench_la_LIBADD = \
 # please add new classes in alphabetical order
 
 pkginclude_HEADERS = \
+  HepMCNodeReader.h \
   PHBBox.h \
   PHG4Detector.h \
   PHG4EventAction.h \
@@ -139,9 +140,12 @@ pkginclude_HEADERS = \
   PHG4Particlev2.h \
   PHG4ParticleGenerator.h \
   PHG4ParticleGeneratorBase.h \
+  PHG4ParticleGeneratorVectorMeson.h \
   PHG4PhenixDetector.h \
+  PHG4PileupGenerator.h \
   PHG4Reco.h \
   PHG4RegionInformation.h \
+  PHG4SimpleEventGenerator.h \
   PHG4Shower.h \
   PHG4Showerv1.h \
   PHG4SteppingAction.h \
@@ -149,6 +153,7 @@ pkginclude_HEADERS = \
   PHG4TrackingAction.h \
   PHG4TrackUserInfoV1.h \
   PHG4TruthInfoContainer.h \
+  PHG4TruthSubsystem.h \
   PHG4Utils.h \
   PHG4VtxPoint.h \
   PHG4VtxPointv1.h
@@ -181,10 +186,7 @@ testexternals.cc:
 PHG4_Dict.cc: \
   HepMCNodeReader.h \
   PHG4ConsistencyCheck.h \
-  PHG4EventHeader.h \
-  PHG4EventHeaderv1.h \
   PHG4HeadReco.h \
-  PHG4InEvent.h \
   PHG4InEventCompress.h \
   PHG4InEventReadBack.h \
   PHG4InputFilter.h \
@@ -203,12 +205,15 @@ PHG4_Dict.cc: \
 	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(RINCLUDES) $^
 
 PHG4Hit_Dict.cc: \
+  PHG4EventHeader.h \
+  PHG4EventHeaderv1.h \
   PHG4HitReadBack.h \
   PHG4Hit.h \
   PHG4HitDefs.h \
   PHG4Hitv1.h \
   PHG4HitEval.h \
   PHG4HitContainer.h \
+  PHG4InEvent.h \
   PHG4Shower.h \
   PHG4Showerv1.h \
   PHG4Particle.h \

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -137,6 +137,7 @@ pkginclude_HEADERS = \
   PHG4Particle.h \
   PHG4Particlev1.h \
   PHG4Particlev2.h \
+  PHG4ParticleGenerator.h \
   PHG4ParticleGeneratorBase.h \
   PHG4PhenixDetector.h \
   PHG4Reco.h \

--- a/simulation/g4simulation/g4main/PHG4HitLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4HitLinkDef.h
@@ -5,10 +5,13 @@
 #pragma link C++ namespace PHG4HitDefs-!;
 
 // first classes with streamers
+#pragma link C++ class PHG4EventHeader+;
+#pragma link C++ class PHG4EventHeaderv1+;
 #pragma link C++ class PHG4Hit+;
 #pragma link C++ class PHG4Hitv1+;
 #pragma link C++ class PHG4HitEval+;
 #pragma link C++ class PHG4HitContainer+;
+#pragma link C++ class PHG4InEvent+;
 #pragma link C++ class PHG4Shower+;
 #pragma link C++ class PHG4Showerv1+;
 #pragma link C++ class PHG4Particle+;

--- a/simulation/g4simulation/g4main/PHG4LinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4LinkDef.h
@@ -2,10 +2,7 @@
 
 #pragma link C++ class HepMCNodeReader-!;
 #pragma link C++ class PHG4ConsistencyCheck-!;
-#pragma link C++ class PHG4EventHeader+;
-#pragma link C++ class PHG4EventHeaderv1+;
 #pragma link C++ class PHG4HeadReco-!;
-#pragma link C++ class PHG4InEvent+;
 #pragma link C++ class PHG4InEventCompress-!;
 #pragma link C++ class PHG4InEventReadBack-!;
 #pragma link C++ class PHG4InputFilter-!;

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -1187,9 +1187,8 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   mRICH_glass_myMPT->AddProperty("RINDEX", mRICH_PhotonEnergy, mRICH_glassRefractiveIndex, mRICH_nEntries1);
   mRICH_glass_myMPT->AddProperty("ABSLENGTH", mRICH_PhotonEnergy, mRICH_glassAbsorption, mRICH_nEntries1);
 
-  //G4NistManager * nist = G4NistManager::Instance();
-  G4Material* mRICH_Borosilicate = nist->FindOrBuildMaterial("G4_Pyrex_Glass");
-  mRICH_Borosilicate->SetName("mRICH_Borosilicate");
+  const G4Material *G4_Pyrex_Glass = nist->FindOrBuildMaterial("G4_Pyrex_Glass");
+  G4Material *mRICH_Borosilicate=  new G4Material("mRICH_Borosilicate",G4_Pyrex_Glass->GetDensity(),G4_Pyrex_Glass);
   mRICH_Borosilicate->SetMaterialPropertiesTable(mRICH_glass_myMPT);
 
   // mRICH_Air ------------------
@@ -1206,7 +1205,6 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   mRICH_Air_myMPT->AddProperty("RINDEX", mRICH_PhotonEnergy, mRICH_AirRefractiveIndex , mRICH_nEntries1);
   const G4Material *G4_AIR = G4Material::GetMaterial("G4_AIR");
   G4Material *mRICH_Air=  new G4Material("mRICH_Air",G4_AIR->GetDensity(),G4_AIR);
-  mRICH_Air->SetName("mRICH_Air");
   mRICH_Air->SetMaterialPropertiesTable(mRICH_Air_myMPT);
 }
 

--- a/simulation/g4simulation/g4main/configure.ac
+++ b/simulation/g4simulation/g4main/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
-  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | gawk '{print $1>=4.8?"1":"0"}'` = 1)
+dnl  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | gawk '{print $1>=4.8?"1":"0"}'` = 1)
 fi
 
 dnl test for root 6


### PR DESCRIPTION
The mRICH had renamed G4_Pyrex_Glass which broke the ePHENIXRICH. Now the mRICH uses a copy of the G4_Pyrex_Glass for its purpose (it adds some properties so it cannot use the original G4_Pyrex_Glass). There might be an issue with the material copying - that still needs to be looked at but this put the ePHENIXRICH back into business.