### PR TITLE
Tower Energy Cut and Tower Energy Scale prior to Jet Finder

### DIFF
--- a/simulation/g4simulation/g4jets/TowerJetInput.h
+++ b/simulation/g4simulation/g4jets/TowerJetInput.h
@@ -12,7 +12,7 @@ class TowerJetInput : public JetInput {
   
 public:
 
-  TowerJetInput(Jet::SRC input);
+  TowerJetInput(Jet::SRC input, double ecut, double towerscale);
   virtual ~TowerJetInput() {}
 
   void identify(std::ostream& os = std::cout);
@@ -24,6 +24,8 @@ public:
 private:
   int _verbosity;
   Jet::SRC _input;
+  double _ecut;
+  double _towerscale;
 };
 
 #endif


### PR DESCRIPTION
Tower Energy Cut (default=0MeV) and Tower Energy Scale (default=1 for CEMC, 1.49 for IHCAL and OHCAL) are added. Values can be modified in macros/macros/g4simulations/G4_Jets.C. More study will be followed up, but currently, it is still useful to have constant values. (presentation at Jet Topical Meeting: https://indico.bnl.gov/getFile.py/access?contribId=3&resId=0&materialId=slides&confId=3749)