### PR TITLE
Cumulative fixes for analyzing jet background production data

### DIFF
--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -4,24 +4,24 @@
 #include <calobase/RawTowerGeomv1.h>
 #include <calobase/RawTowerv1.h>
 
-#include <g4detectors/PHG4HcalDefs.h>
-#include <phparameter/PHParameters.h>
 #include <g4detectors/PHG4Cell.h>
 #include <g4detectors/PHG4CellContainer.h>
 #include <g4detectors/PHG4CellDefs.h>
+#include <g4detectors/PHG4HcalDefs.h>
+#include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Utils.h>
 
-#include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
 
 #include <pdbcalbase/PdbParameterMap.h>
 #include <pdbcalbase/PdbParameterMapContainer.h>
 
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHNodeIterator.h>
+#include <phool/getClass.h>
 
 #include <TSystem.h>
 
@@ -31,341 +31,338 @@
 
 using namespace std;
 
-HcalRawTowerBuilder::HcalRawTowerBuilder(const std::string& name) :
-  SubsysReco(name), 
-  PHParameterInterface(name),
-  _towers(NULL), 
-  rawtowergeom(NULL),
-  detector("NONE"), 
-  emin(NAN),
-  chkenergyconservation(0), 
-  _tower_energy_src(enu_tower_energy_src::unknown),
-  ncell_to_tower(-1),
-  _timer(PHTimeServer::get()->insert_new(name))
+HcalRawTowerBuilder::HcalRawTowerBuilder(const std::string &name)
+  : SubsysReco(name)
+  , PHParameterInterface(name)
+  , _towers(NULL)
+  , rawtowergeom(NULL)
+  , detector("NONE")
+  , emin(NAN)
+  , chkenergyconservation(0)
+  , _tower_energy_src(enu_tower_energy_src::unknown)
+  , ncell_to_tower(-1)
+  , _timer(PHTimeServer::get()->insert_new(name))
 {
   InitializeParameters();
 }
 
-int
-HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
+int HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
 
   // Looking for the DST node
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",
-      "DST"));
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode",
+                                                                            "DST"));
   if (!dstNode)
-    {
-      std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
-      gSystem->Exit(1);
-    }
-  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN" ));
+  {
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+    gSystem->Exit(1);
+  }
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
   string paramnodename = "TOWERPARAM_" + detector;
 
-
   try
-    {
-      CreateNodes(topNode);
-    }
-  catch (std::exception& e)
-    {
-      std::cout << e.what() << std::endl;
-      //exit(1);
-    }
+  {
+    CreateNodes(topNode);
+  }
+  catch (std::exception &e)
+  {
+    std::cout << e.what() << std::endl;
+    //exit(1);
+  }
 
-  // order first default, 
+  // order first default,
   // then parameter from g4detector on node tree
-   ReadParamsFromNodeTree(topNode);
+  ReadParamsFromNodeTree(topNode);
   // then macro setting
   UpdateParametersWithMacro();
   PHNodeIterator runIter(runNode);
-  PHCompositeNode *RunDetNode =  dynamic_cast<PHCompositeNode*>(runIter.findFirst("PHCompositeNode",detector));
-  if (! RunDetNode)
-    {
-      RunDetNode = new PHCompositeNode(detector);
-      runNode->addNode(RunDetNode);
-    }
-  SaveToNodeTree(RunDetNode,paramnodename);
-  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "PAR" ));
+  PHCompositeNode *RunDetNode = dynamic_cast<PHCompositeNode *>(runIter.findFirst("PHCompositeNode", detector));
+  if (!RunDetNode)
+  {
+    RunDetNode = new PHCompositeNode(detector);
+    runNode->addNode(RunDetNode);
+  }
+  SaveToNodeTree(RunDetNode, paramnodename);
+  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "PAR"));
   string geonodename = "TOWERGEO_" + detector;
 
   PHNodeIterator parIter(parNode);
-  PHCompositeNode *ParDetNode =  dynamic_cast<PHCompositeNode*>(parIter.findFirst("PHCompositeNode",detector));
-  if (! ParDetNode)
-    {
-      ParDetNode = new PHCompositeNode(detector);
-      parNode->addNode(ParDetNode);
-    }
-  PutOnParNode(ParDetNode,geonodename);
+  PHCompositeNode *ParDetNode = dynamic_cast<PHCompositeNode *>(parIter.findFirst("PHCompositeNode", detector));
+  if (!ParDetNode)
+  {
+    ParDetNode = new PHCompositeNode(detector);
+    parNode->addNode(ParDetNode);
+  }
+  PutOnParNode(ParDetNode, geonodename);
   _tower_energy_src = get_int_param("tower_energy_source");
   emin = get_double_param("emin");
   ncell_to_tower = get_int_param("n_scinti_plates_per_tower");
   if (Verbosity() >= 1)
+  {
+    cout << "HcalRawTowerBuilder::InitRun :";
+    if (_tower_energy_src == kEnergyDeposition)
     {
-      cout << "HcalRawTowerBuilder::InitRun :";
-      if (_tower_energy_src == kEnergyDeposition)
-	{
-        cout << "save Geant4 energy deposition in towers" << endl;
-	}
-      else if (_tower_energy_src == kLightYield)
-	{
-        cout << "save light yield in towers" << endl;
-	}
-      else if (_tower_energy_src == kIonizationEnergy)
-	{
-        cout << "save ionization energy in towers" << endl;
-	}
-      else
-	{
-	  cout << "unknown energy source" << endl;
-	}
+      cout << "save Geant4 energy deposition in towers" << endl;
     }
+    else if (_tower_energy_src == kLightYield)
+    {
+      cout << "save light yield in towers" << endl;
+    }
+    else if (_tower_energy_src == kIonizationEnergy)
+    {
+      cout << "save ionization energy in towers" << endl;
+    }
+    else
+    {
+      cout << "unknown energy source" << endl;
+    }
+  }
   TowerGeomNodeName = "TOWERGEOM_" + detector;
   rawtowergeom = findNode::getClass<RawTowerGeomContainer>(topNode,
-      TowerGeomNodeName.c_str());
+                                                           TowerGeomNodeName.c_str());
   if (!rawtowergeom)
