### PR TITLE
Clusterizer

### DIFF
--- a/offline/packages/CaloReco/BEmcCluster.h
+++ b/offline/packages/CaloReco/BEmcCluster.h
@@ -139,7 +139,7 @@ public:
   /// Returns the EmcCluster corrected position in Sector (SM) frame
   void GetCorrPos( float* pxc, float* pyc );
   /// Returns the EmcCluster position in PHENIX global coord system
-  void GetGlobalPos( float* pxg, float* pyg, float* pzg );
+  void GetGlobalPos( float& xg, float& yg, float& zg );
   /// Returns the errors for the reconstructed energy and position
   void GetErrors( float* pde, float* pdx, float* pdy, float* pdz);
   /// Substitutes a number of functions above (to save CPU time)

--- a/offline/packages/CaloReco/BEmcRec.cc
+++ b/offline/packages/CaloReco/BEmcRec.cc
@@ -10,8 +10,6 @@
 #include "BEmcCluster.h"
 #include <TMath.h>
 
-#include <cmath>
-
 using namespace std;
 
 // Define and initialize static members
@@ -102,6 +100,42 @@ void  BEmcRec::SetGeometry( int nx, int ny, float txsz, float tysz )
   fNy = ny;
   fModSizex = txsz;
   fModSizey = tysz;
+}
+
+void  BEmcRec::PrintTowerGeometry()
+{
+  printf("Info: Print from BEmcRec::PrintTowerGeometry():\n");
+  printf("      Number of binx: %d %d\n",fNx,fNy);
+  int ich;
+  TowerGeom geom;
+  std::map<int,TowerGeom>::iterator it;
+  for( int iy=0; iy<fNy; iy++ ) {
+    for( int ix=0; ix<fNx; ix++ ) {
+      ich = iy*fNx + ix;
+      it = fTowerGeom.find(ich);
+      if( it != fTowerGeom.end() ) {
+	geom = it->second;
+	printf("       %d %d: %f %f %f\n",ix,iy,geom.Xcenter,geom.Ycenter,geom.Zcenter);
+      }
+    }
+  }
+  /*
+  std::map<int,float>::iterator it = mapOfWords.begin();
+  while(it != mapOfWords.end()) {
+      std::cout<<it->first<<" :: "<<it->second<<std::endl;
+      it++;
+    }
+  */
+}
+
+void  BEmcRec::SetTowerGeometry( int ich, float xx, float yy, float zz )
+{
+  TowerGeom geom;
+  geom.Xcenter = xx;
+  geom.Ycenter = yy;
+  geom.Zcenter = zz;
+
+  fTowerGeom[ich] = geom;
 }
 
 /*
@@ -295,22 +329,7 @@ int BEmcRec::FindClusters()
   
 }
 
-
 // ///////////////////////////////////////////////////////////////////////////
-void BEmcRec::GetImpactAngle(float x, float y, float *sinT )
-  // Get impact angle, (x,y) - position in Sector frame (cm)
-{
-  float xVert, yVert, zVert;
-  float vx, vy, vz;
-
-  GlobalToSector( fVx, fVy, fVz, &xVert, &yVert, &zVert );
-  vz = -zVert;
-  vy = y - yVert;
-  vx = x - xVert;
-  // From this point X coord in sector frame is Z coord in Global Coord System !!!
-  *sinT = sqrt((vx*vx+vy*vy)/(vx*vx+vy*vy+vz*vz));
-}
-
 
 void BEmcRec::GlobalToSector(float xgl, float ygl, float zgl, float* px,
 				 float* py, float* pz)
@@ -330,19 +349,66 @@ void BEmcRec::GlobalToSector(float xgl, float ygl, float zgl, float* px,
 
 // ///////////////////////////////////////////////////////////////////////////
 
-void BEmcRec::SectorToGlobal(float xsec, float ysec, float zsec,
+void BEmcRec::SectorToGlobal(float xC, float yC, float zC,
 				 float* px, float* py, float* pz ) 
 {
-  *px = xsec - fModSizex*(fNx-1)/2.;
-  *py = ysec - fModSizey*(fNy-1)/2.;
-  *pz = 0.;
-  /*
-  PHPoint emcHit(xsec, ysec, zsec);
-  PHPoint phnxHit  = PHGeometry::transformPoint(emcrm, emctr, emcHit);
-  *px =  phnxHit.getX();
-  *py =  phnxHit.getY();
-  *pz =  phnxHit.getZ();
-  */  
+  *px = *py = *pz;
+
+  int ich;
+  std::map<int,TowerGeom>::iterator it;
+
+  int ix = xC+0.5; // tower #
+  if( ix<0 || ix >= fNx ) {
+    printf("Error in BEmcRec::SectorToGlobal: wrong input x: %d\n",ix);
+    return;
+  }
+
+  int iy = yC+0.5; // tower #
+  if( iy<0 || iy >= fNy ) {
+    printf("Error in BEmcRec::SectorToGlobal: wrong input y: %d\n",iy);
+    return;
+  }
+
+  ich = iy*fNx + ix;
+  it = fTowerGeom.find(ich);
+  if( it == fTowerGeom.end() ) {
+    printf("Error in BEmcRec::SectorToGlobal: wrong input (x,y): %f %f\n",xC,yC);
+    return;
+  }
+  TowerGeom geom0 = it->second;
+
+  // Next tower in x
+  ich = iy*fNx + (ix+1);
+  it = fTowerGeom.find(ich);
+  if( it == fTowerGeom.end() ) {
+    ich = iy*fNx + (ix-1);
+    it = fTowerGeom.find(ich);
+    if( it == fTowerGeom.end() ) {
+      printf("Error in BEmcRec::SectorToGlobal: Error in geometery extraction for x= %f\n",xC);
+      return;
+    }
+  }
+  TowerGeom geomx = it->second;
+
+  // Next tower in y
+  ich = (iy+1)*fNx + ix;
+  it = fTowerGeom.find(ich);
+  if( it == fTowerGeom.end() ) {
+    ich = (iy-1)*fNx + ix;
+    it = fTowerGeom.find(ich);
+    if( it == fTowerGeom.end() ) {
+      printf("Error in BEmcRec::SectorToGlobal: Error in geometery extraction for y= %f\n",yC);
+      return;
+    }
+  }
+  TowerGeom geomy = it->second;
+
+  float dx = fabs(geom0.Xcenter - geomx.Xcenter);
+  float dy = fabs(geom0.Ycenter - geomy.Ycenter);
+  *px = geom0.Xcenter + (xC-ix)*dx;
+  *py = geom0.Ycenter + (yC-iy)*dy;
+  *pz = geom0.Zcenter;
+
 }
 
 
