### PR TITLE
Hcal scintillator size fine adjustment

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -148,7 +148,10 @@ void PHG4InnerHcalSubsystem::SetDefaultParameters()
   set_default_double_param("scinti_gap_neighbor", 0.1);
   set_default_double_param("scinti_inner_gap", 0.85);
   set_default_double_param("scinti_outer_gap", 1.22 * (5.0 / 4.0));
-  set_default_double_param("scinti_outer_radius", 133.3);
+// some math issue in the code subtracts 0.4mm so the scintillator
+// does not end at 133.09 as per drawing but at 133.05
+// adding 0.4mm compensates for this (so 133.13 gives the desired 133.09
+  set_default_double_param("scinti_outer_radius", 133.13);
   set_default_double_param("scinti_tile_thickness", 0.7);
   set_default_double_param("size_z", 175.94 * 2);
   set_default_double_param("steplimits", NAN);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -168,7 +168,10 @@ PHG4OuterHcalSubsystem::SetDefaultParameters()
   set_default_double_param("scinti_gap", 0.85);
   set_default_double_param("scinti_gap_neighbor", 0.1);
   set_default_double_param("scinti_inner_radius",183.89);
-  set_default_double_param("scinti_outer_radius",263.27);
+// some math issue in the code subtracts 0.1mm+ so the scintillator
+// does not end at 263.27 as per drawing but at 263.26
+// adding 0.125mm compensates for this (so 263.2825 gives the desired 263.27
+  set_default_double_param("scinti_outer_radius",263.2825);
   set_default_double_param("scinti_tile_thickness", 0.7);
   set_default_double_param("size_z", 304.91 * 2);
   set_default_double_param("steplimits", NAN);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -155,8 +155,15 @@ PHG4OuterHcalSubsystem::SetDefaultParameters()
   set_default_double_param("light_balance_inner_radius", NAN);
   set_default_double_param("light_balance_outer_corr", NAN);
   set_default_double_param("light_balance_outer_radius", NAN);
-  set_default_double_param("magnet_cutout_radius", 195.31);
-  set_default_double_param("magnet_cutout_scinti_radius", 195.96);
+// some math issue in the code does not subtract the magnet cutout correctly
+// (maybe some factor of 2 in a G4 volume creation)
+// The engineering drawing values are:
+//  set_default_double_param("magnet_cutout_radius", 195.31);
+//  set_default_double_param("magnet_cutout_scinti_radius", 195.96);
+// seting this to these values results in the correct edges
+// (verified by looking at the G4 hit coordinates of the inner edges)
+  set_default_double_param("magnet_cutout_radius", 195.72);
+  set_default_double_param("magnet_cutout_scinti_radius",  197.04);
   set_default_double_param("outer_radius", 264.71);
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);

--- a/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
@@ -2,8 +2,8 @@
 
 #include <g4detectors/PHG4Parameters.h>
 
-#include <g4main/PHG4Utils.h>
 #include <g4main/PHG4ColorDefs.h>
