### PR TITLE
replace PHG4Parameter by PHParameter class

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -29,7 +29,8 @@ libg4detectors_io_la_LIBADD = \
   -lboost_filesystem \
   -lboost_system \
   -lpdbcalBase \
-  -lXMLIO
+  -lXMLIO \
+  -lphparameter
 
 libg4detectors_la_LIBADD = \
   libg4detectors_io.la \

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
@@ -1,5 +1,6 @@
 #include "PHG4BeamlineMagnetDetector.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4PhenixDetector.h>
 #include <g4main/PHG4Utils.h>
@@ -29,7 +30,7 @@
 using namespace std;
 
 //_______________________________________________________________
-PHG4BeamlineMagnetDetector::PHG4BeamlineMagnetDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam, const int lyr ):
+PHG4BeamlineMagnetDetector::PHG4BeamlineMagnetDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam, const int lyr ):
   PHG4Detector(Node,dnam),
   params(parameters),
   magnet_physi(NULL),

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.h
@@ -7,7 +7,7 @@
 
 class G4LogicalVolume;
 class G4VPhysicalVolume;
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4BeamlineMagnetDetector: public PHG4Detector
 {
@@ -15,7 +15,7 @@ class PHG4BeamlineMagnetDetector: public PHG4Detector
   public:
 
   //! constructor
-  PHG4BeamlineMagnetDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam, const int layer = 0 );
+  PHG4BeamlineMagnetDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam, const int layer = 0 );
 
   //! destructor
   virtual ~PHG4BeamlineMagnetDetector( void )
@@ -31,7 +31,7 @@ class PHG4BeamlineMagnetDetector: public PHG4Detector
 
   private:
 
-  PHG4Parameters *params;
+  PHParameters *params;
 
   G4VPhysicalVolume* magnet_physi;
   G4VPhysicalVolume* cylinder_physi;

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
@@ -1,6 +1,7 @@
 #include "PHG4BeamlineMagnetSubsystem.h"
 #include "PHG4BeamlineMagnetDetector.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Utils.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -1,5 +1,6 @@
 #include "PHG4BlockDetector.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Utils.h>
 
@@ -22,7 +23,7 @@
 using namespace std;
 
 //_______________________________________________________________
-PHG4BlockDetector::PHG4BlockDetector( PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam, const int lyr):
+PHG4BlockDetector::PHG4BlockDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr):
   PHG4Detector(Node, dnam),
   params(parameters),
   block_physi(nullptr),

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
@@ -4,7 +4,7 @@
 #include <g4main/PHG4Detector.h>
 
 class G4LogicalVolume;
-class PHG4Parameters;
+class PHParameters;
 class G4VPhysicalVolume;
 
 class PHG4BlockDetector: public PHG4Detector
@@ -13,7 +13,7 @@ class PHG4BlockDetector: public PHG4Detector
   public:
 
   //! constructor
-  PHG4BlockDetector( PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam="BLOCK", const int lyr = 0 );
+  PHG4BlockDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam="BLOCK", const int lyr = 0 );
 
   //! destructor
   virtual ~PHG4BlockDetector( void )
@@ -33,7 +33,7 @@ class PHG4BlockDetector: public PHG4Detector
 
   private:
 
-  PHG4Parameters *params;
+  PHParameters *params;
  
   G4VPhysicalVolume* block_physi;
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.cc
@@ -1,7 +1,8 @@
 #include "PHG4BlockSteppingAction.h"
 #include "PHG4BlockDetector.h"
-#include "PHG4Parameters.h"
 #include "PHG4StepStatusDecode.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
@@ -18,7 +19,7 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4BlockSteppingAction::PHG4BlockSteppingAction(PHG4BlockDetector* detector, const PHG4Parameters* parameters)
+PHG4BlockSteppingAction::PHG4BlockSteppingAction(PHG4BlockDetector* detector, const PHParameters* parameters)
   : detector_(detector)
   , params(parameters)
   , hits_(nullptr)

--- a/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.h
@@ -7,14 +7,14 @@ class G4VPhysicalVolume;
 class PHG4BlockDetector;
 class PHG4Hit;
 class PHG4HitContainer;
-class PHG4Parameters;
+class PHParameters;
 class PHG4Shower;
 
 class PHG4BlockSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  PHG4BlockSteppingAction(PHG4BlockDetector *, const PHG4Parameters *parameters);
+  PHG4BlockSteppingAction(PHG4BlockDetector *, const PHParameters *parameters);
 
   //! destructor
   virtual ~PHG4BlockSteppingAction();
@@ -28,7 +28,7 @@ class PHG4BlockSteppingAction : public PHG4SteppingAction
  private:
   //! pointer to the detector
   PHG4BlockDetector *detector_;
-  const PHG4Parameters *params;
+  const PHParameters *params;
   //! pointer to hit container
   PHG4HitContainer *hits_;
   PHG4Hit *hit;

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
@@ -3,7 +3,8 @@
 #include "PHG4BlockGeomContainer.h"
 #include "PHG4BlockGeomv1.h"
 #include "PHG4BlockSteppingAction.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Utils.h>

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -1,5 +1,6 @@
 #include "PHG4CylinderDetector.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Utils.h>
 
@@ -23,7 +24,7 @@
 using namespace std;
 
 //_______________________________________________________________
-PHG4CylinderDetector::PHG4CylinderDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam, const int lyr)
+PHG4CylinderDetector::PHG4CylinderDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr)
   : PHG4Detector(Node, dnam)
   , params(parameters)
   , cylinder_physi(nullptr)

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
@@ -7,13 +7,13 @@
 
 class G4LogicalVolume;
 class G4VPhysicalVolume;
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4CylinderDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4CylinderDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam, const int layer = 0);
+  PHG4CylinderDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int layer = 0);
 
   //! destructor
   virtual ~PHG4CylinderDetector(void)
@@ -28,7 +28,7 @@ class PHG4CylinderDetector : public PHG4Detector
   const std::string SuperDetector() const { return superdetector; }
   int get_Layer() const { return layer; }
  private:
-  PHG4Parameters *params;
+  PHParameters *params;
 
   G4VPhysicalVolume *cylinder_physi;
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom.h
@@ -6,7 +6,7 @@
 #include <phool/phool.h>
 #include <cmath>
 
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4CylinderGeom: public PHObject
 {
@@ -48,8 +48,8 @@ class PHG4CylinderGeom: public PHObject
   virtual double get_pixel_x() const {PHOOL_VIRTUAL_WARN("get_pixel_x"); return NAN;}
   virtual double get_pixel_thickness() const {PHOOL_VIRTUAL_WARN("get_pixel_thickness"); return NAN;}
 
-  //! load parameters from PHG4Parameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHG4Parameters & param) {return ;}
+  //! load parameters from PHParameters, which interface to Database/XML/ROOT files
+  virtual void ImportParameters(const PHParameters & param) {return ;}
 
  protected:
   PHG4CylinderGeom() {}

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.cc
@@ -9,7 +9,8 @@
  */
 
 #include "PHG4CylinderGeom_Spacalv1.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <Geant4/globals.hh>
 #include <Geant4/G4PhysicalConstants.hh>
@@ -154,7 +155,7 @@ PHG4CylinderGeom_Spacalv1::SetDefault()
 }
 
 void
