### PR TITLE
Disable validation for GDML schema, which require remote connection to CERN server

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4MapsDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsDetector.cc
@@ -138,7 +138,7 @@ PHG4MapsDetector::ConstructMaps(G4LogicalVolume* trackerenvelope)
   // import the staves from the gemetry file
   std::unique_ptr<G4GDMLReadStructure>  reader (new G4GDMLReadStructure());
   G4GDMLParser gdmlParser(reader.get());
-  gdmlParser.Read(stave_geometry_file);
+  gdmlParser.Read(stave_geometry_file, false);
   
   // figure out which assembly we want
   char assemblyname[500];


### PR DESCRIPTION
Fix a concern raised by @pinkenburg and @adfrawley . Connection to CERN server, required by MAPS GDML schema validation, sometimes leads to job fails. Disabling it. 