### PR TITLE
support of summing objects from multiple input files under the Run Node

### DIFF
--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -1,20 +1,21 @@
-#include "Fun4AllServer.h"
 #include "Fun4AllDstInputManager.h"
+
 #include "Fun4AllHistoBinDefs.h"
-#include "Fun4AllSyncManager.h"
 #include "Fun4AllReturnCodes.h"
+#include "Fun4AllServer.h"
+#include "Fun4AllSyncManager.h"
 
 #include <ffaobjects/RunHeader.h>
-#include <ffaobjects/SyncObject.h>
 #include <ffaobjects/SyncDefs.h>
+#include <ffaobjects/SyncObject.h>
 
 #include <frog/FROG.h>
 
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNodeIntegrate.h>
 #include <phool/PHNodeIOManager.h>
+#include <phool/PHNodeIntegrate.h>
+#include <phool/getClass.h>
 #include <phool/recoConsts.h>
 
 #include <TSystem.h>
@@ -24,384 +25,377 @@
 
 using namespace std;
 
-Fun4AllDstInputManager::Fun4AllDstInputManager(const string &name, const string &nodename, const string &topnodename) : 
-  Fun4AllInputManager(name, nodename, topnodename),
-  readrunttree(1),
-  isopen(0),
-  events_total(0),
-  events_thisfile(0),
-  events_skipped_during_sync(0),
-  fname(nullptr),
-  RunNode("RUN"),
-  dstNode(nullptr),
-  runNode(nullptr),
-  runNodeCopy(nullptr),
-  runNodeSum(nullptr),
-  IManager(nullptr),
-  syncobject(nullptr)
+Fun4AllDstInputManager::Fun4AllDstInputManager(const string &name, const string &nodename, const string &topnodename)
+  : Fun4AllInputManager(name, nodename, topnodename)
+  , readrunttree(1)
+  , isopen(0)
+  , events_total(0)
+  , events_thisfile(0)
+  , events_skipped_during_sync(0)
+  , RunNode("RUN")
+  , dstNode(nullptr)
+  , runNode(nullptr)
+  , runNodeCopy(nullptr)
+  , runNodeSum(nullptr)
+  , IManager(nullptr)
+  , syncobject(nullptr)
 {
-  return ;
+  return;
 }
 
 Fun4AllDstInputManager::~Fun4AllDstInputManager()
 {
   delete IManager;
-  cout << "runNodeSum:" << endl;
-  runNodeSum->print();
   delete runNodeSum;
   return;
 }
 
-int
-Fun4AllDstInputManager::fileopen(const string &filenam)
+int Fun4AllDstInputManager::fileopen(const string &filenam)
 {
   Fun4AllServer *se = Fun4AllServer::instance();
   if (isopen)
-    {
-      cout << "Closing currently open file "
-           << filename
-           << " and opening " << filenam << endl;
-      fileclose();
-    }
-  filename = filenam;
+  {
+    cout << "Closing currently open file "
+         << filename
+         << " and opening " << filenam << endl;
+    fileclose();
+  }
+  filename = filenam; // filenam is const and .c_str() breaks this
   FROG frog;
-  fname = frog.location(filename.c_str());
+  fullfilename = frog.location(filename.c_str());
   if (verbosity > 0)
-    {
-      cout << ThisName << ": opening file " << filename.c_str() << endl;
-    }
+  {
+    cout << ThisName << ": opening file " << fullfilename << endl;
+  }
   // sanity check - the IManager must be nullptr when this method is executed
   // if not something is very very wrong and we must not continue
   if (IManager)
-    {
-      cout << PHWHERE << " IManager pointer is not nullptr but " << IManager
-           << endl;
-      cout << "Send mail to off-l with this printout and the macro you used"
-           << endl;
-      cout << "Trying to execute IManager->print() to display more info"
-           << endl;
-      cout << "Code will probably segfault now" << endl;
-      IManager->print();
-      cout << "Have someone look into this problem - Exiting now" << endl;
-      exit(1);
-    }
+  {
+    cout << PHWHERE << " IManager pointer is not nullptr but " << IManager
+         << endl;
+    cout << "Send mail to off-l with this printout and the macro you used"
+         << endl;
+    cout << "Trying to execute IManager->print() to display more info"
+         << endl;
+    cout << "Code will probably segfault now" << endl;
+    IManager->print();
+    cout << "Have someone look into this problem - Exiting now" << endl;
+    exit(1);
+  }
   // first read the runnode if not disabled
   if (readrunttree)
+  {
+    IManager = new PHNodeIOManager(fullfilename, PHReadOnly, PHRunTree);
+    if (IManager->isFunctional())
     {
-      IManager = new PHNodeIOManager(frog.location(filename.c_str()), PHReadOnly, PHRunTree);
-      if (IManager->isFunctional())
-	{
+      runNode = se->getNode(RunNode.c_str(), topNodeName.c_str());
+      IManager->read(runNode);
+      // get the current run number
+      RunHeader *runheader = findNode::getClass<RunHeader>(runNode, "RunHeader");
+      if (runheader)
+      {
+        SetRunNumber(runheader->get_RunNumber());
+      }
+      // delete our internal copy of the runnode when opening subsequent files
+      if (runNodeCopy)
+      {
+        cout << PHWHERE
+             << " The impossible happened, we have a valid copy of the run node "
+             << runNodeCopy->getName() << " which should be a nullptr"
+             << endl;
+        gSystem->Exit(1);
+      }
+      runNodeCopy = new PHCompositeNode("RUNNODECOPY");
+      if (!runNodeSum)
+      {
+        runNodeSum = new PHCompositeNode("RUNNODESUM");
+      }
+      PHNodeIOManager *tmpIman = new PHNodeIOManager(fullfilename, PHReadOnly, PHRunTree);
+      tmpIman->read(runNodeCopy);
+      delete tmpIman;
 
-	  runNode = se->getNode(RunNode.c_str(), topNodeName.c_str());
-	  IManager->read(runNode);
-	  // get the current run number
-	  RunHeader *runheader = findNode::getClass<RunHeader>(runNode, "RunHeader");
-	  if (runheader)
-	    {
-	      SetRunNumber(runheader->get_RunNumber());
-	    }
-// delete our internal copy of the runnode when opening subsequent files
-	  if (runNodeCopy)
-	  {
-	    cout << PHWHERE 
-<< " The impossible happened, we have a valid copy of the run node " 
-		 << runNodeCopy->getName() << " which should be a nullptr"
-		 << endl;
-	    gSystem->Exit(1);
-	  }
-	    runNodeCopy = new PHCompositeNode("RUNNODECOPY");
-	  if (!runNodeSum)
-	  {
-	    runNodeSum = new PHCompositeNode("RUNNODESUM");
-	  }
-            PHNodeIOManager *tmpIman = new PHNodeIOManager(frog.location(filename.c_str()), PHReadOnly, PHRunTree);
-	    tmpIman->read(runNodeCopy);
-	    delete tmpIman;
-	  
-	    cout << "integrating" << endl;
-	    PHNodeIntegrate integrate;
-	    integrate.RunNode(runNodeCopy);
-	    integrate.RunSumNode(runNodeSum);
-// run recursively over internal run node copy and integrate objects
-    PHNodeIterator mainIter(runNodeCopy);
-    mainIter.forEach(integrate);
-// we do not need to keep the internal copy, keeping it would crate
-// problems in case a subsequent file does not contain all the
-// runwise objects from the previous file. Keeping this copy would then
-// integrate the missing object again with the old copy
-    delete runNodeCopy;
-    runNodeCopy = nullptr;
-	}
-      // DLW: move the delete outside the if block to cover the case where isFunctional() fails
+      PHNodeIntegrate integrate;
+      integrate.RunNode(runNodeCopy);
+      integrate.RunSumNode(runNodeSum);
+      // run recursively over internal run node copy and integrate objects
+      PHNodeIterator mainIter(runNodeCopy);
+      mainIter.forEach(integrate);
+      // we do not need to keep the internal copy, keeping it would crate
+      // problems in case a subsequent file does not contain all the
+      // runwise objects from the previous file. Keeping this copy would then
+      // integrate the missing object again with the old copy
+      delete runNodeCopy;
+      runNodeCopy = nullptr;
+    }
+    // DLW: move the delete outside the if block to cover the case where isFunctional() fails
     delete IManager;
   }
   // now open the dst node
   dstNode = se->getNode(InputNode.c_str(), topNodeName.c_str());
-  IManager = new PHNodeIOManager(frog.location(filename.c_str()), PHReadOnly);
+  IManager = new PHNodeIOManager(fullfilename, PHReadOnly);
   if (IManager->isFunctional())
-    {
-      isopen = 1;
-      events_thisfile = 0;
-      setBranches(); // set branch selections
-      AddToFileOpened(filename); // add file to the list of files which were opened
-      return 0;
-    }
+  {
+    isopen = 1;
+    events_thisfile = 0;
+    setBranches();              // set branch selections
+    AddToFileOpened(filename);  // add file to the list of files which were opened
+    return 0;
+  }
   else
-    {
-      cout << PHWHERE << ": " << ThisName << " Could not open file "
-           << filename << endl;
-      delete IManager;
-      IManager = 0;
-      return -1;
-    }
+  {
+    cout << PHWHERE << ": " << ThisName << " Could not open file "
+         << filename << endl;
+    delete IManager;
+    IManager = nullptr;
+    return -1;
+  }
 }
 
 int Fun4AllDstInputManager::run(const int nevents)
 {
   if (!isopen)
-    {
-      if (filelist.empty())
+  {
+    if (filelist.empty())
 
-	{
-	  if (verbosity > 0)
-	    {
-	      cout << Name() << ": No Input file open" << endl;
-	    }
-	  return -1;
-        }
-      else
-        {
-          if (OpenNextFile())
-            {
-              cout << Name() << ": No Input file from filelist opened" << endl;
-              return -1;
-            }
-        }
-    }
-  if (verbosity > 3)
     {
-      cout << "Getting Event from " << Name() << endl;
+      if (verbosity > 0)
+      {
+        cout << Name() << ": No Input file open" << endl;
+      }
+      return -1;
     }
- readagain:
+    else
+    {
+      if (OpenNextFile())
+      {
+        cout << Name() << ": No Input file from filelist opened" << endl;
+        return -1;
+      }
+    }
+  }
+  if (verbosity > 3)
+  {
+    cout << "Getting Event from " << Name() << endl;
+  }
+readagain:
   PHCompositeNode *dummy;
   int ncount = 0;
   dummy = IManager->read(dstNode);
   while (dummy)
+  {
+    ncount++;
+    if (nevents > 0 && ncount >= nevents)
     {
-      ncount ++;
-      if (nevents > 0 && ncount >= nevents)
-        {
-          break;
-        }
-      dummy = IManager->read(dstNode);
+      break;
     }
+    dummy = IManager->read(dstNode);
+  }
   if (!dummy)
+  {
+    fileclose();
+    if (!OpenNextFile())
     {
-      fileclose();
-      if (!OpenNextFile())
-        {
-          goto readagain;
-        }
-      return -1;
+      goto readagain;
     }
+    return -1;
+  }
   events_total += ncount;
   events_thisfile += ncount;
   // check if the local SubsysReco discards this event
   if (RejectEvent() != Fun4AllReturnCodes::EVENT_OK)
-    {
-      goto readagain;
-    }
-  syncobject = findNode::getClass<SyncObject>(dstNode,"Sync");
+  {
+    goto readagain;
+  }
+  syncobject = findNode::getClass<SyncObject>(dstNode, "Sync");
   return 0;
 }
 
 int Fun4AllDstInputManager::fileclose()
 {
   if (!isopen)
-    {
-      cout << Name() << ": fileclose: No Input file open" << endl;
-      return -1;
-    }
+  {
+    cout << Name() << ": fileclose: No Input file open" << endl;
+    return -1;
+  }
   delete IManager;
   IManager = 0;
   isopen = 0;
   if (!filelist.empty())
+  {
+    if (repeat)
     {
-      if (repeat)
-        {
-          filelist.push_back(*(filelist.begin()));
-          if (repeat > 0)
-            {
-              repeat--;
-            }
-        }
-      filelist.pop_front();
+      filelist.push_back(*(filelist.begin()));
+      if (repeat > 0)
+      {
+        repeat--;
+      }
     }
+    filelist.pop_front();
+  }
 
   return 0;
 }
 
-int
-Fun4AllDstInputManager::GetSyncObject(SyncObject **mastersync)
+int Fun4AllDstInputManager::GetSyncObject(SyncObject **mastersync)
 {
   // here we copy the sync object from the current file to the
   // location pointed to by mastersync. If mastersync is a 0 pointer
   // the syncobject is cloned. If mastersync allready exists the content
   // of syncobject is copied
   if (!(*mastersync))
-    {
-      if (syncobject) *mastersync = syncobject->clone();
-    }
+  {
+    if (syncobject) *mastersync = syncobject->clone();
+  }
   else
-    {
-      *(*mastersync) = *syncobject; // copy syncobject content
-    }
+  {
+    *(*mastersync) = *syncobject;  // copy syncobject content
+  }
   return Fun4AllReturnCodes::SYNC_OK;
 }
 
