### PR TITLE
use vector.ad() rather than [] to catch possible out of bounds condition

### DIFF
--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -565,19 +565,33 @@ int Fun4AllServer::process_event()
       {
 	cout << "could not find timer for " << timer_name << endl;
       }
-      RetCodes[icnt] = (*iter).first->process_event((*iter).second);
+      int retcode = (*iter).first->process_event((*iter).second);
+// we have observed an index overflow in RetCodes. I assume it is some
+// memory corruption elsewhere which hits the icnt variable. Rather than
+// the previous [], use at() which does bounds checking and throws an 
+// exception which will allow us to catch this and print out icnt and the size
+      try
+      {
+	RetCodes.at(icnt) = retcode;
+      }
+      catch (const exception &e)
+      {
+	cout << PHWHERE << " caught exception thrown during RetCodes.at(icnt)" << endl;
+	cout << "RetCodes.size(): " << RetCodes.size() << ", icnt: " << icnt << endl;
+	cout << "error: " << e.what() << endl;
+	gSystem->Exit(1);
+      }
       if (timer_found)
       {
 	titer->second.stop();
       }
-
     }
     catch (const exception &e)
     {
       cout << PHWHERE << " caught exception thrown during process_event from "
            << (*iter).first->Name() << endl;
       cout << "error: " << e.what() << endl;
-      exit(1);
+      gSystem->Exit(1);
     }
     catch (...)
     {


### PR DESCRIPTION
We have rare crashes and valgrind blames an invalid read in
    if (RetCodes[icnt])
for this. This PR uses .at() in the previous insert at icnt inside a try/catch block. The handling of the RetCodes vector looks clean, this will allow us to print out the values of icnt and the vector size in case of out of bounds conditions, hopefully shedding some light on this