+#include <g4main/PHG4Utils.h>
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
@@ -31,26 +31,8 @@ PHG4TPCDetector::PHG4TPCDetector(PHCompositeNode *Node, PHG4Parameters *paramete
   , g4userlimits(nullptr)
   , active(params->get_int_param("active"))
   , absorberactive(params->get_int_param("absorberactive"))
-  , inner_cage_radius(params->get_double_param("gas_inner_radius")*cm
-		      -params->get_double_param("cage_layer_9_thickness")*cm
-		      -params->get_double_param("cage_layer_8_thickness")*cm
-		      -params->get_double_param("cage_layer_7_thickness")*cm
-		      -params->get_double_param("cage_layer_6_thickness")*cm
-		      -params->get_double_param("cage_layer_5_thickness")*cm
-		      -params->get_double_param("cage_layer_4_thickness")*cm
-		      -params->get_double_param("cage_layer_3_thickness")*cm
-		      -params->get_double_param("cage_layer_2_thickness")*cm
-		      -params->get_double_param("cage_layer_1_thickness")*cm)
-  ,outer_cage_radius(params->get_double_param("gas_outer_radius")*cm
-		      +params->get_double_param("cage_layer_9_thickness")*cm
-		      +params->get_double_param("cage_layer_8_thickness")*cm
-		      +params->get_double_param("cage_layer_7_thickness")*cm
-		      +params->get_double_param("cage_layer_6_thickness")*cm
-		      +params->get_double_param("cage_layer_5_thickness")*cm
-		      +params->get_double_param("cage_layer_4_thickness")*cm
-		      +params->get_double_param("cage_layer_3_thickness")*cm
-		      +params->get_double_param("cage_layer_2_thickness")*cm
-		      +params->get_double_param("cage_layer_1_thickness")*cm)
+  , inner_cage_radius(params->get_double_param("gas_inner_radius") * cm - params->get_double_param("cage_layer_9_thickness") * cm - params->get_double_param("cage_layer_8_thickness") * cm - params->get_double_param("cage_layer_7_thickness") * cm - params->get_double_param("cage_layer_6_thickness") * cm - params->get_double_param("cage_layer_5_thickness") * cm - params->get_double_param("cage_layer_4_thickness") * cm - params->get_double_param("cage_layer_3_thickness") * cm - params->get_double_param("cage_layer_2_thickness") * cm - params->get_double_param("cage_layer_1_thickness") * cm)
+  , outer_cage_radius(params->get_double_param("gas_outer_radius") * cm + params->get_double_param("cage_layer_9_thickness") * cm + params->get_double_param("cage_layer_8_thickness") * cm + params->get_double_param("cage_layer_7_thickness") * cm + params->get_double_param("cage_layer_6_thickness") * cm + params->get_double_param("cage_layer_5_thickness") * cm + params->get_double_param("cage_layer_4_thickness") * cm + params->get_double_param("cage_layer_3_thickness") * cm + params->get_double_param("cage_layer_2_thickness") * cm + params->get_double_param("cage_layer_1_thickness") * cm)
 
 {
 }
@@ -79,17 +61,17 @@ int PHG4TPCDetector::IsInTPC(G4VPhysicalVolume *volume) const
 //_______________________________________________________________
 void PHG4TPCDetector::Construct(G4LogicalVolume *logicWorld)
 {
-// create TPC envelope
-// tpc consists of (from inside to gas volume, outside is reversed up to now)
-// 1st layer cu
-// 2nd layer FR4
-// 3rd layer HoneyComb
-// 4th layer cu
-// 5th layer FR4
-// 6th layer Kapton
-// 7th layer cu
-// 8th layer Kapton
-// 9th layer cu
+  // create TPC envelope
+  // tpc consists of (from inside to gas volume, outside is reversed up to now)
+  // 1st layer cu
+  // 2nd layer FR4
+  // 3rd layer HoneyComb
+  // 4th layer cu
+  // 5th layer FR4
+  // 6th layer Kapton
+  // 7th layer cu
+  // 8th layer Kapton
+  // 9th layer cu
 
   double steplimits = params->get_double_param("steplimits") * cm;
   if (isfinite(steplimits))
@@ -97,13 +79,12 @@ void PHG4TPCDetector::Construct(G4LogicalVolume *logicWorld)
     g4userlimits = new G4UserLimits(steplimits);
   }
 
-  G4VSolid* tpc_envelope = new G4Tubs("tpc_envelope",inner_cage_radius,outer_cage_radius,params->get_double_param("tpc_length")*cm/2.,0.,2*M_PI);
-
+  G4VSolid *tpc_envelope = new G4Tubs("tpc_envelope", inner_cage_radius, outer_cage_radius, params->get_double_param("tpc_length") * cm / 2., 0., 2 * M_PI);
 
   G4LogicalVolume *tpc_envelope_logic = new G4LogicalVolume(tpc_envelope,
-							    G4Material::GetMaterial("G4_AIR"),
-							    "tpc_envelope");
-  G4VisAttributes* visatt = new G4VisAttributes();
+                                                            G4Material::GetMaterial("G4_AIR"),
+                                                            "tpc_envelope");
+  G4VisAttributes *visatt = new G4VisAttributes();
   visatt->SetVisibility(false);
   tpc_envelope_logic->SetVisAttributes(visatt);
 
@@ -113,128 +94,125 @@ void PHG4TPCDetector::Construct(G4LogicalVolume *logicWorld)
   new G4PVPlacement(0, G4ThreeVector(params->get_double_param("place_x") * cm,
                                      params->get_double_param("place_y") * cm,
                                      params->get_double_param("place_z") * cm),
-                    tpc_envelope_logic,"tpc_envelope",
+                    tpc_envelope_logic, "tpc_envelope",
                     logicWorld, 0, false, overlapcheck);
 }
 
-int
-PHG4TPCDetector::ConstructTPCGasVolume(G4LogicalVolume *tpc_envelope)
+int PHG4TPCDetector::ConstructTPCGasVolume(G4LogicalVolume *tpc_envelope)
 {
-  G4VSolid* tpc_gas = new G4Tubs("tpc_gas",params->get_double_param("gas_inner_radius")*cm,params->get_double_param("gas_outer_radius")*cm,params->get_double_param("tpc_length")*cm/2.,0.,2*M_PI);
+  G4VSolid *tpc_gas = new G4Tubs("tpc_gas", params->get_double_param("gas_inner_radius") * cm, params->get_double_param("gas_outer_radius") * cm, params->get_double_param("tpc_length") * cm / 2., 0., 2 * M_PI);
   G4LogicalVolume *tpc_gas_logic = new G4LogicalVolume(tpc_gas,
-						       G4Material::GetMaterial(params->get_string_param("tpc_gas")),
-						       "tpc_gas");
+                                                       G4Material::GetMaterial(params->get_string_param("tpc_gas")),
+                                                       "tpc_gas");
 
   tpc_gas_logic->SetUserLimits(g4userlimits);
