### PR TITLE
Intt sublayer to layer

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
@@ -21,8 +21,9 @@ PHG4CylinderGeom_Siladders::PHG4CylinderGeom_Siladders():
   nladders_layer(-1),
   ladder_z0(NAN),
   ladder_z1(NAN),
-  sensor_radius_inner(NAN),
-  sensor_radius_outer(NAN),
+  sensor_radius(NAN),
+  //sensor_radius_inner(NAN),
+  //sensor_radius_outer(NAN),
   strip_x_offset(NAN),
   offsetphi(NAN),
   offsetrot(NAN),
@@ -64,10 +65,12 @@ void PHG4CylinderGeom_Siladders::find_segment_center(const int segment_z_bin, co
 void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[])
 {
   // The sub layer radius is determined from the ladder phi index, called segment_phi_bin
-  
-  radius = sensor_radius_inner;
+
+  radius = sensor_radius;  
+  /*
   if(segment_phi_bin % 2)
     radius = sensor_radius_outer;
+  */
   //cout << "      setting working sensor radius to " << radius << endl;
   
   // Ladder

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
@@ -22,8 +22,6 @@ PHG4CylinderGeom_Siladders::PHG4CylinderGeom_Siladders():
   ladder_z0(NAN),
   ladder_z1(NAN),
   sensor_radius(NAN),
-  //sensor_radius_inner(NAN),
-  //sensor_radius_outer(NAN),
   strip_x_offset(NAN),
   offsetphi(NAN),
   offsetrot(NAN),
@@ -64,14 +62,7 @@ void PHG4CylinderGeom_Siladders::find_segment_center(const int segment_z_bin, co
 
 void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[])
 {
-  // The sub layer radius is determined from the ladder phi index, called segment_phi_bin
-
   radius = sensor_radius;  
-  /*
-  if(segment_phi_bin % 2)
-    radius = sensor_radius_outer;
-  */
-  //cout << "      setting working sensor radius to " << radius << endl;
   
   // Ladder
   find_segment_center(segment_z_bin, segment_phi_bin, location);

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.cc
@@ -58,6 +58,8 @@ void PHG4CylinderGeom_Siladders::find_segment_center(const int segment_z_bin, co
   location[0] = radius  * cos(phi);
   location[1] = radius  * sin(phi);
   location[2] = signz * ladder_z_[itype];
+
+  //cout << "radius " << radius << " offsetphi " << offsetphi << " rad  dphi_ " << dphi_ << " rad  segment_phi_bin " << segment_phi_bin << " phi " << phi  << " rad " << endl;
 }
 
 void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[])
@@ -81,7 +83,6 @@ void PHG4CylinderGeom_Siladders::find_strip_center(const int segment_z_bin, cons
 
   // Strip rotation
   const double phi    = offsetphi + dphi_ * segment_phi_bin;
-  //const double rotate = phi + offsetrot + M_PI;
   const double rotate = phi + offsetrot;
 
   CLHEP::HepRotation rot;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
@@ -22,8 +22,9 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
       const int    nladders_layer_,
       const double ladder_z0_,
       const double ladder_z1_,
-      const double sensor_radius_inner_,
-      const double sensor_radius_outer_,
+      const double sensor_radius_,
+      //const double sensor_radius_inner_,
+      //const double sensor_radius_outer_,
       const double strip_x_offset_,
       const double offsetphi_,
       const double offsetrot_) :
@@ -38,8 +39,9 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
         nladders_layer(nladders_layer_),
         ladder_z0(ladder_z0_),
         ladder_z1(ladder_z1_),
-        sensor_radius_inner(sensor_radius_inner_),
-        sensor_radius_outer(sensor_radius_outer_),
+        sensor_radius(sensor_radius_),
+	  //sensor_radius_inner(sensor_radius_inner_),
+	  //sensor_radius_outer(sensor_radius_outer_),
         strip_x_offset(strip_x_offset_),
         offsetphi(offsetphi_),
 	offsetrot(offsetrot_),
@@ -73,14 +75,16 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
 
     double get_radius() const
       {
-        return sensor_radius_inner;
+        //return sensor_radius_inner;
+	return sensor_radius;
       }
 
+    /*
     double get_radius_outer() const
       {
         return sensor_radius_outer;
       }
-
+    */
     bool load_geometry();
     void find_segment_center(const int segment_z_bin, const int segment_phi_bin, double location[]);
     void find_strip_center(  const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[]);
@@ -125,8 +129,9 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
     int nladders_layer;
     double ladder_z0;
     double ladder_z1;
-    double sensor_radius_inner;
-    double sensor_radius_outer;
+    double sensor_radius;
+    //double sensor_radius_inner;
+    //double sensor_radius_outer;
     double strip_x_offset;
     double offsetphi;
     double offsetrot;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
@@ -23,8 +23,6 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
       const double ladder_z0_,
       const double ladder_z1_,
       const double sensor_radius_,
-      //const double sensor_radius_inner_,
-      //const double sensor_radius_outer_,
       const double strip_x_offset_,
       const double offsetphi_,
       const double offsetrot_) :
