### PR TITLE
Introduce pre-defined deadmap for INTT

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -64,7 +64,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   int layermin_;
   int layermax_;
 
-  G4double overlap_fraction;
+//  G4double overlap_fraction;
 
   std::string detector_type;
   std::string superdetector;

--- a/simulation/g4simulation/g4hough/Makefile.am
+++ b/simulation/g4simulation/g4hough/Makefile.am
@@ -20,7 +20,8 @@ AM_LDFLAGS = \
   -L$(ROOTSYS)/lib
 
 libg4hough_io_la_LIBADD = \
-  -lphool
+  -lphool \
+  -lg4detectors_io
 
 libg4hough_la_LDFLAGS = \
   `geant4-config --libs`\

--- a/simulation/g4simulation/g4hough/Makefile.am
+++ b/simulation/g4simulation/g4hough/Makefile.am
@@ -46,6 +46,8 @@ pkginclude_HEADERS = \
   SvtxVertex_v1.h \
   SvtxVertexMap.h \
   SvtxVertexMap_v1.h \
+  SvtxDeadMap.h \
+  SvtxDeadMapv1.h \
   PHG4SvtxDeadArea.h \
   PHG4SvtxThresholds.h \
   PHG4SvtxDigitizer.h \
@@ -105,6 +107,10 @@ libg4hough_io_la_SOURCES = \
   SvtxHit_Dict.C \
   SvtxHit_v1.C \
   SvtxHit_v1_Dict.C \
+  SvtxDeadMap.C \
+  SvtxDeadMap_Dict.C \
+  SvtxDeadMapv1.C \
+  SvtxDeadMapv1_Dict.C \
   SvtxHitMap.C \
   SvtxHitMap_Dict.C \
   SvtxHitMap_v1.C \
@@ -171,6 +177,8 @@ libg4hough_la_SOURCES = \
   PHG4SiliconTrackerDigitizer_Dict.C \
   PHG4SvtxDeadArea.C \
   PHG4SvtxDeadArea_Dict.C \
+  PHG4SvtxDeadMapLoader.C \
+  PHG4SvtxDeadMapLoader_Dict.C \
   PHG4SvtxThresholds.C \
   PHG4SvtxThresholds_Dict.C \
   PHG4SvtxDigitizer.C \

--- a/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.C
@@ -142,7 +142,7 @@ void PHG4SiliconTrackerDigitizer::DigitizeLadderCells(PHCompositeNode *topNode) 
   PHG4CellContainer* cells = findNode::getClass<PHG4CellContainer>(topNode,"G4CELL_SILICON_TRACKER");
   if (!cells) return;
 
