### PR TITLE
Memory saver for TPC cells by more than half

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -46,6 +46,7 @@ pkginclude_HEADERS = \
   PHG4BlockGeomContainer.h \
   PHG4Cell.h \
   PHG4Cellv1.h \
+  PHG4Cellv2.h \
   PHG4CellContainer.h \
   PHG4CellDefs.h \
   PHG4CylinderCell.h \
@@ -105,6 +106,8 @@ libg4detectors_io_la_SOURCES = \
   PHG4Cell_Dict.cc \
   PHG4Cellv1.cc \
   PHG4Cellv1_Dict.cc \
+  PHG4Cellv2.cc \
+  PHG4Cellv2_Dict.cc \
   PHG4CellContainer.cc \
   PHG4CellContainer_Dict.cc \
   PHG4CellDefs.cc \

--- a/simulation/g4simulation/g4detectors/PHG4Cell.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cell.h
@@ -95,7 +95,7 @@ class PHG4Cell: public TObject
   virtual void set_stave_index(const int i) {return;}
   virtual int get_stave_index() const {return ~0x0;}
 
-  virtual tpctod* get_train_of_digits() {return 0;}
+//  virtual tpctod* get_train_of_digits() {return 0;}
 
   virtual void set_zbin(const int i) {return;}
   virtual int get_zbin() const {return ~0x0;}

--- a/simulation/g4simulation/g4detectors/PHG4Cell.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cell.h
@@ -3,13 +3,13 @@
 
 #include "PHG4CellDefs.h"
 #include <g4main/PHG4Hit.h>
-#include <phool/PHObject.h>
+#include <TObject.h>
 
 #include <cmath>
 #include <climits>
 #include <map>
 
-class PHG4Cell: public PHObject
+class PHG4Cell: public TObject
 {
  public:
   typedef std::map<PHG4HitDefs::keytype, float> EdepMap;
@@ -155,7 +155,7 @@ class PHG4Cell: public PHObject
   PHG4Cell() {}
   virtual unsigned int get_property_nocheck(const PROPERTY prop_id) const {return UINT_MAX;}
   virtual void set_property_nocheck(const PROPERTY prop_id,const unsigned int) {return;}
-  ClassDef(PHG4Cell,1)
+  ClassDef(PHG4Cell,2)
 };
 
 

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.cc
@@ -220,29 +220,9 @@ PHG4Cellv1::get_property_nocheck(const PROPERTY prop_id) const
 }
 
 void
-PHG4Cellv1::print() const {
-  std::cout<<"New Hitv1  0x"<< hex << cellid << dec << endl;
-  for (prop_map_t::const_iterator i = prop_map.begin(); i!= prop_map.end(); ++i)
-    {
-      PROPERTY prop_id = static_cast<PROPERTY>(i->first);
-      pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-      cout << "\t" << prop_id << ":\t" << property_info.first << " = \t";
-      switch(property_info.second)
-	{
-	case type_int:
-	  cout << get_property_int(prop_id);
-	  break;
-	case type_uint:
-	  cout << get_property_uint(prop_id);
-	  break;
-	case type_float:
-	  cout << get_property_float(prop_id);
-	  break;
-	default:
-	  cout << " unknown type ";
-	}
-      cout <<endl;
-    }
+PHG4Cellv1::print() const
+{
+  identify(cout);
 }
 
 void
@@ -252,4 +232,45 @@ PHG4Cellv1::Reset()
   showeredeps.clear();
   prop_map.clear();
   return;
+}
+
+void PHG4Cellv1::identify(std::ostream& os) const
+{
+  os << "New PHG4Cellv1  0x" << hex << cellid << dec << endl;
+
+  os <<"Associated to "<<hitedeps.size()<<" hits"<<endl;
+  for (const auto pair :hitedeps)
+  {
+    os <<"\t PHG4hit "<<pair.first<<" -> "<<pair.second<<" GeV"<<endl;
+  }
+
+  os <<"Associated to "<<showeredeps.size()<<" showers"<<endl;
+  for (const auto pair :showeredeps)
+  {
+    os <<"\t Shower "<<pair.first<<" -> "<<pair.second<<" GeV"<<endl;
+  }
+
+  os <<"Contains to "<<trainOfDigits.size()<<" TPC digitization chain"<<endl;
+
+  for (prop_map_t::const_iterator i = prop_map.begin(); i != prop_map.end(); ++i)
+  {
+    PROPERTY prop_id = static_cast<PROPERTY>(i->first);
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    os << "\t" << prop_id << ":\t" << property_info.first << " = \t";
+    switch (property_info.second)
+    {
+    case type_int:
+      os << get_property_int(prop_id);
+      break;
+    case type_uint:
+      os << get_property_uint(prop_id);
+      break;
+    case type_float:
+      os << get_property_float(prop_id);
+      break;
+    default:
+      os << " unknown type ";
+    }
+    os << endl;
+  }
 }

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.cc
@@ -250,7 +250,7 @@ void PHG4Cellv1::identify(std::ostream& os) const
     os <<"\t Shower "<<pair.first<<" -> "<<pair.second<<" GeV"<<endl;
   }
 