-  G4VisAttributes* visatt = new G4VisAttributes();
+  G4VisAttributes *visatt = new G4VisAttributes();
   visatt->SetVisibility(true);
   visatt->SetForceSolid(true);
   visatt->SetColor(PHG4TPCColorDefs::tpc_gas_color);
   tpc_gas_logic->SetVisAttributes(visatt);
-  G4VPhysicalVolume *tpc_gas_phys = new G4PVPlacement(0, G4ThreeVector(0,0,0),
-						      tpc_gas_logic,"tpc_gas",
-						      tpc_envelope, 0, false, overlapcheck);
+  G4VPhysicalVolume *tpc_gas_phys = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
+                                                      tpc_gas_logic, "tpc_gas",
+                                                      tpc_envelope, 0, false, overlapcheck);
 
   activevols.insert(tpc_gas_phys);
   return 0;
 }
 
-int
-PHG4TPCDetector::ConstructTPCCageVolume(G4LogicalVolume *tpc_envelope)
+int PHG4TPCDetector::ConstructTPCCageVolume(G4LogicalVolume *tpc_envelope)
 {
-// 8th layer cu
-// 9th layer FR4
-// 10th layer HoneyComb
-// 11th layer FR4
-// 12th layer Kapton
-// 13th layer FR4
+  // 8th layer cu
+  // 9th layer FR4
+  // 10th layer HoneyComb
+  // 11th layer FR4
+  // 12th layer Kapton
+  // 13th layer FR4
   static const int nlayers = 9;
-  static const double thickness[nlayers] =  {params->get_double_param("cage_layer_1_thickness")*cm,
-					     params->get_double_param("cage_layer_2_thickness")*cm,
-					     params->get_double_param("cage_layer_3_thickness")*cm,
-					     params->get_double_param("cage_layer_4_thickness")*cm,
-					     params->get_double_param("cage_layer_5_thickness")*cm,
-					     params->get_double_param("cage_layer_6_thickness")*cm,
-					     params->get_double_param("cage_layer_7_thickness")*cm,
-					     params->get_double_param("cage_layer_8_thickness")*cm,
-					     params->get_double_param("cage_layer_9_thickness")*cm};
+  static const double thickness[nlayers] = {params->get_double_param("cage_layer_1_thickness") * cm,
+                                            params->get_double_param("cage_layer_2_thickness") * cm,
+                                            params->get_double_param("cage_layer_3_thickness") * cm,
+                                            params->get_double_param("cage_layer_4_thickness") * cm,
+                                            params->get_double_param("cage_layer_5_thickness") * cm,
+                                            params->get_double_param("cage_layer_6_thickness") * cm,
+                                            params->get_double_param("cage_layer_7_thickness") * cm,
+                                            params->get_double_param("cage_layer_8_thickness") * cm,
+                                            params->get_double_param("cage_layer_9_thickness") * cm};
 
   static const string material[nlayers] = {params->get_string_param("cage_layer_1_material"),
-					   params->get_string_param("cage_layer_2_material"),
-					   params->get_string_param("cage_layer_3_material"),
-					   params->get_string_param("cage_layer_4_material"),
-					   params->get_string_param("cage_layer_5_material"),
-					   params->get_string_param("cage_layer_6_material"),
-					   params->get_string_param("cage_layer_7_material"),
-					   params->get_string_param("cage_layer_8_material"),
-					   params->get_string_param("cage_layer_9_material")};
+                                           params->get_string_param("cage_layer_2_material"),
+                                           params->get_string_param("cage_layer_3_material"),
+                                           params->get_string_param("cage_layer_4_material"),
+                                           params->get_string_param("cage_layer_5_material"),
+                                           params->get_string_param("cage_layer_6_material"),
+                                           params->get_string_param("cage_layer_7_material"),
+                                           params->get_string_param("cage_layer_8_material"),
+                                           params->get_string_param("cage_layer_9_material")};
 
   static const G4Colour color[nlayers] = {PHG4TPCColorDefs::tpc_cu_color,
                                           PHG4TPCColorDefs::tpc_pcb_color,
-					  PHG4TPCColorDefs::tpc_honeycomb_color,
-					  PHG4TPCColorDefs::tpc_cu_color,
+                                          PHG4TPCColorDefs::tpc_honeycomb_color,
+                                          PHG4TPCColorDefs::tpc_cu_color,
                                           PHG4TPCColorDefs::tpc_pcb_color,
-					  PHG4TPCColorDefs::tpc_kapton_color,
-					  PHG4TPCColorDefs::tpc_cu_color,
-					  PHG4TPCColorDefs::tpc_kapton_color,
-					  PHG4TPCColorDefs::tpc_cu_color};
+                                          PHG4TPCColorDefs::tpc_kapton_color,
+                                          PHG4TPCColorDefs::tpc_cu_color,
+                                          PHG4TPCColorDefs::tpc_kapton_color,
+                                          PHG4TPCColorDefs::tpc_cu_color};
   double tpc_cage_radius = inner_cage_radius;
   ostringstream name;
