### PR TITLE
Tower-by-tower geometry for forward calorimeter evaluation

### DIFF
--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -549,11 +549,19 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
       if (tower->get_energy() < _reco_e_threshold) continue;
 
+      RawTowerGeom * tower_geom =  towergeom->get_tower_geometry(tower->get_id());
+      if (!tower_geom)
+      {
+        cerr << PHWHERE << " ERROR: Can't find tower geometry for this tower hit: "  ;
+        tower->identify();
+        exit(-1);
+      }
+
       float towerid = tower->get_id();
       float ieta = tower->get_bineta();
       float iphi = tower->get_binphi();
-      float eta = towergeom->get_etacenter(tower->get_bineta());
-      float phi = towergeom->get_phicenter(tower->get_binphi());
+      float eta = tower_geom->get_eta();
+      float phi = tower_geom->get_phi();
       float e = tower->get_energy();
 
       PHG4Particle* primary = towereval->max_truth_primary_particle_by_energy(tower);

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -15,6 +15,7 @@
 #include <calobase/RawClusterContainer.h>
 #include <calobase/RawClusterUtility.h>
 #include <calobase/RawTower.h>
+#include <calobase/RawTowerGeom.h>
 #include <calobase/RawTowerContainer.h>
 #include <calobase/RawTowerGeomContainer.h>
 
@@ -557,12 +558,12 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         exit(-1);
       }
 
-      float towerid = tower->get_id();
-      float ieta = tower->get_bineta();
-      float iphi = tower->get_binphi();
-      float eta = tower_geom->get_eta();
-      float phi = tower_geom->get_phi();
-      float e = tower->get_energy();
+      const float towerid = tower->get_id();
+      const float ieta = tower->get_bineta();
+      const float iphi = tower->get_binphi();
+      const float eta = tower_geom->get_eta();
+      const float phi = tower_geom->get_phi();
+      const float e = tower->get_energy();
 
       PHG4Particle* primary = towereval->max_truth_primary_particle_by_energy(tower);
 


### PR DESCRIPTION
Thanks to Jinlong Zhang for pointing out a warning message from the evaluation module of the forward caloriemters, which can not access the tower eta/phi row centers as they are only meaningful for the cylindrical calorimeters. 

Fixed this error for forward calorimeter by using more generic tower-by-tower geometry objects to access the tower eta and phi coordinates. 