### PR TITLE
Fix intt part 4

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
@@ -11,9 +11,6 @@
 
 #include <Geant4/globals.hh>
 
-#include <TMath.h>
-#include <TVector2.h>
-
 #include <sstream>
 
 using namespace std;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -29,7 +29,6 @@ using namespace std;
 
 PHG4SiliconTrackerCellReco::PHG4SiliconTrackerCellReco(const std::string &name)
   : SubsysReco(name)
-  , _timer(PHTimeServer::get()->insert_new(name.c_str()))
   , chkenergyconservation(0)
   , tmin_default(-20.0)  // FVTX NIM paper Fig 32, collision has a timing spread around the triggered event. Accepting negative time too.
   ,  // ns
@@ -108,8 +107,6 @@ int PHG4SiliconTrackerCellReco::InitRun(PHCompositeNode *topNode)
 
 int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
 {
-  _timer.get()->restart();
-
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hit)
   {
@@ -380,12 +377,6 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
   {
     CheckEnergy(topNode);
   }
-  _timer.get()->stop();
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int PHG4SiliconTrackerCellReco::End(PHCompositeNode *topNode)
-{
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -127,7 +127,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
   for (PHG4HitContainer::ConstIterator hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
   {
-    const int sphxlayer = hiter->second->get_layer();
+    const int sphxlayer = hiter->second->get_detid();
     PHG4CylinderGeom_Siladders *layergeom = (PHG4CylinderGeom_Siladders*) geo->GetLayerGeom(sphxlayer);
 
     // checking ADC timing integration window cut

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -260,7 +260,6 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
     gsl_vector_set(m_LocalOutVec, 1, hiter->second->get_local_y(1));
     gsl_vector_set(m_LocalOutVec, 2, hiter->second->get_local_z(1));
     gsl_vector_sub(m_PathVec, m_LocalOutVec);
-    gsl_vector *segvec = gsl_vector_alloc(3);
     for (int i = 0; i < nsegments; i++)
     {
       // Find the tracklet segment location

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -45,7 +45,7 @@ PHG4SiliconTrackerCellReco::PHG4SiliconTrackerCellReco(const std::string &name)
   m_SegmentVec = gsl_vector_alloc(3);
 }
 
-  PHG4SiliconTrackerCellReco::~PHG4SiliconTrackerCellReco()
+PHG4SiliconTrackerCellReco::~PHG4SiliconTrackerCellReco()
 {
   gsl_vector_free(m_LocalOutVec);
   gsl_vector_free(m_PathVec);
@@ -67,31 +67,31 @@ int PHG4SiliconTrackerCellReco::InitRun(PHCompositeNode *topNode)
   }
 
   PHCompositeNode *runNode;
-  runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
+  runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
   if (!runNode)
-    {
-      cout << Name() << "RUN Node missing, exiting." << endl;
-      gSystem->Exit(1);
-      exit(1);
-    }
-  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "PAR" ));
+  {
+    cout << Name() << "RUN Node missing, exiting." << endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
+  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "PAR"));
   if (!parNode)
-    {
-      cout << Name() << "PAR Node missing, exiting." << endl;
-      gSystem->Exit(1);
-      exit(1);
-    }
+  {
+    cout << Name() << "PAR Node missing, exiting." << endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
   string paramnodename = "G4CELLPARAM_" + m_Detector;
 
   PHNodeIterator runiter(runNode);
   PHCompositeNode *RunDetNode =
-    dynamic_cast<PHCompositeNode*>(runiter.findFirst("PHCompositeNode",
-						     m_Detector));
+      dynamic_cast<PHCompositeNode *>(runiter.findFirst("PHCompositeNode",
+                                                        m_Detector));
   if (!RunDetNode)
-    {
-      RunDetNode = new PHCompositeNode(m_Detector);
-      runNode->addNode(RunDetNode);
-    }
+  {
+    RunDetNode = new PHCompositeNode(m_Detector);
+    runNode->addNode(RunDetNode);
+  }
 
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, m_HitNodeName);
   if (!g4hit)
@@ -131,16 +131,16 @@ int PHG4SiliconTrackerCellReco::InitRun(PHCompositeNode *topNode)
   }
 
   UpdateParametersWithMacro();
-  SaveToNodeTree(RunDetNode,paramnodename);
+  SaveToNodeTree(RunDetNode, paramnodename);
   // save this to the parNode for use
   PHNodeIterator parIter(parNode);
-  PHCompositeNode *ParDetNode =  dynamic_cast<PHCompositeNode*>(parIter.findFirst("PHCompositeNode",m_Detector));
-  if (! ParDetNode)
-    {
-      ParDetNode = new PHCompositeNode(m_Detector);
-      parNode->addNode(ParDetNode);
-    }
-  PutOnParNode(ParDetNode,m_GeoNodeName);
+  PHCompositeNode *ParDetNode = dynamic_cast<PHCompositeNode *>(parIter.findFirst("PHCompositeNode", m_Detector));
+  if (!ParDetNode)
+  {
+    ParDetNode = new PHCompositeNode(m_Detector);
+    parNode->addNode(ParDetNode);
+  }
+  PutOnParNode(ParDetNode, m_GeoNodeName);
   m_Tmin = get_double_param("tmin");
   m_Tmax = get_double_param("tmax");
 
@@ -173,12 +173,12 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
 
   // loop over all of the layers in the hit container
   // we need the geometry object for this layer
