### PR TITLE
Boundary condition checks on 3-D field map module

### DIFF
--- a/offline/packages/PHField/PHField3DCylindrical.cc
+++ b/offline/packages/PHField/PHField3DCylindrical.cc
@@ -5,6 +5,7 @@
 #include <TNtuple.h>
 
 #include <set>
+#include <cassert>
 
 using namespace std;
 using namespace CLHEP;  // units
@@ -274,7 +275,20 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
   if (verb_ > 2)
     cout << "GetFieldCyl@ <z,r,phi>: {" << z << "," << r << "," << phi << "}" << endl;
 
-  if (z < z_map_[0] || z > z_map_[z_map_.size() - 1])
+  if (z <= z_map_[0] || z >= z_map_[z_map_.size() - 1])
+  {
+    if (verb_ > 2)
+      cout << "!!!! Point not in defined region (|z| too large)" << endl;
+    return;
+  }
+  if (r < r_map_[0])
+  {
+    r = r_map_[0];
+    if (verb_ > 2)
+      cout << "!!!! Point not in defined region (radius too small in specific z-plane). Use min radius" << endl;
+//    return;
+  }
+  if ( r > r_map_[r_map_.size() - 1])
   {
     if (verb_ > 2)
       cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << endl;
@@ -284,6 +298,11 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
   vector<float>::const_iterator ziter = upper_bound(z_map_.begin(), z_map_.end(), z);
   unsigned int z_index0 = distance(z_map_.begin(), ziter) - 1;
   unsigned int z_index1 = z_index0 + 1;
+
+  assert(z_index0>=0);
+  assert(z_index1>=0);
+  assert(z_index0<z_map_.size());
+  assert(z_index1<z_map_.size());
 
   vector<float>::const_iterator riter = upper_bound(r_map_.begin(), r_map_.end(), r);
   unsigned int r_index0 = distance(r_map_.begin(), riter) - 1;
@@ -302,11 +321,18 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
     return;
   }
 
+  assert(r_index0>=0);
+  assert(r_index1>=0);
+
   vector<float>::const_iterator phiiter = upper_bound(phi_map_.begin(), phi_map_.end(), phi);
   unsigned int phi_index0 = distance(phi_map_.begin(), phiiter) - 1;
   unsigned int phi_index1 = phi_index0 + 1;
   if (phi_index1 >= phi_map_.size())
     phi_index1 = 0;
+
+  assert(phi_index0>=0);
+  assert(phi_index0<phi_map_.size());
+  assert(phi_index1>=0);
 
   double Br000 = BFieldR_[z_index0][r_index0][phi_index0];
   double Br001 = BFieldR_[z_index0][r_index0][phi_index1];


### PR DESCRIPTION
Fixing the z-boundary limit and adding additional phi- and r- boundary checks in the 3-D field map module `PHField3DCylindrical`. Current code segfaults at z=field map boundary. 