### PR TITLE
Fix prototype2/3

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -4,7 +4,6 @@
 
 #include <g4main/PHG4Utils.h>
 
-
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
@@ -23,15 +22,16 @@
 using namespace std;
 
 //_______________________________________________________________
-PHG4BlockDetector::PHG4BlockDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr):
-  PHG4Detector(Node, dnam),
-  m_Params(parameters),
-  m_BlockPhysi(nullptr),
-  m_Layer(lyr)
-{}
+PHG4BlockDetector::PHG4BlockDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr)
+  : PHG4Detector(Node, dnam)
+  , m_Params(parameters)
+  , m_BlockPhysi(nullptr)
+  , m_Layer(lyr)
+{
+}
 
 //_______________________________________________________________
-bool PHG4BlockDetector::IsInBlock(G4VPhysicalVolume * volume) const
+bool PHG4BlockDetector::IsInBlock(G4VPhysicalVolume *volume) const
 {
   if (volume == m_BlockPhysi)
   {
@@ -41,22 +41,20 @@ bool PHG4BlockDetector::IsInBlock(G4VPhysicalVolume * volume) const
 }
 
 //_______________________________________________________________
-void PHG4BlockDetector::Construct( G4LogicalVolume* logicWorld )
+void PHG4BlockDetector::Construct(G4LogicalVolume *logicWorld)
 {
+  G4Material *TrackerMaterial = G4Material::GetMaterial(m_Params->get_string_param("material"));
 
-  G4Material* TrackerMaterial = G4Material::GetMaterial(m_Params->get_string_param("material"));
-
-
-  if ( ! TrackerMaterial )
-    {
-      std::cout << "Error: Can not set material" << std::endl;
-      exit(-1);
-    }
+  if (!TrackerMaterial)
+  {
+    std::cout << "Error: Can not set material" << std::endl;
+    exit(-1);
+  }
 
   G4VSolid *block_solid = new G4Box(G4String(GetName().c_str()),
-                          m_Params->get_double_param("size_x")/2.*cm,
-                          m_Params->get_double_param("size_y")/2.*cm,
-			  m_Params->get_double_param("size_z")/2.*cm);
+                                    m_Params->get_double_param("size_x") / 2. * cm,
+                                    m_Params->get_double_param("size_y") / 2. * cm,
+                                    m_Params->get_double_param("size_z") / 2. * cm);
 
   double steplimits = m_Params->get_double_param("steplimits") * cm;
   G4UserLimits *g4userlimits = nullptr;
@@ -66,30 +64,28 @@ void PHG4BlockDetector::Construct( G4LogicalVolume* logicWorld )
   }
 
   G4LogicalVolume *block_logic = new G4LogicalVolume(block_solid,
-                                    TrackerMaterial,
-                                    G4String(GetName().c_str()),
-                                    nullptr, nullptr, g4userlimits);
+                                                     TrackerMaterial,
+                                                     G4String(GetName().c_str()),
+                                                     nullptr, nullptr, g4userlimits);
   G4VisAttributes matVis;
   if (m_Params->get_int_param("blackhole"))
-    {
-      PHG4Utils::SetColour(&matVis, "BlackHole");
-      matVis.SetVisibility(false);
-      matVis.SetForceSolid(false);
-    }
+  {
+    PHG4Utils::SetColour(&matVis, "BlackHole");
+    matVis.SetVisibility(false);
+    matVis.SetForceSolid(false);
+  }
   else
-    {
-      PHG4Utils::SetColour(&matVis, m_Params->get_string_param("material"));
-      matVis.SetVisibility(true);
-      matVis.SetForceSolid(true);
-    }
+  {
+    PHG4Utils::SetColour(&matVis, m_Params->get_string_param("material"));
+    matVis.SetVisibility(true);
+    matVis.SetForceSolid(true);
+  }
   block_logic->SetVisAttributes(matVis);
 
-  G4RotationMatrix *rotm  = new G4RotationMatrix();
-  rotm->rotateZ(m_Params->get_double_param("rot_z")*deg);
-  m_BlockPhysi = new G4PVPlacement(rotm, G4ThreeVector(m_Params->get_double_param("place_x")*cm,
-                                                      m_Params->get_double_param("place_y")*cm,
-						      m_Params->get_double_param("place_z")*cm),
-                                  block_logic,
-                                  G4String(GetName().c_str()),
-                                  logicWorld, 0, false, OverlapCheck());
+  G4RotationMatrix *rotm = new G4RotationMatrix();
+  rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
+  m_BlockPhysi = new G4PVPlacement(rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm),
+                                   block_logic,
+                                   G4String(GetName().c_str()),
+                                   logicWorld, 0, false, OverlapCheck());
 }

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -25,15 +25,15 @@ using namespace std;
 //_______________________________________________________________
 PHG4BlockDetector::PHG4BlockDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr):
   PHG4Detector(Node, dnam),
-  params(parameters),
-  block_physi(nullptr),
-  layer(lyr)
+  m_Params(parameters),
+  m_BlockPhysi(nullptr),
+  m_Layer(lyr)
 {}
 
 //_______________________________________________________________
 bool PHG4BlockDetector::IsInBlock(G4VPhysicalVolume * volume) const
 {
-  if (volume == block_physi)
+  if (volume == m_BlockPhysi)
   {
     return true;
   }
@@ -44,7 +44,7 @@ bool PHG4BlockDetector::IsInBlock(G4VPhysicalVolume * volume) const
 void PHG4BlockDetector::Construct( G4LogicalVolume* logicWorld )
 {
 
-  G4Material* TrackerMaterial = G4Material::GetMaterial(params->get_string_param("material"));
+  G4Material* TrackerMaterial = G4Material::GetMaterial(m_Params->get_string_param("material"));
 
 
   if ( ! TrackerMaterial )
@@ -54,11 +54,11 @@ void PHG4BlockDetector::Construct( G4LogicalVolume* logicWorld )
     }
 
   G4VSolid *block_solid = new G4Box(G4String(GetName().c_str()),
-                          params->get_double_param("size_x")/2.*cm,
-                          params->get_double_param("size_y")/2.*cm,
-			  params->get_double_param("size_z")/2.*cm);
+                          m_Params->get_double_param("size_x")/2.*cm,
+                          m_Params->get_double_param("size_y")/2.*cm,
+			  m_Params->get_double_param("size_z")/2.*cm);
 
-  double steplimits = params->get_double_param("steplimits") * cm;
+  double steplimits = m_Params->get_double_param("steplimits") * cm;
   G4UserLimits *g4userlimits = nullptr;
   if (isfinite(steplimits))
   {
@@ -69,26 +69,26 @@ void PHG4BlockDetector::Construct( G4LogicalVolume* logicWorld )
                                     TrackerMaterial,
                                     G4String(GetName().c_str()),
                                     nullptr, nullptr, g4userlimits);
-  G4VisAttributes* matVis = new G4VisAttributes();
-  if (params->get_int_param("blackhole"))
+  G4VisAttributes matVis;
+  if (m_Params->get_int_param("blackhole"))
     {
-      PHG4Utils::SetColour(matVis, "BlackHole");
-      matVis->SetVisibility(false);
-      matVis->SetForceSolid(false);
+      PHG4Utils::SetColour(&matVis, "BlackHole");
+      matVis.SetVisibility(false);
+      matVis.SetForceSolid(false);
     }
   else
     {
-      PHG4Utils::SetColour(matVis, params->get_string_param("material"));
-      matVis->SetVisibility(true);
-      matVis->SetForceSolid(true);
+      PHG4Utils::SetColour(&matVis, m_Params->get_string_param("material"));
+      matVis.SetVisibility(true);
+      matVis.SetForceSolid(true);
     }
   block_logic->SetVisAttributes(matVis);
 
   G4RotationMatrix *rotm  = new G4RotationMatrix();
-  rotm->rotateZ(params->get_double_param("rot_z")*deg);
-  block_physi = new G4PVPlacement(rotm, G4ThreeVector(params->get_double_param("place_x")*cm,
-                                                      params->get_double_param("place_y")*cm,
-						      params->get_double_param("place_z")*cm),
+  rotm->rotateZ(m_Params->get_double_param("rot_z")*deg);
+  m_BlockPhysi = new G4PVPlacement(rotm, G4ThreeVector(m_Params->get_double_param("place_x")*cm,
+                                                      m_Params->get_double_param("place_y")*cm,
+						      m_Params->get_double_param("place_z")*cm),
                                   block_logic,
                                   G4String(GetName().c_str()),
                                   logicWorld, 0, false, OverlapCheck());

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
@@ -9,40 +9,36 @@ class G4LogicalVolume;
 class PHParameters;
 class G4VPhysicalVolume;
 
-class PHG4BlockDetector: public PHG4Detector
+class PHG4BlockDetector : public PHG4Detector
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4BlockDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam="BLOCK", const int lyr = 0 );
+  PHG4BlockDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam = "BLOCK", const int lyr = 0);
 
   //! destructor
-  virtual ~PHG4BlockDetector( void )
-  {}
+  virtual ~PHG4BlockDetector(void)
+  {
+  }
 
   //! construct
-  virtual void Construct( G4LogicalVolume* world );
+  virtual void Construct(G4LogicalVolume *world);
 
   //!@name volume accessors
   //@{
-  bool IsInBlock(G4VPhysicalVolume*) const;
+  bool IsInBlock(G4VPhysicalVolume *) const;
   //@}
 
-  void SuperDetector(const std::string &name) {m_SuperDetector = name;}
-  const std::string SuperDetector() const {return m_SuperDetector;}
-  int get_Layer() const {return m_Layer;}
+  void SuperDetector(const std::string &name) { m_SuperDetector = name; }
+  const std::string SuperDetector() const { return m_SuperDetector; }
+  int get_Layer() const { return m_Layer; }
 
-  private:
-
+ private:
   PHParameters *m_Params;
- 
-  G4VPhysicalVolume* m_BlockPhysi;
 
+  G4VPhysicalVolume *m_BlockPhysi;
 
   int m_Layer;
   std::string m_SuperDetector;
-  
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
@@ -1,5 +1,7 @@
-#ifndef PHG4BlockDetector_h
-#define PHG4BlockDetector_h
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4BLOCKDETECTOR_H
+#define G4DETECTORS_PHG4BLOCKDETECTOR_H
 
 #include <g4main/PHG4Detector.h>
 
@@ -27,19 +29,19 @@ class PHG4BlockDetector: public PHG4Detector
   bool IsInBlock(G4VPhysicalVolume*) const;
   //@}
 
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return layer;}
+  void SuperDetector(const std::string &name) {m_SuperDetector = name;}
+  const std::string SuperDetector() const {return m_SuperDetector;}
+  int get_Layer() const {return m_Layer;}
 
   private:
 
-  PHParameters *params;
+  PHParameters *m_Params;
  
-  G4VPhysicalVolume* block_physi;
+  G4VPhysicalVolume* m_BlockPhysi;
 
 
-  int layer;
-  std::string superdetector;
+  int m_Layer;
+  std::string m_SuperDetector;
   
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
@@ -33,8 +33,8 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
 
   void FieldChecker(const G4Step *);
   void EnableFieldChecker(const int i = 1) { m_EnableFieldCheckerFlag = i; }
- 
-private:
+
+ private:
   //! pointer to the detector
   PHG4OuterHcalDetector *m_Detector;
 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
@@ -1,5 +1,7 @@
-#ifndef PHG4OuterHcalSteppingAction_h
-#define PHG4OuterHcalSteppingAction_h
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4OUTERHCALSTEPPINGACTION_H
+#define G4DETECTORS_PHG4OUTERHCALSTEPPINGACTION_H
 
 #include <g4main/PHG4SteppingAction.h>
 
@@ -30,38 +32,38 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
   double GetLightCorrection(const double r) const;
 
   void FieldChecker(const G4Step *);
-  void EnableFieldChecker(const int i = 1) { enable_field_checker = i; }
- private:
+  void EnableFieldChecker(const int i = 1) { m_EnableFieldCheckerFlag = i; }
+ 
+private:
   //! pointer to the detector
-  PHG4OuterHcalDetector *detector_;
+  PHG4OuterHcalDetector *m_Detector;
 
   //! pointer to hit container
-  PHG4HitContainer *hits_;
-  PHG4HitContainer *absorberhits_;
-  PHG4Hit *hit;
-  const PHParameters *params;
-  PHG4HitContainer *savehitcontainer;
-  PHG4Shower *saveshower;
-  G4VPhysicalVolume *savevolpre;
-  G4VPhysicalVolume *savevolpost;
-  int savetrackid;
-  int saveprestepstatus;
-  int savepoststepstatus;
-  int enable_field_checker;
+  PHG4HitContainer *m_Hits;
+  PHG4HitContainer *m_AbsorberHits;
+  PHG4Hit *m_Hit;
+  const PHParameters *m_Params;
+  PHG4HitContainer *m_SaveHitContainer;
+  PHG4Shower *m_SaveShower;
+  G4VPhysicalVolume *m_SaveVolPre;
+  G4VPhysicalVolume *m_SaveVolPost;
+  int m_SaveTrackId;
+  int m_SavePreStepStatus;
+  int m_SavePostStepStatus;
+  int m_EnableFieldCheckerFlag;
 
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables
-  int absorbertruth;
-  int IsActive;
-  int IsBlackHole;
-  int n_scinti_plates;
-  int light_scint_model;
+  int m_IsActiveFlag;
+  int m_IsBlackHoleFlag;
+  int m_NScintiPlates;
+  int m_LightScintModelFlag;
 
-  double light_balance_inner_corr;
-  double light_balance_inner_radius;
-  double light_balance_outer_corr;
-  double light_balance_outer_radius;
+  double m_LightBalanceInnerCorr;
+  double m_LightBalanceInnerRadius;
+  double m_LightBalanceOuterCorr;
+  double m_LightBalanceOuterRadius;
 };
 
 #endif  // PHG4OuterHcalSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -149,7 +149,7 @@ PHG4Prototype2InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
 G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope)
 {
-  int copynum = 9;
+  int copynum = 0;
   G4VSolid* scintiboxsolid = new G4Box(scintimothername,scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -15,10 +15,10 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4RotationMatrix.hh>
+#include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4RotationMatrix.hh>
 
 #include <boost/format.hpp>
 
@@ -30,70 +30,78 @@ using namespace std;
 static const string scintimothername = "InnerHcalScintiMother";
 static const string steelplatename = "InnerHcalSteelPlate";
 
-PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam  ):
-  PHG4Detector(Node, dnam),
-  m_Params(parameters),
-  m_InnerHcalSteelPlate(nullptr),
-  m_InnerHcalAssembly(nullptr),
-  m_SteelPlateCornerUpperLeft(1157.5*mm,-151.44*mm),
-  m_SteelPlateCornerUpperRight(1308.5*mm,-286.96*mm), 
-  m_SteelPlateCornerLowerRight(1298.8*mm,-297.39*mm),
-  m_SteelPlateCornerLowerLeft(1155.8*mm,-163.92*mm),
+PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
+  : PHG4Detector(Node, dnam)
+  , m_Params(parameters)
+  , m_InnerHcalSteelPlate(nullptr)
+  , m_InnerHcalAssembly(nullptr)
+  , m_SteelPlateCornerUpperLeft(1157.5 * mm, -151.44 * mm)
+  , m_SteelPlateCornerUpperRight(1308.5 * mm, -286.96 * mm)
+  , m_SteelPlateCornerLowerRight(1298.8 * mm, -297.39 * mm)
+  , m_SteelPlateCornerLowerLeft(1155.8 * mm, -163.92 * mm)
+  ,
 
-  m_ScintiUoneFrontSize(105.9*mm),
-  m_ScintiUoneCornerUpperLeft(0*mm,0*mm),
-  m_ScintiUoneCornerUpperRight(198.1*mm,0*mm),
-  m_ScintiUoneCornerLowerRight(198.1*mm,-121.3*mm),
-  m_ScintiUoneCornerLowerLeft(0*mm,-m_ScintiUoneFrontSize),
+  m_ScintiUoneFrontSize(105.9 * mm)
+  , m_ScintiUoneCornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiUoneCornerUpperRight(198.1 * mm, 0 * mm)
+  , m_ScintiUoneCornerLowerRight(198.1 * mm, -121.3 * mm)
+  , m_ScintiUoneCornerLowerLeft(0 * mm, -m_ScintiUoneFrontSize)
+  ,
 
-  m_ScintiU2CornerUpperLeft(0*mm,0*mm),
-  m_ScintiU2CornerUpperRight(198.1*mm,-15.4*mm),
-  m_ScintiU2CornerLowerRight(198.1*mm,-141.5*mm),
-  m_ScintiU2CornerLowerLeft(0*mm,-110.59*mm),
+  m_ScintiU2CornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiU2CornerUpperRight(198.1 * mm, -15.4 * mm)
+  , m_ScintiU2CornerLowerRight(198.1 * mm, -141.5 * mm)
+  , m_ScintiU2CornerLowerLeft(0 * mm, -110.59 * mm)
+  ,
 
-  m_ScintiT9DistanceToCorner(26.44*mm),
-  m_ScintiT9FrontSize(140.3*mm),
-  m_ScintiT9CornerUpperLeft(0*mm,0*mm),
-  m_ScintiT9CornerUpperRight(198.1*mm,-134.4*mm),
-  m_ScintiT9CornerLowerRight(198.1*mm,-198.1*mm/tan(52.02/180.*M_PI)-m_ScintiT9FrontSize),
-  m_ScintiT9CornerLowerLeft(0*mm,-m_ScintiT9FrontSize),
+  m_ScintiT9DistanceToCorner(26.44 * mm)
+  , m_ScintiT9FrontSize(140.3 * mm)
+  , m_ScintiT9CornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiT9CornerUpperRight(198.1 * mm, -134.4 * mm)
+  , m_ScintiT9CornerLowerRight(198.1 * mm, -198.1 * mm / tan(52.02 / 180. * M_PI) - m_ScintiT9FrontSize)
+  , m_ScintiT9CornerLowerLeft(0 * mm, -m_ScintiT9FrontSize)
+  ,
 
-  m_ScintiT10FrontSize(149.2*mm),
-  m_ScintiT10CornerUpperLeft(0*mm,0*mm),
-  m_ScintiT10CornerUpperRight(198.1*mm,-154.6*mm),
-  m_ScintiT10CornerLowerRight(198.1*mm,-198.1*mm/tan(48.34/180.*M_PI)-m_ScintiT10FrontSize),
-  m_ScintiT10CornerLowerLeft(0*mm,-m_ScintiT10FrontSize),
+  m_ScintiT10FrontSize(149.2 * mm)
+  , m_ScintiT10CornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiT10CornerUpperRight(198.1 * mm, -154.6 * mm)
+  , m_ScintiT10CornerLowerRight(198.1 * mm, -198.1 * mm / tan(48.34 / 180. * M_PI) - m_ScintiT10FrontSize)
+  , m_ScintiT10CornerLowerLeft(0 * mm, -m_ScintiT10FrontSize)
+  ,
 
+  m_ScintiT11FrontSize(144.3 * mm)
+  , m_ScintiT11CornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiT11CornerUpperRight(198.1 * mm, -176.2 * mm)
+  , m_ScintiT11CornerLowerRight(198.1 * mm, -198.1 * mm / tan(45.14 / 180. * M_PI) - m_ScintiT11FrontSize)
+  , m_ScintiT11CornerLowerLeft(0 * mm, -m_ScintiT11FrontSize)
+  ,
 
-  m_ScintiT11FrontSize(144.3*mm),
-  m_ScintiT11CornerUpperLeft(0*mm,0*mm),
-  m_ScintiT11CornerUpperRight(198.1*mm,-176.2*mm),
-  m_ScintiT11CornerLowerRight(198.1*mm,-198.1*mm/tan(45.14/180.*M_PI)-m_ScintiT11FrontSize),
-  m_ScintiT11CornerLowerLeft(0*mm,-m_ScintiT11FrontSize),
+  m_ScintiT12FrontSize(186.6 * mm)
+  , m_ScintiT12CornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiT12CornerUpperRight(198.1 * mm, -197.11 * mm)
+  , m_ScintiT12CornerLowerRight(198.1 * mm, -198.1 * mm / tan(41.47 / 180. * M_PI) - m_ScintiT12FrontSize)
+  , m_ScintiT12CornerLowerLeft(0 * mm, -m_ScintiT12FrontSize)
+  ,
 
-  m_ScintiT12FrontSize(186.6*mm),
-  m_ScintiT12CornerUpperLeft(0*mm,0*mm),
-  m_ScintiT12CornerUpperRight(198.1*mm,-197.11*mm),
-  m_ScintiT12CornerLowerRight(198.1*mm,-198.1*mm/tan(41.47/180.*M_PI)-m_ScintiT12FrontSize),
-  m_ScintiT12CornerLowerLeft(0*mm,-m_ScintiT12FrontSize),
-
-  m_ScintiX(198.1),
-  m_SteelZ(901.7*mm),
-  m_SizeZ(m_SteelZ),
-  m_ScintiTileZ(m_SteelZ),
-  m_ScintiTileThickness(7*mm),
-  m_ScintiBoxSmaller(0.02*mm), // blargh - off by 20 microns bc scinti tilt angle, need to revisit at some point
-  m_GapBetweenTiles(1*mm),
-  m_ScintiGap(8.5*mm),
-  m_DeltaPhi(2*M_PI/320.),
-  m_VolumeSteel(NAN),
-  m_VolumeScintillator(NAN),
-  m_NScintiPlates(20),
-  m_NSteelPlates(m_NScintiPlates+1),
-  m_ActiveFlag(m_Params->get_int_param("active")),
-  m_AbsorberActiveFlag(m_Params->get_int_param("absorberactive")),
-  m_Layer(0)
-{}
+  m_ScintiX(198.1)
+  , m_SteelZ(901.7 * mm)
+  , m_SizeZ(m_SteelZ)
+  , m_ScintiTileZ(m_SteelZ)
+  , m_ScintiTileThickness(7 * mm)
+  , m_ScintiBoxSmaller(0.02 * mm)
+  ,  // blargh - off by 20 microns bc scinti tilt angle, need to revisit at some point
+  m_GapBetweenTiles(1 * mm)
+  , m_ScintiGap(8.5 * mm)
+  , m_DeltaPhi(2 * M_PI / 320.)
+  , m_VolumeSteel(NAN)
+  , m_VolumeScintillator(NAN)
+  , m_NScintiPlates(20)
+  , m_NSteelPlates(m_NScintiPlates + 1)
+  , m_ActiveFlag(m_Params->get_int_param("active"))
+  , m_AbsorberActiveFlag(m_Params->get_int_param("absorberactive"))
+  , m_Layer(0)
+{
+}
 
 PHG4Prototype2InnerHcalDetector::~PHG4Prototype2InnerHcalDetector()
 {
@@ -102,10 +110,9 @@ PHG4Prototype2InnerHcalDetector::~PHG4Prototype2InnerHcalDetector()
 
 //_______________________________________________________________
 //_______________________________________________________________
-int
-PHG4Prototype2InnerHcalDetector::IsInPrototype2InnerHcal(G4VPhysicalVolume * volume) const
+int PHG4Prototype2InnerHcalDetector::IsInPrototype2InnerHcal(G4VPhysicalVolume* volume) const
 {
-  G4LogicalVolume *logvol = volume->GetLogicalVolume();
+  G4LogicalVolume* logvol = volume->GetLogicalVolume();
   if (m_AbsorberActiveFlag && logvol == m_InnerHcalSteelPlate)
   {
     return -1;
@@ -121,28 +128,28 @@ G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelope)
 {
   if (!m_InnerHcalSteelPlate)
-    {
-      G4VSolid* steel_plate;
-      std::vector<G4TwoVector> vertexes;
-      vertexes.push_back(m_SteelPlateCornerUpperLeft);
-      vertexes.push_back(m_SteelPlateCornerUpperRight);
-      vertexes.push_back(m_SteelPlateCornerLowerRight);
-      vertexes.push_back(m_SteelPlateCornerLowerLeft);
-      G4TwoVector zero(0, 0);
-      steel_plate =  new G4ExtrudedSolid("InnerHcalSteelPlateSolid",
-					 vertexes,
-					 m_SizeZ  / 2.0,
-					 zero, 1.0,
-					 zero, 1.0);
+  {
+    G4VSolid* steel_plate;
+    std::vector<G4TwoVector> vertexes;
+    vertexes.push_back(m_SteelPlateCornerUpperLeft);
+    vertexes.push_back(m_SteelPlateCornerUpperRight);
+    vertexes.push_back(m_SteelPlateCornerLowerRight);
+    vertexes.push_back(m_SteelPlateCornerLowerLeft);
+    G4TwoVector zero(0, 0);
+    steel_plate = new G4ExtrudedSolid("InnerHcalSteelPlateSolid",
+                                      vertexes,
+                                      m_SizeZ / 2.0,
+                                      zero, 1.0,
+                                      zero, 1.0);
 
-      m_VolumeSteel = steel_plate->GetCubicVolume()*m_NSteelPlates;
-      m_InnerHcalSteelPlate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("Steel_A36"),steelplatename, 0, 0, 0);
-      G4VisAttributes visattchk;
-      visattchk.SetVisibility(true);
-      visattchk.SetForceSolid(false);
-      visattchk.SetColour(G4Colour::Blue());
-      m_InnerHcalSteelPlate->SetVisAttributes(visattchk);
-    }
+    m_VolumeSteel = steel_plate->GetCubicVolume() * m_NSteelPlates;
+    m_InnerHcalSteelPlate = new G4LogicalVolume(steel_plate, G4Material::GetMaterial("Steel_A36"), steelplatename, 0, 0, 0);
+    G4VisAttributes visattchk;
+    visattchk.SetVisibility(true);
+    visattchk.SetForceSolid(false);
+    visattchk.SetColour(G4Colour::Blue());
+    m_InnerHcalSteelPlate->SetVisAttributes(visattchk);
+  }
   return m_InnerHcalSteelPlate;
 }
 
@@ -150,58 +157,58 @@ G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope)
 {
   int copynum = 0;
-  G4VSolid* scintiboxsolid = new G4Box(scintimothername,m_ScintiX/2.,(m_ScintiGap-m_ScintiBoxSmaller)/2.,m_ScintiTileZ/2.);
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername, m_ScintiX / 2., (m_ScintiGap - m_ScintiBoxSmaller) / 2., m_ScintiTileZ / 2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
 
-  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),scintimothername, 0, 0, 0);
+  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid, G4Material::GetMaterial("G4_AIR"), scintimothername, 0, 0, 0);
   G4VisAttributes hcalVisAtt;
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
   hcalVisAtt.SetColour(G4Colour::Magenta());
-  G4LogicalVolume *scintit9_logic = ConstructScintiTile9(hcalenvelope);
+  G4LogicalVolume* scintit9_logic = ConstructScintiTile9(hcalenvelope);
   scintit9_logic->SetVisAttributes(hcalVisAtt);
 
-  double distance_to_corner = -m_SizeZ/2.+m_ScintiT9DistanceToCorner;
-  G4RotationMatrix *Rot;  
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,distance_to_corner),scintit9_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  double distance_to_corner = -m_SizeZ / 2. + m_ScintiT9DistanceToCorner;
+  G4RotationMatrix* Rot;
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit9_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
   hcalVisAtt.SetColour(G4Colour::Blue());
-  G4LogicalVolume *scintit10_logic = ConstructScintiTile10(hcalenvelope);
+  G4LogicalVolume* scintit10_logic = ConstructScintiTile10(hcalenvelope);
   scintit10_logic->SetVisAttributes(hcalVisAtt);
 
   distance_to_corner += m_ScintiT9FrontSize + m_GapBetweenTiles;
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,distance_to_corner),scintit10_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit10_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
   hcalVisAtt.SetColour(G4Colour::Yellow());
-  G4LogicalVolume *scintit11_logic = ConstructScintiTile11(hcalenvelope);
+  G4LogicalVolume* scintit11_logic = ConstructScintiTile11(hcalenvelope);
   scintit11_logic->SetVisAttributes(hcalVisAtt);
 
   distance_to_corner += m_ScintiT10FrontSize + m_GapBetweenTiles;
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,distance_to_corner),scintit11_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit11_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
   hcalVisAtt.SetColour(G4Colour::Cyan());
-  G4LogicalVolume *scintit12_logic = ConstructScintiTile12(hcalenvelope);
+  G4LogicalVolume* scintit12_logic = ConstructScintiTile12(hcalenvelope);
   scintit12_logic->SetVisAttributes(hcalVisAtt);
 
   distance_to_corner += m_ScintiT11FrontSize + m_GapBetweenTiles;
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,distance_to_corner),scintit12_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit12_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   //    DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
@@ -209,42 +216,42 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
 
 G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
