### PR TITLE
Add E864 (cut) module forward EMCal

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
@@ -63,6 +63,21 @@ public:
       _tower2_dy = dy;
       _tower2_dz = dz;
     }
+    else if(type==3){
+      _tower3_dx = dx;
+      _tower3_dy = dy;
+      _tower3_dz = dz;
+    }
+    else if(type==4){
+      _tower4_dx = dx;
+      _tower4_dy = dy;
+      _tower4_dz = dz;
+    }
+    else if(type==5){
+      _tower5_dx = dx;
+      _tower5_dy = dy;
+      _tower5_dz = dz;
+    }
   }
 
   void SetPlace( G4double place_in_x, G4double place_in_y, G4double place_in_z) {
@@ -92,7 +107,8 @@ private:
 
   G4LogicalVolume* ConstructTower( int type );
   G4LogicalVolume* ConstructTowerType2();
-  int PlaceTower(G4LogicalVolume* envelope , G4LogicalVolume* tower0, G4LogicalVolume* tower1, G4LogicalVolume* tower2 );
+  G4LogicalVolume* ConstructTowerType3_4_5( int type );
+  int PlaceTower(G4LogicalVolume* envelope , G4LogicalVolume* tower[6]);
   int ParseParametersFromTable();
 
   struct towerposition {
@@ -116,6 +132,18 @@ private:
   G4double _tower2_dx;
   G4double _tower2_dy;
   G4double _tower2_dz;
+
+  G4double _tower3_dx;
+  G4double _tower3_dy;
+  G4double _tower3_dz;
+
+  G4double _tower4_dx;
+  G4double _tower4_dy;
+  G4double _tower4_dz;
+
+  G4double _tower5_dx;
+  G4double _tower5_dy;
+  G4double _tower5_dz;
 
 protected:
 


### PR DESCRIPTION
This set of changes adds a new option for a forward EMCal, based in a "cut" E864 calorimeter module.  The 10x10cm^2 E864 modules is further subdivided into towers using a 6x6 non-regular array of light guides, forming 36 smaller towers.  Because the E864 towers use a 47x47 array of fibers, the light guides come in two varieties - an 8x8 fiber version and an 8x7 fiber version, allowing the construction of three different sizes of towers (an 8x8, 8x7 and 7x8 tower).  While this arrangement complicates the cluster reconstruction and fitting, it is the only way to avoid creating inefficiencies on the edges by having a light guide boundary cross fibers. 

The code adds support for towers type 3,4,5 defined as: 

1.702 x 1.702 cm^2   (type 3, 8x8 fibers)
1.702 x 1.489 cm^2   (type 4 with long dimension horizontal (8x7), 5 with long dimension vertical (7x8))

and the mapping array of light guides onto the face of the E864 calorimeter module is given by: 

5 (1:7,40:47) 3 (8:15,40:47) 3 (16:23,40:47) 3 (24:31,40:47) 3 (32:39,40:47) 4 (40:47,41:47)
3 (1:8,32:39) 4 (9:16,33:39) 3 (17:24,32:39) 3 (25:32,32:39) 5 (33:39,32:39) 3 (40:47,33:40)
3 (1:8,24:31) 3 (9:16,25:32) 5 (17:23,24:31) 4 (24:31,25:31) 3 (32:39,24:31) 3 (40:47,25:32)
3 (1:8,16:23) 3 (9:16,17:24) 4 (17:24,17:23) 5 (25:31,17:24) 3 (32:39,16:23) 3 (40:47,17:24)
3 (1:8,8:15)   5 (9:15,9:16)   3 (16:23,9:16)   3 (24:31,9:16)   4 (32:39,9:15)   3 (40:47, 9:16)
4 (1:8,1:7)     3 (9:16,1:8)     3 (17:24,1:8)     3 (25:32,1:8)     3 (33:40,1:8)     5 (41:47,1:8) 

The calorimeter modules are 16cm in depth, and have a sampling fraction of about 3.1%. 

The software is backwards-compatible with the existing mapping file (v002) and G4_FEMC.C macro.  There are corresponding pull requests (by the same name) to the macros and calibrations repositories to enable the new E864 fEMC configuration. 

The software has been run successfully with overlap checks enabled; the geometry is "clean" with no overlaps with other geometry elements. 

Here's an event display with a 30GeV photon shower: 

![new_femc_30gev_gamma](https://user-images.githubusercontent.com/3042746/50378335-661fd780-05f5-11e9-98fa-aa200fd9a725.png)