-    {
-      rawtowergeom = new RawTowerGeomContainer_Cylinderv1(RawTowerDefs::convert_name_to_caloid(detector));
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom,
-          TowerGeomNodeName.c_str(), "PHObject");
-      RunDetNode->addNode(newNode);
-    }
+  {
+    rawtowergeom = new RawTowerGeomContainer_Cylinderv1(RawTowerDefs::convert_name_to_caloid(detector));
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(rawtowergeom,
+                                                                 TowerGeomNodeName.c_str(), "PHObject");
+    RunDetNode->addNode(newNode);
+  }
   double innerrad = get_double_param(PHG4HcalDefs::innerrad);
-  double thickness = get_double_param(PHG4HcalDefs::outerrad)-innerrad;
+  double thickness = get_double_param(PHG4HcalDefs::outerrad) - innerrad;
   rawtowergeom->set_radius(innerrad);
   rawtowergeom->set_thickness(thickness);
   rawtowergeom->set_phibins(get_int_param(PHG4HcalDefs::n_towers));
   rawtowergeom->set_etabins(get_int_param("etabins"));
-  double geom_ref_radius = innerrad + thickness/2.;
+  double geom_ref_radius = innerrad + thickness / 2.;
   double phistart = 0;
-  for (int i=0; i<get_int_param(PHG4HcalDefs::n_towers); i++)
-    {
-      double phiend = phistart+2.*M_PI/get_int_param(PHG4HcalDefs::n_towers);
-      pair<double, double> range = make_pair(phistart,phiend);
-      phistart = phiend;
-      rawtowergeom->set_phibounds(i,range);
-    }
+  for (int i = 0; i < get_int_param(PHG4HcalDefs::n_towers); i++)
+  {
+    double phiend = phistart + 2. * M_PI / get_int_param(PHG4HcalDefs::n_towers);
+    pair<double, double> range = make_pair(phistart, phiend);
+    phistart = phiend;
+    rawtowergeom->set_phibounds(i, range);
+  }
   double etalowbound = -1.1;
   for (int i = 0; i < get_int_param("etabins"); i++)
-    {
-      double etahibound = etalowbound + 2.2 / get_int_param("etabins");
-      pair<double, double> range = make_pair(etalowbound, etahibound);
-      rawtowergeom->set_etabounds(i, range);
-      etalowbound = etahibound;
-    }
+  {
+    double etahibound = etalowbound + 2.2 / get_int_param("etabins");
+    pair<double, double> range = make_pair(etalowbound, etahibound);
+    rawtowergeom->set_etabounds(i, range);
+    etalowbound = etahibound;
+  }
   for (int iphi = 0; iphi < rawtowergeom->get_phibins(); iphi++)
+  {
+    for (int ieta = 0; ieta < rawtowergeom->get_etabins(); ieta++)
     {
-      for (int ieta = 0; ieta < rawtowergeom->get_etabins(); ieta++)
-	{
-	  RawTowerGeomv1 * tg = new RawTowerGeomv1(RawTowerDefs::encode_towerid(RawTowerDefs::convert_name_to_caloid(detector), ieta, iphi));
+      RawTowerGeomv1 *tg = new RawTowerGeomv1(RawTowerDefs::encode_towerid(RawTowerDefs::convert_name_to_caloid(detector), ieta, iphi));
 
-	  tg->set_center_x(geom_ref_radius * cos(rawtowergeom->get_phicenter(iphi)));
-	  tg->set_center_y(geom_ref_radius * sin(rawtowergeom->get_phicenter(iphi)));
-	  tg->set_center_z(geom_ref_radius / tan(PHG4Utils::get_theta(rawtowergeom->get_etacenter(ieta))));
-	  rawtowergeom->add_tower_geometry(tg);
-	}
+      tg->set_center_x(geom_ref_radius * cos(rawtowergeom->get_phicenter(iphi)));
+      tg->set_center_y(geom_ref_radius * sin(rawtowergeom->get_phicenter(iphi)));
+      tg->set_center_z(geom_ref_radius / tan(PHG4Utils::get_theta(rawtowergeom->get_etacenter(ieta))));
+      rawtowergeom->add_tower_geometry(tg);
     }
+  }
   if (Verbosity() > 0)
