### PR TITLE
Add jetscape examples

### DIFF
--- a/generators/JETSCAPE/FinalStateHadrons.cc
+++ b/generators/JETSCAPE/FinalStateHadrons.cc
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include <chrono>
+#include <thread>
+
+#include "gzstream.h"
+#include "PartonShower.h"
+#include "JetScapeLogger.h"
+#include "JetScapeReader.h"
+#include "JetScapeBanner.h"
+#include "fjcore.hh"
+
+#include <GTL/dfs.h>
+
+using namespace std;
+using namespace fjcore;
+
+using namespace Jetscape;
+
+// You could overload here and then simply use ofstream << p;
+// ostream & operator<<(ostream & ostr, const fjcore::PseudoJet & jet);
+
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+
+  // JetScapeLogger::Instance()->SetInfo(false);
+  JetScapeLogger::Instance()->SetDebug(false);
+  JetScapeLogger::Instance()->SetRemark(false);
+  // //SetVerboseLevel (9 a lot of additional debug output ...)
+  // //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevel(9) or 10
+  JetScapeLogger::Instance()->SetVerboseLevel(0);
+  
+  auto reader=make_shared<JetScapeReaderAscii>("test_out.dat");
+  std::ofstream dist_output ("JetscapeFinalStateHadrons.txt"); //Format is SN, PID, E, Px, Py, Pz, Eta, Phi
+  vector<shared_ptr<Hadron>> hadrons;
+  while (!reader->Finished())
+    {
+      reader->Next();
+      
+      // cout<<"Analyze current event: "<<reader->GetCurrentEvent()<<endl;
+
+      //dist_output<<"Event "<< reader->GetCurrentEvent()+1<<endl;
+      hadrons = reader->GetHadrons();
+      cout<<"Number of hadrons is: " << hadrons.size() << endl;
+      for(unsigned int i=0; i<hadrons.size(); i++)
+	{
+	  dist_output<<i<<" "<<hadrons[i].get()->pid()<<" "<<hadrons[i].get()->pstat()<<" "<< hadrons[i].get()->e() << " "<< hadrons[i].get()->px()<< " "<< hadrons[i].get()->py() << " "<< hadrons[i].get()->pz()<<  endl;
+        }
+    }
+  
+  reader->Close();
+  
+}

--- a/generators/JETSCAPE/FinalStatePartons.cc
+++ b/generators/JETSCAPE/FinalStatePartons.cc
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include <chrono>
+#include <thread>
+
+#include "gzstream.h"
+#include "PartonShower.h"
+#include "JetScapeLogger.h"
+#include "JetScapeReader.h"
+#include "JetScapeBanner.h"
+#include "fjcore.hh"
+
+#include <GTL/dfs.h>
+
+using namespace std;
+using namespace fjcore;
+
+using namespace Jetscape;
+
+// You could overload here and then simply use ofstream << p;
+// ostream & operator<<(ostream & ostr, const fjcore::PseudoJet & jet);
+
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+
+  // JetScapeLogger::Instance()->SetInfo(false);
+  JetScapeLogger::Instance()->SetDebug(false);
+  JetScapeLogger::Instance()->SetRemark(false);
+  // //SetVerboseLevel (9 a lot of additional debug output ...)
+  // //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevel(9) or 10
+  JetScapeLogger::Instance()->SetVerboseLevel(0);
+  
+  auto reader=make_shared<JetScapeReaderAscii>("test_out.dat");
+  std::ofstream dist_output ("JetscapeFinalStatePartons.txt"); //Format is SN, PID, E, Px, Py, Pz, Eta, Phi
+  
+  while (!reader->Finished())
+    {
+      reader->Next();
+      
+      // cout<<"Analyze current event: "<<reader->GetCurrentEvent()<<endl;
+      auto mShowers=reader->GetPartonShowers();     
+
+      dist_output<<"Event "<< reader->GetCurrentEvent()+1<<endl;
+      for (int i=0;i<mShowers.size();i++)
+	{
+	  //  cout<<" Analyze parton shower: "<<i<<endl;
+	  // Let's create a file
+	  for ( int ipart = 0; ipart< mShowers[i]->GetFinalPartons().size(); ++ipart){
+	    Parton p = *mShowers[i]->GetFinalPartons().at(ipart);
+	    dist_output << ipart   << "\t"
+			<< p.pid() << "\t"
+			<< p.pstat() << "\t"
+			<< p.e()   << "\t"
+			<< p.px()  << "\t" 
+			<< p.py()  << "\t" 
+			<< p.pz()  << "\t"
+			<< p.eta()<<  "\t"<< p.phi() << endl;
+	  }
+	}
+
+    }
+  
+  reader->Close(); 
+}

--- a/generators/JETSCAPE/LBT_brickTest.cc
+++ b/generators/JETSCAPE/LBT_brickTest.cc
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+// ------------------------------------------------------------
+// JetScape Framework Brick Test Program
+// (use either shared library (need to add paths; see setup.csh)
+// (or create static library and link in)
+// -------------------------------------------------------------
+
+#include <iostream>
+#include <time.h>
+
+// JetScape Framework includes ...
+#include "JetScape.h"
+#include "JetEnergyLoss.h"
+#include "JetEnergyLossManager.h"
+#include "JetScapeWriterStream.h"
+#ifdef USE_HEPMC
+#include "JetScapeWriterHepMC.h"
+#endif
+
+// User modules derived from jetscape framework clasess
+#include "TrentoInitial.h"
+#include "AdSCFT.h"
+#include "Matter.h"
+#include "LBT.h"
+#include "Martini.h"
+#include "Brick.h"
+#include "GubserHydro.h"
+#include "PGun.h"
+#include "PartonPrinter.h"
+#include "HadronizationManager.h"
+#include "Hadronization.h"
+#include "ColoredHadronization.h"
+#include "ColorlessHadronization.h"
+
+#include <chrono>
+#include <thread>
+
+using namespace std;
+
+using namespace Jetscape;
+
+// Forward declaration
+void Show();
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+  clock_t t; t = clock();
+  time_t start, end; time(&start);
+  
+  cout<<endl;
+    
+  // DEBUG=true by default and REMARK=false
+  // can be also set also via XML file (at least partially)
+  JetScapeLogger::Instance()->SetDebug(false);
+  JetScapeLogger::Instance()->SetRemark(false);
+  //SetVerboseLevel (9 a lot of additional debug output ...)
+  //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevle(9) or 10
+  JetScapeLogger::Instance()->SetVerboseLevel(8);
+   
+  Show();
+
+  auto jetscape = make_shared<JetScape>("./jetscape_init.xml",3);
+  jetscape->SetId("primary");
+
+  // Initial conditions and hydro
+  auto trento = make_shared<TrentoInitial>();
+  auto pGun= make_shared<PGun> ();
+  auto hydro = make_shared<Brick> ();
+  jetscape->Add(trento);
+  jetscape->Add(pGun);
+  jetscape->Add(hydro);
+
+  // Energy loss
+  auto jlossmanager = make_shared<JetEnergyLossManager> ();
+  auto jloss = make_shared<JetEnergyLoss> ();
+  auto lbt = make_shared<LBT> ();
+  jloss->Add(lbt);
+  jlossmanager->Add(jloss);  
+  jetscape->Add(jlossmanager);
+
+  // Hadronization
+  // This helper module currently needs to be added for hadronization.
+  auto printer = make_shared<PartonPrinter> ();
+  jetscape->Add(printer);
+  auto hadroMgr = make_shared<HadronizationManager> ();
+  auto hadro = make_shared<Hadronization> ();
+  auto hadroModule = make_shared<ColoredHadronization> ();
+  hadro->Add(hadroModule);
+  // auto colorless = make_shared<ColorlessHadronization> ();
+  // hadro->Add(colorless);
+  hadroMgr->Add(hadro);
+  jetscape->Add(hadroMgr);
+
+  // Output
+  auto writer= make_shared<JetScapeWriterAscii> ("test_out.dat");
+  // same as JetScapeWriterAscii but gzipped
+  // auto writer= make_shared<JetScapeWriterAsciiGZ> ("test_out.dat.gz");
+  // HEPMC3
+#ifdef USE_HEPMC
+  // auto writer= make_shared<JetScapeWriterHepMC> ("test_out.hepmc");
+#endif
+  jetscape->Add(writer);
+
+  
+  // Intialize all modules tasks
+  jetscape->Init();
+
+  // Run JetScape with all task/modules as specified ...
+  jetscape->Exec();
+
+  // "dummy" so far ...
+  // Most thinkgs done in write and clear ...
+  jetscape->Finish();
+  
+  INFO_NICE<<"Finished!";
+  cout<<endl;
+
+  // wait for 5s
+  //std::this_thread::sleep_for(std::chrono::milliseconds(500000));
+
+  t = clock() - t;
+  time(&end);
+  printf ("CPU time: %f seconds.\n",((float)t)/CLOCKS_PER_SEC);
+  printf ("Real time: %f seconds.\n",difftime(end,start));
+  //printf ("Real time: %f seconds.\n",(start-end));
+  return 0;
+}
+
+// -------------------------------------
+
+void Show()
+{
+  INFO_NICE<<"------------------------------------";
+  INFO_NICE<<"| Brick Test JetScape Framework ... |";
+  INFO_NICE<<"------------------------------------";
+  INFO_NICE;
+}

