### PR TITLE
Generic detector from external GDML files

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -151,6 +151,9 @@ libg4detectors_io_la_SOURCES = \
   PHG4ScintillatorSlatContainer_Dict.cc
 
 libg4detectors_la_SOURCES = \
+  PHG4GDMLDetector.cc \
+  PHG4GDMLSubsystem.cc \
+  PHG4GDMLSubsystem_Dict.cc \
   PHG4BeamlineMagnetDetector.cc \
   PHG4BeamlineMagnetSubsystem.cc \
   PHG4BeamlineMagnetSubsystem_Dict.cc \

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
@@ -82,7 +82,9 @@ void PHG4GDMLDetector::Construct(G4LogicalVolume* logicWorld)
   // import the staves from the gemetry file
   unique_ptr<G4GDMLReadStructure> reader(new G4GDMLReadStructure());
   G4GDMLParser gdmlParser(reader.get());
-  gdmlParser.Read(m_GDMPath, false);
+  gdmlParser.SetOverlapCheck(OverlapCheck());
+//  gdmlParser.Read(m_GDMPath, false);
+  gdmlParser.Read(m_GDMPath, OverlapCheck());
 
   //  G4AssemblyVolume* av_ITSUStave = reader->GetAssembly(assemblyname);
 

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
@@ -12,11 +12,16 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4UserLimits.hh>
 #include <Geant4/G4VisAttributes.hh>
+#include <Geant4/G4SystemOfUnits.hh>
 
 using namespace std;
 

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
@@ -10,6 +10,8 @@
 
 #include "PHG4GDMLDetector.h"
 
+#include <g4main/PHG4Utils.h>
+
 #include <phparameter/PHParameters.h>
 
 #include <phool/PHCompositeNode.h>
@@ -18,23 +20,32 @@
 
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4Box.hh>
-#include <Geant4/G4Colour.hh>
+#include <Geant4/G4GDMLParser.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
+#include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4UserLimits.hh>
-#include <Geant4/G4VisAttributes.hh>
+
+#include <Geant4/G4Colour.hh>
 #include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4VisAttributes.hh>
+
+#include <Geant4/G4Colour.hh>
+
+#include <memory>
 
 using namespace std;
 
-PHG4GDMLDetector::PHG4GDMLDetector(PHCompositeNode *Node, const std::string &dnam, PHParameters *parameters)
+PHG4GDMLDetector::PHG4GDMLDetector(PHCompositeNode* Node, const std::string& dnam, PHParameters* parameters)
   : PHG4Detector(Node, dnam)
   , m_GDMPath(parameters->get_string_param("GDMPath"))
   , m_TopVolName(parameters->get_string_param("TopVolName"))
-  , m_placeX(parameters->get_double_param("place_y") * cm)
-  , m_placeY(parameters->get_double_param("inner_radius") * cm)
+  , m_placeX(parameters->get_double_param("place_x") * cm)
+  , m_placeY(parameters->get_double_param("place_y") * cm)
   , m_placeZ(parameters->get_double_param("place_z") * cm)
-  , m_rotationX(parameters->get_double_param("rot_x") * rad)
-  , m_rotationY(parameters->get_double_param("rot_y") * rad)
-  , m_rotationZ(parameters->get_double_param("rot_z") * rad)
+  , m_rotationX(parameters->get_double_param("rot_x") * degree)
+  , m_rotationY(parameters->get_double_param("rot_y") * degree)
+  , m_rotationZ(parameters->get_double_param("rot_z") * degree)
 {
 }
 
@@ -44,7 +55,7 @@ PHG4GDMLDetector::~PHG4GDMLDetector()
 
 void
 
-PHG4GDMLDetector::Print(const std::string &what) const
+PHG4GDMLDetector::Print(const std::string& what) const
 {
   cout << "PHG4GDMLDetector::" << GetName() << " - import " << m_TopVolName << " from " << m_GDMPath << " with shift "
        << m_placeX << ","
@@ -55,6 +66,142 @@ PHG4GDMLDetector::Print(const std::string &what) const
        << m_rotationZ << "rad" << endl;
 }
 
