### PR TITLE
Added function to fix projectivity problem

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
@@ -47,7 +47,10 @@ public:
   void GetCarbonFiberAdjustments(G4double& adjust_width, G4double& adjust_length);
 
   void GetCarbonFiberSpacing(G4double& CF_width, G4double& Air_CF, G4double& Air_Cry);
-
+  virtual void SetSupermoduleGeometry(const std::string & filename2)
+  {
+    _4x4_construct_file = filename2;
+  }
 
 private:
 


### PR DESCRIPTION
Previously the projective EEMC crashed the default Fun4All_G4_EICDetector.C because a calibration file could not be properly read in. This PR just adds this function and sets a global variable so that the calibration file can be properly read in. 