-PHG4CylinderGeom_Spacalv1::ImportParameters(const PHG4Parameters & param)
+PHG4CylinderGeom_Spacalv1::ImportParameters(const PHParameters & param)
 {
   PHG4CylinderGeomv2::ImportParameters(param);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
@@ -15,7 +15,7 @@
 #include <cmath>
 #include <map>
 
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4CylinderGeom_Spacalv1 : public PHG4CylinderGeomv2
 {
@@ -42,8 +42,8 @@ public:
   void
   SetDefault();
 
-  //! load parameters from PHG4Parameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHG4Parameters & param);
+  //! load parameters from PHParameters, which interface to Database/XML/ROOT files
+  virtual void ImportParameters(const PHParameters & param);
 
   ///@}
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.cc
@@ -9,7 +9,8 @@
  */
 
 #include "PHG4CylinderGeom_Spacalv2.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <Geant4/globals.hh>
 #include <Geant4/G4PhysicalConstants.hh>
@@ -79,7 +80,7 @@ PHG4CylinderGeom_Spacalv2::SetDefault()
 }
 
 void
-PHG4CylinderGeom_Spacalv2::ImportParameters(const PHG4Parameters & param)
+PHG4CylinderGeom_Spacalv2::ImportParameters(const PHParameters & param)
 {
   PHG4CylinderGeom_Spacalv1::ImportParameters(param);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.h
@@ -31,8 +31,8 @@ public:
   virtual void
   SetDefault();
 
-  //! load parameters from PHG4Parameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHG4Parameters & param);
+  //! load parameters from PHParameters, which interface to Database/XML/ROOT files
+  virtual void ImportParameters(const PHParameters & param);
 
   virtual
   int

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
@@ -9,7 +9,8 @@
  */
 
 #include "PHG4CylinderGeom_Spacalv3.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <Geant4/globals.hh>
 #include <Geant4/G4PhysicalConstants.hh>
@@ -100,7 +101,7 @@ PHG4CylinderGeom_Spacalv3::SetDefault()
 }
 
 void
-PHG4CylinderGeom_Spacalv3::ImportParameters(const PHG4Parameters & param)
+PHG4CylinderGeom_Spacalv3::ImportParameters(const PHParameters & param)
 {
   PHG4CylinderGeom_Spacalv2::ImportParameters(param);
 
@@ -260,7 +261,7 @@ PHG4CylinderGeom_Spacalv3::geom_tower::identify(std::ostream& os) const
 
 void
 PHG4CylinderGeom_Spacalv3::geom_tower::ImportParameters(
-    const PHG4Parameters & param, const std::string & param_prefix)
+    const PHParameters & param, const std::string & param_prefix)
 {
 
   id = param.get_int_param(param_prefix + "id");

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
@@ -31,9 +31,9 @@ class PHG4CylinderGeom_Spacalv3 : public PHG4CylinderGeom_Spacalv2
   virtual void
   SetDefault();
 
-  //! load parameters from PHG4Parameters, which interface to Database/XML/ROOT files
+  //! load parameters from PHParameters, which interface to Database/XML/ROOT files
   virtual void
-  ImportParameters(const PHG4Parameters& param);
+  ImportParameters(const PHParameters& param);
 
   double
   get_sidewall_outer_torr() const
@@ -168,9 +168,9 @@ class PHG4CylinderGeom_Spacalv3 : public PHG4CylinderGeom_Spacalv2
     virtual void
     identify(std::ostream& os = std::cout) const;
 
-    //! read via PHG4Parameters
+    //! read via PHParameters
     void
-    ImportParameters(const PHG4Parameters& param,
+    ImportParameters(const PHParameters& param,
                      const std::string& param_prefix);
 
     ClassDef(PHG4CylinderGeom_Spacalv3::geom_tower, 3)

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.cc
@@ -1,6 +1,8 @@
 #include "PHG4CylinderGeomv1.h"
+
+#include <phparameter/PHParameters.h>
+
 #include <cmath>
-#include "PHG4Parameters.h"
 
 using namespace std;
 
@@ -28,7 +30,7 @@ PHG4CylinderGeomv1::identify(std::ostream& os) const
 
 
 void
-PHG4CylinderGeomv1::ImportParameters(const PHG4Parameters & param)
+PHG4CylinderGeomv1::ImportParameters(const PHParameters & param)
 {
   PHG4CylinderGeom::ImportParameters(param);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.h
@@ -33,8 +33,8 @@ class PHG4CylinderGeomv1: public PHG4CylinderGeom
   void set_zmin(const double z) {zmin = z;}
   void set_zmax(const double z) {zmax = z;}
 
-  //! load parameters from PHG4Parameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHG4Parameters & param);
+  //! load parameters from PHParameters, which interface to Database/XML/ROOT files
+  virtual void ImportParameters(const PHParameters & param);
   
  protected:
   int layer;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2.cc
@@ -1,5 +1,6 @@
 #include "PHG4CylinderGeomv2.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 using namespace std;
 
@@ -23,7 +24,7 @@ PHG4CylinderGeomv2::identify(std::ostream& os) const
 }
 
 void
-PHG4CylinderGeomv2::ImportParameters(const PHG4Parameters & param)
+PHG4CylinderGeomv2::ImportParameters(const PHParameters & param)
 {
   PHG4CylinderGeomv1::ImportParameters(param);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2.h
@@ -18,8 +18,8 @@ class PHG4CylinderGeomv2: public PHG4CylinderGeomv1
   void set_nscint(const int i) {nscint = i;}
   int get_nscint() const {return nscint;}
 
-  //! load parameters from PHG4Parameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHG4Parameters & param);
+  //! load parameters from PHParameters, which interface to Database/XML/ROOT files
+  virtual void ImportParameters(const PHParameters & param);
 
  protected:
   int nscint;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -1,7 +1,8 @@
 #include "PHG4CylinderSteppingAction.h"
 #include "PHG4CylinderDetector.h"
-#include "PHG4Parameters.h"
 #include "PHG4StepStatusDecode.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
@@ -21,7 +22,7 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4CylinderSteppingAction::PHG4CylinderSteppingAction(PHG4CylinderDetector* detector, const PHG4Parameters* parameters)
+PHG4CylinderSteppingAction::PHG4CylinderSteppingAction(PHG4CylinderDetector* detector, const PHParameters* parameters)
   : detector_(detector)
   , params(parameters)
   , hits_(nullptr)

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -10,13 +10,13 @@ class PHG4CylinderDetector;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4CylinderSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  PHG4CylinderSteppingAction(PHG4CylinderDetector *, const PHG4Parameters *parameters);
+  PHG4CylinderSteppingAction(PHG4CylinderDetector *, const PHParameters *parameters);
 
   //! destructor
   virtual ~PHG4CylinderSteppingAction();
@@ -32,7 +32,7 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
   //! pointer to the detector
   PHG4CylinderDetector *detector_;
 
-  const PHG4Parameters *params;
+  const PHParameters *params;
 
   //! pointer to hit container
   PHG4HitContainer *hits_;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -3,7 +3,8 @@
 #include "PHG4CylinderGeomContainer.h"
 #include "PHG4CylinderGeomv1.h"
 #include "PHG4CylinderSteppingAction.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4PhenixDetector.h>

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
@@ -1,6 +1,7 @@
 #include "PHG4DetectorSubsystem.h"
-#include "PHG4Parameters.h"
-#include "PHG4ParametersContainer.h"
+
+#include <phparameter/PHParameters.h>
+#include <phparameter/PHParametersContainer.h>
 
 #include <pdbcalbase/PdbParameterMap.h>
 #include <pdbcalbase/PdbParameterMapContainer.h>
@@ -19,7 +20,7 @@ using namespace std;
 
 PHG4DetectorSubsystem::PHG4DetectorSubsystem(const std::string &name, const int lyr): 
   PHG4Subsystem(name),
-  params(new PHG4Parameters(Name())),
+  params(new PHParameters(Name())),
   paramscontainer(NULL),
   savetopNode(NULL),
   overlapcheck(false),
@@ -60,7 +61,7 @@ PHG4DetectorSubsystem::InitRun( PHCompositeNode* topNode )
   if (superdetector != "NONE")
     {
       g4geonodename += SuperDetector();
-      paramscontainer = findNode::getClass<PHG4ParametersContainer>(parNode,g4geonodename);
+      paramscontainer = findNode::getClass<PHParametersContainer>(parNode,g4geonodename);
       if (! paramscontainer)
 	{
 	  PHNodeIterator parIter(parNode);
@@ -70,10 +71,10 @@ PHG4DetectorSubsystem::InitRun( PHCompositeNode* topNode )
 	      DetNode = new PHCompositeNode(SuperDetector());
 	      parNode->addNode(DetNode);
 	    }
-	  paramscontainer = new PHG4ParametersContainer(superdetector);
-	  DetNode->addNode(new PHDataNode<PHG4ParametersContainer>(paramscontainer,g4geonodename));
+	  paramscontainer = new PHParametersContainer(superdetector);
+	  DetNode->addNode(new PHDataNode<PHParametersContainer>(paramscontainer,g4geonodename));
 	}
-      paramscontainer->AddPHG4Parameters(layer,params);
+      paramscontainer->AddPHParameters(layer,params);
       paramnodename += superdetector;
       calibdetname = superdetector;
       isSuperDetector = 1;
@@ -81,7 +82,7 @@ PHG4DetectorSubsystem::InitRun( PHCompositeNode* topNode )
   else
     {
       g4geonodename += params->Name();
-      parNode->addNode(new PHDataNode<PHG4Parameters>(params,g4geonodename));
+      parNode->addNode(new PHDataNode<PHParameters>(params,g4geonodename));
       paramnodename += params->Name();
       calibdetname = params->Name();
     }

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
@@ -6,8 +6,8 @@
 #include <map>
 #include <string>
 
-class PHG4Parameters;
-class PHG4ParametersContainer;
+class PHParameters;
+class PHParametersContainer;
 
 class PHG4DetectorSubsystem : public PHG4Subsystem
 {
@@ -32,7 +32,7 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
   void OverlapCheck(const bool chk = true) {overlapcheck = chk;}
   bool CheckOverlap() const {return overlapcheck;}
 
-  PHG4Parameters *GetParams() const {return params;} 
+  PHParameters *GetParams() const {return params;} 
 
  // Get/Set parameters from macro
   void set_double_param(const std::string &name, const double dval);
@@ -77,8 +77,8 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
   int BeginRunExecuted() const {return beginrunexecuted;}
 
  private:
-  PHG4Parameters *params;
-  PHG4ParametersContainer *paramscontainer;
+  PHParameters *params;
+  PHParametersContainer *paramscontainer;
   PHCompositeNode *savetopNode;
   bool overlapcheck;
   int layer;

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -53,7 +53,7 @@ using namespace std;
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
 PHG4FullProjSpacalDetector::PHG4FullProjSpacalDetector(PHCompositeNode *Node,
-    const std::string& dnam, PHG4Parameters* parameters, const int lyr)
+    const std::string& dnam, PHParameters* parameters, const int lyr)
 : PHG4SpacalDetector(Node, dnam, parameters, lyr, false)
 {
   assert(_geom == nullptr);

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.h
@@ -26,7 +26,7 @@ class G4Tubs;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4UserLimits;
-class PHG4Parameters;
+class PHParameters;
 
 //! Fully projective SPACAL built from 2D tapered modules.
 //! This class is obsolete and for comparison study only. Use PHG4FullProjTiltedSpacalDetector instead.
@@ -37,7 +37,7 @@ class PHG4FullProjSpacalDetector : public PHG4SpacalDetector
   typedef PHG4CylinderGeom_Spacalv3 SpacalGeom_t;
 
   PHG4FullProjSpacalDetector(PHCompositeNode* Node, const std::string& dnam,
-                             PHG4Parameters* parameters, const int layer = 0);
+                             PHParameters* parameters, const int layer = 0);
 
   // empty dtor, step limits are deleted in base class
   virtual ~PHG4FullProjSpacalDetector(void) {}

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -55,7 +55,7 @@ using namespace std;
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
 PHG4FullProjTiltedSpacalDetector::PHG4FullProjTiltedSpacalDetector(PHCompositeNode* Node,
-                                                                   const std::string& dnam, PHG4Parameters* parameters, const int lyr)
+                                                                   const std::string& dnam, PHParameters* parameters, const int lyr)
   : PHG4SpacalDetector(Node, dnam, parameters, lyr, false)
 {
   assert(_geom == nullptr);

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
@@ -26,7 +26,7 @@ class G4Tubs;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4UserLimits;
-class PHG4Parameters;
+class PHParameters;
 
 //! Fully projective SPACAL built from 2D tapered modules and allow azimuthal tilts
 class PHG4FullProjTiltedSpacalDetector : public PHG4SpacalDetector
@@ -35,7 +35,7 @@ class PHG4FullProjTiltedSpacalDetector : public PHG4SpacalDetector
   typedef PHG4CylinderGeom_Spacalv3 SpacalGeom_t;
 
   PHG4FullProjTiltedSpacalDetector(PHCompositeNode* Node, const std::string& dnam,
-                                   PHG4Parameters* parameters, const int layer = 0);
+                                   PHParameters* parameters, const int layer = 0);
 
   // empty dtor, step limits are deleted in base class
   virtual ~PHG4FullProjTiltedSpacalDetector(void) {}

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -1,6 +1,7 @@
 #include "PHG4InnerHcalDetector.h"
 #include "PHG4HcalDefs.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Utils.h>
 
@@ -48,7 +49,7 @@ using namespace std;
 // scintilator length takes care of this
 static double subtract_from_scinti_x = 0.1 * mm;
 
-PHG4InnerHcalDetector::PHG4InnerHcalDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam)
+PHG4InnerHcalDetector::PHG4InnerHcalDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
   : PHG4Detector(Node, dnam)
   , params(parameters)
   , scinti_mother_assembly(nullptr)

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -17,7 +17,7 @@ class G4AssemblyVolume;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4VSolid;
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4InnerHcalDetector : public PHG4Detector
 {
@@ -26,7 +26,7 @@ class PHG4InnerHcalDetector : public PHG4Detector
   typedef CGAL::Point_2<Circular_k> Point_2;
 
   //! constructor
-  PHG4InnerHcalDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam);
+  PHG4InnerHcalDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4InnerHcalDetector();
@@ -58,7 +58,7 @@ class PHG4InnerHcalDetector : public PHG4Detector
   int ConstructInnerHcal(G4LogicalVolume *sandwich);
   int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = nullptr);
   double x_at_y(Point_2 &p0, Point_2 &p1, double yin);
-  PHG4Parameters *params;
+  PHParameters *params;
   G4AssemblyVolume *scinti_mother_assembly;
   double inner_radius;
   double outer_radius;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -1,8 +1,9 @@
 #include "PHG4InnerHcalSteppingAction.h"
 #include "PHG4HcalDefs.h"
 #include "PHG4InnerHcalDetector.h"
-#include "PHG4Parameters.h"
 #include "PHG4StepStatusDecode.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
@@ -38,7 +39,7 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector* detector, const PHG4Parameters* parameters)
+PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector* detector, const PHParameters* parameters)
   : detector_(detector)
   , hits_(nullptr)
   , absorberhits_(nullptr)

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -5,7 +5,7 @@
 
 class G4VPhysicalVolume;
 class PHG4InnerHcalDetector;
