### PR TITLE
Calorimeter dead tower simulation and recovery/masking in reconstruction

### DIFF
--- a/offline/packages/CaloBase/Makefile.am
+++ b/offline/packages/CaloBase/Makefile.am
@@ -23,6 +23,10 @@ libcalo_io_la_SOURCES = \
   RawTowerv1_Dict.cc \
   RawTowerContainer.cc \
   RawTowerContainer_Dict.cc \
+  RawTowerDeadMap.cc \
+  RawTowerDeadMap_Dict.cc \
+  RawTowerDeadMapv1.cc \
+  RawTowerDeadMapv1_Dict.cc \
   RawTowerGeom.cc \
   RawTowerGeom_Dict.cc \
   RawTowerGeomv1.cc \
@@ -74,6 +78,8 @@ pkginclude_HEADERS = \
   RawTowerDefs.h \
   RawTowerv1.h \
   RawTowerContainer.h  \
+  RawTowerDeadMap.h  \
+  RawTowerDeadMapv1.h  \
   RawTowerGeom.h \
   RawTowerGeomv1.h \
   RawTowerGeomv2.h \

--- a/offline/packages/CaloBase/RawCluster.h
+++ b/offline/packages/CaloBase/RawCluster.h
@@ -60,7 +60,7 @@ class RawCluster : public PHObject
     PHOOL_VIRTUAL_WARNING;
     return 0;
   }
