### PR TITLE
Hcal tilt angle default set to engineering drawings

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -747,6 +747,8 @@ void PHG4InnerHcalDetector::SetTiltViaNcross()
   int ncross = params->get_int_param("ncross");
   if (!ncross || isfinite(tilt_angle))
   {
+    // flag ncrossing as not used
+    params->set_int_param("ncross",0);
     return;
   }
   if ((isfinite(tilt_angle)) && (verbosity > 0))

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -152,10 +152,13 @@ void PHG4InnerHcalSubsystem::SetDefaultParameters()
   set_default_double_param("scinti_tile_thickness", 0.7);
   set_default_double_param("size_z", 175.94 * 2);
   set_default_double_param("steplimits", NAN);
-  set_default_double_param("tilt_angle", NAN);  // default is 4 crossinge, angle is calculated from this
+  set_default_double_param("tilt_angle", 36.15);  // engineering drawing
+// corresponds very closely to 4 crossinge (35.5497 deg)
 
   set_default_int_param("light_scint_model", 1);
-  set_default_int_param("ncross", 4);
+// if ncross is set (and tilt_angle is NAN) tilt_angle is calculated 
+// from number of crossings
+  set_default_int_param("ncross", 0); 
   set_default_int_param(PHG4HcalDefs::n_towers, 64);
   set_default_int_param(PHG4HcalDefs::scipertwr, 4);
   set_default_int_param(PHG4HcalDefs::n_scinti_tiles, 12);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -845,6 +845,8 @@ void PHG4OuterHcalDetector::SetTiltViaNcross()
   int ncross = params->get_int_param("ncross");
   if (!ncross || isfinite(tilt_angle))
   {
+// mark ncross parameter as not used
+    params->set_int_param("ncross",0);
     return;
   }
   if ((isfinite(tilt_angle)) && (verbosity > 0))

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -172,11 +172,15 @@ PHG4OuterHcalSubsystem::SetDefaultParameters()
   set_default_double_param("scinti_tile_thickness", 0.7);
   set_default_double_param("size_z", 304.91 * 2);
   set_default_double_param("steplimits", NAN);
-  set_default_double_param("tilt_angle", NAN); // default is 5 crossings
+  set_default_double_param("tilt_angle", -11.23); // engineering drawing
+// corresponds very closely to 4 crossinge (-11.7826 deg)
 
   set_default_int_param("light_scint_model", 1);
   set_default_int_param("magnet_cutout_first_scinti", 8); // tile start at 0, drawing tile starts at 1
-  set_default_int_param("ncross", -4);
+
+// if ncross is set (and tilt_angle is NAN) tilt_angle is calculated 
+// from number of crossings
+  set_default_int_param("ncross", 0);
   set_default_int_param("n_towers", 64);
   set_default_int_param(PHG4HcalDefs::scipertwr, 5);
   set_default_int_param("n_scinti_tiles", 12);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -176,7 +176,7 @@ PHG4OuterHcalSubsystem::SetDefaultParameters()
 
   set_default_int_param("light_scint_model", 1);
   set_default_int_param("magnet_cutout_first_scinti", 8); // tile start at 0, drawing tile starts at 1
-  set_default_int_param("ncross", -5);
+  set_default_int_param("ncross", -4);
   set_default_int_param("n_towers", 64);
   set_default_int_param(PHG4HcalDefs::scipertwr, 5);
   set_default_int_param("n_scinti_tiles", 12);


### PR DESCRIPTION
I switched the default from 4 crossings (not 5 for the outer hcal - sorry about that) to the tilt angle from the engineering drawings. The differences are minute (the vertical line is a geantino, the yellow dots show the points where it enters a new volume):
outer hcal with 4 crossings (-11.7826 deg):
![outer_hcal_4cross](https://user-images.githubusercontent.com/7316141/31032566-7c087502-a52a-11e7-9c73-6dd622daa9cc.png)
outer hcal using -11.23 deg from drawings:
![outer_hcal_engineering](https://user-images.githubusercontent.com/7316141/31032589-96ee9c16-a52a-11e7-8301-3b15f620e0bb.png)
inner hcal with 4 crossings (35.5497 deg):
![inner_hcal_4cross](https://user-images.githubusercontent.com/7316141/31032620-b4b69b22-a52a-11e7-9923-ce68c7f8152d.png)
inner hcal using 36.15 deg from drawings:
![inner_hcal_engineering](https://user-images.githubusercontent.com/7316141/31032635-c250d338-a52a-11e7-9084-4a9f8ddbed8e.png)