-  os <<"Contains to "<<trainOfDigits.size()<<" TPC digitization chain"<<endl;
+//  os <<"Contains to "<<trainOfDigits.size()<<" TPC digitization chain"<<endl;
 
   for (prop_map_t::const_iterator i = prop_map.begin(); i != prop_map.end(); ++i)
   {

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.h
@@ -72,7 +72,7 @@ class PHG4Cellv1: public PHG4Cell
   void set_stave_index(const int i) {set_property(prop_stave_index,i);}
   int get_stave_index() const {return get_property_int(prop_stave_index);}
 
-  tpctod* get_train_of_digits() {return &trainOfDigits;}
+//  tpctod* get_train_of_digits() {return &trainOfDigits;}
 
   void set_zbin(const int i) {set_property(prop_zbin,i);}
   int get_zbin() const {return get_property_int(prop_zbin);}
@@ -98,7 +98,7 @@ class PHG4Cellv1: public PHG4Cell
   PHG4CellDefs::keytype cellid;
   EdepMap hitedeps;
   ShowerEdepMap showeredeps;
-  tpctod trainOfDigits;
+//  tpctod trainOfDigits;
 
   //! storage types for additional property
   typedef uint8_t prop_id_t;
@@ -123,7 +123,7 @@ class PHG4Cellv1: public PHG4Cell
   prop_map_t prop_map;
 
 
-  ClassDef(PHG4Cellv1,2)
+  ClassDef(PHG4Cellv1,3)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.h
@@ -18,7 +18,8 @@ class PHG4Cellv1: public PHG4Cell
   PHG4Cellv1(const PHG4CellDefs::keytype g4cellid);
   virtual ~PHG4Cellv1();
 
-  void Reset();
+  virtual void identify(std::ostream& os = std::cout) const;
+  virtual void Reset();
 
   void set_cellid(const PHG4CellDefs::keytype i) {cellid = i;}
 
@@ -122,7 +123,7 @@ class PHG4Cellv1: public PHG4Cell
   prop_map_t prop_map;
 
 
-  ClassDef(PHG4Cellv1,1)
+  ClassDef(PHG4Cellv1,2)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Cellv2.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv2.cc
@@ -7,19 +7,19 @@
 using namespace std;
 
 PHG4Cellv2::PHG4Cellv2()
-  : cellid(~0x0)
-  , _edep(0)
+  : PHG4Cellv2(~0x0)
 {
 }
 
 PHG4Cellv2::PHG4Cellv2(const PHG4CellDefs::keytype g4cellid)
   : cellid(g4cellid)
+  , _edep(0)
 {
 }
 
 PHG4Cellv2::~PHG4Cellv2()
 {
-//  hitedeps.clear();
+  //  hitedeps.clear();
   return;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4Cellv2.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv2.cc
@@ -1,0 +1,65 @@
+#include "PHG4Cellv2.h"
+
+#include <phool/phool.h>
+
+#include <iostream>
+
+using namespace std;
+
+PHG4Cellv2::PHG4Cellv2()
+  : cellid(~0x0)
+  , _edep(0)
+{
+}
+
+PHG4Cellv2::PHG4Cellv2(const PHG4CellDefs::keytype g4cellid)
+  : cellid(g4cellid)
+{
+}
+
+PHG4Cellv2::~PHG4Cellv2()
+{
+//  hitedeps.clear();
+  return;
+}
+
+void PHG4Cellv2::add_edep(const PHG4HitDefs::keytype g4hitid, const float edep)
+{
+  hitedeps[g4hitid] = edep;
+  return;
+}
+
+bool PHG4Cellv2::has_binning(const PHG4CellDefs::CellBinning binning) const
+{
+  return PHG4CellDefs::has_binning(cellid, binning);
+}
+
+short int
+PHG4Cellv2::get_detid() const
+{
+  return PHG4CellDefs::get_detid(cellid);
+}
+
+void PHG4Cellv2::print() const
+{
+  identify(cout);
+}
+
+void PHG4Cellv2::Reset()
+{
+  hitedeps.clear();
+  return;
+}
+
+void PHG4Cellv2::identify(std::ostream& os) const
+{
+  os << "New PHG4Cellv2  0x" << hex << cellid << dec << endl;
+
+  os << "Associated to " << hitedeps.size() << " hits" << endl;
+  for (const auto pair : hitedeps)
+  {
+    os << "\t PHG4hit " << pair.first << " -> " << pair.second << " GeV" << endl;
+  }
+
+  //  os <<"Contains to "<<trainOfDigits.size()<<" TPC digitization chain"<<endl;
+}

--- a/simulation/g4simulation/g4detectors/PHG4Cellv2.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv2.h
@@ -16,7 +16,7 @@ class PHG4Cellv2 : public PHG4Cell
 {
  public:
   PHG4Cellv2();
-  PHG4Cellv2(const PHG4CellDefs::keytype g4cellid);
+  explicit PHG4Cellv2(const PHG4CellDefs::keytype g4cellid);
   virtual ~PHG4Cellv2();
 
   virtual void identify(std::ostream& os = std::cout) const;

--- a/simulation/g4simulation/g4detectors/PHG4Cellv2.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv2.h
@@ -1,0 +1,53 @@
+#ifndef PHG4Cellv2_h__
+#define PHG4Cellv2_h__
+
+#include "PHG4Cell.h"
+#include "PHG4CellDefs.h"
+#ifdef __CINT__
+#include <stdint.h>
+#else
+#include <cstdint>
+#endif
+#include <iostream>
+#include <map>
+
+//! specialized cells for TPC operations
+class PHG4Cellv2 : public PHG4Cell
+{
+ public:
+  PHG4Cellv2();
+  PHG4Cellv2(const PHG4CellDefs::keytype g4cellid);
+  virtual ~PHG4Cellv2();
+
+  virtual void identify(std::ostream& os = std::cout) const;
+  virtual void Reset();
+
+  void set_cellid(const PHG4CellDefs::keytype i) { cellid = i; }
+  PHG4CellDefs::keytype get_cellid() const { return cellid; }
+  bool has_binning(const PHG4CellDefs::CellBinning binning) const;
+  short int get_detid() const;
+
+  void add_edep(const PHG4HitDefs::keytype g4hitid, const float edep);
+
+  EdepConstRange get_g4hits()
+  {
+    return std::make_pair(hitedeps.begin(), hitedeps.end());
+  }
+
+  void add_edep(const float f) { _edep += f; }
+  double get_edep() const { return _edep; }
+  //  tpctod* get_train_of_digits() {return &trainOfDigits;}
+
+  void print() const;
+
+ protected:
+  PHG4CellDefs::keytype cellid;
+  EdepMap hitedeps;
+
+  float _edep;
+  //  tpctod trainOfDigits;
+
+  ClassDef(PHG4Cellv2, 1)
+};
+
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4Cellv2LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4Cellv2+;
+
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -2,6 +2,7 @@
 #include "PHG4CellContainer.h"
 #include "PHG4CellDefs.h"
 #include "PHG4Cellv1.h"
+#include "PHG4Cellv2.h"
 #include "PHG4CylinderCellGeom.h"
 #include "PHG4CylinderCellGeomContainer.h"
 #include "PHG4CylinderGeom.h"
@@ -593,7 +594,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
               else
               {
                 PHG4CellDefs::keytype akey = PHG4CellDefs::SizeBinning::genkey(*layer, cur_z_bin, cur_phi_bin);
-                cell = new PHG4Cellv1(akey);
+                cell = new PHG4Cellv2(akey);
                 cellptmap[key] = cell;
               }
               if (verbosity > 2000) cout << "    adding edep = neffelectrons = " << neffelectrons << " to cell with key = " << key << endl;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -418,7 +418,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
         cell->add_edep(hiter->first, edep);
         cell->add_edep(edep);
         cell->add_shower_edep(hiter->second->get_shower_id(), edep);
-        if (hiter->second->has_property(PHG4Hit::prop_eion)) cell->add_eion(hiter->second->get_eion());
+//        if (hiter->second->has_property(PHG4Hit::prop_eion)) cell->add_eion(hiter->second->get_eion());
       }
       else
       {  // TPC
@@ -600,7 +600,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
               cell->add_edep(hiter->first, neffelectrons);
               cell->add_edep(neffelectrons);
               cell->add_shower_edep(hiter->second->get_shower_id(), neffelectrons);
-              if (hiter->second->has_property(PHG4Hit::prop_eion)) cell->add_eion(hiter->second->get_eion());
+//              if (hiter->second->has_property(PHG4Hit::prop_eion)) cell->add_eion(hiter->second->get_eion());
             }  //iz
           }    //iphi
         }      // izr

