### PR TITLE
Eic/truthinfo

### DIFF
--- a/simulation/g4simulation/g4main/ReadEICFiles.cc
+++ b/simulation/g4simulation/g4main/ReadEICFiles.cc
@@ -114,6 +114,10 @@ ReadEICFiles::process_event(PHCompositeNode *topNode)
   vector< HepMC::GenParticle* > hepmc_particles;
   vector< unsigned > origin_index;
 
+  /* save pointers to beam particles */
+  HepMC::GenParticle *hepmc_beam1 = NULL;
+  HepMC::GenParticle *hepmc_beam2 = NULL;
+
   for (unsigned ii = 0; ii < GenEvent->GetNTracks(); ii++)
     {
       /* Get particle / track from event records.
@@ -148,6 +152,14 @@ ReadEICFiles::process_event(PHCompositeNode *topNode)
       /* append particle to vector */
       hepmc_particles.push_back(hepmcpart);
       origin_index.push_back( track_ii->GetIndex() );
+
+      /* if first particle, call this the first beam particle */
+      if ( ii == 0 )
+	hepmc_beam1 = hepmcpart;
+
+      /* if second particle, call this the second beam particle */
+      if ( ii == 1 )
+	hepmc_beam2 = hepmcpart;
     }
 
   /* Check if hepmc_particles and origin_index vectors are the same size */
@@ -248,6 +260,9 @@ ReadEICFiles::process_event(PHCompositeNode *topNode)
   /* Add HepMC vertices to event */
   for ( unsigned v = 0; v < hepmc_vertices.size(); v++ )
     evt->add_vertex( hepmc_vertices.at(v) );
+
+  /* set beam particles */
+  evt->set_beam_particles( hepmc_beam1, hepmc_beam2 );
 
   /* pass HepMC to PHNode*/
   PHHepMCGenEvent * success = hepmc_helper . insert_event(evt);

--- a/simulation/g4simulation/g4main/ReadEICFiles.cc
+++ b/simulation/g4simulation/g4main/ReadEICFiles.cc
@@ -108,6 +108,15 @@ ReadEICFiles::process_event(PHCompositeNode *topNode)
   /* add global information to the event */
   evt->set_event_number(entry);
 
+  /* process ID from pythia */
+  evt->set_signal_process_id( GenEvent->GetProcess() );
+
+  /* Set the PDF information */
+  HepMC::PdfInfo pdfinfo;
+  pdfinfo.set_x1( 1 );
+  pdfinfo.set_x2( GenEvent->GetX() );
+  pdfinfo.set_scalePDF( GenEvent->GetQ2() );
+  evt->set_pdf_info( pdfinfo );
 
   /* Loop over all particles for this event in input file and fill
    * vector with HepMC particles */
@@ -127,24 +136,24 @@ ReadEICFiles::process_event(PHCompositeNode *topNode)
 
       /* Create HepMC particle record */
       HepMC::GenParticle *hepmcpart = new HepMC::GenParticle( HepMC::FourVector(track_ii->GetPx(),
-										track_ii->GetPy(),
-										track_ii->GetPz(),
-										track_ii->GetE()),
-							      track_ii->Id());
+                                                                                track_ii->GetPy(),
+                                                                                track_ii->GetPz(),
+                                                                                track_ii->GetE()),
+                                                              track_ii->Id());
 
       /* translate eic-smear status codes to HepMC status codes */
       switch ( track_ii->GetStatus() )
-	{
-	case 1: hepmcpart->set_status( 1 ); break;  // 'stable particle'
+        {
+        case 1: hepmcpart->set_status( 1 ); break;  // 'stable particle'
 
-	case 21: hepmcpart->set_status( 3 ); break; // 'documentation line'
+        case 21: hepmcpart->set_status( 3 ); break; // 'documentation line'
 
-	default: hepmcpart->set_status( 0 ); break; // 'null entry'
-	}
+        default: hepmcpart->set_status( 0 ); break; // 'null entry'
+        }
 
       /* assume the first two particles are the beam particles (which getsHepMC status 4)*/
       if ( ii < 2 )
-	hepmcpart->set_status( 4 );
+        hepmcpart->set_status( 4 );
 
       /* add particle information */
       hepmcpart->setGeneratedMass( track_ii->GetM() );
@@ -181,7 +190,7 @@ ReadEICFiles::process_event(PHCompositeNode *topNode)
 
       /* continue if vertices for particle are already set */
       if ( pp->production_vertex() && pp->end_vertex() )
-	continue;
+        continue;
 
       /* access mother particle vertex */
       erhic::ParticleMC * track_pp = GenEvent->GetTrack(p);
@@ -190,43 +199,43 @@ ReadEICFiles::process_event(PHCompositeNode *topNode)
 
       HepMC::GenParticle *pmother = NULL;
       for ( unsigned m = 0; m < hepmc_particles.size(); m++ )
