### PR TITLE
install include files needed for Root6 macros

### DIFF
--- a/offline/packages/CaloReco/Makefile.am
+++ b/offline/packages/CaloReco/Makefile.am
@@ -8,7 +8,7 @@ AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
   -I$(ROOTSYS)/include 
-  
+
 libcalo_reco_la_SOURCES = \
   RawClusterBuilderGraph.cc \
   RawClusterBuilderGraph_Dict.cc \
@@ -58,7 +58,11 @@ libcalo_reco_la_LIBADD = \
 ##############################################
 # please add new classes in alphabetical order
 
-# pkginclude_HEADERS = 
+pkginclude_HEADERS = \
+  RawClusterBuilderGraph.h \
+  RawClusterBuilderTemplate.h \
+  RawClusterPositionCorrection.h \
+  RawTowerCalibration.h
 
 ################################################
 # linking tests

--- a/simulation/g4simulation/g4calo/Makefile.am
+++ b/simulation/g4simulation/g4calo/Makefile.am
@@ -47,7 +47,9 @@ libg4calo_la_LIBADD = \
 ##############################################
 # please add new classes in alphabetical order
 
-# pkginclude_HEADERS = 
+pkginclude_HEADERS = \
+  RawTowerBuilder.h \
+  RawTowerDigitizer.h
 
 ################################################
 # linking tests

--- a/simulation/g4simulation/g4calo/configure.ac
+++ b/simulation/g4simulation/g4calo/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(g4cemc,[1.00])
+AC_INIT(g4calo,[1.00])
 AC_CONFIG_SRCDIR([configure.ac])
 
 AM_INIT_AUTOMAKE

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -79,12 +79,14 @@ pkginclude_HEADERS = \
   PHG4MapsCellReco.h \
   PHG4MapsSubsystem.h \
   PHG4PrototypeHcalDefs.h \
+  PHG4PSTOFSubsystem.h \
   PHG4ScintillatorSlat.h \
   PHG4ScintillatorSlatContainer.h \
   PHG4ScintillatorSlatDefs.h \
   PHG4SiliconTrackerCellReco.h \
   PHG4SiliconTrackerDefs.h \
   PHG4SiliconTrackerSubsystem.h \
+  PHG4SpacalSubsystem.h \
   PHG4StepStatusDecode.h \
   PHG4TPCDistortion.h \
   PHG4TPCSpaceChargeDistortion.h

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -76,8 +76,10 @@ pkginclude_HEADERS = \
   PHG4DetectorSubsystem.h \
   PHG4DetectorGroupSubsystem.h \
   PHG4HcalDefs.h \
+  PHG4InnerHcalSubsystem.h \
   PHG4MapsCellReco.h \
   PHG4MapsSubsystem.h \
+  PHG4OuterHcalSubsystem.h \
   PHG4PrototypeHcalDefs.h \
   PHG4PSTOFSubsystem.h \
   PHG4ScintillatorSlat.h \

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -76,11 +76,18 @@ pkginclude_HEADERS = \
   PHG4DetectorSubsystem.h \
   PHG4DetectorGroupSubsystem.h \
   PHG4HcalDefs.h \
+  PHG4MapsCellReco.h \
+  PHG4MapsSubsystem.h \
   PHG4PrototypeHcalDefs.h \
   PHG4ScintillatorSlat.h \
   PHG4ScintillatorSlatContainer.h \
   PHG4ScintillatorSlatDefs.h \
-  PHG4StepStatusDecode.h
+  PHG4SiliconTrackerCellReco.h \
+  PHG4SiliconTrackerDefs.h \
+  PHG4SiliconTrackerSubsystem.h \
+  PHG4StepStatusDecode.h \
+  PHG4TPCDistortion.h \
+  PHG4TPCSpaceChargeDistortion.h
 
 libg4detectors_io_la_SOURCES = \
   PHG4BlockCellGeom.cc \