-  for (int i=0; i<nlayers; i++)
+  for (int i = 0; i < nlayers; i++)
   {
     name.str("");
-    int layerno = i+1;
+    int layerno = i + 1;
     name << "tpc_cage_layer_" << layerno;
-    G4VSolid* tpc_cage_layer = new G4Tubs(name.str().c_str(),tpc_cage_radius,tpc_cage_radius+thickness[i],params->get_double_param("tpc_length")*cm/2.,0.,2*M_PI);
+    G4VSolid *tpc_cage_layer = new G4Tubs(name.str().c_str(), tpc_cage_radius, tpc_cage_radius + thickness[i], params->get_double_param("tpc_length") * cm / 2., 0., 2 * M_PI);
     G4LogicalVolume *tpc_cage_layer_logic = new G4LogicalVolume(tpc_cage_layer,
-								G4Material::GetMaterial(material[i]),
-								name.str());
-    G4VisAttributes* visatt = new G4VisAttributes();
+                                                                G4Material::GetMaterial(material[i]),
+                                                                name.str());
+    G4VisAttributes *visatt = new G4VisAttributes();
     visatt->SetVisibility(true);
     visatt->SetForceSolid(true);
     visatt->SetColor(color[i]);
     tpc_cage_layer_logic->SetVisAttributes(visatt);
-    G4VPhysicalVolume *tpc_cage_layer_phys = new G4PVPlacement(0, G4ThreeVector(0,0,0),
-							       tpc_cage_layer_logic,name.str(),
-							       tpc_envelope, 0, false, overlapcheck);
+    G4VPhysicalVolume *tpc_cage_layer_phys = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
+                                                               tpc_cage_layer_logic, name.str(),
+                                                               tpc_envelope, 0, false, overlapcheck);
     absorbervols[tpc_cage_layer_phys] = layerno;
     tpc_cage_radius += thickness[i];
   }
-// outer cage
+  // outer cage
   tpc_cage_radius = outer_cage_radius;
-  for (int i=0; i<nlayers; i++)
+  for (int i = 0; i < nlayers; i++)
   {
     tpc_cage_radius -= thickness[i];
     name.str("");
-    int layerno = 10+1+i; // so the accompanying inner layer is layer - 10
+    int layerno = 10 + 1 + i;  // so the accompanying inner layer is layer - 10
     name << "tpc_cage_layer_" << layerno;
-    G4VSolid* tpc_cage_layer = new G4Tubs(name.str().c_str(),tpc_cage_radius,tpc_cage_radius+thickness[i],params->get_double_param("tpc_length")*cm/2.,0.,2*M_PI);
+    G4VSolid *tpc_cage_layer = new G4Tubs(name.str().c_str(), tpc_cage_radius, tpc_cage_radius + thickness[i], params->get_double_param("tpc_length") * cm / 2., 0., 2 * M_PI);
     G4LogicalVolume *tpc_cage_layer_logic = new G4LogicalVolume(tpc_cage_layer,
-								G4Material::GetMaterial(material[i]),
-								name.str().c_str());
-    G4VisAttributes* visatt = new G4VisAttributes();
+                                                                G4Material::GetMaterial(material[i]),
+                                                                name.str().c_str());
+    G4VisAttributes *visatt = new G4VisAttributes();
     visatt->SetVisibility(true);
     visatt->SetForceSolid(true);
     visatt->SetColor(color[i]);
     tpc_cage_layer_logic->SetVisAttributes(visatt);
-    G4VPhysicalVolume *tpc_cage_layer_phys = new G4PVPlacement(0, G4ThreeVector(0,0,0),
-							       tpc_cage_layer_logic,name.str(),
-							       tpc_envelope, 0, false, overlapcheck);
+    G4VPhysicalVolume *tpc_cage_layer_phys = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
+                                                               tpc_cage_layer_logic, name.str(),
+                                                               tpc_envelope, 0, false, overlapcheck);
     absorbervols[tpc_cage_layer_phys] = layerno;
   }
 
   return 0;
 }
 
-int
-PHG4TPCDetector::DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix *rotm )
+int PHG4TPCDetector::DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm)
 {
   static int i = 0;
-  G4LogicalVolume* checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), "DISPLAYLOGICAL", 0, 0, 0);
-  G4VisAttributes* visattchk = new G4VisAttributes();
+  G4LogicalVolume *checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), "DISPLAYLOGICAL", 0, 0, 0);
+  G4VisAttributes *visattchk = new G4VisAttributes();
   visattchk->SetVisibility(true);
   visattchk->SetForceSolid(false);