-int
-Fun4AllDstInputManager::SyncIt(const SyncObject *mastersync)
+int Fun4AllDstInputManager::SyncIt(const SyncObject *mastersync)
 {
   if (!mastersync)
-    {
-      cout << PHWHERE << Name() << " No MasterSync object, cannot perform synchronization" << endl;
-      cout << "Most likely your first file does not contain a SyncObject and the file" << endl;
-      cout << "opened by the Fun4AllDstInputManager with Name " << Name() << " has one" << endl;
-      cout << "Change your macro and use the file opened by this input manager as first input" << endl;
-      cout << "and you will be okay. Fun4All will not process the current configuration" << endl << endl;
-      return Fun4AllReturnCodes::SYNC_FAIL;
-    }
+  {
+    cout << PHWHERE << Name() << " No MasterSync object, cannot perform synchronization" << endl;
+    cout << "Most likely your first file does not contain a SyncObject and the file" << endl;
+    cout << "opened by the Fun4AllDstInputManager with Name " << Name() << " has one" << endl;
+    cout << "Change your macro and use the file opened by this input manager as first input" << endl;
+    cout << "and you will be okay. Fun4All will not process the current configuration" << endl
+         << endl;
+    return Fun4AllReturnCodes::SYNC_FAIL;
+  }
   int iret = syncobject->Different(mastersync);
-  if (iret) // what to do if files are not in sync
+  if (iret)  // what to do if files are not in sync
+  {
+    if (mastersync->EventNumber() == -999999)  // first file does not contain sync object
     {
-      if (mastersync->EventNumber() == -999999) // first file does not contain sync object
-        {
-          cout << PHWHERE << " Mastersync not filled, your first file does not contain a SyncObject" << endl;
-          cout << "This Event will not be processed further" << endl;
-        }
-      else // okay try to resync here
-        {
-          if (verbosity > 3)
-            {
-              cout << "Need to Resync, mastersync evt no: " << mastersync->EventNumber()
-                   << ", this Event no: " << syncobject->EventNumber() << endl;
-              cout << "mastersync evt counter: " << mastersync->EventCounter()
-                   << ", this Event counter: " << syncobject->EventCounter() << endl;
-              cout << "mastersync run number: " << mastersync->RunNumber()
-                   << ", this run number: " << syncobject->RunNumber() << endl;
-            }
-          while (syncobject->RunNumber() < mastersync->RunNumber())
-
-            {
-              events_skipped_during_sync++;
-              if (verbosity > 2)
-                {
-                  cout << ThisName << " Run Number: " << syncobject->RunNumber()
-                       << ", master: " << mastersync->RunNumber()
-                       << endl;
-                }
-              int iret = ReadNextEventSyncObject();
-              if (iret)
-                {
-                  return iret;
-                }
-            }
-          int igood = 0;
-          if (syncobject->RunNumber() == mastersync->RunNumber())
-            {
-              igood = 1;
-            }
-          // only run up the Segment Number if run numbers are identical
-          while (syncobject->SegmentNumber() < mastersync->SegmentNumber() && igood)
-            {
-              events_skipped_during_sync++;
-              if (verbosity > 2)
-                {
-                  cout << ThisName << " Segment Number: " << syncobject->SegmentNumber()
-                       << ", master: " << mastersync->SegmentNumber()
-                       << endl;
-                }
-              int iret = ReadNextEventSyncObject();
-              if (iret)
-                {
-                  return iret;
-                }
-            }
-          // only run up the Event Counter if run number and segment number are identical
-          if ( syncobject->SegmentNumber() == mastersync->SegmentNumber() && syncobject->RunNumber() == mastersync->RunNumber())
-            {
-              igood = 1;
-            }
-          else
-            {
-              igood = 0;
-            }
-          while (syncobject->EventCounter() < mastersync->EventCounter() && igood)
-            {
-              events_skipped_during_sync++;
-              if (verbosity > 2)
-                {
-                  cout << ThisName
-                       << ", EventCounter: " << syncobject->EventCounter()
-                       << ", master: " << mastersync->EventCounter()
-                       << endl;
-                }
-              int iret = ReadNextEventSyncObject();
-              if (iret)
-                {
-                  return iret;
-                }
-            }
-          // Since up to here we only read the sync object we need to push
-          // the current event back inot the root file (subtract one from the
-          // local root file event counter) so we can read the full event
-          // if it syncs, if it does not sync we also read one event too many
-          // (otherwise we cannot determine that we are "too far")
-          // and also have to push this one back
-          PushBackEvents(1);
-          if (syncobject->RunNumber() > mastersync->RunNumber() ||	// check if run number too large
-              syncobject->EventCounter() > mastersync->EventCounter() ||	// check if event counter too large
-              syncobject->SegmentNumber() > mastersync->SegmentNumber()) // check segment number too large
-            {
-              // the event from first file which determines the mastersync
-              // and which we are trying to find on this file does not exist on this file
-              // so: return failure. This will cause the input managers to read
-              // the next event from the input files file
-              return Fun4AllReturnCodes::SYNC_FAIL;
-            }
-          // Here the event counter and segment number and run number do agree - we found the right match
-          // now read the full event (previously we only read the sync object)
-          PHCompositeNode *dummy;
-          dummy = IManager->read(dstNode);
-          if (!dummy)
-            {
-              cout << PHWHERE << " " << Name() << " Could not read full Event" << endl;
-              cout << "PLEASE NOTIFY PHENIX-OFF-L and post the macro you used" << endl;
-              fileclose();
-              return Fun4AllReturnCodes::SYNC_FAIL;
-            }
-          int iret = syncobject->Different(mastersync); // final check if they really agree
-          if (iret) // if not things are severely wrong
-            {
-              cout << PHWHERE << " MasterSync and SyncObject of " << Name() << " are different" << endl;
-              cout << "This Event will not be processed further, here is some debugging info:" << endl;
-              cout << "PLEASE NOTIFY PHENIX-OFF-L and post the macro you used" << endl;
-              cout << "MasterSync->identify:" << endl;
-              mastersync->identify();
-              cout << Name() << ": SyncObject->identify:" << endl;
-              syncobject->identify();
-              return Fun4AllReturnCodes::SYNC_FAIL;
-            }
-          else if (verbosity > 3)
-            {
-              cout << PHWHERE << " Resynchronization successfull for " << Name() << endl;
-              cout << "MasterSync->identify:" << endl;
-              mastersync->identify();
-              cout << Name() << ": SyncObject->identify:" << endl;
-              syncobject->identify();
-            }
-        }
+      cout << PHWHERE << " Mastersync not filled, your first file does not contain a SyncObject" << endl;
+      cout << "This Event will not be processed further" << endl;
     }
+    else  // okay try to resync here
+    {
+      if (verbosity > 3)
+      {
+        cout << "Need to Resync, mastersync evt no: " << mastersync->EventNumber()
+             << ", this Event no: " << syncobject->EventNumber() << endl;
+        cout << "mastersync evt counter: " << mastersync->EventCounter()
+             << ", this Event counter: " << syncobject->EventCounter() << endl;
+        cout << "mastersync run number: " << mastersync->RunNumber()
+             << ", this run number: " << syncobject->RunNumber() << endl;
+      }
+      while (syncobject->RunNumber() < mastersync->RunNumber())
+
+      {
+        events_skipped_during_sync++;
+        if (verbosity > 2)
+        {
+          cout << ThisName << " Run Number: " << syncobject->RunNumber()
+               << ", master: " << mastersync->RunNumber()
+               << endl;
+        }
+        int iret = ReadNextEventSyncObject();
+        if (iret)
+        {
+          return iret;
+        }
+      }
+      int igood = 0;
+      if (syncobject->RunNumber() == mastersync->RunNumber())
+      {
+        igood = 1;
+      }
+      // only run up the Segment Number if run numbers are identical
+      while (syncobject->SegmentNumber() < mastersync->SegmentNumber() && igood)
+      {
+        events_skipped_during_sync++;
+        if (verbosity > 2)
+        {
+          cout << ThisName << " Segment Number: " << syncobject->SegmentNumber()
+               << ", master: " << mastersync->SegmentNumber()
+               << endl;
+        }
+        int iret = ReadNextEventSyncObject();
+        if (iret)
+        {
+          return iret;
+        }
+      }
+      // only run up the Event Counter if run number and segment number are identical
+      if (syncobject->SegmentNumber() == mastersync->SegmentNumber() && syncobject->RunNumber() == mastersync->RunNumber())
+      {
+        igood = 1;
+      }
+      else
+      {
+        igood = 0;
+      }
+      while (syncobject->EventCounter() < mastersync->EventCounter() && igood)
+      {
+        events_skipped_during_sync++;
+        if (verbosity > 2)
+        {
+          cout << ThisName
+               << ", EventCounter: " << syncobject->EventCounter()
+               << ", master: " << mastersync->EventCounter()
+               << endl;
+        }
+        int iret = ReadNextEventSyncObject();
+        if (iret)
+        {
+          return iret;
+        }
+      }
+      // Since up to here we only read the sync object we need to push
+      // the current event back inot the root file (subtract one from the
+      // local root file event counter) so we can read the full event
+      // if it syncs, if it does not sync we also read one event too many
+      // (otherwise we cannot determine that we are "too far")
+      // and also have to push this one back
+      PushBackEvents(1);
+      if (syncobject->RunNumber() > mastersync->RunNumber() ||        // check if run number too large
+          syncobject->EventCounter() > mastersync->EventCounter() ||  // check if event counter too large
+          syncobject->SegmentNumber() > mastersync->SegmentNumber())  // check segment number too large
+      {
+        // the event from first file which determines the mastersync
+        // and which we are trying to find on this file does not exist on this file
+        // so: return failure. This will cause the input managers to read
+        // the next event from the input files file
+        return Fun4AllReturnCodes::SYNC_FAIL;
+      }
+      // Here the event counter and segment number and run number do agree - we found the right match
+      // now read the full event (previously we only read the sync object)
+      PHCompositeNode *dummy;
+      dummy = IManager->read(dstNode);
+      if (!dummy)
+      {
+        cout << PHWHERE << " " << Name() << " Could not read full Event" << endl;
+        cout << "PLEASE NOTIFY PHENIX-OFF-L and post the macro you used" << endl;
+        fileclose();
+        return Fun4AllReturnCodes::SYNC_FAIL;
+      }
+      int iret = syncobject->Different(mastersync);  // final check if they really agree
+      if (iret)                                      // if not things are severely wrong
+      {
+        cout << PHWHERE << " MasterSync and SyncObject of " << Name() << " are different" << endl;
+        cout << "This Event will not be processed further, here is some debugging info:" << endl;
+        cout << "PLEASE NOTIFY PHENIX-OFF-L and post the macro you used" << endl;
+        cout << "MasterSync->identify:" << endl;
+        mastersync->identify();
+        cout << Name() << ": SyncObject->identify:" << endl;
+        syncobject->identify();
+        return Fun4AllReturnCodes::SYNC_FAIL;
+      }
+      else if (verbosity > 3)
+      {
+        cout << PHWHERE << " Resynchronization successfull for " << Name() << endl;
+        cout << "MasterSync->identify:" << endl;
+        mastersync->identify();
+        cout << Name() << ": SyncObject->identify:" << endl;
+        syncobject->identify();
+      }
+    }
+  }
   //	else
   //		{
   //			cout << "No Need to Resync" << endl;
@@ -409,104 +403,101 @@ Fun4AllDstInputManager::SyncIt(const SyncObject *mastersync)
   return Fun4AllReturnCodes::SYNC_OK;
 }
 