--- a/generators/JETSCAPE/MUSICTest.cc
+++ b/generators/JETSCAPE/MUSICTest.cc
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+// ------------------------------------------------------------
+// JetScape Framework hydro from file Test Program
+// (use either shared library (need to add paths; see setup.csh)
+// (or create static library and link in)
+// -------------------------------------------------------------
+
+#include <iostream>
+#include <time.h>
+
+// JetScape Framework includes ...
+#include "JetScape.h"
+#include "JetEnergyLoss.h"
+#include "JetEnergyLossManager.h"
+#include "JetScapeWriterStream.h"
+#ifdef USE_HEPMC
+#include "JetScapeWriterHepMC.h"
+#endif
+
+// User modules derived from jetscape framework clasess
+#include "AdSCFT.h"
+#include "Matter.h"
+#include "Martini.h"
+#include "MusicWrapper.h"
+#include "iSpectraSamplerWrapper.h"
+#include "TrentoInitial.h"
+#include "PGun.h"
+#include "PartonPrinter.h"
+#include "HadronizationManager.h"
+#include "Hadronization.h"
+#include "ColoredHadronization.h"
+
+#include <chrono>
+#include <thread>
+
+using namespace std;
+
+using namespace Jetscape;
+
+// Forward declaration
+void Show();
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+  clock_t t; t = clock();
+  time_t start, end; time(&start);
+  
+  cout<<endl;
+    
+  // DEBUG=true by default and REMARK=false
+  // can be also set also via XML file (at least partially)
+  JetScapeLogger::Instance()->SetInfo(true);
+  JetScapeLogger::Instance()->SetDebug(true);
+  JetScapeLogger::Instance()->SetRemark(false);
+  //SetVerboseLevel (9 a lot of additional debug output ...)
+  //If you want to suppress it: use SetVerboseLevel(0) or max  SetVerboseLevel(9) or 10
+  JetScapeLogger::Instance()->SetVerboseLevel(8);
+   
+  Show();
+
+  // auto jetscape = make_shared<JetScape>("./jetscape_init.xml",10);
+  // jetscape->SetReuseHydro (true);
+  // jetscape->SetNReuseHydro (5);
+
+  auto jetscape = make_shared<JetScape>("./jetscape_init.xml",1);
+  jetscape->SetReuseHydro (false);
+  jetscape->SetNReuseHydro (0);
+
+  // Initial conditions and hydro
+  auto trento = make_shared<TrentoInitial>();
+  auto pGun= make_shared<PGun> ();
+  auto hydro = make_shared<MpiMusic> ();
+  jetscape->Add(trento);
+  jetscape->Add(pGun);
+  jetscape->Add(hydro);
+
+  // surface sampler
+  auto iSS = make_shared<iSpectraSamplerWrapper> ();
+  jetscape->Add(iSS);
+
+  // Energy loss
+  auto jlossmanager = make_shared<JetEnergyLossManager> ();
+  auto jloss = make_shared<JetEnergyLoss> ();
+
+  auto matter = make_shared<Matter> ();
+  // auto lbt = make_shared<LBT> ();
+  // auto martini = make_shared<Martini> ();
+  // auto adscft = make_shared<AdSCFT> ();
+
+  // Note: if you use Matter, it MUST come first (to set virtuality)
+  jloss->Add(matter);
+  // jloss->Add(lbt);  // go to 3rd party and ./get_lbtTab before adding this module
+  // jloss->Add(martini);
+  // jloss->Add(adscft);  
+  jlossmanager->Add(jloss);  
+  jetscape->Add(jlossmanager);
+  
+  // Hadronization
+  // This helper module currently needs to be added for hadronization.
+  auto printer = make_shared<PartonPrinter> ();
+  jetscape->Add(printer);
+  auto hadroMgr = make_shared<HadronizationManager> ();
+  auto hadro = make_shared<Hadronization> ();
+  auto hadroModule = make_shared<ColoredHadronization> ();
+  hadro->Add(hadroModule);
+  // auto colorless = make_shared<ColorlessHadronization> ();
+  // hadro->Add(colorless);
+  hadroMgr->Add(hadro);
+  jetscape->Add(hadroMgr);
+
+  // Output
+  auto writer= make_shared<JetScapeWriterAscii> ("test_out.dat");
+  // same as JetScapeWriterAscii but gzipped
+  // auto writer= make_shared<JetScapeWriterAsciiGZ> ("test_out.dat.gz");
+  // HEPMC3
+#ifdef USE_HEPMC
+  // auto writer= make_shared<JetScapeWriterHepMC> ("test_out.hepmc");
+#endif
+  jetscape->Add(writer);
+
+  // Intialize all modules tasks
+  jetscape->Init();
+
+  // Run JetScape with all task/modules as specified ...
+  jetscape->Exec();
+
+  // "dummy" so far ...
+  // Most thinkgs done in write and clear ...
+  jetscape->Finish();
+  
+  INFO_NICE<<"Finished!";
+  cout<<endl;
+
+  // wait for 5s
+  //std::this_thread::sleep_for(std::chrono::milliseconds(500000));
+
+  t = clock() - t;
+  time(&end);
+  printf ("CPU time: %f seconds.\n",((float)t)/CLOCKS_PER_SEC);
+  printf ("Real time: %f seconds.\n",difftime(end,start));
+  //printf ("Real time: %f seconds.\n",(start-end));
+  return 0;
+}
+
+// -------------------------------------
+
+void Show()
+{
+  INFO_NICE<<"-----------------------------------------------";
+  INFO_NICE<<"| MUSIC Test JetScape Framework ... |";
+  INFO_NICE<<"-----------------------------------------------";
+  INFO_NICE;
+}

--- a/generators/JETSCAPE/Makefile.am
+++ b/generators/JETSCAPE/Makefile.am
@@ -1,0 +1,60 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -I$(OPT_SPHENIX)/JETSCAPE-1.0/include \
+  -I/usr/include/openmpi-x86_64
+
+#AM_CXXFLAGS = -Werror -Wno-unused-variable
+
+bin_PROGRAMS = \
+  brickTest \
+  FinalStateHadrons \
+  FinalStatePartons \
+  LBT_brickTest \
+  MUSICTest \
+  PythiaBrickTest \
+  SimpleValidate \
+  readerTest \
+  testJetScape
+
+#  hydroFileTest 
+#  hydroJetTest 
+#  hydroJetTestPGun 
+#  freestream-milneTest 
+
+brickTest_SOURCES = brickTest.cc
+FinalStateHadrons_SOURCES = FinalStateHadrons.cc
+FinalStatePartons_SOURCES = FinalStatePartons.cc	
+LBT_brickTest_SOURCES = LBT_brickTest.cc
+MUSICTest_SOURCES = MUSICTest.cc
+PythiaBrickTest_SOURCES = PythiaBrickTest.cc
+SimpleValidate_SOURCES = SimpleValidate.cc
+freestream_milneTest_SOURCES = freestream-milneTest.cc
+hydroFileTest_SOURCES = hydroFileTest.cc
+hydroJetTest_SOURCES = hydroJetTest.cc
+hydroJetTestPGun_SOURCES = hydroJetTestPGun.cc
+readerTest_SOURCES = readerTest.cc
+testJetScape_SOURCES =	testJetScape.cc
+
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(OPT_SPHENIX)/hdf5-1.10.2/lib \
+  -L$(OPT_SPHENIX)/JETSCAPE-1.0/lib \
+  -L/usr/lib64/openmpi/lib \
+  -lboost_system \
+  -lGTL \
+  -lhdf5 \
+  $(OPT_SPHENIX)/HepMC-3.0.0/lib/libHepMC.so \
+  -lhydroFromFile \
+  -liSS_lib \
+  -lJetScape \
+  -lJetScapeThird \
+  -lmpi \
+  -lmpi_cxx \
+  -lmusic_lib \
+  -lpythia8
+