-  SvtxDeadMap *deadmap = findNode::getClass<SvtxDeadMap>(topNode, "DEADMAP_SILICON_TRACKER");
+  const SvtxDeadMap *deadmap = findNode::getClass<SvtxDeadMap>(topNode, "DEADMAP_SILICON_TRACKER");
   if (Verbosity())
   {
     if (deadmap)
@@ -169,12 +169,12 @@ void PHG4SiliconTrackerDigitizer::DigitizeLadderCells(PHCompositeNode *topNode) 
 
     if (deadmap)
     {
-      deadmap->addDeadChannelINTT(
-          cell->get_layer(),               //const int layer,
+      deadmap->isDeadChannelINTT(
+          cell->get_layer(),             //const int layer,
           cell->get_ladder_phi_index(),  //const int ladder_phi,
-          cell->get_ladder_z_index(),  //const int ladder_z,
-          cell->get_zbin(),  //const int strip_z,
-          cell->get_phibin()   //const int strip_phi
+          cell->get_ladder_z_index(),    //const int ladder_z,
+          cell->get_zbin(),              //const int strip_z,
+          cell->get_phibin()             //const int strip_phi
       );
     }
 

--- a/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.C
@@ -4,6 +4,7 @@
 #include "SvtxHitMap_v1.h"
 #include "SvtxHit.h"
 #include "SvtxHit_v1.h"
+#include "SvtxDeadMap.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
@@ -139,8 +140,22 @@ void PHG4SiliconTrackerDigitizer::DigitizeLadderCells(PHCompositeNode *topNode) 
   //----------
  
   PHG4CellContainer* cells = findNode::getClass<PHG4CellContainer>(topNode,"G4CELL_SILICON_TRACKER");
-  if (!cells) return; 
-  
+  if (!cells) return;
+
+  SvtxDeadMap *deadmap = findNode::getClass<SvtxDeadMap>(topNode, "DEADMAP_SILICON_TRACKER");
+  if (Verbosity())
+  {
+    if (deadmap)
+    {
+      cout << "PHG4SiliconTrackerDigitizer::DigitizeLadderCells - Use deadmap ";
+      deadmap->identify();
+    }
+    else
+    {
+      cout << "PHG4SiliconTrackerDigitizer::DigitizeLadderCells - Can not find deadmap, all channels enabled "<<endl;
+    }
+  }
+
   //-------------
   // Digitization
   //-------------
@@ -151,7 +166,18 @@ void PHG4SiliconTrackerDigitizer::DigitizeLadderCells(PHCompositeNode *topNode) 
       ++celliter) {
     
     PHG4Cell* cell = celliter->second;
-    
+
+    if (deadmap)
+    {
+      deadmap->addDeadChannelINTT(
+          cell->get_layer(),               //const int layer,
+          cell->get_ladder_phi_index(),  //const int ladder_phi,
+          cell->get_ladder_z_index(),  //const int ladder_z,
+          cell->get_zbin(),  //const int strip_z,
+          cell->get_phibin()   //const int strip_phi
+      );
+    }
+
     SvtxHit_v1 hit;
 
     const int layer = cell->get_layer();

--- a/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.h
+++ b/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.h
@@ -27,7 +27,7 @@ class PHG4SiliconTrackerDigitizer : public SubsysReco
   int process_event(PHCompositeNode *topNode);
   
   //! end of process
-  int End(PHCompositeNode *topNode) {return 0;}
+  int End(PHCompositeNode *topNode);
   
   void set_adc_scale(const int &layer, const std::vector<double> &userrange)
   {
@@ -64,6 +64,11 @@ class PHG4SiliconTrackerDigitizer : public SubsysReco
 
   const unsigned int nadcbins = 8;
   std::map<int, std::vector< std::pair<double, double> > > _max_fphx_adc;
+
+
+  unsigned int m_nCells ;
+  unsigned int m_nDeadCells ;
+
 };
 
 #endif

--- a/simulation/g4simulation/g4hough/PHG4SvtxDeadMapLoader.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDeadMapLoader.C
@@ -1,0 +1,185 @@
+// $Id: $
+
+/*!
+ * \file PHG4SvtxDeadMapLoader.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "PHG4SvtxDeadMapLoader.h"
+
+#include <calobase/SvtxDeadMapv1.h>
+#include <phparameter/PHParameters.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/getClass.h>
+
+// boost headers
+#include <boost/foreach.hpp>
+#include <boost/tokenizer.hpp>
+// this is an ugly hack, the gcc optimizer has a bug which
+// triggers the uninitialized variable warning which
+// stops compilation because of our -Werror
+#include <boost/version.hpp>  // to get BOOST_VERSION
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700)
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma message "ignoring bogus gcc warning in boost header lexical_cast.hpp"
+#include <boost/lexical_cast.hpp>
+#pragma GCC diagnostic warning "-Wuninitialized"
+#else
+#include <boost/lexical_cast.hpp>
+#endif
+
+#include <cassert>
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <string>
+
+using namespace std;
+
+PHG4SvtxDeadMapLoader::PHG4SvtxDeadMapLoader(const std::string &detector)
+  : SubsysReco("PHG4SvtxDeadMapLoader_" + detector)
+  , m_detector(detector)
+  , m_deadmap(nullptr)
+{
+}
+
+PHG4SvtxDeadMapLoader::~PHG4SvtxDeadMapLoader()
+{
+}
+
+int PHG4SvtxDeadMapLoader::InitRun(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *runNode = static_cast<PHCompositeNode *>(iter.findFirst(
+      "PHCompositeNode", "RUN"));
+  if (!runNode)
+  {
+    std::cerr << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
+              << "Run Node missing, doing nothing." << std::endl;
+    throw std::runtime_error(
+        "Failed to find Run node in RawTowerCalibration::CreateNodes");
+  }
+
+  // Create the tower nodes on the tree
+  PHNodeIterator dstiter(runNode);
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst(
+      "PHCompositeNode", m_detector));
+  if (!DetNode)
+  {
+    DetNode = new PHCompositeNode(m_detector);
+    runNode->addNode(DetNode);
+  }
+
+  // Be careful as a previous calibrator may have been registered for this detector
+  string deadMapName = "DEADMAP_" + m_detector;
+  SvtxDeadMap *m_deadmap = findNode::getClass<SvtxDeadMapv1>(DetNode, deadMapName);
+  if (!m_deadmap)
+  {
+    m_deadmap = new SvtxDeadMapv1();
+    PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(
+        m_deadmap, deadMapName, "PHObject");
+    DetNode->addNode(towerNode);
+  }
+
+  assert(m_deadmap);
+
+  for (const auto pathiter : m_deadMapPathMap)
+  {
+    const unsigned int ilayer = pathiter.first;
+    const string &deadMapPath = pathiter.second;
+
+    int counter = 0;
+
+    PHParameters deadMapParam(m_detector);
+    deadMapParam.ReadFromFile(m_detector, "xml", 0, 0, deadMapPath);
+
+    const auto in_par_ranges = deadMapParam.get_all_int_params();
+
+    for (auto iter = in_par_ranges.first; iter != in_par_ranges.second; ++iter)
+    {
+      const string &deadChanName = iter->first;
+
+      if (Verbosity())
+      {
+        cout << "deadMapParam[" << deadChanName << "] = " << iter->second << ": ";
+      }
+
+      boost::char_separator<char> sep("_");
+      boost::tokenizer<boost::char_separator<char> > tok(deadChanName, sep);
+      boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
+
+      for (tokeniter = tok.begin(); tokeniter != tok.end(); ++tokeniter)
+      {
+        if (*tokeniter == "deadtower")
+        {
+          // Form("deadtower_eta_%d_phi_%d", eta, phi)
+
+          ++tokeniter;
+          assert(tokeniter != tok.end());
+
+          if (*tokeniter == "eta")
+          {
+            ++tokeniter;
+            assert(tokeniter != tok.end());
+            const unsigned int eta = boost::lexical_cast<unsigned int>(*tokeniter);
+
+            ++tokeniter;
+            assert(tokeniter != tok.end());
+            assert(*tokeniter == "phi");
+
+            ++tokeniter;
+            assert(tokeniter != tok.end());
+            const unsigned int phi = boost::lexical_cast<unsigned int>(*tokeniter);
+
+            m_deadmap->addDeadChannel(ilayer, eta, phi);
+            ++counter;
+
+            if (Verbosity())
+            {
+              cout << "add dead channel eta" << eta << " phi" << phi;
+            }
+          }  // if (*tokeniter == "eta")
+          else
+          {
+            if (Verbosity())
+            {
+              cout << "skip " << deadChanName;
+            }
+          }
+
+        }  //      if (*tokeniter == "deadtower")
+        else
+        {
+          if (Verbosity())
+          {
+            cout << "skip " << deadChanName;
+          }
+        }
+
+      }  //     for (tokeniter = tok.begin(); tokeniter != tok.end(); ++tokeniter)
+
+      if (Verbosity())
+      {
+        cout << endl;
+      }
+
+    }  //  for (const auto iter = in_par_ranges.first; iter != in_par_ranges.second; ++iter)
+
+    cout << "PHG4SvtxDeadMapLoader::" << m_detector << "::InitRun - loading " << counter << " dead channel for layer "
+         << ilayer << " from " << deadMapPath << ". Total dead chan = " << m_deadmap->size() << endl;
+  }
+
+  if (Verbosity())
+  {
+    cout << "PHG4SvtxDeadMapLoader::" << m_detector << "::InitRun - loading dead map completed : ";
+    m_deadmap->identify();
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/simulation/g4simulation/g4hough/PHG4SvtxDeadMapLoader.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDeadMapLoader.C
@@ -9,8 +9,8 @@
  */
 
 #include "PHG4SvtxDeadMapLoader.h"
+#include "SvtxDeadMapv1.h"
 
-#include <calobase/SvtxDeadMapv1.h>
 #include <phparameter/PHParameters.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>

--- a/simulation/g4simulation/g4hough/PHG4SvtxDeadMapLoader.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDeadMapLoader.C
@@ -108,7 +108,7 @@ int PHG4SvtxDeadMapLoader::InitRun(PHCompositeNode *topNode)
 
       if (Verbosity())
       {
-        cout << "deadMapParam[" << deadChanName << "] = " << iter->second << ": ";
+        cout << "HG4SvtxDeadMapLoader::InitRun - deadMapParam[" << deadChanName << "] = " << iter->second << ": ";
       }
 
       boost::char_separator<char> sep("_");
@@ -117,44 +117,35 @@ int PHG4SvtxDeadMapLoader::InitRun(PHCompositeNode *topNode)
 
       for (tokeniter = tok.begin(); tokeniter != tok.end(); ++tokeniter)
       {
-        if (*tokeniter == "deadtower")
+        if (*tokeniter == "INTT")
         {
-          // Form("deadtower_eta_%d_phi_%d", eta, phi)
+          // Form("INTT_%d_%d_%d_%d", ladder_phi, ladder_z, strip_z, strip_phi)
 
           ++tokeniter;
           assert(tokeniter != tok.end());
+          int ladder_phi = boost::lexical_cast<int>(*tokeniter);
 
-          if (*tokeniter == "eta")
+          ++tokeniter;
+          assert(tokeniter != tok.end());
+          int ladder_z = boost::lexical_cast<int>(*tokeniter);
+
+          ++tokeniter;
+          assert(tokeniter != tok.end());
+          int strip_z = boost::lexical_cast<int>(*tokeniter);
+
+          ++tokeniter;
+          assert(tokeniter != tok.end());
+          int strip_phi = boost::lexical_cast<int>(*tokeniter);
+
+          m_deadmap->addDeadChannelINTT(ilayer, ladder_phi, ladder_z, strip_z, strip_phi);
+          ++counter;
+
+          if (Verbosity())
           {
-            ++tokeniter;
-            assert(tokeniter != tok.end());
-            const unsigned int eta = boost::lexical_cast<unsigned int>(*tokeniter);
-
-            ++tokeniter;
-            assert(tokeniter != tok.end());
-            assert(*tokeniter == "phi");
-
-            ++tokeniter;
-            assert(tokeniter != tok.end());
-            const unsigned int phi = boost::lexical_cast<unsigned int>(*tokeniter);
-
-            m_deadmap->addDeadChannel(ilayer, eta, phi);
-            ++counter;
-
-            if (Verbosity())
-            {
-              cout << "add dead channel eta" << eta << " phi" << phi;
-            }
-          }  // if (*tokeniter == "eta")
-          else
-          {
-            if (Verbosity())
-            {
-              cout << "skip " << deadChanName;
-            }
+            cout << "add INTT dead channel ladder_phi" << ladder_phi << " ladder_z" << ladder_z
+                <<" strip_z" << strip_z<<" strip_phi"<<strip_phi;
           }
-
-        }  //      if (*tokeniter == "deadtower")
+        }  // if (*tokeniter == "INTT")
         else
         {
           if (Verbosity())

--- a/simulation/g4simulation/g4hough/PHG4SvtxDeadMapLoader.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDeadMapLoader.h
@@ -1,0 +1,56 @@
+// $Id: $
+
+/*!
+ * \file PHG4SvtxDeadMapLoader.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef SIMULATION_CORESOFTWARE_SIMULATION_G4SIMULATION_G4CEMC_PHG4SvtxDeadMapLoader_H_
+#define SIMULATION_CORESOFTWARE_SIMULATION_G4SIMULATION_G4CEMC_PHG4SvtxDeadMapLoader_H_
+
+#include <fun4all/SubsysReco.h>
+#include <string>
+#include <map>
+
+class SvtxDeadMap;
+
+
+/*!
+ * \brief PHG4SvtxDeadMapLoader loads dead map at inti run
+ */
+class PHG4SvtxDeadMapLoader : public SubsysReco
+{
+ public:
+  explicit PHG4SvtxDeadMapLoader(const std::string& detector = "SILICON_TRACKER");
+
+  virtual ~PHG4SvtxDeadMapLoader();
+
+  virtual int InitRun(PHCompositeNode *topNode);
+
+  void deadMapPath(unsigned int layer, const std::string& deadMapPath)
+  {
+    m_deadMapPathMap[layer] = deadMapPath;
+  }
+
+  const std::string& detector() const
+  {
+    return m_detector;
+  }
+
+  void detector(const std::string& detector)
+  {
+    m_detector = detector;
+  }
+
+ private:
+
+  std::map<unsigned int, std::string> m_deadMapPathMap;
+
+  std::string m_detector;
+  SvtxDeadMap * m_deadmap;
+};
+
+#endif /* SIMULATION_CORESOFTWARE_SIMULATION_G4SIMULATION_G4CEMC_PHG4SvtxDeadMapLoader_H_ */

--- a/simulation/g4simulation/g4hough/PHG4SvtxDeadMapLoaderLinkDef.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDeadMapLoaderLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4SvtxDeadMapLoader-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.C
@@ -93,7 +93,7 @@ int PHG4SvtxDigitizer::InitRun(PHCompositeNode* topNode) {
   }
 
   CalculateCylinderCellADCScale(topNode);
-  CalculateLadderCellADCScale(topNode);
+//  CalculateLadderCellADCScale(topNode); // obsolete, use PHG4SiliconTrackerDigitizer
   CalculateMapsLadderCellADCScale(topNode);
   
   //----------------
@@ -129,10 +129,11 @@ int PHG4SvtxDigitizer::process_event(PHCompositeNode *topNode) {
       return Fun4AllReturnCodes::ABORTRUN;
     }
 
-  _hitmap->Reset();
+  //Jin: don't clear up node. Fun4all server does that. Extra cleaning usually cause problems
+//  _hitmap->Reset();
   
   DigitizeCylinderCells(topNode);
-  DigitizeLadderCells(topNode);
+//  DigitizeLadderCells(topNode);  // obsolete, use PHG4SiliconTrackerDigitizer
   DigitizeMapsLadderCells(topNode);
 
   PrintHits(topNode);
@@ -174,37 +175,37 @@ void PHG4SvtxDigitizer::CalculateCylinderCellADCScale(PHCompositeNode *topNode) 
   return;
 }
 
-void PHG4SvtxDigitizer::CalculateLadderCellADCScale(PHCompositeNode *topNode) {
-
-  // defaults to 8-bit ADC, short-axis MIP placed at 1/4 dynamic range
-
-  PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_SILICON_TRACKER");
-    
-  if (!geom_container) return;
-  
-  PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
-  for(PHG4CylinderGeomContainer::ConstIterator layeriter = layerrange.first;
-      layeriter != layerrange.second;
-      ++layeriter) {
-
-    int layer = layeriter->second->get_layer();
-    float thickness = (layeriter->second)->get_thickness();
-    float pitch = (layeriter->second)->get_strip_y_spacing();
-    float length = (layeriter->second)->get_strip_z_spacing();
-   
-    float minpath = pitch;
-    if (length < minpath) minpath = length;
-    if (thickness < minpath) minpath = thickness;
-    float mip_e = 0.003876*minpath;  
-
-    if (_max_adc.find(layer) == _max_adc.end()) {
-      _max_adc[layer] = 255;
-      _energy_scale[layer] = mip_e / 64;
-    }
-  }    
-
-  return;
-}
+//void PHG4SvtxDigitizer::CalculateLadderCellADCScale(PHCompositeNode *topNode) {
+//
+//  // defaults to 8-bit ADC, short-axis MIP placed at 1/4 dynamic range
+//
+//  PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode,"CYLINDERGEOM_SILICON_TRACKER");
+//
+//  if (!geom_container) return;
+//
+//  PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
+//  for(PHG4CylinderGeomContainer::ConstIterator layeriter = layerrange.first;
+//      layeriter != layerrange.second;
+//      ++layeriter) {
+//
+//    int layer = layeriter->second->get_layer();
+//    float thickness = (layeriter->second)->get_thickness();
+//    float pitch = (layeriter->second)->get_strip_y_spacing();
+//    float length = (layeriter->second)->get_strip_z_spacing();
+//
+//    float minpath = pitch;
+//    if (length < minpath) minpath = length;
+//    if (thickness < minpath) minpath = thickness;
+//    float mip_e = 0.003876*minpath;
+//
+//    if (_max_adc.find(layer) == _max_adc.end()) {
+//      _max_adc[layer] = 255;
+//      _energy_scale[layer] = mip_e / 64;
+//    }
+//  }
+//
+//  return;
+//}
 
 void PHG4SvtxDigitizer::CalculateMapsLadderCellADCScale(PHCompositeNode *topNode) {
 
@@ -618,52 +619,52 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
   return;
 }
 
-void PHG4SvtxDigitizer::DigitizeLadderCells(PHCompositeNode *topNode) {
-
-  //----------
-  // Get Nodes
-  //----------
- 
-  PHG4CellContainer* cells = findNode::getClass<PHG4CellContainer>(topNode,"G4CELL_SILICON_TRACKER");
-  if (!cells) return; 
-  
-  //-------------
-  // Digitization
-  //-------------
-
-  vector<PHG4Cell*> cell_list;
-  PHG4CellContainer::ConstRange cellrange = cells->getCells();
-  for(PHG4CellContainer::ConstIterator celliter = cellrange.first;
-      celliter != cellrange.second;
-      ++celliter) {
-    
-    PHG4Cell* cell = celliter->second;
-    
-    SvtxHit_v1 hit;
-
-    hit.set_layer(cell->get_layer());
-    hit.set_cellid(cell->get_cellid());
-
-    unsigned int adc = cell->get_edep() / _energy_scale[hit.get_layer()];
-    if (adc > _max_adc[hit.get_layer()]) adc = _max_adc[hit.get_layer()]; 
-    float e = _energy_scale[hit.get_layer()] * adc;
-    
-    hit.set_adc(adc);
-    hit.set_e(e);
-        
-    SvtxHit* ptr = _hitmap->insert(&hit);      
-    if (!ptr->isValid()) {
-      static bool first = true;
-      if (first) {
-	cout << PHWHERE << "ERROR: Incomplete SvtxHits are being created" << endl;
-	ptr->identify();
-	first = false;
-      }
-    }
-  }
-  
-  return;
-}
+//void PHG4SvtxDigitizer::DigitizeLadderCells(PHCompositeNode *topNode) {
+//
+//  //----------
+//  // Get Nodes
+//  //----------
+//
+//  PHG4CellContainer* cells = findNode::getClass<PHG4CellContainer>(topNode,"G4CELL_SILICON_TRACKER");
+//  if (!cells) return;
+//
+//  //-------------
+//  // Digitization
+//  //-------------
+//
+//  vector<PHG4Cell*> cell_list;
+//  PHG4CellContainer::ConstRange cellrange = cells->getCells();
+//  for(PHG4CellContainer::ConstIterator celliter = cellrange.first;
+//      celliter != cellrange.second;
+//      ++celliter) {
+//
+//    PHG4Cell* cell = celliter->second;
+//
+//    SvtxHit_v1 hit;
+//
+//    hit.set_layer(cell->get_layer());
+//    hit.set_cellid(cell->get_cellid());
+//
+//    unsigned int adc = cell->get_edep() / _energy_scale[hit.get_layer()];
+//    if (adc > _max_adc[hit.get_layer()]) adc = _max_adc[hit.get_layer()];
+//    float e = _energy_scale[hit.get_layer()] * adc;
+//
+//    hit.set_adc(adc);
+//    hit.set_e(e);
+//
+//    SvtxHit* ptr = _hitmap->insert(&hit);
+//    if (!ptr->isValid()) {
+//      static bool first = true;
+//      if (first) {
+//	cout << PHWHERE << "ERROR: Incomplete SvtxHits are being created" << endl;
+//	ptr->identify();
+//	first = false;
+//      }
+//    }
+//  }
+//
+//  return;
+//}
 
 void PHG4SvtxDigitizer::DigitizeMapsLadderCells(PHCompositeNode *topNode) {
 

--- a/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.h
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.h
@@ -47,11 +47,11 @@ class PHG4SvtxDigitizer : public SubsysReco
  private:
 
   void CalculateCylinderCellADCScale(PHCompositeNode *topNode);
-  void CalculateLadderCellADCScale(PHCompositeNode *topNode);
+//  void CalculateLadderCellADCScale(PHCompositeNode *topNode);  // obsolete, use PHG4SiliconTrackerDigitizer
   void CalculateMapsLadderCellADCScale(PHCompositeNode *topNode);
 
   void DigitizeCylinderCells(PHCompositeNode *topNode);
-  void DigitizeLadderCells(PHCompositeNode *topNode);
+//  void DigitizeLadderCells(PHCompositeNode *topNode);  // obsolete, use PHG4SiliconTrackerDigitizer
   void DigitizeMapsLadderCells(PHCompositeNode *topNode);
   void PrintHits(PHCompositeNode *topNode);
   float added_noise();

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.C
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.C
@@ -53,7 +53,7 @@ bool SvtxDeadMap::isDeadChannel(const int layer, const int ieta, const int iphi)
   return isDeadChannel(key);
 }
 
-bool SvtxDeadMap::isDeadChannel(const int layer,
+bool SvtxDeadMap::addDeadChannelINTT(const int layer,
                                 const int ladder_phi, const int ladder_z,
                                 const int strip_z, const int strip_phi)
 {

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.C
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.C
@@ -6,7 +6,8 @@
 
 using namespace std;
 
-PHG4CellDefs::keytype s_wildCardID = -1;
+int
+SvtxDeadMap::s_wildCardID = -1;
 
 const SvtxDeadMap::Map&
 SvtxDeadMap::getDeadChannels(void) const

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.C
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.C
@@ -33,7 +33,7 @@ void SvtxDeadMap::addDeadChannel(PHG4CellDefs::keytype key)
 }
 
 void SvtxDeadMap::addDeadChannelINTT(const unsigned int layer,
-                                     const unsigned int ladder_z, const unsigned int ladder_phi,
+    const unsigned int ladder_phi,const unsigned int ladder_z,
                                      const unsigned int strip_z, const unsigned int strip_phi)
 {
   addDeadChannel(getINTTKey(layer,
@@ -52,7 +52,7 @@ bool SvtxDeadMap::isDeadChannel(const unsigned int layer, const unsigned int iet
   return isDeadChannel(key);
 }
 bool SvtxDeadMap::isDeadChannel(const unsigned int layer,
-                                const unsigned int ladder_z, const unsigned int ladder_phi,
+    const unsigned int ladder_phi,const unsigned int ladder_z,
                                 const unsigned int strip_z, const unsigned int strip_phi)
 {
   return isDeadChannel(getINTTKey(layer,
@@ -75,7 +75,7 @@ void SvtxDeadMap::identify(std::ostream& os) const
 }
 
 PHG4CellDefs::keytype SvtxDeadMap::getINTTKey(const unsigned int layer,
-                                              const unsigned int ladder_z, const unsigned int ladder_phi,
+                                              const unsigned int ladder_phi,const unsigned int ladder_z,
                                               const unsigned int strip_z, const unsigned int strip_phi)
 {
   static const unsigned int layer_bit = 8;
@@ -84,7 +84,14 @@ PHG4CellDefs::keytype SvtxDeadMap::getINTTKey(const unsigned int layer,
   static const unsigned int strip_z_bit = 16;
   static const unsigned int strip_phi_bit = 16;
 
-  assert(layer_bit + ladder_phi_bit + ladder_z_bit + strip_z_bit + strip_phi_bit == numeric_limits<PHG4CellDefs::keytype>::digits());
+  if (layer == s_wildCardID) layer = (1<<layer_bit) - 1;
+  if (ladder_phi == s_wildCardID) ladder_phi = (1<<ladder_phi_bit) - 1;
+  if (ladder_z == s_wildCardID) ladder_z = (1<<ladder_z_bit) - 1;
+  if (strip_z == s_wildCardID) strip_z = (1<<strip_z_bit) - 1;
+  if (strip_phi == s_wildCardID) strip_phi = (1<<strip_phi_bit) - 1;
+
+  assert(layer_bit + ladder_phi_bit + ladder_z_bit + strip_z_bit + strip_phi_bit == numeric_limits<PHG4CellDefs::keytype>::digits);
+  assert(layer < (1 << layer_bit));
   assert(ladder_phi < (1 << ladder_phi_bit));
   assert(ladder_z < (1 << ladder_z_bit));
   assert(strip_z < (1 << strip_z_bit));

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.C
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.C
@@ -7,7 +7,7 @@
 using namespace std;
 
 int
-SvtxDeadMap::s_wildCardID = -1;
+    SvtxDeadMap::s_wildCardID = -1;
 
 const SvtxDeadMap::Map&
 SvtxDeadMap::getDeadChannels(void) const
@@ -42,20 +42,20 @@ void SvtxDeadMap::addDeadChannelINTT(const int layer,
                             strip_z, strip_phi));
 }
 
-bool SvtxDeadMap::isDeadChannel(PHG4CellDefs::keytype key)
+bool SvtxDeadMap::isDeadChannel(PHG4CellDefs::keytype key) const
 {
   return false;
 }
 
-bool SvtxDeadMap::isDeadChannel(const int layer, const int ieta, const int iphi)
+bool SvtxDeadMap::isDeadChannel(const int layer, const int ieta, const int iphi) const
 {
   const PHG4CellDefs::keytype key = PHG4CellDefs::EtaPhiBinning::genkey(layer, ieta, iphi);
   return isDeadChannel(key);
 }
 
-bool SvtxDeadMap::addDeadChannelINTT(const int layer,
-                                const int ladder_phi, const int ladder_z,
-                                const int strip_z, const int strip_phi)
+bool SvtxDeadMap::isDeadChannelINTT(const int layer,
+                                    const int ladder_phi, const int ladder_z,
+                                    const int strip_z, const int strip_phi) const
 {
   if (isDeadChannel(getINTTKey(layer,
                                ladder_phi, ladder_z,

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.C
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.C
@@ -1,5 +1,7 @@
-#include "SvtxDeadMap.h"
 #include <iostream>
+#include "SvtxDeadMap.h"
+
+#include <cassert>
 
 using namespace std;
 
@@ -19,27 +21,45 @@ SvtxDeadMap::getDeadChannels(void)
 
 void SvtxDeadMap::addDeadChannel(const unsigned int layer, const unsigned int ieta, const int unsigned iphi)
 {
+  const PHG4CellDefs::keytype key = PHG4CellDefs::EtaPhiBinning::genkey(layer, ieta, iphi);
+  addDeadChannel(key);
 }
 
 void SvtxDeadMap::addDeadChannel(PHG4CellDefs::keytype key)
 {
 }
 
-bool
-SvtxDeadMap::isDeadChannel(PHG4CellDefs::keytype key)
+void SvtxDeadMap::addDeadChannelINTT(const unsigned int layer,
+                                     const unsigned int ladder_z, const unsigned int ladder_phi,
+                                     const unsigned int strip_z, const unsigned int strip_phi)
+{
+  addDeadChannel(getINTTKey(layer,
+                            ladder_z, ladder_phi,
+                            strip_z, strip_phi));
+}
+
+bool SvtxDeadMap::isDeadChannel(PHG4CellDefs::keytype key)
 {
   return false;
 }
 
-bool
-SvtxDeadMap::isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi)
+bool SvtxDeadMap::isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi)
 {
-  return false;
+  const PHG4CellDefs::keytype key = PHG4CellDefs::EtaPhiBinning::genkey(layer, ieta, iphi);
+  return isDeadChannel(key);
+}
+bool SvtxDeadMap::isDeadChannel(const unsigned int layer,
+                                const unsigned int ladder_z, const unsigned int ladder_phi,
+                                const unsigned int strip_z, const unsigned int strip_phi)
+{
+  return isDeadChannel(getINTTKey(layer,
+                                  ladder_z, ladder_phi,
+                                  strip_z, strip_phi));
 }
 
 int SvtxDeadMap::isValid() const
 {
-  return size()>0;
+  return size() > 0;
 }
 
 void SvtxDeadMap::Reset()
@@ -51,3 +71,37 @@ void SvtxDeadMap::identify(std::ostream& os) const
   os << "SvtxDeadMap" << std::endl;
 }
 
+PHG4CellDefs::keytype SvtxDeadMap::getINTTKey(const unsigned int layer,
+                                              const unsigned int ladder_z, const unsigned int ladder_phi,
+                                              const unsigned int strip_z, const unsigned int strip_phi)
+{
+  static const unsigned int layer_bit = 8;
+  static const unsigned int ladder_phi_bit = 16;
+  static const unsigned int ladder_z_bit = 8;
+  static const unsigned int strip_z_bit = 16;
+  static const unsigned int strip_phi_bit = 16;
+
+  assert(layer_bit + ladder_phi_bit + ladder_z_bit + strip_z_bit + strip_phi_bit == sizeof(PHG4CellDefs::keytype) * 8);
+  assert(ladder_phi < (1 << ladder_phi_bit));
+  assert(ladder_z < (1 << ladder_z_bit));
+  assert(strip_z < (1 << strip_z_bit));
+  assert(strip_phi < (1 << strip_phi_bit));
+
+  PHG4CellDefs::keytype key = 0;
+
+  key += layer;
+
+  key <<= ladder_phi_bit;
+  key += ladder_phi;
+
+  key <<= ladder_z_bit;
+  key += ladder_z;
+
+  key <<= strip_z_bit;
+  key += strip_z;
+
+  key <<= strip_phi_bit;
+  key += strip_phi;
+
+  return key;
+}

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.C
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.C
@@ -1,9 +1,12 @@
-#include <iostream>
 #include "SvtxDeadMap.h"
 
 #include <cassert>
+#include <limits>
+#include <iostream>
 
 using namespace std;
+
+PHG4CellDefs::keytype s_wildCardID = std::numeric_limits<PHG4CellDefs::keytype>::max();
 
 const SvtxDeadMap::Map&
 SvtxDeadMap::getDeadChannels(void) const
@@ -81,7 +84,7 @@ PHG4CellDefs::keytype SvtxDeadMap::getINTTKey(const unsigned int layer,
   static const unsigned int strip_z_bit = 16;
   static const unsigned int strip_phi_bit = 16;
 
-  assert(layer_bit + ladder_phi_bit + ladder_z_bit + strip_z_bit + strip_phi_bit == sizeof(PHG4CellDefs::keytype) * 8);
+  assert(layer_bit + ladder_phi_bit + ladder_z_bit + strip_z_bit + strip_phi_bit == numeric_limits<PHG4CellDefs::keytype>::digits());
   assert(ladder_phi < (1 << ladder_phi_bit));
   assert(ladder_z < (1 << ladder_z_bit));
   assert(strip_z < (1 << strip_z_bit));

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.C
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.C
@@ -1,0 +1,53 @@
+#include "SvtxDeadMap.h"
+#include <iostream>
+
+using namespace std;
+
+const SvtxDeadMap::Map&
+SvtxDeadMap::getDeadChannels(void) const
+{
+  static Map tmp_map;
+  return tmp_map;
+}
+
+SvtxDeadMap::Map&
+SvtxDeadMap::getDeadChannels(void)
+{
+  static Map tmp_map;
+  return tmp_map;
+}
+
+void SvtxDeadMap::addDeadChannel(const unsigned int layer, const unsigned int ieta, const int unsigned iphi)
+{
+}
+
+void SvtxDeadMap::addDeadChannel(PHG4CellDefs::keytype key)
+{
+}
+
+bool
+SvtxDeadMap::isDeadChannel(PHG4CellDefs::keytype key)
+{
+  return false;
+}
+
+bool
+SvtxDeadMap::isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi)
+{
+  return false;
+}
+
+int SvtxDeadMap::isValid() const
+{
+  return size()>0;
+}
+
+void SvtxDeadMap::Reset()
+{
+}
+
+void SvtxDeadMap::identify(std::ostream& os) const
+{
+  os << "SvtxDeadMap" << std::endl;
+}
+

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.h
@@ -25,7 +25,7 @@ class SvtxDeadMap : public PHObject
 
   virtual bool isDeadChannel(PHG4CellDefs::keytype key);
   bool isDeadChannel(const int layer, const int ieta, const int iphi);
-  bool isDeadChannel(const int layer,
+  bool addDeadChannelINTT(const int layer,
                      const int ladder_phi, const int ladder_z,
                      const int strip_z, const int strip_phi);
 

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.h
@@ -19,15 +19,15 @@ class SvtxDeadMap : public PHObject
 
   void addDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
   void addDeadChannelINTT(const unsigned int layer,
-                                  const unsigned int ladder_z, const unsigned int ladder_phi,
-                                  const unsigned int strip_z, const unsigned int strip_phi);
+                          const unsigned int ladder_phi, const unsigned int ladder_z,
+                          const unsigned int strip_z, const unsigned int strip_phi);
   virtual void addDeadChannel(PHG4CellDefs::keytype key);
 
   virtual bool isDeadChannel(PHG4CellDefs::keytype key);
   bool isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
   bool isDeadChannel(const unsigned int layer,
-                             const unsigned int ladder_z, const unsigned int ladder_phi,
-                             const unsigned int strip_z, const unsigned int strip_phi) ;
+                     const unsigned int ladder_phi, const unsigned int ladder_z,
+                     const unsigned int strip_z, const unsigned int strip_phi);
 
   //! return all towers
   virtual const Map &getDeadChannels(void) const;
@@ -36,10 +36,10 @@ class SvtxDeadMap : public PHObject
   virtual unsigned int size() const { return 0; }
 
   static PHG4CellDefs::keytype getINTTKey(const unsigned int layer,
-                                          const unsigned int ladder_z, const unsigned int ladder_phi,
+                                          const unsigned int ladder_phi, const unsigned int ladder_z,
                                           const unsigned int strip_z, const unsigned int strip_phi);
 
-  static PHG4CellDefs::keytype s_wildCardID;
+  static PHG4CellDefs::keytype getWildCardID() {return s_wildCardID;}
 
  protected:
   SvtxDeadMap()
@@ -47,6 +47,8 @@ class SvtxDeadMap : public PHObject
   }
 
  private:
+  static PHG4CellDefs::keytype s_wildCardID;
+
   ClassDef(SvtxDeadMap, 1)
 };
 

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.h
@@ -17,15 +17,15 @@ class SvtxDeadMap : public PHObject
 
   virtual void identify(std::ostream &os = std::cout) const;
 
-  virtual void addDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
-  virtual void addDeadChannelINTT(const unsigned int layer,
+  void addDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
+  void addDeadChannelINTT(const unsigned int layer,
                                   const unsigned int ladder_z, const unsigned int ladder_phi,
                                   const unsigned int strip_z, const unsigned int strip_phi);
   virtual void addDeadChannel(PHG4CellDefs::keytype key);
 
   virtual bool isDeadChannel(PHG4CellDefs::keytype key);
-  virtual bool isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
-  virtual bool isDeadChannel(const unsigned int layer,
+  bool isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
+  bool isDeadChannel(const unsigned int layer,
                              const unsigned int ladder_z, const unsigned int ladder_phi,
                              const unsigned int strip_z, const unsigned int strip_phi) ;
 
@@ -38,6 +38,8 @@ class SvtxDeadMap : public PHObject
   static PHG4CellDefs::keytype getINTTKey(const unsigned int layer,
                                           const unsigned int ladder_z, const unsigned int ladder_phi,
                                           const unsigned int strip_z, const unsigned int strip_phi);
+
+  static PHG4CellDefs::keytype s_wildCardID;
 
  protected:
   SvtxDeadMap()

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.h
@@ -18,15 +18,27 @@ class SvtxDeadMap : public PHObject
   virtual void identify(std::ostream &os = std::cout) const;
 
   virtual void addDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
+  virtual void addDeadChannelINTT(const unsigned int layer,
+                                  const unsigned int ladder_z, const unsigned int ladder_phi,
+                                  const unsigned int strip_z, const unsigned int strip_phi);
   virtual void addDeadChannel(PHG4CellDefs::keytype key);
 
   virtual bool isDeadChannel(PHG4CellDefs::keytype key);
   virtual bool isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
+  virtual bool isDeadChannel(const unsigned int layer,
+                             const unsigned int ladder_z, const unsigned int ladder_phi,
+                             const unsigned int strip_z, const unsigned int strip_phi) ;
+
   //! return all towers
   virtual const Map &getDeadChannels(void) const;
   virtual Map &getDeadChannels(void);
 
   virtual unsigned int size() const { return 0; }
+
+  static PHG4CellDefs::keytype getINTTKey(const unsigned int layer,
+                                          const unsigned int ladder_z, const unsigned int ladder_phi,
+                                          const unsigned int strip_z, const unsigned int strip_phi);
+
  protected:
   SvtxDeadMap()
   {

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.h
@@ -1,0 +1,39 @@
+#ifndef SvtxDeadMap_H__
+#define SvtxDeadMap_H__
+
+#include <g4detectors/PHG4CellDefs.h>
+
+#include <phool/PHObject.h>
+#include <set>
+
+class SvtxDeadMap : public PHObject
+{
+ public:
+  typedef std::set<PHG4CellDefs::keytype> Map;
+
+  virtual ~SvtxDeadMap() {}
+  virtual void Reset();
+  virtual int isValid() const;
+
+  virtual void identify(std::ostream &os = std::cout) const;
+
+  virtual void addDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
+  virtual void addDeadChannel(PHG4CellDefs::keytype key);
+
+  virtual bool isDeadChannel(PHG4CellDefs::keytype key);
+  virtual bool isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
+  //! return all towers
+  virtual const Map &getDeadChannels(void) const;
+  virtual Map &getDeadChannels(void);
+
+  virtual unsigned int size() const { return 0; }
+ protected:
+  SvtxDeadMap()
+  {
+  }
+
+ private:
+  ClassDef(SvtxDeadMap, 1)
+};
+
+#endif /* SvtxDeadMap_H__ */

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.h
@@ -23,11 +23,11 @@ class SvtxDeadMap : public PHObject
                           const int strip_z, const int strip_phi);
   virtual void addDeadChannel(PHG4CellDefs::keytype key);
 
-  virtual bool isDeadChannel(PHG4CellDefs::keytype key);
-  bool isDeadChannel(const int layer, const int ieta, const int iphi);
-  bool addDeadChannelINTT(const int layer,
+  virtual bool isDeadChannel(PHG4CellDefs::keytype key) const;
+  bool isDeadChannel(const int layer, const int ieta, const int iphi) const;
+  bool isDeadChannelINTT(const int layer,
                      const int ladder_phi, const int ladder_z,
-                     const int strip_z, const int strip_phi);
+                     const int strip_z, const int strip_phi) const;
 
   //! return all towers
   virtual const Map &getDeadChannels(void) const;

--- a/simulation/g4simulation/g4hough/SvtxDeadMap.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMap.h
@@ -17,17 +17,17 @@ class SvtxDeadMap : public PHObject
 
   virtual void identify(std::ostream &os = std::cout) const;
 
-  void addDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
-  void addDeadChannelINTT(const unsigned int layer,
-                          const unsigned int ladder_phi, const unsigned int ladder_z,
-                          const unsigned int strip_z, const unsigned int strip_phi);
+  void addDeadChannel(const int layer, const int ieta, const int iphi);
+  void addDeadChannelINTT(const int layer,
+                          const int ladder_phi, const int ladder_z,
+                          const int strip_z, const int strip_phi);
   virtual void addDeadChannel(PHG4CellDefs::keytype key);
 
   virtual bool isDeadChannel(PHG4CellDefs::keytype key);
-  bool isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
-  bool isDeadChannel(const unsigned int layer,
-                     const unsigned int ladder_phi, const unsigned int ladder_z,
-                     const unsigned int strip_z, const unsigned int strip_phi);
+  bool isDeadChannel(const int layer, const int ieta, const int iphi);
+  bool isDeadChannel(const int layer,
+                     const int ladder_phi, const int ladder_z,
+                     const int strip_z, const int strip_phi);
 
   //! return all towers
   virtual const Map &getDeadChannels(void) const;
@@ -35,11 +35,11 @@ class SvtxDeadMap : public PHObject
 
   virtual unsigned int size() const { return 0; }
 
-  static PHG4CellDefs::keytype getINTTKey(const unsigned int layer,
-                                          const unsigned int ladder_phi, const unsigned int ladder_z,
-                                          const unsigned int strip_z, const unsigned int strip_phi);
+  static PHG4CellDefs::keytype getINTTKey( int layer,
+                                           int ladder_phi,  int ladder_z,
+                                           int strip_z,  int strip_phi);
 
-  static PHG4CellDefs::keytype getWildCardID() {return s_wildCardID;}
+  static int getWildCardID() {return s_wildCardID;}
 
  protected:
   SvtxDeadMap()
@@ -47,7 +47,7 @@ class SvtxDeadMap : public PHObject
   }
 
  private:
-  static PHG4CellDefs::keytype s_wildCardID;
+  static int s_wildCardID;
 
   ClassDef(SvtxDeadMap, 1)
 };

--- a/simulation/g4simulation/g4hough/SvtxDeadMapLinkDef.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMapLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxDeadMap+;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4hough/SvtxDeadMapv1.C
+++ b/simulation/g4simulation/g4hough/SvtxDeadMapv1.C
@@ -16,12 +16,6 @@ SvtxDeadMapv1::getDeadChannels(void)
   return m_DeadChannels;
 }
 
-void SvtxDeadMapv1::addDeadChannel(const unsigned int layer, const unsigned int ieta, const int unsigned iphi)
-{
-  PHG4CellDefs::keytype key = PHG4CellDefs::EtaPhiBinning::genkey(layer, ieta, iphi);
-  m_DeadChannels.insert(key);
-}
-
 void SvtxDeadMapv1::addDeadChannel(PHG4CellDefs::keytype key)
 {
   m_DeadChannels.insert(key);
@@ -38,12 +32,6 @@ SvtxDeadMapv1::isDeadChannel(PHG4CellDefs::keytype key)
   return false;
 }
 
-bool
-SvtxDeadMapv1::isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi)
-{
-  PHG4CellDefs::keytype key = PHG4CellDefs::EtaPhiBinning::genkey(layer, ieta, iphi);
-  return isDeadChannel(key);
-}
 
 int SvtxDeadMapv1::isValid() const
 {

--- a/simulation/g4simulation/g4hough/SvtxDeadMapv1.C
+++ b/simulation/g4simulation/g4hough/SvtxDeadMapv1.C
@@ -21,8 +21,7 @@ void SvtxDeadMapv1::addDeadChannel(PHG4CellDefs::keytype key)
   m_DeadChannels.insert(key);
 }
 
-bool
-SvtxDeadMapv1::isDeadChannel(PHG4CellDefs::keytype key)
+bool SvtxDeadMapv1::isDeadChannel(PHG4CellDefs::keytype key) const
 {
   auto it = m_DeadChannels.find(key);
   if (it != m_DeadChannels.end())
@@ -32,10 +31,9 @@ SvtxDeadMapv1::isDeadChannel(PHG4CellDefs::keytype key)
   return false;
 }
 
-
 int SvtxDeadMapv1::isValid() const
 {
-  return size()>0;
+  return size() > 0;
 }
 
 void SvtxDeadMapv1::Reset()
@@ -47,4 +45,3 @@ void SvtxDeadMapv1::identify(std::ostream& os) const
 {
   os << "SvtxDeadMapv1, number of towers: " << size() << std::endl;
 }
-

--- a/simulation/g4simulation/g4hough/SvtxDeadMapv1.C
+++ b/simulation/g4simulation/g4hough/SvtxDeadMapv1.C
@@ -43,5 +43,5 @@ void SvtxDeadMapv1::Reset()
 
 void SvtxDeadMapv1::identify(std::ostream& os) const
 {
-  os << "SvtxDeadMapv1, number of towers: " << size() << std::endl;
+  os << "SvtxDeadMapv1, number of dead channel & sensors: " << size() << std::endl;
 }

--- a/simulation/g4simulation/g4hough/SvtxDeadMapv1.C
+++ b/simulation/g4simulation/g4hough/SvtxDeadMapv1.C
@@ -1,0 +1,62 @@
+#include "SvtxDeadMapv1.h"
+
+#include <iostream>
+
+using namespace std;
+
+const SvtxDeadMapv1::Map&
+SvtxDeadMapv1::getDeadChannels(void) const
+{
+  return m_DeadChannels;
+}
+
+SvtxDeadMapv1::Map&
+SvtxDeadMapv1::getDeadChannels(void)
+{
+  return m_DeadChannels;
+}
+
+void SvtxDeadMapv1::addDeadChannel(const unsigned int layer, const unsigned int ieta, const int unsigned iphi)
+{
+  PHG4CellDefs::keytype key = PHG4CellDefs::EtaPhiBinning::genkey(layer, ieta, iphi);
+  m_DeadChannels.insert(key);
+}
+
+void SvtxDeadMapv1::addDeadChannel(PHG4CellDefs::keytype key)
+{
+  m_DeadChannels.insert(key);
+}
+
+bool
+SvtxDeadMapv1::isDeadChannel(PHG4CellDefs::keytype key)
+{
+  auto it = m_DeadChannels.find(key);
+  if (it != m_DeadChannels.end())
+  {
+    return true;
+  }
+  return false;
+}
+
+bool
+SvtxDeadMapv1::isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi)
+{
+  PHG4CellDefs::keytype key = PHG4CellDefs::EtaPhiBinning::genkey(layer, ieta, iphi);
+  return isDeadChannel(key);
+}
+
+int SvtxDeadMapv1::isValid() const
+{
+  return size()>0;
+}
+
+void SvtxDeadMapv1::Reset()
+{
+  m_DeadChannels.clear();
+}
+
+void SvtxDeadMapv1::identify(std::ostream& os) const
+{
+  os << "SvtxDeadMapv1, number of towers: " << size() << std::endl;
+}
+

--- a/simulation/g4simulation/g4hough/SvtxDeadMapv1.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMapv1.h
@@ -1,0 +1,35 @@
+#ifndef SvtxDeadMapv1_H__
+#define SvtxDeadMapv1_H__
+
+#include "SvtxDeadMap.h"
+
+class SvtxDeadMapv1 : public SvtxDeadMap
+{
+ public:
+
+  SvtxDeadMapv1()
+  {
+  }
+  virtual ~SvtxDeadMapv1() {}
+  virtual void Reset();
+  virtual int isValid() const;
+
+  virtual void identify(std::ostream &os = std::cout) const;
+  virtual void addDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
+  virtual void addDeadChannel(PHG4CellDefs::keytype key);
+
+  virtual bool isDeadChannel(PHG4CellDefs::keytype key);
+  virtual bool isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
+  //! return all towers
+  virtual const Map &getDeadChannels(void) const;
+  virtual Map &getDeadChannels(void);
+
+  virtual unsigned int size() const { return m_DeadChannels.size(); }
+
+ private:
+  Map m_DeadChannels;
+
+  ClassDef(SvtxDeadMapv1, 1)
+};
+
+#endif /* SvtxDeadMapv1_H__ */

--- a/simulation/g4simulation/g4hough/SvtxDeadMapv1.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMapv1.h
@@ -15,11 +15,9 @@ class SvtxDeadMapv1 : public SvtxDeadMap
   virtual int isValid() const;
 
   virtual void identify(std::ostream &os = std::cout) const;
-  virtual void addDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
-  virtual void addDeadChannel(PHG4CellDefs::keytype key);
+  void addDeadChannel(PHG4CellDefs::keytype key);
 
-  virtual bool isDeadChannel(PHG4CellDefs::keytype key);
-  virtual bool isDeadChannel(const unsigned int layer, const unsigned int ieta, const unsigned int iphi);
+  bool isDeadChannel(PHG4CellDefs::keytype key);
   //! return all towers
   virtual const Map &getDeadChannels(void) const;
   virtual Map &getDeadChannels(void);

--- a/simulation/g4simulation/g4hough/SvtxDeadMapv1.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMapv1.h
@@ -17,7 +17,7 @@ class SvtxDeadMapv1 : public SvtxDeadMap
   virtual void identify(std::ostream &os = std::cout) const;
   void addDeadChannel(PHG4CellDefs::keytype key);
 
-  bool isDeadChannel(PHG4CellDefs::keytype key);
+  bool isDeadChannel(PHG4CellDefs::keytype key) const;
   //! return all towers
   virtual const Map &getDeadChannels(void) const;
   virtual Map &getDeadChannels(void);

--- a/simulation/g4simulation/g4hough/SvtxDeadMapv1LinkDef.h
+++ b/simulation/g4simulation/g4hough/SvtxDeadMapv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxDeadMapv1+;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
## Introduction

From Inner detector task force, working on simulating INTT under realistic dead area distributions, which including dead parts and hot channels which is then masked away online or offline.  The dead map is inspired by the experience of forward silicon tracker (FVTX) at PHENIX, whose DAQ is reused for INTT. 

The dead map are defined in calibration repository, read into the DST `RUN` node, applied at the digitization stage of INTT. The same map can also be used in the reconstruction stage for dead-recon and apply to real data. 

Similar approach can be expanded to MAPS and TPC too. 

## Details

The predefined dead map for INTT including random dead areas of three categories: 
* dead/masked sensors, e.g. caused by loss of HV/LV, loss of downstream DAQ cables. Later stage of FVTX operation, this was usually about 2%. 
* dead/masked FPHX chip. This is usually caused by chip mounting issue, whole chip noise or loss of one of two LVDS signal lines. The FVTX dead/hot-masked chips are usually 2%. 
* isolated dead channels: From FVTX experience, isolated dead or hot-masked channels are rare at level of 0.1%

Two categories of dead maps are uploaded to the calibration database (https://github.com/sPHENIX-Collaboration/calibrations):
* `Tracking/INTT/DeadMap_8Percent/`: 6% dead sensor, 2% dead chip. 0.1% isolated dead channels. This is borderline operational for the detector. 
* `Tracking/INTT/DeadMap_4Percent/`: 2% dead sensor, 2% dead chip. 0.1% isolated dead channels. This is a typical dead area for FVTX in Run14. 
Here is an example branch on the Inner Detector Taskforce macro repository to use them: 
https://github.com/sPHENIX-Collaboration/macrosIDTF/compare/SiDeadMap?expand=1 

_Note_: this pull request also carry a fix for duplicated digitization for the INTT hits by both `PHG4SiliconTrackerDigitizer` and `PHG4SvtxDigitizer`. `PHG4SvtxDigitizer::CalculateLadderCellADCScale(PHCompositeNode *topNode)` is now deprecated, as it is now replaced by `PHG4SiliconTrackerDigitizer`. And the new INTT hits carry properly digitized 3-bit ADC, which is reduced from the current 8-bit ADC and this may make the cluster residual slightly worse. 

## Test

To test this pull request, please point `$CALIBRATIONROOT` to your local calibration repository with this update: https://github.com/sPHENIX-Collaboration/calibrations/pull/41 
And here is the macro branch to run it: https://github.com/sPHENIX-Collaboration/macrosIDTF/tree/SiDeadMap 

For example, the hit distribution in INTT is show no-hit region of the predefined dead sensors as in the `DeadMap_8Percent` settings, plot with 
````c++
ntp_hit->Draw("atan2(gy,gx):gz>>intthit(100,-15,15,420,-3.14,3.14)","layer==3","colz")
````
![image](https://user-images.githubusercontent.com/7947083/44542604-53df6c80-a6db-11e8-995a-1feecfad6d47.png)

Under the 8% dead map setting, the track efficiency drop to ~97% for four layer INTT version. 

Request further test by @adfrawley 
