### PR TITLE
Inner Hcal speedup

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -51,40 +51,40 @@ static double subtract_from_scinti_x = 0.1 * mm;
 
 PHG4InnerHcalDetector::PHG4InnerHcalDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
   : PHG4Detector(Node, dnam)
-  , params(parameters)
-  , scinti_mother_assembly(nullptr)
-  , inner_radius(params->get_double_param("inner_radius") * cm)
-  , outer_radius(params->get_double_param("outer_radius") * cm)
-  , size_z(params->get_double_param("size_z") * cm)
-  , scinti_tile_x(NAN)
-  , scinti_tile_x_lower(NAN)
-  , scinti_tile_x_upper(NAN)
-  , scinti_tile_z(size_z)
-  , scinti_tile_thickness(params->get_double_param("scinti_tile_thickness") * cm)
-  , scinti_inner_gap(params->get_double_param("scinti_inner_gap") * cm)
-  , scinti_outer_gap(params->get_double_param("scinti_outer_gap") * cm)
-  , scinti_outer_radius(params->get_double_param("scinti_outer_radius") * cm)
-  , tilt_angle(params->get_double_param("tilt_angle") * deg)
-  , envelope_inner_radius(inner_radius)
-  , envelope_outer_radius(outer_radius)
-  , envelope_z(size_z)
-  , volume_envelope(NAN)
-  , volume_steel(NAN)
-  , volume_scintillator(NAN)
-  , n_scinti_plates(params->get_int_param(PHG4HcalDefs::scipertwr) * params->get_int_param("n_towers"))
-  , n_scinti_tiles(params->get_int_param("n_scinti_tiles"))
-  , active(params->get_int_param("active"))
-  , absorberactive(params->get_int_param("absorberactive"))
-  , layer(0)
+  , m_Params(parameters)
+  , m_ScintiMotherAssembly(nullptr)
+  , m_InnerRadius(m_Params->get_double_param("inner_radius") * cm)
+  , m_OuterRadius(m_Params->get_double_param("outer_radius") * cm)
+  , m_SizeZ(m_Params->get_double_param("size_z") * cm)
+  , m_ScintiTileX(NAN)
+  , m_ScintiTileXLower(NAN)
+  , m_ScintiTileXUpper(NAN)
+  , m_ScintiTileZ(m_SizeZ)
+  , m_ScintiTileThickness(m_Params->get_double_param("scinti_tile_thickness") * cm)
+  , m_ScintiInnerGap(m_Params->get_double_param("scinti_inner_gap") * cm)
+  , m_ScintiOuterGap(m_Params->get_double_param("scinti_outer_gap") * cm)
+  , m_ScintiOuterRadius(m_Params->get_double_param("scinti_outer_radius") * cm)
+  , m_TiltAngle(m_Params->get_double_param("tilt_angle") * deg)
+  , m_EnvelopeInnerRadius(m_InnerRadius)
+  , m_EnvelopeOuterRadius(m_OuterRadius)
+  , m_EnvelopeZ(m_SizeZ)
+  , m_VolumeEnvelope(NAN)
+  , m_VolumeSteel(NAN)
+  , m_VolumeScintillator(NAN)
+  , m_NumScintiPlates(m_Params->get_int_param(PHG4HcalDefs::scipertwr) * m_Params->get_int_param("n_towers"))
+  , m_NumScintiTiles(m_Params->get_int_param("n_scinti_tiles"))
+  , m_Active(m_Params->get_int_param("active"))
+  , m_AbsorberActive(m_Params->get_int_param("absorberactive"))
+  , m_Layer(0)
   , scintilogicnameprefix("HcalInnerScinti")
 {
   // allocate memory for scintillator plates
-  scinti_tiles_vec.assign(2 * n_scinti_tiles, static_cast<G4VSolid *>(nullptr));
+  scinti_tiles_vec.assign(2 * m_NumScintiTiles, static_cast<G4VSolid *>(nullptr));
 }
 
 PHG4InnerHcalDetector::~PHG4InnerHcalDetector()
 {
-  delete scinti_mother_assembly;
+  delete m_ScintiMotherAssembly;
 }
 
 //_______________________________________________________________
@@ -104,14 +104,14 @@ int PHG4InnerHcalDetector::IsInInnerHcal(G4VPhysicalVolume *volume) const
   // 82 the number of the scintillator mother volume
   // HcalInnerScinti_11: name of scintillator slat
   // 11: number of scintillator slat logical volume
-  if (absorberactive)
+  if (m_AbsorberActive)
   {
-    if (steel_absorber_vec.find(volume) != steel_absorber_vec.end())
+    if (m_SteelAbsorberPhysVolSet.find(volume) != m_SteelAbsorberPhysVolSet.end())
     {
       return -1;
     }
   }
-  if (active)
+  if (m_Active)
   {
     if (volume->GetName().find(scintilogicnameprefix) != string::npos)
     {
@@ -124,18 +124,18 @@ int PHG4InnerHcalDetector::IsInInnerHcal(G4VPhysicalVolume *volume) const
 G4VSolid *
 PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
 {
-  double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
+  double mid_radius = m_InnerRadius + (m_OuterRadius - m_InnerRadius) / 2.;
   Point_2 p_in_1(mid_radius, 0);  // center of scintillator
 
   // length of upper edge (middle till outer circle intersect
   // x/y coordinate of end of center vertical
-  double xcoord = scinti_tile_thickness / 2. * sin(fabs(tilt_angle) / rad) + mid_radius;
-  double ycoord = scinti_tile_thickness / 2. * cos(fabs(tilt_angle) / rad) + 0;
+  double xcoord = m_ScintiTileThickness / 2. * sin(fabs(m_TiltAngle) / rad) + mid_radius;
+  double ycoord = m_ScintiTileThickness / 2. * cos(fabs(m_TiltAngle) / rad) + 0;
   Point_2 p_upperedge(xcoord, ycoord);
   Line_2 s2(p_in_1, p_upperedge);  // center vertical
 
   Line_2 perp = s2.perpendicular(p_upperedge);
-  Point_2 sc1(outer_radius, 0), sc2(0, outer_radius), sc3(-outer_radius, 0);
+  Point_2 sc1(m_OuterRadius, 0), sc2(0, m_OuterRadius), sc3(-m_OuterRadius, 0);
   Circle_2 outer_circle(sc1, sc2, sc3);
   vector<CGAL::Object> res;
   CGAL::intersection(outer_circle, perp, std::back_inserter(res));
@@ -151,7 +151,7 @@ PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
         double deltax = CGAL::to_double(point->first.x()) - CGAL::to_double(p_upperedge.x());
         double deltay = CGAL::to_double(point->first.y()) - CGAL::to_double(p_upperedge.y());
         // the scintillator is twice as long
-        scinti_tile_x_upper = sqrt(deltax * deltax + deltay * deltay);  //
+        m_ScintiTileXUpper = sqrt(deltax * deltax + deltay * deltay);  //
         Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
         upperright = pntmp;
       }
@@ -162,12 +162,12 @@ PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
     }
   }
   // length of lower edge (middle till inner circle intersect
-  xcoord = mid_radius - scinti_tile_thickness / 2. * sin(fabs(tilt_angle) / rad);
-  ycoord = 0 - scinti_tile_thickness / 2. * cos(fabs(tilt_angle) / rad);
+  xcoord = mid_radius - m_ScintiTileThickness / 2. * sin(fabs(m_TiltAngle) / rad);
+  ycoord = 0 - m_ScintiTileThickness / 2. * cos(fabs(m_TiltAngle) / rad);
   Point_2 p_loweredge(xcoord, ycoord);
   Line_2 s3(p_in_1, p_loweredge);
   Line_2 l_lower = s3.perpendicular(p_loweredge);
-  Point_2 ic1(inner_radius, 0), ic2(0, inner_radius), ic3(-inner_radius, 0);
+  Point_2 ic1(m_InnerRadius, 0), ic2(0, m_InnerRadius), ic3(-m_InnerRadius, 0);
   Circle_2 inner_circle(ic1, ic2, ic3);
   res.clear();
   CGAL::intersection(inner_circle, l_lower, std::back_inserter(res));
@@ -185,16 +185,16 @@ PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
         minx = CGAL::to_double(point->first.x());
         double deltax = CGAL::to_double(point->first.x()) - CGAL::to_double(p_loweredge.x());
         double deltay = CGAL::to_double(point->first.y()) - CGAL::to_double(p_loweredge.y());
-        scinti_tile_x_lower = sqrt(deltax * deltax + deltay * deltay);
+        m_ScintiTileXLower = sqrt(deltax * deltax + deltay * deltay);
         Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
         lowerleft = pntmp;
       }
     }
   }
-  scinti_tile_x = scinti_tile_x_upper + scinti_tile_x_lower - ((outer_radius - scinti_outer_radius) / cos(tilt_angle / rad));
-  scinti_tile_x -= subtract_from_scinti_x;
-  G4VSolid *scintibox = new G4Box("ScintiTile", scinti_tile_x / 2., scinti_tile_thickness / 2., scinti_tile_z / 2.);
-  volume_scintillator = scintibox->GetCubicVolume() * n_scinti_plates;
+  m_ScintiTileX = m_ScintiTileXUpper + m_ScintiTileXLower - ((m_OuterRadius - m_ScintiOuterRadius) / cos(m_TiltAngle / rad));
+  m_ScintiTileX -= subtract_from_scinti_x;
+  G4VSolid *scintibox = new G4Box("ScintiTile", m_ScintiTileX / 2., m_ScintiTileThickness / 2., m_ScintiTileZ / 2.);
+  m_VolumeScintillator = scintibox->GetCubicVolume() * m_NumScintiPlates;
   return scintibox;
 }
 
