### PR TITLE
Iso map

### DIFF
--- a/offline/packages/CaloBase/RawCluster.cc
+++ b/offline/packages/CaloBase/RawCluster.cc
@@ -4,8 +4,9 @@
  * \file RawCluster.cc
  * \brief 
  * \author Jin Huang <jhuang@bnl.gov>
- * \version $Revision:   $
- * \date $Date: $
+ * \author Francesco Vassalli <Francesco.Vassalli@colorado.edu>
+ * \version $Revision: 2  $
+ * \date $Date: 07/13/18$
  */
 
 #include "RawCluster.h"

--- a/offline/packages/CaloBase/RawCluster.cc
+++ b/offline/packages/CaloBase/RawCluster.cc
@@ -29,10 +29,32 @@ RawCluster::get_property_info(const PROPERTY prop_id)
     return make_pair("reduced chi2 for EM shower", RawCluster::type_float);
     break;
 
-  case prop_et_iso:
-    return make_pair("isolation ET", RawCluster::type_float);
+  case prop_et_iso_calotower_sub_R01:
+    return make_pair("subtracted calortower isolation ET R=.1", RawCluster::type_float);
     break;
 
+  case prop_et_iso_calotower_sub_R02:
+    return make_pair("subtracted calortower isolation ET R=.2", RawCluster::type_float);
+    break;
+  case prop_et_iso_calotower_sub_R03:
+    return make_pair("subtracted calortower isolation ET R=.3", RawCluster::type_float);
+    break;
+  case prop_et_iso_calotower_sub_R04:
+    return make_pair("subtracted calortower isolation ET R=.4", RawCluster::type_float);
+    break;
+  case prop_et_iso_calotower_R01:
+    return make_pair("calortower isolation ET R=.1", RawCluster::type_float);
+    break;
+  case prop_et_iso_calotower_R02:
+    return make_pair("calortower isolation ET R=.2", RawCluster::type_float);
+
+    break;
+  case prop_et_iso_calotower_R03:
+    return make_pair("calortower isolation ET R=.3", RawCluster::type_float);
+    break;
+  case prop_et_iso_calotower_R04:
+    return make_pair("calortower isolation ET R=.4", RawCluster::type_float);
+    break;
 //  case prop_truth_track_ID:
 //    return make_pair("truth cluster's PHG4Particle ID", RawCluster::type_int);
 //    break;

--- a/offline/packages/CaloBase/RawCluster.h
+++ b/offline/packages/CaloBase/RawCluster.h
@@ -157,7 +157,7 @@ class RawCluster : public PHObject
     PHOOL_VIRTUAL_WARN("get_prob()");
     return NAN;
   }
-  //! isolation ET default to R=.3 with substraction by the clusterTower algorithm
+  //! isolation ET default 
   virtual float get_et_iso() const
   {
     PHOOL_VIRTUAL_WARN("get_et_iso()");

--- a/offline/packages/CaloBase/RawCluster.h
+++ b/offline/packages/CaloBase/RawCluster.h
@@ -157,12 +157,19 @@ class RawCluster : public PHObject
     PHOOL_VIRTUAL_WARN("get_prob()");
     return NAN;
   }
-  //! isolation ET
+  //! isolation ET default to R=.3 with substraction by the clusterTower algorithm
   virtual float get_et_iso() const
   {
     PHOOL_VIRTUAL_WARN("get_et_iso()");
     return NAN;
   }
+  //! isolation ET the radius and hueristic can be specified 
+  virtual void get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) 
+  { 
+    PHOOL_VIRTUAL_WARNING("get_et_iso(const int radiusx10, bool subtracted, bool clusterTower)");
+    return NAN;
+  }
+
   //  //! truth cluster's PHG4Particle ID
   //  virtual int get_truth_track_ID() const
   //  {
@@ -202,6 +209,7 @@ class RawCluster : public PHObject
   virtual void set_prob(const float prob) { PHOOL_VIRTUAL_WARNING; }
   //! isolation ET
   virtual void set_et_iso(const float e) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_et_iso(const float e,const int radiusx10, bool subtracted, bool clusterTower) { PHOOL_VIRTUAL_WARNING; }
   //  //! truth cluster's PHG4Particle ID
   //  virtual void set_truth_track_ID(const int i) { PHOOL_VIRTUAL_WARNING; }
   //  //! truth cluster's PHG4Particle flavor