-	{
-	  if ( origin_index.at( m ) == parent_index )
-	    {
-	      pmother = hepmc_particles.at( m );
-	      break;
-	    }
-	}
+        {
+          if ( origin_index.at( m ) == parent_index )
+            {
+              pmother = hepmc_particles.at( m );
+              break;
+            }
+        }
 
       /* if mother does not exist: create new vertex and add this particle as outgoing to vertex */
       if ( !pmother )
-	{
-	  HepMC::GenVertex* hepmcvtx = new HepMC::GenVertex( HepMC::FourVector( track_pp->GetVertex()[0],
-										track_pp->GetVertex()[1],
-										track_pp->GetVertex()[2],
-										0 )
-							     );
-	  hepmc_vertices.push_back( hepmcvtx );
-	  hepmcvtx->add_particle_out(pp);
-	  continue;
-      	}
+        {
+          HepMC::GenVertex* hepmcvtx = new HepMC::GenVertex( HepMC::FourVector( track_pp->GetVertex()[0],
+                                                                                track_pp->GetVertex()[1],
+                                                                                track_pp->GetVertex()[2],
+                                                                                0 )
+                                                             );
+          hepmc_vertices.push_back( hepmcvtx );
+          hepmcvtx->add_particle_out(pp);
+          continue;
+        }
       /* if mother exists and has end vertex: add this particle as outgoing to the mother's end vertex */
       else if ( pmother->end_vertex() )
-	{
-	  pmother->end_vertex()->add_particle_out(pp);
-	}
+        {
+          pmother->end_vertex()->add_particle_out(pp);
+        }
       /* if mother exists and has no end vertex: create new vertex */
       else
-	{
-	  HepMC::GenVertex* hepmcvtx = new HepMC::GenVertex( HepMC::FourVector( track_pp->GetVertex()[0],
-										track_pp->GetVertex()[1],
-										track_pp->GetVertex()[2],
-										0 )
-							     );
-	  hepmc_vertices.push_back( hepmcvtx );
-	  hepmcvtx->add_particle_in(pmother);
-	  pmother->end_vertex()->add_particle_out(pp);
-	}
+        {
+          HepMC::GenVertex* hepmcvtx = new HepMC::GenVertex( HepMC::FourVector( track_pp->GetVertex()[0],
+                                                                                track_pp->GetVertex()[1],
+                                                                                track_pp->GetVertex()[2],
+                                                                                0 )
+                                                             );
+          hepmc_vertices.push_back( hepmcvtx );
+          hepmcvtx->add_particle_in(pmother);
+          pmother->end_vertex()->add_particle_out(pp);
+        }
     }
 
   /* Add end vertex to beam particles if they don't have one yet */
@@ -235,26 +244,26 @@ ReadEICFiles::process_event(PHCompositeNode *topNode)
       HepMC::GenParticle *pp = hepmc_particles.at(p);
 
       if ( ! pp->end_vertex() )
-	{
-	  /* create collision vertex */
-	  HepMC::GenVertex* hepmcvtx = new HepMC::GenVertex( HepMC::FourVector( 0,
-										0,
-										0,
-										0 )
-							     );
-	  hepmc_vertices.push_back( hepmcvtx );
-	  hepmcvtx->add_particle_in( pp );
-	}
+        {
+          /* create collision vertex */
+          HepMC::GenVertex* hepmcvtx = new HepMC::GenVertex( HepMC::FourVector( 0,
+                                                                                0,
+                                                                                0,
+                                                                                0 )
+                                                             );
+          hepmc_vertices.push_back( hepmcvtx );
+          hepmcvtx->add_particle_in( pp );
+        }
     }
 
   /* Check that all particles (except beam particles) have a production vertex */
   for ( unsigned p = 2; p < hepmc_particles.size(); p++ )
     {
       if ( ! hepmc_particles.at(p)->production_vertex() )
-	{
-	  cout << "ReadEICFiles::process_event - Missing production vertex for one or more non-beam particles!" << endl;
-	  return Fun4AllReturnCodes::ABORTRUN;
-	}
+        {
+          cout << "ReadEICFiles::process_event - Missing production vertex for one or more non-beam particles!" << endl;
+          return Fun4AllReturnCodes::ABORTRUN;
+        }
     }
 
   /* Add HepMC vertices to event */


### PR DESCRIPTION
Add x and Q2 kinematics parameters from event generator files created with eic-smear to the HepMC event record created by ReadEICFiles module when reading the events into Fun4All.

x-Q2 distribution plotted from the HepMC events for 20x250 GeV electron-proton collisions generated with Pythia6 looks correct:

![screen shot 2018-03-02 at 3 15 15 pm](https://user-images.githubusercontent.com/9557412/36919997-3b969fae-1e2d-11e8-952f-3d804b35f8a9.png)