-class PHG4Parameters;
+class PHParameters;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
@@ -14,7 +14,7 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector *, const PHG4Parameters *parameters);
+  PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector *, const PHParameters *parameters);
 
   //! destructor
   virtual ~PHG4InnerHcalSteppingAction();
@@ -35,7 +35,7 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   PHG4HitContainer *hits_;
   PHG4HitContainer *absorberhits_;
   PHG4Hit *hit;
-  const PHG4Parameters *params;
+  const PHParameters *params;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
   G4VPhysicalVolume *savevolpre;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -2,7 +2,8 @@
 #include "PHG4HcalDefs.h"
 #include "PHG4InnerHcalDetector.h"
 #include "PHG4InnerHcalSteppingAction.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
@@ -8,7 +8,6 @@
 #include <string>
 
 class PHG4InnerHcalDetector;
-class PHG4Parameters;
 class PHG4InnerHcalSteppingAction;
 
 class PHG4InnerHcalSubsystem : public PHG4DetectorSubsystem

--- a/simulation/g4simulation/g4detectors/PHG4MapsDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsDetector.cc
@@ -1,7 +1,8 @@
 #include "PHG4MapsDetector.h"
 #include "PHG4CylinderGeomContainer.h"
 #include "PHG4CylinderGeom_MAPS.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Utils.h>
 
@@ -34,7 +35,7 @@ using namespace std;
 
 //static double no_overlap = 0.00015 * cm; // added safety margin against overlaps by using same boundary between volumes
 
-PHG4MapsDetector::PHG4MapsDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam ):
+PHG4MapsDetector::PHG4MapsDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam ):
   PHG4Detector(Node, dnam),
   //envelope_inner_radius(26.0*mm),
   //envelope_outer_radius(880*mm),

--- a/simulation/g4simulation/g4detectors/PHG4MapsDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4MapsDetector.h
@@ -1,7 +1,7 @@
 #ifndef PHG4MapsDetector_h
 #define PHG4MapsDetector_h
 
-#include "g4main/PHG4Detector.h"
+#include <g4main/PHG4Detector.h>
 
 #include <Geant4/globals.hh>
 #include <Geant4/G4Types.hh>
@@ -17,7 +17,7 @@ class G4AssemblyVolume;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4VSolid;
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4MapsDetector: public PHG4Detector
 {
@@ -25,7 +25,7 @@ class PHG4MapsDetector: public PHG4Detector
   public:
 
   //! constructor
-  PHG4MapsDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam="BLOCK" );
+  PHG4MapsDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam="BLOCK" );
 
   //! destructor
   virtual ~PHG4MapsDetector();

--- a/simulation/g4simulation/g4detectors/PHG4MapsSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsSteppingAction.cc
@@ -1,5 +1,6 @@
 #include "PHG4MapsSteppingAction.h"
 #include "PHG4MapsDetector.h"
+#include "PHG4CylinderGeom_MAPS.h"
 
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
@@ -7,7 +8,6 @@
 #include <g4main/PHG4TrackUserInfoV1.h>
 #include <g4main/PHG4Shower.h>
 
-#include "PHG4CylinderGeom_MAPS.h"
 #include <phool/getClass.h>
 
 #include <Geant4/G4Step.hh>

--- a/simulation/g4simulation/g4detectors/PHG4MapsSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4MapsSteppingAction.h
@@ -1,7 +1,7 @@
 #ifndef PHG4VMapsSteppingAction_h
 #define PHG4VMapsSteppingAction_h
 
-#include "g4main/PHG4SteppingAction.h"
+#include <g4main/PHG4SteppingAction.h>
 
 class PHG4MapsDetector;
 class PHG4Hit;

--- a/simulation/g4simulation/g4detectors/PHG4MapsSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsSubsystem.cc
@@ -2,7 +2,8 @@
 #include "PHG4MapsDetector.h"
 #include "PHG4EventActionClearZeroEdep.h"
 #include "PHG4MapsSteppingAction.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <Geant4/G4GDMLParser.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -1,6 +1,7 @@
 #include "PHG4OuterHcalDetector.h"
 #include "PHG4HcalDefs.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Utils.h>
 
@@ -49,7 +50,7 @@ using namespace std;
 // scintilator length takes care of this
 static double subtract_from_scinti_x = 0.1 * mm;
 