-{ 
+{
   int copynum = 0;
-  G4VSolid* scintiboxsolid = new G4Box(scintimothername,m_ScintiX/2.,(m_ScintiGap-m_ScintiBoxSmaller)/2.,m_ScintiTileZ/2.);
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername, m_ScintiX / 2., (m_ScintiGap - m_ScintiBoxSmaller) / 2., m_ScintiTileZ / 2.);
   //    DisplayVolume(scintiboxsolid,hcalenvelope);
-  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),scintimothername, 0, 0, 0);
+  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid, G4Material::GetMaterial("G4_AIR"), scintimothername, 0, 0, 0);
   G4VisAttributes hcalVisAtt;
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
   hcalVisAtt.SetColour(G4Colour::Red());
-  G4LogicalVolume *scintiu1_logic = ConstructScintiTileU1(hcalenvelope);
+  G4LogicalVolume* scintiu1_logic = ConstructScintiTileU1(hcalenvelope);
   scintiu1_logic->SetVisAttributes(hcalVisAtt);
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
   hcalVisAtt.SetColour(G4Colour::Cyan());
-  G4LogicalVolume *scintiu2_logic = ConstructScintiTileU2(hcalenvelope);
+  G4LogicalVolume* scintiu2_logic = ConstructScintiTileU2(hcalenvelope);
   scintiu2_logic->SetVisAttributes(hcalVisAtt);
-  G4RotationMatrix *Rot;  
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(-90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,-m_ScintiUoneFrontSize-m_GapBetweenTiles/2.-m_GapBetweenTiles),scintiu2_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  G4RotationMatrix* Rot;
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(-90 * deg);
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, -m_ScintiUoneFrontSize - m_GapBetweenTiles / 2. - m_GapBetweenTiles), scintiu2_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(-90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(-90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,-m_GapBetweenTiles/2.),scintiu1_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, -m_GapBetweenTiles / 2.), scintiu1_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,m_GapBetweenTiles/2.),scintiu1_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, m_GapBetweenTiles / 2.), scintiu1_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,m_ScintiUoneFrontSize+m_GapBetweenTiles/2.+m_GapBetweenTiles),scintiu2_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, m_ScintiUoneFrontSize + m_GapBetweenTiles / 2. + m_GapBetweenTiles), scintiu2_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
   //  DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
 }
@@ -258,13 +265,13 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTileU1(G4LogicalVolume* hcalenve
   vertexes.push_back(m_ScintiUoneCornerLowerRight);
   vertexes.push_back(m_ScintiUoneCornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintiu1 =  new G4ExtrudedSolid("InnerHcalScintiU1",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintiu1 = new G4ExtrudedSolid("InnerHcalScintiU1",
+                                           vertexes,
+                                           m_ScintiTileThickness / 2.0,
+                                           zero, 1.0,
+                                           zero, 1.0);
 
-  G4LogicalVolume *scintiu1_logic = new G4LogicalVolume(scintiu1,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiU1", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintiu1_logic = new G4LogicalVolume(scintiu1, G4Material::GetMaterial("G4_POLYSTYRENE"), "InnerHcalScintiU1", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintiu1,hcalenvelope);
   m_ActiveVolumeSet.insert(scintiu1_logic);
   return scintiu1_logic;
@@ -279,13 +286,13 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenve
   vertexes.push_back(m_ScintiU2CornerLowerRight);
   vertexes.push_back(m_ScintiU2CornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintiu2 =  new G4ExtrudedSolid("InnerHcalScintiU2",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintiu2 = new G4ExtrudedSolid("InnerHcalScintiU2",
+                                           vertexes,
+                                           m_ScintiTileThickness / 2.0,
+                                           zero, 1.0,
+                                           zero, 1.0);
 
-  G4LogicalVolume *scintiu2_logic = new G4LogicalVolume(scintiu2,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiU2", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintiu2_logic = new G4LogicalVolume(scintiu2, G4Material::GetMaterial("G4_POLYSTYRENE"), "InnerHcalScintiU2", nullptr, nullptr, nullptr);
   //   DisplayVolume(scintiu2,hcalenvelope);
   m_ActiveVolumeSet.insert(scintiu2_logic);
   return scintiu2_logic;
@@ -300,13 +307,13 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile9(G4LogicalVolume* hcalenvel
   vertexes.push_back(m_ScintiT9CornerLowerRight);
   vertexes.push_back(m_ScintiT9CornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintit9 =  new G4ExtrudedSolid("InnerHcalScintiT9",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintit9 = new G4ExtrudedSolid("InnerHcalScintiT9",
+                                           vertexes,
+                                           m_ScintiTileThickness / 2.0,
+                                           zero, 1.0,
+                                           zero, 1.0);
 
-  G4LogicalVolume *scintit9_logic = new G4LogicalVolume(scintit9,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT9", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintit9_logic = new G4LogicalVolume(scintit9, G4Material::GetMaterial("G4_POLYSTYRENE"), "InnerHcalScintiT9", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit9,hcalenvelope);
   m_ActiveVolumeSet.insert(scintit9_logic);
   return scintit9_logic;
@@ -321,13 +328,13 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile10(G4LogicalVolume* hcalenve
   vertexes.push_back(m_ScintiT10CornerLowerRight);
   vertexes.push_back(m_ScintiT10CornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintit10 =  new G4ExtrudedSolid("InnerHcalScintiT10",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintit10 = new G4ExtrudedSolid("InnerHcalScintiT10",
+                                            vertexes,
+                                            m_ScintiTileThickness / 2.0,
+                                            zero, 1.0,
+                                            zero, 1.0);
 
-  G4LogicalVolume *scintit10_logic = new G4LogicalVolume(scintit10,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT10", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintit10_logic = new G4LogicalVolume(scintit10, G4Material::GetMaterial("G4_POLYSTYRENE"), "InnerHcalScintiT10", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit10,hcalenvelope);
   m_ActiveVolumeSet.insert(scintit10_logic);
   return scintit10_logic;
@@ -342,13 +349,13 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile11(G4LogicalVolume* hcalenve
   vertexes.push_back(m_ScintiT11CornerLowerRight);
   vertexes.push_back(m_ScintiT11CornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintit11 =  new G4ExtrudedSolid("InnerHcalScintiT11",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintit11 = new G4ExtrudedSolid("InnerHcalScintiT11",
+                                            vertexes,
+                                            m_ScintiTileThickness / 2.0,
+                                            zero, 1.0,
+                                            zero, 1.0);
 
-  G4LogicalVolume *scintit11_logic = new G4LogicalVolume(scintit11,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT11", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintit11_logic = new G4LogicalVolume(scintit11, G4Material::GetMaterial("G4_POLYSTYRENE"), "InnerHcalScintiT11", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit11,hcalenvelope);
   m_ActiveVolumeSet.insert(scintit11_logic);
   return scintit11_logic;
@@ -363,13 +370,13 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
   vertexes.push_back(m_ScintiT12CornerLowerRight);
   vertexes.push_back(m_ScintiT12CornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintit12 =  new G4ExtrudedSolid("InnerHcalScintiT12",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintit12 = new G4ExtrudedSolid("InnerHcalScintiT12",
+                                            vertexes,
+                                            m_ScintiTileThickness / 2.0,
+                                            zero, 1.0,
+                                            zero, 1.0);
 
-  G4LogicalVolume *scintit12_logic = new G4LogicalVolume(scintit12,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT12", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintit12_logic = new G4LogicalVolume(scintit12, G4Material::GetMaterial("G4_POLYSTYRENE"), "InnerHcalScintiT12", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit12,hcalenvelope);
   m_ActiveVolumeSet.insert(scintit12_logic);
   return scintit12_logic;
@@ -377,16 +384,15 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
 
 // Construct the envelope and the call the
 // actual inner hcal construction
-void
-PHG4Prototype2InnerHcalDetector::Construct( G4LogicalVolume* logicWorld )
+void PHG4Prototype2InnerHcalDetector::Construct(G4LogicalVolume* logicWorld)
 {
-  G4ThreeVector g4vec(m_Params->get_double_param("place_x")*cm,
-                      m_Params->get_double_param("place_y")*cm,
-		      m_Params->get_double_param("place_z")*cm);
+  G4ThreeVector g4vec(m_Params->get_double_param("place_x") * cm,
+                      m_Params->get_double_param("place_y") * cm,
+                      m_Params->get_double_param("place_z") * cm);
   G4RotationMatrix Rot;
-  Rot.rotateX(m_Params->get_double_param("rot_x")*deg);
-  Rot.rotateY(m_Params->get_double_param("rot_y")*deg);
-  Rot.rotateZ(m_Params->get_double_param("rot_z")*deg);
+  Rot.rotateX(m_Params->get_double_param("rot_x") * deg);
+  Rot.rotateY(m_Params->get_double_param("rot_y") * deg);
+  Rot.rotateZ(m_Params->get_double_param("rot_z") * deg);
   //  ConstructScintiTile9(logicWorld);
   //    ConstructScintillatorBoxHiEta(logicWorld);
   //ConstructScintillatorBox(logicWorld);
@@ -395,83 +401,82 @@ PHG4Prototype2InnerHcalDetector::Construct( G4LogicalVolume* logicWorld )
   //ConstructSteelPlate(hcal_envelope_log);
   // return;
   ConstructInnerHcal(logicWorld);
-  m_InnerHcalAssembly->MakeImprint(logicWorld,g4vec,&Rot,0,OverlapCheck());
-// this is rather pathetic - there is no way to extract the name when a volume is added
-// to the assembly. The only thing we can do is get an iterator over the placed volumes
-// in the order in which they were placed. Since this code does not install the scintillators
-// for the Al version, parsing the volume names to get the id does not work since it changes
-// So now we loop over all volumes and store them in a map for fast lookup of the row
+  m_InnerHcalAssembly->MakeImprint(logicWorld, g4vec, &Rot, 0, OverlapCheck());
+  // this is rather pathetic - there is no way to extract the name when a volume is added
+  // to the assembly. The only thing we can do is get an iterator over the placed volumes
+  // in the order in which they were placed. Since this code does not install the scintillators
+  // for the Al version, parsing the volume names to get the id does not work since it changes
+  // So now we loop over all volumes and store them in a map for fast lookup of the row
   int isteel = 0;
   int iscinti = 0;
   vector<G4VPhysicalVolume*>::iterator it = m_InnerHcalAssembly->GetVolumesIterator();
-  for (unsigned int i=0; i<m_InnerHcalAssembly-> TotalImprintedVolumes();i++)
+  for (unsigned int i = 0; i < m_InnerHcalAssembly->TotalImprintedVolumes(); i++)
   {
     string volname = (*it)->GetName();
     if (volname.find(steelplatename) != string::npos)
-    { 
-      m_SteelPlateIdMap.insert(make_pair(volname,isteel));
+    {
+      m_SteelPlateIdMap.insert(make_pair(volname, isteel));
       ++isteel;
     }
     else if (volname.find(scintimothername) != string::npos)
     {
-      m_ScintillatorIdMap.insert(make_pair(volname,iscinti));
+      m_ScintillatorIdMap.insert(make_pair(volname, iscinti));
       ++iscinti;
     }
     ++it;
   }
-// print out volume names and their assigned id
-   // map<string,int>::const_iterator iter;
-   // for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
-   // {
-   //   cout << iter->first << ", " << iter->second << endl;
-   // }
-   // for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
-   // {
-   //   cout << iter->first << ", " << iter->second << endl;
-   // }
+  // print out volume names and their assigned id
+  // map<string,int>::const_iterator iter;
+  // for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
+  // {
+  //   cout << iter->first << ", " << iter->second << endl;
+  // }
+  // for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
+  // {
+  //   cout << iter->first << ", " << iter->second << endl;
+  // }
   return;
 }
 
-int
-PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelope)
+int PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelope)
 {
-  G4LogicalVolume* steel_plate = ConstructSteelPlate(hcalenvelope); // bottom steel plate
+  G4LogicalVolume* steel_plate = ConstructSteelPlate(hcalenvelope);  // bottom steel plate
   G4LogicalVolume* scintibox = nullptr;
   if (m_Params->get_int_param("hi_eta"))
-    {
-      scintibox = ConstructScintillatorBoxHiEta(hcalenvelope);
-    }
+  {
+    scintibox = ConstructScintillatorBoxHiEta(hcalenvelope);
+  }
   else
-    {
-      scintibox = ConstructScintillatorBox(hcalenvelope);
-    }
+  {
+    scintibox = ConstructScintillatorBox(hcalenvelope);
+  }
   double phi = 0.;
   double phislat = 0.;
   // the coordinate of the center of the bottom of the bottom steel plate
   // to get the radius of the circle which is the center of the scintillator box
-  double bottom_xmiddle_steel_tile = (m_SteelPlateCornerLowerRight.x()+m_SteelPlateCornerLowerLeft.x())/2.;
-  double bottom_ymiddle_steel_tile = (m_SteelPlateCornerLowerLeft.y()+m_SteelPlateCornerLowerRight.y())/2.;
-  double middlerad = sqrt(bottom_xmiddle_steel_tile*bottom_xmiddle_steel_tile + bottom_ymiddle_steel_tile * bottom_ymiddle_steel_tile);
-  double philow = atan((bottom_ymiddle_steel_tile-m_ScintiGap/2.-0.87*mm)/bottom_xmiddle_steel_tile);
+  double bottom_xmiddle_steel_tile = (m_SteelPlateCornerLowerRight.x() + m_SteelPlateCornerLowerLeft.x()) / 2.;
+  double bottom_ymiddle_steel_tile = (m_SteelPlateCornerLowerLeft.y() + m_SteelPlateCornerLowerRight.y()) / 2.;
+  double middlerad = sqrt(bottom_xmiddle_steel_tile * bottom_xmiddle_steel_tile + bottom_ymiddle_steel_tile * bottom_ymiddle_steel_tile);
+  double philow = atan((bottom_ymiddle_steel_tile - m_ScintiGap / 2. - 0.87 * mm) / bottom_xmiddle_steel_tile);
   double scintiangle = GetScintiAngle();
   for (int i = 0; i < m_NSteelPlates; i++)
+  {
+    G4RotationMatrix Rot;
+    Rot.rotateZ(phi * rad);
+    G4ThreeVector g4vec(0, 0, 0);
+    m_InnerHcalAssembly->AddPlacedVolume(steel_plate, g4vec, &Rot);
+    if (i > 0)
     {
-      G4RotationMatrix Rot;
-      Rot.rotateZ(phi*rad);
-      G4ThreeVector g4vec(0,0,0);
-      m_InnerHcalAssembly->AddPlacedVolume(steel_plate,g4vec,&Rot);
-      if (i > 0)
-	{
-	  double ypos = sin(phi+philow) * middlerad;
-	  double xpos = cos(phi+philow) * middlerad;
-	  G4RotationMatrix Rot1;
-	  Rot1.rotateZ(scintiangle+phislat);
-	  G4ThreeVector g4vecsc(xpos, ypos, 0);
-	  m_InnerHcalAssembly->AddPlacedVolume(scintibox,g4vecsc,&Rot1);
-	  phislat += m_DeltaPhi;
-	}
-      phi += m_DeltaPhi;
+      double ypos = sin(phi + philow) * middlerad;
+      double xpos = cos(phi + philow) * middlerad;
+      G4RotationMatrix Rot1;
+      Rot1.rotateZ(scintiangle + phislat);
+      G4ThreeVector g4vecsc(xpos, ypos, 0);
+      m_InnerHcalAssembly->AddPlacedVolume(scintibox, g4vecsc, &Rot1);
+      phislat += m_DeltaPhi;
     }
+    phi += m_DeltaPhi;
+  }
   return 0;
 }
 
@@ -482,52 +487,50 @@ PHG4Prototype2InnerHcalDetector::GetScintiAngle()
 {
   double xlen = m_SteelPlateCornerUpperRight.x() - m_SteelPlateCornerUpperLeft.x();
   double ylen = m_SteelPlateCornerUpperRight.y() - m_SteelPlateCornerUpperLeft.y();
-  double angle = atan(ylen/xlen);
+  double angle = atan(ylen / xlen);
   return angle;
 }
 
-int
-PHG4Prototype2InnerHcalDetector::DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix *rotm )
+int PHG4Prototype2InnerHcalDetector::DisplayVolume(G4VSolid* volume, G4LogicalVolume* logvol, G4RotationMatrix* rotm)
 {
   G4LogicalVolume* checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), "DISPLAYLOGICAL", 0, 0, 0);
   DisplayVolume(checksolid, logvol, rotm);
   return 0;
 }
 
-int
-PHG4Prototype2InnerHcalDetector::DisplayVolume(G4LogicalVolume *checksolid,  G4LogicalVolume* logvol, G4RotationMatrix *rotm )
+int PHG4Prototype2InnerHcalDetector::DisplayVolume(G4LogicalVolume* checksolid, G4LogicalVolume* logvol, G4RotationMatrix* rotm)
 {
   static int i = 0;
   G4VisAttributes* visattchk = new G4VisAttributes();
   visattchk->SetVisibility(true);
   visattchk->SetForceSolid(false);
-  switch(i)
-    {
-    case 0:
-      visattchk->SetColour(G4Colour::Red());
-      i++;
-      break;
-    case 1:
-      visattchk->SetColour(G4Colour::Magenta());
-      i++;
-      break;
-    case 2:
-      visattchk->SetColour(G4Colour::Yellow());
-      i++;
-      break;
-    case 3:
-      visattchk->SetColour(G4Colour::Blue());
-      i++;
-      break;
-    case 4:
-      visattchk->SetColour(G4Colour::Cyan());
-      i++;
-      break;
-    default:
-      visattchk->SetColour(G4Colour::Green());
-      i = 0;
-      break;
-    }
+  switch (i)
+  {
+  case 0:
+    visattchk->SetColour(G4Colour::Red());
+    i++;
+    break;
+  case 1:
+    visattchk->SetColour(G4Colour::Magenta());
+    i++;
+    break;
+  case 2:
+    visattchk->SetColour(G4Colour::Yellow());
+    i++;
+    break;
+  case 3:
+    visattchk->SetColour(G4Colour::Blue());
+    i++;
+    break;
+  case 4:
+    visattchk->SetColour(G4Colour::Cyan());
+    i++;
+    break;
+  default:
+    visattchk->SetColour(G4Colour::Green());
+    i = 0;
+    break;
+  }
 
   checksolid->SetVisAttributes(visattchk);
   new G4PVPlacement(rotm, G4ThreeVector(0, 0, 0), checksolid, "DISPLAYVOL", logvol, 0, false, OverlapCheck());
@@ -535,20 +538,19 @@ PHG4Prototype2InnerHcalDetector::DisplayVolume(G4LogicalVolume *checksolid,  G4L
   return 0;
 }
 
-void
-PHG4Prototype2InnerHcalDetector::Print(const string &what) const
+void PHG4Prototype2InnerHcalDetector::Print(const string& what) const
 {
   cout << "Inner Hcal Detector:" << endl;
   if (what == "ALL" || what == "VOLUME")
-    {
-      cout << "Volume Steel: " << m_VolumeSteel/cm3 << " cm^3" << endl;
-      cout << "Volume Scintillator: " << m_VolumeScintillator/cm3 << " cm^3" << endl;
-    }
+  {
+    cout << "Volume Steel: " << m_VolumeSteel / cm3 << " cm^3" << endl;
+    cout << "Volume Scintillator: " << m_VolumeScintillator / cm3 << " cm^3" << endl;
+  }
   return;
 }
-int PHG4Prototype2InnerHcalDetector::get_scinti_row_id(const string &volname)
+int PHG4Prototype2InnerHcalDetector::get_scinti_row_id(const string& volname)
 {
-  int id=-9999;
+  int id = -9999;
   auto it = m_ScintillatorIdMap.find(volname);
   if (it != m_ScintillatorIdMap.end())
   {
@@ -562,9 +564,9 @@ int PHG4Prototype2InnerHcalDetector::get_scinti_row_id(const string &volname)
   return id;
 }
 
-int PHG4Prototype2InnerHcalDetector::get_steel_plate_id(const string &volname)
+int PHG4Prototype2InnerHcalDetector::get_steel_plate_id(const string& volname)
 {
-  int id=-9999;
+  int id = -9999;
   auto it = m_SteelPlateIdMap.find(volname);
   if (it != m_SteelPlateIdMap.end())
   {

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -32,67 +32,67 @@ static const string steelplatename = "InnerHcalSteelPlate";
 
 PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam  ):
   PHG4Detector(Node, dnam),
-  params(parameters),
+  m_Params(parameters),
   m_InnerHcalSteelPlate(nullptr),
   m_InnerHcalAssembly(nullptr),
-  steel_plate_corner_upper_left(1157.5*mm,-151.44*mm),
-  steel_plate_corner_upper_right(1308.5*mm,-286.96*mm), 
-  steel_plate_corner_lower_right(1298.8*mm,-297.39*mm),
-  steel_plate_corner_lower_left(1155.8*mm,-163.92*mm),
+  m_SteelPlateCornerUpperLeft(1157.5*mm,-151.44*mm),
+  m_SteelPlateCornerUpperRight(1308.5*mm,-286.96*mm), 
+  m_SteelPlateCornerLowerRight(1298.8*mm,-297.39*mm),
+  m_SteelPlateCornerLowerLeft(1155.8*mm,-163.92*mm),
 
-  scinti_u1_front_size(105.9*mm),
-  scinti_u1_corner_upper_left(0*mm,0*mm),
-  scinti_u1_corner_upper_right(198.1*mm,0*mm),
-  scinti_u1_corner_lower_right(198.1*mm,-121.3*mm),
-  scinti_u1_corner_lower_left(0*mm,-scinti_u1_front_size),
+  m_ScintiUoneFrontSize(105.9*mm),
+  m_ScintiUoneCornerUpperLeft(0*mm,0*mm),
+  m_ScintiUoneCornerUpperRight(198.1*mm,0*mm),
+  m_ScintiUoneCornerLowerRight(198.1*mm,-121.3*mm),
+  m_ScintiUoneCornerLowerLeft(0*mm,-m_ScintiUoneFrontSize),
 
-  scinti_u2_corner_upper_left(0*mm,0*mm),
-  scinti_u2_corner_upper_right(198.1*mm,-15.4*mm),
-  scinti_u2_corner_lower_right(198.1*mm,-141.5*mm),
-  scinti_u2_corner_lower_left(0*mm,-110.59*mm),
+  m_ScintiU2CornerUpperLeft(0*mm,0*mm),
+  m_ScintiU2CornerUpperRight(198.1*mm,-15.4*mm),
+  m_ScintiU2CornerLowerRight(198.1*mm,-141.5*mm),
+  m_ScintiU2CornerLowerLeft(0*mm,-110.59*mm),
 
-  scinti_t9_distance_to_corner(26.44*mm),
-  scinti_t9_front_size(140.3*mm),
-  scinti_t9_corner_upper_left(0*mm,0*mm),
-  scinti_t9_corner_upper_right(198.1*mm,-134.4*mm),
-  scinti_t9_corner_lower_right(198.1*mm,-198.1*mm/tan(52.02/180.*M_PI)-scinti_t9_front_size),
-  scinti_t9_corner_lower_left(0*mm,-scinti_t9_front_size),
+  m_ScintiT9DistanceToCorner(26.44*mm),
+  m_ScintiT9FrontSize(140.3*mm),
+  m_ScintiT9CornerUpperLeft(0*mm,0*mm),
+  m_ScintiT9CornerUpperRight(198.1*mm,-134.4*mm),
+  m_ScintiT9CornerLowerRight(198.1*mm,-198.1*mm/tan(52.02/180.*M_PI)-m_ScintiT9FrontSize),
+  m_ScintiT9CornerLowerLeft(0*mm,-m_ScintiT9FrontSize),
 
-  scinti_t10_front_size(149.2*mm),
-  scinti_t10_corner_upper_left(0*mm,0*mm),
-  scinti_t10_corner_upper_right(198.1*mm,-154.6*mm),
-  scinti_t10_corner_lower_right(198.1*mm,-198.1*mm/tan(48.34/180.*M_PI)-scinti_t10_front_size),
-  scinti_t10_corner_lower_left(0*mm,-scinti_t10_front_size),
+  m_ScintiT10FrontSize(149.2*mm),
+  m_ScintiT10CornerUpperLeft(0*mm,0*mm),
+  m_ScintiT10CornerUpperRight(198.1*mm,-154.6*mm),
+  m_ScintiT10CornerLowerRight(198.1*mm,-198.1*mm/tan(48.34/180.*M_PI)-m_ScintiT10FrontSize),
+  m_ScintiT10CornerLowerLeft(0*mm,-m_ScintiT10FrontSize),
 
 
-  scinti_t11_front_size(144.3*mm),
-  scinti_t11_corner_upper_left(0*mm,0*mm),
-  scinti_t11_corner_upper_right(198.1*mm,-176.2*mm),
-  scinti_t11_corner_lower_right(198.1*mm,-198.1*mm/tan(45.14/180.*M_PI)-scinti_t11_front_size),
-  scinti_t11_corner_lower_left(0*mm,-scinti_t11_front_size),
+  m_ScintiT11FrontSize(144.3*mm),
+  m_ScintiT11CornerUpperLeft(0*mm,0*mm),
+  m_ScintiT11CornerUpperRight(198.1*mm,-176.2*mm),
+  m_ScintiT11CornerLowerRight(198.1*mm,-198.1*mm/tan(45.14/180.*M_PI)-m_ScintiT11FrontSize),
+  m_ScintiT11CornerLowerLeft(0*mm,-m_ScintiT11FrontSize),
 
-  scinti_t12_front_size(186.6*mm),
-  scinti_t12_corner_upper_left(0*mm,0*mm),
-  scinti_t12_corner_upper_right(198.1*mm,-197.11*mm),
-  scinti_t12_corner_lower_right(198.1*mm,-198.1*mm/tan(41.47/180.*M_PI)-scinti_t12_front_size),
-  scinti_t12_corner_lower_left(0*mm,-scinti_t12_front_size),
+  m_ScintiT12FrontSize(186.6*mm),
+  m_ScintiT12CornerUpperLeft(0*mm,0*mm),
+  m_ScintiT12CornerUpperRight(198.1*mm,-197.11*mm),
+  m_ScintiT12CornerLowerRight(198.1*mm,-198.1*mm/tan(41.47/180.*M_PI)-m_ScintiT12FrontSize),
+  m_ScintiT12CornerLowerLeft(0*mm,-m_ScintiT12FrontSize),
 
-  scinti_x(198.1),
-  steel_z(901.7*mm),
-  size_z(steel_z),
-  scinti_tile_z(steel_z),
-  scinti_tile_thickness(7*mm),
-  scinti_box_smaller(0.02*mm), // blargh - off by 20 microns bc scinti tilt angle, need to revisit at some point
-  gap_between_tiles(1*mm),
-  scinti_gap(8.5*mm),
-  deltaphi(2*M_PI/320.),
-  volume_steel(NAN),
-  volume_scintillator(NAN),
-  n_scinti_plates(20),
-  n_steel_plates(n_scinti_plates+1),
-  m_ActiveFlag(params->get_int_param("active")),
-  m_AbsorberActiveFlag(params->get_int_param("absorberactive")),
-  layer(0)
+  m_ScintiX(198.1),
+  m_SteelZ(901.7*mm),
+  m_SizeZ(m_SteelZ),
+  m_ScintiTileZ(m_SteelZ),
+  m_ScintiTileThickness(7*mm),
+  m_ScintiBoxSmaller(0.02*mm), // blargh - off by 20 microns bc scinti tilt angle, need to revisit at some point
+  m_GapBetweenTiles(1*mm),
+  m_ScintiGap(8.5*mm),
+  m_DeltaPhi(2*M_PI/320.),
+  m_VolumeSteel(NAN),
+  m_VolumeScintillator(NAN),
+  m_NScintiPlates(20),
+  m_NSteelPlates(m_NScintiPlates+1),
+  m_ActiveFlag(m_Params->get_int_param("active")),
+  m_AbsorberActiveFlag(m_Params->get_int_param("absorberactive")),
+  m_Layer(0)
 {}
 
 PHG4Prototype2InnerHcalDetector::~PHG4Prototype2InnerHcalDetector()
@@ -124,18 +124,18 @@ PHG4Prototype2InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
     {
       G4VSolid* steel_plate;
       std::vector<G4TwoVector> vertexes;
-      vertexes.push_back(steel_plate_corner_upper_left);
-      vertexes.push_back(steel_plate_corner_upper_right);
-      vertexes.push_back(steel_plate_corner_lower_right);
-      vertexes.push_back(steel_plate_corner_lower_left);
+      vertexes.push_back(m_SteelPlateCornerUpperLeft);
+      vertexes.push_back(m_SteelPlateCornerUpperRight);
+      vertexes.push_back(m_SteelPlateCornerLowerRight);
+      vertexes.push_back(m_SteelPlateCornerLowerLeft);
       G4TwoVector zero(0, 0);
       steel_plate =  new G4ExtrudedSolid("InnerHcalSteelPlateSolid",
 					 vertexes,
-					 size_z  / 2.0,
+					 m_SizeZ  / 2.0,
 					 zero, 1.0,
 					 zero, 1.0);
 
-      volume_steel = steel_plate->GetCubicVolume()*n_steel_plates;
+      m_VolumeSteel = steel_plate->GetCubicVolume()*m_NSteelPlates;
       m_InnerHcalSteelPlate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("Steel_A36"),steelplatename, 0, 0, 0);
       G4VisAttributes visattchk;
       visattchk.SetVisibility(true);
@@ -150,7 +150,7 @@ G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope)
 {
   int copynum = 0;
-  G4VSolid* scintiboxsolid = new G4Box(scintimothername,scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername,m_ScintiX/2.,(m_ScintiGap-m_ScintiBoxSmaller)/2.,m_ScintiTileZ/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
 
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),scintimothername, 0, 0, 0);
@@ -161,11 +161,11 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   G4LogicalVolume *scintit9_logic = ConstructScintiTile9(hcalenvelope);
   scintit9_logic->SetVisAttributes(hcalVisAtt);
 
-  double distance_to_corner = -size_z/2.+scinti_t9_distance_to_corner;
+  double distance_to_corner = -m_SizeZ/2.+m_ScintiT9DistanceToCorner;
   G4RotationMatrix *Rot;  
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit9_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,distance_to_corner),scintit9_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
@@ -173,11 +173,11 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   G4LogicalVolume *scintit10_logic = ConstructScintiTile10(hcalenvelope);
   scintit10_logic->SetVisAttributes(hcalVisAtt);
 
-  distance_to_corner += scinti_t9_front_size + gap_between_tiles;
+  distance_to_corner += m_ScintiT9FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit10_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,distance_to_corner),scintit10_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
@@ -185,11 +185,11 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   G4LogicalVolume *scintit11_logic = ConstructScintiTile11(hcalenvelope);
   scintit11_logic->SetVisAttributes(hcalVisAtt);
 
-  distance_to_corner += scinti_t10_front_size + gap_between_tiles;
+  distance_to_corner += m_ScintiT10FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit11_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,distance_to_corner),scintit11_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
@@ -197,11 +197,11 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   G4LogicalVolume *scintit12_logic = ConstructScintiTile12(hcalenvelope);
   scintit12_logic->SetVisAttributes(hcalVisAtt);
 
-  distance_to_corner += scinti_t11_front_size + gap_between_tiles;
+  distance_to_corner += m_ScintiT11FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit12_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,distance_to_corner),scintit12_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   //    DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
@@ -211,7 +211,7 @@ G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
 { 
   int copynum = 0;
-  G4VSolid* scintiboxsolid = new G4Box(scintimothername,scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername,m_ScintiX/2.,(m_ScintiGap-m_ScintiBoxSmaller)/2.,m_ScintiTileZ/2.);
   //    DisplayVolume(scintiboxsolid,hcalenvelope);
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),scintimothername, 0, 0, 0);
   G4VisAttributes hcalVisAtt;
@@ -229,22 +229,22 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
   G4RotationMatrix *Rot;  
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-scinti_u1_front_size-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,-m_ScintiUoneFrontSize-m_GapBetweenTiles/2.-m_GapBetweenTiles),scintiu2_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-gap_between_tiles/2.),scintiu1_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,-m_GapBetweenTiles/2.),scintiu1_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,gap_between_tiles/2.),scintiu1_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,m_GapBetweenTiles/2.),scintiu1_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,scinti_u1_front_size+gap_between_tiles/2.+gap_between_tiles),scintiu2_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,m_ScintiUoneFrontSize+m_GapBetweenTiles/2.+m_GapBetweenTiles),scintiu2_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
   //  DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
 }
@@ -253,14 +253,14 @@ G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintiTileU1(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_u1_corner_upper_left);
-  vertexes.push_back(scinti_u1_corner_upper_right);
-  vertexes.push_back(scinti_u1_corner_lower_right);
-  vertexes.push_back(scinti_u1_corner_lower_left);
+  vertexes.push_back(m_ScintiUoneCornerUpperLeft);
+  vertexes.push_back(m_ScintiUoneCornerUpperRight);
+  vertexes.push_back(m_ScintiUoneCornerLowerRight);
+  vertexes.push_back(m_ScintiUoneCornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintiu1 =  new G4ExtrudedSolid("InnerHcalScintiU1",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -274,14 +274,14 @@ G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_u2_corner_upper_left);
-  vertexes.push_back(scinti_u2_corner_upper_right);
-  vertexes.push_back(scinti_u2_corner_lower_right);
-  vertexes.push_back(scinti_u2_corner_lower_left);
+  vertexes.push_back(m_ScintiU2CornerUpperLeft);
+  vertexes.push_back(m_ScintiU2CornerUpperRight);
+  vertexes.push_back(m_ScintiU2CornerLowerRight);
+  vertexes.push_back(m_ScintiU2CornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintiu2 =  new G4ExtrudedSolid("InnerHcalScintiU2",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -295,14 +295,14 @@ G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintiTile9(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_t9_corner_upper_left);
-  vertexes.push_back(scinti_t9_corner_upper_right);
-  vertexes.push_back(scinti_t9_corner_lower_right);
-  vertexes.push_back(scinti_t9_corner_lower_left);
+  vertexes.push_back(m_ScintiT9CornerUpperLeft);
+  vertexes.push_back(m_ScintiT9CornerUpperRight);
+  vertexes.push_back(m_ScintiT9CornerLowerRight);
+  vertexes.push_back(m_ScintiT9CornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintit9 =  new G4ExtrudedSolid("InnerHcalScintiT9",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -316,14 +316,14 @@ G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintiTile10(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_t10_corner_upper_left);
-  vertexes.push_back(scinti_t10_corner_upper_right);
-  vertexes.push_back(scinti_t10_corner_lower_right);
-  vertexes.push_back(scinti_t10_corner_lower_left);
+  vertexes.push_back(m_ScintiT10CornerUpperLeft);
+  vertexes.push_back(m_ScintiT10CornerUpperRight);
+  vertexes.push_back(m_ScintiT10CornerLowerRight);
+  vertexes.push_back(m_ScintiT10CornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintit10 =  new G4ExtrudedSolid("InnerHcalScintiT10",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -337,14 +337,14 @@ G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintiTile11(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_t11_corner_upper_left);
-  vertexes.push_back(scinti_t11_corner_upper_right);
-  vertexes.push_back(scinti_t11_corner_lower_right);
-  vertexes.push_back(scinti_t11_corner_lower_left);
+  vertexes.push_back(m_ScintiT11CornerUpperLeft);
+  vertexes.push_back(m_ScintiT11CornerUpperRight);
+  vertexes.push_back(m_ScintiT11CornerLowerRight);
+  vertexes.push_back(m_ScintiT11CornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintit11 =  new G4ExtrudedSolid("InnerHcalScintiT11",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -358,14 +358,14 @@ G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_t12_corner_upper_left);
-  vertexes.push_back(scinti_t12_corner_upper_right);
-  vertexes.push_back(scinti_t12_corner_lower_right);
-  vertexes.push_back(scinti_t12_corner_lower_left);
+  vertexes.push_back(m_ScintiT12CornerUpperLeft);
+  vertexes.push_back(m_ScintiT12CornerUpperRight);
+  vertexes.push_back(m_ScintiT12CornerLowerRight);
+  vertexes.push_back(m_ScintiT12CornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintit12 =  new G4ExtrudedSolid("InnerHcalScintiT12",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -380,13 +380,13 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
 void
 PHG4Prototype2InnerHcalDetector::Construct( G4LogicalVolume* logicWorld )
 {
-  G4ThreeVector g4vec(params->get_double_param("place_x")*cm,
-                      params->get_double_param("place_y")*cm,
-		      params->get_double_param("place_z")*cm);
+  G4ThreeVector g4vec(m_Params->get_double_param("place_x")*cm,
+                      m_Params->get_double_param("place_y")*cm,
+		      m_Params->get_double_param("place_z")*cm);
   G4RotationMatrix Rot;
-  Rot.rotateX(params->get_double_param("rot_x")*deg);
-  Rot.rotateY(params->get_double_param("rot_y")*deg);
-  Rot.rotateZ(params->get_double_param("rot_z")*deg);
+  Rot.rotateX(m_Params->get_double_param("rot_x")*deg);
+  Rot.rotateY(m_Params->get_double_param("rot_y")*deg);
+  Rot.rotateZ(m_Params->get_double_param("rot_z")*deg);
   //  ConstructScintiTile9(logicWorld);
   //    ConstructScintillatorBoxHiEta(logicWorld);
   //ConstructScintillatorBox(logicWorld);
@@ -437,7 +437,7 @@ PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelop
 {
   G4LogicalVolume* steel_plate = ConstructSteelPlate(hcalenvelope); // bottom steel plate
   G4LogicalVolume* scintibox = nullptr;
-  if (params->get_int_param("hi_eta"))
+  if (m_Params->get_int_param("hi_eta"))
     {
       scintibox = ConstructScintillatorBoxHiEta(hcalenvelope);
     }
@@ -447,19 +447,15 @@ PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelop
     }
   double phi = 0.;
   double phislat = 0.;
-  ostringstream name;
   // the coordinate of the center of the bottom of the bottom steel plate
   // to get the radius of the circle which is the center of the scintillator box
-  double bottom_xmiddle_steel_tile = (steel_plate_corner_lower_right.x()+steel_plate_corner_lower_left.x())/2.;
-  double bottom_ymiddle_steel_tile = (steel_plate_corner_lower_left.y()+steel_plate_corner_lower_right.y())/2.;
+  double bottom_xmiddle_steel_tile = (m_SteelPlateCornerLowerRight.x()+m_SteelPlateCornerLowerLeft.x())/2.;
+  double bottom_ymiddle_steel_tile = (m_SteelPlateCornerLowerLeft.y()+m_SteelPlateCornerLowerRight.y())/2.;
   double middlerad = sqrt(bottom_xmiddle_steel_tile*bottom_xmiddle_steel_tile + bottom_ymiddle_steel_tile * bottom_ymiddle_steel_tile);
-  double philow = atan((bottom_ymiddle_steel_tile-scinti_gap/2.-0.87*mm)/bottom_xmiddle_steel_tile);
+  double philow = atan((bottom_ymiddle_steel_tile-m_ScintiGap/2.-0.87*mm)/bottom_xmiddle_steel_tile);
   double scintiangle = GetScintiAngle();
-  for (int i = 0; i < n_steel_plates; i++)
-    //      for (int i = 0; i < 2; i++)
+  for (int i = 0; i < m_NSteelPlates; i++)
     {
-      name.str("");
-      name << "InnerHcalSteel_" << i;
       G4RotationMatrix Rot;
       Rot.rotateZ(phi*rad);
       G4ThreeVector g4vec(0,0,0);
@@ -468,15 +464,13 @@ PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelop
 	{
 	  double ypos = sin(phi+philow) * middlerad;
 	  double xpos = cos(phi+philow) * middlerad;
-	  name.str("");
-	  name << "InnerHcalScintiBox_" << i;
 	  G4RotationMatrix Rot1;
 	  Rot1.rotateZ(scintiangle+phislat);
 	  G4ThreeVector g4vecsc(xpos, ypos, 0);
 	  m_InnerHcalAssembly->AddPlacedVolume(scintibox,g4vecsc,&Rot1);
-	  phislat += deltaphi;
+	  phislat += m_DeltaPhi;
 	}
-      phi += deltaphi;
+      phi += m_DeltaPhi;
     }
   return 0;
 }
@@ -486,8 +480,8 @@ PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelop
 double
 PHG4Prototype2InnerHcalDetector::GetScintiAngle()
 {
-  double xlen = steel_plate_corner_upper_right.x() - steel_plate_corner_upper_left.x();
-  double ylen = steel_plate_corner_upper_right.y() - steel_plate_corner_upper_left.y();
+  double xlen = m_SteelPlateCornerUpperRight.x() - m_SteelPlateCornerUpperLeft.x();
+  double ylen = m_SteelPlateCornerUpperRight.y() - m_SteelPlateCornerUpperLeft.y();
   double angle = atan(ylen/xlen);
   return angle;
 }
@@ -547,8 +541,8 @@ PHG4Prototype2InnerHcalDetector::Print(const string &what) const
   cout << "Inner Hcal Detector:" << endl;
   if (what == "ALL" || what == "VOLUME")
     {
-      cout << "Volume Steel: " << volume_steel/cm/cm/cm << " cm^3" << endl;
-      cout << "Volume Scintillator: " << volume_scintillator/cm/cm/cm << " cm^3" << endl;
+      cout << "Volume Steel: " << m_VolumeSteel/cm3 << " cm^3" << endl;
+      cout << "Volume Scintillator: " << m_VolumeScintillator/cm3 << " cm^3" << endl;
     }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -95,6 +95,11 @@ PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNod
   layer(0)
 {}
 
+PHG4Prototype2InnerHcalDetector::~PHG4Prototype2InnerHcalDetector()
+{
+  delete m_InnerHcalAssembly;
+}
+
 //_______________________________________________________________
 //_______________________________________________________________
 int
@@ -132,10 +137,10 @@ PHG4Prototype2InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
 
       volume_steel = steel_plate->GetCubicVolume()*n_steel_plates;
       m_InnerHcalSteelPlate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("Steel_A36"),steelplatename, 0, 0, 0);
-      G4VisAttributes* visattchk = new G4VisAttributes();
-      visattchk->SetVisibility(true);
-      visattchk->SetForceSolid(false);
-      visattchk->SetColour(G4Colour::Blue());
+      G4VisAttributes visattchk;
+      visattchk.SetVisibility(true);
+      visattchk.SetForceSolid(false);
+      visattchk.SetColour(G4Colour::Blue());
       m_InnerHcalSteelPlate->SetVisAttributes(visattchk);
     }
   return m_InnerHcalSteelPlate;
@@ -378,10 +383,10 @@ PHG4Prototype2InnerHcalDetector::Construct( G4LogicalVolume* logicWorld )
   G4ThreeVector g4vec(params->get_double_param("place_x")*cm,
                       params->get_double_param("place_y")*cm,
 		      params->get_double_param("place_z")*cm);
-  G4RotationMatrix *Rot = new G4RotationMatrix();
-  Rot->rotateX(params->get_double_param("rot_x")*deg);
-  Rot->rotateY(params->get_double_param("rot_y")*deg);
-  Rot->rotateZ(params->get_double_param("rot_z")*deg);
+  G4RotationMatrix Rot;
+  Rot.rotateX(params->get_double_param("rot_x")*deg);
+  Rot.rotateY(params->get_double_param("rot_y")*deg);
+  Rot.rotateZ(params->get_double_param("rot_z")*deg);
   //  ConstructScintiTile9(logicWorld);
   //    ConstructScintillatorBoxHiEta(logicWorld);
   //ConstructScintillatorBox(logicWorld);
@@ -390,7 +395,7 @@ PHG4Prototype2InnerHcalDetector::Construct( G4LogicalVolume* logicWorld )
   //ConstructSteelPlate(hcal_envelope_log);
   // return;
   ConstructInnerHcal(logicWorld);
-  m_InnerHcalAssembly->MakeImprint(logicWorld,g4vec,Rot,0,OverlapCheck());
+  m_InnerHcalAssembly->MakeImprint(logicWorld,g4vec,&Rot,0,OverlapCheck());
 // this is rather pathetic - there is no way to extract the name when a volume is added
 // to the assembly. The only thing we can do is get an iterator over the placed volumes
 // in the order in which they were placed. Since this code does not install the scintillators
@@ -455,20 +460,20 @@ PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelop
     {
       name.str("");
       name << "InnerHcalSteel_" << i;
-      G4RotationMatrix *Rot = new G4RotationMatrix();
-      Rot->rotateZ(phi*rad);
+      G4RotationMatrix Rot;
+      Rot.rotateZ(phi*rad);
       G4ThreeVector g4vec(0,0,0);
-      m_InnerHcalAssembly->AddPlacedVolume(steel_plate,g4vec,Rot);
+      m_InnerHcalAssembly->AddPlacedVolume(steel_plate,g4vec,&Rot);
       if (i > 0)
 	{
 	  double ypos = sin(phi+philow) * middlerad;
 	  double xpos = cos(phi+philow) * middlerad;
 	  name.str("");
 	  name << "InnerHcalScintiBox_" << i;
-	  Rot = new G4RotationMatrix();
-	  Rot->rotateZ(scintiangle+phislat);
+	  G4RotationMatrix Rot1;
+	  Rot1.rotateZ(scintiangle+phislat);
 	  G4ThreeVector g4vecsc(xpos, ypos, 0);
-	  m_InnerHcalAssembly->AddPlacedVolume(scintibox,g4vecsc,Rot);
+	  m_InnerHcalAssembly->AddPlacedVolume(scintibox,g4vecsc,&Rot1);
 	  phislat += deltaphi;
 	}
       phi += deltaphi;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.cc
@@ -17,17 +17,24 @@
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4VisAttributes.hh>
+#include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4RotationMatrix.hh>
+
+#include <boost/format.hpp>
 
 #include <cmath>
 #include <sstream>
 
 using namespace std;
 
+static const string scintimothername = "InnerHcalScintiMother";
+static const string steelplatename = "InnerHcalSteelPlate";
+
 PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam  ):
   PHG4Detector(Node, dnam),
   params(parameters),
-  innerhcalsteelplate(NULL),
-  innerhcalassembly(NULL),
+  m_InnerHcalSteelPlate(nullptr),
+  m_InnerHcalAssembly(nullptr),
   steel_plate_corner_upper_left(1157.5*mm,-151.44*mm),
   steel_plate_corner_upper_right(1308.5*mm,-286.96*mm), 
   steel_plate_corner_lower_right(1298.8*mm,-297.39*mm),
@@ -83,8 +90,8 @@ PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNod
   volume_scintillator(NAN),
   n_scinti_plates(20),
   n_steel_plates(n_scinti_plates+1),
-  active(params->get_int_param("active")),
-  absorberactive(params->get_int_param("absorberactive")),
+  m_ActiveFlag(params->get_int_param("active")),
+  m_AbsorberActiveFlag(params->get_int_param("absorberactive")),
   layer(0)
 {}
 
@@ -93,40 +100,22 @@ PHG4Prototype2InnerHcalDetector::PHG4Prototype2InnerHcalDetector( PHCompositeNod
 int
 PHG4Prototype2InnerHcalDetector::IsInPrototype2InnerHcal(G4VPhysicalVolume * volume) const
 {
-  // G4AssemblyVolumes naming convention:
-  //     av_WWW_impr_XXX_YYY_ZZZ
-
-  // where:
-
-  //     WWW - assembly volume instance number
-  //     XXX - assembly volume imprint number
-  //     YYY - the name of the placed logical volume
-  //     ZZZ - the logical volume index inside the assembly volume
-  // e.g. av_1_impr_82_HcalInnerScinti_11_pv_11
-  // 82 the number of the scintillator mother volume
-  // HcalInnerScinti_11: name of scintillator slat
-  // 11: number of scintillator slat logical volume
-  if (absorberactive)
-    {
-      if (volume->GetName().find("InnerHcalSteelPlate") != string::npos)
-	{
-	  return -1;
-	}
-    }
-  if (active)
-    {
-      if (volume->GetName().find("InnerScinti") != string::npos)
-	{
-	  return 1;
-	}
-    }
+  G4LogicalVolume *logvol = volume->GetLogicalVolume();
+  if (m_AbsorberActiveFlag && logvol == m_InnerHcalSteelPlate)
+  {
+    return -1;
+  }
+  if (m_ActiveFlag && m_ActiveVolumeSet.find(logvol) != m_ActiveVolumeSet.end())
+  {
+    return 1;
+  }
   return 0;
 }
 
 G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelope)
 {
-  if (!innerhcalsteelplate)
+  if (!m_InnerHcalSteelPlate)
     {
       G4VSolid* steel_plate;
       std::vector<G4TwoVector> vertexes;
@@ -142,27 +131,28 @@ PHG4Prototype2InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
 					 zero, 1.0);
 
       volume_steel = steel_plate->GetCubicVolume()*n_steel_plates;
-      innerhcalsteelplate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("Steel_A36"),"InnerHcalSteelPlate", 0, 0, 0);
+      m_InnerHcalSteelPlate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("Steel_A36"),steelplatename, 0, 0, 0);
       G4VisAttributes* visattchk = new G4VisAttributes();
       visattchk->SetVisibility(true);
       visattchk->SetForceSolid(false);
       visattchk->SetColour(G4Colour::Blue());
-      innerhcalsteelplate->SetVisAttributes(visattchk);
+      m_InnerHcalSteelPlate->SetVisAttributes(visattchk);
     }
-  return innerhcalsteelplate;
+  return m_InnerHcalSteelPlate;
 }
 
 G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope)
 {
-  G4VSolid* scintiboxsolid = new G4Box("InnerHcalScintiMother",scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
+  int copynum = 9;
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername,scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
 
-  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String("InnerHcalScintiMother"), 0, 0, 0);
-  G4VisAttributes* hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Magenta());
+  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),scintimothername, 0, 0, 0);
+  G4VisAttributes hcalVisAtt;
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Magenta());
   G4LogicalVolume *scintit9_logic = ConstructScintiTile9(hcalenvelope);
   scintit9_logic->SetVisAttributes(hcalVisAtt);
 
@@ -170,43 +160,43 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   G4RotationMatrix *Rot;  
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit9_logic,"InnerScinti_9", scintiboxlogical, false, 0, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit9_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Blue());
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Blue());
   G4LogicalVolume *scintit10_logic = ConstructScintiTile10(hcalenvelope);
   scintit10_logic->SetVisAttributes(hcalVisAtt);
 
   distance_to_corner += scinti_t9_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit10_logic,"InnerScinti_10", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit10_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Yellow());
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Yellow());
   G4LogicalVolume *scintit11_logic = ConstructScintiTile11(hcalenvelope);
   scintit11_logic->SetVisAttributes(hcalVisAtt);
 
   distance_to_corner += scinti_t10_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit11_logic,"InnerScinti_11", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit11_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Cyan());
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Cyan());
   G4LogicalVolume *scintit12_logic = ConstructScintiTile12(hcalenvelope);
   scintit12_logic->SetVisAttributes(hcalVisAtt);
 
   distance_to_corner += scinti_t11_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit12_logic,"InnerScinti_12", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,distance_to_corner),scintit12_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   //    DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
@@ -215,38 +205,41 @@ PHG4Prototype2InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
 G4LogicalVolume*
 PHG4Prototype2InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
 { 
-  G4VSolid* scintiboxsolid = new G4Box("InnerHcalScintiMother",scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
+  int copynum = 0;
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername,scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
   //    DisplayVolume(scintiboxsolid,hcalenvelope);
-  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String("InnerHcalScintiMother"), 0, 0, 0);
-  G4VisAttributes* hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Red());
+  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),scintimothername, 0, 0, 0);
+  G4VisAttributes hcalVisAtt;
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Red());
   G4LogicalVolume *scintiu1_logic = ConstructScintiTileU1(hcalenvelope);
   scintiu1_logic->SetVisAttributes(hcalVisAtt);
 
