### PR TITLE
Fix up the Intt

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -260,6 +260,7 @@ libg4detectors_la_SOURCES = \
   PHG4SectorSubsystem_Dict.cc \
   PHG4SiliconTrackerCellReco.cc \
   PHG4SiliconTrackerCellReco_Dict.cc \
+  PHG4SiliconTrackerDefs_Dict.cc \
   PHG4SiliconTrackerDetector.cc \
   PHG4SiliconTrackerSteppingAction.cc \
   PHG4SiliconTrackerSubsystem.cc \

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -542,9 +542,25 @@ void PHG4DetectorGroupSubsystem::SetActive(const int detid, const int i)
   set_int_param(detid, "active", i);
 }
 
+void PHG4DetectorGroupSubsystem::SetActive(const int i)
+{
+  for (auto detid = layers.begin(); detid != layers.end(); ++detid)
+  {
+  set_int_param(*detid, "active", i);
+  }
+}
+
 void PHG4DetectorGroupSubsystem::SetAbsorberActive(const int detid, const int i)
 {
   set_int_param(detid, "absorberactive", i);
+}
+
+void PHG4DetectorGroupSubsystem::SetAbsorberActive(const int i)
+{
+  for (auto detid = layers.begin(); detid != layers.end(); ++detid)
+  {
+  set_int_param(*detid, "absorberactive", i);
+  }
 }
 
 void PHG4DetectorGroupSubsystem::BlackHole(const int detid, const int i)
@@ -552,9 +568,25 @@ void PHG4DetectorGroupSubsystem::BlackHole(const int detid, const int i)
   set_int_param(detid, "blackhole", i);
 }
 
+void PHG4DetectorGroupSubsystem::BlackHole(const int i)
+{
+  for (auto detid = layers.begin(); detid != layers.end(); ++detid)
+  {
+  set_int_param(*detid, "blackhole", i);
+  }
+}
+
 void PHG4DetectorGroupSubsystem::SetAbsorberTruth(const int detid, const int i)
 {
   set_int_param(detid, "absorbertruth", i);
+}
+
+void PHG4DetectorGroupSubsystem::SetAbsorberTruth(const int i)
+{
+  for (auto detid = layers.begin(); detid != layers.end(); ++detid)
+  {
+  set_int_param(*detid, "absorbertruth", i);
+  }
 }
 
 void PHG4DetectorGroupSubsystem::PrintDefaultParams() const

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -116,7 +116,7 @@ int PHG4DetectorGroupSubsystem::InitRun(PHCompositeNode *topNode)
   else
   {
     // if not filled from file or DB, check if we have a node containing those calibrations
-    // on the node tree and load them (the embedding wants to use the 
+    // on the node tree and load them (the embedding wants to use the
     // parameters saved on the previous pass)
     PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode, paramnodename);
     if (nodeparams)
@@ -546,7 +546,7 @@ void PHG4DetectorGroupSubsystem::SetActive(const int i)
 {
   for (auto detid = layers.begin(); detid != layers.end(); ++detid)
   {
-  set_int_param(*detid, "active", i);
+    set_int_param(*detid, "active", i);
   }
 }
 
@@ -559,7 +559,7 @@ void PHG4DetectorGroupSubsystem::SetAbsorberActive(const int i)
 {
   for (auto detid = layers.begin(); detid != layers.end(); ++detid)
   {
-  set_int_param(*detid, "absorberactive", i);
+    set_int_param(*detid, "absorberactive", i);
   }
 }
 
@@ -572,7 +572,7 @@ void PHG4DetectorGroupSubsystem::BlackHole(const int i)
 {
   for (auto detid = layers.begin(); detid != layers.end(); ++detid)
   {
-  set_int_param(*detid, "blackhole", i);
+    set_int_param(*detid, "blackhole", i);
   }
 }
 
@@ -585,7 +585,7 @@ void PHG4DetectorGroupSubsystem::SetAbsorberTruth(const int i)
 {
   for (auto detid = layers.begin(); detid != layers.end(); ++detid)
   {
-  set_int_param(*detid, "absorbertruth", i);
+    set_int_param(*detid, "absorbertruth", i);
   }
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.h
@@ -56,10 +56,14 @@ class PHG4DetectorGroupSubsystem : public PHG4Subsystem
   void SetCalibrationFileDir(const std::string &calibdir) { calibfiledir = calibdir; }
   void UpdateParametersWithMacro();
 
-  void SetActive(const int detid, const int i = 1);
-  void SetAbsorberActive(const int detid, const int i = 1);
-  void SetAbsorberTruth(const int detid, const int i = 1);
-  void BlackHole(const int detid, const int i = 1);
+  void SetActive(const int detid, const int i);
+  void SetActive(const int i = 1);
+  void SetAbsorberActive(const int detid, const int i);
+  void SetAbsorberActive(const int i = 1);
+  void SetAbsorberTruth(const int detid, const int i);
+  void SetAbsorberTruth(const int i = 1);
+  void BlackHole(const int detid, const int i);
+  void BlackHole(const int i = 1);
   void SuperDetector(const std::string &name);
   const std::string SuperDetector() const { return superdetector; }
   int GetLayer() const { return layer; }

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDefs.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDefs.h
@@ -1,0 +1,21 @@
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4SILICONTRACKERDEFS_H
+#define G4DETECTORS_PHG4SILICONTRACKERDEFS_H
+
+#include <set>
+
+namespace PHG4SiliconTrackerDefs
+{
+  static const int SEGMENTATION_Z = -1;
+  static const int SEGMENTATION_PHI = -2;
+// this set only exists so we can iterate over the enum
+// yes it can be made more fancy but this will do
+// and yes stupid CINT does not understand C++11
+#ifndef __CINT__
+  static std::set<int> m_SensorSegmentationSet {SEGMENTATION_Z,SEGMENTATION_PHI};
+#endif
+};
+
+#endif
+

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDefs.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDefs.h
@@ -7,15 +7,14 @@
 
 namespace PHG4SiliconTrackerDefs
 {
-  static const int SEGMENTATION_Z = -1;
-  static const int SEGMENTATION_PHI = -2;
+static const int SEGMENTATION_Z = -1;
+static const int SEGMENTATION_PHI = -2;
 // this set only exists so we can iterate over the enum
 // yes it can be made more fancy but this will do
 // and yes stupid CINT does not understand C++11
 #ifndef __CINT__
-  static std::set<int> m_SensorSegmentationSet {SEGMENTATION_Z,SEGMENTATION_PHI};
+static std::set<int> m_SensorSegmentationSet{SEGMENTATION_Z, SEGMENTATION_PHI};
 #endif
-};
+};  // namespace PHG4SiliconTrackerDefs
 
 #endif
-

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -99,21 +99,18 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
 
   {
-//    const int sphxlayer = layeriter->first;
-    const int sphxlayer = layeriter->second;
-      const int inttlayer = layeriter->second;
-      int ilayer = inttlayer;
+      int inttlayer = layeriter->second;
        // get the parameters for this layer
       const PHParameters *params1 = paramscontainer->GetParameters(inttlayer);
       const int laddertype = params1->get_int_param("laddertype");
       const G4double offsetphi = params1->get_double_param("offsetphi")*deg;
       G4double offsetrot = params1->get_double_param("offsetrot")*deg;
-      sensor_radius_inner[ilayer] = params1->get_double_param("sensor_radius_inner")*mm;
-      sensor_radius_outer[ilayer] = params1->get_double_param("sensor_radius_outer")*mm;
+      sensor_radius_inner[inttlayer] = params1->get_double_param("sensor_radius_inner")*mm;
+      sensor_radius_outer[inttlayer] = params1->get_double_param("sensor_radius_outer")*mm;
       const int nladders_layer = params1->get_int_param("nladder");
       cout << "Constructing Silicon Tracker layer: " << endl;
-      cout << "   layer " << ilayer << " laddertype " << laddertype << " nladders_layer " << nladders_layer 
-	   << " sensor_radius_inner " << sensor_radius_inner[ilayer] << " sensor_radius_outer " << sensor_radius_outer[ilayer] << endl;
+      cout << "   layer " << inttlayer << " laddertype " << laddertype << " nladders_layer " << nladders_layer 
+	   << " sensor_radius_inner " << sensor_radius_inner[inttlayer] << " sensor_radius_outer " << sensor_radius_outer[inttlayer] << endl;
 
       // Look up all remaining parameters by the laddertype for this layer
       const PHParameters *params = paramscontainer->GetParameters(laddertype);
@@ -164,10 +161,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  //============================================================
       
 	  // Create a volume for the Si-strip. Use half widths to make the box
-	  G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % sphxlayer %itype).c_str(), 
+	  G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % inttlayer %itype).c_str(), 
 					  strip_x / 2., strip_y / 2. - strip_y / 20000., strip_z / 2. - strip_z / 2. / 10000.);
 	  G4LogicalVolume *strip_volume = new G4LogicalVolume(strip_box, G4Material::GetMaterial("G4_Si"), 
-							      boost::str(boost::format("strip_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+							      boost::str(boost::format("strip_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsActive.find(inttlayer))->second > 0)
 	    {
 	      activelogvols.insert(strip_volume);
@@ -182,9 +179,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  const double siactive_x = strip_x;
 	  const double siactive_y = strip_y * nstrips_phi_sensor; 
 	  const double siactive_z = strip_z * nstrips_z_sensor;  
-	  G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % sphxlayer % itype).c_str(), siactive_x/2, siactive_y/2., siactive_z/2.);
+	  G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % inttlayer % itype).c_str(), siactive_x/2, siactive_y/2., siactive_z/2.);
 	  G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), 
-								 boost::str(boost::format("siactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+								 boost::str(boost::format("siactive_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 	  G4VisAttributes *siactive_vis = new G4VisAttributes();
 	  siactive_vis->SetVisibility(true);
 	  siactive_vis->SetForceSolid(true);
@@ -194,20 +191,20 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  // Now make a G4PVParameterised containing all of the strips in a sensor 
 	  // this works for ladder 0 because there is only one strip type - all cells are identical
 	  G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_sensor, nstrips_z_sensor, strip_y, strip_z);
-	  new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), 
+	  new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % inttlayer % itype).c_str(), 
 				strip_volume, siactive_volume, kZAxis, nstrips_phi_sensor * nstrips_z_sensor, stripparam, false);  // overlap check too long.
 
 	  // Si-sensor full (active+inactive) area
 	  const double sifull_x = siactive_x;
 	  const double sifull_y = siactive_y + 2.0*params->get_double_param("sensor_edge_phi"); 
 	  const double sifull_z = siactive_z + 2.0*params->get_double_param("sensor_edge_z");    
-      	  G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % sphxlayer % itype).c_str(), sifull_x / 2., sifull_y/2.0, sifull_z/2.0);
+      	  G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % inttlayer % itype).c_str(), sifull_x / 2., sifull_y/2.0, sifull_z/2.0);
       
 	  // Si-sensor inactive area
