### PR TITLE
Intt stepping bug fix

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -132,6 +132,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
 
   // loop over all of the layers in the hit container
   // we need the geometry object for this layer
+  if(verbosity > 2) cout << " PHG4SiliconTrackerCellReco: Loop over hits" << endl;
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
   for (PHG4HitContainer::ConstIterator hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
   {
@@ -155,36 +156,57 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
     double location[3] = {-1, -1, -1};
     layergeom->find_strip_center(ladder_z_index, ladder_phi_index, strip_z_index, strip_y_index, location);
 
+    if(verbosity > 2) 
+      {
+	cout << "  g4 hit:  layer " <<  hiter->second->get_layer() << " edep " <<  hiter->second->get_edep() << endl;
+	cout << "   Hit entry point x,y,z = " << hiter->second->get_x(0) << "  " << hiter->second->get_y(0) << "  " << hiter->second->get_z(0) << endl;
+	cout << "   Hit exit point x,y,z = " << hiter->second->get_x(1) << "  " << hiter->second->get_y(1) << "  " << hiter->second->get_z(1) << endl;
+	cout << "  ladder z index " <<  hiter->second->get_ladder_z_index() << " ladder phi index " <<  hiter->second->get_ladder_phi_index() 
+	     << " strip z index " <<  hiter->second->get_strip_z_index() << " strip y index " <<   hiter->second->get_strip_y_index() << endl;
+	cout << "   strip x,y,z from geometry object = " << location[0] << "  " << location[1] << "  " << location[2] << endl;
+	cout << endl;
+      }
+
+    // this string is not unique - it needs the layer too, or it will add g4 hits with the same key together if they are in different layers
     std::string key = boost::str(boost::format("%d-%d_%d_%d") % ladder_z_index % ladder_phi_index % strip_z_index % strip_y_index).c_str();
     PHG4Cell *cell = nullptr;
     map<string, PHG4Cell *>::iterator it;
     it = celllist.find(key);
 
+    // If there is an existing cell to add this hit to, find it    
     if (it != celllist.end())
-    {
-      cell = it->second;
-    }
-    else
-    {
-      unsigned int index = celllist.size();
-      index++;
-      PHG4CellDefs::keytype cellkey = PHG4CellDefs::MapsBinning::genkey(sphxlayer, index);
-      cell = new PHG4Cellv1(cellkey);
-      celllist[key] = cell;
-      // This encodes the z and phi position of the sensor
-      //          celllist[key]->set_sensor_index(boost::str(boost::format("%d_%d") %ladder_z_index %ladder_phi_index).c_str());
+      {
+	// The key does not include the layer number, so it is not unique. We check that the hit is in the same layer as well as having the same key 
+	if( (int) it->second->get_layer() == (int) hiter->second->get_layer() )
+	  {
+	    cell = it->second;
+	  }
+      }
 
-      cell->set_ladder_z_index(ladder_z_index);
-      cell->set_ladder_phi_index(ladder_phi_index);
+    // There is not an existing cell to add this hit to, start a new cell    
+    if(!cell)
+      {
+	unsigned int index = celllist.size();
+	index++;
+	PHG4CellDefs::keytype cellkey = PHG4CellDefs::MapsBinning::genkey(sphxlayer, index);
+	cell = new PHG4Cellv1(cellkey);
+	celllist[key] = cell;
+	// This encodes the z and phi position of the sensor
+	//          celllist[key]->set_sensor_index(boost::str(boost::format("%d_%d") %ladder_z_index %ladder_phi_index).c_str());
+	
+	cell->set_ladder_z_index(ladder_z_index);
+	cell->set_ladder_phi_index(ladder_phi_index);
+	
+	// The z and phi position of the hit strip within the sensor
+	cell->set_zbin(strip_z_index);
+	cell->set_phibin(strip_y_index);
+      }
 
-      // The z and phi position of the hit strip within the sensor
-      cell->set_zbin(strip_z_index);
-      cell->set_phibin(strip_y_index);
-    }
+    // add this hit to the cell
     cell->add_edep(hiter->first, hiter->second->get_edep());
     cell->add_edep(hiter->second->get_edep());
   }  // end loop over g4hits
-
+  
   int numcells = 0;
   for (std::map<std::string, PHG4Cell *>::const_iterator mapiter = celllist.begin(); mapiter != celllist.end(); ++mapiter)
   {
@@ -194,6 +216,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
     if (verbosity > 0)
     {
       std::cout << "Adding cell for "
+		<< " layer " << mapiter->second->get_layer()
                 << " ladder z index: " << mapiter->second->get_ladder_z_index()
                 << ", ladder phi index: " << mapiter->second->get_ladder_phi_index()
                 << ", srip z index: " << mapiter->second->get_zbin()

--- a/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
@@ -156,6 +156,23 @@ bool PHG4SvtxClusterizer::maps_ladder_are_adjacent(const PHG4Cell* lhs,
 
 bool PHG4SvtxClusterizer::ladder_are_adjacent(const PHG4Cell* lhs, const PHG4Cell* rhs) {
 
+  if(verbosity > 2)
+    {
+      cout << " lhs layer " <<  lhs->get_layer() 
+	   << " lhs ladder z index " <<  lhs->get_ladder_z_index() 
+	   << " lhs ladder phi index " <<  lhs->get_ladder_phi_index()
+	   << " lhs z bin " <<  lhs->get_zbin()
+	   << " lhs phi bin " <<  lhs->get_phibin()
+	   << endl;
+      
+      cout << " rhs layer " <<  rhs->get_layer() 
+	   << " rhs ladder z index " <<  rhs->get_ladder_z_index() 
+	   << " rhs ladder phi index " <<  rhs->get_ladder_phi_index()
+	   << " rhs z bin " <<  rhs->get_zbin()
+	   << " rhs phi bin " <<  rhs->get_phibin()
+	   << endl;
+    }
+
   int lhs_layer = lhs->get_layer();
   int rhs_layer = rhs->get_layer();
   if (lhs_layer != rhs_layer) return false;
@@ -172,6 +189,7 @@ bool PHG4SvtxClusterizer::ladder_are_adjacent(const PHG4Cell* lhs, const PHG4Cel
   } else {
     if( fabs(lhs->get_zbin() - rhs->get_zbin()) == 0 ) {
       if( fabs(lhs->get_phibin() - rhs->get_phibin()) <= 1 ){
+	if(verbosity > 2) cout << "    accepted " << endl;
 	return true;
       } 
     }
@@ -874,6 +892,17 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 	}
 	++nhits;
 	if(verbosity > 2) cout << "     nhits = " << nhits << endl;
+	if(verbosity > 2)
+	  {
+	    cout << "  From  geometry object: hit x " << hit_location[0] << " hit y " << hit_location[1] << " hit z " << hit_location[2]  << endl;
+	    cout << "     nhits " << nhits << " clusx  = " << xsum/nhits << " clusy " << ysum/nhits << " clusz " << zsum/nhits  << endl;
+	  }
+	    if( fabs(xsum/nhits - hit_location[0]) > 0.1 ||  fabs(ysum/nhits - hit_location[1]) > 0.1 ||  fabs(zsum/nhits - hit_location[2]) > 0.1)
+	      {
+		cout << "ALERT! in layer " << layer   << " cluster (x,y,z) and hit (x,y,z) are different!" << endl;
+		cout << "     From  geometry object: hit x " << hit_location[0] << " hit y " << hit_location[1] << " hit z " << hit_location[2]  << endl;
+		cout << "        nhits " << nhits << " clusx  = " << xsum/nhits << " clusy " << ysum/nhits << " clusz "  <<  zsum/nhits << endl;		
+	      }
       }
 
       double clusx = NAN;
@@ -995,6 +1024,49 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 	    first = false;
 	  }
 	}
+
+	if(verbosity > 1)
+	  {
+	    // fairly complete sanity check:
+	    // Get the list of g4hit positions for this cluster and compare positions	    
+	    cout << " For cluster " << ptr->get_id() << " in layer " << ptr->get_layer() << " using e_weighting " << _make_e_weights[layer] << endl;
+	    cout << " cluster position: x " << ptr->get_x() << " y " << ptr->get_y() << " z " << ptr->get_z() << endl;
+	    cout << " list of SvtxHit id's: " << endl;
+	    for (SvtxCluster::HitIter iter = ptr->begin_hits(); iter != ptr->end_hits(); ++iter) {
+	      cout << "  " << *iter << " ";
+	      SvtxHit *hit = _hits->get(*iter);
+	      cout << " cell id from hit = " << hit->get_cellid() << " : " << endl; 
+	      PHG4Cell *cell = cells->findCell(hit->get_cellid());
+	      double hit_location[3] = {0.0,0.0,0.0};
+	      geom->find_strip_center(cell->get_ladder_z_index(),
+				      cell->get_ladder_phi_index(),
+				      cell->get_zbin(),
+				      cell->get_phibin(),
+				      hit_location);
+	      cout  << "      cell data: "
+		    << " layer " << cell->get_layer()
+		    << " ladder z index " << cell->get_ladder_z_index()
+		    << " ladder phi index " << cell->get_ladder_phi_index()
+		    << " ladder z bin " << cell->get_zbin()
+		    << " ladder phi bin " << cell->get_phibin()
+		    << " strip x,y,z " << hit_location[0] << "  " << hit_location[1] << "  " << hit_location[2] 
+		    << " cell edep " << cell->get_edep()
+		    << endl;
+	      
+	      for (PHG4Cell::EdepConstIterator g4iter = cell->get_g4hits().first;
+		   g4iter != cell->get_g4hits().second;
+		   ++g4iter) {		
+		PHG4Hit *g4hit = g4hits->findHit(g4iter->first);
+		cout << "      g4hit entry position: x " << g4hit->get_x(0) << " y " << g4hit->get_y(0) << " z " << g4hit->get_z(0) << " edep " << g4hit->get_edep() << " layer " << g4hit->get_layer() << endl;		
+		cout << "      g4hit exit position: x " << g4hit->get_x(1) << " y " << g4hit->get_y(1) << " z " << g4hit->get_z(1) << " edep " << g4hit->get_edep() << " layer " << g4hit->get_layer() << endl;		
+
+		// test that there is not a large difference between the cluster position and the entry position(s) of the g4 hits that contributed to it
+		if( fabs(ptr->get_x() - g4hit->get_x(0)) > 0.1 ||  fabs(ptr->get_y() - g4hit->get_y(0)) > 0.1 ||  fabs(ptr->get_z() - g4hit->get_z(0)) > 2.0)
+		  cout << "        ClusterLadderCells: ALERT! g4hit entry point and cluster (x,y,z) do not agree " << endl;
+	      }
+	    }
+	    cout << endl;
+	  }
 	
 	if (verbosity>1) {
 	  double radius = sqrt(clusx*clusx+clusy*clusy);

--- a/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
@@ -896,15 +896,16 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 	  {
 	    cout << "  From  geometry object: hit x " << hit_location[0] << " hit y " << hit_location[1] << " hit z " << hit_location[2]  << endl;
 	    cout << "     nhits " << nhits << " clusx  = " << xsum/nhits << " clusy " << ysum/nhits << " clusz " << zsum/nhits  << endl;
-	  }
+	    
 	    if( fabs(xsum/nhits - hit_location[0]) > 0.1 ||  fabs(ysum/nhits - hit_location[1]) > 0.1 ||  fabs(zsum/nhits - hit_location[2]) > 0.1)
 	      {
 		cout << "ALERT! in layer " << layer   << " cluster (x,y,z) and hit (x,y,z) are different!" << endl;
 		cout << "     From  geometry object: hit x " << hit_location[0] << " hit y " << hit_location[1] << " hit z " << hit_location[2]  << endl;
-		cout << "        nhits " << nhits << " clusx  = " << xsum/nhits << " clusy " << ysum/nhits << " clusz "  <<  zsum/nhits << endl;		
+		cout << "     From cluster:  nhits " << nhits << " clusx  = " << xsum/nhits << " clusy " << ysum/nhits << " clusz "  <<  zsum/nhits << endl;		
 	      }
+	  }
       }
-
+      
       double clusx = NAN;
       double clusy = NAN;
       double clusz = NAN;


### PR DESCRIPTION
Fixed a bug in PHG4SiliconTrackerCellReco due to the celllist key not being unique between layers. G4 hits from different layers would be added together in one cell in high multiplicity events. Added the layer number to the key.
In PHG4SiliconTrackerSteppingAction, if the prePoint step status is "fUndefined" sometimes G4 returns the copy number for the strip volume from the last call to the stepping action. That is generally an unrelated strip, and so the strip address is recorded in the hit incorrectly, leading to the cluster being in the wrong place. Added a check for this and a calculation of the strip address from the entry position in the sensor.
Added a lot of diagnostic output that can be turned on by verbosity settings, allowing a fairly complete sanity check of the whole chain that produces clusters.