### PR TITLE
Add dca3dz, dca3dzsigma

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -124,12 +124,12 @@ int SvtxEvaluator::Init(PHCompositeNode *topNode) {
 						  "gembed:gprimary:"
 						  "trackID:px:py:pz:pt:eta:phi:"
 						  "charge:quality:chisq:ndf:nhits:layers:nmaps:nintt:ntpc:nlmaps:nlintt:nltpc:"
-						  "dca2d:dca2dsigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:nfromtruth:nwrong:ntrumaps:ntruintt:ntrutpc:layersfromtruth");
+						  "dca2d:dca2dsigma:dca3dxy:dca3dxysigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:nfromtruth:nwrong:ntrumaps:ntruintt:ntrutpc:layersfromtruth");
   
   if (_do_track_eval) _ntp_track = new TNtuple("ntp_track","svtxtrack => max truth",
 					       "event:trackID:px:py:pz:pt:eta:phi:charge:"
 					       "quality:chisq:ndf:nhits:nmaps:nintt:ntpc:nlmaps:nlintt:nltpc:layers:"
-					       "dca2d:dca2dsigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:"
+					       "dca2d:dca2dsigma:dca3dxy:dca3dxysigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:"
 					       "presdphi:presdeta:prese3x3:prese:"   
 					       "cemcdphi:cemcdeta:cemce3x3:cemce:"
 					       "hcalindphi:hcalindeta:hcaline3x3:hcaline:"
@@ -1457,6 +1457,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	unsigned int layers = 0x0;
 	float dca2d         = NAN;
 	float dca2dsigma    = NAN;
+	float dca3dxy		 = NAN;
+	float dca3dxysigma	 = NAN;
 	float dca3dz		 = NAN;
 	float dca3dzsigma	 = NAN;
 	float px            = NAN;
@@ -1522,6 +1524,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	    
 	    dca2d     = track->get_dca2d();
 	    dca2dsigma = track->get_dca2d_error();
+	    dca3dxy     = track->get_dca3d_xy();
+	    dca3dxysigma = track->get_dca3d_xy_error();
 	    dca3dz     = track->get_dca3d_z();
 	    dca3dzsigma = track->get_dca3d_z_error();
 	    px        = track->get_px();
@@ -1553,7 +1557,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	    layersfromtruth = trackeval->get_nclusters_contribution_by_layer(track,g4particle);
 	  }
 	}
-	float gtrack_data[60] = {(float) _ievent,
+	float gtrack_data[62] = {(float) _ievent,
 				 gtrackID,
 				 gflavor,
 				 ng4hits,
@@ -1602,6 +1606,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				 nltpc,
 				 dca2d,      
 				 dca2dsigma,
+				 dca3dxy,
+				 dca3dxysigma,
 				 dca3dz,
 				 dca3dzsigma,
 				 pcax,       
@@ -1701,6 +1707,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	layers = nlmaps+nlintt+nltpc;
 	float dca2d     = track->get_dca2d();
 	float dca2dsigma = track->get_dca2d_error();
+    float dca3dxy     = track->get_dca3d_xy();
+    float dca3dxysigma = track->get_dca3d_xy_error();
     float dca3dz     = track->get_dca3d_z();
     float dca3dzsigma = track->get_dca3d_z_error();
 	float px        = track->get_px();
@@ -1858,7 +1866,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  }
 	}
       
