### PR TITLE
Tag hits in SPACAL support structure for debug purpose

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -367,10 +367,10 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
 
     typedef map<int, pair<int, int> > sign_t;
     sign_t signs;
-    signs[2000] = make_pair(+1, +1);
-    signs[2001] = make_pair(+1, -1);
-    signs[2100] = make_pair(-1, +1);
-    signs[2101] = make_pair(-1, -1);
+    signs[0100] = make_pair(+1, +1);
+    signs[0101] = make_pair(+1, -1);
+    signs[0200] = make_pair(-1, +1);
+    signs[0201] = make_pair(-1, -1);
 
     BOOST_FOREACH (sign_t::value_type& val, signs)
     {
@@ -437,7 +437,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
     divider_VisAtt->SetVisibility(get_geom_v3()->is_azimuthal_seg_visible());
     divider_VisAtt->SetForceSolid(true);
 
-    int ID = 0;
+    int ID = 0300;
     for (const auto& geom : divider_azimuth_geoms)
     {
       G4Box* wall_solid = new G4Box(G4String(GetName() + G4String("_Divider_") + to_string(ID)),

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -332,10 +332,10 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
 
     typedef map<int, double> z_locations_t;
     z_locations_t z_locations;
-    z_locations[0000] = get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm;
-    z_locations[0001] = get_geom_v3()->get_length() * cm / 2.0 - (get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm);
-    z_locations[0100] = -(get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm);
-    z_locations[0101] = -(get_geom_v3()->get_length() * cm / 2.0 - (get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm));
+    z_locations[000] = get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm;
+    z_locations[001] = get_geom_v3()->get_length() * cm / 2.0 - (get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm);
+    z_locations[100] = -(get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm);
+    z_locations[101] = -(get_geom_v3()->get_length() * cm / 2.0 - (get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm));
 
     BOOST_FOREACH (z_locations_t::value_type& val, z_locations)
     {
@@ -367,10 +367,10 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
 
     typedef map<int, pair<int, int> > sign_t;
     sign_t signs;
-    signs[0100] = make_pair(+1, +1);
-    signs[0101] = make_pair(+1, -1);
-    signs[0200] = make_pair(-1, +1);
-    signs[0201] = make_pair(-1, -1);
+    signs[100] = make_pair(+1, +1);
+    signs[101] = make_pair(+1, -1);
+    signs[200] = make_pair(-1, +1);
+    signs[201] = make_pair(-1, -1);
 
     BOOST_FOREACH (sign_t::value_type& val, signs)
     {
@@ -437,7 +437,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
     divider_VisAtt->SetVisibility(get_geom_v3()->is_azimuthal_seg_visible());
     divider_VisAtt->SetForceSolid(true);
 
-    int ID = 0300;
+    int ID = 300;
     for (const auto& geom : divider_azimuth_geoms)
     {
       G4Box* wall_solid = new G4Box(G4String(GetName() + G4String("_Divider_") + to_string(ID)),
@@ -466,6 +466,11 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
         calo_vol[wall_phys] = ID;
         assert(gdml_config);
         gdml_config->exclude_physical_vol(wall_phys);
+
+        if (Verbosity())
+        {
+          cout <<"PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg - placing divider "<<wall_phys->GetName() <<" copy ID "<<ID<<endl;
+        }
 
         ++ID;
       }

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -332,10 +332,10 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
 
     typedef map<int, double> z_locations_t;
     z_locations_t z_locations;
-    z_locations[1000] = get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm;
-    z_locations[1001] = get_geom_v3()->get_length() * cm / 2.0 - (get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm);
-    z_locations[1100] = -(get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm);
-    z_locations[1101] = -(get_geom_v3()->get_length() * cm / 2.0 - (get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm));
+    z_locations[0000] = get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm;
+    z_locations[0001] = get_geom_v3()->get_length() * cm / 2.0 - (get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm);
+    z_locations[0100] = -(get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm);
+    z_locations[0101] = -(get_geom_v3()->get_length() * cm / 2.0 - (get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm));
 
     BOOST_FOREACH (z_locations_t::value_type& val, z_locations)
     {

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
@@ -115,6 +115,15 @@ bool PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         sector_ID = prePoint->GetTouchable()->GetReplicaNumber(1);
       }
 
+      else if (isactive == PHG4SpacalDetector::SUPPORT)
+      {
+        tower_ID = prePoint->GetTouchable()->GetReplicaNumber(0);
+        sector_ID = prePoint->GetTouchable()->GetReplicaNumber(1);
+        fiber_ID =  (1 << (PHG4CylinderGeom_Spacalv3::scint_id_coder::kfiber_bit)) - 1; // use max fiber ID to flag for support strucrtures.
+
+//        cout <<"PHG4SpacalSteppingAction::UserSteppingAction - SUPPORT tower_ID = "<<tower_ID<<endl;
+      }
+
       // compact the tower/sector/fiber ID into 32 bit scint_id, so we could save some space for SPACAL hits
       scint_id = PHG4CylinderGeom_Spacalv3::scint_id_coder(sector_ID, tower_ID, fiber_ID).scint_ID;
     }


### PR DESCRIPTION
Thanks @jdosbo for studying the effect of SPACAL block divider  with https://github.com/sPHENIX-Collaboration/coresoftware/pull/365 . During this process, we found it necessary to explicitly check the shower energy deposition in the divider to ensure the simulation is properly setup. This pull request would allow us to do it. 

For hits on the dividers, the divider ID is encoded in the  ```scint_id``` variable of the result ```PHG4Hit``` on the ```DST/G4HIT_ABSORBER_CEMC``` node. Here is how to read it out interactively:

1. enable ```do_DSTReader = true``` in ```Fun4All_G4_sPHENIX.C```
2. open the result DST reader TTree: ```root G4sPHENIX.root_DSTReader.root```
3. Then interactively on ROOT command line, we can check the hits on the divider: 
```c++
 // whether a hit is on the divider
T->SetAlias("isOnDivider","(( G4HIT_ABSORBER_CEMC.scint_id / (2^13)  ) & ((1<<11)-1))>=300 && (( G4HIT_ABSORBER_CEMC.scint_id / (2^13)  ) & ((1<<11)-1))<310");

// spacial distribution of the hits on divider, which should be tilted slots
T->Draw("G4HIT_ABSORBER_CEMC.x:G4HIT_ABSORBER_CEMC.y","isOnDivider");

// energy deposition in the divider per event. It should be small (10-s of MeV) on average events
T->Scan("Sum$(G4HIT_ABSORBER_CEMC.edep * isOnDivider)");
```