-  virtual TowerConstRange get_towers()
+  virtual TowerConstRange get_towers() const
   {
     PHOOL_VIRTUAL_WARN("get_towers()");
     static TowerMap dummy;

--- a/offline/packages/CaloBase/RawClusterv1.h
+++ b/offline/packages/CaloBase/RawClusterv1.h
@@ -32,7 +32,7 @@ class RawClusterv1 : public RawCluster
   float get_energy() const { return _energy; }
   //! Tower operations
   size_t getNTowers() const { return towermap.size(); }
-  RawCluster::TowerConstRange get_towers() { return make_pair(towermap.begin(), towermap.end()); }
+  RawCluster::TowerConstRange get_towers() const { return make_pair(towermap.begin(), towermap.end()); }
   //! return tower map for c++11 range-based for-loop
   const TowerMap& get_towermap() const { return towermap; }
   //

--- a/offline/packages/CaloBase/RawTowerDeadMap.cc
+++ b/offline/packages/CaloBase/RawTowerDeadMap.cc
@@ -1,0 +1,53 @@
+#include "RawTowerDeadMap.h"
+#include <iostream>
+
+using namespace std;
+
+const RawTowerDeadMap::Map&
+RawTowerDeadMap::getDeadTowers(void) const
+{
+  static Map tmp_map;
+  return tmp_map;
+}
+
+RawTowerDeadMap::Map&
+RawTowerDeadMap::getDeadTowers(void)
+{
+  static Map tmp_map;
+  return tmp_map;
+}
+
+void RawTowerDeadMap::addDeadTower(const unsigned int ieta, const int unsigned iphi)
+{
+}
+
+void RawTowerDeadMap::addDeadTower(RawTowerDefs::keytype key)
+{
+}
+
+bool
+RawTowerDeadMap::isDeadTower(RawTowerDefs::keytype key)
+{
+  return false;
+}
+
+bool
+RawTowerDeadMap::isDeadTower(const unsigned int ieta, const unsigned int iphi)
+{
+  return false;
+}
+
+int RawTowerDeadMap::isValid() const
+{
+  return size()>0;
+}
+
+void RawTowerDeadMap::Reset()
+{
+}
+
+void RawTowerDeadMap::identify(std::ostream& os) const
+{
+  os << "RawTowerDeadMap" << std::endl;
+}
+

--- a/offline/packages/CaloBase/RawTowerDeadMap.h
+++ b/offline/packages/CaloBase/RawTowerDeadMap.h
@@ -1,0 +1,41 @@
+#ifndef RawTowerDeadMap_H__
+#define RawTowerDeadMap_H__
+
+#include "RawTowerDefs.h"
+
+#include <phool/PHObject.h>
+#include <set>
+
+class RawTowerDeadMap : public PHObject
+{
+ public:
+  typedef std::set<RawTowerDefs::keytype> Map;
+
+  virtual ~RawTowerDeadMap() {}
+  virtual void Reset();
+  virtual int isValid() const;
+
+  virtual void identify(std::ostream &os = std::cout) const;
+
+  virtual void setCalorimeterID(RawTowerDefs::CalorimeterId caloid) {}
+  virtual RawTowerDefs::CalorimeterId getCalorimeterID() { return RawTowerDefs::NONE; }
+  virtual void addDeadTower(const unsigned int ieta, const unsigned int iphi);
+  virtual void addDeadTower(RawTowerDefs::keytype key);
+
+  virtual bool isDeadTower(RawTowerDefs::keytype key);
+  virtual bool isDeadTower(const unsigned int ieta, const unsigned int iphi);
+  //! return all towers
+  virtual const Map &getDeadTowers(void) const;
+  virtual Map &getDeadTowers(void);
+
+  virtual unsigned int size() const { return 0; }
+ protected:
+  RawTowerDeadMap(RawTowerDefs::CalorimeterId caloid = RawTowerDefs::NONE)
+  {
+  }
+
+ private:
+  ClassDef(RawTowerDeadMap, 1)
+};
+
+#endif /* RawTowerDeadMap_H__ */

--- a/offline/packages/CaloBase/RawTowerDeadMapLinkDef.h
+++ b/offline/packages/CaloBase/RawTowerDeadMapLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RawTowerDeadMap+;
+
+#endif /* __CINT__ */

--- a/offline/packages/CaloBase/RawTowerDeadMapv1.cc
+++ b/offline/packages/CaloBase/RawTowerDeadMapv1.cc
@@ -1,0 +1,68 @@
+#include "RawTowerDeadMapv1.h"
+
+#include <iostream>
+
+using namespace std;
+
+const RawTowerDeadMapv1::Map&
+RawTowerDeadMapv1::getDeadTowers(void) const
+{
+  return m_DeadTowers;
+}
+
+RawTowerDeadMapv1::Map&
+RawTowerDeadMapv1::getDeadTowers(void)
+{
+  return m_DeadTowers;
+}
+
+void RawTowerDeadMapv1::addDeadTower(const unsigned int ieta, const int unsigned iphi)
+{
+  RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(_caloid, ieta, iphi);
+  m_DeadTowers.insert(key);
+}
+
+void RawTowerDeadMapv1::addDeadTower(RawTowerDefs::keytype key)
+{
+  if (RawTowerDefs::decode_caloid(key) != _caloid)
+  {
+    cout << "RawTowerDeadMapv1::addDeadTower - Error - adding tower to wrong container! Container CaloID = "
+         << _caloid << ", requested CaloID = " << RawTowerDefs::decode_caloid(key) << " based on key " << key << endl;
+    exit(2);
+  }
+  m_DeadTowers.insert(key);
+}
+
+bool
+RawTowerDeadMapv1::isDeadTower(RawTowerDefs::keytype key)
+{
+  auto it = m_DeadTowers.find(key);
+  if (it != m_DeadTowers.end())
+  {
+    return true;
+  }
+  return false;
+}
+
+bool
+RawTowerDeadMapv1::isDeadTower(const unsigned int ieta, const unsigned int iphi)
+{
+  RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(_caloid, ieta, iphi);
+  return isDeadTower(key);
+}
+
+int RawTowerDeadMapv1::isValid() const
+{
+  return size()>0;
+}
+
+void RawTowerDeadMapv1::Reset()
+{
+  m_DeadTowers.clear();
+}
+
+void RawTowerDeadMapv1::identify(std::ostream& os) const
+{
+  os << "RawTowerDeadMapv1, number of towers: " << size() << std::endl;
+}
+

--- a/offline/packages/CaloBase/RawTowerDeadMapv1.h
+++ b/offline/packages/CaloBase/RawTowerDeadMapv1.h
@@ -1,0 +1,40 @@
+#ifndef RawTowerDeadMapv1_H__
+#define RawTowerDeadMapv1_H__
+
+#include "RawTowerDeadMap.h"
+
+class RawTowerDeadMapv1 : public RawTowerDeadMap
+{
+ public:
+
+  RawTowerDeadMapv1(RawTowerDefs::CalorimeterId caloid = RawTowerDefs::NONE)
+    : _caloid(caloid)
+  {
+  }
+  virtual ~RawTowerDeadMapv1() {}
+  virtual void Reset();
+  virtual int isValid() const;
+
+  virtual void identify(std::ostream &os = std::cout) const;
+
+  virtual void setCalorimeterID(RawTowerDefs::CalorimeterId caloid) { _caloid = caloid; }
+  virtual RawTowerDefs::CalorimeterId getCalorimeterID() { return _caloid; }
+  virtual void addDeadTower(const unsigned int ieta, const unsigned int iphi);
+  virtual void addDeadTower(RawTowerDefs::keytype key);
+
+  virtual bool isDeadTower(RawTowerDefs::keytype key);
+  virtual bool isDeadTower(const unsigned int ieta, const unsigned int iphi);
+  //! return all towers
+  virtual const Map &getDeadTowers(void) const;
+  virtual Map &getDeadTowers(void);
+
+  virtual unsigned int size() const { return m_DeadTowers.size(); }
+
+ private:
+  RawTowerDefs::CalorimeterId _caloid;
+  Map m_DeadTowers;
+
+  ClassDef(RawTowerDeadMapv1, 1)
+};
+
+#endif /* RawTowerDeadMapv1_H__ */

--- a/offline/packages/CaloBase/RawTowerDeadMapv1LinkDef.h
+++ b/offline/packages/CaloBase/RawTowerDeadMapv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RawTowerDeadMapv1+;
+
+#endif /* __CINT__ */

--- a/offline/packages/CaloBase/RawTowerGeom.h
+++ b/offline/packages/CaloBase/RawTowerGeom.h
@@ -19,6 +19,11 @@ class RawTowerGeom : public PHObject {
   virtual void set_id(RawTowerDefs::keytype key)  { PHOOL_VIRTUAL_WARN("set_id()");  }
   virtual RawTowerDefs::keytype get_id() const { PHOOL_VIRTUAL_WARN("get_id()"); return 0; }
 
+  virtual int get_bineta() const { PHOOL_VIRTUAL_WARN("get_ieta()"); return -1; }
+  virtual int get_binphi() const { PHOOL_VIRTUAL_WARN("get_iphi()"); return -1; }
+  virtual int get_column() const { PHOOL_VIRTUAL_WARN("get_column()"); return -1; }
+  virtual int get_row() const { PHOOL_VIRTUAL_WARN("get_row()"); return -1; }
+
   virtual void set_center_x( double ) { PHOOL_VIRTUAL_WARN("set_center_x()"); return ; }
   virtual void set_center_y( double ) { PHOOL_VIRTUAL_WARN("set_center_y()"); return ; }
   virtual void set_center_z( double ) { PHOOL_VIRTUAL_WARN("set_center_z()"); return ; }

--- a/offline/packages/CaloBase/RawTowerGeomv1.cc
+++ b/offline/packages/CaloBase/RawTowerGeomv1.cc
@@ -47,6 +47,5 @@ double RawTowerGeomv1::get_phi() const
 
 void RawTowerGeomv1::identify(std::ostream& os) const
 {
-  os << "RawTowerGeomv1:  x: " << get_center_x() << "  y: " << get_center_y() << "  z: " << get_center_z()
-	    << "\n           dx: " << get_size_x() << " dy: " << get_size_y() << " dz: " << get_size_z() << std::endl;
+  os << "RawTowerGeomv1:  x: " << get_center_x() << "  y: " << get_center_y() << "  z: " << get_center_z() << std::endl;
 }

--- a/offline/packages/CaloBase/RawTowerGeomv1.h
+++ b/offline/packages/CaloBase/RawTowerGeomv1.h
@@ -15,6 +15,11 @@ class RawTowerGeomv1 : public RawTowerGeom {
   void set_id(RawTowerDefs::keytype key) {_towerid = key;}
   RawTowerDefs::keytype get_id() const { return _towerid;}
 
+  int get_bineta() const { return RawTowerDefs::decode_index1(_towerid); }
+  int get_binphi() const { return RawTowerDefs::decode_index2(_towerid); }
+  int get_column() const { return RawTowerDefs::decode_index1(_towerid); }
+  int get_row() const { return RawTowerDefs::decode_index2(_towerid); }
+
   void set_center_x( double x ) { _center_x = x; return ; }
   void set_center_y( double y ) { _center_y = y; return ; }
   void set_center_z( double z ) { _center_z = z; return ; }

--- a/offline/packages/CaloBase/RawTowerGeomv2.h
+++ b/offline/packages/CaloBase/RawTowerGeomv2.h
@@ -15,6 +15,11 @@ class RawTowerGeomv2 : public RawTowerGeom {
   void set_id(RawTowerDefs::keytype key) {_towerid = key;}
   RawTowerDefs::keytype get_id() const { return _towerid;}
 
+  int get_bineta() const { return RawTowerDefs::decode_index1(_towerid); }
+  int get_binphi() const { return RawTowerDefs::decode_index2(_towerid); }
+  int get_column() const { return RawTowerDefs::decode_index1(_towerid); }
+  int get_row() const { return RawTowerDefs::decode_index2(_towerid); }
+
   void set_center_x( double x ) { _center_x = x; return ; }
   void set_center_y( double y ) { _center_y = y; return ; }
   void set_center_z( double z ) { _center_z = z; return ; }

--- a/offline/packages/CaloBase/RawTowerGeomv3.h
+++ b/offline/packages/CaloBase/RawTowerGeomv3.h
@@ -15,6 +15,11 @@ class RawTowerGeomv3 : public RawTowerGeom {
   void set_id(RawTowerDefs::keytype key) {_towerid = key;}
   RawTowerDefs::keytype get_id() const { return _towerid;}
 
+  int get_bineta() const { return RawTowerDefs::decode_index1(_towerid); }
+  int get_binphi() const { return RawTowerDefs::decode_index2(_towerid); }
+  int get_column() const { return RawTowerDefs::decode_index1(_towerid); }
+  int get_row() const { return RawTowerDefs::decode_index2(_towerid); }
+
   void set_center_x( double x ) { _center_x = x; return ; }
   void set_center_y( double y ) { _center_y = y; return ; }
   void set_center_z( double z ) { _center_z = z; return ; }

--- a/offline/packages/CaloReco/Makefile.am
+++ b/offline/packages/CaloReco/Makefile.am
@@ -22,6 +22,8 @@ libcalo_reco_la_SOURCES = \
   RawClusterBuilderFwd_Dict.cc \
   RawClusterPositionCorrection.cc \
   RawClusterPositionCorrection_Dict.cc \
+  RawClusterDeadAreaMask.cc \
+  RawClusterDeadAreaMask_Dict.cc \
   RawTowerCombiner.cc \
   RawTowerCombiner_Dict.cc \
   RawTowerCalibration.cc \

--- a/offline/packages/CaloReco/Makefile.am
+++ b/offline/packages/CaloReco/Makefile.am
@@ -26,6 +26,8 @@ libcalo_reco_la_SOURCES = \
   RawTowerCombiner_Dict.cc \
   RawTowerCalibration.cc \
   RawTowerCalibration_Dict.cc \
+  RawTowerDeadTowerInterp.cc \
+  RawTowerDeadTowerInterp_Dict.cc \
   BEmcCluster.cc \
   BEmcRec.cc \
   BEmcRecCEMC.cc \

--- a/offline/packages/CaloReco/Makefile.am
+++ b/offline/packages/CaloReco/Makefile.am
@@ -30,7 +30,9 @@ libcalo_reco_la_SOURCES = \
   BEmcRec.cc \
   BEmcRecCEMC.cc \
   BEmcRecFEMC.cc \
-  BEmcRecEEMC.cc
+  BEmcRecEEMC.cc \
+  RawTowerDeadMapLoader.cc \
+  RawTowerDeadMapLoader_Dict.cc
 
 libcalo_reco_la_LDFLAGS = \
   -L$(libdir) \

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
@@ -394,8 +394,18 @@ void RawClusterBuilderTemplate::CreateNodes(PHCompositeNode *topNode)
       throw std::runtime_error("Failed to find DST node in EmcRawTowerBuilder::CreateNodes");
     }
 
+  //Get the _det_name subnode
+  PHCompositeNode *cemcNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", detector));
+
+  //Check that it is there
+  if (!cemcNode)
+  {
+    cemcNode = new PHCompositeNode(detector);
+    dstNode->addNode(cemcNode);
+  }
+
   _clusters = new RawClusterContainer();
   ClusterNodeName = "CLUSTER_" + detector;
   PHIODataNode<PHObject> *clusterNode = new PHIODataNode<PHObject>(_clusters, ClusterNodeName.c_str(), "PHObject");
-  dstNode->addNode(clusterNode);
+  cemcNode->addNode(clusterNode);
 }

--- a/offline/packages/CaloReco/RawClusterDeadAreaMask.cc
+++ b/offline/packages/CaloReco/RawClusterDeadAreaMask.cc
@@ -48,7 +48,7 @@ int RawClusterDeadAreaMask::process_event(PHCompositeNode *topNode)
   {
     cout << Name() << "::" << m_detector << "::process_event - Entry" << endl;
   }
-  const int nMasked = 0;
+  int nMasked = 0;
 
   const int eta_bins = m_geometry->get_etabins();
   const int phi_bins = m_geometry->get_phibins();
@@ -133,6 +133,7 @@ int RawClusterDeadAreaMask::process_event(PHCompositeNode *topNode)
     bool rejecCluster = false;
 
     for (int search_eta = ceil(avgeta - m_deadTowerMaskHalfWidth); search_eta <= floor(avgeta + m_deadTowerMaskHalfWidth); ++search_eta)
+    {
       for (int search_phi = ceil(avgphi - m_deadTowerMaskHalfWidth); search_phi <= floor(avgphi + m_deadTowerMaskHalfWidth); ++search_phi)
       {
         int ieta = search_eta;
@@ -162,6 +163,9 @@ int RawClusterDeadAreaMask::process_event(PHCompositeNode *topNode)
           break;
         }
       }
+
+      if (rejecCluster) break;
+    }
 
     //container operation
     if (rejecCluster)

--- a/offline/packages/CaloReco/RawClusterDeadAreaMask.cc
+++ b/offline/packages/CaloReco/RawClusterDeadAreaMask.cc
@@ -1,0 +1,249 @@
+#include "RawClusterDeadAreaMask.h"
+
+#include <calobase/RawCluster.h>
+#include <calobase/RawClusterContainer.h>
+#include <calobase/RawClusterv1.h>
+#include <calobase/RawTower.h>
+#include <calobase/RawTowerContainer.h>
+#include <calobase/RawTowerDeadMap.h>
+#include <calobase/RawTowerGeomContainer.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <cassert>
+#include <cfloat>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using namespace std;
+
+RawClusterDeadAreaMask::RawClusterDeadAreaMask(const std::string &name)
+  : SubsysReco(name)
+  , m_detector("NONE")
+  , m_deadTowerMaskHalfWidth(1.6)
+  , m_rawClusters(nullptr)
+  , m_deadMap(nullptr)
+  , m_calibTowers(nullptr)
+  , m_geometry(nullptr)
+{
+}
+
+int RawClusterDeadAreaMask::InitRun(PHCompositeNode *topNode)
+{
+  CreateNodeTree(topNode);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int RawClusterDeadAreaMask::process_event(PHCompositeNode *topNode)
+{
+  if (verbosity)
+  {
+    std::cout << "Processing a NEW EVENT" << std::endl;
+  }
+  const int eta_bins = m_geometry->get_etabins();
+  const int phi_bins = m_geometry->get_phibins();
+
+  assert(eta_bins > 0);
+  assert(phi_bins > 0);
+
+  //loop over the clusters
+  RawClusterContainer::ConstRange begin_end = m_rawClusters->getClusters();
+  RawClusterContainer::ConstIterator iter;
+
+  for (iter = begin_end.first; iter != begin_end.second;)
+  {
+    //    RawClusterDefs::keytype key = iter->first;
+    const RawCluster *cluster = iter->second;
+
+    std::vector<float> toweretas;
+    std::vector<float> towerphis;
+    std::vector<float> towerenergies;
+
+    //loop over the towers in the cluster
+    RawCluster::TowerConstRange towers = cluster->get_towers();
+    RawCluster::TowerConstIterator toweriter;
+
+    for (toweriter = towers.first;
+         toweriter != towers.second;
+         ++toweriter)
+    {
+      RawTower *tower = m_calibTowers->getTower(toweriter->first);
+      assert(tower);
+
+      int towereta = tower->get_bineta();
+      int towerphi = tower->get_binphi();
+      double towerenergy = tower->get_energy();
+
+      //put the etabin, phibin, and energy into the corresponding vectors
+      toweretas.push_back(towereta);
+      towerphis.push_back(towerphi);
+      towerenergies.push_back(towerenergy);
+    }
+
+    int ntowers = toweretas.size();
+    assert(ntowers >= 1);
+
+    //loop over the towers to determine the energy
+    //weighted eta and phi position of the cluster
+
+    float etamult = 0;
+    float etasum = 0;
+    float phimult = 0;
+    float phisum = 0;
+
+    for (int j = 0; j < ntowers; j++)
+    {
+      float energymult = towerenergies.at(j) * toweretas.at(j);
+      etamult += energymult;
+      etasum += towerenergies.at(j);
+
+      int phibin = towerphis.at(j);
+
+      if (phibin - towerphis.at(0) < -phi_bins / 2.0)
+        phibin += phi_bins;
+      else if (phibin - towerphis.at(0) > +phi_bins / 2.0)
+        phibin -= phi_bins;
+      assert(abs(phibin - towerphis.at(0)) <= phi_bins / 2.0);
+
+      energymult = towerenergies.at(j) * phibin;
+      phimult += energymult;
+      phisum += towerenergies.at(j);
+    }
+
+    float avgphi = phimult / phisum;
+    float avgeta = etamult / etasum;
+
+    if (Verbosity() > VERBOSITY_MORE)
+    {
+      cout << Name() << "::" << m_detector << "::process_event - "
+           << "process cluster at average location " << avgeta << "," << avgphi << " : ";
+      cluster->identify();
+    }
+
+    // rejection if close to a dead tower
+    bool rejecCluster = false;
+
+    for (int search_eta = ceil(avgeta - m_deadTowerMaskHalfWidth); search_eta <= floor(avgeta + m_deadTowerMaskHalfWidth); ++search_eta)
+      for (int search_phi = ceil(avgphi - m_deadTowerMaskHalfWidth); search_phi <= floor(avgphi + m_deadTowerMaskHalfWidth); ++search_phi)
+      {
+        int ieta = search_eta;
+        int iphi = search_phi;
+
+        if (ieta >= eta_bins) continue;
+        if (ieta < 0) continue;
+
+        if (iphi >= phi_bins) iphi -= phi_bins;
+        if (iphi < 0) iphi += phi_bins;
+
+        const bool isDead = m_deadMap->isDeadTower(ieta, iphi);
+
+        // dead tower found in cluster
+        if (Verbosity() > VERBOSITY_MORE)
+        {
+          cout << "\t"
+               << "tower " << ieta
+               << "," << iphi
+               << (isDead ? ": is dead." : "OK")
+               << endl;
+        }
+
+        if (isDead)
+        {
+          rejecCluster = true;
+          break;
+        }
+      }
+
+    //container operation
+    if (rejecCluster)
+    {
+      if (Verbosity() > VERBOSITY_MORE)
+      {
+        cout << Name() << "::" << m_detector << "::process_event - "
+             << "reject cluster " << cluster->get_id() << endl;
+        cluster->identify();
+      }
+      m_rawClusters->getClustersMap().erase(iter++);
+    }
+    else
+    {
+      if (Verbosity() > VERBOSITY_MORE)
+      {
+        cout << Name() << "::" << m_detector << "::process_event - "
+             << "keep cluster " << cluster->get_id() << endl;
+      }
+      ++iter;
+    }
+
+  }  //  for (iter = begin_end.first; iter != begin_end.second;)
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void RawClusterDeadAreaMask::CreateNodeTree(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+
+  //Get the DST Node
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+
+  //Check that it is there
+  if (!dstNode)
+  {
+    std::cerr << "DST Node missing, quitting" << std::endl;
+    throw std::runtime_error("failed to find DST node in RawClusterDeadAreaMask::CreateNodeTree");
+  }
+
+  m_rawClusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_" + m_detector);
+  if (!m_rawClusters)
+  {
+    cout << Name() << "::" << m_detector << "::"
+         << "CreateNodeTree "
+            "No "
+         << m_detector << " Cluster Container found while in RawClusterDeadAreaMask, can't proceed!!!" << std::endl;
+    topNode->print();
+    throw std::runtime_error("failed to find CLUSTER node in RawClusterDeadAreaMask::CreateNodeTree");
+  }
+
+  m_calibTowers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_" + m_detector);
+  if (!m_calibTowers)
+  {
+    cout << Name() << "::" << m_detector << "::"
+         << "CreateNodeTree "
+         << "No calibrated " << m_detector << " tower info found while in RawClusterDeadAreaMask, can't proceed!!!" << std::endl;
+    throw std::runtime_error("failed to find TOWER_CALIB node in RawClusterDeadAreaMask::CreateNodeTree");
+  }
+
+  string towergeomnodename = "TOWERGEOM_" + m_detector;
+  m_geometry = findNode::getClass<RawTowerGeomContainer>(topNode, towergeomnodename.c_str());
+  if (!m_geometry)
+  {
+    cout << Name() << "::" << m_detector << "::"
+         << "CreateNodeTree"
+         << ": Could not find node " << towergeomnodename.c_str() << endl;
+    throw std::runtime_error("failed to find TOWERGEOM node in RawClusterDeadAreaMask::CreateNodeTree");
+  }
+
+  const string deadMapName = "DEADMAP_" + m_detector;
+  m_deadMap = findNode::getClass<RawTowerDeadMap>(topNode, deadMapName);
+  if (m_deadMap)
+  {
+    cout << Name() << "::" << m_detector << "::"
+         << "CreateNodeTree"
+         << " use dead map: ";
+    m_deadMap->identify();
+  }
+}
+
+int RawClusterDeadAreaMask::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/CaloReco/RawClusterDeadAreaMask.cc
+++ b/offline/packages/CaloReco/RawClusterDeadAreaMask.cc
@@ -44,13 +44,14 @@ int RawClusterDeadAreaMask::InitRun(PHCompositeNode *topNode)
 
 int RawClusterDeadAreaMask::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity)
+  if (Verbosity() >= VERBOSITY_SOME)
   {
-    std::cout << "Processing a NEW EVENT" << std::endl;
+    cout << Name() << "::" << m_detector << "::process_event - Entry" << endl;
   }
+  const int nMasked = 0;
+
   const int eta_bins = m_geometry->get_etabins();
   const int phi_bins = m_geometry->get_phibins();
-
   assert(eta_bins > 0);
   assert(phi_bins > 0);
 
@@ -171,6 +172,8 @@ int RawClusterDeadAreaMask::process_event(PHCompositeNode *topNode)
              << "reject cluster " << cluster->get_id() << endl;
         cluster->identify();
       }
+
+      ++nMasked;
       m_rawClusters->getClustersMap().erase(iter++);
     }
     else
@@ -185,6 +188,13 @@ int RawClusterDeadAreaMask::process_event(PHCompositeNode *topNode)
 
   }  //  for (iter = begin_end.first; iter != begin_end.second;)
 
