### PR TITLE
Hcal size changes

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -308,6 +308,8 @@ libg4detectors_la_SOURCES = \
 ################################################
 # linking tests
 
+BUILT_SOURCES = testexternals.cc
+
 noinst_PROGRAMS = \
   testexternals_g4detectors \
   testexternals_g4detectors_io

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -4,7 +4,6 @@
 
 #include <g4main/PHG4Utils.h>
 
-
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
@@ -12,78 +11,72 @@
 #include <TSystem.h>
 
 #include <Geant4/G4AssemblyVolume.hh>
-#include <Geant4/G4IntersectionSolid.hh>
-#include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/G4Material.hh>
 #include <Geant4/G4Box.hh>
+#include <Geant4/G4Colour.hh>
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4ExtrudedSolid.hh>
+#include <Geant4/G4IntersectionSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4Trap.hh>
 #include <Geant4/G4Tubs.hh>
+#include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4UserLimits.hh>
-
 #include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4Colour.hh>
 
-#include <CGAL/Exact_circular_kernel_2.h>
-#include <CGAL/point_generators_2.h>
-#include <CGAL/Object.h>
-#include <CGAL/Circular_kernel_intersections.h>
 #include <CGAL/Boolean_set_operations_2.h>
-
-#include <boost/math/special_functions/sign.hpp>
+#include <CGAL/Circular_kernel_intersections.h>
+#include <CGAL/Exact_circular_kernel_2.h>
+#include <CGAL/Object.h>
+#include <CGAL/point_generators_2.h>
 
 #include <cmath>
 #include <sstream>
 
-typedef CGAL::Exact_circular_kernel_2             Circular_k;
-typedef CGAL::Point_2<Circular_k>                 Point_2;
-typedef CGAL::Circle_2<Circular_k>                Circle_2;
-typedef CGAL::Circular_arc_point_2<Circular_k>          Circular_arc_point_2;
-typedef CGAL::Line_2<Circular_k>                Line_2;
-typedef CGAL::Segment_2<Circular_k>                Segment_2;
+typedef CGAL::Circle_2<PHG4InnerHcalDetector::Circular_k> Circle_2;
+typedef CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k> Circular_arc_point_2;
+typedef CGAL::Line_2<PHG4InnerHcalDetector::Circular_k> Line_2;
+typedef CGAL::Segment_2<PHG4InnerHcalDetector::Circular_k> Segment_2;
 
 using namespace std;
 
 // there is still a minute problem for very low tilt angles where the scintillator
 // face touches the boundary instead of the corner, subtracting 1 permille from the total
 // scintilator length takes care of this
-static double subtract_from_scinti_x = 0.1*mm;
+static double subtract_from_scinti_x = 0.1 * mm;
 
-PHG4InnerHcalDetector::PHG4InnerHcalDetector( PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam  ):
-  PHG4Detector(Node, dnam),
-  params(parameters),
-  scinti_mother_assembly(nullptr),
-  inner_radius(params->get_double_param("inner_radius")*cm),
-  outer_radius(params->get_double_param("outer_radius")*cm),
-  size_z(params->get_double_param("size_z")*cm),
-  scinti_tile_x(NAN),
-  scinti_tile_x_lower(NAN),
-  scinti_tile_x_upper(NAN),
-  scinti_tile_z(size_z),
-  scinti_tile_thickness(params->get_double_param("scinti_tile_thickness")*cm),
-  scinti_inner_gap(params->get_double_param("scinti_inner_gap")*cm),
-  scinti_outer_gap(params->get_double_param("scinti_outer_gap")*cm),
-  scinti_outer_radius(params->get_double_param("scinti_outer_radius")*cm),
-  tilt_angle(params->get_double_param("tilt_angle")*deg),
-  envelope_inner_radius(inner_radius),
-  envelope_outer_radius(outer_radius),
-  envelope_z(size_z),
-  volume_envelope(NAN),
-  volume_steel(NAN),
-  volume_scintillator(NAN),
-  n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr)*params->get_int_param("n_towers")),
-  n_scinti_tiles(params->get_int_param("n_scinti_tiles")),
-  active(params->get_int_param("active")),
-  absorberactive(params->get_int_param("absorberactive")),
-  layer(0),
-  scintilogicnameprefix("HcalInnerScinti")
+PHG4InnerHcalDetector::PHG4InnerHcalDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam)
+  : PHG4Detector(Node, dnam)
+  , params(parameters)
+  , scinti_mother_assembly(nullptr)
+  , inner_radius(params->get_double_param("inner_radius") * cm)
+  , outer_radius(params->get_double_param("outer_radius") * cm)
+  , size_z(params->get_double_param("size_z") * cm)
+  , scinti_tile_x(NAN)
+  , scinti_tile_x_lower(NAN)
+  , scinti_tile_x_upper(NAN)
+  , scinti_tile_z(size_z)
+  , scinti_tile_thickness(params->get_double_param("scinti_tile_thickness") * cm)
+  , scinti_inner_gap(params->get_double_param("scinti_inner_gap") * cm)
+  , scinti_outer_gap(params->get_double_param("scinti_outer_gap") * cm)
+  , scinti_outer_radius(params->get_double_param("scinti_outer_radius") * cm)
+  , tilt_angle(params->get_double_param("tilt_angle") * deg)
+  , envelope_inner_radius(inner_radius)
+  , envelope_outer_radius(outer_radius)
+  , envelope_z(size_z)
+  , volume_envelope(NAN)
+  , volume_steel(NAN)
+  , volume_scintillator(NAN)
+  , n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr) * params->get_int_param("n_towers"))
+  , n_scinti_tiles(params->get_int_param("n_scinti_tiles"))
+  , active(params->get_int_param("active"))
+  , absorberactive(params->get_int_param("absorberactive"))
+  , layer(0)
+  , scintilogicnameprefix("HcalInnerScinti")
 {
-
   // allocate memory for scintillator plates
   scinti_tiles_vec.assign(2 * n_scinti_tiles, static_cast<G4VSolid *>(nullptr));
 }
@@ -95,8 +88,7 @@ PHG4InnerHcalDetector::~PHG4InnerHcalDetector()
 
 //_______________________________________________________________
 //_______________________________________________________________
-int
-PHG4InnerHcalDetector::IsInInnerHcal(G4VPhysicalVolume * volume) const
+int PHG4InnerHcalDetector::IsInInnerHcal(G4VPhysicalVolume *volume) const
 {
   // G4AssemblyVolumes naming convention:
   //     av_WWW_impr_XXX_YYY_ZZZ
@@ -112,167 +104,166 @@ PHG4InnerHcalDetector::IsInInnerHcal(G4VPhysicalVolume * volume) const
   // HcalInnerScinti_11: name of scintillator slat
   // 11: number of scintillator slat logical volume
   if (absorberactive)
+  {
+    if (steel_absorber_vec.find(volume) != steel_absorber_vec.end())
     {
-      if (steel_absorber_vec.find(volume) != steel_absorber_vec.end())
-	{
-	  return -1;
-	}
+      return -1;
     }
+  }
   if (active)
+  {
+    if (volume->GetName().find(scintilogicnameprefix) != string::npos)
     {
-      if (volume->GetName().find(scintilogicnameprefix) != string::npos)
-	{
-	  return 1;
-	}
+      return 1;
     }
+  }
   return 0;
 }
 
-G4VSolid*
-PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
+G4VSolid *
+PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
 {
   double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
-  Point_2 p_in_1(mid_radius, 0); // center of scintillator
+  Point_2 p_in_1(mid_radius, 0);  // center of scintillator
 
   // length of upper edge (middle till outer circle intersect
   // x/y coordinate of end of center vertical
-  double xcoord  = scinti_tile_thickness / 2. *sin(fabs(tilt_angle)/rad) +  mid_radius;
-  double ycoord  =   scinti_tile_thickness / 2. * cos(fabs(tilt_angle)/rad) + 0;
+  double xcoord = scinti_tile_thickness / 2. * sin(fabs(tilt_angle) / rad) + mid_radius;
+  double ycoord = scinti_tile_thickness / 2. * cos(fabs(tilt_angle) / rad) + 0;
   Point_2 p_upperedge(xcoord, ycoord);
-  Line_2 s2(p_in_1, p_upperedge); // center vertical
+  Line_2 s2(p_in_1, p_upperedge);  // center vertical
 
-  Line_2 perp =  s2.perpendicular(p_upperedge);
+  Line_2 perp = s2.perpendicular(p_upperedge);
   Point_2 sc1(outer_radius, 0), sc2(0, outer_radius), sc3(-outer_radius, 0);
   Circle_2 outer_circle(sc1, sc2, sc3);
-  vector< CGAL::Object > res;
+  vector<CGAL::Object> res;
   CGAL::intersection(outer_circle, perp, std::back_inserter(res));
   Point_2 upperright;
-  vector< CGAL::Object >::const_iterator iter;
+  vector<CGAL::Object>::const_iterator iter;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) >  CGAL::to_double(p_upperedge.x()))
-	    {
-	      double deltax = CGAL::to_double(point->first.x()) - CGAL::to_double(p_upperedge.x());
-	      double deltay = CGAL::to_double(point->first.y()) - CGAL::to_double(p_upperedge.y());
-	      // the scintillator is twice as long
-	      scinti_tile_x_upper = sqrt(deltax * deltax + deltay * deltay); //
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      upperright = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	}
+      if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_upperedge.x()))
+      {
+        double deltax = CGAL::to_double(point->first.x()) - CGAL::to_double(p_upperedge.x());
+        double deltay = CGAL::to_double(point->first.y()) - CGAL::to_double(p_upperedge.y());
+        // the scintillator is twice as long
+        scinti_tile_x_upper = sqrt(deltax * deltax + deltay * deltay);  //
+        Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        upperright = pntmp;
+      }
     }
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+    }
+  }
   // length of lower edge (middle till inner circle intersect
-  xcoord = mid_radius - scinti_tile_thickness / 2. * sin(fabs(tilt_angle)/rad);
-  ycoord  = 0 -  scinti_tile_thickness / 2. * cos(fabs(tilt_angle)/rad);
+  xcoord = mid_radius - scinti_tile_thickness / 2. * sin(fabs(tilt_angle) / rad);
+  ycoord = 0 - scinti_tile_thickness / 2. * cos(fabs(tilt_angle) / rad);
   Point_2 p_loweredge(xcoord, ycoord);
   Line_2 s3(p_in_1, p_loweredge);
   Line_2 l_lower = s3.perpendicular(p_loweredge);
   Point_2 ic1(inner_radius, 0), ic2(0, inner_radius), ic3(-inner_radius, 0);
-  Circle_2 inner_circle(ic1,ic2,ic3);
+  Circle_2 inner_circle(ic1, ic2, ic3);
   res.clear();
-  CGAL::intersection(inner_circle,l_lower, std::back_inserter(res));
+  CGAL::intersection(inner_circle, l_lower, std::back_inserter(res));
   Point_2 lowerleft;
   // we have 2 intersections - we want the one furthest to the right (largest x). The correct one is
   // certainly > 0 but the second one depends on the tilt angle and might also be > 0
   double minx = 0;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) >  minx)
-	    {
-	      minx = CGAL::to_double(point->first.x());
-	      double deltax = CGAL::to_double(point->first.x()) - CGAL::to_double(p_loweredge.x());
-	      double deltay = CGAL::to_double(point->first.y()) - CGAL::to_double(p_loweredge.y());
-              scinti_tile_x_lower = sqrt(deltax * deltax + deltay * deltay);
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      lowerleft = pntmp;
-	    }
-	}
+      if (CGAL::to_double(point->first.x()) > minx)
+      {
+        minx = CGAL::to_double(point->first.x());
+        double deltax = CGAL::to_double(point->first.x()) - CGAL::to_double(p_loweredge.x());
+        double deltay = CGAL::to_double(point->first.y()) - CGAL::to_double(p_loweredge.y());
+        scinti_tile_x_lower = sqrt(deltax * deltax + deltay * deltay);
+        Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        lowerleft = pntmp;
+      }
     }
-  scinti_tile_x  = scinti_tile_x_upper + scinti_tile_x_lower -((outer_radius-scinti_outer_radius)/cos(tilt_angle/rad));
-  scinti_tile_x  -= subtract_from_scinti_x;
-  G4VSolid* scintibox =  new G4Box("ScintiTile", scinti_tile_x / 2., scinti_tile_thickness / 2., scinti_tile_z / 2.);
-  volume_scintillator = scintibox->GetCubicVolume() *n_scinti_plates;
+  }
+  scinti_tile_x = scinti_tile_x_upper + scinti_tile_x_lower - ((outer_radius - scinti_outer_radius) / cos(tilt_angle / rad));
+  scinti_tile_x -= subtract_from_scinti_x;
+  G4VSolid *scintibox = new G4Box("ScintiTile", scinti_tile_x / 2., scinti_tile_thickness / 2., scinti_tile_z / 2.);
+  volume_scintillator = scintibox->GetCubicVolume() * n_scinti_plates;
   return scintibox;
 }
 
-G4VSolid*
-PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelope)
+G4VSolid *
+PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
 {
   // calculate steel plate on top of the scinti box. Lower edge is the upper edge of
   // the scintibox + 1/2 the airgap
   double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
   // first the lower edge, just like the scinti box, just add the air gap
   // and calculate intersection of edge with inner and outer radius.
-  Point_2 p_in_1(mid_radius, 0); // center of lower scintillator
+  Point_2 p_in_1(mid_radius, 0);  // center of lower scintillator
   double angle_mid_scinti = M_PI / 2. + tilt_angle / rad;
   double xcoord = scinti_inner_gap / 2. * cos(angle_mid_scinti / rad) + mid_radius;
-  double ycoord =   scinti_inner_gap / 2. * sin(angle_mid_scinti / rad) + 0;
+  double ycoord = scinti_inner_gap / 2. * sin(angle_mid_scinti / rad) + 0;
   Point_2 p_loweredge(xcoord, ycoord);
-  Line_2 s2(p_in_1, p_loweredge); // center vertical
-  Line_2 perp =  s2.perpendicular(p_loweredge); // that is the lower edge of the steel plate
+  Line_2 s2(p_in_1, p_loweredge);               // center vertical
+  Line_2 perp = s2.perpendicular(p_loweredge);  // that is the lower edge of the steel plate
   Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
   Circle_2 inner_circle(sc1, sc2, sc3);
-  vector< CGAL::Object > res;
+  vector<CGAL::Object> res;
   CGAL::intersection(inner_circle, perp, std::back_inserter(res));
   Point_2 lowerleft;
-  vector< CGAL::Object >::const_iterator iter;
+  vector<CGAL::Object>::const_iterator iter;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) > 0)
-	    {
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      lowerleft = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	}
+      if (CGAL::to_double(point->first.x()) > 0)
+      {
+        Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        lowerleft = pntmp;
+      }
     }
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+    }
+  }
 
   double xcoord2 = scinti_outer_gap / 2. * cos(angle_mid_scinti / rad) + mid_radius;
-  double ycoord2 =  scinti_outer_gap / 2. * sin(angle_mid_scinti / rad) + 0;
+  double ycoord2 = scinti_outer_gap / 2. * sin(angle_mid_scinti / rad) + 0;
   Point_2 p_loweredge2(xcoord2, ycoord2);
-  Line_2 s2_2(p_in_1, p_loweredge2); // center vertical
-  Line_2 perp2 =  s2_2.perpendicular(p_loweredge2); // that is the lower edge of the steel plate
+  Line_2 s2_2(p_in_1, p_loweredge2);                // center vertical
+  Line_2 perp2 = s2_2.perpendicular(p_loweredge2);  // that is the lower edge of the steel plate
 
   Point_2 so1(outer_radius, 0), so2(0, outer_radius), so3(-outer_radius, 0);
   Circle_2 outer_circle(so1, so2, so3);
-  res.clear(); // just clear the content from the last intersection search
+  res.clear();  // just clear the content from the last intersection search
   CGAL::intersection(outer_circle, perp2, std::back_inserter(res));
   Point_2 lowerright;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) >  CGAL::to_double(p_loweredge.x()))
-	    {
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      lowerright = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	}
+      if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
+      {
+        Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        lowerright = pntmp;
+      }
     }
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+    }
+  }
   // now we have the lower left and rigth corner, now find the upper edge
   // find the center of the upper scintilator
-
 
   double phi_midpoint = 2 * M_PI / n_scinti_plates;
   double xmidpoint = cos(phi_midpoint) * mid_radius;
@@ -286,58 +277,58 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelope)
   Point_2 mid_upperscint(xmidpoint, ymidpoint);
   Point_2 p_upperedge(xcoordup, ycoordup);
   {
-    Line_2 sup(mid_upperscint, p_upperedge); // center vertical
-    Line_2 perp =  sup.perpendicular(p_upperedge); // that is the upper edge of the steel plate
+    Line_2 sup(mid_upperscint, p_upperedge);       // center vertical
+    Line_2 perp = sup.perpendicular(p_upperedge);  // that is the upper edge of the steel plate
     Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
     Circle_2 inner_circle(sc1, sc2, sc3);
-    vector< CGAL::Object > res;
+    vector<CGAL::Object> res;
     CGAL::intersection(inner_circle, perp, std::back_inserter(res));
-    vector< CGAL::Object >::const_iterator iter;
+    vector<CGAL::Object>::const_iterator iter;
     double pxmax = 0.;
     for (iter = res.begin(); iter != res.end(); ++iter)
+    {
+      CGAL::Object obj = *iter;
+      if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
       {
-	CGAL::Object obj = *iter;
-	if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	  {
-	    if (CGAL::to_double(point->first.x()) > pxmax)
-	      {
-		pxmax = CGAL::to_double(point->first.x());
-		Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-		upperleft = pntmp;
-	      }
-	  }
-	else
-	  {
-	    cout << "CGAL::Object type not pair..." << endl;
-	  }
+        if (CGAL::to_double(point->first.x()) > pxmax)
+        {
+          pxmax = CGAL::to_double(point->first.x());
+          Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+          upperleft = pntmp;
+        }
       }
+      else
+      {
+        cout << "CGAL::Object type not pair..." << endl;
+      }
+    }
 
     double xcoordup2 = xmidpoint - scinti_outer_gap / 2. * sin(angle_mid_scinti / rad);
     double ycoordup2 = ymidpoint - scinti_outer_gap / 2. * cos(angle_mid_scinti / rad);
     Point_2 p_upperedge2(xcoordup2, ycoordup2);
-    Line_2 sup2(mid_upperscint, p_upperedge2); // center vertical
-    Line_2 perp2 =  sup2.perpendicular(p_upperedge2); // that is the upper edge of the steel plate
+    Line_2 sup2(mid_upperscint, p_upperedge2);        // center vertical
+    Line_2 perp2 = sup2.perpendicular(p_upperedge2);  // that is the upper edge of the steel plate
 
     Point_2 so1(outer_radius, 0), so2(0, outer_radius), so3(-outer_radius, 0);
     Circle_2 outer_circle(so1, so2, so3);
-    res.clear(); // just clear the content from the last intersection search
+    res.clear();  // just clear the content from the last intersection search
     CGAL::intersection(outer_circle, perp2, std::back_inserter(res));
     for (iter = res.begin(); iter != res.end(); ++iter)
+    {
+      CGAL::Object obj = *iter;
+      if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
       {
-	CGAL::Object obj = *iter;
-	if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	  {
-	    if (CGAL::to_double(point->first.x()) >  CGAL::to_double(p_loweredge.x()))
-	      {
-		Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-		upperright = pntmp;
-	      }
-	  }
-	else
-	  {
-	    cout << "CGAL::Object type not pair..." << endl;
-	  }
+        if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
+        {
+          Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+          upperright = pntmp;
+        }
       }
+      else
+      {
+        cout << "CGAL::Object type not pair..." << endl;
+      }
+    }
   }
   // the left corners are on a secant with the inner boundary, they need to be shifted
   // to be a tangent at the center
@@ -352,19 +343,18 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelope)
   vertexes.push_back(v3);
   vertexes.push_back(v4);
   G4TwoVector zero(0, 0);
-  G4VSolid* steel_plate =  new G4ExtrudedSolid("SteelPlate",
-					       vertexes,
-					       size_z  / 2.0,
-					       zero, 1.0,
-					       zero, 1.0);
+  G4VSolid *steel_plate = new G4ExtrudedSolid("SteelPlate",
+                                              vertexes,
+                                              size_z / 2.0,
+                                              zero, 1.0,
+                                              zero, 1.0);
 
   //  DisplayVolume(steel_plate, hcalenvelope);
-  volume_steel = steel_plate->GetCubicVolume()*n_scinti_plates;
+  volume_steel = steel_plate->GetCubicVolume() * n_scinti_plates;
   return steel_plate;
 }
 
