### PR TITLE
propagate stepping action fixes from the hcal to the cylinder and block stepping action

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.h
@@ -3,6 +3,7 @@
 
 #include <g4main/PHG4SteppingAction.h>
 
+class G4VPhysicalVolume;
 class PHG4BlockDetector;
 class PHG4Hit;
 class PHG4HitContainer;
@@ -32,7 +33,10 @@ class PHG4BlockSteppingAction : public PHG4SteppingAction
   PHG4HitContainer *hits_;
   PHG4Hit *hit;
   PHG4Shower *saveshower;
+  G4VPhysicalVolume *savevolpre;
+  G4VPhysicalVolume *savevolpost;
   int savetrackid;
+  int saveprestepstatus;
   int savepoststepstatus;
   int active;
   int IsBlackHole;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -1,6 +1,7 @@
 #include "PHG4CylinderSteppingAction.h"
 #include "PHG4CylinderDetector.h"
 #include "PHG4Parameters.h"
+#include "PHG4StepStatusDecode.h"
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
@@ -26,8 +27,11 @@ PHG4CylinderSteppingAction::PHG4CylinderSteppingAction(PHG4CylinderDetector* det
   , hits_(nullptr)
   , hit(nullptr)
   , saveshower(nullptr)
+  , savevolpre(nullptr)
+  , savevolpost(nullptr)
   , save_light_yield(params->get_int_param("lightyield"))
   , savetrackid(-1)
+  , saveprestepstatus(-1)
   , savepoststepstatus(-1)
   , active(params->get_int_param("active"))
   , IsBlackHole(params->get_int_param("blackhole"))
@@ -55,7 +59,10 @@ PHG4CylinderSteppingAction::~PHG4CylinderSteppingAction()
 bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
   // get volume of the current step
-  G4VPhysicalVolume* volume = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
+  G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
+  G4TouchableHandle touchpost = aStep->GetPostStepPoint()->GetTouchableHandle();
+
+  G4VPhysicalVolume* volume = touch->GetVolume();
   // G4 just calls  UserSteppingAction for every step (and we loop then over all our
   // steppingactions. First we have to check if we are actually in our volume
   if (!detector_->IsInCylinder(volume))
@@ -104,8 +111,24 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     int prepointstatus = prePoint->GetStepStatus();
     if (prepointstatus == fGeomBoundary ||
         prepointstatus == fUndefined ||
+        (prepointstatus == fPostStepDoItProc && savepoststepstatus == fGeomBoundary) ||
         use_g4_steps > 0)
     {
+      if (prepointstatus == fPostStepDoItProc && savepoststepstatus == fGeomBoundary)
+      {
+	cout << GetName() << ": New Hit for  " << endl;
+	cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+	     << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+	     << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+	     << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
+	cout << "last track: " << savetrackid
+	     << ", current trackid: " << aTrack->GetTrackID() << endl;
+	cout << "phys pre vol: " << volume->GetName()
+	     << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+	cout << " previous phys pre vol: " << savevolpre->GetName()
+	     << " previous phys post vol: " << savevolpost->GetName() << endl;
+      }
+
       if (!hit)
       {
         hit = new PHG4Hitv1();
@@ -162,9 +185,17 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     // check if this hit was created, if not print out last post step status
     if (!hit || !isfinite(hit->get_x(0)))
     {
-      cout << "hit was not created" << endl;
-      cout << "prestep status: " << prePoint->GetStepStatus()
-           << ", last post step status: " << savepoststepstatus << endl;
+      cout << GetName() << ": hit was not created" << endl;
+      cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+           << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
+      cout << "last track: " << savetrackid
+           << ", current trackid: " << aTrack->GetTrackID() << endl;
+      cout << "phys pre vol: " << volume->GetName()
+           << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+      cout << " previous phys pre vol: " << savevolpre->GetName()
+           << " previous phys post vol: " << savevolpost->GetName() << endl;
       exit(1);
     }
     savepoststepstatus = postPoint->GetStepStatus();
@@ -177,6 +208,11 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
            << endl;
       exit(1);
     }
+    saveprestepstatus = prePoint->GetStepStatus();
+    savepoststepstatus = postPoint->GetStepStatus();
+    savevolpre = volume;
+    savevolpost = touchpost->GetVolume();
+ 
     hit->set_x(1, postPoint->GetPosition().x() / cm);
     hit->set_y(1, postPoint->GetPosition().y() / cm);
     hit->set_z(1, postPoint->GetPosition().z() / cm);

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -5,6 +5,7 @@
 
 #include <string>
 
+class G4VPhysicalVolume;
 class PHG4CylinderDetector;
 class PHG4Hit;
 class PHG4HitContainer;
@@ -37,8 +38,11 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
   PHG4HitContainer *hits_;
   PHG4Hit *hit;
   PHG4Shower *saveshower;
+  G4VPhysicalVolume *savevolpre;
+  G4VPhysicalVolume *savevolpost;
   int save_light_yield;
   int savetrackid;
+  int saveprestepstatus;
   int savepoststepstatus;
   int active;
   int IsBlackHole;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -202,6 +202,20 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       {
         break;
       }
+      else
+      {
+	cout << GetName() << ": New Hit for  " << endl;
+cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+<< ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
+      cout << "last track: " << savetrackid
+           << ", current trackid: " << aTrack->GetTrackID() << endl;
+      cout << "phys pre vol: " << volume->GetName()
+           << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+      cout << " previous phys pre vol: " << savevolpre->GetName()
+           << " previous phys post vol: " << savevolpost->GetName() << endl;
+      }
     case fGeomBoundary:
     case fUndefined:
       // if previous hit was saved, hit pointer was set to nullptr

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -231,6 +231,20 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       {
         break;
       }
+      else
+      {
+	cout << GetName() << ": New Hit for  " << endl;
+	cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+	     << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+	     << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+	     << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
+	cout << "last track: " << savetrackid
+	     << ", current trackid: " << aTrack->GetTrackID() << endl;
+	cout << "phys pre vol: " << volume->GetName()
+	     << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+	cout << " previous phys pre vol: " << savevolpre->GetName()
+	     << " previous phys post vol: " << savevolpost->GetName() << endl;
+      }
     case fGeomBoundary:
     case fUndefined:
       if (!hit)


### PR DESCRIPTION
The last round of hijing sims showed that those impossible step status combinations also occur in the cylinder. This pull request adds those protections. It also gives now a printout if an impossible (but handled) stepping action is seen to get an idea how frequent they are and that we can reproduce them to show this at some time to the G4 developers 