+  if (Verbosity() >= VERBOSITY_SOME)
+  {
+    cout << Name() << "::" << m_detector << "::process_event - masked "
+         << nMasked << " clusters. Final cluster containers has "
+         << m_rawClusters->size() << " clusters"
+         << endl;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/CaloReco/RawClusterDeadAreaMask.h
+++ b/offline/packages/CaloReco/RawClusterDeadAreaMask.h
@@ -1,0 +1,48 @@
+#ifndef __RawClusterDeadAreaMask_H__
+#define __RawClusterDeadAreaMask_H__
+
+#include <fun4all/SubsysReco.h>
+#include <phool/PHObject.h>
+#include <phparameter/PHParameters.h>
+#include <string>
+
+class RawClusterContainer;
+class RawTowerContainer;
+class RawTowerGeomContainer;
+class RawTowerDeadMap;
+
+class RawClusterDeadAreaMask : public SubsysReco
+{
+ public:
+  explicit RawClusterDeadAreaMask(const std::string &name = "RawClusterDeadAreaMask");
+
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  //! half width of the dead area around the center of a dead tower, if cluster center fall into this region it is rejected.
+  void deadTowerMaskHalfWidth(double deadTowerMaskHalfWidth)
+  {
+    m_deadTowerMaskHalfWidth = deadTowerMaskHalfWidth;
+  }
+
+  void detector(const std::string &detector)
+  {
+    m_detector = detector;
+  }
+
+ private:
+  void CreateNodeTree(PHCompositeNode *topNode);
+
+  std::string m_detector;
+
+  //! half width of the dead area around the center of a dead tower, if cluster center fall into this region it is rejected.
+  double m_deadTowerMaskHalfWidth;
+
+  RawClusterContainer *m_rawClusters;
+  RawTowerDeadMap *m_deadMap;
+  RawTowerContainer *m_calibTowers;
+  RawTowerGeomContainer *m_geometry;
+};
+
+#endif  // __RawClusterDeadAreaMask_H__

--- a/offline/packages/CaloReco/RawClusterDeadAreaMaskLinkDef.h
+++ b/offline/packages/CaloReco/RawClusterDeadAreaMaskLinkDef.h
@@ -1,0 +1,3 @@
+#ifdef __CINT__
+#pragma link C++ class RawClusterDeadAreaMask-!;
+#endif

--- a/offline/packages/CaloReco/RawClusterPositionCorrection.cc
+++ b/offline/packages/CaloReco/RawClusterPositionCorrection.cc
@@ -35,7 +35,7 @@ RawClusterPositionCorrection::RawClusterPositionCorrection(const std::string &na
   SetDefaultParameters(_ecore_calib_params);
 }
 
-int RawClusterPositionCorrection::Init(PHCompositeNode *topNode)
+int RawClusterPositionCorrection::InitRun(PHCompositeNode *topNode)
 {
   CreateNodeTree(topNode);
 

--- a/offline/packages/CaloReco/RawClusterPositionCorrection.h
+++ b/offline/packages/CaloReco/RawClusterPositionCorrection.h
@@ -17,7 +17,7 @@ class RawClusterPositionCorrection : public SubsysReco
  public:
   explicit RawClusterPositionCorrection(const std::string &name);
 
-  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 

--- a/offline/packages/CaloReco/RawTowerDeadMapLoader.cc
+++ b/offline/packages/CaloReco/RawTowerDeadMapLoader.cc
@@ -1,0 +1,179 @@
+// $Id: $
+
+/*!
+ * \file RawTowerDeadMapLoader.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "RawTowerDeadMapLoader.h"
+
+#include <calobase/RawTowerDeadMapv1.h>
+#include <phparameter/PHParameters.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/getClass.h>
+
+// boost headers
+#include <boost/foreach.hpp>
+#include <boost/tokenizer.hpp>
+// this is an ugly hack, the gcc optimizer has a bug which
+// triggers the uninitialized variable warning which
+// stops compilation because of our -Werror
+#include <boost/version.hpp>  // to get BOOST_VERSION
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700)
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma message "ignoring bogus gcc warning in boost header lexical_cast.hpp"
+#include <boost/lexical_cast.hpp>
+#pragma GCC diagnostic warning "-Wuninitialized"
+#else
+#include <boost/lexical_cast.hpp>
+#endif
+
+#include <cassert>
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <string>
+
+using namespace std;
+
+RawTowerDeadMapLoader::RawTowerDeadMapLoader(const std::string &detector)
+  : SubsysReco("RawTowerDeadMapLoader_" + detector)
+  , m_detector(detector)
+  , m_deadmap(nullptr)
+{
+}
+
+RawTowerDeadMapLoader::~RawTowerDeadMapLoader()
+{
+}
+
+int RawTowerDeadMapLoader::InitRun(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *runNode = static_cast<PHCompositeNode *>(iter.findFirst(
+      "PHCompositeNode", "RUN"));
+  if (!runNode)
+  {
+    std::cerr << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
+              << "Run Node missing, doing nothing." << std::endl;
+    throw std::runtime_error(
+        "Failed to find Run node in RawTowerCalibration::CreateNodes");
+  }
+
+  // Create the tower nodes on the tree
+  PHNodeIterator dstiter(runNode);
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst(
+      "PHCompositeNode", m_detector));
+  if (!DetNode)
+  {
+    DetNode = new PHCompositeNode(m_detector);
+    runNode->addNode(DetNode);
+  }
+
+  // Be careful as a previous calibrator may have been registered for this detector
+  string deadMapName = "DEADMAP_" + m_detector;
+  RawTowerDeadMap *m_deadmap = findNode::getClass<RawTowerDeadMapv1>(DetNode, deadMapName);
+  if (!m_deadmap)
+  {
+    const RawTowerDefs::CalorimeterId caloid = RawTowerDefs::convert_name_to_caloid(m_detector);
+
+    m_deadmap = new RawTowerDeadMapv1(caloid);
+    PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(
+        m_deadmap, deadMapName, "PHObject");
+    DetNode->addNode(towerNode);
+  }
+
+  assert(m_deadmap);
+
+  cout << "RawTowerDeadMapLoader::" << m_detector << "::InitRun - loading dead map from " << m_deadMapPath << endl;
+
+  PHParameters deadMapParam(m_detector);
+  deadMapParam.ReadFromFile("CEMC", "xml", 0, 0, m_deadMapPath);
+
+  const auto in_par_ranges = deadMapParam.get_all_int_params();
+
+  for (auto iter = in_par_ranges.first; iter != in_par_ranges.second; ++iter)
+  {
+    const string &deadChanName = iter->first;
+
+    if (Verbosity())
+    {
+      cout << "deadMapParam[" << deadChanName << "] = " << iter->second << ": ";
+    }
+
+    boost::char_separator<char> sep("_");
+    boost::tokenizer<boost::char_separator<char> > tok(deadChanName, sep);
+    boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
+
+    for (tokeniter = tok.begin(); tokeniter != tok.end(); ++tokeniter)
+    {
+      if (*tokeniter == "deadtower")
+      {
+        // Form("deadtower_eta_%d_phi_%d", eta, phi)
+
+        ++tokeniter;
+        assert(tokeniter != tok.end());
+
+        if (*tokeniter == "eta")
+        {
+          ++tokeniter;
+          assert(tokeniter != tok.end());
+          const int eta = boost::lexical_cast<int>(*tokeniter);
+
+          ++tokeniter;
+          assert(tokeniter != tok.end());
+          assert(*tokeniter == "phi");
+
+          ++tokeniter;
+          assert(tokeniter != tok.end());
+          const int phi = boost::lexical_cast<int>(*tokeniter);
+
+          m_deadmap->addDeadTower(eta, phi);
+
+          if (Verbosity())
+          {
+            cout << "add dead channel eta" << eta << " phi" << phi;
+          }
+        } // if (*tokeniter == "eta")
+        else
+        {
+          if (Verbosity())
+          {
+            cout << "skip " << deadChanName;
+          }
+        }
+
+      }  //      if (*tokeniter == "deadtower")
+      else
+      {
+        if (Verbosity())
+        {
+          cout << "skip " << deadChanName;
+        }
+      }
+
+    }  //     for (tokeniter = tok.begin(); tokeniter != tok.end(); ++tokeniter)
+
+    if (Verbosity())
+    {
+      cout << endl;
+    }
+
+  }  //  for (const auto iter = in_par_ranges.first; iter != in_par_ranges.second; ++iter)
+
+  if (Verbosity())
+  {
+
+    cout << "RawTowerDeadMapLoader::" << m_detector << "::InitRun - loading dead map completed : " ;
+    m_deadmap->identify();
+
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/CaloReco/RawTowerDeadMapLoader.cc
+++ b/offline/packages/CaloReco/RawTowerDeadMapLoader.cc
@@ -95,7 +95,7 @@ int RawTowerDeadMapLoader::InitRun(PHCompositeNode *topNode)
   cout << "RawTowerDeadMapLoader::" << m_detector << "::InitRun - loading dead map from " << m_deadMapPath << endl;
 
   PHParameters deadMapParam(m_detector);
-  deadMapParam.ReadFromFile("CEMC", "xml", 0, 0, m_deadMapPath);
+  deadMapParam.ReadFromFile(m_detector, "xml", 0, 0, m_deadMapPath);
 
   const auto in_par_ranges = deadMapParam.get_all_int_params();
 

--- a/offline/packages/CaloReco/RawTowerDeadMapLoader.h
+++ b/offline/packages/CaloReco/RawTowerDeadMapLoader.h
@@ -1,0 +1,59 @@
+// $Id: $
+
+/*!
+ * \file RawTowerDeadMapLoader.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef SIMULATION_CORESOFTWARE_SIMULATION_G4SIMULATION_G4CEMC_RawTowerDeadMapLoader_H_
+#define SIMULATION_CORESOFTWARE_SIMULATION_G4SIMULATION_G4CEMC_RawTowerDeadMapLoader_H_
+
+#include <fun4all/SubsysReco.h>
+#include <string>
+
+class RawTowerDeadMap;
+
+
+/*!
+ * \brief RawTowerDeadMapLoader loads dead map at inti run
+ */
+class RawTowerDeadMapLoader : public SubsysReco
+{
+ public:
+  RawTowerDeadMapLoader(const std::string& detector);
+
+  virtual ~RawTowerDeadMapLoader();
+
+  virtual int InitRun(PHCompositeNode *topNode);
+
+  const std::string& deadMapPath() const
+  {
+    return m_deadMapPath;
+  }
+
+  void deadMapPath(const std::string& deadMapPath)
+  {
+    m_deadMapPath = deadMapPath;
+  }
+
+  const std::string& detector() const
+  {
+    return m_detector;
+  }
+
+  void detector(const std::string& detector)
+  {
+    m_detector = detector;
+  }
+
+ private:
+  std::string m_detector;
+  std::string m_deadMapPath;
+
+  RawTowerDeadMap * m_deadmap;
+};
+
+#endif /* SIMULATION_CORESOFTWARE_SIMULATION_G4SIMULATION_G4CEMC_RawTowerDeadMapLoader_H_ */

--- a/offline/packages/CaloReco/RawTowerDeadMapLoaderLinkDef.h
+++ b/offline/packages/CaloReco/RawTowerDeadMapLoaderLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RawTowerDeadMapLoader-!;
+
+#endif /* __CINT__ */

--- a/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
+++ b/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
@@ -68,6 +68,7 @@ int RawTowerDeadTowerInterp::process_event(PHCompositeNode *topNode)
 
   double recovery_energy = 0;
   int recoverTower = 0;
+  int deadTowerCnt = 0;
 
   if (m_deadTowerMap)
   {
@@ -80,6 +81,8 @@ int RawTowerDeadTowerInterp::process_event(PHCompositeNode *topNode)
 
     for (const RawTowerDefs::keytype &key : m_deadTowerMap->getDeadTowers())
     {
+      ++deadTowerCnt;
+
       if (Verbosity() >= VERBOSITY_MORE)
       {
         std::cout << Name() << "::" << m_detector << "::"
@@ -135,6 +138,8 @@ int RawTowerDeadTowerInterp::process_event(PHCompositeNode *topNode)
 
         if (m_deadTowerMap->isDeadTower(ieta, iphi)) continue;
 
+        ++n_neighbor;
+
         assert(m_calibTowers);
         RawTower *neighTower =
             m_calibTowers->getTower(ieta, iphi);
@@ -146,11 +151,10 @@ int RawTowerDeadTowerInterp::process_event(PHCompositeNode *topNode)
         }
 
         E_SumNeighbor += neighTower->get_energy();
-        ++n_neighbor;
 
       }  // for (const pair<int, int> &neighborIndex : neighborIndexs)
 
-      if (n_neighbor > 0)
+      if (n_neighbor > 0 and E_SumNeighbor != 0)
       {
         RawTower *deadTower = m_calibTowers->getTower(key);
 
@@ -208,9 +212,9 @@ int RawTowerDeadTowerInterp::process_event(PHCompositeNode *topNode)
     std::cout << Name() << "::" << m_detector << "::"
               << "process_event"
               << "recovery_energy = " << recovery_energy
-              <<" from "<<recoverTower<<" towers"
+              <<" GeV from "<<recoverTower<<" towers out of total "<<deadTowerCnt<<" dead towers"
               << ", output sum energy = "
-              << m_calibTowers->getTotalEdep() << std::endl;
+              << m_calibTowers->getTotalEdep() <<" GeV"<< std::endl;
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
+++ b/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
@@ -1,0 +1,287 @@
+#include "RawTowerDeadTowerInterp.h"
+
+#include <calobase/RawTowerContainer.h>
+#include <calobase/RawTowerDeadMap.h>
+#include <calobase/RawTowerGeom.h>
+#include <calobase/RawTowerGeomContainer.h>
+#include <calobase/RawTowerv1.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/getClass.h>
+
+#include <cassert>
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <string>
+
+using namespace std;
+
+RawTowerDeadTowerInterp::RawTowerDeadTowerInterp(const std::string &name)
+  : SubsysReco(name)
+  , m_calibTowers(nullptr)
+  , m_geometry(nullptr)
+  , m_deadTowerMap(nullptr)
+  , m_detector("NONE")
+  , _calib_tower_node_prefix("CALIB")
+{
+}
+
+int RawTowerDeadTowerInterp::InitRun(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode;
+  dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode",
+                                                           "DST"));
+  if (!dstNode)
+  {
+    cout << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
+              << "DST Node missing, doing nothing." << std::endl;
+    exit(1);
+  }
+
+  try
+  {
+    CreateNodes(topNode);
+  }
+  catch (std::exception &e)
+  {
+    std::cout << e.what() << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int RawTowerDeadTowerInterp::process_event(PHCompositeNode *topNode)
+{
+  if (Verbosity())
+  {
+    std::cout << Name() << "::" << m_detector << "::"
+              << "process_event"
+              << "Process event entered" << std::endl;
+  }
+
+  double recovery_energy = 0;
+  int recoverTower = 0;
+
+  if (m_deadTowerMap)
+  {
+    const int eta_bins = m_geometry->get_etabins();
+    const int phi_bins = m_geometry->get_phibins();
+
+    // assume cylindrical calorimeters for now. Need to add swithc for planary calorimeter
+    assert(eta_bins > 0);
+    assert(phi_bins > 0);
+
+    for (const RawTowerDefs::keytype &key : m_deadTowerMap->getDeadTowers())
+    {
+      if (Verbosity() >= VERBOSITY_MORE)
+      {
+        std::cout << Name() << "::" << m_detector << "::"
+                  << "process_event"
+                  << " - processing tower " << key;
+      }
+
+      // check deadmap validity
+      RawTowerGeom *towerGeom = m_geometry->get_tower_geometry(key);
+      if (towerGeom == nullptr)
+      {
+        std::cerr << Name() << "::" << m_detector << "::"
+                  << "process_event"
+                  << " - invalid dead tower ID " << key << endl;
+
+        exit(2);
+      }
+
+      const int bineta = towerGeom->get_bineta();
+      const int binphi = towerGeom->get_binphi();
+
+      if (Verbosity() >= VERBOSITY_MORE)
+      {
+        cout << " bin " << bineta << "-" << binphi;
+        cout << ". Add neighbors ";
+      }
+
+      assert(bineta >= 0);
+      assert(bineta <= eta_bins);
+      assert(binphi >= 0);
+      assert(binphi <= phi_bins);
+
+      // eight neighbors
+      static const vector<pair<int, int>> neighborIndexs =
+          {{+1, 0}, {+1, +1}, {0, +1}, {-1, +1}, {-1, 0}, {-1, -1}, {0, -1}, {+1, -1}};
+
+      int n_neighbor = 0;
+      double E_SumNeighbor = 0;
+      for (const pair<int, int> &neighborIndex : neighborIndexs)
+      {
+        int ieta = bineta + neighborIndex.first;
+        int iphi = binphi + neighborIndex.second;
+
+        if (ieta >= eta_bins) ieta -= eta_bins;
+        if (iphi >= phi_bins) iphi -= phi_bins;
+        if (ieta < 0) ieta += eta_bins;
+        if (iphi < 0) iphi += phi_bins;
+
+        assert(ieta >= 0);
+        assert(ieta <= eta_bins);
+        assert(iphi >= 0);
+        assert(iphi <= phi_bins);
+
+        if (m_deadTowerMap->isDeadTower(ieta, iphi)) continue;
+
+        assert(m_calibTowers);
+        RawTower *neighTower =
+            m_calibTowers->getTower(ieta, iphi);
+        if (neighTower == nullptr) continue;
+
+        if (Verbosity() >= VERBOSITY_MORE)
+        {
+          cout << neighTower->get_energy() << " (" << ieta << "-" << iphi << "), ";
+        }
+
+        E_SumNeighbor += neighTower->get_energy();
+        ++n_neighbor;
+
+      }  // for (const pair<int, int> &neighborIndex : neighborIndexs)
+
+      if (n_neighbor > 0)
+      {
+        RawTower *deadTower = m_calibTowers->getTower(key);
+
+        if (deadTower == nullptr)
+        {
+          deadTower = new RawTowerv1();
+        }
+        assert(deadTower);
+
+        deadTower->set_energy(E_SumNeighbor / n_neighbor);
+        m_calibTowers->AddTower(key, deadTower);
+
+        recovery_energy += deadTower->get_energy();
+        ++recoverTower;
+
+        if (Verbosity() >= VERBOSITY_MORE)
+        {
+          cout << " -> "<< deadTower->get_energy()<< " GeV @ "<<deadTower->get_id();
+        }
+
+      }  // if (n_neighbor>0)
+      else
+      {
+        if (Verbosity() >= VERBOSITY_MORE)
+        {
+          cout << "No neighbor towers found.";
+        }
+
+      }  // if (n_neighbor>0) -else
+
+      if (Verbosity() >= VERBOSITY_MORE)
+      {
+        cout << endl;
+      }
+    }
+
+  }  //if (m_deadTowerMap)
+  else
+  {
+    static bool once = true;
+
+    if (Verbosity() and once)
+    {
+      once = false;
+
+      std::cout << Name() << "::" << m_detector << "::"
+                << "process_event"
+                << " - missing dead map node. Do nothing ..."
+                << endl;
+    }
+  }
+
+  if (Verbosity())
+  {
+    std::cout << Name() << "::" << m_detector << "::"
+              << "process_event"
+              << "recovery_energy = " << recovery_energy
+              <<" from "<<recoverTower<<" towers"
+              << ", output sum energy = "
+              << m_calibTowers->getTotalEdep() << std::endl;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int RawTowerDeadTowerInterp::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void RawTowerDeadTowerInterp::CreateNodes(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *runNode = static_cast<PHCompositeNode *>(iter.findFirst(
+      "PHCompositeNode", "RUN"));
+  if (!runNode)
+  {
+    std::cerr << Name() << "::" << m_detector << "::"
+              << "CreateNodes"
+              << "Run Node missing, doing nothing." << std::endl;
+    throw std::runtime_error(
+        "Failed to find Run node in RawTowerDeadTowerInterp::CreateNodes");
+  }
+
+  const string deadMapName = "DEADMAP_" + m_detector;
+  m_deadTowerMap = findNode::getClass<RawTowerDeadMap>(topNode, deadMapName);
+  if (m_deadTowerMap)
+  {
+    cout << Name() << "::" << m_detector << "::"
+         << "CreateNodes"
+         << " use dead map: ";
+    m_deadTowerMap->identify();
+  }
+
+  const string geometry_node = "TOWERGEOM_" + m_detector;
+  m_geometry = findNode::getClass<RawTowerGeomContainer>(topNode, geometry_node);
+  if (!m_geometry)
+  {
+    std::cerr << Name() << "::" << m_detector << "::"
+              << "CreateNodes"
+              << " " << geometry_node << " Node missing, doing bail out!"
+              << std::endl;
+    throw std::runtime_error(
+        "Failed to find " + geometry_node + " node in RawTowerDeadTowerInterp::CreateNodes");
+  }
+
+  if (verbosity >= 1)
+  {
+    m_geometry->identify();
+  }
+
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst(
+      "PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    std::cerr << Name() << "::" << m_detector << "::"
+              << "CreateNodes"
+              << "DST Node missing, doing nothing." << std::endl;
+    throw std::runtime_error(
+        "Failed to find DST node in RawTowerDeadTowerInterp::CreateNodes");
+  }
+
+  const string rawTowerNodeName = "TOWER_" + _calib_tower_node_prefix + "_" + m_detector;
+  m_calibTowers = findNode::getClass<RawTowerContainer>(dstNode, rawTowerNodeName);
+  if (!m_calibTowers)
+  {
+    std::cerr << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
+              << " " << rawTowerNodeName << " Node missing, doing bail out!"
+              << std::endl;
+    throw std::runtime_error(
+        "Failed to find " + rawTowerNodeName + " node in RawTowerDeadTowerInterp::CreateNodes");
+  }
+
+  return;
+}

--- a/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
+++ b/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
@@ -104,7 +104,7 @@ int RawTowerDeadTowerInterp::process_event(PHCompositeNode *topNode)
       if (Verbosity() >= VERBOSITY_MORE)
       {
         cout << " bin " << bineta << "-" << binphi;
-        cout << ". Add neighbors ";
+        cout << ". Add neighbors: ";
       }
 
       assert(bineta >= 0);

--- a/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
+++ b/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
@@ -126,9 +126,10 @@ int RawTowerDeadTowerInterp::process_event(PHCompositeNode *topNode)
         int ieta = bineta + neighborIndex.first;
         int iphi = binphi + neighborIndex.second;
 
-        if (ieta >= eta_bins) ieta -= eta_bins;
+        if (ieta >= eta_bins) continue;
+        if (ieta < 0)  continue;
+
         if (iphi >= phi_bins) iphi -= phi_bins;
-        if (ieta < 0) ieta += eta_bins;
         if (iphi < 0) iphi += phi_bins;
 
         assert(ieta >= 0);

--- a/offline/packages/CaloReco/RawTowerDeadTowerInterp.h
+++ b/offline/packages/CaloReco/RawTowerDeadTowerInterp.h
@@ -1,0 +1,44 @@
+#ifndef RawTowerDeadTowerInterp_H__
+#define RawTowerDeadTowerInterp_H__
+
+#include <fun4all/SubsysReco.h>
+#include <string>
+
+class PHCompositeNode;
+class RawTowerContainer;
+class RawTowerGeomContainer;
+class RawTowerDeadMap;
+
+//! RawTowerDeadTowerInterp recovers the energy in the known dead towers with interpolation between alive towers near-by
+class RawTowerDeadTowerInterp : public SubsysReco
+{
+ public:
+  RawTowerDeadTowerInterp(const std::string &name = "RawTowerDeadTowerInterp");
+  virtual ~RawTowerDeadTowerInterp()
+  {
+  }
+
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  void
+  detector(const std::string &d)
+  {
+    m_detector = d;
+  }
+
+ protected:
+  void
+  CreateNodes(PHCompositeNode *topNode);
+
+  RawTowerContainer *m_calibTowers;
+  RawTowerGeomContainer *m_geometry;
+  RawTowerDeadMap *m_deadTowerMap;
+
+  std::string m_detector;
+
+  std::string _calib_tower_node_prefix;
+};
+
+#endif /* RawTowerDeadTowerInterp_H__ */

--- a/offline/packages/CaloReco/RawTowerDeadTowerInterpLinkDef.h
+++ b/offline/packages/CaloReco/RawTowerDeadTowerInterpLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RawTowerDeadTowerInterp-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
@@ -1,4 +1,5 @@
 #include "RawTowerDigitizer.h"
+
 #include <calobase/RawTowerContainer.h>
 #include <calobase/RawTowerDeadMap.h>
 #include <calobase/RawTowerGeom.h>

--- a/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
@@ -1,25 +1,26 @@
 #include "RawTowerDigitizer.h"
 #include <calobase/RawTowerContainer.h>
-#include <calobase/RawTowerGeomContainer.h>
+#include <calobase/RawTowerDeadMap.h>
 #include <calobase/RawTowerGeom.h>
+#include <calobase/RawTowerGeomContainer.h>
 #include <calobase/RawTowerv1.h>
 
-#include <g4detectors/PHG4CylinderCellGeomContainer.h>
-#include <g4detectors/PHG4CylinderCellGeom.h>
-#include <g4detectors/PHG4CylinderCellContainer.h>
 #include <g4detectors/PHG4CylinderCell.h>
+#include <g4detectors/PHG4CylinderCellContainer.h>
 #include <g4detectors/PHG4CylinderCellDefs.h>
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
 
-#include <phool/PHCompositeNode.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHIODataNode.h>
-#include <phool/PHRandomSeed.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
 #include <phool/recoConsts.h>
 
-#include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
+#include <gsl/gsl_rng.h>
 
 #include <cmath>
 #include <iostream>
@@ -28,25 +29,32 @@
 
 using namespace std;
 
-RawTowerDigitizer::RawTowerDigitizer(const std::string& name) :
-  SubsysReco(name), 
-  _digi_algorithm(kNo_digitization), 
-  _sim_towers(nullptr), 
-  _raw_towers(nullptr), 
-  rawtowergeom(nullptr),
-  detector("NONE"),
-  _sim_tower_node_prefix("SIM"), 
-  _raw_tower_node_prefix("RAW"), //
-  _photonelec_yield_visible_GeV(NAN), //default to invalid
-  _photonelec_ADC(NAN), //default to invalid
-  _pedstal_central_ADC(NAN), //default to invalid
-  _pedstal_width_ADC(NAN), //default to invalid
-  _zero_suppression_ADC(0), //default to apply no zero suppression
-  _tower_type(-1),
-  _timer(PHTimeServer::get()->insert_new(name))
+RawTowerDigitizer::RawTowerDigitizer(const std::string &name)
+  : SubsysReco(name)
+  , _digi_algorithm(kNo_digitization)
+  , _sim_towers(nullptr)
+  , _raw_towers(nullptr)
+  , rawtowergeom(nullptr)
+  , m_deadmap(nullptr)
+  , detector("NONE")
+  , _sim_tower_node_prefix("SIM")
+  , _raw_tower_node_prefix("RAW")
+  ,  //
+  _photonelec_yield_visible_GeV(NAN)
+  ,  //default to invalid
+  _photonelec_ADC(NAN)
+  ,  //default to invalid
+  _pedstal_central_ADC(NAN)
+  ,  //default to invalid
+  _pedstal_width_ADC(NAN)
+  ,  //default to invalid
+  _zero_suppression_ADC(0)
+  ,  //default to apply no zero suppression
+  _tower_type(-1)
+  , _timer(PHTimeServer::get()->insert_new(name))
 {
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
-  seed = PHRandomSeed(); // fixed seed handled in PHRandomSeed()
+  seed = PHRandomSeed();  // fixed seed handled in PHRandomSeed()
   cout << Name() << " Random Seed: " << seed << endl;
   gsl_rng_set(RandomGenerator, seed);
 }
@@ -56,136 +64,151 @@ RawTowerDigitizer::~RawTowerDigitizer()
   gsl_rng_free(RandomGenerator);
 }
 
-void
-RawTowerDigitizer::set_seed(const unsigned int iseed)
+void RawTowerDigitizer::set_seed(const unsigned int iseed)
 {
   seed = iseed;
   gsl_rng_set(RandomGenerator, seed);
 }
 
-int
-RawTowerDigitizer::InitRun(PHCompositeNode *topNode)
+int RawTowerDigitizer::InitRun(PHCompositeNode *topNode)
 {
-
   PHNodeIterator iter(topNode);
 
   // Looking for the DST node
   PHCompositeNode *dstNode;
-  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
-    {
-      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-	   << "DST Node missing, doing nothing." << endl;
-      exit(1);
-    }
+  {
+    cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+         << "DST Node missing, doing nothing." << endl;
+    exit(1);
+  }
 
   try
-    {
-      CreateNodes(topNode);
-    }
-  catch (std::exception& e)
-    {
-      cout << e.what() << endl;
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
+  {
+    CreateNodes(topNode);
+  }
+  catch (std::exception &e)
+  {
+    cout << e.what() << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int
-RawTowerDigitizer::process_event(PHCompositeNode *topNode)
+int RawTowerDigitizer::process_event(PHCompositeNode *topNode)
 {
   if (verbosity)
-    {
-      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-	   << "Process event entered. " << "Digitalization method: ";
+  {
+    cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+         << "Process event entered. "
+         << "Digitalization method: ";
 
-      if (kNo_digitization)
-	{
-	  cout << "directly pass the energy of sim tower to digitalized tower";
-	}
-      else if (kSimple_photon_digitization)
-	{
-	  cout << "simple digitization with photon statistics, ADC conversion and pedstal";
-	}
-      cout << endl;
+    if (kNo_digitization)
+    {
+      cout << "directly pass the energy of sim tower to digitalized tower";
     }
+    else if (kSimple_photon_digitization)
+    {
+      cout << "simple digitization with photon statistics, ADC conversion and pedstal";
+    }
+    cout << endl;
+  }
   // loop over all possible towers, even empty ones. The digitization can add towers containing
   // pedestals
   RawTowerGeomContainer::ConstRange all_towers = rawtowergeom->get_tower_geometries();
 
+  double deadChanEnergy = 0;
+
   for (RawTowerGeomContainer::ConstIterator it = all_towers.first;
        it != all_towers.second; ++it)
+  {
+    const RawTowerDefs::keytype key = it->second->get_id();
+    if (_tower_type >= 0)
     {
-      const RawTowerDefs::keytype key = it->second->get_id();
-      if(_tower_type >= 0)
-	{
-	  // Skip towers that don't match the type we are supposed to digitize
-	  if(_tower_type != it->second->get_tower_type())
-	    {
-	      continue;
-	    }
-	}
-
-      RawTower *sim_tower = _sim_towers->getTower(key);
-      RawTower *digi_tower = nullptr;
-
-      if (_digi_algorithm == kNo_digitization)
-	{
-	  // for no digitization just copy existing towers
-	  if (sim_tower)
-	    {
-	      digi_tower = new RawTowerv1(*sim_tower);
-	    }
-	}
-      else if (_digi_algorithm == kSimple_photon_digitization)
-	{
-	  // for photon digitization towers can be created if sim_tower is null pointer
-	  digi_tower = simple_photon_digitization(sim_tower);
-	}
-      else
-	{
-	  cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-	       << " invalid digitization algorithm #" << _digi_algorithm
-	       << endl;
-
-	  return Fun4AllReturnCodes::ABORTRUN;
-	}
-      if (digi_tower)
-	{
-	  _raw_towers->AddTower(key, digi_tower);
-
-	  if (verbosity)
-	    {
-	      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-		   << " output tower:"
-		   << endl;
-	      digi_tower->identify();
-	    }
-	}
-
+      // Skip towers that don't match the type we are supposed to digitize
+      if (_tower_type != it->second->get_tower_type())
+      {
+        continue;
+      }
     }
 
+    RawTower *sim_tower = _sim_towers->getTower(key);
+    if (m_deadmap)
+    {
+      if (m_deadmap->isDeadTower(key))
+      {
+        if (sim_tower) deadChanEnergy += sim_tower->get_energy();
 
-  if (verbosity)
+        sim_tower = nullptr;
+
+        if (Verbosity() >= VERBOSITY_MORE)
+        {
+          cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+               << " apply dead tower " << key << endl;
+        }
+      }
+    }
+
+    RawTower *digi_tower = nullptr;
+
+    if (_digi_algorithm == kNo_digitization)
+    {
+      // for no digitization just copy existing towers
+      if (sim_tower)
+      {
+        digi_tower = new RawTowerv1(*sim_tower);
+      }
+    }
+    else if (_digi_algorithm == kSimple_photon_digitization)
+    {
+      // for photon digitization towers can be created if sim_tower is null pointer
+      digi_tower = simple_photon_digitization(sim_tower);
+    }
+    else
     {
       cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-	   << "input sum energy = " << _sim_towers->getTotalEdep()
-	   << ", output sum digitalized value = " << _raw_towers->getTotalEdep()
-	   << endl;
+           << " invalid digitization algorithm #" << _digi_algorithm
+           << endl;
+
+      return Fun4AllReturnCodes::ABORTRUN;
     }
+
+    if (digi_tower)
+    {
+      _raw_towers->AddTower(key, digi_tower);
+
+      if (Verbosity() >= VERBOSITY_MORE)
+      {
+        cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+             << " output tower:"
+             << endl;
+        digi_tower->identify();
+      }
+    }
+  }
+
+  if (Verbosity())
+  {
+    cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+         << "input sum energy = " << _sim_towers->getTotalEdep() << " GeV"
+         << ", dead channel masked energy = " << deadChanEnergy << " GeV"
+         << ", output sum digitalized value = " << _raw_towers->getTotalEdep() << " ADC"
+         << endl;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 RawTower *
-RawTowerDigitizer::simple_photon_digitization(RawTower * sim_tower)
+RawTowerDigitizer::simple_photon_digitization(RawTower *sim_tower)
 {
   RawTower *digi_tower = nullptr;
 
   double energy = 0;
   if (sim_tower)
-    {
-      energy = sim_tower->get_energy();
-    }
+  {
+    energy = sim_tower->get_energy();
+  }
   const double photon_count_mean = energy * _photonelec_yield_visible_GeV;
   const int photon_count = gsl_ran_poisson(RandomGenerator, photon_count_mean);
   const int signal_ADC = floor(photon_count / _photonelec_ADC);
@@ -194,117 +217,122 @@ RawTowerDigitizer::simple_photon_digitization(RawTower * sim_tower)
   const int sum_ADC = signal_ADC + (int) pedstal;
 
   if (sum_ADC > _zero_suppression_ADC)
+  {
+    // create new digitalizaed tower
+    if (sim_tower)
     {
-      // create new digitalizaed tower
-      if (sim_tower)
-	{
-	  digi_tower = new RawTowerv1(*sim_tower);
-	}
-      else
-	{
-	  digi_tower = new RawTowerv1();
-	}
-      digi_tower->set_energy((double) sum_ADC);
+      digi_tower = new RawTowerv1(*sim_tower);
     }
+    else
+    {
+      digi_tower = new RawTowerv1();
+    }
+    digi_tower->set_energy((double) sum_ADC);
+  }
 
   if (verbosity >= 2)
-    {
-      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-	   << endl;
+  {
+    cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+         << endl;
 
-      cout << "input: ";
-      if (sim_tower)
-	{
-	  sim_tower->identify();
-	}
-      else
-	{
-	  cout << "None" << endl;
-	}
-      cout << "output based on " << "sum_ADC = " << sum_ADC << ", zero_sup = "
-	   << _zero_suppression_ADC << " : ";
-      if (digi_tower)
-	{
-	  digi_tower->identify();
-	}
-      else
-	{
-	  cout << "None" << endl;
-	}
+    cout << "input: ";
+    if (sim_tower)
+    {
+      sim_tower->identify();
     }
+    else
+    {
+      cout << "None" << endl;
+    }
+    cout << "output based on "
+         << "sum_ADC = " << sum_ADC << ", zero_sup = "
+         << _zero_suppression_ADC << " : ";
+    if (digi_tower)
+    {
+      digi_tower->identify();
+    }
+    else
+    {
+      cout << "None" << endl;
+    }
+  }
 
   return digi_tower;
 }
 
-void
-RawTowerDigitizer::CreateNodes(PHCompositeNode *topNode)
+void RawTowerDigitizer::CreateNodes(PHCompositeNode *topNode)
 {
-
   PHNodeIterator iter(topNode);
-  PHCompositeNode *runNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
+  PHCompositeNode *runNode = static_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
   if (!runNode)
-    {
-      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-	   << "Run Node missing, doing nothing." << endl;
-      throw std::runtime_error(
-			       "Failed to find Run node in RawTowerDigitizer::CreateNodes");
-    }
+  {
+    cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+         << "Run Node missing, doing nothing." << endl;
+    throw std::runtime_error(
+        "Failed to find Run node in RawTowerDigitizer::CreateNodes");
+  }
 
   TowerGeomNodeName = "TOWERGEOM_" + detector;
   rawtowergeom = findNode::getClass<RawTowerGeomContainer>(topNode, TowerGeomNodeName.c_str());
   if (!rawtowergeom)
-    {
-      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-	   << " " << TowerGeomNodeName << " Node missing, doing bail out!"
-	   << endl;
-      throw std::runtime_error("Failed to find " + TowerGeomNodeName
-			       + " node in RawTowerDigitizer::CreateNodes");
-    }
+  {
+    cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+         << " " << TowerGeomNodeName << " Node missing, doing bail out!"
+         << endl;
+    throw std::runtime_error("Failed to find " + TowerGeomNodeName + " node in RawTowerDigitizer::CreateNodes");
+  }
 
   if (verbosity >= 1)
-    {
-      rawtowergeom->identify();
-    }
+  {
+    rawtowergeom->identify();
+  }
 
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  const string deadMapName = "DEADMAP_" + detector;
+  m_deadmap = findNode::getClass<RawTowerDeadMap>(topNode, deadMapName);
+  if (m_deadmap)
+  {
+    cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+         << " use dead map: ";
+    m_deadmap->identify();
+  }
+
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
-    {
-      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-	   << "DST Node missing, doing nothing." << endl;
-      throw std::runtime_error("Failed to find DST node in RawTowerDigitizer::CreateNodes");
-    }
+  {
+    cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+         << "DST Node missing, doing nothing." << endl;
+    throw std::runtime_error("Failed to find DST node in RawTowerDigitizer::CreateNodes");
+  }
 
   SimTowerNodeName = "TOWER_" + _sim_tower_node_prefix + "_" + detector;
   _sim_towers = findNode::getClass<RawTowerContainer>(dstNode, SimTowerNodeName.c_str());
   if (!_sim_towers)
-    {
-      cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-	   << " " << SimTowerNodeName << " Node missing, doing bail out!"
-	   << endl;
-      throw std::runtime_error("Failed to find " + SimTowerNodeName
-			       + " node in RawTowerDigitizer::CreateNodes");
-    }
+  {
+    cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
+         << " " << SimTowerNodeName << " Node missing, doing bail out!"
+         << endl;
+    throw std::runtime_error("Failed to find " + SimTowerNodeName + " node in RawTowerDigitizer::CreateNodes");
+  }
 
   // Create the tower nodes on the tree
   PHNodeIterator dstiter(dstNode);
-  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode", detector));
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", detector));
   if (!DetNode)
-    {
-      DetNode = new PHCompositeNode(detector);
-      dstNode->addNode(DetNode);
-    }
+  {
+    DetNode = new PHCompositeNode(detector);
+    dstNode->addNode(DetNode);
+  }
 
   // Be careful as a previous digitizer may have been registered for this detector
   RawTowerNodeName = "TOWER_" + _raw_tower_node_prefix + "_" + detector;
   _raw_towers = findNode::getClass<RawTowerContainer>(DetNode, RawTowerNodeName.c_str());
   if (!_raw_towers)
-    {
-      _raw_towers = new RawTowerContainer( _sim_towers -> getCalorimeterID()  );
-      PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_raw_towers,
-								     RawTowerNodeName.c_str(), "PHObject");
-      DetNode->addNode(towerNode);
-    }
+  {
+    _raw_towers = new RawTowerContainer(_sim_towers->getCalorimeterID());
+    PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_raw_towers,
+                                                                   RawTowerNodeName.c_str(), "PHObject");
+    DetNode->addNode(towerNode);
+  }
 
   return;
 }
-

--- a/simulation/g4simulation/g4calo/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4calo/RawTowerDigitizer.h
@@ -9,6 +9,7 @@
 class PHCompositeNode;
 class RawTowerContainer;
 class RawTowerGeomContainer;
+class RawTowerDeadMap;
 
 class RawTower;
 
@@ -22,20 +23,16 @@ class RawTower;
 //! default output DST node is TOWER_RAW_DETECTOR
 class RawTowerDigitizer : public SubsysReco
 {
-
-public:
-  RawTowerDigitizer(const std::string& name = "RawTowerDigitizer");
+ public:
+  RawTowerDigitizer(const std::string &name = "RawTowerDigitizer");
   virtual ~RawTowerDigitizer();
 
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
-  void Detector(const std::string &d) {detector = d;}
-
-  void TowerType(const int type) {_tower_type = type;} 
-
+  void Detector(const std::string &d) { detector = d; }
+  void TowerType(const int type) { _tower_type = type; }
   void set_seed(const unsigned int iseed);
-  unsigned int get_seed() const {return seed;}
-
+  unsigned int get_seed() const { return seed; }
   enum enu_digi_algorithm
   {
     //! directly pass the energy of sim tower to digitalized tower
@@ -144,7 +141,8 @@ public:
   {
     _sim_tower_node_prefix = simTowerNodePrefix;
   }
-protected:
+
+ protected:
   void CreateNodes(PHCompositeNode *topNode);
 
   enu_digi_algorithm _digi_algorithm;
@@ -152,11 +150,12 @@ protected:
   //! simple digitization with photon statistics, ADC conversion and pedstal
   //! \param  sim_tower simulation tower input
   //! \return a new RawTower object contain digitalized value of ADC output in RawTower::get_energy()
-  RawTower *simple_photon_digitization(RawTower * sim_tower);
+  RawTower *simple_photon_digitization(RawTower *sim_tower);
 
-  RawTowerContainer* _sim_towers;
-  RawTowerContainer* _raw_towers;
+  RawTowerContainer *_sim_towers;
+  RawTowerContainer *_raw_towers;
   RawTowerGeomContainer *rawtowergeom;
+  RawTowerDeadMap *m_deadmap;
 
   std::string detector;
   std::string SimTowerNodeName;
@@ -182,7 +181,7 @@ protected:
   double _zero_suppression_ADC;
 
   //! tower type to act on
-  int _tower_type; 
+  int _tower_type;
 
   PHTimeServer::timer _timer;
 

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -666,9 +666,14 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
     }
 
     // for every cluster
-    for (unsigned int icluster = 0; icluster < clusters->size(); icluster++)
-    {
-      RawCluster* cluster = clusters->getCluster(icluster);
+
+    for (const auto & iterator : clusters->getClustersMap()) {
+
+      RawCluster *cluster = iterator.second;
+
+//    for (unsigned int icluster = 0; icluster < clusters->size(); icluster++)
+//    {
+//      RawCluster* cluster = clusters->getCluster(icluster);
 
       if (cluster->get_energy() < _reco_e_threshold) continue;
 

--- a/simulation/g4simulation/g4hough/PHG4GenFitTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4GenFitTrackProjection.C
@@ -391,9 +391,9 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 #ifdef DEBUG
 			double min_cluster_phi = NAN;
 #endif
-			for (unsigned int k = 0; k < clusterList->size(); ++k) {
+			for (const auto & iterator : clusterList->getClustersMap()) {
 
-				RawCluster *cluster = clusterList->getCluster(k);
+				const RawCluster *cluster = iterator.second;
 
 				//! eta as location mark of cluster relative to (0,0,0)
 				const float cluster_eta = RawClusterUtility::GetPseudorapidity(*cluster, CLHEP::Hep3Vector(0,0,0));
@@ -404,7 +404,7 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 				double r = sqrt(pow(dphi, 2) + pow(deta, 2));
 
 				if (r < min_r) {
-					min_index = k;
+					min_index = iterator.first;
 					min_r = r;
 					min_dphi = dphi;
 					min_deta = deta;

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
@@ -218,9 +218,9 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
       double min_dphi = NAN;
       double min_deta = NAN;
       double min_e = NAN;
-      for (unsigned int k = 0; k < clusterList->size(); ++k) {
+      for (const auto & iterator : clusterList->getClustersMap()) {
 
-	RawCluster *cluster = clusterList->getCluster(k);
+        const RawCluster *cluster = iterator.second;
 
   //! eta as location mark of cluster relative to (0,0,0)
   const float cluster_eta = RawClusterUtility::GetPseudorapidity(*cluster, CLHEP::Hep3Vector(0,0,0));
@@ -230,7 +230,7 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
 	double r = sqrt(pow(dphi,2)+pow(deta,2));
 
 	if (r < min_r) {
-	  min_index = k;
+	  min_index = iterator.first;
 	  min_r = r;
 	  min_dphi = dphi;
 	  min_deta = deta;


### PR DESCRIPTION
# Introduction

We were instructed to demonstrate the impact of calorimeter dead towers in CD-1 review. The levels of dead tower are 5% and 10% in the current Objective Key Performance Parameter (Objective KPP) and Threshold Key Performance Parameter (Threshold KPP), respectively. The goal is to show even in the worse case of Threshold KPP, the experiment can continue with reduced physics performance. 

# Dead tower simulation and reconstruction

A few steps were introduced to handle dead towers

1. `RawTowerDeadMapLoader`: Dead map from calibration database is loaded on DST node in container `RawTowerDeadMap`. 
2. `RawTowerDigitizer`: dead tower signal is not readout. However, it can still carry noise hits, which emulate disconnected front end with a working digitizer. 
3. `RawTowerDeadTowerInterp`: in reconstruction stage after tower energy calibration, the known dead tower is recovered via interpolating energy from neighboring non-dead towers. The aim is to recover the background level and some shower information in the dead towers for jet reco and background determination. 
4. `RawClusterDeadAreaMask`: in reconstruction stage after clustering, cluster . 

_Note_: the last step is aimed for photon cluster analysis, and can lead to significantly increased loss of alive area since cluster usually require multiple towers under the core to be _not_ dead. 
* It does not impact track-based clustering `PHG4GenFitTrackProjection` for electron ID analysis as lower energy tail can be tolerated as loss of electron efficiency 
* It does not impact tower/track based jet reconstruction. Dead tower with energy interpolated from neighboring tower would leads to worsen of jet energy resolution. But we can not afford the loss of reconstructed jet due to a few dead towers. 

# Related updates

* Dead map in calibration repository: https://github.com/sPHENIX-Collaboration/calibrations/pull/33
* Example macros that simulates for dead towers, which is tagged as `CD-1 Objective/Threshold KPP`
** `CD-1 reference` with no dead towers : https://github.com/blackcathj/macros/tree/CD-1-reference-single-production-readback 
** `CD-1 reference with Objective KPP`: https://github.com/blackcathj/macros/tree/CD-1-reference-Objective-KPP-single-production-readback
** `CD-1 reference with Threshold KPP`: https://github.com/blackcathj/macros/tree/CD-1-reference-Threshold-KPP-single-production-readback
** `CD-1 reference with Threshold KPP` tagged branch for HIJING embeddings: https://github.com/blackcathj/macros/tree/CD-1-reference-Threshold-KPP-jet-production-readback-embed

_Note_: final macros will be placed on branches of https://github.com/sPHENIX-Collaboration/macros

# Next

Running tests to check the leading order effects. 

After test, I will request Jet Structure TG to test jet reconstruction and @jdosbo for test the EMCal resolution. 

# Acknowledgement

Thanks to Alexander Bazilevsky @shura95  and Gunther Roland for suggestions on the masking/recovery algorithm, and to Chris Pinkenburg @pinkenburg  who refreshed the single particle central production sample for testing. 