-  if(verbosity > 2) cout << " PHG4SiliconTrackerCellReco: Loop over hits" << endl;
+  if (verbosity > 2) cout << " PHG4SiliconTrackerCellReco: Loop over hits" << endl;
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
   for (PHG4HitContainer::ConstIterator hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
   {
     const int sphxlayer = hiter->second->get_detid();
-    PHG4CylinderGeom_Siladders *layergeom = (PHG4CylinderGeom_Siladders*) geo->GetLayerGeom(sphxlayer);
+    PHG4CylinderGeom_Siladders *layergeom = (PHG4CylinderGeom_Siladders *) geo->GetLayerGeom(sphxlayer);
 
     // checking ADC timing integration window cut
     // uses default values for now
@@ -189,209 +189,213 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
       continue;
 
     // I made this (small) diffusion up for now, we will get actual values for the INTT later
-    double diffusion_width = 5.0e-04;   // diffusion radius 5 microns, in cm
+    double diffusion_width = 5.0e-04;  // diffusion radius 5 microns, in cm
 
     const int ladder_z_index = hiter->second->get_ladder_z_index();
     const int ladder_phi_index = hiter->second->get_ladder_phi_index();
 
-     // What we have is a hit in the sensor. We have not yet assigned the strip(s) that were hit, we do that here
+    // What we have is a hit in the sensor. We have not yet assigned the strip(s) that were hit, we do that here
     //========================================================================
 
-    int strip_y_index_in, strip_z_index_in, strip_y_index_out, strip_z_index_out;    
+    int strip_y_index_in, strip_z_index_in, strip_y_index_out, strip_z_index_out;
     layergeom->find_strip_index_values(ladder_z_index, hiter->second->get_local_y(0), hiter->second->get_local_z(0), strip_y_index_in, strip_z_index_in);
     layergeom->find_strip_index_values(ladder_z_index, hiter->second->get_local_y(1), hiter->second->get_local_z(1), strip_y_index_out, strip_z_index_out);
 
-    if(verbosity > 5)
-      {    
-	// check to see if we get back the positions from these strip index values
-	double check_location[3] = {-1,-1,-1};
-	layergeom->find_strip_center_localcoords(ladder_z_index, strip_y_index_in, strip_z_index_in, check_location);
-	cout << " G4 entry location = " << hiter->second->get_local_x(0) << "  " << hiter->second->get_local_y(0) << "  " << hiter->second->get_local_z(0) << endl; 
-	cout << " Check entry location = " << check_location[0] << "  " << check_location[1] << "  " << check_location[2] << endl; 
-	layergeom->find_strip_center_localcoords(ladder_z_index, strip_y_index_out, strip_z_index_out, check_location);
-	cout << " G4 exit location = " << hiter->second->get_local_x(1) << " " << hiter->second->get_local_y(1) << "  " << hiter->second->get_local_z(1) << endl; 
-	cout << " Check exit location = " << check_location[0] << "  " << check_location[1] << "  " << check_location[2] << endl; 
-      }
+    if (verbosity > 5)
+    {
+      // check to see if we get back the positions from these strip index values
+      double check_location[3] = {-1, -1, -1};
+      layergeom->find_strip_center_localcoords(ladder_z_index, strip_y_index_in, strip_z_index_in, check_location);
+      cout << " G4 entry location = " << hiter->second->get_local_x(0) << "  " << hiter->second->get_local_y(0) << "  " << hiter->second->get_local_z(0) << endl;
+      cout << " Check entry location = " << check_location[0] << "  " << check_location[1] << "  " << check_location[2] << endl;
+      layergeom->find_strip_center_localcoords(ladder_z_index, strip_y_index_out, strip_z_index_out, check_location);
+      cout << " G4 exit location = " << hiter->second->get_local_x(1) << " " << hiter->second->get_local_y(1) << "  " << hiter->second->get_local_z(1) << endl;
+      cout << " Check exit location = " << check_location[0] << "  " << check_location[1] << "  " << check_location[2] << endl;
+    }
 
     // Now we find how many strips were crossed by this track, and divide the energy between them
-    int  minstrip_z = strip_z_index_in;
+    int minstrip_z = strip_z_index_in;
     int maxstrip_z = strip_z_index_out;
-    if(minstrip_z > maxstrip_z) swap(minstrip_z, maxstrip_z);
+    if (minstrip_z > maxstrip_z) swap(minstrip_z, maxstrip_z);
 
     int minstrip_y = strip_y_index_in;
     int maxstrip_y = strip_y_index_out;
-    if(minstrip_y > maxstrip_y) swap(minstrip_y, maxstrip_y);
+    if (minstrip_y > maxstrip_y) swap(minstrip_y, maxstrip_y);
 
     // Use an algorithm similar to the one for the MVTX pixels, since it facilitates adding charge diffusion
     // for now we assume small charge diffusion
-    
+
     vector<int> vybin;
     vector<int> vzbin;
     //vector<double> vlen;
-    vector< pair <double, double> > venergy;
-    
+    vector<pair<double, double> > venergy;
+
     //====================================================
     // Beginning of charge sharing implementation
     //    Find tracklet line inside sensor
-    //    Divide tracklet line into n segments (vary n until answer stabilizes) 
+    //    Divide tracklet line into n segments (vary n until answer stabilizes)
     //    Find centroid of each segment
     //    Diffuse charge at each centroid
     //    Apportion charge between neighboring pixels
     //    Add the pixel energy contributions from different track segments together
     //====================================================
-    
+
     // skip this hit if it involves an unreasonable  number of pixels
-    // this skips it if either the xbin or ybin range traversed is greater than 8 (for 8 adding two pixels at each end makes the range 12) 
-    if(maxstrip_y - minstrip_y > 12 || maxstrip_z - minstrip_z > 12)
+    // this skips it if either the xbin or ybin range traversed is greater than 8 (for 8 adding two pixels at each end makes the range 12)
+    if (maxstrip_y - minstrip_y > 12 || maxstrip_z - minstrip_z > 12)
     {
       continue;
-    }    
+    }
     // this hit is skipped above if this dimensioning would be exceeded
-    double stripenergy[12][12] = {}; // init to 0
-    double stripeion[12][12] = {}; // init to 0
-    
+    double stripenergy[12][12] = {};  // init to 0
+    double stripeion[12][12] = {};    // init to 0
+
     int nsegments = 10;
     // Loop over track segments and diffuse charge at each segment location, collect energy in pixels
     // Get the entry point of the hit in sensor local coordinates
-    gsl_vector_set(m_PathVec, 0,  hiter->second->get_local_x(0));
-    gsl_vector_set(m_PathVec, 1,  hiter->second->get_local_y(0));
-    gsl_vector_set(m_PathVec, 2,  hiter->second->get_local_z(0));
-    gsl_vector_set(m_LocalOutVec,0, hiter->second->get_local_x(1));
-    gsl_vector_set(m_LocalOutVec,1, hiter->second->get_local_y(1));
-    gsl_vector_set(m_LocalOutVec,2, hiter->second->get_local_z(1));
+    gsl_vector_set(m_PathVec, 0, hiter->second->get_local_x(0));
+    gsl_vector_set(m_PathVec, 1, hiter->second->get_local_y(0));
+    gsl_vector_set(m_PathVec, 2, hiter->second->get_local_z(0));
+    gsl_vector_set(m_LocalOutVec, 0, hiter->second->get_local_x(1));
+    gsl_vector_set(m_LocalOutVec, 1, hiter->second->get_local_y(1));
+    gsl_vector_set(m_LocalOutVec, 2, hiter->second->get_local_z(1));
     gsl_vector_sub(m_PathVec, m_LocalOutVec);
     gsl_vector *segvec = gsl_vector_alloc(3);
-    for(int i=0;i<nsegments;i++)
+    for (int i = 0; i < nsegments; i++)
+    {
+      // Find the tracklet segment location
+      // If there are n segments of equal length, we want 2*n intervals
+      // The 1st segment is centered at interval 1, the 2nd at interval 3, the nth at interval 2n -1
+      double interval = 2 * (double) i + 1;
+      double frac = interval / (double) (2 * nsegments);
+      gsl_vector_memcpy(m_SegmentVec, m_PathVec);
+      gsl_vector_scale(m_SegmentVec, frac);
+      gsl_vector_add(m_SegmentVec, m_LocalOutVec);
+      // Caculate the charge diffusion over this drift distance
+      // increases from diffusion width_min to diffusion_width_max
+      double diffusion_radius = diffusion_width;
+
+      if (verbosity > 5)
+        cout << " segment " << i
+             << " interval " << interval
+             << " frac " << frac
+             << " local_in.X " << hiter->second->get_local_x(0)
+             << " local_in.Z " << hiter->second->get_local_z(0)
+             << " local_in.Y " << hiter->second->get_local_y(0)
+             << " pathvec.X " << gsl_vector_get(m_PathVec, 0)
+             << " pathvec.Z " << gsl_vector_get(m_PathVec, 2)
+             << " pathvec.Y " << gsl_vector_get(m_PathVec, 1)
+             << " segvec.X " << gsl_vector_get(m_SegmentVec, 0)
+             << " segvec.Z " << gsl_vector_get(m_SegmentVec, 2)
+             << " segvec.Y " << gsl_vector_get(m_SegmentVec, 1) << endl
+             << " diffusion_radius " << diffusion_radius
+             << endl;
+
+      // Now find the area of overlap of the diffusion circle with each pixel and apportion the energy
+      for (int iz = minstrip_z; iz <= maxstrip_z; iz++)
       {
-	// Find the tracklet segment location
-	// If there are n segments of equal length, we want 2*n intervals
-	// The 1st segment is centered at interval 1, the 2nd at interval 3, the nth at interval 2n -1
-	double interval = 2 * (double ) i  + 1;
-	double frac = interval / (double) (2 * nsegments);
-        gsl_vector_memcpy(m_SegmentVec,m_PathVec);
-	gsl_vector_scale(m_SegmentVec,frac);
-	gsl_vector_add(m_SegmentVec,m_LocalOutVec);
-	// Caculate the charge diffusion over this drift distance
-	// increases from diffusion width_min to diffusion_width_max 
-	double diffusion_radius = diffusion_width;   
-	
-	if(verbosity > 5)
-	  cout << " segment " << i 
-	       << " interval " << interval
-	       << " frac " << frac
-	       << " local_in.X " << hiter->second->get_local_x(0)
-	       << " local_in.Z " << hiter->second->get_local_z(0)
-	       << " local_in.Y " << hiter->second->get_local_y(0)
-	       << " pathvec.X " << gsl_vector_get(m_PathVec,0)
-	       << " pathvec.Z " << gsl_vector_get(m_PathVec,2)
-	       << " pathvec.Y " << gsl_vector_get(m_PathVec,1)
-	       << " segvec.X " << gsl_vector_get(m_SegmentVec,0)
-	       << " segvec.Z " << gsl_vector_get(m_SegmentVec,2)
-	       << " segvec.Y " << gsl_vector_get(m_SegmentVec,1) << endl
-	       << " diffusion_radius " << diffusion_radius
-	       << endl;
-	
-	// Now find the area of overlap of the diffusion circle with each pixel and apportion the energy
-	for(int iz=minstrip_z; iz <= maxstrip_z; iz++)
-	  {
-	    for(int iy = minstrip_y; iy <= maxstrip_y; iy++)
-	      {
-		// Find the pixel corners for this pixel number
-		double location[3] = {-1,-1,-1};
-		layergeom->find_strip_center_localcoords(ladder_z_index, iy, iz, location);
-		// note that (y1,z1) is the top left corner, (y2,z2) is the bottom right corner of the pixel - circle_rectangle_intersection expects this ordering		
-		double y1 = location[1] - layergeom->get_strip_y_spacing() / 2.0;
-		double y2 = location[1] + layergeom->get_strip_y_spacing() / 2.0;
-		double z1 = location[2] + layergeom->get_strip_z_spacing() / 2.0;
-		double z2 = location[2] - layergeom->get_strip_z_spacing() / 2.0;
-		
-		// here m_SegmentVec.1 (Y) and m_SegmentVec.2 (Z) are the center of the circle, and diffusion_radius is the circle radius
-		// circle_rectangle_intersection returns the overlap area of the circle and the pixel. It is very fast if there is no overlap.
-		double striparea_frac = circle_rectangle_intersection(y1, z1, y2, z2, gsl_vector_get(m_SegmentVec,1), gsl_vector_get(m_SegmentVec,2), diffusion_radius) / (M_PI * (diffusion_radius*diffusion_radius) );
-		// assume that the energy is deposited uniformly along the tracklet length, so that this segment gets the fraction 1/nsegments of the energy
-		stripenergy[iy-minstrip_y][iz-minstrip_z] += striparea_frac * hiter->second->get_edep() / (float) nsegments;
-		if (hiter->second->has_property(PHG4Hit::prop_eion))
-		  {
-		    stripeion[iy-minstrip_y][iz-minstrip_z] += striparea_frac * hiter->second->get_eion() / (float) nsegments;
-		  }
-		if(verbosity > 5)
-		  {
-		    cout << "    strip y index " << iy <<  " strip z index  " << iz
-			 << " strip area fraction of circle " << striparea_frac << " accumulated pixel energy " << stripenergy[iy-minstrip_y][iz-minstrip_z]
-			 << endl;
-		  }
-	      }
-	  }
-      }  // end loop over segments
-    // now we have the energy deposited in each pixel, summed over all tracklet segments. We make a vector of all pixels with non-zero energy deposited
-    for(int iz=minstrip_z; iz <= maxstrip_z; iz++)
-      {
-	for(int iy = minstrip_y; iy <= maxstrip_y; iy++)
-	  {
-	    if( stripenergy[iy-minstrip_y][iz-minstrip_z] > 0.0 )
-	      {	      
-		vybin.push_back(iy);
-		vzbin.push_back(iz);
-		pair <double,double> tmppair = make_pair(stripenergy[iy-minstrip_y][iz-minstrip_z],stripeion[iy-minstrip_y][iz-minstrip_z]);
-		venergy.push_back(tmppair);  	  
-		if(verbosity > 1)
-		  cout << " Added ybin " << iy << " zbin " << iz << " to vectors with energy " << stripenergy[iy-minstrip_y][iz-minstrip_z] << endl;
-	      }		    	
-	  }
+        for (int iy = minstrip_y; iy <= maxstrip_y; iy++)
+        {
+          // Find the pixel corners for this pixel number
+          double location[3] = {-1, -1, -1};
+          layergeom->find_strip_center_localcoords(ladder_z_index, iy, iz, location);
+          // note that (y1,z1) is the top left corner, (y2,z2) is the bottom right corner of the pixel - circle_rectangle_intersection expects this ordering
+          double y1 = location[1] - layergeom->get_strip_y_spacing() / 2.0;
+          double y2 = location[1] + layergeom->get_strip_y_spacing() / 2.0;
+          double z1 = location[2] + layergeom->get_strip_z_spacing() / 2.0;
+          double z2 = location[2] - layergeom->get_strip_z_spacing() / 2.0;
+
+          // here m_SegmentVec.1 (Y) and m_SegmentVec.2 (Z) are the center of the circle, and diffusion_radius is the circle radius
+          // circle_rectangle_intersection returns the overlap area of the circle and the pixel. It is very fast if there is no overlap.
+          double striparea_frac = circle_rectangle_intersection(y1, z1, y2, z2, gsl_vector_get(m_SegmentVec, 1), gsl_vector_get(m_SegmentVec, 2), diffusion_radius) / (M_PI * (diffusion_radius * diffusion_radius));
+          // assume that the energy is deposited uniformly along the tracklet length, so that this segment gets the fraction 1/nsegments of the energy
+          stripenergy[iy - minstrip_y][iz - minstrip_z] += striparea_frac * hiter->second->get_edep() / (float) nsegments;
+          if (hiter->second->has_property(PHG4Hit::prop_eion))
+          {
+            stripeion[iy - minstrip_y][iz - minstrip_z] += striparea_frac * hiter->second->get_eion() / (float) nsegments;
+          }
+          if (verbosity > 5)
+          {
+            cout << "    strip y index " << iy << " strip z index  " << iz
+                 << " strip area fraction of circle " << striparea_frac << " accumulated pixel energy " << stripenergy[iy - minstrip_y][iz - minstrip_z]
+                 << endl;
+          }
+        }
       }
-    
+    }  // end loop over segments
+    // now we have the energy deposited in each pixel, summed over all tracklet segments. We make a vector of all pixels with non-zero energy deposited
+    for (int iz = minstrip_z; iz <= maxstrip_z; iz++)
+    {
+      for (int iy = minstrip_y; iy <= maxstrip_y; iy++)
+      {
+        if (stripenergy[iy - minstrip_y][iz - minstrip_z] > 0.0)
+        {
+          vybin.push_back(iy);
+          vzbin.push_back(iz);
+          pair<double, double> tmppair = make_pair(stripenergy[iy - minstrip_y][iz - minstrip_z], stripeion[iy - minstrip_y][iz - minstrip_z]);
+          venergy.push_back(tmppair);
+          if (verbosity > 1)
+            cout << " Added ybin " << iy << " zbin " << iz << " to vectors with energy " << stripenergy[iy - minstrip_y][iz - minstrip_z] << endl;
+        }
+      }
+    }
+
     //===================================
     // End of charge sharing implementation
     //===================================
-    
+
     // Add the strips fired by this hit to the cell list
     //===============================
-    
-    for (unsigned int i1 = 0; i1 < vybin.size(); i1++)   // loop over all fired cells
+
+    for (unsigned int i1 = 0; i1 < vybin.size(); i1++)  // loop over all fired cells
+    {
+      // this string must be unique - it needs the layer too, or in high multiplicity events it will add g4 hits in different layers with the same key together
+      std::string key = (boost::format("%d-%d-%d-%d-%d") % sphxlayer % ladder_z_index % ladder_phi_index % vzbin[i1] % vybin[i1]).str();
+      PHG4Cell *cell = nullptr;
+      map<string, PHG4Cell *>::iterator it;
+
+      it = m_CellList.find(key);
+      // If there is an existing cell to add this hit to, find it
+      if (it != m_CellList.end())
       {
-	// this string must be unique - it needs the layer too, or in high multiplicity events it will add g4 hits in different layers with the same key together
-	std::string key = (boost::format("%d-%d-%d-%d-%d") % sphxlayer % ladder_z_index % ladder_phi_index % vzbin[i1] % vybin[i1]).str();
-	PHG4Cell *cell = nullptr;
-	map<string, PHG4Cell *>::iterator it;
-	
-	it = m_CellList.find(key);
-	// If there is an existing cell to add this hit to, find it    
-	if (it != m_CellList.end())
-	  {
-	    cell = it->second;
-	    if(verbosity > 2)  
-	      cout << " found existing cell with key " << key << endl;
-	  }
-	
-	// There is not an existing cell to add this hit to, start a new cell    
-	if(!cell)
-	  {
-	    if(verbosity > 2) cout << " did not find existing cell with key " << key << " start a new one" << endl;
-	    unsigned int index = m_CellList.size();
-	    index++;
-	    PHG4CellDefs::keytype cellkey = PHG4CellDefs::MapsBinning::genkey(sphxlayer, index);
-	    cell = new PHG4Cellv1(cellkey);
-	    m_CellList[key] = cell;
-	    // This encodes the z and phi position of the sensor
-	    //          m_CellList[key]->set_sensor_index((boost::format("%d_%d") %ladder_z_index %ladder_phi_index).str());
-	    
-	    cell->set_ladder_z_index(ladder_z_index);
-	    cell->set_ladder_phi_index(ladder_phi_index);
-	    
-	    // The z and phi position of the hit strip within the sensor
-	    cell->set_zbin(vzbin[i1]);
-	    cell->set_phibin(vybin[i1]);
-	  }
-	
-	// One way or another we have a cell pointer - add this hit to the cell
-	cell->add_edep(venergy[i1].first);
-	cell->add_edep(hiter->first, venergy[i1].first);  // adds the g4hit association to the cell 
-	cell->add_eion(venergy[i1].second);
+        cell = it->second;
+        if (verbosity > 2)
+        {
+          cout << " found existing cell with key " << key << endl;
+        }
       }
+
+      // There is not an existing cell to add this hit to, start a new cell
+      if (!cell)
+      {
+        if (verbosity > 2)
+        {
+          cout << " did not find existing cell with key " << key << " start a new one" << endl;
+        }
+        unsigned int index = m_CellList.size();
+        index++;
+        PHG4CellDefs::keytype cellkey = PHG4CellDefs::MapsBinning::genkey(sphxlayer, index);
+        cell = new PHG4Cellv1(cellkey);
+        m_CellList[key] = cell;
+        // This encodes the z and phi position of the sensor
+        //          m_CellList[key]->set_sensor_index((boost::format("%d_%d") %ladder_z_index %ladder_phi_index).str());
+
+        cell->set_ladder_z_index(ladder_z_index);
+        cell->set_ladder_phi_index(ladder_phi_index);
+
+        // The z and phi position of the hit strip within the sensor
+        cell->set_zbin(vzbin[i1]);
+        cell->set_phibin(vybin[i1]);
+      }
+
+      // One way or another we have a cell pointer - add this hit to the cell
+      cell->add_edep(venergy[i1].first);
+      cell->add_edep(hiter->first, venergy[i1].first);  // adds the g4hit association to the cell
+      cell->add_eion(venergy[i1].second);
+    }
 
   }  // end loop over g4hits
 
