### PR TITLE
Catch possible throws that could force reconstruction to abort

### DIFF
--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
@@ -710,28 +710,33 @@ double Track::get_charge() const {
 
 	if(!_track) return charge;
 
-	genfit::TrackPoint *tp_base = nullptr;
+	try{
+    genfit::TrackPoint *tp_base = nullptr;
 
-	if(_track->getNumPointsWithMeasurement() > 0) {
-		tp_base = _track->getPointWithMeasurement(0);
-	}
+    if(_track->getNumPointsWithMeasurement() > 0) {
+      tp_base = _track->getPointWithMeasurement(0);
+    }
 
-	if(!tp_base) return charge;
+    if(!tp_base) return charge;
 
-	genfit::AbsTrackRep* rep = _track->getCardinalRep();
-	if(rep) {
+    genfit::AbsTrackRep* rep = _track->getCardinalRep();
+    if(rep) {
 
-		genfit::KalmanFitterInfo* kfi = static_cast<genfit::KalmanFitterInfo*>(tp_base->getFitterInfo(rep));
+      genfit::KalmanFitterInfo* kfi = static_cast<genfit::KalmanFitterInfo*>(tp_base->getFitterInfo(rep));
 
-		if(!kfi) return charge;
+      if(!kfi) return charge;
 
-		const genfit::MeasuredStateOnPlane* state = &(kfi->getFittedState(true));
+      const genfit::MeasuredStateOnPlane* state = &(kfi->getFittedState(true));
 
-		//std::unique_ptr<genfit::StateOnPlane> state (this->extrapolateToLine(TVector3(0, 0, 0), TVector3(1, 0, 0)));
+      //std::unique_ptr<genfit::StateOnPlane> state (this->extrapolateToLine(TVector3(0, 0, 0), TVector3(1, 0, 0)));
 
-		if (state)
-			charge = rep->getCharge(*state);
-	}
+      if (state)
+        charge = rep->getCharge(*state);
+    }
+	}catch (...) {
+    if (verbosity >= 1)
+      std::cerr << "Track::get_charge - Error - obtaining charge failed. Returning NAN as charge." << std::endl;
+  }
 
 	return charge;
 }


### PR DESCRIPTION
During HIJING-embedded tracking production, Chris found GenFit fitter generates uncatched errors, which would force Fun4AllServer to quit. This is one attempt to catch these kind of errors: when Kalman fitter could not find a valid charge, set the track charge to NAN. 