### PR TITLE
adding support for fast tracking EIC using different detector responses at forward+central stations

### DIFF
--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -172,10 +172,10 @@ int PHG4TrackFastSim::End(PHCompositeNode *topNode) {
 
 int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 
-	_event++;
+  _event++;
 
 	if (verbosity >= 2)
-		std::cout << "PHG4TrackFastSim::process_event: " << _event << ".\n";
+	  std::cout << "PHG4TrackFastSim::process_event: " << _event << ".\n";
 
 	GetNodes(topNode);
 
@@ -187,10 +187,10 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 //	}
 
 	if (_trackmap_out)
-		_trackmap_out->empty();
+	  _trackmap_out->empty();
 	else {
-		LogError("_trackmap_out not found!");
-		return Fun4AllReturnCodes::ABORTRUN;
+	  LogError("_trackmap_out not found!");
+	  return Fun4AllReturnCodes::ABORTRUN;
 	}
 
 	vector<PHGenFit::Track*> rf_tracks;
@@ -452,6 +452,7 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
 			continue;
 		}
 
+		int dettype = _phg4_detector_type[ilayer];
 #if _DEBUG_MODE_ == 1
 		std::cout<<"DEBUG: ilayer: " << ilayer <<"; nsublayers: " <<_phg4hits[ilayer]->num_layers() <<" \n";
 #endif
