### PR TITLE
Fixes on Cherenkov simulation

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4RICHSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHSteppingAction.cc
@@ -27,6 +27,7 @@ PHG4RICHSteppingAction::PHG4RICHSteppingAction(PHG4RICHDetector* detector)
   : detector_(detector)
   , hits_(nullptr)
   , hit(nullptr)
+  , fExpectedNextStatus(Undefined)
 {
 }
 

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -429,7 +429,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   */
   theCerenkovProcess->SetMaxNumPhotonsPerStep(100);
   theCerenkovProcess->SetMaxBetaChangePerStep(10.0);
-  theCerenkovProcess->SetTrackSecondariesFirst(true);
+  theCerenkovProcess->SetTrackSecondariesFirst(false); // current PHG4TruthTrackingAction does not support suspect active track and track secondary first
 
   // theScintillationProcess->SetScintillationYieldFactor(1.);
   // theScintillationProcess->SetTrackSecondariesFirst(true);


### PR DESCRIPTION
The Cherenkov  physics list which is used in gas and Aerogel RICH detector simulation was configured to track the Cherenkov photon before completing track the charged track within Geant4. This conflicts the assumption within `PHG4TruthTrackingAction` which split a charged track into multiple duplicates. This significant disrupts truth tracking and truth tracking on EIC detector simulations. 

This pull request should fix that. In addition, it fixes a missing variable init for `PHG4RICHSteppingAction`