-	float track_data[76] = {(float) _ievent,
+	float track_data[78] = {(float) _ievent,
 				trackID, 
 				px,        
 				py,        
@@ -1874,6 +1882,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				(float) layers,
 				dca2d,     
 				dca2dsigma,
+				dca3dxy,
+				dca3dxysigma,
 				dca3dz,
 				dca3dzsigma,
 				pcax,      

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -124,12 +124,12 @@ int SvtxEvaluator::Init(PHCompositeNode *topNode) {
 						  "gembed:gprimary:"
 						  "trackID:px:py:pz:pt:eta:phi:"
 						  "charge:quality:chisq:ndf:nhits:layers:nmaps:nintt:ntpc:nlmaps:nlintt:nltpc:"
-						  "dca2d:dca2dsigma:pcax:pcay:pcaz:nfromtruth:nwrong:ntrumaps:ntruintt:ntrutpc:layersfromtruth");
+						  "dca2d:dca2dsigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:nfromtruth:nwrong:ntrumaps:ntruintt:ntrutpc:layersfromtruth");
   
   if (_do_track_eval) _ntp_track = new TNtuple("ntp_track","svtxtrack => max truth",
 					       "event:trackID:px:py:pz:pt:eta:phi:charge:"
 					       "quality:chisq:ndf:nhits:nmaps:nintt:ntpc:nlmaps:nlintt:nltpc:layers:"
-					       "dca2d:dca2dsigma:pcax:pcay:pcaz:"
+					       "dca2d:dca2dsigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:"
 					       "presdphi:presdeta:prese3x3:prese:"   
 					       "cemcdphi:cemcdeta:cemce3x3:cemce:"
 					       "hcalindphi:hcalindeta:hcaline3x3:hcaline:"
@@ -1457,6 +1457,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	unsigned int layers = 0x0;
 	float dca2d         = NAN;
 	float dca2dsigma    = NAN;
+	float dca3dz		 = NAN;
+	float dca3dzsigma	 = NAN;
 	float px            = NAN;
 	float py            = NAN;
 	float pz            = NAN;
@@ -1520,6 +1522,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	    
 	    dca2d     = track->get_dca2d();
 	    dca2dsigma = track->get_dca2d_error();
+	    dca3dz     = track->get_dca3d_z();
+	    dca3dzsigma = track->get_dca3d_z_error();
 	    px        = track->get_px();
 	    py        = track->get_py();
 	    pz        = track->get_pz();
@@ -1549,7 +1553,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	    layersfromtruth = trackeval->get_nclusters_contribution_by_layer(track,g4particle);
 	  }
 	}
-	float gtrack_data[58] = {(float) _ievent,
+	float gtrack_data[60] = {(float) _ievent,
 				 gtrackID,
 				 gflavor,
 				 ng4hits,
@@ -1597,7 +1601,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				 nlintt,
 				 nltpc,
 				 dca2d,      
-				 dca2dsigma, 			       
+				 dca2dsigma,
+				 dca3dz,
+				 dca3dzsigma,
 				 pcax,       
 				 pcay,       
 				 pcaz,
@@ -1695,6 +1701,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	layers = nlmaps+nlintt+nltpc;
 	float dca2d     = track->get_dca2d();
 	float dca2dsigma = track->get_dca2d_error();
+    float dca3dz     = track->get_dca3d_z();
+    float dca3dzsigma = track->get_dca3d_z_error();
 	float px        = track->get_px();
 	float py        = track->get_py();
 	float pz        = track->get_pz();
@@ -1850,7 +1858,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  }
 	}
       
