### PR TITLE
Si support material

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
@@ -24,8 +24,8 @@ PHG4CylinderGeom_Siladders::PHG4CylinderGeom_Siladders():
   nladders_layer(-1),
   ladder_z0(NAN),
   ladder_z1(NAN),
-  eff_radius(NAN),
-  eff_radius_alternate(NAN),
+  sensor_radius_inner(NAN),
+  sensor_radius_outer(NAN),
   strip_x_offset(NAN),
   offsetphi(NAN),
   offsetrot(NAN),
@@ -58,27 +58,23 @@ void PHG4CylinderGeom_Siladders::find_segment_center(const int segment_z_bin, co
 
   // Ladder
   const double phi  = offsetphi + dphi_ * segment_phi_bin;
-  location[0] = eff_radius  * cos(phi);
-  location[1] = eff_radius  * sin(phi);
+  location[0] = radius  * cos(phi);
+  location[1] = radius  * sin(phi);
   location[2] = signz * ladder_z_[itype];
 }
 
 void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[])
 {
-  cout << endl << "Strip geom:  layer " << layer << " nstrips_z_sensor0 " << nstrips_z_sensor0 << " nstrips_z_sensor1 " 
-       << nstrips_z_sensor1 << " nstrips_phi_cell " << nstrips_phi_cell
-       << " ladderz0 " << ladder_z0 << " ladder_z1 " << ladder_z1 << " eff_radius " << eff_radius << " eff_radius_alternate " << eff_radius_alternate 
-       << " strip_x_offset " << strip_x_offset << " offsetphi " << offsetphi 
-       << endl;
-
-    cout << "    Input :  ladder_z_index " << segment_z_bin << " ladder_phi_index " << segment_phi_bin 
-       << " strip_z_index " << strip_column << " strip_y_index " << strip_index << endl;
-
+  // The sub layer radius is determined from the ladder phi index, called segment_phi_bin
+  
+  radius = sensor_radius_inner;
+  if(segment_phi_bin % 2)
+    radius = sensor_radius_outer;
+  //cout << "      setting working sensor radius to " << radius << endl;
+  
   // Ladder
   find_segment_center(segment_z_bin, segment_phi_bin, location);
   CLHEP::Hep3Vector ladder(location[0], location[1], location[2]);
-
-  cout << "   segment center is at " << location[0] << "  " << location[1] << "  " << location[2] << endl;
 
   // Strip
   const int itype = segment_z_bin % 2;
@@ -86,9 +82,8 @@ void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, cons
   const int nstrips_z_sensor = nstrips_z_sensor_[itype];
 
   const double strip_localpos_z = strip_z*(strip_column%nstrips_z_sensor) -    strip_z/2.*nstrips_z_sensor + strip_z/2.;
-  const double strip_localpos_y = strip_y*strip_index                     - strip_y*nstrips_phi_cell + strip_y/2.;
-  cout << "   Sensor parameters: itype " << itype << " nstrips_z_sensor " << nstrips_z_sensor << " strip_z " << strip_z   
-       << " nstrips_phi " << nstrips_phi_cell << " strip_y " << strip_y << endl;
+  // distance from bottom of sensor = strip_y*strip_index +strip_y/2.0, then subtract nstrips_phi_cell * strip_y / 2.0
+  const double strip_localpos_y = strip_y*strip_index + strip_y/2. - nstrips_phi_cell * strip_y / 2.0;
 
   CLHEP::Hep3Vector strip_localpos(strip_x_offset, strip_localpos_y, strip_localpos_z);
 
@@ -96,19 +91,13 @@ void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, cons
   const double phi    = offsetphi + dphi_ * segment_phi_bin;
   //const double rotate = phi + offsetrot + M_PI;
   const double rotate = phi + offsetrot;
-  cout << "       phi " << phi << " offsetphi " << offsetphi << " dphi_ " << dphi_ << " segment_phi_bin " << segment_phi_bin << " rotate " << rotate << endl;
-
-  cout << "       strip_localpos " << strip_localpos[0] << "  " << strip_localpos[1] << "  " << strip_localpos[2]  << endl;
 
   CLHEP::HepRotation rot;
   rot.rotateZ(rotate);
   strip_localpos = rot*strip_localpos;
-  cout << "       rot*strip_localpos " << strip_localpos[0] << "  " << strip_localpos[1] << "  " << strip_localpos[2]  << endl;
   strip_localpos += ladder;
 
   location[0] = strip_localpos.x();
   location[1] = strip_localpos.y();
   location[2] = strip_localpos.z();
-
-  cout << "    x " << location[0] << " y " << location[1] << " z " << location[2] << endl;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
@@ -23,6 +23,7 @@ PHG4CylinderGeom_Siladders::PHG4CylinderGeom_Siladders():
   ladder_z0(NAN),
   ladder_z1(NAN),
   eff_radius(NAN),
+  eff_radius_alternate(NAN),
   strip_x_offset(NAN),
   offsetphi(NAN),
   offsetrot(NAN),

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
@@ -22,8 +22,8 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
       const int    nladders_layer_,
       const double ladder_z0_,
       const double ladder_z1_,
-      const double eff_radius_,
-      const double eff_radius_alternate_,
+      const double sensor_radius_inner_,
+      const double sensor_radius_outer_,
       const double strip_x_offset_,
       const double offsetphi_,
       const double offsetrot_) :
@@ -38,8 +38,8 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
         nladders_layer(nladders_layer_),
         ladder_z0(ladder_z0_),
         ladder_z1(ladder_z1_),
-        eff_radius(eff_radius_),
-        eff_radius_alternate(eff_radius_alternate_),
+        sensor_radius_inner(sensor_radius_inner_),
+        sensor_radius_outer(sensor_radius_outer_),
         strip_x_offset(strip_x_offset_),
         offsetphi(offsetphi_),
         offsetrot(offsetrot_)
@@ -72,12 +72,12 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
 
     double get_radius() const
       {
-        return eff_radius;
+        return sensor_radius_inner;
       }
 
-    double get_radius_alternate() const
+    double get_radius_outer() const
       {
-        return eff_radius_alternate;
+        return sensor_radius_outer;
       }
 
     bool load_geometry();
@@ -122,8 +122,8 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
     int nladders_layer;
     double ladder_z0;
     double ladder_z1;
-    double eff_radius;
-    double eff_radius_alternate;
+    double sensor_radius_inner;
+    double sensor_radius_outer;
     double strip_x_offset;
     double offsetphi;
     double offsetrot;
@@ -132,6 +132,8 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
     double ladder_z_[2];
     int nstrips_z_sensor_[2];
     double dphi_;
+
+    double radius;
 
     ClassDef(PHG4CylinderGeom_Siladders,1)
   };

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
@@ -23,6 +23,7 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
       const double ladder_z0_,
       const double ladder_z1_,
       const double eff_radius_,
+      const double eff_radius_alternate_,
       const double strip_x_offset_,
       const double offsetphi_,
       const double offsetrot_) :
@@ -38,6 +39,7 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
         ladder_z0(ladder_z0_),
         ladder_z1(ladder_z1_),
         eff_radius(eff_radius_),
+        eff_radius_alternate(eff_radius_alternate_),
         strip_x_offset(strip_x_offset_),
         offsetphi(offsetphi_),
         offsetrot(offsetrot_)
@@ -71,6 +73,11 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
     double get_radius() const
       {
         return eff_radius;
+      }
+
+    double get_radius_alternate() const
+      {
+        return eff_radius_alternate;
       }
 
     bool load_geometry();
@@ -116,6 +123,7 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
     double ladder_z0;
     double ladder_z1;
     double eff_radius;
+    double eff_radius_alternate;
     double strip_x_offset;
     double offsetphi;
     double offsetrot;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -156,8 +156,8 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
     double location[3] = {-1, -1, -1};
     layergeom->find_strip_center(ladder_z_index, ladder_phi_index, strip_z_index, strip_y_index, location);
 
-    if(verbosity > 2) 
-      {
+    //if(verbosity > 2) 
+    //{
 	cout << endl << "  g4 hit:  layer " <<  hiter->second->get_layer() << " edep " <<  hiter->second->get_edep() << endl;
 	cout << "   Hit entry point x,y,z = " << hiter->second->get_x(0) << "  " << hiter->second->get_y(0) << "  " << hiter->second->get_z(0) << endl;
 	cout << "   Hit exit point x,y,z = " << hiter->second->get_x(1) << "  " << hiter->second->get_y(1) << "  " << hiter->second->get_z(1) << endl;
@@ -165,7 +165,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
 	     << " strip z index " <<  hiter->second->get_strip_z_index() << " strip y index " <<   hiter->second->get_strip_y_index() << endl;
 	cout << "   strip x,y,z from geometry object = " << location[0] << "  " << location[1] << "  " << location[2] << endl;
 	cout << endl;
-      }
+	//}
 
     // this string must be unique - it needs the layer too, or in high multiplicity events it will add g4 hits in different layers with the same key together
     std::string key = boost::str(boost::format("%d-%d-%d-%d-%d") % sphxlayer % ladder_z_index % ladder_phi_index % strip_z_index % strip_y_index).c_str();

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -156,8 +156,8 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
     double location[3] = {-1, -1, -1};
     layergeom->find_strip_center(ladder_z_index, ladder_phi_index, strip_z_index, strip_y_index, location);
 
-    //if(verbosity > 2) 
-    //{
+    if(verbosity > 2) 
+    {
 	cout << endl << "  g4 hit:  layer " <<  hiter->second->get_layer() << " edep " <<  hiter->second->get_edep() << endl;
 	cout << "   Hit entry point x,y,z = " << hiter->second->get_x(0) << "  " << hiter->second->get_y(0) << "  " << hiter->second->get_z(0) << endl;
 	cout << "   Hit exit point x,y,z = " << hiter->second->get_x(1) << "  " << hiter->second->get_y(1) << "  " << hiter->second->get_z(1) << endl;
@@ -165,7 +165,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
 	     << " strip z index " <<  hiter->second->get_strip_z_index() << " strip y index " <<   hiter->second->get_strip_y_index() << endl;
 	cout << "   strip x,y,z from geometry object = " << location[0] << "  " << location[1] << "  " << location[2] << endl;
 	cout << endl;
-	//}
+    }
 
     // this string must be unique - it needs the layer too, or in high multiplicity events it will add g4 hits in different layers with the same key together
     std::string key = boost::str(boost::format("%d-%d-%d-%d-%d") % sphxlayer % ladder_z_index % ladder_phi_index % strip_z_index % strip_y_index).c_str();

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -771,6 +771,66 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	    } // end loop over ladder copy placement in phi and positive and negative Z
 	} // end loop over inner or outer sensor
     } // end loop over layers
+
+  // Finally, we add some support material for the silicon detectors
+
+  // 
+  /*
+    6 rails, which are 12mm OD and 9mm ID tubes at a radius of 175 mm.  They are spaced equidistantly in phi.
+          For the 6 rails, there should be one at the very top and bottom (ie, along the vertical), and then the rest are symmetrically placed in phi.  
+         The rails run along the entire length of the TPC and even stick out of the TPC, but I think for the moment you don’t have to put the parts that stick out in the simulation.
+    An inner skin with a OD at 64 mm and a thickness of 0.150 mm.
+    An outer skin with a ID at 157 mm and a thickness of 1 mm (~0.5% rad len).
+    
+    All of the above are carbon fiber.
+  */
+
+  // rails
+  G4Tubs *rail_tube = new G4Tubs(boost::str(boost::format("si_support_rail")).c_str(), 
+			    9.0, 12.0, 2050, -TMath::Pi(), 2.0 * TMath::Pi() );  
+  G4LogicalVolume *rail_volume = new G4LogicalVolume(rail_tube, G4Material::GetMaterial("G4_C"), 
+								      boost::str(boost::format("rail_volume")).c_str(), 0, 0, 0);
+  G4VisAttributes *rail_vis = new G4VisAttributes();
+  rail_vis->SetVisibility(true);
+  rail_vis->SetForceSolid(true);
+  rail_vis->SetColour(G4Colour::Cyan());
+  rail_volume->SetVisAttributes(rail_vis);
+
+  double rail_dphi = TMath::Pi() / 3.0;
+  double rail_phi_start = TMath::Pi() / 6.0;
+  double rail_radius = 175.0;
+  for(int i = 0; i < 6; i++)
+    {
+      double phi = rail_phi_start + i * rail_dphi;
+
+      // place a copy at each rail phi value
+      const double posx = rail_radius * cos(phi);
+      const double posy = rail_radius * sin(phi);      
+
+      new G4PVPlacement(0, G4ThreeVector(posx, posy, 0.0), rail_volume, 
+			boost::str(boost::format("si_support_rail_%d")  % i).c_str(), trackerenvelope, false, 0, OverlapCheck());
+    }
+
+  // Outer skin
+
+  G4Tubs *outer_skin_tube = new G4Tubs(boost::str(boost::format("si_outer_skin")).c_str(), 
+			    157.0, 158.0, 480.0, -TMath::Pi(), 2.0 * TMath::Pi() );  
+  G4LogicalVolume *outer_skin_volume = new G4LogicalVolume(outer_skin_tube, G4Material::GetMaterial("G4_C"), 
+								      boost::str(boost::format("outer_skin_volume")).c_str(), 0, 0, 0);
+  outer_skin_volume->SetVisAttributes(rail_vis);
+  new G4PVPlacement(0, G4ThreeVector(0, 0.0), outer_skin_volume, 
+		    boost::str(boost::format("si_support_outer_skin") ).c_str(), trackerenvelope, false, 0, OverlapCheck());  
+
+  // Inner skin
+
+  G4Tubs *inner_skin_tube = new G4Tubs(boost::str(boost::format("si_inner_skin")).c_str(), 
+			    63.85, 64.0, 480.0, -TMath::Pi(), 2.0 * TMath::Pi() );  
+  G4LogicalVolume *inner_skin_volume = new G4LogicalVolume(inner_skin_tube, G4Material::GetMaterial("G4_C"), 
+								      boost::str(boost::format("inner_skin_volume")).c_str(), 0, 0, 0);
+  inner_skin_volume->SetVisAttributes(rail_vis);
+  new G4PVPlacement(0, G4ThreeVector(0, 0.0), inner_skin_volume, 
+		    boost::str(boost::format("si_support_inner_skin") ).c_str(), trackerenvelope, false, 0, OverlapCheck());
+
   return 0;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -114,6 +114,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       sensor_radius_inner[ilayer] = params1->get_double_param("sensor_radius_inner");
       sensor_radius_outer[ilayer] = params1->get_double_param("sensor_radius_outer");
       const int nladders_layer = params1->get_int_param("nladder");
+      cout << "Constructing Silicon Tracker layer: " << endl;
+      cout << "   layer " << ilayer << " laddertype " << laddertype << " nladders_layer " << nladders_layer 
+	   << " sensor_radius_inner " << sensor_radius_inner[ilayer] << " sensor_radius_outer " << sensor_radius_outer[ilayer] << endl;
 
       // Look up all remaining parameters by the laddertype for this layer
       const PHParameters *params = paramscontainer->GetParameters(laddertype);
@@ -768,7 +771,6 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	    } // end loop over ladder copy placement in phi and positive and negative Z
 	} // end loop over inner or outer sensor
     } // end loop over layers
-  
   return 0;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -229,7 +229,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z");  
 	  hdi_z_[ilayer][itype] = hdi_z;
 	  G4VSolid *hdi_kapton_box = new G4Box(boost::str(boost::format("hdi_kapton_box_%d_%d") % sphxlayer % itype).c_str(), hdi_kapton_x / 2., hdi_y / 2., hdi_z/2.0);
