### PR TITLE
sHijing HIJFRG truth jets config and readback in DST

### DIFF
--- a/generators/hijing/src/hijfst.C
+++ b/generators/hijing/src/hijfst.C
@@ -13,6 +13,9 @@ struct algo_info
   JetAlgorithm algorithm;
   double R;
   int PID;
+  double EtaMin;
+  double EtaMax;
+  double EtMin;
 };
 vector<algo_info> algo_info_vec;
 
@@ -40,7 +43,7 @@ struct loaderObj
 loaderObj loader;
 
 void
-hijfst_control(int enable, vector<string> valgorithm, vector<float> vR, vector<int> vPID)
+hijfst_control(int enable, vector<string> valgorithm, vector<float> vR, vector<int> vPID, vector<float> vEtaMin, vector<float> vEtaMax, vector<float> vEtMin)
 {
   enablep = (enable==1) ? true: false;
   
@@ -53,6 +56,9 @@ hijfst_control(int enable, vector<string> valgorithm, vector<float> vR, vector<i
       algo.algorithm = ((algorithms.find(algorithmName) == algorithms.end()) ? antikt_algorithm : algorithms[algorithmName]);
       algo.R = vR[i];
       algo.PID = vPID[i];
+      algo.EtaMin = vEtaMin[i];
+      algo.EtaMax = vEtaMax[i];
+      algo.EtMin = vEtMin[i];
       algo_info_vec.push_back(algo);
     }
 }
@@ -109,7 +115,8 @@ hijfst_(int *n, int *N, int *K, float *P, float *V)
       for (unsigned i = 0; i < jets.size(); i++) 
 	{
 	  // These cuts should be configurable!
-	  if (abs(jets[i].eta()) > 2.0 or jets[i].E() < 5.0)
+//        if (abs(jets[i].eta()) > 2.0 or jets[i].E() < 5.0)
+      if (jets[i].eta() < a.EtaMin or jets[i].eta() > a.EtaMax or  jets[i].Et() < a.EtMin)
 	    {
 	      continue;
 	    }

--- a/generators/sHijing/Hijing.cxx
+++ b/generators/sHijing/Hijing.cxx
@@ -57,7 +57,7 @@ using namespace std;
 using namespace boost;
 using namespace boost::property_tree;
 
-void hijfst_control(int, vector<string>, vector<float>, vector<int>);
+void hijfst_control(int, vector<string>, vector<float>, vector<int>, vector<float>, vector<float>, vector<float>);
 
 CLHEP::HepRandomEngine * engine;
 
@@ -161,6 +161,9 @@ main (int argc, char **argv)
   std::vector<string> algorithm_v;
   std::vector<float> R_v;
   std::vector<int> PID_v;
+  std::vector<float> EtaMin_v;
+  std::vector<float> EtaMax_v;
+  std::vector<float> EtMin_v;
 
   iptree &it = pt.get_child("HIJING.FASTJET", null);
   BOOST_FOREACH(iptree::value_type &v, it)
@@ -169,10 +172,15 @@ main (int argc, char **argv)
       algorithm_v.push_back(to_upper_copy(v.second.get("NAME", "ANTIKT")));
       R_v.push_back(v.second.get("R", 0.2));
       PID_v.push_back(v.second.get("PID", 2000000));
+
+      EtaMin_v.push_back(v.second.get("EtaMin", -2));
+      EtaMax_v.push_back(v.second.get("EtaMax", 2));
+      EtMin_v.push_back(v.second.get("EtMin", 5));
+
       fastjet_enable_p = 1;
     }
 
-  hijfst_control(fastjet_enable_p, algorithm_v, R_v, PID_v);
+  hijfst_control(fastjet_enable_p, algorithm_v, R_v, PID_v, EtaMin_v, EtaMax_v, EtMin_v);
 
   // The call to Hijing needs simple C-style strings.
   m_frame.copy(frame,m_frame.size());

--- a/generators/sHijing/sHijing.xml
+++ b/generators/sHijing/sHijing.xml
@@ -30,17 +30,26 @@
     <Algorithm>
       <Name>AntikT</Name>
       <R>0.2</R>		
