### PR TITLE
Allow inserting block dividers in EMCal active volume

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
@@ -95,6 +95,8 @@ PHG4CylinderGeom_Spacalv3::SetDefault()
   sidewall_outer_torr = 0.030000;
   sidewall_mat = "SS310";
   max_phi_bin_in_sec = 8;
+  divider_mat = "G4_AIR";
+  divider_width = 13.5;
 }
 
 void
@@ -110,6 +112,10 @@ PHG4CylinderGeom_Spacalv3::ImportParameters(const PHG4Parameters & param)
     sidewall_mat = param.get_string_param("sidewall_mat");
   if (param.exist_int_param("max_phi_bin_in_sec"))
     max_phi_bin_in_sec = param.get_int_param("max_phi_bin_in_sec");
+  if (param.exist_string_param("divider_mat"))
+    divider_mat = param.get_string_param("divider_mat");
+  if (param.exist_double_param("divider_width"))
+    divider_width = param.get_double_param("divider_width");
 
   // load sector_tower_map
   if (param.exist_int_param("sector_tower_map_size"))

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
@@ -96,7 +96,7 @@ PHG4CylinderGeom_Spacalv3::SetDefault()
   sidewall_mat = "SS310";
   max_phi_bin_in_sec = 8;
   divider_mat = "G4_AIR";
-  divider_width = 13.5;
+  divider_width = 14.5;
 }
 
 void

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
@@ -10,18 +10,17 @@
 #ifndef PHG4CylinderGeom_Spacalv3_H__
 #define PHG4CylinderGeom_Spacalv3_H__
 
-#include "PHG4CylinderGeom_Spacalv2.h"
-#include <string>
 #include <map>
-#include <utility>      // std::pair, std::make_pair
+#include <string>
+#include <utility>  // std::pair, std::make_pair
+#include "PHG4CylinderGeom_Spacalv2.h"
 
 class PHG4CylinderGeom_Spacalv3 : public PHG4CylinderGeom_Spacalv2
 {
-public:
+ public:
   PHG4CylinderGeom_Spacalv3();
 
-  virtual
-  ~PHG4CylinderGeom_Spacalv3()
+  virtual ~PHG4CylinderGeom_Spacalv3()
   {
   }
 
@@ -34,7 +33,7 @@ public:
 
   //! load parameters from PHG4Parameters, which interface to Database/XML/ROOT files
   virtual void
-  ImportParameters(const PHG4Parameters & param);
+  ImportParameters(const PHG4Parameters& param);
 
   double
   get_sidewall_outer_torr() const
@@ -72,8 +71,7 @@ public:
     sidewall_mat = absorberMat;
   }
 
-  int
-  get_max_phi_bin_in_sec() const
+  int get_max_phi_bin_in_sec() const
   {
     return max_phi_bin_in_sec;
   }
@@ -84,13 +82,31 @@ public:
     max_phi_bin_in_sec = maxPhiBinInSec;
   }
 
+  const std::string& get_divider_mat() const
+  {
+    return divider_mat;
+  }
+
+  void set_divider_mat(const std::string& dividerMat)
+  {
+    divider_mat = dividerMat;
+  }
+
+  double get_divider_width() const
+  {
+    return divider_width;
+  }
+
+  void set_divider_width(double dividerWidth)
+  {
+    divider_width = dividerWidth;
+  }
 
   class geom_tower
   {
-  public:
+   public:
     geom_tower();
-    virtual
-    ~geom_tower()
+    virtual ~geom_tower()
     {
     }
 
@@ -142,7 +158,6 @@ public:
     double
     get_position_fraction_y_in_sub_tower(int fiber_id) const;
 
-
     //! height of light guide
     double LightguideHeight;
     //! edge length ratio, narrow / wide
@@ -155,11 +170,10 @@ public:
 
     //! read via PHG4Parameters
     void
-    ImportParameters(const PHG4Parameters & param,
-        const std::string & param_prefix);
+    ImportParameters(const PHG4Parameters& param,
+                     const std::string& param_prefix);
 
-  ClassDef(PHG4CylinderGeom_Spacalv3::geom_tower,3)
-
+    ClassDef(PHG4CylinderGeom_Spacalv3::geom_tower, 3)
   };
   typedef std::map<int, geom_tower> tower_map_t;
 
