### PR TITLE
Fix cppcheck warnings

### DIFF
--- a/offline/packages/vararray/VariableArray.cc
+++ b/offline/packages/vararray/VariableArray.cc
@@ -32,7 +32,7 @@ void VariableArray::set_val(const vector<short> &vec)
   sval = new short[nVal];
   vector<short>::const_iterator iter;
   unsigned int i = 0;
-  for (iter = vec.begin(); iter != vec.end(); iter++)
+  for (iter = vec.begin(); iter != vec.end(); ++iter)
   {
     sval[i++] = *iter;
   }

--- a/simulation/g4simulation/EICPhysicsList/AntiBaryonPhysics.cc
+++ b/simulation/g4simulation/EICPhysicsList/AntiBaryonPhysics.cc
@@ -45,7 +45,12 @@
 #include <Geant4/G4SystemOfUnits.hh>
 
 
-AntiBaryonPhysics::AntiBaryonPhysics()
+AntiBaryonPhysics::AntiBaryonPhysics():
+  ftfp(nullptr),
+  stringModel(nullptr),
+  stringDecay(nullptr),
+  fragModel(nullptr),
+  preCompoundModel(nullptr)
 {}
 
 

--- a/simulation/g4simulation/EICPhysicsList/GammaLeptoNuclearPhysics.cc
+++ b/simulation/g4simulation/EICPhysicsList/GammaLeptoNuclearPhysics.cc
@@ -31,7 +31,12 @@
 #include <Geant4/G4SystemOfUnits.hh>
 
 
-GammaLeptoNuclearPhysics::GammaLeptoNuclearPhysics()
+GammaLeptoNuclearPhysics::GammaLeptoNuclearPhysics():
+  qgsp(nullptr),
+  stringModel(nullptr),
+  stringDecay(nullptr),
+  fragModel(nullptr),
+  preCompoundModel(nullptr)
 {}
 
 

--- a/simulation/g4simulation/EICPhysicsList/HyperonPhysics.cc
+++ b/simulation/g4simulation/EICPhysicsList/HyperonPhysics.cc
@@ -35,7 +35,12 @@
 #include <Geant4/G4SystemOfUnits.hh>
 
 
-HyperonPhysics::HyperonPhysics()
+HyperonPhysics::HyperonPhysics():
+  ftfp(nullptr),
+  stringModel(nullptr),
+  stringDecay(nullptr),
+  fragModel(nullptr),
+  preCompoundModel(nullptr)
 {}
 
 

--- a/simulation/g4simulation/EICPhysicsList/IonPhysics.cc
+++ b/simulation/g4simulation/EICPhysicsList/IonPhysics.cc
@@ -34,7 +34,14 @@
 #include <Geant4/G4SystemOfUnits.hh>
 
 
-IonPhysics::IonPhysics()
+IonPhysics::IonPhysics():
+  ftfp(nullptr),
+  stringModel(nullptr),
+  stringDecay(nullptr),
+  fragModel(nullptr),
+  preCompoundModel(nullptr),
+  theGGNuclNuclXS(nullptr),
+  ionGGXS(nullptr)
 {}
 
 

--- a/simulation/g4simulation/EICPhysicsList/KaonPhysics.cc
+++ b/simulation/g4simulation/EICPhysicsList/KaonPhysics.cc
@@ -37,7 +37,12 @@
 #include <Geant4/G4SystemOfUnits.hh>
 
 
-KaonPhysics::KaonPhysics()
+KaonPhysics::KaonPhysics():
+  ftfp(nullptr),
+  stringModel(nullptr),
+  stringDecay(nullptr),
+  fragModel(nullptr),
+  preCompoundModel(nullptr)
 {}
 
 

--- a/simulation/g4simulation/EICPhysicsList/NeutronPhysics.cc
+++ b/simulation/g4simulation/EICPhysicsList/NeutronPhysics.cc
@@ -34,9 +34,13 @@
 #include <Geant4/G4SystemOfUnits.hh>
 
 
-NeutronPhysics::NeutronPhysics()
-{
-}
+NeutronPhysics::NeutronPhysics():
+  ftfp(nullptr),
+  stringModel(nullptr),
+  stringDecay(nullptr),
+  fragModel(nullptr),
+  preCompoundModel(nullptr)
+{}
 
 
 NeutronPhysics::~NeutronPhysics()

