### PR TITLE
Added noise electron when determining ADC value.

### DIFF
--- a/simulation/g4simulation/g4intt/PHG4INTTDigitizer.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTDigitizer.cc
@@ -18,7 +18,10 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHNodeIterator.h>
+#include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
+
+#include <gsl/gsl_randist.h>
 
 #include <cmath>
 #include <iostream>
@@ -27,10 +30,17 @@ using namespace std;
 
 PHG4INTTDigitizer::PHG4INTTDigitizer(const string &name)
   : SubsysReco(name)
+  , mNoiseMean(457.2)
+  , mNoiseSigma(166.6)
+  , mEnergyPerPair(3.62e-9)  // GeV/e-h
   , _hitmap(NULL)
   , m_nCells(0)
   , m_nDeadCells(0)
 {
+  unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
+  cout << Name() << " random seed: " << seed << endl;
+  RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
+  gsl_rng_set(RandomGenerator, seed);
 }
 
 int PHG4INTTDigitizer::InitRun(PHCompositeNode *topNode)
@@ -203,14 +213,26 @@ void PHG4INTTDigitizer::DigitizeLadderCells(PHCompositeNode *topNode)
     if (_energy_scale.count(layer) > 1)
       assert(!"Error: _energy_scale has two or more keys.");
 
+    // Convert Geant4 true cell energy to # of electrons and add noise electrons
+    const int n_true_electron = (int) (cell->get_edep() / mEnergyPerPair);
+    const int n_noise_electron = round(added_noise());
+    const int n_cell_electron = n_true_electron + n_noise_electron;
+
     const float mip_e = _energy_scale[layer];
 
     std::vector<std::pair<double, double> > vadcrange = _max_fphx_adc[layer];
 
     int adc = -1;
     for (unsigned int irange = 0; irange < vadcrange.size(); ++irange)
-      if (cell->get_edep() >= vadcrange[irange].first * (double) mip_e && cell->get_edep() < vadcrange[irange].second * (double) mip_e)
+    {
+      // Convert adc ranges from fraction to the MIP energy to # of electrons.
+      // vadcrange uses FLT_MAX and the order of mEnergyPerPair is e-9, so use double.
+      const double n_adcrange_electron_first = vadcrange[irange].first * mip_e / mEnergyPerPair;
+      const double n_adcrange_electron_second = vadcrange[irange].second * mip_e / mEnergyPerPair;
+
+      if (n_cell_electron >= n_adcrange_electron_first && n_cell_electron < n_adcrange_electron_second)
         adc = (int) irange;
+    }
     //
     if (adc >= 0)
     {
@@ -286,4 +308,12 @@ void PHG4INTTDigitizer::PrintHits(PHCompositeNode *topNode)
   }
 
   return;
+}
+
+float PHG4INTTDigitizer::added_noise()
+{
+  float noise = gsl_ran_gaussian(RandomGenerator, mNoiseSigma) + mNoiseMean;
+  noise = (noise < 0) ? 0 : noise;
+
+  return noise;
 }

--- a/simulation/g4simulation/g4intt/PHG4INTTDigitizer.h
+++ b/simulation/g4simulation/g4intt/PHG4INTTDigitizer.h
@@ -2,11 +2,17 @@
 #define G4INTT_PHG4INTTDIGITIZER_H
 
 #include <fun4all/SubsysReco.h>
+#include <phool/PHTimeServer.h>
 
 #include <cassert>
 #include <cfloat>
 #include <map>
 #include <vector>
+
+// rootcint barfs with this header so we need to hide it
+#ifndef __CINT__
+#include <gsl/gsl_rng.h>
+#endif
 
 class SvtxHitMap;
 
@@ -51,6 +57,13 @@ class PHG4INTTDigitizer : public SubsysReco
   void DigitizeLadderCells(PHCompositeNode *topNode);
   void PrintHits(PHCompositeNode *topNode);
 
+  // noise electrons
+  float added_noise();
+
+  float mNoiseMean;            // Mean of noise electron distribution
+  float mNoiseSigma;           // Sigma of noise electron distribution
+  const float mEnergyPerPair;  // GeV/e-h pair
+
   // settings
   std::map<int, unsigned int> _max_adc;
   std::map<int, float> _energy_scale;
@@ -63,6 +76,11 @@ class PHG4INTTDigitizer : public SubsysReco
 
   unsigned int m_nCells;
   unsigned int m_nDeadCells;