--- a/generators/JETSCAPE/PythiaBrickTest.cc
+++ b/generators/JETSCAPE/PythiaBrickTest.cc
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+// ------------------------------------------------------------
+// JetScape Framework Brick Test Program with Pythia IS
+// (use either shared library (need to add paths; see setup.csh)
+// (or create static library and link in)
+// -------------------------------------------------------------
+
+#include <iostream>
+#include <time.h>
+
+// JetScape Framework includes ...
+#include "JetScape.h"
+#include "JetEnergyLoss.h"
+#include "JetEnergyLossManager.h"
+#include "JetScapeWriterStream.h"
+#ifdef USE_HEPMC
+#include "JetScapeWriterHepMC.h"
+#endif
+
+
+// User modules derived from jetscape framework clasess
+#include "TrentoInitial.h"
+#include "AdSCFT.h"
+#include "Matter.h"
+#include "LBT.h"
+#include "Martini.h"
+#include "Brick.h"
+#include "GubserHydro.h"
+#include "PythiaGun.h"
+#include "PartonPrinter.h"
+#include "HadronizationManager.h"
+#include "Hadronization.h"
+#include "ColoredHadronization.h"
+#include "ColorlessHadronization.h"
+
+#include <chrono>
+#include <thread>
+
+using namespace std;
+
+using namespace Jetscape;
+
+// Forward declaration
+void Show();
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+  clock_t t; t = clock();
+  time_t start, end; time(&start);
+
+  cout<<endl;
+    
+  // DEBUG=true by default and REMARK=false
+  // can be also set also via XML file (at least partially)
+  JetScapeLogger::Instance()->SetInfo(true);
+  JetScapeLogger::Instance()->SetDebug(false);
+  JetScapeLogger::Instance()->SetRemark(false);
+  //SetVerboseLevel (9 a lot of additional debug output ...)
+  //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevle(9) or 10
+  JetScapeLogger::Instance()->SetVerboseLevel(0);
+
+  
+  Show();
+
+  auto jetscape = make_shared<JetScape>("./jetscape_init.xml",200);
+  jetscape->SetId("primary");
+
+  // Initial conditions and hydro
+  auto trento = make_shared<TrentoInitial>();
+  auto pythiaGun= make_shared<PythiaGun> ();
+  auto hydro = make_shared<Brick> ();
+  jetscape->Add(trento);
+  jetscape->Add(pythiaGun);
+  jetscape->Add(hydro);
+
+
+  // Energy loss
+  auto jlossmanager = make_shared<JetEnergyLossManager> ();
+  auto jloss = make_shared<JetEnergyLoss> ();
+
+  auto matter = make_shared<Matter> ();
+  // auto lbt = make_shared<LBT> ();
+  // auto martini = make_shared<Martini> ();
+  // auto adscft = make_shared<AdSCFT> ();
+
+  // Note: if you use Matter, it MUST come first (to set virtuality)
+  jloss->Add(matter);
+  // jloss->Add(lbt);  // go to 3rd party and ./get_lbtTab before adding this module
+  // jloss->Add(martini);
+  // jloss->Add(adscft);  
+  jlossmanager->Add(jloss);  
+  jetscape->Add(jlossmanager);
+
+  
+  // Hadronization
+  // This helper module currently needs to be added for hadronization.
+  auto printer = make_shared<PartonPrinter> ();
+  jetscape->Add(printer);
+  auto hadroMgr = make_shared<HadronizationManager> ();
+  auto hadro = make_shared<Hadronization> ();
+  auto hadroModule = make_shared<ColoredHadronization> ();
+  hadro->Add(hadroModule);
+  // auto colorless = make_shared<ColorlessHadronization> ();
+  // hadro->Add(colorless);
+  hadroMgr->Add(hadro);
+  jetscape->Add(hadroMgr);
+
+  
+  // Output
+  auto writer= make_shared<JetScapeWriterAscii> ("test_out.dat");
+  jetscape->Add(writer);
+#ifdef USE_GZIP
+  // same as JetScapeWriterAscii but gzipped
+  auto writergz= make_shared<JetScapeWriterAsciiGZ> ("test_out.dat.gz");
+  jetscape->Add(writergz);
+#endif
+  // HEPMC3
+#ifdef USE_HEPMC
+  auto hepmcwriter= make_shared<JetScapeWriterHepMC> ("test_out.hepmc");
+  jetscape->Add(hepmcwriter);
+#endif
+
+  // Intialize all modules tasks
+  jetscape->Init();
+
+  // Run JetScape with all task/modules as specified
+  jetscape->Exec();
+
+  // For the future, cleanup is mostly already done in write and clear
+  jetscape->Finish();
+  
+  INFO_NICE<<"Finished!";
+  cout<<endl;
+
+  t = clock() - t;
+  time(&end);
+  printf ("CPU time: %f seconds.\n",((float)t)/CLOCKS_PER_SEC);
+  printf ("Real time: %f seconds.\n",difftime(end,start));
+
+  // Print pythia statistics
+  // pythiaGun->stat();
+
+  // // Demonstrate how to work with pythia statistics
+  // //Pythia8::Info& info = pythiaGun->info;
+  // cout << " nTried    = " << info.nTried() << endl;
+  // cout << " nSelected = " << info.nSelected()  << endl;
+  // cout << " nAccepted = " << info.nAccepted()  << endl;
+  // cout << " sigmaGen  = " <<   info.sigmaGen()  << endl;  
+  // cout << " sigmaErr  = " <<   info.sigmaErr()  << endl;
+   
+  return 0;
+}
+
+// -------------------------------------
+
+void Show()
+{
+  INFO_NICE<<"------------------------------------";
+  INFO_NICE<<"| Brick Test JetScape Framework ... |";
+  INFO_NICE<<"------------------------------------";
+  INFO_NICE;
+}

--- a/generators/JETSCAPE/SimpleValidate.cc
+++ b/generators/JETSCAPE/SimpleValidate.cc
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+
+
+#include <iostream>
+#include <time.h>
+
+// Add includes here to test if it breaks anything
+#include "JetScape.h"
+#include "JetEnergyLoss.h"
+#include "JetEnergyLossManager.h"
+#include "JetScapeWriterStream.h"
+#ifdef USE_HEPMC
+#include "JetScapeWriterHepMC.h"
+#endif
+
+#include "Brick.h"
+#include "PGun.h"
+#include "ElossValidation.h"
+#include "PartonPrinter.h"
+#include "HadronizationManager.h"
+#include "Hadronization.h"
+#include "ColoredHadronization.h"
+
+#include <chrono>
+
+using namespace Jetscape;
+
+// Forward declaration
+void Show();
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+  clock_t t; t = clock();
+  time_t start, end; time(&start);
+  
+  JetScapeLogger::Instance()->SetInfo(true);
+  JetScapeLogger::Instance()->SetDebug(false);
+  JetScapeLogger::Instance()->SetRemark(false);
+  JetScapeLogger::Instance()->SetVerboseLevel(0);
+   
+  Show();
+
+  // Main framework task
+  auto jetscape = make_shared<JetScape>("../examples/simplevalidate.xml",1);
+  jetscape->SetId("primary");
+
+  // Empty initial state
+  auto ini = make_shared<InitialState>();
+  ini->SetId("InitialState");
+
+  // mono-energetic particle gun, fixed parameters in XML file
+  auto pGun= make_shared<PGun> ();
+
+  // Simple brick, parameters in XML file
+  auto hydro = make_shared<Brick> ();
+
+  // Energy loss manager, parameters in XML file
+  auto jlossmanager = make_shared<JetEnergyLossManager> ();
+
+  // Energy loss wrapper
+  auto jloss = make_shared<JetEnergyLoss> ();
+  
+  // Energy loss module, can also add multiple ones.
+  // Parameters in XML file
+  // auto eloss1 = make_shared<ValidationEloss> ();
+  auto eloss1 = make_shared<ElossValidate> ();
+  
+  // Pure Ascii writer
+  auto writer= make_shared<JetScapeWriterAscii> ("validate_out.dat");
+ 
+  //Remark: For now modules have to be added in proper "workflow" order
+  jetscape->Add(ini);
+  jetscape->Add(pGun);
+  jetscape->Add(hydro);
+
+  // add module to the eloss wrapper, than the eloss wrapper to the manager
+  jloss->Add(eloss1);
+  jlossmanager->Add(jloss);  
+  jetscape->Add(jlossmanager);
+
+  // TODO: Should add hadronizer here
+
+  // Add the writer
+  jetscape->Add(writer);
+
+  // Intialize all modules tasks
+  jetscape->Init();
+
+  // Run JetScape with all task/modules as specified ...
+  jetscape->Exec();
+
+  jetscape->Finish();
+  
+  INFO_NICE<<"Finished!";
+  cout<<endl;
+
+  t = clock() - t;
+  time(&end);
+  printf ("CPU time: %f seconds.\n",((float)t)/CLOCKS_PER_SEC);
+  printf ("Real time: %f seconds.\n",difftime(end,start));
+  
+  return 0;
+}
+
+// -------------------------------------
+
+void Show()
+{
+  INFO_NICE<<"--------------------------------------";
+  INFO_NICE<<"| Validation Test JetScape Framework |";
+  INFO_NICE<<"--------------------------------------";
+  INFO_NICE;
+}

--- a/generators/JETSCAPE/autogen.sh
+++ b/generators/JETSCAPE/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"
+

