### PR TITLE
Random generator cleanup

### DIFF
--- a/offline/framework/phool/PHRandomSeed.cc
+++ b/offline/framework/phool/PHRandomSeed.cc
@@ -1,29 +1,39 @@
 #include "PHRandomSeed.h"
 #include "recoConsts.h"
 
-#include <gsl/gsl_const.h>
-#include <gsl/gsl_randist.h>
-#include <gsl/gsl_rng.h>
-
 #include <random>
-#include <cassert>
-#include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <queue>
 
 using namespace std;
 
+static queue<unsigned int> seedqueue;
+static std::mt19937 fRandomGenerator;
+static std::uniform_int_distribution<unsigned int> fDistribution;
+
 bool PHRandomSeed::fInitialized(false);
-mt19937 PHRandomSeed::fRandomGenerator;
-uniform_int_distribution<unsigned int> PHRandomSeed::fDistribution;
+bool PHRandomSeed::fFixed(false);
 
 unsigned int PHRandomSeed::GetSeed()
 {
+  if (! seedqueue.empty())
+  {
+    unsigned int iseed = seedqueue.front();
+    seedqueue.pop();
+    return iseed;
+  }
   if (!fInitialized)
+  {
     InitSeed();
-
-  assert(fInitialized);
+  }
+  if (fFixed)
+  {
   return fDistribution(fRandomGenerator);
+  }
+     std::random_device rdev;
+      uint32_t random_seed = rdev();
+      return random_seed;
 }
 
 void PHRandomSeed::InitSeed()
@@ -33,43 +43,14 @@ void PHRandomSeed::InitSeed()
   {
     // fixed init seed
     const int seed = rc->get_IntFlag("RANDOMSEED");
+    cout << "PHRandomSeed: using fixed seed " << seed << endl;
     fRandomGenerator.seed(seed);
+    fFixed = true;
     fInitialized = true;
-
-    cout << "PHRandomSeed::InitSeed - initialized with fixed random seed " << seed << " from recoConsts.RANDOMSEED. "<<endl
-        <<  "                         To reproduce this random number sequences, please add this line to Fun4All macro: "<<endl
-        <<  "                         recoConsts::instance()->set_IntFlag(\"RANDOMSEED\", " << seed << ");"<<endl;
   }
-  else
-  {
-    // random init seed
+}
 
-    //  that's when we switch to c++11
-    //  std::random_device rdev;
-    //  uint32_t random_seed = rdev();
-    unsigned int random_seed(0);
-    // use /dev/urandom which unlike /dev/random is non blocking
-    // even if entropy is too low. Not for use in cryptographic apps but
-    // good enough for a random seed
-    FILE *fp = fopen("/dev/urandom", "r");
-    if (!fp)
-    {
-      cout << "could not open /dev/urandom for seed" << endl;
-      exit(1);
-    }
-    size_t readbytes = fread(&random_seed, sizeof(random_seed), 1, fp);
-    fclose(fp);
-    if (!readbytes)
-    {
-      cout << "PHRandomSeed: reading /dev/urandom failed" << endl;
-      exit(1);
-    }
-
-    fRandomGenerator.seed(random_seed);
-    fInitialized = true;
-
-    cout << "PHRandomSeed::InitSeed - initialized with random seed " << random_seed << " from /dev/urandom. "<<endl
-         << "                         To reproduce this random number sequences, please add this line to Fun4All macro"<<endl
-         << "                         recoConsts::instance()->set_IntFlag(\"RANDOMSEED\", " << random_seed << ");";
-  }
+void PHRandomSeed::LoadSeed(unsigned int iseed)
+{
+  seedqueue.push(iseed);
 }

--- a/offline/framework/phool/PHRandomSeed.cc
+++ b/offline/framework/phool/PHRandomSeed.cc
@@ -17,23 +17,30 @@ bool PHRandomSeed::fFixed(false);
 
 unsigned int PHRandomSeed::GetSeed()
 {
+  unsigned int iseed;
   if (!seedqueue.empty())
   {
-    unsigned int iseed = seedqueue.front();
+    iseed = seedqueue.front();
     seedqueue.pop();
-    return iseed;
   }
-  if (!fInitialized)
+  else
   {
-    InitSeed();
+    if (!fInitialized)
+    {
+      InitSeed();
+    }
+    if (fFixed)
+    {
+      iseed = fDistribution(fRandomGenerator);
+    }
+    else
+    {
+      std::random_device rdev;
+      iseed = rdev();
+    }
   }
-  if (fFixed)
-  {
-    return fDistribution(fRandomGenerator);
-  }
-  std::random_device rdev;
-  uint32_t random_seed = rdev();
-  return random_seed;
+  cout << "PHRandomSeed::GetSeed() seed: " << iseed << endl;
+  return iseed;
 }
 
 void PHRandomSeed::InitSeed()