-int
-Fun4AllDstInputManager::ReadNextEventSyncObject()
+int Fun4AllDstInputManager::ReadNextEventSyncObject()
 {
- readnextsync:
+readnextsync:
   static int readfull = 0;
-  if (!IManager) // in case the old file was exhausted and there is no new file opened
+  if (!IManager)  // in case the old file was exhausted and there is no new file opened
+  {
+    return Fun4AllReturnCodes::SYNC_FAIL;
+  }
+  if (syncbranchname.empty())
+  {
+    readfull = 1;  // we need to read a full events to set the root branches to phool nodes right for a new file
+    map<string, TBranch *>::const_iterator bIter;
+    for (bIter = IManager->GetBranchMap()->begin(); bIter != IManager->GetBranchMap()->end(); ++bIter)
     {
+      if (verbosity > 2)
+      {
+        cout << ThisName << ": branch: " << bIter->first << endl;
+      }
+      string::size_type pos = bIter->first.find("/Sync");
+      if (pos != string::npos)  // found it
+      {
+        syncbranchname = bIter->first;
+        break;
+      }
+    }
+    if (syncbranchname.empty())
+    {
+      cout << PHWHERE << "Could not locate Sync Branch" << endl;
+      cout << "Please check for it in the following list of branch names and" << endl;
+      cout << "PLEASE NOTIFY PHENIX-OFF-L and post the macro you used" << endl;
+      for (bIter = IManager->GetBranchMap()->begin(); bIter != IManager->GetBranchMap()->end(); ++bIter)
+      {
+        cout << bIter->first << endl;
+      }
       return Fun4AllReturnCodes::SYNC_FAIL;
     }
-  if (syncbranchname.empty())
-    {
-      readfull = 1; // we need to read a full events to set the root branches to phool nodes right for a new file
-      map<string, TBranch*>::const_iterator bIter;
-      for (bIter = IManager->GetBranchMap()->begin(); bIter != IManager->GetBranchMap()->end(); ++bIter)
-        {
-          if (verbosity > 2)
-            {
-              cout << ThisName << ": branch: " << bIter->first << endl;
-            }
-          string::size_type pos = bIter->first.find("/Sync");
-          if (pos != string::npos) // found it
-            {
-              syncbranchname = bIter->first;
-              break;
-            }
-        }
-      if (syncbranchname.empty())
-        {
-          cout << PHWHERE << "Could not locate Sync Branch" << endl;
-          cout << "Please check for it in the following list of branch names and" << endl;
-          cout << "PLEASE NOTIFY PHENIX-OFF-L and post the macro you used" << endl;
-          for (bIter = IManager->GetBranchMap()->begin(); bIter != IManager->GetBranchMap()->end(); ++bIter)
-            {
-              cout << bIter->first << endl;
-            }
-          return Fun4AllReturnCodes::SYNC_FAIL;
-        }
-    }
+  }
   size_t EventOnDst = 0;
   int itest = 0;
   if (!readfull)
+  {
+    // if all files are exhausted, the IManager is deleted and set to nullptr
+    // so check if IManager is valid before getting a new event
+    if (IManager)
     {
-      // if all files are exhausted, the IManager is deleted and set to nullptr
-      // so check if IManager is valid before getting a new event
-      if (IManager)
-	{
-	  EventOnDst = IManager->getEventNumber(); // this returns the next number of the event
-	  itest = IManager->readSpecific(EventOnDst, syncbranchname.c_str());
-	}
-      else
-	{
-	  if (verbosity > 2)
-	    {
-	      cout << ThisName << ": File exhausted while resyncing" << endl;
-	    }
-	  return Fun4AllReturnCodes::SYNC_FAIL;
-	}
+      EventOnDst = IManager->getEventNumber();  // this returns the next number of the event
+      itest = IManager->readSpecific(EventOnDst, syncbranchname.c_str());
     }
-  else
-    {
-      if (IManager->read(dstNode))
-        {
-          itest = 1;
-        }
-      else
-        {
-          itest = 0;
-        }
-    }
-  if (!itest)
+    else
     {
       if (verbosity > 2)
-        {
-          cout << ThisName << ": File exhausted while resyncing" << endl;
-        }
-      fileclose();
-      if (OpenNextFile())
-        {
-
-          return Fun4AllReturnCodes::SYNC_FAIL;
-        }
-      syncbranchname.clear(); // clear the sync branch name, who knows - it might be different on new file
-      goto readnextsync;
+      {
+        cout << ThisName << ": File exhausted while resyncing" << endl;
+      }
+      return Fun4AllReturnCodes::SYNC_FAIL;
     }
-  if (!readfull)
-    {
-      EventOnDst++;
-      IManager->setEventNumber(EventOnDst); // update event number in phool io manager
-    }
+  }
   else
+  {
+    if (IManager->read(dstNode))
     {
-      readfull = 0;
+      itest = 1;
     }
+    else
+    {
+      itest = 0;
+    }
+  }
+  if (!itest)
+  {
+    if (verbosity > 2)
+    {
+      cout << ThisName << ": File exhausted while resyncing" << endl;
+    }
+    fileclose();
+    if (OpenNextFile())
+    {
+      return Fun4AllReturnCodes::SYNC_FAIL;
+    }
+    syncbranchname.clear();  // clear the sync branch name, who knows - it might be different on new file
+    goto readnextsync;
+  }
+  if (!readfull)
+  {
+    EventOnDst++;
+    IManager->setEventNumber(EventOnDst);  // update event number in phool io manager
+  }
+  else
+  {
+    readfull = 0;
+  }
   return 0;
 }
 
-int
-Fun4AllDstInputManager::BranchSelect(const string &branch, const int iflag)
+int Fun4AllDstInputManager::BranchSelect(const string &branch, const int iflag)
 {
   int myflag = iflag;
   // if iflag > 0 the branch is set to read
@@ -514,145 +505,141 @@ Fun4AllDstInputManager::BranchSelect(const string &branch, const int iflag)
   // if iflag < 0 the branchname is erased from our internal branch read map
   // this does not have any effect on phool yet
   if (myflag < 0)
+  {
+    map<const string, int>::iterator branchiter;
+    branchiter = branchread.find(branch);
+    if (branchiter != branchread.end())
     {
-      map<const string, int>::iterator branchiter;
-      branchiter = branchread.find(branch);
-      if (branchiter != branchread.end())
-        {
-          branchread.erase(branchiter);
-        }
-      return 0;
+      branchread.erase(branchiter);
     }
+    return 0;
+  }
 
   if (myflag > 0)
+  {
+    if (verbosity > 1)
     {
-      if (verbosity > 1)
-        {
-          cout << "Setting Root Tree Branch: " << branch << " to read" << endl;
-        }
-      myflag = 1;
+      cout << "Setting Root Tree Branch: " << branch << " to read" << endl;
     }
+    myflag = 1;
+  }
   else
+  {
+    if (verbosity > 1)
     {
-      if (verbosity > 1)
-        {
-          cout << "Setting Root Tree Branch: " << branch << " to NOT read" << endl;
-        }
+      cout << "Setting Root Tree Branch: " << branch << " to NOT read" << endl;
     }
+  }
   branchread[branch] = myflag;
   return 0;
 }
 
-int
-Fun4AllDstInputManager::setBranches()
+int Fun4AllDstInputManager::setBranches()
 {
   if (IManager)
+  {
+    if (!branchread.empty())
     {
-      if (!branchread.empty())
+      map<const string, int>::const_iterator branchiter;
+      for (branchiter = branchread.begin(); branchiter != branchread.end(); ++branchiter)
+      {
+        IManager->selectObjectToRead(branchiter->first.c_str(), branchiter->second);
+        if (verbosity > 0)
         {
-          map<const string, int>::const_iterator branchiter;
-          for (branchiter = branchread.begin(); branchiter != branchread.end(); ++branchiter)
-            {
-              IManager->selectObjectToRead(branchiter->first.c_str(), branchiter->second);
-              if (verbosity > 0)
-                {
-                  cout << branchiter->first << " set to " << branchiter->second << endl;
-                }
-            }
-          // protection against switching off the sync variables
-          // only implemented in the Sync Manager
-          setSyncBranches(IManager);
+          cout << branchiter->first << " set to " << branchiter->second << endl;
         }
+      }
+      // protection against switching off the sync variables
+      // only implemented in the Sync Manager
+      setSyncBranches(IManager);
     }
+  }
   else
-    {
-      cout << PHWHERE << " " << Name() << ": You can only call this function after a file has been opened" << endl;
-      cout << "Do not worry, the branches will be set as soon as you open a file" << endl;
-      return -1;
-    }
+  {
+    cout << PHWHERE << " " << Name() << ": You can only call this function after a file has been opened" << endl;
+    cout << "Do not worry, the branches will be set as soon as you open a file" << endl;
+    return -1;
+  }
   return 0;
 }
 
-int
-Fun4AllDstInputManager::setSyncBranches(PHNodeIOManager *IManager)
+int Fun4AllDstInputManager::setSyncBranches(PHNodeIOManager *IManager)
 {
   // protection against switching off the sync variables
   for (int i = 0; i < syncdefs::NUM_SYNC_VARS; i++)
-    {
-      IManager->selectObjectToRead(syncdefs::SYNCVARS[i], 1);
-    }
+  {
+    IManager->selectObjectToRead(syncdefs::SYNCVARS[i], 1);
+  }
   return 0;
 }
 
-void
-Fun4AllDstInputManager::Print(const string &what) const
+void Fun4AllDstInputManager::Print(const string &what) const
 {
   if (what == "ALL" || what == "BRANCH")
-    {
-      // loop over the map and print out the content (name and location in memory)
-      cout << "--------------------------------------" << endl << endl;
-      cout << "List of selected branches in Fun4AllDstInputManager " << Name() << ":" << endl;
+  {
+    // loop over the map and print out the content (name and location in memory)
+    cout << "--------------------------------------" << endl
+         << endl;
+    cout << "List of selected branches in Fun4AllDstInputManager " << Name() << ":" << endl;
 
-      map<const string, int>::const_iterator iter;
-      for (iter = branchread.begin(); iter != branchread.end(); ++iter)
-	{
-	  cout << iter->first << " is switched ";
-	  if (iter->second)
-	    {
-	      cout << "ON";
-	    }
-	  else
-	    {
-	      cout << "OFF";
-	    }
-	  cout << endl;
-	}
-    }
-  if ( (what == "ALL" || what == "PHOOL") && IManager)
+    map<const string, int>::const_iterator iter;
+    for (iter = branchread.begin(); iter != branchread.end(); ++iter)
     {
-      // loop over the map and print out the content (name and location in memory)
-      cout << "--------------------------------------" << endl << endl;
-      cout << "PHNodeIOManager print in Fun4AllDstInputManager " << Name() << ":" << endl;
-      IManager->print();
+      cout << iter->first << " is switched ";
+      if (iter->second)
+      {
+        cout << "ON";
+      }
+      else
+      {
+        cout << "OFF";
+      }
+      cout << endl;
     }
+  }
+  if ((what == "ALL" || what == "PHOOL") && IManager)
+  {
+    // loop over the map and print out the content (name and location in memory)
+    cout << "--------------------------------------" << endl
+         << endl;
+    cout << "PHNodeIOManager print in Fun4AllDstInputManager " << Name() << ":" << endl;
+    IManager->print();
+  }
   Fun4AllInputManager::Print(what);
-  return ;
+  return;
 }
 
-int
-Fun4AllDstInputManager::OpenNextFile()
+int Fun4AllDstInputManager::OpenNextFile()
 {
   while (!filelist.empty())
+  {
+    list<string>::const_iterator iter = filelist.begin();
+    if (verbosity)
     {
-      list<string>::const_iterator iter = filelist.begin();
-      if (verbosity)
-        {
-          cout << PHWHERE << " opening next file: " << *iter << endl;
-        }
-      if (fileopen(*iter))
-        {
-          cout << PHWHERE << " could not open file: " << *iter << endl;
-          filelist.pop_front();
-        }
-      else
-        {
-          return 0;
-        }
-
+      cout << PHWHERE << " opening next file: " << *iter << endl;
     }
+    if (fileopen(*iter))
+    {
+      cout << PHWHERE << " could not open file: " << *iter << endl;
+      filelist.pop_front();
+    }
+    else
+    {
+      return 0;
+    }
+  }
   return -1;
 }
 
-int
-Fun4AllDstInputManager::PushBackEvents(const int i)
+int Fun4AllDstInputManager::PushBackEvents(const int i)
 {
   if (IManager)
-    {
-      unsigned EventOnDst = IManager->getEventNumber();
-      EventOnDst -= static_cast<unsigned>(i);
-      IManager->setEventNumber(EventOnDst);
-      return 0;
-    }
+  {
+    unsigned EventOnDst = IManager->getEventNumber();
+    EventOnDst -= static_cast<unsigned>(i);
+    IManager->setEventNumber(EventOnDst);
+    return 0;
+  }
   cout << PHWHERE << ThisName << ": could not push back events, Imanager is NULL"
        << " probably the dst is not open yet (you need to call fileopen or run 1 event for lists)" << endl;
   return -1;

--- a/offline/framework/fun4all/Fun4AllDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.h
@@ -40,6 +40,8 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
   std::string syncbranchname;
   PHCompositeNode *dstNode;
   PHCompositeNode *runNode;
+  PHCompositeNode *runNodeCopy;
+  PHCompositeNode *runNodeSum;
   PHNodeIOManager *IManager;
   SyncObject *syncobject;
 };

--- a/offline/framework/fun4all/Fun4AllDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.h
@@ -3,21 +3,22 @@
 
 #include "Fun4AllInputManager.h"
 
-#include <string>
 #include <map>
+#include <string>
 
 class PHCompositeNode;
 class PHNodeIOManager;
 class SyncObject;
