### PR TITLE
return mass in GeV, not internal G4 units

### DIFF
--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
@@ -17,6 +17,7 @@
 
 #include <Geant4/G4ParticleDefinition.hh>
 #include <Geant4/G4ParticleTable.hh>
+#include <Geant4/G4SystemOfUnits.hh>
 
 #include <gsl/gsl_rng.h>
 #include <cassert>
@@ -81,7 +82,7 @@ PHG4ParticleGeneratorBase::get_mass(const int pdgcode) const
   G4ParticleDefinition *particledef = particleTable->FindParticle(get_pdgname(pdgcode));
   if (particledef)
   {
-    return particledef->GetPDGMass();
+    return particledef->GetPDGMass()/GeV;
   }
   return 0;
 }


### PR DESCRIPTION
Thanks to Mickey for finding this - the get_mass() method returned internal G4 units (which is MeV), now returns the mass in GeV which is our standard