@@ -810,60 +876,10 @@ float BEmcRec::fgEpar4 = 4.0;
 
 // ///////////////////////////////////////////////////////////////////////////
 
-void BEmcRec::CorrectEnergy(float Energy, float x, float y, 
-				   float* Ecorr)
-{
-  // Corrects the EM Shower Energy for attenuation in fibers and 
-  // long energy leakage
-  //
-  // (x,y) - impact position (cm) in Sector frame
-
-  float sinT;
-  float att, leak, corr;
-  const float leakPar = 0.0033; // parameter from fit
-  const float attPar = 120; // Attenuation in module (cm)
-  const float X0 = 2; // radiation length (cm)
-
-  *Ecorr = Energy;
-  if( Energy < 0.01 ) return;
-
-  GetImpactAngle(x, y, &sinT); // sinT not used so far
-  leak = 2-sqrt(1+leakPar*log(1+Energy)*log(1+Energy));
-  att = exp(log(Energy)*X0/attPar);
-  corr = leak*att;
-  *Ecorr = Energy/corr;
-}
-
 /////////////////////////////////////////////////////////////////
-
-void BEmcRec::CorrectECore(float Ecore, float x, float y, float* Ecorr)
-{
-  // Corrects the EM Shower Core Energy for attenuation in fibers, 
-  // long energy leakage and angle dependance
-  //
-  // (x,y) - impact position (cm) in Sector frame
-
-  float ec, ec2, corr;
-  float sinT;
-  const float par1 = 0.918;
-  const float par2 = 1.35;
-  const float par3 = 0.003;
-
-  *Ecorr = Ecore;
-  if( Ecore < 0.01 ) return;
-
-  GetImpactAngle(x, y, &sinT );
-  corr = par1 * ( 1 - par2*sinT*sinT*sinT*sinT*(1 - par3*log(Ecore)) );
-  ec = Ecore/corr;
-
-  CorrectEnergy( ec, x, y, &ec2);
-  *Ecorr = ec2;
-}
-
-/////////////////////////////////////////////////////////////////////
-
+/*
 void BEmcRec::CorrectPosition(float Energy, float x, float y,
-				     float* pxc, float* pyc, bool callSetPar)
+				     float* pxc, float* pyc)
 {
   // Corrects the Shower Center of Gravity for the systematic error due to 
   // the limited tower size and angle shift
@@ -921,7 +937,7 @@ void BEmcRec::CorrectPosition(float Energy, float x, float y,
   }
   
 }
-
+*/
 // ///////////////////////////////////////////////////////////////////////////
 
 void BEmcRec::CalculateErrors( float e, float x, float y, float* pde,

--- a/offline/packages/CaloReco/BEmcRec.h
+++ b/offline/packages/CaloReco/BEmcRec.h
@@ -8,7 +8,7 @@
 //#include "PHMatrix.h"
 //#include "PHVector.h"
 #include <vector>
-
+#include <map>
 
 class EmcCluster;
 class EmcModule;
@@ -21,6 +21,14 @@ typedef struct SecGeom{
   float Tower_ySize; // Tower size in Y dir
 
 } SecGeom;
+
+typedef struct TowerGeom{
+
+  float Xcenter;     // Tower center position
+  float Ycenter;
+  float Zcenter;
+
+} TowerGeom;
 
 // ///////////////////////////////////////////////////////////////////////////
 
@@ -36,12 +44,14 @@ class BEmcRec
  public:
 
   BEmcRec();
-  ~BEmcRec();
+  virtual ~BEmcRec();
 
   void SetVertex(float *vv){  fVx = vv[0]; fVy = vv[1]; fVz = vv[2]; }
   void SetGeometry(int nx, int ny, float txsz, float tysz);
   //  void SetGeometry(SecGeom const &geom, PHMatrix * rm, PHVector * tr );
   void SetConf(int nx, int ny) { SetGeometry(nx, ny, 1., 1.); }
+  void SetTowerGeometry(int ich, float xx, float yy, float zz);
+  void PrintTowerGeometry();
 
   void SetPlaneGeometry() { bCYL=false; }
   void SetCylindricalGeometry() { bCYL=true; }
@@ -68,7 +78,7 @@ class BEmcRec
   float fTowerDist(float x1, float x2);
 
   int FindClusters();
-  void GetImpactAngle(float x, float y, float *sinT );
+  //  virtual void GetImpactAngle(float x, float y, float *sinT );
   void GlobalToSector(float, float, float, float*, float*, float*);
   void SectorToGlobal(float xsec, float ysec, float zsec, float* px,
 		      float* py, float* pz );
@@ -97,10 +107,13 @@ class BEmcRec
   float ClusterChisq(int, EmcModule*, float, float, float,
 			     int &ndf); // ndf added MV 28.01.00
   float Chi2Correct(float chi2,int ndf);
-  void CorrectPosition(float energy, float x, float y, float *xcorr,
-				float *ycorr, bool callSetPar=true);
-  void CorrectEnergy(float energy, float x, float y, float *ecorr);
-  void CorrectECore(float ecore, float x, float y, float *ecorecorr);
+
+  // Virtual (Calorimeter specific) functions
+  virtual void CorrectEnergy(float energy, float x, float y, float *ecorr)=0;
+  virtual void CorrectPosition(float energy, float x, float y, float *xcorr, float *ycorr)=0;
+  virtual void CorrectECore(float ecore, float x, float y, float *ecorecorr)=0;
+  virtual void Tower2Global(float en, float xsec, float ysec, float& xA, float& yA, float& zA )=0;
+
   void TwoGamma(int, EmcModule*, float*, float*, float*, float*,
 			float*, float*, float*);
   float Chi2Limit(int ndf);
@@ -127,6 +140,7 @@ class BEmcRec
   bool bCYL; // Cylindrical? 
   int fNx; // length in X direction
   int fNy; // length in Y direction
+  std::map<int,TowerGeom> fTowerGeom;
   float fModSizex; // module size in X direction (cm)
   float fModSizey; // module size in Y direction
   float fVx; // vertex position (cm)

--- a/offline/packages/CaloReco/BEmcRecCEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecCEMC.cc
@@ -1,0 +1,106 @@
+#include "BEmcRecCEMC.h"
+#include "BEmcCluster.h"
+
+#include <cmath>
+
+void BEmcRecCEMC::Tower2Global(float E, float xC, float yC,
+				 float& xA, float& yA, float& zA ) 
+{
+  xA = yA = zA = 0;
+}
+
+void BEmcRecCEMC::CorrectEnergy(float Energy, float x, float y, 
+				   float* Ecorr)
+{
+  // Corrects the EM Shower Energy for attenuation in fibers and 
+  // long energy leakage
+  //
+  // (x,y) - impact position (cm) in Sector frame
+  /*
+  float sinT;
+  float att, leak, corr;
+  const float leakPar = 0.0033; // parameter from fit
+  const float attPar = 120; // Attenuation in module (cm)
+  const float X0 = 2; // radiation length (cm)
+
+  *Ecorr = Energy;
+  if( Energy < 0.01 ) return;
+
+  GetImpactAngle(x, y, &sinT); // sinT not used so far
+  leak = 2-sqrt(1+leakPar*log(1+Energy)*log(1+Energy));
+  att = exp(log(Energy)*X0/attPar);
+  corr = leak*att;
+  *Ecorr = Energy/corr;
+  */
+}
+
+void BEmcRecCEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
+{
+  // Corrects the EM Shower Core Energy for attenuation in fibers, 
+  // long energy leakage and angle dependance
+  //
+  // (x,y) - impact position (cm) in Sector frame
+  
+  const float c0 = 0.950; // For no threshold
+  *Ecorr = Ecore/c0;
+}
+
+void BEmcRecCEMC::CorrectPosition(float Energy, float x, float y,
+				     float* pxc, float* pyc )
+{
+  // Corrects the Shower Center of Gravity for the systematic error due to 
+  // the limited tower size and angle shift
+  //
+  // Everything here is in cell units. 
+  // (x,y) - CG position, (*pxc,*pyc) - corrected position
+
+  float xShift, yShift, xZero, yZero, bx, by;
+  float t, x0, y0;
+  int ix0, iy0;
+  int signx, signy;
+
+  const float Xrad = 0.3; // !!!!! Need to put correct value
+  const float Remc = 90.; // EMCal inner radius. !!!!! Should be obtained from geometry container
+
+  SetProfileParameters( 0, Energy, x, y );
+  if( fSinTx >= 0 ) signx =  1;
+  else 	   signx = -1;
+  if( fSinTy >= 0 ) signy =  1;
+  else 	   signy = -1;
+  t = 5.0+1.0*log(Energy); // In Rad Length units
+  t *= ( Xrad/Remc/GetModSizex() ); // !!!!!
+  xShift = t*fSinTx;
+  yShift = t*fSinTy;
+  xZero=xShift-(0.417*EmcCluster::ABS(fSinTx)+1.500*fSinTx*fSinTx)*signx;
+  yZero=yShift-(0.417*EmcCluster::ABS(fSinTy)+1.500*fSinTy*fSinTy)*signy;
+  xZero = xShift; // ...Somehow this works better !!!!!
+  yZero = yShift; // ...Somehow this works better !!!!!
+  t = 0.98 + 0.98*sqrt(Energy); // !!!!! Still from PHENIX
+  bx = 0.15 + t*fSinTx*fSinTx;
+  by = 0.15 + t*fSinTy*fSinTy;
+
+  x0 = x;
+  x0 = x0 - xShift + xZero;
+  ix0 = EmcCluster::lowint(x0 + 0.5);
+  if( EmcCluster::ABS(x0-ix0) <= 0.5 ) {
+    x0 = (ix0-xZero)+bx*asinh( 2.*(x0-ix0)*sinh(0.5/bx) );
+    *pxc = x0;
+  }
+  else {
+    *pxc =  x - xShift;
+    printf("????? Something wrong in CorrectPosition: x=%f  dx=%f\n", x, x0-ix0);
+  }
+
+  y0 = y;
+  y0 = y0 - yShift + yZero;
+  iy0 = EmcCluster::lowint(y0 + 0.5);
+  if( EmcCluster::ABS(y0-iy0) <= 0.5 ) {
+    y0 = (iy0-yZero)+by*asinh( 2.*(y0-iy0)*sinh(0.5/by) );
+    *pyc = y0;
+  }
+  else {
+    *pyc = y - yShift;
+    printf("????? Something wrong in CorrectPosition: y=%f  dy=%f\n", y, y0-iy0);
+  }
+  
+}

--- a/offline/packages/CaloReco/BEmcRecCEMC.h
+++ b/offline/packages/CaloReco/BEmcRecCEMC.h
@@ -1,0 +1,17 @@
+#ifndef BEMCRECCEMC_H
+#define BEMCRECCEMC_H
+
+#include "BEmcRec.h"
+
+class BEmcRecCEMC : public BEmcRec
+{
+ public:
+  BEmcRecCEMC() {};
+  ~BEmcRecCEMC() {}
+  void CorrectEnergy(float energy, float x, float y, float *ecorr);
+  void CorrectPosition(float energy, float x, float y, float *xcorr, float *ycorr);
+  void CorrectECore(float ecore, float x, float y, float *ecorecorr);
+  void Tower2Global(float E, float xC, float yC, float& xA, float& yA, float& zA ); 
+};
+
+#endif // #ifndef BEMCREC_H

--- a/offline/packages/CaloReco/BEmcRecFEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecFEMC.cc
@@ -1,0 +1,191 @@
+#include "BEmcRecFEMC.h"
+#include "BEmcCluster.h"
+
+#include <cmath>
+
+void BEmcRecFEMC::Tower2Global(float E, float xC, float yC,
+				 float& xA, float& yA, float& zA ) 
+// With shower depth correction reflected in zA
+{
+  const float DZ = 18; // in cm, tower half length
+  const float D = 13.3; // in cm, shower depth at 1 GeV relative to tower face; obtained from GEANT
+  const float X0 = 2.2; // in cm; obtained from GEANT (should be ~ rad length)
+
+  xA = yA = zA = 0;
+
+  int ich;
+  std::map<int,TowerGeom>::iterator it;
+
+  int ix = xC+0.5; // tower #
+  if( ix<0 || ix >= fNx ) {
+    printf("Error in BEmcRec::SectorToGlobal: wrong input x: %d\n",ix);
+    return;
+  }
+
+  int iy = yC+0.5; // tower #
+  if( iy<0 || iy >= fNy ) {
+    printf("Error in BEmcRec::SectorToGlobal: wrong input y: %d\n",iy);
+    return;
+  }
+
+  ich = iy*fNx + ix;
+  it = fTowerGeom.find(ich);
+  if( it == fTowerGeom.end() ) {
+    printf("Error in BEmcRec::SectorToGlobal: wrong input (x,y): %f %f\n",xC,yC);
+    return;
+  }
+  TowerGeom geom0 = it->second;
+
+  // Next tower in x
+  ich = iy*fNx + (ix+1);
+  it = fTowerGeom.find(ich);
+  if( it == fTowerGeom.end() ) {
+    ich = iy*fNx + (ix-1);
+    it = fTowerGeom.find(ich);
+    if( it == fTowerGeom.end() ) {
+      printf("Error in BEmcRec::SectorToGlobal: Error in geometery extraction for x= %f\n",xC);
+      return;
+    }
+  }
+  TowerGeom geomx = it->second;
+
+  // Next tower in y
+  ich = (iy+1)*fNx + ix;
+  it = fTowerGeom.find(ich);
+  if( it == fTowerGeom.end() ) {
+    ich = (iy-1)*fNx + ix;
+    it = fTowerGeom.find(ich);
+    if( it == fTowerGeom.end() ) {
+      printf("Error in BEmcRec::SectorToGlobal: Error in geometery extraction for y= %f\n",yC);
+      return;
+    }
+  }
+  TowerGeom geomy = it->second;
+
+  float dx = fabs(geom0.Xcenter - geomx.Xcenter);
+  float dy = fabs(geom0.Ycenter - geomy.Ycenter);
+  xA = geom0.Xcenter + (xC-ix)*dx;
+  yA = geom0.Ycenter + (yC-iy)*dy;
+
+  float logE = log(0.1);
+  if( E>0.1 ) logE = log(E);
+  float Zcenter = geom0.Zcenter - fVz;
+  float cosT = Zcenter/sqrt(xA*xA+yA*yA+Zcenter*Zcenter);
+  zA = (geom0.Zcenter-DZ) + (D+X0*logE)*cosT;
+}
+
+void BEmcRecFEMC::CorrectEnergy(float Energy, float x, float y, 
+				   float* Ecorr)
+{
+}
+
+float BEmcRecFEMC::GetImpactAngle(float e, float x, float y)
+// Get impact angle, (x,y) - position in Sector frame (cm)
+{
+  /*
+  float xVert, yVert, zVert;
+  float vx, vy, vz;
+
+  GlobalToSector( fVx, fVy, fVz, &xVert, &yVert, &zVert );
+  vz = -zVert;
+  vy = y - yVert;
+  vx = x - xVert;
+  // From this point X coord in sector frame is Z coord in Global Coord System !!!
+  *sinT = sqrt((vx*vx+vy*vy)/(vx*vx+vy*vy+vz*vz));
+  */
+  return 0;
+}
+
+void BEmcRecFEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
+{
+  // Corrects the EM Shower Core Energy for attenuation in fibers, 
+  // long energy leakage and angle dependance
+  //
+  // (x,y) - shower CG in tower units (not projected anywhere!)
+  
+  //  *Ecorr = Ecore;
+  float ec, ec2, corr;
+  const float par1 = 0.938;
+  const float par2 = 0.50;
+  const float par3 = 0.067;
+
+  *Ecorr = Ecore;
+  if( Ecore < 0.01 ) return;
+
+  float xA, yA, zA;
+  Tower2Global(Ecore/0.91, x, y, xA, yA, zA); // 0.91 - average correction
+  float tanT = sqrt(xA*xA+yA*yA)/fabs(zA-fVz);
+  corr = par1 * ( 1 - tanT*tanT*tanT*(par2 + par3*log(Ecore)) );
+  ec = Ecore/corr;
+
+  //  CorrectEnergy( ec, x, y, &ec2);
+  ec2 = ec; // !!!!! CorrectEnergy must be implemented
+  *Ecorr = ec2;
+}
+
+void BEmcRecFEMC::CorrectPosition(float Energy, float x, float y,
+				     float* pxc, float* pyc )
+{
+  // Corrects the Shower Center of Gravity for the systematic error due to 
+  // the limited tower size
+  //
+  // Everything here is in tower units. 
+  // (x,y) - CG position, (*pxc,*pyc) - corrected position
+
+  float xZero, yZero, bx, by;
+  float t, x0, y0;
+  int ix0, iy0;
+
+  *pxc = x;
+  *pyc = y;
+  //  return;
+
+  if( Energy<0.01 ) return;
+
+  float xA, yA, zA;
+  Tower2Global(Energy, x, y, xA, yA, zA);
+  zA -= fVz;
+  float sinTx = xA/sqrt(xA*xA+zA*zA);
+  float sinTy = yA/sqrt(yA*yA+zA*zA);
+  float sin2Tx = sinTx*sinTx;
+  float sin2Ty = sinTy*sinTy;
+
+  if( sinTx > 0 ) xZero= -0.417 *sinTx - 1.500 * sin2Tx ;
+  else            xZero= -0.417 *sinTx + 1.500 * sin2Tx ;
+
+  if( sinTy > 0 ) yZero = -0.417 * sinTy - 1.500 * sin2Ty;
+  else            yZero = -0.417 * sinTy + 1.500 * sin2Ty;
+
+  t = 0.98 + 0.98*sqrt(Energy);
+  t *= 0.7; // Temp correction
+  bx = 0.17-0.009*log(Energy) + t*sin2Tx;
+  by = 0.17-0.009*log(Energy) + t*sin2Ty;
+
+  //  xZero *= 0.5;
+  //  yZero *= 0.5;
+  
+  x0 = x + xZero;
+  ix0 = EmcCluster::lowint(x0 + 0.5);
+
+  if( EmcCluster::ABS(x0-ix0) <= 0.5 ) {
+    x0 = (ix0-xZero)+bx*asinh( 2.*(x0-ix0)*sinh(0.5/bx) );
+    *pxc = x0;
+  }
+  else {
+    *pxc =  x;
+    printf("????? Something wrong in BEmcRecFEMC::CorrectPosition: x=%f  dx=%f\n", x, x0-ix0);
+  }
+
+  y0 = y + yZero;
+  iy0 = EmcCluster::lowint(y0 + 0.5);
+
+  if( EmcCluster::ABS(y0-iy0) <= 0.5 ) {
+    y0 = (iy0-yZero)+by*asinh( 2.*(y0-iy0)*sinh(0.5/by) );
+    *pyc = y0;
+  }
+  else {
+    *pyc = y;
+    printf("????? Something wrong in BEmcRecFEMC::CorrectPosition: y=%f  dy=%f\n", y, y0-iy0);
+  }
+  
+}

--- a/offline/packages/CaloReco/BEmcRecFEMC.h
+++ b/offline/packages/CaloReco/BEmcRecFEMC.h
@@ -1,0 +1,18 @@
+#ifndef BEMCRECFEMC_H
+#define BEMCRECFEMC_H
+
+#include "BEmcRec.h"
+
+class BEmcRecFEMC : public BEmcRec
+{
+ public:
+  BEmcRecFEMC() {};
+  ~BEmcRecFEMC() {}
+  void CorrectEnergy(float energy, float x, float y, float *ecorr);
+  float GetImpactAngle(float e, float x, float y);
+  void CorrectPosition(float energy, float x, float y, float *xcorr, float *ycorr);
+  void CorrectECore(float ecore, float x, float y, float *ecorecorr);
+  void Tower2Global(float E, float xC, float yC, float& xA, float& yA, float& zA ); 
+};
+
+#endif // #ifndef BEMCREC_H

--- a/offline/packages/CaloReco/BEmcRecFEMC.h
+++ b/offline/packages/CaloReco/BEmcRecFEMC.h
@@ -9,7 +9,7 @@ class BEmcRecFEMC : public BEmcRec
   BEmcRecFEMC() {};
   ~BEmcRecFEMC() {}
   void CorrectEnergy(float energy, float x, float y, float *ecorr);
-  float GetImpactAngle(float e, float x, float y);
+  static float GetImpactAngle(float e, float x, float y);
   void CorrectPosition(float energy, float x, float y, float *xcorr, float *ycorr);
   void CorrectECore(float ecore, float x, float y, float *ecorecorr);
   void Tower2Global(float E, float xC, float yC, float& xA, float& yA, float& zA ); 

--- a/offline/packages/CaloReco/Makefile.am
+++ b/offline/packages/CaloReco/Makefile.am
@@ -14,6 +14,8 @@ libcalo_reco_la_SOURCES = \
   RawClusterBuilderGraph_Dict.cc \
   RawClusterBuilderTemplate.cc \
   RawClusterBuilderTemplate_Dict.cc \
+  RawClusterBuilderTemplateFEMC.cc \
+  RawClusterBuilderTemplateFEMC_Dict.cc \
   RawClusterBuilderFwd.cc \
   RawClusterBuilderFwd_Dict.cc \
   RawClusterPositionCorrection.cc \
@@ -23,7 +25,9 @@ libcalo_reco_la_SOURCES = \
   RawTowerCalibration.cc \
   RawTowerCalibration_Dict.cc \
   BEmcCluster.cc \
-  BEmcRec.cc
+  BEmcRec.cc \
+  BEmcRecCEMC.cc \
+  BEmcRecFEMC.cc
 
 libcalo_reco_la_LDFLAGS = \
   -L$(libdir) \

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.h
@@ -9,7 +9,7 @@ class RawCluster;
 class RawClusterContainer;
 class RawTowerContainer;
 class RawTowerGeomContainer;
-class BEmcRec;
+class BEmcRecCEMC;
 
 class RawClusterBuilderTemplate : public SubsysReco {
 
@@ -33,7 +33,7 @@ class RawClusterBuilderTemplate : public SubsysReco {
 
   RawClusterContainer* _clusters;
 
-  BEmcRec* bemc;
+  BEmcRecCEMC* bemc;
   float fEnergyNorm;
 
   float _min_tower_e;

--- a/offline/packages/CaloReco/RawClusterBuilderTemplateFEMC.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplateFEMC.cc
@@ -279,7 +279,7 @@ int RawClusterBuilderTemplateFEMC::process_event(PHCompositeNode *topNode)
 
     //    printf("  iCl=%d (%d): E=%f  x=%f  y=%f\n",ncl,npk,ecl,xcg,ycg);
 
-    for( pp=pPList->begin(); pp!=pPList->end(); pp++){
+    for( pp=pPList->begin(); pp!=pPList->end(); ++pp){
 
       // Cluster energy
       ecl = pp->GetTotalEnergy();

--- a/offline/packages/CaloReco/RawClusterBuilderTemplateFEMC.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplateFEMC.cc
@@ -1,0 +1,419 @@
+#include "RawClusterBuilderTemplateFEMC.h"
+
+#include "BEmcRecFEMC.h"
+#include "BEmcCluster.h"
+
+#include <calobase/RawClusterContainer.h>
+#include <calobase/RawClusterv1.h>
+
+#include <calobase/RawTower.h>
+#include <calobase/RawTowerGeom.h>
+#include <calobase/RawTowerGeomContainer.h>
+#include <calobase/RawTowerContainer.h>
+
+
+#include <phool/PHCompositeNode.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/getClass.h>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+#include <map>
+
+using namespace std;
+
+
+RawClusterBuilderTemplateFEMC::~RawClusterBuilderTemplateFEMC()
+{
+  delete bemc;
+}
+
+RawClusterBuilderTemplateFEMC::RawClusterBuilderTemplateFEMC(const std::string& name):
+  SubsysReco( name ),
+  _clusters(NULL),
+  _min_tower_e(0.020),
+  chkenergyconservation(0),
+  detector("NONE")
+{
+  BINX0 = 0;
+  NBINX = 0;
+  BINY0 = 0;
+  NBINY = 0;
+  Zcenter = 0;
+
+  fEnergyNorm = 1.;
+  bemc = new BEmcRecFEMC();
+  //
+  // Some initial values for clustering
+  //
+  bemc->SetPlaneGeometry();
+  // Configuration: number of towers in Phi and Eta, and tower dimension (here still in angle units and eta units)
+  bemc->SetGeometry( 64, 64, 1.0, 1.0 );
+  // Define vertex ... not used now
+  float vertex[3] = {0,0,0};
+  bemc->SetVertex(vertex);
+  // Define threshold ... not used now
+  bemc->SetTowerThreshold(0);
+}
+
+int RawClusterBuilderTemplateFEMC::InitRun(PHCompositeNode *topNode)
+{
+  try
+    {
+      CreateNodes(topNode);
+    }
+  catch (std::exception &e)
+    {
+      std::cout << PHWHERE << ": " << e.what() << std::endl;
+      throw;
+    }
+
+  string towergeomnodename = "TOWERGEOM_" + detector;
+  RawTowerGeomContainer *towergeom = findNode::getClass<RawTowerGeomContainer>(topNode, towergeomnodename.c_str());
+  if (! towergeom)
+    {
+      cout << PHWHERE << ": Could not find node " << towergeomnodename.c_str() << endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  
+  int ngeom=0;
+  int ixmin= 999999;
+  int ixmax=-999999;
+  int iymin= 999999;
+  int iymax=-999999;
+  float sz = 0;
+  RawTowerGeomContainer::ConstRange begin_end_geom = towergeom->get_tower_geometries();
+  RawTowerGeomContainer::ConstIterator itr_geom = begin_end_geom.first;
+  for (; itr_geom != begin_end_geom.second; ++itr_geom) {
+    RawTowerGeom *towerg = itr_geom->second;
+    RawTowerDefs::keytype towerid = towerg->get_id();
+    int itype = towerg->get_tower_type();
+    if( itype==2 ) { // PbSc
+      int ix = RawTowerDefs::decode_index1(towerid);
+      int iy = RawTowerDefs::decode_index2(towerid);
+      if( ixmin>ix ) ixmin=ix;
+      if( ixmax<ix ) ixmax=ix;
+      if( iymin>iy ) iymin=iy;
+      if( iymax<iy ) iymax=iy;
+      sz += towerg->get_center_z();
+      ngeom++;
+    }
+  }
+  Zcenter = 305.;
+  if( ngeom>0 ) Zcenter = sz/ngeom;
+
+  //  printf("************* Init FEMC: N of geom towers: %d; ix=%d-%d iy=%d-%d Zcenter=%f\n",ngeom,ixmin,ixmax,iymin,iymax,Zcenter);
+
+  if( ixmax<ixmin || iymax<iymin ) return Fun4AllReturnCodes::ABORTEVENT;
+
+  BINX0 = ixmin;
+  NBINX = ixmax-ixmin+1;
+  BINY0 = iymin;
+  NBINY = iymax-iymin+1;
+  
+  bemc->SetGeometry( NBINX, NBINY, 1, 1 ); // !!!!! The last parameter not used for now
+
+  itr_geom = begin_end_geom.first;
+  for (; itr_geom != begin_end_geom.second; ++itr_geom) {
+    RawTowerGeom *towerg = itr_geom->second;
+    RawTowerDefs::keytype towerid = towerg->get_id();
+    int itype = towerg->get_tower_type();
+    if( itype==2 ) { // PbSc
+      int ix = RawTowerDefs::decode_index1(towerid);
+      int iy = RawTowerDefs::decode_index2(towerid);
+      ix -= BINX0;
+      iy -= BINY0;
+      int ich = iy*NBINX + ix;
+      bemc->SetTowerGeometry(ich,towerg->get_center_x(),towerg->get_center_y(),towerg->get_center_z());
+    }
+  }
+
+  //  bemc->PrintTowerGeometry();
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+bool RawClusterBuilderTemplateFEMC::Cell2Abs(RawTowerGeomContainer *towergeom, float xC, float yC, float& xA, float& yA)
+{
+  int ix = xC+0.5; // tower #
+  if( ix<0 || ix >= NBINX ) {
+    printf("RawClusterBuilderTemplateFEMC::Cell2Abs: wrong input x: %d\n",ix);
+    return false;
+  }
+
+  int iy = yC+0.5; // tower #
+  if( iy<0 || iy >= NBINY ) {
+    printf("RawClusterBuilderTemplateFEMC::Cell2Abs: wrong input y: %d\n",iy);
+    return false;
+  }
+
+  ix += BINX0;
+  iy += BINY0;
+
+  RawTowerDefs::keytype key = RawTowerDefs::encode_towerid( towergeom->get_calorimeter_id(), ix , iy );
+  RawTowerGeom* geom0 = towergeom->get_tower_geometry(key);
+
+  // Next tower in x
+  key = RawTowerDefs::encode_towerid(towergeom->get_calorimeter_id(), ix+1, iy);
+  RawTowerGeom* geomx = towergeom->get_tower_geometry(key);
+  if( geomx == NULL ) {
+    key = RawTowerDefs::encode_towerid(towergeom->get_calorimeter_id(), ix-1, iy);
+    geomx = towergeom->get_tower_geometry(key); 
+    if( geomx == NULL ) {
+      printf("RawClusterBuilderTemplateFEMC::Cell2Abs: error in geometry extraction: %d %d\n",ix, iy);
+      return false;
+    }
+  }
+
+  // Next tower in y
+  key = RawTowerDefs::encode_towerid(towergeom->get_calorimeter_id(), ix, iy+1);
+  RawTowerGeom* geomy = towergeom->get_tower_geometry(key);
+  if( geomy == NULL ) {
+    key = RawTowerDefs::encode_towerid(towergeom->get_calorimeter_id(), ix, iy-1);
+    geomy = towergeom->get_tower_geometry(key); 
+    if( geomy == NULL ) {
+      printf("RawClusterBuilderTemplateFEMC::Cell2Abs: error in geometry extraction: %d %d\n",ix, iy);
+      return false;
+    }
+  }
+
+  //  float dx = geom->get_size_x();
+  //  float dy = geom->get_size_y();
+  float dx = fabs(geom0->get_center_x() - geomx->get_center_x());
+  float dy = fabs(geom0->get_center_y() - geomy->get_center_y());
+  xA = geom0->get_center_x() + (xC-ix+BINX0)*dx;
+  yA = geom0->get_center_y() + (yC-iy+BINY0)*dy;
+
+  return true;
+}
+
+int RawClusterBuilderTemplateFEMC::process_event(PHCompositeNode *topNode)
+{
+  string towernodename = "TOWER_CALIB_" + detector;
+  // Grab the towers
+  RawTowerContainer* towers = findNode::getClass<RawTowerContainer>(topNode, towernodename.c_str());
+  if (!towers)
+    {
+      std::cout << PHWHERE << ": Could not find node " << towernodename.c_str() << std::endl;
+      return Fun4AllReturnCodes::DISCARDEVENT;
+    }
+  string towergeomnodename = "TOWERGEOM_" + detector;
+  RawTowerGeomContainer *towergeom = findNode::getClass<RawTowerGeomContainer>(topNode, towergeomnodename.c_str());
+  if (! towergeom)
+    {
+      cout << PHWHERE << ": Could not find node " << towergeomnodename.c_str() << endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+ // _clusters->Reset(); // !!! Not sure if it is necessarry to do it - ask Chris
+
+  // make the list of towers above threshold
+  RawTowerContainer::ConstRange begin_end  = towers->getTowers();
+  RawTowerContainer::ConstIterator itr = begin_end.first;
+
+  // Define vector of towers in EmcModule format to input into BEmc
+  EmcModule vhit;
+  std::vector<EmcModule> HitList;
+  HitList.erase(HitList.begin(), HitList.end());
+  int ich, ix, iy;
+
+  for (; itr != begin_end.second; ++itr)
+    {
+      RawTower* tower = itr->second;
+      //      printf("  Tower e=%f (%f)\n",tower->get_energy(), _min_tower_e);
+      if (tower->get_energy() > _min_tower_e)
+        {
+	  //	  printf("(%d,%d)  (%d,%d)\n",tower->get_column(),tower->get_row(),tower->get_binphi(),tower->get_bineta());
+	  //	  ix = tower->get_column();
+	  ix = tower->get_bineta() - BINX0; // eta: index1
+	  iy = tower->get_binphi() - BINY0; // phi: index2 
+	  if( ix>=0 && ix<NBINX && iy>=0 && iy<NBINY ) {
+	    ich = iy*NBINX + ix;
+	    vhit.ich = ich;
+	    vhit.amp = tower->get_energy()*fEnergyNorm; // !!! Global Calibration
+	    vhit.tof = 0.;
+	    HitList.push_back(vhit);
+	  }
+        }
+    }
+
+  bemc->SetModules(&HitList);
+
+  // Find clusters (as a set of towers with common edge)
+  int ncl = bemc->FindClusters();
+  if( ncl<0 ) {
+    printf("!!! Error in BEmcRec::FindClusters(): Too many clusters, fgMaxLen parameter needs to be increased\n");
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  // Get pointer to clusters
+  std::vector<EmcCluster> *ClusterList = bemc->GetClusters();
+  std::vector<EmcCluster>::iterator pc;
+
+  std::vector<EmcPeakarea>::iterator pp;
+  float ecl, ecore, xcg, ycg, xx, xy, yy;
+  //  float xcorr, ycorr;
+  EmcModule hmax;
+  RawCluster *cluster;
+
+  std::vector<EmcPeakarea> PList;
+  std::vector<EmcModule> Peaks;
+  std::vector<EmcPeakarea> *pPList = &PList;
+  std::vector<EmcModule> *pPeaks = &Peaks;
+
+  float xout, yout, zout;
+  float prob, chi2;
+  int ndf;
+
+  vector<EmcModule>::iterator ph;
+  vector<EmcModule> hlist;
+
+  ncl = 0;
+  for( pc=ClusterList->begin(); pc!=ClusterList->end(); ++pc){
+
+    //    ecl = pc->GetTotalEnergy();
+    //    pc->GetMoments( &xcg, &ycg, &xx, &xy, &yy );
+
+    int npk = pc->GetPeaks(pPList, pPeaks);
+    if( npk<0 ) return Fun4AllReturnCodes::ABORTEVENT;
+
+    //    printf("  iCl=%d (%d): E=%f  x=%f  y=%f\n",ncl,npk,ecl,xcg,ycg);
+
+    for( pp=pPList->begin(); pp!=pPList->end(); pp++){
+
+      // Cluster energy
+      ecl = pp->GetTotalEnergy();
+      ecore = pp->GetECoreCorrected();
+      // 3x3 energy around center of gravity
+      //e9 = pp->GetE9();
+      // Ecore (basically near 2x2 energy around center of gravity)
+      //ecore = pp->GetECore();
+      // Center of Gravity etc.
+      pp->GetMoments( &xcg, &ycg, &xx, &xy, &yy );
+      // Tower with max energy
+      hmax = pp->GetMaxTower();
+
+      //      pp->GetCorrPos(&xcorr,&ycorr);
+      /* 
+      xcorr = xcg;
+      ycorr = ycg;
+      Cell2Abs(towergeom,xcorr,ycorr,xout,yout);
+      */
+      //      const double ref_radius = towergeom->get_radius();
+
+      pp->GetGlobalPos(xout,yout,zout);
+
+      prob = pp->GetProb(chi2,ndf);
+      //      printf("Prob/Chi2/NDF= %f %f %d Ecl=%f\n",prob,chi2,ndf,ecl);
+
+      cluster = new RawClusterv1();
+      cluster->set_energy(ecl);
+      cluster->set_ecore(ecore);
+
+      cluster->set_r(sqrt(xout*xout + yout*yout));
+      cluster->set_phi(atan2(yout, xout));
+      cluster->set_z(zout);
+
+      cluster->set_prob(prob);
+      if( ndf>0 ) cluster->set_chi2(chi2/ndf);
+      else        cluster->set_chi2(0);
+
+      hlist = pp->GetHitList();
+      ph = hlist.begin();
+      while( ph != hlist.end() ) {
+	ich = (*ph).ich;
+	iy = ich/NBINX;
+	ix = ich%NBINX;
+	// that code needs a closer look - here are the towers 
+	// with their energy added to the cluster object where 
+	// the id is the tower id
+	// !!!!! Make sure twrkey is correctly extracted 
+	RawTowerDefs::keytype twrkey = RawTowerDefs::encode_towerid( towers->getCalorimeterID(), ix+BINX0 , iy+BINY0 );
+	//	printf("%d %d: %d e=%f\n",iphi,ieta,twrkey,(*ph).amp);
+	cluster->addTower(twrkey,(*ph).amp/fEnergyNorm);
+	++ph;
+      }
+
+      _clusters->AddCluster(cluster);
+      ncl++;
+
+      //      printf("    ipk=%d: E=%f x=%f (%f)  y=%f (%f)  MaxTower: (%d,%d) e=%f\n",ncl-1,ecl,xcorr,xout,ycorr,yout,hmax.ich%NBINX,hmax.ich/NBINX,hmax.amp);
+
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+bool RawClusterBuilderTemplateFEMC::CorrectPhi(RawCluster* cluster, RawTowerContainer* towers, RawTowerGeomContainer *towergeom)
+{
+  double sum = cluster->get_energy();
+  double phimin = 999.;
+  double phimax = -999.;
+  RawCluster::TowerConstRange begin_end = cluster->get_towers();
+  RawCluster::TowerConstIterator iter;
+  for (iter =begin_end.first; iter != begin_end.second; ++iter)
+    { 
+      RawTower* tmpt = towers->getTower(iter->first);
+      double phi = towergeom->get_phicenter(tmpt->get_binphi());
+      if(phi > M_PI) phi = phi - 2.*M_PI; // correct the cluster phi for slat geometry which is 0-2pi (L. Xue)
+      if (phi < phimin)
+        {
+          phimin = phi;
+        }
+      if (phi > phimax)
+        {
+          phimax = phi;
+        }
+    }
+
+  if ((phimax - phimin) < 3.) return false; // cluster is not at phi discontinuity
+
+  float mean = 0.;
+  for (iter =begin_end.first; iter != begin_end.second; ++iter)
+    { 
+      RawTower* tmpt = towers->getTower(iter->first);
+      double e = tmpt->get_energy();
+      double phi = towergeom->get_phicenter(tmpt->get_binphi());
+      if(phi > M_PI) phi = phi - 2.*M_PI; // correct the cluster phi for slat geometry which is 0-2pi (L. Xue)
+      if (phi < 0.)
+        {
+          phi = phi + 2.*M_PI;  // shift phi range for correct mean calculation
+        }
+      mean += e * phi;
+    }
+  mean = mean / sum;
+  if (mean > M_PI)
+    {
+      mean = mean - 2.*M_PI;  // shift back
+    }
+
+  cluster->set_phi(mean);
+
+  return true; // mean phi was corrected
+}
+
+
+int RawClusterBuilderTemplateFEMC::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void RawClusterBuilderTemplateFEMC::CreateNodes(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+
+  // Grab the cEMC node
+  PHCompositeNode *dstNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+    {
+      std::cerr << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+      throw std::runtime_error("Failed to find DST node in EmcRawTowerBuilder::CreateNodes");
+    }
+
+  _clusters = new RawClusterContainer();
+  ClusterNodeName = "CLUSTER_" + detector;
+  PHIODataNode<PHObject> *clusterNode = new PHIODataNode<PHObject>(_clusters, ClusterNodeName.c_str(), "PHObject");
+  dstNode->addNode(clusterNode);
+}

--- a/offline/packages/CaloReco/RawClusterBuilderTemplateFEMC.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplateFEMC.h
@@ -1,0 +1,52 @@
+#ifndef RawClusterBuilderTemplateFEMC_H__
+#define RawClusterBuilderTemplateFEMC_H__
+
+#include <fun4all/SubsysReco.h>
+#include <string>
+
+class PHCompositeNode;
+class RawCluster;
+class RawClusterContainer;
+class RawTowerContainer;
+class RawTowerGeomContainer;
+class BEmcRecFEMC;
+
+class RawClusterBuilderTemplateFEMC : public SubsysReco {
+
+ public:
+  RawClusterBuilderTemplateFEMC(const std::string& name = "RawClusterBuilderGraph");
+  virtual ~RawClusterBuilderTemplateFEMC();
+
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+  void Detector(const std::string &d) {detector = d;}
+
+  void set_threshold_energy(const float e) {_min_tower_e = e;}
+  void setEnergyNorm(float norm) {fEnergyNorm = norm;}
+  void checkenergy(const int i = 1) {chkenergyconservation = i;}
+
+ private:
+  void CreateNodes(PHCompositeNode *topNode);
+  bool CorrectPhi(RawCluster* cluster, RawTowerContainer* towers, RawTowerGeomContainer *towergemom);
+  bool Cell2Abs(RawTowerGeomContainer *towergeom, float phiC, float etaC, float& phi, float& eta);
+
+  RawClusterContainer* _clusters;
+
+  BEmcRecFEMC* bemc;
+  float fEnergyNorm;
+
+  float _min_tower_e;
+  int chkenergyconservation;
+
+  std::string detector;
+  std::string ClusterNodeName;
+
+  int BINX0;
+  int NBINX;
+  int BINY0;
+  int NBINY;
+  float Zcenter;
+};
+
+#endif /* RawClusterBuilderTemplateFEMC_H__ */

--- a/offline/packages/CaloReco/RawClusterBuilderTemplateFEMCLinkDef.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplateFEMCLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RawClusterBuilderTemplateFEMC-!;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
Modification made to allow PHENIX-style clustering for FEMC

1. RawClusterBuilderTemplateFEMC is introduced, which should be called from G4_FEMC.C::FEMC_Clusters() instead of RawClusterBuilderFwd: 
  RawClusterBuilderTemplateFEMC *ClusterBuilder = new RawClusterBuilderTemplateFEMC("EmcRawClusterBuilderTemplateFEMC");
  ClusterBuilder->Detector("FEMC");
  ClusterBuilder->Verbosity(verbosity);
  se->registerSubsystem(ClusterBuilder);

2. BEmcRec is now a base class, from which BEmcRecCEMC and BEmcRecFEMC inherit base functionality and contains EMCal specific descriptions; RawClusterBuilderTemplate is now for CEMC, therefore it calls BEmcRecCEMC (while RawClusterBuilderTemplateFEMC calls BEmcRecFEMC)

3. Some minor (mainly stylish) modifications in BEmcCluster

4. FEMC clustering outputs a fully corrected position (corrected for shower depth and S-oscillations); shower depth is reflected in cluster z-coordinate (for a photon); plan to do the same for CEMC once full tower geometry info is available from respective geometry node; a fully corrected Ecore is also available