-PHG4OuterHcalDetector::PHG4OuterHcalDetector(PHCompositeNode *Node, PHG4Parameters *parames, const std::string &dnam)
+PHG4OuterHcalDetector::PHG4OuterHcalDetector(PHCompositeNode *Node, PHParameters *parames, const std::string &dnam)
   : PHG4Detector(Node, dnam)
   , field_setup(nullptr)
   , params(parames)

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
@@ -19,7 +19,7 @@ class G4AssemblyVolume;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4VSolid;
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4OuterHcalDetector : public PHG4Detector
 {
@@ -27,7 +27,7 @@ class PHG4OuterHcalDetector : public PHG4Detector
   typedef CGAL::Exact_circular_kernel_2 Circular_k;
   typedef CGAL::Point_2<Circular_k> Point_2;
   //! constructor
-  PHG4OuterHcalDetector(PHCompositeNode *Node, PHG4Parameters *params, const std::string &dnam = "HCALOUT");
+  PHG4OuterHcalDetector(PHCompositeNode *Node, PHParameters *params, const std::string &dnam = "HCALOUT");
 
   //! destructor
   virtual ~PHG4OuterHcalDetector();
@@ -59,7 +59,7 @@ class PHG4OuterHcalDetector : public PHG4Detector
   int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = nullptr);
   G4double x_at_y(Point_2 &p0, Point_2 &p1, G4double yin);
   PHG4OuterHcalFieldSetup *field_setup;
-  PHG4Parameters *params;
+  PHParameters *params;
   G4AssemblyVolume *scinti_mother_assembly;
   G4VSolid *steel_cutout_for_magnet;
   double inner_radius;

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -2,10 +2,11 @@
 #include "PHG4OuterHcalSteppingAction.h"
 #include "PHG4HcalDefs.h"
 #include "PHG4OuterHcalDetector.h"
-#include "PHG4Parameters.h"
 #include "PHG4StepStatusDecode.h"
 
 // our own headers in alphabetical order
+
+#include <phparameter/PHParameters.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllServer.h>
@@ -54,7 +55,7 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4OuterHcalSteppingAction::PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector* detector, const PHG4Parameters* parameters)
+PHG4OuterHcalSteppingAction::PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector* detector, const PHParameters* parameters)
   : detector_(detector)
   , hits_(nullptr)
   , absorberhits_(nullptr)

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
@@ -5,7 +5,7 @@
 
 class G4VPhysicalVolume;
 class PHG4OuterHcalDetector;
-class PHG4Parameters;
+class PHParameters;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
@@ -14,7 +14,7 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector *, const PHG4Parameters *parameters);
+  PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector *, const PHParameters *parameters);
 
   //! destructor
   virtual ~PHG4OuterHcalSteppingAction();
@@ -39,7 +39,7 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
   PHG4HitContainer *hits_;
   PHG4HitContainer *absorberhits_;
   PHG4Hit *hit;
-  const PHG4Parameters *params;
+  const PHParameters *params;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
   G4VPhysicalVolume *savevolpre;

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -2,7 +2,8 @@
 #include "PHG4OuterHcalDetector.h"
 #include "PHG4OuterHcalSteppingAction.h"
 #include "PHG4HcalDefs.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
@@ -7,7 +7,6 @@
 #include <string>
 
 class PHG4OuterHcalDetector;
-class PHG4Parameters;
 class PHG4OuterHcalSteppingAction;
 
 class PHG4OuterHcalSubsystem: public PHG4DetectorSubsystem

--- a/simulation/g4simulation/g4detectors/PHG4ParametersContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ParametersContainer.cc
@@ -55,6 +55,28 @@ PHG4ParametersContainer::FillFrom(const PdbParameterMapContainer *saveparamconta
 }
 
 void
+PHG4ParametersContainer::CreateAndFillFrom(const PdbParameterMapContainer *saveparamcontainer, const string &name)
+{
+  PdbParameterMapContainer::parConstRange begin_end =  saveparamcontainer->get_ParameterMaps();
+  for (PdbParameterMapContainer::parIter iter = begin_end.first; iter != begin_end.second; ++iter)
+  {
+    Iterator pariter = parametermap.find(iter->first);
+    if (pariter != parametermap.end())
+    {
+      PHG4Parameters *params = pariter->second;
+      params->FillFrom(iter->second);
+    }
+    else
+    {
+      PHG4Parameters *params = new PHG4Parameters(name);
+      params->FillFrom(iter->second);
+      AddPHG4Parameters(iter->first,params);
+    }
+  }
+  return;
+}
+
+void
 PHG4ParametersContainer::AddPHG4Parameters(const int layer, PHG4Parameters *params)
 {
   if (parametermap.find(layer) != parametermap.end())

--- a/simulation/g4simulation/g4detectors/PHG4ParametersContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4ParametersContainer.h
@@ -39,6 +39,7 @@ class PHG4ParametersContainer : public PHObject
   int ExistDetid(const int detid) const;
   void clear() { parametermap.clear(); }
   void FillFrom(const PdbParameterMapContainer *saveparamcontainer);
+  void CreateAndFillFrom(const PdbParameterMapContainer *saveparamcontainer, const std::string &name);
 
  protected:
   void CopyToPdbParameterMapContainer(PdbParameterMapContainer *myparm);

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -1,5 +1,7 @@
 #include "PHG4Prototype2InnerHcalDetector.h"
 
+#include <phparameter/PHParameters.h>
+
 #include <g4main/PHG4Utils.h>
 
 #include <phool/PHCompositeNode.h>
@@ -21,7 +23,7 @@
 
 using namespace std;
 
-PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam  ):
+PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam  ):
   PHG4Detector(Node, dnam),
   params(parameters),
   innerhcalsteelplate(NULL),

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
@@ -1,8 +1,6 @@
 #ifndef PHG4Prototype2InnerHcalDetector_h
 #define PHG4Prototype2InnerHcalDetector_h
 
-#include "PHG4Parameters.h"
-
 #include <g4main/PHG4Detector.h>
 
 #include <Geant4/globals.hh>
@@ -19,6 +17,7 @@ class G4AssemblyVolume;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4VSolid;
+class PHParameters;
 
 class PHG4Prototype2InnerHcalDetector: public PHG4Detector
 {
@@ -26,7 +25,7 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   public:
 
   //! constructor
- PHG4Prototype2InnerHcalDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam);
+ PHG4Prototype2InnerHcalDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4Prototype2InnerHcalDetector(){}
@@ -60,7 +59,7 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   int ConstructInnerHcal(G4LogicalVolume* sandwich);
   int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
   int DisplayVolume(G4LogicalVolume *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
-  PHG4Parameters *params;
+  PHParameters *params;
   G4LogicalVolume *innerhcalsteelplate;
   G4AssemblyVolume *innerhcalassembly;
   G4TwoVector steel_plate_corner_upper_left;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
@@ -1,6 +1,7 @@
 #include "PHG4Prototype2InnerHcalSteppingAction.h"
-#include "PHG4Parameters.h"
 #include "PHG4Prototype2InnerHcalDetector.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
@@ -33,7 +34,7 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4Prototype2InnerHcalSteppingAction::PHG4Prototype2InnerHcalSteppingAction(PHG4Prototype2InnerHcalDetector* detector, PHG4Parameters* parameters)
+PHG4Prototype2InnerHcalSteppingAction::PHG4Prototype2InnerHcalSteppingAction(PHG4Prototype2InnerHcalDetector* detector, const PHParameters* parameters)
   : detector_(detector)
   , hits_(nullptr)
   , absorberhits_(nullptr)

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
@@ -5,7 +5,7 @@
 
 class PHG4Hit;
 class PHG4HitContainer;
-class PHG4Parameters;
+class PHParameters;
 class PHG4Prototype2InnerHcalDetector;
 class PHG4Shower;
 
@@ -13,7 +13,7 @@ class PHG4Prototype2InnerHcalSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  PHG4Prototype2InnerHcalSteppingAction(PHG4Prototype2InnerHcalDetector *, PHG4Parameters *parameters);
+  PHG4Prototype2InnerHcalSteppingAction(PHG4Prototype2InnerHcalDetector *, const PHParameters *parameters);
 
   //! dtor
   virtual ~PHG4Prototype2InnerHcalSteppingAction();
@@ -34,7 +34,7 @@ class PHG4Prototype2InnerHcalSteppingAction : public PHG4SteppingAction
   PHG4HitContainer *hits_;
   PHG4HitContainer *absorberhits_;
   PHG4Hit *hit;
-  PHG4Parameters *params;
+  const PHParameters *params;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
   // since getting parameters is a map search we do not want to

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -1,7 +1,8 @@
 #include "PHG4Prototype2InnerHcalSubsystem.h"
-#include "PHG4Parameters.h"
 #include "PHG4Prototype2InnerHcalDetector.h"
 #include "PHG4Prototype2InnerHcalSteppingAction.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -1,5 +1,7 @@
 #include "PHG4Prototype2OuterHcalDetector.h"
 
+#include <phparameter/PHParameters.h>
+
 #include <g4main/PHG4Utils.h>
 
 #include <phool/PHCompositeNode.h>
@@ -23,7 +25,7 @@ using namespace std;
 
 double scinti_box_smaller = 0.02*mm;
 
-PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam  ):
+PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam  ):
   PHG4Detector(Node, dnam),
   params(parameters),
   outerhcalsteelplate(NULL),

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
@@ -1,8 +1,6 @@
 #ifndef PHG4Prototype2OuterHcalDetector_h
 #define PHG4Prototype2OuterHcalDetector_h
 