-    {
-      rawtowergeom->identify();
-    }
+  {
+    rawtowergeom->identify();
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int
-HcalRawTowerBuilder::process_event(PHCompositeNode *topNode)
+int HcalRawTowerBuilder::process_event(PHCompositeNode *topNode)
 {
-  if (Verbosity()>3)
-    {
-      std::cout << PHWHERE << "Process event entered" << std::endl;
-    }
+  if (Verbosity() > 3)
+  {
+    std::cout << PHWHERE << "Process event entered" << std::endl;
+  }
 
   // get cells
   std::string cellnodename = "G4CELL_" + detector;
-  PHG4CellContainer* slats = findNode::getClass<PHG4CellContainer>(topNode, cellnodename.c_str());
+  PHG4CellContainer *slats = findNode::getClass<PHG4CellContainer>(topNode, cellnodename.c_str());
   if (!slats)
-    {
-      std::cerr << PHWHERE << " " << cellnodename
-          << " Node missing, doing nothing." << std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+  {
+    std::cerr << PHWHERE << " " << cellnodename
+              << " Node missing, doing nothing." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   // loop over all slats in an event
   PHG4CellContainer::ConstIterator cell_iter;
   PHG4CellContainer::ConstRange cell_range = slats->getCells();
   for (cell_iter = cell_range.first; cell_iter != cell_range.second;
-      ++cell_iter)
+       ++cell_iter)
+  {
+    PHG4Cell *cell = cell_iter->second;
+
+    if (Verbosity() > 2)
     {
-      PHG4Cell *cell = cell_iter->second;
-
-      if (Verbosity() > 2)
-        {
-          std::cout << PHWHERE << " print out the cell:" << std::endl;
-          cell->identify();
-        }
-      short twrrow = get_tower_row(PHG4CellDefs::ScintillatorSlatBinning::get_row(cell->get_cellid()));
-      // add the energy to the corresponding tower
-      // towers are addressed column/row to make the mapping more intuitive
-      RawTower *tower = _towers->getTower(PHG4CellDefs::ScintillatorSlatBinning::get_column(cell->get_cellid()), twrrow);
-      if (!tower)
-        {
-          tower = new RawTowerv1();
-          tower->set_energy(0);
-          _towers->AddTower(PHG4CellDefs::ScintillatorSlatBinning::get_column(cell->get_cellid()), twrrow, tower);
-        }
-      double cell_weight = 0;
-      if (_tower_energy_src == kEnergyDeposition)
-	{
-	  cell_weight = cell->get_edep();
-	}
-      else if (_tower_energy_src == kLightYield)
-	{
-	  cell_weight = cell->get_light_yield();
-	}
-      else if (_tower_energy_src == kIonizationEnergy)
-	{
-	  cell_weight = cell->get_eion();
-	}
-      else
-	{
-	  cout << Name() << ": unknown tower energy source " 
-	       << _tower_energy_src << endl;
-	  gSystem->Exit(1);
-	}
-
-      tower->add_ecell(cell->get_cellid(), cell_weight);
-
-      PHG4Cell::ShowerEdepConstRange range = cell->get_g4showers();
-      for (PHG4Cell::ShowerEdepConstIterator shower_iter = range.first;
-	   shower_iter != range.second;
-	   ++shower_iter) 
-	{
-	  tower->add_eshower(shower_iter->first,shower_iter->second);
-	}
-      tower->set_energy(tower->get_energy() + cell_weight);
+      std::cout << PHWHERE << " print out the cell:" << std::endl;
+      cell->identify();
     }
+    short twrrow = get_tower_row(PHG4CellDefs::ScintillatorSlatBinning::get_row(cell->get_cellid()));
+    // add the energy to the corresponding tower
+    // towers are addressed column/row to make the mapping more intuitive
+    RawTower *tower = _towers->getTower(PHG4CellDefs::ScintillatorSlatBinning::get_column(cell->get_cellid()), twrrow);
+    if (!tower)
+    {
+      tower = new RawTowerv1();
+      tower->set_energy(0);
+      _towers->AddTower(PHG4CellDefs::ScintillatorSlatBinning::get_column(cell->get_cellid()), twrrow, tower);
+    }
+    double cell_weight = 0;
+    if (_tower_energy_src == kEnergyDeposition)
+    {
+      cell_weight = cell->get_edep();
+    }
+    else if (_tower_energy_src == kLightYield)
+    {
+      cell_weight = cell->get_light_yield();
+    }
+    else if (_tower_energy_src == kIonizationEnergy)
+    {
+      cell_weight = cell->get_eion();
+    }
+    else
+    {
+      cout << Name() << ": unknown tower energy source "
+           << _tower_energy_src << endl;
+      gSystem->Exit(1);
+    }
+
+    tower->add_ecell(cell->get_cellid(), cell_weight);
+
+    PHG4Cell::ShowerEdepConstRange range = cell->get_g4showers();
+    for (PHG4Cell::ShowerEdepConstIterator shower_iter = range.first;
+         shower_iter != range.second;
+         ++shower_iter)
+    {
+      tower->add_eshower(shower_iter->first, shower_iter->second);
+    }
+    tower->set_energy(tower->get_energy() + cell_weight);
+  }
   double towerE = 0;
   if (chkenergyconservation)
+  {
+    double cellE = slats->getTotalEdep();
+    towerE = _towers->getTotalEdep();
+    if (fabs(cellE - towerE) / cellE > 1e-5)
     {
-      double cellE = slats->getTotalEdep();
-      towerE = _towers->getTotalEdep();
-      if (fabs(cellE - towerE) / cellE > 1e-5)
-        {
-          cout << "towerE: " << towerE << ", cellE: " << cellE << ", delta: "
-              << cellE - towerE << endl;
-        }
+      cout << "towerE: " << towerE << ", cellE: " << cellE << ", delta: "
+           << cellE - towerE << endl;
     }
+  }
   if (Verbosity())
-    {
-      towerE = _towers->getTotalEdep();
-    }
+  {
+    towerE = _towers->getTotalEdep();
+  }
 
   _towers->compress(emin);
   if (Verbosity())
+  {
+    cout << "Energy lost by dropping towers with less than " << emin
+         << " energy, lost energy: " << towerE - _towers->getTotalEdep()
+         << endl;
+    _towers->identify();
+    RawTowerContainer::ConstRange begin_end = _towers->getTowers();
+    RawTowerContainer::ConstIterator iter;
+    for (iter = begin_end.first; iter != begin_end.second; ++iter)
     {
-      cout << "Energy lost by dropping towers with less than " << emin
-          << " energy, lost energy: " << towerE - _towers->getTotalEdep()
-          << endl;
-      _towers->identify();
-      RawTowerContainer::ConstRange begin_end = _towers->getTowers();
-      RawTowerContainer::ConstIterator iter;
-      for (iter = begin_end.first; iter != begin_end.second; ++iter)
-        {
-          iter->second->identify();
-        }
+      iter->second->identify();
     }
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void
-HcalRawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
+void HcalRawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
 {
-
   PHNodeIterator iter(topNode);
-  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst(
       "PHCompositeNode", "RUN"));
   if (!runNode)
-    {
-      std::cerr << PHWHERE << "Run Node missing, doing nothing." << std::endl;
-      throw std::runtime_error(
-          "Failed to find Run node in HcalRawTowerBuilder::CreateNodes");
-    }
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+  {
+    std::cerr << PHWHERE << "Run Node missing, doing nothing." << std::endl;
+    throw std::runtime_error(
+        "Failed to find Run node in HcalRawTowerBuilder::CreateNodes");
+  }
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst(
       "PHCompositeNode", "DST"));
   if (!dstNode)
-    {
-      std::cerr << PHWHERE << "DST Node missing, doing nothing." << std::endl;
-      throw std::runtime_error(
-          "Failed to find DST node in HcalRawTowerBuilder::CreateNodes");
-    }
+  {
+    std::cerr << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+    throw std::runtime_error(
+        "Failed to find DST node in HcalRawTowerBuilder::CreateNodes");
+  }
 
   PHNodeIterator dstiter(dstNode);
-  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst(
+  PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst(
       "PHCompositeNode", detector));
   if (!DetNode)
-    {
-      DetNode = new PHCompositeNode(detector);
-      dstNode->addNode(DetNode);
-    }
+  {
+    DetNode = new PHCompositeNode(detector);
+    dstNode->addNode(DetNode);
+  }
 
   // Create the tower nodes on the tree
-  _towers = new RawTowerContainer(RawTowerDefs::convert_name_to_caloid(detector));
   if (_sim_tower_node_prefix.length() == 0)
-    {
-      // no prefix, consistent with older convension
-      TowerNodeName = "TOWER_" + detector;
-    }
+  {
+    // no prefix, consistent with older convension
+    TowerNodeName = "TOWER_" + detector;
+  }
   else
-    {
-      TowerNodeName = "TOWER_" + _sim_tower_node_prefix + "_" + detector;
-    }
-  PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers,
-      TowerNodeName.c_str(), "PHObject");
-  DetNode->addNode(towerNode);
+  {
+    TowerNodeName = "TOWER_" + _sim_tower_node_prefix + "_" + detector;
+  }
+  _towers = findNode::getClass<RawTowerContainer>(DetNode, TowerNodeName.c_str());
+  if (_towers == nullptr)
+  {
+    _towers = new RawTowerContainer(RawTowerDefs::convert_name_to_caloid(detector));
+
+    PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(_towers,
+                                                                   TowerNodeName.c_str(), "PHObject");
+    DetNode->addNode(towerNode);
+  }
   return;
 }
 
-short
-HcalRawTowerBuilder::get_tower_row(const short cellrow) const
+short HcalRawTowerBuilder::get_tower_row(const short cellrow) const
 {
-  short twrrow = cellrow/ncell_to_tower;
+  short twrrow = cellrow / ncell_to_tower;
   return twrrow;
 }
 
-void
-HcalRawTowerBuilder::SetDefaultParameters()
+void HcalRawTowerBuilder::SetDefaultParameters()
 {
-  set_default_int_param(PHG4HcalDefs::scipertwr,5);
-  set_default_int_param("tower_energy_source",kLightYield);
-  set_default_int_param(PHG4HcalDefs::n_towers,64);
-  set_default_int_param("etabins",24);
+  set_default_int_param(PHG4HcalDefs::scipertwr, 5);
+  set_default_int_param("tower_energy_source", kLightYield);
+  set_default_int_param(PHG4HcalDefs::n_towers, 64);
+  set_default_int_param("etabins", 24);
 
-  set_default_double_param("emin",1.e-6);
-  set_default_double_param(PHG4HcalDefs::outerrad,NAN);
-  set_default_double_param(PHG4HcalDefs::innerrad,NAN);
+  set_default_double_param("emin", 1.e-6);
+  set_default_double_param(PHG4HcalDefs::outerrad, NAN);
+  set_default_double_param(PHG4HcalDefs::innerrad, NAN);
 }
 
-void
-HcalRawTowerBuilder::ReadParamsFromNodeTree(PHCompositeNode *topNode)
+void HcalRawTowerBuilder::ReadParamsFromNodeTree(PHCompositeNode *topNode)
 {
   PHParameters *pars = new PHParameters("temp");
   // we need the number of scintillator plates per tower
   string geonodename = "G4GEOPARAM_" + detector;
-  PdbParameterMapContainer *saveparams = findNode::getClass<PdbParameterMapContainer>(topNode,geonodename);
-  if (! saveparams)
-    {
-      cout << "could not find " << geonodename << endl;
-      Fun4AllServer *se = Fun4AllServer::instance();
-      se->Print("NODETREE");
-      return;
-    }
-  pars->FillFrom(saveparams,0);
-  set_int_param(PHG4HcalDefs::scipertwr,pars->get_int_param(PHG4HcalDefs::scipertwr));
-  set_int_param(PHG4HcalDefs::n_towers,pars->get_int_param(PHG4HcalDefs::n_towers));
-  set_int_param("etabins",2*pars->get_int_param(PHG4HcalDefs::n_scinti_tiles));
-  set_double_param(PHG4HcalDefs::innerrad,pars->get_double_param(PHG4HcalDefs::innerrad));
-  set_double_param(PHG4HcalDefs::outerrad,pars->get_double_param(PHG4HcalDefs::outerrad));
+  PdbParameterMapContainer *saveparams = findNode::getClass<PdbParameterMapContainer>(topNode, geonodename);
+  if (!saveparams)
+  {
+    cout << "could not find " << geonodename << endl;
+    Fun4AllServer *se = Fun4AllServer::instance();
+    se->Print("NODETREE");
+    return;
+  }
+  pars->FillFrom(saveparams, 0);
+  set_int_param(PHG4HcalDefs::scipertwr, pars->get_int_param(PHG4HcalDefs::scipertwr));
+  set_int_param(PHG4HcalDefs::n_towers, pars->get_int_param(PHG4HcalDefs::n_towers));
+  set_int_param("etabins", 2 * pars->get_int_param(PHG4HcalDefs::n_scinti_tiles));
+  set_double_param(PHG4HcalDefs::innerrad, pars->get_double_param(PHG4HcalDefs::innerrad));
+  set_double_param(PHG4HcalDefs::outerrad, pars->get_double_param(PHG4HcalDefs::outerrad));
   delete pars;
   return;
 }

--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -198,7 +198,7 @@ int HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
           cout << "HcalRawTowerBuilder::InitRun - building tower geometry " << key << "" << endl;
         }
 