-  hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Cyan());
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Cyan());
   G4LogicalVolume *scintiu2_logic = ConstructScintiTileU2(hcalenvelope);
   scintiu2_logic->SetVisAttributes(hcalVisAtt);
   G4RotationMatrix *Rot;  
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-scinti_u1_front_size-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,"InnerScinti_0", scintiboxlogical, false, 0, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-scinti_u1_front_size-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-gap_between_tiles/2.),scintiu1_logic,"InnerScinti_1", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-gap_between_tiles/2.),scintiu1_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,gap_between_tiles/2.),scintiu1_logic,"InnerScinti_2", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,gap_between_tiles/2.),scintiu1_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,scinti_u1_front_size+gap_between_tiles/2.+gap_between_tiles),scintiu2_logic,"InnerScinti_3", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,scinti_u1_front_size+gap_between_tiles/2.+gap_between_tiles),scintiu2_logic,(boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
   //  DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
 }
@@ -266,8 +259,9 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTileU1(G4LogicalVolume* hcalenve
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintiu1_logic = new G4LogicalVolume(scintiu1,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiU1", NULL, NULL, NULL);
+  G4LogicalVolume *scintiu1_logic = new G4LogicalVolume(scintiu1,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiU1", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintiu1,hcalenvelope);
+  m_ActiveVolumeSet.insert(scintiu1_logic);
   return scintiu1_logic;
 }
 
@@ -286,8 +280,9 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenve
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintiu2_logic = new G4LogicalVolume(scintiu2,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiU2", NULL, NULL, NULL);
+  G4LogicalVolume *scintiu2_logic = new G4LogicalVolume(scintiu2,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiU2", nullptr, nullptr, nullptr);
   //   DisplayVolume(scintiu2,hcalenvelope);
+  m_ActiveVolumeSet.insert(scintiu2_logic);
   return scintiu2_logic;
 }
 
@@ -306,8 +301,9 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile9(G4LogicalVolume* hcalenvel
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintit9_logic = new G4LogicalVolume(scintit9,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT9", NULL, NULL, NULL);
+  G4LogicalVolume *scintit9_logic = new G4LogicalVolume(scintit9,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT9", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit9,hcalenvelope);
+  m_ActiveVolumeSet.insert(scintit9_logic);
   return scintit9_logic;
 }
 
@@ -326,8 +322,9 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile10(G4LogicalVolume* hcalenve
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintit10_logic = new G4LogicalVolume(scintit10,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT10", NULL, NULL, NULL);
+  G4LogicalVolume *scintit10_logic = new G4LogicalVolume(scintit10,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT10", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit10,hcalenvelope);
+  m_ActiveVolumeSet.insert(scintit10_logic);
   return scintit10_logic;
 }
 
@@ -346,8 +343,9 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile11(G4LogicalVolume* hcalenve
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintit11_logic = new G4LogicalVolume(scintit11,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT11", NULL, NULL, NULL);
+  G4LogicalVolume *scintit11_logic = new G4LogicalVolume(scintit11,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT11", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit11,hcalenvelope);
+  m_ActiveVolumeSet.insert(scintit11_logic);
   return scintit11_logic;
 }
 
@@ -366,8 +364,9 @@ PHG4Prototype2InnerHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintit12_logic = new G4LogicalVolume(scintit12,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT12", NULL, NULL, NULL);
+  G4LogicalVolume *scintit12_logic = new G4LogicalVolume(scintit12,G4Material::GetMaterial("G4_POLYSTYRENE"),"InnerHcalScintiT12", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit12,hcalenvelope);
+  m_ActiveVolumeSet.insert(scintit12_logic);
   return scintit12_logic;
 }
 
@@ -387,11 +386,44 @@ PHG4Prototype2InnerHcalDetector::Construct( G4LogicalVolume* logicWorld )
   //    ConstructScintillatorBoxHiEta(logicWorld);
   //ConstructScintillatorBox(logicWorld);
   //  return;
-  innerhcalassembly = new G4AssemblyVolume();
+  m_InnerHcalAssembly = new G4AssemblyVolume();
   //ConstructSteelPlate(hcal_envelope_log);
   // return;
   ConstructInnerHcal(logicWorld);
-  innerhcalassembly->MakeImprint(logicWorld,g4vec,Rot,0,OverlapCheck());
+  m_InnerHcalAssembly->MakeImprint(logicWorld,g4vec,Rot,0,OverlapCheck());
+// this is rather pathetic - there is no way to extract the name when a volume is added
+// to the assembly. The only thing we can do is get an iterator over the placed volumes
+// in the order in which they were placed. Since this code does not install the scintillators
+// for the Al version, parsing the volume names to get the id does not work since it changes
+// So now we loop over all volumes and store them in a map for fast lookup of the row
+  int isteel = 0;
+  int iscinti = 0;
+  vector<G4VPhysicalVolume*>::iterator it = m_InnerHcalAssembly->GetVolumesIterator();
+  for (unsigned int i=0; i<m_InnerHcalAssembly-> TotalImprintedVolumes();i++)
+  {
+    string volname = (*it)->GetName();
+    if (volname.find(steelplatename) != string::npos)
+    { 
+      m_SteelPlateIdMap.insert(make_pair(volname,isteel));
+      ++isteel;
+    }
+    else if (volname.find(scintimothername) != string::npos)
+    {
+      m_ScintillatorIdMap.insert(make_pair(volname,iscinti));
+      ++iscinti;
+    }
+    ++it;
+  }
+// print out volume names and their assigned id
+   // map<string,int>::const_iterator iter;
+   // for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
+   // {
+   //   cout << iter->first << ", " << iter->second << endl;
+   // }
+   // for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
+   // {
+   //   cout << iter->first << ", " << iter->second << endl;
+   // }
   return;
 }
 
@@ -399,7 +431,7 @@ int
 PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelope)
 {
   G4LogicalVolume* steel_plate = ConstructSteelPlate(hcalenvelope); // bottom steel plate
-  G4LogicalVolume* scintibox = NULL;
+  G4LogicalVolume* scintibox = nullptr;
   if (params->get_int_param("hi_eta"))
     {
       scintibox = ConstructScintillatorBoxHiEta(hcalenvelope);
@@ -426,7 +458,7 @@ PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelop
       G4RotationMatrix *Rot = new G4RotationMatrix();
       Rot->rotateZ(phi*rad);
       G4ThreeVector g4vec(0,0,0);
-      innerhcalassembly->AddPlacedVolume(steel_plate,g4vec,Rot);
+      m_InnerHcalAssembly->AddPlacedVolume(steel_plate,g4vec,Rot);
       if (i > 0)
 	{
 	  double ypos = sin(phi+philow) * middlerad;
@@ -436,7 +468,7 @@ PHG4Prototype2InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume* hcalenvelop
 	  Rot = new G4RotationMatrix();
 	  Rot->rotateZ(scintiangle+phislat);
 	  G4ThreeVector g4vecsc(xpos, ypos, 0);
-	  innerhcalassembly->AddPlacedVolume(scintibox,g4vecsc,Rot);
+	  m_InnerHcalAssembly->AddPlacedVolume(scintibox,g4vecsc,Rot);
 	  phislat += deltaphi;
 	}
       phi += deltaphi;
@@ -514,4 +546,34 @@ PHG4Prototype2InnerHcalDetector::Print(const string &what) const
       cout << "Volume Scintillator: " << volume_scintillator/cm/cm/cm << " cm^3" << endl;
     }
   return;
+}
+int PHG4Prototype2InnerHcalDetector::get_scinti_row_id(const string &volname)
+{
+  int id=-9999;
+  auto it = m_ScintillatorIdMap.find(volname);
+  if (it != m_ScintillatorIdMap.end())
+  {
+    id = it->second;
+  }
+  else
+  {
+    cout << "unknown scintillator volume name: " << volname << endl;
+  }
+
+  return id;
+}
+
+int PHG4Prototype2InnerHcalDetector::get_steel_plate_id(const string &volname)
+{
+  int id=-9999;
+  auto it = m_SteelPlateIdMap.find(volname);
+  if (it != m_SteelPlateIdMap.end())
+  {
+    id = it->second;
+  }
+  else
+  {
+    cout << "unknown steel volume name: " << volname << endl;
+  }
+  return id;
 }

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
@@ -16,30 +16,28 @@ class G4VPhysicalVolume;
 class G4VSolid;
 class PHParameters;
 
-class PHG4Prototype2InnerHcalDetector: public PHG4Detector
+class PHG4Prototype2InnerHcalDetector : public PHG4Detector
 {
-
-  public:
-
+ public:
   //! constructor
- PHG4Prototype2InnerHcalDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam);
+  PHG4Prototype2InnerHcalDetector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam);
 
   //! destructor
- virtual ~PHG4Prototype2InnerHcalDetector();
+  virtual ~PHG4Prototype2InnerHcalDetector();
 
   //! construct
-  virtual void Construct( G4LogicalVolume* world );
+  virtual void Construct(G4LogicalVolume* world);
 
-  virtual void Print(const std::string &what = "ALL") const;
+  virtual void Print(const std::string& what = "ALL") const;
 
   //!@name volume accessors
   //@{
   int IsInPrototype2InnerHcal(G4VPhysicalVolume*) const;
   //@}
 
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return m_Layer;}
+  void SuperDetector(const std::string& name) { superdetector = name; }
+  const std::string SuperDetector() const { return superdetector; }
+  int get_Layer() const { return m_Layer; }
 
   G4LogicalVolume* ConstructSteelPlate(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintillatorBox(G4LogicalVolume* hcalenvelope);
@@ -52,20 +50,20 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   G4LogicalVolume* ConstructScintiTile12(G4LogicalVolume* hcalenvelope);
   double GetScintiAngle();
 
-  int get_scinti_row_id(const std::string &volname);
-  int get_steel_plate_id(const std::string &volname);
+  int get_scinti_row_id(const std::string& volname);
+  int get_steel_plate_id(const std::string& volname);
 
-  protected:
+ protected:
   int ConstructInnerHcal(G4LogicalVolume* sandwich);
-  int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
-  int DisplayVolume(G4LogicalVolume *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
-  std::set<G4LogicalVolume *> m_ActiveVolumeSet;
+  int DisplayVolume(G4VSolid* volume, G4LogicalVolume* logvol, G4RotationMatrix* rotm = NULL);
+  int DisplayVolume(G4LogicalVolume* volume, G4LogicalVolume* logvol, G4RotationMatrix* rotm = NULL);
+  std::set<G4LogicalVolume*> m_ActiveVolumeSet;
   std::string superdetector;
-  std::map<std::string,int> m_SteelPlateIdMap;
-  std::map<std::string,int> m_ScintillatorIdMap;
-  PHParameters *m_Params;
-  G4LogicalVolume *m_InnerHcalSteelPlate;
-  G4AssemblyVolume *m_InnerHcalAssembly;
+  std::map<std::string, int> m_SteelPlateIdMap;
+  std::map<std::string, int> m_ScintillatorIdMap;
+  PHParameters* m_Params;
+  G4LogicalVolume* m_InnerHcalSteelPlate;
+  G4AssemblyVolume* m_InnerHcalAssembly;
   G4TwoVector m_SteelPlateCornerUpperLeft;
   G4TwoVector m_SteelPlateCornerUpperRight;
   G4TwoVector m_SteelPlateCornerLowerRight;
@@ -125,7 +123,6 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   int m_AbsorberActiveFlag;
 
   int m_Layer;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
@@ -39,7 +39,7 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
 
   void SuperDetector(const std::string &name) {superdetector = name;}
   const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return layer;}
+  int get_Layer() const {return m_Layer;}
 
   G4LogicalVolume* ConstructSteelPlate(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintillatorBox(G4LogicalVolume* hcalenvelope);
@@ -59,73 +59,72 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   int ConstructInnerHcal(G4LogicalVolume* sandwich);
   int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
   int DisplayVolume(G4LogicalVolume *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
-  PHParameters *params;
+  std::set<G4LogicalVolume *> m_ActiveVolumeSet;
+  std::string superdetector;
+  std::map<std::string,int> m_SteelPlateIdMap;
+  std::map<std::string,int> m_ScintillatorIdMap;
+  PHParameters *m_Params;
   G4LogicalVolume *m_InnerHcalSteelPlate;
   G4AssemblyVolume *m_InnerHcalAssembly;
-  std::set<G4LogicalVolume *> m_ActiveVolumeSet;
-  G4TwoVector steel_plate_corner_upper_left;
-  G4TwoVector steel_plate_corner_upper_right;
-  G4TwoVector steel_plate_corner_lower_right;
-  G4TwoVector steel_plate_corner_lower_left;
-  double scinti_u1_front_size;
-  G4TwoVector scinti_u1_corner_upper_left;
-  G4TwoVector scinti_u1_corner_upper_right;
-  G4TwoVector scinti_u1_corner_lower_right;
-  G4TwoVector scinti_u1_corner_lower_left;
+  G4TwoVector m_SteelPlateCornerUpperLeft;
+  G4TwoVector m_SteelPlateCornerUpperRight;
+  G4TwoVector m_SteelPlateCornerLowerRight;
+  G4TwoVector m_SteelPlateCornerLowerLeft;
+  double m_ScintiUoneFrontSize;
+  G4TwoVector m_ScintiUoneCornerUpperLeft;
+  G4TwoVector m_ScintiUoneCornerUpperRight;
+  G4TwoVector m_ScintiUoneCornerLowerRight;
+  G4TwoVector m_ScintiUoneCornerLowerLeft;
 
-  G4TwoVector scinti_u2_corner_upper_left;
-  G4TwoVector scinti_u2_corner_upper_right;
-  G4TwoVector scinti_u2_corner_lower_right;
-  G4TwoVector scinti_u2_corner_lower_left;
+  G4TwoVector m_ScintiU2CornerUpperLeft;
+  G4TwoVector m_ScintiU2CornerUpperRight;
+  G4TwoVector m_ScintiU2CornerLowerRight;
+  G4TwoVector m_ScintiU2CornerLowerLeft;
 
-  double scinti_t9_distance_to_corner;
-  double scinti_t9_front_size;
-  G4TwoVector scinti_t9_corner_upper_left;
-  G4TwoVector scinti_t9_corner_upper_right;
-  G4TwoVector scinti_t9_corner_lower_right;
-  G4TwoVector scinti_t9_corner_lower_left;
+  double m_ScintiT9DistanceToCorner;
+  double m_ScintiT9FrontSize;
+  G4TwoVector m_ScintiT9CornerUpperLeft;
+  G4TwoVector m_ScintiT9CornerUpperRight;
+  G4TwoVector m_ScintiT9CornerLowerRight;
+  G4TwoVector m_ScintiT9CornerLowerLeft;
 
-  double scinti_t10_front_size;
-  G4TwoVector scinti_t10_corner_upper_left;
-  G4TwoVector scinti_t10_corner_upper_right;
-  G4TwoVector scinti_t10_corner_lower_right;
-  G4TwoVector scinti_t10_corner_lower_left;
+  double m_ScintiT10FrontSize;
+  G4TwoVector m_ScintiT10CornerUpperLeft;
+  G4TwoVector m_ScintiT10CornerUpperRight;
+  G4TwoVector m_ScintiT10CornerLowerRight;
+  G4TwoVector m_ScintiT10CornerLowerLeft;
 
-  double scinti_t11_front_size;
-  G4TwoVector scinti_t11_corner_upper_left;
-  G4TwoVector scinti_t11_corner_upper_right;
-  G4TwoVector scinti_t11_corner_lower_right;
-  G4TwoVector scinti_t11_corner_lower_left;
+  double m_ScintiT11FrontSize;
+  G4TwoVector m_ScintiT11CornerUpperLeft;
+  G4TwoVector m_ScintiT11CornerUpperRight;
+  G4TwoVector m_ScintiT11CornerLowerRight;
+  G4TwoVector m_ScintiT11CornerLowerLeft;
 
-  double scinti_t12_front_size;
-  G4TwoVector scinti_t12_corner_upper_left;
-  G4TwoVector scinti_t12_corner_upper_right;
-  G4TwoVector scinti_t12_corner_lower_right;
-  G4TwoVector scinti_t12_corner_lower_left;
+  double m_ScintiT12FrontSize;
+  G4TwoVector m_ScintiT12CornerUpperLeft;
+  G4TwoVector m_ScintiT12CornerUpperRight;
+  G4TwoVector m_ScintiT12CornerLowerRight;
+  G4TwoVector m_ScintiT12CornerLowerLeft;
 
-  double scinti_x;
-  double steel_z;
-  double size_z;
-  double scinti_tile_z;
-  double scinti_tile_thickness;
-  double scinti_box_smaller;
-  double gap_between_tiles;
-  double scinti_gap;
-  double deltaphi;
-  double volume_steel;
-  double volume_scintillator;
+  double m_ScintiX;
+  double m_SteelZ;
+  double m_SizeZ;
+  double m_ScintiTileZ;
+  double m_ScintiTileThickness;
+  double m_ScintiBoxSmaller;
+  double m_GapBetweenTiles;
+  double m_ScintiGap;
+  double m_DeltaPhi;
+  double m_VolumeSteel;
+  double m_VolumeScintillator;
 
-  int n_scinti_plates;
-  int n_steel_plates;
+  int m_NScintiPlates;
+  int m_NSteelPlates;
 
   int m_ActiveFlag;
   int m_AbsorberActiveFlag;
 
-  int layer;
-//  std::string detector_type;
-  std::string superdetector;
-  std::map<std::string,int> m_SteelPlateIdMap;
-  std::map<std::string,int> m_ScintillatorIdMap;
+  int m_Layer;
 
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
@@ -1,16 +1,18 @@
-#ifndef PHG4Prototype2InnerHcalDetector_h
-#define PHG4Prototype2InnerHcalDetector_h
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4PROTOTYPE2INNERHCALDETECTOR_H
+#define G4DETECTORS_PHG4PROTOTYPE2INNERHCALDETECTOR_H
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/globals.hh>
-#include <Geant4/G4RotationMatrix.hh>
-#include <Geant4/G4SystemOfUnits.hh>
+//#include <Geant4/globals.hh>
+//#include <Geant4/G4RotationMatrix.hh>
+//#include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4TwoVector.hh>
-#include <Geant4/G4Types.hh>
+//#include <Geant4/G4Types.hh>
 
 #include <map>
-#include <vector>
+//#include <vector>
 #include <set>
 
 class G4AssemblyVolume;
@@ -55,13 +57,17 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   G4LogicalVolume* ConstructScintiTile12(G4LogicalVolume* hcalenvelope);
   double GetScintiAngle();
 
+  int get_scinti_row_id(const std::string &volname);
+  int get_steel_plate_id(const std::string &volname);
+
   protected:
   int ConstructInnerHcal(G4LogicalVolume* sandwich);
   int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
   int DisplayVolume(G4LogicalVolume *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
   PHParameters *params;
-  G4LogicalVolume *innerhcalsteelplate;
-  G4AssemblyVolume *innerhcalassembly;
+  G4LogicalVolume *m_InnerHcalSteelPlate;
+  G4AssemblyVolume *m_InnerHcalAssembly;
+  std::set<G4LogicalVolume *> m_ActiveVolumeSet;
   G4TwoVector steel_plate_corner_upper_left;
   G4TwoVector steel_plate_corner_upper_right;
   G4TwoVector steel_plate_corner_lower_right;
@@ -117,12 +123,15 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
   int n_scinti_plates;
   int n_steel_plates;
 
-  int active;
-  int absorberactive;
+  int m_ActiveFlag;
+  int m_AbsorberActiveFlag;
 
   int layer;
-  std::string detector_type;
+//  std::string detector_type;
   std::string superdetector;
+  std::map<std::string,int> m_SteelPlateIdMap;
+  std::map<std::string,int> m_ScintillatorIdMap;
+
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalDetector.h
@@ -5,14 +5,9 @@
 
 #include <g4main/PHG4Detector.h>
 
-//#include <Geant4/globals.hh>
-//#include <Geant4/G4RotationMatrix.hh>
-//#include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4TwoVector.hh>
-//#include <Geant4/G4Types.hh>
 
 #include <map>
-//#include <vector>
 #include <set>
 
 class G4AssemblyVolume;
@@ -30,7 +25,7 @@ class PHG4Prototype2InnerHcalDetector: public PHG4Detector
  PHG4Prototype2InnerHcalDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam);
 
   //! destructor
-  virtual ~PHG4Prototype2InnerHcalDetector(){}
+ virtual ~PHG4Prototype2InnerHcalDetector();
 
   //! construct
   virtual void Construct( G4LogicalVolume* world );

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.cc
@@ -230,7 +230,7 @@ bool PHG4Prototype2InnerHcalSteppingAction::UserSteppingAction(const G4Step* aSt
     m_Hit->set_edep(m_Hit->get_edep() + edep);
     if (geantino)
     {
-      m_Hit->set_edep(-1);    // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      m_Hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
       if (whichactive > 0)  // add light yield for scintillators
       {
         m_Hit->set_light_yield(-1);

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
@@ -1,5 +1,7 @@
-#ifndef PHG4VPrototype2InnerHcalSteppingAction_h
-#define PHG4VPrototype2InnerHcalSteppingAction_h
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4VPROTOTYPE2INNERHCALSTEPPINGACTION_H
+#define G4DETECTORS_PHG4VPROTOTYPE2INNERHCALSTEPPINGACTION_H
 
 #include <g4main/PHG4SteppingAction.h>
 
@@ -28,7 +30,7 @@ class PHG4Prototype2InnerHcalSteppingAction : public PHG4SteppingAction
 
  private:
   //! pointer to the detector
-  PHG4Prototype2InnerHcalDetector *detector_;
+  PHG4Prototype2InnerHcalDetector *m_Detector;
 
   //! pointer to hit container
   PHG4HitContainer *hits_;
@@ -51,4 +53,4 @@ class PHG4Prototype2InnerHcalSteppingAction : public PHG4SteppingAction
   double light_balance_outer_radius;
 };
 
-#endif  // PHG4Prototype2InnerHcalSteppingAction_h
+#endif 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
@@ -33,24 +33,24 @@ class PHG4Prototype2InnerHcalSteppingAction : public PHG4SteppingAction
   PHG4Prototype2InnerHcalDetector *m_Detector;
 
   //! pointer to hit container
-  PHG4HitContainer *hits_;
-  PHG4HitContainer *absorberhits_;
-  PHG4Hit *hit;
-  const PHParameters *params;
-  PHG4HitContainer *savehitcontainer;
-  PHG4Shower *saveshower;
+  PHG4HitContainer *m_HitContainer;
+  PHG4HitContainer *m_AbsorberHitContainer;
+  PHG4Hit *m_Hit;
+  const PHParameters *m_Params;
+  PHG4HitContainer *m_SaveHitContainer;
+  PHG4Shower *m_SaveShower;
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables
-  int absorbertruth;
-  int IsActive;
-  int IsBlackHole;
-  int light_scint_model;
+  int m_AbsorberTruthFlag;
+  int m_IsActiveFlag;
+  int m_IsBlackHoleFlag;
+  int m_LightScintModelFlag;
 
-  double light_balance_inner_corr;
-  double light_balance_inner_radius;
-  double light_balance_outer_corr;
-  double light_balance_outer_radius;
+  double m_LightBalanceInnerCorr;
+  double m_LightBalanceInnerRadius;
+  double m_LightBalanceOuterCorr;
+  double m_LightBalanceOuterRadius;
 };
 
 #endif 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSteppingAction.h
@@ -53,4 +53,4 @@ class PHG4Prototype2InnerHcalSteppingAction : public PHG4SteppingAction
   double m_LightBalanceOuterRadius;
 };
 
-#endif 
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -21,8 +21,8 @@ using namespace std;
 //_______________________________________________________________________
 PHG4Prototype2InnerHcalSubsystem::PHG4Prototype2InnerHcalSubsystem(const std::string &name, const int lyr)
   : PHG4DetectorSubsystem(name, lyr)
-  , detector_(nullptr)
-  , steppingAction_(nullptr)
+  , m_Detector(nullptr)
+  , m_SteppingAction(nullptr)
 {
   InitializeParameters();
 }
@@ -34,9 +34,9 @@ int PHG4Prototype2InnerHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  detector_ = new PHG4Prototype2InnerHcalDetector(topNode, GetParams(), Name());
-  detector_->SuperDetector(SuperDetector());
-  detector_->OverlapCheck(CheckOverlap());
+  m_Detector = new PHG4Prototype2InnerHcalDetector(topNode, GetParams(), Name());
+  m_Detector->SuperDetector(SuperDetector());
+  m_Detector->OverlapCheck(CheckOverlap());
   set<string> nodes;
   if (GetParams()->get_int_param("active"))
   {
@@ -82,14 +82,14 @@ int PHG4Prototype2InnerHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     }
 
     // create stepping action
-    steppingAction_ = new PHG4Prototype2InnerHcalSteppingAction(detector_, GetParams());
+    m_SteppingAction = new PHG4Prototype2InnerHcalSteppingAction(m_Detector, GetParams());
   }
   else
   {
     // if this is a black hole it does not have to be active
     if (GetParams()->get_int_param("blackhole"))
     {
-      steppingAction_ = new PHG4Prototype2InnerHcalSteppingAction(detector_, GetParams());
+      m_SteppingAction = new PHG4Prototype2InnerHcalSteppingAction(m_Detector, GetParams());
     }
   }
   return 0;
@@ -100,9 +100,9 @@ int PHG4Prototype2InnerHcalSubsystem::process_event(PHCompositeNode *topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
-  if (steppingAction_)
+  if (m_SteppingAction)
   {
-    steppingAction_->SetInterfacePointers(topNode);
+    m_SteppingAction->SetInterfacePointers(topNode);
   }
   return 0;
 }
@@ -111,13 +111,13 @@ void PHG4Prototype2InnerHcalSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
   GetParams()->Print();
-  if (detector_)
+  if (m_Detector)
   {
-    detector_->Print(what);
+    m_Detector->Print(what);
   }
-  if (steppingAction_)
+  if (m_SteppingAction)
   {
-    steppingAction_->Print(what);
+    m_SteppingAction->Print(what);
   }
   return;
 }
@@ -125,7 +125,7 @@ void PHG4Prototype2InnerHcalSubsystem::Print(const string &what) const
 //_______________________________________________________________________
 PHG4Detector *PHG4Prototype2InnerHcalSubsystem::GetDetector(void) const
 {
-  return detector_;
+  return m_Detector;
 }
 
 void PHG4Prototype2InnerHcalSubsystem::SetDefaultParameters()

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -146,7 +146,6 @@ void PHG4Prototype2InnerHcalSubsystem::SetDefaultParameters()
   set_default_int_param("hi_eta", 0);
   set_default_int_param("light_scint_model", 1);
   set_default_int_param(PHG4PrototypeHcalDefs::scipertwr, 5);
-
 }
 
 void PHG4Prototype2InnerHcalSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr)

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.h
@@ -1,5 +1,7 @@
-#ifndef PHG4Prototype2InnerHcalSubsystem_h
-#define PHG4Prototype2InnerHcalSubsystem_h
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4PROTOTYPE2INNERHCALSUBSYSTEM_H
+#define G4DETECTORS_PHG4PROTOTYPE2INNERHCALSUBSYSTEM_H
 
 #include "PHG4DetectorSubsystem.h"
 
@@ -38,7 +40,7 @@ class PHG4Prototype2InnerHcalSubsystem : public PHG4DetectorSubsystem
 
   //! accessors (reimplemented)
   virtual PHG4Detector* GetDetector(void) const;
-  virtual PHG4SteppingAction* GetSteppingAction(void) const { return steppingAction_; }
+  virtual PHG4SteppingAction* GetSteppingAction(void) const { return m_SteppingAction; }
   void SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr);
 
  protected:
@@ -46,11 +48,11 @@ class PHG4Prototype2InnerHcalSubsystem : public PHG4DetectorSubsystem
 
   //! detector geometry
   /*! derives from PHG4Detector */
-  PHG4Prototype2InnerHcalDetector* detector_;
+  PHG4Prototype2InnerHcalDetector* m_Detector;
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingAction */
-  PHG4SteppingAction* steppingAction_;
+  PHG4SteppingAction* m_SteppingAction;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -15,9 +15,9 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4SystemOfUnits.hh>
 
 #include <boost/format.hpp>
 
@@ -29,71 +29,80 @@ using namespace std;
 static const string scintimothername = "OuterHcalScintiMother";
 static const string steelplatename = "OuterHcalSteelPlate";
 
-PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam  ):
-  PHG4Detector(Node, dnam),
-  m_Params(parameters),
-  m_OuterHcalSteelPlate(nullptr),
-  m_OuterHcalAssembly(nullptr),
-  m_SteelPlateCornerUpperLeft(1777.6*mm,-433.5*mm),
-  m_SteelPlateCornerUpperRight(2600.4*mm,-417.4*mm), 
-  m_SteelPlateCornerLowerRight(2601.2*mm,-459.8*mm),
-  m_SteelPlateCornerLowerLeft(1770.9*mm,-459.8*mm),
+PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
+  : PHG4Detector(Node, dnam)
+  , m_Params(parameters)
+  , m_OuterHcalSteelPlate(nullptr)
+  , m_OuterHcalAssembly(nullptr)
+  , m_SteelPlateCornerUpperLeft(1777.6 * mm, -433.5 * mm)
+  , m_SteelPlateCornerUpperRight(2600.4 * mm, -417.4 * mm)
+  , m_SteelPlateCornerLowerRight(2601.2 * mm, -459.8 * mm)
+  , m_SteelPlateCornerLowerLeft(1770.9 * mm, -459.8 * mm)
+  ,
 
-  m_ScintiUoneFrontSize(166.2*mm),
-  m_ScintiUoneCornerUpperLeft(0*mm,0*mm),
-  m_ScintiUoneCornerUpperRight(828.9*mm,0*mm),
-  m_ScintiUoneCornerLowerRight(828.9*mm,-240.54*mm),
-  m_ScintiUoneCornerLowerLeft(0*mm,-m_ScintiUoneFrontSize),
+  m_ScintiUoneFrontSize(166.2 * mm)
+  , m_ScintiUoneCornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiUoneCornerUpperRight(828.9 * mm, 0 * mm)
+  , m_ScintiUoneCornerLowerRight(828.9 * mm, -240.54 * mm)
+  , m_ScintiUoneCornerLowerLeft(0 * mm, -m_ScintiUoneFrontSize)
+  ,
 
-  m_ScintiU2CornerUpperLeft(0*mm,0*mm),
-  m_ScintiU2CornerUpperRight(828.9*mm,-74.3*mm),
-  m_ScintiU2CornerLowerRight(828.9*mm,-320.44*mm),
-  m_ScintiU2CornerLowerLeft(0*mm,-171.0*mm),
+  m_ScintiU2CornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiU2CornerUpperRight(828.9 * mm, -74.3 * mm)
+  , m_ScintiU2CornerLowerRight(828.9 * mm, -320.44 * mm)
+  , m_ScintiU2CornerLowerLeft(0 * mm, -171.0 * mm)
+  ,
 
-  m_ScintiT9DistanceToCorner(0.86*mm),
-  m_ScintiT9FrontSize(241.5*mm),
-  m_ScintiT9CornerUpperLeft(0*mm,0*mm),
-  m_ScintiT9CornerUpperRight(697.4*mm,-552.2*mm),
-  m_ScintiT9CornerLowerRight(697.4*mm,-697.4*mm/tan(47.94/180.*M_PI)-m_ScintiT9FrontSize),
-  m_ScintiT9CornerLowerLeft(0*mm,-m_ScintiT9FrontSize),
+  m_ScintiT9DistanceToCorner(0.86 * mm)
+  , m_ScintiT9FrontSize(241.5 * mm)
+  , m_ScintiT9CornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiT9CornerUpperRight(697.4 * mm, -552.2 * mm)
+  , m_ScintiT9CornerLowerRight(697.4 * mm, -697.4 * mm / tan(47.94 / 180. * M_PI) - m_ScintiT9FrontSize)
+  , m_ScintiT9CornerLowerLeft(0 * mm, -m_ScintiT9FrontSize)
+  ,
 
-  m_ScintiT10FrontSize(241.4*mm),
-  m_ScintiT10CornerUpperLeft(0*mm,0*mm),
-  m_ScintiT10CornerUpperRight(697.4*mm,-629.3*mm),
-  m_ScintiT10CornerLowerRight(697.4*mm,-697.4*mm/tan(44.2/180.*M_PI)-m_ScintiT10FrontSize),
-  m_ScintiT10CornerLowerLeft(0*mm,-m_ScintiT10FrontSize),
+  m_ScintiT10FrontSize(241.4 * mm)
+  , m_ScintiT10CornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiT10CornerUpperRight(697.4 * mm, -629.3 * mm)
+  , m_ScintiT10CornerLowerRight(697.4 * mm, -697.4 * mm / tan(44.2 / 180. * M_PI) - m_ScintiT10FrontSize)
+  , m_ScintiT10CornerLowerLeft(0 * mm, -m_ScintiT10FrontSize)
+  ,
 
-  m_ScintiT11FrontSize(241.4*mm),
-  m_ScintiT11CornerUpperLeft(0*mm,0*mm),
-  m_ScintiT11CornerUpperRight(697.4*mm,-717.1*mm),
-  m_ScintiT11CornerLowerRight(697.4*mm,-697.4*mm/tan(42.47/180.*M_PI)-m_ScintiT11FrontSize),
-  m_ScintiT11CornerLowerLeft(0*mm,-m_ScintiT11FrontSize),
+  m_ScintiT11FrontSize(241.4 * mm)
+  , m_ScintiT11CornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiT11CornerUpperRight(697.4 * mm, -717.1 * mm)
+  , m_ScintiT11CornerLowerRight(697.4 * mm, -697.4 * mm / tan(42.47 / 180. * M_PI) - m_ScintiT11FrontSize)
+  , m_ScintiT11CornerLowerLeft(0 * mm, -m_ScintiT11FrontSize)
+  ,
 
-  m_ScintiT12FrontSize(312.7*mm),
-  m_ScintiT12CornerUpperLeft(0*mm,0*mm),
-  m_ScintiT12CornerUpperRight(697.4*mm,-761.8*mm),
-  m_ScintiT12CornerLowerRight(392.9*mm,-827.7),
-  m_ScintiT12CornerLowerLeft(0*mm,-m_ScintiT12FrontSize),
+  m_ScintiT12FrontSize(312.7 * mm)
+  , m_ScintiT12CornerUpperLeft(0 * mm, 0 * mm)
+  , m_ScintiT12CornerUpperRight(697.4 * mm, -761.8 * mm)
+  , m_ScintiT12CornerLowerRight(392.9 * mm, -827.7)
+  , m_ScintiT12CornerLowerLeft(0 * mm, -m_ScintiT12FrontSize)
+  ,
 
-  m_ScintiX(828.9),
-  m_ScintiXHiEta(697.4*mm+121.09*mm),
-  m_SteelZ(1600.*mm),
-  m_SizeZ(m_SteelZ),
-  m_ScintiTileZ(m_SteelZ),
-  m_ScintiTileThickness(7*mm),
-  m_ScintiBoxSmaller(0.02*mm), // blargh - off by 20 microns bc scinti tilt angle, need to revisit at some point
-  m_GapBetweenTiles(1*mm),
-  m_ScintiGap(8.5*mm),
-  m_TiltAngle(12*deg),
-  m_DeltaPhi(2*M_PI/320.),
-  m_VolumeSteel(NAN),
-  m_VolumeScintillator(NAN),
-  m_NScintiPlates(20),
-  m_NSteelPlates(m_NScintiPlates+1),
-  m_ActiveFlag(m_Params->get_int_param("active")),
-  m_AbsorberActiveFlag(m_Params->get_int_param("absorberactive")),
-  m_Layer(0)
-{}
+  m_ScintiX(828.9)
+  , m_ScintiXHiEta(697.4 * mm + 121.09 * mm)
+  , m_SteelZ(1600. * mm)
+  , m_SizeZ(m_SteelZ)
+  , m_ScintiTileZ(m_SteelZ)
+  , m_ScintiTileThickness(7 * mm)
+  , m_ScintiBoxSmaller(0.02 * mm)
+  ,  // blargh - off by 20 microns bc scinti tilt angle, need to revisit at some point
+  m_GapBetweenTiles(1 * mm)
+  , m_ScintiGap(8.5 * mm)
+  , m_TiltAngle(12 * deg)
+  , m_DeltaPhi(2 * M_PI / 320.)
+  , m_VolumeSteel(NAN)
+  , m_VolumeScintillator(NAN)
+  , m_NScintiPlates(20)
+  , m_NSteelPlates(m_NScintiPlates + 1)
+  , m_ActiveFlag(m_Params->get_int_param("active"))
+  , m_AbsorberActiveFlag(m_Params->get_int_param("absorberactive"))
+  , m_Layer(0)
+{
+}
 
 PHG4Prototype2OuterHcalDetector::~PHG4Prototype2OuterHcalDetector()
 {
@@ -102,18 +111,17 @@ PHG4Prototype2OuterHcalDetector::~PHG4Prototype2OuterHcalDetector()
 
 //_______________________________________________________________
 //_______________________________________________________________
-int
-PHG4Prototype2OuterHcalDetector::IsInPrototype2OuterHcal(G4VPhysicalVolume * volume) const
+int PHG4Prototype2OuterHcalDetector::IsInPrototype2OuterHcal(G4VPhysicalVolume* volume) const
 {
-  G4LogicalVolume *logvol = volume->GetLogicalVolume();
+  G4LogicalVolume* logvol = volume->GetLogicalVolume();
   if (m_AbsorberActiveFlag && logvol == m_OuterHcalSteelPlate)
-    {
-      return -1;
-    }
+  {
+    return -1;
+  }
   if (m_ActiveFlag && m_ActiveVolumeSet.find(logvol) != m_ActiveVolumeSet.end())
-    {
-      return 1;
-    }
+  {
+    return 1;
+  }
   return 0;
 }
 
@@ -121,71 +129,70 @@ G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelope)
 {
   if (!m_OuterHcalSteelPlate)
-    {
-      G4VSolid* steel_plate;
-      std::vector<G4TwoVector> vertexes;
-      vertexes.push_back(m_SteelPlateCornerUpperLeft);
-      vertexes.push_back(m_SteelPlateCornerUpperRight);
-      vertexes.push_back(m_SteelPlateCornerLowerRight);
-      vertexes.push_back(m_SteelPlateCornerLowerLeft);
-      G4TwoVector zero(0, 0);
-      steel_plate =  new G4ExtrudedSolid("OuterHcalSteelPlateSolid",
-					 vertexes,
-					 m_SizeZ  / 2.0,
-					 zero, 1.0,
-					 zero, 1.0);
+  {
+    G4VSolid* steel_plate;
+    std::vector<G4TwoVector> vertexes;
+    vertexes.push_back(m_SteelPlateCornerUpperLeft);
+    vertexes.push_back(m_SteelPlateCornerUpperRight);
+    vertexes.push_back(m_SteelPlateCornerLowerRight);
+    vertexes.push_back(m_SteelPlateCornerLowerLeft);
+    G4TwoVector zero(0, 0);
+    steel_plate = new G4ExtrudedSolid("OuterHcalSteelPlateSolid",
+                                      vertexes,
+                                      m_SizeZ / 2.0,
+                                      zero, 1.0,
+                                      zero, 1.0);
 
-      m_VolumeSteel = steel_plate->GetCubicVolume()*m_NSteelPlates;
-      m_OuterHcalSteelPlate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("Steel_A36"),"OuterHcalSteelPlate", 0, 0, 0);
-      G4VisAttributes visattchk;
-      visattchk.SetVisibility(true);
-      visattchk.SetForceSolid(false);
-      visattchk.SetColour(G4Colour::Blue());
-      m_OuterHcalSteelPlate->SetVisAttributes(visattchk);
-    }
+    m_VolumeSteel = steel_plate->GetCubicVolume() * m_NSteelPlates;
+    m_OuterHcalSteelPlate = new G4LogicalVolume(steel_plate, G4Material::GetMaterial("Steel_A36"), "OuterHcalSteelPlate", 0, 0, 0);
+    G4VisAttributes visattchk;
+    visattchk.SetVisibility(true);
+    visattchk.SetForceSolid(false);
+    visattchk.SetColour(G4Colour::Blue());
+    m_OuterHcalSteelPlate->SetVisAttributes(visattchk);
+  }
   return m_OuterHcalSteelPlate;
 }
 
 G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
-{ 
-  int copynum=0;
-  G4VSolid* scintiboxsolid = new G4Box(scintimothername,m_ScintiX/2.,(m_ScintiGap-m_ScintiBoxSmaller)/2.,m_ScintiTileZ/2.);
+{
+  int copynum = 0;
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername, m_ScintiX / 2., (m_ScintiGap - m_ScintiBoxSmaller) / 2., m_ScintiTileZ / 2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
-  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String(scintimothername), 0, 0, 0);
+  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid, G4Material::GetMaterial("G4_AIR"), G4String(scintimothername), 0, 0, 0);
   G4VisAttributes* hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
   hcalVisAtt->SetForceSolid(false);
   hcalVisAtt->SetColour(G4Colour::Red());
-  G4LogicalVolume *scintiu1_logic = ConstructScintiTileU1(hcalenvelope);
+  G4LogicalVolume* scintiu1_logic = ConstructScintiTileU1(hcalenvelope);
   scintiu1_logic->SetVisAttributes(hcalVisAtt);
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
   hcalVisAtt->SetForceSolid(false);
   hcalVisAtt->SetColour(G4Colour::Cyan());
-  G4LogicalVolume *scintiu2_logic = ConstructScintiTileU2(hcalenvelope);
+  G4LogicalVolume* scintiu2_logic = ConstructScintiTileU2(hcalenvelope);
   scintiu2_logic->SetVisAttributes(hcalVisAtt);
-  G4RotationMatrix *Rot;  
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(-90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,-m_ScintiUoneFrontSize-m_GapBetweenTiles/2.-m_GapBetweenTiles),scintiu2_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  G4RotationMatrix* Rot;
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(-90 * deg);
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, -m_ScintiUoneFrontSize - m_GapBetweenTiles / 2. - m_GapBetweenTiles), scintiu2_logic, (boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(-90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(-90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,-m_GapBetweenTiles/2.),scintiu1_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, -m_GapBetweenTiles / 2.), scintiu1_logic, (boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,m_GapBetweenTiles/2.),scintiu1_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, m_GapBetweenTiles / 2.), scintiu1_logic, (boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,m_ScintiUoneFrontSize+m_GapBetweenTiles/2.+m_GapBetweenTiles),scintiu2_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
-
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, m_ScintiUoneFrontSize + m_GapBetweenTiles / 2. + m_GapBetweenTiles), scintiu2_logic, (boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   return scintiboxlogical;
 }
