### PR TITLE
Calorimeter Clustering: switch between cylindrical and plane geometries; remove the cluster size limitation

### DIFF
--- a/offline/packages/CaloReco/BEmcCluster.h
+++ b/offline/packages/CaloReco/BEmcCluster.h
@@ -96,7 +96,6 @@ public:
   /// Returns EmcCluster fHitList
 #ifndef __CINT__
 
-  //  void GetHitList(std::vector<EmcModule> &plist)
   std::vector<EmcModule> GetHitList()
   {
     return fHitList;

--- a/offline/packages/CaloReco/BEmcRec.h
+++ b/offline/packages/CaloReco/BEmcRec.h
@@ -43,6 +43,10 @@ class BEmcRec
   //  void SetGeometry(SecGeom const &geom, PHMatrix * rm, PHVector * tr );
   void SetConf(int nx, int ny) { SetGeometry(nx, ny, 1., 1.); }
 
+  void SetPlaneGeometry() { bCYL=false; }
+  void SetCylindricalGeometry() { bCYL=true; }
+  bool isCylindrical() const { return bCYL; }
+
   int GetNx() const { return fNx; }
   int GetNy() const { return fNy; }
   float GetModSizex() const { return fModSizex; }
@@ -59,6 +63,9 @@ class BEmcRec
   std::vector<EmcModule> *GetModules(){ return fModules; }
   std::vector<EmcCluster> *GetClusters(){ return fClusters; }
 #endif
+
+  int iTowerDist(int ix1, int ix2);
+  float fTowerDist(float x1, float x2);
 
   int FindClusters();
   void GetImpactAngle(float x, float y, float *sinT );
@@ -77,7 +84,6 @@ class BEmcRec
   void Gamma(int, EmcModule*, float*, float*, float*, float*, float*,
 		     float*, float*, float*,
 		     int &ndf); // ndf added MV 28.01.00
-  void Mom1(int, EmcModule*, float*, float*, float*);
   void Momenta(int, EmcModule*, float*, float*, float*, float*, float*,
 	       float* );
   int ShiftX(int ishift, int nh, EmcModule* phit0, EmcModule* phit1);
@@ -118,6 +124,7 @@ class BEmcRec
  protected:
 
   // geometry
+  bool bCYL; // Cylindrical? 
   int fNx; // length in X direction
   int fNy; // length in Y direction
   float fModSizex; // module size in X direction (cm)


### PR DESCRIPTION
Modifications to address two goals: 
1. Introduce bCYL flag in BEmcRec to switch between cylindrical and planar geometries (needed e.g. for forward calorimeter). The default value is true (for cylindrical geometry); the switch to planar geometry use BEmcRec::SetPlaneGeometry()
2. Remove the maximal cluster size limitation (now it can deal with any cluster size); despite that is was large anyway (half of the calorimeter size in phi), I removed this limitation properly correcting the code

The modifications should not affect any existing codes in any way. 