### PR TITLE
phool Cleanup - removal of PHBoolean type

### DIFF
--- a/offline/database/pdbcal/base/PdbBankManager.h
+++ b/offline/database/pdbcal/base/PdbBankManager.h
@@ -8,7 +8,6 @@
 #include "PdbBankID.h"
 
 #include <phool/PHTimeStamp.h>
-#include <phool/phool.h>
 
 #include <ctime>
 #include <map>
@@ -99,7 +98,7 @@ public:
   // 			     const std::string &,
   // 			     PHTimeStamp &) = 0;
 
-  virtual PdbApplication* getApplication(PHBoolean pJob = False) = 0;
+  virtual PdbApplication* getApplication() = 0;
 
   virtual void fillCalibObject(PdbCalBank*,
 			       const std::string &,

--- a/offline/database/pdbcal/pg/PgPostBankManager.cc
+++ b/offline/database/pdbcal/pg/PgPostBankManager.cc
@@ -431,7 +431,7 @@ PgPostBankManager::fetchClosestBank(const string &className, PdbBankID bankID, c
 
 
 
-PdbApplication* PgPostBankManager::getApplication(PHBoolean pJob)
+PdbApplication* PgPostBankManager::getApplication()
 {
   return PgPostApplication::instance();
 }

--- a/offline/database/pdbcal/pg/PgPostBankManager.h
+++ b/offline/database/pdbcal/pg/PgPostBankManager.h
@@ -51,7 +51,7 @@ public:
 
   // void fetchAllBanks(PdbBankList &, const std::string &, const std::string &, PHTimeStamp &);
   
-  PdbApplication* getApplication(PHBoolean pJob = False);
+  PdbApplication* getApplication();
   
   void fillCalibObject(PdbCalBank*, const std::string &,  PHTimeStamp &) {}
 

--- a/offline/framework/phool/PHBase_LinkDef.h
+++ b/offline/framework/phool/PHBase_LinkDef.h
@@ -2,19 +2,19 @@
 
 #pragma link C++ enum PHMessageType;
 #pragma link C++ enum PHAccessType;
-#pragma link C++ enum  PHTreeType;
-#pragma link C++ function PHMessage(const std::string&, int, const std::string&);
-#pragma link C++ class PHRandomSeed-!;
-#pragma link C++ class PHFlag-! ;
-#pragma link C++ class PHObject+ ;
-#pragma link C++ class PHTimeServer-!;
-#pragma link C++ class PHTimeStamp+;
-#pragma link C++ class recoConsts-!;
+#pragma link C++ enum PHTreeType;
+#pragma link C++ function PHMessage(const std::string &, int, const std::string &);
+#pragma link C++ class PHRandomSeed - !;
+#pragma link C++ class PHFlag - !;
+#pragma link C++ class PHObject + ;
+#pragma link C++ class PHTimeServer - !;
+#pragma link C++ class PHTimeStamp + ;
+#pragma link C++ class recoConsts - !;
 
-#pragma link C++ function operator +  (const PHTimeStamp &, time_t);
-#pragma link C++ function operator -  (const PHTimeStamp &, time_t);
-#pragma link C++ function operator -  (const PHTimeStamp &, const PHTimeStamp &);
-#pragma link C++ function operator << (ostream &, const PHTimeStamp &);
-#pragma link C++ function operator >> (istream &, const PHTimeStamp &);
+#pragma link C++ function operator+ (const PHTimeStamp &, time_t);
+#pragma link C++ function operator- (const PHTimeStamp &, time_t);
+#pragma link C++ function operator- (const PHTimeStamp &, const PHTimeStamp &);
+#pragma link C++ function operator<< (ostream &, const PHTimeStamp &);
+#pragma link C++ function operator>> (istream &, const PHTimeStamp &);
 
 #endif /* __CINT__ */

--- a/offline/framework/phool/PHBase_LinkDef.h
+++ b/offline/framework/phool/PHBase_LinkDef.h
@@ -1,6 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ typedef PHBoolean;
 #pragma link C++ enum PHMessageType;
 #pragma link C++ enum PHAccessType;
 #pragma link C++ enum  PHTreeType;

--- a/offline/framework/phool/PHCompositeNode.cc
+++ b/offline/framework/phool/PHCompositeNode.cc
@@ -6,26 +6,28 @@
 //  Implementation of class PHCompositeNode
 //
 //-----------------------------------------------------------------------------
-#include "PHCompositeNode.h" 
+#include "PHCompositeNode.h"
 #include "PHPointerListIterator.h"
-#include "phooldefs.h"
 #include "phool.h"
+#include "phooldefs.h"
 
 #include <iostream>
 
 using namespace std;
 
-PHCompositeNode::PHCompositeNode() : PHNode("NULL")
-{}
+PHCompositeNode::PHCompositeNode()
+  : PHNode("NULL")
+{
+}
 
-PHCompositeNode::PHCompositeNode(const string& name) : 
-  PHNode(name,"PHCompositeNode"),
-  deleteMe(0)
+PHCompositeNode::PHCompositeNode(const string& name)
+  : PHNode(name, "PHCompositeNode")
+  , deleteMe(0)
 {
   type = "PHCompositeNode";
 }
 
-PHCompositeNode::~PHCompositeNode() 
+PHCompositeNode::~PHCompositeNode()
 {
   // we need to mark this node to be to deleted
   // The recursive taking out of deleted subnodes via
@@ -37,23 +39,22 @@ PHCompositeNode::~PHCompositeNode()
   subNodes.clearAndDestroy();
 }
 
-bool
-PHCompositeNode::addNode(PHNode* newNode)
+bool PHCompositeNode::addNode(PHNode* newNode)
 {
   //
   // Check all existing subNodes for name-conflict.
   //
   PHPointerListIterator<PHNode> nodeIter(subNodes);
   PHNode* thisNode;
-  while ((thisNode = nodeIter())) 
+  while ((thisNode = nodeIter()))
+  {
+    if (thisNode->getName() == newNode->getName())
     {
-      if (thisNode->getName() == newNode->getName()) 
-	{
-	  cout << PHWHERE << "Node " << newNode->getName() 
-               << " already exists" << endl;
-	  return false;
-	}
+      cout << PHWHERE << "Node " << newNode->getName()
+           << " already exists" << endl;
+      return false;
     }
+  }
   //
   // No conflict, so we can append the new node.
   //
@@ -61,79 +62,75 @@ PHCompositeNode::addNode(PHNode* newNode)
   return (subNodes.append(newNode));
 }
 
-void
-PHCompositeNode::prune()
+void PHCompositeNode::prune()
 {
   PHPointerListIterator<PHNode> nodeIter(subNodes);
   PHNode* thisNode;
-  while ((thisNode = nodeIter())) 
+  while ((thisNode = nodeIter()))
+  {
+    if (!thisNode->isPersistent())
     {
-      if (!thisNode->isPersistent()) 
-	{
-	  subNodes.removeAt(nodeIter.pos());
-	  --nodeIter;
-	  delete thisNode;
-	}
-      else
-	{
-	  thisNode->prune();
-	}
+      subNodes.removeAt(nodeIter.pos());
+      --nodeIter;
+      delete thisNode;
     }
+    else
+    {
+      thisNode->prune();
+    }
+  }
 }
 
-void
-PHCompositeNode::forgetMe(PHNode* child)
+void PHCompositeNode::forgetMe(PHNode* child)
 {
-// if this PHCompositeNode is supposed to be deleted,
-// do not remove the child from the list,
-// otherwise the clearanddestroy() bookkeeping gets
-// confused and deletes only every other node
-  if (deleteMe) 
-    {
-      return;
-    }
+  // if this PHCompositeNode is supposed to be deleted,
+  // do not remove the child from the list,
+  // otherwise the clearanddestroy() bookkeeping gets
+  // confused and deletes only every other node
+  if (deleteMe)
+  {
+    return;
+  }
   PHPointerListIterator<PHNode> nodeIter(subNodes);
   PHNode* thisNode;
-  while (child && (thisNode = nodeIter())) 
+  while (child && (thisNode = nodeIter()))
+  {
+    if (thisNode == child)
     {
-      if (thisNode == child) 
-	{
-	  subNodes.removeAt(nodeIter.pos());
-	  child = 0;
-	}
-    }   
+      subNodes.removeAt(nodeIter.pos());
+      child = 0;
+    }
+  }
 }
 
-bool
-PHCompositeNode::write(PHIOManager * IOManager, const std::string &path)
+bool PHCompositeNode::write(PHIOManager* IOManager, const std::string& path)
 {
-   string newPath = name;
-   if (!path.empty())
-     {
-       newPath = path + phooldefs::branchpathdelim + name;
-     }
-   PHPointerListIterator<PHNode> nodeIter(subNodes);
-   PHNode* thisNode;
-   bool success = true;
-   while ((thisNode = nodeIter())) 
-     {
-       if (!(thisNode->write(IOManager, newPath)))
-	 {
-	   success = false;
-	 }
-     }
-   return success;
+  string newPath = name;
+  if (!path.empty())
+  {
+    newPath = path + phooldefs::branchpathdelim + name;
+  }
+  PHPointerListIterator<PHNode> nodeIter(subNodes);
+  PHNode* thisNode;
+  bool success = true;
+  while ((thisNode = nodeIter()))
+  {
+    if (!(thisNode->write(IOManager, newPath)))
+    {
+      success = false;
+    }
+  }
+  return success;
 }
 
-void
-PHCompositeNode::print(const string &path)
+void PHCompositeNode::print(const string& path)
 {
   string newPath = "   " + path;
   cout << path << name << " (" << type << ")/" << endl;
   PHPointerListIterator<PHNode> nodeIter(subNodes);
   PHNode* thisNode;
-  while ((thisNode = nodeIter())) 
-    {
-      thisNode->print(newPath);
-    }
+  while ((thisNode = nodeIter()))
+  {
+    thisNode->print(newPath);
+  }
 }

--- a/offline/framework/phool/PHCompositeNode.cc
+++ b/offline/framework/phool/PHCompositeNode.cc
@@ -9,6 +9,7 @@
 #include "PHCompositeNode.h" 
 #include "PHPointerListIterator.h"
 #include "phooldefs.h"
+#include "phool.h"
 
 #include <iostream>
 
@@ -36,7 +37,7 @@ PHCompositeNode::~PHCompositeNode()
   subNodes.clearAndDestroy();
 }
 
-PHBoolean
+bool
 PHCompositeNode::addNode(PHNode* newNode)
 {
   //
@@ -50,7 +51,7 @@ PHCompositeNode::addNode(PHNode* newNode)
 	{
 	  cout << PHWHERE << "Node " << newNode->getName() 
                << " already exists" << endl;
-	  return False;
+	  return false;
 	}
     }
   //

--- a/offline/framework/phool/PHCompositeNode.h
+++ b/offline/framework/phool/PHCompositeNode.h
@@ -4,7 +4,6 @@
 //  Declaration of class PHCompositeNode
 //  Purpose: a node which can hold other nodes
 
-#include "phool.h"
 #include "PHNode.h"
 #include "PHPointerList.h"
 
@@ -22,7 +21,7 @@ public:
    //
    // The user is only allowed to add new nodes, not to delete existing ones.
    //
-   PHBoolean addNode(PHNode*);
+   bool addNode(PHNode*);
 
    //
    // This recursively calls the prune function of all the subnodes.

--- a/offline/framework/phool/PHCompositeNode.h
+++ b/offline/framework/phool/PHCompositeNode.h
@@ -10,39 +10,39 @@
 class PHIOManager;
 class PHNodeIterator;
 
-class PHCompositeNode : public PHNode { 
+class PHCompositeNode : public PHNode
+{
+  friend class PHNodeIterator;
 
-   friend class PHNodeIterator;
-   
-public: 
-   PHCompositeNode(const std::string &); 
-   virtual ~PHCompositeNode(); 
+ public:
+  PHCompositeNode(const std::string &);
+  virtual ~PHCompositeNode();
 
-   //
-   // The user is only allowed to add new nodes, not to delete existing ones.
-   //
-   bool addNode(PHNode*);
+  //
+  // The user is only allowed to add new nodes, not to delete existing ones.
+  //
+  bool addNode(PHNode *);
 
-   //
-   // This recursively calls the prune function of all the subnodes.
-   // If a subnode is found to be marked as transient (non persistent)
-   // the entire sub-tree is deleted.
-   //
-   virtual void prune();
+  //
+  // This recursively calls the prune function of all the subnodes.
+  // If a subnode is found to be marked as transient (non persistent)
+  // the entire sub-tree is deleted.
+  //
+  virtual void prune();
 
-   //
-   // I/O functions
-   //
-   void print(const std::string & = "");
-   virtual bool write(PHIOManager *, const std::string & = "");
+  //
+  // I/O functions
+  //
+  void print(const std::string & = "");
+  virtual bool write(PHIOManager *, const std::string & = "");
 
-protected:
-   virtual void forgetMe(PHNode*);
-   PHPointerList<PHNode> subNodes;
-   int deleteMe;
+ protected:
+  virtual void forgetMe(PHNode *);
+  PHPointerList<PHNode> subNodes;
+  int deleteMe;
 
-private:
-   PHCompositeNode();
-}; 
+ private:
+  PHCompositeNode();
+};
 
 #endif /* PHCOMPOSITENODE_H__ */

--- a/offline/framework/phool/PHDataNode.h
+++ b/offline/framework/phool/PHDataNode.h
@@ -9,93 +9,92 @@
 #include <iostream>
 class TObject;
 
-template <class T> 
-class PHDataNode : public PHNode 
+template <class T>
+class PHDataNode : public PHNode
 {
-public: 
-  PHDataNode(T*, const std::string&); 
-  PHDataNode(T*, const std::string&, const std::string &); 
-  virtual ~PHDataNode(); 
+ public:
+  PHDataNode(T*, const std::string&);
+  PHDataNode(T*, const std::string&, const std::string&);
+  virtual ~PHDataNode();
 
-public:
-  T* getData() {return data.data;}
-  void setData(T* d) {data.data = d;}
+ public:
+  T* getData() { return data.data; }
+  void setData(T* d) { data.data = d; }
   virtual void prune() {}
   virtual void forgetMe(PHNode*) {}
   virtual void print(const std::string&);
-  virtual bool write(PHIOManager *, const std::string& = "") 
-    { 
-      return true; 
-    }
-   
-protected: 
-   union tobjcast
-   {
-     T* data;
-     TObject *tobj;
-   };
-   tobjcast data;
-   PHDataNode(); 
-}; 
+  virtual bool write(PHIOManager*, const std::string& = "")
+  {
+    return true;
+  }
 
-template <class T> 
-PHDataNode<T>::PHDataNode() 
+ protected:
+  union tobjcast {
+    T* data;
+    TObject* tobj;
+  };
+  tobjcast data;
+  PHDataNode();
+};
+
+template <class T>
+PHDataNode<T>::PHDataNode()
 {
   data.data = 0;
 }
 
-template <class T> 
-PHDataNode<T>::PHDataNode(T* d, 
-			  const std::string & name) 
+template <class T>
+PHDataNode<T>::PHDataNode(T* d,
+                          const std::string& name)
   : PHNode(name)
 {
   type = "PHDataNode";
   setData(d);
 }
 
-template <class T> 
-PHDataNode<T>::PHDataNode(T* d, 
-			  const std::string &name,
-			  const std::string &objtype)
-  : PHNode(name,objtype)
+template <class T>
+PHDataNode<T>::PHDataNode(T* d,
+                          const std::string& name,
+                          const std::string& objtype)
+  : PHNode(name, objtype)
 {
   type = "PHDataNode";
   setData(d);
 }
 
-template <class T> 
-PHDataNode<T>::~PHDataNode() 
+template <class T>
+PHDataNode<T>::~PHDataNode()
 {
   // This means that the node has complete responsibility for the
   // data it contains. Check for null pointer just in case some
   // joker adds a node with a null pointer
   if (data.data)
-    {
-      delete data.data;
-      data.data = 0;
-    }
+  {
+    delete data.data;
+    data.data = 0;
+  }
 }
 
-template <class T> 
+template <class T>
 void PHDataNode<T>::print(const std::string& path)
 {
   std::cout << path << name << " (";
-  if (! this->objectclass.empty())
+  if (!this->objectclass.empty())
+  {
+    if (type.find("IO") != std::string::npos)
     {
-      if (type.find("IO") != std::string::npos)
-	{
-	  std::cout << "IO";
-	}
-      else
-	{
-	  std::cout << "Data";
-	}
-      std::cout << "," << this->objectclass;
+      std::cout << "IO";
     }
+    else
+    {
+      std::cout << "Data";
+    }
+    std::cout << "," << this->objectclass;
+  }
   else
-    {
-      std::cout << type;
-    }
+  {
+    std::cout << type;
+  }
   std::cout << ")" << std::endl;
 }
 

--- a/offline/framework/phool/PHDataNodeIterator.h
+++ b/offline/framework/phool/PHDataNodeIterator.h
@@ -1,10 +1,10 @@
 #ifndef __PHDATANODEITERATOR_H__
 #define __PHDATANODEITERATOR_H__
 
+#include <cstddef>
+#include "PHIODataNode.h"
 #include "PHIODataNode.h"
 #include "PHNodeIterator.h"
-#include "PHIODataNode.h"
-#include <cstddef>
 
 /**
  * A special PHOOL node iterator that simplifies finding and adding data
@@ -18,14 +18,12 @@
 
 class PHDataNodeIterator : public PHNodeIterator
 {
-public:
-
+ public:
   /// Constructor
   PHDataNodeIterator(PHCompositeNode* node);
 
   /// Destructor
-  virtual ~PHDataNodeIterator(){}
-
+  virtual ~PHDataNodeIterator() {}
   /**
    * Finds an IODataNode of name "name" containing data of type "T".
    * A null pointer will be returned if the node is not found, or if
@@ -35,7 +33,7 @@ public:
    */
   template <class T>
   PHIODataNode<T>* FindIODataNode(PHIODataNode<T>* node,
-				  const char* name);
+                                  const char* name);
 
   /**
    * Adds a data node called "name" to the tree, and inserts "data".
@@ -45,55 +43,50 @@ public:
    */
   template <class T>
   PHBoolean AddIODataNode(T* data, const char* name);
-
 };
 
-
-inline
-PHDataNodeIterator::PHDataNodeIterator(PHCompositeNode* node)
+inline PHDataNodeIterator::PHDataNodeIterator(PHCompositeNode* node)
   : PHNodeIterator(node)
 {
 }
 
-
 template <class T>
 PHIODataNode<T>*
 PHDataNodeIterator::FindIODataNode(PHIODataNode<T>* node,
-				   const char* name)
+                                   const char* name)
 {
   // TODO:  also check that "name" is not a null string!
-  if (!name) 
-    {
-      return 0;
-    }
+  if (!name)
+  {
+    return 0;
+  }
   // Can't do dynamic_cast here; it fails if node was created as
   // PHIODataNode<X> instead of PHIODataNode<T>, even if T is a
   // derived class of X!
   // In general, T -> X does not imply A<T> -> A<X>.
   // ("->" denotes "derives from", and "A" is any template class)
   node = static_cast<PHIODataNode<T>*>(findFirst("PHIODataNode",
-						 name));
+                                                 name));
   return node;
 }
-
 
 template <class T>
 PHBoolean
 PHDataNodeIterator::AddIODataNode(T* data, const char* name)
 {
   // TODO:  also check that "name" is not a null string!
-  if (!name) 
-    {
-      return False;
-    }
+  if (!name)
+  {
+    return False;
+  }
   // For IODataNode, ought to check (if possible) that T derives
   // from TObject.  Will typeid() give us this info?
 
   PHIODataNode<T>* n = new PHIODataNode<T>(data, name);
-  if (!n) 
-    {
-      return False;  // problem creating node?
-    }
+  if (!n)
+  {
+    return False;  // problem creating node?
+  }
   return addNode(n);
 }
 

--- a/offline/framework/phool/PHFlag.cc
+++ b/offline/framework/phool/PHFlag.cc
@@ -1,7 +1,5 @@
 #include "PHFlag.h"
 
-#include "phool.h"
-
 #include <cstring>
 #include <fstream>
 #include <iostream>

--- a/offline/framework/phool/PHFlag.cc
+++ b/offline/framework/phool/PHFlag.cc
@@ -1,6 +1,6 @@
 #include "PHFlag.h"
 
-#include <phool/phool.h>
+#include "phool.h"
 
 #include <cstring>
 #include <fstream>
@@ -14,13 +14,13 @@ PHFlag::get_CharFlag(const string &flag) const
 {
   map<string, string>::const_iterator iter = charflag.find(flag);
   if (iter != charflag.end())
-    {
-      return iter->second;
-    }
+  {
+    return iter->second;
+  }
   cout << "PHFlag::getString: ERROR Unknown character Flag " << flag
        << ", The following are implemented: " << endl;
   Print();
-  return NULL;
+  return nullptr;
 }
 
 const string
@@ -28,30 +28,29 @@ PHFlag::get_CharFlag(const string &flag, const string &defaultval)
 {
   map<string, string>::const_iterator iter = charflag.find(flag);
   if (iter != charflag.end())
-    {
-      return iter->second;
-    }
+  {
+    return iter->second;
+  }
   else
-    {
-      set_CharFlag(flag, defaultval);
-      return get_CharFlag(flag);
-    }
+  {
+    set_CharFlag(flag, defaultval);
+    return get_CharFlag(flag);
+  }
 }
 