@@ -199,13 +206,13 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTileU1(G4LogicalVolume* hcalenve
   vertexes.push_back(m_ScintiUoneCornerLowerRight);
   vertexes.push_back(m_ScintiUoneCornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintiu1 =  new G4ExtrudedSolid("OuterHcalScintiU1",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintiu1 = new G4ExtrudedSolid("OuterHcalScintiU1",
+                                           vertexes,
+                                           m_ScintiTileThickness / 2.0,
+                                           zero, 1.0,
+                                           zero, 1.0);
 
-  G4LogicalVolume *scintiu1_logic = new G4LogicalVolume(scintiu1,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiU1", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintiu1_logic = new G4LogicalVolume(scintiu1, G4Material::GetMaterial("G4_POLYSTYRENE"), "OuterHcalScintiU1", nullptr, nullptr, nullptr);
   //   DisplayVolume(scintiu1,hcalenvelope);
   m_ActiveVolumeSet.insert(scintiu1_logic);
   return scintiu1_logic;
@@ -220,13 +227,13 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenve
   vertexes.push_back(m_ScintiU2CornerLowerRight);
   vertexes.push_back(m_ScintiU2CornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintiu2 =  new G4ExtrudedSolid("OuterHcalScintiU2",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintiu2 = new G4ExtrudedSolid("OuterHcalScintiU2",
+                                           vertexes,
+                                           m_ScintiTileThickness / 2.0,
+                                           zero, 1.0,
+                                           zero, 1.0);
 
-  G4LogicalVolume *scintiu2_logic = new G4LogicalVolume(scintiu2,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiU2", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintiu2_logic = new G4LogicalVolume(scintiu2, G4Material::GetMaterial("G4_POLYSTYRENE"), "OuterHcalScintiU2", nullptr, nullptr, nullptr);
   //   DisplayVolume(scintiu2,hcalenvelope);
   m_ActiveVolumeSet.insert(scintiu2_logic);
   return scintiu2_logic;
@@ -234,60 +241,60 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenve
 
 G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope)
-{ 
-  int copynum=0;
-  G4VSolid* scintiboxsolid = new G4Box(scintimothername,m_ScintiX/2.,(m_ScintiGap-m_ScintiBoxSmaller)/2.,m_ScintiTileZ/2.);
+{
+  int copynum = 0;
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername, m_ScintiX / 2., (m_ScintiGap - m_ScintiBoxSmaller) / 2., m_ScintiTileZ / 2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
-  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String(scintimothername), 0, 0, 0);
+  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid, G4Material::GetMaterial("G4_AIR"), G4String(scintimothername), 0, 0, 0);
 
   G4VisAttributes hcalVisAtt;
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
   hcalVisAtt.SetColour(G4Colour::Magenta());
-  G4LogicalVolume *scintit9_logic = ConstructScintiTile9(hcalenvelope);
+  G4LogicalVolume* scintit9_logic = ConstructScintiTile9(hcalenvelope);
   scintit9_logic->SetVisAttributes(hcalVisAtt);
 
-  double distance_to_corner = -m_SizeZ/2.+m_ScintiT9DistanceToCorner;
-  G4RotationMatrix *Rot;  
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiXHiEta/2.,0,distance_to_corner),scintit9_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  double distance_to_corner = -m_SizeZ / 2. + m_ScintiT9DistanceToCorner;
+  G4RotationMatrix* Rot;
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiXHiEta / 2., 0, distance_to_corner), scintit9_logic, (boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
   hcalVisAtt.SetColour(G4Colour::Blue());
-  G4LogicalVolume *scintit10_logic = ConstructScintiTile10(hcalenvelope);
+  G4LogicalVolume* scintit10_logic = ConstructScintiTile10(hcalenvelope);
   scintit10_logic->SetVisAttributes(hcalVisAtt);
 
   distance_to_corner += m_ScintiT9FrontSize + m_GapBetweenTiles;
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiXHiEta/2.,0,distance_to_corner),scintit10_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiXHiEta / 2., 0, distance_to_corner), scintit10_logic, (boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
   hcalVisAtt.SetColour(G4Colour::Yellow());
-  G4LogicalVolume *scintit11_logic = ConstructScintiTile11(hcalenvelope);
+  G4LogicalVolume* scintit11_logic = ConstructScintiTile11(hcalenvelope);
   scintit11_logic->SetVisAttributes(hcalVisAtt);
 
   distance_to_corner += m_ScintiT10FrontSize + m_GapBetweenTiles;
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiXHiEta/2.,0,distance_to_corner),scintit11_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiXHiEta / 2., 0, distance_to_corner), scintit11_logic, (boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
   hcalVisAtt.SetColour(G4Colour::Cyan());
-  G4LogicalVolume *scintit12_logic = ConstructScintiTile12(hcalenvelope);
+  G4LogicalVolume* scintit12_logic = ConstructScintiTile12(hcalenvelope);
   scintit12_logic->SetVisAttributes(hcalVisAtt);
 
   distance_to_corner += m_ScintiT11FrontSize + m_GapBetweenTiles;
-  Rot = new G4RotationMatrix();  
-  Rot->rotateX(90*deg);
+  Rot = new G4RotationMatrix();
+  Rot->rotateX(90 * deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiXHiEta/2.,0,distance_to_corner),scintit12_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiXHiEta / 2., 0, distance_to_corner), scintit12_logic, (boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
   //DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
 }
@@ -300,13 +307,13 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile9(G4LogicalVolume* hcalenvel
   vertexes.push_back(m_ScintiT9CornerLowerRight);
   vertexes.push_back(m_ScintiT9CornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintit9 =  new G4ExtrudedSolid("OuterHcalScintiT9",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintit9 = new G4ExtrudedSolid("OuterHcalScintiT9",
+                                           vertexes,
+                                           m_ScintiTileThickness / 2.0,
+                                           zero, 1.0,
+                                           zero, 1.0);
 
-  G4LogicalVolume *scintit9_logic = new G4LogicalVolume(scintit9,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT9", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintit9_logic = new G4LogicalVolume(scintit9, G4Material::GetMaterial("G4_POLYSTYRENE"), "OuterHcalScintiT9", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit9,hcalenvelope);
   m_ActiveVolumeSet.insert(scintit9_logic);
   return scintit9_logic;
@@ -321,13 +328,13 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile10(G4LogicalVolume* hcalenve
   vertexes.push_back(m_ScintiT10CornerLowerRight);
   vertexes.push_back(m_ScintiT10CornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintit10 =  new G4ExtrudedSolid("OuterHcalScintiT10",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintit10 = new G4ExtrudedSolid("OuterHcalScintiT10",
+                                            vertexes,
+                                            m_ScintiTileThickness / 2.0,
+                                            zero, 1.0,
+                                            zero, 1.0);
 
-  G4LogicalVolume *scintit10_logic = new G4LogicalVolume(scintit10,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT10", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintit10_logic = new G4LogicalVolume(scintit10, G4Material::GetMaterial("G4_POLYSTYRENE"), "OuterHcalScintiT10", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit10,hcalenvelope);
   m_ActiveVolumeSet.insert(scintit10_logic);
   return scintit10_logic;
@@ -342,13 +349,13 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile11(G4LogicalVolume* hcalenve
   vertexes.push_back(m_ScintiT11CornerLowerRight);
   vertexes.push_back(m_ScintiT11CornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintit11 =  new G4ExtrudedSolid("OuterHcalScintiT11",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintit11 = new G4ExtrudedSolid("OuterHcalScintiT11",
+                                            vertexes,
+                                            m_ScintiTileThickness / 2.0,
+                                            zero, 1.0,
+                                            zero, 1.0);
 
-  G4LogicalVolume *scintit11_logic = new G4LogicalVolume(scintit11,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT11", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintit11_logic = new G4LogicalVolume(scintit11, G4Material::GetMaterial("G4_POLYSTYRENE"), "OuterHcalScintiT11", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit11,hcalenvelope);
   m_ActiveVolumeSet.insert(scintit11_logic);
   return scintit11_logic;
@@ -363,13 +370,13 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
   vertexes.push_back(m_ScintiT12CornerLowerRight);
   vertexes.push_back(m_ScintiT12CornerLowerLeft);
   G4TwoVector zero(0, 0);
-  G4VSolid *scintit12 =  new G4ExtrudedSolid("OuterHcalScintiT12",
-					    vertexes,
-					    m_ScintiTileThickness  / 2.0,
-					    zero, 1.0,
-					    zero, 1.0);
+  G4VSolid* scintit12 = new G4ExtrudedSolid("OuterHcalScintiT12",
+                                            vertexes,
+                                            m_ScintiTileThickness / 2.0,
+                                            zero, 1.0,
+                                            zero, 1.0);
 
-  G4LogicalVolume *scintit12_logic = new G4LogicalVolume(scintit12,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT12", nullptr, nullptr, nullptr);
+  G4LogicalVolume* scintit12_logic = new G4LogicalVolume(scintit12, G4Material::GetMaterial("G4_POLYSTYRENE"), "OuterHcalScintiT12", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit12,hcalenvelope);
   m_ActiveVolumeSet.insert(scintit12_logic);
   return scintit12_logic;
@@ -377,105 +384,103 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
 
 // Construct the envelope and the call the
 // actual outer hcal construction
-void
-PHG4Prototype2OuterHcalDetector::Construct( G4LogicalVolume* logicWorld )
+void PHG4Prototype2OuterHcalDetector::Construct(G4LogicalVolume* logicWorld)
 {
-  G4ThreeVector g4vec(m_Params->get_double_param("place_x")*cm,
-                      m_Params->get_double_param("place_y")*cm,
-		      m_Params->get_double_param("place_z")*cm);
+  G4ThreeVector g4vec(m_Params->get_double_param("place_x") * cm,
+                      m_Params->get_double_param("place_y") * cm,
+                      m_Params->get_double_param("place_z") * cm);
   G4RotationMatrix Rot;
-  Rot.rotateX(m_Params->get_double_param("rot_x")*deg);
-  Rot.rotateY(m_Params->get_double_param("rot_y")*deg);
-  Rot.rotateZ(m_Params->get_double_param("rot_z")*deg);
+  Rot.rotateX(m_Params->get_double_param("rot_x") * deg);
+  Rot.rotateY(m_Params->get_double_param("rot_y") * deg);
+  Rot.rotateZ(m_Params->get_double_param("rot_z") * deg);
   //  ConstructScintillatorBoxHiEta(logicWorld);
   m_OuterHcalAssembly = new G4AssemblyVolume();
   //ConstructSteelPlate(hcal_envelope_log);
   // return;
   ConstructOuterHcal(logicWorld);
-  m_OuterHcalAssembly->MakeImprint(logicWorld,g4vec,&Rot,0,OverlapCheck());
-// this is rather pathetic - there is no way to extract the name when a volume is added
-// to the assembly. The only thing we can do is get an iterator over the placed volumes
-// in the order in which they were placed. Since this code does not install the scintillators
-// for the Al version, parsing the volume names to get the id does not work since it changes
-// So now we loop over all volumes and store them in a map for fast lookup of the row
+  m_OuterHcalAssembly->MakeImprint(logicWorld, g4vec, &Rot, 0, OverlapCheck());
+  // this is rather pathetic - there is no way to extract the name when a volume is added
+  // to the assembly. The only thing we can do is get an iterator over the placed volumes
+  // in the order in which they were placed. Since this code does not install the scintillators
+  // for the Al version, parsing the volume names to get the id does not work since it changes
+  // So now we loop over all volumes and store them in a map for fast lookup of the row
   int isteel = 0;
   int iscinti = 0;
   vector<G4VPhysicalVolume*>::iterator it = m_OuterHcalAssembly->GetVolumesIterator();
-  for (unsigned int i=0; i<m_OuterHcalAssembly-> TotalImprintedVolumes();i++)
+  for (unsigned int i = 0; i < m_OuterHcalAssembly->TotalImprintedVolumes(); i++)
   {
     string volname = (*it)->GetName();
     if (volname.find(steelplatename) != string::npos)
-    { 
-      m_SteelPlateIdMap.insert(make_pair(volname,isteel));
+    {
+      m_SteelPlateIdMap.insert(make_pair(volname, isteel));
       ++isteel;
     }
     else if (volname.find(scintimothername) != string::npos)
     {
-      m_ScintillatorIdMap.insert(make_pair(volname,iscinti));
+      m_ScintillatorIdMap.insert(make_pair(volname, iscinti));
       ++iscinti;
     }
     ++it;
   }
-// print out volume names and their assigned id
-   // map<string,int>::const_iterator iter;
-   // for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
-   // {
-   //   cout << iter->first << ", " << iter->second << endl;
-   // }
-   // for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
-   // {
-   //   cout << iter->first << ", " << iter->second << endl;
-   // }
+  // print out volume names and their assigned id
+  // map<string,int>::const_iterator iter;
+  // for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
+  // {
+  //   cout << iter->first << ", " << iter->second << endl;
+  // }
+  // for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
+  // {
+  //   cout << iter->first << ", " << iter->second << endl;
+  // }
 
   return;
 }
 
-int
-PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelope)
+int PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelope)
 {
-  G4LogicalVolume* steel_plate = ConstructSteelPlate(hcalenvelope); // bottom steel plate
+  G4LogicalVolume* steel_plate = ConstructSteelPlate(hcalenvelope);  // bottom steel plate
   G4LogicalVolume* scintibox = nullptr;
   if (m_Params->get_int_param("hi_eta"))
-    {
-      scintibox = ConstructScintillatorBoxHiEta(hcalenvelope);
-    }
+  {
+    scintibox = ConstructScintillatorBoxHiEta(hcalenvelope);
+  }
   else
-    {
-      scintibox = ConstructScintillatorBox(hcalenvelope);
-    }
+  {
+    scintibox = ConstructScintillatorBox(hcalenvelope);
+  }
   double phi = 0.;
   double phislat = 0.;
   // the coordinate of the center of the bottom of the bottom steel plate
   // to get the radius of the circle which is the center of the scintillator box
-  double bottom_xmiddle_steel_tile = (m_SteelPlateCornerLowerRight.x()-m_SteelPlateCornerLowerLeft.x())/2.+m_SteelPlateCornerLowerLeft.x();
+  double bottom_xmiddle_steel_tile = (m_SteelPlateCornerLowerRight.x() - m_SteelPlateCornerLowerLeft.x()) / 2. + m_SteelPlateCornerLowerLeft.x();
   double bottom_ymiddle_steel_tile = m_SteelPlateCornerLowerRight.y();
-  double middlerad = sqrt(bottom_xmiddle_steel_tile*bottom_xmiddle_steel_tile + bottom_ymiddle_steel_tile * bottom_ymiddle_steel_tile);
-  double philow = atan((bottom_ymiddle_steel_tile-m_ScintiGap/2.)/bottom_xmiddle_steel_tile);
+  double middlerad = sqrt(bottom_xmiddle_steel_tile * bottom_xmiddle_steel_tile + bottom_ymiddle_steel_tile * bottom_ymiddle_steel_tile);
+  double philow = atan((bottom_ymiddle_steel_tile - m_ScintiGap / 2.) / bottom_xmiddle_steel_tile);
   double scintiangle = GetScintiAngle();
   for (int i = 0; i < m_NSteelPlates; i++)
+  {
+    G4RotationMatrix Rot;
+    Rot.rotateZ(phi * rad);
+    G4ThreeVector g4vec(0, 0, 0);
+    m_OuterHcalAssembly->AddPlacedVolume(steel_plate, g4vec, &Rot);
+    if (i > 0)
     {
-      G4RotationMatrix Rot;
-      Rot.rotateZ(phi*rad);
-      G4ThreeVector g4vec(0,0,0);
-      m_OuterHcalAssembly->AddPlacedVolume(steel_plate,g4vec,&Rot);
-      if (i > 0)
-	{
-	  double ypos = sin(phi+philow) * middlerad;
-	  double xpos = cos(phi+philow) * middlerad;
-	  // the center of the scintillator is not the center of the inner hcal
-	  // but depends on the tilt angle. Therefore we need to shift
-	  // the center from the mid point
-	  ypos += sin((-m_TiltAngle)/rad - phi);
-	  xpos -= cos((-m_TiltAngle)/rad - phi);
-	  G4RotationMatrix Rota;
-	  Rota.rotateZ(scintiangle+phislat);
-	  G4ThreeVector g4vec(xpos, ypos, 0);
+      double ypos = sin(phi + philow) * middlerad;
+      double xpos = cos(phi + philow) * middlerad;
+      // the center of the scintillator is not the center of the inner hcal
+      // but depends on the tilt angle. Therefore we need to shift
+      // the center from the mid point
+      ypos += sin((-m_TiltAngle) / rad - phi);
+      xpos -= cos((-m_TiltAngle) / rad - phi);
+      G4RotationMatrix Rota;
+      Rota.rotateZ(scintiangle + phislat);
+      G4ThreeVector g4vec(xpos, ypos, 0);
 
-	  m_OuterHcalAssembly->AddPlacedVolume(scintibox,g4vec,&Rota);
-	  phislat += m_DeltaPhi;
-	}
-      phi += m_DeltaPhi;
+      m_OuterHcalAssembly->AddPlacedVolume(scintibox, g4vec, &Rota);
+      phislat += m_DeltaPhi;
     }
+    phi += m_DeltaPhi;
+  }
   return 0;
 }
 
@@ -486,25 +491,24 @@ PHG4Prototype2OuterHcalDetector::GetScintiAngle()
 {
   double xlen = m_SteelPlateCornerUpperRight.x() - m_SteelPlateCornerUpperLeft.x();
   double ylen = m_SteelPlateCornerUpperRight.y() - m_SteelPlateCornerUpperLeft.y();
-  double angle =  atan(ylen/xlen);
+  double angle = atan(ylen / xlen);
   return angle;
 }
 
-void
-PHG4Prototype2OuterHcalDetector::Print(const string &what) const
+void PHG4Prototype2OuterHcalDetector::Print(const string& what) const
 {
   cout << "Outer Hcal Detector:" << endl;
   if (what == "ALL" || what == "VOLUME")
-    {
-      cout << "Volume Steel: " << m_VolumeSteel/cm3 << " cm^3" << endl;
-      cout << "Volume Scintillator: " << m_VolumeScintillator/cm3 << " cm^3" << endl;
-    }
+  {
+    cout << "Volume Steel: " << m_VolumeSteel / cm3 << " cm^3" << endl;
+    cout << "Volume Scintillator: " << m_VolumeScintillator / cm3 << " cm^3" << endl;
+  }
   return;
 }
 
-int PHG4Prototype2OuterHcalDetector::get_scinti_row_id(const string &volname)
+int PHG4Prototype2OuterHcalDetector::get_scinti_row_id(const string& volname)
 {
-  int id=-9999;
+  int id = -9999;
   auto it = m_ScintillatorIdMap.find(volname);
   if (it != m_ScintillatorIdMap.end())
   {
@@ -518,9 +522,9 @@ int PHG4Prototype2OuterHcalDetector::get_scinti_row_id(const string &volname)
   return id;
 }
 
-int PHG4Prototype2OuterHcalDetector::get_steel_plate_id(const string &volname)
+int PHG4Prototype2OuterHcalDetector::get_steel_plate_id(const string& volname)
 {
-  int id=-9999;
+  int id = -9999;
   auto it = m_SteelPlateIdMap.find(volname);
   if (it != m_SteelPlateIdMap.end())
   {

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -17,6 +17,7 @@
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4VisAttributes.hh>
+#include <Geant4/G4SystemOfUnits.hh>
 
 #include <boost/format.hpp>
 
@@ -28,72 +29,70 @@ using namespace std;
 static const string scintimothername = "OuterHcalScintiMother";
 static const string steelplatename = "OuterHcalSteelPlate";
 
-double scinti_box_smaller = 0.02*mm;
-
 PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam  ):
   PHG4Detector(Node, dnam),
-  params(parameters),
+  m_Params(parameters),
   m_OuterHcalSteelPlate(nullptr),
   m_OuterHcalAssembly(nullptr),
-  steel_plate_corner_upper_left(1777.6*mm,-433.5*mm),
-  steel_plate_corner_upper_right(2600.4*mm,-417.4*mm), 
-  steel_plate_corner_lower_right(2601.2*mm,-459.8*mm),
-  steel_plate_corner_lower_left(1770.9*mm,-459.8*mm),
+  m_SteelPlateCornerUpperLeft(1777.6*mm,-433.5*mm),
+  m_SteelPlateCornerUpperRight(2600.4*mm,-417.4*mm), 
+  m_SteelPlateCornerLowerRight(2601.2*mm,-459.8*mm),
+  m_SteelPlateCornerLowerLeft(1770.9*mm,-459.8*mm),
 
-  scinti_u1_front_size(166.2*mm),
-  scinti_u1_corner_upper_left(0*mm,0*mm),
-  scinti_u1_corner_upper_right(828.9*mm,0*mm),
-  scinti_u1_corner_lower_right(828.9*mm,-240.54*mm),
-  scinti_u1_corner_lower_left(0*mm,-scinti_u1_front_size),
+  m_ScintiUoneFrontSize(166.2*mm),
+  m_ScintiUoneCornerUpperLeft(0*mm,0*mm),
+  m_ScintiUoneCornerUpperRight(828.9*mm,0*mm),
+  m_ScintiUoneCornerLowerRight(828.9*mm,-240.54*mm),
+  m_ScintiUoneCornerLowerLeft(0*mm,-m_ScintiUoneFrontSize),
 
-  scinti_u2_corner_upper_left(0*mm,0*mm),
-  scinti_u2_corner_upper_right(828.9*mm,-74.3*mm),
-  scinti_u2_corner_lower_right(828.9*mm,-320.44*mm),
-  scinti_u2_corner_lower_left(0*mm,-171.0*mm),
+  m_ScintiU2CornerUpperLeft(0*mm,0*mm),
+  m_ScintiU2CornerUpperRight(828.9*mm,-74.3*mm),
+  m_ScintiU2CornerLowerRight(828.9*mm,-320.44*mm),
+  m_ScintiU2CornerLowerLeft(0*mm,-171.0*mm),
 
-  scinti_t9_distance_to_corner(0.86*mm),
-  scinti_t9_front_size(241.5*mm),
-  scinti_t9_corner_upper_left(0*mm,0*mm),
-  scinti_t9_corner_upper_right(697.4*mm,-552.2*mm),
-  scinti_t9_corner_lower_right(697.4*mm,-697.4*mm/tan(47.94/180.*M_PI)-scinti_t9_front_size),
-  scinti_t9_corner_lower_left(0*mm,-scinti_t9_front_size),
+  m_ScintiT9DistanceToCorner(0.86*mm),
+  m_ScintiT9FrontSize(241.5*mm),
+  m_ScintiT9CornerUpperLeft(0*mm,0*mm),
+  m_ScintiT9CornerUpperRight(697.4*mm,-552.2*mm),
+  m_ScintiT9CornerLowerRight(697.4*mm,-697.4*mm/tan(47.94/180.*M_PI)-m_ScintiT9FrontSize),
+  m_ScintiT9CornerLowerLeft(0*mm,-m_ScintiT9FrontSize),
 
-  scinti_t10_front_size(241.4*mm),
-  scinti_t10_corner_upper_left(0*mm,0*mm),
-  scinti_t10_corner_upper_right(697.4*mm,-629.3*mm),
-  scinti_t10_corner_lower_right(697.4*mm,-697.4*mm/tan(44.2/180.*M_PI)-scinti_t10_front_size),
-  scinti_t10_corner_lower_left(0*mm,-scinti_t10_front_size),
+  m_ScintiT10FrontSize(241.4*mm),
+  m_ScintiT10CornerUpperLeft(0*mm,0*mm),
+  m_ScintiT10CornerUpperRight(697.4*mm,-629.3*mm),
+  m_ScintiT10CornerLowerRight(697.4*mm,-697.4*mm/tan(44.2/180.*M_PI)-m_ScintiT10FrontSize),
+  m_ScintiT10CornerLowerLeft(0*mm,-m_ScintiT10FrontSize),
 
-  scinti_t11_front_size(241.4*mm),
-  scinti_t11_corner_upper_left(0*mm,0*mm),
-  scinti_t11_corner_upper_right(697.4*mm,-717.1*mm),
-  scinti_t11_corner_lower_right(697.4*mm,-697.4*mm/tan(42.47/180.*M_PI)-scinti_t11_front_size),
-  scinti_t11_corner_lower_left(0*mm,-scinti_t11_front_size),
+  m_ScintiT11FrontSize(241.4*mm),
+  m_ScintiT11CornerUpperLeft(0*mm,0*mm),
+  m_ScintiT11CornerUpperRight(697.4*mm,-717.1*mm),
+  m_ScintiT11CornerLowerRight(697.4*mm,-697.4*mm/tan(42.47/180.*M_PI)-m_ScintiT11FrontSize),
+  m_ScintiT11CornerLowerLeft(0*mm,-m_ScintiT11FrontSize),
 
-  scinti_t12_front_size(312.7*mm),
-  scinti_t12_corner_upper_left(0*mm,0*mm),
-  scinti_t12_corner_upper_right(697.4*mm,-761.8*mm),
-  scinti_t12_corner_lower_right(392.9*mm,-827.7),
-  scinti_t12_corner_lower_left(0*mm,-scinti_t12_front_size),
+  m_ScintiT12FrontSize(312.7*mm),
+  m_ScintiT12CornerUpperLeft(0*mm,0*mm),
+  m_ScintiT12CornerUpperRight(697.4*mm,-761.8*mm),
+  m_ScintiT12CornerLowerRight(392.9*mm,-827.7),
+  m_ScintiT12CornerLowerLeft(0*mm,-m_ScintiT12FrontSize),
 
-  scinti_x(828.9),
-  scinti_x_hi_eta(697.4*mm+121.09*mm),
-  steel_z(1600.*mm),
-  size_z(steel_z),
-  scinti_tile_z(steel_z),
-  scinti_tile_thickness(7*mm),
-scinti_box_smaller(0.02*mm), // blargh - off by 20 microns bc scinti tilt angle, need to revisit at some point
-  gap_between_tiles(1*mm),
-  scinti_gap(8.5*mm),
-  tilt_angle(12*deg),
-  deltaphi(2*M_PI/320.),
-  volume_steel(NAN),
-  volume_scintillator(NAN),
-  n_scinti_plates(20),
-  n_steel_plates(n_scinti_plates+1),
-  active(params->get_int_param("active")),
-  absorberactive(params->get_int_param("absorberactive")),
-  layer(0)
+  m_ScintiX(828.9),
+  m_ScintiXHiEta(697.4*mm+121.09*mm),
+  m_SteelZ(1600.*mm),
+  m_SizeZ(m_SteelZ),
+  m_ScintiTileZ(m_SteelZ),
+  m_ScintiTileThickness(7*mm),
+  m_ScintiBoxSmaller(0.02*mm), // blargh - off by 20 microns bc scinti tilt angle, need to revisit at some point
+  m_GapBetweenTiles(1*mm),
+  m_ScintiGap(8.5*mm),
+  m_TiltAngle(12*deg),
+  m_DeltaPhi(2*M_PI/320.),
+  m_VolumeSteel(NAN),
+  m_VolumeScintillator(NAN),
+  m_NScintiPlates(20),
+  m_NSteelPlates(m_NScintiPlates+1),
+  m_ActiveFlag(m_Params->get_int_param("active")),
+  m_AbsorberActiveFlag(m_Params->get_int_param("absorberactive")),
+  m_Layer(0)
 {}
 
 PHG4Prototype2OuterHcalDetector::~PHG4Prototype2OuterHcalDetector()
@@ -107,11 +106,11 @@ int
 PHG4Prototype2OuterHcalDetector::IsInPrototype2OuterHcal(G4VPhysicalVolume * volume) const
 {
   G4LogicalVolume *logvol = volume->GetLogicalVolume();
-  if (absorberactive && logvol == m_OuterHcalSteelPlate)
+  if (m_AbsorberActiveFlag && logvol == m_OuterHcalSteelPlate)
     {
       return -1;
     }
-  if (active && m_ActiveVolumeSet.find(logvol) != m_ActiveVolumeSet.end())
+  if (m_ActiveFlag && m_ActiveVolumeSet.find(logvol) != m_ActiveVolumeSet.end())
     {
       return 1;
     }
@@ -125,18 +124,18 @@ PHG4Prototype2OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
     {
       G4VSolid* steel_plate;
       std::vector<G4TwoVector> vertexes;
-      vertexes.push_back(steel_plate_corner_upper_left);
-      vertexes.push_back(steel_plate_corner_upper_right);
-      vertexes.push_back(steel_plate_corner_lower_right);
-      vertexes.push_back(steel_plate_corner_lower_left);
+      vertexes.push_back(m_SteelPlateCornerUpperLeft);
+      vertexes.push_back(m_SteelPlateCornerUpperRight);
+      vertexes.push_back(m_SteelPlateCornerLowerRight);
+      vertexes.push_back(m_SteelPlateCornerLowerLeft);
       G4TwoVector zero(0, 0);
       steel_plate =  new G4ExtrudedSolid("OuterHcalSteelPlateSolid",
 					 vertexes,
-					 size_z  / 2.0,
+					 m_SizeZ  / 2.0,
 					 zero, 1.0,
 					 zero, 1.0);
 
-      volume_steel = steel_plate->GetCubicVolume()*n_steel_plates;
+      m_VolumeSteel = steel_plate->GetCubicVolume()*m_NSteelPlates;
       m_OuterHcalSteelPlate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("Steel_A36"),"OuterHcalSteelPlate", 0, 0, 0);
       G4VisAttributes visattchk;
       visattchk.SetVisibility(true);
@@ -151,7 +150,7 @@ G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
 { 
   int copynum=0;
-  G4VSolid* scintiboxsolid = new G4Box(scintimothername,scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername,m_ScintiX/2.,(m_ScintiGap-m_ScintiBoxSmaller)/2.,m_ScintiTileZ/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String(scintimothername), 0, 0, 0);
   G4VisAttributes* hcalVisAtt = new G4VisAttributes();
@@ -170,22 +169,22 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
   G4RotationMatrix *Rot;  
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-scinti_u1_front_size-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,-m_ScintiUoneFrontSize-m_GapBetweenTiles/2.-m_GapBetweenTiles),scintiu2_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-gap_between_tiles/2.),scintiu1_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,-m_GapBetweenTiles/2.),scintiu1_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,gap_between_tiles/2.),scintiu1_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,m_GapBetweenTiles/2.),scintiu1_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,scinti_u1_front_size+gap_between_tiles/2.+gap_between_tiles),scintiu2_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiX/2.,0,m_ScintiUoneFrontSize+m_GapBetweenTiles/2.+m_GapBetweenTiles),scintiu2_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
 
   return scintiboxlogical;
@@ -195,14 +194,14 @@ G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintiTileU1(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_u1_corner_upper_left);
-  vertexes.push_back(scinti_u1_corner_upper_right);
-  vertexes.push_back(scinti_u1_corner_lower_right);
-  vertexes.push_back(scinti_u1_corner_lower_left);
+  vertexes.push_back(m_ScintiUoneCornerUpperLeft);
+  vertexes.push_back(m_ScintiUoneCornerUpperRight);
+  vertexes.push_back(m_ScintiUoneCornerLowerRight);
+  vertexes.push_back(m_ScintiUoneCornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintiu1 =  new G4ExtrudedSolid("OuterHcalScintiU1",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -216,14 +215,14 @@ G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_u2_corner_upper_left);
-  vertexes.push_back(scinti_u2_corner_upper_right);
-  vertexes.push_back(scinti_u2_corner_lower_right);
-  vertexes.push_back(scinti_u2_corner_lower_left);
+  vertexes.push_back(m_ScintiU2CornerUpperLeft);
+  vertexes.push_back(m_ScintiU2CornerUpperRight);
+  vertexes.push_back(m_ScintiU2CornerLowerRight);
+  vertexes.push_back(m_ScintiU2CornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintiu2 =  new G4ExtrudedSolid("OuterHcalScintiU2",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -237,7 +236,7 @@ G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope)
 { 
   int copynum=0;
-  G4VSolid* scintiboxsolid = new G4Box(scintimothername,scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername,m_ScintiX/2.,(m_ScintiGap-m_ScintiBoxSmaller)/2.,m_ScintiTileZ/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String(scintimothername), 0, 0, 0);
 
@@ -248,11 +247,11 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   G4LogicalVolume *scintit9_logic = ConstructScintiTile9(hcalenvelope);
   scintit9_logic->SetVisAttributes(hcalVisAtt);
 
-  double distance_to_corner = -size_z/2.+scinti_t9_distance_to_corner;
+  double distance_to_corner = -m_SizeZ/2.+m_ScintiT9DistanceToCorner;
   G4RotationMatrix *Rot;  
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit9_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiXHiEta/2.,0,distance_to_corner),scintit9_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
@@ -260,11 +259,11 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   G4LogicalVolume *scintit10_logic = ConstructScintiTile10(hcalenvelope);
   scintit10_logic->SetVisAttributes(hcalVisAtt);
 
-  distance_to_corner += scinti_t9_front_size + gap_between_tiles;
+  distance_to_corner += m_ScintiT9FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit10_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiXHiEta/2.,0,distance_to_corner),scintit10_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
@@ -272,11 +271,11 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   G4LogicalVolume *scintit11_logic = ConstructScintiTile11(hcalenvelope);
   scintit11_logic->SetVisAttributes(hcalVisAtt);
 
-  distance_to_corner += scinti_t10_front_size + gap_between_tiles;
+  distance_to_corner += m_ScintiT10FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit11_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiXHiEta/2.,0,distance_to_corner),scintit11_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt.SetVisibility(true);
   hcalVisAtt.SetForceSolid(false);
@@ -284,11 +283,11 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   G4LogicalVolume *scintit12_logic = ConstructScintiTile12(hcalenvelope);
   scintit12_logic->SetVisAttributes(hcalVisAtt);
 
-  distance_to_corner += scinti_t11_front_size + gap_between_tiles;
+  distance_to_corner += m_ScintiT11FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
   copynum++;
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit12_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-m_ScintiXHiEta/2.,0,distance_to_corner),scintit12_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
   //DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
 }
@@ -296,14 +295,14 @@ G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintiTile9(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_t9_corner_upper_left);
-  vertexes.push_back(scinti_t9_corner_upper_right);
-  vertexes.push_back(scinti_t9_corner_lower_right);
-  vertexes.push_back(scinti_t9_corner_lower_left);
+  vertexes.push_back(m_ScintiT9CornerUpperLeft);
+  vertexes.push_back(m_ScintiT9CornerUpperRight);
+  vertexes.push_back(m_ScintiT9CornerLowerRight);
+  vertexes.push_back(m_ScintiT9CornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintit9 =  new G4ExtrudedSolid("OuterHcalScintiT9",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -317,14 +316,14 @@ G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintiTile10(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_t10_corner_upper_left);
-  vertexes.push_back(scinti_t10_corner_upper_right);
-  vertexes.push_back(scinti_t10_corner_lower_right);
-  vertexes.push_back(scinti_t10_corner_lower_left);
+  vertexes.push_back(m_ScintiT10CornerUpperLeft);
+  vertexes.push_back(m_ScintiT10CornerUpperRight);
+  vertexes.push_back(m_ScintiT10CornerLowerRight);
+  vertexes.push_back(m_ScintiT10CornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintit10 =  new G4ExtrudedSolid("OuterHcalScintiT10",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -338,14 +337,14 @@ G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintiTile11(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_t11_corner_upper_left);
-  vertexes.push_back(scinti_t11_corner_upper_right);
-  vertexes.push_back(scinti_t11_corner_lower_right);
-  vertexes.push_back(scinti_t11_corner_lower_left);
+  vertexes.push_back(m_ScintiT11CornerUpperLeft);
+  vertexes.push_back(m_ScintiT11CornerUpperRight);
+  vertexes.push_back(m_ScintiT11CornerLowerRight);
+  vertexes.push_back(m_ScintiT11CornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintit11 =  new G4ExtrudedSolid("OuterHcalScintiT11",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -359,14 +358,14 @@ G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenvelope)
 {
   std::vector<G4TwoVector> vertexes;
-  vertexes.push_back(scinti_t12_corner_upper_left);
-  vertexes.push_back(scinti_t12_corner_upper_right);
-  vertexes.push_back(scinti_t12_corner_lower_right);
-  vertexes.push_back(scinti_t12_corner_lower_left);
+  vertexes.push_back(m_ScintiT12CornerUpperLeft);
+  vertexes.push_back(m_ScintiT12CornerUpperRight);
+  vertexes.push_back(m_ScintiT12CornerLowerRight);
+  vertexes.push_back(m_ScintiT12CornerLowerLeft);
   G4TwoVector zero(0, 0);
   G4VSolid *scintit12 =  new G4ExtrudedSolid("OuterHcalScintiT12",
 					    vertexes,
-					    scinti_tile_thickness  / 2.0,
+					    m_ScintiTileThickness  / 2.0,
 					    zero, 1.0,
 					    zero, 1.0);
 
@@ -381,13 +380,13 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
 void
 PHG4Prototype2OuterHcalDetector::Construct( G4LogicalVolume* logicWorld )
 {
-  G4ThreeVector g4vec(params->get_double_param("place_x")*cm,
-                      params->get_double_param("place_y")*cm,
-		      params->get_double_param("place_z")*cm);
+  G4ThreeVector g4vec(m_Params->get_double_param("place_x")*cm,
+                      m_Params->get_double_param("place_y")*cm,
+		      m_Params->get_double_param("place_z")*cm);
   G4RotationMatrix Rot;
-  Rot.rotateX(params->get_double_param("rot_x")*deg);
-  Rot.rotateY(params->get_double_param("rot_y")*deg);
-  Rot.rotateZ(params->get_double_param("rot_z")*deg);
+  Rot.rotateX(m_Params->get_double_param("rot_x")*deg);
+  Rot.rotateY(m_Params->get_double_param("rot_y")*deg);
+  Rot.rotateZ(m_Params->get_double_param("rot_z")*deg);
   //  ConstructScintillatorBoxHiEta(logicWorld);
   m_OuterHcalAssembly = new G4AssemblyVolume();
   //ConstructSteelPlate(hcal_envelope_log);
@@ -418,15 +417,15 @@ PHG4Prototype2OuterHcalDetector::Construct( G4LogicalVolume* logicWorld )
     ++it;
   }
 // print out volume names and their assigned id
-   map<string,int>::const_iterator iter;
-   for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
-   {
-     cout << iter->first << ", " << iter->second << endl;
-   }
-   for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
-   {
-     cout << iter->first << ", " << iter->second << endl;
-   }
+   // map<string,int>::const_iterator iter;
+   // for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
+   // {
+   //   cout << iter->first << ", " << iter->second << endl;
+   // }
+   // for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
+   // {
+   //   cout << iter->first << ", " << iter->second << endl;
+   // }
 
   return;
 }
@@ -436,7 +435,7 @@ PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelop
 {
   G4LogicalVolume* steel_plate = ConstructSteelPlate(hcalenvelope); // bottom steel plate
   G4LogicalVolume* scintibox = nullptr;
-  if (params->get_int_param("hi_eta"))
+  if (m_Params->get_int_param("hi_eta"))
     {
       scintibox = ConstructScintillatorBoxHiEta(hcalenvelope);
     }
@@ -446,20 +445,16 @@ PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelop
     }
   double phi = 0.;
   double phislat = 0.;
-  ostringstream name;
   // the coordinate of the center of the bottom of the bottom steel plate
   // to get the radius of the circle which is the center of the scintillator box
-  double bottom_xmiddle_steel_tile = (steel_plate_corner_lower_right.x()-steel_plate_corner_lower_left.x())/2.+steel_plate_corner_lower_left.x();
-  double bottom_ymiddle_steel_tile = steel_plate_corner_lower_right.y();
+  double bottom_xmiddle_steel_tile = (m_SteelPlateCornerLowerRight.x()-m_SteelPlateCornerLowerLeft.x())/2.+m_SteelPlateCornerLowerLeft.x();
+  double bottom_ymiddle_steel_tile = m_SteelPlateCornerLowerRight.y();
   double middlerad = sqrt(bottom_xmiddle_steel_tile*bottom_xmiddle_steel_tile + bottom_ymiddle_steel_tile * bottom_ymiddle_steel_tile);
-  double philow = atan((bottom_ymiddle_steel_tile-scinti_gap/2.)/bottom_xmiddle_steel_tile);
+  double philow = atan((bottom_ymiddle_steel_tile-m_ScintiGap/2.)/bottom_xmiddle_steel_tile);
   double scintiangle = GetScintiAngle();
-  for (int i = 0; i < n_steel_plates; i++)
-    //      for (int i = 0; i < 2; i++)
+  for (int i = 0; i < m_NSteelPlates; i++)
     {
-      name.str("");
-      name << "OuterHcalSteel_" << i;
-      G4RotationMatrix Rot;// = new G4RotationMatrix();
+      G4RotationMatrix Rot;
       Rot.rotateZ(phi*rad);
       G4ThreeVector g4vec(0,0,0);
       m_OuterHcalAssembly->AddPlacedVolume(steel_plate,g4vec,&Rot);
@@ -470,18 +465,16 @@ PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelop
 	  // the center of the scintillator is not the center of the inner hcal
 	  // but depends on the tilt angle. Therefore we need to shift
 	  // the center from the mid point
-	  ypos += sin((-tilt_angle)/rad - phi);
-	  xpos -= cos((-tilt_angle)/rad - phi);
-	  name.str("");
-	  name << "OuterHcalScintiBox_" << i;
-	  G4RotationMatrix Rota;// = new G4RotationMatrix();
+	  ypos += sin((-m_TiltAngle)/rad - phi);
+	  xpos -= cos((-m_TiltAngle)/rad - phi);
+	  G4RotationMatrix Rota;
 	  Rota.rotateZ(scintiangle+phislat);
 	  G4ThreeVector g4vec(xpos, ypos, 0);
 
 	  m_OuterHcalAssembly->AddPlacedVolume(scintibox,g4vec,&Rota);
-	  phislat += deltaphi;
+	  phislat += m_DeltaPhi;
 	}
-      phi += deltaphi;
+      phi += m_DeltaPhi;
     }
   return 0;
 }
@@ -491,8 +484,8 @@ PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelop
 double
 PHG4Prototype2OuterHcalDetector::GetScintiAngle()
 {
-  double xlen = steel_plate_corner_upper_right.x() - steel_plate_corner_upper_left.x();
-  double ylen = steel_plate_corner_upper_right.y() - steel_plate_corner_upper_left.y();
+  double xlen = m_SteelPlateCornerUpperRight.x() - m_SteelPlateCornerUpperLeft.x();
+  double ylen = m_SteelPlateCornerUpperRight.y() - m_SteelPlateCornerUpperLeft.y();
   double angle =  atan(ylen/xlen);
   return angle;
 }
@@ -503,8 +496,8 @@ PHG4Prototype2OuterHcalDetector::Print(const string &what) const
   cout << "Outer Hcal Detector:" << endl;
   if (what == "ALL" || what == "VOLUME")
     {
-      cout << "Volume Steel: " << volume_steel/cm/cm/cm << " cm^3" << endl;
-      cout << "Volume Scintillator: " << volume_scintillator/cm/cm/cm << " cm^3" << endl;
+      cout << "Volume Steel: " << m_VolumeSteel/cm3 << " cm^3" << endl;
+      cout << "Volume Scintillator: " << m_VolumeScintillator/cm3 << " cm^3" << endl;
     }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -23,13 +23,16 @@
 
 using namespace std;
 
+static const string scintimothername = "OuterHcalScintiMother";
+static const string steelplatename = "OuterHcalSteelPlate";
+
 double scinti_box_smaller = 0.02*mm;
 
 PHG4Prototype2OuterHcalDetector::PHG4Prototype2OuterHcalDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam  ):
   PHG4Detector(Node, dnam),
   params(parameters),
-  outerhcalsteelplate(NULL),
-  outerhcalassembly(NULL),
+  outerhcalsteelplate(nullptr),
+  m_OuterHcalAssembly(nullptr),
   steel_plate_corner_upper_left(1777.6*mm,-433.5*mm),
   steel_plate_corner_upper_right(2600.4*mm,-417.4*mm), 
   steel_plate_corner_lower_right(2601.2*mm,-459.8*mm),
@@ -158,9 +161,9 @@ PHG4Prototype2OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
 G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
 { 
-  G4VSolid* scintiboxsolid = new G4Box("OuterHcalScintiMother",scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername,scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
-  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String("OuterHcalScintiMother"), 0, 0, 0);
+  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String(scintimothername), 0, 0, 0);
   G4VisAttributes* hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
   hcalVisAtt->SetForceSolid(false);
@@ -210,7 +213,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTileU1(G4LogicalVolume* hcalenve
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintiu1_logic = new G4LogicalVolume(scintiu1,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiU1", NULL, NULL, NULL);
+  G4LogicalVolume *scintiu1_logic = new G4LogicalVolume(scintiu1,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiU1", nullptr, nullptr, nullptr);
   //   DisplayVolume(scintiu1,hcalenvelope);
   return scintiu1_logic;
 }
@@ -230,7 +233,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenve
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintiu2_logic = new G4LogicalVolume(scintiu2,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiU2", NULL, NULL, NULL);
+  G4LogicalVolume *scintiu2_logic = new G4LogicalVolume(scintiu2,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiU2", nullptr, nullptr, nullptr);
   //   DisplayVolume(scintiu2,hcalenvelope);
   return scintiu2_logic;
 }
@@ -238,9 +241,9 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenve
 G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope)
 { 
-  G4VSolid* scintiboxsolid = new G4Box("OuterHcalScintiMother",scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
+  G4VSolid* scintiboxsolid = new G4Box(scintimothername,scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
-  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String("OuterHcalScintiMother"), 0, 0, 0);
+  G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String(scintimothername), 0, 0, 0);
 
   G4VisAttributes* hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -253,7 +256,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   G4RotationMatrix *Rot;  
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit9_logic,"OuterScinti_9", scintiboxlogical, false, 0, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit9_logic,"OuterScinti_9", scintiboxlogical, false, 9, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -265,7 +268,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   distance_to_corner += scinti_t9_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit10_logic,"OuterScinti_10", scintiboxlogical, false, 0, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit10_logic,"OuterScinti_10", scintiboxlogical, false, 10, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -277,7 +280,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   distance_to_corner += scinti_t10_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit11_logic,"OuterScinti_11", scintiboxlogical, false, 0, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit11_logic,"OuterScinti_11", scintiboxlogical, false, 11, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -289,7 +292,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   distance_to_corner += scinti_t11_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit12_logic,"OuterScinti_12", scintiboxlogical, false, 0, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit12_logic,"OuterScinti_12", scintiboxlogical, false, 12, OverlapCheck());
   //DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
 }
@@ -308,7 +311,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile9(G4LogicalVolume* hcalenvel
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintit9_logic = new G4LogicalVolume(scintit9,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT9", NULL, NULL, NULL);
+  G4LogicalVolume *scintit9_logic = new G4LogicalVolume(scintit9,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT9", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit9,hcalenvelope);
   return scintit9_logic;
 }
@@ -328,7 +331,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile10(G4LogicalVolume* hcalenve
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintit10_logic = new G4LogicalVolume(scintit10,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT10", NULL, NULL, NULL);
+  G4LogicalVolume *scintit10_logic = new G4LogicalVolume(scintit10,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT10", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit10,hcalenvelope);
   return scintit10_logic;
 }
@@ -348,7 +351,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile11(G4LogicalVolume* hcalenve
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintit11_logic = new G4LogicalVolume(scintit11,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT11", NULL, NULL, NULL);
+  G4LogicalVolume *scintit11_logic = new G4LogicalVolume(scintit11,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT11", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit11,hcalenvelope);
   return scintit11_logic;
 }
@@ -368,7 +371,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTile12(G4LogicalVolume* hcalenve
 					    zero, 1.0,
 					    zero, 1.0);
 
-  G4LogicalVolume *scintit12_logic = new G4LogicalVolume(scintit12,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT12", NULL, NULL, NULL);
+  G4LogicalVolume *scintit12_logic = new G4LogicalVolume(scintit12,G4Material::GetMaterial("G4_POLYSTYRENE"),"OuterHcalScintiT12", nullptr, nullptr, nullptr);
   //     DisplayVolume(scintit12,hcalenvelope);
   return scintit12_logic;
 }
@@ -386,11 +389,45 @@ PHG4Prototype2OuterHcalDetector::Construct( G4LogicalVolume* logicWorld )
   Rot->rotateY(params->get_double_param("rot_y")*deg);
   Rot->rotateZ(params->get_double_param("rot_z")*deg);
   //  ConstructScintillatorBoxHiEta(logicWorld);
-  outerhcalassembly = new G4AssemblyVolume();
+  m_OuterHcalAssembly = new G4AssemblyVolume();
   //ConstructSteelPlate(hcal_envelope_log);
   // return;
   ConstructOuterHcal(logicWorld);
-  outerhcalassembly->MakeImprint(logicWorld,g4vec,Rot,0,OverlapCheck());
+  m_OuterHcalAssembly->MakeImprint(logicWorld,g4vec,Rot,0,OverlapCheck());
+// this is rather pathetic - there is no way to extract the name when a volume is added
+// to the assembly. The only thing we can do is get an iterator over the placed volumes
+// in the order in which they were placed. Since this code does not install the scintillators
+// for the Al version, parsing the volume names to get the id does not work since it changes
+// So now we loop over all volumes and store them in a map for fast lookup of the row
+  int isteel = 0;
+  int iscinti = 0;
+  vector<G4VPhysicalVolume*>::iterator it = m_OuterHcalAssembly->GetVolumesIterator();
+  for (unsigned int i=0; i<m_OuterHcalAssembly-> TotalImprintedVolumes();i++)
+  {
+    string volname = (*it)->GetName();
+    if (volname.find(steelplatename) != string::npos)
+    { 
+      m_SteelPlateIdMap.insert(make_pair(volname,isteel));
+      ++isteel;
+    }
+    else if (volname.find(scintimothername) != string::npos)
+    {
+      m_ScintillatorIdMap.insert(make_pair(volname,iscinti));
+      ++iscinti;
+    }
+    ++it;
+  }
+// print out volume names and their assigned id
+   map<string,int>::const_iterator iter;
+   for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
+   {
+     cout << iter->first << ", " << iter->second << endl;
+   }
+   for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
+   {
+     cout << iter->first << ", " << iter->second << endl;
+   }
+
   return;
 }
 
@@ -398,7 +435,7 @@ int
 PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelope)
 {
   G4LogicalVolume* steel_plate = ConstructSteelPlate(hcalenvelope); // bottom steel plate
-  G4LogicalVolume* scintibox = NULL;
+  G4LogicalVolume* scintibox = nullptr;
   if (params->get_int_param("hi_eta"))
     {
       scintibox = ConstructScintillatorBoxHiEta(hcalenvelope);
@@ -425,7 +462,7 @@ PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelop
       G4RotationMatrix *Rot = new G4RotationMatrix();
       Rot->rotateZ(phi*rad);
       G4ThreeVector g4vec(0,0,0);
-      outerhcalassembly->AddPlacedVolume(steel_plate,g4vec,Rot);
+      m_OuterHcalAssembly->AddPlacedVolume(steel_plate,g4vec,Rot);
       if (i > 0)
 	{
 	  double ypos = sin(phi+philow) * middlerad;
@@ -441,7 +478,7 @@ PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelop
 	  Rot->rotateZ(scintiangle+phislat);
 	  G4ThreeVector g4vec(xpos, ypos, 0);
 
-	  outerhcalassembly->AddPlacedVolume(scintibox,g4vec,Rot);
+	  m_OuterHcalAssembly->AddPlacedVolume(scintibox,g4vec,Rot);
 	  phislat += deltaphi;
 	}
       phi += deltaphi;
@@ -460,56 +497,6 @@ PHG4Prototype2OuterHcalDetector::GetScintiAngle()
   return angle;
 }
 
-int
-PHG4Prototype2OuterHcalDetector::DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix *rotm )
-{
-  G4LogicalVolume* checksolid = new G4LogicalVolume(volume, G4Material::GetMaterial("G4_POLYSTYRENE"), "DISPLAYLOGICAL", 0, 0, 0);
-  DisplayVolume(checksolid,logvol,rotm);
-  return 0;
-}
-
-int
-PHG4Prototype2OuterHcalDetector::DisplayVolume(G4LogicalVolume *checksolid,  G4LogicalVolume* logvol, G4RotationMatrix *rotm )
-{
-  static int i = 0;
-  G4VisAttributes* visattchk = new G4VisAttributes();
-  visattchk->SetVisibility(true);
-  visattchk->SetForceSolid(false);
-  switch(i)
-    {
-    case 0:
-      visattchk->SetColour(G4Colour::Red());
-      i++;
-      break;
-    case 1:
-      visattchk->SetColour(G4Colour::Magenta());
-      i++;
-      break;
-    case 2:
-      visattchk->SetColour(G4Colour::Yellow());
-      i++;
-      break;
-    case 3:
-      visattchk->SetColour(G4Colour::Blue());
-      i++;
-      break;
-    case 4:
-      visattchk->SetColour(G4Colour::Cyan());
-      i++;
-      break;
-    default:
-      visattchk->SetColour(G4Colour::Green());
-      i = 0;
-      break;
-    }
-
-  checksolid->SetVisAttributes(visattchk);
-  new G4PVPlacement(rotm, G4ThreeVector(0, 0, 0), checksolid, "DISPLAYVOL", logvol, 0, false, OverlapCheck());
-  //  new G4PVPlacement(rotm, G4ThreeVector(0, -460.3, 0), checksolid, "DISPLAYVOL", logvol, 0, false, OverlapCheck());
-  return 0;
-}
-
-
 void
 PHG4Prototype2OuterHcalDetector::Print(const string &what) const
 {
@@ -522,3 +509,33 @@ PHG4Prototype2OuterHcalDetector::Print(const string &what) const
   return;
 }
 
+int PHG4Prototype2OuterHcalDetector::get_scinti_row_id(const string &volname)
+{
+  int id=-9999;
+  auto it = m_ScintillatorIdMap.find(volname);
+  if (it != m_ScintillatorIdMap.end())
+  {
+    id = it->second;
+  }
+  else
+  {
+    cout << "unknown scintillator volume name: " << volname << endl;
+  }
+
+  return id;
+}
+
+int PHG4Prototype2OuterHcalDetector::get_steel_plate_id(const string &volname)
+{
+  int id=-9999;
+  auto it = m_SteelPlateIdMap.find(volname);
+  if (it != m_SteelPlateIdMap.end())
+  {
+    id = it->second;
+  }
+  else
+  {
+    cout << "unknown steel volume name: " << volname << endl;
+  }
+  return id;
+}

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -18,6 +18,8 @@
 #include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4VisAttributes.hh>
 
+#include <boost/format.hpp>
+
 #include <cmath>
 #include <sstream>
 
@@ -161,6 +163,7 @@ PHG4Prototype2OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
 G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcalenvelope)
 { 
+  int copynum=0;
   G4VSolid* scintiboxsolid = new G4Box(scintimothername,scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String(scintimothername), 0, 0, 0);
@@ -180,19 +183,22 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume* hcale
   G4RotationMatrix *Rot;  
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-scinti_u1_front_size-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,"OuterScinti_0", scintiboxlogical, false, 0, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-scinti_u1_front_size-gap_between_tiles/2.-gap_between_tiles),scintiu2_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(-90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-gap_between_tiles/2.),scintiu1_logic,"OuterScinti_1", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,-gap_between_tiles/2.),scintiu1_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,gap_between_tiles/2.),scintiu1_logic,"OuterScinti_2", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,gap_between_tiles/2.),scintiu1_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,scinti_u1_front_size+gap_between_tiles/2.+gap_between_tiles),scintiu2_logic,"OuterScinti_3", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x/2.,0,scinti_u1_front_size+gap_between_tiles/2.+gap_between_tiles),scintiu2_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
 
   return scintiboxlogical;
@@ -241,6 +247,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintiTileU2(G4LogicalVolume* hcalenve
 G4LogicalVolume*
 PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* hcalenvelope)
 { 
+  int copynum=0;
   G4VSolid* scintiboxsolid = new G4Box(scintimothername,scinti_x/2.,(scinti_gap-scinti_box_smaller)/2.,scinti_tile_z/2.);
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String(scintimothername), 0, 0, 0);
@@ -256,7 +263,7 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   G4RotationMatrix *Rot;  
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit9_logic,"OuterScinti_9", scintiboxlogical, false, 9, OverlapCheck());
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit9_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -268,7 +275,8 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   distance_to_corner += scinti_t9_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit10_logic,"OuterScinti_10", scintiboxlogical, false, 10, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit10_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -280,7 +288,8 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   distance_to_corner += scinti_t10_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit11_logic,"OuterScinti_11", scintiboxlogical, false, 11, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit11_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -292,7 +301,8 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   distance_to_corner += scinti_t11_front_size + gap_between_tiles;
   Rot = new G4RotationMatrix();  
   Rot->rotateX(90*deg);
-  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit12_logic,"OuterScinti_12", scintiboxlogical, false, 12, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit12_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
   //DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
 }

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.cc
@@ -96,6 +96,11 @@ scinti_box_smaller(0.02*mm), // blargh - off by 20 microns bc scinti tilt angle,
   layer(0)
 {}
 
+PHG4Prototype2OuterHcalDetector::~PHG4Prototype2OuterHcalDetector()
+{
+  delete m_OuterHcalAssembly;
+}
+
 //_______________________________________________________________
 //_______________________________________________________________
 int
@@ -133,10 +138,10 @@ PHG4Prototype2OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume* hcalenvelo
 
       volume_steel = steel_plate->GetCubicVolume()*n_steel_plates;
       m_OuterHcalSteelPlate = new G4LogicalVolume(steel_plate,G4Material::GetMaterial("Steel_A36"),"OuterHcalSteelPlate", 0, 0, 0);
-      G4VisAttributes* visattchk = new G4VisAttributes();
-      visattchk->SetVisibility(true);
-      visattchk->SetForceSolid(false);
-      visattchk->SetColour(G4Colour::Blue());
+      G4VisAttributes visattchk;
+      visattchk.SetVisibility(true);
+      visattchk.SetForceSolid(false);
+      visattchk.SetColour(G4Colour::Blue());
       m_OuterHcalSteelPlate->SetVisAttributes(visattchk);
     }
   return m_OuterHcalSteelPlate;
@@ -236,10 +241,10 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   //  DisplayVolume(scintiboxsolid,hcalenvelope);
   G4LogicalVolume* scintiboxlogical = new G4LogicalVolume(scintiboxsolid,G4Material::GetMaterial("G4_AIR"),G4String(scintimothername), 0, 0, 0);
 
-  G4VisAttributes* hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Magenta());
+  G4VisAttributes hcalVisAtt;
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Magenta());
   G4LogicalVolume *scintit9_logic = ConstructScintiTile9(hcalenvelope);
   scintit9_logic->SetVisAttributes(hcalVisAtt);
 
@@ -249,10 +254,9 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   Rot->rotateX(90*deg);
   new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit9_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Blue());
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Blue());
   G4LogicalVolume *scintit10_logic = ConstructScintiTile10(hcalenvelope);
   scintit10_logic->SetVisAttributes(hcalVisAtt);
 
@@ -262,10 +266,9 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   copynum++;
   new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit10_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Yellow());
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Yellow());
   G4LogicalVolume *scintit11_logic = ConstructScintiTile11(hcalenvelope);
   scintit11_logic->SetVisAttributes(hcalVisAtt);
 
@@ -275,10 +278,9 @@ PHG4Prototype2OuterHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume* 
   copynum++;
   new G4PVPlacement(Rot,G4ThreeVector(-scinti_x_hi_eta/2.,0,distance_to_corner),scintit11_logic,(boost::format("OuterScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Cyan());
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Cyan());
   G4LogicalVolume *scintit12_logic = ConstructScintiTile12(hcalenvelope);
   scintit12_logic->SetVisAttributes(hcalVisAtt);
 
@@ -382,16 +384,16 @@ PHG4Prototype2OuterHcalDetector::Construct( G4LogicalVolume* logicWorld )
   G4ThreeVector g4vec(params->get_double_param("place_x")*cm,
                       params->get_double_param("place_y")*cm,
 		      params->get_double_param("place_z")*cm);
-  G4RotationMatrix *Rot = new G4RotationMatrix();
-  Rot->rotateX(params->get_double_param("rot_x")*deg);
-  Rot->rotateY(params->get_double_param("rot_y")*deg);
-  Rot->rotateZ(params->get_double_param("rot_z")*deg);
+  G4RotationMatrix Rot;
+  Rot.rotateX(params->get_double_param("rot_x")*deg);
+  Rot.rotateY(params->get_double_param("rot_y")*deg);
+  Rot.rotateZ(params->get_double_param("rot_z")*deg);
   //  ConstructScintillatorBoxHiEta(logicWorld);
   m_OuterHcalAssembly = new G4AssemblyVolume();
   //ConstructSteelPlate(hcal_envelope_log);
   // return;
   ConstructOuterHcal(logicWorld);
-  m_OuterHcalAssembly->MakeImprint(logicWorld,g4vec,Rot,0,OverlapCheck());
+  m_OuterHcalAssembly->MakeImprint(logicWorld,g4vec,&Rot,0,OverlapCheck());
 // this is rather pathetic - there is no way to extract the name when a volume is added
 // to the assembly. The only thing we can do is get an iterator over the placed volumes
 // in the order in which they were placed. Since this code does not install the scintillators
@@ -457,10 +459,10 @@ PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelop
     {
       name.str("");
       name << "OuterHcalSteel_" << i;
-      G4RotationMatrix *Rot = new G4RotationMatrix();
-      Rot->rotateZ(phi*rad);
+      G4RotationMatrix Rot;// = new G4RotationMatrix();
+      Rot.rotateZ(phi*rad);
       G4ThreeVector g4vec(0,0,0);
-      m_OuterHcalAssembly->AddPlacedVolume(steel_plate,g4vec,Rot);
+      m_OuterHcalAssembly->AddPlacedVolume(steel_plate,g4vec,&Rot);
       if (i > 0)
 	{
 	  double ypos = sin(phi+philow) * middlerad;
@@ -472,11 +474,11 @@ PHG4Prototype2OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume* hcalenvelop
 	  xpos -= cos((-tilt_angle)/rad - phi);
 	  name.str("");
 	  name << "OuterHcalScintiBox_" << i;
-	  Rot = new G4RotationMatrix();
-	  Rot->rotateZ(scintiangle+phislat);
+	  G4RotationMatrix Rota;// = new G4RotationMatrix();
+	  Rota.rotateZ(scintiangle+phislat);
 	  G4ThreeVector g4vec(xpos, ypos, 0);
 
-	  m_OuterHcalAssembly->AddPlacedVolume(scintibox,g4vec,Rot);
+	  m_OuterHcalAssembly->AddPlacedVolume(scintibox,g4vec,&Rota);
 	  phislat += deltaphi;
 	}
       phi += deltaphi;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
@@ -30,7 +30,7 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
  PHG4Prototype2OuterHcalDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam);
 
   //! destructor
-  virtual ~PHG4Prototype2OuterHcalDetector(){}
+ virtual ~PHG4Prototype2OuterHcalDetector();
 
   //! construct
   virtual void Construct( G4LogicalVolume* world );

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
@@ -5,11 +5,7 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/globals.hh>
-#include <Geant4/G4RotationMatrix.hh>
-#include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4TwoVector.hh>
-#include <Geant4/G4Types.hh>
 
 #include <map>
 #include <vector>
@@ -42,9 +38,9 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
   int IsInPrototype2OuterHcal(G4VPhysicalVolume*) const;
   //@}
 
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return layer;}
+  void SuperDetector(const std::string &name) {m_SuperDetector = name;}
+  const std::string SuperDetector() const {return m_SuperDetector;}
+  int get_Layer() const {return m_Layer;}
 
   G4LogicalVolume* ConstructSteelPlate(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintillatorBox(G4LogicalVolume* hcalenvelope);
@@ -64,72 +60,71 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
   private:
   int ConstructOuterHcal(G4LogicalVolume* sandwich);
   std::set<G4LogicalVolume *> m_ActiveVolumeSet;
-  PHParameters *params;
+  PHParameters *m_Params;
   G4LogicalVolume *m_OuterHcalSteelPlate;
   G4AssemblyVolume *m_OuterHcalAssembly;
-  G4TwoVector steel_plate_corner_upper_left;
-  G4TwoVector steel_plate_corner_upper_right;
-  G4TwoVector steel_plate_corner_lower_right;
-  G4TwoVector steel_plate_corner_lower_left;
+  G4TwoVector m_SteelPlateCornerUpperLeft;
+  G4TwoVector m_SteelPlateCornerUpperRight;
+  G4TwoVector m_SteelPlateCornerLowerRight;
+  G4TwoVector m_SteelPlateCornerLowerLeft;
 
-  double scinti_u1_front_size;
-  G4TwoVector scinti_u1_corner_upper_left;
-  G4TwoVector scinti_u1_corner_upper_right;
-  G4TwoVector scinti_u1_corner_lower_right;
-  G4TwoVector scinti_u1_corner_lower_left;
+  double m_ScintiUoneFrontSize;
+  G4TwoVector m_ScintiUoneCornerUpperLeft;
+  G4TwoVector m_ScintiUoneCornerUpperRight;
+  G4TwoVector m_ScintiUoneCornerLowerRight;
+  G4TwoVector m_ScintiUoneCornerLowerLeft;
 
-  G4TwoVector scinti_u2_corner_upper_left;
-  G4TwoVector scinti_u2_corner_upper_right;
-  G4TwoVector scinti_u2_corner_lower_right;
-  G4TwoVector scinti_u2_corner_lower_left;
-  double scinti_t9_distance_to_corner;
-  double scinti_t9_front_size;
-  G4TwoVector scinti_t9_corner_upper_left;
-  G4TwoVector scinti_t9_corner_upper_right;
-  G4TwoVector scinti_t9_corner_lower_right;
-  G4TwoVector scinti_t9_corner_lower_left;
+  G4TwoVector m_ScintiU2CornerUpperLeft;
+  G4TwoVector m_ScintiU2CornerUpperRight;
+  G4TwoVector m_ScintiU2CornerLowerRight;
+  G4TwoVector m_ScintiU2CornerLowerLeft;
+  double m_ScintiT9DistanceToCorner;
+  double m_ScintiT9FrontSize;
+  G4TwoVector m_ScintiT9CornerUpperLeft;
+  G4TwoVector m_ScintiT9CornerUpperRight;
+  G4TwoVector m_ScintiT9CornerLowerRight;
+  G4TwoVector m_ScintiT9CornerLowerLeft;
 
-  double scinti_t10_front_size;
-  G4TwoVector scinti_t10_corner_upper_left;
-  G4TwoVector scinti_t10_corner_upper_right;
-  G4TwoVector scinti_t10_corner_lower_right;
-  G4TwoVector scinti_t10_corner_lower_left;
+  double m_ScintiT10FrontSize;
+  G4TwoVector m_ScintiT10CornerUpperLeft;
+  G4TwoVector m_ScintiT10CornerUpperRight;
+  G4TwoVector m_ScintiT10CornerLowerRight;
+  G4TwoVector m_ScintiT10CornerLowerLeft;
 
-  double scinti_t11_front_size;
-  G4TwoVector scinti_t11_corner_upper_left;
-  G4TwoVector scinti_t11_corner_upper_right;
-  G4TwoVector scinti_t11_corner_lower_right;
-  G4TwoVector scinti_t11_corner_lower_left;
+  double m_ScintiT11FrontSize;
+  G4TwoVector m_ScintiT11CornerUpperLeft;
+  G4TwoVector m_ScintiT11CornerUpperRight;
+  G4TwoVector m_ScintiT11CornerLowerRight;
+  G4TwoVector m_ScintiT11CornerLowerLeft;
 
-  double scinti_t12_front_size;
-  G4TwoVector scinti_t12_corner_upper_left;
-  G4TwoVector scinti_t12_corner_upper_right;
-  G4TwoVector scinti_t12_corner_lower_right;
-  G4TwoVector scinti_t12_corner_lower_left;
+  double m_ScintiT12FrontSize;
+  G4TwoVector m_ScintiT12CornerUpperLeft;
+  G4TwoVector m_ScintiT12CornerUpperRight;
+  G4TwoVector m_ScintiT12CornerLowerRight;
+  G4TwoVector m_ScintiT12CornerLowerLeft;
 
-  double scinti_x;
-  double scinti_x_hi_eta;
-  double steel_z;
-  double size_z;
-  double scinti_tile_z;
-  double scinti_tile_thickness;
-  double scinti_box_smaller;
-  double gap_between_tiles;
-  double scinti_gap;
-  double tilt_angle;
-  double deltaphi;
-  double volume_steel;
-  double volume_scintillator;
+  double m_ScintiX;
+  double m_ScintiXHiEta;
+  double m_SteelZ;
+  double m_SizeZ;
+  double m_ScintiTileZ;
+  double m_ScintiTileThickness;
+  double m_ScintiBoxSmaller;
+  double m_GapBetweenTiles;
+  double m_ScintiGap;
+  double m_TiltAngle;
+  double m_DeltaPhi;
+  double m_VolumeSteel;
+  double m_VolumeScintillator;
 
-  int n_scinti_plates;
-  int n_steel_plates;
+  int m_NScintiPlates;
+  int m_NSteelPlates;
 
-  int active;
-  int absorberactive;
+  int m_ActiveFlag;
+  int m_AbsorberActiveFlag;
 
-  int layer;
-  std::string detector_type;
-  std::string superdetector;
+  int m_Layer;
+  std::string m_SuperDetector;
   std::map<std::string, int> m_SteelPlateIdMap;
   std::map<std::string, int> m_ScintillatorIdMap;
 };

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
@@ -8,8 +8,8 @@
 #include <Geant4/G4TwoVector.hh>
 
 #include <map>
-#include <vector>
 #include <set>
+#include <vector>
 
 class G4AssemblyVolume;
 class G4LogicalVolume;
@@ -17,30 +17,28 @@ class G4VPhysicalVolume;
 class G4VSolid;
 class PHParameters;
 
-class PHG4Prototype2OuterHcalDetector: public PHG4Detector
+class PHG4Prototype2OuterHcalDetector : public PHG4Detector
 {
-
-  public:
-
+ public:
   //! constructor
- PHG4Prototype2OuterHcalDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam);
+  PHG4Prototype2OuterHcalDetector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam);
 
   //! destructor
- virtual ~PHG4Prototype2OuterHcalDetector();
+  virtual ~PHG4Prototype2OuterHcalDetector();
 
   //! construct
-  virtual void Construct( G4LogicalVolume* world );
+  virtual void Construct(G4LogicalVolume* world);
 
-  virtual void Print(const std::string &what = "ALL") const;
+  virtual void Print(const std::string& what = "ALL") const;
 
   //!@name volume accessors
   //@{
   int IsInPrototype2OuterHcal(G4VPhysicalVolume*) const;
   //@}
 
-  void SuperDetector(const std::string &name) {m_SuperDetector = name;}
-  const std::string SuperDetector() const {return m_SuperDetector;}
-  int get_Layer() const {return m_Layer;}
+  void SuperDetector(const std::string& name) { m_SuperDetector = name; }
+  const std::string SuperDetector() const { return m_SuperDetector; }
+  int get_Layer() const { return m_Layer; }
 
   G4LogicalVolume* ConstructSteelPlate(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintillatorBox(G4LogicalVolume* hcalenvelope);
@@ -51,18 +49,17 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
   G4LogicalVolume* ConstructScintiTile10(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintiTile11(G4LogicalVolume* hcalenvelope);
   G4LogicalVolume* ConstructScintiTile12(G4LogicalVolume* hcalenvelope);
-   double GetScintiAngle();
+  double GetScintiAngle();
 
-  int get_scinti_row_id(const std::string &volname);
-  int get_steel_plate_id(const std::string &volname);
+  int get_scinti_row_id(const std::string& volname);
+  int get_steel_plate_id(const std::string& volname);
 
-
-  private:
+ private:
   int ConstructOuterHcal(G4LogicalVolume* sandwich);
-  std::set<G4LogicalVolume *> m_ActiveVolumeSet;
-  PHParameters *m_Params;
-  G4LogicalVolume *m_OuterHcalSteelPlate;
-  G4AssemblyVolume *m_OuterHcalAssembly;
+  std::set<G4LogicalVolume*> m_ActiveVolumeSet;
+  PHParameters* m_Params;
+  G4LogicalVolume* m_OuterHcalSteelPlate;
+  G4AssemblyVolume* m_OuterHcalAssembly;
   G4TwoVector m_SteelPlateCornerUpperLeft;
   G4TwoVector m_SteelPlateCornerUpperRight;
   G4TwoVector m_SteelPlateCornerLowerRight;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
@@ -1,5 +1,7 @@
-#ifndef PHG4Prototype2OuterHcalDetector_h
-#define PHG4Prototype2OuterHcalDetector_h
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4PROTOTYPE2OUTERHCALDETECTOR_H
+#define G4DETECTORS_PHG4PROTOTYPE2OUTERHCALDETECTOR_H
 
 #include <g4main/PHG4Detector.h>
 
@@ -55,13 +57,15 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
   G4LogicalVolume* ConstructScintiTile12(G4LogicalVolume* hcalenvelope);
    double GetScintiAngle();
 
-  protected:
+  int get_scinti_row_id(const std::string &volname);
+  int get_steel_plate_id(const std::string &volname);
+
+
+  private:
   int ConstructOuterHcal(G4LogicalVolume* sandwich);
-  int DisplayVolume(G4VSolid *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
-  int DisplayVolume(G4LogicalVolume *volume,  G4LogicalVolume* logvol, G4RotationMatrix* rotm=NULL);
   PHParameters *params;
   G4LogicalVolume *outerhcalsteelplate;
-  G4AssemblyVolume *outerhcalassembly;
+  G4AssemblyVolume *m_OuterHcalAssembly;
   G4TwoVector steel_plate_corner_upper_left;
   G4TwoVector steel_plate_corner_upper_right;
   G4TwoVector steel_plate_corner_lower_right;
@@ -125,6 +129,8 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
   int layer;
   std::string detector_type;
   std::string superdetector;
+  std::map<std::string, int> m_SteelPlateIdMap;
+  std::map<std::string, int> m_ScintillatorIdMap;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalDetector.h
@@ -63,8 +63,9 @@ class PHG4Prototype2OuterHcalDetector: public PHG4Detector
 
   private:
   int ConstructOuterHcal(G4LogicalVolume* sandwich);
+  std::set<G4LogicalVolume *> m_ActiveVolumeSet;
   PHParameters *params;
-  G4LogicalVolume *outerhcalsteelplate;
+  G4LogicalVolume *m_OuterHcalSteelPlate;
   G4AssemblyVolume *m_OuterHcalAssembly;
   G4TwoVector steel_plate_corner_upper_left;
   G4TwoVector steel_plate_corner_upper_right;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
@@ -131,9 +131,13 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction(const G4Step* aSt
         break;
       }
     }
-    // cout << "mother volume: " <<  mothervolume->GetName()
-    //      << ", volume name " << volume->GetName() << ", row: " << row_id
-    //  	   << ", column: " << slat_id << endl;
+    int slatid2 = volume->GetCopyNo();
+int rowid2 = detector_->get_scinti_row_id(mothervolume->GetName());
+     cout << "mother volume: " <<  mothervolume->GetName()
+          << ", volume name " << volume->GetName() << ", row: " << row_id
+	  << ", rowid2: " << rowid2
+      	   << ", column: " << slat_id 
+	  << ", slatid2: " << slatid2 << endl;
   }
   else
   {

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.cc
@@ -14,21 +14,7 @@
 
 #include <Geant4/G4MaterialCutsCouple.hh>
 #include <Geant4/G4Step.hh>
-
-#include <boost/foreach.hpp>
-#include <boost/tokenizer.hpp>
-// this is an ugly hack, the gcc optimizer has a bug which
-// triggers the uninitialized variable warning which
-// stops compilation because of our -Werror
-#include <boost/version.hpp>  // to get BOOST_VERSION
-#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700)
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#pragma message "ignoring bogus gcc warning in boost header lexical_cast.hpp"
-#include <boost/lexical_cast.hpp>
-#pragma GCC diagnostic warning "-Wuninitialized"
-#else
-#include <boost/lexical_cast.hpp>
-#endif
+#include <Geant4/G4SystemOfUnits.hh>
 
 #include <iostream>
 
@@ -36,20 +22,20 @@ using namespace std;
 //____________________________________________________________________________..
 PHG4Prototype2OuterHcalSteppingAction::PHG4Prototype2OuterHcalSteppingAction(PHG4Prototype2OuterHcalDetector* detector, const PHParameters* parameters)
   : m_Detector(detector)
-  , hits_(nullptr)
-  , absorberhits_(nullptr)
-  , hit(nullptr)
-  , params(parameters)
-  , savehitcontainer(nullptr)
-  , saveshower(nullptr)
-  , absorbertruth(params->get_int_param("absorbertruth"))
-  , IsActive(params->get_int_param("active"))
-  , IsBlackHole(params->get_int_param("blackhole"))
-  , light_scint_model(params->get_int_param("light_scint_model"))
-  , light_balance_inner_corr(params->get_double_param("light_balance_inner_corr"))
-  , light_balance_inner_radius(params->get_double_param("light_balance_inner_radius") * cm)
-  , light_balance_outer_corr(params->get_double_param("light_balance_outer_corr"))
-  , light_balance_outer_radius(params->get_double_param("light_balance_outer_radius") * cm)
+  , m_Hits(nullptr)
+  , m_AbsorberHits(nullptr)
+  , m_Hit(nullptr)
+  , m_Params(parameters)
+  , m_SaveHitContainer(nullptr)
+  , m_SaveShower(nullptr)
+  , m_AbsorberTruthFlag(m_Params->get_int_param("absorbertruth"))
+  , m_IsActiveFlag(m_Params->get_int_param("active"))
+  , m_IsBlackHoleFlag(m_Params->get_int_param("blackhole"))
+  , m_LightScintModelFlag(m_Params->get_int_param("light_scint_model"))
+  , m_LightBalanceInnerCorr(m_Params->get_double_param("light_balance_inner_corr"))
+  , m_LightBalanceInnerRadius(m_Params->get_double_param("light_balance_inner_radius") * cm)
+  , m_LightBalanceOuterCorr(m_Params->get_double_param("light_balance_outer_corr"))
+  , m_LightBalanceOuterRadius(m_Params->get_double_param("light_balance_outer_radius") * cm)
 {
 }
 
@@ -59,7 +45,7 @@ PHG4Prototype2OuterHcalSteppingAction::~PHG4Prototype2OuterHcalSteppingAction()
   // and the memory is still allocated, so we need to delete it here
   // if the last hit was saved, hit is a nullptr pointer which are
   // legal to delete (it results in a no operation)
-  delete hit;
+  delete m_Hit;
 }
 
 //____________________________________________________________________________..
@@ -103,7 +89,7 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction(const G4Step* aSt
   const G4Track* aTrack = aStep->GetTrack();
 
   // if this block stops everything, just put all kinetic energy into edep
-  if (IsBlackHole)
+  if (m_IsBlackHoleFlag)
   {
     edep = aTrack->GetKineticEnergy() / GeV;
     G4Track* killtrack = const_cast<G4Track*>(aTrack);
@@ -112,7 +98,7 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction(const G4Step* aSt
   int layer_id = m_Detector->get_Layer();
 
   // make sure we are in a volume
-  if (IsActive)
+  if (m_IsActiveFlag)
   {
     bool geantino = false;
 
@@ -133,58 +119,58 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction(const G4Step* aSt
     {
     case fGeomBoundary:
     case fUndefined:
-      if (!hit)
+      if (!m_Hit)
       {
-        hit = new PHG4Hitv1();
+        m_Hit = new PHG4Hitv1();
       }
-      hit->set_row(row_id);  // this is the row
+      m_Hit->set_row(row_id);  // this is the row
       if (whichactive > 0)   // only for scintillators
       {
-        hit->set_scint_id(slat_id);  // the slat id in the mother volume (or steel plate id), the column
+        m_Hit->set_scint_id(slat_id);  // the slat id in the mother volume (or steel plate id), the column
       }
       //here we set the entrance values in cm
-      hit->set_x(0, prePoint->GetPosition().x() / cm);
-      hit->set_y(0, prePoint->GetPosition().y() / cm);
-      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      m_Hit->set_x(0, prePoint->GetPosition().x() / cm);
+      m_Hit->set_y(0, prePoint->GetPosition().y() / cm);
+      m_Hit->set_z(0, prePoint->GetPosition().z() / cm);
       // time in ns
-      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      m_Hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
       //set the track ID
-      hit->set_trkid(aTrack->GetTrackID());
+      m_Hit->set_trkid(aTrack->GetTrackID());
       if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {
         if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
-          hit->set_trkid(pp->GetUserTrackId());
-          hit->set_shower_id(pp->GetShower()->get_id());
+          m_Hit->set_trkid(pp->GetUserTrackId());
+          m_Hit->set_shower_id(pp->GetShower()->get_id());
         }
       }
 
       //set the initial energy deposit
-      hit->set_edep(0);
+      m_Hit->set_edep(0);
 
-      hit->set_hit_type(0);
+      m_Hit->set_hit_type(0);
       if ((aTrack->GetParticleDefinition()->GetParticleName().find("e+") != string::npos) ||
           (aTrack->GetParticleDefinition()->GetParticleName().find("e-") != string::npos))
-        hit->set_hit_type(1);
+        m_Hit->set_hit_type(1);
 
       // here we do things which are different between scintillator and absorber hits
       if (whichactive > 0)  // return of IsInPrototype2OuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
       {
-        savehitcontainer = hits_;
-        hit->set_light_yield(0);  // for scintillator only, initialize light yields
-        hit->set_eion(0);
+        m_SaveHitContainer = m_Hits;
+        m_Hit->set_light_yield(0);  // for scintillator only, initialize light yields
+        m_Hit->set_eion(0);
       }
       else
       {
-        savehitcontainer = absorberhits_;
+        m_SaveHitContainer = m_AbsorberHits;
       }
       if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {
         if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
-          hit->set_trkid(pp->GetUserTrackId());
-          hit->set_shower_id(pp->GetShower()->get_id());
-          saveshower = pp->GetShower();
+          m_Hit->set_trkid(pp->GetUserTrackId());
+          m_Hit->set_shower_id(pp->GetShower()->get_id());
+          m_SaveShower = pp->GetShower();
         }
       }
       break;
@@ -194,44 +180,44 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction(const G4Step* aSt
     // here we just update the exit values, it will be overwritten
     // for every step until we leave the volume or the particle
     // ceases to exist
-    hit->set_x(1, postPoint->GetPosition().x() / cm);
-    hit->set_y(1, postPoint->GetPosition().y() / cm);
-    hit->set_z(1, postPoint->GetPosition().z() / cm);
+    m_Hit->set_x(1, postPoint->GetPosition().x() / cm);
+    m_Hit->set_y(1, postPoint->GetPosition().y() / cm);
+    m_Hit->set_z(1, postPoint->GetPosition().z() / cm);
 
-    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+    m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
 
     if (whichactive > 0)  // return of IsInPrototype2OuterHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
     {
-      hit->set_eion(hit->get_eion() + eion);
+      m_Hit->set_eion(m_Hit->get_eion() + eion);
       light_yield = eion;
-      if (light_scint_model)
+      if (m_LightScintModelFlag)
       {
         light_yield = GetVisibleEnergyDeposition(aStep);  // for scintillator only, calculate light yields
       }
-      if (isfinite(light_balance_outer_radius) &&
-          isfinite(light_balance_inner_radius) &&
-          isfinite(light_balance_outer_corr) &&
-          isfinite(light_balance_inner_corr))
+      if (isfinite(m_LightBalanceOuterRadius) &&
+          isfinite(m_LightBalanceInnerRadius) &&
+          isfinite(m_LightBalanceOuterCorr) &&
+          isfinite(m_LightBalanceInnerCorr))
       {
         double r = sqrt(postPoint->GetPosition().x() * postPoint->GetPosition().x() + postPoint->GetPosition().y() * postPoint->GetPosition().y());
         double cor = GetLightCorrection(r);
         light_yield = light_yield * cor;
       }
-      hit->set_light_yield(hit->get_light_yield() + light_yield);
+      m_Hit->set_light_yield(m_Hit->get_light_yield() + light_yield);
     }
 
     //sum up the energy to get total deposited
-    hit->set_edep(hit->get_edep() + edep);
+    m_Hit->set_edep(m_Hit->get_edep() + edep);
     if (geantino)
     {
-      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      m_Hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
       if (whichactive > 0)
       {
-        hit->set_light_yield(-1);
-        hit->set_eion(-1);
+        m_Hit->set_light_yield(-1);
+        m_Hit->set_eion(-1);
       }
     }
-    if (edep > 0 && (whichactive > 0 || absorbertruth > 0))
+    if (edep > 0 && (whichactive > 0 || m_AbsorberTruthFlag > 0))
     {
       if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {
@@ -256,26 +242,26 @@ bool PHG4Prototype2OuterHcalSteppingAction::UserSteppingAction(const G4Step* aSt
         aTrack->GetTrackStatus() == fStopAndKill)
     {
       // save only hits with energy deposit (or -1 for geantino)
-      if (hit->get_edep())
+      if (m_Hit->get_edep())
       {
-        savehitcontainer->AddHit(layer_id, hit);
-        if (saveshower)
+        m_SaveHitContainer->AddHit(layer_id, m_Hit);
+        if (m_SaveShower)
         {
-          saveshower->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
+          m_SaveShower->add_g4hit_id(m_SaveHitContainer->GetID(), m_Hit->get_hit_id());
         }
         // ownership has been transferred to container, set to null
         // so we will create a new hit for the next track
-        hit = nullptr;
+        m_Hit = nullptr;
       }
       else
       {
         // if this hit has no energy deposit, just reset it for reuse
         // this means we have to delete it in the dtor. If this was
         // the last hit we processed the memory is still allocated
-        hit->Reset();
+        m_Hit->Reset();
       }
     }
-    //       hit->identify();
+    //       m_Hit->identify();
     // return true to indicate the hit was used
     return true;
   }
@@ -302,15 +288,15 @@ void PHG4Prototype2OuterHcalSteppingAction::SetInterfacePointers(PHCompositeNode
   }
 
   //now look for the map and grab a pointer to it.
-  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
-  absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
+  m_Hits = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  m_AbsorberHits = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
 
   // if we do not find the node it's messed up.
-  if (!hits_)
+  if (!m_Hits)
   {
     std::cout << "PHG4Prototype2OuterHcalSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
   }
-  if (!absorberhits_)
+  if (!m_AbsorberHits)
   {
     if (Verbosity() > 1)
     {
@@ -322,8 +308,8 @@ void PHG4Prototype2OuterHcalSteppingAction::SetInterfacePointers(PHCompositeNode
 double
 PHG4Prototype2OuterHcalSteppingAction::GetLightCorrection(const double r) const
 {
-  double m = (light_balance_outer_corr - light_balance_inner_corr) / (light_balance_outer_radius - light_balance_inner_radius);
-  double b = light_balance_inner_corr - m * light_balance_inner_radius;
+  double m = (m_LightBalanceOuterCorr - m_LightBalanceInnerCorr) / (m_LightBalanceOuterRadius - m_LightBalanceInnerRadius);
+  double b = m_LightBalanceInnerCorr - m * m_LightBalanceInnerRadius;
   double value = m * r + b;
   if (value > 1.0) return 1.0;
   if (value < 0.0) return 0.0;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.h
@@ -28,7 +28,7 @@ class PHG4Prototype2OuterHcalSteppingAction : public PHG4SteppingAction
 
  private:
   //! pointer to the detector
-  PHG4Prototype2OuterHcalDetector *detector_;
+  PHG4Prototype2OuterHcalDetector *m_Detector;
 
   //! pointer to hit container
   PHG4HitContainer *hits_;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSteppingAction.h
@@ -1,5 +1,7 @@
-#ifndef PHG4VPrototype2OuterHcalSteppingAction_h
-#define PHG4VPrototype2OuterHcalSteppingAction_h
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4PROTOTYPE2OUTERHCALSTEPPINGACTION_H
+#define G4DETECTORS_PHG4PROTOTYPE2OUTERHCALSTEPPINGACTION_H
 
 #include <g4main/PHG4SteppingAction.h>
 
@@ -31,24 +33,24 @@ class PHG4Prototype2OuterHcalSteppingAction : public PHG4SteppingAction
   PHG4Prototype2OuterHcalDetector *m_Detector;
 
   //! pointer to hit container
-  PHG4HitContainer *hits_;
-  PHG4HitContainer *absorberhits_;
-  PHG4Hit *hit;
-  const PHParameters *params;
-  PHG4HitContainer *savehitcontainer;
-  PHG4Shower *saveshower;
+  PHG4HitContainer *m_Hits;
+  PHG4HitContainer *m_AbsorberHits;
+  PHG4Hit *m_Hit;
+  const PHParameters *m_Params;
+  PHG4HitContainer *m_SaveHitContainer;
+  PHG4Shower *m_SaveShower;
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables
-  int absorbertruth;
-  int IsActive;
-  int IsBlackHole;
-  int light_scint_model;
+  int m_AbsorberTruthFlag;
+  int m_IsActiveFlag;
+  int m_IsBlackHoleFlag;
+  int m_LightScintModelFlag;
 
-  double light_balance_inner_corr;
-  double light_balance_inner_radius;
-  double light_balance_outer_corr;
-  double light_balance_outer_radius;
+  double m_LightBalanceInnerCorr;
+  double m_LightBalanceInnerRadius;
+  double m_LightBalanceOuterCorr;
+  double m_LightBalanceOuterRadius;
 };
 
-#endif  // PHG4Prototype2OuterHcalSteppingAction_h
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
@@ -21,8 +21,8 @@ using namespace std;
 //_______________________________________________________________________
 PHG4Prototype2OuterHcalSubsystem::PHG4Prototype2OuterHcalSubsystem(const std::string &name, const int lyr)
   : PHG4DetectorSubsystem(name, lyr)
-  , detector_(nullptr)
-  , steppingAction_(nullptr)
+  , m_Detector(nullptr)
+  , m_SteppingAction(nullptr)
 {
   InitializeParameters();
 }
@@ -34,9 +34,9 @@ int PHG4Prototype2OuterHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  detector_ = new PHG4Prototype2OuterHcalDetector(topNode, GetParams(), Name());
-  detector_->SuperDetector(SuperDetector());
-  detector_->OverlapCheck(CheckOverlap());
+  m_Detector = new PHG4Prototype2OuterHcalDetector(topNode, GetParams(), Name());
+  m_Detector->SuperDetector(SuperDetector());
+  m_Detector->OverlapCheck(CheckOverlap());
   set<string> nodes;
   if (GetParams()->get_int_param("active"))
   {
@@ -82,14 +82,14 @@ int PHG4Prototype2OuterHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     }
 
     // create stepping action
-    steppingAction_ = new PHG4Prototype2OuterHcalSteppingAction(detector_, GetParams());
+    m_SteppingAction = new PHG4Prototype2OuterHcalSteppingAction(m_Detector, GetParams());
   }
   else
   {
     // if this is a black hole it does not have to be active
     if (GetParams()->get_int_param("blackhole"))
     {
-      steppingAction_ = new PHG4Prototype2OuterHcalSteppingAction(detector_, GetParams());
+      m_SteppingAction = new PHG4Prototype2OuterHcalSteppingAction(m_Detector, GetParams());
     }
   }
   return 0;
@@ -100,9 +100,9 @@ int PHG4Prototype2OuterHcalSubsystem::process_event(PHCompositeNode *topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
-  if (steppingAction_)
+  if (m_SteppingAction)
   {
-    steppingAction_->SetInterfacePointers(topNode);
+    m_SteppingAction->SetInterfacePointers(topNode);
   }
   return 0;
 }
@@ -111,9 +111,9 @@ void PHG4Prototype2OuterHcalSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
   GetParams()->Print();
-  if (detector_)
+  if (m_Detector)
   {
-    detector_->Print(what);
+    m_Detector->Print(what);
   }
   return;
 }
@@ -121,7 +121,7 @@ void PHG4Prototype2OuterHcalSubsystem::Print(const string &what) const
 //_______________________________________________________________________
 PHG4Detector *PHG4Prototype2OuterHcalSubsystem::GetDetector(void) const
 {
-  return detector_;
+  return m_Detector;
 }
 
 void PHG4Prototype2OuterHcalSubsystem::SetDefaultParameters()

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.h
@@ -1,10 +1,10 @@
-#ifndef PHG4Prototype2OuterHcalSubsystem_h
-#define PHG4Prototype2OuterHcalSubsystem_h
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4PROTOTYPE2OUTERHCALSUBSYSTEM_H
+#define G4DETECTORS_PHG4PROTOTYPE2OUTERHCALSUBSYSTEM_H
 
 #include "PHG4DetectorSubsystem.h"
 
-#include <map>
-#include <set>
 #include <string>
 
 class PHG4Prototype2OuterHcalDetector;
@@ -22,7 +22,7 @@ class PHG4Prototype2OuterHcalSubsystem : public PHG4DetectorSubsystem
   }
 
   /*!
-  creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
+  creates the m_Detector object and place it on the node tree, under "DETECTORS" node (or whatever)
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
@@ -40,19 +40,19 @@ class PHG4Prototype2OuterHcalSubsystem : public PHG4DetectorSubsystem
 
   //! accessors (reimplemented)
   virtual PHG4Detector* GetDetector(void) const;
-  virtual PHG4SteppingAction* GetSteppingAction(void) const { return steppingAction_; }
+  virtual PHG4SteppingAction* GetSteppingAction(void) const { return m_SteppingAction; }
   void SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr);
 
- protected:
+ private:
   void SetDefaultParameters();
 
   //! detector geometry
   /*! derives from PHG4Detector */
-  PHG4Prototype2OuterHcalDetector* detector_;
+  PHG4Prototype2OuterHcalDetector* m_Detector;
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingAction */
-  PHG4SteppingAction* steppingAction_;
+  PHG4SteppingAction* m_SteppingAction;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalDetector.cc
@@ -133,10 +133,10 @@ PHG4Prototype3InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelo
 
     m_VolumeSteel = steel_plate->GetCubicVolume() * m_NumSteelPlates;
     m_InnerHcalSteelPlate = new G4LogicalVolume(steel_plate, G4Material::GetMaterial(m_params->get_string_param("material")), steelplatename, 0, 0, 0);
-    G4VisAttributes *visattchk = new G4VisAttributes();
-    visattchk->SetVisibility(true);
-    visattchk->SetForceSolid(false);
-    visattchk->SetColour(G4Colour::Blue());
+    G4VisAttributes visattchk;
+    visattchk.SetVisibility(true);
+    visattchk.SetForceSolid(false);
+    visattchk.SetColour(G4Colour::Blue());
     m_InnerHcalSteelPlate->SetVisAttributes(visattchk);
   }
   return m_InnerHcalSteelPlate;
@@ -150,10 +150,10 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   //DisplayVolume(scintiboxsolid,hcalenvelope);
 
   G4LogicalVolume *scintiboxlogical = new G4LogicalVolume(scintiboxsolid, G4Material::GetMaterial("G4_AIR"), G4String(scintimothername), 0, 0, 0);
-  G4VisAttributes *hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Magenta());
+  G4VisAttributes hcalVisAtt;
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Magenta());
   G4LogicalVolume *scintit9_logic = ConstructScintiTile9(hcalenvelope);
   scintit9_logic->SetVisAttributes(hcalVisAtt);
   double distance_to_corner = -m_SteelZ / 2. + m_ScintiTile9DistanceToCorner;
@@ -162,10 +162,9 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   Rot->rotateX(90 * deg);
   new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit9_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Blue());
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Blue());
   G4LogicalVolume *scintit10_logic = ConstructScintiTile10(hcalenvelope);
   scintit10_logic->SetVisAttributes(hcalVisAtt);
 
@@ -175,10 +174,9 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   copynum++;
   new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit10_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Yellow());
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Yellow());
   G4LogicalVolume *scintit11_logic = ConstructScintiTile11(hcalenvelope);
   scintit11_logic->SetVisAttributes(hcalVisAtt);
 
@@ -188,10 +186,9 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   copynum++;
   new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit11_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
-  hcalVisAtt = new G4VisAttributes();
-  hcalVisAtt->SetVisibility(true);
-  hcalVisAtt->SetForceSolid(false);
-  hcalVisAtt->SetColour(G4Colour::Cyan());
+  hcalVisAtt.SetVisibility(true);
+  hcalVisAtt.SetForceSolid(false);
+  hcalVisAtt.SetColour(G4Colour::Cyan());
   G4LogicalVolume *scintit12_logic = ConstructScintiTile12(hcalenvelope);
   scintit12_logic->SetVisAttributes(hcalVisAtt);
 
@@ -299,13 +296,13 @@ void PHG4Prototype3InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
   G4ThreeVector g4vec(m_params->get_double_param("place_x") * cm,
                       m_params->get_double_param("place_y") * cm,
                       m_params->get_double_param("place_z") * cm);
-  G4RotationMatrix *Rot = new G4RotationMatrix();
-  Rot->rotateX(m_params->get_double_param("rot_x") * deg);
-  Rot->rotateY(m_params->get_double_param("rot_y") * deg);
-  Rot->rotateZ(m_params->get_double_param("rot_z") * deg);
+  G4RotationMatrix Rot;
+  Rot.rotateX(m_params->get_double_param("rot_x") * deg);
+  Rot.rotateY(m_params->get_double_param("rot_y") * deg);
+  Rot.rotateZ(m_params->get_double_param("rot_z") * deg);
   m_InnerHcalAssembly = new G4AssemblyVolume();
   ConstructInnerHcal(logicWorld);
-  m_InnerHcalAssembly->MakeImprint(logicWorld, g4vec, Rot, 0, OverlapCheck());
+  m_InnerHcalAssembly->MakeImprint(logicWorld, g4vec, &Rot, 0, OverlapCheck());
 // this is rather pathetic - there is no way to extract the name when a volume is added
 // to the assembly. The only thing we can do is get an iterator over the placed volumes
 // in the order in which they were placed. Since this code does not install the scintillators
@@ -376,20 +373,19 @@ int PHG4Prototype3InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume *hcalenv
   double xstart = 0;
   double xoff = 0.015 * cm;
   for (int i = 0; i < m_NumSteelPlates; i++)
-  //           for (int i = 0; i < 2; i++)
   {
-    G4RotationMatrix *Rot = new G4RotationMatrix();
-    Rot->rotateZ(phi * rad);
+    G4RotationMatrix Rot;
+    Rot.rotateZ(phi * rad);
     G4ThreeVector g4vec(xstart, 0, 0);
-    m_InnerHcalAssembly->AddPlacedVolume(steel_plate, g4vec, Rot);
+    m_InnerHcalAssembly->AddPlacedVolume(steel_plate, g4vec, &Rot);
     if (m_scintibox && i > 0)
     {
       double ypos = sin(phi + philow) * middlerad;
       double xpos = cos(phi + philow) * middlerad;
-      Rot = new G4RotationMatrix();
-      Rot->rotateZ(scintiangle + phislat);
+      G4RotationMatrix Rot1;
+      Rot1.rotateZ(scintiangle + phislat);
       G4ThreeVector g4vecsc(xpos + xstart, ypos, 0);
-      m_InnerHcalAssembly->AddPlacedVolume(m_scintibox, g4vecsc, Rot);
+      m_InnerHcalAssembly->AddPlacedVolume(m_scintibox, g4vecsc, &Rot1);
       phislat += m_DeltaPhi;
     }
     phi += m_DeltaPhi;

--- a/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalDetector.cc
@@ -21,6 +21,8 @@
 #include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4VisAttributes.hh>
 
+#include <boost/format.hpp>
+
 #include <cmath>
 #include <sstream>
 
@@ -143,6 +145,7 @@ PHG4Prototype3InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelo
 G4LogicalVolume *
 PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *hcalenvelope)
 {
+  int copynum = 0;
   G4VSolid *scintiboxsolid = new G4Box(scintimothername, m_ScintiX / 2., (m_ScintiGap) / 2., m_ScintiTileZ / 2.);
   //DisplayVolume(scintiboxsolid,hcalenvelope);
 
@@ -157,7 +160,7 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   G4RotationMatrix *Rot;
   Rot = new G4RotationMatrix();
   Rot->rotateX(90 * deg);
-  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit9_logic, "InnerScinti_9", scintiboxlogical, false, 0, OverlapCheck());
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit9_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -169,7 +172,8 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   distance_to_corner += m_ScintiTile9FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();
   Rot->rotateX(90 * deg);
-  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit10_logic, "InnerScinti_10", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit10_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -181,7 +185,8 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   distance_to_corner += m_ScintiTile10FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();
   Rot->rotateX(90 * deg);
-  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit11_logic, "InnerScinti_11", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit11_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
 
   hcalVisAtt = new G4VisAttributes();
   hcalVisAtt->SetVisibility(true);
@@ -193,7 +198,8 @@ PHG4Prototype3InnerHcalDetector::ConstructScintillatorBoxHiEta(G4LogicalVolume *
   distance_to_corner += m_ScintiTile11FrontSize + m_GapBetweenTiles;
   Rot = new G4RotationMatrix();
   Rot->rotateX(90 * deg);
-  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit12_logic, "InnerScinti_12", scintiboxlogical, false, 0, OverlapCheck());
+  copynum++;
+  new G4PVPlacement(Rot, G4ThreeVector(-m_ScintiX / 2., 0, distance_to_corner), scintit12_logic, (boost::format("InnerScinti_%d") % copynum).str(), scintiboxlogical, false, copynum, OverlapCheck());
   //    DisplayVolume(scintiboxlogical,hcalenvelope);
   return scintiboxlogical;
 }
