### PR TITLE
Bug fix for PHG4GenFitTrackProjection

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4GenFitTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4GenFitTrackProjection.C
@@ -248,12 +248,9 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 					}
 				}
 
-				TVector3 n(trackstate->get_px(), trackstate->get_py(), 0);
-				genfit::SharedPlanePtr plane(new genfit::DetPlane(pos, n));
 				msop80 = unique_ptr<genfit::MeasuredStateOnPlane> (new genfit::MeasuredStateOnPlane(rep.get()));
 
 				msop80->setPosMomCov(pos, mom, cov);
-				msop80->setPlane(plane);
 			}
 
 #ifdef DEBUG
@@ -269,7 +266,7 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 				field_mgr->getFieldVal(x,y,z,Bx,By,Bz);
 				cout
 				<< __LINE__
-				<< ": { " << msop80->getPos().Perp() << ", " << msop80->getPos().Phi() << ", " << z << "} @ "
+				<< ": { " << msop80->getPos().Perp() << ", " << msop80->getPos().Phi() << ", " << msop80->getPos().Eta() << "} @ "
 				//<< "{ " << Bx << ", " << By << ", " << Bz << "}"
 				<< "{ " << msop80->getMom().Perp() << ", " << msop80->getMom().Phi() << ", " << pz << "} "
 				<<endl;
@@ -299,7 +296,7 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 				field_mgr->getFieldVal(x,y,z,Bx,By,Bz);
 				cout
 				<< __LINE__
-				<< ": { " << msop80->getPos().Perp() << ", " << msop80->getPos().Phi() << ", " << z << "} @ "
+				<< ": { " << msop80->getPos().Perp() << ", " << msop80->getPos().Phi() << ", " << msop80->getPos().Eta() << "} @ "
 				//<< "{ " << Bx << ", " << By << ", " << Bz << "}"
 				<< "{ " << msop80->getMom().Perp() << ", " << msop80->getMom().Phi() << ", " << pz << "} "
 				<<endl;

--- a/simulation/g4simulation/g4hough/PHG4GenFitTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4GenFitTrackProjection.C
@@ -102,8 +102,6 @@ int PHG4GenFitTrackProjection::InitRun(PHCompositeNode *topNode) {
 		return Fun4AllReturnCodes::ABORTRUN;
 	}
 
-	return Fun4AllReturnCodes::EVENT_OK;
-
 	if (verbosity > 0) {
 		cout
 				<< "================== PHG4GenFitTrackProjection::InitRun() ====================="


### PR DESCRIPTION
Thanks for the feedback from Sasha L. and John. L.
Found a major bug in the projection module.

The `genfit::StateOnPlane` for the projection was initialized with wrong pz = 0 GeV
Fixed it in this pull request.

Tested with e-, pT = 1 GeV/c, |vtx_z| < 5cm, eta = 0.8.

matching deta:
![image](https://user-images.githubusercontent.com/10383186/29573577-4fdff056-872d-11e7-9623-af07eda4f0a3.png)

matching dphi:
![image](https://user-images.githubusercontent.com/10383186/29573627-76b20a16-872d-11e7-998c-5c6e93fb3b90.png)

electron EMCal3X3/pT
![image](https://user-images.githubusercontent.com/10383186/29573707-b0790a92-872d-11e7-8a8c-94c392000084.png)




