### PR TITLE
Updated E864 fEMC tower geometry

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
@@ -167,15 +167,15 @@ PHG4ForwardEcalDetector::Construct( G4LogicalVolume* logicWorld )
 		     ecal_envelope_log, name_envelope.str().c_str(), logicWorld, 0, false, OverlapCheck());
 
   /* Construct single calorimeter towers */
-  bool buildType[6] = {false, false, false, false, false, false}; 
+  bool buildType[7] = {false, false, false, false, false, false, false}; 
   typedef std::map< std::string, towerposition>::iterator it_type;
   for(it_type iterator = _map_tower.begin(); iterator != _map_tower.end(); ++iterator) {
-    for(int i=0; i<6; i++)
+    for(int i=0; i<7; i++)
       if(iterator->second.type==i) buildType[i] = true; 
   }
 
-  G4LogicalVolume* singletower[6] = {NULL, NULL, NULL, NULL, NULL, NULL}; 
-  for(int i=0; i<6; i++)
+  G4LogicalVolume* singletower[7] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL}; 
+  for(int i=0; i<7; i++)
     if(buildType[i]) singletower[i] = ConstructTower(i);
 
   /* Place calorimeter towers within envelope */
@@ -196,10 +196,10 @@ PHG4ForwardEcalDetector::ConstructTower( int type )
 
   // This method allows construction of Type 0,1 tower (PbGl or PbW04). 
   // Call a separate routine to generate Type 2 towers (PbSc)
-  // Call a separate routine to generate Type 3-5 towers (E864 Pb-Scifi)
+  // Call a separate routine to generate Type 3-6 towers (E864 Pb-Scifi)
 
   if(type==2) return ConstructTowerType2(); 
-  if((type==3)||(type==4)||(type==5)) return ConstructTowerType3_4_5(type); 
+  if((type==3)||(type==4)||(type==5)||(type==6)) return ConstructTowerType3_4_5_6(type); 
 
   /* create logical volume for single tower */
   G4Material* material_air = G4Material::GetMaterial( "G4_AIR" );
@@ -403,7 +403,7 @@ PHG4ForwardEcalDetector::ConstructTowerType2()
 }
 
 G4LogicalVolume*
