### PR TITLE
Accumulated update on 2018 test beam analysis

### DIFF
--- a/offline/packages/Prototype4/CaloCalibration.C
+++ b/offline/packages/Prototype4/CaloCalibration.C
@@ -86,7 +86,7 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
       bool signal_check_pass = true;
       for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
       {
-        if (vec_signal_samples[i] <= 10 or vec_signal_samples[i] >= ((1 << 14) - 10))
+        if (raw_tower->get_signal_samples(i) <= 10 or raw_tower->get_signal_samples(i) >= ((1 << 14) - 10))
         {
           signal_check_pass = false;
           break;

--- a/offline/packages/Prototype4/CaloCalibration.C
+++ b/offline/packages/Prototype4/CaloCalibration.C
@@ -192,6 +192,12 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
 
       raw_tower->set_energy(peak);
       raw_tower->set_time(peak_sample);
+
+      if (verbosity)
+      {
+        raw_tower->identify();
+      }
+
     }
 
     // store the result - calib_tower

--- a/offline/packages/Prototype4/CaloCalibration.C
+++ b/offline/packages/Prototype4/CaloCalibration.C
@@ -8,10 +8,12 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
+
 #include <cassert>
 #include <cfloat>
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <string>
 
 using namespace std;
@@ -83,25 +85,28 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
           dynamic_cast<RawTower_Prototype4 *>(rtiter->second);
       assert(raw_tower);
 
-      bool signal_check_pass = true;
+      //      bool signal_check_pass = true;
+      //      for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
+      //      {
+      //        if (raw_tower->get_signal_samples(i) <= 10 or raw_tower->get_signal_samples(i) >= ((1 << 14) - 10))
+      //        {
+      //          signal_check_pass = false;
+      //          break;
+      //        }
+      //      }
+
+      //      if (signal_check_pass)
+      //      {
+      ++count;
+
       for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
       {
         if (raw_tower->get_signal_samples(i) <= 10 or raw_tower->get_signal_samples(i) >= ((1 << 14) - 10))
-        {
-          signal_check_pass = false;
-          break;
-        }
-      }
-
-      if (signal_check_pass)
-      {
-        ++count;
-
-        for (int i = 0; i < RawTower_Prototype4::NSAMPLES; i++)
-        {
+          vec_signal_samples[i] = numeric_limits<double>::quiet_NaN();  // invalidate this sample
+        else
           vec_signal_samples[i] += raw_tower->get_signal_samples(i);
-        }
       }
+      //      }
     }
 
     if (count > 0)
@@ -127,21 +132,21 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
       parameters_constraints[5] = parameters_io[5];
       parameters_constraints[6] = parameters_io[6];
 