--- a/generators/JETSCAPE/brickTest.cc
+++ b/generators/JETSCAPE/brickTest.cc
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+// ------------------------------------------------------------
+// JetScape Framework Brick Test Program
+// (use either shared library (need to add paths; see setup.csh)
+// (or create static library and link in)
+// -------------------------------------------------------------
+
+#include <iostream>
+#include <time.h>
+
+// JetScape Framework includes ...
+#include "JetScape.h"
+#include "JetEnergyLoss.h"
+#include "JetEnergyLossManager.h"
+#include "JetScapeWriterStream.h"
+#ifdef USE_HEPMC
+#include "JetScapeWriterHepMC.h"
+#endif
+
+// User modules derived from jetscape framework clasess
+#include "TrentoInitial.h"
+#include "AdSCFT.h"
+#include "Matter.h"
+#include "LBT.h"
+#include "Martini.h"
+#include "Brick.h"
+#include "GubserHydro.h"
+#include "PGun.h"
+#include "PartonPrinter.h"
+#include "HadronizationManager.h"
+#include "Hadronization.h"
+#include "ColoredHadronization.h"
+#include "ColorlessHadronization.h"
+
+#include <chrono>
+#include <thread>
+
+using namespace Jetscape;
+
+// Forward declaration
+void Show();
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+  clock_t t; t = clock();
+  time_t start, end; time(&start);
+  
+  cout<<endl;
+    
+  // DEBUG=true by default and REMARK=false
+  // can be also set also via XML file (at least partially)
+  JetScapeLogger::Instance()->SetInfo(true);
+  JetScapeLogger::Instance()->SetDebug(false);
+  JetScapeLogger::Instance()->SetRemark(false);
+  //SetVerboseLevel (9 adds a lot of additional debug output)
+  //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevle(9) or 10
+  JetScapeLogger::Instance()->SetVerboseLevel(0);
+   
+  Show();
+
+  auto jetscape = make_shared<JetScape>("./jetscape_init.xml",200);
+  jetscape->SetId("primary");
+  
+  // Initial conditions and hydro
+  auto trento = make_shared<TrentoInitial>();
+  auto pGun= make_shared<PGun> ();
+  auto hydro = make_shared<Brick> ();
+  jetscape->Add(trento);
+  jetscape->Add(pGun);
+  jetscape->Add(hydro);
+
+  // Energy loss
+  auto jlossmanager = make_shared<JetEnergyLossManager> ();
+  auto jloss = make_shared<JetEnergyLoss> ();
+
+  auto matter = make_shared<Matter> ();
+  // auto lbt = make_shared<LBT> ();
+  // auto martini = make_shared<Martini> ();
+  // auto adscft = make_shared<AdSCFT> ();
+
+  // Note: if you use Matter, it MUST come first (to set virtuality)
+  jloss->Add(matter);
+  // jloss->Add(lbt);  // go to 3rd party and ./get_lbtTab before adding this module
+  // jloss->Add(martini);
+  // jloss->Add(adscft);  
+  jlossmanager->Add(jloss);  
+  jetscape->Add(jlossmanager);
+
+  
+  // Hadronization
+  // This helper module currently needs to be added for hadronization.
+  auto printer = make_shared<PartonPrinter> ();
+  jetscape->Add(printer);
+  auto hadroMgr = make_shared<HadronizationManager> ();
+  auto hadro = make_shared<Hadronization> ();
+  auto hadroModule = make_shared<ColoredHadronization> ();
+  hadro->Add(hadroModule);
+  // auto colorless = make_shared<ColorlessHadronization> ();
+  // hadro->Add(colorless);
+  hadroMgr->Add(hadro);
+  jetscape->Add(hadroMgr);
+
+  // Output
+  auto writer= make_shared<JetScapeWriterAscii> ("test_out.dat");
+  // same as JetScapeWriterAscii but gzipped
+  // auto writer= make_shared<JetScapeWriterAsciiGZ> ("test_out.dat.gz");
+  // HEPMC3
+#ifdef USE_HEPMC
+  // auto writer= make_shared<JetScapeWriterHepMC> ("test_out.hepmc");
+#endif
+  jetscape->Add(writer);
+
+  // Intialize all modules tasks
+  jetscape->Init();
+
+  // Run JetScape with all task/modules as specified
+  jetscape->Exec();
+
+  // For the future, cleanup is mostly already done in write and clear
+  jetscape->Finish();
+  
+  INFO_NICE<<"Finished!";
+  cout<<endl;
+
+  t = clock() - t;
+  time(&end);
+  printf ("CPU time: %f seconds.\n",((float)t)/CLOCKS_PER_SEC);
+  printf ("Real time: %f seconds.\n",difftime(end,start));
+  return 0;
+}
+
+// -------------------------------------
+
+void Show()
+{
+  INFO_NICE<<"------------------------------------";
+  INFO_NICE<<"| Brick Test JetScape Framework ... |";
+  INFO_NICE<<"------------------------------------";
+  INFO_NICE;
+}

--- a/generators/JETSCAPE/configure.ac
+++ b/generators/JETSCAPE/configure.ac
@@ -1,0 +1,16 @@
+AC_INIT(JETSCAPE-examples,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+AM_INIT_AUTOMAKE
+
+AC_PROG_CXX(CC g++)
+LT_INIT([disable-static])
+
+dnl   no point in suppressing warnings people should
+dnl   at least see them, so here we go for g++: -Wall
+dnl   make warnings fatal errors: -Werror
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall"
+fi
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/generators/JETSCAPE/freestream-milneTest.cc
+++ b/generators/JETSCAPE/freestream-milneTest.cc
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+
+#include <iostream>
+#include <time.h>
+
+// JetScape Framework includes ...
+#include "JetScape.h"
+#include "JetEnergyLoss.h"
+#include "JetEnergyLossManager.h"
+#include "JetScapeWriterStream.h"
+#ifdef USE_HEPMC
+#include "JetScapeWriterHepMC.h"
+#endif
+
+//User modules derived from jetscape framework clasess
+//to be used to run Jetscape ...
+#include "AdSCFT.h"
+#include "Matter.h"
+#include "Martini.h"
+#include "FreestreamMilneWrapper.h"
+#include "MusicWrapper.h"
+#include "TrentoInitial.h"
+#include "PGun.h"
+#include "PythiaGun.h"
+#include "PartonPrinter.h"
+//#include "HadronizationManager.h"
+//#include "Hadronization.h"
+//#include "ColoredHadronization.h"
+
+#include <chrono>
+#include <thread>
+
+using namespace std;
+
+using namespace Jetscape;
+
+// Forward declaration
+void Show();
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+  clock_t t; t = clock();
+  time_t start, end; time(&start);
+
+  cout<<endl;
+
+  //DEBUG=true by default and REMARK=false
+  //can be also set also via XML file (at least partially)
+  JetScapeLogger::Instance()->SetInfo(true);
+  JetScapeLogger::Instance()->SetDebug(true);
+  JetScapeLogger::Instance()->SetRemark(false);
+  //SetVerboseLevel (9 a lot of additional debug output ...)
+  //If you want to suppress it: use SetVerboseLevel(0) or max  SetVerboseLevel(9) or 10
+  JetScapeLogger::Instance()->SetVerboseLevel(0);
+
+  Show();
+
+  //auto jetscape = make_shared<JetScape>("./jetscape_init.xml",10);
+  //jetscape->SetReuseHydro (true);
+  //jetscape->SetNReuseHydro (5);
+
+  auto jetscape = make_shared<JetScape>("./jetscape_init.xml",1);
+  jetscape->SetReuseHydro (false);
+  jetscape->SetNReuseHydro (0);
+
+  auto jlossmanager = make_shared<JetEnergyLossManager> ();
+  auto jloss = make_shared<JetEnergyLoss> ();
+  auto trento = make_shared<TrentoInitial> ();
+  auto freestream = make_shared<FreestreamMilneWrapper> ();
+  auto hydro = make_shared<MpiMusic> ();
+  //auto hydro = make_shared<GubserHydro> ();
+
+  auto matter = make_shared<Matter> ();
+  auto martini = make_shared<Martini> ();
+  auto adscft = make_shared<AdSCFT> ();
+  //DBEUG: Remark:
+  //does not matter unfortunately since not called recursively, done by JetEnergyLoss class ...
+  //matter->SetActive(false);
+  //martini->SetActive(false);
+  // This works ... (check with above logic ...)
+  //jloss->SetActive(false);
+
+  // auto pGun= make_shared<PGun> ();
+  auto pythiaGun= make_shared<PythiaGun> ();
+
+  auto printer = make_shared<PartonPrinter> ();
+
+  //auto hadroMgr = make_shared<HadronizationManager> ();
+  //auto hadro = make_shared<Hadronization> ();
+  //auto hadroModule = make_shared<ColoredHadronization> ();
+
+  // only pure Ascii writer implemented and working with graph output ...
+  auto writer= make_shared<JetScapeWriterAscii> ("test_out.dat");
+  //auto writer= make_shared<JetScapeWriterAsciiGZ> ("test_out.dat.gz");
+#ifdef USE_HEPMC
+  //auto writer= make_shared<JetScapeWriterHepMC> ("test_out.dat");
+#endif
+  //writer->SetActive(false);
+
+  //Remark: For now modules have to be added
+  //in proper "workflow" order (can be defined via xml and sorted if necessary)
+
+  jetscape->Add(trento);
+
+  // jetscape->Add(pGun);
+  jetscape->Add(pythiaGun);
+
+  jetscape->Add(freestream);
+
+  //Some modifications will be needed for reusing hydro events, so far
+  //simple test hydros always executed "on the fly" ...
+  jetscape->Add(hydro);
+
+  // Matter with silly "toy shower (no physics)
+  // and Martini dummy ...
+  // Switching Q2 (or whatever variable used
+  // hardcoded at 5 to be changed to xml)
+  jloss->Add(matter);
+  //jloss->Add(martini);
+  //jloss->Add(adscft);
+
+  jlossmanager->Add(jloss);
+
+  jetscape->Add(jlossmanager);
+
+
+  jetscape->Add(printer);
+
+  //hadro->Add(hadroModule);
+  //hadroMgr->Add(hadro);
+  //jetscape->Add(hadroMgr);
+
+
+
+  jetscape->Add(writer);
+
+  // Intialize all modules tasks
+  jetscape->Init();
+
+  // Run JetScape with all task/modules as specified ...
+  jetscape->Exec();
+
+  // "dummy" so far ...
+  // Most thinkgs done in write and clear ...
+  jetscape->Finish();
+
+  INFO_NICE<<"Finished!";
+  cout<<endl;
+
+  // wait for 5s
+  //std::this_thread::sleep_for(std::chrono::milliseconds(500000));
+
+  t = clock() - t;
+  time(&end);
+  printf ("CPU time: %f seconds.\n",((float)t)/CLOCKS_PER_SEC);
+  printf ("Real time: %f seconds.\n",difftime(end,start));
+  //printf ("Real time: %f seconds.\n",(start-end));
+  return 0;
+}
+
+// -------------------------------------
+
+void Show()
+{
+  INFO_NICE<<"-----------------------------------------------";
+  INFO_NICE<<"| freestream-milne Test JetScape Framework ... |";
+  INFO_NICE<<"-----------------------------------------------";
+  INFO_NICE;
+}