--- a/simulation/g4simulation/EICPhysicsList/PionPhysics.cc
+++ b/simulation/g4simulation/EICPhysicsList/PionPhysics.cc
@@ -36,7 +36,13 @@
 #include <Geant4/G4SystemOfUnits.hh>
 
 
-PionPhysics::PionPhysics()
+PionPhysics::PionPhysics():
+  ftfp(nullptr),
+  stringModel(nullptr),
+  stringDecay(nullptr),
+  fragModel(nullptr),
+  preCompoundModel(nullptr)
+
 {}
 
 

--- a/simulation/g4simulation/EICPhysicsList/ProtonPhysics.cc
+++ b/simulation/g4simulation/EICPhysicsList/ProtonPhysics.cc
@@ -30,7 +30,12 @@
 #include <Geant4/G4SystemOfUnits.hh>
 
 
-ProtonPhysics::ProtonPhysics()
+ProtonPhysics::ProtonPhysics():
+  ftfp(nullptr),
+  stringModel(nullptr),
+  stringDecay(nullptr),
+  fragModel(nullptr),
+  preCompoundModel(nullptr)
 {}
 
 

--- a/simulation/g4simulation/g4detectors/PHG4ConeRegionSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeRegionSteppingAction.cc
@@ -31,10 +31,10 @@ void PHG4ConeRegionSteppingAction::UserSteppingAction( const G4Step* aStep)
 
   const G4Track* aTrack = aStep->GetTrack();
 
