### PR TITLE
Update the definition of primary vertex in the truth information

### DIFF
--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -83,6 +83,9 @@ void PHG4TruthInfoContainer::identify(ostream& os) const {
     cout << "embeded vertex id: " << eter->first
 	 << " flag: " << eter->second << endl;
   }
+
+  cout << "---primary vertex-------------------" << endl;
+  cout <<"Vertex "<<GetPrimaryVertexIndex()<<" is identified as the primary vertex"<<endl;
    
   return;
 }
@@ -320,7 +323,7 @@ int PHG4TruthInfoContainer::GetPrimaryVertexIndex() const
     //         ; iter->second->identify();
     const int embedding_ID = isEmbededVtx(iter->first);
 
-    if (embedding_ID > highest_embedding_ID)
+    if (embedding_ID >= highest_embedding_ID)
     {
       highest_embedding_ID = embedding_ID;
       vtx_id_for_highest_embedding_ID = iter->first;


### PR DESCRIPTION
Primary vertex in the truth information is used for the fast simulation of BBC and the current place-holder for the vertex seeding. After the implementation of the pile up tool chain, the primary vertex is defined as the first vertex with highest embedding ID as in #372. 

However, as Sanghoon find out, in the Pythia-8 event simulations, the collision vertex is saved to the last vertex in the truth container, and the first vertex is usually a decay vertex which leads to low track seeding efficiency. Therefore, this pull request change the primary vertex definition to the last vertex with the highest embedding ID. 

Tested with few Pythia-8 B-jet events. Looks working fine.