### PR TITLE
Hot-fix on field setting storage objects

### DIFF
--- a/offline/packages/PHField/PHFieldConfig_v1.h
+++ b/offline/packages/PHField/PHFieldConfig_v1.h
@@ -23,6 +23,10 @@ class PHFieldConfig_v1 : public PHFieldConfig
       FieldConfigTypes field_config,
       const std::string& filename,
       double magfield_rescale = 1.);
+
+  //! default constructor for ROOT file IO
+  PHFieldConfig_v1(): PHFieldConfig_v1(kFieldInvalid, "INVALID FILE") {}
+
   virtual ~PHFieldConfig_v1();
 
   /// Virtual copy constructor.

--- a/offline/packages/PHField/PHFieldConfig_v2.h
+++ b/offline/packages/PHField/PHFieldConfig_v2.h
@@ -25,6 +25,10 @@ class PHFieldConfig_v2 : public PHFieldConfig
       double field_mag_y,
       double field_mag_z
       );
+
+  //! default constructor for ROOT file IO
+  PHFieldConfig_v2(): PHFieldConfig_v2(0,0,0) {}
+
   virtual ~PHFieldConfig_v2();
 
   /// Virtual copy constructor.


### PR DESCRIPTION
Thanks to @dvperepelitsa for the check, the DST object for field map is missing the default constructor, which is necessary for ROOT file read back. Added into this pull request.  