### PR TITLE
Implementation of second iterative step for UE background determination.

### DIFF
--- a/offline/packages/jetbackground/CopyAndSubtractJets.C
+++ b/offline/packages/jetbackground/CopyAndSubtractJets.C
@@ -1,0 +1,236 @@
+#include "CopyAndSubtractJets.h"
+
+// PHENIX includes
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHTypedNodeIterator.h>
+#include <phool/getClass.h>
+
+// sPHENIX includes
+#include <jetbackground/TowerBackground.h>
+#include <g4cemc/RawTower.h>
+#include <g4cemc/RawTowerv1.h>
+#include <g4cemc/RawTowerContainer.h>
+#include <g4cemc/RawTowerGeom.h>
+#include <g4cemc/RawTowerGeomContainer.h>
+#include <g4cemc/RawTowerGeomContainer_Cylinderv1.h>
+#include <g4jets/JetMap.h>
+#include <g4jets/JetMapV1.h>
+#include <g4jets/Jet.h>
+#include <g4jets/JetV1.h>
+
+// standard includes
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+CopyAndSubtractJets::CopyAndSubtractJets(const std::string &name)
+  : SubsysReco(name)
+{
+
+
+}
+
+CopyAndSubtractJets::~CopyAndSubtractJets()
+{
+}
+
+int CopyAndSubtractJets::Init(PHCompositeNode *topNode)
+{
+  if (verbosity > 0)
+    std::cout << "CopyAndSubtractJets::Init: initialized" << std::endl;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CopyAndSubtractJets::InitRun(PHCompositeNode *topNode)
+{
+
+  CreateNode(topNode);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CopyAndSubtractJets::process_event(PHCompositeNode *topNode)
+{
+  if (verbosity > 0)
+    std::cout << "CopyAndSubtractJets::process_event: entering" << std::endl;
+
+  // pull out needed calo tower info
+  RawTowerContainer *towersEM3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC_RETOWER");
+  RawTowerContainer *towersIH3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALIN");
+  RawTowerContainer *towersOH3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALOUT");
+
+  RawTowerGeomContainer *geomIH = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
+  RawTowerGeomContainer *geomOH = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
+
+  // pull out jets and background
+  JetMap* unsub_jets = findNode::getClass<JetMap>(topNode,"AntiKt_Tower_HIRecoSeedsRaw_r02");
+  JetMap* sub_jets = findNode::getClass<JetMap>(topNode,"AntiKt_Tower_HIRecoSeedsSub_r02");
+
+  TowerBackground* background = findNode::getClass<TowerBackground>(topNode,"TowerBackground_Sub1");
+
+  std::vector<float> background_UE_0 = background->get_UE( 0 );
+  std::vector<float> background_UE_1 = background->get_UE( 1 );
+  std::vector<float> background_UE_2 = background->get_UE( 2 );
+
+  if (verbosity > 0) {
+    std::cout << "CopyAndSubtractJets::process_event: entering with # unsubtracted jets = " << unsub_jets->size() << std::endl;
+    std::cout << "CopyAndSubtractJets::process_event: entering with # subtracted jets = " << sub_jets->size() << std::endl;
+  }
+
+  // iterate over old jets
+  int ijet = 0;
+  for (JetMap::Iter iter = unsub_jets->begin(); iter != unsub_jets->end(); ++iter) {
+    
+    Jet* this_jet = iter->second;
+    
+    float this_pt = this_jet->get_pt();
+    float this_phi = this_jet->get_phi();
+    float this_eta = this_jet->get_eta();
+
+    Jet *new_jet = new JetV1();
+
+    float new_total_px = 0;
+    float new_total_py = 0;
+    float new_total_pz = 0;
+    float new_total_e = 0;    
+
+    //if (this_jet->get_pt() < 5) continue;
+    
+    if (verbosity > 1 && this_jet->get_pt() >  5)
+      std::cout << "CopyAndSubtractJets::process_event: unsubtracted jet with pt / eta / phi = " << this_pt << " / " << this_eta << " / " << this_phi << std::endl;
+    
+    for (Jet::ConstIter comp = this_jet->begin_comp(); comp !=  this_jet->end_comp(); ++comp) {
+      
+      RawTower *tower = 0;
+      RawTowerGeom *tower_geom = 0;
+
+      double comp_e = 0;
+      double comp_eta = 0;
+      double comp_phi = 0;
+
+      int comp_ieta = 0;
+
+      double comp_background = 0;
+
+      if ( (*comp).first == 5 ) {
+	tower = towersIH3->getTower( (*comp).second );
+	tower_geom = geomIH->get_tower_geometry(tower->get_key());
+
+	comp_ieta = geomIH->get_etabin( tower_geom->get_eta() );
+	comp_background = background_UE_1.at( comp_ieta );
+      }
+      else if ( (*comp).first == 7 ) {
+	tower = towersOH3->getTower( (*comp).second );
+	tower_geom = geomOH->get_tower_geometry(tower->get_key());
+
+	comp_ieta = geomOH->get_etabin( tower_geom->get_eta() );
+	comp_background = background_UE_2.at( comp_ieta );
+      }
+      else if ( (*comp).first == 13 ) {
+	tower = towersEM3->getTower( (*comp).second );
+	tower_geom = geomIH->get_tower_geometry(tower->get_key());
+
+	comp_ieta = geomIH->get_etabin( tower_geom->get_eta() );
+	comp_background = background_UE_0.at( comp_ieta );
+      }
+
+      if (tower) 
+	comp_e = tower->get_energy();
+      if (tower_geom) {
+	comp_eta = tower_geom->get_eta();
+	comp_phi = tower_geom->get_phi();
+      }
+      
+      if (verbosity > 4 && this_jet->get_pt() > 5) {
+	std::cout << "CopyAndSubtractJets::process_event: --> constituent in layer " << (*comp).first << ", has unsub E = " << comp_e << ", is at ieta #" << comp_ieta << ", and has UE = " << comp_background << std::endl;
+      }
+
+      // update constituent energy based on the background
+      double comp_sub_e = comp_e - comp_background;
+      
+      // now define new kinematics
+      
+      double comp_px = comp_sub_e / cosh( comp_eta ) * cos( comp_phi );
+      double comp_py = comp_sub_e / cosh( comp_eta ) * sin( comp_phi );
+      double comp_pz = comp_sub_e * tanh( comp_eta );
+
+      new_total_px += comp_px;
+      new_total_py += comp_py;
+      new_total_pz += comp_pz;
+      new_total_e += comp_sub_e;
+    }
+
+    new_jet->set_px( new_total_px );
+    new_jet->set_py( new_total_py );
+    new_jet->set_pz( new_total_pz );
+    new_jet->set_e( new_total_e );
+    new_jet->set_id(ijet);
+
+    sub_jets->insert( new_jet );
+
+    if (verbosity > 1 && this_pt > 5) {
+      std::cout << "CopyAndSubtractJets::process_event: old jet #" << ijet << ", old px / py / pz / e = " << this_jet->get_px() << " / " << this_jet->get_py() << " / " << this_jet->get_pz() << " / " << this_jet->get_e() << std::endl;
+      std::cout << "CopyAndSubtractJets::process_event: new jet #" << ijet << ", new px / py / pz / e = " << new_jet->get_px() << " / " << new_jet->get_py() << " / " << new_jet->get_pz() << " / " << new_jet->get_e() << std::endl;
+    }
+        
+    ijet++;
+      
+  }	
+
+  if (verbosity > 0) {
+    std::cout << "CopyAndSubtractJets::process_event: exiting with # subtracted jets = " << sub_jets->size() << std::endl;
+  }
+
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CopyAndSubtractJets::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CopyAndSubtractJets::CreateNode(PHCompositeNode *topNode)
+{
+
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode) {
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  // Looking for the ANTIKT node
+  PHCompositeNode *antiktNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "ANTIKT"));
+  if (!antiktNode) {
+    std::cout << PHWHERE << "ANTIKT node not found, doing nothing." << std::endl;
+  }
+
+  // Looking for the TOWER node
+  PHCompositeNode *towerNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "TOWER"));
+  if (!towerNode) {
+    std::cout << PHWHERE << "TOWER node not found, doing nothing." << std::endl;
+  }
+
+  // store the new jet collection
+  JetMap* test_jets = findNode::getClass<JetMap>(topNode,"AntiKt_Tower_HIRecoSeedsSub_r02");
+  if ( !test_jets ) {
+
+    if (verbosity > 0) std::cout << "CopyAndSubtractJets::CreateNode : creating AntiKt_Tower_HIRecoSeedsSub_r02 node " << std::endl;
+    
+    JetMap *sub_jets = new JetMapV1();
+    PHIODataNode<PHObject> *subjetNode = new PHIODataNode<PHObject>( sub_jets, "AntiKt_Tower_HIRecoSeedsSub_r02", "PHObject");
+    towerNode->addNode(subjetNode);
+    
+  } else {
+    std::cout << "CopyAndSubtractJets::CreateNode : AntiKt_Tower_HIRecoSeedsSub_r02 already exists! " << std::endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/jetbackground/CopyAndSubtractJets.h
+++ b/offline/packages/jetbackground/CopyAndSubtractJets.h
@@ -1,0 +1,48 @@
+#ifndef __COPYANDSUBTRACTJETS_H__
+#define __COPYANDSUBTRACTJETS_H__
+
+//===========================================================
+/// \file CopyAndSubtractJets.h
+/// \brief Creates subtracted copy of a jet collection
+/// \author Dennis V. Perepelitsa
+//===========================================================
+
+// PHENIX includes
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>
+#include <phool/PHTimeServer.h>
+
+// standard includes
+#include <vector>
+
+#include <g4cemc/RawTowerContainer.h>
+
+// forward declarations
+class PHCompositeNode;
+
+/// \class CopyAndSubtractJets
+///
+/// \brief Creates subtractd copy of a jet collection
+///
+/// Makes a copy of a jet collection with a new name and then updates
+/// the kinematics of the jets in that collection based on a given UE
+/// background (intended use is to create the set of jets used as
+/// seeds in the second part of UE determination procedure)
+///
+class CopyAndSubtractJets : public SubsysReco
+{
+ public:
+  CopyAndSubtractJets(const std::string &name = "CopyAndSubtractJets");
+  virtual ~CopyAndSubtractJets();
+
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+ private:
+  int CreateNode(PHCompositeNode *topNode);
+
+};
+
+#endif  // __COPYANDSUBTRACTJETS_H__

--- a/offline/packages/jetbackground/CopyAndSubtractJetsLinkDef.h
+++ b/offline/packages/jetbackground/CopyAndSubtractJetsLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class CopyAndSubtractJets+;
+
+#endif /* __CINT__ */

--- a/offline/packages/jetbackground/DetermineTowerBackground.C
+++ b/offline/packages/jetbackground/DetermineTowerBackground.C
@@ -91,31 +91,6 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
   _seed_eta.resize(0);
   _seed_phi.resize(0);
 
-  // 
-  if (_seed_type == 1) {
-    JetMap* reco2_jets = findNode::getClass<JetMap>(topNode,"AntiKt_Tower_r02");
-
-    if (verbosity > 1)
-      std::cout << "DetermineTowerBackground::proess_event: examining possible seeds ... " << std::endl;
-    
-    for (JetMap::Iter iter = reco2_jets->begin(); iter != reco2_jets->end(); ++iter) {
-      Jet* this_jet = iter->second;
-      
-      float this_pt = this_jet->get_pt();
-      float this_phi = this_jet->get_phi();
-      float this_eta = this_jet->get_eta();
-
-      if (this_jet->get_pt() < 25) continue;
-
-      _seed_eta.push_back( this_eta );
-      _seed_phi.push_back( this_phi );
-
-      if (verbosity > 1)
-	std::cout << "DetermineTowerBackground::proess_event: adding seed at eta / phi = " << this_eta << " / " << this_phi << " ( R=0.2 jet with pt = " << this_pt << " ) " << std::endl;
-    }
-    
-  }
-
   // pull out the tower containers and geometry objects at the start
   RawTowerContainer *towersEM3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC_RETOWER");
   RawTowerContainer *towersIH3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALIN");
@@ -128,6 +103,138 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 
   RawTowerGeomContainer *geomIH = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
   RawTowerGeomContainer *geomOH = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
+
+  // seed type 0 is D > 3 R=0.2 jets run on retowerized CEMC
+  if (_seed_type == 0) {
+    JetMap* reco2_jets = findNode::getClass<JetMap>(topNode,"AntiKt_Tower_HIRecoSeedsRaw_r02");
+
+    if (verbosity > 1)
+      std::cout << "DetermineTowerBackground::process_event: examining possible seeds (1st iteration) ... " << std::endl;
+
+    for (JetMap::Iter iter = reco2_jets->begin(); iter != reco2_jets->end(); ++iter) {
+
+      Jet* this_jet = iter->second;
+
+      float this_pt = this_jet->get_pt();
+      float this_phi = this_jet->get_phi();
+      float this_eta = this_jet->get_eta();
+
+      if (this_jet->get_pt() < 5) continue;
+
+      if (verbosity > 1)
+	std::cout << "DetermineTowerBackground::process_event: possible seed jet with pt / eta / phi = " << this_pt << " / " << this_eta << " / " << this_phi << ", examining constituents..." << std::endl;
+
+      std::map< int, double > constituent_ETsum;
+
+      for (Jet::ConstIter comp = this_jet->begin_comp(); comp !=  this_jet->end_comp(); ++comp) {
+
+	int comp_ieta = -1;
+	int comp_iphi = -1;
+	float comp_ET = 0;
+
+	RawTower *tower;
+	RawTowerGeom *tower_geom;
+	
+        if ( (*comp).first == 5 ) {
+          tower = towersIH3->getTower( (*comp).second );
+          tower_geom = geomIH->get_tower_geometry(tower->get_key());
+
+	  comp_ieta = geomIH->get_etabin( tower_geom->get_eta() );
+	  comp_iphi =  geomIH->get_phibin( tower_geom->get_phi() );
+	  comp_ET = tower->get_energy() / cosh( tower_geom->get_eta() );
+        }
+        else if ( (*comp).first == 7 ) {
+          tower = towersOH3->getTower( (*comp).second );
+          tower_geom = geomOH->get_tower_geometry(tower->get_key());
+
+	  comp_ieta = geomIH->get_etabin( tower_geom->get_eta() );
+	  comp_iphi =  geomIH->get_phibin( tower_geom->get_phi() );
+	  comp_ET = tower->get_energy() / cosh( tower_geom->get_eta() );
+        }
+        else if ( (*comp).first == 13 ) {
+          tower = towersEM3->getTower( (*comp).second );
+          tower_geom = geomIH->get_tower_geometry(tower->get_key());
+
+	  comp_ieta = geomIH->get_etabin( tower_geom->get_eta() );
+	  comp_iphi =  geomIH->get_phibin( tower_geom->get_phi() );
+	  comp_ET = tower->get_energy() / cosh( tower_geom->get_eta() );
+	}
+
+	int comp_ikey = 1000 * comp_ieta + comp_iphi;
+
+	if (verbosity > 4)
+	  std::cout << "DetermineTowerBackground::process_event: --> --> constituent in layer " << (*comp).first << " at ieta / iphi = " << comp_ieta << " / " << comp_iphi << ", filling map with key = " << comp_ikey << " and ET = " << comp_ET << std::endl;
+
+	constituent_ETsum[ comp_ikey ] += comp_ET;
+
+	if (verbosity > 4)
+	  std::cout << "DetermineTowerBackground::process_event: --> --> ET sum map at key = " << comp_ikey << " now has ET = " << constituent_ETsum[ comp_ikey ] << std::endl;
+	
+      }
+
+      // now iterate over constituent_ET sums to find maximum and mean
+      float constituent_max_ET = 0;
+      float constituent_sum_ET = 0;
+      int nconstituents = 0;
+      
+      if (verbosity > 4)
+	std::cout << "DetermineTowerBackground::process_event: --> now iterating over map..." << std::endl;
+      for (std::map<int,double>::iterator map_iter = constituent_ETsum.begin(); map_iter != constituent_ETsum.end(); ++map_iter) {
+	if (verbosity > 4)
+	  std::cout << "DetermineTowerBackground::process_event: --> --> map has key # " << map_iter->first << " and ET = " << map_iter->second << std::endl;
+	nconstituents++;
+	constituent_sum_ET +=  map_iter->second;
+	if ( map_iter->second > constituent_max_ET ) constituent_max_ET = map_iter->second;
+      }
+
+      float mean_constituent_ET = constituent_sum_ET / nconstituents;
+      float seed_D = constituent_max_ET / mean_constituent_ET;
+      
+      if (verbosity > 1)
+	std::cout << "DetermineTowerBackground::process_event: --> jet has < ET > = " << constituent_sum_ET << " / " << nconstituents << " = " << mean_constituent_ET << ", max-ET = " << constituent_max_ET << ", and D = " << seed_D << std::endl;
+      
+      if ( seed_D > 3 ) {
+	_seed_eta.push_back( this_eta );
+	_seed_phi.push_back( this_phi );
+	
+	if (verbosity > 1)
+	  std::cout << "DetermineTowerBackground::process_event: --> adding seed at eta / phi = " << this_eta << " / " << this_phi << " ( R=0.2 jet with pt = " << this_pt << ", D = " << seed_D << " ) " << std::endl;
+      } else {
+	if (verbosity > 1)
+	  std::cout << "DetermineTowerBackground::process_event: --> discarding potential seed at eta / phi = " << this_eta << " / " << this_phi << " ( R=0.2 jet with pt = " << this_pt << ", D = " << seed_D << " ) " << std::endl;
+      }
+      
+    }
+
+  }
+
+  // seed type 1 is the set of those jets above which, when their
+  // kinematics are updated for the first background subtraction, have
+  // pT > 20 GeV
+  if (_seed_type == 1) {
+    JetMap* reco2_jets = findNode::getClass<JetMap>(topNode,"AntiKt_Tower_HIRecoSeedsSub_r02");
+
+    if (verbosity > 1)
+      std::cout << "DetermineTowerBackground::process_event: examining possible seeds (2nd iteration) ... " << std::endl;
+    
+    for (JetMap::Iter iter = reco2_jets->begin(); iter != reco2_jets->end(); ++iter) {
+      Jet* this_jet = iter->second;
+      
+      float this_pt = this_jet->get_pt();
+      float this_phi = this_jet->get_phi();
+      float this_eta = this_jet->get_eta();
+
+      if (this_jet->get_pt() < 15) continue;
+
+      _seed_eta.push_back( this_eta );
+      _seed_phi.push_back( this_phi );
+
+      if (verbosity > 1)
+	std::cout << "DetermineTowerBackground::process_event: adding seed at eta / phi = " << this_eta << " / " << this_phi << " ( R=0.2 jet with pt = " << this_pt << " ) " << std::endl;
+    }
+    
+  }
+
 
   // get the binning from the geometry (different for 1D vs 2D...)
   if (_HCAL_NETA < 0) {

--- a/offline/packages/jetbackground/Makefile.am
+++ b/offline/packages/jetbackground/Makefile.am
@@ -33,6 +33,7 @@ pkginclude_HEADERS = \
   DetermineTowerBackground.h \
   SubtractTowers.h \
   RetowerCEMC.h \
+  CopyAndSubtractJets.h \
   FastJetAlgoSub.h \
   TowerBackground.h \
   TowerBackground_v1.h
@@ -50,7 +51,9 @@ libjetbackground_la_SOURCES = \
   SubtractTowers.C \
   SubtractTowers_Dict.C \
   RetowerCEMC.C \
-  RetowerCEMC_Dict.C
+  RetowerCEMC_Dict.C \
+  CopyAndSubtractJets.C \
+  CopyAndSubtractJets_Dict.C
 
 # Rule for generating table CINT dictionaries.
 %_Dict.C: %.h %LinkDef.h

--- a/offline/packages/jetbackground/SubtractTowers.C
+++ b/offline/packages/jetbackground/SubtractTowers.C
@@ -82,7 +82,7 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
     std::cout << "SubtractTowers::process_event: starting with " << ohcal_towers->size() << " TOWER_CALIB_HCALOUT_SUB1 towers" << std::endl;
   }
 
-  TowerBackground* towerbackground = findNode::getClass<TowerBackground>(topNode,"TowerBackground_Sub1");
+  TowerBackground* towerbackground = findNode::getClass<TowerBackground>(topNode,"TowerBackground_Sub2");
 
   // EMCal
   

--- a/simulation/g4simulation/g4jets/Jet.h
+++ b/simulation/g4simulation/g4jets/Jet.h
@@ -23,7 +23,8 @@ public:
     HCALOUT_TOWER=7, HCALOUT_CLUSTER=8,
     FEMC_TOWER=9, FEMC_CLUSTER=10,
     FHCAL_TOWER=11, FHCAL_CLUSTER=12,
-    CEMC_TOWER_SUB1=13, HCALIN_TOWER_SUB1=14, HCALOUT_TOWER_SUB1=15, /* needed for HI jet reco */
+    CEMC_TOWER_RETOWER=13,                                           /* needed for HI jet reco */
+    CEMC_TOWER_SUB1=14, HCALIN_TOWER_SUB1=15, HCALOUT_TOWER_SUB1=16, /* needed for HI jet reco */
   };
 
   enum PROPERTY {prop_JetCharge = 1,prop_BFrac = 2};

