### PR TITLE
use of PAI (PhotoAbsorption Ionization) model for tpc gas, use FTFP_BERT for G4 10.03.p03

### DIFF
--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -1394,8 +1394,11 @@ int Fun4AllServer::run(const int nevnts, const bool require_nevents)
     if (verbosity >= VERBOSITY_SOME)
     {
       // print event cycle counter in log scale if VERBOSITY_SOME
-
-      const double significand = icnt / pow(10, (int) (log10(icnt)));
+      double significand = 0;
+      if (icnt > 0)
+      {
+        significand = icnt / pow(10, (int) (log10(icnt)));
+      }
 
       if ((fmod(significand, 1.0) == 0 && significand <= 10) or icnt == 0)
       {

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -203,6 +203,7 @@ PHG4_Dict.cc: \
   PHG4Reco.h \
   PHG4Subsystem.h \
   PHG4TruthSubsystem.h \
+  PHG4Utils.h \
   ReadEICFiles.h \
   PHG4LinkDef.h
 	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(RINCLUDES) $^

--- a/simulation/g4simulation/g4main/PHG4LinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4LinkDef.h
@@ -16,6 +16,7 @@
 #pragma link C++ class PHG4PileupGenerator-!;
 #pragma link C++ class PHG4Subsystem-!;
 #pragma link C++ class PHG4TruthSubsystem-!;
+#pragma link C++ class PHG4Utils-!;
 //#pragma link C++ class PHG4UIsession-!;
 #pragma link C++ class ReadEICFiles-!;
 

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -129,7 +129,11 @@ PHG4Reco::PHG4Reco(const string &name)
   , fieldmapfile("NONE")
   , worldshape("G4Tubs")
   , worldmaterial("G4_AIR")
+#if  G4VERSION_NUMBER >= 1033
+  , physicslist("FTFP_BERT")
+#else
   , physicslist("QGSP_BERT")
+#endif
   , active_decayer_(true)
   , active_force_decay_(false)
   , force_decay_type_(kAll)
@@ -187,7 +191,6 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
   runManager_ = new G4RunManager();
 
   DefineMaterials();
-
   // create physics processes
   G4VModularPhysicsList *myphysicslist = nullptr;
   if (physicslist == "FTFP_BERT")
@@ -1259,7 +1262,7 @@ PHG4Reco::DefineRegions()
   G4ProductionCuts *gcuts = new G4ProductionCuts(*(theRegionStore->GetRegion("DefaultRegionForTheWorld")->GetProductionCuts()));
   G4Region *tpcregion = new G4Region("REGION_TPCGAS");
   tpcregion->SetProductionCuts(gcuts);
-#if G4VERSION_NUMBER >= 1003
+#if G4VERSION_NUMBER >= 1033
 // Use this from the new G4 version 10.03 on
 // add the PAI model to the TPCGAS region
 // undocumented, painfully digged out with debugger by tracing what

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -240,15 +240,13 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
     myphysicslist->RegisterPhysics(decayer);
   }
   myphysicslist->RegisterPhysics(new G4StepLimiterPhysics());
-
+// initialize cuts so we can ask the world region for it's default
+// cuts to propagate them to other regions in DefineRegions()
+  myphysicslist->SetCutsWithDefault();
   runManager_->SetUserInitialization(myphysicslist);
-  // const G4RegionStore* theRegionStore = G4RegionStore::GetInstance();
-  // G4ProductionCuts *gcuts = new G4ProductionCuts(*(theRegionStore->GetRegion("DefaultRegionForTheWorld")->GetProductionCuts()));
-  G4Region *tpcregion = new G4Region("TPCGAS");
-  G4EmParameters *g4emparams = G4EmParameters::Instance();
-  g4emparams->AddPAIModel("all", "TPCGAS", "PAI");
 
-// tpcregion->SetProductionCuts(gcuts);
+  DefineRegions();
+
   // initialize registered subsystems
   BOOST_FOREACH (SubsysReco *reco, subsystems_)
   {
@@ -396,7 +394,6 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   // initialize
   runManager_->Initialize();
 
-  DefineRegions();
   // add cerenkov and optical photon processes
   // cout << endl << "Ignore the next message - we implemented this correctly" << endl;
   G4Cerenkov *theCerenkovProcess = new G4Cerenkov("Cerenkov");
@@ -1260,15 +1257,13 @@ PHG4Reco::DefineRegions()
 {
   const G4RegionStore* theRegionStore = G4RegionStore::GetInstance();
   G4ProductionCuts *gcuts = new G4ProductionCuts(*(theRegionStore->GetRegion("DefaultRegionForTheWorld")->GetProductionCuts()));
-  G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
-  G4Region *tpcregion =  theRegionStore->GetRegion("TPCGAS");
- tpcregion->SetProductionCuts(gcuts);
+  G4Region *tpcregion = new G4Region("TPCGAS");
+  tpcregion->SetProductionCuts(gcuts);
 // add the PAI model to the TPCGAS region
 // undocumented, painfully digged out with debugger by tracing what
-// is done for command /process/em/AddPAIRegion all TPCGAS PAI
-  // G4EmParameters *g4emparams = G4EmParameters::Instance();
-  // g4emparams->AddPAIModel("all", "TPCGAS", "PAI");
-  // ApplyCommand("/run/physicsModified");
+// is done for command "/process/em/AddPAIRegion all TPCGAS PAI"
+  G4EmParameters *g4emparams = G4EmParameters::Instance();
+  g4emparams->AddPAIModel("all", "TPCGAS", "PAI");
   return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -15,6 +15,14 @@
 #include <g4decayer/EDecayType.hh>
 #include <g4decayer/P6DExtDecayerPhysics.hh>
 
+#include <phgeom/PHGeomUtility.h>
+
+#include <g4gdml/PHG4GDMLUtility.hh>
+
+#include <phfield/PHFieldUtility.h>
+#include <phfield/PHFieldConfig_v1.h>
+#include <phfield/PHFieldConfig_v2.h>
+
 #include <fun4all/Fun4AllReturnCodes.h>
 
 #include <phool/PHCompositeNode.h>
@@ -22,11 +30,6 @@
 #include <phool/getClass.h>
 #include <phool/recoConsts.h>
 
-#include <phgeom/PHGeomUtility.h>
-#include <g4gdml/PHG4GDMLUtility.hh>
-#include <phfield/PHFieldUtility.h>
-#include <phfield/PHFieldConfig_v1.h>
-#include <phfield/PHFieldConfig_v2.h>
 
 #include <TThread.h>
 
@@ -37,6 +40,8 @@
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4NistManager.hh>
 #include <Geant4/G4OpenGLImmediateX.hh>
+#include <Geant4/G4Region.hh>
+#include <Geant4/G4RegionStore.hh>
 #include <Geant4/G4StepLimiterPhysics.hh>
 #include <Geant4/G4UIExecutive.hh>
 #include <Geant4/G4UImanager.hh>
@@ -44,6 +49,7 @@
 #include <Geant4/G4Cerenkov.hh>
 #include <Geant4/G4EmProcessOptions.hh>
 #include <Geant4/G4EmSaturation.hh>
+#include <Geant4/G4FastSimulationManager.hh>
 #include <Geant4/G4HadronicProcessStore.hh>
 #include <Geant4/G4LossTableManager.hh>
 #include <Geant4/G4OpAbsorption.hh>
@@ -53,6 +59,7 @@
 #include <Geant4/G4OpWLS.hh>
 #include <Geant4/G4OpticalPhoton.hh>
 #include <Geant4/G4OpticalPhysics.hh>
+#include <Geant4/G4PAIModel.hh>
 #include <Geant4/G4PEEffectFluoModel.hh>
 #include <Geant4/G4EmProcessOptions.hh>
 #include <Geant4/G4HadronicProcessStore.hh>
@@ -168,7 +175,8 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
   if (verbosity > 1) cout << "PHG4Reco::Init - create run manager" << endl;
 
   // redirect GEANT verbosity to nowhere
-  if (verbosity < 1)
+//  if (verbosity < 1)
+  if (0)
   {
     G4UImanager *uimanager = G4UImanager::GetUIpointer();
     uisession_ = new PHG4UIsession();
@@ -232,8 +240,15 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
     myphysicslist->RegisterPhysics(decayer);
   }
   myphysicslist->RegisterPhysics(new G4StepLimiterPhysics());
-  runManager_->SetUserInitialization(myphysicslist);
 
+  runManager_->SetUserInitialization(myphysicslist);
+  // const G4RegionStore* theRegionStore = G4RegionStore::GetInstance();
+  // G4ProductionCuts *gcuts = new G4ProductionCuts(*(theRegionStore->GetRegion("DefaultRegionForTheWorld")->GetProductionCuts()));
+  G4Region *tpcregion = new G4Region("TPCGAS");
+  G4EmParameters *g4emparams = G4EmParameters::Instance();
+  g4emparams->AddPAIModel("all", "TPCGAS", "PAI");
+
+// tpcregion->SetProductionCuts(gcuts);
   // initialize registered subsystems
   BOOST_FOREACH (SubsysReco *reco, subsystems_)
   {
@@ -381,6 +396,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   // initialize
   runManager_->Initialize();
 
+  DefineRegions();
   // add cerenkov and optical photon processes
   // cout << endl << "Ignore the next message - we implemented this correctly" << endl;
   G4Cerenkov *theCerenkovProcess = new G4Cerenkov("Cerenkov");
@@ -445,7 +461,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
 
   // quiet some G4 print-outs (EM and Hadronic settings during first event)
   G4HadronicProcessStore::Instance()->SetVerbose(0);
-  G4LossTableManager::Instance()->SetVerbose(0);
+  G4LossTableManager::Instance()->SetVerbose(1);
 
   if ((verbosity < 1) && (uisession_))
   {
@@ -647,7 +663,7 @@ void PHG4Reco::G4Seed(const unsigned int i)
 void g4guithread(void *ptr)
 {
   TThread::Lock();
-  G4UIExecutive *ui = new G4UIExecutive(0, nullptr);
+  G4UIExecutive *ui = new G4UIExecutive(0, nullptr, "Xm");
   if (ui->IsGUI() && boost::filesystem::exists("gui.mac"))
   {
     UImanager->ApplyCommand("/control/execute gui.mac");
@@ -1237,6 +1253,23 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   const G4Material *G4_AIR = G4Material::GetMaterial("G4_AIR");
   G4Material *mRICH_Air=  new G4Material("mRICH_Air",G4_AIR->GetDensity(),G4_AIR,G4_AIR->GetState(),G4_AIR->GetTemperature(),G4_AIR->GetPressure());
   mRICH_Air->SetMaterialPropertiesTable(mRICH_Air_myMPT);
+}
+
+void
+PHG4Reco::DefineRegions()
+{
+  const G4RegionStore* theRegionStore = G4RegionStore::GetInstance();
+  G4ProductionCuts *gcuts = new G4ProductionCuts(*(theRegionStore->GetRegion("DefaultRegionForTheWorld")->GetProductionCuts()));
+  G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
+  G4Region *tpcregion =  theRegionStore->GetRegion("TPCGAS");
+ tpcregion->SetProductionCuts(gcuts);
+// add the PAI model to the TPCGAS region
+// undocumented, painfully digged out with debugger by tracing what
+// is done for command /process/em/AddPAIRegion all TPCGAS PAI
+  // G4EmParameters *g4emparams = G4EmParameters::Instance();
+  // g4emparams->AddPAIModel("all", "TPCGAS", "PAI");
+  // ApplyCommand("/run/physicsModified");
+  return;
 }
 
 PHG4Subsystem *

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -1259,11 +1259,14 @@ PHG4Reco::DefineRegions()
   G4ProductionCuts *gcuts = new G4ProductionCuts(*(theRegionStore->GetRegion("DefaultRegionForTheWorld")->GetProductionCuts()));
   G4Region *tpcregion = new G4Region("REGION_TPCGAS");
   tpcregion->SetProductionCuts(gcuts);
+#if G4VERSION_NUMBER >= 1003
+// Use this from the new G4 version 10.03 on
 // add the PAI model to the TPCGAS region
 // undocumented, painfully digged out with debugger by tracing what
 // is done for command "/process/em/AddPAIRegion all TPCGAS PAI"
   G4EmParameters *g4emparams = G4EmParameters::Instance();
   g4emparams->AddPAIModel("all", "REGION_TPCGAS", "PAI");
+#endif
   return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -1257,13 +1257,13 @@ PHG4Reco::DefineRegions()
 {
   const G4RegionStore* theRegionStore = G4RegionStore::GetInstance();
   G4ProductionCuts *gcuts = new G4ProductionCuts(*(theRegionStore->GetRegion("DefaultRegionForTheWorld")->GetProductionCuts()));
-  G4Region *tpcregion = new G4Region("TPCGAS");
+  G4Region *tpcregion = new G4Region("REGION_TPCGAS");
   tpcregion->SetProductionCuts(gcuts);
 // add the PAI model to the TPCGAS region
 // undocumented, painfully digged out with debugger by tracing what
 // is done for command "/process/em/AddPAIRegion all TPCGAS PAI"
   G4EmParameters *g4emparams = G4EmParameters::Instance();
-  g4emparams->AddPAIModel("all", "TPCGAS", "PAI");
+  g4emparams->AddPAIModel("all", "REGION_TPCGAS", "PAI");
   return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -21,6 +21,7 @@ class PHG4PhenixSteppingAction;
 class PHG4PhenixTrackingAction;
 class PHG4Subsystem;
 class PHG4EventGenerator;
+class G4VModularPhysicsList;
 class G4TBMagneticFieldSetup;
 class G4VUserPrimaryGeneratorAction;
 class PHG4UIsession;
@@ -132,6 +133,7 @@ class PHG4Reco : public SubsysReco
  protected:
   int InitUImanager();
   void DefineMaterials();
+  void DefineRegions();
   float magfield;
   float magfield_rescale;
   double WorldSize[3];

--- a/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
@@ -118,10 +118,13 @@ int PHG4TPCDetector::ConstructTPCGasVolume(G4LogicalVolume *tpc_envelope)
                                                       tpc_envelope, 0, false, overlapcheck);
 
   activevols.insert(tpc_gas_phys);
+
+#if G4VERSION_NUMBER >= 1003
   const G4RegionStore* theRegionStore = G4RegionStore::GetInstance();
   G4Region *tpcregion = theRegionStore->GetRegion("REGION_TPCGAS");
   tpc_gas_logic->SetRegion(tpcregion);
   tpcregion->AddRootLogicalVolume(tpc_gas_logic);
+#endif
   return 0;
 }
 

--- a/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
@@ -119,7 +119,7 @@ int PHG4TPCDetector::ConstructTPCGasVolume(G4LogicalVolume *tpc_envelope)
 
   activevols.insert(tpc_gas_phys);
 
-#if G4VERSION_NUMBER >= 1003
+#if G4VERSION_NUMBER >= 1033
   const G4RegionStore* theRegionStore = G4RegionStore::GetInstance();
   G4Region *tpcregion = theRegionStore->GetRegion("REGION_TPCGAS");
   tpc_gas_logic->SetRegion(tpcregion);

--- a/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
@@ -14,6 +14,8 @@
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4PhysicalConstants.hh>
+#include <Geant4/G4Region.hh>
+#include <Geant4/G4RegionStore.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4UserLimits.hh>
@@ -116,6 +118,10 @@ int PHG4TPCDetector::ConstructTPCGasVolume(G4LogicalVolume *tpc_envelope)
                                                       tpc_envelope, 0, false, overlapcheck);
 
   activevols.insert(tpc_gas_phys);
+  const G4RegionStore* theRegionStore = G4RegionStore::GetInstance();
+  G4Region *tpcregion = theRegionStore->GetRegion("REGION_TPCGAS");
+  tpc_gas_logic->SetRegion(tpcregion);
+  tpcregion->AddRootLogicalVolume(tpc_gas_logic);
   return 0;
 }
 


### PR DESCRIPTION
According to Alice test beam results the PAI model gives a better description of the ionization than the standard Urban model. 
![pai_alice](https://user-images.githubusercontent.com/7316141/32463387-b7f59fe2-c30a-11e7-9343-660694e00122.png)
What is more important for us is that the dEdx from PAI is less dependent on the Geant4 Step Size:
![urban_g4step](https://user-images.githubusercontent.com/7316141/32463529-165daba6-c30b-11e7-95e2-84ffa780fd4c.png)
![pai_g4step](https://user-images.githubusercontent.com/7316141/32463540-20cfd6fe-c30b-11e7-8602-c82e810b92f2.png)
(yes these plots also show that we have to be careful not to use too small steps). The PAI model is activated for a G4Region (REGION_TPCGAS) which is used by the tpc gas volume. The code is only active for the new G4 version 10.03.p03, there are no changes affecting our current version PAI has changed, backporting this to G4 10.02 would require some validation). 
While at it I changed the default physics list to FTFP_BERT for the new G4 version.
Some minor bugfixes (spawning the g4 menu in a separate window works again, and one can actually issue commands from it) as well as an invalid log(0) in the verbosity scaling for printouts. The G4 debug version has fpe enabled, this fix was needed to get over the first event (evt number=0)