@@ -203,17 +203,17 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
 {
   // calculate steel plate on top of the scinti box. Lower edge is the upper edge of
   // the scintibox + 1/2 the airgap
-  double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
+  double mid_radius = m_InnerRadius + (m_OuterRadius - m_InnerRadius) / 2.;
   // first the lower edge, just like the scinti box, just add the air gap
   // and calculate intersection of edge with inner and outer radius.
   Point_2 p_in_1(mid_radius, 0);  // center of lower scintillator
-  double angle_mid_scinti = M_PI / 2. + tilt_angle / rad;
-  double xcoord = scinti_inner_gap / 2. * cos(angle_mid_scinti / rad) + mid_radius;
-  double ycoord = scinti_inner_gap / 2. * sin(angle_mid_scinti / rad) + 0;
+  double angle_mid_scinti = M_PI / 2. + m_TiltAngle / rad;
+  double xcoord = m_ScintiInnerGap / 2. * cos(angle_mid_scinti / rad) + mid_radius;
+  double ycoord = m_ScintiInnerGap / 2. * sin(angle_mid_scinti / rad) + 0;
   Point_2 p_loweredge(xcoord, ycoord);
   Line_2 s2(p_in_1, p_loweredge);               // center vertical
   Line_2 perp = s2.perpendicular(p_loweredge);  // that is the lower edge of the steel plate
-  Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
+  Point_2 sc1(m_InnerRadius, 0), sc2(0, m_InnerRadius), sc3(-m_InnerRadius, 0);
   Circle_2 inner_circle(sc1, sc2, sc3);
   vector<CGAL::Object> res;
   CGAL::intersection(inner_circle, perp, std::back_inserter(res));
@@ -236,13 +236,13 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
     }
   }
 
-  double xcoord2 = scinti_outer_gap / 2. * cos(angle_mid_scinti / rad) + mid_radius;
-  double ycoord2 = scinti_outer_gap / 2. * sin(angle_mid_scinti / rad) + 0;
+  double xcoord2 = m_ScintiOuterGap / 2. * cos(angle_mid_scinti / rad) + mid_radius;
+  double ycoord2 = m_ScintiOuterGap / 2. * sin(angle_mid_scinti / rad) + 0;
   Point_2 p_loweredge2(xcoord2, ycoord2);
   Line_2 s2_2(p_in_1, p_loweredge2);                // center vertical
   Line_2 perp2 = s2_2.perpendicular(p_loweredge2);  // that is the lower edge of the steel plate
 
-  Point_2 so1(outer_radius, 0), so2(0, outer_radius), so3(-outer_radius, 0);
+  Point_2 so1(m_OuterRadius, 0), so2(0, m_OuterRadius), so3(-m_OuterRadius, 0);
   Circle_2 outer_circle(so1, so2, so3);
   res.clear();  // just clear the content from the last intersection search
   CGAL::intersection(outer_circle, perp2, std::back_inserter(res));
@@ -266,13 +266,13 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
   // now we have the lower left and rigth corner, now find the upper edge
   // find the center of the upper scintilator
 
-  double phi_midpoint = 2 * M_PI / n_scinti_plates;
+  double phi_midpoint = 2 * M_PI / m_NumScintiPlates;
   double xmidpoint = cos(phi_midpoint) * mid_radius;
   double ymidpoint = sin(phi_midpoint) * mid_radius;
   // angle of perp line at center of scintillator
-  angle_mid_scinti = (M_PI / 2. - phi_midpoint) - (M_PI / 2. + tilt_angle / rad);
-  double xcoordup = xmidpoint - scinti_inner_gap / 2. * sin(angle_mid_scinti / rad);
-  double ycoordup = ymidpoint - scinti_inner_gap / 2. * cos(angle_mid_scinti / rad);
+  angle_mid_scinti = (M_PI / 2. - phi_midpoint) - (M_PI / 2. + m_TiltAngle / rad);
+  double xcoordup = xmidpoint - m_ScintiInnerGap / 2. * sin(angle_mid_scinti / rad);
+  double ycoordup = ymidpoint - m_ScintiInnerGap / 2. * cos(angle_mid_scinti / rad);
   Point_2 upperleft;
   Point_2 upperright;
   Point_2 mid_upperscint(xmidpoint, ymidpoint);
@@ -280,7 +280,7 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
   {
     Line_2 sup(mid_upperscint, p_upperedge);       // center vertical
     Line_2 perp = sup.perpendicular(p_upperedge);  // that is the upper edge of the steel plate
-    Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
+    Point_2 sc1(m_InnerRadius, 0), sc2(0, m_InnerRadius), sc3(-m_InnerRadius, 0);
     Circle_2 inner_circle(sc1, sc2, sc3);
     vector<CGAL::Object> res;
     CGAL::intersection(inner_circle, perp, std::back_inserter(res));
@@ -304,13 +304,13 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
       }
     }
 
-    double xcoordup2 = xmidpoint - scinti_outer_gap / 2. * sin(angle_mid_scinti / rad);
-    double ycoordup2 = ymidpoint - scinti_outer_gap / 2. * cos(angle_mid_scinti / rad);
+    double xcoordup2 = xmidpoint - m_ScintiOuterGap / 2. * sin(angle_mid_scinti / rad);
+    double ycoordup2 = ymidpoint - m_ScintiOuterGap / 2. * cos(angle_mid_scinti / rad);
     Point_2 p_upperedge2(xcoordup2, ycoordup2);
     Line_2 sup2(mid_upperscint, p_upperedge2);        // center vertical
     Line_2 perp2 = sup2.perpendicular(p_upperedge2);  // that is the upper edge of the steel plate
 
-    Point_2 so1(outer_radius, 0), so2(0, outer_radius), so3(-outer_radius, 0);
+    Point_2 so1(m_OuterRadius, 0), so2(0, m_OuterRadius), so3(-m_OuterRadius, 0);
     Circle_2 outer_circle(so1, so2, so3);
     res.clear();  // just clear the content from the last intersection search
     CGAL::intersection(outer_circle, perp2, std::back_inserter(res));
@@ -346,12 +346,12 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
   G4TwoVector zero(0, 0);
   G4VSolid *steel_plate = new G4ExtrudedSolid("SteelPlate",
                                               vertexes,
-                                              size_z / 2.0,
+                                              m_SizeZ / 2.0,
                                               zero, 1.0,
                                               zero, 1.0);
 
   //  DisplayVolume(steel_plate, hcalenvelope);
-  volume_steel = steel_plate->GetCubicVolume() * n_scinti_plates;
+  m_VolumeSteel = steel_plate->GetCubicVolume() * m_NumScintiPlates;
   return steel_plate;
 }
 
@@ -364,7 +364,7 @@ void PHG4InnerHcalDetector::ShiftSecantToTangent(Point_2 &lowleft, Point_2 &uple
   double ymid = (CGAL::to_double(lowleft.y()) + CGAL::to_double(upleft.y())) / 2.;
   Point_2 midpoint(xmid, ymid);
   Line_2 sekperp = secant.perpendicular(midpoint);
-  Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
+  Point_2 sc1(m_InnerRadius, 0), sc2(0, m_InnerRadius), sc3(-m_InnerRadius, 0);
   Circle_2 inner_circle(sc1, sc2, sc3);
   vector<CGAL::Object> res;
   CGAL::intersection(inner_circle, sekperp, std::back_inserter(res));
@@ -407,8 +407,8 @@ void PHG4InnerHcalDetector::ShiftSecantToTangent(Point_2 &lowleft, Point_2 &uple
 void PHG4InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
 {
   G4Material *Air = G4Material::GetMaterial("G4_AIR");
-  G4VSolid *hcal_envelope_cylinder = new G4Tubs("InnerHcal_envelope_solid", envelope_inner_radius, envelope_outer_radius, envelope_z / 2., 0, 2 * M_PI);
-  volume_envelope = hcal_envelope_cylinder->GetCubicVolume();
+  G4VSolid *hcal_envelope_cylinder = new G4Tubs("InnerHcal_envelope_solid", m_EnvelopeInnerRadius, m_EnvelopeOuterRadius, m_EnvelopeZ / 2., 0, 2 * M_PI);
+  m_VolumeEnvelope = hcal_envelope_cylinder->GetCubicVolume();
   G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("Hcal_envelope"), 0, 0, 0);
   G4VisAttributes *hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(false);
@@ -416,10 +416,10 @@ void PHG4InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
   hcalVisAtt->SetColour(G4Colour::White());
   hcal_envelope_log->SetVisAttributes(hcalVisAtt);
   G4RotationMatrix hcal_rotm;
-  hcal_rotm.rotateX(params->get_double_param("rot_x") * deg);
-  hcal_rotm.rotateY(params->get_double_param("rot_y") * deg);
-  hcal_rotm.rotateZ(params->get_double_param("rot_z") * deg);
-  new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(params->get_double_param("place_x") * cm, params->get_double_param("place_y") * cm, params->get_double_param("place_z") * cm)), hcal_envelope_log, "InnerHcalEnvelope", logicWorld, 0, false, OverlapCheck());
+  hcal_rotm.rotateX(m_Params->get_double_param("rot_x") * deg);
+  hcal_rotm.rotateY(m_Params->get_double_param("rot_y") * deg);
+  hcal_rotm.rotateZ(m_Params->get_double_param("rot_z") * deg);
+  new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "InnerHcalEnvelope", logicWorld, 0, false, OverlapCheck());
   ConstructInnerHcal(hcal_envelope_log);
   return;
 }
