### PR TITLE
Introducing radiation dose / fluence recording

### DIFF
--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -202,6 +202,7 @@ PHG4_Dict.cc: \
   PHG4ParticleGeneratorVectorMeson.h \
   PHG4ParticleGeneratorD0.h \
   PHG4Reco.h \
+  PHG4ScoringManager.h \
   PHG4Subsystem.h \
   PHG4TruthSubsystem.h \
   PHG4Utils.h \

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -93,6 +93,7 @@ libg4testbench_la_SOURCES = \
     PHG4_Dict.cc \
     PHG4PrimaryGeneratorAction.cc \
     PHG4Reco.cc \
+    PHG4ScoringManager.cc \
     PHG4RegionInformation.cc \
     PHG4TrackUserInfoV1.cc \
     PHG4TruthEventAction.cc \

--- a/simulation/g4simulation/g4main/PHG4LinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4LinkDef.h
@@ -12,6 +12,7 @@
 #pragma link C++ class PHG4ParticleGeneratorVectorMeson-!;
 #pragma link C++ class PHG4ParticleGeneratorD0-!;
 #pragma link C++ class PHG4Reco-!;
+#pragma link C++ class PHG4ScoringManager-!;
 #pragma link C++ class PHG4SimpleEventGenerator-!;
 #pragma link C++ class PHG4PileupGenerator-!;
 #pragma link C++ class PHG4Subsystem-!;

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -72,7 +72,6 @@
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Version.hh>
 #include <Geant4/globals.hh>
-#include <Geant4/G4ScoringManager.hh>
 
 // physics lists
 #include <Geant4/FTFP_BERT.hh>
@@ -189,7 +188,6 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
   }
 
   runManager_ = new G4RunManager();
-  /*G4ScoringManager* scoringManager = */G4ScoringManager::GetScoringManager();
 
   DefineMaterials();
   // create physics processes

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -138,6 +138,7 @@ PHG4Reco::PHG4Reco(const string &name)
   , active_force_decay_(false)
   , force_decay_type_(kAll)
   , save_DST_geometry_(true)
+  , m_disableSteppingActions(false)
   , _timer(PHTimeServer::get()->insert_new(name))
 {
   for (int i = 0; i < 3; i++)
@@ -375,10 +376,21 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
       {
         cout << "Adding steppingaction for " << g4sub->Name() << endl;
       }
-//      steppingAction_->AddAction(g4sub->GetSteppingAction());
+
+      steppingAction_->AddAction(g4sub->GetSteppingAction());
     }
   }
-  runManager_->SetUserAction(steppingAction_);
+
+  if (m_disableSteppingActions)
+  {
+    cout << "PHG4Reco::InitRun - WARNING - stepping action disabled! "
+         << "This is aimed to reduce resource consumption for G4 running only. E.g. dose analysis. "
+         << "Meanwhile, it will disable all Geant4 based analysis. Toggle this feature on/off with PHG4Reco::setDisableSteppingActions()" << endl;
+  }
+  else
+  {
+    runManager_->SetUserAction(steppingAction_);
+  }
 
   // create main tracking action, add subsystems and register to GEANT
   trackingAction_ = new PHG4PhenixTrackingAction();

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -375,7 +375,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
       {
         cout << "Adding steppingaction for " << g4sub->Name() << endl;
       }
-      steppingAction_->AddAction(g4sub->GetSteppingAction());
+//      steppingAction_->AddAction(g4sub->GetSteppingAction());
     }
   }
   runManager_->SetUserAction(steppingAction_);

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -72,6 +72,7 @@
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Version.hh>
 #include <Geant4/globals.hh>
+#include <Geant4/G4ScoringManager.hh>
 
 // physics lists
 #include <Geant4/FTFP_BERT.hh>
@@ -188,6 +189,7 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
   }
 
   runManager_ = new G4RunManager();
+  /*G4ScoringManager* scoringManager = */G4ScoringManager::GetScoringManager();
 
   DefineMaterials();
   // create physics processes

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -130,6 +130,10 @@ class PHG4Reco : public SubsysReco
   void Dump_GDML(const std::string &filename);
 
   void G4Verbosity(const int i);