+
 class Fun4AllDstInputManager : public Fun4AllInputManager
 {
  public:
-   Fun4AllDstInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
+  Fun4AllDstInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
   virtual ~Fun4AllDstInputManager();
   int fileopen(const std::string &filenam);
   int fileclose();
   int run(const int nevents = 0);
-  int isOpen() {return isopen;}
+  int isOpen() { return isopen; }
   int GetSyncObject(SyncObject **mastersync);
   int SyncIt(const SyncObject *mastersync);
   int BranchSelect(const std::string &branch, const int iflag);
@@ -34,7 +35,7 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
   int events_total;
   int events_thisfile;
   int events_skipped_during_sync;
-  const char *fname;
+  std::string fullfilename;
   std::string RunNode;
   std::map<const std::string, int> branchread;
   std::string syncbranchname;

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.cc
@@ -1,4 +1,5 @@
 #include "Fun4AllDstOutputManager.h"
+
 #include "Fun4AllServer.h"
 
 #include <phool/PHNode.h>
@@ -39,34 +40,14 @@ Fun4AllDstOutputManager::~Fun4AllDstOutputManager()
 int
 Fun4AllDstOutputManager::AddNode(const string &nodename)
 {
-  string newnode = nodename;
-  vector<string>::const_iterator iter;
-  for (iter = savenodes.begin(); iter != savenodes.end(); ++iter)
-    {
-      if ( *iter == newnode)
-        {
-          cout << "Node " << newnode << " allready in list" << endl;
-          return -1;
-        }
-    }
-  savenodes.push_back(newnode);
+  savenodes.insert(nodename);
   return 0;
 }
 
 int
 Fun4AllDstOutputManager::StripNode(const string &nodename)
 {
-  string newnode = nodename;
-  vector<string>::const_iterator iter;
-  for (iter = stripnodes.begin(); iter != stripnodes.end(); ++iter)
-    {
-      if ( *iter == newnode)
-        {
-          cout << "Node " << newnode << " allready in list" << endl;
-          return -1;
-        }
-    }
-  stripnodes.push_back(newnode);
+  stripnodes.insert(nodename);
   return 0;
 }
 
@@ -93,24 +74,6 @@ Fun4AllDstOutputManager::outfileopen(const string &fname)
   return 0;
 }
 
-int
-Fun4AllDstOutputManager::RemoveNode(const string &nodename)
-{
-  string node = nodename;
-  vector<string>::iterator iter;
-  for (iter = savenodes.begin(); iter != savenodes.end(); ++iter)
-  if ( *iter == node) {
-    savenodes.erase(iter);
-    cout << "Removing " << node << " from list" << endl;
-    return 0;
-  }
-  
-  cout << "Could not find " << node << " in list" << endl;
-  
-  return -1;
-
-}
-
 void
 Fun4AllDstOutputManager::Print(const string &what) const
 {
@@ -126,17 +89,17 @@ Fun4AllDstOutputManager::Print(const string &what) const
             }
           else
             {
-              for (iter = stripnodes.begin(); iter != stripnodes.end(); ++iter)
-                {
-                  cout << ThisName << ": Node " << *iter << " will be stripped" << endl;
-                }
+              BOOST_FOREACH(string nodename, stripnodes)
+	      {
+                  cout << ThisName << ": Node " << nodename << " will be stripped" << endl;
+	      }
             }
         }
       else
         {
-          for (iter = savenodes.begin(); iter != savenodes.end(); ++iter)
+          BOOST_FOREACH(string nodename, savenodes)
             {
-              cout << ThisName << ": Node " << *iter << " is written out" << endl;
+              cout << ThisName << ": Node " << nodename << " is written out" << endl;
             }
         }
     }