-#include "PHG4Parameters.h"
-
 #include <g4main/PHG4Detector.h>
 
 #include <Geant4/globals.hh>
@@ -19,6 +17,7 @@ class G4AssemblyVolume;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4VSolid;
+class PHParameters;
 
 class PHG4Prototype2OuterHcalDetector: public PHG4Detector
 {
@@ -26,7 +25,7 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
   public:
 
   //! constructor
- PHG4Prototype2OuterHcalDetector( PHCompositeNode *Node,  PHG4Parameters *parameters, const std::string &dnam);
+ PHG4Prototype2OuterHcalDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4Prototype2OuterHcalDetector(){}
@@ -60,7 +59,7 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
   int ConstructOuterHcal(G4LogicalVolume* sandwich);
   int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
   int DisplayVolume(G4LogicalVolume *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
-  PHG4Parameters *params;
+  PHParameters *params;
   G4LogicalVolume *outerhcalsteelplate;
   G4AssemblyVolume *outerhcalassembly;
   G4TwoVector steel_plate_corner_upper_left;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
@@ -1,6 +1,7 @@
 #include "PHG4Prototype2OuterHcalSteppingAction.h"
-#include "PHG4Parameters.h"
 #include "PHG4Prototype2OuterHcalDetector.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
@@ -33,7 +34,7 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4Prototype2OuterHcalSteppingAction::PHG4Prototype2OuterHcalSteppingAction(PHG4Prototype2OuterHcalDetector* detector, PHG4Parameters* parameters)
+PHG4Prototype2OuterHcalSteppingAction::PHG4Prototype2OuterHcalSteppingAction(PHG4Prototype2OuterHcalDetector* detector, const PHParameters* parameters)
   : detector_(detector)
   , hits_(nullptr)
   , absorberhits_(nullptr)

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.h
@@ -4,7 +4,7 @@
 #include <g4main/PHG4SteppingAction.h>
 
 class PHG4Prototype2OuterHcalDetector;
-class PHG4Parameters;
+class PHParameters;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
@@ -13,7 +13,7 @@ class PHG4Prototype2OuterHcalSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  PHG4Prototype2OuterHcalSteppingAction(PHG4Prototype2OuterHcalDetector *, PHG4Parameters *parameters);
+  PHG4Prototype2OuterHcalSteppingAction(PHG4Prototype2OuterHcalDetector *, const PHParameters *parameters);
 
   //! dtor
   virtual ~PHG4Prototype2OuterHcalSteppingAction();
@@ -34,7 +34,7 @@ class PHG4Prototype2OuterHcalSteppingAction : public PHG4SteppingAction
   PHG4HitContainer *hits_;
   PHG4HitContainer *absorberhits_;
   PHG4Hit *hit;
-  PHG4Parameters *params;
+  const PHParameters *params;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
   // since getting parameters is a map search we do not want to

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
@@ -1,7 +1,8 @@
 #include "PHG4Prototype2OuterHcalSubsystem.h"
-#include "PHG4Parameters.h"
 #include "PHG4Prototype2OuterHcalDetector.h"
 #include "PHG4Prototype2OuterHcalSteppingAction.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -8,6 +8,8 @@
 #include "PHG4SpacalDetector.h"
 #include "PHG4CylinderGeomContainer.h"
 
+#include <phparameter/PHParameters.h>
+
 #include <g4main/PHG4PhenixDetector.h>
 #include <g4main/PHG4Utils.h>
 
@@ -44,7 +46,7 @@ using namespace std;
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
 PHG4SpacalDetector::PHG4SpacalDetector(PHCompositeNode *Node,
-                                       const std::string &dnam, PHG4Parameters *parameters, const int lyr, bool init_geom)
+                                       const std::string &dnam, PHParameters *parameters, const int lyr, bool init_geom)
   : PHG4Detector(Node, dnam)
   , _region(NULL)
   , cylinder_solid(NULL)

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
@@ -11,8 +11,9 @@
 #ifndef PHG4SpacalDetector_h
 #define PHG4SpacalDetector_h
 
-#include "g4main/PHG4Detector.h"
 #include "PHG4CylinderGeom_Spacalv1.h"
+
+#include <g4main/PHG4Detector.h>
 
 #include <Geant4/globals.hh>
 #include <Geant4/G4Region.hh>
@@ -29,7 +30,7 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4UserLimits;
 class PHG4GDMLConfig;
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4SpacalDetector : public PHG4Detector
 {
@@ -38,7 +39,7 @@ public:
   typedef PHG4CylinderGeom_Spacalv1 SpacalGeom_t;
 
   PHG4SpacalDetector(PHCompositeNode* Node, const std::string& dnam,
-      PHG4Parameters *parameters,  const int layer = 0, bool init_geom = true);
+      PHParameters *parameters,  const int layer = 0, bool init_geom = true);
 
   virtual
   ~PHG4SpacalDetector(void);

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.cc
@@ -1,6 +1,7 @@
 #include "PHG4SpacalPrototypeDetector.h"
 #include "PHG4CylinderGeomContainer.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4PhenixDetector.h>
 #include <g4main/PHG4Utils.h>
@@ -43,7 +44,7 @@ using namespace std;
 
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4SpacalPrototypeDetector::PHG4SpacalPrototypeDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam) :
+PHG4SpacalPrototypeDetector::PHG4SpacalPrototypeDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam) :
     PHG4Detector(Node, dnam), 
     construction_params(parameters),
     cylinder_solid(NULL), 

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.h
@@ -19,7 +19,7 @@ class G4Material;
 class G4UserLimits;
 class G4VPhysicalVolume;
 class G4VSolid;
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4SpacalPrototypeDetector : public PHG4Detector
 {
@@ -27,7 +27,7 @@ class PHG4SpacalPrototypeDetector : public PHG4Detector
 public:
   typedef PHG4CylinderGeom_Spacalv3 SpacalGeom_t;
 
-  PHG4SpacalPrototypeDetector(PHCompositeNode* Node, PHG4Parameters *parameters, const std::string& dnam);
+  PHG4SpacalPrototypeDetector(PHCompositeNode* Node, PHParameters *parameters, const std::string& dnam);
 
   virtual
   ~PHG4SpacalPrototypeDetector(void);
@@ -108,7 +108,7 @@ public:
 
 protected:
 
-  PHG4Parameters *construction_params;
+  PHParameters *construction_params;
 
   G4VSolid* cylinder_solid;
   G4LogicalVolume* cylinder_logic;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
@@ -7,8 +7,8 @@
 #include "PHG4CylinderGeomContainer.h"
 #include "PHG4SpacalPrototypeSteppingAction.h"
 
-#include "PHG4ParametersContainer.h"
-#include "PHG4Parameters.h"
+#include <phparameter/PHParameters.h>
+#include <phparameter/PHParametersContainer.h>
 
 #include <g4main/PHG4Utils.h>
 #include <g4main/PHG4PhenixDetector.h>

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -14,7 +14,8 @@
 //#include "PHG4ProjSpacalDetector.h"
 #include "PHG4SpacalDetector.h"
 #include "PHG4SpacalSteppingAction.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4PhenixDetector.h>

--- a/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
@@ -17,7 +17,8 @@
  * Materials are defined in gmain/PHG4Reco::DefineMaterials      *
  *===============================================================*/
 #include "PHG4mRICHDetector.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Utils.h>
 #include <phool/PHCompositeNode.h>
@@ -53,7 +54,7 @@ using namespace std;
 using namespace CLHEP;
 
 //_______________________________________________________________
-PHG4mRICHDetector::PHG4mRICHDetector( PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam, const int lyr):
+PHG4mRICHDetector::PHG4mRICHDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr):
   PHG4Detector(Node, dnam),
   params(parameters),
   //block_physi(NULL),