-void PHG4GDMLDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4GDMLDetector::Construct(G4LogicalVolume* logicWorld)
 {
+  if (Verbosity() > 0)
+  {
+    cout << " PHG4MapsDetector::Construct:";
+    Print();
+    //      cout << endl;
+  }
+
+  //===================================
+  // Import the stave physical volume here
+  //===================================
+
+  // import the staves from the gemetry file
+  unique_ptr<G4GDMLReadStructure> reader(new G4GDMLReadStructure());
+  G4GDMLParser gdmlParser(reader.get());
+  gdmlParser.Read(m_GDMPath, false);
+
+  //  G4AssemblyVolume* av_ITSUStave = reader->GetAssembly(assemblyname);
+
+  G4LogicalVolume* vol = reader->GetVolume(m_TopVolName);
+
+  if (not vol)
+  {
+    cout << "PHG4GDMLDetector::Construct - Fatal Error - failed to find G4LogicalVolume " << m_TopVolName << " - Print: ";
+    Print();
+    exit(121);
+  }
+
+  G4RotationMatrix* rotm = new G4RotationMatrix();
+  rotm->rotateX(m_rotationX);
+  rotm->rotateY(m_rotationY);
+  rotm->rotateZ(m_rotationZ);
+  G4ThreeVector placeVec(m_placeX, m_placeY, m_placeZ);
+
+  //  av_ITSUStave->MakeImprint(trackerenvelope, Tr, 0, OverlapCheck());
+
+  new G4PVPlacement(rotm, placeVec,
+                    vol,
+                    G4String(GetName().c_str()),
+                    logicWorld, false, 0, OverlapCheck());
+  SetDisplayProperty(vol);
+}
+
+void PHG4GDMLDetector::SetDisplayProperty(G4AssemblyVolume* av)
+{
+  //  cout <<"SetDisplayProperty - G4AssemblyVolume w/ TotalImprintedVolumes "<<av->TotalImprintedVolumes()
+  //   <<"/"<<av->GetImprintsCount()<<endl;
+
+  std::vector<G4VPhysicalVolume*>::iterator it = av->GetVolumesIterator();
+
+  int nDaughters = av->TotalImprintedVolumes();
+  for (int i = 0; i < nDaughters; ++i, ++it)
+  {
+    //  cout <<"SetDisplayProperty - AV["<<i<<"] = "<<(*it)->GetName()<<endl;
+    G4VPhysicalVolume* pv = (*it);
+
+    G4LogicalVolume* worldLogical = pv->GetLogicalVolume();
+    SetDisplayProperty(worldLogical);
+  }
+}
+
+void PHG4GDMLDetector::SetDisplayProperty(G4LogicalVolume* lv)
+{
+  string material_name(
+      lv->GetMaterial()->GetName());
+
+  if (Verbosity() >= 5)
+    cout << "SetDisplayProperty - LV " << lv->GetName() << " built with "
+         << material_name << endl;
+
+  G4VisAttributes* matVis = new G4VisAttributes();
+  if (material_name.find("SI") != std::string::npos)
+  {
+    PHG4Utils::SetColour(matVis, "G4_Si");
+    matVis->SetVisibility(true);
+    matVis->SetForceSolid(true);
+    if (Verbosity() >= 5)
+      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with G4_Si" << endl;
+  }
+  else if (material_name.find("KAPTON") != std::string::npos)
+  {
+    PHG4Utils::SetColour(matVis, "G4_KAPTON");
+    matVis->SetVisibility(true);
+    matVis->SetForceSolid(true);
+    if (Verbosity() >= 5)
+      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with G4_KAPTON" << endl;
+  }
+  else if (material_name.find("ALUMINUM") != std::string::npos)
+  {
+    PHG4Utils::SetColour(matVis, "G4_Al");
+    matVis->SetVisibility(true);
+    matVis->SetForceSolid(true);
+    if (Verbosity() >= 5)
+      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with G4_Al" << endl;
+  }
+  else if (material_name.find("Carbon") != std::string::npos)
+  {
+    matVis->SetColour(0.5, 0.5, 0.5, .25);
+    matVis->SetVisibility(true);
+    matVis->SetForceSolid(true);
+    if (Verbosity() >= 5)
+      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with Gray" << endl;
+  }
+  else if (material_name.find("M60J3K") != std::string::npos)
+  {
+    matVis->SetColour(0.25, 0.25, 0.25, .25);
+    matVis->SetVisibility(true);
+    matVis->SetForceSolid(true);
+    if (Verbosity() >= 5)
+      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with Gray" << endl;
+  }
+  else if (material_name.find("WATER") != std::string::npos)
+  {
+    matVis->SetColour(0.0, 0.5, 0.0, .25);
+    matVis->SetVisibility(true);
+    matVis->SetForceSolid(true);
+    if (Verbosity() >= 5)
+      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with WATER" << endl;
+  }
+  else
+  {
+    matVis->SetColour(.2, .2, .7, .25);
+    matVis->SetVisibility(true);
+    matVis->SetForceSolid(true);
+  }
+  lv->SetVisAttributes(matVis);
+
+  int nDaughters = lv->GetNoDaughters();
+  for (int i = 0; i < nDaughters; ++i)
+  {
+    G4VPhysicalVolume* pv = lv->GetDaughter(i);
+
+    // cout <<"SetDisplayProperty - PV["<<i<<"] = "<<pv->GetName()<<endl;
+
+    G4LogicalVolume* worldLogical = pv->GetLogicalVolume();
+    SetDisplayProperty(worldLogical);
+  }
 }

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
@@ -1,0 +1,55 @@
+// $Id: $
+
+/*!
+ * \file PHG4GDMLDetector.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "PHG4GDMLDetector.h"
+
+#include <phparameter/PHParameters.h>
+
+#include <Geant4/G4AssemblyVolume.hh>
+#include <Geant4/G4Box.hh>
+#include <Geant4/G4Colour.hh>
+#include <Geant4/G4UserLimits.hh>
+#include <Geant4/G4VisAttributes.hh>
+
+using namespace std;
+
+PHG4GDMLDetector::PHG4GDMLDetector(PHCompositeNode *Node, const std::string &dnam, PHParameters *parameters)
+  : PHG4Detector(Node, dnam)
+  , m_GDMPath(parameters->get_string_param("GDMPath"))
+  , m_TopVolName(parameters->get_string_param("TopVolName"))
+  , m_placeX(parameters->get_double_param("place_y") * cm)
+  , m_placeY(parameters->get_double_param("inner_radius") * cm)
+  , m_placeZ(parameters->get_double_param("place_z") * cm)
+  , m_rotationX(parameters->get_double_param("rot_x") * rad)
+  , m_rotationY(parameters->get_double_param("rot_y") * rad)
+  , m_rotationZ(parameters->get_double_param("rot_z") * rad)
+{
+}
+
+PHG4GDMLDetector::~PHG4GDMLDetector()
+{
+}
+
+void
+
+PHG4GDMLDetector::Print(const std::string &what) const
+{
+  cout << "PHG4GDMLDetector::" << GetName() << " - import " << m_TopVolName << " from " << m_GDMPath << " with shift "
+       << m_placeX << ","
+       << m_placeY << ","
+       << m_placeZ << "cm and rotation "
+       << m_rotationX << ","
+       << m_rotationY << ","
+       << m_rotationZ << "rad" << endl;
+}
+
+void PHG4GDMLDetector::Construct(G4LogicalVolume *logicWorld)
+{
+}

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
@@ -1,34 +1,36 @@
 // $Id: $
 
 /*!
- * \file PHG4GDMDetector.h
+ * \file PHG4GDMLDetector.h
  * \brief 
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $
  */
 
