### PR TITLE
this change makes the cling loading complaint about JetMap.h go away

### DIFF
--- a/simulation/g4simulation/g4jets/JetMapv1LinkDef.h
+++ b/simulation/g4simulation/g4jets/JetMapv1LinkDef.h
@@ -1,7 +1,9 @@
 #ifdef __CINT__
+#pragma link C++ class JetMapv1 + ;
 
+#ifndef __CLING__
 #pragma link C++ class std::pair < unsigned int, Jet* > +;
 #pragma link C++ class std::map < unsigned int, Jet* > +;
-#pragma link C++ class JetMapv1 + ;
+#endif
 
 #endif /* __CINT__ */


### PR DESCRIPTION
It's not clear to me why this works or what those additional entries in the LinkDef file were about. They are still visible to root5 CINT. Lets see how this goes