@@ -40,8 +38,6 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
         ladder_z0(ladder_z0_),
         ladder_z1(ladder_z1_),
         sensor_radius(sensor_radius_),
-	  //sensor_radius_inner(sensor_radius_inner_),
-	  //sensor_radius_outer(sensor_radius_outer_),
         strip_x_offset(strip_x_offset_),
         offsetphi(offsetphi_),
 	offsetrot(offsetrot_),
@@ -79,12 +75,6 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
 	return sensor_radius;
       }
 
-    /*
-    double get_radius_outer() const
-      {
-        return sensor_radius_outer;
-      }
-    */
     bool load_geometry();
     void find_segment_center(const int segment_z_bin, const int segment_phi_bin, double location[]);
     void find_strip_center(  const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[]);
@@ -130,8 +120,6 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
     double ladder_z0;
     double ladder_z1;
     double sensor_radius;
-    //double sensor_radius_inner;
-    //double sensor_radius_outer;
     double strip_x_offset;
     double offsetphi;
     double offsetrot;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Siladders.h
@@ -71,7 +71,6 @@ class PHG4CylinderGeom_Siladders: public PHG4CylinderGeom
 
     double get_radius() const
       {
-        //return sensor_radius_inner;
 	return sensor_radius;
       }
 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -107,7 +107,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
     const PHParameters *params1 = m_ParamsContainer->GetParameters(inttlayer);
     const int laddertype = params1->get_int_param("laddertype");
     const double offsetphi = (params1->get_double_param("offsetphi") * deg) / rad;  // use rad internally
-    double offsetrot = (params1->get_double_param("offsetrot") * deg) / rad;        // use rad internally
+    double offsetrot = (params1->get_double_param("offsetrot") * deg) / rad;        // offsetrot is specified in deg, we convert to rad here
     m_SensorRadius[inttlayer] = params1->get_double_param("sensor_radius") * cm;
     const int nladders_layer = params1->get_int_param("nladder");
 
@@ -131,7 +131,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
     cout << "Constructing Silicon Tracker layer: " << endl;
     cout << "  layer " << inttlayer << " laddertype " << laddertype << " nladders_layer " << nladders_layer
-         << " sensor_radius " << m_SensorRadius[inttlayer]  << " offsetphi " << offsetphi * rad/deg << " deg " 
+         << " sensor_radius " << m_SensorRadius[inttlayer]  << " offsetphi " << offsetphi << " rad " << " offsetphi " << offsetphi * rad/deg << " deg " 
 	 << endl;
 
     // We loop over inner, then outer, sensors, where  itype specifies the inner or outer sensor
@@ -774,12 +774,11 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
                             (boost::format("ladderext_%d_%d_%d_posz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
         }
 
-
-	cout << "   Ladder copy " << icopy << " radius " << radius << " phi " << phi << " itype " << itype << " posz " << m_PosZ[inttlayer][itype] 
-	     << " fRotate " << fRotate << " posx " << posx << " posy " << posy 
-	     << endl;
-	
-	
+	if (Verbosity() > 100)
+	  cout << "   Ladder copy " << icopy << " radius " << radius << " phi " << phi << " itype " << itype << " posz " << m_PosZ[inttlayer][itype] 
+	       << " fRotate " << fRotate << " posx " << posx << " posy " << posy 
+	       << endl;
+		
       }  // end loop over ladder copy placement in phi and positive and negative Z
     }    // end loop over inner or outer sensor
   }      // end loop over layers