-void
-PHG4InnerHcalDetector::ShiftSecantToTangent(Point_2 &lowleft, Point_2 &upleft, Point_2 &upright, Point_2 &lowright)
+void PHG4InnerHcalDetector::ShiftSecantToTangent(Point_2 &lowleft, Point_2 &upleft, Point_2 &upright, Point_2 &lowright)
 {
   Line_2 secant(lowleft, upleft);
   Segment_2 upedge(upleft, upright);
@@ -375,72 +365,70 @@ PHG4InnerHcalDetector::ShiftSecantToTangent(Point_2 &lowleft, Point_2 &upleft, P
   Line_2 sekperp = secant.perpendicular(midpoint);
   Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
   Circle_2 inner_circle(sc1, sc2, sc3);
-  vector< CGAL::Object > res;
+  vector<CGAL::Object> res;
   CGAL::intersection(inner_circle, sekperp, std::back_inserter(res));
-  vector< CGAL::Object >::const_iterator iter;
+  vector<CGAL::Object>::const_iterator iter;
   double pxmax = 0.;
   Point_2 tangtouch;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) > pxmax)
-	    {
-	      pxmax = CGAL::to_double(point->first.x());
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      tangtouch = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	}
+      if (CGAL::to_double(point->first.x()) > pxmax)
+      {
+        pxmax = CGAL::to_double(point->first.x());
+        Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        tangtouch = pntmp;
+      }
     }
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+    }
+  }
   Line_2 leftside = sekperp.perpendicular(tangtouch);
   CGAL::Object result = CGAL::intersection(upedge, leftside);
   if (const Point_2 *ipoint = CGAL::object_cast<Point_2>(&result))
-    {
-      upleft = *ipoint;
-    }
+  {
+    upleft = *ipoint;
+  }
   result = CGAL::intersection(lowedge, leftside);
   if (const Point_2 *ipoint = CGAL::object_cast<Point_2>(&result))
-    {
-      lowleft = *ipoint;
-    }
+  {
+    lowleft = *ipoint;
+  }
   return;
 }
 
 // Construct the envelope and the call the
 // actual inner hcal construction
-void
-PHG4InnerHcalDetector::Construct( G4LogicalVolume* logicWorld )
+void PHG4InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
 {
-  G4Material* Air = G4Material::GetMaterial("G4_AIR");
-  G4VSolid* hcal_envelope_cylinder = new G4Tubs("InnerHcal_envelope_solid",  envelope_inner_radius, envelope_outer_radius, envelope_z / 2., 0, 2 * M_PI);
+  G4Material *Air = G4Material::GetMaterial("G4_AIR");
+  G4VSolid *hcal_envelope_cylinder = new G4Tubs("InnerHcal_envelope_solid", envelope_inner_radius, envelope_outer_radius, envelope_z / 2., 0, 2 * M_PI);
   volume_envelope = hcal_envelope_cylinder->GetCubicVolume();
-  G4LogicalVolume* hcal_envelope_log =  new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("Hcal_envelope"), 0, 0, 0);
-  G4VisAttributes* hcalVisAtt = new G4VisAttributes();
+  G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("Hcal_envelope"), 0, 0, 0);
+  G4VisAttributes *hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(false);
   hcalVisAtt->SetForceSolid(false);
   hcalVisAtt->SetColour(G4Colour::White());
   hcal_envelope_log->SetVisAttributes(hcalVisAtt);
   G4RotationMatrix hcal_rotm;
-  hcal_rotm.rotateX(params->get_double_param("rot_x")*deg);
-  hcal_rotm.rotateY(params->get_double_param("rot_y")*deg);
-  hcal_rotm.rotateZ(params->get_double_param("rot_z")*deg);
-  new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(params->get_double_param("place_x")*cm, params->get_double_param("place_y")*cm, params->get_double_param("place_z")*cm)), hcal_envelope_log, "InnerHcalEnvelope", logicWorld, 0, false, overlapcheck);
+  hcal_rotm.rotateX(params->get_double_param("rot_x") * deg);
+  hcal_rotm.rotateY(params->get_double_param("rot_y") * deg);
+  hcal_rotm.rotateZ(params->get_double_param("rot_z") * deg);
+  new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(params->get_double_param("place_x") * cm, params->get_double_param("place_y") * cm, params->get_double_param("place_z") * cm)), hcal_envelope_log, "InnerHcalEnvelope", logicWorld, 0, false, overlapcheck);
   ConstructInnerHcal(hcal_envelope_log);
   return;
 }
 
-int
-PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelope)
+int PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume *hcalenvelope)
 {
   ConsistencyCheck();
-  SetTiltViaNcross(); // if number of crossings is set, use it to determine tilt
-  CheckTiltAngle(); // die if the tilt angle is out of range
-  G4VSolid *steel_plate  = ConstructSteelPlate(hcalenvelope);
+  SetTiltViaNcross();  // if number of crossings is set, use it to determine tilt
+  CheckTiltAngle();    // die if the tilt angle is out of range
+  G4VSolid *steel_plate = ConstructSteelPlate(hcalenvelope);
   G4LogicalVolume *steel_logical = new G4LogicalVolume(steel_plate, G4Material::GetMaterial(params->get_string_param("material")), "HcalInnerSteelPlate", 0, 0, 0);
   G4VisAttributes *visattchk = new G4VisAttributes();
   visattchk->SetVisibility(true);
@@ -452,72 +440,70 @@ PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelope)
   double deltaphi = 2 * M_PI / n_scinti_plates;
   ostringstream name;
   double middlerad = outer_radius - (outer_radius - inner_radius) / 2.;
-// for shorter scintillators we have to shift by 1/2 the "missing length"
+  // for shorter scintillators we have to shift by 1/2 the "missing length"
   double scinti_tile_orig_length = scinti_tile_x_upper + scinti_tile_x_lower - subtract_from_scinti_x;
-  double shiftslat = fabs(scinti_tile_x_lower - scinti_tile_x_upper)/2. + (scinti_tile_orig_length-scinti_tile_x)/2.;
-  // calculate phi offset (copied from code inside following loop): 
+  double shiftslat = fabs(scinti_tile_x_lower - scinti_tile_x_upper) / 2. + (scinti_tile_orig_length - scinti_tile_x) / 2.;
+  // calculate phi offset (copied from code inside following loop):
   // first get the center point (phi=0) so it's middlerad/0
   // then shift the scintillator center as documented in loop
-  // then 
+  // then
   // for positive tilt angles we need the lower left corner of the scintillator
   // for negative tilt angles we need the upper right corner of the scintillator
   // as it turns out the code uses the middle of the face of the scintillator
   // as reference, if this is a problem the code needs to be modified to
-  // actually calculate the corner (but the math of the construction is that 
+  // actually calculate the corner (but the math of the construction is that
   // the middle of the scintillator sits at zero)
   double xp = cos(phi) * middlerad;
   double yp = sin(phi) * middlerad;
-  xp -= cos((-tilt_angle)/rad - phi)*shiftslat;
-  yp += sin((-tilt_angle)/rad - phi)*shiftslat;
-  if (tilt_angle >0)
-    {
-      double xo = xp - (scinti_tile_x/2.)*cos(tilt_angle/rad);
-      double yo = yp - (scinti_tile_x/2.)*sin(tilt_angle/rad);
-      phi = -atan(yo/xo);
-    }
+  xp -= cos((-tilt_angle) / rad - phi) * shiftslat;
+  yp += sin((-tilt_angle) / rad - phi) * shiftslat;
+  if (tilt_angle > 0)
+  {
+    double xo = xp - (scinti_tile_x / 2.) * cos(tilt_angle / rad);
+    double yo = yp - (scinti_tile_x / 2.) * sin(tilt_angle / rad);
+    phi = -atan(yo / xo);
+  }
   else if (tilt_angle < 0)
-    {
-      double xo = xp + (scinti_tile_x/2.)*cos(tilt_angle/rad);
-      double yo = yp + (scinti_tile_x/2.)*sin(tilt_angle/rad);
-      phi = -atan(yo/xo);
-    }
+  {
+    double xo = xp + (scinti_tile_x / 2.) * cos(tilt_angle / rad);
+    double yo = yp + (scinti_tile_x / 2.) * sin(tilt_angle / rad);
+    phi = -atan(yo / xo);
+  }
   // else (for tilt_angle = 0) phi stays zero
   for (int i = 0; i < n_scinti_plates; i++)
-    {
-      G4RotationMatrix *Rot = new G4RotationMatrix();
-      double ypos = sin(phi) * middlerad;
-      double xpos = cos(phi) * middlerad;
-      // the center of the scintillator is not the center of the inner hcal
-      // but depends on the tilt angle. Therefore we need to shift
-      // the center from the mid point
-      // ypos += sin((-tilt_angle)/rad - phi)*(-2*shiftslat+(outer_radius-scinti_outer_radius));
-      // xpos -= cos((-tilt_angle)/rad - phi)*(-2*shiftslat+(outer_radius-scinti_outer_radius));
-      ypos += sin((-tilt_angle)/rad - phi)*shiftslat;
-      xpos -= cos((-tilt_angle)/rad - phi)*shiftslat;
-      Rot->rotateZ(phi * rad + tilt_angle);
-      G4ThreeVector g4vec(xpos, ypos, 0);
-      // great the MakeImprint always adds 1 to the copy number and 0 has a 
-      // special meaning (which then also adds 1). Basically our volume names
-      // will start at 1 instead of 0 and there is nothing short of patching this
-      // method. I'll take care of this in the decoding of the volume name
-      // AAAAAAARHGS 
-      scinti_mother_assembly->MakeImprint(hcalenvelope, g4vec, Rot, i, overlapcheck);
-      Rot = new G4RotationMatrix();
-      Rot->rotateZ(-phi * rad);
-      name.str("");
-      name << "InnerHcalSteel_" << i;
-      steel_absorber_vec.insert(new G4PVPlacement(Rot, G4ThreeVector(0, 0, 0), steel_logical, name.str().c_str(), hcalenvelope, 0, i, overlapcheck));
-      phi += deltaphi;
-    }
+  {
+    G4RotationMatrix *Rot = new G4RotationMatrix();
+    double ypos = sin(phi) * middlerad;
+    double xpos = cos(phi) * middlerad;
+    // the center of the scintillator is not the center of the inner hcal
+    // but depends on the tilt angle. Therefore we need to shift
+    // the center from the mid point
+    // ypos += sin((-tilt_angle)/rad - phi)*(-2*shiftslat+(outer_radius-scinti_outer_radius));
+    // xpos -= cos((-tilt_angle)/rad - phi)*(-2*shiftslat+(outer_radius-scinti_outer_radius));
+    ypos += sin((-tilt_angle) / rad - phi) * shiftslat;
+    xpos -= cos((-tilt_angle) / rad - phi) * shiftslat;
+    Rot->rotateZ(phi * rad + tilt_angle);
+    G4ThreeVector g4vec(xpos, ypos, 0);
+    // great the MakeImprint always adds 1 to the copy number and 0 has a
+    // special meaning (which then also adds 1). Basically our volume names
+    // will start at 1 instead of 0 and there is nothing short of patching this
+    // method. I'll take care of this in the decoding of the volume name
+    // AAAAAAARHGS
+    scinti_mother_assembly->MakeImprint(hcalenvelope, g4vec, Rot, i, overlapcheck);
+    Rot = new G4RotationMatrix();
+    Rot->rotateZ(-phi * rad);
+    name.str("");
+    name << "InnerHcalSteel_" << i;
+    steel_absorber_vec.insert(new G4PVPlacement(Rot, G4ThreeVector(0, 0, 0), steel_logical, name.str().c_str(), hcalenvelope, 0, i, overlapcheck));
+    phi += deltaphi;
+  }
   return 0;
 }
-
 
 // split the big scintillator into tiles covering eta ranges
 // since they are tilted it is not a straightforward theta cut
 // it starts at a given eta at the inner radius but the outer radius needs adjusting
-void
-PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume* hcalenvelope)
+void PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hcalenvelope)
 {
   G4VSolid *bigtile = ConstructScintillatorBox(hcalenvelope);
   // eta->theta
@@ -528,76 +514,75 @@ PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume* hcalenv
   G4double z[4];
   ostringstream name;
   double overhang = (scinti_tile_x - (outer_radius - inner_radius)) / 2.;
-  double offset = 1 * cm + overhang; // add 1cm to make sure the G4ExtrudedSolid
+  double offset = 1 * cm + overhang;  // add 1cm to make sure the G4ExtrudedSolid
   // is larger than the tile so we do not have
   // funny edge effects when overlapping vols
-  double scinti_gap_neighbor = params->get_double_param("scinti_gap_neighbor")*cm;
+  double scinti_gap_neighbor = params->get_double_param("scinti_gap_neighbor") * cm;
   for (int i = 0; i < n_scinti_tiles; i++)
+  {
+    theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
+    x[0] = inner_radius - overhang;
+    z[0] = tan(theta) * inner_radius;
+    x[1] = outer_radius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
+    z[1] = tan(theta) * outer_radius;
+    eta += delta_eta;
+    theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
+    x[2] = inner_radius - overhang;
+    z[2] = tan(theta) * inner_radius;
+    x[3] = outer_radius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
+    z[3] = tan(theta) * outer_radius;
+    // apply gap between scintillators
+    z[0] += scinti_gap_neighbor / 2.;
+    z[1] += scinti_gap_neighbor / 2.;
+    z[2] -= scinti_gap_neighbor / 2.;
+    z[3] -= scinti_gap_neighbor / 2.;
+    Point_2 leftsidelow(z[0], x[0]);
+    Point_2 leftsidehigh(z[1], x[1]);
+    x[0] = inner_radius - offset;
+    z[0] = x_at_y(leftsidelow, leftsidehigh, x[0]);
+    x[1] = outer_radius + offset;
+    z[1] = x_at_y(leftsidelow, leftsidehigh, x[1]);
+    Point_2 rightsidelow(z[2], x[2]);
+    Point_2 rightsidehigh(z[3], x[3]);
+    x[2] = outer_radius + offset;
+    z[2] = x_at_y(rightsidelow, rightsidehigh, x[2]);
+    x[3] = inner_radius - offset;
+    z[3] = x_at_y(rightsidelow, rightsidehigh, x[3]);
+
+    vector<G4TwoVector> vertexes;
+    for (int j = 0; j < 4; j++)
     {
-      theta = M_PI / 2 - PHG4Utils::get_theta(eta); // theta = 90 for eta=0
-      x[0] = inner_radius - overhang;
-      z[0] = tan(theta) * inner_radius;
-      x[1] = outer_radius + overhang; // since the tile is tilted, x is not at the outer radius but beyond
-      z[1] = tan(theta) * outer_radius;
-      eta += delta_eta;
-      theta = M_PI / 2 - PHG4Utils::get_theta(eta); // theta = 90 for eta=0
-      x[2] = inner_radius - overhang;
-      z[2] =  tan(theta) * inner_radius;
-      x[3] =  outer_radius + overhang; // since the tile is tilted, x is not at the outer radius but beyond
-      z[3] = tan(theta) * outer_radius;
-      // apply gap between scintillators
-      z[0] += scinti_gap_neighbor / 2.;
-      z[1] += scinti_gap_neighbor / 2.;
-      z[2] -= scinti_gap_neighbor / 2.;
-      z[3] -= scinti_gap_neighbor / 2.;
-      Point_2 leftsidelow(z[0], x[0]);
-      Point_2 leftsidehigh(z[1], x[1]);
-      x[0] = inner_radius - offset;
-      z[0] = x_at_y(leftsidelow, leftsidehigh, x[0]);
-      x[1] = outer_radius + offset;
-      z[1] = x_at_y(leftsidelow, leftsidehigh, x[1]);
-      Point_2 rightsidelow(z[2], x[2]);
-      Point_2 rightsidehigh(z[3], x[3]);
-      x[2] = outer_radius + offset;
-      z[2] = x_at_y(rightsidelow, rightsidehigh, x[2]);
-      x[3] = inner_radius - offset;
-      z[3] = x_at_y(rightsidelow, rightsidehigh, x[3]);
-
-
-      vector<G4TwoVector> vertexes;
-      for (int j = 0; j < 4; j++)
-	{
-	  G4TwoVector v(x[j], z[j]);
-	  vertexes.push_back(v);
-	}
-      G4TwoVector zero(0, 0);
-
-      G4VSolid *scinti =  new G4ExtrudedSolid("ScintillatorTile",
-					      vertexes,
-					      scinti_tile_thickness + 0.2 * mm,
-					      zero, 1.0,
-					      zero, 1.0);
-      G4RotationMatrix *rotm = new G4RotationMatrix();
-      rotm->rotateX(-90 * deg);
-      name.str("");
-      name << "scintillator_" << i << "_left";
-      G4VSolid *scinti_tile =  new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(inner_radius + outer_radius) / 2., 0, 0));
-      scinti_tiles_vec[i + n_scinti_tiles] = scinti_tile;
-      rotm = new G4RotationMatrix();
-      rotm->rotateX(90 * deg);
-      name.str("");
-      name << "scintillator_" << i << "_right";
-      scinti_tile =  new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(inner_radius + outer_radius) / 2., 0, 0));
-      scinti_tiles_vec[n_scinti_tiles - i - 1] =  scinti_tile;
+      G4TwoVector v(x[j], z[j]);
+      vertexes.push_back(v);
     }
+    G4TwoVector zero(0, 0);
 
- // for (unsigned int i=0; i<scinti_tiles_vec.size(); i++)
- //    {
- //      if (scinti_tiles_vec[i])
- //  	 {
- //   	   DisplayVolume(scinti_tiles_vec[i],hcalenvelope );
- //   	 }
- //     }
+    G4VSolid *scinti = new G4ExtrudedSolid("ScintillatorTile",
+                                           vertexes,
+                                           scinti_tile_thickness + 0.2 * mm,
+                                           zero, 1.0,
+                                           zero, 1.0);
+    G4RotationMatrix *rotm = new G4RotationMatrix();
+    rotm->rotateX(-90 * deg);
+    name.str("");
+    name << "scintillator_" << i << "_left";
+    G4VSolid *scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(inner_radius + outer_radius) / 2., 0, 0));
+    scinti_tiles_vec[i + n_scinti_tiles] = scinti_tile;
+    rotm = new G4RotationMatrix();
+    rotm->rotateX(90 * deg);
+    name.str("");
+    name << "scintillator_" << i << "_right";
+    scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(inner_radius + outer_radius) / 2., 0, 0));
+    scinti_tiles_vec[n_scinti_tiles - i - 1] = scinti_tile;
+  }
+
+  // for (unsigned int i=0; i<scinti_tiles_vec.size(); i++)
+  //    {
+  //      if (scinti_tiles_vec[i])
+  //  	 {
+  //   	   DisplayVolume(scinti_tiles_vec[i],hcalenvelope );
+  //   	 }
+  //     }
 
   return;
 }
@@ -618,243 +603,235 @@ PHG4InnerHcalDetector::x_at_y(Point_2 &p0, Point_2 &p1, double yin)
   Point_2 p1new(newx, yin);
   Segment_2 s(p0new, p1new);
   CGAL::Object result = CGAL::intersection(l, s);
-  if ( const Point_2 *ipoint = CGAL::object_cast<Point_2>(&result))
-    {
-      xret = CGAL::to_double(ipoint->x());
-    }
+  if (const Point_2 *ipoint = CGAL::object_cast<Point_2>(&result))
+  {
+    xret = CGAL::to_double(ipoint->x());
+  }
   else
-    {
-      cout << PHWHERE << " failed for y = " << y << endl;
-      cout << "p0(x): " << CGAL::to_double(p0.x()) << ", p0(y): " <<  CGAL::to_double(p0.y()) << endl;
-      cout << "p1(x): " << CGAL::to_double(p1.x()) << ", p1(y): " <<  CGAL::to_double(p1.y()) << endl;
-      exit(1);
-    }
+  {
+    cout << PHWHERE << " failed for y = " << y << endl;
+    cout << "p0(x): " << CGAL::to_double(p0.x()) << ", p0(y): " << CGAL::to_double(p0.y()) << endl;
+    cout << "p1(x): " << CGAL::to_double(p1.x()) << ", p1(y): " << CGAL::to_double(p1.y()) << endl;
+    exit(1);
+  }
   return xret;
 }
 
 G4AssemblyVolume *
-PHG4InnerHcalDetector::ConstructHcalScintillatorAssembly(G4LogicalVolume* hcalenvelope)
+PHG4InnerHcalDetector::ConstructHcalScintillatorAssembly(G4LogicalVolume *hcalenvelope)
 {
   ConstructHcalSingleScintillators(hcalenvelope);
   G4AssemblyVolume *assmeblyvol = new G4AssemblyVolume();
   ostringstream name;
   G4ThreeVector g4vec;
 
-  double steplimits = params->get_double_param("steplimits")*cm;
+  double steplimits = params->get_double_param("steplimits") * cm;
   for (unsigned int i = 0; i < scinti_tiles_vec.size(); i++)
+  {
+    name.str("");
+    name << scintilogicnameprefix << i;
+    G4UserLimits *g4userlimits = nullptr;
+    if (isfinite(steplimits))
     {
-      name.str("");
-      name << scintilogicnameprefix << i;
-      G4UserLimits *g4userlimits = nullptr;
-      if (isfinite(steplimits))
-	{
-	  g4userlimits = new G4UserLimits(steplimits);
-	}
-      G4LogicalVolume *scinti_tile_logic = new G4LogicalVolume(scinti_tiles_vec[i], G4Material::GetMaterial("G4_POLYSTYRENE"), name.str().c_str(), nullptr, nullptr, g4userlimits);
-      G4VisAttributes *visattchk = new G4VisAttributes();
-      visattchk->SetVisibility(true);
-      visattchk->SetForceSolid(true);
-      visattchk->SetColour(G4Colour::Green());
-      scinti_tile_logic->SetVisAttributes(visattchk);
-      assmeblyvol->AddPlacedVolume(scinti_tile_logic, g4vec, nullptr);
+      g4userlimits = new G4UserLimits(steplimits);
     }
+    G4LogicalVolume *scinti_tile_logic = new G4LogicalVolume(scinti_tiles_vec[i], G4Material::GetMaterial("G4_POLYSTYRENE"), name.str().c_str(), nullptr, nullptr, g4userlimits);
+    G4VisAttributes *visattchk = new G4VisAttributes();
+    visattchk->SetVisibility(true);
+    visattchk->SetForceSolid(true);
+    visattchk->SetColour(G4Colour::Green());
+    scinti_tile_logic->SetVisAttributes(visattchk);
+    assmeblyvol->AddPlacedVolume(scinti_tile_logic, g4vec, nullptr);
+  }
   return assmeblyvol;
 }
 