-  int layer_id = 0;
   // make sure we are in a volume
   if ( detector_->IsInConeActive(volume) )
     {
+      int layer_id = 0;
       G4StepPoint * prePoint = aStep->GetPreStepPoint();
       G4StepPoint * postPoint = aStep->GetPostStepPoint();
        cout << "track id " << aTrack->GetTrackID() << endl;

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
@@ -79,7 +79,6 @@ bool PHG4CrystalCalorimeterSteppingAction::UserSteppingAction( const G4Step* aSt
   int tower_id = -1;
   int idx_j = -1;
   int idx_k = -1;
-  int idx_l = -1;
 
   if (whichactive > 0) // in crystal
     {
@@ -115,6 +114,7 @@ bool PHG4CrystalCalorimeterSteppingAction::UserSteppingAction( const G4Step* aSt
   /* Make sure we are in a volume */
   if ( detector_->IsActive() )
     {
+      int idx_l = -1;
       /* Check if particle is 'geantino' */
       bool geantino = false;
       if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
@@ -322,19 +322,16 @@ int
 PHG4CrystalCalorimeterSteppingAction::FindTowerIndex2LevelUp(G4TouchableHandle touch, int& j, int& k)
 {
         int j_0, k_0;           //The k and k indices for the crystal within the 2x2 matrix
-        int j_1, k_1;           //The k and k indices for the 2x2 within the 4x4
-        int j_2, k_2;           //The k and k indices for the 4x4 within the mother volume
-        //int j, k;             //The final indices of the crystal
 
 	string name = touch->GetVolume(0)->GetName();
-	string name_2 = touch->GetVolume(1)->GetName();
 
 	if (name.find("rystal") != string::npos)
 	{
 		G4VPhysicalVolume* crystal = touch->GetVolume(0);		//Get the crystal solid
 		G4VPhysicalVolume* TwoByTwo = touch->GetVolume(1);		//Get the crystal solid
 		G4VPhysicalVolume* FourByFour = touch->GetVolume(2);		//Get the crystal solid
-
+                int j_1, k_1;  //The k and k indices for the 2x2 within the 4x4
+                int j_2, k_2;  //The k and k indices for the 4x4 within the mother volume
 		ParseG4VolumeName(crystal, j_0, k_0);
 		ParseG4VolumeName(TwoByTwo, j_1, k_1);
 		ParseG4VolumeName(FourByFour, j_2, k_2);

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4.cc
@@ -1,4 +1,5 @@
 #include "PHG4CylinderGeomv4.h"
+
 #include <cmath>
 
 using namespace std;
@@ -18,6 +19,7 @@ PHG4CylinderGeomv4::PHG4CylinderGeomv4():
   N_staggers(-1),
   strip_z_spacing(NAN),
   strip_y_spacing(NAN),
+  thickness(NAN),
   strip_tilt(NAN)
 
 {

--- a/simulation/g4simulation/g4detectors/PHG4FPbScRegionSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScRegionSteppingAction.cc
@@ -32,10 +32,10 @@ void PHG4FPbScRegionSteppingAction::UserSteppingAction( const G4Step* aStep)
 
   const G4Track* aTrack = aStep->GetTrack();
 
-  int layer_id = 0;
   // make sure we are in a volume
   if ( detector_->isInScintillator(volume) )
     {
+      int layer_id = 0;
       G4StepPoint * prePoint = aStep->GetPreStepPoint();
       G4StepPoint * postPoint = aStep->GetPostStepPoint();
        cout << "track id " << aTrack->GetTrackID() << endl;

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
@@ -43,7 +43,7 @@ public:
   int IsInForwardEcal(G4VPhysicalVolume*) const;
 
   //! Select mapping file for calorimeter tower
-  void SetTowerMappingFile( std::string filename ) {
+  void SetTowerMappingFile( const std::string &filename ) {
     _mapping_tower_file = filename;
   }
 
@@ -78,7 +78,7 @@ public:
       _tower5_dy = dy;
       _tower5_dz = dz;
     }
-     else if(type==5){
+     else if(type==6){
       _tower6_dx = dx;
       _tower6_dy = dy;
       _tower6_dz = dz;

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSteppingAction.cc
@@ -77,7 +77,7 @@ bool PHG4ForwardEcalSteppingAction::UserSteppingAction( const G4Step* aStep, boo
   int tower_id = -1;
   int idx_j = -1;
   int idx_k = -1;
-  int idx_l = -1;
+//  int idx_l = -1;
 
   if (whichactive > 0) // in scintillator
     {
@@ -109,6 +109,7 @@ bool PHG4ForwardEcalSteppingAction::UserSteppingAction( const G4Step* aStep, boo
   /* Make sure we are in a volume */
   if ( detector_->IsActive() )
     {
+      int idx_l = -1;
       /* Check if particle is 'geantino' */
       bool geantino = false;
       if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.h
@@ -43,7 +43,7 @@ public:
 
   /** Set mapping file for calorimeter towers
    */
-  void SetTowerMappingFile( std::string filename )
+  void SetTowerMappingFile( const std::string &filename )
   {
     mappingfile_ = filename;
   }

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.h
@@ -44,7 +44,7 @@ public:
 
 
   //! Select mapping file for calorimeter tower
-  void SetTowerMappingFile( std::string filename ) {
+  void SetTowerMappingFile( const std::string &filename ) {
     _mapping_tower_file = filename;
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSteppingAction.cc
@@ -78,7 +78,6 @@ bool PHG4ForwardHcalSteppingAction::UserSteppingAction( const G4Step* aStep, boo
   int tower_id = -1;
   int idx_j = -1;
   int idx_k = -1;
-  int idx_l = -1;
 
   if (whichactive > 0) // in sctintillator
     {
@@ -110,6 +109,7 @@ bool PHG4ForwardHcalSteppingAction::UserSteppingAction( const G4Step* aStep, boo
   /* Make sure we are in a volume */
   if ( detector_->IsActive() )
     {
+      int idx_l = -1;
       /* Check if particle is 'geantino' */
       bool geantino = false;
       if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystem.h
@@ -43,7 +43,7 @@ public:
 
   /** Set mapping file for calorimeter towers
    */
-  void SetTowerMappingFile( std::string filename )
+  void SetTowerMappingFile( const std::string &filename )
   {
     mappingfile_ = filename;
   }

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -41,7 +41,6 @@ using namespace std;
 PHG4FullProjSpacalCellReco::PHG4FullProjSpacalCellReco(const string &name) :
   SubsysReco(name),
   PHParameterInterface(name),
-  _timer(PHTimeServer::get()->insert_new(name.c_str())), 
   sum_energy_g4hit(0),
   chkenergyconservation(0),
   tmin(NAN),
@@ -320,7 +319,6 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
 int
 PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
 {
-  _timer.get()->restart();
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hit)
     {
@@ -489,7 +487,6 @@ PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
     {
       CheckEnergy(topNode);
     }
-  _timer.get()->stop();
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
@@ -5,8 +5,6 @@
 
 #include <fun4all/SubsysReco.h>
 
-#include <phool/PHTimeServer.h>
-
 #include <map>
 #include <string>
 #include <vector>
@@ -86,7 +84,6 @@ class PHG4FullProjSpacalCellReco : public SubsysReco,  public PHParameterInterfa
   std::string geonodename;
   std::string seggeonodename;
 
-  PHTimeServer::timer _timer;
   double sum_energy_g4hit;
   int chkenergyconservation;
   std::map<unsigned int, PHG4Cell *> celllist;

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -14,10 +14,11 @@
 #include <g4main/PHG4PhenixDetector.h>
 #include <g4main/PHG4Utils.h>
 
+#include <g4gdml/PHG4GDMLConfig.hh>
+
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
-#include <g4gdml/PHG4GDMLConfig.hh>
 
 #include <Geant4/G4Trd.hh>
 #include <Geant4/G4Trap.hh>
@@ -38,6 +39,11 @@
 #include <Geant4/G4VisAttributes.hh>
 #include <Geant4/G4Vector3D.hh>
 
+#include <TSystem.h>
+
+#include <boost/math/special_functions/sign.hpp>
+#include <boost/foreach.hpp>
+
 #include <numeric>      // std::accumulate
 #include <cassert>
 #include <cmath>
@@ -45,8 +51,6 @@
 #include <algorithm>
 #include <string>     // std::string, std::to_string
 #include <sstream>
-#include <boost/math/special_functions/sign.hpp>
-#include <boost/foreach.hpp>
 
 using namespace std;
 
@@ -66,7 +70,6 @@ PHG4FullProjSpacalDetector::PHG4FullProjSpacalDetector(PHCompositeNode *Node,
           << endl;
       exit(1);
     }
-  assert(get_geom_v3()); // conversion check
 
   //this class loads Chris Cullen 2D spacal design July 2015 by default.
   get_geom_v3() -> load_demo_sector_tower_map_2015_Chris_Cullen_2D_spacal();
@@ -82,7 +85,6 @@ PHG4FullProjSpacalDetector::PHG4FullProjSpacalDetector(PHCompositeNode *Node,
 void
 PHG4FullProjSpacalDetector::Construct(G4LogicalVolume* logicWorld)
 {
-  assert(get_geom_v3());
 
   if (get_geom_v3()->get_construction_verbose() >= 1)
     {
@@ -103,8 +105,11 @@ PHG4FullProjSpacalDetector::Construct(G4LogicalVolume* logicWorld)
 std::pair<G4LogicalVolume *, G4Transform3D>
 PHG4FullProjSpacalDetector::Construct_AzimuthalSeg()
 {
-  assert(get_geom_v3());
-  assert(get_geom_v3()->get_azimuthal_n_sec()>4);
+      if (!(get_geom_v3()->get_azimuthal_n_sec()>4))
+      {
+	cout << "azimuthal_n_sec <= 4: " << get_geom_v3()->get_azimuthal_n_sec() << endl;
+	gSystem->Exit(1);
+      }
 
   G4Tubs* sec_solid = new G4Tubs(G4String(GetName() + string("_sec")),
       get_geom_v3()->get_radius() * cm, get_geom_v3()->get_max_radius() * cm,
@@ -293,7 +298,6 @@ PHG4FullProjSpacalDetector::Construct_Fibers_SameLengthFiberPerTower(
     const PHG4FullProjSpacalDetector::SpacalGeom_t::geom_tower & g_tower,
     G4LogicalVolume* LV_tower)
 {
-  assert(get_geom_v3());
 
   // construct fibers
 
@@ -458,8 +462,6 @@ PHG4FullProjSpacalDetector::Construct_Fibers(
     const PHG4FullProjSpacalDetector::SpacalGeom_t::geom_tower & g_tower,
     G4LogicalVolume* LV_tower)
 {
-  assert(get_geom_v3());
-
   G4Vector3D v_zshift = G4Vector3D(tan(g_tower.pTheta) * cos(g_tower.pPhi),
       tan(g_tower.pTheta) * sin(g_tower.pPhi), 1) * g_tower.pDz;
   int fiber_cnt = 0;
@@ -579,7 +581,6 @@ G4LogicalVolume*
 PHG4FullProjSpacalDetector::Construct_Tower(
     const PHG4FullProjSpacalDetector::SpacalGeom_t::geom_tower & g_tower)
 {
-  assert(get_geom_v3());
 
   std::stringstream sout;
   sout << "_" << g_tower.id;

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.h
@@ -18,6 +18,7 @@
 #include <Geant4/G4Types.hh>
 #include <Geant4/globals.hh>
 
+#include <cassert>
 #include <map>
 #include <set>
 
@@ -74,13 +75,17 @@ class PHG4FullProjSpacalDetector : public PHG4SpacalDetector
   SpacalGeom_t *
   get_geom_v3()
   {
-    return dynamic_cast<SpacalGeom_t *> (_geom);
+    SpacalGeom_t *v3_geom =  dynamic_cast<SpacalGeom_t *> (_geom);
+    assert(v3_geom);
+    return v3_geom;
   }
 
   const SpacalGeom_t *
   get_geom_v3() const
   {
-    return dynamic_cast<const SpacalGeom_t *> (_geom);
+    SpacalGeom_t *v3_geom =  dynamic_cast<SpacalGeom_t *> (_geom);
+    assert(v3_geom);
+    return v3_geom;
   }
 
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
@@ -18,6 +18,7 @@
 #include <Geant4/G4Types.hh>
 #include <Geant4/globals.hh>
 
+#include <cassert>
 #include <map>
 #include <set>
 
@@ -76,13 +77,17 @@ class PHG4FullProjTiltedSpacalDetector : public PHG4SpacalDetector
   SpacalGeom_t *
   get_geom_v3()
   {
-    return dynamic_cast<SpacalGeom_t *> (_geom);
+    SpacalGeom_t *v3_geom =  dynamic_cast<SpacalGeom_t *> (_geom);
+    assert(v3_geom);
+    return v3_geom;
   }
 
   const SpacalGeom_t *
   get_geom_v3() const
   {
-    return dynamic_cast<const SpacalGeom_t *> (_geom);
+    SpacalGeom_t *v3_geom =  dynamic_cast<SpacalGeom_t *> (_geom);
+    assert(v3_geom);
+    return v3_geom;
   }
 
 };

--- a/simulation/g4simulation/g4detectors/PHG4RICHSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4RICHSubsystem.h
@@ -65,7 +65,7 @@ class PHG4RICHSubsystem: public PHG4Subsystem
 
     ePHENIXRICH::RICH_Geometry & get_RICH_geometry() {return geom;}
     
-    void set_RICH_geometry(ePHENIXRICH::RICH_Geometry g) {geom = g;}
+    void set_RICH_geometry(const ePHENIXRICH::RICH_Geometry &g) {geom = g;}
 
   private:
     

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
@@ -21,9 +21,7 @@
 #include <Geant4/G4SDManager.hh>
 #include <Geant4/G4VisAttributes.hh>
 #include <Geant4/G4Colour.hh>
-
 #include <Geant4/G4NistManager.hh>
-
 #include <Geant4/G4Ellipsoid.hh>
 #include <Geant4/G4Sphere.hh>
 #include <Geant4/G4Orb.hh>
@@ -42,7 +40,7 @@
 using namespace PHG4Sector;
 using namespace std;
 
-PHG4SectorConstructor::PHG4SectorConstructor(std::string name) :
+PHG4SectorConstructor::PHG4SectorConstructor(const std::string &name) :
     name_base(name), DetectorVisAtt(NULL)
 {
   // TODO Auto-generated constructor stub

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
@@ -43,10 +43,10 @@ namespace PHG4Sector
   {
   public:
     Layer( //! name base for this layer
-        std::string _name,
+        const std::string &_name,
 
         //! material name in G4
-        std::string _material,
+        const std::string &_material,
 
         //! depth in G4 units
         double _depth,
@@ -146,14 +146,14 @@ namespace PHG4Sector
 
 #ifndef __CINT__
     void
-    set_layer_list(std::vector<Layer> layerList)
+    set_layer_list(const std::vector<Layer> &layerList)
     {
       layer_list = layerList;
     }
 #endif
 
     void
-    set_material(std::string _material)
+    set_material(const std::string &_material)
     {
       material = _material;
     }
@@ -369,7 +369,7 @@ namespace PHG4Sector
   class PHG4SectorConstructor
   {
   public:
-    PHG4SectorConstructor(std::string name);
+    PHG4SectorConstructor(const std::string &name);
     virtual
     ~PHG4SectorConstructor();
 

--- a/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.h
@@ -1,9 +1,10 @@
 #ifndef PHG4SectorSubsystem_h
 #define PHG4SectorSubsystem_h
 
-#include "g4main/PHG4Subsystem.h"
 
 #include "PHG4SectorConstructor.h"
+
+#include <g4main/PHG4Subsystem.h>
 
 class PHG4SectorDetector;
 class PHG4SectorSteppingAction;
@@ -62,7 +63,7 @@ public:
 
   //! geometry manager PHG4Sector::Sector_Geometry
   void
-  set_geometry(PHG4Sector::Sector_Geometry g)
+  set_geometry(const PHG4Sector::Sector_Geometry &g)
   {
     geom = g;
   }

--- a/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
@@ -159,9 +159,9 @@ PHG4mRICHDetector::BoxPar::BoxPar()
 //________________________________________________________________________//
 PHG4mRICHDetector::BoxPar::~BoxPar() {;}
 //________________________________________________________________________//
-PHG4mRICHDetector::PolyPar::PolyPar()
+PHG4mRICHDetector::PolyPar::PolyPar():
+  name("")
 {
-  name="";
   pos=G4ThreeVector(0*mm,0*mm,0*mm);
   start=(G4double) 0;
   theta=(G4double) 0;
@@ -181,7 +181,8 @@ PHG4mRICHDetector::PolyPar::PolyPar()
 //________________________________________________________________________//
 PHG4mRICHDetector::PolyPar::~PolyPar() {;}
 //________________________________________________________________________//
-PHG4mRICHDetector::LensPar::LensPar()
+PHG4mRICHDetector::LensPar::LensPar():
+  name("")
 {
   n=0;
   f=0;
@@ -190,7 +191,6 @@ PHG4mRICHDetector::LensPar::LensPar()
   centerThickness=0;
   grooveWidth=0;
 
-  name="";
   fill(begin(halfXYZ),end(halfXYZ),(G4double) 0*mm);
   pos=G4ThreeVector(0*mm,0*mm,0*mm);;
   material=G4Material::GetMaterial("G4_AIR");;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -1779,7 +1779,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           float zsize = cluster->get_z_size();
 
           float trackID = NAN;
-          if (track) trackID = track->get_id();
+          trackID = track->get_id();
 
           float g4hitID = NAN;
           float gx = NAN;

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWrite.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWrite.cc
@@ -91,7 +91,7 @@ void PHG4GDMLWrite::AddAuxInfo(PHG4GDMLAuxListType* auxInfoList,
                              xercesc::DOMElement* element)
 {
   for(std::vector<PHG4GDMLAuxStructType>::const_iterator
-      iaux = auxInfoList->begin(); iaux != auxInfoList->end(); iaux++ )
+      iaux = auxInfoList->begin(); iaux != auxInfoList->end(); ++iaux )
   {
     xercesc::DOMElement* auxiliaryElement = NewElement("auxiliary");
     element->appendChild(auxiliaryElement);

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWrite.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWrite.cc
@@ -280,15 +280,15 @@ G4Transform3D PHG4GDMLWrite::Write(const G4String& fname,
 
 void PHG4GDMLWrite::AddModule(const G4VPhysicalVolume* const physvol)
 {
-   G4String fname = GenerateName(physvol->GetName(),physvol);
-   G4cout << "PHG4GDML: Adding module '" << fname << "'..." << G4endl;
-
    if (physvol == 0)
    {
      G4Exception("PHG4GDMLWrite::AddModule()", "InvalidSetup", FatalException,
                  "Invalid NULL pointer is specified for modularization!");
      return;
    }
+   G4String fname = GenerateName(physvol->GetName(),physvol);
+   G4cout << "PHG4GDML: Adding module '" << fname << "'..." << G4endl;
+
    if (dynamic_cast<const G4PVDivision*>(physvol))
    {
      G4Exception("PHG4GDMLWrite::AddModule()", "InvalidSetup", FatalException,

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteMaterials.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteMaterials.cc
@@ -239,7 +239,7 @@ void PHG4GDMLWriteMaterials::PropertyWrite(xercesc::DOMElement* matElement,
                  std::less<G4String> >::const_iterator mpos;
    std::map< G4String, G4double,
                  std::less<G4String> >::const_iterator cpos;
-   for (mpos=pmap->begin(); mpos!=pmap->end(); mpos++)
+   for (mpos=pmap->begin(); mpos!=pmap->end(); ++mpos)
    {
       propElement = NewElement("property");
       propElement->setAttributeNode(NewAttribute("name", mpos->first));
@@ -259,7 +259,7 @@ void PHG4GDMLWriteMaterials::PropertyWrite(xercesc::DOMElement* matElement,
          continue;
       }
    }
-   for (cpos=cmap->begin(); cpos!=cmap->end(); cpos++)
+   for (cpos=cmap->begin(); cpos!=cmap->end(); ++cpos)
    {
       propElement = NewElement("property");
       propElement->setAttributeNode(NewAttribute("name", cpos->first));

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteSolids.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteSolids.cc
@@ -96,9 +96,6 @@ MultiUnionWrite(xercesc::DOMElement* solElement,
    G4int numSolids=munionSolid->GetNumberOfSolids();
    G4String tag("multiUnion");
 
-//   G4VSolid* solid;
-//   G4Transform3D* transform;
-
    const G4String& name = GenerateName(munionSolid->GetName(),munionSolid);
    xercesc::DOMElement* multiUnionElement = NewElement(tag);
    multiUnionElement->setAttributeNode(NewAttribute("name",name));

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteSolids.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteSolids.cc
@@ -96,8 +96,8 @@ MultiUnionWrite(xercesc::DOMElement* solElement,
    G4int numSolids=munionSolid->GetNumberOfSolids();
    G4String tag("multiUnion");
 
-   G4VSolid* solid;
-   G4Transform3D* transform;
+//   G4VSolid* solid;
+//   G4Transform3D* transform;
 
    const G4String& name = GenerateName(munionSolid->GetName(),munionSolid);
    xercesc::DOMElement* multiUnionElement = NewElement(tag);
@@ -105,8 +105,8 @@ MultiUnionWrite(xercesc::DOMElement* solElement,
 
    for (G4int i=0; i<numSolids; ++i)
    {
-      solid = munionSolid->GetSolid(i);
-      transform = munionSolid->GetTransformation(i);
+      G4VSolid* solid = munionSolid->GetSolid(i);
+      G4Transform3D* transform = munionSolid->GetTransformation(i);
 
       HepGeom::Rotate3D rot3d;
       HepGeom::Translate3D transl ;

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteStructure.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteStructure.cc
@@ -330,7 +330,7 @@ PHG4GDMLWriteStructure::GetSkinSurface(const G4LogicalVolume* const lvol)
     const G4LogicalSkinSurfaceTable* stable =
           G4LogicalSkinSurface::GetSurfaceTable();
     std::vector<G4LogicalSkinSurface*>::const_iterator pos;
-    for (pos = stable->begin(); pos != stable->end(); pos++)
+    for (pos = stable->begin(); pos != stable->end(); ++pos)
     {
       if (lvol == (*pos)->GetLogicalVolume())
       {
@@ -351,7 +351,7 @@ PHG4GDMLWriteStructure::GetBorderSurface(const G4VPhysicalVolume* const pvol)
     const G4LogicalBorderSurfaceTable* btable =
           G4LogicalBorderSurface::GetSurfaceTable();
     std::vector<G4LogicalBorderSurface*>::const_iterator pos;
-    for (pos = btable->begin(); pos != btable->end(); pos++)
+    for (pos = btable->begin(); pos != btable->end(); ++pos)
     {
       if (pvol == (*pos)->GetVolume1())  // just the first in the couple
       {                                  // is enough
@@ -367,11 +367,11 @@ void PHG4GDMLWriteStructure::SurfacesWrite()
    G4cout << "PHG4GDML: Writing surfaces..." << G4endl;
 
    std::vector<xercesc::DOMElement*>::const_iterator pos;
-   for (pos = skinElementVec.begin(); pos != skinElementVec.end(); pos++)
+   for (pos = skinElementVec.begin(); pos != skinElementVec.end(); ++pos)
    {
      structureElement->appendChild(*pos);
    }
-   for (pos = borderElementVec.begin(); pos != borderElementVec.end(); pos++)
+   for (pos = borderElementVec.begin(); pos != borderElementVec.end(); ++pos)
    {
      structureElement->appendChild(*pos);
    }

--- a/simulation/g4simulation/g4histos/G4RootScintillatorSlatContainer.cc
+++ b/simulation/g4simulation/g4histos/G4RootScintillatorSlatContainer.cc
@@ -11,7 +11,8 @@ using namespace std;
 static const int NMAX = 1000;
 
 G4RootScintillatorSlatContainer::G4RootScintillatorSlatContainer()
-  : etotal(NAN)
+  : idet(-9999)
+  , etotal(NAN)
   , eion(NAN)
   , leakage(NAN)
   , event(0)

--- a/simulation/g4simulation/g4histos/G4ScintillatorSlatTTree.cc
+++ b/simulation/g4simulation/g4histos/G4ScintillatorSlatTTree.cc
@@ -22,6 +22,7 @@ G4ScintillatorSlatTTree::G4ScintillatorSlatTTree(const std::string &name)
   , saveslats(1)
   , evtno(0)
   , hm(nullptr)
+  , etot_hist(nullptr)
 {
 }
 

--- a/simulation/g4simulation/g4jets/JetReco.cc
+++ b/simulation/g4simulation/g4jets/JetReco.cc
@@ -158,7 +158,7 @@ void JetReco::FillJetNode(PHCompositeNode *topNode, int ipos, std::vector<Jet *>
   }
   else
   {
-    jetmap = (JetMap *) JetMapNode->getData();
+    jetmap = dynamic_cast<JetMap *> (JetMapNode->getData());
   }
 
   jetmap->set_algo(_algos[ipos]->get_algo());

--- a/simulation/g4simulation/g4jets/JetReco.h
+++ b/simulation/g4simulation/g4jets/JetReco.h
@@ -46,8 +46,8 @@ class JetReco : public SubsysReco
     _outputs.push_back(output);
   }
 
-  void set_algo_node(std::string algonode) { _algonode = algonode; }
-  void set_input_node(std::string inputnode) { _inputnode = inputnode; }
+  void set_algo_node(const std::string &algonode) { _algonode = algonode; }
+  void set_input_node(const std::string &inputnode) { _inputnode = inputnode; }
 
  private:
   int CreateNodes(PHCompositeNode *topNode);

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -3,9 +3,6 @@
 #include "PHG4Particlev1.h"
 #include "PHG4Particlev2.h"
 
-#include <Geant4/G4ParticleDefinition.hh>
-#include <Geant4/G4ParticleTable.hh>
-
 #include <fun4all/Fun4AllReturnCodes.h>
 
 #include <phhepmc/PHHepMCGenEvent.h>
@@ -14,6 +11,9 @@
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
 #include <phool/recoConsts.h>
+
+#include <Geant4/G4ParticleDefinition.hh>
+#include <Geant4/G4ParticleTable.hh>
 
 #include <HepMC/GenEvent.h>
 
@@ -274,12 +274,10 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
 
         // For pile-up simulation: vertex position
         vtxindex = ineve->AddVtx(xpos, ypos, zpos, time);
-        int trackid = -1;
         for (fiter = finalstateparticles.begin();
              fiter != finalstateparticles.end();
              ++fiter)
         {
-          ++trackid;
 
           if (Verbosity() > 1) (*fiter)->print();
 

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -425,7 +425,7 @@ void PHG4TruthEventAction::ProcessShowers() {
 
 	// summary info
 	
-	if (g4hit)                                   ++nhits;
+	++nhits;
 	if (!isnan(g4hit->get_edep()))               edep += g4hit->get_edep();
 	if (!isnan(g4hit->get_eion()))               eion += g4hit->get_eion();
 	if (!isnan(g4hit->get_light_yield())) light_yield += g4hit->get_light_yield();

--- a/simulation/g4simulation/g4main/ReadEICFiles.h
+++ b/simulation/g4simulation/g4main/ReadEICFiles.h
@@ -29,7 +29,7 @@ class ReadEICFiles : public SubsysReco
   /** Set first entry from input tree to be used */
   void SetFirstEntry(int e) { entry = e; }
   /** Set name of output node */
-  void SetNodeName(std::string s) { _node_name = s; }
+  void SetNodeName(const std::string &s) { _node_name = s; }
   //! toss a new vertex according to a Uniform or Gaus distribution
   void set_vertex_distribution_function(PHHepMCGenHelper::VTXFUNC x, PHHepMCGenHelper::VTXFUNC y, PHHepMCGenHelper::VTXFUNC z, PHHepMCGenHelper::VTXFUNC t)
   {


### PR DESCRIPTION
After the number of cppcheck warnings went up (due to the EIC physics list), I went after most of them. One Caveat: PHG4CellDefs has a mixed up ordering of parameters in a genkey method (column and row are swapped). Just changing the order leads to changes in the results. I left this as is, that  needs to be looked at, it'll be the source of endless confusion