--- a/simulation/g4simulation/g4eval/Makefile.am
+++ b/simulation/g4simulation/g4eval/Makefile.am
@@ -23,25 +23,23 @@ libg4eval_la_LIBADD = \
 pkginclude_HEADERS = \
   BaseTruthEval.h \
   CaloEvalStack.h \
-  CaloTruthEval.h \
-  CaloRawTowerEval.h \
-  CaloRawClusterEval.h \
   CaloEvaluator.h \
+  CaloRawClusterEval.h \
+  CaloRawTowerEval.h \
+  CaloTruthEval.h \
   JetEvalStack.h \
-  JetTruthEval.h \
-  JetRecoEval.h \
   JetEvaluator.h \
+  JetRecoEval.h \
+  JetTruthEval.h \
+  MomentumEvaluator.h \
+  PHG4DstCompressReco.h \
   SvtxEvalStack.h \
-  SvtxTruthEval.h \
+  SvtxEvaluator.h \
   SvtxHitEval.h \
   SvtxClusterEval.h \
   SvtxTrackEval.h \
-  SvtxVertexEval.h \
-  SvtxEvaluator.h \
-  MomentumEvaluator.h \
-  PHG4DstCompressReco.h
-
-#pkginclude_HEADERS = $(include_HEADERS)
+  SvtxTruthEval.h \
+  SvtxVertexEval.h
 
 libg4eval_la_SOURCES = \
   BaseTruthEval.C \

--- a/simulation/g4simulation/g4eval/Makefile.am
+++ b/simulation/g4simulation/g4eval/Makefile.am
@@ -33,6 +33,7 @@ pkginclude_HEADERS = \
   JetTruthEval.h \
   MomentumEvaluator.h \
   PHG4DstCompressReco.h \
+  PHG4DSTReader.h \
   SvtxEvalStack.h \
   SvtxEvaluator.h \
   SvtxHitEval.h \

--- a/simulation/g4simulation/g4hough/Makefile.am
+++ b/simulation/g4simulation/g4hough/Makefile.am
@@ -44,35 +44,10 @@ libg4hough_la_LIBADD = \
   libg4hough_io.la
 
 pkginclude_HEADERS = \
-  SvtxVertex.h \
-  SvtxVertex_v1.h \
-  SvtxVertexMap.h \
-  SvtxVertexMap_v1.h \
-  SvtxDeadMap.h \
-  SvtxDeadMapv1.h \
-  PHG4SvtxDeadArea.h \
-  PHG4SvtxThresholds.h \
-  PHG4SvtxDigitizer.h \
-  PHG4SvtxClusterizer.h \
-  SvtxHit.h \
-  SvtxHit_v1.h \
-  SvtxHitMap.h \
-  SvtxHitMap_v1.h \
-  SvtxCluster.h \
-  SvtxCluster_v1.h \
-  SvtxClusterMap.h \
-  SvtxClusterMap_v1.h \
-  SvtxTrackState.h \
-  SvtxTrackState_v1.h \
-  SvtxTrack.h \
-  SvtxTrack_v1.h \
-  SvtxTrack_FastSim.h \
-  SvtxTrackMap.h \
-  SvtxTrackMap_v1.h \
-  SvtxBeamSpot.h \
+  CellularAutomaton.h \
+  CellularAutomaton_v1.h \
   Cluster3D.h \
-  Track3D.h \
-  HelixTrackState.h \
+  FunctionGradHessian.h \
   HelixHoughSpace.h \
   HelixHoughSpace_v1.h \
   HelixHoughBin.h \
@@ -80,29 +55,55 @@ pkginclude_HEADERS = \
   HelixHoughFuncs.h \
   HelixHoughFuncs_v1.h \
   HelixKalmanFilter.h \
-  CellularAutomaton.h \
-  CellularAutomaton_v1.h \
-  FunctionGradHessian.h \
-  SquareGradient.h \
+  HelixTrackState.h \
   NewtonMinimizerGradHessian.h \