-      <PID>2000000</PID>		
+      <PID>2000000</PID>		    
+      <EtaMin>-2</EtaMin>	      
+      <EtaMax>2</EtaMax>	      
+      <EtMin>2</EtMin>	 	
     </Algorithm>
     <Algorithm>
       <Name>AntikT</Name>
       <R>0.4</R>		
-      <PID>4000000</PID>		
+      <PID>4000000</PID>		    
+      <EtaMin>-2</EtaMin>	      
+      <EtaMax>2</EtaMax>	      
+      <EtMin>2</EtMin>	 	
     </Algorithm>
     <Algorithm>
       <Name>AntikT</Name>
       <R>0.6</R>		
-      <PID>6000000</PID>		
+      <PID>6000000</PID>		    
+      <EtaMin>-2</EtaMin>	      
+      <EtaMax>2</EtaMax>	      
+      <EtMin>2</EtMin>	 	
     </Algorithm>
   </FastJet>
 </HIJING>

--- a/simulation/g4simulation/g4jets/Jet.h
+++ b/simulation/g4simulation/g4jets/Jet.h
@@ -25,9 +25,17 @@ public:
     FHCAL_TOWER=11, FHCAL_CLUSTER=12,
     CEMC_TOWER_RETOWER=13,                                           /* needed for HI jet reco */
     CEMC_TOWER_SUB1=14, HCALIN_TOWER_SUB1=15, HCALOUT_TOWER_SUB1=16, /* needed for HI jet reco */
+    HEPMC_IMPORT = 20, /*Direct import HEPMC containers, such as sHijing HIJFRG truth jets loaded by JetHepMCLoader*/
   };
 
