### PR TITLE
EMCal divider simulation bug fix

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -440,12 +440,12 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
     int ID = 300;
     for (const auto& geom : divider_azimuth_geoms)
     {
-      G4Box* wall_solid = new G4Box(G4String(GetName() + G4String("_Divider_") + to_string(ID)),
+      G4Box* divider_solid = new G4Box(G4String(GetName() + G4String("_Divider_") + to_string(ID)),
                                     geom.thickness / 2.0,
                                     geom.width / 2.,
                                     (get_geom_v3()->get_length() / 2. - 2 * (get_geom_v3()->get_sidewall_thickness() + 2. * get_geom_v3()->get_assembly_spacing())) * cm * .5);
 
-      G4LogicalVolume* wall_logic = new G4LogicalVolume(wall_solid, wall_mat,
+      G4LogicalVolume* wall_logic = new G4LogicalVolume(divider_solid, divider_mat,
                                                         G4String(G4String(GetName() + G4String("_Divider_") + to_string(ID))), 0, 0,
                                                         nullptr);
       wall_logic->SetVisAttributes(divider_VisAtt);


### PR DESCRIPTION
During the last EMCal meeting, a bug was found in the divider material assignment for the EMCal simulation. Divider is a new support structure to EMCal which is introduced in #365 and #374 , and it is still under evaluation. This bug would affect the conclusion on the effect of divider on the EMCal energy response.

This pull request should fix it. 

To demonstrate the proper assignment of material to the dividers, here is a comparison of energy deposition in the divider materials for pT=16 GeV/c electron showers. 
* Red: divider material is air, which represent effectively no divider installed. Very little energy (tipically keV) per shower is deposited in the air gap.
* Blue: divider material is solid Tungsten, which maximize energy deposition in the divider. Energy deposition is much higher, typically 10-100 MeV per shower:
![image](https://user-images.githubusercontent.com/7947083/32558456-c806f868-c472-11e7-99c8-fcb5b0bb3e7a.png)
