### PR TITLE
limit cellsize in TPC to prevent excessive memory usage

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -23,6 +23,7 @@
 #include <TH1F.h>
 #include <TProfile2D.h>
 #include <TROOT.h>
+#include <TSystem.h>
 
 #include <CLHEP/Units/PhysicalConstants.h>
 #include <CLHEP/Units/SystemOfUnits.h>
@@ -204,7 +205,15 @@ int PHG4CylinderCellTPCReco::InitRun(PHCompositeNode *topNode)
     layerseggeo->set_zstep(size_z);
     layerseggeo->set_phibins(nbins[0]);
     layerseggeo->set_phistep(phistepsize);
-    
+// Chris Pinkenburg: greater causes huge memory growth which causes problems
+// on our farm. If you need to increase this - TALK TO ME first
+    if (nbins[1]*nbins[0]> 5000000)
+    {
+      cout << "increase TPC cellsize, number of cells exceed 5M for layer " 
+	   << layer << endl;
+      cout << "minimum working values for cells are  0.12/0.17" << endl;
+      gSystem->Exit(1);
+    }
     seggeo->AddLayerCellGeom(layerseggeo);
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -207,10 +207,11 @@ int PHG4CylinderCellTPCReco::InitRun(PHCompositeNode *topNode)
     layerseggeo->set_phistep(phistepsize);
 // Chris Pinkenburg: greater causes huge memory growth which causes problems
 // on our farm. If you need to increase this - TALK TO ME first
-    if (nbins[1]*nbins[0]> 5000000)
+    if (nbins[1]*nbins[0]> 5100000)
     {
-      cout << "increase TPC cellsize, number of cells exceed 5M for layer " 
-	   << layer << endl;
+      cout << "increase TPC cellsize, number of cells "
+	   << nbins[1]*nbins[0] << " for layer " << layer
+	   << " exceed 5.1M limit" << endl;
       cout << "minimum working values for cells are  0.12/0.17" << endl;
       gSystem->Exit(1);
     }


### PR DESCRIPTION
just a dumb check on the total number of cells in a given layer. The current default (0.12/0.17) results in 5+M cells in the outer layer, the limit is set to 5.1M