-//      //special constraint if Peak Time 1 == Peak Time 2
-//      if (abs(parameters_constraints[6] - parameters_constraints[3]) < 0.1)
-//      {
-//        const double average_peak_time = (parameters_constraints[6] + parameters_constraints[3]) / 2.;
-//
-//        std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-//                  << ": two shaping time are too close "
-//                  << parameters_constraints[3] << " VS " << parameters_constraints[6]
-//                  << ". Use average peak time instead: " << average_peak_time
-//                  << std::endl;
-//
-//        parameters_constraints[6] = average_peak_time;
-//        parameters_constraints[3] = average_peak_time;
-//        parameters_constraints[5] = 0;
-//      }
+      //      //special constraint if Peak Time 1 == Peak Time 2
+      //      if (abs(parameters_constraints[6] - parameters_constraints[3]) < 0.1)
+      //      {
+      //        const double average_peak_time = (parameters_constraints[6] + parameters_constraints[3]) / 2.;
+      //
+      //        std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+      //                  << ": two shaping time are too close "
+      //                  << parameters_constraints[3] << " VS " << parameters_constraints[6]
+      //                  << ". Use average peak time instead: " << average_peak_time
+      //                  << std::endl;
+      //
+      //        parameters_constraints[6] = average_peak_time;
+      //        parameters_constraints[3] = average_peak_time;
+      //        parameters_constraints[5] = 0;
+      //      }
     }
     else
     {

--- a/offline/packages/Prototype4/CaloCalibration.C
+++ b/offline/packages/Prototype4/CaloCalibration.C
@@ -119,13 +119,29 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
       PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(vec_signal_samples, peak,
                                                   peak_sample, pedstal, parameters_io, verbosity);
       //    std::map<int, double> &parameters_io,  //! IO for fullset of parameters. If a parameter exist and not an NAN, the fit parameter will be fixed to that value. The order of the parameters are
-      //    ("Amplitude 1", "Sample Start", "Power", "Peak Time 1", "Pedestal", "Amplitude 2", "Peak Time 2")
+      //    ("Amplitude", "Sample Start", "Power", "Peak Time 1", "Pedestal", "Amplitude ratio", "Peak Time 2")
 
       parameters_constraints[1] = parameters_io[1];
       parameters_constraints[2] = parameters_io[2];
       parameters_constraints[3] = parameters_io[3];
       parameters_constraints[5] = parameters_io[5];
       parameters_constraints[6] = parameters_io[6];
+
+//      //special constraint if Peak Time 1 == Peak Time 2
+//      if (abs(parameters_constraints[6] - parameters_constraints[3]) < 0.1)
+//      {
+//        const double average_peak_time = (parameters_constraints[6] + parameters_constraints[3]) / 2.;
+//
+//        std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+//                  << ": two shaping time are too close "
+//                  << parameters_constraints[3] << " VS " << parameters_constraints[6]
+//                  << ". Use average peak time instead: " << average_peak_time
+//                  << std::endl;
+//
+//        parameters_constraints[6] = average_peak_time;
+//        parameters_constraints[3] = average_peak_time;
+//        parameters_constraints[5] = 0;
+//      }
     }
     else
     {
@@ -184,7 +200,7 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
 
     case kPeakSample:
       PROTOTYPE4_FEM::SampleFit_PeakSample(vec_signal_samples, peak,
-                                            peak_sample, pedstal, verbosity);
+                                           peak_sample, pedstal, verbosity);
       break;
 
     case kPowerLawDoubleExp:

--- a/offline/packages/Prototype4/CaloCalibration.C
+++ b/offline/packages/Prototype4/CaloCalibration.C
@@ -104,12 +104,13 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
     double peak = NAN;
     double peak_sample = NAN;
     double pedstal = NAN;
+    map<int, double> parameters_io;
 
-//    PROTOTYPE4_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
-//                                          peak_sample, pedstal, verbosity);
+    //    PROTOTYPE4_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
+    //                                          peak_sample, pedstal, verbosity);
 
     PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(vec_signal_samples, peak,
-                                          peak_sample, pedstal, verbosity);
+                                                peak_sample, pedstal, parameters_io, verbosity);
 
     // store the result - raw_tower
     if (std::isnan(raw_tower->get_energy()))

--- a/offline/packages/Prototype4/CaloCalibration.h
+++ b/offline/packages/Prototype4/CaloCalibration.h
@@ -72,8 +72,24 @@ class CaloCalibration : public SubsysReco
     _calib_params = calib_params;
   }
 
+  enum FitMethodType
+  {
+    //! single power-low-exp fit, PROTOTYPE4_FEM::SampleFit_PowerLawExp()
+    kPowerLawExp,
+
+    //! power-low-double-exp fit, PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp
+    kPowerLawDoubleExp,
+
+    //! power-low-double-exp fit, PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp, and constraining all tower take identical shape
+    kPowerLawDoubleExpWithGlobalFitConstraint,
+
+    //! just use the peak sample, PROTOTYPE4_FEM::SampleFit_PeakSample()
+    kPeakSample
+
+  };
+
   void
-  SetUseGlobalFitConstraints(bool b = true) {use_global_fit_constraints = b;}
+  SetFitType(FitMethodType t) {_fit_type = t;}
 
  private:
   RawTowerContainer *_calib_towers;
@@ -88,7 +104,7 @@ class CaloCalibration : public SubsysReco
 
   PHParameters _calib_params;
 
-  bool use_global_fit_constraints;
+  FitMethodType _fit_type;
 
   //! load the default parameter to param
   void

--- a/offline/packages/Prototype4/CaloCalibration.h
+++ b/offline/packages/Prototype4/CaloCalibration.h
@@ -34,7 +34,7 @@ class CaloCalibration : public SubsysReco
   }
 
   void
-  set_calib_tower_node_prefix(std::string calibTowerNodePrefix)
+  set_calib_tower_node_prefix(const std::string & calibTowerNodePrefix)
   {
     _calib_tower_node_prefix = calibTowerNodePrefix;
   }