@@ -945,8 +944,8 @@ void PHG4SiliconTrackerDetector::AddGeometryNode()
           m_PosZ[ilayer][1] / cm,
           m_SensorRadius[ilayer] / cm,
           0.0,
-          params_layer->get_double_param("offsetphi"),
-          params_layer->get_double_param("offsetrot"));
+          params_layer->get_double_param("offsetphi") * deg/rad,    // expects radians
+          params_layer->get_double_param("offsetrot") * deg/rad );   
       geo->AddLayerGeom(sphxlayer, mygeom);
       if (Verbosity() > 0)
       {

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.h
@@ -63,10 +63,9 @@ class PHG4SiliconTrackerDetector : public PHG4Detector
 
   int m_IsSupportActive;
 
-  double m_PosZ[4][2];
-  double m_SensorRadiusInner[4];
-  double m_SensorRadiusOuter[4];
-  double m_StripOffsetX[4];
+  double m_PosZ[8][2];
+  double m_SensorRadius[8];
+  double m_StripOffsetX[8];
 
   std::set<G4LogicalVolume *> m_ActiveLogVols;
   std::map<int, int> m_IsActiveMap;

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -339,7 +339,12 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
 	if(postPoint->GetStepStatus() != 1 && aTrack->GetParentID() == 0)   // primary tracks should not end strangely!
 	  {
 	    cout << "***** Strange termination of hit from primary track with postPoint->GetStepStatus = " << postPoint->GetStepStatus() << " aTrack->GetTrackStatus = " 
-		 << aTrack->GetTrackStatus() 	<< " aTrack->GetParentID " << aTrack->GetParentID() << endl;
+		 << aTrack->GetTrackStatus() << endl;
+	    cout << "     aTrack->GetTrackID " << aTrack->GetTrackID() << " aTrack->GetParentID " << aTrack->GetParentID() << endl;
+	    cout << "     sphxlayer " << sphxlayer <<  " ladderz " << ladderz << " ladderphi " << ladderphi << endl;
+	    cout  << "     px0 " << m_Hit->get_px(0) << " py0 " << m_Hit->get_py(0) << " pz0 " << m_Hit->get_pz(0) << endl;
+	    cout  << "     px1 " << m_Hit->get_px(1) << " py1 " << m_Hit->get_py(1) << " pz1 " << m_Hit->get_pz(1) << " edep " << m_Hit->get_edep() << endl;
+
 	    /*
 	    cout << " postStepStatus: fWorldBoundary " << fWorldBoundary 
 		 << " fGeomBoundary " << fGeomBoundary 

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSteppingAction.cc
@@ -132,7 +132,7 @@ bool PHG4SiliconTrackerSteppingAction::UserSteppingAction(const G4Step* aStep, b
       // if we are in an active logical volume whioch is located in this ladder
       auto iter = m_Detector->get_ActiveVolumeTuple(touch->GetVolume(1));
       tie(inttlayer, ladderz, ladderphi, zposneg) = iter->second;
-      if (inttlayer < 0 || inttlayer > 3)
+      if (inttlayer < 0 || inttlayer > 7)
 	{
 	  assert(!"PHG4SiliconTrackerSteppingAction: check INTT ladder layer.");
 	}

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -135,22 +135,25 @@ PHG4Detector *PHG4SiliconTrackerSubsystem::GetDetector(void) const
 
 void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
 {
-  // We have only two types of ladders, one with vertical strips (0) and one with horizontal strips (1)
+  // We have only two types of ladders, one with vertical strips (SEGMENTATION_Z) and one with horizontal strips (SEGMENTATION_PHI)
   // There are 4 sensors in each ladder
   //     In ladder type 0 the sensor is special and inner and outer sensors are the same.
   //     In ladder type 1 there are two different sensor types, inner and outer
-
   // We do not want to hard code the ladder types for the layers
-  // We define default ladder types for 4 layers, but these can be changed at the macro level
-  int laddertype[4] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z,
-                       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
-                       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
-                       PHG4SiliconTrackerDefs::SEGMENTATION_PHI};
-  int nladder[4] = {34, 30, 36, 42};
-  double sensor_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};
-  double sensor_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};
 
-  // sensor radius_inner and sensor_radius_outer are set in the constructor for now, to avoid a problem with the parameter class
+  // We define default ladder types for 8 layers, but these can be changed at the macro level
+
+  int laddertype[8] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+		       PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI};  // default
+  int nladder[8] = {17,  17, 15, 15, 18, 18, 21, 21};  // default
+  double sensor_radius[8] = {6.876, 7.462, 8.987, 9.545, 10.835, 11.361, 12.676, 13.179};  // radius of center of sensor for layer default
+
   auto detid = GetDetIds();  // get pair of iterators to begin/end of set<int> of detids
   for (auto detiter = detid.first; detiter != detid.second; ++detiter)
   {
@@ -159,15 +162,16 @@ void PHG4SiliconTrackerSubsystem::SetDefaultParameters()
     // To reconfigure the layers, all you have to do is overide the defaults for these four arrays from the tracking macro
     set_default_int_param(*detiter, "laddertype", laddertype[*detiter]);
     set_default_int_param(*detiter, "nladder", nladder[*detiter]);  // ladders per layer
-    set_default_double_param(*detiter, "sensor_radius_inner", sensor_radius_inner[*detiter]);
-    set_default_double_param(*detiter, "sensor_radius_outer", sensor_radius_outer[*detiter]);
+    set_default_double_param(*detiter, "sensor_radius", sensor_radius[*detiter]);
     // These offsets should be kept at zero in the new design
     set_default_double_param(*detiter, "offsetphi", 0.);
     set_default_double_param(*detiter, "offsetrot", 0.);
     cout << " PHG4SiliconTrackerSubsystem setting default parameters to: " << endl;
     cout << "  layer " << *detiter << " laddertype " << laddertype[*detiter] << " nladder " << nladder[*detiter]
-         << " sensor_radius_inner " << sensor_radius_inner[*detiter] << " sensor_radius_outer " << sensor_radius_outer[*detiter] << endl;
+         << " sensor_radius " << sensor_radius[*detiter]  << endl;
   }
+
+  // These are the parameters that describe the internal ladder geometry for the two ladder types
   {  // just being lazy, using namespace in this scope for less clutter
     using namespace PHG4SiliconTrackerDefs;
     set_default_int_param(SEGMENTATION_Z, "nstrips_phi_cell", 1);

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -977,7 +977,6 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       float gdz       = fabs(g4hit->get_z(1) - g4hit->get_z(0));
       float gedep     = g4hit->get_edep();
       float glayer    = g4hit->get_layer();
-  
       float gtrackID  = g4hit->get_trkid();
 
       float gflavor   = NAN;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -35,7 +35,7 @@ public:
                 const std::string &filename = "g4eval.root",
                 const std::string &trackmapname = "SvtxTrackMap",
 		unsigned int nlayers_maps = 3,
-		unsigned int nlayers_intt = 4,
+		unsigned int nlayers_intt = 8,
 		unsigned int nlayers_tpc = 60);
   virtual ~SvtxEvaluator() {}
 		
@@ -86,7 +86,7 @@ public:
   bool _scan_for_embedded;
 
   unsigned int _nlayers_maps = 3;
-  unsigned int _nlayers_intt = 4;
+  unsigned int _nlayers_intt = 8;
   unsigned int _nlayers_tpc = 60;
 
   TNtuple *_ntp_vertex;

--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
@@ -3206,9 +3206,9 @@ int PHG4KalmanPatRec::OutputPHGenFitTrack(PHCompositeNode* topNode, MapPHGenFitT
 		  if(_nlayers_intt>0&&layer>=_nlayers_maps&&layer<_nlayers_maps+_nlayers_intt){
 		    n_intt++;
 		  }
-		  if(n_intt >4)
+		  if(n_intt >8)
 		    {
-		      cout << PHWHERE << " Can not have more than 4 INTT layers, quit!" << endl;
+		      cout << PHWHERE << " Can not have more than 8 INTT layers, quit!" << endl;
 		      exit(1);
 		    }
 		  if(_nlayers_tpc>0&&

--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
@@ -259,25 +259,41 @@ PHG4KalmanPatRec::PHG4KalmanPatRec(
 //	unsigned int intt_layers[] = {3, 4, 5, 6};
 //	this->set_intt_layers(intt_layers, 4);
 
-	_max_search_win_phi_intt[0] =    0.20;
-	_max_search_win_phi_intt[1] = 0.0050;
+	_max_search_win_phi_intt[0] = 0.20;
+	_max_search_win_phi_intt[1] = 0.20;
 	_max_search_win_phi_intt[2] = 0.0050;
 	_max_search_win_phi_intt[3] = 0.0050;
+	_max_search_win_phi_intt[4] = 0.0050;
+	_max_search_win_phi_intt[5] = 0.0050;
+	_max_search_win_phi_intt[6] = 0.0050;
+	_max_search_win_phi_intt[7] = 0.0050;
 
 	_min_search_win_phi_intt[0] =   0.2000;
-	_min_search_win_phi_intt[1] =   0.0;
+	_min_search_win_phi_intt[1] =   0.2000;
 	_min_search_win_phi_intt[2] =   0.0;
 	_min_search_win_phi_intt[3] =   0.0;
+	_min_search_win_phi_intt[4] =   0.0;
+	_min_search_win_phi_intt[5] =   0.0;
+	_min_search_win_phi_intt[6] =   0.0;
+	_min_search_win_phi_intt[7] =   0.0;
 
 	_max_search_win_theta_intt[0] = 0.010;
-	_max_search_win_theta_intt[1] = 0.2000;
+	_max_search_win_theta_intt[1] = 0.010;
 	_max_search_win_theta_intt[2] =  0.2000;
 	_max_search_win_theta_intt[3] =  0.2000;
+	_max_search_win_theta_intt[4] =  0.2000;
+	_max_search_win_theta_intt[5] =  0.2000;
+	_max_search_win_theta_intt[6] =  0.2000;
+	_max_search_win_theta_intt[7] =  0.2000;
 
 	_min_search_win_theta_intt[0] = 0.000;
-	_min_search_win_theta_intt[1] = 0.200;
+	_min_search_win_theta_intt[1] = 0.000;
 	_min_search_win_theta_intt[2] = 0.200;
 	_min_search_win_theta_intt[3] = 0.200;
+	_min_search_win_theta_intt[4] = 0.200;
+	_min_search_win_theta_intt[5] = 0.200;
+	_min_search_win_theta_intt[6] = 0.200;
+	_min_search_win_theta_intt[7] = 0.200;
 
 	//int seeding_layers[] = {7,15,25,35,45,55,66};
 	int ninner_layer = _nlayers_maps+_nlayers_intt;

--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.h
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.h
@@ -79,7 +79,7 @@ public:
 	PHG4KalmanPatRec(
 			const std::string &name = "PHG4KalmanPatRec",
 			unsigned int nlayers_maps = 3,
-			unsigned int nlayers_intt = 4,
+			unsigned int nlayers_intt = 8,
 			unsigned int nlayers_tpc = 60,
 			unsigned int seeding_nlayer = 7,
 			unsigned int min_seeding_nlayer = 4);
@@ -866,10 +866,10 @@ private:
 	float _max_search_win_theta_tpc;
 	float _min_search_win_theta_tpc;
 
-	float _max_search_win_phi_intt[4];
-	float _min_search_win_phi_intt[4];
-	float _max_search_win_theta_intt[4];
-	float _min_search_win_theta_intt[4];
+	float _max_search_win_phi_intt[8];
+	float _min_search_win_phi_intt[8];
+	float _max_search_win_theta_intt[8];
+	float _min_search_win_theta_intt[8];
 
 	float _max_search_win_phi_maps;
 	float _min_search_win_phi_maps;


### PR DESCRIPTION
Modified the INTT simulation code so that what was formerly up to 4 layers with 2 sub-layers each, now becomes up to 8 single layers that can be configured independently. This is intended to make the setup more flexible, and make it easier to study the performance.

I also added some checks in the stepping action for glitches in the G4 handling of the active volume. There seem to be no problems in the present code, which uses a single active sensor volume and determines the strip later in the cell reco. The only strange events observed in the INTT sensors (track does not exit volume) appear to be due to hadronic interactions that kill the track. 

I will also commit a matching tracking macro.
