### PR TITLE
New zigzag pads

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -50,6 +50,8 @@ PHG4CylinderCellTPCReco::PHG4CylinderCellTPCReco(int n_pixel,
   , sigmaT(0.04)
   , elec_per_gev(38. * 1e6)
   , driftv(3.0 / 1000.0)
+  , fpad{nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr}
+  , fcharge(nullptr)
   ,  // cm per ns
   num_pixel_layers(n_pixel)
   , tmin_default(0.0)

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -70,7 +70,7 @@ PHG4CylinderCellTPCReco::PHG4CylinderCellTPCReco(int n_pixel,
   , fShapingLead(32.0 * 3.0 / 1000.0)
   ,                                  // ns
   fShapingTail(48.0 * 3.0 / 1000.0)  // ns
-  , zigzag_pads(0) 
+  , zigzag_pads(1) 
 {
   memset(nbins, 0, sizeof(nbins));
   unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -93,7 +93,7 @@ protected:
   double sigmaT;
   double elec_per_gev;
   double driftv;
-  TF1 *fpad;
+  TF1 *fpad[10];
   TF1 *fcharge;
 
   int num_pixel_layers;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -16,6 +16,7 @@
 class PHCompositeNode;
 class PHG4TPCDistortion;
 class TH1;
+class TF1;
 class TProfile2D;
 class PHG4CylinderCellGeom;
 
@@ -36,7 +37,9 @@ public:
   
   void Detector(const std::string &d);
   void cellsize(const int i, const double sr, const double sz);
-  void populate_phibins(PHG4CylinderCellGeom *geo, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share);
+  void setZigzags(const bool zzpads){zigzag_pads = zzpads;}
+  void populate_rectangular_phibins(PHG4CylinderCellGeom *geo, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share);
+  void populate_zigzag_phibins(PHG4CylinderCellGeom *geo, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share);
   void populate_zbins(PHG4CylinderCellGeom *geo, const double z,  const double cloud_sig_zz[2], std::vector<int> &pad_zbin, std::vector<double> &pad_zbin_share);
   void OutputDetector(const std::string &d) {outdetector = d;}
 
@@ -90,6 +93,8 @@ protected:
   double sigmaT;
   double elec_per_gev;
   double driftv;
+  TF1 *fpad;
+  TF1 *fcharge;
 
   int num_pixel_layers;
 
@@ -110,6 +115,8 @@ protected:
   double fFractZZsm;
   double fShapingLead;
   double fShapingTail;
+  bool zigzag_pads;
+
 #ifndef __CINT__
   //! random generator that conform with sPHENIX standard
   gsl_rng *RandomGenerator;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -17,6 +17,7 @@ class PHCompositeNode;
 class PHG4TPCDistortion;
 class TH1;
 class TProfile2D;
+class PHG4CylinderCellGeom;
 
 class PHG4CylinderCellTPCReco : public SubsysReco
 {
@@ -35,6 +36,8 @@ public:
   
   void Detector(const std::string &d);
   void cellsize(const int i, const double sr, const double sz);
+  void populate_phibins(PHG4CylinderCellGeom *geo, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share);
+  void populate_zbins(PHG4CylinderCellGeom *geo, const double z,  const double cloud_sig_zz[2], std::vector<int> &pad_zbin, std::vector<double> &pad_zbin_share);
   void OutputDetector(const std::string &d) {outdetector = d;}
 
   void setHalfLength(const double hz){fHalfLength = hz;}
@@ -67,6 +70,10 @@ protected:
   std::map<int, std::pair<double,double>> cell_size; // cell size in phi/z
   std::map<int, double> phistep;
   std::map<int, double> etastep;
+  std::vector<int> adc_zbin;
+  std::vector<int> pad_phibin;
+  std::vector<double> pad_phibin_share;
+  std::vector<double> adc_zbin_share;
   std::string detector;
   std::string outdetector;
   std::string hitnodename;

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -346,7 +346,7 @@ void PHG4TPCClusterizer::find_phi_range(int zbin, int phibin, int phimax, float 
   for(int ip=0; ip<=fFitRangeP; ++ip) {
     int cp = wrap_phibin(phibin + ip);
     int bin = zbin * fNPhiBins + cp;
-    if(fAmps[bin] <= fFitEnergyThreshold*peak){
+    if(fAmps[bin] < fFitEnergyThreshold*peak){
       phiup = ip;
       break; // skip small (include empty)
     }
@@ -363,7 +363,7 @@ void PHG4TPCClusterizer::find_phi_range(int zbin, int phibin, int phimax, float 
   for(int ip=0; ip<=fFitRangeP; ++ip) {
     int cp = wrap_phibin(phibin - ip);
     int bin = zbin * fNPhiBins + cp;
-    if(fAmps[bin] <= fFitEnergyThreshold*peak){
+    if(fAmps[bin] < fFitEnergyThreshold*peak){
       phidown = ip;
       break; // skip small (include empty)
     }
@@ -401,7 +401,7 @@ void PHG4TPCClusterizer::find_z_range(int zbin, int phibin, int zmax, float peak
       int bin1 = (cz+1) * fNPhiBins + cp;
       int bin2 = (cz+2) * fNPhiBins + cp;
       int bin3 = (cz+3) * fNPhiBins + cp;
-      if(fAmps[bin] <= fFitEnergyThreshold*peak) {
+      if(fAmps[bin] < fFitEnergyThreshold*peak) {
 	zup = iz;
 	if(verbosity > 1000) cout << " failed threshold cut, set izup to " << zup << endl;
 	break;
@@ -451,7 +451,7 @@ void PHG4TPCClusterizer::find_z_range(int zbin, int phibin, int zmax, float peak
 //===================
 void PHG4TPCClusterizer::fit(int pbin, int zbin, int& nhits_tot) {
   float peak = fAmps[zbin * fNPhiBins + pbin];
-  fFitW = 0;
+  fFitW = peak;
   fFitP0 = fGeoLayer->get_phicenter( pbin );
   fFitZ0 = fGeoLayer->get_zcenter( zbin );
   fFitSumP = 0;
@@ -513,34 +513,24 @@ void PHG4TPCClusterizer::fit(int pbin, int zbin, int& nhits_tot) {
 	std::cout << Form("%.2f | ",fAmps[bin]);
 	if(ip==fFitRangeP) std::cout << std::endl;
       }
-      if(fAmps[bin] < fFitEnergyThreshold*peak) 
-	{
-	  if(verbosity > 5000)  cout << " skip ip = " << ip << " because ee  " << fAmps[bin] << " smaller than fFitEnergyThreshold " <<  fFitEnergyThreshold << " times peak " << peak <<  endl;
-	  continue; // skip small (include empty)
-	}
+      if(fAmps[bin] < fFitEnergyThreshold*peak) continue; // skip small (include empty)
       used = true;
-      if(verbosity>5000) cout << " calculating centroid for ip =  " << ip << endl;
       nphis++;
       float ee = fAmps[bin];
       float dz = fGeoLayer->get_zcenter(cz) - fFitZ0;
       float dp = fGeoLayer->get_phicenter(cp) - fFitP0;
-      if(verbosity > 5000) cout << " dp " << dp << " cp " << cp << " phicenter " <<  fGeoLayer->get_phicenter(cp) << " fFitP0 " <<  fFitP0 << endl;
       if(dp<-3.0) dp = dp + _twopi; // binphi has been reduced;
       if(dp>+3.0) dp = dp - _twopi; // binphi has been increased;
-       if(verbosity > 5000) cout << " ee " << ee << " dp " << dp << " fFitSumP before " << fFitSumP;
       fFitW += ee;
       fFitSumP += ee*dp;
       fFitSumZ += ee*dz;
       fFitSumP2 += ee*dp*dp;
       fFitSumZ2 += ee*dz*dz;
       fFitSumPZ += ee*dp*dz;
-      if(verbosity > 5000)  cout << " add  bin with iz " << iz << " cz " << cz << " dz " << dz << " ip " << ip << " cp " << cp << " dp " << dp 
-				 << " bin " << bin << " famps " << ee <<  " fFitSumP after " << fFitSumP << endl;
       nhits_tot -= 1; //taken
       fNHitsPerZ[cz] -= 1; //taken
       fAmps[bin] = 0.; //removed
     }
-    if(verbosity>5000) cout << " fFitSumP " << fFitSumP << " fFitW " << fFitW << " mean " << fFitSumP/fFitW << endl;
     if(used) fFitSizeZ++;
     fFitSizeP = TMath::Max(fFitSizeP,float(nphis));
   }
@@ -717,7 +707,6 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
 	  fFitRangeP = int( fClusterWindow*sigmaP/(radius*stepp) + 1);
 
 	  if(fFitRangeP<1) fFitRangeP = 1;
-	  if(fFitRangeP < 5)   fFitRangeP = 5;
 	  if(fFitRangeP>fFitRangeMP) fFitRangeP = fFitRangeMP;
           if(!is_local_maximum(phibin, zbin)) continue;
 	  if(verbosity>2000){

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -451,7 +451,6 @@ void PHG4TPCClusterizer::find_z_range(int zbin, int phibin, int zmax, float peak
 //===================
 void PHG4TPCClusterizer::fit(int pbin, int zbin, int& nhits_tot) {
   float peak = fAmps[zbin * fNPhiBins + pbin];
-  //fFitW = peak; // bug!
   fFitW = 0;
   fFitP0 = fGeoLayer->get_phicenter( pbin );
   fFitZ0 = fGeoLayer->get_zcenter( zbin );


### PR DESCRIPTION
New version of PHG4CylinderCellTPCReco that provides a zigzag pad readout for the TPC as the default. Optionally, rectangular pads can be used instead by putting in the tracking macro:
(PHG4CylinderCellTPCReco* svtx_cells = .........)
   bool use_zigzag_pads = false;
   svtx_cells->setZigzags(use_zigzag_pads);  

I will make a presentation at the February 27 simulations meeting showing some test results.