--- a/simulation/g4simulation/g4hough/SvtxHit.h
+++ b/simulation/g4simulation/g4hough/SvtxHit.h
@@ -1,12 +1,12 @@
 #ifndef __SVTXHIT_H__
 #define __SVTXHIT_H__
 
-#include <phool/PHObject.h>
+#include <TObject.h>
 #include <g4detectors/PHG4CellDefs.h>
 #include <iostream>
 #include <limits.h>
 
-class SvtxHit : public PHObject {
+class SvtxHit : public TObject {
 
 public:
   
@@ -43,7 +43,7 @@ protected:
   
 private:
   
-  ClassDef(SvtxHit, 1);
+  ClassDef(SvtxHit, 2);
 };
 
 #endif

--- a/simulation/g4simulation/g4hough/SvtxHit_v1.h
+++ b/simulation/g4simulation/g4hough/SvtxHit_v1.h
@@ -45,7 +45,7 @@ private:
   float        _e;                 //< digitized energy value
   PHG4CellDefs::keytype _cellid;            //< geant4 cell object
   
-  ClassDef(SvtxHit_v1, 1);
+  ClassDef(SvtxHit_v1, 2);
 };
 
 #endif


### PR DESCRIPTION
@adfrawley pointed out the full pile up simulation pushed our memory usage to the 22 GB condor limit, which significantly limited our capability to evaluate the performance dependency on the event occupancy. 

