### PR TITLE
fix forgotten dictionaries

### DIFF
--- a/simulation/g4simulation/g4hough/Makefile.am
+++ b/simulation/g4simulation/g4hough/Makefile.am
@@ -92,8 +92,8 @@ ROOTDICTS = \
   HelixHoughFuncs_v1_Dict.cc \
   CellularAutomaton_Dict.cc \
   CellularAutomaton_v1_Dict.cc \
-  SvtxBeamSpot_Dict.cc \
-  SimpleTrack_Dict.cc
+  SimpleTrack_Dict.cc \
+  SvtxBeamSpot_Dict.cc
 
 if MAKEROOT6
   pcmdir = $(libdir)
@@ -106,6 +106,7 @@ if MAKEROOT6
   HelixHoughFuncs_v1_Dict_rdict.pcm \
   CellularAutomaton_Dict_rdict.pcm \
   CellularAutomaton_v1_Dict_rdict.pcm \
+  SimpleTrack_Dict_rdict.pcm \
   SvtxBeamSpot_Dict_rdict.pcm
 else
   ROOT5_DICTS = \

--- a/simulation/g4simulation/g4intt/Makefile.am
+++ b/simulation/g4simulation/g4intt/Makefile.am
@@ -68,6 +68,7 @@ if MAKEROOT6
 else
   ROOT5_DICTS = \
     PHG4INTTDeadMapLoader_Dict.cc \
+    PHG4INTTDefs_Dict.cc \
     PHG4INTTDigitizer_Dict.cc \
     PHG4INTTCellReco_Dict.cc \
     PHG4INTTSubsystem_Dict.cc
@@ -85,7 +86,6 @@ libg4intt_la_SOURCES = \
   PHG4INTTDeadMapLoader.cc \
   PHG4INTTDigitizer.cc \
   PHG4INTTCellReco.cc \
-  PHG4INTTDefs_Dict.cc \
   PHG4INTTDetector.cc \
   PHG4INTTSteppingAction.cc \
   PHG4INTTSubsystem.cc \


### PR DESCRIPTION
two more dictionaries, now we can build with root6 without having to copy the pcm files by hand after building