-  switch(i)
+  switch (i)
   {
   case 0:
     visattchk->SetColour(G4Colour::Red());

--- a/simulation/g4simulation/g4tpc/PHG4TPCDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCDetector.h
@@ -33,9 +33,8 @@ class PHG4TPCDetector : public PHG4Detector
   int IsInTPC(G4VPhysicalVolume *) const;
   void SuperDetector(const std::string &name) { superdetector = name; }
   const std::string SuperDetector() const { return superdetector; }
-
  private:
-  int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix *rotm );
+  int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm);
   int ConstructTPCGasVolume(G4LogicalVolume *tpc_envelope);
   int ConstructTPCCageVolume(G4LogicalVolume *tpc_envelope);
   PHG4Parameters *params;

--- a/simulation/g4simulation/g4tpc/PHG4TPCSteppingAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCSteppingAction.cc
@@ -92,7 +92,7 @@ bool PHG4TPCSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
   int layer_id = 0;
   if (whichactive < 0)  // support structures
   {
-    layer_id = fabs(whichactive); // we want a positive layer id
+    layer_id = fabs(whichactive);  // we want a positive layer id
   }
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
@@ -123,25 +123,25 @@ bool PHG4TPCSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
   //       cout << "track id " << aTrack->GetTrackID() << endl;
   //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
   //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
-  if ((use_g4_steps > 0 && whichactive>0) || 
-      prepointstatus == fGeomBoundary || 
+  if ((use_g4_steps > 0 && whichactive > 0) ||
+      prepointstatus == fGeomBoundary ||
       prepointstatus == fUndefined ||
       (prepointstatus == fPostStepDoItProc && savepoststepstatus == fGeomBoundary))
   {
-// this is for debugging weird occurances we have occasionally
+    // this is for debugging weird occurances we have occasionally
     if (prepointstatus == fPostStepDoItProc && savepoststepstatus == fGeomBoundary)
     {
       cout << GetName() << ": New Hit for  " << endl;
       cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-	   << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-	   << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
-	   << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
+           << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
       cout << "last track: " << savetrackid
-	   << ", current trackid: " << aTrack->GetTrackID() << endl;
+           << ", current trackid: " << aTrack->GetTrackID() << endl;
       cout << "phys pre vol: " << volume->GetName()
-	   << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+           << " post vol : " << touchpost->GetVolume()->GetName() << endl;
       cout << " previous phys pre vol: " << savevolpre->GetName()
-	   << " previous phys post vol: " << savevolpost->GetName() << endl;
+           << " previous phys post vol: " << savevolpost->GetName() << endl;
     }
     // if previous hit was saved, hit pointer was set to nullptr
     // and we have to make a new one
@@ -163,7 +163,7 @@ bool PHG4TPCSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     hit->set_edep(0);
     if (whichactive > 0)  // return of IsInTPCDetector, > 0 hit in tpc gas volume, < 0 hit in support structures
     {
-      hit->set_eion(0);  
+      hit->set_eion(0);
       // Now save the container we want to add this hit to
       savehitcontainer = hits_;
     }
@@ -175,9 +175,9 @@ bool PHG4TPCSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     {
       if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
       {
-	hit->set_trkid(pp->GetUserTrackId());
-	hit->set_shower_id(pp->GetShower()->get_id());
-	saveshower = pp->GetShower();
+        hit->set_trkid(pp->GetUserTrackId());
+        hit->set_shower_id(pp->GetShower()->get_id());
+        saveshower = pp->GetShower();
       }
     }
     // some sanity checks for inconsistencies
@@ -186,15 +186,15 @@ bool PHG4TPCSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     {
       cout << GetName() << ": hit was not created" << endl;
       cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-	   << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-	   << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
-	   << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
+           << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
       cout << "last track: " << savetrackid
-	   << ", current trackid: " << aTrack->GetTrackID() << endl;
+           << ", current trackid: " << aTrack->GetTrackID() << endl;
       cout << "phys pre vol: " << volume->GetName()
-	   << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+           << " post vol : " << touchpost->GetVolume()->GetName() << endl;
       cout << " previous phys pre vol: " << savevolpre->GetName()
-	   << " previous phys post vol: " << savevolpost->GetName() << endl;
+           << " previous phys post vol: " << savevolpost->GetName() << endl;
       exit(1);
     }
     // check if track id matches the initial one when the hit was created
@@ -202,10 +202,10 @@ bool PHG4TPCSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     {
       cout << GetName() << ": hits do not belong to the same track" << endl;
       cout << "saved track: " << savetrackid
-	   << ", current trackid: " << aTrack->GetTrackID()
-	   << ", prestep status: " << prePoint->GetStepStatus()
-	   << ", previous post step status: " << savepoststepstatus
-	   << endl;
+           << ", current trackid: " << aTrack->GetTrackID()
+           << ", prestep status: " << prePoint->GetStepStatus()
+           << ", previous post step status: " << savepoststepstatus
+           << endl;
 
       exit(1);
     }
@@ -233,17 +233,17 @@ bool PHG4TPCSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
       if (whichactive > 0)
       {
-	hit->set_eion(-1);
-      } 
-   }
+        hit->set_eion(-1);
+      }
+    }
     if (edep > 0)
     {
       if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {
-	if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
-	{
-	  pp->SetKeep(1);  // we want to keep the track
-	}
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
       }
     }
 
