### PR TITLE
Remove classimp

### DIFF
--- a/offline/packages/Prototype3/RawTower_Prototype3.cc
+++ b/offline/packages/Prototype3/RawTower_Prototype3.cc
@@ -10,8 +10,6 @@
 
 using namespace std;
 
-ClassImp(RawTower_Prototype3)
-
 RawTower_Prototype3::RawTower_Prototype3() :
     towerid(~0), // initialize all bits on
     energy(0), time(NAN), HBD_channel(-1)

--- a/offline/packages/Prototype3/RawTower_Temperature.cc
+++ b/offline/packages/Prototype3/RawTower_Temperature.cc
@@ -11,8 +11,6 @@
 
 using namespace std;
 
-ClassImp(RawTower_Temperature)
-
 RawTower_Temperature::RawTower_Temperature() :
     towerid(~0) // initialize all bits on
 {}

--- a/offline/packages/Prototype4/RawTower_Prototype4.cc
+++ b/offline/packages/Prototype4/RawTower_Prototype4.cc
@@ -10,8 +10,6 @@
 
 using namespace std;
 
-ClassImp(RawTower_Prototype4)
-
     RawTower_Prototype4::RawTower_Prototype4()
   : towerid(~0)
   ,  // initialize all bits on

--- a/offline/packages/Prototype4/RawTower_Temperature.cc
+++ b/offline/packages/Prototype4/RawTower_Temperature.cc
@@ -11,8 +11,6 @@
 
 using namespace std;
 
-ClassImp(RawTower_Temperature)
-
     RawTower_Temperature::RawTower_Temperature()
   : towerid(~0)  // initialize all bits on
 {

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -120,7 +120,6 @@ endif
 libphg4hit_la_SOURCES = \
   $(ROOTHITDICTS) \
   $(ROOT5HITDICTS) \
-  PHG4EventHeader.cc \
   PHG4EventHeaderv1.cc \
   PHG4Hit.cc \
   PHG4Hitv1.cc \
@@ -131,7 +130,6 @@ libphg4hit_la_SOURCES = \
   PHG4Particle.cc \
   PHG4Particlev1.cc \
   PHG4Particlev2.cc \
-  PHG4Shower.cc \
   PHG4Showerv1.cc \
   PHG4TruthInfoContainer.cc \
   PHG4VtxPoint.cc \

--- a/simulation/g4simulation/g4main/PHG4EventHeader.cc
+++ b/simulation/g4simulation/g4main/PHG4EventHeader.cc
@@ -1,3 +1,0 @@
-#include "PHG4EventHeader.h"
-
-ClassImp(PHG4EventHeader)

--- a/simulation/g4simulation/g4main/PHG4EventHeaderv1.cc
+++ b/simulation/g4simulation/g4main/PHG4EventHeaderv1.cc
@@ -1,7 +1,5 @@
 #include "PHG4EventHeaderv1.h"
 
-ClassImp(PHG4EventHeaderv1)
-
 using namespace std;
 
 PHG4EventHeaderv1::PHG4EventHeaderv1():

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -7,8 +7,6 @@
 
 using namespace std;
 
-ClassImp(PHG4Hitv1)
-
 PHG4Hitv1::PHG4Hitv1():
  hitid(ULONG_LONG_MAX),
  trackid(INT_MIN),

--- a/simulation/g4simulation/g4main/PHG4InEvent.cc
+++ b/simulation/g4simulation/g4main/PHG4InEvent.cc
@@ -1,4 +1,5 @@
 #include "PHG4InEvent.h"
+
 #include "PHG4Particle.h"
 #include "PHG4VtxPointv1.h"
 
@@ -7,8 +8,6 @@
 #include <cstdlib>
 
 using namespace std;
-
-ClassImp(PHG4InEvent)
 
 PHG4InEvent::~PHG4InEvent()
 {

--- a/simulation/g4simulation/g4main/PHG4Particle.cc
+++ b/simulation/g4simulation/g4main/PHG4Particle.cc
@@ -1,7 +1,5 @@
 #include "PHG4Particle.h"
 
-ClassImp(PHG4Particle)
-
 using namespace std;
 
 void

--- a/simulation/g4simulation/g4main/PHG4Particlev1.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev1.cc
@@ -1,7 +1,5 @@
 #include "PHG4Particlev1.h"
 
-ClassImp(PHG4Particlev1)
-
 using namespace std;
 
 PHG4Particlev1::PHG4Particlev1():

--- a/simulation/g4simulation/g4main/PHG4Particlev2.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.cc
@@ -1,7 +1,5 @@
 #include "PHG4Particlev2.h"
 
-ClassImp(PHG4Particlev2)
-
 using namespace std;
 
 PHG4Particlev2::PHG4Particlev2():

--- a/simulation/g4simulation/g4main/PHG4Shower.cc
+++ b/simulation/g4simulation/g4main/PHG4Shower.cc
@@ -1,7 +1,0 @@
-#include "PHG4Shower.h"
-
-#include <cmath>
-
-using namespace std;
-
-ClassImp(PHG4Shower);

--- a/simulation/g4simulation/g4main/PHG4Showerv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Showerv1.cc
@@ -7,8 +7,6 @@
 
 using namespace std;
 
-ClassImp(PHG4Showerv1);
-
 PHG4Showerv1::PHG4Showerv1()
   : _id(0xFFFFFFFF)
   , _parent_particle_id(0)

--- a/simulation/g4simulation/g4main/PHG4VtxPoint.cc
+++ b/simulation/g4simulation/g4main/PHG4VtxPoint.cc
@@ -1,8 +1,6 @@
 #include "PHG4VtxPoint.h"
 
 
-ClassImp(PHG4VtxPoint)
-
 using namespace std;
 
 void

--- a/simulation/g4simulation/g4main/PHG4VtxPointv1.cc
+++ b/simulation/g4simulation/g4main/PHG4VtxPointv1.cc
@@ -1,8 +1,6 @@
 #include "PHG4VtxPointv1.h"
 
 
-ClassImp(PHG4VtxPointv1)
-
 using namespace std;
 
 void


### PR DESCRIPTION
The ClassImp macro has been obsolete for more than 10 years, removing it so it finally stops propagating