-#ifndef PHG4GDMDETECTOR_H_
-#define PHG4GDMDETECTOR_H_
+#ifndef PHG4GDMLDetector_H_
+#define PHG4GDMLDetector_H_
 
 #include <g4main/PHG4Detector.h>
 #include <string>
 
-#include <Geant4/globals.hh>
 #include <Geant4/G4Types.hh>
+#include <Geant4/globals.hh>
 
 class PHCompositeNode;
 class PHParameters;
+class G4UserSteppingAction;
+class G4UserSteppingAction;
 
 /*!
- * \brief PHG4GDMDetector is a generic detector built from a GDML import
+ * \brief PHG4GDMLDetector is a generic detector built from a GDML import
  */
-class PHG4GDMDetector : public PHG4Detector
+class PHG4GDMLDetector : public PHG4Detector
 {
  public:
-  PHG4GDMDetector(PHCompositeNode* Node, const std::string& dnam, PHParameters *parameters);
+  PHG4GDMLDetector(PHCompositeNode* Node, const std::string& dnam, PHParameters* parameters);
 
-  virtual ~PHG4GDMDetector();
+  virtual ~PHG4GDMLDetector();
 
   //! construct
   void Construct(G4LogicalVolume* world);
@@ -39,7 +41,6 @@ class PHG4GDMDetector : public PHG4Detector
   }
 
   void Print(const std::string& what = "ALL") const;