-PHG4ForwardEcalDetector::ConstructTowerType3_4_5(int type)
+PHG4ForwardEcalDetector::ConstructTowerType3_4_5_6(int type)
 {
   if ( Verbosity() > 0 )
     {
@@ -433,25 +433,31 @@ PHG4ForwardEcalDetector::ConstructTowerType3_4_5(int type)
     tower_dx = _tower3_dx; 
     tower_dy = _tower3_dy; 
     tower_dz = _tower3_dz; 
-    num_fibers_x = 8; 
-    num_fibers_y = 8; 
+    num_fibers_x = 10; 
+    num_fibers_y = 10; 
     break; 
   case 4:
     tower_dx = _tower4_dx; 
     tower_dy = _tower4_dy; 
     tower_dz = _tower4_dz;
-    num_fibers_x = 8; 
-    num_fibers_y = 7;  
+    num_fibers_x = 9; 
+    num_fibers_y = 10;  
     break; 
   case 5:
     tower_dx = _tower5_dx; 
     tower_dy = _tower5_dy; 
     tower_dz = _tower5_dz; 
-    num_fibers_x = 7; 
-    num_fibers_y = 8;  
+    num_fibers_x = 10; 
+    num_fibers_y = 9;  
+   case 6:
+    tower_dx = _tower6_dx; 
+    tower_dy = _tower6_dy; 
+    tower_dz = _tower6_dz; 
+    num_fibers_x = 9; 
+    num_fibers_y = 9;  
     break; 
   default: 
-    cout << "PHG4ForwardEcalDetector: Invalid tower type in ConstructTowerType3_4_5, stopping..." << endl;
+    cout << "PHG4ForwardEcalDetector: Invalid tower type in ConstructTowerType3_4_5_6, stopping..." << endl;
     return NULL; 
 
   }
@@ -568,7 +574,7 @@ PHG4ForwardEcalDetector::ConstructTowerType3_4_5(int type)
 
 
 int
-PHG4ForwardEcalDetector::PlaceTower(G4LogicalVolume* ecalenvelope, G4LogicalVolume* singletowerIn[6])
+PHG4ForwardEcalDetector::PlaceTower(G4LogicalVolume* ecalenvelope, G4LogicalVolume* singletowerIn[7])
 {
   /* Loop over all tower positions in vector and place tower */
   typedef std::map< std::string, towerposition>::iterator it_type;
@@ -594,6 +600,8 @@ PHG4ForwardEcalDetector::PlaceTower(G4LogicalVolume* ecalenvelope, G4LogicalVolu
 	singletower = singletowerIn[4]; 
       else if(iterator->second.type==5)
 	singletower = singletowerIn[5]; 
+      else if(iterator->second.type==6)
+	singletower = singletowerIn[6]; 
       else
 	cout << "PHG4ForwardEcalDetector::PlaceTower invalid type =  " << iterator->second.type << endl; 
 
@@ -769,6 +777,18 @@ PHG4ForwardEcalDetector::ParseParametersFromTable()
   parit = _map_global_parameter.find("Gtower5_dz");
   if (parit != _map_global_parameter.end())
     _tower5_dz = parit->second * cm;
+
+  parit = _map_global_parameter.find("Gtower6_dx");
+  if (parit != _map_global_parameter.end())
+    _tower6_dx = parit->second * cm;
+
+  parit = _map_global_parameter.find("Gtower6_dy");
+  if (parit != _map_global_parameter.end())
+    _tower6_dy = parit->second * cm;
+
+  parit = _map_global_parameter.find("Gtower6_dz");
+  if (parit != _map_global_parameter.end())
+    _tower6_dz = parit->second * cm;
 
   parit = _map_global_parameter.find("Gr1_inner");
   if (parit != _map_global_parameter.end())

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
@@ -448,8 +448,9 @@ PHG4ForwardEcalDetector::ConstructTowerType3_4_5_6(int type)
     tower_dy = _tower5_dy; 
     tower_dz = _tower5_dz; 
     num_fibers_x = 10; 
-    num_fibers_y = 9;  
-   case 6:
+    num_fibers_y = 9; 
+    break; 
+  case 6:
     tower_dx = _tower6_dx; 
     tower_dy = _tower6_dy; 
     tower_dz = _tower6_dz; 

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
@@ -78,6 +78,11 @@ public:
       _tower5_dy = dy;
       _tower5_dz = dz;
     }
+     else if(type==5){
+      _tower6_dx = dx;
+      _tower6_dy = dy;
+      _tower6_dz = dz;
+    }
   }
 
   void SetPlace( G4double place_in_x, G4double place_in_y, G4double place_in_z) {
@@ -107,7 +112,7 @@ private:
 
   G4LogicalVolume* ConstructTower( int type );
   G4LogicalVolume* ConstructTowerType2();
-  G4LogicalVolume* ConstructTowerType3_4_5( int type );
+  G4LogicalVolume* ConstructTowerType3_4_5_6( int type );
   int PlaceTower(G4LogicalVolume* envelope , G4LogicalVolume* tower[6]);
   int ParseParametersFromTable();
 
@@ -144,6 +149,10 @@ private:
   G4double _tower5_dx;
   G4double _tower5_dy;
   G4double _tower5_dz;
+
+  G4double _tower6_dx;
+  G4double _tower6_dy;
+  G4double _tower6_dz;
 
 protected:
 


### PR DESCRIPTION
This pull request updates the forward EMC (based on cut down E864 modules) tower geometry to use the tower structure suggested by @blackcathj: 

// In order to keep the light guide boundaries between fibers in the E864 47x47 fiber array, 
// we need to have two types of light guides yielding three sizes of towers with different
// numbers of fibers. 

// 2.128 x 2.128 cm^2   (type 3, 10x10 fibers)
// 1.915 x 2.128 cm^2   (type 4 with short dimension horizontal (9x10), 5 with short dimension vertical (10x9))
// 1.915 x 1.915 cm^2   (type 6, 9x9 fibers)

// 3 (1:10,38:47) 4 (11:19,38:47) 4 (20:28,38:47) 4 (29:37,38:47) 3 (38:47,38:47)
// 5 (1:10,29:37) 6 (11:19,29:37) 6 (20:28,29:37) 6 (39:37,29:37) 5 (38:47,39:37)
// 5 (1:10,20:28) 6 (11:19,20:28) 6 (20:28,20:28) 6 (29:37,20:28) 5 (38:47,20:28)
// 5 (1:10,11:19) 6 (11:19,11:19) 6 (20:28,11:19) 6 (29:37,11:19) 5 (38:47,11:19)
// 3 (1:10,1:10)  4 (11:19,1:10)  4 (20:28,1:10)  4 (29:37,1:10)  3 (38:47,1:10)

The overall result is that the E864 tower is now divided into a 5x5 array instead of a 6x6 array, so the towers are more uniform, and this fixes the previous geometry that did not cover the central fiber of each E864 tower. 

Here's a view of a 30GeV photon in the calorimeter: 

![new_femc](https://user-images.githubusercontent.com/3042746/52735173-99933880-2f8c-11e9-880a-db8928ebe3df.png)

and here is the total tower energy and largest cluster energy for a sample of 30 GeV electrons between 1.3 < eta < 3.0 : 

![femc_sum](https://user-images.githubusercontent.com/3042746/52735310-ed9e1d00-2f8c-11e9-9489-4fdf6adb954e.png)

![cluster](https://user-images.githubusercontent.com/3042746/52735312-f0990d80-2f8c-11e9-89ec-716777f70ebc.png)

Note that there are corresponding updates required to the calibrations and macros repositories. 