+
+  //! disable stepping actions to reduce resource consumption for G4 running only. E.g. dose analysis
+  void setDisableSteppingActions(bool b = true) {m_disableSteppingActions = b;}
+
  protected:
   int InitUImanager();
   void DefineMaterials();
@@ -182,6 +186,7 @@ class PHG4Reco : public SubsysReco
   EDecayType force_decay_type_;  //< forced decay channel setting
 
   bool save_DST_geometry_;
+  bool m_disableSteppingActions;
 
   //! module timer.
   PHTimeServer::timer _timer;

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -1,0 +1,95 @@
+// $Id: $
+
+/*!
+ * \file PHG4ScoringManager.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "PHG4ScoringManager.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <Geant4/G4RunManager.hh>
+#include <Geant4/G4ScoringManager.hh>
+#include <Geant4/G4UImanager.hh>
+
+#include <TH1.h>
+#include <TH2.h>
+#include <TH3.h>
+
+#include <cassert>
+#include <iostream>
+
+using namespace std;
+
+PHG4ScoringManager::PHG4ScoringManager()
+  : SubsysReco("PHG4ScoringManager")
+{
+}
+
+PHG4ScoringManager::~PHG4ScoringManager()
+{
+}
+
+//_________________________________________________________________
+int PHG4ScoringManager::Init(PHCompositeNode *topNode)
+{
+  return 0;
+}
+
+int PHG4ScoringManager::InitRun(PHCompositeNode *topNode)
+{
+  //1. check G4RunManager
+  G4RunManager *runManager = G4RunManager::GetRunManager();
+  if (runManager == nullptr)
+  {
+    cout << "PHG4ScoringManager::InitRun - fatal error: G4RunManager was not initialized yet. Please do include the Geant4 simulation in this Fun4All run." << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  //2. Init scoring manager
+  G4ScoringManager *scoringManager = G4ScoringManager::GetScoringManager();
+
+  //3. run scoring commands
+  G4UImanager *UImanager = G4UImanager::GetUIpointer();
+  assert(UImanager);
+
+  for (const string &cmd : m_commands)
+  {
+    if (Verbosity() >= VERBOSITY_SOME)
+    {
+      cout << "PHG4ScoringManager::InitRun - execute Geatn4 command: " << cmd << endl;
+    }
+    UImanager->ApplyCommand(cmd.c_str());
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_________________________________________________________________
+void PHG4ScoringManager::G4Command(const string &cmd)
+{
+  m_commands.push_back(cmd);
+  return;
+}
+//_________________________________________________________________
+
+//_________________________________________________________________
+int PHG4ScoringManager::process_event(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4ScoringManager::ResetEvent(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_________________________________________________________________
+int PHG4ScoringManager::End(PHCompositeNode *)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -10,15 +10,22 @@
 
 #include "PHG4ScoringManager.h"
 
+#include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/PHTFileServer.h>
 
 #include <Geant4/G4RunManager.hh>
 #include <Geant4/G4ScoringManager.hh>
 #include <Geant4/G4UImanager.hh>
 
+#include <TFile.h>
 #include <TH1.h>
+#include <TH1D.h>
 #include <TH2.h>
+#include <TH2D.h>
 #include <TH3.h>
+#include <TString.h>
 
 #include <cassert>
 #include <iostream>
@@ -37,7 +44,23 @@ PHG4ScoringManager::~PHG4ScoringManager()
 //_________________________________________________________________
 int PHG4ScoringManager::Init(PHCompositeNode *topNode)
 {
-  return 0;
+  if (Verbosity() >= VERBOSITY_SOME)
+    cout << "PHG4ScoringManager::get_HistoManager - Making PHTFileServer " << m_outputFileName
+         << endl;
+  PHTFileServer::get().open(m_outputFileName, "RECREATE");
+
+  Fun4AllHistoManager *hm = getHistoManager();
+  assert(hm);
+  TH1D *h = new TH1D("hNormalization",  //
+                     "Normalization;Items;Summed quantity", 10, .5, 10.5);
+  int i = 1;
+  h->GetXaxis()->SetBinLabel(i++, "Event count");
+  //  h->GetXaxis()->SetBinLabel(i++, "Collision count");
+  //  h->GetXaxis()->SetBinLabel(i++, "G4Hit count");
+  h->GetXaxis()->LabelsOption("v");
+  hm->registerHisto(h);
+
+  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int PHG4ScoringManager::InitRun(PHCompositeNode *topNode)
@@ -81,6 +104,14 @@ void PHG4ScoringManager::G4Command(const string &cmd)
 //_________________________________________________________________
 int PHG4ScoringManager::process_event(PHCompositeNode *topNode)
 {
+  Fun4AllHistoManager *hm = getHistoManager();
+  assert(hm);
+
+  TH1D *h_norm = dynamic_cast<TH1D *>(hm->getHisto("hNormalization"));
+  assert(h_norm);
+
+  h_norm->Fill("Event count", 1);
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -92,5 +123,35 @@ int PHG4ScoringManager::ResetEvent(PHCompositeNode *topNode)
 //_________________________________________________________________
 int PHG4ScoringManager::End(PHCompositeNode *)
 {
+  if (not m_outputFileName.empty())
+  {
+    PHTFileServer::get().cd(m_outputFileName);
+    cout << "PHG4ScoringManager::End - save results to " << m_outputFileName << endl;
+
+    Fun4AllHistoManager *hm = getHistoManager();
+    assert(hm);
+    for (unsigned int i = 0; i < hm->nHistos(); i++)
+      hm->getHisto(i)->Write();
+  }  //   if (not m_outputFileName.empty())
+
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+Fun4AllHistoManager *
+PHG4ScoringManager::getHistoManager()
+{
+  static string histname("PHG4ScoringManager_HISTOS");
+  Fun4AllServer *se = Fun4AllServer::instance();
+  Fun4AllHistoManager *hm = se->getHistoManager(histname);
+  if (not hm)
+  {
+    if (Verbosity())
+      cout
+          << "PHG4ScoringManager::get_HistoManager - Making Fun4AllHistoManager " << histname
+          << endl;
+    hm = new Fun4AllHistoManager(histname);
+    se->registerHistoManager(hm);
+  }
+  assert(hm);
+  return hm;
 }

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -306,7 +306,7 @@ void PHG4ScoringManager::makeScoringHistograms()
 
     MeshScoreMap fSMap = g4mesh->GetScoreMap();
     MeshScoreMap::const_iterator msMapItr = fSMap.begin();
-    for (; msMapItr != fSMap.end(); msMapItr++)
+    for (; msMapItr != fSMap.end(); ++msMapItr)
     {
       G4String psname = msMapItr->first;
       std::map<G4int, G4double *> &score = *(msMapItr->second->GetMap());

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -18,14 +18,17 @@
 #include <Geant4/G4RunManager.hh>
 #include <Geant4/G4ScoringManager.hh>
 #include <Geant4/G4UImanager.hh>
+#include <Geant4/G4VPrimitiveScorer.hh>
 
 #include <TFile.h>
 #include <TH1.h>
 #include <TH1D.h>
 #include <TH2.h>
 #include <TH2D.h>
-#include <TH3.h>
+#include <TH3D.h>
 #include <TString.h>
+
+#include <boost/format.hpp>
 
 #include <cassert>
 #include <iostream>
@@ -128,13 +131,108 @@ int PHG4ScoringManager::End(PHCompositeNode *)
     PHTFileServer::get().cd(m_outputFileName);
     cout << "PHG4ScoringManager::End - save results to " << m_outputFileName << endl;
 
+    makeScoringHistograms();
+
     Fun4AllHistoManager *hm = getHistoManager();
     assert(hm);
     for (unsigned int i = 0; i < hm->nHistos(); i++)
       hm->getHisto(i)->Write();
+
   }  //   if (not m_outputFileName.empty())
 
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//! based on G4VScoreWriter::DumpAllQuantitiesToFile()
+void PHG4ScoringManager::makeScoringHistograms()
+{
+  Fun4AllHistoManager *hm = getHistoManager();
+  assert(hm);
+
+  G4ScoringManager *scoringManager = G4ScoringManager::GetScoringManager();
+  assert(scoringManager);
+
+  for (unsigned int imesh = 0; imesh < scoringManager->GetNumberOfMesh(); ++imesh)
+  {
+    G4VScoringMesh *g4mesh = scoringManager->GetMesh(imesh);
+    assert(g4mesh);
+
+    const string meshName(g4mesh->GetWorldName().data());
+    if (Verbosity())
+    {
+      cout << "PHG4ScoringManager::makeScoringHistograms - processing mesh " << meshName << endl;
+    }
+
+    // descriptors
+    G4int nMeshSegments[3];  // number of segments of the mesh
+    g4mesh->GetNumberOfSegments(nMeshSegments);
+
+    G4String divisionAxisNames[3];
+    g4mesh->GetDivisionAxisNames(divisionAxisNames);
+
+    MeshScoreMap fSMap = g4mesh->GetScoreMap();
+    MeshScoreMap::const_iterator msMapItr = fSMap.begin();
+    for (; msMapItr != fSMap.end(); msMapItr++)
+    {
+      G4String psname = msMapItr->first;
+      std::map<G4int, G4double *> &score = *(msMapItr->second->GetMap());
+
+      G4double unitValue = g4mesh->GetPSUnitValue(psname);
+      G4String unit = g4mesh->GetPSUnit(psname);
+
+      const string hname = boost::str(boost::format("hScore_%1%_%2%") % meshName.data() % psname.data());
+      const string htitle = boost::str(boost::format("Mesh %1%, Primitive scorer %2%: score [%3%]") % meshName.c_str() % psname.data() % unit.data());
+
+      if (Verbosity())
+        cout << "PHG4ScoringManager::makeScoringHistograms - processing mesh " << meshName
+             << "  scorer " << psname
+             << "  with axis: "
+             << "# i" << divisionAxisNames[0]
+             << ", i" << divisionAxisNames[1]
+             << ", i" << divisionAxisNames[2]
+             << ", value "
+             << "[unit: " << unit << "]."
+             << " Saving to histogram " << hname << " : " << htitle
+             << endl;
+
+      //book histogram
+      TH3 *h = new TH3D(hname.c_str(),   //
+                        htitle.c_str(),  //
+                        nMeshSegments[0],
+                        -.5, nMeshSegments[0] - .5,
+                        nMeshSegments[1],
+                        -.5, nMeshSegments[1] - .5,
+                        nMeshSegments[2],
+                        -.5, nMeshSegments[2] - .5);
+      hm->registerHisto(h);
+
+      h->GetXaxis()->SetTitle(divisionAxisNames[0].data() + TString(" index"));
+      h->GetYaxis()->SetTitle(divisionAxisNames[1].data() + TString(" index"));
+      h->GetZaxis()->SetTitle(divisionAxisNames[2].data() + TString(" index"));
+
+      // write quantity
+      for (int x = 0; x < nMeshSegments[0]; x++)
+      {
+        for (int y = 0; y < nMeshSegments[1]; y++)
+        {
+          for (int z = 0; z < nMeshSegments[2]; z++)
+          {
+            const int idx = x * nMeshSegments[1] * nMeshSegments[2] + y * nMeshSegments[2] + z;
+
+            std::map<G4int, G4double *>::iterator value = score.find(idx);
+
+            if (value != score.end())
+            {
+              h->SetBinContent(x, y, z, *(value->second) / unitValue);
+            }
+
+          }  //           for (int z = 0; z < fNMeshSegments[2]; z++)
+        }
+      }  //       for (int x = 0; x < nMeshSegments[0]; x++)
+
+    }  //     for (; msMapItr != fSMap.end(); msMapItr++)
+
+  }  //   for (int imesh = 0; imesh < scoringManager->GetNumberOfMesh(); ++imesh)
 }
 
 Fun4AllHistoManager *

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -47,22 +47,6 @@ PHG4ScoringManager::~PHG4ScoringManager()
 //_________________________________________________________________
 int PHG4ScoringManager::Init(PHCompositeNode *topNode)
 {
-  if (Verbosity() >= VERBOSITY_SOME)
-    cout << "PHG4ScoringManager::get_HistoManager - Making PHTFileServer " << m_outputFileName
-         << endl;
-  PHTFileServer::get().open(m_outputFileName, "RECREATE");
-
-  Fun4AllHistoManager *hm = getHistoManager();
-  assert(hm);
-  TH1D *h = new TH1D("hNormalization",  //
-                     "Normalization;Items;Summed quantity", 10, .5, 10.5);
-  int i = 1;
-  h->GetXaxis()->SetBinLabel(i++, "Event count");
-  //  h->GetXaxis()->SetBinLabel(i++, "Collision count");
-  //  h->GetXaxis()->SetBinLabel(i++, "G4Hit count");
-  h->GetXaxis()->LabelsOption("v");
-  hm->registerHisto(h);
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -92,6 +76,23 @@ int PHG4ScoringManager::InitRun(PHCompositeNode *topNode)
     }
     UImanager->ApplyCommand(cmd.c_str());
   }
+
+  //4 init IOs
+  if (Verbosity() >= VERBOSITY_SOME)
+    cout << "PHG4ScoringManager::InitRun - Making PHTFileServer " << m_outputFileName
+         << endl;
+  PHTFileServer::get().open(m_outputFileName, "RECREATE");
+
+  Fun4AllHistoManager *hm = getHistoManager();
+  assert(hm);
+  TH1D *h = new TH1D("hNormalization",  //
+                     "Normalization;Items;Summed quantity", 10, .5, 10.5);
+  int i = 1;
+  h->GetXaxis()->SetBinLabel(i++, "Event count");
+  //  h->GetXaxis()->SetBinLabel(i++, "Collision count");
+  //  h->GetXaxis()->SetBinLabel(i++, "G4Hit count");
+  h->GetXaxis()->LabelsOption("v");
+  hm->registerHisto(h);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -223,7 +224,7 @@ void PHG4ScoringManager::makeScoringHistograms()
 
             if (value != score.end())
             {
-              h->SetBinContent(x, y, z, *(value->second) / unitValue);
+              h->SetBinContent(x+1, y+1, z+1, *(value->second) / unitValue);
             }
 
           }  //           for (int z = 0; z < fNMeshSegments[2]; z++)

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -276,13 +276,18 @@ void PHG4ScoringManager::makeScoringHistograms()
       //      fDivisionAxisNames[0] = "Z";
       //      fDivisionAxisNames[1] = "PHI";
       //      fDivisionAxisNames[2] = "R";
-
-      meshBoundMin[0] = (-meshSize[0] + meshTranslate[0]) / cm;
-      meshBoundMax[0] = (meshSize[0] + meshTranslate[0]) / cm;
+//      G4VSolid * tubsSolid = new G4Tubs(tubsName+"0", // name
+//                0.,           // R min
+//                fSize[0],     // R max
+//                fSize[1],     // Dz
+//                0.,           // starting phi
+//                                        twopi*rad);   // segment phi
+      meshBoundMin[0] = (-meshSize[1] + meshTranslate[0]) / cm;
+      meshBoundMax[0] = (meshSize[1] + meshTranslate[0]) / cm;
       meshBoundMin[1] = 0;
       meshBoundMax[1] = 2 * M_PI;
       meshBoundMin[2] = 0;
-      meshBoundMax[2] = meshSize[2] / cm;
+      meshBoundMax[2] = meshSize[0] / cm;
     }
     else
     {

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -52,6 +52,7 @@ int PHG4ScoringManager::InitRun(PHCompositeNode *topNode)
 
   //2. Init scoring manager
   G4ScoringManager *scoringManager = G4ScoringManager::GetScoringManager();
+  assert(scoringManager);
 
   //3. run scoring commands
   G4UImanager *UImanager = G4UImanager::GetUIpointer();

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -270,6 +270,10 @@ void PHG4ScoringManager::makeScoringHistograms()
       meshBoundMax[1] = (meshSize[1] + meshTranslate[1]) / cm;
       meshBoundMin[2] = (-meshSize[2] + meshTranslate[2]) / cm;
       meshBoundMax[2] = (meshSize[2] + meshTranslate[2]) / cm;
+
+      divisionAxisNames[0] += " [cm]";
+      divisionAxisNames[1] += " [cm]";
+      divisionAxisNames[2] += " [cm]";
     }
     else if (meshShape == cylinderMesh)
     {
@@ -288,6 +292,10 @@ void PHG4ScoringManager::makeScoringHistograms()
       meshBoundMax[1] = 2 * M_PI;
       meshBoundMin[2] = 0;
       meshBoundMax[2] = meshSize[0] / cm;
+
+      divisionAxisNames[0] += " [cm]";
+      divisionAxisNames[1] += " [rad]";
+      divisionAxisNames[2] += " [cm]";
     }
     else
     {

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.h
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.h
@@ -45,7 +45,7 @@ class PHG4ScoringManager : public SubsysReco
   int End(PHCompositeNode *);
 
   //! Output result to a ROOT file with this name
-  void setOutputFileName(const std::string &outputfilename){m_outputFileName = outputfilename};
+  void setOutputFileName(const std::string &outputfilename) { m_outputFileName = outputfilename; };
 
   //! \brief Run this Geant4 command after initialization of G4ScoringManager in the InitRun() stage
   //! You can call this command multiple times to stage multiple commands to run
@@ -63,10 +63,9 @@ class PHG4ScoringManager : public SubsysReco
 
       \endcode
    */
