### PR TITLE
install includes needed for root6 macros

### DIFF
--- a/offline/QA/modules/Makefile.am
+++ b/offline/QA/modules/Makefile.am
@@ -25,6 +25,10 @@ libqa_modules_la_LIBADD = \
   -lg4jets_io \
   -lg4eval
 
+pkginclude_HEADERS = \
+  QAG4SimulationCalorimeter.h \
+  QAHistManagerDef.h
+
 libqa_modules_la_SOURCES = \
   QAHistManagerDef.C \
   QAHistManagerDef_Dict.C \

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -46,6 +46,7 @@ pkginclude_HEADERS = \
   PHG4BlockCellGeomContainer.h \
   PHG4BlockGeom.h \
   PHG4BlockGeomContainer.h \
+  PHG4BlockSubsystem.h \
   PHG4Cell.h \
   PHG4Cellv1.h \
   PHG4Cellv2.h \
@@ -91,6 +92,10 @@ pkginclude_HEADERS = \
   PHG4MapsSubsystem.h \
   PHG4OuterHcalSubsystem.h \
   PHG4PrototypeHcalDefs.h \
+  PHG4Prototype2HcalCellReco.h \
+  PHG4Prototype2OuterHcalSubsystem.h \
+  PHG4Prototype2InnerHcalSubsystem.h \
+  PHG4Prototype3InnerHcalSubsystem.h \
   PHG4PSTOFSubsystem.h \
   PHG4RICHSubsystem.h \
   PHG4ScintillatorSlat.h \
@@ -102,6 +107,7 @@ pkginclude_HEADERS = \
   PHG4SiliconTrackerDefs.h \
   PHG4SiliconTrackerSubsystem.h \
   PHG4SpacalSubsystem.h \
+  PHG4SpacalPrototypeSubsystem.h \
   PHG4StepStatusDecode.h \
   PHG4TPCDistortion.h \
   PHG4TPCSpaceChargeDistortion.h

--- a/simulation/g4simulation/g4histos/Makefile.am
+++ b/simulation/g4simulation/g4histos/Makefile.am
@@ -18,7 +18,6 @@ noinst_HEADERS = \
   G4CellNtuple.h \
   G4EdepNtuple.h \
   G4EvtTree.h \
-  G4HitNtuple.h \
   G4HitTTree.h \
   G4RawTowerTTree.h \
   G4RootHitContainer.h \
@@ -26,6 +25,9 @@ noinst_HEADERS = \
   G4RootRawTowerContainer.h \
   G4SnglNtuple.h \
   G4SnglTree.h
+
+pkginclude_HEADERS = \
+  G4HitNtuple.h
 
 libg4histos_la_SOURCES = \
   G4CellNtuple.cc \


### PR DESCRIPTION
Installing a few more header files which are needed for root6 macros - for Fun4AllG4_EICDetector.C and the sim macro under packages/prototype4