-void
-PHFlag::set_CharFlag(const string &flag, const string &charstr)
+void PHFlag::set_CharFlag(const string &flag, const string &charstr)
 {
   charflag[flag] = charstr;
-  return ;
+  return;
 }
 
 double PHFlag::get_DoubleFlag(const string &name) const
 {
   map<string, double>::const_iterator iter = doubleflag.find(name);
   if (iter != doubleflag.end())
-    {
-      return iter->second;
-    }
+  {
+    return iter->second;
+  }
   cout << "PHFlag::getFlag: ERROR Unknown Double Flag " << name
        << ", The following are implemented: " << endl;
   Print();
@@ -62,29 +61,29 @@ double PHFlag::get_DoubleFlag(const string &name, const double defaultval)
 {
   map<string, double>::const_iterator iter = doubleflag.find(name);
   if (iter != doubleflag.end())
-    {
-      return iter->second;
-    }
+  {
+    return iter->second;
+  }
   else
-    {
-      set_DoubleFlag(name,defaultval);
-      return get_DoubleFlag(name);
-    }
+  {
+    set_DoubleFlag(name, defaultval);
+    return get_DoubleFlag(name);
+  }
 }
 
 void PHFlag::set_DoubleFlag(const string &name, const double iflag)
 {
   doubleflag[name] = iflag;
-  return ;
+  return;
 }
 
 float PHFlag::get_FloatFlag(const string &name) const
 {
   map<string, float>::const_iterator iter = floatflag.find(name);
   if (iter != floatflag.end())
-    {
-      return iter->second;
-    }
+  {
+    return iter->second;
+  }
   cout << "PHFlag::getFlag: ERROR Unknown Float Flag " << name
        << ", The following are implemented: " << endl;
   Print();
@@ -95,29 +94,29 @@ float PHFlag::get_FloatFlag(const string &name, const float defaultval)
 {
   map<string, float>::const_iterator iter = floatflag.find(name);
   if (iter != floatflag.end())
-    {
-      return iter->second;
-    }
+  {
+    return iter->second;
+  }
   else
-    {
-      set_FloatFlag(name,defaultval);
-      return get_FloatFlag(name);
-    }
+  {
+    set_FloatFlag(name, defaultval);
+    return get_FloatFlag(name);
+  }
 }
 
 void PHFlag::set_FloatFlag(const string &name, const float iflag)
 {
   floatflag[name] = iflag;
-  return ;
+  return;
 }
 
 int PHFlag::get_IntFlag(const string &name) const
 {
   map<string, int>::const_iterator iter = intflag.find(name);
   if (iter != intflag.end())
-    {
-      return iter->second;
-    }
+  {
+    return iter->second;
+  }
   cout << "PHFlag::getFlag: ERROR Unknown Int Flag " << name
        << ", The following are implemented: " << endl;
   Print();
@@ -128,20 +127,20 @@ int PHFlag::get_IntFlag(const string &name, int defaultval)
 {
   map<string, int>::const_iterator iter = intflag.find(name);
   if (iter != intflag.end())
-    {
-      return iter->second;
-    }
+  {
+    return iter->second;
+  }
   else
-    {
-      set_IntFlag(name,defaultval);
-      return get_IntFlag(name);
-    }
+  {
+    set_IntFlag(name, defaultval);
+    return get_IntFlag(name);
+  }
 }
 
 void PHFlag::set_IntFlag(const string &name, const int iflag)
 {
   intflag[name] = iflag;
-  return ;
+  return;
 }
 
 void PHFlag::Print() const
@@ -150,79 +149,83 @@ void PHFlag::Print() const
   PrintFloatFlags();
   PrintDoubleFlags();
   PrintCharFlags();
-  return ;
+  return;
 }
 
 void PHFlag::PrintIntFlags() const
 {
   // loop over the map and print out the content (name and location in memory)
-  cout << endl << "Integer Flags:" << endl;
+  cout << endl
+       << "Integer Flags:" << endl;
   map<string, int>::const_iterator intiter;
   for (intiter = intflag.begin(); intiter != intflag.end(); ++intiter)
-    {
-      cout << intiter->first << " is " << intiter->second << endl;
-    }
-  return ;
+  {
+    cout << intiter->first << " is " << intiter->second << endl;
+  }
+  return;
 }
 
 void PHFlag::PrintDoubleFlags() const
 {
   // loop over the map and print out the content (name and location in memory)
-  cout << endl << "Double Flags:" << endl;
+  cout << endl
+       << "Double Flags:" << endl;
   map<string, double>::const_iterator doubleiter;
   for (doubleiter = doubleflag.begin(); doubleiter != doubleflag.end(); ++doubleiter)
-    {
-      cout << doubleiter->first << " is " << doubleiter->second << endl;
-    }
-  return ;
+  {
+    cout << doubleiter->first << " is " << doubleiter->second << endl;
+  }
+  return;
 }
 
 void PHFlag::PrintFloatFlags() const
 {
   // loop over the map and print out the content (name and location in memory)
-  cout << endl << "Float Flags:" << endl;
+  cout << endl
+       << "Float Flags:" << endl;
   map<string, float>::const_iterator floatiter;
   for (floatiter = floatflag.begin(); floatiter != floatflag.end(); ++floatiter)
-    {
-      cout << floatiter->first << " is " << floatiter->second << endl;
-    }
-  return ;
+  {
+    cout << floatiter->first << " is " << floatiter->second << endl;
+  }
+  return;
 }
 
 void PHFlag::PrintCharFlags() const
 {
   // loop over the map and print out the content (name and location in memory)
-  cout << endl << "char* Flags:" << endl;
+  cout << endl
+       << "char* Flags:" << endl;
   map<string, string>::const_iterator chariter;
   for (chariter = charflag.begin(); chariter != charflag.end(); ++chariter)
-    {
-      cout << chariter->first << " is " << chariter->second << endl;
-    }
-  return ;
+  {
+    cout << chariter->first << " is " << chariter->second << endl;
+  }
+  return;
 }
 
 int PHFlag::FlagExist(const string &name) const
 {
   map<string, int>::const_iterator iter = intflag.find(name);
   if (iter != intflag.end())
-    {
-      return 1;
-    }
+  {
+    return 1;
+  }
   map<string, float>::const_iterator fiter = floatflag.find(name);
   if (fiter != floatflag.end())
-    {
-      return 1;
-    }
+  {
+    return 1;
+  }
   map<string, double>::const_iterator diter = doubleflag.find(name);
   if (diter != doubleflag.end())
-    {
-      return 1;
-    }
+  {
+    return 1;
+  }
   map<string, string>::const_iterator citer = charflag.find(name);
   if (citer != charflag.end())
-    {
-      return 1;
-    }
+  {
+    return 1;
+  }
   return 0;
 }
 
@@ -241,47 +244,51 @@ void PHFlag::ReadFromFile(const string &name)
   int junkcount = 0;
 
   ifstream infile(name.c_str());
-  while(infile>>label)
+  while (infile >> label)
   {
-    cout<<"Label"<<label;
-    if(label.substr(0,1)=="C")
+    cout << "Label" << label;
+    if (label.substr(0, 1) == "C")
     {
-      infile>>cvalue;
+      infile >> cvalue;
       cvaluecount++;
-      set_CharFlag(label.substr(1,label.size()-1), cvalue);
-      cout<<" C read "<< cvalue << endl;
-    }else if(label.substr(0,1)=="F")
-    {
-      infile>>fvalue;
-      fvaluecount++;
-      set_FloatFlag(label.substr(1,label.size()-1), fvalue);
-      cout<<" F read "<< fvalue << endl;
-    }else if(label.substr(0,1)=="D")
-    {
-      infile>>dvalue;
-      dvaluecount++;
-      set_DoubleFlag(label.substr(1,label.size()-1), dvalue);
-      cout<<" D read "<< dvalue << endl;
-    }else if(label.substr(0,1)=="I")
-    {
-      infile>>ivalue;
-      ivaluecount++;
-      set_IntFlag(label.substr(1,label.size()-1), ivalue);
-      cout<<" I read "<< ivalue << endl;
-    }else{
-      infile>>junk;
-      junkcount++;
-      cout<<" Junk read "<< junk << endl;
+      set_CharFlag(label.substr(1, label.size() - 1), cvalue);
+      cout << " C read " << cvalue << endl;
     }
-
+    else if (label.substr(0, 1) == "F")
+    {
+      infile >> fvalue;
+      fvaluecount++;
+      set_FloatFlag(label.substr(1, label.size() - 1), fvalue);
+      cout << " F read " << fvalue << endl;
+    }
+    else if (label.substr(0, 1) == "D")
+    {
+      infile >> dvalue;
+      dvaluecount++;
+      set_DoubleFlag(label.substr(1, label.size() - 1), dvalue);
+      cout << " D read " << dvalue << endl;
+    }
+    else if (label.substr(0, 1) == "I")
+    {
+      infile >> ivalue;
+      ivaluecount++;
+      set_IntFlag(label.substr(1, label.size() - 1), ivalue);
+      cout << " I read " << ivalue << endl;
+    }
+    else
+    {
+      infile >> junk;
+      junkcount++;
+      cout << " Junk read " << junk << endl;
+    }
   }
 
-  cout<<"Read CharFlags("<< cvaluecount
-    <<") FloatFlags("  << fvaluecount
-    <<") DoubleFlags("  << dvaluecount
-    <<") IntFlags("    << ivaluecount
-    <<") JunkEntries(" << junkcount
-    <<") from file "<< name <<endl;
+  cout << "Read CharFlags(" << cvaluecount
+       << ") FloatFlags(" << fvaluecount
+       << ") DoubleFlags(" << dvaluecount
+       << ") IntFlags(" << ivaluecount
+       << ") JunkEntries(" << junkcount
+       << ") from file " << name << endl;
 
   infile.close();
 }

--- a/offline/framework/phool/PHFlag.h
+++ b/offline/framework/phool/PHFlag.h
@@ -19,10 +19,8 @@
 class PHFlag
 {
  public:
-
   PHFlag() {}
   virtual ~PHFlag() {}
-
   virtual const std::string get_CharFlag(const std::string &flag) const;
   virtual const std::string get_CharFlag(const std::string &name, const std::string &defaultval);
   virtual void set_CharFlag(const std::string &name, const std::string &flag);
@@ -49,18 +47,15 @@ class PHFlag
 
   virtual int FlagExist(const std::string &name) const;
 
-  virtual const std::map<std::string, int> *IntMap() const {return &intflag;}
-  virtual const std::map<std::string, float> *FloatMap() const {return &floatflag;}
-  virtual const std::map<std::string, double> *DoubleMap() const {return &doubleflag;}
-  virtual const std::map<std::string, std::string> *CharMap() const {return &charflag;}
-
+  virtual const std::map<std::string, int> *IntMap() const { return &intflag; }
+  virtual const std::map<std::string, float> *FloatMap() const { return &floatflag; }
+  virtual const std::map<std::string, double> *DoubleMap() const { return &doubleflag; }
+  virtual const std::map<std::string, std::string> *CharMap() const { return &charflag; }
  protected:
-
   std::map<std::string, int> intflag;
   std::map<std::string, double> doubleflag;
   std::map<std::string, float> floatflag;
   std::map<std::string, std::string> charflag;
-
 };
 
 #endif /* PHFLAG_H */

--- a/offline/framework/phool/PHIODataNode.h
+++ b/offline/framework/phool/PHIODataNode.h
@@ -15,59 +15,58 @@
 #include <string>
 
 template <typename T>
-class PHIODataNode : public PHDataNode <T>
+class PHIODataNode : public PHDataNode<T>
 {
   friend class PHNodeIOManager;
 
  public:
-  T* operator*() {return this->getData();}
-  PHIODataNode(T*, const std::string &);
-  PHIODataNode(T*, const std::string &, const std::string &);
+  T *operator*() { return this->getData(); }
+  PHIODataNode(T *, const std::string &);
+  PHIODataNode(T *, const std::string &, const std::string &);
   virtual ~PHIODataNode() {}
   typedef PHTypedNodeIterator<T> iterator;
 
  protected:
-  virtual bool write(PHIOManager *, const std::string& = "");
+  virtual bool write(PHIOManager *, const std::string & = "");
   PHIODataNode() {}
 };
 
 template <class T>
-PHIODataNode<T>::PHIODataNode(T* d, const std::string& name)
+PHIODataNode<T>::PHIODataNode(T *d, const std::string &name)
   : PHDataNode<T>(d, name)
 {
   this->type = "PHIODataNode";
-  TObject *TO = static_cast<TObject *> (d);
+  TObject *TO = static_cast<TObject *>(d);
   this->objectclass = TO->GetName();
 }
 
 template <class T>
-PHIODataNode<T>::PHIODataNode(T* d, const std::string& name,
-                              const std::string& objtype)
+PHIODataNode<T>::PHIODataNode(T *d, const std::string &name,
+                              const std::string &objtype)
   : PHDataNode<T>(d, name, objtype)
 {
   this->type = "PHIODataNode";
-  TObject *TO = static_cast<TObject *> (d);
+  TObject *TO = static_cast<TObject *>(d);
   this->objectclass = TO->GetName();
 }
 
 template <class T>
-bool
-PHIODataNode<T>::write(PHIOManager* IOManager, const std::string& path)
+bool PHIODataNode<T>::write(PHIOManager *IOManager, const std::string &path)
 {
   if (this->persistent)
+  {
+    PHNodeIOManager *np = dynamic_cast<PHNodeIOManager *>(IOManager);
+    if (np)
     {
-      PHNodeIOManager *np = dynamic_cast<PHNodeIOManager*>(IOManager);
-      if (np)
-        {
-	  std::string newPath = path + phooldefs::branchpathdelim + this->name;
-	  bool bret = false;
-	  if (dynamic_cast<TObject *> (this->data.data))
-	    {
-	      bret =  np->write(&(this->data.tobj), newPath);
-	    }
-	  return bret;
-        }
+      std::string newPath = path + phooldefs::branchpathdelim + this->name;
+      bool bret = false;
+      if (dynamic_cast<TObject *>(this->data.data))
+      {
+        bret = np->write(&(this->data.tobj), newPath);
+      }
+      return bret;
     }
+  }
   return true;
 }
 

--- a/offline/framework/phool/PHIOManager.cc
+++ b/offline/framework/phool/PHIOManager.cc
@@ -10,6 +10,7 @@
 
 #include "PHIOManager.h"
 
-PHIOManager::PHIOManager():
-  eventNumber(0)
-{}
+PHIOManager::PHIOManager()
+  : eventNumber(0)
+{
+}

--- a/offline/framework/phool/PHIOManager.h
+++ b/offline/framework/phool/PHIOManager.h
@@ -9,22 +9,26 @@
 
 class PHCompositeNode;
 
-class PHIOManager { 
-public: 
-   virtual ~PHIOManager(){} 
+class PHIOManager
+{
+ public:
+  virtual ~PHIOManager() {}
+ public:
+  std::string getFilename() const { return filename; }
+  size_t getEventNumber() const { return eventNumber; }
+  void setEventNumber(const size_t evno)
+  {
+    eventNumber = evno;
+    return;
+  }
+  virtual void closeFile() = 0;
+  virtual bool write(PHCompositeNode *) = 0;
+  virtual void print() const = 0;
 
-public:
-   std::string getFilename() const {return filename;}
-   size_t getEventNumber() const { return eventNumber; }
-   void setEventNumber(const size_t evno) { eventNumber = evno; return;}
-   virtual void closeFile() = 0;
-   virtual bool write(PHCompositeNode *) = 0;
-   virtual void print() const = 0;
-   
-protected: 
-   PHIOManager();
-   std::string        filename;
-   size_t          eventNumber;
-}; 
+ protected:
+  PHIOManager();
+  std::string filename;
+  size_t eventNumber;
+};
 
 #endif /* PHIOMANAGER_H__ */

--- a/offline/framework/phool/PHIOManager.h
+++ b/offline/framework/phool/PHIOManager.h
@@ -1,11 +1,9 @@
-#ifndef __PHIOMANAGER_H__
-#define __PHIOMANAGER_H__
+#ifndef PHIOMANAGER_H__
+#define PHIOMANAGER_H__
 
 //  Declaration of class PHIOManager
 //  Purpose: Abstract base class for file IO
 //  Author: Matthias Messer
-
-#include "phool.h"
 
 #include <string>
 
@@ -20,7 +18,7 @@ public:
    size_t getEventNumber() const { return eventNumber; }
    void setEventNumber(const size_t evno) { eventNumber = evno; return;}
    virtual void closeFile() = 0;
-   virtual PHBoolean write(PHCompositeNode *) = 0;
+   virtual bool write(PHCompositeNode *) = 0;
    virtual void print() const = 0;
    
 protected: 
@@ -29,4 +27,4 @@ protected:
    size_t          eventNumber;
 }; 
 
-#endif /* __PHIOMANAGER_H__ */
+#endif /* PHIOMANAGER_H__ */

--- a/offline/framework/phool/PHMessage.cc
+++ b/offline/framework/phool/PHMessage.cc
@@ -7,22 +7,22 @@ using namespace std;
 
 void PHMessage(const std::string& functionName, int messageType, const std::string& message)
 {
-   switch (messageType) {
-   case (PHError):
-      cerr << functionName << endl;
-      cerr << "\tERROR" << endl;
-      cerr << "\t" << message << endl;
-      break;
-   case(PHWarning):
-      cout << functionName << endl;
-      cout << "\tWARNING" << endl;
-      cout << "\t" << message << endl;
-      break;
-   case(PHHullo):
-      cout << functionName << endl;
-      cout << "\tHULLO HULLO HULLO" << endl;
-      cout << "\t" << message << endl;
-      break;
-   }
+  switch (messageType)
+  {
+  case (PHError):
+    cerr << functionName << endl;
+    cerr << "\tERROR" << endl;
+    cerr << "\t" << message << endl;
+    break;
+  case (PHWarning):
+    cout << functionName << endl;
+    cout << "\tWARNING" << endl;
+    cout << "\t" << message << endl;
+    break;
+  case (PHHullo):
+    cout << functionName << endl;
+    cout << "\tHULLO HULLO HULLO" << endl;
+    cout << "\t" << message << endl;
+    break;
+  }
 }
-

--- a/offline/framework/phool/PHNode.cc
+++ b/offline/framework/phool/PHNode.cc
@@ -2,6 +2,8 @@
 
 #include "PHNode.h"
 
+#include "phool.h"
+
 #include <cstdlib>
 #include <iostream>
 
@@ -79,17 +81,11 @@ PHNode::operator=(const PHNode&)
   exit(1);
 }
 
-void
-PHNode::setResetFlag(const int val)
-{
-  reset_able = (val) ? true : false;
-}
-
-PHBoolean  
-PHNode::getResetFlag() const
-{
-  return reset_able;
-}
+// void
+// PHNode::setResetFlag(const int val)
+// {
+//   reset_able = (val) ? true : false;
+// }
 
 // Implementation of external functions.
 std::ostream & 

--- a/offline/framework/phool/PHNode.cc
+++ b/offline/framework/phool/PHNode.cc
@@ -9,71 +9,71 @@
 
 using namespace std;
 
-PHNode::PHNode() : 
-  parent(NULL),
-  persistent(true),
-  type("PHNode"),
-  reset_able(true)
+PHNode::PHNode()
+  : parent(NULL)
+  , persistent(true)
+  , type("PHNode")
+  , reset_able(true)
 {
   return;
 }
 
-PHNode::PHNode(const string& n) : 
-  parent(NULL),
-  persistent(true),
-  type("PHNode"),
-  reset_able(true)
+PHNode::PHNode(const string& n)
+  : parent(NULL)
+  , persistent(true)
+  , type("PHNode")
+  , reset_able(true)
 {
   if (n.find(".") != string::npos)
-    {
-      cout << PHWHERE << " No nodenames containing decimal point possible: "
-	   << n << endl;
-      exit(1);
-    }
+  {
+    cout << PHWHERE << " No nodenames containing decimal point possible: "
+         << n << endl;
+    exit(1);
+  }
   name = n;
   return;
 }
 
-PHNode::PHNode(const string& n, const string& typ) : 
-  parent(NULL),
-  persistent(true),
-  type("PHNode"),
-  objecttype(typ),
-  reset_able(true)
+PHNode::PHNode(const string& n, const string& typ)
+  : parent(NULL)
+  , persistent(true)
+  , type("PHNode")
+  , objecttype(typ)
+  , reset_able(true)
 {
   if (n.find(".") != string::npos)
-    {
-      cout << PHWHERE << " No nodenames containing decimal point possible: "
-	   << n << endl;
-      exit(1);
-    }
+  {
+    cout << PHWHERE << " No nodenames containing decimal point possible: "
+         << n << endl;
+    exit(1);
+  }
   name = n;
   return;
 }
 
-PHNode::~PHNode() 
+PHNode::~PHNode()
 {
-   if (parent)
-     {
-       parent->forgetMe(this);
-     }
+  if (parent)
+  {
+    parent->forgetMe(this);
+  }
 }
 