@@ -172,7 +186,7 @@ public:
   void
   load_demo_sector_tower_map4();
 
-  const tower_map_t &
+  const tower_map_t&
   get_sector_tower_map() const
   {
     return sector_tower_map;
@@ -180,47 +194,45 @@ public:
 
   //! get approximate radial position of tower
   double
-  get_tower_radial_position(const geom_tower & tower) const;
+  get_tower_radial_position(const geom_tower& tower) const;
 
   //! check that all towers has consistent sub-tower divider
   void
   subtower_consistency_check() const;
   //! sub-tower divider along the polar direction
-  int
-  get_n_subtower_eta() const;
+  int get_n_subtower_eta() const;
   //! sub-tower divider along the azimuthal direction
-  int
-  get_n_subtower_phi() const;
+  int get_n_subtower_phi() const;
   //! max tolerance needed for the light guide
   double
   get_max_lightguide_height() const;
 
-//
-//  void
-//  set_geom_super_tower_map(geom_super_tower_map_t geomSuperTowerMap)
-//  {
-//    geom_super_tower_map = geomSuperTowerMap;
-//  }
+  //
+  //  void
+  //  set_geom_super_tower_map(geom_super_tower_map_t geomSuperTowerMap)
+  //  {
+  //    geom_super_tower_map = geomSuperTowerMap;
+  //  }
 
-//! compact ID of each fiber in 32bit PHG4Hit::set_scint_id(). Buffer the result for repeated use.
+  //! compact ID of each fiber in 32bit PHG4Hit::set_scint_id(). Buffer the result for repeated use.
   class scint_id_coder
   {
-
-  public:
-
+   public:
     explicit scint_id_coder(int scint_id);
     scint_id_coder(int sector_id, int tower_id, int fiber_id);
-    virtual
-    ~scint_id_coder()
+    virtual ~scint_id_coder()
     {
     }
 
     virtual void
     identify(std::ostream& os = std::cout) const
     {
-      os << "scint_id_coder with " << "scint_ID(" << scint_ID << ") = "
-          << "sector_ID(" << sector_ID << "), " << "tower_ID(" << tower_ID
-          << "), " << "fiber_ID(" << fiber_ID << ")" << std::endl;
+      os << "scint_id_coder with "
+         << "scint_ID(" << scint_ID << ") = "
+         << "sector_ID(" << sector_ID << "), "
+         << "tower_ID(" << tower_ID
+         << "), "
+         << "fiber_ID(" << fiber_ID << ")" << std::endl;
     }
 
     int scint_ID;
@@ -228,11 +240,11 @@ public:
     int tower_ID;
     int fiber_ID;
 
-    static const int kfiber_bit = 13; // max 8192 fiber per tower
-    static const int ktower_bit = 11; // max 2048 towers per sector
-    static const int ksector_bit = 8; // max 256 sectors
+    static const int kfiber_bit = 13;  // max 8192 fiber per tower
+    static const int ktower_bit = 11;  // max 2048 towers per sector
+    static const int ksector_bit = 8;  // max 256 sectors
 
-  ClassDef(PHG4CylinderGeom_Spacalv3::scint_id_coder,1)
+    ClassDef(PHG4CylinderGeom_Spacalv3::scint_id_coder, 1)
   };
 
   //! convert tower_ID + sector ID to eta and z bins as in other cylindrical calorimeters
@@ -240,7 +252,7 @@ public:
   virtual std::pair<int, int>
   get_tower_z_phi_ID(const int tower_ID, const int sector_ID) const;
 
-protected:
+ protected:
   double sidewall_thickness;
   double sidewall_outer_torr;
   std::string sidewall_mat;
@@ -248,8 +260,12 @@ protected:
 
   tower_map_t sector_tower_map;
 
-ClassDef(PHG4CylinderGeom_Spacalv3,3)
+  //! wdith along the approximate radial direction
+  double divider_width;
+  //! material for divider
+  std::string divider_mat;
 
+  ClassDef(PHG4CylinderGeom_Spacalv3, 4)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -155,30 +155,66 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
     G4double angle;
     G4double projection_center_y;
     G4double projection_center_x;
+    G4double projection_length;
   };
   vector<block_azimuth_geom> block_azimuth_geoms(phi_bin_in_sec,
-                                                 block_azimuth_geom{numeric_limits<double>::signaling_NaN(), numeric_limits<double>::signaling_NaN(), numeric_limits<double>::signaling_NaN()});  // [phi-bin in sector] -> azimuth geometry
+                                                 block_azimuth_geom{
+                                                     numeric_limits<double>::signaling_NaN(),
+                                                     numeric_limits<double>::signaling_NaN(),
+                                                     numeric_limits<double>::signaling_NaN(),
+                                                     numeric_limits<double>::signaling_NaN()});  // [phi-bin in sector] -> azimuth geometry
   G4double block_x_edge1 = block_edge1_half_width;
   for (int s = 0; s < phi_bin_in_sec; ++s)
   {
-    const G4double angle = block_azimuth_angle * (0.5 + s) + edge1_tilt_angle;
-    const G4double block_x_size = block_half_height_width / cos(angle);
+    block_azimuth_geom& geom = block_azimuth_geoms[s];
+
+    geom.angle = block_azimuth_angle * (0.5 + s) + edge1_tilt_angle;
+    const G4double block_x_size = block_half_height_width / cos(geom.angle);
     assert(block_x_size > 0);
     const G4double x_center = block_x_edge1 - 0.5 * block_x_size;
 
     // projection center per block
-    const G4double projection_length = block_half_height_width / 2. / tan(block_azimuth_angle / 2.);
-    assert(projection_length > 0);
-    const G4double projection_center_y = enclosure_center - projection_length * cos(angle);
-    const G4double projection_center_x = x_center + projection_length * sin(angle);
-
-    //save
-    block_azimuth_geom geom{angle, projection_center_y, projection_center_x};
-    block_azimuth_geoms.at(s) = geom;
+    geom.projection_length = block_half_height_width / 2. / tan(block_azimuth_angle / 2.);
+    assert(geom.projection_length > 0);
+    geom.projection_center_y = enclosure_center - geom.projection_length * cos(geom.angle);
+    geom.projection_center_x = x_center + geom.projection_length * sin(geom.angle);
 
     // next step
     block_x_edge1 -= block_x_size;
   }