@@ -256,29 +256,29 @@ bool PHG4TPCSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     // aTrack->GetTrackStatus() == fStopAndKill is also set)
     // aTrack->GetTrackStatus() == fStopAndKill: track ends
     if ((use_g4_steps > 0 && whichactive > 0) ||
-	postPoint->GetStepStatus() == fGeomBoundary ||
-	postPoint->GetStepStatus() == fWorldBoundary ||
-	postPoint->GetStepStatus() == fAtRestDoItProc ||
-	aTrack->GetTrackStatus() == fStopAndKill)
+        postPoint->GetStepStatus() == fGeomBoundary ||
+        postPoint->GetStepStatus() == fWorldBoundary ||
+        postPoint->GetStepStatus() == fAtRestDoItProc ||
+        aTrack->GetTrackStatus() == fStopAndKill)
     {
       // save only hits with energy deposit (or -1 for geantino)
       if (hit->get_edep())
       {
-	savehitcontainer->AddHit(layer_id, hit);
-	if (saveshower)
-	{
-	  saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
-	}
-	// ownership has been transferred to container, set to null
-	// so we will create a new hit for the next track
-	hit = nullptr;
+        savehitcontainer->AddHit(layer_id, hit);
+        if (saveshower)
+        {
+          saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
+        }
+        // ownership has been transferred to container, set to null
+        // so we will create a new hit for the next track
+        hit = nullptr;
       }
       else
       {
-	// if this hit has no energy deposit, just reset it for reuse
-	// this means we have to delete it in the dtor. If this was
-	// the last hit we processed the memory is still allocated
-	hit->Reset();
+        // if this hit has no energy deposit, just reset it for reuse
+        // this means we have to delete it in the dtor. If this was
+        // the last hit we processed the memory is still allocated
+        hit->Reset();
       }
     }
     // return true to indicate the hit was used

--- a/simulation/g4simulation/g4tpc/PHG4TPCSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCSubsystem.cc
@@ -20,20 +20,19 @@
 using namespace std;
 
 //_______________________________________________________________________
-PHG4TPCSubsystem::PHG4TPCSubsystem( const std::string &name, const int lyr ):
-  PHG4DetectorSubsystem( name, lyr ),
-  detector_(nullptr),
-  steppingAction_( nullptr )
+PHG4TPCSubsystem::PHG4TPCSubsystem(const std::string &name, const int lyr)
+  : PHG4DetectorSubsystem(name, lyr)
+  , detector_(nullptr)
+  , steppingAction_(nullptr)
 {
   InitializeParameters();
 }
 
 //_______________________________________________________________________
-int 
-PHG4TPCSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
+int PHG4TPCSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
-  PHNodeIterator iter( topNode );
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
   detector_ = new PHG4TPCDetector(topNode, GetParams(), Name());
@@ -41,148 +40,141 @@ PHG4TPCSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
   detector_->OverlapCheck(CheckOverlap());
   set<string> nodes;
   if (GetParams()->get_int_param("active"))
+  {
+    PHNodeIterator dstIter(dstNode);
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", SuperDetector()));
+    if (!DetNode)
     {
-      PHNodeIterator dstIter( dstNode );
-      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstIter.findFirst("PHCompositeNode",SuperDetector()));
-      if (! DetNode)
-	{
-          DetNode = new PHCompositeNode(SuperDetector());
-          dstNode->addNode(DetNode);
-        }
+      DetNode = new PHCompositeNode(SuperDetector());
+      dstNode->addNode(DetNode);
+    }
 
