### PR TITLE
fix coverity complaint (the code is valid but unclear what it is up to)

### DIFF
--- a/offline/database/PHParameter/PHParameters.cc
+++ b/offline/database/PHParameter/PHParameters.cc
@@ -529,7 +529,7 @@ PHParameters::ReadFromFile(const string &name, const string &extension, const in
           // this checks if the filename starts with fileprefix
           // (start pos of substring=0), if not coninue
           string basename = i.filename().string();
-          if (basename.find(fileprefix))
+          if (basename.find(fileprefix) != 0)
             {
               continue;
             }

--- a/simulation/g4simulation/g4detectors/PHG4Parameters.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Parameters.cc
@@ -529,7 +529,7 @@ PHG4Parameters::ReadFromFile(const string &name, const string &extension, const 
           // this checks if the filename starts with fileprefix
           // (start pos of substring=0), if not coninue
           string basename = i.filename().string();
-          if (basename.find(fileprefix))
+          if (basename.find(fileprefix) != 0)
             {
               continue;
             }


### PR DESCRIPTION
coverity flagged this as an error. The code does what it is supposed to but the construct is a bit misleading. This makes it more explicit that we are checking if the substring starts at position 0