### PR TITLE
Removal of unused includes which prevent easy transition to hepmc3, use C++11 shared ptr

### DIFF
--- a/offline/packages/Prototype2/Prototype2DSTReader.cc
+++ b/offline/packages/Prototype2/Prototype2DSTReader.cc
@@ -8,6 +8,8 @@
  * \date $Date: 2015/01/06 02:52:07 $
  */
 
+#include "Prototype2DSTReader.h"
+
 #include <fun4all/PHTFileServer.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 //#include <PHGeometry.h>
@@ -20,16 +22,13 @@
 #include <phparameter/PHParameters.h>
 
 #include <TTree.h>
-#include <TMath.h>
 
-#include <boost/foreach.hpp>
 #include <map>
 #include <set>
 #include <cassert>
 
 #include<sstream>
 
-#include "Prototype2DSTReader.h"
 
 using namespace std;
 
@@ -98,7 +97,7 @@ Prototype2DSTReader::Init(PHCompositeNode*)
       record rec;
       rec._cnt = 0;
       rec._name = hname;
-      rec._arr = boost::make_shared<TClonesArray>(class_name, arr_size);
+      rec._arr = make_shared<TClonesArray>(class_name, arr_size);
       rec._arr_ptr = rec._arr.get();
       rec._dvalue = 0;
       rec._type = record::typ_tower;

--- a/offline/packages/Prototype2/Prototype2DSTReader.h
+++ b/offline/packages/Prototype2/Prototype2DSTReader.h
@@ -14,21 +14,17 @@
 #include "RawTower_Prototype2.h"
 #include "RawTower_Temperature.h"
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/SimpleVector.h>
 #include <fun4all/SubsysReco.h>
-#include <string>
-#include <iostream>
-#include <vector>
+
 #include <TClonesArray.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
 
 class TTree;
 
-#ifndef __CINT__
-
-#include <boost/smart_ptr.hpp>
-
-#endif
 
 /*!
  * \brief Prototype2DSTReader save information from DST to an evaluator, which could include hit. particle, vertex, towers and jet (to be activated)
@@ -98,7 +94,7 @@ protected:
 
 #ifndef __CINT__
 
-  typedef boost::shared_ptr<TClonesArray> arr_ptr;
+  typedef std::shared_ptr<TClonesArray> arr_ptr;
 
   struct record
   {

--- a/offline/packages/Prototype3/Prototype3DSTReader.cc
+++ b/offline/packages/Prototype3/Prototype3DSTReader.cc
@@ -8,6 +8,8 @@
  * \date $Date: 2015/01/06 02:52:07 $
  */
 
+#include "Prototype3DSTReader.h"
+
 #include <fun4all/PHTFileServer.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 //#include <PHGeometry.h>
@@ -20,22 +22,18 @@
 #include <phparameter/PHParameters.h>
 
 #include <TTree.h>
-#include <TMath.h>
 
-#include <boost/foreach.hpp>
+#include <cassert>
 #include <map>
 #include <set>
-#include <cassert>
-
 #include<sstream>
 
-#include "Prototype3DSTReader.h"
 
 using namespace std;
 
 Prototype3DSTReader::Prototype3DSTReader(const string &filename) :
     SubsysReco("Prototype3DSTReader"), nblocks(0), _event(0), //