@@ -430,20 +430,20 @@ int PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume *hcalenvelope)
   SetTiltViaNcross();  // if number of crossings is set, use it to determine tilt
   CheckTiltAngle();    // die if the tilt angle is out of range
   G4VSolid *steel_plate = ConstructSteelPlate(hcalenvelope);
-  G4LogicalVolume *steel_logical = new G4LogicalVolume(steel_plate, G4Material::GetMaterial(params->get_string_param("material")), "HcalInnerSteelPlate", 0, 0, 0);
+  G4LogicalVolume *steel_logical = new G4LogicalVolume(steel_plate, G4Material::GetMaterial(m_Params->get_string_param("material")), "HcalInnerSteelPlate", 0, 0, 0);
   G4VisAttributes *visattchk = new G4VisAttributes();
   visattchk->SetVisibility(true);
   visattchk->SetForceSolid(true);
   visattchk->SetColour(G4Colour::Grey());
   steel_logical->SetVisAttributes(visattchk);
-  scinti_mother_assembly = ConstructHcalScintillatorAssembly(hcalenvelope);
+  m_ScintiMotherAssembly = ConstructHcalScintillatorAssembly(hcalenvelope);
   double phi = 0;
-  double deltaphi = 2 * M_PI / n_scinti_plates;
+  double deltaphi = 2 * M_PI / m_NumScintiPlates;
   ostringstream name;
-  double middlerad = outer_radius - (outer_radius - inner_radius) / 2.;
+  double middlerad = m_OuterRadius - (m_OuterRadius - m_InnerRadius) / 2.;
   // for shorter scintillators we have to shift by 1/2 the "missing length"
-  double scinti_tile_orig_length = scinti_tile_x_upper + scinti_tile_x_lower - subtract_from_scinti_x;
-  double shiftslat = fabs(scinti_tile_x_lower - scinti_tile_x_upper) / 2. + (scinti_tile_orig_length - scinti_tile_x) / 2.;
+  double scinti_tile_orig_length = m_ScintiTileXUpper + m_ScintiTileXLower - subtract_from_scinti_x;
+  double shiftslat = fabs(m_ScintiTileXLower - m_ScintiTileXUpper) / 2. + (scinti_tile_orig_length - m_ScintiTileX) / 2.;
   // calculate phi offset (copied from code inside following loop):
   // first get the center point (phi=0) so it's middlerad/0
   // then shift the scintillator center as documented in loop
@@ -456,22 +456,22 @@ int PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume *hcalenvelope)
   // the middle of the scintillator sits at zero)
   double xp = cos(phi) * middlerad;
   double yp = sin(phi) * middlerad;
-  xp -= cos((-tilt_angle) / rad - phi) * shiftslat;
-  yp += sin((-tilt_angle) / rad - phi) * shiftslat;
-  if (tilt_angle > 0)
+  xp -= cos((-m_TiltAngle) / rad - phi) * shiftslat;
+  yp += sin((-m_TiltAngle) / rad - phi) * shiftslat;
+  if (m_TiltAngle > 0)
   {
-    double xo = xp - (scinti_tile_x / 2.) * cos(tilt_angle / rad);
-    double yo = yp - (scinti_tile_x / 2.) * sin(tilt_angle / rad);
+    double xo = xp - (m_ScintiTileX / 2.) * cos(m_TiltAngle / rad);
+    double yo = yp - (m_ScintiTileX / 2.) * sin(m_TiltAngle / rad);
     phi = -atan(yo / xo);
   }
-  else if (tilt_angle < 0)
+  else if (m_TiltAngle < 0)
   {
-    double xo = xp + (scinti_tile_x / 2.) * cos(tilt_angle / rad);
-    double yo = yp + (scinti_tile_x / 2.) * sin(tilt_angle / rad);
+    double xo = xp + (m_ScintiTileX / 2.) * cos(m_TiltAngle / rad);
+    double yo = yp + (m_ScintiTileX / 2.) * sin(m_TiltAngle / rad);
     phi = -atan(yo / xo);
   }
-  // else (for tilt_angle = 0) phi stays zero
-  for (int i = 0; i < n_scinti_plates; i++)
+  // else (for m_TiltAngle = 0) phi stays zero
+  for (int i = 0; i < m_NumScintiPlates; i++)
   {
     G4RotationMatrix *Rot = new G4RotationMatrix();
     double ypos = sin(phi) * middlerad;
@@ -479,21 +479,21 @@ int PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume *hcalenvelope)
     // the center of the scintillator is not the center of the inner hcal
     // but depends on the tilt angle. Therefore we need to shift
     // the center from the mid point
-    ypos += sin((-tilt_angle) / rad - phi) * shiftslat;
-    xpos -= cos((-tilt_angle) / rad - phi) * shiftslat;
-    Rot->rotateZ(phi * rad + tilt_angle);
+    ypos += sin((-m_TiltAngle) / rad - phi) * shiftslat;
+    xpos -= cos((-m_TiltAngle) / rad - phi) * shiftslat;
+    Rot->rotateZ(phi * rad + m_TiltAngle);
     G4ThreeVector g4vec(xpos, ypos, 0);
     // great the MakeImprint always adds 1 to the copy number and 0 has a
     // special meaning (which then also adds 1). Basically our volume names
     // will start at 1 instead of 0 and there is nothing short of patching this
     // method. I'll take care of this in the decoding of the volume name
     // AAAAAAARHGS
-    scinti_mother_assembly->MakeImprint(hcalenvelope, g4vec, Rot, i, OverlapCheck());
+    m_ScintiMotherAssembly->MakeImprint(hcalenvelope, g4vec, Rot, i, OverlapCheck());
     Rot = new G4RotationMatrix();
     Rot->rotateZ(-phi * rad);
     name.str("");
     name << "InnerHcalSteel_" << i;
-    steel_absorber_vec.insert(new G4PVPlacement(Rot, G4ThreeVector(0, 0, 0), steel_logical, name.str().c_str(), hcalenvelope, 0, i, OverlapCheck()));
+    m_SteelAbsorberPhysVolSet.insert(new G4PVPlacement(Rot, G4ThreeVector(0, 0, 0), steel_logical, name.str().c_str(), hcalenvelope, 0, i, OverlapCheck()));
     phi += deltaphi;
   }
   return 0;
@@ -506,30 +506,30 @@ void PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
 {
   G4VSolid *bigtile = ConstructScintillatorBox(hcalenvelope);
   // eta->theta
-  G4double delta_eta = params->get_double_param("scinti_eta_coverage") / n_scinti_tiles;
+  G4double delta_eta = m_Params->get_double_param("scinti_eta_coverage") / m_NumScintiTiles;
   G4double eta = 0;
   G4double theta;
   G4double x[4];
   G4double z[4];
   ostringstream name;
-  double overhang = (scinti_tile_x - (outer_radius - inner_radius)) / 2.;
+  double overhang = (m_ScintiTileX - (m_OuterRadius - m_InnerRadius)) / 2.;
   double offset = 1 * cm + overhang;  // add 1cm to make sure the G4ExtrudedSolid
   // is larger than the tile so we do not have
   // funny edge effects when overlapping vols
-  double scinti_gap_neighbor = params->get_double_param("scinti_gap_neighbor") * cm;
-  for (int i = 0; i < n_scinti_tiles; i++)
+  double scinti_gap_neighbor = m_Params->get_double_param("scinti_gap_neighbor") * cm;
+  for (int i = 0; i < m_NumScintiTiles; i++)
   {
     theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
-    x[0] = inner_radius - overhang;
-    z[0] = tan(theta) * inner_radius;
-    x[1] = outer_radius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
-    z[1] = tan(theta) * outer_radius;
+    x[0] = m_InnerRadius - overhang;
+    z[0] = tan(theta) * m_InnerRadius;
+    x[1] = m_OuterRadius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
+    z[1] = tan(theta) * m_OuterRadius;
     eta += delta_eta;
     theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
-    x[2] = inner_radius - overhang;
-    z[2] = tan(theta) * inner_radius;
-    x[3] = outer_radius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
-    z[3] = tan(theta) * outer_radius;
+    x[2] = m_InnerRadius - overhang;
+    z[2] = tan(theta) * m_InnerRadius;
+    x[3] = m_OuterRadius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
+    z[3] = tan(theta) * m_OuterRadius;
     // apply gap between scintillators
     z[0] += scinti_gap_neighbor / 2.;
     z[1] += scinti_gap_neighbor / 2.;
@@ -537,15 +537,15 @@ void PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
     z[3] -= scinti_gap_neighbor / 2.;
     Point_2 leftsidelow(z[0], x[0]);
     Point_2 leftsidehigh(z[1], x[1]);
-    x[0] = inner_radius - offset;
+    x[0] = m_InnerRadius - offset;
     z[0] = x_at_y(leftsidelow, leftsidehigh, x[0]);
-    x[1] = outer_radius + offset;
+    x[1] = m_OuterRadius + offset;
     z[1] = x_at_y(leftsidelow, leftsidehigh, x[1]);
     Point_2 rightsidelow(z[2], x[2]);
     Point_2 rightsidehigh(z[3], x[3]);
-    x[2] = outer_radius + offset;
+    x[2] = m_OuterRadius + offset;
     z[2] = x_at_y(rightsidelow, rightsidehigh, x[2]);
-    x[3] = inner_radius - offset;
+    x[3] = m_InnerRadius - offset;
     z[3] = x_at_y(rightsidelow, rightsidehigh, x[3]);
 
     vector<G4TwoVector> vertexes;
@@ -558,21 +558,21 @@ void PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
 
     G4VSolid *scinti = new G4ExtrudedSolid("ScintillatorTile",
                                            vertexes,
-                                           scinti_tile_thickness + 0.2 * mm,
+                                           m_ScintiTileThickness + 0.2 * mm,
                                            zero, 1.0,
                                            zero, 1.0);
     G4RotationMatrix *rotm = new G4RotationMatrix();
     rotm->rotateX(-90 * deg);
     name.str("");
     name << "scintillator_" << i << "_left";
-    G4VSolid *scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(inner_radius + outer_radius) / 2., 0, 0));
-    scinti_tiles_vec[i + n_scinti_tiles] = scinti_tile;
+    G4VSolid *scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(m_InnerRadius + m_OuterRadius) / 2., 0, 0));
+    scinti_tiles_vec[i + m_NumScintiTiles] = scinti_tile;
     rotm = new G4RotationMatrix();
     rotm->rotateX(90 * deg);
     name.str("");
     name << "scintillator_" << i << "_right";
