### PR TITLE
Fix shower hit index in stepping actions

### DIFF
--- a/offline/QA/modules/QAG4SimulationJet.C
+++ b/offline/QA/modules/QAG4SimulationJet.C
@@ -577,9 +577,12 @@ QAG4SimulationJet::process_Spectrum(PHCompositeNode *topNode,
               }
             }
 
-          cout << "cemc_e sum = " << cemc_e << endl;
-          cout << "hcalin_e sum = " <<hcalin_e<< endl;
-          cout << "leading_jet->get_e() = " << leading_jet->get_e() << endl;
+          if (Verbosity() >= VERBOSITY_A_LOT)
+          {
+            cout << "cemc_e sum = " << cemc_e << endl;
+            cout << "hcalin_e sum = " <<hcalin_e<< endl;
+            cout << "leading_jet->get_e() = " << leading_jet->get_e() << endl;
+          }
 
           lcemcr->Fill(cemc_e / leading_jet->get_e());
           lemchcalr->Fill((cemc_e + hcalin_e) / leading_jet->get_e());

--- a/offline/QA/modules/QAG4SimulationJet.C
+++ b/offline/QA/modules/QAG4SimulationJet.C
@@ -474,6 +474,17 @@ QAG4SimulationJet::process_Spectrum(PHCompositeNode *topNode,
           JetRecoEval* recoeval = eval_stack->get_reco_eval();
           assert(recoeval);
 
+          if (Verbosity()>=VERBOSITY_A_LOT)
+          {
+            cout << __PRETTY_FUNCTION__ << "Leading Jet " << jet_name << ": ";
+            //            leading_jet->identify();
+            cout << "CEMC_TOWER sum = " << recoeval->get_energy_contribution(leading_jet, Jet::CEMC_TOWER) << endl;
+            cout << "CEMC_CLUSTER sum = " << recoeval->get_energy_contribution(leading_jet, Jet::CEMC_CLUSTER) << endl;
+            cout << "HCALIN_TOWER sum = " << recoeval->get_energy_contribution(leading_jet, Jet::HCALIN_TOWER) << endl;
+            cout << "HCALIN_CLUSTER sum = " << recoeval->get_energy_contribution(leading_jet, Jet::HCALIN_CLUSTER) << endl;
+            cout << "leading_jet->get_e() = " << leading_jet->get_e() << endl;
+          }
+
           lcemcr->Fill( //
               (recoeval->get_energy_contribution(leading_jet, Jet::CEMC_TOWER) //
               +//
@@ -506,9 +517,17 @@ QAG4SimulationJet::process_Spectrum(PHCompositeNode *topNode,
           set<PHG4Shower*> showers = _jettrutheval->all_truth_showers(
               leading_jet);
 
+
           for (set<PHG4Shower*>::const_iterator it = showers.begin();
               it != showers.end(); ++it)
             {
+
+              if (Verbosity()>=VERBOSITY_A_LOT)
+              {
+                cout << __PRETTY_FUNCTION__ << "Leading Truth Jet shower : ";
+                (*it)->identify();
+              }
+
               cemc_e += (*it)->get_edep(
                   PHG4HitDefs::get_volume_id("G4HIT_CEMC"));
               cemc_e += (*it)->get_edep(
@@ -526,7 +545,41 @@ QAG4SimulationJet::process_Spectrum(PHCompositeNode *topNode,
                   PHG4HitDefs::get_volume_id("G4HIT_BH_FORWARD_PLUS"));
               bh_e += (*it)->get_edep(
                   PHG4HitDefs::get_volume_id("G4HIT_BH_FORWARD_NEG"));
+
+              if (Verbosity() >= VERBOSITY_A_LOT)
+              {
+                //            leading_jet->identify();
+                cout << "Shower cemc_e sum = "
+                     << (*it)->get_edep(PHG4HitDefs::get_volume_id("G4HIT_CEMC"))
+                     << " + "
+                     << (*it)->get_edep(
+                            PHG4HitDefs::get_volume_id("G4HIT_CEMC_ELECTRONICS"))
+                     << " + "
+                     << (*it)->get_edep(
+                            PHG4HitDefs::get_volume_id("G4HIT_ABSORBER_CEMC"))
+                     << endl;
+                cout << "Shower hcalin_e sum = "
+                     << (*it)->get_edep(
+                            PHG4HitDefs::get_volume_id("G4HIT_HCALIN"))
+                     << " + "
+                     << (*it)->get_edep(
+                            PHG4HitDefs::get_volume_id("G4HIT_ABSORBER_HCALIN"))
+                     << endl;
+                cout << "Shower bh_e sum = "
+                     << (*it)->get_edep(PHG4HitDefs::get_volume_id("G4HIT_BH_1"))
+                     << " + "
+                     << (*it)->get_edep(
+                            PHG4HitDefs::get_volume_id("G4HIT_BH_FORWARD_PLUS"))
+                     << " + "
+                     << (*it)->get_edep(
+                            PHG4HitDefs::get_volume_id("G4HIT_BH_FORWARD_NEG"))
+                     << endl;
+              }
             }
+
+          cout << "cemc_e sum = " << cemc_e << endl;
+          cout << "hcalin_e sum = " <<hcalin_e<< endl;
+          cout << "leading_jet->get_e() = " << leading_jet->get_e() << endl;
 
           lcemcr->Fill(cemc_e / leading_jet->get_e());
           lemchcalr->Fill((cemc_e + hcalin_e) / leading_jet->get_e());

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
@@ -254,7 +254,7 @@ bool PHG4ForwardEcalSteppingAction::UserSteppingAction( const G4Step* aStep, boo
 	      hitcontainer->AddHit(layer_id, hit);
 	      if (saveshower)
 		{
-		  saveshower->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
+		  saveshower->add_g4hit_id(hitcontainer->GetID(),hit->get_hit_id());
 		}
 	      // ownership has been transferred to container, set to null
 	      // so we will create a new hit for the next track

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
@@ -256,7 +256,7 @@ bool PHG4ForwardHcalSteppingAction::UserSteppingAction( const G4Step* aStep, boo
 	      hitcontainer->AddHit(layer_id, hit);
 	      if (saveshower)
 		{
-		  saveshower->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
+		  saveshower->add_g4hit_id(hitcontainer->GetID(),hit->get_hit_id());
 		}
 	      // ownership has been transferred to container, set to null
 	      // so we will create a new hit for the next track

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -365,7 +365,7 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
         savehitcontainer->AddHit(layer_id, hit);
         if (saveshower)
         {
-          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+          saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
         }
         // ownership has been transferred to container, set to null
         // so we will create a new hit for the next track

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -391,7 +391,7 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         savehitcontainer->AddHit(layer_id, hit);
         if (saveshower)
         {
-          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+          saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
         }
         // ownership has been transferred to container, set to null
         // so we will create a new hit for the next track

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
@@ -154,7 +154,7 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
       if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
       {
         hit->set_trkid(pp->GetUserTrackId());
-	pp->GetShower()->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+	pp->GetShower()->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
       }
     }
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
@@ -301,7 +301,7 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction(const G4Step* aSt
         savehitcontainer->AddHit(layer_id, hit);
         if (saveshower)
         {
-          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+          saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
         }
         // ownership has been transferred to container, set to null
         // so we will create a new hit for the next track

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
@@ -303,7 +303,7 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction(const G4Step* aSt
         savehitcontainer->AddHit(layer_id, hit);
         if (saveshower)
         {
-          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+          saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
         }
         // ownership has been transferred to container, set to null
         // so we will create a new hit for the next track

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -457,7 +457,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       savehitcontainer->AddHit(sphxlayer, hit);
       if (saveshower)
       {
-        saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+        saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
       }
       if (verbosity > 1)
         hit->print();

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSteppingAction.cc
@@ -283,7 +283,7 @@ PHG4SpacalPrototypeSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 	      if (saveshower)
 		{
 		  // save shower under container id of active volume (for running without absorber hit container to save space)
-		  saveshower->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
+		  saveshower->add_g4hit_id(savehitcontainer->GetID(),hit->get_hit_id());
 		}
 	      // ownership has been transferred to container, set to null
 	      // so we will create a new hit for the next track

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
@@ -295,7 +295,7 @@ bool PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         savehitcontainer->AddHit(layer_id, hit);
         if (saveshower)
         {
-          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+          saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
         }
         // ownership has been transferred to container, set to null
         // so we will create a new hit for the next track


### PR DESCRIPTION
From QAing of the last jet production, we found the absorber truth energy contribution is missing during the simulation truth tracing. This problem was traced to multiple mismatch between ```hitcontainer->AddHit()``` and ```PHG4Shower::add_g4hit_id()```. They are corrected in this pull request. 