### PR TITLE
Fix crash if no valid state was found

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -242,6 +242,9 @@ void PHG4HoughTransform::projectToRadius(const SvtxTrack* track,
     }
   }
 
+  // check if any state was found
+  if (closest == nullptr) return;
+
   // if we just got back the previous case, bail
   if (closest->get_pathlength() == 0.0) return;
 


### PR DESCRIPTION
Another quick fix to avoid crashes from the old version of track propagation toolset. 