-      	  G4VSolid *siinactive_box = new G4SubtractionSolid(boost::str(boost::format("siinactive_box_%d_%d") % sphxlayer % itype).c_str(), 
+      	  G4VSolid *siinactive_box = new G4SubtractionSolid(boost::str(boost::format("siinactive_box_%d_%d") % inttlayer % itype).c_str(), 
 							    sifull_box, siactive_box, 0, G4ThreeVector(0, 0, 0));
 	  G4LogicalVolume *siinactive_volume = new G4LogicalVolume(siinactive_box, G4Material::GetMaterial("G4_Si"), 
-								   boost::str(boost::format("siinactive_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+								   boost::str(boost::format("siinactive_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(siinactive_volume);
@@ -222,13 +219,13 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
 	  // This makes HDI volumes that matche this sensor in Z length
 	  const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z");  
-	  hdi_z_[ilayer][itype] = hdi_z;
-	  G4VSolid *hdi_kapton_box = new G4Box(boost::str(boost::format("hdi_kapton_box_%d_%d") % sphxlayer % itype).c_str(), hdi_kapton_x / 2., hdi_y / 2., hdi_z/2.0);
+	  hdi_z_[inttlayer][itype] = hdi_z;
+	  G4VSolid *hdi_kapton_box = new G4Box(boost::str(boost::format("hdi_kapton_box_%d_%d") % inttlayer % itype).c_str(), hdi_kapton_x / 2., hdi_y / 2., hdi_z/2.0);
 	  G4LogicalVolume *hdi_kapton_volume = new G4LogicalVolume(hdi_kapton_box, G4Material::GetMaterial("G4_KAPTON"), 
-							    boost::str(boost::format("hdi_kapton_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-	  G4VSolid *hdi_copper_box = new G4Box(boost::str(boost::format("hdi_copper_box_%d_%d") % sphxlayer % itype).c_str(), hdi_copper_x / 2., hdi_y / 2., hdi_z/2.0);
+							    boost::str(boost::format("hdi_kapton_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *hdi_copper_box = new G4Box(boost::str(boost::format("hdi_copper_box_%d_%d") % inttlayer % itype).c_str(), hdi_copper_x / 2., hdi_y / 2., hdi_z/2.0);
 	  G4LogicalVolume *hdi_copper_volume = new G4LogicalVolume(hdi_copper_box, G4Material::GetMaterial("G4_Cu"), 
-							    boost::str(boost::format("hdi_copper_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+							    boost::str(boost::format("hdi_copper_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(hdi_kapton_volume);
@@ -236,15 +233,15 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	    }
 
 	  // This is the part of the HDI that extends beyond the sensor
-	  const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z  - hdi_z_[ilayer][0] - hdi_z;  // need to assign nonzero value for itype=0
-	  G4VSolid *hdiext_kapton_box = new G4Box(boost::str(boost::format("hdiext_kapton_box_%d_%s") % sphxlayer % itype).c_str(), 
+	  const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z  - hdi_z_[inttlayer][0] - hdi_z;  // need to assign nonzero value for itype=0
+	  G4VSolid *hdiext_kapton_box = new G4Box(boost::str(boost::format("hdiext_kapton_box_%d_%s") % inttlayer % itype).c_str(), 
 						  hdi_kapton_x / 2., hdi_y / 2., hdiext_z / 2.0);
 	  G4LogicalVolume *hdiext_kapton_volume = new G4LogicalVolume(hdiext_kapton_box, G4Material::GetMaterial("G4_KAPTON"),  // was "FPC" 
-							       boost::str(boost::format("hdiext_kapton_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
-	  G4VSolid *hdiext_copper_box = new G4Box(boost::str(boost::format("hdiext_copper_box_%d_%s") % sphxlayer % itype).c_str(), 
+							       boost::str(boost::format("hdiext_kapton_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *hdiext_copper_box = new G4Box(boost::str(boost::format("hdiext_copper_box_%d_%s") % inttlayer % itype).c_str(), 
 						  hdi_copper_x / 2., hdi_y / 2., hdiext_z / 2.0);
 	  G4LogicalVolume *hdiext_copper_volume = new G4LogicalVolume(hdiext_copper_box, G4Material::GetMaterial("G4_Cu"), 
-							       boost::str(boost::format("hdiext_copper_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+							       boost::str(boost::format("hdiext_copper_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(hdiext_kapton_volume);
@@ -264,9 +261,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  hdiext_copper_volume->SetVisAttributes(hdi_copper_vis);
 
 	  // FPHX
-	  G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % sphxlayer % itype).c_str(), fphx_x / 2., fphx_y / 2., fphx_z / 2.);
+	  G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % inttlayer % itype).c_str(), fphx_x / 2., fphx_y / 2., fphx_z / 2.);
 	  G4LogicalVolume *fphx_volume = new G4LogicalVolume(fphx_box, G4Material::GetMaterial("G4_Si"), 
-							     boost::str(boost::format("fphx_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+							     boost::str(boost::format("fphx_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(fphx_volume);
@@ -281,10 +278,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       
 	  //  FPHX Container
 	  // make a container for the FPHX chips needed for this sensor, and  then place them in the container
-	  G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % sphxlayer % itype).c_str(), 
+	  G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % inttlayer % itype).c_str(), 
 						  fphx_x / 2., fphx_y / 2., hdi_z / 2.);
 	  G4LogicalVolume *fphxcontainer_volume = new G4LogicalVolume(fphxcontainer_box, G4Material::GetMaterial("G4_AIR"), 
-								      boost::str(boost::format("fphxcontainer_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+								      boost::str(boost::format("fphxcontainer_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(fphxcontainer_volume);
@@ -318,24 +315,24 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  cell_length_z = strip_z * nstrips_z_sensor / ncopy;
 	  offsetz = (ncopy % 2 == 0) ? -2. * cell_length_z / 2. * double(ncopy / 2) + cell_length_z / 2. : -2. * cell_length_z / 2. * double(ncopy / 2);
 	  G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * cell_length_z / 2., ncopy);
-	  new G4PVParameterised(boost::str(boost::format("fphxcontainer_%d_%d") % sphxlayer % itype).c_str(), 
+	  new G4PVParameterised(boost::str(boost::format("fphxcontainer_%d_%d") % inttlayer % itype).c_str(), 
 				fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, OverlapCheck());
 
 	  // PGS   - this is the carbon sheet that the HDI sits on. It forms the wall of the cooling tube that cools the HDI
         
 	  const double pgs_y = hdi_y;
 	  const double pgs_z = hdi_z;
-	  G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., pgs_z / 2.);
+	  G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % inttlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., pgs_z / 2.);
 	  G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("CFRP_INTT"), 
-							    boost::str(boost::format("pgs_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+							    boost::str(boost::format("pgs_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(pgs_volume);
 	    }
 	  // The part that extends beyond this sensor, see above for hdiext
-	  G4VSolid *pgsext_box = new G4Box(boost::str(boost::format("pgsext_box_%d_%s") % sphxlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., hdiext_z / 2.);
+	  G4VSolid *pgsext_box = new G4Box(boost::str(boost::format("pgsext_box_%d_%s") % inttlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., hdiext_z / 2.);
 	  G4LogicalVolume *pgsext_volume = new G4LogicalVolume(pgsext_box, G4Material::GetMaterial("CFRP_INTT"), 
-							       boost::str(boost::format("pgsext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+							       boost::str(boost::format("pgsext_volume_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
 
 	  G4VisAttributes *pgs_vis = new G4VisAttributes();
 	  pgs_vis->SetVisibility(true);
@@ -370,14 +367,14 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
 	  for(int i=0;i<4;i++)
 	    {
-	      stave_curve_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_cons_%d_%d_%d") %sphxlayer % itype %i).c_str(), 
+	      stave_curve_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_cons_%d_%d_%d") %inttlayer % itype %i).c_str(), 
 					       Rcmin, Rcmax, stave_z / 2., phic_begin[i], dphic[i]);
 	      stave_curve_volume[i] = new G4LogicalVolume(stave_curve_cons[i], G4Material::GetMaterial("CFRP_INTT"), 
-							  boost::str(boost::format("stave_curve_volume_%d_%d_%d") % sphxlayer % itype % i).c_str(), 0, 0, 0);
-	      stave_curve_ext_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_ext_cons_%d_%d_%d") %sphxlayer % itype %i).c_str(), 
+							  boost::str(boost::format("stave_curve_volume_%d_%d_%d") % inttlayer % itype % i).c_str(), 0, 0, 0);
+	      stave_curve_ext_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_ext_cons_%d_%d_%d") %inttlayer % itype %i).c_str(), 
 						   Rcmin, Rcmax, hdiext_z / 2., phic_begin[i], dphic[i]);
 	      stave_curve_ext_volume[i] = new G4LogicalVolume(stave_curve_ext_cons[i], G4Material::GetMaterial("CFRP_INTT"), 
-							      boost::str(boost::format("stave_curve_ext_volume_%d_%d_%d") % sphxlayer % itype %i).c_str(), 0, 0, 0);
+							      boost::str(boost::format("stave_curve_ext_volume_%d_%d_%d") % inttlayer % itype %i).c_str(), 0, 0, 0);
 
 	      G4VisAttributes *stave_curve_vis = new G4VisAttributes();
 	      stave_curve_vis->SetVisibility(true);
@@ -394,34 +391,34 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  
 	  // Outer straight sections of stave
 	  double stave_wall_thickness = 0.03*cm;
-	  G4VSolid *stave_straight_outer_box = new G4Box(boost::str(boost::format("stave_straight_outer_box_%d_%d") % sphxlayer % itype).c_str(), 
+	  G4VSolid *stave_straight_outer_box = new G4Box(boost::str(boost::format("stave_straight_outer_box_%d_%d") % inttlayer % itype).c_str(), 
 							 stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
 	  G4LogicalVolume *stave_straight_outer_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("CFRP_INTT"), 
-									     boost::str(boost::format("stave_straight_outer_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-	  G4VSolid *stave_straight_outer_ext_box = new G4Box(boost::str(boost::format("stave_straight_outer_ext_box_%d_%s") % sphxlayer % itype).c_str(), 
+									     boost::str(boost::format("stave_straight_outer_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *stave_straight_outer_ext_box = new G4Box(boost::str(boost::format("stave_straight_outer_ext_box_%d_%s") % inttlayer % itype).c_str(), 
 							     stave_wall_thickness/2., stave_straight_outer_y/2., hdiext_z / 2.);
 	  G4LogicalVolume *stave_straight_outer_ext_volume = new G4LogicalVolume(stave_straight_outer_ext_box, G4Material::GetMaterial("CFRP_INTT"), 
-										 boost::str(boost::format("stave_straight_outer_ext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+										 boost::str(boost::format("stave_straight_outer_ext_volume_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
 	  
 	  // connects cooling tubes together, only needed for laddertype PHG4SiliconTrackerDefs::SEGMENTATION_PHI, for laddertype PHG4SiliconTrackerDefs::SEGMENTATION_Z we just make a dummy
-	  G4VSolid *stave_straight_inner_box = new G4Box(boost::str(boost::format("stave_straight_inner_box_%d_%d") % sphxlayer % itype).c_str(), 
+	  G4VSolid *stave_straight_inner_box = new G4Box(boost::str(boost::format("stave_straight_inner_box_%d_%d") % inttlayer % itype).c_str(), 
 							 stave_wall_thickness / 2., stave_straight_inner_y / 2., stave_z / 2.);
 	  G4LogicalVolume *stave_straight_inner_volume = new G4LogicalVolume(stave_straight_inner_box, G4Material::GetMaterial("CFRP_INTT"), 
-									     boost::str(boost::format("stave_straight_inner_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-	  G4VSolid *stave_straight_inner_ext_box = new G4Box(boost::str(boost::format("stave_straight_inner_ext_box_%d_%d") % sphxlayer % itype).c_str(), 
+									     boost::str(boost::format("stave_straight_inner_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *stave_straight_inner_ext_box = new G4Box(boost::str(boost::format("stave_straight_inner_ext_box_%d_%d") % inttlayer % itype).c_str(), 
 							     stave_wall_thickness / 2., stave_straight_inner_y / 2., hdiext_z / 2.);
 	  G4LogicalVolume *stave_straight_inner_ext_volume  = new G4LogicalVolume(stave_straight_inner_ext_box, G4Material::GetMaterial("CFRP_INTT"), 
-										  boost::str(boost::format("stave_straight_inner_ext_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+										  boost::str(boost::format("stave_straight_inner_ext_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 	  
 	  //Top surface of cooler tube
-	  G4VSolid *stave_straight_cooler_box = new G4Box(boost::str(boost::format("stave_straight_cooler_box_%d_%d") % sphxlayer % itype).c_str(), 
+	  G4VSolid *stave_straight_cooler_box = new G4Box(boost::str(boost::format("stave_straight_cooler_box_%d_%d") % inttlayer % itype).c_str(), 
 							  stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
 	  G4LogicalVolume *stave_straight_cooler_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("CFRP_INTT"), 
-									      boost::str(boost::format("stave_straight_cooler_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
-	  G4VSolid *stave_straight_cooler_ext_box = new G4Box(boost::str(boost::format("stave_straight_cooler_ext_box_%d_%d") % sphxlayer % itype).c_str(), 
+									      boost::str(boost::format("stave_straight_cooler_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *stave_straight_cooler_ext_box = new G4Box(boost::str(boost::format("stave_straight_cooler_ext_box_%d_%d") % inttlayer % itype).c_str(), 
 							      stave_wall_thickness / 2., stave_straight_cooler_y / 2., hdiext_z / 2.);
 	  G4LogicalVolume *stave_straight_cooler_ext_volume = new G4LogicalVolume(stave_straight_cooler_ext_box, G4Material::GetMaterial("CFRP_INTT"), 
-										  boost::str(boost::format("stave_straight_cooler_ext_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+										  boost::str(boost::format("stave_straight_cooler_ext_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 	  
 	  G4VisAttributes *stave_vis = new G4VisAttributes();
 	  stave_vis->SetVisibility(true);
@@ -447,18 +444,18 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  double cooler_x = cooler_gap_x + cooler_wall; 
 	  const double stave_x = cooler_x;  // we do not include the PGS in the stave volume
 	  const double stave_y = hdi_y;
-	  G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % sphxlayer % itype).c_str(), stave_x / 2., stave_y / 2., stave_z / 2.);
+	  G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % inttlayer % itype).c_str(), stave_x / 2., stave_y / 2., stave_z / 2.);
 	  G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_AIR"), 
-							      boost::str(boost::format("stave_volume_%d_%d") % sphxlayer % itype).c_str(), 0, 0, 0);
+							      boost::str(boost::format("stave_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 	  /*
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(stave_volume);
 	    }
 	  */
-	  G4VSolid *staveext_box = new G4Box(boost::str(boost::format("staveext_box_%d_%s") % sphxlayer % itype).c_str(), stave_x / 2., stave_y / 2., hdiext_z / 2.);
+	  G4VSolid *staveext_box = new G4Box(boost::str(boost::format("staveext_box_%d_%s") % inttlayer % itype).c_str(), stave_x / 2., stave_y / 2., hdiext_z / 2.);
 	  G4LogicalVolume *staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"), 
-								 boost::str(boost::format("staveext_volume_%d_%s") % sphxlayer % itype).c_str(), 0, 0, 0);
+								 boost::str(boost::format("staveext_volume_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
 	  /*
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
@@ -496,16 +493,16 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 		  if(i==0)
 		    {
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume, 
-					boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % i % inttlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume, 
-					boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % i % inttlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
 		    }
 		  else
 		    {
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume, 
-					boost::str(boost::format("stave_straight_outer_%d_%d_%d") % i % sphxlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_outer_%d_%d_%d") % i % inttlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume, 
-					boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % i % sphxlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % i % inttlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
 		    }
 		}
 	      // The cooler curved sections are made using 2 curved sections in a recurve on each side of the cooler straight section 
@@ -532,9 +529,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	      for(int i=0;i<4;i++)
 		{
 		  new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_volume[i], 
-				    boost::str(boost::format("stave_curve_%d_%d_%d") % sphxlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
+				    boost::str(boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
 		  new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_ext_volume[i], 
-				    boost::str(boost::format("stave_curve_ext_%d_%d_%s") % sphxlayer % itype %i).c_str(), staveext_volume, false, 0, OverlapCheck());
+				    boost::str(boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype %i).c_str(), staveext_volume, false, 0, OverlapCheck());
 		}
 	    }
 	  else if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI) 	      // The type PHG4SiliconTrackerDefs::SEGMENTATION_PHI ladder has two cooling tubes
@@ -563,23 +560,23 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 		  if(i==0)
 		    {
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_volume, 
-					boost::str(boost::format("stave_straight_inner_%d_%d_%d") % sphxlayer % itype %i).c_str(), stave_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_inner_%d_%d_%d") % inttlayer % itype %i).c_str(), stave_volume, false, 0, OverlapCheck());
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_ext_volume, 
-					boost::str(boost::format("stave_straight_inner_ext_%d_%d_%s") % sphxlayer % itype %i).c_str(), staveext_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_inner_ext_%d_%d_%s") % inttlayer % itype %i).c_str(), staveext_volume, false, 0, OverlapCheck());
 		    }
 		  else if(i==1 || i==2)
 		    {
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume, 
-					boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % sphxlayer % itype %i).c_str(), stave_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % inttlayer % itype %i).c_str(), stave_volume, false, 0, OverlapCheck());
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume, 
-					boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % sphxlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % inttlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
 		    }
 		  else
 		    {
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume, 
-					boost::str(boost::format("stave_straight_outer_%d_%d_%d") % sphxlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_outer_%d_%d_%d") % inttlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
 		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume, 
-					boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % sphxlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
+					boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % inttlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
 		    }
 		}
 	      
@@ -620,9 +617,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 		    ivol = i - 4;
 
 		  new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_volume[ivol], boost::str(boost::format("stave_curve_%d_%d_%d") 
-															     % sphxlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
+															     % inttlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
 		  new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_ext_volume[ivol], boost::str(boost::format("stave_curve_ext_%d_%d_%s") 
-																 % sphxlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
+																 % inttlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
 		}
 	    }
 	  else
@@ -649,16 +646,16 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  {
             ladder_y = ladder_y + 2.0* sensor_offset_y;
 	  }	    
-	  G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % sphxlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., ladder_z / 2.);
-	  G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_%d_%d_%d") % sphxlayer % inttlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % inttlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., ladder_z / 2.);
+	  G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_%d_%d_%d") % inttlayer % inttlayer % itype).c_str(), 0, 0, 0);
 
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(ladder_volume);
 	    }
 
-	  G4VSolid *ladderext_box = new G4Box(boost::str(boost::format("ladderext_box_%d_%s") % sphxlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladderext_%d_%d_%d") % sphxlayer % inttlayer % itype).c_str(), 0, 0, 0);
+	  G4VSolid *ladderext_box = new G4Box(boost::str(boost::format("ladderext_box_%d_%s") % inttlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., hdiext_z / 2.);
+	  G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladderext_%d_%d_%d") % inttlayer % inttlayer % itype).c_str(), 0, 0, 0);
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(ladderext_volume);
@@ -685,35 +682,35 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
             TVstave_y = - sensor_offset_y;  // for type PHG4SiliconTrackerDefs::SEGMENTATION_Z the stave is offset from the sensor center, and the sensor center is the middle of the stave volume
 	  }
 	  const double TVstave_x = ladder_x / 2. - stave_x / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVstave_x, TVstave_y, 0.0), stave_volume, boost::str(boost::format("stave_%d_%d") % sphxlayer % itype).c_str(), 
+	  new G4PVPlacement(0, G4ThreeVector(TVstave_x, TVstave_y, 0.0), stave_volume, boost::str(boost::format("stave_%d_%d") % inttlayer % itype).c_str(), 
 			    ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVstave_x, TVstave_y, 0.0), staveext_volume, boost::str(boost::format("staveext_%d_%s") % sphxlayer % itype).c_str(), 
+	  new G4PVPlacement(0, G4ThreeVector(TVstave_x, TVstave_y, 0.0), staveext_volume, boost::str(boost::format("staveext_%d_%s") % inttlayer % itype).c_str(), 
 			    ladderext_volume, false, 0, OverlapCheck());
 
 	  // PGS
 	  const double TVpgs_x = TVstave_x - stave_x / 2. - pgs_x / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVpgs_x, TVstave_y, 0.0), pgs_volume, boost::str(boost::format("pgs_%d_%d") % sphxlayer % itype).c_str(), 
+	  new G4PVPlacement(0, G4ThreeVector(TVpgs_x, TVstave_y, 0.0), pgs_volume, boost::str(boost::format("pgs_%d_%d") % inttlayer % itype).c_str(), 
 			    ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVpgs_x, TVstave_y, 0.0), pgsext_volume, boost::str(boost::format("pgsext_%d_%s") % sphxlayer % itype).c_str(), 
+	  new G4PVPlacement(0, G4ThreeVector(TVpgs_x, TVstave_y, 0.0), pgsext_volume, boost::str(boost::format("pgsext_%d_%s") % inttlayer % itype).c_str(), 
 			    ladderext_volume, false, 0, OverlapCheck());
 
 	  // HDI Kapton        
 	  const double TVhdi_kapton_x = TVpgs_x - pgs_x / 2. - hdi_kapton_x / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdi_kapton_volume, boost::str(boost::format("hdikapton_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdiext_kapton_volume, boost::str(boost::format("hdiextkapton_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdi_kapton_volume, boost::str(boost::format("hdikapton_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdiext_kapton_volume, boost::str(boost::format("hdiextkapton_%d_%s") % inttlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
 	  // HDI copper        
 	  const double TVhdi_copper_x = TVhdi_kapton_x - hdi_kapton_x / 2. - hdi_copper_x / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdi_copper_volume, boost::str(boost::format("hdicopper_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdiext_copper_volume, boost::str(boost::format("hdiextcopper_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdi_copper_volume, boost::str(boost::format("hdicopper_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdiext_copper_volume, boost::str(boost::format("hdiextcopper_%d_%s") % inttlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
 	  // Si-sensor        
 	  const double TVSi_x = TVhdi_copper_x - hdi_copper_x / 2. - siactive_x / 2.;
 	  // sensor is centered in y in the ladder volume for both types
 	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siinactive_volume, 
-			    boost::str(boost::format("siinactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+			    boost::str(boost::format("siinactive_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siactive_volume, 
-			    boost::str(boost::format("siactive_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+			    boost::str(boost::format("siactive_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
 	  // FPHX container
 	  const double TVfphx_x = TVhdi_copper_x - hdi_copper_x / 2. - fphx_x / 2.;
@@ -721,9 +718,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  // laddertype PHG4SiliconTrackerDefs::SEGMENTATION_Z has only one FPHX, laddertype PHG4SiliconTrackerDefs::SEGMENTATION_PHI has two
 	  if(laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI)
 	  {
-	    new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	    new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 	  }
-	  new G4PVPlacement(0, G4ThreeVector(TVfphx_x, -TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerm_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVfphx_x, -TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerm_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
 	  // ----- Step 3 --------------------------------------------------------------------------------------------------------------------
 	  // We install the section of ladder for this sensor at all requested phi values and at positive and negative Z
@@ -739,10 +736,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  const double dphi = 2 * M_PI / nladders_layer;
 
 	  // there is no single radius for a layer
-	  ladder_radius_inner[ilayer] = sensor_radius_inner[ilayer] + sensor_offset_x_ladder;
-	  ladder_radius_outer[ilayer] = sensor_radius_outer[ilayer] + sensor_offset_x_ladder;
-	  posz[ilayer][itype] = (itype == 0) ? hdi_z / 2. : hdi_z_[ilayer][0] + hdi_z / 2.; // location of center of ladder in Z
-	  strip_x_offset[ilayer] = sensor_offset_x_ladder;
+	  ladder_radius_inner[inttlayer] = sensor_radius_inner[inttlayer] + sensor_offset_x_ladder;
+	  ladder_radius_outer[inttlayer] = sensor_radius_outer[inttlayer] + sensor_offset_x_ladder;
+	  posz[inttlayer][itype] = (itype == 0) ? hdi_z / 2. : hdi_z_[inttlayer][0] + hdi_z / 2.; // location of center of ladder in Z
+	  strip_x_offset[inttlayer] = sensor_offset_x_ladder;
 	  
 	  // The sensors have no tilt in the new design
 	  //    The type 1 ladders have the sensor at the center of the ladder in phi, so that is easy
@@ -752,9 +749,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  for (G4int icopy = 0; icopy < nladders_layer; icopy++)
 	    {
 	      const double phi = offsetphi + dphi * (double) icopy;  // offsetphi is zero by default, so we start at zero
-	      double radius = ladder_radius_inner[ilayer];
+	      double radius = ladder_radius_inner[inttlayer];
 	      if(icopy%2)
-		radius = ladder_radius_outer[ilayer];  // every odd numbered copy is placed at the larger radius
+		radius = ladder_radius_outer[inttlayer];  // every odd numbered copy is placed at the larger radius
 
 	      const double posx = radius * cos(phi);
 	      const double posy = radius * sin(phi);
@@ -764,25 +761,25 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	      ladderrotation->rotateZ(fRotate);
 
 	      // place the copy at its ladder phi value, and at positive (2) and negative (1) Z
-	      new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, -posz[ilayer][itype])), ladder_volume, 
-				boost::str(boost::format("ladder_%d_%d_%d_%d_1")  % sphxlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
-	      new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, +posz[ilayer][itype])), ladder_volume, 
-				boost::str(boost::format("ladder_%d_%d_%d_%d_2") % sphxlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+	      new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, -posz[inttlayer][itype])), ladder_volume, 
+				boost::str(boost::format("ladder_%d_%d_%d_%d_1")  % inttlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+	      new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, +posz[inttlayer][itype])), ladder_volume, 
+				boost::str(boost::format("ladder_%d_%d_%d_%d_2") % inttlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
 
 	
 	      if (itype != 0)
 		{  
 		  // We have added the outer sensor above, now we add the HDI extension tab to the end of the outer sensor HDI
-		  const G4double posz_ext = (hdi_z_[ilayer][0] + hdi_z) + hdiext_z / 2.;
+		  const G4double posz_ext = (hdi_z_[inttlayer][0] + hdi_z) + hdiext_z / 2.;
 
 		  new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, -posz_ext)), ladderext_volume, 
-				    boost::str(boost::format("ladderext_%d_%d_%d_%d_1") % sphxlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+				    boost::str(boost::format("ladderext_%d_%d_%d_%d_1") % inttlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
 		  new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, +posz_ext)), ladderext_volume, 
-				    boost::str(boost::format("ladderext_%d_%d_%d_%d_2") % sphxlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+				    boost::str(boost::format("ladderext_%d_%d_%d_%d_2") % inttlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
 		}
 
 	      /*
-	      cout << "Ladder copy " << icopy << " radius " << radius << " phi " << phi << " itype " << itype << " posz " << posz[ilayer][itype] 
+	      cout << "Ladder copy " << icopy << " radius " << radius << " phi " << phi << " itype " << itype << " posz " << posz[inttlayer][itype] 
 		   << " fRotate " << fRotate << " posx " << posx << " posy " << posy << " sensor_offset_x_ladder " << sensor_offset_x_ladder 
 		   << endl;
 	      */

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -311,6 +311,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 	  {
 	    cout << PHWHERE << "invalid laddertype " << laddertype << endl;
 	    gSystem->Exit(1);
+// this is just to make the optimizer happy which otherwise complains about possibly
+// uninitialized variables. It doesn't know gSystem->Exit(1) quits, 
+// this exit here terminates the program for it
+	    exit(1);
 	  }
 	  cell_length_z = strip_z * nstrips_z_sensor / ncopy;
 	  offsetz = (ncopy % 2 == 0) ? -2. * cell_length_z / 2. * double(ncopy / 2) + cell_length_z / 2. : -2. * cell_length_z / 2. * double(ncopy / 2);
@@ -647,7 +651,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
             ladder_y = ladder_y + 2.0* sensor_offset_y;
 	  }	    
 	  G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % inttlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., ladder_z / 2.);
-	  G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_%d_%d_%d") % inttlayer % inttlayer % itype).c_str(), 0, 0, 0);
+	  G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
@@ -762,9 +766,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
 	      // place the copy at its ladder phi value, and at positive (2) and negative (1) Z
 	      new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, -posz[inttlayer][itype])), ladder_volume, 
-				boost::str(boost::format("ladder_%d_%d_%d_%d_1")  % inttlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+				boost::str(boost::format("ladder_%d_%d_%d_1") % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
 	      new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, +posz[inttlayer][itype])), ladder_volume, 
-				boost::str(boost::format("ladder_%d_%d_%d_%d_2") % inttlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+				boost::str(boost::format("ladder_%d_%d_%d_2") % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
 
 	
 	      if (itype != 0)

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -698,13 +698,13 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
 	  // HDI Kapton        
 	  const double TVhdi_kapton_x = TVpgs_x - pgs_x / 2. - hdi_kapton_x / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdi_kapton_volume, boost::str(boost::format("hdi_kapton_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdiext_kapton_volume, boost::str(boost::format("hdiext_kapton_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdi_kapton_volume, boost::str(boost::format("hdikapton_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdiext_kapton_volume, boost::str(boost::format("hdiextkapton_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
 	  // HDI copper        
 	  const double TVhdi_copper_x = TVhdi_kapton_x - hdi_kapton_x / 2. - hdi_copper_x / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdi_copper_volume, boost::str(boost::format("hdi_copper_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdiext_copper_volume, boost::str(boost::format("hdiext_copper_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdi_copper_volume, boost::str(boost::format("hdicopper_%d_%d") % sphxlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdiext_copper_volume, boost::str(boost::format("hdiextcopper_%d_%s") % sphxlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
 	  // Si-sensor        
 	  const double TVSi_x = TVhdi_copper_x - hdi_copper_x / 2. - siactive_x / 2.;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -33,17 +33,18 @@
 
 using namespace std;
 
-PHG4SiliconTrackerDetector::PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> &layer_b_e)
+PHG4SiliconTrackerDetector::PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const pair<vector<pair<int,int>>::const_iterator, vector<pair<int,int>>::const_iterator> &layer_b_e)
   : PHG4Detector(Node, dnam)
   , paramscontainer(parameters)
   , layer_begin_end(layer_b_e)
 {
   for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
   {
-    cout << "getting params for layer " << *layeriter << endl;
-    const PHParameters *par = paramscontainer->GetParameters(*layeriter);
-    IsActive[*layeriter] = par->get_int_param("active");
-    IsAbsorberActive[*layeriter] = par->get_int_param("absorberactive");
+    int layer = layeriter->second;
+    cout << "getting params for layer " << layer << endl;
+    const PHParameters *par = paramscontainer->GetParameters(layer);
+    IsActive[layer] = par->get_int_param("active");
+    IsAbsorberActive[layer] = par->get_int_param("absorberactive");
   }
 }
 
@@ -77,7 +78,7 @@ void PHG4SiliconTrackerDetector::Construct(G4LogicalVolume *logicWorld)
     std::cout << "PHG4SiliconTrackerDetector::Construct called for layers " << std::endl;
   for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
   {
-    cout << "layer " << *layeriter << endl;
+    cout << "layer " << layeriter->second << endl;
   }
   }
   // the tracking layers are placed directly in the world volume, since some layers are (touching) double layers
@@ -98,8 +99,8 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
 
   {
-    const int sphxlayer = *layeriter;
-      const int inttlayer = sphxlayer;
+    const int sphxlayer = layeriter->first;
+      const int inttlayer = layeriter->second;
       int ilayer = inttlayer;
        // get the parameters for this layer
       const PHParameters *params1 = paramscontainer->GetParameters(inttlayer);
@@ -957,9 +958,9 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
 
   for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
     {
-      const int sphxlayer = *layeriter;
-      const int inttlayer = *layeriter;
-int ilayer = *layeriter;
+      const int sphxlayer = layeriter->first;
+      const int inttlayer = layeriter->second;
+int ilayer = inttlayer;
        const PHParameters *params_layer = paramscontainer->GetParameters(inttlayer);
       const int laddertype = params_layer->get_int_param("laddertype");
       // parameters are in cm, so conversion needed here to get from mm to cm

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -15,15 +15,15 @@
 #include <TSystem.h>
 
 #include <Geant4/G4Box.hh>
-#include <Geant4/G4Cons.hh>
-#include <Geant4/G4Tubs.hh>
 #include <Geant4/G4Colour.hh>
+#include <Geant4/G4Cons.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4NistManager.hh>
 #include <Geant4/G4PVParameterised.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4SubtractionSolid.hh>
+#include <Geant4/G4Tubs.hh>
 #include <Geant4/G4VisAttributes.hh>
 
 #include <cmath>
@@ -33,7 +33,7 @@
 
 using namespace std;
 
-PHG4SiliconTrackerDetector::PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const pair<vector<pair<int,int>>::const_iterator, vector<pair<int,int>>::const_iterator> &layer_b_e)
+PHG4SiliconTrackerDetector::PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const pair<vector<pair<int, int>>::const_iterator, vector<pair<int, int>>::const_iterator> &layer_b_e)
   : PHG4Detector(Node, dnam)
   , paramscontainer(parameters)
   , layer_begin_end(layer_b_e)
@@ -75,10 +75,10 @@ void PHG4SiliconTrackerDetector::Construct(G4LogicalVolume *logicWorld)
   if (Verbosity() > 0)
   {
     cout << "PHG4SiliconTrackerDetector::Construct called for layers " << endl;
-  for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
-  {
-    cout << "layer " << layeriter->second << endl;
-  }
+    for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
+    {
+      cout << "layer " << layeriter->second << endl;
+    }
   }
   // the tracking layers are placed directly in the world volume, since some layers are (touching) double layers
   ConstructSiliconTracker(logicWorld);
@@ -98,702 +98,690 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
 
   {
-      int inttlayer = layeriter->second;
-       // get the parameters for this layer
-      const PHParameters *params1 = paramscontainer->GetParameters(inttlayer);
-      const int laddertype = params1->get_int_param("laddertype");
-      const G4double offsetphi = params1->get_double_param("offsetphi")*deg;
-      G4double offsetrot = params1->get_double_param("offsetrot")*deg;
-      sensor_radius_inner[inttlayer] = params1->get_double_param("sensor_radius_inner")*mm;
-      sensor_radius_outer[inttlayer] = params1->get_double_param("sensor_radius_outer")*mm;
-      const int nladders_layer = params1->get_int_param("nladder");
-      cout << "Constructing Silicon Tracker layer: " << endl;
-      cout << "   layer " << inttlayer << " laddertype " << laddertype << " nladders_layer " << nladders_layer 
-	   << " sensor_radius_inner " << sensor_radius_inner[inttlayer] << " sensor_radius_outer " << sensor_radius_outer[inttlayer] << endl;
+    int inttlayer = layeriter->second;
+    // get the parameters for this layer
+    const PHParameters *params1 = paramscontainer->GetParameters(inttlayer);
+    const int laddertype = params1->get_int_param("laddertype");
+    const G4double offsetphi = params1->get_double_param("offsetphi") * deg;
+    G4double offsetrot = params1->get_double_param("offsetrot") * deg;
+    sensor_radius_inner[inttlayer] = params1->get_double_param("sensor_radius_inner") * mm;
+    sensor_radius_outer[inttlayer] = params1->get_double_param("sensor_radius_outer") * mm;
+    const int nladders_layer = params1->get_int_param("nladder");
+    cout << "Constructing Silicon Tracker layer: " << endl;
+    cout << "   layer " << inttlayer << " laddertype " << laddertype << " nladders_layer " << nladders_layer
+         << " sensor_radius_inner " << sensor_radius_inner[inttlayer] << " sensor_radius_outer " << sensor_radius_outer[inttlayer] << endl;
 
-      // Look up all remaining parameters by the laddertype for this layer
-      const PHParameters *params = paramscontainer->GetParameters(laddertype);
-      const G4double strip_x = params->get_double_param("strip_x")*mm;
-      const G4double strip_y = params->get_double_param("strip_y")*mm;
-      const int nstrips_phi_sensor = params->get_int_param("nstrips_phi_sensor");
-      const G4double sensor_offset_y = params->get_double_param("sensor_offset_y")*mm;
-      const G4double hdi_y = params->get_double_param("hdi_y")*mm;
-      double hdi_kapton_x = params->get_double_param("hdi_kapton_x")*mm;
-      double hdi_copper_x = params->get_double_param("hdi_copper_x")*mm;
-      double fphx_x = params->get_double_param("fphx_x")*mm;
-      double fphx_y = params->get_double_param("fphx_y")*mm;
-      double fphx_z = params->get_double_param("fphx_z")*mm;
-      double pgs_x = params->get_double_param("pgs_x")*mm;
-      double halfladder_z = params->get_double_param("halfladder_z")*mm;
-      double stave_straight_outer_y = params->get_double_param("stave_straight_outer_y")*mm;
-      double stave_straight_inner_y = params->get_double_param("stave_straight_inner_y")*mm;
-      double stave_straight_cooler_y = params->get_double_param("stave_straight_cooler_y")*mm;
+    // Look up all remaining parameters by the laddertype for this layer
+    const PHParameters *params = paramscontainer->GetParameters(laddertype);
+    const G4double strip_x = params->get_double_param("strip_x") * mm;
+    const G4double strip_y = params->get_double_param("strip_y") * mm;
+    const int nstrips_phi_sensor = params->get_int_param("nstrips_phi_sensor");
+    const G4double sensor_offset_y = params->get_double_param("sensor_offset_y") * mm;
+    const G4double hdi_y = params->get_double_param("hdi_y") * mm;
+    double hdi_kapton_x = params->get_double_param("hdi_kapton_x") * mm;
+    double hdi_copper_x = params->get_double_param("hdi_copper_x") * mm;
+    double fphx_x = params->get_double_param("fphx_x") * mm;
+    double fphx_y = params->get_double_param("fphx_y") * mm;
+    double fphx_z = params->get_double_param("fphx_z") * mm;
+    double pgs_x = params->get_double_param("pgs_x") * mm;
+    double halfladder_z = params->get_double_param("halfladder_z") * mm;
+    double stave_straight_outer_y = params->get_double_param("stave_straight_outer_y") * mm;
+    double stave_straight_inner_y = params->get_double_param("stave_straight_inner_y") * mm;
+    double stave_straight_cooler_y = params->get_double_param("stave_straight_cooler_y") * mm;
 
-      // We loop over inner, then outer, sensors, where  itype specifies the inner or outer sensor
-      // The rest of this loop will construct and put in place a section of a ladder corresponding to the Z range of this sensor only
-      for (int itype = 0; itype < 2; ++itype)
-	{
-	  if (!(itype >= 0 && itype <= 1))
-	    {
-	      assert(!"Error: check ladder type.");
-	    }
-	  G4double strip_z;
-	  int nstrips_z_sensor;
-	  switch (itype)
-	    {
-	    case 0:
-	      strip_z = params->get_double_param("strip_z_0")*mm;
-	      nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_0");
-	      break;
-	    case 1:
-	      strip_z = params->get_double_param("strip_z_1")*mm;
-	      nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_1");
-	      break;
-	    default:
-	      cout << "invalid itype " << itype << endl;
-	      exit(1);
-	    }
+    // We loop over inner, then outer, sensors, where  itype specifies the inner or outer sensor
+    // The rest of this loop will construct and put in place a section of a ladder corresponding to the Z range of this sensor only
+    for (int itype = 0; itype < 2; ++itype)
+    {
+      if (!(itype >= 0 && itype <= 1))
+      {
+        assert(!"Error: check ladder type.");
+      }
+      G4double strip_z;
+      int nstrips_z_sensor;
+      switch (itype)
+      {
+      case 0:
+        strip_z = params->get_double_param("strip_z_0") * mm;
+        nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_0");
+        break;
+      case 1:
+        strip_z = params->get_double_param("strip_z_1") * mm;
+        nstrips_z_sensor = params->get_int_param("nstrips_z_sensor_1");
+        break;
+      default:
+        cout << "invalid itype " << itype << endl;
+        exit(1);
+      }
 
-	  // ----- Step 1 ---------------------------------------------------------------------------------------------
-	  // We make the volumes for Si-sensor, FPHX, HDI, PGS sheet, and stave components
-	  // We add them to the ladder later
-	  //============================================================
-      
-	  // Create a volume for the Si-strip. Use half widths to make the box
-	  G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % inttlayer %itype).c_str(), 
-					  strip_x / 2., strip_y / 2. - strip_y / 20000., strip_z / 2. - strip_z / 2. / 10000.);
-	  G4LogicalVolume *strip_volume = new G4LogicalVolume(strip_box, G4Material::GetMaterial("G4_Si"), 
-							      boost::str(boost::format("strip_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  if ((IsActive.find(inttlayer))->second > 0)
-	    {
-	      activelogvols.insert(strip_volume);
-	    }
-	  G4VisAttributes *strip_vis = new G4VisAttributes();
-	  strip_vis->SetVisibility(false);
-	  strip_vis->SetForceSolid(false);
-	  strip_vis->SetColour(G4Colour::White());
-	  strip_volume->SetVisAttributes(strip_vis);
-      
-	  // Create Si-sensor active volume
-	  const double siactive_x = strip_x;
-	  const double siactive_y = strip_y * nstrips_phi_sensor; 
-	  const double siactive_z = strip_z * nstrips_z_sensor;  
-	  G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % inttlayer % itype).c_str(), siactive_x/2, siactive_y/2., siactive_z/2.);
-	  G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"), 
-								 boost::str(boost::format("siactive_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  G4VisAttributes *siactive_vis = new G4VisAttributes();
-	  siactive_vis->SetVisibility(true);
-	  siactive_vis->SetForceSolid(true);
-	  siactive_vis->SetColour(G4Colour::White());
-	  siactive_volume->SetVisAttributes(siactive_vis);
-      
-	  // Now make a G4PVParameterised containing all of the strips in a sensor 
-	  // this works for ladder 0 because there is only one strip type - all cells are identical
-	  G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_sensor, nstrips_z_sensor, strip_y, strip_z);
-	  new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % inttlayer % itype).c_str(), 
-				strip_volume, siactive_volume, kZAxis, nstrips_phi_sensor * nstrips_z_sensor, stripparam, false);  // overlap check too long.
+      // ----- Step 1 ---------------------------------------------------------------------------------------------
+      // We make the volumes for Si-sensor, FPHX, HDI, PGS sheet, and stave components
+      // We add them to the ladder later
+      //============================================================
 
-	  // Si-sensor full (active+inactive) area
-	  const double sifull_x = siactive_x;
-	  const double sifull_y = siactive_y + 2.0*params->get_double_param("sensor_edge_phi"); 
-	  const double sifull_z = siactive_z + 2.0*params->get_double_param("sensor_edge_z");    
-      	  G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % inttlayer % itype).c_str(), sifull_x / 2., sifull_y/2.0, sifull_z/2.0);
-      
-	  // Si-sensor inactive area
-      	  G4VSolid *siinactive_box = new G4SubtractionSolid(boost::str(boost::format("siinactive_box_%d_%d") % inttlayer % itype).c_str(), 
-							    sifull_box, siactive_box, 0, G4ThreeVector(0, 0, 0));
-	  G4LogicalVolume *siinactive_volume = new G4LogicalVolume(siinactive_box, G4Material::GetMaterial("G4_Si"), 
-								   boost::str(boost::format("siinactive_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
-	    {
-	      absorberlogvols.insert(siinactive_volume);
-	    }
-	  G4VisAttributes *siinactive_vis = new G4VisAttributes();
-	  siinactive_vis->SetVisibility(true);
-	  siinactive_vis->SetForceSolid(true);
-	  siinactive_vis->SetColour(G4Colour::Red());
-	  siinactive_volume->SetVisAttributes(siinactive_vis);
-      
-	  // Make the HDI Kapton and copper volumes
+      // Create a volume for the Si-strip. Use half widths to make the box
+      G4VSolid *strip_box = new G4Box(boost::str(boost::format("strip_box_%d_%d") % inttlayer % itype).c_str(),
+                                      strip_x / 2., strip_y / 2. - strip_y / 20000., strip_z / 2. - strip_z / 2. / 10000.);
+      G4LogicalVolume *strip_volume = new G4LogicalVolume(strip_box, G4Material::GetMaterial("G4_Si"),
+                                                          boost::str(boost::format("strip_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      if ((IsActive.find(inttlayer))->second > 0)
+      {
+        activelogvols.insert(strip_volume);
+      }
+      G4VisAttributes *strip_vis = new G4VisAttributes();
+      strip_vis->SetVisibility(false);
+      strip_vis->SetForceSolid(false);
+      strip_vis->SetColour(G4Colour::White());
+      strip_volume->SetVisAttributes(strip_vis);
 
-	  // This makes HDI volumes that matche this sensor in Z length
-	  const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z");  
-	  hdi_z_[inttlayer][itype] = hdi_z;
-	  G4VSolid *hdi_kapton_box = new G4Box(boost::str(boost::format("hdi_kapton_box_%d_%d") % inttlayer % itype).c_str(), hdi_kapton_x / 2., hdi_y / 2., hdi_z/2.0);
-	  G4LogicalVolume *hdi_kapton_volume = new G4LogicalVolume(hdi_kapton_box, G4Material::GetMaterial("G4_KAPTON"), 
-							    boost::str(boost::format("hdi_kapton_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  G4VSolid *hdi_copper_box = new G4Box(boost::str(boost::format("hdi_copper_box_%d_%d") % inttlayer % itype).c_str(), hdi_copper_x / 2., hdi_y / 2., hdi_z/2.0);
-	  G4LogicalVolume *hdi_copper_volume = new G4LogicalVolume(hdi_copper_box, G4Material::GetMaterial("G4_Cu"), 
-							    boost::str(boost::format("hdi_copper_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
-	    {
-	      absorberlogvols.insert(hdi_kapton_volume);
-	      absorberlogvols.insert(hdi_copper_volume);
-	    }
+      // Create Si-sensor active volume
+      const double siactive_x = strip_x;
+      const double siactive_y = strip_y * nstrips_phi_sensor;
+      const double siactive_z = strip_z * nstrips_z_sensor;
+      G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % inttlayer % itype).c_str(), siactive_x / 2, siactive_y / 2., siactive_z / 2.);
+      G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"),
+                                                             boost::str(boost::format("siactive_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      G4VisAttributes *siactive_vis = new G4VisAttributes();
+      siactive_vis->SetVisibility(true);
+      siactive_vis->SetForceSolid(true);
+      siactive_vis->SetColour(G4Colour::White());
+      siactive_volume->SetVisAttributes(siactive_vis);
 
-	  // This is the part of the HDI that extends beyond the sensor
-	  const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z  - hdi_z_[inttlayer][0] - hdi_z;  // need to assign nonzero value for itype=0
-	  G4VSolid *hdiext_kapton_box = new G4Box(boost::str(boost::format("hdiext_kapton_box_%d_%s") % inttlayer % itype).c_str(), 
-						  hdi_kapton_x / 2., hdi_y / 2., hdiext_z / 2.0);
-	  G4LogicalVolume *hdiext_kapton_volume = new G4LogicalVolume(hdiext_kapton_box, G4Material::GetMaterial("G4_KAPTON"),  // was "FPC" 
-							       boost::str(boost::format("hdiext_kapton_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
-	  G4VSolid *hdiext_copper_box = new G4Box(boost::str(boost::format("hdiext_copper_box_%d_%s") % inttlayer % itype).c_str(), 
-						  hdi_copper_x / 2., hdi_y / 2., hdiext_z / 2.0);
-	  G4LogicalVolume *hdiext_copper_volume = new G4LogicalVolume(hdiext_copper_box, G4Material::GetMaterial("G4_Cu"), 
-							       boost::str(boost::format("hdiext_copper_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
-	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
-	    {
-	      absorberlogvols.insert(hdiext_kapton_volume);
-	      absorberlogvols.insert(hdiext_copper_volume);
-	    }
-	  G4VisAttributes *hdi_kapton_vis = new G4VisAttributes();
-	  hdi_kapton_vis->SetVisibility(true);
-	  hdi_kapton_vis->SetForceSolid(true);
-	  hdi_kapton_vis->SetColour(G4Colour::Yellow());
-	  hdi_kapton_volume->SetVisAttributes(hdi_kapton_vis);
-	  hdiext_kapton_volume->SetVisAttributes(hdi_kapton_vis);
-	  G4VisAttributes *hdi_copper_vis = new G4VisAttributes();
-	  hdi_copper_vis->SetVisibility(true);
-	  hdi_copper_vis->SetForceSolid(true);
-	  hdi_copper_vis->SetColour(G4Colour::White());
-	  hdi_copper_volume->SetVisAttributes(hdi_copper_vis);
-	  hdiext_copper_volume->SetVisAttributes(hdi_copper_vis);
+      // Now make a G4PVParameterised containing all of the strips in a sensor
+      // this works for ladder 0 because there is only one strip type - all cells are identical
+      G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_sensor, nstrips_z_sensor, strip_y, strip_z);
+      new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % inttlayer % itype).c_str(),
+                            strip_volume, siactive_volume, kZAxis, nstrips_phi_sensor * nstrips_z_sensor, stripparam, false);  // overlap check too long.
 
-	  // FPHX
-	  G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % inttlayer % itype).c_str(), fphx_x / 2., fphx_y / 2., fphx_z / 2.);
-	  G4LogicalVolume *fphx_volume = new G4LogicalVolume(fphx_box, G4Material::GetMaterial("G4_Si"), 
-							     boost::str(boost::format("fphx_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
-	    {
-	      absorberlogvols.insert(fphx_volume);
-	    }
-	  G4VisAttributes *fphx_vis = new G4VisAttributes();
-	  fphx_vis->SetVisibility(true);
-	  fphx_vis->SetForceSolid(true);
-	  fphx_vis->SetColour(G4Colour::Blue());
-	  fphx_volume->SetVisAttributes(fphx_vis);
+      // Si-sensor full (active+inactive) area
+      const double sifull_x = siactive_x;
+      const double sifull_y = siactive_y + 2.0 * params->get_double_param("sensor_edge_phi");
+      const double sifull_z = siactive_z + 2.0 * params->get_double_param("sensor_edge_z");
+      G4VSolid *sifull_box = new G4Box(boost::str(boost::format("sifull_box_%d_%d") % inttlayer % itype).c_str(), sifull_x / 2., sifull_y / 2.0, sifull_z / 2.0);
 
-	  const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx");
-      
-	  //  FPHX Container
-	  // make a container for the FPHX chips needed for this sensor, and  then place them in the container
-	  G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % inttlayer % itype).c_str(), 
-						  fphx_x / 2., fphx_y / 2., hdi_z / 2.);
-	  G4LogicalVolume *fphxcontainer_volume = new G4LogicalVolume(fphxcontainer_box, G4Material::GetMaterial("G4_AIR"), 
-								      boost::str(boost::format("fphxcontainer_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
-	    {
-	      absorberlogvols.insert(fphxcontainer_volume);
-	    }
-	  G4VisAttributes *fphxcontainer_vis = new G4VisAttributes();
-	  fphxcontainer_vis->SetVisibility(false);
-	  fphxcontainer_vis->SetForceSolid(false);
-	  fphxcontainer_volume->SetVisAttributes(fphxcontainer_vis);
+      // Si-sensor inactive area
+      G4VSolid *siinactive_box = new G4SubtractionSolid(boost::str(boost::format("siinactive_box_%d_%d") % inttlayer % itype).c_str(),
+                                                        sifull_box, siactive_box, 0, G4ThreeVector(0, 0, 0));
+      G4LogicalVolume *siinactive_volume = new G4LogicalVolume(siinactive_box, G4Material::GetMaterial("G4_Si"),
+                                                               boost::str(boost::format("siinactive_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      if ((IsAbsorberActive.find(inttlayer))->second > 0)
+      {
+        absorberlogvols.insert(siinactive_volume);
+      }
+      G4VisAttributes *siinactive_vis = new G4VisAttributes();
+      siinactive_vis->SetVisibility(true);
+      siinactive_vis->SetForceSolid(true);
+      siinactive_vis->SetColour(G4Colour::Red());
+      siinactive_volume->SetVisAttributes(siinactive_vis);
 
-	  // Install multiple FPHX volumes in the FPHX container volume 
-	  // one FPHX chip per cell - each cell is 128 channels
-	  const double offsetx = 0.;
-	  const double offsety = 0.;
-	  int ncopy;
-	  double offsetz, cell_length_z;
+      // Make the HDI Kapton and copper volumes
 
-	  if(laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_Z)  // vertical strips
-	    {
-	      // For laddertype 0, we have 5 cells per sensor, but the strips are vertical, so we have to treat it specially
-	      ncopy = nstrips_z_sensor / 128.0;
-	    }
-	  else if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI)
-	    {
-	      ncopy = nstrips_z_sensor;
-	    }
-	  else
-	  {
-	    cout << PHWHERE << "invalid laddertype " << laddertype << endl;
-	    gSystem->Exit(1);
-// this is just to make the optimizer happy which otherwise complains about possibly
-// uninitialized variables. It doesn't know gSystem->Exit(1) quits, 
-// this exit here terminates the program for it
-	    exit(1);
-	  }
-	  cell_length_z = strip_z * nstrips_z_sensor / ncopy;
-	  offsetz = (ncopy % 2 == 0) ? -2. * cell_length_z / 2. * double(ncopy / 2) + cell_length_z / 2. : -2. * cell_length_z / 2. * double(ncopy / 2);
-	  G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * cell_length_z / 2., ncopy);
-	  new G4PVParameterised(boost::str(boost::format("fphxcontainer_%d_%d") % inttlayer % itype).c_str(), 
-				fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, OverlapCheck());
+      // This makes HDI volumes that matche this sensor in Z length
+      const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z");
+      hdi_z_[inttlayer][itype] = hdi_z;
+      G4VSolid *hdi_kapton_box = new G4Box(boost::str(boost::format("hdi_kapton_box_%d_%d") % inttlayer % itype).c_str(), hdi_kapton_x / 2., hdi_y / 2., hdi_z / 2.0);
+      G4LogicalVolume *hdi_kapton_volume = new G4LogicalVolume(hdi_kapton_box, G4Material::GetMaterial("G4_KAPTON"),
+                                                               boost::str(boost::format("hdi_kapton_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      G4VSolid *hdi_copper_box = new G4Box(boost::str(boost::format("hdi_copper_box_%d_%d") % inttlayer % itype).c_str(), hdi_copper_x / 2., hdi_y / 2., hdi_z / 2.0);
+      G4LogicalVolume *hdi_copper_volume = new G4LogicalVolume(hdi_copper_box, G4Material::GetMaterial("G4_Cu"),
+                                                               boost::str(boost::format("hdi_copper_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      if ((IsAbsorberActive.find(inttlayer))->second > 0)
+      {
+        absorberlogvols.insert(hdi_kapton_volume);
+        absorberlogvols.insert(hdi_copper_volume);
+      }
 
-	  // PGS   - this is the carbon sheet that the HDI sits on. It forms the wall of the cooling tube that cools the HDI
-        
-	  const double pgs_y = hdi_y;
-	  const double pgs_z = hdi_z;
-	  G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % inttlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., pgs_z / 2.);
-	  G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("CFRP_INTT"), 
-							    boost::str(boost::format("pgs_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
-	    {
-	      absorberlogvols.insert(pgs_volume);
-	    }
-	  // The part that extends beyond this sensor, see above for hdiext
-	  G4VSolid *pgsext_box = new G4Box(boost::str(boost::format("pgsext_box_%d_%s") % inttlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *pgsext_volume = new G4LogicalVolume(pgsext_box, G4Material::GetMaterial("CFRP_INTT"), 
-							       boost::str(boost::format("pgsext_volume_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
+      // This is the part of the HDI that extends beyond the sensor
+      const G4double hdiext_z = (itype == 0) ? 0.000001 : halfladder_z - hdi_z_[inttlayer][0] - hdi_z;  // need to assign nonzero value for itype=0
+      G4VSolid *hdiext_kapton_box = new G4Box(boost::str(boost::format("hdiext_kapton_box_%d_%s") % inttlayer % itype).c_str(),
+                                              hdi_kapton_x / 2., hdi_y / 2., hdiext_z / 2.0);
+      G4LogicalVolume *hdiext_kapton_volume = new G4LogicalVolume(hdiext_kapton_box, G4Material::GetMaterial("G4_KAPTON"),  // was "FPC"
+                                                                  boost::str(boost::format("hdiext_kapton_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
+      G4VSolid *hdiext_copper_box = new G4Box(boost::str(boost::format("hdiext_copper_box_%d_%s") % inttlayer % itype).c_str(),
+                                              hdi_copper_x / 2., hdi_y / 2., hdiext_z / 2.0);
+      G4LogicalVolume *hdiext_copper_volume = new G4LogicalVolume(hdiext_copper_box, G4Material::GetMaterial("G4_Cu"),
+                                                                  boost::str(boost::format("hdiext_copper_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
+      if ((IsAbsorberActive.find(inttlayer))->second > 0)
+      {
+        absorberlogvols.insert(hdiext_kapton_volume);
+        absorberlogvols.insert(hdiext_copper_volume);
+      }
+      G4VisAttributes *hdi_kapton_vis = new G4VisAttributes();
+      hdi_kapton_vis->SetVisibility(true);
+      hdi_kapton_vis->SetForceSolid(true);
+      hdi_kapton_vis->SetColour(G4Colour::Yellow());
+      hdi_kapton_volume->SetVisAttributes(hdi_kapton_vis);
+      hdiext_kapton_volume->SetVisAttributes(hdi_kapton_vis);
+      G4VisAttributes *hdi_copper_vis = new G4VisAttributes();
+      hdi_copper_vis->SetVisibility(true);
+      hdi_copper_vis->SetForceSolid(true);
+      hdi_copper_vis->SetColour(G4Colour::White());
+      hdi_copper_volume->SetVisAttributes(hdi_copper_vis);
+      hdiext_copper_volume->SetVisAttributes(hdi_copper_vis);
 
-	  G4VisAttributes *pgs_vis = new G4VisAttributes();
-	  pgs_vis->SetVisibility(true);
-	  pgs_vis->SetForceSolid(true);
-	  pgs_vis->SetColour(G4Colour::Red());
-	  pgs_volume->SetVisAttributes(pgs_vis);
-	  pgsext_volume->SetVisAttributes(pgs_vis);
+      // FPHX
+      G4VSolid *fphx_box = new G4Box(boost::str(boost::format("fphx_box_%d_%d") % inttlayer % itype).c_str(), fphx_x / 2., fphx_y / 2., fphx_z / 2.);
+      G4LogicalVolume *fphx_volume = new G4LogicalVolume(fphx_box, G4Material::GetMaterial("G4_Si"),
+                                                         boost::str(boost::format("fphx_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      if ((IsAbsorberActive.find(inttlayer))->second > 0)
+      {
+        absorberlogvols.insert(fphx_volume);
+      }
+      G4VisAttributes *fphx_vis = new G4VisAttributes();
+      fphx_vis->SetVisibility(true);
+      fphx_vis->SetForceSolid(true);
+      fphx_vis->SetColour(G4Colour::Blue());
+      fphx_volume->SetVisAttributes(fphx_vis);
 
-	  // Carbon stave. This is the formed sheet that sits on the PGS and completes the cooling tube
-	  // Formed from straight sections and sections of a tube of radius 2.3 mm. All have wall thickness of 0.3 mm.
-	  // These are different for laddertype PHG4SiliconTrackerDefs::SEGMENTATION_Z  and PHG4SiliconTrackerDefs::SEGMENTATION_PHI, but they use some common elements.
+      const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx");
 
-	  // The curved section is made from a G4Cons, which is a generalized section of a cone
-	  // Two curved sections combined should move the inner wall to be 2.0 mm away from the PGS, then 2 more sections bring it back
-	  // For 1 of these tube sections,starting at 90 degrees, take decrease in y=1 mm at avge R. 
-	  // If avge R = 2.15 mm, dtheta = invcos( (R - y)/R ) = invcos(1.15/2.15) = 53.49 deg
-	  // The extent along the x axis is then R*sin(dtheta) = 1.728 mm, so two sections combined have dx = 3.456 mm length in y 
-	  const double Rcmin = 0.20*cm; // 2 mm  inner radius of curved section, same at both ends
-	  const double Rcmax = 0.23*cm; //cm  outer radius of curved section, same at both ends
-	  double Rcavge = (Rcmax+Rcmin)/2.0;
-	  double dphi_c = acos( (Rcavge-Rcmin/2.) / Rcavge);
-	  const double stave_z = pgs_z;
+      //  FPHX Container
+      // make a container for the FPHX chips needed for this sensor, and  then place them in the container
+      G4VSolid *fphxcontainer_box = new G4Box(boost::str(boost::format("fphxcontainer_box_%d_%d") % inttlayer % itype).c_str(),
+                                              fphx_x / 2., fphx_y / 2., hdi_z / 2.);
+      G4LogicalVolume *fphxcontainer_volume = new G4LogicalVolume(fphxcontainer_box, G4Material::GetMaterial("G4_AIR"),
+                                                                  boost::str(boost::format("fphxcontainer_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      if ((IsAbsorberActive.find(inttlayer))->second > 0)
+      {
+        absorberlogvols.insert(fphxcontainer_volume);
+      }
+      G4VisAttributes *fphxcontainer_vis = new G4VisAttributes();
+      fphxcontainer_vis->SetVisibility(false);
+      fphxcontainer_vis->SetForceSolid(false);
+      fphxcontainer_volume->SetVisAttributes(fphxcontainer_vis);
 
-	  // makecurved sections for cooler tube
-	  const double phic_begin[4] = {M_PI - dphi_c, - dphi_c, 0.0, M_PI};
-	  const double dphic[4] = {dphi_c, dphi_c, dphi_c, dphi_c};
+      // Install multiple FPHX volumes in the FPHX container volume
+      // one FPHX chip per cell - each cell is 128 channels
+      const double offsetx = 0.;
+      const double offsety = 0.;
+      int ncopy;
+      double offsetz, cell_length_z;
 
-	  G4Tubs *stave_curve_cons[4];
-	  G4Tubs *stave_curve_ext_cons[4];
-	  G4LogicalVolume *stave_curve_volume[4];
-	  G4LogicalVolume *stave_curve_ext_volume[4];
+      if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_Z)  // vertical strips
+      {
+        // For laddertype 0, we have 5 cells per sensor, but the strips are vertical, so we have to treat it specially
+        ncopy = nstrips_z_sensor / 128.0;
+      }
+      else if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI)
+      {
+        ncopy = nstrips_z_sensor;
+      }
+      else
+      {
+        cout << PHWHERE << "invalid laddertype " << laddertype << endl;
+        gSystem->Exit(1);
+        // this is just to make the optimizer happy which otherwise complains about possibly
+        // uninitialized variables. It doesn't know gSystem->Exit(1) quits,
+        // this exit here terminates the program for it
+        exit(1);
+      }
+      cell_length_z = strip_z * nstrips_z_sensor / ncopy;
+      offsetz = (ncopy % 2 == 0) ? -2. * cell_length_z / 2. * double(ncopy / 2) + cell_length_z / 2. : -2. * cell_length_z / 2. * double(ncopy / 2);
+      G4VPVParameterisation *fphxparam = new PHG4SiliconTrackerFPHXParameterisation(offsetx, +offsety, offsetz, 2. * cell_length_z / 2., ncopy);
+      new G4PVParameterised(boost::str(boost::format("fphxcontainer_%d_%d") % inttlayer % itype).c_str(),
+                            fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, OverlapCheck());
 
-	  for(int i=0;i<4;i++)
-	    {
-	      stave_curve_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_cons_%d_%d_%d") %inttlayer % itype %i).c_str(), 
-					       Rcmin, Rcmax, stave_z / 2., phic_begin[i], dphic[i]);
-	      stave_curve_volume[i] = new G4LogicalVolume(stave_curve_cons[i], G4Material::GetMaterial("CFRP_INTT"), 
-							  boost::str(boost::format("stave_curve_volume_%d_%d_%d") % inttlayer % itype % i).c_str(), 0, 0, 0);
-	      stave_curve_ext_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_ext_cons_%d_%d_%d") %inttlayer % itype %i).c_str(), 
-						   Rcmin, Rcmax, hdiext_z / 2., phic_begin[i], dphic[i]);
-	      stave_curve_ext_volume[i] = new G4LogicalVolume(stave_curve_ext_cons[i], G4Material::GetMaterial("CFRP_INTT"), 
-							      boost::str(boost::format("stave_curve_ext_volume_%d_%d_%d") % inttlayer % itype %i).c_str(), 0, 0, 0);
+      // PGS   - this is the carbon sheet that the HDI sits on. It forms the wall of the cooling tube that cools the HDI
 
-	      G4VisAttributes *stave_curve_vis = new G4VisAttributes();
-	      stave_curve_vis->SetVisibility(true);
-	      stave_curve_vis->SetForceSolid(true);
-	      stave_curve_vis->SetColour(G4Colour::White());
-	      stave_curve_volume[i]->SetVisAttributes(stave_curve_vis);
-	      stave_curve_ext_volume[i]->SetVisAttributes(stave_curve_vis);
-	    }
+      const double pgs_y = hdi_y;
+      const double pgs_z = hdi_z;
+      G4VSolid *pgs_box = new G4Box(boost::str(boost::format("pgs_box_%d_%d") % inttlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., pgs_z / 2.);
+      G4LogicalVolume *pgs_volume = new G4LogicalVolume(pgs_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                        boost::str(boost::format("pgs_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      if ((IsAbsorberActive.find(inttlayer))->second > 0)
+      {
+        absorberlogvols.insert(pgs_volume);
+      }
+      // The part that extends beyond this sensor, see above for hdiext
+      G4VSolid *pgsext_box = new G4Box(boost::str(boost::format("pgsext_box_%d_%s") % inttlayer % itype).c_str(), pgs_x / 2., pgs_y / 2., hdiext_z / 2.);
+      G4LogicalVolume *pgsext_volume = new G4LogicalVolume(pgsext_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                           boost::str(boost::format("pgsext_volume_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
 
-	  // we will need the length in y of the curved section as it is installed in the stave box
-	  double curve_length_y = Rcavge * sin(dphi_c);
+      G4VisAttributes *pgs_vis = new G4VisAttributes();
+      pgs_vis->SetVisibility(true);
+      pgs_vis->SetForceSolid(true);
+      pgs_vis->SetColour(G4Colour::Red());
+      pgs_volume->SetVisAttributes(pgs_vis);
+      pgsext_volume->SetVisAttributes(pgs_vis);
 
-	  // Make several straight sections for use in making the stave
-	  
-	  // Outer straight sections of stave
-	  double stave_wall_thickness = 0.03*cm;
-	  G4VSolid *stave_straight_outer_box = new G4Box(boost::str(boost::format("stave_straight_outer_box_%d_%d") % inttlayer % itype).c_str(), 
-							 stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
-	  G4LogicalVolume *stave_straight_outer_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("CFRP_INTT"), 
-									     boost::str(boost::format("stave_straight_outer_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  G4VSolid *stave_straight_outer_ext_box = new G4Box(boost::str(boost::format("stave_straight_outer_ext_box_%d_%s") % inttlayer % itype).c_str(), 
-							     stave_wall_thickness/2., stave_straight_outer_y/2., hdiext_z / 2.);
-	  G4LogicalVolume *stave_straight_outer_ext_volume = new G4LogicalVolume(stave_straight_outer_ext_box, G4Material::GetMaterial("CFRP_INTT"), 
-										 boost::str(boost::format("stave_straight_outer_ext_volume_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
-	  
-	  // connects cooling tubes together, only needed for laddertype PHG4SiliconTrackerDefs::SEGMENTATION_PHI, for laddertype PHG4SiliconTrackerDefs::SEGMENTATION_Z we just make a dummy
-	  G4VSolid *stave_straight_inner_box = new G4Box(boost::str(boost::format("stave_straight_inner_box_%d_%d") % inttlayer % itype).c_str(), 
-							 stave_wall_thickness / 2., stave_straight_inner_y / 2., stave_z / 2.);
-	  G4LogicalVolume *stave_straight_inner_volume = new G4LogicalVolume(stave_straight_inner_box, G4Material::GetMaterial("CFRP_INTT"), 
-									     boost::str(boost::format("stave_straight_inner_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  G4VSolid *stave_straight_inner_ext_box = new G4Box(boost::str(boost::format("stave_straight_inner_ext_box_%d_%d") % inttlayer % itype).c_str(), 
-							     stave_wall_thickness / 2., stave_straight_inner_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *stave_straight_inner_ext_volume  = new G4LogicalVolume(stave_straight_inner_ext_box, G4Material::GetMaterial("CFRP_INTT"), 
-										  boost::str(boost::format("stave_straight_inner_ext_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  
-	  //Top surface of cooler tube
-	  G4VSolid *stave_straight_cooler_box = new G4Box(boost::str(boost::format("stave_straight_cooler_box_%d_%d") % inttlayer % itype).c_str(), 
-							  stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
-	  G4LogicalVolume *stave_straight_cooler_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("CFRP_INTT"), 
-									      boost::str(boost::format("stave_straight_cooler_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  G4VSolid *stave_straight_cooler_ext_box = new G4Box(boost::str(boost::format("stave_straight_cooler_ext_box_%d_%d") % inttlayer % itype).c_str(), 
-							      stave_wall_thickness / 2., stave_straight_cooler_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *stave_straight_cooler_ext_volume = new G4LogicalVolume(stave_straight_cooler_ext_box, G4Material::GetMaterial("CFRP_INTT"), 
-										  boost::str(boost::format("stave_straight_cooler_ext_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  
-	  G4VisAttributes *stave_vis = new G4VisAttributes();
-	  stave_vis->SetVisibility(true);
-	  stave_vis->SetForceSolid(true);
-	  stave_vis->SetColour(G4Colour::White());
-	  stave_straight_cooler_volume->SetVisAttributes(stave_vis);
-	  stave_straight_cooler_ext_volume->SetVisAttributes(stave_vis);
-	  if(laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI) 
-	  {
-            stave_straight_inner_volume->SetVisAttributes(stave_vis);
-	  }
-	  if(laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI) 
-	  {
-            stave_straight_inner_ext_volume->SetVisAttributes(stave_vis);
-	  }
-	  stave_straight_outer_volume->SetVisAttributes(stave_vis);
-	  stave_straight_outer_ext_volume->SetVisAttributes(stave_vis);
-	  
-	  // Now we combine the elements of a stave defined above into a stave
-	  // Create a stave volume to install the stave sections into. The volume has to be big enouigh to contain the cooling tube
-	  double cooler_gap_x = 0.2*cm;  // id of cooling tube in cm
-	  double cooler_wall = 0.03*cm;   // outer wall thickness of cooling tube 
-	  double cooler_x = cooler_gap_x + cooler_wall; 
-	  const double stave_x = cooler_x;  // we do not include the PGS in the stave volume
-	  const double stave_y = hdi_y;
-	  G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % inttlayer % itype).c_str(), stave_x / 2., stave_y / 2., stave_z / 2.);
-	  G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_AIR"), 
-							      boost::str(boost::format("stave_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
-	  /*
+      // Carbon stave. This is the formed sheet that sits on the PGS and completes the cooling tube
+      // Formed from straight sections and sections of a tube of radius 2.3 mm. All have wall thickness of 0.3 mm.
+      // These are different for laddertype PHG4SiliconTrackerDefs::SEGMENTATION_Z  and PHG4SiliconTrackerDefs::SEGMENTATION_PHI, but they use some common elements.
+
+      // The curved section is made from a G4Cons, which is a generalized section of a cone
+      // Two curved sections combined should move the inner wall to be 2.0 mm away from the PGS, then 2 more sections bring it back
+      // For 1 of these tube sections,starting at 90 degrees, take decrease in y=1 mm at avge R.
+      // If avge R = 2.15 mm, dtheta = invcos( (R - y)/R ) = invcos(1.15/2.15) = 53.49 deg
+      // The extent along the x axis is then R*sin(dtheta) = 1.728 mm, so two sections combined have dx = 3.456 mm length in y
+      const double Rcmin = 0.20 * cm;  // 2 mm  inner radius of curved section, same at both ends
+      const double Rcmax = 0.23 * cm;  //cm  outer radius of curved section, same at both ends
+      double Rcavge = (Rcmax + Rcmin) / 2.0;
+      double dphi_c = acos((Rcavge - Rcmin / 2.) / Rcavge);
+      const double stave_z = pgs_z;
+
+      // makecurved sections for cooler tube
+      const double phic_begin[4] = {M_PI - dphi_c, -dphi_c, 0.0, M_PI};
+      const double dphic[4] = {dphi_c, dphi_c, dphi_c, dphi_c};
+
+      G4Tubs *stave_curve_cons[4];
+      G4Tubs *stave_curve_ext_cons[4];
+      G4LogicalVolume *stave_curve_volume[4];
+      G4LogicalVolume *stave_curve_ext_volume[4];
+
+      for (int i = 0; i < 4; i++)
+      {
+        stave_curve_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_cons_%d_%d_%d") % inttlayer % itype % i).c_str(),
+                                         Rcmin, Rcmax, stave_z / 2., phic_begin[i], dphic[i]);
+        stave_curve_volume[i] = new G4LogicalVolume(stave_curve_cons[i], G4Material::GetMaterial("CFRP_INTT"),
+                                                    boost::str(boost::format("stave_curve_volume_%d_%d_%d") % inttlayer % itype % i).c_str(), 0, 0, 0);
+        stave_curve_ext_cons[i] = new G4Tubs(boost::str(boost::format("stave_curve_ext_cons_%d_%d_%d") % inttlayer % itype % i).c_str(),
+                                             Rcmin, Rcmax, hdiext_z / 2., phic_begin[i], dphic[i]);
+        stave_curve_ext_volume[i] = new G4LogicalVolume(stave_curve_ext_cons[i], G4Material::GetMaterial("CFRP_INTT"),
+                                                        boost::str(boost::format("stave_curve_ext_volume_%d_%d_%d") % inttlayer % itype % i).c_str(), 0, 0, 0);
+
+        G4VisAttributes *stave_curve_vis = new G4VisAttributes();
+        stave_curve_vis->SetVisibility(true);
+        stave_curve_vis->SetForceSolid(true);
+        stave_curve_vis->SetColour(G4Colour::White());
+        stave_curve_volume[i]->SetVisAttributes(stave_curve_vis);
+        stave_curve_ext_volume[i]->SetVisAttributes(stave_curve_vis);
+      }
+
+      // we will need the length in y of the curved section as it is installed in the stave box
+      double curve_length_y = Rcavge * sin(dphi_c);
+
+      // Make several straight sections for use in making the stave
+
+      // Outer straight sections of stave
+      double stave_wall_thickness = 0.03 * cm;
+      G4VSolid *stave_straight_outer_box = new G4Box(boost::str(boost::format("stave_straight_outer_box_%d_%d") % inttlayer % itype).c_str(),
+                                                     stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
+      G4LogicalVolume *stave_straight_outer_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                         boost::str(boost::format("stave_straight_outer_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      G4VSolid *stave_straight_outer_ext_box = new G4Box(boost::str(boost::format("stave_straight_outer_ext_box_%d_%s") % inttlayer % itype).c_str(),
+                                                         stave_wall_thickness / 2., stave_straight_outer_y / 2., hdiext_z / 2.);
+      G4LogicalVolume *stave_straight_outer_ext_volume = new G4LogicalVolume(stave_straight_outer_ext_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                             boost::str(boost::format("stave_straight_outer_ext_volume_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
+
+      // connects cooling tubes together, only needed for laddertype PHG4SiliconTrackerDefs::SEGMENTATION_PHI, for laddertype PHG4SiliconTrackerDefs::SEGMENTATION_Z we just make a dummy
+      G4VSolid *stave_straight_inner_box = new G4Box(boost::str(boost::format("stave_straight_inner_box_%d_%d") % inttlayer % itype).c_str(),
+                                                     stave_wall_thickness / 2., stave_straight_inner_y / 2., stave_z / 2.);
+      G4LogicalVolume *stave_straight_inner_volume = new G4LogicalVolume(stave_straight_inner_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                         boost::str(boost::format("stave_straight_inner_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      G4VSolid *stave_straight_inner_ext_box = new G4Box(boost::str(boost::format("stave_straight_inner_ext_box_%d_%d") % inttlayer % itype).c_str(),
+                                                         stave_wall_thickness / 2., stave_straight_inner_y / 2., hdiext_z / 2.);
+      G4LogicalVolume *stave_straight_inner_ext_volume = new G4LogicalVolume(stave_straight_inner_ext_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                             boost::str(boost::format("stave_straight_inner_ext_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+
+      //Top surface of cooler tube
+      G4VSolid *stave_straight_cooler_box = new G4Box(boost::str(boost::format("stave_straight_cooler_box_%d_%d") % inttlayer % itype).c_str(),
+                                                      stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
+      G4LogicalVolume *stave_straight_cooler_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                          boost::str(boost::format("stave_straight_cooler_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      G4VSolid *stave_straight_cooler_ext_box = new G4Box(boost::str(boost::format("stave_straight_cooler_ext_box_%d_%d") % inttlayer % itype).c_str(),
+                                                          stave_wall_thickness / 2., stave_straight_cooler_y / 2., hdiext_z / 2.);
+      G4LogicalVolume *stave_straight_cooler_ext_volume = new G4LogicalVolume(stave_straight_cooler_ext_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                              boost::str(boost::format("stave_straight_cooler_ext_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+
+      G4VisAttributes *stave_vis = new G4VisAttributes();
+      stave_vis->SetVisibility(true);
+      stave_vis->SetForceSolid(true);
+      stave_vis->SetColour(G4Colour::White());
+      stave_straight_cooler_volume->SetVisAttributes(stave_vis);
+      stave_straight_cooler_ext_volume->SetVisAttributes(stave_vis);
+      if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI)
+      {
+        stave_straight_inner_volume->SetVisAttributes(stave_vis);
+      }
+      if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI)
+      {
+        stave_straight_inner_ext_volume->SetVisAttributes(stave_vis);
+      }
+      stave_straight_outer_volume->SetVisAttributes(stave_vis);
+      stave_straight_outer_ext_volume->SetVisAttributes(stave_vis);
+
+      // Now we combine the elements of a stave defined above into a stave
+      // Create a stave volume to install the stave sections into. The volume has to be big enouigh to contain the cooling tube
+      double cooler_gap_x = 0.2 * cm;  // id of cooling tube in cm
+      double cooler_wall = 0.03 * cm;  // outer wall thickness of cooling tube
+      double cooler_x = cooler_gap_x + cooler_wall;
+      const double stave_x = cooler_x;  // we do not include the PGS in the stave volume
+      const double stave_y = hdi_y;
+      G4VSolid *stave_box = new G4Box(boost::str(boost::format("stave_box_%d_%d") % inttlayer % itype).c_str(), stave_x / 2., stave_y / 2., stave_z / 2.);
+      G4LogicalVolume *stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_AIR"),
+                                                          boost::str(boost::format("stave_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      /*
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(stave_volume);
 	    }
 	  */
-	  G4VSolid *staveext_box = new G4Box(boost::str(boost::format("staveext_box_%d_%s") % inttlayer % itype).c_str(), stave_x / 2., stave_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"), 
-								 boost::str(boost::format("staveext_volume_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
-	  /*
+      G4VSolid *staveext_box = new G4Box(boost::str(boost::format("staveext_box_%d_%s") % inttlayer % itype).c_str(), stave_x / 2., stave_y / 2., hdiext_z / 2.);
+      G4LogicalVolume *staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"),
+                                                             boost::str(boost::format("staveext_volume_%d_%s") % inttlayer % itype).c_str(), 0, 0, 0);
+      /*
 	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
 	    {
 	      absorberlogvols.insert(staveext_volume);
 	    }
 	  */
-	  G4VisAttributes *stave_box_vis = new G4VisAttributes();
-	  stave_box_vis->SetVisibility(false);
-	  stave_box_vis->SetForceSolid(false);
-	  stave_volume->SetVisAttributes(stave_box_vis);
-	  staveext_volume->SetVisAttributes(stave_box_vis);
-	  
-	  // Assemble the elements into the stave volume and the stave extension volume
-	  // They are place relative to the center of the stave box. Thus the offset of the center of the segment is relative to the center of the satev box.
-	  // But we want the segment to be located relative to the lowest x limit of the stave box. 
-	  if(laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_Z)
-	    {
-	      // only one cooling tube in laddertype 0
-	      // Place the straight sections. We add the middle, then above x axis, then below x axis
-	      double x_off_str[3] = 
-		{
-		  Rcavge - stave_x / 2., 
-		  (Rcmax - Rcmin) / 2. - stave_x / 2., 
-		  (Rcmax - Rcmin) / 2. - stave_x / 2.
-		};
-	      double y_off_str[3] = 
-		{
-		  0.0,
-		  stave_straight_cooler_y / 2. + 2.0 * curve_length_y + stave_straight_outer_y / 2.0,
-		  -stave_straight_cooler_y / 2. - 2.0 * curve_length_y - stave_straight_outer_y / 2.0	  
-		};
-	      
-   	      for(int i=0;i<3;i++)
-		{	  	  
-		  if(i==0)
-		    {
-		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume, 
-					boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % i % inttlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
-		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume, 
-					boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % i % inttlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
-		    }
-		  else
-		    {
-		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume, 
-					boost::str(boost::format("stave_straight_outer_%d_%d_%d") % i % inttlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
-		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume, 
-					boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % i % inttlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
-		    }
-		}
-	      // The cooler curved sections are made using 2 curved sections in a recurve on each side of the cooler straight section 
-	      // The tube sections used here have the origin of their volume at their center of rotation. Rcavge
-	      //      Each curve section is moved to the center of the stave volume by a translation of +/- Rcavge
-	      //      Then it is moved to the outside or the inside of the stave volume by a translation of +/-  cooler_gap_x / 2.
-	      // we start at lowest y and work up in y
+      G4VisAttributes *stave_box_vis = new G4VisAttributes();
+      stave_box_vis->SetVisibility(false);
+      stave_box_vis->SetForceSolid(false);
+      stave_volume->SetVisAttributes(stave_box_vis);
+      staveext_volume->SetVisAttributes(stave_box_vis);
 
-	      double x_off_cooler[4] = 
-		{
-		  Rcavge -cooler_gap_x / 2. ,
-		  - Rcavge  + cooler_gap_x / 2.,
-		  - Rcavge + cooler_gap_x / 2.,
-		  Rcavge - cooler_gap_x / 2.
-		};
-	      double y_off_cooler[4] = 
-		{
-		  - stave_straight_cooler_y / 2. - 2. * curve_length_y,     
-		  - stave_straight_cooler_y / 2.,          
-		  stave_straight_cooler_y / 2.,
-		  stave_straight_cooler_y / 2. + 2. * curve_length_y    
-		};
-	      
-	      for(int i=0;i<4;i++)
-		{
-		  new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_volume[i], 
-				    boost::str(boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
-		  new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_ext_volume[i], 
-				    boost::str(boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype %i).c_str(), staveext_volume, false, 0, OverlapCheck());
-		}
-	    }
-	  else if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI) 	      // The type PHG4SiliconTrackerDefs::SEGMENTATION_PHI ladder has two cooling tubes
-	    {
-	      // First place the straight sections, do the extension at the same time
-	      // we alternate  positive and negative y values here
-	      double x_off_str[5] = 
-		{
-		  (Rcmax-Rcmin) / 2. -stave_x / 2., // against the PGS
-		  (Rcmax+Rcmin) / 2. - stave_x / 2.,   // top of cooler
-		  (Rcmax+Rcmin) / 2. - stave_x / 2.,   // top of cooler
-		  (Rcmax-Rcmin) / 2. - stave_x / 2., 
-		  (Rcmax-Rcmin) / 2 - stave_x / 2.
-		};
-	      double y_off_str[5] = 
-		{
-		  0.0,  // center section against PGS
-		  stave_straight_inner_y/2. + 2. * curve_length_y + stave_straight_cooler_y/2.,  // top of cooler
-		  - stave_straight_inner_y/2. - 2. * curve_length_y - stave_straight_cooler_y/2.,  // top of cooler
-		  stave_straight_inner_y/2. + 2. * curve_length_y + stave_straight_cooler_y + 2. *  curve_length_y + stave_straight_outer_y/2.,
-		  - stave_straight_inner_y/2. - 2. * curve_length_y - stave_straight_cooler_y - 2. *  curve_length_y - stave_straight_outer_y/2.,
-		};
-	      
-	      for(int i=0;i<5;i++)
-		{
-		  if(i==0)
-		    {
-		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_volume, 
-					boost::str(boost::format("stave_straight_inner_%d_%d_%d") % inttlayer % itype %i).c_str(), stave_volume, false, 0, OverlapCheck());
-		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_ext_volume, 
-					boost::str(boost::format("stave_straight_inner_ext_%d_%d_%s") % inttlayer % itype %i).c_str(), staveext_volume, false, 0, OverlapCheck());
-		    }
-		  else if(i==1 || i==2)
-		    {
-		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume, 
-					boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % inttlayer % itype %i).c_str(), stave_volume, false, 0, OverlapCheck());
-		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume, 
-					boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % inttlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
-		    }
-		  else
-		    {
-		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume, 
-					boost::str(boost::format("stave_straight_outer_%d_%d_%d") % inttlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
-		      new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume, 
-					boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % inttlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
-		    }
-		}
-	      
-	      // Place the curved sections
-	      // here we do all above the x axis, then all below the x axis, each in order of increasing y
+      // Assemble the elements into the stave volume and the stave extension volume
+      // They are place relative to the center of the stave box. Thus the offset of the center of the segment is relative to the center of the satev box.
+      // But we want the segment to be located relative to the lowest x limit of the stave box.
+      if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_Z)
+      {
+        // only one cooling tube in laddertype 0
+        // Place the straight sections. We add the middle, then above x axis, then below x axis
+        double x_off_str[3] =
+            {
+                Rcavge - stave_x / 2.,
+                (Rcmax - Rcmin) / 2. - stave_x / 2.,
+                (Rcmax - Rcmin) / 2. - stave_x / 2.};
+        double y_off_str[3] =
+            {
+                0.0,
+                stave_straight_cooler_y / 2. + 2.0 * curve_length_y + stave_straight_outer_y / 2.0,
+                -stave_straight_cooler_y / 2. - 2.0 * curve_length_y - stave_straight_outer_y / 2.0};
 
-	      double x_off_curve[8] = 
-		{
-		  // below x axis, increasing in y
-		  Rcavge -cooler_gap_x / 2. ,
-		  - Rcavge  + cooler_gap_x / 2.,
-		  - Rcavge + cooler_gap_x / 2.,
-		  Rcavge - cooler_gap_x / 2.,
-		  // above x axis, increasing in y
-		  Rcavge -cooler_gap_x / 2. ,
-		  - Rcavge  + cooler_gap_x / 2.,
-		  - Rcavge + cooler_gap_x / 2.,
-		  Rcavge - cooler_gap_x / 2.
-		};
-	      double y_off_curve[8] = 
-		{
-		  // below the x axis, increasing in y
-		  - stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y - 2.* curve_length_y,
-		  - stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y,
-		  - stave_straight_inner_y / 2. - 2. * curve_length_y,     
-		  - stave_straight_inner_y / 2.,          
-		  // above the x axis, increasing in y
-		  stave_straight_inner_y / 2.,
-		  stave_straight_inner_y / 2. + 2. * curve_length_y,
-		  stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y,
-		  stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y + 2.* curve_length_y
-   		};
-	      
-	      for(int i=0;i<8;i++)
-		{
-		  int ivol = i;
-		  if(i > 3) 
-		    ivol = i - 4;
+        for (int i = 0; i < 3; i++)
+        {
+          if (i == 0)
+          {
+            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume,
+                              boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % i % inttlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume,
+                              boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % i % inttlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+          }
+          else
+          {
+            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume,
+                              boost::str(boost::format("stave_straight_outer_%d_%d_%d") % i % inttlayer % itype).c_str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume,
+                              boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % i % inttlayer % itype).c_str(), staveext_volume, false, 0, OverlapCheck());
+          }
+        }
+        // The cooler curved sections are made using 2 curved sections in a recurve on each side of the cooler straight section
+        // The tube sections used here have the origin of their volume at their center of rotation. Rcavge
+        //      Each curve section is moved to the center of the stave volume by a translation of +/- Rcavge
+        //      Then it is moved to the outside or the inside of the stave volume by a translation of +/-  cooler_gap_x / 2.
+        // we start at lowest y and work up in y
 
-		  new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_volume[ivol], boost::str(boost::format("stave_curve_%d_%d_%d") 
-															     % inttlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
-		  new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_ext_volume[ivol], boost::str(boost::format("stave_curve_ext_%d_%d_%s") 
-																 % inttlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
-		}
-	    }
-	  else
-	  {
-	    cout << PHWHERE << "invalid laddertype " << laddertype << endl;
-	    gSystem->Exit(1);
-	  }
+        double x_off_cooler[4] =
+            {
+                Rcavge - cooler_gap_x / 2.,
+                -Rcavge + cooler_gap_x / 2.,
+                -Rcavge + cooler_gap_x / 2.,
+                Rcavge - cooler_gap_x / 2.};
+        double y_off_cooler[4] =
+            {
+                -stave_straight_cooler_y / 2. - 2. * curve_length_y,
+                -stave_straight_cooler_y / 2.,
+                stave_straight_cooler_y / 2.,
+                stave_straight_cooler_y / 2. + 2. * curve_length_y};
 
-      
+        for (int i = 0; i < 4; i++)
+        {
+          new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_volume[i],
+                            boost::str(boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
+          new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_ext_volume[i],
+                            boost::str(boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
+        }
+      }
+      else if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI)  // The type PHG4SiliconTrackerDefs::SEGMENTATION_PHI ladder has two cooling tubes
+      {
+        // First place the straight sections, do the extension at the same time
+        // we alternate  positive and negative y values here
+        double x_off_str[5] =
+            {
+                (Rcmax - Rcmin) / 2. - stave_x / 2.,  // against the PGS
+                (Rcmax + Rcmin) / 2. - stave_x / 2.,  // top of cooler
+                (Rcmax + Rcmin) / 2. - stave_x / 2.,  // top of cooler
+                (Rcmax - Rcmin) / 2. - stave_x / 2.,
+                (Rcmax - Rcmin) / 2 - stave_x / 2.};
+        double y_off_str[5] =
+            {
+                0.0,                                                                                // center section against PGS
+                stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y / 2.,   // top of cooler
+                -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y / 2.,  // top of cooler
+                stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y + 2. * curve_length_y + stave_straight_outer_y / 2.,
+                -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y - 2. * curve_length_y - stave_straight_outer_y / 2.,
+            };
 
-	  // ----- Step 2 ------------------------------------------------------------------------------------
-	  // We place Si-sensor, FPHX, HDI, PGS sheet, and stave in the ladder  volume.
-	  // ======================================================
+        for (int i = 0; i < 5; i++)
+        {
+          if (i == 0)
+          {
+            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_volume,
+                              boost::str(boost::format("stave_straight_inner_%d_%d_%d") % inttlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_ext_volume,
+                              boost::str(boost::format("stave_straight_inner_ext_%d_%d_%s") % inttlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
+          }
+          else if (i == 1 || i == 2)
+          {
+            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume,
+                              boost::str(boost::format("stave_straight_cooler_%d_%d_%d") % inttlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume,
+                              boost::str(boost::format("stave_straight_cooler_ext_%d_%d_%s") % inttlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
+          }
+          else
+          {
+            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume,
+                              boost::str(boost::format("stave_straight_outer_%d_%d_%d") % inttlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume,
+                              boost::str(boost::format("stave_straight_outer_ext_%d_%d_%s") % inttlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
+          }
+        }
 
-	  // Make the ladder volume first
-	  // We are still in the loop over inner or outer sensors. This is the ladder volume corresponding to this sensor. The FPHX is taller than the sensor in x.
-	  const double ladder_x = stave_x  + pgs_x  + hdi_kapton_x  + hdi_copper_x + fphx_x;
-	  double ladder_y = hdi_y;
-	  const double ladder_z = hdi_z;
+        // Place the curved sections
+        // here we do all above the x axis, then all below the x axis, each in order of increasing y
 
-	  // For laddertype PHG4SiliconTrackerDefs::SEGMENTATION_Z we need to make the ladder big enough in y so that the sensor can be placed at the center
-	  // Thus when we rotate the ladder into place, the sensor will be at the correct radius and perpendicular to the radial vector through its center
-	  if(laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_Z)
-	  {
-            ladder_y = ladder_y + 2.0* sensor_offset_y;
-	  }	    
-	  G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % inttlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., ladder_z / 2.);
-	  G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+        double x_off_curve[8] =
+            {
+                // below x axis, increasing in y
+                Rcavge - cooler_gap_x / 2.,
+                -Rcavge + cooler_gap_x / 2.,
+                -Rcavge + cooler_gap_x / 2.,
+                Rcavge - cooler_gap_x / 2.,
+                // above x axis, increasing in y
+                Rcavge - cooler_gap_x / 2.,
+                -Rcavge + cooler_gap_x / 2.,
+                -Rcavge + cooler_gap_x / 2.,
+                Rcavge - cooler_gap_x / 2.};
+        double y_off_curve[8] =
+            {
+                // below the x axis, increasing in y
+                -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y - 2. * curve_length_y,
+                -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y,
+                -stave_straight_inner_y / 2. - 2. * curve_length_y,
+                -stave_straight_inner_y / 2.,
+                // above the x axis, increasing in y
+                stave_straight_inner_y / 2.,
+                stave_straight_inner_y / 2. + 2. * curve_length_y,
+                stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y,
+                stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y + 2. * curve_length_y};
 
-	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
-	    {
-	      absorberlogvols.insert(ladder_volume);
-	    }
+        for (int i = 0; i < 8; i++)
+        {
+          int ivol = i;
+          if (i > 3)
+            ivol = i - 4;
 
-	  G4VSolid *ladderext_box = new G4Box(boost::str(boost::format("ladderext_box_%d_%s") % inttlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., hdiext_z / 2.);
-	  G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladderext_%d_%d_%d") % inttlayer % inttlayer % itype).c_str(), 0, 0, 0);
-	  if ((IsAbsorberActive.find(inttlayer))->second > 0)
-	    {
-	      absorberlogvols.insert(ladderext_volume);
-	    }
+          new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_volume[ivol], boost::str(boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).c_str(), stave_volume, false, 0, OverlapCheck());
+          new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_ext_volume[ivol], boost::str(boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype % i).c_str(), staveext_volume, false, 0, OverlapCheck());
+        }
+      }
+      else
+      {
+        cout << PHWHERE << "invalid laddertype " << laddertype << endl;
+        gSystem->Exit(1);
+      }
 
-	  G4VisAttributes *ladder_vis = new G4VisAttributes();
-	  ladder_vis->SetVisibility(false);
-	  ladder_vis->SetForceSolid(false);
-	  ladder_vis->SetColour(G4Colour::Cyan());
-	  ladder_volume->SetVisAttributes(ladder_vis);
-	  ladderext_volume->SetVisAttributes(ladder_vis);
+      // ----- Step 2 ------------------------------------------------------------------------------------
+      // We place Si-sensor, FPHX, HDI, PGS sheet, and stave in the ladder  volume.
+      // ======================================================
 
-	  // Now add the components of the ladder to the ladder volume
-	  // The sensor is closest to the beam pipe, the stave cooler is furthest away
-	  // Note that the cooler has been assembled in the stave volume with the top at larger x, so the sensor will be at smaller x
-	  // That will be the configuration when the ladder is at phi = 0 degrees, the positive x direction
+      // Make the ladder volume first
+      // We are still in the loop over inner or outer sensors. This is the ladder volume corresponding to this sensor. The FPHX is taller than the sensor in x.
+      const double ladder_x = stave_x + pgs_x + hdi_kapton_x + hdi_copper_x + fphx_x;
+      double ladder_y = hdi_y;
+      const double ladder_z = hdi_z;
 
-	  // We start at the most positive x value and add the stave first
+      // For laddertype PHG4SiliconTrackerDefs::SEGMENTATION_Z we need to make the ladder big enough in y so that the sensor can be placed at the center
+      // Thus when we rotate the ladder into place, the sensor will be at the correct radius and perpendicular to the radial vector through its center
+      if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_Z)
+      {
+        ladder_y = ladder_y + 2.0 * sensor_offset_y;
+      }
+      G4VSolid *ladder_box = new G4Box(boost::str(boost::format("ladder_box_%d_%d") % inttlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., ladder_z / 2.);
+      G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladder_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
 
-	  // Carbon stave        
-	  double TVstave_y = 0.0;
-	  if(laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_Z)
-	  {
-            TVstave_y = - sensor_offset_y;  // for type PHG4SiliconTrackerDefs::SEGMENTATION_Z the stave is offset from the sensor center, and the sensor center is the middle of the stave volume
-	  }
-	  const double TVstave_x = ladder_x / 2. - stave_x / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVstave_x, TVstave_y, 0.0), stave_volume, boost::str(boost::format("stave_%d_%d") % inttlayer % itype).c_str(), 
-			    ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVstave_x, TVstave_y, 0.0), staveext_volume, boost::str(boost::format("staveext_%d_%s") % inttlayer % itype).c_str(), 
-			    ladderext_volume, false, 0, OverlapCheck());
+      if ((IsAbsorberActive.find(inttlayer))->second > 0)
+      {
+        absorberlogvols.insert(ladder_volume);
+      }
 
-	  // PGS
-	  const double TVpgs_x = TVstave_x - stave_x / 2. - pgs_x / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVpgs_x, TVstave_y, 0.0), pgs_volume, boost::str(boost::format("pgs_%d_%d") % inttlayer % itype).c_str(), 
-			    ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVpgs_x, TVstave_y, 0.0), pgsext_volume, boost::str(boost::format("pgsext_%d_%s") % inttlayer % itype).c_str(), 
-			    ladderext_volume, false, 0, OverlapCheck());
+      G4VSolid *ladderext_box = new G4Box(boost::str(boost::format("ladderext_box_%d_%s") % inttlayer % itype).c_str(), ladder_x / 2., ladder_y / 2., hdiext_z / 2.);
+      G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), boost::str(boost::format("ladderext_%d_%d_%d") % inttlayer % inttlayer % itype).c_str(), 0, 0, 0);
+      if ((IsAbsorberActive.find(inttlayer))->second > 0)
+      {
+        absorberlogvols.insert(ladderext_volume);
+      }
 
-	  // HDI Kapton        
-	  const double TVhdi_kapton_x = TVpgs_x - pgs_x / 2. - hdi_kapton_x / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdi_kapton_volume, boost::str(boost::format("hdikapton_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdiext_kapton_volume, boost::str(boost::format("hdiextkapton_%d_%s") % inttlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
+      G4VisAttributes *ladder_vis = new G4VisAttributes();
+      ladder_vis->SetVisibility(false);
+      ladder_vis->SetForceSolid(false);
+      ladder_vis->SetColour(G4Colour::Cyan());
+      ladder_volume->SetVisAttributes(ladder_vis);
+      ladderext_volume->SetVisAttributes(ladder_vis);
 
-	  // HDI copper        
-	  const double TVhdi_copper_x = TVhdi_kapton_x - hdi_kapton_x / 2. - hdi_copper_x / 2.;
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdi_copper_volume, boost::str(boost::format("hdicopper_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdiext_copper_volume, boost::str(boost::format("hdiextcopper_%d_%s") % inttlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
+      // Now add the components of the ladder to the ladder volume
+      // The sensor is closest to the beam pipe, the stave cooler is furthest away
+      // Note that the cooler has been assembled in the stave volume with the top at larger x, so the sensor will be at smaller x
+      // That will be the configuration when the ladder is at phi = 0 degrees, the positive x direction
 
-	  // Si-sensor        
-	  const double TVSi_x = TVhdi_copper_x - hdi_copper_x / 2. - siactive_x / 2.;
-	  // sensor is centered in y in the ladder volume for both types
-	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siinactive_volume, 
-			    boost::str(boost::format("siinactive_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-	  new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siactive_volume, 
-			    boost::str(boost::format("siactive_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+      // We start at the most positive x value and add the stave first
 
-	  // FPHX container
-	  const double TVfphx_x = TVhdi_copper_x - hdi_copper_x / 2. - fphx_x / 2.;
-	  const double TVfphx_y = sifull_y / 2. + gap_sensor_fphx + fphx_y / 2.;
-	  // laddertype PHG4SiliconTrackerDefs::SEGMENTATION_Z has only one FPHX, laddertype PHG4SiliconTrackerDefs::SEGMENTATION_PHI has two
-	  if(laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI)
-	  {
-	    new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
-	  }
-	  new G4PVPlacement(0, G4ThreeVector(TVfphx_x, -TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerm_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+      // Carbon stave
+      double TVstave_y = 0.0;
+      if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_Z)
+      {
+        TVstave_y = -sensor_offset_y;  // for type PHG4SiliconTrackerDefs::SEGMENTATION_Z the stave is offset from the sensor center, and the sensor center is the middle of the stave volume
+      }
+      const double TVstave_x = ladder_x / 2. - stave_x / 2.;
+      new G4PVPlacement(0, G4ThreeVector(TVstave_x, TVstave_y, 0.0), stave_volume, boost::str(boost::format("stave_%d_%d") % inttlayer % itype).c_str(),
+                        ladder_volume, false, 0, OverlapCheck());
+      new G4PVPlacement(0, G4ThreeVector(TVstave_x, TVstave_y, 0.0), staveext_volume, boost::str(boost::format("staveext_%d_%s") % inttlayer % itype).c_str(),
+                        ladderext_volume, false, 0, OverlapCheck());
 
-	  // ----- Step 3 --------------------------------------------------------------------------------------------------------------------
-	  // We install the section of ladder for this sensor at all requested phi values and at positive and negative Z
-	  //========================================================================
+      // PGS
+      const double TVpgs_x = TVstave_x - stave_x / 2. - pgs_x / 2.;
+      new G4PVPlacement(0, G4ThreeVector(TVpgs_x, TVstave_y, 0.0), pgs_volume, boost::str(boost::format("pgs_%d_%d") % inttlayer % itype).c_str(),
+                        ladder_volume, false, 0, OverlapCheck());
+      new G4PVPlacement(0, G4ThreeVector(TVpgs_x, TVstave_y, 0.0), pgsext_volume, boost::str(boost::format("pgsext_%d_%s") % inttlayer % itype).c_str(),
+                        ladderext_volume, false, 0, OverlapCheck());
 
-	  // Distribute Ladders in phi
-	  // We are still in the loops over layer and sensor type, we will place copies of the ladder section for this sensor
-	  //  at all ladder phi values, and at both positive and negative Z values.
+      // HDI Kapton
+      const double TVhdi_kapton_x = TVpgs_x - pgs_x / 2. - hdi_kapton_x / 2.;
+      new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdi_kapton_volume, boost::str(boost::format("hdikapton_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+      new G4PVPlacement(0, G4ThreeVector(TVhdi_kapton_x, TVstave_y, 0.0), hdiext_kapton_volume, boost::str(boost::format("hdiextkapton_%d_%s") % inttlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
-	  // given radius values are for the center of the sensor, we need the x offset from center of ladder to center of sensor so we can place the ladder
-	  double sensor_offset_x_ladder = 0.0 - TVSi_x; // ladder center is at x = 0.0 by construction. Sensor is at lower x, so TVSi_x is negative
+      // HDI copper
+      const double TVhdi_copper_x = TVhdi_kapton_x - hdi_kapton_x / 2. - hdi_copper_x / 2.;
+      new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdi_copper_volume, boost::str(boost::format("hdicopper_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+      new G4PVPlacement(0, G4ThreeVector(TVhdi_copper_x, TVstave_y, 0.0), hdiext_copper_volume, boost::str(boost::format("hdiextcopper_%d_%s") % inttlayer % itype).c_str(), ladderext_volume, false, 0, OverlapCheck());
 
-	  const double dphi = 2 * M_PI / nladders_layer;
+      // Si-sensor
+      const double TVSi_x = TVhdi_copper_x - hdi_copper_x / 2. - siactive_x / 2.;
+      // sensor is centered in y in the ladder volume for both types
+      new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siinactive_volume,
+                        boost::str(boost::format("siinactive_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+      new G4PVPlacement(0, G4ThreeVector(TVSi_x, 0.0, 0.0), siactive_volume,
+                        boost::str(boost::format("siactive_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
-	  // there is no single radius for a layer
-	  ladder_radius_inner[inttlayer] = sensor_radius_inner[inttlayer] + sensor_offset_x_ladder;
-	  ladder_radius_outer[inttlayer] = sensor_radius_outer[inttlayer] + sensor_offset_x_ladder;
-	  posz[inttlayer][itype] = (itype == 0) ? hdi_z / 2. : hdi_z_[inttlayer][0] + hdi_z / 2.; // location of center of ladder in Z
-	  strip_x_offset[inttlayer] = sensor_offset_x_ladder;
-	  
-	  // The sensors have no tilt in the new design
-	  //    The type 1 ladders have the sensor at the center of the ladder in phi, so that is easy
-	  //    The type 0 ladders are more complicated because the sensor center is perpendicular to the radial vector and the sensor is not at the ladder center
-	  //         We made the stave box symmetric in y around the sensor center to simplify things
+      // FPHX container
+      const double TVfphx_x = TVhdi_copper_x - hdi_copper_x / 2. - fphx_x / 2.;
+      const double TVfphx_y = sifull_y / 2. + gap_sensor_fphx + fphx_y / 2.;
+      // laddertype PHG4SiliconTrackerDefs::SEGMENTATION_Z has only one FPHX, laddertype PHG4SiliconTrackerDefs::SEGMENTATION_PHI has two
+      if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI)
+      {
+        new G4PVPlacement(0, G4ThreeVector(TVfphx_x, +TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerp_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
+      }
+      new G4PVPlacement(0, G4ThreeVector(TVfphx_x, -TVfphx_y, 0.0), fphxcontainer_volume, boost::str(boost::format("fphxcontainerm_%d_%d") % inttlayer % itype).c_str(), ladder_volume, false, 0, OverlapCheck());
 
-	  for (G4int icopy = 0; icopy < nladders_layer; icopy++)
-	    {
-	      const double phi = offsetphi + dphi * (double) icopy;  // offsetphi is zero by default, so we start at zero
-	      double radius = ladder_radius_inner[inttlayer];
-	      if(icopy%2)
-		radius = ladder_radius_outer[inttlayer];  // every odd numbered copy is placed at the larger radius
+      // ----- Step 3 --------------------------------------------------------------------------------------------------------------------
+      // We install the section of ladder for this sensor at all requested phi values and at positive and negative Z
+      //========================================================================
 
-	      const double posx = radius * cos(phi);
-	      const double posy = radius * sin(phi);
-	      const double fRotate = phi + offsetrot; // no initial rotation, since we assembled the ladder in phi = 0 orientation 
-	      G4RotationMatrix *ladderrotation = new G4RotationMatrix();
-	      //ladderrotation->rotateZ(-fRotate);
-	      ladderrotation->rotateZ(fRotate);
+      // Distribute Ladders in phi
+      // We are still in the loops over layer and sensor type, we will place copies of the ladder section for this sensor
+      //  at all ladder phi values, and at both positive and negative Z values.
 
-	      // place the copy at its ladder phi value, and at positive (2) and negative (1) Z
-	      new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, -posz[inttlayer][itype])), ladder_volume, 
-				boost::str(boost::format("ladder_%d_%d_%d_1") % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
-	      new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, +posz[inttlayer][itype])), ladder_volume, 
-				boost::str(boost::format("ladder_%d_%d_%d_2") % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+      // given radius values are for the center of the sensor, we need the x offset from center of ladder to center of sensor so we can place the ladder
+      double sensor_offset_x_ladder = 0.0 - TVSi_x;  // ladder center is at x = 0.0 by construction. Sensor is at lower x, so TVSi_x is negative
 
-	
-	      if (itype != 0)
-		{  
-		  // We have added the outer sensor above, now we add the HDI extension tab to the end of the outer sensor HDI
-		  const G4double posz_ext = (hdi_z_[inttlayer][0] + hdi_z) + hdiext_z / 2.;
+      const double dphi = 2 * M_PI / nladders_layer;
 
-		  new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, -posz_ext)), ladderext_volume, 
-				    boost::str(boost::format("ladderext_%d_%d_%d_%d_1") % inttlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
-		  new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, +posz_ext)), ladderext_volume, 
-				    boost::str(boost::format("ladderext_%d_%d_%d_%d_2") % inttlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
-		}
+      // there is no single radius for a layer
+      ladder_radius_inner[inttlayer] = sensor_radius_inner[inttlayer] + sensor_offset_x_ladder;
+      ladder_radius_outer[inttlayer] = sensor_radius_outer[inttlayer] + sensor_offset_x_ladder;
+      posz[inttlayer][itype] = (itype == 0) ? hdi_z / 2. : hdi_z_[inttlayer][0] + hdi_z / 2.;  // location of center of ladder in Z
+      strip_x_offset[inttlayer] = sensor_offset_x_ladder;
 
-	      /*
+      // The sensors have no tilt in the new design
+      //    The type 1 ladders have the sensor at the center of the ladder in phi, so that is easy
+      //    The type 0 ladders are more complicated because the sensor center is perpendicular to the radial vector and the sensor is not at the ladder center
+      //         We made the stave box symmetric in y around the sensor center to simplify things
+
+      for (G4int icopy = 0; icopy < nladders_layer; icopy++)
+      {
+        const double phi = offsetphi + dphi * (double) icopy;  // offsetphi is zero by default, so we start at zero
+        double radius = ladder_radius_inner[inttlayer];
+        if (icopy % 2)
+          radius = ladder_radius_outer[inttlayer];  // every odd numbered copy is placed at the larger radius
+
+        const double posx = radius * cos(phi);
+        const double posy = radius * sin(phi);
+        const double fRotate = phi + offsetrot;  // no initial rotation, since we assembled the ladder in phi = 0 orientation
+        G4RotationMatrix *ladderrotation = new G4RotationMatrix();
+        //ladderrotation->rotateZ(-fRotate);
+        ladderrotation->rotateZ(fRotate);
+
+        // place the copy at its ladder phi value, and at positive (2) and negative (1) Z
+        new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, -posz[inttlayer][itype])), ladder_volume,
+                          boost::str(boost::format("ladder_%d_%d_%d_1") % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+        new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, +posz[inttlayer][itype])), ladder_volume,
+                          boost::str(boost::format("ladder_%d_%d_%d_2") % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+
+        if (itype != 0)
+        {
+          // We have added the outer sensor above, now we add the HDI extension tab to the end of the outer sensor HDI
+          const G4double posz_ext = (hdi_z_[inttlayer][0] + hdi_z) + hdiext_z / 2.;
+
+          new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, -posz_ext)), ladderext_volume,
+                            boost::str(boost::format("ladderext_%d_%d_%d_%d_1") % inttlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+          new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, +posz_ext)), ladderext_volume,
+                            boost::str(boost::format("ladderext_%d_%d_%d_%d_2") % inttlayer % inttlayer % itype % icopy).c_str(), trackerenvelope, false, 0, OverlapCheck());
+        }
+
+        /*
 	      cout << "Ladder copy " << icopy << " radius " << radius << " phi " << phi << " itype " << itype << " posz " << posz[inttlayer][itype] 
 		   << " fRotate " << fRotate << " posx " << posx << " posy " << posy << " sensor_offset_x_ladder " << sensor_offset_x_ladder 
 		   << endl;
 	      */
 
-	    } // end loop over ladder copy placement in phi and positive and negative Z
-	} // end loop over inner or outer sensor
-    } // end loop over layers
+      }  // end loop over ladder copy placement in phi and positive and negative Z
+    }    // end loop over inner or outer sensor
+  }      // end loop over layers
 
   // Finally, we add some support material for the silicon detectors
 
-  // 
+  //
   /*
     6 rails, which are 12mm OD and 9mm ID tubes at a radius of 175 mm.  They are spaced equidistantly in phi.
           For the 6 rails, there should be one at the very top and bottom (ie, along the vertical), and then the rest are symmetrically placed in phi.  
@@ -805,13 +793,13 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   */
 
   // rails
-  double rail_inner_radius = 4.5; 
+  double rail_inner_radius = 4.5;
   double rail_outer_radius = 6.0;
   double rail_length = 410.0 * 10.0;  // TPC length is 410 cm
-  G4Tubs *rail_tube = new G4Tubs(boost::str(boost::format("si_support_rail")).c_str(), 
-			    rail_inner_radius, rail_outer_radius, rail_length / 2.0, -M_PI, 2.0 * M_PI );  
-  G4LogicalVolume *rail_volume = new G4LogicalVolume(rail_tube, G4Material::GetMaterial("CFRP_INTT"), 
-								      boost::str(boost::format("rail_volume")).c_str(), 0, 0, 0);
+  G4Tubs *rail_tube = new G4Tubs(boost::str(boost::format("si_support_rail")).c_str(),
+                                 rail_inner_radius, rail_outer_radius, rail_length / 2.0, -M_PI, 2.0 * M_PI);
+  G4LogicalVolume *rail_volume = new G4LogicalVolume(rail_tube, G4Material::GetMaterial("CFRP_INTT"),
+                                                     boost::str(boost::format("rail_volume")).c_str(), 0, 0, 0);
   G4VisAttributes *rail_vis = new G4VisAttributes();
   rail_vis->SetVisibility(true);
   rail_vis->SetForceSolid(true);
@@ -821,37 +809,37 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   double rail_dphi = M_PI / 3.0;
   double rail_phi_start = M_PI / 6.0;
   double rail_radius = 175.0;
-  for(int i = 0; i < 6; i++)
-    {
-      double phi = rail_phi_start + i * rail_dphi;
+  for (int i = 0; i < 6; i++)
+  {
+    double phi = rail_phi_start + i * rail_dphi;
 
-      // place a copy at each rail phi value
-      const double posx = rail_radius * cos(phi);
-      const double posy = rail_radius * sin(phi);      
+    // place a copy at each rail phi value
+    const double posx = rail_radius * cos(phi);
+    const double posy = rail_radius * sin(phi);
 
-      new G4PVPlacement(0, G4ThreeVector(posx, posy, 0.0), rail_volume, 
-			boost::str(boost::format("si_support_rail_%d")  % i).c_str(), trackerenvelope, false, 0, OverlapCheck());
-    }
+    new G4PVPlacement(0, G4ThreeVector(posx, posy, 0.0), rail_volume,
+                      boost::str(boost::format("si_support_rail_%d") % i).c_str(), trackerenvelope, false, 0, OverlapCheck());
+  }
 
   // Outer skin
 
-  G4Tubs *outer_skin_tube = new G4Tubs(boost::str(boost::format("si_outer_skin")).c_str(), 
-			    157.0, 158.0, 480.0, -M_PI, 2.0 * M_PI );  
-  G4LogicalVolume *outer_skin_volume = new G4LogicalVolume(outer_skin_tube, G4Material::GetMaterial("CFRP_INTT"), 
-								      boost::str(boost::format("outer_skin_volume")).c_str(), 0, 0, 0);
+  G4Tubs *outer_skin_tube = new G4Tubs(boost::str(boost::format("si_outer_skin")).c_str(),
+                                       157.0, 158.0, 480.0, -M_PI, 2.0 * M_PI);
+  G4LogicalVolume *outer_skin_volume = new G4LogicalVolume(outer_skin_tube, G4Material::GetMaterial("CFRP_INTT"),
+                                                           boost::str(boost::format("outer_skin_volume")).c_str(), 0, 0, 0);
   outer_skin_volume->SetVisAttributes(rail_vis);
-  new G4PVPlacement(0, G4ThreeVector(0, 0.0), outer_skin_volume, 
-		    boost::str(boost::format("si_support_outer_skin") ).c_str(), trackerenvelope, false, 0, OverlapCheck());  
+  new G4PVPlacement(0, G4ThreeVector(0, 0.0), outer_skin_volume,
+                    boost::str(boost::format("si_support_outer_skin")).c_str(), trackerenvelope, false, 0, OverlapCheck());
 
   // Inner skin
 
-  G4Tubs *inner_skin_tube = new G4Tubs(boost::str(boost::format("si_inner_skin")).c_str(), 
-			    63.85, 64.0, 480.0, -M_PI, 2.0 * M_PI );  
-  G4LogicalVolume *inner_skin_volume = new G4LogicalVolume(inner_skin_tube, G4Material::GetMaterial("CFRP_INTT"), 
-								      boost::str(boost::format("inner_skin_volume")).c_str(), 0, 0, 0);
+  G4Tubs *inner_skin_tube = new G4Tubs(boost::str(boost::format("si_inner_skin")).c_str(),
+                                       63.85, 64.0, 480.0, -M_PI, 2.0 * M_PI);
+  G4LogicalVolume *inner_skin_volume = new G4LogicalVolume(inner_skin_tube, G4Material::GetMaterial("CFRP_INTT"),
+                                                           boost::str(boost::format("inner_skin_volume")).c_str(), 0, 0, 0);
   inner_skin_volume->SetVisAttributes(rail_vis);
-  new G4PVPlacement(0, G4ThreeVector(0, 0.0), inner_skin_volume, 
-		    boost::str(boost::format("si_support_inner_skin") ).c_str(), trackerenvelope, false, 0, OverlapCheck());
+  new G4PVPlacement(0, G4ThreeVector(0, 0.0), inner_skin_volume,
+                    boost::str(boost::format("si_support_inner_skin")).c_str(), trackerenvelope, false, 0, OverlapCheck());
 
   //=======================================================
   // Add an outer shell for the MVTX - move this to the MVTX detector module
@@ -865,28 +853,28 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   double mvtx_shell_foam_core_inner_radius = mvtx_shell_inner_skin_inner_radius + skin_thickness;
   double mvtx_shell_outer_skin_inner_radius = mvtx_shell_foam_core_inner_radius + foam_core_thickness;
 
-  G4Tubs *mvtx_shell_inner_skin_tube = new G4Tubs(boost::str(boost::format("mvtx_shell_inner_skin")).c_str(), 
-			    mvtx_shell_inner_skin_inner_radius, mvtx_shell_inner_skin_inner_radius + skin_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI );  
-  G4LogicalVolume *mvtx_shell_inner_skin_volume = new G4LogicalVolume(mvtx_shell_inner_skin_tube, G4Material::GetMaterial("CFRP_INTT"), 
-								      boost::str(boost::format("mvtx_shell_inner_skin_volume")).c_str(), 0, 0, 0);
-  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_inner_skin_volume, 
-		    boost::str(boost::format("mvtx_shell_inner_skin") ).c_str(), trackerenvelope, false, 0, OverlapCheck());
+  G4Tubs *mvtx_shell_inner_skin_tube = new G4Tubs(boost::str(boost::format("mvtx_shell_inner_skin")).c_str(),
+                                                  mvtx_shell_inner_skin_inner_radius, mvtx_shell_inner_skin_inner_radius + skin_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
+  G4LogicalVolume *mvtx_shell_inner_skin_volume = new G4LogicalVolume(mvtx_shell_inner_skin_tube, G4Material::GetMaterial("CFRP_INTT"),
+                                                                      boost::str(boost::format("mvtx_shell_inner_skin_volume")).c_str(), 0, 0, 0);
+  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_inner_skin_volume,
+                    boost::str(boost::format("mvtx_shell_inner_skin")).c_str(), trackerenvelope, false, 0, OverlapCheck());
   mvtx_shell_inner_skin_volume->SetVisAttributes(rail_vis);
 
-  G4Tubs *mvtx_shell_foam_core_tube = new G4Tubs(boost::str(boost::format("mvtx_shell_foam_core")).c_str(), 
-			    mvtx_shell_foam_core_inner_radius, mvtx_shell_foam_core_inner_radius + foam_core_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI );  
-  G4LogicalVolume *mvtx_shell_foam_core_volume = new G4LogicalVolume(mvtx_shell_foam_core_tube, G4Material::GetMaterial("ROHACELL_FOAM_110"), 
-								      boost::str(boost::format("mvtx_shell_foam_core_volume")).c_str(), 0, 0, 0);
-  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_foam_core_volume, 
-		    boost::str(boost::format("mvtx_shell_foam_core") ).c_str(), trackerenvelope, false, 0, OverlapCheck());
+  G4Tubs *mvtx_shell_foam_core_tube = new G4Tubs(boost::str(boost::format("mvtx_shell_foam_core")).c_str(),
+                                                 mvtx_shell_foam_core_inner_radius, mvtx_shell_foam_core_inner_radius + foam_core_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
+  G4LogicalVolume *mvtx_shell_foam_core_volume = new G4LogicalVolume(mvtx_shell_foam_core_tube, G4Material::GetMaterial("ROHACELL_FOAM_110"),
+                                                                     boost::str(boost::format("mvtx_shell_foam_core_volume")).c_str(), 0, 0, 0);
+  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_foam_core_volume,
+                    boost::str(boost::format("mvtx_shell_foam_core")).c_str(), trackerenvelope, false, 0, OverlapCheck());
   mvtx_shell_foam_core_volume->SetVisAttributes(rail_vis);
 
-  G4Tubs *mvtx_shell_outer_skin_tube = new G4Tubs(boost::str(boost::format("mvtx_shell_outer_skin")).c_str(), 
-			    mvtx_shell_outer_skin_inner_radius, mvtx_shell_outer_skin_inner_radius + skin_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI );  
-  G4LogicalVolume *mvtx_shell_outer_skin_volume = new G4LogicalVolume(mvtx_shell_outer_skin_tube, G4Material::GetMaterial("CFRP_INTT"), 
-								      boost::str(boost::format("mvtx_shell_outer_skin_volume")).c_str(), 0, 0, 0);
-  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_outer_skin_volume, 
-		    boost::str(boost::format("mvtx_shell_outer_skin") ).c_str(), trackerenvelope, false, 0, OverlapCheck());
+  G4Tubs *mvtx_shell_outer_skin_tube = new G4Tubs(boost::str(boost::format("mvtx_shell_outer_skin")).c_str(),
+                                                  mvtx_shell_outer_skin_inner_radius, mvtx_shell_outer_skin_inner_radius + skin_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
+  G4LogicalVolume *mvtx_shell_outer_skin_volume = new G4LogicalVolume(mvtx_shell_outer_skin_tube, G4Material::GetMaterial("CFRP_INTT"),
+                                                                      boost::str(boost::format("mvtx_shell_outer_skin_volume")).c_str(), 0, 0, 0);
+  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_outer_skin_volume,
+                    boost::str(boost::format("mvtx_shell_outer_skin")).c_str(), trackerenvelope, false, 0, OverlapCheck());
   mvtx_shell_outer_skin_volume->SetVisAttributes(rail_vis);
   return 0;
 }
@@ -957,12 +945,12 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
       runNode->addNode(newNode);
     }
 
-  for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
+    for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
     {
       const int sphxlayer = layeriter->first;
       const int inttlayer = layeriter->second;
-int ilayer = inttlayer;
-       const PHParameters *params_layer = paramscontainer->GetParameters(inttlayer);
+      int ilayer = inttlayer;
+      const PHParameters *params_layer = paramscontainer->GetParameters(inttlayer);
       const int laddertype = params_layer->get_int_param("laddertype");
       // parameters are in cm, so conversion needed here to get from mm to cm
       const PHParameters *params = paramscontainer->GetParameters(laddertype);
@@ -974,16 +962,16 @@ int ilayer = inttlayer;
           params->get_double_param("strip_z_1") / cm,
           params->get_int_param("nstrips_z_sensor_0"),
           params->get_int_param("nstrips_z_sensor_1"),
-          params->get_int_param("nstrips_phi_sensor") ,
+          params->get_int_param("nstrips_phi_sensor"),
           params_layer->get_int_param("nladder"),
           posz[ilayer][0] / cm,
           posz[ilayer][1] / cm,
           sensor_radius_inner[ilayer] / cm,
           sensor_radius_outer[ilayer] / cm,
           //strip_x_offset[ilayer] / cm,
-	  0.0,
+          0.0,
           params_layer->get_double_param("offsetphi"),
-          params_layer->get_double_param("offsetrot") );
+          params_layer->get_double_param("offsetrot"));
       geo->AddLayerGeom(sphxlayer, mygeom);
       if (Verbosity() > 0)
         geo->identify();

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -99,7 +99,8 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
 
   {
-    const int sphxlayer = layeriter->first;
+//    const int sphxlayer = layeriter->first;
+    const int sphxlayer = layeriter->second;
       const int inttlayer = layeriter->second;
       int ilayer = inttlayer;
        // get the parameters for this layer

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -41,7 +41,6 @@ PHG4SiliconTrackerDetector::PHG4SiliconTrackerDetector(PHCompositeNode *Node, PH
   for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
   {
     int layer = layeriter->second;
-    cout << "getting params for layer " << layer << endl;
     const PHParameters *par = paramscontainer->GetParameters(layer);
     IsActive[layer] = par->get_int_param("active");
     IsAbsorberActive[layer] = par->get_int_param("absorberactive");
@@ -73,9 +72,9 @@ int PHG4SiliconTrackerDetector::IsInSiliconTracker(G4VPhysicalVolume *volume) co
 
 void PHG4SiliconTrackerDetector::Construct(G4LogicalVolume *logicWorld)
 {
-  // if (Verbosity() > 0)
+  if (Verbosity() > 0)
   {
-    std::cout << "PHG4SiliconTrackerDetector::Construct called for layers " << std::endl;
+    cout << "PHG4SiliconTrackerDetector::Construct called for layers " << endl;
   for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
   {
     cout << "layer " << layeriter->second << endl;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -25,7 +25,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
  public:
   typedef std::vector<std::pair<int, int>> vpair;
   //! constructor
-  PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::vector<std::pair<int,int>>::const_iterator, std::vector<std::pair<int,int>>::const_iterator> &layer_b_e);
+  PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::vector<std::pair<int, int>>::const_iterator, std::vector<std::pair<int, int>>::const_iterator> &layer_b_e);
 
   //! destructor
   virtual ~PHG4SiliconTrackerDetector() {}
@@ -60,7 +60,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = nullptr);
 
   PHParametersContainer *paramscontainer;
-//  vpair layerconfig_;
+  //  vpair layerconfig_;
   /* unsigned int nlayer_; */
   /* int layermin_; */
   /* int layermax_; */
@@ -81,7 +81,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   std::set<G4LogicalVolume *> activelogvols;
   std::map<int, int> IsActive;
   std::map<int, int> IsAbsorberActive;
-  std::pair<std::vector<std::pair<int,int>>::const_iterator, std::vector<std::pair<int,int>>::const_iterator> layer_begin_end;
+  std::pair<std::vector<std::pair<int, int>>::const_iterator, std::vector<std::pair<int, int>>::const_iterator> layer_begin_end;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -1,6 +1,8 @@
 #ifndef PHG4SiliconTrackerDetector_h
 #define PHG4SiliconTrackerDetector_h
 
+#include "PHG4SiliconTrackerDefs.h"
+
 #include <g4main/PHG4Detector.h>
 
 #include <Geant4/G4RotationMatrix.hh>
@@ -22,9 +24,8 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
 {
  public:
   typedef std::vector<std::pair<int, int>> vpair;
-
   //! constructor
-  PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam = "SILICON_TRACKER", const vpair &layerconfig = vpair(0));
+  PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> &layer_b_e);
 
   //! destructor
   virtual ~PHG4SiliconTrackerDetector() {}
@@ -59,10 +60,10 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = nullptr);
 
   PHParametersContainer *paramscontainer;
-  vpair layerconfig_;
-  unsigned int nlayer_;
-  int layermin_;
-  int layermax_;
+//  vpair layerconfig_;
+  /* unsigned int nlayer_; */
+  /* int layermin_; */
+  /* int layermax_; */
 
   G4double overlap_fraction;
 
@@ -80,6 +81,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   std::set<G4LogicalVolume *> activelogvols;
   std::map<int, int> IsActive;
   std::map<int, int> IsAbsorberActive;
+  std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> layer_begin_end;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -25,7 +25,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
  public:
   typedef std::vector<std::pair<int, int>> vpair;
   //! constructor
-  PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> &layer_b_e);
+  PHG4SiliconTrackerDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::vector<std::pair<int,int>>::const_iterator, std::vector<std::pair<int,int>>::const_iterator> &layer_b_e);
 
   //! destructor
   virtual ~PHG4SiliconTrackerDetector() {}
@@ -81,7 +81,7 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
   std::set<G4LogicalVolume *> activelogvols;
   std::map<int, int> IsActive;
   std::map<int, int> IsAbsorberActive;
-  std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> layer_begin_end;
+  std::pair<std::vector<std::pair<int,int>>::const_iterator, std::vector<std::pair<int,int>>::const_iterator> layer_begin_end;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -1,6 +1,6 @@
 #include "PHG4SiliconTrackerSteppingAction.h"
-#include "PHG4SiliconTrackerDetector.h"
 #include "PHG4SiliconTrackerDefs.h"
+#include "PHG4SiliconTrackerDetector.h"
 
 #include "PHG4StepStatusDecode.h"
 
@@ -47,7 +47,7 @@
 using namespace std;
 
 //____________________________________________________________________________..
-PHG4SiliconTrackerSteppingAction::PHG4SiliconTrackerSteppingAction(PHG4SiliconTrackerDetector* detector, const PHParametersContainer* parameters,  const pair<vector<pair<int,int>>::const_iterator, vector<pair<int,int>>::const_iterator> &layer_begin_end)
+PHG4SiliconTrackerSteppingAction::PHG4SiliconTrackerSteppingAction(PHG4SiliconTrackerDetector* detector, const PHParametersContainer* parameters, const pair<vector<pair<int, int>>::const_iterator, vector<pair<int, int>>::const_iterator>& layer_begin_end)
   : detector_(detector)
   , hits_(nullptr)
   , absorberhits_(nullptr)
@@ -62,22 +62,21 @@ PHG4SiliconTrackerSteppingAction::PHG4SiliconTrackerSteppingAction(PHG4SiliconTr
   for (auto layeriter = layer_begin_end.first; layeriter != layer_begin_end.second; ++layeriter)
   {
     int layer = layeriter->second;
-    const PHParameters *par = paramscontainer->GetParameters(layer);
+    const PHParameters* par = paramscontainer->GetParameters(layer);
     IsActive[layer] = par->get_int_param("active");
     IsBlackHole[layer] = par->get_int_param("blackhole");
-    m_LadderTypeMap.insert(make_pair(layer,par->get_int_param("laddertype")));
+    m_LadderTypeMap.insert(make_pair(layer, par->get_int_param("laddertype")));
     m_InttToTrackerLayerMap.insert(make_pair(layeriter->second, layeriter->first));
   }
 
   // Get the parameters for each laddertype
   for (auto iter = PHG4SiliconTrackerDefs::m_SensorSegmentationSet.begin(); iter != PHG4SiliconTrackerDefs::m_SensorSegmentationSet.end(); ++iter)
   {
-const PHParameters *par = paramscontainer->GetParameters(*iter);
-m_StripYMap.insert(make_pair(*iter, par->get_double_param("strip_y") *cm));
-m_StripZMap.insert(make_pair(*iter,make_pair(par->get_double_param("strip_z_0") *cm, par->get_double_param("strip_z_1") *cm)));
-m_nStripsPhiCell.insert(make_pair(*iter,par->get_int_param("nstrips_phi_cell")));
-m_nStripsZSensor.insert(make_pair(*iter,make_pair(par->get_int_param("nstrips_z_sensor_0"),par->get_int_param("nstrips_z_sensor_1"))));
-
+    const PHParameters* par = paramscontainer->GetParameters(*iter);
+    m_StripYMap.insert(make_pair(*iter, par->get_double_param("strip_y") * cm));
+    m_StripZMap.insert(make_pair(*iter, make_pair(par->get_double_param("strip_z_0") * cm, par->get_double_param("strip_z_1") * cm)));
+    m_nStripsPhiCell.insert(make_pair(*iter, par->get_int_param("nstrips_phi_cell")));
+    m_nStripsZSensor.insert(make_pair(*iter, make_pair(par->get_int_param("nstrips_z_sensor_0"), par->get_int_param("nstrips_z_sensor_1"))));
   }
   AbsorberIndex["ladder"] = -1;
   AbsorberIndex["stave"] = -2;
@@ -145,7 +144,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     {
       cout << endl
            << "PHG4SilicoTrackerSteppingAction::UserSteppingAction for volume name (pre) " << touch->GetVolume()->GetName()
-	   << " volume name (2) " << touch->GetVolume(2)->GetName()
+           << " volume name (2) " << touch->GetVolume(2)->GetName()
            << " volume->GetTranslation " << touch->GetVolume()->GetTranslation()
            << " volume->GetCopyNo() " << volume->GetCopyNo()
            << endl;
@@ -154,20 +153,20 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     // Get the layer and ladder information
     // thi is the same for all strips in the sensor
     boost::char_separator<char> sep("_");
-    boost::tokenizer<boost::char_separator<char> > tok(touch->GetVolume(2)->GetName(), sep);
-    boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
+    boost::tokenizer<boost::char_separator<char>> tok(touch->GetVolume(2)->GetName(), sep);
+    boost::tokenizer<boost::char_separator<char>>::const_iterator tokeniter;
     tokeniter = tok.begin();
     if (*tokeniter == "ladder")
     {
       // advance the tokeniter and then cast it if first token is "ladder"
-//      sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
-//      cout << "sphxlayer orig: " << sphxlayer;
+      //      sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
+      //      cout << "sphxlayer orig: " << sphxlayer;
       inttlayer = boost::lexical_cast<int>(*(++tokeniter));
       sphxlayer = m_InttToTrackerLayerMap.find(inttlayer)->second;
-//      cout << ", from intt: " << sphxlayer << endl;
-      ladderz = boost::lexical_cast<int>(*(++tokeniter));  // inner sensor itype = 0, outer sensor itype = 1
+      //      cout << ", from intt: " << sphxlayer << endl;
+      ladderz = boost::lexical_cast<int>(*(++tokeniter));    // inner sensor itype = 0, outer sensor itype = 1
       ladderphi = boost::lexical_cast<int>(*(++tokeniter));  // copy number in phi
-      zposneg =  boost::lexical_cast<int>(*(++tokeniter));  // 1 for negative z, 2 for positive z
+      zposneg = boost::lexical_cast<int>(*(++tokeniter));    // 1 for negative z, 2 for positive z
     }
     else
     {
@@ -188,10 +187,10 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     }
 
     // Find the strip y and z index values from the copy number (integer division, quotient is strip_y, remainder is strip_z)
-//    div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor[laddertype[inttlayer]][ladderz]);
+    //    div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor[laddertype[inttlayer]][ladderz]);
     int laddertype = (m_LadderTypeMap.find(inttlayer))->second;
     int nstrips_z_sensor;
-    switch(ladderz)
+    switch (ladderz)
     {
     case 0:
       nstrips_z_sensor = m_nStripsZSensor.find(laddertype)->second.first;
@@ -202,10 +201,10 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     default:
       cout << "Bad ladderz: " << ladderz << endl;
       gSystem->Exit(1);
-// this is just to make the optimizer happy which otherwise complains about possibly
-// uninitialized variables. It doesn't know gSystem->Exit(1) quits, 
-// this exit here terminates the program for it
-	    exit(1);
+      // this is just to make the optimizer happy which otherwise complains about possibly
+      // uninitialized variables. It doesn't know gSystem->Exit(1) quits,
+      // this exit here terminates the program for it
+      exit(1);
     }
     div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor);
     strip_y_index = copydiv.quot;
@@ -217,12 +216,12 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     G4ThreeVector strip_pos = volume->GetTranslation();
     G4ThreeVector prepos = prePoint->GetPosition();
     G4ThreeVector postpos = postPoint->GetPosition();
-    if(Verbosity() > 0)
+    if (Verbosity() > 0)
     {
-      cout << " sphxlayer " << sphxlayer << " inttlayer " << inttlayer << " ladderz " << ladderz << " ladderphi " << ladderphi 
-	   << " zposneg " << zposneg
-	   << " copy no. " <<  volume->GetCopyNo() << " nstrips_z_sensor " <<  nstrips_z_sensor 
-	   << " strip_y_index " << strip_y_index << " strip_z_index " << strip_z_index << endl;
+      cout << " sphxlayer " << sphxlayer << " inttlayer " << inttlayer << " ladderz " << ladderz << " ladderphi " << ladderphi
+           << " zposneg " << zposneg
+           << " copy no. " << volume->GetCopyNo() << " nstrips_z_sensor " << nstrips_z_sensor
+           << " strip_y_index " << strip_y_index << " strip_z_index " << strip_z_index << endl;
       sameevent = 1;
     }
     // There are two failure modes observed for this stupid parameterised volume:
@@ -230,13 +229,12 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     //  2) If the  pre and post step are in the same volume but they both have status fGeomBoundary, the volume is assigned the copy number of the next volume, which is usually off by one in strip_y_index
     // in both cases we need to find the correct strip_y_index and strip_z_index values the hard way - that is what is done here
     int fixit = 0;
-      G4VPhysicalVolume* volume_post = postPoint->GetTouchableHandle()->GetVolume();
-//      G4VPhysicalVolume* volume_pre = prePoint->GetTouchableHandle()->GetVolume();
-      G4LogicalVolume* logvolpre = volume->GetLogicalVolume();
-      G4LogicalVolume* logvolpost = volume_post->GetLogicalVolume();
-    if ( prePoint->GetStepStatus() == fGeomBoundary && postPoint->GetStepStatus() == fGeomBoundary)
+    G4VPhysicalVolume* volume_post = postPoint->GetTouchableHandle()->GetVolume();
+    //      G4VPhysicalVolume* volume_pre = prePoint->GetTouchableHandle()->GetVolume();
+    G4LogicalVolume* logvolpre = volume->GetLogicalVolume();
+    G4LogicalVolume* logvolpost = volume_post->GetLogicalVolume();
+    if (prePoint->GetStepStatus() == fGeomBoundary && postPoint->GetStepStatus() == fGeomBoundary)
     {
-
       // this is just failsafe - we still have those impossible hits where pre and poststep
       // are in the same volume with status fGeomBoundary
       // but the extraction of the strip index above works for those
@@ -244,14 +242,14 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       // the physics step size is taken rather the geometric step size
       if (logvolpre == logvolpost)
       {
-        if (volume->GetCopyNo() == volume_post->GetCopyNo() ||  prePoint->GetStepStatus() == fUndefined)
+        if (volume->GetCopyNo() == volume_post->GetCopyNo() || prePoint->GetStepStatus() == fUndefined)
         {
-	  fixit = 1;
-	}
+          fixit = 1;
+        }
       }
     }
 
-    if ( prePoint->GetStepStatus() == fUndefined)
+    if (prePoint->GetStepStatus() == fUndefined)
     {
       fixit = 2;
 
@@ -275,154 +273,155 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       // 	  cout << "no post step proc either" << endl;
       // 	}
       // }
-	// G4ThreeVector preworldPos = prePoint->GetPosition();
-	// G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
-	// G4ThreeVector postworldPos = postPoint->GetPosition();
-	// G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
-	// cout << "preworldpos: " << preworldPos << endl;
-	// cout << "pre strip pos: " << strip_pos << endl;
-	// cout << "postworldPos: " << postPoint->GetPosition() << endl;
-	// cout << "poststrip_pos: " << poststrip_pos << endl;
+      // G4ThreeVector preworldPos = prePoint->GetPosition();
+      // G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
+      // G4ThreeVector postworldPos = postPoint->GetPosition();
+      // G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
+      // cout << "preworldpos: " << preworldPos << endl;
+      // cout << "pre strip pos: " << strip_pos << endl;
+      // cout << "postworldPos: " << postPoint->GetPosition() << endl;
+      // cout << "poststrip_pos: " << poststrip_pos << endl;
     }
 
-    if( fixit )
-      {
-//	cout << "fixit: " << fixit << endl;
-	int strip_y_index_old = strip_y_index;
-	int strip_z_index_old = strip_z_index;
-
-	// we need a hack to compare the values above with the correct strip index values
-	// the transform of the world coordinates into the sensor frame will work correctly,
-	// so we determine the strip indices from the hit position
-	G4ThreeVector preworldPos = prePoint->GetPosition();
-	G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
-	G4ThreeVector postworldPos = postPoint->GetPosition();
-	G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
-	
-	strip_z_index = 0;
-	double strip_z;
-        int nstrips_z_sensor;
-	switch(ladderz)
-	{
-	case 0:
-	  strip_z =   m_StripZMap.find(laddertype)->second.first;
-          nstrips_z_sensor = m_nStripsZSensor.find(laddertype)->second.first;
-	  break;
-	case 1:
-	  strip_z =   m_StripZMap.find(laddertype)->second.second;
-          nstrips_z_sensor = m_nStripsZSensor.find(laddertype)->second.second;
-	  break;
-	default:
-      cout << "Bad ladderz: " << ladderz << endl;
-      gSystem->Exit(1);
-// this is just to make the optimizer happy which otherwise complains about possibly
-// uninitialized variables. It doesn't know gSystem->Exit(1) quits, 
-// this exit here terminates the program for it
-	    exit(1);
-	}
-	// cout << "nstrips_z_sensor: " << nstrips_z_sensor 
-	//      << ", strip_z: " << strip_z
-	//      << endl;
-	for (int i = 0; i < nstrips_z_sensor; ++i)
-          {
-            const double zmin = strip_z * i - (strip_z / 2.) * nstrips_z_sensor;
-            const double zmax = strip_z * (i + 1) - (strip_z / 2.) *  nstrips_z_sensor;
-            if (strip_pos.z() / mm > zmin && strip_pos.z() / mm <= zmax)
-	      {
-		strip_z_index = i;
-		if (Verbosity() > 1) std::cout << "                            revised strip z position = " << strip_z_index << std::endl;
-		break;
-	      }
-          }
-	
-	strip_y_index = 0;
-	int nstrips_phi_cell = m_nStripsPhiCell.find(laddertype)->second;
-	double strip_y = m_StripYMap.find(laddertype)->second;
-	// cout << "nstrips_phi_cell: " << nstrips_phi_cell
-	//      << ", strip_y: " << strip_y
-	//      << endl;
-	for (int i = 0; i < 2 * nstrips_phi_cell; ++i)
-          {
-            const double ymin = strip_y * i - strip_y * nstrips_phi_cell;;
-            const double ymax = strip_y * (i + 1) - strip_y * nstrips_phi_cell;
-            if (strip_pos.y() / mm > ymin && strip_pos.y() / mm <= ymax)
-	      {
-		strip_y_index = i;
-		if (Verbosity() > 1) std::cout << "                            revised strip y position = " << strip_y_index << std::endl;
-		break;
-	      }
-          }
-
-	if(fixit == 1)
-	  {
-	    if (strip_y_index_old != strip_y_index || strip_z_index_old != strip_z_index)
-	      {
-		G4VPhysicalVolume* volume_post = postPoint->GetTouchableHandle()->GetVolume();
-		G4LogicalVolume* logvolpre = volume->GetLogicalVolume();
-		G4LogicalVolume* logvolpost = volume_post->GetLogicalVolume();
-		G4ThreeVector preworldPos = prePoint->GetPosition();
-		G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
-		G4ThreeVector postworldPos = postPoint->GetPosition();
-		G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
-		
-		cout << "Overlap detected in volume " << volume->GetName() << " where post volume "
-		     << volume_post->GetName() << " has same copy no." << volume->GetCopyNo()
-		     << " pre and post step point of same volume for step status fGeomBoundary" << endl;
-		cout << "logvol name " << logvolpre->GetName() << ", post: " << logvolpost->GetName() << endl;
-		cout << "strip y bef: " << strip_y_index_old << ", strip z: " << strip_z_index_old << endl;
-		cout << " strip y aft: " << strip_y_index << ", strip z: " << strip_z_index << endl;
-		cout << "pre hitpos x: " << strip_pos.x() << ", y: " << strip_pos.y() << ", z: "
-		     << strip_pos.z() << endl;
-		cout << "posthitpos x: " << poststrip_pos.x() << ", y: " << poststrip_pos.y() << ", z: "
-		     << poststrip_pos.z() << endl;
-		cout << "eloss: " << aStep->GetTotalEnergyDeposit() / GeV << " GeV" << endl;
-		cout << "safety prestep: " << prePoint->GetSafety()
-		     << ", poststep: " << postPoint->GetSafety() << endl;
-	      }
-	  }
-	else 
-	  {
-	    if(Verbosity() > 1) cout << "Detected fUndefined for prePoint step status, re-calculated strip_z_index and strip_y_index independently above" << endl;
-	  }
-      } 
-  } // end of whichactive > 0 block
-  else  // silicon inactive area, FPHX, stabe etc. as absorbers
+    if (fixit)
     {
-     try
-       {
-	  boost::char_separator<char> sep("_");
-	  boost::tokenizer<boost::char_separator<char> > tok(touch->GetVolume(0)->GetName(), sep);
-	  boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
-	  tokeniter = tok.begin();
-	  map<string, int>::const_iterator iter = AbsorberIndex.find(*tokeniter);
-	  if (iter == AbsorberIndex.end())
-	    {
-	      cout << "Absorber " << *tokeniter << " not in list" << endl;
-	      missingabsorbers.insert(*tokeniter);
-	      ladderz = -AbsorberIndex.size();
-	      AbsorberIndex[*tokeniter] = ladderz;
-	    }
-	  else
-	    {
-	      ladderz = iter->second;
-	    }
-//	  cout << "volume: " << touch->GetVolume(0)->GetName();
-	  inttlayer = boost::lexical_cast<int>(*(++tokeniter));
-//	  cout << ", inttlayer: " << inttlayer;
-          sphxlayer = m_InttToTrackerLayerMap.find(inttlayer)->second;
-//	  cout << ", sphxlayer(intt): " << sphxlayer << endl;
-       }
-     catch (...)
-       {
-	 cout << " that did not work for " << touch->GetVolume(0)->GetName() << endl;
-	 missingabsorbers.insert(touch->GetVolume(0)->GetName());
-       }
-    } // end of si inactive area block
-  
+      //	cout << "fixit: " << fixit << endl;
+      int strip_y_index_old = strip_y_index;
+      int strip_z_index_old = strip_z_index;
+
+      // we need a hack to compare the values above with the correct strip index values
+      // the transform of the world coordinates into the sensor frame will work correctly,
+      // so we determine the strip indices from the hit position
+      G4ThreeVector preworldPos = prePoint->GetPosition();
+      G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
+      G4ThreeVector postworldPos = postPoint->GetPosition();
+      G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
+
+      strip_z_index = 0;
+      double strip_z;
+      int nstrips_z_sensor;
+      switch (ladderz)
+      {
+      case 0:
+        strip_z = m_StripZMap.find(laddertype)->second.first;
+        nstrips_z_sensor = m_nStripsZSensor.find(laddertype)->second.first;
+        break;
+      case 1:
+        strip_z = m_StripZMap.find(laddertype)->second.second;
+        nstrips_z_sensor = m_nStripsZSensor.find(laddertype)->second.second;
+        break;
+      default:
+        cout << "Bad ladderz: " << ladderz << endl;
+        gSystem->Exit(1);
+        // this is just to make the optimizer happy which otherwise complains about possibly
+        // uninitialized variables. It doesn't know gSystem->Exit(1) quits,
+        // this exit here terminates the program for it
+        exit(1);
+      }
+      // cout << "nstrips_z_sensor: " << nstrips_z_sensor
+      //      << ", strip_z: " << strip_z
+      //      << endl;
+      for (int i = 0; i < nstrips_z_sensor; ++i)
+      {
+        const double zmin = strip_z * i - (strip_z / 2.) * nstrips_z_sensor;
+        const double zmax = strip_z * (i + 1) - (strip_z / 2.) * nstrips_z_sensor;
+        if (strip_pos.z() / mm > zmin && strip_pos.z() / mm <= zmax)
+        {
+          strip_z_index = i;
+          if (Verbosity() > 1) std::cout << "                            revised strip z position = " << strip_z_index << std::endl;
+          break;
+        }
+      }
+
+      strip_y_index = 0;
+      int nstrips_phi_cell = m_nStripsPhiCell.find(laddertype)->second;
+      double strip_y = m_StripYMap.find(laddertype)->second;
+      // cout << "nstrips_phi_cell: " << nstrips_phi_cell
+      //      << ", strip_y: " << strip_y
+      //      << endl;
+      for (int i = 0; i < 2 * nstrips_phi_cell; ++i)
+      {
+        const double ymin = strip_y * i - strip_y * nstrips_phi_cell;
+        ;
+        const double ymax = strip_y * (i + 1) - strip_y * nstrips_phi_cell;
+        if (strip_pos.y() / mm > ymin && strip_pos.y() / mm <= ymax)
+        {
+          strip_y_index = i;
+          if (Verbosity() > 1) std::cout << "                            revised strip y position = " << strip_y_index << std::endl;
+          break;
+        }
+      }
+
+      if (fixit == 1)
+      {
+        if (strip_y_index_old != strip_y_index || strip_z_index_old != strip_z_index)
+        {
+          G4VPhysicalVolume* volume_post = postPoint->GetTouchableHandle()->GetVolume();
+          G4LogicalVolume* logvolpre = volume->GetLogicalVolume();
+          G4LogicalVolume* logvolpost = volume_post->GetLogicalVolume();
+          G4ThreeVector preworldPos = prePoint->GetPosition();
+          G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
+          G4ThreeVector postworldPos = postPoint->GetPosition();
+          G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
+
+          cout << "Overlap detected in volume " << volume->GetName() << " where post volume "
+               << volume_post->GetName() << " has same copy no." << volume->GetCopyNo()
+               << " pre and post step point of same volume for step status fGeomBoundary" << endl;
+          cout << "logvol name " << logvolpre->GetName() << ", post: " << logvolpost->GetName() << endl;
+          cout << "strip y bef: " << strip_y_index_old << ", strip z: " << strip_z_index_old << endl;
+          cout << " strip y aft: " << strip_y_index << ", strip z: " << strip_z_index << endl;
+          cout << "pre hitpos x: " << strip_pos.x() << ", y: " << strip_pos.y() << ", z: "
+               << strip_pos.z() << endl;
+          cout << "posthitpos x: " << poststrip_pos.x() << ", y: " << poststrip_pos.y() << ", z: "
+               << poststrip_pos.z() << endl;
+          cout << "eloss: " << aStep->GetTotalEnergyDeposit() / GeV << " GeV" << endl;
+          cout << "safety prestep: " << prePoint->GetSafety()
+               << ", poststep: " << postPoint->GetSafety() << endl;
+        }
+      }
+      else
+      {
+        if (Verbosity() > 1) cout << "Detected fUndefined for prePoint step status, re-calculated strip_z_index and strip_y_index independently above" << endl;
+      }
+    }
+  }     // end of whichactive > 0 block
+  else  // silicon inactive area, FPHX, stabe etc. as absorbers
+  {
+    try
+    {
+      boost::char_separator<char> sep("_");
+      boost::tokenizer<boost::char_separator<char>> tok(touch->GetVolume(0)->GetName(), sep);
+      boost::tokenizer<boost::char_separator<char>>::const_iterator tokeniter;
+      tokeniter = tok.begin();
+      map<string, int>::const_iterator iter = AbsorberIndex.find(*tokeniter);
+      if (iter == AbsorberIndex.end())
+      {
+        cout << "Absorber " << *tokeniter << " not in list" << endl;
+        missingabsorbers.insert(*tokeniter);
+        ladderz = -AbsorberIndex.size();
+        AbsorberIndex[*tokeniter] = ladderz;
+      }
+      else
+      {
+        ladderz = iter->second;
+      }
+      //	  cout << "volume: " << touch->GetVolume(0)->GetName();
+      inttlayer = boost::lexical_cast<int>(*(++tokeniter));
+      //	  cout << ", inttlayer: " << inttlayer;
+      sphxlayer = m_InttToTrackerLayerMap.find(inttlayer)->second;
+      //	  cout << ", sphxlayer(intt): " << sphxlayer << endl;
+    }
+    catch (...)
+    {
+      cout << " that did not work for " << touch->GetVolume(0)->GetName() << endl;
+      missingabsorbers.insert(touch->GetVolume(0)->GetName());
+    }
+  }  // end of si inactive area block
+
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
   G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
-  
+
   // if this block stops everything, just put all kinetic energy into edep
   if ((IsBlackHole.find(inttlayer))->second == 1)
   {
@@ -446,8 +445,8 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
   case fGeomBoundary:
   case fUndefined:
 
-    if(Verbosity() > 1) cout << " found prePoint step status of fGeomBoundary or fUndefined, start a new hit " << endl;
- 
+    if (Verbosity() > 1) cout << " found prePoint step status of fGeomBoundary or fUndefined, start a new hit " << endl;
+
     // if previous hit was saved, hit pointer was set to nullptr
     // and we have to make a new one
     if (!hit)
@@ -458,7 +457,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     hit->set_layer((unsigned int) sphxlayer);
 
     // set the index values needed to locate the sensor strip
-    if(zposneg == 2) ladderz += 2;  // ladderz = 0, 1 for negative z and = 2, 3 for positive z
+    if (zposneg == 2) ladderz += 2;  // ladderz = 0, 1 for negative z and = 2, 3 for positive z
     hit->set_ladder_z_index(ladderz);
     if (whichactive > 0)
     {
@@ -512,10 +511,10 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
         saveshower = pp->GetShower();
       }
     }
-    if (hit->get_strip_z_index() == 1 && 
+    if (hit->get_strip_z_index() == 1 &&
         hit->get_strip_y_index() == 178 &&
         hit->get_ladder_z_index() == 3 &&
-	hit->get_ladder_phi_index() == 1)
+        hit->get_ladder_phi_index() == 1)
     {
       hit->identify();
       cout << "initial strip_z_index: " << save_strip_z_index << endl;
@@ -573,20 +572,19 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       aTrack->GetTrackStatus() == fStopAndKill)
   {
     if (Verbosity() > 1)
-      {
-	cout << " postPoint step status changed to " << postPoint->GetStepStatus() << " save hit and delete it" << endl;
-	cout  << " fWorldBoundary " << fWorldBoundary
-	      << " fGeomBoundary = " << fGeomBoundary
-	     << " fAtRestDoItProc " << fAtRestDoItProc
-	     << " fAlongStepDoItProc " << fAlongStepDoItProc
-	      << " fPostStepDoItProc " << fPostStepDoItProc
-	      << " fUserDefinedLimit " << fUserDefinedLimit
-	      << " fExclusivelyForcedProc " << fExclusivelyForcedProc
-	      << " fUndefined " << fUndefined
-	     << " fStopAndKill " << fStopAndKill
-	     << endl;
-
-      }
+    {
+      cout << " postPoint step status changed to " << postPoint->GetStepStatus() << " save hit and delete it" << endl;
+      cout << " fWorldBoundary " << fWorldBoundary
+           << " fGeomBoundary = " << fGeomBoundary
+           << " fAtRestDoItProc " << fAtRestDoItProc
+           << " fAlongStepDoItProc " << fAlongStepDoItProc
+           << " fPostStepDoItProc " << fPostStepDoItProc
+           << " fUserDefinedLimit " << fUserDefinedLimit
+           << " fExclusivelyForcedProc " << fExclusivelyForcedProc
+           << " fUndefined " << fUndefined
+           << " fStopAndKill " << fStopAndKill
+           << endl;
+    }
     // save only hits with energy deposit (or -1 for geantino)
     if (hit->get_edep())
     {

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -166,10 +166,10 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     {
       // advance the tokeniter and then cast it if first token is "ladder"
       sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
-      cout << "sphxlayer orig: " << sphxlayer;
+//      cout << "sphxlayer orig: " << sphxlayer;
       inttlayer = boost::lexical_cast<int>(*(++tokeniter));
       sphxlayer = m_InttToTrackerLayerMap.find(inttlayer)->second;
-      cout << ", from intt: " << sphxlayer << endl;
+//      cout << ", from intt: " << sphxlayer << endl;
       ladderz = boost::lexical_cast<int>(*(++tokeniter));  // inner sensor itype = 0, outer sensor itype = 1
       ladderphi = boost::lexical_cast<int>(*(++tokeniter));  // copy number in phi
       zposneg =  boost::lexical_cast<int>(*(++tokeniter));  // 1 for negative z, 2 for positive z
@@ -403,8 +403,13 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
 	    {
 	      ladderz = iter->second;
 	    }
+	  cout << "volume: " << touch->GetVolume(0)->GetName();
 	  sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
 	  inttlayer = boost::lexical_cast<int>(*(++tokeniter));
+	  cout << ", inttlayer: " << inttlayer;
+	  cout << ", sphxlayer orig: " << sphxlayer;
+          sphxlayer = m_InttToTrackerLayerMap.find(sphxlayer)->second;
+	  cout << ", sphxlayer(intt): " << sphxlayer << endl;
        }
      catch (...)
        {

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -75,11 +75,6 @@ PHG4SiliconTrackerSteppingAction::PHG4SiliconTrackerSteppingAction(PHG4SiliconTr
 const PHParameters *par = paramscontainer->GetParameters(*iter);
 m_StripYMap.insert(make_pair(*iter, par->get_double_param("strip_y") *cm));
 m_StripZMap.insert(make_pair(*iter,make_pair(par->get_double_param("strip_z_0") *cm, par->get_double_param("strip_z_1") *cm)));
-cout << "laddertype: " << *iter
-     << ", strip_y: " << par->get_double_param("strip_y") *cm
-     << ", strip_z_0: " << par->get_double_param("strip_z_0") *cm
-     << ", strip_z_1: " << par->get_double_param("strip_z_1") *cm
-     << endl;
 m_nStripsPhiCell.insert(make_pair(*iter,par->get_int_param("nstrips_phi_cell")));
 m_nStripsZSensor.insert(make_pair(*iter,make_pair(par->get_int_param("nstrips_z_sensor_0"),par->get_int_param("nstrips_z_sensor_1"))));
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -22,6 +22,7 @@
 #include <Geant4/G4ThreeVector.hh>
 #include <Geant4/G4TouchableHandle.hh>
 #include <Geant4/G4TouchableHistory.hh>
+#include <Geant4/G4VProcess.hh>
 
 #include <boost/foreach.hpp>
 #include <boost/format.hpp>
@@ -207,7 +208,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     G4ThreeVector strip_pos = volume->GetTranslation();
     G4ThreeVector prepos = prePoint->GetPosition();
     G4ThreeVector postpos = postPoint->GetPosition();
-    if(Verbosity() > 0 || (strip_z_index == 1 && strip_y_index == 50 && ladderz == 1 && ladderphi == 1))
+    if(Verbosity() > 0)
     {
       cout << " sphxlayer " << sphxlayer << " inttlayer " << inttlayer << " ladderz " << ladderz << " ladderphi " << ladderphi 
 	   << " zposneg " << zposneg
@@ -220,11 +221,12 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     //  2) If the  pre and post step are in the same volume but they both have status fGeomBoundary, the volume is assigned the copy number of the next volume, which is usually off by one in strip_y_index
     // in both cases we need to find the correct strip_y_index and strip_z_index values the hard way - that is what is done here
     int fixit = 0;
-    if ( prePoint->GetStepStatus() == fGeomBoundary && postPoint->GetStepStatus() == fGeomBoundary)
-    {
       G4VPhysicalVolume* volume_post = postPoint->GetTouchableHandle()->GetVolume();
+      G4VPhysicalVolume* volume_pre = prePoint->GetTouchableHandle()->GetVolume();
       G4LogicalVolume* logvolpre = volume->GetLogicalVolume();
       G4LogicalVolume* logvolpost = volume_post->GetLogicalVolume();
+    if ( prePoint->GetStepStatus() == fGeomBoundary && postPoint->GetStepStatus() == fGeomBoundary)
+    {
 
       // this is just failsafe - we still have those impossible hits where pre and poststep
       // are in the same volume with status fGeomBoundary
@@ -241,11 +243,42 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     }
 
     if ( prePoint->GetStepStatus() == fUndefined)
+    {
       fixit = 2;
+
+      // cout << "copy pre vol: " << volume->GetCopyNo() << ", " << volume->GetName()
+      // 	   << ", post: " << volume_post->GetCopyNo() << ", " << volume_post->GetName()
+      // 	   << ", pre: " << volume_pre->GetCopyNo() << ", " << volume_pre->GetName()
+      // 	   << endl;
+      // if (prePoint->GetProcessDefinedStep())
+      // {
+      // cout << prePoint->GetProcessDefinedStep()->GetProcessName() << endl;
+      // }
+      // else
+      // {
+      // 	cout << "Process is null ptr, try post step" << endl;
+      // 	if (postPoint->GetProcessDefinedStep())
+      // 	{
+      // 	  cout << postPoint->GetProcessDefinedStep()->GetProcessName() << endl;
+      // 	}
+      // 	else
+      // 	{
+      // 	  cout << "no post step proc either" << endl;
+      // 	}
+      // }
+	// G4ThreeVector preworldPos = prePoint->GetPosition();
+	// G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
+	// G4ThreeVector postworldPos = postPoint->GetPosition();
+	// G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
+	// cout << "preworldpos: " << preworldPos << endl;
+	// cout << "pre strip pos: " << strip_pos << endl;
+	// cout << "postworldPos: " << postPoint->GetPosition() << endl;
+	// cout << "poststrip_pos: " << poststrip_pos << endl;
+    }
 
     if( fixit )
       {
-	cout << "fixit: " << fixit << endl;
+//	cout << "fixit: " << fixit << endl;
 	int strip_y_index_old = strip_y_index;
 	int strip_z_index_old = strip_z_index;
 
@@ -274,9 +307,9 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       cout << "Bad ladderz: " << ladderz << endl;
       gSystem->Exit(1);
 	}
-	cout << "nstrips_z_sensor: " << nstrips_z_sensor 
-	     << ", strip_z: " << strip_z
-	     << endl;
+	// cout << "nstrips_z_sensor: " << nstrips_z_sensor 
+	//      << ", strip_z: " << strip_z
+	//      << endl;
 	for (int i = 0; i < nstrips_z_sensor; ++i)
           {
             const double zmin = strip_z * i - (strip_z / 2.) * nstrips_z_sensor;
@@ -292,9 +325,9 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
 	strip_y_index = 0;
 	int nstrips_phi_cell = m_nStripsPhiCell.find(laddertype)->second;
 	double strip_y = m_StripYMap.find(laddertype)->second;
-	cout << "nstrips_phi_cell: " << nstrips_phi_cell
-	     << ", strip_y: " << strip_y
-	     << endl;
+	// cout << "nstrips_phi_cell: " << nstrips_phi_cell
+	//      << ", strip_y: " << strip_y
+	//      << endl;
 	for (int i = 0; i < 2 * nstrips_phi_cell; ++i)
           {
             const double ymin = strip_y * i - strip_y * nstrips_phi_cell;;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -165,7 +165,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     if (*tokeniter == "ladder")
     {
       // advance the tokeniter and then cast it if first token is "ladder"
-      sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
+//      sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
 //      cout << "sphxlayer orig: " << sphxlayer;
       inttlayer = boost::lexical_cast<int>(*(++tokeniter));
       sphxlayer = m_InttToTrackerLayerMap.find(inttlayer)->second;
@@ -207,6 +207,10 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     default:
       cout << "Bad ladderz: " << ladderz << endl;
       gSystem->Exit(1);
+// this is just to make the optimizer happy which otherwise complains about possibly
+// uninitialized variables. It doesn't know gSystem->Exit(1) quits, 
+// this exit here terminates the program for it
+	    exit(1);
     }
     div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor);
     strip_y_index = copydiv.quot;
@@ -232,7 +236,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
     // in both cases we need to find the correct strip_y_index and strip_z_index values the hard way - that is what is done here
     int fixit = 0;
       G4VPhysicalVolume* volume_post = postPoint->GetTouchableHandle()->GetVolume();
-      G4VPhysicalVolume* volume_pre = prePoint->GetTouchableHandle()->GetVolume();
+//      G4VPhysicalVolume* volume_pre = prePoint->GetTouchableHandle()->GetVolume();
       G4LogicalVolume* logvolpre = volume->GetLogicalVolume();
       G4LogicalVolume* logvolpost = volume_post->GetLogicalVolume();
     if ( prePoint->GetStepStatus() == fGeomBoundary && postPoint->GetStepStatus() == fGeomBoundary)
@@ -316,6 +320,10 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
 	default:
       cout << "Bad ladderz: " << ladderz << endl;
       gSystem->Exit(1);
+// this is just to make the optimizer happy which otherwise complains about possibly
+// uninitialized variables. It doesn't know gSystem->Exit(1) quits, 
+// this exit here terminates the program for it
+	    exit(1);
 	}
 	// cout << "nstrips_z_sensor: " << nstrips_z_sensor 
 	//      << ", strip_z: " << strip_z
@@ -403,13 +411,11 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
 	    {
 	      ladderz = iter->second;
 	    }
-	  cout << "volume: " << touch->GetVolume(0)->GetName();
-	  sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
+//	  cout << "volume: " << touch->GetVolume(0)->GetName();
 	  inttlayer = boost::lexical_cast<int>(*(++tokeniter));
-	  cout << ", inttlayer: " << inttlayer;
-	  cout << ", sphxlayer orig: " << sphxlayer;
-          sphxlayer = m_InttToTrackerLayerMap.find(sphxlayer)->second;
-	  cout << ", sphxlayer(intt): " << sphxlayer << endl;
+//	  cout << ", inttlayer: " << inttlayer;
+          sphxlayer = m_InttToTrackerLayerMap.find(inttlayer)->second;
+//	  cout << ", sphxlayer(intt): " << sphxlayer << endl;
        }
      catch (...)
        {

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <set>
+#include <vector>
 
 class PHG4SiliconTrackerDetector;
 class PHParametersContainer;
@@ -15,7 +16,7 @@ class PHG4Shower;
 class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
 {
  public:
-  PHG4SiliconTrackerSteppingAction(PHG4SiliconTrackerDetector *, const PHParametersContainer *parameters, const std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> &layer_begin_end);
+  PHG4SiliconTrackerSteppingAction(PHG4SiliconTrackerDetector *, const PHParametersContainer *parameters, const std::pair<std::vector<std::pair<int,int>>::const_iterator, std::vector<std::pair<int,int>>::const_iterator> &layer_begin_end);
 
   virtual ~PHG4SiliconTrackerSteppingAction();
 
@@ -35,17 +36,13 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
   PHG4Shower *saveshower;
   const PHParametersContainer *paramscontainer;
 
-//  int laddertype[4];
+  std::map<int, int> m_InttToTrackerLayerMap;
   std::map<int, int> m_LadderTypeMap;
   std::map<int, double> m_StripYMap;
   std::map<int, std::pair<double, double>> m_StripZMap;
   std::map<int, int> m_nStripsPhiCell;
   std::map<int, std::pair<int,int>> m_nStripsZSensor;
 
-  /* double strip_y[2]; */
-  /* double strip_z[2][2]; */
-  /* int nstrips_z_sensor[2][2]; */
-  /* int nstrips_phi_cell[2]; */
   std::map<int, int> IsActive;
   std::map<int, int> IsBlackHole;
   std::map<std::string, int> AbsorberIndex;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -16,7 +16,7 @@ class PHG4Shower;
 class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
 {
  public:
-  PHG4SiliconTrackerSteppingAction(PHG4SiliconTrackerDetector *, const PHParametersContainer *parameters, const std::pair<std::vector<std::pair<int,int>>::const_iterator, std::vector<std::pair<int,int>>::const_iterator> &layer_begin_end);
+  PHG4SiliconTrackerSteppingAction(PHG4SiliconTrackerDetector *, const PHParametersContainer *parameters, const std::pair<std::vector<std::pair<int, int>>::const_iterator, std::vector<std::pair<int, int>>::const_iterator> &layer_begin_end);
 
   virtual ~PHG4SiliconTrackerSteppingAction();
 
@@ -41,7 +41,7 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
   std::map<int, double> m_StripYMap;
   std::map<int, std::pair<double, double>> m_StripZMap;
   std::map<int, int> m_nStripsPhiCell;
-  std::map<int, std::pair<int,int>> m_nStripsZSensor;
+  std::map<int, std::pair<int, int>> m_nStripsZSensor;
 
   std::map<int, int> IsActive;
   std::map<int, int> IsBlackHole;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -4,6 +4,7 @@
 #include <g4main/PHG4SteppingAction.h>
 
 #include <map>
+#include <set>
 
 class PHG4SiliconTrackerDetector;
 class PHParametersContainer;
@@ -14,7 +15,7 @@ class PHG4Shower;
 class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
 {
  public:
-  PHG4SiliconTrackerSteppingAction(PHG4SiliconTrackerDetector *, const PHParametersContainer *parameters);
+  PHG4SiliconTrackerSteppingAction(PHG4SiliconTrackerDetector *, const PHParametersContainer *parameters, const std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> &layer_begin_end);
 
   virtual ~PHG4SiliconTrackerSteppingAction();
 
@@ -34,11 +35,17 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
   PHG4Shower *saveshower;
   const PHParametersContainer *paramscontainer;
 
-  int laddertype[4];
-  double strip_y[2];
-  double strip_z[2][2];
-  int nstrips_z_sensor[2][2];
-  int nstrips_phi_cell[2];
+//  int laddertype[4];
+  std::map<int, int> m_LadderTypeMap;
+  std::map<int, double> m_StripYMap;
+  std::map<int, std::pair<double, double>> m_StripZMap;
+  std::map<int, int> m_nStripsPhiCell;
+  std::map<int, std::pair<int,int>> m_nStripsZSensor;
+
+  /* double strip_y[2]; */
+  /* double strip_z[2][2]; */
+  /* int nstrips_z_sensor[2][2]; */
+  /* int nstrips_phi_cell[2]; */
   std::map<int, int> IsActive;
   std::map<int, int> IsBlackHole;
   std::map<std::string, int> AbsorberIndex;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -51,38 +51,6 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &dete
 
 
 //_______________________________________________________________________
-/*
-PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const double sensor_radius_inner_[], const double sensor_radius_outer_[], const std::string &detectorname, const vpair &layerconfig)
-   : PHG4DetectorGroupSubsystem(detectorname)
-  , detector_(0)
-  , steppingAction_(nullptr)
-  , layerconfig_(layerconfig)
-  , detector_type(detectorname)
-{
-  // This constructor is an ugly way to get around a problem with the parameter class - it can be removed once that is fixed
-  nlayers = 0;
-  for (vector<pair<int, int>>::const_iterator piter = layerconfig.begin(); piter != layerconfig.end(); ++piter)
-  {
-    if(verbosity > 1) cout << PHWHERE << " adding INTT layer " << (*piter).second << endl;
-    nlayers++;
-    AddDetId((*piter).second);
-  }
-
-  for(int i=0;i<nlayers;i++)
-    {
-      sensor_radius_inner[i] = sensor_radius_inner_[i];
-      sensor_radius_outer[i] = sensor_radius_outer_[i];
-    }
-
-  InitializeParameters();
-  // put the layer into the name so we get unique names
-  // for multiple layers
-  Name(detectorname);
-  SuperDetector(detectorname);
-}
-*/
-
-//_______________________________________________________________________
 int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
   if (verbosity > 0)
@@ -94,7 +62,8 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  detector_ = new PHG4SiliconTrackerDetector(topNode, GetParamsContainer(), Name(), GetDetIds());
+  pair<vector<pair<int,int>>::const_iterator, vector<pair<int,int>>::const_iterator> layer_begin_end = make_pair(layerconfig_.begin(),layerconfig_.end());
+  detector_ = new PHG4SiliconTrackerDetector(topNode, GetParamsContainer(), Name(), layer_begin_end);
   detector_->SuperDetector(SuperDetector());
   detector_->Detector(detector_type);
   detector_->OverlapCheck(CheckOverlap());

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -1,6 +1,7 @@
 #include "PHG4SiliconTrackerSubsystem.h"
 #include "PHG4SiliconTrackerDetector.h"
 #include "PHG4SiliconTrackerSteppingAction.h"
+#include "PHG4SiliconTrackerDefs.h"
 
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
@@ -27,7 +28,7 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &dete
   nlayers = 0;
   for (vector<pair<int, int>>::const_iterator piter = layerconfig.begin(); piter != layerconfig.end(); ++piter)
   {
-    if(verbosity > 1) cout << PHWHERE << " adding INTT layer " << (*piter).second << endl;
+    cout << PHWHERE << " adding INTT layer " << (*piter).second << endl;
     nlayers++;
     AddDetId((*piter).second);
   }
@@ -84,13 +85,15 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const double sensor_rad
 int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
   if (verbosity > 0)
+  {
     std::cout << "PHG4SiliconTrackerSubsystem::Init started" << std::endl;
+  }
 
   PHNodeIterator iter(topNode);
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  detector_ = new PHG4SiliconTrackerDetector(topNode, GetParamsContainer(), Name(), layerconfig_);
+  detector_ = new PHG4SiliconTrackerDetector(topNode, GetParamsContainer(), Name(), GetDetIds());
   detector_->SuperDetector(SuperDetector());
   detector_->Detector(detector_type);
   detector_->OverlapCheck(CheckOverlap());
@@ -100,6 +103,7 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   int blackhole = 0;
   for (set<int>::const_iterator parcontaineriter = GetDetIds().first; parcontaineriter != GetDetIds().second; ++parcontaineriter)
   {
+    const PHParameters *par = GetParamsContainer()->GetParameters(*parcontaineriter);
     if (active || GetParamsContainer()->GetParameters(*parcontaineriter)->get_int_param("active"))
     {
       active = 1;
@@ -141,13 +145,13 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     }
 
     // create stepping action
-    steppingAction_ = new PHG4SiliconTrackerSteppingAction(detector_, GetParamsContainer());
+    steppingAction_ = new PHG4SiliconTrackerSteppingAction(detector_, GetParamsContainer(), GetDetIds());
   }
   else
   {
     if (blackhole)
     {
-      steppingAction_ = new PHG4SiliconTrackerSteppingAction(detector_, GetParamsContainer());
+      steppingAction_ = new PHG4SiliconTrackerSteppingAction(detector_, GetParamsContainer(),GetDetIds());
     }
   }
 
@@ -178,78 +182,86 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
   //     In ladder type 0 the sensor is special and inner and outer sensors are the same. 
   //     In ladder type 1 there are two different sensor types, inner and outer 
 
-  // We define default parameters for laddertype 0 or 1, all dimensions in cm
-  int nstrips_phi_sensor[2] = {1, 256};  
-  int nstrips_z_sensor_0[2] = {128*5, 8};  // inner sensor  
-  int nstrips_z_sensor_1[2] = {128*5, 5};  // outer sensor
-  double strip_y[2] = {1.6, 0.0078};
-  double strip_z_0[2] = {0.01406, 1.6};
-  double strip_z_1[2] = {0.01406, 2.0};
-  double halfladder_z[2] = {48.0, 48.0};
-  double hdi_y[2] = {2.55, 3.8};
-  double stave_straight_outer_y[2] = {0.672, 0.522};
-  double stave_straight_inner_y[2] = {0.1, 0.344};  // the first value is a dummy, not used, to avoid issues with making a G4Logical;Volume with y = 0
-  double stave_straight_cooler_y[2] = {0.47, 0.47};
-  double sensor_offset_y[2] = {0.304, 0.0};
 
   // We do not want to hard code the ladder types for the layers
   // We define default ladder types for 4 layers, but these can be changed at the macro level
-  int laddertype[4] = {0, 1, 1, 1};
+  int laddertype[4] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI};
   int nladder[4] = {34, 30, 36, 42};
   // sensor radius_inner and sensor_radius_outer are set in the constructor for now, to avoid a problem with the parameter class
+  cout << "layers: " << nlayers << endl;
+  auto detid = GetDetIds(); // get pair of iterators to begin/end of set<int> of detids
+  for (auto detiter = detid.first; detiter != detid.second; ++detiter)
+  {
+      set_default_int_param(*detiter,"active",1);
 
-  for(int i=0;i<nlayers;i++)
-    {
       // To reconfigure the layers, all you have to do is overide the defaults for these four arrays from the tracking macro
-      set_default_int_param(i, "laddertype", laddertype[i]);
-      set_default_int_param(i, "nladder", nladder[i]);  // ladders per layer
-      set_default_double_param(i, "sensor_radius_inner", sensor_radius_inner[i]*cm);
-      set_default_double_param(i, "sensor_radius_outer", sensor_radius_outer[i]*cm);
-      //cout << " PHG4SiliconTrackerSubsystem setting default parameters to: " << endl;
-      //cout << "  layer " << i << " laddertype " << laddertype[i] << " nladder " << nladder[i] 
-      //   << " sensor_radius_inner " << sensor_radius_inner[i] << " sensor_radius_outer " << sensor_radius_outer[i] << endl;
-      // These should be kept at zero in the new design
-      set_default_double_param(i, "offsetphi", 0.);
-      set_default_double_param(i, "offsetrot", 0.);
+      set_default_int_param(*detiter, "laddertype", laddertype[*detiter]);
+      set_default_int_param(*detiter, "nladder", nladder[*detiter]);  // ladders per layer
+      set_default_double_param(*detiter, "sensor_radius_inner", sensor_radius_inner[*detiter]*cm);
+      set_default_double_param(*detiter, "sensor_radius_outer", sensor_radius_outer[*detiter]*cm);
+      // These offsets should be kept at zero in the new design
+    set_default_double_param(*detiter,"offsetphi",0.);
+    set_default_double_param(*detiter,"offsetrot",0.);
+      cout << " PHG4SiliconTrackerSubsystem setting default parameters to: " << endl;
+      cout << "  layer " << *detiter << " laddertype " << laddertype[*detiter] << " nladder " << nladder[*detiter] 
+	   << " sensor_radius_inner " << sensor_radius_inner[*detiter] << " sensor_radius_outer " << sensor_radius_outer[*detiter] << endl;
     }
+  { // just being lazy, using namespace in this scope for less clutter
+    using namespace PHG4SiliconTrackerDefs; 
+    set_default_int_param(SEGMENTATION_Z,"nstrips_phi_cell",1);
+    set_default_int_param(SEGMENTATION_Z,"nstrips_phi_sensor",1);
+    set_default_int_param(SEGMENTATION_Z,"nstrips_z_sensor_0",128*5);
+    set_default_int_param(SEGMENTATION_Z,"nstrips_z_sensor_1",128*5);
+    set_default_double_param(SEGMENTATION_Z,"fphx_x",0.032*cm);
+    set_default_double_param(SEGMENTATION_Z,"fphx_y",0.27*cm);
+    set_default_double_param(SEGMENTATION_Z,"fphx_z",0.91*cm);
+    set_default_double_param(SEGMENTATION_Z,"gap_sensor_fphx",0.1*cm);
+    set_default_double_param(SEGMENTATION_Z,"halfladder_z",48.0*cm);
+    set_default_double_param(SEGMENTATION_Z,"hdi_copper_x",0.0052*cm);
+    set_default_double_param(SEGMENTATION_Z,"hdi_edge_z",0.*cm);
+    set_default_double_param(SEGMENTATION_Z,"hdi_kapton_x",0.038*cm);
+    set_default_double_param(SEGMENTATION_Z,"hdi_y",2.55*cm);
+    set_default_double_param(SEGMENTATION_Z,"pgs_x",0.02*cm);
+    set_default_double_param(SEGMENTATION_Z,"sensor_edge_phi",0.13*cm);
+    set_default_double_param(SEGMENTATION_Z,"sensor_edge_z",0.1*cm);
+    set_default_double_param(SEGMENTATION_Z,"sensor_offset_y",0.304*cm);
+    set_default_double_param(SEGMENTATION_Z,"stave_straight_cooler_y",0.47*cm);
+    set_default_double_param(SEGMENTATION_Z,"stave_straight_inner_y",0.1*cm);
+    set_default_double_param(SEGMENTATION_Z,"stave_straight_outer_y",0.672*cm);
+    set_default_double_param(SEGMENTATION_Z,"strip_x",0.032*cm);
+    set_default_double_param(SEGMENTATION_Z,"strip_y",1.6*cm);
+    set_default_double_param(SEGMENTATION_Z,"strip_z_0",0.01406*cm);
+    set_default_double_param(SEGMENTATION_Z,"strip_z_1",0.01406*cm);
 
-  // Set the parameters for the two laddertypes. All values in cm!
-  for (int i = 0; i < 2; i++)
-  {
-    set_default_int_param(i, "nstrips_z_sensor_0", nstrips_z_sensor_0[i]);
-    set_default_int_param(i, "nstrips_z_sensor_1", nstrips_z_sensor_1[i]);
-    set_default_int_param(i, "nstrips_phi_sensor", nstrips_phi_sensor[i]);
-    set_default_int_param(i, "nstrips_phi_cell", nstrips_phi_sensor[i]);
-
-    set_default_double_param(i, "stave_straight_inner_y", stave_straight_inner_y[i]*cm);
-    set_default_double_param(i, "stave_straight_outer_y", stave_straight_outer_y[i]*cm);
-    set_default_double_param(i, "stave_straight_cooler_y", stave_straight_cooler_y[i]*cm);
-
-    set_default_double_param(i, "strip_y", strip_y[i]*cm);
-    set_default_double_param(i, "strip_z_0", strip_z_0[i]*cm);
-    set_default_double_param(i, "strip_z_1", strip_z_1[i]*cm);
-    set_default_double_param(i, "strip_x", 0.032*cm);  // 320 microns deep
-    set_default_double_param(i, "sensor_edge_phi", 0.13*cm);
-    set_default_double_param(i, "sensor_edge_z", 0.10*cm);
-    set_default_double_param(i, "sensor_offset_y", sensor_offset_y[i]*cm);
-    set_default_double_param(i, "hdi_kapton_x", 0.038*cm);
-    set_default_double_param(i, "hdi_copper_x", 0.0052*cm);  // effective width of all copper in ground layers and signal layers
-    set_default_double_param(i, "hdi_y", hdi_y[i]*cm);
-    set_default_double_param(i, "hdi_edge_z", 0.0*cm);
-    set_default_double_param(i, "fphx_x", 0.032*cm); 
-    set_default_double_param(i, "fphx_y", 0.27*cm);
-    set_default_double_param(i, "fphx_z", 0.91*cm);
-    set_default_double_param(i, "gap_sensor_fphx", 0.1*cm);
-    set_default_double_param(i, "pgs_x", 0.02*cm);  // 0.2 mm
-    set_default_double_param(i, "halfladder_z", halfladder_z[i]*cm);
+    set_default_int_param(SEGMENTATION_PHI,"nstrips_phi_cell",256);
+    set_default_int_param(SEGMENTATION_PHI,"nstrips_phi_sensor",256);
+    set_default_int_param(SEGMENTATION_PHI,"nstrips_z_sensor_0",8);
+    set_default_int_param(SEGMENTATION_PHI,"nstrips_z_sensor_1",5);
+    set_default_double_param(SEGMENTATION_PHI,"fphx_x",0.032*cm);
+    set_default_double_param(SEGMENTATION_PHI,"fphx_y",0.27*cm);
+    set_default_double_param(SEGMENTATION_PHI,"fphx_z",0.91*cm);
+    set_default_double_param(SEGMENTATION_PHI,"gap_sensor_fphx",0.1*cm);
+    set_default_double_param(SEGMENTATION_PHI,"halfladder_z",48.0*cm);
+    set_default_double_param(SEGMENTATION_PHI,"hdi_copper_x",0.0052*cm);
+    set_default_double_param(SEGMENTATION_PHI,"hdi_edge_z",0.*cm);
+    set_default_double_param(SEGMENTATION_PHI,"hdi_kapton_x",0.038*cm);
+    set_default_double_param(SEGMENTATION_PHI,"hdi_y",3.8*cm);
+    set_default_double_param(SEGMENTATION_PHI,"pgs_x",0.02*cm);
+    set_default_double_param(SEGMENTATION_PHI,"sensor_edge_phi",0.13*cm);
+    set_default_double_param(SEGMENTATION_PHI,"sensor_edge_z",0.1*cm);
+    set_default_double_param(SEGMENTATION_PHI,"sensor_offset_y",0.*cm);
+    set_default_double_param(SEGMENTATION_PHI,"stave_straight_cooler_y",0.47*cm);
+    set_default_double_param(SEGMENTATION_PHI,"stave_straight_inner_y",0.344*cm);
+    set_default_double_param(SEGMENTATION_PHI,"stave_straight_outer_y",0.522*cm);
+    set_default_double_param(SEGMENTATION_PHI,"strip_x",0.032*cm);
+    set_default_double_param(SEGMENTATION_PHI,"strip_y",0.0078*cm);
+    set_default_double_param(SEGMENTATION_PHI,"strip_z_0",1.6*cm);
+    set_default_double_param(SEGMENTATION_PHI,"strip_z_1",2.*cm);
   }
 
-  //std::pair<std::set<int>::const_iterator, std::set<int>::const_iterator> begin_end = GetDetIds();
-  //for (set<int>::const_iterator it = begin_end.first; it != begin_end.second; ++it)
-  for (int i=0; i < nlayers; ++i)
-  {
-    set_default_int_param(i, "active", 1);
-  }
 
   return;
 }
@@ -257,6 +269,8 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
 void PHG4SiliconTrackerSubsystem::Print(const string &what) const
 {
   PrintDefaultParams();
+  cout << endl << "------" << endl;
   PrintMacroParams();
+  cout << endl << "------" << endl << endl;
   GetParamsContainer()->Print();
 }

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -62,7 +62,6 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   int blackhole = 0;
   for (set<int>::const_iterator parcontaineriter = GetDetIds().first; parcontaineriter != GetDetIds().second; ++parcontaineriter)
   {
-    const PHParameters *par = GetParamsContainer()->GetParameters(*parcontaineriter);
     if (active || GetParamsContainer()->GetParameters(*parcontaineriter)->get_int_param("active"))
     {
       active = 1;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -25,22 +25,11 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &dete
   , layerconfig_(layerconfig)
   , detector_type(detectorname)
 {
-  nlayers = 0;
   for (vector<pair<int, int>>::const_iterator piter = layerconfig.begin(); piter != layerconfig.end(); ++piter)
   {
     cout << PHWHERE << " adding INTT layer " << (*piter).second << endl;
-    nlayers++;
     AddDetId((*piter).second);
   }
-
-  // set the default sensor radii to the current design
-  double sensor_radius_inner_[4] = {6.876, 8.987, 10.835, 12.676};
-  double sensor_radius_outer_[4] = {7.462, 9.545, 11.361, 13.179};
-  for(int i=0;i<nlayers;i++)
-    {
-      sensor_radius_inner[i] = sensor_radius_inner_[i];
-      sensor_radius_outer[i] = sensor_radius_outer_[i];
-    }
 
   InitializeParameters();
   // put the layer into the name so we get unique names
@@ -160,8 +149,10 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
 		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
 		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI};
   int nladder[4] = {34, 30, 36, 42};
+  double sensor_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};
+  double sensor_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};
+
   // sensor radius_inner and sensor_radius_outer are set in the constructor for now, to avoid a problem with the parameter class
-  cout << "layers: " << nlayers << endl;
   auto detid = GetDetIds(); // get pair of iterators to begin/end of set<int> of detids
   for (auto detiter = detid.first; detiter != detid.second; ++detiter)
   {

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -51,6 +51,7 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &dete
 
 
 //_______________________________________________________________________
+/*
 PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const double sensor_radius_inner_[], const double sensor_radius_outer_[], const std::string &detectorname, const vpair &layerconfig)
    : PHG4DetectorGroupSubsystem(detectorname)
   , detector_(0)
@@ -79,7 +80,7 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const double sensor_rad
   Name(detectorname);
   SuperDetector(detectorname);
 }
-
+*/
 
 //_______________________________________________________________________
 int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -1,7 +1,7 @@
 #include "PHG4SiliconTrackerSubsystem.h"
+#include "PHG4SiliconTrackerDefs.h"
 #include "PHG4SiliconTrackerDetector.h"
 #include "PHG4SiliconTrackerSteppingAction.h"
-#include "PHG4SiliconTrackerDefs.h"
 
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
@@ -38,7 +38,6 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &dete
   SuperDetector(detectorname);
 }
 
-
 //_______________________________________________________________________
 int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
@@ -51,7 +50,7 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  pair<vector<pair<int,int>>::const_iterator, vector<pair<int,int>>::const_iterator> layer_begin_end = make_pair(layerconfig_.begin(),layerconfig_.end());
+  pair<vector<pair<int, int>>::const_iterator, vector<pair<int, int>>::const_iterator> layer_begin_end = make_pair(layerconfig_.begin(), layerconfig_.end());
   detector_ = new PHG4SiliconTrackerDetector(topNode, GetParamsContainer(), Name(), layer_begin_end);
   detector_->SuperDetector(SuperDetector());
   detector_->Detector(detector_type);
@@ -137,91 +136,89 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
 {
   // We have only two types of ladders, one with vertical strips (0) and one with horizontal strips (1)
   // There are 4 sensors in each ladder
-  //     In ladder type 0 the sensor is special and inner and outer sensors are the same. 
-  //     In ladder type 1 there are two different sensor types, inner and outer 
-
+  //     In ladder type 0 the sensor is special and inner and outer sensors are the same.
+  //     In ladder type 1 there are two different sensor types, inner and outer
 
   // We do not want to hard code the ladder types for the layers
   // We define default ladder types for 4 layers, but these can be changed at the macro level
-  int laddertype[4] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
-		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
-		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
-		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI};
+  int laddertype[4] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z,
+                       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+                       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+                       PHG4SiliconTrackerDefs::SEGMENTATION_PHI};
   int nladder[4] = {34, 30, 36, 42};
   double sensor_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};
   double sensor_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};
 
   // sensor radius_inner and sensor_radius_outer are set in the constructor for now, to avoid a problem with the parameter class
-  auto detid = GetDetIds(); // get pair of iterators to begin/end of set<int> of detids
+  auto detid = GetDetIds();  // get pair of iterators to begin/end of set<int> of detids
   for (auto detiter = detid.first; detiter != detid.second; ++detiter)
   {
-      set_default_int_param(*detiter,"active",1);
+    set_default_int_param(*detiter, "active", 1);
 
-      // To reconfigure the layers, all you have to do is overide the defaults for these four arrays from the tracking macro
-      set_default_int_param(*detiter, "laddertype", laddertype[*detiter]);
-      set_default_int_param(*detiter, "nladder", nladder[*detiter]);  // ladders per layer
-      set_default_double_param(*detiter, "sensor_radius_inner", sensor_radius_inner[*detiter]*cm);
-      set_default_double_param(*detiter, "sensor_radius_outer", sensor_radius_outer[*detiter]*cm);
-      // These offsets should be kept at zero in the new design
-    set_default_double_param(*detiter,"offsetphi",0.);
-    set_default_double_param(*detiter,"offsetrot",0.);
-      cout << " PHG4SiliconTrackerSubsystem setting default parameters to: " << endl;
-      cout << "  layer " << *detiter << " laddertype " << laddertype[*detiter] << " nladder " << nladder[*detiter] 
-	   << " sensor_radius_inner " << sensor_radius_inner[*detiter] << " sensor_radius_outer " << sensor_radius_outer[*detiter] << endl;
-    }
-  { // just being lazy, using namespace in this scope for less clutter
-    using namespace PHG4SiliconTrackerDefs; 
-    set_default_int_param(SEGMENTATION_Z,"nstrips_phi_cell",1);
-    set_default_int_param(SEGMENTATION_Z,"nstrips_phi_sensor",1);
-    set_default_int_param(SEGMENTATION_Z,"nstrips_z_sensor_0",128*5);
-    set_default_int_param(SEGMENTATION_Z,"nstrips_z_sensor_1",128*5);
-    set_default_double_param(SEGMENTATION_Z,"fphx_x",0.032*cm);
-    set_default_double_param(SEGMENTATION_Z,"fphx_y",0.27*cm);
-    set_default_double_param(SEGMENTATION_Z,"fphx_z",0.91*cm);
-    set_default_double_param(SEGMENTATION_Z,"gap_sensor_fphx",0.1*cm);
-    set_default_double_param(SEGMENTATION_Z,"halfladder_z",48.0*cm);
-    set_default_double_param(SEGMENTATION_Z,"hdi_copper_x",0.0052*cm);
-    set_default_double_param(SEGMENTATION_Z,"hdi_edge_z",0.*cm);
-    set_default_double_param(SEGMENTATION_Z,"hdi_kapton_x",0.038*cm);
-    set_default_double_param(SEGMENTATION_Z,"hdi_y",2.55*cm);
-    set_default_double_param(SEGMENTATION_Z,"pgs_x",0.02*cm);
-    set_default_double_param(SEGMENTATION_Z,"sensor_edge_phi",0.13*cm);
-    set_default_double_param(SEGMENTATION_Z,"sensor_edge_z",0.1*cm);
-    set_default_double_param(SEGMENTATION_Z,"sensor_offset_y",0.304*cm);
-    set_default_double_param(SEGMENTATION_Z,"stave_straight_cooler_y",0.47*cm);
-    set_default_double_param(SEGMENTATION_Z,"stave_straight_inner_y",0.1*cm);
-    set_default_double_param(SEGMENTATION_Z,"stave_straight_outer_y",0.672*cm);
-    set_default_double_param(SEGMENTATION_Z,"strip_x",0.032*cm);
-    set_default_double_param(SEGMENTATION_Z,"strip_y",1.6*cm);
-    set_default_double_param(SEGMENTATION_Z,"strip_z_0",0.01406*cm);
-    set_default_double_param(SEGMENTATION_Z,"strip_z_1",0.01406*cm);
-
-    set_default_int_param(SEGMENTATION_PHI,"nstrips_phi_cell",256);
-    set_default_int_param(SEGMENTATION_PHI,"nstrips_phi_sensor",256);
-    set_default_int_param(SEGMENTATION_PHI,"nstrips_z_sensor_0",8);
-    set_default_int_param(SEGMENTATION_PHI,"nstrips_z_sensor_1",5);
-    set_default_double_param(SEGMENTATION_PHI,"fphx_x",0.032*cm);
-    set_default_double_param(SEGMENTATION_PHI,"fphx_y",0.27*cm);
-    set_default_double_param(SEGMENTATION_PHI,"fphx_z",0.91*cm);
-    set_default_double_param(SEGMENTATION_PHI,"gap_sensor_fphx",0.1*cm);
-    set_default_double_param(SEGMENTATION_PHI,"halfladder_z",48.0*cm);
-    set_default_double_param(SEGMENTATION_PHI,"hdi_copper_x",0.0052*cm);
-    set_default_double_param(SEGMENTATION_PHI,"hdi_edge_z",0.*cm);
-    set_default_double_param(SEGMENTATION_PHI,"hdi_kapton_x",0.038*cm);
-    set_default_double_param(SEGMENTATION_PHI,"hdi_y",3.8*cm);
-    set_default_double_param(SEGMENTATION_PHI,"pgs_x",0.02*cm);
-    set_default_double_param(SEGMENTATION_PHI,"sensor_edge_phi",0.13*cm);
-    set_default_double_param(SEGMENTATION_PHI,"sensor_edge_z",0.1*cm);
-    set_default_double_param(SEGMENTATION_PHI,"sensor_offset_y",0.*cm);
-    set_default_double_param(SEGMENTATION_PHI,"stave_straight_cooler_y",0.47*cm);
-    set_default_double_param(SEGMENTATION_PHI,"stave_straight_inner_y",0.344*cm);
-    set_default_double_param(SEGMENTATION_PHI,"stave_straight_outer_y",0.522*cm);
-    set_default_double_param(SEGMENTATION_PHI,"strip_x",0.032*cm);
-    set_default_double_param(SEGMENTATION_PHI,"strip_y",0.0078*cm);
-    set_default_double_param(SEGMENTATION_PHI,"strip_z_0",1.6*cm);
-    set_default_double_param(SEGMENTATION_PHI,"strip_z_1",2.*cm);
+    // To reconfigure the layers, all you have to do is overide the defaults for these four arrays from the tracking macro
+    set_default_int_param(*detiter, "laddertype", laddertype[*detiter]);
+    set_default_int_param(*detiter, "nladder", nladder[*detiter]);  // ladders per layer
+    set_default_double_param(*detiter, "sensor_radius_inner", sensor_radius_inner[*detiter] * cm);
+    set_default_double_param(*detiter, "sensor_radius_outer", sensor_radius_outer[*detiter] * cm);
+    // These offsets should be kept at zero in the new design
+    set_default_double_param(*detiter, "offsetphi", 0.);
+    set_default_double_param(*detiter, "offsetrot", 0.);
+    cout << " PHG4SiliconTrackerSubsystem setting default parameters to: " << endl;
+    cout << "  layer " << *detiter << " laddertype " << laddertype[*detiter] << " nladder " << nladder[*detiter]
+         << " sensor_radius_inner " << sensor_radius_inner[*detiter] << " sensor_radius_outer " << sensor_radius_outer[*detiter] << endl;
   }
+  {  // just being lazy, using namespace in this scope for less clutter
+    using namespace PHG4SiliconTrackerDefs;
+    set_default_int_param(SEGMENTATION_Z, "nstrips_phi_cell", 1);
+    set_default_int_param(SEGMENTATION_Z, "nstrips_phi_sensor", 1);
+    set_default_int_param(SEGMENTATION_Z, "nstrips_z_sensor_0", 128 * 5);
+    set_default_int_param(SEGMENTATION_Z, "nstrips_z_sensor_1", 128 * 5);
+    set_default_double_param(SEGMENTATION_Z, "fphx_x", 0.032 * cm);
+    set_default_double_param(SEGMENTATION_Z, "fphx_y", 0.27 * cm);
+    set_default_double_param(SEGMENTATION_Z, "fphx_z", 0.91 * cm);
+    set_default_double_param(SEGMENTATION_Z, "gap_sensor_fphx", 0.1 * cm);
+    set_default_double_param(SEGMENTATION_Z, "halfladder_z", 48.0 * cm);
+    set_default_double_param(SEGMENTATION_Z, "hdi_copper_x", 0.0052 * cm);
+    set_default_double_param(SEGMENTATION_Z, "hdi_edge_z", 0. * cm);
+    set_default_double_param(SEGMENTATION_Z, "hdi_kapton_x", 0.038 * cm);
+    set_default_double_param(SEGMENTATION_Z, "hdi_y", 2.55 * cm);
+    set_default_double_param(SEGMENTATION_Z, "pgs_x", 0.02 * cm);
+    set_default_double_param(SEGMENTATION_Z, "sensor_edge_phi", 0.13 * cm);
+    set_default_double_param(SEGMENTATION_Z, "sensor_edge_z", 0.1 * cm);
+    set_default_double_param(SEGMENTATION_Z, "sensor_offset_y", 0.304 * cm);
+    set_default_double_param(SEGMENTATION_Z, "stave_straight_cooler_y", 0.47 * cm);
+    set_default_double_param(SEGMENTATION_Z, "stave_straight_inner_y", 0.1 * cm);
+    set_default_double_param(SEGMENTATION_Z, "stave_straight_outer_y", 0.672 * cm);
+    set_default_double_param(SEGMENTATION_Z, "strip_x", 0.032 * cm);
+    set_default_double_param(SEGMENTATION_Z, "strip_y", 1.6 * cm);
+    set_default_double_param(SEGMENTATION_Z, "strip_z_0", 0.01406 * cm);
+    set_default_double_param(SEGMENTATION_Z, "strip_z_1", 0.01406 * cm);
 
+    set_default_int_param(SEGMENTATION_PHI, "nstrips_phi_cell", 256);
+    set_default_int_param(SEGMENTATION_PHI, "nstrips_phi_sensor", 256);
+    set_default_int_param(SEGMENTATION_PHI, "nstrips_z_sensor_0", 8);
+    set_default_int_param(SEGMENTATION_PHI, "nstrips_z_sensor_1", 5);
+    set_default_double_param(SEGMENTATION_PHI, "fphx_x", 0.032 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "fphx_y", 0.27 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "fphx_z", 0.91 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "gap_sensor_fphx", 0.1 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "halfladder_z", 48.0 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "hdi_copper_x", 0.0052 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "hdi_edge_z", 0. * cm);
+    set_default_double_param(SEGMENTATION_PHI, "hdi_kapton_x", 0.038 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "hdi_y", 3.8 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "pgs_x", 0.02 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "sensor_edge_phi", 0.13 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "sensor_edge_z", 0.1 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "sensor_offset_y", 0. * cm);
+    set_default_double_param(SEGMENTATION_PHI, "stave_straight_cooler_y", 0.47 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "stave_straight_inner_y", 0.344 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "stave_straight_outer_y", 0.522 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "strip_x", 0.032 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "strip_y", 0.0078 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "strip_z_0", 1.6 * cm);
+    set_default_double_param(SEGMENTATION_PHI, "strip_z_1", 2. * cm);
+  }
 
   return;
 }
@@ -229,8 +226,11 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
 void PHG4SiliconTrackerSubsystem::Print(const string &what) const
 {
   PrintDefaultParams();
-  cout << endl << "------" << endl;
+  cout << endl
+       << "------" << endl;
   PrintMacroParams();
-  cout << endl << "------" << endl << endl;
+  cout << endl
+       << "------" << endl
+       << endl;
   GetParamsContainer()->Print();
 }

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -104,13 +104,13 @@ int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     }
 
     // create stepping action
-    steppingAction_ = new PHG4SiliconTrackerSteppingAction(detector_, GetParamsContainer(), GetDetIds());
+    steppingAction_ = new PHG4SiliconTrackerSteppingAction(detector_, GetParamsContainer(), layer_begin_end);
   }
   else
   {
     if (blackhole)
     {
-      steppingAction_ = new PHG4SiliconTrackerSteppingAction(detector_, GetParamsContainer(),GetDetIds());
+      steppingAction_ = new PHG4SiliconTrackerSteppingAction(detector_, GetParamsContainer(), layer_begin_end);
     }
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
@@ -20,7 +20,7 @@ class PHG4SiliconTrackerSubsystem : public PHG4DetectorGroupSubsystem
   //! constructor
   PHG4SiliconTrackerSubsystem(const std::string &name = "SILICONTRACKER", const vpair &layerconfig = vpair(0));  
 
-  PHG4SiliconTrackerSubsystem(const double sensor_radius_inner_[], const double sensor_radius_outer_[], const std::string &name = "SILICONTRACKER", const vpair &layerconfig = vpair(0));
+//  PHG4SiliconTrackerSubsystem(const double sensor_radius_inner_[], const double sensor_radius_outer_[], const std::string &name = "SILICONTRACKER", const vpair &layerconfig = vpair(0));
 
   //! destructor
   virtual ~PHG4SiliconTrackerSubsystem(void)

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
@@ -18,9 +18,9 @@ class PHG4SiliconTrackerSubsystem : public PHG4DetectorGroupSubsystem
   typedef std::vector<std::pair<int, int>> vpair;
 
   //! constructor
-  PHG4SiliconTrackerSubsystem(const std::string &name = "SILICONTRACKER", const vpair &layerconfig = vpair(0));  
+  PHG4SiliconTrackerSubsystem(const std::string &name = "SILICONTRACKER", const vpair &layerconfig = vpair(0));
 
-//  PHG4SiliconTrackerSubsystem(const double sensor_radius_inner_[], const double sensor_radius_outer_[], const std::string &name = "SILICONTRACKER", const vpair &layerconfig = vpair(0));
+  //  PHG4SiliconTrackerSubsystem(const double sensor_radius_inner_[], const double sensor_radius_outer_[], const std::string &name = "SILICONTRACKER", const vpair &layerconfig = vpair(0));
 
   //! destructor
   virtual ~PHG4SiliconTrackerSubsystem(void)
@@ -47,7 +47,6 @@ class PHG4SiliconTrackerSubsystem : public PHG4DetectorGroupSubsystem
   PHG4SteppingAction *GetSteppingAction(void) const { return steppingAction_; }
   void Print(const std::string &what = "ALL") const;
 
-
  private:
   void SetDefaultParameters();
 
@@ -61,7 +60,6 @@ class PHG4SiliconTrackerSubsystem : public PHG4DetectorGroupSubsystem
 
   std::vector<std::pair<int, int>> layerconfig_;
   std::string detector_type;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.h
@@ -62,11 +62,6 @@ class PHG4SiliconTrackerSubsystem : public PHG4DetectorGroupSubsystem
   std::vector<std::pair<int, int>> layerconfig_;
   std::string detector_type;
 
-  int nlayers;
-
-  double sensor_radius_inner[4];
-  double sensor_radius_outer[4];
-
 };
 
 #endif


### PR DESCRIPTION
This pull request implements the capability to change the number of layers consistently (previous version only worked with default 4 layers). It is possible to change the parameters but this version still contains all the problems of the original implementation (one has to use mm when changing double params due to inconsistent application of the units). This pull request reproduces the results from the previous version identically, any bugfixes in the next pull request won't do this. Also changing the internal unit used by the parameters from mm to cm will result in small changes due to different conversions of the input value. Hits from active absorber volumes should also work now (they sort of didn't in the original version)