### PR TITLE
adding const access function for cluster/tower containers.

### DIFF
--- a/offline/packages/CaloBase/RawClusterContainer.cc
+++ b/offline/packages/CaloBase/RawClusterContainer.cc
@@ -37,7 +37,19 @@ RawClusterContainer::AddCluster(RawCluster *rawcluster)
 RawCluster *
 RawClusterContainer::getCluster(const unsigned int key)
 {
-  Iterator it = _clusters.find(key);
+  ConstIterator it = _clusters.find(key);
+  if (it != _clusters.end())
+    {
+      return it->second;
+    }
+  return NULL;
+}
+
+const
+RawCluster *
+RawClusterContainer::getCluster(const unsigned int key) const
+{
+  ConstIterator it = _clusters.find(key);
   if (it != _clusters.end())
     {
       return it->second;

--- a/offline/packages/CaloBase/RawClusterContainer.h
+++ b/offline/packages/CaloBase/RawClusterContainer.h
@@ -28,7 +28,10 @@ class RawClusterContainer : public PHObject
   int isValid() const;
   void identify(std::ostream& os=std::cout) const;
   ConstIterator AddCluster(RawCluster *clus);
+
   RawCluster *getCluster(const RawClusterDefs::keytype id);
+  const RawCluster *getCluster(const RawClusterDefs::keytype id) const;
+
   //! return all clusters
   ConstRange getClusters( void ) const;
   Range getClusters( void );

--- a/offline/packages/CaloBase/RawTowerContainer.cc
+++ b/offline/packages/CaloBase/RawTowerContainer.cc
@@ -73,7 +73,19 @@ RawTowerContainer::AddTower(RawTowerDefs::keytype key, RawTower *twr)
 RawTower *
 RawTowerContainer::getTower(RawTowerDefs::keytype key)
 {
-  Iterator it = _towers.find(key);
+  ConstIterator it = _towers.find(key);
+  if (it != _towers.end())
+    {
+      return it->second;
+    }
+  return NULL;
+}
+
+const
+RawTower *
+RawTowerContainer::getTower(RawTowerDefs::keytype key) const
+{
+  ConstIterator it = _towers.find(key);
   if (it != _towers.end())
     {
       return it->second;
@@ -83,6 +95,14 @@ RawTowerContainer::getTower(RawTowerDefs::keytype key)
 
 RawTower *
 RawTowerContainer::getTower(const unsigned int ieta, const unsigned int iphi)
+{
+  RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(_caloid,ieta,iphi);
+  return getTower(key);
+}
+
+const
+RawTower *
+RawTowerContainer::getTower(const unsigned int ieta, const unsigned int iphi) const
 {
   RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(_caloid,ieta,iphi);
   return getTower(key);

--- a/offline/packages/CaloBase/RawTowerContainer.h
+++ b/offline/packages/CaloBase/RawTowerContainer.h
@@ -35,8 +35,13 @@ class RawTowerContainer : public PHObject
 
   ConstIterator AddTower(const unsigned int ieta, const unsigned int iphi, RawTower *twr);
   ConstIterator AddTower(RawTowerDefs::keytype key, RawTower *twr);
-  RawTower *getTower(RawTowerDefs::keytype key);
-  RawTower *getTower(const unsigned int ieta, const unsigned int iphi);
+
+  RawTower *getTower(RawTowerDefs::keytype key) ;
+  const RawTower *getTower(RawTowerDefs::keytype key) const;
+
+  RawTower *getTower(const unsigned int ieta, const unsigned int iphi) ;
+  const RawTower *getTower(const unsigned int ieta, const unsigned int iphi) const;
+
   //! return all towers
   ConstRange getTowers( void ) const;
   Range getTowers( void );


### PR DESCRIPTION
Adding the const access functions of `get_cluster()`/`get_tower()` on the cluster/tower containers, to allow using these containers as constant objects in the downstream analysis modules. 

Thanks @FrancescoVassalli  at UCB for pointing out these missing const getters. 