+
+  //write out the azimuthal block divider's geometry
+  struct block_divider_azimuth_geom
+  {
+    G4double angle;  //! rotation angle
+    G4double projection_center_y;
+    G4double projection_center_x;
+    G4double thickness;            // thickness in the approximate azimuth direction
+    G4double radial_displacement;  //! displacement along the width direction, which is the radial direction if tilt = 0
+    G4double width;                //! wdith along the approximate radial direction
+  };
+  assert(phi_bin_in_sec >= 1);
+  vector<block_divider_azimuth_geom> divider_azimuth_geoms(phi_bin_in_sec - 1,
+                                                           block_divider_azimuth_geom{
+                                                               numeric_limits<double>::signaling_NaN(),
+                                                               numeric_limits<double>::signaling_NaN(),
+                                                               numeric_limits<double>::signaling_NaN(),
+                                                               numeric_limits<double>::signaling_NaN(),
+                                                               numeric_limits<double>::signaling_NaN(),
+                                                               numeric_limits<double>::signaling_NaN()});
+  for (int s = 0; s < phi_bin_in_sec - 1; ++s)
+  {
+    block_divider_azimuth_geom& geom = divider_azimuth_geoms[s];
+
+    geom.angle = 0.5 * (block_azimuth_geoms[s].angle + block_azimuth_geoms[s + 1].angle);
+    geom.projection_center_y = 0.5 * (block_azimuth_geoms[s].projection_center_y + block_azimuth_geoms[s + 1].projection_center_y);
+    geom.projection_center_x = 0.5 * (block_azimuth_geoms[s].projection_center_x + block_azimuth_geoms[s + 1].projection_center_x);
+    geom.radial_displacement = 0.5 * (block_azimuth_geoms[s].projection_length + block_azimuth_geoms[s + 1].projection_length);
+
+    geom.thickness = 2.0 * get_geom_v3()->get_assembly_spacing() * cm * cos(block_azimuth_angle / 2.) - 2 * um;
+    geom.width = get_geom_v3()->get_divider_width() * cm;
+  }
+
   if (fabs(block_x_edge1 - (-block_edge2_half_width)) > get_geom_v3()->get_assembly_spacing() * cm)
   {
     cout << "PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg - ERROR - " << endl
@@ -207,6 +243,15 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
       cout << "\t block[" << s << "].angle = " << block_azimuth_geoms[s].angle << endl;
       cout << "\t block[" << s << "].projection_center_y = " << block_azimuth_geoms[s].projection_center_y << endl;
       cout << "\t block[" << s << "].projection_center_x = " << block_azimuth_geoms[s].projection_center_x << endl;
+    }
+    for (int s = 0; s < phi_bin_in_sec - 1; ++s)
+    {
+      cout << "\t divider[" << s << "].angle = " << divider_azimuth_geoms[s].angle << endl;
+      cout << "\t divider[" << s << "].projection_center_x = " << divider_azimuth_geoms[s].projection_center_x << endl;
+      cout << "\t divider[" << s << "].projection_center_y = " << divider_azimuth_geoms[s].projection_center_y << endl;
+      cout << "\t divider[" << s << "].radial_displacement = " << divider_azimuth_geoms[s].radial_displacement << endl;
+      cout << "\t divider[" << s << "].thickness = " << divider_azimuth_geoms[s].thickness << endl;
+      cout << "\t divider[" << s << "].width = " << divider_azimuth_geoms[s].width << endl;
     }
   }
 