@@ -167,9 +130,9 @@ Fun4AllDstOutputManager::Write(PHCompositeNode *startNode)
       se->MakeNodesPersistent(startNode);
       if (! stripnodes.empty())
 	{
-	  for (iter = stripnodes.begin(); iter != stripnodes.end(); ++iter)
+	  BOOST_FOREACH(string nodename, stripnodes)
 	    {
-	      ChosenNode = nodeiter.findFirst("PHIODataNode", iter->c_str());
+	      ChosenNode = nodeiter.findFirst("PHIODataNode", nodename);
 	      if (ChosenNode)
 		{
 		  ChosenNode->makeTransient();
@@ -178,7 +141,7 @@ Fun4AllDstOutputManager::Write(PHCompositeNode *startNode)
 		{
 		  if (verbosity > 0)
 		    {
-		      cout << PHWHERE << ThisName << ": Node " << *iter
+		      cout << PHWHERE << ThisName << ": Node " << nodename
 			   << " does not exist" << endl;
 		    }
 		}
@@ -188,9 +151,9 @@ Fun4AllDstOutputManager::Write(PHCompositeNode *startNode)
     }
   else
     {
-      for (iter = savenodes.begin(); iter != savenodes.end(); ++iter)
+      BOOST_FOREACH(string nodename, savenodes)
         {
-          ChosenNode = nodeiter.findFirst("PHIODataNode", iter->c_str());
+          ChosenNode = nodeiter.findFirst("PHIODataNode", nodename);
           if (ChosenNode)
             {
               ChosenNode->makePersistent();
@@ -199,7 +162,7 @@ Fun4AllDstOutputManager::Write(PHCompositeNode *startNode)
 	    {
 	      if (verbosity > 0)
 		{
-		  cout << PHWHERE << ThisName << ": Node " << *iter 
+		  cout << PHWHERE << ThisName << ": Node " << nodename
 		       << " does not exist" << endl;
 		}
 	    }
@@ -214,9 +177,9 @@ Fun4AllDstOutputManager::Write(PHCompositeNode *startNode)
     }
   else
     {
-      for (iter = savenodes.begin(); iter != savenodes.end(); ++iter)
+          BOOST_FOREACH(string nodename, savenodes)
         {
-          ChosenNode = nodeiter.findFirst("PHIODataNode", iter->c_str());
+          ChosenNode = nodeiter.findFirst("PHIODataNode", nodename);
           if (ChosenNode)
             {
               ChosenNode->makeTransient();

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.cc
@@ -231,7 +231,6 @@ Fun4AllDstOutputManager::WriteNode(PHCompositeNode *thisNode)
 {
   delete dstOut;
   dstOut = new PHNodeIOManager(outfilename.c_str(), PHUpdate, PHRunTree);
-  dstOut->write(thisNode);
   Fun4AllServer *se = Fun4AllServer::instance();
   se->MakeNodesPersistent(thisNode);
   if (! striprunnodes.empty())

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.h
@@ -6,7 +6,6 @@
 
 #include <set>
 #include <string>
-#include <vector>
 
 class PHNodeIOManager;
 class PHCompositeNode;
@@ -22,7 +21,6 @@ class Fun4AllDstOutputManager: public Fun4AllOutputManager
   int StripNode(const std::string  &nodename);
   int StripRunNode(const std::string  &nodename);
   int outfileopen(const std::string &fname);
-  int RemoveNode(const std::string &nodename);
 
   void Print(const std::string &what = "ALL") const;
 
@@ -30,8 +28,8 @@ class Fun4AllDstOutputManager: public Fun4AllOutputManager
   int WriteNode(PHCompositeNode *thisNode);
 
  protected:
-  std::vector <std::string> savenodes;
-  std::vector <std::string> stripnodes;
+  std::set <std::string> savenodes;
+  std::set <std::string> stripnodes;
   std::set <std::string> striprunnodes;
   PHNodeIOManager *dstOut;
 };

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.h
@@ -1,6 +1,5 @@
-#ifndef __FUN4ALLDSTOUTPUTMANAGER_H__
-#define __FUN4ALLDSTOUTPUTMANAGER_H__
-
+#ifndef FUN4ALLDSTOUTPUTMANAGER_H__
+#define FUN4ALLDSTOUTPUTMANAGER_H__
 
 #include "Fun4AllOutputManager.h"
 
@@ -10,16 +9,15 @@
 class PHNodeIOManager;
 class PHCompositeNode;
 
-class Fun4AllDstOutputManager: public Fun4AllOutputManager
+class Fun4AllDstOutputManager : public Fun4AllOutputManager
 {
  public:
-
-  Fun4AllDstOutputManager(const std::string &myname = "DSTOUT" , const std::string &filename = "dstout.root");
+  Fun4AllDstOutputManager(const std::string &myname = "DSTOUT", const std::string &filename = "dstout.root");
   virtual ~Fun4AllDstOutputManager();
 
-  int AddNode(const std::string  &nodename);
-  int StripNode(const std::string  &nodename);
-  int StripRunNode(const std::string  &nodename);
+  int AddNode(const std::string &nodename);
+  int StripNode(const std::string &nodename);
+  int StripRunNode(const std::string &nodename);
   int outfileopen(const std::string &fname);
 
   void Print(const std::string &what = "ALL") const;
@@ -28,10 +26,10 @@ class Fun4AllDstOutputManager: public Fun4AllOutputManager
   int WriteNode(PHCompositeNode *thisNode);
 
  protected:
-  std::set <std::string> savenodes;
-  std::set <std::string> stripnodes;
-  std::set <std::string> striprunnodes;
+  std::set<std::string> savenodes;
+  std::set<std::string> stripnodes;
+  std::set<std::string> striprunnodes;
   PHNodeIOManager *dstOut;
 };
 
-#endif /* __FUN4ALLDSTOUTPUTMANAGER_H__ */
+#endif /* FUN4ALLDSTOUTPUTMANAGER_H__ */

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.h
@@ -3,6 +3,8 @@
 
 
 #include "Fun4AllOutputManager.h"
+
+#include <set>
 #include <string>
 #include <vector>
 
@@ -18,6 +20,7 @@ class Fun4AllDstOutputManager: public Fun4AllOutputManager
 
   int AddNode(const std::string  &nodename);
   int StripNode(const std::string  &nodename);
+  int StripRunNode(const std::string  &nodename);
   int outfileopen(const std::string &fname);
   int RemoveNode(const std::string &nodename);
 
@@ -29,6 +32,7 @@ class Fun4AllDstOutputManager: public Fun4AllOutputManager
  protected:
   std::vector <std::string> savenodes;
   std::vector <std::string> stripnodes;
+  std::set <std::string> striprunnodes;
   PHNodeIOManager *dstOut;
 };
 

--- a/offline/framework/fun4all/Fun4AllOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllOutputManager.cc
@@ -7,34 +7,32 @@
 
 using namespace std;
 
-Fun4AllOutputManager::Fun4AllOutputManager(const string &name ): Fun4AllBase(name)
+Fun4AllOutputManager::Fun4AllOutputManager(const string &name)
+  : Fun4AllBase(name)
+  , nEvents(0)
 {
-  nEvents = 0;
-  return ;
 }
 
 //___________________________________________________________________
-int 
-Fun4AllOutputManager::AddEventSelector(const string &recomodule)
+int Fun4AllOutputManager::AddEventSelector(const string &recomodule)
 {
   string newselector = recomodule;
   vector<string>::iterator iter;
 
   for (iter = EventSelectors.begin(); iter != EventSelectors.end(); ++iter)
-    if ( *iter == newselector)
-      {
-	cout << "Event Selector " << newselector << " allready in list" << endl;
-            return -1;
-      }
-  
+    if (*iter == newselector)
+    {
+      cout << "Event Selector " << newselector << " allready in list" << endl;
+      return -1;
+    }
+
   cout << "EventSelector: " << &EventSelectors << endl;
   EventSelectors.push_back(newselector);
   return 0;
 }
 
 //___________________________________________________________________
-int 
-Fun4AllOutputManager::WriteGeneric(PHCompositeNode *startNode)
+int Fun4AllOutputManager::WriteGeneric(PHCompositeNode *startNode)
 {
   nEvents++;
   int iret = Write(startNode);
@@ -42,35 +40,33 @@ Fun4AllOutputManager::WriteGeneric(PHCompositeNode *startNode)
 }
 
 //___________________________________________________________________
-void
-Fun4AllOutputManager::Print(const string &what) const
+void Fun4AllOutputManager::Print(const string &what) const
 {
   if (what == "ALL" || what == "EVENTSELECTOR")
+  {
+    unsigned icnt = 0;
+    for (vector<string>::const_iterator iter = EventSelectors.begin(); iter != EventSelectors.end(); ++iter)
     {
-      unsigned icnt = 0;
-      for ( vector<string>::const_iterator iter = EventSelectors.begin(); iter != EventSelectors.end(); ++iter)
-	{
-	  cout << ThisName << ": Reco Module " << *iter << " select Events" << endl;
-	  cout << ThisName << ": Reco Module Index: " << recomoduleindex[icnt] << endl;
-	  icnt++;
-	}
+      cout << ThisName << ": Reco Module " << *iter << " select Events" << endl;
+      cout << ThisName << ": Reco Module Index: " << recomoduleindex[icnt] << endl;
+      icnt++;
     }
+  }
   if (what == "ALL" || what == "EVENTSWRITTEN")
-    {
-      cout << ThisName << " wrote " << EventsWritten() << " Events" << endl;
-    }
+  {
+    cout << ThisName << " wrote " << EventsWritten() << " Events" << endl;
+  }
   return;
 }
 
 //___________________________________________________________________
-int 
-Fun4AllOutputManager::DoNotWriteEvent(vector <int> *retcodes) const
+int Fun4AllOutputManager::DoNotWriteEvent(vector<int> *retcodes) const
 {
   int iret = 0;
-  for( vector<unsigned>::const_iterator iter = recomoduleindex.begin(); iter != recomoduleindex.end(); ++iter) {
+  for (vector<unsigned>::const_iterator iter = recomoduleindex.begin(); iter != recomoduleindex.end(); ++iter)
+  {
     const unsigned index = *iter;
     iret += (*retcodes)[index];
   }
   return iret;
 }
-

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -3,33 +3,39 @@
 
 #include "Fun4AllBase.h"
 
-#include <vector>
 #include <string>
+#include <vector>
 
 class PHCompositeNode;
 
-class Fun4AllOutputManager: public Fun4AllBase
+class Fun4AllOutputManager : public Fun4AllBase
 {
  public:
-
   //! destructor
-  virtual ~Fun4AllOutputManager() 
-  {}
+  virtual ~Fun4AllOutputManager()
+  {
+  }
 
   //! print method (dump event selector)
   virtual void Print(const std::string &what = "ALL") const;
 
   //! add a node in outputmanager
-  virtual int AddNode(const std::string& /*nodename*/)
-  { return 0; }
+  virtual int AddNode(const std::string & /*nodename*/)
+  {
+    return 0;
+  }
 
   //! not write a node in outputmanager
-  virtual int StripNode(const std::string& /*nodename*/)
-  { return 0; }
+  virtual int StripNode(const std::string & /*nodename*/)
+  {
+    return 0;
+  }
 
   //! not write a runwise node in outputmanager
-  virtual int StripRunNode(const std::string& /*nodename*/)
-  { return 0; }
+  virtual int StripRunNode(const std::string & /*nodename*/)
+  {
+    return 0;
+  }
 
   /*! \brief
     add an event selector to the outputmanager.
@@ -39,53 +45,60 @@ class Fun4AllOutputManager: public Fun4AllBase
   virtual int AddEventSelector(const std::string &recomodule);
 
   //! opens output file
-  virtual int outfileopen(const std::string& /*nodename*/)
-  { return 0; }
+  virtual int outfileopen(const std::string & /*nodename*/)
+  {
+    return 0;
+  }
 
   //! Common method, called before calling virtual Write
   int WriteGeneric(PHCompositeNode *startNode);
 
   //! write starting from given node
-  virtual int Write(PHCompositeNode* /*startNode*/)
-  { return 0; }
+  virtual int Write(PHCompositeNode * /*startNode*/)
+  {
+    return 0;
+  }
 
   //! write specified node
-  virtual int WriteNode(PHCompositeNode* /*thisNode*/)
-  { return 0; }
-  
+  virtual int WriteNode(PHCompositeNode * /*thisNode*/)
+  {
+    return 0;
+  }
+
   //! retrieves pointer to vector of event selector module names
-  virtual std::vector <std::string> *EventSelector() 
-  {return &EventSelectors;}
-  
+  virtual std::vector<std::string> *EventSelector()
+  {
+    return &EventSelectors;
+  }
+
   //! retrieves pointer to vector of event selector module ids
-  virtual std::vector <unsigned> *RecoModuleIndex()
-  {return &recomoduleindex;}
-  
+  virtual std::vector<unsigned> *RecoModuleIndex()
+  {
+    return &recomoduleindex;
+  }
+
   //! decides if event is to be written or not
-  virtual int DoNotWriteEvent(std::vector <int> *retcodes) const;
+  virtual int DoNotWriteEvent(std::vector<int> *retcodes) const;
 
   //! get number of Events
-  virtual size_t EventsWritten() const {return nEvents;}
-
+  virtual size_t EventsWritten() const { return nEvents; }
   //! get output file name
-  virtual std::string OutFileName() const {return outfilename;}
-
+  virtual std::string OutFileName() const { return outfilename; }
  protected:
-
   /*! 
     constructor.
     is protected since we do not want the  class to be created in root macros
   */
-  Fun4AllOutputManager(const std::string &myname );
+  Fun4AllOutputManager(const std::string &myname);
 
   //! Number of Events
   size_t nEvents;
-  
+
   //! vector of event selectors modules
-  std::vector <std::string> EventSelectors;
+  std::vector<std::string> EventSelectors;
 
   //! vector of associated module indexes
-  std::vector <unsigned> recomoduleindex;
+  std::vector<unsigned> recomoduleindex;
 
   //! output file name
   std::string outfilename;

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -27,6 +27,10 @@ class Fun4AllOutputManager: public Fun4AllBase
   virtual int StripNode(const std::string& /*nodename*/)
   { return 0; }
 
+  //! not write a runwise node in outputmanager
+  virtual int StripRunNode(const std::string& /*nodename*/)
+  { return 0; }
+
   /*! \brief
     add an event selector to the outputmanager.
     event will get written only if all event selectors process_event method

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -42,10 +42,6 @@ class Fun4AllOutputManager: public Fun4AllBase
   virtual int outfileopen(const std::string& /*nodename*/)
   { return 0; }
 
-  //! removes a node from outputmanager
-  virtual int RemoveNode(const std::string& /*nodename*/)
-  { return 0; }
-
   //! Common method, called before calling virtual Write
   int WriteGeneric(PHCompositeNode *startNode);
 

--- a/offline/framework/phool/Makefile.am
+++ b/offline/framework/phool/Makefile.am
@@ -24,6 +24,7 @@ libphool_la_SOURCES = \
   PHMessage.cc \
   PHNode.cc \
   PHNodeIOManager.cc \
+  PHNodeIntegrate.cc \
   PHNodeIterator.cc \
   PHNodeReset.cc \
   PHObject.cc \
@@ -45,6 +46,7 @@ pkginclude_HEADERS =  \
   PHIOManager.h \
   PHNode.h \
   PHNodeIOManager.h \
+  PHNodeIntegrate.h \
   PHNodeOperation.h \
   PHNodeReset.h \
   PHNodeIterator.h \

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -3,23 +3,23 @@
 
 #include "PHNodeIOManager.h"
 #include "PHCompositeNode.h"
-#include "PHNodeIterator.h"
 #include "PHIODataNode.h"
+#include "PHNodeIterator.h"
 #include "PHObject.h"
 #include "phool.h"
 #include "phooldefs.h"
 
-#include <TFile.h>
-#include <TTree.h>
-#include <TBranchObject.h>
-#include <TObject.h>
-#include <TLeafObject.h>
-#include <TClass.h>
-#include <TROOT.h>
 #include <RVersion.h>
+#include <TBranchObject.h>
+#include <TClass.h>
+#include <TFile.h>
+#include <TLeafObject.h>
+#include <TObject.h>
+#include <TROOT.h>
+#include <TTree.h>
 
 // ROOT version taken from RVersion.h
-#if ROOT_VERSION_CODE >= ROOT_VERSION(3,01,5)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(3, 01, 5)
 #include <TBranchElement.h>
 #endif
 
@@ -33,56 +33,57 @@
 
 using namespace std;
 
-PHNodeIOManager::PHNodeIOManager ():
-  file(NULL),
-  tree(NULL),
-  TreeName("T"),
-  bufSize(0),
-  split(0),
-  accessMode(PHReadOnly),
-  CompressionLevel(3),
-  isFunctionalFlag(0)
-{}
+PHNodeIOManager::PHNodeIOManager()
+  : file(nullptr)
+  , tree(nullptr)
+  , TreeName("T")
+  , bufSize(0)
+  , split(0)
+  , accessMode(PHReadOnly)
+  , CompressionLevel(3)
+  , isFunctionalFlag(0)
+{
+}
 
-PHNodeIOManager::PHNodeIOManager (const string& f,
-                                  const PHAccessType a):
-  file(NULL),
-  tree(NULL),
-  TreeName("T"),
-  CompressionLevel(3)
+PHNodeIOManager::PHNodeIOManager(const string& f,
+                                 const PHAccessType a)
+  : file(nullptr)
+  , tree(nullptr)
+  , TreeName("T")
+  , CompressionLevel(3)
 {
   isFunctionalFlag = setFile(f, "titled by PHOOL", a) ? 1 : 0;
 }
 
-PHNodeIOManager::PHNodeIOManager (const string& f, const string& title,
-                                  const PHAccessType a):
-  file(NULL),
-  tree(NULL),
-  TreeName("T"),
-  CompressionLevel(3)
+PHNodeIOManager::PHNodeIOManager(const string& f, const string& title,
+                                 const PHAccessType a)
+  : file(nullptr)
+  , tree(nullptr)
+  , TreeName("T")
+  , CompressionLevel(3)
 {
-  isFunctionalFlag = setFile(f, title , a) ? 1 : 0;
+  isFunctionalFlag = setFile(f, title, a) ? 1 : 0;
 }
 
-PHNodeIOManager::PHNodeIOManager (const string& f, const PHAccessType a,
-                                  const PHTreeType treeindex):
-  file(NULL),
-  tree(NULL),
-  TreeName("T"),
-  CompressionLevel(3)
+PHNodeIOManager::PHNodeIOManager(const string& f, const PHAccessType a,
+                                 const PHTreeType treeindex)
+  : file(nullptr)
+  , tree(nullptr)
+  , TreeName("T")
+  , CompressionLevel(3)
 {
   if (treeindex != PHEventTree)
-    {
-      ostringstream temp;
-      temp << TreeName << treeindex; // create e.g. T1
-      TreeName = temp.str();
-    }
-  isFunctionalFlag = setFile(f, "titled by PHOOL" , a) ? 1 : 0;
+  {
+    ostringstream temp;
+    temp << TreeName << treeindex;  // create e.g. T1
+    TreeName = temp.str();
+  }
+  isFunctionalFlag = setFile(f, "titled by PHOOL", a) ? 1 : 0;
 }
 
-PHNodeIOManager::~PHNodeIOManager ()
+PHNodeIOManager::~PHNodeIOManager()
 {
-  closeFile ();
+  closeFile();
   //   if (tree)
   //     {
   //       tree->Delete();
@@ -90,75 +91,74 @@ PHNodeIOManager::~PHNodeIOManager ()
   delete file;
 }
 
-void
-PHNodeIOManager::closeFile ()
+void PHNodeIOManager::closeFile()
 {
   if (file)
+  {
+    if (accessMode == PHWrite || accessMode == PHUpdate)
     {
-      if (accessMode == PHWrite || accessMode == PHUpdate)
-        {
-          file->Write();
-        }
-      file->Close();
+      file->Write();
     }
+    file->Close();
+  }
 }
 
 PHBoolean
-PHNodeIOManager::setFile (const string& f, const string& title,
-                          const PHAccessType a)
+PHNodeIOManager::setFile(const string& f, const string& title,
+                         const PHAccessType a)
 {
   filename = f;
   bufSize = 32000;
   split = 0;
   accessMode = a;
   if (file)
+  {
+    if (file->IsOpen())
     {
-      if (file->IsOpen())
-	{
-          closeFile();
-	}
-      delete file;
-      file = 0;
+      closeFile();
     }
+    delete file;
+    file = 0;
+  }
   string currdir = gDirectory->GetPath();
   gROOT->cd();
   switch (accessMode)
+  {
+  case PHWrite:
+    file = TFile::Open(filename.c_str(), "RECREATE", title.c_str());
+    if (!file)
     {
-    case PHWrite:
-      file = TFile::Open(filename.c_str(), "RECREATE", title.c_str());
-      if (!file)
-        {
-          return False;
-        }
-      file ->SetCompressionLevel(CompressionLevel);
-      tree = new TTree(TreeName.c_str(), title.c_str());
-      tree->SetMaxTreeSize(900000000000LL); // set max size to ~900 GB
-      gROOT->cd(currdir.c_str());
-      return True;
-      break;
-    case PHReadOnly:
-      file = TFile::Open(filename.c_str());
-      tree = 0;
-      if (!file)
-        {
-          return False;
-        }
-      selectObjectToRead("*", true);
-      gROOT->cd(currdir.c_str());
-      return True;
-      break;
-    case PHUpdate:
-      file = TFile::Open(filename.c_str(), "UPDATE", title.c_str());
-      if (!file)
-        {
-          return False;
-        }
-      file ->SetCompressionLevel(CompressionLevel);
-      tree = new TTree(TreeName.c_str(), title.c_str());
-      gROOT->cd(currdir.c_str());
-      return True;
-      break;
+      return False;
     }
+    file->SetCompressionLevel(CompressionLevel);
+    tree = new TTree(TreeName.c_str(), title.c_str());
+    tree->SetMaxTreeSize(900000000000LL);  // set max size to ~900 GB
+    gROOT->cd(currdir.c_str());
+    return True;
+    break;
+  case PHReadOnly:
+    file = TFile::Open(filename.c_str());
+    tree = 0;
+    if (!file)
+    {
+      return False;
+    }
+    selectObjectToRead("*", true);
+    gROOT->cd(currdir.c_str());
+    return True;
+    break;
+  case PHUpdate:
+    file = TFile::Open(filename.c_str(), "UPDATE", title.c_str());
+    if (!file)
+    {
+      return False;
+    }
+    file->SetCompressionLevel(CompressionLevel);
+    tree = new TTree(TreeName.c_str(), title.c_str());
+    gROOT->cd(currdir.c_str());
+    return True;
+    break;
+  }
 
   return False;
 }
@@ -172,16 +172,15 @@ PHNodeIOManager::write(PHCompositeNode* topNode)
   // Root-branch corresponding to the data of each PHRootIODataNode.
   topNode->write(this);
 
-
   // Now all PHRootIODataNodes should have called the write function
   // of this I/O-manager and thus created their branch. The tree can
   // be filled.
   if (file && tree)
-    {
-      tree->Fill();
-      eventNumber++;
-      return True;
-    }
+  {
+    tree->Fill();
+    eventNumber++;
+    return True;
+  }
 
   return False;
 }
@@ -190,133 +189,128 @@ PHBoolean
 PHNodeIOManager::write(TObject** data, const string& path)
 {
   if (file && tree)
+  {
+    TBranch* thisBranch = tree->GetBranch(path.c_str());
+    if (!thisBranch)
     {
-      TBranch *thisBranch = tree->GetBranch(path.c_str());
-      if (!thisBranch)
-        {
-          // Here is were we decide how to save the data in the root
-          // tree. split=0(prior to Root3.01/05; needs -1 afterwards
-          // for classes with custom streamers, as our old PHTable(s))
-          // means data are hidden, interactive T->draw() will not
-          // work. The old wrapped tables seem to need that, with
-          // split = 1 they cannot be read back.  The new PHObjects
-          // can be saved either way, but split = 1 makes interactive
-          // display possible.
-          split = 99;
-          if ((*data)->InheritsFrom("PHObject"))
-            {
-	      PHObject *phob = dynamic_cast<PHObject *> (*data);
-	      split = phob->SplitLevel();
-	      bufSize = phob->BufferSize();
-	    }
-          tree->Branch(path.c_str(), (*data)->ClassName(),
-                                    data, bufSize, split);
-        }
-      else
-        {
-          thisBranch->SetAddress(data);
-        }
-      return True;
+      // Here is were we decide how to save the data in the root
+      // tree. split=0(prior to Root3.01/05; needs -1 afterwards
+      // for classes with custom streamers, as our old PHTable(s))
+      // means data are hidden, interactive T->draw() will not
+      // work. The old wrapped tables seem to need that, with
+      // split = 1 they cannot be read back.  The new PHObjects
+      // can be saved either way, but split = 1 makes interactive
+      // display possible.
+      split = 99;
+      if ((*data)->InheritsFrom("PHObject"))
+      {
+        PHObject* phob = dynamic_cast<PHObject*>(*data);
+        split = phob->SplitLevel();
+        bufSize = phob->BufferSize();
+      }
+      tree->Branch(path.c_str(), (*data)->ClassName(),
+                   data, bufSize, split);
     }
+    else
+    {
+      thisBranch->SetAddress(data);
+    }
+    return True;
+  }
 
   return False;
 }
-
 
 PHBoolean
 PHNodeIOManager::read(size_t requestedEvent)
 {
   if (readEventFromFile(requestedEvent))
-    {
-      return True;
-    }
+  {
+    return True;
+  }
   else
-    {
-      return False;
-    }
+  {
+    return False;
+  }
 }
 
 PHCompositeNode*
 PHNodeIOManager::read(PHCompositeNode* topNode, size_t requestedEvent)
 {
-
   // No tree means we have not yet looked at the file,
   // so we'll reconstruct the node tree now.
   if (!tree)
-    {
-      topNode = reconstructNodeTree(topNode);
-    }
+  {
+    topNode = reconstructNodeTree(topNode);
+  }
 
   // If everything worked, there should be a tree now.
   if (tree && readEventFromFile(requestedEvent))
-    {
-      return topNode;
-    }
+  {
+    return topNode;
+  }
   else
-    {
-     return 0;
-    }
+  {
+    return 0;
+  }
 }
 
-
-void
-PHNodeIOManager::print() const
+void PHNodeIOManager::print() const
 {
   if (file)
+  {
+    if (accessMode == PHReadOnly)
     {
-      if (accessMode == PHReadOnly)
-	{
-	  cout << "PHNodeIOManager reading  " << filename << endl;
-	}
-      else
-	{
-	  cout << "PHNodeIOManager writing  " << filename << endl;
-	}
+      cout << "PHNodeIOManager reading  " << filename << endl;
     }
+    else
+    {
+      cout << "PHNodeIOManager writing  " << filename << endl;
+    }
+  }
   if (file && tree)
-    {
-      tree->Print();
-    }
+  {
+    tree->Print();
+  }
   cout << "\n\nList of selected objects to read:" << endl;
   map<string, PHBoolean>::const_iterator classiter;
   for (classiter = objectToRead.begin(); classiter != objectToRead.end(); ++classiter)
-    {
-      cout << classiter->first << " is set to " << classiter->second << endl;
-    }
+  {
+    cout << classiter->first << " is set to " << classiter->second << endl;
+  }
 }
 
 string
 PHNodeIOManager::getBranchClassName(TBranch* branch)
 {
-  // OK. Here all the game is to find out the name of the type
-  // contained in this branch.  In ROOT pre-3.01/05 versions, all
-  // branches we used were of the same type = TBranchObject, so that
-  // was easy.  Since version 3.01/05 ROOT introduced new branch style
-  // with some TBranchElement objects. So far so good.  The problem is
-  // that I did not find a common way to grab the typename of the
-  // object contained in those branches, so I hereby use some durty if
-  // { } else if { } ...
+// OK. Here all the game is to find out the name of the type
+// contained in this branch.  In ROOT pre-3.01/05 versions, all
+// branches we used were of the same type = TBranchObject, so that
+// was easy.  Since version 3.01/05 ROOT introduced new branch style
+// with some TBranchElement objects. So far so good.  The problem is
+// that I did not find a common way to grab the typename of the
+// object contained in those branches, so I hereby use some durty if
+// { } else if { } ...
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(3,01,5)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(3, 01, 5)
   TBranchElement* be = dynamic_cast<TBranchElement*>(branch);
 
   if (be)
-    {
-      // TBranchElement has a nice GetClassName() method for us :
-      return be->GetClassName();
-    }
+  {
+    // TBranchElement has a nice GetClassName() method for us :
+    return be->GetClassName();
+  }
 #endif
 
   TBranchObject* bo = dynamic_cast<TBranchObject*>(branch);
   if (bo)
-    {
-      // For this one we need to go down a little before getting the
-      // name...
-      TLeafObject* leaf = static_cast<TLeafObject*>
-	(branch->GetLeaf(branch->GetName()));
-      assert(leaf != 0);
-      return leaf->GetTypeName();
-    }
+  {
+    // For this one we need to go down a little before getting the
+    // name...
+    TLeafObject* leaf = static_cast<TLeafObject*>(branch->GetLeaf(branch->GetName()));
+    assert(leaf != 0);
+    return leaf->GetTypeName();
+  }
   cout << PHWHERE << "Fatal error, dynamic cast of TBranchObject failed" << endl;
   exit(1);
 }
@@ -327,11 +321,11 @@ PHNodeIOManager::readEventFromFile(size_t requestedEvent)
   // Se non c'e niente, non possiamo fare niente.  Logisch, n'est ce
   // pas?
   if (!tree)
-    {
-      PHMessage("PHNodeIOManager::readEventFromFile", PHError,
-                "Tree not initialized.");
-      return False;
-    }
+  {
+    PHMessage("PHNodeIOManager::readEventFromFile", PHError,
+              "Tree not initialized.");
+    return False;
+  }
 
   int bytesRead;
 
@@ -340,38 +334,37 @@ PHNodeIOManager::readEventFromFile(size_t requestedEvent)
   // otherwise mixing of reading 2.25/03 DST with writing some
   // 3.01/05 trees will fail.
   string currdir = gDirectory->GetPath();
-  TFile* file_ptr = gFile; // save current gFile
+  TFile* file_ptr = gFile;  // save current gFile
   file->cd();
 
   if (requestedEvent)
+  {
+    if ((bytesRead = tree->GetEvent(requestedEvent)))
     {
-      if ((bytesRead = tree->GetEvent(requestedEvent)))
-        {
-          eventNumber = requestedEvent + 1;
-        }
+      eventNumber = requestedEvent + 1;
     }
+  }
   else
-    {
-      bytesRead = tree->GetEvent(eventNumber++);
-    }
+  {
+    bytesRead = tree->GetEvent(eventNumber++);
+  }
 
-  gFile = file_ptr; // recover gFile
+  gFile = file_ptr;  // recover gFile
   gROOT->cd(currdir.c_str());
-   
+
   if (!bytesRead)
-    {
-      return False;
-    }
+  {
+    return False;
+  }
   if (bytesRead == -1)
-    {
-      cout << PHWHERE << "Error: Input TTree corrupt, exiting now" << endl;
-      exit(1);
-    }
+  {
+    cout << PHWHERE << "Error: Input TTree corrupt, exiting now" << endl;
+    exit(1);
+  }
   return True;
 }
 
-int
-PHNodeIOManager::readSpecific(size_t requestedEvent, const char* objectName)
+int PHNodeIOManager::readSpecific(size_t requestedEvent, const char* objectName)
 {
   // objectName should be one of the valid branch name of the "T" TTree, and
   // should be one of the branches selected by selectObjectToRead() method.
@@ -380,45 +373,45 @@ PHNodeIOManager::readSpecific(size_t requestedEvent, const char* objectName)
   map<string, TBranch*>::const_iterator p = fBranches.find(name);
 
   if (p != fBranches.end())
+  {
+    TBranch* branch = p->second;
+    if (branch)
     {
-      TBranch* branch = p->second;
-      if (branch)
-        {
-          return branch->GetEvent(requestedEvent);
-        }
+      return branch->GetEvent(requestedEvent);
     }
+  }
   else
-    {
-      PHMessage("PHNodeIOManager::readSpecific", PHError,
-                "Unknown object name");
-    }
+  {
+    PHMessage("PHNodeIOManager::readSpecific", PHError,
+              "Unknown object name");
+  }
   return 0;
 }
 
 PHCompositeNode*
 PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
 {
-  if (! file)
+  if (!file)
+  {
+    if (filename.empty())
     {
-      if (filename.empty())
-	{
-	  cout << PHWHERE << "filename was never set" << endl;
-	}
-      else
-	{
-	  cout << PHWHERE << "TFile " << filename << " NULL pointer" << endl;
-	}
-      return NULL;
+      cout << PHWHERE << "filename was never set" << endl;
     }
+    else
+    {
+      cout << PHWHERE << "TFile " << filename << " NULL pointer" << endl;
+    }
+    return nullptr;
+  }
 
   tree = static_cast<TTree*>(file->Get(TreeName.c_str()));
 
   if (!tree)
-    {
-      cout << PHWHERE << "PHNodeIOManager::reconstructNodeTree : Root Tree "
-	   << TreeName << " not found in file " << file->GetName() << endl;
-      return NULL;
-    }
+  {
+    cout << PHWHERE << "PHNodeIOManager::reconstructNodeTree : Root Tree "
+         << TreeName << " not found in file " << file->GetName() << endl;
+    return nullptr;
+  }
 
   // ROOT sucks, we need a unique name for the tree so we can open multiple
   // files. So we take the memory location of the file pointer which
@@ -426,147 +419,142 @@ PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
   ostringstream nname;
   nname << TreeName << file;
 
-
   tree->SetName(nname.str().c_str());
 
   // Select the branches according to objectToRead
   map<string, PHBoolean>::const_iterator it;
 
   if (tree->GetNbranches() > 0)
+  {
+    for (it = objectToRead.begin(); it != objectToRead.end(); ++it)
     {
-      for (it = objectToRead.begin(); it != objectToRead.end(); ++it)
-	{
-	  tree->SetBranchStatus((it->first).c_str(),
-				static_cast<bool>(it->second));
-	}
+      tree->SetBranchStatus((it->first).c_str(),
+                            static_cast<bool>(it->second));
     }
+  }
   // The file contains a TTree with a list of the TBranchObjects
   // attached to it.
-  TObjArray *branchArray = tree->GetListOfBranches();
+  TObjArray* branchArray = tree->GetListOfBranches();
 
   // We need these in the loops down below...
   size_t i, j;
 
   // If a topNode was provided, we can feed the iterator with it.
   if (!topNode)
-    {
-      topNode = new PHCompositeNode("TOP"); // create topNode if we got a null pointer
-    }
+  {
+    topNode = new PHCompositeNode("TOP");  // create topNode if we got a null pointer
+  }
   PHNodeIterator nodeIter(topNode);
 
   // Loop over all branches in the tree. Each branch-name contains the
   // full 'path' of composite-nodes in the original node tree. We
   // split the name and reconstruct the tree.
-  string delimeters = phooldefs::branchpathdelim + "/"; // add old backslash for backward compat
+  string delimeters = phooldefs::branchpathdelim + "/";  // add old backslash for backward compat
   for (i = 0; i < (size_t)(branchArray->GetEntriesFast()); i++)
+  {
+    string branchname = (*branchArray)[i]->GetName();
+    vector<string> splitvec;
+    boost::split(splitvec, branchname, boost::is_any_of(delimeters));
+    for (size_t ia = 1; ia < splitvec.size() - 1; ia++)  // -1 so we skip the node name
     {
-      string branchname = (*branchArray)[i]->GetName();
-      vector<string> splitvec;
-      boost::split(splitvec, branchname, boost::is_any_of(delimeters));
-      for (size_t ia = 1; ia< splitvec.size()-1; ia++) // -1 so we skip the node name
-       	{
-	  if (!nodeIter.cd(splitvec[ia]))
-	    {
-	      nodeIter.addNode(new PHCompositeNode(splitvec[ia]));
-	      nodeIter.cd(splitvec[ia]);
-	    }
-       	}
-      TBranch *thisBranch = (TBranch*)((*branchArray)[i]);
-
-      // Skip non-selected branches
-      if (thisBranch->TestBit(kDoNotProcess))
-        {
-          continue;
-        }
-
-      string branchClassName = getBranchClassName(thisBranch);
-      string branchName = thisBranch->GetName();
-      fBranches[branchName] = thisBranch;
-
-      assert(gROOT != 0);
-      TClass* thisClass = gROOT->GetClass(branchClassName.c_str());
-
-      if (!thisClass)
-	{
-	  cout << PHWHERE << endl;
-	  cout << "Missing Class: " << branchClassName.c_str() << endl;
-	  cout << "Did you forget to load the shared library which contains "
-	       << branchClassName.c_str() << "?" << endl;
-	}
-      // it does not make sense to continue - the code coredumps
-      // later if a class is not loaded
-      assert(thisClass != 0);
-
-      PHIODataNode<TObject> *newIODataNode =
-	static_cast<PHIODataNode<TObject> *> (nodeIter.findFirst("PHIODataNode", (*splitvec.rbegin()).c_str()));
-      if (! newIODataNode)
-	{
-	  TObject *newTObject = static_cast<TObject*>(thisClass->New());
-	  newIODataNode = new PHIODataNode<TObject>(newTObject, (*splitvec.rbegin()).c_str());
-	  nodeIter.addNode(newIODataNode);
-	}
-      else
-	{
-	  TObject *oldobject = newIODataNode->getData();
-	  string oldclass = oldobject->ClassName();
-	  if (oldclass != branchClassName)
-	    {
-	      cout << "You only have to worry if you get this message when reading parallel files"
-		   << endl
-		   << "if you get this when opening the 2nd, 3rd,... file" << endl
-		   << "It looks like your objects are not of the same version in these files" << endl;
-	      cout << PHWHERE << "Found object " << oldobject->ClassName()
-		   << " in node tree but the  file "
-		   << filename << " contains a " << branchClassName
-		   << " object. The object will be replaced without harming you" << endl;
-	      cout << "CAVEAT: If you use local copies of pointers to data nodes" << endl
-		   << "instead of searching the node tree you are in trouble now" << endl;
-	      delete newIODataNode;
-	      TObject *newTObject = static_cast<TObject*>(thisClass->New());
-	      newIODataNode = new PHIODataNode<TObject>(newTObject, (*splitvec.rbegin()).c_str());
-	      nodeIter.addNode(newIODataNode);
-	    }
-
-	}
-
-      if (thisClass->InheritsFrom("PHObject"))
-	{
-	  newIODataNode->setObjectType("PHObject");
-	}
-      else
-	{
-	  cout << PHWHERE << branchClassName.c_str()
-	       << " inherits neither from PHTable nor from PHObject"
-	       << " setting type to PHObject" << endl;
-	  newIODataNode->setObjectType("PHObject");
-	}
-      thisBranch->SetAddress(&(newIODataNode->data));
-	      for (j = 1; j < splitvec.size() - 1; j++)
-	{
-	  nodeIter.cd("..");
-	}
-
+      if (!nodeIter.cd(splitvec[ia]))
+      {
+        nodeIter.addNode(new PHCompositeNode(splitvec[ia]));
+        nodeIter.cd(splitvec[ia]);
+      }
     }
+    TBranch* thisBranch = (TBranch*) ((*branchArray)[i]);
+
+    // Skip non-selected branches
+    if (thisBranch->TestBit(kDoNotProcess))
+    {
+      continue;
+    }
+
+    string branchClassName = getBranchClassName(thisBranch);
+    string branchName = thisBranch->GetName();
+    fBranches[branchName] = thisBranch;
+
+    assert(gROOT != 0);
+    TClass* thisClass = gROOT->GetClass(branchClassName.c_str());
+
+    if (!thisClass)
+    {
+      cout << PHWHERE << endl;
+      cout << "Missing Class: " << branchClassName.c_str() << endl;
+      cout << "Did you forget to load the shared library which contains "
+           << branchClassName.c_str() << "?" << endl;
+    }
+    // it does not make sense to continue - the code coredumps
+    // later if a class is not loaded
+    assert(thisClass != 0);
+
+    PHIODataNode<TObject>* newIODataNode =
+        static_cast<PHIODataNode<TObject>*>(nodeIter.findFirst("PHIODataNode", (*splitvec.rbegin()).c_str()));
+    if (!newIODataNode)
+    {
+      TObject* newTObject = static_cast<TObject*>(thisClass->New());
+      newIODataNode = new PHIODataNode<TObject>(newTObject, (*splitvec.rbegin()).c_str());
+      nodeIter.addNode(newIODataNode);
+    }
+    else
+    {
+      TObject* oldobject = newIODataNode->getData();
+      string oldclass = oldobject->ClassName();
+      if (oldclass != branchClassName)
+      {
+        cout << "You only have to worry if you get this message when reading parallel files"
+             << endl
+             << "if you get this when opening the 2nd, 3rd,... file" << endl
+             << "It looks like your objects are not of the same version in these files" << endl;
+        cout << PHWHERE << "Found object " << oldobject->ClassName()
+             << " in node tree but the  file "
+             << filename << " contains a " << branchClassName
+             << " object. The object will be replaced without harming you" << endl;
+        cout << "CAVEAT: If you use local copies of pointers to data nodes" << endl
+             << "instead of searching the node tree you are in trouble now" << endl;
+        delete newIODataNode;
+        TObject* newTObject = static_cast<TObject*>(thisClass->New());
+        newIODataNode = new PHIODataNode<TObject>(newTObject, (*splitvec.rbegin()).c_str());
+        nodeIter.addNode(newIODataNode);
+      }
+    }
+
+    if (thisClass->InheritsFrom("PHObject"))
+    {
+      newIODataNode->setObjectType("PHObject");
+    }
+    else
+    {
+      cout << PHWHERE << branchClassName.c_str()
+           << " inherits neither from PHTable nor from PHObject"
+           << " setting type to PHObject" << endl;
+      newIODataNode->setObjectType("PHObject");
+    }
+    thisBranch->SetAddress(&(newIODataNode->data));
+    for (j = 1; j < splitvec.size() - 1; j++)
+    {
+      nodeIter.cd("..");
+    }
+  }
   return topNode;
 }
 
-void
-PHNodeIOManager::selectObjectToRead(const char* objectName, PHBoolean readit)
+void PHNodeIOManager::selectObjectToRead(const char* objectName, PHBoolean readit)
 {
   objectToRead[objectName] = readit;
 
   // If tree is already open, loop over map and set branch status
   if (tree)
+  {
+    map<string, PHBoolean>::const_iterator it;
+
+    for (it = objectToRead.begin(); it != objectToRead.end(); ++it)
     {
-      map<string, PHBoolean>::const_iterator it;
-
-      for (it = objectToRead.begin(); it != objectToRead.end(); ++it)
-        {
-          tree->SetBranchStatus((it->first).c_str(),
-                                static_cast<bool>(it->second));
-        }
-
+      tree->SetBranchStatus((it->first).c_str(),
+                            static_cast<bool>(it->second));
     }
+  }
   return;
 }
 
@@ -577,9 +565,9 @@ PHNodeIOManager::isSelected(const char* objectName)
   map<string, TBranch*>::const_iterator p = fBranches.find(name);
 
   if (p != fBranches.end())
-    {
-      return True;
-    }
+  {
+    return True;
+  }
 
   return False;
 }
@@ -588,14 +576,14 @@ PHBoolean
 PHNodeIOManager::SetCompressionLevel(const int level)
 {
   if (level < 0)
-    {
-      return False;
-    }
+  {
+    return False;
+  }
   CompressionLevel = level;
   if (file)
-    {
-      file ->SetCompressionLevel(CompressionLevel);
-    }
+  {
+    file->SetCompressionLevel(CompressionLevel);
+  }
 
   return True;
 }
@@ -607,35 +595,34 @@ PHNodeIOManager::GetBytesWritten()
   return 0.;
 }
 
-map<string, TBranch*> *
+map<string, TBranch*>*
 PHNodeIOManager::GetBranchMap()
 {
   FillBranchMap();
   return &fBranches;
 }
 
-int
-PHNodeIOManager::FillBranchMap()
+int PHNodeIOManager::FillBranchMap()
 {
   if (fBranches.empty())
+  {
+    TTree* treetmp = static_cast<TTree*>(file->Get(TreeName.c_str()));
+    if (treetmp)
     {
-      TTree *treetmp = static_cast<TTree *>(file->Get(TreeName.c_str()));
-      if (treetmp)
-        {
-          TObjArray *branchArray = treetmp->GetListOfBranches();
-          for (size_t i = 0; i < (size_t)(branchArray->GetEntriesFast()); i++)
-            {
-              TBranch *thisBranch = (TBranch*)((*branchArray)[i]);
-              string branchName = (*branchArray)[i]->GetName();
-              fBranches[branchName] = thisBranch;
-            }
-        }
-      else
-        {
-          cout << PHWHERE << " No Root Tree " << TreeName
-          << " on file " << filename << endl;
-          return -1;
-        }
+      TObjArray* branchArray = treetmp->GetListOfBranches();
+      for (size_t i = 0; i < (size_t)(branchArray->GetEntriesFast()); i++)
+      {
+        TBranch* thisBranch = (TBranch*) ((*branchArray)[i]);
+        string branchName = (*branchArray)[i]->GetName();
+        fBranches[branchName] = thisBranch;
+      }
     }
+    else
+    {
+      cout << PHWHERE << " No Root Tree " << TreeName
+           << " on file " << filename << endl;
+      return -1;
+    }
+  }
   return 0;
 }

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -6,59 +6,60 @@
 //  Author: Matthias Messer
 
 #include "PHIOManager.h"
-#include <string>
-#include <map>
 
+#include <map>
+#include <string>
 
 class TObject;
 class TFile;
 class TTree;
 class TBranch;
 
-class PHNodeIOManager : public PHIOManager { 
-public: 
-   PHNodeIOManager();
-   PHNodeIOManager(const std::string&, const PHAccessType = PHReadOnly);
-   PHNodeIOManager(const std::string&, const std::string&, const PHAccessType = PHReadOnly);
-   PHNodeIOManager(const std::string&, const PHAccessType , const PHTreeType);
-   virtual ~PHNodeIOManager(); 
+class PHNodeIOManager : public PHIOManager
+{
+ public:
+  PHNodeIOManager();
+  PHNodeIOManager(const std::string &, const PHAccessType = PHReadOnly);
+  PHNodeIOManager(const std::string &, const std::string &, const PHAccessType = PHReadOnly);
+  PHNodeIOManager(const std::string &, const PHAccessType, const PHTreeType);
+  virtual ~PHNodeIOManager();
 
-public:
-   virtual void closeFile() ;
-   virtual PHBoolean write(PHCompositeNode *) ;   
-   virtual void print() const ;
+ public:
+  virtual void closeFile();
+  virtual PHBoolean write(PHCompositeNode *);
+  virtual void print() const;
 
-   PHBoolean setFile(const std::string&, const std::string&, const PHAccessType = PHReadOnly) ;
-   PHCompositeNode * read(PHCompositeNode * = 0, size_t = 0); 
-   PHBoolean read(size_t requestedEvent) ;
-   int readSpecific(size_t requestedEvent, const char* objectName) ;
-   void selectObjectToRead(const char* objectName, PHBoolean readit) ;
-   PHBoolean isSelected(const char* objectName) ;
-   int isFunctional() const {return isFunctionalFlag;}
-   PHBoolean SetCompressionLevel(const int level);
-   double GetBytesWritten();
-   std::map<std::string,TBranch*> *GetBranchMap();
+  PHBoolean setFile(const std::string &, const std::string &, const PHAccessType = PHReadOnly);
+  PHCompositeNode *read(PHCompositeNode * = nullptr, size_t = 0);
+  PHBoolean read(size_t requestedEvent);
+  int readSpecific(size_t requestedEvent, const char *objectName);
+  void selectObjectToRead(const char *objectName, PHBoolean readit);
+  PHBoolean isSelected(const char *objectName);
+  int isFunctional() const { return isFunctionalFlag; }
+  PHBoolean SetCompressionLevel(const int level);
+  double GetBytesWritten();
+  std::map<std::string, TBranch *> *GetBranchMap();
 
-public:
-   PHBoolean write(TObject**, const std::string&);
-private:
-   int FillBranchMap();
-   PHCompositeNode * reconstructNodeTree(PHCompositeNode *);
-   PHBoolean readEventFromFile(size_t requestedEvent);
-   std::string getBranchClassName(TBranch*) ;
+ public:
+  PHBoolean write(TObject **, const std::string &);
+
+ private:
+  int FillBranchMap();
+  PHCompositeNode *reconstructNodeTree(PHCompositeNode *);
+  PHBoolean readEventFromFile(size_t requestedEvent);
+  std::string getBranchClassName(TBranch *);
 
   TFile *file;
   TTree *tree;
   std::string TreeName;
-  int   bufSize;
-  int   split;
-  int   accessMode;
-  int   CompressionLevel;
-  std::map<std::string,TBranch*> fBranches ;
-  std::map<std::string,PHBoolean> objectToRead ;
+  int bufSize;
+  int split;
+  int accessMode;
+  int CompressionLevel;
+  std::map<std::string, TBranch *> fBranches;
+  std::map<std::string, PHBoolean> objectToRead;
 
   int isFunctionalFlag;  // flag to tell if that object initialized properly
-
-}; 
+};
 
 #endif /* __PHNODEIOMANAGER_H__ */

--- a/offline/framework/phool/PHNodeIntegrate.cc
+++ b/offline/framework/phool/PHNodeIntegrate.cc
@@ -1,0 +1,61 @@
+//  Implementation of class PHNodeIntegrate
+//  Author: Matthias Messer
+
+#include "PHNodeIntegrate.h"
+
+#include "getClass.h"
+#include "PHCompositeNode.h"
+#include "PHDataNode.h"
+#include "PHIODataNode.h"
+#include "PHObject.h"
+
+#include <iostream>
+
+using namespace std;
+
+void PHNodeIntegrate::perform(PHNode* node)
+{
+  if (verbosity > 0)
+  {
+    cout << "PHNodeIntegrate: Integrateting " << node->getName() << endl;
+  }
+  if (node->getType() == "PHDataNode" || node->getType() == "PHIODataNode")
+  {
+    if (node->getObjectType() == "PHObject")
+    {
+      PHObject *obj = static_cast<PHDataNode<PHObject>*>(node)->getData();
+      if (obj->Integrate(nullptr) > 0)
+      {
+	cout << "finding " << node->getName() << " on " <<  runsumnode->getName() << endl;
+	PHObject *sumobj = findNode::getClass<PHObject>( runsumnode,node->getName());
+	if (sumobj)
+	{
+	  cout << "found sumobj on " <<  runsumnode->getName() << endl;
+	  sumobj->identify();
+	  sumobj->Integrate(obj);
+	  cout << "after integration" << endl;
+	  sumobj->identify();
+// now finally copy the summed object to the runwise node
+// since the runwise nodes were copied from the input file we are guaranteed
+// that it exists (and we handle only objects which come from the current
+// input file
+	PHObject *runobj = findNode::getClass<PHObject>( runnode,node->getName());
+	runobj->CopyContent(sumobj);
+	}
+	else
+	{
+          sumobj =  obj->clone();
+ PHIODataNode<PHObject> *intnode = new  PHIODataNode<PHObject>(sumobj,node->getName(),"PHObject");
+ runsumnode->addNode(intnode);
+	  cout << "needed to clone " << runsumnode->getName() << endl;
+	  sumobj->identify();
+	}
+	//     int iret = (static_cast<PHDataNode<PHObject>*>(node))->getData()->Integrate(obj);
+
+PHObject *runobj = findNode::getClass<PHObject>( runnode,node->getName());
+cout << "final run object:" << endl;
+runobj->identify();
+      }
+    }
+  }
+}

--- a/offline/framework/phool/PHNodeIntegrate.cc
+++ b/offline/framework/phool/PHNodeIntegrate.cc
@@ -1,60 +1,48 @@
-//  Implementation of class PHNodeIntegrate
-//  Author: Matthias Messer
-
 #include "PHNodeIntegrate.h"
 
-#include "getClass.h"
 #include "PHCompositeNode.h"
 #include "PHDataNode.h"
 #include "PHIODataNode.h"
 #include "PHObject.h"
+#include "getClass.h"
 
 #include <iostream>
 
 using namespace std;
 
-void PHNodeIntegrate::perform(PHNode* node)
+void PHNodeIntegrate::perform(PHNode *node)
 {
   if (verbosity > 0)
   {
-    cout << "PHNodeIntegrate: Integrateting " << node->getName() << endl;
+    cout << "PHNodeIntegrate: Integrating " << node->getName() << endl;
   }
   if (node->getType() == "PHDataNode" || node->getType() == "PHIODataNode")
   {
     if (node->getObjectType() == "PHObject")
     {
-      PHObject *obj = static_cast<PHDataNode<PHObject>*>(node)->getData();
-      if (obj->Integrate(nullptr) > 0)
+      PHObject *obj = static_cast<PHDataNode<PHObject> *>(node)->getData();
+      if (obj->Integrate())
       {
-	cout << "finding " << node->getName() << " on " <<  runsumnode->getName() << endl;
-	PHObject *sumobj = findNode::getClass<PHObject>( runsumnode,node->getName());
-	if (sumobj)
-	{
-	  cout << "found sumobj on " <<  runsumnode->getName() << endl;
-	  sumobj->identify();
-	  sumobj->Integrate(obj);
-	  cout << "after integration" << endl;
-	  sumobj->identify();
-// now finally copy the summed object to the runwise node
-// since the runwise nodes were copied from the input file we are guaranteed
-// that it exists (and we handle only objects which come from the current
-// input file
-	PHObject *runobj = findNode::getClass<PHObject>( runnode,node->getName());
-	runobj->CopyContent(sumobj);
-	}
-	else
-	{
-          sumobj =  obj->clone();
- PHIODataNode<PHObject> *intnode = new  PHIODataNode<PHObject>(sumobj,node->getName(),"PHObject");
- runsumnode->addNode(intnode);
-	  cout << "needed to clone " << runsumnode->getName() << endl;
-	  sumobj->identify();
-	}
-	//     int iret = (static_cast<PHDataNode<PHObject>*>(node))->getData()->Integrate(obj);
-
-PHObject *runobj = findNode::getClass<PHObject>( runnode,node->getName());
-cout << "final run object:" << endl;
-runobj->identify();
+        PHObject *sumobj = findNode::getClass<PHObject>(runsumnode, node->getName());
+        if (sumobj)
+        {
+          sumobj->Integrate(obj);
+          // now copy the summed object to the runwise node
+          // since the runwise nodes were copied from the input file
+          // we are guaranteed that it exists (and we handle only
+          // objects which come from the current input file
+          PHObject *runobj = findNode::getClass<PHObject>(runnode, node->getName());
+          runobj->CopyContent(sumobj);
+        }
+        else
+        {
+          // since this object was also copied to the node tree we only need
+          // to store it in case a second file gets opened where this one then
+          // serves as the object which contains the sum
+          sumobj = obj->clone();
+          PHIODataNode<PHObject> *sumobjnode = new PHIODataNode<PHObject>(sumobj, node->getName(), "PHObject");
+          runsumnode->addNode(sumobjnode);
+        }
       }
     }
   }

--- a/offline/framework/phool/PHNodeIntegrate.h
+++ b/offline/framework/phool/PHNodeIntegrate.h
@@ -2,8 +2,8 @@
 #define PHNodeIntegrate_h
 
 //  Declaration of class PHNodeIntegrate
-//  Purpose: strategy which calls integrate() on a PHNode
-//  Author: Matthias Messer
+//  Purpose: strategy which calls Integrate() on a PHNode if it is
+//  a PHObject
 
 #include "PHNodeOperation.h"
 
@@ -16,13 +16,18 @@ class PHNodeIntegrate : public PHNodeOperation
   PHNodeIntegrate() {}
   virtual ~PHNodeIntegrate() {}
   void RunNode(PHCompositeNode *node)
-  {runnode = node;}
+  {
+    runnode = node;
+  }
   void RunSumNode(PHCompositeNode *node)
-  {runsumnode = node;}
+  {
+    runsumnode = node;
+  }
 
  protected:
-  virtual void perform(PHNode*);
-private:
+  virtual void perform(PHNode *);
+
+ private:
   PHCompositeNode *runnode;
   PHCompositeNode *runsumnode;
 };

--- a/offline/framework/phool/PHNodeIntegrate.h
+++ b/offline/framework/phool/PHNodeIntegrate.h
@@ -1,0 +1,30 @@
+#ifndef PHNodeIntegrate_h
+#define PHNodeIntegrate_h
+
+//  Declaration of class PHNodeIntegrate
+//  Purpose: strategy which calls integrate() on a PHNode
+//  Author: Matthias Messer
+
+#include "PHNodeOperation.h"
+
+class PHNode;
+class PHCompositeNode;
+
+class PHNodeIntegrate : public PHNodeOperation
+{
+ public:
+  PHNodeIntegrate() {}
+  virtual ~PHNodeIntegrate() {}
+  void RunNode(PHCompositeNode *node)
+  {runnode = node;}
+  void RunSumNode(PHCompositeNode *node)
+  {runsumnode = node;}
+
+ protected:
+  virtual void perform(PHNode*);
+private:
+  PHCompositeNode *runnode;
+  PHCompositeNode *runsumnode;
+};
+
+#endif /* PHNodeIntegrate_h */

--- a/offline/framework/phool/PHNodeReset.cc
+++ b/offline/framework/phool/PHNodeReset.cc
@@ -2,6 +2,7 @@
 //  Author: Matthias Messer
 
 #include "PHNodeReset.h"
+
 #include "PHDataNode.h"
 #include "PHIODataNode.h"
 #include "PHObject.h"
@@ -17,18 +18,11 @@ void PHNodeReset::perform(PHNode* node)
   {
     cout << "PHNodeReset: Resetting " << node->getName() << endl;
   }
-  if (node->getType() == "PHDataNode")
+  if (node->getType() == "PHDataNode" || node->getType() == "PHIODataNode")
   {
     if (node->getObjectType() == "PHObject")
     {
       (static_cast<PHDataNode<PHObject>*>(node))->getData()->Reset();
-    }
-  }
-  else if (node->getType() == "PHIODataNode")
-  {
-    if (node->getObjectType() == "PHObject")
-    {
-      (static_cast<PHIODataNode<PHObject>*>(node))->getData()->Reset();
     }
   }
 }

--- a/offline/framework/phool/PHObject.cc
+++ b/offline/framework/phool/PHObject.cc
@@ -122,9 +122,9 @@ int PHObject::isImplemented(const unsigned int) const
   return 0;
 }
 