+
+#ifndef __CINT__
+  //! random generator that conform with sPHENIX standard
+  gsl_rng *RandomGenerator;
+#endif
 };
 
 #endif

--- a/simulation/g4simulation/g4intt/PHG4INTTDigitizer.h
+++ b/simulation/g4simulation/g4intt/PHG4INTTDigitizer.h
@@ -1,6 +1,8 @@
 #ifndef G4INTT_PHG4INTTDIGITIZER_H
 #define G4INTT_PHG4INTTDIGITIZER_H
 
+#include <phparameter/PHParameterInterface.h>
+
 #include <fun4all/SubsysReco.h>
 #include <phool/PHTimeServer.h>
 
@@ -16,7 +18,7 @@
 
 class SvtxHitMap;
 
-class PHG4INTTDigitizer : public SubsysReco
+class PHG4INTTDigitizer : public SubsysReco, public PHParameterInterface
 {
  public:
   PHG4INTTDigitizer(const std::string &name = "PHG4INTTDigitizer");
@@ -33,6 +35,10 @@ class PHG4INTTDigitizer : public SubsysReco
 
   //! end of process
   int End(PHCompositeNode *topNode);
+
+  void SetDefaultParameters();
+
+  void Detector(const std::string &d) {detector = d;}
 
   void set_adc_scale(const int &layer, const std::vector<double> &userrange)
   {
@@ -51,6 +57,11 @@ class PHG4INTTDigitizer : public SubsysReco
     _max_fphx_adc.insert(std::make_pair(layer, vadcrange));
   }
 
+ protected:
+  std::string detector;
+  std::string hitnodename;
+  std::string cellnodename;
+
  private:
   void CalculateLadderCellADCScale(PHCompositeNode *topNode);
 
@@ -60,9 +71,9 @@ class PHG4INTTDigitizer : public SubsysReco
   // noise electrons
   float added_noise();
 
-  float mNoiseMean;            // Mean of noise electron distribution
-  float mNoiseSigma;           // Sigma of noise electron distribution
-  const float mEnergyPerPair;  // GeV/e-h pair
+  float mNoiseMean;      // Mean of noise electron distribution
+  float mNoiseSigma;     // Sigma of noise electron distribution
+  float mEnergyPerPair;  // GeV/e-h pair
 
   // settings
   std::map<int, unsigned int> _max_adc;


### PR DESCRIPTION
### Introduction

This is a pull request to implement the contribution from noise electrons into the determination of INTT hit ADC values. The noise electron distribution for 320um thick silicon cell was obtained using INTT prototype modules, which is shown in the right panel of the below figure. The mean(457e-) and sigma(166e-) values of the noise electron distribution are available only in this plot right now. Once we have a new INTT prototype module with 320um thick cell, we will confirm these values again. For now we want to set up an infrastructure to handle the noise contributions.

![intt_prototype_320um](https://user-images.githubusercontent.com/29286848/52419500-39991f80-2abe-11e9-9636-1539e6a088ef.png)

### How to implement the noise contribution
Currently the ADC value of INTT hit is determined by directly comparing the true deposited energy in a cell (cell->get_edep()) to the energy threshold (vadcrange * mip_e). 

The code change strategy here is as follows:
1.  Convert the true deposited in cell and ADC threshold energies to the number of electrons
2. Add the noise electrons to the # of electrons from the true deposited energy in cell
3. Compare # of electrons from true deposited energy+noise to the # of electrons converted from the ADC threshold 

### Result

We ran simulations with an identical random number seed for both the with and without noise cases.
The histograms are normalized at ADC=4 to compare their shapes. One can find that the distribution  with noise becomes slightly wider than that without noise.

The second plot below shows the pointing resolution of INTT clusters in phi and z direction.
Because only phi sensitive layers are going to be installed in our future detector, so are they
in this simulation. The resolution in phi direction is very sharp in both cases. The poorer resolution
in z direction is because of the length of cell in this direction. The widths before/after look quite similar.

![adcwnoise](https://user-images.githubusercontent.com/29286848/52424714-85e95d00-2ac8-11e9-9a7a-3c379d54eeb2.png)

![inttclusterpointres](https://user-images.githubusercontent.com/29286848/52441879-da540300-2aef-11e9-8446-15a9f94ccf0b.png)