-
-int
-PHG4InnerHcalDetector::DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix *rotm )
+int PHG4InnerHcalDetector::DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm)
 {
   static int i = 0;
-  G4LogicalVolume* checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), "DISPLAYLOGICAL", 0, 0, 0);
-  G4VisAttributes* visattchk = new G4VisAttributes();
+  G4LogicalVolume *checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), "DISPLAYLOGICAL", 0, 0, 0);
+  G4VisAttributes *visattchk = new G4VisAttributes();
   visattchk->SetVisibility(true);
   visattchk->SetForceSolid(false);
-  switch(i)
-    {
-    case 0:
-      visattchk->SetColour(G4Colour::Red());
-      i++;
-      break;
-    case 1:
-      visattchk->SetColour(G4Colour::Magenta());
-      i++;
-      break;
-    case 2:
-      visattchk->SetColour(G4Colour::Yellow());
-      i++;
-      break;
-    case 3:
-      visattchk->SetColour(G4Colour::Blue());
-      i++;
-      break;
-    case 4:
-      visattchk->SetColour(G4Colour::Cyan());
-      i++;
-      break;
-    default:
-      visattchk->SetColour(G4Colour::Green());
-      i = 0;
-      break;
-    }
+  switch (i)
+  {
+  case 0:
+    visattchk->SetColour(G4Colour::Red());
+    i++;
+    break;
+  case 1:
+    visattchk->SetColour(G4Colour::Magenta());
+    i++;
+    break;
+  case 2:
+    visattchk->SetColour(G4Colour::Yellow());
+    i++;
+    break;
+  case 3:
+    visattchk->SetColour(G4Colour::Blue());
+    i++;
+    break;
+  case 4:
+    visattchk->SetColour(G4Colour::Cyan());
+    i++;
+    break;
+  default:
+    visattchk->SetColour(G4Colour::Green());
+    i = 0;
+    break;
+  }
 
   checksolid->SetVisAttributes(visattchk);
   new G4PVPlacement(rotm, G4ThreeVector(0, 0, 0), checksolid, "DISPLAYVOL", logvol, 0, false, overlapcheck);
   return 0;
 }
 // check if tilt angle is reasonable - too large, no intersections with inner radius
-int
-PHG4InnerHcalDetector::CheckTiltAngle() const
+int PHG4InnerHcalDetector::CheckTiltAngle() const
 {
-  if (fabs(tilt_angle/rad) >= M_PI)
-    {
-      cout << PHWHERE << "invalid tilt angle, abs(tilt) >= 90 deg: " << (tilt_angle / deg)
-	   << endl;
-      exit(1);
-    }
+  if (fabs(tilt_angle / rad) >= M_PI)
+  {
+    cout << PHWHERE << "invalid tilt angle, abs(tilt) >= 90 deg: " << (tilt_angle / deg)
+         << endl;
+    exit(1);
+  }
 
   double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
-  Point_2 pmid(mid_radius, 0); // center of scintillator
+  Point_2 pmid(mid_radius, 0);  // center of scintillator
   double xcoord = 0;
-  double ycoord = mid_radius * tan(tilt_angle / rad) ;
+  double ycoord = mid_radius * tan(tilt_angle / rad);
   Point_2 pxnull(xcoord, ycoord);
   Line_2 s2(pmid, pxnull);
   Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
   Circle_2 inner_circle(sc1, sc2, sc3);
-  vector< CGAL::Object > res;
+  vector<CGAL::Object> res;
   CGAL::intersection(inner_circle, s2, std::back_inserter(res));
   if (res.size() == 0)
-    {
-      cout << PHWHERE << " Tilt angle " << (tilt_angle / deg)
-	   << " too large, no intersection with inner radius" << endl;
-      exit(1);
-    }
+  {
+    cout << PHWHERE << " Tilt angle " << (tilt_angle / deg)
+         << " too large, no intersection with inner radius" << endl;
+    exit(1);
+  }
   return 0;
 }
 
-
-int
-PHG4InnerHcalDetector::ConsistencyCheck() const
+int PHG4InnerHcalDetector::ConsistencyCheck() const
 {
   // just make sure the parameters make a bit of sense
   if (inner_radius >= outer_radius)
-    {
-      cout << PHWHERE << ": Inner Radius " << inner_radius/cm
-	   << " cm larger than Outer Radius " << outer_radius/cm
-	   << " cm" << endl;
-      gSystem->Exit(1);
-    }
+  {
+    cout << PHWHERE << ": Inner Radius " << inner_radius / cm
+         << " cm larger than Outer Radius " << outer_radius / cm
+         << " cm" << endl;
+    gSystem->Exit(1);
+  }
   if (scinti_tile_thickness > scinti_inner_gap)
-    {
-      cout << PHWHERE << "Scintillator thickness " << scinti_tile_thickness/cm
-	   << " cm larger than scintillator inner gap " << scinti_inner_gap/cm
-	   << " cm" << endl;
-      gSystem->Exit(1);
-    }
+  {
+    cout << PHWHERE << "Scintillator thickness " << scinti_tile_thickness / cm
+         << " cm larger than scintillator inner gap " << scinti_inner_gap / cm
+         << " cm" << endl;
+    gSystem->Exit(1);
+  }
   if (scinti_outer_radius <= inner_radius)
   {
-    cout <<  PHWHERE << "Scintillator outer radius " << scinti_outer_radius/cm
-	 << " cm smaller than inner radius " << inner_radius/cm 
-	 << " cm" << endl;
-      gSystem->Exit(1);
-    }
+    cout << PHWHERE << "Scintillator outer radius " << scinti_outer_radius / cm
+         << " cm smaller than inner radius " << inner_radius / cm
+         << " cm" << endl;
+    gSystem->Exit(1);
+  }
 
   return 0;
 }
 
-void
-PHG4InnerHcalDetector::SetTiltViaNcross()
+void PHG4InnerHcalDetector::SetTiltViaNcross()
 {
   // if tilt angle is set it takes precedence
   // this happens during readback where the tilt angle was set
   // in this method
   int ncross = params->get_int_param("ncross");
-  if (! ncross || isfinite(tilt_angle))
-    {
-      return;
-    }
-  if ((isfinite(tilt_angle))&&(verbosity > 0))
-    {
-      cout << "both number of crossings and tilt angle are set" << endl;
-      cout << "using number of crossings to determine tilt angle" << endl;
-    }
-  double mid_radius = inner_radius + (outer_radius-inner_radius)/2.;
-  double deltaphi = (2*M_PI/n_scinti_plates)*ncross;
-  Point_2 pnull(0,0);
-  Point_2 plow(inner_radius,0);
-  Point_2 phightmp(1,tan(deltaphi));
-  Point_2 pin1(inner_radius,0), pin2(0,inner_radius),pin3(-inner_radius,0);
-  Circle_2 inner_circle(pin1,pin2,pin3);
-  Point_2 pmid1(mid_radius,0), pmid2(0,mid_radius),pmid3(-mid_radius,0);
-  Circle_2 mid_circle(pmid1,pmid2,pmid3);
-  Point_2 pout1(outer_radius,0), pout2(0,outer_radius),pout3(-outer_radius,0);
-  Circle_2 outer_circle(pout1,pout2,pout3);
-  Line_2 l_up(pnull,phightmp);
-  vector< CGAL::Object > res;
+  if (!ncross || isfinite(tilt_angle))
+  {
+    return;
+  }
+  if ((isfinite(tilt_angle)) && (verbosity > 0))
+  {
+    cout << "both number of crossings and tilt angle are set" << endl;
+    cout << "using number of crossings to determine tilt angle" << endl;
+  }
+  double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
+  double deltaphi = (2 * M_PI / n_scinti_plates) * ncross;
+  Point_2 pnull(0, 0);
+  Point_2 plow(inner_radius, 0);
+  Point_2 phightmp(1, tan(deltaphi));
+  Point_2 pin1(inner_radius, 0), pin2(0, inner_radius), pin3(-inner_radius, 0);
+  Circle_2 inner_circle(pin1, pin2, pin3);
+  Point_2 pmid1(mid_radius, 0), pmid2(0, mid_radius), pmid3(-mid_radius, 0);
+  Circle_2 mid_circle(pmid1, pmid2, pmid3);
+  Point_2 pout1(outer_radius, 0), pout2(0, outer_radius), pout3(-outer_radius, 0);
+  Circle_2 outer_circle(pout1, pout2, pout3);
+  Line_2 l_up(pnull, phightmp);
+  vector<CGAL::Object> res;
   CGAL::intersection(outer_circle, l_up, std::back_inserter(res));
   Point_2 upperright;
-  vector< CGAL::Object >::const_iterator iter;
+  vector<CGAL::Object>::const_iterator iter;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) >  0)
-	    {
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      upperright = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	  exit(1);
-	}
+      if (CGAL::to_double(point->first.x()) > 0)
+      {
+        Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        upperright = pntmp;
+      }
     }
-  Line_2 l_right(plow,upperright);
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+      exit(1);
+    }
+  }
+  Line_2 l_right(plow, upperright);
   res.clear();
   Point_2 midpoint;
   CGAL::intersection(mid_circle, l_right, std::back_inserter(res));
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) >  0)
-	    {
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      midpoint = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	  exit(1);
-	}
+      if (CGAL::to_double(point->first.x()) > 0)
+      {
+        Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        midpoint = pntmp;
+      }
     }
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+      exit(1);
+    }
+  }
   // length left side
-  double ll = sqrt((CGAL::to_double(midpoint.x()) - inner_radius)*(CGAL::to_double(midpoint.x()) - inner_radius) + CGAL::to_double(midpoint.y())*CGAL::to_double(midpoint.y()));
-  double upside = sqrt(CGAL::to_double(midpoint.x())*CGAL::to_double(midpoint.x()) + CGAL::to_double(midpoint.y())*CGAL::to_double(midpoint.y()));
+  double ll = sqrt((CGAL::to_double(midpoint.x()) - inner_radius) * (CGAL::to_double(midpoint.x()) - inner_radius) + CGAL::to_double(midpoint.y()) * CGAL::to_double(midpoint.y()));
+  double upside = sqrt(CGAL::to_double(midpoint.x()) * CGAL::to_double(midpoint.x()) + CGAL::to_double(midpoint.y()) * CGAL::to_double(midpoint.y()));
   //  c^2 = a^2+b^2 - 2ab*cos(gamma)
   // gamma = acos((a^2+b^2=c^2)/2ab
-  double tiltangle = acos((ll*ll + upside*upside-inner_radius*inner_radius)/(2*ll*upside));
-  tiltangle = tiltangle*rad;
-  tilt_angle = copysign(tiltangle,ncross);
-  params->set_double_param("tilt_angle",tilt_angle/deg);
+  double tiltangle = acos((ll * ll + upside * upside - inner_radius * inner_radius) / (2 * ll * upside));
+  tiltangle = tiltangle * rad;
+  tilt_angle = copysign(tiltangle, ncross);
+  params->set_double_param("tilt_angle", tilt_angle / deg);
   return;
 }
 
-void
-PHG4InnerHcalDetector::Print(const string &what) const
+void PHG4InnerHcalDetector::Print(const string &what) const
 {
   cout << "Inner Hcal Detector:" << endl;
   if (what == "ALL" || what == "VOLUME")
-    {
-      cout << "Volume Envelope: " << volume_envelope/cm/cm/cm << " cm^3" << endl;
-      cout << "Volume Steel: " << volume_steel/cm/cm/cm << " cm^3" << endl;
-      cout << "Volume Scintillator: " << volume_scintillator/cm/cm/cm << " cm^3" << endl;
-      cout << "Volume Air: " << (volume_envelope - volume_steel - volume_scintillator)/cm/cm/cm << " cm^3" << endl;
-    }
+  {
+    cout << "Volume Envelope: " << volume_envelope / cm / cm / cm << " cm^3" << endl;
+    cout << "Volume Steel: " << volume_steel / cm / cm / cm << " cm^3" << endl;
+    cout << "Volume Scintillator: " << volume_scintillator / cm / cm / cm << " cm^3" << endl;
+    cout << "Volume Air: " << (volume_envelope - volume_steel - volume_scintillator) / cm / cm / cm << " cm^3" << endl;
+  }
   return;
 }
-

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -478,8 +478,6 @@ int PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume *hcalenvelope)
     // the center of the scintillator is not the center of the inner hcal
     // but depends on the tilt angle. Therefore we need to shift
     // the center from the mid point
-    // ypos += sin((-tilt_angle)/rad - phi)*(-2*shiftslat+(outer_radius-scinti_outer_radius));
-    // xpos -= cos((-tilt_angle)/rad - phi)*(-2*shiftslat+(outer_radius-scinti_outer_radius));
     ypos += sin((-tilt_angle) / rad - phi) * shiftslat;
     xpos -= cos((-tilt_angle) / rad - phi) * shiftslat;
     Rot->rotateZ(phi * rad + tilt_angle);
@@ -738,7 +736,6 @@ int PHG4InnerHcalDetector::ConsistencyCheck() const
          << " cm" << endl;
     gSystem->Exit(1);
   }
-
   return 0;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -56,7 +56,7 @@ class PHG4InnerHcalDetector : public PHG4Detector
 
  protected:
   int ConstructInnerHcal(G4LogicalVolume *sandwich);
-  int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = NULL);
+  int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = nullptr);
   double x_at_y(Point_2 &p0, Point_2 &p1, double yin);
   PHG4Parameters *params;
   G4AssemblyVolume *scinti_mother_assembly;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -10,8 +10,8 @@
 #include <CGAL/point_generators_2.h>
 
 #include <map>
-#include <vector>
 #include <set>
+#include <vector>
 
 class G4AssemblyVolume;
 class G4LogicalVolume;
@@ -19,46 +19,44 @@ class G4VPhysicalVolume;
 class G4VSolid;
 class PHG4Parameters;
 
-class PHG4InnerHcalDetector: public PHG4Detector
+class PHG4InnerHcalDetector : public PHG4Detector
 {
-typedef CGAL::Exact_circular_kernel_2             Circular_k;
-typedef CGAL::Point_2<Circular_k>                 Point_2;
-
-  public:
+ public:
+  typedef CGAL::Exact_circular_kernel_2 Circular_k;
+  typedef CGAL::Point_2<Circular_k> Point_2;
 
   //! constructor
- PHG4InnerHcalDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam);
+  PHG4InnerHcalDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam);
 
   //! destructor
- virtual ~PHG4InnerHcalDetector();
+  virtual ~PHG4InnerHcalDetector();
 
   //! construct
-  virtual void Construct( G4LogicalVolume* world );
+  virtual void Construct(G4LogicalVolume *world);
 
   virtual void Print(const std::string &what = "ALL") const;
 
   //!@name volume accessors
   //@{
-  int IsInInnerHcal(G4VPhysicalVolume*) const;
+  int IsInInnerHcal(G4VPhysicalVolume *) const;
   //@}
 
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return layer;}
-
-  G4VSolid* ConstructSteelPlate(G4LogicalVolume* hcalenvelope);
-  G4VSolid* ConstructScintillatorBox(G4LogicalVolume* hcalenvelope);
+  void SuperDetector(const std::string &name) { superdetector = name; }
+  const std::string SuperDetector() const { return superdetector; }
+  int get_Layer() const { return layer; }
+  G4VSolid *ConstructSteelPlate(G4LogicalVolume *hcalenvelope);
+  G4VSolid *ConstructScintillatorBox(G4LogicalVolume *hcalenvelope);
   void ShiftSecantToTangent(Point_2 &lowleft, Point_2 &upleft, Point_2 &upright, Point_2 &lowright);
 
-  G4AssemblyVolume *ConstructHcalScintillatorAssembly(G4LogicalVolume* hcalenvelope);
-  void ConstructHcalSingleScintillators(G4LogicalVolume* hcalenvelope);
+  G4AssemblyVolume *ConstructHcalScintillatorAssembly(G4LogicalVolume *hcalenvelope);
+  void ConstructHcalSingleScintillators(G4LogicalVolume *hcalenvelope);
   int CheckTiltAngle() const;
   int ConsistencyCheck() const;
   void SetTiltViaNcross();
 
-  protected:
-  int ConstructInnerHcal(G4LogicalVolume* sandwich);
-  int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
+ protected:
+  int ConstructInnerHcal(G4LogicalVolume *sandwich);
+  int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = NULL);
   double x_at_y(Point_2 &p0, Point_2 &p1, double yin);
   PHG4Parameters *params;
   G4AssemblyVolume *scinti_mother_assembly;
@@ -90,8 +88,8 @@ typedef CGAL::Point_2<Circular_k>                 Point_2;
   int layer;
   std::string detector_type;
   std::string superdetector;
-  std::set<G4VPhysicalVolume *>steel_absorber_vec;
-  std::vector<G4VSolid *> scinti_tiles_vec; 
+  std::set<G4VPhysicalVolume *> steel_absorber_vec;
+  std::vector<G4VSolid *> scinti_tiles_vec;
   std::string scintilogicnameprefix;
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -72,6 +72,7 @@ typedef CGAL::Point_2<Circular_k>                 Point_2;
   double scinti_tile_thickness;
   double scinti_inner_gap;
   double scinti_outer_gap;
+  double scinti_outer_radius;
   double tilt_angle;
   double envelope_inner_radius;
   double envelope_outer_radius;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -224,7 +224,6 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
       {
         hit = new PHG4Hitv1();
       }
-      hit->set_scint_id(tower_id);  // the slat id (or steel plate id)
       //here we set the entrance values in cm
       hit->set_x(0, prePoint->GetPosition().x() / cm);
       hit->set_y(0, prePoint->GetPosition().y() / cm);
@@ -238,6 +237,7 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
       hit->set_edep(0);
       if (whichactive > 0)  // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
       {
+        hit->set_scint_id(tower_id);  // the slat id
         hit->set_eion(0);         // only implemented for v5 otherwise empty
         hit->set_light_yield(0);  // for scintillator only, initialize light yields
         // Now save the container we want to add this hit to

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -204,17 +204,17 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       }
       else
       {
-	cout << GetName() << ": New Hit for  " << endl;
-cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-<< ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
-           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
-      cout << "last track: " << savetrackid
-           << ", current trackid: " << aTrack->GetTrackID() << endl;
-      cout << "phys pre vol: " << volume->GetName()
-           << " post vol : " << touchpost->GetVolume()->GetName() << endl;
-      cout << " previous phys pre vol: " << savevolpre->GetName()
-           << " previous phys post vol: " << savevolpost->GetName() << endl;
+        cout << GetName() << ": New Hit for  " << endl;
+        cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+             << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+             << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+             << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
+        cout << "last track: " << savetrackid
+             << ", current trackid: " << aTrack->GetTrackID() << endl;
+        cout << "phys pre vol: " << volume->GetName()
+             << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+        cout << " previous phys pre vol: " << savevolpre->GetName()
+             << " previous phys post vol: " << savevolpost->GetName() << endl;
       }
     case fGeomBoundary:
     case fUndefined:
@@ -238,8 +238,8 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
       if (whichactive > 0)  // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
       {
         hit->set_scint_id(tower_id);  // the slat id
-        hit->set_eion(0);         // only implemented for v5 otherwise empty
-        hit->set_light_yield(0);  // for scintillator only, initialize light yields
+        hit->set_eion(0);             // only implemented for v5 otherwise empty
+        hit->set_light_yield(0);      // for scintillator only, initialize light yields
         // Now save the container we want to add this hit to
         savehitcontainer = hits_;
       }

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -150,12 +150,12 @@ PHG4Detector* PHG4InnerHcalSubsystem::GetDetector( void ) const
 void
 PHG4InnerHcalSubsystem::SetDefaultParameters()
 {
-  set_default_double_param(PHG4HcalDefs::innerrad,116.);
+  set_default_double_param(PHG4HcalDefs::innerrad,117.27);
   set_default_double_param("light_balance_inner_corr", NAN);
   set_default_double_param("light_balance_inner_radius", NAN);
   set_default_double_param("light_balance_outer_corr", NAN);
   set_default_double_param("light_balance_outer_radius", NAN);
-  set_default_double_param(PHG4HcalDefs::outerrad, 136.);
+  set_default_double_param(PHG4HcalDefs::outerrad, 134.42);
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);
   set_default_double_param("place_z", 0.);