-      ostringstream nodename;
+    ostringstream nodename;
+    if (SuperDetector() != "NONE")
+    {
+      nodename << "G4HIT_" << SuperDetector();
+    }
+    else
+    {
+      nodename << "G4HIT_" << Name();
+    }
+    nodes.insert(nodename.str());
+    if (GetParams()->get_int_param("absorberactive"))
+    {
+      nodename.str("");
       if (SuperDetector() != "NONE")
-	{
-	  nodename <<  "G4HIT_" << SuperDetector();
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << SuperDetector();
+      }
       else
-	{
-	  nodename <<  "G4HIT_" << Name();
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << Name();
+      }
       nodes.insert(nodename.str());
-      if (GetParams()->get_int_param("absorberactive"))
-	{
-	  nodename.str("");
-	  if (SuperDetector() != "NONE")
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << SuperDetector();
-	    }
-	  else
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << Name();
-	    }
-          nodes.insert(nodename.str());
-	}
-      BOOST_FOREACH(string node, nodes)
-	{
-	  PHG4HitContainer* g4_hits =  findNode::getClass<PHG4HitContainer>( topNode , node.c_str());
-	  if ( !g4_hits )
-	    {
-	      g4_hits = new PHG4HitContainer(node);
-              DetNode->addNode( new PHIODataNode<PHObject>( g4_hits, node.c_str(), "PHObject" ));
-	    }
-	}
+    }
+    BOOST_FOREACH (string node, nodes)
+    {
+      PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, node.c_str());
+      if (!g4_hits)
+      {
+        g4_hits = new PHG4HitContainer(node);
+        DetNode->addNode(new PHIODataNode<PHObject>(g4_hits, node.c_str(), "PHObject"));
+      }
+    }
 
-      // create stepping action
+    // create stepping action
+    steppingAction_ = new PHG4TPCSteppingAction(detector_, GetParams());
+  }
+  else
+  {
+    // if this is a black hole it does not have to be active
+    if (GetParams()->get_int_param("blackhole"))
+    {
       steppingAction_ = new PHG4TPCSteppingAction(detector_, GetParams());
     }
-  else
-    {
-      // if this is a black hole it does not have to be active
-      if (GetParams()->get_int_param("blackhole"))
-	{
-	  steppingAction_ = new PHG4TPCSteppingAction(detector_, GetParams());
-	}
-    }
+  }
   return 0;
-
 }
 
 //_______________________________________________________________________
-int
-PHG4TPCSubsystem::process_event( PHCompositeNode * topNode )
+int PHG4TPCSubsystem::process_event(PHCompositeNode *topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
   if (steppingAction_)
-    {
-      steppingAction_->SetInterfacePointers( topNode );
-    }
+  {
+    steppingAction_->SetInterfacePointers(topNode);
+  }
   return 0;
 }
 
-
-void
-PHG4TPCSubsystem::Print(const string &what) const
+void PHG4TPCSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
   GetParams()->Print();
   if (detector_)
-    {
-      detector_->Print(what);
-    }
+  {
+    detector_->Print(what);
+  }
   if (steppingAction_)
-    {
-      steppingAction_->Print(what);
-    }
+  {
+    steppingAction_->Print(what);
+  }
 
   return;
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4TPCSubsystem::GetDetector( void ) const
+PHG4Detector *PHG4TPCSubsystem::GetDetector(void) const
 {
   return detector_;
 }
 
-void
-PHG4TPCSubsystem::SetDefaultParameters()
+void PHG4TPCSubsystem::SetDefaultParameters()
 {
-  set_default_double_param("gas_inner_radius",21.);
-  set_default_double_param("gas_outer_radius",77.);
+  set_default_double_param("gas_inner_radius", 21.);
+  set_default_double_param("gas_outer_radius", 77.);
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);
   set_default_double_param("place_z", 0.);
   set_default_double_param("rot_x", 0.);
   set_default_double_param("rot_y", 0.);
   set_default_double_param("rot_z", 0.);
-  set_default_double_param("tpc_length",211.);
+  set_default_double_param("tpc_length", 211.);
 
   set_default_double_param("steplimits", NAN);
 
   set_default_string_param("tpc_gas", "sPHENIX_TPC_Gas");
 
-// material budget:
-// Cu (all layers): 0.5 oz cu per square foot, 1oz == 0.0347mm --> 0.5 oz ==  0.00347cm/2. 
-// Kapton insulation 18 layers of * 5mil = 18*0.0127=0.2286
-// 250 um FR4 (Substrate for Cu layers)
-// HoneyComb (nomex) 1/2 inch=0.5*2.54 cm
-  set_default_string_param("cage_layer_1_material","G4_Cu");
-  set_default_double_param("cage_layer_1_thickness",0.00347/2.);
+  // material budget:
+  // Cu (all layers): 0.5 oz cu per square foot, 1oz == 0.0347mm --> 0.5 oz ==  0.00347cm/2.
+  // Kapton insulation 18 layers of * 5mil = 18*0.0127=0.2286
+  // 250 um FR4 (Substrate for Cu layers)
+  // HoneyComb (nomex) 1/2 inch=0.5*2.54 cm
+  set_default_string_param("cage_layer_1_material", "G4_Cu");
+  set_default_double_param("cage_layer_1_thickness", 0.00347 / 2.);
 
-  set_default_string_param("cage_layer_2_material","FR4");
-  set_default_double_param("cage_layer_2_thickness",0.025);
+  set_default_string_param("cage_layer_2_material", "FR4");
+  set_default_double_param("cage_layer_2_thickness", 0.025);
 
