### PR TITLE
Revive Fun4AllHepMCOutputManager

### DIFF
--- a/generators/phhepmc/Fun4AllHepMCOutputManager.h
+++ b/generators/phhepmc/Fun4AllHepMCOutputManager.h
@@ -32,6 +32,18 @@ class Fun4AllHepMCOutputManager: public Fun4AllOutputManager
 
   int AddComment(const std::string &text);
 
+  //! embedding ID for the sub-event to be output
+  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
+  //! negative IDs are backgrounds, .e.g out of time pile up collisions
+  //! Usually, ID = 0 means the primary Au+Au collision background
+  int get_embedding_id() const { return _embedding_id; }
+  //
+  //! embedding ID for the sub-event to be output
+  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
+  //! negative IDs are backgrounds, .e.g out of time pile up collisions
+  //! Usually, ID = 0 means the primary Au+Au collision background
+  void set_embedding_id(int id) { _embedding_id = id; }
+
  protected:
   std::string outfilename;
   HepMC::IO_GenEvent *ascii_out;
@@ -41,6 +53,11 @@ class Fun4AllHepMCOutputManager: public Fun4AllOutputManager
   // some pointers for use in compression handling
   std::ofstream *filestream; // holds compressed filestream
   std::ostream *zipstream;   // feed into HepMC
+
+  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
+  //! negative IDs are backgrounds, .e.g out of time pile up collisions
+  //! Usually, ID = 0 means the primary Au+Au collision background
+  int _embedding_id;
 };
 
 #endif /* FUN4ALLHEPMCOUTPUTMANAGER_H__ */


### PR DESCRIPTION
This is another follow up to https://github.com/sPHENIX-Collaboration/coresoftware/pull/364 to revive ```Fun4AllHepMCOutputManager```.

@sookhyun and Sanghoon have been testing p+p embedding and need a hepMC p+p pythia event for embedding stream input. This pull request revive the ```Fun4AllHepMCOutputManager```, which can be used in another Fun4All cycle to save PHPythia output to HepMC file for later use in embedding. 

* Example macro to generate MB hepMC file: https://github.com/blackcathj/macros/blob/pythia_MB_HepMC_Output/macros/g4simulations/Fun4All_PythiaHepMC.C
* Example macro to do p+p pile up simulation: https://github.com/blackcathj/macros/blob/pythia_MB_HepMC_Output/macros/g4simulations/Fun4All_G4_sPHENIX.C 