-        tg = new RawTowerGeomv1();
+        tg = new RawTowerGeomv1(key);
 
         tg->set_center_x(x);
         tg->set_center_y(y);

--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.h
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.h
@@ -1,12 +1,11 @@
 #ifndef HcalRawTowerBuilder_H__
 #define HcalRawTowerBuilder_H__
 
-#include <phparameter/PHParameterInterface.h>
 #include <fun4all/SubsysReco.h>
 #include <phool/PHTimeServer.h>
+#include <phparameter/PHParameterInterface.h>
 
 #include <string>
-
 
 class PHCompositeNode;
 class RawTowerContainer;
@@ -14,16 +13,15 @@ class RawTowerGeomContainer;
 
 class HcalRawTowerBuilder : public SubsysReco, public PHParameterInterface
 {
-
  public:
-  HcalRawTowerBuilder(const std::string& name="HcalRawTowerBuilder");
-  virtual ~HcalRawTowerBuilder(){}
+  HcalRawTowerBuilder(const std::string &name = "HcalRawTowerBuilder");
+  virtual ~HcalRawTowerBuilder() {}
 
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
-  void Detector(const std::string &d) {detector = d;}
-  void EminCut(const double e) {emin = e;}
-  void checkenergy(const int i = 1) {chkenergyconservation = i;}
+  void Detector(const std::string &d) { detector = d; }
+  void EminCut(const double e) { emin = e; }
+  void checkenergy(const int i = 1) { chkenergyconservation = i; }
 
   enum enu_tower_energy_src
   {
@@ -39,8 +37,7 @@ class HcalRawTowerBuilder : public SubsysReco, public PHParameterInterface
     unknown = -1
   };
 
-  int
-  get_tower_energy_src() const
+  int get_tower_energy_src() const
   {
     return _tower_energy_src;
   }
@@ -65,7 +62,7 @@ class HcalRawTowerBuilder : public SubsysReco, public PHParameterInterface
   void CreateNodes(PHCompositeNode *topNode);
   void ReadParamsFromNodeTree(PHCompositeNode *topNode);
 
-  RawTowerContainer* _towers;
+  RawTowerContainer *_towers;
   RawTowerGeomContainer *rawtowergeom;
 
   std::string detector;
@@ -73,12 +70,11 @@ class HcalRawTowerBuilder : public SubsysReco, public PHParameterInterface
   std::string TowerGeomNodeName;
   std::string _sim_tower_node_prefix;
 
-  double emin;	
+  double emin;
   int chkenergyconservation;
   int _tower_energy_src;
   int ncell_to_tower;
   PHTimeServer::timer _timer;
-
 };
 
 #endif /* HcalRawTowerBuilder_H__ */

