### PR TITLE
suppress warnings for new boost version

### DIFF
--- a/generators/flowAfterburner/main.cc
+++ b/generators/flowAfterburner/main.cc
@@ -18,19 +18,20 @@
 #include <CLHEP/Geometry/Point3D.h>
 
 #include <boost/version.hpp> // to get BOOST_VERSION
-#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && BOOST_VERSION == 106000 )
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && (BOOST_VERSION == 106000  || BOOST_VERSION == 106700 ))
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma message "ignoring bogus gcc warning in boost header ptree.hpp"
 #include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/xml_parser.hpp>
 #pragma GCC diagnostic warning "-Wshadow"
+#pragma GCC diagnostic warning "-Wunused-parameter"
 #else
 #include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/xml_parser.hpp>
 #endif
 
 #include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 
 
 #include <iostream>

--- a/generators/flowAfterburner/test.cc
+++ b/generators/flowAfterburner/test.cc
@@ -12,17 +12,18 @@
 // triggers the uninitialized variable warning which
 // stops compilation because of our -Werror 
 #include <boost/version.hpp> // to get BOOST_VERSION
-#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && BOOST_VERSION == 106000 )
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && (BOOST_VERSION == 106000  || BOOST_VERSION == 106700 ))
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma message "ignoring bogus gcc warning in boost header ptree.hpp"
 #include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/xml_parser.hpp>
 #pragma GCC diagnostic warning "-Wshadow"
+#pragma GCC diagnostic warning "-Wunused-parameter"
 #else
 #include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/xml_parser.hpp>
 #endif
 
+#include <boost/property_tree/xml_parser.hpp>
 
 #include <gsl/gsl_histogram.h>
 


### PR DESCRIPTION
boost/property_tree/ptree.hpp still shadows variable, and new - an unused parameter warning
backward compatible