@@ -230,9 +238,22 @@ class RawCluster : public PHObject
     prop_chi2 = 2,
 
     // ----- analysis specific quantities -----
-    //! isolation ET
-    prop_et_iso = 20,
-
+    //! isolation ET by the calorimeter tower heuristic with subtracted background R=.1
+    prop_et_iso_calotower_sub_R01 = 20,
+    //! isolation ET by the calorimeter tower heuristic no subtracted background R=.1
+    prop_et_iso_calotower_R01 = 21,
+    //! isolation ET by the calorimeter tower heuristic with subtracted background R=.2
+    prop_et_iso_calotower_sub_R02 = 22,
+     //! isolation ET by the calorimeter tower heuristic with subtracted background R=.2
+    prop_et_iso_calotower_R02 = 23,
+     //! isolation ET by the calorimeter tower heuristic with subtracted background R=.2
+    prop_et_iso_calotower_sub_R03 = 24,
+     //! isolation ET by the calorimeter tower heuristic with subtracted background R=.2
+    prop_et_iso_calotowe_R03 = 25,
+     //! isolation ET by the calorimeter tower heuristic with subtracted background R=.2
+    prop_et_iso_calotower_sub_R04 = 26,
+     //! isolation ET by the calorimeter tower heuristic with subtracted background R=.2
+    prop_et_iso_calotower_R04 = 27,
     //    // ----- truth cluster quantities -----
     //    //! truth cluster's PHG4Particle ID
     //    prop_truth_track_ID = 100,

--- a/offline/packages/CaloBase/RawCluster.h
+++ b/offline/packages/CaloBase/RawCluster.h
@@ -164,9 +164,9 @@ class RawCluster : public PHObject
     return NAN;
   }
   //! isolation ET the radius and hueristic can be specified 
-  virtual void get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) 
+  virtual float get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) const
   { 
-    PHOOL_VIRTUAL_WARNING("get_et_iso(const int radiusx10, bool subtracted, bool clusterTower)");
+    PHOOL_VIRTUAL_WARN("get_et_iso(const int radiusx10, bool subtracted, bool clusterTower)");
     return NAN;
   }
 
@@ -249,7 +249,7 @@ class RawCluster : public PHObject
      //! isolation ET by the calorimeter tower heuristic with subtracted background R=.2
     prop_et_iso_calotower_sub_R03 = 24,
      //! isolation ET by the calorimeter tower heuristic with subtracted background R=.2
-    prop_et_iso_calotowe_R03 = 25,
+    prop_et_iso_calotower_R03 = 25,
      //! isolation ET by the calorimeter tower heuristic with subtracted background R=.2
     prop_et_iso_calotower_sub_R04 = 26,
      //! isolation ET by the calorimeter tower heuristic with subtracted background R=.2

--- a/offline/packages/CaloBase/RawClusterv1.cc
+++ b/offline/packages/CaloBase/RawClusterv1.cc
@@ -181,6 +181,60 @@ void RawClusterv1::set_property(const PROPERTY prop_id, const unsigned int value
   }
   prop_map[prop_id] = u_property(value).get_storage();
 }