-	float track_data[74] = {(float) _ievent,
+	float track_data[76] = {(float) _ievent,
 				trackID, 
 				px,        
 				py,        
@@ -1865,7 +1873,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				nhits,nmaps,nintt,ntpc,nlmaps,nlintt,nltpc,   
 				(float) layers,
 				dca2d,     
-				dca2dsigma,      
+				dca2dsigma,
+				dca3dz,
+				dca3dzsigma,
 				pcax,      
 				pcay,      
 				pcaz,      

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
@@ -174,7 +174,7 @@ PHG4TrackKalmanFitter::PHG4TrackKalmanFitter(const string &name) :
 		_over_write_svtxtrackmap(true),
 		_over_write_svtxvertexmap(true),
 		_fit_primary_tracks(false),
-		_use_truth_vertex(true),
+		_use_truth_vertex(false),
 		_fitter( NULL),
 		_track_fitting_alg_name("DafRef"),
 		_primary_pid_guess(211),
@@ -1306,9 +1306,13 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 	 * dca3d_xy, dca3d_z
 	 */
 
+
+	/*
+	// Rotate from u,v,n to n X Z, nX(nXZ), n using 5D state/cov
+	// commented on 2017-10-09
+
 	TMatrixF pos_in(3,1);
 	TMatrixF cov_in(3,3);
-
 	pos_in[0][0] = gf_state_vertex_ca->getState()[3];
 	pos_in[1][0] = gf_state_vertex_ca->getState()[4];
 	pos_in[2][0] = 0.;
@@ -1342,7 +1346,8 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 
 	float dca3d_xy_error = sqrt(cov_out[0][0] + vertex_cov_out[0][0]);
 	float dca3d_z_error  = sqrt(cov_out[1][1] + vertex_cov_out[1][1]);
-	//Begin DEBUG
+
+		//Begin DEBUG
 //	LogDebug("rotation debug---------- ");
 //	gf_state_vertex_ca->Print();
 //	LogDebug("dca rotation---------- ");
@@ -1362,6 +1367,73 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 //	vertex_cov.Print();
 //	vertex_cov_out.Print();
 	//End DEBUG
+	*/
+
+	//
+	// in: X, Y, Z; out; r: n X Z, Z X r, Z
+
+	float dca3d_xy = NAN;
+	float dca3d_z  = NAN;
+	float dca3d_xy_error = NAN;
+	float dca3d_z_error  = NAN;
+
+	try{
+		TMatrixF pos_in(3,1);
+		TMatrixF cov_in(3,3);
+		TMatrixF pos_out(3,1);
+		TMatrixF cov_out(3,3);
+
+		TVectorD state6(6); // pos(3), mom(3)
+		TMatrixDSym cov6(6,6); //
+
+		gf_state_vertex_ca->get6DStateCov(state6, cov6);
+
+		TVector3 vn(state6[3], state6[4], state6[5]);
+
+		// mean of two multivariate gaussians Pos - Vertex
+		pos_in[0][0] = state6[0] - vertex_position.X();
+		pos_in[1][0] = state6[1] - vertex_position.Y();
+		pos_in[2][0] = state6[2] - vertex_position.Z();
+
+
+		for(int i=0;i<3;++i){
+			for(int j=0;j<3;++j){
+				cov_in[i][j] = cov6[i][j] + vertex_cov[i][j];
+			}
+		}
+
+		pos_cov_XYZ_to_RZ(vn, pos_in, cov_in, pos_out, cov_out);
+
+		dca3d_xy = pos_out[0][0];
+		dca3d_z  = pos_out[2][0];
+		dca3d_xy_error = sqrt(cov_out[0][0]);
+		dca3d_z_error  = sqrt(cov_out[2][2]);
+
+		cout<<__LINE__<<": Vertex: ----------------"<<endl;
+		vertex_position.Print();
+		vertex_cov.Print();
+
+		cout<<__LINE__<<": State: ----------------"<<endl;
+		state6.Print();
+		cov6.Print();
+
+		cout<<__LINE__<<": Mean: ----------------"<<endl;
+		pos_in.Print();
+		cout<<"===>"<<endl;
+		pos_out.Print();
+
+		cout<<__LINE__<<": Cov: ----------------"<<endl;
+		cov_in.Print();
+		cout<<"===>"<<endl;
+		cov_out.Print();
+
+		cout<<endl;
+
+
+	} catch (...) {
+		if (verbosity > 0)
+			LogWarning("DCA calculationfailed!");
+	}
 
 	out_track->set_dca3d_xy(dca3d_xy);
 	out_track->set_dca3d_z(dca3d_z);
@@ -1774,6 +1846,63 @@ bool PHG4TrackKalmanFitter::get_vertex_error_uvn(const TVector3 u,
 
 	cov_out.ResizeTo(3, 3);
 
+	cov_out = R * cov_in * R_T;
+
+	return true;
+}
+
+
+bool PHG4TrackKalmanFitter::pos_cov_XYZ_to_RZ(
+		const TVector3 n, const TMatrixF pos_in, const TMatrixF cov_in,
+		TMatrixF& pos_out, TMatrixF& cov_out) const {
+
+	if(pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3) {
+		if(verbosity > 0) LogWarning("pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3");
+		return false;
+	}
+
+	if(cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3) {
+		if(verbosity > 0) LogWarning("cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3");
+		return false;
+	}
+
+	TVector3 r = n.Cross(TVector3(0.,0.,1.));
+
+	if(r.Mag() < 0.00001){
+		if(verbosity > 0) LogWarning("n is parallel to z");
+		return false;
+	}
+
+
+	// R: rotation from u,v,n to n X Z, nX(nXZ), n
+	TMatrixF R(3, 3);
+	TMatrixF R_T(3,3);
+
+	try {
+		// rotate u along z to up
+		float phi = -TMath::ATan2(r.Y(), r.X());
+		R[0][0] = cos(phi);
+		R[0][1] = -sin(phi);
+		R[0][2] = 0;
+		R[1][0] = sin(phi);
+		R[1][1] = cos(phi);
+		R[1][2] = 0;
+		R[2][0] = 0;
+		R[2][1] = 0;
+		R[2][2] = 1;
+
+		R_T.Transpose(R);
+	} catch (...) {
+		if (verbosity > 0)
+			LogWarning("Can't get rotation matrix");
+
+		return false;
+	}
+
+	pos_out.ResizeTo(3, 1);
+	cov_out.ResizeTo(3, 3);
+
+	pos_out = R * pos_in;
 	cov_out = R * cov_in * R_T;
 
 	return true;

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
@@ -1310,7 +1310,7 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 
 
 	/*
-	// Rotate from u,v,n to n X Z, nX(nXZ), n using 5D state/cov
+	// Rotate from u,v,n to r: n X Z, Z': n X r, n using 5D state/cov
 	// commented on 2017-10-09
 
 	TMatrixF pos_in(3,1);
@@ -1411,6 +1411,7 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 		dca3d_xy_error = sqrt(cov_out[0][0]);
 		dca3d_z_error  = sqrt(cov_out[2][2]);
 
+#ifdef _DEBUG_
 		cout<<__LINE__<<": Vertex: ----------------"<<endl;
 		vertex_position.Print();
 		vertex_cov.Print();
@@ -1430,7 +1431,7 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 		cov_out.Print();
 
 		cout<<endl;
-
+#endif
 
 	} catch (...) {
 		if (verbosity > 0)
@@ -1752,8 +1753,8 @@ bool PHG4TrackKalmanFitter::FillSvtxVertexMap(
 //	return true;
 //}
 
-bool PHG4TrackKalmanFitter::pos_cov_uvn_to_rz(const TVector3 u, const TVector3 v,
-		const TVector3 n, const TMatrixF pos_in, const TMatrixF cov_in,
+bool PHG4TrackKalmanFitter::pos_cov_uvn_to_rz(const TVector3& u, const TVector3& v,
+		const TVector3& n, const TMatrixF& pos_in, const TMatrixF& cov_in,
 		TMatrixF& pos_out, TMatrixF& cov_out) const {
 
 	if(pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3) {
@@ -1809,8 +1810,8 @@ bool PHG4TrackKalmanFitter::pos_cov_uvn_to_rz(const TVector3 u, const TVector3 v
 	return true;
 }
 
-bool PHG4TrackKalmanFitter::get_vertex_error_uvn(const TVector3 u,
-		const TVector3 v, const TVector3 n, const TMatrixF cov_in,
+bool PHG4TrackKalmanFitter::get_vertex_error_uvn(const TVector3& u,
+		const TVector3& v, const TVector3& n, const TMatrixF& cov_in,
 		TMatrixF& cov_out) const {
 
 	/*!
@@ -1855,7 +1856,7 @@ bool PHG4TrackKalmanFitter::get_vertex_error_uvn(const TVector3 u,
 
 
 bool PHG4TrackKalmanFitter::pos_cov_XYZ_to_RZ(
-		const TVector3 n, const TMatrixF pos_in, const TMatrixF cov_in,
+		const TVector3& n, const TMatrixF& pos_in, const TMatrixF& cov_in,
 		TMatrixF& pos_out, TMatrixF& cov_out) const {
 
 	if(pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3) {

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
@@ -226,27 +226,27 @@ private:
 			const std::vector<genfit::Track*> & gf_tracks);
 
 	bool pos_cov_uvn_to_rz(
-			const TVector3 u,
-			const TVector3 v,
-			const TVector3 n,
-			const TMatrixF pos_in,
-			const TMatrixF cov_in,
+			const TVector3& u,
+			const TVector3& v,
+			const TVector3& n,
+			const TMatrixF& pos_in,
+			const TMatrixF& cov_in,
 			TMatrixF & pos_out,
 			TMatrixF & cov_out
 			) const;
 
 	bool get_vertex_error_uvn(
-			const TVector3 u,
-			const TVector3 v,
-			const TVector3 n,
-			const TMatrixF cov_in,
+			const TVector3& u,
+			const TVector3& v,
+			const TVector3& n,
+			const TMatrixF& cov_in,
 			TMatrixF & cov_out
 			) const;
 
 	bool pos_cov_XYZ_to_RZ(
-			const TVector3 n,
-			const TMatrixF pos_in,
-			const TMatrixF cov_in,
+			const TVector3& n,
+			const TMatrixF& pos_in,
+			const TMatrixF& cov_in,
 			TMatrixF & pos_out,
 			TMatrixF & cov_out
 			) const;

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.h
@@ -235,6 +235,14 @@ private:
 			TMatrixF & cov_out
 			) const;
 
+	bool pos_cov_XYZ_to_RZ(
+			const TVector3 n,
+			const TMatrixF pos_in,
+			const TMatrixF cov_in,
+			TMatrixF & pos_out,
+			TMatrixF & cov_out
+			) const;
+
 	/*!
 	 * Get 3D Rotation Matrix that rotates frame (x,y,z) to (x',y',z')
 	 * Default rotate local to global, or rotate vector in global to local representation


### PR DESCRIPTION
Add dca3dz, dca3dzsigma to the `SvtxEvaluator` for convenience.
dca3d is calculated using PCA with regarding to the reconstructed vertex.
So this is related to pull request [356](https://github.com/sPHENIX-Collaboration/coresoftware/pull/356)

dca2d is calculated using PCA with regarding to a line parallel to beam pipe and through the reconstructed vertex. (line x=vx, y=vy)