--- a/simulation/g4simulation/g4jets/TowerJetInput.C
+++ b/simulation/g4simulation/g4jets/TowerJetInput.C
@@ -85,6 +85,12 @@ std::vector<Jet*> TowerJetInput::get_input(PHCompositeNode *topNode) {
     if (!towers||!geom) {
       return std::vector<Jet*>();
     }
+  } else if (_input == Jet::CEMC_TOWER_RETOWER) {
+    towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_CEMC_RETOWER");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode,"TOWERGEOM_HCALIN");
+    if (!towers||!geom) {
+      return std::vector<Jet*>();
+    }
   } else if (_input == Jet::CEMC_TOWER_SUB1) {
     towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_CEMC_RETOWER_SUB1");
     geom = findNode::getClass<RawTowerGeomContainer>(topNode,"TOWERGEOM_HCALIN");


### PR DESCRIPTION
These changes implement the second iterative step (really the first of the two steps in the sequence) in the UE background determination as described in nucl-ex/1203.1353 . (Note that the commensurate reconstruction macro will be updated separately in the macros repository.)

Summary of major changes: 
* The DetermineBackground module now implements an additional possible seed definition, which is based on the discriminant D (max tower ET / mean tower ET) > 3 within R=0.2 jets initially reconstructed without any subtraction. I've also lowered the minimum pT cut (from 25 GeV to 15 GeV) on jets entering as seeds in the second iteration, since their kinematics will now reflect the first UE subtraction iteration.
*  The core TowerJet reconstruction code now needs another possible tower input (TOWER_CALIB_CEMC_RETOWER) -- e.g. the 0.1x0.1-retowerized CEMC without subtraction.
* A new module, CopyAndSubtractJets, is needed to make a modified copy of the original unsubtracted jet collection, now updated with the UE estimate from the first iteration step. That collection is then used to define the seeds in the second round.
* The SubtractTowers module now applies a default TowerBackground object with a changed name (since this is now the result of the second iteration step).