+void set_et_iso(const float et_iso,const int radiusx10, bool subtracted, bool clusterTower=1){
+  if (clusterTower)
+      {
+        if (subtracted)
+        {
+          switch(radiusx10){
+            case 1:
+              r=set_property_float(prop_et_iso_calotower_sub_R01, et_iso);
+              break;
+            case 2:
+              r=set_property_float(prop_et_iso_calotower_sub_R02, et_iso);
+              break;
+            case 3:
+              r=set_property_float(prop_et_iso_calotower_sub_R03, et_iso);
+              break;
+            case 4:
+              r=set_property_float(prop_et_iso_calotower_sub_R04, et_iso);
+              break;
+            default:
+              std::string warning = "set_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - radius:"+std::to_string(radiusx10)+" has not been defined";
+              PHOOL_VIRTUAL_WARNING(warning.c_str());
+              r=NAN;
+              break;
+          }
+        }
+        else{
+          switch(radiusx10){
+            case 1:
+              r=set_property_float(prop_et_iso_calotower_R01, et_iso);
+              break;
+            case 2:
+              r=set_property_float(prop_et_iso_calotower_R02, et_iso);
+              break;
+            case 3:
+              r=set_property_float(prop_et_iso_calotower_R03, et_iso);
+              break;
+            case 4:
+              r=set_property_float(prop_et_iso_calotower_R04, et_iso);
+              break;
+            default:
+              std::string warning = "set_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - radius:"+std::to_string(radiusx10)+" has not been defined";
+              PHOOL_VIRTUAL_WARNING(warning.c_str());
+              r=NAN;
+              break;
+          }
+        }
+      }
+      else{
+        PHOOL_VIRTUAL_WARNING("set_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - nonclusterTower algorithms have not been defined");
+        r=NAN;
+      }
+  return r;
+}
+
 
 unsigned int
 RawClusterv1::get_property_nocheck(const PROPERTY prop_id) const
@@ -191,4 +245,60 @@ RawClusterv1::get_property_nocheck(const PROPERTY prop_id) const
     return iter->second;
   }
   return UINT_MAX;
+}
+
+void get_et_iso(const int radiusx10, bool subtracted, bool clusterTower=1) 
+  { 
+    float r; 
+    if (clusterTower)
+    {
+      if (subtracted)
+      {
+        switch(radiusx10){
+          case 1:
+            r=get_property_float(prop_et_iso_calotower_sub_R01);
+            break;
+          case 2:
+            r=get_property_float(prop_et_iso_calotower_sub_R02);
+            break;
+          case 3:
+            r=get_property_float(prop_et_iso_calotower_sub_R03);
+            break;
+          case 4:
+            r=get_property_float(prop_et_iso_calotower_sub_R04);
+            break;
+          default:
+            std::string warning = "get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - radius:"+std::to_string(radiusx10)+" has not been defined";
+            PHOOL_VIRTUAL_WARNING(warning.c_str());
+            r=NAN;
+            break;
+        }
+      }
+      else{
+        switch(radiusx10){
+          case 1:
+            r=get_property_float(prop_et_iso_calotower_R01);
+            break;
+          case 2:
+            r=get_property_float(prop_et_iso_calotower_R02);
+            break;
+          case 3:
+            r=get_property_float(prop_et_iso_calotower_R03);
+            break;
+          case 4:
+            r=get_property_float(prop_et_iso_calotower_R04);
+            break;
+          default:
+            std::string warning = "get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - radius:"+std::to_string(radiusx10)+" has not been defined";
+            PHOOL_VIRTUAL_WARNING(warning.c_str());
+            r=NAN;
+            break;
+        }
+      }
+    }
+    else{
+      PHOOL_VIRTUAL_WARNING("get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - nonclusterTower algorithms have not been defined");
+      r=NAN;
+    }
+    return r;
 }

--- a/offline/packages/CaloBase/RawClusterv1.cc
+++ b/offline/packages/CaloBase/RawClusterv1.cc
@@ -181,58 +181,54 @@ void RawClusterv1::set_property(const PROPERTY prop_id, const unsigned int value
   }
   prop_map[prop_id] = u_property(value).get_storage();
 }