This pull request represent an effort to reduce the memory usage. A memory profiling showed the majority memory is used by the TPC hits and cells. These objects represent non-zero ADC bins in the TPC, which are 10x-100x the number of PHG4Hits (ionizing hit per layer) in the TPC. Therefore, this pull request focuses on strip down the Hits/cells, in particular for those used by TPC: 
* Reduce the base class for ```PHG4Cell``` and ```SvtxHit``` from ```PHObject``` to ```TObject```. They do not have to be on the Node Tree directly, therefore, not needing the 2x4 B data members in PHObject that describing the splitting level in storage. 
* Ionizing energy loss and shower tagging in TPC cells are not needed. Removing them. 
* Use a specialized version of ```PHG4Cellv2``` to be specialized for the TPC storage only, which removes the property map and shower map entirely. This also speed up the edep access. 

Together, the following test will show cell storage usage reduces to 40% of night-build and the overall memory usage reduces to 49%.

A long term solution would require the new chain of TPC simulation which store TPC digitized data as a time-sequence of ADC bins as in #373 and #352. 
 
# Tests

Tested with a faster version of pile up simulation in the tracking detectors alone: 1 event of peripheral Au+Au collisions + 3x off-time pile up of peripheral Au+Au collisions. Tracking simulation, reconstruction and evaluation is enabled. The memory profiling was performed using the valgrind tool of massif. 

## Nightly-build

The nightly build memory usage peaks at 4.1 GB with 0.7 GB spent via ```PHG4SvtxDigitizer``` and 2.9 GB spent via tracker cells reco ```PHG4CylinderCellTPCReco```. 

The time-dependence shown as following 

![image](https://user-images.githubusercontent.com/7947083/32474411-732d3aac-c33a-11e7-8501-1f4af92ad2c0.png)

Stats separated by calling: 

![image](https://user-images.githubusercontent.com/7947083/32474427-886181a8-c33a-11e7-9445-529d51fe01fa.png)


## This pull request

The nightly build memory usage peaks at 2.0 GB with 0.6 GB spent via ```PHG4SvtxDigitizer``` and 1.2 GB spent via tracker cells reco, ```PHG4CylinderCellTPCReco```. 

The time-dependence shown as following 
![image](https://user-images.githubusercontent.com/7947083/32474789-583baf6a-c33c-11e7-9d88-6e897430eb6d.png)



Stats separated by calling: 
![image](https://user-images.githubusercontent.com/7947083/32474653-8449a202-c33b-11e7-8e02-be2b652ce302.png)


