### PR TITLE
Update MVTX Stave Geometry

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_MAPS.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_MAPS.cc
@@ -63,7 +63,8 @@ PHG4CylinderGeom_MAPS::PHG4CylinderGeom_MAPS(int in_layer, int in_stave_type, in
   // Units here are cm, same as in the gdml file
 
   // for all layers
-  double loc_sensor_in_chip_data[3] = {0.0, -0.0016, 0.0};
+  //double loc_sensor_in_chip_data[3] = {0.0, -0.0016, 0.0};
+  double loc_sensor_in_chip_data[3] = {0.0620, -0.0016, 0.0}; // mvtx_stave_v01.gdml
   
   for(int i=0;i<3;i++)
     loc_sensor_in_chip[i] = loc_sensor_in_chip_data[i];
@@ -71,6 +72,7 @@ PHG4CylinderGeom_MAPS::PHG4CylinderGeom_MAPS(int in_layer, int in_stave_type, in
   // inner barrel layers stave construction 
   //========================== 
   // (stave_type == 0)
+  /*
   double inner_loc_chip_in_module_data[9][3] = {
     0.0, -0.00875, -12.04,
     0.0, -0.00875, -9.03,
@@ -81,6 +83,21 @@ PHG4CylinderGeom_MAPS::PHG4CylinderGeom_MAPS(int in_layer, int in_stave_type, in
     0.0, -0.00875, 6.02,	   
     0.0, -0.00875, 9.03,	   
     0.0, -0.00875, 12.04};	   
+  double inner_loc_module_in_halfstave_data[3] = {0.0, 0.0, 0.0};   // only one module
+  double inner_loc_halfstave_in_stave_data[3] = {0.0, 0.00625, 0.0}; 
+  */
+
+  // from mvtx_stave_v01.gdml
+  double inner_loc_chip_in_module_data[9][3] = {
+    0.0, -0.00875, -12.060,
+    0.0, -0.00875, -9.0450,
+    0.0, -0.00875, -6.0300,
+    0.0, -0.00875, -3.0150,	   
+    0.0, -0.00875, 0.0,
+    0.0, -0.00875, 3.0150,	   
+    0.0, -0.00875, 6.0300,	   
+    0.0, -0.00875, 9.0450,	   
+    0.0, -0.00875, 12.060};	   
   double inner_loc_module_in_halfstave_data[3] = {0.0, 0.0, 0.0};   // only one module
   double inner_loc_halfstave_in_stave_data[3] = {0.0, 0.00625, 0.0}; 
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_MAPS.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_MAPS.cc
@@ -33,8 +33,8 @@ PHG4CylinderGeom_MAPS::PHG4CylinderGeom_MAPS(int in_layer, int in_stave_type, in
   //    For mid and outer layer (stave types 1 and 2):   0.7500 x 0.0009 x 1.5000
   if( stave_type == 0 )
     {
-      Zsensor = 3.01;   // cm
-      Xsensor = 1.505;   // cm  
+      Zsensor = 2.994; //3.01;   // cm
+      Xsensor = 1.376; //1.505;   // cm  
     }
   else
     {

--- a/simulation/g4simulation/g4detectors/PHG4MapsDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4MapsDetector.h
@@ -36,6 +36,7 @@ class PHG4MapsDetector: public PHG4Detector
   //!@name volume accessors
   //@{
   int IsInMaps(G4VPhysicalVolume*) const;
+  int IsSensor(G4VPhysicalVolume*) const;
   //@}
 
   void set_stave_type(const int st){stave_type = st;}
@@ -70,6 +71,14 @@ class PHG4MapsDetector: public PHG4Detector
   int ConstructMaps(G4LogicalVolume* sandwich);
   void SetDisplayProperty( G4AssemblyVolume* av);
   void SetDisplayProperty( G4LogicalVolume* lv);
+  void FillPVArray( G4AssemblyVolume* av );
+  void FindSensor ( G4LogicalVolume* lv);
+
+  // map of sensor physical volume pointers
+  std::map<G4VPhysicalVolume*, int> sensor_vol;
+  int sensor_count; 
+  std::map<G4VPhysicalVolume*, int> stave_vol;
+  int stave_count;
 
   // the cylinder envelope
   G4double envelope_inner_radius;

--- a/simulation/g4simulation/g4detectors/PHG4MapsSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsSteppingAction.cc
@@ -117,7 +117,8 @@ bool PHG4MapsSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
   boost::char_separator<char> sep("_");
   boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
 
-  // chip number is from  "ITSUChip[layer number]_[chip number]
+  //OLD ITS.gdml: chip number is from  "ITSUChip[layer number]_[chip number]
+  //NEW: chip number is from  "MVTXChip_[chip number]
   G4VPhysicalVolume* v1 = touch->GetVolume(1);
   boost::tokenizer<boost::char_separator<char> > tok1(v1->GetName(), sep);
   tokeniter = tok1.begin();

--- a/simulation/g4simulation/g4detectors/PHG4MapsSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsSteppingAction.cc
@@ -56,13 +56,32 @@ bool PHG4MapsSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
   //  0 if outside of Maps
   //  1 if inside sensor
 
-  // This checks to see if the string "ITSUSensor[layer number]" is contained in the volume name
-  int whichactive = detector_->IsInMaps(sensor_volume);
+  // This checks if the volume is a sensor (doesn't tell us unique layer)
+  // PHG4MapsTelescopeDetector_->IsSensor(volume)
+  // returns
+  //  1 if volume is a sensor
+  //  0 if not
+  int whichactive = detector_->IsSensor(sensor_volume);
 
   if (!whichactive)
-    {
-      return false;
-    }
+  {
+    return false;
+  }
+
+  // This tells us if the volume belongs to the right stave for this layer
+  // From the GDML file the 3rd volume up should be the half-stave
+  // PHG4MapsTelescopeDetector_->IsInMaps(volume)
+  // returns
+  //  1 if in ladder belonging to this layer
+  //  0 if not
+  G4VPhysicalVolume* vstave = touch->GetVolume(3);
+  whichactive = detector_->IsInMaps(vstave);
+
+
+  if (!whichactive)
+  {
+    return false;
+  }
 
   if(Verbosity() > 5)
     {


### PR DESCRIPTION
This pull request updates the stave (or ladder) geometry of the inner MAPS to better conform to the current MVTX proposed geometry.

The bulk of the changes occur in a modified gdml file from which the geometry is read. The updated gdml file is currently located here:

/phenix/hhj3/dcm07e/sPHENIX/macros/macros/g4simulations/mvtx_stave_v01.gdml

The major changes to the gdml file are:
- Renaming volumes to use MVTX rather than ITSU
- File now contains only the geometry for a single stave & support, rather than the full ITS
- Sensor size has been reduced to the correct active area and shifted to the correct position within the chip
- Silicon chip size updated
- Include space between chips

This pull request mainly deals with updating hard-coded values in the various MAPS construction, stepping action, and digitization modules to reflect the above changes.

These changes also require changes to the simulation macros, which will come in a separate pull request.