### PR TITLE
Patch CaloTruthEval to analyze stripped DST without G4hit nodes

### DIFF
--- a/simulation/g4simulation/g4eval/CaloTruthEval.h
+++ b/simulation/g4simulation/g4eval/CaloTruthEval.h
@@ -126,6 +126,7 @@ private:
   int _caloid;
   PHG4TruthInfoContainer* _truthinfo;
   PHG4HitContainer* _g4hits;
+  int _g4hit_container_id;
 
   bool _strict;
   int _verbosity;


### PR DESCRIPTION
During production stage with DST compression enabled, the calorimeter G4hit nodes are removed. The calorimeter tower truth information are linked with the primary particles with the G4Shower objects. CaloTruthEval need this minor patch to allow it safely ignore the missing G4hit node