### PR TITLE
Abort reconstruction is missing vertex during tower-jet reco

### DIFF
--- a/simulation/g4simulation/g4jets/TowerJetInput.C
+++ b/simulation/g4simulation/g4jets/TowerJetInput.C
@@ -46,6 +46,10 @@ std::vector<Jet*> TowerJetInput::get_input(PHCompositeNode *topNode) {
 
   GlobalVertexMap* vertexmap = findNode::getClass<GlobalVertexMap>(topNode,"GlobalVertexMap");
   if (!vertexmap) {
+
+    cout <<"TowerJetInput::get_input - Fatal Error - vertexmap is missing. Turn back on do_global flag in the main macro in order to reconstruct the global vertex."<<endl;
+    assert(vertexmap); // force quit
+
     return std::vector<Jet*>();
   }
 

--- a/simulation/g4simulation/g4jets/TowerJetInput.C
+++ b/simulation/g4simulation/g4jets/TowerJetInput.C
@@ -47,7 +47,7 @@ std::vector<Jet*> TowerJetInput::get_input(PHCompositeNode *topNode) {
   GlobalVertexMap* vertexmap = findNode::getClass<GlobalVertexMap>(topNode,"GlobalVertexMap");
   if (!vertexmap) {
 
-    cout <<"TowerJetInput::get_input - Fatal Error - vertexmap is missing. Turn back on do_global flag in the main macro in order to reconstruct the global vertex."<<endl;
+    cout <<"TowerJetInput::get_input - Fatal Error - GlobalVertexMap node is missing. Please turn on the do_global flag in the main macro in order to reconstruct the global vertex."<<endl;
     assert(vertexmap); // force quit
 
     return std::vector<Jet*>();


### PR DESCRIPTION
During a jet reco test with Raghav Elayavalli, we noticed the jet finder will discard tower input silently if missing the necessary global vertex node. Vertex is used to convert tower coordinate into eta for FastJet. The default behavior of discarding tower silently prevents users from identifying the source of the problem. 

This pull request is a quick update that make the global vertex node a requirement for TowerJets to be processed. Otherwise, the reconstruction aborts with an error message about how to recover the vertex node. 