-  
   int numcells = 0;
   for (std::map<std::string, PHG4Cell *>::const_iterator mapiter = m_CellList.begin(); mapiter != m_CellList.end(); ++mapiter)
   {
@@ -399,19 +403,19 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
     numcells++;
 
     if (verbosity > 0)
-      {
-	std::cout << "Adding cell for "
-		  << " layer " << mapiter->second->get_layer()
-		  << " ladder z index: " << mapiter->second->get_ladder_z_index()
-		  << ", ladder phi index: " << mapiter->second->get_ladder_phi_index()
-		  << ", srip z: " << mapiter->second->get_zbin()
-		  << ", strip y: " << mapiter->second->get_phibin()
-		  << ", energy dep: " << mapiter->second->get_edep()
-		  << std::endl;
-      }
+    {
+      std::cout << "Adding cell for "
+                << " layer " << mapiter->second->get_layer()
+                << " ladder z index: " << mapiter->second->get_ladder_z_index()
+                << ", ladder phi index: " << mapiter->second->get_ladder_phi_index()
+                << ", srip z: " << mapiter->second->get_zbin()
+                << ", strip y: " << mapiter->second->get_phibin()
+                << ", energy dep: " << mapiter->second->get_edep()
+                << std::endl;
+    }
   }
   m_CellList.clear();
