### PR TITLE
Disable geometry export for EMCal blocks and wall volumes

### DIFF
--- a/offline/packages/PHGeometry/macros/PHGeom_DSTInspection.C
+++ b/offline/packages/PHGeometry/macros/PHGeom_DSTInspection.C
@@ -25,6 +25,7 @@ PHGeom_DSTInspection(string DST_file_name = "sPHENIX.root_DST.root",
   // in case DST contains sPHENIX stuff
   gSystem->Load("libcemc.so");
   gSystem->Load("libg4vertex.so");
+  gSystem->Load("libcalotrigger_io.so");
   gSystem->Load("libg4eval.so");
 
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -184,6 +184,8 @@ PHG4FullProjSpacalDetector::Construct_AzimuthalSeg()
               false, val.first, overlapcheck);
 
           calo_vol[wall_phys] = val.first;
+          assert(gdml_config);
+          gdml_config->exclude_physical_vol(wall_phys);
         }
     }
 
@@ -248,6 +250,9 @@ PHG4FullProjSpacalDetector::Construct_AzimuthalSeg()
               false, val.first, overlapcheck);
 
           calo_vol[wall_phys] = val.first;
+
+          assert(gdml_config);
+          gdml_config->exclude_physical_vol(wall_phys);
         }
     }
 
@@ -271,6 +276,8 @@ PHG4FullProjSpacalDetector::Construct_AzimuthalSeg()
           g_tower.id, overlapcheck_block);
       block_vol[block_phys] = g_tower.id;
 
+      assert(gdml_config);
+      gdml_config->exclude_physical_vol(block_phys);
     }
 
   cout << "PHG4FullProjSpacalDetector::Construct_AzimuthalSeg::" << GetName()
@@ -426,6 +433,7 @@ PHG4FullProjSpacalDetector::Construct_Fibers_SameLengthFiberPerTower(
           G4String(name.str().c_str()), LV_tower, false, fiber_ID,
           overlapcheck_fiber);
       fiber_vol[fiber_physi] = fiber_ID;
+
       assert(gdml_config);
       gdml_config->exclude_physical_vol(fiber_physi);
 
@@ -550,6 +558,7 @@ PHG4FullProjSpacalDetector::Construct_Fibers(
               fiber_logic, G4String(name.str().c_str()), LV_tower, false,
               fiber_ID, overlapcheck_fiber);
           fiber_vol[fiber_physi] = fiber_ID;
+
           assert(gdml_config);
           gdml_config->exclude_physical_vol(fiber_physi);
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -302,6 +302,8 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
                                                    false, val.first, overlapcheck);
 
       calo_vol[wall_phys] = val.first;
+      assert(gdml_config);
+      gdml_config->exclude_physical_vol(wall_phys);
     }
   }
   //
@@ -364,6 +366,8 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
                                                    false, val.first, overlapcheck);
 
       calo_vol[wall_phys] = val.first;
+      assert(gdml_config);
+      gdml_config->exclude_physical_vol(wall_phys);
     }
   }
 
@@ -397,6 +401,8 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
                                                   G4String(GetName().c_str()) + G4String("_Tower_") + to_string(g_tower.id), sec_logic, false,
                                                   g_tower.id, overlapcheck_block);
     block_vol[block_phys] = g_tower.id;
+    assert(gdml_config);
+    gdml_config->exclude_physical_vol(block_phys);
 
     if (g_tower.LightguideHeight > 0)
     {
@@ -415,6 +421,9 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
                                                      sec_logic, false, g_tower.id, overlapcheck_block);
 
           block_vol[lg_phys] = g_tower.id * 100 + ix * 10 + iy;
+
+          assert(gdml_config);
+          gdml_config->exclude_physical_vol(lg_phys);
         }
       }
     }

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -189,6 +189,9 @@ void PHG4SpacalDetector::Construct(G4LogicalVolume *logicWorld)
                                                  G4String(name.str().c_str()), cylinder_logic, false, sec,
                                                  overlapcheck);
     calo_vol[calo_phys] = sec;
+
+    assert(gdml_config);
+    gdml_config->exclude_physical_vol(calo_phys);
   }
   _geom->set_nscint(_geom->get_nscint() * _geom->get_sector_map().size());
 


### PR DESCRIPTION
Following discussion of today's simulation meeting on #341, disabling the geometry export for EMCal blocks and wall volumes. In the current Geant4->GDML->ROOT TGeo export/import chain, the SPACAL blocks was not properly translated and is placed overlapping active volumes of tracking detectors. 

@HaiwangYu : please cross check