-void set_et_iso(const float et_iso,const int radiusx10, bool subtracted, bool clusterTower=1){
+void RawClusterv1::set_et_iso(const float et_iso,const int radiusx10, bool subtracted, bool clusterTower=1){
   if (clusterTower)
       {
         if (subtracted)
         {
           switch(radiusx10){
             case 1:
-              r=set_property_float(prop_et_iso_calotower_sub_R01, et_iso);
+              set_property(prop_et_iso_calotower_sub_R01, et_iso);
               break;
             case 2:
-              r=set_property_float(prop_et_iso_calotower_sub_R02, et_iso);
+              set_property(prop_et_iso_calotower_sub_R02, et_iso);
               break;
             case 3:
-              r=set_property_float(prop_et_iso_calotower_sub_R03, et_iso);
+              set_property(prop_et_iso_calotower_sub_R03, et_iso);
               break;
             case 4:
-              r=set_property_float(prop_et_iso_calotower_sub_R04, et_iso);
+              set_property(prop_et_iso_calotower_sub_R04, et_iso);
               break;
             default:
               std::string warning = "set_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - radius:"+std::to_string(radiusx10)+" has not been defined";
-              PHOOL_VIRTUAL_WARNING(warning.c_str());
-              r=NAN;
+              PHOOL_VIRTUAL_WARN(warning.c_str());
               break;
           }
         }
         else{
           switch(radiusx10){
             case 1:
-              r=set_property_float(prop_et_iso_calotower_R01, et_iso);
+              set_property(prop_et_iso_calotower_R01, et_iso);
               break;
             case 2:
-              r=set_property_float(prop_et_iso_calotower_R02, et_iso);
+              set_property(prop_et_iso_calotower_R02, et_iso);
               break;
             case 3:
-              r=set_property_float(prop_et_iso_calotower_R03, et_iso);
+              set_property(prop_et_iso_calotower_R03, et_iso);
               break;
             case 4:
-              r=set_property_float(prop_et_iso_calotower_R04, et_iso);
+              set_property(prop_et_iso_calotower_R04, et_iso);
               break;
             default:
               std::string warning = "set_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - radius:"+std::to_string(radiusx10)+" has not been defined";
-              PHOOL_VIRTUAL_WARNING(warning.c_str());
-              r=NAN;
+              PHOOL_VIRTUAL_WARN(warning.c_str());
               break;
           }
         }
       }
       else{
-        PHOOL_VIRTUAL_WARNING("set_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - nonclusterTower algorithms have not been defined");
-        r=NAN;
+        PHOOL_VIRTUAL_WARN("set_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - nonclusterTower algorithms have not been defined");
       }
-  return r;
 }
 
 
@@ -247,7 +243,7 @@ RawClusterv1::get_property_nocheck(const PROPERTY prop_id) const
   return UINT_MAX;
 }
 
-void get_et_iso(const int radiusx10, bool subtracted, bool clusterTower=1) 
+float RawClusterv1::get_et_iso(const int radiusx10, bool subtracted, bool clusterTower=1) 
   { 
     float r; 
     if (clusterTower)
@@ -269,7 +265,7 @@ void get_et_iso(const int radiusx10, bool subtracted, bool clusterTower=1)
             break;
           default:
             std::string warning = "get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - radius:"+std::to_string(radiusx10)+" has not been defined";
-            PHOOL_VIRTUAL_WARNING(warning.c_str());
+            PHOOL_VIRTUAL_WARN(warning.c_str());
             r=NAN;
             break;
         }
@@ -290,14 +286,14 @@ void get_et_iso(const int radiusx10, bool subtracted, bool clusterTower=1)
             break;
           default:
             std::string warning = "get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - radius:"+std::to_string(radiusx10)+" has not been defined";
-            PHOOL_VIRTUAL_WARNING(warning.c_str());
+            PHOOL_VIRTUAL_WARN(warning.c_str());
             r=NAN;
             break;
         }
       }
     }
     else{
-      PHOOL_VIRTUAL_WARNING("get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - nonclusterTower algorithms have not been defined");
+      PHOOL_VIRTUAL_WARN("get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) - nonclusterTower algorithms have not been defined");
       r=NAN;
     }
     return r;

--- a/offline/packages/CaloBase/RawClusterv1.cc
+++ b/offline/packages/CaloBase/RawClusterv1.cc
@@ -243,7 +243,7 @@ RawClusterv1::get_property_nocheck(const PROPERTY prop_id) const
   return UINT_MAX;
 }
 
