### PR TITLE
Fix insure complaints

### DIFF
--- a/offline/framework/phool/PHTimeServer.h
+++ b/offline/framework/phool/PHTimeServer.h
@@ -13,6 +13,7 @@
 #include "PHTimer.h"
 
 #include <iostream>
+#include <memory>
 #include <map>
 #include <string>
 
@@ -54,7 +55,7 @@ class PHTimeServer
 
    private:
 #ifndef __CINT__
-    boost::shared_ptr<PHTimer> _timer;
+    std::shared_ptr<PHTimer> _timer;
 #endif
     unsigned short _uid;
   };

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -51,7 +51,7 @@ void PHG4BlockDetector::Construct(G4LogicalVolume *logicWorld)
     exit(-1);
   }
 
-  G4VSolid *block_solid = new G4Box(G4String(GetName().c_str()),
+  G4VSolid *block_solid = new G4Box(G4String(GetName()),
                                     m_Params->get_double_param("size_x") / 2. * cm,
                                     m_Params->get_double_param("size_y") / 2. * cm,
                                     m_Params->get_double_param("size_z") / 2. * cm);
@@ -65,7 +65,7 @@ void PHG4BlockDetector::Construct(G4LogicalVolume *logicWorld)
 
   G4LogicalVolume *block_logic = new G4LogicalVolume(block_solid,
                                                      TrackerMaterial,
-                                                     G4String(GetName().c_str()),
+                                                     G4String(GetName()),
                                                      nullptr, nullptr, g4userlimits);
   G4VisAttributes matVis;
   if (m_Params->get_int_param("blackhole"))
@@ -86,6 +86,6 @@ void PHG4BlockDetector::Construct(G4LogicalVolume *logicWorld)
   rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
   m_BlockPhysi = new G4PVPlacement(rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm),
                                    block_logic,
-                                   G4String(GetName().c_str()),
+                                   G4String(GetName()),
                                    logicWorld, 0, false, OverlapCheck());
 }

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
@@ -52,20 +52,20 @@ int PHG4BlockSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     }
 
     // create hit list
-    PHG4HitContainer *block_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+    PHG4HitContainer *block_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str());
     if (!block_hits)
     {
-      dstNode->addNode(new PHIODataNode<PHObject>(block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject"));
+      dstNode->addNode(new PHIODataNode<PHObject>(block_hits = new PHG4HitContainer(nodename.str()), nodename.str(), "PHObject"));
     }
 
     block_hits->AddLayer(GetLayer());
     PHG4BlockGeomContainer *geocont = findNode::getClass<PHG4BlockGeomContainer>(topNode,
-                                                                                 geonode.str().c_str());
+                                                                                 geonode.str());
     if (!geocont)
     {
       geocont = new PHG4BlockGeomContainer();
       PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geocont, geonode.str().c_str(), "PHObject");
+      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geocont, geonode.str(), "PHObject");
       runNode->addNode(newNode);
     }
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -70,7 +70,7 @@ void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
   // determine length of cylinder using PHENIX's rapidity coverage if flag is true
   double radius = params->get_double_param("radius") * cm;
   double thickness = params->get_double_param("thickness") * cm;
-  G4VSolid *cylinder_solid = new G4Tubs(G4String(GetName().c_str()),
+  G4VSolid *cylinder_solid = new G4Tubs(G4String(GetName()),
                                         radius,
                                         radius + thickness,
                                         params->get_double_param("length") * cm / 2., 0, twopi);
@@ -83,13 +83,13 @@ void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
 
   G4LogicalVolume *cylinder_logic = new G4LogicalVolume(cylinder_solid,
                                                         TrackerMaterial,
-                                                        G4String(GetName().c_str()),
+                                                        G4String(GetName()),
                                                         nullptr, nullptr, g4userlimits);
   cylinder_logic->SetVisAttributes(siliconVis);
   cylinder_physi = new G4PVPlacement(0, G4ThreeVector(params->get_double_param("place_x") * cm,
                                                       params->get_double_param("place_y") * cm,
                                                       params->get_double_param("place_z") * cm),
                                      cylinder_logic,
-                                     G4String(GetName().c_str()),
+                                     G4String(GetName()),
                                      logicWorld, 0, false, OverlapCheck());
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -77,17 +77,17 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
       nodename << "G4HIT_" << Name();
       geonode << "CYLINDERGEOM_" << Name();
     }