-	  G4LogicalVolume *hdi_kapton_volume = new G4LogicalVolume(hdi_kapton_box, G4Material::GetMaterial("FPC"), 
+	  G4LogicalVolume *hdi_kapton_volume = new G4LogicalVolume(hdi_kapton_box, G4Material::GetMaterial("G4_KAPTON"), 
 							    boost::str(boost::format("hdi_kapton_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  G4VSolid *hdi_copper_box = new G4Box(boost::str(boost::format("hdi_copper_box_%d_%d") % sphxlayer % itype).c_str(), hdi_copper_x / 2., hdi_y / 2., hdi_z/2.0);
 	  G4LogicalVolume *hdi_copper_volume = new G4LogicalVolume(hdi_copper_box, G4Material::GetMaterial("G4_Cu"), 
@@ -244,7 +244,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z  - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
 	  G4VSolid *hdiext_kapton_box = new G4Box(boost::str(boost::format("hdiext_kapton_box_%d_%s") % sphxlayer % itype).c_str(), 
 						  hdi_kapton_x / 2., hdi_y / 2., hdiext_z / 2.0);
-	  G4LogicalVolume *hdiext_kapton_volume = new G4LogicalVolume(hdiext_kapton_box, G4Material::GetMaterial("FPC"), 
+	  G4LogicalVolume *hdiext_kapton_volume = new G4LogicalVolume(hdiext_kapton_box, G4Material::GetMaterial("G4_KAPTON"),  // was "FPC" 
 							       boost::str(boost::format("hdiext_kapton_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  G4VSolid *hdiext_copper_box = new G4Box(boost::str(boost::format("hdiext_copper_box_%d_%s") % sphxlayer % itype).c_str(), 
 						  hdi_copper_x / 2., hdi_y / 2., hdiext_z / 2.0);
@@ -326,7 +326,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  const double pgs_y = hdi_y;
 	  const double pgs_z = hdi_z;
 	  G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., pgs_z / 2.);
-	  G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("G4_C"), 
+	  G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("CFRP_INTT"), 
 							    boost::str(boost::format("pgs_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
@@ -334,7 +334,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	    }
 	  // The part that extends beyond this sensor, see above for hdiext
 	  G4VSolid *pgsext_box = new G4Box(boost::str(boost::format("pgsext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *pgsext_volume = new G4LogicalVolume(pgsext_box, G4Material::GetMaterial("G4_C"), 
+	  G4LogicalVolume *pgsext_volume = new G4LogicalVolume(pgsext_box, G4Material::GetMaterial("CFRP_INTT"), 
 							       boost::str(boost::format("pgsext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
 
 	  G4VisAttributes *pgs_vis = new G4VisAttributes();
@@ -372,11 +372,11 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	    {
 	      stave_curve_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_cons_%d_%d_%d") %sphxlayer % itype %i).c_str(), 
 					       Rcmin, Rcmax, stave_z / 2., phic_begin[i], dphic[i]);
-	      stave_curve_volume[i] = new G4LogicalVolume(stave_curve_cons[i], G4Material::GetMaterial("G4_C"), 
+	      stave_curve_volume[i] = new G4LogicalVolume(stave_curve_cons[i], G4Material::GetMaterial("CFRP_INTT"), 
 							  boost::str(boost::format("stave_curve_volume_%d_%d_%d") % sphxlayer % itype % i).c_str(), 0, 0, 0);
 	      stave_curve_ext_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_ext_cons_%d_%d_%d") %sphxlayer % itype %i).c_str(), 
 						   Rcmin, Rcmax, hdiext_z / 2., phic_begin[i], dphic[i]);
-	      stave_curve_ext_volume[i] = new G4LogicalVolume(stave_curve_ext_cons[i], G4Material::GetMaterial("G4_C"), 
+	      stave_curve_ext_volume[i] = new G4LogicalVolume(stave_curve_ext_cons[i], G4Material::GetMaterial("CFRP_INTT"), 
 							      boost::str(boost::format("stave_curve_ext_volume_%d_%d_%d") % sphxlayer % itype %i).c_str(), 0, 0, 0);
 
 	      G4VisAttributes *stave_curve_vis = new G4VisAttributes();
@@ -396,31 +396,31 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  double stave_wall_thickness = 0.03*cm;
 	  G4VSolid *stave_straight_outer_box = new G4Box(boost::str(boost::format("stave_straight_outer_box_%d_%d") % sphxlayer % itype).c_str(), 
 							 stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
-	  G4LogicalVolume *stave_straight_outer_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("G4_C"), 
+	  G4LogicalVolume *stave_straight_outer_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("CFRP_INTT"), 
 									     boost::str(boost::format("stave_straight_outer_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  G4VSolid *stave_straight_outer_ext_box = new G4Box(boost::str(boost::format("stave_straight_outer_ext_box_%d_%s") % sphxlayer % itype).c_str(), 
 							     stave_wall_thickness/2., stave_straight_outer_y/2., hdiext_z / 2.);
-	  G4LogicalVolume *stave_straight_outer_ext_volume = new G4LogicalVolume(stave_straight_outer_ext_box, G4Material::GetMaterial("G4_C"), 
+	  G4LogicalVolume *stave_straight_outer_ext_volume = new G4LogicalVolume(stave_straight_outer_ext_box, G4Material::GetMaterial("CFRP_INTT"), 
 										 boost::str(boost::format("stave_straight_outer_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  
 	  // connects cooling tubes together, only needed for laddertype 1, for laddertype 0 we just make a dummy
 	  G4VSolid *stave_straight_inner_box = new G4Box(boost::str(boost::format("stave_straight_inner_box_%d_%d") % sphxlayer % itype).c_str(), 
 							 stave_wall_thickness / 2., stave_straight_inner_y / 2., stave_z / 2.);
-	  G4LogicalVolume *stave_straight_inner_volume = new G4LogicalVolume(stave_straight_inner_box, G4Material::GetMaterial("G4_C"), 
+	  G4LogicalVolume *stave_straight_inner_volume = new G4LogicalVolume(stave_straight_inner_box, G4Material::GetMaterial("CFRP_INTT"), 
 									     boost::str(boost::format("stave_straight_inner_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  G4VSolid *stave_straight_inner_ext_box = new G4Box(boost::str(boost::format("stave_straight_inner_ext_box_%d_%d") % sphxlayer % itype).c_str(), 
 							     stave_wall_thickness / 2., stave_straight_inner_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *stave_straight_inner_ext_volume  = new G4LogicalVolume(stave_straight_inner_ext_box, G4Material::GetMaterial("G4_C"), 
+	  G4LogicalVolume *stave_straight_inner_ext_volume  = new G4LogicalVolume(stave_straight_inner_ext_box, G4Material::GetMaterial("CFRP_INTT"), 
 										  boost::str(boost::format("stave_straight_inner_ext_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  
 	  //Top surface of cooler tube
 	  G4VSolid *stave_straight_cooler_box = new G4Box(boost::str(boost::format("stave_straight_cooler_box_%d_%d") % sphxlayer % itype).c_str(), 
 							  stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
-	  G4LogicalVolume *stave_straight_cooler_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("G4_C"), 
+	  G4LogicalVolume *stave_straight_cooler_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("CFRP_INTT"), 
 									      boost::str(boost::format("stave_straight_cooler_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  G4VSolid *stave_straight_cooler_ext_box = new G4Box(boost::str(boost::format("stave_straight_cooler_ext_box_%d_%d") % sphxlayer % itype).c_str(), 
 							      stave_wall_thickness / 2., stave_straight_cooler_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *stave_straight_cooler_ext_volume = new G4LogicalVolume(stave_straight_cooler_ext_box, G4Material::GetMaterial("G4_C"), 
+	  G4LogicalVolume *stave_straight_cooler_ext_volume = new G4LogicalVolume(stave_straight_cooler_ext_box, G4Material::GetMaterial("CFRP_INTT"), 
 										  boost::str(boost::format("stave_straight_cooler_ext_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  
 	  G4VisAttributes *stave_vis = new G4VisAttributes();
@@ -788,7 +788,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   // rails
   G4Tubs *rail_tube = new G4Tubs(boost::str(boost::format("si_support_rail")).c_str(), 
 			    9.0, 12.0, 2050, -TMath::Pi(), 2.0 * TMath::Pi() );  
-  G4LogicalVolume *rail_volume = new G4LogicalVolume(rail_tube, G4Material::GetMaterial("G4_C"), 
+  G4LogicalVolume *rail_volume = new G4LogicalVolume(rail_tube, G4Material::GetMaterial("CFRP_INTT"), 
 								      boost::str(boost::format("rail_volume")).c_str(), 0, 0, 0);
   G4VisAttributes *rail_vis = new G4VisAttributes();
   rail_vis->SetVisibility(true);
@@ -815,7 +815,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
   G4Tubs *outer_skin_tube = new G4Tubs(boost::str(boost::format("si_outer_skin")).c_str(), 
 			    157.0, 158.0, 480.0, -TMath::Pi(), 2.0 * TMath::Pi() );  
-  G4LogicalVolume *outer_skin_volume = new G4LogicalVolume(outer_skin_tube, G4Material::GetMaterial("G4_C"), 
+  G4LogicalVolume *outer_skin_volume = new G4LogicalVolume(outer_skin_tube, G4Material::GetMaterial("CFRP_INTT"), 
 								      boost::str(boost::format("outer_skin_volume")).c_str(), 0, 0, 0);
   outer_skin_volume->SetVisAttributes(rail_vis);
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), outer_skin_volume, 
@@ -825,7 +825,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
   G4Tubs *inner_skin_tube = new G4Tubs(boost::str(boost::format("si_inner_skin")).c_str(), 
 			    63.85, 64.0, 480.0, -TMath::Pi(), 2.0 * TMath::Pi() );  
-  G4LogicalVolume *inner_skin_volume = new G4LogicalVolume(inner_skin_tube, G4Material::GetMaterial("G4_C"), 
+  G4LogicalVolume *inner_skin_volume = new G4LogicalVolume(inner_skin_tube, G4Material::GetMaterial("CFRP_INTT"), 
 								      boost::str(boost::format("inner_skin_volume")).c_str(), 0, 0, 0);
   inner_skin_volume->SetVisAttributes(rail_vis);
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), inner_skin_volume, 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -786,8 +786,11 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   */
 
   // rails
+  double rail_inner_radius = 4.5; 
+  double rail_outer_radius = 6.0;
+  double rail_length = 410.0 * 10.0;  // TPC length is 410 cm
   G4Tubs *rail_tube = new G4Tubs(boost::str(boost::format("si_support_rail")).c_str(), 
-			    9.0, 12.0, 2050, -TMath::Pi(), 2.0 * TMath::Pi() );  
+			    rail_inner_radius, rail_outer_radius, rail_length / 2.0, -TMath::Pi(), 2.0 * TMath::Pi() );  
   G4LogicalVolume *rail_volume = new G4LogicalVolume(rail_tube, G4Material::GetMaterial("CFRP_INTT"), 
 								      boost::str(boost::format("rail_volume")).c_str(), 0, 0, 0);
   G4VisAttributes *rail_vis = new G4VisAttributes();
@@ -830,6 +833,42 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   inner_skin_volume->SetVisAttributes(rail_vis);
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), inner_skin_volume, 
 		    boost::str(boost::format("si_support_inner_skin") ).c_str(), trackerenvelope, false, 0, OverlapCheck());
+
+  //=======================================================
+  // Add an outer shell for the MVTX - move this to the MVTX detector module
+  //=======================================================
+  // A Rohacell foam sandwich made of 0.1 mm thick CFRP skin and 1.8 mm Rohacell 110 foam core, it has a density of 110 kg/m**3.
+  double skin_thickness = 0.1;
+  double foam_core_thickness = 1.8;
+  double mvtx_shell_length = 420.0;
+
+  double mvtx_shell_inner_skin_inner_radius = 48.0;
+  double mvtx_shell_foam_core_inner_radius = mvtx_shell_inner_skin_inner_radius + skin_thickness;
+  double mvtx_shell_outer_skin_inner_radius = mvtx_shell_foam_core_inner_radius + foam_core_thickness;
+
+  G4Tubs *mvtx_shell_inner_skin_tube = new G4Tubs(boost::str(boost::format("mvtx_shell_inner_skin")).c_str(), 
+			    mvtx_shell_inner_skin_inner_radius, mvtx_shell_inner_skin_inner_radius + skin_thickness, mvtx_shell_length / 2.0, -TMath::Pi(), 2.0 * TMath::Pi() );  
+  G4LogicalVolume *mvtx_shell_inner_skin_volume = new G4LogicalVolume(mvtx_shell_inner_skin_tube, G4Material::GetMaterial("CFRP_INTT"), 
+								      boost::str(boost::format("mvtx_shell_inner_skin_volume")).c_str(), 0, 0, 0);
+  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_inner_skin_volume, 
+		    boost::str(boost::format("mvtx_shell_inner_skin") ).c_str(), trackerenvelope, false, 0, OverlapCheck());
+  mvtx_shell_inner_skin_volume->SetVisAttributes(rail_vis);
+
+  G4Tubs *mvtx_shell_foam_core_tube = new G4Tubs(boost::str(boost::format("mvtx_shell_foam_core")).c_str(), 
+			    mvtx_shell_foam_core_inner_radius, mvtx_shell_foam_core_inner_radius + foam_core_thickness, mvtx_shell_length / 2.0, -TMath::Pi(), 2.0 * TMath::Pi() );  
+  G4LogicalVolume *mvtx_shell_foam_core_volume = new G4LogicalVolume(mvtx_shell_foam_core_tube, G4Material::GetMaterial("ROHACELL_FOAM_110"), 
+								      boost::str(boost::format("mvtx_shell_foam_core_volume")).c_str(), 0, 0, 0);
+  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_foam_core_volume, 
+		    boost::str(boost::format("mvtx_shell_foam_core") ).c_str(), trackerenvelope, false, 0, OverlapCheck());
+  mvtx_shell_foam_core_volume->SetVisAttributes(rail_vis);
+
+  G4Tubs *mvtx_shell_outer_skin_tube = new G4Tubs(boost::str(boost::format("mvtx_shell_outer_skin")).c_str(), 
+			    mvtx_shell_outer_skin_inner_radius, mvtx_shell_outer_skin_inner_radius + skin_thickness, mvtx_shell_length / 2.0, -TMath::Pi(), 2.0 * TMath::Pi() );  
+  G4LogicalVolume *mvtx_shell_outer_skin_volume = new G4LogicalVolume(mvtx_shell_outer_skin_tube, G4Material::GetMaterial("CFRP_INTT"), 
+								      boost::str(boost::format("mvtx_shell_outer_skin_volume")).c_str(), 0, 0, 0);
+  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_outer_skin_volume, 
+		    boost::str(boost::format("mvtx_shell_outer_skin") ).c_str(), trackerenvelope, false, 0, OverlapCheck());
+  mvtx_shell_outer_skin_volume->SetVisAttributes(rail_vis);
 
   return 0;
 }

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -13,6 +13,7 @@
 #include <phool/getClass.h>
 
 #include <Geant4/G4Box.hh>
+#include <Geant4/G4Cons.hh>
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
@@ -23,6 +24,7 @@
 #include <Geant4/G4VisAttributes.hh>
 
 #include <cmath>
+#include <TMath.h>
 
 #include <boost/foreach.hpp>
 #include <boost/format.hpp>
@@ -99,517 +101,601 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   // We have 2 types of sensors (inner and outer)
 
   double hdi_z_[nlayer_][2];
+  // we loop over layers. All layers have only one laddertype
   for (unsigned int ilayer = 0; ilayer < nlayer_; ++ilayer)
-  {
-    const int sphxlayer = layerconfig_[ilayer].first;
-    const int inttlayer = layerconfig_[ilayer].second;
-    // get the laddertype for this layer
-    PHParameters *params = paramscontainer->GetParameters(inttlayer);
-    const int laddertype = params->get_int_param("laddertype");
-
-    // Look up all remaining parameters by laddertype
-    params = paramscontainer->GetParameters(laddertype);
-    const G4double strip_x = params->get_double_param("strip_x") * cm;
-    const G4double strip_y = params->get_double_param("strip_y") * cm;
-    const int nstrips_phi_sensor = params->get_int_param("nstrips_phi_sensor");
-    const int nladders_layer = params->get_int_param("nladders");
-    const G4double radius = params->get_double_param("radius") * cm;
-    const G4double offsetphi = params->get_double_param("offsetphi") * deg;
-    const G4double offsetrot = params->get_double_param("offsetrot") * deg;
-    const G4double hdi_y = params->get_double_param("hdi_y") * cm;
-    double hdi_x = params->get_double_param("hdi_x") * cm;
-    double fphx_x = params->get_double_param("fphx_x") * cm;
-    double fphx_y = params->get_double_param("fphx_y") * cm;
-    double fphx_z = params->get_double_param("fphx_z") * cm;
-    double pgs_x = params->get_double_param("pgs_x") * cm;
-    //double stave_x = params->get_double_param("stave_x") * cm;
-    double halfladder_z = params->get_double_param("halfladder_z") * cm;
-
-    // itype specifies inner or outer sensor type
-    for (int itype = 0; itype < 2; ++itype)
     {
-      if (!(itype >= 0 && itype <= 1))
-      {
-        assert(!"Error: check ladder type.");
-      }
-      G4double strip_z;
-      int nstrips_z_sensor;
-      switch (itype)
-      {
-      case 0:
-        strip_z = params->get_double_param("strip_z_0") * cm;
-        nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_0");
-        break;
-      case 1:
-        strip_z = params->get_double_param("strip_z_1") * cm;
-        nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_1");
-        break;
-      default:
-        cout << "invalid itype " << itype << endl;
-        exit(1);
-      }
+      const int sphxlayer = layerconfig_[ilayer].first;
+      const int inttlayer = layerconfig_[ilayer].second;
 
-      // ----- Step 1 ------------------------------------------------------------------------------
-      // We make the volumes for Si-sensor, FPHX, HDI, PGS sheet, and stave.
-      // We add them to the ladder later
-      //===================================================
-      
-      // Create a volume for the Si-strip
-      // use half widths to make the box
-      G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % sphxlayer %itype).c_str(), 
-				      strip_x / 2., strip_y / 2. - strip_y / 20000., strip_z / 2. - strip_z / 2. / 10000.);
-      G4LogicalVolume *strip_volume = new G4LogicalVolume(strip_box, G4Material::GetMaterial("G4_Si"), 
-							  boost::str(boost::format("strip_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-      if ((IsActive.find(inttlayer))->second > 0)
+      // get the parameters for this layer
+      const PHParameters *params1 = paramscontainer->GetParameters(inttlayer);
+      const int laddertype = params1->get_int_param("laddertype");
+      double layer_radius_inner = params1->get_double_param("ladder_radius_inner") * cm;
+      double layer_radius_outer = params1->get_double_param("ladder_radius_outer") * cm;
+
+      // Look up all remaining parameters by the laddertype for this layer
+      const PHParameters *params = paramscontainer->GetParameters(laddertype);
+      const G4double strip_x = params->get_double_param("strip_x") * cm;
+      const G4double strip_y = params->get_double_param("strip_y") * cm;
+      const int nstrips_phi_sensor = params->get_int_param("nstrips_phi_sensor");
+      const int nladders_layer = params->get_int_param("nladders");
+      const G4double offsetphi = params->get_double_param("offsetphi") * deg;
+      const G4double offsetrot = params->get_double_param("offsetrot") * deg;
+      const G4double hdi_y = params->get_double_param("hdi_y") * cm;
+      double hdi_x = params->get_double_param("hdi_x") * cm;
+      double fphx_x = params->get_double_param("fphx_x") * cm;
+      double fphx_y = params->get_double_param("fphx_y") * cm;
+      double fphx_z = params->get_double_param("fphx_z") * cm;
+      double pgs_x = params->get_double_param("pgs_x") * cm;
+      double halfladder_z = params->get_double_param("halfladder_z") * cm;
+      double stave_straight_outer_y = params->get_double_param("stave_straight_outer_y") * cm;
+      double stave_straight_inner_y = params->get_double_param("stave_straight_inner_y") * cm;
+      double stave_straight_cooler_y = params->get_double_param("stave_straight_cooler_y") * cm;
+
+      // We loop over inner, then outer, sensors, where  itype specifies the inner or outer sensor type
+      // The rest of this loop will construct and put in place a section of a ladder corresponding to the 
+      // Z range of this sensor only
+      for (int itype = 0; itype < 2; ++itype)
 	{
-	  activelogvols.insert(strip_volume);
-	}
-      G4VisAttributes *strip_vis = new G4VisAttributes();
-      strip_vis->SetVisibility(false);
-      strip_vis->SetForceSolid(false);
-      strip_vis->SetColour(G4Colour::White());
-      strip_volume->SetVisAttributes(strip_vis);
-      
-      // Create Si-sensor active volume
-      // Use half-widths to make the box      
-      const double siactive_x = strip_x;
-      const double siactive_y = strip_y * nstrips_phi_sensor; 
-      const double siactive_z = strip_z * nstrips_z_sensor;  
-      
-      G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x, siactive_y, siactive_z);
-      G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), 
-							     boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-      
-      // Now make a G4PVParameterised containing all of the strips in a sensor 
-      // this works for ladder 0 because there is only one strip type - all cells are identical
-      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_sensor, nstrips_z_sensor, strip_y/2.0, strip_z/2.0);
-      new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), strip_volume, siactive_volume, kZAxis, nstrips_phi_sensor * nstrips_z_sensor, stripparam, false);  // overlap check too long.
-      
-      
-      // Si-sensor full (active+inactive) area
+	  if (!(itype >= 0 && itype <= 1))
+	    {
+	      assert(!"Error: check ladder type.");
+	    }
+	  G4double strip_z;
+	  int nstrips_z_sensor;
+	  switch (itype)
+	    {
+	    case 0:
+	      strip_z = params->get_double_param("strip_z_0") * cm;
+	      nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_0");
+	      break;
+	    case 1:
+	      strip_z = params->get_double_param("strip_z_1") * cm;
+	      nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_1");
+	      break;
+	    default:
+	      cout << "invalid itype " << itype << endl;
+	      exit(1);
+	    }
 
-      const double sifull_x = siactive_x;
-      const double sifull_y = siactive_y + 2.0*params->get_double_param("sensor_edge_phi") * cm; 
-      const double sifull_z = siactive_z + 2.0*params->get_double_param("sensor_edge_z") * cm;    
+	  // ----- Step 1 ---------------------------------------------------------------------------------------------
+	  // We make the volumes for Si-sensor, FPHX, HDI, PGS sheet, and stave components
+	  // We add them to the ladder later
+	  //============================================================
       
-      G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % sphxlayer % itype).c_str(), sifull_x / 2., sifull_y/2.0, sifull_z/2.0);
+	  // Create a volume for the Si-strip. Use half widths to make the box
+	  G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % sphxlayer %itype).c_str(), 
+					  strip_x / 2., strip_y / 2. - strip_y / 20000., strip_z / 2. - strip_z / 2. / 10000.);
+	  G4LogicalVolume *strip_volume = new G4LogicalVolume(strip_box, G4Material::GetMaterial("G4_Si"), 
+							      boost::str(boost::format("strip_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  if ((IsActive.find(inttlayer))->second > 0)
+	    {
+	      activelogvols.insert(strip_volume);
+	    }
+	  G4VisAttributes *strip_vis = new G4VisAttributes();
+	  strip_vis->SetVisibility(false);
+	  strip_vis->SetForceSolid(false);
+	  strip_vis->SetColour(G4Colour::White());
+	  strip_volume->SetVisAttributes(strip_vis);
       
-      // Si-sensor inactive area
+	  // Create Si-sensor active volume
+	  const double siactive_x = strip_x;
+	  const double siactive_y = strip_y * nstrips_phi_sensor; 
+	  const double siactive_z = strip_z * nstrips_z_sensor;  
       
-      G4VSolid *siinactive_box = new G4SubtractionSolid(boost::str(boost::format("siinactive_box_%d_%d") % sphxlayer % itype).c_str(), 
-							sifull_box, siactive_box, 0, G4ThreeVector(0, 0, 0));
-      G4LogicalVolume *siinactive_volume = new G4LogicalVolume(siinactive_box, G4Material::GetMaterial("G4_Si"), 
-							       boost::str(boost::format("siinactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-      if ((IsAbsorberActive.find(inttlayer))->second > 0)
-	{
-	  absorberlogvols.insert(siinactive_volume);
-	}
-      G4VisAttributes *siinactive_vis = new G4VisAttributes();
-      siinactive_vis->SetVisibility(true);
-      siinactive_vis->SetForceSolid(true);
-      siinactive_vis->SetColour(G4Colour::Gray());
-      siinactive_volume->SetVisAttributes(siinactive_vis);
+	  G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x, siactive_y, siactive_z);
+	  G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), 
+								 boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       
+	  // Now make a G4PVParameterised containing all of the strips in a sensor 
+	  // this works for ladder 0 because there is only one strip type - all cells are identical
+	  G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_sensor, nstrips_z_sensor, strip_y, strip_z);
+	  new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), 
+				strip_volume, siactive_volume, kZAxis, nstrips_phi_sensor * nstrips_z_sensor, stripparam, false);  // overlap check too long.
+      
+      
+	  // Si-sensor full (active+inactive) area
+	  const double sifull_x = siactive_x;
+	  const double sifull_y = siactive_y + 2.0*params->get_double_param("sensor_edge_phi") * cm; 
+	  const double sifull_z = siactive_z + 2.0*params->get_double_param("sensor_edge_z") * cm;    
+      	  G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % sphxlayer % itype).c_str(), sifull_x / 2., sifull_y/2.0, sifull_z/2.0);
+      
+	  // Si-sensor inactive area
+      	  G4VSolid *siinactive_box = new G4SubtractionSolid(boost::str(boost::format("siinactive_box_%d_%d") % sphxlayer % itype).c_str(), 
+							    sifull_box, siactive_box, 0, G4ThreeVector(0, 0, 0));
+	  G4LogicalVolume *siinactive_volume = new G4LogicalVolume(siinactive_box, G4Material::GetMaterial("G4_Si"), 
+								   boost::str(boost::format("siinactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
+	    {
+	      absorberlogvols.insert(siinactive_volume);
+	    }
+	  G4VisAttributes *siinactive_vis = new G4VisAttributes();
+	  siinactive_vis->SetVisibility(true);
+	  siinactive_vis->SetForceSolid(true);
+	  siinactive_vis->SetColour(G4Colour::Gray());
+	  siinactive_volume->SetVisAttributes(siinactive_vis);
+      
+	  // Make the HDI volume
+	  // This makes a HDI volume that matches this sensor in Z length
+	  const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z") * cm;  
+	  hdi_z_[ilayer][itype] = hdi_z;
 
-      // Make the HDI volume
-      // This makes a HDI volume that matches this sensor in Z length
+	  G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdi_z/2.0);
+	  G4LogicalVolume *hdi_volume = new G4LogicalVolume(hdi_box, G4Material::GetMaterial("FPC"), 
+							    boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
+	    {
+	      absorberlogvols.insert(hdi_volume);
+	    }
 
-      const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z") * cm;  
-      hdi_z_[ilayer][itype] = hdi_z;
+	  // This is the part of the HDI that extends beyond the sensor
+	  const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z  - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
+	  G4VSolid *hdiext_box = new G4Box(boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdiext_z / 2.0);
+	  G4LogicalVolume *hdiext_volume = new G4LogicalVolume(hdiext_box, G4Material::GetMaterial("FPC"), 
+							       boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
+	    {
+	      absorberlogvols.insert(hdiext_volume);
+	    }
+	  G4VisAttributes *hdi_vis = new G4VisAttributes();
+	  hdi_vis->SetVisibility(true);
+	  hdi_vis->SetForceSolid(true);
+	  hdi_vis->SetColour(G4Colour::Magenta());
+	  hdi_volume->SetVisAttributes(hdi_vis);
+	  hdiext_volume->SetVisAttributes(hdi_vis);
 
-      G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdi_z/2.0);
-      G4LogicalVolume *hdi_volume = new G4LogicalVolume(hdi_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-      if ((IsAbsorberActive.find(inttlayer))->second > 0)
-      {
-        absorberlogvols.insert(hdi_volume);
-      }
-
-      // This is the part of the HDI that extends beyond the sensor
-      const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z  - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
-      G4VSolid *hdiext_box = new G4Box(boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdiext_z / 2.0);
-      G4LogicalVolume *hdiext_volume = new G4LogicalVolume(hdiext_box, G4Material::GetMaterial("FPC"), 
-							   boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
-      if ((IsAbsorberActive.find(inttlayer))->second > 0)
-      {
-        absorberlogvols.insert(hdiext_volume);
-      }
-      G4VisAttributes *hdi_vis = new G4VisAttributes();
-      hdi_vis->SetVisibility(true);
-      hdi_vis->SetForceSolid(true);
-      hdi_vis->SetColour(G4Colour::Magenta());
-      hdi_volume->SetVisAttributes(hdi_vis);
-
-      // FPHX
+	  // FPHX
         
-      G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % sphxlayer % itype).c_str(), fphx_x / 2., fphx_y / 2., fphx_z / 2.);
-      G4LogicalVolume *fphx_volume = new G4LogicalVolume(fphx_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("fphx_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-      if ((IsAbsorberActive.find(inttlayer))->second > 0)
-      {
-        absorberlogvols.insert(fphx_volume);
-      }
-      G4VisAttributes *fphx_vis = new G4VisAttributes();
-      fphx_vis->SetVisibility(true);
-      fphx_vis->SetForceSolid(true);
-      fphx_vis->SetColour(G4Colour::Gray());
-      fphx_volume->SetVisAttributes(fphx_vis);
+	  G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % sphxlayer % itype).c_str(), fphx_x / 2., fphx_y / 2., fphx_z / 2.);
+	  G4LogicalVolume *fphx_volume = new G4LogicalVolume(fphx_box, G4Material::GetMaterial("G4_Si"), 
+							     boost::str(boost::format("fphx_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
+	    {
+	      absorberlogvols.insert(fphx_volume);
+	    }
+	  G4VisAttributes *fphx_vis = new G4VisAttributes();
+	  fphx_vis->SetVisibility(true);
+	  fphx_vis->SetForceSolid(true);
+	  fphx_vis->SetColour(G4Colour::Gray());
+	  fphx_volume->SetVisAttributes(fphx_vis);
 
-      const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx") * cm;
+	  const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx") * cm;
       
-      //  FPHX Container
-      // make a container for the FPHX chips needed for this sensor, and  then place them in the container
-      const double fphxcontainer_x = fphx_x / 2.;
-      const double fphxcontainer_y = fphx_y / 2.;
-      const double fphxcontainer_z = hdi_z / 2.0;
+	  //  FPHX Container
+	  // make a container for the FPHX chips needed for this sensor, and  then place them in the container
+	  const double fphxcontainer_x = fphx_x / 2.;
+	  const double fphxcontainer_y = fphx_y / 2.;
+	  const double fphxcontainer_z = hdi_z / 2.0;
 
-      G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % sphxlayer % itype).c_str(), 
-					      fphxcontainer_x, fphxcontainer_y, fphxcontainer_z);
-      G4LogicalVolume *fphxcontainer_volume = new G4LogicalVolume(fphxcontainer_box, G4Material::GetMaterial("G4_AIR"), 
-								  boost::str(boost::format("fphxcontainer_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-      if ((IsAbsorberActive.find(inttlayer))->second > 0)
-      {
-        absorberlogvols.insert(fphxcontainer_volume);
-      }
-      G4VisAttributes *fphxcontainer_vis = new G4VisAttributes();
-      fphxcontainer_vis->SetVisibility(false);
-      fphxcontainer_vis->SetForceSolid(false);
-      fphxcontainer_volume->SetVisAttributes(fphxcontainer_vis);
+	  G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % sphxlayer % itype).c_str(), 
+						  fphxcontainer_x, fphxcontainer_y, fphxcontainer_z);
+	  G4LogicalVolume *fphxcontainer_volume = new G4LogicalVolume(fphxcontainer_box, G4Material::GetMaterial("G4_AIR"), 
+								      boost::str(boost::format("fphxcontainer_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
+	    {
+	      absorberlogvols.insert(fphxcontainer_volume);
+	    }
+	  G4VisAttributes *fphxcontainer_vis = new G4VisAttributes();
+	  fphxcontainer_vis->SetVisibility(false);
+	  fphxcontainer_vis->SetForceSolid(false);
+	  fphxcontainer_volume->SetVisAttributes(fphxcontainer_vis);
 
-      // Install multiple FPHX volumes in the FPHX container volume 
-      // one FPHX chip per cell - each cell is 128 channels
-      const double offsetx = 0.;
-      const double offsety = 0.;
-      int ncopy;
-      double offsetz, cell_length_z;
-      // For layer 0, we have 5 cells per sensor, but the strips are vertical, so we have to treat it specially
-      if(nstrips_z_sensor == 1)
-	{
-	  ncopy = nstrips_z_sensor / 128.0;
-	}
-      else
-	{
-	  ncopy = nstrips_z_sensor;
-	}
-      cell_length_z = strip_z * nstrips_z_sensor / ncopy;
-      offsetz = (ncopy % 2 == 0) ? -2. * cell_length_z / 2. * double(ncopy / 2) + cell_length_z / 2. : -2. * cell_length_z / 2. * double(ncopy / 2);
+	  // Install multiple FPHX volumes in the FPHX container volume 
+	  // one FPHX chip per cell - each cell is 128 channels
+	  const double offsetx = 0.;
+	  const double offsety = 0.;
+	  int ncopy;
+	  double offsetz, cell_length_z;
+	  // For layer 0, we have 5 cells per sensor, but the strips are vertical, so we have to treat it specially
+	  if(nstrips_z_sensor == 1)
+	    {
+	      ncopy = nstrips_z_sensor / 128.0;
+	    }
+	  else
+	    {
+	      ncopy = nstrips_z_sensor;
+	    }
+	  cell_length_z = strip_z * nstrips_z_sensor / ncopy;
+	  offsetz = (ncopy % 2 == 0) ? -2. * cell_length_z / 2. * double(ncopy / 2) + cell_length_z / 2. : -2. * cell_length_z / 2. * double(ncopy / 2);
 
-      G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * strip_z / 2., ncopy);
-      new G4PVParameterised(boost::str(boost::format("fphxcontainer_%d_%d") % sphxlayer % itype).c_str(), 
-			    fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, OverlapCheck());
+	  G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * strip_z / 2., ncopy);
+	  new G4PVParameterised(boost::str(boost::format("fphxcontainer_%d_%d") % sphxlayer % itype).c_str(), 
+				fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, OverlapCheck());
 
-      // PGS   - this is the carbon sheet that the HDI sits on. It forms the wall of the cooling tube that cools the HDI
+	  // PGS   - this is the carbon sheet that the HDI sits on. It forms the wall of the cooling tube that cools the HDI
         
-      const double pgs_y = hdi_y;
-      const double pgs_z = hdi_z;
+	  const double pgs_y = hdi_y;
+	  const double pgs_z = hdi_z;
 
-      G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., pgs_z / 2.);
-      G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgs_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-      if ((IsAbsorberActive.find(inttlayer))->second > 0)
-      {
-        absorberlogvols.insert(pgs_volume);
-      }
-      // The part that extends beyond this sensor, see above for hdiext
-      G4VSolid *pgsext_box = new G4Box(boost::str(boost::format("pgsext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., hdiext_z / 2.);
-      G4LogicalVolume *pgsext_volume = new G4LogicalVolume(pgsext_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgsext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., pgs_z / 2.);
+	  G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("G4_C"), 
+							    boost::str(boost::format("pgs_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
+	    {
+	      absorberlogvols.insert(pgs_volume);
+	    }
+	  // The part that extends beyond this sensor, see above for hdiext
+	  G4VSolid *pgsext_box = new G4Box(boost::str(boost::format("pgsext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., hdiext_z / 2.);
+	  G4LogicalVolume *pgsext_volume = new G4LogicalVolume(pgsext_box, G4Material::GetMaterial("G4_C"), 
+							       boost::str(boost::format("pgsext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
 
-      G4VisAttributes *pgs_vis = new G4VisAttributes();
-      pgs_vis->SetVisibility(true);
-      pgs_vis->SetForceSolid(true);
-      pgs_vis->SetColour(G4Colour::Yellow());
-      pgs_volume->SetVisAttributes(pgs_vis);
+	  G4VisAttributes *pgs_vis = new G4VisAttributes();
+	  pgs_vis->SetVisibility(true);
+	  pgs_vis->SetForceSolid(true);
+	  pgs_vis->SetColour(G4Colour::Yellow());
+	  pgs_volume->SetVisAttributes(pgs_vis);
+	  pgsext_volume->SetVisAttributes(pgs_vis);
 
-      // Carbon stave. This is the formed sheet that sits on the PGS and completes the cooling tube
-      // Formed from straight sections and sections of a tube of radius 2.3 mm. All have wall thickness of 0.3 mm.
-      // These are different for laddertype 0 and 1, but they use some common elements.
+	  // Carbon stave. This is the formed sheet that sits on the PGS and completes the cooling tube
+	  // Formed from straight sections and sections of a tube of radius 2.3 mm. All have wall thickness of 0.3 mm.
+	  // These are different for laddertype 0 and 1, but they use some common elements.
 
-      // The curved section is made from a G4Cons, which is a generalized section of a cone
-      // Two curved sections combined should move the inner wall to be 2.0 mm away from the PGS, then 2 more sections bring it back
-      // For 1 of these tube sections,starting at 90 degrees, take decrease in y=1 mm at avge R. If avge R = 2.15 mm, dtheta = invcos( (R - y)/R ) = invcos(1.15/2.15) = 53.49 deg
-      // The extent along the x axis is then R*sin(dtheta) = 1.728 mm, so two sections combined have dx = 3.456 mm length in y 
-      const double Rcmin = 0.20; //cm  inner radius of curved section, same at both ends
-      const double Rcmax = 0.23; //cm  outer radius of curved section, same at both ends
-      double Rcavge = (Rcmax+Rcmin)/2.0;
-      double dphic = TMath::Acos( (Rcavge-1.0) / Rcavge);
-      const double stave_z = pgs_z;
-      const double phic_begin = M_PI / 2.;
+	  // The curved section is made from a G4Cons, which is a generalized section of a cone
+	  // Two curved sections combined should move the inner wall to be 2.0 mm away from the PGS, then 2 more sections bring it back
+	  // For 1 of these tube sections,starting at 90 degrees, take decrease in y=1 mm at avge R. 
+	  // If avge R = 2.15 mm, dtheta = invcos( (R - y)/R ) = invcos(1.15/2.15) = 53.49 deg
+	  // The extent along the x axis is then R*sin(dtheta) = 1.728 mm, so two sections combined have dx = 3.456 mm length in y 
+	  const double Rcmin = 0.20; //cm  inner radius of curved section, same at both ends
+	  const double Rcmax = 0.23; //cm  outer radius of curved section, same at both ends
+	  double Rcavge = (Rcmax+Rcmin)/2.0;
+	  double dphic = TMath::ACos( (Rcavge-1.0) / Rcavge);
+	  const double phic_begin = TMath::Pi() / 2.;
+	  const double stave_z = pgs_z;
 
-      // make a single curved section and reuse it later
-      G4Cons *stave_curve_cons = new G4Cons(boost:str(boost:format("stave_curve_%d_%d") %sphxlayer % itype).c_str(), 
-				       Rcmin, Rcmax, Rcmin, Rcmax, stave_z / 2., phic_begin, dphic);
-      G4LogicalVolume *stave_curve_volume = new G4LogicalVolume(stave_curve_cons, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_curve_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
-      G4VisAttributes *stave_curve_vis = new G4VisAttributes();
-      stave_curve_vis->SetVisibility(true);
-      stave_curve_vis->SetForceSolid(true);
-      stave_curve_vis->SetColour(G4Colour::Yellow());
-      stave_curve_volume->SetVisAttributes(stave_curve_vis);
+	  // make a single curved section and reuse it later
+	  G4Cons *stave_curve_cons = new G4Cons(boost::str(boost::format("stave_curve_%d_%d") %sphxlayer % itype).c_str(), 
+						Rcmin, Rcmax, Rcmin, Rcmax, stave_z / 2., phic_begin, dphic);
+	  G4LogicalVolume *stave_curve_volume = new G4LogicalVolume(stave_curve_cons, G4Material::GetMaterial("G4_C"), 
+								    boost::str(boost::format("stave_curve_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
 
-      // Make several straight sections
-      // Outer straight sections of stave
-      double stave_wall_thickness = 0.3;
-      G4VSolid *stave_straight_outer_box = new G4Box(boost::str(boost::format("stave_straight_outer_box_%d_%d") % sphxlayer % itype).c_str(), stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
-      G4LogicalVolume *stave_straight_outer_box_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_straight_outer_box_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  G4Cons *stave_curve_ext_cons = new G4Cons(boost::str(boost::format("stave_curve_%d_%d") %sphxlayer % itype).c_str(), 
+						    Rcmin, Rcmax, Rcmin, Rcmax, hdiext_z / 2., phic_begin, dphic);
+	  G4LogicalVolume *stave_curve_ext_volume = new G4LogicalVolume(stave_curve_ext_cons, G4Material::GetMaterial("G4_C"), 
+									boost::str(boost::format("stave_curve_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
 
-      // connects cooling tubes together, only needed for laddertype 1
-      G4VSolid *stave_straight_inner_box = new G4Box(boost::str(boost::format("stave_straight_inner_box_%d_%d") % sphxlayer % itype).c_str(), stave_wall_thickness / 2., stave_straight_inner_y / 2., stave_z / 2.);
-      G4LogicalVolume *stave_straight_inner_box_volume = new G4LogicalVolume(stave_straight_inner_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_straight_inner_box_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  // Make several straight sections for use in making the stave
 
-      //Top surface of cooler tube
-      G4VSolid *stave_straight_cooler_box = new G4Box(boost::str(boost::format("stave_straight_cooler_box_%d_%d") % sphxlayer % itype).c_str(), stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
-      G4LogicalVolume *stave_straight_cooler_box_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_straight_cooler_box_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  // Outer straight sections of stave
+	  double stave_wall_thickness = 0.3;
+	  G4VSolid *stave_straight_outer_box = new G4Box(boost::str(boost::format("stave_straight_outer_box_%d_%d") % sphxlayer % itype).c_str(), 
+							 stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
+	  G4LogicalVolume *stave_straight_outer_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("G4_C"), 
+									     boost::str(boost::format("stave_straight_outer_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *stave_straight_outer_ext_box = new G4Box(boost::str(boost::format("stave_straight_outer_ext_box_%d_%s") % sphxlayer % itype).c_str(), 
+							     stave_wall_thickness/2., stave_straight_outer_y/2., hdiext_z / 2.);
+	  G4LogicalVolume *stave_straight_outer_ext_volume = new G4LogicalVolume(stave_straight_outer_ext_box, G4Material::GetMaterial("G4_C"), 
+										 boost::str(boost::format("stave_straight_outer_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
 
-      // Now we combine the elements of a stave defined above into a stave
-      // Create a stave volume to install the stave sections into. The volume has to be big enouigh to contain the cooling tube
-      double cooler_gap_x = 0.2;  // id of cooling tube 
-      double cooler_wall = 0.03;   // outer wall thickness of cooling tube 
-      double cooler_x = cooler_gap_x + cooler_wall; 
-      const double stave_x = cooler_x;  // we do not include the PGS
-      const double stave_y = hdi_y;
-      G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % sphxlayer % itype).c_str(), stave_x / 2., stave_y / 2., stave_z / 2.);
-      G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_Air"), boost::str(boost::format("stave_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-      if ((IsAbsorberActive.find(inttlayer))->second > 0)
-      {
-        absorberlogvols.insert(stave_volume);
-      }
-      G4VSolid *staveext_box = new G4Box(boost::str(boost::format("staveext_box_%d_%s") % sphxlayer % itype).c_str(), stave_x / 2., stave_y, hdiext_z);
-      G4LogicalVolume *staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_Air"), boost::str(boost::format("staveext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
-      if ((IsAbsorberActive.find(inttlayer))->second > 0)
-      {
-        absorberlogvols.insert(staveext_volume);
-      }
+	  // connects cooling tubes together, only needed for laddertype 1
+	  G4VSolid *stave_straight_inner_box = new G4Box(boost::str(boost::format("stave_straight_inner_box_%d_%d") % sphxlayer % itype).c_str(), 
+							 stave_wall_thickness / 2., stave_straight_inner_y / 2., stave_z / 2.);
+	  G4LogicalVolume *stave_straight_inner_volume = new G4LogicalVolume(stave_straight_inner_box, G4Material::GetMaterial("G4_C"), 
+									     boost::str(boost::format("stave_straight_inner_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *stave_straight_inner_ext_box = new G4Box(boost::str(boost::format("stave_straight_inner_ext_box_%d_%d") % sphxlayer % itype).c_str(), 
+							     stave_wall_thickness / 2., stave_straight_inner_y / 2., hdiext_z / 2.);
+	  G4LogicalVolume *stave_straight_inner_ext_volume = new G4LogicalVolume(stave_straight_inner_ext_box, G4Material::GetMaterial("G4_C"), 
+										 boost::str(boost::format("stave_straight_inner_ext_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 
-      // Assemble the elements into the stave volume
-      if(laddertype == 0)
-	{
-	  // only one cooling tube in laddertype 0
-	  // Place the straight sections
-	  // middle, above x axis, below x axis
-	  x_off_str[3] = {Rcavge, (Rcmax - Rcmin) / 2., (Rcmax - Rcmin) / 2.};
-	  y_off_str[3] = {
-	    0.0;
-	    stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ) + 2.0 * Rcavge*TMath::Sin(dphic / 2.) + stave_straight_outer_y / 2.0,
-	    -stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ) - 2.0 * Rcavge*TMath::Sin(dphic / 2.) - stave_straight_outer_y / 2.0	  
-	  };
+	  //Top surface of cooler tube
+	  G4VSolid *stave_straight_cooler_box = new G4Box(boost::str(boost::format("stave_straight_cooler_box_%d_%d") % sphxlayer % itype).c_str(), 
+							  stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
+	  G4LogicalVolume *stave_straight_cooler_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("G4_C"), 
+									      boost::str(boost::format("stave_straight_cooler_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *stave_straight_cooler_ext_box = new G4Box(boost::str(boost::format("stave_straight_cooler_ext_box_%d_%d") % sphxlayer % itype).c_str(), 
+							      stave_wall_thickness / 2., stave_straight_cooler_y / 2., hdiext_z / 2.);
+	  G4LogicalVolume *stave_straight_cooler_ext_volume = new G4LogicalVolume(stave_straight_cooler_ext_box, G4Material::GetMaterial("G4_C"), 
+										  boost::str(boost::format("stave_straight_cooler_ext_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+
+	  G4VisAttributes *stave_curve_vis = new G4VisAttributes();
+	  stave_curve_vis->SetVisibility(true);
+	  stave_curve_vis->SetForceSolid(true);
+	  stave_curve_vis->SetColour(G4Colour::Yellow());
+	  stave_curve_volume->SetVisAttributes(stave_curve_vis);
+	  stave_curve_ext_volume->SetVisAttributes(stave_curve_vis);
+	  stave_straight_cooler_volume->SetVisAttributes(stave_curve_vis);
+	  stave_straight_cooler_ext_volume->SetVisAttributes(stave_curve_vis);
+	  stave_straight_inner_volume->SetVisAttributes(stave_curve_vis);
+	  stave_straight_inner_ext_volume->SetVisAttributes(stave_curve_vis);
+	  stave_straight_outer_volume->SetVisAttributes(stave_curve_vis);
+	  stave_straight_outer_ext_volume->SetVisAttributes(stave_curve_vis);
+
+	  // Now we combine the elements of a stave defined above into a stave
+	  // Create a stave volume to install the stave sections into. The volume has to be big enouigh to contain the cooling tube
+	  double cooler_gap_x = 0.2;  // id of cooling tube in cm
+	  double cooler_wall = 0.03;   // outer wall thickness of cooling tube 
+	  double cooler_x = cooler_gap_x + cooler_wall; 
+	  const double stave_x = cooler_x;  // we do not include the PGS in the stave volume
+	  const double stave_y = hdi_y;
+	  G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % sphxlayer % itype).c_str(), stave_x / 2., stave_y / 2., stave_z / 2.);
+	  G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_Air"), 
+							      boost::str(boost::format("stave_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
+	    {
+	      absorberlogvols.insert(stave_volume);
+	    }
+	  G4VSolid *staveext_box = new G4Box(boost::str(boost::format("staveext_box_%d_%s") % sphxlayer % itype).c_str(), stave_x / 2., stave_y / 2., hdiext_z / 2.);
+	  G4LogicalVolume *staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_Air"), 
+								 boost::str(boost::format("staveext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
+	    {
+	      absorberlogvols.insert(staveext_volume);
+	    }
+
+	  // Assemble the elements into the stave volume and the stave extension volume
+	  if(laddertype == 0)
+	    {
+	      // only one cooling tube in laddertype 0
+	      // Place the straight sections. We add the middle, then above x axis, then below x axis
+	      double x_off_str[3] = {Rcavge, (Rcmax - Rcmin) / 2., (Rcmax - Rcmin) / 2.};
+	      double y_off_str[3] = 
+		{
+		  // Rcavge*TMath::Sin(dphic / 2.) is half the width of a curved section in y
+		  0.0,
+		  stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ) + 2.0 * Rcavge*TMath::Sin(dphic / 2.) + stave_straight_outer_y / 2.0,
+		  -stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ) - 2.0 * Rcavge*TMath::Sin(dphic / 2.) - stave_straight_outer_y / 2.0	  
+		};
+
+   	      for(int i=0;i<3;i++)
+		{	  	  
+		  if(i==0)
+		    {
+		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume, 
+					boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume, 
+					boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+		    }
+		  else
+		    {
+		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume, 
+					boost::str(boost::format("stave_straight_outer_%d_%d_%d") % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume, 
+					boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+		    }
+		}
+	      // The cooler curved sections are made using 2 curved sections in a recurve on each side of the cooler straight section 
+	      double frot[4] = {-TMath::Pi()/2., -TMath::Pi()/2.,  TMath::Pi() / 2. + dphic, TMath::Pi()/2.};
+	      double x_off_cooler[4] = 
+		{
+		  Rcavge*TMath::Cos(dphic / 2.), 
+		  Rcavge*TMath::Cos(dphic / 2.), 
+		  Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
+		  Rcavge - Rcavge*TMath::Cos(dphic / 2.) 
+		};
+	      double y_off_cooler[4] = 
+		{
+		  stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ),  
+		  - stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ), 
+		  stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ) + 2.0 * Rcavge*TMath::Sin(dphic / 2.),  
+		  - stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ) - 2.0 * Rcavge*TMath::Sin(dphic / 2.)
+		};
+	      
+	      for(int icurve=0;icurve<4;icurve++)
+		{
+		  G4RotationMatrix *rot = new G4RotationMatrix();
+		  rot->rotateZ(frot[icurve]);
+		  new G4PVPlacement(rot, G4ThreeVector(x_off_cooler[icurve], y_off_cooler[icurve], 0.0), stave_curve_volume, 
+				    boost::str(boost::format("stave_curve_%d_%d_%d") % icurve % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+		  new G4PVPlacement(rot, G4ThreeVector(x_off_cooler[icurve], y_off_cooler[icurve], 0.0), stave_curve_ext_volume, 
+				    boost::str(boost::format("stave_curve_ext_%d_%d_%s") % icurve % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+		}
+	    }
+	  else
+	    {
+	      // The type 1 ladder has two cooling tubes
+	      // Place the straight sections, do the extension at the same time
+	      // we alternate  positive and negative y values here
+	      double x_off_str[5] = 
+		{
+		  (Rcmax-Rcmin) / 2., // against the PGS
+		  (Rcmax+Rcmin) / 2.,   // top of cooler
+		  (Rcmax+Rcmin) / 2.,   // top of cooler
+		  (Rcmax-Rcmin) / 2., 
+		  (Rcmax-Rcmin) / 2.
+		};
+	      double y_off_str[5] = 
+		{
+		  0.0,
+		  stave_straight_inner_y/2. + 2. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y/2.,  // top of cooler
+		  - stave_straight_inner_y/2. - 2. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y/2.,  // top of cooler
+		  stave_straight_inner_y/2. + 2. * Rcavge*TMath::Sin( dphic / 2.) + stave_straight_cooler_y + 2. *  Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_outer_y/2.,
+		  - stave_straight_inner_y/2. - 2. * Rcavge*TMath::Sin( dphic / 2.) - stave_straight_cooler_y - 2. *  Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_outer_y/2.,
+		};
+	      
+	      for(int i=0;i<5;i++)
+		{
+		  if(i==0)
+		    {
+		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_volume, 
+					boost::str(boost::format("stave_straight_inner_%d_%d_%d") % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_ext_volume, 
+					boost::str(boost::format("stave_straight_inner_ext_%d_%d_%s") % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+		    }
+		  else if(i==1 || i==2)
+		    {
+		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume, 
+					boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume, 
+					boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+		    }
+		  else
+		    {
+		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume, 
+					boost::str(boost::format("stave_straight_outer_%d_%d_%d") % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume, 
+					boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+		    }
+		}
 	  
-	  for(int i=0;i<3;i++)
-	    {	  	  
-	      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_ends[i], 0.0), stave_volume, boost::str(boost::format("stave_straight_%d_%d_%d") 
-													     % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
-	      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_ends[i], 0.0), staveext_volume, boost::str(boost::format("stave_straight_ext_%d_%d_%s") 
-														% i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
-	    }
-
-	  // The cooler curved sections
-	  double frot[4] = {-TMath::PI/2., -TMath::PI/2.,  TMath::PI / 2. + dphic, TMath::PI/2.};
-	  double x_off_cooler[4] = {
-	    Rcavge*TMath::Cos(dphic / 2.), 
-	    Rcavge*TMath::Cos(dphic / 2.), 
-	    Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
-	    Rcavge - Rcavge*TMath::Cos(dphic / 2.) 
-	  };
-	  double y_off_cooler[4] = {
-	    stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ),  
-	    - stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ), 
-	    stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ) + 2.0 * Rcavge*TMath::Sin(dphic / 2.),  
-	    - stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ) - 2.0 * Rcavge*TMath::Sin(dphic / 2.)
-	  };
-
-	  for(int icurve=0;icurve<4;icurve++)
-	    {
-	      G4RotationMatrix *rot = new G4RotationMatrix();
-	      rot->rotateZ(frot[i]);
-	      new G4PVPlacement(rot, G4ThreeVector(x_off_cooler[icurve], y_off_cooler[icurve], 0.0), stave_volume, boost::str(boost::format("stave_curve_%d_%d_%d") 
-															      % icurve % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
-	      new G4PVPlacement(rot, G4ThreeVector(x_off_cooler[icurve], y_off_cooler[icurve], 0.0), staveext_volume, boost::str(boost::format("stave_curve_ext_%d_%d_%s")
-																 % icurve % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
-	    }
-	}
-      else
-	{
-	  // The type 1 ladder has two cooling tubes
-	  // Place the straight sections
-	  // alternating above and below x axis
-	  double x_off_str[5] = {
-	    (Rcmax-Rcmin) / 2., 
-	    (Rcmax+Rcmin) / 2.,   // top of cooler
-	    (Rcmax+Rcmin) / 2.,   // top of cooler
-	    (Rcmax-Rcmin) / 2., 
-	    (Rcmax-Rcmin) / 2.
-	  };
-	  double y_off_str[5] = {
-	    0.0,
-	    stave_straight_inner_y/2. + 2. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y/2.,  // top of cooler
-	    - stave_straight_inner_y/2. - 2. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y/2.,  // top of cooler
-	    stave_straight_inner_y/2. + 2. * Rcavge*TMath::Sin( dphic / 2.) + stave_straight_cooler_y/2. + 2. *  Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_end_y/2.,
-	    - stave_straight_inner_y/2. - 2. * Rcavge*TMath::Sin( dphic / 2.) - stave_straight_cooler_y/2. - 2. *  Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_end_y/2.,
-	  };
-
-	  for(int i=0;i<5;i++)
-	    {
-	      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_volume, boost::str(boost::format("stave_straight_%d_%d_%d") 
-													    % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
-	      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), staveext_volume, boost::str(boost::format("stave_straight_ext_%d_%d_%s") 
-													       % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
-	    }
+	      // Place the curved sections
+	      // hre we do all above the x axis, then all below the x axis, each in order of increasing y
+	      double frot[8] = 
+		{
+		  TMath::Pi()/2., 
+		  -TMath::Pi()/2.,  
+		  - TMath::Pi()/2. + dphic, 
+		  TMath::Pi(),
+		  TMath::Pi()/2., 
+		  -TMath::Pi()/2.,  
+		  - TMath::Pi()/2. + dphic, 
+		  TMath::Pi()
+		};
+	      double x_off_curve[8] = 
+		{
+		  Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
+		  Rcavge*TMath::Cos(dphic / 2.), 
+		  Rcavge*TMath::Cos(dphic / 2.), 
+		  Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
+		  Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
+		  Rcavge*TMath::Cos(dphic / 2.), 
+		  Rcavge*TMath::Cos(dphic / 2.), 
+		  Rcavge - Rcavge*TMath::Cos(dphic / 2.) 
+		};
+	      double y_off_curve[8] = 
+		{
+		  stave_straight_inner_y / 2. + Rcavge*TMath::Sin( dphic / 2.),  
+		  stave_straight_inner_y / 2. + 2. * Rcavge*TMath::Sin( dphic / 2. ) + Rcavge*TMath::Sin(dphic / 2.),  
+		  stave_straight_inner_y / 2. + 4. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y + Rcavge*TMath::Sin(dphic / 2.),  
+		  stave_straight_inner_y / 2. + 6. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y + Rcavge*TMath::Sin(dphic / 2.),  
+		  - stave_straight_inner_y / 2. - 6. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y - Rcavge*TMath::Sin(dphic / 2.),  
+		  - stave_straight_inner_y / 2. - 4. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y - Rcavge*TMath::Sin(dphic / 2.),  
+		  - stave_straight_inner_y / 2. - 2. * Rcavge*TMath::Sin( dphic / 2. ) - Rcavge*TMath::Sin(dphic / 2.),  
+		  - stave_straight_inner_y / 2. - Rcavge*TMath::Sin( dphic / 2.)  
+		};
 	  
-	  // Place the curved sections
-	  // all above x axis, then all below x axis, each in order of increasing y
-	  double frot[8] = {
-	    +TMath::PI/2., 
-	    -TMath::PI/2.,  
-	    - TMath::PI/2. + dphic, 
-	    TMath::PI.
-	    +TMath::PI/2., 
-	    -TMath::PI/2.,  
-	    - TMath::PI/2. + dphic, 
-	    TMath::PI.
-	  };
-	  double x_off_curve[8] = {
-	    Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
-	    Rcavge*TMath::Cos(dphic / 2.), 
-	    Rcavge*TMath::Cos(dphic / 2.), 
-	    Rcavge - Rcavge*TMath::Cos(dphic / 2.) 
-	    Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
-	    Rcavge*TMath::Cos(dphic / 2.), 
-	    Rcavge*TMath::Cos(dphic / 2.), 
-	    Rcavge - Rcavge*TMath::Cos(dphic / 2.) 
-	  };
-	  double y_off_curve[8] = {
-	    stave_straight_inner_y / 2. + Rcavge*TMath::Sin( dphic / 2.),  
-	    stave_straight_inner_y / 2. + 2. * Rcavge*TMath::Sin( dphic / 2. ) + Rcavge*TMath::Sin(dphic / 2.),  
-	    stave_straight_inner_y / 2. + 4. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y + Rcavge*TMath::Sin(dphic / 2.),  
-	    stave_straight_inner_y / 2. + 6. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y + Rcavge*TMath::Sin(dphic / 2.),  
-	    - stave_straight_inner_y / 2. - 6. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y - Rcavge*TMath::Sin(dphic / 2.),  
-	    - stave_straight_inner_y / 2. - 4. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y - Rcavge*TMath::Sin(dphic / 2.),  
-	    - stave_straight_inner_y / 2. - 2. * Rcavge*TMath::Sin( dphic / 2. ) - Rcavge*TMath::Sin(dphic / 2.),  
-	    - stave_straight_inner_y / 2. - Rcavge*TMath::Sin( dphic / 2.),  
-	  };
-
-	  for(int i=0;i<8;i++)
-	    {
-	      new G4PVPlacement(frot[i], G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_volume, boost::str(boost::format("stave_curve_%d_%d_%d") 
-														      % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
-	      new G4PVPlacement(frot[i], G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), staveext_volume, boost::str(boost::format("stave_curve_ext_%d_%d_%s") 
-														     % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+	      for(int i=0;i<8;i++)
+		{
+		  G4RotationMatrix *rot = new G4RotationMatrix();
+		  rot->rotateZ(frot[i]);
+		  new G4PVPlacement(rot, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_volume, boost::str(boost::format("stave_curve_%d_%d_%d") 
+															  % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+		  new G4PVPlacement(rot, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_curve_ext_volume, boost::str(boost::format("stave_curve_ext_%d_%d_%s") 
+															 % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+		}
 	    }
-	}
       
 
-      // ----- Step 2 ------------------------------------------------------------------------------------
-      // We place Si-sensor, FPHX, HDI, PGS sheet, and stave in the ladder  volume.
-      // ======================================================
+	  // ----- Step 2 ------------------------------------------------------------------------------------
+	  // We place Si-sensor, FPHX, HDI, PGS sheet, and stave in the ladder  volume.
+	  // ======================================================
 
-      // Make the ladder volume first
-        
-      const double ladder_x = stave_x  + pgs_x  + hdi_x  + fphx_x;
-      const double ladder_y = hdi_y;
-      const double ladder_z = hdi_z;
-      G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., ladder_z / 2.);
-      G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-      if ((IsAbsorberActive.find(inttlayer))->second > 0)
-      {
-        absorberlogvols.insert(ladder_volume);
-      }
-      G4VSolid *ladderext_box = new G4Box(boost::str(boost::format("ladderext_box_%d_%s") % sphxlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., hdiext_z / 2.);
-      G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladderext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
-      if ((IsAbsorberActive.find(inttlayer))->second > 0)
-      {
-        absorberlogvols.insert(ladderext_volume);
-      }
-      G4VisAttributes *ladder_vis = new G4VisAttributes();
-      ladder_vis->SetVisibility(true);
-      ladder_vis->SetForceSolid(true);
-      ladder_vis->SetColour(G4Colour::Cyan());
-      ladder_volume->SetVisAttributes(ladder_vis);
+	  // Make the ladder volume first
+	  // We are still in the loop over inner or outer sensors. This is the ladder volume corresponding to this sensor. The FPHX is taller than the sensor in x.
+	  const double ladder_x = stave_x  + pgs_x  + hdi_x  + fphx_x;
+	  const double ladder_y = hdi_y;
+	  const double ladder_z = hdi_z;
+	  G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., ladder_z / 2.);
+	  G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
+	    {
+	      absorberlogvols.insert(ladder_volume);
+	    }
+	  G4VSolid *ladderext_box = new G4Box(boost::str(boost::format("ladderext_box_%d_%s") % sphxlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., hdiext_z / 2.);
+	  G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladderext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
+	    {
+	      absorberlogvols.insert(ladderext_volume);
+	    }
+	  G4VisAttributes *ladder_vis = new G4VisAttributes();
+	  ladder_vis->SetVisibility(true);
+	  ladder_vis->SetForceSolid(true);
+	  ladder_vis->SetColour(G4Colour::Cyan());
+	  ladder_volume->SetVisAttributes(ladder_vis);
+	  ladderext_volume->SetVisAttributes(ladder_vis);
 
-      // Now add the components of the ladder
-      // start from where?
+	  // Now add the components of the ladder to the ladder volume
+	  // The sensor is closest to the beam pipe, the stave cooler is furthest away
+	  // Note that the cooler has been assembled in the stave volume with the top at larger x, so the sensor will be at smaller x
+	  // That will be the configuration when the ladder is at phi = 180 degrees, the positive x direction
+	  // So we start at the most positive x value and add the stave first
 
-      // Carbon stave        
-      const double TVstave_x = -ladder_x / 2. + stave_x / 2.;
-      new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), stave_volume, boost::str(boost::format("stave_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-      new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), staveext_volume, boost::str(boost::format("staveext_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
+	  // Carbon stave        
+	  const double TVstave_x = ladder_x / 2. - stave_x / 2.;
+	  new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), stave_volume, boost::str(boost::format("stave_%d_%d") % sphxlayer % itype).c_str(), 
+			    ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), staveext_volume, boost::str(boost::format("staveext_%d_%s") % sphxlayer % itype).c_str(), 
+			    ladderext_volume, false, 0, OverlapCheck());
 
-      // PGS
-        
-      const double TVpgs_x = TVstave_x + stave_x / 2. + pgs_x / 2.;
-      new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgs_volume, boost::str(boost::format("pgs_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-      new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgsext_volume, boost::str(boost::format("pgsext_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
+	  // PGS
+	  const double TVpgs_x = TVstave_x - stave_x / 2. - pgs_x / 2.;
+	  new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgs_volume, boost::str(boost::format("pgs_%d_%d") % sphxlayer % itype).c_str(), 
+			    ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgsext_volume, boost::str(boost::format("pgsext_%d_%s") % sphxlayer % itype).c_str(), 
+			    ladderext_volume, false, 0, OverlapCheck());
 
-      // HDI
-        
-      const double TVhdi_x = TVpgs_x + pgs_x / 2. + hdi_x / 2.;
-      new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdi_volume, boost::str(boost::format("hdi_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-      new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdiext_volume, boost::str(boost::format("hdiext_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
+	  // HDI        
+	  const double TVhdi_x = TVpgs_x - pgs_x / 2. - hdi_x / 2.;
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdi_volume, boost::str(boost::format("hdi_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdiext_volume, boost::str(boost::format("hdiext_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
-      // Si-sensor
-        
-      const double TVSi_x = TVhdi_x + hdi_x / 2. + siactive_x / 2.;
-      new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siinactive_volume, boost::str(boost::format("siinactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-      new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siactive_volume, boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  // Si-sensor        
+	  const double TVSi_x = TVhdi_x - hdi_x / 2. - siactive_x / 2.;
+	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siinactive_volume, boost::str(boost::format("siinactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siactive_volume, boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
-      // FPHX
-        
-      const double TVfphx_x = TVhdi_x + hdi_x / 2. + fphx_x / 2.;
-      const double TVfphx_y = sifull_y + gap_sensor_fphx + fphx_y / 2.;
-      new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-      new G4PVPlacement(0, G4ThreeVector(TVfphx_x, -TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerm_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  // FPHX        
+	  const double TVfphx_x = TVhdi_x - hdi_x / 2. - fphx_x / 2.;
+	  const double TVfphx_y = sifull_y + gap_sensor_fphx + fphx_y / 2.;
+	  new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVfphx_x, -TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerm_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
-      // ----- Step 3 ----------------------------------------------------------------------------------
-      // We make a cylinder volume in each layer and then install the silicon ladders
-      //======================================================
+	  // ----- Step 3 --------------------------------------------------------------------------------------------------------------------
+	  // We install the section of ladder for this sensor at all requested phi values and at positive and negative Z
+	  //========================================================================
 
-      // Distribute Ladders in phi
-      // The ladders have no tilt in the new design,  the ladders are alternately offset in radius to get overlap in phi        
+	  // Distribute Ladders in phi
+	  // We are still in the loops over layer and sensor type, we will place copies of the ladder section for this sensor
+	  //  at all ladder phi values, and at both positive and negative Z values.
 
-      // radius values are for the center of the sensor, we need the offset from center of ladder to center of sensor
-      double sensor_offset = 0.0 - TVSi_x; // ladder center is at 0.0 by construction
+	  // The ladders have no tilt in the new design, they are alternately offset in radius to get overlap in phi        
+	  // radius values are for the center of the sensor, we need the offset from center of ladder to center of sensor
+	  double sensor_offset = 0.0 - TVSi_x; // ladder center is at 0.0 by construction
 
-      const double dphi = 2 * M_PI / nladders_layer;
+	  const double dphi = 2 * TMath::Pi() / nladders_layer;
 
-      // need to fix this - there is no single radius for a layer!
-      // problem is what to write to geom object
-      //eff_radius[ilayer] = radius + ladder_x - 2. * (fphx_x / 2. - strip_x / 2.);
-      posz[ilayer][itype] = (itype == 0) ? hdi_z : 2. * hdi_z_[ilayer][0] + hdi_z;
-      strip_x_offset[ilayer] = ladder_x - 2. * (fphx_x / 2. - strip_x / 2.) - strip_x / 2.;
+	  // there is no single radius for a layer
+	  eff_radius[ilayer] = layer_radius_inner + sensor_offset;
+	  eff_radius_alternate[ilayer] = layer_radius_outer + sensor_offset;
+	  posz[ilayer][itype] = (itype == 0) ? hdi_z : hdi_z_[ilayer][0] + hdi_z;
+	  strip_x_offset[ilayer] = sensor_offset;
 
-      for (G4int icopy = 0; icopy < nladders_layer; icopy++)
-      {
-        const double phi = offsetphi + dphi * (double) icopy;
-	double radius = layer_radius_inner;
-	if(icopy%2)
-	  radius = layer_radius_outer;
-	radius += sensor_offset;
-        const double posx = radius * cos(phi);
-        const double posy = radius * sin(phi);
-        const double fRotate = phi + offsetrot + M_PI;   // starts with a rotation of 180 deg 
+	  for (G4int icopy = 0; icopy < nladders_layer; icopy++)
+	    {
+	      const double phi = offsetphi + dphi * (double) icopy;  // offsetphi is zero by default, so we start at zero
+	      double radius = eff_radius[ilayer];
+	      if(icopy%2)
+		radius = eff_radius_alternate[ilayer];  // every odd numbered copy is placed at the larger radius
+	      const double posx = radius * cos(phi);
+	      const double posy = radius * sin(phi);
+	      const double fRotate = phi + offsetrot; // no initial rotation, since we assembled the ladder in phi = 0 orientation 
 
-        G4RotationMatrix *ladderrotation = new G4RotationMatrix();
-        ladderrotation->rotateZ(-fRotate);
+	      G4RotationMatrix *ladderrotation = new G4RotationMatrix();
+	      ladderrotation->rotateZ(-fRotate);
 
-        int sitype[2] = {-1};
-        if (itype == 0)
-        {
-          sitype[0] = 1;
-          sitype[1] = 2;
-        }
-        else
-        {
-          sitype[0] = 0;
-          sitype[1] = 3;
-        }
+	      // place the copy at its ladder phi value, and at positive and negative Z
+	      new G4PVPlacement(ladderrotation, G4ThreeVector(posx, posy, -posz[ilayer][itype]), ladder_volume, boost::str(boost::format("ladder_%d_%d_%d_%d") 
+															   % sphxlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+	      new G4PVPlacement(ladderrotation, G4ThreeVector(posx, posy, +posz[ilayer][itype]), ladder_volume, boost::str(boost::format("ladder_%d_%d_%d_%d") 
+															   % sphxlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+	
+	      if (itype != 0)
+		{  
+		  // The HDI extension tab has to be added for the outer sensor
+		  const G4double posz_ext = 2. * (hdi_z_[ilayer][0] + hdi_z) + hdiext_z;
+		  new G4PVPlacement(ladderrotation, G4ThreeVector(posx, posy, -posz_ext), ladderext_volume, boost::str(boost::format("ladderext_%d_%d_%d_%d") 
+														       % sphxlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+		  new G4PVPlacement(ladderrotation, G4ThreeVector(posx, posy, +posz_ext), ladderext_volume, boost::str(boost::format("ladderext_%d_%d_%d_%d") 
+														       % sphxlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+		  cout <<"            posz_ext " << posz_ext << endl;
+		}
 
-        new G4PVPlacement(ladderrotation, G4ThreeVector(posx, posy, -posz[ilayer][itype]), ladder_volume, boost::str(boost::format("ladder_%d_%d_%d_%d") % sphxlayer % inttlayer % sitype[0] % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
-        new G4PVPlacement(ladderrotation, G4ThreeVector(posx, posy, +posz[ilayer][itype]), ladder_volume, boost::str(boost::format("ladder_%d_%d_%d_%d") % sphxlayer % inttlayer % sitype[1] % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+	      cout << "Ladder copy " << icopy << " radius " << radius << " phi " << phi << " itype " << itype << " posz " << posz[ilayer][itype] 
+		   << " fRotate " << fRotate << " posx " << posx << " posy " << posy << " sensor_offset " << sensor_offset 
+		   << endl;
 
-        if (itype != 0)
-        {  // HDI tab
-          const G4double posz_ext = 2. * (hdi_z_[ilayer][0] + hdi_z) + hdiext_z;
-          new G4PVPlacement(ladderrotation, G4ThreeVector(posx, posy, -posz_ext), ladderext_volume, boost::str(boost::format("ladderext_%d_%d_%d_%d") % sphxlayer % inttlayer % sitype[0] % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
-          new G4PVPlacement(ladderrotation, G4ThreeVector(posx, posy, +posz_ext), ladderext_volume, boost::str(boost::format("ladderext_%d_%d_%d_%d") % sphxlayer % inttlayer % sitype[1] % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
-        }
-      }
-    }
-  }
-
+	    } // end loop over ladder copy placement in phi and positive and negative Z
+	} // end loop over inner or outer sensor
+    } // end loop over layers
+  
   return 0;
 }
 
@@ -699,6 +785,7 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
           posz[ilayer][0] / cm,
           posz[ilayer][1] / cm,
           eff_radius[ilayer] / cm,
+          eff_radius_alternate[ilayer] / cm,
           strip_x_offset[ilayer] / cm,
           params->get_double_param("offsetphi") * deg / rad,
           params->get_double_param("offsetrot") * deg / rad);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -114,6 +114,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       double layer_radius_inner = params1->get_double_param("ladder_radius_inner");
       double layer_radius_outer = params1->get_double_param("ladder_radius_outer");
       const int nladders_layer = params1->get_int_param("nladder");
+      cout << " Start on INTT layer " << ilayer << " laddertype " << laddertype << " layer radii " << layer_radius_inner << "   " << layer_radius_outer << endl; 
 
       // Look up all remaining parameters by the laddertype for this layer
       const PHParameters *params = paramscontainer->GetParameters(laddertype);
@@ -124,7 +125,8 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       const G4double offsetrot = params->get_double_param("offsetrot");
       const G4double sensor_offset_y = params->get_double_param("sensor_offset_y");
       const G4double hdi_y = params->get_double_param("hdi_y");
-      double hdi_x = params->get_double_param("hdi_x");
+      double hdi_kapton_x = params->get_double_param("hdi_kapton_x");
+      double hdi_copper_x = params->get_double_param("hdi_copper_x");
       double fphx_x = params->get_double_param("fphx_x");
       double fphx_y = params->get_double_param("fphx_y");
       double fphx_z = params->get_double_param("fphx_z");
@@ -225,35 +227,53 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  siinactive_vis->SetColour(G4Colour::Red());
 	  siinactive_volume->SetVisAttributes(siinactive_vis);
       
-	  // Make the HDI volume
-	  // This makes a HDI volume that matches this sensor in Z length
+	  // Make the HDI Kapton and copper volumes
+
+	  // This makes HDI volumes that matche this sensor in Z length
 	  const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z");  
 	  hdi_z_[ilayer][itype] = hdi_z;
-	  cout << "make hdi volume with hdi_z " << hdi_z << endl;	  
-	  G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdi_z/2.0);
-	  G4LogicalVolume *hdi_volume = new G4LogicalVolume(hdi_box, G4Material::GetMaterial("FPC"), 
-							    boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  cout << "make hdi Polymide volume with hid_z " << hdi_z << " hdi_kapton_x " << hdi_kapton_x << endl;	  
+	  G4VSolid *hdi_kapton_box = new G4Box(boost::str(boost::format("hdi_kapton_box_%d_%d") % sphxlayer % itype).c_str(), hdi_kapton_x / 2., hdi_y / 2., hdi_z/2.0);
+	  G4LogicalVolume *hdi_kapton_volume = new G4LogicalVolume(hdi_kapton_box, G4Material::GetMaterial("FPC"), 
+							    boost::str(boost::format("hdi_kapton_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  cout << "make hdi copper volume with hdi_copper_x " << hdi_copper_x << endl;	  
+	  G4VSolid *hdi_copper_box = new G4Box(boost::str(boost::format("hdi_copper_box_%d_%d") % sphxlayer % itype).c_str(), hdi_copper_x / 2., hdi_y / 2., hdi_z/2.0);
+	  G4LogicalVolume *hdi_copper_volume = new G4LogicalVolume(hdi_copper_box, G4Material::GetMaterial("G4_Cu"), 
+							    boost::str(boost::format("hdi_copper_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
-	      absorberlogvols.insert(hdi_volume);
+	      absorberlogvols.insert(hdi_kapton_volume);
+	      absorberlogvols.insert(hdi_copper_volume);
 	    }
 
 	  // This is the part of the HDI that extends beyond the sensor
 	  const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z  - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
-	  cout << "make hdiext volume" << endl;	  
-	  G4VSolid *hdiext_box = new G4Box(boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdiext_z / 2.0);
-	  G4LogicalVolume *hdiext_volume = new G4LogicalVolume(hdiext_box, G4Material::GetMaterial("FPC"), 
-							       boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  cout << "make hdiext volume with hdiext_z " << hdiext_z << endl;	  
+	  G4VSolid *hdiext_kapton_box = new G4Box(boost::str(boost::format("hdiext_kapton_box_%d_%s") % sphxlayer % itype).c_str(), 
+						  hdi_kapton_x / 2., hdi_y / 2., hdiext_z / 2.0);
+	  G4LogicalVolume *hdiext_kapton_volume = new G4LogicalVolume(hdiext_kapton_box, G4Material::GetMaterial("FPC"), 
+							       boost::str(boost::format("hdiext_kapton_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *hdiext_copper_box = new G4Box(boost::str(boost::format("hdiext_copper_box_%d_%s") % sphxlayer % itype).c_str(), 
+						  hdi_copper_x / 2., hdi_y / 2., hdiext_z / 2.0);
+	  G4LogicalVolume *hdiext_copper_volume = new G4LogicalVolume(hdiext_copper_box, G4Material::GetMaterial("G4_Cu"), 
+							       boost::str(boost::format("hdiext_copper_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
-	      absorberlogvols.insert(hdiext_volume);
+	      absorberlogvols.insert(hdiext_kapton_volume);
+	      absorberlogvols.insert(hdiext_copper_volume);
 	    }
-	  G4VisAttributes *hdi_vis = new G4VisAttributes();
-	  hdi_vis->SetVisibility(true);
-	  hdi_vis->SetForceSolid(true);
-	  hdi_vis->SetColour(G4Colour::Yellow());
-	  hdi_volume->SetVisAttributes(hdi_vis);
-	  hdiext_volume->SetVisAttributes(hdi_vis);
+	  G4VisAttributes *hdi_kapton_vis = new G4VisAttributes();
+	  hdi_kapton_vis->SetVisibility(true);
+	  hdi_kapton_vis->SetForceSolid(true);
+	  hdi_kapton_vis->SetColour(G4Colour::Yellow());
+	  hdi_kapton_volume->SetVisAttributes(hdi_kapton_vis);
+	  hdiext_kapton_volume->SetVisAttributes(hdi_kapton_vis);
+	  G4VisAttributes *hdi_copper_vis = new G4VisAttributes();
+	  hdi_copper_vis->SetVisibility(true);
+	  hdi_copper_vis->SetForceSolid(true);
+	  hdi_copper_vis->SetColour(G4Colour::White());
+	  hdi_copper_volume->SetVisAttributes(hdi_copper_vis);
+	  hdiext_copper_volume->SetVisAttributes(hdi_copper_vis);
 
 	  // FPHX
 	  cout << "make fphx volume" << endl;	          
@@ -274,9 +294,6 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       
 	  //  FPHX Container
 	  // make a container for the FPHX chips needed for this sensor, and  then place them in the container
-	  //const double fphxcontainer_x = fphx_x / 2.;
-	  //const double fphxcontainer_y = fphx_y / 2.;
-	  //const double fphxcontainer_z = hdi_z / 2.0;
 	  cout << "make fphx container volume with x " << fphx_x  << " y " << fphx_y << " hdi_z " << hdi_z  << endl;	  
 	  G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % sphxlayer % itype).c_str(), 
 						  fphx_x / 2., fphx_y / 2., hdi_z / 2.);
@@ -432,13 +449,6 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  stave_vis->SetVisibility(true);
 	  stave_vis->SetForceSolid(true);
 	  stave_vis->SetColour(G4Colour::White());
-	  /*	
-		for(int i=0;i<4;i++)
-		{
-		stave_curve_volume[i]->SetVisAttributes(stave_vis);
-		stave_curve_ext_volume[i]->SetVisAttributes(stave_vis);
-		}
-	  */
 	  stave_straight_cooler_volume->SetVisAttributes(stave_vis);
 	  stave_straight_cooler_ext_volume->SetVisAttributes(stave_vis);
 	  if(laddertype == 1) stave_straight_inner_volume->SetVisAttributes(stave_vis);
@@ -475,7 +485,6 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  G4VisAttributes *stave_box_vis = new G4VisAttributes();
 	  stave_box_vis->SetVisibility(false);
 	  stave_box_vis->SetForceSolid(false);
-	  stave_box_vis->SetColour(G4Colour::White());
 	  stave_volume->SetVisAttributes(stave_box_vis);
 	  staveext_volume->SetVisAttributes(stave_box_vis);
 	  
@@ -518,9 +527,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 		    }
 		}
 	      // The cooler curved sections are made using 2 curved sections in a recurve on each side of the cooler straight section 
-	      // The tube sections used here have the origin of their volumr at their center of rotation. Rcavge
-	      // Each curve section is moved to the center of the stave volume by a translation of +/- Rcavge
-	      // Then it is moved to the outside or the inside of the stave volume by a translation of +/-  cooler_gap_x / 2.
+	      // The tube sections used here have the origin of their volume at their center of rotation. Rcavge
+	      //      Each curve section is moved to the center of the stave volume by a translation of +/- Rcavge
+	      //      Then it is moved to the outside or the inside of the stave volume by a translation of +/-  cooler_gap_x / 2.
 	      // we start at lowest y and work up in y
 
 	      double x_off_cooler[4] = 
@@ -650,11 +659,11 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
 	  // Make the ladder volume first
 	  // We are still in the loop over inner or outer sensors. This is the ladder volume corresponding to this sensor. The FPHX is taller than the sensor in x.
-	  const double ladder_x = stave_x  + pgs_x  + hdi_x  + fphx_x;
+	  const double ladder_x = stave_x  + pgs_x  + hdi_kapton_x  + hdi_copper_x + fphx_x;
 	  const double ladder_y = hdi_y;
 	  const double ladder_z = hdi_z;
 	  cout << " sphxlayer " << sphxlayer << " laddertype " << laddertype << " itype " << itype << " stave_x " << stave_x << " pgs_x " 
-	       << pgs_x << " hdi_x " << hdi_x << " fphx_x " << fphx_x << endl;
+	       << pgs_x << " hdi_kapton_x " << hdi_kapton_x << " hdi_copper_x " << hdi_copper_x << " fphx_x " << fphx_x << endl;
 	  cout << "Create ladder volume with ladder_x " << ladder_x  <<  " ladder_y " << ladder_y << " ladder_z " << ladder_z << endl;
 	  G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., ladder_z / 2.);
 	  G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_%d_%d_%d") % sphxlayer % inttlayer % itype).c_str(), 0, 0, 0);
@@ -672,7 +681,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	    }
 
 	  G4VisAttributes *ladder_vis = new G4VisAttributes();
-	  ladder_vis->SetVisibility(true);
+	  ladder_vis->SetVisibility(false);
 	  ladder_vis->SetForceSolid(false);
 	  ladder_vis->SetColour(G4Colour::Cyan());
 	  ladder_volume->SetVisAttributes(ladder_vis);
@@ -700,23 +709,29 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgsext_volume, boost::str(boost::format("pgsext_%d_%s") % sphxlayer % itype).c_str(), 
 			    ladderext_volume, false, 0, OverlapCheck());
 
-	  // HDI        
-	  const double TVhdi_x = TVpgs_x - pgs_x / 2. - hdi_x / 2.;
-	  cout << "Place hdi in ladder with TVhdi_x " << TVhdi_x << " y 0 " << " z  0"<< endl;
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdi_volume, boost::str(boost::format("hdi_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdiext_volume, boost::str(boost::format("hdiext_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
+	  // HDI Kapton        
+	  const double TVhdi_kapton_x = TVpgs_x - pgs_x / 2. - hdi_kapton_x / 2.;
+	  cout << "Place hdi Kapton in ladder with TVhdi_kapton_x " << TVhdi_kapton_x << " y 0 " << " z  0"<< endl;
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, 0.0, 0.0), hdi_kapton_volume, boost::str(boost::format("hdi_kapton_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, 0.0, 0.0), hdiext_kapton_volume, boost::str(boost::format("hdiext_kapton_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
+
+	  // HDI copper        
+	  const double TVhdi_copper_x = TVhdi_kapton_x - hdi_kapton_x / 2. - hdi_copper_x / 2.;
+	  cout << "Place hdi Kapton in ladder with TVhdi_copper_x " << TVhdi_copper_x << " y 0 " << " z  0"<< endl;
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, 0.0, 0.0), hdi_copper_volume, boost::str(boost::format("hdi_copper_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, 0.0, 0.0), hdiext_copper_volume, boost::str(boost::format("hdiext_copper_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
 	  // Si-sensor        
-	  const double TVSi_x = TVhdi_x - hdi_x / 2. - siactive_x / 2.;
+	  const double TVSi_x = TVhdi_copper_x - hdi_copper_x / 2. - siactive_x / 2.;
 	  cout << "Place Si sensor in ladder with TVSi_x " << TVSi_x << " y 0 " << " z  0"<< endl;
 	  // laddertype 0 has a sensor offset on the HDI
 	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, sensor_offset_y, 0.0), siinactive_volume, boost::str(boost::format("siinactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, sensor_offset_y, 0.0), siactive_volume, boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
 	  // FPHX        
-	  const double TVfphx_x = TVhdi_x - hdi_x / 2. - fphx_x / 2.;
+	  const double TVfphx_x = TVhdi_copper_x - hdi_copper_x / 2. - fphx_x / 2.;
 	  const double TVfphx_y = sifull_y / 2. + gap_sensor_fphx - sensor_offset_y + fphx_y / 2.;
-	  cout << "Place fphxcontainer in ladder with TVfph_x " << TVfphx_x << " TVfphx_y " << TVfphx_y << " z  0"<< endl;
+	  cout << "Place fphxcontainer in ladder with TVfphx_x " << TVfphx_x << " TVfphx_y " << TVfphx_y << " z  0"<< endl;
 	  // laddertype 0 has only one FPHX, and the sensor is offset in y
 	  if(laddertype == 1)
 	    new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -14,6 +14,7 @@
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Cons.hh>
+#include <Geant4/G4Tubs.hh>
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
@@ -110,31 +111,31 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       // get the parameters for this layer
       const PHParameters *params1 = paramscontainer->GetParameters(inttlayer);
       const int laddertype = params1->get_int_param("laddertype");
-      double layer_radius_inner = params1->get_double_param("ladder_radius_inner") * cm;
-      double layer_radius_outer = params1->get_double_param("ladder_radius_outer") * cm;
+      double layer_radius_inner = params1->get_double_param("ladder_radius_inner");
+      double layer_radius_outer = params1->get_double_param("ladder_radius_outer");
+      const int nladders_layer = params1->get_int_param("nladder");
 
       // Look up all remaining parameters by the laddertype for this layer
       const PHParameters *params = paramscontainer->GetParameters(laddertype);
-      const G4double strip_x = params->get_double_param("strip_x") * cm;
-      const G4double strip_y = params->get_double_param("strip_y") * cm;
+      const G4double strip_x = params->get_double_param("strip_x");
+      const G4double strip_y = params->get_double_param("strip_y");
       const int nstrips_phi_sensor = params->get_int_param("nstrips_phi_sensor");
-      const int nladders_layer = params->get_int_param("nladders");
-      const G4double offsetphi = params->get_double_param("offsetphi") * deg;
-      const G4double offsetrot = params->get_double_param("offsetrot") * deg;
-      const G4double hdi_y = params->get_double_param("hdi_y") * cm;
-      double hdi_x = params->get_double_param("hdi_x") * cm;
-      double fphx_x = params->get_double_param("fphx_x") * cm;
-      double fphx_y = params->get_double_param("fphx_y") * cm;
-      double fphx_z = params->get_double_param("fphx_z") * cm;
-      double pgs_x = params->get_double_param("pgs_x") * cm;
-      double halfladder_z = params->get_double_param("halfladder_z") * cm;
-      double stave_straight_outer_y = params->get_double_param("stave_straight_outer_y") * cm;
-      double stave_straight_inner_y = params->get_double_param("stave_straight_inner_y") * cm;
-      double stave_straight_cooler_y = params->get_double_param("stave_straight_cooler_y") * cm;
+      const G4double offsetphi = params->get_double_param("offsetphi");
+      const G4double offsetrot = params->get_double_param("offsetrot");
+      const G4double sensor_offset_y = params->get_double_param("sensor_offset_y");
+      const G4double hdi_y = params->get_double_param("hdi_y");
+      double hdi_x = params->get_double_param("hdi_x");
+      double fphx_x = params->get_double_param("fphx_x");
+      double fphx_y = params->get_double_param("fphx_y");
+      double fphx_z = params->get_double_param("fphx_z");
+      double pgs_x = params->get_double_param("pgs_x");
+      double halfladder_z = params->get_double_param("halfladder_z");
+      double stave_straight_outer_y = params->get_double_param("stave_straight_outer_y");
+      double stave_straight_inner_y = params->get_double_param("stave_straight_inner_y");
+      double stave_straight_cooler_y = params->get_double_param("stave_straight_cooler_y");
 
-      // We loop over inner, then outer, sensors, where  itype specifies the inner or outer sensor type
-      // The rest of this loop will construct and put in place a section of a ladder corresponding to the 
-      // Z range of this sensor only
+      // We loop over inner, then outer, sensors, where  itype specifies the inner or outer sensor
+      // The rest of this loop will construct and put in place a section of a ladder corresponding to the Z range of this sensor only
       for (int itype = 0; itype < 2; ++itype)
 	{
 	  if (!(itype >= 0 && itype <= 1))
@@ -146,11 +147,11 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  switch (itype)
 	    {
 	    case 0:
-	      strip_z = params->get_double_param("strip_z_0") * cm;
+	      strip_z = params->get_double_param("strip_z_0");
 	      nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_0");
 	      break;
 	    case 1:
-	      strip_z = params->get_double_param("strip_z_1") * cm;
+	      strip_z = params->get_double_param("strip_z_1");
 	      nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_1");
 	      break;
 	    default:
@@ -182,25 +183,34 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  const double siactive_x = strip_x;
 	  const double siactive_y = strip_y * nstrips_phi_sensor; 
 	  const double siactive_z = strip_z * nstrips_z_sensor;  
-      
-	  G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x, siactive_y, siactive_z);
+	  cout << "make siactive volume with siactive_z " << siactive_z << endl;	        
+	  G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x/2, siactive_y/2., siactive_z/2.);
 	  G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), 
 								 boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  G4VisAttributes *siactive_vis = new G4VisAttributes();
+	  siactive_vis->SetVisibility(true);
+	  siactive_vis->SetForceSolid(true);
+	  siactive_vis->SetColour(G4Colour::White());
+	  siactive_volume->SetVisAttributes(siactive_vis);
       
 	  // Now make a G4PVParameterised containing all of the strips in a sensor 
 	  // this works for ladder 0 because there is only one strip type - all cells are identical
+	  cout << "Make parameterised for strips for sphxlayer " << sphxlayer << " itype " << itype << " nstrips_phi_sensor " << nstrips_phi_sensor 
+	       << " nstrips_z_sensor " << nstrips_z_sensor << " strip_y " << strip_y << " strip_z " << strip_z << endl;
 	  G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_sensor, nstrips_z_sensor, strip_y, strip_z);
 	  new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), 
 				strip_volume, siactive_volume, kZAxis, nstrips_phi_sensor * nstrips_z_sensor, stripparam, false);  // overlap check too long.
-      
-      
+     	  cout << "Finished with parameterise for strips" << endl;
+
 	  // Si-sensor full (active+inactive) area
 	  const double sifull_x = siactive_x;
-	  const double sifull_y = siactive_y + 2.0*params->get_double_param("sensor_edge_phi") * cm; 
-	  const double sifull_z = siactive_z + 2.0*params->get_double_param("sensor_edge_z") * cm;    
+	  const double sifull_y = siactive_y + 2.0*params->get_double_param("sensor_edge_phi"); 
+	  const double sifull_z = siactive_z + 2.0*params->get_double_param("sensor_edge_z");    
+	  cout << "sphxlayer " << sphxlayer << " itype " << itype << " make sifull box with sifull_z " << sifull_z << endl;	  
       	  G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % sphxlayer % itype).c_str(), sifull_x / 2., sifull_y/2.0, sifull_z/2.0);
       
 	  // Si-sensor inactive area
+	  cout << "make siinactive volume" << endl;	  
       	  G4VSolid *siinactive_box = new G4SubtractionSolid(boost::str(boost::format("siinactive_box_%d_%d") % sphxlayer % itype).c_str(), 
 							    sifull_box, siactive_box, 0, G4ThreeVector(0, 0, 0));
 	  G4LogicalVolume *siinactive_volume = new G4LogicalVolume(siinactive_box, G4Material::GetMaterial("G4_Si"), 
@@ -212,14 +222,14 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  G4VisAttributes *siinactive_vis = new G4VisAttributes();
 	  siinactive_vis->SetVisibility(true);
 	  siinactive_vis->SetForceSolid(true);
-	  siinactive_vis->SetColour(G4Colour::Gray());
+	  siinactive_vis->SetColour(G4Colour::Red());
 	  siinactive_volume->SetVisAttributes(siinactive_vis);
       
 	  // Make the HDI volume
 	  // This makes a HDI volume that matches this sensor in Z length
-	  const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z") * cm;  
+	  const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z");  
 	  hdi_z_[ilayer][itype] = hdi_z;
-
+	  cout << "make hdi volume with hdi_z " << hdi_z << endl;	  
 	  G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdi_z/2.0);
 	  G4LogicalVolume *hdi_volume = new G4LogicalVolume(hdi_box, G4Material::GetMaterial("FPC"), 
 							    boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
@@ -230,6 +240,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
 	  // This is the part of the HDI that extends beyond the sensor
 	  const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z  - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
+	  cout << "make hdiext volume" << endl;	  
 	  G4VSolid *hdiext_box = new G4Box(boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdiext_z / 2.0);
 	  G4LogicalVolume *hdiext_volume = new G4LogicalVolume(hdiext_box, G4Material::GetMaterial("FPC"), 
 							       boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
@@ -240,12 +251,12 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  G4VisAttributes *hdi_vis = new G4VisAttributes();
 	  hdi_vis->SetVisibility(true);
 	  hdi_vis->SetForceSolid(true);
-	  hdi_vis->SetColour(G4Colour::Magenta());
+	  hdi_vis->SetColour(G4Colour::Yellow());
 	  hdi_volume->SetVisAttributes(hdi_vis);
 	  hdiext_volume->SetVisAttributes(hdi_vis);
 
 	  // FPHX
-        
+	  cout << "make fphx volume" << endl;	          
 	  G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % sphxlayer % itype).c_str(), fphx_x / 2., fphx_y / 2., fphx_z / 2.);
 	  G4LogicalVolume *fphx_volume = new G4LogicalVolume(fphx_box, G4Material::GetMaterial("G4_Si"), 
 							     boost::str(boost::format("fphx_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
@@ -256,19 +267,19 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  G4VisAttributes *fphx_vis = new G4VisAttributes();
 	  fphx_vis->SetVisibility(true);
 	  fphx_vis->SetForceSolid(true);
-	  fphx_vis->SetColour(G4Colour::Gray());
+	  fphx_vis->SetColour(G4Colour::Blue());
 	  fphx_volume->SetVisAttributes(fphx_vis);
 
-	  const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx") * cm;
+	  const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx");
       
 	  //  FPHX Container
 	  // make a container for the FPHX chips needed for this sensor, and  then place them in the container
-	  const double fphxcontainer_x = fphx_x / 2.;
-	  const double fphxcontainer_y = fphx_y / 2.;
-	  const double fphxcontainer_z = hdi_z / 2.0;
-
+	  //const double fphxcontainer_x = fphx_x / 2.;
+	  //const double fphxcontainer_y = fphx_y / 2.;
+	  //const double fphxcontainer_z = hdi_z / 2.0;
+	  cout << "make fphx container volume with x " << fphx_x  << " y " << fphx_y << " hdi_z " << hdi_z  << endl;	  
 	  G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % sphxlayer % itype).c_str(), 
-						  fphxcontainer_x, fphxcontainer_y, fphxcontainer_z);
+						  fphx_x / 2., fphx_y / 2., hdi_z / 2.);
 	  G4LogicalVolume *fphxcontainer_volume = new G4LogicalVolume(fphxcontainer_box, G4Material::GetMaterial("G4_AIR"), 
 								      boost::str(boost::format("fphxcontainer_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
@@ -286,9 +297,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  const double offsety = 0.;
 	  int ncopy;
 	  double offsetz, cell_length_z;
-	  // For layer 0, we have 5 cells per sensor, but the strips are vertical, so we have to treat it specially
-	  if(nstrips_z_sensor == 1)
+
+	  if(laddertype == 0)  // vertical strips
 	    {
+	      // For laddertype 0, we have 5 cells per sensor, but the strips are vertical, so we have to treat it specially
 	      ncopy = nstrips_z_sensor / 128.0;
 	    }
 	  else
@@ -297,16 +309,19 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	    }
 	  cell_length_z = strip_z * nstrips_z_sensor / ncopy;
 	  offsetz = (ncopy % 2 == 0) ? -2. * cell_length_z / 2. * double(ncopy / 2) + cell_length_z / 2. : -2. * cell_length_z / 2. * double(ncopy / 2);
-
-	  G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * strip_z / 2., ncopy);
+	  cout << "make FPHX parameterisation with ncopy " << ncopy << " offsetz " << offsetz << " offsety " << offsety << " cell_length_z " << cell_length_z 
+	       << " nstrips_z_sensor " << nstrips_z_sensor << " nstrips_phi_sensor " << nstrips_phi_sensor 
+	       << endl;	  
+	  G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * cell_length_z / 2., ncopy);
 	  new G4PVParameterised(boost::str(boost::format("fphxcontainer_%d_%d") % sphxlayer % itype).c_str(), 
 				fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, OverlapCheck());
+	  cout << "Finished with FPHX parameterised" << endl;
 
 	  // PGS   - this is the carbon sheet that the HDI sits on. It forms the wall of the cooling tube that cools the HDI
         
 	  const double pgs_y = hdi_y;
 	  const double pgs_z = hdi_z;
-
+	  cout << "make PGS volume" << endl;	  
 	  G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., pgs_z / 2.);
 	  G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("G4_C"), 
 							    boost::str(boost::format("pgs_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
@@ -315,6 +330,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	      absorberlogvols.insert(pgs_volume);
 	    }
 	  // The part that extends beyond this sensor, see above for hdiext
+	  cout << "make pgsext volume" << endl;	  
 	  G4VSolid *pgsext_box = new G4Box(boost::str(boost::format("pgsext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., hdiext_z / 2.);
 	  G4LogicalVolume *pgsext_volume = new G4LogicalVolume(pgsext_box, G4Material::GetMaterial("G4_C"), 
 							       boost::str(boost::format("pgsext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
@@ -322,7 +338,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  G4VisAttributes *pgs_vis = new G4VisAttributes();
 	  pgs_vis->SetVisibility(true);
 	  pgs_vis->SetForceSolid(true);
-	  pgs_vis->SetColour(G4Colour::Yellow());
+	  pgs_vis->SetColour(G4Colour::Red());
 	  pgs_volume->SetVisAttributes(pgs_vis);
 	  pgsext_volume->SetVisAttributes(pgs_vis);
 
@@ -335,28 +351,52 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  // For 1 of these tube sections,starting at 90 degrees, take decrease in y=1 mm at avge R. 
 	  // If avge R = 2.15 mm, dtheta = invcos( (R - y)/R ) = invcos(1.15/2.15) = 53.49 deg
 	  // The extent along the x axis is then R*sin(dtheta) = 1.728 mm, so two sections combined have dx = 3.456 mm length in y 
-	  const double Rcmin = 0.20; //cm  inner radius of curved section, same at both ends
-	  const double Rcmax = 0.23; //cm  outer radius of curved section, same at both ends
+	  const double Rcmin = 0.20*cm; // 2 mm  inner radius of curved section, same at both ends
+	  const double Rcmax = 0.23*cm; //cm  outer radius of curved section, same at both ends
 	  double Rcavge = (Rcmax+Rcmin)/2.0;
-	  double dphic = TMath::ACos( (Rcavge-1.0) / Rcavge);
-	  const double phic_begin = TMath::Pi() / 2.;
+	  double dphi_c = TMath::ACos( (Rcavge-Rcmin/2.) / Rcavge);
 	  const double stave_z = pgs_z;
 
-	  // make a single curved section and reuse it later
-	  G4Cons *stave_curve_cons = new G4Cons(boost::str(boost::format("stave_curve_%d_%d") %sphxlayer % itype).c_str(), 
-						Rcmin, Rcmax, Rcmin, Rcmax, stave_z / 2., phic_begin, dphic);
-	  G4LogicalVolume *stave_curve_volume = new G4LogicalVolume(stave_curve_cons, G4Material::GetMaterial("G4_C"), 
-								    boost::str(boost::format("stave_curve_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  // makecurved sections for cooler tube
+	  const double phic_begin[4] = {TMath::Pi() - dphi_c, - dphi_c, 0.0, TMath::Pi()};
+	  const double dphic[4] = {dphi_c, dphi_c, dphi_c, dphi_c};
 
-	  G4Cons *stave_curve_ext_cons = new G4Cons(boost::str(boost::format("stave_curve_%d_%d") %sphxlayer % itype).c_str(), 
-						    Rcmin, Rcmax, Rcmin, Rcmax, hdiext_z / 2., phic_begin, dphic);
-	  G4LogicalVolume *stave_curve_ext_volume = new G4LogicalVolume(stave_curve_ext_cons, G4Material::GetMaterial("G4_C"), 
-									boost::str(boost::format("stave_curve_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  G4Tubs *stave_curve_cons[4];
+	  G4Tubs *stave_curve_ext_cons[4];
+	  G4LogicalVolume *stave_curve_volume[4];
+	  G4LogicalVolume *stave_curve_ext_volume[4];
+
+	  for(int i=0;i<4;i++)
+	    {
+	      stave_curve_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_cons_%d_%d_%d") %sphxlayer % itype %i).c_str(), 
+					       Rcmin, Rcmax, stave_z / 2., phic_begin[i], dphic[i]);
+	      stave_curve_volume[i] = new G4LogicalVolume(stave_curve_cons[i], G4Material::GetMaterial("G4_C"), 
+							  boost::str(boost::format("stave_curve_volume_%d_%d_%d") % sphxlayer % itype % i).c_str(), 0, 0, 0);
+	      stave_curve_ext_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_ext_cons_%d_%d_%d") %sphxlayer % itype %i).c_str(), 
+						   Rcmin, Rcmax, hdiext_z / 2., phic_begin[i], dphic[i]);
+	      stave_curve_ext_volume[i] = new G4LogicalVolume(stave_curve_ext_cons[i], G4Material::GetMaterial("G4_C"), 
+							      boost::str(boost::format("stave_curve_ext_volume_%d_%d_%d") % sphxlayer % itype %i).c_str(), 0, 0, 0);
+
+	      G4VisAttributes *stave_curve_vis = new G4VisAttributes();
+	      stave_curve_vis->SetVisibility(true);
+	      stave_curve_vis->SetForceSolid(true);
+	      stave_curve_vis->SetColour(G4Colour::White());
+	      //if(i == 1)  stave_curve_vis->SetColour(G4Colour::Red());
+	      //if(i == 2)  stave_curve_vis->SetColour(G4Colour::Yellow());
+	      //if(i == 3)  stave_curve_vis->SetColour(G4Colour::Blue());
+	      stave_curve_volume[i]->SetVisAttributes(stave_curve_vis);
+	      stave_curve_ext_volume[i]->SetVisAttributes(stave_curve_vis);
+	    }
+
+	  // we will need the length in y of the curved section as it is installed in the stave box
+	  double curve_length_y = Rcavge * sin(dphi_c);
+	  cout << " curve length y  = " << curve_length_y  << endl;
 
 	  // Make several straight sections for use in making the stave
-
+	  
 	  // Outer straight sections of stave
-	  double stave_wall_thickness = 0.3;
+	  cout << "make stave_straight_outer volumes" << endl;	  
+	  double stave_wall_thickness = 0.03*cm;
 	  G4VSolid *stave_straight_outer_box = new G4Box(boost::str(boost::format("stave_straight_outer_box_%d_%d") % sphxlayer % itype).c_str(), 
 							 stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
 	  G4LogicalVolume *stave_straight_outer_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("G4_C"), 
@@ -365,18 +405,20 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 							     stave_wall_thickness/2., stave_straight_outer_y/2., hdiext_z / 2.);
 	  G4LogicalVolume *stave_straight_outer_ext_volume = new G4LogicalVolume(stave_straight_outer_ext_box, G4Material::GetMaterial("G4_C"), 
 										 boost::str(boost::format("stave_straight_outer_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
-
-	  // connects cooling tubes together, only needed for laddertype 1
+	  
+	  // connects cooling tubes together, only needed for laddertype 1, for laddertype 0 we just make a dummy
+	  cout << "make stave_straight_inner volumes" << endl;	  
 	  G4VSolid *stave_straight_inner_box = new G4Box(boost::str(boost::format("stave_straight_inner_box_%d_%d") % sphxlayer % itype).c_str(), 
 							 stave_wall_thickness / 2., stave_straight_inner_y / 2., stave_z / 2.);
 	  G4LogicalVolume *stave_straight_inner_volume = new G4LogicalVolume(stave_straight_inner_box, G4Material::GetMaterial("G4_C"), 
 									     boost::str(boost::format("stave_straight_inner_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
 	  G4VSolid *stave_straight_inner_ext_box = new G4Box(boost::str(boost::format("stave_straight_inner_ext_box_%d_%d") % sphxlayer % itype).c_str(), 
 							     stave_wall_thickness / 2., stave_straight_inner_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *stave_straight_inner_ext_volume = new G4LogicalVolume(stave_straight_inner_ext_box, G4Material::GetMaterial("G4_C"), 
-										 boost::str(boost::format("stave_straight_inner_ext_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-
+	  G4LogicalVolume *stave_straight_inner_ext_volume  = new G4LogicalVolume(stave_straight_inner_ext_box, G4Material::GetMaterial("G4_C"), 
+										  boost::str(boost::format("stave_straight_inner_ext_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  
 	  //Top surface of cooler tube
+	  cout << "make stave_straight_cooler volumes" << endl;	  
 	  G4VSolid *stave_straight_cooler_box = new G4Box(boost::str(boost::format("stave_straight_cooler_box_%d_%d") % sphxlayer % itype).c_str(), 
 							  stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
 	  G4LogicalVolume *stave_straight_cooler_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("G4_C"), 
@@ -385,58 +427,81 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 							      stave_wall_thickness / 2., stave_straight_cooler_y / 2., hdiext_z / 2.);
 	  G4LogicalVolume *stave_straight_cooler_ext_volume = new G4LogicalVolume(stave_straight_cooler_ext_box, G4Material::GetMaterial("G4_C"), 
 										  boost::str(boost::format("stave_straight_cooler_ext_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-
-	  G4VisAttributes *stave_curve_vis = new G4VisAttributes();
-	  stave_curve_vis->SetVisibility(true);
-	  stave_curve_vis->SetForceSolid(true);
-	  stave_curve_vis->SetColour(G4Colour::Yellow());
-	  stave_curve_volume->SetVisAttributes(stave_curve_vis);
-	  stave_curve_ext_volume->SetVisAttributes(stave_curve_vis);
-	  stave_straight_cooler_volume->SetVisAttributes(stave_curve_vis);
-	  stave_straight_cooler_ext_volume->SetVisAttributes(stave_curve_vis);
-	  stave_straight_inner_volume->SetVisAttributes(stave_curve_vis);
-	  stave_straight_inner_ext_volume->SetVisAttributes(stave_curve_vis);
-	  stave_straight_outer_volume->SetVisAttributes(stave_curve_vis);
-	  stave_straight_outer_ext_volume->SetVisAttributes(stave_curve_vis);
-
+	  
+	  G4VisAttributes *stave_vis = new G4VisAttributes();
+	  stave_vis->SetVisibility(true);
+	  stave_vis->SetForceSolid(true);
+	  stave_vis->SetColour(G4Colour::White());
+	  /*	
+		for(int i=0;i<4;i++)
+		{
+		stave_curve_volume[i]->SetVisAttributes(stave_vis);
+		stave_curve_ext_volume[i]->SetVisAttributes(stave_vis);
+		}
+	  */
+	  stave_straight_cooler_volume->SetVisAttributes(stave_vis);
+	  stave_straight_cooler_ext_volume->SetVisAttributes(stave_vis);
+	  if(laddertype == 1) stave_straight_inner_volume->SetVisAttributes(stave_vis);
+	  if(laddertype == 1) stave_straight_inner_ext_volume->SetVisAttributes(stave_vis);
+	  stave_straight_outer_volume->SetVisAttributes(stave_vis);
+	  stave_straight_outer_ext_volume->SetVisAttributes(stave_vis);
+	  
 	  // Now we combine the elements of a stave defined above into a stave
 	  // Create a stave volume to install the stave sections into. The volume has to be big enouigh to contain the cooling tube
-	  double cooler_gap_x = 0.2;  // id of cooling tube in cm
-	  double cooler_wall = 0.03;   // outer wall thickness of cooling tube 
-	  double cooler_x = cooler_gap_x + cooler_wall; 
+	  double cooler_gap_x = 0.2*cm;  // id of cooling tube in cm
+	  double cooler_wall = 0.03*cm;   // outer wall thickness of cooling tube 
+	  double cooler_x = cooler_gap_x + cooler_wall + 0.001; 
 	  const double stave_x = cooler_x;  // we do not include the PGS in the stave volume
 	  const double stave_y = hdi_y;
+	  cout << "Make stave volume with stave_x " << stave_x << " stave_y " << stave_y << " stave_z " << stave_z << endl;
 	  G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % sphxlayer % itype).c_str(), stave_x / 2., stave_y / 2., stave_z / 2.);
-	  G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_Air"), 
+	  G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_AIR"), 
 							      boost::str(boost::format("stave_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  /*
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(stave_volume);
 	    }
+	  */
 	  G4VSolid *staveext_box = new G4Box(boost::str(boost::format("staveext_box_%d_%s") % sphxlayer % itype).c_str(), stave_x / 2., stave_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_Air"), 
+	  G4LogicalVolume *staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"), 
 								 boost::str(boost::format("staveext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  /*
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(staveext_volume);
 	    }
-
+	  */
+	  G4VisAttributes *stave_box_vis = new G4VisAttributes();
+	  stave_box_vis->SetVisibility(false);
+	  stave_box_vis->SetForceSolid(false);
+	  stave_box_vis->SetColour(G4Colour::White());
+	  stave_volume->SetVisAttributes(stave_box_vis);
+	  staveext_volume->SetVisAttributes(stave_box_vis);
+	  
 	  // Assemble the elements into the stave volume and the stave extension volume
+	  // They are place relative to the center of the stave box. Thus the offset of the center of the segment is relative to the center of the satev box.
+	  // But we want the segment to be located relative to the lowest x limit of the stave box. 
 	  if(laddertype == 0)
 	    {
 	      // only one cooling tube in laddertype 0
 	      // Place the straight sections. We add the middle, then above x axis, then below x axis
-	      double x_off_str[3] = {Rcavge, (Rcmax - Rcmin) / 2., (Rcmax - Rcmin) / 2.};
+	      double x_off_str[3] = 
+		{
+		  Rcavge - stave_x / 2., 
+		  (Rcmax - Rcmin) / 2. - stave_x / 2., 
+		  (Rcmax - Rcmin) / 2. - stave_x / 2.
+		};
 	      double y_off_str[3] = 
 		{
-		  // Rcavge*TMath::Sin(dphic / 2.) is half the width of a curved section in y
 		  0.0,
-		  stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ) + 2.0 * Rcavge*TMath::Sin(dphic / 2.) + stave_straight_outer_y / 2.0,
-		  -stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ) - 2.0 * Rcavge*TMath::Sin(dphic / 2.) - stave_straight_outer_y / 2.0	  
+		  stave_straight_cooler_y / 2. + 2.0 * curve_length_y + stave_straight_outer_y / 2.0,
+		  -stave_straight_cooler_y / 2. - 2.0 * curve_length_y - stave_straight_outer_y / 2.0	  
 		};
-
+	      
    	      for(int i=0;i<3;i++)
 		{	  	  
+		  cout << "Add straight to stave volume for itype " << itype << " i "  << i << " with x_off " << x_off_str[i] << " y_off " << y_off_str[i] << " z 0 " << endl;
 		  if(i==0)
 		    {
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume, 
@@ -453,123 +518,128 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 		    }
 		}
 	      // The cooler curved sections are made using 2 curved sections in a recurve on each side of the cooler straight section 
-	      double frot[4] = {-TMath::Pi()/2., -TMath::Pi()/2.,  TMath::Pi() / 2. + dphic, TMath::Pi()/2.};
+	      // The tube sections used here have the origin of their volumr at their center of rotation. Rcavge
+	      // Each curve section is moved to the center of the stave volume by a translation of +/- Rcavge
+	      // Then it is moved to the outside or the inside of the stave volume by a translation of +/-  cooler_gap_x / 2.
+	      // we start at lowest y and work up in y
+
 	      double x_off_cooler[4] = 
 		{
-		  Rcavge*TMath::Cos(dphic / 2.), 
-		  Rcavge*TMath::Cos(dphic / 2.), 
-		  Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
-		  Rcavge - Rcavge*TMath::Cos(dphic / 2.) 
+		  Rcavge -cooler_gap_x / 2. ,
+		  - Rcavge  + cooler_gap_x / 2.,
+		  - Rcavge + cooler_gap_x / 2.,
+		  Rcavge - cooler_gap_x / 2.
 		};
 	      double y_off_cooler[4] = 
 		{
-		  stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ),  
-		  - stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ), 
-		  stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ) + 2.0 * Rcavge*TMath::Sin(dphic / 2.),  
-		  - stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ) - 2.0 * Rcavge*TMath::Sin(dphic / 2.)
+		  - stave_straight_cooler_y / 2. - 2. * curve_length_y,     
+		  - stave_straight_cooler_y / 2.,          
+		  stave_straight_cooler_y / 2.,
+		  stave_straight_cooler_y / 2. + 2. * curve_length_y    
 		};
 	      
-	      for(int icurve=0;icurve<4;icurve++)
+	      for(int i=0;i<4;i++)
 		{
-		  G4RotationMatrix *rot = new G4RotationMatrix();
-		  rot->rotateZ(frot[icurve]);
-		  new G4PVPlacement(rot, G4ThreeVector(x_off_cooler[icurve], y_off_cooler[icurve], 0.0), stave_curve_volume, 
-				    boost::str(boost::format("stave_curve_%d_%d_%d") % icurve % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
-		  new G4PVPlacement(rot, G4ThreeVector(x_off_cooler[icurve], y_off_cooler[icurve], 0.0), stave_curve_ext_volume, 
-				    boost::str(boost::format("stave_curve_ext_%d_%d_%s") % icurve % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+		  new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_volume[i], 
+				    boost::str(boost::format("stave_curve_%d_%d_%d") % sphxlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
+		  new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_ext_volume[i], 
+				    boost::str(boost::format("stave_curve_ext_%d_%d_%s") % sphxlayer % itype %i).c_str(), staveext_volume, false, 0, OverlapCheck());
 		}
 	    }
-	  else
+	  else   	      // The type 1 ladder has two cooling tubes
 	    {
-	      // The type 1 ladder has two cooling tubes
-	      // Place the straight sections, do the extension at the same time
+	      // First place the straight sections, do the extension at the same time
 	      // we alternate  positive and negative y values here
 	      double x_off_str[5] = 
 		{
-		  (Rcmax-Rcmin) / 2., // against the PGS
-		  (Rcmax+Rcmin) / 2.,   // top of cooler
-		  (Rcmax+Rcmin) / 2.,   // top of cooler
-		  (Rcmax-Rcmin) / 2., 
-		  (Rcmax-Rcmin) / 2.
+		  (Rcmax-Rcmin) / 2. -stave_x / 2., // against the PGS
+		  (Rcmax+Rcmin) / 2. - stave_x / 2.,   // top of cooler
+		  (Rcmax+Rcmin) / 2. - stave_x / 2.,   // top of cooler
+		  (Rcmax-Rcmin) / 2. - stave_x / 2., 
+		  (Rcmax-Rcmin) / 2 - stave_x / 2.
 		};
 	      double y_off_str[5] = 
 		{
-		  0.0,
-		  stave_straight_inner_y/2. + 2. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y/2.,  // top of cooler
-		  - stave_straight_inner_y/2. - 2. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y/2.,  // top of cooler
-		  stave_straight_inner_y/2. + 2. * Rcavge*TMath::Sin( dphic / 2.) + stave_straight_cooler_y + 2. *  Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_outer_y/2.,
-		  - stave_straight_inner_y/2. - 2. * Rcavge*TMath::Sin( dphic / 2.) - stave_straight_cooler_y - 2. *  Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_outer_y/2.,
+		  0.0,  // center section against PGS
+		  stave_straight_inner_y/2. + 2. * curve_length_y + stave_straight_cooler_y/2.,  // top of cooler
+		  - stave_straight_inner_y/2. - 2. * curve_length_y - stave_straight_cooler_y/2.,  // top of cooler
+		  stave_straight_inner_y/2. + 2. * curve_length_y + stave_straight_cooler_y + 2. *  curve_length_y + stave_straight_outer_y/2.,
+		  - stave_straight_inner_y/2. - 2. * curve_length_y - stave_straight_cooler_y - 2. *  curve_length_y - stave_straight_outer_y/2.,
 		};
 	      
 	      for(int i=0;i<5;i++)
 		{
+		  cout << "Add straight to stave volume for itype " << itype << " i "  << i << " with x_off " << x_off_str[i] << " y_off " << y_off_str[i] << " z 0 " << endl;
 		  if(i==0)
 		    {
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_volume, 
-					boost::str(boost::format("stave_straight_inner_%d_%d_%d") % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_inner_%d_%d_%d") % sphxlayer % itype %i).c_str(), stave_volume, false, 0, OverlapCheck());
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_ext_volume, 
-					boost::str(boost::format("stave_straight_inner_ext_%d_%d_%s") % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_inner_ext_%d_%d_%s") % sphxlayer % itype %i).c_str(), staveext_volume, false, 0, OverlapCheck());
 		    }
 		  else if(i==1 || i==2)
 		    {
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume, 
-					boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % sphxlayer % itype %i).c_str(), stave_volume, false, 0, OverlapCheck());
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume, 
-					boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % sphxlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
 		    }
 		  else
 		    {
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume, 
-					boost::str(boost::format("stave_straight_outer_%d_%d_%d") % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_outer_%d_%d_%d") % sphxlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume, 
-					boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % sphxlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
 		    }
 		}
-	  
+	      
 	      // Place the curved sections
-	      // hre we do all above the x axis, then all below the x axis, each in order of increasing y
-	      double frot[8] = 
-		{
-		  TMath::Pi()/2., 
-		  -TMath::Pi()/2.,  
-		  - TMath::Pi()/2. + dphic, 
-		  TMath::Pi(),
-		  TMath::Pi()/2., 
-		  -TMath::Pi()/2.,  
-		  - TMath::Pi()/2. + dphic, 
-		  TMath::Pi()
-		};
+	      // here we do all above the x axis, then all below the x axis, each in order of increasing y
+
 	      double x_off_curve[8] = 
 		{
-		  Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
-		  Rcavge*TMath::Cos(dphic / 2.), 
-		  Rcavge*TMath::Cos(dphic / 2.), 
-		  Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
-		  Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
-		  Rcavge*TMath::Cos(dphic / 2.), 
-		  Rcavge*TMath::Cos(dphic / 2.), 
-		  Rcavge - Rcavge*TMath::Cos(dphic / 2.) 
+		  // below x axis, increasing in y
+		  Rcavge -cooler_gap_x / 2. ,
+		  - Rcavge  + cooler_gap_x / 2.,
+		  - Rcavge + cooler_gap_x / 2.,
+		  Rcavge - cooler_gap_x / 2.,
+		  // above x axis, increasing in y
+		  Rcavge -cooler_gap_x / 2. ,
+		  - Rcavge  + cooler_gap_x / 2.,
+		  - Rcavge + cooler_gap_x / 2.,
+		  Rcavge - cooler_gap_x / 2.
 		};
 	      double y_off_curve[8] = 
 		{
-		  stave_straight_inner_y / 2. + Rcavge*TMath::Sin( dphic / 2.),  
-		  stave_straight_inner_y / 2. + 2. * Rcavge*TMath::Sin( dphic / 2. ) + Rcavge*TMath::Sin(dphic / 2.),  
-		  stave_straight_inner_y / 2. + 4. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y + Rcavge*TMath::Sin(dphic / 2.),  
-		  stave_straight_inner_y / 2. + 6. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y + Rcavge*TMath::Sin(dphic / 2.),  
-		  - stave_straight_inner_y / 2. - 6. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y - Rcavge*TMath::Sin(dphic / 2.),  
-		  - stave_straight_inner_y / 2. - 4. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y - Rcavge*TMath::Sin(dphic / 2.),  
-		  - stave_straight_inner_y / 2. - 2. * Rcavge*TMath::Sin( dphic / 2. ) - Rcavge*TMath::Sin(dphic / 2.),  
-		  - stave_straight_inner_y / 2. - Rcavge*TMath::Sin( dphic / 2.)  
-		};
-	  
+		  // below the x axis, increasing in y
+		  - stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y - 2.* curve_length_y,
+		  - stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y,
+		  - stave_straight_inner_y / 2. - 2. * curve_length_y,     
+		  - stave_straight_inner_y / 2.,          
+		  // above the x axis, increasing in y
+		  stave_straight_inner_y / 2.,
+		  stave_straight_inner_y / 2. + 2. * curve_length_y,
+		  stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y,
+		  stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y + 2.* curve_length_y
+   		};
+	      
 	      for(int i=0;i<8;i++)
 		{
-		  G4RotationMatrix *rot = new G4RotationMatrix();
-		  rot->rotateZ(frot[i]);
-		  new G4PVPlacement(rot, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_volume, boost::str(boost::format("stave_curve_%d_%d_%d") 
-															  % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
-		  new G4PVPlacement(rot, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_curve_ext_volume, boost::str(boost::format("stave_curve_ext_%d_%d_%s") 
-															 % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+		  cout << "Place curve for i " << i << " laddertype " << laddertype << " inttlayer " << inttlayer 
+		       << " xoff " << x_off_curve[i] << " yoff " << y_off_curve[i]
+		       << " curve_length_y " << curve_length_y
+		       << " stave_straight_inner_y " << stave_straight_inner_y
+		       << " stave_straight_cooler_y " << stave_straight_cooler_y
+		       << endl;
+
+		  int ivol = i;
+		  if(i > 3) 
+		    ivol = i - 4;
+
+		  new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_volume[ivol], boost::str(boost::format("stave_curve_%d_%d_%d") 
+															     % sphxlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
+		  new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_ext_volume[ivol], boost::str(boost::format("stave_curve_ext_%d_%d_%s") 
+																 % sphxlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
 		}
 	    }
       
@@ -583,21 +653,27 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  const double ladder_x = stave_x  + pgs_x  + hdi_x  + fphx_x;
 	  const double ladder_y = hdi_y;
 	  const double ladder_z = hdi_z;
+	  cout << " sphxlayer " << sphxlayer << " laddertype " << laddertype << " itype " << itype << " stave_x " << stave_x << " pgs_x " 
+	       << pgs_x << " hdi_x " << hdi_x << " fphx_x " << fphx_x << endl;
+	  cout << "Create ladder volume with ladder_x " << ladder_x  <<  " ladder_y " << ladder_y << " ladder_z " << ladder_z << endl;
 	  G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., ladder_z / 2.);
-	  G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_%d_%d_%d") % sphxlayer % inttlayer % itype).c_str(), 0, 0, 0);
+
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(ladder_volume);
 	    }
+
 	  G4VSolid *ladderext_box = new G4Box(boost::str(boost::format("ladderext_box_%d_%s") % sphxlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladderext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+	  G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladderext_%d_%d_%d") % sphxlayer % inttlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(ladderext_volume);
 	    }
+
 	  G4VisAttributes *ladder_vis = new G4VisAttributes();
-	  ladder_vis->SetVisibility(true);
-	  ladder_vis->SetForceSolid(true);
+	  ladder_vis->SetVisibility(false);
+	  ladder_vis->SetForceSolid(false);
 	  ladder_vis->SetColour(G4Colour::Cyan());
 	  ladder_volume->SetVisAttributes(ladder_vis);
 	  ladderext_volume->SetVisAttributes(ladder_vis);
@@ -610,6 +686,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
 	  // Carbon stave        
 	  const double TVstave_x = ladder_x / 2. - stave_x / 2.;
+	  cout << "Place Stave in ladder with TVstave_x " << TVstave_x << " y 0 " << " z  0"<< endl;
 	  new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), stave_volume, boost::str(boost::format("stave_%d_%d") % sphxlayer % itype).c_str(), 
 			    ladder_volume, false, 0, OverlapCheck());
 	  new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), staveext_volume, boost::str(boost::format("staveext_%d_%s") % sphxlayer % itype).c_str(), 
@@ -617,6 +694,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
 	  // PGS
 	  const double TVpgs_x = TVstave_x - stave_x / 2. - pgs_x / 2.;
+	  cout << "Place pgs in ladder with TVpgs_x " << TVpgs_x << " y 0 " << " z  0"<< endl;
 	  new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgs_volume, boost::str(boost::format("pgs_%d_%d") % sphxlayer % itype).c_str(), 
 			    ladder_volume, false, 0, OverlapCheck());
 	  new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgsext_volume, boost::str(boost::format("pgsext_%d_%s") % sphxlayer % itype).c_str(), 
@@ -624,18 +702,24 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
 	  // HDI        
 	  const double TVhdi_x = TVpgs_x - pgs_x / 2. - hdi_x / 2.;
+	  cout << "Place hdi in ladder with TVhdi_x " << TVhdi_x << " y 0 " << " z  0"<< endl;
 	  new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdi_volume, boost::str(boost::format("hdi_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 	  new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdiext_volume, boost::str(boost::format("hdiext_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
 	  // Si-sensor        
 	  const double TVSi_x = TVhdi_x - hdi_x / 2. - siactive_x / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siinactive_volume, boost::str(boost::format("siinactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siactive_volume, boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  cout << "Place Si sensor in ladder with TVSi_x " << TVSi_x << " y 0 " << " z  0"<< endl;
+	  // laddertype 0 has a sensor offset on the HDI
+	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, sensor_offset_y, 0.0), siinactive_volume, boost::str(boost::format("siinactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, sensor_offset_y, 0.0), siactive_volume, boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
 	  // FPHX        
-	  const double TVfphx_x = TVhdi_x - hdi_x / 2. - fphx_x / 2.;
-	  const double TVfphx_y = sifull_y + gap_sensor_fphx + fphx_y / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  const double TVfphx_x = TVSi_x - TVSi_x / 2. - fphx_x / 2.;
+	  const double TVfphx_y = sifull_y / 2. + gap_sensor_fphx - sensor_offset_y + fphx_y / 2.;
+	  cout << "Place fphxcontainer in ladder with TVfph_x " << TVfphx_x << " TVfphx_y " << TVfphx_y << " z  0"<< endl;
+	  // laddertype 0 has only one FPHX, and the sensor is offset in y
+	  if(laddertype == 1)
+	    new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 	  new G4PVPlacement(0, G4ThreeVector(TVfphx_x, -TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerm_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
 	  // ----- Step 3 --------------------------------------------------------------------------------------------------------------------
@@ -655,7 +739,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  // there is no single radius for a layer
 	  eff_radius[ilayer] = layer_radius_inner + sensor_offset;
 	  eff_radius_alternate[ilayer] = layer_radius_outer + sensor_offset;
-	  posz[ilayer][itype] = (itype == 0) ? hdi_z : hdi_z_[ilayer][0] + hdi_z;
+	  posz[ilayer][itype] = (itype == 0) ? hdi_z / 2. : hdi_z_[ilayer][0] + hdi_z / 2.; // location of center of ladder in Z
 	  strip_x_offset[ilayer] = sensor_offset;
 
 	  for (G4int icopy = 0; icopy < nladders_layer; icopy++)
@@ -680,7 +764,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	      if (itype != 0)
 		{  
 		  // The HDI extension tab has to be added for the outer sensor
-		  const G4double posz_ext = 2. * (hdi_z_[ilayer][0] + hdi_z) + hdiext_z;
+		  const G4double posz_ext = (hdi_z_[ilayer][0] + hdi_z) + hdiext_z / 2.;
 		  new G4PVPlacement(ladderrotation, G4ThreeVector(posx, posy, -posz_ext), ladderext_volume, boost::str(boost::format("ladderext_%d_%d_%d_%d") 
 														       % sphxlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
 		  new G4PVPlacement(ladderrotation, G4ThreeVector(posx, posy, +posz_ext), ladderext_volume, boost::str(boost::format("ladderext_%d_%d_%d_%d") 
@@ -769,9 +853,11 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
     {
       const int sphxlayer = layerconfig_[ilayer].first;
       const int inttlayer = layerconfig_[ilayer].second;
-
-      const PHParameters *params = paramscontainer->GetParameters(inttlayer);
+      cout << "Enter geometry maker for sphxlayer " << sphxlayer << " inttlayer " << inttlayer << endl;
+      const PHParameters *params_layer = paramscontainer->GetParameters(inttlayer);
+      const int laddertype = params_layer->get_int_param("laddertype");
       // parameters are in cm, so no conversion needed here to get to cm (*cm/cm)
+      const PHParameters *params = paramscontainer->GetParameters(laddertype);
       PHG4CylinderGeom *mygeom = new PHG4CylinderGeom_Siladders(
           sphxlayer,
           params->get_double_param("strip_x"),
@@ -782,13 +868,13 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
           params->get_int_param("nstrips_z_sensor_1"),
           params->get_int_param("nstrips_phi_sensor"),
           params->get_int_param("nladder"),
-          posz[ilayer][0] / cm,
-          posz[ilayer][1] / cm,
-          eff_radius[ilayer] / cm,
-          eff_radius_alternate[ilayer] / cm,
-          strip_x_offset[ilayer] / cm,
-          params->get_double_param("offsetphi") * deg / rad,
-          params->get_double_param("offsetrot") * deg / rad);
+          posz[ilayer][0],
+          posz[ilayer][1],
+          eff_radius[ilayer],
+          eff_radius_alternate[ilayer],
+          strip_x_offset[ilayer],
+          params_layer->get_double_param("offsetphi"),
+          params_layer->get_double_param("offsetrot") );
       geo->AddLayerGeom(sphxlayer, mygeom);
       if (Verbosity() > 0)
         geo->identify();

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -42,7 +42,7 @@ PHG4SiliconTrackerDetector::PHG4SiliconTrackerDetector(PHCompositeNode *Node, PH
   for (unsigned int ilayer = 0; ilayer < nlayer_; ++ilayer)
   {
     const int inttlayer = layerconfig_[ilayer].second;
-    if (inttlayer < 0 || inttlayer >= 5)
+    if (inttlayer < 0 || inttlayer >= 4)
     {
       assert(!"PHG4SiliconTrackerDetector: check INTT ladder layer.");
     }
@@ -94,17 +94,25 @@ void PHG4SiliconTrackerDetector::Construct(G4LogicalVolume *logicWorld)
 
 int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *trackerenvelope)
 {
+  // We have an arbitray number of layers (nlayer_)
+  // We have 2 types of ladders (vertical strips and horizontal strips)
+  // We have 2 types of sensors (inner and outer)
+
   double hdi_z_[nlayer_][2];
   for (unsigned int ilayer = 0; ilayer < nlayer_; ++ilayer)
   {
     const int sphxlayer = layerconfig_[ilayer].first;
     const int inttlayer = layerconfig_[ilayer].second;
-    const PHParameters *params = paramscontainer->GetParameters(inttlayer);
+    // get the laddertype for this layer
+    PHParameters *params = paramscontainer->GetParameters(inttlayer);
+    const int laddertype = params->get_int_param("laddertype");
+
+    // Look up all remaining parameters by laddertype
+    params = paramscontainer->GetParameters(laddertype);
     const G4double strip_x = params->get_double_param("strip_x") * cm;
     const G4double strip_y = params->get_double_param("strip_y") * cm;
-    const int nstrips_phi_cell = params->get_int_param("nstrips_phi_cell");
-
-    const int nladders_layer = params->get_int_param("nladder");
+    const int nstrips_phi_sensor = params->get_int_param("nstrips_phi_sensor");
+    const int nladders_layer = params->get_int_param("nladders");
     const G4double radius = params->get_double_param("radius") * cm;
     const G4double offsetphi = params->get_double_param("offsetphi") * deg;
     const G4double offsetrot = params->get_double_param("offsetrot") * deg;
@@ -114,8 +122,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
     double fphx_y = params->get_double_param("fphx_y") * cm;
     double fphx_z = params->get_double_param("fphx_z") * cm;
     double pgs_x = params->get_double_param("pgs_x") * cm;
-    double stave_x = params->get_double_param("stave_x") * cm;
+    //double stave_x = params->get_double_param("stave_x") * cm;
     double halfladder_z = params->get_double_param("halfladder_z") * cm;
+
+    // itype specifies inner or outer sensor type
     for (int itype = 0; itype < 2; ++itype)
     {
       if (!(itype >= 0 && itype <= 1))
@@ -139,78 +149,86 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
         exit(1);
       }
 
-      /*----- Step 1 -----
-       * We make volume for Si-sensor, FPHX, HDI, PGS sheet, and stave.
-         * Then we make ladder volume large enough to enclose the above volume.
-         */
-
-      /*
-         * Si-strip
-         */
-      G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % sphxlayer % itype).c_str(), strip_x / 2., strip_y / 2. - strip_y / 20000., strip_z / 2. - strip_z / 2. / 10000.);
-      G4LogicalVolume *strip_volume = new G4LogicalVolume(strip_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("strip_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+      // ----- Step 1 ------------------------------------------------------------------------------
+      // We make the volumes for Si-sensor, FPHX, HDI, PGS sheet, and stave.
+      // We add them to the ladder later
+      //===================================================
+      
+      // Create a volume for the Si-strip
+      // use half widths to make the box
+      G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % sphxlayer %itype).c_str(), 
+				      strip_x / 2., strip_y / 2. - strip_y / 20000., strip_z / 2. - strip_z / 2. / 10000.);
+      G4LogicalVolume *strip_volume = new G4LogicalVolume(strip_box, G4Material::GetMaterial("G4_Si"), 
+							  boost::str(boost::format("strip_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsActive.find(inttlayer))->second > 0)
-      {
-        activelogvols.insert(strip_volume);
-      }
+	{
+	  activelogvols.insert(strip_volume);
+	}
       G4VisAttributes *strip_vis = new G4VisAttributes();
       strip_vis->SetVisibility(false);
       strip_vis->SetForceSolid(false);
       strip_vis->SetColour(G4Colour::White());
       strip_volume->SetVisAttributes(strip_vis);
+      
+      // Create Si-sensor active volume
+      // Use half-widths to make the box      
+      const double siactive_x = strip_x;
+      const double siactive_y = strip_y * nstrips_phi_sensor; 
+      const double siactive_z = strip_z * nstrips_z_sensor;  
+      
+      G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x, siactive_y, siactive_z);
+      G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), 
+							     boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+      
+      // Now make a G4PVParameterised containing all of the strips in a sensor 
+      // this works for ladder 0 because there is only one strip type - all cells are identical
+      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_sensor, nstrips_z_sensor, strip_y/2.0, strip_z/2.0);
+      new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), strip_volume, siactive_volume, kZAxis, nstrips_phi_sensor * nstrips_z_sensor, stripparam, false);  // overlap check too long.
+      
+      
+      // Si-sensor full (active+inactive) area
 
-      /*
-         * Si-sensor active area
-         */
-      const double siactive_x = strip_x;                          // 0.24mm/2
-      const double siactive_y = strip_y * nstrips_phi_cell;       // (0.078mm * 2*128)/2 = 0.078mm * 128
-      const double siactive_z = strip_z / 2. * nstrips_z_sensor;  // (20mm * 5or8)/2 = 10mm * 5or8
-
-      G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x / 2., siactive_y, siactive_z);
-      G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-
-      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_cell * 2, nstrips_z_sensor, strip_y, strip_z);
-      new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), strip_volume, siactive_volume, kZAxis, nstrips_phi_cell * 2 * nstrips_z_sensor, stripparam, false);  // overlap check too long.
-
-      /*
-         * Si-sensor full (active+inactive) area
-         */
-      const double sifull_x = siactive_x;                                                     // 0.24mm/2
-      const double sifull_y = siactive_y + params->get_double_param("sensor_edge_phi") * cm;  // (1.305mm  + 0.078mm * 2*128 + 1.305mm)/2 = 0.078mm * 128 + 1.305mm
-      const double sifull_z = siactive_z + params->get_double_param("sensor_edge_z") * cm;    // (0.98mm + 20mm * 5 + 0.98mm)/2 = 10mm * 5 + 0.98mm
-
-      G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % sphxlayer % itype).c_str(), sifull_x / 2., sifull_y, sifull_z);
-
-      /*
-         * Si-sensor inactive area
-         */
-      G4VSolid *siinactive_box = new G4SubtractionSolid(boost::str(boost::format("siinactive_box_%d_%d") % sphxlayer % itype).c_str(), sifull_box, siactive_box, 0, G4ThreeVector(0, 0, 0));
-      G4LogicalVolume *siinactive_volume = new G4LogicalVolume(siinactive_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("siinactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+      const double sifull_x = siactive_x;
+      const double sifull_y = siactive_y + 2.0*params->get_double_param("sensor_edge_phi") * cm; 
+      const double sifull_z = siactive_z + 2.0*params->get_double_param("sensor_edge_z") * cm;    
+      
+      G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % sphxlayer % itype).c_str(), sifull_x / 2., sifull_y/2.0, sifull_z/2.0);
+      
+      // Si-sensor inactive area
+      
+      G4VSolid *siinactive_box = new G4SubtractionSolid(boost::str(boost::format("siinactive_box_%d_%d") % sphxlayer % itype).c_str(), 
+							sifull_box, siactive_box, 0, G4ThreeVector(0, 0, 0));
+      G4LogicalVolume *siinactive_volume = new G4LogicalVolume(siinactive_box, G4Material::GetMaterial("G4_Si"), 
+							       boost::str(boost::format("siinactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
-      {
-        absorberlogvols.insert(siinactive_volume);
-      }
+	{
+	  absorberlogvols.insert(siinactive_volume);
+	}
       G4VisAttributes *siinactive_vis = new G4VisAttributes();
       siinactive_vis->SetVisibility(true);
       siinactive_vis->SetForceSolid(true);
       siinactive_vis->SetColour(G4Colour::Gray());
       siinactive_volume->SetVisAttributes(siinactive_vis);
+      
 
-      /*
-         * HDI
-         */
-      const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z") * cm;  // hdi_edge_z = 100micron
+      // Make the HDI volume
+      // This makes a HDI volume that matches this sensor in Z length
+
+      const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z") * cm;  
       hdi_z_[ilayer][itype] = hdi_z;
 
-      G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdi_z);
+      G4VSolid *hdi_box = new G4Box(boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdi_z/2.0);
       G4LogicalVolume *hdi_volume = new G4LogicalVolume(hdi_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdi_box_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
         absorberlogvols.insert(hdi_volume);
       }
-      const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z / 2. - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
-      G4VSolid *hdiext_box = new G4Box(boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdiext_z);
-      G4LogicalVolume *hdiext_volume = new G4LogicalVolume(hdiext_box, G4Material::GetMaterial("FPC"), boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+
+      // This is the part of the HDI that extends beyond the sensor
+      const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z  - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
+      G4VSolid *hdiext_box = new G4Box(boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), hdi_x / 2., hdi_y / 2., hdiext_z / 2.0);
+      G4LogicalVolume *hdiext_volume = new G4LogicalVolume(hdiext_box, G4Material::GetMaterial("FPC"), 
+							   boost::str(boost::format("hdiext_box_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
         absorberlogvols.insert(hdiext_volume);
@@ -221,9 +239,8 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       hdi_vis->SetColour(G4Colour::Magenta());
       hdi_volume->SetVisAttributes(hdi_vis);
 
-      /*
-         * FPHX
-         */
+      // FPHX
+        
       G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % sphxlayer % itype).c_str(), fphx_x / 2., fphx_y / 2., fphx_z / 2.);
       G4LogicalVolume *fphx_volume = new G4LogicalVolume(fphx_box, G4Material::GetMaterial("G4_Si"), boost::str(boost::format("fphx_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
@@ -237,16 +254,17 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       fphx_volume->SetVisAttributes(fphx_vis);
 
       const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx") * cm;
-
-      /*
-         * FPHX Container
-         */
+      
+      //  FPHX Container
+      // make a container for the FPHX chips needed for this sensor, and  then place them in the container
       const double fphxcontainer_x = fphx_x / 2.;
       const double fphxcontainer_y = fphx_y / 2.;
-      const double fphxcontainer_z = hdi_z;
+      const double fphxcontainer_z = hdi_z / 2.0;
 
-      G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % sphxlayer % itype).c_str(), fphxcontainer_x, fphxcontainer_y, fphxcontainer_z);
-      G4LogicalVolume *fphxcontainer_volume = new G4LogicalVolume(fphxcontainer_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("fphxcontainer_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+      G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % sphxlayer % itype).c_str(), 
+					      fphxcontainer_x, fphxcontainer_y, fphxcontainer_z);
+      G4LogicalVolume *fphxcontainer_volume = new G4LogicalVolume(fphxcontainer_box, G4Material::GetMaterial("G4_AIR"), 
+								  boost::str(boost::format("fphxcontainer_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
         absorberlogvols.insert(fphxcontainer_volume);
@@ -256,27 +274,41 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       fphxcontainer_vis->SetForceSolid(false);
       fphxcontainer_volume->SetVisAttributes(fphxcontainer_vis);
 
-      const int ncopy = nstrips_z_sensor;
+      // Install multiple FPHX volumes in the FPHX container volume 
+      // one FPHX chip per cell - each cell is 128 channels
       const double offsetx = 0.;
       const double offsety = 0.;
-      const double offsetz = (ncopy % 2 == 0) ? -2. * strip_z / 2. * double(ncopy / 2) + strip_z / 2. : -2. * strip_z / 2. * double(ncopy / 2);
+      int ncopy;
+      double offsetz, cell_length_z;
+      // For layer 0, we have 5 cells per sensor, but the strips are vertical, so we have to treat it specially
+      if(nstrips_z_sensor == 1)
+	{
+	  ncopy = nstrips_z_sensor / 128.0;
+	}
+      else
+	{
+	  ncopy = nstrips_z_sensor;
+	}
+      cell_length_z = strip_z * nstrips_z_sensor / ncopy;
+      offsetz = (ncopy % 2 == 0) ? -2. * cell_length_z / 2. * double(ncopy / 2) + cell_length_z / 2. : -2. * cell_length_z / 2. * double(ncopy / 2);
 
       G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * strip_z / 2., ncopy);
-      new G4PVParameterised(boost::str(boost::format("fphxcontainer_%d_%d") % sphxlayer % itype).c_str(), fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, OverlapCheck());
+      new G4PVParameterised(boost::str(boost::format("fphxcontainer_%d_%d") % sphxlayer % itype).c_str(), 
+			    fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, OverlapCheck());
 
-      /*
-         * PGS
-         */
-      const double pgs_y = sifull_y + gap_sensor_fphx + 2. * fphx_y / 2.;  // between FPHX's outer edges
+      // PGS   - this is the carbon sheet that the HDI sits on. It forms the wall of the cooling tube that cools the HDI
+        
+      const double pgs_y = hdi_y;
       const double pgs_z = hdi_z;
 
-      G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y, pgs_z);
+      G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., pgs_z / 2.);
       G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgs_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
         absorberlogvols.insert(pgs_volume);
       }
-      G4VSolid *pgsext_box = new G4Box(boost::str(boost::format("pgsext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y, hdiext_z);
+      // The part that extends beyond this sensor, see above for hdiext
+      G4VSolid *pgsext_box = new G4Box(boost::str(boost::format("pgsext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., hdiext_z / 2.);
       G4LogicalVolume *pgsext_volume = new G4LogicalVolume(pgsext_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("pgsext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
 
       G4VisAttributes *pgs_vis = new G4VisAttributes();
@@ -285,43 +317,198 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       pgs_vis->SetColour(G4Colour::Yellow());
       pgs_volume->SetVisAttributes(pgs_vis);
 
-      /*
-         * Carbon stave
-         */
-      const double stave_y = pgs_y;
-      const double stave_z = hdi_z;
+      // Carbon stave. This is the formed sheet that sits on the PGS and completes the cooling tube
+      // Formed from straight sections and sections of a tube of radius 2.3 mm. All have wall thickness of 0.3 mm.
+      // These are different for laddertype 0 and 1, but they use some common elements.
 
-      G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % sphxlayer % itype).c_str(), stave_x / 2., stave_y, stave_z);
-      G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+      // The curved section is made from a G4Cons, which is a generalized section of a cone
+      // Two curved sections combined should move the inner wall to be 2.0 mm away from the PGS, then 2 more sections bring it back
+      // For 1 of these tube sections,starting at 90 degrees, take decrease in y=1 mm at avge R. If avge R = 2.15 mm, dtheta = invcos( (R - y)/R ) = invcos(1.15/2.15) = 53.49 deg
+      // The extent along the x axis is then R*sin(dtheta) = 1.728 mm, so two sections combined have dx = 3.456 mm length in y 
+      const double Rcmin = 0.20; //cm  inner radius of curved section, same at both ends
+      const double Rcmax = 0.23; //cm  outer radius of curved section, same at both ends
+      double Rcavge = (Rcmax+Rcmin)/2.0;
+      double dphic = TMath::Acos( (Rcavge-1.0) / Rcavge);
+      const double stave_z = pgs_z;
+      const double phic_begin = M_PI / 2.;
+
+      // make a single curved section and reuse it later
+      G4Cons *stave_curve_cons = new G4Cons(boost:str(boost:format("stave_curve_%d_%d") %sphxlayer % itype).c_str(), 
+				       Rcmin, Rcmax, Rcmin, Rcmax, stave_z / 2., phic_begin, dphic);
+      G4LogicalVolume *stave_curve_volume = new G4LogicalVolume(stave_curve_cons, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_curve_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+      G4VisAttributes *stave_curve_vis = new G4VisAttributes();
+      stave_curve_vis->SetVisibility(true);
+      stave_curve_vis->SetForceSolid(true);
+      stave_curve_vis->SetColour(G4Colour::Yellow());
+      stave_curve_volume->SetVisAttributes(stave_curve_vis);
+
+      // Make several straight sections
+      // Outer straight sections of stave
+      double stave_wall_thickness = 0.3;
+      G4VSolid *stave_straight_outer_box = new G4Box(boost::str(boost::format("stave_straight_outer_box_%d_%d") % sphxlayer % itype).c_str(), stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
+      G4LogicalVolume *stave_straight_outer_box_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_straight_outer_box_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+
+      // connects cooling tubes together, only needed for laddertype 1
+      G4VSolid *stave_straight_inner_box = new G4Box(boost::str(boost::format("stave_straight_inner_box_%d_%d") % sphxlayer % itype).c_str(), stave_wall_thickness / 2., stave_straight_inner_y / 2., stave_z / 2.);
+      G4LogicalVolume *stave_straight_inner_box_volume = new G4LogicalVolume(stave_straight_inner_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_straight_inner_box_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+
+      //Top surface of cooler tube
+      G4VSolid *stave_straight_cooler_box = new G4Box(boost::str(boost::format("stave_straight_cooler_box_%d_%d") % sphxlayer % itype).c_str(), stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
+      G4LogicalVolume *stave_straight_cooler_box_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("stave_straight_cooler_box_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+
+      // Now we combine the elements of a stave defined above into a stave
+      // Create a stave volume to install the stave sections into. The volume has to be big enouigh to contain the cooling tube
+      double cooler_gap_x = 0.2;  // id of cooling tube 
+      double cooler_wall = 0.03;   // outer wall thickness of cooling tube 
+      double cooler_x = cooler_gap_x + cooler_wall; 
+      const double stave_x = cooler_x;  // we do not include the PGS
+      const double stave_y = hdi_y;
+      G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % sphxlayer % itype).c_str(), stave_x / 2., stave_y / 2., stave_z / 2.);
+      G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_Air"), boost::str(boost::format("stave_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
         absorberlogvols.insert(stave_volume);
       }
       G4VSolid *staveext_box = new G4Box(boost::str(boost::format("staveext_box_%d_%s") % sphxlayer % itype).c_str(), stave_x / 2., stave_y, hdiext_z);
-      G4LogicalVolume *staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_C"), boost::str(boost::format("staveext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+      G4LogicalVolume *staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_Air"), boost::str(boost::format("staveext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
         absorberlogvols.insert(staveext_volume);
       }
-      G4VisAttributes *stave_vis = new G4VisAttributes();
-      stave_vis->SetVisibility(true);
-      stave_vis->SetForceSolid(true);
-      stave_vis->SetColour(G4Colour::Yellow());
-      stave_volume->SetVisAttributes(stave_vis);
 
-      /*
-         * Ladder
-         */
-      const double ladder_x = stave_x / 2. + pgs_x / 2. + hdi_x / 2. + fphx_x / 2.;
+      // Assemble the elements into the stave volume
+      if(laddertype == 0)
+	{
+	  // only one cooling tube in laddertype 0
+	  // Place the straight sections
+	  // middle, above x axis, below x axis
+	  x_off_str[3] = {Rcavge, (Rcmax - Rcmin) / 2., (Rcmax - Rcmin) / 2.};
+	  y_off_str[3] = {
+	    0.0;
+	    stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ) + 2.0 * Rcavge*TMath::Sin(dphic / 2.) + stave_straight_outer_y / 2.0,
+	    -stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ) - 2.0 * Rcavge*TMath::Sin(dphic / 2.) - stave_straight_outer_y / 2.0	  
+	  };
+	  
+	  for(int i=0;i<3;i++)
+	    {	  	  
+	      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_ends[i], 0.0), stave_volume, boost::str(boost::format("stave_straight_%d_%d_%d") 
+													     % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+	      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_ends[i], 0.0), staveext_volume, boost::str(boost::format("stave_straight_ext_%d_%d_%s") 
+														% i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+	    }
+
+	  // The cooler curved sections
+	  double frot[4] = {-TMath::PI/2., -TMath::PI/2.,  TMath::PI / 2. + dphic, TMath::PI/2.};
+	  double x_off_cooler[4] = {
+	    Rcavge*TMath::Cos(dphic / 2.), 
+	    Rcavge*TMath::Cos(dphic / 2.), 
+	    Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
+	    Rcavge - Rcavge*TMath::Cos(dphic / 2.) 
+	  };
+	  double y_off_cooler[4] = {
+	    stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ),  
+	    - stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ), 
+	    stave_straight_cooler_y / 2. + Rcavge*TMath::Sin( dphic / 2. ) + 2.0 * Rcavge*TMath::Sin(dphic / 2.),  
+	    - stave_straight_cooler_y / 2. - Rcavge*TMath::Sin( dphic / 2. ) - 2.0 * Rcavge*TMath::Sin(dphic / 2.)
+	  };
+
+	  for(int icurve=0;icurve<4;icurve++)
+	    {
+	      G4RotationMatrix *rot = new G4RotationMatrix();
+	      rot->rotateZ(frot[i]);
+	      new G4PVPlacement(rot, G4ThreeVector(x_off_cooler[icurve], y_off_cooler[icurve], 0.0), stave_volume, boost::str(boost::format("stave_curve_%d_%d_%d") 
+															      % icurve % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+	      new G4PVPlacement(rot, G4ThreeVector(x_off_cooler[icurve], y_off_cooler[icurve], 0.0), staveext_volume, boost::str(boost::format("stave_curve_ext_%d_%d_%s")
+																 % icurve % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+	    }
+	}
+      else
+	{
+	  // The type 1 ladder has two cooling tubes
+	  // Place the straight sections
+	  // alternating above and below x axis
+	  double x_off_str[5] = {
+	    (Rcmax-Rcmin) / 2., 
+	    (Rcmax+Rcmin) / 2.,   // top of cooler
+	    (Rcmax+Rcmin) / 2.,   // top of cooler
+	    (Rcmax-Rcmin) / 2., 
+	    (Rcmax-Rcmin) / 2.
+	  };
+	  double y_off_str[5] = {
+	    0.0,
+	    stave_straight_inner_y/2. + 2. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y/2.,  // top of cooler
+	    - stave_straight_inner_y/2. - 2. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y/2.,  // top of cooler
+	    stave_straight_inner_y/2. + 2. * Rcavge*TMath::Sin( dphic / 2.) + stave_straight_cooler_y/2. + 2. *  Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_end_y/2.,
+	    - stave_straight_inner_y/2. - 2. * Rcavge*TMath::Sin( dphic / 2.) - stave_straight_cooler_y/2. - 2. *  Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_end_y/2.,
+	  };
+
+	  for(int i=0;i<5;i++)
+	    {
+	      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_volume, boost::str(boost::format("stave_straight_%d_%d_%d") 
+													    % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+	      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), staveext_volume, boost::str(boost::format("stave_straight_ext_%d_%d_%s") 
+													       % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+	    }
+	  
+	  // Place the curved sections
+	  // all above x axis, then all below x axis, each in order of increasing y
+	  double frot[8] = {
+	    +TMath::PI/2., 
+	    -TMath::PI/2.,  
+	    - TMath::PI/2. + dphic, 
+	    TMath::PI.
+	    +TMath::PI/2., 
+	    -TMath::PI/2.,  
+	    - TMath::PI/2. + dphic, 
+	    TMath::PI.
+	  };
+	  double x_off_curve[8] = {
+	    Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
+	    Rcavge*TMath::Cos(dphic / 2.), 
+	    Rcavge*TMath::Cos(dphic / 2.), 
+	    Rcavge - Rcavge*TMath::Cos(dphic / 2.) 
+	    Rcavge - Rcavge*TMath::Cos(dphic / 2.), 
+	    Rcavge*TMath::Cos(dphic / 2.), 
+	    Rcavge*TMath::Cos(dphic / 2.), 
+	    Rcavge - Rcavge*TMath::Cos(dphic / 2.) 
+	  };
+	  double y_off_curve[8] = {
+	    stave_straight_inner_y / 2. + Rcavge*TMath::Sin( dphic / 2.),  
+	    stave_straight_inner_y / 2. + 2. * Rcavge*TMath::Sin( dphic / 2. ) + Rcavge*TMath::Sin(dphic / 2.),  
+	    stave_straight_inner_y / 2. + 4. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y + Rcavge*TMath::Sin(dphic / 2.),  
+	    stave_straight_inner_y / 2. + 6. * Rcavge*TMath::Sin( dphic / 2. ) + stave_straight_cooler_y + Rcavge*TMath::Sin(dphic / 2.),  
+	    - stave_straight_inner_y / 2. - 6. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y - Rcavge*TMath::Sin(dphic / 2.),  
+	    - stave_straight_inner_y / 2. - 4. * Rcavge*TMath::Sin( dphic / 2. ) - stave_straight_cooler_y - Rcavge*TMath::Sin(dphic / 2.),  
+	    - stave_straight_inner_y / 2. - 2. * Rcavge*TMath::Sin( dphic / 2. ) - Rcavge*TMath::Sin(dphic / 2.),  
+	    - stave_straight_inner_y / 2. - Rcavge*TMath::Sin( dphic / 2.),  
+	  };
+
+	  for(int i=0;i<8;i++)
+	    {
+	      new G4PVPlacement(frot[i], G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_volume, boost::str(boost::format("stave_curve_%d_%d_%d") 
+														      % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+	      new G4PVPlacement(frot[i], G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), staveext_volume, boost::str(boost::format("stave_curve_ext_%d_%d_%s") 
+														     % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+	    }
+	}
+      
+
+      // ----- Step 2 ------------------------------------------------------------------------------------
+      // We place Si-sensor, FPHX, HDI, PGS sheet, and stave in the ladder  volume.
+      // ======================================================
+
+      // Make the ladder volume first
+        
+      const double ladder_x = stave_x  + pgs_x  + hdi_x  + fphx_x;
       const double ladder_y = hdi_y;
       const double ladder_z = hdi_z;
-      G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x, ladder_y / 2., ladder_z);
+      G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., ladder_z / 2.);
       G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
         absorberlogvols.insert(ladder_volume);
       }
-      G4VSolid *ladderext_box = new G4Box(boost::str(boost::format("ladderext_box_%d_%s") % sphxlayer % itype).c_str(), ladder_x, ladder_y / 2., hdiext_z);
+      G4VSolid *ladderext_box = new G4Box(boost::str(boost::format("ladderext_box_%d_%s") % sphxlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., hdiext_z / 2.);
       G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladderext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
       if ((IsAbsorberActive.find(inttlayer))->second > 0)
       {
@@ -333,67 +520,67 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       ladder_vis->SetColour(G4Colour::Cyan());
       ladder_volume->SetVisAttributes(ladder_vis);
 
-      /*----- Step 2 -----
-         * We place Si-sensor, FPHX, HDI, PGS sheet, and stave at the ladder
-         volume.
-         -----*/
+      // Now add the components of the ladder
+      // start from where?
 
-      /*
-         * Carbon stave
-         */
-      const double TVstave_x = -ladder_x + stave_x / 2.;
+      // Carbon stave        
+      const double TVstave_x = -ladder_x / 2. + stave_x / 2.;
       new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), stave_volume, boost::str(boost::format("stave_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
       new G4PVPlacement(0, G4ThreeVector(TVstave_x, 0.0, 0.0), staveext_volume, boost::str(boost::format("staveext_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
-      /*
-         * PGS
-         */
+      // PGS
+        
       const double TVpgs_x = TVstave_x + stave_x / 2. + pgs_x / 2.;
       new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgs_volume, boost::str(boost::format("pgs_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
       new G4PVPlacement(0, G4ThreeVector(TVpgs_x, 0.0, 0.0), pgsext_volume, boost::str(boost::format("pgsext_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
-      /*
-         * HDI
-         */
+      // HDI
+        
       const double TVhdi_x = TVpgs_x + pgs_x / 2. + hdi_x / 2.;
       new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdi_volume, boost::str(boost::format("hdi_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
       new G4PVPlacement(0, G4ThreeVector(TVhdi_x, 0.0, 0.0), hdiext_volume, boost::str(boost::format("hdiext_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
-      /*
-         * Si-sensor
-         */
+      // Si-sensor
+        
       const double TVSi_x = TVhdi_x + hdi_x / 2. + siactive_x / 2.;
       new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siinactive_volume, boost::str(boost::format("siinactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
       new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siactive_volume, boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
-      /*
-         * FPHX
-         */
+      // FPHX
+        
       const double TVfphx_x = TVhdi_x + hdi_x / 2. + fphx_x / 2.;
       const double TVfphx_y = sifull_y + gap_sensor_fphx + fphx_y / 2.;
       new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-
       new G4PVPlacement(0, G4ThreeVector(TVfphx_x, -TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerm_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
-      /*----- Step 3 -----
-         * We make cylinder volume in each layer and then install the silicon
-         ladders
-         -----*/
+      // ----- Step 3 ----------------------------------------------------------------------------------
+      // We make a cylinder volume in each layer and then install the silicon ladders
+      //======================================================
 
-      /*
-         * Ladder
-         */
+      // Distribute Ladders in phi
+      // The ladders have no tilt in the new design,  the ladders are alternately offset in radius to get overlap in phi        
+
+      // radius values are for the center of the sensor, we need the offset from center of ladder to center of sensor
+      double sensor_offset = 0.0 - TVSi_x; // ladder center is at 0.0 by construction
+
       const double dphi = 2 * M_PI / nladders_layer;
-      eff_radius[ilayer] = radius + ladder_x - 2. * (fphx_x / 2. - strip_x / 2.);
+
+      // need to fix this - there is no single radius for a layer!
+      // problem is what to write to geom object
+      //eff_radius[ilayer] = radius + ladder_x - 2. * (fphx_x / 2. - strip_x / 2.);
       posz[ilayer][itype] = (itype == 0) ? hdi_z : 2. * hdi_z_[ilayer][0] + hdi_z;
       strip_x_offset[ilayer] = ladder_x - 2. * (fphx_x / 2. - strip_x / 2.) - strip_x / 2.;
 
       for (G4int icopy = 0; icopy < nladders_layer; icopy++)
       {
         const double phi = offsetphi + dphi * (double) icopy;
-        const double posx = eff_radius[ilayer] * cos(phi);
-        const double posy = eff_radius[ilayer] * sin(phi);
-        const double fRotate = phi + offsetrot + M_PI;
+	double radius = layer_radius_inner;
+	if(icopy%2)
+	  radius = layer_radius_outer;
+	radius += sensor_offset;
+        const double posx = radius * cos(phi);
+        const double posy = radius * sin(phi);
+        const double fRotate = phi + offsetrot + M_PI;   // starts with a rotation of 180 deg 
 
         G4RotationMatrix *ladderrotation = new G4RotationMatrix();
         ladderrotation->rotateZ(-fRotate);
@@ -507,7 +694,7 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
           params->get_double_param("strip_z_1"),
           params->get_int_param("nstrips_z_sensor_0"),
           params->get_int_param("nstrips_z_sensor_1"),
-          params->get_int_param("nstrips_phi_cell"),
+          params->get_int_param("nstrips_phi_sensor"),
           params->get_int_param("nladder"),
           posz[ilayer][0] / cm,
           posz[ilayer][1] / cm,

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -672,7 +672,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	    }
 
 	  G4VisAttributes *ladder_vis = new G4VisAttributes();
-	  ladder_vis->SetVisibility(false);
+	  ladder_vis->SetVisibility(true);
 	  ladder_vis->SetForceSolid(false);
 	  ladder_vis->SetColour(G4Colour::Cyan());
 	  ladder_volume->SetVisAttributes(ladder_vis);
@@ -681,7 +681,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  // Now add the components of the ladder to the ladder volume
 	  // The sensor is closest to the beam pipe, the stave cooler is furthest away
 	  // Note that the cooler has been assembled in the stave volume with the top at larger x, so the sensor will be at smaller x
-	  // That will be the configuration when the ladder is at phi = 180 degrees, the positive x direction
+	  // That will be the configuration when the ladder is at phi = 0 degrees, the positive x direction
 	  // So we start at the most positive x value and add the stave first
 
 	  // Carbon stave        
@@ -714,7 +714,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, sensor_offset_y, 0.0), siactive_volume, boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
 	  // FPHX        
-	  const double TVfphx_x = TVSi_x - TVSi_x / 2. - fphx_x / 2.;
+	  const double TVfphx_x = TVhdi_x - hdi_x / 2. - fphx_x / 2.;
 	  const double TVfphx_y = sifull_y / 2. + gap_sensor_fphx - sensor_offset_y + fphx_y / 2.;
 	  cout << "Place fphxcontainer in ladder with TVfph_x " << TVfphx_x << " TVfphx_y " << TVfphx_y << " z  0"<< endl;
 	  // laddertype 0 has only one FPHX, and the sensor is offset in y
@@ -731,16 +731,16 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  //  at all ladder phi values, and at both positive and negative Z values.
 
 	  // The ladders have no tilt in the new design, they are alternately offset in radius to get overlap in phi        
-	  // radius values are for the center of the sensor, we need the offset from center of ladder to center of sensor
-	  double sensor_offset = 0.0 - TVSi_x; // ladder center is at 0.0 by construction
+	  // given radius values are for the center of the sensor, we need the offset from center of ladder to center of sensor so we can place the ladder
+	  double sensor_offset_ladder = 0.0 - TVSi_x; // ladder center is at 0.0 by construction
 
 	  const double dphi = 2 * TMath::Pi() / nladders_layer;
 
 	  // there is no single radius for a layer
-	  eff_radius[ilayer] = layer_radius_inner + sensor_offset;
-	  eff_radius_alternate[ilayer] = layer_radius_outer + sensor_offset;
+	  eff_radius[ilayer] = layer_radius_inner + sensor_offset_ladder;
+	  eff_radius_alternate[ilayer] = layer_radius_outer + sensor_offset_ladder;
 	  posz[ilayer][itype] = (itype == 0) ? hdi_z / 2. : hdi_z_[ilayer][0] + hdi_z / 2.; // location of center of ladder in Z
-	  strip_x_offset[ilayer] = sensor_offset;
+	  strip_x_offset[ilayer] = sensor_offset_ladder;
 
 	  for (G4int icopy = 0; icopy < nladders_layer; icopy++)
 	    {
@@ -763,7 +763,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	
 	      if (itype != 0)
 		{  
-		  // The HDI extension tab has to be added for the outer sensor
+		  // We have added the outer sensor above, now we add the HDI extension tab to the end of the outer sensor HDI
 		  const G4double posz_ext = (hdi_z_[ilayer][0] + hdi_z) + hdiext_z / 2.;
 		  new G4PVPlacement(ladderrotation, G4ThreeVector(posx, posy, -posz_ext), ladderext_volume, boost::str(boost::format("ladderext_%d_%d_%d_%d") 
 														       % sphxlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
@@ -773,7 +773,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 		}
 
 	      cout << "Ladder copy " << icopy << " radius " << radius << " phi " << phi << " itype " << itype << " posz " << posz[ilayer][itype] 
-		   << " fRotate " << fRotate << " posx " << posx << " posy " << posy << " sensor_offset " << sensor_offset 
+		   << " fRotate " << fRotate << " posx " << posx << " posy " << posy << " sensor_offset_ladder " << sensor_offset_ladder 
 		   << endl;
 
 	    } // end loop over ladder copy placement in phi and positive and negative Z

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -69,10 +69,10 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   std::string detector_type;
   std::string superdetector;
 
-  G4double layer_radius_inner[4];
-  G4double layer_radius_outer[4];
-  G4double eff_radius[4];
-  G4double eff_radius_alternate[4];
+  G4double sensor_radius_inner[4];
+  G4double sensor_radius_outer[4];
+  G4double ladder_radius_inner[4];
+  G4double ladder_radius_outer[4];
   G4double posz[4][2];
   G4double strip_x_offset[4];
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -69,6 +69,8 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   std::string detector_type;
   std::string superdetector;
 
+  G4double layer_radius_inner[4];
+  G4double layer_radius_outer[4];
   G4double eff_radius[4];
   G4double eff_radius_alternate[4];
   G4double posz[4][2];

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -70,6 +70,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   std::string superdetector;
 
   G4double eff_radius[4];
+  G4double eff_radius_alternate[4];
   G4double posz[4][2];
   G4double strip_x_offset[4];
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerParameterisation.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerParameterisation.cc
@@ -16,7 +16,7 @@ PHG4SiliconTrackerStripParameterisation::PHG4SiliconTrackerStripParameterisation
       fYStrip[icopy] = (iy + 0.5) * dy - offsety;
       fZStrip[icopy] = (iz + 0.5) * dz - offsetz;
 
-
+      /*
 	std::cout << "      icopy " << icopy
 		  << " iy " << iy << " iz " << iz
 		  << " offsety " << offsety
@@ -25,7 +25,8 @@ PHG4SiliconTrackerStripParameterisation::PHG4SiliconTrackerStripParameterisation
 		  << " fYStrip[icopy] " << fYStrip[icopy]
 		  << " fZStrip[icopy] " << fZStrip[icopy]
 		  << std::endl;
-     
+      */
+
       icopy++;
     }
 }
@@ -44,7 +45,7 @@ PHG4SiliconTrackerFPHXParameterisation::PHG4SiliconTrackerFPHXParameterisation(c
     fXFPHX[icopy] = offsetx;
     fYFPHX[icopy] = offsety;
     fZFPHX[icopy] = offsetz + icopy * dz;
-
+    /*
     std::cout << "      icopy " << icopy
 	      << " offsety " << offsety
 	      << " offsetz " << offsetz
@@ -53,7 +54,7 @@ PHG4SiliconTrackerFPHXParameterisation::PHG4SiliconTrackerFPHXParameterisation(c
 	      << " fYFPHX[icopy] " << fYFPHX[icopy]
 	      << " fZFPHX[icopy] " << fZFPHX[icopy]
 	      << std::endl;
-    
+    */
   }
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerParameterisation.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerParameterisation.cc
@@ -7,7 +7,7 @@ PHG4SiliconTrackerStripParameterisation::PHG4SiliconTrackerStripParameterisation
 {
   const double offsety = ny * dy * 0.5;
   const double offsetz = nz * dz * 0.5;
-
+ 
   int icopy = 0;
   for (unsigned int iy = 0; iy < ny; iy++)
     for (unsigned int iz = 0; iz < nz; iz++)
@@ -16,7 +16,7 @@ PHG4SiliconTrackerStripParameterisation::PHG4SiliconTrackerStripParameterisation
       fYStrip[icopy] = (iy + 0.5) * dy - offsety;
       fZStrip[icopy] = (iz + 0.5) * dz - offsetz;
 
-      if(icopy < 5)
+
 	std::cout << "      icopy " << icopy
 		  << " iy " << iy << " iz " << iz
 		  << " offsety " << offsety
@@ -44,6 +44,16 @@ PHG4SiliconTrackerFPHXParameterisation::PHG4SiliconTrackerFPHXParameterisation(c
     fXFPHX[icopy] = offsetx;
     fYFPHX[icopy] = offsety;
     fZFPHX[icopy] = offsetz + icopy * dz;
+
+    std::cout << "      icopy " << icopy
+	      << " offsety " << offsety
+	      << " offsetz " << offsetz
+	      << " dz " << dz
+	      << " fXFPHX[icopy] " << fXFPHX[icopy]
+	      << " fYFPHX[icopy] " << fYFPHX[icopy]
+	      << " fZFPHX[icopy] " << fZFPHX[icopy]
+	      << std::endl;
+    
   }
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerParameterisation.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerParameterisation.cc
@@ -16,7 +16,7 @@ PHG4SiliconTrackerStripParameterisation::PHG4SiliconTrackerStripParameterisation
       fYStrip[icopy] = (iy + 0.5) * dy - offsety;
       fZStrip[icopy] = (iz + 0.5) * dz - offsetz;
 
-      /*
+      if(icopy < 5)
 	std::cout << "      icopy " << icopy
 		  << " iy " << iy << " iz " << iz
 		  << " offsety " << offsety
@@ -25,8 +25,7 @@ PHG4SiliconTrackerStripParameterisation::PHG4SiliconTrackerStripParameterisation
 		  << " fYStrip[icopy] " << fYStrip[icopy]
 		  << " fZStrip[icopy] " << fZStrip[icopy]
 		  << std::endl;
-	*/
-
+     
       icopy++;
     }
 }

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -120,6 +120,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
   int inttlayer = 0;
   int ladderz = 0;
   int ladderphi = 0;
+  int zposneg = 0;
   int strip_z_index = 0;
   int strip_y_index = 0;
 
@@ -148,6 +149,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       inttlayer = boost::lexical_cast<int>(*(++tokeniter));
       ladderz = boost::lexical_cast<int>(*(++tokeniter));  // inner sensor itype = 0, outer sensor itype = 1
       ladderphi = boost::lexical_cast<int>(*(++tokeniter));  // copy number in phi
+      zposneg =  boost::lexical_cast<int>(*(++tokeniter));  // 1 for negative z, 2 for positive z
     }
     else
     {
@@ -166,8 +168,6 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     {
       return false;
     }
-    // convert ladder type [0-3] to silicon sensor type [0-1]
-    //const int laddertype = (ladderz == 1 || ladderz == 2) ? 0 : 1;
 
     // Find the strip y and z index values from the copy number (integer division, quotient is strip_y, remainder is strip_z)
     div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor[laddertype[inttlayer]][ladderz]);
@@ -177,8 +177,8 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     G4ThreeVector prepos = prePoint->GetPosition();
     G4ThreeVector postpos = postPoint->GetPosition();
 
-    if(Verbosity() > -1)
-      cout << " sphxlayer " << sphxlayer << " ladderz " << ladderz << " ladderphi " << ladderphi 
+    //if(Verbosity() > -1)
+    cout << " sphxlayer " << sphxlayer << " ladderz " << ladderz << " ladderphi " << ladderphi << " zposneg " << zposneg
 	   << " copy no. " <<  volume->GetCopyNo() << " nstrips_z_sensor " <<  nstrips_z_sensor[laddertype[inttlayer]][ladderz] 
 	   << " strip_y_index " << strip_y_index << " strip_z_index " << strip_z_index << endl;
     
@@ -351,6 +351,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     hit->set_layer((unsigned int) sphxlayer);
 
     // set the index values needed to locate the sensor strip
+    if(zposneg == 2) ladderz += 2;  // ladderz = 0, 1 for negative z and = 2, 3 for positive z
     hit->set_ladder_z_index(ladderz);
     if (whichactive > 0)
     {
@@ -363,6 +364,11 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     hit->set_x(0, prePoint->GetPosition().x() / cm);
     hit->set_y(0, prePoint->GetPosition().y() / cm);
     hit->set_z(0, prePoint->GetPosition().z() / cm);
+
+    cout << "     hit position x,y,z = " << prePoint->GetPosition().x() / cm
+    << "    " << prePoint->GetPosition().y() / cm
+    << "     " << prePoint->GetPosition().z() / cm
+    << endl;
 
     hit->set_px(0, prePoint->GetMomentum().x() / GeV);
     hit->set_py(0, prePoint->GetMomentum().y() / GeV);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -126,7 +126,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
 
   if (whichactive > 0)  // silicon acrive sensor
   {
-    if (Verbosity() > -1)
+    if (Verbosity() > 0)
     {
       cout << endl
            << "PHG4SilicoTrackerSteppingAction::UserSteppingAction for volume name (pre) " << touch->GetVolume()->GetName()
@@ -177,8 +177,9 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     G4ThreeVector prepos = prePoint->GetPosition();
     G4ThreeVector postpos = postPoint->GetPosition();
 
-    //if(Verbosity() > -1)
-    cout << " sphxlayer " << sphxlayer << " ladderz " << ladderz << " ladderphi " << ladderphi << " zposneg " << zposneg
+    if(Verbosity() > 0)
+      cout << " sphxlayer " << sphxlayer << " inttlayer " << inttlayer << " ladderz " << ladderz << " ladderphi " << ladderphi 
+	   << " zposneg " << zposneg
 	   << " copy no. " <<  volume->GetCopyNo() << " nstrips_z_sensor " <<  nstrips_z_sensor[laddertype[inttlayer]][ladderz] 
 	   << " strip_y_index " << strip_y_index << " strip_z_index " << strip_z_index << endl;
     
@@ -365,10 +366,12 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     hit->set_y(0, prePoint->GetPosition().y() / cm);
     hit->set_z(0, prePoint->GetPosition().z() / cm);
 
+    /*
     cout << "     hit position x,y,z = " << prePoint->GetPosition().x() / cm
     << "    " << prePoint->GetPosition().y() / cm
     << "     " << prePoint->GetPosition().z() / cm
     << endl;
+    */
 
     hit->set_px(0, prePoint->GetMomentum().x() / GeV);
     hit->set_py(0, prePoint->GetMomentum().y() / GeV);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -53,18 +53,26 @@ PHG4SiliconTrackerSteppingAction::PHG4SiliconTrackerSteppingAction(PHG4SiliconTr
   , saveshower(nullptr)
   , paramscontainer(parameters)
 {
+  // loop over layers to get laddertype for each layer
   PHParametersContainer::ConstRange begin_end = paramscontainer->GetAllParameters();
   for (PHParametersContainer::ConstIterator iter = begin_end.first; iter != begin_end.second; ++iter)
   {
     PHParameters* par = iter->second;
     IsActive[iter->first] = par->get_int_param("active");
     IsBlackHole[iter->first] = par->get_int_param("blackhole");
-    strip_y[iter->first] = par->get_double_param("strip_y") * cm;
-    strip_z[iter->first][0] = par->get_double_param("strip_z_0") * cm;
-    strip_z[iter->first][1] = par->get_double_param("strip_z_1") * cm;
-    nstrips_z_sensor[iter->first][0] = par->get_int_param("nstrips_z_sensor_0");
-    nstrips_z_sensor[iter->first][1] = par->get_int_param("nstrips_z_sensor_1");
-    nstrips_phi_cell[iter->first] = par->get_int_param("nstrips_phi_cell");
+    laddertype[iter->first] = par->get_int_param("laddertype");
+  }
+
+  // Get the parameters for each laddertype
+  for(int laddertype=0;laddertype<2;laddertype++)
+    {
+      const PHParameters *par = paramscontainer->GetParameters(laddertype);
+      strip_y[laddertype] = par->get_double_param("strip_y") * cm;
+      strip_z[laddertype][0] = par->get_double_param("strip_z_0") * cm;
+      strip_z[laddertype][1] = par->get_double_param("strip_z_1") * cm;
+      nstrips_z_sensor[laddertype][0] = par->get_int_param("nstrips_z_sensor_0");
+      nstrips_z_sensor[laddertype][1] = par->get_int_param("nstrips_z_sensor_1");
+      nstrips_phi_cell[laddertype] = par->get_int_param("nstrips_phi_cell");
   }
   AbsorberIndex["ladder"] = -1;
   AbsorberIndex["stave"] = -2;
@@ -117,7 +125,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
 
   if (whichactive > 0)  // silicon acrive sensor
   {
-    if (Verbosity() > 1)
+    if (Verbosity() > -1)
     {
       cout << endl
            << "PHG4SilicoTrackerSteppingAction::UserSteppingAction for volume name (pre) " << touch->GetVolume()->GetName()
@@ -138,15 +146,15 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       // advance the tokeniter and then cast it if first token is "ladder"
       sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
       inttlayer = boost::lexical_cast<int>(*(++tokeniter));
-      ladderz = boost::lexical_cast<int>(*(++tokeniter));
-      ladderphi = boost::lexical_cast<int>(*(++tokeniter));
+      ladderz = boost::lexical_cast<int>(*(++tokeniter));  // inner sensor itype = 0, outer sensor itype = 1
+      ladderphi = boost::lexical_cast<int>(*(++tokeniter));  // copy number in phi
     }
     else
     {
       cout << GetName() << "parsing of " << touch->GetVolume(2)->GetName() << " failed, it does not start with ladder_" << endl;
       exit(1);
     }
-    if (inttlayer < 0 || inttlayer >= 4)
+    if (inttlayer < 0 || inttlayer > 3)
       assert(!"PHG4SiliconTrackerSteppingAction: check INTT ladder layer.");
     map<int, int>::const_iterator activeiter = IsActive.find(inttlayer);
     if (activeiter == IsActive.end())
@@ -159,19 +167,19 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       return false;
     }
     // convert ladder type [0-3] to silicon sensor type [0-1]
-    const int laddertype = (ladderz == 1 || ladderz == 2) ? 0 : 1;
+    //const int laddertype = (ladderz == 1 || ladderz == 2) ? 0 : 1;
 
     // Find the strip y and z index values from the copy number (integer division, quotient is strip_y, remainder is strip_z)
-    div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor[inttlayer][laddertype]);
+    div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor[laddertype[inttlayer]][ladderz]);
     strip_y_index = copydiv.quot;
     strip_z_index = copydiv.rem;
     G4ThreeVector strip_pos = volume->GetTranslation();
     G4ThreeVector prepos = prePoint->GetPosition();
     G4ThreeVector postpos = postPoint->GetPosition();
 
-    if(Verbosity() > 1)
+    if(Verbosity() > -1)
       cout << " sphxlayer " << sphxlayer << " ladderz " << ladderz << " ladderphi " << ladderphi 
-	   << " copy no. " <<  volume->GetCopyNo() << " nstrips_z_sensor " <<  nstrips_z_sensor[inttlayer][laddertype] 
+	   << " copy no. " <<  volume->GetCopyNo() << " nstrips_z_sensor " <<  nstrips_z_sensor[laddertype[inttlayer]][ladderz] 
 	   << " strip_y_index " << strip_y_index << " strip_z_index " << strip_z_index << endl;
     
     // There are two failure modes observed for this stupid parameterised volume:
@@ -216,10 +224,10 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
 	G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
 	
 	strip_z_index = 0;
-	for (int i = 0; i < nstrips_z_sensor[inttlayer][laddertype]; ++i)
+	for (int i = 0; i < nstrips_z_sensor[laddertype[inttlayer]][ladderz]; ++i)
           {
-            const double zmin = strip_z[inttlayer][laddertype] * (double) (i) -strip_z[inttlayer][laddertype] / 2. * (double) nstrips_z_sensor[inttlayer][laddertype];
-            const double zmax = strip_z[inttlayer][laddertype] * (double) (i + 1) - strip_z[inttlayer][laddertype] / 2. * (double) nstrips_z_sensor[inttlayer][laddertype];
+            const double zmin = strip_z[laddertype[inttlayer]][ladderz] * (double) (i) -strip_z[laddertype[inttlayer]][ladderz] / 2. * (double) nstrips_z_sensor[laddertype[inttlayer]][ladderz];
+            const double zmax = strip_z[laddertype[inttlayer]][ladderz] * (double) (i + 1) - strip_z[laddertype[inttlayer]][ladderz] / 2. * (double) nstrips_z_sensor[laddertype[inttlayer]][ladderz];
             if (strip_pos.z() / mm > zmin && strip_pos.z() / mm <= zmax)
 	      {
 		strip_z_index = i;
@@ -229,10 +237,10 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
           }
 	
 	strip_y_index = 0;
-	for (int i = 0; i < 2 * nstrips_phi_cell[inttlayer]; ++i)
+	for (int i = 0; i < 2 * nstrips_phi_cell[laddertype[inttlayer]]; ++i)
           {
-            const double ymin = strip_y[inttlayer] * (double) (i) -strip_y[inttlayer] * (double) nstrips_phi_cell[inttlayer];
-            const double ymax = strip_y[inttlayer] * (double) (i + 1) - strip_y[inttlayer] * (double) nstrips_phi_cell[inttlayer];
+            const double ymin = strip_y[laddertype[inttlayer]] * (double) (i) -strip_y[laddertype[inttlayer]] * (double) nstrips_phi_cell[laddertype[inttlayer]];
+            const double ymax = strip_y[laddertype[inttlayer]] * (double) (i + 1) - strip_y[laddertype[inttlayer]] * (double) nstrips_phi_cell[laddertype[inttlayer]];
             if (strip_pos.y() / mm > ymin && strip_pos.y() / mm <= ymax)
 	      {
 		strip_y_index = i;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -34,10 +34,11 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
   PHG4Shower *saveshower;
   const PHParametersContainer *paramscontainer;
 
-  double strip_y[4];
-  double strip_z[4][2];
-  int nstrips_z_sensor[4][2];
-  int nstrips_phi_cell[4];
+  int laddertype[4];
+  double strip_y[2];
+  double strip_z[2][2];
+  int nstrips_z_sensor[2][2];
+  int nstrips_phi_cell[2];
   std::map<int, int> IsActive;
   std::map<int, int> IsBlackHole;
   std::map<std::string, int> AbsorberIndex;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -32,12 +32,53 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &dete
     AddDetId((*piter).second);
   }
 
+  // set the default sensor radii to the current design
+  double sensor_radius_inner_[4] = {6.876, 8.987, 10.835, 12.676};
+  double sensor_radius_outer_[4] = {7.462, 9.545, 11.361, 13.179};
+  for(int i=0;i<nlayers;i++)
+    {
+      sensor_radius_inner[i] = sensor_radius_inner_[i];
+      sensor_radius_outer[i] = sensor_radius_outer_[i];
+    }
+
   InitializeParameters();
   // put the layer into the name so we get unique names
   // for multiple layers
   Name(detectorname);
   SuperDetector(detectorname);
 }
+
+
+//_______________________________________________________________________
+PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const double sensor_radius_inner_[], const double sensor_radius_outer_[], const std::string &detectorname, const vpair &layerconfig)
+   : PHG4DetectorGroupSubsystem(detectorname)
+  , detector_(0)
+  , steppingAction_(nullptr)
+  , layerconfig_(layerconfig)
+  , detector_type(detectorname)
+{
+  // This constructor is an ugly way to get around a problem with the parameter class - it can be removed once that is fixed
+  nlayers = 0;
+  for (vector<pair<int, int>>::const_iterator piter = layerconfig.begin(); piter != layerconfig.end(); ++piter)
+  {
+    if(verbosity > 1) cout << PHWHERE << " adding INTT layer " << (*piter).second << endl;
+    nlayers++;
+    AddDetId((*piter).second);
+  }
+
+  for(int i=0;i<nlayers;i++)
+    {
+      sensor_radius_inner[i] = sensor_radius_inner_[i];
+      sensor_radius_outer[i] = sensor_radius_outer_[i];
+    }
+
+  InitializeParameters();
+  // put the layer into the name so we get unique names
+  // for multiple layers
+  Name(detectorname);
+  SuperDetector(detectorname);
+}
+
 
 //_______________________________________________________________________
 int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
@@ -149,15 +190,13 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   double stave_straight_outer_y[2] = {0.672, 0.522};
   double stave_straight_inner_y[2] = {0.1, 0.344};  // the first value is a dummy, not used, to avoid issues with making a G4Logical;Volume with y = 0
   double stave_straight_cooler_y[2] = {0.47, 0.47};
-  //double sensor_offset_y[2] = {0.295, 0.0};
   double sensor_offset_y[2] = {0.304, 0.0};
 
   // We do not want to hard code the ladder types for the layers
   // We define default ladder types for 4 layers, but these can be changed at the macro level
   int laddertype[4] = {0, 1, 1, 1};
   int nladder[4] = {34, 30, 36, 42};
-  double sensor_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};
-  double sensor_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};
+  // sensor radius_inner and sensor_radius_outer are set in the constructor for now, to avoid a problem with the parameter class
 
   for(int i=0;i<nlayers;i++)
     {
@@ -166,7 +205,9 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
       set_default_int_param(i, "nladder", nladder[i]);  // ladders per layer
       set_default_double_param(i, "sensor_radius_inner", sensor_radius_inner[i]*cm);
       set_default_double_param(i, "sensor_radius_outer", sensor_radius_outer[i]*cm);
-
+      cout << " PHG4SiliconTrackerSubsystem setting default parameters to: " << endl;
+      cout << "  layer " << i << " laddertype " << laddertype[i] << " nladder " << nladder[i] 
+	   << " sensor_radius_inner " << sensor_radius_inner[i] << " sensor_radius_outer " << sensor_radius_outer[i] << endl;
       // These should be kept at zero in the new design
       set_default_double_param(i, "offsetphi", 0.);
       set_default_double_param(i, "offsetrot", 0.);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -149,7 +149,8 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   double stave_straight_outer_y[2] = {0.672, 0.522};
   double stave_straight_inner_y[2] = {0.1, 0.344};  // the first value is a dummy, not used, to avoid issues with making a G4Logical;Volume with y = 0
   double stave_straight_cooler_y[2] = {0.47, 0.47};
-  double sensor_offset_y[2] = {0.295, 0.0};
+  //double sensor_offset_y[2] = {0.295, 0.0};
+  double sensor_offset_y[2] = {0.304, 0.0};
 
   // We do not want to hard code the ladder types for the layers
   // We define default ladder types for 4 layers, but these can be changed at the macro level

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -205,9 +205,9 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
       set_default_int_param(i, "nladder", nladder[i]);  // ladders per layer
       set_default_double_param(i, "sensor_radius_inner", sensor_radius_inner[i]*cm);
       set_default_double_param(i, "sensor_radius_outer", sensor_radius_outer[i]*cm);
-      cout << " PHG4SiliconTrackerSubsystem setting default parameters to: " << endl;
-      cout << "  layer " << i << " laddertype " << laddertype[i] << " nladder " << nladder[i] 
-	   << " sensor_radius_inner " << sensor_radius_inner[i] << " sensor_radius_outer " << sensor_radius_outer[i] << endl;
+      //cout << " PHG4SiliconTrackerSubsystem setting default parameters to: " << endl;
+      //cout << "  layer " << i << " laddertype " << laddertype[i] << " nladder " << nladder[i] 
+      //   << " sensor_radius_inner " << sensor_radius_inner[i] << " sensor_radius_outer " << sensor_radius_outer[i] << endl;
       // These should be kept at zero in the new design
       set_default_double_param(i, "offsetphi", 0.);
       set_default_double_param(i, "offsetrot", 0.);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -156,19 +156,16 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   // We define default ladder types for 4 layers, but these can be changed at the macro level
   int laddertype[4] = {0, 1, 1, 1};
   int nladder[4] = {34, 30, 36, 42};
-  double ladder_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};
-  double ladder_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};
+  double sensor_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};
+  double sensor_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};
 
   for(int i=0;i<nlayers;i++)
     {
-      cout << " default radius values in mm are:  " << " ladder_radius_inner " << ladder_radius_inner[i]*cm 
-	   << " ladder_radius_outer " << ladder_radius_outer[i]*cm  << endl; 
-
       // To reconfigure the layers, all you have to do is overide the defaults for these four arrays from the tracking macro
       set_default_int_param(i, "laddertype", laddertype[i]);
       set_default_int_param(i, "nladder", nladder[i]);  // ladders per layer
-      set_default_double_param(i, "ladder_radius_inner", ladder_radius_inner[i]*cm);
-      set_default_double_param(i, "ladder_radius_outer", ladder_radius_outer[i]*cm);
+      set_default_double_param(i, "sensor_radius_inner", sensor_radius_inner[i]*cm);
+      set_default_double_param(i, "sensor_radius_outer", sensor_radius_outer[i]*cm);
 
       // These should be kept at zero in the new design
       set_default_double_param(i, "offsetphi", 0.);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -132,6 +132,69 @@ PHG4Detector *PHG4SiliconTrackerSubsystem::GetDetector(void) const
 
 void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
 {
+  // We have only two types of ladders, one with vertical strips (0) and one with horizontal strips (1)
+  // There are 4 sensors in each ladder
+  //     In ladder type 0 the sensor is special and inner and outer sensors are the same. 
+  //     In ladder type 1 there are two different sensor types, inner and outer 
+
+  // We define default parameters for laddertype 0 or 1
+  int nstrips_phi_sensor[2] = {1, 128};  
+  int nstrips_z_sensor_0[2] = {128*5, 8};  // inner sensor  
+  int nstrips_z_sensor_1[2] = {128*5, 5};  // outer sensor
+  double strip_y[2] = {1.6, 0.0070};
+  double strip_z_0[2] = {0.01406, 1.6};
+  double strip_z_1[2] = {0.01406, 2.0};
+  double halfladder_z[2] = {24.0, 24.0};
+  double hdi_y[2] = {2.55, 3.8};
+  double stave_straight_outer_y[2] = {0.672, 0.522};
+  double stave_straight_inner_y[2] = {0.0, 0.344};
+  double stave_straight_cooler_y[2] = {0.47, 0.47};
+
+
+  // We do not want to hard code the ladder types for the layers
+  // We define default ladder types for 4 layers, but these can be changed at the macro level
+  int laddertype[4] = {0, 1, 1, 1};
+  int nladder[4] = {34, 30, 36, 42};
+  double ladder_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};
+  double ladder_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};
+  for(int i=0;i<4;i++)
+    {
+      set_default_int_param(i, "laddertype", laddertype[i]);
+      set_default_int_param(i, "nladders", nladder[i]);
+      set_default_double_param(i, "ladder_radius_inner", ladder_radius_inner[i]);
+      set_default_double_param(i, "ladder_radius_outer", ladder_radius_outer[i]);
+    }
+
+
+  // Set the parameters for the two laddertypes. All values in cm!
+  for (int i = 0; i < 2; i++)
+  {
+    set_default_int_param(i, "nstrips_z_sensor_0", nstrips_z_sensor_0[i]);
+    set_default_int_param(i, "nstrips_z_sensor_1", nstrips_z_sensor_1[i]);
+    set_default_int_param(i, "nstrips_phi_sensor", nstrips_phi_sensor[i]);
+
+    set_default_int_param(i, "stave_straight_inner_y", stave_straight_inner_y[i]);
+    set_default_int_param(i, "stave_straight_outer_y", stave_straight_outer_y[i]);
+    set_default_int_param(i, "stave_straight_cooler_y", stave_straight_cooler_y[i]);
+
+    set_default_double_param(i, "strip_y", strip_y[i]);
+    set_default_double_param(i, "strip_z_0", strip_z_0[i]);
+    set_default_double_param(i, "strip_z_1", strip_z_1[i]);
+    set_default_double_param(i, "strip_x", 0.032);  // 320 microns deep
+    set_default_double_param(i, "sensor_edge_phi", 0.13);
+    set_default_double_param(i, "sensor_edge_z", 0.10);
+    set_default_double_param(i, "hdi_x", 0.0438);
+    set_default_double_param(i, "hdi_y", hdi_y[i]);
+    set_default_double_param(i, "hdi_edge_z", 0.01);
+    set_default_double_param(i, "fphx_x", 0.032);
+    set_default_double_param(i, "fphx_y", 0.27);
+    set_default_double_param(i, "fphx_z", 0.9);
+    set_default_double_param(i, "gap_sensor_fphx", 0.1);
+    set_default_double_param(i, "pgs_x", 0.02);  // 0.2 mm
+    set_default_double_param(i, "offsetphi", 0.);
+  }
+
+  /*
   int nladder[4] = {20, 26, 32, 38};
   int nstrips_z_sensor_0[4] = {5, 8, 8, 8};
   int nstrips_z_sensor_1[4] = {5, 5, 5, 5};
@@ -171,57 +234,6 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
     set_default_double_param(i, "strip_z_0", strip_z_0[i]);
     set_default_double_param(i, "strip_z_1", strip_z_1[i]);
   }
-
-  /*
-  set_default_int_param(0, "nladder", 22);
-  set_default_int_param(1, "nladder", 26);
-  set_default_int_param(2, "nladder", 32);
-  set_default_int_param(3, "nladder", 38);
-
-  set_default_int_param(0, "nstrips_z_sensor_0", 5);
-  set_default_int_param(1, "nstrips_z_sensor_0", 8);
-  set_default_int_param(2, "nstrips_z_sensor_0", 8);
-  set_default_int_param(3, "nstrips_z_sensor_0", 8);
-
-  set_default_int_param(0, "nstrips_z_sensor_1", 5);
-  set_default_int_param(1, "nstrips_z_sensor_1", 5);
-  set_default_int_param(2, "nstrips_z_sensor_1", 5);
-  set_default_int_param(3, "nstrips_z_sensor_1", 5);
-
-  set_default_double_param(0, "halfladder_z", 22.);
-  set_default_double_param(1, "halfladder_z", 26.8);
-  set_default_double_param(2, "halfladder_z", 26.8);
-  set_default_double_param(3, "halfladder_z", 26.8);
-
-  set_default_double_param(0, "hdi_y", 3.8);
-  set_default_double_param(1, "hdi_y", 4.3);
-  set_default_double_param(2, "hdi_y", 4.3);
-  set_default_double_param(3, "hdi_y", 4.3);
-
-  set_default_double_param(0, "offsetrot", 14.0);
-  set_default_double_param(1, "offsetrot", 14.0);
-  set_default_double_param(2, "offsetrot", 12.0);
-  set_default_double_param(3, "offsetrot", 11.5);
-
-  set_default_double_param(0, "radius", 6.);
-  set_default_double_param(1, "radius", 8.);
-  set_default_double_param(2, "radius", 10.);
-  set_default_double_param(3, "radius", 12.);
-
-  set_default_double_param(0, "strip_y", 0.0078);
-  set_default_double_param(1, "strip_y", 0.0086);
-  set_default_double_param(2, "strip_y", 0.0086);
-  set_default_double_param(3, "strip_y", 0.0086);
-
-  set_default_double_param(0, "strip_z_0", 1.8);
-  set_default_double_param(1, "strip_z_0", 1.6);
-  set_default_double_param(2, "strip_z_0", 1.6);
-  set_default_double_param(3, "strip_z_0", 1.6);
-
-  set_default_double_param(0, "strip_z_1", 1.8);
-  set_default_double_param(1, "strip_z_1", 2.0);
-  set_default_double_param(2, "strip_z_1", 2.0);
-  set_default_double_param(3, "strip_z_1", 2.0);
   */
 
   std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> begin_end = GetDetIds();

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -144,13 +144,12 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   double strip_y[2] = {1.6, 0.0078};
   double strip_z_0[2] = {0.01406, 1.6};
   double strip_z_1[2] = {0.01406, 2.0};
-  double halfladder_z[2] = {24.0, 24.0};
+  double halfladder_z[2] = {48.0, 48.0};
   double hdi_y[2] = {2.55, 3.8};
   double stave_straight_outer_y[2] = {0.672, 0.522};
   double stave_straight_inner_y[2] = {0.1, 0.344};  // the first value is a dummy, not used, to avoid issues with making a G4Logical;Volume with y = 0
   double stave_straight_cooler_y[2] = {0.47, 0.47};
   double sensor_offset_y[2] = {0.295, 0.0};
-
 
   // We do not want to hard code the ladder types for the layers
   // We define default ladder types for 4 layers, but these can be changed at the macro level
@@ -159,20 +158,21 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   double ladder_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};
   double ladder_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};
 
-
-
-  for(int i=0;i<4;i++)
+  for(int i=0;i<nlayers;i++)
     {
-      cout << "radius values in mm are: cm = " << cm << " mm " << mm << " ladder_radius_inner " << ladder_radius_inner[i]*cm << " ladder_radius_outer " << ladder_radius_outer[i]*cm  << endl; 
+      cout << " default radius values in mm are:  " << " ladder_radius_inner " << ladder_radius_inner[i]*cm 
+	   << " ladder_radius_outer " << ladder_radius_outer[i]*cm  << endl; 
+
+      // To reconfigure the layers, all you have to do is overide the defaults for these four arrays from the tracking macro
       set_default_int_param(i, "laddertype", laddertype[i]);
-      set_default_int_param(i, "nladder", nladder[i]);
+      set_default_int_param(i, "nladder", nladder[i]);  // ladders per layer
       set_default_double_param(i, "ladder_radius_inner", ladder_radius_inner[i]*cm);
       set_default_double_param(i, "ladder_radius_outer", ladder_radius_outer[i]*cm);
 
+      // These should be kept at zero in the new design
       set_default_double_param(i, "offsetphi", 0.);
       set_default_double_param(i, "offsetrot", 0.);
     }
-
 
   // Set the parameters for the two laddertypes. All values in cm!
   for (int i = 0; i < 2; i++)
@@ -193,10 +193,11 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
     set_default_double_param(i, "sensor_edge_phi", 0.13*cm);
     set_default_double_param(i, "sensor_edge_z", 0.10*cm);
     set_default_double_param(i, "sensor_offset_y", sensor_offset_y[i]*cm);
-    set_default_double_param(i, "hdi_x", 0.0438*cm);
+    set_default_double_param(i, "hdi_kapton_x", 0.038*cm);
+    set_default_double_param(i, "hdi_copper_x", 0.0052*cm);  // effective width of all copper in ground layers and signal layers
     set_default_double_param(i, "hdi_y", hdi_y[i]*cm);
     set_default_double_param(i, "hdi_edge_z", 0.0*cm);
-    set_default_double_param(i, "fphx_x", 0.1*cm);  // guess for now - fix!!!
+    set_default_double_param(i, "fphx_x", 0.032*cm); 
     set_default_double_param(i, "fphx_y", 0.27*cm);
     set_default_double_param(i, "fphx_z", 0.91*cm);
     set_default_double_param(i, "gap_sensor_fphx", 0.1*cm);
@@ -204,52 +205,11 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
     set_default_double_param(i, "halfladder_z", halfladder_z[i]*cm);
   }
 
-  /*
-  int nladder[4] = {20, 26, 32, 38};
-  int nstrips_z_sensor_0[4] = {5, 8, 8, 8};
-  int nstrips_z_sensor_1[4] = {5, 5, 5, 5};
-  double halfladder_z[4] = {22.0, 26.8, 26.8, 26.8};
-  double hdi_y[4] = {3.8, 4.3, 4.3, 4.3};
-  double offsetrot[4] = {14.0, 14.0, 12.0, 11.5};
-  double radius[4] = {6.0, 8.0, 10.0, 12.0};
-  double strip_y[4] = {0.0078, 0.0086, 0.0086, 0.0086};
-  double strip_z_0[4] = {1.8, 1.6, 1.6, 1.6};
-  double strip_z_1[4] = {1.8, 2.0, 2.0, 2.0};
-
-  // all values in cm!
-  for (int i = 0; i < nlayers; i++)
+  //std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> begin_end = GetDetIds();
+  //for (set<int>::const_iterator it = begin_end.first; it != begin_end.second; ++it)
+  for (int i=0; i < nlayers; ++i)
   {
-    set_default_int_param(i, "nstrips_phi_cell", 128);
-    set_default_double_param(i, "fphx_x", 0.032);
-    set_default_double_param(i, "fphx_y", 0.27);
-    set_default_double_param(i, "fphx_z", 0.9);
-    set_default_double_param(i, "gap_sensor_fphx", 0.1);
-    set_default_double_param(i, "hdi_x", 0.038626);
-    set_default_double_param(i, "hdi_edge_z", 0.01);
-    set_default_double_param(i, "offsetphi", 0.);
-    set_default_double_param(i, "pgs_x", 0.021);
-    set_default_double_param(i, "sensor_edge_phi", 0.1305);
-    set_default_double_param(i, "sensor_edge_z", 0.098);
-    set_default_double_param(i, "stave_x", 0.023);
-    set_default_double_param(i, "strip_x", 0.02);
-
-    set_default_int_param(i, "nladder", nladder[i]);
-    set_default_int_param(i, "nstrips_z_sensor_0", nstrips_z_sensor_0[i]);
-    set_default_int_param(i, "nstrips_z_sensor_1", nstrips_z_sensor_1[i]);
-    set_default_double_param(i, "halfladder_z", halfladder_z[i]);
-    set_default_double_param(i, "hdi_y", hdi_y[i]);
-    set_default_double_param(i, "offsetrot", offsetrot[i]);
-    set_default_double_param(i, "radius", radius[i]);
-    set_default_double_param(i, "strip_y", strip_y[i]);
-    set_default_double_param(i, "strip_z_0", strip_z_0[i]);
-    set_default_double_param(i, "strip_z_1", strip_z_1[i]);
-  }
-  */
-
-  std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> begin_end = GetDetIds();
-  for (set<int>::const_iterator it = begin_end.first; it != begin_end.second; ++it)
-  {
-    set_default_int_param(*it, "active", 1);
+    set_default_int_param(i, "active", 1);
   }
 
   return;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -169,9 +169,12 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   // Set the parameters for the two laddertypes. All values in cm!
   for (int i = 0; i < 2; i++)
   {
+
+
     set_default_int_param(i, "nstrips_z_sensor_0", nstrips_z_sensor_0[i]);
     set_default_int_param(i, "nstrips_z_sensor_1", nstrips_z_sensor_1[i]);
     set_default_int_param(i, "nstrips_phi_sensor", nstrips_phi_sensor[i]);
+    set_default_int_param(i, "nstrips_phi_cell", nstrips_phi_sensor[i]);
 
     set_default_int_param(i, "stave_straight_inner_y", stave_straight_inner_y[i]);
     set_default_int_param(i, "stave_straight_outer_y", stave_straight_outer_y[i]);
@@ -192,6 +195,8 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
     set_default_double_param(i, "gap_sensor_fphx", 0.1);
     set_default_double_param(i, "pgs_x", 0.02);  // 0.2 mm
     set_default_double_param(i, "offsetphi", 0.);
+    set_default_double_param(i, "halfladder_z", halfladder_z[i]);
+
   }
 
   /*

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -137,18 +137,19 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   //     In ladder type 0 the sensor is special and inner and outer sensors are the same. 
   //     In ladder type 1 there are two different sensor types, inner and outer 
 
-  // We define default parameters for laddertype 0 or 1
-  int nstrips_phi_sensor[2] = {1, 128};  
+  // We define default parameters for laddertype 0 or 1, all dimensions in cm
+  int nstrips_phi_sensor[2] = {1, 256};  
   int nstrips_z_sensor_0[2] = {128*5, 8};  // inner sensor  
   int nstrips_z_sensor_1[2] = {128*5, 5};  // outer sensor
-  double strip_y[2] = {1.6, 0.0070};
+  double strip_y[2] = {1.6, 0.0078};
   double strip_z_0[2] = {0.01406, 1.6};
   double strip_z_1[2] = {0.01406, 2.0};
   double halfladder_z[2] = {24.0, 24.0};
   double hdi_y[2] = {2.55, 3.8};
   double stave_straight_outer_y[2] = {0.672, 0.522};
-  double stave_straight_inner_y[2] = {0.0, 0.344};
+  double stave_straight_inner_y[2] = {0.1, 0.344};  // the first value is a dummy, not used, to avoid issues with making a G4Logical;Volume with y = 0
   double stave_straight_cooler_y[2] = {0.47, 0.47};
+  double sensor_offset_y[2] = {0.295, 0.0};
 
 
   // We do not want to hard code the ladder types for the layers
@@ -157,46 +158,50 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   int nladder[4] = {34, 30, 36, 42};
   double ladder_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};
   double ladder_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};
+
+
+
   for(int i=0;i<4;i++)
     {
+      cout << "radius values in mm are: cm = " << cm << " mm " << mm << " ladder_radius_inner " << ladder_radius_inner[i]*cm << " ladder_radius_outer " << ladder_radius_outer[i]*cm  << endl; 
       set_default_int_param(i, "laddertype", laddertype[i]);
-      set_default_int_param(i, "nladders", nladder[i]);
-      set_default_double_param(i, "ladder_radius_inner", ladder_radius_inner[i]);
-      set_default_double_param(i, "ladder_radius_outer", ladder_radius_outer[i]);
+      set_default_int_param(i, "nladder", nladder[i]);
+      set_default_double_param(i, "ladder_radius_inner", ladder_radius_inner[i]*cm);
+      set_default_double_param(i, "ladder_radius_outer", ladder_radius_outer[i]*cm);
+
+      set_default_double_param(i, "offsetphi", 0.);
+      set_default_double_param(i, "offsetrot", 0.);
     }
 
 
   // Set the parameters for the two laddertypes. All values in cm!
   for (int i = 0; i < 2; i++)
   {
-
-
     set_default_int_param(i, "nstrips_z_sensor_0", nstrips_z_sensor_0[i]);
     set_default_int_param(i, "nstrips_z_sensor_1", nstrips_z_sensor_1[i]);
     set_default_int_param(i, "nstrips_phi_sensor", nstrips_phi_sensor[i]);
     set_default_int_param(i, "nstrips_phi_cell", nstrips_phi_sensor[i]);
 
-    set_default_int_param(i, "stave_straight_inner_y", stave_straight_inner_y[i]);
-    set_default_int_param(i, "stave_straight_outer_y", stave_straight_outer_y[i]);
-    set_default_int_param(i, "stave_straight_cooler_y", stave_straight_cooler_y[i]);
+    set_default_double_param(i, "stave_straight_inner_y", stave_straight_inner_y[i]*cm);
+    set_default_double_param(i, "stave_straight_outer_y", stave_straight_outer_y[i]*cm);
+    set_default_double_param(i, "stave_straight_cooler_y", stave_straight_cooler_y[i]*cm);
 
-    set_default_double_param(i, "strip_y", strip_y[i]);
-    set_default_double_param(i, "strip_z_0", strip_z_0[i]);
-    set_default_double_param(i, "strip_z_1", strip_z_1[i]);
-    set_default_double_param(i, "strip_x", 0.032);  // 320 microns deep
-    set_default_double_param(i, "sensor_edge_phi", 0.13);
-    set_default_double_param(i, "sensor_edge_z", 0.10);
-    set_default_double_param(i, "hdi_x", 0.0438);
-    set_default_double_param(i, "hdi_y", hdi_y[i]);
-    set_default_double_param(i, "hdi_edge_z", 0.01);
-    set_default_double_param(i, "fphx_x", 0.032);
-    set_default_double_param(i, "fphx_y", 0.27);
-    set_default_double_param(i, "fphx_z", 0.9);
-    set_default_double_param(i, "gap_sensor_fphx", 0.1);
-    set_default_double_param(i, "pgs_x", 0.02);  // 0.2 mm
-    set_default_double_param(i, "offsetphi", 0.);
-    set_default_double_param(i, "halfladder_z", halfladder_z[i]);
-
+    set_default_double_param(i, "strip_y", strip_y[i]*cm);
+    set_default_double_param(i, "strip_z_0", strip_z_0[i]*cm);
+    set_default_double_param(i, "strip_z_1", strip_z_1[i]*cm);
+    set_default_double_param(i, "strip_x", 0.032*cm);  // 320 microns deep
+    set_default_double_param(i, "sensor_edge_phi", 0.13*cm);
+    set_default_double_param(i, "sensor_edge_z", 0.10*cm);
+    set_default_double_param(i, "sensor_offset_y", sensor_offset_y[i]*cm);
+    set_default_double_param(i, "hdi_x", 0.0438*cm);
+    set_default_double_param(i, "hdi_y", hdi_y[i]*cm);
+    set_default_double_param(i, "hdi_edge_z", 0.0*cm);
+    set_default_double_param(i, "fphx_x", 0.1*cm);  // guess for now - fix!!!
+    set_default_double_param(i, "fphx_y", 0.27*cm);
+    set_default_double_param(i, "fphx_z", 0.91*cm);
+    set_default_double_param(i, "gap_sensor_fphx", 0.1*cm);
+    set_default_double_param(i, "pgs_x", 0.02*cm);  // 0.2 mm
+    set_default_double_param(i, "halfladder_z", halfladder_z[i]*cm);
   }
 
   /*

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
@@ -18,7 +18,9 @@ class PHG4SiliconTrackerSubsystem : public PHG4DetectorGroupSubsystem
   typedef std::vector<std::pair<int, int>> vpair;
 
   //! constructor
-  PHG4SiliconTrackerSubsystem(const std::string &name = "SILICONTRACKER", const vpair &layerconfig = vpair(0));
+  PHG4SiliconTrackerSubsystem(const std::string &name = "SILICONTRACKER", const vpair &layerconfig = vpair(0));  
+
+  PHG4SiliconTrackerSubsystem(const double sensor_radius_inner_[], const double sensor_radius_outer_[], const std::string &name = "SILICONTRACKER", const vpair &layerconfig = vpair(0));
 
   //! destructor
   virtual ~PHG4SiliconTrackerSubsystem(void)
@@ -45,6 +47,7 @@ class PHG4SiliconTrackerSubsystem : public PHG4DetectorGroupSubsystem
   PHG4SteppingAction *GetSteppingAction(void) const { return steppingAction_; }
   void Print(const std::string &what = "ALL") const;
 
+
  private:
   void SetDefaultParameters();
 
@@ -60,6 +63,10 @@ class PHG4SiliconTrackerSubsystem : public PHG4DetectorGroupSubsystem
   std::string detector_type;
 
   int nlayers;
+
+  double sensor_radius_inner[4];
+  double sensor_radius_outer[4];
+
 };
 
 #endif

--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
@@ -220,12 +220,7 @@ PHG4KalmanPatRec::PHG4KalmanPatRec(
       _max_search_win_phi_tpc(    0.0040),
       _min_search_win_phi_tpc(    0.0000),
       _max_search_win_theta_tpc(  0.0040),
-      _min_search_win_theta_tpc(  0.0000),
-      
-      _max_search_win_phi_intt(   0.0050),
-      _min_search_win_phi_intt(   0.0000),
-      _max_search_win_theta_intt( 0.2000),
-      _min_search_win_theta_intt( 0.2000),
+      _min_search_win_theta_tpc(  0.0000),      
       
       _max_search_win_phi_maps(   0.0050),
       _min_search_win_phi_maps(   0.0000),
@@ -263,6 +258,26 @@ PHG4KalmanPatRec::PHG4KalmanPatRec(
 //
 //	unsigned int intt_layers[] = {3, 4, 5, 6};
 //	this->set_intt_layers(intt_layers, 4);
+
+	_max_search_win_phi_intt[0] =    0.20;
+	_max_search_win_phi_intt[1] = 0.0050;
+	_max_search_win_phi_intt[2] = 0.0050;
+	_max_search_win_phi_intt[3] = 0.0050;
+
+	_min_search_win_phi_intt[0] =   0.2000;
+	_min_search_win_phi_intt[1] =   0.0;
+	_min_search_win_phi_intt[2] =   0.0;
+	_min_search_win_phi_intt[3] =   0.0;
+
+	_max_search_win_theta_intt[0] = 0.010;
+	_max_search_win_theta_intt[1] = 0.2000;
+	_max_search_win_theta_intt[2] =  0.2000;
+	_max_search_win_theta_intt[3] =  0.2000;
+
+	_min_search_win_theta_intt[0] = 0.000;
+	_min_search_win_theta_intt[1] = 0.200;
+	_min_search_win_theta_intt[2] = 0.200;
+	_min_search_win_theta_intt[3] = 0.200;
 
 	//int seeding_layers[] = {7,15,25,35,45,55,66};
 	int ninner_layer = _nlayers_maps+_nlayers_intt;
@@ -3191,6 +3206,11 @@ int PHG4KalmanPatRec::OutputPHGenFitTrack(PHCompositeNode* topNode, MapPHGenFitT
 		  if(_nlayers_intt>0&&layer>=_nlayers_maps&&layer<_nlayers_maps+_nlayers_intt){
 		    n_intt++;
 		  }
+		  if(n_intt >4)
+		    {
+		      cout << PHWHERE << " Can not have more than 4 INTT layers, quit!" << endl;
+		      exit(1);
+		    }
 		  if(_nlayers_tpc>0&&
 		     layer>=(_nlayers_maps+_nlayers_intt)&&
 		     layer<(_nlayers_maps+_nlayers_intt+_nlayers_tpc)){ 
@@ -3603,10 +3623,10 @@ int PHG4KalmanPatRec::TrackPropPatRec(
 			if (theta_window   > _max_search_win_theta_maps)   theta_window   = _max_search_win_theta_maps;
 			if (theta_window   < _min_search_win_theta_maps)   theta_window   = _min_search_win_theta_maps;
 		} else if(layer < _nlayers_maps + _nlayers_intt) {
-			if (phi_window > _max_search_win_phi_intt) phi_window = _max_search_win_phi_intt;
-			if (phi_window < _min_search_win_phi_intt) phi_window = _min_search_win_phi_intt;
-			if (theta_window   > _max_search_win_theta_intt)   theta_window   = _max_search_win_theta_intt;
-			if (theta_window   < _min_search_win_theta_intt)   theta_window   = _min_search_win_theta_intt;
+			if (phi_window > _max_search_win_phi_intt[layer - _nlayers_maps]) phi_window = _max_search_win_phi_intt[layer - _nlayers_maps];
+			if (phi_window < _min_search_win_phi_intt[layer - _nlayers_maps]) phi_window = _min_search_win_phi_intt[layer - _nlayers_maps];
+			if (theta_window   > _max_search_win_theta_intt[layer - _nlayers_maps])   theta_window   = _max_search_win_theta_intt[layer - _nlayers_maps];
+			if (theta_window   < _min_search_win_theta_intt[layer - _nlayers_maps])   theta_window   = _min_search_win_theta_intt[layer - _nlayers_maps];
 		} else {
 			if (phi_window > _max_search_win_phi_tpc) phi_window = _max_search_win_phi_tpc;
 			if (phi_window < _min_search_win_phi_tpc) phi_window = _min_search_win_phi_tpc;

--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.h
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.h
@@ -453,12 +453,12 @@ public:
 		_blowup_factor = blowupFactor;
 	}
 
-	float get_max_search_win_phi_intt() const {
-		return _max_search_win_phi_intt;
+	float get_max_search_win_phi_intt(int inttlayer) const {
+		return _max_search_win_phi_intt[inttlayer];
 	}
 
-	void set_max_search_win_phi_intt(float maxSearchWinPhiIntt) {
-		_max_search_win_phi_intt = maxSearchWinPhiIntt;
+	void set_max_search_win_phi_intt(int inttlayer, float maxSearchWinPhiIntt) {
+		_max_search_win_phi_intt[inttlayer] = maxSearchWinPhiIntt;
 	}
 
 	float get_max_search_win_phi_maps() const {
@@ -469,12 +469,12 @@ public:
 		_max_search_win_phi_maps = maxSearchWinPhiMaps;
 	}
 
-	float get_max_search_win_theta_intt() const {
-		return _max_search_win_theta_intt;
+	float get_max_search_win_theta_intt(int inttlayer) const {
+		return _max_search_win_theta_intt[inttlayer];
 	}
 
-	void set_max_search_win_theta_intt(float maxSearchWinThetaIntt) {
-		_max_search_win_theta_intt = maxSearchWinThetaIntt;
+	void set_max_search_win_theta_intt(int inttlayer, float maxSearchWinThetaIntt) {
+		_max_search_win_theta_intt[inttlayer] = maxSearchWinThetaIntt;
 	}
 
 	float get_max_search_win_theta_maps() const {
@@ -485,12 +485,12 @@ public:
 		_max_search_win_theta_maps = maxSearchWinThetaMaps;
 	}
 
-	float get_min_search_win_phi_intt() const {
-		return _min_search_win_phi_intt;
+	float get_min_search_win_phi_intt(int inttlayer) const {
+		return _min_search_win_phi_intt[inttlayer];
 	}
 
-	void set_min_search_win_phi_intt(float minSearchWinPhiIntt) {
-		_min_search_win_phi_intt = minSearchWinPhiIntt;
+	void set_min_search_win_phi_intt(int inttlayer, float minSearchWinPhiIntt) {
+		_min_search_win_phi_intt[inttlayer] = minSearchWinPhiIntt;
 	}
 
 	float get_min_search_win_phi_maps() const {
@@ -509,12 +509,12 @@ public:
 		_min_search_win_phi_tpc = minSearchWinPhiTpc;
 	}
 
-	float get_min_search_win_theta_intt() const {
-		return _min_search_win_theta_intt;
+	float get_min_search_win_theta_intt(int inttlayer) const {
+		return _min_search_win_theta_intt[inttlayer];
 	}
 
-	void set_min_search_win_theta_intt(float minSearchWinThetaIntt) {
-		_min_search_win_theta_intt = minSearchWinThetaIntt;
+	void set_min_search_win_theta_intt(int inttlayer, float minSearchWinThetaIntt) {
+		_min_search_win_theta_intt[inttlayer] = minSearchWinThetaIntt;
 	}
 
 	float get_min_search_win_theta_maps() const {
@@ -866,10 +866,10 @@ private:
 	float _max_search_win_theta_tpc;
 	float _min_search_win_theta_tpc;
 
-	float _max_search_win_phi_intt;
-	float _min_search_win_phi_intt;
-	float _max_search_win_theta_intt;
-	float _min_search_win_theta_intt;
+	float _max_search_win_phi_intt[4];
+	float _min_search_win_phi_intt[4];
+	float _max_search_win_theta_intt[4];
+	float _min_search_win_theta_intt[4];
 
 	float _max_search_win_phi_maps;
 	float _min_search_win_phi_maps;

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -725,6 +725,12 @@ void PHG4Reco::DefineMaterials()
   quartz->AddElement(G4Element::GetElement("Si"), 1);
   quartz->AddElement(G4Element::GetElement("O"), 2);
 
+  // making carbon fiber epoxy
+  G4Material *cfrp_intt = new G4Material("CFRP_INTT", density = 1.69 * g / cm3, ncomponents = 3);
+  cfrp_intt->AddElement(G4Element::GetElement("C"), 10);
+  cfrp_intt->AddElement(G4Element::GetElement("H"), 6);
+  cfrp_intt->AddElement(G4Element::GetElement("O"), 1);
+
   // gas mixture for the MuID in fsPHENIX. CLS 02-25-14
   G4Material *IsoButane = new G4Material("Isobutane", 0.00265 * g / cm3, 2);
   IsoButane->AddElement(G4Element::GetElement("C"), 4);

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -731,6 +731,14 @@ void PHG4Reco::DefineMaterials()
   cfrp_intt->AddElement(G4Element::GetElement("H"), 6);
   cfrp_intt->AddElement(G4Element::GetElement("O"), 1);
 
+  // making Rohacell foam 110
+  G4Material *rohacell_foam_110 = new G4Material("ROHACELL_FOAM_110", density = 0.110 * g / cm3, ncomponents = 4);
+  rohacell_foam_110->AddElement(G4Element::GetElement("C"), 8);
+  rohacell_foam_110->AddElement(G4Element::GetElement("H"),11);
+  rohacell_foam_110->AddElement(G4Element::GetElement("O"), 2);
+  rohacell_foam_110->AddElement(G4Element::GetElement("N"), 1);
+
+
   // gas mixture for the MuID in fsPHENIX. CLS 02-25-14
   G4Material *IsoButane = new G4Material("Isobutane", 0.00265 * g / cm3, 2);
   IsoButane->AddElement(G4Element::GetElement("C"), 4);


### PR DESCRIPTION
Built on top of PR #466 (new INTT configuration. Added support structure material inside the acceptance for the INTT and also the MVTX outer shell. All support material description is from discussions with MIckey Chiu/Dan Cacace/Walt Sondheim.

Material included is:
INTT support rails (CFRP)
INTT outer shell (CFRP)
INTT inner shell (CFRP)
MVTX outer shell (Rohacell foam/CFRP)

Note: The MVTX outer shell is built in the INTT detector module for now. Once things are merged, I will move it to the MVTX module.