### PR TITLE
Tpc time window fix

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SiliconTrackerDetector.cc
@@ -94,13 +94,12 @@ void PHG4SiliconTrackerDetector::Construct(G4LogicalVolume *logicWorld)
 
 int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *trackerenvelope)
 {
-  // We have an arbitray number of layers (nlayer_)
+  // We have an arbitray number of layers (nlayer_) up to 8
   // We have 2 types of ladders (vertical strips and horizontal strips)
   // We have 2 types of sensors (inner and outer)
-  double hdi_z_arr[4][2];
+  double hdi_z_arr[8][2];
   // we loop over layers. All layers have only one laddertype
   for (auto layeriter = m_LayerBeginEndIteratorPair.first; layeriter != m_LayerBeginEndIteratorPair.second; ++layeriter)
-
   {
     int inttlayer = layeriter->second;
     // get the parameters for this layer
@@ -187,8 +186,8 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
 
       // Si-sensor full (active+inactive) area
       const double sifull_x = siactive_x;
-      const double sifull_y = siactive_y + 2.0 * params->get_double_param("sensor_edge_phi");
-      const double sifull_z = siactive_z + 2.0 * params->get_double_param("sensor_edge_z");
+      const double sifull_y = siactive_y + 2.0 * params->get_double_param("sensor_edge_phi") * cm;
+      const double sifull_z = siactive_z + 2.0 * params->get_double_param("sensor_edge_z") * cm;
       G4VSolid *sifull_box = new G4Box((boost::format("sifull_box_%d_%d") % inttlayer % itype).str(), sifull_x / 2., sifull_y / 2.0, sifull_z / 2.0);
 
       // Si-sensor inactive area
@@ -210,7 +209,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       // Make the HDI Kapton and copper volumes
 
       // This makes HDI volumes that matche this sensor in Z length
-      const double hdi_z = sifull_z + params->get_double_param("hdi_edge_z");
+      const double hdi_z = sifull_z + params->get_double_param("hdi_edge_z") * cm;
       hdi_z_arr[inttlayer][itype] = hdi_z;
       G4VSolid *hdi_kapton_box = new G4Box((boost::format("hdi_kapton_box_%d_%d") % inttlayer % itype).str(), hdi_kapton_x / 2., hdi_y / 2., hdi_z / 2.0);
       G4LogicalVolume *hdi_kapton_volume = new G4LogicalVolume(hdi_kapton_box, G4Material::GetMaterial("G4_KAPTON"),
@@ -273,7 +272,7 @@ int PHG4SiliconTrackerDetector::ConstructSiliconTracker(G4LogicalVolume *tracker
       fphx_vis.SetColour(G4Colour::Blue());
       fphx_volume->SetVisAttributes(fphx_vis);
 
-      const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx");
+      const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx") * cm;
 
       //  FPHX Container
       // make a container for the FPHX chips needed for this sensor, and  then place them in the container

--- a/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.cc
@@ -142,16 +142,19 @@ int PHG4TPCElectronDrift::InitRun(PHCompositeNode *topNode)
     }
   PutOnParNode(ParDetNode,geonodename);
 
+  tpc_length = 211.;
   diffusion_long = get_double_param("diffusion_long");
   added_smear_sigma_long = get_double_param("added_smear_long");
   diffusion_trans = get_double_param("diffusion_trans");
   added_smear_sigma_trans = get_double_param("added_smear_trans");
   drift_velocity = get_double_param("drift_velocity");
+  min_time = 0.0;
+  max_time = (tpc_length/ 2.) / drift_velocity;
   electrons_per_gev = get_double_param("electrons_per_gev");
   min_active_radius = get_double_param("min_active_radius");
   max_active_radius = get_double_param("max_active_radius");
 
-// find TPC Geo
+  // find TPC Geo
   PHNodeIterator tpcpariter(ParDetNode);
   PHParametersContainer *tpcparams = findNode::getClass<PHParametersContainer>(ParDetNode,tpcgeonodename);
   if (!tpcparams)
@@ -197,7 +200,7 @@ int PHG4TPCElectronDrift::process_event(PHCompositeNode *topNode)
 
   PHG4HitContainer::ConstIterator hiter;
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
-  double tpc_length = 211.;
+
   double ihit = 0;
   for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
   {
@@ -283,7 +286,7 @@ int PHG4TPCElectronDrift::process_event(PHCompositeNode *topNode)
 
 	if (t_final < min_time || t_final > max_time)
 	  {
-	    cout << "skip this, t_final out of range" << endl;
+	    //cout << "skip this, t_final = " << t_final << " is out of range " << min_time <<  " to " << max_time << endl;
 	    continue;
 	  }
 	double ranphi = gsl_ran_flat(RandomGenerator,-M_PI,M_PI);
@@ -407,15 +410,13 @@ double CF4_NTotal = 100;   // Number/cm
 double TPC_NTot = 0.9*Ne_NTotal + 0.1*CF4_NTotal;
 double TPC_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
 double  TPC_ElectronsPerKeV = TPC_NTot / TPC_dEdx;
-  set_default_double_param("diffusion_long",0.015); // cm/SQRT(cm)
-  set_default_double_param("diffusion_trans",0.006); // cm/SQRT(cm)
-  set_default_double_param("drift_velocity",8.0 / 1000.0); // cm/ns
-  set_default_double_param("electrons_per_gev",TPC_ElectronsPerKeV*1000000.);
-  set_default_double_param("min_active_radius",30.); // cm
-  set_default_double_param("max_active_radius",78.); // cm
-  set_default_double_param("min_time",0.); // ns
-  set_default_double_param("max_time",14000.); // ns
-
+ set_default_double_param("diffusion_long",0.015); // cm/SQRT(cm)
+ set_default_double_param("diffusion_trans",0.006); // cm/SQRT(cm)
+ set_default_double_param("electrons_per_gev",TPC_ElectronsPerKeV*1000000.);
+ set_default_double_param("min_active_radius",30.); // cm
+ set_default_double_param("max_active_radius",78.); // cm
+ set_default_double_param("drift_velocity",8.0 / 1000.0);  // cm/ns 
+ 
   // These are purely fudge factors, used to increase the resolution to 150 microns and 500 microns, respectively
   // override them from the macro to get a different resolution
   set_default_double_param("added_smear_trans", 0.12);   // cm

--- a/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.h
@@ -57,6 +57,7 @@ private:
   double diffusion_long;
   double added_smear_sigma_long;
   double drift_velocity;
+  double tpc_length;
   double electrons_per_gev;
   double min_active_radius;
   double max_active_radius;


### PR DESCRIPTION
This pull request contains two unrelated bug fixes:

1) Fix to a bug in the g4tpc code that caused the TPC valid time window check to effectively not be made in the electron drift module. 

2) Fix to a bug found by Takahito in the INTT code. The dimensioning of one of the arrays used to construct the INTT was not increased from 4 to 8 when we switched from layers to sublayers. This caused problems for setups containing more than 4 sublayers. Fixing this bug corrected a problem reported separately by Sanghoon today. He saw bad behavior in the sublayers beyond 4. 
Before the bug fix, I reproduced Sanghoon's problem using the 6 layer setup "INTTLADDER6" in G4_Tracking.C. After the bug fix, the distribution of clusters in phi-Z space looks normal. See the before and after plots below.
[INTTLADDER6_before.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/2551611/INTTLADDER6_before.pdf)
[INTTLADDER6_after.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/2551612/INTTLADDER6_after.pdf)

Also fixed some minor bugs in the dimensioning of edge regions pointed out by Takahito.



 