@@ -164,7 +164,7 @@ PHG4InnerHcalSubsystem::SetDefaultParameters()
   set_default_double_param("rot_z", 0.);
   set_default_double_param("scinti_eta_coverage", 1.1);
   set_default_double_param("scinti_inner_gap", 0.85);
-  set_default_double_param("scinti_outer_gap", 1.22);
+  set_default_double_param("scinti_outer_gap", 1.22*(5.0/4.0));
   set_default_double_param("scinti_outer_radius", 133.3);
   set_default_double_param("scinti_gap_neighbor", 0.1);
   set_default_double_param("scinti_tile_thickness", 0.7);

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -165,6 +165,7 @@ PHG4InnerHcalSubsystem::SetDefaultParameters()
   set_default_double_param("scinti_eta_coverage", 1.1);
   set_default_double_param("scinti_inner_gap", 0.85);
   set_default_double_param("scinti_outer_gap", 1.22);
+  set_default_double_param("scinti_outer_radius", 133.3);
   set_default_double_param("scinti_gap_neighbor", 0.1);
   set_default_double_param("scinti_tile_thickness", 0.7);
   set_default_double_param("size_z", 175.94 * 2);

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -145,10 +145,10 @@ void PHG4InnerHcalSubsystem::SetDefaultParameters()
   set_default_double_param("rot_y", 0.);
   set_default_double_param("rot_z", 0.);
   set_default_double_param("scinti_eta_coverage", 1.1);
+  set_default_double_param("scinti_gap_neighbor", 0.1);
   set_default_double_param("scinti_inner_gap", 0.85);
   set_default_double_param("scinti_outer_gap", 1.22 * (5.0 / 4.0));
   set_default_double_param("scinti_outer_radius", 133.3);
-  set_default_double_param("scinti_gap_neighbor", 0.1);
   set_default_double_param("scinti_tile_thickness", 0.7);
   set_default_double_param("size_z", 175.94 * 2);
   set_default_double_param("steplimits", NAN);

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -1,8 +1,7 @@
 #include "PHG4InnerHcalSubsystem.h"
-#include "PHG4InnerHcalDetector.h"
-#include "PHG4EventActionClearZeroEdep.h"
-#include "PHG4InnerHcalSteppingAction.h"
 #include "PHG4HcalDefs.h"
+#include "PHG4InnerHcalDetector.h"
+#include "PHG4InnerHcalSteppingAction.h"
 #include "PHG4Parameters.h"
 
 #include <g4main/PHG4HitContainer.h>
@@ -21,21 +20,19 @@
 using namespace std;
 
 //_______________________________________________________________________
-PHG4InnerHcalSubsystem::PHG4InnerHcalSubsystem( const std::string &name, const int lyr ):
-  PHG4DetectorSubsystem( name, lyr ),
-  detector_(NULL),
-  steppingAction_( NULL ),
-  eventAction_(NULL)
+PHG4InnerHcalSubsystem::PHG4InnerHcalSubsystem(const std::string &name, const int lyr)
+  : PHG4DetectorSubsystem(name, lyr)
+  , detector_(nullptr)
+  , steppingAction_(nullptr)
 {
   InitializeParameters();
 }
 
 //_______________________________________________________________________
-int 
-PHG4InnerHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
+int PHG4InnerHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
-  PHNodeIterator iter( topNode );
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
   detector_ = new PHG4InnerHcalDetector(topNode, GetParams(), Name());
@@ -43,114 +40,99 @@ PHG4InnerHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
   detector_->OverlapCheck(CheckOverlap());
   set<string> nodes;
   if (GetParams()->get_int_param("active"))
+  {
+    PHNodeIterator dstIter(dstNode);
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", SuperDetector()));
+    if (!DetNode)
     {
-      PHNodeIterator dstIter( dstNode );
-      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstIter.findFirst("PHCompositeNode",SuperDetector()));
-      if (! DetNode)
-	{
-          DetNode = new PHCompositeNode(SuperDetector());
-          dstNode->addNode(DetNode);
-        }
+      DetNode = new PHCompositeNode(SuperDetector());
+      dstNode->addNode(DetNode);
+    }
 
-      ostringstream nodename;
+    ostringstream nodename;
+    if (SuperDetector() != "NONE")
+    {
+      nodename << "G4HIT_" << SuperDetector();
+    }
+    else
+    {
+      nodename << "G4HIT_" << Name();
+    }
+    nodes.insert(nodename.str());
+    if (GetParams()->get_int_param("absorberactive"))
+    {
+      nodename.str("");
       if (SuperDetector() != "NONE")
-	{
-	  nodename <<  "G4HIT_" << SuperDetector();
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << SuperDetector();
+      }
       else
-	{
-	  nodename <<  "G4HIT_" << Name();
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << Name();
+      }
       nodes.insert(nodename.str());
-      if (GetParams()->get_int_param("absorberactive"))
-	{
-	  nodename.str("");
-	  if (SuperDetector() != "NONE")
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << SuperDetector();
-	    }
-	  else
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << Name();
-	    }
-          nodes.insert(nodename.str());
-	}
-      BOOST_FOREACH(string node, nodes)
-	{
-	  PHG4HitContainer* g4_hits =  findNode::getClass<PHG4HitContainer>( topNode , node.c_str());
-	  if ( !g4_hits )
-	    {
-	      g4_hits = new PHG4HitContainer(node);
-              DetNode->addNode( new PHIODataNode<PHObject>( g4_hits, node.c_str(), "PHObject" ));
-	    }
-	  if (! eventAction_)
-	    {
-	      eventAction_ = new PHG4EventActionClearZeroEdep(topNode, node);
-	    }
-	  else
-	    {
-	      PHG4EventActionClearZeroEdep *evtact = dynamic_cast<PHG4EventActionClearZeroEdep *>(eventAction_);
+    }
+    BOOST_FOREACH (string node, nodes)
+    {
+      PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, node.c_str());
+      if (!g4_hits)
+      {
+        g4_hits = new PHG4HitContainer(node);
+        DetNode->addNode(new PHIODataNode<PHObject>(g4_hits, node.c_str(), "PHObject"));
+      }
+    }
 
-	      evtact->AddNode(node);
-	    }
-	}
-
-      // create stepping action
+    // create stepping action
+    steppingAction_ = new PHG4InnerHcalSteppingAction(detector_, GetParams());
+  }
+  else
+  {
+    // if this is a black hole it does not have to be active
+    if (GetParams()->get_int_param("blackhole"))
+    {
       steppingAction_ = new PHG4InnerHcalSteppingAction(detector_, GetParams());
     }
-  else
-    {
-      // if this is a black hole it does not have to be active
-      if (GetParams()->get_int_param("blackhole"))
-	{
-	  steppingAction_ = new PHG4InnerHcalSteppingAction(detector_, GetParams());
-	}
-    }
+  }
   return 0;
-
 }
 
 //_______________________________________________________________________
-int
-PHG4InnerHcalSubsystem::process_event( PHCompositeNode * topNode )
+int PHG4InnerHcalSubsystem::process_event(PHCompositeNode *topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
   if (steppingAction_)
-    {
-      steppingAction_->SetInterfacePointers( topNode );
-    }
+  {
+    steppingAction_->SetInterfacePointers(topNode);
+  }
   return 0;
 }
 
-
-void
-PHG4InnerHcalSubsystem::Print(const string &what) const
+void PHG4InnerHcalSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
   GetParams()->Print();
   if (detector_)
-    {
-      detector_->Print(what);
-    }
+  {
+    detector_->Print(what);
+  }
   if (steppingAction_)
-    {
-      steppingAction_->Print(what);
-    }
+  {
+    steppingAction_->Print(what);
+  }
 
   return;
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4InnerHcalSubsystem::GetDetector( void ) const
+PHG4Detector *PHG4InnerHcalSubsystem::GetDetector(void) const
 {
   return detector_;
 }
 
-void
-PHG4InnerHcalSubsystem::SetDefaultParameters()
+void PHG4InnerHcalSubsystem::SetDefaultParameters()
 {
-  set_default_double_param(PHG4HcalDefs::innerrad,117.27);
+  set_default_double_param(PHG4HcalDefs::innerrad, 117.27);
   set_default_double_param("light_balance_inner_corr", NAN);
   set_default_double_param("light_balance_inner_radius", NAN);
   set_default_double_param("light_balance_outer_corr", NAN);
@@ -164,13 +146,13 @@ PHG4InnerHcalSubsystem::SetDefaultParameters()
   set_default_double_param("rot_z", 0.);
   set_default_double_param("scinti_eta_coverage", 1.1);
   set_default_double_param("scinti_inner_gap", 0.85);
-  set_default_double_param("scinti_outer_gap", 1.22*(5.0/4.0));
+  set_default_double_param("scinti_outer_gap", 1.22 * (5.0 / 4.0));
   set_default_double_param("scinti_outer_radius", 133.3);
   set_default_double_param("scinti_gap_neighbor", 0.1);
   set_default_double_param("scinti_tile_thickness", 0.7);
   set_default_double_param("size_z", 175.94 * 2);
   set_default_double_param("steplimits", NAN);
-  set_default_double_param("tilt_angle", NAN); // default is 4 crossinge, angle is calculated from this
+  set_default_double_param("tilt_angle", NAN);  // default is 4 crossinge, angle is calculated from this
 
   set_default_int_param("light_scint_model", 1);
   set_default_int_param("ncross", 4);
@@ -181,9 +163,7 @@ PHG4InnerHcalSubsystem::SetDefaultParameters()
   set_default_string_param("material", "SS310");
 }
 
-
-void
-PHG4InnerHcalSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr)
+void PHG4InnerHcalSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr)
 {
   set_double_param("light_balance_inner_corr", inner_corr);
   set_double_param("light_balance_inner_radius", inner_radius);

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
@@ -10,48 +10,41 @@
 class PHG4InnerHcalDetector;
 class PHG4Parameters;
 class PHG4InnerHcalSteppingAction;
-class PHG4EventAction;
 
-class PHG4InnerHcalSubsystem: public PHG4DetectorSubsystem
+class PHG4InnerHcalSubsystem : public PHG4DetectorSubsystem
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4InnerHcalSubsystem( const std::string &name = "HCALIN", const int layer = 0 );
+  PHG4InnerHcalSubsystem(const std::string& name = "HCALIN", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4InnerHcalSubsystem( void )
-  {}
+  virtual ~PHG4InnerHcalSubsystem(void)
+  {
+  }
 
   /*!
   creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode*);
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode*);
 
   //! Print info (from SubsysReco)
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string& what = "ALL") const;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector( void ) const;
-  PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
+  PHG4Detector* GetDetector(void) const;
+  PHG4SteppingAction* GetSteppingAction(void) const { return steppingAction_; }
+  void SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr);
 
-  PHG4EventAction* GetEventAction() const {return eventAction_;}
-
-  void SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr);
-
-
-  private:
-
+ private:
   void SetDefaultParameters();
 
   //! detector geometry
@@ -61,10 +54,6 @@ class PHG4InnerHcalSubsystem: public PHG4DetectorSubsystem
   //! detector "stepping" action, executes after every G4 step
   /*! derives from PHG4SteppingAction */
   PHG4SteppingAction* steppingAction_;
-
-  //! detector event action executes before/after every event
-  /*! derives from PHG4EventAction */
-  PHG4EventAction *eventAction_;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -599,11 +599,27 @@ void PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
   // here, this is why the indices are seemingly mixed up
   double xsteelcut[4];
   double zsteelcut[4];
+double xsteelcut_1[4];
+double zsteelcut_1[4];
   fill_n(zsteelcut, 4, NAN);
-  xsteelcut[0] = x_inner + magnet_cutout_x;
+  fill_n(zsteelcut_1, 4, NAN);
+  xsteelcut_1[0] = x_inner + magnet_cutout_x;
+  xsteelcut_1[1] = xsteelcut_1[0];
+  xsteelcut_1[2] = scinti_inner_radius - offset;
+  xsteelcut_1[3] = xsteelcut_1[2];
+  double steel_overhang =  (scinti_tile_x_upper + scinti_tile_x_lower - subtract_from_scinti_x - (outer_radius - inner_radius)) / 2.;
+  double steel_offset = 1 * cm + steel_overhang;  // add 1cm to make sure the G4ExtrudedSolid
+  double steel_x_inner = inner_radius - overhang;
+  double steel_magnet_cutout_x = (params->get_double_param("magnet_cutout_radius") * cm - inner_radius) / cos(tilt_angle / rad);
+ 
+  xsteelcut[0] = steel_x_inner + steel_magnet_cutout_x;
   xsteelcut[1] = xsteelcut[0];
-  xsteelcut[2] = scinti_inner_radius - offset;
+  xsteelcut[2] = inner_radius - steel_offset;
   xsteelcut[3] = xsteelcut[2];
+  for (int i=0; i<4; i++)
+  {
+    cout << "xs[" << i << "]: " << xsteelcut[i] << ", xs_1: " << xsteelcut_1[i] << endl;
+  }
   double scinti_gap_neighbor = params->get_double_param("scinti_gap_neighbor") * cm;
   for (int i = 0; i < n_scinti_tiles; i++)
   {

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -587,7 +587,7 @@ PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume* hcalenv
   double offset = 1 * cm + overhang; // add 1cm to make sure the G4ExtrudedSolid
   // is larger than the tile so we do not have
   // funny edge effects when overlapping vols
-  double magnet_cutout_x = params->get_double_param("magnet_cutout")*cm/cos(tilt_angle/rad);
+  double magnet_cutout_x = (params->get_double_param("magnet_cutout_radius")*cm-inner_radius)/cos(tilt_angle/rad);
   double x_inner = inner_radius - overhang;
   double inner_offset = offset;
   // coordinates like the steel plates:
@@ -619,7 +619,7 @@ PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume* hcalenv
       z[1] = tan(theta) * outer_radius;
       if (i >= params->get_int_param("magnet_cutout_first_scinti"))
 	{
-	  z[0] =  tan(theta) * (inner_radius +  params->get_double_param("magnet_cutout")*cm);
+	  z[0] =  tan(theta) * (inner_radius +  (params->get_double_param("magnet_cutout_radius")*cm-inner_radius));
 	}
       eta += delta_eta;
       theta = M_PI / 2 - PHG4Utils::get_theta(eta); // theta = 90 for eta=0
@@ -627,7 +627,7 @@ PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume* hcalenv
       z[2] =  tan(theta) * inner_radius;
       if (i >= params->get_int_param("magnet_cutout_first_scinti"))
 	{
-	  z[2] =  tan(theta) * (inner_radius + params->get_double_param("magnet_cutout")*cm);
+	  z[2] =  tan(theta) * (inner_radius + (params->get_double_param("magnet_cutout_radius")*cm-inner_radius));
 	}
       x[3] =  outer_radius + overhang; // since the tile is tilted, x is not at the outer radius but beyond
       z[3] = tan(theta) * outer_radius;

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -415,7 +415,7 @@ PHG4OuterHcalDetector::Construct( G4LogicalVolume* logicWorld )
   volume_envelope = hcal_envelope_cylinder->GetCubicVolume();
   G4LogicalVolume* hcal_envelope_log =  new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("OuterHcal_envelope"), 0, 0, 0);
   G4VisAttributes* hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
+  hcalVisAtt->SetVisibility(false);
   hcalVisAtt->SetForceSolid(false);
   hcalVisAtt->SetColour(G4Colour::White());
   hcal_envelope_log->SetVisAttributes(hcalVisAtt);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -761,9 +761,6 @@ PHG4OuterHcalDetector::ConstructHcalScintillatorAssembly(G4LogicalVolume *hcalen
   ostringstream name;
   G4ThreeVector g4vec;
   double steplimits = params->get_double_param("steplimits") * cm;
-  G4Colour colors[6] = {G4Colour::Red(), G4Colour::Magenta(), G4Colour::Yellow(),
-                        G4Colour::Blue(), G4Colour::Cyan(), G4Colour::Green()};
-  int j = 0;
   for (unsigned int i = 0; i < scinti_tiles_vec.size(); i++)
   {
     name.str("");
@@ -776,21 +773,13 @@ PHG4OuterHcalDetector::ConstructHcalScintillatorAssembly(G4LogicalVolume *hcalen
     G4LogicalVolume *scinti_tile_logic = new G4LogicalVolume(scinti_tiles_vec[i], G4Material::GetMaterial("G4_POLYSTYRENE"), name.str().c_str(), nullptr, nullptr, g4userlimits);
     G4VisAttributes *visattchk = new G4VisAttributes();
     visattchk->SetVisibility(true);
-    visattchk->SetForceSolid(false);
-    //    visattchk->SetColour(G4Colour::Green());
-    visattchk->SetColour(colors[j]);
-    j++;
-    if (j >= 6)
-    {
-      j = 0;
-    }
+    visattchk->SetForceSolid(true);
+    visattchk->SetColour(G4Colour::Green());
     scinti_tile_logic->SetVisAttributes(visattchk);
     assmeblyvol->AddPlacedVolume(scinti_tile_logic, g4vec, nullptr);
 
     //field after burner
-    scinti_tile_logic->SetFieldManager(
-        field_setup->get_Field_Manager_Gap(),
-        true);
+    scinti_tile_logic->SetFieldManager(field_setup->get_Field_Manager_Gap(), true);
   }
   return assmeblyvol;
 }

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -4,7 +4,6 @@
 
 #include <g4main/PHG4Utils.h>
 
-
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
@@ -12,76 +11,74 @@
 #include <TSystem.h>
 
 #include <Geant4/G4AssemblyVolume.hh>
-#include <Geant4/G4IntersectionSolid.hh>
-#include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/G4Material.hh>
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4ExtrudedSolid.hh>
+#include <Geant4/G4IntersectionSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4Trap.hh>
 #include <Geant4/G4Tubs.hh>
+#include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4UserLimits.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#include <CGAL/Exact_circular_kernel_2.h>
-#include <CGAL/point_generators_2.h>
-#include <CGAL/Object.h>
-#include <CGAL/Circular_kernel_intersections.h>
 #include <CGAL/Boolean_set_operations_2.h>
+#include <CGAL/Circular_kernel_intersections.h>
+#include <CGAL/Exact_circular_kernel_2.h>
+#include <CGAL/Object.h>
+#include <CGAL/point_generators_2.h>
 
 #include <cmath>
 #include <sstream>
 
-typedef CGAL::Exact_circular_kernel_2             Circular_k;
-typedef CGAL::Point_2<Circular_k>                 Point_2;
-typedef CGAL::Circle_2<Circular_k>                Circle_2;
-typedef CGAL::Circular_arc_point_2<Circular_k>          Circular_arc_point_2;
-typedef CGAL::Line_2<Circular_k>                Line_2;
-typedef CGAL::Segment_2<Circular_k>                Segment_2;
+typedef CGAL::Circle_2<PHG4OuterHcalDetector::Circular_k> Circle_2;
+typedef CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k> Circular_arc_point_2;
+typedef CGAL::Line_2<PHG4OuterHcalDetector::Circular_k> Line_2;
+typedef CGAL::Segment_2<PHG4OuterHcalDetector::Circular_k> Segment_2;
 
 using namespace std;
 
+//#define SCINTITEST
 // face touches the boundary instead of the corner, subtracting 1 permille from the total
 // scintilator length takes care of this
-static double subtract_from_scinti_x = 0.1*mm;
+static double subtract_from_scinti_x = 0.1 * mm;
 
-PHG4OuterHcalDetector::PHG4OuterHcalDetector( PHCompositeNode *Node, PHG4Parameters *parames, const std::string &dnam):
-  PHG4Detector(Node, dnam),
-  field_setup(nullptr),
-  params(parames),
-  scinti_mother_assembly(nullptr),
-  steel_cutout_for_magnet(nullptr),
-  inner_radius(params->get_double_param("inner_radius")*cm),
-  outer_radius(params->get_double_param("outer_radius")*cm),
-  size_z(params->get_double_param("size_z")*cm),
-  scinti_tile_x(NAN),
-  scinti_tile_x_lower(NAN),
-  scinti_tile_x_upper(NAN),
-  scinti_tile_z(size_z),
-  scinti_tile_thickness(params->get_double_param("scinti_tile_thickness")*cm),
-  scinti_gap(params->get_double_param("scinti_gap")*cm),
-  scinti_inner_radius(params->get_double_param("scinti_inner_radius") * cm),
-  scinti_outer_radius(params->get_double_param("scinti_outer_radius") * cm),
-  tilt_angle(params->get_double_param("tilt_angle")*deg),
-  envelope_inner_radius(inner_radius),
-  envelope_outer_radius(outer_radius),
-  envelope_z(size_z),
-  volume_envelope(NAN),
-  volume_steel(NAN),
-  volume_scintillator(NAN),
-  n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr)*params->get_int_param("n_towers")),
-  n_scinti_tiles(params->get_int_param("n_scinti_tiles")),
-  active(params->get_int_param("active")),
-  absorberactive(params->get_int_param("absorberactive")),
-  layer(0),
-  scintilogicnameprefix("HcalOuterScinti")
+PHG4OuterHcalDetector::PHG4OuterHcalDetector(PHCompositeNode *Node, PHG4Parameters *parames, const std::string &dnam)
+  : PHG4Detector(Node, dnam)
+  , field_setup(nullptr)
+  , params(parames)
+  , scinti_mother_assembly(nullptr)
+  , steel_cutout_for_magnet(nullptr)
+  , inner_radius(params->get_double_param("inner_radius") * cm)
+  , outer_radius(params->get_double_param("outer_radius") * cm)
+  , size_z(params->get_double_param("size_z") * cm)
+  , scinti_tile_x(NAN)
+  , scinti_tile_x_lower(NAN)
+  , scinti_tile_x_upper(NAN)
+  , scinti_tile_z(size_z)
+  , scinti_tile_thickness(params->get_double_param("scinti_tile_thickness") * cm)
+  , scinti_gap(params->get_double_param("scinti_gap") * cm)
+  , scinti_inner_radius(params->get_double_param("scinti_inner_radius") * cm)
+  , scinti_outer_radius(params->get_double_param("scinti_outer_radius") * cm)
+  , tilt_angle(params->get_double_param("tilt_angle") * deg)
+  , envelope_inner_radius(inner_radius)
+  , envelope_outer_radius(outer_radius)
+  , envelope_z(size_z)
+  , volume_envelope(NAN)
+  , volume_steel(NAN)
+  , volume_scintillator(NAN)
+  , n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr) * params->get_int_param("n_towers"))
+  , n_scinti_tiles(params->get_int_param("n_scinti_tiles"))
+  , active(params->get_int_param("active"))
+  , absorberactive(params->get_int_param("absorberactive"))
+  , layer(0)
+  , scintilogicnameprefix("HcalOuterScinti")
 {
-  scinti_tiles_vec.assign(2*n_scinti_tiles,static_cast<G4VSolid *>(nullptr));
-
+  scinti_tiles_vec.assign(2 * n_scinti_tiles, static_cast<G4VSolid *>(nullptr));
 }
 
 PHG4OuterHcalDetector::~PHG4OuterHcalDetector()
