### PR TITLE
Intt strips pacement

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom.h
@@ -35,6 +35,8 @@ class PHG4CylinderGeom: public PHObject
 
   virtual void find_segment_center(const int segment_z_bin, const int segment_phi_bin, double location[]){PHOOL_VIRTUAL_WARN("find_sensor_center"); return;}
   virtual void find_strip_center(const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[]){PHOOL_VIRTUAL_WARN("find_strip_center"); return;}
+ virtual void find_strip_index_values(const int segment_z_bin, const double ypos, const double zpos, int &strip_y_index, int &strip_z_index){PHOOL_VIRTUAL_WARN("find_strip_index_values"); return;}
+  virtual void find_strip_center_local_coords(const int segment_z_bin, const int strip_y_index, const int strip_z_index, double location[]){PHOOL_VIRTUAL_WARN("find_strip_center_localcoords"); return;}
 
   virtual double get_strip_y_spacing() const {PHOOL_VIRTUAL_WARN("get_strip_y_spacing"); return NAN;}
   virtual double get_strip_z_spacing() const {PHOOL_VIRTUAL_WARN("get_strip_z_spacing"); return NAN;}

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
@@ -114,9 +114,9 @@ void PHG4CylinderGeom_Siladders::find_strip_index_values(const int segment_z_bin
       return;
     }
 
-  // convert mm to cm
-  double zpos = zin / 10.0;
-  double ypos = yin / 10.0;
+  // expect cm
+  double zpos = zin;
+  double ypos = yin;
   
   const double strip_z  = strip_z_[itype];
   const int nstrips_z_sensor = nstrips_z_sensor_[itype];

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
@@ -101,3 +101,67 @@ void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, cons
   location[1] = strip_localpos.y();
   location[2] = strip_localpos.z();
 }
+
+void PHG4CylinderGeom_Siladders::find_strip_index_values(const int segment_z_bin, const double yin, const double zin,  int &strip_y_index, int &strip_z_index)
+{
+  // Given the location in y and z in sensor local coordinates, find the strip y and z index values
+
+  // find the sensor type (inner or outer) from the segment_z_bin (location of sensor on ladder)
+  const int itype = segment_z_bin % 2;  
+  if(itype != 0 && itype != 1)
+    {
+      cout  << "Problem: itype = " << itype << endl; 
+      return;
+    }
+
+  // convert mm to cm
+  double zpos = zin / 10.0;
+  double ypos = yin / 10.0;
+  
+  const double strip_z  = strip_z_[itype];
+  const int nstrips_z_sensor = nstrips_z_sensor_[itype];
+  const int nstrips_y_sensor = nstrips_phi_cell;
+  
+  // get the strip z index
+  double zup = (double) nstrips_z_sensor * strip_z / 2.0 + zpos;  
+  strip_z_index = (int) (zup / strip_z);
+
+  // get the strip y index
+  double yup = (double) nstrips_y_sensor * strip_y / 2.0 + ypos;
+  strip_y_index = (int) (yup / strip_y);
+
+  /*
+  cout << "segment_z_bin " << segment_z_bin << " ypos " << ypos << " zpos " << zpos << " zup " << zup << " yup " << yup << endl;
+  cout << "      -- itype " << itype << " strip_y " << strip_y << " strip_z " << strip_z << " nstrips_z_sensor " << nstrips_z_sensor 
+       << " nstrips_y_sensor " << nstrips_y_sensor << endl;
+  cout << "      --  strip_z_index " << strip_z_index << " strip_y_index " << strip_y_index << endl;
+  */  
+}
+
+void PHG4CylinderGeom_Siladders::find_strip_center_localcoords(const int segment_z_bin, const int strip_y_index, const int strip_z_index, double location[])
+{
+  // find the sensor type (inner or outer) from the segment_z_bin (location of sensor on ladder)
+  const int itype = segment_z_bin % 2;  
+  if(itype != 0 && itype != 1)
+    {
+      cout  << "Problem: itype = " << itype << endl; 
+      return;
+    }
+
+  const double strip_z  = strip_z_[itype];
+  const int nstrips_z_sensor = nstrips_z_sensor_[itype];
+  const int nstrips_y_sensor = nstrips_phi_cell;
+
+  // center of strip in y
+  double ypos = (double) strip_y_index * strip_y + strip_y/2.0 - (double) nstrips_y_sensor * strip_y/2.0;
+
+  // center of strip in z
+  double zpos = (double) strip_z_index * strip_z + strip_z/2.0 - (double) nstrips_z_sensor * strip_z/2.0;
+
+  location[0] = 0.0;
+  location[1] = ypos;
+  location[2] = zpos;
+
+
+}
+

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
@@ -83,6 +83,8 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
     bool load_geometry();
     void find_segment_center(const int segment_z_bin, const int segment_phi_bin, double location[]);
     void find_strip_center(  const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[]);