@@ -46,7 +46,7 @@ class CaloCalibration : public SubsysReco
   }
 
   void
-  set_raw_tower_node_prefix(std::string rawTowerNodePrefix)
+  set_raw_tower_node_prefix(const std::string & rawTowerNodePrefix)
   {
     _raw_tower_node_prefix = rawTowerNodePrefix;
   }

--- a/offline/packages/Prototype4/CaloCalibration.h
+++ b/offline/packages/Prototype4/CaloCalibration.h
@@ -72,6 +72,9 @@ class CaloCalibration : public SubsysReco
     _calib_params = calib_params;
   }
 
+  void
+  SetUseGlobalFitConstraints(bool b = true) {use_global_fit_constraints = b;}
+
  private:
   RawTowerContainer *_calib_towers;
   RawTowerContainer *_raw_towers;
@@ -84,6 +87,8 @@ class CaloCalibration : public SubsysReco
   std::string _raw_tower_node_prefix;
 
   PHParameters _calib_params;
+
+  bool use_global_fit_constraints;
 
   //! load the default parameter to param
   void

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -23,7 +23,7 @@
 
 using namespace std;
 
-int PROTOTYPE4_FEM::GetChannelNumber(std::string caloname, int i_column, int i_row)
+int PROTOTYPE4_FEM::GetChannelNumber(const std::string & caloname, int i_column, int i_row)
 {
   if (caloname == "HCALIN")
   {

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -253,7 +253,7 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
   double peakval = pedestal;
   const double risetime = 2;
 
-  for (int iSample = 0; iSample < NSAMPLES; iSample++)
+  for (int iSample = 0; iSample < NSAMPLES - risetime*2; iSample++)
   {
     if (abs(gpulse.GetY()[iSample] - pedestal) > abs(peakval - pedestal))
     {
@@ -325,8 +325,8 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
       {
         cout << "PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp - parameter [" << i << "]: "
              << "default value = " << default_values[i].def
-             << "min value = " << default_values[i].min
-             << "max value = " << default_values[i].max << endl;
+             << ", min value = " << default_values[i].min
+             << ", max value = " << default_values[i].max << endl;
       }
     }
     else
@@ -392,12 +392,13 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
 
   const double peakpos1 = fits.GetParameter(3);
   const double peakpos2 = fits.GetParameter(6);
-  const double max_peakpos = peakpos1 > peakpos2 ? peakpos1 : peakpos2;
+  double max_peakpos = fits.GetParameter(1) + (peakpos1 > peakpos2 ? peakpos1 : peakpos2);
+  if (max_peakpos > NSAMPLES - 1) max_peakpos = NSAMPLES - 1;
 
   if (peakval > 0)
-    peak_sample = fits.GetMaximumX(fits.GetParameter(1), fits.GetParameter(1) + max_peakpos);
+    peak_sample = fits.GetMaximumX(fits.GetParameter(1), max_peakpos);
   else
-    peak_sample = fits.GetMinimumX(fits.GetParameter(1), fits.GetParameter(1) + max_peakpos);
+    peak_sample = fits.GetMinimumX(fits.GetParameter(1), max_peakpos);
 
   peak = fits.Eval(peak_sample) - pedestal;
 

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -253,7 +253,7 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
   double peakval = pedestal;
   const double risetime = 2;
 
-  for (int iSample = 0; iSample < NSAMPLES - risetime*2; iSample++)
+  for (int iSample = 0; iSample < NSAMPLES - risetime*3; iSample++)
   {
     if (abs(gpulse.GetY()[iSample] - pedestal) > abs(peakval - pedestal))
     {

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -295,14 +295,7 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
 
   vector<default_values_t> default_values(n_parameter, default_values_t(numeric_limits<double>::signaling_NaN(), numeric_limits<double>::signaling_NaN(), numeric_limits<double>::signaling_NaN()));
 
-  if (peakval > 0)
-  {
-    default_values[0] = default_values_t(peakval * .7, 0, peakval * 1.5);
-  }
-  else
-  {
-    default_values[0] = default_values_t(peakval * .7, peakval * 1.5, 0);
-  }
+  default_values[0] = default_values_t(peakval * .7, peakval * -1.5, peakval * 1.5);
   default_values[1] = default_values_t(peakPos - risetime, peakPos - 3 * risetime, peakPos + risetime);
   default_values[2] = default_values_t(2., 1, 10.);
   default_values[3] = default_values_t(5, risetime * .5, risetime * 4);
@@ -395,12 +388,28 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
   double max_peakpos = fits.GetParameter(1) + (peakpos1 > peakpos2 ? peakpos1 : peakpos2);
   if (max_peakpos > NSAMPLES - 1) max_peakpos = NSAMPLES - 1;
 
-  if (peakval > 0)
+  if (fits.GetParameter(0) > 0)
     peak_sample = fits.GetMaximumX(fits.GetParameter(1), max_peakpos);
   else
     peak_sample = fits.GetMinimumX(fits.GetParameter(1), max_peakpos);
 
   peak = fits.Eval(peak_sample) - pedestal;
+
+
+  if (verbosity)
+  {
+
+    TGraph g_max(NSAMPLES);
+
+    g_max.GetX()[0] = peak_sample;
+    g_max.GetY()[0] = peak + pedestal;
+
+    g_max.SetMarkerStyle(kFullCircle);
+    g_max.SetMarkerSize(2);
+    g_max.SetMarkerColor(kRed);
+
+    static_cast<TGraph *>(g_max.DrawClone("p"));
+  }
 
   for (int i = 0; i < n_parameter; ++i)
   {

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -297,15 +297,15 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
 
   default_values[0] = default_values_t(peakval * .7, peakval * -1.5, peakval * 1.5);
   default_values[1] = default_values_t(peakPos - risetime, peakPos - 3 * risetime, peakPos + risetime);
-  default_values[2] = default_values_t(2., 1, 10.);
+  default_values[2] = default_values_t(2., 1, 5.);
   default_values[3] = default_values_t(5, risetime * .5, risetime * 4);
   default_values[4] = default_values_t(pedestal, pedestal - abs(peakval), pedestal + abs(peakval));
-  default_values[5] = default_values_t(.3, 0, 100);
+  default_values[5] = default_values_t(.3, 0, 1);
   default_values[6] = default_values_t(5, risetime * .5, risetime * 4);
 
   // fit function
   TF1 fits("f_SignalShape_PowerLawDoubleExp", SignalShape_PowerLawDoubleExp, 0., NSAMPLES, n_parameter);
-  fits.SetParNames("Amplitude 1", "Sample Start", "Power", "Peak Time 1", "Pedestal", "Amplitude 2/1 ratio", "Peak Time 2");
+  fits.SetParNames("Amplitude", "Sample Start", "Power", "Peak Time 1", "Pedestal", "Amplitude ratio", "Peak Time 2");
 
   for (int i = 0; i < n_parameter; ++i)
   {
@@ -335,9 +335,9 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
   }
 
   if (verbosity <= 1)
-    gpulse.Fit(&fits, "MQRN0W", "goff", 0., (double) NSAMPLES);
+    gpulse.Fit(&fits, "QRN0W", "goff", 0., (double) NSAMPLES);
   else
-    gpulse.Fit(&fits, "MRN0VW", "goff", 0., (double) NSAMPLES);
+    gpulse.Fit(&fits, "RN0VW", "goff", 0., (double) NSAMPLES);
 
   if (verbosity)
   {
@@ -359,7 +359,7 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
 
     TF1 f1("f_SignalShape_PowerLawExp1", SignalShape_PowerLawExp, 0., NSAMPLES, 5);
     f1.SetParameters(
-        fits.GetParameter(0) / pow(fits.GetParameter(3), fits.GetParameter(2)) * exp(fits.GetParameter(2)),
+        fits.GetParameter(0) * (1- fits.GetParameter(5)) / pow(fits.GetParameter(3), fits.GetParameter(2)) * exp(fits.GetParameter(2)),
         fits.GetParameter(1),
         fits.GetParameter(2),
         fits.GetParameter(2) / fits.GetParameter(3),
@@ -441,7 +441,7 @@ PROTOTYPE4_FEM::SignalShape_PowerLawDoubleExp(double *x, double *par)
   double signal =                                                                                    //
       par[0]                                                                                         //
       * pow((x[0] - par[1]), par[2])                                                                 //
-      * ((1. / pow(par[3], par[2]) * exp(par[2])) * exp(-(x[0] - par[1]) * (par[2] / par[3]))        //
+      * (((1. - par[5]) / pow(par[3], par[2]) * exp(par[2])) * exp(-(x[0] - par[1]) * (par[2] / par[3]))        //
          + (par[5] / pow(par[6], par[2]) * exp(par[2])) * exp(-(x[0] - par[1]) * (par[2] / par[6]))  //
          );
   return pedestal + signal;

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.C
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.C
@@ -253,7 +253,7 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
   double peakval = pedestal;
   const double risetime = 2;
 
-  for (int iSample = 0; iSample < NSAMPLES - risetime*3; iSample++)
+  for (int iSample = 0; iSample < NSAMPLES - risetime * 3; iSample++)
   {
     if (abs(gpulse.GetY()[iSample] - pedestal) > abs(peakval - pedestal))
     {
@@ -395,10 +395,8 @@ bool PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(  //
 
   peak = fits.Eval(peak_sample) - pedestal;
 
-
   if (verbosity)
   {
-
     TGraph g_max(NSAMPLES);
 
     g_max.GetX()[0] = peak_sample;
@@ -447,4 +445,47 @@ PROTOTYPE4_FEM::SignalShape_PowerLawDoubleExp(double *x, double *par)
          + (par[5] / pow(par[6], par[2]) * exp(par[2])) * exp(-(x[0] - par[1]) * (par[2] / par[6]))  //
          );
   return pedestal + signal;
+}
+
+bool PROTOTYPE4_FEM::SampleFit_PeakSample(  //
+    const std::vector<double> &samples,     //
+    double &peak,                           //
+    double &peak_sample,                    //
+    double &pedestal,                       //
+    const int verbosity)
+{
+  int peakPos = 0.;
+
+  assert(samples.size() == NSAMPLES);
+
+  const static int N_pedestal = 3;
+  pedestal = 0;
+  for (int iSample = 0; iSample < N_pedestal; iSample++)
+  {
+    pedestal += samples[iSample];
+  }
+  pedestal /= N_pedestal;
+
+  double peakval = pedestal;
+  for (int iSample = N_pedestal; iSample < NSAMPLES; iSample++)
+  {
+    if (abs(samples[iSample] - pedestal) > abs(peakval - pedestal))
+    {
+      peakval = samples[iSample];
+      peakPos = iSample;
+    }
+  }
+
+  peak = peakval - pedestal;
+  peak_sample = peakPos;
+
+  if (verbosity)
+  {
+    cout << "PROTOTYPE4_FEM::SampleFit_PeakSample - "
+         << "pedestal = " << pedestal << ", "
+         << "peakval = " << peakval << ", "
+         << "peakPos = " << peakPos << endl;
+  }
+
+  return true;
 }

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.h
@@ -1,6 +1,7 @@
 #ifndef __PROTOTYPE4_FEM_H__
 #define __PROTOTYPE4_FEM_H__
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -44,11 +45,12 @@ bool SampleFit_PowerLawExp(              //
     double &pedstal,                     //
     const int verbosity = 0);
 
-bool SampleFit_PowerLawDoubleExp(        //
-    const std::vector<double> &samples,  //
-    double &peak,                        //
-    double &peak_sample,                 //
-    double &pedstal,                     //
+bool SampleFit_PowerLawDoubleExp(          //
+    const std::vector<double> &samples,    //
+    double &peak,                          //! peak amplitude.
+    double &peak_sample,                   //! peak sample position. Fixed to the input value if NOT NAN
+    double &pedestal,                      //! pedestal
+    std::map<int, double> &parameters_io,  //! IO for fullset of parameters. If a parameter exist and not an NAN, the fit parameter will be fixed to that value. The order of the parameters are ("Amplitude 1", "Sample Start", "Power", "Peak Time 1", "Pedestal", "Amplitude 2", "Peak Time 2")
     const int verbosity = 0);
 
 // Abhisek's power-law + exp signal shape model

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.h
@@ -45,6 +45,7 @@ bool SampleFit_PowerLawExp(              //
     double &pedstal,                     //
     const int verbosity = 0);
 
+//! Power law double exp fit
 bool SampleFit_PowerLawDoubleExp(          //
     const std::vector<double> &samples,    //
     double &peak,                          //! peak amplitude.
@@ -52,6 +53,15 @@ bool SampleFit_PowerLawDoubleExp(          //
     double &pedestal,                      //! pedestal
     std::map<int, double> &parameters_io,  //! IO for fullset of parameters. If a parameter exist and not an NAN, the fit parameter will be fixed to that value. The order of the parameters are ("Amplitude 1", "Sample Start", "Power", "Peak Time 1", "Pedestal", "Amplitude 2", "Peak Time 2")
     const int verbosity = 0);
+
+//! Just return the max sample...
+bool SampleFit_PeakSample(          //
+    const std::vector<double> &samples,    //
+    double &peak,                          //! peak amplitude.
+    double &peak_sample,                   //! peak sample position. Fixed to the input value if NOT NAN
+    double &pedestal,                      //! pedestal
+    const int verbosity = 0);
+
 
 // Abhisek's power-law + exp signal shape model
 double

--- a/offline/packages/Prototype4/PROTOTYPE4_FEM.h
+++ b/offline/packages/Prototype4/PROTOTYPE4_FEM.h
@@ -35,7 +35,7 @@ const int SATURATED_ADC_ERROR = 100;
 const int DEAD_CHANNEL_ERROR = 300;
 
 //! FEM mapping of channel -> calorimeter col and rows
-int GetChannelNumber(std::string caloname, int i_column, int i_row);
+int GetChannelNumber(const std::string &caloname, int i_column, int i_row);
 
 //! Abhisek's power-law + exp fit
 bool SampleFit_PowerLawExp(              //

--- a/offline/packages/Prototype4/RawTower_Prototype4.cc
+++ b/offline/packages/Prototype4/RawTower_Prototype4.cc
@@ -124,13 +124,15 @@ RawTower_Prototype4::get_energy_power_law_double_exp(int verbosity)
   double pedstal = NAN;
 
   vector<double> vec_signal_samples;
+  map<int, double> parameters_io;
+
   for (int i = 0; i < NSAMPLES; i++)
   {
     vec_signal_samples.push_back(signal_samples[i]);
   }
 
   PROTOTYPE4_FEM::
-      SampleFit_PowerLawDoubleExp(vec_signal_samples, peak, peak_sample, pedstal, verbosity);
+      SampleFit_PowerLawDoubleExp(vec_signal_samples, peak, peak_sample, pedstal, parameters_io, verbosity);
 
   return peak;
 }

--- a/offline/packages/Prototype4/RawTower_Prototype4.cc
+++ b/offline/packages/Prototype4/RawTower_Prototype4.cc
@@ -117,6 +117,25 @@ RawTower_Prototype4::get_energy_power_law_exp(int verbosity)
 }
 
 double
+RawTower_Prototype4::get_energy_peak_sample(int verbosity)
+{
+  double peak = NAN;
+  double peak_sample = NAN;
+  double pedstal = NAN;
+
+  vector<double> vec_signal_samples;
+  for (int i = 0; i < NSAMPLES; i++)
+  {
+    vec_signal_samples.push_back(signal_samples[i]);
+  }
+
+  PROTOTYPE4_FEM::
+      SampleFit_PeakSample(vec_signal_samples, peak, peak_sample, pedstal, verbosity);
+
+  return peak;
+}
+
+double
 RawTower_Prototype4::get_energy_power_law_double_exp(int verbosity)
 {
   double peak = NAN;

--- a/offline/packages/Prototype4/RawTower_Prototype4.h
+++ b/offline/packages/Prototype4/RawTower_Prototype4.h
@@ -54,6 +54,7 @@ class RawTower_Prototype4 : public RawTower
 
   //---Fits------------------------------------------------------------
 
+  double get_energy_peak_sample(int verbosity = 0);
   double get_energy_power_law_exp(int verbosity = 0);
   double get_energy_power_law_double_exp(int verbosity = 0);
 


### PR DESCRIPTION
Accumulated update on 2018 test beam analysis:
* Introduce global ADC-time-series fit constraints following suggestions from Edward Kistenev 
* Further ADC-time-series fit tunings
* Introducing simple peak finding as energy for non-shaped signals (VETO, Cherenkovs)
Getting ready to migrate from test productions to official productions. 

Also building analysis modules and macros under https://github.com/sPHENIX-Collaboration/analysis/tree/master/Prototype4/  . Tutorials and examples to come soon too. 