-PHNode::PHNode(const PHNode &phn):
-  parent(NULL),
-  persistent(phn.persistent),
-  type(phn.type),
-  objecttype(phn.objecttype),
-  name(phn.name),
-  objectclass(phn.objectclass),
-  reset_able(phn.reset_able)
+PHNode::PHNode(const PHNode& phn)
+  : parent(NULL)
+  , persistent(phn.persistent)
+  , type(phn.type)
+  , objecttype(phn.objecttype)
+  , name(phn.name)
+  , objectclass(phn.objectclass)
+  , reset_able(phn.reset_able)
 {
   cout << "copy ctor not implemented because of pointer to parent" << endl;
   cout << "which needs implementing for this to be reasonable" << endl;
   exit(1);
 }
 
-PHNode &
+PHNode&
 PHNode::operator=(const PHNode&)
 {
   cout << "= operator not implemented because of pointer to parent" << endl;
@@ -88,11 +88,10 @@ PHNode::operator=(const PHNode&)
 // }
 
 // Implementation of external functions.
-std::ostream & 
-operator << (std::ostream & stream, const PHNode & node)
+std::ostream&
+operator<<(std::ostream& stream, const PHNode& node)
 {
   stream << node.getType() << " : " << node.getName() << " class " << node.getClass();
 
-   return stream;
+  return stream;
 }
-

--- a/offline/framework/phool/PHNode.cc
+++ b/offline/framework/phool/PHNode.cc
@@ -10,7 +10,7 @@
 using namespace std;
 
 PHNode::PHNode()
-  : parent(NULL)
+  : parent(nullptr)
   , persistent(true)
   , type("PHNode")
   , reset_able(true)
@@ -19,7 +19,7 @@ PHNode::PHNode()
 }
 
 PHNode::PHNode(const string& n)
-  : parent(NULL)
+  : parent(nullptr)
   , persistent(true)
   , type("PHNode")
   , reset_able(true)
@@ -35,7 +35,7 @@ PHNode::PHNode(const string& n)
 }
 
 PHNode::PHNode(const string& n, const string& typ)
-  : parent(NULL)
+  : parent(nullptr)
   , persistent(true)
   , type("PHNode")
   , objecttype(typ)
@@ -60,7 +60,7 @@ PHNode::~PHNode()
 }
 
 PHNode::PHNode(const PHNode& phn)
-  : parent(NULL)
+  : parent(nullptr)
   , persistent(phn.persistent)
   , type(phn.type)
   , objecttype(phn.objecttype)

--- a/offline/framework/phool/PHNode.h
+++ b/offline/framework/phool/PHNode.h
@@ -9,47 +9,40 @@
 
 class PHIOManager;
 
-class PHNode 
-{ 
-public: 
-
+class PHNode
+{
+ public:
   // Note that the constructor makes a node transient by default.
-  PHNode(const std::string &); 
-  PHNode(const std::string &, const std::string&); 
-  virtual ~PHNode(); 
+  PHNode(const std::string &);
+  PHNode(const std::string &, const std::string &);
+  virtual ~PHNode();
 
-public:
-
-  PHNode* getParent() const { return parent; }
-  
+ public:
+  PHNode *getParent() const { return parent; }
   bool isPersistent() const { return persistent; }
-  void makePersistent() { persistent = true;}
-  
+  void makePersistent() { persistent = true; }
   const std::string getObjectType() const { return objecttype; }
   const std::string getType() const { return type; }
   const std::string getName() const { return name; }
-  const std::string getClass() const {return objectclass;}
-
+  const std::string getClass() const { return objectclass; }
   void setParent(PHNode *p) { parent = p; }
-  void setName(const std::string &n) {name = n;}
-  void setObjectType(const std::string &type) {objecttype = type;} 
+  void setName(const std::string &n) { name = n; }
+  void setObjectType(const std::string &type) { objecttype = type; }
   virtual void prune() = 0;
   virtual void print(const std::string &) = 0;
-  virtual void forgetMe(PHNode*) = 0;
-  virtual bool write(PHIOManager *, const std::string& = "") = 0;
+  virtual void forgetMe(PHNode *) = 0;
+  virtual bool write(PHIOManager *, const std::string & = "") = 0;
 
-//  virtual void setResetFlag(const int val);
-  virtual void setResetFlag(const bool b) {reset_able = b;}
-  virtual bool getResetFlag() const {return reset_able;}
-  void makeTransient()  { persistent = false;}
-  
-protected:
-  
+  //  virtual void setResetFlag(const int val);
+  virtual void setResetFlag(const bool b) { reset_able = b; }
+  virtual bool getResetFlag() const { return reset_able; }
+  void makeTransient() { persistent = false; }
+ protected:
   PHNode();
-  PHNode(const PHNode&); // implement invalid copy ctor
-  PHNode & operator=(const PHNode&);
-  
-  PHNode*   parent;
+  PHNode(const PHNode &);  // implement invalid copy ctor
+  PHNode &operator=(const PHNode &);
+
+  PHNode *parent;
   bool persistent;
   std::string type;
   std::string objecttype;
@@ -58,6 +51,6 @@ protected:
   bool reset_able;
 };
 
-std::ostream & operator << (std::ostream &, const PHNode &);
+std::ostream &operator<<(std::ostream &, const PHNode &);
 
 #endif /* __PHNODE_H__ */

--- a/offline/framework/phool/PHNode.h
+++ b/offline/framework/phool/PHNode.h
@@ -33,7 +33,6 @@ class PHNode
   virtual void forgetMe(PHNode *) = 0;
   virtual bool write(PHIOManager *, const std::string & = "") = 0;
 
-  //  virtual void setResetFlag(const int val);
   virtual void setResetFlag(const bool b) { reset_able = b; }
   virtual bool getResetFlag() const { return reset_able; }
   void makeTransient() { persistent = false; }

--- a/offline/framework/phool/PHNode.h
+++ b/offline/framework/phool/PHNode.h
@@ -4,8 +4,6 @@
 //  Declaration of class PHNode
 //  Purpose: abstract base class for all node classes
 
-#include "phool.h"
-
 #include <iosfwd>
 #include <string>
 
@@ -24,8 +22,8 @@ public:
 
   PHNode* getParent() const { return parent; }
   
-  PHBoolean isPersistent() const { return persistent; }
-  void makePersistent() { persistent = True;}
+  bool isPersistent() const { return persistent; }
+  void makePersistent() { persistent = true;}
   
   const std::string getObjectType() const { return objecttype; }
   const std::string getType() const { return type; }
@@ -40,9 +38,10 @@ public:
   virtual void forgetMe(PHNode*) = 0;
   virtual bool write(PHIOManager *, const std::string& = "") = 0;
 
-  virtual void setResetFlag(const int val);
-  virtual PHBoolean getResetFlag() const;
-  void makeTransient()  { persistent = False;}
+//  virtual void setResetFlag(const int val);
+  virtual void setResetFlag(const bool b) {reset_able = b;}
+  virtual bool getResetFlag() const {return reset_able;}
+  void makeTransient()  { persistent = false;}
   
 protected:
   

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -6,7 +6,6 @@
 #include "PHIODataNode.h"
 #include "PHNodeIterator.h"
 #include "PHObject.h"
-#include "phool.h"
 #include "phooldefs.h"
 
 #include <RVersion.h>
@@ -103,7 +102,7 @@ void PHNodeIOManager::closeFile()
   }
 }
 
-PHBoolean
+bool
 PHNodeIOManager::setFile(const string& f, const string& title,
                          const PHAccessType a)
 {
@@ -128,42 +127,42 @@ PHNodeIOManager::setFile(const string& f, const string& title,
     file = TFile::Open(filename.c_str(), "RECREATE", title.c_str());
     if (!file)
     {
-      return False;
+      return false;
     }
     file->SetCompressionLevel(CompressionLevel);
     tree = new TTree(TreeName.c_str(), title.c_str());
     tree->SetMaxTreeSize(900000000000LL);  // set max size to ~900 GB
     gROOT->cd(currdir.c_str());
-    return True;
+    return true;
     break;
   case PHReadOnly:
     file = TFile::Open(filename.c_str());
     tree = 0;
     if (!file)
     {
-      return False;
+      return false;
     }
     selectObjectToRead("*", true);
     gROOT->cd(currdir.c_str());
-    return True;
+    return true;
     break;
   case PHUpdate:
     file = TFile::Open(filename.c_str(), "UPDATE", title.c_str());
     if (!file)
     {
-      return False;
+      return false;
     }
     file->SetCompressionLevel(CompressionLevel);
     tree = new TTree(TreeName.c_str(), title.c_str());
     gROOT->cd(currdir.c_str());
-    return True;
+    return true;
     break;
   }
 
-  return False;
+  return false;
 }
 
-PHBoolean
+bool
 PHNodeIOManager::write(PHCompositeNode* topNode)
 {
   // The write function of the PHCompositeNode topNode will
@@ -179,13 +178,13 @@ PHNodeIOManager::write(PHCompositeNode* topNode)
   {
     tree->Fill();
     eventNumber++;
-    return True;
+    return true;
   }
 
-  return False;
+  return false;
 }
 
-PHBoolean
+bool
 PHNodeIOManager::write(TObject** data, const string& path)
 {
   if (file && tree)
@@ -215,22 +214,22 @@ PHNodeIOManager::write(TObject** data, const string& path)
     {
       thisBranch->SetAddress(data);
     }
-    return True;
+    return true;
   }
 
-  return False;
+  return false;
 }
 
-PHBoolean
+bool
 PHNodeIOManager::read(size_t requestedEvent)
 {
   if (readEventFromFile(requestedEvent))
   {
-    return True;
+    return true;
   }
   else
   {
-    return False;
+    return false;
   }
 }
 
@@ -273,7 +272,7 @@ void PHNodeIOManager::print() const
     tree->Print();
   }
   cout << "\n\nList of selected objects to read:" << endl;
-  map<string, PHBoolean>::const_iterator classiter;
+  map<string, bool>::const_iterator classiter;
   for (classiter = objectToRead.begin(); classiter != objectToRead.end(); ++classiter)
   {
     cout << classiter->first << " is set to " << classiter->second << endl;
@@ -315,7 +314,7 @@ PHNodeIOManager::getBranchClassName(TBranch* branch)
   exit(1);
 }
 
-PHBoolean
+bool
 PHNodeIOManager::readEventFromFile(size_t requestedEvent)
 {
   // Se non c'e niente, non possiamo fare niente.  Logisch, n'est ce
@@ -324,7 +323,7 @@ PHNodeIOManager::readEventFromFile(size_t requestedEvent)
   {
     PHMessage("PHNodeIOManager::readEventFromFile", PHError,
               "Tree not initialized.");
-    return False;
+    return false;
   }
 
   int bytesRead;
@@ -354,14 +353,14 @@ PHNodeIOManager::readEventFromFile(size_t requestedEvent)
 
   if (!bytesRead)
   {
-    return False;
+    return false;
   }
   if (bytesRead == -1)
   {
     cout << PHWHERE << "Error: Input TTree corrupt, exiting now" << endl;
     exit(1);
   }
-  return True;
+  return true;
 }
 
 int PHNodeIOManager::readSpecific(size_t requestedEvent, const char* objectName)
@@ -422,7 +421,7 @@ PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
   tree->SetName(nname.str().c_str());
 
   // Select the branches according to objectToRead
-  map<string, PHBoolean>::const_iterator it;
+  map<string, bool>::const_iterator it;
 
   if (tree->GetNbranches() > 0)
   {
@@ -540,14 +539,14 @@ PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
   return topNode;
 }
 
-void PHNodeIOManager::selectObjectToRead(const char* objectName, PHBoolean readit)
+void PHNodeIOManager::selectObjectToRead(const char* objectName, bool readit)
 {
   objectToRead[objectName] = readit;
 
   // If tree is already open, loop over map and set branch status
   if (tree)
   {
-    map<string, PHBoolean>::const_iterator it;
+    map<string, bool>::const_iterator it;
 
     for (it = objectToRead.begin(); it != objectToRead.end(); ++it)
     {
@@ -558,7 +557,7 @@ void PHNodeIOManager::selectObjectToRead(const char* objectName, PHBoolean readi
   return;
 }
 
-PHBoolean
+bool
 PHNodeIOManager::isSelected(const char* objectName)
 {
   string name = objectName;
@@ -566,18 +565,18 @@ PHNodeIOManager::isSelected(const char* objectName)
 
   if (p != fBranches.end())
   {
-    return True;
+    return true;
   }
 
-  return False;
+  return false;
 }
 
-PHBoolean
+bool
 PHNodeIOManager::SetCompressionLevel(const int level)
 {
   if (level < 0)
   {
-    return False;
+    return false;
   }
   CompressionLevel = level;
   if (file)
@@ -585,7 +584,7 @@ PHNodeIOManager::SetCompressionLevel(const int level)
     file->SetCompressionLevel(CompressionLevel);
   }
 
-  return True;
+  return true;
 }
 
 double

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -102,9 +102,8 @@ void PHNodeIOManager::closeFile()
   }
 }
 
