### PR TITLE
Use an explicit definition of primary in the truth information

### DIFF
--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <limits>
 #include <cstdlib>
 
 using namespace std;
@@ -304,4 +305,35 @@ bool
 PHG4TruthInfoContainer::is_primary(const PHG4Particle* p) const
 {
   return (p->get_track_id() > 0);
+}
+
+int PHG4TruthInfoContainer::GetPrimaryVertexIndex() const
+{
+  ConstVtxRange vrange = GetPrimaryVtxRange();
+
+  int highest_embedding_ID = numeric_limits<int>::min();
+  int vtx_id_for_highest_embedding_ID = 0;
+
+  for (auto iter = vrange.first; iter != vrange.second; ++iter)
+  {
+    //    cout <<"PHG4TruthInfoContainer::GetPrimaryVertexIndex - vertex ID "<<iter->first<<" embedding ID "<< g4truth->isEmbededVtx(iter->first) <<": "
+    //         ; iter->second->identify();
+    const int embedding_ID = isEmbededVtx(iter->first);
+
+    if (embedding_ID > highest_embedding_ID)
+    {
+      highest_embedding_ID = embedding_ID;
+      vtx_id_for_highest_embedding_ID = iter->first;
+    }
+  }
+
+  if (highest_embedding_ID == numeric_limits<int>::min())
+  {
+    cout << "PHG4TruthInfoContainer::GetPrimaryVertexIndex - "
+         << "WARNING: no valid primary vertex. Return an invalid ID of 0"
+         << endl;
+    return 0;
+  }
+
+  return vtx_id_for_highest_embedding_ID;
 }

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -124,8 +124,9 @@ public:
   int maxvtxindex() const;
   int minvtxindex() const;
 
-  // returns the first primary vertex that was processed by Geant4
-  int GetPrimaryVertexIndex() {return (vtxmap.lower_bound(1))->first;}
+  //! Return ID of the truth primary vertex with highest embedding ID.
+  //! For vertex with identical embedding ID, return first one simulated in Geant4.
+  int GetPrimaryVertexIndex() const;
 
   //! Retrieve the embedding ID for the HepMC subevent or track to be analyzed.
   //! positive ID is the embedded event of interest, e.g. jetty event from pythia


### PR DESCRIPTION
Thanks @adfrawley for checking #364 , which showed low overall tracking efficiency for the pile up simulations. This problem was traced to a pile up vertex would be used as the primary vertex in the truth container, and thereafter used as source of the vertex seed during the pattern recognition stage. 

In the current code base, ```PHG4TruthInfoContainer::GetPrimaryVertexIndex()``` depends on the order of tracks simulated by Geant4. This pull request introduce an explicit definition that ```PHG4TruthInfoContainer::GetPrimaryVertexIndex()``` return the primary vertex with highest embedding ID which is usually used for the signal sub-event. 

Small scale test showed reasonable tracking efficiency with multiple Au+Au pile up simulations. Further test welcomed. 