### PR TITLE
protect against use of out of bounds layer id

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.C
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.C
@@ -2565,9 +2565,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode *topNode) {
 	     ++iter) {
 	  PHG4Hit* g4hit = *iter;
 	  unsigned int layer = g4hit->get_layer();
-	  if (layer < 0)
+	  if (layer >= _nlayers_maps+_nlayers_intt+_nlayers_tpc)
 	  {
-	    cout << PHWHERE << " skipping negative detector id " << layer << endl;
+	    cout << PHWHERE << " skipping out of bounds detector id " << layer << endl;
 	    continue;
 	  }
 	  xval[layer] = g4hit->get_avg_x();


### PR DESCRIPTION
if for some reason the layer id stored in the G4hit is outside of the x/y/z val array (given by the sum of the numbers of layers in the mvtx, intt and tpc) this will corrupt the memory. This PR checks that the layer id is within the allowed range  