-  VertexFitter.h \
-  VertexFitFuncs.h \
+  PHG4GenFitTrackProjection.h \
   PHG4HoughTransform.h \
   PHG4HoughTransformTPC.h \
-  PHG4KalmanPatRec.h \
   PHG4InitZVertexing.h \
+  PHG4KalmanPatRec.h \
   PHG4PatternReco.h \
+  PHG4SiliconTrackerDigitizer.h \
+  PHG4SvtxBeamSpotReco.h \
+  PHG4SvtxClusterizer.h \
+  PHG4SvtxDeadArea.h \
+  PHG4SvtxDigitizer.h \
+  PHG4SvtxMomentumRecal.h \
+  PHG4SvtxThresholds.h \
+  PHG4SvtxTrackProjection.h \
+  PHG4TPCClusterizer.h \
+  PHG4TrackFastSim.h \
   PHG4TrackGhostRejection.h \
   PHG4TrackKalmanFitter.h \
   PHG4TruthPatRec.h \
-  PHG4TrackFastSim.h \
   PHRaveVertexing.h \
-  PHG4SvtxMomentumRecal.h \
-  PHG4GenFitTrackProjection.h \
-  PHG4SvtxTrackProjection.h \
-  PHG4SvtxBeamSpotReco.h \
-  PHG4TPCClusterizer.h \
-  SimpleTrack.h
+  SimpleTrack.h \
+  SquareGradient.h \
+  SvtxBeamSpot.h \
+  SvtxDeadMap.h \
+  SvtxDeadMapv1.h \
+  SvtxCluster.h \
+  SvtxCluster_v1.h \
+  SvtxClusterMap.h \
+  SvtxClusterMap_v1.h \
+  SvtxHit.h \
+  SvtxHit_v1.h \
+  SvtxHitMap.h \
+  SvtxHitMap_v1.h \
+  SvtxTrack.h \
+  SvtxTrack_v1.h \
+  SvtxTrack_FastSim.h \
+  SvtxTrackMap.h \
+  SvtxTrackMap_v1.h \
+  SvtxTrackState.h \
+  SvtxTrackState_v1.h \
+  SvtxVertex.h \
+  SvtxVertex_v1.h \
+  SvtxVertexMap.h \
+  SvtxVertexMap_v1.h \
+  Track3D.h \
+  VertexFitter.h \
+  VertexFitFuncs.h
 
 libg4hough_io_la_SOURCES = \
   SvtxHit.C \

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -145,6 +145,7 @@ pkginclude_HEADERS = \
   PHG4ParticleGenerator.h \
   PHG4ParticleGeneratorBase.h \
   PHG4ParticleGeneratorVectorMeson.h \
+  PHG4ParticleGun.h \
   PHG4PhenixDetector.h \
   PHG4PileupGenerator.h \
   PHG4Reco.h \

--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -23,7 +23,12 @@ libg4tpc_la_LIBADD = \
   -lphparameter
 
 pkginclude_HEADERS = \
-  PHG4CellTPCv1.h
+  PHG4CellTPCv1.h \
+  PHG4TPCElectronDrift.h \
+  PHG4TPCPadPlane.h \
+  PHG4TPCPadPlaneReadout.h \
+  PHG4TPCSubsystem.h
+
 
 libg4tpc_la_SOURCES = \
   PHG4TPCDetector.cc \

--- a/simulation/g4simulation/g4vertex/Makefile.am
+++ b/simulation/g4simulation/g4vertex/Makefile.am
@@ -29,6 +29,7 @@ libg4vertex_la_LIBADD = \
 pkginclude_HEADERS = \
   GlobalVertex.h \
   GlobalVertex_v1.h \
+  GlobalVertexFastSimReco.h \
   GlobalVertexMap.h \
   GlobalVertexMap_v1.h \
   GlobalVertexReco.h


### PR DESCRIPTION
root6 macros insist on having all include files available for objects one instantiates in the macros. These ones are needed to make Fun4All_G4_sPHENIX.C and the macros it loads functional