### PR TITLE
compile with root6 while keeping backward compatibility with root5

### DIFF
--- a/offline/database/pdbcal/base/PdbBankListIterator.h
+++ b/offline/database/pdbcal/base/PdbBankListIterator.h
@@ -27,12 +27,8 @@ class PdbBankListIterator : public PHPointerListIterator<PdbCalBank>
   }
 
   ~PdbBankListIterator() {}
-#ifndef __CINT__
-  PdbBankListIterator() = delete;
-#else
- private:
-  PdbBankListIterator() {}
-#endif
+  private: 
+   PdbBankListIterator() {} 
 };
 
 #endif  // PDBCAL_BASE_PDBBANKLISTITERATOR_H

--- a/offline/framework/phool/PHPointerListIterator.h
+++ b/offline/framework/phool/PHPointerListIterator.h
@@ -10,15 +10,9 @@
 template <class T>
 class PHPointerListIterator
 {
- public:
-#ifndef __CINT__
-  PHPointerListIterator() = delete;
-#else
- private:
-  PHPointerListIterator() {}
- public:
-#endif
-
+  protected: 
+ PHPointerListIterator():m_List(0) {} 
+  public:
   PHPointerListIterator(const PHPointerList<T>&);
   virtual ~PHPointerListIterator() {}
   T* operator()();

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -73,8 +73,6 @@ PHG4TPCClusterizer::PHG4TPCClusterizer(const char *name) :
   fDeconMode(false),
   fDCT(0.006),
   fDCL(0.012),
-  fSource(NULL),
-  fResponse(NULL),
   _inv_sqrt12( 1.0/TMath::Sqrt(12) ),
   _twopi( TMath::TwoPi() ),
   fHClusterEnergy(NULL),
@@ -91,7 +89,9 @@ PHG4TPCClusterizer::PHG4TPCClusterizer(const char *name) :
   fHClusterWindowP(NULL),
   fHClusterWindowZ(NULL),
   fSW(NULL),
-  fHTime(NULL)
+  fHTime(NULL),
+  fSource(NULL),
+  fResponse(NULL)
 {
 }
 //===================
@@ -260,13 +260,23 @@ void PHG4TPCClusterizer::prepare_layer(float radius){
     delete[] fResponse;
   }
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 10, 4)
+  fSource = new double *[fNZBins];  
+  fResponse = new double *[fNZBins];  
+#else
   fSource = new float *[fNZBins];  
   fResponse = new float *[fNZBins];  
+#endif
 
   for (Int_t i=0;i<fNZBins;i++){
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 10, 4)
+    fSource[i]=new double[fNPhiBins];
+    fResponse[i]=new double[fNPhiBins];
+#else
     fSource[i]=new float[fNPhiBins];
     fResponse[i]=new float[fNPhiBins];
-
+#endif
     for(Int_t j = 0;j<fNPhiBins;j++){
       fResponse[i][j] = 0;
       fSource[i][j] = 0;

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.h
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.h
@@ -2,6 +2,7 @@
 #define __PHG4TPCCLUSTERIZER_H__
 
 #include <fun4all/SubsysReco.h>
+#include <RVersion.h>
 #include <vector>
 #include <limits.h>
 
@@ -12,7 +13,7 @@ class TStopwatch;
 
 class PHG4TPCClusterizer : public SubsysReco {
  public:
-  PHG4TPCClusterizer(const char *name = "PHG4SvtxClusterizer");
+  PHG4TPCClusterizer(const char *name = "PHG4TPCClusterizer");
   ~PHG4TPCClusterizer();
 
   int Init(PHCompositeNode *topNode) { return 0; }
@@ -80,8 +81,6 @@ class PHG4TPCClusterizer : public SubsysReco {
   bool  fDeconMode;
   float fDCT;
   float fDCL;
-  float **fSource;
-  float **fResponse;
   float _inv_sqrt12;
   float _twopi;
 
@@ -100,7 +99,15 @@ class PHG4TPCClusterizer : public SubsysReco {
   TProfile2D *fHClusterWindowZ;
   TStopwatch *fSW;
   TH1F *fHTime;
-
+#ifndef __CINT__
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 10, 4)
+  double **fSource;
+  double **fResponse;
+#else
+  float **fSource;
+  float **fResponse;
+#endif
+#endif
 };
 
 #endif


### PR DESCRIPTION
The interface of a method in TSpectrum has changed (double instead of float which makes sense - we should get away from using floats, there is no advantage to that except in i/o objects to reduce output file size). rootcling does not understand C++11 == delete, going back to previous use of protecte/private ctors. Changes do not affect results