-
 
  private:
   std::string m_GDMPath;
@@ -54,4 +55,4 @@ class PHG4GDMDetector : public PHG4Detector
   G4double m_rotationZ;
 };
 
-#endif /* PHG4GDMDETECTOR_H_ */
+#endif /* PHG4GDMLDetector_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
@@ -1,0 +1,57 @@
+// $Id: $
+
+/*!
+ * \file PHG4GDMDetector.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef PHG4GDMDETECTOR_H_
+#define PHG4GDMDETECTOR_H_
+
+#include <g4main/PHG4Detector.h>
+#include <string>
+
+#include <Geant4/globals.hh>
+#include <Geant4/G4Types.hh>
+
+class PHCompositeNode;
+class PHParameters;
+
+/*!
+ * \brief PHG4GDMDetector is a generic detector built from a GDML import
+ */
+class PHG4GDMDetector : public PHG4Detector
+{
+ public:
+  PHG4GDMDetector(PHCompositeNode* Node, const std::string& dnam, PHParameters *parameters);
+
+  virtual ~PHG4GDMDetector();
+
+  //! construct
+  void Construct(G4LogicalVolume* world);
+
+  G4UserSteppingAction* GetSteppingAction()
+  {
+    return nullptr;
+  }
+
+  void Print(const std::string& what = "ALL") const;
+
+
+ private:
+  std::string m_GDMPath;
+  std::string m_TopVolName;
+
+  G4double m_placeX;
+  G4double m_placeY;
+  G4double m_placeZ;
+
+  G4double m_rotationX;
+  G4double m_rotationY;
+  G4double m_rotationZ;
+};
+
+#endif /* PHG4GDMDETECTOR_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
@@ -19,6 +19,8 @@
 
 class PHCompositeNode;
 class PHParameters;
+class G4LogicalVolume;
+class G4AssemblyVolume;
 class G4UserSteppingAction;
 class G4UserSteppingAction;
 
@@ -43,6 +45,9 @@ class PHG4GDMLDetector : public PHG4Detector
   void Print(const std::string& what = "ALL") const;
 
  private:
