### PR TITLE
2018 test beam production code

### DIFF
--- a/offline/packages/CaloBase/RawTower.h
+++ b/offline/packages/CaloBase/RawTower.h
@@ -12,7 +12,11 @@
 class RawTower : public PHObject {
 
  public:
-  typedef std::map<PHG4CellDefs::keytype, float> CellMap;
+
+  //! key type for cell map which should be consistent with CellKeyType
+  typedef unsigned long long CellKeyType;
+
+  typedef std::map<CellKeyType, float> CellMap;
   typedef CellMap::iterator CellIterator;
   typedef CellMap::const_iterator CellConstIterator;
   typedef std::pair<CellIterator, CellIterator> CellRange;
@@ -59,9 +63,9 @@ class RawTower : public PHObject {
     CellMap dummy;
     return make_pair(dummy.begin(), dummy.end());
   }
-  virtual CellIterator find_g4cell(PHG4CellDefs::keytype id) {return CellMap().end();}
-  virtual CellConstIterator find_g4cell(PHG4CellDefs::keytype id) const {return CellMap().end();}
-  virtual void add_ecell(const PHG4CellDefs::keytype  g4cellid, const float ecell) {PHOOL_VIRTUAL_WARN("add_ecell(const PHG4CellDefs::keytype g4cellid, const float ecell)"); return;}
+  virtual CellIterator find_g4cell(CellKeyType id) {return CellMap().end();}
+  virtual CellConstIterator find_g4cell(CellKeyType id) const {return CellMap().end();}
+  virtual void add_ecell(const CellKeyType  g4cellid, const float ecell) {PHOOL_VIRTUAL_WARN("add_ecell(const CellKeyType g4cellid, const float ecell)"); return;}
   virtual void clear_g4cells() {}
 
   virtual bool empty_g4showers() const {return true;}

--- a/offline/packages/CaloBase/RawTowerv1.cc
+++ b/offline/packages/CaloBase/RawTowerv1.cc
@@ -80,7 +80,7 @@ RawTowerv1::identify(std::ostream& os) const
 }
 
 void
-RawTowerv1::add_ecell(const PHG4CellDefs::keytype g4cellid,
+RawTowerv1::add_ecell(const CellKeyType g4cellid,
     const float ecell)
 {
   if (ecells.find(g4cellid) == ecells.end())

--- a/offline/packages/CaloBase/RawTowerv1.h
+++ b/offline/packages/CaloBase/RawTowerv1.h
@@ -39,7 +39,7 @@ class RawTowerv1 : public RawTower {
   }
   RawTower::CellIterator find_g4cell(int id) { return ecells.find(id); }
   RawTower::CellConstIterator find_g4cell(int id) const {return ecells.find(id);}
-  void add_ecell(const PHG4CellDefs::keytype g4cellid,
+  void add_ecell(const CellKeyType g4cellid,
                  const float ecell);
   void clear_g4cells() { ecells.clear(); }
 

--- a/offline/packages/CaloBase/RawTowerv1.h
+++ b/offline/packages/CaloBase/RawTowerv1.h
@@ -68,7 +68,7 @@ class RawTowerv1 : public RawTower {
   CellMap ecells;      //< default truth storage
   ShowerMap eshowers;  //< alternate truth storage for smaller filesizes
 
-  ClassDef(RawTowerv1, 4)
+  ClassDef(RawTowerv1, 5)
 };
 
 #endif /* RAWTOWERV1_H_ */

--- a/offline/packages/Prototype4/CaloCalibration.C
+++ b/offline/packages/Prototype4/CaloCalibration.C
@@ -2,196 +2,197 @@
 #include "PROTOTYPE4_FEM.h"
 #include "RawTower_Prototype4.h"
 
-#include <calobase/RawTowerContainer.h>
-#include <phool/PHCompositeNode.h>
-#include <phool/phool.h>
-#include <phool/getClass.h>
-#include <fun4all/Fun4AllReturnCodes.h>
-#include <iostream>
 #include <TString.h>
-#include <cmath>
-#include <string>
+#include <calobase/RawTowerContainer.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
 #include <cassert>
 #include <cfloat>
+#include <cmath>
+#include <iostream>
+#include <string>
 
 using namespace std;
 
 //____________________________________
-CaloCalibration::CaloCalibration(const std::string& name) : //
-    SubsysReco(string("CaloCalibration_") + name), //
-    _calib_towers(NULL), _raw_towers(NULL), detector(name), //
-    _calib_tower_node_prefix("CALIB"), //
-    _raw_tower_node_prefix("RAW"), //
-    _calib_params(name)
+CaloCalibration::CaloCalibration(const std::string &name)
+  :  //
+  SubsysReco(string("CaloCalibration_") + name)
+  ,  //
+  _calib_towers(NULL)
+  , _raw_towers(NULL)
+  , detector(name)
+  ,  //
+  _calib_tower_node_prefix("CALIB")
+  ,  //
+  _raw_tower_node_prefix("RAW")
+  ,  //
+  _calib_params(name)
 {
   SetDefaultParameters(_calib_params);
 }
 
 //____________________________________
-int
-CaloCalibration::Init(PHCompositeNode *topNode)
+int CaloCalibration::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_____________________________________
-int
-CaloCalibration::InitRun(PHCompositeNode *topNode)
+int CaloCalibration::InitRun(PHCompositeNode *topNode)
 {
   CreateNodeTree(topNode);
 
   if (verbosity)
-    {
-      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << " - print calibration parameters: "<<endl;
-      _calib_params.Print();
-    }
+  {
+    std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+              << " - print calibration parameters: " << endl;
+    _calib_params.Print();
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________
-int
-CaloCalibration::process_event(PHCompositeNode *topNode)
+int CaloCalibration::process_event(PHCompositeNode *topNode)
 {
-
   if (verbosity)
-    {
-      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << "Process event entered" << std::endl;
-    }
+  {
+    std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+              << "Process event entered" << std::endl;
+  }
 
   const double calib_const_scale = _calib_params.get_double_param(
       "calib_const_scale");
   const bool use_chan_calibration = _calib_params.get_int_param(
-      "use_chan_calibration") > 0;
+                                        "use_chan_calibration") > 0;
 
   RawTowerContainer::Range begin_end = _raw_towers->getTowers();
   RawTowerContainer::Iterator rtiter;
   for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
+  {
+    RawTowerDefs::keytype key = rtiter->first;
+    RawTower_Prototype4 *raw_tower =
+        dynamic_cast<RawTower_Prototype4 *>(rtiter->second);
+    assert(raw_tower);
+
+    double calibration_const = calib_const_scale;
+
+    if (use_chan_calibration)
     {
-      RawTowerDefs::keytype key = rtiter->first;
-      RawTower_Prototype4 *raw_tower =
-          dynamic_cast<RawTower_Prototype4 *>(rtiter->second);
-      assert(raw_tower);
+      // channel to channel calibration.
+      const int column = raw_tower->get_column();
+      const int row = raw_tower->get_row();
 
-      double calibration_const = calib_const_scale;
+      assert(column >= 0);
+      assert(row >= 0);
 
-      if (use_chan_calibration)
-        {
-          // channel to channel calibration.
-          const int column = raw_tower->get_column();
-          const int row = raw_tower->get_row();
+      string calib_const_name(Form("calib_const_column%d_row%d", column, row));
 
-          assert(column >= 0);
-          assert(row >= 0);
+      calibration_const *= _calib_params.get_double_param(calib_const_name);
+    }
 
-          string calib_const_name(Form("calib_const_column%d_row%d",column,row));
+    vector<double> vec_signal_samples;
+    for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
+    {
+      vec_signal_samples.push_back(
+          raw_tower->get_signal_samples(i));
+    }
 
-          calibration_const *= _calib_params.get_double_param(calib_const_name);
-        }
+    double peak = NAN;
+    double peak_sample = NAN;
+    double pedstal = NAN;
 
-      vector<double> vec_signal_samples;
-      for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
-        {
-          vec_signal_samples.push_back(
-              raw_tower->get_signal_samples(i));
-        }
+    PROTOTYPE4_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
+                                          peak_sample, pedstal, verbosity);
 
-      double peak = NAN;
-      double peak_sample = NAN;
-      double pedstal = NAN;
+    // store the result - raw_tower
+    if (std::isnan(raw_tower->get_energy()))
+    {
+      //Raw tower was never fit, store the current fit
 
-      PROTOTYPE4_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
-          peak_sample, pedstal, verbosity);
+      raw_tower->set_energy(peak);
+      raw_tower->set_time(peak_sample);
+    }
 
-      // store the result - raw_tower
-      if (std::isnan(raw_tower->get_energy()))
-        {
-          //Raw tower was never fit, store the current fit
+    // store the result - calib_tower
+    RawTower_Prototype4 *calib_tower = new RawTower_Prototype4(*raw_tower);
+    calib_tower->set_energy(peak * calibration_const);
+    calib_tower->set_time(peak_sample);
 
-          raw_tower->set_energy(peak);
-          raw_tower->set_time(peak_sample);
-        }
+    for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
+    {
+      calib_tower->set_signal_samples(i, (vec_signal_samples[i] - pedstal) * calibration_const);
+    }
 
-      // store the result - calib_tower
-      RawTower_Prototype4 *calib_tower = new RawTower_Prototype4(*raw_tower);
-      calib_tower->set_energy(peak * calibration_const);
-      calib_tower->set_time(peak_sample);
+    _calib_towers->AddTower(key, calib_tower);
 
-      for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
-        {
-          calib_tower->set_signal_samples(i, (vec_signal_samples[i] - pedstal) * calibration_const);
-        }
-
-      _calib_towers->AddTower(key, calib_tower);
-
-    } //  for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
+  }  //  for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
 
   if (verbosity)
-    {
-      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << "input sum energy = " << _raw_towers->getTotalEdep()
-          << ", output sum digitalized value = "
-          << _calib_towers->getTotalEdep() << std::endl;
-    }
+  {
+    std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+              << "input sum energy = " << _raw_towers->getTotalEdep()
+              << ", output sum digitalized value = "
+              << _calib_towers->getTotalEdep() << std::endl;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_______________________________________
-void
-CaloCalibration::CreateNodeTree(PHCompositeNode *topNode)
+void CaloCalibration::CreateNodeTree(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
 
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst(
       "PHCompositeNode", "DST"));
   if (!dstNode)
-    {
-      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << "DST Node missing, doing nothing." << std::endl;
-      throw std::runtime_error(
-          "Failed to find DST node in RawTowerCalibration::CreateNodes");
-    }
+  {
+    std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+              << "DST Node missing, doing nothing." << std::endl;
+    throw std::runtime_error(
+        "Failed to find DST node in RawTowerCalibration::CreateNodes");
+  }
 
   RawTowerNodeName = "TOWER_" + _raw_tower_node_prefix + "_" + detector;
   _raw_towers = findNode::getClass<RawTowerContainer>(dstNode,
-      RawTowerNodeName.c_str());
+                                                      RawTowerNodeName.c_str());
   if (!_raw_towers)
-    {
-      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-          << " " << RawTowerNodeName << " Node missing, doing bail out!"
-          << std::endl;
-      throw std::runtime_error(
-          "Failed to find " + RawTowerNodeName
-              + " node in RawTowerCalibration::CreateNodes");
-    }
+  {
+    std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+              << " " << RawTowerNodeName << " Node missing, doing bail out!"
+              << std::endl;
+    throw std::runtime_error(
+        "Failed to find " + RawTowerNodeName + " node in RawTowerCalibration::CreateNodes");
+  }
 
   // Create the tower nodes on the tree
   PHNodeIterator dstiter(dstNode);
-  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst(
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst(
       "PHCompositeNode", detector));
   if (!DetNode)
-    {
-      DetNode = new PHCompositeNode(detector);
-      dstNode->addNode(DetNode);
-    }
+  {
+    DetNode = new PHCompositeNode(detector);
+    dstNode->addNode(DetNode);
+  }
 
   // Be careful as a previous calibrator may have been registered for this detector
   CaliTowerNodeName = "TOWER_" + _calib_tower_node_prefix + "_" + detector;
   _calib_towers = findNode::getClass<RawTowerContainer>(DetNode,
-      CaliTowerNodeName.c_str());
+                                                        CaliTowerNodeName.c_str());
   if (!_calib_towers)
-    {
-      _calib_towers = new RawTowerContainer(_raw_towers->getCalorimeterID());
-      PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(
-          _calib_towers, CaliTowerNodeName.c_str(), "PHObject");
-      DetNode->addNode(towerNode);
-    }
+  {
+    _calib_towers = new RawTowerContainer(_raw_towers->getCalorimeterID());
+    PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(
+        _calib_towers, CaliTowerNodeName.c_str(), "PHObject");
+    DetNode->addNode(towerNode);
+  }
 
   // update the parameters on the node tree
-  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst(
       "PHCompositeNode", "RUN"));
   assert(parNode);
   const string paramnodename = string("Calibration_") + detector;
@@ -199,24 +200,19 @@ CaloCalibration::CreateNodeTree(PHCompositeNode *topNode)
   //   this step is moved to after detector construction
   //   save updated persistant copy on node tree
   _calib_params.SaveToNodeTree(parNode, paramnodename);
-
 }
 
 //___________________________________
-int
-CaloCalibration::End(PHCompositeNode *topNode)
+int CaloCalibration::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void
-CaloCalibration::SetDefaultParameters(PHParameters & param)
+void CaloCalibration::SetDefaultParameters(PHParameters &param)
 {
-
   param.set_int_param("use_chan_calibration", 0);
 
   // additional scale for the calibration constant
   // negative pulse -> positive with -1
   param.set_double_param("calib_const_scale", -1);
-
 }

--- a/offline/packages/Prototype4/CaloCalibration.C
+++ b/offline/packages/Prototype4/CaloCalibration.C
@@ -217,5 +217,5 @@ void CaloCalibration::SetDefaultParameters(PHParameters &param)
 
   // additional scale for the calibration constant
   // negative pulse -> positive with -1
-  param.set_double_param("calib_const_scale", -1);
+  param.set_double_param("calib_const_scale", 1);
 }

--- a/offline/packages/Prototype4/CaloCalibration.C
+++ b/offline/packages/Prototype4/CaloCalibration.C
@@ -1,0 +1,222 @@
+#include "CaloCalibration.h"
+#include "PROTOTYPE3_FEM.h"
+#include "RawTower_Prototype3.h"
+
+#include <calobase/RawTowerContainer.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <iostream>
+#include <TString.h>
+#include <cmath>
+#include <string>
+#include <cassert>
+#include <cfloat>
+
+using namespace std;
+
+//____________________________________
+CaloCalibration::CaloCalibration(const std::string& name) : //
+    SubsysReco(string("CaloCalibration_") + name), //
+    _calib_towers(NULL), _raw_towers(NULL), detector(name), //
+    _calib_tower_node_prefix("CALIB"), //
+    _raw_tower_node_prefix("RAW"), //
+    _calib_params(name)
+{
+  SetDefaultParameters(_calib_params);
+}
+
+//____________________________________
+int
+CaloCalibration::Init(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________
+int
+CaloCalibration::InitRun(PHCompositeNode *topNode)
+{
+  CreateNodeTree(topNode);
+
+  if (verbosity)
+    {
+      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << " - print calibration parameters: "<<endl;
+      _calib_params.Print();
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________
+int
+CaloCalibration::process_event(PHCompositeNode *topNode)
+{
+
+  if (verbosity)
+    {
+      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << "Process event entered" << std::endl;
+    }
+
+  const double calib_const_scale = _calib_params.get_double_param(
+      "calib_const_scale");
+  const bool use_chan_calibration = _calib_params.get_int_param(
+      "use_chan_calibration") > 0;
+
+  RawTowerContainer::Range begin_end = _raw_towers->getTowers();
+  RawTowerContainer::Iterator rtiter;
+  for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
+    {
+      RawTowerDefs::keytype key = rtiter->first;
+      RawTower_Prototype3 *raw_tower =
+          dynamic_cast<RawTower_Prototype3 *>(rtiter->second);
+      assert(raw_tower);
+
+      double calibration_const = calib_const_scale;
+
+      if (use_chan_calibration)
+        {
+          // channel to channel calibration.
+          const int column = raw_tower->get_column();
+          const int row = raw_tower->get_row();
+
+          assert(column >= 0);
+          assert(row >= 0);
+
+          string calib_const_name(Form("calib_const_column%d_row%d",column,row));
+
+          calibration_const *= _calib_params.get_double_param(calib_const_name);
+        }
+
+      vector<double> vec_signal_samples;
+      for (int i = 0; i < RawTower_Prototype3::NSAMPLES; i++)
+        {
+          vec_signal_samples.push_back(
+              raw_tower->get_signal_samples(i));
+        }
+
+      double peak = NAN;
+      double peak_sample = NAN;
+      double pedstal = NAN;
+
+      PROTOTYPE3_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
+          peak_sample, pedstal, verbosity);
+
+      // store the result - raw_tower
+      if (std::isnan(raw_tower->get_energy()))
+        {
+          //Raw tower was never fit, store the current fit
+
+          raw_tower->set_energy(peak);
+          raw_tower->set_time(peak_sample);
+        }
+
+      // store the result - calib_tower
+      RawTower_Prototype3 *calib_tower = new RawTower_Prototype3(*raw_tower);
+      calib_tower->set_energy(peak * calibration_const);
+      calib_tower->set_time(peak_sample);
+
+      for (int i = 0; i < RawTower_Prototype3::NSAMPLES; i++)
+        {
+          calib_tower->set_signal_samples(i, (vec_signal_samples[i] - pedstal) * calibration_const);
+        }
+
+      _calib_towers->AddTower(key, calib_tower);
+
+    } //  for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
+
+  if (verbosity)
+    {
+      std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << "input sum energy = " << _raw_towers->getTotalEdep()
+          << ", output sum digitalized value = "
+          << _calib_towers->getTotalEdep() << std::endl;
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_______________________________________
+void
+CaloCalibration::CreateNodeTree(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+      "PHCompositeNode", "DST"));
+  if (!dstNode)
+    {
+      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << "DST Node missing, doing nothing." << std::endl;
+      throw std::runtime_error(
+          "Failed to find DST node in RawTowerCalibration::CreateNodes");
+    }
+
+  RawTowerNodeName = "TOWER_" + _raw_tower_node_prefix + "_" + detector;
+  _raw_towers = findNode::getClass<RawTowerContainer>(dstNode,
+      RawTowerNodeName.c_str());
+  if (!_raw_towers)
+    {
+      std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+          << " " << RawTowerNodeName << " Node missing, doing bail out!"
+          << std::endl;
+      throw std::runtime_error(
+          "Failed to find " + RawTowerNodeName
+              + " node in RawTowerCalibration::CreateNodes");
+    }
+
+  // Create the tower nodes on the tree
+  PHNodeIterator dstiter(dstNode);
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst(
+      "PHCompositeNode", detector));
+  if (!DetNode)
+    {
+      DetNode = new PHCompositeNode(detector);
+      dstNode->addNode(DetNode);
+    }
+
+  // Be careful as a previous calibrator may have been registered for this detector
+  CaliTowerNodeName = "TOWER_" + _calib_tower_node_prefix + "_" + detector;
+  _calib_towers = findNode::getClass<RawTowerContainer>(DetNode,
+      CaliTowerNodeName.c_str());
+  if (!_calib_towers)
+    {
+      _calib_towers = new RawTowerContainer(_raw_towers->getCalorimeterID());
+      PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(
+          _calib_towers, CaliTowerNodeName.c_str(), "PHObject");
+      DetNode->addNode(towerNode);
+    }
+
+  // update the parameters on the node tree
+  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+      "PHCompositeNode", "RUN"));
+  assert(parNode);
+  const string paramnodename = string("Calibration_") + detector;
+
+  //   this step is moved to after detector construction
+  //   save updated persistant copy on node tree
+  _calib_params.SaveToNodeTree(parNode, paramnodename);
+
+}
+
+//___________________________________
+int
+CaloCalibration::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void
+CaloCalibration::SetDefaultParameters(PHParameters & param)
+{
+
+  param.set_int_param("use_chan_calibration", 0);
+
+  // additional scale for the calibration constant
+  // negative pulse -> positive with -1
+  param.set_double_param("calib_const_scale", -1);
+
+}

--- a/offline/packages/Prototype4/CaloCalibration.C
+++ b/offline/packages/Prototype4/CaloCalibration.C
@@ -105,7 +105,10 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
     double peak_sample = NAN;
     double pedstal = NAN;
 
-    PROTOTYPE4_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
+//    PROTOTYPE4_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
+//                                          peak_sample, pedstal, verbosity);
+
+    PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(vec_signal_samples, peak,
                                           peak_sample, pedstal, verbosity);
 
     // store the result - raw_tower

--- a/offline/packages/Prototype4/CaloCalibration.C
+++ b/offline/packages/Prototype4/CaloCalibration.C
@@ -1,6 +1,6 @@
 #include "CaloCalibration.h"
-#include "PROTOTYPE3_FEM.h"
-#include "RawTower_Prototype3.h"
+#include "PROTOTYPE4_FEM.h"
+#include "RawTower_Prototype4.h"
 
 #include <calobase/RawTowerContainer.h>
 #include <phool/PHCompositeNode.h>
@@ -71,8 +71,8 @@ CaloCalibration::process_event(PHCompositeNode *topNode)
   for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
     {
       RawTowerDefs::keytype key = rtiter->first;
-      RawTower_Prototype3 *raw_tower =
-          dynamic_cast<RawTower_Prototype3 *>(rtiter->second);
+      RawTower_Prototype4 *raw_tower =
+          dynamic_cast<RawTower_Prototype4 *>(rtiter->second);
       assert(raw_tower);
 
       double calibration_const = calib_const_scale;
@@ -92,7 +92,7 @@ CaloCalibration::process_event(PHCompositeNode *topNode)
         }
 
       vector<double> vec_signal_samples;
-      for (int i = 0; i < RawTower_Prototype3::NSAMPLES; i++)
+      for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
         {
           vec_signal_samples.push_back(
               raw_tower->get_signal_samples(i));
@@ -102,7 +102,7 @@ CaloCalibration::process_event(PHCompositeNode *topNode)
       double peak_sample = NAN;
       double pedstal = NAN;
 
-      PROTOTYPE3_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
+      PROTOTYPE4_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
           peak_sample, pedstal, verbosity);
 
       // store the result - raw_tower
@@ -115,11 +115,11 @@ CaloCalibration::process_event(PHCompositeNode *topNode)
         }
 
       // store the result - calib_tower
-      RawTower_Prototype3 *calib_tower = new RawTower_Prototype3(*raw_tower);
+      RawTower_Prototype4 *calib_tower = new RawTower_Prototype4(*raw_tower);
       calib_tower->set_energy(peak * calibration_const);
       calib_tower->set_time(peak_sample);
 
-      for (int i = 0; i < RawTower_Prototype3::NSAMPLES; i++)
+      for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
         {
           calib_tower->set_signal_samples(i, (vec_signal_samples[i] - pedstal) * calibration_const);
         }

--- a/offline/packages/Prototype4/CaloCalibration.h
+++ b/offline/packages/Prototype4/CaloCalibration.h
@@ -6,27 +6,23 @@
 
 #include <fun4all/SubsysReco.h>
 #include <phool/PHObject.h>
-#include <string>
 #include <phparameter/PHParameters.h>
+#include <string>
 
 class RawTowerContainer;
 
 class CaloCalibration : public SubsysReco
 {
-public:
-  CaloCalibration(const std::string& name);
+ public:
+  CaloCalibration(const std::string &name);
 
-  int
-  Init(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode);
 
-  int
-  InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
 
-  int
-  process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
 
-  int
-  End(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
 
   void
   CreateNodeTree(PHCompositeNode *topNode);
@@ -71,15 +67,14 @@ public:
 
   //! Overwrite the parameter. Useful fields are listed in SetDefaultParameters();
   void
-  SetCalibrationParameters(const PHParameters & calib_params)
+  SetCalibrationParameters(const PHParameters &calib_params)
   {
     _calib_params = calib_params;
   }
 
-private:
-
-  RawTowerContainer* _calib_towers;
-  RawTowerContainer* _raw_towers;
+ private:
+  RawTowerContainer *_calib_towers;
+  RawTowerContainer *_raw_towers;
 
   std::string detector;
   std::string RawTowerNodeName;
@@ -92,8 +87,7 @@ private:
 
   //! load the default parameter to param
   void
-  SetDefaultParameters(PHParameters & param);
-
+  SetDefaultParameters(PHParameters &param);
 };
 
-#endif //**CaloCalibrationF**//
+#endif  //**CaloCalibrationF**//

--- a/offline/packages/Prototype4/CaloCalibration.h
+++ b/offline/packages/Prototype4/CaloCalibration.h
@@ -1,0 +1,99 @@
+#ifndef __CaloCalibrationF__
+#define __CaloCalibrationF__
+
+//* Unpacks raw HCAL PRDF files *//
+//Abhisek Sen
+
+#include <fun4all/SubsysReco.h>
+#include <phool/PHObject.h>
+#include <string>
+#include <phparameter/PHParameters.h>
+
+class RawTowerContainer;
+
+class CaloCalibration : public SubsysReco
+{
+public:
+  CaloCalibration(const std::string& name);
+
+  int
+  Init(PHCompositeNode *topNode);
+
+  int
+  InitRun(PHCompositeNode *topNode);
+
+  int
+  process_event(PHCompositeNode *topNode);
+
+  int
+  End(PHCompositeNode *topNode);
+
+  void
+  CreateNodeTree(PHCompositeNode *topNode);
+
+  std::string
+  get_calib_tower_node_prefix() const
+  {
+    return _calib_tower_node_prefix;
+  }
+
+  void
+  set_calib_tower_node_prefix(std::string calibTowerNodePrefix)
+  {
+    _calib_tower_node_prefix = calibTowerNodePrefix;
+  }
+
+  std::string
+  get_raw_tower_node_prefix() const
+  {
+    return _raw_tower_node_prefix;
+  }
+
+  void
+  set_raw_tower_node_prefix(std::string rawTowerNodePrefix)
+  {
+    _raw_tower_node_prefix = rawTowerNodePrefix;
+  }
+
+  //! Get the parameters for readonly
+  const PHParameters &
+  GetCalibrationParameters() const
+  {
+    return _calib_params;
+  }
+
+  //! Get the parameters for update. Useful fields are listed in SetDefaultParameters();
+  PHParameters &
+  GetCalibrationParameters()
+  {
+    return _calib_params;
+  }
+
+  //! Overwrite the parameter. Useful fields are listed in SetDefaultParameters();
+  void
+  SetCalibrationParameters(const PHParameters & calib_params)
+  {
+    _calib_params = calib_params;
+  }
+
+private:
+
+  RawTowerContainer* _calib_towers;
+  RawTowerContainer* _raw_towers;
+
+  std::string detector;
+  std::string RawTowerNodeName;
+  std::string CaliTowerNodeName;
+
+  std::string _calib_tower_node_prefix;
+  std::string _raw_tower_node_prefix;
+
+  PHParameters _calib_params;
+
+  //! load the default parameter to param
+  void
+  SetDefaultParameters(PHParameters & param);
+
+};
+
+#endif //**CaloCalibrationF**//

--- a/offline/packages/Prototype4/CaloCalibrationLinkDef.h
+++ b/offline/packages/Prototype4/CaloCalibrationLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class CaloCalibration-!;
+
+#endif

--- a/offline/packages/Prototype4/CaloUnpackPRDF.C
+++ b/offline/packages/Prototype4/CaloUnpackPRDF.C
@@ -1,0 +1,300 @@
+#include "RawTower_Prototype3.h"
+#include "PROTOTYPE3_FEM.h"
+#include "CaloUnpackPRDF.h"
+
+#include <Event/Event.h>
+#include <Event/EventTypes.h>
+#include <Event/packetConstants.h>
+#include <Event/packet.h>
+#include <Event/packet_hbd_fpgashort.h>
+#include <calobase/RawTowerContainer.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <pdbcalbase/PdbParameterMap.h>
+#include <phparameter/PHParameters.h>
+
+#include <iostream>
+#include <string>
+#include <cassert>
+
+using namespace std;
+
+//____________________________________
+CaloUnpackPRDF::CaloUnpackPRDF() :
+    SubsysReco("CaloUnpackPRDF"),
+    /*Event**/_event(NULL),
+    /*Packet_hbd_fpgashort**/_packet(NULL),
+    /*int*/_nevents(0),
+    _use_high_eta_EMCal (-1),
+    /*PHCompositeNode **/dst_node(NULL),
+    /*PHCompositeNode **/data_node(NULL),
+    /*RawTowerContainer**/hcalin_towers_lg(NULL),
+    /*RawTowerContainer**/hcalout_towers_lg(NULL),
+    /*RawTowerContainer**/hcalin_towers_hg(NULL),
+    /*RawTowerContainer**/hcalout_towers_hg(NULL),
+    /*RawTowerContainer**/emcal_towers(NULL)
+{
+}
+
+//____________________________________
+int
+CaloUnpackPRDF::Init(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________
+int
+CaloUnpackPRDF::InitRun(PHCompositeNode *topNode)
+{
+  CreateNodeTree(topNode);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________
+int
+CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
+{
+  _nevents++;
+  _event = findNode::getClass<Event>(topNode, "PRDF");
+  if (_event == 0)
+    {
+      cout << "CaloUnpackPRDF::Process_Event - Event not found" << endl;
+      return -1;
+    }
+
+  PdbParameterMap *info = findNode::getClass<PdbParameterMap>(topNode,
+      "RUN_INFO");
+
+  if (not info)
+    {
+      cout
+          << "CaloUnpackPRDF::Process_Event - missing run info. Please run RunInfoUnpackPRDF first"
+          << endl;
+      return -1;
+    }
+
+  int emcal_is_higheta = _use_high_eta_EMCal;
+
+  if (_use_high_eta_EMCal < 0)
+  {
+    PHParameters run_info_copy("RunInfo");
+    run_info_copy.FillFrom(info);
+    emcal_is_higheta = run_info_copy.get_int_param("EMCAL_Is_HighEta");
+  }
+  if (verbosity)
+    {
+      cout << PHWHERE << "Process event entered" << std::endl;
+    }
+
+  if (verbosity)
+    _event->identify();
+  _packet = dynamic_cast<Packet_hbd_fpgashort*>(_event->getPacket(
+      PROTOTYPE3_FEM::PACKET_ID));
+
+  if (!_packet)
+    {
+      //They could be special events at the beginning or end of run
+      if (_event->getEvtType() == DATAEVENT)
+        {
+          cout << "CaloUnpackPRDF::Process_Event - Packet not found" << endl;
+          _event->identify();
+        }
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+  _packet->setNumSamples(PROTOTYPE3_FEM::NSAMPLES);
+  RawTower_Prototype3 *tower_lg = NULL;
+  RawTower_Prototype3 *tower_hg = NULL;
+
+  //HCALIN
+  assert(hcalin_towers_lg);
+  assert(hcalin_towers_hg);
+  for (int ibinz = 0; ibinz < PROTOTYPE3_FEM::NCH_IHCAL_ROWS; ibinz++)
+    {
+      for (int ibinphi = 0; ibinphi < PROTOTYPE3_FEM::NCH_IHCAL_COLUMNS;
+          ibinphi++)
+        {
+          tower_lg =
+              dynamic_cast<RawTower_Prototype3*>(hcalin_towers_lg->getTower(
+                  ibinz, ibinphi));
+          if (!tower_lg)
+            {
+              tower_lg = new RawTower_Prototype3();
+              tower_lg->set_energy(NAN);
+              hcalin_towers_lg->AddTower(ibinz, ibinphi, tower_lg);
+            }
+          tower_hg =
+              dynamic_cast<RawTower_Prototype3*>(hcalin_towers_hg->getTower(
+                  ibinz, ibinphi));
+          if (!tower_hg)
+            {
+              tower_hg = new RawTower_Prototype3();
+              tower_hg->set_energy(NAN);
+              hcalin_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
+            }
+
+          int ich = PROTOTYPE3_FEM::GetHBDCh("HCALIN", ibinz, ibinphi);
+          tower_lg->set_HBD_channel_number(ich);
+          tower_hg->set_HBD_channel_number(ich);
+          for (int isamp = 0; isamp < PROTOTYPE3_FEM::NSAMPLES; isamp++)
+            {
+              tower_hg->set_signal_samples(isamp, _packet->iValue(ich, isamp));
+              tower_lg->set_signal_samples(isamp,
+                  _packet->iValue(ich + 1, isamp));
+            }
+        }
+    }
+
+  //HCALOUT
+  assert(hcalout_towers_lg);
+  assert(hcalout_towers_hg);
+  for (int ibinz = 0; ibinz < PROTOTYPE3_FEM::NCH_OHCAL_ROWS; ibinz++)
+    {
+      for (int ibinphi = 0; ibinphi < PROTOTYPE3_FEM::NCH_OHCAL_COLUMNS;
+          ibinphi++)
+        {
+          tower_lg =
+              dynamic_cast<RawTower_Prototype3*>(hcalout_towers_lg->getTower(
+                  ibinz, ibinphi));
+          if (!tower_lg)
+            {
+              tower_lg = new RawTower_Prototype3();
+              tower_lg->set_energy(NAN);
+              hcalout_towers_lg->AddTower(ibinz, ibinphi, tower_lg);
+            }
+          tower_hg =
+              dynamic_cast<RawTower_Prototype3*>(hcalout_towers_hg->getTower(
+                  ibinz, ibinphi));
+          if (!tower_hg)
+            {
+              tower_hg = new RawTower_Prototype3();
+              tower_hg->set_energy(NAN);
+              hcalout_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
+            }
+          int ich = PROTOTYPE3_FEM::GetHBDCh("HCALOUT", ibinz, ibinphi);
+          tower_lg->set_HBD_channel_number(ich);
+          tower_hg->set_HBD_channel_number(ich);
+          for (int isamp = 0; isamp < PROTOTYPE3_FEM::NSAMPLES; isamp++)
+            {
+              tower_hg->set_signal_samples(isamp, _packet->iValue(ich, isamp));
+              tower_lg->set_signal_samples(isamp,
+                  _packet->iValue(ich + 1, isamp));
+            }
+        }
+    }
+
+  //EMCAL
+  RawTower_Prototype3 *tower = NULL;
+  assert(emcal_towers);
+  for (int ibinz = 0; ibinz < PROTOTYPE3_FEM::NCH_EMCAL_ROWS; ibinz++)
+    {
+      for (int ibinphi = 0; ibinphi < PROTOTYPE3_FEM::NCH_EMCAL_COLUMNS;
+          ibinphi++)
+        {
+          tower = dynamic_cast<RawTower_Prototype3*>(emcal_towers->getTower(
+              ibinz, ibinphi));
+          if (!tower)
+            {
+              tower = new RawTower_Prototype3();
+              tower->set_energy(NAN);
+              emcal_towers->AddTower(ibinz, ibinphi, tower);
+            }
+
+          int ich = PROTOTYPE3_FEM::GetHBDCh(
+              emcal_is_higheta ? "EMCAL_HIGHETA" : "EMCAL_PROTOTYPE2", ibinz,
+              ibinphi);
+          tower->set_HBD_channel_number(ich);
+          for (int isamp = 0; isamp < PROTOTYPE3_FEM::NSAMPLES; isamp++)
+            {
+              tower->set_signal_samples(isamp, _packet->iValue(ich, isamp));
+            }
+        }
+    }
+
+  if (verbosity)
+    {
+      cout << "HCALIN Towers: " << endl;
+      hcalin_towers_hg->identify();
+      RawTowerContainer::ConstRange begin_end = hcalin_towers_lg->getTowers();
+      RawTowerContainer::ConstIterator iter;
+      for (iter = begin_end.first; iter != begin_end.second; ++iter)
+        {
+          RawTower_Prototype3 *tower =
+              dynamic_cast<RawTower_Prototype3*>(iter->second);
+          tower->identify();
+          cout << "Signal Samples: [" << endl;
+          for (int isamp = 0; isamp < PROTOTYPE3_FEM::NSAMPLES; isamp++)
+            {
+              cout << tower->get_signal_samples(isamp) << ", ";
+            }
+          cout << " ]" << endl;
+        }
+    }
+  delete _packet;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_______________________________________
+void
+CaloUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
+{
+  PHNodeIterator nodeItr(topNode);
+  //DST node
+  dst_node = static_cast<PHCompositeNode*>(nodeItr.findFirst("PHCompositeNode",
+      "DST"));
+  if (!dst_node)
+    {
+      cout << "PHComposite node created: DST" << endl;
+      dst_node = new PHCompositeNode("DST");
+      topNode->addNode(dst_node);
+    }
+
+  //DATA nodes
+  data_node = static_cast<PHCompositeNode*>(nodeItr.findFirst("PHCompositeNode",
+      "RAW_DATA"));
+  if (!data_node)
+    {
+      if (Verbosity())
+        cout << "PHComposite node created: RAW_DATA" << endl;
+      data_node = new PHCompositeNode("RAW_DATA");
+      dst_node->addNode(data_node);
+    }
+
+  PHIODataNode<PHObject> *tower_node = NULL;
+
+  //HCAL Towers
+  hcalin_towers_lg = new RawTowerContainer(RawTowerDefs::HCALIN);
+  tower_node = new PHIODataNode<PHObject>(hcalin_towers_lg,
+      "TOWER_RAW_LG_HCALIN", "PHObject");
+  data_node->addNode(tower_node);
+  hcalin_towers_hg = new RawTowerContainer(RawTowerDefs::HCALIN);
+  tower_node = new PHIODataNode<PHObject>(hcalin_towers_hg,
+      "TOWER_RAW_HG_HCALIN", "PHObject");
+  data_node->addNode(tower_node);
+
+  hcalout_towers_lg = new RawTowerContainer(RawTowerDefs::HCALOUT);
+  tower_node = new PHIODataNode<PHObject>(hcalout_towers_lg,
+      "TOWER_RAW_LG_HCALOUT", "PHObject");
+  data_node->addNode(tower_node);
+  hcalout_towers_hg = new RawTowerContainer(RawTowerDefs::HCALOUT);
+  tower_node = new PHIODataNode<PHObject>(hcalout_towers_hg,
+      "TOWER_RAW_HG_HCALOUT", "PHObject");
+  data_node->addNode(tower_node);
+
+  //EMCAL towers
+  emcal_towers = new RawTowerContainer(RawTowerDefs::CEMC);
+  PHIODataNode<PHObject> *emcal_towerNode = new PHIODataNode<PHObject>(
+      emcal_towers, "TOWER_RAW_CEMC", "PHObject");
+  data_node->addNode(emcal_towerNode);
+}
+
+//___________________________________
+int
+CaloUnpackPRDF::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+

--- a/offline/packages/Prototype4/CaloUnpackPRDF.C
+++ b/offline/packages/Prototype4/CaloUnpackPRDF.C
@@ -120,7 +120,7 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
         hcalin_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
       }
 
-      int ich = PROTOTYPE4_FEM::GetHBDCh("HCALIN", ibinz, ibinphi);
+      int ich = PROTOTYPE4_FEM::GetChannelNumber("HCALIN", ibinz, ibinphi);
       tower_lg->set_HBD_channel_number(ich);
       tower_hg->set_HBD_channel_number(ich);
       for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
@@ -157,7 +157,7 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
         tower_hg->set_energy(NAN);
         hcalout_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
       }
-      int ich = PROTOTYPE4_FEM::GetHBDCh("HCALOUT", ibinz, ibinphi);
+      int ich = PROTOTYPE4_FEM::GetChannelNumber("HCALOUT", ibinz, ibinphi);
       tower_lg->set_HBD_channel_number(ich);
       tower_hg->set_HBD_channel_number(ich);
       for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
@@ -185,8 +185,8 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
         emcal_towers->AddTower(ibinz, ibinphi, tower);
       }
 
-      int ich = PROTOTYPE4_FEM::GetHBDCh("EMCAL", ibinz,
-                                         ibinphi);
+      int ich = PROTOTYPE4_FEM::GetChannelNumber("EMCAL", ibinz,
+                                                 ibinphi);
       tower->set_HBD_channel_number(ich);
       for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
       {

--- a/offline/packages/Prototype4/CaloUnpackPRDF.C
+++ b/offline/packages/Prototype4/CaloUnpackPRDF.C
@@ -88,7 +88,7 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
       cout << "CaloUnpackPRDF::Process_Event - Packet not found" << endl;
       _event->identify();
     }
-    return Fun4AllReturnCodes::ABORTEVENT;
+    return Fun4AllReturnCodes::DISCARDEVENT;
   }
   RawTower_Prototype4 *tower_lg = NULL;
   RawTower_Prototype4 *tower_hg = NULL;

--- a/offline/packages/Prototype4/CaloUnpackPRDF.C
+++ b/offline/packages/Prototype4/CaloUnpackPRDF.C
@@ -1,5 +1,5 @@
-#include "RawTower_Prototype3.h"
-#include "PROTOTYPE3_FEM.h"
+#include "RawTower_Prototype4.h"
+#include "PROTOTYPE4_FEM.h"
 #include "CaloUnpackPRDF.h"
 
 #include <Event/Event.h>
@@ -92,7 +92,7 @@ CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
   if (verbosity)
     _event->identify();
   _packet = dynamic_cast<Packet_hbd_fpgashort*>(_event->getPacket(
-      PROTOTYPE3_FEM::PACKET_ID));
+      PROTOTYPE4_FEM::PACKET_ID));
 
   if (!_packet)
     {
@@ -105,41 +105,41 @@ CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-  _packet->setNumSamples(PROTOTYPE3_FEM::NSAMPLES);
-  RawTower_Prototype3 *tower_lg = NULL;
-  RawTower_Prototype3 *tower_hg = NULL;
+  _packet->setNumSamples(PROTOTYPE4_FEM::NSAMPLES);
+  RawTower_Prototype4 *tower_lg = NULL;
+  RawTower_Prototype4 *tower_hg = NULL;
 
   //HCALIN
   assert(hcalin_towers_lg);
   assert(hcalin_towers_hg);
-  for (int ibinz = 0; ibinz < PROTOTYPE3_FEM::NCH_IHCAL_ROWS; ibinz++)
+  for (int ibinz = 0; ibinz < PROTOTYPE4_FEM::NCH_IHCAL_ROWS; ibinz++)
     {
-      for (int ibinphi = 0; ibinphi < PROTOTYPE3_FEM::NCH_IHCAL_COLUMNS;
+      for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_IHCAL_COLUMNS;
           ibinphi++)
         {
           tower_lg =
-              dynamic_cast<RawTower_Prototype3*>(hcalin_towers_lg->getTower(
+              dynamic_cast<RawTower_Prototype4*>(hcalin_towers_lg->getTower(
                   ibinz, ibinphi));
           if (!tower_lg)
             {
-              tower_lg = new RawTower_Prototype3();
+              tower_lg = new RawTower_Prototype4();
               tower_lg->set_energy(NAN);
               hcalin_towers_lg->AddTower(ibinz, ibinphi, tower_lg);
             }
           tower_hg =
-              dynamic_cast<RawTower_Prototype3*>(hcalin_towers_hg->getTower(
+              dynamic_cast<RawTower_Prototype4*>(hcalin_towers_hg->getTower(
                   ibinz, ibinphi));
           if (!tower_hg)
             {
-              tower_hg = new RawTower_Prototype3();
+              tower_hg = new RawTower_Prototype4();
               tower_hg->set_energy(NAN);
               hcalin_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
             }
 
-          int ich = PROTOTYPE3_FEM::GetHBDCh("HCALIN", ibinz, ibinphi);
+          int ich = PROTOTYPE4_FEM::GetHBDCh("HCALIN", ibinz, ibinphi);
           tower_lg->set_HBD_channel_number(ich);
           tower_hg->set_HBD_channel_number(ich);
-          for (int isamp = 0; isamp < PROTOTYPE3_FEM::NSAMPLES; isamp++)
+          for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
             {
               tower_hg->set_signal_samples(isamp, _packet->iValue(ich, isamp));
               tower_lg->set_signal_samples(isamp,
@@ -151,33 +151,33 @@ CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
   //HCALOUT
   assert(hcalout_towers_lg);
   assert(hcalout_towers_hg);
-  for (int ibinz = 0; ibinz < PROTOTYPE3_FEM::NCH_OHCAL_ROWS; ibinz++)
+  for (int ibinz = 0; ibinz < PROTOTYPE4_FEM::NCH_OHCAL_ROWS; ibinz++)
     {
-      for (int ibinphi = 0; ibinphi < PROTOTYPE3_FEM::NCH_OHCAL_COLUMNS;
+      for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_OHCAL_COLUMNS;
           ibinphi++)
         {
           tower_lg =
-              dynamic_cast<RawTower_Prototype3*>(hcalout_towers_lg->getTower(
+              dynamic_cast<RawTower_Prototype4*>(hcalout_towers_lg->getTower(
                   ibinz, ibinphi));
           if (!tower_lg)
             {
-              tower_lg = new RawTower_Prototype3();
+              tower_lg = new RawTower_Prototype4();
               tower_lg->set_energy(NAN);
               hcalout_towers_lg->AddTower(ibinz, ibinphi, tower_lg);
             }
           tower_hg =
-              dynamic_cast<RawTower_Prototype3*>(hcalout_towers_hg->getTower(
+              dynamic_cast<RawTower_Prototype4*>(hcalout_towers_hg->getTower(
                   ibinz, ibinphi));
           if (!tower_hg)
             {
-              tower_hg = new RawTower_Prototype3();
+              tower_hg = new RawTower_Prototype4();
               tower_hg->set_energy(NAN);
               hcalout_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
             }
-          int ich = PROTOTYPE3_FEM::GetHBDCh("HCALOUT", ibinz, ibinphi);
+          int ich = PROTOTYPE4_FEM::GetHBDCh("HCALOUT", ibinz, ibinphi);
           tower_lg->set_HBD_channel_number(ich);
           tower_hg->set_HBD_channel_number(ich);
-          for (int isamp = 0; isamp < PROTOTYPE3_FEM::NSAMPLES; isamp++)
+          for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
             {
               tower_hg->set_signal_samples(isamp, _packet->iValue(ich, isamp));
               tower_lg->set_signal_samples(isamp,
@@ -187,27 +187,27 @@ CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
     }
 
   //EMCAL
-  RawTower_Prototype3 *tower = NULL;
+  RawTower_Prototype4 *tower = NULL;
   assert(emcal_towers);
-  for (int ibinz = 0; ibinz < PROTOTYPE3_FEM::NCH_EMCAL_ROWS; ibinz++)
+  for (int ibinz = 0; ibinz < PROTOTYPE4_FEM::NCH_EMCAL_ROWS; ibinz++)
     {
-      for (int ibinphi = 0; ibinphi < PROTOTYPE3_FEM::NCH_EMCAL_COLUMNS;
+      for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_EMCAL_COLUMNS;
           ibinphi++)
         {
-          tower = dynamic_cast<RawTower_Prototype3*>(emcal_towers->getTower(
+          tower = dynamic_cast<RawTower_Prototype4*>(emcal_towers->getTower(
               ibinz, ibinphi));
           if (!tower)
             {
-              tower = new RawTower_Prototype3();
+              tower = new RawTower_Prototype4();
               tower->set_energy(NAN);
               emcal_towers->AddTower(ibinz, ibinphi, tower);
             }
 
-          int ich = PROTOTYPE3_FEM::GetHBDCh(
+          int ich = PROTOTYPE4_FEM::GetHBDCh(
               emcal_is_higheta ? "EMCAL_HIGHETA" : "EMCAL_PROTOTYPE2", ibinz,
               ibinphi);
           tower->set_HBD_channel_number(ich);
-          for (int isamp = 0; isamp < PROTOTYPE3_FEM::NSAMPLES; isamp++)
+          for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
             {
               tower->set_signal_samples(isamp, _packet->iValue(ich, isamp));
             }
@@ -222,11 +222,11 @@ CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
       RawTowerContainer::ConstIterator iter;
       for (iter = begin_end.first; iter != begin_end.second; ++iter)
         {
-          RawTower_Prototype3 *tower =
-              dynamic_cast<RawTower_Prototype3*>(iter->second);
+          RawTower_Prototype4 *tower =
+              dynamic_cast<RawTower_Prototype4*>(iter->second);
           tower->identify();
           cout << "Signal Samples: [" << endl;
-          for (int isamp = 0; isamp < PROTOTYPE3_FEM::NSAMPLES; isamp++)
+          for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
             {
               cout << tower->get_signal_samples(isamp) << ", ";
             }

--- a/offline/packages/Prototype4/CaloUnpackPRDF.C
+++ b/offline/packages/Prototype4/CaloUnpackPRDF.C
@@ -95,7 +95,7 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
 
   //HCALIN
   assert(hcalin_towers_lg);
-  assert(hcalin_towers_hg);
+//  assert(hcalin_towers_hg);
   for (int ibinz = 0; ibinz < PROTOTYPE4_FEM::NCH_IHCAL_ROWS; ibinz++)
   {
     for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_IHCAL_COLUMNS;
@@ -110,22 +110,22 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
         tower_lg->set_energy(NAN);
         hcalin_towers_lg->AddTower(ibinz, ibinphi, tower_lg);
       }
-      tower_hg =
-          dynamic_cast<RawTower_Prototype4 *>(hcalin_towers_hg->getTower(
-              ibinz, ibinphi));
-      if (!tower_hg)
-      {
-        tower_hg = new RawTower_Prototype4();
-        tower_hg->set_energy(NAN);
-        hcalin_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
-      }
+//      tower_hg =
+//          dynamic_cast<RawTower_Prototype4 *>(hcalin_towers_hg->getTower(
+//              ibinz, ibinphi));
+//      if (!tower_hg)
+//      {
+//        tower_hg = new RawTower_Prototype4();
+//        tower_hg->set_energy(NAN);
+//        hcalin_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
+//      }
 
       int ich = PROTOTYPE4_FEM::GetChannelNumber("HCALIN", ibinz, ibinphi);
       tower_lg->set_HBD_channel_number(ich);
-      tower_hg->set_HBD_channel_number(ich);
+//      tower_hg->set_HBD_channel_number(ich);
       for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
       {
-        tower_hg->set_signal_samples(isamp, _packet->iValue(isamp, ich) & PROTOTYPE4_FEM::ADC_DATA_MASK);
+//        tower_hg->set_signal_samples(isamp, _packet->iValue(isamp, ich) & PROTOTYPE4_FEM::ADC_DATA_MASK);
         tower_lg->set_signal_samples(isamp, _packet->iValue(isamp, ich + 1) & PROTOTYPE4_FEM::ADC_DATA_MASK);
       }
     }

--- a/offline/packages/Prototype4/CaloUnpackPRDF.C
+++ b/offline/packages/Prototype4/CaloUnpackPRDF.C
@@ -6,7 +6,6 @@
 #include <Event/EventTypes.h>
 #include <Event/packet.h>
 #include <Event/packetConstants.h>
-#include <Event/packet_hbd_fpgashort.h>
 #include <calobase/RawTowerContainer.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <pdbcalbase/PdbParameterMap.h>
@@ -71,17 +70,6 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
     return -1;
   }
 
-  PdbParameterMap *info = findNode::getClass<PdbParameterMap>(topNode,
-                                                              "RUN_INFO");
-
-  if (not info)
-  {
-    cout
-        << "CaloUnpackPRDF::Process_Event - missing run info. Please run RunInfoUnpackPRDF first"
-        << endl;
-    return -1;
-  }
-
   if (verbosity)
   {
     cout << PHWHERE << "Process event entered" << std::endl;
@@ -89,8 +77,8 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
 
   if (verbosity)
     _event->identify();
-  _packet = dynamic_cast<Packet_hbd_fpgashort *>(_event->getPacket(
-      PROTOTYPE4_FEM::PACKET_ID));
+
+  _packet = _event->getPacket(PROTOTYPE4_FEM::PACKET_ID);
 
   if (!_packet)
   {
@@ -102,8 +90,6 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
     }
     return Fun4AllReturnCodes::ABORTEVENT;
   }
-
-  _packet->setNumSamples(PROTOTYPE4_FEM::NSAMPLES);
   RawTower_Prototype4 *tower_lg = NULL;
   RawTower_Prototype4 *tower_hg = NULL;
 
@@ -139,9 +125,8 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
       tower_hg->set_HBD_channel_number(ich);
       for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
       {
-        tower_hg->set_signal_samples(isamp, _packet->iValue(ich, isamp));
-        tower_lg->set_signal_samples(isamp,
-                                     _packet->iValue(ich + 1, isamp));
+        tower_hg->set_signal_samples(isamp, _packet->iValue(isamp, ich) & PROTOTYPE4_FEM::ADC_DATA_MASK);
+        tower_lg->set_signal_samples(isamp, _packet->iValue(isamp, ich + 1) & PROTOTYPE4_FEM::ADC_DATA_MASK);
       }
     }
   }
@@ -177,9 +162,8 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
       tower_hg->set_HBD_channel_number(ich);
       for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
       {
-        tower_hg->set_signal_samples(isamp, _packet->iValue(ich, isamp));
-        tower_lg->set_signal_samples(isamp,
-                                     _packet->iValue(ich + 1, isamp));
+        tower_hg->set_signal_samples(isamp, _packet->iValue(isamp, ich) & PROTOTYPE4_FEM::ADC_DATA_MASK);
+        tower_lg->set_signal_samples(isamp, _packet->iValue(isamp, ich + 1) & PROTOTYPE4_FEM::ADC_DATA_MASK);
       }
     }
   }
@@ -206,7 +190,7 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
       tower->set_HBD_channel_number(ich);
       for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
       {
-        tower->set_signal_samples(isamp, _packet->iValue(ich, isamp));
+        tower->set_signal_samples(isamp, _packet->iValue(isamp, ich) & PROTOTYPE4_FEM::ADC_DATA_MASK);
       }
     }
   }

--- a/offline/packages/Prototype4/CaloUnpackPRDF.C
+++ b/offline/packages/Prototype4/CaloUnpackPRDF.C
@@ -1,109 +1,107 @@
-#include "RawTower_Prototype4.h"
-#include "PROTOTYPE4_FEM.h"
 #include "CaloUnpackPRDF.h"
+#include "PROTOTYPE4_FEM.h"
+#include "RawTower_Prototype4.h"
 
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
-#include <Event/packetConstants.h>
 #include <Event/packet.h>
+#include <Event/packetConstants.h>
 #include <Event/packet_hbd_fpgashort.h>
 #include <calobase/RawTowerContainer.h>
-#include <phool/PHCompositeNode.h>
-#include <phool/phool.h>
-#include <phool/getClass.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <pdbcalbase/PdbParameterMap.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
 #include <phparameter/PHParameters.h>
 
+#include <cassert>
 #include <iostream>
 #include <string>
-#include <cassert>
 
 using namespace std;
 
 //____________________________________
-CaloUnpackPRDF::CaloUnpackPRDF() :
-    SubsysReco("CaloUnpackPRDF"),
-    /*Event**/_event(NULL),
-    /*Packet_hbd_fpgashort**/_packet(NULL),
-    /*int*/_nevents(0),
-    _use_high_eta_EMCal (-1),
-    /*PHCompositeNode **/dst_node(NULL),
-    /*PHCompositeNode **/data_node(NULL),
-    /*RawTowerContainer**/hcalin_towers_lg(NULL),
-    /*RawTowerContainer**/hcalout_towers_lg(NULL),
-    /*RawTowerContainer**/hcalin_towers_hg(NULL),
-    /*RawTowerContainer**/hcalout_towers_hg(NULL),
-    /*RawTowerContainer**/emcal_towers(NULL)
+CaloUnpackPRDF::CaloUnpackPRDF()
+  : SubsysReco("CaloUnpackPRDF")
+  ,
+  /*Event**/ _event(NULL)
+  ,
+  /*Packet_hbd_fpgashort**/ _packet(NULL)
+  ,
+  /*int*/ _nevents(0)
+  ,
+  /*PHCompositeNode **/ dst_node(NULL)
+  ,
+  /*PHCompositeNode **/ data_node(NULL)
+  ,
+  /*RawTowerContainer**/ hcalin_towers_lg(NULL)
+  ,
+  /*RawTowerContainer**/ hcalout_towers_lg(NULL)
+  ,
+  /*RawTowerContainer**/ hcalin_towers_hg(NULL)
+  ,
+  /*RawTowerContainer**/ hcalout_towers_hg(NULL)
+  ,
+  /*RawTowerContainer**/ emcal_towers(NULL)
 {
 }
 
 //____________________________________
-int
-CaloUnpackPRDF::Init(PHCompositeNode *topNode)
+int CaloUnpackPRDF::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_____________________________________
-int
-CaloUnpackPRDF::InitRun(PHCompositeNode *topNode)
+int CaloUnpackPRDF::InitRun(PHCompositeNode *topNode)
 {
   CreateNodeTree(topNode);
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________
-int
-CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
+int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
 {
   _nevents++;
   _event = findNode::getClass<Event>(topNode, "PRDF");
   if (_event == 0)
-    {
-      cout << "CaloUnpackPRDF::Process_Event - Event not found" << endl;
-      return -1;
-    }
+  {
+    cout << "CaloUnpackPRDF::Process_Event - Event not found" << endl;
+    return -1;
+  }
 
   PdbParameterMap *info = findNode::getClass<PdbParameterMap>(topNode,
-      "RUN_INFO");
+                                                              "RUN_INFO");
 
   if (not info)
-    {
-      cout
-          << "CaloUnpackPRDF::Process_Event - missing run info. Please run RunInfoUnpackPRDF first"
-          << endl;
-      return -1;
-    }
-
-  int emcal_is_higheta = _use_high_eta_EMCal;
-
-  if (_use_high_eta_EMCal < 0)
   {
-    PHParameters run_info_copy("RunInfo");
-    run_info_copy.FillFrom(info);
-    emcal_is_higheta = run_info_copy.get_int_param("EMCAL_Is_HighEta");
+    cout
+        << "CaloUnpackPRDF::Process_Event - missing run info. Please run RunInfoUnpackPRDF first"
+        << endl;
+    return -1;
   }
+
   if (verbosity)
-    {
-      cout << PHWHERE << "Process event entered" << std::endl;
-    }
+  {
+    cout << PHWHERE << "Process event entered" << std::endl;
+  }
 
   if (verbosity)
     _event->identify();
-  _packet = dynamic_cast<Packet_hbd_fpgashort*>(_event->getPacket(
+  _packet = dynamic_cast<Packet_hbd_fpgashort *>(_event->getPacket(
       PROTOTYPE4_FEM::PACKET_ID));
 
   if (!_packet)
+  {
+    //They could be special events at the beginning or end of run
+    if (_event->getEvtType() == DATAEVENT)
     {
-      //They could be special events at the beginning or end of run
-      if (_event->getEvtType() == DATAEVENT)
-        {
-          cout << "CaloUnpackPRDF::Process_Event - Packet not found" << endl;
-          _event->identify();
-        }
-      return Fun4AllReturnCodes::ABORTEVENT;
+      cout << "CaloUnpackPRDF::Process_Event - Packet not found" << endl;
+      _event->identify();
     }
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   _packet->setNumSamples(PROTOTYPE4_FEM::NSAMPLES);
   RawTower_Prototype4 *tower_lg = NULL;
@@ -113,175 +111,173 @@ CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
   assert(hcalin_towers_lg);
   assert(hcalin_towers_hg);
   for (int ibinz = 0; ibinz < PROTOTYPE4_FEM::NCH_IHCAL_ROWS; ibinz++)
+  {
+    for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_IHCAL_COLUMNS;
+         ibinphi++)
     {
-      for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_IHCAL_COLUMNS;
-          ibinphi++)
-        {
-          tower_lg =
-              dynamic_cast<RawTower_Prototype4*>(hcalin_towers_lg->getTower(
-                  ibinz, ibinphi));
-          if (!tower_lg)
-            {
-              tower_lg = new RawTower_Prototype4();
-              tower_lg->set_energy(NAN);
-              hcalin_towers_lg->AddTower(ibinz, ibinphi, tower_lg);
-            }
-          tower_hg =
-              dynamic_cast<RawTower_Prototype4*>(hcalin_towers_hg->getTower(
-                  ibinz, ibinphi));
-          if (!tower_hg)
-            {
-              tower_hg = new RawTower_Prototype4();
-              tower_hg->set_energy(NAN);
-              hcalin_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
-            }
+      tower_lg =
+          dynamic_cast<RawTower_Prototype4 *>(hcalin_towers_lg->getTower(
+              ibinz, ibinphi));
+      if (!tower_lg)
+      {
+        tower_lg = new RawTower_Prototype4();
+        tower_lg->set_energy(NAN);
+        hcalin_towers_lg->AddTower(ibinz, ibinphi, tower_lg);
+      }
+      tower_hg =
+          dynamic_cast<RawTower_Prototype4 *>(hcalin_towers_hg->getTower(
+              ibinz, ibinphi));
+      if (!tower_hg)
+      {
+        tower_hg = new RawTower_Prototype4();
+        tower_hg->set_energy(NAN);
+        hcalin_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
+      }
 
-          int ich = PROTOTYPE4_FEM::GetHBDCh("HCALIN", ibinz, ibinphi);
-          tower_lg->set_HBD_channel_number(ich);
-          tower_hg->set_HBD_channel_number(ich);
-          for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
-            {
-              tower_hg->set_signal_samples(isamp, _packet->iValue(ich, isamp));
-              tower_lg->set_signal_samples(isamp,
-                  _packet->iValue(ich + 1, isamp));
-            }
-        }
+      int ich = PROTOTYPE4_FEM::GetHBDCh("HCALIN", ibinz, ibinphi);
+      tower_lg->set_HBD_channel_number(ich);
+      tower_hg->set_HBD_channel_number(ich);
+      for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
+      {
+        tower_hg->set_signal_samples(isamp, _packet->iValue(ich, isamp));
+        tower_lg->set_signal_samples(isamp,
+                                     _packet->iValue(ich + 1, isamp));
+      }
     }
+  }
 
   //HCALOUT
   assert(hcalout_towers_lg);
   assert(hcalout_towers_hg);
   for (int ibinz = 0; ibinz < PROTOTYPE4_FEM::NCH_OHCAL_ROWS; ibinz++)
+  {
+    for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_OHCAL_COLUMNS;
+         ibinphi++)
     {
-      for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_OHCAL_COLUMNS;
-          ibinphi++)
-        {
-          tower_lg =
-              dynamic_cast<RawTower_Prototype4*>(hcalout_towers_lg->getTower(
-                  ibinz, ibinphi));
-          if (!tower_lg)
-            {
-              tower_lg = new RawTower_Prototype4();
-              tower_lg->set_energy(NAN);
-              hcalout_towers_lg->AddTower(ibinz, ibinphi, tower_lg);
-            }
-          tower_hg =
-              dynamic_cast<RawTower_Prototype4*>(hcalout_towers_hg->getTower(
-                  ibinz, ibinphi));
-          if (!tower_hg)
-            {
-              tower_hg = new RawTower_Prototype4();
-              tower_hg->set_energy(NAN);
-              hcalout_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
-            }
-          int ich = PROTOTYPE4_FEM::GetHBDCh("HCALOUT", ibinz, ibinphi);
-          tower_lg->set_HBD_channel_number(ich);
-          tower_hg->set_HBD_channel_number(ich);
-          for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
-            {
-              tower_hg->set_signal_samples(isamp, _packet->iValue(ich, isamp));
-              tower_lg->set_signal_samples(isamp,
-                  _packet->iValue(ich + 1, isamp));
-            }
-        }
+      tower_lg =
+          dynamic_cast<RawTower_Prototype4 *>(hcalout_towers_lg->getTower(
+              ibinz, ibinphi));
+      if (!tower_lg)
+      {
+        tower_lg = new RawTower_Prototype4();
+        tower_lg->set_energy(NAN);
+        hcalout_towers_lg->AddTower(ibinz, ibinphi, tower_lg);
+      }
+      tower_hg =
+          dynamic_cast<RawTower_Prototype4 *>(hcalout_towers_hg->getTower(
+              ibinz, ibinphi));
+      if (!tower_hg)
+      {
+        tower_hg = new RawTower_Prototype4();
+        tower_hg->set_energy(NAN);
+        hcalout_towers_hg->AddTower(ibinz, ibinphi, tower_hg);
+      }
+      int ich = PROTOTYPE4_FEM::GetHBDCh("HCALOUT", ibinz, ibinphi);
+      tower_lg->set_HBD_channel_number(ich);
+      tower_hg->set_HBD_channel_number(ich);
+      for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
+      {
+        tower_hg->set_signal_samples(isamp, _packet->iValue(ich, isamp));
+        tower_lg->set_signal_samples(isamp,
+                                     _packet->iValue(ich + 1, isamp));
+      }
     }
+  }
 
   //EMCAL
   RawTower_Prototype4 *tower = NULL;
   assert(emcal_towers);
   for (int ibinz = 0; ibinz < PROTOTYPE4_FEM::NCH_EMCAL_ROWS; ibinz++)
+  {
+    for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_EMCAL_COLUMNS;
+         ibinphi++)
     {
-      for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_EMCAL_COLUMNS;
-          ibinphi++)
-        {
-          tower = dynamic_cast<RawTower_Prototype4*>(emcal_towers->getTower(
-              ibinz, ibinphi));
-          if (!tower)
-            {
-              tower = new RawTower_Prototype4();
-              tower->set_energy(NAN);
-              emcal_towers->AddTower(ibinz, ibinphi, tower);
-            }
+      tower = dynamic_cast<RawTower_Prototype4 *>(emcal_towers->getTower(
+          ibinz, ibinphi));
+      if (!tower)
+      {
+        tower = new RawTower_Prototype4();
+        tower->set_energy(NAN);
+        emcal_towers->AddTower(ibinz, ibinphi, tower);
+      }
 
-          int ich = PROTOTYPE4_FEM::GetHBDCh(
-              emcal_is_higheta ? "EMCAL_HIGHETA" : "EMCAL_PROTOTYPE2", ibinz,
-              ibinphi);
-          tower->set_HBD_channel_number(ich);
-          for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
-            {
-              tower->set_signal_samples(isamp, _packet->iValue(ich, isamp));
-            }
-        }
+      int ich = PROTOTYPE4_FEM::GetHBDCh("EMCAL", ibinz,
+                                         ibinphi);
+      tower->set_HBD_channel_number(ich);
+      for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
+      {
+        tower->set_signal_samples(isamp, _packet->iValue(ich, isamp));
+      }
     }
+  }
 
   if (verbosity)
+  {
+    cout << "HCALIN Towers: " << endl;
+    hcalin_towers_hg->identify();
+    RawTowerContainer::ConstRange begin_end = hcalin_towers_lg->getTowers();
+    RawTowerContainer::ConstIterator iter;
+    for (iter = begin_end.first; iter != begin_end.second; ++iter)
     {
-      cout << "HCALIN Towers: " << endl;
-      hcalin_towers_hg->identify();
-      RawTowerContainer::ConstRange begin_end = hcalin_towers_lg->getTowers();
-      RawTowerContainer::ConstIterator iter;
-      for (iter = begin_end.first; iter != begin_end.second; ++iter)
-        {
-          RawTower_Prototype4 *tower =
-              dynamic_cast<RawTower_Prototype4*>(iter->second);
-          tower->identify();
-          cout << "Signal Samples: [" << endl;
-          for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
-            {
-              cout << tower->get_signal_samples(isamp) << ", ";
-            }
-          cout << " ]" << endl;
-        }
+      RawTower_Prototype4 *tower =
+          dynamic_cast<RawTower_Prototype4 *>(iter->second);
+      tower->identify();
+      cout << "Signal Samples: [" << endl;
+      for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
+      {
+        cout << tower->get_signal_samples(isamp) << ", ";
+      }
+      cout << " ]" << endl;
     }
+  }
   delete _packet;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_______________________________________
-void
-CaloUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
+void CaloUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
 {
   PHNodeIterator nodeItr(topNode);
   //DST node
-  dst_node = static_cast<PHCompositeNode*>(nodeItr.findFirst("PHCompositeNode",
-      "DST"));
+  dst_node = static_cast<PHCompositeNode *>(nodeItr.findFirst("PHCompositeNode",
+                                                              "DST"));
   if (!dst_node)
-    {
-      cout << "PHComposite node created: DST" << endl;
-      dst_node = new PHCompositeNode("DST");
-      topNode->addNode(dst_node);
-    }
+  {
+    cout << "PHComposite node created: DST" << endl;
+    dst_node = new PHCompositeNode("DST");
+    topNode->addNode(dst_node);
+  }
 
   //DATA nodes
-  data_node = static_cast<PHCompositeNode*>(nodeItr.findFirst("PHCompositeNode",
-      "RAW_DATA"));
+  data_node = static_cast<PHCompositeNode *>(nodeItr.findFirst("PHCompositeNode",
+                                                               "RAW_DATA"));
   if (!data_node)
-    {
-      if (Verbosity())
-        cout << "PHComposite node created: RAW_DATA" << endl;
-      data_node = new PHCompositeNode("RAW_DATA");
-      dst_node->addNode(data_node);
-    }
+  {
+    if (Verbosity())
+      cout << "PHComposite node created: RAW_DATA" << endl;
+    data_node = new PHCompositeNode("RAW_DATA");
+    dst_node->addNode(data_node);
+  }
 
   PHIODataNode<PHObject> *tower_node = NULL;
 
   //HCAL Towers
   hcalin_towers_lg = new RawTowerContainer(RawTowerDefs::HCALIN);
   tower_node = new PHIODataNode<PHObject>(hcalin_towers_lg,
-      "TOWER_RAW_LG_HCALIN", "PHObject");
+                                          "TOWER_RAW_LG_HCALIN", "PHObject");
   data_node->addNode(tower_node);
   hcalin_towers_hg = new RawTowerContainer(RawTowerDefs::HCALIN);
   tower_node = new PHIODataNode<PHObject>(hcalin_towers_hg,
-      "TOWER_RAW_HG_HCALIN", "PHObject");
+                                          "TOWER_RAW_HG_HCALIN", "PHObject");
   data_node->addNode(tower_node);
 
   hcalout_towers_lg = new RawTowerContainer(RawTowerDefs::HCALOUT);
   tower_node = new PHIODataNode<PHObject>(hcalout_towers_lg,
-      "TOWER_RAW_LG_HCALOUT", "PHObject");
+                                          "TOWER_RAW_LG_HCALOUT", "PHObject");
   data_node->addNode(tower_node);
   hcalout_towers_hg = new RawTowerContainer(RawTowerDefs::HCALOUT);
   tower_node = new PHIODataNode<PHObject>(hcalout_towers_hg,
-      "TOWER_RAW_HG_HCALOUT", "PHObject");
+                                          "TOWER_RAW_HG_HCALOUT", "PHObject");
   data_node->addNode(tower_node);
 
   //EMCAL towers
@@ -292,9 +288,7 @@ CaloUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
 }
 
 //___________________________________
-int
-CaloUnpackPRDF::End(PHCompositeNode *topNode)
+int CaloUnpackPRDF::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
-

--- a/offline/packages/Prototype4/CaloUnpackPRDF.h
+++ b/offline/packages/Prototype4/CaloUnpackPRDF.h
@@ -1,0 +1,65 @@
+#ifndef __CaloUnpackPRDFF__
+#define __CaloUnpackPRDFF__
+
+//* Unpacks raw HCAL PRDF files *//
+//Abhisek Sen
+
+#include <fun4all/SubsysReco.h>
+#include <phool/PHObject.h>
+
+class Event;
+class Packet;
+class Packet_hbd_fpgashort;
+class RawTowerContainer;
+class RawTower;
+
+class CaloUnpackPRDF : public SubsysReco
+{
+public:
+  CaloUnpackPRDF();
+
+  int
+  Init(PHCompositeNode *topNode);
+
+  int
+  InitRun(PHCompositeNode *topNode);
+
+  int
+  process_event(PHCompositeNode *topNode);
+
+  int
+  End(PHCompositeNode *topNode);
+
+  void
+  CreateNodeTree(PHCompositeNode *topNode);
+
+  //! whether to use high eta EMCal
+  void set_use_high_eta_EMCal(bool b)
+  {
+    _use_high_eta_EMCal = b ? 1 : 0;
+  }
+
+private:
+
+  Event* _event;
+  Packet_hbd_fpgashort* _packet;
+  int _nevents;
+
+  //! -1 - read from RunInfo, +1, true, 0 false;
+  int _use_high_eta_EMCal;
+
+  // HCAL node
+  PHCompositeNode * dst_node;
+  PHCompositeNode * data_node;
+
+  //Towers
+  RawTowerContainer* hcalin_towers_lg;
+  RawTowerContainer* hcalout_towers_lg;
+
+  RawTowerContainer* hcalin_towers_hg;
+  RawTowerContainer* hcalout_towers_hg;
+
+  RawTowerContainer* emcal_towers;
+};
+
+#endif //**CaloUnpackPRDFF**//

--- a/offline/packages/Prototype4/CaloUnpackPRDF.h
+++ b/offline/packages/Prototype4/CaloUnpackPRDF.h
@@ -9,7 +9,6 @@
 
 class Event;
 class Packet;
-class Packet_hbd_fpgashort;
 class RawTowerContainer;
 class RawTower;
 
@@ -31,7 +30,7 @@ class CaloUnpackPRDF : public SubsysReco
 
  private:
   Event* _event;
-  Packet_hbd_fpgashort* _packet;
+  Packet* _packet;
   int _nevents;
 
   // HCAL node

--- a/offline/packages/Prototype4/CaloUnpackPRDF.h
+++ b/offline/packages/Prototype4/CaloUnpackPRDF.h
@@ -15,42 +15,28 @@ class RawTower;
 
 class CaloUnpackPRDF : public SubsysReco
 {
-public:
+ public:
   CaloUnpackPRDF();
 
-  int
-  Init(PHCompositeNode *topNode);
+  int Init(PHCompositeNode* topNode);
 
-  int
-  InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode* topNode);
 
-  int
-  process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode* topNode);
 
-  int
-  End(PHCompositeNode *topNode);
+  int End(PHCompositeNode* topNode);
 
   void
-  CreateNodeTree(PHCompositeNode *topNode);
+  CreateNodeTree(PHCompositeNode* topNode);
 
-  //! whether to use high eta EMCal
-  void set_use_high_eta_EMCal(bool b)
-  {
-    _use_high_eta_EMCal = b ? 1 : 0;
-  }
-
-private:
-
+ private:
   Event* _event;
   Packet_hbd_fpgashort* _packet;
   int _nevents;
 
-  //! -1 - read from RunInfo, +1, true, 0 false;
-  int _use_high_eta_EMCal;
-
   // HCAL node
-  PHCompositeNode * dst_node;
-  PHCompositeNode * data_node;
+  PHCompositeNode* dst_node;
+  PHCompositeNode* data_node;
 
   //Towers
   RawTowerContainer* hcalin_towers_lg;
@@ -62,4 +48,4 @@ private:
   RawTowerContainer* emcal_towers;
 };
 
-#endif //**CaloUnpackPRDFF**//
+#endif  //**CaloUnpackPRDFF**//

--- a/offline/packages/Prototype4/CaloUnpackPRDFLinkDef.h
+++ b/offline/packages/Prototype4/CaloUnpackPRDFLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class CaloUnpackPRDF-!;
+
+#endif

--- a/offline/packages/Prototype4/EventInfoSummary.C
+++ b/offline/packages/Prototype4/EventInfoSummary.C
@@ -1,26 +1,26 @@
 #include "EventInfoSummary.h"
-#include "RawTower_Prototype4.h"
 #include "PROTOTYPE4_FEM.h"
+#include "RawTower_Prototype4.h"
 
-#include <calobase/RawTowerContainer.h>
-#include <ffaobjects/EventHeaderv1.h>
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
-#include <Event/packetConstants.h>
 #include <Event/packet.h>
-#include <pdbcalbase/PdbParameterMap.h>
-#include <phparameter/PHParameters.h>
-#include <phool/PHCompositeNode.h>
-#include <phool/phool.h>
-#include <phool/getClass.h>
+#include <Event/packetConstants.h>
+#include <calobase/RawTowerContainer.h>
+#include <ffaobjects/EventHeaderv1.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <pdbcalbase/PdbParameterMap.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phparameter/PHParameters.h>
 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics.hpp>
 
+#include <cassert>
 #include <iostream>
 #include <string>
-#include <cassert>
 
 using namespace std;
 using namespace boost::accumulators;
@@ -28,232 +28,225 @@ using namespace boost::accumulators;
 typedef PHIODataNode<PHObject> PHObjectNode_t;
 
 //____________________________________
-EventInfoSummary::EventInfoSummary() :
-    SubsysReco("EventInfoSummary"), eventinfo_node_name("EVENT_INFO")
+EventInfoSummary::EventInfoSummary()
+  : SubsysReco("EventInfoSummary")
+  , eventinfo_node_name("EVENT_INFO")
 {
 }
 
 //____________________________________
-int
-EventInfoSummary::Init(PHCompositeNode *topNode)
+int EventInfoSummary::Init(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_____________________________________
-int
-EventInfoSummary::InitRun(PHCompositeNode *topNode)
+int EventInfoSummary::InitRun(PHCompositeNode* topNode)
 {
   CreateNodeTree(topNode);
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________
-int
-EventInfoSummary::process_event(PHCompositeNode *topNode)
+int EventInfoSummary::process_event(PHCompositeNode* topNode)
 {
   Event* event = findNode::getClass<Event>(topNode, "PRDF");
   if (event == NULL)
-    {
-      if (Verbosity() >= VERBOSITY_SOME)
-        cout << "EventInfoSummary::Process_Event - Event not found" << endl;
-      return Fun4AllReturnCodes::DISCARDEVENT;
-    }
+  {
+    if (Verbosity() >= VERBOSITY_SOME)
+      cout << "EventInfoSummary::Process_Event - Event not found" << endl;
+    return Fun4AllReturnCodes::DISCARDEVENT;
+  }
 
   // search for run info
   if (event->getEvtType() != DATAEVENT)
     return Fun4AllReturnCodes::EVENT_OK;
-  else // DATAEVENT
+  else  // DATAEVENT
+  {
+    if (verbosity >= VERBOSITY_SOME)
     {
-      if (verbosity >= VERBOSITY_SOME)
-        {
-          cout << "EventInfoSummary::process_event - with DATAEVENT events ";
-          event->identify();
-        }
-
-      map<int, Packet*> packet_list;
-
-      PHParameters Params("EventInfo");
-
-      // spill indicator
-        {
-          RawTowerContainer* TOWER_RAW_SPILL_WARBLER = findNode::getClass<
-              RawTowerContainer>(topNode, "TOWER_RAW_SPILL_WARBLER");
-          assert(TOWER_RAW_SPILL_WARBLER);
-
-          RawTower_Prototype4 *raw_tower =
-              dynamic_cast<RawTower_Prototype4 *>(TOWER_RAW_SPILL_WARBLER->getTower(0));
-          assert(raw_tower);
-
-          accumulator_set<double, features<tag::variance>> acc;
-
-          vector<double> vec_signal_samples;
-          for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
-            {
-              acc(raw_tower->get_signal_samples(i));
-            }
-
-          const double warbler_rms = variance(acc);
-          const bool is_in_spill = warbler_rms > (1000*1000);
-          Params.set_double_param("beam_SPILL_WARBLER_RMS", warbler_rms);
-          Params.set_double_param("beam_Is_In_Spill", is_in_spill);
-          Params.set_int_param("beam_Is_In_Spill", is_in_spill);
-        }
-
-      // energy sums
-        {
-          RawTowerContainer* TOWER_CALIB_CEMC = findNode::getClass<
-              RawTowerContainer>(topNode, "TOWER_CALIB_CEMC");
-          assert(TOWER_CALIB_CEMC);
-
-          RawTowerContainer* TOWER_CALIB_LG_HCALIN = findNode::getClass<
-              RawTowerContainer>(topNode, "TOWER_CALIB_LG_HCALIN");
-
-          RawTowerContainer* TOWER_CALIB_LG_HCALOUT = findNode::getClass<
-              RawTowerContainer>(topNode, "TOWER_CALIB_LG_HCALOUT");
-
-          // process inner HCAL
-          if (TOWER_CALIB_CEMC)
-            {
-              double sum_energy_calib = 0;
-
-              auto range = TOWER_CALIB_CEMC->getTowers();
-              for (auto it = range.first; it != range.second; ++it)
-                {
-
-                  RawTower* tower = it->second;
-                  assert(tower);
-
-                  const int col = tower->get_bineta();
-                  const int row = tower->get_binphi();
-
-                  if (col < 0 or col >= 8)
-                    continue;
-                  if (row < 0 or row >= 8)
-                    continue;
-
-                  const double energy_calib = tower->get_energy();
-                  sum_energy_calib += energy_calib;
-
-                } //       for (auto it = range.first; it != range.second; ++it)
-              Params.set_double_param("CALIB_CEMC_Sum", sum_energy_calib);
-            } // process inner HCAL
-
-          // process inner HCAL
-          if (TOWER_CALIB_LG_HCALIN)
-            {
-              double sum_energy_calib = 0;
-
-              auto range = TOWER_CALIB_LG_HCALIN->getTowers();
-              for (auto it = range.first; it != range.second; ++it)
-                {
-
-                  RawTower* tower = it->second;
-                  assert(tower);
-
-                  const int col = tower->get_bineta();
-                  const int row = tower->get_binphi();
-
-                  if (col < 0 or col >= 4)
-                    continue;
-                  if (row < 0 or row >= 4)
-                    continue;
-
-                  const double energy_calib = tower->get_energy();
-                  sum_energy_calib += energy_calib;
-
-                } //       for (auto it = range.first; it != range.second; ++it)
-              Params.set_double_param("CALIB_LG_HCALIN_Sum", sum_energy_calib);
-            } // process inner HCAL
-
-          // process outer HCAL
-          if (TOWER_CALIB_LG_HCALOUT)
-            {
-              double sum_energy_calib = 0;
-
-              auto range = TOWER_CALIB_LG_HCALOUT->getTowers();
-              for (auto it = range.first; it != range.second; ++it)
-                {
-
-                  RawTower* tower = it->second;
-                  assert(tower);
-
-                  const int col = tower->get_bineta();
-                  const int row = tower->get_binphi();
-
-                  if (col < 0 or col >= 4)
-                    continue;
-                  if (row < 0 or row >= 4)
-                    continue;
-
-                  const double energy_calib = tower->get_energy();
-                  sum_energy_calib += energy_calib;
-
-                } //       for (auto it = range.first; it != range.second; ++it)
-
-              Params.set_double_param("CALIB_LG_HCALOUT_Sum", sum_energy_calib);
-            } // process outer HCAL
-
-        }
-
-      // generic packets
-      for (typ_channel_map::const_iterator it = channel_map.begin();
-          it != channel_map.end(); ++it)
-        {
-          const string & name = it->first;
-          const channel_info & info = it->second;
-
-          if (packet_list.find(info.packet_id) == packet_list.end())
-            {
-              packet_list[info.packet_id] = event->getPacket(info.packet_id);
-            }
-
-          Packet * packet = packet_list[info.packet_id];
-
-          if (!packet)
-            {
-//          if (Verbosity() >= VERBOSITY_SOME)
-              cout
-                  << "EventInfoSummary::process_event - failed to locate packet "
-                  << info.packet_id << " from ";
-              event->identify();
-
-              Params.set_double_param(name, NAN);
-              continue;
-            }
-
-          const int ivalue = packet->iValue(info.offset);
-
-          const double dvalue = ivalue * info.calibration_const;
-
-          if (verbosity >= VERBOSITY_SOME)
-            {
-              cout << "EventInfoSummary::process_event - " << name << " = "
-                  << dvalue << ", raw = " << ivalue << " @ packet "
-                  << info.packet_id << ", offset " << info.offset << endl;
-            }
-
-          Params.set_double_param(name, dvalue);
-        }
-
-      for (map<int, Packet*>::iterator it = packet_list.begin();
-          it != packet_list.end(); ++it)
-        {
-          if (it->second)
-            delete it->second;
-        }
-
-      Params.SaveToNodeTree(topNode, eventinfo_node_name);
-
-      if (verbosity >= VERBOSITY_SOME)
-        Params.Print();
+      cout << "EventInfoSummary::process_event - with DATAEVENT events ";
+      event->identify();
     }
+
+    map<int, Packet*> packet_list;
+
+    PHParameters Params("EventInfo");
+
+    // spill indicator
+    {
+      RawTowerContainer* TOWER_RAW_SPILL_WARBLER = findNode::getClass<
+          RawTowerContainer>(topNode, "TOWER_RAW_SPILL_WARBLER");
+      assert(TOWER_RAW_SPILL_WARBLER);
+
+      RawTower_Prototype4* raw_tower =
+          dynamic_cast<RawTower_Prototype4*>(TOWER_RAW_SPILL_WARBLER->getTower(0));
+      assert(raw_tower);
+
+      accumulator_set<double, features<tag::variance>> acc;
+
+      vector<double> vec_signal_samples;
+      for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
+      {
+        acc(raw_tower->get_signal_samples(i));
+      }
+
+      const double warbler_rms = variance(acc);
+      const bool is_in_spill = warbler_rms > (1000 * 1000);
+      Params.set_double_param("beam_SPILL_WARBLER_RMS", warbler_rms);
+      Params.set_double_param("beam_Is_In_Spill", is_in_spill);
+      Params.set_int_param("beam_Is_In_Spill", is_in_spill);
+    }
+
+    // energy sums
+    {
+      RawTowerContainer* TOWER_CALIB_CEMC = findNode::getClass<
+          RawTowerContainer>(topNode, "TOWER_CALIB_CEMC");
+      assert(TOWER_CALIB_CEMC);
+
+      RawTowerContainer* TOWER_CALIB_LG_HCALIN = findNode::getClass<
+          RawTowerContainer>(topNode, "TOWER_CALIB_LG_HCALIN");
+
+      RawTowerContainer* TOWER_CALIB_LG_HCALOUT = findNode::getClass<
+          RawTowerContainer>(topNode, "TOWER_CALIB_LG_HCALOUT");
+
+      // process inner HCAL
+      if (TOWER_CALIB_CEMC)
+      {
+        double sum_energy_calib = 0;
+
+        auto range = TOWER_CALIB_CEMC->getTowers();
+        for (auto it = range.first; it != range.second; ++it)
+        {
+          RawTower* tower = it->second;
+          assert(tower);
+
+          const int col = tower->get_bineta();
+          const int row = tower->get_binphi();
+
+          if (col < 0 or col >= 8)
+            continue;
+          if (row < 0 or row >= 8)
+            continue;
+
+          const double energy_calib = tower->get_energy();
+          sum_energy_calib += energy_calib;
+
+        }  //       for (auto it = range.first; it != range.second; ++it)
+        Params.set_double_param("CALIB_CEMC_Sum", sum_energy_calib);
+      }  // process inner HCAL
+
+      // process inner HCAL
+      if (TOWER_CALIB_LG_HCALIN)
+      {
+        double sum_energy_calib = 0;
+
+        auto range = TOWER_CALIB_LG_HCALIN->getTowers();
+        for (auto it = range.first; it != range.second; ++it)
+        {
+          RawTower* tower = it->second;
+          assert(tower);
+
+          const int col = tower->get_bineta();
+          const int row = tower->get_binphi();
+
+          if (col < 0 or col >= 4)
+            continue;
+          if (row < 0 or row >= 4)
+            continue;
+
+          const double energy_calib = tower->get_energy();
+          sum_energy_calib += energy_calib;
+
+        }  //       for (auto it = range.first; it != range.second; ++it)
+        Params.set_double_param("CALIB_LG_HCALIN_Sum", sum_energy_calib);
+      }  // process inner HCAL
+
+      // process outer HCAL
+      if (TOWER_CALIB_LG_HCALOUT)
+      {
+        double sum_energy_calib = 0;
+
+        auto range = TOWER_CALIB_LG_HCALOUT->getTowers();
+        for (auto it = range.first; it != range.second; ++it)
+        {
+          RawTower* tower = it->second;
+          assert(tower);
+
+          const int col = tower->get_bineta();
+          const int row = tower->get_binphi();
+
+          if (col < 0 or col >= 4)
+            continue;
+          if (row < 0 or row >= 4)
+            continue;
+
+          const double energy_calib = tower->get_energy();
+          sum_energy_calib += energy_calib;
+
+        }  //       for (auto it = range.first; it != range.second; ++it)
+
+        Params.set_double_param("CALIB_LG_HCALOUT_Sum", sum_energy_calib);
+      }  // process outer HCAL
+    }
+
+    // generic packets
+    for (typ_channel_map::const_iterator it = channel_map.begin();
+         it != channel_map.end(); ++it)
+    {
+      const string& name = it->first;
+      const channel_info& info = it->second;
+
+      if (packet_list.find(info.packet_id) == packet_list.end())
+      {
+        packet_list[info.packet_id] = event->getPacket(info.packet_id);
+      }
+
+      Packet* packet = packet_list[info.packet_id];
+
+      if (!packet)
+      {
+        //          if (Verbosity() >= VERBOSITY_SOME)
+        cout
+            << "EventInfoSummary::process_event - failed to locate packet "
+            << info.packet_id << " from ";
+        event->identify();
+
+        Params.set_double_param(name, NAN);
+        continue;
+      }
+
+      const int ivalue = packet->iValue(info.offset);
+
+      const double dvalue = ivalue * info.calibration_const;
+
+      if (verbosity >= VERBOSITY_SOME)
+      {
+        cout << "EventInfoSummary::process_event - " << name << " = "
+             << dvalue << ", raw = " << ivalue << " @ packet "
+             << info.packet_id << ", offset " << info.offset << endl;
+      }
+
+      Params.set_double_param(name, dvalue);
+    }
+
+    for (map<int, Packet*>::iterator it = packet_list.begin();
+         it != packet_list.end(); ++it)
+    {
+      if (it->second)
+        delete it->second;
+    }
+
+    Params.SaveToNodeTree(topNode, eventinfo_node_name);
+
+    if (verbosity >= VERBOSITY_SOME)
+      Params.Print();
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_______________________________________
-void
-EventInfoSummary::CreateNodeTree(PHCompositeNode *topNode)
+void EventInfoSummary::CreateNodeTree(PHCompositeNode* topNode)
 {
   PHNodeIterator nodeItr(topNode);
 
@@ -263,34 +256,31 @@ EventInfoSummary::CreateNodeTree(PHCompositeNode *topNode)
   PHCompositeNode* dst_node =
       static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dst_node)
-    {
-      cout << "PHComposite node created: DST" << endl;
-      dst_node = new PHCompositeNode("DST");
-      topNode->addNode(dst_node);
-    }
+  {
+    cout << "PHComposite node created: DST" << endl;
+    dst_node = new PHCompositeNode("DST");
+    topNode->addNode(dst_node);
+  }
 
-  PdbParameterMap *nodeparams =
+  PdbParameterMap* nodeparams =
       findNode::getClass<PdbParameterMap>(dst_node, eventinfo_node_name);
   if (not nodeparams)
-    {
-      dst_node->addNode(new PHIODataNode<PdbParameterMap>(new PdbParameterMap(), eventinfo_node_name));
-    }
-
+  {
+    dst_node->addNode(new PHIODataNode<PdbParameterMap>(new PdbParameterMap(), eventinfo_node_name));
+  }
 }
 
 //___________________________________
-int
-EventInfoSummary::End(PHCompositeNode *topNode)
+int EventInfoSummary::End(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void
-EventInfoSummary::add_channel(const std::string & name, //! name of the channel
-    const int packet_id, //! packet id
-    const unsigned int offset, //! offset in packet data
-    const double calibration_const //! conversion constant from integer to meaningful value
-    )
+void EventInfoSummary::add_channel(const std::string& name,        //! name of the channel
+                                   const int packet_id,            //! packet id
+                                   const unsigned int offset,      //! offset in packet data
+                                   const double calibration_const  //! conversion constant from integer to meaningful value
+                                   )
 {
   channel_map.insert(make_pair(name, channel_info(packet_id, offset, calibration_const)));
 }

--- a/offline/packages/Prototype4/EventInfoSummary.C
+++ b/offline/packages/Prototype4/EventInfoSummary.C
@@ -1,6 +1,6 @@
 #include "EventInfoSummary.h"
-#include "RawTower_Prototype3.h"
-#include "PROTOTYPE3_FEM.h"
+#include "RawTower_Prototype4.h"
+#include "PROTOTYPE4_FEM.h"
 
 #include <calobase/RawTowerContainer.h>
 #include <ffaobjects/EventHeaderv1.h>
@@ -81,14 +81,14 @@ EventInfoSummary::process_event(PHCompositeNode *topNode)
               RawTowerContainer>(topNode, "TOWER_RAW_SPILL_WARBLER");
           assert(TOWER_RAW_SPILL_WARBLER);
 
-          RawTower_Prototype3 *raw_tower =
-              dynamic_cast<RawTower_Prototype3 *>(TOWER_RAW_SPILL_WARBLER->getTower(0));
+          RawTower_Prototype4 *raw_tower =
+              dynamic_cast<RawTower_Prototype4 *>(TOWER_RAW_SPILL_WARBLER->getTower(0));
           assert(raw_tower);
 
           accumulator_set<double, features<tag::variance>> acc;
 
           vector<double> vec_signal_samples;
-          for (int i = 0; i < RawTower_Prototype3::NSAMPLES; i++)
+          for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
             {
               acc(raw_tower->get_signal_samples(i));
             }

--- a/offline/packages/Prototype4/EventInfoSummary.C
+++ b/offline/packages/Prototype4/EventInfoSummary.C
@@ -1,0 +1,296 @@
+#include "EventInfoSummary.h"
+#include "RawTower_Prototype3.h"
+#include "PROTOTYPE3_FEM.h"
+
+#include <calobase/RawTowerContainer.h>
+#include <ffaobjects/EventHeaderv1.h>
+#include <Event/Event.h>
+#include <Event/EventTypes.h>
+#include <Event/packetConstants.h>
+#include <Event/packet.h>
+#include <pdbcalbase/PdbParameterMap.h>
+#include <phparameter/PHParameters.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics.hpp>
+
+#include <iostream>
+#include <string>
+#include <cassert>
+
+using namespace std;
+using namespace boost::accumulators;
+
+typedef PHIODataNode<PHObject> PHObjectNode_t;
+
+//____________________________________
+EventInfoSummary::EventInfoSummary() :
+    SubsysReco("EventInfoSummary"), eventinfo_node_name("EVENT_INFO")
+{
+}
+
+//____________________________________
+int
+EventInfoSummary::Init(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________
+int
+EventInfoSummary::InitRun(PHCompositeNode *topNode)
+{
+  CreateNodeTree(topNode);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________
+int
+EventInfoSummary::process_event(PHCompositeNode *topNode)
+{
+  Event* event = findNode::getClass<Event>(topNode, "PRDF");
+  if (event == NULL)
+    {
+      if (Verbosity() >= VERBOSITY_SOME)
+        cout << "EventInfoSummary::Process_Event - Event not found" << endl;
+      return Fun4AllReturnCodes::DISCARDEVENT;
+    }
+
+  // search for run info
+  if (event->getEvtType() != DATAEVENT)
+    return Fun4AllReturnCodes::EVENT_OK;
+  else // DATAEVENT
+    {
+      if (verbosity >= VERBOSITY_SOME)
+        {
+          cout << "EventInfoSummary::process_event - with DATAEVENT events ";
+          event->identify();
+        }
+
+      map<int, Packet*> packet_list;
+
+      PHParameters Params("EventInfo");
+
+      // spill indicator
+        {
+          RawTowerContainer* TOWER_RAW_SPILL_WARBLER = findNode::getClass<
+              RawTowerContainer>(topNode, "TOWER_RAW_SPILL_WARBLER");
+          assert(TOWER_RAW_SPILL_WARBLER);
+
+          RawTower_Prototype3 *raw_tower =
+              dynamic_cast<RawTower_Prototype3 *>(TOWER_RAW_SPILL_WARBLER->getTower(0));
+          assert(raw_tower);
+
+          accumulator_set<double, features<tag::variance>> acc;
+
+          vector<double> vec_signal_samples;
+          for (int i = 0; i < RawTower_Prototype3::NSAMPLES; i++)
+            {
+              acc(raw_tower->get_signal_samples(i));
+            }
+
+          const double warbler_rms = variance(acc);
+          const bool is_in_spill = warbler_rms > (1000*1000);
+          Params.set_double_param("beam_SPILL_WARBLER_RMS", warbler_rms);
+          Params.set_double_param("beam_Is_In_Spill", is_in_spill);
+          Params.set_int_param("beam_Is_In_Spill", is_in_spill);
+        }
+
+      // energy sums
+        {
+          RawTowerContainer* TOWER_CALIB_CEMC = findNode::getClass<
+              RawTowerContainer>(topNode, "TOWER_CALIB_CEMC");
+          assert(TOWER_CALIB_CEMC);
+
+          RawTowerContainer* TOWER_CALIB_LG_HCALIN = findNode::getClass<
+              RawTowerContainer>(topNode, "TOWER_CALIB_LG_HCALIN");
+
+          RawTowerContainer* TOWER_CALIB_LG_HCALOUT = findNode::getClass<
+              RawTowerContainer>(topNode, "TOWER_CALIB_LG_HCALOUT");
+
+          // process inner HCAL
+          if (TOWER_CALIB_CEMC)
+            {
+              double sum_energy_calib = 0;
+
+              auto range = TOWER_CALIB_CEMC->getTowers();
+              for (auto it = range.first; it != range.second; ++it)
+                {
+
+                  RawTower* tower = it->second;
+                  assert(tower);
+
+                  const int col = tower->get_bineta();
+                  const int row = tower->get_binphi();
+
+                  if (col < 0 or col >= 8)
+                    continue;
+                  if (row < 0 or row >= 8)
+                    continue;
+
+                  const double energy_calib = tower->get_energy();
+                  sum_energy_calib += energy_calib;
+
+                } //       for (auto it = range.first; it != range.second; ++it)
+              Params.set_double_param("CALIB_CEMC_Sum", sum_energy_calib);
+            } // process inner HCAL
+
+          // process inner HCAL
+          if (TOWER_CALIB_LG_HCALIN)
+            {
+              double sum_energy_calib = 0;
+
+              auto range = TOWER_CALIB_LG_HCALIN->getTowers();
+              for (auto it = range.first; it != range.second; ++it)
+                {
+
+                  RawTower* tower = it->second;
+                  assert(tower);
+
+                  const int col = tower->get_bineta();
+                  const int row = tower->get_binphi();
+
+                  if (col < 0 or col >= 4)
+                    continue;
+                  if (row < 0 or row >= 4)
+                    continue;
+
+                  const double energy_calib = tower->get_energy();
+                  sum_energy_calib += energy_calib;
+
+                } //       for (auto it = range.first; it != range.second; ++it)
+              Params.set_double_param("CALIB_LG_HCALIN_Sum", sum_energy_calib);
+            } // process inner HCAL
+
+          // process outer HCAL
+          if (TOWER_CALIB_LG_HCALOUT)
+            {
+              double sum_energy_calib = 0;
+
+              auto range = TOWER_CALIB_LG_HCALOUT->getTowers();
+              for (auto it = range.first; it != range.second; ++it)
+                {
+
+                  RawTower* tower = it->second;
+                  assert(tower);
+
+                  const int col = tower->get_bineta();
+                  const int row = tower->get_binphi();
+
+                  if (col < 0 or col >= 4)
+                    continue;
+                  if (row < 0 or row >= 4)
+                    continue;
+
+                  const double energy_calib = tower->get_energy();
+                  sum_energy_calib += energy_calib;
+
+                } //       for (auto it = range.first; it != range.second; ++it)
+
+              Params.set_double_param("CALIB_LG_HCALOUT_Sum", sum_energy_calib);
+            } // process outer HCAL
+
+        }
+
+      // generic packets
+      for (typ_channel_map::const_iterator it = channel_map.begin();
+          it != channel_map.end(); ++it)
+        {
+          const string & name = it->first;
+          const channel_info & info = it->second;
+
+          if (packet_list.find(info.packet_id) == packet_list.end())
+            {
+              packet_list[info.packet_id] = event->getPacket(info.packet_id);
+            }
+
+          Packet * packet = packet_list[info.packet_id];
+
+          if (!packet)
+            {
+//          if (Verbosity() >= VERBOSITY_SOME)
+              cout
+                  << "EventInfoSummary::process_event - failed to locate packet "
+                  << info.packet_id << " from ";
+              event->identify();
+
+              Params.set_double_param(name, NAN);
+              continue;
+            }
+
+          const int ivalue = packet->iValue(info.offset);
+
+          const double dvalue = ivalue * info.calibration_const;
+
+          if (verbosity >= VERBOSITY_SOME)
+            {
+              cout << "EventInfoSummary::process_event - " << name << " = "
+                  << dvalue << ", raw = " << ivalue << " @ packet "
+                  << info.packet_id << ", offset " << info.offset << endl;
+            }
+
+          Params.set_double_param(name, dvalue);
+        }
+
+      for (map<int, Packet*>::iterator it = packet_list.begin();
+          it != packet_list.end(); ++it)
+        {
+          if (it->second)
+            delete it->second;
+        }
+
+      Params.SaveToNodeTree(topNode, eventinfo_node_name);
+
+      if (verbosity >= VERBOSITY_SOME)
+        Params.Print();
+    }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_______________________________________
+void
+EventInfoSummary::CreateNodeTree(PHCompositeNode *topNode)
+{
+  PHNodeIterator nodeItr(topNode);
+
+  PHNodeIterator iter(topNode);
+
+  //DST node
+  PHCompositeNode* dst_node =
+      static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dst_node)
+    {
+      cout << "PHComposite node created: DST" << endl;
+      dst_node = new PHCompositeNode("DST");
+      topNode->addNode(dst_node);
+    }
+
+  PdbParameterMap *nodeparams =
+      findNode::getClass<PdbParameterMap>(dst_node, eventinfo_node_name);
+  if (not nodeparams)
+    {
+      dst_node->addNode(new PHIODataNode<PdbParameterMap>(new PdbParameterMap(), eventinfo_node_name));
+    }
+
+}
+
+//___________________________________
+int
+EventInfoSummary::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void
+EventInfoSummary::add_channel(const std::string & name, //! name of the channel
+    const int packet_id, //! packet id
+    const unsigned int offset, //! offset in packet data
+    const double calibration_const //! conversion constant from integer to meaningful value
+    )
+{
+  channel_map.insert(make_pair(name, channel_info(packet_id, offset, calibration_const)));
+}

--- a/offline/packages/Prototype4/EventInfoSummary.h
+++ b/offline/packages/Prototype4/EventInfoSummary.h
@@ -1,0 +1,66 @@
+#ifndef __CaloUnpackPRDFF__
+#define __CaloUnpackPRDFF__
+
+#include <fun4all/SubsysReco.h>
+#include <phool/PHObject.h>
+#include <string>
+#include <map>
+#include <utility>
+
+class Event;
+class Packet;
+class RawTowerContainer;
+class RawTower;
+
+class EventInfoSummary : public SubsysReco
+{
+public:
+  EventInfoSummary();
+
+  int
+  Init(PHCompositeNode *topNode);
+
+  int
+  InitRun(PHCompositeNode *topNode);
+
+  int
+  process_event(PHCompositeNode *topNode);
+
+  int
+  End(PHCompositeNode *topNode);
+
+  void
+  CreateNodeTree(PHCompositeNode *topNode);
+
+  //! add stuff to be unpacked
+  void
+  add_channel(const std::string & name, //! name of the channel
+      const int packet_id, //! packet id
+      const unsigned int offset, //! offset in packet data
+      const double calibration_const = +1 //! conversion constant from integer to meaningful value
+      );
+
+private:
+
+  class channel_info
+  {
+  public:
+    channel_info(int p, unsigned int o, double c) :
+        packet_id(p), offset(o), calibration_const(c)
+    {
+    }
+
+    int packet_id;
+    unsigned offset;
+    double calibration_const;
+  };
+
+  //! list of channel name -> channel info
+  typedef std::map<std::string, channel_info> typ_channel_map;
+
+  typ_channel_map channel_map;
+
+  std::string eventinfo_node_name;
+};
+
+#endif //**CaloUnpackPRDFF**//

--- a/offline/packages/Prototype4/EventInfoSummary.h
+++ b/offline/packages/Prototype4/EventInfoSummary.h
@@ -3,8 +3,8 @@
 
 #include <fun4all/SubsysReco.h>
 #include <phool/PHObject.h>
-#include <string>
 #include <map>
+#include <string>
 #include <utility>
 
 class Event;
@@ -14,39 +14,36 @@ class RawTower;
 
 class EventInfoSummary : public SubsysReco
 {
-public:
+ public:
   EventInfoSummary();
 
-  int
-  Init(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode);
 
-  int
-  InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
 
-  int
-  process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
 
-  int
-  End(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
 
   void
   CreateNodeTree(PHCompositeNode *topNode);
 
   //! add stuff to be unpacked
   void
-  add_channel(const std::string & name, //! name of the channel
-      const int packet_id, //! packet id
-      const unsigned int offset, //! offset in packet data
-      const double calibration_const = +1 //! conversion constant from integer to meaningful value
-      );
+  add_channel(const std::string &name,             //! name of the channel
+              const int packet_id,                 //! packet id
+              const unsigned int offset,           //! offset in packet data
+              const double calibration_const = +1  //! conversion constant from integer to meaningful value
+              );
 
-private:
-
+ private:
   class channel_info
   {
-  public:
-    channel_info(int p, unsigned int o, double c) :
-        packet_id(p), offset(o), calibration_const(c)
+   public:
+    channel_info(int p, unsigned int o, double c)
+      : packet_id(p)
+      , offset(o)
+      , calibration_const(c)
     {
     }
 
@@ -63,4 +60,4 @@ private:
   std::string eventinfo_node_name;
 };
 
-#endif //**CaloUnpackPRDFF**//
+#endif  //**CaloUnpackPRDFF**//

--- a/offline/packages/Prototype4/EventInfoSummaryLinkDef.h
+++ b/offline/packages/Prototype4/EventInfoSummaryLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class EventInfoSummary-!;
+
+#endif

--- a/offline/packages/Prototype4/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.C
@@ -6,7 +6,6 @@
 #include <Event/EventTypes.h>
 #include <Event/packet.h>
 #include <Event/packetConstants.h>
-#include <Event/packet_hbd_fpgashort.h>
 #include <calobase/RawTowerContainer.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
@@ -57,10 +56,10 @@ int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
   if (verbosity >= VERBOSITY_SOME)
     _event->identify();
 
-  map<int, Packet_hbd_fpgashort *> packet_list;
+  map<int, Packet *> packet_list;
 
-  for (hbd_channel_map::const_iterator it = _hbd_channel_map.begin();
-       it != _hbd_channel_map.end(); ++it)
+  for (channel_map::const_iterator it = _channel_map.begin();
+       it != _channel_map.end(); ++it)
   {
     const int packet_id = it->first.first;
     const int channel = it->first.second;
@@ -69,10 +68,10 @@ int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
     if (packet_list.find(packet_id) == packet_list.end())
     {
       packet_list[packet_id] =
-          dynamic_cast<Packet_hbd_fpgashort *>(_event->getPacket(packet_id));
+          dynamic_cast<Packet *>(_event->getPacket(packet_id));
     }
 
-    Packet_hbd_fpgashort *packet = packet_list[packet_id];
+    Packet *packet = packet_list[packet_id];
 
     if (!packet)
     {
@@ -83,7 +82,7 @@ int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
     }
     assert(packet);
 
-    packet->setNumSamples(PROTOTYPE4_FEM::NSAMPLES);
+    //    packet->setNumSamples(PROTOTYPE4_FEM::NSAMPLES);
 
     RawTower_Prototype4 *tower =
         dynamic_cast<RawTower_Prototype4 *>(_towers->getTower(tower_id));
@@ -100,7 +99,7 @@ int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
     }
   }
 
-  for (map<int, Packet_hbd_fpgashort *>::iterator it = packet_list.begin();
+  for (map<int, Packet *>::iterator it = packet_list.begin();
        it != packet_list.end(); ++it)
   {
     if (it->second)
@@ -153,14 +152,14 @@ void GenericUnpackPRDF::add_channel(const int packet_id,  //! packet id
                                     const int tower_id    //! output tower id
                                     )
 {
-  hbd_channel_typ hbd_channel(packet_id, channel);
+  channel_typ hbd_channel(packet_id, channel);
 
-  if (_hbd_channel_map.find(hbd_channel) != _hbd_channel_map.end())
+  if (_channel_map.find(hbd_channel) != _channel_map.end())
   {
     cout << "GenericUnpackPRDF::add_channel - packet " << packet_id
          << ", channel " << channel << " is already registered as tower "
-         << _hbd_channel_map.find(hbd_channel)->second << endl;
+         << _channel_map.find(hbd_channel)->second << endl;
     exit(12);
   }
-  _hbd_channel_map[hbd_channel] = tower_id;
+  _channel_map[hbd_channel] = tower_id;
 }

--- a/offline/packages/Prototype4/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.C
@@ -1,0 +1,170 @@
+#include "RawTower_Prototype3.h"
+#include "PROTOTYPE3_FEM.h"
+#include "GenericUnpackPRDF.h"
+
+#include <Event/Event.h>
+#include <Event/EventTypes.h>
+#include <Event/packetConstants.h>
+#include <Event/packet.h>
+#include <Event/packet_hbd_fpgashort.h>
+#include <calobase/RawTowerContainer.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <iostream>
+#include <string>
+#include <cassert>
+
+using namespace std;
+
+//____________________________________
+GenericUnpackPRDF::GenericUnpackPRDF(const string & detector) :
+    SubsysReco("GenericUnpackPRDF_" + detector), //
+    _detector(detector),
+    /*Event**/_event(NULL),
+    /*PHCompositeNode **/_towers(NULL)
+{
+}
+
+//____________________________________
+int
+GenericUnpackPRDF::Init(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________
+int
+GenericUnpackPRDF::InitRun(PHCompositeNode *topNode)
+{
+  CreateNodeTree(topNode);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________
+int
+GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
+{
+  _event = findNode::getClass<Event>(topNode, "PRDF");
+  if (_event == NULL)
+    {
+      if (Verbosity() >= VERBOSITY_SOME)
+        cout << "GenericUnpackPRDF::Process_Event - Event not found" << endl;
+      return Fun4AllReturnCodes::DISCARDEVENT;
+    }
+
+  if (verbosity >= VERBOSITY_SOME)
+    _event->identify();
+
+  map<int, Packet_hbd_fpgashort*> packet_list;
+
+  for (hbd_channel_map::const_iterator it = _hbd_channel_map.begin();
+      it != _hbd_channel_map.end(); ++it)
+    {
+
+      const int packet_id = it->first.first;
+      const int channel = it->first.second;
+      const int tower_id = it->second;
+
+      if (packet_list.find(packet_id) == packet_list.end())
+        {
+          packet_list[packet_id] =
+              dynamic_cast<Packet_hbd_fpgashort*>(_event->getPacket(packet_id));
+        }
+
+      Packet_hbd_fpgashort * packet = packet_list[packet_id];
+
+      if (!packet)
+        {
+//          if (Verbosity() >= VERBOSITY_SOME)
+          cout << "GenericUnpackPRDF::process_event - failed to locate packet "
+              << packet_id << endl;
+          continue;
+        }
+      assert(packet);
+
+      packet->setNumSamples(PROTOTYPE3_FEM::NSAMPLES);
+
+      RawTower_Prototype3 *tower =
+          dynamic_cast<RawTower_Prototype3*>(_towers->getTower(tower_id));
+      if (!tower)
+        {
+          tower = new RawTower_Prototype3();
+          tower->set_energy(NAN);
+          _towers->AddTower(tower_id, tower);
+        }
+      tower->set_HBD_channel_number(channel);
+      for (int isamp = 0; isamp < PROTOTYPE3_FEM::NSAMPLES; isamp++)
+        {
+          tower->set_signal_samples(isamp, packet->iValue(channel, isamp));
+        }
+    }
+
+  for (map<int, Packet_hbd_fpgashort*>::iterator it = packet_list.begin();
+      it != packet_list.end(); ++it)
+    {
+      if (it->second)
+        delete it->second;
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_______________________________________
+void
+GenericUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
+{
+  PHNodeIterator nodeItr(topNode);
+  //DST node
+  PHCompositeNode * dst_node = static_cast<PHCompositeNode*>(nodeItr.findFirst(
+      "PHCompositeNode", "DST"));
+  if (!dst_node)
+    {
+      cout << "PHComposite node created: DST" << endl;
+      dst_node = new PHCompositeNode("DST");
+      topNode->addNode(dst_node);
+    }
+
+  //DATA nodes
+  PHCompositeNode * data_node = static_cast<PHCompositeNode*>(nodeItr.findFirst(
+      "PHCompositeNode", "RAW_DATA"));
+  if (!data_node)
+    {
+      if (Verbosity())
+        cout << "PHComposite node created: RAW_DATA" << endl;
+      data_node = new PHCompositeNode("RAW_DATA");
+      dst_node->addNode(data_node);
+    }
+
+  //output as towers
+  _towers = new RawTowerContainer(RawTowerDefs::NONE);
+  PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers,
+      "TOWER_RAW_" + _detector, "PHObject");
+  data_node->addNode(towerNode);
+}
+
+//___________________________________
+int
+GenericUnpackPRDF::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void
+GenericUnpackPRDF::add_channel(const int packet_id, //! packet id
+    const int channel, //! channel in packet
+    const int tower_id //! output tower id
+    )
+{
+  hbd_channel_typ hbd_channel(packet_id, channel);
+
+  if (_hbd_channel_map.find(hbd_channel) != _hbd_channel_map.end())
+    {
+      cout << "GenericUnpackPRDF::add_channel - packet " << packet_id
+          << ", channel " << channel << " is already registered as tower "
+          << _hbd_channel_map.find(hbd_channel)->second << endl;
+      exit(12);
+    }
+  _hbd_channel_map[hbd_channel] = tower_id;
+}

--- a/offline/packages/Prototype4/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.C
@@ -56,6 +56,10 @@ int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
   if (verbosity >= VERBOSITY_SOME)
     _event->identify();
 
+  // search for data event
+  if (_event->getEvtType() != DATAEVENT)
+    return Fun4AllReturnCodes::EVENT_OK;
+
   map<int, Packet *> packet_list;
 
   for (channel_map::const_iterator it = _channel_map.begin();
@@ -69,6 +73,13 @@ int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
     {
       packet_list[packet_id] =
           dynamic_cast<Packet *>(_event->getPacket(packet_id));
+
+      if (packet_list[packet_id] and Verbosity() >= VERBOSITY_MORE)
+      {
+        cout << "GenericUnpackPRDF::process_event - open packet " << packet_id << ":" << endl;
+//        packet_list[packet_id]->identify(cout);
+        packet_list[packet_id]->dump(cout);
+      }
     }
 
     Packet *packet = packet_list[packet_id];

--- a/offline/packages/Prototype4/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.C
@@ -1,170 +1,166 @@
-#include "RawTower_Prototype4.h"
-#include "PROTOTYPE4_FEM.h"
 #include "GenericUnpackPRDF.h"
+#include "PROTOTYPE4_FEM.h"
+#include "RawTower_Prototype4.h"
 
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
-#include <Event/packetConstants.h>
 #include <Event/packet.h>
+#include <Event/packetConstants.h>
 #include <Event/packet_hbd_fpgashort.h>
 #include <calobase/RawTowerContainer.h>
-#include <phool/PHCompositeNode.h>
-#include <phool/phool.h>
-#include <phool/getClass.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <cassert>
 #include <iostream>
 #include <string>
-#include <cassert>
 
 using namespace std;
 
 //____________________________________
-GenericUnpackPRDF::GenericUnpackPRDF(const string & detector) :
-    SubsysReco("GenericUnpackPRDF_" + detector), //
-    _detector(detector),
-    /*Event**/_event(NULL),
-    /*PHCompositeNode **/_towers(NULL)
+GenericUnpackPRDF::GenericUnpackPRDF(const string &detector)
+  : SubsysReco("GenericUnpackPRDF_" + detector)
+  ,  //
+  _detector(detector)
+  ,
+  /*Event**/ _event(NULL)
+  ,
+  /*PHCompositeNode **/ _towers(NULL)
 {
 }
 
 //____________________________________
-int
-GenericUnpackPRDF::Init(PHCompositeNode *topNode)
+int GenericUnpackPRDF::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_____________________________________
-int
-GenericUnpackPRDF::InitRun(PHCompositeNode *topNode)
+int GenericUnpackPRDF::InitRun(PHCompositeNode *topNode)
 {
   CreateNodeTree(topNode);
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________
-int
-GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
+int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
 {
   _event = findNode::getClass<Event>(topNode, "PRDF");
   if (_event == NULL)
-    {
-      if (Verbosity() >= VERBOSITY_SOME)
-        cout << "GenericUnpackPRDF::Process_Event - Event not found" << endl;
-      return Fun4AllReturnCodes::DISCARDEVENT;
-    }
+  {
+    if (Verbosity() >= VERBOSITY_SOME)
+      cout << "GenericUnpackPRDF::Process_Event - Event not found" << endl;
+    return Fun4AllReturnCodes::DISCARDEVENT;
+  }
 
   if (verbosity >= VERBOSITY_SOME)
     _event->identify();
 
-  map<int, Packet_hbd_fpgashort*> packet_list;
+  map<int, Packet_hbd_fpgashort *> packet_list;
 
   for (hbd_channel_map::const_iterator it = _hbd_channel_map.begin();
-      it != _hbd_channel_map.end(); ++it)
+       it != _hbd_channel_map.end(); ++it)
+  {
+    const int packet_id = it->first.first;
+    const int channel = it->first.second;
+    const int tower_id = it->second;
+
+    if (packet_list.find(packet_id) == packet_list.end())
     {
-
-      const int packet_id = it->first.first;
-      const int channel = it->first.second;
-      const int tower_id = it->second;
-
-      if (packet_list.find(packet_id) == packet_list.end())
-        {
-          packet_list[packet_id] =
-              dynamic_cast<Packet_hbd_fpgashort*>(_event->getPacket(packet_id));
-        }
-
-      Packet_hbd_fpgashort * packet = packet_list[packet_id];
-
-      if (!packet)
-        {
-//          if (Verbosity() >= VERBOSITY_SOME)
-          cout << "GenericUnpackPRDF::process_event - failed to locate packet "
-              << packet_id << endl;
-          continue;
-        }
-      assert(packet);
-
-      packet->setNumSamples(PROTOTYPE4_FEM::NSAMPLES);
-
-      RawTower_Prototype4 *tower =
-          dynamic_cast<RawTower_Prototype4*>(_towers->getTower(tower_id));
-      if (!tower)
-        {
-          tower = new RawTower_Prototype4();
-          tower->set_energy(NAN);
-          _towers->AddTower(tower_id, tower);
-        }
-      tower->set_HBD_channel_number(channel);
-      for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
-        {
-          tower->set_signal_samples(isamp, packet->iValue(channel, isamp));
-        }
+      packet_list[packet_id] =
+          dynamic_cast<Packet_hbd_fpgashort *>(_event->getPacket(packet_id));
     }
 
-  for (map<int, Packet_hbd_fpgashort*>::iterator it = packet_list.begin();
-      it != packet_list.end(); ++it)
+    Packet_hbd_fpgashort *packet = packet_list[packet_id];
+
+    if (!packet)
     {
-      if (it->second)
-        delete it->second;
+      //          if (Verbosity() >= VERBOSITY_SOME)
+      cout << "GenericUnpackPRDF::process_event - failed to locate packet "
+           << packet_id << endl;
+      continue;
     }
+    assert(packet);
+
+    packet->setNumSamples(PROTOTYPE4_FEM::NSAMPLES);
+
+    RawTower_Prototype4 *tower =
+        dynamic_cast<RawTower_Prototype4 *>(_towers->getTower(tower_id));
+    if (!tower)
+    {
+      tower = new RawTower_Prototype4();
+      tower->set_energy(NAN);
+      _towers->AddTower(tower_id, tower);
+    }
+    tower->set_HBD_channel_number(channel);
+    for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
+    {
+      tower->set_signal_samples(isamp, packet->iValue(channel, isamp));
+    }
+  }
+
+  for (map<int, Packet_hbd_fpgashort *>::iterator it = packet_list.begin();
+       it != packet_list.end(); ++it)
+  {
+    if (it->second)
+      delete it->second;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_______________________________________
-void
-GenericUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
+void GenericUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
 {
   PHNodeIterator nodeItr(topNode);
   //DST node
-  PHCompositeNode * dst_node = static_cast<PHCompositeNode*>(nodeItr.findFirst(
+  PHCompositeNode *dst_node = static_cast<PHCompositeNode *>(nodeItr.findFirst(
       "PHCompositeNode", "DST"));
   if (!dst_node)
-    {
-      cout << "PHComposite node created: DST" << endl;
-      dst_node = new PHCompositeNode("DST");
-      topNode->addNode(dst_node);
-    }
+  {
+    cout << "PHComposite node created: DST" << endl;
+    dst_node = new PHCompositeNode("DST");
+    topNode->addNode(dst_node);
+  }
 
   //DATA nodes
-  PHCompositeNode * data_node = static_cast<PHCompositeNode*>(nodeItr.findFirst(
+  PHCompositeNode *data_node = static_cast<PHCompositeNode *>(nodeItr.findFirst(
       "PHCompositeNode", "RAW_DATA"));
   if (!data_node)
-    {
-      if (Verbosity())
-        cout << "PHComposite node created: RAW_DATA" << endl;
-      data_node = new PHCompositeNode("RAW_DATA");
-      dst_node->addNode(data_node);
-    }
+  {
+    if (Verbosity())
+      cout << "PHComposite node created: RAW_DATA" << endl;
+    data_node = new PHCompositeNode("RAW_DATA");
+    dst_node->addNode(data_node);
+  }
 
   //output as towers
   _towers = new RawTowerContainer(RawTowerDefs::NONE);
   PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers,
-      "TOWER_RAW_" + _detector, "PHObject");
+                                                                 "TOWER_RAW_" + _detector, "PHObject");
   data_node->addNode(towerNode);
 }
 
 //___________________________________
-int
-GenericUnpackPRDF::End(PHCompositeNode *topNode)
+int GenericUnpackPRDF::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void
-GenericUnpackPRDF::add_channel(const int packet_id, //! packet id
-    const int channel, //! channel in packet
-    const int tower_id //! output tower id
-    )
+void GenericUnpackPRDF::add_channel(const int packet_id,  //! packet id
+                                    const int channel,    //! channel in packet
+                                    const int tower_id    //! output tower id
+                                    )
 {
   hbd_channel_typ hbd_channel(packet_id, channel);
 
   if (_hbd_channel_map.find(hbd_channel) != _hbd_channel_map.end())
-    {
-      cout << "GenericUnpackPRDF::add_channel - packet " << packet_id
-          << ", channel " << channel << " is already registered as tower "
-          << _hbd_channel_map.find(hbd_channel)->second << endl;
-      exit(12);
-    }
+  {
+    cout << "GenericUnpackPRDF::add_channel - packet " << packet_id
+         << ", channel " << channel << " is already registered as tower "
+         << _hbd_channel_map.find(hbd_channel)->second << endl;
+    exit(12);
+  }
   _hbd_channel_map[hbd_channel] = tower_id;
 }

--- a/offline/packages/Prototype4/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.C
@@ -1,5 +1,5 @@
-#include "RawTower_Prototype3.h"
-#include "PROTOTYPE3_FEM.h"
+#include "RawTower_Prototype4.h"
+#include "PROTOTYPE4_FEM.h"
 #include "GenericUnpackPRDF.h"
 
 #include <Event/Event.h>
@@ -84,18 +84,18 @@ GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
         }
       assert(packet);
 
-      packet->setNumSamples(PROTOTYPE3_FEM::NSAMPLES);
+      packet->setNumSamples(PROTOTYPE4_FEM::NSAMPLES);
 
-      RawTower_Prototype3 *tower =
-          dynamic_cast<RawTower_Prototype3*>(_towers->getTower(tower_id));
+      RawTower_Prototype4 *tower =
+          dynamic_cast<RawTower_Prototype4*>(_towers->getTower(tower_id));
       if (!tower)
         {
-          tower = new RawTower_Prototype3();
+          tower = new RawTower_Prototype4();
           tower->set_energy(NAN);
           _towers->AddTower(tower_id, tower);
         }
       tower->set_HBD_channel_number(channel);
-      for (int isamp = 0; isamp < PROTOTYPE3_FEM::NSAMPLES; isamp++)
+      for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
         {
           tower->set_signal_samples(isamp, packet->iValue(channel, isamp));
         }

--- a/offline/packages/Prototype4/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.C
@@ -106,7 +106,7 @@ int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
     tower->set_HBD_channel_number(channel);
     for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
     {
-      tower->set_signal_samples(isamp, packet->iValue(channel, isamp));
+      tower->set_signal_samples(isamp, (packet->iValue(channel, isamp)) & PROTOTYPE4_FEM::ADC_DATA_MASK);
     }
   }
 

--- a/offline/packages/Prototype4/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.C
@@ -106,7 +106,7 @@ int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
     tower->set_HBD_channel_number(channel);
     for (int isamp = 0; isamp < PROTOTYPE4_FEM::NSAMPLES; isamp++)
     {
-      tower->set_signal_samples(isamp, (packet->iValue(channel, isamp)) & PROTOTYPE4_FEM::ADC_DATA_MASK);
+      tower->set_signal_samples(isamp, (packet->iValue( isamp, channel)) & PROTOTYPE4_FEM::ADC_DATA_MASK);
     }
   }
 

--- a/offline/packages/Prototype4/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.C
@@ -71,8 +71,7 @@ int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
 
     if (packet_list.find(packet_id) == packet_list.end())
     {
-      packet_list[packet_id] =
-          dynamic_cast<Packet *>(_event->getPacket(packet_id));
+      packet_list[packet_id] =_event->getPacket(packet_id);
 
       if (packet_list[packet_id] and Verbosity() >= VERBOSITY_MORE)
       {

--- a/offline/packages/Prototype4/GenericUnpackPRDF.h
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.h
@@ -1,0 +1,57 @@
+#ifndef __CaloUnpackPRDFF__
+#define __CaloUnpackPRDFF__
+
+
+#include <fun4all/SubsysReco.h>
+#include <phool/PHObject.h>
+#include <string>
+#include <map>
+#include <utility>
+
+class Event;
+class Packet;
+class RawTowerContainer;
+class RawTower;
+
+
+class GenericUnpackPRDF : public SubsysReco
+{
+ public:
+  GenericUnpackPRDF(const std::string & detector);
+
+  int Init(PHCompositeNode *topNode);
+
+  int InitRun(PHCompositeNode *topNode);
+
+  int process_event(PHCompositeNode *topNode);
+
+  int End(PHCompositeNode *topNode);
+  
+  void CreateNodeTree(PHCompositeNode *topNode);
+
+  //! add stuff to be unpacked
+  void add_channel(
+      const int packet_id, //! packet id
+      const int channel, //! channel in packet
+      const int tower_id //! output tower id
+  );
+
+ private:
+  std::string _detector;
+
+  //!packet_id, channel number to define a hbd_channel
+  typedef std::pair<int, int> hbd_channel_typ;
+
+  //! list of hbd_channel -> channel id which is also tower id
+  typedef std::map<hbd_channel_typ, int> hbd_channel_map;
+
+  hbd_channel_map _hbd_channel_map;
+
+  Event* _event;
+
+  //output -> Towers
+  RawTowerContainer* _towers;
+};
+
+
+#endif //**CaloUnpackPRDFF**//

--- a/offline/packages/Prototype4/GenericUnpackPRDF.h
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.h
@@ -1,11 +1,10 @@
 #ifndef __CaloUnpackPRDFF__
 #define __CaloUnpackPRDFF__
 
-
 #include <fun4all/SubsysReco.h>
 #include <phool/PHObject.h>
-#include <string>
 #include <map>
+#include <string>
 #include <utility>
 
 class Event;
@@ -13,11 +12,10 @@ class Packet;
 class RawTowerContainer;
 class RawTower;
 
-
 class GenericUnpackPRDF : public SubsysReco
 {
  public:
-  GenericUnpackPRDF(const std::string & detector);
+  GenericUnpackPRDF(const std::string &detector);
 
   int Init(PHCompositeNode *topNode);
 
@@ -26,15 +24,15 @@ class GenericUnpackPRDF : public SubsysReco
   int process_event(PHCompositeNode *topNode);
 
   int End(PHCompositeNode *topNode);
-  
+
   void CreateNodeTree(PHCompositeNode *topNode);
 
   //! add stuff to be unpacked
   void add_channel(
-      const int packet_id, //! packet id
-      const int channel, //! channel in packet
-      const int tower_id //! output tower id
-  );
+      const int packet_id,  //! packet id
+      const int channel,    //! channel in packet
+      const int tower_id    //! output tower id
+      );
 
  private:
   std::string _detector;
@@ -47,11 +45,10 @@ class GenericUnpackPRDF : public SubsysReco
 
   hbd_channel_map _hbd_channel_map;
 
-  Event* _event;
+  Event *_event;
 
   //output -> Towers
-  RawTowerContainer* _towers;
+  RawTowerContainer *_towers;
 };
 
-
-#endif //**CaloUnpackPRDFF**//
+#endif  //**CaloUnpackPRDFF**//

--- a/offline/packages/Prototype4/GenericUnpackPRDF.h
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.h
@@ -38,12 +38,12 @@ class GenericUnpackPRDF : public SubsysReco
   std::string _detector;
 
   //!packet_id, channel number to define a hbd_channel
-  typedef std::pair<int, int> hbd_channel_typ;
+  typedef std::pair<int, int> channel_typ;
 
   //! list of hbd_channel -> channel id which is also tower id
-  typedef std::map<hbd_channel_typ, int> hbd_channel_map;
+  typedef std::map<channel_typ, int> channel_map;
 
-  hbd_channel_map _hbd_channel_map;
+  channel_map _channel_map;
 
   Event *_event;
 

--- a/offline/packages/Prototype4/GenericUnpackPRDFLinkDef.h
+++ b/offline/packages/Prototype4/GenericUnpackPRDFLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class GenericUnpackPRDF-!;
+
+#endif

--- a/offline/packages/Prototype4/Makefile.am
+++ b/offline/packages/Prototype4/Makefile.am
@@ -5,21 +5,21 @@ AM_CPPFLAGS = \
   -I$(OFFLINE_MAIN)/include \
   -I`root-config --incdir`
 
-libPrototype3_la_LDFLAGS = \
+libPrototype4_la_LDFLAGS = \
   -nodefaultlibs \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
   `root-config --libs`
 
 lib_LTLIBRARIES = \
-  libPrototype3.la
+  libPrototype4.la
 
 pkginclude_HEADERS = \
   RawTower_Prototype4.h \
   RawTower_Temperature.h \
   PROTOTYPE4_FEM.h
 
-libPrototype3_la_SOURCES = \
+libPrototype4_la_SOURCES = \
   RawTower_Prototype4.cc \
   RawTower_Prototype4Dict.C \
   Prototype4DSTReader.cc \
@@ -41,7 +41,7 @@ libPrototype3_la_SOURCES = \
   RawTower_Temperature.cc \
   RawTower_TemperatureDict.C
 
-libPrototype3_la_LIBADD = \
+libPrototype4_la_LIBADD = \
   -lSubsysReco \
   -lphool \
   -lfun4all \
@@ -55,7 +55,7 @@ noinst_PROGRAMS = \
   testexternals
 
 testexternals_LDADD = \
-  libPrototype3.la
+  libPrototype4.la
 
 testexternals.C:
 	echo "//*** this is a generated file. Do not commit, do not edit" > $@

--- a/offline/packages/Prototype4/Makefile.am
+++ b/offline/packages/Prototype4/Makefile.am
@@ -15,15 +15,15 @@ lib_LTLIBRARIES = \
   libPrototype3.la
 
 pkginclude_HEADERS = \
-  RawTower_Prototype3.h \
+  RawTower_Prototype4.h \
   RawTower_Temperature.h \
-  PROTOTYPE3_FEM.h
+  PROTOTYPE4_FEM.h
 
 libPrototype3_la_SOURCES = \
-  RawTower_Prototype3.cc \
-  RawTower_Prototype3Dict.C \
-  Prototype3DSTReader.cc \
-  Prototype3DSTReaderDict.C \
+  RawTower_Prototype4.cc \
+  RawTower_Prototype4Dict.C \
+  Prototype4DSTReader.cc \
+  Prototype4DSTReaderDict.C \
   CaloUnpackPRDF.C \
   CaloUnpackPRDFDict.C \
   TempInfoUnpackPRDF.C \
@@ -36,8 +36,8 @@ libPrototype3_la_SOURCES = \
   CaloCalibrationDict.C \
   GenericUnpackPRDF.C \
   GenericUnpackPRDFDict.C \
-  PROTOTYPE3_FEM.C \
-  PROTOTYPE3_FEMDict.C \
+  PROTOTYPE4_FEM.C \
+  PROTOTYPE4_FEMDict.C \
   RawTower_Temperature.cc \
   RawTower_TemperatureDict.C
 

--- a/offline/packages/Prototype4/Makefile.am
+++ b/offline/packages/Prototype4/Makefile.am
@@ -1,0 +1,76 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -I`root-config --incdir`
+
+libPrototype3_la_LDFLAGS = \
+  -nodefaultlibs \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  `root-config --libs`
+
+lib_LTLIBRARIES = \
+  libPrototype3.la
+
+pkginclude_HEADERS = \
+  RawTower_Prototype3.h \
+  RawTower_Temperature.h \
+  PROTOTYPE3_FEM.h
+
+libPrototype3_la_SOURCES = \
+  RawTower_Prototype3.cc \
+  RawTower_Prototype3Dict.C \
+  Prototype3DSTReader.cc \
+  Prototype3DSTReaderDict.C \
+  CaloUnpackPRDF.C \
+  CaloUnpackPRDFDict.C \
+  TempInfoUnpackPRDF.C \
+  TempInfoUnpackPRDFDict.C \
+  RunInfoUnpackPRDF.C \
+  RunInfoUnpackPRDFDict.C \
+  EventInfoSummary.C \
+  EventInfoSummaryDict.C \
+  CaloCalibration.C \
+  CaloCalibrationDict.C \
+  GenericUnpackPRDF.C \
+  GenericUnpackPRDFDict.C \
+  PROTOTYPE3_FEM.C \
+  PROTOTYPE3_FEMDict.C \
+  RawTower_Temperature.cc \
+  RawTower_TemperatureDict.C
+
+libPrototype3_la_LIBADD = \
+  -lSubsysReco \
+  -lphool \
+  -lfun4all \
+  -lcalo_util \
+  -lphparameter
+
+BUILT_SOURCES = \
+  testexternals.C
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_LDADD = \
+  libPrototype3.la
+
+testexternals.C:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+##############################################
+# please add new classes in alphabetical order
+# Rule for generating CINT dictionaries from class headers.
+%Dict.C: %.h %LinkDef.h
+	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+
+clean-local:
+	rm -f *Dict*
+
+testexternals_SOURCES = testexternals.C

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -1,0 +1,222 @@
+// $Id: $                                                                                             
+
+/*!
+ * \file PROTOTYPE3_FEM.C
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "PROTOTYPE3_FEM.h"
+
+#include <iostream>
+#include <cassert>
+#include <cmath>
+#include <TGraph.h>
+#include <TF1.h>
+#include <TCanvas.h>
+
+using namespace std;
+
+int
+PROTOTYPE3_FEM::GetHBDCh(std::string caloname, int i_column, int i_row)
+{
+  if (caloname == "HCALIN")
+    {
+      return 64 + 8 * i_column + 2 * i_row;
+    }
+  else if (caloname == "HCALOUT")
+    {
+      return 112 + 8 * i_column + 2 * i_row;
+    }
+  else if (caloname == "EMCAL_PROTOTYPE2")
+    {
+      // EMcal cable mapping from John haggerty
+      assert(i_column >= 0);
+      assert(i_column < NCH_EMCAL_COLUMNS);
+      assert(i_row >= 0);
+      assert(i_row < NCH_EMCAL_ROWS);
+
+      static int canmap[NCH_EMCAL_ROWS * NCH_EMCAL_COLUMNS] =
+        {
+        // 1 ... 15
+            10 + 48, 11 + 48, 8 + 48, 9 + 48, 14 + 48, 15 + 48, 12 + 48, 13
+                + 48,
+            // 9 ... 16
+            2 + 48, 3 + 48, 0 + 48, 1 + 48, 6 + 48, 7 + 48, 4 + 48, 5 + 48,
+
+            // 17 ... 24
+            10 + 32, 11 + 32, 8 + 32, 9 + 32, 14 + 32, 15 + 32, 12 + 32, 13
+                + 32,
+            // 25 ... 32
+            2 + 32, 3 + 32, 0 + 32, 1 + 32, 6 + 32, 7 + 32, 4 + 32, 5 + 32,
+
+            // 33 ... 40
+            10 + 16, 11 + 16, 8 + 16, 9 + 16, 14 + 16, 15 + 16, 12 + 16, 13
+                + 16,
+            // 41 42 43 44 45 46 47 48
+            2 + 16, 3 + 16, 0 + 16, 1 + 16, 6 + 16, 7 + 16, 4 + 16, 5 + 16,
+
+            // 49 50 51 52 53 54 55 56
+            10, 11, 8, 9, 14, 15, 12, 13,
+            // 57 58 59 60 61 62 63 64
+            2, 3, 0, 1, 6, 7, 4, 5 };
+
+      const int tower_index = i_column
+          + NCH_EMCAL_COLUMNS * (NCH_EMCAL_ROWS - 1 - i_row);
+
+      assert(tower_index >= 0);
+      assert(tower_index < NCH_EMCAL_ROWS * NCH_EMCAL_COLUMNS);
+
+      return canmap[tower_index];
+    }
+  else if (caloname == "EMCAL_HIGHETA")
+    {
+      // EMcal cable mapping from John haggerty
+      assert(i_column >= 0);
+      assert(i_column < NCH_EMCAL_COLUMNS);
+      assert(i_row >= 0);
+      assert(i_row < NCH_EMCAL_ROWS);
+
+      static int canmap[] =
+        {
+//            > https://docdb.sphenix.bnl.gov/0000/000034/001/T1044-2017a-2.xlsx
+//            Sean and John spot checked a number of these towers at BNL.  There could be mistakes, but cosmics look reasonable.
+//            Front view (looking downstream, same as above) but in HBD channel numbers
+//            3  , 2  , 19 , 18 , 35 , 34 , 51 , 50,
+//            1  , 0  , 17 , 16 , 33 , 32 , 49 , 48,
+//            7  , 6  , 23 , 22 , 39 , 38 , 55 , 54,
+//            5  , 4  , 21 , 20 , 37 , 36 , 53 , 52,
+//            11 , 10 , 27 , 26 , 43 , 42 , 59 , 58,
+//            9  , 8  , 25 , 24 , 41 , 40 , 57 , 56,
+//            15 , 14 , 31 , 30 , 47 , 46 , 63 , 62,
+//            13 , 12 , 29 , 28 , 45 , 44 , 61 , 60,
+                        3  , 2  , 19 , 18 , 35 , 34 , 51 , 50,
+                        1  , 0  , 17 , 16 , 33 , 32 , 49 , 48,
+                        7  , 6  , 23 , 22 , 39 , 38 , 55 , 54,
+                        5  , 4  , 21 , 20 , 37 , 36 , 53 , 52,
+                        11 , 10 , 27 , 26 , 43 , 42 , 59 , 58,
+                        9  , 8  , 25 , 24 , 41 , 40 , 57 , 56,
+                        15 , 14 , 31 , 30 , 47 , 46 , 63 , 62,
+                        13 , 12 , 29 , 28 , 45 , 44 , 61 , 60,
+            0};
+
+      const int tower_index = i_column
+          + NCH_EMCAL_COLUMNS * (NCH_EMCAL_ROWS - 1 - i_row);
+
+      assert(tower_index >= 0);
+      assert(tower_index < NCH_EMCAL_ROWS * NCH_EMCAL_COLUMNS);
+
+      return canmap[tower_index];
+    }
+
+  std::cout << "PROTOTYPE3_FEM::GetHBDCh - invalid input caloname " << caloname
+      << " i_column " << i_column << " i_row " << i_row << std::endl;
+  exit(1);
+  return -9999;
+}
+
+bool
+PROTOTYPE3_FEM::SampleFit_PowerLawExp(//
+    const std::vector<double> & samples, //
+    double & peak,//
+    double & peak_sample,//
+    double & pedstal, //
+    const int verbosity)
+{
+  int peakPos = 0.;
+
+  assert(samples.size( ) == NSAMPLES);
+
+  TGraph gpulse(NSAMPLES);
+  for (int i = 0; i < NSAMPLES; i++)
+    {
+      (gpulse.GetX())[i] = i;
+
+      (gpulse.GetY())[i] = samples[i];
+    }
+
+  double pedestal = gpulse.GetY()[0]; //(double) PEDESTAL;
+  double peakval = pedestal;
+  const double risetime = 4;
+
+  for (int iSample = 0; iSample < NSAMPLES; iSample++)
+    {
+
+      if (abs(gpulse.GetY()[iSample] - pedestal) > abs(peakval - pedestal))
+        {
+          peakval = gpulse.GetY()[iSample];
+          peakPos = iSample;
+
+        }
+    }
+  peakval -= pedestal;
+
+  // fit function
+  TF1 fits("f_SignalShape_PowerLawExp",SignalShape_PowerLawExp, 0., 24., 6);
+
+
+  double par[6] =
+    { 0 };
+  par[0] = peakval; // /3.;
+  par[1] = peakPos - risetime;
+  if (par[1] < 0.)
+    par[1] = 0.;
+  par[2] = 4.;
+  par[3] = 1.5;
+  par[4] = pedestal;
+  par[5] = 0;
+  fits.SetParameters(par);
+  fits.SetParLimits(0, peakval * 0.9, peakval * 1.1);
+  fits.SetParLimits(1, 0, 24);
+  fits.SetParLimits(2, 2, 4.);
+  fits.SetParLimits(3, 1., 2.);
+  fits.SetParLimits(4, pedestal - abs(peakval), pedestal + abs(peakval));
+//  fits.SetParLimits(5, - abs(peakval),  + abs(peakval));
+  fits.FixParameter(5, 0);
+
+  //Saturation correction - Abhisek
+   for(int ipoint=0; ipoint<gpulse.GetN(); ipoint++)
+    if((gpulse.GetY())[ipoint]==0 or (gpulse.GetY())[ipoint]>=4090) // drop point if touching max or low limit on ADCs
+     {
+      gpulse.RemovePoint(ipoint);
+      ipoint--;
+     }
+
+  gpulse.Fit(&fits, "MQRN0", "goff", 0., (double) NSAMPLES);
+
+  if (verbosity)
+    {
+      TCanvas *canvas = new TCanvas("PROTOTYPE3_FEM_SampleFit_PowerLawExp","PROTOTYPE3_FEM::SampleFit_PowerLawExp");
+      gpulse.DrawClone("ap*l");
+      fits.DrawClone("same");
+      fits.Print();
+      canvas->Update();
+      sleep(1);
+    }
+
+//  peak = fits.GetParameter(0); // not exactly peak height
+  peak = (fits.GetParameter(0)*pow(fits.GetParameter(2)/fits.GetParameter(3),fits.GetParameter(2)))/exp(fits.GetParameter(2));// exact peak height is (p0*Power(p2/p3,p2))/Power(E,p2)
+
+//  peak_sample = fits.GetParameter(1); // signal start time
+  peak_sample = fits.GetParameter(1) + fits.GetParameter(2)/fits.GetParameter(3); // signal peak time
+
+  // peak integral = p0*Power(p3,-1 - p2)*Gamma(1 + p2). Note yet used in output
+
+  pedstal = fits.GetParameter(4);
+
+  return true;
+}
+
+double
+PROTOTYPE3_FEM::SignalShape_PowerLawExp(double *x, double *par)
+{
+  double pedestal = par[4] + ((x[0] - 1.5* par[1])>0) * par[5]; // quick fix on exting tails on the signal function
+  if (x[0] < par[1])
+    return pedestal;
+  //double  signal = (-1)*par[0]*pow((x[0]-par[1]),par[2])*exp(-(x[0]-par[1])*par[3]);
+  double signal = par[0] * pow((x[0] - par[1]), par[2])
+      * exp(-(x[0] - par[1]) * par[3]);
+  return pedestal + signal;
+}

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -109,7 +109,7 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawExp(  //
   peakval -= pedestal;
 
   // fit function
-  TF1 fits("f_SignalShape_PowerLawExp", SignalShape_PowerLawExp, 0., NSAMPLES, 6);
+  TF1 fits("f_SignalShape_PowerLawExp", SignalShape_PowerLawExp, 0., NSAMPLES, 5);
 
   double par[6] =
       {0};
@@ -129,11 +129,11 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawExp(  //
   fits.SetParLimits(3, 1., 2.);
   fits.SetParLimits(4, pedestal - abs(peakval), pedestal + abs(peakval));
   //  fits.SetParLimits(5, - abs(peakval),  + abs(peakval));
-  fits.FixParameter(5, 0);
+//  fits.FixParameter(5, 0);
 
   //Saturation correction - Abhisek
   for (int ipoint = 0; ipoint < gpulse.GetN(); ipoint++)
-    if ((gpulse.GetY())[ipoint] == 0 or (gpulse.GetY())[ipoint] >= 4090)  // drop point if touching max or low limit on ADCs
+    if ((gpulse.GetY())[ipoint] <=10  or (gpulse.GetY())[ipoint] >= ((1<<14) - 10))  // drop point if touching max or low limit on ADCs
     {
       gpulse.RemovePoint(ipoint);
       ipoint--;
@@ -148,11 +148,12 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawExp(  //
 
     TCanvas *canvas = new TCanvas(
         (string("PROTOTYPE4_FEM_SampleFit_PowerLawExp") + to_string(id)).c_str(), "PROTOTYPE4_FEM::SampleFit_PowerLawExp");
-    gpulse.DrawClone("ap*l");
+    TGraph * g_plot = static_cast<TGraph *>(gpulse.DrawClone("ap*l"));
+    g_plot->SetTitle("ADC data and fit;Sample number;ADC value");
     fits.DrawClone("same");
     fits.Print();
     canvas->Update();
-    sleep(1);
+//    sleep(1);
   }
 
   //  peak = fits.GetParameter(0); // not exactly peak height
@@ -171,7 +172,8 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawExp(  //
 double
 PROTOTYPE4_FEM::SignalShape_PowerLawExp(double *x, double *par)
 {
-  double pedestal = par[4] + ((x[0] - 1.5 * par[1]) > 0) * par[5];  // quick fix on exting tails on the signal function
+  double pedestal = par[4];
+//                        + ((x[0] - 1.5 * par[1]) > 0) * par[5];  // quick fix on exting tails on the signal function
   if (x[0] < par[1])
     return pedestal;
   //double  signal = (-1)*par[0]*pow((x[0]-par[1]),par[2])*exp(-(x[0]-par[1])*par[3]);

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -51,6 +51,11 @@ int PROTOTYPE4_FEM::GetChannelNumber(std::string caloname, int i_column, int i_r
   }
   else if (caloname == "EMCAL")
   {
+    assert(i_row >= 0);
+    assert(i_row < NCH_EMCAL_ROWS);
+    assert(i_column >= 0);
+    assert(i_column < NCH_EMCAL_COLUMNS);
+
     //    > Anthony Hodges
     //    > PhD. Student, Georgia State University
     //    > Nuclear and High Energy Physics
@@ -61,17 +66,45 @@ int PROTOTYPE4_FEM::GetChannelNumber(std::string caloname, int i_column, int i_r
     // This map here takes in a channel number and gives you the corresponding canvas position
     // Presumably we want the opposite, put in canvas position, output channel number
     // So we'll work backwards
-    Float_t canmap[64] = {6, 7, 14, 15, 4, 5, 12, 13, 2, 3, 10, 11, 0, 1, 8, 9, 22, 23, 30, 31, 20, 21, 28, 29,
-                          18, 19, 26, 27, 16, 17, 24, 25, 38, 39, 46, 47, 36, 37, 44, 45, 34, 35, 42, 43,
-                          32, 33, 40, 41, 54, 55, 62, 63, 52, 53, 60, 61, 50, 51, 58, 59, 48, 49, 56, 57};
+    //    Float_t canmap[64] = {6, 7, 14, 15, 4, 5, 12, 13, 2, 3, 10, 11, 0, 1, 8, 9, 22, 23, 30, 31, 20, 21, 28, 29,
+    //                          18, 19, 26, 27, 16, 17, 24, 25, 38, 39, 46, 47, 36, 37, 44, 45, 34, 35, 42, 43,
+    //                          32, 33, 40, 41, 54, 55, 62, 63, 52, 53, 60, 61, 50, 51, 58, 59, 48, 49, 56, 57};
+    //    static int hbdchanEMC[8][8];  //I'm gonna fill this boy with the above channels
+    //    for (int chan = 0; chan < 64; chan++)
+    //    {
+    //      hbdchanEMC[(int) floor(canmap[chan] / 8)][((int) canmap[chan]) % 8] = chan;
+    //    }
 
-    static int hbdchanEMC[8][8];  //I'm gonna fill this boy with the above channels
-    for (int chan = 0; chan < 64; chan++)
-    {
-      hbdchanEMC[(int) floor(canmap[chan] / 8)][((int) canmap[chan]) % 8] = chan;
-    }
+    // Revision from Martin with static reverse:
+    //    This is now lining up towers from 0....63, and tells you
+    //
+    //    for tower i, what is the actual ADC index I have to go to?
+    //
+    //    tower[0] -> chvector[0] = 12  is then the adc channel nr.
+    //
+    //
+    //
+    //
+    //
+    //
+    //     static const int  chvector[]=  {12 , 13 , 8 , 9 , 4 ,5 ,0 ,1 ,14 ,15
+    //    ,10 ,11 ,6 ,7 ,2 ,3 ,28 ,29 ,24 ,25 ,20 ,21 ,
+    //                                      16 ,17 ,30 ,31 ,26 ,27 ,22 ,23 ,18 ,19
+    //    ,44 ,45 ,40 ,41 ,36 ,37 ,32 ,33 ,46 ,47 ,42 ,43 ,38 ,
+    //                                      39 ,34 ,35 ,60 ,61 ,56 ,57 ,52 ,53 ,48
+    //    ,49 ,62 ,63 ,58 ,59 ,54 ,55 ,50 ,51};
+    const static int canmap[64] = {
+        12, 13, 8, 9, 4, 5, 0, 1, 14, 15, 10, 11, 6, 7, 2, 3, 28, 29, 24, 25, 20, 21,
+        16, 17, 30, 31, 26, 27, 22, 23, 18, 19, 44, 45, 40, 41, 36, 37, 32, 33, 46, 47, 42, 43, 38,
+        39, 34, 35, 60, 61, 56, 57, 52, 53, 48, 49, 62, 63, 58, 59, 54, 55, 50, 51
+    };
 
-    return hbdchanEMC[i_row][i_column];
+    const int linear_channel_ID = (NCH_EMCAL_ROWS - i_row - 1) * NCH_EMCAL_COLUMNS + i_column;
+
+    assert(linear_channel_ID >= 0);
+    assert(linear_channel_ID < 64);
+
+    return canmap[linear_channel_ID];
   }
 
   std::cout << "PROTOTYPE4_FEM::GetHBDCh - invalid input caloname " << caloname

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -22,53 +22,56 @@
 
 using namespace std;
 
-int PROTOTYPE4_FEM::GetHBDCh(std::string caloname, int i_column, int i_row)
+int PROTOTYPE4_FEM::GetChannelNumber(std::string caloname, int i_column, int i_row)
 {
   if (caloname == "HCALIN")
   {
-    return 64 + 8 * i_column + 2 * i_row;
+    //    > Anthony Hodges
+    //    > PhD. Student, Georgia State University
+    //    > Nuclear and High Energy Physics
+    //    > ahodges21@student.gsu.edu
+
+    static const int hbdchanIHC[4][4] = {{4, 8, 12, 16},
+                                         {3, 7, 11, 15},
+                                         {2, 6, 10, 14},
+                                         {1, 5, 9, 13}};
+
+    assert(i_row >= 0);
+    assert(i_row < NCH_IHCAL_ROWS);
+    assert(i_column >= 0);
+    assert(i_column < NCH_IHCAL_COLUMNS);
+
+    return hbdchanIHC[i_row][i_column] + 64;
   }
   else if (caloname == "HCALOUT")
   {
+    // Place holder
+
     return 112 + 8 * i_column + 2 * i_row;
   }
   else if (caloname == "EMCAL")
   {
-    // EMcal cable mapping from John haggerty
-    assert(i_column >= 0);
-    assert(i_column < NCH_EMCAL_COLUMNS);
-    assert(i_row >= 0);
-    assert(i_row < NCH_EMCAL_ROWS);
+    //    > Anthony Hodges
+    //    > PhD. Student, Georgia State University
+    //    > Nuclear and High Energy Physics
+    //    > ahodges21@student.gsu.edu
 
-    static int canmap[] =
-        {
-            //            > https://docdb.sphenix.bnl.gov/0000/000034/001/T1044-2017a-2.xlsx
-            //            Sean and John spot checked a number of these towers at BNL.  There could be mistakes, but cosmics look reasonable.
-            //            Front view (looking downstream, same as above) but in HBD channel numbers
-            //            3  , 2  , 19 , 18 , 35 , 34 , 51 , 50,
-            //            1  , 0  , 17 , 16 , 33 , 32 , 49 , 48,
-            //            7  , 6  , 23 , 22 , 39 , 38 , 55 , 54,
-            //            5  , 4  , 21 , 20 , 37 , 36 , 53 , 52,
-            //            11 , 10 , 27 , 26 , 43 , 42 , 59 , 58,
-            //            9  , 8  , 25 , 24 , 41 , 40 , 57 , 56,
-            //            15 , 14 , 31 , 30 , 47 , 46 , 63 , 62,
-            //            13 , 12 , 29 , 28 , 45 , 44 , 61 , 60,
-            3, 2, 19, 18, 35, 34, 51, 50,
-            1, 0, 17, 16, 33, 32, 49, 48,
-            7, 6, 23, 22, 39, 38, 55, 54,
-            5, 4, 21, 20, 37, 36, 53, 52,
-            11, 10, 27, 26, 43, 42, 59, 58,
-            9, 8, 25, 24, 41, 40, 57, 56,
-            15, 14, 31, 30, 47, 46, 63, 62,
-            13, 12, 29, 28, 45, 44, 61, 60,
-            0};
+    // mapping taken from John Haggerty's emcalall.C found here:
+    // /gpfs/mnt/gpfs02/sphenix/data/data01/caladc/wd/wd409/macros
+    // This map here takes in a channel number and gives you the corresponding canvas position
+    // Presumably we want the opposite, put in canvas position, output channel number
+    // So we'll work backwards
+    Float_t canmap[64] = {6, 7, 14, 15, 4, 5, 12, 13, 2, 3, 10, 11, 0, 1, 8, 9, 22, 23, 30, 31, 20, 21, 28, 29,
+                          18, 19, 26, 27, 16, 17, 24, 25, 38, 39, 46, 47, 36, 37, 44, 45, 34, 35, 42, 43,
+                          32, 33, 40, 41, 54, 55, 62, 63, 52, 53, 60, 61, 50, 51, 58, 59, 48, 49, 56, 57};
 
-    const int tower_index = i_column + NCH_EMCAL_COLUMNS * (NCH_EMCAL_ROWS - 1 - i_row);
+    static int hbdchanEMC[8][8];  //I'm gonna fill this boy with the above channels
+    for (int chan = 0; chan < 64; chan++)
+    {
+      hbdchanEMC[(int) floor(canmap[chan] / 8)][((int) canmap[chan]) % 8] = chan;
+    }
 
-    assert(tower_index >= 0);
-    assert(tower_index < NCH_EMCAL_ROWS * NCH_EMCAL_COLUMNS);
-
-    return canmap[tower_index];
+    return hbdchanEMC[i_row][i_column];
   }
 
   std::cout << "PROTOTYPE4_FEM::GetHBDCh - invalid input caloname " << caloname

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -13,6 +13,8 @@
 #include <TCanvas.h>
 #include <TF1.h>
 #include <TGraph.h>
+#include <TStyle.h>
+#include <TVirtualFitter.h>
 #include <cassert>
 #include <cmath>
 #include <iostream>
@@ -122,38 +124,45 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawExp(  //
   par[4] = pedestal;
   par[5] = 0;
   fits.SetParameters(par);
-  fits.SetParNames("Amplitude", "Peak Sample", "Power", "Decay","Pedstal","Baseline shift");
-  fits.SetParLimits(0, peakval * 0.9, peakval * 1.1);
+  fits.SetParNames("Amplitude", "Peak Sample", "Power", "Decay", "Pedstal", "Baseline shift");
+  fits.SetParLimits(0, peakval * 0.5, peakval * 10);
   fits.SetParLimits(1, 0, NSAMPLES);
-  fits.SetParLimits(2, 2, 4.);
-  fits.SetParLimits(3, 1., 2.);
+  fits.SetParLimits(2, 0, 10.);
+  fits.SetParLimits(3, 0, 10);
   fits.SetParLimits(4, pedestal - abs(peakval), pedestal + abs(peakval));
   //  fits.SetParLimits(5, - abs(peakval),  + abs(peakval));
-//  fits.FixParameter(5, 0);
+  //  fits.FixParameter(5, 0);
 
   //Saturation correction - Abhisek
   for (int ipoint = 0; ipoint < gpulse.GetN(); ipoint++)
-    if ((gpulse.GetY())[ipoint] <=10  or (gpulse.GetY())[ipoint] >= ((1<<14) - 10))  // drop point if touching max or low limit on ADCs
+    if ((gpulse.GetY())[ipoint] <= 10 or (gpulse.GetY())[ipoint] >= ((1 << 14) - 10))  // drop point if touching max or low limit on ADCs
     {
       gpulse.RemovePoint(ipoint);
       ipoint--;
     }
 
-  gpulse.Fit(&fits, "MQRN0", "goff", 0., (double) NSAMPLES);
+  if (verbosity <= 1)
+    gpulse.Fit(&fits, "MQRN0W", "goff", 0., (double) NSAMPLES);
+  else
+    gpulse.Fit(&fits, "MRN0VW", "goff", 0., (double) NSAMPLES);
 
   if (verbosity)
   {
     static int id = 0;
     ++id;
 
+    string c_name(string("PROTOTYPE4_FEM_SampleFit_PowerLawExp_") + to_string(id));
+
     TCanvas *canvas = new TCanvas(
-        (string("PROTOTYPE4_FEM_SampleFit_PowerLawExp") + to_string(id)).c_str(), "PROTOTYPE4_FEM::SampleFit_PowerLawExp");
-    TGraph * g_plot = static_cast<TGraph *>(gpulse.DrawClone("ap*l"));
+        c_name.c_str(), c_name.c_str());
+    canvas->Update();
+
+    TGraph *g_plot = static_cast<TGraph *>(gpulse.DrawClone("ap*l"));
     g_plot->SetTitle("ADC data and fit;Sample number;ADC value");
     fits.DrawClone("same");
     fits.Print();
     canvas->Update();
-//    sleep(1);
+    //    sleep(1);
   }
 
   //  peak = fits.GetParameter(0); // not exactly peak height
@@ -173,10 +182,166 @@ double
 PROTOTYPE4_FEM::SignalShape_PowerLawExp(double *x, double *par)
 {
   double pedestal = par[4];
-//                        + ((x[0] - 1.5 * par[1]) > 0) * par[5];  // quick fix on exting tails on the signal function
+  //                        + ((x[0] - 1.5 * par[1]) > 0) * par[5];  // quick fix on exting tails on the signal function
   if (x[0] < par[1])
     return pedestal;
   //double  signal = (-1)*par[0]*pow((x[0]-par[1]),par[2])*exp(-(x[0]-par[1])*par[3]);
   double signal = par[0] * pow((x[0] - par[1]), par[2]) * exp(-(x[0] - par[1]) * par[3]);
+  return pedestal + signal;
+}
+
+bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
+    const std::vector<double> &samples,            //
+    double &peak,                                  //
+    double &peak_sample,                           //
+    double &pedstal,                               //
+    const int verbosity)
+{
+  int peakPos = 0.;
+
+  assert(samples.size() == NSAMPLES);
+
+  TGraph gpulse(NSAMPLES);
+  for (int i = 0; i < NSAMPLES; i++)
+  {
+    (gpulse.GetX())[i] = i;
+
+    (gpulse.GetY())[i] = samples[i];
+  }
+
+  double pedestal = gpulse.GetY()[0];  //(double) PEDESTAL;
+  double peakval = pedestal;
+  const double risetime = 4;
+
+  for (int iSample = 0; iSample < NSAMPLES; iSample++)
+  {
+    if (abs(gpulse.GetY()[iSample] - pedestal) > abs(peakval - pedestal))
+    {
+      peakval = gpulse.GetY()[iSample];
+      peakPos = iSample;
+    }
+  }
+  peakval -= pedestal;
+
+  // fit function
+  TF1 fits("f_SignalShape_PowerLawDoubleExp", SignalShape_PowerLawDoubleExp, 0., NSAMPLES, 7);
+
+  double par[10] =
+      {0};
+  par[0] = peakval;  // /3.;
+  par[1] = peakPos - risetime;
+  if (par[1] < 0.)
+    par[1] = 0.;
+  par[2] = 2.;
+  par[3] = 1.5;
+  par[4] = pedestal;
+  par[5] = peakval / 20;
+  par[6] = 1;
+  fits.SetParameters(par);
+  fits.SetParNames("Amplitude1", "Peak Sample", "Power", "Decay1", "Pedestal", "Amplitude2", "Decay2");
+  fits.SetParLimits(0, peakval * 0.5, peakval * 5);
+  fits.SetParLimits(1, 0, NSAMPLES);
+  fits.SetParLimits(2, 1, 10.);
+  fits.SetParLimits(3, 1., 2.5);
+  fits.SetParLimits(4, pedestal - abs(peakval), pedestal + abs(peakval));
+  fits.SetParLimits(5, 0, peakval * 1.5);
+  fits.SetParLimits(6, 0, 1);
+
+  //Saturation correction - Abhisek
+  for (int ipoint = 0; ipoint < gpulse.GetN(); ipoint++)
+    if ((gpulse.GetY())[ipoint] <= 10 or (gpulse.GetY())[ipoint] >= ((1 << 14) - 10))  // drop point if touching max or low limit on ADCs
+    {
+      gpulse.RemovePoint(ipoint);
+      ipoint--;
+    }
+
+  if (verbosity <= 1)
+    gpulse.Fit(&fits, "MQRN0W", "goff", 0., (double) NSAMPLES);
+  else
+    gpulse.Fit(&fits, "MRN0VW", "goff", 0., (double) NSAMPLES);
+
+  if (verbosity)
+  {
+    static int id = 0;
+    ++id;
+
+    string c_name(string("PROTOTYPE4_FEM_SampleFit_PowerLawDoubleExp_") + to_string(id));
+
+    TCanvas *canvas = new TCanvas(
+        c_name.c_str(), c_name.c_str());
+    canvas->Update();
+
+    TGraph *g_plot = static_cast<TGraph *>(gpulse.DrawClone("ap*l"));
+    g_plot->SetTitle("ADC data and fit;Sample number;ADC value");
+
+    fits.SetLineColor(kMagenta);
+    fits.DrawClone("same");
+    fits.Print();
+
+    TF1 f1("f_SignalShape_PowerLawExp1", SignalShape_PowerLawExp, 0., NSAMPLES, 5);
+    f1.SetParameters(
+        fits.GetParameter(0),
+        fits.GetParameter(1),
+        fits.GetParameter(2),
+        fits.GetParameter(3),
+        fits.GetParameter(4));
+    f1.SetLineColor(kBlue);
+    f1.DrawClone("same");
+
+    TF1 f2("f_SignalShape_PowerLawExp2", SignalShape_PowerLawExp, 0., NSAMPLES, 5);
+    f2.SetParameters(
+        fits.GetParameter(5),
+        fits.GetParameter(1),
+        fits.GetParameter(2),
+        fits.GetParameter(6),
+        fits.GetParameter(4));
+    f2.SetLineColor(kRed);
+    f2.DrawClone("same");
+
+    canvas->Update();
+
+    //    sleep(1);
+  }
+
+  //  peak = fits.GetParameter(0); // not exactly peak height
+  //  peak = (fits.GetParameter(0) * pow(fits.GetParameter(2) / fits.GetParameter(3), fits.GetParameter(2)))    //
+  //             / exp(fits.GetParameter(2))                                                                    //
+  //         + (fits.GetParameter(5) * pow(fits.GetParameter(2) / fits.GetParameter(6), fits.GetParameter(2)))  //
+  //               / exp(fits.GetParameter(2));
+  // exact peak height is (p0*Power(p2/p3,p2))/Power(E,p2)
+
+  //  peak_sample = fits.GetParameter(1); // signal start time
+  //  peak_sample = fits.GetParameter(1) + fits.GetParameter(2) / fits.GetParameter(3);  // signal peak time
+
+  // peak integral = p0*Power(p3,-1 - p2)*Gamma(1 + p2). Note yet used in output
+
+  pedstal = fits.GetParameter(4);
+  peak_sample = fits.GetMaximumX(fits.GetParameter(1), fits.GetParameter(1) + fits.GetParameter(2) / fits.GetParameter(6));
+  peak = fits.Eval(peak_sample) - pedstal;
+
+  if (verbosity)
+  {
+    cout << "PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp - "
+         << "peak_sample = " << peak_sample << ", "
+         << "peak = " << peak << ", "
+         << "pedstal = " << pedstal << endl;
+  }
+
+  return true;
+}
+
+double
+PROTOTYPE4_FEM::SignalShape_PowerLawDoubleExp(double *x, double *par)
+{
+  double pedestal = par[4];
+  //                        + ((x[0] - 1.5 * par[1]) > 0) * par[5];  // quick fix on exting tails on the signal function
+  if (x[0] < par[1])
+    return pedestal;
+  //double  signal = (-1)*par[0]*pow((x[0]-par[1]),par[2])*exp(-(x[0]-par[1])*par[3]);
+  double signal =                                   //
+      pow((x[0] - par[1]), par[2])                  //
+      * (par[0] * exp(-(x[0] - par[1]) * par[3])    //
+         + par[5] * exp(-(x[0] - par[1]) * par[6])  //
+         );
   return pedestal + signal;
 }

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -1,14 +1,14 @@
 // $Id: $                                                                                             
 
 /*!
- * \file PROTOTYPE3_FEM.C
+ * \file PROTOTYPE4_FEM.C
  * \brief 
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $
  */
 
-#include "PROTOTYPE3_FEM.h"
+#include "PROTOTYPE4_FEM.h"
 
 #include <iostream>
 #include <cassert>
@@ -20,7 +20,7 @@
 using namespace std;
 
 int
-PROTOTYPE3_FEM::GetHBDCh(std::string caloname, int i_column, int i_row)
+PROTOTYPE4_FEM::GetHBDCh(std::string caloname, int i_column, int i_row)
 {
   if (caloname == "HCALIN")
     {
@@ -111,14 +111,14 @@ PROTOTYPE3_FEM::GetHBDCh(std::string caloname, int i_column, int i_row)
       return canmap[tower_index];
     }
 
-  std::cout << "PROTOTYPE3_FEM::GetHBDCh - invalid input caloname " << caloname
+  std::cout << "PROTOTYPE4_FEM::GetHBDCh - invalid input caloname " << caloname
       << " i_column " << i_column << " i_row " << i_row << std::endl;
   exit(1);
   return -9999;
 }
 
 bool
-PROTOTYPE3_FEM::SampleFit_PowerLawExp(//
+PROTOTYPE4_FEM::SampleFit_PowerLawExp(//
     const std::vector<double> & samples, //
     double & peak,//
     double & peak_sample,//
@@ -188,7 +188,7 @@ PROTOTYPE3_FEM::SampleFit_PowerLawExp(//
 
   if (verbosity)
     {
-      TCanvas *canvas = new TCanvas("PROTOTYPE3_FEM_SampleFit_PowerLawExp","PROTOTYPE3_FEM::SampleFit_PowerLawExp");
+      TCanvas *canvas = new TCanvas("PROTOTYPE4_FEM_SampleFit_PowerLawExp","PROTOTYPE4_FEM::SampleFit_PowerLawExp");
       gpulse.DrawClone("ap*l");
       fits.DrawClone("same");
       fits.Print();
@@ -210,7 +210,7 @@ PROTOTYPE3_FEM::SampleFit_PowerLawExp(//
 }
 
 double
-PROTOTYPE3_FEM::SignalShape_PowerLawExp(double *x, double *par)
+PROTOTYPE4_FEM::SignalShape_PowerLawExp(double *x, double *par)
 {
   double pedestal = par[4] + ((x[0] - 1.5* par[1])>0) * par[5]; // quick fix on exting tails on the signal function
   if (x[0] < par[1])

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -1,4 +1,4 @@
-// $Id: $                                                                                             
+// $Id: $
 
 /*!
  * \file PROTOTYPE4_FEM.C
@@ -10,156 +10,109 @@
 
 #include "PROTOTYPE4_FEM.h"
 
-#include <iostream>
+#include <TCanvas.h>
+#include <TF1.h>
+#include <TGraph.h>
 #include <cassert>
 #include <cmath>
-#include <TGraph.h>
-#include <TF1.h>
-#include <TCanvas.h>
+#include <iostream>
 
 using namespace std;
 
-int
-PROTOTYPE4_FEM::GetHBDCh(std::string caloname, int i_column, int i_row)
+int PROTOTYPE4_FEM::GetHBDCh(std::string caloname, int i_column, int i_row)
 {
   if (caloname == "HCALIN")
-    {
-      return 64 + 8 * i_column + 2 * i_row;
-    }
+  {
+    return 64 + 8 * i_column + 2 * i_row;
+  }
   else if (caloname == "HCALOUT")
-    {
-      return 112 + 8 * i_column + 2 * i_row;
-    }
-  else if (caloname == "EMCAL_PROTOTYPE2")
-    {
-      // EMcal cable mapping from John haggerty
-      assert(i_column >= 0);
-      assert(i_column < NCH_EMCAL_COLUMNS);
-      assert(i_row >= 0);
-      assert(i_row < NCH_EMCAL_ROWS);
+  {
+    return 112 + 8 * i_column + 2 * i_row;
+  }
+  else if (caloname == "EMCAL")
+  {
+    // EMcal cable mapping from John haggerty
+    assert(i_column >= 0);
+    assert(i_column < NCH_EMCAL_COLUMNS);
+    assert(i_row >= 0);
+    assert(i_row < NCH_EMCAL_ROWS);
 
-      static int canmap[NCH_EMCAL_ROWS * NCH_EMCAL_COLUMNS] =
+    static int canmap[] =
         {
-        // 1 ... 15
-            10 + 48, 11 + 48, 8 + 48, 9 + 48, 14 + 48, 15 + 48, 12 + 48, 13
-                + 48,
-            // 9 ... 16
-            2 + 48, 3 + 48, 0 + 48, 1 + 48, 6 + 48, 7 + 48, 4 + 48, 5 + 48,
-
-            // 17 ... 24
-            10 + 32, 11 + 32, 8 + 32, 9 + 32, 14 + 32, 15 + 32, 12 + 32, 13
-                + 32,
-            // 25 ... 32
-            2 + 32, 3 + 32, 0 + 32, 1 + 32, 6 + 32, 7 + 32, 4 + 32, 5 + 32,
-
-            // 33 ... 40
-            10 + 16, 11 + 16, 8 + 16, 9 + 16, 14 + 16, 15 + 16, 12 + 16, 13
-                + 16,
-            // 41 42 43 44 45 46 47 48
-            2 + 16, 3 + 16, 0 + 16, 1 + 16, 6 + 16, 7 + 16, 4 + 16, 5 + 16,
-
-            // 49 50 51 52 53 54 55 56
-            10, 11, 8, 9, 14, 15, 12, 13,
-            // 57 58 59 60 61 62 63 64
-            2, 3, 0, 1, 6, 7, 4, 5 };
-
-      const int tower_index = i_column
-          + NCH_EMCAL_COLUMNS * (NCH_EMCAL_ROWS - 1 - i_row);
-
-      assert(tower_index >= 0);
-      assert(tower_index < NCH_EMCAL_ROWS * NCH_EMCAL_COLUMNS);
-
-      return canmap[tower_index];
-    }
-  else if (caloname == "EMCAL_HIGHETA")
-    {
-      // EMcal cable mapping from John haggerty
-      assert(i_column >= 0);
-      assert(i_column < NCH_EMCAL_COLUMNS);
-      assert(i_row >= 0);
-      assert(i_row < NCH_EMCAL_ROWS);
-
-      static int canmap[] =
-        {
-//            > https://docdb.sphenix.bnl.gov/0000/000034/001/T1044-2017a-2.xlsx
-//            Sean and John spot checked a number of these towers at BNL.  There could be mistakes, but cosmics look reasonable.
-//            Front view (looking downstream, same as above) but in HBD channel numbers
-//            3  , 2  , 19 , 18 , 35 , 34 , 51 , 50,
-//            1  , 0  , 17 , 16 , 33 , 32 , 49 , 48,
-//            7  , 6  , 23 , 22 , 39 , 38 , 55 , 54,
-//            5  , 4  , 21 , 20 , 37 , 36 , 53 , 52,
-//            11 , 10 , 27 , 26 , 43 , 42 , 59 , 58,
-//            9  , 8  , 25 , 24 , 41 , 40 , 57 , 56,
-//            15 , 14 , 31 , 30 , 47 , 46 , 63 , 62,
-//            13 , 12 , 29 , 28 , 45 , 44 , 61 , 60,
-                        3  , 2  , 19 , 18 , 35 , 34 , 51 , 50,
-                        1  , 0  , 17 , 16 , 33 , 32 , 49 , 48,
-                        7  , 6  , 23 , 22 , 39 , 38 , 55 , 54,
-                        5  , 4  , 21 , 20 , 37 , 36 , 53 , 52,
-                        11 , 10 , 27 , 26 , 43 , 42 , 59 , 58,
-                        9  , 8  , 25 , 24 , 41 , 40 , 57 , 56,
-                        15 , 14 , 31 , 30 , 47 , 46 , 63 , 62,
-                        13 , 12 , 29 , 28 , 45 , 44 , 61 , 60,
+            //            > https://docdb.sphenix.bnl.gov/0000/000034/001/T1044-2017a-2.xlsx
+            //            Sean and John spot checked a number of these towers at BNL.  There could be mistakes, but cosmics look reasonable.
+            //            Front view (looking downstream, same as above) but in HBD channel numbers
+            //            3  , 2  , 19 , 18 , 35 , 34 , 51 , 50,
+            //            1  , 0  , 17 , 16 , 33 , 32 , 49 , 48,
+            //            7  , 6  , 23 , 22 , 39 , 38 , 55 , 54,
+            //            5  , 4  , 21 , 20 , 37 , 36 , 53 , 52,
+            //            11 , 10 , 27 , 26 , 43 , 42 , 59 , 58,
+            //            9  , 8  , 25 , 24 , 41 , 40 , 57 , 56,
+            //            15 , 14 , 31 , 30 , 47 , 46 , 63 , 62,
+            //            13 , 12 , 29 , 28 , 45 , 44 , 61 , 60,
+            3, 2, 19, 18, 35, 34, 51, 50,
+            1, 0, 17, 16, 33, 32, 49, 48,
+            7, 6, 23, 22, 39, 38, 55, 54,
+            5, 4, 21, 20, 37, 36, 53, 52,
+            11, 10, 27, 26, 43, 42, 59, 58,
+            9, 8, 25, 24, 41, 40, 57, 56,
+            15, 14, 31, 30, 47, 46, 63, 62,
+            13, 12, 29, 28, 45, 44, 61, 60,
             0};
 
-      const int tower_index = i_column
-          + NCH_EMCAL_COLUMNS * (NCH_EMCAL_ROWS - 1 - i_row);
+    const int tower_index = i_column + NCH_EMCAL_COLUMNS * (NCH_EMCAL_ROWS - 1 - i_row);
 
-      assert(tower_index >= 0);
-      assert(tower_index < NCH_EMCAL_ROWS * NCH_EMCAL_COLUMNS);
+    assert(tower_index >= 0);
+    assert(tower_index < NCH_EMCAL_ROWS * NCH_EMCAL_COLUMNS);
 
-      return canmap[tower_index];
-    }
+    return canmap[tower_index];
+  }
 
   std::cout << "PROTOTYPE4_FEM::GetHBDCh - invalid input caloname " << caloname
-      << " i_column " << i_column << " i_row " << i_row << std::endl;
+            << " i_column " << i_column << " i_row " << i_row << std::endl;
   exit(1);
   return -9999;
 }
 
-bool
-PROTOTYPE4_FEM::SampleFit_PowerLawExp(//
-    const std::vector<double> & samples, //
-    double & peak,//
-    double & peak_sample,//
-    double & pedstal, //
+bool PROTOTYPE4_FEM::SampleFit_PowerLawExp(  //
+    const std::vector<double> &samples,      //
+    double &peak,                            //
+    double &peak_sample,                     //
+    double &pedstal,                         //
     const int verbosity)
 {
   int peakPos = 0.;
 
-  assert(samples.size( ) == NSAMPLES);
+  assert(samples.size() == NSAMPLES);
 
   TGraph gpulse(NSAMPLES);
   for (int i = 0; i < NSAMPLES; i++)
-    {
-      (gpulse.GetX())[i] = i;
+  {
+    (gpulse.GetX())[i] = i;
 
-      (gpulse.GetY())[i] = samples[i];
-    }
+    (gpulse.GetY())[i] = samples[i];
+  }
 
-  double pedestal = gpulse.GetY()[0]; //(double) PEDESTAL;
+  double pedestal = gpulse.GetY()[0];  //(double) PEDESTAL;
   double peakval = pedestal;
   const double risetime = 4;
 
   for (int iSample = 0; iSample < NSAMPLES; iSample++)
+  {
+    if (abs(gpulse.GetY()[iSample] - pedestal) > abs(peakval - pedestal))
     {
-
-      if (abs(gpulse.GetY()[iSample] - pedestal) > abs(peakval - pedestal))
-        {
-          peakval = gpulse.GetY()[iSample];
-          peakPos = iSample;
-
-        }
+      peakval = gpulse.GetY()[iSample];
+      peakPos = iSample;
     }
+  }
   peakval -= pedestal;
 
   // fit function
-  TF1 fits("f_SignalShape_PowerLawExp",SignalShape_PowerLawExp, 0., 24., 6);
-
+  TF1 fits("f_SignalShape_PowerLawExp", SignalShape_PowerLawExp, 0., 24., 6);
 
   double par[6] =
-    { 0 };
-  par[0] = peakval; // /3.;
+      {0};
+  par[0] = peakval;  // /3.;
   par[1] = peakPos - risetime;
   if (par[1] < 0.)
     par[1] = 0.;
@@ -173,34 +126,34 @@ PROTOTYPE4_FEM::SampleFit_PowerLawExp(//
   fits.SetParLimits(2, 2, 4.);
   fits.SetParLimits(3, 1., 2.);
   fits.SetParLimits(4, pedestal - abs(peakval), pedestal + abs(peakval));
-//  fits.SetParLimits(5, - abs(peakval),  + abs(peakval));
+  //  fits.SetParLimits(5, - abs(peakval),  + abs(peakval));
   fits.FixParameter(5, 0);
 
   //Saturation correction - Abhisek
-   for(int ipoint=0; ipoint<gpulse.GetN(); ipoint++)
-    if((gpulse.GetY())[ipoint]==0 or (gpulse.GetY())[ipoint]>=4090) // drop point if touching max or low limit on ADCs
-     {
+  for (int ipoint = 0; ipoint < gpulse.GetN(); ipoint++)
+    if ((gpulse.GetY())[ipoint] == 0 or (gpulse.GetY())[ipoint] >= 4090)  // drop point if touching max or low limit on ADCs
+    {
       gpulse.RemovePoint(ipoint);
       ipoint--;
-     }
+    }
 
   gpulse.Fit(&fits, "MQRN0", "goff", 0., (double) NSAMPLES);
 
   if (verbosity)
-    {
-      TCanvas *canvas = new TCanvas("PROTOTYPE4_FEM_SampleFit_PowerLawExp","PROTOTYPE4_FEM::SampleFit_PowerLawExp");
-      gpulse.DrawClone("ap*l");
-      fits.DrawClone("same");
-      fits.Print();
-      canvas->Update();
-      sleep(1);
-    }
+  {
+    TCanvas *canvas = new TCanvas("PROTOTYPE4_FEM_SampleFit_PowerLawExp", "PROTOTYPE4_FEM::SampleFit_PowerLawExp");
+    gpulse.DrawClone("ap*l");
+    fits.DrawClone("same");
+    fits.Print();
+    canvas->Update();
+    sleep(1);
+  }
 
-//  peak = fits.GetParameter(0); // not exactly peak height
-  peak = (fits.GetParameter(0)*pow(fits.GetParameter(2)/fits.GetParameter(3),fits.GetParameter(2)))/exp(fits.GetParameter(2));// exact peak height is (p0*Power(p2/p3,p2))/Power(E,p2)
+  //  peak = fits.GetParameter(0); // not exactly peak height
+  peak = (fits.GetParameter(0) * pow(fits.GetParameter(2) / fits.GetParameter(3), fits.GetParameter(2))) / exp(fits.GetParameter(2));  // exact peak height is (p0*Power(p2/p3,p2))/Power(E,p2)
 
-//  peak_sample = fits.GetParameter(1); // signal start time
-  peak_sample = fits.GetParameter(1) + fits.GetParameter(2)/fits.GetParameter(3); // signal peak time
+  //  peak_sample = fits.GetParameter(1); // signal start time
+  peak_sample = fits.GetParameter(1) + fits.GetParameter(2) / fits.GetParameter(3);  // signal peak time
 
   // peak integral = p0*Power(p3,-1 - p2)*Gamma(1 + p2). Note yet used in output
 
@@ -212,7 +165,7 @@ PROTOTYPE4_FEM::SampleFit_PowerLawExp(//
 double
 PROTOTYPE4_FEM::SignalShape_PowerLawExp(double *x, double *par)
 {
-  double pedestal = par[4] + ((x[0] - 1.5* par[1])>0) * par[5]; // quick fix on exting tails on the signal function
+  double pedestal = par[4] + ((x[0] - 1.5 * par[1]) > 0) * par[5];  // quick fix on exting tails on the signal function
   if (x[0] < par[1])
     return pedestal;
   //double  signal = (-1)*par[0]*pow((x[0]-par[1]),par[2])*exp(-(x[0]-par[1])*par[3]);

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
+#include <string>
 
 using namespace std;
 
@@ -108,7 +109,7 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawExp(  //
   peakval -= pedestal;
 
   // fit function
-  TF1 fits("f_SignalShape_PowerLawExp", SignalShape_PowerLawExp, 0., 24., 6);
+  TF1 fits("f_SignalShape_PowerLawExp", SignalShape_PowerLawExp, 0., NSAMPLES, 6);
 
   double par[6] =
       {0};
@@ -121,8 +122,9 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawExp(  //
   par[4] = pedestal;
   par[5] = 0;
   fits.SetParameters(par);
+  fits.SetParNames("Amplitude", "Peak Sample", "Power", "Decay","Pedstal","Baseline shift");
   fits.SetParLimits(0, peakval * 0.9, peakval * 1.1);
-  fits.SetParLimits(1, 0, 24);
+  fits.SetParLimits(1, 0, NSAMPLES);
   fits.SetParLimits(2, 2, 4.);
   fits.SetParLimits(3, 1., 2.);
   fits.SetParLimits(4, pedestal - abs(peakval), pedestal + abs(peakval));
@@ -141,7 +143,11 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawExp(  //
 
   if (verbosity)
   {
-    TCanvas *canvas = new TCanvas("PROTOTYPE4_FEM_SampleFit_PowerLawExp", "PROTOTYPE4_FEM::SampleFit_PowerLawExp");
+    static int id = 0;
+    ++id;
+
+    TCanvas *canvas = new TCanvas(
+        (string("PROTOTYPE4_FEM_SampleFit_PowerLawExp") + to_string(id)).c_str(), "PROTOTYPE4_FEM::SampleFit_PowerLawExp");
     gpulse.DrawClone("ap*l");
     fits.DrawClone("same");
     fits.Print();
@@ -169,7 +175,6 @@ PROTOTYPE4_FEM::SignalShape_PowerLawExp(double *x, double *par)
   if (x[0] < par[1])
     return pedestal;
   //double  signal = (-1)*par[0]*pow((x[0]-par[1]),par[2])*exp(-(x[0]-par[1])*par[3]);
-  double signal = par[0] * pow((x[0] - par[1]), par[2])
-      * exp(-(x[0] - par[1]) * par[3]);
+  double signal = par[0] * pow((x[0] - par[1]), par[2]) * exp(-(x[0] - par[1]) * par[3]);
   return pedestal + signal;
 }

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.h
@@ -1,0 +1,60 @@
+#ifndef __PROTOTYPE3_FEM_H__
+#define __PROTOTYPE3_FEM_H__
+
+#include <string>
+#include <vector>
+
+namespace PROTOTYPE3_FEM
+{
+
+  /*! Packet ID */
+  const int PACKET_ID = 21101;
+
+  /*! Number of ADC Samples per tower */
+  const int NSAMPLES = 24;
+
+  /*! Number of Inner HCAL towers */
+  const int NCH_IHCAL_ROWS = 4;
+  const int NCH_IHCAL_COLUMNS = 4;
+
+  /*! Number of Outer HCAL towers */
+  const int NCH_OHCAL_ROWS = 4;
+  const int NCH_OHCAL_COLUMNS = 4;
+
+  /*! Number of EMCAL towers */
+  const int NCH_EMCAL_ROWS = 8;
+  const int NCH_EMCAL_COLUMNS = 8;
+
+  /*! Error assigned to saturated ADCs */
+  const int SATURATED_ADC_ERROR = 100;
+
+  /*! Error assigned to dead channels */
+  const int DEAD_CHANNEL_ERROR = 300;
+
+  //! FEM mapping of channel -> calorimeter col and rows
+  int
+  GetHBDCh(std::string caloname, int i_column, int i_row);
+
+  //! Abhisek's power-law + exp fit
+  bool
+  SampleFit_PowerLawExp(//
+      const std::vector<double> & samples, //
+      double & peak,//
+      double & peak_sample,//
+      double & pedstal, //
+      const int verbosity = 0
+      );
+
+  // Abhisek's power-law + exp signal shape model
+  double
+  SignalShape_PowerLawExp(double *x, double *par);
+
+
+  //! special treatment for EMCal tagging packet
+  //! See also https://wiki.bnl.gov/sPHENIX/index.php/2017_calorimeter_beam_test#What_is_new_in_the_data_structures_in_2017
+  //! Result stored in RUN_INFO node under variable EMCAL_Is_HighEta
+  const int PACKET_EMCAL_HIGHETA_FLAG = 905;
+
+}
+
+#endif

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.h
@@ -13,7 +13,7 @@ const int PACKET_ID = 21351;
 const int NSAMPLES = 31;
 
 //! Mask to obtain ADC from DWord data
-const int ADC_DATA_MASK = (1<<14)-1;
+const int ADC_DATA_MASK = (1 << 14) - 1;
 
 /*! Number of Inner HCAL towers */
 const int NCH_IHCAL_ROWS = 4;
@@ -34,7 +34,7 @@ const int SATURATED_ADC_ERROR = 100;
 const int DEAD_CHANNEL_ERROR = 300;
 
 //! FEM mapping of channel -> calorimeter col and rows
-int GetHBDCh(std::string caloname, int i_column, int i_row);
+int GetChannelNumber(std::string caloname, int i_column, int i_row);
 
 //! Abhisek's power-law + exp fit
 bool SampleFit_PowerLawExp(              //
@@ -44,7 +44,7 @@ bool SampleFit_PowerLawExp(              //
     double &pedstal,                     //
     const int verbosity = 0);
 
-bool SampleFit_PowerLawDoubleExp(              //
+bool SampleFit_PowerLawDoubleExp(        //
     const std::vector<double> &samples,  //
     double &peak,                        //
     double &peak_sample,                 //

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.h
@@ -6,55 +6,49 @@
 
 namespace PROTOTYPE4_FEM
 {
+/*! Packet ID */
+const int PACKET_ID = 21101;
 
-  /*! Packet ID */
-  const int PACKET_ID = 21101;
+/*! Number of ADC Samples per tower */
+const int NSAMPLES = 24;
 
-  /*! Number of ADC Samples per tower */
-  const int NSAMPLES = 24;
+/*! Number of Inner HCAL towers */
+const int NCH_IHCAL_ROWS = 4;
+const int NCH_IHCAL_COLUMNS = 4;
 
-  /*! Number of Inner HCAL towers */
-  const int NCH_IHCAL_ROWS = 4;
-  const int NCH_IHCAL_COLUMNS = 4;
+/*! Number of Outer HCAL towers */
+const int NCH_OHCAL_ROWS = 4;
+const int NCH_OHCAL_COLUMNS = 4;
 
-  /*! Number of Outer HCAL towers */
-  const int NCH_OHCAL_ROWS = 4;
-  const int NCH_OHCAL_COLUMNS = 4;
+/*! Number of EMCAL towers */
+const int NCH_EMCAL_ROWS = 8;
+const int NCH_EMCAL_COLUMNS = 8;
 
-  /*! Number of EMCAL towers */
-  const int NCH_EMCAL_ROWS = 8;
-  const int NCH_EMCAL_COLUMNS = 8;
+/*! Error assigned to saturated ADCs */
+const int SATURATED_ADC_ERROR = 100;
 
-  /*! Error assigned to saturated ADCs */
-  const int SATURATED_ADC_ERROR = 100;
+/*! Error assigned to dead channels */
+const int DEAD_CHANNEL_ERROR = 300;
 
-  /*! Error assigned to dead channels */
-  const int DEAD_CHANNEL_ERROR = 300;
+//! FEM mapping of channel -> calorimeter col and rows
+int GetHBDCh(std::string caloname, int i_column, int i_row);
 
-  //! FEM mapping of channel -> calorimeter col and rows
-  int
-  GetHBDCh(std::string caloname, int i_column, int i_row);
+//! Abhisek's power-law + exp fit
+bool SampleFit_PowerLawExp(              //
+    const std::vector<double> &samples,  //
+    double &peak,                        //
+    double &peak_sample,                 //
+    double &pedstal,                     //
+    const int verbosity = 0);
 
-  //! Abhisek's power-law + exp fit
-  bool
-  SampleFit_PowerLawExp(//
-      const std::vector<double> & samples, //
-      double & peak,//
-      double & peak_sample,//
-      double & pedstal, //
-      const int verbosity = 0
-      );
+// Abhisek's power-law + exp signal shape model
+double
+SignalShape_PowerLawExp(double *x, double *par);
 
-  // Abhisek's power-law + exp signal shape model
-  double
-  SignalShape_PowerLawExp(double *x, double *par);
-
-
-  //! special treatment for EMCal tagging packet
-  //! See also https://wiki.bnl.gov/sPHENIX/index.php/2017_calorimeter_beam_test#What_is_new_in_the_data_structures_in_2017
-  //! Result stored in RUN_INFO node under variable EMCAL_Is_HighEta
-  const int PACKET_EMCAL_HIGHETA_FLAG = 905;
-
+//! special treatment for EMCal tagging packet
+//! See also https://wiki.bnl.gov/sPHENIX/index.php/2017_calorimeter_beam_test#What_is_new_in_the_data_structures_in_2017
+//! Result stored in RUN_INFO node under variable EMCAL_Is_HighEta
+const int PACKET_EMCAL_HIGHETA_FLAG = 905;
 }
 
 #endif

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.h
@@ -12,6 +12,9 @@ const int PACKET_ID = 21351;
 /*! Number of ADC Samples per tower */
 const int NSAMPLES = 31;
 
+//! Mask to obtain ADC from DWord data
+const int ADC_DATA_MASK = (1<<14)-1;
+
 /*! Number of Inner HCAL towers */
 const int NCH_IHCAL_ROWS = 4;
 const int NCH_IHCAL_COLUMNS = 4;

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.h
@@ -7,10 +7,10 @@
 namespace PROTOTYPE4_FEM
 {
 /*! Packet ID */
-const int PACKET_ID = 21101;
+const int PACKET_ID = 21351;
 
 /*! Number of ADC Samples per tower */
-const int NSAMPLES = 24;
+const int NSAMPLES = 31;
 
 /*! Number of Inner HCAL towers */
 const int NCH_IHCAL_ROWS = 4;

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.h
@@ -44,9 +44,18 @@ bool SampleFit_PowerLawExp(              //
     double &pedstal,                     //
     const int verbosity = 0);
 
+bool SampleFit_PowerLawDoubleExp(              //
+    const std::vector<double> &samples,  //
+    double &peak,                        //
+    double &peak_sample,                 //
+    double &pedstal,                     //
+    const int verbosity = 0);
+
 // Abhisek's power-law + exp signal shape model
 double
 SignalShape_PowerLawExp(double *x, double *par);
+double
+SignalShape_PowerLawDoubleExp(double *x, double *par);
 
 //! special treatment for EMCal tagging packet
 //! See also https://wiki.bnl.gov/sPHENIX/index.php/2017_calorimeter_beam_test#What_is_new_in_the_data_structures_in_2017

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.h
@@ -1,10 +1,10 @@
-#ifndef __PROTOTYPE3_FEM_H__
-#define __PROTOTYPE3_FEM_H__
+#ifndef __PROTOTYPE4_FEM_H__
+#define __PROTOTYPE4_FEM_H__
 
 #include <string>
 #include <vector>
 
-namespace PROTOTYPE3_FEM
+namespace PROTOTYPE4_FEM
 {
 
   /*! Packet ID */

--- a/offline/packages/Prototype4/PROTOTYPE4_FEMLinkDef.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEMLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ namespace PROTOTYPE3_FEM-!;
+
+#endif /* __CINT__ */

--- a/offline/packages/Prototype4/PROTOTYPE4_FEMLinkDef.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEMLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ namespace PROTOTYPE3_FEM-!;
+#pragma link C++ namespace PROTOTYPE4_FEM-!;
 
 #endif /* __CINT__ */

--- a/offline/packages/Prototype4/Prototype3DSTReader.cc
+++ b/offline/packages/Prototype4/Prototype3DSTReader.cc
@@ -1,0 +1,423 @@
+// $Id: Prototype3DSTReader.cc,v 1.11 2015/01/06 02:52:07 jinhuang Exp $
+
+/*!
+ * \file Prototype3DSTReader.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision: 1.11 $
+ * \date $Date: 2015/01/06 02:52:07 $
+ */
+
+#include <fun4all/PHTFileServer.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+//#include <PHGeometry.h>
+
+#include <phool/getClass.h>
+#include <phool/getClass.h>
+
+#include <calobase/RawTowerContainer.h>
+#include <pdbcalbase/PdbParameterMap.h>
+#include <phparameter/PHParameters.h>
+
+#include <TTree.h>
+#include <TMath.h>
+
+#include <boost/foreach.hpp>
+#include <map>
+#include <set>
+#include <cassert>
+
+#include<sstream>
+
+#include "Prototype3DSTReader.h"
+
+using namespace std;
+
+Prototype3DSTReader::Prototype3DSTReader(const string &filename) :
+    SubsysReco("Prototype3DSTReader"), nblocks(0), _event(0), //
+    _out_file_name(filename), /*_file(NULL), */_T(NULL), //
+    _tower_zero_sup(-10000000)
+{
+
+}
+
+Prototype3DSTReader::~Prototype3DSTReader()
+{
+  cout << "Prototype3DSTReader::destructor - Clean ups" << endl;
+
+  if (_T)
+    {
+      _T->ResetBranchAddresses();
+    }
+
+  _records.clear();
+}
+
+int
+Prototype3DSTReader::Init(PHCompositeNode*)
+{
+
+  const static int arr_size = 100;
+
+  if (_tower_postfix.size())
+    {
+      cout
+          << "Prototype3DSTReader::Init - zero suppression for calorimeter towers = "
+          << _tower_zero_sup << " GeV" << endl;
+    }
+  for (vector<string>::const_iterator it = _runinfo_list.begin();
+      it != _runinfo_list.end(); ++it)
+    {
+      const string & nodenam = *it;
+
+      record rec;
+      rec._cnt = 0;
+      rec._name = nodenam;
+      rec._arr = NULL;
+      rec._arr_ptr = NULL;
+      rec._dvalue = 0;
+      rec._type = record::typ_runinfo;
+
+      _records.push_back(rec);
+
+      nblocks++;
+    }
+  for (vector<string>::const_iterator it = _eventinfo_list.begin();
+      it != _eventinfo_list.end(); ++it)
+    {
+      const string & nodenam = *it;
+
+      record rec;
+      rec._cnt = 0;
+      rec._name = nodenam;
+      rec._arr = NULL;
+      rec._arr_ptr = NULL;
+      rec._dvalue = 0;
+      rec._type = record::typ_eventinfo;
+
+      _records.push_back(rec);
+
+      nblocks++;
+    }
+
+  for (vector<string>::const_iterator it = _tower_postfix.begin();
+      it != _tower_postfix.end(); ++it)
+    {
+      const char * class_name = RawTower_type::Class()->GetName();
+
+      const string & nodenam = *it;
+
+      string hname = Form("TOWER_%s", nodenam.c_str());
+//      _node_name.push_back(hname);
+      cout << "Prototype3DSTReader::Init - saving raw tower info from node: "
+          << hname << " - " << class_name << endl;
+
+      record rec;
+      rec._cnt = 0;
+      rec._name = hname;
+      rec._arr = boost::make_shared<TClonesArray>(class_name, arr_size);
+      rec._arr_ptr = rec._arr.get();
+      rec._dvalue = 0;
+      rec._type = record::typ_tower;
+
+      _records.push_back(rec);
+
+      nblocks++;
+    }
+
+  for (vector<string>::const_iterator it = _towertemp_postfix.begin();
+      it != _towertemp_postfix.end(); ++it)
+    {
+      const string & nodenam = *it;
+      string hname = Form("TOWER_TEMPERATURE_%s", nodenam.c_str());
+
+      cout << "Prototype3DSTReader::Init - saving average tower temperature info from node: "
+          << hname<< endl;
+
+      record rec;
+      rec._cnt = 0;
+      rec._name = hname;
+      rec._arr = NULL;
+      rec._arr_ptr = NULL;
+      rec._dvalue = 0;
+      rec._type = record::typ_towertemp;
+
+      _records.push_back(rec);
+
+      nblocks++;
+    }
+  cout << "Prototype3DSTReader::Init - requested " << nblocks << " nodes"
+      << endl;
+
+  build_tree();
+
+  return 0;
+}
+
+void
+Prototype3DSTReader::build_tree()
+{
+  cout << "Prototype3DSTReader::build_tree - output to " << _out_file_name
+      << endl;
+
+  static const int BUFFER_SIZE = 32000;
+
+  // open TFile
+  PHTFileServer::get().open(_out_file_name, "RECREATE");
+
+  _T = new TTree("T", "Prototype3DSTReader");
+
+  nblocks = 0;
+  for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
+    {
+      record & rec = *it;
+
+      cout << "Prototype3DSTReader::build_tree - Add " << rec._name << endl;
+
+      if (rec._type == record::typ_runinfo)
+        {
+
+          const string name_cnt = rec._name;
+          const string name_cnt_desc = name_cnt + "/D";
+          _T->Branch(name_cnt.c_str(), &(rec._dvalue), name_cnt_desc.c_str(),
+              BUFFER_SIZE);
+        }
+      if (rec._type == record::typ_eventinfo)
+        {
+
+          const string name_cnt = rec._name;
+          const string name_cnt_desc = name_cnt + "/D";
+          _T->Branch(name_cnt.c_str(), &(rec._dvalue), name_cnt_desc.c_str(),
+              BUFFER_SIZE);
+        }
+      else if (rec._type == record::typ_tower)
+        {
+
+          const string name_cnt = "n_" + rec._name;
+          const string name_cnt_desc = name_cnt + "/I";
+          _T->Branch(name_cnt.c_str(), &(rec._cnt), name_cnt_desc.c_str(),
+              BUFFER_SIZE);
+          _T->Branch(rec._name.c_str(), &(rec._arr_ptr), BUFFER_SIZE, 99);
+        }
+      else if (rec._type == record::typ_towertemp)
+        {
+
+          const string name_cnt = rec._name + "_AVG";
+          const string name_cnt_desc = name_cnt + "/D";
+          _T->Branch(name_cnt.c_str(), &(rec._dvalue), name_cnt_desc.c_str(),
+              BUFFER_SIZE);
+        }
+
+      nblocks++;
+    }
+
+  cout << "Prototype3DSTReader::build_tree - added " << nblocks << " nodes"
+      << endl;
+
+  _T->SetAutoSave(16000);
+}
+
+int
+Prototype3DSTReader::process_event(PHCompositeNode* topNode)
+{
+
+//  const double significand = _event / TMath::Power(10, (int) (log10(_event)));
+//
+//  if (fmod(significand, 1.0) == 0 && significand <= 10)
+//    cout << "Prototype3DSTReader::process_event - " << _event << endl;
+  _event++;
+
+  for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
+    {
+      record & rec = *it;
+
+      rec._cnt = 0;
+
+      if (rec._type == record::typ_hit)
+        {
+          assert(0);
+        } //      if (rec._type == record::typ_hit)
+      else if (rec._type == record::typ_tower)
+        {
+          assert(rec._arr.get() == rec._arr_ptr);
+          assert(rec._arr.get());
+          rec._arr->Clear();
+
+          if (Verbosity() >= 2)
+            cout << "Prototype3DSTReader::process_event - processing tower "
+                << rec._name << endl;
+
+          RawTowerContainer *hits = findNode::getClass<RawTowerContainer>(
+              topNode, rec._name);
+          if (!hits)
+            {
+              if (_event < 2)
+                cout
+                    << "Prototype3DSTReader::process_event - Error - can not find node "
+                    << rec._name << endl;
+
+            }
+          else
+            {
+              RawTowerContainer::ConstRange hit_range = hits->getTowers();
+
+              if (Verbosity() >= 2)
+                cout << "Prototype3DSTReader::process_event - processing "
+                    << rec._name << " and received " << hits->size()
+                    << " tower hits" << endl;
+
+              for (RawTowerContainer::ConstIterator hit_iter = hit_range.first;
+                  hit_iter != hit_range.second; hit_iter++)
+                {
+                  RawTower * hit_raw = hit_iter->second;
+
+                  RawTower_type * hit = dynamic_cast<RawTower_type *>(hit_raw);
+//                  RawTower * hit = hit_iter->second;
+
+                  assert(hit);
+
+                  if (hit->get_energy() < _tower_zero_sup)
+                    {
+
+                      if (Verbosity() >= 2)
+                        cout
+                            << "Prototype3DSTReader::process_event - suppress low energy tower hit "
+                            << rec._name << " @ ("
+//                            << hit->get_thetaMin()
+//                            << ", " << hit->get_phiMin()
+                            << "), Energy = " << hit->get_energy() << endl;
+
+                      continue;
+                    }
+
+                  new ((*(rec._arr.get()))[rec._cnt]) RawTower_type();
+
+                  if (Verbosity() >= 2)
+                    cout
+                        << "Prototype3DSTReader::process_event - processing Tower hit "
+                        << rec._name << " @ ("
+//                        << hit->get_thetaMin() << ", "
+//                        << hit->get_phiMin()
+                        << "), Energy = " << hit->get_energy() << " - "
+                        << rec._arr.get()->At(rec._cnt)->ClassName() << endl;
+
+//                  rec._arr->Print();
+
+                  RawTower_type * new_hit =
+                      dynamic_cast<RawTower_type *>(rec._arr.get()->At(rec._cnt));
+                  assert(new_hit);
+
+                  *new_hit = (*hit);
+
+                  rec._cnt++;
+                }
+            } // if (!hits)
+        } //      if (rec._type == record::typ_hit)
+      else if (rec._type == record::typ_towertemp)
+        {
+          if (Verbosity() >= 2)
+            cout
+                << "Prototype3DSTReader::process_event - processing tower temperature "
+                << rec._name << endl;
+
+          RawTowerContainer *hits = findNode::getClass<RawTowerContainer>(
+              topNode, rec._name);
+          if (!hits)
+            {
+              if (_event < 2)
+                cout
+                    << "Prototype3DSTReader::process_event - Error - can not find node "
+                    << rec._name << endl;
+
+            }
+          else
+            {
+              RawTowerContainer::ConstRange hit_range = hits->getTowers();
+
+              if (Verbosity() >= 2)
+                cout << "Prototype3DSTReader::process_event - processing "
+                    << rec._name << " and received " << hits->size()
+                    << " tower hits" << endl;
+
+              rec._cnt = 0;
+
+              for (RawTowerContainer::ConstIterator hit_iter = hit_range.first;
+                  hit_iter != hit_range.second; hit_iter++)
+                {
+                  RawTower * hit_raw = hit_iter->second;
+
+                  RawTowerT_type * hit = dynamic_cast<RawTowerT_type *>(hit_raw);
+//                  RawTower * hit = hit_iter->second;
+
+                  assert(hit);
+
+                  rec._dvalue += hit->get_temperature_from_entry(
+                      hit->get_nr_entries() - 1);
+
+                  ++rec._cnt;
+                }
+
+              rec._dvalue /= rec._cnt;
+            } // if (!hits)
+        } //      if (rec._type == record::typ_hit)
+      else if (rec._type == record::typ_runinfo)
+        {
+
+          PdbParameterMap *info = findNode::getClass<PdbParameterMap>(topNode,
+              "RUN_INFO");
+
+          assert(info);
+
+          PHParameters run_info_copy("RunInfo");
+          run_info_copy.FillFrom(info);
+
+          rec._dvalue = run_info_copy.get_double_param(rec._name);
+
+        } //
+      else if (rec._type == record::typ_eventinfo)
+        {
+
+          PdbParameterMap *info = findNode::getClass<PdbParameterMap>(topNode,
+              "EVENT_INFO");
+
+          assert(info);
+
+          PHParameters event_info_copy("EVENT_INFO");
+          event_info_copy.FillFrom(info);
+
+          rec._dvalue = event_info_copy.get_double_param(rec._name);
+
+        } //      if (rec._type == record::typ_hit)
+      else if (rec._type == record::typ_part)
+        {
+          assert(0);
+        } //      if (rec._type == record::typ_part)
+      else if (rec._type == record::typ_vertex)
+        {
+          assert(0);
+        } //          if (_load_all_particle)
+
+    } //  for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
+
+  if (_T)
+    _T->Fill();
+
+  return 0;
+} //  for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
+
+int
+Prototype3DSTReader::End(PHCompositeNode * /*topNode*/)
+{
+  cout << "Prototype3DSTReader::End - Clean ups" << endl;
+
+  if (_T)
+    {
+      PHTFileServer::get().cd(_out_file_name);
+      _T->Write();
+      _T->ResetBranchAddresses();
+    }
+
+  _records.clear();
+
+  return 0;
+}

--- a/offline/packages/Prototype4/Prototype3DSTReader.h
+++ b/offline/packages/Prototype4/Prototype3DSTReader.h
@@ -1,0 +1,145 @@
+// $Id: Prototype3DSTReader.h,v 1.7 2015/02/27 23:42:23 jinhuang Exp $
+
+/*!
+ * \file Prototype3DSTReader.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision: 1.7 $
+ * \date $Date: 2015/02/27 23:42:23 $
+ */
+
+#ifndef Prototype3DSTReader_H_
+#define Prototype3DSTReader_H_
+
+#include "RawTower_Prototype3.h"
+#include "RawTower_Temperature.h"
+
+#include <HepMC/GenEvent.h>
+#include <HepMC/SimpleVector.h>
+#include <fun4all/SubsysReco.h>
+#include <string>
+#include <iostream>
+#include <vector>
+#include <TClonesArray.h>
+
+class TTree;
+
+#ifndef __CINT__
+
+#include <boost/smart_ptr.hpp>
+
+#endif
+
+/*!
+ * \brief Prototype3DSTReader save information from DST to an evaluator, which could include hit. particle, vertex, towers and jet (to be activated)
+ */
+class Prototype3DSTReader : public SubsysReco
+{
+public:
+  Prototype3DSTReader(const std::string &filename);
+  virtual
+  ~Prototype3DSTReader();
+
+  //! full initialization
+  int
+  Init(PHCompositeNode *);
+
+  //! event processing method
+  int
+  process_event(PHCompositeNode *);
+
+  //! end of run method
+  int
+  End(PHCompositeNode *);
+
+  void
+  AddTower(const std::string &name)
+  {
+    _tower_postfix.push_back(name);
+  }
+
+  void
+  AddTowerTemperature(const std::string &name)
+  {
+    _towertemp_postfix.push_back(name);
+  }
+
+  void
+  AddRunInfo(const std::string &name)
+  {
+    _runinfo_list.push_back(name);
+  }
+  void
+  AddEventInfo(const std::string &name)
+  {
+    _eventinfo_list.push_back(name);
+  }
+
+  //! zero suppression for all calorimeters
+  double
+  get_tower_zero_sup()
+  {
+    return _tower_zero_sup;
+  }
+
+  //! zero suppression for all calorimeters
+  void
+  set_tower_zero_sup(double b)
+  {
+    _tower_zero_sup = b;
+  }
+
+protected:
+
+//  std::vector<std::string> _node_postfix;
+  std::vector<std::string> _tower_postfix;
+  //! tower temperature
+  std::vector<std::string> _towertemp_postfix;
+//  std::vector<std::string> _jet_postfix;
+//  std::vector<std::string> _node_name;
+  std::vector<std::string> _runinfo_list;
+  std::vector<std::string> _eventinfo_list;
+
+  int nblocks;
+
+#ifndef __CINT__
+
+  typedef boost::shared_ptr<TClonesArray> arr_ptr;
+
+  struct record
+  {
+    unsigned int _cnt;
+    std::string _name;
+    arr_ptr _arr;
+    TClonesArray * _arr_ptr;
+    double _dvalue;
+
+    enum enu_type
+    {
+      typ_hit, typ_part, typ_vertex, typ_tower, typ_jets, typ_runinfo, typ_eventinfo, typ_towertemp
+    };
+    enu_type _type;
+  };
+  typedef std::vector<record> records_t;
+  records_t _records;
+
+  typedef RawTower_Prototype3 RawTower_type;
+
+  typedef RawTower_Temperature RawTowerT_type;
+#endif
+
+  int _event;
+
+  std::string _out_file_name;
+
+//  TFile * _file;
+  TTree * _T;
+
+  //! zero suppression for all calorimeters
+  double _tower_zero_sup;
+
+  void
+  build_tree();
+};
+
+#endif /* Prototype3DSTReader_H_ */

--- a/offline/packages/Prototype4/Prototype3DSTReaderLinkDef.h
+++ b/offline/packages/Prototype4/Prototype3DSTReaderLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class Prototype3DSTReader-!;
-
-#endif /* __CINT__ */

--- a/offline/packages/Prototype4/Prototype3DSTReaderLinkDef.h
+++ b/offline/packages/Prototype4/Prototype3DSTReaderLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class Prototype3DSTReader-!;
+
+#endif /* __CINT__ */

--- a/offline/packages/Prototype4/Prototype4DSTReader.cc
+++ b/offline/packages/Prototype4/Prototype4DSTReader.cc
@@ -1,7 +1,7 @@
-// $Id: Prototype3DSTReader.cc,v 1.11 2015/01/06 02:52:07 jinhuang Exp $
+// $Id: Prototype4DSTReader.cc,v 1.11 2015/01/06 02:52:07 jinhuang Exp $
 
 /*!
- * \file Prototype3DSTReader.cc
+ * \file Prototype4DSTReader.cc
  * \brief 
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision: 1.11 $
@@ -29,21 +29,21 @@
 
 #include<sstream>
 
-#include "Prototype3DSTReader.h"
+#include "Prototype4DSTReader.h"
 
 using namespace std;
 
-Prototype3DSTReader::Prototype3DSTReader(const string &filename) :
-    SubsysReco("Prototype3DSTReader"), nblocks(0), _event(0), //
+Prototype4DSTReader::Prototype4DSTReader(const string &filename) :
+    SubsysReco("Prototype4DSTReader"), nblocks(0), _event(0), //
     _out_file_name(filename), /*_file(NULL), */_T(NULL), //
     _tower_zero_sup(-10000000)
 {
 
 }
 
-Prototype3DSTReader::~Prototype3DSTReader()
+Prototype4DSTReader::~Prototype4DSTReader()
 {
-  cout << "Prototype3DSTReader::destructor - Clean ups" << endl;
+  cout << "Prototype4DSTReader::destructor - Clean ups" << endl;
 
   if (_T)
     {
@@ -54,7 +54,7 @@ Prototype3DSTReader::~Prototype3DSTReader()
 }
 
 int
-Prototype3DSTReader::Init(PHCompositeNode*)
+Prototype4DSTReader::Init(PHCompositeNode*)
 {
 
   const static int arr_size = 100;
@@ -62,7 +62,7 @@ Prototype3DSTReader::Init(PHCompositeNode*)
   if (_tower_postfix.size())
     {
       cout
-          << "Prototype3DSTReader::Init - zero suppression for calorimeter towers = "
+          << "Prototype4DSTReader::Init - zero suppression for calorimeter towers = "
           << _tower_zero_sup << " GeV" << endl;
     }
   for (vector<string>::const_iterator it = _runinfo_list.begin();
@@ -109,7 +109,7 @@ Prototype3DSTReader::Init(PHCompositeNode*)
 
       string hname = Form("TOWER_%s", nodenam.c_str());
 //      _node_name.push_back(hname);
-      cout << "Prototype3DSTReader::Init - saving raw tower info from node: "
+      cout << "Prototype4DSTReader::Init - saving raw tower info from node: "
           << hname << " - " << class_name << endl;
 
       record rec;
@@ -131,7 +131,7 @@ Prototype3DSTReader::Init(PHCompositeNode*)
       const string & nodenam = *it;
       string hname = Form("TOWER_TEMPERATURE_%s", nodenam.c_str());
 
-      cout << "Prototype3DSTReader::Init - saving average tower temperature info from node: "
+      cout << "Prototype4DSTReader::Init - saving average tower temperature info from node: "
           << hname<< endl;
 
       record rec;
@@ -146,7 +146,7 @@ Prototype3DSTReader::Init(PHCompositeNode*)
 
       nblocks++;
     }
-  cout << "Prototype3DSTReader::Init - requested " << nblocks << " nodes"
+  cout << "Prototype4DSTReader::Init - requested " << nblocks << " nodes"
       << endl;
 
   build_tree();
@@ -155,9 +155,9 @@ Prototype3DSTReader::Init(PHCompositeNode*)
 }
 
 void
-Prototype3DSTReader::build_tree()
+Prototype4DSTReader::build_tree()
 {
-  cout << "Prototype3DSTReader::build_tree - output to " << _out_file_name
+  cout << "Prototype4DSTReader::build_tree - output to " << _out_file_name
       << endl;
 
   static const int BUFFER_SIZE = 32000;
@@ -165,14 +165,14 @@ Prototype3DSTReader::build_tree()
   // open TFile
   PHTFileServer::get().open(_out_file_name, "RECREATE");
 
-  _T = new TTree("T", "Prototype3DSTReader");
+  _T = new TTree("T", "Prototype4DSTReader");
 
   nblocks = 0;
   for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
     {
       record & rec = *it;
 
-      cout << "Prototype3DSTReader::build_tree - Add " << rec._name << endl;
+      cout << "Prototype4DSTReader::build_tree - Add " << rec._name << endl;
 
       if (rec._type == record::typ_runinfo)
         {
@@ -211,20 +211,20 @@ Prototype3DSTReader::build_tree()
       nblocks++;
     }
 
-  cout << "Prototype3DSTReader::build_tree - added " << nblocks << " nodes"
+  cout << "Prototype4DSTReader::build_tree - added " << nblocks << " nodes"
       << endl;
 
   _T->SetAutoSave(16000);
 }
 
 int
-Prototype3DSTReader::process_event(PHCompositeNode* topNode)
+Prototype4DSTReader::process_event(PHCompositeNode* topNode)
 {
 
 //  const double significand = _event / TMath::Power(10, (int) (log10(_event)));
 //
 //  if (fmod(significand, 1.0) == 0 && significand <= 10)
-//    cout << "Prototype3DSTReader::process_event - " << _event << endl;
+//    cout << "Prototype4DSTReader::process_event - " << _event << endl;
   _event++;
 
   for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
@@ -244,7 +244,7 @@ Prototype3DSTReader::process_event(PHCompositeNode* topNode)
           rec._arr->Clear();
 
           if (Verbosity() >= 2)
-            cout << "Prototype3DSTReader::process_event - processing tower "
+            cout << "Prototype4DSTReader::process_event - processing tower "
                 << rec._name << endl;
 
           RawTowerContainer *hits = findNode::getClass<RawTowerContainer>(
@@ -253,7 +253,7 @@ Prototype3DSTReader::process_event(PHCompositeNode* topNode)
             {
               if (_event < 2)
                 cout
-                    << "Prototype3DSTReader::process_event - Error - can not find node "
+                    << "Prototype4DSTReader::process_event - Error - can not find node "
                     << rec._name << endl;
 
             }
@@ -262,7 +262,7 @@ Prototype3DSTReader::process_event(PHCompositeNode* topNode)
               RawTowerContainer::ConstRange hit_range = hits->getTowers();
 
               if (Verbosity() >= 2)
-                cout << "Prototype3DSTReader::process_event - processing "
+                cout << "Prototype4DSTReader::process_event - processing "
                     << rec._name << " and received " << hits->size()
                     << " tower hits" << endl;
 
@@ -281,7 +281,7 @@ Prototype3DSTReader::process_event(PHCompositeNode* topNode)
 
                       if (Verbosity() >= 2)
                         cout
-                            << "Prototype3DSTReader::process_event - suppress low energy tower hit "
+                            << "Prototype4DSTReader::process_event - suppress low energy tower hit "
                             << rec._name << " @ ("
 //                            << hit->get_thetaMin()
 //                            << ", " << hit->get_phiMin()
@@ -294,7 +294,7 @@ Prototype3DSTReader::process_event(PHCompositeNode* topNode)
 
                   if (Verbosity() >= 2)
                     cout
-                        << "Prototype3DSTReader::process_event - processing Tower hit "
+                        << "Prototype4DSTReader::process_event - processing Tower hit "
                         << rec._name << " @ ("
 //                        << hit->get_thetaMin() << ", "
 //                        << hit->get_phiMin()
@@ -317,7 +317,7 @@ Prototype3DSTReader::process_event(PHCompositeNode* topNode)
         {
           if (Verbosity() >= 2)
             cout
-                << "Prototype3DSTReader::process_event - processing tower temperature "
+                << "Prototype4DSTReader::process_event - processing tower temperature "
                 << rec._name << endl;
 
           RawTowerContainer *hits = findNode::getClass<RawTowerContainer>(
@@ -326,7 +326,7 @@ Prototype3DSTReader::process_event(PHCompositeNode* topNode)
             {
               if (_event < 2)
                 cout
-                    << "Prototype3DSTReader::process_event - Error - can not find node "
+                    << "Prototype4DSTReader::process_event - Error - can not find node "
                     << rec._name << endl;
 
             }
@@ -335,7 +335,7 @@ Prototype3DSTReader::process_event(PHCompositeNode* topNode)
               RawTowerContainer::ConstRange hit_range = hits->getTowers();
 
               if (Verbosity() >= 2)
-                cout << "Prototype3DSTReader::process_event - processing "
+                cout << "Prototype4DSTReader::process_event - processing "
                     << rec._name << " and received " << hits->size()
                     << " tower hits" << endl;
 
@@ -406,9 +406,9 @@ Prototype3DSTReader::process_event(PHCompositeNode* topNode)
 } //  for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
 
 int
-Prototype3DSTReader::End(PHCompositeNode * /*topNode*/)
+Prototype4DSTReader::End(PHCompositeNode * /*topNode*/)
 {
-  cout << "Prototype3DSTReader::End - Clean ups" << endl;
+  cout << "Prototype4DSTReader::End - Clean ups" << endl;
 
   if (_T)
     {

--- a/offline/packages/Prototype4/Prototype4DSTReader.cc
+++ b/offline/packages/Prototype4/Prototype4DSTReader.cc
@@ -8,8 +8,8 @@
  * \date $Date: 2015/01/06 02:52:07 $
  */
 
-#include <fun4all/PHTFileServer.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/PHTFileServer.h>
 //#include <PHGeometry.h>
 
 #include <phool/getClass.h>
@@ -19,26 +19,30 @@
 #include <pdbcalbase/PdbParameterMap.h>
 #include <phparameter/PHParameters.h>
 
-#include <TTree.h>
 #include <TMath.h>
+#include <TTree.h>
 
 #include <boost/foreach.hpp>
+#include <cassert>
 #include <map>
 #include <set>
-#include <cassert>
 
-#include<sstream>
+#include <sstream>
 
 #include "Prototype4DSTReader.h"
 
 using namespace std;
 
-Prototype4DSTReader::Prototype4DSTReader(const string &filename) :
-    SubsysReco("Prototype4DSTReader"), nblocks(0), _event(0), //
-    _out_file_name(filename), /*_file(NULL), */_T(NULL), //
-    _tower_zero_sup(-10000000)
+Prototype4DSTReader::Prototype4DSTReader(const string &filename)
+  : SubsysReco("Prototype4DSTReader")
+  , nblocks(0)
+  , _event(0)
+  ,  //
+  _out_file_name(filename)
+  , /*_file(NULL), */ _T(NULL)
+  ,  //
+  _tower_zero_sup(-10000000)
 {
-
 }
 
 Prototype4DSTReader::~Prototype4DSTReader()
@@ -46,119 +50,116 @@ Prototype4DSTReader::~Prototype4DSTReader()
   cout << "Prototype4DSTReader::destructor - Clean ups" << endl;
 
   if (_T)
-    {
-      _T->ResetBranchAddresses();
-    }
+  {
+    _T->ResetBranchAddresses();
+  }
 
   _records.clear();
 }
 
-int
-Prototype4DSTReader::Init(PHCompositeNode*)
+int Prototype4DSTReader::Init(PHCompositeNode *)
 {
-
   const static int arr_size = 100;
 
   if (_tower_postfix.size())
-    {
-      cout
-          << "Prototype4DSTReader::Init - zero suppression for calorimeter towers = "
-          << _tower_zero_sup << " GeV" << endl;
-    }
+  {
+    cout
+        << "Prototype4DSTReader::Init - zero suppression for calorimeter towers = "
+        << _tower_zero_sup << " GeV" << endl;
+  }
   for (vector<string>::const_iterator it = _runinfo_list.begin();
-      it != _runinfo_list.end(); ++it)
-    {
-      const string & nodenam = *it;
+       it != _runinfo_list.end(); ++it)
+  {
+    const string &nodenam = *it;
 
-      record rec;
-      rec._cnt = 0;
-      rec._name = nodenam;
-      rec._arr = NULL;
-      rec._arr_ptr = NULL;
-      rec._dvalue = 0;
-      rec._type = record::typ_runinfo;
+    record rec;
+    rec._cnt = 0;
+    rec._name = nodenam;
+    rec._arr = NULL;
+    rec._arr_ptr = NULL;
+    rec._dvalue = 0;
+    rec._type = record::typ_runinfo;
 
-      _records.push_back(rec);
+    _records.push_back(rec);
 
-      nblocks++;
-    }
+    nblocks++;
+  }
   for (vector<string>::const_iterator it = _eventinfo_list.begin();
-      it != _eventinfo_list.end(); ++it)
-    {
-      const string & nodenam = *it;
+       it != _eventinfo_list.end(); ++it)
+  {
+    const string &nodenam = *it;
 
-      record rec;
-      rec._cnt = 0;
-      rec._name = nodenam;
-      rec._arr = NULL;
-      rec._arr_ptr = NULL;
-      rec._dvalue = 0;
-      rec._type = record::typ_eventinfo;
+    record rec;
+    rec._cnt = 0;
+    rec._name = nodenam;
+    rec._arr = NULL;
+    rec._arr_ptr = NULL;
+    rec._dvalue = 0;
+    rec._type = record::typ_eventinfo;
 
-      _records.push_back(rec);
+    _records.push_back(rec);
 
-      nblocks++;
-    }
+    nblocks++;
+  }
 
   for (vector<string>::const_iterator it = _tower_postfix.begin();
-      it != _tower_postfix.end(); ++it)
-    {
-      const char * class_name = RawTower_type::Class()->GetName();
+       it != _tower_postfix.end(); ++it)
+  {
+    const char *class_name = RawTower_type::Class()->GetName();
 
-      const string & nodenam = *it;
+    const string &nodenam = *it;
 
-      string hname = Form("TOWER_%s", nodenam.c_str());
-//      _node_name.push_back(hname);
-      cout << "Prototype4DSTReader::Init - saving raw tower info from node: "
-          << hname << " - " << class_name << endl;
+    string hname = Form("TOWER_%s", nodenam.c_str());
+    //      _node_name.push_back(hname);
+    cout << "Prototype4DSTReader::Init - saving raw tower info from node: "
+         << hname << " - " << class_name << endl;
 
-      record rec;
-      rec._cnt = 0;
-      rec._name = hname;
-      rec._arr = boost::make_shared<TClonesArray>(class_name, arr_size);
-      rec._arr_ptr = rec._arr.get();
-      rec._dvalue = 0;
-      rec._type = record::typ_tower;
+    record rec;
+    rec._cnt = 0;
+    rec._name = hname;
+    rec._arr = boost::make_shared<TClonesArray>(class_name, arr_size);
+    rec._arr_ptr = rec._arr.get();
+    rec._dvalue = 0;
+    rec._type = record::typ_tower;
 
-      _records.push_back(rec);
+    _records.push_back(rec);
 
-      nblocks++;
-    }
+    nblocks++;
+  }
 
   for (vector<string>::const_iterator it = _towertemp_postfix.begin();
-      it != _towertemp_postfix.end(); ++it)
-    {
-      const string & nodenam = *it;
-      string hname = Form("TOWER_TEMPERATURE_%s", nodenam.c_str());
+       it != _towertemp_postfix.end(); ++it)
+  {
+    const string &nodenam = *it;
+    string hname = Form("TOWER_TEMPERATURE_%s", nodenam.c_str());
 
-      cout << "Prototype4DSTReader::Init - saving average tower temperature info from node: "
-          << hname<< endl;
+    cout << "Prototype4DSTReader::Init - saving average tower temperature info from node: "
+         << hname << endl;
 
-      record rec;
-      rec._cnt = 0;
-      rec._name = hname;
-      rec._arr = NULL;
-      rec._arr_ptr = NULL;
-      rec._dvalue = 0;
-      rec._type = record::typ_towertemp;
+    record rec;
+    rec._cnt = 0;
+    rec._name = hname;
+    rec._arr = NULL;
+    rec._arr_ptr = NULL;
+    rec._dvalue = 0;
+    rec._type = record::typ_towertemp;
 
-      _records.push_back(rec);
+    _records.push_back(rec);
 
-      nblocks++;
-    }
+    nblocks++;
+  }
   cout << "Prototype4DSTReader::Init - requested " << nblocks << " nodes"
-      << endl;
+       << endl;
 
   build_tree();
 
   return 0;
 }
 
-void
-Prototype4DSTReader::build_tree()
+void Prototype4DSTReader::build_tree()
 {
   cout << "Prototype4DSTReader::build_tree - output to " << _out_file_name
-      << endl;
+       << endl;
 
   static const int BUFFER_SIZE = 32000;
 
@@ -169,253 +170,241 @@ Prototype4DSTReader::build_tree()
 
   nblocks = 0;
   for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
+  {
+    record &rec = *it;
+
+    cout << "Prototype4DSTReader::build_tree - Add " << rec._name << endl;
+
+    if (rec._type == record::typ_runinfo)
     {
-      record & rec = *it;
-
-      cout << "Prototype4DSTReader::build_tree - Add " << rec._name << endl;
-
-      if (rec._type == record::typ_runinfo)
-        {
-
-          const string name_cnt = rec._name;
-          const string name_cnt_desc = name_cnt + "/D";
-          _T->Branch(name_cnt.c_str(), &(rec._dvalue), name_cnt_desc.c_str(),
-              BUFFER_SIZE);
-        }
-      if (rec._type == record::typ_eventinfo)
-        {
-
-          const string name_cnt = rec._name;
-          const string name_cnt_desc = name_cnt + "/D";
-          _T->Branch(name_cnt.c_str(), &(rec._dvalue), name_cnt_desc.c_str(),
-              BUFFER_SIZE);
-        }
-      else if (rec._type == record::typ_tower)
-        {
-
-          const string name_cnt = "n_" + rec._name;
-          const string name_cnt_desc = name_cnt + "/I";
-          _T->Branch(name_cnt.c_str(), &(rec._cnt), name_cnt_desc.c_str(),
-              BUFFER_SIZE);
-          _T->Branch(rec._name.c_str(), &(rec._arr_ptr), BUFFER_SIZE, 99);
-        }
-      else if (rec._type == record::typ_towertemp)
-        {
-
-          const string name_cnt = rec._name + "_AVG";
-          const string name_cnt_desc = name_cnt + "/D";
-          _T->Branch(name_cnt.c_str(), &(rec._dvalue), name_cnt_desc.c_str(),
-              BUFFER_SIZE);
-        }
-
-      nblocks++;
+      const string name_cnt = rec._name;
+      const string name_cnt_desc = name_cnt + "/D";
+      _T->Branch(name_cnt.c_str(), &(rec._dvalue), name_cnt_desc.c_str(),
+                 BUFFER_SIZE);
+    }
+    if (rec._type == record::typ_eventinfo)
+    {
+      const string name_cnt = rec._name;
+      const string name_cnt_desc = name_cnt + "/D";
+      _T->Branch(name_cnt.c_str(), &(rec._dvalue), name_cnt_desc.c_str(),
+                 BUFFER_SIZE);
+    }
+    else if (rec._type == record::typ_tower)
+    {
+      const string name_cnt = "n_" + rec._name;
+      const string name_cnt_desc = name_cnt + "/I";
+      _T->Branch(name_cnt.c_str(), &(rec._cnt), name_cnt_desc.c_str(),
+                 BUFFER_SIZE);
+      _T->Branch(rec._name.c_str(), &(rec._arr_ptr), BUFFER_SIZE, 99);
+    }
+    else if (rec._type == record::typ_towertemp)
+    {
+      const string name_cnt = rec._name + "_AVG";
+      const string name_cnt_desc = name_cnt + "/D";
+      _T->Branch(name_cnt.c_str(), &(rec._dvalue), name_cnt_desc.c_str(),
+                 BUFFER_SIZE);
     }
 
+    nblocks++;
+  }
+
   cout << "Prototype4DSTReader::build_tree - added " << nblocks << " nodes"
-      << endl;
+       << endl;
 
   _T->SetAutoSave(16000);
 }
 
-int
-Prototype4DSTReader::process_event(PHCompositeNode* topNode)
+int Prototype4DSTReader::process_event(PHCompositeNode *topNode)
 {
-
-//  const double significand = _event / TMath::Power(10, (int) (log10(_event)));
-//
-//  if (fmod(significand, 1.0) == 0 && significand <= 10)
-//    cout << "Prototype4DSTReader::process_event - " << _event << endl;
+  //  const double significand = _event / TMath::Power(10, (int) (log10(_event)));
+  //
+  //  if (fmod(significand, 1.0) == 0 && significand <= 10)
+  //    cout << "Prototype4DSTReader::process_event - " << _event << endl;
   _event++;
 
   for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
+  {
+    record &rec = *it;
+
+    rec._cnt = 0;
+
+    if (rec._type == record::typ_hit)
     {
-      record & rec = *it;
+      assert(0);
+    }  //      if (rec._type == record::typ_hit)
+    else if (rec._type == record::typ_tower)
+    {
+      assert(rec._arr.get() == rec._arr_ptr);
+      assert(rec._arr.get());
+      rec._arr->Clear();
 
-      rec._cnt = 0;
+      if (Verbosity() >= 2)
+        cout << "Prototype4DSTReader::process_event - processing tower "
+             << rec._name << endl;
 
-      if (rec._type == record::typ_hit)
+      RawTowerContainer *hits = findNode::getClass<RawTowerContainer>(
+          topNode, rec._name);
+      if (!hits)
+      {
+        if (_event < 2)
+          cout
+              << "Prototype4DSTReader::process_event - Error - can not find node "
+              << rec._name << endl;
+      }
+      else
+      {
+        RawTowerContainer::ConstRange hit_range = hits->getTowers();
+
+        if (Verbosity() >= 2)
+          cout << "Prototype4DSTReader::process_event - processing "
+               << rec._name << " and received " << hits->size()
+               << " tower hits" << endl;
+
+        for (RawTowerContainer::ConstIterator hit_iter = hit_range.first;
+             hit_iter != hit_range.second; hit_iter++)
         {
-          assert(0);
-        } //      if (rec._type == record::typ_hit)
-      else if (rec._type == record::typ_tower)
-        {
-          assert(rec._arr.get() == rec._arr_ptr);
-          assert(rec._arr.get());
-          rec._arr->Clear();
+          RawTower *hit_raw = hit_iter->second;
 
-          if (Verbosity() >= 2)
-            cout << "Prototype4DSTReader::process_event - processing tower "
-                << rec._name << endl;
+          RawTower_type *hit = dynamic_cast<RawTower_type *>(hit_raw);
+          //                  RawTower * hit = hit_iter->second;
 
-          RawTowerContainer *hits = findNode::getClass<RawTowerContainer>(
-              topNode, rec._name);
-          if (!hits)
-            {
-              if (_event < 2)
-                cout
-                    << "Prototype4DSTReader::process_event - Error - can not find node "
-                    << rec._name << endl;
+          assert(hit);
 
-            }
-          else
-            {
-              RawTowerContainer::ConstRange hit_range = hits->getTowers();
+          if (hit->get_energy() < _tower_zero_sup)
+          {
+            if (Verbosity() >= 2)
+              cout
+                  << "Prototype4DSTReader::process_event - suppress low energy tower hit "
+                  << rec._name << " @ ("
+                  //                            << hit->get_thetaMin()
+                  //                            << ", " << hit->get_phiMin()
+                  << "), Energy = " << hit->get_energy() << endl;
 
-              if (Verbosity() >= 2)
-                cout << "Prototype4DSTReader::process_event - processing "
-                    << rec._name << " and received " << hits->size()
-                    << " tower hits" << endl;
+            continue;
+          }
 
-              for (RawTowerContainer::ConstIterator hit_iter = hit_range.first;
-                  hit_iter != hit_range.second; hit_iter++)
-                {
-                  RawTower * hit_raw = hit_iter->second;
+          new ((*(rec._arr.get()))[rec._cnt]) RawTower_type();
 
-                  RawTower_type * hit = dynamic_cast<RawTower_type *>(hit_raw);
-//                  RawTower * hit = hit_iter->second;
-
-                  assert(hit);
-
-                  if (hit->get_energy() < _tower_zero_sup)
-                    {
-
-                      if (Verbosity() >= 2)
-                        cout
-                            << "Prototype4DSTReader::process_event - suppress low energy tower hit "
-                            << rec._name << " @ ("
-//                            << hit->get_thetaMin()
-//                            << ", " << hit->get_phiMin()
-                            << "), Energy = " << hit->get_energy() << endl;
-
-                      continue;
-                    }
-
-                  new ((*(rec._arr.get()))[rec._cnt]) RawTower_type();
-
-                  if (Verbosity() >= 2)
-                    cout
-                        << "Prototype4DSTReader::process_event - processing Tower hit "
-                        << rec._name << " @ ("
-//                        << hit->get_thetaMin() << ", "
-//                        << hit->get_phiMin()
-                        << "), Energy = " << hit->get_energy() << " - "
-                        << rec._arr.get()->At(rec._cnt)->ClassName() << endl;
-
-//                  rec._arr->Print();
-
-                  RawTower_type * new_hit =
-                      dynamic_cast<RawTower_type *>(rec._arr.get()->At(rec._cnt));
-                  assert(new_hit);
-
-                  *new_hit = (*hit);
-
-                  rec._cnt++;
-                }
-            } // if (!hits)
-        } //      if (rec._type == record::typ_hit)
-      else if (rec._type == record::typ_towertemp)
-        {
           if (Verbosity() >= 2)
             cout
-                << "Prototype4DSTReader::process_event - processing tower temperature "
-                << rec._name << endl;
+                << "Prototype4DSTReader::process_event - processing Tower hit "
+                << rec._name << " @ ("
+                //                        << hit->get_thetaMin() << ", "
+                //                        << hit->get_phiMin()
+                << "), Energy = " << hit->get_energy() << " - "
+                << rec._arr.get()->At(rec._cnt)->ClassName() << endl;
 
-          RawTowerContainer *hits = findNode::getClass<RawTowerContainer>(
-              topNode, rec._name);
-          if (!hits)
-            {
-              if (_event < 2)
-                cout
-                    << "Prototype4DSTReader::process_event - Error - can not find node "
-                    << rec._name << endl;
+          //                  rec._arr->Print();
 
-            }
-          else
-            {
-              RawTowerContainer::ConstRange hit_range = hits->getTowers();
+          RawTower_type *new_hit =
+              dynamic_cast<RawTower_type *>(rec._arr.get()->At(rec._cnt));
+          assert(new_hit);
 
-              if (Verbosity() >= 2)
-                cout << "Prototype4DSTReader::process_event - processing "
-                    << rec._name << " and received " << hits->size()
-                    << " tower hits" << endl;
+          *new_hit = (*hit);
 
-              rec._cnt = 0;
+          rec._cnt++;
+        }
+      }  // if (!hits)
+    }    //      if (rec._type == record::typ_hit)
+    else if (rec._type == record::typ_towertemp)
+    {
+      if (Verbosity() >= 2)
+        cout
+            << "Prototype4DSTReader::process_event - processing tower temperature "
+            << rec._name << endl;
 
-              for (RawTowerContainer::ConstIterator hit_iter = hit_range.first;
-                  hit_iter != hit_range.second; hit_iter++)
-                {
-                  RawTower * hit_raw = hit_iter->second;
+      RawTowerContainer *hits = findNode::getClass<RawTowerContainer>(
+          topNode, rec._name);
+      if (!hits)
+      {
+        if (_event < 2)
+          cout
+              << "Prototype4DSTReader::process_event - Error - can not find node "
+              << rec._name << endl;
+      }
+      else
+      {
+        RawTowerContainer::ConstRange hit_range = hits->getTowers();
 
-                  RawTowerT_type * hit = dynamic_cast<RawTowerT_type *>(hit_raw);
-//                  RawTower * hit = hit_iter->second;
+        if (Verbosity() >= 2)
+          cout << "Prototype4DSTReader::process_event - processing "
+               << rec._name << " and received " << hits->size()
+               << " tower hits" << endl;
 
-                  assert(hit);
+        rec._cnt = 0;
 
-                  rec._dvalue += hit->get_temperature_from_entry(
-                      hit->get_nr_entries() - 1);
-
-                  ++rec._cnt;
-                }
-
-              rec._dvalue /= rec._cnt;
-            } // if (!hits)
-        } //      if (rec._type == record::typ_hit)
-      else if (rec._type == record::typ_runinfo)
+        for (RawTowerContainer::ConstIterator hit_iter = hit_range.first;
+             hit_iter != hit_range.second; hit_iter++)
         {
+          RawTower *hit_raw = hit_iter->second;
 
-          PdbParameterMap *info = findNode::getClass<PdbParameterMap>(topNode,
-              "RUN_INFO");
+          RawTowerT_type *hit = dynamic_cast<RawTowerT_type *>(hit_raw);
+          //                  RawTower * hit = hit_iter->second;
 
-          assert(info);
+          assert(hit);
 
-          PHParameters run_info_copy("RunInfo");
-          run_info_copy.FillFrom(info);
+          rec._dvalue += hit->get_temperature_from_entry(
+              hit->get_nr_entries() - 1);
 
-          rec._dvalue = run_info_copy.get_double_param(rec._name);
+          ++rec._cnt;
+        }
 
-        } //
-      else if (rec._type == record::typ_eventinfo)
-        {
+        rec._dvalue /= rec._cnt;
+      }  // if (!hits)
+    }    //      if (rec._type == record::typ_hit)
+    else if (rec._type == record::typ_runinfo)
+    {
+      PdbParameterMap *info = findNode::getClass<PdbParameterMap>(topNode,
+                                                                  "RUN_INFO");
 
-          PdbParameterMap *info = findNode::getClass<PdbParameterMap>(topNode,
-              "EVENT_INFO");
+      assert(info);
 
-          assert(info);
+      PHParameters run_info_copy("RunInfo");
+      run_info_copy.FillFrom(info);
 
-          PHParameters event_info_copy("EVENT_INFO");
-          event_info_copy.FillFrom(info);
+      rec._dvalue = run_info_copy.get_double_param(rec._name);
 
-          rec._dvalue = event_info_copy.get_double_param(rec._name);
+    }  //
+    else if (rec._type == record::typ_eventinfo)
+    {
+      PdbParameterMap *info = findNode::getClass<PdbParameterMap>(topNode,
+                                                                  "EVENT_INFO");
 
-        } //      if (rec._type == record::typ_hit)
-      else if (rec._type == record::typ_part)
-        {
-          assert(0);
-        } //      if (rec._type == record::typ_part)
-      else if (rec._type == record::typ_vertex)
-        {
-          assert(0);
-        } //          if (_load_all_particle)
+      assert(info);
 
-    } //  for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
+      PHParameters event_info_copy("EVENT_INFO");
+      event_info_copy.FillFrom(info);
+
+      rec._dvalue = event_info_copy.get_double_param(rec._name);
+
+    }  //      if (rec._type == record::typ_hit)
+    else if (rec._type == record::typ_part)
+    {
+      assert(0);
+    }  //      if (rec._type == record::typ_part)
+    else if (rec._type == record::typ_vertex)
+    {
+      assert(0);
+    }  //          if (_load_all_particle)
+
+  }  //  for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
 
   if (_T)
     _T->Fill();
 
   return 0;
-} //  for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
+}  //  for (records_t::iterator it = _records.begin(); it != _records.end(); ++it)
 
-int
-Prototype4DSTReader::End(PHCompositeNode * /*topNode*/)
+int Prototype4DSTReader::End(PHCompositeNode * /*topNode*/)
 {
   cout << "Prototype4DSTReader::End - Clean ups" << endl;
 
   if (_T)
-    {
-      PHTFileServer::get().cd(_out_file_name);
-      _T->Write();
-      _T->ResetBranchAddresses();
-    }
+  {
+    PHTFileServer::get().cd(_out_file_name);
+    _T->Write();
+    _T->ResetBranchAddresses();
+  }
 
   _records.clear();
 

--- a/offline/packages/Prototype4/Prototype4DSTReader.cc
+++ b/offline/packages/Prototype4/Prototype4DSTReader.cc
@@ -24,7 +24,7 @@
 
 #include <boost/foreach.hpp>
 #include <cassert>
-#include <climit>
+#include <limits>
 #include <map>
 #include <set>
 #include <sstream>

--- a/offline/packages/Prototype4/Prototype4DSTReader.cc
+++ b/offline/packages/Prototype4/Prototype4DSTReader.cc
@@ -24,9 +24,9 @@
 
 #include <boost/foreach.hpp>
 #include <cassert>
+#include <climit>
 #include <map>
 #include <set>
-
 #include <sstream>
 
 #include "Prototype4DSTReader.h"
@@ -375,7 +375,10 @@ int Prototype4DSTReader::process_event(PHCompositeNode *topNode)
       PHParameters event_info_copy("EVENT_INFO");
       event_info_copy.FillFrom(info);
 
-      rec._dvalue = event_info_copy.get_double_param(rec._name);
+      rec._dvalue = numeric_limits<double>::quiet_NaN();
+
+      if (event_info_copy.exist_double_param(rec._name))
+        rec._dvalue = event_info_copy.get_double_param(rec._name);
 
     }  //      if (rec._type == record::typ_hit)
     else if (rec._type == record::typ_part)

--- a/offline/packages/Prototype4/Prototype4DSTReader.h
+++ b/offline/packages/Prototype4/Prototype4DSTReader.h
@@ -1,17 +1,17 @@
-// $Id: Prototype3DSTReader.h,v 1.7 2015/02/27 23:42:23 jinhuang Exp $
+// $Id: Prototype4DSTReader.h,v 1.7 2015/02/27 23:42:23 jinhuang Exp $
 
 /*!
- * \file Prototype3DSTReader.h
+ * \file Prototype4DSTReader.h
  * \brief 
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision: 1.7 $
  * \date $Date: 2015/02/27 23:42:23 $
  */
 
-#ifndef Prototype3DSTReader_H_
-#define Prototype3DSTReader_H_
+#ifndef Prototype4DSTReader_H_
+#define Prototype4DSTReader_H_
 
-#include "RawTower_Prototype3.h"
+#include "RawTower_Prototype4.h"
 #include "RawTower_Temperature.h"
 
 #include <HepMC/GenEvent.h>
@@ -31,14 +31,14 @@ class TTree;
 #endif
 
 /*!
- * \brief Prototype3DSTReader save information from DST to an evaluator, which could include hit. particle, vertex, towers and jet (to be activated)
+ * \brief Prototype4DSTReader save information from DST to an evaluator, which could include hit. particle, vertex, towers and jet (to be activated)
  */
-class Prototype3DSTReader : public SubsysReco
+class Prototype4DSTReader : public SubsysReco
 {
 public:
-  Prototype3DSTReader(const std::string &filename);
+  Prototype4DSTReader(const std::string &filename);
   virtual
-  ~Prototype3DSTReader();
+  ~Prototype4DSTReader();
 
   //! full initialization
   int
@@ -123,7 +123,7 @@ protected:
   typedef std::vector<record> records_t;
   records_t _records;
 
-  typedef RawTower_Prototype3 RawTower_type;
+  typedef RawTower_Prototype4 RawTower_type;
 
   typedef RawTower_Temperature RawTowerT_type;
 #endif
@@ -142,4 +142,4 @@ protected:
   build_tree();
 };
 
-#endif /* Prototype3DSTReader_H_ */
+#endif /* Prototype4DSTReader_H_ */

--- a/offline/packages/Prototype4/Prototype4DSTReader.h
+++ b/offline/packages/Prototype4/Prototype4DSTReader.h
@@ -16,11 +16,11 @@
 
 #include <HepMC/GenEvent.h>
 #include <HepMC/SimpleVector.h>
-#include <fun4all/SubsysReco.h>
-#include <string>
-#include <iostream>
-#include <vector>
 #include <TClonesArray.h>
+#include <fun4all/SubsysReco.h>
+#include <iostream>
+#include <string>
+#include <vector>
 
 class TTree;
 
@@ -35,22 +35,18 @@ class TTree;
  */
 class Prototype4DSTReader : public SubsysReco
 {
-public:
+ public:
   Prototype4DSTReader(const std::string &filename);
-  virtual
-  ~Prototype4DSTReader();
+  virtual ~Prototype4DSTReader();
 
   //! full initialization
-  int
-  Init(PHCompositeNode *);
+  int Init(PHCompositeNode *);
 
   //! event processing method
-  int
-  process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *);
 
   //! end of run method
-  int
-  End(PHCompositeNode *);
+  int End(PHCompositeNode *);
 
   void
   AddTower(const std::string &name)
@@ -89,14 +85,13 @@ public:
     _tower_zero_sup = b;
   }
 
-protected:
-
-//  std::vector<std::string> _node_postfix;
+ protected:
+  //  std::vector<std::string> _node_postfix;
   std::vector<std::string> _tower_postfix;
   //! tower temperature
   std::vector<std::string> _towertemp_postfix;
-//  std::vector<std::string> _jet_postfix;
-//  std::vector<std::string> _node_name;
+  //  std::vector<std::string> _jet_postfix;
+  //  std::vector<std::string> _node_name;
   std::vector<std::string> _runinfo_list;
   std::vector<std::string> _eventinfo_list;
 
@@ -111,12 +106,19 @@ protected:
     unsigned int _cnt;
     std::string _name;
     arr_ptr _arr;
-    TClonesArray * _arr_ptr;
+    TClonesArray *_arr_ptr;
     double _dvalue;
 
     enum enu_type
     {
-      typ_hit, typ_part, typ_vertex, typ_tower, typ_jets, typ_runinfo, typ_eventinfo, typ_towertemp
+      typ_hit,
+      typ_part,
+      typ_vertex,
+      typ_tower,
+      typ_jets,
+      typ_runinfo,
+      typ_eventinfo,
+      typ_towertemp
     };
     enu_type _type;
   };
@@ -132,8 +134,8 @@ protected:
 
   std::string _out_file_name;
 
-//  TFile * _file;
-  TTree * _T;
+  //  TFile * _file;
+  TTree *_T;
 
   //! zero suppression for all calorimeters
   double _tower_zero_sup;

--- a/offline/packages/Prototype4/Prototype4DSTReaderLinkDef.h
+++ b/offline/packages/Prototype4/Prototype4DSTReaderLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class Prototype4DSTReader-!;
+
+#endif /* __CINT__ */

--- a/offline/packages/Prototype4/RawTower_Prototype4.cc
+++ b/offline/packages/Prototype4/RawTower_Prototype4.cc
@@ -1,10 +1,10 @@
 #include "RawTower_Prototype4.h"
 #include <calobase/RawTowerDefs.h>
-#include <iostream>
 #include <algorithm>
-#include <cmath>
-#include <map>
 #include <cassert>
+#include <cmath>
+#include <iostream>
+#include <map>
 
 #include "PROTOTYPE4_FEM.h"
 
@@ -12,80 +12,88 @@ using namespace std;
 
 ClassImp(RawTower_Prototype4)
 
-RawTower_Prototype4::RawTower_Prototype4() :
-    towerid(~0), // initialize all bits on
-    energy(0), time(NAN), HBD_channel(-1)
+    RawTower_Prototype4::RawTower_Prototype4()
+  : towerid(~0)
+  ,  // initialize all bits on
+  energy(0)
+  , time(NAN)
+  , HBD_channel(-1)
 {
-  for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
+  for (int i = 0; i < NSAMPLES; ++i) signal_samples[i] = -9999;
 }
 
-RawTower_Prototype4::RawTower_Prototype4(const RawTower & tower)
+RawTower_Prototype4::RawTower_Prototype4(const RawTower& tower)
 {
   towerid = (tower.get_id());
   energy = (tower.get_energy());
   time = (tower.get_time());
   HBD_channel = -1;
-  for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
+  for (int i = 0; i < NSAMPLES; ++i) signal_samples[i] = -9999;
 }
 
-RawTower_Prototype4::RawTower_Prototype4(RawTowerDefs::keytype id) :
-    towerid(id), energy(0), time(NAN), HBD_channel(-1)
+RawTower_Prototype4::RawTower_Prototype4(RawTowerDefs::keytype id)
+  : towerid(id)
+  , energy(0)
+  , time(NAN)
+  , HBD_channel(-1)
 {
-  for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
+  for (int i = 0; i < NSAMPLES; ++i) signal_samples[i] = -9999;
 }
 
-RawTower_Prototype4::RawTower_Prototype4(const unsigned int icol, const unsigned int irow) :
-    towerid(0), energy(0), time(NAN), HBD_channel(-1)
+RawTower_Prototype4::RawTower_Prototype4(const unsigned int icol, const unsigned int irow)
+  : towerid(0)
+  , energy(0)
+  , time(NAN)
+  , HBD_channel(-1)
 {
   towerid = RawTowerDefs::encode_towerid(RawTowerDefs::NONE, icol, irow);
-  for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
+  for (int i = 0; i < NSAMPLES; ++i) signal_samples[i] = -9999;
 }
 
 RawTower_Prototype4::RawTower_Prototype4(const RawTowerDefs::CalorimeterId caloid,
-    const unsigned int ieta, const unsigned int iphi) :
-    towerid(0), energy(0), time(NAN), HBD_channel(-1)
+                                         const unsigned int ieta, const unsigned int iphi)
+  : towerid(0)
+  , energy(0)
+  , time(NAN)
+  , HBD_channel(-1)
 {
   towerid = RawTowerDefs::encode_towerid(caloid, ieta, iphi);
-  for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
+  for (int i = 0; i < NSAMPLES; ++i) signal_samples[i] = -9999;
 }
 
 RawTower_Prototype4::~RawTower_Prototype4()
 {
 }
 
-void
-RawTower_Prototype4::Reset()
+void RawTower_Prototype4::Reset()
 {
   energy = 0;
   time = NAN;
 }
 
-int
-RawTower_Prototype4::isValid() const
+int RawTower_Prototype4::isValid() const
 {
   return get_energy() != 0;
 }
 
-void
-RawTower_Prototype4::identify(std::ostream& os) const
+void RawTower_Prototype4::identify(std::ostream& os) const
 {
   os << "RawTower_Prototype4: etabin: " << get_bineta() << ", phibin: " << get_binphi()
-      << " energy=" << get_energy() << std::endl;
+     << " energy=" << get_energy() << std::endl;
 }
 
-void
-RawTower_Prototype4::set_signal_samples(int i, RawTower_Prototype4::signal_type sig)
+void RawTower_Prototype4::set_signal_samples(int i, RawTower_Prototype4::signal_type sig)
 {
-  assert(i>=0);
-  assert(i<NSAMPLES);
+  assert(i >= 0);
+  assert(i < NSAMPLES);
   signal_samples[i] = sig;
 }
 
 RawTower_Prototype4::signal_type
 RawTower_Prototype4::get_signal_samples(int i) const
 {
-  assert(i>=0);
-  assert(i<NSAMPLES);
+  assert(i >= 0);
+  assert(i < NSAMPLES);
   return signal_samples[i];
 }
 
@@ -98,12 +106,12 @@ RawTower_Prototype4::get_energy_power_law_exp(int verbosity)
 
   vector<double> vec_signal_samples;
   for (int i = 0; i < NSAMPLES; i++)
-    {
-      vec_signal_samples.push_back(signal_samples[i]);
-    }
+  {
+    vec_signal_samples.push_back(signal_samples[i]);
+  }
 
   PROTOTYPE4_FEM::
-  SampleFit_PowerLawExp(vec_signal_samples, peak, peak_sample, pedstal, verbosity);
+      SampleFit_PowerLawExp(vec_signal_samples, peak, peak_sample, pedstal, verbosity);
 
   return peak;
 }

--- a/offline/packages/Prototype4/RawTower_Prototype4.cc
+++ b/offline/packages/Prototype4/RawTower_Prototype4.cc
@@ -115,3 +115,22 @@ RawTower_Prototype4::get_energy_power_law_exp(int verbosity)
 
   return peak;
 }
+
+double
+RawTower_Prototype4::get_energy_power_law_double_exp(int verbosity)
+{
+  double peak = NAN;
+  double peak_sample = NAN;
+  double pedstal = NAN;
+
+  vector<double> vec_signal_samples;
+  for (int i = 0; i < NSAMPLES; i++)
+  {
+    vec_signal_samples.push_back(signal_samples[i]);
+  }
+
+  PROTOTYPE4_FEM::
+      SampleFit_PowerLawDoubleExp(vec_signal_samples, peak, peak_sample, pedstal, verbosity);
+
+  return peak;
+}

--- a/offline/packages/Prototype4/RawTower_Prototype4.cc
+++ b/offline/packages/Prototype4/RawTower_Prototype4.cc
@@ -1,4 +1,4 @@
-#include "RawTower_Prototype3.h"
+#include "RawTower_Prototype4.h"
 #include <calobase/RawTowerDefs.h>
 #include <iostream>
 #include <algorithm>
@@ -6,20 +6,20 @@
 #include <map>
 #include <cassert>
 
-#include "PROTOTYPE3_FEM.h"
+#include "PROTOTYPE4_FEM.h"
 
 using namespace std;
 
-ClassImp(RawTower_Prototype3)
+ClassImp(RawTower_Prototype4)
 
-RawTower_Prototype3::RawTower_Prototype3() :
+RawTower_Prototype4::RawTower_Prototype4() :
     towerid(~0), // initialize all bits on
     energy(0), time(NAN), HBD_channel(-1)
 {
   for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
 }
 
-RawTower_Prototype3::RawTower_Prototype3(const RawTower & tower)
+RawTower_Prototype4::RawTower_Prototype4(const RawTower & tower)
 {
   towerid = (tower.get_id());
   energy = (tower.get_energy());
@@ -28,20 +28,20 @@ RawTower_Prototype3::RawTower_Prototype3(const RawTower & tower)
   for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
 }
 
-RawTower_Prototype3::RawTower_Prototype3(RawTowerDefs::keytype id) :
+RawTower_Prototype4::RawTower_Prototype4(RawTowerDefs::keytype id) :
     towerid(id), energy(0), time(NAN), HBD_channel(-1)
 {
   for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
 }
 
-RawTower_Prototype3::RawTower_Prototype3(const unsigned int icol, const unsigned int irow) :
+RawTower_Prototype4::RawTower_Prototype4(const unsigned int icol, const unsigned int irow) :
     towerid(0), energy(0), time(NAN), HBD_channel(-1)
 {
   towerid = RawTowerDefs::encode_towerid(RawTowerDefs::NONE, icol, irow);
   for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
 }
 
-RawTower_Prototype3::RawTower_Prototype3(const RawTowerDefs::CalorimeterId caloid,
+RawTower_Prototype4::RawTower_Prototype4(const RawTowerDefs::CalorimeterId caloid,
     const unsigned int ieta, const unsigned int iphi) :
     towerid(0), energy(0), time(NAN), HBD_channel(-1)
 {
@@ -49,40 +49,40 @@ RawTower_Prototype3::RawTower_Prototype3(const RawTowerDefs::CalorimeterId caloi
   for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
 }
 
-RawTower_Prototype3::~RawTower_Prototype3()
+RawTower_Prototype4::~RawTower_Prototype4()
 {
 }
 
 void
-RawTower_Prototype3::Reset()
+RawTower_Prototype4::Reset()
 {
   energy = 0;
   time = NAN;
 }
 
 int
-RawTower_Prototype3::isValid() const
+RawTower_Prototype4::isValid() const
 {
   return get_energy() != 0;
 }
 
 void
-RawTower_Prototype3::identify(std::ostream& os) const
+RawTower_Prototype4::identify(std::ostream& os) const
 {
-  os << "RawTower_Prototype3: etabin: " << get_bineta() << ", phibin: " << get_binphi()
+  os << "RawTower_Prototype4: etabin: " << get_bineta() << ", phibin: " << get_binphi()
       << " energy=" << get_energy() << std::endl;
 }
 
 void
-RawTower_Prototype3::set_signal_samples(int i, RawTower_Prototype3::signal_type sig)
+RawTower_Prototype4::set_signal_samples(int i, RawTower_Prototype4::signal_type sig)
 {
   assert(i>=0);
   assert(i<NSAMPLES);
   signal_samples[i] = sig;
 }
 
-RawTower_Prototype3::signal_type
-RawTower_Prototype3::get_signal_samples(int i) const
+RawTower_Prototype4::signal_type
+RawTower_Prototype4::get_signal_samples(int i) const
 {
   assert(i>=0);
   assert(i<NSAMPLES);
@@ -90,7 +90,7 @@ RawTower_Prototype3::get_signal_samples(int i) const
 }
 
 double
-RawTower_Prototype3::get_energy_power_law_exp(int verbosity)
+RawTower_Prototype4::get_energy_power_law_exp(int verbosity)
 {
   double peak = NAN;
   double peak_sample = NAN;
@@ -102,7 +102,7 @@ RawTower_Prototype3::get_energy_power_law_exp(int verbosity)
       vec_signal_samples.push_back(signal_samples[i]);
     }
 
-  PROTOTYPE3_FEM::
+  PROTOTYPE4_FEM::
   SampleFit_PowerLawExp(vec_signal_samples, peak, peak_sample, pedstal, verbosity);
 
   return peak;

--- a/offline/packages/Prototype4/RawTower_Prototype4.cc
+++ b/offline/packages/Prototype4/RawTower_Prototype4.cc
@@ -1,0 +1,109 @@
+#include "RawTower_Prototype3.h"
+#include <calobase/RawTowerDefs.h>
+#include <iostream>
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <cassert>
+
+#include "PROTOTYPE3_FEM.h"
+
+using namespace std;
+
+ClassImp(RawTower_Prototype3)
+
+RawTower_Prototype3::RawTower_Prototype3() :
+    towerid(~0), // initialize all bits on
+    energy(0), time(NAN), HBD_channel(-1)
+{
+  for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
+}
+
+RawTower_Prototype3::RawTower_Prototype3(const RawTower & tower)
+{
+  towerid = (tower.get_id());
+  energy = (tower.get_energy());
+  time = (tower.get_time());
+  HBD_channel = -1;
+  for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
+}
+
+RawTower_Prototype3::RawTower_Prototype3(RawTowerDefs::keytype id) :
+    towerid(id), energy(0), time(NAN), HBD_channel(-1)
+{
+  for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
+}
+
+RawTower_Prototype3::RawTower_Prototype3(const unsigned int icol, const unsigned int irow) :
+    towerid(0), energy(0), time(NAN), HBD_channel(-1)
+{
+  towerid = RawTowerDefs::encode_towerid(RawTowerDefs::NONE, icol, irow);
+  for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
+}
+
+RawTower_Prototype3::RawTower_Prototype3(const RawTowerDefs::CalorimeterId caloid,
+    const unsigned int ieta, const unsigned int iphi) :
+    towerid(0), energy(0), time(NAN), HBD_channel(-1)
+{
+  towerid = RawTowerDefs::encode_towerid(caloid, ieta, iphi);
+  for (int i=0; i<NSAMPLES; ++i  ) signal_samples[i] = -9999;
+}
+
+RawTower_Prototype3::~RawTower_Prototype3()
+{
+}
+
+void
+RawTower_Prototype3::Reset()
+{
+  energy = 0;
+  time = NAN;
+}
+
+int
+RawTower_Prototype3::isValid() const
+{
+  return get_energy() != 0;
+}
+
+void
+RawTower_Prototype3::identify(std::ostream& os) const
+{
+  os << "RawTower_Prototype3: etabin: " << get_bineta() << ", phibin: " << get_binphi()
+      << " energy=" << get_energy() << std::endl;
+}
+
+void
+RawTower_Prototype3::set_signal_samples(int i, RawTower_Prototype3::signal_type sig)
+{
+  assert(i>=0);
+  assert(i<NSAMPLES);
+  signal_samples[i] = sig;
+}
+
+RawTower_Prototype3::signal_type
+RawTower_Prototype3::get_signal_samples(int i) const
+{
+  assert(i>=0);
+  assert(i<NSAMPLES);
+  return signal_samples[i];
+}
+
+double
+RawTower_Prototype3::get_energy_power_law_exp(int verbosity)
+{
+  double peak = NAN;
+  double peak_sample = NAN;
+  double pedstal = NAN;
+
+  vector<double> vec_signal_samples;
+  for (int i = 0; i < NSAMPLES; i++)
+    {
+      vec_signal_samples.push_back(signal_samples[i]);
+    }
+
+  PROTOTYPE3_FEM::
+  SampleFit_PowerLawExp(vec_signal_samples, peak, peak_sample, pedstal, verbosity);
+
+  return peak;
+}

--- a/offline/packages/Prototype4/RawTower_Prototype4.h
+++ b/offline/packages/Prototype4/RawTower_Prototype4.h
@@ -1,22 +1,22 @@
-#ifndef RAWTOWER_PROTOTYPE3_H_
-#define RAWTOWER_PROTOTYPE3_H_
+#ifndef RAWTOWER_PROTOTYPE4_H_
+#define RAWTOWER_PROTOTYPE4_H_
 
 #include <calobase/RawTower.h>
 #include <calobase/RawTowerDefs.h>
 #include <map>
 #include <stdint.h>
 
-#include "PROTOTYPE3_FEM.h"
+#include "PROTOTYPE4_FEM.h"
 
-class RawTower_Prototype3 : public RawTower {
+class RawTower_Prototype4 : public RawTower {
  public:
-  RawTower_Prototype3();
-  RawTower_Prototype3(const RawTower& tower);
-  RawTower_Prototype3(RawTowerDefs::keytype id);
-  RawTower_Prototype3(const unsigned int icol, const unsigned int irow);
-  RawTower_Prototype3(const RawTowerDefs::CalorimeterId caloid, const unsigned int ieta,
+  RawTower_Prototype4();
+  RawTower_Prototype4(const RawTower& tower);
+  RawTower_Prototype4(RawTowerDefs::keytype id);
+  RawTower_Prototype4(const unsigned int icol, const unsigned int irow);
+  RawTower_Prototype4(const RawTowerDefs::CalorimeterId caloid, const unsigned int ieta,
              const unsigned int iphi);
-  virtual ~RawTower_Prototype3();
+  virtual ~RawTower_Prototype4();
 
   void Reset();
   int isValid() const;
@@ -37,7 +37,7 @@ class RawTower_Prototype3 : public RawTower {
 
   enum
   {
-    NSAMPLES = PROTOTYPE3_FEM::NSAMPLES
+    NSAMPLES = PROTOTYPE4_FEM::NSAMPLES
   };
   typedef float signal_type;
 
@@ -67,7 +67,7 @@ class RawTower_Prototype3 : public RawTower {
   signal_type signal_samples[NSAMPLES];  //Low Gain
   int HBD_channel;
 
-  ClassDef(RawTower_Prototype3, 3)
+  ClassDef(RawTower_Prototype4, 3)
 };
 
 #endif /* RAWTOWER_PROTOTYPE3_H_ */

--- a/offline/packages/Prototype4/RawTower_Prototype4.h
+++ b/offline/packages/Prototype4/RawTower_Prototype4.h
@@ -3,19 +3,20 @@
 
 #include <calobase/RawTower.h>
 #include <calobase/RawTowerDefs.h>
-#include <map>
 #include <stdint.h>
+#include <map>
 
 #include "PROTOTYPE4_FEM.h"
 
-class RawTower_Prototype4 : public RawTower {
+class RawTower_Prototype4 : public RawTower
+{
  public:
   RawTower_Prototype4();
   RawTower_Prototype4(const RawTower& tower);
   RawTower_Prototype4(RawTowerDefs::keytype id);
   RawTower_Prototype4(const unsigned int icol, const unsigned int irow);
   RawTower_Prototype4(const RawTowerDefs::CalorimeterId caloid, const unsigned int ieta,
-             const unsigned int iphi);
+                      const unsigned int iphi);
   virtual ~RawTower_Prototype4();
 
   void Reset();
@@ -32,7 +33,6 @@ class RawTower_Prototype4 : public RawTower {
   void set_energy(const double e) { energy = e; }
   float get_time() const { return time; }
   void set_time(const float t) { time = t; }
-
   //---Raw data access------------------------------------------------------------
 
   enum
@@ -41,17 +41,20 @@ class RawTower_Prototype4 : public RawTower {
   };
   typedef float signal_type;
 
-  void set_signal_samples(int i,signal_type sig);
+  void set_signal_samples(int i, signal_type sig);
   signal_type get_signal_samples(int i) const;
   void set_HBD_channel_number(int i)
-    { HBD_channel=i; }
+  {
+    HBD_channel = i;
+  }
   int get_HBD_channel_number() const
-    { return HBD_channel; }
+  {
+    return HBD_channel;
+  }
 
   //---Fits------------------------------------------------------------
 
-    double get_energy_power_law_exp(int verbosity = 0);
-
+  double get_energy_power_law_exp(int verbosity = 0);
 
  protected:
   RawTowerDefs::keytype towerid;

--- a/offline/packages/Prototype4/RawTower_Prototype4.h
+++ b/offline/packages/Prototype4/RawTower_Prototype4.h
@@ -1,0 +1,73 @@
+#ifndef RAWTOWER_PROTOTYPE3_H_
+#define RAWTOWER_PROTOTYPE3_H_
+
+#include <calobase/RawTower.h>
+#include <calobase/RawTowerDefs.h>
+#include <map>
+#include <stdint.h>
+
+#include "PROTOTYPE3_FEM.h"
+
+class RawTower_Prototype3 : public RawTower {
+ public:
+  RawTower_Prototype3();
+  RawTower_Prototype3(const RawTower& tower);
+  RawTower_Prototype3(RawTowerDefs::keytype id);
+  RawTower_Prototype3(const unsigned int icol, const unsigned int irow);
+  RawTower_Prototype3(const RawTowerDefs::CalorimeterId caloid, const unsigned int ieta,
+             const unsigned int iphi);
+  virtual ~RawTower_Prototype3();
+
+  void Reset();
+  int isValid() const;
+  void identify(std::ostream& os = std::cout) const;
+
+  void set_id(RawTowerDefs::keytype id) { towerid = id; }
+  RawTowerDefs::keytype get_id() const { return towerid; }
+  int get_bineta() const { return RawTowerDefs::decode_index1(towerid); }
+  int get_binphi() const { return RawTowerDefs::decode_index2(towerid); }
+  int get_column() const { return RawTowerDefs::decode_index1(towerid); }
+  int get_row() const { return RawTowerDefs::decode_index2(towerid); }
+  double get_energy() const { return energy; }
+  void set_energy(const double e) { energy = e; }
+  float get_time() const { return time; }
+  void set_time(const float t) { time = t; }
+
+  //---Raw data access------------------------------------------------------------
+
+  enum
+  {
+    NSAMPLES = PROTOTYPE3_FEM::NSAMPLES
+  };
+  typedef float signal_type;
+
+  void set_signal_samples(int i,signal_type sig);
+  signal_type get_signal_samples(int i) const;
+  void set_HBD_channel_number(int i)
+    { HBD_channel=i; }
+  int get_HBD_channel_number() const
+    { return HBD_channel; }
+
+  //---Fits------------------------------------------------------------
+
+    double get_energy_power_law_exp(int verbosity = 0);
+
+
+ protected:
+  RawTowerDefs::keytype towerid;
+
+  //! energy assigned to the tower. Depending on stage of process and DST node
+  //! name, it could be energy deposition, light yield or calibrated energies
+  double energy;
+  //! Time stamp assigned to the tower. Depending on the tower maker, it could
+  //! be rise time or peak time.
+  float time;
+
+  //Signal samples from DATA
+  signal_type signal_samples[NSAMPLES];  //Low Gain
+  int HBD_channel;
+
+  ClassDef(RawTower_Prototype3, 3)
+};
+
+#endif /* RAWTOWER_PROTOTYPE3_H_ */

--- a/offline/packages/Prototype4/RawTower_Prototype4.h
+++ b/offline/packages/Prototype4/RawTower_Prototype4.h
@@ -55,6 +55,7 @@ class RawTower_Prototype4 : public RawTower
   //---Fits------------------------------------------------------------
 
   double get_energy_power_law_exp(int verbosity = 0);
+  double get_energy_power_law_double_exp(int verbosity = 0);
 
  protected:
   RawTowerDefs::keytype towerid;

--- a/offline/packages/Prototype4/RawTower_Prototype4LinkDef.h
+++ b/offline/packages/Prototype4/RawTower_Prototype4LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RawTower_Prototype3+;
+
+#endif /* __CINT__ */

--- a/offline/packages/Prototype4/RawTower_Prototype4LinkDef.h
+++ b/offline/packages/Prototype4/RawTower_Prototype4LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class RawTower_Prototype3+;
+#pragma link C++ class RawTower_Prototype4+;
 
 #endif /* __CINT__ */

--- a/offline/packages/Prototype4/RawTower_Temperature.cc
+++ b/offline/packages/Prototype4/RawTower_Temperature.cc
@@ -1,0 +1,114 @@
+#include "RawTower_Temperature.h"
+#include <calobase/RawTowerDefs.h>
+#include <iostream>
+#include <iomanip>
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <cassert>
+
+#include "PROTOTYPE3_FEM.h"
+
+using namespace std;
+
+ClassImp(RawTower_Temperature)
+
+RawTower_Temperature::RawTower_Temperature() :
+    towerid(~0) // initialize all bits on
+{}
+
+// we can copy only from another  RawTower_Temperature, not a generic tower
+RawTower_Temperature::RawTower_Temperature(const RawTower_Temperature & tower)
+{
+  towerid = tower.get_id();
+
+  for ( int i = 0; i < tower.get_nr_entries(); i++)
+    {
+      add_entry( tower.get_eventnumber_from_entry(i)
+		 ,tower.get_time_from_entry(i)
+		 ,tower.get_temperature_from_entry(i) );
+    }
+}
+
+RawTower_Temperature::RawTower_Temperature(RawTowerDefs::keytype id) :
+    towerid(id)
+{
+
+}
+
+RawTower_Temperature::RawTower_Temperature(const unsigned int icol, const unsigned int irow)
+{
+  towerid = RawTowerDefs::encode_towerid(RawTowerDefs::NONE, icol, irow);
+}
+
+
+RawTower_Temperature::~RawTower_Temperature()
+{
+}
+
+void
+RawTower_Temperature::Reset()
+{
+  eventnumbers.clear();
+  times.clear();
+  temperatures.clear();
+}
+
+float  RawTower_Temperature::get_temperature_from_time(const time_t t) const
+{
+  if ( !isValid() ) return -1;
+
+  if ( t < get_time_from_entry(0) ) // if we ask for a time before the start time, we return the first reading
+    {
+      return get_temperature_from_entry( 0);
+    }
+
+
+  int lowest_entry=0;
+  int above_entry=0;
+
+  for ( int i = 0; i < get_nr_entries() ; i++)
+    {
+      if ( get_time_from_entry(i) < t )
+	{
+	  lowest_entry = i;
+	}
+      else
+	{
+	  if ( !above_entry) above_entry = i;
+	}
+    }
+
+  if ( !above_entry  ) // we didn't find a entry later than this
+    {
+      return get_temperature_from_entry( lowest_entry);
+    }
+
+  double m = ( get_temperature_from_entry(above_entry) - get_temperature_from_entry(lowest_entry)) /
+    ( get_time_from_entry(above_entry) - get_time_from_entry(lowest_entry));
+
+  return get_temperature_from_entry(lowest_entry) + m * ( t-get_time_from_entry(lowest_entry) );
+
+}
+void
+RawTower_Temperature::identify(std::ostream& os) const
+{
+  os << "RawTower_Temperature col=" << get_column() << " row=" << get_row() << ":  " << temperatures.size() << " entries"  << std::endl;
+}
+
+void
+RawTower_Temperature::print(std::ostream& os) const
+{
+  identify(os);
+
+  cout << "entry    event     time        T" << endl;
+  for ( int i = 0; i < get_nr_entries(); i++)
+    {
+      os << setw( 4) << i << "  " 
+	 << setw(7) <<  get_eventnumber_from_entry(i) << "  "
+	 << setw(7) <<  get_time_from_entry(i)        << "  "
+	 << setw(5) <<  get_temperature_from_entry(i) 
+	 << endl;
+    }
+}
+

--- a/offline/packages/Prototype4/RawTower_Temperature.cc
+++ b/offline/packages/Prototype4/RawTower_Temperature.cc
@@ -7,7 +7,7 @@
 #include <map>
 #include <cassert>
 
-#include "PROTOTYPE3_FEM.h"
+#include "PROTOTYPE4_FEM.h"
 
 using namespace std;
 

--- a/offline/packages/Prototype4/RawTower_Temperature.cc
+++ b/offline/packages/Prototype4/RawTower_Temperature.cc
@@ -1,11 +1,11 @@
 #include "RawTower_Temperature.h"
 #include <calobase/RawTowerDefs.h>
-#include <iostream>
-#include <iomanip>
 #include <algorithm>
-#include <cmath>
-#include <map>
 #include <cassert>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <map>
 
 #include "PROTOTYPE4_FEM.h"
 
@@ -13,27 +13,25 @@ using namespace std;
 
 ClassImp(RawTower_Temperature)
 
-RawTower_Temperature::RawTower_Temperature() :
-    towerid(~0) // initialize all bits on
-{}
+    RawTower_Temperature::RawTower_Temperature()
+  : towerid(~0)  // initialize all bits on
+{
+}
 
 // we can copy only from another  RawTower_Temperature, not a generic tower
-RawTower_Temperature::RawTower_Temperature(const RawTower_Temperature & tower)
+RawTower_Temperature::RawTower_Temperature(const RawTower_Temperature& tower)
 {
   towerid = tower.get_id();
 
-  for ( int i = 0; i < tower.get_nr_entries(); i++)
-    {
-      add_entry( tower.get_eventnumber_from_entry(i)
-		 ,tower.get_time_from_entry(i)
-		 ,tower.get_temperature_from_entry(i) );
-    }
+  for (int i = 0; i < tower.get_nr_entries(); i++)
+  {
+    add_entry(tower.get_eventnumber_from_entry(i), tower.get_time_from_entry(i), tower.get_temperature_from_entry(i));
+  }
 }
 
-RawTower_Temperature::RawTower_Temperature(RawTowerDefs::keytype id) :
-    towerid(id)
+RawTower_Temperature::RawTower_Temperature(RawTowerDefs::keytype id)
+  : towerid(id)
 {
-
 }
 
 RawTower_Temperature::RawTower_Temperature(const unsigned int icol, const unsigned int irow)
@@ -41,74 +39,67 @@ RawTower_Temperature::RawTower_Temperature(const unsigned int icol, const unsign
   towerid = RawTowerDefs::encode_towerid(RawTowerDefs::NONE, icol, irow);
 }
 
-
 RawTower_Temperature::~RawTower_Temperature()
 {
 }
 
-void
-RawTower_Temperature::Reset()
+void RawTower_Temperature::Reset()
 {
   eventnumbers.clear();
   times.clear();
   temperatures.clear();
 }
 
-float  RawTower_Temperature::get_temperature_from_time(const time_t t) const
+float RawTower_Temperature::get_temperature_from_time(const time_t t) const
 {
-  if ( !isValid() ) return -1;
+  if (!isValid()) return -1;
 
-  if ( t < get_time_from_entry(0) ) // if we ask for a time before the start time, we return the first reading
+  if (t < get_time_from_entry(0))  // if we ask for a time before the start time, we return the first reading
+  {
+    return get_temperature_from_entry(0);
+  }
+
+  int lowest_entry = 0;
+  int above_entry = 0;
+
+  for (int i = 0; i < get_nr_entries(); i++)
+  {
+    if (get_time_from_entry(i) < t)
     {
-      return get_temperature_from_entry( 0);
+      lowest_entry = i;
     }
-
-
-  int lowest_entry=0;
-  int above_entry=0;
-
-  for ( int i = 0; i < get_nr_entries() ; i++)
+    else
     {
-      if ( get_time_from_entry(i) < t )
-	{
-	  lowest_entry = i;
-	}
-      else
-	{
-	  if ( !above_entry) above_entry = i;
-	}
+      if (!above_entry) above_entry = i;
     }
+  }
 
-  if ( !above_entry  ) // we didn't find a entry later than this
-    {
-      return get_temperature_from_entry( lowest_entry);
-    }
+  if (!above_entry)  // we didn't find a entry later than this
+  {
+    return get_temperature_from_entry(lowest_entry);
+  }
 
-  double m = ( get_temperature_from_entry(above_entry) - get_temperature_from_entry(lowest_entry)) /
-    ( get_time_from_entry(above_entry) - get_time_from_entry(lowest_entry));
+  double m = (get_temperature_from_entry(above_entry) - get_temperature_from_entry(lowest_entry)) /
+             (get_time_from_entry(above_entry) - get_time_from_entry(lowest_entry));
 
-  return get_temperature_from_entry(lowest_entry) + m * ( t-get_time_from_entry(lowest_entry) );
-
+  return get_temperature_from_entry(lowest_entry) + m * (t - get_time_from_entry(lowest_entry));
 }
-void
-RawTower_Temperature::identify(std::ostream& os) const
+void RawTower_Temperature::identify(std::ostream& os) const
 {
-  os << "RawTower_Temperature col=" << get_column() << " row=" << get_row() << ":  " << temperatures.size() << " entries"  << std::endl;
+  os << "RawTower_Temperature col=" << get_column() << " row=" << get_row() << ":  " << temperatures.size() << " entries" << std::endl;
 }
 
-void
-RawTower_Temperature::print(std::ostream& os) const
+void RawTower_Temperature::print(std::ostream& os) const
 {
   identify(os);
 
   cout << "entry    event     time        T" << endl;
-  for ( int i = 0; i < get_nr_entries(); i++)
-    {
-      os << setw( 4) << i << "  " 
-	 << setw(7) <<  get_eventnumber_from_entry(i) << "  "
-	 << setw(7) <<  get_time_from_entry(i)        << "  "
-	 << setw(5) <<  get_temperature_from_entry(i) 
-	 << endl;
-    }
+  for (int i = 0; i < get_nr_entries(); i++)
+  {
+    os << setw(4) << i << "  "
+       << setw(7) << get_eventnumber_from_entry(i) << "  "
+       << setw(7) << get_time_from_entry(i) << "  "
+       << setw(5) << get_temperature_from_entry(i)
+       << endl;
+  }
 }
-

--- a/offline/packages/Prototype4/RawTower_Temperature.h
+++ b/offline/packages/Prototype4/RawTower_Temperature.h
@@ -1,0 +1,78 @@
+#ifndef RAWTOWER_TEMPERATURE_H_
+#define RAWTOWER_TEMPERATURE_H_
+
+#include <calobase/RawTower.h>
+#include <calobase/RawTowerDefs.h>
+#include <vector>
+#include <stdint.h>
+
+class RawTower_Temperature : public RawTower {
+ public:
+  RawTower_Temperature();
+  RawTower_Temperature(const RawTower_Temperature & tower);
+  RawTower_Temperature(const unsigned int icol, const unsigned int irow);
+  RawTower_Temperature(RawTowerDefs::keytype id);
+  virtual ~RawTower_Temperature();
+
+  //  void set_id(RawTowerDefs::keytype id) { towerid = id; }
+
+  void Reset();
+  int isValid() const { return get_nr_entries(); }
+  void identify(std::ostream& os = std::cout) const;
+  void print(std::ostream& os = std::cout) const;
+
+  int get_column() const { return RawTowerDefs::decode_index1(towerid); }
+  int get_row() const { return RawTowerDefs::decode_index2(towerid); }
+
+  void set_id(RawTowerDefs::keytype id) { towerid = id; }
+  RawTowerDefs::keytype get_id() const { return towerid; }
+
+  int get_nr_entries() const { return temperatures.size(); }
+
+  int add_entry( const int eventnr, const time_t t, const float temp)
+  {
+    eventnumbers.push_back(eventnr);
+    times.push_back(t);
+    temperatures.push_back(temp);
+    return get_nr_entries();
+  }
+
+  float  get_temperature_from_entry(const unsigned int entry) const 
+  { 
+    if ( entry >= temperatures.size() ) return -1; 
+    return temperatures[entry];
+  }
+
+  time_t  get_time_from_entry(const unsigned int entry) const 
+  { 
+    if ( entry >=  times.size() ) return 0;   //1970...
+    return times[entry];
+  }
+
+  int  get_eventnumber_from_entry(const unsigned int entry) const 
+  { 
+    if ( entry >= eventnumbers.size() ) return -1; 
+    return eventnumbers[entry];
+  }
+
+  float  get_temperature_from_time(const time_t t) const;
+  
+
+  //---Raw data access------------------------------------------------------------
+
+ protected:
+  RawTowerDefs::keytype towerid;
+
+  //! Temperature readings 
+  //! since we do not have more than 100 entries per run typically,
+  //! we trade efficiency for some simplicity and just use some vectors.
+  //! 
+  std::vector<int> eventnumbers;  
+  std::vector<time_t> times;  
+  std::vector<float> temperatures;  
+
+  ClassDef(RawTower_Temperature, 1)
+};
+
+#endif /* RAWTOWER_PROTOTYPE3_H_ */
+

--- a/offline/packages/Prototype4/RawTower_TemperatureLinkDef.h
+++ b/offline/packages/Prototype4/RawTower_TemperatureLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RawTower_Temperature+;
+
+#endif /* __CINT__ */

--- a/offline/packages/Prototype4/RunInfoUnpackPRDF.C
+++ b/offline/packages/Prototype4/RunInfoUnpackPRDF.C
@@ -1,6 +1,6 @@
 #include "RunInfoUnpackPRDF.h"
-#include "RawTower_Prototype3.h"
-#include "PROTOTYPE3_FEM.h"
+#include "RawTower_Prototype4.h"
+#include "PROTOTYPE4_FEM.h"
 
 #include <ffaobjects/EventHeaderv1.h>
 #include <Event/Event.h>
@@ -90,7 +90,7 @@ RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
         {
           int has_new_EMCal = 0;
 
-          if (event->existPacket(PROTOTYPE3_FEM::PACKET_EMCAL_HIGHETA_FLAG))
+          if (event->existPacket(PROTOTYPE4_FEM::PACKET_EMCAL_HIGHETA_FLAG))
             {
               // react properly - new emcal!
               has_new_EMCal = 1;

--- a/offline/packages/Prototype4/RunInfoUnpackPRDF.C
+++ b/offline/packages/Prototype4/RunInfoUnpackPRDF.C
@@ -1,212 +1,206 @@
-#include "RunInfoUnpackPRDF.h"
-#include "RawTower_Prototype4.h"
 #include "PROTOTYPE4_FEM.h"
+#include "RawTower_Prototype4.h"
+#include "RunInfoUnpackPRDF.h"
 
-#include <ffaobjects/EventHeaderv1.h>
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
-#include <Event/packetConstants.h>
 #include <Event/packet.h>
-#include <pdbcalbase/PdbParameterMap.h>
-#include <phparameter/PHParameters.h>
-#include <phool/PHCompositeNode.h>
-#include <phool/phool.h>
-#include <phool/getClass.h>
+#include <Event/packetConstants.h>
+#include <ffaobjects/EventHeaderv1.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <pdbcalbase/PdbParameterMap.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phparameter/PHParameters.h>
 
+#include <cassert>
 #include <iostream>
 #include <string>
-#include <cassert>
 
 using namespace std;
 
-typedef PHIODataNode <PHObject> PHObjectNode_t;
+typedef PHIODataNode<PHObject> PHObjectNode_t;
 
 //____________________________________
-RunInfoUnpackPRDF::RunInfoUnpackPRDF() :
-    SubsysReco("RunInfoUnpackPRDF"), runinfo_node_name("RUN_INFO")
+RunInfoUnpackPRDF::RunInfoUnpackPRDF()
+  : SubsysReco("RunInfoUnpackPRDF")
+  , runinfo_node_name("RUN_INFO")
 {
 }
 
 //____________________________________
-int
-RunInfoUnpackPRDF::Init(PHCompositeNode *topNode)
+int RunInfoUnpackPRDF::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_____________________________________
-int
-RunInfoUnpackPRDF::InitRun(PHCompositeNode *topNode)
+int RunInfoUnpackPRDF::InitRun(PHCompositeNode *topNode)
 {
   CreateNodeTree(topNode);
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________
-int
-RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
+int RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
 {
-  Event* event = findNode::getClass<Event>(topNode, "PRDF");
+  Event *event = findNode::getClass<Event>(topNode, "PRDF");
   if (event == NULL)
-    {
-      if (Verbosity() >= VERBOSITY_SOME)
-        cout << "RunInfoUnpackPRDF::Process_Event - Event not found" << endl;
-      return Fun4AllReturnCodes::DISCARDEVENT;
-    }
+  {
+    if (Verbosity() >= VERBOSITY_SOME)
+      cout << "RunInfoUnpackPRDF::Process_Event - Event not found" << endl;
+    return Fun4AllReturnCodes::DISCARDEVENT;
+  }
 
   // construct event info
-  EventHeaderv1* eventheader = findNode::getClass<
+  EventHeaderv1 *eventheader = findNode::getClass<
       EventHeaderv1>(topNode, "EventHeader");
   if (eventheader)
+  {
+    eventheader->set_RunNumber(event->getRunNumber());
+    eventheader->set_EvtSequence(event->getEvtSequence());
+    eventheader->set_EvtType(event->getEvtType());
+    eventheader->set_TimeStamp(event->getTime());
+    if (verbosity)
     {
-      eventheader->set_RunNumber(event->getRunNumber());
-      eventheader->set_EvtSequence(event->getEvtSequence());
-      eventheader->set_EvtType(event->getEvtType());
-      eventheader->set_TimeStamp(event->getTime());
-      if (verbosity)
-        {
-          eventheader->identify();
-        }
+      eventheader->identify();
     }
+  }
 
   // search for run info
   if (event->getEvtType() != BEGRUNEVENT)
     return Fun4AllReturnCodes::EVENT_OK;
   else
+  {
+    if (verbosity >= VERBOSITY_SOME)
     {
-      if (verbosity >= VERBOSITY_SOME)
-        {
-          cout << "RunInfoUnpackPRDF::process_event - with BEGRUNEVENT events ";
-          event->identify();
-        }
-
-      map<int, Packet*> packet_list;
-
-      PHParameters Params("RunInfo");
-
-      // special treatment for EMCal tagging packet
-      // https://wiki.bnl.gov/sPHENIX/index.php/2017_calorimeter_beam_test#What_is_new_in_the_data_structures_in_2017
-        {
-          int has_new_EMCal = 0;
-
-          if (event->existPacket(PROTOTYPE4_FEM::PACKET_EMCAL_HIGHETA_FLAG))
-            {
-              // react properly - new emcal!
-              has_new_EMCal = 1;
-            }
-
-          Params.set_double_param("EMCAL_Is_HighEta", has_new_EMCal);
-          Params.set_int_param("EMCAL_Is_HighEta", has_new_EMCal);
-        }
-
-        // generic packets
-      for (typ_channel_map::const_iterator it = channel_map.begin();
-          it != channel_map.end(); ++it)
-        {
-          const string & name = it->first;
-          const channel_info & info = it->second;
-
-          if (packet_list.find(info.packet_id) == packet_list.end())
-            {
-              packet_list[info.packet_id] = event->getPacket(info.packet_id);
-            }
-
-          Packet * packet = packet_list[info.packet_id];
-
-          if (!packet)
-            {
-//          if (Verbosity() >= VERBOSITY_SOME)
-              cout
-                  << "RunInfoUnpackPRDF::process_event - failed to locate packet "
-                  << info.packet_id << " from ";
-              event->identify();
-
-              Params.set_double_param(name, NAN);
-              continue;
-            }
-
-          const int ivalue = packet->iValue(info.offset);
-
-          const double dvalue = ivalue * info.calibration_const;
-
-          if (verbosity >= VERBOSITY_SOME)
-            {
-              cout << "RunInfoUnpackPRDF::process_event - " << name << " = "
-                  << dvalue << ", raw = " << ivalue << " @ packet "
-                  << info.packet_id << ", offset " << info.offset << endl;
-            }
-
-          Params.set_double_param(name, dvalue);
-        }
-
-      for (map<int, Packet*>::iterator it = packet_list.begin();
-          it != packet_list.end(); ++it)
-        {
-          if (it->second)
-            delete it->second;
-        }
-
-      Params.SaveToNodeTree(topNode, runinfo_node_name);
-
-      if (verbosity >= VERBOSITY_SOME)
-        Params.Print();
+      cout << "RunInfoUnpackPRDF::process_event - with BEGRUNEVENT events ";
+      event->identify();
     }
+
+    map<int, Packet *> packet_list;
+
+    PHParameters Params("RunInfo");
+
+    // special treatment for EMCal tagging packet
+    // https://wiki.bnl.gov/sPHENIX/index.php/2017_calorimeter_beam_test#What_is_new_in_the_data_structures_in_2017
+    {
+      int has_new_EMCal = 0;
+
+      if (event->existPacket(PROTOTYPE4_FEM::PACKET_EMCAL_HIGHETA_FLAG))
+      {
+        // react properly - new emcal!
+        has_new_EMCal = 1;
+      }
+
+      Params.set_double_param("EMCAL_Is_HighEta", has_new_EMCal);
+      Params.set_int_param("EMCAL_Is_HighEta", has_new_EMCal);
+    }
+
+    // generic packets
+    for (typ_channel_map::const_iterator it = channel_map.begin();
+         it != channel_map.end(); ++it)
+    {
+      const string &name = it->first;
+      const channel_info &info = it->second;
+
+      if (packet_list.find(info.packet_id) == packet_list.end())
+      {
+        packet_list[info.packet_id] = event->getPacket(info.packet_id);
+      }
+
+      Packet *packet = packet_list[info.packet_id];
+
+      if (!packet)
+      {
+        //          if (Verbosity() >= VERBOSITY_SOME)
+        cout
+            << "RunInfoUnpackPRDF::process_event - failed to locate packet "
+            << info.packet_id << " from ";
+        event->identify();
+
+        Params.set_double_param(name, NAN);
+        continue;
+      }
+
+      const int ivalue = packet->iValue(info.offset);
+
+      const double dvalue = ivalue * info.calibration_const;
+
+      if (verbosity >= VERBOSITY_SOME)
+      {
+        cout << "RunInfoUnpackPRDF::process_event - " << name << " = "
+             << dvalue << ", raw = " << ivalue << " @ packet "
+             << info.packet_id << ", offset " << info.offset << endl;
+      }
+
+      Params.set_double_param(name, dvalue);
+    }
+
+    for (map<int, Packet *>::iterator it = packet_list.begin();
+         it != packet_list.end(); ++it)
+    {
+      if (it->second)
+        delete it->second;
+    }
+
+    Params.SaveToNodeTree(topNode, runinfo_node_name);
+
+    if (verbosity >= VERBOSITY_SOME)
+      Params.Print();
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_______________________________________
-void
-RunInfoUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
+void RunInfoUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
 {
   PHNodeIterator nodeItr(topNode);
   //DST node
-  PHCompositeNode * run_node = static_cast<PHCompositeNode*>(nodeItr.findFirst(
+  PHCompositeNode *run_node = static_cast<PHCompositeNode *>(nodeItr.findFirst(
       "PHCompositeNode", "RUN"));
   if (!run_node)
-    {
-      cout << "PHComposite node created: RUN" << endl;
-      run_node = new PHCompositeNode("RUN");
-      topNode->addNode(run_node);
-    }
-
-  PdbParameterMap *nodeparams = findNode::getClass<PdbParameterMap>(run_node,
-      runinfo_node_name);
-  if (not nodeparams)
-    {
-      run_node->addNode(
-          new PHIODataNode<PdbParameterMap>(new PdbParameterMap(),
-              runinfo_node_name));
-    }
-
-  //DST node
-  PHCompositeNode* dst_node = static_cast<PHCompositeNode*>( nodeItr.findFirst("PHCompositeNode", "DST" ));
-  if(!dst_node)
   {
-    cout << "PHComposite node created: DST" << endl;
-    dst_node  = new PHCompositeNode( "DST" );
-    topNode->addNode( dst_node );
+    cout << "PHComposite node created: RUN" << endl;
+    run_node = new PHCompositeNode("RUN");
+    topNode->addNode(run_node);
   }
 
-  EventHeaderv1* eventheader = new EventHeaderv1();
-  PHObjectNode_t *EventHeaderNode = new PHObjectNode_t(eventheader, "EventHeader", "PHObject"); // contain PHObject
-  dst_node->addNode(EventHeaderNode);
+  PdbParameterMap *nodeparams = findNode::getClass<PdbParameterMap>(run_node,
+                                                                    runinfo_node_name);
+  if (not nodeparams)
+  {
+    run_node->addNode(
+        new PHIODataNode<PdbParameterMap>(new PdbParameterMap(),
+                                          runinfo_node_name));
+  }
 
+  //DST node
+  PHCompositeNode *dst_node = static_cast<PHCompositeNode *>(nodeItr.findFirst("PHCompositeNode", "DST"));
+  if (!dst_node)
+  {
+    cout << "PHComposite node created: DST" << endl;
+    dst_node = new PHCompositeNode("DST");
+    topNode->addNode(dst_node);
+  }
+
+  EventHeaderv1 *eventheader = new EventHeaderv1();
+  PHObjectNode_t *EventHeaderNode = new PHObjectNode_t(eventheader, "EventHeader", "PHObject");  // contain PHObject
+  dst_node->addNode(EventHeaderNode);
 }
 
 //___________________________________
-int
-RunInfoUnpackPRDF::End(PHCompositeNode *topNode)
+int RunInfoUnpackPRDF::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void
-RunInfoUnpackPRDF::add_channel(const std::string & name, //! name of the channel
-    const int packet_id, //! packet id
-    const unsigned int offset, //! offset in packet data
-    const double calibration_const //! conversion constant from integer to meaningful value
-    )
+void RunInfoUnpackPRDF::add_channel(const std::string &name,        //! name of the channel
+                                    const int packet_id,            //! packet id
+                                    const unsigned int offset,      //! offset in packet data
+                                    const double calibration_const  //! conversion constant from integer to meaningful value
+                                    )
 {
   channel_map.insert(
       make_pair(name, channel_info(packet_id, offset, calibration_const)));

--- a/offline/packages/Prototype4/RunInfoUnpackPRDF.C
+++ b/offline/packages/Prototype4/RunInfoUnpackPRDF.C
@@ -1,0 +1,213 @@
+#include "RunInfoUnpackPRDF.h"
+#include "RawTower_Prototype3.h"
+#include "PROTOTYPE3_FEM.h"
+
+#include <ffaobjects/EventHeaderv1.h>
+#include <Event/Event.h>
+#include <Event/EventTypes.h>
+#include <Event/packetConstants.h>
+#include <Event/packet.h>
+#include <pdbcalbase/PdbParameterMap.h>
+#include <phparameter/PHParameters.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <iostream>
+#include <string>
+#include <cassert>
+
+using namespace std;
+
+typedef PHIODataNode <PHObject> PHObjectNode_t;
+
+//____________________________________
+RunInfoUnpackPRDF::RunInfoUnpackPRDF() :
+    SubsysReco("RunInfoUnpackPRDF"), runinfo_node_name("RUN_INFO")
+{
+}
+
+//____________________________________
+int
+RunInfoUnpackPRDF::Init(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________
+int
+RunInfoUnpackPRDF::InitRun(PHCompositeNode *topNode)
+{
+  CreateNodeTree(topNode);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________
+int
+RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
+{
+  Event* event = findNode::getClass<Event>(topNode, "PRDF");
+  if (event == NULL)
+    {
+      if (Verbosity() >= VERBOSITY_SOME)
+        cout << "RunInfoUnpackPRDF::Process_Event - Event not found" << endl;
+      return Fun4AllReturnCodes::DISCARDEVENT;
+    }
+
+  // construct event info
+  EventHeaderv1* eventheader = findNode::getClass<
+      EventHeaderv1>(topNode, "EventHeader");
+  if (eventheader)
+    {
+      eventheader->set_RunNumber(event->getRunNumber());
+      eventheader->set_EvtSequence(event->getEvtSequence());
+      eventheader->set_EvtType(event->getEvtType());
+      eventheader->set_TimeStamp(event->getTime());
+      if (verbosity)
+        {
+          eventheader->identify();
+        }
+    }
+
+  // search for run info
+  if (event->getEvtType() != BEGRUNEVENT)
+    return Fun4AllReturnCodes::EVENT_OK;
+  else
+    {
+      if (verbosity >= VERBOSITY_SOME)
+        {
+          cout << "RunInfoUnpackPRDF::process_event - with BEGRUNEVENT events ";
+          event->identify();
+        }
+
+      map<int, Packet*> packet_list;
+
+      PHParameters Params("RunInfo");
+
+      // special treatment for EMCal tagging packet
+      // https://wiki.bnl.gov/sPHENIX/index.php/2017_calorimeter_beam_test#What_is_new_in_the_data_structures_in_2017
+        {
+          int has_new_EMCal = 0;
+
+          if (event->existPacket(PROTOTYPE3_FEM::PACKET_EMCAL_HIGHETA_FLAG))
+            {
+              // react properly - new emcal!
+              has_new_EMCal = 1;
+            }
+
+          Params.set_double_param("EMCAL_Is_HighEta", has_new_EMCal);
+          Params.set_int_param("EMCAL_Is_HighEta", has_new_EMCal);
+        }
+
+        // generic packets
+      for (typ_channel_map::const_iterator it = channel_map.begin();
+          it != channel_map.end(); ++it)
+        {
+          const string & name = it->first;
+          const channel_info & info = it->second;
+
+          if (packet_list.find(info.packet_id) == packet_list.end())
+            {
+              packet_list[info.packet_id] = event->getPacket(info.packet_id);
+            }
+
+          Packet * packet = packet_list[info.packet_id];
+
+          if (!packet)
+            {
+//          if (Verbosity() >= VERBOSITY_SOME)
+              cout
+                  << "RunInfoUnpackPRDF::process_event - failed to locate packet "
+                  << info.packet_id << " from ";
+              event->identify();
+
+              Params.set_double_param(name, NAN);
+              continue;
+            }
+
+          const int ivalue = packet->iValue(info.offset);
+
+          const double dvalue = ivalue * info.calibration_const;
+
+          if (verbosity >= VERBOSITY_SOME)
+            {
+              cout << "RunInfoUnpackPRDF::process_event - " << name << " = "
+                  << dvalue << ", raw = " << ivalue << " @ packet "
+                  << info.packet_id << ", offset " << info.offset << endl;
+            }
+
+          Params.set_double_param(name, dvalue);
+        }
+
+      for (map<int, Packet*>::iterator it = packet_list.begin();
+          it != packet_list.end(); ++it)
+        {
+          if (it->second)
+            delete it->second;
+        }
+
+      Params.SaveToNodeTree(topNode, runinfo_node_name);
+
+      if (verbosity >= VERBOSITY_SOME)
+        Params.Print();
+    }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_______________________________________
+void
+RunInfoUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
+{
+  PHNodeIterator nodeItr(topNode);
+  //DST node
+  PHCompositeNode * run_node = static_cast<PHCompositeNode*>(nodeItr.findFirst(
+      "PHCompositeNode", "RUN"));
+  if (!run_node)
+    {
+      cout << "PHComposite node created: RUN" << endl;
+      run_node = new PHCompositeNode("RUN");
+      topNode->addNode(run_node);
+    }
+
+  PdbParameterMap *nodeparams = findNode::getClass<PdbParameterMap>(run_node,
+      runinfo_node_name);
+  if (not nodeparams)
+    {
+      run_node->addNode(
+          new PHIODataNode<PdbParameterMap>(new PdbParameterMap(),
+              runinfo_node_name));
+    }
+
+  //DST node
+  PHCompositeNode* dst_node = static_cast<PHCompositeNode*>( nodeItr.findFirst("PHCompositeNode", "DST" ));
+  if(!dst_node)
+  {
+    cout << "PHComposite node created: DST" << endl;
+    dst_node  = new PHCompositeNode( "DST" );
+    topNode->addNode( dst_node );
+  }
+
+  EventHeaderv1* eventheader = new EventHeaderv1();
+  PHObjectNode_t *EventHeaderNode = new PHObjectNode_t(eventheader, "EventHeader", "PHObject"); // contain PHObject
+  dst_node->addNode(EventHeaderNode);
+
+}
+
+//___________________________________
+int
+RunInfoUnpackPRDF::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void
+RunInfoUnpackPRDF::add_channel(const std::string & name, //! name of the channel
+    const int packet_id, //! packet id
+    const unsigned int offset, //! offset in packet data
+    const double calibration_const //! conversion constant from integer to meaningful value
+    )
+{
+  channel_map.insert(
+      make_pair(name, channel_info(packet_id, offset, calibration_const)));
+}

--- a/offline/packages/Prototype4/RunInfoUnpackPRDF.h
+++ b/offline/packages/Prototype4/RunInfoUnpackPRDF.h
@@ -1,0 +1,66 @@
+#ifndef __CaloUnpackPRDFF__
+#define __CaloUnpackPRDFF__
+
+#include <fun4all/SubsysReco.h>
+#include <phool/PHObject.h>
+#include <string>
+#include <map>
+#include <utility>
+
+class Event;
+class Packet;
+class RawTowerContainer;
+class RawTower;
+
+class RunInfoUnpackPRDF : public SubsysReco
+{
+public:
+  RunInfoUnpackPRDF();
+
+  int
+  Init(PHCompositeNode *topNode);
+
+  int
+  InitRun(PHCompositeNode *topNode);
+
+  int
+  process_event(PHCompositeNode *topNode);
+
+  int
+  End(PHCompositeNode *topNode);
+
+  void
+  CreateNodeTree(PHCompositeNode *topNode);
+
+  //! add stuff to be unpacked
+  void
+  add_channel(const std::string & name, //! name of the channel
+      const int packet_id, //! packet id
+      const unsigned int offset, //! offset in packet data
+      const double calibration_const = +1 //! conversion constant from integer to meaningful value
+      );
+
+private:
+
+  class channel_info
+  {
+  public:
+    channel_info(int p, unsigned int o, double c) :
+        packet_id(p), offset(o), calibration_const(c)
+    {
+    }
+
+    int packet_id;
+    unsigned offset;
+    double calibration_const;
+  };
+
+  //! list of channel name -> channel info
+  typedef std::map<std::string, channel_info> typ_channel_map;
+
+  typ_channel_map channel_map;
+
+  std::string runinfo_node_name;
+};
+
+#endif //**CaloUnpackPRDFF**//

--- a/offline/packages/Prototype4/RunInfoUnpackPRDF.h
+++ b/offline/packages/Prototype4/RunInfoUnpackPRDF.h
@@ -3,8 +3,8 @@
 
 #include <fun4all/SubsysReco.h>
 #include <phool/PHObject.h>
-#include <string>
 #include <map>
+#include <string>
 #include <utility>
 
 class Event;
@@ -14,39 +14,36 @@ class RawTower;
 
 class RunInfoUnpackPRDF : public SubsysReco
 {
-public:
+ public:
   RunInfoUnpackPRDF();
 
-  int
-  Init(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode);
 
-  int
-  InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
 
-  int
-  process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
 
-  int
-  End(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
 
   void
   CreateNodeTree(PHCompositeNode *topNode);
 
   //! add stuff to be unpacked
   void
-  add_channel(const std::string & name, //! name of the channel
-      const int packet_id, //! packet id
-      const unsigned int offset, //! offset in packet data
-      const double calibration_const = +1 //! conversion constant from integer to meaningful value
-      );
+  add_channel(const std::string &name,             //! name of the channel
+              const int packet_id,                 //! packet id
+              const unsigned int offset,           //! offset in packet data
+              const double calibration_const = +1  //! conversion constant from integer to meaningful value
+              );
 
-private:
-
+ private:
   class channel_info
   {
-  public:
-    channel_info(int p, unsigned int o, double c) :
-        packet_id(p), offset(o), calibration_const(c)
+   public:
+    channel_info(int p, unsigned int o, double c)
+      : packet_id(p)
+      , offset(o)
+      , calibration_const(c)
     {
     }
 
@@ -63,4 +60,4 @@ private:
   std::string runinfo_node_name;
 };
 
-#endif //**CaloUnpackPRDFF**//
+#endif  //**CaloUnpackPRDFF**//

--- a/offline/packages/Prototype4/RunInfoUnpackPRDFLinkDef.h
+++ b/offline/packages/Prototype4/RunInfoUnpackPRDFLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RunInfoUnpackPRDF-!;
+
+#endif

--- a/offline/packages/Prototype4/TempInfoUnpackPRDF.C
+++ b/offline/packages/Prototype4/TempInfoUnpackPRDF.C
@@ -1,5 +1,5 @@
 #include "RawTower_Temperature.h"
-#include "PROTOTYPE3_FEM.h"
+#include "PROTOTYPE4_FEM.h"
 #include "TempInfoUnpackPRDF.h"
 
 #include <Event/Event.h>
@@ -125,9 +125,9 @@ int  TempInfoUnpackPRDF::addPacketInfo(Packet *p, PHCompositeNode *topNode, cons
 
   if ( packetid == 974 || packetid == 1074 ) // Inner Hcal
     {
-      for(int ibinz=0; ibinz<PROTOTYPE3_FEM::NCH_IHCAL_ROWS; ibinz++)
+      for(int ibinz=0; ibinz<PROTOTYPE4_FEM::NCH_IHCAL_ROWS; ibinz++)
 	{
-	  for(int ibinphi=0; ibinphi<PROTOTYPE3_FEM::NCH_IHCAL_COLUMNS; ibinphi++)
+	  for(int ibinphi=0; ibinphi<PROTOTYPE4_FEM::NCH_IHCAL_COLUMNS; ibinphi++)
 	    {
 	      tower = dynamic_cast<RawTower_Temperature*>(hcalin_temperature->getTower(ibinz,ibinphi));
 	      if(!tower)
@@ -135,16 +135,16 @@ int  TempInfoUnpackPRDF::addPacketInfo(Packet *p, PHCompositeNode *topNode, cons
 		  tower = new RawTower_Temperature();
 		  hcalin_temperature->AddTower(ibinz,ibinphi,tower);
 		}
-	      tower->add_entry( evtnr, etime, p->iValue(ibinz*PROTOTYPE3_FEM::NCH_IHCAL_COLUMNS + ibinphi)/1000. ); 
+	      tower->add_entry( evtnr, etime, p->iValue(ibinz*PROTOTYPE4_FEM::NCH_IHCAL_COLUMNS + ibinphi)/1000. ); 
 	    }
 	}
     }
 
   else  if ( packetid == 975 || packetid == 1075 ) // outer Hcal
     {
-      for(int ibinz=0; ibinz<PROTOTYPE3_FEM::NCH_OHCAL_ROWS; ibinz++)
+      for(int ibinz=0; ibinz<PROTOTYPE4_FEM::NCH_OHCAL_ROWS; ibinz++)
 	{
-	  for(int ibinphi=0; ibinphi<PROTOTYPE3_FEM::NCH_OHCAL_COLUMNS; ibinphi++)
+	  for(int ibinphi=0; ibinphi<PROTOTYPE4_FEM::NCH_OHCAL_COLUMNS; ibinphi++)
 	    {
 	      tower = dynamic_cast<RawTower_Temperature*>(hcalout_temperature->getTower(ibinz,ibinphi));
 	      if(!tower)
@@ -152,16 +152,16 @@ int  TempInfoUnpackPRDF::addPacketInfo(Packet *p, PHCompositeNode *topNode, cons
 		  tower = new RawTower_Temperature();
 		  hcalout_temperature->AddTower(ibinz,ibinphi,tower);
 		}
-	      tower->add_entry( evtnr, etime, p->iValue(ibinz*PROTOTYPE3_FEM::NCH_OHCAL_COLUMNS + ibinphi)/1000. ); 
+	      tower->add_entry( evtnr, etime, p->iValue(ibinz*PROTOTYPE4_FEM::NCH_OHCAL_COLUMNS + ibinphi)/1000. ); 
 	    }
 	}
     }
 
   else  if ( packetid == 982 || packetid == 1082 ) // emcal
     {
-      for(int ibinz=0; ibinz<PROTOTYPE3_FEM::NCH_EMCAL_ROWS; ibinz++)
+      for(int ibinz=0; ibinz<PROTOTYPE4_FEM::NCH_EMCAL_ROWS; ibinz++)
 	{
-	  for(int ibinphi=0; ibinphi<PROTOTYPE3_FEM::NCH_EMCAL_COLUMNS; ibinphi++)
+	  for(int ibinphi=0; ibinphi<PROTOTYPE4_FEM::NCH_EMCAL_COLUMNS; ibinphi++)
 	    {
 	      tower = dynamic_cast<RawTower_Temperature*>(emcal_temperature->getTower(ibinz,ibinphi));
 	      if(!tower)
@@ -171,7 +171,7 @@ int  TempInfoUnpackPRDF::addPacketInfo(Packet *p, PHCompositeNode *topNode, cons
 		}
 	      // this takes care of the newly found "reverse" mapping. (0,0) is module 7, (0,7) is module 0, and 
 	      // the 63 - (...) takes care of the reversed vector.  
-	      tower->add_entry( evtnr, etime, p->iValue( 63- (ibinz*PROTOTYPE3_FEM::NCH_EMCAL_COLUMNS + (7-ibinphi) ) /1000. ) ); 
+	      tower->add_entry( evtnr, etime, p->iValue( 63- (ibinz*PROTOTYPE4_FEM::NCH_EMCAL_COLUMNS + (7-ibinphi) ) /1000. ) ); 
 	    }
 	}
     }

--- a/offline/packages/Prototype4/TempInfoUnpackPRDF.C
+++ b/offline/packages/Prototype4/TempInfoUnpackPRDF.C
@@ -1,0 +1,222 @@
+#include "RawTower_Temperature.h"
+#include "PROTOTYPE3_FEM.h"
+#include "TempInfoUnpackPRDF.h"
+
+#include <Event/Event.h>
+#include <Event/EventTypes.h>
+#include <Event/packetConstants.h>
+#include <Event/packet.h>
+#include <calobase/RawTowerContainer.h>
+#include <pdbcalbase/PdbParameterMap.h>
+#include <phparameter/PHParameters.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <iostream>
+#include <string>
+#include <cassert>
+
+using namespace std;
+
+//____________________________________
+TempInfoUnpackPRDF::TempInfoUnpackPRDF() :
+  SubsysReco("TempInfoUnpackPRDF"), hcalin_temperature(NULL), hcalout_temperature(NULL), emcal_temperature(NULL)
+{
+}
+
+//____________________________________
+int
+TempInfoUnpackPRDF::Init(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________
+int
+TempInfoUnpackPRDF::InitRun(PHCompositeNode *topNode)
+{
+  CreateNodeTree(topNode);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________
+int
+TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
+{
+  Event* event = findNode::getClass<Event>(topNode, "PRDF");
+  if (!event)
+    {
+      if (Verbosity() >= VERBOSITY_SOME)
+        cout << "TempInfoUnpackPRDF::Process_Event - Event not found" << endl;
+      return Fun4AllReturnCodes::DISCARDEVENT;
+    }
+
+
+  Packet *p_hcalin;
+  Packet *p_hcalout;
+  Packet *p_emcal;
+
+  // if (verbosity >= VERBOSITY_SOME)
+  //   {
+  //     cout << "TempInfoUnpackPRDF::process_event - ";
+  //     event->identify();
+  //   }
+
+
+  if (event->getEvtType() == BEGRUNEVENT)
+    {
+      p_hcalin  = event->getPacket(974);
+      p_hcalout = event->getPacket(975);
+      p_emcal   = event->getPacket(982);
+    }
+  else
+    {
+      p_hcalin  = event->getPacket(1074);
+      p_hcalout = event->getPacket(1075);
+      p_emcal   = event->getPacket(1082);
+    }
+
+  time_t etime= event->getTime();
+  int evtnr = event->getEvtSequence();
+
+
+  if (verbosity >= VERBOSITY_SOME && ( p_hcalin || p_hcalout || p_emcal) )
+    {
+      cout << "TempInfoUnpackPRDF::found temperature packet in Event - ";
+      event->identify();
+    }
+
+
+
+  if ( p_hcalin)
+    {
+      addPacketInfo (p_hcalin, topNode, etime, evtnr);
+      if (verbosity > VERBOSITY_SOME) p_hcalin->dump();
+      delete p_hcalin;
+    }
+
+  if ( p_hcalout)
+    {
+      addPacketInfo (p_hcalout, topNode, etime, evtnr);
+      if (verbosity > VERBOSITY_SOME) p_hcalout->dump();
+      delete p_hcalout;
+    }
+
+  if ( p_emcal)
+    {
+      addPacketInfo (p_emcal, topNode, etime, evtnr);
+      if (verbosity > VERBOSITY_SOME) p_emcal->dump();
+      delete p_emcal;
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+//____________________________________
+int  TempInfoUnpackPRDF::addPacketInfo(Packet *p, PHCompositeNode *topNode, const time_t  etime, const int evtnr)
+{
+
+  int packetid = p->getIdentifier();
+
+  RawTower_Temperature *tower;
+
+
+  if ( packetid == 974 || packetid == 1074 ) // Inner Hcal
+    {
+      for(int ibinz=0; ibinz<PROTOTYPE3_FEM::NCH_IHCAL_ROWS; ibinz++)
+	{
+	  for(int ibinphi=0; ibinphi<PROTOTYPE3_FEM::NCH_IHCAL_COLUMNS; ibinphi++)
+	    {
+	      tower = dynamic_cast<RawTower_Temperature*>(hcalin_temperature->getTower(ibinz,ibinphi));
+	      if(!tower)
+		{
+		  tower = new RawTower_Temperature();
+		  hcalin_temperature->AddTower(ibinz,ibinphi,tower);
+		}
+	      tower->add_entry( evtnr, etime, p->iValue(ibinz*PROTOTYPE3_FEM::NCH_IHCAL_COLUMNS + ibinphi)/1000. ); 
+	    }
+	}
+    }
+
+  else  if ( packetid == 975 || packetid == 1075 ) // outer Hcal
+    {
+      for(int ibinz=0; ibinz<PROTOTYPE3_FEM::NCH_OHCAL_ROWS; ibinz++)
+	{
+	  for(int ibinphi=0; ibinphi<PROTOTYPE3_FEM::NCH_OHCAL_COLUMNS; ibinphi++)
+	    {
+	      tower = dynamic_cast<RawTower_Temperature*>(hcalout_temperature->getTower(ibinz,ibinphi));
+	      if(!tower)
+		{
+		  tower = new RawTower_Temperature();
+		  hcalout_temperature->AddTower(ibinz,ibinphi,tower);
+		}
+	      tower->add_entry( evtnr, etime, p->iValue(ibinz*PROTOTYPE3_FEM::NCH_OHCAL_COLUMNS + ibinphi)/1000. ); 
+	    }
+	}
+    }
+
+  else  if ( packetid == 982 || packetid == 1082 ) // emcal
+    {
+      for(int ibinz=0; ibinz<PROTOTYPE3_FEM::NCH_EMCAL_ROWS; ibinz++)
+	{
+	  for(int ibinphi=0; ibinphi<PROTOTYPE3_FEM::NCH_EMCAL_COLUMNS; ibinphi++)
+	    {
+	      tower = dynamic_cast<RawTower_Temperature*>(emcal_temperature->getTower(ibinz,ibinphi));
+	      if(!tower)
+		{
+		  tower = new RawTower_Temperature();
+		  emcal_temperature->AddTower(ibinz,ibinphi,tower);
+		}
+	      // this takes care of the newly found "reverse" mapping. (0,0) is module 7, (0,7) is module 0, and 
+	      // the 63 - (...) takes care of the reversed vector.  
+	      tower->add_entry( evtnr, etime, p->iValue( 63- (ibinz*PROTOTYPE3_FEM::NCH_EMCAL_COLUMNS + (7-ibinphi) ) /1000. ) ); 
+	    }
+	}
+    }
+  return 0;
+}
+
+
+
+
+
+
+//_______________________________________
+void TempInfoUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
+{
+  PHNodeIterator nodeItr(topNode);
+  //DST node
+  PHCompositeNode * run_node = static_cast<PHCompositeNode*>(nodeItr.findFirst( "PHCompositeNode", "RUN"));
+  if (!run_node)
+    {
+      run_node = new PHCompositeNode("RUN");
+      topNode->addNode(run_node);
+      cout << "PHComposite node created: RUN" << endl;
+    }
+
+  PHIODataNode<PHObject> *tower_node = NULL;
+
+
+  //HCAL Towers
+  hcalin_temperature = new RawTowerContainer(RawTowerDefs::HCALIN);
+  tower_node = new PHIODataNode<PHObject>(hcalin_temperature, "TOWER_TEMPERATURE_HCALIN", "PHObject" );
+  run_node->addNode(tower_node);
+
+  hcalout_temperature = new RawTowerContainer(RawTowerDefs::HCALOUT);
+  tower_node = new PHIODataNode<PHObject>(hcalout_temperature, "TOWER_TEMPERATURE_HCALOUT", "PHObject" );
+  run_node->addNode(tower_node);
+
+  emcal_temperature = new RawTowerContainer(RawTowerDefs::CEMC);
+  tower_node = new PHIODataNode<PHObject>(emcal_temperature, "TOWER_TEMPERATURE_EMCAL", "PHObject" );
+  run_node->addNode(tower_node);
+
+}
+
+//___________________________________
+int TempInfoUnpackPRDF::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+

--- a/offline/packages/Prototype4/TempInfoUnpackPRDF.C
+++ b/offline/packages/Prototype4/TempInfoUnpackPRDF.C
@@ -1,57 +1,56 @@
-#include "RawTower_Temperature.h"
 #include "PROTOTYPE4_FEM.h"
+#include "RawTower_Temperature.h"
 #include "TempInfoUnpackPRDF.h"
 
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
-#include <Event/packetConstants.h>
 #include <Event/packet.h>
+#include <Event/packetConstants.h>
 #include <calobase/RawTowerContainer.h>
-#include <pdbcalbase/PdbParameterMap.h>
-#include <phparameter/PHParameters.h>
-#include <phool/PHCompositeNode.h>
-#include <phool/phool.h>
-#include <phool/getClass.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <pdbcalbase/PdbParameterMap.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phparameter/PHParameters.h>
+#include <cassert>
 #include <iostream>
 #include <string>
-#include <cassert>
 
 using namespace std;
 
 //____________________________________
-TempInfoUnpackPRDF::TempInfoUnpackPRDF() :
-  SubsysReco("TempInfoUnpackPRDF"), hcalin_temperature(NULL), hcalout_temperature(NULL), emcal_temperature(NULL)
+TempInfoUnpackPRDF::TempInfoUnpackPRDF()
+  : SubsysReco("TempInfoUnpackPRDF")
+  , hcalin_temperature(NULL)
+  , hcalout_temperature(NULL)
+  , emcal_temperature(NULL)
 {
 }
 
 //____________________________________
-int
-TempInfoUnpackPRDF::Init(PHCompositeNode *topNode)
+int TempInfoUnpackPRDF::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_____________________________________
-int
-TempInfoUnpackPRDF::InitRun(PHCompositeNode *topNode)
+int TempInfoUnpackPRDF::InitRun(PHCompositeNode *topNode)
 {
   CreateNodeTree(topNode);
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________
-int
-TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
+int TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
 {
-  Event* event = findNode::getClass<Event>(topNode, "PRDF");
+  Event *event = findNode::getClass<Event>(topNode, "PRDF");
   if (!event)
-    {
-      if (Verbosity() >= VERBOSITY_SOME)
-        cout << "TempInfoUnpackPRDF::Process_Event - Event not found" << endl;
-      return Fun4AllReturnCodes::DISCARDEVENT;
-    }
-
+  {
+    if (Verbosity() >= VERBOSITY_SOME)
+      cout << "TempInfoUnpackPRDF::Process_Event - Event not found" << endl;
+    return Fun4AllReturnCodes::DISCARDEVENT;
+  }
 
   Packet *p_hcalin;
   Packet *p_hcalout;
@@ -63,155 +62,141 @@ TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
   //     event->identify();
   //   }
 
-
   if (event->getEvtType() == BEGRUNEVENT)
-    {
-      p_hcalin  = event->getPacket(974);
-      p_hcalout = event->getPacket(975);
-      p_emcal   = event->getPacket(982);
-    }
+  {
+    p_hcalin = event->getPacket(974);
+    p_hcalout = event->getPacket(975);
+    p_emcal = event->getPacket(982);
+  }
   else
-    {
-      p_hcalin  = event->getPacket(1074);
-      p_hcalout = event->getPacket(1075);
-      p_emcal   = event->getPacket(1082);
-    }
+  {
+    p_hcalin = event->getPacket(1074);
+    p_hcalout = event->getPacket(1075);
+    p_emcal = event->getPacket(1082);
+  }
 
-  time_t etime= event->getTime();
+  time_t etime = event->getTime();
   int evtnr = event->getEvtSequence();
 
+  if (verbosity >= VERBOSITY_SOME && (p_hcalin || p_hcalout || p_emcal))
+  {
+    cout << "TempInfoUnpackPRDF::found temperature packet in Event - ";
+    event->identify();
+  }
 
-  if (verbosity >= VERBOSITY_SOME && ( p_hcalin || p_hcalout || p_emcal) )
-    {
-      cout << "TempInfoUnpackPRDF::found temperature packet in Event - ";
-      event->identify();
-    }
+  if (p_hcalin)
+  {
+    addPacketInfo(p_hcalin, topNode, etime, evtnr);
+    if (verbosity > VERBOSITY_SOME) p_hcalin->dump();
+    delete p_hcalin;
+  }
 
+  if (p_hcalout)
+  {
+    addPacketInfo(p_hcalout, topNode, etime, evtnr);
+    if (verbosity > VERBOSITY_SOME) p_hcalout->dump();
+    delete p_hcalout;
+  }
 
-
-  if ( p_hcalin)
-    {
-      addPacketInfo (p_hcalin, topNode, etime, evtnr);
-      if (verbosity > VERBOSITY_SOME) p_hcalin->dump();
-      delete p_hcalin;
-    }
-
-  if ( p_hcalout)
-    {
-      addPacketInfo (p_hcalout, topNode, etime, evtnr);
-      if (verbosity > VERBOSITY_SOME) p_hcalout->dump();
-      delete p_hcalout;
-    }
-
-  if ( p_emcal)
-    {
-      addPacketInfo (p_emcal, topNode, etime, evtnr);
-      if (verbosity > VERBOSITY_SOME) p_emcal->dump();
-      delete p_emcal;
-    }
+  if (p_emcal)
+  {
+    addPacketInfo(p_emcal, topNode, etime, evtnr);
+    if (verbosity > VERBOSITY_SOME) p_emcal->dump();
+    delete p_emcal;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-
 //____________________________________
-int  TempInfoUnpackPRDF::addPacketInfo(Packet *p, PHCompositeNode *topNode, const time_t  etime, const int evtnr)
+int TempInfoUnpackPRDF::addPacketInfo(Packet *p, PHCompositeNode *topNode, const time_t etime, const int evtnr)
 {
-
   int packetid = p->getIdentifier();
 
   RawTower_Temperature *tower;
 
-
-  if ( packetid == 974 || packetid == 1074 ) // Inner Hcal
+  if (packetid == 974 || packetid == 1074)  // Inner Hcal
+  {
+    for (int ibinz = 0; ibinz < PROTOTYPE4_FEM::NCH_IHCAL_ROWS; ibinz++)
     {
-      for(int ibinz=0; ibinz<PROTOTYPE4_FEM::NCH_IHCAL_ROWS; ibinz++)
-	{
-	  for(int ibinphi=0; ibinphi<PROTOTYPE4_FEM::NCH_IHCAL_COLUMNS; ibinphi++)
-	    {
-	      tower = dynamic_cast<RawTower_Temperature*>(hcalin_temperature->getTower(ibinz,ibinphi));
-	      if(!tower)
-		{
-		  tower = new RawTower_Temperature();
-		  hcalin_temperature->AddTower(ibinz,ibinphi,tower);
-		}
-	      tower->add_entry( evtnr, etime, p->iValue(ibinz*PROTOTYPE4_FEM::NCH_IHCAL_COLUMNS + ibinphi)/1000. ); 
-	    }
-	}
+      for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_IHCAL_COLUMNS; ibinphi++)
+      {
+        tower = dynamic_cast<RawTower_Temperature *>(hcalin_temperature->getTower(ibinz, ibinphi));
+        if (!tower)
+        {
+          tower = new RawTower_Temperature();
+          hcalin_temperature->AddTower(ibinz, ibinphi, tower);
+        }
+        tower->add_entry(evtnr, etime, p->iValue(ibinz * PROTOTYPE4_FEM::NCH_IHCAL_COLUMNS + ibinphi) / 1000.);
+      }
     }
+  }
 
-  else  if ( packetid == 975 || packetid == 1075 ) // outer Hcal
+  else if (packetid == 975 || packetid == 1075)  // outer Hcal
+  {
+    for (int ibinz = 0; ibinz < PROTOTYPE4_FEM::NCH_OHCAL_ROWS; ibinz++)
     {
-      for(int ibinz=0; ibinz<PROTOTYPE4_FEM::NCH_OHCAL_ROWS; ibinz++)
-	{
-	  for(int ibinphi=0; ibinphi<PROTOTYPE4_FEM::NCH_OHCAL_COLUMNS; ibinphi++)
-	    {
-	      tower = dynamic_cast<RawTower_Temperature*>(hcalout_temperature->getTower(ibinz,ibinphi));
-	      if(!tower)
-		{
-		  tower = new RawTower_Temperature();
-		  hcalout_temperature->AddTower(ibinz,ibinphi,tower);
-		}
-	      tower->add_entry( evtnr, etime, p->iValue(ibinz*PROTOTYPE4_FEM::NCH_OHCAL_COLUMNS + ibinphi)/1000. ); 
-	    }
-	}
+      for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_OHCAL_COLUMNS; ibinphi++)
+      {
+        tower = dynamic_cast<RawTower_Temperature *>(hcalout_temperature->getTower(ibinz, ibinphi));
+        if (!tower)
+        {
+          tower = new RawTower_Temperature();
+          hcalout_temperature->AddTower(ibinz, ibinphi, tower);
+        }
+        tower->add_entry(evtnr, etime, p->iValue(ibinz * PROTOTYPE4_FEM::NCH_OHCAL_COLUMNS + ibinphi) / 1000.);
+      }
     }
+  }
 
-  else  if ( packetid == 982 || packetid == 1082 ) // emcal
+  else if (packetid == 982 || packetid == 1082)  // emcal
+  {
+    for (int ibinz = 0; ibinz < PROTOTYPE4_FEM::NCH_EMCAL_ROWS; ibinz++)
     {
-      for(int ibinz=0; ibinz<PROTOTYPE4_FEM::NCH_EMCAL_ROWS; ibinz++)
-	{
-	  for(int ibinphi=0; ibinphi<PROTOTYPE4_FEM::NCH_EMCAL_COLUMNS; ibinphi++)
-	    {
-	      tower = dynamic_cast<RawTower_Temperature*>(emcal_temperature->getTower(ibinz,ibinphi));
-	      if(!tower)
-		{
-		  tower = new RawTower_Temperature();
-		  emcal_temperature->AddTower(ibinz,ibinphi,tower);
-		}
-	      // this takes care of the newly found "reverse" mapping. (0,0) is module 7, (0,7) is module 0, and 
-	      // the 63 - (...) takes care of the reversed vector.  
-	      tower->add_entry( evtnr, etime, p->iValue( 63- (ibinz*PROTOTYPE4_FEM::NCH_EMCAL_COLUMNS + (7-ibinphi) ) /1000. ) ); 
-	    }
-	}
+      for (int ibinphi = 0; ibinphi < PROTOTYPE4_FEM::NCH_EMCAL_COLUMNS; ibinphi++)
+      {
+        tower = dynamic_cast<RawTower_Temperature *>(emcal_temperature->getTower(ibinz, ibinphi));
+        if (!tower)
+        {
+          tower = new RawTower_Temperature();
+          emcal_temperature->AddTower(ibinz, ibinphi, tower);
+        }
+        // this takes care of the newly found "reverse" mapping. (0,0) is module 7, (0,7) is module 0, and
+        // the 63 - (...) takes care of the reversed vector.
+        tower->add_entry(evtnr, etime, p->iValue(63 - (ibinz * PROTOTYPE4_FEM::NCH_EMCAL_COLUMNS + (7 - ibinphi)) / 1000.));
+      }
     }
+  }
   return 0;
 }
-
-
-
-
-
 
 //_______________________________________
 void TempInfoUnpackPRDF::CreateNodeTree(PHCompositeNode *topNode)
 {
   PHNodeIterator nodeItr(topNode);
   //DST node
-  PHCompositeNode * run_node = static_cast<PHCompositeNode*>(nodeItr.findFirst( "PHCompositeNode", "RUN"));
+  PHCompositeNode *run_node = static_cast<PHCompositeNode *>(nodeItr.findFirst("PHCompositeNode", "RUN"));
   if (!run_node)
-    {
-      run_node = new PHCompositeNode("RUN");
-      topNode->addNode(run_node);
-      cout << "PHComposite node created: RUN" << endl;
-    }
+  {
+    run_node = new PHCompositeNode("RUN");
+    topNode->addNode(run_node);
+    cout << "PHComposite node created: RUN" << endl;
+  }
 
   PHIODataNode<PHObject> *tower_node = NULL;
 
-
   //HCAL Towers
   hcalin_temperature = new RawTowerContainer(RawTowerDefs::HCALIN);
-  tower_node = new PHIODataNode<PHObject>(hcalin_temperature, "TOWER_TEMPERATURE_HCALIN", "PHObject" );
+  tower_node = new PHIODataNode<PHObject>(hcalin_temperature, "TOWER_TEMPERATURE_HCALIN", "PHObject");
   run_node->addNode(tower_node);
 
   hcalout_temperature = new RawTowerContainer(RawTowerDefs::HCALOUT);
-  tower_node = new PHIODataNode<PHObject>(hcalout_temperature, "TOWER_TEMPERATURE_HCALOUT", "PHObject" );
+  tower_node = new PHIODataNode<PHObject>(hcalout_temperature, "TOWER_TEMPERATURE_HCALOUT", "PHObject");
   run_node->addNode(tower_node);
 
   emcal_temperature = new RawTowerContainer(RawTowerDefs::CEMC);
-  tower_node = new PHIODataNode<PHObject>(emcal_temperature, "TOWER_TEMPERATURE_EMCAL", "PHObject" );
+  tower_node = new PHIODataNode<PHObject>(emcal_temperature, "TOWER_TEMPERATURE_EMCAL", "PHObject");
   run_node->addNode(tower_node);
-
 }
 
 //___________________________________
@@ -219,4 +204,3 @@ int TempInfoUnpackPRDF::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
-

--- a/offline/packages/Prototype4/TempInfoUnpackPRDF.h
+++ b/offline/packages/Prototype4/TempInfoUnpackPRDF.h
@@ -1,0 +1,48 @@
+#ifndef __TempInfoUnpackPRDFF__
+#define __TempInfoUnpackPRDFF__
+
+#include <fun4all/SubsysReco.h>
+#include <phool/PHObject.h>
+#include <string>
+#include <map>
+#include <utility>
+
+class Event;
+class Packet;
+class RawTowerContainer;
+class RawTower;
+
+class TempInfoUnpackPRDF : public SubsysReco
+{
+public:
+  TempInfoUnpackPRDF();
+  virtual ~TempInfoUnpackPRDF() {};
+
+  int
+  Init(PHCompositeNode *topNode);
+
+  int
+  InitRun(PHCompositeNode *topNode);
+
+  int
+  process_event(PHCompositeNode *topNode);
+
+  int
+  End(PHCompositeNode *topNode);
+
+  void
+  CreateNodeTree(PHCompositeNode *topNode);
+
+
+protected:
+
+  int addPacketInfo(Packet *p, PHCompositeNode *topNode, const time_t  etime, const int evtnr);
+
+  RawTowerContainer* hcalin_temperature;
+  RawTowerContainer* hcalout_temperature;
+  RawTowerContainer* emcal_temperature;
+
+};
+
+
+#endif //**TempInfoUnpackPRDFF**//

--- a/offline/packages/Prototype4/TempInfoUnpackPRDF.h
+++ b/offline/packages/Prototype4/TempInfoUnpackPRDF.h
@@ -3,8 +3,8 @@
 
 #include <fun4all/SubsysReco.h>
 #include <phool/PHObject.h>
-#include <string>
 #include <map>
+#include <string>
 #include <utility>
 
 class Event;
@@ -14,35 +14,27 @@ class RawTower;
 
 class TempInfoUnpackPRDF : public SubsysReco
 {
-public:
+ public:
   TempInfoUnpackPRDF();
-  virtual ~TempInfoUnpackPRDF() {};
+  virtual ~TempInfoUnpackPRDF(){};
 
-  int
-  Init(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode);
 
-  int
-  InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
 
-  int
-  process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
 
-  int
-  End(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
 
   void
   CreateNodeTree(PHCompositeNode *topNode);
 
+ protected:
+  int addPacketInfo(Packet *p, PHCompositeNode *topNode, const time_t etime, const int evtnr);
 
-protected:
-
-  int addPacketInfo(Packet *p, PHCompositeNode *topNode, const time_t  etime, const int evtnr);
-
-  RawTowerContainer* hcalin_temperature;
-  RawTowerContainer* hcalout_temperature;
-  RawTowerContainer* emcal_temperature;
-
+  RawTowerContainer *hcalin_temperature;
+  RawTowerContainer *hcalout_temperature;
+  RawTowerContainer *emcal_temperature;
 };
 
-
-#endif //**TempInfoUnpackPRDFF**//
+#endif  //**TempInfoUnpackPRDFF**//

--- a/offline/packages/Prototype4/TempInfoUnpackPRDFLinkDef.h
+++ b/offline/packages/Prototype4/TempInfoUnpackPRDFLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TempInfoUnpackPRDF+;
+
+#endif /* __CINT__ */

--- a/offline/packages/Prototype4/autogen.sh
+++ b/offline/packages/Prototype4/autogen.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"
+
+

--- a/offline/packages/Prototype4/configure.ac
+++ b/offline/packages/Prototype4/configure.ac
@@ -1,0 +1,22 @@
+AC_INIT(prototype4,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+AM_INIT_AUTOMAKE
+
+AC_PROG_CXX(g++)
+LT_INIT([disable-static])
+
+dnl   no point in suppressing warnings people should
+dnl   at least see them, so here we go for g++: -Wall
+dnl   make warnings fatal errors: -Werror
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+fi
+
+dnl test for root 6
+if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+AC_SUBST(CINTDEFS)
+fi
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
Anthony Hodges and I have been preparing the production code for the 2018 test beam. This is a preview of the reconstruction modules. These modules reads the the 14-bit sPHENIX ADC data under sPHENIX analysis framework, and produce the calorimeter DST node structure that is identical to that of the simulation. The decoder part is based on John Haggerty's stand-alone analysis code ```WD409```. 

This is a preview for most functionalities. Anthony is working on mapping between channel and towers, which is a placeholder in this pull request. To be updated prior to merging. 

Related macros update: https://github.com/sPHENIX-Collaboration/macros/pull/99
And analysis macros: https://github.com/sPHENIX-Collaboration/analysis/tree/master/Prototype4/EMCal/macros 

# Test

Some test based on LED pulse data on EMCal taken at Fermilab on Feb20: 
```/sphenix/data/data03//phnxreco/sphenix/t1044/fnal/led/led_00000254-0000.prdf```
which has LED pulsed on each EMCal tower with some amplitude of signals. Two checks are performed to show the signals are decoded and fit to extract the amplitudes: 

## ADC VS samples for each EMCal tower

![image](https://user-images.githubusercontent.com/7947083/36521234-c2f26cec-1763-11e8-9093-de1a70c554a7.png)


## Peak amplitude for each EMCal tower

![image](https://user-images.githubusercontent.com/7947083/36521241-ccd995a0-1763-11e8-8fca-09c57ddd8e14.png)