--- a/generators/JETSCAPE/hydroFileTest.cc
+++ b/generators/JETSCAPE/hydroFileTest.cc
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+// ------------------------------------------------------------
+// JetScape Framework hydro from file Test Program
+// (use either shared library (need to add paths; see setup.csh)
+// (or create static library and link in)
+// -------------------------------------------------------------
+
+#include <iostream>
+#include <time.h>
+#include <chrono>
+#include <thread>
+
+// JetScape Framework includes ...
+#include "JetScape.h"
+#include "JetEnergyLoss.h"
+#include "JetEnergyLossManager.h"
+#include "JetScapeWriterStream.h"
+#ifdef USE_HEPMC
+#include "JetScapeWriterHepMC.h"
+#endif
+
+// User modules derived from jetscape framework clasess
+// to be used to run Jetscape ...
+#include "AdSCFT.h"
+#include "Matter.h"
+#include "Martini.h"
+#include "Brick.h"
+#include "GubserHydro.h"
+#include "HydroFromFile.h"
+#include "PGun.h"
+
+#ifdef USE_HDF5
+#include "InitialFromFile.h"
+#endif
+// using namespace std;
+
+using namespace Jetscape;
+
+// Forward declaration
+void Show();
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+  clock_t t; t = clock();
+  time_t start, end; time(&start);
+  
+  cout<<endl;
+    
+  // DEBUG=true by default and REMARK=false
+  // can be also set also via XML file (at least partially)
+  JetScapeLogger::Instance()->SetDebug(false);
+  JetScapeLogger::Instance()->SetRemark(false);
+  //SetVerboseLevel (9 a lot of additional debug output ...)
+  //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevle(9) or 10
+  JetScapeLogger::Instance()->SetVerboseLevel(8);
+   
+  Show();
+
+  auto jetscape = make_shared<JetScape>("./jetscape_init.xml", 5);
+  jetscape->SetReuseHydro (true);
+  jetscape->SetNReuseHydro (5);
+
+  auto jlossmanager = make_shared<JetEnergyLossManager> ();
+  auto jloss = make_shared<JetEnergyLoss> ();
+  auto hydro = make_shared<HydroFromFile> ();
+  //auto hydro = make_shared<GubserHydro> ();
+  
+  auto matter = make_shared<Matter> ();
+  auto martini = make_shared<Martini> ();
+  auto adscft = make_shared<AdSCFT> ();
+  //DBEUG: Remark:
+  //does not matter unfortunately since not called recursively, done by JetEnergyLoss class ...
+  //matter->SetActive(false);
+  //martini->SetActive(false);
+  // This works ... (check with above logic ...)
+  //jloss->SetActive(false);
+  //
+
+  auto pGun= make_shared<PGun> ();
+
+  // only pure Ascii writer implemented and working with graph output ...
+  auto writer= make_shared<JetScapeWriterAscii> ("test_out.dat");
+  //auto writer= make_shared<JetScapeWriterAsciiGZ> ("test_out.dat.gz");  
+#ifdef USE_HEPMC
+  auto writerhepmc= make_shared<JetScapeWriterHepMC> ("test_out.hepmc");
+  jetscape->Add(writerhepmc);
+#endif
+  //writer->SetActive(false);
+
+  //Remark: For now modules have to be added
+  //in proper "workflow" order (can be defined via xml and sorted if necessary)
+  
+#ifdef USE_HDF5
+  auto initial = make_shared<InitialFromFile>();
+  jetscape->Add(initial);
+#endif
+
+  jetscape->Add(pGun);
+
+   //Some modifications will be needed for reusing hydro events, so far
+  //simple test hydros always executed "on the fly" ...
+  jetscape->Add(hydro);
+
+  // Matter with silly "toy shower (no physics)
+  // and Martini dummy ...
+  // Switching Q2 (or whatever variable used
+  // hardcoded at 5 to be changed to xml)
+  jloss->Add(matter);
+  //jloss->Add(martini);
+  // jloss->Add(adscft);
+  
+  jlossmanager->Add(jloss);
+  
+  jetscape->Add(jlossmanager);
+  
+  jetscape->Add(writer);
+
+  // Intialize all modules tasks
+  jetscape->Init();
+
+  // Run JetScape with all task/modules as specified ...
+  jetscape->Exec();
+
+  // "dummy" so far ...
+  // Most thinkgs done in write and clear ...
+  jetscape->Finish();
+  
+  INFO_NICE<<"Finished!";
+  cout<<endl;
+
+  // wait for 5s
+  //std::this_thread::sleep_for(std::chrono::milliseconds(500000));
+
+  t = clock() - t;
+  time(&end);
+  printf ("CPU time: %f seconds.\n",((float)t)/CLOCKS_PER_SEC);
+  printf ("Real time: %f seconds.\n",difftime(end,start));
+  //printf ("Real time: %f seconds.\n",(start-end));
+  return 0;
+}
+
+// -------------------------------------
+
+void Show()
+{
+  INFO_NICE<<"-----------------------------------------------";
+  INFO_NICE<<"| Hydro from file Test JetScape Framework ... |";
+  INFO_NICE<<"-----------------------------------------------";
+  INFO_NICE;
+}

--- a/generators/JETSCAPE/hydroJetTest.cc
+++ b/generators/JETSCAPE/hydroJetTest.cc
@@ -1,0 +1,229 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+// ------------------------------------------------------------
+// JetScape Framework jet in hydro from file Test Program
+// (use either shared library (need to add paths; see setup.csh)
+// (or create static library and link in)
+// -------------------------------------------------------------
+
+#include <iostream>
+#include <time.h>
+#include <chrono>
+#include <thread>
+
+// JetScape Framework includes ...
+#include "JetScape.h"
+#include "JetEnergyLoss.h"
+#include "JetEnergyLossManager.h"
+#include "JetScapeWriterStream.h"
+#ifdef USE_HEPMC
+#include "JetScapeWriterHepMC.h"
+#endif
+
+// User modules derived from jetscape framework clasess
+// to be used to run Jetscape ...
+#include "AdSCFT.h"
+#include "Matter.h"
+#include "LBT.h"
+#include "Martini.h"
+#include "Brick.h"
+#include "GubserHydro.h"
+#include "HydroFromFile.h"
+#include "PythiaGun.h"
+#include "PartonPrinter.h"
+#include "HadronizationManager.h"
+#include "Hadronization.h"
+#include "ColoredHadronization.h"
+#include "ColorlessHadronization.h"
+
+#ifdef USE_HDF5
+#include "InitialFromFile.h"
+#endif
+// using namespace std;
+// Add initial state module for test
+#include "TrentoInitial.h"
+
+#include <chrono>
+#include <thread>
+
+using namespace Jetscape;
+
+// Forward declaration
+void Show();
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+  clock_t t; t = clock();
+  time_t start, end; time(&start);
+  
+  cout<<endl;
+    
+  // DEBUG=true by default and REMARK=false
+  // can be also set also via XML file (at least partially)
+  JetScapeLogger::Instance()->SetInfo(true);
+  JetScapeLogger::Instance()->SetDebug(false);
+  JetScapeLogger::Instance()->SetRemark(false);
+  //SetVerboseLevel (9 a lot of additional debug output ...)
+  //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevle(9) or 10
+  JetScapeLogger::Instance()->SetVerboseLevel(8);
+   
+  Show();
+
+  auto jetscape = make_shared<JetScape>("./jetscape_init.xml", 20);
+  // auto jetscape = make_shared<JetScape>("./jetscape_init_pythiagun.xml",5);
+  jetscape->SetId("primary");
+  jetscape->SetReuseHydro (true);
+  jetscape->SetNReuseHydro (20);
+
+  auto jlossmanager = make_shared<JetEnergyLossManager> ();
+  auto jloss = make_shared<JetEnergyLoss> ();
+  auto hydro = make_shared<HydroFromFile> ();
+  //auto hydro = make_shared<GubserHydro> ();
+  
+  auto matter = make_shared<Matter> ();
+  auto lbt = make_shared<LBT> ();
+  auto martini = make_shared<Martini> ();
+  auto adscft = make_shared<AdSCFT> ();
+  //DBEUG: Remark:
+  //does not matter unfortunately since not called recursively, done by JetEnergyLoss class ...
+  //matter->SetActive(false);
+  //martini->SetActive(false);
+  // This works ... (check with above logic ...)
+  //jloss->SetActive(false);
+
+  auto pythiaGun= make_shared<PythiaGun> ();
+
+  auto printer = make_shared<PartonPrinter> ();
+
+  auto hadroMgr = make_shared<HadronizationManager> ();
+  auto hadro = make_shared<Hadronization> ();
+  auto hadroModule = make_shared<ColoredHadronization> ();
+  auto colorless = make_shared<ColorlessHadronization> ();
+
+  // only pure Ascii writer implemented and working with graph output ...
+  auto writer= make_shared<JetScapeWriterAscii> ("test_out.dat");
+  //auto writer= make_shared<JetScapeWriterAsciiGZ> ("test_out.dat.gz");  
+#ifdef USE_HEPMC
+  auto writerhepmc= make_shared<JetScapeWriterHepMC> ("test_out.hepmc");
+  jetscape->Add(writerhepmc);
+#endif
+  //writer->SetActive(false);
+
+  //Remark: For now modules have to be added
+  //in proper "workflow" order (can be defined via xml and sorted if necessary)
+  
+#ifdef USE_HDF5
+  auto initial = make_shared<InitialFromFile>();
+  jetscape->Add(initial);
+#endif
+
+  jetscape->Add(pythiaGun);
+
+   //Some modifications will be needed for reusing hydro events, so far
+  //simple test hydros always executed "on the fly" ...
+  jetscape->Add(hydro);
+
+  // Matter with silly "toy shower (no physics)
+  // and Martini dummy ...
+  // Switching Q2 (or whatever variable used
+  // hardcoded at 5 to be changed to xml)
+  jloss->Add(matter);
+  //jloss->Add(lbt);  // go to 3rd party and ./get_lbtTab before adding this module
+  //jloss->Add(martini);
+  jloss->Add(adscft);
+  
+  jlossmanager->Add(jloss);
+  
+  jetscape->Add(jlossmanager);
+
+  jetscape->Add(printer);
+
+  hadro->Add(hadroModule);
+  //hadro->Add(colorless);
+  hadroMgr->Add(hadro);
+  jetscape->Add(hadroMgr);
+
+  jetscape->Add(writer);
+
+  // Intialize all modules tasks
+  jetscape->Init();
+
+  // Run JetScape with all task/modules as specified ...
+  jetscape->Exec();
+
+  // "dummy" so far ...
+  // Most thinkgs done in write and clear ...
+  jetscape->Finish();
+  
+  INFO_NICE<<"Finished!";
+  cout<<endl;
+
+// Some information is only known after the full run,
+  // Therefore store information at the end of the file, in a footer
+  writer->WriteComment ( "EVENT GENERATION INFORMATION" );
+  Pythia8::Info& info = pythiaGun->info;
+  std::ostringstream oss;
+  oss.str(""); oss << "nTried    = " << info.nTried();
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "nSelected = " << info.nSelected();
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "nAccepted = " << info.nAccepted();
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "sigmaGen  = " << info.sigmaGen();  
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "sigmaErr  = " << info.sigmaErr();
+  writer->WriteComment ( oss.str() );
+
+  oss.str(""); oss << "eCM  = " << info.eCM();
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "pTHatMin  = " << pythiaGun->GetpTHatMin();
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "pTHatMax  = " << pythiaGun->GetpTHatMax();
+  //writer->WriteComment ( oss.str() );
+  //oss.str(""); oss << "JETSCAPE Random Seed  = " << JetScapeTaskSupport::Instance()->GetRandomSeed();
+  writer->WriteComment ( oss.str() );
+  writer->WriteComment ( "/EVENT GENERATION INFORMATION" );
+
+  t = clock() - t;
+  time(&end);
+  printf ("CPU time: %f seconds.\n",((float)t)/CLOCKS_PER_SEC);
+  printf ("Real time: %f seconds.\n",difftime(end,start));
+
+  // Print pythia statistics
+  // pythiaGun->stat();
+
+  // Demonstrate how to work with pythia statistics
+  //Pythia8::Info& info = pythiaGun->info;
+  cout << " nTried    = " << info.nTried() << endl;
+  cout << " nSelected = " << info.nSelected()  << endl;
+  cout << " nAccepted = " << info.nAccepted()  << endl;
+  cout << " sigmaGen  = " <<   info.sigmaGen()  << endl;  
+  cout << " sigmaErr  = " <<   info.sigmaErr()  << endl;
+ 
+  
+  return 0;
+}
+
+// -------------------------------------
+
+void Show()
+{
+  INFO_NICE<<"------------------------------------------------------";
+  INFO_NICE<<"| Jet in hydro from file Test JetScape Framework ... |";
+  INFO_NICE<<"------------------------------------------------------";
+  INFO_NICE;
+}