-  
+
   if (verbosity > 0)
     std::cout << Name() << ": found " << numcells << " silicon strips with energy deposition" << std::endl;
 
@@ -432,13 +436,16 @@ int PHG4SiliconTrackerCellReco::CheckEnergy(PHCompositeNode *topNode)
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
   PHG4HitContainer::ConstIterator hiter;
   for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
+  {
     sum_energy_g4hit += hiter->second->get_edep();
+  }
 
   PHG4CellContainer::ConstRange cell_begin_end = cells->getCells();
   PHG4CellContainer::ConstIterator citer;
   for (citer = cell_begin_end.first; citer != cell_begin_end.second; ++citer)
+  {
     sum_energy_cells += citer->second->get_edep();
-
+  }
   // the fractional eloss for particles traversing eta bins leads to minute rounding errors
   if (fabs(sum_energy_cells - sum_energy_g4hit) / sum_energy_g4hit > 1e-6)
   {
@@ -452,37 +459,38 @@ int PHG4SiliconTrackerCellReco::CheckEnergy(PHCompositeNode *topNode)
   else
   {
     if (verbosity > 0)
+    {
       std::cout << Name() << ": total energy for this event: " << sum_energy_g4hit << " GeV" << std::endl;
+    }
   }
   return 0;
 }
 