@@ -92,177 +89,175 @@ PHG4OuterHcalDetector::~PHG4OuterHcalDetector()
 
 //_______________________________________________________________
 //_______________________________________________________________
-int
-PHG4OuterHcalDetector::IsInOuterHcal(G4VPhysicalVolume * volume) const
+int PHG4OuterHcalDetector::IsInOuterHcal(G4VPhysicalVolume *volume) const
 {
   // G4AssemblyVolumes naming convention:
-//     av_WWW_impr_XXX_YYY_ZZZ
+  //     av_WWW_impr_XXX_YYY_ZZZ
 
-// where:
+  // where:
 
-//     WWW - assembly volume instance number
-//     XXX - assembly volume imprint number
-//     YYY - the name of the placed logical volume
-//     ZZZ - the logical volume index inside the assembly volume
-// e.g. av_1_impr_82_HcalOuterScinti_11_pv_11
-// 82 the number of the scintillator mother volume
-// HcalOuterScinti_11: name of scintillator slat
-// 11: number of scintillator slat logical volume
+  //     WWW - assembly volume instance number
+  //     XXX - assembly volume imprint number
+  //     YYY - the name of the placed logical volume
+  //     ZZZ - the logical volume index inside the assembly volume
+  // e.g. av_1_impr_82_HcalOuterScinti_11_pv_11
+  // 82 the number of the scintillator mother volume
+  // HcalOuterScinti_11: name of scintillator slat
+  // 11: number of scintillator slat logical volume
   if (absorberactive)
+  {
+    if (steel_absorber_vec.find(volume) != steel_absorber_vec.end())
     {
-      if (steel_absorber_vec.find(volume) != steel_absorber_vec.end())
-	{
-	  return -1;
-	}
+      return -1;
     }
+  }
   if (active)
+  {
+    if (volume->GetName().find(scintilogicnameprefix) != string::npos)
     {
-      if (volume->GetName().find(scintilogicnameprefix) != string::npos)
-	{
-	  return 1;
-	}
+      return 1;
     }
+  }
   return 0;
 }
 
-G4VSolid*
-PHG4OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
+G4VSolid *
+PHG4OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
 {
   double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
-  Point_2 p_in_1(mid_radius, 0); // center of scintillator
+  PHG4OuterHcalDetector::Point_2 p_in_1(mid_radius, 0);  // center of scintillator
 
   // length of upper edge (middle till outer circle intersect
   // x/y coordinate of end of center vertical
-  double xcoord  = scinti_tile_thickness / 2. *sin(fabs(tilt_angle)/rad) +  mid_radius;
-  double ycoord  =   scinti_tile_thickness / 2. * cos(fabs(tilt_angle)/rad) + 0;
-  Point_2 p_upperedge(xcoord, ycoord);
-  Line_2 s2(p_in_1, p_upperedge); // center vertical
+  double xcoord = scinti_tile_thickness / 2. * sin(fabs(tilt_angle) / rad) + mid_radius;
+  double ycoord = scinti_tile_thickness / 2. * cos(fabs(tilt_angle) / rad) + 0;
+  PHG4OuterHcalDetector::Point_2 p_upperedge(xcoord, ycoord);
+  Line_2 s2(p_in_1, p_upperedge);  // center vertical
 
-  Line_2 perp =  s2.perpendicular(p_upperedge);
-  Point_2 sc1(outer_radius, 0), sc2(0, outer_radius), sc3(-outer_radius, 0);
+  Line_2 perp = s2.perpendicular(p_upperedge);
+  PHG4OuterHcalDetector::Point_2 sc1(outer_radius, 0), sc2(0, outer_radius), sc3(-outer_radius, 0);
   Circle_2 outer_circle(sc1, sc2, sc3);
-  vector< CGAL::Object > res;
+  vector<CGAL::Object> res;
   CGAL::intersection(outer_circle, perp, std::back_inserter(res));
-  Point_2 upperright;
-  vector< CGAL::Object >::const_iterator iter;
+  PHG4OuterHcalDetector::Point_2 upperright;
+  vector<CGAL::Object>::const_iterator iter;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) >  CGAL::to_double(p_upperedge.x()))
-	    {
-	      double deltax = CGAL::to_double(point->first.x()) - CGAL::to_double(p_upperedge.x());
-	      double deltay = CGAL::to_double(point->first.y()) - CGAL::to_double(p_upperedge.y());
-	      // the scintillator is twice as long
-	      scinti_tile_x_upper = sqrt(deltax * deltax + deltay * deltay); //
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      upperright = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	}
+      if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_upperedge.x()))
+      {
+        double deltax = CGAL::to_double(point->first.x()) - CGAL::to_double(p_upperedge.x());
+        double deltay = CGAL::to_double(point->first.y()) - CGAL::to_double(p_upperedge.y());
+        // the scintillator is twice as long
+        scinti_tile_x_upper = sqrt(deltax * deltax + deltay * deltay);  //
+        PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        upperright = pntmp;
+      }
     }
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+    }
+  }
   // length of lower edge (middle till inner circle intersect
-  xcoord = mid_radius - scinti_tile_thickness / 2. * sin(fabs(tilt_angle)/rad);
-  ycoord  = 0 -  scinti_tile_thickness / 2. * cos(fabs(tilt_angle)/rad);
-  Point_2 p_loweredge(xcoord, ycoord);
+  xcoord = mid_radius - scinti_tile_thickness / 2. * sin(fabs(tilt_angle) / rad);
+  ycoord = 0 - scinti_tile_thickness / 2. * cos(fabs(tilt_angle) / rad);
+  PHG4OuterHcalDetector::Point_2 p_loweredge(xcoord, ycoord);
   Line_2 s3(p_in_1, p_loweredge);
   Line_2 l_lower = s3.perpendicular(p_loweredge);
-  Point_2 ic1(inner_radius, 0), ic2(0, inner_radius), ic3(-inner_radius, 0);
-  Circle_2 inner_circle(ic1,ic2,ic3);
+  PHG4OuterHcalDetector::Point_2 ic1(inner_radius, 0), ic2(0, inner_radius), ic3(-inner_radius, 0);
+  Circle_2 inner_circle(ic1, ic2, ic3);
   res.clear();
-  CGAL::intersection(inner_circle,l_lower, std::back_inserter(res));
-  Point_2 lowerleft;
+  CGAL::intersection(inner_circle, l_lower, std::back_inserter(res));
+  PHG4OuterHcalDetector::Point_2 lowerleft;
   // we have 2 intersections - we want the one furthest to the right (largest x). The correct one is
   // certainly > 0 but the second one depends on the tilt angle and might also be > 0
   double minx = 0;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) >  minx)
-	    {
-	      minx = CGAL::to_double(point->first.x());
-	      double deltax = CGAL::to_double(point->first.x()) - CGAL::to_double(p_loweredge.x());
-	      double deltay = CGAL::to_double(point->first.y()) - CGAL::to_double(p_loweredge.y());
-              scinti_tile_x_lower = sqrt(deltax * deltax + deltay * deltay);
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      lowerleft = pntmp;
-	    }
-	}
+      if (CGAL::to_double(point->first.x()) > minx)
+      {
+        minx = CGAL::to_double(point->first.x());
+        double deltax = CGAL::to_double(point->first.x()) - CGAL::to_double(p_loweredge.x());
+        double deltay = CGAL::to_double(point->first.y()) - CGAL::to_double(p_loweredge.y());
+        scinti_tile_x_lower = sqrt(deltax * deltax + deltay * deltay);
+        PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        lowerleft = pntmp;
+      }
     }
-  scinti_tile_x  = scinti_tile_x_upper + scinti_tile_x_lower - (outer_radius - scinti_outer_radius) / cos(tilt_angle / rad) - (scinti_inner_radius - inner_radius) / cos(tilt_angle / rad);
-  scinti_tile_x  -= subtract_from_scinti_x;
-  G4VSolid* scintibox =  new G4Box("ScintiTile", scinti_tile_x / 2., scinti_tile_thickness / 2., scinti_tile_z / 2.);
-  volume_scintillator = scintibox->GetCubicVolume() *n_scinti_plates;
+  }
+  scinti_tile_x = scinti_tile_x_upper + scinti_tile_x_lower - (outer_radius - scinti_outer_radius) / cos(tilt_angle / rad) - (scinti_inner_radius - inner_radius) / cos(tilt_angle / rad);
+  scinti_tile_x -= subtract_from_scinti_x;
+  G4VSolid *scintibox = new G4Box("ScintiTile", scinti_tile_x / 2., scinti_tile_thickness / 2., scinti_tile_z / 2.);
+  volume_scintillator = scintibox->GetCubicVolume() * n_scinti_plates;
   return scintibox;
 }
 
-G4VSolid*
-PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelope)
+G4VSolid *
+PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
 {
   // calculate steel plate on top of the scinti box. Lower edge is the upper edge of
   // the scintibox + 1/2 the airgap
   double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
   // first the lower edge, just like the scinti box, just add the air gap
   // and calculate intersection of edge with inner and outer radius.
-  Point_2 p_in_1(mid_radius, 0); // center of lower scintillator
+  PHG4OuterHcalDetector::Point_2 p_in_1(mid_radius, 0);  // center of lower scintillator
   double angle_mid_scinti = M_PI / 2. + tilt_angle / rad;
   double xcoord = scinti_gap / 2. * cos(angle_mid_scinti / rad) + mid_radius;
-  double ycoord =   scinti_gap / 2. * sin(angle_mid_scinti / rad) + 0;
-  Point_2 p_loweredge(xcoord, ycoord);
-  Line_2 s2(p_in_1, p_loweredge); // center vertical
-  Line_2 perp =  s2.perpendicular(p_loweredge); // that is the lower edge of the steel plate
-  Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
+  double ycoord = scinti_gap / 2. * sin(angle_mid_scinti / rad) + 0;
+  PHG4OuterHcalDetector::Point_2 p_loweredge(xcoord, ycoord);
+  Line_2 s2(p_in_1, p_loweredge);               // center vertical
+  Line_2 perp = s2.perpendicular(p_loweredge);  // that is the lower edge of the steel plate
+  PHG4OuterHcalDetector::Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
   Circle_2 inner_circle(sc1, sc2, sc3);
-  vector< CGAL::Object > res;
+  vector<CGAL::Object> res;
   CGAL::intersection(inner_circle, perp, std::back_inserter(res));
-  Point_2 lowerleft;
-  vector< CGAL::Object >::const_iterator iter;
+  PHG4OuterHcalDetector::Point_2 lowerleft;
+  vector<CGAL::Object>::const_iterator iter;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) > 0)
-	    {
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      lowerleft = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	}
+      if (CGAL::to_double(point->first.x()) > 0)
+      {
+        PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        lowerleft = pntmp;
+      }
     }
-  Point_2 so1(outer_radius, 0), so2(0, outer_radius), so3(-outer_radius, 0);
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+    }
+  }
+  PHG4OuterHcalDetector::Point_2 so1(outer_radius, 0), so2(0, outer_radius), so3(-outer_radius, 0);
   Circle_2 outer_circle(so1, so2, so3);
-  res.clear(); // just clear the content from the last intersection search
+  res.clear();  // just clear the content from the last intersection search
   CGAL::intersection(outer_circle, perp, std::back_inserter(res));
-  Point_2 lowerright;
+  PHG4OuterHcalDetector::Point_2 lowerright;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) >  CGAL::to_double(p_loweredge.x()))
-	    {
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      lowerright = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	}
+      if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
+      {
+        PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        lowerright = pntmp;
+      }
     }
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+    }
+  }
   // now we have the lower left and rigth corner, now find the upper edge
   // find the center of the upper scintilator
-
 
   double phi_midpoint = 2 * M_PI / n_scinti_plates;
   double xmidpoint = cos(phi_midpoint) * mid_radius;
@@ -271,56 +266,56 @@ PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelope)
   angle_mid_scinti = (M_PI / 2. - phi_midpoint) - (M_PI / 2. + tilt_angle / rad);
   double xcoordup = xmidpoint - scinti_gap / 2. * sin(angle_mid_scinti / rad);
   double ycoordup = ymidpoint - scinti_gap / 2. * cos(angle_mid_scinti / rad);
-  Point_2 upperleft;
-  Point_2 upperright;
-  Point_2 mid_upperscint(xmidpoint, ymidpoint);
-  Point_2 p_upperedge(xcoordup, ycoordup);
+  PHG4OuterHcalDetector::Point_2 upperleft;
+  PHG4OuterHcalDetector::Point_2 upperright;
+  PHG4OuterHcalDetector::Point_2 mid_upperscint(xmidpoint, ymidpoint);
+  PHG4OuterHcalDetector::Point_2 p_upperedge(xcoordup, ycoordup);
   {
-    Line_2 sup(mid_upperscint, p_upperedge); // center vertical
-    Line_2 perp =  sup.perpendicular(p_upperedge); // that is the upper edge of the steel plate
-    Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
+    Line_2 sup(mid_upperscint, p_upperedge);       // center vertical
+    Line_2 perp = sup.perpendicular(p_upperedge);  // that is the upper edge of the steel plate
+    PHG4OuterHcalDetector::Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
     Circle_2 inner_circle(sc1, sc2, sc3);
-    vector< CGAL::Object > res;
+    vector<CGAL::Object> res;
     CGAL::intersection(inner_circle, perp, std::back_inserter(res));
-    vector< CGAL::Object >::const_iterator iter;
+    vector<CGAL::Object>::const_iterator iter;
     double pxmax = 0.;
     for (iter = res.begin(); iter != res.end(); ++iter)
+    {
+      CGAL::Object obj = *iter;
+      if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
       {
-	CGAL::Object obj = *iter;
-	if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	  {
-	    if (CGAL::to_double(point->first.x()) > pxmax)
-	      {
-		pxmax = CGAL::to_double(point->first.x());
-		Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-		upperleft = pntmp;
-	      }
-	  }
-	else
-	  {
-	    cout << "CGAL::Object type not pair..." << endl;
-	  }
+        if (CGAL::to_double(point->first.x()) > pxmax)
+        {
+          pxmax = CGAL::to_double(point->first.x());
+          PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+          upperleft = pntmp;
+        }
       }
-    Point_2 so1(outer_radius, 0), so2(0, outer_radius), so3(-outer_radius, 0);
+      else
+      {
+        cout << "CGAL::Object type not pair..." << endl;
+      }
+    }
+    PHG4OuterHcalDetector::Point_2 so1(outer_radius, 0), so2(0, outer_radius), so3(-outer_radius, 0);
     Circle_2 outer_circle(so1, so2, so3);
-    res.clear(); // just clear the content from the last intersection search
+    res.clear();  // just clear the content from the last intersection search
     CGAL::intersection(outer_circle, perp, std::back_inserter(res));
     for (iter = res.begin(); iter != res.end(); ++iter)
+    {
+      CGAL::Object obj = *iter;
+      if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
       {
-	CGAL::Object obj = *iter;
-	if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	  {
-	    if (CGAL::to_double(point->first.x()) >  CGAL::to_double(p_loweredge.x()))
-	      {
-		Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-		upperright = pntmp;
-	      }
-	  }
-	else
-	  {
-	    cout << "CGAL::Object type not pair..." << endl;
-	  }
+        if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
+        {
+          PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+          upperright = pntmp;
+        }
       }
+      else
+      {
+        cout << "CGAL::Object type not pair..." << endl;
+      }
+    }
   }
   // the left corners are on a secant with the inner boundary, they need to be shifted
   // to be a tangent at the center
@@ -335,119 +330,121 @@ PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelope)
   vertexes.push_back(v3);
   vertexes.push_back(v4);
   G4TwoVector zero(0, 0);
-  G4VSolid* steel_plate_uncut =  new G4ExtrudedSolid("SteelPlateUnCut",
-						     vertexes,
-						     size_z  / 2.0,
-						     zero, 1.0,
-						     zero, 1.0);
-      
+  G4VSolid *steel_plate_uncut = new G4ExtrudedSolid("SteelPlateUnCut",
+                                                    vertexes,
+                                                    size_z / 2.0,
+                                                    zero, 1.0,
+                                                    zero, 1.0);
+
   G4RotationMatrix *rotm = new G4RotationMatrix();
   rotm->rotateX(-90 * deg);
-  volume_steel = steel_plate_uncut->GetCubicVolume()*n_scinti_plates;
+  volume_steel = steel_plate_uncut->GetCubicVolume() * n_scinti_plates;
   // now cut out space for magnet at the ends
-  G4VSolid* steel_firstcut_solid = new G4SubtractionSolid("SteelPlateFirstCut",steel_plate_uncut,steel_cutout_for_magnet,rotm,G4ThreeVector(0,0,0));
+  G4VSolid *steel_firstcut_solid = new G4SubtractionSolid("SteelPlateFirstCut", steel_plate_uncut, steel_cutout_for_magnet, rotm, G4ThreeVector(0, 0, 0));
   //   DisplayVolume(steel_plate_uncut, hcalenvelope);
   //    DisplayVolume(steel_cutout_for_magnet, hcalenvelope);
   //    DisplayVolume(steel_cutout_for_magnet, hcalenvelope,rotm);
   //    DisplayVolume(steel_firstcut_solid, hcalenvelope);
   rotm = new G4RotationMatrix();
   rotm->rotateX(90 * deg);
-  G4VSolid* steel_cut_solid = new G4SubtractionSolid("SteelPlateCut",steel_firstcut_solid,steel_cutout_for_magnet,rotm,G4ThreeVector(0,0,0));
+  G4VSolid *steel_cut_solid = new G4SubtractionSolid("SteelPlateCut", steel_firstcut_solid, steel_cutout_for_magnet, rotm, G4ThreeVector(0, 0, 0));
   //           DisplayVolume(steel_cut_solid, hcalenvelope);
- 
+
   return steel_cut_solid;
 }
 
-void
-PHG4OuterHcalDetector::ShiftSecantToTangent(Point_2 &lowleft, Point_2 &upleft, Point_2 &upright, Point_2 &lowright)
+void PHG4OuterHcalDetector::ShiftSecantToTangent(PHG4OuterHcalDetector::Point_2 &lowleft, PHG4OuterHcalDetector::Point_2 &upleft, PHG4OuterHcalDetector::Point_2 &upright, PHG4OuterHcalDetector::Point_2 &lowright)
 {
   Line_2 secant(lowleft, upleft);
   Segment_2 upedge(upleft, upright);
   Segment_2 lowedge(lowleft, lowright);
   double xmid = (CGAL::to_double(lowleft.x()) + CGAL::to_double(upleft.x())) / 2.;
   double ymid = (CGAL::to_double(lowleft.y()) + CGAL::to_double(upleft.y())) / 2.;
-  Point_2 midpoint(xmid, ymid);
+  PHG4OuterHcalDetector::Point_2 midpoint(xmid, ymid);
   Line_2 sekperp = secant.perpendicular(midpoint);
-  Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
+  PHG4OuterHcalDetector::Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
   Circle_2 inner_circle(sc1, sc2, sc3);
-  vector< CGAL::Object > res;
+  vector<CGAL::Object> res;
   CGAL::intersection(inner_circle, sekperp, std::back_inserter(res));
-  vector< CGAL::Object >::const_iterator iter;
+  vector<CGAL::Object>::const_iterator iter;
   double pxmax = 0.;
-  Point_2 tangtouch;
+  PHG4OuterHcalDetector::Point_2 tangtouch;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) > pxmax)
-	    {
-	      pxmax = CGAL::to_double(point->first.x());
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      tangtouch = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	}
+      if (CGAL::to_double(point->first.x()) > pxmax)
+      {
+        pxmax = CGAL::to_double(point->first.x());
+        PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        tangtouch = pntmp;
+      }
     }
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+    }
+  }
   Line_2 leftside = sekperp.perpendicular(tangtouch);
   CGAL::Object result = CGAL::intersection(upedge, leftside);