-    scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(inner_radius + outer_radius) / 2., 0, 0));
-    scinti_tiles_vec[n_scinti_tiles - i - 1] = scinti_tile;
+    scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(m_InnerRadius + m_OuterRadius) / 2., 0, 0));
+    scinti_tiles_vec[m_NumScintiTiles - i - 1] = scinti_tile;
   }
 
   // for (unsigned int i=0; i<scinti_tiles_vec.size(); i++)
@@ -624,7 +624,7 @@ PHG4InnerHcalDetector::ConstructHcalScintillatorAssembly(G4LogicalVolume *hcalen
   ostringstream name;
   G4ThreeVector g4vec;
 
-  double steplimits = params->get_double_param("steplimits") * cm;
+  double steplimits = m_Params->get_double_param("steplimits") * cm;
   for (unsigned int i = 0; i < scinti_tiles_vec.size(); i++)
   {
     name.str("");
@@ -645,68 +645,29 @@ PHG4InnerHcalDetector::ConstructHcalScintillatorAssembly(G4LogicalVolume *hcalen
   return assmeblyvol;
 }
 
-int PHG4InnerHcalDetector::DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm)
-{
-  static int i = 0;
-  G4LogicalVolume *checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), "DISPLAYLOGICAL", 0, 0, 0);
-  G4VisAttributes *visattchk = new G4VisAttributes();
-  visattchk->SetVisibility(true);
-  visattchk->SetForceSolid(false);
-  switch (i)
-  {
-  case 0:
-    visattchk->SetColour(G4Colour::Red());
-    i++;
-    break;
-  case 1:
-    visattchk->SetColour(G4Colour::Magenta());
-    i++;
-    break;
-  case 2:
-    visattchk->SetColour(G4Colour::Yellow());
-    i++;
-    break;
-  case 3:
-    visattchk->SetColour(G4Colour::Blue());
-    i++;
-    break;
-  case 4:
-    visattchk->SetColour(G4Colour::Cyan());
-    i++;
-    break;
-  default:
-    visattchk->SetColour(G4Colour::Green());
-    i = 0;
-    break;
-  }
-
-  checksolid->SetVisAttributes(visattchk);
-  new G4PVPlacement(rotm, G4ThreeVector(0, 0, 0), checksolid, "DISPLAYVOL", logvol, 0, false, OverlapCheck());
-  return 0;
-}
 // check if tilt angle is reasonable - too large, no intersections with inner radius
 int PHG4InnerHcalDetector::CheckTiltAngle() const
 {
-  if (fabs(tilt_angle / rad) >= M_PI)
+  if (fabs(m_TiltAngle / rad) >= M_PI)
   {
-    cout << PHWHERE << "invalid tilt angle, abs(tilt) >= 90 deg: " << (tilt_angle / deg)
+    cout << PHWHERE << "invalid tilt angle, abs(tilt) >= 90 deg: " << (m_TiltAngle / deg)
          << endl;
     exit(1);
   }
 
-  double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
+  double mid_radius = m_InnerRadius + (m_OuterRadius - m_InnerRadius) / 2.;
   Point_2 pmid(mid_radius, 0);  // center of scintillator
   double xcoord = 0;
-  double ycoord = mid_radius * tan(tilt_angle / rad);
+  double ycoord = mid_radius * tan(m_TiltAngle / rad);
   Point_2 pxnull(xcoord, ycoord);
   Line_2 s2(pmid, pxnull);
-  Point_2 sc1(inner_radius, 0), sc2(0, inner_radius), sc3(-inner_radius, 0);
+  Point_2 sc1(m_InnerRadius, 0), sc2(0, m_InnerRadius), sc3(-m_InnerRadius, 0);
   Circle_2 inner_circle(sc1, sc2, sc3);
   vector<CGAL::Object> res;
   CGAL::intersection(inner_circle, s2, std::back_inserter(res));
   if (res.size() == 0)
   {
-    cout << PHWHERE << " Tilt angle " << (tilt_angle / deg)
+    cout << PHWHERE << " Tilt angle " << (m_TiltAngle / deg)
          << " too large, no intersection with inner radius" << endl;
     exit(1);
   }
@@ -716,24 +677,24 @@ int PHG4InnerHcalDetector::CheckTiltAngle() const
 int PHG4InnerHcalDetector::ConsistencyCheck() const
 {
   // just make sure the parameters make a bit of sense
-  if (inner_radius >= outer_radius)
+  if (m_InnerRadius >= m_OuterRadius)
   {
-    cout << PHWHERE << ": Inner Radius " << inner_radius / cm
-         << " cm larger than Outer Radius " << outer_radius / cm
+    cout << PHWHERE << ": Inner Radius " << m_InnerRadius / cm
+         << " cm larger than Outer Radius " << m_OuterRadius / cm
          << " cm" << endl;
     gSystem->Exit(1);
   }
-  if (scinti_tile_thickness > scinti_inner_gap)
+  if (m_ScintiTileThickness > m_ScintiInnerGap)
   {
-    cout << PHWHERE << "Scintillator thickness " << scinti_tile_thickness / cm
-         << " cm larger than scintillator inner gap " << scinti_inner_gap / cm
+    cout << PHWHERE << "Scintillator thickness " << m_ScintiTileThickness / cm
+         << " cm larger than scintillator inner gap " << m_ScintiInnerGap / cm
          << " cm" << endl;
     gSystem->Exit(1);
   }
-  if (scinti_outer_radius <= inner_radius)
+  if (m_ScintiOuterRadius <= m_InnerRadius)
   {
-    cout << PHWHERE << "Scintillator outer radius " << scinti_outer_radius / cm
-         << " cm smaller than inner radius " << inner_radius / cm
+    cout << PHWHERE << "Scintillator outer radius " << m_ScintiOuterRadius / cm
+         << " cm smaller than inner radius " << m_InnerRadius / cm
          << " cm" << endl;
     gSystem->Exit(1);
   }
@@ -745,28 +706,28 @@ void PHG4InnerHcalDetector::SetTiltViaNcross()
   // if tilt angle is set it takes precedence
   // this happens during readback where the tilt angle was set
   // in this method
-  int ncross = params->get_int_param("ncross");
-  if (!ncross || isfinite(tilt_angle))
+  int ncross = m_Params->get_int_param("ncross");
+  if (!ncross || isfinite(m_TiltAngle))
   {
     // flag ncrossing as not used
-    params->set_int_param("ncross",0);
+    m_Params->set_int_param("ncross",0);
     return;
   }
-  if ((isfinite(tilt_angle)) && (Verbosity() > 0))
+  if ((isfinite(m_TiltAngle)) && (Verbosity() > 0))
   {
     cout << "both number of crossings and tilt angle are set" << endl;
     cout << "using number of crossings to determine tilt angle" << endl;
   }
-  double mid_radius = inner_radius + (outer_radius - inner_radius) / 2.;
-  double deltaphi = (2 * M_PI / n_scinti_plates) * ncross;
+  double mid_radius = m_InnerRadius + (m_OuterRadius - m_InnerRadius) / 2.;
+  double deltaphi = (2 * M_PI / m_NumScintiPlates) * ncross;
   Point_2 pnull(0, 0);
-  Point_2 plow(inner_radius, 0);
+  Point_2 plow(m_InnerRadius, 0);
   Point_2 phightmp(1, tan(deltaphi));
-  Point_2 pin1(inner_radius, 0), pin2(0, inner_radius), pin3(-inner_radius, 0);
+  Point_2 pin1(m_InnerRadius, 0), pin2(0, m_InnerRadius), pin3(-m_InnerRadius, 0);
   Circle_2 inner_circle(pin1, pin2, pin3);
   Point_2 pmid1(mid_radius, 0), pmid2(0, mid_radius), pmid3(-mid_radius, 0);
   Circle_2 mid_circle(pmid1, pmid2, pmid3);
-  Point_2 pout1(outer_radius, 0), pout2(0, outer_radius), pout3(-outer_radius, 0);
+  Point_2 pout1(m_OuterRadius, 0), pout2(0, m_OuterRadius), pout3(-m_OuterRadius, 0);
   Circle_2 outer_circle(pout1, pout2, pout3);
   Line_2 l_up(pnull, phightmp);
   vector<CGAL::Object> res;
@@ -812,14 +773,14 @@ void PHG4InnerHcalDetector::SetTiltViaNcross()
     }
   }
   // length left side
