### PR TITLE
Modified protection against exceeding list length in find_z_range, ca…

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -393,7 +393,7 @@ void PHG4TPCClusterizer::find_z_range(int zbin, int phibin, int zmax, float peak
     {
       int cz = zbin + iz;
       if(cz < 0) continue; // truncate edge
-      if(cz >= fNZBins) continue; // truncate edge
+      if(cz >= fNZBins-3) continue; // truncate edge
       
       // consider only the peak bin in phi when searching for Z limit     
       int cp = wrap_phibin(phibin);
@@ -421,7 +421,7 @@ void PHG4TPCClusterizer::find_z_range(int zbin, int phibin, int zmax, float peak
   for(int iz=0; iz< zmax; iz++)
     {
       int cz = zbin - iz;
-      if(cz < 0) continue; // truncate edge
+      if(cz <= 3) continue; // truncate edge
       if(cz >= fNZBins) continue; // truncate edge
       
       int cp = wrap_phibin(phibin);


### PR DESCRIPTION
…used occasional segfault. 

In "find_z_range" the protection against going outside the allowed list space needs to stop 3 steps away from the edge of the (fixed length) list. Caused segfault sometimes. Experienced no segfaults after this modification.