### PR TITLE
Modifications in PHENIX-style Clustering

### DIFF
--- a/simulation/g4simulation/g4cemc/BEmcCluster.h
+++ b/simulation/g4simulation/g4cemc/BEmcCluster.h
@@ -130,6 +130,8 @@ public:
   float GetE9( int ich );
   /// Returns the cluster energy taking into account towers with E>Ethresh
   float GetECore();
+  /// Ecore corrected for energy leak sidewise core towers
+  float GetECoreCorrected();
   /// Returns the EmcCluster total energy
   float GetTotalEnergy();
   /// Returns EmcCluster 1-st (pxcg,pycg) and 2-d momenta (pxx,pxy,pyy)
@@ -149,7 +151,7 @@ public:
 		float* pxx, float* pxy, float* pyy,
 		float* pde, float* pdx, float* pdy, float* pdz );
   /// Splits the EmcCluster onto peakarea's; also returns peak tower array corresponding to peakarea array
-  int GetPeaks(EmcPeakarea*, EmcModule*);
+  int GetPeaks( std::vector<EmcPeakarea> *PkList, std::vector<EmcModule> *ppeaks );
   float GetProb(float &chi2, int &ndf);
 
 protected:

--- a/simulation/g4simulation/g4cemc/BEmcRec.cc
+++ b/simulation/g4simulation/g4cemc/BEmcRec.cc
@@ -162,7 +162,7 @@ int BEmcRec::FindClusters()
   vector<EmcModule>::iterator ph;
   vector<EmcModule> hl;
   
-  (*fClusters).erase(  (*fClusters).begin(),  (*fClusters).end() );
+  (*fClusters).clear();
   nhit = (*fModules).size();
   
   if( nhit <= 0 ) return 0;
@@ -250,7 +250,7 @@ int BEmcRec::FindClusters()
     ib=0;
     for( int iCl=0; iCl<nCl; iCl++ ) { 
       leng=LenCl[iCl];
-      hl.erase( hl.begin(), hl.end() );
+      hl.clear();
       for( ich=0; ich<leng; ich++ ) hl.push_back(vhit[ib+ich]);
       Clt.ReInitialize(hl);
       ib += LenCl[iCl];
@@ -533,7 +533,11 @@ int BEmcRec::ShiftX(int ishift, int nh, EmcModule* phit0, EmcModule* phit1)
     phit1[i].ich = ich;
   }
 
-  if( ishift==0 && ixmax-ixmin > fNx/2 ) printf("!!! Warning: Too long cluster (%d towers): reconstruction may be wrong !!!\n",ixmax-ixmin+1);
+  if( ishift==0 && ixmax-ixmin > fNx/2 ) {
+    printf("!!! Error BEmcRec::ShiftX(): Too long cluster (>%d towers in phi): reconstruction may be wrong. May need tower energy threshold increase for clustering.\n",fNx/2);
+    return -999;
+  }
+
   return ish;
 }
 
