### PR TITLE
Make datamembers of the Fun4AllBase class private, use accessors

### DIFF
--- a/generators/PHPythia6/PHPythia6.C
+++ b/generators/PHPythia6/PHPythia6.C
@@ -345,7 +345,7 @@ void PHPythia6::print_config() const {
 
 int PHPythia6::process_event(PHCompositeNode *topNode) {
 
-  if (verbosity > 1) cout << "PHPythia6::process_event - event: " << _eventcount << endl;
+  if (Verbosity() > 1) cout << "PHPythia6::process_event - event: " << _eventcount << endl;
 
   bool passedTrigger = false;
   std::vector<bool> theTriggerResults;
@@ -394,14 +394,14 @@ int PHPythia6::process_event(PHCompositeNode *topNode) {
     // test trigger logic
     
     bool andScoreKeeper = true;
-    if (verbosity > 2) {
+    if (Verbosity() > 2) {
       cout << "PHPythia6::process_event - triggersize: " << _registeredTriggers.size() << endl;
     }
 
     for (unsigned int tr = 0; tr < _registeredTriggers.size(); tr++) { 
       bool trigResult = _registeredTriggers[tr]->Apply(evt);
 
-      if (verbosity > 2) {
+      if (Verbosity() > 2) {
 	cout << "PHPythia6::process_event trigger: "
 	     << _registeredTriggers[tr]->GetName() << "  " << trigResult << endl;
       }
@@ -413,7 +413,7 @@ int PHPythia6::process_event(PHCompositeNode *topNode) {
 	andScoreKeeper &= trigResult;
       }
       
-      if (verbosity > 2 && !passedTrigger) {
+      if (Verbosity() > 2 && !passedTrigger) {
 	cout << "PHPythia8::process_event - failed trigger: "
 	     << _registeredTriggers[tr]->GetName() <<  endl;
       }
@@ -444,7 +444,7 @@ int PHPythia6::process_event(PHCompositeNode *topNode) {
     return Fun4AllReturnCodes::ABORTRUN;
   }
   /* print outs*/
-  if (verbosity > 2) cout << "PHPythia6::process_event - FINISHED WHOLE EVENT" << endl;
+  if (Verbosity() > 2) cout << "PHPythia6::process_event - FINISHED WHOLE EVENT" << endl;
 
   ++_eventcount;
   return Fun4AllReturnCodes::EVENT_OK;
@@ -475,6 +475,6 @@ int PHPythia6::ResetEvent(PHCompositeNode *topNode) {
 }
 
 void PHPythia6::register_trigger(PHPy6GenTrigger *theTrigger) {
-  if(verbosity > 1) cout << "PHPythia6::registerTrigger - trigger " << theTrigger->GetName() << " registered" << endl;
+  if(Verbosity() > 1) cout << "PHPythia6::registerTrigger - trigger " << theTrigger->GetName() << " registered" << endl;
   _registeredTriggers.push_back(theTrigger);
 }

--- a/generators/PHPythia8/PHPythia8.C
+++ b/generators/PHPythia8/PHPythia8.C
@@ -108,9 +108,9 @@ int PHPythia8::Init(PHCompositeNode *topNode)
 
 int PHPythia8::End(PHCompositeNode *topNode)
 {
-  if (verbosity >= VERBOSITY_MORE) cout << "PHPythia8::End - I'm here!" << endl;
+  if (Verbosity() >= VERBOSITY_MORE) cout << "PHPythia8::End - I'm here!" << endl;
 
-  if (verbosity >= VERBOSITY_SOME)
+  if (Verbosity() >= VERBOSITY_SOME)
   {
     //-* dump out closing info (cross-sections, etc)
     _pythia->stat();
@@ -143,7 +143,7 @@ int PHPythia8::read_config(const char *cfg_file)
 {
   if (cfg_file) _configFile = cfg_file;
 
-  if (verbosity >= VERBOSITY_SOME)
+  if (Verbosity() >= VERBOSITY_SOME)
     cout << "PHPythia8::read_config - Reading " << _configFile << endl;
 
   ifstream infile(_configFile.c_str());
@@ -166,7 +166,7 @@ void PHPythia8::print_config() const
 
 int PHPythia8::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity >= VERBOSITY_MORE) cout << "PHPythia8::process_event - event: " << _eventcount << endl;
+  if (Verbosity() >= VERBOSITY_MORE) cout << "PHPythia8::process_event - event: " << _eventcount << endl;
 
   bool passedGen = false;
   bool passedTrigger = false;
@@ -185,7 +185,7 @@ int PHPythia8::process_event(PHCompositeNode *topNode)
     // test trigger logic
 
     bool andScoreKeeper = true;
-    if (verbosity >= VERBOSITY_EVEN_MORE)
+    if (Verbosity() >= VERBOSITY_EVEN_MORE)
     {
       cout << "PHPythia8::process_event - triggersize: " << _registeredTriggers.size() << endl;
     }
@@ -194,7 +194,7 @@ int PHPythia8::process_event(PHCompositeNode *topNode)
     {
       bool trigResult = _registeredTriggers[tr]->Apply(_pythia);
 
-      if (verbosity >= VERBOSITY_EVEN_MORE)
+      if (Verbosity() >= VERBOSITY_EVEN_MORE)
       {
         cout << "PHPythia8::process_event trigger: "
              << _registeredTriggers[tr]->GetName() << "  " << trigResult << endl;
@@ -210,7 +210,7 @@ int PHPythia8::process_event(PHCompositeNode *topNode)
         andScoreKeeper &= trigResult;
       }
 
-      if (verbosity >= VERBOSITY_EVEN_MORE && !passedTrigger)
+      if (Verbosity() >= VERBOSITY_EVEN_MORE && !passedTrigger)
       {
         cout << "PHPythia8::process_event - failed trigger: "
              << _registeredTriggers[tr]->GetName() << endl;
@@ -241,9 +241,9 @@ int PHPythia8::process_event(PHCompositeNode *topNode)
 
   // print outs
 
-  if (verbosity >= VERBOSITY_MORE) cout << "PHPythia8::process_event - FINISHED WHOLE EVENT" << endl;
-  if (_eventcount < 2 && verbosity >= VERBOSITY_SOME) _pythia->event.list();
-  if (_eventcount >= 2 && verbosity >= VERBOSITY_A_LOT) _pythia->event.list();
+  if (Verbosity() >= VERBOSITY_MORE) cout << "PHPythia8::process_event - FINISHED WHOLE EVENT" << endl;
+  if (_eventcount < 2 && Verbosity() >= VERBOSITY_SOME) _pythia->event.list();
+  if (_eventcount >= 2 && Verbosity() >= VERBOSITY_A_LOT) _pythia->event.list();
 
   ++_eventcount;
 
@@ -302,6 +302,6 @@ int PHPythia8::ResetEvent(PHCompositeNode *topNode)
 
 void PHPythia8::register_trigger(PHPy8GenTrigger *theTrigger)
 {
-  if (verbosity >= VERBOSITY_MORE) cout << "PHPythia8::registerTrigger - trigger " << theTrigger->GetName() << " registered" << endl;
+  if (Verbosity() >= VERBOSITY_MORE) cout << "PHPythia8::registerTrigger - trigger " << theTrigger->GetName() << " registered" << endl;
   _registeredTriggers.push_back(theTrigger);
 }

--- a/generators/PHSartre/PHSartre.C
+++ b/generators/PHSartre/PHSartre.C
@@ -99,7 +99,7 @@ int PHSartre::Init(PHCompositeNode *topNode) {
   
 int PHSartre::End(PHCompositeNode *topNode) {
   
-  if (verbosity > 1) cout << "PHSartre::End - I'm here!" << endl;
+  if (Verbosity() > 1) cout << "PHSartre::End - I'm here!" << endl;
 
   cout << "PHSartre: " << " Total cross-section: " << _sartre->totalCrossSection() << " nb" << endl;
   _sartre->listStatus();   
@@ -127,7 +127,7 @@ void PHSartre::print_config() const {
 
 int PHSartre::process_event(PHCompositeNode *topNode) {
 
-  if (verbosity > 1) cout << "PHSartre::process_event - event: " << _eventcount << endl;
+  if (Verbosity() > 1) cout << "PHSartre::process_event - event: " << _eventcount << endl;
   
   bool passedTrigger = false;
   Event *event = NULL;
@@ -220,14 +220,14 @@ int PHSartre::process_event(PHCompositeNode *topNode) {
     // test trigger logic
     
     bool andScoreKeeper = true;
-    if (verbosity > 2) {
+    if (Verbosity() > 2) {
       cout << "PHSartre::process_event - triggersize: " << _registeredTriggers.size() << endl;
     }
 
     for (unsigned int tr = 0; tr < _registeredTriggers.size(); tr++) { 
       bool trigResult = _registeredTriggers[tr]->Apply(event);
 
-      if (verbosity > 2) {
+      if (Verbosity() > 2) {
 	cout << "PHSartre::process_event trigger: "
 	     << _registeredTriggers[tr]->GetName() << "  " << trigResult << endl;
       }
@@ -239,7 +239,7 @@ int PHSartre::process_event(PHCompositeNode *topNode) {
 	andScoreKeeper &= trigResult;
       }
       
-      if (verbosity > 2 && !passedTrigger) {
+      if (Verbosity() > 2 && !passedTrigger) {
 	cout << "PHSartre::process_event - failed trigger: "
 	     << _registeredTriggers[tr]->GetName() <<  endl;
       }
@@ -436,7 +436,7 @@ int PHSartre::process_event(PHCompositeNode *topNode) {
 
   // print outs
   
-  if (verbosity > 2) cout << "PHSartre::process_event - FINISHED WHOLE EVENT" << endl;
+  if (Verbosity() > 2) cout << "PHSartre::process_event - FINISHED WHOLE EVENT" << endl;
 
   ++_eventcount;
   return Fun4AllReturnCodes::EVENT_OK;
@@ -454,7 +454,7 @@ int PHSartre::ResetEvent(PHCompositeNode *topNode) {
 }
 
 void PHSartre::register_trigger(PHSartreGenTrigger *theTrigger) {
-  if(verbosity > 1) cout << "PHSartre::registerTrigger - trigger " << theTrigger->GetName() << " registered" << endl;
+  if(Verbosity() > 1) cout << "PHSartre::registerTrigger - trigger " << theTrigger->GetName() << " registered" << endl;
   _registeredTriggers.push_back(theTrigger);
 }
 

--- a/generators/phhepmc/Fun4AllHepMCInputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCInputManager.cc
@@ -99,9 +99,9 @@ int Fun4AllHepMCInputManager::fileopen(const string &filenam)
   filename = filenam;
   FROG frog;
   string fname(frog.location(filename.c_str()));
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
-    cout << ThisName << ": opening file " << fname << endl;
+    cout << Name() << ": opening file " << fname << endl;
   }
 
   if (readoscar)
@@ -164,7 +164,7 @@ int Fun4AllHepMCInputManager::run(const int nevents)
       if (!filelist.size())
 
       {
-        if (verbosity > 0)
+        if (Verbosity() > 0)
         {
           cout << "Fun4AllHepMCInputManager::run::" << Name() << ": No Input file open" << endl;
         }
@@ -199,7 +199,7 @@ int Fun4AllHepMCInputManager::run(const int nevents)
 
     if (!evt)
     {
-      if (verbosity > 1)
+      if (Verbosity() > 1)
       {
         cout << "Fun4AllHepMCInputManager::run::" << Name()
              << ": error type: " << ascii_in->error_type()
@@ -210,7 +210,7 @@ int Fun4AllHepMCInputManager::run(const int nevents)
     else
     {
       mySyncManager->CurrentEvent(evt->event_number());
-      if (verbosity > 0)
+      if (Verbosity() > 0)
       {
         cout << "Fun4AllHepMCInputManager::run::" << Name()
              << ": hepmc evt no: " << evt->event_number() << endl;
@@ -287,7 +287,7 @@ int Fun4AllHepMCInputManager::OpenNextFile()
   while (filelist.size() > 0)
   {
     list<string>::const_iterator iter = filelist.begin();
-    if (verbosity)
+    if (Verbosity())
     {
       cout << PHWHERE << " opening next file: " << *iter << endl;
     }
@@ -315,21 +315,21 @@ int Fun4AllHepMCInputManager::PushBackEvents(const int i)
   {
     if (i == 1 && evt)  // check on evt pointer makes sure it is not done from the cmd line
     {
-      if (verbosity > 3)
+      if (Verbosity() > 3)
       {
-        cout << ThisName << ": pushing back evt no " << evt->event_number() << endl;
+        cout << Name() << ": pushing back evt no " << evt->event_number() << endl;
       }
       save_evt = evt;
       return 0;
     }
-    cout << PHWHERE << ThisName
+    cout << PHWHERE << Name()
          << " Fun4AllHepMCInputManager cannot pop back events into file"
          << endl;
     return -1;
   }
   if (!isopen)
   {
-    cout << PHWHERE << ThisName
+    cout << PHWHERE << Name()
          << " no file opened yet" << endl;
     return -1;
   }
@@ -351,7 +351,7 @@ int Fun4AllHepMCInputManager::PushBackEvents(const int i)
     }
     else
     {
-      if (verbosity > 3)
+      if (Verbosity() > 3)
       {
         cout << "Skipping evt no: " << evt->event_number() << endl;
       }
@@ -375,7 +375,7 @@ Fun4AllHepMCInputManager::ConvertFromOscar()
   //use PHENIX unit
   evt = new HepMC::GenEvent(HepMC::Units::GEV, HepMC::Units::CM);
 
-  if (verbosity > 1) cout << "Reading Oscar Event " << events_total << endl;
+  if (Verbosity() > 1) cout << "Reading Oscar Event " << events_total << endl;
   //Grab New Event From Oscar
   string theLine;
   vector<vector<double> > theEventVec;
@@ -430,7 +430,7 @@ Fun4AllHepMCInputManager::ConvertFromOscar()
     p->suggest_barcode(i + 1);
     v->add_particle_out(p);
   }
-  if (verbosity > 3)
+  if (Verbosity() > 3)
   {
     evt->print();
   }

--- a/generators/phhepmc/Fun4AllHepMCOutputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCOutputManager.cc
@@ -99,7 +99,7 @@ Fun4AllHepMCOutputManager::~Fun4AllHepMCOutputManager()
 void
 Fun4AllHepMCOutputManager::Print(const string &what) const
 {
-  cout << ThisName << " writes " << outfilename << endl;
+  cout << Name() << " writes " << outfilename << endl;
   if (comment.size())
     {
       cout << "comment : " << comment << endl;

--- a/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
@@ -117,7 +117,7 @@ int Fun4AllHepMCPileupInputManager::run(const int nevents)
         {
           if (!filelist.size())
           {
-            if (verbosity > 0)
+            if (Verbosity() > 0)
             {
               cout << Name() << ": No Input file open" << endl;
             }
@@ -153,7 +153,7 @@ int Fun4AllHepMCPileupInputManager::run(const int nevents)
 
         if (!evt)
         {
-          if (verbosity > 1)
+          if (Verbosity() > 1)
           {
             cout << "error type: " << ascii_in->error_type()
                  << ", rdstate: " << ascii_in->rdstate() << endl;
@@ -163,7 +163,7 @@ int Fun4AllHepMCPileupInputManager::run(const int nevents)
         else
         {
           mySyncManager->CurrentEvent(evt->event_number());
-          if (verbosity > 0)
+          if (Verbosity() > 0)
           {
             cout << "hepmc evt no: " << evt->event_number() << endl;
           }

--- a/generators/phhepmc/Fun4AllOscarInputManager.cc
+++ b/generators/phhepmc/Fun4AllOscarInputManager.cc
@@ -94,9 +94,9 @@ Fun4AllOscarInputManager::fileopen(const string &filenam)
   filename = filenam;
   FROG frog;
   string fname(frog.location(filename.c_str()));
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
-      cout << ThisName << ": opening file " << fname << endl;
+      cout << Name() << ": opening file " << fname << endl;
     }
 
   TString tstr(fname);
@@ -148,7 +148,7 @@ int Fun4AllOscarInputManager::run(const int nevents)
     {
       if (!filelist.size())
 	{
-	  if (verbosity > 0)
+	  if (Verbosity() > 0)
 	    {
 	      cout << Name() << ": No Input file open" << endl;
 	    }
@@ -175,12 +175,12 @@ int Fun4AllOscarInputManager::run(const int nevents)
   */
   if (code == 1 || evt == NULL) 
     {
-      if (verbosity > 1) cout << "Finished file!" << endl;
+      if (Verbosity() > 1) cout << "Finished file!" << endl;
       fileclose();
       goto readagain;
     }
 
-//  if(verbosity > 4) cout << "SIZE: " << phhepmcgenevt->size() << endl;
+//  if(Verbosity() > 4) cout << "SIZE: " << phhepmcgenevt->size() << endl;
   //mySyncManager->CurrentEvent(evt->event_number());
   events_total++;
   events_thisfile++;
@@ -249,7 +249,7 @@ Fun4AllOscarInputManager::OpenNextFile()
   while (filelist.size() > 0)
     {
       list<string>::const_iterator iter = filelist.begin();
-      if (verbosity)
+      if (Verbosity())
 	{
 	  cout << PHWHERE << " opening next file: " << *iter << endl;
 	}
@@ -331,7 +331,7 @@ Fun4AllOscarInputManager::ConvertFromOscar()
     }
   evt = new HepMC::GenEvent(HepMC::Units::GEV, HepMC::Units::MM);
 
-  if(verbosity > 1) cout << "Reading Oscar Event " <<  events_total+skippedEvents+1 << endl;
+  if(Verbosity() > 1) cout << "Reading Oscar Event " <<  events_total+skippedEvents+1 << endl;
   //Grab New Event From Oscar
   string theLine;
   vector< vector<double> > theEventVec;
@@ -398,7 +398,7 @@ Fun4AllOscarInputManager::ConvertFromOscar()
   if(skippedEvents < skipEvents)
     {
       skippedEvents++;
-      if (verbosity > 5) cout << "Skipping event " << skippedEvents << endl;
+      if (Verbosity() > 5) cout << "Skipping event " << skippedEvents << endl;
       return 2;
     }
   */
@@ -461,8 +461,8 @@ Fun4AllOscarInputManager::ConvertFromOscar()
 
   
   evt->print();
-  if(verbosity > 5) evt->print();
-  if(verbosity > 3) cout << "Adding Event to phhepmcgenevt" << endl;
+  if(Verbosity() > 5) evt->print();
+  if(Verbosity() > 3) cout << "Adding Event to phhepmcgenevt" << endl;
 
   PHHepMCGenEventMap::Iter ievt =
       hepmc_helper.get_geneventmap()->find(hepmc_helper.get_embedding_id());

--- a/generators/phhepmc/HepMCFlowAfterBurner.cc
+++ b/generators/phhepmc/HepMCFlowAfterBurner.cc
@@ -130,7 +130,7 @@ int HepMCFlowAfterBurner::process_event(PHCompositeNode *topNode)
       cout << PHWHERE << " no evt pointer under HEPMC Node found" << endl;
       return Fun4AllReturnCodes::ABORTEVENT;
     }
-    if (verbosity > 0)
+    if (Verbosity() > 0)
     {
       cout << "calling flowAfterburner with algorithm "
            << algorithmName << ", mineta " << mineta

--- a/generators/phhepmc/PHHepMCParticleSelectorDecayProductChain.cc
+++ b/generators/phhepmc/PHHepMCParticleSelectorDecayProductChain.cc
@@ -74,7 +74,7 @@ int PHHepMCParticleSelectorDecayProductChain::process_event(PHCompositeNode *top
   HepMC::GenEvent* event = inEvent->getEvent();
   int npart = event->particles_size();
   int nvert = event->vertices_size();
-  if(verbosity > 0) cout << "=========== Event " << event->event_number() << " contains " << npart << " particles and " << nvert << " vertices." << endl;
+  if(Verbosity() > 0) cout << "=========== Event " << event->event_number() << " contains " << npart << " particles and " << nvert << " vertices." << endl;
 
   // list of vertices to keep
   vector<HepMC::GenVertex> vkeep;
@@ -156,7 +156,7 @@ int PHHepMCParticleSelectorDecayProductChain::process_event(PHCompositeNode *top
       if(!goodvertex)
 	{
 	  bool tmp = event->remove_vertex((*v));
-	  if(verbosity > 10 && tmp)
+	  if(Verbosity() > 10 && tmp)
 	    {
 	      cout << PHWHERE << " Erasing empty vertex." << endl;
 	    }
@@ -227,7 +227,7 @@ int PHHepMCParticleSelectorDecayProductChain::process_event(PHCompositeNode *top
 
 
   int partcount = 0;
-  if(verbosity > 0)
+  if(Verbosity() > 0)
     {
       cout << "FINAL Event " << event->event_number() << " contains " << event->particles_size() << " particles and " << event->vertices_size() << " vertices." << endl;
       cout << "FINAL LIST OF PARTICLES:" << endl;
@@ -240,7 +240,7 @@ int PHHepMCParticleSelectorDecayProductChain::process_event(PHCompositeNode *top
       double pt = ((*p)->momentum()).perp();
       double eta = ((*p)->momentum()).eta();
       double mass  = ((*p)->momentum()).m();
-      if(verbosity > 0)
+      if(Verbosity() > 0)
 	{
 	  cout << pid << " " << mass << " " << status << " " << pt << " " << pz << " " << eta << " " << (*p)->production_vertex() << " " << (*p)->end_vertex() << endl;
 	}
@@ -250,7 +250,7 @@ int PHHepMCParticleSelectorDecayProductChain::process_event(PHCompositeNode *top
   // if there is nothing to write out the code crashes
   if(partcount == 0)
     {
-      if(verbosity > 0)
+      if(Verbosity() > 0)
 	{
 	  cout << "EVENT ABORTED: No particles to write out." << endl;
 	}

--- a/offline/QA/modules/QAG4SimulationCalorimeter.C
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.C
@@ -105,7 +105,7 @@ QAG4SimulationCalorimeter::InitRun(PHCompositeNode *topNode)
         {
           _caloevalstack.reset( new CaloEvalStack(topNode, _calo_name));
           _caloevalstack->set_strict(true);
-          _caloevalstack->set_verbosity(verbosity + 1);
+          _caloevalstack->set_verbosity(Verbosity() + 1);
         }
       else
         {
@@ -143,21 +143,21 @@ QAG4SimulationCalorimeter::Init(PHCompositeNode *topNode)
   if (flag(kProcessG4Hit))
     {
 
-      if (verbosity >= 1)
+      if (Verbosity() >= 1)
         cout << "QAG4SimulationCalorimeter::Init - Process sampling fraction"
             << endl;
       Init_G4Hit(topNode);
     }
   if (flag(kProcessTower))
     {
-      if (verbosity >= 1)
+      if (Verbosity() >= 1)
         cout << "QAG4SimulationCalorimeter::Init - Process tower occupancies"
             << endl;
       Init_Tower(topNode);
     }
   if (flag(kProcessCluster))
     {
-      if (verbosity >= 1)
+      if (Verbosity() >= 1)
         cout << "QAG4SimulationCalorimeter::Init - Process tower occupancies"
             << endl;
       Init_Cluster(topNode);
@@ -170,7 +170,7 @@ int
 QAG4SimulationCalorimeter::process_event(PHCompositeNode *topNode)
 {
 
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     cout << "QAG4SimulationCalorimeter::process_event() entered" << endl;
 
   if (_caloevalstack)
@@ -276,7 +276,7 @@ int
 QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
 {
 
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     cout << "QAG4SimulationCalorimeter::process_event_G4Hit() entered" << endl;
 
   TH1F* h = nullptr;
@@ -306,7 +306,7 @@ QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
       _truth_container->GetMap().rbegin()->second;
   assert(last_primary);
 
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     {
       cout
           << "QAG4SimulationCalorimeter::process_event_G4Hit() handle this truth particle"
@@ -316,7 +316,7 @@ QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
   const PHG4VtxPoint* primary_vtx = //
       _truth_container->GetPrimaryVtx(last_primary->get_vtx_id());
   assert(primary_vtx);
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     {
       cout
           << "QAG4SimulationCalorimeter::process_event_G4Hit() handle this vertex"
@@ -422,7 +422,7 @@ QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
         }
     }
 
-  if (verbosity > 3)
+  if (Verbosity() > 3)
     cout << "QAG4SimulationCalorimeter::process_event_G4Hit::" << _calo_name
         << " - SF = " << e_calo / (e_calo + ea_calo + 1e-9) << ", VSF = "
         << ev_calo / (e_calo + ea_calo + 1e-9) << endl;
@@ -451,7 +451,7 @@ QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
       h->Fill(ev_calo_em / (ev_calo));
     }
 
-  if (verbosity > 3)
+  if (Verbosity() > 3)
     cout << "QAG4SimulationCalorimeter::process_event_G4Hit::" << _calo_name
         << " - histogram " << h->GetName() << " Get Sum = " << h->GetSum()
         << endl;
@@ -525,7 +525,7 @@ QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
 {
   const string detector(_calo_name);
 
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     cout << "QAG4SimulationCalorimeter::process_event_Tower() entered" << endl;
 
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
@@ -667,7 +667,7 @@ int
 QAG4SimulationCalorimeter::process_event_Cluster(PHCompositeNode *topNode)
 {
 
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     cout << "QAG4SimulationCalorimeter::process_event_Cluster() entered"
         << endl;
 
@@ -700,7 +700,7 @@ QAG4SimulationCalorimeter::process_event_Cluster(PHCompositeNode *topNode)
   PHG4Particle * last_primary = _truth_container->GetMap().rbegin()->second;
   assert(last_primary);
 
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     {
       cout
           << "QAG4SimulationCalorimeter::process_event_Cluster() handle this truth particle"
@@ -721,7 +721,7 @@ QAG4SimulationCalorimeter::process_event_Cluster(PHCompositeNode *topNode)
     {
       // has a cluster matched and best cluster selected
 
-      if (verbosity > 3)
+      if (Verbosity() > 3)
         cout << "QAG4SimulationCalorimeter::process_event_Cluster::"
             << _calo_name << " - get cluster with energy "
             << cluster->get_energy() << " VS primary energy "
@@ -735,7 +735,7 @@ QAG4SimulationCalorimeter::process_event_Cluster(PHCompositeNode *topNode)
       const PHG4VtxPoint* primary_vtx = //
           _truth_container->GetPrimaryVtx(last_primary->get_vtx_id());
       assert(primary_vtx);
-      if (verbosity > 2)
+      if (Verbosity() > 2)
         {
           cout
               << "QAG4SimulationCalorimeter::process_event_Cluster() handle this vertex"
@@ -775,7 +775,7 @@ QAG4SimulationCalorimeter::process_event_Cluster(PHCompositeNode *topNode)
     }
   else
     {
-      if (verbosity > 3)
+      if (Verbosity() > 3)
         cout << "QAG4SimulationCalorimeter::process_event_Cluster::"
             << _calo_name << " - missing cluster !";
       h->Fill(0); // no cluster matched

--- a/offline/QA/modules/QAG4SimulationCalorimeterSum.C
+++ b/offline/QA/modules/QAG4SimulationCalorimeterSum.C
@@ -80,21 +80,21 @@ QAG4SimulationCalorimeterSum::InitRun(PHCompositeNode *topNode)
           _caloevalstack_cemc.reset(
               new CaloEvalStack(topNode, _calo_name_cemc));
           _caloevalstack_cemc->set_strict(true);
-          _caloevalstack_cemc->set_verbosity(verbosity + 1);
+          _caloevalstack_cemc->set_verbosity(Verbosity() + 1);
         }
       if (!_caloevalstack_hcalin)
         {
           _caloevalstack_hcalin.reset(
               new CaloEvalStack(topNode, _calo_name_hcalin));
           _caloevalstack_hcalin->set_strict(true);
-          _caloevalstack_hcalin->set_verbosity(verbosity + 1);
+          _caloevalstack_hcalin->set_verbosity(Verbosity() + 1);
         }
       if (!_caloevalstack_hcalout)
         {
           _caloevalstack_hcalout.reset(
               new CaloEvalStack(topNode, _calo_name_hcalout));
           _caloevalstack_hcalout->set_strict(true);
-          _caloevalstack_hcalout->set_verbosity(verbosity + 1);
+          _caloevalstack_hcalout->set_verbosity(Verbosity() + 1);
         }
     }
 
@@ -104,7 +104,7 @@ QAG4SimulationCalorimeterSum::InitRun(PHCompositeNode *topNode)
         {
           _svtxevalstack.reset(new SvtxEvalStack(topNode));
           _svtxevalstack->set_strict(true);
-          _svtxevalstack->set_verbosity(verbosity + 1);
+          _svtxevalstack->set_verbosity(Verbosity() + 1);
         }
     }
   return Fun4AllReturnCodes::EVENT_OK;
@@ -139,14 +139,14 @@ QAG4SimulationCalorimeterSum::Init(PHCompositeNode *topNode)
 
 //  if (flag(kProcessTower))
 //    {
-//      if (verbosity >= 1)
+//      if (Verbosity() >= 1)
 //        cout << "QAG4SimulationCalorimeterSum::Init - Process tower occupancies"
 //            << endl;
 //      Init_Tower(topNode);
 //    }
   if (flag(kProcessCluster))
     {
-      if (verbosity >= 1)
+      if (Verbosity() >= 1)
         cout << "QAG4SimulationCalorimeterSum::Init - Process tower occupancies"
             << endl;
       Init_Cluster(topNode);
@@ -155,7 +155,7 @@ QAG4SimulationCalorimeterSum::Init(PHCompositeNode *topNode)
   if (flag(kProcessTrackProj))
     {
 
-      if (verbosity >= 1)
+      if (Verbosity() >= 1)
         cout << "QAG4SimulationCalorimeterSum::Init - Process sampling fraction"
             << endl;
       Init_TrackProj(topNode);
@@ -167,7 +167,7 @@ int
 QAG4SimulationCalorimeterSum::process_event(PHCompositeNode *topNode)
 {
 
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     cout << "QAG4SimulationCalorimeterSum::process_event() entered" << endl;
 
   if (_caloevalstack_cemc)
@@ -283,7 +283,7 @@ int
 QAG4SimulationCalorimeterSum::process_event_TrackProj(PHCompositeNode *topNode)
 {
 
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     cout << "QAG4SimulationCalorimeterSum::process_event_TrackProj() entered"
         << endl;
 
@@ -358,7 +358,7 @@ QAG4SimulationCalorimeterSum::eval_trk_proj(const string &detector, SvtxTrack * 
   const
   double radius = towergeo->get_radius() + towergeo->get_thickness() * 0.5;
 
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     {
       towergeo->identify();
     }
@@ -368,7 +368,7 @@ QAG4SimulationCalorimeterSum::eval_trk_proj(const string &detector, SvtxTrack * 
       towernodename.c_str());
   assert(towerList);
 
-  if (verbosity > 3)
+  if (Verbosity() > 3)
     {
       cout << __PRETTY_FUNCTION__ << " - info - handling track track p = ("
           << track->get_px() << ", " << track->get_py() << ", "
@@ -424,7 +424,7 @@ QAG4SimulationCalorimeterSum::eval_trk_proj(const string &detector, SvtxTrack * 
       towergeo->get_phicenter(binphi) - phi + 5 * M_PI, 2 * M_PI) - M_PI)
       / phibin_width;
 
-  if (verbosity > 3)
+  if (Verbosity() > 3)
     cout << __PRETTY_FUNCTION__ << " - info - handling track proj. (" << x
         << ", " << y << ", " << z << ")" << ", eta " << eta << ", phi" << phi
         << ", bineta " << bineta << " - ["
@@ -460,7 +460,7 @@ QAG4SimulationCalorimeterSum::eval_trk_proj(const string &detector, SvtxTrack * 
         if (ieta >= towergeo->get_etabins())
           continue;
 
-        if (verbosity > 3)
+        if (Verbosity() > 3)
           cout << __PRETTY_FUNCTION__ << " - info - processing tower"
               << ", bineta " << ieta << " - ["
               << towergeo->get_etabounds(ieta).first << ", "
@@ -472,7 +472,7 @@ QAG4SimulationCalorimeterSum::eval_trk_proj(const string &detector, SvtxTrack * 
         double energy = 0;
         if (tower)
           {
-            if (verbosity > 1)
+            if (Verbosity() > 1)
               cout << __PRETTY_FUNCTION__ << " - info - tower " << ieta << " "
                   << wrapphi << " energy = " << tower->get_energy() << endl;
 
@@ -502,7 +502,7 @@ QAG4SimulationCalorimeterSum::eval_trk_proj(const string &detector, SvtxTrack * 
 //int
 //QAG4SimulationCalorimeterSum::process_event_Tower(PHCompositeNode *topNode)
 //{
-//  if (verbosity > 2)
+//  if (Verbosity() > 2)
 //    cout << "QAG4SimulationCalorimeterSum::process_event_Tower() entered"
 //        << endl;
 //
@@ -575,7 +575,7 @@ int
 QAG4SimulationCalorimeterSum::process_event_Cluster(PHCompositeNode *topNode)
 {
 
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     cout << "QAG4SimulationCalorimeterSum::process_event_Cluster() entered"
         << endl;
 
@@ -620,7 +620,7 @@ QAG4SimulationCalorimeterSum::process_event_Cluster(PHCompositeNode *topNode)
   if (cluster_cemc_e + cluster_hcalin_e + cluster_hcalout_e > 0)
     {
 
-      if (verbosity)
+      if (Verbosity())
         {
           cout << "QAG4SimulationCalorimeterSum::process_event_Cluster - "
               << " cluster_cemc_e = " << cluster_cemc_e

--- a/offline/QA/modules/QAG4SimulationJet.C
+++ b/offline/QA/modules/QAG4SimulationJet.C
@@ -73,7 +73,7 @@ QAG4SimulationJet::InitRun(PHCompositeNode *topNode)
                   > (new JetEvalStack(topNode, reco_jet, _truth_jet));
               assert(_jetevalstacks[reco_jet]);
               _jetevalstacks[reco_jet]->set_strict(true);
-              _jetevalstacks[reco_jet]->set_verbosity(verbosity + 1);
+              _jetevalstacks[reco_jet]->set_verbosity(Verbosity() + 1);
             }
           else
             {
@@ -90,7 +90,7 @@ QAG4SimulationJet::InitRun(PHCompositeNode *topNode)
 
       assert(_jettrutheval);
       _jettrutheval->set_strict(true);
-      _jettrutheval->set_verbosity(verbosity + 1);
+      _jettrutheval->set_verbosity(Verbosity() + 1);
     }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -112,7 +112,7 @@ QAG4SimulationJet::Init(PHCompositeNode *topNode)
 
   if (flag(kProcessTruthSpectrum))
     {
-      if (verbosity >= 1)
+      if (Verbosity() >= 1)
         cout << "QAG4SimulationJet::Init - Process TruthSpectrum " << _truth_jet
             << endl;
       Init_Spectrum(topNode, _truth_jet);
@@ -124,7 +124,7 @@ QAG4SimulationJet::Init(PHCompositeNode *topNode)
           it_reco_jets != _reco_jets.end(); ++it_reco_jets)
         {
           const string & reco_jet = *it_reco_jets;
-          if (verbosity >= 1)
+          if (Verbosity() >= 1)
             cout << "QAG4SimulationJet::Init - Process Reco jet spectrum "
                 << reco_jet << endl;
           Init_Spectrum(topNode, reco_jet);
@@ -137,7 +137,7 @@ QAG4SimulationJet::Init(PHCompositeNode *topNode)
           it_reco_jets != _reco_jets.end(); ++it_reco_jets)
         {
           const string & reco_jet = *it_reco_jets;
-          if (verbosity >= 1)
+          if (Verbosity() >= 1)
             cout << "QAG4SimulationJet::Init - Process Reco jet spectrum "
                 << reco_jet << endl;
           Init_TruthMatching(topNode, reco_jet);
@@ -151,7 +151,7 @@ int
 QAG4SimulationJet::process_event(PHCompositeNode *topNode)
 {
 
-  if (verbosity > 2)
+  if (Verbosity() > 2)
     cout << "QAG4SimulationJet::process_event() entered" << endl;
 
   for (jetevalstacks_map::iterator it_jetevalstack = _jetevalstacks.begin();
@@ -165,7 +165,7 @@ QAG4SimulationJet::process_event(PHCompositeNode *topNode)
 
   if (flag(kProcessTruthSpectrum))
     {
-      if (verbosity >= 1)
+      if (Verbosity() >= 1)
         cout << "QAG4SimulationJet::process_event - Process TruthSpectrum "
             << _truth_jet << endl;
       process_Spectrum(topNode, _truth_jet, false);
@@ -177,7 +177,7 @@ QAG4SimulationJet::process_event(PHCompositeNode *topNode)
           it_reco_jets != _reco_jets.end(); ++it_reco_jets)
         {
           const string & reco_jet = *it_reco_jets;
-          if (verbosity >= 1)
+          if (Verbosity() >= 1)
             cout
                 << "QAG4SimulationJet::process_event - Process Reco jet spectrum "
                 << reco_jet << endl;
@@ -191,7 +191,7 @@ QAG4SimulationJet::process_event(PHCompositeNode *topNode)
           it_reco_jets != _reco_jets.end(); ++it_reco_jets)
         {
           const string & reco_jet = *it_reco_jets;
-          if (verbosity >= 1)
+          if (Verbosity() >= 1)
             cout
                 << "QAG4SimulationJet::process_event - Process Reco jet spectrum "
                 << reco_jet << endl;
@@ -415,7 +415,7 @@ QAG4SimulationJet::process_Spectrum(PHCompositeNode *topNode,
 
   if (leading_jet)
     {
-      if (verbosity)
+      if (Verbosity())
         {
           cout
               << "QAG4SimulationJet::process_Spectrum - processing leading jet with # comp = "
@@ -727,7 +727,7 @@ QAG4SimulationJet::process_TruthMatching(PHCompositeNode *topNode,
   // match leading truth
   if (truthjet)
     {
-      if (verbosity > 1)
+      if (Verbosity() > 1)
         {
           cout << "QAG4SimulationJet::process_TruthMatching - " << _truth_jet
               << " process truth jet ";
@@ -739,7 +739,7 @@ QAG4SimulationJet::process_TruthMatching(PHCompositeNode *topNode,
         { // inclusive best energy match
 
           const Jet* recojet = recoeval->best_jet_from(truthjet);
-          if (verbosity > 1)
+          if (Verbosity() > 1)
             {
               cout << "QAG4SimulationJet::process_TruthMatching - " << _truth_jet
                   << " inclusively matched with best reco jet: ";
@@ -787,7 +787,7 @@ QAG4SimulationJet::process_TruthMatching(PHCompositeNode *topNode,
           if (recojet)
             {
 
-              if (verbosity > 1)
+              if (Verbosity() > 1)
                 {
                   cout << "QAG4SimulationJet::process_TruthMatching - " << _truth_jet
                       << " uniquely matched with reco jet: ";
@@ -856,7 +856,7 @@ QAG4SimulationJet::process_TruthMatching(PHCompositeNode *topNode,
   // match leading reco jet
   if (recojet)
     {
-      if (verbosity > 1)
+      if (Verbosity() > 1)
         {
           cout << "QAG4SimulationJet::process_TruthMatching - " << reco_jet_name
               << " process reco jet ";

--- a/offline/framework/fun4all/Fun4AllBase.cc
+++ b/offline/framework/fun4all/Fun4AllBase.cc
@@ -6,9 +6,7 @@ using namespace std;
 
 Fun4AllBase::Fun4AllBase(const string &name):
   m_ThisName(name),
-  m_Verbosity(VERBOSITY_QUIET),
-  ThisName(name),
-  verbosity(VERBOSITY_QUIET)  
+  m_Verbosity(VERBOSITY_QUIET)
 {
   return;
 }
@@ -27,41 +25,3 @@ void Fun4AllBase::Print(const string& /*what*/) const
   cout << Name() << " did not implement Print method" << endl;
   return;
 }
-
-void
-Fun4AllBase::Name(const std::string &name)
-{
-  m_ThisName = name;
-  ThisName = name;
-}
-
-const string
-Fun4AllBase::Name() const
-{
-  m_ThisName = ThisName;
-  return m_ThisName;
-}
-
-void
-Fun4AllBase::Verbosity(const int ival)
-{
-  m_Verbosity = ival;
-  verbosity = ival;
-  return;
-}
-
-void
-Fun4AllBase::Verbosity(enu_Verbosity ival) 
-{
-  m_Verbosity = ival;
-  verbosity = ival;
-  return;
-}
-
-int
-Fun4AllBase::Verbosity() const
-{
-  m_Verbosity = verbosity;
-  return m_Verbosity;
-}
-

--- a/offline/framework/fun4all/Fun4AllBase.cc
+++ b/offline/framework/fun4all/Fun4AllBase.cc
@@ -4,9 +4,9 @@
 
 using namespace std;
 
-Fun4AllBase::Fun4AllBase(const string &name):
-  m_ThisName(name),
-  m_Verbosity(VERBOSITY_QUIET)
+Fun4AllBase::Fun4AllBase(const string& name)
+  : m_ThisName(name)
+  , m_Verbosity(VERBOSITY_QUIET)
 {
   return;
 }
@@ -14,9 +14,9 @@ Fun4AllBase::Fun4AllBase(const string &name):
 Fun4AllBase::~Fun4AllBase()
 {
   if (Verbosity() >= VERBOSITY_MORE)
-    {
-      cout << "Deleting " << Name () << endl;
-    }
+  {
+    cout << "Deleting " << Name() << endl;
+  }
   return;
 }
 

--- a/offline/framework/fun4all/Fun4AllBase.h
+++ b/offline/framework/fun4all/Fun4AllBase.h
@@ -3,8 +3,8 @@
 #ifndef FUN4ALL_FUN4ALLBASE_H
 #define FUN4ALL_FUN4ALLBASE_H
 
+#include <climits>  // std::numeric_limits
 #include <string>
-#include <climits>       // std::numeric_limits
 
 /** Base class for all Fun4All Classes
  *
@@ -14,25 +14,24 @@
 class Fun4AllBase
 {
  public:
-
-
   /** dtor. 
       Does nothing as this is a base class only.
   */
   virtual ~Fun4AllBase();
 
   /// Returns the name of this module.
-  virtual const std::string Name() const {return m_ThisName;}
+  virtual const std::string Name() const { return m_ThisName; }
 
   /// Sets the name of this module.
-  virtual void Name(const std::string &name) {m_ThisName = name;}
+  virtual void Name(const std::string &name) { m_ThisName = name; }
 
   /** Print out some info about this module. 
       @param what can be used to specify what to print exactly.
   */
   virtual void Print(const std::string &what = "ALL") const;
 
-  enum enu_Verbosity{
+  enum enu_Verbosity
+  {
 
     //! Quiet mode. Only output critical messages. Intended for batch production mode.
     VERBOSITY_QUIET = 0,
@@ -52,26 +51,25 @@ class Fun4AllBase
     // ... use your imagination ...
 
     //! Show all messages. Useful for step-by-step debugging
-    VERBOSITY_MAX =  INT_MAX - 10
+    VERBOSITY_MAX = INT_MAX - 10
 
-  } ;
-
-  /// Sets the verbosity of this module (0 by default=quiet).
-  virtual void Verbosity(const int ival) {m_Verbosity = ival;}
+  };
 
   /// Sets the verbosity of this module (0 by default=quiet).
-  virtual void Verbosity(enu_Verbosity ival) {m_Verbosity = ival;}
+  virtual void Verbosity(const int ival) { m_Verbosity = ival; }
+
+  /// Sets the verbosity of this module (0 by default=quiet).
+  virtual void Verbosity(enu_Verbosity ival) { m_Verbosity = ival; }
 
   /// Gets the verbosity of this module.
-  virtual int Verbosity() const {return m_Verbosity;}
+  virtual int Verbosity() const { return m_Verbosity; }
 
  protected:
-
   /** ctor.
   */
   Fun4AllBase(const std::string &name = "NONAME");
 
-private:
+ private:
   std::string m_ThisName;
 
   /// The verbosity level. 0 means not verbose at all.
@@ -79,4 +77,3 @@ private:
 };
 
 #endif
-

--- a/offline/framework/fun4all/Fun4AllBase.h
+++ b/offline/framework/fun4all/Fun4AllBase.h
@@ -22,10 +22,10 @@ class Fun4AllBase
   virtual ~Fun4AllBase();
 
   /// Returns the name of this module.
-  virtual const std::string Name() const;
+  virtual const std::string Name() const {return m_ThisName;}
 
   /// Sets the name of this module.
-  virtual void Name(const std::string &name);
+  virtual void Name(const std::string &name) {m_ThisName = name;}
 
   /** Print out some info about this module. 
       @param what can be used to specify what to print exactly.
@@ -57,13 +57,13 @@ class Fun4AllBase
   } ;
 
   /// Sets the verbosity of this module (0 by default=quiet).
-  virtual void Verbosity(const int ival);
+  virtual void Verbosity(const int ival) {m_Verbosity = ival;}
 
   /// Sets the verbosity of this module (0 by default=quiet).
-  virtual void Verbosity(enu_Verbosity ival);
+  virtual void Verbosity(enu_Verbosity ival) {m_Verbosity = ival;}
 
   /// Gets the verbosity of this module.
-  virtual int Verbosity() const;
+  virtual int Verbosity() const {return m_Verbosity;}
 
  protected:
 
@@ -72,15 +72,11 @@ class Fun4AllBase
   Fun4AllBase(const std::string &name = "NONAME");
 
 private:
+  std::string m_ThisName;
 
-  mutable std::string m_ThisName;
-  mutable int m_Verbosity;
-
-protected:
-  std::string ThisName;
   /// The verbosity level. 0 means not verbose at all.
-  int verbosity;
+  int m_Verbosity;
 };
 
-#endif /* __FUN4ALLBASE_H__ */
+#endif
 

--- a/offline/packages/CaloReco/RawClusterBuilderFwd.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderFwd.cc
@@ -212,7 +212,7 @@ int RawClusterBuilderFwd::process_event(PHCompositeNode *topNode)
       cluster->set_z(sum_z);
     }
 
-    if (verbosity > 1)
+    if (Verbosity() > 1)
     {
       cout << "RawClusterBuilder constucted ";
       cluster->identify();

--- a/offline/packages/CaloReco/RawClusterBuilderGraph.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderGraph.cc
@@ -232,7 +232,7 @@ int RawClusterBuilderGraph::process_event(PHCompositeNode *topNode)
       cluster->set_z(sum_z);
     }
 
-    if (verbosity > 1)
+    if (Verbosity() > 1)
     {
       cout << "RawClusterBuilderGraph constucted ";
       cluster->identify();

--- a/offline/packages/CaloReco/RawClusterPositionCorrection.cc
+++ b/offline/packages/CaloReco/RawClusterPositionCorrection.cc
@@ -39,7 +39,7 @@ int RawClusterPositionCorrection::InitRun(PHCompositeNode *topNode)
 {
   CreateNodeTree(topNode);
 
-  if (verbosity)
+  if (Verbosity())
   {
     std::cout << "RawClusterPositionCorrection is running for clusters in the EMCal with eclus parameters:" << endl;
     _eclus_calib_params.Print();
@@ -98,7 +98,7 @@ int RawClusterPositionCorrection::InitRun(PHCompositeNode *topNode)
 
 int RawClusterPositionCorrection::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity)
+  if (Verbosity())
   {
     std::cout << "Processing a NEW EVENT" << std::endl;
   }
@@ -213,9 +213,9 @@ int RawClusterPositionCorrection::process_event(PHCompositeNode *topNode)
       if (fmodeta >= binvals.at(j) && fmodeta <= binvals.at(j + 1))
         etabin = j;
 
-    if ((phibin < 0 || etabin < 0) && verbosity)
+    if ((phibin < 0 || etabin < 0) && Verbosity())
     {
-      if (verbosity)
+      if (Verbosity())
         std::cout << "couldn't recalibrate cluster, something went wrong??" << std::endl;
     }
 
@@ -231,7 +231,7 @@ int RawClusterPositionCorrection::process_event(PHCompositeNode *topNode)
     recalibcluster->set_ecore(cluster->get_ecore() / ecore_recalib_val);
     _recalib_clusters->AddCluster(recalibcluster);
 
-    if (verbosity && clus_energy > 1)
+    if (Verbosity() && clus_energy > 1)
     {
       std::cout << "Input eclus cluster energy: " << clus_energy << endl;
       std::cout << "Recalib value: " << eclus_recalib_val << endl;

--- a/offline/packages/CaloReco/RawTowerCalibration.cc
+++ b/offline/packages/CaloReco/RawTowerCalibration.cc
@@ -70,7 +70,7 @@ RawTowerCalibration::InitRun(PHCompositeNode *topNode)
 int
 RawTowerCalibration::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity)
+  if (Verbosity())
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
           << "Process event entered" << std::endl;
@@ -147,7 +147,7 @@ RawTowerCalibration::process_event(PHCompositeNode *topNode)
         }
     } //  for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
 
-  if (verbosity)
+  if (Verbosity())
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
           << "input sum energy = " << _raw_towers->getTotalEdep()
@@ -191,7 +191,7 @@ RawTowerCalibration::CreateNodes(PHCompositeNode *topNode)
               + " node in RawTowerCalibration::CreateNodes");
     }
 
-  if (verbosity >= 1)
+  if (Verbosity() >= 1)
     {
       rawtowergeom->identify();
     }

--- a/offline/packages/CaloReco/RawTowerCombiner.cc
+++ b/offline/packages/CaloReco/RawTowerCombiner.cc
@@ -82,7 +82,7 @@ RawTowerCombiner::process_event(PHCompositeNode *topNode)
   const double input_e_sum = _towers->getTotalEdep();
   const double input_n_tower = _towers->size();
 
-  if (verbosity)
+  if (Verbosity())
     {
       std::cout << __PRETTY_FUNCTION__ << "Process event entered" << std::endl;
     }
@@ -113,7 +113,7 @@ RawTowerCombiner::process_event(PHCompositeNode *topNode)
           assert(output_tower);
           new_tower_map[make_pair(output_eta, output_phi)] = output_tower;
 
-          if (verbosity >= VERBOSITY_MORE)
+          if (Verbosity() >= VERBOSITY_MORE)
             {
               std::cout << __PRETTY_FUNCTION__ << "::" << detector << "::"
                   << " new output tower (prior to tower ID assignment): ";
@@ -152,7 +152,7 @@ RawTowerCombiner::process_event(PHCompositeNode *topNode)
                   shower_iter->second);
             }
 
-          if (verbosity >= VERBOSITY_MORE)
+          if (Verbosity() >= VERBOSITY_MORE)
             {
               std::cout << __PRETTY_FUNCTION__ << "::" << detector << "::"
                   << " merget into output tower (prior to tower ID assignment) : ";
@@ -176,7 +176,7 @@ RawTowerCombiner::process_event(PHCompositeNode *topNode)
       _towers->AddTower(eta, phi, tower);
     }
 
-  if (verbosity)
+  if (Verbosity())
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
           << "input sum energy = " << input_e_sum <<" from "<<input_n_tower<< " towers, merged sum energy = "
@@ -301,7 +301,7 @@ RawTowerCombiner::CreateNodes(PHCompositeNode *topNode)
 
         towergeom->add_tower_geometry(tg);
       }
-  if (verbosity >= VERBOSITY_SOME)
+  if (Verbosity() >= VERBOSITY_SOME)
     {
       towergeom->identify();
     }

--- a/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
+++ b/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
@@ -261,7 +261,7 @@ void RawTowerDeadTowerInterp::CreateNodes(PHCompositeNode *topNode)
         "Failed to find " + geometry_node + " node in RawTowerDeadTowerInterp::CreateNodes");
   }
 
-  if (verbosity >= 1)
+  if (Verbosity() >= 1)
   {
     m_geometry->identify();
   }

--- a/offline/packages/Prototype2/CaloCalibration.C
+++ b/offline/packages/Prototype2/CaloCalibration.C
@@ -40,7 +40,7 @@ CaloCalibration::InitRun(PHCompositeNode *topNode)
 {
   CreateNodeTree(topNode);
 
-  if (verbosity)
+  if (Verbosity())
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
           << " - print calibration parameters: "<<endl;
@@ -55,7 +55,7 @@ int
 CaloCalibration::process_event(PHCompositeNode *topNode)
 {
 
-  if (verbosity)
+  if (Verbosity())
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
           << "Process event entered" << std::endl;
@@ -103,7 +103,7 @@ CaloCalibration::process_event(PHCompositeNode *topNode)
       double pedstal = NAN;
 
       PROTOTYPE2_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
-          peak_sample, pedstal, verbosity);
+          peak_sample, pedstal, Verbosity());
 
       // store the result - raw_tower
       if (std::isnan(raw_tower->get_energy()))
@@ -128,7 +128,7 @@ CaloCalibration::process_event(PHCompositeNode *topNode)
 
     } //  for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
 
-  if (verbosity)
+  if (Verbosity())
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
           << "input sum energy = " << _raw_towers->getTotalEdep()

--- a/offline/packages/Prototype2/CaloUnpackPRDF.C
+++ b/offline/packages/Prototype2/CaloUnpackPRDF.C
@@ -58,12 +58,12 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
   return -1;
  }
 
- if(verbosity)
+ if(Verbosity())
  {
   cout << PHWHERE << "Process event entered" << std::endl;
  }
 
- if(verbosity) _event->identify();
+ if(Verbosity()) _event->identify();
  _packet = dynamic_cast<Packet_hbd_fpgashort*>(_event->getPacket(PROTOTYPE2_FEM::PACKET_ID));
 
  if(!_packet)
@@ -169,7 +169,7 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
   }
  }
 
- if(verbosity)
+ if(Verbosity())
  {
    cout << "HCALIN Towers: " << endl;
    hcalin_towers_hg->identify();

--- a/offline/packages/Prototype2/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype2/GenericUnpackPRDF.C
@@ -54,7 +54,7 @@ GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::DISCARDEVENT;
     }
 
-  if (verbosity >= VERBOSITY_SOME)
+  if (Verbosity() >= VERBOSITY_SOME)
     _event->identify();
 
   map<int, Packet_hbd_fpgashort*> packet_list;

--- a/offline/packages/Prototype2/RunInfoUnpackPRDF.C
+++ b/offline/packages/Prototype2/RunInfoUnpackPRDF.C
@@ -64,7 +64,7 @@ RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
       eventheader->set_EvtSequence(event->getEvtSequence());
       eventheader->set_EvtType(event->getEvtType());
       eventheader->set_TimeStamp(event->getTime());
-      if (verbosity)
+      if (Verbosity())
         {
           eventheader->identify();
         }
@@ -75,7 +75,7 @@ RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::EVENT_OK;
   else
     {
-      if (verbosity >= VERBOSITY_SOME)
+      if (Verbosity() >= VERBOSITY_SOME)
         {
           cout << "RunInfoUnpackPRDF::process_event - with BEGRUNEVENT events ";
           event->identify();
@@ -114,7 +114,7 @@ RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
 
           const double dvalue = ivalue * info.calibration_const;
 
-          if (verbosity >= VERBOSITY_SOME)
+          if (Verbosity() >= VERBOSITY_SOME)
             {
               cout << "RunInfoUnpackPRDF::process_event - " << name << " = "
                   << dvalue << ", raw = " << ivalue << " @ packet "
@@ -133,7 +133,7 @@ RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
 
       Params.SaveToNodeTree(topNode, runinfo_node_name);
 
-      if (verbosity >= VERBOSITY_SOME)
+      if (Verbosity() >= VERBOSITY_SOME)
         Params.Print();
     }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/Prototype2/TempInfoUnpackPRDF.C
+++ b/offline/packages/Prototype2/TempInfoUnpackPRDF.C
@@ -57,7 +57,7 @@ TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
   Packet *p_hcalout;
   Packet *p_emcal;
 
-  // if (verbosity >= VERBOSITY_SOME)
+  // if (Verbosity() >= VERBOSITY_SOME)
   //   {
   //     cout << "TempInfoUnpackPRDF::process_event - ";
   //     event->identify();
@@ -81,7 +81,7 @@ TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
   int evtnr = event->getEvtSequence();
 
 
-  if (verbosity >= VERBOSITY_SOME && ( p_hcalin || p_hcalout || p_emcal) )
+  if (Verbosity() >= VERBOSITY_SOME && ( p_hcalin || p_hcalout || p_emcal) )
     {
       cout << "TempInfoUnpackPRDF::found temperature packet in Event - ";
       event->identify();
@@ -92,21 +92,21 @@ TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
   if ( p_hcalin)
     {
       addPacketInfo (p_hcalin, topNode, etime, evtnr);
-      if (verbosity > VERBOSITY_SOME) p_hcalin->dump();
+      if (Verbosity() > VERBOSITY_SOME) p_hcalin->dump();
       delete p_hcalin;
     }
 
   if ( p_hcalout)
     {
       addPacketInfo (p_hcalout, topNode, etime, evtnr);
-      if (verbosity > VERBOSITY_SOME) p_hcalout->dump();
+      if (Verbosity() > VERBOSITY_SOME) p_hcalout->dump();
       delete p_hcalout;
     }
 
   if ( p_emcal)
     {
       addPacketInfo (p_emcal, topNode, etime, evtnr);
-      if (verbosity > VERBOSITY_SOME) p_emcal->dump();
+      if (Verbosity() > VERBOSITY_SOME) p_emcal->dump();
       delete p_emcal;
     }
 

--- a/offline/packages/Prototype3/CaloCalibration.C
+++ b/offline/packages/Prototype3/CaloCalibration.C
@@ -40,7 +40,7 @@ CaloCalibration::InitRun(PHCompositeNode *topNode)
 {
   CreateNodeTree(topNode);
 
-  if (verbosity)
+  if (Verbosity())
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
           << " - print calibration parameters: "<<endl;
@@ -55,7 +55,7 @@ int
 CaloCalibration::process_event(PHCompositeNode *topNode)
 {
 
-  if (verbosity)
+  if (Verbosity())
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
           << "Process event entered" << std::endl;
@@ -103,7 +103,7 @@ CaloCalibration::process_event(PHCompositeNode *topNode)
       double pedstal = NAN;
 
       PROTOTYPE3_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
-          peak_sample, pedstal, verbosity);
+          peak_sample, pedstal, Verbosity());
 
       // store the result - raw_tower
       if (std::isnan(raw_tower->get_energy()))
@@ -128,7 +128,7 @@ CaloCalibration::process_event(PHCompositeNode *topNode)
 
     } //  for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
 
-  if (verbosity)
+  if (Verbosity())
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
           << "input sum energy = " << _raw_towers->getTotalEdep()

--- a/offline/packages/Prototype3/CaloUnpackPRDF.C
+++ b/offline/packages/Prototype3/CaloUnpackPRDF.C
@@ -84,12 +84,12 @@ CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
     run_info_copy.FillFrom(info);
     emcal_is_higheta = run_info_copy.get_int_param("EMCAL_Is_HighEta");
   }
-  if (verbosity)
+  if (Verbosity())
     {
       cout << PHWHERE << "Process event entered" << std::endl;
     }
 
-  if (verbosity)
+  if (Verbosity())
     _event->identify();
   _packet = dynamic_cast<Packet_hbd_fpgashort*>(_event->getPacket(
       PROTOTYPE3_FEM::PACKET_ID));
@@ -214,7 +214,7 @@ CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
         }
     }
 
-  if (verbosity)
+  if (Verbosity())
     {
       cout << "HCALIN Towers: " << endl;
       hcalin_towers_hg->identify();

--- a/offline/packages/Prototype3/EventInfoSummary.C
+++ b/offline/packages/Prototype3/EventInfoSummary.C
@@ -65,7 +65,7 @@ EventInfoSummary::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::EVENT_OK;
   else // DATAEVENT
     {
-      if (verbosity >= VERBOSITY_SOME)
+      if (Verbosity() >= VERBOSITY_SOME)
         {
           cout << "EventInfoSummary::process_event - with DATAEVENT events ";
           event->identify();
@@ -226,7 +226,7 @@ EventInfoSummary::process_event(PHCompositeNode *topNode)
 
           const double dvalue = ivalue * info.calibration_const;
 
-          if (verbosity >= VERBOSITY_SOME)
+          if (Verbosity() >= VERBOSITY_SOME)
             {
               cout << "EventInfoSummary::process_event - " << name << " = "
                   << dvalue << ", raw = " << ivalue << " @ packet "
@@ -245,7 +245,7 @@ EventInfoSummary::process_event(PHCompositeNode *topNode)
 
       Params.SaveToNodeTree(topNode, eventinfo_node_name);
 
-      if (verbosity >= VERBOSITY_SOME)
+      if (Verbosity() >= VERBOSITY_SOME)
         Params.Print();
     }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/Prototype3/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype3/GenericUnpackPRDF.C
@@ -54,7 +54,7 @@ GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::DISCARDEVENT;
     }
 
-  if (verbosity >= VERBOSITY_SOME)
+  if (Verbosity() >= VERBOSITY_SOME)
     _event->identify();
 
   map<int, Packet_hbd_fpgashort*> packet_list;

--- a/offline/packages/Prototype3/RunInfoUnpackPRDF.C
+++ b/offline/packages/Prototype3/RunInfoUnpackPRDF.C
@@ -64,7 +64,7 @@ RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
       eventheader->set_EvtSequence(event->getEvtSequence());
       eventheader->set_EvtType(event->getEvtType());
       eventheader->set_TimeStamp(event->getTime());
-      if (verbosity)
+      if (Verbosity())
         {
           eventheader->identify();
         }
@@ -75,7 +75,7 @@ RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::EVENT_OK;
   else
     {
-      if (verbosity >= VERBOSITY_SOME)
+      if (Verbosity() >= VERBOSITY_SOME)
         {
           cout << "RunInfoUnpackPRDF::process_event - with BEGRUNEVENT events ";
           event->identify();
@@ -130,7 +130,7 @@ RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
 
           const double dvalue = ivalue * info.calibration_const;
 
-          if (verbosity >= VERBOSITY_SOME)
+          if (Verbosity() >= VERBOSITY_SOME)
             {
               cout << "RunInfoUnpackPRDF::process_event - " << name << " = "
                   << dvalue << ", raw = " << ivalue << " @ packet "
@@ -149,7 +149,7 @@ RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
 
       Params.SaveToNodeTree(topNode, runinfo_node_name);
 
-      if (verbosity >= VERBOSITY_SOME)
+      if (Verbosity() >= VERBOSITY_SOME)
         Params.Print();
     }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/Prototype3/TempInfoUnpackPRDF.C
+++ b/offline/packages/Prototype3/TempInfoUnpackPRDF.C
@@ -57,7 +57,7 @@ TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
   Packet *p_hcalout;
   Packet *p_emcal;
 
-  // if (verbosity >= VERBOSITY_SOME)
+  // if (Verbosity() >= VERBOSITY_SOME)
   //   {
   //     cout << "TempInfoUnpackPRDF::process_event - ";
   //     event->identify();
@@ -81,7 +81,7 @@ TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
   int evtnr = event->getEvtSequence();
 
 
-  if (verbosity >= VERBOSITY_SOME && ( p_hcalin || p_hcalout || p_emcal) )
+  if (Verbosity() >= VERBOSITY_SOME && ( p_hcalin || p_hcalout || p_emcal) )
     {
       cout << "TempInfoUnpackPRDF::found temperature packet in Event - ";
       event->identify();
@@ -92,21 +92,21 @@ TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
   if ( p_hcalin)
     {
       addPacketInfo (p_hcalin, topNode, etime, evtnr);
-      if (verbosity > VERBOSITY_SOME) p_hcalin->dump();
+      if (Verbosity() > VERBOSITY_SOME) p_hcalin->dump();
       delete p_hcalin;
     }
 
   if ( p_hcalout)
     {
       addPacketInfo (p_hcalout, topNode, etime, evtnr);
-      if (verbosity > VERBOSITY_SOME) p_hcalout->dump();
+      if (Verbosity() > VERBOSITY_SOME) p_hcalout->dump();
       delete p_hcalout;
     }
 
   if ( p_emcal)
     {
       addPacketInfo (p_emcal, topNode, etime, evtnr);
-      if (verbosity > VERBOSITY_SOME) p_emcal->dump();
+      if (Verbosity() > VERBOSITY_SOME) p_emcal->dump();
       delete p_emcal;
     }
 

--- a/offline/packages/Prototype4/CaloCalibration.C
+++ b/offline/packages/Prototype4/CaloCalibration.C
@@ -43,7 +43,7 @@ int CaloCalibration::InitRun(PHCompositeNode *topNode)
 {
   CreateNodeTree(topNode);
 
-  if (verbosity)
+  if (Verbosity())
   {
     std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
               << " - print calibration parameters: " << endl;
@@ -56,7 +56,7 @@ int CaloCalibration::InitRun(PHCompositeNode *topNode)
 //____________________________________
 int CaloCalibration::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity)
+  if (Verbosity())
   {
     std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
               << "Process event entered" << std::endl;
@@ -65,7 +65,7 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
   map<int, double> parameters_constraints;
   if (_fit_type == kPowerLawDoubleExpWithGlobalFitConstraint and _raw_towers->size() > 1)
   {
-    if (verbosity)
+    if (Verbosity())
     {
       std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
                 << "Extract global fit parameter for constraining individual fits" << std::endl;
@@ -122,7 +122,7 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
       map<int, double> parameters_io;
 
       PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(vec_signal_samples, peak,
-                                                  peak_sample, pedstal, parameters_io, verbosity);
+                                                  peak_sample, pedstal, parameters_io, Verbosity());
       //    std::map<int, double> &parameters_io,  //! IO for fullset of parameters. If a parameter exist and not an NAN, the fit parameter will be fixed to that value. The order of the parameters are
       //    ("Amplitude", "Sample Start", "Power", "Peak Time 1", "Pedestal", "Amplitude ratio", "Peak Time 2")
 
@@ -200,12 +200,12 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
     {
     case kPowerLawExp:
       PROTOTYPE4_FEM::SampleFit_PowerLawExp(vec_signal_samples, peak,
-                                            peak_sample, pedstal, verbosity);
+                                            peak_sample, pedstal, Verbosity());
       break;
 
     case kPeakSample:
       PROTOTYPE4_FEM::SampleFit_PeakSample(vec_signal_samples, peak,
-                                           peak_sample, pedstal, verbosity);
+                                           peak_sample, pedstal, Verbosity());
       break;
 
     case kPowerLawDoubleExp:
@@ -213,7 +213,7 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
       map<int, double> parameters_io;
 
       PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(vec_signal_samples, peak,
-                                                  peak_sample, pedstal, parameters_io, verbosity);
+                                                  peak_sample, pedstal, parameters_io, Verbosity());
     }
     break;
 
@@ -222,7 +222,7 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
       map<int, double> parameters_io(parameters_constraints);
 
       PROTOTYPE4_FEM::SampleFit_PowerLawDoubleExp(vec_signal_samples, peak,
-                                                  peak_sample, pedstal, parameters_io, verbosity);
+                                                  peak_sample, pedstal, parameters_io, Verbosity());
     }
     break;
     default:
@@ -239,7 +239,7 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
       raw_tower->set_energy(peak);
       raw_tower->set_time(peak_sample);
 
-      if (verbosity)
+      if (Verbosity())
       {
         raw_tower->identify();
       }
@@ -259,7 +259,7 @@ int CaloCalibration::process_event(PHCompositeNode *topNode)
 
   }  //  for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
 
-  if (verbosity)
+  if (Verbosity())
   {
     std::cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
               << "input sum energy = " << _raw_towers->getTotalEdep()

--- a/offline/packages/Prototype4/CaloUnpackPRDF.C
+++ b/offline/packages/Prototype4/CaloUnpackPRDF.C
@@ -70,12 +70,12 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
     return -1;
   }
 
-  if (verbosity)
+  if (Verbosity())
   {
     cout << PHWHERE << "Process event entered" << std::endl;
   }
 
-  if (verbosity)
+  if (Verbosity())
     _event->identify();
 
   _packet = _event->getPacket(PROTOTYPE4_FEM::PACKET_ID);
@@ -195,7 +195,7 @@ int CaloUnpackPRDF::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity)
+  if (Verbosity())
   {
     cout << "HCALIN Towers: " << endl;
     hcalin_towers_hg->identify();

--- a/offline/packages/Prototype4/EventInfoSummary.C
+++ b/offline/packages/Prototype4/EventInfoSummary.C
@@ -63,7 +63,7 @@ int EventInfoSummary::process_event(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::EVENT_OK;
   else  // DATAEVENT
   {
-    if (verbosity >= VERBOSITY_SOME)
+    if (Verbosity() >= VERBOSITY_SOME)
     {
       cout << "EventInfoSummary::process_event - with DATAEVENT events ";
       event->identify();
@@ -220,7 +220,7 @@ int EventInfoSummary::process_event(PHCompositeNode* topNode)
 
       const double dvalue = ivalue * info.calibration_const;
 
-      if (verbosity >= VERBOSITY_SOME)
+      if (Verbosity() >= VERBOSITY_SOME)
       {
         cout << "EventInfoSummary::process_event - " << name << " = "
              << dvalue << ", raw = " << ivalue << " @ packet "
@@ -239,7 +239,7 @@ int EventInfoSummary::process_event(PHCompositeNode* topNode)
 
     Params.SaveToNodeTree(topNode, eventinfo_node_name);
 
-    if (verbosity >= VERBOSITY_SOME)
+    if (Verbosity() >= VERBOSITY_SOME)
       Params.Print();
   }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/Prototype4/GenericUnpackPRDF.C
+++ b/offline/packages/Prototype4/GenericUnpackPRDF.C
@@ -53,7 +53,7 @@ int GenericUnpackPRDF::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::DISCARDEVENT;
   }
 
-  if (verbosity >= VERBOSITY_SOME)
+  if (Verbosity() >= VERBOSITY_SOME)
     _event->identify();
 
   // search for data event

--- a/offline/packages/Prototype4/RunInfoUnpackPRDF.C
+++ b/offline/packages/Prototype4/RunInfoUnpackPRDF.C
@@ -62,7 +62,7 @@ int RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
     eventheader->set_EvtSequence(event->getEvtSequence());
     eventheader->set_EvtType(event->getEvtType());
     eventheader->set_TimeStamp(event->getTime());
-    if (verbosity)
+    if (Verbosity())
     {
       eventheader->identify();
     }
@@ -73,7 +73,7 @@ int RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::EVENT_OK;
   else
   {
-    if (verbosity >= VERBOSITY_SOME)
+    if (Verbosity() >= VERBOSITY_SOME)
     {
       cout << "RunInfoUnpackPRDF::process_event - with BEGRUNEVENT events ";
       event->identify();
@@ -128,7 +128,7 @@ int RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
 
       const double dvalue = ivalue * info.calibration_const;
 
-      if (verbosity >= VERBOSITY_SOME)
+      if (Verbosity() >= VERBOSITY_SOME)
       {
         cout << "RunInfoUnpackPRDF::process_event - " << name << " = "
              << dvalue << ", raw = " << ivalue << " @ packet "
@@ -147,7 +147,7 @@ int RunInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
 
     Params.SaveToNodeTree(topNode, runinfo_node_name);
 
-    if (verbosity >= VERBOSITY_SOME)
+    if (Verbosity() >= VERBOSITY_SOME)
       Params.Print();
   }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/Prototype4/TempInfoUnpackPRDF.C
+++ b/offline/packages/Prototype4/TempInfoUnpackPRDF.C
@@ -56,7 +56,7 @@ int TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
   Packet *p_hcalout;
   Packet *p_emcal;
 
-  // if (verbosity >= VERBOSITY_SOME)
+  // if (Verbosity() >= VERBOSITY_SOME)
   //   {
   //     cout << "TempInfoUnpackPRDF::process_event - ";
   //     event->identify();
@@ -78,7 +78,7 @@ int TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
   time_t etime = event->getTime();
   int evtnr = event->getEvtSequence();
 
-  if (verbosity >= VERBOSITY_SOME && (p_hcalin || p_hcalout || p_emcal))
+  if (Verbosity() >= VERBOSITY_SOME && (p_hcalin || p_hcalout || p_emcal))
   {
     cout << "TempInfoUnpackPRDF::found temperature packet in Event - ";
     event->identify();
@@ -87,21 +87,21 @@ int TempInfoUnpackPRDF::process_event(PHCompositeNode *topNode)
   if (p_hcalin)
   {
     addPacketInfo(p_hcalin, topNode, etime, evtnr);
-    if (verbosity > VERBOSITY_SOME) p_hcalin->dump();
+    if (Verbosity() > VERBOSITY_SOME) p_hcalin->dump();
     delete p_hcalin;
   }
 
   if (p_hcalout)
   {
     addPacketInfo(p_hcalout, topNode, etime, evtnr);
-    if (verbosity > VERBOSITY_SOME) p_hcalout->dump();
+    if (Verbosity() > VERBOSITY_SOME) p_hcalout->dump();
     delete p_hcalout;
   }
 
   if (p_emcal)
   {
     addPacketInfo(p_emcal, topNode, etime, evtnr);
-    if (verbosity > VERBOSITY_SOME) p_emcal->dump();
+    if (Verbosity() > VERBOSITY_SOME) p_emcal->dump();
     delete p_emcal;
   }
 

--- a/offline/packages/jetbackground/CopyAndSubtractJets.C
+++ b/offline/packages/jetbackground/CopyAndSubtractJets.C
@@ -40,7 +40,7 @@ CopyAndSubtractJets::~CopyAndSubtractJets()
 
 int CopyAndSubtractJets::Init(PHCompositeNode *topNode)
 {
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     std::cout << "CopyAndSubtractJets::Init: initialized" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -56,7 +56,7 @@ int CopyAndSubtractJets::InitRun(PHCompositeNode *topNode)
 
 int CopyAndSubtractJets::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     std::cout << "CopyAndSubtractJets::process_event: entering, with _use_flow_modulation = " << _use_flow_modulation << std::endl;
 
   // pull out needed calo tower info
@@ -80,7 +80,7 @@ int CopyAndSubtractJets::process_event(PHCompositeNode *topNode)
   float background_v2 = background->get_v2();
   float background_Psi2 = background->get_Psi2();
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     std::cout << "CopyAndSubtractJets::process_event: entering with # unsubtracted jets = " << unsub_jets->size() << std::endl;
     std::cout << "CopyAndSubtractJets::process_event: entering with # subtracted jets = " << sub_jets->size() << std::endl;
   }
@@ -104,7 +104,7 @@ int CopyAndSubtractJets::process_event(PHCompositeNode *topNode)
 
     //if (this_jet->get_pt() < 5) continue;
     
-    if (verbosity > 1 && this_jet->get_pt() >  5)
+    if (Verbosity() > 1 && this_jet->get_pt() >  5)
       std::cout << "CopyAndSubtractJets::process_event: unsubtracted jet with pt / eta / phi = " << this_pt << " / " << this_eta << " / " << this_phi << std::endl;
     
     for (Jet::ConstIter comp = this_jet->begin_comp(); comp !=  this_jet->end_comp(); ++comp) {
@@ -149,14 +149,14 @@ int CopyAndSubtractJets::process_event(PHCompositeNode *topNode)
 	comp_phi = tower_geom->get_phi();
       }
       
-      if (verbosity > 4 && this_jet->get_pt() > 5) {
+      if (Verbosity() > 4 && this_jet->get_pt() > 5) {
 	std::cout << "CopyAndSubtractJets::process_event: --> constituent in layer " << (*comp).first << ", has unsub E = " << comp_e << ", is at ieta #" << comp_ieta << ", and has UE = " << comp_background << std::endl;
       }
 
       // flow modulate background if turned on
       if ( _use_flow_modulation ) {
 	comp_background = comp_background * ( 1 + 2 * background_v2 * cos( 2 * ( comp_phi - background_Psi2 ) ) );
-	if (verbosity > 4 && this_jet->get_pt() > 5)
+	if (Verbosity() > 4 && this_jet->get_pt() > 5)
 	  std::cout << "CopyAndSubtractJets::process_event: --> --> flow mod, at phi = " << comp_phi << ", v2 and Psi2 are = " << background_v2 << " , " << background_Psi2 << ", UE after modulation = " << comp_background << std::endl;
 	
       }
@@ -184,7 +184,7 @@ int CopyAndSubtractJets::process_event(PHCompositeNode *topNode)
 
     sub_jets->insert( new_jet );
 
-    if (verbosity > 1 && this_pt > 5) {
+    if (Verbosity() > 1 && this_pt > 5) {
       std::cout << "CopyAndSubtractJets::process_event: old jet #" << ijet << ", old px / py / pz / e = " << this_jet->get_px() << " / " << this_jet->get_py() << " / " << this_jet->get_pz() << " / " << this_jet->get_e() << std::endl;
       std::cout << "CopyAndSubtractJets::process_event: new jet #" << ijet << ", new px / py / pz / e = " << new_jet->get_px() << " / " << new_jet->get_py() << " / " << new_jet->get_pz() << " / " << new_jet->get_e() << std::endl;
     }
@@ -193,7 +193,7 @@ int CopyAndSubtractJets::process_event(PHCompositeNode *topNode)
       
   }	
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     std::cout << "CopyAndSubtractJets::process_event: exiting with # subtracted jets = " << sub_jets->size() << std::endl;
   }
 
@@ -234,7 +234,7 @@ int CopyAndSubtractJets::CreateNode(PHCompositeNode *topNode)
   JetMap* test_jets = findNode::getClass<JetMap>(topNode,"AntiKt_Tower_HIRecoSeedsSub_r02");
   if ( !test_jets ) {
 
-    if (verbosity > 0) std::cout << "CopyAndSubtractJets::CreateNode : creating AntiKt_Tower_HIRecoSeedsSub_r02 node " << std::endl;
+    if (Verbosity() > 0) std::cout << "CopyAndSubtractJets::CreateNode : creating AntiKt_Tower_HIRecoSeedsSub_r02 node " << std::endl;
     
     JetMap *sub_jets = new JetMapV1();
     PHIODataNode<PHObject> *subjetNode = new PHIODataNode<PHObject>( sub_jets, "AntiKt_Tower_HIRecoSeedsSub_r02", "PHObject");

--- a/offline/packages/jetbackground/DetermineTowerBackground.C
+++ b/offline/packages/jetbackground/DetermineTowerBackground.C
@@ -73,7 +73,7 @@ void DetermineTowerBackground::SetSeedType( int seed_type ) {
 
 int DetermineTowerBackground::Init(PHCompositeNode *topNode)
 {
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     std::cout << "DetermineTowerBackground::Init: initialized" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -86,7 +86,7 @@ int DetermineTowerBackground::InitRun(PHCompositeNode *topNode)
 
 int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     std::cout << "DetermineTowerBackground::process_event: entering with do_flow = " << _do_flow << ", seed type = " << _seed_type << ", ";
     if ( _seed_type == 0 ) std::cout << " D = " << _seed_jet_D << std::endl;
     else if ( _seed_type == 1 ) std::cout << " pT = " << _seed_jet_pt << std::endl;
@@ -101,7 +101,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
   RawTowerContainer *towersEM3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC_RETOWER");
   RawTowerContainer *towersIH3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALIN");
   RawTowerContainer *towersOH3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALOUT");
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     std::cout << "DetermineTowerBackground::process_event: " << towersEM3->size() << " TOWER_CALIB_CEMC_RETOWER towers" << std::endl;
     std::cout << "DetermineTowerBackground::process_event: " << towersIH3->size() << " TOWER_CALIB_HCALIN towers" << std::endl;
     std::cout << "DetermineTowerBackground::process_event: " << towersOH3->size() << " TOWER_CALIB_HCALOUT towers" << std::endl;
@@ -114,7 +114,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
   if (_seed_type == 0) {
     JetMap* reco2_jets = findNode::getClass<JetMap>(topNode,"AntiKt_Tower_HIRecoSeedsRaw_r02");
 
-    if (verbosity > 1)
+    if (Verbosity() > 1)
       std::cout << "DetermineTowerBackground::process_event: examining possible seeds (1st iteration) ... " << std::endl;
 
     for (JetMap::Iter iter = reco2_jets->begin(); iter != reco2_jets->end(); ++iter) {
@@ -127,7 +127,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 
       if (this_jet->get_pt() < 5) continue;
 
-      if (verbosity > 2)
+      if (Verbosity() > 2)
 	std::cout << "DetermineTowerBackground::process_event: possible seed jet with pt / eta / phi = " << this_pt << " / " << this_eta << " / " << this_phi << ", examining constituents..." << std::endl;
 
       std::map< int, double > constituent_ETsum;
@@ -168,12 +168,12 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 
 	int comp_ikey = 1000 * comp_ieta + comp_iphi;
 
-	if (verbosity > 4)
+	if (Verbosity() > 4)
 	  std::cout << "DetermineTowerBackground::process_event: --> --> constituent in layer " << (*comp).first << " at ieta / iphi = " << comp_ieta << " / " << comp_iphi << ", filling map with key = " << comp_ikey << " and ET = " << comp_ET << std::endl;
 
 	constituent_ETsum[ comp_ikey ] += comp_ET;
 
-	if (verbosity > 4)
+	if (Verbosity() > 4)
 	  std::cout << "DetermineTowerBackground::process_event: --> --> ET sum map at key = " << comp_ikey << " now has ET = " << constituent_ETsum[ comp_ikey ] << std::endl;
 	
       }
@@ -183,10 +183,10 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       float constituent_sum_ET = 0;
       int nconstituents = 0;
       
-      if (verbosity > 4)
+      if (Verbosity() > 4)
 	std::cout << "DetermineTowerBackground::process_event: --> now iterating over map..." << std::endl;
       for (std::map<int,double>::iterator map_iter = constituent_ETsum.begin(); map_iter != constituent_ETsum.end(); ++map_iter) {
-	if (verbosity > 4)
+	if (Verbosity() > 4)
 	  std::cout << "DetermineTowerBackground::process_event: --> --> map has key # " << map_iter->first << " and ET = " << map_iter->second << std::endl;
 	nconstituents++;
 	constituent_sum_ET +=  map_iter->second;
@@ -196,17 +196,17 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       float mean_constituent_ET = constituent_sum_ET / nconstituents;
       float seed_D = constituent_max_ET / mean_constituent_ET;
       
-      if (verbosity > 3)
+      if (Verbosity() > 3)
 	std::cout << "DetermineTowerBackground::process_event: --> jet has < ET > = " << constituent_sum_ET << " / " << nconstituents << " = " << mean_constituent_ET << ", max-ET = " << constituent_max_ET << ", and D = " << seed_D << std::endl;
       
       if ( seed_D > _seed_jet_D ) {
 	_seed_eta.push_back( this_eta );
 	_seed_phi.push_back( this_phi );
 	
-	if (verbosity > 1)
+	if (Verbosity() > 1)
 	  std::cout << "DetermineTowerBackground::process_event: --> adding seed at eta / phi = " << this_eta << " / " << this_phi << " ( R=0.2 jet with pt = " << this_pt << ", D = " << seed_D << " ) " << std::endl;
       } else {
-	if (verbosity > 3)
+	if (Verbosity() > 3)
 	  std::cout << "DetermineTowerBackground::process_event: --> discarding potential seed at eta / phi = " << this_eta << " / " << this_phi << " ( R=0.2 jet with pt = " << this_pt << ", D = " << seed_D << " ) " << std::endl;
       }
       
@@ -220,7 +220,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
   if (_seed_type == 1) {
     JetMap* reco2_jets = findNode::getClass<JetMap>(topNode,"AntiKt_Tower_HIRecoSeedsSub_r02");
 
-    if (verbosity > 1)
+    if (Verbosity() > 1)
       std::cout << "DetermineTowerBackground::process_event: examining possible seeds (2nd iteration) ... " << std::endl;
     
     for (JetMap::Iter iter = reco2_jets->begin(); iter != reco2_jets->end(); ++iter) {
@@ -235,7 +235,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       _seed_eta.push_back( this_eta );
       _seed_phi.push_back( this_phi );
 
-      if (verbosity > 1)
+      if (Verbosity() > 1)
 	std::cout << "DetermineTowerBackground::process_event: --> adding seed at eta / phi = " << this_eta << " / " << this_phi << " ( R=0.2 jet with pt = " << this_pt << " ) " << std::endl;
     }
     
@@ -263,7 +263,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
     _FULLCALOFLOW_PHI_E.resize( _HCAL_NPHI, 0 );
     _FULLCALOFLOW_PHI_VAL.resize( _HCAL_NPHI, 0 );
 
-    if (verbosity > 0) {
+    if (Verbosity() > 0) {
       std::cout << "DetermineTowerBackground::process_event: setting number of towers in eta / phi: " << _HCAL_NETA << " / " << _HCAL_NPHI << std::endl;
     }
 
@@ -298,7 +298,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 
     _EMCAL_E[ this_etabin ][ this_phibin ] += this_E;
     
-    if (verbosity > 2 && tower->get_energy() > 1)
+    if (Verbosity() > 2 && tower->get_energy() > 1)
       {
 	std::cout << "DetermineTowerBackground::process_event: EMCal tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << this_etabin << " ) / " << this_phi << " ( " << this_phibin << " ) / " << this_E << std::endl;
       }
@@ -319,7 +319,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 
     _IHCAL_E[ this_etabin ][ this_phibin ] += this_E;
 
-    if (verbosity > 2 && tower->get_energy() > 1)
+    if (Verbosity() > 2 && tower->get_energy() > 1)
     {
       std::cout << "DetermineTowerBackground::process_event: IHCal tower at eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << this_etabin << " ) / " << this_phi << " ( " << this_phibin << " ) / " << this_E << std::endl;
     }
@@ -340,7 +340,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 
     _OHCAL_E[ this_etabin ][ this_phibin ] += this_E;
 
-    if (verbosity > 2 && tower->get_energy() > 1)
+    if (Verbosity() > 2 && tower->get_energy() > 1)
     {
       std::cout << "DetermineTowerBackground::process_event: OHCal tower at eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << this_etabin << " ) / " << this_phi << " ( " << this_phibin << " ) / " << this_E << std::endl;
     }
@@ -380,7 +380,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 	    float dR = sqrt( pow( deta, 2 ) + pow( dphi, 2 ) );
 	    if (dR < 0.4) {
 	      isExcluded = true;
-	      if (verbosity > 10) std::cout << " setting excluded mark from seed at eta / phi = " << _seed_eta[ iseed ] << " / " << _seed_phi[ iseed ] << std::endl;
+	      if (Verbosity() > 10) std::cout << " setting excluded mark from seed at eta / phi = " << _seed_eta[ iseed ] << " / " << _seed_phi[ iseed ] << std::endl;
 	    }
 	  }
 	  
@@ -393,7 +393,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 	// if this eta strip can be used for flow determination, fill it now
 	if (!isAnyTowerExcluded) {
 	  
-	  if ( verbosity > 4) 
+	  if ( Verbosity() > 4) 
 	    std::cout << " strip at layer " << layer << ", eta " << eta << " has no excluded towers and can be used for flow determination " << std::endl;
 	  nStripsAvailableForFlow++;
 	  
@@ -409,7 +409,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 	  }
 	  
 	} else {
-	  if ( verbosity > 4) 
+	  if ( Verbosity() > 4) 
 	    std::cout << " strip at layer " << layer << ", eta " << eta << " DOES have excluded towers and CANNOT be used for flow determination " << std::endl;
 	  nStripsUnavailableForFlow++;
 	}
@@ -425,7 +425,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
     
     float sum_cos2dphi = 0;
     
-    if (verbosity > 0 )
+    if (Verbosity() > 0 )
       std::cout << "DetermineTowerBackground::process_event: # of strips (summed over layers) available / unavailable for flow determination: " << nStripsAvailableForFlow << " / " << nStripsUnavailableForFlow << std::endl;
     
     if ( nStripsAvailableForFlow > 0 ) { 
@@ -450,18 +450,18 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
     } else {
       _Psi2 = 0;
       _v2 = 0;
-      if (verbosity > 0 )
+      if (Verbosity() > 0 )
 	std::cout << "DetermineTowerBackground::process_event: no full strips available for flow modulation, setting v2 and Psi = 0" << std::endl;
     }
 
-    if (verbosity > 0 ) {
+    if (Verbosity() > 0 ) {
       
       std::cout << "DetermineTowerBackground::process_event: unnormalized Q vector (Qx, Qy) = ( " << Q_x << ", " << Q_y << " ) with Sum E_i = " << E << std::endl;
       std::cout << "DetermineTowerBackground::process_event: Psi2 = " << _Psi2 << " ( " << _Psi2 / 3.14159 << " * pi ) , v2 = " << _v2 << std::endl;
     }
   } // if do flow
   else {
-    if (verbosity > 0 ) {
+    if (Verbosity() > 0 ) {
       std::cout << "DetermineTowerBackground::process_event: flow not enabled, setting Psi2 = " << _Psi2 << " ( " << _Psi2 / 3.14159 << " * pi ) , v2 = " << _v2 << std::endl;
     }
   }
@@ -494,7 +494,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 	  float dR = sqrt( pow( deta, 2 ) + pow( dphi, 2 ) );
 	  if (dR < 0.4) {
 	    isExcluded = true;
-	    if (verbosity > 10) std::cout << " setting excluded mark from seed at eta / phi = " << _seed_eta[ iseed ] << " / " << _seed_phi[ iseed ] << std::endl;
+	    if (Verbosity() > 10) std::cout << " setting excluded mark from seed at eta / phi = " << _seed_eta[ iseed ] << " / " << _seed_phi[ iseed ] << std::endl;
 	  }
 	}
 
@@ -504,7 +504,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 	  if ( layer == 2 ) total_E += _OHCAL_E[ eta ][ phi ] / ( 1 + 2 * _v2 * cos( 2 * ( this_phi - _Psi2 ) ) );
 	  total_tower++;
 	} else {
-	  if (verbosity > 10) std::cout << " tower at eta / phi = " << this_eta << " / " << this_phi << " with E = " << total_E << " excluded due to seed " << std::endl;
+	  if (Verbosity() > 10) std::cout << " tower at eta / phi = " << this_eta << " / " << this_phi << " with E = " << total_E << " excluded due to seed " << std::endl;
 	}
 
       }
@@ -517,14 +517,14 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       float total_area = total_tower * deta * dphi;
       _UE[ layer ].at( eta ) = total_E / total_tower;
       
-      if (verbosity > 3 ) {
+      if (Verbosity() > 3 ) {
 	std::cout << "DetermineTowerBackground::process_event: at layer / eta index ( eta range ) = " << layer << " / " << eta << " ( " << etabounds.first << " - " << etabounds.second << " ) , total E / total Ntower / total area = " << total_E << " / " << total_tower << " / " << total_area << " , UE per tower = " << total_E / total_tower << std::endl;
       }
       
     }
   }
 
-  if (verbosity > 0 ) {
+  if (Verbosity() > 0 ) {
 
     for (int layer = 0; layer < 3; layer++) {
       std::cout << "DetermineTowerBackground::process_event: summary UE in layer " << layer << " : ";
@@ -538,7 +538,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
 
   FillNode(topNode);
 
-  if (verbosity > 0) std::cout << "DetermineTowerBackground::process_event: exiting" << std::endl;
+  if (Verbosity() > 0) std::cout << "DetermineTowerBackground::process_event: exiting" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/jetbackground/RetowerCEMC.C
+++ b/offline/packages/jetbackground/RetowerCEMC.C
@@ -34,7 +34,7 @@ RetowerCEMC::~RetowerCEMC()
 
 int RetowerCEMC::Init(PHCompositeNode *topNode)
 {
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     std::cout << "RetowerCEMC::Init: initialized" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -50,7 +50,7 @@ int RetowerCEMC::InitRun(PHCompositeNode *topNode)
 
 int RetowerCEMC::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     std::cout << "RetowerCEMC::process_event: entering" << std::endl;
 
   // pull out the tower containers and geometry objects at the start
@@ -60,7 +60,7 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
   RawTowerGeomContainer *geomEM = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
   RawTowerGeomContainer *geomIH = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     std::cout << "RetowerCEMC::process_event: " << towersEM3->size() << " TOWER_CALIB_CEMC towers" << std::endl;
   }
 
@@ -96,7 +96,7 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
 
   RawTowerContainer* emcal_retower = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_CEMC_RETOWER");
   
-  if (verbosity > 0) std::cout << "RetowerCEMC::process_event: filling TOWER_CALIB_CEMC_RETOWER node, with initial size = " << emcal_retower->size() << std::endl;
+  if (Verbosity() > 0) std::cout << "RetowerCEMC::process_event: filling TOWER_CALIB_CEMC_RETOWER node, with initial size = " << emcal_retower->size() << std::endl;
 
   // create new towers
   for (int eta = 0; eta < _NETA; eta++) {
@@ -110,9 +110,9 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity > 0) std::cout << "RetowerCEMC::process_event: finished filling TOWER_CALIB_CEMC_RETOWER node, with final size = " << emcal_retower->size() << std::endl;
+  if (Verbosity() > 0) std::cout << "RetowerCEMC::process_event: finished filling TOWER_CALIB_CEMC_RETOWER node, with final size = " << emcal_retower->size() << std::endl;
 
-  if (verbosity > 0) std::cout << "RetowerCEMC::process_event: exiting" << std::endl;
+  if (Verbosity() > 0) std::cout << "RetowerCEMC::process_event: exiting" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -142,7 +142,7 @@ int RetowerCEMC::CreateNode(PHCompositeNode *topNode)
   RawTowerContainer* test_emcal_retower = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_CEMC_RETOWER");
   if ( !test_emcal_retower ) {
 
-    if (verbosity > 0) std::cout << "RetowerCEMC::CreateNode : creating TOWER_CALIB_CEMC_RETOWER node " << std::endl;
+    if (Verbosity() > 0) std::cout << "RetowerCEMC::CreateNode : creating TOWER_CALIB_CEMC_RETOWER node " << std::endl;
 
     RawTowerContainer *emcal_retower = new RawTowerContainer( RawTowerDefs::CalorimeterId::HCALIN );
     PHIODataNode<PHObject> *emcalTowerNode = new PHIODataNode<PHObject>( emcal_retower, "TOWER_CALIB_CEMC_RETOWER", "PHObject");

--- a/offline/packages/jetbackground/SubtractTowers.C
+++ b/offline/packages/jetbackground/SubtractTowers.C
@@ -41,7 +41,7 @@ SubtractTowers::~SubtractTowers()
 
 int SubtractTowers::Init(PHCompositeNode *topNode)
 {
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     std::cout << "SubtractTowers::Init: initialized" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -57,7 +57,7 @@ int SubtractTowers::InitRun(PHCompositeNode *topNode)
 
 int SubtractTowers::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     std::cout << "SubtractTowers::process_event: entering, with _use_flow_modulation = " << _use_flow_modulation << std::endl;
 
   // pull out the tower containers and geometry objects at the start
@@ -68,7 +68,7 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
   RawTowerGeomContainer *geomIH = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
   RawTowerGeomContainer *geomOH = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     std::cout << "SubtractTowers::process_event: " << towersEM3->size() << " TOWER_CALIB_CEMC_RETOWER towers" << std::endl;
     std::cout << "SubtractTowers::process_event: " << towersIH3->size() << " TOWER_CALIB_HCALIN towers" << std::endl;
     std::cout << "SubtractTowers::process_event: " << towersOH3->size() << " TOWER_CALIB_HCALOUT towers" << std::endl;
@@ -79,7 +79,7 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
   RawTowerContainer* ihcal_towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALIN_SUB1");
   RawTowerContainer* ohcal_towers = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALOUT_SUB1");
   
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     std::cout << "SubtractTowers::process_event: starting with " << emcal_towers->size() << " TOWER_CALIB_CEMC_RETOWER_SUB1 towers" << std::endl;
     std::cout << "SubtractTowers::process_event: starting with " << ihcal_towers->size() << " TOWER_CALIB_HCALIN_SUB1 towers" << std::endl;
     std::cout << "SubtractTowers::process_event: starting with " << ohcal_towers->size() << " TOWER_CALIB_HCALOUT_SUB1 towers" << std::endl;
@@ -131,7 +131,7 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
     }
     float new_energy = raw_energy - UE;
     tower->set_energy( new_energy );
-    if (verbosity > 5) 
+    if (Verbosity() > 5) 
       std::cout << " SubtractTowers::process_event : EMCal tower at eta / phi = " << tower->get_bineta() << " / " << tower->get_binphi() << ", pre-sub / after-sub E = " << raw_energy << " / " << tower->get_energy() << std::endl;
   }
 
@@ -219,13 +219,13 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
     tower->set_energy( new_energy );
   }
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     std::cout << "SubtractTowers::process_event: ending with " << emcal_towers->size() << " TOWER_CALIB_CEMC_RETOWER_SUB1 towers" << std::endl;
     std::cout << "SubtractTowers::process_event: ending with " << ihcal_towers->size() << " TOWER_CALIB_HCALIN_SUB1 towers" << std::endl;
     std::cout << "SubtractTowers::process_event: ending with " << ohcal_towers->size() << " TOWER_CALIB_HCALOUT_SUB1 towers" << std::endl;
   }
 
-  if (verbosity > 0) std::cout << "SubtractTowers::process_event: exiting" << std::endl;
+  if (Verbosity() > 0) std::cout << "SubtractTowers::process_event: exiting" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -255,7 +255,7 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
   RawTowerContainer* test_emcal_tower = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_CEMC_RETOWER_SUB1");
   if ( !test_emcal_tower ) {
 
-    if (verbosity > 0) std::cout << "SubtractTowers::CreateNode : creating TOWER_CALIB_CEMC_RETOWER_SUB1 node " << std::endl;
+    if (Verbosity() > 0) std::cout << "SubtractTowers::CreateNode : creating TOWER_CALIB_CEMC_RETOWER_SUB1 node " << std::endl;
 
     RawTowerContainer* emcal_towers = new RawTowerContainer( RawTowerDefs::CalorimeterId::HCALIN );
     PHIODataNode<PHObject> *emcalTowerNode = new PHIODataNode<PHObject>(emcal_towers, "TOWER_CALIB_CEMC_RETOWER_SUB1", "PHObject");
@@ -274,7 +274,7 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
   RawTowerContainer* test_ihcal_tower = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALIN_SUB1");
   if ( !test_ihcal_tower ) {
 
-    if (verbosity > 0) std::cout << "SubtractTowers::CreateNode : creating TOWER_CALIB_HCALIN_SUB1 node " << std::endl;
+    if (Verbosity() > 0) std::cout << "SubtractTowers::CreateNode : creating TOWER_CALIB_HCALIN_SUB1 node " << std::endl;
 
     RawTowerContainer* ihcal_towers = new RawTowerContainer( RawTowerDefs::CalorimeterId::HCALIN );
     PHIODataNode<PHObject> *ihcalTowerNode = new PHIODataNode<PHObject>(ihcal_towers, "TOWER_CALIB_HCALIN_SUB1", "PHObject");
@@ -293,7 +293,7 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
   RawTowerContainer* test_ohcal_tower = findNode::getClass<RawTowerContainer>(topNode,"TOWER_CALIB_HCALOUT_SUB1");
   if ( !test_ohcal_tower ) {
 
-    if (verbosity > 0) std::cout << "SubtractTowers::CreateNode : creating TOWER_CALIB_HCALOUT_SUB1 node " << std::endl;
+    if (Verbosity() > 0) std::cout << "SubtractTowers::CreateNode : creating TOWER_CALIB_HCALOUT_SUB1 node " << std::endl;
 
     RawTowerContainer* ohcal_towers = new RawTowerContainer( RawTowerDefs::CalorimeterId::HCALOUT );
     PHIODataNode<PHObject> *ohcalTowerNode = new PHIODataNode<PHObject>(ohcal_towers, "TOWER_CALIB_HCALOUT_SUB1", "PHObject");

--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -123,7 +123,7 @@ int MvtxClusterizer::InitRun(PHCompositeNode* topNode)
   // Report Settings
   //----------------
   
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     cout << "====================== MvtxClusterizer::InitRun() =====================" << endl;
     cout << " Z-dimension Clustering = " << boolalpha << m_makeZClustering << noboolalpha << endl;
@@ -162,7 +162,7 @@ int MvtxClusterizer::process_event(PHCompositeNode *topNode) {
 
 void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode) {
   
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     cout << "Entering MvtxClusterizer::ClusterMvtx " << endl;
   
   //-----------
@@ -179,7 +179,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode) {
     
     TrkrHitSet* hitset = hitsetitr->second;
 
-    if (verbosity>2)
+    if (Verbosity()>2)
       hitset->identify();
     
 
@@ -197,7 +197,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode) {
       unsigned int row = MvtxDefs::getRow(hitr->first);
       hitvec.push_back(make_pair(col, row));
     }
-    if ( verbosity>2 )
+    if ( Verbosity()>2 )
       cout << "hitvec.size(): " << hitvec.size() << endl;
     
     // do the clustering
@@ -244,7 +244,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode) {
 
       multimap<int, pixel>::iterator mapiter = clusrange.first;
 
-      if (verbosity > 2)
+      if (Verbosity() > 2)
         cout << "Filling cluster id " << clusid << endl;
 
       // make cluster
@@ -342,7 +342,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode) {
       clus->setError( 2 , 2 , ERR[2][2] );
 
 
-      if ( verbosity > 2 )
+      if ( Verbosity() > 2 )
         clus->identify();
 
     } // clusitr
@@ -355,7 +355,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode) {
 void MvtxClusterizer::PrintClusters(PHCompositeNode * topNode)
 {
 
-  if (verbosity >= 1) {
+  if (Verbosity() >= 1) {
 
     TrkrClusterContainer *clusterlist = findNode::getClass<TrkrClusterContainer>(topNode, "TrkrClusterContainer");
     if (!clusterlist) return;

--- a/offline/packages/trigger/CaloTriggerSim.C
+++ b/offline/packages/trigger/CaloTriggerSim.C
@@ -115,7 +115,7 @@ float CaloTriggerSim::truncate_8bit( float raw_E  ) {
 
 int CaloTriggerSim::Init(PHCompositeNode *topNode)
 {
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     std::cout << "CaloTriggerSim::Init: initialized" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -128,14 +128,14 @@ int CaloTriggerSim::InitRun(PHCompositeNode *topNode)
 
 int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     std::cout << "CaloTriggerSim::process_event: entering" << std::endl;
 
   // pull out the tower containers and geometry objects at the start
   RawTowerContainer *towersEM3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC");
   RawTowerContainer *towersIH3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALIN");
   RawTowerContainer *towersOH3 = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALOUT");
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     std::cout << "CaloTriggerSim::process_event: " << towersEM3->size() << " TOWER_CALIB_CEMC towers" << std::endl;
     std::cout << "CaloTriggerSim::process_event: " << towersIH3->size() << " TOWER_CALIB_HCALIN towers" << std::endl;
     std::cout << "CaloTriggerSim::process_event: " << towersOH3->size() << " TOWER_CALIB_HCALOUT towers" << std::endl;
@@ -171,7 +171,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
     _EMCAL_2x2_MAP.resize(_EMCAL_2x2_NETA, std::vector<float>(_EMCAL_2x2_NPHI, 0));
     _EMCAL_4x4_MAP.resize(_EMCAL_4x4_NETA, std::vector<float>(_EMCAL_4x4_NPHI, 0));
 
-    if (verbosity > 0)
+    if (Verbosity() > 0)
     {
       std::cout << "CaloTriggerSim::process_event: setting number of window in eta / phi,";
       std::cout << "1x1 are " << _EMCAL_1x1_NETA << " / " << _EMCAL_1x1_NPHI << ", ";
@@ -204,7 +204,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
     _EMCAL_1x1_MAP[this_etabin][this_phibin] += this_E;
 
-    if (verbosity > 1 && tower->get_energy() > 1)
+    if (Verbosity() > 1 && tower->get_energy() > 1)
     {
       std::cout << "CaloTriggerSim::process_event: EMCal 1x1 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << this_etabin << " ) / " << this_phi << " ( " << this_phibin << " ) / " << this_E << std::endl;
     }
@@ -249,7 +249,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
       if (this_phi > 3.14159) this_phi -= 2 * 3.14159;
       if (this_phi < -3.14159) this_phi += 2 * 3.14159;
 
-      if (verbosity > 1 && this_sum > 1)
+      if (Verbosity() > 1 && this_sum > 1)
       {
         std::cout << "CaloTriggerSim::process_event: EMCal 2x2 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
       }
@@ -263,7 +263,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     std::cout << "CaloTriggerSim::process_event: best EMCal 2x2 window is at eta / phi = " << _EMCAL_2x2_BEST_ETA << " / " << _EMCAL_2x2_BEST_PHI << " and E = " << _EMCAL_2x2_BEST_E << std::endl;
   }
@@ -319,7 +319,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
       _EMCAL_4x4_MAP[ieta][iphi] = this_sum;
 
-      if (verbosity > 1 && this_sum > 1)
+      if (Verbosity() > 1 && this_sum > 1)
       {
         std::cout << "CaloTriggerSim::process_event: EMCal 4x4 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
       }
@@ -373,7 +373,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     std::cout << "CaloTriggerSim::process_event: best EMCal 4x4 window is at eta / phi = " << _EMCAL_4x4_BEST_ETA << " / " << _EMCAL_4x4_BEST_PHI << " and E = " << _EMCAL_4x4_BEST_E << std::endl;
     std::cout << "CaloTriggerSim::process_event: 2nd best EMCal 4x4 window is at eta / phi = " << _EMCAL_4x4_BEST2_ETA << " / " << _EMCAL_4x4_BEST2_PHI << " and E = " << _EMCAL_4x4_BEST2_E << std::endl;
@@ -428,7 +428,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
     _FULLCALO_0p8x0p8_MAP.resize(_FULLCALO_0p8x0p8_NETA, std::vector<float>(_FULLCALO_0p8x0p8_NPHI, 0));
     _FULLCALO_1p0x1p0_MAP.resize(_FULLCALO_1p0x1p0_NETA, std::vector<float>(_FULLCALO_1p0x1p0_NPHI, 0));
 
-    if (verbosity > 0)
+    if (Verbosity() > 0)
     {
       std::cout << "CaloTriggerSim::process_event: determining phi range for 0.1x0.1 full calo map: " << _FULLCALO_PHI_START << " to " << _FULLCALO_PHI_END << std::endl;
       std::cout << "CaloTriggerSim::process_event: setting number of full calo window in eta / phi:" << std::endl;
@@ -470,7 +470,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
     _FULLCALO_0p1x0p1_MAP[ this_etabin ][ this_phibin ] += this_E;
 
-    if (verbosity > 1 && tower->get_energy() > 1)
+    if (Verbosity() > 1 && tower->get_energy() > 1)
     {
       std::cout << "CaloTriggerSim::process_event: EMCal tower at eta / phi (added to fullcalo map with etabin / phibin ) / E = " << std::setprecision(6) << this_eta << " / " << this_phi << " ( " << this_etabin << " / " << this_phibin << " ) / " << this_E << std::endl;
     }
@@ -496,7 +496,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
     _FULLCALO_0p1x0p1_MAP[ this_etabin ][ this_phibin ] += this_E;
 
-    if (verbosity > 1 && tower->get_energy() > 0.5)
+    if (Verbosity() > 1 && tower->get_energy() > 0.5)
     {
       std::cout << "CaloTriggerSim::process_event: IHCal tower at eta / phi (added to fullcalo map with etabin / phibin ) / E = " << std::setprecision(6) << this_eta << " / " << this_phi << " ( " << this_etabin << " / " << this_phibin << " ) / " << this_E << std::endl;
     }
@@ -522,7 +522,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
     _FULLCALO_0p1x0p1_MAP[ this_etabin ][ this_phibin ] += this_E;
 
-    if (verbosity > 1 && tower->get_energy() > 0.5)
+    if (Verbosity() > 1 && tower->get_energy() > 0.5)
     {
       std::cout << "CaloTriggerSim::process_event: OHCal tower at eta / phi (added to fullcalo map with etabin / phibin ) / E = " << std::setprecision(6) << this_eta << " / " << this_phi << " ( " << this_etabin << " / " << this_phibin << " ) / " << this_E << std::endl;
     }
@@ -561,7 +561,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
       float this_eta = 0.5 * (geomOH->get_etacenter(2 * ieta) + geomOH->get_etacenter(2 * ieta + 1));
       float this_phi = 0.5 * (geomOH->get_phicenter(2 * iphi) + geomOH->get_phicenter(2 * iphi + 1));
 
-      if (verbosity > 1 && this_sum > 1)
+      if (Verbosity() > 1 && this_sum > 1)
       {
         std::cout << "CaloTriggerSim::process_event: FullCalo 0.2x0.2 window eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
       }
@@ -575,7 +575,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     std::cout << "CaloTriggerSim::process_event: best FullCalo 0.2x0.2 window is at eta / phi = " << _FULLCALO_0p2x0p2_BEST_ETA << " / " << _FULLCALO_0p2x0p2_BEST_PHI << " and E = " << _FULLCALO_0p2x0p2_BEST_E << std::endl;
   }
@@ -617,7 +617,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
       _FULLCALO_0p4x0p4_MAP[ieta][iphi] = this_sum;
 
-      if (verbosity > 1 && this_sum > 2)
+      if (Verbosity() > 1 && this_sum > 2)
       {
         std::cout << "CaloTriggerSim::process_event: FullCalo  0.4x0.4 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
       }
@@ -631,7 +631,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     std::cout << "CaloTriggerSim::process_event: best FullCalo 0.4x0.4 window is at eta / phi = " << _FULLCALO_0p4x0p4_BEST_ETA << " / " << _FULLCALO_0p4x0p4_BEST_PHI << " and E = " << _FULLCALO_0p4x0p4_BEST_E << std::endl;
   }
@@ -680,7 +680,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
       _FULLCALO_0p6x0p6_MAP[ieta][iphi] = this_sum;
 
-      if (verbosity > 1 && this_sum > 3)
+      if (Verbosity() > 1 && this_sum > 3)
       {
         std::cout << "CaloTriggerSim::process_event: FullCalo  0.6x0.6 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
       }
@@ -694,7 +694,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     std::cout << "CaloTriggerSim::process_event: best FullCalo 0.6x0.6 window is at eta / phi = " << _FULLCALO_0p6x0p6_BEST_ETA << " / " << _FULLCALO_0p6x0p6_BEST_PHI << " and E = " << _FULLCALO_0p6x0p6_BEST_E << std::endl;
   }
@@ -752,7 +752,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
       _FULLCALO_0p8x0p8_MAP[ieta][iphi] = this_sum;
 
-      if (verbosity > 1 && this_sum > 4)
+      if (Verbosity() > 1 && this_sum > 4)
       {
         std::cout << "CaloTriggerSim::process_event: FullCalo  0.8x0.8 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
       }
@@ -766,7 +766,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     std::cout << "CaloTriggerSim::process_event: best FullCalo 0.8x0.8 window is at eta / phi = " << _FULLCALO_0p8x0p8_BEST_ETA << " / " << _FULLCALO_0p8x0p8_BEST_PHI << " and E = " << _FULLCALO_0p8x0p8_BEST_E << std::endl;
   }
@@ -835,7 +835,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
       _FULLCALO_1p0x1p0_MAP[ieta][iphi] = this_sum;
 
-      if (verbosity > 1 && this_sum > 5)
+      if (Verbosity() > 1 && this_sum > 5)
       {
         std::cout << "CaloTriggerSim::process_event: FullCalo  1.0x1.0 tower eta ( bin ) / phi ( bin ) / E = " << std::setprecision(6) << this_eta << " ( " << ieta << " ) / " << this_phi << " ( " << iphi << " ) / " << this_sum << std::endl;
       }
@@ -849,7 +849,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     std::cout << "CaloTriggerSim::process_event: best FullCalo 1.0x1.0 window is at eta / phi = " << _FULLCALO_1p0x1p0_BEST_ETA << " / " << _FULLCALO_1p0x1p0_BEST_PHI << " and E = " << _FULLCALO_1p0x1p0_BEST_E << std::endl;
   }
@@ -858,7 +858,7 @@ int CaloTriggerSim::process_event(PHCompositeNode *topNode)
 
   FillNode(topNode);
 
-  if (verbosity > 0) std::cout << "CaloTriggerSim::process_event: exiting" << std::endl;
+  if (Verbosity() > 0) std::cout << "CaloTriggerSim::process_event: exiting" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4bbc/BbcVertexFastSimReco.C
+++ b/simulation/g4simulation/g4bbc/BbcVertexFastSimReco.C
@@ -48,7 +48,7 @@ int BbcVertexFastSimReco::InitRun(PHCompositeNode *topNode) {
   unsigned int seed = PHRandomSeed(); // fixed random seed handled in PHRandomSeed()
   gsl_rng_set(RandomGenerator,seed);
   
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "===================== BbcVertexFastSimReco::InitRun() =====================" << endl;
     cout << " t smearing: " << _t_smear << " cm " << endl;
     cout << "  z smearing: " << _z_smear << " cm " << endl;
@@ -61,7 +61,7 @@ int BbcVertexFastSimReco::InitRun(PHCompositeNode *topNode) {
 
 int BbcVertexFastSimReco::process_event(PHCompositeNode *topNode) {
   
-  if (verbosity > 1) cout << "BbcVertexFastSimReco::process_event -- entered" << endl;
+  if (Verbosity() > 1) cout << "BbcVertexFastSimReco::process_event -- entered" << endl;
 
   //---------------------------------
   // Get Objects off of the Node Tree

--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -100,7 +100,7 @@ HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
   _tower_energy_src = get_int_param("tower_energy_source");
   emin = get_double_param("emin");
   ncell_to_tower = get_int_param("n_scinti_plates_per_tower");
-  if (verbosity >= 1)
+  if (Verbosity() >= 1)
     {
       cout << "HcalRawTowerBuilder::InitRun :";
       if (_tower_energy_src == kEnergyDeposition)
@@ -165,7 +165,7 @@ HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
 	  rawtowergeom->add_tower_geometry(tg);
 	}
     }
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       rawtowergeom->identify();
     }
@@ -175,7 +175,7 @@ HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
 int
 HcalRawTowerBuilder::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity>3)
+  if (Verbosity()>3)
     {
       std::cout << PHWHERE << "Process event entered" << std::endl;
     }
@@ -198,7 +198,7 @@ HcalRawTowerBuilder::process_event(PHCompositeNode *topNode)
     {
       PHG4Cell *cell = cell_iter->second;
 
-      if (verbosity > 2)
+      if (Verbosity() > 2)
         {
           std::cout << PHWHERE << " print out the cell:" << std::endl;
           cell->identify();
@@ -255,13 +255,13 @@ HcalRawTowerBuilder::process_event(PHCompositeNode *topNode)
               << cellE - towerE << endl;
         }
     }
-  if (verbosity)
+  if (Verbosity())
     {
       towerE = _towers->getTotalEdep();
     }
 
   _towers->compress(emin);
-  if (verbosity)
+  if (Verbosity())
     {
       cout << "Energy lost by dropping towers with less than " << emin
           << " energy, lost energy: " << towerE - _towers->getTotalEdep()

--- a/simulation/g4simulation/g4calo/Prototype2RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/Prototype2RawTowerBuilder.cc
@@ -130,7 +130,7 @@ int Prototype2RawTowerBuilder::InitRun(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity >= 1)
+  if (Verbosity() >= 1)
   {
     cout << "Prototype2RawTowerBuilder::InitRun :";
     if (m_TowerEnergySrc == kEnergyDeposition)
@@ -150,7 +150,7 @@ int Prototype2RawTowerBuilder::InitRun(PHCompositeNode *topNode)
 
 int Prototype2RawTowerBuilder::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity > 3)
+  if (Verbosity() > 3)
   {
     std::cout << PHWHERE << "Process event entered" << std::endl;
   }
@@ -178,7 +178,7 @@ int Prototype2RawTowerBuilder::process_event(PHCompositeNode *topNode)
   {
     PHG4ScintillatorSlat *cell = cell_iter->second;
 
-    if (verbosity > 2)
+    if (Verbosity() > 2)
     {
       std::cout << PHWHERE << " print out the cell:" << std::endl;
       cell->identify();
@@ -222,13 +222,13 @@ int Prototype2RawTowerBuilder::process_event(PHCompositeNode *topNode)
            << cellE - towerE << endl;
     }
   }
-  if (verbosity)
+  if (Verbosity())
   {
     towerE = towers->getTotalEdep();
   }
 
   towers->compress(m_Emin);
-  if (verbosity)
+  if (Verbosity())
   {
     cout << "Energy lost by dropping towers with less than " << m_Emin
          << " energy, lost energy: " << towerE - towers->getTotalEdep()

--- a/simulation/g4simulation/g4calo/RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/RawTowerBuilder.cc
@@ -85,7 +85,7 @@ int RawTowerBuilder::InitRun(PHCompositeNode *topNode)
     //exit(1);
   }
 
-  if (verbosity >= 1)
+  if (Verbosity() >= 1)
   {
     cout << "RawTowerBuilder::InitRun :";
     if (m_TowerEnergySrcEnum == kEnergyDeposition)
@@ -104,7 +104,7 @@ int RawTowerBuilder::InitRun(PHCompositeNode *topNode)
 
 int RawTowerBuilder::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity)
+  if (Verbosity())
   {
     std::cout << PHWHERE << "Process event entered" << std::endl;
   }
@@ -126,7 +126,7 @@ int RawTowerBuilder::process_event(PHCompositeNode *topNode)
   {
     PHG4Cell *cell = cell_iter->second;
 
-    if (verbosity > 2)
+    if (Verbosity() > 2)
     {
       std::cout << PHWHERE << " print out the cell:" << std::endl;
       cell->identify();
@@ -181,7 +181,7 @@ int RawTowerBuilder::process_event(PHCompositeNode *topNode)
 
     tower->set_energy(tower->get_energy() + cell_weight);
 
-    if (verbosity > 2)
+    if (Verbosity() > 2)
     {
       m_RawTowerGeomContainer = findNode::getClass<RawTowerGeomContainer>(topNode, m_TowerGeomNodeName);
       tower->identify();
@@ -198,13 +198,13 @@ int RawTowerBuilder::process_event(PHCompositeNode *topNode)
            << cellE - towerE << endl;
     }
   }
-  if (verbosity)
+  if (Verbosity())
   {
     towerE = m_TowerContainer->getTotalEdep();
   }
 
   m_TowerContainer->compress(m_Emin);
-  if (verbosity)
+  if (Verbosity())
   {
     cout << "Energy lost by dropping towers with less than " << m_Emin
          << " GeV energy, lost energy: " << towerE - m_TowerContainer->getTotalEdep()
@@ -276,7 +276,7 @@ void RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
     PHG4CylinderCellGeom *cellgeo = miter->second;
     first_cellgeo = miter->second;
 
-    if (verbosity)
+    if (Verbosity())
     {
       cellgeo->identify();
     }
@@ -469,7 +469,7 @@ void RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
     exit(1);
   }
 
-  if (verbosity >= 1)
+  if (Verbosity() >= 1)
   {
     m_RawTowerGeomContainer->identify();
   }

--- a/simulation/g4simulation/g4calo/RawTowerBuilderByHitIndex.cc
+++ b/simulation/g4simulation/g4calo/RawTowerBuilderByHitIndex.cc
@@ -129,13 +129,13 @@ RawTowerBuilderByHitIndex::process_event(PHCompositeNode *topNode)
 
   float towerE = 0.;
 
-  if (verbosity)
+  if (Verbosity())
     {
       towerE = towers_->getTotalEdep();
     }
 
   towers_->compress(emin_);
-  if (verbosity)
+  if (Verbosity())
     {
       cout << "Energy lost by dropping towers with less than " << emin_
 	   << " energy, lost energy: "  << towerE - towers_->getTotalEdep() << endl;
@@ -244,7 +244,7 @@ bool RawTowerBuilderByHitIndex::ReadGeometryFromTable() {
       /* Skip lines starting with / including a '#' */
       if ( line_mapping.find("#") != string::npos )
 	{
-	  if ( verbosity > 0 )
+	  if ( Verbosity() > 0 )
 	    {
 	      cout << "RawTowerBuilderByHitIndex: SKIPPING line in mapping file: " << line_mapping << endl;
 	    }
@@ -364,7 +364,7 @@ bool RawTowerBuilderByHitIndex::ReadGeometryFromTable() {
       it->second->set_center_y( y_temp_rt );
       it->second->set_center_z( z_temp_rt );
 
-      if ( verbosity > 2 )
+      if ( Verbosity() > 2 )
 	{
 	  cout << "* Local tower x y z : " << x_temp << " " << y_temp << " " << z_temp << endl;
 	  cout << "* Globl tower x y z : " << x_temp_rt << " " << y_temp_rt << " " << z_temp_rt << endl;

--- a/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
@@ -99,7 +99,7 @@ int RawTowerDigitizer::InitRun(PHCompositeNode *topNode)
 
 int RawTowerDigitizer::process_event(PHCompositeNode *topNode)
 {
-  if (verbosity)
+  if (Verbosity())
   {
     cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
          << "Process event entered. "
@@ -231,7 +231,7 @@ RawTowerDigitizer::simple_photon_digitization(RawTower *sim_tower)
     digi_tower->set_energy((double) sum_ADC);
   }
 
-  if (verbosity >= 2)
+  if (Verbosity() >= 2)
   {
     cout << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
          << endl;
@@ -283,7 +283,7 @@ void RawTowerDigitizer::CreateNodes(PHCompositeNode *topNode)
     throw std::runtime_error("Failed to find " + TowerGeomNodeName + " node in RawTowerDigitizer::CreateNodes");
   }
 
-  if (verbosity >= 1)
+  if (Verbosity() >= 1)
   {
     rawtowergeom->identify();
   }

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -114,7 +114,7 @@ int PHG4BlockCellReco::InitRun(PHCompositeNode *topNode)
 
   }
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     geo->identify();
   }
@@ -234,7 +234,7 @@ int PHG4BlockCellReco::InitRun(PHCompositeNode *topNode)
     
     // add geo object filled by different binning methods
     seggeo->AddLayerCellGeom(layerseggeo);
-    if (verbosity > 1)
+    if (Verbosity() > 1)
     {
       layerseggeo->identify();
     }
@@ -329,7 +329,7 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
 
         if (etabin[0] < 0)
         {
-          if (verbosity > 0)
+          if (Verbosity() > 0)
           {
             hiter->second->identify();
           }
@@ -379,7 +379,7 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
 
         if (intxbin == intxbinout && intetabin == intetabinout)   // single cell fired
         {
-          if (verbosity > 0) cout << "SINGLE CELL FIRED: " << intxbin << " " << intetabin << endl;
+          if (Verbosity() > 0) cout << "SINGLE CELL FIRED: " << intxbin << " " << intetabin << endl;
           vx.push_back(intxbin);
           veta.push_back(intetabin);
           vdedx.push_back(trklen);
@@ -400,7 +400,7 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
               bool yesno = line_and_rectangle_intersect(ax, ay, bx, by, cx, cy, dx, dy, &rr);
               if (yesno)
               {
-                if (verbosity > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << rr << endl;
+                if (Verbosity() > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << rr << endl;
                 vx.push_back(ibp);
                 veta.push_back(ibz);
                 vdedx.push_back(rr);
@@ -408,16 +408,16 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
             }
           }
         }
-        if (verbosity > 0) cout << "NUMBER OF FIRED CELLS = " << vx.size() << endl;
+        if (Verbosity() > 0) cout << "NUMBER OF FIRED CELLS = " << vx.size() << endl;
 
         double tmpsum = 0.;
         for (unsigned int ii = 0; ii < vx.size(); ii++)
         {
           tmpsum += vdedx[ii];
           vdedx[ii] = vdedx[ii] / trklen;
-          if (verbosity > 0) cout << "  CELL " << ii << "  dE/dX = " <<  vdedx[ii] << endl;
+          if (Verbosity() > 0) cout << "  CELL " << ii << "  dE/dX = " <<  vdedx[ii] << endl;
         }
-        if (verbosity > 0) cout << "    TOTAL TRACK LENGTH = " << tmpsum << " " << trklen << endl;
+        if (Verbosity() > 0) cout << "    TOTAL TRACK LENGTH = " << tmpsum << " " << trklen << endl;
 
 
         for (unsigned int i1 = 0; i1 < vx.size(); i1++)   // loop over all fired cells
@@ -462,7 +462,7 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
           {
             cells->AddCell(cellptarray[ibin]);
             numcells++;
-            if (verbosity > 1)
+            if (Verbosity() > 1)
             {
               cout << "Adding cell in bin x: " << ix
                    << " x: " << geo->get_xcenter(ix) * 180./M_PI
@@ -477,7 +477,7 @@ PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
         }
       }
 
-      if (verbosity > 0)
+      if (Verbosity() > 0)
       {
         cout << Name() << ": found " << numcells << " eta/x cells with energy deposition" << endl;
       }
@@ -762,7 +762,7 @@ PHG4BlockCellReco::CheckEnergy(PHCompositeNode *topNode)
 
   else
     {
-      if (verbosity > 0)
+      if (Verbosity() > 0)
 	{
 	  cout << Name() << ": sum hit energy: " << sum_energy_g4hit << " GeV" << endl;
 	  cout << Name() << ": sum cell energy: " << sum_energy_cells << " GeV" << endl;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -111,7 +111,7 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
       exit(1);
 
     }
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       geo->identify();
     }
@@ -286,14 +286,14 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
 	}
       // add geo object filled by different binning methods
       seggeo->AddLayerCellGeom(layerseggeo);
-      if (verbosity > 1)
+      if (Verbosity() > 1)
 	{
 	  layerseggeo->identify();
 	}
     }
 
   // print out settings
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       cout << "===================== PHG4CylinderCellReco::InitRun() =====================" << endl;
       cout << " " << outdetector << " Segmentation Description: " << endl;
@@ -404,7 +404,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 
 	      if (etabin[0] < 0)
 		{
-		  if (verbosity > 0)
+		  if (Verbosity() > 0)
 		    {
 		      hiter->second->identify();
 		    }
@@ -452,7 +452,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 
 	      if (intphibin == intphibinout && intetabin == intetabinout)   // single cell fired
 		{
-		  if (verbosity > 0) cout << "SINGLE CELL FIRED: " << intphibin << " " << intetabin << endl;
+		  if (Verbosity() > 0) cout << "SINGLE CELL FIRED: " << intphibin << " " << intetabin << endl;
 		  vphi.push_back(intphibin);
 		  veta.push_back(intetabin);
 		  vdedx.push_back(trklen);
@@ -475,7 +475,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 			  bool yesno = line_and_rectangle_intersect(ax, ay, bx, by, cx, cy, dx, dy, &rr);
 			  if (yesno)
 			    {
-			      if (verbosity > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << rr << endl;
+			      if (Verbosity() > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << rr << endl;
 			      vphi.push_back(ibp);
 			      veta.push_back(ibz);
 			      vdedx.push_back(rr);
@@ -483,16 +483,16 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 			}
 		    }
 		}
-	      if (verbosity > 0) cout << "NUMBER OF FIRED CELLS = " << vphi.size() << endl;
+	      if (Verbosity() > 0) cout << "NUMBER OF FIRED CELLS = " << vphi.size() << endl;
 
 	      double tmpsum = 0.;
 	      for (unsigned int ii = 0; ii < vphi.size(); ii++)
 		{
 		  tmpsum += vdedx[ii];
 		  vdedx[ii] = vdedx[ii] / trklen;
-		  if (verbosity > 0) cout << "  CELL " << ii << "  dE/dX = " <<  vdedx[ii] << endl;
+		  if (Verbosity() > 0) cout << "  CELL " << ii << "  dE/dX = " <<  vdedx[ii] << endl;
 		}
-	      if (verbosity > 0) cout << "    TOTAL TRACK LENGTH = " << tmpsum << " " << trklen << endl;
+	      if (Verbosity() > 0) cout << "    TOTAL TRACK LENGTH = " << tmpsum << " " << trklen << endl;
 
 	      for (unsigned int i1 = 0; i1 < vphi.size(); i1++)   // loop over all fired cells
 		{
@@ -506,7 +506,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		  unsigned long long tmp = iphibin;
 		  unsigned long long key = tmp << 32;
 		  key += ietabin;
-		  if(verbosity > 1)
+		  if(Verbosity() > 1)
 		    {
 		      cout << " iphibin " << iphibin << " ietabin " << ietabin << " key 0x" << hex << key << dec << endl;
 		    }
@@ -552,7 +552,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 	    {
 	      cells->AddCell(it->second);
 	      numcells++;
-	      if (verbosity > 1)
+	      if (Verbosity() > 1)
 		{
 		  cout << "Adding cell in bin phi: " << PHG4CellDefs::EtaPhiBinning::get_phibin(it->second->get_cellid())
 		       << " phi: " << geo->get_phicenter(PHG4CellDefs::EtaPhiBinning::get_phibin(it->second->get_cellid())) * 180. / M_PI
@@ -563,7 +563,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		}
 	    }
 
-	  if (verbosity > 0)
+	  if (Verbosity() > 0)
 	    {
 	      cout << Name() << ": found " << numcells << " eta/phi cells with energy deposition" << endl;
 	    }
@@ -597,7 +597,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 	      double z[2];
 	      double phibin[2];
 	      double zbin[2];
-	      if (verbosity > 0) cout << "--------- new hit in layer # " << *layer << endl;
+	      if (Verbosity() > 0) cout << "--------- new hit in layer # " << *layer << endl;
 
 	      for (int i = 0; i < 2; i++)
 		{
@@ -610,8 +610,8 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		  phibin[i] = geo->get_phibin( phi[i] );
 		  zbin[i] = geo->get_zbin( hiter->second->get_z(i) );
 
-		  if (verbosity > 0) cout << " " << i << "  phibin: " << phibin[i] << ", phi: " << phi[i] << ", stepsize: " << phistepsize << endl;
-		  if (verbosity > 0) cout << " " << i << "  zbin: " << zbin[i] << ", z = " << hiter->second->get_z(i) << ", stepsize: " << zstepsize << " offset: " <<  zmin_max[*layer].first << endl;
+		  if (Verbosity() > 0) cout << " " << i << "  phibin: " << phibin[i] << ", phi: " << phi[i] << ", stepsize: " << phistepsize << endl;
+		  if (Verbosity() > 0) cout << " " << i << "  zbin: " << zbin[i] << ", z = " << hiter->second->get_z(i) << ", stepsize: " << zstepsize << " offset: " <<  zmin_max[*layer].first << endl;
 		}
 	      // check bin range
 	      if (phibin[0] < 0 || phibin[0] >= nphibins || phibin[1] < 0 || phibin[1] >= nphibins)
@@ -636,7 +636,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 	      int intphibinout = phibin[1];
 	      int intzbinout = zbin[1];
 
-	      if (verbosity > 0)
+	      if (Verbosity() > 0)
 		{
 		  cout << "    phi bin range: " << intphibin << " to " << intphibinout << " phi: " << phi[0] << " to " << phi[1] << endl;
 		  cout << "    Z bin range: " << intzbin << " to " << intzbinout << " Z: " << z[0] << " to " << z[1] << endl;
@@ -685,7 +685,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 
 	      if (intphibin == intphibinout && intzbin == intzbinout)   // single cell fired
 		{
-		  if (verbosity > 0)
+		  if (Verbosity() > 0)
 		    {
 		      cout << "SINGLE CELL FIRED: " << intphibin << " " << intzbin << endl;
 		    }
@@ -711,7 +711,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 			  bool yesno = line_and_rectangle_intersect(ax, ay, bx, by, cx, cy, dx, dy, &rr);
 			  if (yesno)
 			    {
-			      if (verbosity > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << rr << endl;
+			      if (Verbosity() > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << rr << endl;
 			      vphi.push_back(ibp);
 			      vz.push_back(ibz);
 			      vdedx.push_back(rr);
@@ -719,16 +719,16 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 			}
 		    }
 		}
-	      if (verbosity > 0) cout << "NUMBER OF FIRED CELLS = " << vz.size() << endl;
+	      if (Verbosity() > 0) cout << "NUMBER OF FIRED CELLS = " << vz.size() << endl;
 
 	      double tmpsum = 0.;
 	      for (unsigned int ii = 0; ii < vz.size(); ii++)
 		{
 		  tmpsum += vdedx[ii];
 		  vdedx[ii] = vdedx[ii] / trklen;
-		  if (verbosity > 0) cout << "  CELL " << ii << "  dE/dX = " <<  vdedx[ii] << endl;
+		  if (Verbosity() > 0) cout << "  CELL " << ii << "  dE/dX = " <<  vdedx[ii] << endl;
 		}
-	      if (verbosity > 0) cout << "    TOTAL TRACK LENGTH = " << tmpsum << " " << trklen << endl;
+	      if (Verbosity() > 0) cout << "    TOTAL TRACK LENGTH = " << tmpsum << " " << trklen << endl;
 
 	      for (unsigned int i1 = 0; i1 < vphi.size(); i1++)   // loop over all fired cells
 		{
@@ -738,7 +738,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		  unsigned long long tmp = iphibin;
 		  unsigned long long key = tmp << 32;
 		  key += izbin;
-		  if(verbosity > 1)
+		  if(Verbosity() > 1)
 		    {
 		      cout << " iphibin " << iphibin << " izbin " << izbin << " key 0x" << hex << key << dec << endl;
 		    }
@@ -749,12 +749,12 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		  if(it != cellptmap.end())
 		    {
 		      cell = it->second;
-		      if(verbosity > 1)
+		      if(Verbosity() > 1)
 			{
 			  cout << "  add energy to existing cell for key = " << cellptmap.find(key)->first << endl;
 			}
 
-		      if(verbosity > 1 && hiter->second->has_property(PHG4Hit::prop_light_yield) && std::isnan(hiter->second->get_light_yield()*vdedx[i1]))
+		      if(Verbosity() > 1 && hiter->second->has_property(PHG4Hit::prop_light_yield) && std::isnan(hiter->second->get_light_yield()*vdedx[i1]))
 			{
 
 			  cout << "    NAN lighy yield with vdedx[i1] = " << vdedx[i1]
@@ -764,7 +764,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		    }
 		  else
 		    {
-		      if(verbosity > 1)
+		      if(Verbosity() > 1)
 			{
 			  cout << "    did not find a previous entry for key = " << key << " create a new one" << endl;
 			}
@@ -782,7 +782,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		  if (hiter->second->has_property(PHG4Hit::prop_light_yield))
 		    {
 		      cell->add_light_yield(hiter->second->get_light_yield()*vdedx[i1]);
-		      if(verbosity > 1 && !std::isfinite(hiter->second->get_light_yield()*vdedx[i1]))
+		      if(Verbosity() > 1 && !std::isfinite(hiter->second->get_light_yield()*vdedx[i1]))
 			{
 			  cout << "    NAN lighy yield with vdedx[i1] = " << vdedx[i1]
 			       << " and hiter->second->get_light_yield() = " << hiter->second->get_light_yield() << endl;
@@ -802,7 +802,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 	    {
 	      cells->AddCell(it->second);
 	      numcells++;
-	      if (verbosity > 1)
+	      if (Verbosity() > 1)
 		{
 		  cout << "Adding cell for key " << it->first << " in bin phi: " << PHG4CellDefs::SizeBinning::get_phibin(it->second->get_cellid())
 		       << " phi: " << geo->get_phicenter(PHG4CellDefs::SizeBinning::get_phibin(it->second->get_cellid())) * 180. / M_PI
@@ -813,7 +813,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		}
 	    }
 
-	  if (verbosity > 0)
+	  if (Verbosity() > 0)
 	    {
 	      cout << "found " << numcells << " z/phi cells with energy deposition" << endl;
 	    }
@@ -821,7 +821,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 
       //==========================================================
       // now reset the cell map before moving on to the next layer
-      if(verbosity > 1)
+      if(Verbosity() > 1)
 	{
 	  cout << "cellptmap for layer " << *layer << " has final length " << cellptmap.size();
 	}
@@ -830,7 +830,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 	  // Assumes that memmory is freed by the cylinder cell container when it is destroyed
 	  cellptmap.erase(cellptmap.begin());
 	}
-      if(verbosity > 1)
+      if(Verbosity() > 1)
 	{
 	  cout << " reset it to " << cellptmap.size() << endl;
 	}
@@ -1129,7 +1129,7 @@ PHG4CylinderCellReco::CheckEnergy(PHCompositeNode *topNode)
     }
   else
     {
-      if (verbosity > 0)
+      if (Verbosity() > 0)
 	{
 	  cout << Name() << ":total energy for this event: " << sum_energy_g4hit << " GeV" << endl;
 	  cout << Name() << ": sum cell energy: " << sum_energy_cells << " GeV" << endl;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellTPCReco.cc
@@ -107,7 +107,7 @@ void PHG4CylinderCellTPCReco::cellsize(const int i, const double sr, const doubl
 
 int PHG4CylinderCellTPCReco::Init(PHCompositeNode *top_node)
 {
-  if (verbosity > 1)
+  if (Verbosity() > 1)
   {
     Fun4AllServer *se = Fun4AllServer::instance();
     fHWindowP = new TProfile2D("TPCGEO_WindowP", "TPCGEO_WindowP", 50, -0.5, 49.5, 220, -110, +110);
@@ -307,7 +307,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
     PHG4HitContainer::ConstIterator hiter;
     PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits(*layer);
     PHG4CylinderCellGeom *geo = seggeo->GetLayerCellGeom(*layer);
-    if (verbosity > 1000)
+    if (Verbosity() > 1000)
     {
       std::cout << "Layer " << (*layer);
       std::cout << " Radius " << geo->get_radius();
@@ -347,7 +347,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
       double r = sqrt(xinout * xinout + yinout * yinout);
       phi = atan2(hiter->second->get_avg_y(), hiter->second->get_avg_x());
       z = hiter->second->get_avg_z();
-      if (verbosity > 2000)
+      if (Verbosity() > 2000)
         cout << "loop over hits, hit avge z = " << hiter->second->get_avg_z()
              << " hit avge x = " << hiter->second->get_avg_x()
              << " hit avge y = " << hiter->second->get_avg_y()
@@ -398,11 +398,11 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
       double zdisp = z - geo->get_zcenter(zbin);
 
       double edep = hiter->second->get_edep();
-      if (verbosity > 1)
+      if (Verbosity() > 1)
       {
         fHMeanEDepPerCell->Fill(float(*layer), z, edep);
       }
-      if (verbosity > 2000) cout << "Find or start a cell for this hit" << endl;
+      if (Verbosity() > 2000) cout << "Find or start a cell for this hit" << endl;
 
       if ((*layer) < (unsigned int) num_pixel_layers)
       {  // MAPS + ITT
@@ -438,7 +438,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
           continue;
         }
         double nelec = gsl_ran_poisson(RandomGenerator, elec_per_gev * eion);
-        if (verbosity > 1)
+        if (Verbosity() > 1)
         {
           fHElectrons->Fill(nelec);
         }
@@ -484,7 +484,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
         cloud_sig_zz[0] *= (1 + fFractZZsm);
         cloud_sig_zz[1] *= (1 + fFractZZsm);
 
-        if (verbosity > 2000)
+        if (Verbosity() > 2000)
           cout << "After adding random displacement: phi = " << phi << " z = " << z << " phibin = " << phibin << " zbin = " << zbin << endl
                << " phidisp = " << phidisp << " zdisp = " << zdisp << " new cloud_sig_rp " << cloud_sig_rp << " cloud_sig_zz[0] " << cloud_sig_zz[0]
                << " cloud_sig_zz[1] " << cloud_sig_zz[1] << endl;
@@ -499,7 +499,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
         // Note that we ignore the difference in drift-diffusion between segments here, for convenience - it will be tiny
 
         double zrange = fabs(hiter->second->get_z(1) - hiter->second->get_z(0));
-        if (verbosity > 2000) cout << " *********** zrange " << zrange << " zout " << hiter->second->get_z(1) << " zin " << hiter->second->get_z(0) << endl;
+        if (Verbosity() > 2000) cout << " *********** zrange " << zrange << " zout " << hiter->second->get_z(1) << " zin " << hiter->second->get_z(0) << endl;
 
 	int nseg = (int)zrange/cloud_sig_zz[0];  // must be odd number
 	if(nseg%2==0)nseg+=1;
@@ -516,7 +516,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
           }
           double zdispseg = z + zsegoffset - geo->get_zcenter(zbinseg);
 
-          if (verbosity > 2000) cout << " ---------- segment izr = " << izr << " with zsegoffset " << zsegoffset << " zbinseg " << zbinseg << " zdispseg " << zdispseg << endl;
+          if (Verbosity() > 2000) cout << " ---------- segment izr = " << izr << " with zsegoffset " << zsegoffset << " zbinseg " << zbinseg << " zdispseg " << zdispseg << endl;
 
           // Now distribute the charge between the pads in phi
 	  //====================================
@@ -582,7 +582,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
 		  if(pad_num >= nphibins) cout << " Error making key: pad_phibin " << pad_num << " nphibins " << nphibins << endl;
 		  unsigned long key = zbin_num * nphibins + pad_num;
 		  
-		  if(verbosity > 5000)
+		  if(Verbosity() > 5000)
 		    cout << "    zbin " << zbin_num << " z of bin " <<  geo->get_zcenter(zbin_num)  << " z integral " << adc_bin_share
 			 << " pad " << pad_num  << " phi of pad " <<  geo->get_phicenter(pad_num)  << " phi integral " << pad_share 
 			 << " nelectrons = " << neffelectrons << " key = " << key << endl;
@@ -615,7 +615,7 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
 		} // end of loop over adc bins
 	    } // end of loop over zigzag pads
 
-	  if(verbosity > 5000)
+	  if(Verbosity() > 5000)
 	    {	  
 	      cout << " quick centroid using neffelectrons " << endl;
 	      cout << "      phi centroid = " << phi_integral / weight << " truth phi " << truth_phi << " z centroid = " << z_integral / weight << " truth z " << truth_z << endl;
@@ -630,19 +630,19 @@ int PHG4CylinderCellTPCReco::process_event(PHCompositeNode *topNode)
       cells->AddCell(it->second);
       int phibin = PHG4CellDefs::SizeBinning::get_phibin(it->second->get_cellid());
       int zbin = PHG4CellDefs::SizeBinning::get_zbin(it->second->get_cellid());
-      if (verbosity > 1)
+      if (Verbosity() > 1)
       {
         float zthis = geo->get_zcenter(zbin);
         fHMeanElectronsPerCell->Fill(float(*layer), zthis, it->second->get_edep());
       }
-      if (verbosity > 2000)
+      if (Verbosity() > 2000)
         std::cout << " Adding phibin " << phibin << " zbin " << zbin << " with edep " << it->second->get_edep() << std::endl;
       count += 1;
     }
-    if (verbosity > 1000)
+    if (Verbosity() > 1000)
       std::cout << " || Number of cells hit " << count << std::endl;
   }
-  if (verbosity > 1000) std::cout << "PHG4CylinderCellTPCReco end" << std::endl;
+  if (Verbosity() > 1000) std::cout << "PHG4CylinderCellTPCReco end" << std::endl;
   _timer.get()->stop();
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -695,7 +695,7 @@ void PHG4CylinderCellTPCReco::populate_zigzag_phibins(PHG4CylinderCellGeom *geo,
   fcharge->SetParameter(0, 1.0);
   fcharge->SetParameter(1, rphi);
   fcharge->SetParameter(2, cloud_sig_rp);
-  if(verbosity > 5000) cout << " fcharge created: radius " << (geo->get_radius() + geo->get_thickness() / 2.0) << " rphi " << rphi << " cloud_sig_rp " << cloud_sig_rp << endl;
+  if(Verbosity() > 5000) cout << " fcharge created: radius " << (geo->get_radius() + geo->get_thickness() / 2.0) << " rphi " << rphi << " cloud_sig_rp " << cloud_sig_rp << endl;
   
   // Get the range of phi values that completely contains all pads  that touch the charge distribution - (nsigmas + 1/2 pad width) in each direction
   double philim_low = phi - nsigmas * cloud_sig_rp /  ( (geo->get_radius() + geo->get_thickness() / 2.0) -  geo->get_phistep() );
@@ -705,7 +705,7 @@ void PHG4CylinderCellTPCReco::populate_zigzag_phibins(PHG4CylinderCellGeom *geo,
   double phibin_low = geo->get_phibin(philim_low);
   double phibin_high = geo->get_phibin(philim_high);
   int npads = phibin_high - phibin_low;
-  if(verbosity>5000)   cout << " zigzags: phi " << phi << " philim_low " << philim_low << " phibin_low " << phibin_low 
+  if(Verbosity()>5000)   cout << " zigzags: phi " << phi << " philim_low " << philim_low << " phibin_low " << phibin_low 
 			    << " philim_high " << philim_high << " phibin_high " << phibin_high << " npads " << npads << endl;
   if(npads < 0 || npads >9) npads = 9;  // can happen if phibin_high wraps around. If so, limit to 10 pads and fix below
 
@@ -726,7 +726,7 @@ void PHG4CylinderCellTPCReco::populate_zigzag_phibins(PHG4CylinderCellGeom *geo,
       fpad[ipad]->SetParameter(0,pad_rphi/2.0);
       fpad[ipad]->SetParameter(1, rphi_pad_now);
 
-      if(verbosity>5000) cout << " zigzags: make fpad for ipad " << ipad << " pad_now " << pad_now << " pad_rphi/2 " << pad_rphi/2.0 
+      if(Verbosity()>5000) cout << " zigzags: make fpad for ipad " << ipad << " pad_now " << pad_now << " pad_rphi/2 " << pad_rphi/2.0 
 			      << " rphi_pad_now " << rphi_pad_now << endl;
     }
 
@@ -760,7 +760,7 @@ void PHG4CylinderCellTPCReco::populate_zigzag_phibins(PHG4CylinderCellGeom *geo,
     {
       pad_phibin.push_back(pad_keep[ipad]);
       pad_phibin_share.push_back(overlap[ipad]);      
-      if(verbosity > 5000) cout << "         zigzags: for pad " << ipad  << " integral is " << overlap[ipad] << endl;	     	      
+      if(Verbosity() > 5000) cout << "         zigzags: for pad " << ipad  << " integral is " << overlap[ipad] << endl;	     	      
     }
   
   return;
@@ -808,7 +808,7 @@ void PHG4CylinderCellTPCReco::populate_zbins(PHG4CylinderCellGeom *geo, const do
       // 1/2 * the erf is the integral probability from the argument Z value to zero, so this is the integral probability between the Z limits
       double z_integral = 0.5 * (erf(zLim1) - erf(zLim2));
 
-      if(verbosity > 5000) 
+      if(Verbosity() > 5000) 
 	cout << "   populate_zbins:  cur_z_bin " << cur_z_bin << "  center z " << geo->get_zcenter(cur_z_bin) 
 	     << "  zLim1 " << zLim1 << " zLim2 " << zLim2 << " z_integral " << z_integral << endl;
       

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
@@ -28,13 +28,13 @@ int PHG4FPbScSubsystem::Init( PHCompositeNode* topNode )
   hitnodename <<  "G4HIT_" << Name(); 
  
   // create hit list
-  PHG4HitContainer* fcal_hits =  findNode::getClass<PHG4HitContainer>( topNode , ("G4HIT_"+ThisName).c_str() );
+  PHG4HitContainer* fcal_hits =  findNode::getClass<PHG4HitContainer>( topNode , ("G4HIT_"+Name()).c_str() );
   if ( !fcal_hits )
   {
     
     PHNodeIterator iter( topNode );
     PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","DST" ));
-    dstNode->addNode( new PHIODataNode<PHObject>( fcal_hits = new PHG4HitContainer(("G4HIT_"+ThisName)), ("G4HIT_"+ThisName).c_str(),"PHObject" ));
+    dstNode->addNode( new PHIODataNode<PHObject>( fcal_hits = new PHG4HitContainer(("G4HIT_"+Name())), ("G4HIT_"+Name()),"PHObject" ));
   }
   
   // create detector

--- a/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardCalCellReco.cc
@@ -127,7 +127,7 @@ PHG4ForwardCalCellReco::process_event(PHCompositeNode *topNode)
 	  numcells++;
 	}
       celllist.clear();
-      if (verbosity > 0)
+      if (Verbosity() > 0)
 	{
 	  cout << Name() << ": found " << numcells << " eta/slat cells with energy deposition" << endl;
 	}
@@ -182,7 +182,7 @@ PHG4ForwardCalCellReco::CheckEnergy(PHCompositeNode *topNode)
     }
   else
     {
-      if (verbosity > 0)
+      if (Verbosity() > 0)
 	{
 	  cout << Name() << ": total energy for this event: " << sum_energy_g4hit << " GeV" << endl;
 	}

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.cc
@@ -48,7 +48,7 @@ int PHG4ForwardEcalSubsystem::Init( PHCompositeNode* topNode )
   detector_->SetAbsorberActive(absorber_active);
   detector_->BlackHole(blackhole);
   detector_->OverlapCheck(overlapcheck);
-  detector_->Verbosity(verbosity);
+  detector_->Verbosity(Verbosity());
   detector_->SetTowerMappingFile( mappingfile_ );
 
   if (active)

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystem.cc
@@ -42,7 +42,7 @@ int PHG4ForwardHcalSubsystem::Init( PHCompositeNode* topNode )
   detector_->SetAbsorberActive(absorber_active);
   detector_->BlackHole(blackhole);
   detector_->OverlapCheck(overlapcheck);
-  detector_->Verbosity(verbosity);
+  detector_->Verbosity(Verbosity());
   detector_->SetTowerMappingFile( mappingfile_ );
 
   if (active)

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -106,7 +106,7 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
       topNode->print();
       exit(1);
     }
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       cout << "PHG4FullProjSpacalCellReco::InitRun - incoming geometry:"
            << endl;
@@ -137,7 +137,7 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
 	   << layergeom_raw->ClassName() << endl;
       exit(1);
     }
-  if (verbosity > 1)
+  if (Verbosity() > 1)
     {
       layergeom->identify();
     }
@@ -257,7 +257,7 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
 	      layerseggeo->set_etabounds(sub_tower_etabin,etabounds);
 	      layerseggeo->set_zbounds(sub_tower_etabin,zbounds);
 
-	      if (verbosity >= VERBOSITY_SOME)
+	      if (Verbosity() >= VERBOSITY_SOME)
 	        {
 	          cout << "PHG4FullProjSpacalCellReco::InitRun::" << Name()
                << "\t tower_ID_z = " << tower_ID_z
@@ -281,7 +281,7 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
 
       // add geo object filled by different binning methods
   seggeo->AddLayerCellGeom(layerseggeo);
-  if (verbosity >= VERBOSITY_SOME)
+  if (Verbosity() >= VERBOSITY_SOME)
     {
       cout << "PHG4FullProjSpacalCellReco::InitRun::" << Name()
 	   << " - Done layer" << (layergeom->get_layer())
@@ -462,7 +462,7 @@ PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
     {
       cells->AddCell(mapiter->second);
       numcells++;
-      if (verbosity > 1)
+      if (Verbosity() > 1)
 	{
 	  cout << "PHG4FullProjSpacalCellReco::process_event::" << Name()
 	       << " - " << "Adding cell in bin eta "
@@ -477,7 +477,7 @@ PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
 	}
     }
   celllist.clear();
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       cout << "PHG4FullProjSpacalCellReco::process_event::" << Name()
 	   << " - " << " found " << numcells
@@ -485,7 +485,7 @@ PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
     }
     
 
-  if (chkenergyconservation || verbosity > 4)
+  if (chkenergyconservation || Verbosity() > 4)
     {
       CheckEnergy(topNode);
     }
@@ -517,7 +517,7 @@ PHG4FullProjSpacalCellReco::CheckEnergy(PHCompositeNode *topNode)
     }
   else
     {
-      if (verbosity > 0)
+      if (Verbosity() > 0)
         {
           cout << "PHG4FullProjSpacalCellReco::CheckEnergy::" << Name()
               << " - total energy for this event: " << sum_energy_g4hit

--- a/simulation/g4simulation/g4detectors/PHG4GenHit.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GenHit.cc
@@ -58,7 +58,7 @@ PHG4GenHit::process_event(PHCompositeNode *topNode)
   hit->set_edep(eloss);
   hit->set_trkid(-1);
   hits_->AddHit(layer, hit);
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
   cout << "phi " << phi << " inner rad: " << inner_radius
        << ", outer rad: " << outer_radius

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -175,7 +175,7 @@ PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
 	    }
 	}
     }
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       cout << Name() << ": found " << nslathits << " slats with energy deposition" << endl;
     }
@@ -227,7 +227,7 @@ PHG4HcalCellReco::CheckEnergy(PHCompositeNode *topNode)
     }
   else
     {
-      if (verbosity > 0)
+      if (Verbosity() > 0)
 	{
 	  cout << Name() << ": total energy for this event: " << sum_energy_g4hit << " GeV" << endl;
 	}

--- a/simulation/g4simulation/g4detectors/PHG4MapsCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsCellReco.cc
@@ -41,7 +41,7 @@ PHG4MapsCellReco::PHG4MapsCellReco(const string &name) :
   SetDefaultParameters();   // sets default timing window
   memset(nbins, 0, sizeof(nbins));
 
-  if(verbosity > 0)  
+  if(Verbosity() > 0)  
     cout << "Creating PHG4MapsCellReco for name = " << name << endl;
 }
 
@@ -90,7 +90,7 @@ int PHG4MapsCellReco::InitRun(PHCompositeNode *topNode)
       cout << "Could not locate geometry node " << geonodename << endl;
       exit(1);
     }
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       geo->identify();
     }
@@ -144,7 +144,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
       if(!layergeom)
 	exit(1);
 
-      if(verbosity > 2)
+      if(Verbosity() > 2)
 	layergeom->identify();
 
       // Get some layer parameters for later use
@@ -158,7 +158,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
       for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
 	{
 	  //cout << "From PHG4MapsCellReco: Call hit print method: " << endl;
-	  if(verbosity >4)
+	  if(Verbosity() >4)
 	    hiter->second->print();
 
 	  // checking ADC timing integration window cut
@@ -167,7 +167,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
 	      cout  << PHWHERE << "Maps layers only go up to three! Quit." << endl;
 	      exit(1);
 	    }
-	  if(verbosity > 1)
+	  if(Verbosity() > 1)
 	    cout << " layer " << *layer << " t0 " << hiter->second->get_t(0) << " t1 " << hiter->second->get_t(1)
 		 << " tmin " <<  tmin_max[*layer].first << " tmax " <<  tmin_max[*layer].second
 		 << endl;
@@ -184,7 +184,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
  	  TVector3 local_out( hiter->second->get_local_x(1),  hiter->second->get_local_y(1),  hiter->second->get_local_z(1) );
 	  TVector3 midpoint( (local_in.X() + local_out.X()) / 2.0, (local_in.Y() + local_out.Y()) / 2.0, (local_in.Z() + local_out.Z()) / 2.0 );
 
-	  if(verbosity > 4)
+	  if(Verbosity() > 4)
 	    {
 	      cout << endl << "  world entry point position: " << hiter->second->get_x(0) << " " << hiter->second->get_y(0) << " " << hiter->second->get_z(0) << endl;
 	      cout << "  world exit point position: " << hiter->second->get_x(1) << " " << hiter->second->get_y(1) << " " << hiter->second->get_z(1) << endl;
@@ -197,7 +197,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
 	      cout << endl;
 	    }
 
-	  if(verbosity > 2)
+	  if(Verbosity() > 2)
 	    {
 	      // As a check, get the positions of the hit pixels in world coordinates from the geo object 
 	      TVector3 location_in = layergeom->get_world_from_local_coords(stave_number, half_stave_number, module_number, chip_number, local_in);
@@ -270,7 +270,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
 
 	    }
 
-	  if(verbosity > 0)
+	  if(Verbosity() > 0)
 	    cout << "entry pixel number " << pixel_number_in << " exit pixel number " << pixel_number_out << endl;
 
 	  vector<int> vpixel;
@@ -350,7 +350,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
 	  if(xbin_max > maxNX) xbin_max = maxNX;
 	  if(zbin_max > maxNZ) xbin_max = maxNZ;
 
-	  if(verbosity > 1)
+	  if(Verbosity() > 1)
 	    {
 	      cout << " xbin_in " << xbin_in << " xbin_out " << xbin_out << " xbin_min " << xbin_min << " xbin_max " << xbin_max << endl;
 	      cout << " zbin_in " << zbin_in << " zbin_out " << zbin_out << " zbin_min " << zbin_min << " zbin_max " << zbin_max << endl;
@@ -384,7 +384,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
 	      // increases from diffusion width_min to diffusion_width_max 
 	      double ydiffusion_radius = diffusion_width_min + (ydrift / ydrift_max) * (diffusion_width_max - diffusion_width_min);  
 	      
-	      if(verbosity > 5)
+	      if(Verbosity() > 5)
 		cout << " segment " << i 
 		     << " interval " << interval
 		     << " frac " << frac
@@ -437,7 +437,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
 			{
                           pixeion[ix-xbin_min][iz-zbin_min] += pixarea_frac * hiter->second->get_eion() / (float) nsegments;
 			}
-		      if(verbosity > 5)
+		      if(Verbosity() > 5)
 			{
 			  cout << "    pixnum " << pixnum << " xbin " << ix << " zbin " << iz
 			       << " pixel_area fraction of circle " << pixarea_frac << " accumulated pixel energy " << pixenergy[ix-xbin_min][iz-zbin_min]
@@ -460,7 +460,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
 		      vzbin.push_back(iz);
 		      pair <double,double> tmppair = make_pair(pixenergy[ix-xbin_min][iz-zbin_min],pixeion[ix-xbin_min][iz-zbin_min]);
 		      venergy.push_back(tmppair);  	  
-		      if(verbosity > 1)
+		      if(Verbosity() > 1)
 			cout << " Added pixel number " << pixnum << " xbin " << ix << " zbin " << iz << " to vectors with energy " << pixenergy[ix-xbin_min][iz-zbin_min] << endl;
 		    }		    	
 		}
@@ -553,7 +553,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
 		}
 	      cell->add_edep( venergy[i1].first);
 	      
-	      if(verbosity > 1)
+	      if(Verbosity() > 1)
 		{
 		  cout << " looping over fired cells: cell " << i1 << " inkey 0x" << hex << inkey << dec 
 		       << " cell energy " << venergy[i1].first
@@ -569,7 +569,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
 	  cells->AddCell(mapiter->second);
 	  numcells++;
 	  
-	  if (verbosity > 0)
+	  if (Verbosity() > 0)
 	    {
 	      cout << "From MapsCellReco: Adding cell for stave: " << mapiter->second->get_stave_index()
 		   << " , half stave index: " << mapiter->second->get_half_stave_index()
@@ -581,7 +581,7 @@ PHG4MapsCellReco::process_event(PHCompositeNode *topNode)
 	    }
 	}
       celllist.clear();
-      if (verbosity > 0)
+      if (Verbosity() > 0)
 	{
 	  cout << Name() << ": found " << numcells << " silicon pixels with energy deposition" << endl;
 	}
@@ -632,7 +632,7 @@ PHG4MapsCellReco::CheckEnergy(PHCompositeNode *topNode)
     }
   else
     {
-      if (verbosity > 0)
+      if (Verbosity() > 0)
 	{
 	  cout << Name() << ": total energy for this event: " << sum_energy_g4hit << " GeV" << endl;
 	}
@@ -803,7 +803,7 @@ double  PHG4MapsCellReco::circle_rectangle_intersection( double x1, double y1,  
   y1 -= my; 
   y2 -= my;
 
-  if(verbosity > 7)
+  if(Verbosity() > 7)
     {
       cout << " mx " << mx << " my " << my << " r " << r << " x1 " << x1 << " x2 " << x2 << " y1 " << y1 << " y2 " << y2 << endl;
       cout << " sA21 " << sA(r,x2,y1)

--- a/simulation/g4simulation/g4detectors/PHG4MapsSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsSubsystem.cc
@@ -58,7 +58,7 @@ PHG4MapsSubsystem::PHG4MapsSubsystem( const std::string &name, const int lyr, in
 //_______________________________________________________________________
 int PHG4MapsSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 {
-  if(verbosity>0)
+  if(Verbosity()>0)
     cout << "PHG4MapsSubsystem::Init started" << endl;
 
   PHNodeIterator iter( topNode );

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2HcalCellReco.cc
@@ -176,7 +176,7 @@ int PHG4Prototype2HcalCellReco::process_event(PHCompositeNode *topNode)
         }
       }
     }
-    if (verbosity > 0)
+    if (Verbosity() > 0)
     {
       cout << Name() << ": found " << nslathits << " slats with energy deposition" << endl;
     }
@@ -218,7 +218,7 @@ int PHG4Prototype2HcalCellReco::CheckEnergy(PHCompositeNode *topNode)
   }
   else
   {
-    if (verbosity > 0)
+    if (Verbosity() > 0)
     {
       cout << Name() << ": total energy for this event: " << sum_energy_g4hit << " GeV" << endl;
     }

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerCellReco.cc
@@ -125,7 +125,7 @@ int PHG4SiliconTrackerCellReco::InitRun(PHCompositeNode *topNode)
     exit(1);
   }
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     geo->identify();
   }
@@ -173,7 +173,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
 
   // loop over all of the layers in the hit container
   // we need the geometry object for this layer
-  if (verbosity > 2) cout << " PHG4SiliconTrackerCellReco: Loop over hits" << endl;
+  if (Verbosity() > 2) cout << " PHG4SiliconTrackerCellReco: Loop over hits" << endl;
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
   for (PHG4HitContainer::ConstIterator hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
   {
@@ -201,7 +201,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
     layergeom->find_strip_index_values(ladder_z_index, hiter->second->get_local_y(0), hiter->second->get_local_z(0), strip_y_index_in, strip_z_index_in);
     layergeom->find_strip_index_values(ladder_z_index, hiter->second->get_local_y(1), hiter->second->get_local_z(1), strip_y_index_out, strip_z_index_out);
 
-    if (verbosity > 5)
+    if (Verbosity() > 5)
     {
       // check to see if we get back the positions from these strip index values
       double check_location[3] = {-1, -1, -1};
@@ -274,7 +274,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
       // increases from diffusion width_min to diffusion_width_max
       double diffusion_radius = diffusion_width;
 
-      if (verbosity > 5)
+      if (Verbosity() > 5)
         cout << " segment " << i
              << " interval " << interval
              << " frac " << frac
@@ -313,7 +313,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
           {
             stripeion[iy - minstrip_y][iz - minstrip_z] += striparea_frac * hiter->second->get_eion() / (float) nsegments;
           }
-          if (verbosity > 5)
+          if (Verbosity() > 5)
           {
             cout << "    strip y index " << iy << " strip z index  " << iz
                  << " strip area fraction of circle " << striparea_frac << " accumulated pixel energy " << stripenergy[iy - minstrip_y][iz - minstrip_z]
@@ -333,7 +333,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
           vzbin.push_back(iz);
           pair<double, double> tmppair = make_pair(stripenergy[iy - minstrip_y][iz - minstrip_z], stripeion[iy - minstrip_y][iz - minstrip_z]);
           venergy.push_back(tmppair);
-          if (verbosity > 1)
+          if (Verbosity() > 1)
             cout << " Added ybin " << iy << " zbin " << iz << " to vectors with energy " << stripenergy[iy - minstrip_y][iz - minstrip_z] << endl;
         }
       }
@@ -358,7 +358,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
       if (it != m_CellList.end())
       {
         cell = it->second;
-        if (verbosity > 2)
+        if (Verbosity() > 2)
         {
           cout << " found existing cell with key " << key << endl;
         }
@@ -367,7 +367,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
       // There is not an existing cell to add this hit to, start a new cell
       if (!cell)
       {
-        if (verbosity > 2)
+        if (Verbosity() > 2)
         {
           cout << " did not find existing cell with key " << key << " start a new one" << endl;
         }
@@ -401,7 +401,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
     cells->AddCell(mapiter->second);
     numcells++;
 
-    if (verbosity > 0)
+    if (Verbosity() > 0)
     {
       std::cout << "Adding cell for "
                 << " layer " << mapiter->second->get_layer()
@@ -415,7 +415,7 @@ int PHG4SiliconTrackerCellReco::process_event(PHCompositeNode *topNode)
   }
   m_CellList.clear();
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     std::cout << Name() << ": found " << numcells << " silicon strips with energy deposition" << std::endl;
 
   if (m_ChkEnergyConservationFlag)
@@ -457,7 +457,7 @@ int PHG4SiliconTrackerCellReco::CheckEnergy(PHCompositeNode *topNode)
   }
   else
   {
-    if (verbosity > 0)
+    if (Verbosity() > 0)
     {
       std::cout << Name() << ": total energy for this event: " << sum_energy_g4hit << " GeV" << std::endl;
     }
@@ -476,7 +476,7 @@ double PHG4SiliconTrackerCellReco::circle_rectangle_intersection(double x1, doub
   y1 -= my;
   y2 -= my;
 
-  if (verbosity > 7)
+  if (Verbosity() > 7)
   {
     cout << " mx " << mx << " my " << my << " r " << r << " x1 " << x1 << " x2 " << x2 << " y1 " << y1 << " y2 " << y2 << endl;
     cout << " sA21 " << sA(r, x2, y1)

--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerSubsystem.cc
@@ -40,7 +40,7 @@ PHG4SiliconTrackerSubsystem::PHG4SiliconTrackerSubsystem(const std::string &dete
 //_______________________________________________________________________
 int PHG4SiliconTrackerSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     std::cout << "PHG4SiliconTrackerSubsystem::Init started" << std::endl;
   }

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
@@ -43,7 +43,7 @@ PHG4SpacalPrototypeSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   PHNodeIterator iter( topNode );
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     cout
         << "PHG4SpacalPrototypeSubsystem::InitRun - use PHG4SpacalPrototypeDetector"
         << endl;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -56,7 +56,7 @@ int PHG4SpacalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   switch (GetParams()->get_int_param("config"))
   {
   case PHG4CylinderGeom_Spacalv1::kNonProjective:
-    if (verbosity > 0) cout << "PHG4SpacalSubsystem::InitRun - use PHG4SpacalDetector" << endl;
+    if (Verbosity() > 0) cout << "PHG4SpacalSubsystem::InitRun - use PHG4SpacalDetector" << endl;
     detector_ = new PHG4SpacalDetector(topNode, Name(), GetParams(), GetLayer());
     break;
 
@@ -68,13 +68,13 @@ int PHG4SpacalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
 
   case PHG4CylinderGeom_Spacalv1::kFullProjective_2DTaper:
   case PHG4CylinderGeom_Spacalv1::kFullProjective_2DTaper_SameLengthFiberPerTower:
-    if (verbosity > 0) cout << "PHG4SpacalSubsystem::InitRun - use PHG4FullProjSpacalDetector" << endl;
+    if (Verbosity() > 0) cout << "PHG4SpacalSubsystem::InitRun - use PHG4FullProjSpacalDetector" << endl;
     detector_ = new PHG4FullProjSpacalDetector(topNode, Name(), GetParams(), GetLayer());
     break;
 
   case PHG4CylinderGeom_Spacalv1::kFullProjective_2DTaper_Tilted:
   case PHG4CylinderGeom_Spacalv1::kFullProjective_2DTaper_Tilted_SameLengthFiberPerTower:
-    if (verbosity > 0) cout << "PHG4SpacalSubsystem::InitRun - use PHG4FullProjTiltedSpacalDetector" << endl;
+    if (Verbosity() > 0) cout << "PHG4SpacalSubsystem::InitRun - use PHG4FullProjTiltedSpacalDetector" << endl;
     detector_ = new PHG4FullProjTiltedSpacalDetector(topNode, Name(), GetParams(), GetLayer());
     break;
 

--- a/simulation/g4simulation/g4eval/CaloEvaluator.C
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.C
@@ -55,9 +55,7 @@ CaloEvaluator::CaloEvaluator(const string& name, const string& caloname, const s
   , _ntp_cluster(nullptr)
   , _filename(filename)
   , _tfile(nullptr)
-{
-  verbosity = 0;
-}
+{}
 
 int CaloEvaluator::Init(PHCompositeNode* topNode)
 {
@@ -97,7 +95,7 @@ int CaloEvaluator::process_event(PHCompositeNode* topNode)
   {
     _caloevalstack = new CaloEvalStack(topNode, _caloname);
     _caloevalstack->set_strict(_strict);
-    _caloevalstack->set_verbosity(verbosity + 1);
+    _caloevalstack->set_verbosity(Verbosity() + 1);
   }
   else
   {
@@ -140,7 +138,7 @@ int CaloEvaluator::End(PHCompositeNode* topNode)
 
   delete _tfile;
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     cout << "========================= " << Name() << "::End() ============================" << endl;
     cout << " " << _ievent << " events of output written to: " << _filename << endl;
@@ -154,11 +152,11 @@ int CaloEvaluator::End(PHCompositeNode* topNode)
 
 void CaloEvaluator::printInputInfo(PHCompositeNode* topNode)
 {
-  if (verbosity > 2) cout << "CaloEvaluator::printInputInfo() entered" << endl;
+  if (Verbosity() > 2) cout << "CaloEvaluator::printInputInfo() entered" << endl;
 
   // print out the truth container
 
-  if (verbosity > 1)
+  if (Verbosity() > 1)
   {
     cout << endl;
     cout << PHWHERE << "   NEW INPUT FOR EVENT " << _ievent << endl;
@@ -191,7 +189,7 @@ void CaloEvaluator::printInputInfo(PHCompositeNode* topNode)
 
 void CaloEvaluator::printOutputInfo(PHCompositeNode* topNode)
 {
-  if (verbosity > 2) cout << "CaloEvaluator::printOutputInfo() entered" << endl;
+  if (Verbosity() > 2) cout << "CaloEvaluator::printOutputInfo() entered" << endl;
 
   CaloRawClusterEval* clustereval = _caloevalstack->get_rawcluster_eval();
   CaloTruthEval* trutheval = _caloevalstack->get_truth_eval();
@@ -200,7 +198,7 @@ void CaloEvaluator::printOutputInfo(PHCompositeNode* topNode)
   // print out some useful stuff for debugging
   //==========================================
 
-  if (verbosity > 1)
+  if (Verbosity() > 1)
   {
     // event information
     cout << endl;
@@ -344,7 +342,7 @@ void CaloEvaluator::printOutputInfo(PHCompositeNode* topNode)
 
 void CaloEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 {
-  if (verbosity > 2) cout << "CaloEvaluator::fillOutputNtuples() entered" << endl;
+  if (Verbosity() > 2) cout << "CaloEvaluator::fillOutputNtuples() entered" << endl;
 
   CaloRawClusterEval* clustereval = _caloevalstack->get_rawcluster_eval();
   CaloRawTowerEval* towereval = _caloevalstack->get_rawtower_eval();
@@ -404,7 +402,7 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
   if (_ntp_gshower)
   {
-    if (verbosity > 1) cout << Name() << " CaloEvaluator::filling gshower ntuple..." << endl;
+    if (Verbosity() > 1) cout << Name() << " CaloEvaluator::filling gshower ntuple..." << endl;
 
     GlobalVertexMap* vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
 
@@ -524,7 +522,7 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
   if (_do_tower_eval)
   {
-    if (verbosity > 1) cout << "CaloEvaluator::filling tower ntuple..." << endl;
+    if (Verbosity() > 1) cout << "CaloEvaluator::filling tower ntuple..." << endl;
 
     string towernode = "TOWER_CALIB_" + _caloname;
     RawTowerContainer* towers = findNode::getClass<RawTowerContainer>(topNode, towernode.c_str());
@@ -653,7 +651,7 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
   if (_do_cluster_eval)
   {
-    if (verbosity > 1) cout << "CaloEvaluator::filling gcluster ntuple..." << endl;
+    if (Verbosity() > 1) cout << "CaloEvaluator::filling gcluster ntuple..." << endl;
 
     GlobalVertexMap* vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
 

--- a/simulation/g4simulation/g4eval/JetEvaluator.C
+++ b/simulation/g4simulation/g4eval/JetEvaluator.C
@@ -35,9 +35,8 @@ JetEvaluator::JetEvaluator(const string &name,
     _ntp_recojet(nullptr),
     _ntp_truthjet(nullptr),
     _filename(filename),
-    _tfile(nullptr) {
-  verbosity = 0;
-}
+    _tfile(nullptr) 
+{}
 
 int JetEvaluator::Init(PHCompositeNode *topNode) {
   
@@ -63,7 +62,7 @@ int JetEvaluator::process_event(PHCompositeNode *topNode) {
   if (!_jetevalstack) {
     _jetevalstack = new JetEvalStack(topNode,_recojetname,_truthjetname); 
     _jetevalstack->set_strict(_strict);
-    _jetevalstack->set_verbosity(verbosity+1);
+    _jetevalstack->set_verbosity(Verbosity()+1);
   } else {
     _jetevalstack->next_event(topNode);
   }
@@ -102,7 +101,7 @@ int JetEvaluator::End(PHCompositeNode *topNode) {
 
   delete _tfile;
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "========================== JetEvaluator::End() ============================" << endl;
     cout << " " << _ievent << " events of output written to: " << _filename << endl;
     cout << "===========================================================================" << endl;
@@ -125,7 +124,7 @@ void JetEvaluator::printOutputInfo(PHCompositeNode *topNode) {
 
 void JetEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   
-  if (verbosity > 2) cout << "JetEvaluator::fillOutputNtuples() entered" << endl;
+  if (Verbosity() > 2) cout << "JetEvaluator::fillOutputNtuples() entered" << endl;
 
   JetRecoEval*   recoeval = _jetevalstack->get_reco_eval();
   //JetTruthEval* trutheval = _jetevalstack->get_truth_eval();
@@ -135,7 +134,7 @@ void JetEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //-------------------------
 
   if (_do_recojet_eval) {
-    if (verbosity > 1) cout << "JetEvaluator::filling recojet ntuple..." << endl;
+    if (Verbosity() > 1) cout << "JetEvaluator::filling recojet ntuple..." << endl;
 
     JetMap* recojets = findNode::getClass<JetMap>(topNode,_recojetname.c_str());
     if (!recojets) {
@@ -200,7 +199,7 @@ void JetEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //-------------------------
 
   if (_do_truthjet_eval) {
-    if (verbosity > 1) cout << "JetEvaluator::filling truthjet ntuple..." << endl;
+    if (Verbosity() > 1) cout << "JetEvaluator::filling truthjet ntuple..." << endl;
 
     JetMap* truthjets = findNode::getClass<JetMap>(topNode,_truthjetname.c_str());
     if (!truthjets) {

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -73,9 +73,7 @@ SvtxEvaluator::SvtxEvaluator(const string &name, const string &filename, const s
   _trackmapname(trackmapname),
   _tfile(nullptr),
   _timer(nullptr)
-{
-  verbosity = 0;
-}
+{}
 
 int SvtxEvaluator::Init(PHCompositeNode *topNode) {
   
@@ -174,14 +172,14 @@ int SvtxEvaluator::InitRun(PHCompositeNode *topNode) {
   
 int SvtxEvaluator::process_event(PHCompositeNode *topNode) {
   
-  if ((verbosity > 0)&&(_ievent%100==0)) {
+  if ((Verbosity() > 0)&&(_ievent%100==0)) {
     cout << "SvtxEvaluator::process_event - Event = " << _ievent << endl;
   }
 
   if (!_svtxevalstack) {
     _svtxevalstack = new SvtxEvalStack(topNode);
     _svtxevalstack->set_strict(_strict);
-    _svtxevalstack->set_verbosity(verbosity+1);
+    _svtxevalstack->set_verbosity(Verbosity()+1);
   } else {
     _svtxevalstack->next_event(topNode);
   }
@@ -225,7 +223,7 @@ int SvtxEvaluator::End(PHCompositeNode *topNode) {
 
   delete _tfile;
 
-  if (verbosity >  0) {
+  if (Verbosity() >  0) {
     cout << "========================= SvtxEvaluator::End() ============================" << endl;
     cout << " " << _ievent << " events of output written to: " << _filename << endl;
     cout << "===========================================================================" << endl;
@@ -233,8 +231,8 @@ int SvtxEvaluator::End(PHCompositeNode *topNode) {
 
   _errors += _svtxevalstack->get_errors();
   
-  if (verbosity > -1) {
-    if ((_errors > 0)||(verbosity > 0)) {
+  if (Verbosity() > -1) {
+    if ((_errors > 0)||(Verbosity() > 0)) {
       cout << "SvtxEvaluator::End() - Error Count: " << _errors << endl;
     }
   }
@@ -246,9 +244,9 @@ int SvtxEvaluator::End(PHCompositeNode *topNode) {
 
 void SvtxEvaluator::printInputInfo(PHCompositeNode *topNode) {
   
-  if (verbosity > 1) cout << "SvtxEvaluator::printInputInfo() entered" << endl;
+  if (Verbosity() > 1) cout << "SvtxEvaluator::printInputInfo() entered" << endl;
 
-  if (verbosity > 3) {
+  if (Verbosity() > 3) {
     
     // event information
     cout << endl;
@@ -320,13 +318,13 @@ void SvtxEvaluator::printInputInfo(PHCompositeNode *topNode) {
 
 void SvtxEvaluator::printOutputInfo(PHCompositeNode *topNode) {
   
-  if (verbosity > 1) cout << "SvtxEvaluator::printOutputInfo() entered" << endl;
+  if (Verbosity() > 1) cout << "SvtxEvaluator::printOutputInfo() entered" << endl;
 
   //==========================================
   // print out some useful stuff for debugging
   //==========================================
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     
     SvtxTrackEval*     trackeval = _svtxevalstack->get_track_eval();
     SvtxClusterEval* clustereval = _svtxevalstack->get_cluster_eval();
@@ -408,7 +406,7 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode *topNode) {
     else cout << 0 << endl;
 
     // cluster wise information
-    if (verbosity > 1) {
+    if (Verbosity() > 1) {
  
       for(std::set<PHG4Hit*>::iterator iter = g4hits.begin();
 	  iter != g4hits.end();
@@ -581,14 +579,14 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode *topNode) {
       
     cout << endl;
 
-  } // if verbosity
+  } // if Verbosity()
 
   return;
 }
 
 void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
-  if (verbosity > 0) cout << "SvtxEvaluator::fillOutputNtuples() entered" << endl;
+  if (Verbosity() > 0) cout << "SvtxEvaluator::fillOutputNtuples() entered" << endl;
 
   SvtxVertexEval*   vertexeval = _svtxevalstack->get_vertex_eval();
   SvtxTrackEval*     trackeval = _svtxevalstack->get_track_eval();
@@ -621,7 +619,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //-----------------------
 
   if (_ntp_vertex) {
-    if (verbosity > 0){
+    if (Verbosity() > 0){
       cout << "Filling ntp_vertex " << endl;
       cout << "start vertex time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
       _timer->restart();
@@ -859,7 +857,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       }
 
     }
-    if(verbosity >= 1){
+    if(Verbosity() >= 1){
       _timer->stop();
       cout << "vertex time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
     }
@@ -871,7 +869,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
   if (_ntp_gpoint)
   {
-    if (verbosity > 0)
+    if (Verbosity() > 0)
     {
       cout << "Filling ntp_gpoint " << endl;
       _timer->restart();
@@ -943,7 +941,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
         }
       }
     }
-    if (verbosity >= 1)
+    if (Verbosity() >= 1)
     {
       _timer->stop();
       cout << "gpoint time:                " << _timer->get_accumulated_time() / 1000. << " sec" << endl;
@@ -955,7 +953,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //---------------------
 
   if (_ntp_g4hit) {
-    if (verbosity > 0) {cout << "Filling ntp_g4hit " << endl;_timer->restart();}
+    if (Verbosity() > 0) {cout << "Filling ntp_g4hit " << endl;_timer->restart();}
     std::set<PHG4Hit*> g4hits = trutheval->all_truth_hits();
     for (std::set<PHG4Hit*>::iterator iter = g4hits.begin();
 	 iter != g4hits.end();
@@ -1136,7 +1134,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
       _ntp_g4hit->Fill(g4hit_data);
     }
-    if(verbosity >= 1){
+    if(Verbosity() >= 1){
       _timer->stop();
       cout << "g4hit time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
     }
@@ -1147,7 +1145,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //--------------------
 
   if (_ntp_hit) {
-    if (verbosity > 0){ cout << "Filling ntp_hit " << endl;_timer->restart();}
+    if (Verbosity() > 0){ cout << "Filling ntp_hit " << endl;_timer->restart();}
     // need things off of the DST...
     SvtxHitMap* hitmap = findNode::getClass<SvtxHitMap>(topNode,"SvtxHitMap");
     PHG4CylinderCellGeomContainer* geom_container =
@@ -1310,7 +1308,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	_ntp_hit->Fill(hit_data);     
       }
     }
-    if(verbosity >= 1){
+    if(Verbosity() >= 1){
       _timer->stop();
       cout << "hit time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
     }
@@ -1320,10 +1318,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   // fill the Cluster NTuple
   //------------------------
 
-  if (verbosity > 0){ cout << "check for ntp_cluster" << endl;_timer->restart();}
+  if (Verbosity() > 0){ cout << "check for ntp_cluster" << endl;_timer->restart();}
 
   if (_ntp_cluster && !_scan_for_embedded) {
-    if (verbosity > 0) cout << "Filling ntp_cluster (all of them) " << endl;
+    if (Verbosity() > 0) cout << "Filling ntp_cluster (all of them) " << endl;
     // need things off of the DST...
     SvtxClusterMap* clustermap = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
     if (clustermap) {
@@ -1623,7 +1621,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
     
   } else if (_ntp_cluster && _scan_for_embedded) {
 
-    if (verbosity > 0) cout << "Filling ntp_cluster (embedded only) " << endl;
+    if (Verbosity() > 0) cout << "Filling ntp_cluster (embedded only) " << endl;
 
     // if only scanning embedded signals, loop over all the tracks from
     // embedded particles and report all of their clusters, including those
@@ -1799,7 +1797,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       }
     }
   }
-  if(verbosity >= 1){
+  if(Verbosity() >= 1){
     _timer->stop();
     cout << "cluster time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
   }
@@ -1812,7 +1810,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //cout << "check for ntp_gtrack" << endl;
 
   if (_ntp_gtrack) {
-    if (verbosity > 0){ cout << "Filling ntp_gtrack " << endl;_timer->restart();}
+    if (Verbosity() > 0){ cout << "Filling ntp_gtrack " << endl;_timer->restart();}
 
     PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");   
     SvtxClusterMap* clustermap = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
@@ -2110,7 +2108,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
       }	     
     }
-    if(verbosity >= 1){
+    if(Verbosity() >= 1){
       _timer->stop();
       cout << "gtrack time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
     }
@@ -2123,7 +2121,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 
 
   if (_ntp_track) {
-    if (verbosity > 0){ cout << "Filling ntp_track " << endl;_timer->restart();}
+    if (Verbosity() > 0){ cout << "Filling ntp_track " << endl;_timer->restart();}
 
     // need things off of the DST...
     SvtxTrackMap* trackmap = findNode::getClass<SvtxTrackMap>(topNode,_trackmapname.c_str());
@@ -2435,7 +2433,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	_ntp_track->Fill(track_data);
       }
     }
-    if(verbosity >= 1){
+    if(Verbosity() >= 1){
       _timer->stop();
       cout << "track time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
     }
@@ -2446,7 +2444,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
   //---------------------
 
   if (_ntp_gseed ) {
-    if (verbosity > 0) {cout << "Filling ntp_gseed " << endl;_timer->restart();}
+    if (Verbosity() > 0) {cout << "Filling ntp_gseed " << endl;_timer->restart();}
     
     PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode,"G4TruthInfo");
     
@@ -2581,7 +2579,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
       }
     }
 
-    if(verbosity >= 1){
+    if(Verbosity() >= 1){
       _timer->stop();
       cout << "g4hit time:                "<<_timer->get_accumulated_time()/1000. << " sec" <<endl;
     }

--- a/simulation/g4simulation/g4hough/PHG4GenFitTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4GenFitTrackProjection.C
@@ -94,14 +94,14 @@ int PHG4GenFitTrackProjection::InitRun(PHCompositeNode *topNode) {
 			"DafRef",
 			"RKTrackRep", false);
 
-	_fitter->set_verbosity(verbosity);
+	_fitter->set_verbosity(Verbosity());
 
 	if (!_fitter) {
 		cerr << PHWHERE << endl;
 		return Fun4AllReturnCodes::ABORTRUN;
 	}
 
-	if (verbosity > 0) {
+	if (Verbosity() > 0) {
 		cout
 				<< "================== PHG4GenFitTrackProjection::InitRun() ====================="
 				<< endl;
@@ -125,7 +125,7 @@ int PHG4GenFitTrackProjection::InitRun(PHCompositeNode *topNode) {
 }
 
 int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
-	if (verbosity > 1)
+	if (Verbosity() > 1)
 		cout << "PHG4GenFitTrackProjection::process_event -- entered" << endl;
 
 	//---------------------------------
@@ -145,7 +145,7 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 		if (std::isnan(_cal_radii[i]))
 			continue;
 
-		if (verbosity > 1)
+		if (Verbosity() > 1)
 			cout << "Projecting tracks into: " << _cal_names[i] << endl;
 
 		// pull the tower geometry
@@ -189,14 +189,14 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 			<<endl;
 #endif
 			if(!track) {
-				if(verbosity >= 2) LogWarning("!track");
+				if(Verbosity() >= 2) LogWarning("!track");
 				continue;
 			}
 
-			if (verbosity > 1)
+			if (Verbosity() > 1)
 				cout << "projecting track id " << track->get_id() << endl;
 
-			if (verbosity > 1) {
+			if (Verbosity() > 1) {
 				cout << " track pt = " << track->get_pt() << endl;
 			}
 
@@ -208,7 +208,7 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 			SvtxTrackState * trackstate = last_state_iter->second;
 
 			if(!trackstate) {
-				if(verbosity >= 2) LogWarning("!trackstate");
+				if(Verbosity() >= 2) LogWarning("!trackstate");
 				continue;
 			}
 
@@ -273,7 +273,7 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 				rep->extrapolateToCylinder(*msop80, _cal_radii[i], TVector3(0,0,0),  TVector3(0,0,1));
 				//rep->extrapolateToCylinder(*msop80, 5., TVector3(0,0,0),  TVector3(0,0,1));
 			} catch (...) {
-				if(verbosity >= 2) LogWarning("extrapolateToCylinder failed");
+				if(Verbosity() >= 2) LogWarning("extrapolateToCylinder failed");
 				continue;
 			}
 
@@ -327,7 +327,7 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 			double phi = atan2(y, x);
 			double eta = asinh(z / sqrt(x * x + y * y));
 
-			if (verbosity > 1) {
+			if (Verbosity() > 1) {
 				cout << " initial track phi = " << track->get_phi();
 				cout << ", eta = " << track->get_eta() << endl;
 				cout << " calorimeter phi = " << phi << ", eta = " << eta
@@ -371,7 +371,7 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 						if (abs(iphi - binphi) <= 1 and abs(ieta - bineta) <= 1)
 							energy_3x3 += tower->get_energy();
 
-						if (verbosity > 1)
+						if (Verbosity() > 1)
 							cout << " tower " << ieta << " " << wrapphi
 									<< " energy = " << tower->get_energy()
 									<< endl;
@@ -428,7 +428,7 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 			<<endl;
 #endif
 
-				if (verbosity > 1) {
+				if (Verbosity() > 1) {
 					cout << " nearest cluster dphi = " << min_dphi << " deta = "
 							<< min_deta << " e = " << min_e << endl;
 				}
@@ -437,7 +437,7 @@ int PHG4GenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 		} // end track loop
 	} // end calorimeter layer loop
 
-	if (verbosity > 1)
+	if (Verbosity() > 1)
 		cout << "PHG4GenFitTrackProjection::process_event -- exited" << endl;
 
 	return Fun4AllReturnCodes::EVENT_OK;

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -104,7 +104,7 @@ int PHG4HoughTransform::InitRun(PHCompositeNode* topNode) {
   
   int code = CreateNodes(topNode);
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "====================== PHG4HoughTransform::InitRun() ======================" << endl;
     cout << " Magnetic field set to: " << _magField << " Tesla" << endl;
     cout << " Number of tracking layers: " << _nlayers << endl;
@@ -144,7 +144,7 @@ int PHG4HoughTransform::InitRun(PHCompositeNode* topNode) {
 
 int PHG4HoughTransform::process_event(PHCompositeNode *topNode) {
   
-  if (verbosity > 0) cout << "PHG4HoughTransform::process_event -- entered" << endl;
+  if (Verbosity() > 0) cout << "PHG4HoughTransform::process_event -- entered" << endl;
 
   // start fresh  
   _clusters.clear();
@@ -434,20 +434,20 @@ int PHG4HoughTransform::CreateNodes(PHCompositeNode* topNode) {
   if (!tb_node) {
     tb_node = new PHCompositeNode("SVTX");
     dstNode->addNode(tb_node);
-    if (verbosity > 0) cout << "SVTX node added" << endl;
+    if (Verbosity() > 0) cout << "SVTX node added" << endl;
   }
 
   _g4tracks = new SvtxTrackMap_v1;
   PHIODataNode<PHObject>* tracks_node =
     new PHIODataNode<PHObject>(_g4tracks, "SvtxTrackMap", "PHObject");
   tb_node->addNode(tracks_node);
-  if (verbosity > 0) cout << "Svtx/SvtxTrackMap node added" << endl;
+  if (Verbosity() > 0) cout << "Svtx/SvtxTrackMap node added" << endl;
 
   _g4vertexes = new SvtxVertexMap_v1;
   PHIODataNode<PHObject>* vertexes_node =
     new PHIODataNode<PHObject>(_g4vertexes, "SvtxVertexMap", "PHObject");
   tb_node->addNode(vertexes_node);
-  if (verbosity > 0) cout << "Svtx/SvtxVertexMap node added" << endl;
+  if (Verbosity() > 0) cout << "Svtx/SvtxVertexMap node added" << endl;
 
   /*
   PHG4CylinderGeomContainer* geoms =
@@ -556,7 +556,7 @@ int PHG4HoughTransform::InitializeGeometry(PHCompositeNode *topNode) {
     for( ; miter != begin_end.second; miter++) {
       PHG4CylinderCellGeom *cellgeo = miter->second;
       
-      if (verbosity > 1) cellgeo->identify();
+      if (Verbosity() > 1) cellgeo->identify();
       
       _radii[_layer_ilayer_map[cellgeo->get_layer()]] = cellgeo->get_radius();      
     }
@@ -568,7 +568,7 @@ int PHG4HoughTransform::InitializeGeometry(PHCompositeNode *topNode) {
     for( ; miter != begin_end.second; miter++) {
       PHG4CylinderGeom *geo = miter->second;
       
-      if (verbosity > 1) geo->identify();
+      if (Verbosity() > 1) geo->identify();
       
       _radii[_layer_ilayer_map[geo->get_layer()]] = geo->get_radius();      
     }
@@ -580,7 +580,7 @@ int PHG4HoughTransform::InitializeGeometry(PHCompositeNode *topNode) {
     for( ; miter != begin_end.second; miter++) {
       PHG4CylinderGeom *geo = miter->second;
       
-      if (verbosity > 1) geo->identify();
+      if (Verbosity() > 1) geo->identify();
       
       _radii[_layer_ilayer_map[geo->get_layer()]] = geo->get_radius();      
     }
@@ -852,7 +852,7 @@ int PHG4HoughTransform::setup_tracker_object() {
   _tracker->setChi2RemovalCut(_chi2_cut_full*0.5);
   _tracker->setCellularAutomatonChi2Cut(_ca_chi2_cut);
   _tracker->setPrintTimings(false);
-  //_tracker->setVerbosity(verbosity);
+  //_tracker->setVerbosity(Verbosity());
   _tracker->setCutOnDca(_cut_on_dca);
   _tracker->setDcaCut(_dcaxy_cut);
   _tracker->setSmoothBack(true);
@@ -937,7 +937,7 @@ int PHG4HoughTransform::translate_input() {
     _clusters.push_back(hit3d);
   }
 
-  if (verbosity > 20) {
+  if (Verbosity() > 20) {
     cout << "-------------------------------------------------------------------" << endl;
     cout << "PHG4HoughTransform::process_event has the following input clusters:" << endl;
 
@@ -965,7 +965,7 @@ int PHG4HoughTransform::fast_vertex_from_bbc() {
       _vertex[1] = 0.0;
       _vertex[2] = vertex->get_z();
 
-      if (verbosity) cout << " initial bbc vertex guess: "
+      if (Verbosity()) cout << " initial bbc vertex guess: "
 			  << _vertex[0] << " "
 			  << _vertex[1] << " "
 			  << _vertex[2] << endl;      
@@ -1019,7 +1019,7 @@ int PHG4HoughTransform::fast_vertex_guessing() {
   _vertex.clear();
   _vertex.assign(3,0.0);
   
-  if (verbosity) cout << " seed track finding count: " << _tracks.size() << endl;
+  if (Verbosity()) cout << " seed track finding count: " << _tracks.size() << endl;
 
   if (!_tracks.empty()) {
 
@@ -1033,7 +1033,7 @@ int PHG4HoughTransform::fast_vertex_guessing() {
 
     _vertex[2] = zsum / _tracks.size();
 
-    if (verbosity > 0) {
+    if (Verbosity() > 0) {
       cout << " seed track vertex pre-fit: "
 	   << _vertex[0] << " "
 	   << _vertex[1] << " "
@@ -1051,7 +1051,7 @@ int PHG4HoughTransform::fast_vertex_guessing() {
   _track_errors.clear();
   _track_covars.clear();
   
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << " seed track vertex post-fit: "
 	 << _vertex[0] << " " << _vertex[1] << " " << _vertex[2] << endl;
   }  
@@ -1094,7 +1094,7 @@ int PHG4HoughTransform::initial_vertex_finding() {
   // don't need the tracker object anymore
   _tracker_vertex->clear();
   
-  if (verbosity) cout << " initial track finding count: " << _tracks.size() << endl;
+  if (Verbosity()) cout << " initial track finding count: " << _tracks.size() << endl;
 
   if (!_tracks.empty()) {
 
@@ -1114,7 +1114,7 @@ int PHG4HoughTransform::initial_vertex_finding() {
     _vertex[1] = ysum / _tracks.size();
     _vertex[2] = zsum / _tracks.size();
 
-    if (verbosity > 0) {
+    if (Verbosity() > 0) {
       cout << " initial track vertex pre-fit: "
 	   << _vertex[0] - shift_dx << " "
 	   << _vertex[1] - shift_dy << " "
@@ -1135,7 +1135,7 @@ int PHG4HoughTransform::initial_vertex_finding() {
   // shift back to the global coordinates
   shift_coordinate_system(-shift_dx,-shift_dy,-shift_dz);
   
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << " initial track vertex post-fit: "
 	 << _vertex[0] << " " << _vertex[1] << " " << _vertex[2] << endl;
   }  
@@ -1170,11 +1170,11 @@ int PHG4HoughTransform::full_tracking_and_vertexing() {
   // we will need the tracker object below to refit the tracks... so we won't
   // reset it here
   
-  if (verbosity > 0) cout << " final track count: " << _tracks.size() << endl;
+  if (Verbosity() > 0) cout << " final track count: " << _tracks.size() << endl;
 
   if (!_tracks.empty()) {
 
-    if (verbosity > 0) {
+    if (Verbosity() > 0) {
       cout << " final vertex pre-fit: "
 	   << _vertex[0] - shift_dx << " "
 	   << _vertex[1] - shift_dy << " "
@@ -1186,7 +1186,7 @@ int PHG4HoughTransform::full_tracking_and_vertexing() {
     _vertexFinder.findVertex( _tracks, _track_covars, _vertex, 0.020, false );
     _vertexFinder.findVertex( _tracks, _track_covars, _vertex, 0.005, false );
   
-    if (verbosity > 0) {
+    if (Verbosity() > 0) {
       cout << " final vertex post-fit: "
 	   << _vertex[0] - shift_dx << " "
 	   << _vertex[1] - shift_dy << " "
@@ -1342,7 +1342,7 @@ int PHG4HoughTransform::export_output() {
     _g4tracks->insert(&track);
     vertex.insert_track(track.get_id());
 
-    if (verbosity > 5) {
+    if (Verbosity() > 5) {
       cout << "track " << itrack << " quality = " << track.get_quality()
            << endl;
       cout << "px = " << track.get_px() << " py = " << track.get_py()
@@ -1351,9 +1351,9 @@ int PHG4HoughTransform::export_output() {
   }  // track loop
 
   SvtxVertex *vtxptr = _g4vertexes->insert(&vertex);
-  if (verbosity > 5) vtxptr->identify();
+  if (Verbosity() > 5) vtxptr->identify();
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "PHG4HoughTransform::process_event -- leaving process_event"
          << endl;
   }

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -134,7 +134,7 @@ int PHG4HoughTransformTPC::InitRun(PHCompositeNode *topNode)
 {
   int code = CreateNodes(topNode);
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "====================== PHG4HoughTransformTPC::InitRun() ======================" << endl;
     cout << " Magnetic field set to: " << _magField << " Tesla" << endl;
     cout << " Number of tracking layers: " << _nlayers << endl;
@@ -178,11 +178,11 @@ int PHG4HoughTransformTPC::InitRun(PHCompositeNode *topNode)
 
 int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
 {
-  if(verbosity>1000) std::cout << "PHG4HoughTransformTPC::Process_Event" << std::endl;
+  if(Verbosity()>1000) std::cout << "PHG4HoughTransformTPC::Process_Event" << std::endl;
   _timer.get()->restart();
   if(_write_reco_tree==true){ _recoevent->tracks.clear();}
 
-  if(verbosity > 0) cout << "PHG4HoughTransformTPC::process_event -- entered" << endl;
+  if(Verbosity() > 0) cout << "PHG4HoughTransformTPC::process_event -- entered" << endl;
 
   _clusters_init.clear();
   _clusters.clear();
@@ -208,7 +208,7 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
   // Find an initial z-vertex position
   //------------------------------------
 
-  if (verbosity>0 || _use_bbc){
+  if (Verbosity()>0 || _use_bbc){
     fast_vertex_from_bbc();
     if(!_use_bbc)  _vertex[2]=0.0;
   }
@@ -235,7 +235,7 @@ int PHG4HoughTransformTPC::process_event(PHCompositeNode *topNode)
   }
 
   _timer.get()->stop();
-  if(verbosity>1000) std::cout << "PHG4HoughTransformTPC::Process_Event DONE" << std::endl;
+  if(Verbosity()>1000) std::cout << "PHG4HoughTransformTPC::Process_Event DONE" << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -477,18 +477,18 @@ int PHG4HoughTransformTPC::CreateNodes(PHCompositeNode *topNode)
   {
   tb_node = new PHCompositeNode("SVTX");
   dstNode->addNode(tb_node);
-  if (verbosity>0) cout << "SVTX node added" << endl;
+  if (Verbosity()>0) cout << "SVTX node added" << endl;
   }
 
   _g4tracks = new SvtxTrackMap_v1;
   PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(_g4tracks,"SvtxTrackMap","PHObject");
   tb_node->addNode(tracks_node);
-  if (verbosity>0) cout << "Svtx/SvtxTrackMap node added" << endl;
+  if (Verbosity()>0) cout << "Svtx/SvtxTrackMap node added" << endl;
   
   _g4vertexes = new SvtxVertexMap_v1;
   PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(_g4vertexes,"SvtxVertexMap","PHObject");
   tb_node->addNode(vertexes_node);
-  if (verbosity>0) cout << "Svtx/SvtxVertexMap node added" << endl;
+  if (Verbosity()>0) cout << "Svtx/SvtxVertexMap node added" << endl;
 
   return InitializeGeometry(topNode);
 }
@@ -625,7 +625,7 @@ int PHG4HoughTransformTPC::InitializeGeometry(PHCompositeNode *topNode) {
       for( ; miter != begin_end.second; miter++) {
 	PHG4CylinderCellGeom *cellgeo = miter->second;
       
-	if (verbosity > 1) cellgeo->identify();
+	if (Verbosity() > 1) cellgeo->identify();
 
 	_radii[_layer_ilayer_map[cellgeo->get_layer()]] = cellgeo->get_radius();      
 	_smear_xy_layer[_layer_ilayer_map[cellgeo->get_layer()]] = cellgeo->get_radius()*cellgeo->get_phistep();
@@ -639,7 +639,7 @@ int PHG4HoughTransformTPC::InitializeGeometry(PHCompositeNode *topNode) {
       for( ; miter != begin_end.second; miter++) {
 	PHG4CylinderGeom *geo = miter->second;
 	
-	if (verbosity > 1) geo->identify();
+	if (Verbosity() > 1) geo->identify();
 	
 	_radii[_layer_ilayer_map[geo->get_layer()]] = geo->get_radius();      
 	_smear_xy_layer[_layer_ilayer_map[geo->get_layer()]] = geo->get_strip_y_spacing();
@@ -653,7 +653,7 @@ int PHG4HoughTransformTPC::InitializeGeometry(PHCompositeNode *topNode) {
       for( ; miter != begin_end.second; miter++) {
 	PHG4CylinderGeom *geo = miter->second;
 	
-	if (verbosity > 1) geo->identify();
+	if (Verbosity() > 1) geo->identify();
 	
 	_radii[_layer_ilayer_map[geo->get_layer()]] = geo->get_radius();      
 	_smear_xy_layer[_layer_ilayer_map[geo->get_layer()]] = geo->get_pixel_x();
@@ -965,7 +965,7 @@ int PHG4HoughTransformTPC::translate_input(){
     which_vec->push_back(hit3d);
   }
 
-  if (verbosity > 20) {
+  if (Verbosity() > 20) {
     cout << "-------------------------------------------------------------------" << endl;
     cout << "PHG4HoughTransformTPC::process_event has the following input clusters:" << endl;
 
@@ -1004,19 +1004,19 @@ int PHG4HoughTransformTPC::initial_zvertex_finding() {
   // loop over initial tracking windows
   std::vector<SimpleTrack3D> newtracks;
 
-  if(verbosity) std::cout <<" positive eta seeded track finding.. "<< std::endl;
+  if(Verbosity()) std::cout <<" positive eta seeded track finding.. "<< std::endl;
   _tracker_etap_seed->clear();
   _tracker_etap_seed->findHelices(_clusters_init, _min_vtx_hits, _max_vtx_hits,
                                   newtracks, maxtracks);
 
-  if (verbosity) cout << " seed track finding count: " << newtracks.size() << endl;
+  if (Verbosity()) cout << " seed track finding count: " << newtracks.size() << endl;
   for (unsigned int t = 0; t < newtracks.size(); ++t) {
     if(newtracks[t].z0 < _min_z0 || newtracks[t].z0 > _max_z0 
 				|| (newtracks[t].z0)!=newtracks[t].z0){
-      if (verbosity) cout << " z0 out of bound: " << newtracks[t].z0 << endl;
+      if (Verbosity()) cout << " z0 out of bound: " << newtracks[t].z0 << endl;
       continue;
     }
-    if (verbosity) cout << " z0: " << newtracks[t].z0 << endl;
+    if (Verbosity()) cout << " z0: " << newtracks[t].z0 << endl;
     _tracks.push_back(newtracks[t]);
     _track_covars.push_back( (_tracker_etap_seed->getKalmanStates())[t].C );
   }
@@ -1024,19 +1024,19 @@ int PHG4HoughTransformTPC::initial_zvertex_finding() {
   _tracker_etap_seed->clear();
   newtracks.clear();
 
-  if(verbosity) std::cout <<" negative eta seeded track finding.. "<< std::endl;
+  if(Verbosity()) std::cout <<" negative eta seeded track finding.. "<< std::endl;
   _tracker_etam_seed->clear();
   _tracker_etam_seed->findHelices(_clusters_init, _min_vtx_hits, _max_vtx_hits,
                                   newtracks, maxtracks);
 
-  if (verbosity) cout << " seed track finding count: " << newtracks.size() << endl;
+  if (Verbosity()) cout << " seed track finding count: " << newtracks.size() << endl;
   for (unsigned int t = 0; t < newtracks.size(); ++t) {
     if(newtracks[t].z0 < _min_z0 || newtracks[t].z0 > _max_z0 
 				|| (newtracks[t].z0)!=newtracks[t].z0){
-      if (verbosity) cout << " z0 out of bound: " << newtracks[t].z0 << endl;
+      if (Verbosity()) cout << " z0 out of bound: " << newtracks[t].z0 << endl;
       continue;
     }
-    if (verbosity) cout << " z0: " << newtracks[t].z0 << endl;
+    if (Verbosity()) cout << " z0: " << newtracks[t].z0 << endl;
     _tracks.push_back(newtracks[t]);
     _track_covars.push_back( (_tracker_etam_seed->getKalmanStates())[t].C );
   }
@@ -1048,7 +1048,7 @@ int PHG4HoughTransformTPC::initial_zvertex_finding() {
   _vertex.assign(3,0.0);
 
 
-  if (verbosity) cout << " seed track used count: " << _tracks.size() << endl;
+  if (Verbosity()) cout << " seed track used count: " << _tracks.size() << endl;
 
   if (!_tracks.empty()) {
 
@@ -1069,7 +1069,7 @@ int PHG4HoughTransformTPC::initial_zvertex_finding() {
     zmse /= (_tracks.size()-1);
     zmse = sqrt(zmse);
 
-    if (verbosity > 0) {
+    if (Verbosity() > 0) {
 	cout << " seed track vertex pre-fit: "
            << _vertex[0] << " "
            << _vertex[1] << " "
@@ -1082,7 +1082,7 @@ int PHG4HoughTransformTPC::initial_zvertex_finding() {
     _vertexFinder.findVertex( _tracks, _track_covars, _vertex, 0.02, true);
   }
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << " seed track vertex post-fit: "
          << _vertex[0] << " " << _vertex[1] << " " << _vertex[2] << endl;
   }
@@ -1108,10 +1108,10 @@ int PHG4HoughTransformTPC::full_tracking_and_vertexing() {
   _timer_initial_hough.get()->restart();
 
   // final track finding
-  if(verbosity) std::cout <<" final track finding.. "<< std::endl;
+  if(Verbosity()) std::cout <<" final track finding.. "<< std::endl;
   _tracker->findHelices(_clusters_init, _min_combo_hits, _max_combo_hits, _tracks);
 
-  if (verbosity > 0){
+  if (Verbosity() > 0){
     cout << " final track count, 1st pass: " << _tracks.size() << endl;
   }
 
@@ -1148,7 +1148,7 @@ int PHG4HoughTransformTPC::full_tracking_and_vertexing() {
 
   // we will need the tracker object below to refit the tracks... so we won't
   // reset it here
-  if (verbosity > 0){ 
+  if (Verbosity() > 0){ 
     cout << " final track count, 2nd pass: " << _tracks.size() << endl;
     cout<< "PHG4HoughTransformTPC::process_event -- calculating final vertex" << endl;
   }
@@ -1178,7 +1178,7 @@ int PHG4HoughTransformTPC::full_tracking_and_vertexing() {
       }
     }
 
-    if (verbosity > 0) {
+    if (Verbosity() > 0) {
       cout << " final vertex pre-fit: "
            << _vertex[0] - shift_dx << " "
            << _vertex[1] - shift_dy << " "
@@ -1190,7 +1190,7 @@ int PHG4HoughTransformTPC::full_tracking_and_vertexing() {
     _vertexFinder.findVertex( vtx_tracks, vtx_covars, _vertex, 0.020, false );
     _vertexFinder.findVertex( vtx_tracks, vtx_covars, _vertex, 0.005, false );
 
-    if (verbosity > 0) {
+    if (Verbosity() > 0) {
       cout << " final vertex post-fit: "
            << _vertex[0] - shift_dx << " "
            << _vertex[1] - shift_dy << " "
@@ -1201,7 +1201,7 @@ int PHG4HoughTransformTPC::full_tracking_and_vertexing() {
   // shift back to global coordinates
   shift_coordinate_system(-shift_dx,-shift_dy,-shift_dz);
 
-  if(verbosity > 0)
+  if(Verbosity() > 0)
   {
     cout << "PHG4HoughTransformTPC::process_event -- final vertex: " 
 	 << _vertex[0] << " " << _vertex[1] << " " << _vertex[2] << endl;
@@ -1243,7 +1243,7 @@ int PHG4HoughTransformTPC::full_tracking_and_vertexing() {
 
 int PHG4HoughTransformTPC::export_output() {
 
-  if(verbosity > 0)
+  if(Verbosity() > 0)
   {
     cout << "PHG4HoughTransformTPC::process_event -- producing PHG4Track objects..." << endl;
   }
@@ -1364,7 +1364,7 @@ int PHG4HoughTransformTPC::export_output() {
     _g4tracks->insert(&track);
     vertex.insert_track(track.get_id());
 
-    if (verbosity > 5) {
+    if (Verbosity() > 5) {
       cout << "track " << itrack << " quality = " << track.get_quality()
            << endl;
       cout << "px = " << track.get_px() << " py = " << track.get_py()
@@ -1373,9 +1373,9 @@ int PHG4HoughTransformTPC::export_output() {
   }  // track loop
 
   SvtxVertex *vtxptr = _g4vertexes->insert(&vertex);
-  if (verbosity > 5) vtxptr->identify();
+  if (Verbosity() > 5) vtxptr->identify();
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "PHG4HoughTransform::process_event -- leaving process_event"
          << endl;
   }
@@ -1570,7 +1570,7 @@ int PHG4HoughTransformTPC::fast_vertex_from_bbc() {
       _vertex[1] = 0.0;
       _vertex[2] = vertex->get_z();
      
-      if (verbosity) cout << " initial bbc vertex guess: "
+      if (Verbosity()) cout << " initial bbc vertex guess: "
 			  << _vertex[0] << " "
 			  << _vertex[1] << " "
 			  << _vertex[2] << endl;      

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.h
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.h
@@ -66,11 +66,6 @@ public:
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
-  /// set verbosity
-  void Verbosity(int verb) {
-    verbosity = verb; // SubsysReco verbosity
-  }
-
   /// external handle for projecting tracks into the calorimetry
   static void projectToRadius(const SvtxTrack* track,
 			      double magfield, // in Tesla

--- a/simulation/g4simulation/g4hough/PHG4InitZVertexing.C
+++ b/simulation/g4simulation/g4hough/PHG4InitZVertexing.C
@@ -233,7 +233,7 @@ int PHG4InitZVertexing::InitRun(PHCompositeNode* topNode) {
 	_t_output_io = new PHTimer("_t_output_io");
 	_t_output_io->stop();
 
-	if (verbosity > 0) {
+	if (Verbosity() > 0) {
 		cout
 				<< "====================== PHG4InitZVertexing::InitRun() ======================"
 				<< endl;
@@ -265,7 +265,7 @@ int PHG4InitZVertexing::InitRun(PHCompositeNode* topNode) {
 int PHG4InitZVertexing::process_event(PHCompositeNode *topNode) 
 {
 
-	if (verbosity > 0)
+	if (Verbosity() > 0)
 		cout << "PHG4InitZVertexing::process_event -- entered" << endl;
 
 	// start fresh
@@ -499,7 +499,7 @@ int PHG4InitZVertexing::create_nodes(PHCompositeNode* topNode) {
 	if (!tb_node) {
 		tb_node = new PHCompositeNode("SVTX");
 		dstNode->addNode(tb_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "SVTX node added" << endl;
 	}
 
@@ -507,14 +507,14 @@ int PHG4InitZVertexing::create_nodes(PHCompositeNode* topNode) {
 	PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(_trackmap,
 			"SvtxTrackMap", "PHObject");
 	tb_node->addNode(tracks_node);
-	if (verbosity > 0)
+	if (Verbosity() > 0)
 		cout << "Svtx/SvtxTrackMap node added" << endl;
 
 	_vertexmap = new SvtxVertexMap_v1;
 	PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(
 			_vertexmap, "SvtxVertexMap", "PHObject");
 	tb_node->addNode(vertexes_node);
-	if (verbosity > 0)
+	if (Verbosity() > 0)
 		cout << "Svtx/SvtxVertexMap node added" << endl;
 
 
@@ -604,7 +604,7 @@ int PHG4InitZVertexing::initialize_geometry(PHCompositeNode *topNode) {
 
 			//if(cellgeo->get_layer() > (int) _radii.size() ) continue;
 
-//			if (verbosity >= 2)
+//			if (Verbosity() >= 2)
 //			cellgeo->identify();
 
 			//TODO
@@ -628,7 +628,7 @@ int PHG4InitZVertexing::initialize_geometry(PHCompositeNode *topNode) {
 
 			//if(geo->get_layer() > (int) _radii.size() ) continue;
 
-//			if (verbosity >= 2)
+//			if (Verbosity() >= 2)
 //			geo->identify();
 
 			_radii_all[_layer_ilayer_map_all[geo->get_layer()]] =
@@ -650,7 +650,7 @@ int PHG4InitZVertexing::initialize_geometry(PHCompositeNode *topNode) {
 
 			//if(geo->get_layer() > (int) _radii.size() ) continue;
 
-//			if (verbosity >= 2)
+//			if (Verbosity() >= 2)
 //				geo->identify();
 
 			_radii_all[_layer_ilayer_map_all[geo->get_layer()]] =
@@ -750,7 +750,7 @@ int PHG4InitZVertexing::translate_input(PHCompositeNode* topNode) {
 		hits_used.insert(std::pair<unsigned int, bool>(hit3d.get_id(),false));
         }
 	
-        if (verbosity > 10) {
+        if (Verbosity() > 10) {
         cout << "-------------------------------------------------------------------"
              << endl;
         cout << "PHG4InitZVertexing::process_event has the following input clusters:"
@@ -905,7 +905,7 @@ int PHG4InitZVertexing::export_output(){
                 _trackmap->insert(&track);
                 svtx_vertex_list[vid].insert_track(track.get_id());
 
-                if (verbosity > 5) {
+                if (Verbosity() > 5) {
                         cout << "track " << itrack << " quality = " << track.get_quality()
                         << endl;
                         cout << "px = " << track.get_px() << " py = " << track.get_py()
@@ -916,7 +916,7 @@ int PHG4InitZVertexing::export_output(){
 //	cout<<"track loop"<<endl;
 	for (unsigned int vid = 0; vid < _vertex_list.size(); ++vid ){
         SvtxVertex *vtxptr = _vertexmap->insert(&svtx_vertex_list[vid]);
-        if (verbosity > 5) vtxptr->identify();
+        if (Verbosity() > 5) vtxptr->identify();
 	}
 
         hits_map.clear();
@@ -2186,7 +2186,7 @@ int PHG4InitZVertexing::fit_vertex(){
 	{
 		if (_multi_vtx_tracks[i].size()==0) continue;
 		_vertex[2] = _multi_vtx[i];
-    		if (verbosity > 0) {
+    		if (Verbosity() > 0) {
       		cout << " seed track vertex pre-fit: "
            		<< _vertex[0] << " "
         		<< _vertex[1] << " "
@@ -2200,7 +2200,7 @@ int PHG4InitZVertexing::fit_vertex(){
 		n_vtx_tracks = _multi_vtx_tracks[i].size();
 		cout<<"number of fitted tracks for vertex "<<i<< " : "<<n_vtx_tracks <<endl;
 
-  		if (verbosity > 0) {
+  		if (Verbosity() > 0) {
     			cout << " seed track vertex post-fit: "
          		<< _vertex[0] << " " << _vertex[1] << " " << _vertex[2] << endl;
   		}

--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
@@ -452,7 +452,7 @@ int PHG4KalmanPatRec::InitRun(PHCompositeNode* topNode) {
 	_t_output_io = new PHTimer("_t_output_io");
 	_t_output_io->stop();
 
-	if (verbosity > 0) {
+	if (Verbosity() > 0) {
 		cout
 				<< "====================== PHG4KalmanPatRec::InitRun() ======================"
 				<< endl;
@@ -497,7 +497,7 @@ int PHG4KalmanPatRec::InitRun(PHCompositeNode* topNode) {
 
 int PHG4KalmanPatRec::process_event(PHCompositeNode *topNode) {
 
-  if (verbosity > 0){
+  if (Verbosity() > 0){
 	  cout << "PHG4KalmanPatRec::process_event -- entered" << endl;
 	  cout << "nMapsLayers = " << _nlayers_maps << endl;
 	  cout << "nInttLayers = " << _nlayers_intt << endl;
@@ -544,7 +544,7 @@ int PHG4KalmanPatRec::process_event(PHCompositeNode *topNode) {
 	    _min_combo_hits = min_layers;
 	    _max_combo_hits = nlayers_seeds;
 	    code = InitializeGeometry(topNode);
-	    if(verbosity >= 1) _t_seed_init1->restart();
+	    if(Verbosity() >= 1) _t_seed_init1->restart();
 	    if(code != Fun4AllReturnCodes::EVENT_OK)
 	      return code;
 	  }
@@ -578,7 +578,7 @@ int PHG4KalmanPatRec::process_event(PHCompositeNode *topNode) {
 	    _min_combo_hits = min_layers;
 	    _max_combo_hits = nlayers_seeds;
 	    code = InitializeGeometry(topNode);
-	    if(verbosity >= 1) _t_seed_init2->restart();
+	    if(Verbosity() >= 1) _t_seed_init2->restart();
 
 	    if(code != Fun4AllReturnCodes::EVENT_OK)
 	      return code;
@@ -609,15 +609,15 @@ int PHG4KalmanPatRec::process_event(PHCompositeNode *topNode) {
 	    _max_combo_hits = nlayers_seeds;
 
 	    code = InitializeGeometry(topNode);
-	    if(verbosity >= 1) _t_seed_init3->restart();
+	    if(Verbosity() >= 1) _t_seed_init3->restart();
 	    if(code != Fun4AllReturnCodes::EVENT_OK)
 	      return code;
 	  }
 
-	  if(verbosity >= 1)
+	  if(Verbosity() >= 1)
 	    cout << "Iteration number " << _n_iteration << endl; 
 	  _min_nlayers_seeding--;
-	  if(verbosity >= 1) _t_seeding->restart();
+	  if(Verbosity() >= 1) _t_seeding->restart();
 	  
 	  //-----------------------------------
 	  // Translate into Helix_Hough objects
@@ -653,12 +653,12 @@ int PHG4KalmanPatRec::process_event(PHCompositeNode *topNode) {
 	  if (code != Fun4AllReturnCodes::EVENT_OK)
 	    return code;
 	  
-	  if(verbosity >= 1) _t_seeding->stop();
-	  if(verbosity >= 1&&_n_iteration==3) _t_seed_init3->stop();
-	  if(verbosity >= 1&&_n_iteration==2) _t_seed_init2->stop();
-	  if(verbosity >= 1&&_n_iteration==1) _t_seed_init1->stop();
+	  if(Verbosity() >= 1) _t_seeding->stop();
+	  if(Verbosity() >= 1&&_n_iteration==3) _t_seed_init3->stop();
+	  if(Verbosity() >= 1&&_n_iteration==2) _t_seed_init2->stop();
+	  if(Verbosity() >= 1&&_n_iteration==1) _t_seed_init1->stop();
 
-	  if(verbosity >= 1) _t_kalman_pat_rec->restart();
+	  if(Verbosity() >= 1) _t_kalman_pat_rec->restart();
 	  
 	  //-----------------------------------
 	  // Kalman cluster association
@@ -668,7 +668,7 @@ int PHG4KalmanPatRec::process_event(PHCompositeNode *topNode) {
 	    if (code != Fun4AllReturnCodes::EVENT_OK)
 	      return code;
 	  }
-	  if(verbosity >= 1) _t_kalman_pat_rec->stop();
+	  if(Verbosity() >= 1) _t_kalman_pat_rec->stop();
 	  
 	  //-----------------------------------
 	  // Translate back into SVTX objects
@@ -676,7 +676,7 @@ int PHG4KalmanPatRec::process_event(PHCompositeNode *topNode) {
 	  
 	  //	  add_tracks();
 	  
-	  if(verbosity > 1) print_timers();
+	  if(Verbosity() > 1) print_timers();
 	  
 	  
 	}
@@ -989,7 +989,7 @@ int PHG4KalmanPatRec::CreateNodes(PHCompositeNode* topNode) {
 	if (!tb_node) {
 		tb_node = new PHCompositeNode("SVTX");
 		dstNode->addNode(tb_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "SVTX node added" << endl;
 	}
 
@@ -997,14 +997,14 @@ int PHG4KalmanPatRec::CreateNodes(PHCompositeNode* topNode) {
 	PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(_g4tracks,
 			"SvtxTrackMap", "PHObject");
 	tb_node->addNode(tracks_node);
-	if (verbosity > 0)
+	if (Verbosity() > 0)
 		cout << "Svtx/SvtxTrackMap node added" << endl;
 
 	_g4vertexes = new SvtxVertexMap_v1;
 	PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(
 			_g4vertexes, "SvtxVertexMap", "PHObject");
 	tb_node->addNode(vertexes_node);
-	if (verbosity > 0)
+	if (Verbosity() > 0)
 		cout << "Svtx/SvtxVertexMap node added" << endl;
 
 	/*
@@ -1104,7 +1104,7 @@ int PHG4KalmanPatRec::InitializeGeometry(PHCompositeNode *topNode) {
     }
   }
   
-  //	if (verbosity >= 2) {
+  //	if (Verbosity() >= 2) {
   //		for (map<float, int>::const_iterator iter = radius_layer_map.begin();
   //				iter != radius_layer_map.end(); iter++) {
   //			cout << "radius_layer_map: first: " << iter->first << "; second: "
@@ -1128,7 +1128,7 @@ int PHG4KalmanPatRec::InitializeGeometry(PHCompositeNode *topNode) {
     //if(ilayer >= (int) _radii.size()) break; //yuhw
   }
   
-  //	if (verbosity >= 10) {
+  //	if (Verbosity() >= 10) {
   //		for (map<int, unsigned int>::const_iterator iter = _layer_ilayer_map_all.begin();
   //				iter != _layer_ilayer_map_all.end(); iter++) {
   //			cout << "_layer_ilayer_map_all: first: " << iter->first << "; second: "
@@ -1146,7 +1146,7 @@ int PHG4KalmanPatRec::InitializeGeometry(PHCompositeNode *topNode) {
       
       //if(cellgeo->get_layer() > (int) _radii.size() ) continue;
       
-      //			if (verbosity >= 2)
+      //			if (Verbosity() >= 2)
       //				cellgeo->identify();
       
       //TODO
@@ -1171,7 +1171,7 @@ int PHG4KalmanPatRec::InitializeGeometry(PHCompositeNode *topNode) {
       
       //if(geo->get_layer() > (int) _radii.size() ) continue;
       
-      //			if (verbosity >= 2)
+      //			if (Verbosity() >= 2)
       //				geo->identify();
       
       _radii_all[_layer_ilayer_map_all[geo->get_layer()]] =
@@ -1193,7 +1193,7 @@ int PHG4KalmanPatRec::InitializeGeometry(PHCompositeNode *topNode) {
       
       //if(geo->get_layer() > (int) _radii.size() ) continue;
       
-      //			if (verbosity >= 2)
+      //			if (Verbosity() >= 2)
       //				geo->identify();
       
       //TODO
@@ -1248,7 +1248,7 @@ int PHG4KalmanPatRec::InitializeGeometry(PHCompositeNode *topNode) {
 						      topNode, "G4CELL_MAPS");
   
   if (!_cells_svtx and !_cells_intt and !_cells_maps) {
-    if (verbosity >= 0) {
+    if (Verbosity() >= 0) {
       LogError("No PHG4CellContainer found!");}
     return Fun4AllReturnCodes::ABORTRUN;
   }
@@ -1537,9 +1537,9 @@ int PHG4KalmanPatRec::setup_tracker_object() {
 	_tracker->setChi2RemovalCut(_chi2_cut_full * 0.5);
 	_tracker->setCellularAutomatonChi2Cut(_ca_chi2_cut);
 	_tracker->setPrintTimings(false);
-	if(verbosity >= 2)
+	if(Verbosity() >= 2)
 		_tracker->setPrintTimings(true);
-	//_tracker->setVerbosity(verbosity);
+	//_tracker->setVerbosity(Verbosity());
 	_tracker->setCutOnDca(_cut_on_dca);
 	_tracker->setDcaCut(_dcaxy_cut);
 	_tracker->setSmoothBack(true);
@@ -1686,7 +1686,7 @@ int PHG4KalmanPatRec::translate_input() {
     _clusters.push_back(hit3d);
   }
   
-  if (verbosity > 20) {
+  if (Verbosity() > 20) {
     cout
       << "-------------------------------------------------------------------"
       << endl;
@@ -1704,10 +1704,10 @@ int PHG4KalmanPatRec::translate_input() {
       << endl;
   }
   
-  if(verbosity >= 1){
+  if(Verbosity() >= 1){
     cout << "CPUSCALE hits: " << count << endl;
     }
-  if(verbosity >= 10){
+  if(Verbosity() >= 10){
     for(int i  = 0;i<60;i++){
       cout << "layer: " << i << " << hits: " << nhits[i] << " | " << nhits_all[i] << endl;
     }
@@ -1728,7 +1728,7 @@ int PHG4KalmanPatRec::fast_vertex_from_bbc() {
 			_vertex[1] = 0.0;
 			_vertex[2] = vertex->get_z();
 
-			if (verbosity)
+			if (Verbosity())
 				cout << " initial bbc vertex guess: " << _vertex[0] << " "
 						<< _vertex[1] << " " << _vertex[2] << endl;
 		}
@@ -1781,7 +1781,7 @@ int PHG4KalmanPatRec::fast_vertex_guessing() {
 	_vertex.clear();
 	_vertex.assign(3, 0.0);
 
-	if (verbosity)
+	if (Verbosity())
 		cout << " seed track finding count: " << _tracks.size() << endl;
 
 	if (!_tracks.empty()) {
@@ -1796,7 +1796,7 @@ int PHG4KalmanPatRec::fast_vertex_guessing() {
 
 		_vertex[2] = zsum / _tracks.size();
 
-		if (verbosity > 0) {
+		if (Verbosity() > 0) {
 			cout << " seed track vertex pre-fit: " << _vertex[0] << " "
 					<< _vertex[1] << " " << _vertex[2] << endl;
 		}
@@ -1812,7 +1812,7 @@ int PHG4KalmanPatRec::fast_vertex_guessing() {
 	_track_errors.clear();
 	_track_covars.clear();
 
-	if (verbosity > 0) {
+	if (Verbosity() > 0) {
 		cout << " seed track vertex post-fit: " << _vertex[0] << " "
 				<< _vertex[1] << " " << _vertex[2] << endl;
 	}
@@ -1855,7 +1855,7 @@ int PHG4KalmanPatRec::initial_vertex_finding() {
 	// don't need the tracker object anymore
 	_tracker_vertex->clear();
 
-	if (verbosity)
+	if (Verbosity())
 		cout << " initial track finding count: " << _tracks.size() << endl;
 
 	if (!_tracks.empty()) {
@@ -1876,7 +1876,7 @@ int PHG4KalmanPatRec::initial_vertex_finding() {
 		_vertex[1] = ysum / _tracks.size();
 		_vertex[2] = zsum / _tracks.size();
 
-		if (verbosity > 0) {
+		if (Verbosity() > 0) {
 			cout << " initial track vertex pre-fit: " << _vertex[0] - shift_dx
 					<< " " << _vertex[1] - shift_dy << " "
 					<< _vertex[2] - shift_dz << endl;
@@ -1897,7 +1897,7 @@ int PHG4KalmanPatRec::initial_vertex_finding() {
 	// shift back to the global coordinates
 	shift_coordinate_system(-shift_dx, -shift_dy, -shift_dz);
 
-	if (verbosity > 0) {
+	if (Verbosity() > 0) {
 		cout << " initial track vertex post-fit: " << _vertex[0] << " "
 				<< _vertex[1] << " " << _vertex[2] << endl;
 	}
@@ -1931,7 +1931,7 @@ int PHG4KalmanPatRec::vertexing(PHCompositeNode* topNode) {
 	gsl_rng_free(RandomGenerator);
 #endif
 
-	if (verbosity > 1) {
+	if (Verbosity() > 1) {
 		cout << __LINE__ << " PHG4KalmanPatRec::vertexing: {" << _vertex[0]
 				<< ", " << _vertex[1] << ", " << _vertex[2] << "} +- {"
 				<< _vertex_error[0] << ", " << _vertex_error[1] << ", "
@@ -1957,16 +1957,16 @@ int PHG4KalmanPatRec::full_track_seeding() {
 	_tracker->clear();
 	// final track finding
 	_tracker->findHelices(_clusters, _min_combo_hits, _max_combo_hits, _tracks);
-	if(verbosity >= 1)
+	if(Verbosity() >= 1)
 	  cout << "SEEDSTUDY nbefore clean (" << _min_nlayers_seeding << "): " << _tracks.size() << endl;
 	// Cleanup Seeds
 #ifdef _USE_ALAN_TRACK_REFITTING_
 #else
-	if(verbosity >= 1) _t_seeds_cleanup->restart();
+	if(Verbosity() >= 1) _t_seeds_cleanup->restart();
 	CleanupSeeds();
-	if(verbosity >= 1) _t_seeds_cleanup->stop();
+	if(Verbosity() >= 1) _t_seeds_cleanup->stop();
 #endif
-	if(verbosity >= 1)
+	if(Verbosity() >= 1)
 	  cout << "SEEDSTUDY nafter clean: " << _tracks.size() << endl;
 	for (unsigned int tt = 0; tt < _tracks.size(); ++tt) {
 		_track_covars.push_back((_tracker->getKalmanStates())[tt].C);
@@ -1976,12 +1976,12 @@ int PHG4KalmanPatRec::full_track_seeding() {
 	// we will need the tracker object below to refit the tracks... so we won't
 	// reset it here
 
-	if (verbosity > 0)
+	if (Verbosity() > 0)
 		cout << " final track count: " << _tracks.size() << endl;
 #ifdef _USE_ALAN_FULL_VERTEXING_
 	if (!_tracks.empty()) {
 
-		if (verbosity > 0) {
+		if (Verbosity() > 0) {
 			cout << " final vertex pre-fit: " << _vertex[0] - shift_dx << " "
 					<< _vertex[1] - shift_dy << " " << _vertex[2] - shift_dz
 					<< endl;
@@ -1992,7 +1992,7 @@ int PHG4KalmanPatRec::full_track_seeding() {
 		_vertexFinder.findVertex(_tracks, _track_covars, _vertex, 0.020, false);
 		_vertexFinder.findVertex(_tracks, _track_covars, _vertex, 0.005, false);
 
-		if (verbosity > 0) {
+		if (Verbosity() > 0) {
 			cout << " final vertex post-fit: " << _vertex[0] - shift_dx << " "
 					<< _vertex[1] - shift_dy << " " << _vertex[2] - shift_dz
 					<< endl;
@@ -2003,7 +2003,7 @@ int PHG4KalmanPatRec::full_track_seeding() {
 	shift_coordinate_system(-shift_dx, -shift_dy, -shift_dz);
 
 #ifdef _USE_ALAN_TRACK_REFITTING_
-	if(verbosity >= 1) _t_seeds_cleanup->restart();
+	if(Verbosity() >= 1) _t_seeds_cleanup->restart();
 	// we still need to update the track fields for DCA and PCA
 	// we can do that from the final vertex position
 
@@ -2019,13 +2019,13 @@ int PHG4KalmanPatRec::full_track_seeding() {
 	std::vector<double> refit_errors;
 	std::vector<Eigen::Matrix<float, 5, 5> > refit_covars;
 
-	if(verbosity >= 1){
+	if(Verbosity() >= 1){
 	  cout<<__LINE__<< ": Event: "<< _event << ": # tracks before cleanup: "<< _tracks.size() <<endl;
 	}
 
 	_tracker->finalize(_tracks, refit_tracks);
 
-	if(verbosity >= 1){
+	if(Verbosity() >= 1){
 	  cout<<__LINE__<< ": Event: "<< _event << ": # tracks after cleanup: "<< _tracks.size()  <<endl;
 	}
 
@@ -2041,7 +2041,7 @@ int PHG4KalmanPatRec::full_track_seeding() {
 
 	// shift back to global coordinates
 	shift_coordinate_system(-shift_dx, -shift_dy, -shift_dz);
-	if(verbosity >= 1) _t_seeds_cleanup->stop();
+	if(Verbosity() >= 1) _t_seeds_cleanup->stop();
 #endif
 
 	// okay now we are done with the tracker
@@ -2178,7 +2178,7 @@ int PHG4KalmanPatRec::export_output() {
 		_g4tracks->insert(&track);
 		vertex.insert_track(track.get_id());
 
-		if (verbosity > 5) {
+		if (Verbosity() > 5) {
 			cout << "track " << itrack << " quality = " << track.get_quality()
 					<< endl;
 			cout << "px = " << track.get_px() << " py = " << track.get_py()
@@ -2187,10 +2187,10 @@ int PHG4KalmanPatRec::export_output() {
 	}  // track loop
 
 	SvtxVertex *vtxptr = _g4vertexes->insert(&vertex);
-	if (verbosity > 5)
+	if (Verbosity() > 5)
 		vtxptr->identify();
 
-	if (verbosity > 0) {
+	if (Verbosity() > 0) {
 		cout << "PHG4KalmanPatRec::process_event -- leaving process_event"
 				<< endl;
 	}
@@ -2371,7 +2371,7 @@ int PHG4KalmanPatRec::CleanupSeedsByHitPattern() {
         std::vector<SimpleTrack3D> _tracks_cleanup;
         _tracks_cleanup.clear();
 
-	if(verbosity >= 1){
+	if(Verbosity() >= 1){
 	  cout<<__LINE__<< ": Event: "<< _event << ": # tracks before cleanup: "<< _tracks.size() <<endl;
 	}
 
@@ -2535,7 +2535,7 @@ int PHG4KalmanPatRec::CleanupSeedsByHitPattern() {
 	  }
 	*/
 		
-	if(verbosity >= 1){
+	if(Verbosity() >= 1){
 	  cout<<__LINE__<< ": Event: "<< _event <<endl;
 	  cout << ": # tracks after cleanup: "<< _tracks.size() << " ol:" <<OutputList.size()  <<endl;
 	}
@@ -2549,7 +2549,7 @@ int PHG4KalmanPatRec::CleanupTracksByHitPattern() {
         std::vector<SimpleTrack3D> _tracks_cleanup;
         _tracks_cleanup.clear();
 
-	//	if(verbosity >= 1)
+	//	if(Verbosity() >= 1)
 	{
 	    cout<<__LINE__<< ": Event: "<< _event << ": # tracks before cleanup: "<< _tracks.size() <<endl;
 	  }
@@ -2713,7 +2713,7 @@ int PHG4KalmanPatRec::CleanupTracksByHitPattern() {
 	}
 	
 		
-       	if(verbosity >= 1)
+       	if(Verbosity() >= 1)
 	  {
 	    cout<<__LINE__<< ": Event: "<< _event <<endl;
 	    cout << ": # tracks after cleanup: "<< _tracks.size() << " ol:" <<OutputList.size()  <<endl;
@@ -2737,7 +2737,7 @@ int PHG4KalmanPatRec::check_track_exists(MapPHGenFitTrack::iterator iter){
   }
   int code = 0;
   if(((float)n_clu_used/n_clu)>0.3){
-    if(verbosity>=1)
+    if(Verbosity()>=1)
       cout << "Found duplicate track. n_clu: " << n_clu << " c_clu_used: " << n_clu_used << " n_iter: " << _n_iteration<< endl;
     /*
     for(unsigned int iCluId = 0; iCluId < clusterIDs.size(); ++iCluId){
@@ -3002,9 +3002,9 @@ int PHG4KalmanPatRec::FullTrackFitting(PHCompositeNode* topNode) {
 		/*!
 		 * Translate SimpleTrack3D To PHGenFitTracks
 		 */
-		if(verbosity > 1) _t_translate_to_PHGenFitTrack->restart();
+		if(Verbosity() > 1) _t_translate_to_PHGenFitTrack->restart();
 		SimpleTrack3DToPHGenFitTracks(topNode, itrack);
-		if(verbosity > 1) _t_translate_to_PHGenFitTrack->stop();
+		if(Verbosity() > 1) _t_translate_to_PHGenFitTrack->stop();
 
 		/*!
 		 * Handle track propagation, termination, output and evt disp.
@@ -3153,16 +3153,16 @@ int PHG4KalmanPatRec::OutputPHGenFitTrack(PHCompositeNode* topNode, MapPHGenFitT
 		track.set_id(_g4tracks->size());
 
 #ifdef _DO_FULL_FITTING_
-		if(verbosity >= 1) _t_full_fitting->restart();
+		if(Verbosity() >= 1) _t_full_fitting->restart();
 		if (_fitter->processTrack(iter->second.get(), false) != 0) {
-			if (verbosity >= 1)
+			if (Verbosity() >= 1)
 				LogWarning("Track fitting failed\n");
 			//delete track;
 			return -1;
 		}
-		if(verbosity >= 1) _t_full_fitting->stop();
+		if(Verbosity() >= 1) _t_full_fitting->stop();
 
-		if(verbosity >= 1) _t_output_io->restart();
+		if(Verbosity() >= 1) _t_output_io->restart();
 //		iter->second->getGenFitTrack()->Print();
 
 		track.set_chisq(iter->second->get_chi2());
@@ -3175,7 +3175,7 @@ int PHG4KalmanPatRec::OutputPHGenFitTrack(PHCompositeNode* topNode, MapPHGenFitT
 			gf_state_vertex_ca = std::unique_ptr < genfit::MeasuredStateOnPlane
 					> (iter->second->extrapolateToPoint(vertex_position));
 		} catch (...) {
-			if (verbosity >= 2)
+			if (Verbosity() >= 2)
 				LogWarning("extrapolateToPoint failed!");
 		}
 		if (!gf_state_vertex_ca) {
@@ -3248,14 +3248,14 @@ int PHG4KalmanPatRec::OutputPHGenFitTrack(PHCompositeNode* topNode, MapPHGenFitT
 		    
 		    _g4tracks->insert(&track);
 		  }
-		if (verbosity > 5) {
+		if (Verbosity() > 5) {
 			cout << "track " << _g4tracks->size() << " quality = " << track.get_quality()
 					<< endl;
 			cout << "px = " << track.get_px() << " py = " << track.get_py()
 					<< " pz = " << track.get_pz() << endl;
 		}
 
-		if(verbosity >= 1) _t_output_io->stop();
+		if(Verbosity() >= 1) _t_output_io->stop();
 //	}
 
 
@@ -3272,7 +3272,7 @@ int PHG4KalmanPatRec::SimpleTrack3DToPHGenFitTracks(PHCompositeNode* topNode, un
 	double time1 = 0;
 	double time2 = 0;
 
-	if(verbosity > 1){
+	if(Verbosity() > 1){
 	  time1 = _t_translate1->get_accumulated_time();
 	  time2 = _t_translate1->get_accumulated_time();
 	  _t_translate1->restart();
@@ -3291,17 +3291,17 @@ int PHG4KalmanPatRec::SimpleTrack3DToPHGenFitTracks(PHCompositeNode* topNode, un
 	float dt = 0;
 
 	if(_tracks.at(itrack).hits.size() == 0) {
-	  if(verbosity > 1) _t_translate1->stop();
+	  if(Verbosity() > 1) _t_translate1->stop();
 	  return 1;
 	}
 
 	if(!(kappa==kappa && d==d && phi==phi && dzdl==dzdl && z0==z0)) {
-	  if(verbosity > 1) _t_translate1->stop();
+	  if(Verbosity() > 1) _t_translate1->stop();
 	  return 1;
 	}
 
 	if(kappa == 0) {
-	  if(verbosity > 1) _t_translate1->stop();
+	  if(Verbosity() > 1) _t_translate1->stop();
 	  return 1;
 	}
 
@@ -3354,7 +3354,7 @@ int PHG4KalmanPatRec::SimpleTrack3DToPHGenFitTracks(PHCompositeNode* topNode, un
 	convertHelixCovarianceToEuclideanCovariance(_magField, phi, d, kappa,
 			z0, dzdl, _track_covars[itrack], euclidean_cov);
 
-	if(verbosity > 1) _t_translate2->restart();
+	if(Verbosity() > 1) _t_translate2->restart();
 
 	//TODO optimize
 	const float blowup_factor = 1.;
@@ -3418,14 +3418,14 @@ int PHG4KalmanPatRec::SimpleTrack3DToPHGenFitTracks(PHCompositeNode* topNode, un
 	}
 	track->addMeasurements(measurements);
 
-	if(verbosity > 1) _t_translate2->stop();
-	if(verbosity > 1) _t_translate3->restart();
+	if(Verbosity() > 1) _t_translate2->stop();
+	if(Verbosity() > 1) _t_translate3->restart();
 
 	if (_fitter->processTrack(track.get(), false) != 0) {
-		if (verbosity >= 1)
+		if (Verbosity() >= 1)
 			LogWarning("Seed fitting failed")<<std::endl;
-		if(verbosity > 1) _t_translate3->stop();
-		if(verbosity > 1){
+		if(Verbosity() > 1) _t_translate3->stop();
+		if(Verbosity() > 1){
 		  _t_translate1->stop();
 		  time2 = _t_translate1->get_accumulated_time();
 		}
@@ -3445,8 +3445,8 @@ int PHG4KalmanPatRec::SimpleTrack3DToPHGenFitTracks(PHCompositeNode* topNode, un
 						PHG4KalmanPatRec::TrackQuality(nhits, chi2, ndf, nhits, 0, 0), track)
 		);
 	}
-	if(verbosity > 1) _t_translate3->stop();
-	if(verbosity > 1){
+	if(Verbosity() > 1) _t_translate3->stop();
+	if(Verbosity() > 1){
 	  _t_translate1->stop();
 	  time2 = _t_translate1->get_accumulated_time();
 	}
@@ -3498,7 +3498,7 @@ int PHG4KalmanPatRec::TrackPropPatRec(
 	}
 
 	if(first_extrapolate_base_TP_id < 0) {
-		if(verbosity > 0)
+		if(Verbosity() > 0)
 			LogError("first_extrapolate_base_TP_id < 0");
 		return -1;
 	}
@@ -3522,7 +3522,7 @@ int PHG4KalmanPatRec::TrackPropPatRec(
 		 * if miss too many layers terminate track propagating
 		 */
 		if(consecutive_missing_layer > _max_consecutive_missing_layer) {
-			if(verbosity > 1) {
+			if(Verbosity() > 1) {
 				LogWarning ("consecutive_missing_layer > ") << _max_consecutive_missing_layer << endl;
 			}
 			if(track->get_cluster_IDs().size() >= _min_good_track_hits)
@@ -3590,14 +3590,14 @@ int PHG4KalmanPatRec::TrackPropPatRec(
 //		genfit::MeasuredStateOnPlane *state = track->extrapolateToCylinder(
 //				layer_r, TVector3(0, 0, 0), TVector3(0, 0, 1), 0);
 		} catch (...) {
-			if (verbosity > 1) {
+			if (Verbosity() > 1) {
 				LogWarning("Can not extrapolate to Cylinder!")<<std::endl;
 			}
 			continue;
 		}
 
 		if(!state) {
-			if (verbosity > 1) {
+			if (Verbosity() > 1) {
 				LogWarning("Can not extrapolate to Cylinder!")<<std::endl;
 			}
 			continue;
@@ -3673,10 +3673,10 @@ int PHG4KalmanPatRec::TrackPropPatRec(
 //				);
 #endif
 
-		if(verbosity >= 1) _t_search_clusters->restart();
+		if(Verbosity() >= 1) _t_search_clusters->restart();
 		std::vector<unsigned int> new_cluster_IDs = SearchHitsNearBy(layer,
 				theta_center, phi_center, theta_window, phi_window);
-		if(verbosity >= 1) _t_search_clusters->stop();
+		if(Verbosity() >= 1) _t_search_clusters->stop();
 
 #ifdef _DEBUG_
 		cout<<__LINE__<< ": new_cluster_IDs size: " << new_cluster_IDs.size() << std::endl;
@@ -3703,11 +3703,11 @@ int PHG4KalmanPatRec::TrackPropPatRec(
 		cout<<__LINE__<<": measurements.size(): "<<measurements.size()<<endl;
 #endif
 
-		if(verbosity >= 1) _t_track_propagation->restart();
+		if(Verbosity() >= 1) _t_track_propagation->restart();
 		track->updateOneMeasurementKalman(measurements, incr_chi2s_new_tracks, extrapolate_base_TP_id, direction, blowup_factor, use_fitted_state);
 		use_fitted_state = false;
 		blowup_factor = 1.;
-		if(verbosity >= 1) _t_track_propagation->stop();
+		if(Verbosity() >= 1) _t_track_propagation->stop();
 
 #ifdef _DEBUG_
 		cout<<__LINE__<<": incr_chi2s_new_tracks.size(): "<<incr_chi2s_new_tracks.size()<<endl;
@@ -3865,7 +3865,7 @@ PHGenFit::Measurement* PHG4KalmanPatRec::SvtxClusterToPHGenFitMeasurement(
 	if(_cells_intt) cell_intt = _cells_intt->findCell(svtxhit->get_cellid());
 	if(_cells_maps) cell_maps = _cells_maps->findCell(svtxhit->get_cellid());
 	if(!(cell_svtx or cell_intt or cell_maps)){
-		if(verbosity>=0)
+		if(Verbosity()>=0)
 			LogError("!(cell_svtx or cell_intt or cell_maps)");
 		return nullptr;
 	}
@@ -4008,9 +4008,9 @@ std::vector<unsigned int> PHG4KalmanPatRec::SearchHitsNearBy(const unsigned int 
 	for (unsigned int iz = lower_z_bin; iz <= upper_z_bin; ++iz) {
 		for (unsigned int irphi = lower_phi_bin; irphi <= upper_phi_bin;
 				++irphi) {
-			if(verbosity >= 2) _t_search_clusters_encoding->restart();
+			if(Verbosity() >= 2) _t_search_clusters_encoding->restart();
 			unsigned int idx = encode_cluster_index(layer, iz, irphi);
-			if(verbosity >= 2) _t_search_clusters_encoding->stop();
+			if(Verbosity() >= 2) _t_search_clusters_encoding->stop();
 
 //#ifdef _DEBUG_
 //			cout
@@ -4023,7 +4023,7 @@ std::vector<unsigned int> PHG4KalmanPatRec::SearchHitsNearBy(const unsigned int 
 //			<<_layer_thetaID_phiID_cluserID.count(idx)
 //			<<endl;
 //#endif
-			if(verbosity >= 2) _t_search_clusters_map_iter->restart();
+			if(Verbosity() >= 2) _t_search_clusters_map_iter->restart();
 			for (auto iter = _layer_thetaID_phiID_cluserID.lower_bound(idx);
 					iter != _layer_thetaID_phiID_cluserID.upper_bound(idx);
 					++iter) {
@@ -4045,7 +4045,7 @@ std::vector<unsigned int> PHG4KalmanPatRec::SearchHitsNearBy(const unsigned int 
 				<<endl;
 #endif
 			}
-			if(verbosity >= 2) _t_search_clusters_map_iter->stop();
+			if(Verbosity() >= 2) _t_search_clusters_map_iter->stop();
 		}
 	}
 

--- a/simulation/g4simulation/g4hough/PHG4PatternReco.C
+++ b/simulation/g4simulation/g4hough/PHG4PatternReco.C
@@ -242,7 +242,7 @@ int PHG4PatternReco::InitRun(PHCompositeNode* topNode) {
 	_t_output_io = new PHTimer("_t_output_io");
 	_t_output_io->stop();
 
-	if (verbosity > 0) {
+	if (Verbosity() > 0) {
 		cout
 				<< "====================== PHG4PatternReco::InitRun() ======================"
 				<< endl;
@@ -274,7 +274,7 @@ int PHG4PatternReco::InitRun(PHCompositeNode* topNode) {
 int PHG4PatternReco::process_event(PHCompositeNode *topNode) 
 {
 
-	if (verbosity > 0)
+	if (Verbosity() > 0)
 		cout << "PHG4PatternReco::process_event -- entered" << endl;
 
 	// start fresh
@@ -486,7 +486,7 @@ int PHG4PatternReco::create_nodes(PHCompositeNode* topNode) {
 	if (!tb_node) {
 		tb_node = new PHCompositeNode("SVTX");
 		dstNode->addNode(tb_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "SVTX node added" << endl;
 	}
 
@@ -494,14 +494,14 @@ int PHG4PatternReco::create_nodes(PHCompositeNode* topNode) {
 	PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(_trackmap,
 			"SvtxTrackMap", "PHObject");
 	tb_node->addNode(tracks_node);
-	if (verbosity > 0)
+	if (Verbosity() > 0)
 		cout << "Svtx/SvtxTrackMap node added" << endl;
 
 	_vertexmap = new SvtxVertexMap_v1;
 	PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(
 			_vertexmap, "SvtxVertexMap", "PHObject");
 	tb_node->addNode(vertexes_node);
-	if (verbosity > 0)
+	if (Verbosity() > 0)
 		cout << "Svtx/SvtxVertexMap node added" << endl;
 
 
@@ -591,7 +591,7 @@ int PHG4PatternReco::initialize_geometry(PHCompositeNode *topNode) {
 
 			//if(cellgeo->get_layer() > (int) _radii.size() ) continue;
 
-//			if (verbosity >= 2)
+//			if (Verbosity() >= 2)
 //			cellgeo->identify();
 
 			//TODO
@@ -615,7 +615,7 @@ int PHG4PatternReco::initialize_geometry(PHCompositeNode *topNode) {
 
 			//if(geo->get_layer() > (int) _radii.size() ) continue;
 
-//			if (verbosity >= 2)
+//			if (Verbosity() >= 2)
 //			geo->identify();
 
 			_radii_all[_layer_ilayer_map_all[geo->get_layer()]] =
@@ -637,7 +637,7 @@ int PHG4PatternReco::initialize_geometry(PHCompositeNode *topNode) {
 
 			//if(geo->get_layer() > (int) _radii.size() ) continue;
 
-//			if (verbosity >= 2)
+//			if (Verbosity() >= 2)
 //				geo->identify();
 
 			_radii_all[_layer_ilayer_map_all[geo->get_layer()]] =
@@ -737,7 +737,7 @@ int PHG4PatternReco::translate_input(PHCompositeNode* topNode) {
 		hits_used.insert(std::pair<unsigned int, bool>(hit3d.get_id(),false));
         }
 	
-        if (verbosity > 10) {
+        if (Verbosity() > 10) {
         cout << "-------------------------------------------------------------------"
              << endl;
         cout << "PHG4PatternReco::process_event has the following input clusters:"
@@ -848,7 +848,7 @@ int PHG4PatternReco::export_output(){
                         track_hits.at(ihit).get_id());
                         clusterID = cluster->get_id();
 
-			if (verbosity > 5) {
+			if (Verbosity() > 5) {
                         cout
                         <<__LINE__
                         <<": itrack: " << itrack
@@ -931,7 +931,7 @@ int PHG4PatternReco::export_output(){
 
 		//if a triplet doesn't have a reco vertex tied to it, assign 9999
 		if (fabs(z0 - distance)>0.05) vid = 9999;		
-		if (verbosity > 5) cout<<"vertex_id "<<vid<<endl;
+		if (Verbosity() > 5) cout<<"vertex_id "<<vid<<endl;
 		// pca 
 		if (vid==9999){
 		track.set_x(0.);
@@ -947,7 +947,7 @@ int PHG4PatternReco::export_output(){
 		if (vid==9999) fake_vertex.insert_track(track.get_id());
                 else svtx_vertex_list[vid]->insert_track(track.get_id());
 
-                if (verbosity > 5) {
+                if (Verbosity() > 5) {
                         cout << "track " << itrack << " quality = " << track.get_quality()
                         << endl;
                         cout << "px = " << track.get_px() << " py = " << track.get_py()
@@ -957,12 +957,12 @@ int PHG4PatternReco::export_output(){
 
 //	do not repeat saving vertices this time, add only fake vertex
  	SvtxVertex *vtxptr = _vertexmap->insert(&fake_vertex);
-	if (verbosity > 5) vtxptr->identify();
+	if (Verbosity() > 5) vtxptr->identify();
 
 /*	
 	for (unsigned int vid = 0; vid < _vertex_list.size(); ++vid ){
         SvtxVertex *vtxptr = _vertexmap->insert(&svtx_vertex_list[vid]);
-        if (verbosity > 5) vtxptr->identify();
+        if (Verbosity() > 5) vtxptr->identify();
 	}
 */
         hits_map.clear();
@@ -2251,7 +2251,7 @@ int PHG4PatternReco::fit_vertex(){
 	{
 		if (_multi_vtx_tracks[i].size()==0) continue;
 		_vertex[2] = _multi_vtx[i];
-    		if (verbosity > 0) {
+    		if (Verbosity() > 0) {
       		cout << " seed track vertex pre-fit: "
            		<< _vertex[0] << " "
         		<< _vertex[1] << " "
@@ -2265,7 +2265,7 @@ int PHG4PatternReco::fit_vertex(){
 		n_vtx_tracks = _multi_vtx_tracks[i].size();
 		cout<<"number of fitted tracks for vertex "<<i<< " : "<<n_vtx_tracks <<endl;
 
-  		if (verbosity > 0) {
+  		if (Verbosity() > 0) {
     			cout << " seed track vertex post-fit: "
          		<< _vertex[0] << " " << _vertex[1] << " " << _vertex[2] << endl;
   		}

--- a/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SiliconTrackerDigitizer.C
@@ -71,7 +71,7 @@ int PHG4SiliconTrackerDigitizer::InitRun(PHCompositeNode* topNode) {
   // Report Settings
   //----------------
   
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "====================== PHG4SiliconTrackerDigitizer::InitRun() =====================" << endl;
     for (std::map<int,unsigned int>::iterator iter = _max_adc.begin();
 	 iter != _max_adc.end();
@@ -254,7 +254,7 @@ int PHG4SiliconTrackerDigitizer::End(PHCompositeNode *topNode)
 
 void PHG4SiliconTrackerDigitizer::PrintHits(PHCompositeNode *topNode) {
 
-  if (verbosity >= VERBOSITY_EVEN_MORE) {
+  if (Verbosity() >= VERBOSITY_EVEN_MORE) {
 
     SvtxHitMap *hitlist = findNode::getClass<SvtxHitMap>(topNode,"SvtxHitMap");
     if (!hitlist) return;

--- a/simulation/g4simulation/g4hough/PHG4SvtxBeamSpotReco.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxBeamSpotReco.C
@@ -65,7 +65,7 @@ int PHG4SvtxBeamSpotReco::InitRun(PHCompositeNode* topNode) {
     return Fun4AllReturnCodes::ABORTEVENT;
   }
   
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "=================== PHG4SvtxBeamSpotReco::InitRun() =======================" << endl;
     cout << " Storing cumulative beam spot location under PAR/SVTX/SvtxBeamSpot" << endl;
     cout << "===========================================================================" << endl;
@@ -102,7 +102,7 @@ int PHG4SvtxBeamSpotReco::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity > 1) _beamspot->identify();
+  if (Verbosity() > 1) _beamspot->identify();
   
   _timer.get()->stop();
   return Fun4AllReturnCodes::EVENT_OK;
@@ -110,7 +110,7 @@ int PHG4SvtxBeamSpotReco::process_event(PHCompositeNode *topNode)
 
 int PHG4SvtxBeamSpotReco::End(PHCompositeNode* topNode) {
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "=================== PHG4SvtxBeamSpotReco::End() ===========================" << endl;
     _beamspot->identify();
     cout << "===========================================================================" << endl;

--- a/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxClusterizer.C
@@ -156,7 +156,7 @@ bool PHG4SvtxClusterizer::maps_ladder_are_adjacent(const PHG4Cell* lhs,
 
 bool PHG4SvtxClusterizer::ladder_are_adjacent(const PHG4Cell* lhs, const PHG4Cell* rhs) {
 
-  if(verbosity > 2)
+  if(Verbosity() > 2)
     {
       cout << " lhs layer " <<  lhs->get_layer() 
 	   << " lhs ladder z index " <<  lhs->get_ladder_z_index() 
@@ -189,7 +189,7 @@ bool PHG4SvtxClusterizer::ladder_are_adjacent(const PHG4Cell* lhs, const PHG4Cel
   } else {
     if( fabs(lhs->get_zbin() - rhs->get_zbin()) == 0 ) {
       if( fabs(lhs->get_phibin() - rhs->get_phibin()) <= 1 ){
-	if(verbosity > 2) cout << "    accepted " << endl;
+	if(Verbosity() > 2) cout << "    accepted " << endl;
 	return true;
       } 
     }
@@ -266,7 +266,7 @@ int PHG4SvtxClusterizer::InitRun(PHCompositeNode* topNode) {
   // Report Settings
   //----------------
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "====================== PHG4SvtxClusterizer::InitRun() =====================" << endl;
     cout << " Fraction of expected thickness MIP energy = " << _fraction_of_mip << endl;
     for (std::map<int,float>::iterator iter = _thresholds_by_layer.begin();
@@ -671,13 +671,13 @@ void PHG4SvtxClusterizer::ClusterCylinderCells(PHCompositeNode *topNode) {
 	  }
 	}
 	
-	if (verbosity>1) {
+	if (Verbosity()>1) {
 	  cout << "r=" << radius << " phi=" << clusphi << " z=" << clusz << endl;
 	  cout << "pos=(" << clus.get_position(0) << ", " << clus.get_position(1)
 	       << ", " << clus.get_position(2) << ")" << endl;
 	  cout << endl;
 	}
-      }	else if (verbosity>1) {
+      }	else if (Verbosity()>1) {
 	cout << "silicon cylinder cell: removed, clus_energy = " << clus_energy << " below threshold of " <<  get_threshold_by_layer(layer)  << " clus_adc " << clus_adc <<  " r=" << radius << " phi=" << clusphi << " z=" << clusz << endl;
 	cout << "pos=(" << clus.get_position(0) << ", " << clus.get_position(1)
 	     << ", " << clus.get_position(2) << ")" << endl;
@@ -691,7 +691,7 @@ void PHG4SvtxClusterizer::ClusterCylinderCells(PHCompositeNode *topNode) {
 
 void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 
-  if(verbosity > 0)
+  if(Verbosity() > 0)
     cout << "Entering PHG4SvtxClusterizer::ClusterLadderCells " << endl;
 
   //----------
@@ -734,7 +734,7 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
       ++layeriter) {
 
     int layer = layeriter->second->get_layer();
-    if(verbosity > 0)
+    if(Verbosity() > 0)
       cout << " layer loop, current layer = " << layer << endl;
 
     if ((unsigned int)layer < _min_layer) continue;
@@ -747,7 +747,7 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 	 ++hiter) {
       SvtxHit* hit = hiter->second;
       PHG4Cell* cell = cells->findCell(hit->get_cellid());
-      if(verbosity > 2) 
+      if(Verbosity() > 2) 
 	{
 	  cout << "adding cell to cell_hit_map: ";
 	  cell->print();
@@ -765,10 +765,10 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
     Graph G;
 
     // Find adjacent cell
-    if(verbosity > 2) cout << "Find adjacent cells for layer " << layer << endl;
+    if(Verbosity() > 2) cout << "Find adjacent cells for layer " << layer << endl;
     for(unsigned int i=0; i<cell_list.size(); i++) {
       for(unsigned int j=i+1; j<cell_list.size(); j++) {
-	if(verbosity > 2) 
+	if(Verbosity() > 2) 
 	  {
 	    cout << "compare cells " << i << " and " << j << endl;
 	    cell_list[i]->print();
@@ -777,7 +777,7 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
         if(ladder_are_adjacent(cell_list[i], cell_list[j]) )
 	  {
 	    add_edge(i,j,G);
-	    if(verbosity > 2) 
+	    if(Verbosity() > 2) 
 	      {
 		cout << "Found edge " << i << "   " << j << endl;
 		cell_list[i]->print();
@@ -788,7 +788,7 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
       
       add_edge(i,i,G);
     }
-    if(verbosity > 2) cout << "finished looking for adjacent cells for layer " << layer << endl;
+    if(Verbosity() > 2) cout << "finished looking for adjacent cells for layer " << layer << endl;
 
     // Find the connections between the vertices of the graph (vertices are the rawhits, 
     // connections are made when they are adjacent to one another)
@@ -859,7 +859,7 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
       for(mapiter = clusrange.first; mapiter != clusrange.second; mapiter++ ) {
         PHG4Cell* cell = mapiter->second;
 	SvtxHit* hit = cell_hit_map[cell];
-	if(verbosity>0)
+	if(Verbosity()>0)
 	  {
 	    cout << "Add hit: "; 
 	    hit->identify();
@@ -891,8 +891,8 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 	  zsum += hit_location[2];
 	}
 	++nhits;
-	if(verbosity > 2) cout << "     nhits = " << nhits << endl;
-	if(verbosity > 2)
+	if(Verbosity() > 2) cout << "     nhits = " << nhits << endl;
+	if(Verbosity() > 2)
 	  {
 	    cout << "  From  geometry object: hit x " << hit_location[0] << " hit y " << hit_location[1] << " hit z " << hit_location[2]  << endl;
 	    cout << "     nhits " << nhits << " clusx  = " << xsum/nhits << " clusy " << ysum/nhits << " clusz " << zsum/nhits  << endl;
@@ -1026,7 +1026,7 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 	  }
 	}
 
-	if(verbosity > 1)
+	if(Verbosity() > 1)
 	  {
 	    // fairly complete sanity check:
 	    // Get the list of g4hit positions for this cluster and compare positions	    
@@ -1069,7 +1069,7 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 	    cout << endl;
 	  }
 	
-	if (verbosity>1) {
+	if (Verbosity()>1) {
 	  double radius = sqrt(clusx*clusx+clusy*clusy);
 	  double clusphi = atan2(clusy,clusx);
 	  cout << "INTT ladder cluster r=" << radius << " phi=" << clusphi << " z=" << clusz << endl;
@@ -1077,7 +1077,7 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 	       << ", " << clus.get_position(2) << ")" << endl;
 	  cout << endl;
 	}
-      }	else if (verbosity>1) {
+      }	else if (Verbosity()>1) {
 	double radius = sqrt(clusx*clusx+clusy*clusy);
 	double clusphi = atan2(clusy,clusx);
 	cout << "removed r=" << radius << " phi=" << clusphi << " z=" << clusz << endl;
@@ -1093,7 +1093,7 @@ void PHG4SvtxClusterizer::ClusterLadderCells(PHCompositeNode *topNode) {
 
 void PHG4SvtxClusterizer::ClusterMapsLadderCells(PHCompositeNode *topNode) {
 
-  if(verbosity > 0)
+  if(Verbosity() > 0)
     cout << "Entering PHG4SvtxClusterizer::ClusterMapsLadderCells " << endl;
 
   //----------
@@ -1149,7 +1149,7 @@ void PHG4SvtxClusterizer::ClusterMapsLadderCells(PHCompositeNode *topNode) {
 
     double hitx=0, hity=0, hitz =0;
 
-    if(verbosity >4)
+    if(Verbosity() >4)
       {
 	cout << "get g4_hit hit positions for layer  " << layer << endl;
 	PHG4HitContainer::ConstIterator hiter;
@@ -1209,7 +1209,7 @@ void PHG4SvtxClusterizer::ClusterMapsLadderCells(PHCompositeNode *topNode) {
       int layer = mapiter->second->get_layer();
       PHG4CylinderGeom_MAPS *geom = (PHG4CylinderGeom_MAPS*) geom_container->GetLayerGeom(layer);
 
-      if(verbosity > 2)
+      if(Verbosity() > 2)
 	cout << "Filling cluster id " << clusid << " in  layer " << layer << endl;
       
       SvtxCluster_v1 clus;
@@ -1233,7 +1233,7 @@ void PHG4SvtxClusterizer::ClusterMapsLadderCells(PHCompositeNode *topNode) {
 	int binz = geom->get_pixel_Z_from_pixel_number(pixel_number);
 	zbins.insert(binz);
 
-	if(verbosity > 2)
+	if(Verbosity() > 2)
 	  cout << "   pixel number " << pixel_number << " binphi = " << binphi  << " binz = " << binz  << endl;
       }
 
@@ -1259,7 +1259,7 @@ void PHG4SvtxClusterizer::ClusterMapsLadderCells(PHCompositeNode *topNode) {
       for(mapiter = clusrange.first; mapiter != clusrange.second; mapiter++ ) {
         PHG4Cell* cell = mapiter->second;
 
-	//if(verbosity > 2)	
+	//if(Verbosity() > 2)	
 	  //cell->identify();
 	
 	SvtxHit* hit = cell_hit_map[cell];
@@ -1290,7 +1290,7 @@ void PHG4SvtxClusterizer::ClusterMapsLadderCells(PHCompositeNode *topNode) {
 	  zsum += hit_location[2];
 	}
 	
-	if(verbosity > 2)
+	if(Verbosity() > 2)
 	  {
 	    cout << "  From  geometry object: hit x " << hit_location[0] << " hit y " << hit_location[1] << " hit z " << hit_location[2] << " from hit object: e " << hit->get_e() << " hit adc " << hit->get_adc() << " e weight " << _make_e_weights[layer] << endl;
 	  }
@@ -1415,7 +1415,7 @@ void PHG4SvtxClusterizer::ClusterMapsLadderCells(PHCompositeNode *topNode) {
 	    first = false;
 	  }
 	}
-	if(verbosity > 1)
+	if(Verbosity() > 1)
 	  {
 	    // fairly complete sanity check:
 	    // Get the list of g4hit positions for this cluster and compare positions	    
@@ -1450,7 +1450,7 @@ void PHG4SvtxClusterizer::ClusterMapsLadderCells(PHCompositeNode *topNode) {
 	    cout << endl;
 	  }
 
-	if (verbosity>1) {
+	if (Verbosity()>1) {
 	  double radius = sqrt(clusx*clusx+clusy*clusy);
 	  double clusphi = atan2(clusy,clusx);
 	  cout << "clus energy " << clus_energy << " clus_adc " << clus_adc << " r=" << radius << " phi=" << clusphi << " z=" << clusz << endl;
@@ -1458,7 +1458,7 @@ void PHG4SvtxClusterizer::ClusterMapsLadderCells(PHCompositeNode *topNode) {
 	       << ", " << clus.get_position(2) << ")" << endl;
 	  cout << endl;
 	}
-      }	else if (verbosity>1) {
+      }	else if (Verbosity()>1) {
 	double radius = sqrt(clusx*clusx+clusy*clusy);
 	double clusphi = atan2(clusy,clusx);
 	cout << "MAPS ladder cell: removed, clus_energy = " << clus_energy << " below threshold of " <<  get_threshold_by_layer(layer)  << " clus_adc " << clus_adc <<  " r=" << radius << " phi=" << clusphi << " z=" << clusz << endl;
@@ -1475,7 +1475,7 @@ void PHG4SvtxClusterizer::ClusterMapsLadderCells(PHCompositeNode *topNode) {
 
 void PHG4SvtxClusterizer::PrintClusters(PHCompositeNode *topNode) {
 
-  if (verbosity >= 1) {
+  if (Verbosity() >= 1) {
 
     SvtxClusterMap *clusterlist = findNode::getClass<SvtxClusterMap>(topNode,"SvtxClusterMap");
     if (!clusterlist) return;

--- a/simulation/g4simulation/g4hough/PHG4SvtxDeadArea.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDeadArea.C
@@ -53,7 +53,7 @@ int PHG4SvtxDeadArea::InitRun(PHCompositeNode* topNode) {
   GenericFillDeadAreaMap(topNode,"SVTX");
   GenericFillDeadAreaMap(topNode,"SILICON_TRACKER");
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "====================== PHG4SvtxDeadArea::InitRun() ========================" << endl;
     cout << " Random number seed = " << seed << endl;    
     for (std::map<int,float>::iterator iter = _eff_by_layer.begin();
@@ -80,7 +80,7 @@ int PHG4SvtxDeadArea::process_event(PHCompositeNode *topNode) {
 
     if (gsl_rng_uniform_pos(RandomGenerator) > get_hit_efficiency(hit->get_layer())) {
       remove_hits.push_back(hit->get_id());
-      if(verbosity > 5)
+      if(Verbosity() > 5)
 	cout << "removing hit" << hit->get_id() << endl;
     }
   }
@@ -101,7 +101,7 @@ PHG4SvtxDeadArea::GenericFillDeadAreaMap(PHCompositeNode *topNode, const std::st
     
   if (!geom_container) return;
 
-  if(verbosity > 0)
+  if(Verbosity() > 0)
     cout << "Found " << nodename << endl;
 
   PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();

--- a/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxDigitizer.C
@@ -49,7 +49,7 @@ PHG4SvtxDigitizer::PHG4SvtxDigitizer(const string &name) :
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
   gsl_rng_set(RandomGenerator, seed);
 
-  if(verbosity > 0)
+  if(Verbosity() > 0)
     cout << "Creating PHG4SvtxDigitizer with name = " << name << endl;
 }
 
@@ -103,7 +103,7 @@ int PHG4SvtxDigitizer::InitRun(PHCompositeNode* topNode) {
   // Report Settings
   //----------------
   
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "====================== PHG4SvtxDigitizer::InitRun() =====================" << endl;
     for (std::map<int,unsigned int>::iterator iter = _max_adc.begin();
 	 iter != _max_adc.end();
@@ -342,7 +342,7 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
     {    
       PHG4Cell* cell =  celliter->second; 
 
-      if(verbosity > 100)
+      if(Verbosity() > 100)
 	if( (unsigned int) cell->get_layer() == print_layer)
 	  {
 	    for (PHG4Cell::EdepConstIterator g4iter = cell->get_g4hits().first;
@@ -356,7 +356,7 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
 
       if( (unsigned int) cell->get_layer() < TPCMinLayer) 
 	{
-	  if(verbosity>0) std::cout << "Skipping layer " << cell->get_layer() << std::endl;
+	  if(Verbosity()>0) std::cout << "Skipping layer " << cell->get_layer() << std::endl;
 	  continue;
 	}
       //cout << "Digitizer: cell identify:" << endl;
@@ -463,7 +463,7 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
 		  // digitize this bin and the following 4 bins
 
 
-		  if(verbosity > 100)
+		  if(Verbosity() > 100)
 		    if(layer == print_layer) cout << endl << "  (neg z) Above threshold of " << ADCThreshold*ADCNoiseConversionGain << " for phibin " << iphi 
 						  << " iz " << iz << " with adc_input " << adc_input[iz] << " digitize this and 4 following bins: "  << endl;
 
@@ -475,7 +475,7 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
 			  if(adc_input[iz+izup] < 0) adc_output = 0;
 			  if (adc_output > 1023) adc_output = 1023;
 
-			  if(verbosity > 100)
+			  if(Verbosity() > 100)
 			    if(layer == print_layer)  cout << "    (neg z) iz+izup " << iz+izup << " adc_cellid " << adc_cellid[iz+izup] 
 							   << "  adc_input "  << adc_input[iz+izup] << " ADCThreshold " << ADCThreshold*ADCNoiseConversionGain 
 							   << " adc_output " << adc_output << endl;
@@ -492,7 +492,7 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
 			      cell->add_edep(adc_input[iz+izup] / ADCSignalConversionGain);  //convert from voltage back to electrons from GEM
 			      adc_cellid[iz+izup]=cell->get_cellid();
 
-			      if(verbosity > 100)
+			      if(Verbosity() > 100)
 				if(layer == print_layer)  cout << " will digitize noise hit for iphi " << iphi << " zbin " << iz+izup 
 							       << " created new cell with cellid " << cell->get_cellid() 
 							       << " adc_input " << adc_input[iz+izup] << " edep " << cell->get_edep() << endl; 
@@ -522,7 +522,7 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
 			    }
 			  binpointer ++;
 
-			  if(verbosity > 100)
+			  if(Verbosity() > 100)
 			    if(layer == print_layer)
 			      { 
 				//cout << endl << "Digitizer: Hit identify after insertion:" << endl;
@@ -561,7 +561,7 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
 		{
 		  // digitize this bin and the following 4 bins
 		  
-		  if(verbosity > 100)
+		  if(Verbosity() > 100)
 		    if(layer == print_layer) cout << endl << "  (pos z) Above threshold  of " << ADCThreshold*ADCNoiseConversionGain << " for iz " << iz 
 						  << " with adc_input " << adc_input[iz] << " digitize this and 4 following bins: " << endl;
 		  
@@ -574,7 +574,7 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
 			  if(adc_input[iz-izup] < 0) adc_output = 0;
 			  if (adc_output > 1023) adc_output = 1023;
 
-			  if(verbosity > 100)
+			  if(Verbosity() > 100)
 			    if(layer == print_layer)  cout << "    (pos z) iz-izup " << iz-izup << " adc_cellid " << adc_cellid[iz-izup] 
 							   << "  adc_input "  << adc_input[iz-izup] << " ADCThreshold " << ADCThreshold*ADCNoiseConversionGain 
 							   << " adc_output " << adc_output << endl;
@@ -590,7 +590,7 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
 
 			      cell->add_edep(adc_input[iz-izup] / ADCSignalConversionGain);  //convert from voltage back to electrons from GEM stack 
 			      adc_cellid[iz-izup]=cell->get_cellid();
-			      if(verbosity > 100)
+			      if(Verbosity() > 100)
 				if(layer == print_layer)  cout  << " will digitize noise hit for iphi " << iphi << " zbin " << iz-izup 
 								<< " created new cell with cellid " << cell->get_cellid() 
 								<< " edep " << cell->get_edep() << endl; 
@@ -621,7 +621,7 @@ void PHG4SvtxDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode) {
 			    }
 			  binpointer--;
 
-			  if(verbosity > 100)
+			  if(Verbosity() > 100)
 			    if(layer == print_layer)
 			      {
 				//cout << endl << "Digitizer (pos z): Hit identify after insertion:" << endl;
@@ -755,7 +755,7 @@ void PHG4SvtxDigitizer::DigitizeMapsLadderCells(PHCompositeNode *topNode) {
 
 void PHG4SvtxDigitizer::PrintHits(PHCompositeNode *topNode) {
 
-  if (verbosity >= 1) {
+  if (Verbosity() >= 1) {
 
     SvtxHitMap *hitlist = findNode::getClass<SvtxHitMap>(topNode,"SvtxHitMap");
     if (!hitlist) return;

--- a/simulation/g4simulation/g4hough/PHG4SvtxMomentumRecal.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxMomentumRecal.C
@@ -27,7 +27,7 @@ int PHG4SvtxMomentumRecal::Init(PHCompositeNode *topNode)
 
 int PHG4SvtxMomentumRecal::InitRun(PHCompositeNode *topNode) 
 {
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "================== PHG4SvtxMomentumRecal::InitRun() =====================" << endl;
     cout << "===========================================================================" << endl;
   }
@@ -37,7 +37,7 @@ int PHG4SvtxMomentumRecal::InitRun(PHCompositeNode *topNode)
 
 int PHG4SvtxMomentumRecal::process_event(PHCompositeNode *topNode)
 {
-  if(verbosity > 1) cout << "PHG4SvtxMomentumRecal::process_event -- entered" << endl;
+  if(Verbosity() > 1) cout << "PHG4SvtxMomentumRecal::process_event -- entered" << endl;
 
   if (!_corr) return Fun4AllReturnCodes::EVENT_OK;
   
@@ -75,7 +75,7 @@ int PHG4SvtxMomentumRecal::process_event(PHCompositeNode *topNode)
     track->set_pz( track->get_pz() * rescale );
   } // end track loop
 
-  if (verbosity > 1) cout << "PHG4SvtxMomentumRecal::process_event -- exited" << endl;
+  if (Verbosity() > 1) cout << "PHG4SvtxMomentumRecal::process_event -- exited" << endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxThresholds.C
@@ -39,7 +39,7 @@ int PHG4SvtxThresholds::InitRun(PHCompositeNode* topNode) {
   CalculateLadderThresholds(topNode);
   CalculateMapsLadderThresholds(topNode);
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "====================== PHG4SvtxThresholds::InitRun() ======================" << endl;
     for (std::map<int,float>::iterator iter = _fraction_of_mip.begin();
 	 iter != _fraction_of_mip.end();
@@ -79,7 +79,7 @@ int PHG4SvtxThresholds::process_event(PHCompositeNode *topNode)
     SvtxHit* hit = iter->second;
    
     if (hit->get_e() < get_threshold_by_layer(hit->get_layer())) {
-      if(verbosity > 2)
+      if(Verbosity() > 2)
 	cout << "Removing hit with energy " << hit->get_e() <<  " in layer " << hit->get_layer() << " threshold = " << get_threshold_by_layer(hit->get_layer()) << endl;
       remove_hits.push_back(hit->get_id());
     }
@@ -119,7 +119,7 @@ void PHG4SvtxThresholds::CalculateCylinderThresholds(PHCompositeNode* topNode) {
       float threshold = 0.0;      
       if (_fraction_of_mip.find(layer) != _fraction_of_mip.end()) {	
 	threshold = _fraction_of_mip[layer]*0.003876*thickness;
-	if(verbosity >2) 
+	if(Verbosity() >2) 
 	  cout << " using thickness: threshold = " << threshold << " thickness = " << thickness << " fraction of mip = " << _fraction_of_mip[layer] << " layer " << layer << endl;
       }	  
       _thresholds_by_layer.insert(std::make_pair(layer,threshold));
@@ -134,7 +134,7 @@ void PHG4SvtxThresholds::CalculateCylinderThresholds(PHCompositeNode* topNode) {
 	threshold = _fraction_of_mip[layer]*0.003876*minpath;  
       }	      
       _thresholds_by_layer.insert(std::make_pair(layer,threshold));
-      if(verbosity >2) 
+      if(Verbosity() >2) 
 	cout << " not using thickness: threshold = " << threshold << " thickness = " << thickness << " fraction of mip = " << _fraction_of_mip[layer] << " layer " << layer << endl;
     }
   }
@@ -203,7 +203,7 @@ void PHG4SvtxThresholds::CalculateMapsLadderThresholds(PHCompositeNode* topNode)
       float threshold = 0.0;
       if (_fraction_of_mip.find(layer) != _fraction_of_mip.end()) {
 	threshold = _fraction_of_mip[layer]*0.003876*thickness;
-	if(verbosity >2) 
+	if(Verbosity() >2) 
 	  cout << " using thickness: threshold = " << threshold << " thickness = " << thickness << " fraction of mip = " << _fraction_of_mip[layer] << " layer " << layer << endl;
       }
       _thresholds_by_layer.insert(std::make_pair(layer,threshold));
@@ -218,7 +218,7 @@ void PHG4SvtxThresholds::CalculateMapsLadderThresholds(PHCompositeNode* topNode)
 	threshold = _fraction_of_mip[layer]*0.003876*minpath;
       }
       _thresholds_by_layer.insert(std::make_pair(layer,threshold));
-	if(verbosity >2) 
+	if(Verbosity() >2) 
 	  cout << " not using thickness: threshold = " << threshold << " thickness = " << thickness << " fraction of mip = " << _fraction_of_mip[layer] << " layer " << layer << endl;
     }
   }

--- a/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
+++ b/simulation/g4simulation/g4hough/PHG4SvtxTrackProjection.C
@@ -53,7 +53,7 @@ int PHG4SvtxTrackProjection::InitRun(PHCompositeNode *topNode)
     if (geo) _cal_radii[i] = geo->get_radius();
   }
   
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "================== PHG4SvtxTrackProjection::InitRun() =====================" << endl;
     for (int i=0;i<_num_cal_layers;++i) {
       if (!std::isnan(_cal_radii[i])) {
@@ -71,7 +71,7 @@ int PHG4SvtxTrackProjection::InitRun(PHCompositeNode *topNode)
 
 int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
 {
-  if(verbosity > 1) cout << "PHG4SvtxTrackProjection::process_event -- entered" << endl;
+  if(Verbosity() > 1) cout << "PHG4SvtxTrackProjection::process_event -- entered" << endl;
 
   //---------------------------------
   // Get Objects off of the Node Tree
@@ -88,7 +88,7 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
 
     if (std::isnan(_cal_radii[i])) continue;
 
-    if (verbosity > 1) cout << "Projecting tracks into: " << _cal_names[i] << endl;
+    if (Verbosity() > 1) cout << "Projecting tracks into: " << _cal_names[i] << endl;
 
     // pull the tower geometry
     string towergeonodename = "TOWERGEOM_" + _cal_names[i];
@@ -120,9 +120,9 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
 	 ++iter) {
       SvtxTrack *track = iter->second;
 
-      if (verbosity > 1) cout << "projecting track id " << track->get_id() << endl;
+      if (Verbosity() > 1) cout << "projecting track id " << track->get_id() << endl;
 
-      if (verbosity > 1) {
+      if (Verbosity() > 1) {
 	cout << " track pt = " << track->get_pt() << endl;
       }
 
@@ -164,7 +164,7 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
       double phi = atan2(y,x);
       double eta = asinh(z/sqrt(x*x+y*y));
 
-      if (verbosity > 1) {
+      if (Verbosity() > 1) {
 	cout << " initial track phi = " << track->get_phi();
 	cout << ", eta = " << track->get_eta() << endl;
 	cout << " calorimeter phi = " << phi << ", eta = " << eta << endl;
@@ -204,7 +204,7 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
 	      if (abs(iphi - binphi)<=1 and abs(ieta - bineta)<=1 )
 	        energy_3x3 += tower->get_energy();
 
-	    if (verbosity > 1) cout << " tower " << ieta << " " << wrapphi << " energy = " << tower->get_energy() << endl;
+	    if (Verbosity() > 1) cout << " tower " << ieta << " " << wrapphi << " energy = " << tower->get_energy() << endl;
 	  }
       	}
       }
@@ -244,7 +244,7 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
 	track->set_cal_cluster_id(_cal_types[i],min_index);
 	track->set_cal_cluster_e(_cal_types[i],min_e);
 
-	if (verbosity > 1) {
+	if (Verbosity() > 1) {
 	  cout << " nearest cluster dphi = " << min_dphi << " deta = " << min_deta << " e = " << min_e << endl;
 	}
       }
@@ -253,7 +253,7 @@ int PHG4SvtxTrackProjection::process_event(PHCompositeNode *topNode)
   } // end calorimeter layer loop
 
  
-  if(verbosity > 1) cout << "PHG4SvtxTrackProjection::process_event -- exited" << endl;
+  if(Verbosity() > 1) cout << "PHG4SvtxTrackProjection::process_event -- exited" << endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
+++ b/simulation/g4simulation/g4hough/PHG4TPCClusterizer.C
@@ -417,7 +417,7 @@ void PHG4TPCClusterizer::find_z_range(int zbin, int phibin, int zmax, float peak
       int bin3 = (cz+3) * fNPhiBins + cp;
       if(fAmps[bin] == 0) {
 	zup = iz;
-	if(verbosity > 1000) cout << " failed threshold cut, set izup to " << zup << endl;
+	if(Verbosity() > 1000) cout << " failed threshold cut, set izup to " << zup << endl;
 	break;
       }
       if(fClusterZSplit){
@@ -445,7 +445,7 @@ void PHG4TPCClusterizer::find_z_range(int zbin, int phibin, int zmax, float peak
       int bin3 = (cz-3) * fNPhiBins + cp;
       if(fAmps[bin] == 0) {
 	zdown = iz;
-	if(verbosity > 1000) cout << " failed threshold cut, set izdown to " << zdown << endl;
+	if(Verbosity() > 1000) cout << " failed threshold cut, set izdown to " << zdown << endl;
 	break;
       }
       if(fClusterZSplit){
@@ -506,9 +506,9 @@ void PHG4TPCClusterizer::fit(int pbin, int zbin, int& nhits_tot) {
       izdownmax = izdown[ip+fFitRangeP];
   }
 
-  if(verbosity>1000) 
+  if(Verbosity()>1000) 
     std::cout << "max " << fAmps[zbin*fNPhiBins+pbin] << std::endl;
-  if(verbosity>1000) 
+  if(Verbosity()>1000) 
     std::cout << "izdown " << izdown << " izup " << izup << std::endl;
 
   for(int iz=-izdownmax; iz<izupmax; ++iz) {
@@ -523,7 +523,7 @@ void PHG4TPCClusterizer::fit(int pbin, int zbin, int& nhits_tot) {
       if(iz>izup[ip+fFitRangeP])continue;
       int cp = wrap_phibin(pbin + ip);
       int bin = cz * fNPhiBins + cp;
-      if(verbosity>1000) {
+      if(Verbosity()>1000) {
 	std::cout << Form("%.2f | ",fAmps[bin]);
 	if(ip==fFitRangeP) std::cout << std::endl;
       }
@@ -551,14 +551,14 @@ void PHG4TPCClusterizer::fit(int pbin, int zbin, int& nhits_tot) {
     if(used) fFitSizeZ++;
     fFitSizeP = TMath::Max(fFitSizeP,float(nphis));
   }
-  if(verbosity>1000) {
+  if(Verbosity()>1000) {
     std::cout << " FIT | phi " << fit_p_mean() << " from " << fFitP0;
     std::cout << " | z " << fit_z_mean() << " from " << fFitZ0 << std::endl;
   }
 }
 //===================
 int PHG4TPCClusterizer::InitRun(PHCompositeNode* topNode) {
-  if(verbosity>1) {
+  if(Verbosity()>1) {
     fHClusterEnergy = new TH1F("CLUSTER_Energy","CLUSTER_Energy",1000,0,1000);
     fHClusterDensity = new TProfile2D("CLUSTER_Density","CLUSTER_Density;LayerNo;ZZ;<E>",50,-0.5,49.5,220,-110,+110);
     fHClusterSizePP = new TProfile2D("CLUSTER_SizePP","CLUSTER_SizePP;LayerNo;ZZ;<rphisize>",50,-0.5,49.5,220,-110,+110);
@@ -596,8 +596,8 @@ int PHG4TPCClusterizer::InitRun(PHCompositeNode* topNode) {
 void PHG4TPCClusterizer::reset() {}
 //===================
 int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
-  if(verbosity>1000) std::cout << "PHG4TPCClusterizer::Process_Event" << std::endl;
-  if(verbosity>1) {
+  if(Verbosity()>1000) std::cout << "PHG4TPCClusterizer::Process_Event" << std::endl;
+  if(Verbosity()>1) {
     fSW->Reset();
     fSW->Start();
   }
@@ -645,7 +645,7 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
        ++layeriter) {
     //cout << "Layer " << layeriter->second->get_layer() << endl;
     if( (unsigned int) layeriter->second->get_layer() < fMinLayer) {
-      if(verbosity>1000) std::cout << "Skipping layer " << layeriter->second->get_layer() << std::endl;
+      if(Verbosity()>1000) std::cout << "Skipping layer " << layeriter->second->get_layer() << std::endl;
       continue;
     }
     layer_sorted.push_back(std::vector<const SvtxHit*>());
@@ -666,7 +666,7 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
     fGeoLayer = geom_container->GetLayerCellGeom(layer);
     fNPhiBins = layeriter->second->get_phibins();
     fNZBins = layeriter->second->get_zbins();
-    if(verbosity>0) {
+    if(Verbosity()>0) {
       std::cout << "************ Layer " << layer;
       std::cout << " fNPhiBins " << fNPhiBins;
       std::cout << " fNZBins " << fNZBins;
@@ -682,18 +682,18 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
     for(unsigned int i = 0; i < layer_sorted[layer - fMinLayer].size(); ++i) {
       const SvtxHit* hit = layer_sorted[layer - fMinLayer][i];
       if(hit->get_e() <= 0.) continue;
-      if(verbosity>2000) 
+      if(Verbosity()>2000) 
 	std::cout << hit->get_cellid();
       PHG4Cell* cell = cells->findCell(hit->get_cellid()); //not needed once geofixed
       int phibin = PHG4CellDefs::SizeBinning::get_phibin(cell->get_cellid());//cell->get_binphi();
       int zbin = PHG4CellDefs::SizeBinning::get_zbin(cell->get_cellid());//cell->get_binz();
-      if(verbosity>0) std::cout << " phibin " << phibin << " zbin " << zbin << " z " << fGeoLayer->get_zcenter( zbin ) << " adc " << hit->get_adc() - fPedestal << std::endl;
+      if(Verbosity()>0) std::cout << " phibin " << phibin << " zbin " << zbin << " z " << fGeoLayer->get_zcenter( zbin ) << " adc " << hit->get_adc() - fPedestal << std::endl;
       fNHitsPerZ[zbin] += 1;
       fAmps[zbin * fNPhiBins + phibin] += hit->get_adc() - fPedestal;  // subtract pedestal in ADC counts, determined elsewhere
       if(fAmps[zbin * fNPhiBins + phibin] < 0)  fAmps[zbin * fNPhiBins + phibin]  = 0;  // our simple clustering algorithm does not handle negative bins well
       fCellIDs[zbin * fNPhiBins + phibin] = hit->get_id();
       //if(Verbosity() > 100)
-      if(verbosity > 100)
+      if(Verbosity() > 100)
 	//if(layer == 47) 
 	  {
 	    cout << "Clusterizer: adding input SvtxHit " <<  hit->get_id() << endl;;
@@ -709,14 +709,14 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
     int nhits_tot = 0;
     for(int zbin = 0; zbin!=fNZBins; ++zbin)
       nhits_tot += fNHitsPerZ[zbin];
-    if(verbosity>0) 
+    if(Verbosity()>0) 
       std::cout << " nhits_tot " << nhits_tot << std::endl;
 
     float stepz = fGeoLayer->get_zstep();
     float stepp = fGeoLayer->get_phistep();
 
     //while(nhits_tot > 2) {
-    if(verbosity>0) 
+    if(Verbosity()>0) 
       std::cout << " => nhits_tot " << nhits_tot << std::endl;
       for(int zbin = 0; zbin!=fNZBins; ++zbin) {
         if(fNHitsPerZ[zbin]<=0) continue;
@@ -726,7 +726,7 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
 	float sigmaP = TMath::Sqrt(pow(TPC_padgeo_sigma, 2) + fDCT*fDCT*(105.5-abszbincenter)); // readout geometry + drift diffusion, used only to calculate FitRangeP
 	fFitRangeZ = int( fClusterWindow*sigmaZ/stepz + 1);
 	if(fFitRangeZ<1) fFitRangeZ = 1; // should never happen
-	if(verbosity > 2000) 
+	if(Verbosity() > 2000) 
 	  cout << " sigmaZ " << sigmaZ << " fFitRangeZ " << fFitRangeZ << " sigmaP " << sigmaP << endl;
 
         for(int phibin = 0; phibin!=fNPhiBins; ++phibin) {
@@ -736,7 +736,7 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
 	  if(fFitRangeP<1) fFitRangeP = 1;
 	  if(fFitRangeP>fFitRangeMP) fFitRangeP = fFitRangeMP;
           if(!is_local_maximum(phibin, zbin)) continue;
-	  if(verbosity>2000){
+	  if(Verbosity()>2000){
 	    std::cout << " maxima found in window rphi z " << fFitRangeP << " " << fFitRangeZ << std::endl;
 	    cout << " phibin: "  << phibin << " zbin: " << zbin 
 		 << endl;
@@ -774,7 +774,7 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
 	  float pp_size = radius*fFitSizeP*fGeoLayer->get_phistep();
 	  float zz_size = fFitSizeZ*fGeoLayer->get_zstep();
 
-	  if(verbosity > 100)
+	  if(Verbosity() > 100)
 	    //if(layer == 47) 
 	      {
 		cout << endl << " clusterizer: layer " << layer << " fFitW " << fFitW << " number of primary electrons (adc) = " << fFitW * 0.14 
@@ -784,7 +784,7 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
 
 	      }
 
-	  if(verbosity>1) {
+	  if(Verbosity()>1) {
 	    fHClusterEnergy->Fill(fFitW);
 	    fHClusterDensity->Fill(layer,zz,fFitW);
 	    fHClusterSizePP->Fill(layer,zz,pp_size);
@@ -799,9 +799,9 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
 	    fHClusterWindowP->Fill(layer,zz,fFitRangeP);
 	    fHClusterWindowZ->Fill(layer,zz,fFitRangeZ);
 	  }
-	  if(verbosity>2000)
+	  if(Verbosity()>2000)
 	    std::cout << " cluster fitted " << std::endl;
-	    if(verbosity>1000)
+	    if(Verbosity()>1000)
 	    {
 	    std::cout << " | rad " << radius;
 	    std::cout << " | size rp z " << pp_size << " " << zz_size;
@@ -913,7 +913,7 @@ int PHG4TPCClusterizer::process_event(PHCompositeNode* topNode) {
     }
   }
   reset();
-  if(verbosity>1000) std::cout << "PHG4TPCClusterizer::Process_Event DONE" << std::endl;
-  if(verbosity>1) fHTime->Fill( fSW->RealTime() );
+  if(Verbosity()>1000) std::cout << "PHG4TPCClusterizer::Process_Event DONE" << std::endl;
+  if(Verbosity()>1) fHTime->Fill( fSW->RealTime() );
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -110,7 +110,7 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode *topNode) {
 		return Fun4AllReturnCodes::ABORTRUN;
 	}
 
-	_fitter->set_verbosity(verbosity);
+	_fitter->set_verbosity(Verbosity());
 
 	// tower geometry for track states
 
@@ -174,7 +174,7 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 
   _event++;
 
-	if (verbosity >= 2)
+	if (Verbosity() >= 2)
 	  std::cout << "PHG4TrackFastSim::process_event: " << _event << ".\n";
 
 	GetNodes(topNode);
@@ -239,7 +239,7 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 				   seed_cov);
 
 	  if (measurements.size() < 3) {
-	    if (verbosity >= 2) {
+	    if (Verbosity() >= 2) {
 	      //LogWarning("measurements.size() < 3");
 	      std::cout << "event: " << _event << " : measurements.size() < 3"
 			<< "\n";
@@ -285,7 +285,7 @@ int PHG4TrackFastSim::process_event(PHCompositeNode *topNode) {
 	  int fitting_err = _fitter->processTrack(track, false);
 
 	  if (fitting_err != 0) {
-	    if (verbosity >= 2) {
+	    if (Verbosity() >= 2) {
 	      //LogWarning("measurements.size() < 3");
 	      std::cout << "event: " << _event
 			<< " : fitting_err != 0, next track." << "\n";
@@ -346,7 +346,7 @@ int PHG4TrackFastSim::CreateNodes(PHCompositeNode *topNode) {
 	if (!tb_node) {
 		tb_node = new PHCompositeNode(_sub_top_node_name.c_str());
 		dstNode->addNode(tb_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << _sub_top_node_name.c_str() << " node added" << endl;
 	}
 
@@ -355,7 +355,7 @@ int PHG4TrackFastSim::CreateNodes(PHCompositeNode *topNode) {
 //	PHIODataNode<PHObject>* clusters_node = new PHIODataNode<PHObject>(
 //			_clustermap_out, _clustermap_out_name.c_str(), "PHObject");
 //	tb_node->addNode(clusters_node);
-//	if (verbosity > 0)
+//	if (Verbosity() > 0)
 //		cout << _clustermap_out_name.c_str() <<" node added" << endl;
 
 	_trackmap_out = new SvtxTrackMap_v1;
@@ -363,7 +363,7 @@ int PHG4TrackFastSim::CreateNodes(PHCompositeNode *topNode) {
 	PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(
 			_trackmap_out, _trackmap_out_name.c_str(), "PHObject");
 	tb_node->addNode(tracks_node);
-	if (verbosity > 0)
+	if (Verbosity() > 0)
 		cout << _trackmap_out_name.c_str() << " node added" << endl;
 
 	return Fun4AllReturnCodes::EVENT_OK;

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.h
@@ -69,11 +69,6 @@ public:
 	//!End, write and close files
 	int End(PHCompositeNode *);
 
-	/// set verbosity
-	void Verbosity(int verb) {
-		verbosity = verb; // SubsysReco verbosity
-	}
-
 	bool is_do_evt_display() const {
 		return _do_evt_display;
 	}

--- a/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.C
@@ -35,7 +35,7 @@ int PHG4TrackGhostRejection::Init(PHCompositeNode *topNode)
 
 int PHG4TrackGhostRejection::InitRun(PHCompositeNode *topNode)
 {
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "================== PHG4TrackGhostRejection::InitRun() =====================" << endl;
     cout << " Maximum allowed shared hits: " << _max_shared_hits << endl;
     for (unsigned int i=0;i<_layer_enabled.size();++i) {
@@ -49,7 +49,7 @@ int PHG4TrackGhostRejection::InitRun(PHCompositeNode *topNode)
 
 int PHG4TrackGhostRejection::process_event(PHCompositeNode *topNode)
 {
-  if(verbosity > 0) cout << "PHG4TrackGhostRejection::process_event -- entered" << endl;
+  if(Verbosity() > 0) cout << "PHG4TrackGhostRejection::process_event -- entered" << endl;
 
   //---------------------------------
   // Get Objects off of the Node Tree
@@ -63,7 +63,7 @@ int PHG4TrackGhostRejection::process_event(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-  if (verbosity > 1) {
+  if (Verbosity() > 1) {
     _g4tracks->identify();
     for (SvtxTrackMap::Iter iter = _g4tracks->begin();
 	 iter != _g4tracks->end();
@@ -196,7 +196,7 @@ int PHG4TrackGhostRejection::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if (verbosity > 1) {
+  if (Verbosity() > 1) {
     _g4tracks->identify();
     for (SvtxTrackMap::Iter iter = _g4tracks->begin();
 	 iter != _g4tracks->end();
@@ -206,12 +206,12 @@ int PHG4TrackGhostRejection::process_event(PHCompositeNode *topNode)
     }
   }
 
-  if(verbosity > 0)
+  if(Verbosity() > 0)
     cout << "PHG4TrackGhostRejection - rejected and removed " 
          << initial_size - _g4tracks->size()
          << " tracks" << endl;;
   
-  if(verbosity > 0) cout << "PHG4TrackGhostRejection::process_event -- exited" << endl;
+  if(Verbosity() > 0) cout << "PHG4TrackGhostRejection::process_event -- exited" << endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
@@ -99,10 +99,10 @@ class PHRaveVertexFactory {
 
 public:
 	//! ctor
-	PHRaveVertexFactory(const int verbosity) {
+	PHRaveVertexFactory(const int Verbosity()) {
 		rave::ConstantMagneticField mfield(0., 0., 0.); // RAVE use Tesla
 		_factory = new rave::VertexFactory(mfield, rave::VacuumPropagator(),
-				"default", verbosity);
+				"default", Verbosity());
 
 		IdGFTrackStateMap_.clear();
 	}
@@ -239,7 +239,7 @@ int PHG4TrackKalmanFitter::InitRun(PHCompositeNode *topNode) {
 	_fitter = PHGenFit::Fitter::getInstance(tgeo_manager,
 	    field, _track_fitting_alg_name,
 			"RKTrackRep", _do_evt_display);
-	_fitter->set_verbosity(verbosity);
+	_fitter->set_verbosity(Verbosity());
 
 	if (!_fitter) {
 		cerr << PHWHERE << endl;
@@ -248,12 +248,12 @@ int PHG4TrackKalmanFitter::InitRun(PHCompositeNode *topNode) {
 
 	//LogDebug(genfit::FieldManager::getInstance()->getFieldVal(TVector3(0, 0, 0)).Z());
 
-	_vertex_finder = new genfit::GFRaveVertexFactory(verbosity);
+	_vertex_finder = new genfit::GFRaveVertexFactory(Verbosity());
 	//_vertex_finder->setMethod("kalman-smoothing:1"); //! kalman-smoothing:1 is the defaul method
 	_vertex_finder->setMethod(_vertexing_method.data());
 	//_vertex_finder->setBeamspot();
 
-	//_vertex_finder = new PHRaveVertexFactory(verbosity);
+	//_vertex_finder = new PHRaveVertexFactory(Verbosity());
 
 	if (!_vertex_finder) {
 		cerr << PHWHERE << endl;
@@ -261,7 +261,7 @@ int PHG4TrackKalmanFitter::InitRun(PHCompositeNode *topNode) {
 	}
 
 	if (_do_eval) {
-		if(verbosity >= 1)
+		if(Verbosity() >= 1)
 			cout << PHWHERE << " Openning file: " << _eval_outname << endl;
 		PHTFileServer::get().open(_eval_outname, "RECREATE");
 		init_eval_tree();
@@ -278,7 +278,7 @@ int PHG4TrackKalmanFitter::InitRun(PHCompositeNode *topNode) {
 int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 	_event++;
 
-	if(verbosity > 1)
+	if(Verbosity() > 1)
 		std::cout << PHWHERE << "Events processed: " << _event << std::endl;
 //	if (_event % 1000 == 0)
 //		cout << PHWHERE << "Events processed: " << _event << endl;
@@ -338,7 +338,7 @@ int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 		try {
 			_vertex_finder->findVertices(&rave_vertices, rf_gf_tracks);
 		} catch (...) {
-			if(verbosity > 1)
+			if(Verbosity() > 1)
 				std::cout << PHWHERE << "GFRaveVertexFactory::findVertices failed!";
 		}
 	}
@@ -520,7 +520,7 @@ int PHG4TrackKalmanFitter::process_event(PHCompositeNode *topNode) {
 int PHG4TrackKalmanFitter::End(PHCompositeNode *topNode) {
 
 	if (_do_eval) {
-		if(verbosity >= 1)
+		if(Verbosity() >= 1)
 			cout << PHWHERE << " Writing to file: " << _eval_outname << endl;
 		PHTFileServer::get().cd(_eval_outname);
 		_eval_tree->Write();
@@ -689,7 +689,7 @@ int PHG4TrackKalmanFitter::CreateNodes(PHCompositeNode *topNode) {
 	if (!tb_node) {
 		tb_node = new PHCompositeNode("SVTX");
 		dstNode->addNode(tb_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "SVTX node added" << endl;
 	}
 
@@ -698,7 +698,7 @@ int PHG4TrackKalmanFitter::CreateNodes(PHCompositeNode *topNode) {
 		PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(
 				_trackmap_refit, "SvtxTrackMapRefit", "PHObject");
 		tb_node->addNode(tracks_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "Svtx/SvtxTrackMapRefit node added" << endl;
 	}
 
@@ -708,7 +708,7 @@ int PHG4TrackKalmanFitter::CreateNodes(PHCompositeNode *topNode) {
 				new PHIODataNode<PHObject>(_primary_trackmap, "PrimaryTrackMap",
 						"PHObject");
 		tb_node->addNode(primary_tracks_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "Svtx/PrimaryTrackMap node added" << endl;
 	}
 
@@ -717,14 +717,14 @@ int PHG4TrackKalmanFitter::CreateNodes(PHCompositeNode *topNode) {
 		PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(
 				_vertexmap_refit, "SvtxVertexMapRefit", "PHObject");
 		tb_node->addNode(vertexes_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "Svtx/SvtxVertexMapRefit node added" << endl;
 	} else if (!findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap")) {
 		_vertexmap = new SvtxVertexMap_v1;
 		PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(
 				_vertexmap, "SvtxVertexMap", "PHObject");
 		tb_node->addNode(vertexes_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "Svtx/SvtxVertexMap node added" << endl;
 	}
 
@@ -846,7 +846,7 @@ std::shared_ptr<PHGenFit::Track> PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNo
 			topNode, "G4CELL_MAPS");
 
 	if (!cells_svtx and !cells_intt and !cells_maps) {
-		if (verbosity >= 0) {
+		if (Verbosity() >= 0) {
 			LogError("No PHG4CellContainer found!");
 		}
 		return nullptr;
@@ -880,7 +880,7 @@ std::shared_ptr<PHGenFit::Track> PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNo
 	 * if fit track as a primary track
 	 */
 
-//	if(invertex and verbosity >= 2)
+//	if(invertex and Verbosity() >= 2)
 //	{
 //		LogDebug(invertex->size_tracks());
 //		LogDebug(invertex->get_chisq());
@@ -954,7 +954,7 @@ std::shared_ptr<PHGenFit::Track> PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNo
 			PHGenFit::Measurement* meas = new PHGenFit::SpacepointMeasurement(
 					pos, cov);
 			measurements.push_back(meas);
-//			if(verbosity >= 2)
+//			if(Verbosity() >= 2)
 //			{
 //				meas->getMeasurement()->Print();
 //			}
@@ -1008,7 +1008,7 @@ std::shared_ptr<PHGenFit::Track> PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNo
 					PHG4HitContainer>(topNode, "G4HIT_MAPS");
 
 			if (!phg4hits_svtx and !phg4hits_intt and !phg4hits_maps) {
-				if (verbosity >= 0) {
+				if (Verbosity() >= 0) {
 					LogError("No PHG4HitContainer found!");
 				}
 				continue;
@@ -1021,7 +1021,7 @@ std::shared_ptr<PHGenFit::Track> PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNo
 			if(!cell && cells_intt) cell = cells_intt->findCell(svtxhit->get_cellid());
 			if(!cell && cells_maps) cell = cells_maps->findCell(svtxhit->get_cellid());
 			if(!cell){
-				if(verbosity>=0)
+				if(Verbosity()>=0)
 					LogError("!cell");
 				continue;
 			}
@@ -1032,7 +1032,7 @@ std::shared_ptr<PHGenFit::Track> PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNo
 			if(!phg4hit and phg4hits_maps) phg4hit = phg4hits_maps->findHit(cell->get_g4hits().first->first);
 
 			if (!phg4hit) {
-				if (verbosity >= 0)
+				if (Verbosity() >= 0)
 					LogError("!phg4hit");
 				continue;
 			}
@@ -1082,7 +1082,7 @@ std::shared_ptr<PHGenFit::Track> PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNo
 		if(cells_intt) cell_intt = cells_intt->findCell(svtxhit->get_cellid());
 		if(cells_maps) cell_maps = cells_maps->findCell(svtxhit->get_cellid());
 		if(!(cell_svtx or cell_intt or cell_maps)){
-			if(verbosity>=0)
+			if(Verbosity()>=0)
 				LogError("!(cell_svtx or cell_intt or cell_maps)");
 			continue;
 		}
@@ -1192,7 +1192,7 @@ std::shared_ptr<PHGenFit::Track> PHG4TrackKalmanFitter::ReFitTrack(PHCompositeNo
 	 *  ret code 0 means 0 error or good status
 	 */
 	if (_fitter->processTrack(track.get(), false) != 0) {
-		if (verbosity >= 1)
+		if (Verbosity() >= 1)
 			LogWarning("Track fitting failed");
 		//delete track;
 		return NULL;
@@ -1220,7 +1220,7 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 	if(_use_truth_vertex) {
 		PHG4VtxPoint* first_point = _truth_container->GetPrimaryVtx(_truth_container->GetPrimaryVertexIndex());
 		vertex_position.SetXYZ(first_point->get_x(), first_point->get_y(), first_point->get_z());
-		if(verbosity > 1) {
+		if(Verbosity() > 1) {
 			cout<<"Using: truth vertex: {" << vertex_position.X() << ", " << vertex_position.Y() << ", " << vertex_position.Z() << "} " <<endl;
 		}
 	} else if (vertex) {
@@ -1240,7 +1240,7 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 		gf_state_beam_line_ca = std::shared_ptr<genfit::MeasuredStateOnPlane>(phgf_track->extrapolateToLine(vertex_position,
 				TVector3(0., 0., 1.)));
 	} catch (...) {
-		if (verbosity >= 2)
+		if (Verbosity() >= 2)
 			LogWarning("extrapolateToLine failed!");
 	}
 	if(!gf_state_beam_line_ca) return NULL;
@@ -1274,7 +1274,7 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 		gf_state_vertex_ca = std::shared_ptr < genfit::MeasuredStateOnPlane
 				> (phgf_track->extrapolateToPoint(vertex_position));
 	} catch (...) {
-		if (verbosity >= 2)
+		if (Verbosity() >= 2)
 			LogWarning("extrapolateToPoint failed!");
 	}
 	if (!gf_state_vertex_ca) {
@@ -1433,7 +1433,7 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 #endif
 
 	} catch (...) {
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			LogWarning("DCA calculationfailed!");
 	}
 
@@ -1484,11 +1484,11 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 //					> (phgf_track->extrapolateToCylinder(radius,
 //							TVector3(0, 0, 0), TVector3(0, 0, 1), 0));
 //		} catch (...) {
-//			if (verbosity >= 2)
+//			if (Verbosity() >= 2)
 //				LogWarning("Exrapolation failed!");
 //		}
 //		if (!gf_state) {
-//			if (verbosity > 1)
+//			if (Verbosity() > 1)
 //				LogWarning("Exrapolation failed!");
 //			continue;
 //		}
@@ -1532,14 +1532,14 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 		genfit::TrackPoint *trpoint = gftrack->getPointWithMeasurementAndFitterInfo(id, gftrack->getCardinalRep());
 
 		if(!trpoint) {
-			if (verbosity > 1)
+			if (Verbosity() > 1)
 				LogWarning("!trpoint");
 			continue;
 		}
 
 		genfit::KalmanFitterInfo* kfi = static_cast<genfit::KalmanFitterInfo*>( trpoint->getFitterInfo(rep) );
 		if(!kfi) {
-			if (verbosity > 1)
+			if (Verbosity() > 1)
 				LogWarning("!kfi");
 			continue;
 		}
@@ -1550,11 +1550,11 @@ std::shared_ptr<SvtxTrack> PHG4TrackKalmanFitter::MakeSvtxTrack(const SvtxTrack*
 			const genfit::MeasuredStateOnPlane* temp_state = &(kfi->getFittedState(true));
 			gf_state = std::shared_ptr <genfit::MeasuredStateOnPlane> (new genfit::MeasuredStateOnPlane(*temp_state));
 		} catch (...) {
-			if (verbosity > 1)
+			if (Verbosity() > 1)
 				LogWarning("Exrapolation failed!");
 		}
 		if (!gf_state) {
-			if (verbosity > 1)
+			if (Verbosity() > 1)
 				LogWarning("Exrapolation failed!");
 			continue;
 		}
@@ -1648,7 +1648,7 @@ bool PHG4TrackKalmanFitter::FillSvtxVertexMap(
 			}
 		}
 
-//		if (verbosity >= 2) {
+//		if (Verbosity() >= 2) {
 //			cout << PHWHERE << endl;
 //			svtx_vtx->Print();
 //			_vertexmap_refit->Print();
@@ -1665,18 +1665,18 @@ bool PHG4TrackKalmanFitter::FillSvtxVertexMap(
 //		TMatrixF& pos_out, TMatrixF& cov_out) const {
 //
 //	if(pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3) {
-//		if(verbosity > 0) LogWarning("pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3");
+//		if(Verbosity() > 0) LogWarning("pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3");
 //		return false;
 //	}
 //
 //	if(cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3) {
-//		if(verbosity > 0) LogWarning("cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3");
+//		if(Verbosity() > 0) LogWarning("cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3");
 //		return false;
 //	}
 //
 //	TVector3 up = TVector3(0., 0., 1.).Cross(n);
 //	if(up.Mag() < 0.00001){
-//		if(verbosity > 0) LogWarning("n is parallel to z");
+//		if(Verbosity() > 0) LogWarning("n is parallel to z");
 //		return false;
 //	}
 //
@@ -1737,7 +1737,7 @@ bool PHG4TrackKalmanFitter::FillSvtxVertexMap(
 //		R_inv_T.Transpose(R_inv);
 //
 //	} catch (...) {
-//		if (verbosity > 0)
+//		if (Verbosity() > 0)
 //			LogWarning("Can't get rotation matrix");
 //
 //		return false;
@@ -1757,12 +1757,12 @@ bool PHG4TrackKalmanFitter::pos_cov_uvn_to_rz(const TVector3& u, const TVector3&
 		TMatrixF& pos_out, TMatrixF& cov_out) const {
 
 	if(pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3) {
-		if(verbosity > 0) LogWarning("pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3");
+		if(Verbosity() > 0) LogWarning("pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3");
 		return false;
 	}
 
 	if(cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3) {
-		if(verbosity > 0) LogWarning("cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3");
+		if(Verbosity() > 0) LogWarning("cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3");
 		return false;
 	}
 
@@ -1770,7 +1770,7 @@ bool PHG4TrackKalmanFitter::pos_cov_uvn_to_rz(const TVector3& u, const TVector3&
 	TVector3 up_uvn = TVector3(0., 0., 1.).Cross(Z_uvn); // n_uvn X Z_uvn
 
 	if(up_uvn.Mag() < 0.00001){
-		if(verbosity > 0) LogWarning("n is parallel to z");
+		if(Verbosity() > 0) LogWarning("n is parallel to z");
 		return false;
 	}
 
@@ -1794,7 +1794,7 @@ bool PHG4TrackKalmanFitter::pos_cov_uvn_to_rz(const TVector3& u, const TVector3&
 
 		R_T.Transpose(R);
 	} catch (...) {
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			LogWarning("Can't get rotation matrix");
 
 		return false;
@@ -1825,19 +1825,19 @@ bool PHG4TrackKalmanFitter::get_vertex_error_uvn(const TVector3& u,
 //	cout<<"R.Determinant() = "<<R.Determinant()<<"\n";
 
 	if(!(abs(R.Determinant()-1)<0.01)) {
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			LogWarning("!(abs(R.Determinant()-1)<0.0001)");
 		return false;
 	}
 
 	if (R.GetNcols() != 3 || R.GetNrows() != 3) {
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			LogWarning("R.GetNcols() != 3 || R.GetNrows() != 3");
 		return false;
 	}
 
 	if (cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3) {
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			LogWarning("cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3");
 		return false;
 	}
@@ -1859,19 +1859,19 @@ bool PHG4TrackKalmanFitter::pos_cov_XYZ_to_RZ(
 		TMatrixF& pos_out, TMatrixF& cov_out) const {
 
 	if(pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3) {
-		if(verbosity > 0) LogWarning("pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3");
+		if(Verbosity() > 0) LogWarning("pos_in.GetNcols() != 1 || pos_in.GetNrows() != 3");
 		return false;
 	}
 
 	if(cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3) {
-		if(verbosity > 0) LogWarning("cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3");
+		if(Verbosity() > 0) LogWarning("cov_in.GetNcols() != 3 || cov_in.GetNrows() != 3");
 		return false;
 	}
 
 	TVector3 r = n.Cross(TVector3(0.,0.,1.));
 
 	if(r.Mag() < 0.00001){
-		if(verbosity > 0) LogWarning("n is parallel to z");
+		if(Verbosity() > 0) LogWarning("n is parallel to z");
 		return false;
 	}
 
@@ -1895,7 +1895,7 @@ bool PHG4TrackKalmanFitter::pos_cov_XYZ_to_RZ(
 
 		R_T.Transpose(R);
 	} catch (...) {
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			LogWarning("Can't get rotation matrix");
 
 		return false;
@@ -1931,7 +1931,7 @@ TMatrixF PHG4TrackKalmanFitter::get_rotation_matrix(const TVector3 x,
 			abs(xu*zu) < max_diff and
 			abs(yu*zu) < max_diff
 			)) {
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			LogWarning("input frame error!");
 		return R;
 	}
@@ -1945,7 +1945,7 @@ TMatrixF PHG4TrackKalmanFitter::get_rotation_matrix(const TVector3 x,
 			abs(xpu*zpu) < max_diff and
 			abs(ypu*zpu) < max_diff
 			)) {
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			LogWarning("output frame error!");
 		return R;
 	}
@@ -2037,7 +2037,7 @@ TMatrixF PHG4TrackKalmanFitter::get_rotation_matrix(const TVector3 x,
 //		cout<<"R.Determinant() = "<<R.Determinant()<<"\n";
 
 	} catch (...) {
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			LogWarning("Can't get rotation matrix");
 
 		return R;

--- a/simulation/g4simulation/g4hough/PHG4TruthPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4TruthPatRec.C
@@ -69,7 +69,7 @@ int PHG4TruthPatRec::process_event(PHCompositeNode* topNode) {
 			topNode, "G4HIT_MAPS");
 
 	if (!phg4hits_svtx and phg4hits_intt and !phg4hits_maps) {
-		if (verbosity >= 0) {
+		if (Verbosity() >= 0) {
 			LogError("No PHG4HitContainer found!");
 		}
 		return Fun4AllReturnCodes::ABORTRUN;
@@ -93,7 +93,7 @@ int PHG4TruthPatRec::process_event(PHCompositeNode* topNode) {
 			topNode, "G4CELL_MAPS");
 
 	if (!cells_svtx and !cells_intt and !cells_maps) {
-		if (verbosity >= 0) {
+		if (Verbosity() >= 0) {
 			LogError("No PHG4CellContainer found!");
 		}
 		return Fun4AllReturnCodes::ABORTRUN;
@@ -113,7 +113,7 @@ int PHG4TruthPatRec::process_event(PHCompositeNode* topNode) {
 		if(!cell and cells_maps) cell = cells_maps->findCell(svtxhit->get_cellid());
 
 		if(!cell){
-			if(verbosity >= 1) {
+			if(Verbosity() >= 1) {
 				LogError("!cell");
 			}
 			continue;
@@ -130,7 +130,7 @@ int PHG4TruthPatRec::process_event(PHCompositeNode* topNode) {
 			if(!phg4hit and phg4hits_maps) phg4hit = phg4hits_maps->findHit(hits_it->first);
 
 			if(!phg4hit){
-				if(verbosity >= 1) {
+				if(Verbosity() >= 1) {
 					LogError("!phg4hit");
 				}
 				continue;
@@ -169,7 +169,7 @@ int PHG4TruthPatRec::process_event(PHCompositeNode* topNode) {
 		}
 	}
 
-	if (verbosity >= 2) {
+	if (Verbosity() >= 2) {
 		for (SvtxTrackMap::Iter iter = _trackmap->begin();
 				iter != _trackmap->end(); ++iter) {
 			SvtxTrack* svtx_track = iter->second;
@@ -250,7 +250,7 @@ int PHG4TruthPatRec::CreateNodes(PHCompositeNode* topNode) {
 	if (!tb_node) {
 		tb_node = new PHCompositeNode("SVTX");
 		dstNode->addNode(tb_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "SVTX node added" << endl;
 	}
 
@@ -258,7 +258,7 @@ int PHG4TruthPatRec::CreateNodes(PHCompositeNode* topNode) {
 	PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(_trackmap,
 			"SvtxTrackMap", "PHObject");
 	tb_node->addNode(tracks_node);
-	if (verbosity > 0)
+	if (Verbosity() > 0)
 		cout << "Svtx/SvtxTrackMap node added" << endl;
 
 	return Fun4AllReturnCodes::EVENT_OK;

--- a/simulation/g4simulation/g4hough/PHRaveVertexing.C
+++ b/simulation/g4simulation/g4hough/PHRaveVertexing.C
@@ -131,14 +131,14 @@ int PHRaveVertexing::InitRun(PHCompositeNode *topNode) {
 	_fitter = PHGenFit::Fitter::getInstance(tgeo_manager,
 	    field, "DafRef",
 			"RKTrackRep", false);
-	_fitter->set_verbosity(verbosity);
+	_fitter->set_verbosity(Verbosity());
 
 	if (!_fitter) {
 		cerr << PHWHERE << endl;
 		return Fun4AllReturnCodes::ABORTRUN;
 	}
 
-	_vertex_finder = new genfit::GFRaveVertexFactory(verbosity);
+	_vertex_finder = new genfit::GFRaveVertexFactory(Verbosity());
 	_vertex_finder->setMethod(_vertexing_method.data());
 	//_vertex_finder->setBeamspot();
 
@@ -164,7 +164,7 @@ int PHRaveVertexing::InitRun(PHCompositeNode *topNode) {
 int PHRaveVertexing::process_event(PHCompositeNode *topNode) {
 	_event++;
 
-	if(verbosity > 1)
+	if(Verbosity() > 1)
 		std::cout << PHWHERE << "Events processed: " << _event << std::endl;
 
 	GetNodes(topNode);
@@ -172,7 +172,7 @@ int PHRaveVertexing::process_event(PHCompositeNode *topNode) {
 	//! stands for Refit_GenFit_Tracks
 	GenFitTrackMap gf_track_map;
 	vector<genfit::Track*> gf_tracks;
-	if(verbosity > 1) _t_translate->restart();
+	if(Verbosity() > 1) _t_translate->restart();
 	for (SvtxTrackMap::Iter iter = _trackmap->begin(); iter != _trackmap->end();
 			++iter) {
 		SvtxTrack* svtx_track = iter->second;
@@ -189,24 +189,24 @@ int PHRaveVertexing::process_event(PHCompositeNode *topNode) {
 		gf_track_map.insert({genfit_track, iter->first});
 		gf_tracks.push_back(const_cast<genfit::Track*> (genfit_track));
 	}
-	if(verbosity > 1) _t_translate->stop();
+	if(Verbosity() > 1) _t_translate->stop();
 
-	if(verbosity > 1) _t_rave->restart();
+	if(Verbosity() > 1) _t_rave->restart();
 	vector<genfit::GFRaveVertex*> rave_vertices;
 	if (gf_tracks.size() >= 2) {
 		try {
 			_vertex_finder->findVertices(&rave_vertices, gf_tracks);
 		} catch (...) {
-			if(verbosity > 1)
+			if(Verbosity() > 1)
 				std::cout << PHWHERE << "GFRaveVertexFactory::findVertices failed!";
 		}
 	}
-	if(verbosity > 1) _t_rave->stop();
+	if(Verbosity() > 1) _t_rave->stop();
 	FillSvtxVertexMap(rave_vertices, gf_track_map);
 
 	for(auto iter : gf_track_map) delete iter.first;
 
-	if(verbosity > 1) {
+	if(Verbosity() > 1) {
 		std::cout << "=============== Timers: ===============" << std::endl;
 		std::cout << "Event: " << _event << std::endl;
 		std::cout << "Translate:                "<<_t_translate->get_accumulated_time()/1000. << " sec" <<std::endl;
@@ -250,7 +250,7 @@ int PHRaveVertexing::CreateNodes(PHCompositeNode *topNode) {
 	if (!tb_node) {
 		tb_node = new PHCompositeNode("SVTX");
 		dstNode->addNode(tb_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "SVTX node added" << endl;
 	}
 
@@ -259,14 +259,14 @@ int PHRaveVertexing::CreateNodes(PHCompositeNode *topNode) {
 		PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(
 				_vertexmap_refit, _svtxvertexmaprefit_node_name.c_str(), "PHObject");
 		tb_node->addNode(vertexes_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "Svtx/SvtxVertexMapRefit node added" << endl;
 	} else if (!findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap")) {
 		_vertexmap = new SvtxVertexMap_v1;
 		PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(
 				_vertexmap, "SvtxVertexMap", "PHObject");
 		tb_node->addNode(vertexes_node);
-		if (verbosity > 0)
+		if (Verbosity() > 0)
 			cout << "Svtx/SvtxVertexMap node added" << endl;
 	}
 

--- a/simulation/g4simulation/g4jets/JetReco.C
+++ b/simulation/g4simulation/g4jets/JetReco.C
@@ -27,9 +27,8 @@ JetReco::JetReco(const string &name)
     _algos(),
     _algonode(),
     _inputnode(),
-    _outputs() {
-  verbosity = 0;
-}
+    _outputs() 
+{}
 
 JetReco::~JetReco() {
   for (unsigned int i=0; i<_inputs.size(); ++i) delete _inputs[i];
@@ -45,7 +44,7 @@ int JetReco::Init(PHCompositeNode *topNode) {
 
 int JetReco::InitRun(PHCompositeNode *topNode) {
   
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "========================== JetReco::InitRun() =============================" << endl;
     cout << " Input Selections:" << endl;
     for (unsigned int i=0; i<_inputs.size(); ++i) _inputs[i]->identify();
@@ -59,7 +58,7 @@ int JetReco::InitRun(PHCompositeNode *topNode) {
 
 int JetReco::process_event(PHCompositeNode *topNode) {
   
-  if (verbosity > 1) cout << "JetReco::process_event -- entered" << endl;
+  if (Verbosity() > 1) cout << "JetReco::process_event -- entered" << endl;
 
   //---------------------------------
   // Get Objects off of the Node Tree
@@ -88,7 +87,7 @@ int JetReco::process_event(PHCompositeNode *topNode) {
   for (unsigned int i=0;i<inputs.size();++i) delete inputs[i];
   inputs.clear();
   
-  if (verbosity > 1) cout << "JetReco::process_event -- exited" << endl;
+  if (Verbosity() > 1) cout << "JetReco::process_event -- exited" << endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -281,7 +281,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
         {
           ++trackid;
 
-          if (verbosity > 1) (*fiter)->print();
+          if (Verbosity() > 1) (*fiter)->print();
 
           PHG4Particle *particle = new PHG4Particlev1();
           particle->set_pid((*fiter)->pdg_id());
@@ -300,7 +300,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
 
   }  // For pile-up simulation: loop end for PHHepMC event map
 
-  if (verbosity > 0) ineve->identify();
+  if (Verbosity() > 0) ineve->identify();
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4main/PHG4HeadReco.cc
+++ b/simulation/g4simulation/g4main/PHG4HeadReco.cc
@@ -72,7 +72,7 @@ PHG4HeadReco::process_event(PHCompositeNode *topNode)
 	}
     }
   evtheader->set_EvtSequence(evtseq);
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       evtheader->identify();
     }

--- a/simulation/g4simulation/g4main/PHG4InputFilter.cc
+++ b/simulation/g4simulation/g4main/PHG4InputFilter.cc
@@ -28,7 +28,7 @@ PHG4InputFilter::process_event(PHCompositeNode *topNode)
     }
   pair<multimap<int, PHG4Particle *>::iterator, multimap<int, PHG4Particle *>::iterator > beginend =   ineve->GetParticles_Modify();
   multimap<int, PHG4Particle *>::iterator particleiter;
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       cout << "PHG4InputFilter before filter" << endl;
       ineve->identify();
@@ -86,7 +86,7 @@ PHG4InputFilter::process_event(PHCompositeNode *topNode)
         }
       ++particleiter;
     }
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       cout << "PHG4InputFilter: after filter" << endl;
       ineve->identify();

--- a/simulation/g4simulation/g4main/PHG4ParticleGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGenerator.cc
@@ -95,7 +95,7 @@ PHG4ParticleGenerator::process_event(PHCompositeNode *topNode)
       (*iter)->set_pz(particle->get_pz());
       ineve->AddParticle(vtxindex, particle);
     }
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     ineve->identify();
   }

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
@@ -227,7 +227,7 @@ int PHG4ParticleGeneratorBase::ReuseExistingVertex(PHCompositeNode *topNode)
 
       set_vtx(vtx.x(), vtx.y(), vtx.z());
 
-      if (verbosity > 0) {
+      if (Verbosity() > 0) {
         cout <<"PHG4ParticleGeneratorBase::ReuseExistingVertex - reuse PHHepMCGenEventMap vertex "
             << vtx.x()<<", "<< vtx.y()<<", "<< vtx.z()<<" cm. Source event:"
             <<endl;
@@ -254,7 +254,7 @@ int PHG4ParticleGeneratorBase::ReuseExistingVertex(PHCompositeNode *topNode)
       cout << PHWHERE << "::Error - PHG4SimpleEventGenerator expects an existing vertex in PHG4InEvent, but none exists" << endl;
       exit(1);
     }
-    if (verbosity > 0)
+    if (Verbosity() > 0)
     {
       cout << PHWHERE << "::Info - use this primary vertex from PHG4InEvent:" << endl;
       vtx->identify();
@@ -283,7 +283,7 @@ int PHG4ParticleGeneratorBase::ReuseExistingVertex(PHCompositeNode *topNode)
       exit(1);
     }
 
-    if (verbosity > 0)
+    if (Verbosity() > 0)
     {
       cout << PHWHERE << "::Info - use this primary vertex from PHG4TruthInfoContainer:" << endl;
       vtx->identify();

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
@@ -184,7 +184,7 @@ PHG4ParticleGeneratorD0::process_event(PHCompositeNode *topNode)
   double gamma = vd0.Gamma();
   double lifetime = gsl_ran_exponential(RandomGenerator,410.1e-03)* 1.0e-12; // life time in seconds
   double lifepath = lifetime*gamma*beta*cc;  // path in cm
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       cout << "D0 px,py,pz: " << vd0.Px() << " " << vd0.Py() << " " << vd0.Pz() << " " << beta << " " << gamma << endl;
       cout << "   ctau = " << ctau << " " << lifetime << " " << lifepath << " " << lifepath*1.0e+04 << endl;
@@ -195,7 +195,7 @@ PHG4ParticleGeneratorD0::process_event(PHCompositeNode *topNode)
   vtx_z = vtx_z + vd0.Pz()/vd0.P()*lifepath;
   t0 = lifetime;
   int vtxindex = ineve->AddVtx(vtx_x,vtx_y,vtx_z,t0);
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       cout << "  XY vertex: " << sqrt(vtx_x*vtx_x+vtx_y*vtx_y) << " " << sqrt(vtx_x*vtx_x+vtx_y*vtx_y)*1.0e+04 << endl;
     }
@@ -251,7 +251,7 @@ PHG4ParticleGeneratorD0::process_event(PHCompositeNode *topNode)
 
   // List what has been put into ineve for this event
 
-  if(verbosity > 0)
+  if(Verbosity() > 0)
     {  
       ineve->identify();
 

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -429,7 +429,7 @@ PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
     }
     // List what has been put into ineve for this event
 
-    if(verbosity > 0)
+    if(Verbosity() > 0)
       {  
       ineve->identify();
 

--- a/simulation/g4simulation/g4main/PHG4ParticleGun.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGun.cc
@@ -37,7 +37,7 @@ PHG4ParticleGun::process_event(PHCompositeNode *topNode)
       SetParticleId(particle,ineve);
       ineve->AddParticle(vtxindex, particle);
     }
-  if (verbosity > 0)
+  if (Verbosity() > 0)
     {
       ineve->identify();
     }

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -168,7 +168,7 @@ PHG4Reco::~PHG4Reco(void)
 //_________________________________________________________________
 int PHG4Reco::Init(PHCompositeNode *topNode)
 {
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     cout << "========================= PHG4Reco::Init() ================================" << endl;
   }
@@ -176,10 +176,10 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
   G4Seed(iseed);  // fixed seed handled in PHRandomSeed()
 
   // create GEANT run manager
-  if (verbosity > 1) cout << "PHG4Reco::Init - create run manager" << endl;
+  if (Verbosity() > 1) cout << "PHG4Reco::Init - create run manager" << endl;
 
   // redirect GEANT verbosity to nowhere
-//  if (verbosity < 1)
+//  if (Verbosity() < 1)
   if (0)
   {
     G4UImanager *uimanager = G4UImanager::GetUIpointer();
@@ -195,39 +195,39 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
   G4VModularPhysicsList *myphysicslist = nullptr;
   if (physicslist == "FTFP_BERT")
   {
-    myphysicslist = new FTFP_BERT(verbosity);
+    myphysicslist = new FTFP_BERT(Verbosity());
   }
   else if (physicslist == "QGSP_BERT")
   {
-    myphysicslist = new QGSP_BERT(verbosity);
+    myphysicslist = new QGSP_BERT(Verbosity());
   }
   else if (physicslist == "QGSP_BIC")
   {
-    myphysicslist = new QGSP_BIC(verbosity);
+    myphysicslist = new QGSP_BIC(Verbosity());
   }
   else if (physicslist == "QGSP_BIC_HP")
   {
     setenv("AllowForHeavyElements", "1", 1);
-    myphysicslist = new QGSP_BIC_HP(verbosity);
+    myphysicslist = new QGSP_BIC_HP(Verbosity());
   }
 #ifdef HAVE_LHEP
   else if (physicslist == "LHEP")
   {
-    myphysicslist = new LHEP(verbosity);
+    myphysicslist = new LHEP(Verbosity());
   }
 #endif
 #ifdef HAVE_FTFP_BERT_HP
   else if (physicslist == "FTFP_BERT_HP")
   {
     setenv("AllowForHeavyElements", "1", 1);
-    myphysicslist = new FTFP_BERT_HP(verbosity);
+    myphysicslist = new FTFP_BERT_HP(Verbosity());
   }
 #endif
 #ifdef HAVE_QGSP_BERT_HP
   else if (physicslist == "QGSP_BERT_HP")
   {
     setenv("AllowForHeavyElements", "1", 1);
-    myphysicslist = new QGSP_BERT_HP(verbosity);
+    myphysicslist = new QGSP_BERT_HP(Verbosity());
   }
 #endif
   else
@@ -262,7 +262,7 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
     reco->Init(topNode);
   }
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     cout << "===========================================================================" << endl;
   }
@@ -271,7 +271,7 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
 
 int PHG4Reco::InitField(PHCompositeNode *topNode)
 {
-  if (verbosity > 1) cout << "PHG4Reco::InitField - create magnetic field setup" << endl;
+  if (Verbosity() > 1) cout << "PHG4Reco::InitField - create magnetic field setup" << endl;
 
   unique_ptr<PHFieldConfig> default_field_cfg(nullptr);
 
@@ -284,7 +284,7 @@ int PHG4Reco::InitField(PHCompositeNode *topNode)
     default_field_cfg.reset(new PHFieldConfig_v2(0, 0, magfield * magfield_rescale));
   }
 
-  if (verbosity > 1) cout << "PHG4Reco::InitField - create magnetic field setup" << endl;
+  if (Verbosity() > 1) cout << "PHG4Reco::InitField - create magnetic field setup" << endl;
 
   PHField * phfield = PHFieldUtility::GetFieldMapNode(default_field_cfg.get(), topNode, Verbosity()+1);
   assert(phfield);
@@ -310,7 +310,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::EVENT_OK;
   }
   InitRunDone = 1;
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     cout << "========================= PHG4Reco::InitRun() ================================" << endl;
   }
@@ -332,9 +332,9 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   }
 
   // create phenix detector, add subsystems, and register to GEANT
-  if (verbosity > 1) cout << "PHG4Reco::Init - create detector" << endl;
+  if (Verbosity() > 1) cout << "PHG4Reco::Init - create detector" << endl;
   detector_ = new PHG4PhenixDetector();
-  detector_->Verbosity(verbosity);
+  detector_->Verbosity(Verbosity());
   detector_->SetWorldSizeX(WorldSize[0] * cm);
   detector_->SetWorldSizeY(WorldSize[1] * cm);
   detector_->SetWorldSizeZ(WorldSize[2] * cm);
@@ -384,7 +384,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
     PHG4SteppingAction *action = g4sub->GetSteppingAction();
     if (action)
     {
-      if (verbosity > 1)
+      if (Verbosity() > 1)
       {
         cout << "Adding steppingaction for " << g4sub->Name() << endl;
       }
@@ -430,7 +430,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   // G4Scintillation* theScintillationProcess      = new G4Scintillation("Scintillation");
 
   /*
-    if (verbosity > 0)
+    if (Verbosity() > 0)
     {
     // This segfaults
     theCerenkovProcess->DumpPhysicsTable();
@@ -489,7 +489,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   G4HadronicProcessStore::Instance()->SetVerbose(0);
   G4LossTableManager::Instance()->SetVerbose(1);
 
-  if ((verbosity < 1) && (uisession_))
+  if ((Verbosity() < 1) && (uisession_))
   {
     uisession_->Verbosity(1);  // let messages after setup come through
   }
@@ -509,7 +509,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
     PHGeomUtility::RemoveGeometryFile(filename);
   }
 
-  if (verbosity > 0)
+  if (Verbosity() > 0)
   {
     cout << "===========================================================================" << endl;
   }
@@ -972,7 +972,7 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   LiF->AddElement(G4Element::GetElement("Li"), natoms = 1);
   LiF->AddElement(G4Element::GetElement("F"), natoms = 1);
 
-  if (verbosity > 1)
+  if (Verbosity() > 1)
   {
     cout << "g4_lif: " << g4_lif << endl;
     cout << "LiF: " << LiF << endl;
@@ -1326,7 +1326,7 @@ PHG4Reco::getSubsystem(const string &name)
   {
     if (subsys->Name() == name)
     {
-      if (verbosity > 0)
+      if (Verbosity() > 0)
       {
         cout << "Found Subsystem " << name << endl;
       }

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
@@ -192,7 +192,7 @@ int PHG4SimpleEventGenerator::InitRun(PHCompositeNode *topNode) {
     dstNode->addNode(newNode);
   }
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "================ PHG4SimpleEventGenerator::InitRun() ======================" << endl;
     cout << " Random seed = " << get_seed() << endl;
     cout << " Particles:" << endl;
@@ -243,7 +243,7 @@ int PHG4SimpleEventGenerator::InitRun(PHCompositeNode *topNode) {
 
 int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "====================== PHG4SimpleEventGenerator::process_event() =====================" << endl;
     cout <<"PHG4SimpleEventGenerator::process_event - reuse_existing_vertex = "<<reuse_existing_vertex<<endl;
   }
@@ -263,7 +263,7 @@ int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
   vtx_y += _vertex_offset_y;
   vtx_z += _vertex_offset_z;
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
   cout <<"PHG4SimpleEventGenerator::process_event - vertex center"<<reuse_existing_vertex
       << vtx_x<<", "<< vtx_y<<", "<< vtx_z<<" cm"
       <<endl;
@@ -333,7 +333,7 @@ int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode) {
     }
   }
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     _ineve->identify();
     cout << "======================================================================================" << endl;
   } 

--- a/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.cc
@@ -187,7 +187,6 @@ int PHG4TPCElectronDrift::InitRun(PHCompositeNode *topNode)
 
 int PHG4TPCElectronDrift::process_event(PHCompositeNode *topNode)
 {
-  //int verbosity = 101;
 
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hit)
@@ -209,7 +208,7 @@ int PHG4TPCElectronDrift::process_event(PHCompositeNode *topNode)
     }
     double eion = hiter->second->get_eion();   
     unsigned int n_electrons = gsl_ran_poisson(RandomGenerator,eion*electrons_per_gev);
-    if(verbosity > 100) 
+    if(Verbosity() > 100) 
       cout << "  new hit with t0, " <<  t0 << " g4hitid " << hiter->first 
 	   << " eion " << eion << " n_electrons " << n_electrons 
 	   << " entry z " << hiter->second->get_z(0) << " exit z " << hiter->second->get_z(1) << " avg z" << (hiter->second->get_z(0) + hiter->second->get_z(1))/2.0 
@@ -235,7 +234,7 @@ int PHG4TPCElectronDrift::process_event(PHCompositeNode *topNode)
     double t_start = hiter->second->get_t(0) + dt/2.;
 
 
-    if(verbosity > 100)
+    if(Verbosity() > 100)
       {
 	//double xin =  hiter->second->get_x(0);
 	//double xout =  hiter->second->get_x(1);
@@ -288,7 +287,7 @@ int PHG4TPCElectronDrift::process_event(PHCompositeNode *topNode)
 	    continue;
 	  }
 
-	if(verbosity > 1000)
+	if(Verbosity() > 1000)
 	  {
 	    cout << "electron " << i << " g4hitid " << hiter->first << endl; 
 	    cout << "radstart " << radstart  << " x_start: " << x_start
@@ -305,7 +304,7 @@ int PHG4TPCElectronDrift::process_event(PHCompositeNode *topNode)
 		   << " z_final " << z_final << " t_final " << t_final << " zdiff " << z_final - z_start << endl; 
 	  }
 
-	if(verbosity > 0)
+	if(Verbosity() > 0)
 	  nt->Fill(ihit,t_start,t_final,t_sigma,rad_final,z_start,z_final);    
 
 	// this fills the cells and updates them on the node tree for this drifted electron hitting the GEM stack
@@ -318,7 +317,7 @@ int PHG4TPCElectronDrift::process_event(PHCompositeNode *topNode)
     ihit++;
   }
 
-  if (verbosity > 1)
+  if (Verbosity() > 1)
     {
       cout << endl << " loop over cells for these hits for layer 47 " << endl;
       {

--- a/simulation/g4simulation/g4tpc/PHG4TPCPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCPadPlaneReadout.cc
@@ -108,7 +108,6 @@ void PHG4TPCPadPlaneReadout::MapToPadPlane(PHG4CellContainer *g4cells, const dou
   // The x_gem and y_gem values have already been randomized within the transverse drift diffusion width 
   // The z_gem value already reflects the drift time of the primary electron from the production point, and is randomized within the longitudinal diffusion witdth
 
-  //int verbosity = 101;
 
   double phi = atan2(y_gem,x_gem);
  if (phi > +M_PI) phi -= 2 * M_PI;
@@ -162,7 +161,7 @@ void PHG4TPCPadPlaneReadout::MapToPadPlane(PHG4CellContainer *g4cells, const dou
   // Distribute the charge between the pads in phi
   //====================================
 
-  if(verbosity > 200)
+  if(Verbosity() > 200)
     cout << "  populate phi bins for " 
 	 << " layernum " << layernum 
 	 << " phi " << phi 
@@ -189,7 +188,7 @@ void PHG4TPCPadPlaneReadout::MapToPadPlane(PHG4CellContainer *g4cells, const dou
   
   // Distribute the charge between the pads in z
   //====================================
-  if(verbosity > 100 && layernum == 47)
+  if(Verbosity() > 100 && layernum == 47)
     cout << "  populate z bins for layernum " << layernum 
 	 << " with z_gem " << z_gem << " sigmaL[0] " << sigmaL[0] << " sigmaL[1] " << sigmaL[1] << endl;
 
@@ -239,7 +238,7 @@ void PHG4TPCPadPlaneReadout::MapToPadPlane(PHG4CellContainer *g4cells, const dou
 	  phi_integral += phicenter*neffelectrons;
 	  z_integral += zcenter*neffelectrons;
 	  weight += neffelectrons;
-	  if(verbosity > 100 && layernum == 47)
+	  if(Verbosity() > 100 && layernum == 47)
 	    cout << "   zbin_num " << zbin_num << " zcenter " << zcenter << " pad_num " << pad_num << " phicenter " << phicenter 
 		 << " neffelectrons " << neffelectrons << " neffelectrons_threshold " << neffelectrons_threshold << endl; 
 
@@ -253,15 +252,15 @@ void PHG4TPCPadPlaneReadout::MapToPadPlane(PHG4CellContainer *g4cells, const dou
 	    }
 	  cell->add_edep(neffelectrons);
 	  cell->add_edep(hiter->first, neffelectrons);  // associates g4hit with this edep
-	  //if(verbosity > 100 && layernum == 50)  cell->identify();
+	  //if(Verbosity() > 100 && layernum == 50)  cell->identify();
 	} // end of loop over adc Z bins
     } // end of loop over zigzag pads
 
   // Capture the input values at the gem stack and the quick clustering results, elecron-by-electron
-  if(verbosity > 0)
+  if(Verbosity() > 0)
     ntpad->Fill(layernum, phi, phi_integral/weight, z_gem, z_integral/weight);
   
-  if(verbosity > 100)
+  if(Verbosity() > 100)
     if( layernum == 47)
       {
 	cout << " hit " << hit << " quick centroid for this electron " << endl;
@@ -331,7 +330,7 @@ void PHG4TPCPadPlaneReadout::populate_zigzag_phibins(const unsigned int layernum
   fcharge->SetParameter(0, 1.0);
   fcharge->SetParameter(1, rphi);
   fcharge->SetParameter(2, cloud_sig_rp);
-  if(verbosity > 100)
+  if(Verbosity() > 100)
     if(LayerGeom->get_layer() == 47)
       {
 	cout << "     populate_zigzag_phibins for layer " << layernum << " with radius " << radius << " phi " << phi 
@@ -348,7 +347,7 @@ void PHG4TPCPadPlaneReadout::populate_zigzag_phibins(const unsigned int layernum
   int phibin_high = LayerGeom->get_phibin(philim_high);
   int npads = phibin_high - phibin_low;
 
-  if(verbosity > 100)
+  if(Verbosity() > 100)
     if(layernum == 47)
       cout << "           zigzags: phi " << phi << " philim_low " << philim_low << " phibin_low " << phibin_low 
 	   << " philim_high " << philim_high << " phibin_high " << phibin_high << " npads " << npads << endl;
@@ -373,7 +372,7 @@ void PHG4TPCPadPlaneReadout::populate_zigzag_phibins(const unsigned int layernum
       fpad[ipad]->SetParameter(0,pad_rphi/2.0);
       fpad[ipad]->SetParameter(1, rphi_pad_now);
 
-      if(verbosity > 100)
+      if(Verbosity() > 100)
 	if(layernum == 47)
 	  cout << " zigzags: make fpad for ipad " << ipad << " pad_now " << pad_now << " pad_rphi/2 " << pad_rphi/2.0 
 	       << " rphi_pad_now " << rphi_pad_now << endl;
@@ -427,7 +426,7 @@ void PHG4TPCPadPlaneReadout::populate_zbins( const double z,  const double cloud
   double zstepsize = LayerGeom->get_zstep();
   double zdisp = z - LayerGeom->get_zcenter(zbin);
 
-  if(verbosity > 100)
+  if(Verbosity() > 100)
     cout << "     input:  z " << z << " zbin " << zbin << " zstepsize " << zstepsize << " z center " << LayerGeom->get_zcenter(zbin) << " zdisp " << zdisp << endl;
 
   // Because of diffusion, hits can be shared across the membrane, so we allow all z bins
@@ -445,13 +444,13 @@ void PHG4TPCPadPlaneReadout::populate_zbins( const double z,  const double cloud
     zsect = 1;
   
   int n_zz = int(3 * (cloud_sig_zz[0] + cloud_sig_zz[1]) / (2.0 * zstepsize) + 1);  
-  if(verbosity > 100)  cout << " n_zz " << n_zz << " cloud_sigzz[0] " << cloud_sig_zz[0] << " cloud_sig_zz[1] " << cloud_sig_zz[1] << endl;
+  if(Verbosity() > 100)  cout << " n_zz " << n_zz << " cloud_sigzz[0] " << cloud_sig_zz[0] << " cloud_sig_zz[1] " << cloud_sig_zz[1] << endl;
   for (int iz = -n_zz; iz != n_zz + 1; ++iz)
     {
       int cur_z_bin = zbin + iz;
       if ((cur_z_bin < min_cell_zbin) || (cur_z_bin > max_cell_zbin)) continue;
 
-      if(verbosity > 100)
+      if(Verbosity() > 100)
 	cout << " iz " << iz  << " cur_z_bin " << cur_z_bin << " min_cell_zbin " << min_cell_zbin << " max_cell_zbin " << max_cell_zbin  << endl;
 
       double z_integral = 0.0;
@@ -474,7 +473,7 @@ void PHG4TPCPadPlaneReadout::populate_zbins( const double z,  const double cloud
 	  // 1/2 * the erf is the integral probability from the argument Z value to zero, so this is the integral probability between the Z limits
 	  double z_integral1 = 0.5 * (erf(zLim1) - erf(zLim2));
 	  
-	  if(verbosity > 100)
+	  if(Verbosity() > 100)
 	    if(LayerGeom->get_layer() == 47)
 	    cout << "   populate_zbins:  cur_z_bin " << cur_z_bin << "  center z " << LayerGeom->get_zcenter(cur_z_bin) 
 		 << " index1 " << index1 << "  zLim1 " << zLim1 << " zLim2 " << zLim2 << " z_integral1 " << z_integral1 << endl;
@@ -483,7 +482,7 @@ void PHG4TPCPadPlaneReadout::populate_zbins( const double z,  const double cloud
 	  zLim1 = 0.5 * M_SQRT2 * ( 0.5 * zstepsize - zdisp) * cloud_sig_zz_inv[index2];  
 	  double z_integral2 = 0.5 * (erf(zLim1) - erf(zLim2));
 	  
-	  if(verbosity > 100)
+	  if(Verbosity() > 100)
 	    if(LayerGeom->get_layer() == 47)
 	      cout << "   populate_zbins:  cur_z_bin " << cur_z_bin << "  center z " << LayerGeom->get_zcenter(cur_z_bin) 
 		   << " index2 " << index2 << "  zLim1 " << zLim1 << " zLim2 " << zLim2 << " z_integral2 " << z_integral2 << endl;
@@ -513,7 +512,7 @@ void PHG4TPCPadPlaneReadout::populate_zbins( const double z,  const double cloud
 	  double zLim2 = 0.5 * M_SQRT2 * ((iz - 0.5) * zstepsize - zdisp) * cloud_sig_zz_inv[index];  
 	  z_integral = 0.5 * (erf(zLim1) - erf(zLim2));  
 
-	  if(verbosity > 100)
+	  if(Verbosity() > 100)
 	    if(LayerGeom->get_layer() == 47)
 	      cout << "   populate_zbins:  z_bin " << cur_z_bin << "  center z " << LayerGeom->get_zcenter(cur_z_bin) 
 		   << " index " << index << "  zLim1 " << zLim1 << " zLim2 " << zLim2 << " z_integral " << z_integral << endl;

--- a/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.C
+++ b/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.C
@@ -52,7 +52,7 @@ int GlobalVertexFastSimReco::InitRun(PHCompositeNode *topNode) {
   unsigned int seed = PHRandomSeed(); // fixed seed handled in PHRandomSeed()
   gsl_rng_set(RandomGenerator,seed);
   
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "=================== GlobalVertexFastSimReco::InitRun() ====================" << endl;
     cout << " x smearing: " << _x_smear << " cm " << endl;
     cout << " y smearing: " << _y_smear << " cm " << endl;
@@ -67,7 +67,7 @@ int GlobalVertexFastSimReco::InitRun(PHCompositeNode *topNode) {
 
 int GlobalVertexFastSimReco::process_event(PHCompositeNode *topNode) {
   
-  if (verbosity > 1) cout << "GlobalVertexFastSimReco::process_event -- entered" << endl;
+  if (Verbosity() > 1) cout << "GlobalVertexFastSimReco::process_event -- entered" << endl;
 
   //---------------------------------
   // Get Objects off of the Node Tree

--- a/simulation/g4simulation/g4vertex/GlobalVertexReco.C
+++ b/simulation/g4simulation/g4vertex/GlobalVertexReco.C
@@ -30,9 +30,8 @@ GlobalVertexReco::GlobalVertexReco(const string &name)
     _ydefault(0.0),
     _yerr(0.3),
     _tdefault(0.0),
-    _terr(0.2) {
-  verbosity = 0;
-}
+    _terr(0.2) 
+{}
 
 GlobalVertexReco::~GlobalVertexReco() {}
 
@@ -42,7 +41,7 @@ int GlobalVertexReco::Init(PHCompositeNode *topNode) {
 
 int GlobalVertexReco::InitRun(PHCompositeNode *topNode) {
 
-  if (verbosity > 0) {
+  if (Verbosity() > 0) {
     cout << "======================= GlobalVertexReco::InitRun() =======================" << endl;
     cout << "===========================================================================" << endl;
   }
@@ -52,7 +51,7 @@ int GlobalVertexReco::InitRun(PHCompositeNode *topNode) {
 
 int GlobalVertexReco::process_event(PHCompositeNode *topNode) {
   
-  if (verbosity > 1) cout << "GlobalVertexReco::process_event -- entered" << endl;
+  if (Verbosity() > 1) cout << "GlobalVertexReco::process_event -- entered" << endl;
 
   //---------------------------------
   // Get Objects off of the Node Tree
@@ -87,7 +86,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode) {
   
   if (svtxmap && bbcmap) {
 
-    if (verbosity) cout <<"GlobalVertexReco::process_event - svtxmap && bbcmap"<<endl;
+    if (Verbosity()) cout <<"GlobalVertexReco::process_event - svtxmap && bbcmap"<<endl;
     
     for (SvtxVertexMap::ConstIter svtxiter = svtxmap->begin();
 	 svtxiter != svtxmap->end();
@@ -134,14 +133,14 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode) {
       
       globalmap->insert(vertex);
 
-      if (verbosity) vertex->identify();
+      if (Verbosity()) vertex->identify();
     }
   }
 
   // okay now loop over all unused SVTX vertexes (2nd class)...
   if (svtxmap) {
 
-    if (verbosity) cout <<"GlobalVertexReco::process_event - svtxmap "<<endl;
+    if (Verbosity()) cout <<"GlobalVertexReco::process_event - svtxmap "<<endl;
     
     for (SvtxVertexMap::ConstIter svtxiter = svtxmap->begin();
 	 svtxiter != svtxmap->end();
@@ -173,14 +172,14 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode) {
 
       globalmap->insert(vertex);      
 
-      if (verbosity) vertex->identify();
+      if (Verbosity()) vertex->identify();
     }    
   }
 
   // okay now loop over all unused BBC vertexes (3rd class)...
   if (bbcmap) {
 
-    if (verbosity) cout <<"GlobalVertexReco::process_event -  bbcmap"<<endl;
+    if (Verbosity()) cout <<"GlobalVertexReco::process_event -  bbcmap"<<endl;
 
     for (BbcVertexMap::ConstIter bbciter = bbcmap->begin();
 	 bbciter != bbcmap->end();
@@ -218,7 +217,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode) {
 
       globalmap->insert(vertex);    
 
-      if (verbosity) vertex->identify();
+      if (Verbosity()) vertex->identify();
     }
   }
   


### PR DESCRIPTION
We should have done this a long time ago, exposing the datamembers of the Fun4AllBase class (verbosity, ThisName) to derived classes was just a bad idea. We had a wild mixture of accessors and direct accesses (sometimes within the same source). Sadly changing to accessors only touche a lot of files in a lot of packages. I only did search/replace, no reformatting or other edits so this should merge with your private checkouts okay. If you have merging problems, take your copy and just change verbosity by Verbosity() and ThisName by Name()