-  double ll = sqrt((CGAL::to_double(midpoint.x()) - inner_radius) * (CGAL::to_double(midpoint.x()) - inner_radius) + CGAL::to_double(midpoint.y()) * CGAL::to_double(midpoint.y()));
+  double ll = sqrt((CGAL::to_double(midpoint.x()) - m_InnerRadius) * (CGAL::to_double(midpoint.x()) - m_InnerRadius) + CGAL::to_double(midpoint.y()) * CGAL::to_double(midpoint.y()));
   double upside = sqrt(CGAL::to_double(midpoint.x()) * CGAL::to_double(midpoint.x()) + CGAL::to_double(midpoint.y()) * CGAL::to_double(midpoint.y()));
   //  c^2 = a^2+b^2 - 2ab*cos(gamma)
   // gamma = acos((a^2+b^2=c^2)/2ab
-  double tiltangle = acos((ll * ll + upside * upside - inner_radius * inner_radius) / (2 * ll * upside));
+  double tiltangle = acos((ll * ll + upside * upside - m_InnerRadius * m_InnerRadius) / (2 * ll * upside));
   tiltangle = tiltangle * rad;
-  tilt_angle = copysign(tiltangle, ncross);
-  params->set_double_param("tilt_angle", tilt_angle / deg);
+  m_TiltAngle = copysign(tiltangle, ncross);
+  m_Params->set_double_param("tilt_angle", m_TiltAngle / deg);
   return;
 }
 
@@ -828,10 +789,10 @@ void PHG4InnerHcalDetector::Print(const string &what) const
   cout << "Inner Hcal Detector:" << endl;
   if (what == "ALL" || what == "VOLUME")
   {
-    cout << "Volume Envelope: " << volume_envelope / cm / cm / cm << " cm^3" << endl;
-    cout << "Volume Steel: " << volume_steel / cm / cm / cm << " cm^3" << endl;
-    cout << "Volume Scintillator: " << volume_scintillator / cm / cm / cm << " cm^3" << endl;
-    cout << "Volume Air: " << (volume_envelope - volume_steel - volume_scintillator) / cm / cm / cm << " cm^3" << endl;
+    cout << "Volume Envelope: " << m_VolumeEnvelope / cm3 << " cm^3" << endl;
+    cout << "Volume Steel: " << m_VolumeSteel / cm3 << " cm^3" << endl;
+    cout << "Volume Scintillator: " << m_VolumeScintillator / cm3 << " cm^3" << endl;
+    cout << "Volume Air: " << (m_VolumeEnvelope - m_VolumeSteel - m_VolumeScintillator) / cm3 << " cm^3" << endl;
   }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -34,8 +34,8 @@
 #include <CGAL/Object.h>
 #include <CGAL/point_generators_2.h>
 
-#include <boost/tokenizer.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/tokenizer.hpp>
 
 #include <cmath>
 #include <sstream>
@@ -134,7 +134,7 @@ PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_upperedge.x()))
       {
@@ -168,7 +168,7 @@ PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > minx)
       {
@@ -212,7 +212,7 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > 0)
       {
@@ -240,7 +240,7 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
       {
@@ -279,7 +279,7 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
     for (iter = res.begin(); iter != res.end(); ++iter)
     {
       CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
+      if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned>>(&obj))
       {
         if (CGAL::to_double(point->first.x()) > pxmax)
         {
@@ -307,7 +307,7 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
     for (iter = res.begin(); iter != res.end(); ++iter)
     {
       CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
+      if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned>>(&obj))
       {
         if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
         {
@@ -364,7 +364,7 @@ void PHG4InnerHcalDetector::ShiftSecantToTangent(Point_2 &lowleft, Point_2 &uple
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > pxmax)
       {
@@ -411,8 +411,8 @@ void PHG4InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
   hcal_rotm.rotateZ(m_Params->get_double_param("rot_z") * deg);
   new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "InnerHcalEnvelope", logicWorld, 0, false, OverlapCheck());
   ConstructInnerHcal(hcal_envelope_log);
-  vector<G4VPhysicalVolume*>::iterator it = m_ScintiMotherAssembly->GetVolumesIterator();
-  for (unsigned int i=0; i<m_ScintiMotherAssembly->TotalImprintedVolumes();i++)
+  vector<G4VPhysicalVolume *>::iterator it = m_ScintiMotherAssembly->GetVolumesIterator();
+  for (unsigned int i = 0; i < m_ScintiMotherAssembly->TotalImprintedVolumes(); i++)
   {
     // G4AssemblyVolumes naming convention:
     //     av_WWW_impr_XXX_YYY_ZZZ
@@ -433,8 +433,8 @@ void PHG4InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
     // so we can use the CopyNo rather than decoding the string further
     // looking for "pv"
     boost::char_separator<char> sep("_");
-    boost::tokenizer<boost::char_separator<char> > tok((*it)->GetName(), sep);
-    boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
+    boost::tokenizer<boost::char_separator<char>> tok((*it)->GetName(), sep);
+    boost::tokenizer<boost::char_separator<char>>::const_iterator tokeniter;
     for (tokeniter = tok.begin(); tokeniter != tok.end(); ++tokeniter)
     {
       if (*tokeniter == "impr")
@@ -447,10 +447,10 @@ void PHG4InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
           // to give the first volume id=0, so they go from id=1 to id=n.
           // I am not going to start with fortran again - our indices start
           // at zero, id=0 to id=n-1. So subtract one here
-	  int tower_id = (*it)->GetCopyNo() - layer_id;
+          int tower_id = (*it)->GetCopyNo() - layer_id;
           layer_id--;
-	  pair<int, int> layer_twr = make_pair(layer_id, tower_id);
-	  m_ScintiTilePhysVolMap.insert(pair<G4VPhysicalVolume *, pair<int, int>> (*it,layer_twr));
+          pair<int, int> layer_twr = make_pair(layer_id, tower_id);
+          m_ScintiTilePhysVolMap.insert(pair<G4VPhysicalVolume *, pair<int, int>>(*it, layer_twr));
           if (layer_id < 0 || layer_id >= m_NumScintiPlates)
           {
             cout << "invalid scintillator row " << layer_id
@@ -464,7 +464,7 @@ void PHG4InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
                << " for mother volume number " << endl;
           gSystem->Exit(1);
         }
-	break;
+        break;
       }
     }
     ++it;
@@ -758,7 +758,7 @@ void PHG4InnerHcalDetector::SetTiltViaNcross()
   if (!ncross || isfinite(m_TiltAngle))
   {
     // flag ncrossing as not used
-    m_Params->set_int_param("ncross",0);
+    m_Params->set_int_param("ncross", 0);
     return;
   }
   if ((isfinite(m_TiltAngle)) && (Verbosity() > 0))
@@ -785,7 +785,7 @@ void PHG4InnerHcalDetector::SetTiltViaNcross()
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > 0)
       {
@@ -806,7 +806,7 @@ void PHG4InnerHcalDetector::SetTiltViaNcross()
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > 0)
       {
@@ -855,7 +855,7 @@ std::pair<int, int> PHG4InnerHcalDetector::GetLayerTowerId(G4VPhysicalVolume *vo
   cout << "could not locate volume " << volume->GetName()
        << " in Inner Hcal scintillator map" << endl;
   gSystem->Exit(1);
-// that's dumb but code checkers do not know that gSystem->Exit() 
-// terminates, so using the standard exit() makes them happy
+  // that's dumb but code checkers do not know that gSystem->Exit()
+  // terminates, so using the standard exit() makes them happy
   exit(1);
 }

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -95,4 +95,4 @@ class PHG4InnerHcalDetector : public PHG4Detector
   std::string m_ScintiLogicNamePrefix;
 };
 
-#endif // G4DETECTORS_PHG4INNERHCALDETECTOR_H
+#endif  // G4DETECTORS_PHG4INNERHCALDETECTOR_H

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -1,5 +1,5 @@
-#ifndef PHG4InnerHcalDetector_h
-#define PHG4InnerHcalDetector_h
+#ifndef G4DETECTORS_PHG4INNERHCALDETECTOR_H
+#define G4DETECTORS_PHG4INNERHCALDETECTOR_H
 
 #include <g4main/PHG4Detector.h>
 
@@ -41,9 +41,9 @@ class PHG4InnerHcalDetector : public PHG4Detector
   int IsInInnerHcal(G4VPhysicalVolume *) const;
   //@}
 
-  void SuperDetector(const std::string &name) { superdetector = name; }
-  const std::string SuperDetector() const { return superdetector; }
-  int get_Layer() const { return layer; }
+  void SuperDetector(const std::string &name) { m_SuperDetector = name; }
+  const std::string SuperDetector() const { return m_SuperDetector; }
+  int get_Layer() const { return m_Layer; }
   G4VSolid *ConstructSteelPlate(G4LogicalVolume *hcalenvelope);
   G4VSolid *ConstructScintillatorBox(G4LogicalVolume *hcalenvelope);
   void ShiftSecantToTangent(Point_2 &lowleft, Point_2 &upleft, Point_2 &upright, Point_2 &lowright);
@@ -56,41 +56,40 @@ class PHG4InnerHcalDetector : public PHG4Detector
 
  protected:
   int ConstructInnerHcal(G4LogicalVolume *sandwich);
-  int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = nullptr);
   double x_at_y(Point_2 &p0, Point_2 &p1, double yin);
-  PHParameters *params;
-  G4AssemblyVolume *scinti_mother_assembly;
-  double inner_radius;
-  double outer_radius;
-  double size_z;
-  double scinti_tile_x;
-  double scinti_tile_x_lower;
-  double scinti_tile_x_upper;
-  double scinti_tile_z;
-  double scinti_tile_thickness;
-  double scinti_inner_gap;
-  double scinti_outer_gap;
-  double scinti_outer_radius;
-  double tilt_angle;
-  double envelope_inner_radius;
-  double envelope_outer_radius;
-  double envelope_z;
-  double volume_envelope;
-  double volume_steel;
-  double volume_scintillator;
+  PHParameters *m_Params;
+  G4AssemblyVolume *m_ScintiMotherAssembly;
+  double m_InnerRadius;
+  double m_OuterRadius;
+  double m_SizeZ;
+  double m_ScintiTileX;
+  double m_ScintiTileXLower;
+  double m_ScintiTileXUpper;
+  double m_ScintiTileZ;
+  double m_ScintiTileThickness;
+  double m_ScintiInnerGap;
+  double m_ScintiOuterGap;
+  double m_ScintiOuterRadius;
+  double m_TiltAngle;
+  double m_EnvelopeInnerRadius;
+  double m_EnvelopeOuterRadius;
+  double m_EnvelopeZ;
+  double m_VolumeEnvelope;
+  double m_VolumeSteel;
+  double m_VolumeScintillator;
 
-  int n_scinti_plates;
-  int n_scinti_tiles;
+  int m_NumScintiPlates;
+  int m_NumScintiTiles;
 
-  int active;
-  int absorberactive;
+  int m_Active;
+  int m_AbsorberActive;
 
-  int layer;
-  std::string detector_type;
-  std::string superdetector;
-  std::set<G4VPhysicalVolume *> steel_absorber_vec;
+  int m_Layer;
+//  std::string m_DetectorType;
+  std::string m_SuperDetector;
+  std::set<G4VPhysicalVolume *> m_SteelAbsorberPhysVolSet;
   std::vector<G4VSolid *> scinti_tiles_vec;
   std::string scintilogicnameprefix;
 };
 
-#endif
+#endif // G4DETECTORS_PHG4INNERHCALDETECTOR_H

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -53,6 +53,7 @@ class PHG4InnerHcalDetector : public PHG4Detector
   int CheckTiltAngle() const;
   int ConsistencyCheck() const;
   void SetTiltViaNcross();
+  std::pair<int, int> GetLayerTowerId(G4VPhysicalVolume *volume) const;
 
  protected:
   int ConstructInnerHcal(G4LogicalVolume *sandwich);
@@ -85,11 +86,11 @@ class PHG4InnerHcalDetector : public PHG4Detector
   int m_AbsorberActive;
 
   int m_Layer;
-//  std::string m_DetectorType;
   std::string m_SuperDetector;
   std::set<G4VPhysicalVolume *> m_SteelAbsorberPhysVolSet;
-  std::vector<G4VSolid *> scinti_tiles_vec;
-  std::string scintilogicnameprefix;
+  std::map<G4VPhysicalVolume *, std::pair<int, int>> m_ScintiTilePhysVolMap;
+  std::vector<G4VSolid *> m_ScintiTilesVec;
+  std::string m_ScintiLogicNamePrefix;
 };
 
 #endif // G4DETECTORS_PHG4INNERHCALDETECTOR_H

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -1,3 +1,5 @@
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
 #ifndef G4DETECTORS_PHG4INNERHCALDETECTOR_H
 #define G4DETECTORS_PHG4INNERHCALDETECTOR_H
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -42,8 +42,8 @@ PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector* 
 {
   SetLightCorrection(m_Params->get_double_param("light_balance_inner_radius") * cm,
                      m_Params->get_double_param("light_balance_inner_corr"),
-		     m_Params->get_double_param("light_balance_outer_radius") * cm,
-		     m_Params->get_double_param("light_balance_outer_corr"));
+                     m_Params->get_double_param("light_balance_outer_radius") * cm,
+                     m_Params->get_double_param("light_balance_outer_corr"));
   SetName(m_Detector->GetName());
 }
 
@@ -79,11 +79,11 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
   int tower_id = -1;
   if (whichactive > 0)  // scintillator
   {
-    pair<int, int> layer_tower =  m_Detector->GetLayerTowerId(volume);
+    pair<int, int> layer_tower = m_Detector->GetLayerTowerId(volume);
     layer_id = layer_tower.first;
     tower_id = layer_tower.second;
-     // cout << "name " << volume->GetName() << ", mid: " << layer_id
-     //  	   << ", twr: " << tower_id << endl;
+    // cout << "name " << volume->GetName() << ", mid: " << layer_id
+    //  	   << ", twr: " << tower_id << endl;
   }
   else
   {
@@ -228,10 +228,9 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
     m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
 
-
     //sum up the energy to get total deposited
     m_Hit->set_edep(m_Hit->get_edep() + edep);
-    if (whichactive > 0) // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
+    if (whichactive > 0)  // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
     {
       m_Hit->set_eion(m_Hit->get_eion() + eion);
       light_yield = eion;
@@ -239,7 +238,7 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       {
         light_yield = GetVisibleEnergyDeposition(aStep);  // for scintillator only, calculate light yields
       }
-      light_yield = light_yield *GetLightCorrection(postPoint->GetPosition().x(),postPoint->GetPosition().y()) ;
+      light_yield = light_yield * GetLightCorrection(postPoint->GetPosition().x(), postPoint->GetPosition().y());
       m_Hit->set_light_yield(m_Hit->get_light_yield() + light_yield);
     }
     if (geantino)

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -40,10 +40,10 @@
 using namespace std;
 //____________________________________________________________________________..
 PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector* detector, const PHParameters* parameters)
-  : detector_(detector)
-  , hits_(nullptr)
-  , absorberhits_(nullptr)
-  , hit(nullptr)
+  : m_Detector(detector)
+  , m_Hits(nullptr)
+  , m_Absorberhits(nullptr)
+  , m_Hit(nullptr)
   , params(parameters)
   , savehitcontainer(nullptr)
   , saveshower(nullptr)
@@ -62,7 +62,7 @@ PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector* 
   , light_balance_outer_corr(params->get_double_param("light_balance_outer_corr"))
   , light_balance_outer_radius(params->get_double_param("light_balance_outer_radius") * cm)
 {
-  GetName() = detector_->GetName();
+  GetName() = m_Detector->GetName();
 }
 
 PHG4InnerHcalSteppingAction::~PHG4InnerHcalSteppingAction()
@@ -71,7 +71,7 @@ PHG4InnerHcalSteppingAction::~PHG4InnerHcalSteppingAction()
   // and the memory is still allocated, so we need to delete it here
   // if the last hit was saved, hit is a nullptr pointer which are
   // legal to delete (it results in a no operation)
-  delete hit;
+  delete m_Hit;
 }
 //____________________________________________________________________________..
 bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
