### PR TITLE
Try2: Integrated luminosity for normalization

### DIFF
--- a/generators/PHPythia8/PHPythia8.C
+++ b/generators/PHPythia8/PHPythia8.C
@@ -17,7 +17,7 @@
 #include <Pythia8Plugins/HepMC2.h>
 #include <HepMC/GenEvent.h>
 
-#include <TString.h> // needed for Form()
+#include <boost/format.hpp>
 
 #include <gsl/gsl_randist.h>
 
@@ -90,7 +90,7 @@ int PHPythia8::Init(PHCompositeNode *topNode) {
 
   if ( (seed>0) && (seed<=900000000) ) {
     _pythia->readString("Random:setSeed = on");
-    _pythia->readString(Form("Random:seed = %u",seed));
+    _pythia->readString( str(boost::format("Random:seed = %1%") % seed) );
   } else {
     cout << PHWHERE << " ERROR: seed " << seed << " is not valid" << endl;
     exit(1); 
@@ -120,7 +120,7 @@ int PHPythia8::End(PHCompositeNode *topNode) {
 
   if (_integral_node)
   {
-    cout << "Integral information on stored on node SUM/PHGenIntegral:"<<endl;
+    cout << "Integral information on stored on node RUN/PHGenIntegral:"<<endl;
     _integral_node->identify();
     cout << " *-------  End PYTHIA Integral Node Print  ------------------------"
          << "-------------------------------------------------* " << endl;
@@ -249,7 +249,7 @@ int PHPythia8::create_node_tree(PHCompositeNode *topNode) {
   PHCompositeNode *sumNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
   if (!sumNode)
   {
-    cout << PHWHERE << "SUM Node missing doing nothing" << endl;
+    cout << PHWHERE << "RUN Node missing doing nothing" << endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
@@ -263,10 +263,10 @@ int PHPythia8::create_node_tree(PHCompositeNode *topNode) {
   else
   {
     cout <<"PHPythia8::create_node_tree - Fatal Error - "
-        <<"SUM/PHGenIntegral node already exist. "
+        <<"RUN/PHGenIntegral node already exist. "
         <<"It is messy to overwrite integrated luminosities. Please turn off this function in the macro with "<<endl;
     cout <<"                              PHPythia8::save_integrated_luminosity(false);"<<endl;
-    cout <<"The current SUM/PHGenIntegral node is ";
+    cout <<"The current RUN/PHGenIntegral node is ";
     _integral_node->identify(cout);
 
     exit(EXIT_FAILURE);

--- a/generators/PHPythia8/PHPythia8.C
+++ b/generators/PHPythia8/PHPythia8.C
@@ -246,7 +246,7 @@ int PHPythia8::create_node_tree(PHCompositeNode *topNode) {
 
 
   PHNodeIterator iter(topNode);
-  PHCompositeNode *sumNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SUM"));
+  PHCompositeNode *sumNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
   if (!sumNode)
   {
     cout << PHWHERE << "SUM Node missing doing nothing" << endl;
@@ -257,7 +257,7 @@ int PHPythia8::create_node_tree(PHCompositeNode *topNode) {
   if (!_integral_node)
   {
     _integral_node = new PHGenIntegralv1("PHPythia8 with embedding ID of "+std::to_string(hepmc_helper.get_embedding_id()));
-    PHIODataNode<PHObject> *newmapnode = new PHIODataNode<PHObject>(_integral_node, "PHHepMCGenEventMap", "PHObject");
+    PHIODataNode<PHObject> *newmapnode = new PHIODataNode<PHObject>(_integral_node, "PHGenIntegral", "PHObject");
     sumNode->addNode(newmapnode);
   }
   else

--- a/generators/PHPythia8/PHPythia8.C
+++ b/generators/PHPythia8/PHPythia8.C
@@ -4,11 +4,11 @@
 
 #include <phhepmc/PHHepMCGenEvent.h>
 #include <phhepmc/PHHepMCGenEventMap.h>
+#include <phhepmc/PHGenIntegralv1.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHCompositeNode.h>
-#include <phool/PHNodeIterator.h>
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
 
@@ -17,9 +17,12 @@
 #include <Pythia8Plugins/HepMC2.h>
 #include <HepMC/GenEvent.h>
 
+#include <TString.h> // needed for Form()
+
 #include <gsl/gsl_randist.h>
 
-#include <TString.h> // needed for Form()
+#include <cstdlib>
+#include <cassert>
 
 using namespace std;
 
@@ -36,7 +39,10 @@ PHPythia8::PHPythia8(const std::string &name):
   _pythia(NULL),
   _configFile("phpythia8.cfg"),
   _commands(),
-  _pythiaToHepMC(NULL) {
+  _pythiaToHepMC(NULL),
+  _save_integrated_luminosity(true),
+  _integral_node(nullptr)
+{
 
   char *charPath = getenv("PYTHIA8");
   if (!charPath) {
@@ -111,6 +117,14 @@ int PHPythia8::End(PHCompositeNode *topNode) {
        << " = " << _eventcount/float(_pythia->info.nAccepted()) << endl;
   cout << " *-------  End PYTHIA Trigger Statistics  ------------------------"
        << "-------------------------------------------------* " << endl;
+
+  if (_integral_node)
+  {
+    cout << "Integral information on stored on node SUM/PHGenIntegral:"<<endl;
+    _integral_node->identify();
+    cout << " *-------  End PYTHIA Integral Node Print  ------------------------"
+         << "-------------------------------------------------* " << endl;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -202,6 +216,7 @@ int PHPythia8::process_event(PHCompositeNode *topNode) {
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
+
   // print outs
   
   if (verbosity > 2) cout << "PHPythia8::process_event - FINISHED WHOLE EVENT" << endl;
@@ -209,12 +224,54 @@ int PHPythia8::process_event(PHCompositeNode *topNode) {
   if (_eventcount >= 2 && verbosity > 5) _pythia->event.list();
 
   ++_eventcount;
+
+
+  // save statistics
+  if (_integral_node)
+  {
+    _integral_node->set_N_Generator_Accepted_Event(_pythia->info.nAccepted());
+    _integral_node->set_N_Processed_Event(_eventcount);
+    _integral_node->set_Sum_Of_Weight(_pythia->info.weightSum());
+    _integral_node->set_Integrated_Lumi(_pythia->info.nAccepted() / (_pythia->info.sigmaGen() * 1e9));
+  }
+
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int PHPythia8::create_node_tree(PHCompositeNode *topNode) {
 
+  // HepMC IO
   hepmc_helper.create_node_tree(topNode);
+
+
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *sumNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SUM"));
+  if (!sumNode)
+  {
+    cout << PHWHERE << "SUM Node missing doing nothing" << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  _integral_node = findNode::getClass<PHGenIntegral>(sumNode, "PHGenIntegral");
+  if (!_integral_node)
+  {
+    _integral_node = new PHGenIntegralv1("PHPythia8 with embedding ID of "+std::to_string(hepmc_helper.get_embedding_id()));
+    PHIODataNode<PHObject> *newmapnode = new PHIODataNode<PHObject>(_integral_node, "PHHepMCGenEventMap", "PHObject");
+    sumNode->addNode(newmapnode);
+  }
+  else
+  {
+    cout <<"PHPythia8::create_node_tree - Fatal Error - "
+        <<"SUM/PHGenIntegral node already exist. "
+        <<"It is messy to overwrite integrated luminosities. Please turn off this function in the macro with "<<endl;
+    cout <<"                              PHPythia8::save_integrated_luminosity(false);"<<endl;
+    cout <<"The current SUM/PHGenIntegral node is ";
+    _integral_node->identify(cout);
+
+    exit(EXIT_FAILURE);
+  }
+  assert(_integral_node);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/generators/PHPythia8/PHPythia8.C
+++ b/generators/PHPythia8/PHPythia8.C
@@ -2,27 +2,26 @@
 
 #include "PHPy8GenTrigger.h"
 
+#include <phhepmc/PHGenIntegralv1.h>
 #include <phhepmc/PHHepMCGenEvent.h>
 #include <phhepmc/PHHepMCGenEventMap.h>
-#include <phhepmc/PHGenIntegralv1.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHIODataNode.h>
 #include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
 
-
+#include <HepMC/GenEvent.h>
 #include <Pythia8/Pythia.h>
 #include <Pythia8Plugins/HepMC2.h>
-#include <HepMC/GenEvent.h>
 
 #include <boost/format.hpp>
 
 #include <gsl/gsl_randist.h>
 
-#include <cstdlib>
 #include <cassert>
+#include <cstdlib>
 
 using namespace std;
 
@@ -30,22 +29,22 @@ typedef PHIODataNode<PHObject> PHObjectNode_t;
 
 //static const Float_t CM2MM = 10.; // cm to mm comversion \todo why not use HepMC functions?
 
-PHPythia8::PHPythia8(const std::string &name):
-  SubsysReco(name),
-  _eventcount(0),
-  _registeredTriggers(),
-  _triggersOR(true),
-  _triggersAND(false),
-  _pythia(NULL),
-  _configFile("phpythia8.cfg"),
-  _commands(),
-  _pythiaToHepMC(NULL),
-  _save_integrated_luminosity(true),
-  _integral_node(nullptr)
+PHPythia8::PHPythia8(const std::string &name)
+  : SubsysReco(name)
+  , _eventcount(0)
+  , _registeredTriggers()
+  , _triggersOR(true)
+  , _triggersAND(false)
+  , _pythia(NULL)
+  , _configFile("phpythia8.cfg")
+  , _commands()
+  , _pythiaToHepMC(NULL)
+  , _save_integrated_luminosity(true)
+  , _integral_node(nullptr)
 {
-
   char *charPath = getenv("PYTHIA8");
-  if (!charPath) {
+  if (!charPath)
+  {
     cout << "PHPythia8::Could not find $PYTHIA8 path!" << endl;
     return;
   }
@@ -59,17 +58,19 @@ PHPythia8::PHPythia8(const std::string &name):
   _pythiaToHepMC->set_store_pdf(true);
   _pythiaToHepMC->set_store_xsec(true);
 
-  hepmc_helper.set_embedding_id(1); // default embedding ID to 1
+  hepmc_helper.set_embedding_id(1);  // default embedding ID to 1
 }
 
-PHPythia8::~PHPythia8() {
+PHPythia8::~PHPythia8()
+{
   delete _pythia;
 }
 
-int PHPythia8::Init(PHCompositeNode *topNode) {
-
+int PHPythia8::Init(PHCompositeNode *topNode)
+{
   if (!_configFile.empty()) read_config();
-  for (unsigned int j = 0; j < _commands.size(); j++) {
+  for (unsigned int j = 0; j < _commands.size(); j++)
+  {
     _pythia->readString(_commands[j]);
   }
 
@@ -84,14 +85,18 @@ int PHPythia8::Init(PHCompositeNode *topNode) {
 
   unsigned int seed = PHRandomSeed();
 
-  if (seed > 900000000) {
+  if (seed > 900000000)
+  {
     seed = seed % 900000000;
   }
 
-  if ( (seed>0) && (seed<=900000000) ) {
+  if ((seed > 0) && (seed <= 900000000))
+  {
     _pythia->readString("Random:setSeed = on");
-    _pythia->readString( str(boost::format("Random:seed = %1%") % seed) );
-  } else {
+    _pythia->readString(str(boost::format("Random:seed = %1%") % seed));
+  }
+  else
+  {
     cout << PHWHERE << " ERROR: seed " << seed << " is not valid" << endl;
     exit(1);
   }
@@ -101,8 +106,8 @@ int PHPythia8::Init(PHCompositeNode *topNode) {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHPythia8::End(PHCompositeNode *topNode) {
-
+int PHPythia8::End(PHCompositeNode *topNode)
+{
   if (verbosity >= VERBOSITY_MORE) cout << "PHPythia8::End - I'm here!" << endl;
 
   if (verbosity >= VERBOSITY_SOME)
@@ -117,13 +122,13 @@ int PHPythia8::End(PHCompositeNode *topNode) {
          << " events passed trigger" << endl;
     cout << "                         Fraction passed: " << _eventcount
          << "/" << _pythia->info.nAccepted()
-         << " = " << _eventcount/float(_pythia->info.nAccepted()) << endl;
+         << " = " << _eventcount / float(_pythia->info.nAccepted()) << endl;
     cout << " *-------  End PYTHIA Trigger Statistics  ------------------------"
          << "-------------------------------------------------* " << endl;
 
     if (_integral_node)
     {
-      cout << "Integral information on stored on node RUN/PHGenIntegral:"<<endl;
+      cout << "Integral information on stored on node RUN/PHGenIntegral:" << endl;
       _integral_node->identify();
       cout << " *-------  End PYTHIA Integral Node Print  ------------------------"
            << "-------------------------------------------------* " << endl;
@@ -134,15 +139,16 @@ int PHPythia8::End(PHCompositeNode *topNode) {
 }
 
 //__________________________________________________________
-int PHPythia8::read_config(const char *cfg_file) {
-
-  if ( cfg_file ) _configFile = cfg_file;
+int PHPythia8::read_config(const char *cfg_file)
+{
+  if (cfg_file) _configFile = cfg_file;
 
   if (verbosity >= VERBOSITY_SOME)
     cout << "PHPythia8::read_config - Reading " << _configFile << endl;
 
-  ifstream infile( _configFile.c_str() );
-  if (infile.fail ()) {
+  ifstream infile(_configFile.c_str());
+  if (infile.fail())
+  {
     cout << "PHPythia8::read_config - Failed to open file " << _configFile << endl;
     exit(2);
   }
@@ -153,55 +159,66 @@ int PHPythia8::read_config(const char *cfg_file) {
 }
 
 //-* print pythia config info
-void PHPythia8::print_config() const {
+void PHPythia8::print_config() const
+{
   _pythia->info.list();
 }
 
-int PHPythia8::process_event(PHCompositeNode *topNode) {
-
+int PHPythia8::process_event(PHCompositeNode *topNode)
+{
   if (verbosity >= VERBOSITY_MORE) cout << "PHPythia8::process_event - event: " << _eventcount << endl;
 
   bool passedGen = false;
   bool passedTrigger = false;
   int genCounter = 0;
 
-  while (!passedTrigger) {
+  while (!passedTrigger)
+  {
     ++genCounter;
 
     // generate another pythia event
-    while (!passedGen) {
+    while (!passedGen)
+    {
       passedGen = _pythia->next();
     }
 
     // test trigger logic
 
     bool andScoreKeeper = true;
-    if (verbosity >= VERBOSITY_EVEN_MORE) {
+    if (verbosity >= VERBOSITY_EVEN_MORE)
+    {
       cout << "PHPythia8::process_event - triggersize: " << _registeredTriggers.size() << endl;
     }
 
-    for (unsigned int tr = 0; tr < _registeredTriggers.size(); tr++) {
+    for (unsigned int tr = 0; tr < _registeredTriggers.size(); tr++)
+    {
       bool trigResult = _registeredTriggers[tr]->Apply(_pythia);
 
-      if (verbosity >= VERBOSITY_EVEN_MORE) {
-	cout << "PHPythia8::process_event trigger: "
-	     << _registeredTriggers[tr]->GetName() << "  " << trigResult << endl;
+      if (verbosity >= VERBOSITY_EVEN_MORE)
+      {
+        cout << "PHPythia8::process_event trigger: "
+             << _registeredTriggers[tr]->GetName() << "  " << trigResult << endl;
       }
 
-      if (_triggersOR && trigResult) {
-	passedTrigger = true;
-	break;
-      } else if (_triggersAND) {
-	andScoreKeeper &= trigResult;
+      if (_triggersOR && trigResult)
+      {
+        passedTrigger = true;
+        break;
+      }
+      else if (_triggersAND)
+      {
+        andScoreKeeper &= trigResult;
       }
 
-      if (verbosity >=VERBOSITY_EVEN_MORE && !passedTrigger) {
-	cout << "PHPythia8::process_event - failed trigger: "
-	     << _registeredTriggers[tr]->GetName() <<  endl;
+      if (verbosity >= VERBOSITY_EVEN_MORE && !passedTrigger)
+      {
+        cout << "PHPythia8::process_event - failed trigger: "
+             << _registeredTriggers[tr]->GetName() << endl;
       }
     }
 
-    if ((andScoreKeeper && _triggersAND) || (_registeredTriggers.size() == 0)) {
+    if ((andScoreKeeper && _triggersAND) || (_registeredTriggers.size() == 0))
+    {
       passedTrigger = true;
       genCounter = 0;
     }
@@ -214,14 +231,13 @@ int PHPythia8::process_event(PHCompositeNode *topNode) {
   HepMC::GenEvent *genevent = new HepMC::GenEvent(HepMC::Units::GEV, HepMC::Units::MM);
   _pythiaToHepMC->fill_next_event(*_pythia, genevent, _eventcount);
 
-
   /* pass HepMC to PHNode*/
-  PHHepMCGenEvent * success = hepmc_helper . insert_event(genevent);
-  if (!success) {
+  PHHepMCGenEvent *success = hepmc_helper.insert_event(genevent);
+  if (!success)
+  {
     cout << "PHPythia8::process_event - Failed to add event to HepMC record!" << endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
-
 
   // print outs
 
@@ -230,7 +246,6 @@ int PHPythia8::process_event(PHCompositeNode *topNode) {
   if (_eventcount >= 2 && verbosity >= VERBOSITY_A_LOT) _pythia->event.list();
 
   ++_eventcount;
-
 
   // save statistics
   if (_integral_node)
@@ -241,15 +256,13 @@ int PHPythia8::process_event(PHCompositeNode *topNode) {
     _integral_node->set_Integrated_Lumi(_pythia->info.nAccepted() / (_pythia->info.sigmaGen() * 1e9));
   }
 
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHPythia8::create_node_tree(PHCompositeNode *topNode) {
-
+int PHPythia8::create_node_tree(PHCompositeNode *topNode)
+{
   // HepMC IO
   hepmc_helper.create_node_tree(topNode);
-
 
   PHNodeIterator iter(topNode);
   PHCompositeNode *sumNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
@@ -262,17 +275,17 @@ int PHPythia8::create_node_tree(PHCompositeNode *topNode) {
   _integral_node = findNode::getClass<PHGenIntegral>(sumNode, "PHGenIntegral");
   if (!_integral_node)
   {
-    _integral_node = new PHGenIntegralv1("PHPythia8 with embedding ID of "+std::to_string(hepmc_helper.get_embedding_id()));
+    _integral_node = new PHGenIntegralv1("PHPythia8 with embedding ID of " + std::to_string(hepmc_helper.get_embedding_id()));
     PHIODataNode<PHObject> *newmapnode = new PHIODataNode<PHObject>(_integral_node, "PHGenIntegral", "PHObject");
     sumNode->addNode(newmapnode);
   }
   else
   {
-    cout <<"PHPythia8::create_node_tree - Fatal Error - "
-        <<"RUN/PHGenIntegral node already exist. "
-        <<"It is messy to overwrite integrated luminosities. Please turn off this function in the macro with "<<endl;
-    cout <<"                              PHPythia8::save_integrated_luminosity(false);"<<endl;
-    cout <<"The current RUN/PHGenIntegral node is ";
+    cout << "PHPythia8::create_node_tree - Fatal Error - "
+         << "RUN/PHGenIntegral node already exist. "
+         << "It is messy to overwrite integrated luminosities. Please turn off this function in the macro with " << endl;
+    cout << "                              PHPythia8::save_integrated_luminosity(false);" << endl;
+    cout << "The current RUN/PHGenIntegral node is ";
     _integral_node->identify(cout);
 
     exit(EXIT_FAILURE);
@@ -282,11 +295,13 @@ int PHPythia8::create_node_tree(PHCompositeNode *topNode) {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHPythia8::ResetEvent(PHCompositeNode *topNode) {
+int PHPythia8::ResetEvent(PHCompositeNode *topNode)
+{
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void PHPythia8::register_trigger(PHPy8GenTrigger *theTrigger) {
-  if(verbosity >= VERBOSITY_MORE) cout << "PHPythia8::registerTrigger - trigger " << theTrigger->GetName() << " registered" << endl;
+void PHPythia8::register_trigger(PHPy8GenTrigger *theTrigger)
+{
+  if (verbosity >= VERBOSITY_MORE) cout << "PHPythia8::registerTrigger - trigger " << theTrigger->GetName() << " registered" << endl;
   _registeredTriggers.push_back(theTrigger);
 }

--- a/generators/PHPythia8/PHPythia8.h
+++ b/generators/PHPythia8/PHPythia8.h
@@ -18,7 +18,7 @@
 class PHCompositeNode;
 class PHHepMCGenEvent;
 class PHHepMCFilter;
-
+class PHGenIntegral;
 class PHPy8GenTrigger;
 
 namespace HepMC {
@@ -102,6 +102,11 @@ public:
   //! negative IDs are backgrounds, .e.g out of time pile up collisions
   //! Usually, ID = 0 means the primary Au+Au collision background
   void set_embedding_id(int id) { hepmc_helper.set_embedding_id(id); }
+
+  //! whether to store the integrated luminosity and other event statistics to the TOP/SUM/PHGenIntegral node
+  void save_integrated_luminosity(const bool b) {_save_integrated_luminosity = b;}
+
+
 private:
 
   int read_config(const char *cfg_file = 0);
@@ -129,6 +134,11 @@ private:
   //! helper for insert HepMC event to DST node and add vertex smearing
   PHHepMCGenHelper hepmc_helper;
 
+  //! whether to store the integrated luminosity and other event statistics to the TOP/SUM/PHGenIntegral node
+  bool _save_integrated_luminosity;
+
+  //! pointer to data node saving the integrated luminosity
+  PHGenIntegral * _integral_node;
 };
 
 #endif	/* __PHPYTHIA8_H__ */

--- a/generators/PHPythia8/PHPythia8.h
+++ b/generators/PHPythia8/PHPythia8.h
@@ -103,7 +103,7 @@ public:
   //! Usually, ID = 0 means the primary Au+Au collision background
   void set_embedding_id(int id) { hepmc_helper.set_embedding_id(id); }
 
-  //! whether to store the integrated luminosity and other event statistics to the TOP/SUM/PHGenIntegral node
+  //! whether to store the integrated luminosity and other event statistics to the TOP/RUN/PHGenIntegral node
   void save_integrated_luminosity(const bool b) {_save_integrated_luminosity = b;}
 
 
@@ -134,7 +134,7 @@ private:
   //! helper for insert HepMC event to DST node and add vertex smearing
   PHHepMCGenHelper hepmc_helper;
 
-  //! whether to store the integrated luminosity and other event statistics to the TOP/SUM/PHGenIntegral node
+  //! whether to store the integrated luminosity and other event statistics to the TOP/RUN/PHGenIntegral node
   bool _save_integrated_luminosity;
 
   //! pointer to data node saving the integrated luminosity

--- a/generators/PHPythia8/PHPythia8.h
+++ b/generators/PHPythia8/PHPythia8.h
@@ -21,50 +21,59 @@ class PHHepMCFilter;
 class PHGenIntegral;
 class PHPy8GenTrigger;
 
-namespace HepMC {
-  class GenEvent;
-  class Pythia8ToHepMC;
+namespace HepMC
+{
+class GenEvent;
+class Pythia8ToHepMC;
 };
 
-namespace Pythia8 {
-  class Pythia;
+namespace Pythia8
+{
+class Pythia;
 };
 
-class PHPythia8: public SubsysReco {
-  
-public:
-  
+class PHPythia8 : public SubsysReco
+{
+ public:
   PHPythia8(const std::string &name = "PHPythia8");
   virtual ~PHPythia8();
 
   int Init(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode); 
-  int ResetEvent(PHCompositeNode *topNode); 
+  int process_event(PHCompositeNode *topNode);
+  int ResetEvent(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
-  
-  void set_config_file( const char* cfg_file ) {
-    if ( cfg_file ) _configFile = cfg_file;
+
+  void set_config_file(const char *cfg_file)
+  {
+    if (cfg_file) _configFile = cfg_file;
   }
 
   void print_config() const;
 
   /// set event selection criteria
   void register_trigger(PHPy8GenTrigger *theTrigger);
-  void set_trigger_OR() { _triggersOR = true; _triggersAND = false; } // default true
-  void set_trigger_AND() { _triggersAND = true; _triggersOR = false; }
+  void set_trigger_OR()
+  {
+    _triggersOR = true;
+    _triggersAND = false;
+  }  // default true
+  void set_trigger_AND()
+  {
+    _triggersAND = true;
+    _triggersOR = false;
+  }
 
   /// pass commands directly to PYTHIA8
-  void process_string(std::string s) {_commands.push_back(s);}
-  
+  void process_string(std::string s) { _commands.push_back(s); }
   void beam_vertex_parameters(double beamX,
-			      double beamY,
-			      double beamZ,
-			      double beamXsigma,
-			      double beamYsigma,
-			      double beamZsigma) {
+                              double beamY,
+                              double beamZ,
+                              double beamXsigma,
+                              double beamYsigma,
+                              double beamZsigma)
+  {
     set_vertex_distribution_mean(beamX, beamY, beamZ, 0);
     set_vertex_distribution_width(beamXsigma, beamYsigma, beamZsigma, 0);
-
   }
 
   //! toss a new vertex according to a Uniform or Gaus distribution
@@ -102,32 +111,27 @@ public:
   //! negative IDs are backgrounds, .e.g out of time pile up collisions
   //! Usually, ID = 0 means the primary Au+Au collision background
   void set_embedding_id(int id) { hepmc_helper.set_embedding_id(id); }
-
   //! whether to store the integrated luminosity and other event statistics to the TOP/RUN/PHGenIntegral node
-  void save_integrated_luminosity(const bool b) {_save_integrated_luminosity = b;}
-
-
-private:
-
+  void save_integrated_luminosity(const bool b) { _save_integrated_luminosity = b; }
+ private:
   int read_config(const char *cfg_file = 0);
   int create_node_tree(PHCompositeNode *topNode);
-  double percent_diff(const double a, const double b){return abs((a-b)/a);}
-  
+  double percent_diff(const double a, const double b) { return abs((a - b) / a); }
   int _eventcount;
 
   // event selection
-  std::vector<PHPy8GenTrigger*> _registeredTriggers;
+  std::vector<PHPy8GenTrigger *> _registeredTriggers;
   bool _triggersOR;
   bool _triggersAND;
-  
-  // PYTHIA  
-  #ifndef __CINT__
+
+// PYTHIA
+#ifndef __CINT__
   Pythia8::Pythia *_pythia;
-  #endif
+#endif
 
   std::string _configFile;
   std::vector<std::string> _commands;
-  
+
   // HepMC
   HepMC::Pythia8ToHepMC *_pythiaToHepMC;
 
@@ -138,8 +142,7 @@ private:
   bool _save_integrated_luminosity;
 
   //! pointer to data node saving the integrated luminosity
-  PHGenIntegral * _integral_node;
+  PHGenIntegral *_integral_node;
 };
 
-#endif	/* __PHPYTHIA8_H__ */
-
+#endif /* __PHPYTHIA8_H__ */

--- a/generators/phhepmc/Makefile.am
+++ b/generators/phhepmc/Makefile.am
@@ -23,6 +23,8 @@ pkginclude_HEADERS = \
   PHGenEventv1.h \
   PHGenEventList.h \
   PHGenEventListv1.h \
+  PHGenIntegral.h \
+  PHGenIntegralv1.h \
   PHHepMCGenEvent.h \
   PHHepMCGenEventMap.h \
   PHHepMCGenHelper.h
@@ -59,7 +61,11 @@ libphhepmc_io_la_SOURCES = \
   PHGenEventListv1.cc \
   PHHepMCGenEvent.cc \
   PHHepMCGenEventMap.cc \
-  PHHepMC_io_Dict.C
+  PHHepMC_io_Dict.C \
+  PHGenIntegral.cc \
+  PHGenIntegral_Dict.C \
+  PHGenIntegralv1.cc \
+  PHGenIntegralv1_Dict.C
 
 
 libphhepmc_io_la_LDFLAGS = \

--- a/generators/phhepmc/PHGenIntegral.cc
+++ b/generators/phhepmc/PHGenIntegral.cc
@@ -1,0 +1,42 @@
+// $Id: $
+
+/*!
+ * \file PHGenIntegral.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "PHGenIntegral.h"
+
+#include <limits>
+
+PHGenIntegral::PHGenIntegral()
+{
+  // TODO Auto-generated constructor stub
+}
+
+PHGenIntegral::~PHGenIntegral()
+{
+  // TODO Auto-generated destructor stub
+}
+
+//! cross sections for the processed events in pb
+Double_t PHGenIntegral::get_CrossSection_Processed_Event() const
+{
+  return get_Integrated_Lumi() > 0 ? get_N_Processed_Event() / get_Integrated_Lumi() : std::numeric_limits<Double_t>::signaling_NaN();
+}
+
+//! cross sections for the events accepted by the event generator in pb
+Double_t PHGenIntegral::get_CrossSection_Generator_Accepted_Event() const
+{
+  return get_Integrated_Lumi() > 0 ? get_N_Generator_Accepted_Event() / get_Integrated_Lumi() : std::numeric_limits<Double_t>::signaling_NaN();
+}
+
+//! description on the source
+const std::string& PHGenIntegral::get_Description() const
+{
+  static const std::string s_invalid("Invalid");
+  return s_invalid;
+}

--- a/generators/phhepmc/PHGenIntegral.h
+++ b/generators/phhepmc/PHGenIntegral.h
@@ -1,0 +1,91 @@
+// $Id: $
+
+/*!
+ * \file PHGenIntegral.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef SIMULATION_CORESOFTWARE_GENERATORS_PHHEPMC_PHGENINTEGRAL_H_
+#define SIMULATION_CORESOFTWARE_GENERATORS_PHHEPMC_PHGENINTEGRAL_H_
+
+#include <phool/PHObject.h>
+#include <string>
+
+/*!
+ * \brief PHGenIntegral
+ */
+class PHGenIntegral : public PHObject
+{
+ public:
+  PHGenIntegral();
+  virtual ~PHGenIntegral();
+
+  //! Integrated luminosity in pb^-1
+  virtual Double_t get_Integrated_Lumi() const
+  {
+    return 0;
+  }
+
+  //! Integrated luminosity in pb^-1
+  virtual void set_Integrated_Lumi(Double_t integratedLumi)
+  {
+  }
+
+  //! Number of accepted events in the event generator. This can be higher than fNProcessedEvent depending on trigger on the event generator
+  virtual ULong64_t get_N_Generator_Accepted_Event() const
+  {
+    return 0;
+  }
+
+  //! Number of accepted events in the event generator. This can be higher than fNProcessedEvent depending on trigger on the event generator
+  virtual void set_N_Generator_Accepted_Event(ULong64_t nGeneratorAcceptedEvent)
+  {
+  }
+
+  //! Number of processed events in the Fun4All cycles
+  virtual ULong64_t get_N_Processed_Event() const
+  {
+    return 0;
+  }
+
+  //! Number of processed events in the Fun4All cycles
+  virtual void set_N_Processed_Event(ULong64_t nProcessedEvent)
+  {
+  }
+
+  //! Sum of weight assigned to the events by the generators.
+  //! Event weight is normally 1 and thus equal to number of the generated event and is uninteresting.
+  //! However, there are several cases where one may have nontrivial event weights, e.g. using user hooks in Pythia8 generators to reweight the phase space
+  virtual Double_t get_Sum_Of_Weight() const
+  {
+    return 0;
+  }
+
+  //! Sum of weight assigned to the events by the generators.
+  //! Event weight is normally 1 and thus equal to number of the generated event and is uninteresting.
+  //! However, there are several cases where one may have nontrivial event weights, e.g. using user hooks in Pythia8 generators to reweight the phase space
+  virtual void set_Sum_Of_Weight(Double_t sumOfWeight)
+  {
+  }
+
+  //! cross sections for the processed events in pb
+  virtual Double_t get_CrossSection_Processed_Event() const;
+
+  //! cross sections for the events accepted by the event generator in pb
+  virtual Double_t get_CrossSection_Generator_Accepted_Event() const;
+
+  //! description on the source
+  virtual const std::string& get_Description() const;
+
+  //! description on the source
+  virtual void set_Description(const std::string& description)
+  {
+  }
+
+  ClassDef(PHGenIntegral, 1)
+};
+
+#endif /* SIMULATION_CORESOFTWARE_GENERATORS_PHHEPMC_PHGENINTEGRAL_H_ */

--- a/generators/phhepmc/PHGenIntegralLinkDef.h
+++ b/generators/phhepmc/PHGenIntegralLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHGenIntegral+;
+
+#endif

--- a/generators/phhepmc/PHGenIntegralv1.cc
+++ b/generators/phhepmc/PHGenIntegralv1.cc
@@ -12,6 +12,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <cassert>
 using namespace std;
 
 PHGenIntegralv1::PHGenIntegralv1()
@@ -53,9 +54,9 @@ void PHGenIntegralv1::Reset()
   fDescription = "Source Not Provided";
 }
 
-int PHGenIntegralv1::Integrate(PHObject* incoming_object)
+int PHGenIntegralv1::Integrate( PHObject* incoming_object)
 {
-  PHGenIntegral* in_gen = dynamic_cast<PHGenIntegral*>(incoming_object);
+  const PHGenIntegral* in_gen = dynamic_cast<const PHGenIntegral*>(incoming_object);
 
   if (!in_gen)
   {
@@ -81,4 +82,25 @@ int PHGenIntegralv1::Integrate(PHObject* incoming_object)
   fSumOfWeight += in_gen->get_Sum_Of_Weight();
 
   return fNProcessedEvent;
+}
+
+void PHGenIntegralv1::CopyContent( PHObject* incoming_object)
+{
+  const PHGenIntegral * in_gen = dynamic_cast<const PHGenIntegral *>(incoming_object);
+
+  if (!in_gen)
+  {
+    cout << "PHGenIntegralv1::CopyContent - Fatal Error - "
+         << "input object is not a PHGenIntegral: ";
+    incoming_object->identify();
+
+    exit(EXIT_FAILURE);
+  }
+
+  fNProcessedEvent = in_gen->get_N_Processed_Event();
+  fNGeneratorAcceptedEvent = in_gen->get_N_Generator_Accepted_Event();
+  fIntegratedLumi = in_gen->get_Integrated_Lumi();
+  fSumOfWeight = in_gen->get_Sum_Of_Weight();
+  fDescription = in_gen->get_Description();
+
 }

--- a/generators/phhepmc/PHGenIntegralv1.cc
+++ b/generators/phhepmc/PHGenIntegralv1.cc
@@ -53,7 +53,7 @@ void PHGenIntegralv1::Reset()
   fDescription = "Source Not Provided";
 }
 
-void PHGenIntegralv1::Integrate(PHObject* incoming_object)
+int PHGenIntegralv1::Integrate(PHObject* incoming_object)
 {
   PHGenIntegral* in_gen = dynamic_cast<PHGenIntegral*>(incoming_object);
 
@@ -79,4 +79,6 @@ void PHGenIntegralv1::Integrate(PHObject* incoming_object)
   fNGeneratorAcceptedEvent += in_gen->get_N_Generator_Accepted_Event();
   fIntegratedLumi += in_gen->get_Integrated_Lumi();
   fSumOfWeight += in_gen->get_Sum_Of_Weight();
+
+  return fNProcessedEvent;
 }

--- a/generators/phhepmc/PHGenIntegralv1.cc
+++ b/generators/phhepmc/PHGenIntegralv1.cc
@@ -1,0 +1,82 @@
+// $Id: $
+
+/*!
+ * \file PHGenIntegralv1.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "PHGenIntegralv1.h"
+
+#include <cstdlib>
+#include <iostream>
+using namespace std;
+
+PHGenIntegralv1::PHGenIntegralv1()
+{
+  Reset();
+}
+
+PHGenIntegralv1::PHGenIntegralv1(const std::string& description)
+{
+  Reset();
+  fDescription = description;
+}
+
+PHGenIntegralv1::~PHGenIntegralv1()
+{
+}
+
+PHObject* PHGenIntegralv1::clone() const
+{
+  //this class is simple, use the default copy constructor for cloning
+  return new PHGenIntegralv1(*this);
+}
+
+void PHGenIntegralv1::identify(ostream& os) const
+{
+  os << "PHGenIntegralv1::identify: " << get_Description() << endl
+     << " N_Generator_Accepted_Event = " << get_N_Generator_Accepted_Event() << " @ " << get_CrossSection_Generator_Accepted_Event() << " pb" << endl
+     << "          N_Processed_Event = " << get_N_Processed_Event() << " @ " << get_CrossSection_Processed_Event() << " pb" << endl
+     << "              Sum_Of_Weight = " << get_Sum_Of_Weight() << endl
+     << "            Integrated_Lumi = " << get_Integrated_Lumi() << " pb^-1" << endl;
+}
+
+void PHGenIntegralv1::Reset()
+{
+  fNProcessedEvent = 0;
+  fNGeneratorAcceptedEvent = 0;
+  fIntegratedLumi = 0;
+  fSumOfWeight = 0;
+  fDescription = "Source Not Provided";
+}
+
+void PHGenIntegralv1::Integrate(PHObject* incoming_object)
+{
+  PHGenIntegral* in_gen = dynamic_cast<PHGenIntegral*>(incoming_object);
+
+  if (!in_gen)
+  {
+    cout << "PHGenIntegralv1::Integrate - Fatal Error - "
+         << "input object is not a PHGenIntegral: ";
+    incoming_object->identify();
+
+    exit(EXIT_FAILURE);
+  }
+
+  if (fIntegratedLumi == 0 and fNProcessedEvent == 0)
+  {
+    fDescription = in_gen->get_Description();
+  }
+  else if (fDescription != in_gen->get_Description())
+  {
+    fDescription = fDescription + ", and " + in_gen->get_Description();
+  }
+
+  fNProcessedEvent += in_gen->get_N_Processed_Event();
+  fNGeneratorAcceptedEvent += in_gen->get_N_Generator_Accepted_Event();
+  fIntegratedLumi += in_gen->get_Integrated_Lumi();
+  fSumOfWeight += in_gen->get_Sum_Of_Weight();
+}

--- a/generators/phhepmc/PHGenIntegralv1.h
+++ b/generators/phhepmc/PHGenIntegralv1.h
@@ -28,6 +28,7 @@ class PHGenIntegralv1 : public PHGenIntegral
   virtual void identify(std::ostream& os = std::cout) const;
   virtual void Reset();
 
+  virtual int Integrate() const { return 1; }
   /// For integral objects, e.g. integrated luminosity counter, integrate with another object from another run
   virtual void Integrate(PHObject*);
 

--- a/generators/phhepmc/PHGenIntegralv1.h
+++ b/generators/phhepmc/PHGenIntegralv1.h
@@ -20,7 +20,7 @@ class PHGenIntegralv1 : public PHGenIntegral
 {
  public:
   PHGenIntegralv1();
-  PHGenIntegralv1(const std::string & description);
+  explicit PHGenIntegralv1(const std::string & description);
   virtual ~PHGenIntegralv1();
 
   virtual PHObject* clone() const;

--- a/generators/phhepmc/PHGenIntegralv1.h
+++ b/generators/phhepmc/PHGenIntegralv1.h
@@ -30,7 +30,7 @@ class PHGenIntegralv1 : public PHGenIntegral
 
   virtual int Integrate() const { return 1; }
   /// For integral objects, e.g. integrated luminosity counter, integrate with another object from another run
-  virtual void Integrate(PHObject*);
+  virtual int Integrate(PHObject*);
 
   //! Integrated luminosity in pb^-1
   Double_t get_Integrated_Lumi() const

--- a/generators/phhepmc/PHGenIntegralv1.h
+++ b/generators/phhepmc/PHGenIntegralv1.h
@@ -1,0 +1,119 @@
+// $Id: $
+
+/*!
+ * \file PHGenIntegralv1.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef SIMULATION_CORESOFTWARE_GENERATORS_PHHEPMC_PHGENINTEGRALV1_H_
+#define SIMULATION_CORESOFTWARE_GENERATORS_PHHEPMC_PHGENINTEGRALV1_H_
+
+#include "PHGenIntegral.h"
+
+/*!
+ * \brief PHGenIntegralv1
+ */
+class PHGenIntegralv1 : public PHGenIntegral
+{
+ public:
+  PHGenIntegralv1();
+  PHGenIntegralv1(const std::string & description);
+  virtual ~PHGenIntegralv1();
+
+  virtual PHObject* clone() const;
+  virtual int isValid() const { return 1; }
+  virtual void identify(std::ostream& os = std::cout) const;
+  virtual void Reset();
+
+  /// For integral objects, e.g. integrated luminosity counter, integrate with another object from another run
+  virtual void Integrate(PHObject*);
+
+  //! Integrated luminosity in pb^-1
+  Double_t get_Integrated_Lumi() const
+  {
+    return fIntegratedLumi;
+  }
+
+  //! Integrated luminosity in pb^-1
+  void set_Integrated_Lumi(Double_t integratedLumi)
+  {
+    fIntegratedLumi = integratedLumi;
+  }
+
+  //! Number of accepted events in the event generator. This can be higher than fNProcessedEvent depending on trigger on the event generator
+  ULong64_t get_N_Generator_Accepted_Event() const
+  {
+    return fNGeneratorAcceptedEvent;
+  }
+
+  //! Number of accepted events in the event generator. This can be higher than fNProcessedEvent depending on trigger on the event generator
+  void set_N_Generator_Accepted_Event(ULong64_t nGeneratorAcceptedEvent)
+  {
+    fNGeneratorAcceptedEvent = nGeneratorAcceptedEvent;
+  }
+
+  //! Number of processed events in the Fun4All cycles
+  ULong64_t get_N_Processed_Event() const
+  {
+    return fNProcessedEvent;
+  }
+
+  //! Number of processed events in the Fun4All cycles
+  void set_N_Processed_Event(ULong64_t nProcessedEvent)
+  {
+    fNProcessedEvent = nProcessedEvent;
+  }
+
+  //! Sum of weight assigned to the events by the generators.
+  //! Event weight is normally 1 and thus equal to number of the generated event and is uninteresting.
+  //! However, there are several cases where one may have nontrivial event weights, e.g. using user hooks in Pythia8 generators to reweight the phase space
+  Double_t get_Sum_Of_Weight() const
+  {
+    return fSumOfWeight;
+  }
+
+  //! Sum of weight assigned to the events by the generators.
+  //! Event weight is normally 1 and thus equal to number of the generated event and is uninteresting.
+  //! However, there are several cases where one may have nontrivial event weights, e.g. using user hooks in Pythia8 generators to reweight the phase space
+  void set_Sum_Of_Weight(Double_t sumOfWeight)
+  {
+    fSumOfWeight = sumOfWeight;
+  }
+
+  //! description on the source
+  const std::string& get_Description() const
+  {
+    return fDescription;
+  }
+
+  //! description on the source
+  void set_Description(const std::string& description)
+  {
+    fDescription = description;
+  }
+
+ private:
+  //! Number of processed events in the Fun4All cycles
+  ULong64_t fNProcessedEvent;
+
+  //! Number of accepted events in the event generator. This can be higher than fNProcessedEvent depending on trigger on the event generator
+  ULong64_t fNGeneratorAcceptedEvent;
+
+  //! Integrated luminosity in pb^-1
+  Double_t fIntegratedLumi;
+
+  //! Sum of weight assigned to the events by the generators.
+  //! Event weight is normally 1 and thus equal to number of the generated event and is uninteresting.
+  //! However, there are several cases where one may have nontrivial event weights, e.g. using user hooks in Pythia8 generators to reweight the phase space
+  Double_t fSumOfWeight;
+
+  //! description on the source
+  std::string fDescription;
+
+  ClassDef(PHGenIntegralv1, 1)
+};
+
+#endif /* SIMULATION_CORESOFTWARE_GENERATORS_PHHEPMC_PHGENINTEGRALV1_H_ */

--- a/generators/phhepmc/PHGenIntegralv1.h
+++ b/generators/phhepmc/PHGenIntegralv1.h
@@ -31,6 +31,7 @@ class PHGenIntegralv1 : public PHGenIntegral
   virtual int Integrate() const { return 1; }
   /// For integral objects, e.g. integrated luminosity counter, integrate with another object from another run
   virtual int Integrate(PHObject*);
+  virtual void CopyContent(PHObject* obj);
 
   //! Integrated luminosity in pb^-1
   Double_t get_Integrated_Lumi() const

--- a/generators/phhepmc/PHGenIntegralv1LinkDef.h
+++ b/generators/phhepmc/PHGenIntegralv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHGenIntegralv1+;
+
+#endif

--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -115,7 +115,7 @@ int Fun4AllDstInputManager::fileopen(const string &filenam)
       delete tmpIman;
 
       PHNodeIntegrate integrate;
-      integrate.RunNode(runNodeCopy);
+      integrate.RunNode(runNode);
       integrate.RunSumNode(runNodeSum);
       // run recursively over internal run node copy and integrate objects
       PHNodeIterator mainIter(runNodeCopy);

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.cc
@@ -74,7 +74,7 @@ void Fun4AllDstOutputManager::Print(const string &what) const
 {
   if (what == "ALL" || what == "WRITENODES")
   {
-    vector<string>::const_iterator iter;
+//    vector<string>::const_iterator iter;
     cout << ThisName << " writes " << outfilename << endl;
     if (savenodes.empty())
     {
@@ -115,7 +115,7 @@ void Fun4AllDstOutputManager::Print(const string &what) const
 int Fun4AllDstOutputManager::Write(PHCompositeNode *startNode)
 {
   PHNodeIterator nodeiter(startNode);
-  vector<string>::iterator iter;
+//  vector<string>::iterator iter;
   PHNode *ChosenNode = 0;
   if (savenodes.empty())
   {

--- a/offline/framework/phool/PHNodeIntegrate.h
+++ b/offline/framework/phool/PHNodeIntegrate.h
@@ -13,7 +13,7 @@ class PHCompositeNode;
 class PHNodeIntegrate : public PHNodeOperation
 {
  public:
-  PHNodeIntegrate() {}
+  PHNodeIntegrate():runnode(nullptr),runsumnode(nullptr) {}
   virtual ~PHNodeIntegrate() {}
   void RunNode(PHCompositeNode *node)
   {


### PR DESCRIPTION
Following framework update in #387 , revive PR #378 to store integrated quantities from Pythia8 event generator, including integrated luminosity and events. The integrated luminosity will be summed automatically when multiple DST files are analyzed. 

## Examples

# Run time

Pythia8 simulation will produce the following nodes on the node tree:

```
List of Nodes in Fun4AllServer:
Node Tree under TopNode TOP
TOP (PHCompositeNode)/
   DST (PHCompositeNode)/
      .....
   RUN (PHCompositeNode)/
      PHGenIntegral (IO,PHGenIntegralv1)    <- the new node
       ....
```

And at the end of processing, print out the content in this node, e.g.:

```
 *-------  PYTHIA Event and Cross Section Statistics  -------------------------------------------------------------*
 |                                                                                                                 |
 | Subprocess                                    Code |            Number of events       |      sigma +- delta    |
 |                                                    |       Tried   Selected   Accepted |     (estimated) (mb)   |
 |                                                    |                                   |                        |
 |-----------------------------------------------------------------------------------------------------------------|
......
 | sum                                                |       10006       1396       1396 |   4.640e-03  6.152e-05 |
 |                                                                                                                 |
 *-------  End PYTHIA Event and Cross Section Statistics ----------------------------------------------------------*
......
 *-------  End PYTHIA Trigger Statistics  -------------------------------------------------------------------------* 
Integral information on stored on node SUM/PHGenIntegral:
PHGenIntegralv1::identify: PHPythia8 with embedding ID of 1
 N_Generator_Accepted_Event = 1396 @ 4.640e+06 pb
          N_Processed_Event = 10 @ 3.324e+04 pb
              Sum_Of_Weight = 1.396e+03
            Integrated_Lumi = 3.009e-04 pb^-1
 *-------  End PYTHIA Integral Node Print  -------------------------------------------------------------------------* 

```

This information can be accessed programmatically with analysis module via the ```RUN/PHGenIntegral``` node tree, or interactively via ROOT command prompt:

```
[jinhuang@rcas2075 macros]$ root
root [0]  gSystem->Load("libg4dst.so");
root [1] new TFile("G4sPHENIX.root") // DST file produced after analyzing four of above pythia runs
root [2]  T1->Scan("RUN.PHGenIntegral.identify()") 
************************
*    Row   * RUN.PHGen *
************************
PHGenIntegralv1::identify: PHPythia8 with embedding ID of 1
 N_Generator_Accepted_Event = 6042 @ 4.65722e+06 pb
          N_Processed_Event = 40 @ 30832.3 pb
              Sum_Of_Weight = 6042
            Integrated_Lumi = 0.00129734 pb^-1
*        0 *         0 *
************************
``` 