-    PHG4HitContainer *cylinder_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+    PHG4HitContainer *cylinder_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str());
     if (!cylinder_hits)
     {
-      dstNode->addNode(new PHIODataNode<PHObject>(cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject"));
+      dstNode->addNode(new PHIODataNode<PHObject>(cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str(), "PHObject"));
     }
     cylinder_hits->AddLayer(GetLayer());
-    PHG4CylinderGeomContainer *geo = findNode::getClass<PHG4CylinderGeomContainer>(topNode, geonode.str().c_str());
+    PHG4CylinderGeomContainer *geo = findNode::getClass<PHG4CylinderGeomContainer>(topNode, geonode.str());
     if (!geo)
     {
       geo = new PHG4CylinderGeomContainer();
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geo, geonode.str().c_str(), "PHObject");
+      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geo, geonode.str(), "PHObject");
       runNode->addNode(newNode);
     }
     PHG4CylinderGeom *mygeom = new PHG4CylinderGeomv1(GetParams()->get_double_param("radius"), GetParams()->get_double_param("place_z") - detlength / 2., GetParams()->get_double_param("place_z") + detlength / 2., GetParams()->get_double_param("thickness"));

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
@@ -35,7 +35,7 @@ PHG4DetectorSubsystem::PHG4DetectorSubsystem(const std::string &name, const int 
   // for multiple layers
   ostringstream nam;
   nam << name << "_" << lyr;
-  Name(nam.str().c_str());
+  Name(nam.str());
 }
 
 int 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -347,7 +347,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
       G4Transform3D wall_trans = G4TranslateZ3D(val.second);
 
       G4PVPlacement* wall_phys = new G4PVPlacement(wall_trans, wall_logic,
-                                                   G4String(GetName().c_str()) + G4String("_EndWall_") + to_string(val.first), sec_logic,
+                                                   G4String(GetName()) + G4String("_EndWall_") + to_string(val.first), sec_logic,
                                                    false, val.first, OverlapCheck());
 
       calo_vol[wall_phys] = val.first;
@@ -411,7 +411,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
           G4TranslateX3D(-sign_azimuth * (get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_sidewall_outer_torr() * cm));
 
       G4PVPlacement* wall_phys = new G4PVPlacement(wall_trans, wall_logic,
-                                                   G4String(GetName().c_str()) + G4String("_SideWall_") + to_string(val.first), sec_logic,
+                                                   G4String(GetName()) + G4String("_SideWall_") + to_string(val.first), sec_logic,
                                                    false, val.first, OverlapCheck());
 
       calo_vol[wall_phys] = val.first;
@@ -460,7 +460,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
             G4TranslateZ3D(sign_z * (get_geom_v3()->get_length() * cm / 4));
 
         G4PVPlacement* wall_phys = new G4PVPlacement(wall_trans, wall_logic,
-                                                     G4String(GetName().c_str()) + G4String("_Divider_") + to_string(ID), sec_logic,
+                                                     G4String(GetName()) + G4String("_Divider_") + to_string(ID), sec_logic,
                                                      false, ID, OverlapCheck());
 
         calo_vol[wall_phys] = ID;
@@ -504,7 +504,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
     const bool overlapcheck_block = OverlapCheck() and (get_geom_v3()->get_construction_verbose() >= 2);
 
     G4PVPlacement* block_phys = new G4PVPlacement(block_trans, LV_tower,
-                                                  G4String(GetName().c_str()) + G4String("_Tower_") + to_string(g_tower.id), sec_logic, false,
+                                                  G4String(GetName()) + G4String("_Tower_") + to_string(g_tower.id), sec_logic, false,
                                                   g_tower.id, overlapcheck_block);
     block_vol[block_phys] = g_tower.id;
     assert(gdml_config);