-double  PHG4SiliconTrackerCellReco::circle_rectangle_intersection( double x1, double y1,  double x2,  double y2,  double mx,  double my,  double r ) const
+double PHG4SiliconTrackerCellReco::circle_rectangle_intersection(double x1, double y1, double x2, double y2, double mx, double my, double r) const
 {
-  // Find the area of overlap of a circle and rectangle 
+  // Find the area of overlap of a circle and rectangle
   // Calls sA, which uses an analytic formula to determine the integral of the circle between limits set by the corners of the rectangle
 
   // move the rectangle to the frame where the circle is at (0,0)
-  x1 -= mx; 
-  x2 -= mx; 
-  y1 -= my; 
+  x1 -= mx;
+  x2 -= mx;
+  y1 -= my;
   y2 -= my;
 
-  if(verbosity > 7)
-    {
-      cout << " mx " << mx << " my " << my << " r " << r << " x1 " << x1 << " x2 " << x2 << " y1 " << y1 << " y2 " << y2 << endl;
-      cout << " sA21 " << sA(r,x2,y1)
-	   << " sA11 " << sA(r,x1,y1)
-	   << " sA22 " << sA(r,x2,y2)
-	   << " sA12 " << sA(r,x1,y2)
-	   << endl;
-    }
+  if (verbosity > 7)
+  {
+    cout << " mx " << mx << " my " << my << " r " << r << " x1 " << x1 << " x2 " << x2 << " y1 " << y1 << " y2 " << y2 << endl;
+    cout << " sA21 " << sA(r, x2, y1)
+         << " sA11 " << sA(r, x1, y1)
+         << " sA22 " << sA(r, x2, y2)
+         << " sA12 " << sA(r, x1, y2)
+         << endl;
+  }
 
   return sA(r, x2, y1) - sA(r, x1, y1) - sA(r, x2, y2) + sA(r, x1, y2);
-  
 }
 
-double  PHG4SiliconTrackerCellReco::sA(double r, double x, double y) const
+double PHG4SiliconTrackerCellReco::sA(double r, double x, double y) const
 {
   // Uses analytic formula for the integral of a circle between limits set by the corner of a rectangle
   // It is called repeatedly to find the overlap area between the circle and rectangle
@@ -492,49 +500,46 @@ double  PHG4SiliconTrackerCellReco::sA(double r, double x, double y) const
 
   double a;
 
-  if (x < 0) 
-    {
-      return -sA(r, -x, y);
-    }
-  
-	if (y < 0) 
-	  {
-	    return -sA(r, x, -y);
-	  }
+  if (x < 0)
+  {
+    return -sA(r, -x, y);
+  }
 
-	if (x > r) 
-	  {
-	    x = r;
-	  }
-	
-	if (y > r) 
-	  {
-	    y = r;
-	  }
-	
-	if (x*x + y*y > r*r) 
-	  {
-	    a = r*r*asin(x/r) + x*sqrt(r*r-x*x)
-	      + r*r*asin(y/r) + y*sqrt(r*r-y*y)
-	      - r*r*M_PI_2;
-	    
-	    a *= 0.5;
-	  } 
-	else 
-	  {
-	    a = x*y;
-	  }
-	
-	return a;
+  if (y < 0)
+  {
+    return -sA(r, x, -y);
+  }
+
+  if (x > r)
+  {
+    x = r;
+  }
+
+  if (y > r)
+  {
+    y = r;
+  }
+
+  if (x * x + y * y > r * r)
+  {
+    a = r * r * asin(x / r) + x * sqrt(r * r - x * x) + r * r * asin(y / r) + y * sqrt(r * r - y * y) - r * r * M_PI_2;
+
+    a *= 0.5;
+  }
+  else
+  {
+    a = x * y;
+  }
+
+  return a;
 }
 
