### PR TITLE
Fix prototype4

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalDetector.cc
@@ -157,7 +157,7 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   G4RotationMatrix *Rot;
   Rot = new G4RotationMatrix();
   Rot->rotateX(90 * deg);
-  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit9_logic, "InnerScinti_9", scintiboxlogical, false, 9, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit9_logic, "InnerScinti_9", scintiboxlogical, false, 0, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -169,7 +169,7 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   distance_to_corner += m_ScintiTile9FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();
   Rot->rotateX(90 * deg);
-  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit10_logic, "InnerScinti_10", scintiboxlogical, false, 10, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit10_logic, "InnerScinti_10", scintiboxlogical, false, 0, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -181,7 +181,7 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   distance_to_corner += m_ScintiTile10FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();
   Rot->rotateX(90 * deg);
-  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit11_logic, "InnerScinti_11", scintiboxlogical, false, 11, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit11_logic, "InnerScinti_11", scintiboxlogical, false, 0, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -193,7 +193,7 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   distance_to_corner += m_ScintiTile11FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();
   Rot->rotateX(90 * deg);
-  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit12_logic, "InnerScinti_12", scintiboxlogical, false, 12, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit12_logic, "InnerScinti_12", scintiboxlogical, false, 0, OverlapCheck());
   //    DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
 }

--- a/simulation/g4simulation/g4histos/G4TowerNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4TowerNtuple.cc
@@ -61,7 +61,7 @@ G4TowerNtuple::process_event( PHCompositeNode* topNode )
     {
       int detid = (_detid.find(*iter))->second;
       nodename.str("");
-      nodename << "TOWER_CALIB_" << *iter;
+      nodename << "TOWER_" << _tower_type[*iter];
       geonodename.str("");
       geonodename << "TOWERGEOM_" << *iter;
       RawTowerGeomContainer* towergeom = findNode::getClass<RawTowerGeomContainer>(topNode, geonodename.str().c_str());
@@ -119,9 +119,12 @@ G4TowerNtuple::End(PHCompositeNode * topNode)
 }
 
 void
-G4TowerNtuple::AddNode(const std::string &name, const int detid)
+G4TowerNtuple::AddNode(const std::string &name, const std::string &twrtype, const int detid)
 {
+  ostringstream twrname;
+  twrname << twrtype << "_" << name;
  _node_postfix.insert(name);
+  _tower_type.insert(make_pair(name,twrname.str()));
  _detid[name] = detid;
  return;
 }

--- a/simulation/g4simulation/g4histos/G4TowerNtuple.h
+++ b/simulation/g4simulation/g4histos/G4TowerNtuple.h
@@ -34,7 +34,7 @@ class G4TowerNtuple: public SubsysReco
   //! end of run method
   int End(PHCompositeNode *);
 
-  void AddNode(const std::string &name, const int detid=0);
+  void AddNode(const std::string &name, const std::string &twrtype, const int detid);
 
 protected:
   int nblocks;
@@ -44,6 +44,7 @@ protected:
   //  std::vector<TH2 *> nhit_edep;
   std::string _filename;
   std::set<std::string> _node_postfix;
+  std::map<std::string, std::string> _tower_type;
   std::map<std::string, int> _detid;
   TNtuple *ntup;
   TFile *outfile;


### PR DESCRIPTION
The eta bins started at 10 putting a monkey wrench into the analysis code. Now the g4vplacements use copy no = 0 just like for the other prototypes which makes the etabin start at 0