-  if (const Point_2 *ipoint = CGAL::object_cast<Point_2>(&result))
-    {
-      upleft = *ipoint;
-    }
+  if (const PHG4OuterHcalDetector::Point_2 *ipoint = CGAL::object_cast<PHG4OuterHcalDetector::Point_2>(&result))
+  {
+    upleft = *ipoint;
+  }
   result = CGAL::intersection(lowedge, leftside);
-  if (const Point_2 *ipoint = CGAL::object_cast<Point_2>(&result))
-    {
-      lowleft = *ipoint;
-    }
+  if (const PHG4OuterHcalDetector::Point_2 *ipoint = CGAL::object_cast<PHG4OuterHcalDetector::Point_2>(&result))
+  {
+    lowleft = *ipoint;
+  }
   return;
 }
 
-void
-PHG4OuterHcalDetector::Construct( G4LogicalVolume* logicWorld )
+void PHG4OuterHcalDetector::Construct(G4LogicalVolume *logicWorld)
 {
-
-  G4Material* Air = G4Material::GetMaterial("G4_AIR");
-  G4VSolid* hcal_envelope_cylinder = new G4Tubs("OuterHcal_envelope_solid",  envelope_inner_radius, envelope_outer_radius, envelope_z/2.,0,2*M_PI);
+#ifdef SCINTITEST
+  ConstructOuterHcal(logicWorld);
+  return;
+#endif
+  G4Material *Air = G4Material::GetMaterial("G4_AIR");
+  G4VSolid *hcal_envelope_cylinder = new G4Tubs("OuterHcal_envelope_solid", envelope_inner_radius, envelope_outer_radius, envelope_z / 2., 0, 2 * M_PI);
   volume_envelope = hcal_envelope_cylinder->GetCubicVolume();
-  G4LogicalVolume* hcal_envelope_log =  new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("OuterHcal_envelope"), 0, 0, 0);
-  G4VisAttributes* hcalVisAtt = new G4VisAttributes();
+  G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("OuterHcal_envelope"), 0, 0, 0);
+  G4VisAttributes *hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(false);
   hcalVisAtt->SetForceSolid(false);
   hcalVisAtt->SetColour(G4Colour::White());
   hcal_envelope_log->SetVisAttributes(hcalVisAtt);
   G4RotationMatrix hcal_rotm;
-  hcal_rotm.rotateX(params->get_double_param("rot_x")*deg);
-  hcal_rotm.rotateY(params->get_double_param("rot_y")*deg);
-  hcal_rotm.rotateZ(params->get_double_param("rot_z")*deg);
-  new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(params->get_double_param("place_x")*cm, params->get_double_param("place_y")*cm, params->get_double_param("place_z")*cm)), hcal_envelope_log, "OuterHcal", logicWorld, 0, false, overlapcheck);
+  hcal_rotm.rotateX(params->get_double_param("rot_x") * deg);
+  hcal_rotm.rotateY(params->get_double_param("rot_y") * deg);
+  hcal_rotm.rotateZ(params->get_double_param("rot_z") * deg);
+  new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(params->get_double_param("place_x") * cm, params->get_double_param("place_y") * cm, params->get_double_param("place_z") * cm)), hcal_envelope_log, "OuterHcal", logicWorld, 0, false, overlapcheck);
   ConstructOuterHcal(hcal_envelope_log);
 
   return;
 }
 
-int
-PHG4OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelope)
+int PHG4OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume *hcalenvelope)
 {
   ConsistencyCheck();
-  SetTiltViaNcross(); // if number of crossings is set, use it to determine tilt
-  CheckTiltAngle(); // die if the tilt angle is out of range
+  SetTiltViaNcross();  // if number of crossings is set, use it to determine tilt
+  CheckTiltAngle();    // die if the tilt angle is out of range
   // the needed steel cutout volume for the magnet is constructed with
   // the scintillators since we have the theta angle at that point
 
   // call field setup here where we have the calculated tilt angle if number
   // of crossings is given
   field_setup = new PHG4OuterHcalFieldSetup(
-  n_scinti_plates,/*G4int steelPlates*/
-  scinti_gap, /*G4double scintiGap*/
-  tilt_angle);/*G4double tiltAngle*/
-
+      n_scinti_plates, /*G4int steelPlates*/
+      scinti_gap,      /*G4double scintiGap*/
+      tilt_angle);     /*G4double tiltAngle*/
 
   scinti_mother_assembly = ConstructHcalScintillatorAssembly(hcalenvelope);
-  G4VSolid *steel_plate =  ConstructSteelPlate(hcalenvelope);
+#ifdef SCINTITEST
+  return 0;
+#endif
+  G4VSolid *steel_plate = ConstructSteelPlate(hcalenvelope);
   //   DisplayVolume(steel_plate_4 ,hcalenvelope);
   G4LogicalVolume *steel_logical = new G4LogicalVolume(steel_plate, G4Material::GetMaterial(params->get_string_param("material")), "HcalOuterSteelPlate", 0, 0, 0);
   G4VisAttributes *visattchk = new G4VisAttributes();
@@ -459,136 +456,139 @@ PHG4OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelope)
   double deltaphi = 2 * M_PI / n_scinti_plates;
   ostringstream name;
   double middlerad = outer_radius - (outer_radius - inner_radius) / 2.;
-// okay this is crude. Since the inner and outer radius of the scintillator is different from the inner/outer
-// radius of the steel so the scintillator needs some shifting to get the gaps right
-// basically the first shift (sumshift) puts it at the inner radius of the steel
-// then it needs to be shifted up by twice the difference between the inner steel and inner scintillator radius
-// since sumshift is div by 2 for G4 but we need to shift the full delta(inner radius)
+  // okay this is crude. Since the inner and outer radius of the scintillator is different from the inner/outer
+  // radius of the steel so the scintillator needs some shifting to get the gaps right
+  // basically the first shift (sumshift) puts it at the inner radius of the steel
+  // then it needs to be shifted up by twice the difference between the inner steel and inner scintillator radius
+  // since sumshift is div by 2 for G4 but we need to shift the full delta(inner radius)
   double scinti_tile_orig_length = scinti_tile_x_upper + scinti_tile_x_lower - subtract_from_scinti_x;
   double shiftup = (scinti_inner_radius - inner_radius) / cos(tilt_angle / rad);
   double sumshift = scinti_tile_orig_length - scinti_tile_x;
-  sumshift = sumshift - 2*shiftup;
-  double shiftslat = fabs(scinti_tile_x_lower - scinti_tile_x_upper) / 2. + sumshift/2.;
-  // calculate phi offset (copied from code inside following loop): 
+  sumshift = sumshift - 2 * shiftup;
+  double shiftslat = fabs(scinti_tile_x_lower - scinti_tile_x_upper) / 2. + sumshift / 2.;
+  // calculate phi offset (copied from code inside following loop):
   // first get the center point (phi=0) so it's middlerad/0
   // then shift the scintillator center as documented in loop
-  // then 
+  // then
   // for positive tilt angles we need the lower left corner of the scintillator
   // for negative tilt angles we nee the upper right corner of the scintillator
   // as it turns out the code uses the middle of the face of the scintillator
   // as reference, if this is a problem the code needs to be modified to
-  // actually calculate the corner (but the math of the construction is that 
+  // actually calculate the corner (but the math of the construction is that
   // the middle of the scintillator sits at zero)
   double xp = cos(phi) * middlerad;
   double yp = sin(phi) * middlerad;
-  xp -= cos((-tilt_angle)/rad - phi)*shiftslat;
-  yp +=  sin((-tilt_angle)/rad - phi)*shiftslat;
-  if (tilt_angle >0)
-    {
-      double xo = xp - (scinti_tile_x/2.)*cos(tilt_angle/rad);
-      double yo = yp - (scinti_tile_x/2.)*sin(tilt_angle/rad);
-      phi = -atan(yo/xo);
-    }
+  xp -= cos((-tilt_angle) / rad - phi) * shiftslat;
+  yp += sin((-tilt_angle) / rad - phi) * shiftslat;
+  if (tilt_angle > 0)
+  {
+    double xo = xp - (scinti_tile_x / 2.) * cos(tilt_angle / rad);
+    double yo = yp - (scinti_tile_x / 2.) * sin(tilt_angle / rad);
+    phi = -atan(yo / xo);
+  }
   else if (tilt_angle < 0)
-    {
-      double xo = xp + (scinti_tile_x/2.)*cos(tilt_angle/rad);
-      double yo = yp + (scinti_tile_x/2.)*sin(tilt_angle/rad);
-      phi = -atan(yo/xo);
-    }
+  {
+    double xo = xp + (scinti_tile_x / 2.) * cos(tilt_angle / rad);
+    double yo = yp + (scinti_tile_x / 2.) * sin(tilt_angle / rad);
+    phi = -atan(yo / xo);
+  }
   // else (for tilt_angle = 0) phi stays zero
-  for (int i = 0; i < n_scinti_plates; i++)
-    {
-      G4RotationMatrix *Rot = new G4RotationMatrix();
-      double ypos = sin(phi) * middlerad;
-      double xpos = cos(phi) * middlerad;
-      // the center of the scintillator is not the center of the inner hcal
-      // but depends on the tilt angle. Therefore we need to shift
-      // the center from the mid point
-      ypos += sin((-tilt_angle)/rad - phi)*shiftslat;
-      xpos -= cos((-tilt_angle)/rad - phi)*shiftslat;
-      Rot->rotateZ(phi * rad + tilt_angle);
-      G4ThreeVector g4vec(xpos, ypos, 0);
-      // great the MakeImprint always adds 1 to the copy number and 0 has a 
-      // special meaning (which then also adds 1). Basically our volume names
-      // will start at 1 instead of 0 and there is nothing short of patching this
-      // method. I'll take care of this in the decoding of the volume name
-      // AAAAAAARHGS 
-      scinti_mother_assembly->MakeImprint(hcalenvelope, g4vec, Rot, i, overlapcheck);
-      Rot = new G4RotationMatrix();
-      Rot->rotateZ(-phi * rad);
-      name.str("");
-      name << "OuterHcalSteel_" << i;
-      steel_absorber_vec.insert(new G4PVPlacement(Rot, G4ThreeVector(0, 0, 0), steel_logical, name.str().c_str(), hcalenvelope, 0, i, overlapcheck));
-      phi += deltaphi;
-    }
+//  for (int i = 0; i < n_scinti_plates; i++)
+  for (int i = 0; i < 1; i++)
+  {
+    G4RotationMatrix *Rot = new G4RotationMatrix();
+    double ypos = sin(phi) * middlerad;
+    double xpos = cos(phi) * middlerad;
+    // the center of the scintillator is not the center of the inner hcal
+    // but depends on the tilt angle. Therefore we need to shift
+    // the center from the mid point
+    ypos += sin((-tilt_angle) / rad - phi) * shiftslat;
+    xpos -= cos((-tilt_angle) / rad - phi) * shiftslat;
+    Rot->rotateZ(phi * rad + tilt_angle);
+    G4ThreeVector g4vec(xpos, ypos, 0);
+    // great the MakeImprint always adds 1 to the copy number and 0 has a
+    // special meaning (which then also adds 1). Basically our volume names
+    // will start at 1 instead of 0 and there is nothing short of patching this
+    // method. I'll take care of this in the decoding of the volume name
+    // AAAAAAARHGS
+    scinti_mother_assembly->MakeImprint(hcalenvelope, g4vec, Rot, i, overlapcheck);
+    Rot = new G4RotationMatrix();
+    Rot->rotateZ(-phi * rad);
+    name.str("");
+    name << "OuterHcalSteel_" << i;
+    steel_absorber_vec.insert(new G4PVPlacement(Rot, G4ThreeVector(0, 0, 0), steel_logical, name.str().c_str(), hcalenvelope, 0, i, overlapcheck));
+    phi += deltaphi;
+  }
   hcalenvelope->SetFieldManager(
-      field_setup -> get_Field_Manager_Gap(),
+      field_setup->get_Field_Manager_Gap(),
       false);
 
   steel_logical->SetFieldManager(
-      field_setup -> get_Field_Manager_Iron(),
+      field_setup->get_Field_Manager_Iron(),
       true);
   return 0;
 }
 
-int
-PHG4OuterHcalDetector::DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol,G4RotationMatrix *rotm )
+int PHG4OuterHcalDetector::DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm)
 {
   static int i = 0;
-  G4LogicalVolume* checksolid = new G4LogicalVolume(volume,G4Material::GetMaterial("G4_POLYSTYRENE"),"DISPLAYLOGICAL", 0, 0, 0);
-  G4VisAttributes* visattchk = new G4VisAttributes();
+  G4LogicalVolume *checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), volume->GetName(), 0, 0, 0);
+  G4VisAttributes *visattchk = new G4VisAttributes();
   visattchk->SetVisibility(true);
   visattchk->SetForceSolid(false);
-  switch(i)
-    {
-    case 0:
-      visattchk->SetColour(G4Colour::Red());
-      i++;
-      break;
-    case 1:
-      visattchk->SetColour(G4Colour::Magenta());
-      i++;
-      break;
-    case 2:
-      visattchk->SetColour(G4Colour::Yellow());
-      i++;
-      break;
-    case 3:
-      visattchk->SetColour(G4Colour::Blue());
-      i++;
-      break;
-    case 4:
-      visattchk->SetColour(G4Colour::Cyan());
-      i++;
-      break;
-    default:
-      visattchk->SetColour(G4Colour::Green());
-      i=0;
-      break;
-    }
+  switch (i)
+  {
+  case 0:
+    visattchk->SetColour(G4Colour::Red());
+    i++;
+    break;
+  case 1:
+    visattchk->SetColour(G4Colour::Magenta());
+    i++;
+    break;
+  case 2:
+    visattchk->SetColour(G4Colour::Yellow());
+    i++;
+    break;
+  case 3:
+    visattchk->SetColour(G4Colour::Blue());
+    i++;
+    break;
+  case 4:
+    visattchk->SetColour(G4Colour::Cyan());
+    i++;
+    break;
+  default:
+    visattchk->SetColour(G4Colour::Green());
+    i = 0;
+    break;
+  }
 
   checksolid->SetVisAttributes(visattchk);
-  new G4PVPlacement(rotm,G4ThreeVector(0,0,0),checksolid,"DISPLAYVOL",logvol, 0, false, overlapcheck);
+  G4PVPlacement *placement = new G4PVPlacement(rotm, G4ThreeVector(0, 0, 0), checksolid, checksolid->GetName(), logvol, 0, false);
+  if (overlapcheck)
+  {
+    placement->CheckOverlaps(1000,0.,true,1);
+  }
   return 0;
 }
 
-void
-PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume* hcalenvelope)
+void PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hcalenvelope)
 {
   G4VSolid *bigtile = ConstructScintillatorBox(hcalenvelope);
   // eta->theta
-  G4double delta_eta =  params->get_double_param("scinti_eta_coverage") / n_scinti_tiles;
+  G4double delta_eta = params->get_double_param("scinti_eta_coverage") / n_scinti_tiles;
   G4double eta = 0;
   G4double theta;
   G4double x[4];
   G4double z[4];
   ostringstream name;
-  double overhang = (scinti_tile_x - (outer_radius - inner_radius)) / 2.;
-  double offset = 1 * cm + overhang; // add 1cm to make sure the G4ExtrudedSolid
+  double overhang = (scinti_tile_x - (scinti_outer_radius - scinti_inner_radius)) / 2.;
+  double offset = 1 * cm + overhang;  // add 1cm to make sure the G4ExtrudedSolid
   // is larger than the tile so we do not have
   // funny edge effects when overlapping vols
-  double magnet_cutout_x = (params->get_double_param("magnet_cutout_radius")*cm-inner_radius)/cos(tilt_angle/rad);
-  double x_inner = inner_radius - overhang;
+  double magnet_cutout_x = (params->get_double_param("magnet_cutout_scinti_radius") * cm - scinti_inner_radius) / cos(tilt_angle / rad);
+  double x_inner = scinti_inner_radius - overhang;
   double inner_offset = offset;
   // coordinates like the steel plates:
   // 0/0 upper left
@@ -599,116 +599,119 @@ PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume* hcalenv
   // here, this is why the indices are seemingly mixed up
   double xsteelcut[4];
   double zsteelcut[4];
-  fill_n(zsteelcut,4,NAN);
+  fill_n(zsteelcut, 4, NAN);
   xsteelcut[0] = x_inner + magnet_cutout_x;
   xsteelcut[1] = xsteelcut[0];
-  xsteelcut[2] = inner_radius - offset;
+  xsteelcut[2] = scinti_inner_radius - offset;
   xsteelcut[3] = xsteelcut[2];
-  double scinti_gap_neighbor =  params->get_double_param("scinti_gap_neighbor")*cm;
+  double scinti_gap_neighbor = params->get_double_param("scinti_gap_neighbor") * cm;
   for (int i = 0; i < n_scinti_tiles; i++)
+  {
+    if (i >= params->get_int_param("magnet_cutout_first_scinti"))
     {
-      if (i >= params->get_int_param("magnet_cutout_first_scinti"))
-	{
-          x_inner = inner_radius - overhang + magnet_cutout_x;
-	  inner_offset = offset - magnet_cutout_x;
-	}
-      theta = M_PI / 2 - PHG4Utils::get_theta(eta); // theta = 90 for eta=0
-      x[0] = x_inner;
-      z[0] = tan(theta) * inner_radius;
-      x[1] = outer_radius + overhang; // since the tile is tilted, x is not at the outer radius but beyond
-      z[1] = tan(theta) * outer_radius;
-      if (i >= params->get_int_param("magnet_cutout_first_scinti"))
-	{
-	  z[0] =  tan(theta) * (inner_radius +  (params->get_double_param("magnet_cutout_radius")*cm-inner_radius));
-	}
-      eta += delta_eta;
-      theta = M_PI / 2 - PHG4Utils::get_theta(eta); // theta = 90 for eta=0
-      x[2] = x_inner;
-      z[2] =  tan(theta) * inner_radius;
-      if (i >= params->get_int_param("magnet_cutout_first_scinti"))
-	{
-	  z[2] =  tan(theta) * (inner_radius + (params->get_double_param("magnet_cutout_radius")*cm-inner_radius));
-	}
-      x[3] =  outer_radius + overhang; // since the tile is tilted, x is not at the outer radius but beyond
-      z[3] = tan(theta) * outer_radius;
-      // apply gap between scintillators
-      z[0] += scinti_gap_neighbor / 2.;
-      z[1] += scinti_gap_neighbor / 2.;
-      z[2] -= scinti_gap_neighbor / 2.;
-      z[3] -= scinti_gap_neighbor / 2.;
-      Point_2 leftsidelow(z[0], x[0]);
-      Point_2 leftsidehigh(z[1], x[1]);
-      x[0] = inner_radius - inner_offset;
-      z[0] = x_at_y(leftsidelow, leftsidehigh, x[0]);
-      x[1] = outer_radius + offset;
-      z[1] = x_at_y(leftsidelow, leftsidehigh, x[1]);
-      Point_2 rightsidelow(z[2], x[2]);
-      Point_2 rightsidehigh(z[3], x[3]);
-      x[2] = outer_radius + offset;
-      z[2] = x_at_y(rightsidelow, rightsidehigh, x[2]);
-      x[3] = inner_radius - inner_offset;
-      z[3] = x_at_y(rightsidelow, rightsidehigh, x[3]);
-      // store corner points of extruded solid we need to subtract from steel
-      if ( i == params->get_int_param("magnet_cutout_first_scinti"))
-	{
-	  zsteelcut[0] = z[0];
-	  // we have to use the inner reference, not the already
-	  // adjusted one for the scintillator from above
-	  double xpos = inner_radius - offset; 
-	  zsteelcut[3] =  x_at_y(leftsidelow, leftsidehigh, xpos);
-	}
-      zsteelcut[1] = z[2]+1*cm;
-      zsteelcut[2] = z[2]+1*cm;
-      vector<G4TwoVector> vertexes;
-      for (int j = 0; j < 4; j++)
-	{
-	  G4TwoVector v(x[j], z[j]);
-	  vertexes.push_back(v);
-	}
-      G4TwoVector zero(0, 0);
-
-      G4VSolid *scinti =  new G4ExtrudedSolid("ScintillatorTile",
-					      vertexes,
-					      scinti_tile_thickness + 0.2 * mm,
-					      zero, 1.0,
-					      zero, 1.0);
-      G4RotationMatrix *rotm = new G4RotationMatrix();
-      rotm->rotateX(-90 * deg);
-      name.str("");
-      name << "scintillator_" << i << "_left";
-      G4VSolid *scinti_tile =  new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(inner_radius + outer_radius) / 2., 0, 0));
-      scinti_tiles_vec[i + n_scinti_tiles] = scinti_tile;
-      rotm = new G4RotationMatrix();
-      rotm->rotateX(90 * deg);
-      name.str("");
-      name << "scintillator_" << i << "_right";
-      scinti_tile =  new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(inner_radius + outer_radius) / 2., 0, 0));
-      scinti_tiles_vec[n_scinti_tiles - i - 1] =  scinti_tile;
+      x_inner = scinti_inner_radius - overhang + magnet_cutout_x;
+      inner_offset = offset - magnet_cutout_x;
     }