-bool
-PHNodeIOManager::setFile(const string& f, const string& title,
-                         const PHAccessType a)
+bool PHNodeIOManager::setFile(const string& f, const string& title,
+                              const PHAccessType a)
 {
   filename = f;
   bufSize = 32000;
@@ -162,8 +161,7 @@ PHNodeIOManager::setFile(const string& f, const string& title,
   return false;
 }
 
-bool
-PHNodeIOManager::write(PHCompositeNode* topNode)
+bool PHNodeIOManager::write(PHCompositeNode* topNode)
 {
   // The write function of the PHCompositeNode topNode will
   // recursively call the write functions of its subnodes, thus
@@ -184,8 +182,7 @@ PHNodeIOManager::write(PHCompositeNode* topNode)
   return false;
 }
 
-bool
-PHNodeIOManager::write(TObject** data, const string& path)
+bool PHNodeIOManager::write(TObject** data, const string& path)
 {
   if (file && tree)
   {
@@ -220,8 +217,7 @@ PHNodeIOManager::write(TObject** data, const string& path)
   return false;
 }
 
-bool
-PHNodeIOManager::read(size_t requestedEvent)
+bool PHNodeIOManager::read(size_t requestedEvent)
 {
   if (readEventFromFile(requestedEvent))
   {
@@ -314,8 +310,7 @@ PHNodeIOManager::getBranchClassName(TBranch* branch)
   exit(1);
 }
 
-bool
-PHNodeIOManager::readEventFromFile(size_t requestedEvent)
+bool PHNodeIOManager::readEventFromFile(size_t requestedEvent)
 {
   // Se non c'e niente, non possiamo fare niente.  Logisch, n'est ce
   // pas?
@@ -557,8 +552,7 @@ void PHNodeIOManager::selectObjectToRead(const char* objectName, bool readit)
   return;
 }
 
-bool
-PHNodeIOManager::isSelected(const char* objectName)
+bool PHNodeIOManager::isSelected(const char* objectName)
 {
   string name = objectName;
   map<string, TBranch*>::const_iterator p = fBranches.find(name);
@@ -571,8 +565,7 @@ PHNodeIOManager::isSelected(const char* objectName)
   return false;
 }
 
-bool
-PHNodeIOManager::SetCompressionLevel(const int level)
+bool PHNodeIOManager::SetCompressionLevel(const int level)
 {
   if (level < 0)
   {

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -7,6 +7,8 @@
 
 #include "PHIOManager.h"
 
+#include "phool.h"
+
 #include <map>
 #include <string>
 
@@ -26,27 +28,27 @@ class PHNodeIOManager : public PHIOManager
 
  public:
   virtual void closeFile();
-  virtual PHBoolean write(PHCompositeNode *);
+  virtual bool write(PHCompositeNode *);
   virtual void print() const;
 
-  PHBoolean setFile(const std::string &, const std::string &, const PHAccessType = PHReadOnly);
+  bool setFile(const std::string &, const std::string &, const PHAccessType = PHReadOnly);
   PHCompositeNode *read(PHCompositeNode * = nullptr, size_t = 0);
-  PHBoolean read(size_t requestedEvent);
+  bool read(size_t requestedEvent);
   int readSpecific(size_t requestedEvent, const char *objectName);
-  void selectObjectToRead(const char *objectName, PHBoolean readit);
-  PHBoolean isSelected(const char *objectName);
+  void selectObjectToRead(const char *objectName, bool readit);
+  bool isSelected(const char *objectName);
   int isFunctional() const { return isFunctionalFlag; }
-  PHBoolean SetCompressionLevel(const int level);
+  bool SetCompressionLevel(const int level);
   double GetBytesWritten();
   std::map<std::string, TBranch *> *GetBranchMap();
 
  public:
-  PHBoolean write(TObject **, const std::string &);
+  bool write(TObject **, const std::string &);
 
  private:
   int FillBranchMap();
   PHCompositeNode *reconstructNodeTree(PHCompositeNode *);
-  PHBoolean readEventFromFile(size_t requestedEvent);
+  bool readEventFromFile(size_t requestedEvent);
   std::string getBranchClassName(TBranch *);
 
   TFile *file;
@@ -57,7 +59,7 @@ class PHNodeIOManager : public PHIOManager
   int accessMode;
   int CompressionLevel;
   std::map<std::string, TBranch *> fBranches;
-  std::map<std::string, PHBoolean> objectToRead;
+  std::map<std::string, bool> objectToRead;
 
   int isFunctionalFlag;  // flag to tell if that object initialized properly
 };

--- a/offline/framework/phool/PHNodeIntegrate.h
+++ b/offline/framework/phool/PHNodeIntegrate.h
@@ -13,7 +13,11 @@ class PHCompositeNode;
 class PHNodeIntegrate : public PHNodeOperation
 {
  public:
-  PHNodeIntegrate():runnode(nullptr),runsumnode(nullptr) {}
+  PHNodeIntegrate()
+    : runnode(nullptr)
+    , runsumnode(nullptr)
+  {
+  }
   virtual ~PHNodeIntegrate() {}
   void RunNode(PHCompositeNode *node)
   {

--- a/offline/framework/phool/PHNodeIterator.cc
+++ b/offline/framework/phool/PHNodeIterator.cc
@@ -25,7 +25,7 @@ PHNodeIterator::PHNodeIterator(PHCompositeNode* node)
 }
 
 PHNodeIterator::PHNodeIterator()
-  : currentNode(NULL)
+  : currentNode(nullptr)
 {
 }
 

--- a/offline/framework/phool/PHNodeIterator.cc
+++ b/offline/framework/phool/PHNodeIterator.cc
@@ -8,8 +8,8 @@
 //  Author: Matthias Messer
 //-----------------------------------------------------------------------------
 #include "PHNodeIterator.h"
-#include "PHPointerListIterator.h"
 #include "PHNodeOperation.h"
+#include "PHPointerListIterator.h"
 #include "phooldefs.h"
 
 #include <boost/algorithm/string.hpp>
@@ -19,29 +19,30 @@
 
 using namespace std;
 
-PHNodeIterator::PHNodeIterator(PHCompositeNode* node):
-  currentNode(node)
-{}
+PHNodeIterator::PHNodeIterator(PHCompositeNode* node)
+  : currentNode(node)
+{
+}
 
-PHNodeIterator::PHNodeIterator():
-  currentNode(NULL)
-{}
+PHNodeIterator::PHNodeIterator()
+  : currentNode(NULL)
+{
+}
 
 PHPointerList<PHNode>&
 PHNodeIterator::ls()
 {
   PHPointerListIterator<PHNode> iter(currentNode->subNodes);
   subNodeList.clear();
-  PHNode *thisNode;
+  PHNode* thisNode;
   while ((thisNode = iter()))
-    {
-      subNodeList.append(thisNode);
-    }
+  {
+    subNodeList.append(thisNode);
+  }
   return subNodeList;
 }
 
-void
-PHNodeIterator::print()
+void PHNodeIterator::print()
 {
   currentNode->print();
 }
@@ -50,23 +51,23 @@ PHNode*
 PHNodeIterator::findFirst(const string& requiredType, const string& requiredName)
 {
   PHPointerListIterator<PHNode> iter(currentNode->subNodes);
-  PHNode *thisNode;
+  PHNode* thisNode;
   while ((thisNode = iter()))
+  {
+    if (thisNode->getType() == requiredType && thisNode->getName() == requiredName)
     {
-      if (thisNode->getType() == requiredType && thisNode->getName() == requiredName)
-        {
-          return thisNode;
-        }
-      else
-        {
-          if (thisNode->getType() == "PHCompositeNode")
-            {
-              PHNodeIterator nodeIter(static_cast<PHCompositeNode*>(thisNode));
-              PHNode *nodeFoundInSubTree = nodeIter.findFirst(requiredType.c_str(), requiredName.c_str());
-              if (nodeFoundInSubTree) return nodeFoundInSubTree;
-            }
-        }
+      return thisNode;
     }
+    else
+    {
+      if (thisNode->getType() == "PHCompositeNode")
+      {
+        PHNodeIterator nodeIter(static_cast<PHCompositeNode*>(thisNode));
+        PHNode* nodeFoundInSubTree = nodeIter.findFirst(requiredType.c_str(), requiredName.c_str());
+        if (nodeFoundInSubTree) return nodeFoundInSubTree;
+      }
+    }
+  }
   return 0;
 }
 
@@ -74,111 +75,107 @@ PHNode*
 PHNodeIterator::findFirst(const string& requiredName)
 {
   PHPointerListIterator<PHNode> iter(currentNode->subNodes);
-  PHNode *thisNode;
+  PHNode* thisNode;
   while ((thisNode = iter()))
+  {
+    if (thisNode->getName() == requiredName)
     {
-      if (thisNode->getName() == requiredName)
-        {
-          return thisNode;
-        }
-      else
-        {
-          if (thisNode->getType() == "PHCompositeNode")
-            {
-              PHNodeIterator nodeIter(static_cast<PHCompositeNode*>(thisNode));
-              PHNode *nodeFoundInSubTree = nodeIter.findFirst(requiredName.c_str());
-              if (nodeFoundInSubTree)
-                {
-                  return nodeFoundInSubTree;
-                }
-            }
-        }
+      return thisNode;
     }
+    else
+    {
+      if (thisNode->getType() == "PHCompositeNode")
+      {
+        PHNodeIterator nodeIter(static_cast<PHCompositeNode*>(thisNode));
+        PHNode* nodeFoundInSubTree = nodeIter.findFirst(requiredName.c_str());
+        if (nodeFoundInSubTree)
+        {
+          return nodeFoundInSubTree;
+        }
+      }
+    }
+  }
   return 0;
 }
 
-bool
-PHNodeIterator::cd(const string &pathString)
+bool PHNodeIterator::cd(const string& pathString)
 {
   bool success = true;
   if (pathString.empty())
+  {
+    while (currentNode->getParent())
     {
-      while (currentNode->getParent())
+      currentNode = static_cast<PHCompositeNode*>(currentNode->getParent());
+    }
+  }
+  else
+  {
+    vector<string> splitpath;
+    boost::split(splitpath, pathString, boost::is_any_of(phooldefs::nodetreepathdelim));
+    bool pathFound;
+    PHNode* subNode;
+    int i = 0;
+    for (vector<string>::const_iterator iter = splitpath.begin(); iter != splitpath.end(); ++iter)
+    {
+      i++;
+      if (*iter == "..")
+      {
+        if (currentNode->getParent())
         {
           currentNode = static_cast<PHCompositeNode*>(currentNode->getParent());
         }
-    }
-  else
-    {
-      vector<string> splitpath;
-      boost::split(splitpath, pathString, boost::is_any_of(phooldefs::nodetreepathdelim));
-      bool pathFound;
-      PHNode    *subNode;
-      int i=0;
-      for (vector<string>::const_iterator iter = splitpath.begin(); iter != splitpath.end(); ++iter)
+        else
         {
-	  i++;
-          if (*iter == "..")
-            {
-              if (currentNode->getParent())
-                {
-                  currentNode = static_cast<PHCompositeNode*>(currentNode->getParent());
-                }
-              else
-                {
-                  success = false;
-                }
-            }
-          else
-            {
-              PHPointerListIterator<PHNode> subNodeIter(currentNode->subNodes);
-              pathFound = false;
-              while ((subNode = subNodeIter()))
-                {
-                  if (subNode->getType() == "PHCompositeNode" && subNode->getName() == *iter)
-                    {
-                      currentNode = static_cast<PHCompositeNode*>(subNode);
-                      pathFound = true;
-                    }
-                }
-              if (!pathFound)
-                {
-                  success = false;
-                }
-            }
+          success = false;
         }
+      }
+      else
+      {
+        PHPointerListIterator<PHNode> subNodeIter(currentNode->subNodes);
+        pathFound = false;
+        while ((subNode = subNodeIter()))
+        {
+          if (subNode->getType() == "PHCompositeNode" && subNode->getName() == *iter)
+          {
+            currentNode = static_cast<PHCompositeNode*>(subNode);
+            pathFound = true;
+          }
+        }
+        if (!pathFound)
+        {
+          success = false;
+        }
+      }
     }
+  }
   return success;
 }
 
-bool
-PHNodeIterator::addNode(PHNode* newNode)
+bool PHNodeIterator::addNode(PHNode* newNode)
 {
   return currentNode->addNode(newNode);
 }
 
-void
-PHNodeIterator::forEach(PHNodeOperation& operation)
+void PHNodeIterator::forEach(PHNodeOperation& operation)
 {
   operation(currentNode);
   PHPointerListIterator<PHNode> iter(currentNode->subNodes);
-  PHNode *thisNode;
+  PHNode* thisNode;
   while ((thisNode = iter()))
+  {
+    if (thisNode->getType() == "PHCompositeNode")
     {
-      if (thisNode->getType() == "PHCompositeNode")
-        {
-          PHNodeIterator subNodeIter(static_cast<PHCompositeNode*>(thisNode));
-          subNodeIter.forEach(operation);
-        }
-      else
-        {
-          operation(thisNode);
-        }
+      PHNodeIterator subNodeIter(static_cast<PHCompositeNode*>(thisNode));
+      subNodeIter.forEach(operation);
     }
+    else
+    {
+      operation(thisNode);
+    }
+  }
 }
 
-void
-PHNodeIterator::for_each(PHNodeOperation& operation)
+void PHNodeIterator::for_each(PHNodeOperation& operation)
 {
   forEach(operation);
 }

--- a/offline/framework/phool/PHNodeIterator.cc
+++ b/offline/framework/phool/PHNodeIterator.cc
@@ -97,10 +97,10 @@ PHNodeIterator::findFirst(const string& requiredName)
   return 0;
 }
 
-PHBoolean
+bool
 PHNodeIterator::cd(const string &pathString)
 {
-  PHBoolean success = True;
+  bool success = true;
   if (pathString.empty())
     {
       while (currentNode->getParent())
@@ -112,7 +112,7 @@ PHNodeIterator::cd(const string &pathString)
     {
       vector<string> splitpath;
       boost::split(splitpath, pathString, boost::is_any_of(phooldefs::nodetreepathdelim));
-      PHBoolean pathFound;
+      bool pathFound;
       PHNode    *subNode;
       int i=0;
       for (vector<string>::const_iterator iter = splitpath.begin(); iter != splitpath.end(); ++iter)
@@ -126,24 +126,24 @@ PHNodeIterator::cd(const string &pathString)
                 }
               else
                 {
-                  success = False;
+                  success = false;
                 }
             }
           else
             {
               PHPointerListIterator<PHNode> subNodeIter(currentNode->subNodes);
-              pathFound = False;
+              pathFound = false;
               while ((subNode = subNodeIter()))
                 {
                   if (subNode->getType() == "PHCompositeNode" && subNode->getName() == *iter)
                     {
                       currentNode = static_cast<PHCompositeNode*>(subNode);
-                      pathFound = True;
+                      pathFound = true;
                     }
                 }
               if (!pathFound)
                 {
-                  success = False;
+                  success = false;
                 }
             }
         }
@@ -151,7 +151,7 @@ PHNodeIterator::cd(const string &pathString)
   return success;
 }
 
-PHBoolean
+bool
 PHNodeIterator::addNode(PHNode* newNode)
 {
   return currentNode->addNode(newNode);

--- a/offline/framework/phool/PHNodeIterator.h
+++ b/offline/framework/phool/PHNodeIterator.h
@@ -5,7 +5,6 @@
 //  Purpose: iterator to navigate a node tree
 //  Author: Matthias Messer
 
-#include "phool.h"
 #include "PHCompositeNode.h"
 #include "PHPointerList.h"
 
@@ -23,8 +22,8 @@ public:
    PHPointerList<PHNode>& ls();
    PHNode*                findFirst(const std::string&, const std::string&);
    PHNode*                findFirst(const std::string&);
-   PHBoolean              cd(const std::string &pathString = "");
-   PHBoolean              addNode(PHNode*);
+   bool              cd(const std::string &pathString = "");
+   bool              addNode(PHNode*);
    void                   forEach(PHNodeOperation&);
    void                   for_each(PHNodeOperation&);
    PHCompositeNode *get_currentNode() const {return  currentNode;}

--- a/offline/framework/phool/PHNodeIterator.h
+++ b/offline/framework/phool/PHNodeIterator.h
@@ -10,28 +10,26 @@
 
 class PHNodeOperation;
 
-class PHNodeIterator { 
+class PHNodeIterator
+{
+ public:
+  PHNodeIterator(PHCompositeNode*);
+  virtual ~PHNodeIterator() {}
+  PHNodeIterator();
 
-public: 
-   PHNodeIterator(PHCompositeNode*); 
-   virtual ~PHNodeIterator() {} 
-   PHNodeIterator(); 
-   
-public:
-   void                   print();
-   PHPointerList<PHNode>& ls();
-   PHNode*                findFirst(const std::string&, const std::string&);
-   PHNode*                findFirst(const std::string&);
-   bool              cd(const std::string &pathString = "");
-   bool              addNode(PHNode*);
-   void                   forEach(PHNodeOperation&);
-   void                   for_each(PHNodeOperation&);
-   PHCompositeNode *get_currentNode() const {return  currentNode;}
-
-protected: 
-   PHCompositeNode *currentNode;
-   PHPointerList<PHNode> subNodeList;
-
-}; 
+ public:
+  void print();
+  PHPointerList<PHNode>& ls();
+  PHNode* findFirst(const std::string&, const std::string&);
+  PHNode* findFirst(const std::string&);
+  bool cd(const std::string& pathString = "");
+  bool addNode(PHNode*);
+  void forEach(PHNodeOperation&);
+  void for_each(PHNodeOperation&);
+  PHCompositeNode* get_currentNode() const { return currentNode; }
+ protected:
+  PHCompositeNode* currentNode;
+  PHPointerList<PHNode> subNodeList;
+};
 
 #endif /* __PHNODEITERATOR_H__ */

--- a/offline/framework/phool/PHNodeReset.cc
+++ b/offline/framework/phool/PHNodeReset.cc
@@ -13,7 +13,7 @@ using namespace std;
 
 void PHNodeReset::perform(PHNode* node)
 {
-  if (node->getResetFlag() != True) return;
+  if (node->getResetFlag() != true) return;
   if (verbosity > 0)
   {
     cout << "PHNodeReset: Resetting " << node->getName() << endl;

--- a/offline/framework/phool/PHObject.cc
+++ b/offline/framework/phool/PHObject.cc
@@ -1,7 +1,8 @@
 #include "PHObject.h"
+#include "phool.h"
+
 #include <cstdlib>
 #include <iostream>
-#include "phool.h"
 
 PHObject::PHObject()
   : split(99)

--- a/offline/framework/phool/PHOperation.cc
+++ b/offline/framework/phool/PHOperation.cc
@@ -8,13 +8,14 @@
 //
 //  Author: Matthias Messer
 //-----------------------------------------------------------------------------
-#include "PHOperation.h" 
+#include "PHOperation.h"
 
-template <class T> PHOperation<T>::PHOperation() 
+template <class T>
+PHOperation<T>::PHOperation()
 {
 }
 
-template <class T> PHOperation<T>::~PHOperation() 
+template <class T>
+PHOperation<T>::~PHOperation()
 {
 }
-

--- a/offline/framework/phool/PHOperation.h
+++ b/offline/framework/phool/PHOperation.h
@@ -5,25 +5,25 @@
 //  Purpose: abstract strategy base class
 //  Author: Matthias Messer
 
-template <class T> 
-class PHOperation 
-{ 
-public: 
-  PHOperation(); 
-  virtual ~PHOperation(); 
+template <class T>
+class PHOperation
+{
+ public:
+  PHOperation();
+  virtual ~PHOperation();
 
-public: 
+ public:
   virtual void perform(T*) = 0;
-  void 
-  operator () (T& o) 
-  { 
-    perform(&o); 
+  void
+  operator()(T& o)
+  {
+    perform(&o);
   }
-  void 
-  operator () (T* o) 
-  { 
-    perform(o); 
+  void
+  operator()(T* o)
+  {
+    perform(o);
   }
-}; 
+};
 
 #endif /* __PHOPERATION_H__ */

--- a/offline/framework/phool/PHPointerList.h
+++ b/offline/framework/phool/PHPointerList.h
@@ -24,7 +24,6 @@
 //
 //  Author: Matthias Messer
 
-#include "phool.h"
 #include "PHNode.h"
 
 #include <iostream>
@@ -46,11 +45,11 @@ public:
   size_t	length() const;
   T*		removeLast();
   T*		removeAt(size_t);
-  PHBoolean    append(T*);
-  PHBoolean    insertAt(T*, size_t);
+  bool    append(T*);
+  bool    insertAt(T*, size_t);
   
 private:
-  PHBoolean grow(size_t = 0);
+  bool grow(size_t = 0);
   
 private: 
   T**       items;
@@ -97,7 +96,7 @@ PHPointerList<T>::~PHPointerList()
 }
 
 template<class T> 
-PHBoolean 
+bool 
 PHPointerList<T>::grow(size_t newSize)
 {
   if (newSize == 0) 
@@ -118,10 +117,10 @@ PHPointerList<T>::grow(size_t newSize)
   else 
     {
       std::cout << "PHPointerList<T>::grow: Out of memory?" << std::endl;
-      return False;
+      return false;
     }
 
-  return True;
+  return true;
 }
 
 template<class T> inline T* PHPointerList<T>::operator[](size_t i) const
@@ -138,14 +137,14 @@ template<class T> inline T* PHPointerList<T>::operator[](size_t i) const
 }
 
 template<class T> 
-inline PHBoolean 
+inline bool 
 PHPointerList<T>::append(T* item)
 {
   if (nItems < maxNItems) 
     {
       items[nItems] = item;
       ++nItems;
-      return True;
+      return true;
     }
   else 
     {
@@ -153,25 +152,25 @@ PHPointerList<T>::append(T* item)
 	{
 	  items[nItems] = item;
 	  ++nItems;
-	  return True;
+	  return true;
 	}
       else 
 	{
 	  std::cout << "PHPointerList<T>::append: max nItems exceeded" << std::endl;
-	  return False;
+	  return false;
 	}
     }
 }
 
 template<class T> 
-inline PHBoolean 
+inline bool 
 PHPointerList<T>::insertAt(T* item, size_t pos)
 {
   // This function inserts item at pos in the internal list
   if (pos > nItems) 
     {
       std::cout << "PHPointerList<T>::insertAt: insert beyond nItems" << std::endl;
-      return False;
+      return false;
     }
   
   // Append is used here as a convenient way to let the list grow, if necessary.
@@ -185,7 +184,7 @@ PHPointerList<T>::insertAt(T* item, size_t pos)
   
   items[pos] = item;
   
-  return True;
+  return true;
 }
 
 template<class T> 

--- a/offline/framework/phool/PHPointerList.h
+++ b/offline/framework/phool/PHPointerList.h
@@ -28,178 +28,178 @@
 
 #include <iostream>
 
-template <class T> 
-class PHPointerList 
-{ 
-  
-public: 
-  PHPointerList(size_t = 2); 
-  PHPointerList(const PHPointerList<T> &);
-  PHPointerList<T> & operator = (const PHPointerList<T> &);
-  virtual ~PHPointerList(); 
-  
-public: 
-  T*           operator[](size_t) const;
-  void	   	clear();
-  void		clearAndDestroy();
-  size_t	length() const;
-  T*		removeLast();
-  T*		removeAt(size_t);
-  bool    append(T*);
-  bool    insertAt(T*, size_t);
-  
-private:
+template <class T>
+class PHPointerList
+{
+ public:
+  PHPointerList(size_t = 2);
+  PHPointerList(const PHPointerList<T>&);
+  PHPointerList<T>& operator=(const PHPointerList<T>&);
+  virtual ~PHPointerList();
+
+ public:
+  T* operator[](size_t) const;
+  void clear();
+  void clearAndDestroy();
+  size_t length() const;
+  T* removeLast();
+  T* removeAt(size_t);
+  bool append(T*);
+  bool insertAt(T*, size_t);
+
+ private:
   bool grow(size_t = 0);
-  
-private: 
-  T**       items;
-  size_t    maxNItems;
-  size_t    nItems;
+
+ private:
+  T** items;
+  size_t maxNItems;
+  size_t nItems;
 };
 
 // Implementation of member functions
-template<class T> 
+template <class T>
 PHPointerList<T>::PHPointerList(size_t initialSize)
-{   
+{
   maxNItems = initialSize;
   items = new T*[maxNItems];
   nItems = 0;
 }
 
-template<class T> 
-PHPointerList<T>::PHPointerList(const PHPointerList<T> & l)
+template <class T>
+PHPointerList<T>::PHPointerList(const PHPointerList<T>& l)
 {
   *this = l;
 }
 
-template<class T> 
-PHPointerList<T> & 
-PHPointerList<T>::operator = (const PHPointerList<T> & l)
+template <class T>
+PHPointerList<T>&
+PHPointerList<T>::operator=(const PHPointerList<T>& l)
 {
-  if(this != &l){
+  if (this != &l)
+  {
     maxNItems = l.maxNItems;
     grow(l.maxNItems);
     nItems = l.length();
-    for (size_t i=0; i<nItems; ++i)
-      {
-	items[i] = l[i];
-      }
+    for (size_t i = 0; i < nItems; ++i)
+    {
+      items[i] = l[i];
+    }
   }
   return *this;
 }
 
-template<class T> 
+template <class T>
 PHPointerList<T>::~PHPointerList()
 {
   // This deletes the internal list of pointers and NOT the actual objects.
-  delete [] items;
+  delete[] items;
 }
 
-template<class T> 
-bool 
-PHPointerList<T>::grow(size_t newSize)
+template <class T>
+bool PHPointerList<T>::grow(size_t newSize)
 {
-  if (newSize == 0) 
-    {
-      newSize = maxNItems * 2;
-    }
+  if (newSize == 0)
+  {
+    newSize = maxNItems * 2;
+  }
   T** buffer = items;
   items = new T*[newSize];
-  if (items) 
+  if (items)
+  {
+    for (size_t i = 0; i < maxNItems; ++i)
     {
-      for (size_t i=0; i<maxNItems; ++i)
-	{
-	  items[i] = buffer[i];
-	}
-      delete [] buffer;
-      maxNItems = newSize;
+      items[i] = buffer[i];
     }
-  else 
-    {
-      std::cout << "PHPointerList<T>::grow: Out of memory?" << std::endl;
-      return false;
-    }
+    delete[] buffer;
+    maxNItems = newSize;
+  }
+  else
+  {
+    std::cout << "PHPointerList<T>::grow: Out of memory?" << std::endl;
+    return false;
+  }
 
   return true;
 }
 
-template<class T> inline T* PHPointerList<T>::operator[](size_t i) const
+template <class T>
+inline T* PHPointerList<T>::operator[](size_t i) const
 {
-  if (i < nItems) 
-    {
-      return items[i];
-    }
-  else 
-    {
-      std::cout << "PHPointerList<T>::operator[]: nItems exceeded" << std::endl;
-      return 0;
-    }
+  if (i < nItems)
+  {
+    return items[i];
+  }
+  else
+  {
+    std::cout << "PHPointerList<T>::operator[]: nItems exceeded" << std::endl;
+    return 0;
+  }
 }
 
-template<class T> 
-inline bool 
+template <class T>
+inline bool
 PHPointerList<T>::append(T* item)
 {
-  if (nItems < maxNItems) 
+  if (nItems < maxNItems)
+  {
+    items[nItems] = item;
+    ++nItems;
+    return true;
+  }
+  else
+  {
+    if (grow())
     {
       items[nItems] = item;
       ++nItems;
       return true;
     }
-  else 
+    else
     {
-      if (grow()) 
-	{
-	  items[nItems] = item;
-	  ++nItems;
-	  return true;
-	}
-      else 
-	{
-	  std::cout << "PHPointerList<T>::append: max nItems exceeded" << std::endl;
-	  return false;
-	}
+      std::cout << "PHPointerList<T>::append: max nItems exceeded" << std::endl;
+      return false;
     }
+  }
 }
 
-template<class T> 
-inline bool 
+template <class T>
+inline bool
 PHPointerList<T>::insertAt(T* item, size_t pos)
 {
   // This function inserts item at pos in the internal list
-  if (pos > nItems) 
-    {
-      std::cout << "PHPointerList<T>::insertAt: insert beyond nItems" << std::endl;
-      return false;
-    }
-  
+  if (pos > nItems)
+  {
+    std::cout << "PHPointerList<T>::insertAt: insert beyond nItems" << std::endl;
+    return false;
+  }
+
   // Append is used here as a convenient way to let the list grow, if necessary.
   append(item);
-  
+
   // Now all items are shifted upwards in the list by one, starting at pos.
-  for (size_t i=nItems; i>pos; --i)
-    {
-      items[i] = items[i-1];
-    }
-  
+  for (size_t i = nItems; i > pos; --i)
+  {
+    items[i] = items[i - 1];
+  }
+
   items[pos] = item;
-  
+
   return true;
 }
 
-template<class T> 
-inline void 
+template <class T>
+inline void
 PHPointerList<T>::clear()
 {
   nItems = 0;
   items[nItems] = 0;
 }
 
-template<class T> 
-inline void 
+template <class T>
+inline void
 PHPointerList<T>::clearAndDestroy()
 {
-  for (size_t i=0; i<nItems; ++i)
+  for (size_t i = 0; i < nItems; ++i)
   {
     delete items[i];
   }
@@ -207,59 +207,59 @@ PHPointerList<T>::clearAndDestroy()
   items[nItems] = 0;
 }
 
-template<class T> 
-inline size_t 
+template <class T>
+inline size_t
 PHPointerList<T>::length() const
 {
   return nItems;
 }
 
-template<class T> 
-inline T* 
+template <class T>
+inline T*
 PHPointerList<T>::removeLast()
 {
-  if (nItems > 0) 
-    {
-      return items[nItems--];
-    }
-   else 
-     {
-       std::cout << "PHPointerList<T>::removeLast: no items in list" << std::endl;
-       return 0;
-     }  
+  if (nItems > 0)
+  {
+    return items[nItems--];
+  }
+  else
+  {
+    std::cout << "PHPointerList<T>::removeLast: no items in list" << std::endl;
+    return 0;
+  }
 }
 
-template<class T> 
-inline T* 
+template <class T>
+inline T*
 PHPointerList<T>::removeAt(size_t i)
 {
-  if (i > nItems) 
-    {
-      return 0;
-    }
+  if (i > nItems)
+  {
+    return 0;
+  }
 
-  T *item = items[i];
-  
-   for (size_t j=i; j<nItems-1; ++j)
-     {
-       items[j] = items[j+1];
-     }
-   --nItems;
-   
-   return item;
+  T* item = items[i];
+
+  for (size_t j = i; j < nItems - 1; ++j)
+  {
+    items[j] = items[j + 1];
+  }
+  --nItems;
+
+  return item;
 }
 
 // Implementation of external functions.
-template<class T> 
-std::ostream & 
-operator << (std::ostream & stream , const PHPointerList<T> & thislist)
+template <class T>
+std::ostream&
+operator<<(std::ostream& stream, const PHPointerList<T>& thislist)
 {
-   for (size_t i=0; i<thislist.length(); ++i) 
-     {
-       stream << *(thislist[i]) << std::endl;
-     }
+  for (size_t i = 0; i < thislist.length(); ++i)
+  {
+    stream << *(thislist[i]) << std::endl;
+  }
 
-   return stream;
+  return stream;
 }
 
 #endif /* __PHPOINTERLIST_H__ */

--- a/offline/framework/phool/PHPointerListIterator.h
+++ b/offline/framework/phool/PHPointerListIterator.h
@@ -7,58 +7,61 @@
 
 #include "PHPointerList.h"
 
-template <class T> 
-class PHPointerListIterator 
-{ 
-public: 
-  PHPointerListIterator(const PHPointerList<T> &); 
+template <class T>
+class PHPointerListIterator
+{
+ public:
+  PHPointerListIterator(const PHPointerList<T>&);
   virtual ~PHPointerListIterator() {}
+ public:
+  T* operator()();
+  void operator--();
+  void reset();
+  size_t pos() const { return index; }
+ protected:
+  PHPointerListIterator()
+    : list(0)
+    , index(0)
+  {
+  }
 
-public: 
-   T*		operator()();
-   void         operator--();
-   void		reset();
-   size_t       pos() const { return index; }
-
-protected:
-  PHPointerListIterator() : list(0),index(0) {}
-  
-private: 
+ private:
   const PHPointerList<T>& list;
-  size_t index;   
+  size_t index;
 };
 
 template <class T>
-PHPointerListIterator<T>::PHPointerListIterator(const PHPointerList<T>& lis) 
+PHPointerListIterator<T>::PHPointerListIterator(const PHPointerList<T>& lis)
   : list(lis)
 {
   reset();
 }
 
-template <class T> T* 
-PHPointerListIterator<T>::operator()()
+template <class T>
+T* PHPointerListIterator<T>::operator()()
 {
-   index++;
-   if (index < list.length())
-      {
-	return list[index];
-      }
-   else
-     {
-       return 0;
-     }
+  index++;
+  if (index < list.length())
+  {
+    return list[index];
+  }
+  else
+  {
+    return 0;
+  }
 }
 
-template <class T> void 
-PHPointerListIterator<T>::operator--()
+template <class T>
+void
+    PHPointerListIterator<T>::operator--()
 {
-    --index;
+  --index;
 }
 
-template <class T> void 
-PHPointerListIterator<T>::reset()
+template <class T>
+void PHPointerListIterator<T>::reset()
 {
-   index =  ~(size_t) 0;
+  index = ~(size_t) 0;
 }
 
 #endif /* __PHPOINTERLISTITERATOR_H__ */

--- a/offline/framework/phool/PHRandomSeed.cc
+++ b/offline/framework/phool/PHRandomSeed.cc
@@ -14,6 +14,7 @@ static std::uniform_int_distribution<unsigned int> fDistribution;
 
 bool PHRandomSeed::fInitialized(false);
 bool PHRandomSeed::fFixed(false);
+int PHRandomSeed::verbose(0);
 
 unsigned int PHRandomSeed::GetSeed()
 {
@@ -39,7 +40,10 @@ unsigned int PHRandomSeed::GetSeed()
       iseed = rdev();
     }
   }
-  cout << "PHRandomSeed::GetSeed() seed: " << iseed << endl;
+  if (verbose)
+  {
+    cout << "PHRandomSeed::GetSeed() seed: " << iseed << endl;
+  }
   return iseed;
 }
 
@@ -57,7 +61,12 @@ void PHRandomSeed::InitSeed()
   }
 }
 
-void PHRandomSeed::LoadSeed(unsigned int iseed)
+void PHRandomSeed::LoadSeed(const unsigned int iseed)
 {
   seedqueue.push(iseed);
+}
+
+void PHRandomSeed::Verbosity(const int iverb)
+{
+  verbose = iverb;
 }

--- a/offline/framework/phool/PHRandomSeed.h
+++ b/offline/framework/phool/PHRandomSeed.h
@@ -19,12 +19,14 @@ class PHRandomSeed
 
   //! get a seed
   static unsigned int GetSeed();
-  static void LoadSeed(unsigned int iseed);
+  static void LoadSeed(const unsigned int iseed);
+  static void Verbosity(const int iverb);
 
  protected:
   static void InitSeed();
   static bool fFixed;
   static bool fInitialized;
+  static int verbose;
 };
 
 #endif

--- a/offline/framework/phool/PHRawDataNode.cc
+++ b/offline/framework/phool/PHRawDataNode.cc
@@ -4,12 +4,13 @@
 #include "PHRawDataNode.h"
 #include "PHRawOManager.h"
 
-PHRawDataNode::PHRawDataNode():
-  length(0),
-  ID(0),
-  wordLength(0),
-  hitFormat(0)
-{}
+PHRawDataNode::PHRawDataNode()
+  : length(0)
+  , ID(0)
+  , wordLength(0)
+  , hitFormat(0)
+{
+}
 
 PHRawDataNode::~PHRawDataNode()
 {
@@ -19,24 +20,24 @@ PHRawDataNode::~PHRawDataNode()
   setData(NULL);
 }
 
-PHRawDataNode::PHRawDataNode(PHDWORD * d, const string& n, 
-			     const int l, const int i, const int w, const int h) : 
-  PHDataNode<PHDWORD>(d, n),
-  length(l),
-  ID(i),
-  wordLength(w),
-  hitFormat(h)
-{}
+PHRawDataNode::PHRawDataNode(PHDWORD* d, const string& n,
+                             const int l, const int i, const int w, const int h)
+  : PHDataNode<PHDWORD>(d, n)
+  , length(l)
+  , ID(i)
+  , wordLength(w)
+  , hitFormat(h)
+{
+}
 
-bool 
-PHRawDataNode::write(PHIOManager * IOManager, const string&)
+bool PHRawDataNode::write(PHIOManager* IOManager, const string&)
 {
   PHRawOManager* rawOManager = dynamic_cast<PHRawOManager*>(IOManager);
   bool bret = false;
-  if (rawOManager) 
-    {
-      bret = rawOManager->write(this);
-    }
-  
+  if (rawOManager)
+  {
+    bret = rawOManager->write(this);
+  }
+
   return bret;
 }

--- a/offline/framework/phool/PHRawDataNode.cc
+++ b/offline/framework/phool/PHRawDataNode.cc
@@ -17,7 +17,7 @@ PHRawDataNode::~PHRawDataNode()
   // set the data poitner to 0 so
   // the dtor of the PHDataNode parent class doesn't try
   // to delete it
-  setData(NULL);
+  setData(nullptr);
 }
 
 PHRawDataNode::PHRawDataNode(PHDWORD* d, const string& n,

--- a/offline/framework/phool/PHRawDataNode.h
+++ b/offline/framework/phool/PHRawDataNode.h
@@ -11,32 +11,29 @@
 
 #include <string>
 
-class PHRawDataNode : public PHDataNode<PHDWORD> 
-{ 
+class PHRawDataNode : public PHDataNode<PHDWORD>
+{
+ public:
+  PHRawDataNode();
+  PHRawDataNode(PHDWORD *, const std::string &, const int, const int, const int, const int);
+  virtual ~PHRawDataNode();
 
-public: 
-   PHRawDataNode();
-   PHRawDataNode(PHDWORD *, const std::string&, const int, const int, const int, const int);
-   virtual ~PHRawDataNode();
+ public:
+  virtual bool write(PHIOManager *, const std::string & = "");
 
-public:
-   virtual bool write(PHIOManager *, const std::string& = "");
-
-   int getLength()     const { return length; }
-   int getID()         const { return ID; }
-   int getWordLength() const { return wordLength; }
-   int getHitFormat()  const { return hitFormat; }
-
-   void setLength(const int val)     { length = val; }
-   void setID(const int val)         { ID = val; }
-   void setWordLength(const int val) { wordLength = val; }
-   void setHitFormat(const int val)  { hitFormat = val; }
-
-private: 
-   int length;
-   int ID;
-   int wordLength;
-   int hitFormat;
-}; 
+  int getLength() const { return length; }
+  int getID() const { return ID; }
+  int getWordLength() const { return wordLength; }
+  int getHitFormat() const { return hitFormat; }
+  void setLength(const int val) { length = val; }
+  void setID(const int val) { ID = val; }
+  void setWordLength(const int val) { wordLength = val; }
+  void setHitFormat(const int val) { hitFormat = val; }
+ private:
+  int length;
+  int ID;
+  int wordLength;
+  int hitFormat;
+};
 
 #endif /* PHRAWDATANODE_H__ */

--- a/offline/framework/phool/PHRawOManager.cc
+++ b/offline/framework/phool/PHRawOManager.cc
@@ -10,6 +10,7 @@
 #include "PHRawOManager.h"
 #include "PHCompositeNode.h"
 #include "PHRawDataNode.h"
+#include "phool.h"
 
 #include <Event/ogzBuffer.h>
 #include <Event/EventTypes.h>
@@ -73,7 +74,7 @@ PHRawOManager::closeFile()
     }
 }
 
-PHBoolean
+bool
 PHRawOManager::setFile(const string &setFile, const int setRun, const int setBufl, const int setEvtl, const int complvl)
 {
   filename         = setFile;
@@ -104,7 +105,7 @@ PHRawOManager::setFile(const string &setFile, const int setRun, const int setBuf
     {
 
       PHMessage("PHRawOManager::setFile", PHError, "could not open file");
-      return False;
+      return false;
     }
   memBuffer  = new PHDWORD[bufferSize];
   if (compressionLevel == 0)
@@ -114,7 +115,7 @@ PHRawOManager::setFile(const string &setFile, const int setRun, const int setBuf
       if (status > 0)
         {
           PHMessage("PHRawOManager::setFile", PHError, "could not open file");
-          return False;
+          return false;
         }
     }
   else if (1 <= compressionLevel && compressionLevel <= 9)
@@ -124,7 +125,7 @@ PHRawOManager::setFile(const string &setFile, const int setRun, const int setBuf
       if (status > 0)
         {
           PHMessage("PHRawOManager::setFile", PHError, "could not open file");
-          return False;
+          return false;
         }
     }
   else
@@ -132,10 +133,10 @@ PHRawOManager::setFile(const string &setFile, const int setRun, const int setBuf
       PHMessage("PHRawOManager::setFile", PHWarning, "illegal compression level, no compression done");
     }
 
-  return True;
+  return true;
 }
 
-PHBoolean
+bool
 PHRawOManager::write(PHCompositeNode* topNode)
 {
   //
@@ -149,12 +150,12 @@ PHRawOManager::write(PHCompositeNode* topNode)
       fileBuffer->nextEvent(eventLength, DATAEVENT);
       topNode->write(this);
       eventNumber++;
-      return True;
+      return true;
     }
-  return False;
+  return false;
 }
 
-PHBoolean
+bool
 PHRawOManager::write(PHRawDataNode* node)
 {
   if (filedesc >= 0 && fileBuffer)
@@ -164,11 +165,11 @@ PHRawOManager::write(PHRawDataNode* node)
       if (bytesAddedToBuffer <= 0)
         {
           PHMessage("PHRawOManager::write", PHError, "Zero bytes added to buffer");
-          return False;
+          return false;
         }
-      return True;
+      return true;
     }
-  return False;
+  return false;
 }
 
 void

--- a/offline/framework/phool/PHRawOManager.cc
+++ b/offline/framework/phool/PHRawOManager.cc
@@ -33,16 +33,16 @@ PHRawOManager::PHRawOManager(const string& newFile, const int run, const int buf
   {
     filename = "file open failed";
     filedesc = -1;
-    memBuffer = NULL;
-    fileBuffer = NULL;
+    memBuffer = nullptr;
+    fileBuffer = nullptr;
     compressionLevel = 0;
   }
 }
 
 PHRawOManager::PHRawOManager()
   : filedesc(-1)
-  , memBuffer(NULL)
-  , fileBuffer(NULL)
+  , memBuffer(nullptr)
+  , fileBuffer(nullptr)
   , runNumber(0)
   , bufferSize(0)
   , eventLength(0)

--- a/offline/framework/phool/PHRawOManager.cc
+++ b/offline/framework/phool/PHRawOManager.cc
@@ -12,132 +12,129 @@
 #include "PHRawDataNode.h"
 #include "phool.h"
 
-#include <Event/ogzBuffer.h>
 #include <Event/EventTypes.h>
+#include <Event/ogzBuffer.h>
 #include <Event/packetConstants.h>
 
-#include <iostream>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <iostream>
 
 using namespace std;
 
-PHRawOManager::PHRawOManager(const string &newFile, const int run, const int bufl, const int evtl, const int complvl):
-  filedesc(-1),
-  runNumber(0),
-  bufferSize(0),
-  eventLength(0)
+PHRawOManager::PHRawOManager(const string& newFile, const int run, const int bufl, const int evtl, const int complvl)
+  : filedesc(-1)
+  , runNumber(0)
+  , bufferSize(0)
+  , eventLength(0)
 {
   if (!setFile(newFile, run, bufl, evtl, complvl))
-    {
-      filename         = "file open failed";
-      filedesc         = -1;
-      memBuffer        = NULL;
-      fileBuffer       = NULL;
-      compressionLevel = 0;
-    }
+  {
+    filename = "file open failed";
+    filedesc = -1;
+    memBuffer = NULL;
+    fileBuffer = NULL;
+    compressionLevel = 0;
+  }
 }
 
-PHRawOManager::PHRawOManager():
-  filedesc(-1),
-  memBuffer(NULL),
-  fileBuffer(NULL),
-  runNumber(0),
-  bufferSize(0),
-  eventLength(0),
-  compressionLevel(0)
-{}
+PHRawOManager::PHRawOManager()
+  : filedesc(-1)
+  , memBuffer(NULL)
+  , fileBuffer(NULL)
+  , runNumber(0)
+  , bufferSize(0)
+  , eventLength(0)
+  , compressionLevel(0)
+{
+}
 
 PHRawOManager::~PHRawOManager()
 {
   closeFile();
 }
 
-void
-PHRawOManager::closeFile()
+void PHRawOManager::closeFile()
 {
   if (fileBuffer)
-    {
-      delete fileBuffer;
-    }
+  {
+    delete fileBuffer;
+  }
   if (memBuffer)
-    {
-      delete memBuffer;
-    }
+  {
+    delete memBuffer;
+  }
   fileBuffer = 0;
   memBuffer = 0;
   if (filedesc >= 0)
-    {
-      close(filedesc);
-      filedesc = -1;
-    }
+  {
+    close(filedesc);
+    filedesc = -1;
+  }
 }
 
-bool
-PHRawOManager::setFile(const string &setFile, const int setRun, const int setBufl, const int setEvtl, const int complvl)
+bool PHRawOManager::setFile(const string& setFile, const int setRun, const int setBufl, const int setEvtl, const int complvl)
 {
-  filename         = setFile;
-  runNumber        = setRun;
-  bufferSize       = setBufl;
+  filename = setFile;
+  runNumber = setRun;
+  bufferSize = setBufl;
   compressionLevel = complvl;
 
   if (setEvtl == -1)
-    {
-      eventLength = bufferSize / 4;
-    }
+  {
+    eventLength = bufferSize / 4;
+  }
   else
-    {
-      eventLength = setEvtl;
-    }
+  {
+    eventLength = setEvtl;
+  }
 
   if (filedesc >= 0)
-    {
-      closeFile();  // close the file if it is open (originally unprotected close)
-    }
+  {
+    closeFile();  // close the file if it is open (originally unprotected close)
+  }
 
   // open file
-  filedesc =  open(filename.c_str(), 
-		   O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE ,
-		   S_IRWXU | S_IROTH | S_IRGRP );
+  filedesc = open(filename.c_str(),
+                  O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE,
+                  S_IRWXU | S_IROTH | S_IRGRP);
 
   if (filedesc < 0)
+  {
+    PHMessage("PHRawOManager::setFile", PHError, "could not open file");
+    return false;
+  }
+  memBuffer = new PHDWORD[bufferSize];
+  if (compressionLevel == 0)
+  {
+    int status = 0;
+    fileBuffer = new oBuffer(filedesc, memBuffer, bufferSize, status, runNumber);
+    if (status > 0)
     {
-
       PHMessage("PHRawOManager::setFile", PHError, "could not open file");
       return false;
     }
-  memBuffer  = new PHDWORD[bufferSize];
-  if (compressionLevel == 0)
-    {
-      int status = 0;
-      fileBuffer = new oBuffer(filedesc, memBuffer, bufferSize, status, runNumber);
-      if (status > 0)
-        {
-          PHMessage("PHRawOManager::setFile", PHError, "could not open file");
-          return false;
-        }
-    }
+  }
   else if (1 <= compressionLevel && compressionLevel <= 9)
+  {
+    int status = 0;
+    fileBuffer = new ogzBuffer(filedesc, memBuffer, bufferSize, status, runNumber, compressionLevel);
+    if (status > 0)
     {
-      int status = 0;
-      fileBuffer = new ogzBuffer(filedesc, memBuffer, bufferSize,  status, runNumber, compressionLevel);
-      if (status > 0)
-        {
-          PHMessage("PHRawOManager::setFile", PHError, "could not open file");
-          return false;
-        }
+      PHMessage("PHRawOManager::setFile", PHError, "could not open file");
+      return false;
     }
+  }
   else
-    {
-      PHMessage("PHRawOManager::setFile", PHWarning, "illegal compression level, no compression done");
-    }
+  {
+    PHMessage("PHRawOManager::setFile", PHWarning, "illegal compression level, no compression done");
+  }
 
   return true;
 }
 
-bool
-PHRawOManager::write(PHCompositeNode* topNode)
+bool PHRawOManager::write(PHCompositeNode* topNode)
 {
   //
   // The write function of the PHCompositeNode topNode will
@@ -146,38 +143,36 @@ PHRawOManager::write(PHCompositeNode* topNode)
   // below.
   //
   if (filedesc >= 0 && fileBuffer)
-    {
-      fileBuffer->nextEvent(eventLength, DATAEVENT);
-      topNode->write(this);
-      eventNumber++;
-      return true;
-    }
+  {
+    fileBuffer->nextEvent(eventLength, DATAEVENT);
+    topNode->write(this);
+    eventNumber++;
+    return true;
+  }
   return false;
 }
 
-bool
-PHRawOManager::write(PHRawDataNode* node)
+bool PHRawOManager::write(PHRawDataNode* node)
 {
   if (filedesc >= 0 && fileBuffer)
+  {
+    int bytesAddedToBuffer = fileBuffer->addUnstructPacketData(node->getData(), node->getLength(), node->getID(),
+                                                               node->getWordLength(), node->getHitFormat());
+    if (bytesAddedToBuffer <= 0)
     {
-      int bytesAddedToBuffer = fileBuffer->addUnstructPacketData(node->getData(), node->getLength(), node->getID(),
-								 node->getWordLength(), node->getHitFormat());
-      if (bytesAddedToBuffer <= 0)
-        {
-          PHMessage("PHRawOManager::write", PHError, "Zero bytes added to buffer");
-          return false;
-        }
-      return true;
+      PHMessage("PHRawOManager::write", PHError, "Zero bytes added to buffer");
+      return false;
     }
+    return true;
+  }
   return false;
 }
 
-void
-PHRawOManager::print() const
+void PHRawOManager::print() const
 {
-  cout << "File attached : " << filename    << endl;
-  cout << "Buffer size   : " << bufferSize  << endl;
+  cout << "File attached : " << filename << endl;
+  cout << "Buffer size   : " << bufferSize << endl;
   cout << "Event Length  : " << eventLength << endl;
-  cout << "Run number    : " << runNumber   << endl;
+  cout << "Run number    : " << runNumber << endl;
   cout << "Events written: " << eventNumber << endl;
 }

--- a/offline/framework/phool/PHRawOManager.h
+++ b/offline/framework/phool/PHRawOManager.h
@@ -44,10 +44,10 @@ public:
    PHRawOManager(const std::string &, const int run = 0, const int bufl = 100000, const int evtl = -1, const int complvl = 3); 
    virtual ~PHRawOManager(); 
 
-   PHBoolean setFile(const std::string &, const int setRun, const int setBufl, const int setEvtl, const int complvl);
+   bool setFile(const std::string &, const int setRun, const int setBufl, const int setEvtl, const int complvl);
    virtual void closeFile();
-   virtual PHBoolean write(PHCompositeNode *);
-   PHBoolean write(PHRawDataNode*);
+   virtual bool write(PHCompositeNode *);
+   bool write(PHRawDataNode*);
 
    virtual void print() const;
    

--- a/offline/framework/phool/PHRawOManager.h
+++ b/offline/framework/phool/PHRawOManager.h
@@ -37,28 +37,28 @@ class PHCompositeNode;
 class PHRawDataNode;
 class oBuffer;
 
-class PHRawOManager : public PHIOManager { 
+class PHRawOManager : public PHIOManager
+{
+ public:
+  PHRawOManager();
+  PHRawOManager(const std::string &, const int run = 0, const int bufl = 100000, const int evtl = -1, const int complvl = 3);
+  virtual ~PHRawOManager();
 
-public: 
-   PHRawOManager(); 
-   PHRawOManager(const std::string &, const int run = 0, const int bufl = 100000, const int evtl = -1, const int complvl = 3); 
-   virtual ~PHRawOManager(); 
+  bool setFile(const std::string &, const int setRun, const int setBufl, const int setEvtl, const int complvl);
+  virtual void closeFile();
+  virtual bool write(PHCompositeNode *);
+  bool write(PHRawDataNode *);
 
-   bool setFile(const std::string &, const int setRun, const int setBufl, const int setEvtl, const int complvl);
-   virtual void closeFile();
-   virtual bool write(PHCompositeNode *);
-   bool write(PHRawDataNode*);
+  virtual void print() const;
 
-   virtual void print() const;
-   
-private: 
-   int    filedesc;
-   PHDWORD   *memBuffer;
-   oBuffer *fileBuffer;
-   int     runNumber;
-   int     bufferSize;
-   int     eventLength;
-   int     compressionLevel;
-}; 
+ private:
+  int filedesc;
+  PHDWORD *memBuffer;
+  oBuffer *fileBuffer;
+  int runNumber;
+  int bufferSize;
+  int eventLength;
+  int compressionLevel;
+};
 
 #endif /* PHRAWOMANAGER_H__ */

--- a/offline/framework/phool/PHTimeServer.cc
+++ b/offline/framework/phool/PHTimeServer.cc
@@ -10,167 +10,162 @@
 
 #include "PHTimeServer.h"
 #include <algorithm>
-#include <stdexcept>
 #include <cstdio>
+#include <stdexcept>
 
 using namespace std;
 
 //_________________________________________________________
-PHTimeServer::timer PHTimeServer::insert_new( const string& key )
+PHTimeServer::timer PHTimeServer::insert_new(const string& key)
 {
-    string tmp_key( key );
+  string tmp_key(key);
 
-    int version = 0;
-    while( ( _timers.find(tmp_key) ) != _timers.end() )
-    {
-        version++;
-        ostringstream o;
-        o << key << "_" << version;
-        tmp_key = o.str();
-    }
+  int version = 0;
+  while ((_timers.find(tmp_key)) != _timers.end())
+  {
+    version++;
+    ostringstream o;
+    o << key << "_" << version;
+    tmp_key = o.str();
+  }
 
-    // create a new timer
-    _timers.insert( pair<string,timer>( tmp_key, timer( tmp_key, _timer_id ) ) );
-    _timer_id++;
+  // create a new timer
+  _timers.insert(pair<string, timer>(tmp_key, timer(tmp_key, _timer_id)));
+  _timer_id++;
 
-    // returns timer
-    return _timers.find( tmp_key )->second;
+  // returns timer
+  return _timers.find(tmp_key)->second;
 }
 //_________________________________________________________
-PHTimeServer::timer PHTimeServer::insert_new_single_shot( const string& key )
+PHTimeServer::timer PHTimeServer::insert_new_single_shot(const string& key)
 {
-    string tmp_key( key );
+  string tmp_key(key);
 
-    int version = 0;
-    while( ( _single_shot_timers.find(tmp_key) ) != _single_shot_timers.end() )
-    {
-        version++;
-        ostringstream o;
-        o << key << "_" << version;
-        tmp_key = o.str();
-    }
+  int version = 0;
+  while ((_single_shot_timers.find(tmp_key)) != _single_shot_timers.end())
+  {
+    version++;
+    ostringstream o;
+    o << key << "_" << version;
+    tmp_key = o.str();
+  }
 
-    // create a new timer
-    _single_shot_timers.insert( pair<string,timer>( tmp_key, timer( tmp_key, _single_shot_timer_id ) ) );
-    _single_shot_timer_id++;
+  // create a new timer
+  _single_shot_timers.insert(pair<string, timer>(tmp_key, timer(tmp_key, _single_shot_timer_id)));
+  _single_shot_timer_id++;
 
-    // returns timer
-    return _single_shot_timers.find( tmp_key )->second;
-}
-
-//_________________________________________________________
-PHTimeServer::timer PHTimeServer::get_timer( const string& key )
-{
-    // check for existing timer matching key
-    time_iterator _iter = _timers.find( key );
-    if( _iter != _timers.end() ) return _iter->second;
-    else
-    {
-        ostringstream what;
-        what << "unknown timer \"" << key	<< "\" requested.";
-        throw invalid_argument(what.str());
-    }
+  // returns timer
+  return _single_shot_timers.find(tmp_key)->second;
 }
 
 //_________________________________________________________
-PHTimeServer::timer PHTimeServer::get_single_shot_timer( const string& key )
+PHTimeServer::timer PHTimeServer::get_timer(const string& key)
 {
-    // check for existing timer matching key
-    time_iterator _iter = _single_shot_timers.find( key );
-    if( _iter != _single_shot_timers.end() ) return _iter->second;
-    else
-    {
-        ostringstream what;
-        what << "unknown timer \"" << key	<< "\" requested.";
-        throw invalid_argument(what.str());
-    }
+  // check for existing timer matching key
+  time_iterator _iter = _timers.find(key);
+  if (_iter != _timers.end())
+    return _iter->second;
+  else
+  {
+    ostringstream what;
+    what << "unknown timer \"" << key << "\" requested.";
+    throw invalid_argument(what.str());
+  }
 }
 
 //_________________________________________________________
-void PHTimeServer::print( ostream & out ) const
+PHTimeServer::timer PHTimeServer::get_single_shot_timer(const string& key)
 {
-    PHTimer::PRINT(out,"Mutoo PHTimeServer");
+  // check for existing timer matching key
+  time_iterator _iter = _single_shot_timers.find(key);
+  if (_iter != _single_shot_timers.end())
+    return _iter->second;
+  else
+  {
+    ostringstream what;
+    what << "unknown timer \"" << key << "\" requested.";
+    throw invalid_argument(what.str());
+  }
+}
 
-    // run over normal timers
-    for( const_time_iterator iter = _timers.begin(); iter != _timers.end(); ++iter )
-    {
+//_________________________________________________________
+void PHTimeServer::print(ostream& out) const
+{
+  PHTimer::PRINT(out, "Mutoo PHTimeServer");
 
-        char str[512];
-        sprintf( str, "%-20s [%2i] - %-6g ms (%s)-.",
+  // run over normal timers
+  for (const_time_iterator iter = _timers.begin(); iter != _timers.end(); ++iter)
+  {
+    char str[512];
+    sprintf(str, "%-20s [%2i] - %-6g ms (%s)-.",
             iter->second.get()->get_name().c_str(),
             iter->second.get_uid(),
             iter->second.get()->elapsed(),
-            (char*)((iter->second.get()->get_state() == PHTimer::RUN) ? " (running)":" (stopped)")
-            );
-        out << str << endl;
-    }
+            (char*) ((iter->second.get()->get_state() == PHTimer::RUN) ? " (running)" : " (stopped)"));
+    out << str << endl;
+  }
 
-    // run over single_shot timers
-    PHTimer::PRINT(out,"Mutoo PHTimeServer - single_shots");
-    for( const_time_iterator iter = _single_shot_timers.begin(); iter != _single_shot_timers.end(); ++iter ){
-        char str[512];
-        sprintf( str, "single_shot - %-20s [%2i] - %-6g ms (%s)-.",
+  // run over single_shot timers
+  PHTimer::PRINT(out, "Mutoo PHTimeServer - single_shots");
+  for (const_time_iterator iter = _single_shot_timers.begin(); iter != _single_shot_timers.end(); ++iter)
+  {
+    char str[512];
+    sprintf(str, "single_shot - %-20s [%2i] - %-6g ms (%s)-.",
             iter->second.get()->get_name().c_str(),
             iter->second.get_uid(),
             iter->second.get()->elapsed(),
-            (char*)((iter->second.get()->get_state() == PHTimer::RUN) ? " (running)":" (stopped)")
-            );
-        out << str << endl;
-    }
+            (char*) ((iter->second.get()->get_state() == PHTimer::RUN) ? " (running)" : " (stopped)"));
+    out << str << endl;
+  }
 
-    PHTimer::PRINT(out,"**");
+  PHTimer::PRINT(out, "**");
 
-    return;
+  return;
 }
 
 //_________________________________________________________
-void PHTimeServer::print_stat( ostream & out ) const
+void PHTimeServer::print_stat(ostream& out) const
 {
+  // print nothing if no timer was registered
+  if (_timers.empty() && _single_shot_timers.empty()) return;
 
-    // print nothing if no timer was registered
-    if( _timers.empty() && _single_shot_timers.empty() ) return;
+  // header
+  PHTimer::PRINT(out, "Mutoo PHTimeServer statistics");
 
-    // header
-    PHTimer::PRINT(out,"Mutoo PHTimeServer statistics");
-
-    // normal timers
-    for( const_time_iterator iter = _timers.begin(); iter != _timers.end(); ++iter )
-        if( iter->second.get()->get_ncycle() )
+  // normal timers
+  for (const_time_iterator iter = _timers.begin(); iter != _timers.end(); ++iter)
+    if (iter->second.get()->get_ncycle())
     {
-
-        char str[512];
-        sprintf( str, "%-20s [%2i] - Accumulated time: %-6g ms. cycles: %-10u. Time per cycle: %-6g ms",
-            iter->second.get()->get_name().c_str(),
-            iter->second.get_uid(),
-            iter->second.get()->get_accumulated_time(),
-            iter->second.get()->get_ncycle(),
-            iter->second.get()->get_time_per_cycle() );
-        out << str << endl;
-
+      char str[512];
+      sprintf(str, "%-20s [%2i] - Accumulated time: %-6g ms. cycles: %-10u. Time per cycle: %-6g ms",
+              iter->second.get()->get_name().c_str(),
+              iter->second.get_uid(),
+              iter->second.get()->get_accumulated_time(),
+              iter->second.get()->get_ncycle(),
+              iter->second.get()->get_time_per_cycle());
+      out << str << endl;
     }
 
-    // single shot timers
-    PHTimer::PRINT(out,"Mutoo PHTimeServer single_shots statistics");
-    for( const_time_iterator iter = _single_shot_timers.begin(); iter != _single_shot_timers.end(); ++iter )
-        if( iter->second.get()->get_ncycle() )
+  // single shot timers
+  PHTimer::PRINT(out, "Mutoo PHTimeServer single_shots statistics");
+  for (const_time_iterator iter = _single_shot_timers.begin(); iter != _single_shot_timers.end(); ++iter)
+    if (iter->second.get()->get_ncycle())
     {
+      char str[512];
+      sprintf(str, "single_shot - %-20s [%2i] - accumulated: %-6g ms.",
+              iter->second.get()->get_name().c_str(),
+              iter->second.get_uid(),
+              iter->second.get()->get_accumulated_time());
+      out << str;
 
-        char str[512];
-        sprintf( str, "single_shot - %-20s [%2i] - accumulated: %-6g ms.",
-            iter->second.get()->get_name().c_str(),
-            iter->second.get_uid(),
-            iter->second.get()->get_accumulated_time() );
-        out << str;
+      // check timer _was_ single shot
+      if (iter->second.get()->get_ncycle() != 1)
+        out << " WARNING: single_shot started more than once.";
 
-        // check timer _was_ single shot
-        if( iter->second.get()->get_ncycle() != 1 )
-            out << " WARNING: single_shot started more than once.";
-
-        out << endl;
-
+      out << endl;
     }
 
-    PHTimer::PRINT(out,"**");
+  PHTimer::PRINT(out, "**");
 
-    return;
+  return;
 }

--- a/offline/framework/phool/PHTimeServer.h
+++ b/offline/framework/phool/PHTimeServer.h
@@ -13,11 +13,11 @@
 #include "PHTimer.h"
 
 #include <iostream>
-#include <string>
 #include <map>
+#include <string>
 
 #ifndef __CINT__
-#include<boost/smart_ptr.hpp>
+#include <boost/smart_ptr.hpp>
 #endif
 /*!
 \class	 PHTimeServer
@@ -26,140 +26,139 @@
 
 class PHTimeServer
 {
-
-    public:
-
-    //! wrapper around PHTimer, for storage in a map
-    class timer
+ public:
+  //! wrapper around PHTimer, for storage in a map
+  class timer
+  {
+   public:
+    timer(const std::string& key, unsigned short uid)
+      : _timer(new PHTimer(key))
+      , _uid(uid)
     {
-
-        public:
-        timer( const std::string& key, unsigned short uid ):
-            _timer( new PHTimer(key) ),
-            _uid( uid )
-        {}
-
-        PHTimer* get( void )
-        { return _timer.get(); }
-
-        const PHTimer* get( void ) const
-        { return _timer.get(); }
-
-        unsigned short get_uid( void ) const
-        { return _uid; }
-
-        private:
-#ifndef __CINT__
-        boost::shared_ptr<PHTimer> _timer;
-#endif
-        unsigned short _uid;
-    };
-
-    //! singleton accessor
-    static PHTimeServer* get( void )
-    {
-        static PHTimeServer* _server = new PHTimeServer();
-        return _server;
     }
 
-    //! destructor
-    virtual ~PHTimeServer()
-    {}
-
-    //! insert new timer in map.
-    timer insert_new( const std::string& );
-
-    //! insert new single_shot timer in map.
-    timer insert_new_single_shot( const std::string& );
-
-    //! retrieve existing timer. throw exception if not found
-    timer get_timer( const std::string& );
-
-    //! retrieve existing timer. throw exception if not found
-    timer get_single_shot_timer( const std::string& );
-
-    //! dump all registered timer value.
-    void print( std::ostream& out = std::cout ) const;
-
-    //! dump all registered timer statistics.
-    void print_stat( std::ostream& out = std::cout ) const;
-
-    protected:
-
-    //! constructor
-    PHTimeServer():
-        _timer_id(0),
-        _single_shot_timer_id(0)
-    {}
-
-    private:
-
-    //! map
-    typedef std::map<std::string, timer > time_map;
-
-    //! iterator over the map.
-    typedef std::map<std::string, timer >::iterator time_iterator;
-
-    //! iterator over the map.
-    typedef std::map<std::string, timer >::const_iterator const_time_iterator;
-
-    //! list of timers
-    time_map _timers;
-
-    //! list of single shot timers
-    time_map _single_shot_timers;
-
-    //! running timer unique id
-    unsigned short _timer_id;
-
-    //! running single shot timer unique id
-    unsigned short _single_shot_timer_id;
-
-    public:
-
-    //! light iterator over PHTimer map
-    class iterator
+    PHTimer* get(void)
     {
-        public:
+      return _timer.get();
+    }
 
-        //! get PHTimer associated to current iterator position, advance iterator
-        PHTimeServer::timer* next()
-        {
-            if( _iter == _map.end() ) return 0;
-            PHTimeServer::timer* out( &_iter->second );
-            _iter++;
-            return out;
-        }
+    const PHTimer* get(void) const
+    {
+      return _timer.get();
+    }
 
-        //! get PHTimer associated to current iterator position
-        PHTimeServer::timer* current()
-        {
-            if( _iter == _map.end() ) return 0;
-            return &_iter->second;
-        }
+    unsigned short get_uid(void) const
+    {
+      return _uid;
+    }
 
+   private:
+#ifndef __CINT__
+    boost::shared_ptr<PHTimer> _timer;
+#endif
+    unsigned short _uid;
+  };
 
-        protected:
-        //! creator
-        iterator( PHTimeServer::time_map map ):
-            _map( map ),
-            _iter( _map.begin() )
-        {}
+  //! singleton accessor
+  static PHTimeServer* get(void)
+  {
+    static PHTimeServer* _server = new PHTimeServer();
+    return _server;
+  }
 
-        private:
+  //! destructor
+  virtual ~PHTimeServer()
+  {
+  }
 
-        //! map of PHTimer
-        PHTimeServer::time_map _map;
+  //! insert new timer in map.
+  timer insert_new(const std::string&);
 
-        //! iterator over the map
-        PHTimeServer::time_iterator _iter;
+  //! insert new single_shot timer in map.
+  timer insert_new_single_shot(const std::string&);
 
-        friend class PHTimeServer;
-    };
+  //! retrieve existing timer. throw exception if not found
+  timer get_timer(const std::string&);
 
-    //! return iterator over the map, located at begin
-    iterator range( void ) { return iterator( _timers ); }
+  //! retrieve existing timer. throw exception if not found
+  timer get_single_shot_timer(const std::string&);
 
+  //! dump all registered timer value.
+  void print(std::ostream& out = std::cout) const;
 
+  //! dump all registered timer statistics.
+  void print_stat(std::ostream& out = std::cout) const;
+
+ protected:
+  //! constructor
+  PHTimeServer()
+    : _timer_id(0)
+    , _single_shot_timer_id(0)
+  {
+  }
+
+ private:
+  //! map
+  typedef std::map<std::string, timer> time_map;
+
+  //! iterator over the map.
+  typedef std::map<std::string, timer>::iterator time_iterator;
+
+  //! iterator over the map.
+  typedef std::map<std::string, timer>::const_iterator const_time_iterator;
+
+  //! list of timers
+  time_map _timers;
+
+  //! list of single shot timers
+  time_map _single_shot_timers;
+
+  //! running timer unique id
+  unsigned short _timer_id;
+
+  //! running single shot timer unique id
+  unsigned short _single_shot_timer_id;
+
+ public:
+  //! light iterator over PHTimer map
+  class iterator
+  {
+   public:
+    //! get PHTimer associated to current iterator position, advance iterator
+    PHTimeServer::timer* next()
+    {
+      if (_iter == _map.end()) return 0;
+      PHTimeServer::timer* out(&_iter->second);
+      _iter++;
+      return out;
+    }
+
+    //! get PHTimer associated to current iterator position
+    PHTimeServer::timer* current()
+    {
+      if (_iter == _map.end()) return 0;
+      return &_iter->second;
+    }
+
+   protected:
+    //! creator
+    iterator(PHTimeServer::time_map map)
+      : _map(map)
+      , _iter(_map.begin())
+    {
+    }
+
+   private:
+    //! map of PHTimer
+    PHTimeServer::time_map _map;
+
+    //! iterator over the map
+    PHTimeServer::time_iterator _iter;
+
+    friend class PHTimeServer;
+  };
+
+  //! return iterator over the map, located at begin
+  iterator range(void) { return iterator(_timers); }
 };
 #endif

--- a/offline/framework/phool/PHTimeStamp.cc
+++ b/offline/framework/phool/PHTimeStamp.cc
@@ -16,14 +16,12 @@
 
 using namespace std;
 
-#ifndef HAVE_STRPTIME_PROTOTYPE 
-extern "C" 
-{
-   char *strptime(const char *s, const char  *format,  struct
-      tm *tm);
+#ifndef HAVE_STRPTIME_PROTOTYPE
+extern "C" {
+char *strptime(const char *s, const char *format, struct
+               tm *tm);
 }
 #endif
-
 
 #ifdef WIN32
 const phtime_t ticOffset = 35067168000000000UL;
@@ -33,54 +31,51 @@ const phtime_t ticOffset = 35067168000000000ULL;
 
 const phtime_t ticFactor = 10000000;
 
-PHTimeStamp::PHTimeStamp() 
+PHTimeStamp::PHTimeStamp()
 {
-   setTics(time(0));
-  
-   setenv("TZ","EST5EDT",1);
+  setTics(time(0));
+
+  setenv("TZ", "EST5EDT", 1);
 }
 
-PHTimeStamp::PHTimeStamp(const int year, const int month, const int day, const int hour, const int minute, const int second, const int fraction) 
+PHTimeStamp::PHTimeStamp(const int year, const int month, const int day, const int hour, const int minute, const int second, const int fraction)
 {
-   set(year, month, day, hour, minute, second, fraction);
-   setenv("TZ","EST5EDT",1);
-
+  set(year, month, day, hour, minute, second, fraction);
+  setenv("TZ", "EST5EDT", 1);
 }
 
-PHTimeStamp::PHTimeStamp(const time_t t) 
+PHTimeStamp::PHTimeStamp(const time_t t)
 {
-   setTics(t);
-   setenv("TZ","EST5EDT",1);
+  setTics(t);
+  setenv("TZ", "EST5EDT", 1);
 }
 
-
-void 
-PHTimeStamp::set(const int year, const int month, const int day, 
-		 const int hour, const int minute, 
-		 const int second, const int fraction)
+void PHTimeStamp::set(const int year, const int month, const int day,
+                      const int hour, const int minute,
+                      const int second, const int fraction)
 {
-   if (year < 1900)
-     {
-       setTics(0);
-       return;
-     }
-   tm newTime;
-   newTime.tm_year = year - 1900;
-   newTime.tm_mon  = month - 1;
-   newTime.tm_mday = day;
-   newTime.tm_hour = hour;
-   newTime.tm_min  = minute;
-   newTime.tm_sec  = second;
+  if (year < 1900)
+  {
+    setTics(0);
+    return;
+  }
+  tm newTime;
+  newTime.tm_year = year - 1900;
+  newTime.tm_mon = month - 1;
+  newTime.tm_mday = day;
+  newTime.tm_hour = hour;
+  newTime.tm_min = minute;
+  newTime.tm_sec = second;
 
-   // This tells mktime that it's not known whether it's daylight
-   // savings time or not.
-   newTime.tm_isdst = -1;  
+  // This tells mktime that it's not known whether it's daylight
+  // savings time or not.
+  newTime.tm_isdst = -1;
 
-   setTics(mktime(&newTime));
-   binaryTime += fraction;
+  setTics(mktime(&newTime));
+  binaryTime += fraction;
 }
 
-void PHTimeStamp::set(const char * timeString)
+void PHTimeStamp::set(const char *timeString)
 {
   tm newTime;
 #ifndef WIN32
@@ -91,17 +86,17 @@ void PHTimeStamp::set(const char * timeString)
 
 void PHTimeStamp::setToSystemTime()
 {
-   setTics(time(0));
+  setTics(time(0));
 }
 
 time_t PHTimeStamp::getTics() const
 {
-   return binaryTimeToTics(binaryTime);
+  return binaryTimeToTics(binaryTime);
 }
 
 void PHTimeStamp::setTics(const time_t tics)
 {
-   binaryTime = ticsToBinaryTime(tics);
+  binaryTime = ticsToBinaryTime(tics);
 }
 
 void PHTimeStamp::setBinTics(const phtime_t t)
@@ -111,83 +106,82 @@ void PHTimeStamp::setBinTics(const phtime_t t)
 
 phtime_t PHTimeStamp::ticsToBinaryTime(time_t tics) const
 {
-   return tics * ticFactor + ticOffset;
+  return tics * ticFactor + ticOffset;
 }
 
 time_t PHTimeStamp::binaryTimeToTics(phtime_t bt) const
 {
-   return (bt - ticOffset) / ticFactor;
+  return (bt - ticOffset) / ticFactor;
 }
 
-int PHTimeStamp::isInRange(const PHTimeStamp & t1, const PHTimeStamp & t2)
+int PHTimeStamp::isInRange(const PHTimeStamp &t1, const PHTimeStamp &t2)
 {
-   return ( binaryTime > t1.getBinaryTime() && binaryTime < t2.getBinaryTime());
+  return (binaryTime > t1.getBinaryTime() && binaryTime < t2.getBinaryTime());
 }
 
 void PHTimeStamp::print()
 {
-   cout << *this;
+  cout << *this;
 }
 
 //
 // Operators
 //
-int PHTimeStamp::operator == (const PHTimeStamp & t) const
+int PHTimeStamp::operator==(const PHTimeStamp &t) const
 {
-   return binaryTime == t.getBinaryTime();
+  return binaryTime == t.getBinaryTime();
 }
 
-int PHTimeStamp::operator != (const PHTimeStamp & t) const
+int PHTimeStamp::operator!=(const PHTimeStamp &t) const
 {
-   return binaryTime != t.getBinaryTime();
+  return binaryTime != t.getBinaryTime();
 }
 
-int PHTimeStamp::operator > (const PHTimeStamp & t) const
+int PHTimeStamp::operator>(const PHTimeStamp &t) const
 {
-   return binaryTime > t.getBinaryTime();
+  return binaryTime > t.getBinaryTime();
 }
 
-int PHTimeStamp::operator < (const PHTimeStamp & t) const
+int PHTimeStamp::operator<(const PHTimeStamp &t) const
 {
-   return binaryTime < t.getBinaryTime();
+  return binaryTime < t.getBinaryTime();
 }
 
-int PHTimeStamp::operator >= (const PHTimeStamp & t) const
+int PHTimeStamp::operator>=(const PHTimeStamp &t) const
 {
-   return binaryTime >= t.getBinaryTime();
+  return binaryTime >= t.getBinaryTime();
 }
 
-int PHTimeStamp::operator <= (const PHTimeStamp & t) const
+int PHTimeStamp::operator<=(const PHTimeStamp &t) const
 {
-   return binaryTime <= t.getBinaryTime();
+  return binaryTime <= t.getBinaryTime();
 }
 
-PHTimeStamp & PHTimeStamp::operator = (const PHTimeStamp & t)
+PHTimeStamp &PHTimeStamp::operator=(const PHTimeStamp &t)
 {
-   binaryTime = t.getBinaryTime();
-   return *this;
+  binaryTime = t.getBinaryTime();
+  return *this;
 }
 
-PHTimeStamp PHTimeStamp::operator += (time_t t)
+PHTimeStamp PHTimeStamp::operator+=(time_t t)
 {
-   binaryTime += t * ticFactor;
-   return *this;
+  binaryTime += t * ticFactor;
+  return *this;
 }
 
-PHTimeStamp PHTimeStamp::operator -= (time_t t)
+PHTimeStamp PHTimeStamp::operator-=(time_t t)
 {
-   binaryTime -= t * ticFactor;
-   return *this;
+  binaryTime -= t * ticFactor;
+  return *this;
 }
 
 void PHTimeStamp::print() const
 {
-   cout << *this << endl;
+  cout << *this << endl;
 }
-char * PHTimeStamp::formatTimeString() const
+char *PHTimeStamp::formatTimeString() const
 {
-
-  // this one gives, for naming purposes, the time string 
+  // this one gives, for naming purposes, the time string
   // without blanks
 
   time_t tics = getTics();
@@ -196,15 +190,15 @@ char * PHTimeStamp::formatTimeString() const
   strncpy(timeString, ctime(&tics), 24);
   char *line = new char[25];
 
-  char *u = strtok (timeString, " ");
+  char *u = strtok(timeString, " ");
 
-  if (u) strcpy (line,u);
+  if (u) strcpy(line, u);
 
-  while ( (u=strtok(0," ")) )
-    {
-	strcat (line, "_");
-	strcat (line, u);
-    }
+  while ((u = strtok(0, " ")))
+  {
+    strcat(line, "_");
+    strcat(line, u);
+  }
   return line;
 }
 
@@ -212,38 +206,38 @@ char * PHTimeStamp::formatTimeString() const
 // Non member operators and functions
 //
 
-PHTimeStamp operator + (const PHTimeStamp & t1, time_t t2)
+PHTimeStamp operator+(const PHTimeStamp &t1, time_t t2)
 {
-   PHTimeStamp newTime = t1;
-   newTime += t2;
-   return newTime;
+  PHTimeStamp newTime = t1;
+  newTime += t2;
+  return newTime;
 }
 
-PHTimeStamp operator - (const PHTimeStamp & t1, time_t t2)
+PHTimeStamp operator-(const PHTimeStamp &t1, time_t t2)
 {
-   PHTimeStamp newTime = t1;
-   newTime -= t2;
-   return newTime;
+  PHTimeStamp newTime = t1;
+  newTime -= t2;
+  return newTime;
 }
 
-time_t operator - (const PHTimeStamp & t1, const PHTimeStamp & t2)
+time_t operator-(const PHTimeStamp &t1, const PHTimeStamp &t2)
 {
-   return t1.getTics() - t2.getTics();
+  return t1.getTics() - t2.getTics();
 }
 
-ostream & operator << (ostream & s, const PHTimeStamp & t)
+ostream &operator<<(ostream &s, const PHTimeStamp &t)
 {
-   time_t tics = t.getTics();
-   char timeString[25];
-   timeString[24] = '\0';
-   strncpy(timeString, ctime(&tics), 24);
-   return s << timeString;
+  time_t tics = t.getTics();
+  char timeString[25];
+  timeString[24] = '\0';
+  strncpy(timeString, ctime(&tics), 24);
+  return s << timeString;
 }
 
-istream & operator >> (istream & s, PHTimeStamp & t)
+istream &operator>>(istream &s, PHTimeStamp &t)
 {
-    char timeString[25];
-   s.getline(timeString, 25);
-   t.set(timeString);
-   return s;
+  char timeString[25];
+  s.getline(timeString, 25);
+  t.set(timeString);
+  return s;
 }

--- a/offline/framework/phool/PHTimeStamp.h
+++ b/offline/framework/phool/PHTimeStamp.h
@@ -14,68 +14,65 @@
 
 #include <ctime>
 
-
-
 typedef unsigned long long phtime_t;
 
-  class  PHTimeStamp : public PHObject
-{ 
+class PHTimeStamp : public PHObject
+{
+ public:
+  enum
+  {
+    PHFarFuture = 2147483647
+  };
 
-  public:
-    enum { PHFarFuture = 2147483647 };
-   
-    PHTimeStamp();
+  PHTimeStamp();
 
-    PHTimeStamp(const int, const int, const int, const int, const int, const int, const int = 0);
-    PHTimeStamp(const time_t);
-    void setBinTics(const phtime_t t);
-   
-    virtual ~PHTimeStamp() {}
+  PHTimeStamp(const int, const int, const int, const int, const int, const int, const int = 0);
+  PHTimeStamp(const time_t);
+  void setBinTics(const phtime_t t);
 
-  public: 
-    void set(const int, const int, const int, const int, const int, const int, const int = 0);
+  virtual ~PHTimeStamp() {}
+ public:
+  void set(const int, const int, const int, const int, const int, const int, const int = 0);
 
-    void set(const char *);
+  void set(const char *);
 
-    void setToSystemTime();
-    void setToFarFuture() { setTics(PHFarFuture); }
-   
-    phtime_t getBinaryTime() const { return binaryTime; }
-    time_t getTics() const;
-    void   setTics(const time_t);
+  void setToSystemTime();
+  void setToFarFuture() { setTics(PHFarFuture); }
+  phtime_t getBinaryTime() const { return binaryTime; }
+  time_t getTics() const;
+  void setTics(const time_t);
 
-    int isInRange(const PHTimeStamp &, const PHTimeStamp &);
-    void print();
-   
-    int operator == (const PHTimeStamp &) const;
-    int operator != (const PHTimeStamp &) const;
-    int operator >  (const PHTimeStamp &) const;
-    int operator >= (const PHTimeStamp &) const;
-    int operator <  (const PHTimeStamp &) const;
-    int operator <= (const PHTimeStamp &) const;
+  int isInRange(const PHTimeStamp &, const PHTimeStamp &);
+  void print();
 
-    PHTimeStamp & operator =  (const PHTimeStamp &);
-    PHTimeStamp   operator += (time_t);
-    PHTimeStamp   operator -= (time_t);
+  int operator==(const PHTimeStamp &) const;
+  int operator!=(const PHTimeStamp &) const;
+  int operator>(const PHTimeStamp &) const;
+  int operator>=(const PHTimeStamp &) const;
+  int operator<(const PHTimeStamp &) const;
+  int operator<=(const PHTimeStamp &) const;
 
+  PHTimeStamp &operator=(const PHTimeStamp &);
+  PHTimeStamp operator+=(time_t);
+  PHTimeStamp operator-=(time_t);
 
-    char * formatTimeString() const;
-    void print() const;
-  
-  private:
-    phtime_t ticsToBinaryTime(time_t) const;
-    time_t   binaryTimeToTics(phtime_t) const;
-  
-  protected: 
-    phtime_t binaryTime;
-    ClassDef(PHTimeStamp,1)
-  }; 
+  char *formatTimeString() const;
+  void print() const;
 
-  PHTimeStamp operator + (const PHTimeStamp &, time_t);
-  PHTimeStamp operator - (const PHTimeStamp &, time_t);
-  time_t      operator - (const PHTimeStamp &, const PHTimeStamp &);
+ private:
+  phtime_t ticsToBinaryTime(time_t) const;
+  time_t binaryTimeToTics(phtime_t) const;
 
-  std::ostream &   operator << (std::ostream &, const PHTimeStamp &);
-  std::istream &   operator >> (std::istream &, PHTimeStamp &);
-   
-#endif /* __PHTIMESTAMP_H__ */ 
+ protected:
+  phtime_t binaryTime;
+  ClassDef(PHTimeStamp, 1)
+};
+
+PHTimeStamp operator+(const PHTimeStamp &, time_t);
+PHTimeStamp operator-(const PHTimeStamp &, time_t);
+time_t operator-(const PHTimeStamp &, const PHTimeStamp &);
+
+std::ostream &operator<<(std::ostream &, const PHTimeStamp &);
+std::istream &operator>>(std::istream &, PHTimeStamp &);
+
+#endif /* __PHTIMESTAMP_H__ */

--- a/offline/framework/phool/PHTimer.cc
+++ b/offline/framework/phool/PHTimer.cc
@@ -10,79 +10,84 @@
 
 #include "PHTimer.h"
 
-#include <cmath>
 #include <climits>
-#include <stdexcept>
+#include <cmath>
 #include <fstream>
+#include <stdexcept>
 
 //______________________________________________________________________
 // static members
 PHTimer::Frequency PHTimer::_frequency = PHTimer::Frequency();
-const double PHTimer::_twopower32 = pow(2,32);
+const double PHTimer::_twopower32 = pow(2, 32);
 
 //______________________________________________________________________
-void PHTimer::Frequency::set_cpu_freq(const char * path)
+void PHTimer::Frequency::set_cpu_freq(const char* path)
 {
-    // Set the default to 2 GHz
-    _frequency = 2e9;
+  // Set the default to 2 GHz
+  _frequency = 2e9;
 
-    // Open the cpuinfo file
-    std::ifstream cpuProcFile(path);
-    if ( !cpuProcFile.is_open())
-        throw std::runtime_error(std::string("cpu info. unavailable"));
-    else {
-        // Now parse it looking for the string "cpu MHz"
-        char readLine[1024];
-        std::string searchString("cpu MHz");
-        while ((cpuProcFile.rdstate() & std::ios::failbit) == 0 ) {
-            // Read into the raw char array and then construct a std::string
-            // (std::string) to do the searching
-            cpuProcFile.getline(readLine, 1024);
-            std::string readLineString(readLine);
-            if (readLineString.find(searchString) != std::string::npos) {
+  // Open the cpuinfo file
+  std::ifstream cpuProcFile(path);
+  if (!cpuProcFile.is_open())
+    throw std::runtime_error(std::string("cpu info. unavailable"));
+  else
+  {
+    // Now parse it looking for the string "cpu MHz"
+    char readLine[1024];
+    std::string searchString("cpu MHz");
+    while ((cpuProcFile.rdstate() & std::ios::failbit) == 0)
+    {
+      // Read into the raw char array and then construct a std::string
+      // (std::string) to do the searching
+      cpuProcFile.getline(readLine, 1024);
+      std::string readLineString(readLine);
+      if (readLineString.find(searchString) != std::string::npos)
+      {
+        // Now look for the :, the clock frequency will follow it
+        size_t semicolonPosition = readLineString.find(':', 0);
+        if (semicolonPosition == std::string::npos) throw std::runtime_error(std::string("wrong format for cpu info file"));
+        std::string frequencyString(readLineString.substr(semicolonPosition + 1));
 
-                // Now look for the :, the clock frequency will follow it
-                size_t semicolonPosition = readLineString.find(':', 0);
-                if( semicolonPosition == std::string::npos ) throw std::runtime_error(std::string("wrong format for cpu info file"));
-                std::string frequencyString(readLineString.substr(semicolonPosition + 1));
+        // Make a string stream for the conversion to floating number
+        double freqMHz = 0;
+        std::istringstream frequencySstream(frequencyString);
 
-                // Make a string stream for the conversion to floating number
-                double freqMHz = 0;
-                std::istringstream frequencySstream(frequencyString);
-
-                frequencySstream >> freqMHz;
-                _frequency = freqMHz*1e6;
-
-            }
-        }
+        frequencySstream >> freqMHz;
+        _frequency = freqMHz * 1e6;
+      }
     }
+  }
 }
 
 //______________________________________________________________________
-double PHTimer::get_difference( const PHTimer::time_struct &t0, const PHTimer::time_struct &t1 )
+double PHTimer::get_difference(const PHTimer::time_struct& t0, const PHTimer::time_struct& t1)
 {
-    unsigned long diff_high = t0._high - t1._high;
-    unsigned long diff_low;
-    if (t0._low < t1._low) {
-        --diff_high;
-        diff_low = (UINT_MAX - t1._low) + t0._low + 1;
-    } else diff_low = t0._low - t1._low;
+  unsigned long diff_high = t0._high - t1._high;
+  unsigned long diff_low;
+  if (t0._low < t1._low)
+  {
+    --diff_high;
+    diff_low = (UINT_MAX - t1._low) + t0._low + 1;
+  }
+  else
+    diff_low = t0._low - t1._low;
 
-    return (_twopower32*diff_high + diff_low)*_frequency.period();
+  return (_twopower32 * diff_high + diff_low) * _frequency.period();
 }
 
 //_______________________________________________________
 void PHTimer::PRINT(std::ostream& os, const std::string& message)
 {
-    const int max_col=80;
-    if(!message.size()) {
-        os << std::string(max_col,'-') << std::endl;
-        return;
-    }
-    int fill = max_col - message.size() - 2;
-    int pre = static_cast<int>(std::floor(fill/2.0));
-    int post = fill - pre;
-    os << std::string(pre,'-') << " ";
-    os << message << " ";
-    os << std::string(post,'-') << std::endl;
+  const int max_col = 80;
+  if (!message.size())
+  {
+    os << std::string(max_col, '-') << std::endl;
+    return;
+  }
+  int fill = max_col - message.size() - 2;
+  int pre = static_cast<int>(std::floor(fill / 2.0));
+  int post = fill - pre;
+  os << std::string(pre, '-') << " ";
+  os << message << " ";
+  os << std::string(post, '-') << std::endl;
 }

--- a/offline/framework/phool/PHTimer.h
+++ b/offline/framework/phool/PHTimer.h
@@ -11,209 +11,234 @@
 \date		$Date: 2013/01/07 09:27:01 $
 */
 
+#include <unistd.h>
 #include <iostream>
 #include <sstream>
-#include <unistd.h>
 
-#define rdtsc(low,high) \
-__asm__ __volatile__("rdtsc" : "=a" (low), "=d" (high))
+#define rdtsc(low, high)       \
+  __asm__ __volatile__("rdtsc" \
+                       : "=a"(low), "=d"(high))
 
 /*! \ingroup classes */
 //! high precision timer
 /*! high precision timer */
 class PHTimer
 {
-    public:
+ public:
+  //! enum for timer state
+  enum State
+  {
+    STOP = 0,
+    RUN = 1
+  };
 
-    //! enum for timer state
-    enum State
+  //! access timer state
+  State get_state(void) const
+  {
+    return _state;
+  }
+
+  //! Construct with a name
+  PHTimer(const std::string& name = "Generic Timer")
+    : _name(name)
+    , _state(STOP)
+    , _start_time(get_clock_counts())
+    , _stop_time(get_clock_counts())
+    , _accumulated_time(0)
+    , _ncycle(0)
+  {
+    _stop_time._low++;
+  }
+
+  //! stops the counter
+  void stop()
+  {
+    if (_state == STOP) return;
+    _stop_time = get_clock_counts();
+    _state = STOP;
+    _ncycle++;
+    _accumulated_time += elapsed();
+  }
+
+  //! Restart timer
+  void restart()
+  {
+    _start_time = get_clock_counts();
+    _state = RUN;
+  }
+
+  //! Dump elapsed time to provided ostream
+  void print(std::ostream& os = std::cout) const
+  {
+    double elapse(elapsed());
+    PRINT(os, "Timing for " + _name);
+    os << "time (ms): " << elapse << std::endl;
+    PRINT();
+  }
+
+  //! Dump statistics
+  void print_stat(std::ostream& os = std::cout) const
+  {
+    PRINT(os, std::string("Stats for " + _name));
+    if (_ncycle)
     {
-        STOP=0,
-        RUN=1
-    };
-
-    //! access timer state
-    State get_state( void ) const
-    { return _state; }
-
-    //! Construct with a name
-    PHTimer(const std::string& name = "Generic Timer") :
-        _name(name),
-        _state( STOP ),
-      _start_time(get_clock_counts()),
-      _stop_time(get_clock_counts()),
-        _accumulated_time( 0 ),
-        _ncycle( 0 )
+      os << "accumulated time (ms):	" << _accumulated_time << std::endl;
+      os << "per event time: (ms)	 " << _accumulated_time / _ncycle << std::endl;
+    }
+    else
     {
-        _stop_time._low++;
+      os << "never started.\n";
+    }
+    PRINT(os, "**");
+  }
+
+  //! Set timer name
+  void set_name(const std::string& name)
+  {
+    _name = name;
+  }
+
+  //! get timer name
+  std::string get_name(void) const
+  {
+    return _name;
+  }
+
+  //! get cumulated time
+  double get_accumulated_time(void) const
+  {
+    return _accumulated_time;
+  }
+
+  //! get number of cycles
+  unsigned int get_ncycle(void) const
+  {
+    return _ncycle;
+  }
+
+  //! get averaged time/cycle
+  double get_time_per_cycle(void) const
+  {
+    return _accumulated_time / _ncycle;
+  }
+
+  //! retrieve elapsed value since last restart (in ms)
+  double elapsed(void) const
+  {
+    return 1000.0 * get_difference(
+                        (_state == RUN) ? get_clock_counts() : _stop_time,
+                        _start_time);
+  }
+
+  //! test PHTimer for a given amount of time (in ms)
+  void test(double time, std::ostream& os = std::cout)
+  {
+    std::ostringstream tmp;
+    tmp << "Test for " << _name << " - " << time << "ms";
+    PRINT(os, tmp.str());
+    restart();
+    usleep((unsigned int) (time * 1000));
+    print(os);
+  }
+
+  //! print a message (formated) to a stream
+  static void PRINT(std::ostream& os = std::cout, const std::string& message = "");
+
+ private:
+  //! internal frequency read from cpu information file
+  class Frequency
+  {
+   public:
+    //! constructor
+    Frequency()
+    {
+      try
+      {
+        set_cpu_freq();
+      }
+      catch (std::exception& e)
+      {
+        std::cerr << e.what() << std::endl;
+      }
+      _period = 1.0 / _frequency;
     }
 
-    //! stops the counter
-    void stop(){
-        if( _state == STOP ) return;
-        _stop_time = get_clock_counts();
-        _state = STOP;
-        _ncycle++;
-        _accumulated_time+=elapsed();
+    //! frequency accessor
+    operator double() const
+    {
+      return _frequency;
     }
 
-    //! Restart timer
-    void restart(){ _start_time = get_clock_counts(); _state = RUN; }
-
-    //! Dump elapsed time to provided ostream
-    void print(std::ostream& os = std::cout) const
+    //! period accessor
+    double period() const
     {
-        double elapse( elapsed() );
-        PRINT(os,"Timing for " + _name);
-        os << "time (ms): " << elapse << std::endl;
-        PRINT();
+      return _period;
     }
 
-    //! Dump statistics
-    void print_stat( std::ostream& os = std::cout ) const
+   private:
+    //! pc frequency
+    double _frequency;
+
+    //! pc period
+    double _period;
+
+    //! read pc frequency from cpuinfo place
+    void set_cpu_freq(const char* cpuinfopath = "/proc/cpuinfo");
+  };
+
+  //! used to store high precision time using two integers
+  struct time_struct
+  {
+    //! constructor
+    time_struct(void)
+      : _low(0)
+      , _high(0)
     {
-        PRINT(os, std::string( "Stats for " + _name ) );
-        if( _ncycle )
-        {
-            os << "accumulated time (ms):	" << _accumulated_time << std::endl;
-            os << "per event time: (ms)	 " <<	_accumulated_time/_ncycle << std::endl;
-        } else {
-            os << "never started.\n";
-        }
-        PRINT(os,"**");
     }
 
-    //! Set timer name
-    void set_name(const std::string& name)
-    { _name = name; }
+    //! low wheight bits cpu count
+    unsigned long _low;
 
-    //! get timer name
-    std::string get_name( void ) const
-    { return _name; }
+    //! high wheight bits cpu count
+    unsigned long _high;
+  };
 
-    //! get cumulated time
-    double get_accumulated_time( void ) const
-    { return _accumulated_time; }
+  //! gets time from cpu clock counts
+  static time_struct get_clock_counts(void)
+  {
+    time_struct t;
+    rdtsc(t._low, t._high);
+    return t;
+  }
 
-    //! get number of cycles
-    unsigned int get_ncycle( void ) const
-    { return _ncycle; }
+  //! returns difference between to time
+  static double get_difference(
+      const time_struct&,
+      const time_struct&);
 
-    //! get averaged time/cycle
-    double get_time_per_cycle( void ) const
-    { return _accumulated_time/_ncycle; }
+  //! static frequency object
+  static Frequency _frequency;
 
-    //! retrieve elapsed value since last restart (in ms)
-    double elapsed( void ) const
-    {
-        return 1000.0*get_difference(
-            ( _state==RUN ) ? get_clock_counts():_stop_time,
-            _start_time );
-    }
+  //! to stores 2^32
+  static const double _twopower32;
 
-    //! test PHTimer for a given amount of time (in ms)
-    void test( double time, std::ostream& os = std::cout)
-    {
-        std::ostringstream tmp;
-        tmp << "Test for " << _name << " - " << time << "ms";
-        PRINT(os, tmp.str());
-        restart();
-        usleep( (unsigned int)(time*1000) );
-        print( os );
-    }
+  //! timer name
+  std::string _name;
 
-    	//! print a message (formated) to a stream
-    static void PRINT(std::ostream& os = std::cout, const std::string& message = "");
+  //! timer state
+  State _state;
 
-    private:
+  //! start time structure
+  time_struct _start_time;
 
-    //! internal frequency read from cpu information file
-    class Frequency
-    {
-        public:
+  //! stop time structure
+  time_struct _stop_time;
 
-        //! constructor
-      Frequency()
-        {
-            try { set_cpu_freq(); }
-            catch (std::exception& e) { std::cerr << e.what() << std::endl; }
-            _period = 1.0/_frequency;
-        }
+  //! cumulated time
+  double _accumulated_time;
 
-        //! frequency accessor
-        operator double() const
-        {return _frequency;}
-
-        //! period accessor
-        double period() const
-        {return _period;}
-
-        private:
-
-        //! pc frequency
-        double _frequency;
-
-        //! pc period
-        double _period;
-
-        //! read pc frequency from cpuinfo place
-        void set_cpu_freq(const char * cpuinfopath = "/proc/cpuinfo");
-    };
-
-    //! used to store high precision time using two integers
-    struct time_struct
-    {
-
-        //! constructor
-        time_struct( void ):
-            _low(0),
-            _high(0)
-        {}
-
-        //! low wheight bits cpu count
-        unsigned long _low;
-
-        //! high wheight bits cpu count
-        unsigned long _high;
-
-    };
-
-    //! gets time from cpu clock counts
-    static time_struct get_clock_counts( void ) {
-        time_struct t;
-        rdtsc(t._low, t._high);
-        return t;
-    }
-
-    //! returns difference between to time
-    static double get_difference(
-        const time_struct &,
-        const time_struct & );
-
-    //! static frequency object
-    static Frequency _frequency;
-
-    //! to stores 2^32
-    static const double _twopower32;
-
-    //! timer name
-    std::string _name;
-
-    //! timer state
-    State _state;
-
-    //! start time structure
-    time_struct _start_time;
-
-    //! stop time structure
-    time_struct _stop_time;
-
-    //! cumulated time
-    double _accumulated_time;
-
-    //! number of restart/stop cycles
-    unsigned int _ncycle;
-
+  //! number of restart/stop cycles
+  unsigned int _ncycle;
 };
 
 #endif

--- a/offline/framework/phool/PHTypedNodeIterator.h
+++ b/offline/framework/phool/PHTypedNodeIterator.h
@@ -51,9 +51,9 @@ public:
    * object, so remember to "cd" to the desired location in the tree!
    *
    */
-  PHBoolean AddIODataNode(T* data, const char* name);
+  bool AddIODataNode(T* data, const char* name);
 
-  PHBoolean insert(T* data, const char* name);
+  bool insert(T* data, const char* name);
   
 protected:
   PHIODataNode<T>* myIODataNode;  
@@ -96,20 +96,20 @@ PHTypedNodeIterator<T>::find(const char* name)
 }
 
 template <class T>
-PHBoolean
+bool
 PHTypedNodeIterator<T>::AddIODataNode(T* data, const char* name)
 {
   return insert(data, name);
 }
 
 template <class T>
-PHBoolean
+bool
 PHTypedNodeIterator<T>::insert(T* data, const char* name)
 {
   // TODO:  also check that "name" is not a null string!
   if (!name)
     {
-      return False;
+      return false;
     }
   
   // For IODataNode, ought to check (if possible) that T derives from
@@ -118,7 +118,7 @@ PHTypedNodeIterator<T>::insert(T* data, const char* name)
   if (!n) 
     {
       // problem creating node?
-      return False;
+      return false;
     }
 
   return addNode(n);

--- a/offline/framework/phool/PHTypedNodeIterator.h
+++ b/offline/framework/phool/PHTypedNodeIterator.h
@@ -6,7 +6,8 @@
 #include <cstddef>
 
 class TObject;
-template<typename T> class PHIODataNode;
+template <typename T>
+class PHIODataNode;
 class PHCompositeNode;
 
 //  A special PHOOL node iterator that simplifies finding and adding
@@ -18,14 +19,17 @@ class PHCompositeNode;
 template <class T>
 class PHTypedNodeIterator : public PHNodeIterator
 {
-public:
-
+ public:
   /// Constructor
-  PHTypedNodeIterator(PHCompositeNode* n) : PHNodeIterator(n) { 
+  PHTypedNodeIterator(PHCompositeNode* n)
+    : PHNodeIterator(n)
+  {
     myIODataNode = 0;
   }
 
-  PHTypedNodeIterator() : PHNodeIterator() {    
+  PHTypedNodeIterator()
+    : PHNodeIterator()
+  {
     myIODataNode = 0;
   }
 
@@ -34,7 +38,6 @@ public:
   /// Destructor
   //  virtual ~PHTypedNodeIterator();  // Need a virtual ~PHNodeIterator() !
   ~PHTypedNodeIterator() {}
-
   /**
    * Finds an IODataNode of name "name" containing data of type "T".
    * A null pointer will be returned if the node is not found, or if
@@ -43,7 +46,6 @@ public:
   PHIODataNode<T>* FindIODataNode(const char* name);
 
   PHIODataNode<T>* find(const char* name);
-  
 
   /**
    * Adds a data node called "name" to the tree, and inserts "data".
@@ -54,15 +56,14 @@ public:
   bool AddIODataNode(T* data, const char* name);
 
   bool insert(T* data, const char* name);
-  
-protected:
-  PHIODataNode<T>* myIODataNode;  
 
+ protected:
+  PHIODataNode<T>* myIODataNode;
 };
 
 template <class T>
 T&
-PHTypedNodeIterator<T>::operator*()
+    PHTypedNodeIterator<T>::operator*()
 {
   return *(myIODataNode->getData());
 }
@@ -79,47 +80,45 @@ PHIODataNode<T>*
 PHTypedNodeIterator<T>::find(const char* name)
 {
   // TODO:  also check that "name" is not a null string!
-  if (!name) 
-    {
-      return 0;
-    }
+  if (!name)
+  {
+    return 0;
+  }
 
   // Can't do dynamic_cast here; it fails if node was created as
   // PHIODataNode<X> instead of PHIODataNode<T>, even if T is a
   // derived class of X!  In general, T -> X does not imply A<T> ->
   // A<X>.  ("->" denotes "derives from", and "A" is any template
   // class)
-  myIODataNode = 
-    static_cast<PHIODataNode<T>*>(findFirst("PHIODataNode", name));
+  myIODataNode =
+      static_cast<PHIODataNode<T>*>(findFirst("PHIODataNode", name));
 
   return myIODataNode;
 }
 
 template <class T>
-bool
-PHTypedNodeIterator<T>::AddIODataNode(T* data, const char* name)
+bool PHTypedNodeIterator<T>::AddIODataNode(T* data, const char* name)
 {
   return insert(data, name);
 }
 
 template <class T>
-bool
-PHTypedNodeIterator<T>::insert(T* data, const char* name)
+bool PHTypedNodeIterator<T>::insert(T* data, const char* name)
 {
   // TODO:  also check that "name" is not a null string!
   if (!name)
-    {
-      return false;
-    }
-  
+  {
+    return false;
+  }
+
   // For IODataNode, ought to check (if possible) that T derives from
   // TObject.  Will typeid() give us this info?
   PHIODataNode<T>* n = new PHIODataNode<T>(data, name);
-  if (!n) 
-    {
-      // problem creating node?
-      return false;
-    }
+  if (!n)
+  {
+    // problem creating node?
+    return false;
+  }
 
   return addNode(n);
 }

--- a/offline/framework/phool/getClass.h
+++ b/offline/framework/phool/getClass.h
@@ -1,10 +1,10 @@
 #ifndef GETCLASS_H__
 #define GETCLASS_H__
 
-#include "PHNodeIterator.h"
-#include "PHIODataNode.h"
 #include "PHDataNode.h"
+#include "PHIODataNode.h"
 #include "PHNode.h"
+#include "PHNodeIterator.h"
 
 #include <TObject.h>
 
@@ -14,47 +14,47 @@ class PHCompositeNode;
 
 namespace findNode
 {
-  template <class T>
-    T* getClass(PHCompositeNode *top, const std::string &name)
-    {
-      PHNodeIterator iter(top);
-      PHNode *FoundNode = iter.findFirst(name.c_str()); // returns pointer to PHNode
-      if (!FoundNode)
-	{
-	  return NULL;
-	}
-      // first test if it is a PHDataNode
-      PHDataNode<T> *DNode = dynamic_cast<PHDataNode<T>*>(FoundNode);
-      if (DNode)
-	{
-	  T* object = dynamic_cast<T*>(DNode->getData());
-	  if (object)
-	    {
-	      return object;
-	    }
-	}
-
-      // We make a static cast for PHIODataNode<TObject> since all
-      // PHIODataNodes have to contain a TObject (otherwise it cannot be
-      // written out and it should be a PHDataNode. dynamic cast does not 
-      // work (see some explanation in PHTypedNodeIterator.h)
-
-      PHIODataNode<TObject> *IONode = static_cast<PHIODataNode<TObject>*>(FoundNode);
-      if (IONode)
-	{
-	  T* object = dynamic_cast<T*>(IONode->getData());
-	  if (!object)
-	    {
-	      return NULL;
-	    }
-	  else
-	    {
-	      return object;
-	    }
-	}
-
+template <class T>
+T *getClass(PHCompositeNode *top, const std::string &name)
+{
+  PHNodeIterator iter(top);
+  PHNode *FoundNode = iter.findFirst(name.c_str());  // returns pointer to PHNode
+  if (!FoundNode)
+  {
     return NULL;
   }
+  // first test if it is a PHDataNode
+  PHDataNode<T> *DNode = dynamic_cast<PHDataNode<T> *>(FoundNode);
+  if (DNode)
+  {
+    T *object = dynamic_cast<T *>(DNode->getData());
+    if (object)
+    {
+      return object;
+    }
+  }
+
+  // We make a static cast for PHIODataNode<TObject> since all
+  // PHIODataNodes have to contain a TObject (otherwise it cannot be
+  // written out and it should be a PHDataNode. dynamic cast does not
+  // work (see some explanation in PHTypedNodeIterator.h)
+
+  PHIODataNode<TObject> *IONode = static_cast<PHIODataNode<TObject> *>(FoundNode);
+  if (IONode)
+  {
+    T *object = dynamic_cast<T *>(IONode->getData());
+    if (!object)
+    {
+      return NULL;
+    }
+    else
+    {
+      return object;
+    }
+  }
+
+  return NULL;
+}
 }
 
 #endif /* GETCLASS_H */

--- a/offline/framework/phool/phool.h
+++ b/offline/framework/phool/phool.h
@@ -6,11 +6,8 @@
 
 #include <iostream>
 
-static const int False = 0;
-static const int True = 1;
 
 //  Global type definitions
-typedef int PHBoolean;
 enum PHMessageType {PHError, PHWarning, PHHullo};
 enum PHAccessType {PHReadOnly, PHWrite, PHUpdate};
 enum PHTreeType {PHEventTree, PHRunTree};

--- a/offline/framework/phool/phool.h
+++ b/offline/framework/phool/phool.h
@@ -6,24 +6,46 @@
 
 #include <iostream>
 
-
 //  Global type definitions
-enum PHMessageType {PHError, PHWarning, PHHullo};
-enum PHAccessType {PHReadOnly, PHWrite, PHUpdate};
-enum PHTreeType {PHEventTree, PHRunTree};
-
+enum PHMessageType
+{
+  PHError,
+  PHWarning,
+  PHHullo
+};
+enum PHAccessType
+{
+  PHReadOnly,
+  PHWrite,
+  PHUpdate
+};
+enum PHTreeType
+{
+  PHEventTree,
+  PHRunTree
+};
 
 // General purpose functions
 void PHMessage(const std::string&, int, const std::string&);
 
 #ifndef __CINT__
 #define PHWHERE __FILE__ << ":" << __LINE__ << ": "
-#define PHMESSAGE(x) do {std::cout << PHWHERE << (x) << std::endl;} while(0)
-#define PHOOL_VIRTUAL_WARNING do {std::cout << PHWHERE << "using virtual function, doing nothing" << std::endl;} while (0)
+#define PHMESSAGE(x)                          \
+  do                                          \
+  {                                           \
+    std::cout << PHWHERE << (x) << std::endl; \
+  } while (0)
+#define PHOOL_VIRTUAL_WARNING                                                     \
+  do                                                                              \
+  {                                                                               \
+    std::cout << PHWHERE << "using virtual function, doing nothing" << std::endl; \
+  } while (0)
 // now one where you can give an argument, e.g. the method name
-#define PHOOL_VIRTUAL_WARN(x) do {std::cout << PHWHERE << "using virtual function " << x << " doing nothing" << std::endl;} while (0)
+#define PHOOL_VIRTUAL_WARN(x)                                                                \
+  do                                                                                         \
+  {                                                                                          \
+    std::cout << PHWHERE << "using virtual function " << x << " doing nothing" << std::endl; \
+  } while (0)
 #endif
-
-
 
 #endif /* __PHOOL_H__ */

--- a/offline/framework/phool/phooldefs.h
+++ b/offline/framework/phool/phooldefs.h
@@ -5,9 +5,8 @@
 
 namespace phooldefs
 {
-  static const std::string branchpathdelim = ".";
-  static const std::string nodetreepathdelim = "/";
+static const std::string branchpathdelim = ".";
+static const std::string nodetreepathdelim = "/";
 };
 
 #endif
-

--- a/offline/framework/phool/recoConsts.cc
+++ b/offline/framework/phool/recoConsts.cc
@@ -1,11 +1,8 @@
 #include "recoConsts.h"
 
-using namespace std;
+recoConsts* recoConsts::__instance = nullptr;
 
-recoConsts* recoConsts::__instance = NULL;
-
-void 
-recoConsts::Print() const
+void recoConsts::Print() const
 {
   // methods from PHFlag
   PrintCharFlags();

--- a/offline/framework/phool/recoConsts.h
+++ b/offline/framework/phool/recoConsts.h
@@ -8,26 +8,19 @@
 
 class recoConsts : public PHFlag
 {
-
  public:
-
-  static recoConsts * instance()
-    {
-      if (__instance) return __instance;
-      __instance =  new recoConsts();
-      return __instance;
-    }
+  static recoConsts *instance()
+  {
+    if (__instance) return __instance;
+    __instance = new recoConsts();
+    return __instance;
+  }
 
   void Print() const;
 
- protected: 
+ protected:
   recoConsts() {}
-  
   static recoConsts *__instance;
-
 };
 
-
 #endif /* __RECOCONSTS_H__ */
-
-

--- a/offline/packages/NodeDump/DumpObject.cc
+++ b/offline/packages/NodeDump/DumpObject.cc
@@ -4,6 +4,7 @@
 #include <phool/PHNode.h>
 
 #include <fstream>
+#include <iostream>
 #include <string>
 
 using namespace std;
@@ -12,10 +13,10 @@ DumpObject::DumpObject(const string &NodeName):
   ThisName(NodeName),
   verbosity(0),
   write_run_event(1),
-  fout(NULL),
+  fout(nullptr),
   OutDir("./"),
   fp_precision(-1),
-  myNodeDump(NULL),
+  myNodeDump(nullptr),
   no_output(0)
 {
   return;

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
@@ -1,11 +1,11 @@
 #include "PHG4BeamlineMagnetDetector.h"
 #include "PHG4Parameters.h"
-//#include "PHG4QuadrupoleMagField.h"
 
 #include <g4main/PHG4PhenixDetector.h>
 #include <g4main/PHG4Utils.h>
 
 #include <phool/PHCompositeNode.h>
+#include <phool/phool.h>
 
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4LogicalVolume.hh>


### PR DESCRIPTION
Getting rid of legacy - phool had an int PHBoolean type with global declarations int False=0/True=1 rather than using bool. This was only used in phool itself, but phool.h which includes this typedef is included all over the place. This lead to some minor changes in unrelated sources. Ran clang-format to get the formatting up to standard,
 
Also putting the printout of the PHRandomSeed behind a verbosity setting