@@ -662,7 +662,7 @@ int PHG4FullProjTiltedSpacalDetector::Construct_Fibers_SameLengthFiberPerTower(
 
     const bool overlapcheck_fiber = OverlapCheck() and (get_geom_v3()->get_construction_verbose() >= 3);
     G4PVPlacement* fiber_physi = new G4PVPlacement(fiber_place, fiber_logic,
-                                                   G4String(name.str().c_str()), LV_tower, false, fiber_ID,
+                                                   G4String(name.str()), LV_tower, false, fiber_ID,
                                                    overlapcheck_fiber);
     fiber_vol[fiber_physi] = fiber_ID;
     assert(gdml_config);
@@ -764,7 +764,7 @@ int PHG4FullProjTiltedSpacalDetector::Construct_Fibers(
 
       const bool overlapcheck_fiber = OverlapCheck() and (get_geom_v3()->get_construction_verbose() >= 3);
       G4PVPlacement* fiber_physi = new G4PVPlacement(fiber_place,
-                                                     fiber_logic, G4String(name.str().c_str()), LV_tower, false,
+                                                     fiber_logic, G4String(name.str()), LV_tower, false,
                                                      fiber_ID, overlapcheck_fiber);
       fiber_vol[fiber_physi] = fiber_ID;
       assert(gdml_config);
@@ -796,7 +796,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_Tower(
   //Processed PostionSeeds 1 from 1 1
 
   G4Trap* block_solid = new G4Trap(
-      /*const G4String& pName*/ G4String(GetName().c_str()) + sTowerID,
+      /*const G4String& pName*/ G4String(GetName()) + sTowerID,
       g_tower.pDz * cm,                                         // G4double pDz,
       g_tower.pTheta * rad, g_tower.pPhi * rad,                 // G4double pTheta, G4double pPhi,
       g_tower.pDy1 * cm, g_tower.pDx1 * cm, g_tower.pDx2 * cm,  // G4double pDy1, G4double pDx1, G4double pDx2,
@@ -898,7 +898,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_LightGuide(
                                (-g_tower.NSubtowerY + 1. + 2 * index_y) / (double) (g_tower.NSubtowerY);
 
   G4VSolid* block_solid = new G4Trap(
-      /*const G4String& pName*/ G4String(GetName().c_str()) + sTowerID,
+      /*const G4String& pName*/ G4String(GetName()) + sTowerID,
       0.5 * g_tower.LightguideHeight * cm,  // G4double pDz,
       0 * rad, 0 * rad,                     // G4double pTheta, G4double pPhi,
       g_tower.LightguideTaperRatio * lg_pDy1 * cm,

--- a/simulation/g4simulation/g4detectors/PHG4MapsSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4MapsSubsystem.cc
@@ -45,7 +45,7 @@ PHG4MapsSubsystem::PHG4MapsSubsystem( const std::string &name, const int lyr, in
   // for multiple layers
   ostringstream nam;
   nam << name << "_" << lyr;
-  Name(nam.str().c_str());
+  Name(nam.str());
 //  for (int i = 0; i < 3; i++)
 //    {
 //      dimension[i] = 100.0 * cm;
@@ -103,11 +103,11 @@ int PHG4MapsSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 	  nodename <<  "G4HIT_" << detector_type << "_" << layer;
 	}
       // create hit list
-      PHG4HitContainer* block_hits =  findNode::getClass<PHG4HitContainer>( topNode , nodename.str().c_str());
+      PHG4HitContainer* block_hits =  findNode::getClass<PHG4HitContainer>( topNode , nodename.str());
       if ( !block_hits )
 	{
 
-	  dstNode->addNode( new PHIODataNode<PHObject>( block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject" ));
+	  dstNode->addNode( new PHIODataNode<PHObject>( block_hits = new PHG4HitContainer(nodename.str()), nodename.str(), "PHObject" ));
 
 	}
       if (Verbosity())
@@ -125,11 +125,11 @@ int PHG4MapsSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 	    {
 	      nodename <<  "G4HIT_ABSORBER_" << detector_type << "_" << layer;
 	    }
-	  block_hits =  findNode::getClass<PHG4HitContainer>( topNode , nodename.str().c_str());
+	  block_hits =  findNode::getClass<PHG4HitContainer>( topNode , nodename.str());
 	  if ( !block_hits )
 	    {
 
-	      dstNode->addNode( new PHIODataNode<PHObject>( block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject" ));
+	      dstNode->addNode( new PHIODataNode<PHObject>( block_hits = new PHG4HitContainer(nodename.str()), nodename.str(), "PHObject" ));
 
 	    }
 	  eventaction->AddNode(nodename.str());

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -140,7 +140,7 @@ void PHG4SpacalDetector::Construct(G4LogicalVolume *logicWorld)
     exit(-1);
   }
 
-  G4Tubs *_cylinder_solid = new G4Tubs(G4String(GetName().c_str()),
+  G4Tubs *_cylinder_solid = new G4Tubs(G4String(GetName()),
                                        _geom->get_radius() * cm, _geom->get_max_radius() * cm,
                                        _geom->get_length() * cm / 2.0, 0, twopi);
 
@@ -150,7 +150,7 @@ void PHG4SpacalDetector::Construct(G4LogicalVolume *logicWorld)
   assert(cylinder_mat);
 
   cylinder_logic = new G4LogicalVolume(cylinder_solid, cylinder_mat,
-                                       G4String(GetName().c_str()), 0, 0, 0);
+                                       G4String(GetName()), 0, 0, 0);
   G4VisAttributes *VisAtt = new G4VisAttributes();
   PHG4Utils::SetColour(VisAtt, "W_Epoxy");
   VisAtt->SetVisibility(true);
@@ -160,7 +160,7 @@ void PHG4SpacalDetector::Construct(G4LogicalVolume *logicWorld)
   cylinder_physi = new G4PVPlacement(0,
                                      G4ThreeVector(_geom->get_xpos() * cm, _geom->get_ypos() * cm,
                                                    _geom->get_zpos() * cm),
-                                     cylinder_logic, G4String(GetName().c_str()),
+                                     cylinder_logic, G4String(GetName()),
                                      logicWorld, false, 0, OverlapCheck());
 
   // install sectors
@@ -188,7 +188,7 @@ void PHG4SpacalDetector::Construct(G4LogicalVolume *logicWorld)
     name << GetName() << "_sec" << sec;
 
     G4PVPlacement *calo_phys = new G4PVPlacement(sec_place, sec_logic,
-                                                 G4String(name.str().c_str()), cylinder_logic, false, sec,
+                                                 G4String(name.str()), cylinder_logic, false, sec,
                                                  OverlapCheck());
     calo_vol[calo_phys] = sec;
 
@@ -209,7 +209,7 @@ void PHG4SpacalDetector::Construct(G4LogicalVolume *logicWorld)
       geonode << "CYLINDERGEOM_" << detector_type << "_" << layer;
     }
     PHG4CylinderGeomContainer *geo = findNode::getClass<
-        PHG4CylinderGeomContainer>(topNode(), geonode.str().c_str());
+        PHG4CylinderGeomContainer>(topNode(), geonode.str());
     if (!geo)
     {
       geo = new PHG4CylinderGeomContainer();
@@ -218,7 +218,7 @@ void PHG4SpacalDetector::Construct(G4LogicalVolume *logicWorld)
           dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode",
                                                          "RUN"));
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geo,
-                                                                   geonode.str().c_str(), "PHObject");
+                                                                   geonode.str(), "PHObject");
       runNode->addNode(newNode);
     }
     // here in the detector class we have internal units, convert to cm
@@ -240,7 +240,7 @@ void PHG4SpacalDetector::Construct(G4LogicalVolume *logicWorld)
       geonode << "CYLINDERGEOM_ABSORBER_" << detector_type << "_" << layer;
     }
     PHG4CylinderGeomContainer *geo = findNode::getClass<
-        PHG4CylinderGeomContainer>(topNode(), geonode.str().c_str());
+        PHG4CylinderGeomContainer>(topNode(), geonode.str());
     if (!geo)
     {
       geo = new PHG4CylinderGeomContainer();
@@ -249,7 +249,7 @@ void PHG4SpacalDetector::Construct(G4LogicalVolume *logicWorld)
           dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode",
                                                          "RUN"));
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geo,
-                                                                   geonode.str().c_str(), "PHObject");
+                                                                   geonode.str(), "PHObject");
       runNode->addNode(newNode);
     }
     // here in the detector class we have internal units, convert to cm