@@ -81,13 +81,13 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
   // get volume of the current step
   G4VPhysicalVolume* volume = touch->GetVolume();
 
-  // detector_->IsInInnerHcal(volume)
+  // m_Detector->IsInInnerHcal(volume)
   // returns
   //  0 is outside of InnerHcal
   //  1 is inside scintillator
   // -1 is steel absorber
 
-  int whichactive = detector_->IsInInnerHcal(volume);
+  int whichactive = m_Detector->IsInInnerHcal(volume);
 
   if (!whichactive)
   {
@@ -97,68 +97,11 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
   int tower_id = -1;
   if (whichactive > 0)  // scintillator
   {
-    // G4AssemblyVolumes naming convention:
-    //     av_WWW_impr_XXX_YYY_ZZZ
-    // where:
-
-    //     WWW - assembly volume instance number
-    //     XXX - assembly volume imprint number
-    //     YYY - the name of the placed logical volume
-    //     ZZZ - the logical volume index inside the assembly volume
-    // e.g. av_1_impr_82_HcalInnerScinti_11_pv_11
-    // 82 the number of the scintillator mother volume
-    // HcalInnerScinti_11: name of scintillator slat
-    // 11: number of scintillator slat logical volume
-    // use boost tokenizer to separate the _, then take value
-    // after "impr" for mother volume and after "pv" for scintillator slat
-    // use boost lexical cast for string -> int conversion
-    boost::char_separator<char> sep("_");
-    boost::tokenizer<boost::char_separator<char> > tok(volume->GetName(), sep);
-    boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
-    for (tokeniter = tok.begin(); tokeniter != tok.end(); ++tokeniter)
-    {
-      if (*tokeniter == "impr")
-      {
-        ++tokeniter;
-        if (tokeniter != tok.end())
-        {
-          layer_id = boost::lexical_cast<int>(*tokeniter);
-          // check detector description, for assemblyvolumes it is not possible
-          // to give the first volume id=0, so they go from id=1 to id=n.
-          // I am not going to start with fortran again - our indices start
-          // at zero, id=0 to id=n-1. So subtract one here
-          layer_id--;
-          if (layer_id < 0 || layer_id >= n_scinti_plates)
-          {
-            cout << "invalid scintillator row " << layer_id
-                 << ", valid range 0 < row < " << n_scinti_plates << endl;
-            gSystem->Exit(1);
-          }
-        }
-        else
-        {
-          cout << PHWHERE << " Error parsing " << volume->GetName()
-               << " for mother volume number " << endl;
-          gSystem->Exit(1);
-        }
-      }
-      else if (*tokeniter == "pv")
-      {
-        ++tokeniter;
-        if (tokeniter != tok.end())
-        {
-          tower_id = boost::lexical_cast<int>(*tokeniter);
-        }
-        else
-        {
-          cout << PHWHERE << " Error parsing " << volume->GetName()
-               << " for mother scinti slat id " << endl;
-          gSystem->Exit(1);
-        }
-      }
-    }
-    // cout << "name " << volume->GetName() << ", mid: " << layer_id
-    //  	   << ", twr: " << tower_id << endl;
+    pair<int, int> layer_tower =  m_Detector->GetLayerTowerId(volume);
+    layer_id = layer_tower.first;
+    tower_id = layer_tower.second;
+     // cout << "name " << volume->GetName() << ", mid: " << layer_id
+     //  	   << ", twr: " << tower_id << endl;
   }
   else
   {
@@ -221,39 +164,39 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     case fUndefined:
       // if previous hit was saved, hit pointer was set to nullptr
       // and we have to make a new one
-      if (!hit)
+      if (!m_Hit)
       {
-        hit = new PHG4Hitv1();
+        m_Hit = new PHG4Hitv1();
       }
       //here we set the entrance values in cm
-      hit->set_x(0, prePoint->GetPosition().x() / cm);
-      hit->set_y(0, prePoint->GetPosition().y() / cm);
-      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      m_Hit->set_x(0, prePoint->GetPosition().x() / cm);
+      m_Hit->set_y(0, prePoint->GetPosition().y() / cm);
+      m_Hit->set_z(0, prePoint->GetPosition().z() / cm);
       // time in ns
-      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      m_Hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
       //set and save the track ID
-      hit->set_trkid(aTrack->GetTrackID());
+      m_Hit->set_trkid(aTrack->GetTrackID());
       savetrackid = aTrack->GetTrackID();
       //set the initial energy deposit
-      hit->set_edep(0);
+      m_Hit->set_edep(0);
       if (whichactive > 0)  // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
       {
-        hit->set_scint_id(tower_id);  // the slat id
-        hit->set_eion(0);             // only implemented for v5 otherwise empty
-        hit->set_light_yield(0);      // for scintillator only, initialize light yields
+        m_Hit->set_scint_id(tower_id);  // the slat id
+        m_Hit->set_eion(0);             // only implemented for v5 otherwise empty
+        m_Hit->set_light_yield(0);      // for scintillator only, initialize light yields
         // Now save the container we want to add this hit to
-        savehitcontainer = hits_;
+        savehitcontainer = m_Hits;
       }
       else
       {
-        savehitcontainer = absorberhits_;
+        savehitcontainer = m_Absorberhits;
       }
       if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {
         if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
-          hit->set_trkid(pp->GetUserTrackId());
-          hit->set_shower_id(pp->GetShower()->get_id());
+          m_Hit->set_trkid(pp->GetUserTrackId());
+          m_Hit->set_shower_id(pp->GetShower()->get_id());
           saveshower = pp->GetShower();
         }
       }
@@ -263,7 +206,7 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     }
     // some sanity checks for inconsistencies
     // check if this hit was created, if not print out last post step status