@@ -369,6 +414,53 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
       assert(gdml_config);
       gdml_config->exclude_physical_vol(wall_phys);
     }
+  }
+
+  // construct dividers
+  if (get_geom_v3()->get_divider_width() > 0)
+  {
+    if (get_geom_v3()->get_construction_verbose() >= 1)
+    {
+      cout << "PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg::" << GetName()
+           << " - construct dividers" << endl;
+    }
+
+    G4Material* divider_mat = G4Material::GetMaterial(get_geom_v3()->get_divider_mat());
+    assert(divider_mat);
+
+    int ID = 0;
+    for (const auto& geom : divider_azimuth_geoms)
+    {
+      G4Box* wall_solid = new G4Box(G4String(GetName() + G4String("_Divider_") + to_string(ID)),
+                                    geom.thickness / 2.0,
+                                    geom.width / 2.,
+                                    (get_geom_v3()->get_length() / 2. - 2 * (get_geom_v3()->get_sidewall_thickness() + 2. * get_geom_v3()->get_assembly_spacing())) * cm * .5);
+
+      G4LogicalVolume* wall_logic = new G4LogicalVolume(wall_solid, wall_mat,
+                                                        G4String(G4String(GetName() + G4String("_Divider_") + to_string(ID))), 0, 0,
+                                                        nullptr);
+      wall_logic->SetVisAttributes(wall_VisAtt);
+
+      for (int sign_z = -1; sign_z <= 1; sign_z += 2)
+      {
+        G4Transform3D wall_trans =
+            G4TranslateX3D(geom.projection_center_x) *
+            G4TranslateY3D(geom.projection_center_y) *
+            G4RotateZ3D(geom.angle) *
+            G4TranslateY3D(geom.radial_displacement) *
+            G4TranslateZ3D(sign_z * (get_geom_v3()->get_length() * cm / 4));
+
+        G4PVPlacement* wall_phys = new G4PVPlacement(wall_trans, wall_logic,
+                                                     G4String(GetName().c_str()) + G4String("_Divider_") + to_string(ID), sec_logic,
+                                                     false, ID, overlapcheck);
+
+        calo_vol[wall_phys] = ID;
+        assert(gdml_config);
+        gdml_config->exclude_physical_vol(wall_phys);
+
+        ++ID;
+      }
+    }  //    for (const auto & geom : divider_azimuth_geoms)
   }
 
   //  // construct towers

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -433,7 +433,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
     assert(divider_mat);
 
     G4VisAttributes* divider_VisAtt = new G4VisAttributes();
-    divider_VisAtt->SetColor(.7, .7, .7, .3);
+    divider_VisAtt->SetColor(.7, 1, .7, .1);
     divider_VisAtt->SetVisibility(get_geom_v3()->is_azimuthal_seg_visible());
     divider_VisAtt->SetForceSolid(true);
 