-float RawClusterv1::get_et_iso(const int radiusx10, bool subtracted, bool clusterTower=1) 
+float RawClusterv1::get_et_iso(const int radiusx10=3, bool subtracted=1, bool clusterTower=1) const
   { 
     float r; 
     if (clusterTower)

--- a/offline/packages/CaloBase/RawClusterv1.h
+++ b/offline/packages/CaloBase/RawClusterv1.h
@@ -62,8 +62,10 @@ class RawClusterv1 : public RawCluster
   virtual float get_chi2() const { return get_property_float(prop_chi2); }
   //! cluster template probability for EM shower
   virtual float get_prob() const { return get_property_float(prop_prob); }
-  //! isolation ET
+  //! isolation ET default to R=.3 with substraction by the clusterTower algorithm
   virtual float get_et_iso() const { return get_property_float(prop_et_iso); }
+  //! isolation ET the radius and hueristic can be specified 
+  virtual void get_et_iso(const int radiusx10, bool subtracted, bool clusterTower=1);
 //  //! truth cluster's PHG4Particle ID
 //  virtual int get_truth_track_ID() const { return get_property_int(prop_truth_track_ID); }
 //  //! truth cluster's PHG4Particle flavor
@@ -92,8 +94,10 @@ class RawClusterv1 : public RawCluster
   virtual void set_chi2(const float chi2) { set_property(prop_chi2, chi2); }
   //! cluster template probability for EM shower
   virtual void set_prob(const float prob) { set_property(prop_prob, prob); }
-  //! isolation ET
+  //! isolation ET default to R=.3 with substraction by the clusterTower algorithm
   virtual void set_et_iso(const float e) { set_property(prop_et_iso, e); }
+  //! isolation ET the radius and hueristic can be specified 
+  virtual void set_et_iso(const float et_iso,const int radiusx10, bool subtracted, bool clusterTower=1);
 //  //! truth cluster's PHG4Particle ID
 //  virtual void set_truth_track_ID(const int i) { set_property(prop_truth_track_ID, i); }
 //  //! truth cluster's PHG4Particle flavor
@@ -155,7 +159,7 @@ class RawClusterv1 : public RawCluster
   /** @} */  // end of property map definitions
 
   //
- protected: // why it protected declared twice? 
+ protected:  
   //! cluster ID
   RawClusterDefs::keytype clusterid;
   //! total energy

--- a/offline/packages/CaloBase/RawClusterv1.h
+++ b/offline/packages/CaloBase/RawClusterv1.h
@@ -65,7 +65,7 @@ class RawClusterv1 : public RawCluster
   //! isolation ET default to R=.3 with substraction by the clusterTower algorithm
   virtual float get_et_iso() const { return get_property_float(prop_et_iso_calotower_sub_R03); }
   //! isolation ET the radius and hueristic can be specified 
-  virtual void get_et_iso(const int radiusx10, bool subtracted, bool clusterTower=1);
+  virtual float get_et_iso(const int radiusx10, bool subtracted, bool clusterTower);
 //  //! truth cluster's PHG4Particle ID
 //  virtual int get_truth_track_ID() const { return get_property_int(prop_truth_track_ID); }
 //  //! truth cluster's PHG4Particle flavor
@@ -97,7 +97,7 @@ class RawClusterv1 : public RawCluster
   //! isolation ET default to R=.3 with substraction by the clusterTower algorithm
   virtual void set_et_iso(const float e) { set_property(prop_et_iso_calotower_sub_R03, e); }
   //! isolation ET the radius and hueristic can be specified 
-  virtual void set_et_iso(const float et_iso,const int radiusx10, bool subtracted, bool clusterTower=1);
+  virtual void set_et_iso(const float et_iso,const int radiusx10, bool subtracted, bool clusterTower);
 //  //! truth cluster's PHG4Particle ID
 //  virtual void set_truth_track_ID(const int i) { set_property(prop_truth_track_ID, i); }
 //  //! truth cluster's PHG4Particle flavor

--- a/offline/packages/CaloBase/RawClusterv1.h
+++ b/offline/packages/CaloBase/RawClusterv1.h
@@ -115,7 +115,7 @@ class RawClusterv1 : public RawCluster
   void set_property(const PROPERTY prop_id, const int value);
   void set_property(const PROPERTY prop_id, const unsigned int value);
 
- protected:
+ protected: // protected is declared twice !?
   unsigned int get_property_nocheck(const PROPERTY prop_id) const;
   void set_property_nocheck(const PROPERTY prop_id, const unsigned int ui) { prop_map[prop_id] = ui; }
   //! storage types for additional property
@@ -155,7 +155,7 @@ class RawClusterv1 : public RawCluster
   /** @} */  // end of property map definitions
 
   //
- protected:
+ protected: // why it protected declared twice? 
   //! cluster ID
   RawClusterDefs::keytype clusterid;
   //! total energy

--- a/offline/packages/CaloBase/RawClusterv1.h
+++ b/offline/packages/CaloBase/RawClusterv1.h
@@ -65,7 +65,7 @@ class RawClusterv1 : public RawCluster
   //! isolation ET default 
   virtual float get_et_iso() const { return get_property_float(prop_et_iso_calotower_sub_R03); }
   //! isolation ET the radius and hueristic can be specified 
-  virtual float get_et_iso(const int radiusx10, bool subtracted, bool clusterTower);
+  virtual float get_et_iso (const int radiusx10, bool subtracted, bool clusterTower) const;
 //  //! truth cluster's PHG4Particle ID
 //  virtual int get_truth_track_ID() const { return get_property_int(prop_truth_track_ID); }
 //  //! truth cluster's PHG4Particle flavor

--- a/offline/packages/CaloBase/RawClusterv1.h
+++ b/offline/packages/CaloBase/RawClusterv1.h
@@ -62,7 +62,7 @@ class RawClusterv1 : public RawCluster
   virtual float get_chi2() const { return get_property_float(prop_chi2); }
   //! cluster template probability for EM shower
   virtual float get_prob() const { return get_property_float(prop_prob); }
-  //! isolation ET default to R=.3 with substraction by the clusterTower algorithm
+  //! isolation ET default 
   virtual float get_et_iso() const { return get_property_float(prop_et_iso_calotower_sub_R03); }
   //! isolation ET the radius and hueristic can be specified 
   virtual float get_et_iso(const int radiusx10, bool subtracted, bool clusterTower);
@@ -94,7 +94,7 @@ class RawClusterv1 : public RawCluster
   virtual void set_chi2(const float chi2) { set_property(prop_chi2, chi2); }
   //! cluster template probability for EM shower
   virtual void set_prob(const float prob) { set_property(prop_prob, prob); }
-  //! isolation ET default to R=.3 with substraction by the clusterTower algorithm
+  //! isolation ET default 
   virtual void set_et_iso(const float e) { set_property(prop_et_iso_calotower_sub_R03, e); }
   //! isolation ET the radius and hueristic can be specified 
   virtual void set_et_iso(const float et_iso,const int radiusx10, bool subtracted, bool clusterTower);

--- a/offline/packages/CaloBase/RawClusterv1.h
+++ b/offline/packages/CaloBase/RawClusterv1.h
@@ -63,7 +63,7 @@ class RawClusterv1 : public RawCluster
   //! cluster template probability for EM shower
   virtual float get_prob() const { return get_property_float(prop_prob); }
   //! isolation ET default to R=.3 with substraction by the clusterTower algorithm
-  virtual float get_et_iso() const { return get_property_float(prop_et_iso); }
+  virtual float get_et_iso() const { return get_property_float(prop_et_iso_calotower_sub_R03); }
   //! isolation ET the radius and hueristic can be specified 
   virtual void get_et_iso(const int radiusx10, bool subtracted, bool clusterTower=1);
 //  //! truth cluster's PHG4Particle ID
@@ -95,7 +95,7 @@ class RawClusterv1 : public RawCluster
   //! cluster template probability for EM shower
   virtual void set_prob(const float prob) { set_property(prop_prob, prob); }
   //! isolation ET default to R=.3 with substraction by the clusterTower algorithm
-  virtual void set_et_iso(const float e) { set_property(prop_et_iso, e); }
+  virtual void set_et_iso(const float e) { set_property(prop_et_iso_calotower_sub_R03, e); }
   //! isolation ET the radius and hueristic can be specified 
   virtual void set_et_iso(const float et_iso,const int radiusx10, bool subtracted, bool clusterTower=1);
 //  //! truth cluster's PHG4Particle ID


### PR DESCRIPTION
Added more Property types to the RawCluster class.  These new Property types can be used to store iso_et for several different radii and algorithms.  I then ensured that RawClusterv1 inherited the virtual functions for access and mutation of the new Property types.  Access and mutation can be done by specifying the radius of isolation and using booleans to specify which algorithm is used. 