-    if (!hit || !isfinite(hit->get_x(0)))
+    if (!m_Hit || !isfinite(m_Hit->get_x(0)))
     {
       cout << GetName() << ": hit was not created" << endl;
       cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
@@ -297,11 +240,11 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     // here we just update the exit values, it will be overwritten
     // for every step until we leave the volume or the particle
     // ceases to exist
-    hit->set_x(1, postPoint->GetPosition().x() / cm);
-    hit->set_y(1, postPoint->GetPosition().y() / cm);
-    hit->set_z(1, postPoint->GetPosition().z() / cm);
+    m_Hit->set_x(1, postPoint->GetPosition().x() / cm);
+    m_Hit->set_y(1, postPoint->GetPosition().y() / cm);
+    m_Hit->set_z(1, postPoint->GetPosition().z() / cm);
 
-    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+    m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
 
     if (whichactive > 0)  // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
     {
@@ -325,16 +268,16 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     }
 
     //sum up the energy to get total deposited
-    hit->set_edep(hit->get_edep() + edep);
+    m_Hit->set_edep(m_Hit->get_edep() + edep);
     if (whichactive > 0)
     {
-      hit->set_eion(hit->get_eion() + eion);
-      hit->set_light_yield(hit->get_light_yield() + light_yield);
+      m_Hit->set_eion(m_Hit->get_eion() + eion);
+      m_Hit->set_light_yield(m_Hit->get_light_yield() + light_yield);
     }
     if (geantino)
     {
-      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-      hit->set_eion(-1);
+      m_Hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      m_Hit->set_eion(-1);
     }
     if (edep > 0)
     {
@@ -361,23 +304,23 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         aTrack->GetTrackStatus() == fStopAndKill)
     {
       // save only hits with energy deposit (or -1 for geantino)
-      if (hit->get_edep())
+      if (m_Hit->get_edep())
       {
-        savehitcontainer->AddHit(layer_id, hit);
+        savehitcontainer->AddHit(layer_id, m_Hit);
         if (saveshower)
         {
-          saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
+          saveshower->add_g4hit_id(savehitcontainer->GetID(), m_Hit->get_hit_id());
         }
         // ownership has been transferred to container, set to null
         // so we will create a new hit for the next track
-        hit = nullptr;
+        m_Hit = nullptr;
       }
       else
       {
         // if this hit has no energy deposit, just reset it for reuse
         // this means we have to delete it in the dtor. If this was
         // the last hit we processed the memory is still allocated
-        hit->Reset();
+        m_Hit->Reset();
       }
     }
     // return true to indicate the hit was used
@@ -394,27 +337,27 @@ void PHG4InnerHcalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
   string hitnodename;
   string absorbernodename;
-  if (detector_->SuperDetector() != "NONE")
+  if (m_Detector->SuperDetector() != "NONE")
   {
-    hitnodename = "G4HIT_" + detector_->SuperDetector();
-    absorbernodename = "G4HIT_ABSORBER_" + detector_->SuperDetector();
+    hitnodename = "G4HIT_" + m_Detector->SuperDetector();
+    absorbernodename = "G4HIT_ABSORBER_" + m_Detector->SuperDetector();
   }
   else
   {
-    hitnodename = "G4HIT_" + detector_->GetName();
-    absorbernodename = "G4HIT_ABSORBER_" + detector_->GetName();
+    hitnodename = "G4HIT_" + m_Detector->GetName();
+    absorbernodename = "G4HIT_ABSORBER_" + m_Detector->GetName();
   }
 
   //now look for the map and grab a pointer to it.
-  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
-  absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
+  m_Hits = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  m_Absorberhits = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
 
   // if we do not find the node it's messed up.
-  if (!hits_)
+  if (!m_Hits)
   {
     std::cout << "PHG4InnerHcalSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
   }
-  if (!absorberhits_)
+  if (!m_Absorberhits)
   {
     if (Verbosity() > 1)
     {

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -49,7 +49,6 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   int m_IsActive;
   int m_IsBlackHole;
   int m_LightScintModel;
-
 };
 
 #endif  // G4DETECTORS_PHG4INNERHCALSTEPPINGACTION_H

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -29,12 +29,12 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
 
  private:
   //! pointer to the detector
-  PHG4InnerHcalDetector *detector_;
+  PHG4InnerHcalDetector *m_Detector;
 
   //! pointer to hit container
-  PHG4HitContainer *hits_;
-  PHG4HitContainer *absorberhits_;
-  PHG4Hit *hit;
+  PHG4HitContainer *m_Hits;
+  PHG4HitContainer *m_Absorberhits;
+  PHG4Hit *m_Hit;
   const PHParameters *params;
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -1,5 +1,5 @@
-#ifndef PHG4VInnerHcalSteppingAction_h
-#define PHG4VInnerHcalSteppingAction_h
+#ifndef G4DETECTORS_PHG4INNERHCALSTEPPINGACTION_H
+#define G4DETECTORS_PHG4INNERHCALSTEPPINGACTION_H
 
 #include <g4main/PHG4SteppingAction.h>
 
@@ -25,8 +25,6 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   //! reimplemented from base class
   virtual void SetInterfacePointers(PHCompositeNode *);
 
-  double GetLightCorrection(const double r) const;
-
  private:
   //! pointer to the detector
   PHG4InnerHcalDetector *m_Detector;
@@ -35,27 +33,21 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   PHG4HitContainer *m_Hits;
   PHG4HitContainer *m_Absorberhits;
   PHG4Hit *m_Hit;
-  const PHParameters *params;
-  PHG4HitContainer *savehitcontainer;
-  PHG4Shower *saveshower;
-  G4VPhysicalVolume *savevolpre;
-  G4VPhysicalVolume *savevolpost;
-  int savetrackid;
-  int saveprestepstatus;
-  int savepoststepstatus;
+  const PHParameters *m_Params;
+  PHG4HitContainer *m_SaveHitContainer;
+  PHG4Shower *m_SaveShower;
+  G4VPhysicalVolume *m_SaveVolPre;
+  G4VPhysicalVolume *m_SaveVolPost;
+  int m_SaveTrackId;
+  int m_SavePreStepStatus;
+  int m_SavePostStepStatus;
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables
-  int absorbertruth;
-  int IsActive;
-  int IsBlackHole;
-  int n_scinti_plates;
-  int light_scint_model;
+  int m_IsActive;
+  int m_IsBlackHole;
+  int m_LightScintModel;
 
-  double light_balance_inner_corr;
-  double light_balance_inner_radius;
-  double light_balance_outer_corr;
-  double light_balance_outer_radius;
 };
 
-#endif  // PHG4InnerHcalSteppingAction_h
+#endif  // G4DETECTORS_PHG4INNERHCALSTEPPINGACTION_H

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -1,3 +1,5 @@
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
 #ifndef G4DETECTORS_PHG4INNERHCALSTEPPINGACTION_H
 #define G4DETECTORS_PHG4INNERHCALSTEPPINGACTION_H
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -23,8 +23,8 @@ using namespace std;
 //_______________________________________________________________________
 PHG4InnerHcalSubsystem::PHG4InnerHcalSubsystem(const std::string &name, const int lyr)
   : PHG4DetectorSubsystem(name, lyr)
-  , detector_(nullptr)
-  , steppingAction_(nullptr)
+  , m_Detector(nullptr)
+  , m_SteppingAction(nullptr)
 {
   InitializeParameters();
 }
@@ -36,9 +36,9 @@ int PHG4InnerHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  detector_ = new PHG4InnerHcalDetector(topNode, GetParams(), Name());
-  detector_->SuperDetector(SuperDetector());
-  detector_->OverlapCheck(CheckOverlap());
+  m_Detector = new PHG4InnerHcalDetector(topNode, GetParams(), Name());
+  m_Detector->SuperDetector(SuperDetector());
+  m_Detector->OverlapCheck(CheckOverlap());
   set<string> nodes;
   if (GetParams()->get_int_param("active"))
   {
@@ -84,14 +84,14 @@ int PHG4InnerHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     }
 
     // create stepping action
-    steppingAction_ = new PHG4InnerHcalSteppingAction(detector_, GetParams());
+    m_SteppingAction = new PHG4InnerHcalSteppingAction(m_Detector, GetParams());
   }
   else
   {
     // if this is a black hole it does not have to be active
     if (GetParams()->get_int_param("blackhole"))
     {
-      steppingAction_ = new PHG4InnerHcalSteppingAction(detector_, GetParams());
+      m_SteppingAction = new PHG4InnerHcalSteppingAction(m_Detector, GetParams());
     }
   }
   return 0;
