### PR TITLE
no streamer for RawTowerDefs, suppress warnings from rootcling

### DIFF
--- a/offline/packages/CaloBase/RawTowerDefsLinkDef.h
+++ b/offline/packages/CaloBase/RawTowerDefsLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ namespace RawTowerDefs;
+#pragma link C++ namespace RawTowerDefs-!;
 
 #endif /* __CINT__ */

--- a/offline/packages/trackbase/configure.ac
+++ b/offline/packages/trackbase/configure.ac
@@ -14,7 +14,7 @@ fi
 
 dnl test for root 6
 if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override"
 AC_SUBST(CINTDEFS)
 fi
 


### PR DESCRIPTION
The RawTowerDefs were created with streamer (which was wrong but root5 is somewhat forgiving), now run it with -! like the other namespace Defs we have. For some unknown reason  offline/packages/trackbase generates warning in rootcling (the makefile and the includes and linkdefs look like the ones from other packages). Added an option to rootcling to suppress this warning. We certainly want to look at this at some point