@@ -558,8 +562,10 @@ void BEmcRec::Momenta(int nh, EmcModule* phit, float* pe, float* px,
   //  p=phit;
   EmcModule* phit1 = new EmcModule[nh];
   int ish = ShiftX(0, nh, phit, phit1);
-  p = phit1;
 
+  if( ish<-fNx ) return;
+
+  p = phit1;
   x=0;
   y=0;
   e=0;
@@ -931,11 +937,16 @@ void BEmcRec::SetProfileParameters(int sec, float Energy, float x,
   
   if( Energy <= 1.e-10 ) lgE=0;
   else lgE=log(Energy);
-  
+  /*  
   fPpar1=0.59-(1.45+0.13*lgE)*sin2a;
   fPpar2=0.265+(0.80+0.32*lgE)*sin2a;
   fPpar3=0.25+(0.45-0.036*lgE)*sin2a;
   fPpar4=0.42;
+  */
+  fPpar1=0.549;
+  fPpar2=0.304;
+  fPpar3=0.389;
+  fPpar4=0.326;
   
   if( fSinTx > 0 ) sign = 1;
   else sign = -1;

--- a/simulation/g4simulation/g4cemc/RawCluster.h
+++ b/simulation/g4simulation/g4cemc/RawCluster.h
@@ -33,6 +33,7 @@ class RawCluster : public PHObject {
   virtual float get_eta() const { PHOOL_VIRTUAL_WARN("get_eta()"); return NAN; }
   virtual float get_phi() const { PHOOL_VIRTUAL_WARN("get_phi()"); return NAN; }
   virtual float get_energy() const { PHOOL_VIRTUAL_WARN("get_energy()"); return NAN; }
+  virtual float get_ecore() const { PHOOL_VIRTUAL_WARN("get_ecore()"); return NAN; }
   virtual float get_prob() const { PHOOL_VIRTUAL_WARN("get_prob()"); return NAN; }
   virtual float get_chi2() const { PHOOL_VIRTUAL_WARN("get_chi2()"); return NAN; }
 
@@ -40,6 +41,7 @@ class RawCluster : public PHObject {
   virtual void set_eta(const float eta) { PHOOL_VIRTUAL_WARN("set_eta(const float eta)");}
   virtual void set_phi(const float phi) { PHOOL_VIRTUAL_WARN("set_phi(const float phi)");}
   virtual void set_energy(const float energy) { PHOOL_VIRTUAL_WARN("set_energy(const float energy)");}
+  virtual void set_ecore(const float ecore) { PHOOL_VIRTUAL_WARN("set_ecore(const float ecore)");}
   virtual void set_prob(const float prob) { PHOOL_VIRTUAL_WARN("set_prob(const float prob)");}
   virtual void set_chi2(const float chi2) { PHOOL_VIRTUAL_WARN("set_chi2(const float chi2)");}
 

--- a/simulation/g4simulation/g4cemc/RawClusterv1.cc
+++ b/simulation/g4simulation/g4cemc/RawClusterv1.cc
@@ -9,6 +9,7 @@ RawClusterv1::RawClusterv1():
   _eta(0.0),
   _phi(0.0),
   _energy(0.0),
+  _ecore(0.0),
   _chi2(numeric_limits<float>::signaling_NaN()),
   _prob(numeric_limits<float>::signaling_NaN())
 {}
@@ -20,6 +21,7 @@ RawClusterv1::Reset()
   _eta = 0.0;
   _phi = 0.0;
   _energy = 0.0;
+  _ecore = 0.0;
   towermap.clear();
 }
 

--- a/simulation/g4simulation/g4cemc/RawClusterv1.h
+++ b/simulation/g4simulation/g4cemc/RawClusterv1.h
@@ -21,6 +21,7 @@ class RawClusterv1 : public RawCluster {
   float get_eta() const { return _eta; }
   float get_phi() const { return _phi; }
   float get_energy() const { return _energy; }
+  float get_ecore() const { return _ecore; }
   float get_chi2() const { return _chi2; }
   float get_prob() const { return _prob; }
 
@@ -28,6 +29,7 @@ class RawClusterv1 : public RawCluster {
   void set_eta(const float eta) { _eta = eta; }
   void set_phi(const float phi) { _phi = phi; }
   void set_energy(const float energy) { _energy = energy; }
+  void set_ecore(const float ecore) { _ecore = ecore; }
   void set_chi2(const float chi2) { _chi2 = chi2; }
   void set_prob(const float prob) { _prob = prob; }
 
@@ -44,6 +46,7 @@ class RawClusterv1 : public RawCluster {
   float _eta;
   float _phi;
   float _energy;
+  float _ecore;
   float _chi2;
   float _prob;
   std::vector<std::pair<int,int> > _towers;

--- a/simulation/g4simulation/g4cemc/RawClusterv1.h
+++ b/simulation/g4simulation/g4cemc/RawClusterv1.h
@@ -53,7 +53,7 @@ class RawClusterv1 : public RawCluster {
 
   TowerMap towermap;
 
-  ClassDef(RawClusterv1,1)
+  ClassDef(RawClusterv1,2)
 
 };
 


### PR DESCRIPTION
* RawCluster.h,cc:
    New filed "ecore" and corresponding get and set functions
* BEmcRec.cc:
    New shower profile parameters and other minor modifications (more clear error message if cluster is too large ... I'll remove this limitation later)
* BEmcCluster.h,cc:
    Change output data format in GetPeaks(): from fixed size array to vector
    Introduce GetECoreCorrected()
    Increase parameter fgMaxNofPeaks to make sure clustering will go on even for very large clusters
    Tune ECore for sPHENIX
    Other minor modifications
RawClusterBuilder.cc
    AbortEvent on clustering error with proper message
    Set default tower threshold of 20MeV - looks safe even for central HI collisions
    Some more modification related to changes in BEmcCluster.h(cc), RawCluster.h(cc)