### PR TITLE
clean up lib dependencies in offline/packages/mvtx/MakeFile.am

### DIFF
--- a/offline/packages/mvtx/Makefile.am
+++ b/offline/packages/mvtx/Makefile.am
@@ -14,12 +14,7 @@ AM_LDFLAGS = \
   -L$(OFFLINE_MAIN)/lib
 
 libmvtx_la_LIBADD = \
-  -lCLHEP \
-  -lphool \
-  -lg4detectors \
-  -lg4hough \
-  -ltrack_io \
-  -ltrack_util
+  -ltrack_io
 
 pkginclude_HEADERS = \
   MvtxDefUtil.h \


### PR DESCRIPTION
the dependency on libg4detectors crashed the build (in the build order this package came before g4detectors). This dependency is not needed (as are most of the others). The only one needed is the dependency on libtrack_io from trackbase for this to build and link