-  // for (unsigned int i=0; i<scinti_tiles_vec.size(); i++)
-  //   {
-  //     if (scinti_tiles_vec[i])
-  // 	 {
-  // 	   DisplayVolume(scinti_tiles_vec[i],hcalenvelope );
-  // 	 }
-  //   }
-  vector<G4TwoVector> vertexes;
-  for (int j = 0; j < 4; j++)
+    theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
+    x[0] = x_inner;
+    z[0] = tan(theta) * scinti_inner_radius;
+    x[1] = scinti_outer_radius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
+    z[1] = tan(theta) * scinti_outer_radius;
+    if (i >= params->get_int_param("magnet_cutout_first_scinti"))
     {
-      G4TwoVector v(xsteelcut[j], zsteelcut[j]);
+      z[0] = tan(theta) * (scinti_inner_radius + (params->get_double_param("magnet_cutout_scinti_radius") * cm - scinti_inner_radius));
+    }
+    eta += delta_eta;
+    theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
+    x[2] = x_inner;
+    z[2] = tan(theta) * scinti_inner_radius;
+    if (i >= params->get_int_param("magnet_cutout_first_scinti"))
+    {
+      z[2] = tan(theta) * (scinti_inner_radius + (params->get_double_param("magnet_cutout_scinti_radius") * cm - scinti_inner_radius));
+    }
+    x[3] = scinti_outer_radius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
+    z[3] = tan(theta) * scinti_outer_radius;
+    // apply gap between scintillators
+    z[0] += scinti_gap_neighbor / 2.;
+    z[1] += scinti_gap_neighbor / 2.;
+    z[2] -= scinti_gap_neighbor / 2.;
+    z[3] -= scinti_gap_neighbor / 2.;
+    PHG4OuterHcalDetector::Point_2 leftsidelow(z[0], x[0]);
+    PHG4OuterHcalDetector::Point_2 leftsidehigh(z[1], x[1]);
+    x[0] = scinti_inner_radius - inner_offset;
+    z[0] = x_at_y(leftsidelow, leftsidehigh, x[0]);
+    x[1] = scinti_outer_radius + offset;
+    z[1] = x_at_y(leftsidelow, leftsidehigh, x[1]);
+    PHG4OuterHcalDetector::Point_2 rightsidelow(z[2], x[2]);
+    PHG4OuterHcalDetector::Point_2 rightsidehigh(z[3], x[3]);
+    x[2] = scinti_outer_radius + offset;
+    z[2] = x_at_y(rightsidelow, rightsidehigh, x[2]);
+    x[3] = scinti_inner_radius - inner_offset;
+    z[3] = x_at_y(rightsidelow, rightsidehigh, x[3]);
+    // store corner points of extruded solid we need to subtract from steel
+    if (i == params->get_int_param("magnet_cutout_first_scinti"))
+    {
+      zsteelcut[0] = z[0];
+      // we have to use the inner reference, not the already
+      // adjusted one for the scintillator from above
+      double xpos = scinti_inner_radius - offset;
+      zsteelcut[3] = x_at_y(leftsidelow, leftsidehigh, xpos);
+    }
+    zsteelcut[1] = z[2] + 1 * cm;
+    zsteelcut[2] = z[2] + 1 * cm;
+    vector<G4TwoVector> vertexes;
+    for (int j = 0; j < 4; j++)
+    {
+      G4TwoVector v(x[j], z[j]);
       vertexes.push_back(v);
     }
+    G4TwoVector zero(0, 0);
+
+    G4VSolid *scinti = new G4ExtrudedSolid("ScintillatorTile",
+                                           vertexes,
+                                           scinti_tile_thickness + 0.2 * mm,
+                                           zero, 1.0,
+                                           zero, 1.0);
+    G4RotationMatrix *rotm = new G4RotationMatrix();
+    rotm->rotateX(-90 * deg);
+    name.str("");
+    name << "scintillator_" << i << "_left";
+    G4VSolid *scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(scinti_inner_radius + scinti_outer_radius) / 2., 0, 0));
+    scinti_tiles_vec[i + n_scinti_tiles] = scinti_tile;
+    rotm = new G4RotationMatrix();
+    rotm->rotateX(90 * deg);
+    name.str("");
+    name << "scintillator_" << i << "_right";
+    scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(scinti_inner_radius + scinti_outer_radius) / 2., 0, 0));
+    scinti_tiles_vec[n_scinti_tiles - i - 1] = scinti_tile;
+  }
+#ifdef SCINTITEST
+   for (unsigned int i=0; i<scinti_tiles_vec.size(); i++)
+     {
+       if (scinti_tiles_vec[i])
+   	 {
+   	   DisplayVolume(scinti_tiles_vec[i],hcalenvelope );
+   	 }
+     }
+#endif
+
+  vector<G4TwoVector> vertexes;
+  for (int j = 0; j < 4; j++)
+  {
+    G4TwoVector v(xsteelcut[j], zsteelcut[j]);
+    vertexes.push_back(v);
+  }
   G4TwoVector zero(0, 0);
-  steel_cutout_for_magnet =  new G4ExtrudedSolid("ScintillatorTile",
-						 vertexes,
-						 scinti_tile_thickness + 20 * cm,
-						 zero, 1.0,
-						 zero, 1.0);
+  steel_cutout_for_magnet = new G4ExtrudedSolid("ScintillatorTile",
+                                                vertexes,
+                                                scinti_tile_thickness + 20 * cm,
+                                                zero, 1.0,
+                                                zero, 1.0);
   return;
 }
 
 G4double
-PHG4OuterHcalDetector::x_at_y(Point_2 &p0, Point_2 &p1, G4double yin)
+PHG4OuterHcalDetector::x_at_y(PHG4OuterHcalDetector::Point_2 &p0, PHG4OuterHcalDetector::Point_2 &p1, G4double yin)
 {
   double xret = NAN;
   double x[2];
@@ -716,77 +719,87 @@ PHG4OuterHcalDetector::x_at_y(Point_2 &p0, Point_2 &p1, G4double yin)
   x[1] = CGAL::to_double(p1.x());
   Line_2 l(p0, p1);
   double newx = fabs(x[0]) + fabs(x[1]);
-  Point_2 p0new(-newx, yin);
-  Point_2 p1new(newx, yin);
+  PHG4OuterHcalDetector::Point_2 p0new(-newx, yin);
+  PHG4OuterHcalDetector::Point_2 p1new(newx, yin);
   Segment_2 s(p0new, p1new);
   CGAL::Object result = CGAL::intersection(l, s);
-  if ( const Point_2 *ipoint = CGAL::object_cast<Point_2>(&result))
-    {
-      xret = CGAL::to_double(ipoint->x());
-    }
+  if (const PHG4OuterHcalDetector::Point_2 *ipoint = CGAL::object_cast<PHG4OuterHcalDetector::Point_2>(&result))
+  {
+    xret = CGAL::to_double(ipoint->x());
+  }
   else
-    {
-      cout << PHWHERE << " failed for y = " << yin << endl;
-      cout << "p0(x): " << CGAL::to_double(p0.x()) << ", p0(y): " <<  CGAL::to_double(p0.y()) << endl;
-      cout << "p1(x): " << CGAL::to_double(p1.x()) << ", p1(y): " <<  CGAL::to_double(p1.y()) << endl;
-      exit(1);
-    }
+  {
+    cout << PHWHERE << " failed for y = " << yin << endl;
+    cout << "p0(x): " << CGAL::to_double(p0.x()) << ", p0(y): " << CGAL::to_double(p0.y()) << endl;
+    cout << "p1(x): " << CGAL::to_double(p1.x()) << ", p1(y): " << CGAL::to_double(p1.y()) << endl;
+    exit(1);
+  }
   return xret;
 }
 
 G4AssemblyVolume *
-PHG4OuterHcalDetector::ConstructHcalScintillatorAssembly(G4LogicalVolume* hcalenvelope)
+PHG4OuterHcalDetector::ConstructHcalScintillatorAssembly(G4LogicalVolume *hcalenvelope)
 {
+#ifdef SCINTITEST
+  ConstructHcalSingleScintillators(hcalenvelope);
+  return nullptr;
+#endif
   ConstructHcalSingleScintillators(hcalenvelope);
   G4AssemblyVolume *assmeblyvol = new G4AssemblyVolume();
   ostringstream name;
   G4ThreeVector g4vec;
-  double steplimits = params->get_double_param("steplimits")*cm;
-
-  for (unsigned int i=0; i<scinti_tiles_vec.size(); i++)
+  double steplimits = params->get_double_param("steplimits") * cm;
+  G4Colour colors[6] = {G4Colour::Red(), G4Colour::Magenta(), G4Colour::Yellow(),
+			G4Colour::Blue(), G4Colour::Cyan(), G4Colour::Green()};
+  int j = 0;
+  for (unsigned int i = 0; i < scinti_tiles_vec.size(); i++)
+  {
+    name.str("");
+    name << scintilogicnameprefix << i;
+    G4UserLimits *g4userlimits = nullptr;
+    if (isfinite(steplimits))
     {
-      name.str("");
-      name << scintilogicnameprefix << i;
-      G4UserLimits *g4userlimits = nullptr;
-      if (isfinite(steplimits))
-	{
-	  g4userlimits = new G4UserLimits(steplimits);
-	}
-      G4LogicalVolume *scinti_tile_logic = new G4LogicalVolume(scinti_tiles_vec[i],G4Material::GetMaterial("G4_POLYSTYRENE"),name.str().c_str(), nullptr, nullptr, g4userlimits);
-      G4VisAttributes *visattchk = new G4VisAttributes();
-      visattchk->SetVisibility(true);
-      visattchk->SetForceSolid(true);
-      visattchk->SetColour(G4Colour::Green());
-      scinti_tile_logic->SetVisAttributes(visattchk);
-      assmeblyvol->AddPlacedVolume(scinti_tile_logic,g4vec, nullptr);
-
-      //field after burner
-      scinti_tile_logic->SetFieldManager(
-          field_setup -> get_Field_Manager_Gap(),
-          true);
-
+      g4userlimits = new G4UserLimits(steplimits);
     }
+    G4LogicalVolume *scinti_tile_logic = new G4LogicalVolume(scinti_tiles_vec[i], G4Material::GetMaterial("G4_POLYSTYRENE"), name.str().c_str(), nullptr, nullptr, g4userlimits);
+    G4VisAttributes *visattchk = new G4VisAttributes();
+    visattchk->SetVisibility(true);
+    visattchk->SetForceSolid(false);
+//    visattchk->SetColour(G4Colour::Green());
+    visattchk->SetColour(colors[j]);
+    j++;
+    if (j>=6)
+    {
+      j = 0;
+    }
+    scinti_tile_logic->SetVisAttributes(visattchk);
+    assmeblyvol->AddPlacedVolume(scinti_tile_logic, g4vec, nullptr);
+
+    //field after burner
+    scinti_tile_logic->SetFieldManager(
+        field_setup->get_Field_Manager_Gap(),
+        true);
+  }
   return assmeblyvol;
 }
 
-int
-PHG4OuterHcalDetector::ConsistencyCheck() const
+int PHG4OuterHcalDetector::ConsistencyCheck() const
 {
   // just make sure the parameters make a bit of sense
   if (inner_radius >= outer_radius)
-    {
-      cout << PHWHERE << ": Inner Radius " << inner_radius/cm
-	   << " cm larger than Outer Radius " << outer_radius/cm
-	   << " cm" << endl;
-      gSystem->Exit(1);
-    }
+  {
+    cout << PHWHERE << ": Inner Radius " << inner_radius / cm
+         << " cm larger than Outer Radius " << outer_radius / cm
+         << " cm" << endl;
+    gSystem->Exit(1);
+  }
   if (scinti_tile_thickness > scinti_gap)
-    {
-      cout << PHWHERE << "Scintillator thickness " << scinti_tile_thickness/cm
-	   << " cm larger than scintillator gap " << scinti_gap/cm
-	   << " cm" << endl;
-      gSystem->Exit(1);
-    }
+  {
+    cout << PHWHERE << "Scintillator thickness " << scinti_tile_thickness / cm
+         << " cm larger than scintillator gap " << scinti_gap / cm
+         << " cm" << endl;
+    gSystem->Exit(1);
+  }
   if (scinti_outer_radius <= scinti_inner_radius)
   {
     cout << PHWHERE << "Scintillator outer radius " << scinti_outer_radius / cm
@@ -812,125 +825,122 @@ PHG4OuterHcalDetector::ConsistencyCheck() const
   return 0;
 }
 
-void
-PHG4OuterHcalDetector::SetTiltViaNcross()
+void PHG4OuterHcalDetector::SetTiltViaNcross()
 {
   int ncross = params->get_int_param("ncross");
-  if (! ncross || isfinite(tilt_angle))
-    {
-      return;
-    }
-  if ((isfinite(tilt_angle))&&(verbosity > 0))
-    {
-      cout << "both number of crossings and tilt angle are set" << endl;
-      cout << "using number of crossings to determine tilt angle" << endl;
-    }
-  double mid_radius = inner_radius + (outer_radius-inner_radius)/2.;
-  double deltaphi = (2*M_PI/n_scinti_plates)*ncross;
-  Point_2 pnull(0,0);
-  Point_2 plow(inner_radius,0);
-  Point_2 phightmp(1,tan(deltaphi));
-  Point_2 pin1(inner_radius,0), pin2(0,inner_radius),pin3(-inner_radius,0);
-  Circle_2 inner_circle(pin1,pin2,pin3);
-  Point_2 pmid1(mid_radius,0), pmid2(0,mid_radius),pmid3(-mid_radius,0);
-  Circle_2 mid_circle(pmid1,pmid2,pmid3);
-  Point_2 pout1(outer_radius,0), pout2(0,outer_radius),pout3(-outer_radius,0);
-  Circle_2 outer_circle(pout1,pout2,pout3);
-  Line_2 l_up(pnull,phightmp);
-  vector< CGAL::Object > res;
+  if (!ncross || isfinite(tilt_angle))
+  {
+    return;
+  }
+  if ((isfinite(tilt_angle)) && (verbosity > 0))
+  {
+    cout << "both number of crossings and tilt angle are set" << endl;
+    cout << "using number of crossings to determine tilt angle" << endl;
+  }
+  double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
+  double deltaphi = (2 * M_PI / n_scinti_plates) * ncross;
+  PHG4OuterHcalDetector::Point_2 pnull(0, 0);
+  PHG4OuterHcalDetector::Point_2 plow(inner_radius, 0);
+  PHG4OuterHcalDetector::Point_2 phightmp(1, tan(deltaphi));
+  PHG4OuterHcalDetector::Point_2 pin1(inner_radius, 0), pin2(0, inner_radius), pin3(-inner_radius, 0);
+  Circle_2 inner_circle(pin1, pin2, pin3);
+  PHG4OuterHcalDetector::Point_2 pmid1(mid_radius, 0), pmid2(0, mid_radius), pmid3(-mid_radius, 0);
+  Circle_2 mid_circle(pmid1, pmid2, pmid3);
+  PHG4OuterHcalDetector::Point_2 pout1(outer_radius, 0), pout2(0, outer_radius), pout3(-outer_radius, 0);
+  Circle_2 outer_circle(pout1, pout2, pout3);
+  Line_2 l_up(pnull, phightmp);
+  vector<CGAL::Object> res;
   CGAL::intersection(outer_circle, l_up, std::back_inserter(res));
-  Point_2 upperright;
-  vector< CGAL::Object >::const_iterator iter;
+  PHG4OuterHcalDetector::Point_2 upperright;
+  vector<CGAL::Object>::const_iterator iter;
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) >  0)
-	    {
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      upperright = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	  exit(1);
-	}
+      if (CGAL::to_double(point->first.x()) > 0)
+      {
+        PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        upperright = pntmp;
+      }
     }
-  Line_2 l_right(plow,upperright);
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+      exit(1);
+    }
+  }
+  Line_2 l_right(plow, upperright);
   res.clear();
-  Point_2 midpoint;
+  PHG4OuterHcalDetector::Point_2 midpoint;
   CGAL::intersection(mid_circle, l_right, std::back_inserter(res));
   for (iter = res.begin(); iter != res.end(); ++iter)
+  {
+    CGAL::Object obj = *iter;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<Circular_k>, unsigned> >(&obj))
-	{
-	  if (CGAL::to_double(point->first.x()) >  0)
-	    {
-	      Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	      midpoint = pntmp;
-	    }
-	}
-      else
-	{
-	  cout << "CGAL::Object type not pair..." << endl;
-	  exit(1);
-	}
+      if (CGAL::to_double(point->first.x()) > 0)
+      {
+        PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        midpoint = pntmp;
+      }
     }
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
+      exit(1);
+    }
+  }
   // length left side
-  double ll = sqrt((CGAL::to_double(midpoint.x()) - inner_radius)*(CGAL::to_double(midpoint.x()) - inner_radius) + CGAL::to_double(midpoint.y())*CGAL::to_double(midpoint.y()));
-  double upside = sqrt(CGAL::to_double(midpoint.x())*CGAL::to_double(midpoint.x()) + CGAL::to_double(midpoint.y())*CGAL::to_double(midpoint.y()));
+  double ll = sqrt((CGAL::to_double(midpoint.x()) - inner_radius) * (CGAL::to_double(midpoint.x()) - inner_radius) + CGAL::to_double(midpoint.y()) * CGAL::to_double(midpoint.y()));
+  double upside = sqrt(CGAL::to_double(midpoint.x()) * CGAL::to_double(midpoint.x()) + CGAL::to_double(midpoint.y()) * CGAL::to_double(midpoint.y()));
   //  c^2 = a^2+b^2 - 2ab*cos(gamma)
   // gamma = acos((a^2+b^2=c^2)/2ab
-  double tiltangle = acos((ll*ll + upside*upside-inner_radius*inner_radius)/(2*ll*upside));
-  tiltangle = tiltangle*rad;
-  tilt_angle = copysign(tiltangle,ncross);
-  params->set_double_param("tilt_angle",tilt_angle/deg);
+  double tiltangle = acos((ll * ll + upside * upside - inner_radius * inner_radius) / (2 * ll * upside));
+  tiltangle = tiltangle * rad;
+  tilt_angle = copysign(tiltangle, ncross);
+  params->set_double_param("tilt_angle", tilt_angle / deg);
   return;
 }
 
 // check if tilt angle is reasonable - too large, no intersections with inner radius
-int
-PHG4OuterHcalDetector::CheckTiltAngle() const
+int PHG4OuterHcalDetector::CheckTiltAngle() const
 {
   if (fabs(tilt_angle) >= M_PI)
-    {
-      cout << PHWHERE << "invalid tilt angle, abs(tilt) >= 90 deg: " << (tilt_angle / deg)
-	   << endl;
-      exit(1);
-    }
+  {
+    cout << PHWHERE << "invalid tilt angle, abs(tilt) >= 90 deg: " << (tilt_angle / deg)
+         << endl;
+    exit(1);
+  }
 
   double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
-  Point_2 pmid(mid_radius, 0); // center of scintillator
+  PHG4OuterHcalDetector::Point_2 pmid(mid_radius, 0);  // center of scintillator
   double xcoord = 0;
-  double ycoord = mid_radius * tan(tilt_angle / rad) ;
-  Point_2 pxnull(xcoord, ycoord);
+  double ycoord = mid_radius * tan(tilt_angle / rad);
+  PHG4OuterHcalDetector::Point_2 pxnull(xcoord, ycoord);
   Line_2 s2(pmid, pxnull);
-  Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
+  PHG4OuterHcalDetector::Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
   Circle_2 inner_circle(sc1, sc2, sc3);
-  vector< CGAL::Object > res;
+  vector<CGAL::Object> res;
   CGAL::intersection(inner_circle, s2, std::back_inserter(res));
   if (res.size() == 0)
-    {
-      cout << PHWHERE << " Tilt angle " << (tilt_angle / deg)
-	   << " too large, no intersection with inner radius" << endl;
-      exit(1);
-    }
+  {
+    cout << PHWHERE << " Tilt angle " << (tilt_angle / deg)
+         << " too large, no intersection with inner radius" << endl;
+    exit(1);
+  }
   return 0;
 }
 
