### PR TITLE
Add minimum leading particle z to trigger

### DIFF
--- a/generators/PHPythia8/PHPy8JetTrigger.h
+++ b/generators/PHPythia8/PHPy8JetTrigger.h
@@ -22,6 +22,7 @@ class PHPy8JetTrigger : public PHPy8GenTrigger {
   void SetEtaHighLow(double etaHigh, double etaLow);
   void SetMinJetPt(double minPt);
   void SetJetR(double R);
+  void SetMinLeadingZ(double minZ);
 
   void PrintConfig();
 
@@ -29,7 +30,8 @@ class PHPy8JetTrigger : public PHPy8GenTrigger {
 
   double _theEtaHigh;
   double _theEtaLow;
-  double _minPt; 
+  double _minPt;
+  double _minZ; 
   double _R; 
 
 };


### PR DESCRIPTION
Add the ability to select the minimum Z of the leading particle in a jet. Very useful for generating an enhanced sample of high-Z jets for study. 