@@ -304,7 +304,7 @@ PHG4SpacalDetector::Construct_AzimuthalSeg()
     name << GetName() << "_fiber_" << fiber_count;
 
     G4PVPlacement *fiber_physi = new G4PVPlacement(fiber_place, fiber_logic,
-                                                   G4String(name.str().c_str()), sec_logic, false, fiber_count,
+                                                   G4String(name.str()), sec_logic, false, fiber_count,
                                                    OverlapCheck());
     fiber_vol[fiber_physi] = fiber_count;
     assert(gdml_config);

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeDetector.cc
@@ -199,11 +199,11 @@ PHG4SpacalPrototypeDetector::Construct(G4LogicalVolume* logicWorld)
 
       G4Transform3D sec_place = G4RotateZ3D(rot) * sec_trans;
 
-      stringstream name;
+      ostringstream name;
       name << GetName() << "_sec" << sec;
 
-      G4PVPlacement * calo_phys = new G4PVPlacement(sec_place, sec_logic,
-          G4String(name.str().c_str()), cylinder_logic, false, sec,
+      G4PVPlacement *calo_phys = new G4PVPlacement(sec_place, sec_logic,
+          G4String(name.str()), cylinder_logic, false, sec,
           OverlapCheck());
       calo_vol[calo_phys] = sec;
 
@@ -298,7 +298,7 @@ PHG4SpacalPrototypeDetector::Construct(G4LogicalVolume* logicWorld)
           geonode << "CYLINDERGEOM_" << detector_type;
         }
       PHG4CylinderGeomContainer *geo = findNode::getClass<