@@ -102,9 +102,9 @@ int PHG4InnerHcalSubsystem::process_event(PHCompositeNode *topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
-  if (steppingAction_)
+  if (m_SteppingAction)
   {
-    steppingAction_->SetInterfacePointers(topNode);
+    m_SteppingAction->SetInterfacePointers(topNode);
   }
   return 0;
 }
@@ -113,13 +113,13 @@ void PHG4InnerHcalSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
   GetParams()->Print();
-  if (detector_)
+  if (m_Detector)
   {
-    detector_->Print(what);
+    m_Detector->Print(what);
   }
-  if (steppingAction_)
+  if (m_SteppingAction)
   {
-    steppingAction_->Print(what);
+    m_SteppingAction->Print(what);
   }
 
   return;
@@ -128,7 +128,7 @@ void PHG4InnerHcalSubsystem::Print(const string &what) const
 //_______________________________________________________________________
 PHG4Detector *PHG4InnerHcalSubsystem::GetDetector(void) const
 {
-  return detector_;
+  return m_Detector;
 }
 
 void PHG4InnerHcalSubsystem::SetDefaultParameters()

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -149,20 +149,20 @@ void PHG4InnerHcalSubsystem::SetDefaultParameters()
   set_default_double_param("scinti_gap_neighbor", 0.1);
   set_default_double_param("scinti_inner_gap", 0.85);
   set_default_double_param("scinti_outer_gap", 1.22 * (5.0 / 4.0));
-// some math issue in the code subtracts 0.4mm so the scintillator
-// does not end at 133.09 as per drawing but at 133.05
-// adding 0.4mm compensates for this (so 133.13 gives the desired 133.09
+  // some math issue in the code subtracts 0.4mm so the scintillator
+  // does not end at 133.09 as per drawing but at 133.05
+  // adding 0.4mm compensates for this (so 133.13 gives the desired 133.09
   set_default_double_param("scinti_outer_radius", 133.13);
   set_default_double_param("scinti_tile_thickness", 0.7);
   set_default_double_param("size_z", 175.94 * 2);
   set_default_double_param("steplimits", NAN);
   set_default_double_param("tilt_angle", 36.15);  // engineering drawing
-// corresponds very closely to 4 crossinge (35.5497 deg)
+                                                  // corresponds very closely to 4 crossinge (35.5497 deg)
 
   set_default_int_param("light_scint_model", 1);
-// if ncross is set (and tilt_angle is NAN) tilt_angle is calculated 
-// from number of crossings
-  set_default_int_param("ncross", 0); 
+  // if ncross is set (and tilt_angle is NAN) tilt_angle is calculated
+  // from number of crossings
+  set_default_int_param("ncross", 0);
   set_default_int_param(PHG4HcalDefs::n_towers, 64);
   set_default_int_param(PHG4HcalDefs::scipertwr, 4);
   set_default_int_param(PHG4HcalDefs::n_scinti_tiles, 12);

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
@@ -1,5 +1,7 @@
-#ifndef PHG4InnerHcalSubsystem_h
-#define PHG4InnerHcalSubsystem_h
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4INNERHCALSUBSYSTEM_H
+#define G4DETECTORS_PHG4INNERHCALSUBSYSTEM_H
 
 #include "PHG4DetectorSubsystem.h"
 
@@ -22,7 +24,7 @@ class PHG4InnerHcalSubsystem : public PHG4DetectorSubsystem
   }
 
   /*!
-  creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
+  creates the m_Detector object and place it on the node tree, under "DETECTORS" node (or whatever)
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
@@ -40,7 +42,7 @@ class PHG4InnerHcalSubsystem : public PHG4DetectorSubsystem
 
   //! accessors (reimplemented)
   PHG4Detector* GetDetector(void) const;
-  PHG4SteppingAction* GetSteppingAction(void) const { return steppingAction_; }
+  PHG4SteppingAction* GetSteppingAction(void) const { return m_SteppingAction; }
   void SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr);
 
  private:
@@ -48,11 +50,11 @@ class PHG4InnerHcalSubsystem : public PHG4DetectorSubsystem
 
   //! detector geometry
   /*! derives from PHG4Detector */
-  PHG4InnerHcalDetector* detector_;
+  PHG4InnerHcalDetector* m_Detector;
 
   //! detector "stepping" action, executes after every G4 step
   /*! derives from PHG4SteppingAction */
-  PHG4SteppingAction* steppingAction_;
+  PHG4SteppingAction* m_SteppingAction;
 };
 
-#endif
+#endif // G4DETECTORS_PHG4INNERHCALSUBSYSTEM_H

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
@@ -57,4 +57,4 @@ class PHG4InnerHcalSubsystem : public PHG4DetectorSubsystem
   PHG4SteppingAction* m_SteppingAction;
 };
 
-#endif // G4DETECTORS_PHG4INNERHCALSUBSYSTEM_H
+#endif  // G4DETECTORS_PHG4INNERHCALSUBSYSTEM_H

--- a/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalSteppingAction.cc
@@ -35,18 +35,18 @@ PHG4Prototype3InnerHcalSteppingAction::PHG4Prototype3InnerHcalSteppingAction(PHG
   , m_HitContainer(nullptr)
   , m_AbsorberHitContainer(nullptr)
   , m_Hit(nullptr)
-  , m_params(parameters)
+  , m_Params(parameters)
   , m_SaveHitContainer(nullptr)
   , m_SaveShower(nullptr)
-  , m_AbsorberTruth(m_params->get_int_param("absorbertruth"))
-  , m_IsActive(m_params->get_int_param("active"))
-  , m_IsBlackHole(m_params->get_int_param("blackhole"))
-  , m_LightScintModel(m_params->get_int_param("light_scint_model"))
+  , m_AbsorberTruth(m_Params->get_int_param("absorbertruth"))
+  , m_IsActive(m_Params->get_int_param("active"))
+  , m_IsBlackHole(m_Params->get_int_param("blackhole"))
+  , m_LightScintModel(m_Params->get_int_param("light_scint_model"))
 {
-  SetLightCorrection(m_params->get_double_param("light_balance_inner_radius") * cm,
-                     m_params->get_double_param("light_balance_inner_corr"),
-		     m_params->get_double_param("light_balance_outer_radius") * cm,
-		     m_params->get_double_param("light_balance_outer_corr"));
+  SetLightCorrection(m_Params->get_double_param("light_balance_inner_radius") * cm,
+                     m_Params->get_double_param("light_balance_inner_corr"),
+		     m_Params->get_double_param("light_balance_outer_radius") * cm,
+		     m_Params->get_double_param("light_balance_outer_corr"));
 }
 
 PHG4Prototype3InnerHcalSteppingAction::~PHG4Prototype3InnerHcalSteppingAction()

--- a/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalSteppingAction.h
@@ -34,7 +34,7 @@ class PHG4Prototype3InnerHcalSteppingAction : public PHG4SteppingAction
   PHG4HitContainer *m_HitContainer;
   PHG4HitContainer *m_AbsorberHitContainer;
   PHG4Hit *m_Hit;
-  const PHParameters *m_params;
+  const PHParameters *m_Params;
   PHG4HitContainer *m_SaveHitContainer;
   PHG4Shower *m_SaveShower;
   // since getting parameters is a map search we do not want to

--- a/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.h
@@ -1,5 +1,5 @@
-#ifndef PHG4TPCElectronDrift_h
-#define PHG4TPCElectronDrift_h
+#ifndef G4TPC_PHG4TPCELECTRONDRIFT_H
+#define G4TPC_PHG4TPCELECTRONDRIFT_H
 
 #include <fun4all/SubsysReco.h>
 
@@ -62,4 +62,4 @@ private:
 #endif
 };
 
-#endif // PHG4TPCElectronDrift_h
+#endif // G4TPC_PHG4TPCELECTRONDRIFT_H


### PR DESCRIPTION
small speedup by not decoding volume name in stepping action (now a map filled in PHG4InnerHcalDetector provides a lookup for the layer/tower id). Apply coding convention, clean up code - use light correction from base class