@@ -304,8 +310,7 @@ void PHG4Prototype3InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
 // to the assembly. The only thing we can do is get an iterator over the placed volumes
 // in the order in which they were placed. Since this code does not install the scintillators
 // for the Al version, parsing the volume names to get the id does not work since it changes
-// So now we loop over all volumes and assign consecutive id's to their name by hand which
-// is then used to look those up in the stepping action where we only have the volume name
+// So now we loop over all volumes and store them in a map for fast lookup of the row
   int isteel = 0;
   int iscinti = 0;
   vector<G4VPhysicalVolume*>::iterator it = m_InnerHcalAssembly->GetVolumesIterator();
@@ -325,15 +330,15 @@ void PHG4Prototype3InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
     ++it;
   }
 // print out volume names and their assigned id
-  // map<string,int>::const_iterator iter;
-  // for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
-  // {
-  //   cout << iter->first << ", " << iter->second << endl;
-  // }
-  // for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
-  // {
-  //   cout << iter->first << ", " << iter->second << endl;
-  // }
+   // map<string,int>::const_iterator iter;
+   // for (iter = m_SteelPlateIdMap.begin(); iter != m_SteelPlateIdMap.end(); ++iter)
+   // {
+   //   cout << iter->first << ", " << iter->second << endl;
+   // }
+   // for (iter = m_ScintillatorIdMap.begin(); iter != m_ScintillatorIdMap.end(); ++iter)
+   // {
+   //   cout << iter->first << ", " << iter->second << endl;
+   // }
   return;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalDetector.h
@@ -2,6 +2,7 @@
 // This file is really -*- C++ -*-.
 #ifndef G4DETECTORS_PHG4PROTOTYPE3INNERHCALDETECTOR_H
 #define G4DETECTORS_PHG4PROTOTYPE3INNERHCALDETECTOR_H
+
 #include <g4main/PHG4Detector.h>
 
 #include <Geant4/G4RotationMatrix.hh>


### PR DESCRIPTION
The numbering in terms of rows/columns of the scintillators in the hcals is inconsistent. This pull request (which is still being worked on - so do not merge) makes the numbers consistent between inner and outer hcal for the 3rd testbeam (2nd testbeam inner hcal still needs to be looked at). The rows are unchanged, the columns go from 0-3.
Sadly this is not just a number change, while the scintillators stay the same (except their column number), the resulting towers and their energies are very different. Maybe its the lookup of calibration constants which his probably keyed to the row/column numbers