-          PHG4CylinderGeomContainer>(topNode(), geonode.str().c_str());
+          PHG4CylinderGeomContainer>(topNode(), geonode.str());
       if (!geo)
         {
           geo = new PHG4CylinderGeomContainer();
@@ -307,7 +307,7 @@ PHG4SpacalPrototypeDetector::Construct(G4LogicalVolume* logicWorld)
               dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",
                   "RUN"));
           PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geo,
-              geonode.str().c_str(), "PHObject");
+              geonode.str(), "PHObject");
           runNode->addNode(newNode);
         }
       // here in the detector class we have internal units, convert to cm
@@ -334,8 +334,7 @@ PHG4SpacalPrototypeDetector::Construct(G4LogicalVolume* logicWorld)
         {
           geonode << "CYLINDERGEOM_ABSORBER_" << detector_type << "_" << 0;
         }
-      PHG4CylinderGeomContainer *geo = findNode::getClass<
-          PHG4CylinderGeomContainer>(topNode(), geonode.str().c_str());
+      PHG4CylinderGeomContainer *geo = findNode::getClass<PHG4CylinderGeomContainer>(topNode(), geonode.str());
       if (!geo)
         {
           geo = new PHG4CylinderGeomContainer();
@@ -343,8 +342,7 @@ PHG4SpacalPrototypeDetector::Construct(G4LogicalVolume* logicWorld)
           PHCompositeNode *runNode =
               dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode",
                   "RUN"));
-          PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geo,
-              geonode.str().c_str(), "PHObject");
+          PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(geo,geonode.str(), "PHObject");
           runNode->addNode(newNode);
         }
       // here in the detector class we have internal units, convert to cm