-  enum PROPERTY {prop_JetCharge = 1,prop_BFrac = 2};
+  enum PROPERTY {
+
+    //! jet charge
+    prop_JetCharge = 1,
+
+    //! b-jet fraction
+    prop_BFrac = 2,
+  };
 
   Jet();
   virtual ~Jet() {}

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.C
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.C
@@ -1,0 +1,22 @@
+// $Id: $
+
+/*!
+ * \file JetHepMCLoader.C
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "JetHepMCLoader.h"
+
+JetHepMCLoader::JetHepMCLoader(const std::string &name)
+  : SubsysReco(name)
+{
+  // TODO Auto-generated constructor stub
+}
+
+JetHepMCLoader::~JetHepMCLoader()
+{
+  // TODO Auto-generated destructor stub
+}

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.C
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.C
@@ -10,17 +10,29 @@
 
 #include "JetHepMCLoader.h"
 
-#include "Jet.h"
 #include "JetMapV1.h"
+#include "JetV1.h"
 
+#include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <phhepmc/PHHepMCGenEvent.h>
+#include <phhepmc/PHHepMCGenEventMap.h>
+
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHTypedNodeIterator.h>
 #include <phool/getClass.h>
 
+#include <TH1D.h>
 #include <TH2F.h>
+
+#include <boost/algorithm/string.hpp>
+
+#include <cassert>
+#include <iostream>
 
 using namespace std;
 
@@ -42,30 +54,186 @@ int JetHepMCLoader::Init(PHCompositeNode *topNode)
 
 int JetHepMCLoader::InitRun(PHCompositeNode *topNode)
 {
+  if (m_saveQAPlots)
+  {
+    Fun4AllHistoManager *hm = getHistoManager();
+    assert(hm);
+
+    const int n_bins = 1 + m_jetSrc.size();
+
+    TH1D *h = new TH1D("hNormalization",  //
+                       "Normalization;Items;Summed quantity", n_bins, .5, n_bins + .5);
+    int i = 1;
+    h->GetXaxis()->SetBinLabel(i++, "Event count");
+    for (const hepmc_jet_src &src : m_jetSrc)
+    {
+      h->GetXaxis()->SetBinLabel(i++, (string("SubEvent ") + src.m_name).c_str());
+    }
+    h->GetXaxis()->LabelsOption("v");
+    hm->registerHisto(h);
+
+    for (const hepmc_jet_src &src : m_jetSrc)
+    {
+      hm->registerHisto(
+          new TH2F((string("hJetEtEta_") + src.m_name).c_str(),  //
+                   ("Jet distribution from " + src.m_name + ";Jet #eta;Jet E_{T} [GeV]").c_str(),
+                   40, -4., 4.,
+                   100, 0, 100));
+    }
+  }  //   if (m_saveQAPlots)
+
   return CreateNodes(topNode);
 }
 
 int JetHepMCLoader::process_event(PHCompositeNode *topNode)
 {
+  // For pile-up simulation: define GenEventMap
+  PHHepMCGenEventMap *genevtmap = findNode::getClass<PHHepMCGenEventMap>(topNode, "PHHepMCGenEventMap");
+
+  if (!genevtmap)
+  {
+    static bool once = true;
+
+    if (once and Verbosity())
+    {
+      once = false;
+
+      cout << "HepMCNodeReader::process_event - No PHHepMCGenEventMap node. Do not perform HepMC->Geant4 input" << endl;
+    }
+
+    return Fun4AllReturnCodes::DISCARDEVENT;
+  }
+
+  if (m_saveQAPlots)
+  {
+    Fun4AllHistoManager *hm = getHistoManager();
+    assert(hm);
+    TH1D *h_norm = dynamic_cast<TH1D *>(hm->getHisto("hNormalization"));
+    assert(h_norm);
+    h_norm->Fill("Event count", 1);
+  }  //   if (m_saveQAPlots)
+
+  for (const hepmc_jet_src &src : m_jetSrc)
+  {
+    JetMap *jets = findNode::getClass<JetMap>(topNode, src.m_name);
+    assert(jets);
+
+    jets->set_algo(src.m_algorithmID);
+    jets->set_par(src.m_parameter);
+    jets->insert_src(Jet::HEPMC_IMPORT);
+
+    PHHepMCGenEvent *genevt =
+        genevtmap->get(src.m_embeddingID);
+
+    if (genevt == nullptr) continue;
+
+    HepMC::GenEvent *evt = genevt->getEvent();
+    if (!evt)
+    {
+      cout << PHWHERE << " no evt pointer under HEPMC Node found:";
+      genevt->identify();
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+    assert(genevt->get_embedding_id() == src.m_embeddingID);
+
+    TH2F *hjet = nullptr;
+
+    if (m_saveQAPlots)
+    {
+      Fun4AllHistoManager *hm = getHistoManager();
+      assert(hm);
+      TH1D *h_norm = dynamic_cast<TH1D *>(hm->getHisto("hNormalization"));
+      assert(h_norm);
+      h_norm->Fill((string("SubEvent ") + src.m_name).c_str(), 1);
+
+      hjet = dynamic_cast<TH2F *>(hm->getHisto(string("hJetEtEta_") + src.m_name));
+      assert(hjet);
+
+    }  //   if (m_saveQAPlots)
+
+    const double mom_factor = HepMC::Units::conversion_factor(evt->momentum_unit(), HepMC::Units::GEV);
+
+    for (HepMC::GenEvent::particle_const_iterator p = evt->particles_begin();
+         p != evt->particles_end(); ++p)
+    {
+      HepMC::GenParticle *part = (*p);
+
+      assert(part);
+      if (Verbosity() >= VERBOSITY_A_LOT)
+        part->print();
+
+      if (part->status() == src.m_tagStatus and part->pdg_id() == src.m_tagPID)
+      {
+        Jet *jet = new JetV1();
+
+        jet->set_px(part->momentum().px() * mom_factor);
+        jet->set_py(part->momentum().py() * mom_factor);
+        jet->set_pz(part->momentum().pz() * mom_factor);
+        jet->set_e(part->momentum().e() * mom_factor);
+
+        jet->insert_comp(Jet::HEPMC_IMPORT, part->barcode());
+
+        jets->insert(jet);
+
+        if (hjet)
+        {
+          hjet->Fill(jet->get_eta(), jet->get_et());
+        }
+
+      }  //       if (part->status() == src.m_tagStatus and part->pdg_id() == src.m_tagPID)
+    }
+  }  //  for (const hepmc_jet_src &src : m_jetSrc)
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int JetHepMCLoader::End(PHCompositeNode *topNode)
 {
+  if (m_saveQAPlots)
+  {
+    Fun4AllHistoManager *hm = getHistoManager();
+    assert(hm);
+
+    cout << "JetHepMCLoader::End - saving QA histograms to " << Name() + ".root" << endl;
+    hm->dumpHistos(Name() + ".root", "RECREATE");
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 void JetHepMCLoader::addJet(
     const std::string &name,
     int embeddingID,
-    const std::string &algorithmName,
+    Jet::ALGO algorithm,
     double parameter,
     int tagPID,
     int tagStatus)
 {
-  hepmc_jet_src src{name, embeddingID, algorithmName, parameter, tagPID, tagStatus};
+  string algorithmName = "Undefined_Jet_Algorithm";
 
-  m_jetSrc.insert(src);
+  switch (algorithm)
+  {
+  case Jet::ANTIKT:
+    algorithmName = "ANTIKT";
+    break;
+
+  case Jet::KT:
+    algorithmName = "KT";
+    break;
+
+  case Jet::CAMBRIDGE:
+    algorithmName = "CAMBRIDGE";
+    break;
+
+  default:
+
+    break;
+  }
+
+  hepmc_jet_src src{name, embeddingID, algorithmName, algorithm, parameter, tagPID, tagStatus};
+
+  m_jetSrc.push_back(src);
 }
 
 int JetHepMCLoader::CreateNodes(PHCompositeNode *topNode)
@@ -108,4 +276,26 @@ int JetHepMCLoader::CreateNodes(PHCompositeNode *topNode)
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+Fun4AllHistoManager *
+JetHepMCLoader::getHistoManager()
+{
+  string histname(Name() + "_HISTOS");
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  Fun4AllHistoManager *hm = se->getHistoManager(histname);
+
+  if (not hm)
+  {
+    cout
+        << "TPCDataStreamEmulator::get_HistoManager - Making Fun4AllHistoManager " << histname
+        << endl;
+    hm = new Fun4AllHistoManager(histname);
+    se->registerHistoManager(hm);
+  }
+
+  assert(hm);
+
+  return hm;
 }

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.C
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.C
@@ -10,13 +10,102 @@
 
 #include "JetHepMCLoader.h"
 
-JetHepMCLoader::JetHepMCLoader(const std::string &name)
-  : SubsysReco(name)
+#include "Jet.h"
+#include "JetMapV1.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHTypedNodeIterator.h>
+#include <phool/getClass.h>
+
+#include <TH2F.h>
+
+using namespace std;
+
+JetHepMCLoader::JetHepMCLoader(const std::string &jetInputCategory)
+  : SubsysReco("JetHepMCLoader_" + jetInputCategory)
+  , m_jetInputCategory(jetInputCategory)
+  , m_saveQAPlots(false)
 {
-  // TODO Auto-generated constructor stub
 }
 
 JetHepMCLoader::~JetHepMCLoader()
 {
-  // TODO Auto-generated destructor stub
+}
+
+int JetHepMCLoader::Init(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int JetHepMCLoader::InitRun(PHCompositeNode *topNode)
+{
+  return CreateNodes(topNode);
+}
+
+int JetHepMCLoader::process_event(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int JetHepMCLoader::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void JetHepMCLoader::addJet(
+    const std::string &name,
+    int embeddingID,
+    const std::string &algorithmName,
+    double parameter,
+    int tagPID,
+    int tagStatus)
+{
+  hepmc_jet_src src{name, embeddingID, algorithmName, parameter, tagPID, tagStatus};
+
+  m_jetSrc.insert(src);
+}
+
+int JetHepMCLoader::CreateNodes(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode = static_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    cout << PHWHERE << "DST Node missing, doing nothing." << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  for (const hepmc_jet_src &src : m_jetSrc)
+  {
+    // Create the AntiKt node if required
+    PHCompositeNode *AlgoNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", src.m_algorithmName.c_str()));
+    if (!AlgoNode)
+    {
+      AlgoNode = new PHCompositeNode(src.m_algorithmName.c_str());
+      dstNode->addNode(AlgoNode);
+    }
+
+    // Create the Input node if required
+    PHCompositeNode *InputNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", m_jetInputCategory.c_str()));
+    if (!InputNode)
+    {
+      InputNode = new PHCompositeNode(m_jetInputCategory.c_str());
+      AlgoNode->addNode(InputNode);
+    }
+
+    JetMap *jets = findNode::getClass<JetMap>(topNode, src.m_name);
+    if (!jets)
+    {
+      jets = new JetMapV1();
+      PHIODataNode<PHObject> *JetMapNode = new PHIODataNode<PHObject>(jets, src.m_name.c_str(), "PHObject");
+      InputNode->addNode(JetMapNode);
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.h
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.h
@@ -1,0 +1,26 @@
+// $Id: $
+
+/*!
+ * \file JetHepMCLoader.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef JETHEPMCLOADER_H_
+#define JETHEPMCLOADER_H_
+
+#include <fun4all/SubsysReco.h>
+
+/*!
+ * \brief JetHepMCLoader loads special jet objects encoded in HepMC records to DST Jet nodes. Example use are loading sHijing HIJFRG jets
+ */
+class JetHepMCLoader : public SubsysReco
+{
+ public:
+  JetHepMCLoader(const std::string &name = "JetHepMCLoader");
+  virtual ~JetHepMCLoader();
+};
+
+#endif /* JETHEPMCLOADER_H_ */

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.h
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.h
@@ -11,10 +11,13 @@
 #ifndef JETHEPMCLOADER_H_
 #define JETHEPMCLOADER_H_
 
