### PR TITLE
typo in dictionary file

### DIFF
--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -104,7 +104,7 @@ else
     PHG4ParticleGun_Dict.cc \
     PHG4ParticleGenerator_Dict.cc \
     PHG4ParticleGeneratorBase_Dict.cc \
-    PHG4ParticleGeneratorVectorMeson \
+    PHG4ParticleGeneratorVectorMeson_Dict.cc \
     PHG4ParticleGeneratorD0_Dict.cc \
     PHG4Reco_Dict.cc \
     PHG4ScoringManager_Dict.cc \


### PR DESCRIPTION
Just a quick fix for a typo in the Makefile.am (PHG4ParticleGeneratorVectorMeson instead of PHG4ParticleGeneratorVectorMeson_Dict.cc in the root 5 dictionary list). We do need testing macros to find those mistakes! Thanks to Sasha to point this out