-  void PHG4ScoringManager::G4Command(const std::string &cmd);
+  void G4Command(const std::string &cmd);
 
  private:
-
   std::vector<std::string> m_commands;
 
   std::string m_outputFileName;

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.h
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.h
@@ -16,12 +16,14 @@
 #include <string>
 #include <vector>
 
+class Fun4AllHistoManager;
+
 /*!
  * \brief PHG4ScoringManager is the connection between Fun4All to G4ScoringManager
  *  Track primitive score like flux or energy deposition integrated over events and save to histograms
  *  More on G4ScoringManager see
- *  http://geant4-userdoc.web.cern.ch/geant4-userdoc/UsersGuides/ForApplicationDeveloper/BackupVersions/V9.6/html/ch04s08.html
- *  And talkhttp://geant4.slac.stanford.edu/JLAB2012/Scoring1.pdf
+ *  Manual http://geant4-userdoc.web.cern.ch/geant4-userdoc/UsersGuides/ForApplicationDeveloper/BackupVersions/V9.6/html/ch04s08.html
+ *  And talk http://geant4.slac.stanford.edu/JLAB2012/Scoring1.pdf
  */
 class PHG4ScoringManager : public SubsysReco
 {
@@ -66,6 +68,9 @@ class PHG4ScoringManager : public SubsysReco
   void G4Command(const std::string &cmd);
 
  private:
+
+  Fun4AllHistoManager *getHistoManager();
+
   std::vector<std::string> m_commands;
 
   std::string m_outputFileName;

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.h
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.h
@@ -1,0 +1,75 @@
+// $Id: $
+
+/*!
+ * \file PHG4ScoringManager.h
+ * \brief the connection between Fun4All to G4ScoringManager
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef PHG4SCORINGMANAGER_H_
+#define PHG4SCORINGMANAGER_H_
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+#include <vector>
+
+/*!
+ * \brief PHG4ScoringManager is the connection between Fun4All to G4ScoringManager
+ *  Track primitive score like flux or energy deposition integrated over events and save to histograms
+ *  More on G4ScoringManager see
+ *  http://geant4-userdoc.web.cern.ch/geant4-userdoc/UsersGuides/ForApplicationDeveloper/BackupVersions/V9.6/html/ch04s08.html
+ *  And talkhttp://geant4.slac.stanford.edu/JLAB2012/Scoring1.pdf
+ */
+class PHG4ScoringManager : public SubsysReco
+{
+ public:
+  PHG4ScoringManager();
+
+  virtual ~PHG4ScoringManager();
+
+  //! full initialization
+  int Init(PHCompositeNode *);
+
+  int InitRun(PHCompositeNode *topNode);
+
+  //! event processing method
+  int process_event(PHCompositeNode *);
+
+  //! Clean up after each event.
+  int ResetEvent(PHCompositeNode *);
+
+  //! end of run method
+  int End(PHCompositeNode *);
+
+  //! Output result to a ROOT file with this name
+  void setOutputFileName(const std::string &outputfilename){m_outputFileName = outputfilename};
+
+  //! \brief Run this Geant4 command after initialization of G4ScoringManager in the InitRun() stage
+  //! You can call this command multiple times to stage multiple commands to run
+  /*!
+   *  Example
+      \code{.cpp}
+
+      PHG4ScoringManager * g4score = new PHG4ScoringManager();
+      g4score->G4Command("/score/create/cylinderMesh cyl_score");
+      g4score->G4Command("/score/mesh/cylinderSize 100. 400. cm");
+      g4score->G4Command("/score/mesh/nBin 100 800 8");
+      g4score->G4Command("/score/quantity/eDep cyl_edep");
+      g4score->G4Command("/score/quantity/cellFlux cyl_flux");
+      g4score->G4Command("/score/close");
+
+      \endcode
+   */
+  void PHG4ScoringManager::G4Command(const std::string &cmd);
+
+ private:
+
+  std::vector<std::string> m_commands;
+
+  std::string m_outputFileName;
+};
+
+#endif /* PHG4SCORINGMANAGER_H_ */

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.h
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 class Fun4AllHistoManager;
+class TH1;
 
 /*!
  * \brief PHG4ScoringManager is the connection between Fun4All to G4ScoringManager
@@ -70,6 +71,7 @@ class PHG4ScoringManager : public SubsysReco
  private:
 
   Fun4AllHistoManager *getHistoManager();
+  void makeScoringHistograms();
 
   std::vector<std::string> m_commands;
 


### PR DESCRIPTION
# Introduction

`Geant4` tool kit has a built in tool, `G4ScoringManager`, to record radiation dose and fluence by analyzing passage and interaction of particle tracks with user defined x-y-z or cylindrical meshed volumes. 

This pull request introduce interface to `G4ScoringManager`, configuring it to run with full sPHENIX/EIC simulation and record the result for further analysis. 

In addition, related updates include:
* Added a switch to disable stepping actions with `PHG4Reco::setDisableSteppingActions()`. Stepping action produce the `PHG4Hits` which interface to the rest of Fun4All based analysis. Disabling it make dose focused simulation run much faster and use smaller memory foot print. 
* Example macro to drive the dose simulation: https://github.com/blackcathj/macros/blob/dose_tests/macros/g4simulations/Fun4All_G4_sPHENIX.C
* Macros to plot the result: https://github.com/sPHENIX-Collaboration/analysis/blob/master/Fluence/DrawFluence.C

# Tests

* This new feature is tested with 10k simulations of 0-20 fm `sHIJING` events, which produce an average dN_ch/deta of 170-180 in the central pseudorapidities: 
![auau200_10k_iter2_sum xml_g4score rootdnchdeta](https://user-images.githubusercontent.com/7947083/43786317-5b136b34-9a36-11e8-9a82-5128eaff8406.png)
* 30-cm wide vertex-z distribution is used. The test result used flat distribution and the example macro above is fixed with Gaussian distribution. 
* The pre-packaged `QGSP_BERT_HP` physics list is used in Geant4. All currently implemented sPHENIX parts are enabled, including the forward plug door. 
* All results are scaled up to 1.5 Trillion AuAu collisions, which corresponding to the AuAu  portion of the five year sPHENIX operation as in [sPH-TRG-2018-001](https://indico.bnl.gov/event/4788/)

**Please note the result is not yet verified with any existing RHIC background measurement.** They just provide a preview for the new functionality, rather than radiation estimation for sPHENIX.

## Radial-z graphs

From left top to right bottom: 
* **Right top:** Total energy deposition in each radial-z bins. Bin size is 2x2 cm
* **Right bottom:** Radiation dose in rad
* **Left top:** charged particle fluence with minimal kinematic energy cut of 1 MeV
* **Left bottom:** neutron fluence with minimal kinematic energy cut of 0.1 MeV

![auau200_10k_iter2_sum xml_g4score rootfullcyl](https://user-images.githubusercontent.com/7947083/43786653-28021140-9a37-11e8-94d2-ccc413c3afaa.png)

## Radial averages

In the central region, the dose and fluence is mostly radially dependent. Therefore, within |z|<30 cm, the average radial dependence is extracted: 

![auau200_10k_iter2_sum xml_g4score rootfullcylrproj_30](https://user-images.githubusercontent.com/7947083/43787094-31f2ba00-9a38-11e8-838f-8679f06ce5ba.png)


# Next

The most important steps prior to producing reliable result are verification and tuning. 

Tuning include
* Try different physics list, with reference to radiation studies by other collaborations
* Add experimental hall and other known support structures such as beam and electronics elements in the vertex region. 

Verification include
* Cross check with PHENIX radiation monitor data installed near the vertex region.
* Cross check with the STAR results: [DOI:10.1016/j.nima.2014.04.035](https://doi.org/10.1016/j.nima.2014.04.035)

It will also be nice to show it for sPHENIX-EIC setup too. 

Suggestions and helps in carrying out such studies are welcomed. 