-#include <fun4all/SubsysReco.h>
-#include <set>
-#include <string>
+#include "Jet.h"
 
+#include <fun4all/SubsysReco.h>
+#include <string>
+#include <vector>
+
+class Fun4AllHistoManager;
 class PHCompositeNode;
 
 /*!
@@ -23,7 +26,6 @@ class PHCompositeNode;
 class JetHepMCLoader : public SubsysReco
 {
  public:
-
   //! \param[in] jetInputCategory is the DST PHCompositeNode name that list the output jet maps, e.g. sHijing_HIJFRG for sHijing HIJFRG truth jets
   JetHepMCLoader(const std::string &jetInputCategory);
   virtual ~JetHepMCLoader();
@@ -40,20 +42,24 @@ class JetHepMCLoader : public SubsysReco
   //!   \endcode
   //! \param[in] name name of the jet category
   //! \param[in] embeddingID hepmc event's embedding ID
+  //! \param[in] algorithm pick one from Jet::ALGO
   //! \param[in] parameter jet parameter, e.g. radius
   //! \param[in] tagPID HepMC entry identifying tag on PID
   //! \param[in] tagStatus HepMC entry identifying tag on status
   void addJet(
       const std::string &name,
       int embeddingID,
-      const std::string &algorithmName,
+      Jet::ALGO algorithm,
       double parameter,
       int tagPID,
       int tagStatus);
 
-  void saveQAPlots(bool b) { m_saveQAPlots = b; }
+  void saveQAPlots(bool b = true) { m_saveQAPlots = b; }
 
  private:
+  int CreateNodes(PHCompositeNode *topNode);
+  Fun4AllHistoManager *getHistoManager();
+
   std::string m_jetInputCategory;
 
   bool m_saveQAPlots;
@@ -69,6 +75,8 @@ class JetHepMCLoader : public SubsysReco
     //! Name of jet algorithm
     std::string m_algorithmName;
 
+    Jet::ALGO m_algorithmID;
+
     //! jet parameter, e.g. radius
     double m_parameter;
 
@@ -79,10 +87,7 @@ class JetHepMCLoader : public SubsysReco
     int m_tagStatus;
   };
 
-  int CreateNodes(PHCompositeNode *topNode);
-
-  std::set< hepmc_jet_src> m_jetSrc;
-
+  std::vector<hepmc_jet_src> m_jetSrc;
 };
 
 #endif /* JETHEPMCLOADER_H_ */

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.h
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.h
@@ -12,6 +12,10 @@
 #define JETHEPMCLOADER_H_
 
 #include <fun4all/SubsysReco.h>