-void
-PHG4OuterHcalDetector::Print(const string &what) const
+void PHG4OuterHcalDetector::Print(const string &what) const
 {
   cout << "Outer Hcal Detector:" << endl;
   if (what == "ALL" || what == "VOLUME")
-    {
-      cout << "Volume Envelope: " << volume_envelope/cm/cm/cm << " cm^3" << endl;
-      cout << "Volume Steel: " << volume_steel/cm/cm/cm << " cm^3" << endl;
-      cout << "Volume Scintillator: " << volume_scintillator/cm/cm/cm << " cm^3" << endl;
-      cout << "Volume Air: " << (volume_envelope - volume_steel - volume_scintillator)/cm/cm/cm << " cm^3" << endl;
-    }
+  {
+    cout << "Volume Envelope: " << volume_envelope / cm / cm / cm << " cm^3" << endl;
+    cout << "Volume Steel: " << volume_steel / cm / cm / cm << " cm^3" << endl;
+    cout << "Volume Scintillator: " << volume_scintillator / cm / cm / cm << " cm^3" << endl;
+    cout << "Volume Air: " << (volume_envelope - volume_steel - volume_scintillator) / cm / cm / cm << " cm^3" << endl;
+  }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -340,7 +340,7 @@ PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
 
   volume_steel = steel_plate_uncut->GetCubicVolume() * n_scinti_plates;
   // now cut out space for magnet at the ends
-  if (! steel_cutout_for_magnet)
+  if (!steel_cutout_for_magnet)
   {
     return steel_plate_uncut;
   }
@@ -524,9 +524,9 @@ int PHG4OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume *hcalenvelope)
     steel_absorber_vec.insert(new G4PVPlacement(Rot, G4ThreeVector(0, 0, 0), steel_logical, name.str().c_str(), hcalenvelope, 0, i, overlapcheck));
     phi += deltaphi;
   }
-  hcalenvelope->SetFieldManager(field_setup->get_Field_Manager_Gap(),false);
+  hcalenvelope->SetFieldManager(field_setup->get_Field_Manager_Gap(), false);
 
-  steel_logical->SetFieldManager(field_setup->get_Field_Manager_Iron(),true);
+  steel_logical->SetFieldManager(field_setup->get_Field_Manager_Iron(), true);
   return 0;
 }
 
@@ -569,7 +569,7 @@ int PHG4OuterHcalDetector::DisplayVolume(G4VSolid *volume, G4LogicalVolume *logv
   G4PVPlacement *placement = new G4PVPlacement(rotm, G4ThreeVector(0, 0, 0), checksolid, checksolid->GetName(), logvol, 0, false);
   if (overlapcheck)
   {
-    placement->CheckOverlaps(1000,0.,true,1);
+    placement->CheckOverlaps(1000, 0., true, 1);
   }
   return 0;
 }
@@ -601,7 +601,7 @@ void PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
   double xsteelcut[4];
   double zsteelcut[4];
   fill_n(zsteelcut, 4, NAN);
-  double steel_overhang =  (scinti_tile_x_upper + scinti_tile_x_lower - subtract_from_scinti_x - (outer_radius - inner_radius)) / 2.;
+  double steel_overhang = (scinti_tile_x_upper + scinti_tile_x_lower - subtract_from_scinti_x - (outer_radius - inner_radius)) / 2.;
   double steel_offset = 1 * cm + steel_overhang;  // add 1cm to make sure the G4ExtrudedSolid
   double steel_x_inner = inner_radius - steel_overhang;
   double steel_magnet_cutout_x = (params->get_double_param("magnet_cutout_radius") * cm - inner_radius) / cos(tilt_angle / rad);
@@ -664,7 +664,7 @@ void PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
       zsteelcut[3] = x_at_y(leftsidelow, leftsidehigh, xpos);
     }
     double x2 = outer_radius + steel_offset;
-    double z2 =  x_at_y(rightsidelow, rightsidehigh, x2);
+    double z2 = x_at_y(rightsidelow, rightsidehigh, x2);
     zsteelcut[1] = z2 + 1 * cm;
     zsteelcut[2] = z2 + 1 * cm;
     vector<G4TwoVector> vertexes;
@@ -694,22 +694,22 @@ void PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
     scinti_tiles_vec[n_scinti_tiles - i - 1] = scinti_tile;
   }
 #ifdef SCINTITEST
-   for (unsigned int i=0; i<scinti_tiles_vec.size(); i++)
-     {
-       if (scinti_tiles_vec[i])
-   	 {
-   	   DisplayVolume(scinti_tiles_vec[i],hcalenvelope );
-   	 }
-     }
+  for (unsigned int i = 0; i < scinti_tiles_vec.size(); i++)
+  {
+    if (scinti_tiles_vec[i])
+    {
+      DisplayVolume(scinti_tiles_vec[i], hcalenvelope);
+    }
+  }
 #endif
 
   vector<G4TwoVector> vertexes;
   for (int j = 0; j < 4; j++)
   {
-    if (! isfinite(zsteelcut[j]))
-      {
-	return;
-      }
+    if (!isfinite(zsteelcut[j]))
+    {
+      return;
+    }
     G4TwoVector v(xsteelcut[j], zsteelcut[j]);
     vertexes.push_back(v);
   }
@@ -762,7 +762,7 @@ PHG4OuterHcalDetector::ConstructHcalScintillatorAssembly(G4LogicalVolume *hcalen
   G4ThreeVector g4vec;
   double steplimits = params->get_double_param("steplimits") * cm;
   G4Colour colors[6] = {G4Colour::Red(), G4Colour::Magenta(), G4Colour::Yellow(),
-			G4Colour::Blue(), G4Colour::Cyan(), G4Colour::Green()};
+                        G4Colour::Blue(), G4Colour::Cyan(), G4Colour::Green()};
   int j = 0;
   for (unsigned int i = 0; i < scinti_tiles_vec.size(); i++)
   {
@@ -777,10 +777,10 @@ PHG4OuterHcalDetector::ConstructHcalScintillatorAssembly(G4LogicalVolume *hcalen
     G4VisAttributes *visattchk = new G4VisAttributes();
     visattchk->SetVisibility(true);
     visattchk->SetForceSolid(false);
-//    visattchk->SetColour(G4Colour::Green());
+    //    visattchk->SetColour(G4Colour::Green());
     visattchk->SetColour(colors[j]);
     j++;
-    if (j>=6)
+    if (j >= 6)
     {
       j = 0;
     }
@@ -833,21 +833,21 @@ int PHG4OuterHcalDetector::ConsistencyCheck() const
          << " cm" << endl;
     gSystem->Exit(1);
   }
-  if (params->get_double_param("magnet_cutout_scinti_radius")*cm < scinti_inner_radius)
+  if (params->get_double_param("magnet_cutout_scinti_radius") * cm < scinti_inner_radius)
   {
     cout << PHWHERE << "Magnet scintillator cutout radius " << params->get_double_param("magnet_cutout_scinti_radius")
          << " cm smaller than inner scintillator radius " << scinti_inner_radius / cm
          << " cm" << endl;
     gSystem->Exit(1);
   }
-  if (params->get_double_param("magnet_cutout_radius")*cm < inner_radius)
+  if (params->get_double_param("magnet_cutout_radius") * cm < inner_radius)
   {
     cout << PHWHERE << "Magnet steel cutout radius " << params->get_double_param("magnet_cutout_radius")
          << " cm smaller than inner radius " << inner_radius / cm
          << " cm" << endl;
     gSystem->Exit(1);
   }
- 
+
   return 0;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
@@ -12,8 +12,8 @@
 #include <CGAL/point_generators_2.h>
 
 #include <map>
-#include <vector>
 #include <set>
+#include <vector>
 
 class G4AssemblyVolume;
 class G4LogicalVolume;
@@ -21,46 +21,44 @@ class G4VPhysicalVolume;
 class G4VSolid;
 class PHG4Parameters;
 
-class PHG4OuterHcalDetector: public PHG4Detector
+class PHG4OuterHcalDetector : public PHG4Detector
 {
-  typedef CGAL::Exact_circular_kernel_2             Circular_k;
-  typedef CGAL::Point_2<Circular_k>                 Point_2;
-
-  public:
-
+ public:
+  typedef CGAL::Exact_circular_kernel_2 Circular_k;
+  typedef CGAL::Point_2<Circular_k> Point_2;
   //! constructor
-  PHG4OuterHcalDetector( PHCompositeNode *Node, PHG4Parameters *params, const std::string &dnam="HCALOUT");
+  PHG4OuterHcalDetector(PHCompositeNode *Node, PHG4Parameters *params, const std::string &dnam = "HCALOUT");
 
   //! destructor
   virtual ~PHG4OuterHcalDetector();
 
   //! construct
-  virtual void Construct( G4LogicalVolume* world );
+  virtual void Construct(G4LogicalVolume *world);
 
   virtual void Print(const std::string &what = "ALL") const;
 
   //!@name volume accessors
   //@{
-  int IsInOuterHcal(G4VPhysicalVolume*) const;
+  int IsInOuterHcal(G4VPhysicalVolume *) const;
   //@}
 
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return layer;}
+  void SuperDetector(const std::string &name) { superdetector = name; }
+  const std::string SuperDetector() const { return superdetector; }
+  int get_Layer() const { return layer; }
   void ShiftSecantToTangent(Point_2 &lowleft, Point_2 &upleft, Point_2 &upright, Point_2 &lowright);
   int ConsistencyCheck() const;
   void SetTiltViaNcross();
   int CheckTiltAngle() const;
-  void ConstructHcalSingleScintillators(G4LogicalVolume* hcalenvelope);
-  G4VSolid *ConstructScintillatorBox(G4LogicalVolume* hcalenvelope);
+  void ConstructHcalSingleScintillators(G4LogicalVolume *hcalenvelope);
+  G4VSolid *ConstructScintillatorBox(G4LogicalVolume *hcalenvelope);
 
-  protected:
-  int ConstructOuterHcal(G4LogicalVolume* hcalenvelope);
-  G4VSolid *ConstructSteelPlate(G4LogicalVolume* hcalenvelope);
-  G4AssemblyVolume *ConstructHcalScintillatorAssembly(G4LogicalVolume* hcalenvelope);
-  int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
+ protected:
+  int ConstructOuterHcal(G4LogicalVolume *hcalenvelope);
+  G4VSolid *ConstructSteelPlate(G4LogicalVolume *hcalenvelope);
+  G4AssemblyVolume *ConstructHcalScintillatorAssembly(G4LogicalVolume *hcalenvelope);
+  int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = nullptr);
   G4double x_at_y(Point_2 &p0, Point_2 &p1, G4double yin);
-  PHG4OuterHcalFieldSetup * field_setup;
+  PHG4OuterHcalFieldSetup *field_setup;
   PHG4Parameters *params;
   G4AssemblyVolume *scinti_mother_assembly;
   G4VSolid *steel_cutout_for_magnet;
@@ -93,8 +91,8 @@ class PHG4OuterHcalDetector: public PHG4Detector
   std::string detector_type;
   std::string superdetector;
   std::string scintilogicnameprefix;
-  std::vector<G4VSolid *> scinti_tiles_vec; 
-  std::set<G4VPhysicalVolume *>steel_absorber_vec;
+  std::vector<G4VSolid *> scinti_tiles_vec;
+  std::set<G4VPhysicalVolume *> steel_absorber_vec;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
@@ -73,6 +73,8 @@ class PHG4OuterHcalDetector: public PHG4Detector
   double scinti_tile_z;
   double scinti_tile_thickness;
   double scinti_gap;
+  double scinti_inner_radius;
+  double scinti_outer_radius;
   double tilt_angle;
   double envelope_inner_radius;
   double envelope_outer_radius;

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -251,7 +251,6 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       {
         hit = new PHG4Hitv1();
       }
-      hit->set_scint_id(tower_id);  // the slat id (or steel plate id)
       //here we set the entrance values in cm
       hit->set_x(0, prePoint->GetPosition().x() / cm);
       hit->set_y(0, prePoint->GetPosition().y() / cm);
@@ -265,6 +264,7 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       hit->set_edep(0);
       if (whichactive > 0)  // return of IsInOuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
       {
+        hit->set_scint_id(tower_id);  // the slat id
         hit->set_eion(0);
         hit->set_light_yield(0);  //  for scintillator only, initialize light yields
         // Now save the container we want to add this hit to

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -233,17 +233,17 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       }
       else
       {
-	cout << GetName() << ": New Hit for  " << endl;
-	cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-	     << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-	     << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
-	     << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
-	cout << "last track: " << savetrackid
-	     << ", current trackid: " << aTrack->GetTrackID() << endl;
-	cout << "phys pre vol: " << volume->GetName()
-	     << " post vol : " << touchpost->GetVolume()->GetName() << endl;
-	cout << " previous phys pre vol: " << savevolpre->GetName()
-	     << " previous phys post vol: " << savevolpost->GetName() << endl;
+        cout << GetName() << ": New Hit for  " << endl;
+        cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+             << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+             << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+             << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
+        cout << "last track: " << savetrackid
+             << ", current trackid: " << aTrack->GetTrackID() << endl;
+        cout << "phys pre vol: " << volume->GetName()
+             << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+        cout << " previous phys pre vol: " << savevolpre->GetName()
+             << " previous phys post vol: " << savevolpost->GetName() << endl;
       }
     case fGeomBoundary:
     case fUndefined:

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -161,13 +161,13 @@ PHG4OuterHcalSubsystem::SetLightCorrection(const double inner_radius, const doub
 void
 PHG4OuterHcalSubsystem::SetDefaultParameters()
 {
-  set_default_double_param("inner_radius", 178.);
+  set_default_double_param("inner_radius", 183.3);
   set_default_double_param("light_balance_inner_corr", NAN);
   set_default_double_param("light_balance_inner_radius", NAN);
   set_default_double_param("light_balance_outer_corr", NAN);
   set_default_double_param("light_balance_outer_radius", NAN);
-  set_default_double_param("magnet_cutout", 12.);
-  set_default_double_param("outer_radius", 260.);
+  set_default_double_param("magnet_cutout_radius", 195.31);
+  set_default_double_param("outer_radius", 264.71);
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);
   set_default_double_param("place_z", 0.);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -167,9 +167,9 @@ PHG4OuterHcalSubsystem::SetDefaultParameters()
   set_default_double_param("scinti_eta_coverage", 1.1);
   set_default_double_param("scinti_gap", 0.85);
   set_default_double_param("scinti_gap_neighbor", 0.1);
-  set_default_double_param("scinti_tile_thickness", 0.7);
   set_default_double_param("scinti_inner_radius",183.89);
   set_default_double_param("scinti_outer_radius",263.27);
+  set_default_double_param("scinti_tile_thickness", 0.7);
   set_default_double_param("size_z", 304.91 * 2);
   set_default_double_param("steplimits", NAN);
   set_default_double_param("tilt_angle", NAN); // default is 5 crossings

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -155,7 +155,7 @@ PHG4OuterHcalSubsystem::SetDefaultParameters()
   set_default_double_param("light_balance_inner_radius", NAN);
   set_default_double_param("light_balance_outer_corr", NAN);
   set_default_double_param("light_balance_outer_radius", NAN);
-//  set_default_double_param("magnet_cutout_radius", 195.31);
+  set_default_double_param("magnet_cutout_radius", 195.31);
   set_default_double_param("magnet_cutout_scinti_radius", 195.96);
   set_default_double_param("outer_radius", 264.71);
   set_default_double_param("place_x", 0.);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -22,9 +22,9 @@ using namespace std;
 //_______________________________________________________________________
 PHG4OuterHcalSubsystem::PHG4OuterHcalSubsystem( const std::string &name, const int lyr ):
   PHG4DetectorSubsystem( name, lyr ),
-  detector_( NULL ),
-  steppingAction_( NULL ),
-  eventAction_(NULL),
+  detector_( nullptr ),
+  steppingAction_( nullptr ),
+  eventAction_(nullptr),
   enable_field_checker(0)
 {
   InitializeParameters();
@@ -178,6 +178,8 @@ PHG4OuterHcalSubsystem::SetDefaultParameters()
   set_default_double_param("scinti_gap", 0.85);
   set_default_double_param("scinti_gap_neighbor", 0.1);
   set_default_double_param("scinti_tile_thickness", 0.7);
+  set_default_double_param("scinti_inner_radius",183.89);
+  set_default_double_param("scinti_outer_radius",263.27);
   set_default_double_param("size_z", 304.91 * 2);
   set_default_double_param("steplimits", NAN);
   set_default_double_param("tilt_angle", NAN); // default is 4 crossinge

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -1,6 +1,5 @@
 #include "PHG4OuterHcalSubsystem.h"
 #include "PHG4OuterHcalDetector.h"
-#include "PHG4EventActionClearZeroEdep.h"
 #include "PHG4OuterHcalSteppingAction.h"
 #include "PHG4HcalDefs.h"
 #include "PHG4Parameters.h"
@@ -24,7 +23,6 @@ PHG4OuterHcalSubsystem::PHG4OuterHcalSubsystem( const std::string &name, const i
   PHG4DetectorSubsystem( name, lyr ),
   detector_( nullptr ),
   steppingAction_( nullptr ),
-  eventAction_(nullptr),
   enable_field_checker(0)
 {
   InitializeParameters();
@@ -81,15 +79,6 @@ PHG4OuterHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 	    {
 	      g4_hits = new PHG4HitContainer(node);
 	      DetNode->addNode( new PHIODataNode<PHObject>( g4_hits, node.c_str(), "PHObject" ));
-	    }
-	  if (! eventAction_)
-	    {
-	      eventAction_ = new PHG4EventActionClearZeroEdep(topNode, node);
-	    }
-	  else
-	    {
-	      PHG4EventActionClearZeroEdep *evtact = dynamic_cast<PHG4EventActionClearZeroEdep *>(eventAction_);
-	      evtact->AddNode(node);
 	    }
 	}
       // create stepping action
@@ -166,7 +155,8 @@ PHG4OuterHcalSubsystem::SetDefaultParameters()
   set_default_double_param("light_balance_inner_radius", NAN);
   set_default_double_param("light_balance_outer_corr", NAN);
   set_default_double_param("light_balance_outer_radius", NAN);
-  set_default_double_param("magnet_cutout_radius", 195.31);
+//  set_default_double_param("magnet_cutout_radius", 195.31);
+  set_default_double_param("magnet_cutout_scinti_radius", 195.96);
   set_default_double_param("outer_radius", 264.71);
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);
@@ -182,11 +172,11 @@ PHG4OuterHcalSubsystem::SetDefaultParameters()
   set_default_double_param("scinti_outer_radius",263.27);
   set_default_double_param("size_z", 304.91 * 2);
   set_default_double_param("steplimits", NAN);
-  set_default_double_param("tilt_angle", NAN); // default is 4 crossinge
+  set_default_double_param("tilt_angle", NAN); // default is 5 crossings
 
   set_default_int_param("light_scint_model", 1);
   set_default_int_param("magnet_cutout_first_scinti", 8); // tile start at 0, drawing tile starts at 1
-  set_default_int_param("ncross", -4);
+  set_default_int_param("ncross", -5);
   set_default_int_param("n_towers", 64);
   set_default_int_param(PHG4HcalDefs::scipertwr, 5);
   set_default_int_param("n_scinti_tiles", 12);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
@@ -9,7 +9,6 @@
 class PHG4OuterHcalDetector;
 class PHG4Parameters;
 class PHG4OuterHcalSteppingAction;
-class PHG4EventAction;
 
 class PHG4OuterHcalSubsystem: public PHG4DetectorSubsystem
 {
@@ -44,8 +43,6 @@ class PHG4OuterHcalSubsystem: public PHG4DetectorSubsystem
   PHG4Detector* GetDetector( void ) const;
   PHG4SteppingAction* GetSteppingAction( void ) const;
 
-  PHG4EventAction* GetEventAction() const {return eventAction_;}
-
   void SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr);
 
   void EnableFieldChecker(const int i=1) {enable_field_checker = i;}
@@ -61,10 +58,6 @@ class PHG4OuterHcalSubsystem: public PHG4DetectorSubsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
   PHG4SteppingAction* steppingAction_;
-
-  //! begin/end of event action
-  /*! derives from PHG4EventAction */
-  PHG4EventAction *eventAction_;
 
   int enable_field_checker;
 };


### PR DESCRIPTION
The hcal implementation used the envelope as inner/outer radius rather than the actual radii from the engineering drawings. The defaults were adjusted to reflect the radii from the drawings. The scintillators are also shorter which is now properly implemented. Material scan for the old inner hcal:
![old_inner_hcal](https://user-images.githubusercontent.com/7316141/31000402-4a657fd0-a4a9-11e7-9a35-8f72b5fae34b.png)
new inner hcal:
![new_inner_hcal](https://user-images.githubusercontent.com/7316141/31000424-63b582b4-a4a9-11e7-8c9c-0c24fa8916b0.png)
shows a reduction of the interaction length by about 20%. The material scan for the old outer hcal
![old_outer_hcal](https://user-images.githubusercontent.com/7316141/31000470-ba04d03e-a4a9-11e7-9e1f-0150cc4faa29.png)
and the new outer hcal:
![new_outer_hcal](https://user-images.githubusercontent.com/7316141/31000482-c351dca4-a4a9-11e7-9f98-13db70a7cebc.png)
shows negligent differences