-void
-PHG4SiliconTrackerCellReco::SetDefaultParameters()
+void PHG4SiliconTrackerCellReco::SetDefaultParameters()
 {
-// if we ever need separate timing windows, don't patch around here!
-// use PHParameterContainerInterface which
-// provides for multiple layers/detector types
-  set_default_double_param("tmax",80.0);  // FVTX NIM paper Fig 32
-  set_default_double_param("tmin",-20.0); // FVTX NIM paper Fig 32, collision has a timing spread around the triggered event. Accepting negative time too.
+  // if we ever need separate timing windows, don't patch around here!
+  // use PHParameterContainerInterface which
+  // provides for multiple layers/detector types
+  set_default_double_param("tmax", 80.0);   // FVTX NIM paper Fig 32
+  set_default_double_param("tmin", -20.0);  // FVTX NIM paper Fig 32, collision has a timing spread around the triggered event. Accepting negative time too.
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -148,6 +148,17 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
     //========================================================================
 
     // Get the entry point of the hit in sensor local coordinates
+    gsl_vector *in_local = gsl_vector_alloc (3);
+    gsl_vector_set(in_local, 0,  hiter->second->get_local_x(0));
+    gsl_vector_set(in_local, 1,  hiter->second->get_local_y(0));
+    gsl_vector_set(in_local, 2,  hiter->second->get_local_z(0));
+    gsl_vector *out_local = gsl_vector_alloc (3);
+    gsl_vector_set(out_local,0, hiter->second->get_local_x(1));
+    gsl_vector_set(out_local,1, hiter->second->get_local_y(1));
+    gsl_vector_set(out_local,2, hiter->second->get_local_z(1));
+gsl_vector *path_vec = gsl_vector_alloc (3);
+gsl_vector_memcpy(path_vec, in_local);
+gsl_vector_sub(path_vec, out_local);
     TVector3 local_in( hiter->second->get_local_x(0),  hiter->second->get_local_y(0),  hiter->second->get_local_z(0) );
     TVector3 local_out( hiter->second->get_local_x(1),  hiter->second->get_local_y(1),  hiter->second->get_local_z(1) );
     TVector3 pathvec = local_in - local_out;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
@@ -9,9 +9,7 @@
 #include <gsl/gsl_vector.h>
 #endif
 
-#include <map>
 #include <string>
-#include <vector>
 
 class PHCompositeNode;
 class PHG4Cell;
@@ -31,25 +29,25 @@ class PHG4SiliconTrackerCellReco : public SubsysReco, public PHParameterInterfac
   //! set default parameter values
   void SetDefaultParameters();
 
-  void Detector(const std::string &d) { detector = d; }
-  void checkenergy(const int i = 1) { chkenergyconservation = i; }
+  void Detector(const std::string &d) { m_Detector = d; }
+  void checkenergy(const int i = 1) { m_ChkEnergyConservationFlag = i; }
 
-  double circle_rectangle_intersection(double x1, double y1,  double x2,  double y2,  double mx, double my,  double r);
-  double sA(double r, double x, double y) ;
+  double circle_rectangle_intersection(double x1, double y1,  double x2,  double y2,  double mx, double my,  double r) const;
+  double sA(double r, double x, double y) const;
   
  protected:
   int CheckEnergy(PHCompositeNode *topNode);
-  std::map<int, int> binning;
-  std::string detector;
-  std::string hitnodename;
-  std::string cellnodename;
-  std::string geonodename;
-  int nbins[2];
-  int chkenergyconservation;
-  std::map<std::string, PHG4Cell *> celllist;  // This map holds the hit cells
+  std::string m_Detector;
+  std::string m_HitNodeName;
+  std::string m_CellNodeName;
+  std::string m_GeoNodeName;
+
+  int m_ChkEnergyConservationFlag;
+  std::map<std::string, PHG4Cell *> m_CellList;  // This map holds the hit cells
 
   double m_Tmin;
   double m_Tmax;
+
 #ifndef __CINT__
   gsl_vector *m_LocalOutVec;
   gsl_vector *m_PathVec;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
@@ -1,6 +1,8 @@
 #ifndef PHG4SILICONTRACKERCELLRECO_H
 #define PHG4SILICONTRACKERCELLRECO_H
 
+#include <phparameter/PHParameterInterface.h>
+
 #include <fun4all/SubsysReco.h>
 
 #ifndef __CINT__
@@ -14,7 +16,7 @@
 class PHCompositeNode;
 class PHG4Cell;
 
-class PHG4SiliconTrackerCellReco : public SubsysReco
+class PHG4SiliconTrackerCellReco : public SubsysReco, public PHParameterInterface
 {
  public:
   PHG4SiliconTrackerCellReco(const std::string &name = "SILICON_TRACKER");
@@ -26,19 +28,11 @@ class PHG4SiliconTrackerCellReco : public SubsysReco
   //! event processing
   int process_event(PHCompositeNode *topNode);
 
+  //! set default parameter values
+  void SetDefaultParameters();
+
   void Detector(const std::string &d) { detector = d; }
   void checkenergy(const int i = 1) { chkenergyconservation = i; }
-  double get_timing_window_min(const int i) { return tmin_max[i].first; }
-  double get_timing_window_max(const int i) { return tmin_max[i].second; }
-  void set_timing_window(const int i, const double tmin, const double tmax)
-  {
-    tmin_max[i] = std::make_pair(tmin, tmax);
-  }
-  void set_timing_window_defaults(const double tmin, const double tmax)
-  {
-    tmin_default = tmin;
-    tmax_default = tmax;
-  }
 
   double circle_rectangle_intersection(double x1, double y1,  double x2,  double y2,  double mx, double my,  double r);
   double sA(double r, double x, double y) ;
@@ -54,9 +48,8 @@ class PHG4SiliconTrackerCellReco : public SubsysReco
   int chkenergyconservation;
   std::map<std::string, PHG4Cell *> celllist;  // This map holds the hit cells
 
-  double tmin_default;
-  double tmax_default;
-  std::map<int, std::pair<double, double> > tmin_max;
+  double m_Tmin;
+  double m_Tmax;
 #ifndef __CINT__
   gsl_vector *m_LocalOutVec;
   gsl_vector *m_PathVec;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
@@ -3,6 +3,11 @@
 
 #include <fun4all/SubsysReco.h>
 #include <phool/PHTimeServer.h>
+
+#ifndef __CINT__
+#include <gsl/gsl_vector.h>
+#endif
+
 #include <map>
 #include <string>
 #include <vector>
@@ -15,7 +20,7 @@ class PHG4SiliconTrackerCellReco : public SubsysReco
  public:
   PHG4SiliconTrackerCellReco(const std::string &name = "SILICON_TRACKER");
 
-  virtual ~PHG4SiliconTrackerCellReco() {}
+  virtual ~PHG4SiliconTrackerCellReco();
   //! module initialization
   int InitRun(PHCompositeNode *topNode);
 
@@ -57,6 +62,11 @@ class PHG4SiliconTrackerCellReco : public SubsysReco
   double tmin_default;
   double tmax_default;
   std::map<int, std::pair<double, double> > tmin_max;
+#ifndef __CINT__
+  gsl_vector *m_LocalOutVec;
+  gsl_vector *m_PathVec;
+  gsl_vector *m_SegmentVec;
+#endif
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
@@ -2,7 +2,6 @@
 #define PHG4SILICONTRACKERCELLRECO_H
 
 #include <fun4all/SubsysReco.h>
-#include <phool/PHTimeServer.h>
 
 #ifndef __CINT__
 #include <gsl/gsl_vector.h>
@@ -26,9 +25,6 @@ class PHG4SiliconTrackerCellReco : public SubsysReco
 
   //! event processing
   int process_event(PHCompositeNode *topNode);
-
-  //! end of process
-  int End(PHCompositeNode *topNode);
 
   void Detector(const std::string &d) { detector = d; }
   void checkenergy(const int i = 1) { chkenergyconservation = i; }
@@ -54,7 +50,6 @@ class PHG4SiliconTrackerCellReco : public SubsysReco
   std::string hitnodename;
   std::string cellnodename;
   std::string geonodename;
-  PHTimeServer::timer _timer;
   int nbins[2];
   int chkenergyconservation;
   std::map<std::string, PHG4Cell *> celllist;  // This map holds the hit cells

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
@@ -1,5 +1,7 @@
-#ifndef PHG4SILICONTRACKERCELLRECO_H
-#define PHG4SILICONTRACKERCELLRECO_H
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4SILICONTRACKERCELLRECO_H
+#define G4DETECTORS_PHG4SILICONTRACKERCELLRECO_H
 
 #include <phparameter/PHParameterInterface.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.h
@@ -32,9 +32,9 @@ class PHG4SiliconTrackerCellReco : public SubsysReco, public PHParameterInterfac
   void Detector(const std::string &d) { m_Detector = d; }
   void checkenergy(const int i = 1) { m_ChkEnergyConservationFlag = i; }
 
-  double circle_rectangle_intersection(double x1, double y1,  double x2,  double y2,  double mx, double my,  double r) const;
+  double circle_rectangle_intersection(double x1, double y1, double x2, double y2, double mx, double my, double r) const;
   double sA(double r, double x, double y) const;
-  
+
  protected:
   int CheckEnergy(PHCompositeNode *topNode);
   std::string m_Detector;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -175,10 +175,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       {
         m_ActiveLogVols.insert(siactive_volume);
       }
-      G4VisAttributes *siactive_vis = new G4VisAttributes();
-      siactive_vis->SetVisibility(true);
-      siactive_vis->SetForceSolid(true);
-      siactive_vis->SetColour(G4Colour::White());
+      G4VisAttributes siactive_vis;
+      siactive_vis.SetVisibility(true);
+      siactive_vis.SetForceSolid(true);
+      siactive_vis.SetColour(G4Colour::White());
       siactive_volume->SetVisAttributes(siactive_vis);
 
       // We do not subdivide the sensor in G4. We will assign hits to strips in the stepping action, using the geometry object
@@ -199,10 +199,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       {
         m_PassiveVolumeTuple.insert(make_pair(siinactive_volume, make_tuple(inttlayer, PHG4SiliconTrackerDefs::SI_INACTIVE)));
       }
-      G4VisAttributes *siinactive_vis = new G4VisAttributes();
-      siinactive_vis->SetVisibility(true);
-      siinactive_vis->SetForceSolid(true);
-      siinactive_vis->SetColour(G4Colour::Red());
+      G4VisAttributes siinactive_vis;
+      siinactive_vis.SetVisibility(true);
+      siinactive_vis.SetForceSolid(true);
+      siinactive_vis.SetColour(G4Colour::Red());
       siinactive_volume->SetVisAttributes(siinactive_vis);
 
       // Make the HDI Kapton and copper volumes
@@ -243,16 +243,16 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       {
         m_PassiveVolumeTuple.insert(make_pair(hdiext_copper_volume, make_tuple(inttlayer, PHG4SiliconTrackerDefs::HDIEXT_COPPER)));
       }
-      G4VisAttributes *hdi_kapton_vis = new G4VisAttributes();
-      hdi_kapton_vis->SetVisibility(true);
-      hdi_kapton_vis->SetForceSolid(true);
-      hdi_kapton_vis->SetColour(G4Colour::Yellow());
+      G4VisAttributes hdi_kapton_vis;
+      hdi_kapton_vis.SetVisibility(true);
+      hdi_kapton_vis.SetForceSolid(true);
+      hdi_kapton_vis.SetColour(G4Colour::Yellow());
       hdi_kapton_volume->SetVisAttributes(hdi_kapton_vis);
       hdiext_kapton_volume->SetVisAttributes(hdi_kapton_vis);
-      G4VisAttributes *hdi_copper_vis = new G4VisAttributes();
-      hdi_copper_vis->SetVisibility(true);
-      hdi_copper_vis->SetForceSolid(true);
-      hdi_copper_vis->SetColour(G4Colour::White());
+      G4VisAttributes hdi_copper_vis;
+      hdi_copper_vis.SetVisibility(true);
+      hdi_copper_vis.SetForceSolid(true);
+      hdi_copper_vis.SetColour(G4Colour::White());
       hdi_copper_volume->SetVisAttributes(hdi_copper_vis);
       hdiext_copper_volume->SetVisAttributes(hdi_copper_vis);
 
@@ -265,10 +265,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
         m_PassiveVolumeTuple.insert(make_pair(fphx_volume, make_tuple(inttlayer, PHG4SiliconTrackerDefs::FPHX)));
       }
 
-      G4VisAttributes *fphx_vis = new G4VisAttributes();
-      fphx_vis->SetVisibility(true);
-      fphx_vis->SetForceSolid(true);
-      fphx_vis->SetColour(G4Colour::Blue());
+      G4VisAttributes fphx_vis;
+      fphx_vis.SetVisibility(true);
+      fphx_vis.SetForceSolid(true);
+      fphx_vis.SetColour(G4Colour::Blue());
       fphx_volume->SetVisAttributes(fphx_vis);
 
       const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx");
@@ -330,10 +330,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       {
         m_PassiveVolumeTuple.insert(make_pair(pgsext_volume, make_tuple(inttlayer, PHG4SiliconTrackerDefs::PGSEXT)));
       }
-      G4VisAttributes *pgs_vis = new G4VisAttributes();
-      pgs_vis->SetVisibility(true);
-      pgs_vis->SetForceSolid(true);
-      pgs_vis->SetColour(G4Colour::Red());
+      G4VisAttributes pgs_vis;
+      pgs_vis.SetVisibility(true);
+      pgs_vis.SetForceSolid(true);
+      pgs_vis.SetColour(G4Colour::Red());
       pgs_volume->SetVisAttributes(pgs_vis);
       pgsext_volume->SetVisAttributes(pgs_vis);
 
@@ -380,10 +380,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
         {
           m_PassiveVolumeTuple.insert(make_pair(stave_curve_ext_volume[i], make_tuple(inttlayer, PHG4SiliconTrackerDefs::STAVEEXT_CURVE)));
         }
-        G4VisAttributes *stave_curve_vis = new G4VisAttributes();
-        stave_curve_vis->SetVisibility(true);
-        stave_curve_vis->SetForceSolid(true);
-        stave_curve_vis->SetColour(G4Colour::White());
+        G4VisAttributes stave_curve_vis;
+        stave_curve_vis.SetVisibility(true);
+        stave_curve_vis.SetForceSolid(true);
+        stave_curve_vis.SetColour(G4Colour::White());
         stave_curve_volume[i]->SetVisAttributes(stave_curve_vis);
         stave_curve_ext_volume[i]->SetVisAttributes(stave_curve_vis);
       }