-void  PHObject::CopyContent(PHObject *obj)
+void PHObject::CopyContent(PHObject* obj)
 {
-std::cout << PHWHERE
-	  << " CopyContent(PHObject *obj) is not implemented" << std::endl;
-exit(1);
+  std::cout << PHWHERE
+            << " CopyContent(PHObject *obj) is not implemented" << std::endl;
+  exit(1);
 }

--- a/offline/framework/phool/PHObject.cc
+++ b/offline/framework/phool/PHObject.cc
@@ -121,3 +121,10 @@ int PHObject::isImplemented(const unsigned int) const
             << std::endl;
   return 0;
 }
+
+void  PHObject::CopyContent(PHObject *obj)
+{
+std::cout << PHWHERE
+	  << " CopyContent(PHObject *obj) is not implemented" << std::endl;
+exit(1);
+}

--- a/offline/framework/phool/PHObject.h
+++ b/offline/framework/phool/PHObject.h
@@ -40,10 +40,9 @@ class PHObject : public TObject
   virtual int isImplemented(const int i) const;
   virtual int isImplemented(const unsigned int i) const;
 
-  virtual int Integrate() const {return 0;}
-  virtual int Integrate(PHObject *obj) {return -1;}
-
-  virtual void CopyContent(PHObject *obj);
+  virtual int Integrate() const { return 0; }
+  virtual int Integrate(PHObject* obj) { return -1; }
+  virtual void CopyContent(PHObject* obj);
 
   void SplitLevel(const int i) { split = i; }
   int SplitLevel() const { return split; }