+  void SetDisplayProperty( G4AssemblyVolume* av);
+  void SetDisplayProperty( G4LogicalVolume* lv);
+
   std::string m_GDMPath;
   std::string m_TopVolName;
 

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
@@ -1,0 +1,136 @@
+// $Id: $
+
+/*!
+ * \file PHG4GDMLSubsystem.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "PHG4GDMLSubsystem.h"
+#include "PHG4GDMLDetector.h"
+
+#include <pdbcalbase/PdbParameterMap.h>
+#include <phparameter/PHParameters.h>
+
+#include <phool/getClass.h>
+
+#include <Geant4/globals.hh>
+
+PHG4GDMLSubsystem::PHG4GDMLSubsystem()
+  : PHG4DetectorSubsystem(name, 0)
+  , m_Detector(nullptr)
+  , m_SteppingAction(nullptr)
+{
+  InitializeParameters();
+}
+
+PHG4GDMLSubsystem::~PHG4GDMLSubsystem()
+{
+}
+
+//_______________________________________________________________________
+int PHG4GDMLSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+
+  // create detector
+  m_Detector = new PHG4InnerHcalDetector(topNode, Name(), GetParams());
+  m_Detector->OverlapCheck(CheckOverlap());
+
+  //  set<string> nodes;
+  //  if (GetParams()->get_int_param("active"))
+  //  {
+  //    PHNodeIterator dstIter(dstNode);
+  //    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", SuperDetector()));
+  //    if (!DetNode)
+  //    {
+  //      DetNode = new PHCompositeNode(SuperDetector());
+  //      dstNode->addNode(DetNode);
+  //    }
+  //
+  //    ostringstream nodename;
+  //    if (SuperDetector() != "NONE")
+  //    {
+  //      nodename << "G4HIT_" << SuperDetector();
+  //    }
+  //    else
+  //    {
+  //      nodename << "G4HIT_" << Name();
+  //    }
+  //    nodes.insert(nodename.str());
+  //    if (GetParams()->get_int_param("absorberactive"))
+  //    {
+  //      nodename.str("");
+  //      if (SuperDetector() != "NONE")
+  //      {
+  //        nodename << "G4HIT_ABSORBER_" << SuperDetector();
+  //      }
+  //      else
+  //      {
+  //        nodename << "G4HIT_ABSORBER_" << Name();
+  //      }
+  //      nodes.insert(nodename.str());
+  //    }
+  //    BOOST_FOREACH (string node, nodes)
+  //    {
+  //      PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, node.c_str());
+  //      if (!g4_hits)
+  //      {
+  //        g4_hits = new PHG4HitContainer(node);
+  //        DetNode->addNode(new PHIODataNode<PHObject>(g4_hits, node.c_str(), "PHObject"));
+  //      }
+  //    }
+  //
+  //    // create stepping action
+  //    m_SteppingAction = new PHG4InnerHcalSteppingAction(m_Detector, GetParams());
+  //  }
+  //  else
+  //  {
+  //    // if this is a black hole it does not have to be active
+  //    if (GetParams()->get_int_param("blackhole"))
+  //    {
+  //      m_SteppingAction = new PHG4InnerHcalSteppingAction(m_Detector, GetParams());
+  //    }
+  //  }
+  return 0;
+}
+
+//_______________________________________________________________________
+int PHG4GDMLSubsystem::process_event(PHCompositeNode *topNode)
+{
+  return 0;
+}
+
+void PHG4GDMLSubsystem::Print(const string &what) const
+{
+  cout << Name() << " Parameters: " << endl;
+  GetParams()->Print();
+  if (m_Detector)
+  {
+    m_Detector->Print(what);
+  }
+
+  return;
+}
+
+//_______________________________________________________________________
+PHG4Detector *PHG4GDMLSubsystem::GetDetector(void) const
+{
+  return m_Detector;
+}
+
+void PHG4GDMLSubsystem::SetDefaultParameters()
+{
+  set_default_double_param("place_x", 0.);
+  set_default_double_param("place_y", 0.);
+  set_default_double_param("place_z", 0.);
+  set_default_double_param("rot_x", 0.);
+  set_default_double_param("rot_y", 0.);
+  set_default_double_param("rot_z", 0.);
+
+  set_default_string_param("GDMPath", "DefaultParameters-InvadPath");
+  set_default_string_param("TopVolName", "DefaultParameters-InvadVol");
+}

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
@@ -18,10 +18,11 @@
 
 #include <Geant4/globals.hh>
 
-PHG4GDMLSubsystem::PHG4GDMLSubsystem()
+using namespace std;
+
+PHG4GDMLSubsystem::PHG4GDMLSubsystem(const std::string &name)
   : PHG4DetectorSubsystem(name, 0)
   , m_Detector(nullptr)
-  , m_SteppingAction(nullptr)
 {
   InitializeParameters();
 }
@@ -33,11 +34,11 @@ PHG4GDMLSubsystem::~PHG4GDMLSubsystem()
 //_______________________________________________________________________
 int PHG4GDMLSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
-  PHNodeIterator iter(topNode);
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+//  PHNodeIterator iter(topNode);
+//  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  m_Detector = new PHG4InnerHcalDetector(topNode, Name(), GetParams());
+  m_Detector = new PHG4GDMLDetector(topNode, Name(), GetParams());
   m_Detector->OverlapCheck(CheckOverlap());
 
   //  set<string> nodes;

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.h
@@ -1,0 +1,59 @@
+// $Id: $
+
+/*!
+ * \file PHG4GDMLSubsystem.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef PHG4GDMLSUBSYSTEM_H_
+#define PHG4GDMLSUBSYSTEM_H_
+
+#include "PHG4DetectorSubsystem.h"
+#include <string>
+
+class PHG4GDMLDetector;
+
+/*!
+ * \brief PHG4GDMLSubsystem is a generic detector built from a GDML import
+ */
+class PHG4GDMLSubsystem : public PHG4Subsystem
+{
+ public:
+  PHG4GDMLSubsystem(const std::string &name);
+  virtual ~PHG4GDMLSubsystem();
+
+
+  /*!
+  creates the m_Detector object and place it on the node tree, under "DETECTORS" node (or whatever)
+  reates the stepping action and place it on the node tree, under "ACTIONS" node
+  creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
+  */
+  int InitRunSubsystem(PHCompositeNode*);
+
+  //! event processing
+  /*!
+  get all relevant nodes from top nodes (namely hit list)
+  and pass that to the stepping action
+  */
+  int process_event(PHCompositeNode*);
+
+  //! Print info (from SubsysReco)
+  void Print(const std::string& what = "ALL") const;
+
+  //! accessors (reimplemented)
+  PHG4Detector* GetDetector(void) const;
+  PHG4SteppingAction* GetSteppingAction(void) const { return nullptr; }
+
+ private:
+  void SetDefaultParameters();
+
+  //! detector geometry
+  /*! derives from PHG4Detector */
+  PHG4GDMLDetector* m_Detector;
+
+};
+
+#endif /* PHG4GDMLSUBSYSTEM_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.h
@@ -19,9 +19,10 @@ class PHG4GDMLDetector;
 /*!
  * \brief PHG4GDMLSubsystem is a generic detector built from a GDML import
  */