--- a/generators/JETSCAPE/hydroJetTestPGun.cc
+++ b/generators/JETSCAPE/hydroJetTestPGun.cc
@@ -1,0 +1,232 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+// ------------------------------------------------------------
+// JetScape Framework jet in hydro from file Test Program
+// (use either shared library (need to add paths; see setup.csh)
+// (or create static library and link in)
+// -------------------------------------------------------------
+
+#include <iostream>
+#include <time.h>
+#include <chrono>
+#include <thread>
+
+// JetScape Framework includes ...
+#include "JetScape.h"
+#include "JetEnergyLoss.h"
+#include "JetEnergyLossManager.h"
+#include "JetScapeWriterStream.h"
+#ifdef USE_HEPMC
+#include "JetScapeWriterHepMC.h"
+#endif
+
+// User modules derived from jetscape framework clasess
+// to be used to run Jetscape ...
+#include "AdSCFT.h"
+#include "Matter.h"
+#include "LBT.h"
+#include "Martini.h"
+#include "Brick.h"
+#include "GubserHydro.h"
+#include "HydroFromFile.h"
+#include "PGun.h"
+#include "PythiaGun.h"
+#include "PartonPrinter.h"
+#include "HadronizationManager.h"
+#include "Hadronization.h"
+#include "ColoredHadronization.h"
+#include "ColorlessHadronization.h"
+
+#ifdef USE_HDF5
+#include "InitialFromFile.h"
+#endif
+// using namespace std;
+// Add initial state module for test
+#include "TrentoInitial.h"
+
+#include <chrono>
+#include <thread>
+
+using namespace Jetscape;
+
+// Forward declaration
+void Show();
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+  clock_t t; t = clock();
+  time_t start, end; time(&start);
+  
+  cout<<endl;
+    
+  // DEBUG=true by default and REMARK=false
+  // can be also set also via XML file (at least partially)
+  JetScapeLogger::Instance()->SetInfo(true);
+  JetScapeLogger::Instance()->SetDebug(false);
+  JetScapeLogger::Instance()->SetRemark(false);
+  //SetVerboseLevel (9 a lot of additional debug output ...)
+  //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevle(9) or 10
+  JetScapeLogger::Instance()->SetVerboseLevel(6);
+   
+  Show();
+
+  auto jetscape = make_shared<JetScape>("./jetscape_init.xml", 2000);
+  // auto jetscape = make_shared<JetScape>("./jetscape_init_pythiagun.xml",5);
+  jetscape->SetId("primary");
+  jetscape->SetReuseHydro (true);
+  jetscape->SetNReuseHydro (10001);
+    
+    auto pGun= make_shared<PGun> ();
+
+  auto jlossmanager = make_shared<JetEnergyLossManager> ();
+  auto jloss = make_shared<JetEnergyLoss> ();
+  auto hydro = make_shared<HydroFromFile> ();
+  //auto hydro = make_shared<GubserHydro> ();
+  
+  auto matter = make_shared<Matter> ();
+  auto lbt = make_shared<LBT> ();
+  auto martini = make_shared<Martini> ();
+  auto adscft = make_shared<AdSCFT> ();
+  //DBEUG: Remark:
+  //does not matter unfortunately since not called recursively, done by JetEnergyLoss class ...
+  //matter->SetActive(false);
+  //martini->SetActive(false);
+  // This works ... (check with above logic ...)
+  //jloss->SetActive(false);
+
+  //auto pythiaGun= make_shared<PythiaGun> ();
+
+  auto printer = make_shared<PartonPrinter> ();
+
+  auto hadroMgr = make_shared<HadronizationManager> ();
+  auto hadro = make_shared<Hadronization> ();
+  auto hadroModule = make_shared<ColoredHadronization> ();
+  auto colorless = make_shared<ColorlessHadronization> ();
+
+  // only pure Ascii writer implemented and working with graph output ...
+  auto writer= make_shared<JetScapeWriterAscii> ("test_out.dat");
+  //auto writer= make_shared<JetScapeWriterAsciiGZ> ("test_out.dat.gz");  
+#ifdef USE_HEPMC
+  //auto writer= make_shared<JetScapeWriterHepMC> ("test_out.hepmc");
+#endif
+  //writer->SetActive(false);
+
+  //Remark: For now modules have to be added
+  //in proper "workflow" order (can be defined via xml and sorted if necessary)
+  
+#ifdef USE_HDF5
+  auto initial = make_shared<InitialFromFile>();
+  jetscape->Add(initial);
+#endif
+
+//  jetscape->Add(pythiaGun);
+    jetscape->Add(pGun);
+
+   //Some modifications will be needed for reusing hydro events, so far
+  //simple test hydros always executed "on the fly" ...
+  jetscape->Add(hydro);
+
+  // Matter with silly "toy shower (no physics)
+  // and Martini dummy ...
+  // Switching Q2 (or whatever variable used
+  // hardcoded at 5 to be changed to xml)
+  jloss->Add(matter);
+  //jloss->Add(lbt);  // go to 3rd party and ./get_lbtTab before adding this module
+  //jloss->Add(martini);
+  //jloss->Add(adscft);
+  
+  jlossmanager->Add(jloss);
+  
+  jetscape->Add(jlossmanager);
+
+  jetscape->Add(printer);
+
+  hadro->Add(hadroModule);
+  //hadro->Add(colorless);
+  hadroMgr->Add(hadro);
+  jetscape->Add(hadroMgr);
+
+  jetscape->Add(writer);
+
+  // Intialize all modules tasks
+  jetscape->Init();
+
+  // Run JetScape with all task/modules as specified ...
+  jetscape->Exec();
+
+  // "dummy" so far ...
+  // Most thinkgs done in write and clear ...
+  jetscape->Finish();
+  
+  INFO_NICE<<"Finished!";
+  cout<<endl;
+
+// Some information is only known after the full run,
+  // Therefore store information at the end of the file, in a footer
+/*  writer->WriteComment ( "EVENT GENERATION INFORMATION" );
+  Pythia8::Info& info = pythiaGun->info;
+  std::ostringstream oss;
+  oss.str(""); oss << "nTried    = " << info.nTried();
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "nSelected = " << info.nSelected();
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "nAccepted = " << info.nAccepted();
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "sigmaGen  = " << info.sigmaGen();  
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "sigmaErr  = " << info.sigmaErr();
+  writer->WriteComment ( oss.str() );
+
+  oss.str(""); oss << "eCM  = " << info.eCM();
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "pTHatMin  = " << pythiaGun->GetpTHatMin();
+  writer->WriteComment ( oss.str() );
+  oss.str(""); oss << "pTHatMax  = " << pythiaGun->GetpTHatMax();
+  //writer->WriteComment ( oss.str() );
+  //oss.str(""); oss << "JETSCAPE Random Seed  = " << JetScapeTaskSupport::Instance()->GetRandomSeed();
+  writer->WriteComment ( oss.str() );
+  writer->WriteComment ( "/EVENT GENERATION INFORMATION" );
+*/
+  t = clock() - t;
+  time(&end);
+  printf ("CPU time: %f seconds.\n",((float)t)/CLOCKS_PER_SEC);
+  printf ("Real time: %f seconds.\n",difftime(end,start));
+
+  // Print pythia statistics
+  // pythiaGun->stat();
+
+  // Demonstrate how to work with pythia statistics
+  //Pythia8::Info& info = pythiaGun->info;
+/*  cout << " nTried    = " << info.nTried() << endl;
+  cout << " nSelected = " << info.nSelected()  << endl;
+  cout << " nAccepted = " << info.nAccepted()  << endl;
+  cout << " sigmaGen  = " <<   info.sigmaGen()  << endl;  
+  cout << " sigmaErr  = " <<   info.sigmaErr()  << endl;
+*/
+  
+  return 0;
+}
+
+// -------------------------------------
+
+void Show()
+{
+  INFO_NICE<<"------------------------------------------------------";
+  INFO_NICE<<"| Jet in hydro from file Test JetScape Framework ... |";
+  INFO_NICE<<"------------------------------------------------------";
+  INFO_NICE;
+}