--- a/offline/framework/phool/PHObject.h
+++ b/offline/framework/phool/PHObject.h
@@ -39,6 +39,9 @@ class PHObject : public TObject
   virtual int isImplemented(const double f) const;
   virtual int isImplemented(const int i) const;
   virtual int isImplemented(const unsigned int i) const;
+
+  virtual int Integrate(PHObject *obj) {return -1;}
+
   void SplitLevel(const int i) { split = i; }
   int SplitLevel() const { return split; }
   void BufferSize(const int i) { bufSize = i; }

--- a/offline/framework/phool/PHObject.h
+++ b/offline/framework/phool/PHObject.h
@@ -40,7 +40,10 @@ class PHObject : public TObject
   virtual int isImplemented(const int i) const;
   virtual int isImplemented(const unsigned int i) const;
 
+  virtual int Integrate() const {return 0;}
   virtual int Integrate(PHObject *obj) {return -1;}
+
+  virtual void CopyContent(PHObject *obj);
 
   void SplitLevel(const int i) { split = i; }
   int SplitLevel() const { return split; }


### PR DESCRIPTION
This pull request adds the capability to integrate objects which are stored under the Run Node when reading multiple input files. These objects have to implement the following methods:

int Integrate() const {return 1;} // just a flag that this object wants to take part in this
int Integrate(PHObject *obj); 
void CopyContent(PHObject *obj);

The Integrate(PHObject *) method does the actual summing - it is called by the summed object, the result is stored locally in the respective DstInputManager. The CopyContent() method is needed to copy the content of the local summed object to the object under the node tree. This approach should give us the most flexibility when it comes to reading multiple input files in parallel while also dealing with changing versions of the stored objects (the worst case scenario, I hope we'll never get there). Again when reading multiple input files in parallel the last file opened wins in terms of objects on the Run Node. Storing the Dst content under different run nodes is also supported. One caveat - the path is not preserved for the summed local object. If you dare to save identically named objects on different branches you are doomed.

This PR also copies the recently in PHENIX added functionality to strip runwise nodes from the output over to sPHENIX.