-class PHG4GDMLSubsystem : public PHG4Subsystem
+class PHG4GDMLSubsystem : public PHG4DetectorSubsystem
 {
  public:
+
   PHG4GDMLSubsystem(const std::string &name);
   virtual ~PHG4GDMLSubsystem();
 

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystemLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4GDMLSubsystem-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.h
@@ -1,7 +1,7 @@
 #ifndef PHG4HcalDetector_h
 #define PHG4HcalDetector_h
 
-#include "g4main/PHG4Detector.h"
+#include <g4main/PHG4Detector.h>
 
 #include <Geant4/globals.hh>
 #include <Geant4/G4Region.hh>


### PR DESCRIPTION
Adding a generic detector in Geant4 simulation, which are defined in external GDML files. This module can be used to import mechanical drawing or externally defined detector geometry to be used as part of the Geant4 simulation. Currently, the imported detectors are not active, but it is possible to define an associated stepping action to enable recording the hits. 

Example macros is: https://github.com/blackcathj/macros/blob/dose_PHENIX/macros/g4simulations/Fun4All_G4_sPHENIX.C , which import the whole PHENIX detector into the simulation: 

Top view of a few 10+ GeV pions in the full PHENIX detector:
![phenix5](https://user-images.githubusercontent.com/7947083/44697392-8d9cd400-aa49-11e8-9f39-3711fe7fa24f.png)
![phenix4](https://user-images.githubusercontent.com/7947083/44697408-9beaf000-aa49-11e8-90f9-60d2893baea1.png)