@@ -734,7 +732,7 @@ PHG4SpacalPrototypeDetector::Construct_Fibers_SameLengthFiberPerTower(
   const G4double fiber_length = min_fiber_length;
   vector<G4double> fiber_cut;
 
-  stringstream ss;
+  ostringstream ss;
   ss << string("_Tower") << g_tower.id;
   G4LogicalVolume *fiber_logic = Construct_Fiber(fiber_length, ss.str());
 
@@ -781,14 +779,14 @@ PHG4SpacalPrototypeDetector::Construct_Fibers_SameLengthFiberPerTower(
           G4Translate3D(center_fiber.x(), center_fiber.y(), center_fiber.z())
               * G4Rotate3D(rotation_angle, rotation_axis));
 
-      stringstream name;
+      ostringstream name;
       name << GetName() + string("_Tower") << g_tower.id << "_fiber"
           << ss.str();
 
       const bool overlapcheck_fiber = OverlapCheck()
           and (_geom->get_construction_verbose() >= 3);
       G4PVPlacement * fiber_physi = new G4PVPlacement(fiber_place, fiber_logic,
-          G4String(name.str().c_str()), LV_tower, false, fiber_ID,
+          G4String(name.str()), LV_tower, false, fiber_ID,
           overlapcheck_fiber);
       fiber_vol[fiber_physi] = fiber_ID;
 
@@ -822,7 +820,7 @@ PHG4SpacalPrototypeDetector::Construct_Tower(
       g_tower.identify(cout);
     }
 
-  std::stringstream sout;
+  std::ostringstream sout;
   sout << "_" << g_tower.id;
   const G4String sTowerID(sout.str());
 
@@ -875,7 +873,7 @@ PHG4SpacalPrototypeDetector::Construct_LightGuide(
 {
   assert(_geom);
 
-  std::stringstream sout;
+  std::ostringstream sout;
   sout << "_Lightguide_" << g_tower.id << "_" << index_x << "_" << index_y;
   const G4String sTowerID(sout.str());
 

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
@@ -66,13 +66,13 @@ PHG4SpacalPrototypeSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
           nodename << "G4HIT_" << Name();
         }
       PHG4HitContainer* cylinder_hits = findNode::getClass<PHG4HitContainer>(
-          topNode, nodename.str().c_str());
+          topNode, nodename.str());
       if (!cylinder_hits)
         {
           dstNode->addNode(
               new PHIODataNode<PHObject>(
                   cylinder_hits = new PHG4HitContainer(nodename.str()),
-                  nodename.str().c_str(), "PHObject"));
+                  nodename.str(), "PHObject"));
         }
       cylinder_hits->AddLayer(0);
       if (GetParams()->get_int_param("absorberactive"))
@@ -87,14 +87,11 @@ PHG4SpacalPrototypeSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
               nodename << "G4HIT_ABSORBER_" << Name();
             }
           PHG4HitContainer* cylinder_hits =
-              findNode::getClass<PHG4HitContainer>(topNode,
-                  nodename.str().c_str());
+              findNode::getClass<PHG4HitContainer>(topNode,nodename.str());
           if (!cylinder_hits)
             {
-              dstNode->addNode(
-                  new PHIODataNode<PHObject>(cylinder_hits =
-                      new PHG4HitContainer(nodename.str()),
-                      nodename.str().c_str(), "PHObject"));
+	      cylinder_hits =  new PHG4HitContainer(nodename.str());
+              dstNode->addNode(new PHIODataNode<PHObject>(cylinder_hits, nodename.str(), "PHObject"));
             }
           cylinder_hits->AddLayer(0);
         }

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -100,10 +100,10 @@ int PHG4SpacalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
     {
       nodename << "G4HIT_" <<  Name() << "_" << GetLayer();
     }
