### PR TITLE
Added threshold cut for cells, settable from macro, defaults to 1000 …

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -50,6 +50,7 @@ PHG4CylinderCellTPCReco::PHG4CylinderCellTPCReco(int n_pixel,
   , sigmaT(0.04)
   , elec_per_gev(38. * 1e6)
   , driftv(3.0 / 1000.0)
+  , neffelectrons_threshold(2000.0)
   , fpad{nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr}
   , fcharge(nullptr)
   ,  // cm per ns

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -50,7 +50,7 @@ PHG4CylinderCellTPCReco::PHG4CylinderCellTPCReco(int n_pixel,
   , sigmaT(0.04)
   , elec_per_gev(38. * 1e6)
   , driftv(3.0 / 1000.0)
-  , neffelectrons_threshold(2000.0)
+  , neffelectrons_threshold(1000.0)
   , fpad{nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr}
   , fcharge(nullptr)
   ,  // cm per ns

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -575,8 +575,8 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
 		  
 		  // adding constant electron avalanche (value chosen so that digitizer will not trip)
 		  float neffelectrons = (2000.0 / nseg) * nelec * (pad_share) * (adc_bin_share);  
-		  
-		  if (neffelectrons < 50) continue;  // skip no or very small signals to keep number of cells down
+		  if (neffelectrons < neffelectrons_threshold) continue;  // skip signals that will be below the noise suppression threshold
+
 		  if(zbin_num >= nzbins) cout << " Error making key: adc_zbin " << zbin_num << " nzbins " << nzbins << endl;
 		  if(pad_num >= nphibins) cout << " Error making key: pad_phibin " << pad_num << " nphibins " << nphibins << endl;
 		  unsigned long key = zbin_num * nphibins + pad_num;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.h
@@ -49,6 +49,7 @@ public:
   void setSigmaT    (const double gem) {sigmaT = gem;}  //  avalanche-induced charge spread...
   void setElectronsPerKeV(const double epk){elec_per_gev = epk*1e6;}
   void set_drift_velocity(const double cm_per_ns) { driftv = cm_per_ns;}
+ void setEffElectronsThreshold(const double elec_threshold) { neffelectrons_threshold = elec_threshold;}
 
   void setSmearRPhi(const double v) {fFractRPsm=v;}
   void setSmearZ(const double v) {fFractZZsm=v;}
@@ -93,6 +94,8 @@ protected:
   double sigmaT;
   double elec_per_gev;
   double driftv;
+  double neffelectrons_threshold;
+
   TF1 *fpad[10];
   TF1 *fcharge;
 


### PR DESCRIPTION
…effective electrons

Reduces number of cells by about 35% with a threshold cut of 1000 effective electrons (which is the default set in the constructor). This is about twice the reported noise level of 500 effective electrons in the TPC readout.

The threshold setting can be changed from the macro using:
  PHG4CylinderCellTPCReco* svtx_cells = new PHG4CylinderCellTPCReco(n_maps_layer + n_intt_layer);
  svtx_cells->setEffElectronsThreshold(1000.0); 