@@ -94,7 +95,7 @@ G4LogicalVolume* PHG4mRICHDetector::Construct_a_mRICH( G4LogicalVolume* logicWor
   /*lens                        */ build_lens(parameters->GetLensPar("fresnelLens"), hollowVol->GetLogicalVolume());
   /*mirror                      */ build_mirror(parameters,hollowVol);
   /*sensor plane                */ build_sensor(parameters,hollowVol->GetLogicalVolume());
-  /*readout electronics         */ build_polyhedra(parameters->GetPolyPar("readout"),hollowVol->GetLogicalVolume());
+  /*readout electronics         */passive_volumes.insert(build_polyhedra(parameters->GetPolyPar("readout"),hollowVol->GetLogicalVolume()));
 
   printf("============== detector built ================\n");
 
@@ -584,8 +585,8 @@ G4VPhysicalVolume* PHG4mRICHDetector::build_holderBox(mRichParameter* detectorPa
 //________________________________________________________________________//
 void PHG4mRICHDetector::build_foamHolder(mRichParameter* detectorParameter,G4LogicalVolume* motherLV)
 {
-  build_box(detectorParameter->GetBoxPar("foamHolderBox"),motherLV);
-  build_polyhedra(detectorParameter->GetPolyPar("foamHolderPoly"),motherLV);
+  passive_volumes.insert(build_box(detectorParameter->GetBoxPar("foamHolderBox"),motherLV));
+  passive_volumes.insert(build_polyhedra(detectorParameter->GetPolyPar("foamHolderPoly"),motherLV));
 }
 //________________________________________________________________________//
 void PHG4mRICHDetector::build_aerogel(mRichParameter* detectorParameter,G4VPhysicalVolume* motherPV)
@@ -662,10 +663,10 @@ void PHG4mRICHDetector::build_sensor(mRichParameter* detectorParameter,G4Logical
     }
 
     detectorParameter->SetPar_glassWindow(x,y);
-    build_box(detectorParameter->GetBoxPar("glassWindow"),motherLV);
+    passive_volumes.insert(build_box(detectorParameter->GetBoxPar("glassWindow"),motherLV));;
 
     detectorParameter->SetPar_sensor(x,y);
-    build_box(detectorParameter->GetBoxPar("sensor"),motherLV);
+    active_volumes.insert(build_box(detectorParameter->GetBoxPar("sensor"),motherLV));
 
     last_x=x;
     last_y=y;

--- a/simulation/g4simulation/g4detectors/PHG4mRICHDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHDetector.h
@@ -5,18 +5,18 @@
 #ifndef PHG4mRICHDetector_h
 #define PHG4mRICHDetector_h
 
-#include <string>
-
 #include <g4main/PHG4Detector.h>
 #include <Geant4/G4ThreeVector.hh>
 #include <Geant4/G4Colour.hh>
+
+#include <set>
+#include <string>
 
 class G4LogicalVolume;
 class PHParameters;
 class G4VPhysicalVolume;
 class G4Material;
 
-using namespace std;
 //___________________________________________________________________________
 class PHG4mRICHDetector: public PHG4Detector
 {
@@ -70,6 +70,8 @@ class PHG4mRICHDetector: public PHG4Detector
   int layer;
   //int blackhole;
   std::string superdetector;
+  std::set<G4VPhysicalVolume*> active_volumes;
+  std::set<G4VPhysicalVolume*> passive_volumes;
   
 };
 //___________________________________________________________________________
@@ -102,7 +104,7 @@ class PHG4mRICHDetector::mRichParameter
 class PHG4mRICHDetector::BoxPar
 {
  public:
-  string name;
+  std::string name;
   G4double halfXYZ[3];
   G4ThreeVector pos;
   G4Material* material;
@@ -120,7 +122,7 @@ class PHG4mRICHDetector::BoxPar
 class PHG4mRICHDetector::PolyPar
 {
  public:
-  string name;
+  std::string name;
   G4ThreeVector pos;
   G4double start;
   G4double theta;
@@ -151,7 +153,7 @@ class PHG4mRICHDetector::LensPar
   G4double centerThickness;
   G4double grooveWidth;
 
-  string name;
+  std::string name;
   G4double halfXYZ[3];
   G4ThreeVector pos;
   G4Material* material;

--- a/simulation/g4simulation/g4detectors/PHG4mRICHDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHDetector.h
@@ -12,7 +12,7 @@
 #include <Geant4/G4Colour.hh>
 
 class G4LogicalVolume;
-class PHG4Parameters;
+class PHParameters;
 class G4VPhysicalVolume;
 class G4Material;
 
@@ -24,7 +24,7 @@ class PHG4mRICHDetector: public PHG4Detector
  public:
   
   //! constructor
-  PHG4mRICHDetector( PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam="BLOCK", const int lyr = 0);
+  PHG4mRICHDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam="BLOCK", const int lyr = 0);
   
   //! destructor
   virtual ~PHG4mRICHDetector( void ) {}
@@ -49,7 +49,7 @@ class PHG4mRICHDetector: public PHG4Detector
   class PolyPar;
   class LensPar;
 
-  PHG4Parameters *params;
+  PHParameters *params;
   
   G4VPhysicalVolume* build_box(BoxPar* par, G4LogicalVolume* motherLV);
   G4VPhysicalVolume* build_polyhedra(PolyPar* par, G4LogicalVolume* motherLV);

--- a/simulation/g4simulation/g4detectors/PHG4mRICHSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHSteppingAction.cc
@@ -9,7 +9,8 @@
  *===============================================================*/
 #include "PHG4mRICHSteppingAction.h"
 #include "PHG4mRICHDetector.h"
-#include "PHG4Parameters.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
@@ -44,7 +45,7 @@ using namespace std;
 using namespace CLHEP;
 
 //____________________________________________________________________________..
-PHG4mRICHSteppingAction::PHG4mRICHSteppingAction( PHG4mRICHDetector* detector,PHG4Parameters* params):
+PHG4mRICHSteppingAction::PHG4mRICHSteppingAction( PHG4mRICHDetector* detector,PHParameters* params):
   detector_( detector ),
   active(params->get_int_param("active")),
   IsBlackHole(params->get_int_param("blackhole")),

--- a/simulation/g4simulation/g4detectors/PHG4mRICHSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHSteppingAction.h
@@ -1,13 +1,12 @@
 #ifndef PHG4mRICHSteppingAction_h
 #define PHG4mRICHSteppingAction_h
 
-#include "g4main/PHG4SteppingAction.h"
-//#include "PHG4Parameters.h"
+#include <g4main/PHG4SteppingAction.h>
 
 class PHG4mRICHDetector;
 class PHG4Hit;
 class PHG4HitContainer;
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4mRICHSteppingAction : public PHG4SteppingAction
 {
@@ -15,7 +14,7 @@ class PHG4mRICHSteppingAction : public PHG4SteppingAction
   public:
 
   //! constructor
-  PHG4mRICHSteppingAction(PHG4mRICHDetector* detector,PHG4Parameters* params );
+  PHG4mRICHSteppingAction(PHG4mRICHDetector* detector,PHParameters* params );
 
   //! destroctor
   virtual ~PHG4mRICHSteppingAction()

--- a/simulation/g4simulation/g4detectors/PHG4mRICHSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHSubsystem.cc
@@ -4,9 +4,10 @@
  *===============================================================*/
 #include "PHG4mRICHSubsystem.h"
 #include "PHG4mRICHDetector.h"
-#include "PHG4Parameters.h"
 #include "PHG4EventActionClearZeroEdep.h"
 #include "PHG4mRICHSteppingAction.h"
+
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Utils.h>

--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -27,6 +27,10 @@ libg4tpc_la_SOURCES = \
   PHG4TPCDetector.cc \
   PHG4TPCElectronDrift.cc \
   PHG4TPCElectronDrift_Dict.cc \
+  PHG4TPCPadPlane.cc \
+  PHG4TPCPadPlane_Dict.cc \
+  PHG4TPCPadPlaneSimple.cc \
+  PHG4TPCPadPlaneSimple_Dict.cc \
   PHG4TPCSteppingAction.cc \
   PHG4TPCSubsystem.cc \
   PHG4TPCSubsystem_Dict.cc

--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -19,7 +19,8 @@ libg4tpc_la_LIBADD = \
   -lphool \
   -lg4testbench \
   -lphg4hit \
-  -lg4detectors
+  -lg4detectors \
+  -lphparameter
 
 #pkginclude_HEADERS =
 

--- a/simulation/g4simulation/g4tpc/PHG4CellTPCv1.cc
+++ b/simulation/g4simulation/g4tpc/PHG4CellTPCv1.cc
@@ -24,15 +24,14 @@ PHG4CellTPCv1::~PHG4CellTPCv1()
 void
 PHG4CellTPCv1::add_edep(const PHG4HitDefs::keytype g4hitid, const int tbin, const float edep)
 {
-// blach that was complicated
-// first we see if we find if the time bin has already been used
+// If the returned boolean from the map.insert is
+// true: the element was inserted
+// false: the element existed 
+// in any case an iterator to the element in the map is returned
+ 
     EdepMap edepmap;
-    pair<map<int,EdepMap>::iterator, bool> ret;
-
-  map<int,EdepMap>::iterator mapiter;
-//  map<int,EdepMap>::iterator mapiter = timeseq.find(tbin);
-    ret = timeseq.insert(make_pair(tbin,edepmap));
-    mapiter = ret.first;
+    pair<map<int,EdepMap>::iterator, bool> ret = timeseq.insert(make_pair(tbin,edepmap));
+     map<int,EdepMap>::iterator mapiter = ret.first;
 //  map<int,EdepMap>::iterator mapiter = timeseq.find(tbin);
 /*
   if (mapiter == timeseq.end())
@@ -46,20 +45,13 @@ PHG4CellTPCv1::add_edep(const PHG4HitDefs::keytype g4hitid, const int tbin, cons
     mapiter = ret.first;
   }
 */
-  EdepIterator eiter = (mapiter->second).find(g4hitid);
-  cout << "edepmap size: " << (mapiter->second).size() << endl;
-  if (eiter != (mapiter->second).end())
-  {
-    eiter->second += edep;
-    cout << "Adding to 0x" << hex << " edep " << edep << endl;
-  }
-  else
-  {
-    pair<EdepIterator, bool> ret;
-    ret = (mapiter->second).insert(make_pair(g4hitid,edep));
-    eiter = ret.first;
-    cout << "inserting 0x" << hex << g4hitid << dec << " edep: " << edep << endl;
-  }
+
+//  EdepIterator eiter = (mapiter->second).find(g4hitid);
+  float dummy_edep = 0.;
+  pair<EdepIterator, bool> edepret = (mapiter->second).insert(make_pair(g4hitid,dummy_edep));
+  EdepIterator eiter = edepret.first;
+  eiter->second += edep;
+
   cout << "inserting 0x" << hex << g4hitid << dec << " with edep: " << edep 
        << ", size: " << timeseq.size() 
        << " total edep: " << eiter->second << endl;

--- a/simulation/g4simulation/g4tpc/PHG4CellTPCv1.cc
+++ b/simulation/g4simulation/g4tpc/PHG4CellTPCv1.cc
@@ -32,29 +32,10 @@ PHG4CellTPCv1::add_edep(const PHG4HitDefs::keytype g4hitid, const int tbin, cons
     EdepMap edepmap;
     pair<map<int,EdepMap>::iterator, bool> ret = timeseq.insert(make_pair(tbin,edepmap));
      map<int,EdepMap>::iterator mapiter = ret.first;
-//  map<int,EdepMap>::iterator mapiter = timeseq.find(tbin);
-/*
-  if (mapiter == timeseq.end())
-  {
-// if not we use map.insert which returns an iterator
-// to the new entry (the boolean is 
-
-    EdepMap edepmap;
-    pair<map<int,EdepMap>::iterator, bool> ret;
-    ret = timeseq.insert(make_pair(tbin,edepmap));
-    mapiter = ret.first;
-  }
-*/
-
-//  EdepIterator eiter = (mapiter->second).find(g4hitid);
-  float dummy_edep = 0.;
-  pair<EdepIterator, bool> edepret = (mapiter->second).insert(make_pair(g4hitid,dummy_edep));
+// insert 0 edep so edep can be added no matter if hits was found or not
+  pair<EdepIterator, bool> edepret = (mapiter->second).insert(make_pair(g4hitid,0.));
   EdepIterator eiter = edepret.first;
   eiter->second += edep;
-
-  cout << "inserting 0x" << hex << g4hitid << dec << " with edep: " << edep 
-       << ", size: " << timeseq.size() 
-       << " total edep: " << eiter->second << endl;
   return;
 }
 

--- a/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
@@ -1,7 +1,7 @@
 #include "PHG4TPCDetector.h"
 #include "PHG4TPCDefs.h"
 
-#include <g4detectors/PHG4Parameters.h>
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4ColorDefs.h>
 #include <g4main/PHG4Utils.h>
@@ -28,7 +28,7 @@
 using namespace std;
 
 //_______________________________________________________________
-PHG4TPCDetector::PHG4TPCDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam)
+PHG4TPCDetector::PHG4TPCDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
   : PHG4Detector(Node, dnam)
   , params(parameters)
   , g4userlimits(nullptr)

--- a/simulation/g4simulation/g4tpc/PHG4TPCDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCDetector.h
@@ -13,13 +13,13 @@ class G4LogicalVolume;
 class G4UserLimits;
 class G4VPhysicalVolume;
 class G4VSolid;
-class PHG4Parameters;
+class PHParameters;
 
 class PHG4TPCDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4TPCDetector(PHCompositeNode *Node, PHG4Parameters *parameters, const std::string &dnam);
+  PHG4TPCDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4TPCDetector(void)
@@ -36,7 +36,7 @@ class PHG4TPCDetector : public PHG4Detector
   int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm);
   int ConstructTPCGasVolume(G4LogicalVolume *tpc_envelope);
   int ConstructTPCCageVolume(G4LogicalVolume *tpc_envelope);
-  PHG4Parameters *params;
+  PHParameters *params;
   G4UserLimits *g4userlimits;
   int active;
   int absorberactive;

--- a/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.cc
@@ -48,6 +48,11 @@ PHG4TPCElectronDrift::PHG4TPCElectronDrift(const std::string& name):
   return;
 }
 
+PHG4TPCElectronDrift::~PHG4TPCElectronDrift()
+{
+  gsl_rng_free(RandomGenerator);
+}
+
 int PHG4TPCElectronDrift::InitRun(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);

--- a/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.cc
@@ -121,6 +121,29 @@ g4cells = new PHG4CellContainer();
 
 int PHG4TPCElectronDrift::process_event(PHCompositeNode *topNode)
 {
+/*
+  int radbin1 = 10;
+  int phibin1 = 20;
+  int tbin1 = 200;
+  PHG4CellDefs::keytype key = PHG4CellDefs::TPCBinning::genkey(0,radbin1,phibin1);
+  PHG4Cell *cell = g4cells->findCell(key);
+  if (! cell)
+  {
+    cell = new PHG4CellTPCv1(key);
+    g4cells->AddCell(cell);
+  }
+  cell->add_edep(key,tbin1,1.);
+  cell->add_edep(key,tbin1,2.);
+  {
+  PHG4CellContainer::ConstRange cells = g4cells->getCells();
+  PHG4CellContainer::ConstIterator celliter;
+  for (celliter=cells.first;celliter != cells.second; ++celliter)
+  {
+    celliter->second->print();
+  }
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+*/
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hit)
     {

--- a/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.h
@@ -19,7 +19,7 @@ class  PHG4TPCElectronDrift: public SubsysReco, public PHG4ParameterInterface
 {
 public:
   PHG4TPCElectronDrift(const std::string& name = "PHG4TPCElectronDrift");
-  virtual ~PHG4TPCElectronDrift() {}
+  virtual ~PHG4TPCElectronDrift();
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);

--- a/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.h
@@ -10,7 +10,10 @@
 #include <gsl/gsl_rng.h>
 #endif
 
+#include <vector>
+
 class PHG4CellContainer;
+class PHG4TPCPadPlane;
 class PHCompositeNode;
 class TH1;
 class TNtuple;
@@ -20,6 +23,7 @@ class  PHG4TPCElectronDrift: public SubsysReco, public PHG4ParameterInterface
 public:
   PHG4TPCElectronDrift(const std::string& name = "PHG4TPCElectronDrift");
   virtual ~PHG4TPCElectronDrift();
+  int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
@@ -31,6 +35,8 @@ public:
   void set_seed(const unsigned int iseed);
 //  void Amplify(const double x, const double y, const double z);
   void MapToPadPlane(const double x, const double y, const double t);
+  void registerPadPlane(PHG4TPCPadPlane *padplane);
+
 private:
   PHG4CellContainer *g4cells;
   TH1 *dlong;
@@ -50,6 +56,7 @@ private:
   double max_active_radius;
   double min_time;
   double max_time;
+  std::vector<PHG4TPCPadPlane *> tpcpadplane;
 #ifndef __CINT__
   gsl_rng *RandomGenerator;
 #endif

--- a/simulation/g4simulation/g4tpc/PHG4TPCPadPlane.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCPadPlane.cc
@@ -1,0 +1,48 @@
+#include "PHG4TPCPadPlane.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHNodeIterator.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+
+#include <string>
+
+using namespace std;
+
+PHG4TPCPadPlane::PHG4TPCPadPlane(const std::string &name): 
+  SubsysReco(name),
+  PHG4ParameterInterface(name),
+  detector("TPC")
+{}
+
+int PHG4TPCPadPlane::InitRun(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN" ));
+  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "PAR" ));
+  string paramnodename = "G4TPCPADPLANE";
+  string geonodename = "G4TPCPADPLANEPAR";
+   UpdateParametersWithMacro();
+  PHNodeIterator runIter(runNode);
+  PHCompositeNode *RunDetNode =  dynamic_cast<PHCompositeNode*>(runIter.findFirst("PHCompositeNode",detector));
+  if (! RunDetNode)
+    {
+      RunDetNode = new PHCompositeNode(detector);
+      runNode->addNode(RunDetNode);
+    }
+  SaveToNodeTree(RunDetNode,paramnodename);
+
+  // save this to the parNode for use
+  PHNodeIterator parIter(parNode);
+  PHCompositeNode *ParDetNode =  dynamic_cast<PHCompositeNode*>(parIter.findFirst("PHCompositeNode",detector));
+  if (! ParDetNode)
+    {
+      ParDetNode = new PHCompositeNode(detector);
+      parNode->addNode(ParDetNode);
+    }
+  PutOnParNode(ParDetNode,geonodename);
+  UpdateInternalParameters();
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/simulation/g4simulation/g4tpc/PHG4TPCPadPlane.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCPadPlane.cc
@@ -13,7 +13,7 @@ using namespace std;
 
 PHG4TPCPadPlane::PHG4TPCPadPlane(const std::string &name): 
   SubsysReco(name),
-  PHG4ParameterInterface(name),
+  PHParameterInterface(name),
   detector("TPC")
 {}
 

--- a/simulation/g4simulation/g4tpc/PHG4TPCPadPlane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCPadPlane.h
@@ -1,13 +1,13 @@
 #ifndef PHG4TPCPadPlane_h
 #define PHG4TPCPadPlane_h
 
-#include <g4detectors/PHG4ParameterInterface.h>
+#include <phparameter/PHParameterInterface.h>
 #include <fun4all/SubsysReco.h>
 
 class PHG4CellContainer;
 class PHCompositeNode;
 
-class PHG4TPCPadPlane: public SubsysReco, public PHG4ParameterInterface
+class PHG4TPCPadPlane: public SubsysReco, public PHParameterInterface
 {
 public:
   PHG4TPCPadPlane(const std::string &name="PHG4TPCPadPlane"); 

--- a/simulation/g4simulation/g4tpc/PHG4TPCPadPlane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCPadPlane.h
@@ -1,0 +1,31 @@
+#ifndef PHG4TPCPadPlane_h
+#define PHG4TPCPadPlane_h
+
+#include <g4detectors/PHG4ParameterInterface.h>
+#include <fun4all/SubsysReco.h>
+
+class PHG4CellContainer;
+class PHCompositeNode;
+
+class PHG4TPCPadPlane: public SubsysReco, public PHG4ParameterInterface
+{
+public:
+  PHG4TPCPadPlane(const std::string &name="PHG4TPCPadPlane"); 
+
+virtual ~PHG4TPCPadPlane(){}
+
+#ifndef __CINT__
+  int process_event(PHCompositeNode *) final {return 0;}
+#else
+  int process_event(PHCompositeNode *) {return 0;}
+#endif
+  int InitRun(PHCompositeNode *topNode);
+  virtual void UpdateInternalParameters() {return;}
+  virtual void MapToPadPlane(PHG4CellContainer *g4cells, const double x_gem, const double y_gem, const double t_gem) {}
+  void Detector(const std::string &name) {detector = name;}
+protected:
+
+  std::string detector;
+};
+
+#endif

--- a/simulation/g4simulation/g4tpc/PHG4TPCPadPlaneLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCPadPlaneLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4TPCPadPlane-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4tpc/PHG4TPCPadPlaneSimple.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCPadPlaneSimple.cc
@@ -1,0 +1,67 @@
+#include "PHG4TPCPadPlaneSimple.h"
+#include "PHG4CellTPCv1.h"
+
+#include <g4detectors/PHG4CellContainer.h>
+
+#include <cmath>
+#include <iostream>
+
+using namespace std;
+
+PHG4TPCPadPlaneSimple::PHG4TPCPadPlaneSimple(const string &name):
+PHG4TPCPadPlane(name),
+max_active_radius(NAN),
+min_active_radius(NAN),
+rbinwidth(NAN),
+phibinwidth(NAN),
+tbinwidth(NAN)
+{
+  InitializeParameters();
+  return;
+}
+
+
+void PHG4TPCPadPlaneSimple::MapToPadPlane(PHG4CellContainer *g4cells, const double x_gem, const double y_gem, const double t_gem)
+{
+  double phi = atan2(y_gem,x_gem);
+  double rad_gem = sqrt(x_gem*x_gem + y_gem*y_gem);
+  int phibin = (phi+M_PI)/phibinwidth;
+  int radbin = (rad_gem-min_active_radius)/rbinwidth;
+  int tbin = t_gem/tbinwidth;
+//  ntpad->Fill(t_gem,phi,rad_gem,phibin,radbin);
+  // cout << ", phi: " << phi
+  //      << ", phibin: " << phibin
+  //      << ", rad: " << rad_gem
+  //      << ", radbin: " << radbin
+  //      << ", t_gem: " << t_gem 
+  //      << endl;
+  PHG4CellDefs::keytype key = PHG4CellDefs::TPCBinning::genkey(0,radbin,phibin);
+  PHG4Cell *cell = g4cells->findCell(key);
+  if (! cell)
+  {
+    cell = new PHG4CellTPCv1(key);
+    g4cells->AddCell(cell);
+  }
+  cell->add_edep(key,tbin,1.);
+   return;
+}
+
+void PHG4TPCPadPlaneSimple::SetDefaultParameters()
+{
+  set_default_int_param("nbins_phi",360);
+  set_default_int_param("nbins_r",40);
+
+  set_default_double_param("binwidth_t",53.); //  2*Rhic clock = 106/2.
+  set_default_double_param("max_active_radius",75.);
+  set_default_double_param("min_active_radius",30.);
+  return;
+}
+
+void PHG4TPCPadPlaneSimple::UpdateInternalParameters()
+{
+  max_active_radius = get_double_param("max_active_radius");
+  min_active_radius = get_double_param("min_active_radius");
+  rbinwidth = (max_active_radius - min_active_radius)/get_int_param("nbins_r");
+  phibinwidth = 2*M_PI/get_int_param("nbins_phi");
+  tbinwidth = get_double_param("binwidth_t");
+}

--- a/simulation/g4simulation/g4tpc/PHG4TPCPadPlaneSimple.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCPadPlaneSimple.h
@@ -1,0 +1,27 @@
+#ifndef PHG4TPCPadPlaneSimple_h
+#define PHG4TPCPadPlaneSimple_h
+
+#include "PHG4TPCPadPlane.h"
+
+class PHG4CellContainer;
+
+class PHG4TPCPadPlaneSimple: public PHG4TPCPadPlane
+{
+public:
+  PHG4TPCPadPlaneSimple(const std::string& name = "SimplePadPlane");
+  virtual ~PHG4TPCPadPlaneSimple(){}
+
+  void MapToPadPlane(PHG4CellContainer *g4cells, const double x_gem, const double y_gem, const double t_gem);
+
+  void SetDefaultParameters();
+  void UpdateInternalParameters();
+
+protected:
+  double max_active_radius;
+  double min_active_radius;
+  double rbinwidth;
+  double phibinwidth;
+  double tbinwidth;
+};
+
+#endif

--- a/simulation/g4simulation/g4tpc/PHG4TPCPadPlaneSimpleLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCPadPlaneSimpleLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4TPCPadPlaneSimple-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4tpc/PHG4TPCSteppingAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCSteppingAction.cc
@@ -1,7 +1,7 @@
 #include "PHG4TPCSteppingAction.h"
 #include "PHG4TPCDetector.h"
 
-#include <g4detectors/PHG4Parameters.h>
+#include <phparameter/PHParameters.h>
 #include <g4detectors/PHG4StepStatusDecode.h>
 
 #include <g4main/PHG4Hit.h>
@@ -38,7 +38,7 @@
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4TPCSteppingAction::PHG4TPCSteppingAction(PHG4TPCDetector* detector, const PHG4Parameters* parameters)
+PHG4TPCSteppingAction::PHG4TPCSteppingAction(PHG4TPCDetector* detector, const PHParameters* parameters)
   : detector_(detector)
   , hits_(nullptr)
   , absorberhits_(nullptr)

--- a/simulation/g4simulation/g4tpc/PHG4TPCSteppingAction.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCSteppingAction.h
@@ -5,7 +5,7 @@
 
 class G4VPhysicalVolume;
 class PHG4TPCDetector;
-class PHG4Parameters;
+class PHParameters;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
@@ -14,7 +14,7 @@ class PHG4TPCSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  PHG4TPCSteppingAction(PHG4TPCDetector *, const PHG4Parameters *parameters);
+  PHG4TPCSteppingAction(PHG4TPCDetector *, const PHParameters *parameters);
 
   //! destructor
   virtual ~PHG4TPCSteppingAction();
@@ -33,7 +33,7 @@ class PHG4TPCSteppingAction : public PHG4SteppingAction
   PHG4HitContainer *hits_;
   PHG4HitContainer *absorberhits_;
   PHG4Hit *hit;
-  const PHG4Parameters *params;
+  const PHParameters *params;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
   G4VPhysicalVolume *savevolpre;

--- a/simulation/g4simulation/g4tpc/PHG4TPCSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCSubsystem.cc
@@ -2,7 +2,7 @@
 #include "PHG4TPCDetector.h"
 #include "PHG4TPCSteppingAction.h"
 
-#include <g4detectors/PHG4Parameters.h>
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
 


### PR DESCRIPTION
This pull request removes all remnants of the PHG4Parameter classes. It touches a lot of files, I kept the changes to the bare minimum so this pull request shouldn't result in merging conflicts. I did not remove the PHG4Parameter classes so private code doesn't break right away when linking against the nightly build. A check with running 2 sim events gave identical results between using the old PHG4Parameter and the new PHParameter classes. This pull request also updates the tpc code (still needs work before prime time)