@@ -445,10 +445,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       {
         m_PassiveVolumeTuple.insert(make_pair(stave_straight_cooler_ext_volume, make_tuple(inttlayer, PHG4SiliconTrackerDefs::STAVEEXT_STRAIGHT_COOLER)));
       }
-      G4VisAttributes *stave_vis = new G4VisAttributes();
-      stave_vis->SetVisibility(true);
-      stave_vis->SetForceSolid(true);
-      stave_vis->SetColour(G4Colour::White());
+      G4VisAttributes stave_vis;
+      stave_vis.SetVisibility(true);
+      stave_vis.SetForceSolid(true);
+      stave_vis.SetColour(G4Colour::White());
       stave_straight_cooler_volume->SetVisAttributes(stave_vis);
       stave_straight_cooler_ext_volume->SetVisAttributes(stave_vis);
       if (laddertype == PHG4SiliconTrackerDefs::SEGMENTATION_PHI)
@@ -475,9 +475,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4VSolid *staveext_box = new G4Box((boost::format("staveext_box_%d_%d") % inttlayer % itype).str(), stave_x / 2., stave_y / 2., hdiext_z / 2.);
       G4LogicalVolume *staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"),
                                                              (boost::format("staveext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      G4VisAttributes *stave_box_vis = new G4VisAttributes();
-      stave_box_vis->SetVisibility(false);
-      stave_box_vis->SetForceSolid(false);
+      G4VisAttributes stave_box_vis;
+      stave_box_vis.SetVisibility(false);
+      stave_box_vis.SetForceSolid(false);
       stave_volume->SetVisAttributes(stave_box_vis);
       staveext_volume->SetVisAttributes(stave_box_vis);
 
@@ -653,10 +653,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       G4VSolid *ladderext_box = new G4Box((boost::format("ladderext_box_%d_%s") % inttlayer % itype).str(), ladder_x / 2., ladder_y / 2., hdiext_z / 2.);
       G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), (boost::format("ladderext_%d_%d_%d") % inttlayer % inttlayer % itype).str(), 0, 0, 0);
 
-      G4VisAttributes *ladder_vis = new G4VisAttributes();
-      ladder_vis->SetVisibility(false);
-      ladder_vis->SetForceSolid(false);
-      ladder_vis->SetColour(G4Colour::Cyan());
+      G4VisAttributes ladder_vis;
+      ladder_vis.SetVisibility(false);
+      ladder_vis.SetForceSolid(false);
+      ladder_vis.SetColour(G4Colour::Cyan());
       ladder_volume->SetVisAttributes(ladder_vis);
       ladderext_volume->SetVisAttributes(ladder_vis);
 
@@ -752,13 +752,15 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
         const double posx = radius * cos(phi);
         const double posy = radius * sin(phi);
         const double fRotate = phi + offsetrot;  // no initial rotation, since we assembled the ladder in phi = 0 orientation
-        G4RotationMatrix *ladderrotation = new G4RotationMatrix();
-        ladderrotation->rotateZ(fRotate);
+        // G4RotationMatrix *ladderrotation = new G4RotationMatrix();
+        // ladderrotation->rotateZ(fRotate);
+        G4RotationMatrix ladderrotation;
+        ladderrotation.rotateZ(fRotate);
 
         // place the copy at its ladder phi value, and at positive (2) and negative (1) Z
