### PR TITLE
Hot-Fix 2: fix the unit in field wrapper for GenFit

### DIFF
--- a/offline/packages/PHGenFitPkg/GenFitExp/Field.cc
+++ b/offline/packages/PHGenFitPkg/GenFitExp/Field.cc
@@ -139,8 +139,8 @@ void Field::get(const double& x, const double& y, const double& z, double& Bx, d
 {
   assert(field_);
 
-  const double Point[4] = {x, y, z, 0};
-  double Bfield[6] = {std::numeric_limits<double>::signaling_NaN(),
+  const double Point[] = {x*CLHEP::cm, y*CLHEP::cm, z*CLHEP::cm, 0};
+  double Bfield[] = {std::numeric_limits<double>::signaling_NaN(),
                       std::numeric_limits<double>::signaling_NaN(),
                       std::numeric_limits<double>::signaling_NaN(),
                       std::numeric_limits<double>::signaling_NaN(),


### PR DESCRIPTION
Thanks @adfrawley for cross check the result of #349 , in which he found worse Upsilon resolution over full acceptance. This problem was traced to worsening resolution in the higher psuedorapidity regions. And it was finally traced to units consistency issue of field map wrapper for GenFit. GenFit used cm-kG units, while ```PHField``` used ```CLHEP``` units to max Geant4-use speed. The length unit translation at this stage was missed in #349 

This was fixed in this pull request. Tested with muons in |eta|<1 and the overall resolution is slightly improved when compared to before #349 and slightly more tracks were found. 

Request @adfrawley to test this setup again after today's build around 1PM.