@@ -448,7 +448,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
       G4LogicalVolume* wall_logic = new G4LogicalVolume(wall_solid, wall_mat,
                                                         G4String(G4String(GetName() + G4String("_Divider_") + to_string(ID))), 0, 0,
                                                         nullptr);
-      wall_logic->SetVisAttributes(wall_VisAtt);
+      wall_logic->SetVisAttributes(divider_VisAtt);
 
       for (int sign_z = -1; sign_z <= 1; sign_z += 2)
       {

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -202,17 +202,21 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
                                                                numeric_limits<double>::signaling_NaN(),
                                                                numeric_limits<double>::signaling_NaN(),
                                                                numeric_limits<double>::signaling_NaN()});
-  for (int s = 0; s < phi_bin_in_sec - 1; ++s)
+
+  if (get_geom_v3()->get_sidewall_thickness() > 0)
   {
-    block_divider_azimuth_geom& geom = divider_azimuth_geoms[s];
+    for (int s = 0; s < phi_bin_in_sec - 1; ++s)
+    {
+      block_divider_azimuth_geom& geom = divider_azimuth_geoms[s];
 
-    geom.angle = 0.5 * (block_azimuth_geoms[s].angle + block_azimuth_geoms[s + 1].angle);
-    geom.projection_center_y = 0.5 * (block_azimuth_geoms[s].projection_center_y + block_azimuth_geoms[s + 1].projection_center_y);
-    geom.projection_center_x = 0.5 * (block_azimuth_geoms[s].projection_center_x + block_azimuth_geoms[s + 1].projection_center_x);
-    geom.radial_displacement = 0.5 * (block_azimuth_geoms[s].projection_length + block_azimuth_geoms[s + 1].projection_length);
+      geom.angle = 0.5 * (block_azimuth_geoms[s].angle + block_azimuth_geoms[s + 1].angle);
+      geom.projection_center_y = 0.5 * (block_azimuth_geoms[s].projection_center_y + block_azimuth_geoms[s + 1].projection_center_y);
+      geom.projection_center_x = 0.5 * (block_azimuth_geoms[s].projection_center_x + block_azimuth_geoms[s + 1].projection_center_x);
+      geom.radial_displacement = 0.5 * (block_azimuth_geoms[s].projection_length + block_azimuth_geoms[s + 1].projection_length);
 
-    geom.thickness = 2.0 * get_geom_v3()->get_assembly_spacing() * cm * cos(block_azimuth_angle / 2.) - 2 * um;
-    geom.width = get_geom_v3()->get_divider_width() * cm;
+      geom.thickness = 2.0 * get_geom_v3()->get_assembly_spacing() * cm * cos(block_azimuth_angle / 2.) - 2 * um;
+      geom.width = get_geom_v3()->get_divider_width() * cm;
+    }
   }
 
   if (fabs(block_x_edge1 - (-block_edge2_half_width)) > get_geom_v3()->get_assembly_spacing() * cm)
@@ -427,6 +431,11 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
 
     G4Material* divider_mat = G4Material::GetMaterial(get_geom_v3()->get_divider_mat());
     assert(divider_mat);
+
+    G4VisAttributes* divider_VisAtt = new G4VisAttributes();
+    divider_VisAtt->SetColor(.7, .7, .7, .3);
+    divider_VisAtt->SetVisibility(get_geom_v3()->is_azimuthal_seg_visible());
+    divider_VisAtt->SetForceSolid(true);
 
     int ID = 0;
     for (const auto& geom : divider_azimuth_geoms)

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -433,7 +433,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
     assert(divider_mat);
 
     G4VisAttributes* divider_VisAtt = new G4VisAttributes();
-    divider_VisAtt->SetColor(.7, 1, .7, .1);
+    divider_VisAtt->SetColor(.8, 1, .8, .3);
     divider_VisAtt->SetVisibility(get_geom_v3()->is_azimuthal_seg_visible());
     divider_VisAtt->SetForceSolid(true);
 

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -174,5 +174,9 @@ void PHG4SpacalSubsystem::SetDefaultParameters()
   set_default_int_param("azimuthal_seg_visible", 0.);
   set_default_int_param("virualize_fiber", 0.);
   set_default_int_param("config", static_cast<int>(PHG4CylinderGeom_Spacalv1::kNonProjective));