-        auto pointer_negz = new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, -m_PosZ[inttlayer][itype])), ladder_volume,
+        auto pointer_negz = new G4PVPlacement(G4Transform3D(ladderrotation, G4ThreeVector(posx, posy, -m_PosZ[inttlayer][itype])), ladder_volume,
                                               (boost::format("ladder_%d_%d_%d_negz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
-        auto pointer_posz = new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, +m_PosZ[inttlayer][itype])), ladder_volume,
+        auto pointer_posz = new G4PVPlacement(G4Transform3D(ladderrotation, G4ThreeVector(posx, posy, +m_PosZ[inttlayer][itype])), ladder_volume,
                                               (boost::format("ladder_%d_%d_%d_posz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
         if (m_IsActiveMap.find(inttlayer) != m_IsActiveMap.end())
         {
@@ -771,9 +773,9 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
           // We have added the outer sensor above, now we add the HDI extension tab to the end of the outer sensor HDI
           const double posz_ext = (hdi_z_arr[inttlayer][0] + hdi_z) + hdiext_z / 2.;
 
-          new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, -posz_ext)), ladderext_volume,
+          new G4PVPlacement(G4Transform3D(ladderrotation, G4ThreeVector(posx, posy, -posz_ext)), ladderext_volume,
                             (boost::format("ladderext_%d_%d_%d_negz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
-          new G4PVPlacement(G4Transform3D(*ladderrotation, G4ThreeVector(posx, posy, +posz_ext)), ladderext_volume,
+          new G4PVPlacement(G4Transform3D(ladderrotation, G4ThreeVector(posx, posy, +posz_ext)), ladderext_volume,
                             (boost::format("ladderext_%d_%d_%d_posz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
         }
 
@@ -812,10 +814,10 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
   {
     m_PassiveVolumeTuple.insert(make_pair(rail_volume, make_tuple(PHG4SiliconTrackerDefs::SUPPORT_DETID, PHG4SiliconTrackerDefs::SUPPORT_RAIL)));
   }
-  G4VisAttributes *rail_vis = new G4VisAttributes();
-  rail_vis->SetVisibility(true);
-  rail_vis->SetForceSolid(true);
-  rail_vis->SetColour(G4Colour::Cyan());
+  G4VisAttributes rail_vis;
+  rail_vis.SetVisibility(true);
+  rail_vis.SetForceSolid(true);
+  rail_vis.SetColour(G4Colour::Cyan());
   rail_volume->SetVisAttributes(rail_vis);
 
   double rail_dphi = M_PI / 3.0;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -63,9 +63,9 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
 
   int m_IsSupportActive;
 
+  double m_PosZ[4][2];
   double m_SensorRadiusInner[4];
   double m_SensorRadiusOuter[4];
-  double m_PosZ[4][2];
   double m_StripOffsetX[4];
 
   std::set<G4LogicalVolume *> m_ActiveLogVols;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerParameterisation.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerParameterisation.cc
@@ -3,39 +3,6 @@
 #include <Geant4/G4ThreeVector.hh>
 #include <Geant4/G4VPhysicalVolume.hh>
 
-PHG4SiliconTrackerStripParameterisation::PHG4SiliconTrackerStripParameterisation(const unsigned int ny, const unsigned int nz, const double dy, const double dz)
-{
-  const double offsety = ny * dy * 0.5;
-  const double offsetz = nz * dz * 0.5;
- 
-  int icopy = 0;
-  for (unsigned int iy = 0; iy < ny; iy++)
-    for (unsigned int iz = 0; iz < nz; iz++)
-    {
-      fXStrip[icopy] = 0.0;
-      fYStrip[icopy] = (iy + 0.5) * dy - offsety;
-      fZStrip[icopy] = (iz + 0.5) * dz - offsetz;
-
-      /*
-	std::cout << "      icopy " << icopy
-		  << " iy " << iy << " iz " << iz
-		  << " offsety " << offsety
-		  << " offsetz " << offsetz
-		  << " fXStrip[icopy] " << fXStrip[icopy]
-		  << " fYStrip[icopy] " << fYStrip[icopy]
-		  << " fZStrip[icopy] " << fZStrip[icopy]
-		  << std::endl;
-      */
-
-      icopy++;
-    }
-}
-
-void PHG4SiliconTrackerStripParameterisation::ComputeTransformation(const G4int icopy, G4VPhysicalVolume *physVol) const
-{
-  physVol->SetTranslation(G4ThreeVector(fXStrip[icopy], fYStrip[icopy], fZStrip[icopy]));
-}
-
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 PHG4SiliconTrackerFPHXParameterisation::PHG4SiliconTrackerFPHXParameterisation(const double offsetx, const double offsety, const double offsetz, const double dz, const int ncopy)

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerParameterisation.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerParameterisation.h
@@ -1,26 +1,11 @@
-#ifndef PHG4SiliconTrackerParameterisation_H
-#define PHG4SiliconTrackerParameterisation_H 1
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4SILICONTRACKERPARAMETERISATION_H
+#define G4DETECTORS_PHG4SILICONTRACKERPARAMETERISATION_H
 
 #include <Geant4/G4VPVParameterisation.hh>
-#include <Geant4/globals.hh>
 
 class G4VPhysicalVolume;
-
-/*
- * Strip location
- */
-class PHG4SiliconTrackerStripParameterisation : public G4VPVParameterisation
-{
- public:
-  PHG4SiliconTrackerStripParameterisation(const unsigned int ny, const unsigned int nz, const double dy, const double dz);
-  virtual ~PHG4SiliconTrackerStripParameterisation() {}
-  virtual void ComputeTransformation(const G4int icopy, G4VPhysicalVolume *physVol) const;
-
- private:
-  G4double fXStrip[128 * 2 * 8];
-  G4double fYStrip[128 * 2 * 8];
-  G4double fZStrip[128 * 2 * 8];
-};
 
 /*
  * FPHX location

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -208,8 +208,6 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
 
     if (whichactive > 0)
     {
-      m_Hit->set_strip_z_index(-1);  // N/A
-      m_Hit->set_strip_y_index(-1);  // N/A
       m_Hit->set_ladder_phi_index(ladderphi);
       m_Hit->set_px(0, prePoint->GetMomentum().x() / GeV);
       m_Hit->set_py(0, prePoint->GetMomentum().y() / GeV);

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -200,8 +200,6 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       m_Hit = new PHG4Hitv1();
     }
 
-    m_Hit->set_layer((unsigned int) sphxlayer);
-
     // set the index values needed to locate the sensor strip
     if (zposneg == 1) ladderz += 2;  // ladderz = 0, 1 for negative z and = 2, 3 for positive z
     m_Hit->set_ladder_z_index(ladderz);


### PR DESCRIPTION
Removal of 3 unused variables. The layer id is coded into the hit id, the access is way faster than going via the property map, the method is set/get_detid() to get rid of this layer number since it can be used for subdetectors as well. Replace TVectors by gsl vectors (TVectors should not be used since they use TMath internally which involves the pathetic TMath suppression of invalid values). Use PHParameter interface to store/retrieve/set tmin/tmax, fix memory leaks by use of new G4Visattribute and new G4RotationMatrix (the logical volumes copy this, which leaves the memory dangling).
No changes for the resulting Cells