### PR TITLE
Fixed bug in clusterizer. Yield for peak bin was added twice to clust…

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -451,7 +451,7 @@ void PHG4TPCClusterizer::find_z_range(int zbin, int phibin, int zmax, float peak
 //===================
 void PHG4TPCClusterizer::fit(int pbin, int zbin, int& nhits_tot) {
   float peak = fAmps[zbin * fNPhiBins + pbin];
-  fFitW = peak;
+  fFitW = 0.0;
   fFitP0 = fGeoLayer->get_phicenter( pbin );
   fFitZ0 = fGeoLayer->get_zcenter( zbin );
   fFitSumP = 0;


### PR DESCRIPTION
…er weight, resulted in biased values of reconstructed phi.

Found a bug in PHG4TPCClusterizer that caused the weight of each cluster to be too large, systematically biasing the reconstructed phi values. The plots below show the error in the reconstructed phi vs phi in a small phi window from before and after the fix.

[tpc_clusterfix_before_outer_tpc_dphi_gphi.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/1759878/tpc_clusterfix_before_outer_tpc_dphi_gphi.pdf)

[tpc_clusterfix_after_outer_tpc_dphi_gphi.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/1759879/tpc_clusterfix_after_outer_tpc_dphi_gphi.pdf)

This bug was less obvious when smaller pad spacing in phi was used, but becomes important when going to the pad spacing we actually plan to use.