@@ -42,7 +49,7 @@ void PHRandomSeed::InitSeed()
   if (rc->FlagExist("RANDOMSEED"))
   {
     // fixed init seed
-    const int seed = rc->get_IntFlag("RANDOMSEED");
+    const unsigned int seed = rc->get_IntFlag("RANDOMSEED");
     cout << "PHRandomSeed: using fixed seed " << seed << endl;
     fRandomGenerator.seed(seed);
     fFixed = true;

--- a/offline/framework/phool/PHRandomSeed.cc
+++ b/offline/framework/phool/PHRandomSeed.cc
@@ -1,10 +1,10 @@
 #include "PHRandomSeed.h"
 #include "recoConsts.h"
 
-#include <random>
 #include <cstdlib>
 #include <iostream>
 #include <queue>
+#include <random>
 
 using namespace std;
 
@@ -17,7 +17,7 @@ bool PHRandomSeed::fFixed(false);
 
 unsigned int PHRandomSeed::GetSeed()
 {
-  if (! seedqueue.empty())
+  if (!seedqueue.empty())
   {
     unsigned int iseed = seedqueue.front();
     seedqueue.pop();
@@ -29,11 +29,11 @@ unsigned int PHRandomSeed::GetSeed()
   }
   if (fFixed)
   {
-  return fDistribution(fRandomGenerator);
+    return fDistribution(fRandomGenerator);
   }
-     std::random_device rdev;
-      uint32_t random_seed = rdev();
-      return random_seed;
+  std::random_device rdev;
+  uint32_t random_seed = rdev();
+  return random_seed;
 }
 
 void PHRandomSeed::InitSeed()

--- a/offline/framework/phool/PHRandomSeed.h
+++ b/offline/framework/phool/PHRandomSeed.h
@@ -1,14 +1,11 @@
 #ifndef PHRANDOMSEED_H
 #define PHRANDOMSEED_H
 
-#ifndef __CINT__
-#include <random>
-#endif
-
 //! standard way to get a random seed:
 //! `unsigned int seed = PHRandomSeed();`
 //! It return fix seed sequence if recoConsts RANDOMSEED is set.
-//! otherwise it return a random seed from /dev/urandom
+//! If values are preloaded via PHRandomSeed::LoadSeed, they are returned in loaded order
+//! otherwise it return a random seed from std::random_device rdev
 class PHRandomSeed
 {
  public:
@@ -22,15 +19,12 @@ class PHRandomSeed
 
   //! get a seed
   static unsigned int GetSeed();
+  static void LoadSeed(unsigned int iseed);
 
  protected:
   static void InitSeed();
-
-#ifndef __CINT__
+  static bool fFixed;
   static bool fInitialized;
-  static std::mt19937 fRandomGenerator;
-  static std::uniform_int_distribution<unsigned int> fDistribution;
-#endif
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
@@ -34,7 +34,6 @@ PHG4ParticleGeneratorBase::PHG4ParticleGeneratorBase(const string &name)
 {
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
   seed = PHRandomSeed();  // fixed seed is handled in this funtcion
-  cout << Name() << " random seed: " << seed << endl;
   gsl_rng_set(RandomGenerator, seed);
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -172,7 +172,6 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
     cout << "========================= PHG4Reco::Init() ================================" << endl;
   }
   unsigned int iseed = PHRandomSeed();
-  cout << Name() << " G4 Random Seed: " << iseed << endl;
   G4Seed(iseed);  // fixed seed handled in PHRandomSeed()
 
   // create GEANT run manager


### PR DESCRIPTION
This PR maximizes entropy by always returning a value from rdev rather than a uniform distribution initialized by a single seed. With PHRandomSeed::LoadSeed(unsigned int) seeds can be preloaded to reproduce any sequence. If the RANDOMSEED flag is set, it still uses this seed to initialize a uniform random number distribution.
It prints out the random seeds so a script can pull the seeds from a log file to recover the sequence. It is not necessary anymore for consumers to print out the seed themselves