--- a/generators/JETSCAPE/readerTest.cc
+++ b/generators/JETSCAPE/readerTest.cc
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+// Reader test (focus on graph)
+
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include <chrono>
+#include <thread>
+
+#include "gzstream.h"
+#include "PartonShower.h"
+#include "JetScapeLogger.h"
+#include "JetScapeReader.h"
+#include "JetScapeBanner.h"
+#include "fjcore.hh"
+
+#include <GTL/dfs.h>
+
+using namespace std;
+//using namespace fjcore;
+
+using namespace Jetscape;
+
+// -------------------------------------
+
+// Forward declaration
+void Show();
+void AnalyzeGraph(shared_ptr<PartonShower> mS);
+ostream & operator<<(ostream & ostr, const fjcore::PseudoJet & jet);
+
+// -------------------------------------
+
+// Create a pdf of the shower graph:
+// Use with graphviz (on Mac: brew install graphviz --with-app)
+// in shell: dot GVfile.gv -Tpdf -o outputPDF.pdf
+// [or you can also use the GraphViz app for Mac Os X (in the "cellar" of homebrew)]
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+  JetScapeLogger::Instance()->SetDebug(false);
+  JetScapeLogger::Instance()->SetRemark(false);
+  //SetVerboseLevel (9 a lot of additional debug output ...)
+  //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevle(9) or 10
+  JetScapeLogger::Instance()->SetVerboseLevel(0);
+  
+  cout<<endl;
+  Show();
+
+  //Do some dummy jetfinding ...
+  fjcore::JetDefinition jet_def(fjcore::antikt_algorithm, 0.7);
+  
+  vector<shared_ptr<PartonShower>> mShowers;
+
+  //Directly with template: provide the relevant stream
+  //auto reader=make_shared<JetScapeReader<ifstream>>("test_out.dat");
+  //auto reader=make_shared<JetScapeReader<igzstream>>("test_out.dat.gz");
+  
+  // Hide Template (see class declarations in reader/JetScapeReader.h) ...
+  auto reader=make_shared<JetScapeReaderAscii>("test_out.dat");
+  //auto reader=make_shared<JetScapeReaderAsciiGZ>("test_out.dat.gz");
+
+  // reads in multiple events and multiple shower per event
+  // commentend out so that you get the dot graph file for the first shower in the first event
+  // (add in and the file gets overriden)
+  //while (!reader->Finished())
+    {
+      reader->Next();
+
+      cout<<"Analyze current event = "<<reader->GetCurrentEvent()<<endl;
+      mShowers=reader->GetPartonShowers();     
+
+      int finals = 0;
+      for (int i=0;i<mShowers.size();i++)
+	{
+	  cout<<" Analyze parton shower = "<<i<<endl;
+	 
+	  mShowers[i]->PrintVertices();
+	  mShowers[i]->PrintPartons();	
+
+	  finals += mShowers[i]->GetFinalPartonsForFastJet().size();
+	   
+	  fjcore::ClusterSequence cs(mShowers[i]->GetFinalPartonsForFastJet(), jet_def);
+
+	  vector<fjcore::PseudoJet> jets = fjcore::sorted_by_pt(cs.inclusive_jets(2));
+	  cout<<endl;
+	  cout<<jet_def.description()<<endl;
+	  // Output of found jets ...
+	  //cout<<endl;	 
+	  for (int k=0;k<jets.size();k++)	    
+	    cout<<"Anti-kT jet "<<k<<" : "<<jets[k]<<endl;
+	  cout<<endl;
+	  cout<<"Shower initiating parton : "<<*(mShowers[i]->GetPartonAt(0))<<endl;
+	  cout<<endl;
+	  
+	  AnalyzeGraph(mShowers[i]);
+
+	  if (i==0)
+	    {
+	      mShowers[i]->SaveAsGV("my_test.gv");
+	      mShowers[i]->SaveAsGML("my_test.gml");
+	      mShowers[i]->SaveAsGraphML("my_test.graphml");
+	    }
+
+	  // wait for 5s
+	  //std::this_thread::sleep_for(std::chrono::milliseconds(5000));  
+	}
+      cout << " Found " << finals << " final state partons." << endl;
+      auto hadrons = reader->GetHadrons();
+      cout<<"Number of hadrons is: " << hadrons.size() << endl;
+      
+      fjcore::ClusterSequence hcs(reader->GetHadronsForFastJet(), jet_def);
+      vector<fjcore::PseudoJet> hjets = fjcore::sorted_by_pt(hcs.inclusive_jets(2));
+      cout<<"AT HADRONIC LEVEL " << endl;
+      for (int k=0;k<hjets.size();k++)	    
+	cout<<"Anti-kT jet "<<k<<" : "<<hjets[k]<<endl;
+
+      // for(unsigned int i=0; i<hadrons.size(); i++) {
+      // 	cout<<"For Hadron Number "<<i<<" "<< hadrons[i].get()->e() << " "<< hadrons[i].get()->px()<< " "<< hadrons[i].get()->py() << " "<< hadrons[i].get()->pz()<< " "<< hadrons[i].get()->pt()<<  endl;
+      // }
+    }
+    
+    reader->Close(); 
+}
+
+// -------------------------------------
+
+void AnalyzeGraph(shared_ptr<PartonShower> mS)
+{
+  INFO<<"Some GTL graph/shower analysis/dfs search output:";
+
+  // quick and dirty ...
+  dfs search;
+  search.calc_comp_num(true);
+  search.scan_whole_graph(true);
+  search.start_node();// defaulted to first node ...
+  search.run(*mS);
+
+  cout<<endl;
+  cout<<"DFS graph search feature from GTL:"<<endl;
+  cout<<"Number of Nodes reached from node 0 = "<< search.number_of_reached_nodes () <<endl;
+  cout<<"Node/Vertex ordering result from DFS:"<<endl;
+  dfs::dfs_iterator itt2, endt2;
+  for (itt2 = search.begin(), endt2=search.end(); itt2 !=endt2; ++itt2)
+    {
+      cout<<*itt2<<" ";//<<"="<<search.dfs_num(*itt2)<<" ";
+    }
+  cout<<endl;
+  cout<<"Edge/Parton ordering result from DFS:"<<endl;
+  dfs::tree_edges_iterator itt, endt;
+  for (itt = search.tree_edges_begin(), endt=search.tree_edges_end(); itt !=endt; ++itt)
+    {
+        cout<<*itt;//<<endl;
+    }
+  cout<<endl;
+  
+  dfs::roots_iterator itt3, endt3;
+  cout<<"List of root nodes found in graph/shower : ";
+  for (itt3 = search.roots_begin(), endt3=search.roots_end(); itt3 !=endt3; ++itt3)
+    {
+      cout<<**itt3;
+    }
+  cout<<endl;
+  cout<<endl;
+}
+
+
+// -------------------------------------
+
+void Show()
+{
+  ShowJetscapeBanner();
+  INFO_NICE;
+  INFO_NICE<<"------------------------------------";
+  INFO_NICE<<"| Reader Test JetScape Framework ... |";
+  INFO_NICE<<"------------------------------------";
+  INFO_NICE;
+}
+
+//----------------------------------------------------------------------
+/// overloaded jet info output
+
+ostream & operator<<(ostream & ostr, const fjcore::PseudoJet & jet) {
+  if (jet == 0) {
+    ostr << " 0 ";
+  } else {
+    ostr << " pt = " << jet.pt()
+         << " m = " << jet.m()
+         << " y = " << jet.rap()
+         << " phi = " << jet.phi();
+  }
+  return ostr;
+}
+
+
+//----------------------------------------------------------------------