+    void find_strip_index_values(const int segment_z_bin, const double ypos, const double zpos,  int &strip_y_index, int &strip_z_index);
+    void find_strip_center_localcoords(const int segment_z_bin, const int strip_y_index, const int strip_z_index, double location[]);
 
     double get_thickness() const
       {

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -17,6 +17,8 @@
 
 #include <PHG4CylinderGeom_Siladders.h>
 #include <boost/format.hpp>
+#include <TF1.h>
+#include <TVector3.h>
 
 #include <cmath>
 #include <cstdlib>
@@ -90,17 +92,6 @@ int PHG4SiliconTrackerCellReco::InitRun(PHCompositeNode *topNode)
   if (verbosity > 0)
     geo->identify();
 
-  // ADF: removed this because it hard-codes the layer numbers!
-  // binning.insert(std::make_pair(2, 0));
-  // binning.insert(std::make_pair(3, 1));
-  // binning.insert(std::make_pair(4, 2));
-  // binning.insert(std::make_pair(5, 3));
-  // for (std::map<int,int>::iterator iter = binning.begin(); iter != binning.end(); ++iter)
-  //   {
-  //     // if the user doesn't set an integration window, set the default
-  //     tmin_max.insert(std::make_pair(/*layer*/iter->first, std::make_pair(tmin_default, tmax_default)));
-  //   }
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -137,7 +128,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
   for (PHG4HitContainer::ConstIterator hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
   {
     const int sphxlayer = hiter->second->get_layer();
-    PHG4CylinderGeom *layergeom = geo->GetLayerGeom(sphxlayer);
+    PHG4CylinderGeom_Siladders *layergeom = (PHG4CylinderGeom_Siladders*) geo->GetLayerGeom(sphxlayer);
 
     // checking ADC timing integration window cut
     // uses default values for now
@@ -149,9 +140,164 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
 
     const int ladder_z_index = hiter->second->get_ladder_z_index();
     const int ladder_phi_index = hiter->second->get_ladder_phi_index();
-    const int strip_z_index = hiter->second->get_strip_z_index();
-    const int strip_y_index = hiter->second->get_strip_y_index();
 
+     // What we have here is a hit in the sensor. We have not yet assigned the strip(s) that were hit, we do that here.
+    //===========================================================================
+
+    // Get the entry point of the hit in sensor local coordinates
+    TVector3 local_in( hiter->second->get_local_x(0),  hiter->second->get_local_y(0),  hiter->second->get_local_z(0) );
+    TVector3 local_out( hiter->second->get_local_x(1),  hiter->second->get_local_y(1),  hiter->second->get_local_z(1) );
+    //TVector3 midpoint( (local_in.X() + local_out.X()) / 2.0, (local_in.Y() + local_out.Y()) / 2.0, (local_in.Z() + local_out.Z()) / 2.0 );
+    TVector3 pathvec = local_in - local_out;
+    double path_length = pathvec.Mag();
+
+    int strip_y_index_in, strip_z_index_in, strip_y_index_out, strip_z_index_out;    
+    layergeom->find_strip_index_values(ladder_z_index, local_in.y(), local_in.z(), strip_y_index_in, strip_z_index_in);
+    layergeom->find_strip_index_values(ladder_z_index, local_out.y(), local_out.z(), strip_y_index_out, strip_z_index_out);
+    
+    // Now we find how many strips were crossed by this track, and divide the energy between them
+
+    int  minstrip_z = strip_z_index_in;
+    int maxstrip_z = strip_z_index_out;
+    if(minstrip_z > maxstrip_z) swap(minstrip_z, maxstrip_z);
+
+    int minstrip_y = strip_y_index_in;
+    int maxstrip_y = strip_y_index_out;
+    if(minstrip_y > maxstrip_y) swap(minstrip_y, maxstrip_y);
+
+    cout << " minstrip_y " << minstrip_y << " maxstrip_y " << maxstrip_y << " minstrip_z " << minstrip_z << " maxstrip_z " << maxstrip_z << endl;
+
+    // define the (assumed) straight line of the path
+    double dzdy = ( local_out.Z() - local_in.Z() ) / ( local_out.Y() - local_in.Y() );
+    double z0 =  local_in.Z()  - dzdy * local_in.Y();
+    TF1* fpath1 = new TF1("fpath1", "[0] + [1]*x");
+    fpath1->SetParameter(0, z0);
+    fpath1->SetParameter(1, dzdy);
+
+    double dydz = ( local_out.Y() - local_in.Y() ) / ( local_out.Z() - local_in.Z() );
+    double y0 =  local_in.Y()  - dydz * local_in.Z();
+    TF1* fpath2 = new TF1("fpath2", "[0] + [1]*x");
+    fpath2->SetParameter(0, y0);
+    fpath2->SetParameter(1, dydz);
+
+    // loop over the strips touched by this track
+    for(int iz=minstrip_z; iz <= maxstrip_z; iz++)
+      {
+	for(int iy = minstrip_y; iy <= maxstrip_y; iy++)
+	  {
+	    double point[2][2] = {-10000, -10000, -10000, -10000};
+
+	    double location[3] = {-1,-1,-1};
+	    layergeom->find_strip_center_localcoords(ladder_z_index, iy, iz, location);
+	    // define the rectangular box corresponding to this strip
+	    double strip_ymin = location[1] - layergeom->get_strip_y_spacing() / 2.0;
+	    double strip_ymax = location[1] + layergeom->get_strip_y_spacing() / 2.0;
+	    double strip_zmin = location[2] - layergeom->get_strip_z_spacing() / 2.0;
+	    double strip_zmax = location[2] + layergeom->get_strip_z_spacing() / 2.0;
+
+	    // does the line pass through this box?
+	    int got_it = 0;
+	    double z1 = fpath1->Eval(strip_ymin);
+	    if( z1 > strip_zmin && z1 < strip_zmax) 
+	      {
+		// crosses the boundary at ymin
+		point[got_it][0] = strip_ymin;
+		point[got_it][1] = z1; 
+		got_it++;
+	      }
+	      double z2 = fpath1->Eval(strip_ymax);
+	      if (z2 > strip_zmin && z2 < strip_zmax)
+	      {
+		// crosses the boundary at ymax
+		point[got_it][0] = strip_ymax;
+		point[got_it][1] = z1; 
+		got_it++;
+	      }
+
+	    double y1 = fpath2->Eval(strip_zmin);
+	    if( (y1 > strip_ymin && y1 < strip_ymax))
+	      {
+		// crosses the boundary at zmin
+		point[got_it][0] = y1;
+		point[got_it][1] = strip_zmin; 
+		got_it++;
+	      }
+	    double y2 = fpath2->Eval(strip_zmax);
+	    if( (y2 > strip_ymin && y2 < strip_ymax) )
+	      {
+		// crosses the boundary at zmax
+		point[got_it][0] = y2;
+		point[got_it][1] = strip_zmax; 
+		got_it++;
+	      }
+
+	    // the path does not enter the volume
+	    if(got_it == 0)
+	      {
+		cout << " track did not intersect z or y boundary of strip with iy " << iy << " iz " << iz << "  ---  got_it = " << got_it << endl; 
+		continue;
+	      }
+	      if(got_it != 2)
+		{
+		  cout << "Oops! That's not right: got_it = " << got_it << endl;
+		  continue;
+		}
+
+	      // now we can get the energy deposit in this strip
+	      double plength = sqrt( pow( (point[0][0] - point[1][0]), 2) + pow( (point[0][1] - point[1][1]), 2)  );
+	      double efrac = plength/path_length;
+	      cout << " Make cell for layer " << sphxlayer << " ladder_z_index " << ladder_z_index << " ladder_phi_index " << ladder_phi_index << endl;
+	      cout << "         strip_y_index " << iy << " strip_z_index " << iz << endl; 
+	      cout << "         path_length " << path_length << " plength " << plength << " efrac " << efrac << " strip energy " << efrac * hiter->second->get_edep()
+		   << endl;
+
+	    // Add this strip to the cell list
+	    //====================
+
+	    // this string must be unique - it needs the layer too, or in high multiplicity events it will add g4 hits in different layers with the same key together
+	    std::string key = boost::str(boost::format("%d-%d-%d-%d-%d") % sphxlayer % ladder_z_index % ladder_phi_index % iz % iy).c_str();
+	    PHG4Cell *cell = nullptr;
+	    map<string, PHG4Cell *>::iterator it;
+	    
+	    it = celllist.find(key);
+	    // If there is an existing cell to add this hit to, find it    
+	    if (it != celllist.end())
+	      {
+		cell = it->second;
+		if(verbosity > 2)  cout << " found existing cell with key " << key << endl;
+	      }
+	    
+	    // There is not an existing cell to add this hit to, start a new cell    
+	    if(!cell)
+	      {
+		if(verbosity > 2) cout << " did not find existing cell with key " << key << " start a new one" << endl;
+		unsigned int index = celllist.size();
+		index++;
+		PHG4CellDefs::keytype cellkey = PHG4CellDefs::MapsBinning::genkey(sphxlayer, index);
+		cell = new PHG4Cellv1(cellkey);
+		celllist[key] = cell;
+		// This encodes the z and phi position of the sensor
+		//          celllist[key]->set_sensor_index(boost::str(boost::format("%d_%d") %ladder_z_index %ladder_phi_index).c_str());
+		
+		cell->set_ladder_z_index(ladder_z_index);
+		cell->set_ladder_phi_index(ladder_phi_index);
+		
+		// The z and phi position of the hit strip within the sensor
+		cell->set_zbin(iz);
+		cell->set_phibin(iy);
+	      }
+	    
+	    // One way or another we have a cell pointer - add this hit to the cell
+	    cell->add_edep(hiter->first, efrac * hiter->second->get_edep());
+	    cell->add_edep(efrac * hiter->second->get_edep());
+	  }
+      }
+    
+    
+
+
+    //=============================================================================
+    /*    
     // As a check, get the positions of the hit strips from the geo object
     double location[3] = {-1, -1, -1};
     layergeom->find_strip_center(ladder_z_index, ladder_phi_index, strip_z_index, strip_y_index, location);
@@ -203,7 +349,11 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
     // One way or another we have a cell pointer - add this hit to the cell
     cell->add_edep(hiter->first, hiter->second->get_edep());
     cell->add_edep(hiter->second->get_edep());
+    */
+
   }  // end loop over g4hits
+
+
   
   int numcells = 0;
   for (std::map<std::string, PHG4Cell *>::const_iterator mapiter = celllist.begin(); mapiter != celllist.end(); ++mapiter)

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
@@ -39,6 +39,9 @@ class PHG4SiliconTrackerCellReco : public SubsysReco
     tmax_default = tmax;
   }
 
+  double circle_rectangle_intersection(double x1, double y1,  double x2,  double y2,  double mx, double my,  double r);
+  double sA(double r, double x, double y) ;
+  
  protected:
   int CheckEnergy(PHCompositeNode *topNode);
   std::map<int, int> binning;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDefs.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDefs.h
@@ -7,8 +7,8 @@
 
 namespace PHG4SiliconTrackerDefs
 {
-static const int SEGMENTATION_Z = -1;
-static const int SEGMENTATION_PHI = -2;
+static const int SEGMENTATION_Z = 0;
+static const int SEGMENTATION_PHI = 1;
 // this set only exists so we can iterate over the enum
 // yes it can be made more fancy but this will do
 // and yes stupid CINT does not understand C++11

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -181,17 +181,51 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4VSolid *siactive_box = new G4Box(boost::str(boost::format("siactive_box_%d_%d") % inttlayer % itype).c_str(), siactive_x / 2, siactive_y / 2., siactive_z / 2.);
       G4LogicalVolume *siactive_volume = new G4LogicalVolume(siactive_box, G4Material::GetMaterial("G4_Si"),
                                                              boost::str(boost::format("siactive_volume_%d_%d") % inttlayer % itype).c_str(), 0, 0, 0);
+      if ((IsActive.find(inttlayer))->second > 0)
+      {
+        activelogvols.insert(siactive_volume);
+      }
       G4VisAttributes *siactive_vis = new G4VisAttributes();
       siactive_vis->SetVisibility(true);
       siactive_vis->SetForceSolid(true);
       siactive_vis->SetColour(G4Colour::White());
       siactive_volume->SetVisAttributes(siactive_vis);
 
+      // We do not subdivide the sensor in G4. We will assign hits to strips in the stepping action, using the geometry object
+
+      /*
       // Now make a G4PVParameterised containing all of the strips in a sensor
       // this works for ladder 0 because there is only one strip type - all cells are identical
       G4VPVParameterisation *stripparam = new PHG4SiliconTrackerStripParameterisation(nstrips_phi_sensor, nstrips_z_sensor, strip_y, strip_z);
       new G4PVParameterised(boost::str(boost::format("siactive_%d_%d") % inttlayer % itype).c_str(),
                             strip_volume, siactive_volume, kZAxis, nstrips_phi_sensor * nstrips_z_sensor, stripparam, false);  // overlap check too long.
+      */
+      /*
+      // Place strips in the active sensor volume
+      const double strip_offsety = nstrips_phi_sensor * strip_y * 0.5;
+      const double strip_offsetz = nstrips_z_sensor * strip_z * 0.5;
+      cout << "   inttlayer " << inttlayer << " layer " << layeriter->first << " laddertype " << laddertype << " itype " << itype 
+	   << " strip_x " << strip_x << " strip_y " << strip_y << " strip_z " << strip_z  << endl;
+      cout << "   strip_offsety " << strip_offsety << " nstrips_phi_sensor " << nstrips_phi_sensor << " strip_y " << strip_y  << endl;  
+      cout << "   strip_offsetz " << strip_offsetz << " nstrips_z_sensor " << nstrips_z_sensor << " strip_z " << strip_z  << endl;  
+
+      int icopy = 0;
+      for(int iy = 0;iy < nstrips_phi_sensor; iy++)
+	{
+	  for(int iz =0; iz < nstrips_z_sensor; iz++)
+	    {
+	      // calculate the location of the strip in the sensor active volume
+	      double fXStrip = 0.0;
+	      double fYStrip = (iy + 0.5) * strip_y - strip_offsety;
+	      double fZStrip = (iz + 0.5) * strip_z - strip_offsetz;	      
+	      new G4PVPlacement(0, G4ThreeVector(fXStrip, fYStrip, fZStrip), strip_volume,
+				boost::str(boost::format("siactive_%d_%d_%d") % inttlayer % itype % icopy).c_str(), siactive_volume, false, 0, OverlapCheck());
+	      //cout << "inttlayer " << inttlayer << " layer " << layeriter->first << " itype " << itype << " strip_x " << strip_x << " strip_y " << strip_y << " strip_z " << strip_z  
+	      //   << " placed strip copy " << icopy << " at x = " << fXStrip << " y = " << fYStrip << " z = " << fZStrip << endl;
+	      icopy++;
+	    }
+	}
+      */      
 
       // Si-sensor full (active+inactive) area
       const double sifull_x = siactive_x;
@@ -216,7 +250,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
       // Make the HDI Kapton and copper volumes
 
-      // This makes HDI volumes that matche this sensor in Z length
+      // This makes HDI volumes that matches this sensor in Z length
       const G4double hdi_z = sifull_z + params->get_double_param("hdi_edge_z");
       hdi_z_[inttlayer][itype] = hdi_z;
       G4VSolid *hdi_kapton_box = new G4Box(boost::str(boost::format("hdi_kapton_box_%d_%d") % inttlayer % itype).c_str(), hdi_kapton_x / 2., hdi_y / 2., hdi_z / 2.0);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -162,7 +162,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
 	  //      cout << "sphxlayer orig: " << sphxlayer;
 	  inttlayer = boost::lexical_cast<int>(*(++tokeniter));
 	  sphxlayer = m_InttToTrackerLayerMap.find(inttlayer)->second;
-	  //      cout << ", from intt: " << sphxlayer << endl;
+	  cout << " inttlayer " << inttlayer << ", sphhxlayer from intt: " << sphxlayer << endl;
 	  ladderz = boost::lexical_cast<int>(*(++tokeniter));    // inner sensor itype = 0, outer sensor itype = 1
 	  ladderphi = boost::lexical_cast<int>(*(++tokeniter));  // copy number in phi
 	  zposneg = boost::lexical_cast<int>(*(++tokeniter));    // 1 for negative z, 2 for positive z
@@ -248,7 +248,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
 
       if(prePoint->GetStepStatus() == fUndefined)   cout << PHWHERE << "***** Warning: prePoint step status of fUndefined found " << endl;      
 
-      //if (Verbosity() > 1) 
+      if (Verbosity() > 1) 
       cout << " found prePoint step status of fGeomBoundary (" << fGeomBoundary << ")" << " or fUndefined (" << fUndefined << ") = " << prePoint->GetStepStatus() << "  start a new hit " << endl;
       
       // if previous hit was saved, hit pointer was set to nullptr

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -1,6 +1,11 @@
 #include "PHG4SiliconTrackerSteppingAction.h"
 #include "PHG4SiliconTrackerDefs.h"
 #include "PHG4SiliconTrackerDetector.h"
+#include "PHG4CylinderCellGeom.h"
+#include "PHG4CylinderCellGeomContainer.h"
+#include "PHG4CylinderGeomContainer.h"
+#include <PHG4CylinderGeom.h>
+#include <PHG4CylinderGeom_Siladders.h>
 
 #include "PHG4StepStatusDecode.h"
 
@@ -131,405 +136,196 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
   int ladderz = 0;
   int ladderphi = 0;
   int zposneg = 0;
-  int strip_z_index = 0;
-  int strip_y_index = 0;
-  int sameevent = 0;
-  int save_strip_z_index = 0;
-  int save_strip_y_index = 0;
-  int save_ladderz = 0;
-  int save_ladderphi = 0;
+
   if (whichactive > 0)  // silicon acrive sensor
-  {
-    if (Verbosity() > 0)
     {
-      cout << endl
-           << "PHG4SilicoTrackerSteppingAction::UserSteppingAction for volume name (pre) " << touch->GetVolume()->GetName()
-           << " volume name (2) " << touch->GetVolume(2)->GetName()
-           << " volume->GetTranslation " << touch->GetVolume()->GetTranslation()
-           << " volume->GetCopyNo() " << volume->GetCopyNo()
-           << endl;
-    }
-
-    // Get the layer and ladder information
-    // thi is the same for all strips in the sensor
-    boost::char_separator<char> sep("_");
-    boost::tokenizer<boost::char_separator<char>> tok(touch->GetVolume(2)->GetName(), sep);
-    boost::tokenizer<boost::char_separator<char>>::const_iterator tokeniter;
-    tokeniter = tok.begin();
-    if (*tokeniter == "ladder")
-    {
-      // advance the tokeniter and then cast it if first token is "ladder"
-      //      sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
-      //      cout << "sphxlayer orig: " << sphxlayer;
-      inttlayer = boost::lexical_cast<int>(*(++tokeniter));
-      sphxlayer = m_InttToTrackerLayerMap.find(inttlayer)->second;
-      //      cout << ", from intt: " << sphxlayer << endl;
-      ladderz = boost::lexical_cast<int>(*(++tokeniter));    // inner sensor itype = 0, outer sensor itype = 1
-      ladderphi = boost::lexical_cast<int>(*(++tokeniter));  // copy number in phi
-      zposneg = boost::lexical_cast<int>(*(++tokeniter));    // 1 for negative z, 2 for positive z
-    }
-    else
-    {
-      cout << GetName() << "parsing of " << touch->GetVolume(2)->GetName() << " failed, it does not start with ladder_" << endl;
-      exit(1);
-    }
-    if (inttlayer < 0 || inttlayer > 3)
-      assert(!"PHG4SiliconTrackerSteppingAction: check INTT ladder layer.");
-    map<int, int>::const_iterator activeiter = IsActive.find(inttlayer);
-    if (activeiter == IsActive.end())
-    {
-      cout << "PHG4SiliconTrackerSteppingAction: could not find active flag for layer " << inttlayer << endl;
-      gSystem->Exit(1);
-    }
-    if (activeiter->second == 0)
-    {
-      return false;
-    }
-
-    // Find the strip y and z index values from the copy number (integer division, quotient is strip_y, remainder is strip_z)
-    //    div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor[laddertype[inttlayer]][ladderz]);
-    int laddertype = (m_LadderTypeMap.find(inttlayer))->second;
-    int nstrips_z_sensor;
-    switch (ladderz)
-    {
-    case 0:
-      nstrips_z_sensor = m_nStripsZSensor.find(laddertype)->second.first;
-      break;
-    case 1:
-      nstrips_z_sensor = m_nStripsZSensor.find(laddertype)->second.second;
-      break;
-    default:
-      cout << "Bad ladderz: " << ladderz << endl;
-      gSystem->Exit(1);
-      // this is just to make the optimizer happy which otherwise complains about possibly
-      // uninitialized variables. It doesn't know gSystem->Exit(1) quits,
-      // this exit here terminates the program for it
-      exit(1);
-    }
-    div_t copydiv = div(volume->GetCopyNo(), nstrips_z_sensor);
-    strip_y_index = copydiv.quot;
-    strip_z_index = copydiv.rem;
-    save_strip_z_index = strip_z_index;
-    save_strip_y_index = strip_y_index;
-    save_ladderz = ladderz;
-    save_ladderphi = ladderphi;
-    G4ThreeVector strip_pos = volume->GetTranslation();
-    G4ThreeVector prepos = prePoint->GetPosition();
-    G4ThreeVector postpos = postPoint->GetPosition();
-    if (Verbosity() > 0)
-    {
-      cout << " sphxlayer " << sphxlayer << " inttlayer " << inttlayer << " ladderz " << ladderz << " ladderphi " << ladderphi
-           << " zposneg " << zposneg
-           << " copy no. " << volume->GetCopyNo() << " nstrips_z_sensor " << nstrips_z_sensor
-           << " strip_y_index " << strip_y_index << " strip_z_index " << strip_z_index << endl;
-      sameevent = 1;
-    }
-    // There are two failure modes observed for this stupid parameterised volume:
-    //  1) If the prePoint step status is "fUndefined" then the copy number is sometimes kept from the last hit, which is often an unrelated volume
-    //  2) If the  pre and post step are in the same volume but they both have status fGeomBoundary, the volume is assigned the copy number of the next volume, which is usually off by one in strip_y_index
-    // in both cases we need to find the correct strip_y_index and strip_z_index values the hard way - that is what is done here
-    int fixit = 0;
-    G4VPhysicalVolume* volume_post = postPoint->GetTouchableHandle()->GetVolume();
-    //      G4VPhysicalVolume* volume_pre = prePoint->GetTouchableHandle()->GetVolume();
-    G4LogicalVolume* logvolpre = volume->GetLogicalVolume();
-    G4LogicalVolume* logvolpost = volume_post->GetLogicalVolume();
-    if (prePoint->GetStepStatus() == fGeomBoundary && postPoint->GetStepStatus() == fGeomBoundary)
-    {
-      // this is just failsafe - we still have those impossible hits where pre and poststep
-      // are in the same volume with status fGeomBoundary
-      // but the extraction of the strip index above works for those
-      // my assumption is that the end of a physics step coincides with the boundary and
-      // the physics step size is taken rather the geometric step size
-      if (logvolpre == logvolpost)
-      {
-        if (volume->GetCopyNo() == volume_post->GetCopyNo() || prePoint->GetStepStatus() == fUndefined)
-        {
-          fixit = 1;
-        }
-      }
-    }
-
-    if (prePoint->GetStepStatus() == fUndefined)
-    {
-      fixit = 2;
-
-      // cout << "copy pre vol: " << volume->GetCopyNo() << ", " << volume->GetName()
-      // 	   << ", post: " << volume_post->GetCopyNo() << ", " << volume_post->GetName()
-      // 	   << ", pre: " << volume_pre->GetCopyNo() << ", " << volume_pre->GetName()
-      // 	   << endl;
-      // if (prePoint->GetProcessDefinedStep())
-      // {
-      // cout << prePoint->GetProcessDefinedStep()->GetProcessName() << endl;
-      // }
-      // else
-      // {
-      // 	cout << "Process is null ptr, try post step" << endl;
-      // 	if (postPoint->GetProcessDefinedStep())
-      // 	{
-      // 	  cout << postPoint->GetProcessDefinedStep()->GetProcessName() << endl;
-      // 	}
-      // 	else
-      // 	{
-      // 	  cout << "no post step proc either" << endl;
-      // 	}
-      // }
-      // G4ThreeVector preworldPos = prePoint->GetPosition();
-      // G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
-      // G4ThreeVector postworldPos = postPoint->GetPosition();
-      // G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
-      // cout << "preworldpos: " << preworldPos << endl;
-      // cout << "pre strip pos: " << strip_pos << endl;
-      // cout << "postworldPos: " << postPoint->GetPosition() << endl;
-      // cout << "poststrip_pos: " << poststrip_pos << endl;
-    }
-
-    if (fixit)
-    {
-      //	cout << "fixit: " << fixit << endl;
-      int strip_y_index_old = strip_y_index;
-      int strip_z_index_old = strip_z_index;
-
-      // we need a hack to compare the values above with the correct strip index values
-      // the transform of the world coordinates into the sensor frame will work correctly,
-      // so we determine the strip indices from the hit position
-      G4ThreeVector preworldPos = prePoint->GetPosition();
-      G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
-      G4ThreeVector postworldPos = postPoint->GetPosition();
-      G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
-
-      strip_z_index = 0;
-      double strip_z;
-      int nstrips_z_sensor;
-      switch (ladderz)
-      {
-      case 0:
-        strip_z = m_StripZMap.find(laddertype)->second.first;
-        nstrips_z_sensor = m_nStripsZSensor.find(laddertype)->second.first;
-        break;
-      case 1:
-        strip_z = m_StripZMap.find(laddertype)->second.second;
-        nstrips_z_sensor = m_nStripsZSensor.find(laddertype)->second.second;
-        break;
-      default:
-        cout << "Bad ladderz: " << ladderz << endl;
-        gSystem->Exit(1);
-        // this is just to make the optimizer happy which otherwise complains about possibly
-        // uninitialized variables. It doesn't know gSystem->Exit(1) quits,
-        // this exit here terminates the program for it
-        exit(1);
-      }
-      // cout << "nstrips_z_sensor: " << nstrips_z_sensor
-      //      << ", strip_z: " << strip_z
-      //      << endl;
-      for (int i = 0; i < nstrips_z_sensor; ++i)
-      {
-        const double zmin = strip_z * i - (strip_z / 2.) * nstrips_z_sensor;
-        const double zmax = strip_z * (i + 1) - (strip_z / 2.) * nstrips_z_sensor;
-        if (strip_pos.z() / mm > zmin && strip_pos.z() / mm <= zmax)
-        {
-          strip_z_index = i;
-          if (Verbosity() > 1) std::cout << "                            revised strip z position = " << strip_z_index << std::endl;
-          break;
-        }
-      }
-
-      strip_y_index = 0;
-      int nstrips_phi_cell = m_nStripsPhiCell.find(laddertype)->second;
-      double strip_y = m_StripYMap.find(laddertype)->second;
-      // cout << "nstrips_phi_cell: " << nstrips_phi_cell
-      //      << ", strip_y: " << strip_y
-      //      << endl;
-      for (int i = 0; i < 2 * nstrips_phi_cell; ++i)
-      {
-        const double ymin = strip_y * i - strip_y * nstrips_phi_cell;
-        ;
-        const double ymax = strip_y * (i + 1) - strip_y * nstrips_phi_cell;
-        if (strip_pos.y() / mm > ymin && strip_pos.y() / mm <= ymax)
-        {
-          strip_y_index = i;
-          if (Verbosity() > 1) std::cout << "                            revised strip y position = " << strip_y_index << std::endl;
-          break;
-        }
-      }
-
-      if (fixit == 1)
-      {
-        if (strip_y_index_old != strip_y_index || strip_z_index_old != strip_z_index)
-        {
-          G4VPhysicalVolume* volume_post = postPoint->GetTouchableHandle()->GetVolume();
-          G4LogicalVolume* logvolpre = volume->GetLogicalVolume();
-          G4LogicalVolume* logvolpost = volume_post->GetLogicalVolume();
-          G4ThreeVector preworldPos = prePoint->GetPosition();
-          G4ThreeVector strip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
-          G4ThreeVector postworldPos = postPoint->GetPosition();
-          G4ThreeVector poststrip_pos = touch->GetHistory()->GetTransform(touch->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
-
-          cout << "Overlap detected in volume " << volume->GetName() << " where post volume "
-               << volume_post->GetName() << " has same copy no." << volume->GetCopyNo()
-               << " pre and post step point of same volume for step status fGeomBoundary" << endl;
-          cout << "logvol name " << logvolpre->GetName() << ", post: " << logvolpost->GetName() << endl;
-          cout << "strip y bef: " << strip_y_index_old << ", strip z: " << strip_z_index_old << endl;
-          cout << " strip y aft: " << strip_y_index << ", strip z: " << strip_z_index << endl;
-          cout << "pre hitpos x: " << strip_pos.x() << ", y: " << strip_pos.y() << ", z: "
-               << strip_pos.z() << endl;
-          cout << "posthitpos x: " << poststrip_pos.x() << ", y: " << poststrip_pos.y() << ", z: "
-               << poststrip_pos.z() << endl;
-          cout << "eloss: " << aStep->GetTotalEnergyDeposit() / GeV << " GeV" << endl;
-          cout << "safety prestep: " << prePoint->GetSafety()
-               << ", poststep: " << postPoint->GetSafety() << endl;
-        }
-      }
-      else
-      {
-        if (Verbosity() > 1) cout << "Detected fUndefined for prePoint step status, re-calculated strip_z_index and strip_y_index independently above" << endl;
-      }
-    }
-  }     // end of whichactive > 0 block
-  else  // silicon inactive area, FPHX, stabe etc. as absorbers
-  {
-    try
-    {
+      //if (Verbosity() > 0)
+	{
+          cout << endl
+	       << "PHG4SilicoTrackerSteppingAction::UserSteppingAction for volume name (pre) " << touch->GetVolume()->GetName()
+	       << " volume name (1) " << touch->GetVolume(1)->GetName()
+	       << " volume->GetTranslation " << touch->GetVolume()->GetTranslation()
+	       << endl;
+	}
+      
+      // We have a hit in the sensor volume
+      
+      // Get the layer and ladder information
       boost::char_separator<char> sep("_");
-      boost::tokenizer<boost::char_separator<char>> tok(touch->GetVolume(0)->GetName(), sep);
+      boost::tokenizer<boost::char_separator<char>> tok(touch->GetVolume(1)->GetName(), sep);
       boost::tokenizer<boost::char_separator<char>>::const_iterator tokeniter;
       tokeniter = tok.begin();
-      map<string, int>::const_iterator iter = AbsorberIndex.find(*tokeniter);
-      if (iter == AbsorberIndex.end())
-      {
-        cout << "Absorber " << *tokeniter << " not in list" << endl;
-        missingabsorbers.insert(*tokeniter);
-        ladderz = -AbsorberIndex.size();
-        AbsorberIndex[*tokeniter] = ladderz;
-      }
+      if (*tokeniter == "ladder")
+	{
+	  // advance the tokeniter and then cast it if first token is "ladder"
+	  //      sphxlayer = boost::lexical_cast<int>(*(++tokeniter));
+	  //      cout << "sphxlayer orig: " << sphxlayer;
+	  inttlayer = boost::lexical_cast<int>(*(++tokeniter));
+	  sphxlayer = m_InttToTrackerLayerMap.find(inttlayer)->second;
+	  //      cout << ", from intt: " << sphxlayer << endl;
+	  ladderz = boost::lexical_cast<int>(*(++tokeniter));    // inner sensor itype = 0, outer sensor itype = 1
+	  ladderphi = boost::lexical_cast<int>(*(++tokeniter));  // copy number in phi
+	  zposneg = boost::lexical_cast<int>(*(++tokeniter));    // 1 for negative z, 2 for positive z
+	}
       else
-      {
-        ladderz = iter->second;
-      }
-      //	  cout << "volume: " << touch->GetVolume(0)->GetName();
-      inttlayer = boost::lexical_cast<int>(*(++tokeniter));
-      //	  cout << ", inttlayer: " << inttlayer;
-      sphxlayer = m_InttToTrackerLayerMap.find(inttlayer)->second;
-      //	  cout << ", sphxlayer(intt): " << sphxlayer << endl;
-    }
-    catch (...)
-    {
-      cout << " that did not work for " << touch->GetVolume(0)->GetName() << endl;
-      missingabsorbers.insert(touch->GetVolume(0)->GetName());
-    }
-  }  // end of si inactive area block
+	{
+	  cout << GetName() << "parsing of " << touch->GetVolume(1)->GetName() << " failed, it does not start with ladder_" << endl;
+	  exit(1);
+	}
+      if (inttlayer < 0 || inttlayer > 3)
+	assert(!"PHG4SiliconTrackerSteppingAction: check INTT ladder layer.");
+      map<int, int>::const_iterator activeiter = IsActive.find(inttlayer);
+      if (activeiter == IsActive.end())
+	{
+	  cout << "PHG4SiliconTrackerSteppingAction: could not find active flag for layer " << inttlayer << endl;
+	  gSystem->Exit(1);
+	}
+      if (activeiter->second == 0)
+	{
+	  return false;
+	}
 
+    }     // end of whichactive > 0 block
+  else  // silicon inactive area, FPHX, stabe etc. as absorbers
+    {
+      try
+	{
+	  boost::char_separator<char> sep("_");
+	  boost::tokenizer<boost::char_separator<char>> tok(touch->GetVolume(0)->GetName(), sep);
+	  boost::tokenizer<boost::char_separator<char>>::const_iterator tokeniter;
+	  tokeniter = tok.begin();
+	  map<string, int>::const_iterator iter = AbsorberIndex.find(*tokeniter);
+	  if (iter == AbsorberIndex.end())
+	    {
+	      cout << "Absorber " << *tokeniter << " not in list" << endl;
+	      missingabsorbers.insert(*tokeniter);
+	      ladderz = -AbsorberIndex.size();
+	      AbsorberIndex[*tokeniter] = ladderz;
+	    }
+	  else
+	    {
+	      ladderz = iter->second;
+	    }
+	  cout << "volume: " << touch->GetVolume(0)->GetName();
+	  inttlayer = boost::lexical_cast<int>(*(++tokeniter));
+	  cout << ", inttlayer: " << inttlayer;
+	  sphxlayer = m_InttToTrackerLayerMap.find(inttlayer)->second;
+	  cout << ", sphxlayer(intt): " << sphxlayer << endl;
+	}
+      catch (...)
+	{
+	  cout << " that did not work for " << touch->GetVolume(0)->GetName() << endl;
+	  missingabsorbers.insert(touch->GetVolume(0)->GetName());
+	}
+    }  // end of si inactive area block
+  
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
   G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
-
+  
   // if this block stops everything, just put all kinetic energy into edep
   if ((IsBlackHole.find(inttlayer))->second == 1)
-  {
-    edep = aTrack->GetKineticEnergy() / GeV;
-    G4Track* killtrack = const_cast<G4Track*>(aTrack);
-    killtrack->SetTrackStatus(fStopAndKill);
-  }
-
+    {
+      edep = aTrack->GetKineticEnergy() / GeV;
+      G4Track* killtrack = const_cast<G4Track*>(aTrack);
+      killtrack->SetTrackStatus(fStopAndKill);
+    }
+  
   bool geantino = false;
-
+  
   // the check for the pdg code speeds things up, I do not want to make
   // an expensive string compare for every track when we know
   // geantino or chargedgeantino has pid=0
   if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 && aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
     geantino = true;
-
-  if (Verbosity() > 1)
-    cout << "prePoint step status = " << prePoint->GetStepStatus() << " postPoint step status = " << postPoint->GetStepStatus() << endl;
+  
+  //if (Verbosity() > 1)
+  cout << "prePoint step status = " << prePoint->GetStepStatus() << " postPoint step status = " << postPoint->GetStepStatus() << endl;
   switch (prePoint->GetStepStatus())
-  {
-  case fGeomBoundary:
-  case fUndefined:
-
-    if (Verbosity() > 1) cout << " found prePoint step status of fGeomBoundary or fUndefined, start a new hit " << endl;
-
-    // if previous hit was saved, hit pointer was set to nullptr
-    // and we have to make a new one
-    if (!hit)
     {
-      hit = new PHG4Hitv1();
+    case fGeomBoundary:
+    case fUndefined:
+
+      if(prePoint->GetStepStatus() == fUndefined)   cout << PHWHERE << "***** Warning: prePoint step status of fUndefined found " << endl;      
+
+      //if (Verbosity() > 1) 
+      cout << " found prePoint step status of fGeomBoundary (" << fGeomBoundary << ")" << " or fUndefined (" << fUndefined << ") = " << prePoint->GetStepStatus() << "  start a new hit " << endl;
+      
+      // if previous hit was saved, hit pointer was set to nullptr
+      // and we have to make a new one
+      if (!hit)
+	{
+	  hit = new PHG4Hitv1();
+	}
+      
+      hit->set_layer((unsigned int) sphxlayer);
+      
+      // set the index values needed to locate the sensor strip
+      if (zposneg == 2) ladderz += 2;  // ladderz = 0, 1 for negative z and = 2, 3 for positive z
+      hit->set_ladder_z_index(ladderz);
+
+      if (whichactive > 0)
+	{
+	  hit->set_strip_z_index(-1);  // N/A
+	  hit->set_strip_y_index(-1);  // N/A
+	  hit->set_ladder_phi_index(ladderphi);
+	}
+
+      // Store the local coordinates for the entry point 
+      StoreLocalCoordinate(hit, aStep, true, false);
+	  
+      //here we set the entrance values in cm
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      
+
+	cout << "    Adding G4 hit with hit position x,y,z = " << prePoint->GetPosition().x() / cm
+	<< "    " << prePoint->GetPosition().y() / cm
+	<< "     " << prePoint->GetPosition().z() / cm
+	<< endl;
+
+      
+      hit->set_px(0, prePoint->GetMomentum().x() / GeV);
+      hit->set_py(0, prePoint->GetMomentum().y() / GeV);
+      hit->set_pz(0, prePoint->GetMomentum().z() / GeV);
+      
+      // time in ns
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      
+      //set the track ID
+      hit->set_trkid(aTrack->GetTrackID());
+      
+      //set the initial energy deposit
+      hit->set_edep(0);
+      hit->set_eion(0);  // only implemented for v5 otherwise empty
+      
+      if (whichactive > 0)  // return of IsInSiliconTracker, > 0 hit in si-strip, < 0 hit in absorber
+	{
+	  // Now save the container we want to add this hit to
+	  savehitcontainer = hits_;
+	}
+      else
+	{
+	  savehitcontainer = absorberhits_;
+	}
+      
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+	{
+	  if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+	    {
+	      hit->set_trkid(pp->GetUserTrackId());
+	      hit->set_shower_id(pp->GetShower()->get_id());
+	      saveshower = pp->GetShower();
+	    }
+	}
+      
+      break;
+      
+    default:
+      break;
     }
-
-    hit->set_layer((unsigned int) sphxlayer);
-
-    // set the index values needed to locate the sensor strip
-    if (zposneg == 2) ladderz += 2;  // ladderz = 0, 1 for negative z and = 2, 3 for positive z
-    hit->set_ladder_z_index(ladderz);
-    if (whichactive > 0)
-    {
-      hit->set_strip_z_index(strip_z_index);
-      hit->set_strip_y_index(strip_y_index);
-      hit->set_ladder_phi_index(ladderphi);
-    }
-
-    //here we set the entrance values in cm
-    hit->set_x(0, prePoint->GetPosition().x() / cm);
-    hit->set_y(0, prePoint->GetPosition().y() / cm);
-    hit->set_z(0, prePoint->GetPosition().z() / cm);
-
-    /*
-    cout << "     hit position x,y,z = " << prePoint->GetPosition().x() / cm
-    << "    " << prePoint->GetPosition().y() / cm
-    << "     " << prePoint->GetPosition().z() / cm
-    << endl;
-    */
-
-    hit->set_px(0, prePoint->GetMomentum().x() / GeV);
-    hit->set_py(0, prePoint->GetMomentum().y() / GeV);
-    hit->set_pz(0, prePoint->GetMomentum().z() / GeV);
-
-    // time in ns
-    hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
-
-    //set the track ID
-    hit->set_trkid(aTrack->GetTrackID());
-
-    //set the initial energy deposit
-    hit->set_edep(0);
-    hit->set_eion(0);  // only implemented for v5 otherwise empty
-
-    if (whichactive > 0)  // return of IsInSiliconTracker, > 0 hit in si-strip, < 0 hit in absorber
-    {
-      // Now save the container we want to add this hit to
-      savehitcontainer = hits_;
-    }
-    else
-    {
-      savehitcontainer = absorberhits_;
-    }
-
-    if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
-    {
-      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
-      {
-        hit->set_trkid(pp->GetUserTrackId());
-        hit->set_shower_id(pp->GetShower()->get_id());
-        saveshower = pp->GetShower();
-      }
-    }
-    if (hit->get_strip_z_index() == 1 &&
-        hit->get_strip_y_index() == 178 &&
-        hit->get_ladder_z_index() == 3 &&
-        hit->get_ladder_phi_index() == 1)
-    {
-      hit->identify();
-      cout << "initial strip_z_index: " << save_strip_z_index << endl;
-      cout << "initial strip_y_index: " << save_strip_y_index << endl;
-      cout << "initial ladderz: " << save_ladderz << endl;
-      cout << "initial ladderphi: " << save_ladderphi << endl;
-      cout << "same event: " << sameevent << endl;
-    }
-
-    break;
-
-  default:
-    break;
-  }
-
+  
   // here we just update the exit values, it will be overwritten
   // for every step until we leave the volume or the particle
   // ceases to exist
@@ -537,27 +333,30 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
   hit->set_y(1, postPoint->GetPosition().y() / cm);
   hit->set_z(1, postPoint->GetPosition().z() / cm);
 
+ // Store the local coordinates for the exit point 
+ StoreLocalCoordinate(hit, aStep, false, true);
+  
   hit->set_px(1, postPoint->GetMomentum().x() / GeV);
   hit->set_py(1, postPoint->GetMomentum().y() / GeV);
   hit->set_pz(1, postPoint->GetMomentum().z() / GeV);
-
+  
   hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
-
+  
   //sum up the energy to get total deposited
   hit->set_edep(hit->get_edep() + edep);
   hit->set_eion(hit->get_eion() + eion);
-
+  
   if (geantino)
-  {
-    hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-    hit->set_eion(-1);
-  }
-
+    {
+      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      hit->set_eion(-1);
+    }
+  
   if (edep > 0)
     if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         pp->SetKeep(1);  // we want to keep the track
-
+  
   // if any of these conditions is true this is the last step in
   // this volume and we need to save the hit
   // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
@@ -570,99 +369,101 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       postPoint->GetStepStatus() == fWorldBoundary ||
       postPoint->GetStepStatus() == fAtRestDoItProc ||
       aTrack->GetTrackStatus() == fStopAndKill)
-  {
-    if (Verbosity() > 1)
     {
-      cout << " postPoint step status changed to " << postPoint->GetStepStatus() << " save hit and delete it" << endl;
-      cout << " fWorldBoundary " << fWorldBoundary
-           << " fGeomBoundary = " << fGeomBoundary
-           << " fAtRestDoItProc " << fAtRestDoItProc
-           << " fAlongStepDoItProc " << fAlongStepDoItProc
-           << " fPostStepDoItProc " << fPostStepDoItProc
-           << " fUserDefinedLimit " << fUserDefinedLimit
-           << " fExclusivelyForcedProc " << fExclusivelyForcedProc
-           << " fUndefined " << fUndefined
-           << " fStopAndKill " << fStopAndKill
-           << endl;
+      //if (Verbosity() > 1)
+	{
+	  cout << " postPoint step status changed to " << postPoint->GetStepStatus() << " save hit and delete it" << endl;
+	  /*
+	  cout << " fWorldBoundary " << fWorldBoundary
+	       << " fGeomBoundary = " << fGeomBoundary
+	       << " fAtRestDoItProc " << fAtRestDoItProc
+	       << " fAlongStepDoItProc " << fAlongStepDoItProc
+	       << " fPostStepDoItProc " << fPostStepDoItProc
+	       << " fUserDefinedLimit " << fUserDefinedLimit
+	       << " fExclusivelyForcedProc " << fExclusivelyForcedProc
+	       << " fUndefined " << fUndefined
+	       << " fStopAndKill " << fStopAndKill
+	       << endl;
+	  */
+	}
+      // save only hits with energy deposit (or -1 for geantino)
+      if (hit->get_edep())
+	{
+	  savehitcontainer->AddHit(sphxlayer, hit);
+	  if (saveshower)
+	    {
+	      saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
+	    }
+	  if (Verbosity() > 1)
+	    hit->print();
+	  // ownership has been transferred to container, set to null
+	  // so we will create a new hit for the next track
+	  hit = nullptr;
+	}
+      else
+	{
+	  // if this hit has no energy deposit, just reset it for reuse
+	  // this means we have to delete it in the dtor. If this was
+	  // the last hit we processed the memory is still allocated
+	  hit->Reset();
+	}
     }
-    // save only hits with energy deposit (or -1 for geantino)
-    if (hit->get_edep())
-    {
-      savehitcontainer->AddHit(sphxlayer, hit);
-      if (saveshower)
-      {
-        saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
-      }
-      if (Verbosity() > 1)
-        hit->print();
-      // ownership has been transferred to container, set to null
-      // so we will create a new hit for the next track
-      hit = nullptr;
-    }
-    else
-    {
-      // if this hit has no energy deposit, just reset it for reuse
-      // this means we have to delete it in the dtor. If this was
-      // the last hit we processed the memory is still allocated
-      hit->Reset();
-    }
-  }
-
+  
   if (Verbosity() > 1)
-  {
-    G4StepPoint* prePoint = aStep->GetPreStepPoint();
-    G4StepPoint* postPoint = aStep->GetPostStepPoint();
-    G4ThreeVector preworldPos = prePoint->GetPosition();
-    G4ThreeVector postworldPos = postPoint->GetPosition();
-
-    cout << " entry point world pos " << prePoint->GetPosition().x() << "  " << prePoint->GetPosition().y() << "  " << prePoint->GetPosition().z() << endl;
-    cout << " exit point world pos " << postPoint->GetPosition().x() << "  " << postPoint->GetPosition().y() << "  " << postPoint->GetPosition().z() << endl;
-
-    // The exit point transforms do not work here because the particle has already entered the next volume
-    // - go back and find Jin's fix for this
-
-    // strip local pos
-    G4TouchableHistory* theTouchable = (G4TouchableHistory*) (prePoint->GetTouchable());
-    G4ThreeVector prelocalPos = theTouchable->GetHistory()->GetTopTransform().TransformPoint(preworldPos);
-    cout << " entry point strip local pos: "
-         << " is " << prelocalPos.x() << " " << prelocalPos.y() << " " << prelocalPos.z() << endl;
-    G4TouchableHistory* postTouchable = (G4TouchableHistory*) (postPoint->GetTouchable());
-    G4ThreeVector postlocalPos = postTouchable->GetHistory()->GetTopTransform().TransformPoint(postworldPos);
-    cout << " exit point strip local pos: " << postlocalPos.x() << " " << postlocalPos.y() << " " << postlocalPos.z() << endl;
-
-    // sensor local pos
-    G4ThreeVector presensorLocalPos = theTouchable->GetHistory()->GetTransform(theTouchable->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
-    cout << " entry point sensor local pos: " << presensorLocalPos.x() << " " << presensorLocalPos.y() << " " << presensorLocalPos.z() << endl;
-    G4ThreeVector postsensorLocalPos = postTouchable->GetHistory()->GetTransform(postTouchable->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
-    cout << " exit point sensor local pos: " << postsensorLocalPos.x() << " " << postsensorLocalPos.y() << " " << postsensorLocalPos.z() << endl;
-  }
-
+    {
+      G4StepPoint* prePoint = aStep->GetPreStepPoint();
+      G4StepPoint* postPoint = aStep->GetPostStepPoint();
+      G4ThreeVector preworldPos = prePoint->GetPosition();
+      G4ThreeVector postworldPos = postPoint->GetPosition();
+      
+      cout << " entry point world pos " << prePoint->GetPosition().x() << "  " << prePoint->GetPosition().y() << "  " << prePoint->GetPosition().z() << endl;
+      cout << " exit point world pos " << postPoint->GetPosition().x() << "  " << postPoint->GetPosition().y() << "  " << postPoint->GetPosition().z() << endl;
+      
+      // The exit point transforms do not work here because the particle has already entered the next volume
+      // - go back and find Jin's fix for this
+      
+      // strip local pos
+      G4TouchableHistory* theTouchable = (G4TouchableHistory*) (prePoint->GetTouchable());
+      G4ThreeVector prelocalPos = theTouchable->GetHistory()->GetTopTransform().TransformPoint(preworldPos);
+      cout << " entry point strip local pos: "
+      << " is " << prelocalPos.x() << " " << prelocalPos.y() << " " << prelocalPos.z() << endl;
+      G4TouchableHistory* postTouchable = (G4TouchableHistory*) (postPoint->GetTouchable());
+      G4ThreeVector postlocalPos = postTouchable->GetHistory()->GetTopTransform().TransformPoint(postworldPos);
+      cout << " exit point strip local pos: " << postlocalPos.x() << " " << postlocalPos.y() << " " << postlocalPos.z() << endl;
+      
+      // sensor local pos
+      G4ThreeVector presensorLocalPos = theTouchable->GetHistory()->GetTransform(theTouchable->GetHistory()->GetDepth() - 1).TransformPoint(preworldPos);
+      cout << " entry point sensor local pos: " << presensorLocalPos.x() << " " << presensorLocalPos.y() << " " << presensorLocalPos.z() << endl;
+      G4ThreeVector postsensorLocalPos = postTouchable->GetHistory()->GetTransform(postTouchable->GetHistory()->GetDepth() - 1).TransformPoint(postworldPos);
+      cout << " exit point sensor local pos: " << postsensorLocalPos.x() << " " << postsensorLocalPos.y() << " " << postsensorLocalPos.z() << endl;
+    }
+  
   if (whichactive > 0 && Verbosity() > 0)  // return of IsInSiliconTracker, > 0 hit in si-strip, < 0 hit in absorber
-  {
-    G4StepPoint* prePoint = aStep->GetPreStepPoint();
-    G4StepPoint* postPoint = aStep->GetPostStepPoint();
-    cout << "----- PHg4SiliconTrackerSteppingAction::UserSteppingAction - active volume = " << volume->GetName() << endl;
-    cout << "       strip_z_index = " << strip_z_index << " strip_y_index = " << strip_y_index << endl;
-    cout << "       prepoint x position " << prePoint->GetPosition().x() / cm << endl;
-    cout << "       prepoint y position " << prePoint->GetPosition().y() / cm << endl;
-    cout << "       prepoint z position " << prePoint->GetPosition().z() / cm << endl;
-    cout << "       postpoint x position " << postPoint->GetPosition().x() / cm << endl;
-    cout << "       postpoint y position " << postPoint->GetPosition().y() / cm << endl;
-    cout << "       postpoint z position " << postPoint->GetPosition().z() / cm << endl;
-    cout << "       edep " << edep << endl;
-    cout << "       eion " << eion << endl;
-  }
-
+    {
+      G4StepPoint* prePoint = aStep->GetPreStepPoint();
+      G4StepPoint* postPoint = aStep->GetPostStepPoint();
+      cout << "----- PHg4SiliconTrackerSteppingAction::UserSteppingAction - active volume = " << volume->GetName() << endl;
+      //cout << "       strip_z_index = " << strip_z_index << " strip_y_index = " << strip_y_index << endl;
+      cout << "       prepoint x position " << prePoint->GetPosition().x() / cm << endl;
+      cout << "       prepoint y position " << prePoint->GetPosition().y() / cm << endl;
+      cout << "       prepoint z position " << prePoint->GetPosition().z() / cm << endl;
+      cout << "       postpoint x position " << postPoint->GetPosition().x() / cm << endl;
+      cout << "       postpoint y position " << postPoint->GetPosition().y() / cm << endl;
+      cout << "       postpoint z position " << postPoint->GetPosition().z() / cm << endl;
+      cout << "       edep " << edep << endl;
+      cout << "       eion " << eion << endl;
+    }
+  
   return true;
 }
-
+				     
 //____________________________________________________________________________..
 void PHG4SiliconTrackerSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
   const string detectorname = (detector_->SuperDetector() != "NONE") ? detector_->SuperDetector() : detector_->GetName();
   const string hitnodename = "G4HIT_" + detectorname;
   const string absorbernodename = "G4HIT_ABSORBER_" + detectorname;
-
+  
   //now look for the map and grab a pointer to it.
   hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
@@ -673,4 +474,12 @@ void PHG4SiliconTrackerSteppingAction::SetInterfacePointers(PHCompositeNode* top
 
   if (!absorberhits_ && Verbosity() > 1)
     cout << "PHG4SiliconTrackerSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
+
+  const string geonodename = "CYLINDERGEOM_" + detectorname;
+  geo_ = findNode::getClass<PHG4CylinderGeomContainer>(topNode, geonodename.c_str());
+  if (!geo_)
+    {
+      std::cout << "Could not locate geometry node " << geonodename << std::endl;
+      exit(1);
+    }
 }

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.h
@@ -12,6 +12,8 @@ class PHParametersContainer;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
+class  PHG4CylinderGeomContainer;
+class PHG4CylinderGeom_Siladders;
 
 class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
 {
@@ -35,6 +37,7 @@ class PHG4SiliconTrackerSteppingAction : public PHG4SteppingAction
   PHG4HitContainer *savehitcontainer;
   PHG4Shower *saveshower;
   const PHParametersContainer *paramscontainer;
+ PHG4CylinderGeomContainer *geo_;
 
   std::map<int, int> m_InttToTrackerLayerMap;
   std::map<int, int> m_LadderTypeMap;


### PR DESCRIPTION
GEANT suffers failures at the 5% level in identifying the INTT strip volume that is associated with a G4 hit. I have made many attempts to repair this, but without complete success. I have given up, and now the simulation contains only the sensor volume as the active volume. The hit strips are assigned now in PHG4SiliconTrackerCellReco, using the G4 hit entry and exit points in the sensor and the INTT geometry object (similar to how the pixels are assigned for the MVTX).

The algorithm that assigns strips to the G4 hits is similar to the one used for the MVTX pixels, and it allows charge diffusion to be added in a convenient way. Currently I have added a small charge diffusion - it can be tweaked later when we have measurements.

These changes have been merged with the recent ones from Chris (which were made in parallel with mine). There were lots of conflicts in the stepping action and detector class. I think I resolved them correctly, but Chris should look it over.  

[geom_intt_strips_clusres.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/2342064/geom_intt_strips_clusres.pdf)