-  set_default_string_param("cage_layer_3_material","NOMEX");
-  set_default_double_param("cage_layer_3_thickness",0.5*2.54);
+  set_default_string_param("cage_layer_3_material", "NOMEX");
+  set_default_double_param("cage_layer_3_thickness", 0.5 * 2.54);
 
-  set_default_string_param("cage_layer_4_material","G4_Cu");
-  set_default_double_param("cage_layer_4_thickness",0.00347/2.);
+  set_default_string_param("cage_layer_4_material", "G4_Cu");
+  set_default_double_param("cage_layer_4_thickness", 0.00347 / 2.);
 
-  set_default_string_param("cage_layer_5_material","FR4");
-  set_default_double_param("cage_layer_5_thickness",0.025);
+  set_default_string_param("cage_layer_5_material", "FR4");
+  set_default_double_param("cage_layer_5_thickness", 0.025);
 
-  set_default_string_param("cage_layer_6_material","G4_KAPTON");
-  set_default_double_param("cage_layer_6_thickness",0.2286);
+  set_default_string_param("cage_layer_6_material", "G4_KAPTON");
+  set_default_double_param("cage_layer_6_thickness", 0.2286);
 
-  set_default_string_param("cage_layer_7_material","G4_Cu");
-  set_default_double_param("cage_layer_7_thickness",0.00347/2.);
+  set_default_string_param("cage_layer_7_material", "G4_Cu");
+  set_default_double_param("cage_layer_7_thickness", 0.00347 / 2.);
 
-  set_default_string_param("cage_layer_8_material","G4_KAPTON");
-  set_default_double_param("cage_layer_8_thickness",0.05); // 50 um
+  set_default_string_param("cage_layer_8_material", "G4_KAPTON");
+  set_default_double_param("cage_layer_8_thickness", 0.05);  // 50 um
 
-  set_default_string_param("cage_layer_9_material","G4_Cu");
-  set_default_double_param("cage_layer_9_thickness",0.00347/2.);
+  set_default_string_param("cage_layer_9_material", "G4_Cu");
+  set_default_double_param("cage_layer_9_thickness", 0.00347 / 2.);
 }
-
-

--- a/simulation/g4simulation/g4tpc/PHG4TPCSubsystem.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCSubsystem.h
@@ -11,17 +11,16 @@ class PHG4TPCDetector;
 class PHG4Parameters;
 class PHG4TPCSteppingAction;
 
-class PHG4TPCSubsystem: public PHG4DetectorSubsystem
+class PHG4TPCSubsystem : public PHG4DetectorSubsystem
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4TPCSubsystem( const std::string &name = "TPC", const int layer = 0 );
+  PHG4TPCSubsystem(const std::string &name = "TPC", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4TPCSubsystem( void )
-  {}
+  virtual ~PHG4TPCSubsystem(void)
+  {
+  }
 
   /*!
   creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
@@ -41,20 +40,18 @@ class PHG4TPCSubsystem: public PHG4DetectorSubsystem
   void Print(const std::string &what = "ALL") const;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector( void ) const;
-  PHG4SteppingAction* GetSteppingAction( void ) const {return steppingAction_;}
-
-  private:
-
+  PHG4Detector *GetDetector(void) const;
+  PHG4SteppingAction *GetSteppingAction(void) const { return steppingAction_; }
+ private:
   void SetDefaultParameters();
 
   //! detector geometry
   /*! derives from PHG4Detector */
-  PHG4TPCDetector* detector_;
+  PHG4TPCDetector *detector_;
 
   //! detector "stepping" action, executes after every G4 step
   /*! derives from PHG4SteppingAction */
-  PHG4SteppingAction* steppingAction_;
+  PHG4SteppingAction *steppingAction_;
 
   //! detector event action executes before/after every event
   /*! derives from PHG4EventAction */


### PR DESCRIPTION
A scan with geantinos showed that the scintillator for the inner hcal is too short (typo in scintillator radius). But even after fixing this it is too short by by 0.4mm. For the outer hcal it is 0.1mm. It doesn't really matter but while I was at it I might as well fix this by tweaking the scintillator radius. There must be somewhere a small math issue in the geometry code. Here are the entry and exit hit distributions for scintillators and absorbers. Inner hcal before this patch:
![inner_hcal_edges](https://user-images.githubusercontent.com/7316141/31098848-0a540b3c-a792-11e7-98f2-3185c7ed915b.png)
after:
![inner_hcal_edges_new](https://user-images.githubusercontent.com/7316141/31098886-299f1d6a-a792-11e7-9c82-b855043a7e30.png)
Outer hcal before:
![outer_hcal_edge](https://user-images.githubusercontent.com/7316141/31098941-5db94fc6-a792-11e7-8a38-7f838b23cdc9.png)
after:
![outer_hcal_edge_new](https://user-images.githubusercontent.com/7316141/31098953-63677a10-a792-11e7-806c-c098addbbf4b.png)