--- a/generators/JETSCAPE/testJetScape.cc
+++ b/generators/JETSCAPE/testJetScape.cc
@@ -1,0 +1,252 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ * 
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+// ------------------------------------------------------------
+// JetScape Framework Test Program
+// (use either shared library (need to add paths; see setup.csh)
+// (or create static library and link in)
+// -------------------------------------------------------------
+
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "JetScape.h"
+#include "JetEnergyLoss.h"
+#include "JetEnergyLossManager.h"
+#include "JetScapeSignalManager.h"
+#include "FluidDynamics.h"
+#include "JetScapeLogger.h"
+#include "JetScapeXML.h"
+#include "Matter.h"
+#include "Martini.h"
+#include "JetScapeWriterStream.h"
+#ifdef USE_HEPMC
+#include "JetScapeWriterHepMC.h"
+#endif
+
+
+#include "sigslot.h"
+
+// for test case ...
+#include "Brick.h"
+#include "GubserHydro.h"
+
+using namespace std;
+using namespace sigslot;
+
+using namespace Jetscape;
+
+void Show();
+
+// -------------------------------------
+
+int main(int argc, char** argv)
+{
+  cout<<endl;
+  
+  // DEBUG=true by default and REMARK=false
+  // can be also set via XML file
+  JetScapeLogger::Instance()->SetDebug(true);
+  //JetScapeLogger::Instance()->SetRemark(true);  
+  JetScapeLogger::Instance()->SetVerboseLevel(9);
+   
+  Show();
+
+  //JetScapeSignalManager::Instance();
+  
+  //Test verbose ...
+  // Verbose Level 10 should be the highest ... (not check though in class) 
+  //JetScapeLogger::Instance()->Verbose(4)<<"Test Verbose ...";
+  //VERBOSE(4)<<" Test Verbose ...";
+  
+  //With definitions above/in logger class  as a shortcut
+  //JSDEBUG<<" Test";
+  
+  //JetScapeXML::Instance()->SetXMLFileName("./jetscape_init.xml");
+  //JetScapeXML::Instance()->OpenXMLFile();
+  //JetScapeXML::Instance()->OpenXMLFile("./jetscape_init.xml");	
+  
+  //shared_ptr<JetScape> jetscape = make_shared<JetScape> ();
+  // or shorter ...
+  //auto jetscape = make_shared<JetScape> ();
+  //jetscape->SetXMLFileName("./jetscape_init.xml");
+
+  // JetScape Clas acts as TaskManager (should be generalized at some point)
+  // Make it truly recursive (not yet really implemented that way)
+  // Think harder and maybe in general/decide on shared vs. unique vs. raw pointer usage ...
+  // Current: Just use make_shared always (propably not the most efficient solution ...)
+  
+  //auto jetscape = make_shared<JetScape>("/Users/putschke/JetScape/framework_xcode/jetscape_init.xml",3);
+  auto jetscape = make_shared<JetScape>("./jetscape_init.xml",3);
+  // if << overloaded for classes then for example (see commented out in JetScape.h)
+  //cout<<*jetscape<<endl; 
+  // try to automatically create in Add()!? and to handle things behind the scene ...
+  auto jlossmanager = make_shared<JetEnergyLossManager> ();
+  auto jloss = make_shared<JetEnergyLoss> ();
+  //auto hydro = make_shared<FluidDynamics> ();
+  //auto hydro = make_shared<Brick> ();
+  auto hydro = make_shared<GubserHydro> ();
+  
+  auto matter = make_shared<Matter> ();
+  auto martini = make_shared<Martini> ();
+
+  //auto writer= make_shared<JetScapeWriterAsciiGZ> ("test_out.dat.gz");
+  auto writer= make_shared<JetScapeWriterAscii> ("test_out.dat");
+#ifdef USE_HEPMC
+  //auto writer= make_shared<JetScapeWriterHepMC> ("test_out.dat");
+#endif
+  writer->SetActive(false);
+  
+  jetscape->Add(hydro);
+
+  jloss->Add(matter);
+  jloss->Add(martini);
+
+  //jetscape->Add(jloss);
+  
+  jlossmanager->Add(jloss);
+  jetscape->Add(jlossmanager);
+
+  //jetscape->Add(writer);
+
+  // can add before or after jetscape (order does not matter)
+  
+  //INFO<<"Number of JetScape Tasks = "<<jetscape->GetNumberOfTasks();
+  //INFO<<"Number of Eloss Tasks = "<<jloss->GetNumberOfTasks();
+  
+  jetscape->Init();
+
+   // maybe smarter to deal with multiple eloss instances (think of di-jet) in seperate task Manager !??
+  //auto jloss2=make_shared<JetEnergyLoss> (*jloss);
+  //jetscape->Add(jloss2);
+
+  REMARK<<"Module testing for now on Module Base class!";
+  REMARK<<"jetscape->Init(); Calls all Init()'s of jetscape modules tasks, ";
+  REMARK<<"since list/vector is sortable, can be used to ensure correct order or via xml file"; 
+
+  // --------------------------
+  /*
+  //cout<<((JetEnergyLoss*) (jloss.get()))->GetQhat()<<endl;
+  auto jloss2=make_shared<JetEnergyLoss> (*jloss); //default copy works with STL vector list but no deep copy!!? See below
+  // to be implemented in class ...
+  
+  cout<<jloss->GetNumberOfTasks()<<" "<<jloss2->GetNumberOfTasks()<<endl;
+  
+  cout<<jloss.get()<<" "<<jloss2.get()<<endl;
+  cout<<jloss->GetTaskAt(0).get()<<" "<<jloss2->GetTaskAt(0).get() <<endl;
+  
+  cout<<((Matter*) (jloss->GetTaskAt(0).get()))->GetQhat()<<endl; //check with shared ...
+  cout<<((Matter*) (jloss2->GetTaskAt(0).get()))->GetQhat()<<endl;
+  ((Matter*) (jloss2->GetTaskAt(0).get()))->SetQhat(12);
+  cout<<((Matter*) (jloss->GetTaskAt(0).get()))->GetQhat()<<endl; //check with shared ...
+  cout<<((Matter*) (jloss2->GetTaskAt(0).get()))->GetQhat()<<endl;
+  */
+  
+  /*
+  //cout<<((Martini*) (jloss->GetTaskAt(1).get()))->GetQhat()<<endl;
+  //cout<<((Martini*) (jloss2->GetTaskAt(1).get()))->GetQhat()<<endl;
+  */
+
+  /*
+  auto matter2 = make_shared<Matter> (*matter);
+  matter2->SetQhat(15);
+  cout<<matter2->GetQhat()<<endl;
+  cout<<matter->GetQhat()<<endl;
+  */
+  // --------------------------
+  
+  //
+  // Simple signal/slot creation
+  //
+  //hydro.get() --> old C++ style pointer needd for sigslot code ...
+  //Maybe switch to boost signal2 for more modern implementation ... 
+  //jloss->jetSignal.connect(hydro.get(), &FluidDynamics::UpdateEnergyDeposit);
+  
+  //Signal itself defined in JetEnergyLoss class
+  //Signal not allowed virtual ... (think about inheritence and user interface ...!?)
+  //matter->jetSignal.connect(hydro.get(), &FluidDynamics::UpdateEnergyDeposit);
+  //matter2->jetSignal.connect(hydro.get(), &FluidDynamics::UpdateEnergyDeposit);
+  //martini->jetSignal.connect(hydro.get(), &FluidDynamics::UpdateEnergyDeposit);
+
+  //JSDEBUG<<"Connect Signal/Slot : jetSignal.connect(hydro.get(), &FluidDynamics::UpdateEnergyDeposit);";
+  //REMARK<<"Can be handelded in own connection class ...";
+
+  //matter2->jetSignal(1,2);
+  
+  // ------------------
+  //some quick and dirty debug ...
+  //cout<<jetscape.use_count()<<endl;
+  //cout<<jloss.use_count()<<endl;
+  
+  //VERBOSE(9)<<" : Martini use count = "<<  martini.use_count() ;
+
+  /*
+  //martini = NULL;
+  //martini.reset();
+  //delete martini.get();
+  JetScapeLogger::Instance()->Verbose(9)<<" Martini after nullptr ... "<<  martini.use_count() ; 
+
+  cout<<jetscape.use_count()<<endl;
+  cout<<jloss.use_count()<<endl;
+  */
+  // ------------------
+  
+  jetscape->Exec();
+
+  //jetscape->Finish();
+  
+  //REMARK<<"Overload Exec for Hydro ...";
+
+  // Others like finish and write (and in general data structure handling to be added/implmented accordingly)
+  
+  // If not handeled via task class can be called individually or put in jetscape main class ...
+  //jloss->Init();
+  //hydro->Init();
+  
+  //this_thread::sleep_for(std::chrono::milliseconds(1000000));
+
+  
+  INFO_NICE<<"Finished!";
+  cout<<endl;
+
+  /*
+  Parameter parameter_list;
+    parameter_list.hydro_input_filename = *(argv+1);
+
+    Brick *brick_ptr = new Brick();
+    brick_ptr->InitializeHydro(parameter_list);
+    brick_ptr->EvolveHydro();
+     for (int i=1;i<20;i++)
+      {
+	FluidCellInfo* check_fluid_info_ptr = new FluidCellInfo;
+	brick_ptr->GetHydroInfo(i, 1.0, 1.0, 0.0, check_fluid_info_ptr);
+	//brick_ptr->PrintFluidCellInformation(check_fluid_info_ptr);
+	cout<<i<<" "<<check_fluid_info_ptr->energy_density<<" "<<check_fluid_info_ptr->temperature<<endl;
+	cout<<i<<" "<<brick_ptr->GetTemperature(i, 1.0, 1.0, 0.0)<<endl;
+	delete check_fluid_info_ptr;
+      }
+  */
+  
+  return 0;
+}
+
+// -------------------------------------
+
+void Show()
+{
+  INFO_NICE<<"-------------------------------";
+  INFO_NICE<<"| Test JetScape Framework ... |";
+  INFO_NICE<<"-------------------------------";
+}


### PR DESCRIPTION
Normally one has to build JETSCAPE in its full glory to compile these examples as part of it. I pulled the examples out and added a Makefile which will build them against our centrally installed jetscape version