+#include <set>
+#include <string>
+
+class PHCompositeNode;
 
 /*!
  * \brief JetHepMCLoader loads special jet objects encoded in HepMC records to DST Jet nodes. Example use are loading sHijing HIJFRG jets
@@ -19,8 +23,66 @@
 class JetHepMCLoader : public SubsysReco
 {
  public:
-  JetHepMCLoader(const std::string &name = "JetHepMCLoader");
+
+  //! \param[in] jetInputCategory is the DST PHCompositeNode name that list the output jet maps, e.g. sHijing_HIJFRG for sHijing HIJFRG truth jets
+  JetHepMCLoader(const std::string &jetInputCategory);
   virtual ~JetHepMCLoader();
+
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  //! \brief addJet add HepMC entries for a particular type of jets
+  //! Example of adding sHijing HIJFRG truth jets with R=0.4:
+  //!   \code{.cpp}
+  //!     addJet("AntiKt_sHijing_HIJFRG_r04",0,"ANTIKT",0.4,4000000,103);
+  //!   \endcode
+  //! \param[in] name name of the jet category
+  //! \param[in] embeddingID hepmc event's embedding ID
+  //! \param[in] parameter jet parameter, e.g. radius
+  //! \param[in] tagPID HepMC entry identifying tag on PID
+  //! \param[in] tagStatus HepMC entry identifying tag on status
+  void addJet(
+      const std::string &name,
+      int embeddingID,
+      const std::string &algorithmName,
+      double parameter,
+      int tagPID,
+      int tagStatus);
+
+  void saveQAPlots(bool b) { m_saveQAPlots = b; }
+
+ private:
+  std::string m_jetInputCategory;
+
+  bool m_saveQAPlots;
+
+  struct hepmc_jet_src
+  {
+    //! name
+    std::string m_name;
+
+    //! hepmc event's embedding ID
+    int m_embeddingID;
+
+    //! Name of jet algorithm
+    std::string m_algorithmName;
+
+    //! jet parameter, e.g. radius
+    double m_parameter;
+
+    //! HepMC entry identifying tag on PID
+    int m_tagPID;
+
+    //! HepMC entry identifying tag on status
+    int m_tagStatus;
+  };
+
+  int CreateNodes(PHCompositeNode *topNode);
+
+  std::set< hepmc_jet_src> m_jetSrc;
+
 };
 
 #endif /* JETHEPMCLOADER_H_ */

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.h
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.h
@@ -22,6 +22,22 @@ class PHCompositeNode;
 
 /*!
  * \brief JetHepMCLoader loads special jet objects encoded in HepMC records to DST Jet nodes. Example use are loading sHijing HIJFRG jets
+ *
+ * Example use for readback HIJFRAG truth jets from the sHijing HepMC records:
+ *
+ * \code{.cpp}
+
+    JetHepMCLoader * hepmcjet = new JetHepMCLoader("sHijing_HIJFRG");
+
+    hepmcjet->saveQAPlots();
+    hepmcjet->addJet("AntiKt_sHijing_HIJFRG_r02",0,Jet::ANTIKT,0.2,2000000,103);
+    hepmcjet->addJet("AntiKt_sHijing_HIJFRG_r04",0,Jet::ANTIKT,0.4,4000000,103);
+    hepmcjet->addJet("AntiKt_sHijing_HIJFRG_r06",0,Jet::ANTIKT,0.6,6000000,103);
+
+    se->registerSubsystem(hepmcjet);
+
+ * \endcode
+ *
  */
 class JetHepMCLoader : public SubsysReco
 {

--- a/simulation/g4simulation/g4jets/JetHepMCLoaderLinkDef.h
+++ b/simulation/g4simulation/g4jets/JetHepMCLoaderLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class JetHepMCLoader-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4jets/Makefile.am
+++ b/simulation/g4simulation/g4jets/Makefile.am
@@ -29,6 +29,7 @@ libg4jets_la_LIBADD = \
   -lg4vertex_io \
   -lCGAL \
   -lfastjet \
+  -lphhepmc_io \
   libg4jets_io.la
 
 pkginclude_HEADERS = \
@@ -60,6 +61,8 @@ libg4jets_io_la_SOURCES = \
 libg4jets_la_SOURCES = \
   JetReco.C \
   JetReco_Dict.C \
+  JetHepMCLoader.C \
+  JetHepMCLoader_Dict.C \
   TruthJetInput.C \
   TruthJetInput_Dict.C \
   TrackJetInput.C \


### PR DESCRIPTION
## Introduction

In the last jet structure group meeting, we discussed running large (2M) hijing production to study the fake jet rate and rejection in Geant4 simulation of the current calorimeter stacks. Last study was published in [DOI: 10.1103/PhysRevC.86.024908](https://journals.aps.org/prc/abstract/10.1103/PhysRevC.86.024908) with fast calorimetry simulations. 

Aaron Angerami pointed out up that we need to recover the capability of reading the sHijing HIJFRG truth jets, which records hard process originated from each HIJFRG subprocess. In the discussion, it was also clear that we also need to make these truth jets in the analysis via jets objets on the DST nodes. 

This pull request implements both suggestions. 

## Config kinematic cuts on sHijing HIJFRG truth jets

The current sHijing hard code |eta|<2 and E_total > 5 GeV cut. This pull request make both configurable: 
* Eta range are provided by `EtaMin` `EtaMax` in the xml config file
* Jet energy is now cut with minimal E_T via `EtMin` parameter in the xml config file

Example is 2 GeV ET cut in the new `coresoftware/generators/sHijing/sHijing.xml`
```xml

    <Algorithm>
      <Name>AntikT</Name>
      <R>0.2</R>		
      <PID>2000000</PID>		    
      <EtaMin>-2</EtaMin>	      
      <EtaMax>2</EtaMax>	      
      <EtMin>2</EtMin>	 	
    </Algorithm>

```

## Readback of the sHijing truth jets

sHijing store the HIJFRG jets as HepMC entries of special PID and status tag. New utility `JetHepMCLoader` loads those records as jet objects onto DST truth jet containers. 

Example macros to drive this module is 

```c++
    JetHepMCLoader * hepmcjet = new JetHepMCLoader("sHijing_HIJFRG");
    hepmcjet->saveQAPlots(); // whether to save QA plots in a root file
    hepmcjet->addJet("AntiKt_sHijing_HIJFRG_r02",0,Jet::ANTIKT,0.2,2000000,103);
    hepmcjet->addJet("AntiKt_sHijing_HIJFRG_r04",0,Jet::ANTIKT,0.4,4000000,103);
    hepmcjet->addJet("AntiKt_sHijing_HIJFRG_r06",0,Jet::ANTIKT,0.6,6000000,103);
    se->registerSubsystem(hepmcjet);
```
This add new DST Jet containers with following path: 
```
TOP (PHCompositeNode)/
   DST (PHCompositeNode)/
         TRUTH (PHCompositeNode)/
            ....
         TOWER (PHCompositeNode)/
            ....
         sHijing_HIJFRG (PHCompositeNode)/
            AntiKt_sHijing_HIJFRG_r02 (IO,JetMapV1)
            AntiKt_sHijing_HIJFRG_r04 (IO,JetMapV1)
            AntiKt_sHijing_HIJFRG_r06 (IO,JetMapV1)
```

## Verifications

Run 10k events in b=0-4.4 fm central AuAu collisions to verify the truth jet yield when compared with [DOI: 10.1103/PhysRevC.86.024908](https://journals.aps.org/prc/abstract/10.1103/PhysRevC.86.024908). Note, b=0-4.4 fm approximates the 0-10% centrality with the impact parameter space, which is different from the centrality definition in [DOI: 10.1103/PhysRevC.86.024908](https://journals.aps.org/prc/abstract/10.1103/PhysRevC.86.024908) as measured by the truth charge-multiplicity 3<|eta|<4. After sHijing produce the HepMC file, truth spectrum are produced by the HepMC readback in sPHENIX analysis framework and the QA histograms in the `JetHepMCLoader` module. 

The result sHijing HIJFRG truth jets spectrum is as following: 

![c1](https://user-images.githubusercontent.com/7947083/45653617-a75c9480-baa6-11e8-9685-318657dae1e6.png)

This yield is similar or a factor of a few higher than that shown in [DOI: 10.1103/PhysRevC.86.024908](https://journals.aps.org/prc/abstract/10.1103/PhysRevC.86.024908), depending on the assumption of eta-cuts in the paper. Still checking...