-    _out_file_name(filename), /*_file(NULL), */_T(NULL), //
+    _out_file_name(filename), /*_file(NULL), */_T(nullptr), //
     _tower_zero_sup(-10000000)
 {
 
@@ -115,7 +113,7 @@ Prototype3DSTReader::Init(PHCompositeNode*)
       record rec;
       rec._cnt = 0;
       rec._name = hname;
-      rec._arr = boost::make_shared<TClonesArray>(class_name, arr_size);
+      rec._arr = make_shared<TClonesArray>(class_name, arr_size);
       rec._arr_ptr = rec._arr.get();
       rec._dvalue = 0;
       rec._type = record::typ_tower;

--- a/offline/packages/Prototype3/Prototype3DSTReader.h
+++ b/offline/packages/Prototype3/Prototype3DSTReader.h
@@ -14,21 +14,17 @@
 #include "RawTower_Prototype3.h"
 #include "RawTower_Temperature.h"
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/SimpleVector.h>
 #include <fun4all/SubsysReco.h>
-#include <string>
-#include <iostream>
-#include <vector>
+
 #include <TClonesArray.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
 
 class TTree;
 
-#ifndef __CINT__
-
-#include <boost/smart_ptr.hpp>
-
-#endif
 
 /*!
  * \brief Prototype3DSTReader save information from DST to an evaluator, which could include hit. particle, vertex, towers and jet (to be activated)
@@ -104,7 +100,7 @@ protected:
 
 #ifndef __CINT__
 
-  typedef boost::shared_ptr<TClonesArray> arr_ptr;
+  typedef std::shared_ptr<TClonesArray> arr_ptr;
 
   struct record
   {

--- a/offline/packages/Prototype4/Prototype4DSTReader.cc
+++ b/offline/packages/Prototype4/Prototype4DSTReader.cc
@@ -8,9 +8,10 @@
  * \date $Date: 2015/01/06 02:52:07 $
  */
 
+#include "Prototype4DSTReader.h"
+
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/PHTFileServer.h>
-//#include <PHGeometry.h>
 
 #include <phool/getClass.h>
 #include <phool/getClass.h>
@@ -19,17 +20,14 @@
 #include <pdbcalbase/PdbParameterMap.h>
 #include <phparameter/PHParameters.h>
 
-#include <TMath.h>
 #include <TTree.h>
 
-#include <boost/foreach.hpp>
 #include <cassert>
 #include <limits>
 #include <map>
 #include <set>
 #include <sstream>
 
-#include "Prototype4DSTReader.h"
 
 using namespace std;
 
@@ -39,7 +37,7 @@ Prototype4DSTReader::Prototype4DSTReader(const string &filename)
   , _event(0)
   ,  //
   _out_file_name(filename)
-  , /*_file(NULL), */ _T(NULL)
+  , /*_file(NULL), */ _T(nullptr)
   ,  //
   _tower_zero_sup(-10000000)
 {
@@ -117,7 +115,7 @@ int Prototype4DSTReader::Init(PHCompositeNode *)
     record rec;
     rec._cnt = 0;
     rec._name = hname;
-    rec._arr = boost::make_shared<TClonesArray>(class_name, arr_size);
+    rec._arr = make_shared<TClonesArray>(class_name, arr_size);
     rec._arr_ptr = rec._arr.get();
     rec._dvalue = 0;
     rec._type = record::typ_tower;

--- a/offline/packages/Prototype4/Prototype4DSTReader.h
+++ b/offline/packages/Prototype4/Prototype4DSTReader.h
@@ -14,21 +14,16 @@
 #include "RawTower_Prototype4.h"
 #include "RawTower_Temperature.h"
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/SimpleVector.h>
-#include <TClonesArray.h>
 #include <fun4all/SubsysReco.h>
+
+#include <TClonesArray.h>
+
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
 class TTree;
-
-#ifndef __CINT__
-
-#include <boost/smart_ptr.hpp>
-
-#endif
 
 /*!
  * \brief Prototype4DSTReader save information from DST to an evaluator, which could include hit. particle, vertex, towers and jet (to be activated)
@@ -99,7 +94,7 @@ class Prototype4DSTReader : public SubsysReco
 
 #ifndef __CINT__
 
-  typedef boost::shared_ptr<TClonesArray> arr_ptr;
+  typedef std::shared_ptr<TClonesArray> arr_ptr;
 
   struct record
   {


### PR DESCRIPTION
This is just a cleanup, not sure why those two were included in the first place:
#include <HepMC/GenEvent.h>
#include <HepMC/SimpleVector.h>
while at it, replaced
boost:shared_ptr by std::shared_ptr (easy since the syntax is identical) but gets rid of an #ifdef __CINT__ since <memory> can be digested by rootcint
