### PR TITLE
add light version for vertex evaluator

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -82,9 +82,9 @@ int SvtxEvaluator::Init(PHCompositeNode *topNode) {
   _tfile = new TFile(_filename.c_str(), "RECREATE");
 
   if (_do_vertex_eval) _ntp_vertex = new TNtuple("ntp_vertex","vertex => max truth",
-						 "event:vx:vy:vz:ntracks:"
-						 "gvx:gvy:gvz:gvt:gntracks:"
-						 "nfromtruth");
+                                                 "event:vx:vy:vz:ntracks:"
+                                                 "gvx:gvy:gvz:gvt:gembed:gntracks:gntracksmaps:"
+                                                 "gnootvtx:nfromtruth");
 
   if (_do_gpoint_eval) _ntp_gpoint = new TNtuple("ntp_gpoint","g4point => best vertex",
 						 "event:gvx:gvy:gvz:gvt:gntracks:gembed:"
@@ -92,21 +92,22 @@ int SvtxEvaluator::Init(PHCompositeNode *topNode) {
 						 "nfromtruth");
   
   if (_do_g4hit_eval) _ntp_g4hit = new TNtuple("ntp_g4hit","g4hit => best svtxcluster",
-					       "event:g4hitID:gx:gy:gz:gt:gedep:gphi"
+					       "event:g4hitID:gx:gy:gz:gt:gedep:geta:gphi:"
+					       "gdphi:gdz:"
 					       "glayer:gtrackID:gflavor:"
 					       "gpx:gpy:gpz:"
 					       "gvx:gvy:gvz:"
 					       "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
 					       "gembed:gprimary:nclusters:"
-					       "clusID:x:y:z:e:adc:layer:size:"
-					       "phisize:zsize:efromtruth");
+					       "clusID:x:y:z:eta:phi:e:adc:layer:size:"
+					       "phisize:zsize:efromtruth:dphitru:detatru:dztru:drtru");
 
   if (_do_hit_eval) _ntp_hit = new TNtuple("ntp_hit","svtxhit => max truth",
 					   "event:hitID:e:adc:layer:"
 					   "cellID:ecell:phibin:zbin:phi:z:"
 					   "g4hitID:gedep:gx:gy:gz:gt:"
 					   "gtrackID:gflavor:"
-					   "gpx:gpy:gpz:gvx:gvy:gvz:"
+					   "gpx:gpy:gpz:gvx:gvy:gvz:gvt:"
 					   "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
 					   "gembed:gprimary:efromtruth");
 
@@ -115,7 +116,7 @@ int SvtxEvaluator::Init(PHCompositeNode *topNode) {
 						   "e:adc:layer:size:phisize:"
 						   "zsize:trackID:g4hitID:gx:"
 						   "gy:gz:gr:gphi:geta:gt:gtrackID:gflavor:"
-						   "gpx:gpy:gpz:gvx:gvy:gvz:"
+						   "gpx:gpy:gpz:gvx:gvy:gvz:gvt:"
 						   "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
 						   "gembed:gprimary:efromtruth:nparticles");
 
@@ -586,9 +587,113 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       cout << "Filling ntp_vertex " << endl;
       _timer->restart();
     }