@@ -479,11 +480,11 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
 
 					if (gRandom->Uniform(0, 1) <= _pat_rec_hit_finding_eff) {
 					  PHGenFit::Measurement* meas = NULL;
-					  if (_detector_type == Vertical_Plane){
+					  if (dettype == Vertical_Plane){
 					    meas = PHG4HitToMeasurementVerticalPlane(hit,
 										     _phi_resolution, _r_resolution);
 					  }
-					  else if (_detector_type == Cylinder){
+					  else if (dettype == Cylinder){
 					    meas = PHG4HitToMeasurementCylinder(hit,
 										_phi_resolution, _z_resolution);
 					  }

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -453,6 +453,11 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
 		}
 
 		int dettype = _phg4_detector_type[ilayer];
+		float detradres = _phg4_detector_radres[ilayer];
+		float detphires = _phg4_detector_phires[ilayer];
+		float detlonres = _phg4_detector_lonres[ilayer];
+		float dethiteff = _phg4_detector_hitfindeff[ilayer];
+		float detnoise = _phg4_detector_noise[ilayer];
 #if _DEBUG_MODE_ == 1
 		std::cout<<"DEBUG: ilayer: " << ilayer <<"; nsublayers: " <<_phg4hits[ilayer]->num_layers() <<" \n";
 #endif
@@ -463,7 +468,6 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
 			for (PHG4HitContainer::ConstIterator itr =
 					_phg4hits[ilayer]->getHits(*layerit).first;
 					itr != _phg4hits[ilayer]->getHits(*layerit).second; ++itr) {
-
 				PHG4Hit * hit = itr->second;
 				if (!hit) {
 					LogDebug("No PHG4Hit Found!");
@@ -476,17 +480,17 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
 #endif
 
 				if (hit->get_trkid() == particle->get_track_id()
-						|| gRandom->Uniform(0, 1) < _pat_rec_noise_prob) {
+						|| gRandom->Uniform(0, 1) < detnoise) {
 
-					if (gRandom->Uniform(0, 1) <= _pat_rec_hit_finding_eff) {
+					if (gRandom->Uniform(0, 1) <= dethiteff) {
 					  PHGenFit::Measurement* meas = NULL;
 					  if (dettype == Vertical_Plane){
 					    meas = PHG4HitToMeasurementVerticalPlane(hit,
-										     _phi_resolution, _r_resolution);
+										     detphires, detradres);
 					  }
 					  else if (dettype == Cylinder){
 					    meas = PHG4HitToMeasurementCylinder(hit,
-										_phi_resolution, _z_resolution);
+										detphires, detlonres);
 					  }
 					  else {
 					    LogError("Type not implemented!");

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -136,6 +136,17 @@ public:
 	void set_phg4hits_names(const std::vector<std::string>& phg4hitsNames) {
 		_phg4hits_names = phg4hitsNames;
 		_N_DETECTOR_LAYER = _phg4hits_names.size();
+		_phg4_detector_type.push_back(_detector_type);
+	}
+
+	void set_phg4hits_names(const std::string* phg4hitsNames,
+				const DETECTOR_TYPE* phg4dettype, const int nlayer) {
+		_phg4hits_names.clear();
+		for(int i=0;i<nlayer;++i) {
+			_phg4hits_names.push_back(phg4hitsNames[i]);
+			_phg4_detector_type.push_back(phg4dettype[i]);
+		}
+		_N_DETECTOR_LAYER = _phg4hits_names.size();
 	}
 
 	void set_phg4hits_names(const std::string* phg4hitsNames, const int nlayer) {
@@ -264,6 +275,7 @@ private:
 
 	std::vector<PHG4HitContainer*> _phg4hits;
 	std::vector<std::string> _phg4hits_names;
+	std::vector<DETECTOR_TYPE> _phg4_detector_type;
 
 	//! Output Node pointers
 

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -134,27 +134,71 @@ public:
 	}
 
 	void set_phg4hits_names(const std::vector<std::string>& phg4hitsNames) {
-		_phg4hits_names = phg4hitsNames;
-		_N_DETECTOR_LAYER = _phg4hits_names.size();
-		_phg4_detector_type.push_back(_detector_type);
-	}
-
-	void set_phg4hits_names(const std::string* phg4hitsNames,
-				const DETECTOR_TYPE* phg4dettype, const int nlayer) {
-		_phg4hits_names.clear();
-		for(int i=0;i<nlayer;++i) {
-			_phg4hits_names.push_back(phg4hitsNames[i]);
-			_phg4_detector_type.push_back(phg4dettype[i]);
-		}
-		_N_DETECTOR_LAYER = _phg4hits_names.size();
+	  _phg4hits_names.clear();
+	  _phg4_detector_type.clear();
+	  _phg4_detector_radres.clear();
+	  _phg4_detector_phires.clear();
+	  _phg4_detector_lonres.clear();
+	  _phg4_detector_hitfindeff.clear();
+	  _phg4_detector_noise.clear();
+	  //==
+	  _phg4hits_names = phg4hitsNames;
+	  _N_DETECTOR_LAYER = _phg4hits_names.size();
+	  for(int i=0; i!=_N_DETECTOR_LAYER; ++i) { //defaulting
+	    _phg4_detector_type.push_back(Cylinder);
+	    _phg4_detector_radres.push_back(1e-4);
+	    _phg4_detector_phires.push_back(1e-4);
+	    _phg4_detector_lonres.push_back(1e-4);
+	    _phg4_detector_hitfindeff.push_back(1.0);
+	    _phg4_detector_noise.push_back(0.0);
+	  }
 	}
 
 	void set_phg4hits_names(const std::string* phg4hitsNames, const int nlayer) {
-		_phg4hits_names.clear();
-		for(int i=0;i<nlayer;++i) {
-			_phg4hits_names.push_back(phg4hitsNames[i]);
-		}
-		_N_DETECTOR_LAYER = _phg4hits_names.size();
+	  _phg4hits_names.clear();
+	  _phg4_detector_type.clear();
+	  _phg4_detector_radres.clear();
+	  _phg4_detector_phires.clear();
+	  _phg4_detector_lonres.clear();
+	  _phg4_detector_hitfindeff.clear();
+	  _phg4_detector_noise.clear();
+	  for(int i=0;i<nlayer;++i) {
+	    _phg4hits_names.push_back(phg4hitsNames[i]);
+	    _phg4_detector_type.push_back(Cylinder);
+	    _phg4_detector_radres.push_back(1e-4);
+	    _phg4_detector_phires.push_back(1e-4);
+	    _phg4_detector_lonres.push_back(1e-4);
+	    _phg4_detector_hitfindeff.push_back(1.0);
+	    _phg4_detector_noise.push_back(0.0);
+	  }
+	  _N_DETECTOR_LAYER = _phg4hits_names.size();
+	}
+
+	void set_phg4hits_names(const std::string* phg4hitsNames,
+				const DETECTOR_TYPE* phg4dettype, 
+				const float *radres,
+				const float *phires,
+				const float *lonres,
+				const float *eff,
+				const float *noise,
+				const int nlayer) {
+	  _phg4hits_names.clear();
+	  _phg4_detector_type.clear();
+	  _phg4_detector_radres.clear();
+	  _phg4_detector_phires.clear();
+	  _phg4_detector_lonres.clear();
+	  _phg4_detector_hitfindeff.clear();
+	  _phg4_detector_noise.clear();
+	  for(int i=0;i<nlayer;++i) {
+	    _phg4hits_names.push_back(phg4hitsNames[i]);
+	    _phg4_detector_type.push_back(phg4dettype[i]);
+            _phg4_detector_radres.push_back(radres[i]);
+            _phg4_detector_phires.push_back(phires[i]);
+            _phg4_detector_lonres.push_back(lonres[i]);
+	    _phg4_detector_hitfindeff.push_back(eff[i]);
+	    _phg4_detector_noise.push_back(noise[i]);
+	  }
+	  _N_DETECTOR_LAYER = _phg4hits_names.size();
 	}
 
 	void set_state_names(const std::string* stateNames, const int nlayer) {
@@ -268,7 +312,7 @@ private:
 	//! Event counter
 	int _event;
 
-	DETECTOR_TYPE _detector_type;
+	DETECTOR_TYPE _detector_type; // deprecated
 
 	//! Input Node pointers
 	PHG4TruthInfoContainer* _truth_container;
@@ -276,6 +320,11 @@ private:
 	std::vector<PHG4HitContainer*> _phg4hits;
 	std::vector<std::string> _phg4hits_names;
 	std::vector<DETECTOR_TYPE> _phg4_detector_type;
+	std::vector<float> _phg4_detector_radres;
+	std::vector<float> _phg4_detector_phires;
+	std::vector<float> _phg4_detector_lonres;
+	std::vector<float> _phg4_detector_hitfindeff;
+	std::vector<float> _phg4_detector_noise;
 
 	//! Output Node pointers
 
@@ -319,17 +368,17 @@ private:
 	double _vertex_xy_resolution;
 	double _vertex_z_resolution;
 
-	double _phi_resolution;
+	double _phi_resolution; //deprecated
 
-	double _r_resolution;
+	double _r_resolution; //deprecated
 
-	double _z_resolution;
-
-	//!
-	double _pat_rec_hit_finding_eff;
+	double _z_resolution; //deprecated
 
 	//!
-	double _pat_rec_noise_prob;
+	double _pat_rec_hit_finding_eff; //deprecated
+
+	//!
+	double _pat_rec_noise_prob; //deprecated
 
 	//!
 	int _N_DETECTOR_LAYER;
@@ -346,22 +395,6 @@ private:
 };
 
 #endif /*__PHG4TrackFastSim_H__*/
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 


### PR DESCRIPTION
fasttrack can work at unison with vertical/cylindrical detectors using different resolutions and efficiencies. Mod was needed to do tracking with EIC detectors at forward-central rapidities.

macros will be uploaded too

[res.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/2128100/res.pdf)
[eff.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/2128098/eff.pdf)
