### PR TITLE
double params from macro were not propagated

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -295,17 +295,17 @@ void PHG4DetectorGroupSubsystem::UpdateParametersWithMacro()
   map<int, map<const std::string, double>>::const_iterator iter;
   for (iter = dparams.begin(); iter != dparams.end(); ++iter)
   {
+    PHParameters *params = GetParamsContainer()->GetParametersToModify(iter->first);
     map<const std::string, double>::const_iterator diter;
     for (diter = iter->second.begin(); diter != iter->second.end(); ++diter)
     {
-      set_double_param(iter->first, diter->first, diter->second);
+      params->set_double_param(diter->first, diter->second);
     }
   }
   map<int, map<const std::string, int>>::const_iterator iiter;
   for (iiter = iparams.begin(); iiter != iparams.end(); ++iiter)
   {
     PHParameters *params = GetParamsContainer()->GetParametersToModify(iiter->first);
-
     map<const std::string, int>::const_iterator iiter2;
     for (iiter2 = iiter->second.begin(); iiter2 != iiter->second.end(); ++iiter2)
     {
@@ -315,10 +315,11 @@ void PHG4DetectorGroupSubsystem::UpdateParametersWithMacro()
   map<int, map<const std::string, string>>::const_iterator siter;
   for (siter = cparams.begin(); siter != cparams.end(); ++siter)
   {
+    PHParameters *params = GetParamsContainer()->GetParametersToModify(siter->first);
     map<const std::string, string>::const_iterator siter2;
     for (siter2 = siter->second.begin(); siter2 != siter->second.end(); ++siter2)
     {
-      set_string_param(siter->first, siter2->first, siter2->second);
+      params->set_string_param(siter2->first, siter2->second);
     }
   }
   return;


### PR DESCRIPTION
the copying of the double params which were set in the macro wasn't done correctly (for the detector groups where so far the intt is the only customer). This is fixed now, strings might still have an issue - I just want to get this bugfix out so the Intt development can continue