### PR TITLE
Correct SPACAL tower eta position reporting

### DIFF
--- a/simulation/g4simulation/g4cemc/RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4cemc/RawTowerBuilder.cc
@@ -232,6 +232,14 @@ RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
       throw std::runtime_error("Failed to find Run node in RawTowerBuilder::CreateNodes");
     }
 
+  PHNodeIterator runIter(runNode);
+  PHCompositeNode *RunDetNode =  dynamic_cast<PHCompositeNode*>(runIter.findFirst("PHCompositeNode",detector));
+  if (! RunDetNode)
+    {
+      RunDetNode = new PHCompositeNode(detector);
+      runNode->addNode(RunDetNode);
+    }
+
   const RawTowerDefs::CalorimeterId caloid = RawTowerDefs::convert_name_to_caloid(detector);
 
   // get the cell geometry and build up the tower geometry object
@@ -251,7 +259,7 @@ RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
     {
       rawtowergeom = new RawTowerGeomContainer_Cylinderv1(caloid);
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom, TowerGeomNodeName.c_str(), "PHObject");
-      runNode->addNode(newNode);
+      RunDetNode->addNode(newNode);
     }
   // fill the number of layers in the calorimeter
   _nlayers = cellgeos->get_NLayers();

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -234,9 +234,12 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
 	  const double dz = fabs(0.5 * (tower.pDy1 + tower.pDy2) / sin(tower.pRotationAngleX));
 	  const double tower_radial = layergeom->get_tower_radial_position(tower);
 
-	  const double eta_central = -log(tan(0.5 * atan2(tower_radial, tower.centralZ)));
+	  auto z_to_eta = [&tower_radial](const double &z){return -log(tan(0.5 * atan2(tower_radial, z)));};
+
+	  const double eta_central = z_to_eta(tower.centralZ);
 	  // half eta-range
-	  const double deta = fabs(eta_central - (-log(tan(0.5 * atan2(tower_radial, tower.centralZ + dz)))));
+	  const double deta = (z_to_eta( tower.centralZ + dz) - z_to_eta( tower.centralZ - dz))/2;
+	  assert(deta > 0);
 
 	  for (int sub_tower_ID_y = 0; sub_tower_ID_y < tower.NSubtowerY;
 	       ++sub_tower_ID_y)
@@ -245,12 +248,31 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
 	      // do not overlap to the next bin.
 	      const int sub_tower_etabin = etabin * layergeom->get_n_subtower_eta() + sub_tower_ID_y;
 
-	      layerseggeo->set_etabounds(sub_tower_etabin,
-					 make_pair<double, double>(eta_central - deta + sub_tower_ID_y * 2 * deta / tower.NSubtowerY, 
-								   eta_central - deta + (sub_tower_ID_y + 1) * 2 * deta / tower.NSubtowerY));
-	      layerseggeo->set_zbounds(sub_tower_etabin,
-				       make_pair<double, double>(tower.centralZ - dz + sub_tower_ID_y * 2 * dz / tower.NSubtowerY,
-								 tower.centralZ - dz + (sub_tower_ID_y + 1) * 2 * dz / tower.NSubtowerY));
+	      const pair<double, double>etabounds  (eta_central - deta + sub_tower_ID_y * 2 * deta / tower.NSubtowerY,
+            eta_central - deta + (sub_tower_ID_y + 1) * 2 * deta / tower.NSubtowerY);
+
+	      const pair<double, double>zbounds  (tower.centralZ - dz + sub_tower_ID_y * 2 * dz / tower.NSubtowerY,
+            tower.centralZ - dz + (sub_tower_ID_y + 1) * 2 * dz / tower.NSubtowerY);
+
+	      layerseggeo->set_etabounds(sub_tower_etabin,etabounds);
+	      layerseggeo->set_zbounds(sub_tower_etabin,zbounds);
+
+	      if (verbosity >= VERBOSITY_SOME)
+	        {
+	          cout << "PHG4FullProjSpacalCellReco::InitRun::" << Name()
+               << "\t tower_ID_z = " << tower_ID_z
+               << "\t tower_ID_phi = " << tower_ID_phi
+               << "\t sub_tower_ID_y = " << sub_tower_ID_y
+               << "\t sub_tower_etabin = " << sub_tower_etabin
+               << "\t dz = " << dz
+               << "\t tower_radial = " << tower_radial
+               << "\t eta_central = " << eta_central
+               << "\t deta = " << deta
+               << "\t etabounds = [" <<etabounds.first << ", " << etabounds.second<<"]"
+               << "\t zbounds = [" <<zbounds.first << ", " << zbounds.second<<"]"
+               <<endl;
+	        }
+
 	    }
 
 	}
@@ -543,10 +565,12 @@ PHG4FullProjSpacalCellReco::LightCollectionModel::load_data_file(
   assert(fin);
   assert(fin->IsOpen());
 
+  if (data_grid_light_guide_efficiency) delete data_grid_light_guide_efficiency;
   data_grid_light_guide_efficiency = dynamic_cast<TH2 *>(fin->Get(histogram_light_guide_model.c_str()));
   assert(data_grid_light_guide_efficiency);
   data_grid_light_guide_efficiency->SetDirectory(nullptr);
 
+  if (data_grid_fiber_trans) delete data_grid_fiber_trans;
   data_grid_fiber_trans = dynamic_cast<TH1 *>(fin->Get(histogram_fiber_model.c_str()));
   assert(data_grid_fiber_trans);
   data_grid_fiber_trans->SetDirectory(nullptr);

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -231,7 +231,7 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
       if (tower_ID_phi == layergeom->get_max_phi_bin_in_sec() / 2)
 	{
 	  // half z-range
-	  const double dz = fabs(0.5 * (tower.pDy1 + tower.pDy2) * sin(tower.pRotationAngleX));
+	  const double dz = fabs(0.5 * (tower.pDy1 + tower.pDy2) / sin(tower.pRotationAngleX));
 	  const double tower_radial = layergeom->get_tower_radial_position(tower);
 
 	  const double eta_central = -log(tan(0.5 * atan2(tower_radial, tower.centralZ)));


### PR DESCRIPTION
During pi0/photon analysis, Alexander Bazilevsky found unexpected variation in SPACAL tower-to-tower spacing as reported by geometry node ```RUN/TOWERGEOM_CEMC```

This problem was traced to the calculation error in the tower position reporting, which is corrected in this pull request. 

The corrected tower size and spacing in psudorapidity is checked here. Note the non-zero spacing between towers when they are not belong to the same 2x2 block, and the larger spacing between two EMCal half sectors at the center. 
![spacalblocks blocklocation](https://user-images.githubusercontent.com/7947083/30602904-f9f532ba-9d33-11e7-9df1-16f1866db876.png)