--- a/simulation/g4simulation/g4calo/RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/RawTowerBuilder.cc
@@ -437,25 +437,25 @@ void RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
         {
           if (Verbosity() > 0)
           {
-            cout << "HcalRawTowerBuilder::InitRun - Tower geometry " << key << " already exists" << endl;
+            cout << "RawTowerBuilder::CreateNodes - Tower geometry " << key << " already exists" << endl;
           }
 
           if (fabs(tg->get_center_x() - x) > 1e-4)
           {
-            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
+            cout << "RawTowerBuilder::CreateNodes - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
                  << endl;
 
             exit(1);
           }
           if (fabs(tg->get_center_y() - y) > 1e-4)
           {
-            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing y = " << tg->get_center_y() << " and expected y = " << y
+            cout << "RawTowerBuilder::CreateNodes - Fatal Error - duplicated Tower geometry " << key << " with existing y = " << tg->get_center_y() << " and expected y = " << y
                  << endl;
             exit(1);
           }
           if (fabs(tg->get_center_z() - z) > 1e-4)
           {
-            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing z= " << tg->get_center_z() << " and expected z = " << z
+            cout << "RawTowerBuilder::CreateNodes - Fatal Error - duplicated Tower geometry " << key << " with existing z= " << tg->get_center_z() << " and expected z = " << z
                  << endl;
             exit(1);
           }
@@ -464,10 +464,10 @@ void RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
         {
           if (Verbosity() > 0)
           {
-            cout << "HcalRawTowerBuilder::InitRun - building tower geometry " << key << "" << endl;
+            cout << "RawTowerBuilder::CreateNodes - building tower geometry " << key << "" << endl;
           }
 
-          tg = new RawTowerGeomv1();
+          tg = new RawTowerGeomv1(key);
 
           tg->set_center_x(x);
           tg->set_center_y(y);
@@ -506,25 +506,25 @@ void RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
         {
           if (Verbosity() > 0)
           {
-            cout << "HcalRawTowerBuilder::InitRun - Tower geometry " << key << " already exists" << endl;
+            cout << "RawTowerBuilder::CreateNodes - Tower geometry " << key << " already exists" << endl;
           }
 
           if (fabs(tg->get_center_x() - x) > 1e-4)
           {
-            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
+            cout << "RawTowerBuilder::CreateNodes - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
                  << endl;
 
             exit(1);
           }
           if (fabs(tg->get_center_y() - y) > 1e-4)
           {
-            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing y = " << tg->get_center_y() << " and expected y = " << y
+            cout << "RawTowerBuilder::CreateNodes - Fatal Error - duplicated Tower geometry " << key << " with existing y = " << tg->get_center_y() << " and expected y = " << y
                  << endl;
             exit(1);
           }
           if (fabs(tg->get_center_z() - z) > 1e-4)
           {
-            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing z= " << tg->get_center_z() << " and expected z = " << z
+            cout << "RawTowerBuilder::CreateNodes - Fatal Error - duplicated Tower geometry " << key << " with existing z= " << tg->get_center_z() << " and expected z = " << z
                  << endl;
             exit(1);
           }
@@ -533,10 +533,10 @@ void RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
         {
           if (Verbosity() > 0)
           {
-            cout << "HcalRawTowerBuilder::InitRun - building tower geometry " << key << "" << endl;
+            cout << "RawTowerBuilder::CreateNodes - building tower geometry " << key << "" << endl;
           }
 
-          tg = new RawTowerGeomv1();
+          tg = new RawTowerGeomv1(key);
 
           tg->set_center_x(x);
           tg->set_center_y(y);

--- a/simulation/g4simulation/g4calo/RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/RawTowerBuilder.cc
@@ -115,7 +115,7 @@ int RawTowerBuilder::process_event(PHCompositeNode *topNode)
   if (!cells)
   {
     cout << PHWHERE << " " << cellnodename
-              << " Node missing, doing nothing." << std::endl;
+         << " Node missing, doing nothing." << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -247,7 +247,7 @@ void RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
   if (!cellgeos)
   {
     cout << PHWHERE << " " << geonodename
-              << " Node missing, doing nothing." << std::endl;
+         << " Node missing, doing nothing." << std::endl;
     throw std::runtime_error(
         "Failed to find " + geonodename + " node in RawTowerBuilder::CreateNodes");
   }
@@ -491,7 +491,6 @@ void RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
   }
 
   // Create the tower nodes on the tree
-  m_TowerContainer = new RawTowerContainer(caloid);
   if (m_SimTowerNodePrefix.empty())
   {
     // no prefix, consistent with older convention
@@ -501,8 +500,14 @@ void RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
   {
     m_TowerNodeName = "TOWER_" + m_SimTowerNodePrefix + "_" + m_Detector;
   }
-  PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(m_TowerContainer, m_TowerNodeName, "PHObject");
-  DetNode->addNode(towerNode);
+  m_TowerContainer = findNode::getClass<RawTowerContainer>(DetNode, m_TowerNodeName.c_str());
+  if (m_TowerContainer == nullptr)
+  {
+    m_TowerContainer = new RawTowerContainer(caloid);
+
+    PHIODataNode<PHObject> *towerNode = new PHIODataNode<PHObject>(m_TowerContainer, m_TowerNodeName, "PHObject");
+    DetNode->addNode(towerNode);
+  }
 
   return;
 }

--- a/simulation/g4simulation/g4calo/RawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/RawTowerBuilder.cc
@@ -425,12 +425,55 @@ void RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
     {
       for (int ieta = 0; ieta < m_RawTowerGeomContainer->get_etabins(); ieta++)
       {
-        RawTowerGeomv1 *tg = new RawTowerGeomv1(RawTowerDefs::encode_towerid(caloid, ieta, iphi));
+        const RawTowerDefs::keytype key =
+            RawTowerDefs::encode_towerid(caloid, ieta, iphi);
 
-        tg->set_center_x(r * cos(m_RawTowerGeomContainer->get_phicenter(iphi)));
-        tg->set_center_y(r * sin(m_RawTowerGeomContainer->get_phicenter(iphi)));
-        tg->set_center_z(r / tan(PHG4Utils::get_theta(m_RawTowerGeomContainer->get_etacenter(ieta))));
-        m_RawTowerGeomContainer->add_tower_geometry(tg);
+        const double x(r * cos(m_RawTowerGeomContainer->get_phicenter(iphi)));
+        const double y(r * sin(m_RawTowerGeomContainer->get_phicenter(iphi)));
+        const double z(r / tan(PHG4Utils::get_theta(m_RawTowerGeomContainer->get_etacenter(ieta))));
+
+        RawTowerGeom *tg = m_RawTowerGeomContainer->get_tower_geometry(key);
+        if (tg)
+        {
+          if (Verbosity() > 0)
+          {
+            cout << "HcalRawTowerBuilder::InitRun - Tower geometry " << key << " already exists" << endl;
+          }
+
+          if (fabs(tg->get_center_x() - x) > 1e-4)
+          {
+            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
+                 << endl;
+
+            exit(1);
+          }
+          if (fabs(tg->get_center_y() - y) > 1e-4)
+          {
+            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing y = " << tg->get_center_y() << " and expected y = " << y
+                 << endl;
+            exit(1);
+          }
+          if (fabs(tg->get_center_z() - z) > 1e-4)
+          {
+            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing z= " << tg->get_center_z() << " and expected z = " << z
+                 << endl;
+            exit(1);
+          }
+        }
+        else
+        {
+          if (Verbosity() > 0)
+          {
+            cout << "HcalRawTowerBuilder::InitRun - building tower geometry " << key << "" << endl;
+          }
+
+          tg = new RawTowerGeomv1();
+
+          tg->set_center_x(x);
+          tg->set_center_y(y);
+          tg->set_center_z(z);
+          m_RawTowerGeomContainer->add_tower_geometry(tg);
+        }
       }
     }
   }
@@ -452,13 +495,54 @@ void RawTowerBuilder::CreateNodes(PHCompositeNode *topNode)
     {
       for (int ibin = 0; ibin < first_cellgeo->get_zbins(); ibin++)
       {
-        RawTowerGeomv1 *tg = new RawTowerGeomv1(RawTowerDefs::encode_towerid(caloid, ibin, iphi));
+        const RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(caloid, ibin, iphi);
 
-        tg->set_center_x(r * cos(m_RawTowerGeomContainer->get_phicenter(iphi)));
-        tg->set_center_y(r * sin(m_RawTowerGeomContainer->get_phicenter(iphi)));
-        tg->set_center_z(first_cellgeo->get_zcenter(ibin));
+        const double x(r * cos(m_RawTowerGeomContainer->get_phicenter(iphi)));
+        const double y(r * sin(m_RawTowerGeomContainer->get_phicenter(iphi)));
+        const double z(first_cellgeo->get_zcenter(ibin));
 
-        m_RawTowerGeomContainer->add_tower_geometry(tg);
+        RawTowerGeom *tg = m_RawTowerGeomContainer->get_tower_geometry(key);
+        if (tg)
+        {
+          if (Verbosity() > 0)
+          {
+            cout << "HcalRawTowerBuilder::InitRun - Tower geometry " << key << " already exists" << endl;
+          }
+
+          if (fabs(tg->get_center_x() - x) > 1e-4)
+          {
+            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
+                 << endl;
+
+            exit(1);
+          }
+          if (fabs(tg->get_center_y() - y) > 1e-4)
+          {
+            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing y = " << tg->get_center_y() << " and expected y = " << y
+                 << endl;
+            exit(1);
+          }
+          if (fabs(tg->get_center_z() - z) > 1e-4)
+          {
+            cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing z= " << tg->get_center_z() << " and expected z = " << z
+                 << endl;
+            exit(1);
+          }
+        }
+        else
+        {
+          if (Verbosity() > 0)
+          {
+            cout << "HcalRawTowerBuilder::InitRun - building tower geometry " << key << "" << endl;
+          }
+
+          tg = new RawTowerGeomv1();
+
+          tg->set_center_x(x);
+          tg->set_center_y(y);
+          tg->set_center_z(z);
+          m_RawTowerGeomContainer->add_tower_geometry(tg);
+        }
       }
     }
   }

--- a/simulation/g4simulation/g4main/PHG4Shower.h
+++ b/simulation/g4simulation/g4main/PHG4Shower.h
@@ -63,9 +63,11 @@ public:
   virtual unsigned int get_nhits(int volume) const {return 0;}
   virtual void         set_nhits(int volume, unsigned int nhits) {}
   
+  virtual double       get_edep() const {return NAN;}
   virtual float        get_edep(int volume) const {return NAN;}
   virtual void         set_edep(int volume, float edep) {}
 
+  virtual double       get_eion() const {return NAN;}
   virtual float        get_eion(int volume) const {return NAN;}
   virtual void         set_eion(int volume, float eion) {}
 

--- a/simulation/g4simulation/g4main/PHG4Showerv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Showerv1.cc
@@ -10,27 +10,31 @@ using namespace std;
 ClassImp(PHG4Showerv1);
 
 PHG4Showerv1::PHG4Showerv1()
-    : _id(0xFFFFFFFF),
-      _parent_particle_id(0),
-      _parent_shower_id(0),
-      _pos(),
-      _covar(),
-      _edep(),
-      _eion(),
-      _light_yield(),
-      _eh_ratio(),
-      _g4particle_ids(),
-      _g4hit_ids() {
+  : _id(0xFFFFFFFF)
+  , _parent_particle_id(0)
+  , _parent_shower_id(0)
+  , _pos()
+  , _covar()
+  , _edep()
+  , _eion()
+  , _light_yield()
+  , _eh_ratio()
+  , _g4particle_ids()
+  , _g4hit_ids()
+{
   for (int i = 0; i < 3; ++i) _pos[i] = NAN;
 
-  for (int j = 0; j < 3; ++j) {
-    for (int i = j; i < 3; ++i) {
+  for (int j = 0; j < 3; ++j)
+  {
+    for (int i = j; i < 3; ++i)
+    {
       set_covar(i, j, NAN);
     }
   }
 }
 
-void PHG4Showerv1::identify(ostream &os) const {
+void PHG4Showerv1::identify(ostream &os) const
+{
   os << "---PHG4Showerv1-------------------------------" << endl;
   os << "id: " << get_id() << endl;
   os << "parent_particle_id: " << get_parent_particle_id() << endl;
@@ -54,7 +58,8 @@ void PHG4Showerv1::identify(ostream &os) const {
 
   os << "VOLUME ID : edep eion light_yield" << endl;
   for (std::map<int, float>::const_iterator iter = _edep.begin();
-       iter != _edep.end(); ++iter) {
+       iter != _edep.end(); ++iter)
+  {
     int volid = iter->first;
     os << volid << " : " << get_edep(volid) << " " << get_eion(volid) << " "
        << get_light_yield(volid) << endl;
@@ -62,7 +67,8 @@ void PHG4Showerv1::identify(ostream &os) const {
 
   os << "G4Particle IDs" << endl;
   for (std::set<int>::const_iterator iter = _g4particle_ids.begin();
-       iter != _g4particle_ids.end(); ++iter) {
+       iter != _g4particle_ids.end(); ++iter)
+  {
     os << *iter << " ";
   }
   os << endl;
@@ -70,10 +76,12 @@ void PHG4Showerv1::identify(ostream &os) const {
   os << "G4Hit IDs" << endl;
   for (std::map<int, std::set<PHG4HitDefs::keytype> >::const_iterator iter =
            _g4hit_ids.begin();
-       iter != _g4hit_ids.end(); ++iter) {
+       iter != _g4hit_ids.end(); ++iter)
+  {
     for (std::set<PHG4HitDefs::keytype>::const_iterator jter =
              iter->second.begin();
-         jter != iter->second.end(); ++jter) {
+         jter != iter->second.end(); ++jter)
+    {
       os << *jter << " ";
     }
   }
@@ -84,15 +92,19 @@ void PHG4Showerv1::identify(ostream &os) const {
   return;
 }
 
-int PHG4Showerv1::isValid() const {
+int PHG4Showerv1::isValid() const
+{
   if (_id == 0)
     return 0;
-  for (int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 3; ++i)
+  {
     if (isnan(_pos[i]))
       return 0;
   }
-  for (int j = 0; j < 3; ++j) {
-    for (int i = j; i < 3; ++i) {
+  for (int j = 0; j < 3; ++j)
+  {
+    for (int i = j; i < 3; ++i)
+    {
       if (isnan(get_covar(i, j)))
         return 0;
     }
@@ -100,22 +112,26 @@ int PHG4Showerv1::isValid() const {
   return 1;
 }
 
-void PHG4Showerv1::set_covar(unsigned int i, unsigned int j, float value) {
+void PHG4Showerv1::set_covar(unsigned int i, unsigned int j, float value)
+{
   _covar[covar_index(i, j)] = value;
   return;
 }
 
-float PHG4Showerv1::get_covar(unsigned int i, unsigned int j) const {
+float PHG4Showerv1::get_covar(unsigned int i, unsigned int j) const
+{
   return _covar[covar_index(i, j)];
 }
 
-unsigned int PHG4Showerv1::covar_index(unsigned int i, unsigned int j) const {
+unsigned int PHG4Showerv1::covar_index(unsigned int i, unsigned int j) const
+{
   if (i > j)
     std::swap(i, j);
   return i + 1 + (j + 1) * (j) / 2 - 1;
 }
 
-unsigned int PHG4Showerv1::get_nhits(int volume) const {
+unsigned int PHG4Showerv1::get_nhits(int volume) const
+{
   std::map<int, unsigned int>::const_iterator citer =
       _nhits.find(volume);
   if (citer == _nhits.end())
@@ -123,7 +139,8 @@ unsigned int PHG4Showerv1::get_nhits(int volume) const {
   return citer->second;
 }
 
-float PHG4Showerv1::get_edep(int volume) const {
+float PHG4Showerv1::get_edep(int volume) const
+{
   std::map<int, float>::const_iterator citer =
       _edep.find(volume);
   if (citer == _edep.end())
@@ -131,7 +148,18 @@ float PHG4Showerv1::get_edep(int volume) const {
   return citer->second;
 }
 
-float PHG4Showerv1::get_eion(int volume) const {
+double PHG4Showerv1::get_edep() const
+{
+  double sum = 0;
+  for (const auto &iter : _edep)
+  {
+    sum += iter.second;
+  }
+  return sum;
+}
+
+float PHG4Showerv1::get_eion(int volume) const
+{
   std::map<int, float>::const_iterator citer =
       _eion.find(volume);
   if (citer == _eion.end())
@@ -139,7 +167,18 @@ float PHG4Showerv1::get_eion(int volume) const {
   return citer->second;
 }
 
-float PHG4Showerv1::get_light_yield(int volume) const {
+double PHG4Showerv1::get_eion() const
+{
+  double sum = 0;
+  for (const auto &iter : _eion)
+  {
+    sum += iter.second;
+  }
+  return sum;
+}
+
+float PHG4Showerv1::get_light_yield(int volume) const
+{
   std::map<int, float>::const_iterator citer =
       _light_yield.find(volume);
   if (citer == _light_yield.end())
@@ -147,7 +186,8 @@ float PHG4Showerv1::get_light_yield(int volume) const {
   return citer->second;
 }
 
-float PHG4Showerv1::get_eh_ratio(int volume) const {
+float PHG4Showerv1::get_eh_ratio(int volume) const
+{
   std::map<int, float>::const_iterator citer =
       _eh_ratio.find(volume);
   if (citer == _eh_ratio.end())

--- a/simulation/g4simulation/g4main/PHG4Showerv1.h
+++ b/simulation/g4simulation/g4main/PHG4Showerv1.h
@@ -53,9 +53,11 @@ public:
   unsigned int get_nhits(int volume) const;
   void         set_nhits(int volume, unsigned int nhits) {_nhits[volume] = nhits;}
   
+  double       get_edep() const ;
   float        get_edep(int volume) const;
   void         set_edep(int volume, float edep) {_edep[volume] = edep;}
 
+  double       set_eion() const ;
   float        get_eion(int volume) const;
   void         set_eion(int volume, float eion) {_eion[volume] = eion;}
 

--- a/simulation/g4simulation/g4main/PHG4Showerv1.h
+++ b/simulation/g4simulation/g4main/PHG4Showerv1.h
@@ -57,7 +57,7 @@ public:
   float        get_edep(int volume) const;
   void         set_edep(int volume, float edep) {_edep[volume] = edep;}
 
-  double       set_eion() const ;
+  double       get_eion() const ;
   float        get_eion(int volume) const;
   void         set_eion(int volume, float eion) {_eion[volume] = eion;}
 

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -310,8 +310,11 @@ void PHG4TruthEventAction::PruneShowers() {
     PHG4Shower* shower = iter->second;
 
     if (shower->empty_g4particle_id() && shower->empty_g4hit_id()) {
-      truthInfoList_->delete_shower(iter++);
-      continue;
+      if (shower ->get_edep() == 0) // check whether this shower has already been processed in the previous simulation cycles
+      {
+        truthInfoList_->delete_shower(iter++);
+        continue;
+      }
     }
 
     ++iter;


### PR DESCRIPTION
Cumulative fixes for analyzing jet background production data, which is the first time we strip hits, save calorimeter towers-only then perform embedding simulation on top again. 

Specific changes are
- Allow the embedding process to append simulation tower energy rather than overwrite it
- During the embedding process, check whether tower geometry would be consistent. If pass check, avoiding the warning message of overwriting tower geometry
- In the embedding process, avoid pruning the `PHG4Shower` objects produced the previous background simulation and preserve truth tracing for the background towers and showers. 
- [clang-format the source code](https://wiki.bnl.gov/sPHENIX/index.php/Codingconventions#Style_reformatting_tools)