### PR TITLE
Fix to enable iterative tracking without maps or intt

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
@@ -93,7 +93,6 @@
 //ROOT includes for debugging
 #include <TFile.h>
 #include <TNtuple.h>
-#include <TGeoManager.h>
 
 #define LogDebug(exp)		std::cout<<"DEBUG: "  <<__FILE__<<": "<<__LINE__<<": "<< exp
 #define LogError(exp)		std::cout<<"ERROR: "  <<__FILE__<<": "<<__LINE__<<": "<< exp
@@ -1222,11 +1221,6 @@ int PHG4KalmanPatRec::InitializePHGenFit(PHCompositeNode* topNode) {
 	//_fitter = new PHGenFit::Fitter("sPHENIX_Geo.root","sPHENIX.2d.root", 1.4 / 1.5);
 	_fitter = PHGenFit::Fitter::getInstance(tgeo_manager, field, _track_fitting_alg_name,
 					"RKTrackRep", _do_evt_display);
-  TFile outfile("sPhenixTGeo.root","RECREATE");
-  outfile.cd();
-  tgeo_manager->Write();
-  outfile.Close();
-
 
 	if (!_fitter) {
 		cerr << PHWHERE << endl;

--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
@@ -622,9 +622,9 @@ int PHG4KalmanPatRec::process_event(PHCompositeNode *topNode) {
 void PHG4KalmanPatRec::print_timers() {
   
   std::cout << "=============== Timers: ===============" << std::endl;
-  std::cout << "Seeding time:                "<<_t_seeding->get_accumulated_time()/1000. << " sec" <<std::endl;
+  std::cout << "CPUSCALE Seeding time:                "<<_t_seeding->get_accumulated_time()/1000. << " sec" <<std::endl;
   std::cout << "\t - Seeds Cleanup:          "<<_t_seeds_cleanup->get_accumulated_time()/1000. << " sec" <<std::endl;
-  std::cout << "Pattern recognition time:    "<<_t_kalman_pat_rec->get_accumulated_time()/1000. << " sec" <<std::endl;
+  std::cout << "CPUSCALE Pattern recognition time:    "<<_t_kalman_pat_rec->get_accumulated_time()/1000. << " sec" <<std::endl;
   std::cout << "\t - Track Translation time: "<<_t_translate_to_PHGenFitTrack->get_accumulated_time()/1000. << " sec" <<std::endl;
   std::cout << "\t - Cluster searching time: "<<_t_search_clusters->get_accumulated_time()/1000. << " sec" <<std::endl;
   std::cout << "\t\t - Encoding time:        "<<_t_search_clusters_encoding->get_accumulated_time()/1000. << " sec" <<std::endl;
@@ -1607,6 +1607,7 @@ int PHG4KalmanPatRec::translate_input() {
 	}
 
 	if(verbosity >= 1){
+	  cout << "CPUSCALE hits: " << count << endl;
 	  cout << "cluster count iter #" << _n_iteration << " : " << count 
 	       << " | l7: " << count7 
 	       << " | l46: " << count46 

--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.h
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.h
@@ -725,6 +725,9 @@ private:
 
 	int _event;
 	PHTimer *_t_seeding;
+	PHTimer *_t_seed_init1;
+	PHTimer *_t_seed_init2;
+	PHTimer *_t_seed_init3;
 	PHTimer *_t_seeds_cleanup;
 	PHTimer *_t_translate_to_PHGenFitTrack;
 	PHTimer *_t_kalman_pat_rec;


### PR DESCRIPTION
Previously a bug in the initialization of the seeding geometry caused the iterative approach to detonate when taking out some of the detector layers in front of the TPC. Fixed now. 