-    PHG4HitContainer* cylinder_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+    PHG4HitContainer* cylinder_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str());
     if (!cylinder_hits)
     {
-      dstNode->addNode(new PHIODataNode<PHObject>(cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject"));
+      dstNode->addNode(new PHIODataNode<PHObject>(cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str(), "PHObject"));
     }
     cylinder_hits->AddLayer(GetLayer());
     if (GetParams()->get_int_param("absorberactive"))
@@ -117,10 +117,10 @@ int PHG4SpacalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
       {
         nodename << "G4HIT_ABSORBER_" << Name() << "_" << GetLayer();
       }
-      PHG4HitContainer* cylinder_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+      PHG4HitContainer* cylinder_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str());
       if (!cylinder_hits)
       {
-        dstNode->addNode(new PHIODataNode<PHObject>(cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject"));
+        dstNode->addNode(new PHIODataNode<PHObject>(cylinder_hits = new PHG4HitContainer(nodename.str()), nodename.str(), "PHObject"));
       }
       cylinder_hits->AddLayer(GetLayer());
     }

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -139,7 +139,6 @@ PHG4Reco::PHG4Reco(const string &name)
   , force_decay_type_(kAll)
   , save_DST_geometry_(true)
   , m_disableUserActions(false)
-  , _timer(PHTimeServer::get()->insert_new(name))
 {
   for (int i = 0; i < 3; i++)
   {
@@ -347,7 +346,10 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
 
   BOOST_FOREACH (PHG4Subsystem *g4sub, subsystems_)
   {
-    detector_->AddDetector(g4sub->GetDetector());
+    if (g4sub->GetDetector())
+    {
+      detector_->AddDetector(g4sub->GetDetector());
+    }
   }
   runManager_->SetUserInitialization(detector_);
 
@@ -585,8 +587,6 @@ int PHG4Reco::process_event(PHCompositeNode *topNode)
     }
   }
 
-  _timer.get()->restart();
-
   // run one event
   if (Verbosity() >= 2)
   {
@@ -595,7 +595,6 @@ int PHG4Reco::process_event(PHCompositeNode *topNode)
     ineve->identify();
   }
   runManager_->BeamOn(1);
-  _timer.get()->stop();
 
   BOOST_FOREACH (PHG4Subsystem *g4sub, subsystems_)
   {

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -1,13 +1,11 @@
-#ifndef PHG4Reco_h
-#define PHG4Reco_h
+#ifndef G4MAIN_PHG4RECO_H
+#define G4MAIN_PHG4RECO_H
 
 #include <g4decayer/EDecayType.hh>
 
 #include <fun4all/SubsysReco.h>
 
 #include <phfield/PHFieldConfig.h>
-
-#include <phool/PHTimeServer.h>
 
 #include <list>
 
@@ -188,8 +186,6 @@ class PHG4Reco : public SubsysReco
   bool save_DST_geometry_;
   bool m_disableUserActions;
 
-  //! module timer.
-  PHTimeServer::timer _timer;
 };
 
 #endif

--- a/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCDetector.cc
@@ -202,7 +202,7 @@ int PHG4TPCDetector::ConstructTPCCageVolume(G4LogicalVolume *tpc_envelope)
     name.str("");
     int layerno = i + 1;
     name << "tpc_cage_layer_" << layerno;
-    G4VSolid *tpc_cage_layer = new G4Tubs(name.str().c_str(), tpc_cage_radius, tpc_cage_radius + thickness[i], params->get_double_param("tpc_length") * cm / 2., 0., 2 * M_PI);
+    G4VSolid *tpc_cage_layer = new G4Tubs(name.str(), tpc_cage_radius, tpc_cage_radius + thickness[i], params->get_double_param("tpc_length") * cm / 2., 0., 2 * M_PI);
     G4LogicalVolume *tpc_cage_layer_logic = new G4LogicalVolume(tpc_cage_layer,
                                                                 G4Material::GetMaterial(material[i]),
                                                                 name.str());
@@ -225,10 +225,10 @@ int PHG4TPCDetector::ConstructTPCCageVolume(G4LogicalVolume *tpc_envelope)
     name.str("");
     int layerno = 10 + 1 + i;  // so the accompanying inner layer is layer - 10
     name << "tpc_cage_layer_" << layerno;
-    G4VSolid *tpc_cage_layer = new G4Tubs(name.str().c_str(), tpc_cage_radius, tpc_cage_radius + thickness[i], params->get_double_param("tpc_length") * cm / 2., 0., 2 * M_PI);
+    G4VSolid *tpc_cage_layer = new G4Tubs(name.str(), tpc_cage_radius, tpc_cage_radius + thickness[i], params->get_double_param("tpc_length") * cm / 2., 0., 2 * M_PI);
     G4LogicalVolume *tpc_cage_layer_logic = new G4LogicalVolume(tpc_cage_layer,
                                                                 G4Material::GetMaterial(material[i]),
-                                                                name.str().c_str());
+                                                                name.str());
     G4VisAttributes *visatt = new G4VisAttributes();
     visatt->SetVisibility(true);
     visatt->SetForceSolid(true);


### PR DESCRIPTION
insure flags std::string.c_str() as copying an uninitialized pointer (which is strictly speaking correct, but the uninitialized parts are not used). Since our interface is std::string, not const char *, all those conversions from srting to char * are redundant. So rather than add all of those occurrences to the suppression list this PR replaces std::string.c_str() by std::string. As of now there is one last insure error in g4gdml when it deals with the parametrized volume from the intt which I am not sure if this is real or not. 2 more false positives were added to the suppression. Other than the one from g4gdml, no insure complaints when running Fun4All_G4_sPHENIX.C This should make insure usable again.