+
+  set_default_double_param("divider_width", 13.5); // radial size of the divider between blocks
+  set_default_string_param("divider_mat", "G4_AIR"); // materials of the divider. G4_AIR is equivalent to not installing one in the term of material distribution
+
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -175,7 +175,7 @@ void PHG4SpacalSubsystem::SetDefaultParameters()
   set_default_int_param("virualize_fiber", 0.);
   set_default_int_param("config", static_cast<int>(PHG4CylinderGeom_Spacalv1::kNonProjective));
 
-  set_default_double_param("divider_width", 13.5); // radial size of the divider between blocks
+  set_default_double_param("divider_width", 14.5); // radial size of the divider between blocks
   set_default_string_param("divider_mat", "G4_AIR"); // materials of the divider. G4_AIR is equivalent to not installing one in the term of material distribution
 
   return;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -175,7 +175,7 @@ void PHG4SpacalSubsystem::SetDefaultParameters()
   set_default_int_param("virualize_fiber", 0.);
   set_default_int_param("config", static_cast<int>(PHG4CylinderGeom_Spacalv1::kNonProjective));
 
-  set_default_double_param("divider_width", 14.5); // radial size of the divider between blocks
+  set_default_double_param("divider_width", 0); // radial size of the divider between blocks. <=0 means no dividers
   set_default_string_param("divider_mat", "G4_AIR"); // materials of the divider. G4_AIR is equivalent to not installing one in the term of material distribution
 
   return;


### PR DESCRIPTION
During the EMCal meeting ( https://indico.bnl.gov/conferenceDisplay.py?confId=3577 ) , we need to answer a design decision regarding whether to place block dividers in EMCal active volume to assist assembly. If so, what would be the optimal material: Stainless steel or carbon/glass fiber type of materials. 

This pull request allow us to perform simulation to reach a conclusion quantitatively.  The default behavior is no block divider which is the setting for the current reference design. 

Similar to the engineering design, 15 mil divider space is inserted into between EMCal block rows: 
* User can turn ON/OFF via macro by setting parameter ```divider_width``` to a positive value. Suggested width is 14.5 cm. Default is OFF with width of 0 cm, until the EMCal group finalize the decision on the divider.
* The material choice of the divider can be set in macro too: via parameter ```divider_mat```
 
An example macro of enabling simulating a FR4 glass fiber divider is as following:
```c++
    cemc = new PHG4SpacalSubsystem("CEMC", ilayer);

    //......

    cemc->UseCalibFiles(PHG4DetectorSubsystem::xml);
    cemc->SetCalibrationFileDir(string(getenv("CALIBRATIONROOT")) + string("/CEMC/Geometry_2017ProjTilted/"));
    cemc->set_double_param("radius", radius);            // overwrite minimal radius
    cemc->set_double_param("thickness", cemcthickness);  // overwrite thickness

//    cemc->set_double_param("divider_width", 0);  // turn off divider
    cemc->set_double_param("divider_width", 14.5);  // overwrite thickness
//    cemc->set_string_param("divider_mat", "G4_AIR");  // Effectively no divider
//    cemc->set_string_param("divider_mat", "SS310");  // Possible dense material
    cemc->set_string_param("divider_mat", "FR4");  // Possible light material
    
// ....
```

## QA checks

Since this only introduce 15mil extra material between 2x2 blocks in the azimuthal direction, the change in bulk response is negligible. Checked with electron with pT = 16 GeV in full acceptance:

### Steel divider vs air divider (effectively no divider)
![image](https://user-images.githubusercontent.com/7947083/31285672-f850c75e-aa89-11e7-9c66-2fcbc8bdde93.png)
![image](https://user-images.githubusercontent.com/7947083/31285663-f253c392-aa89-11e7-9938-1c0a6c356cb1.png)


### Nylon divider (gemerioc) vs air divider (effectively no divider)
![image](https://user-images.githubusercontent.com/7947083/31285756-28a0427c-aa8a-11e7-83c6-08af71b4aca0.png)
![image](https://user-images.githubusercontent.com/7947083/31285769-2eb41044-aa8a-11e7-93b7-92ec3bd275f0.png)


## Request of follow up studies

Request @jdosbo to perform check of phi-boundary response with 5 GeV electron/positron and 20 GeV photons.  We can compare no divider, FR4 fiber glass divider and SS310 steel divider