+
+
     SvtxVertexMap* vertexmap = findNode::getClass<SvtxVertexMap>(topNode,"SvtxVertexMap");
     PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
     if (vertexmap && truthinfo) {
+
+      const auto prange = truthinfo->GetPrimaryParticleRange();
+      map<int, unsigned int> embedvtxid_particle_count;
+      map<int, unsigned int> embedvtxid_maps_particle_count;
+      map<int, unsigned int> vertex_particle_count;
+
+      for (auto iter = prange.first; iter != prange.second; ++iter) // process all primary paricle
+      {
+        const int point_id = iter->second->get_vtx_id();
+        int gembed = truthinfo->isEmbededVtx(iter->second->get_vtx_id());
+        ++vertex_particle_count[point_id];
+        ++embedvtxid_particle_count[gembed];
+        PHG4Particle* g4particle = iter->second;
+
+        if ( (_scan_for_embedded && gembed <=0)|| (_do_eval_light==true)) continue;
+
+        std::set<SvtxCluster*> g4clusters = clustereval->all_clusters_from(g4particle);
+        unsigned int nglmaps = 0;
+        unsigned int nglintt = 0;
+        unsigned int ngltpc  = 0;
+
+        int lmaps[_nlayers_maps+1];
+        if(_nlayers_maps>0) for(unsigned int i = 0;i<_nlayers_maps;i++) lmaps[i] = 0;
+
+        int lintt[_nlayers_intt+1];
+        if(_nlayers_intt>0) for(unsigned int i = 0;i<_nlayers_intt;i++) lintt[i] = 0;
+
+        int ltpc[_nlayers_tpc+1];
+        if(_nlayers_tpc>0) for(unsigned int i = 0;i<_nlayers_tpc;i++) ltpc[i] = 0;
+
+        for(const SvtxCluster* g4cluster : g4clusters){
+          unsigned int layer = g4cluster->get_layer();
+          //cout<<__LINE__<<": " << _ievent <<": " <<gtrackID << ": " << layer <<": " <<g4cluster->get_id() <<endl;
+          if(_nlayers_maps>0&&layer<_nlayers_maps) {
+                  lmaps[layer] = 1;
+          }
+
+          if(_nlayers_intt>0&&layer>=_nlayers_maps&&layer<_nlayers_maps+_nlayers_intt){
+            lintt[layer-_nlayers_maps] = 1;
+          }
+
+          if(_nlayers_tpc>0&&layer>=_nlayers_maps+_nlayers_intt && layer<_nlayers_maps+_nlayers_intt+_nlayers_tpc){
+            ltpc[layer-(_nlayers_maps+_nlayers_intt)] = 1;
+          }
+        }
+        if(_nlayers_maps>0) for(unsigned int i = 0;i<_nlayers_maps;i++) nglmaps+=lmaps[i];
+        if(_nlayers_intt>0) for(unsigned int i = 0;i<_nlayers_intt;i++) nglintt+=lintt[i];
+        if(_nlayers_tpc>0)  for(unsigned int i = 0;i<_nlayers_tpc;i++)  ngltpc+=ltpc[i];
+
+//        float gflavor   = g4particle->get_pid();
+        float gpx       = g4particle->get_px();
+        float gpy       = g4particle->get_py();
+        float gpz       = g4particle->get_pz();
+        float gpt       = NAN;
+        float geta      = NAN;
+
+        if(gpx!=0&&gpy!=0){
+          TVector3 gv(gpx,gpy,gpz);
+          gpt  = gv.Pt();
+          geta = gv.Eta();
+        }
+
+        if (nglmaps==3 && fabs(geta)<1.0 && gpt>0.5)
+        ++embedvtxid_maps_particle_count[gembed];
+      }
+
+      auto vrange = truthinfo->GetPrimaryVtxRange();
+      map<int, bool> embedvtxid_found;
+      map<int, int> embedvtxid_vertex_id;
+      map<int, PHG4VtxPoint*> embedvtxid_vertex;
+      for (auto iter = vrange.first; iter != vrange.second; ++iter) // process all primary vertexes
+      {
+        const int point_id = iter->first;
+        int gembed = truthinfo->isEmbededVtx(point_id);
+        if (_scan_for_embedded && gembed <= 0) continue;
+
+        auto search = embedvtxid_found.find(gembed);
+        if (search != embedvtxid_found.end())
+        {
+        embedvtxid_vertex_id[gembed] = point_id;
+        embedvtxid_vertex[gembed] = iter->second;
+        }
+        else
+        {
+          if (vertex_particle_count[embedvtxid_vertex_id[gembed]] < vertex_particle_count[point_id])
+          {
+          embedvtxid_vertex_id[gembed] = point_id;
+          embedvtxid_vertex[gembed] = iter->second;
+          }
+        }
+        embedvtxid_found[gembed]=false;
+      }
+
+      unsigned int ngootvtx=0;// number of out of time vertexes
+      for (std::map<int,bool>::iterator iter = embedvtxid_found.begin();
+        iter != embedvtxid_found.end();
+        ++iter)
+      {
+        if (iter->first >= 0 || iter->first != iter->first) continue;
+        ++ngootvtx;
+      }
+
       for (SvtxVertexMap::Iter iter = vertexmap->begin();
 	   iter != vertexmap->end();
 	   ++iter) {
@@ -600,46 +705,111 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float vz         = vertex->get_z();
 	float ntracks    = vertex->size_tracks();
 
-	float gvx        = NAN;
-	float gvy        = NAN;
-	float gvz        = NAN;
-	float gvt        = NAN;
-	float gntracks   = truthinfo->GetNumPrimaryVertexParticles();
-	float nfromtruth = NAN;
+        float gvx        = NAN;
+        float gvy        = NAN;
+        float gvz        = NAN;
+        float gvt        = NAN;
+        float gembed     = NAN;
+        float gntracks   = truthinfo->GetNumPrimaryVertexParticles();
+        float gntracksmaps = NAN;
+        float gnootvtx   = NAN;
+        float nfromtruth = NAN;
 	
 	if (point) {
-	  gvx        = point->get_x();
-	  gvy        = point->get_y();
-	  gvz        = point->get_z();
-	  gvt        = point->get_t();
-	  gntracks   = truthinfo->GetNumPrimaryVertexParticles();
-	  nfromtruth = vertexeval->get_ntracks_contribution(vertex,point);
+          const int point_id = point->get_id();
+          gvx        = point->get_x();
+          gvy        = point->get_y();
+          gvz        = point->get_z();
+          gvt        = point->get_t();
+          gembed     = truthinfo->isEmbededVtx(point_id);
+          gntracks   = embedvtxid_particle_count[(int)gembed];
+          if (embedvtxid_maps_particle_count[(int)gembed]>0 
+		&& fabs(gvt)<2000.&& fabs(gvz)<13.0 && (_do_eval_light==false))
+          gntracksmaps = embedvtxid_maps_particle_count[(int)gembed];
+          gnootvtx    = (float) ngootvtx;
+          nfromtruth = vertexeval->get_ntracks_contribution(vertex,point);
+          embedvtxid_found[(int)gembed]= true;
 	}
 	  
-	float vertex_data[12] = {(float) _ievent,
-				 vx,
-				 vy,
-				 vz,
-				 ntracks,
-				 gvx,
-				 gvy,
-				 gvz,
-				 gvt,
-				 gntracks,
-				 nfromtruth
+        float vertex_data[14] = {(float) _ievent,
+                                 vx,
+                                 vy,
+                                 vz,
+                                 ntracks,
+                                 gvx,
+                                 gvy,
+                                 gvz,
+                                 gvt,
+                                 gembed,
+                                 gntracks,
+                                 gntracksmaps,
+                                 gnootvtx,
+                                 nfromtruth
 	};
-
-	/*
-	cout << "vertex: " 
-	     << " ievent " << vertex_data[0]
-	     << " vx " << vertex_data[1]
-	     << " vy " << vertex_data[2]
-	     << " vz " << vertex_data[3]
-	     << endl;
-	*/
-
+	      
 	_ntp_vertex->Fill(vertex_data);      
       }
+
+      if (!_scan_for_embedded) {
+      for (std::map<int,bool>::iterator iter = embedvtxid_found.begin();
+        iter != embedvtxid_found.end();
+        ++iter)
+      {
+        if (embedvtxid_found[iter->first]) continue;
+
+        float vx         = NAN;
+        float vy         = NAN;
+        float vz         = NAN;
+        float ntracks    = NAN;
+
+        float gvx        = NAN;
+        float gvy        = NAN;
+        float gvz        = NAN;
+        float gvt        = NAN;
+        float gembed     = iter->first;
+        float gntracks   = NAN;
+        float gntracksmaps = NAN;
+        float gnootvtx    = NAN;
+        float nfromtruth = NAN;
+
+        PHG4VtxPoint* point = embedvtxid_vertex[gembed];
+
+        if (point){
+        const int point_id = point->get_id();
+        gvx        = point->get_x();
+        gvy        = point->get_y();
+        gvz        = point->get_z();
+        gvt        = point->get_t();
+        gembed     = truthinfo->isEmbededVtx(point_id);
+        gntracks   = embedvtxid_particle_count[(int)gembed];
+        if (embedvtxid_maps_particle_count[(int)gembed]>0 
+		&& fabs(gvt)<2000&& fabs(gvz)<13.0 && (_do_eval_light==false))
+        gntracksmaps = embedvtxid_maps_particle_count[(int)gembed];
+        gnootvtx    = (float) ngootvtx;
+//        nfromtruth = vertexeval->get_ntracks_contribution(vertex,point);
+        }
+
+        float vertex_data[14] = {(float) _ievent,
+                                 vx,
+                                 vy,
+                                 vz,
+                                 ntracks,
+                                 gvx,
+                                 gvy,
+                                 gvz,
+                                 gvt,
+                                 gembed,
+                                 gntracks,
+                                 gntracksmaps,
+                                 gnootvtx,
+                                 nfromtruth
+        };
+
+        _ntp_vertex->Fill(vertex_data);
+
+      }
+      }
+
     }
     if(verbosity >= 1){
       _timer->stop();
@@ -746,7 +916,12 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       float gx        = g4hit->get_avg_x();
       float gy        = g4hit->get_avg_y();
       float gz        = g4hit->get_avg_z();
+      TVector3 vg4(gx,gy,gz);
       float gt        = g4hit->get_avg_t();
+      TVector3 vin(g4hit->get_x(0),g4hit->get_y(0),g4hit->get_z(0));
+      TVector3 vout(g4hit->get_x(1),g4hit->get_y(1),g4hit->get_z(1));
+      float gdphi     = vin.DeltaPhi(vout);
+      float gdz       = fabs(g4hit->get_z(1) - g4hit->get_z(0));
       float gedep     = g4hit->get_edep();
       float glayer    = g4hit->get_layer();
   
@@ -757,6 +932,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       float gpy       = NAN;
       float gpz       = NAN;
       TVector3 vec(g4hit->get_avg_x(),g4hit->get_avg_y(),g4hit->get_avg_z());
+      float geta      = vec.Eta();
       float gphi      = vec.Phi();
       float gvx       = NAN;
       float gvy       = NAN;
@@ -818,6 +994,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       float x          = NAN;
       float y          = NAN;
       float z          = NAN;
+      float eta        = NAN;
+      float phi        = NAN;
       float e          = NAN;
       float adc        = NAN;
       float layer      = NAN;
@@ -825,31 +1003,45 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       float phisize    = NAN;
       float zsize      = NAN;
       float efromtruth = NAN;
+      float dphitru    = NAN;
+      float detatru    = NAN;
+      float dztru      = NAN;
+      float drtru      = NAN;
 
       if (cluster) {
 	clusID     = cluster->get_id();
 	x          = cluster->get_x();
 	y          = cluster->get_y();
 	z          = cluster->get_z();
+	TVector3 vec2(x,y,z);
+	eta        = vec2.Eta();
+	phi        = vec2.Phi();
 	e          = cluster->get_e();
 	adc        = cluster->get_adc();
 	layer      = cluster->get_layer();
 	size       = cluster->size_hits();
 	phisize    = cluster->get_phi_size();
 	zsize      = cluster->get_z_size();
+	dphitru    = vec2.DeltaPhi(vg4);
+	detatru    = eta - geta;
+	dztru      = z - gz;
+	drtru	   = vec2.DeltaR(vg4);
 	if (g4particle) {
 	  efromtruth = clustereval->get_energy_contribution(cluster,g4particle);
 	}
       }
 
-      float g4hit_data[37] = {(float) _ievent,
+      float g4hit_data[46] = {(float) _ievent,
 			      g4hitID,
 			      gx,
 			      gy,
 			      gz,
 			      gt,
 			      gedep,
+			      geta,
 			      gphi,
+			      gdphi,
+			      gdz,
 			      glayer,
 			      gtrackID,
 			      gflavor,
@@ -871,14 +1063,20 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 			      clusID,  
 			      x,      
 			      y,      
-			      z,      
+			      z,  
+			      eta,
+			      phi,
 			      e,      
 			      adc,    
 			      layer,  
 			      size,   
 			      phisize,
 			      zsize,  
-			      efromtruth
+			      efromtruth,
+			      dphitru,
+			      detatru,
+			      dztru,
+			      drtru
       };
 
       _ntp_g4hit->Fill(g4hit_data);
@@ -927,9 +1125,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
  	int zbin     = NAN;
  	float phi    = NAN;
  	float z      = NAN;
-	PHG4CylinderCellGeom *GeoLayer = geom_container->GetLayerCellGeom(layer);
 
 	if(layer>=_nlayers_maps+_nlayers_intt){
+	  PHG4CylinderCellGeom *GeoLayer = geom_container->GetLayerCellGeom(layer);
 	  //"cellID:ecell:phibin:zbin:phi:z"
 	  phibin = PHG4CellDefs::SizeBinning::get_phibin(g4cell->get_cellid());//cell->get_binphi();
 	  zbin = PHG4CellDefs::SizeBinning::get_zbin(g4cell->get_cellid());//cell->get_binz();
@@ -951,6 +1149,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gvx      = NAN;
 	float gvy      = NAN;
 	float gvz      = NAN;
+	float gvt      = NAN;
 	float gfpx     = NAN;
 	float gfpy     = NAN;
 	float gfpz     = NAN;
@@ -988,6 +1187,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	      gvx      = vtx->get_x();
 	      gvy      = vtx->get_y();
 	      gvz      = vtx->get_z();
+	      gvt      = vtx->get_t();
 	    }
 
 	    PHG4Hit* outerhit = NULL;
@@ -1010,7 +1210,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  efromtruth = hiteval->get_energy_contribution(hit,g4particle);
 	}
 
-	float hit_data[35] = {
+	float hit_data[36] = {
 	  event,
 	  hitID,
 	  e,
@@ -1036,6 +1236,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  gvx,
 	  gvy,
 	  gvz,
+	  gvt,
 	  gfpx,
 	  gfpy,
 	  gfpz,
@@ -1118,6 +1319,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	float gvx      = NAN;
 	float gvy      = NAN;
 	float gvz      = NAN;
+	float gvt      = NAN;
 	float gfpx     = NAN;
 	float gfpy     = NAN;
 	float gfpz     = NAN;
@@ -1153,6 +1355,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	      gvx      = vtx->get_x();
 	      gvy      = vtx->get_y();
 	      gvz      = vtx->get_z();
+	      gvt      = vtx->get_t();
 	    }
 	    
 	    PHG4Hit* outerhit = nullptr;
@@ -1178,8 +1381,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	}
 
 	float nparticles = clustereval->all_truth_particles(cluster).size();
-
-	float cluster_data[45] = {(float) _ievent,
+	float cluster_data[46] = {(float) _ievent,
 				  hitID,
 				  x,
 				  y,
@@ -1214,6 +1416,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 				  gvx,
 				  gvy,
 				  gvz,
+				  gvt,
 				  gfpx,
 				  gfpy,
 				  gfpz,
@@ -1267,7 +1470,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	  float x        = cluster->get_x();
 	  float y        = cluster->get_y();
 	  float z        = cluster->get_z();
-
+	  TVector3 pos(x,y,z);
+	  float r = pos.Perp();
+	  float phi = pos.Phi();
+	  float eta = pos.Eta();
 	  float ex       = sqrt(cluster->get_error(0,0));
 	  float ey       = sqrt(cluster->get_error(1,1));
 	  float ez       = cluster->get_z_error();
@@ -1352,11 +1558,14 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
 	  float nparticles = clustereval->all_truth_particles(cluster).size();
 
-	  float cluster_data[39] = {(float) _ievent,
+	  float cluster_data[42] = {(float) _ievent,
 				    hitID,
 				    x,
 				    y,
 				    z,
+				    r,
+				    phi,
+				    eta,
 				    ex,
 				    ey,
 				    ez,


### PR DESCRIPTION
Add _do_eval_light option to reduce CPU time.
gntracksmaps will not be counted with _do_eval_light==true.