### PR TITLE
Fix noname node

### DIFF
--- a/offline/framework/phool/PHCompositeNode.cc
+++ b/offline/framework/phool/PHCompositeNode.cc
@@ -15,11 +15,6 @@
 
 using namespace std;
 
-PHCompositeNode::PHCompositeNode()
-  : PHNode("NULL")
-{
-}
-
 PHCompositeNode::PHCompositeNode(const string& name)
   : PHNode(name, "PHCompositeNode")
   , deleteMe(0)

--- a/offline/framework/phool/PHCompositeNode.h
+++ b/offline/framework/phool/PHCompositeNode.h
@@ -42,7 +42,7 @@ class PHCompositeNode : public PHNode
   int deleteMe;
 
  private:
-  PHCompositeNode();
+  PHCompositeNode() = delete;
 };
 
 #endif /* PHCOMPOSITENODE_H__ */

--- a/offline/framework/phool/PHCompositeNode.h
+++ b/offline/framework/phool/PHCompositeNode.h
@@ -1,5 +1,5 @@
-#ifndef PHCOMPOSITENODE_H__
-#define PHCOMPOSITENODE_H__
+#ifndef PHOOL_PHCOMPOSITENODE_H
+#define PHOOL_PHCOMPOSITENODE_H
 
 //  Declaration of class PHCompositeNode
 //  Purpose: a node which can hold other nodes
@@ -15,7 +15,7 @@ class PHCompositeNode : public PHNode
   friend class PHNodeIterator;
 
  public:
-  PHCompositeNode(const std::string &);
+  explicit PHCompositeNode(const std::string &);
   virtual ~PHCompositeNode();
 
   //
@@ -45,4 +45,4 @@ class PHCompositeNode : public PHNode
   PHCompositeNode() = delete;
 };
 
-#endif /* PHCOMPOSITENODE_H__ */
+#endif

--- a/offline/framework/phool/PHDataNode.h
+++ b/offline/framework/phool/PHDataNode.h
@@ -34,14 +34,9 @@ class PHDataNode : public PHNode
     TObject* tobj;
   };
   tobjcast data;
-  PHDataNode();
+  PHDataNode() = delete;
 };
 
-template <class T>
-PHDataNode<T>::PHDataNode()
-{
-  data.data = 0;
-}
 
 template <class T>
 PHDataNode<T>::PHDataNode(T* d,

--- a/offline/framework/phool/PHDataNode.h
+++ b/offline/framework/phool/PHDataNode.h
@@ -1,5 +1,5 @@
-#ifndef PHDATANODE_H__
-#define PHDATANODE_H__
+#ifndef PHOOL_PHDATANODE_H
+#define PHOOL_PHDATANODE_H
 
 //  Declaration of class PHDataNode
 //  Purpose: a node which can hold a data object (template)
@@ -93,4 +93,4 @@ void PHDataNode<T>::print(const std::string& path)
   std::cout << ")" << std::endl;
 }
 
-#endif /* __PHDATANODE_H__ */
+#endif

--- a/offline/framework/phool/PHDataNode.h
+++ b/offline/framework/phool/PHDataNode.h
@@ -37,7 +37,6 @@ class PHDataNode : public PHNode
   PHDataNode() = delete;
 };
 
-
 template <class T>
 PHDataNode<T>::PHDataNode(T* d,
                           const std::string& name)

--- a/offline/framework/phool/PHDataNodeIterator.h
+++ b/offline/framework/phool/PHDataNodeIterator.h
@@ -1,10 +1,10 @@
 #ifndef PHOOL_PHDATANODEITERATOR_H
 #define PHOOL_PHDATANODEITERATOR_H
 
-#include <cstddef>
-#include "PHIODataNode.h"
 #include "PHIODataNode.h"
 #include "PHNodeIterator.h"
+
+#include <cstddef>
 
 /**
  * A special PHOOL node iterator that simplifies finding and adding data

--- a/offline/framework/phool/PHDataNodeIterator.h
+++ b/offline/framework/phool/PHDataNodeIterator.h
@@ -1,5 +1,5 @@
-#ifndef __PHDATANODEITERATOR_H__
-#define __PHDATANODEITERATOR_H__
+#ifndef PHOOL_PHDATANODEITERATOR_H
+#define PHOOL_PHDATANODEITERATOR_H
 
 #include <cstddef>
 #include "PHIODataNode.h"
@@ -90,4 +90,4 @@ PHDataNodeIterator::AddIODataNode(T* data, const char* name)
   return addNode(n);
 }
 
-#endif /* __PHDATANODEITERATOR_H__ */
+#endif

--- a/offline/framework/phool/PHFlag.h
+++ b/offline/framework/phool/PHFlag.h
@@ -51,6 +51,7 @@ class PHFlag
   virtual const std::map<std::string, float> *FloatMap() const { return &floatflag; }
   virtual const std::map<std::string, double> *DoubleMap() const { return &doubleflag; }
   virtual const std::map<std::string, std::string> *CharMap() const { return &charflag; }
+
  protected:
   std::map<std::string, int> intflag;
   std::map<std::string, double> doubleflag;

--- a/offline/framework/phool/PHFlag.h
+++ b/offline/framework/phool/PHFlag.h
@@ -1,5 +1,5 @@
-#ifndef PHFLAG_H
-#define PHFLAG_H
+#ifndef PHOOL_PHFLAG_H
+#define PHOOL_PHFLAG_H
 
 /*
   General purpose flag package:
@@ -58,4 +58,4 @@ class PHFlag
   std::map<std::string, std::string> charflag;
 };
 
-#endif /* PHFLAG_H */
+#endif

--- a/offline/framework/phool/PHFlagLinkDef.h
+++ b/offline/framework/phool/PHFlagLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHFlag-!;
+#pragma link C++ class PHFlag - !;
 
 #endif /* __CINT__ */

--- a/offline/framework/phool/PHIODataNode.h
+++ b/offline/framework/phool/PHIODataNode.h
@@ -1,5 +1,5 @@
-#ifndef PHIODATANODE_H__
-#define PHIODATANODE_H__
+#ifndef PHOOL_PHIODATANODE_H
+#define PHOOL_PHIODATANODE_H
 
 //  Declaration of class PHIODataNode which can hold persistent data
 //  Author: Matthias Messer

--- a/offline/framework/phool/PHIODataNode.h
+++ b/offline/framework/phool/PHIODataNode.h
@@ -28,7 +28,7 @@ class PHIODataNode : public PHDataNode<T>
 
  protected:
   virtual bool write(PHIOManager *, const std::string & = "");
-  PHIODataNode() {}
+  PHIODataNode() = delete;
 };
 
 template <class T>

--- a/offline/framework/phool/PHIOManager.h
+++ b/offline/framework/phool/PHIOManager.h
@@ -13,6 +13,7 @@ class PHIOManager
 {
  public:
   virtual ~PHIOManager() {}
+
  public:
   std::string getFilename() const { return filename; }
   size_t getEventNumber() const { return eventNumber; }

--- a/offline/framework/phool/PHIOManager.h
+++ b/offline/framework/phool/PHIOManager.h
@@ -1,5 +1,5 @@
-#ifndef PHIOMANAGER_H__
-#define PHIOMANAGER_H__
+#ifndef PHOOL_PHIOMANAGER_H
+#define PHOOL_PHIOMANAGER_H
 
 //  Declaration of class PHIOManager
 //  Purpose: Abstract base class for file IO
@@ -31,4 +31,4 @@ class PHIOManager
   size_t eventNumber;
 };
 
-#endif /* PHIOMANAGER_H__ */
+#endif

--- a/offline/framework/phool/PHNode.cc
+++ b/offline/framework/phool/PHNode.cc
@@ -13,8 +13,10 @@
 
 using namespace std;
 
-PHNode::PHNode(const string& n): PHNode(n,"")
-{}
+PHNode::PHNode(const string& n)
+  : PHNode(n, "")
+{
+}
 
 PHNode::PHNode(const string& n, const string& typ)
   : parent(nullptr)
@@ -58,7 +60,6 @@ PHNode::~PHNode()
     parent->forgetMe(this);
   }
 }
-
 
 // Implementation of external functions.
 std::ostream&

--- a/offline/framework/phool/PHNode.cc
+++ b/offline/framework/phool/PHNode.cc
@@ -4,19 +4,14 @@
 
 #include "phool.h"
 
+#include <TSystem.h>
+
+#include <boost/stacktrace.hpp>
+
 #include <cstdlib>
 #include <iostream>
 
 using namespace std;
-
-PHNode::PHNode()
-  : parent(nullptr)
-  , persistent(true)
-  , type("PHNode")
-  , reset_able(true)
-{
-  return;
-}
 
 PHNode::PHNode(const string& n)
   : parent(nullptr)
@@ -24,30 +19,38 @@ PHNode::PHNode(const string& n)
   , type("PHNode")
   , reset_able(true)
 {
+  int badnode = 0;
   if (n.find(".") != string::npos)
   {
     cout << PHWHERE << " No nodenames containing decimal point possible: "
          << n << endl;
-    exit(1);
+    badnode = 1;
+  }
+  if (n.empty())
+  {
+    cout << PHWHERE << "Empty string as nodename given" << endl;
+    badnode = 1;
+  }
+  if (n.find(" ") != string::npos)
+  {
+    badnode = 1;
+    cout << PHWHERE << "No nodenames with spaces" << endl;
+  }
+  if (badnode)
+  {
+    cout << "Here is the stacktrace: " << endl;
+    cout << boost::stacktrace::stacktrace();
+    cout << "Check the stacktrace for the guilty party (typically #2)" << endl;
+    gSystem->Exit(1);
   }
   name = n;
   return;
 }
 
 PHNode::PHNode(const string& n, const string& typ)
-  : parent(nullptr)
-  , persistent(true)
-  , type("PHNode")
-  , objecttype(typ)
-  , reset_able(true)
+  : PHNode(n)
 {
-  if (n.find(".") != string::npos)
-  {
-    cout << PHWHERE << " No nodenames containing decimal point possible: "
-         << n << endl;
-    exit(1);
-  }
-  name = n;
+  objecttype = typ;
   return;
 }
 

--- a/offline/framework/phool/PHNode.cc
+++ b/offline/framework/phool/PHNode.cc
@@ -13,10 +13,14 @@
 
 using namespace std;
 
-PHNode::PHNode(const string& n)
+PHNode::PHNode(const string& n): PHNode(n,"")
+{}
+
+PHNode::PHNode(const string& n, const string& typ)
   : parent(nullptr)
   , persistent(true)
   , type("PHNode")
+  , objecttype(typ)
   , reset_able(true)
 {
   int badnode = 0;
@@ -44,13 +48,6 @@ PHNode::PHNode(const string& n)
     gSystem->Exit(1);
   }
   name = n;
-  return;
-}
-
-PHNode::PHNode(const string& n, const string& typ)
-  : PHNode(n)
-{
-  objecttype = typ;
   return;
 }
 

--- a/offline/framework/phool/PHNode.h
+++ b/offline/framework/phool/PHNode.h
@@ -36,8 +36,8 @@ class PHNode
   virtual void setResetFlag(const bool b) { reset_able = b; }
   virtual bool getResetFlag() const { return reset_able; }
   void makeTransient() { persistent = false; }
- protected:
 
+ protected:
   PHNode *parent;
   bool persistent;
   std::string type;
@@ -45,7 +45,8 @@ class PHNode
   std::string name;
   bool reset_able;
   std::string objectclass;
-private:
+
+ private:
   PHNode() = delete;
   PHNode(const PHNode &) = delete;
   PHNode &operator=(const PHNode &) = delete;

--- a/offline/framework/phool/PHNode.h
+++ b/offline/framework/phool/PHNode.h
@@ -37,16 +37,16 @@ class PHNode
   virtual bool getResetFlag() const { return reset_able; }
   void makeTransient() { persistent = false; }
  protected:
-  PHNode();
 
   PHNode *parent;
   bool persistent;
   std::string type;
   std::string objecttype;
   std::string name;
-  std::string objectclass;
   bool reset_able;
+  std::string objectclass;
 private:
+  PHNode() = delete;
   PHNode(const PHNode &) = delete;
   PHNode &operator=(const PHNode &) = delete;
 };

--- a/offline/framework/phool/PHNode.h
+++ b/offline/framework/phool/PHNode.h
@@ -1,5 +1,5 @@
-#ifndef PHNODE_H__
-#define PHNODE_H__
+#ifndef PHOOL_PHNODE_H
+#define PHOOL_PHNODE_H
 
 //  Declaration of class PHNode
 //  Purpose: abstract base class for all node classes
@@ -53,4 +53,4 @@ private:
 
 std::ostream &operator<<(std::ostream &, const PHNode &);
 
-#endif /* __PHNODE_H__ */
+#endif

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -278,14 +278,14 @@ void PHNodeIOManager::print() const
 string
 PHNodeIOManager::getBranchClassName(TBranch* branch)
 {
-// OK. Here all the game is to find out the name of the type
-// contained in this branch.  In ROOT pre-3.01/05 versions, all
-// branches we used were of the same type = TBranchObject, so that
-// was easy.  Since version 3.01/05 ROOT introduced new branch style
-// with some TBranchElement objects. So far so good.  The problem is
-// that I did not find a common way to grab the typename of the
-// object contained in those branches, so I hereby use some durty if
-// { } else if { } ...
+  // OK. Here all the game is to find out the name of the type
+  // contained in this branch.  In ROOT pre-3.01/05 versions, all
+  // branches we used were of the same type = TBranchObject, so that
+  // was easy.  Since version 3.01/05 ROOT introduced new branch style
+  // with some TBranchElement objects. So far so good.  The problem is
+  // that I did not find a common way to grab the typename of the
+  // object contained in those branches, so I hereby use some durty if
+  // { } else if { } ...
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(3, 01, 5)
   TBranchElement* be = dynamic_cast<TBranchElement*>(branch);

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -1,5 +1,5 @@
-#ifndef PHNODEIOMANAGER_H__
-#define PHNODEIOMANAGER_H__
+#ifndef PHOOL_PHNODEIOMANAGER_H
+#define PHOOL_PHNODEIOMANAGER_H
 
 //  Declaration of class PHNodeIOManager
 //  Purpose: manages file IO for PHIODataNodes
@@ -64,4 +64,4 @@ class PHNodeIOManager : public PHIOManager
   int isFunctionalFlag;  // flag to tell if that object initialized properly
 };
 
-#endif /* __PHNODEIOMANAGER_H__ */
+#endif

--- a/offline/framework/phool/PHNodeIntegrate.h
+++ b/offline/framework/phool/PHNodeIntegrate.h
@@ -1,5 +1,5 @@
-#ifndef PHNodeIntegrate_h
-#define PHNodeIntegrate_h
+#ifndef PHOOL_PHNODEINTEGRATE_H
+#define PHOOL_PHNODEINTEGRATE_H
 
 //  Declaration of class PHNodeIntegrate
 //  Purpose: strategy which calls Integrate() on a PHNode if it is
@@ -36,4 +36,4 @@ class PHNodeIntegrate : public PHNodeOperation
   PHCompositeNode *runsumnode;
 };
 
-#endif /* PHNodeIntegrate_h */
+#endif

--- a/offline/framework/phool/PHNodeIterator.h
+++ b/offline/framework/phool/PHNodeIterator.h
@@ -1,5 +1,5 @@
-#ifndef PHNODEITERATOR_H__
-#define PHNODEITERATOR_H__
+#ifndef PHOOL_PHNODEITERATOR_H
+#define PHOOL_PHNODEITERATOR_H
 
 //  Declaration of class PHNodeIterator
 //  Purpose: iterator to navigate a node tree
@@ -13,7 +13,7 @@ class PHNodeOperation;
 class PHNodeIterator
 {
  public:
-  PHNodeIterator(PHCompositeNode*);
+  explicit PHNodeIterator(PHCompositeNode*);
   virtual ~PHNodeIterator() {}
   PHNodeIterator();
 
@@ -32,4 +32,4 @@ class PHNodeIterator
   PHPointerList<PHNode> subNodeList;
 };
 
-#endif /* __PHNODEITERATOR_H__ */
+#endif

--- a/offline/framework/phool/PHNodeIterator.h
+++ b/offline/framework/phool/PHNodeIterator.h
@@ -27,6 +27,7 @@ class PHNodeIterator
   void forEach(PHNodeOperation&);
   void for_each(PHNodeOperation&);
   PHCompositeNode* get_currentNode() const { return currentNode; }
+
  protected:
   PHCompositeNode* currentNode;
   PHPointerList<PHNode> subNodeList;

--- a/offline/framework/phool/PHNodeOperation.h
+++ b/offline/framework/phool/PHNodeOperation.h
@@ -28,6 +28,7 @@ class PHNodeOperation
 
   virtual void Verbosity(const int i) { verbosity = i; }
   virtual int Verbosity() const { return verbosity; }
+
  protected:
   virtual void perform(PHNode*) = 0;
   int verbosity;

--- a/offline/framework/phool/PHNodeOperation.h
+++ b/offline/framework/phool/PHNodeOperation.h
@@ -1,5 +1,5 @@
-#ifndef PHNodeOperation_h
-#define PHNodeOperation_h
+#ifndef PHOOL_PHNODEOPERATION_H
+#define PHOOL_PHNODEOPERATION_H
 
 //  Declaration of class PHNodeOperation
 //  Purpose: abstract strategy base class which operates on PHNodes
@@ -33,4 +33,4 @@ class PHNodeOperation
   int verbosity;
 };
 
-#endif /* PHNodeOperation_h */
+#endif

--- a/offline/framework/phool/PHNodeReset.h
+++ b/offline/framework/phool/PHNodeReset.h
@@ -14,6 +14,7 @@ class PHNodeReset : public PHNodeOperation
  public:
   PHNodeReset() {}
   virtual ~PHNodeReset() {}
+
  protected:
   virtual void perform(PHNode*);
 };

--- a/offline/framework/phool/PHNodeReset.h
+++ b/offline/framework/phool/PHNodeReset.h
@@ -1,5 +1,5 @@
-#ifndef PHNodeReset_h
-#define PHNodeReset_h
+#ifndef PHOOL_PHNODERESET_H
+#define PHOOL_PHNODERESET_H
 
 //  Declaration of class PHNodeReset
 //  Purpose: strategy which calls reset() on a PHNode
@@ -18,4 +18,4 @@ class PHNodeReset : public PHNodeOperation
   virtual void perform(PHNode*);
 };
 
-#endif /* PHNodeReset_h */
+#endif

--- a/offline/framework/phool/PHObject.h
+++ b/offline/framework/phool/PHObject.h
@@ -46,8 +46,8 @@ class PHObject : public TObject
 
   int SplitLevel() const { return 99; }
   int BufferSize() const { return 32000; }
- private:
 
+ private:
   ClassDef(PHObject, 0)  // no I/O
 };
 

--- a/offline/framework/phool/PHObjectLinkDef.h
+++ b/offline/framework/phool/PHObjectLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHObject+;
+#pragma link C++ class PHObject + ;
 
 #endif /* __CINT__ */

--- a/offline/framework/phool/PHOperation.h
+++ b/offline/framework/phool/PHOperation.h
@@ -1,5 +1,5 @@
-#ifndef __PHOPERATION_H__
-#define __PHOPERATION_H__
+#ifndef PHOOL_PHOPERATION_H
+#define PHOOL_PHOPERATION_H
 
 //  Declaration of class PHOperation
 //  Purpose: abstract strategy base class

--- a/offline/framework/phool/PHPointerList.h
+++ b/offline/framework/phool/PHPointerList.h
@@ -1,5 +1,5 @@
-#ifndef PHPOINTERLIST_H__
-#define PHPOINTERLIST_H__
+#ifndef PHOOL_PHPOINTERLIST_H
+#define PHOOL_PHPOINTERLIST_H
 
 //  Purpose: a template list of pointers
 //
@@ -30,7 +30,7 @@ template <class T>
 class PHPointerList
 {
  public:
-  PHPointerList(size_t = 2);
+  explicit PHPointerList(size_t = 2);
   PHPointerList(const PHPointerList<T>&);
   PHPointerList<T>& operator=(const PHPointerList<T>&);
   virtual ~PHPointerList();
@@ -260,4 +260,4 @@ operator<<(std::ostream& stream, const PHPointerList<T>& thislist)
   return stream;
 }
 
-#endif /* __PHPOINTERLIST_H__ */
+#endif

--- a/offline/framework/phool/PHPointerListIterator.h
+++ b/offline/framework/phool/PHPointerListIterator.h
@@ -10,18 +10,21 @@
 template <class T>
 class PHPointerListIterator
 {
-  public:
+ public:
   explicit PHPointerListIterator(const PHPointerList<T>&);
   virtual ~PHPointerListIterator() {}
   T* operator()();
   void operator--();
   void reset();
   size_t pos() const { return m_Index; }
+
  private:
-#if defined(__CINT__) && ! defined(__CLING__)
-  PHPointerListIterator() {}
+#if defined(__CINT__) && !defined(__CLING__)
+  PHPointerListIterator()
+  {
+  }
 #else
-  PHPointerListIterator() = delete; 
+  PHPointerListIterator() = delete;
 #endif
   const PHPointerList<T>& m_List;
   size_t m_Index;

--- a/offline/framework/phool/PHPointerListIterator.h
+++ b/offline/framework/phool/PHPointerListIterator.h
@@ -11,7 +11,7 @@ template <class T>
 class PHPointerListIterator
 {
   public:
-  PHPointerListIterator(const PHPointerList<T>&);
+  explicit PHPointerListIterator(const PHPointerList<T>&);
   virtual ~PHPointerListIterator() {}
   T* operator()();
   void operator--();

--- a/offline/framework/phool/PHRandomSeed.h
+++ b/offline/framework/phool/PHRandomSeed.h
@@ -1,5 +1,5 @@
-#ifndef PHRANDOMSEED_H
-#define PHRANDOMSEED_H
+#ifndef PHOOL_PHRANDOMSEED_H
+#define PHOOL_PHRANDOMSEED_H
 
 //! standard way to get a random seed:
 //! `unsigned int seed = PHRandomSeed();`

--- a/offline/framework/phool/PHRandomSeedLinkDef.h
+++ b/offline/framework/phool/PHRandomSeedLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHRandomSeed-!;
+#pragma link C++ class PHRandomSeed - !;
 
 #endif /* __CINT__ */

--- a/offline/framework/phool/PHRawDataNode.h
+++ b/offline/framework/phool/PHRawDataNode.h
@@ -29,6 +29,7 @@ class PHRawDataNode : public PHDataNode<PHDWORD>
   void setID(const int val) { ID = val; }
   void setWordLength(const int val) { wordLength = val; }
   void setHitFormat(const int val) { hitFormat = val; }
+
  private:
   int length;
   int ID;

--- a/offline/framework/phool/PHRawDataNode.h
+++ b/offline/framework/phool/PHRawDataNode.h
@@ -1,5 +1,5 @@
-#ifndef PHRAWDATANODE_H__
-#define PHRAWDATANODE_H__
+#ifndef PHOOL_PHRAWDATANODE_H
+#define PHOOL_PHRAWDATANODE_H
 
 //  Declaration of class PHRawDataNode
 //  Purpose: Node digested by the PHRawOManager
@@ -36,4 +36,4 @@ class PHRawDataNode : public PHDataNode<PHDWORD>
   int hitFormat;
 };
 
-#endif /* PHRAWDATANODE_H__ */
+#endif

--- a/offline/framework/phool/PHRawOManager.h
+++ b/offline/framework/phool/PHRawOManager.h
@@ -1,5 +1,5 @@
-#ifndef PHRAWOMANAGER_H__
-#define PHRAWOMANAGER_H__
+#ifndef PHOOL_PHRAWOMANAGER_H
+#define PHOOL_PHRAWOMANAGER_H
 
 //-----------------------------------------------------------------------------
 //
@@ -61,4 +61,4 @@ class PHRawOManager : public PHIOManager
   int compressionLevel;
 };
 
-#endif /* PHRAWOMANAGER_H__ */
+#endif

--- a/offline/framework/phool/PHTimeServer.h
+++ b/offline/framework/phool/PHTimeServer.h
@@ -142,7 +142,7 @@ class PHTimeServer
 
    protected:
     //! creator
-    iterator(PHTimeServer::time_map &map)
+    explicit iterator(PHTimeServer::time_map &map)
       : _map(map)
       , _iter(_map.begin())
     {

--- a/offline/framework/phool/PHTimeServer.h
+++ b/offline/framework/phool/PHTimeServer.h
@@ -12,8 +12,8 @@
 #include "PHTimer.h"
 
 #include <iostream>
-#include <memory>
 #include <map>
+#include <memory>
 #include <string>
 
 #ifndef __CINT__
@@ -142,7 +142,7 @@ class PHTimeServer
 
    protected:
     //! creator
-    explicit iterator(PHTimeServer::time_map &map)
+    explicit iterator(PHTimeServer::time_map& map)
       : _map(map)
       , _iter(_map.begin())
     {

--- a/offline/framework/phool/PHTimeServerLinkDef.h
+++ b/offline/framework/phool/PHTimeServerLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHTimeServer-!;
+#pragma link C++ class PHTimeServer - !;
 
 #endif /* __CINT__ */

--- a/offline/framework/phool/PHTimeStamp.cc
+++ b/offline/framework/phool/PHTimeStamp.cc
@@ -18,9 +18,9 @@ using namespace std;
 const unsigned long long PHTimeStamp::PHFarFuture = ULLONG_MAX;
 
 #ifndef HAVE_STRPTIME_PROTOTYPE
-extern "C" {
-char *strptime(const char *s, const char *format, struct
-               tm *tm);
+extern "C"
+{
+  char *strptime(const char *s, const char *format, struct tm *tm);
 }
 #endif
 

--- a/offline/framework/phool/PHTimeStamp.h
+++ b/offline/framework/phool/PHTimeStamp.h
@@ -19,8 +19,7 @@ typedef unsigned long long phtime_t;
 class PHTimeStamp : public PHObject
 {
  public:
-
-  static const unsigned long long PHFarFuture;// set to ULLONG_MAX
+  static const unsigned long long PHFarFuture;  // set to ULLONG_MAX
 
   PHTimeStamp();
 
@@ -29,6 +28,7 @@ class PHTimeStamp : public PHObject
   void setBinTics(const phtime_t t);
 
   virtual ~PHTimeStamp() {}
+
  public:
   void set(const int, const int, const int, const int, const int, const int, const int = 0);
 

--- a/offline/framework/phool/PHTimeStampLinkDef.h
+++ b/offline/framework/phool/PHTimeStampLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHTimeStamp+;
+#pragma link C++ class PHTimeStamp + ;
 
 #ifndef __CLING__
 #pragma link C++ function operator+ (const PHTimeStamp &, time_t);

--- a/offline/framework/phool/PHTimer.h
+++ b/offline/framework/phool/PHTimer.h
@@ -1,7 +1,5 @@
-// $Id: PHTimer.h,v 1.6 2013/01/07 09:27:01 bbannier Exp $
-
-#ifndef __PHTIMER_H__
-#define __PHTIMER_H__
+#ifndef PHOOL_PHTIMER_H
+#define PHOOL_PHTIMER_H
 
 /*!
 \file		PHTimer.h
@@ -39,7 +37,7 @@ class PHTimer
   }
 
   //! Construct with a name
-  PHTimer(const std::string& name = "Generic Timer")
+  explicit PHTimer(const std::string& name = "Generic Timer")
     : _name(name)
     , _state(STOP)
     , _start_time(get_clock_counts())

--- a/offline/framework/phool/PHTypedNodeIterator.h
+++ b/offline/framework/phool/PHTypedNodeIterator.h
@@ -1,5 +1,5 @@
-#ifndef __PHTYPEDNODEITERATOR_H__
-#define __PHTYPEDNODEITERATOR_H__
+#ifndef PHOOL_PHTYPEDNODEITERATOR_H
+#define PHOOL_PHTYPEDNODEITERATOR_H
 
 #include "PHNodeIterator.h"
 
@@ -21,16 +21,16 @@ class PHTypedNodeIterator : public PHNodeIterator
 {
  public:
   /// Constructor
-  PHTypedNodeIterator(PHCompositeNode* n)
+  explicit PHTypedNodeIterator(PHCompositeNode* n)
     : PHNodeIterator(n)
   {
-    myIODataNode = 0;
+    myIODataNode = nullptr;
   }
 
   PHTypedNodeIterator()
     : PHNodeIterator()
   {
-    myIODataNode = 0;
+    myIODataNode = nullptr;
   }
 
   T& operator*();
@@ -126,4 +126,4 @@ bool PHTypedNodeIterator<T>::insert(T* data, const char* name)
 // Typedef to simplify notation.
 typedef PHTypedNodeIterator<TObject> PHRootNodeIterator;
 
-#endif /* __PHTYPEDNODEITERATOR_H__ */
+#endif

--- a/offline/framework/phool/getClass.h
+++ b/offline/framework/phool/getClass.h
@@ -1,5 +1,5 @@
-#ifndef GETCLASS_H__
-#define GETCLASS_H__
+#ifndef PHOOL_GETCLASS_H
+#define PHOOL_GETCLASS_H
 
 #include "PHDataNode.h"
 #include "PHIODataNode.h"
@@ -21,7 +21,7 @@ T *getClass(PHCompositeNode *top, const std::string &name)
   PHNode *FoundNode = iter.findFirst(name.c_str());  // returns pointer to PHNode
   if (!FoundNode)
   {
-    return NULL;
+    return nullptr;
   }
   // first test if it is a PHDataNode
   PHDataNode<T> *DNode = dynamic_cast<PHDataNode<T> *>(FoundNode);
@@ -45,7 +45,7 @@ T *getClass(PHCompositeNode *top, const std::string &name)
     T *object = dynamic_cast<T *>(IONode->getData());
     if (!object)
     {
-      return NULL;
+      return nullptr;
     }
     else
     {
@@ -53,8 +53,8 @@ T *getClass(PHCompositeNode *top, const std::string &name)
     }
   }
 
-  return NULL;
+  return nullptr;
 }
 }
 
-#endif /* GETCLASS_H */
+#endif

--- a/offline/framework/phool/getClass.h
+++ b/offline/framework/phool/getClass.h
@@ -55,6 +55,6 @@ T *getClass(PHCompositeNode *top, const std::string &name)
 
   return nullptr;
 }
-}
+}  // namespace findNode
 
 #endif

--- a/offline/framework/phool/phool.h
+++ b/offline/framework/phool/phool.h
@@ -1,5 +1,5 @@
-#ifndef __PHOOL_H__
-#define __PHOOL_H__
+#ifndef PHOOL_PHOOL_H
+#define PHOOL_PHOOL_H
 
 //  Standard PHOOL's header file.
 //  Purpose: declarations and definitions for PHOOL

--- a/offline/framework/phool/phooldefs.h
+++ b/offline/framework/phool/phooldefs.h
@@ -7,6 +7,6 @@ namespace phooldefs
 {
 static const std::string branchpathdelim = ".";
 static const std::string nodetreepathdelim = "/";
-};
+};  // namespace phooldefs
 
 #endif

--- a/offline/framework/phool/phooldefs.h
+++ b/offline/framework/phool/phooldefs.h
@@ -1,5 +1,5 @@
-#ifndef PHOOLDEFS_H__
-#define PHOOLDEFS_H__
+#ifndef PHOOL_PHOOLDEFS_H
+#define PHOOL_PHOOLDEFS_H
 
 #include <string>
 

--- a/offline/framework/phool/recoConsts.h
+++ b/offline/framework/phool/recoConsts.h
@@ -1,8 +1,8 @@
 // Do yourself and others a favour, please sort variable/function name
 // according to the roman alphabet
 
-#ifndef RECOCONSTS_H__
-#define RECOCONSTS_H__
+#ifndef PHOOL_RECOCONSTS_H
+#define PHOOL_RECOCONSTS_H
 
 #include "PHFlag.h"
 
@@ -18,9 +18,9 @@ class recoConsts : public PHFlag
 
   void Print() const;
 
- protected:
+ private:
   recoConsts() {}
   static recoConsts *__instance;
 };
 
-#endif /* __RECOCONSTS_H__ */
+#endif

--- a/offline/framework/phool/recoConstsLinkDef.h
+++ b/offline/framework/phool/recoConstsLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class recoConsts-!;
+#pragma link C++ class recoConsts - !;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4jets/Jet.h
+++ b/simulation/g4simulation/g4jets/Jet.h
@@ -63,6 +63,7 @@ class Jet : public PHObject
     prop_SeedItr = 4,
   };
 
+  Jet() {}
   virtual ~Jet() {}
 
   virtual void identify(std::ostream& os = std::cout) const;
@@ -135,11 +136,6 @@ class Jet : public PHObject
   virtual Iter upper_bound_comp(Jet::SRC source) { return typ_comp_ids().end(); }
   virtual Iter find(Jet::SRC source) { return typ_comp_ids().end(); }
   virtual Iter end_comp() { return typ_comp_ids().end(); }
-
- protected:
-  Jet() {}
-
-  /*! @} */
 
   ClassDef(Jet, 1);
 };

--- a/simulation/g4simulation/g4jets/JetMap.h
+++ b/simulation/g4simulation/g4jets/JetMap.h
@@ -21,6 +21,7 @@ class JetMap : public PHObject
   typedef std::set<Jet::SRC>::const_iterator ConstSrcIter;
   typedef std::set<Jet::SRC>::iterator SrcIter;
 
+  JetMap();
   virtual ~JetMap() {}
 
   virtual void identify(std::ostream& os = std::cout) const;
@@ -69,9 +70,6 @@ class JetMap : public PHObject
   virtual Iter begin() { return typ_JetMap().end(); }
   virtual Iter find(unsigned int idkey) { return typ_JetMap().end(); }
   virtual Iter end() { return typ_JetMap().end(); }
-
- protected:
-  JetMap();
 
  private:
   ClassDef(JetMap, 1);

--- a/simulation/g4simulation/g4jets/JetMapv1LinkDef.h
+++ b/simulation/g4simulation/g4jets/JetMapv1LinkDef.h
@@ -1,9 +1,5 @@
 #ifdef __CINT__
-#pragma link C++ class JetMapv1 + ;
 
-#ifndef __CLING__
-#pragma link C++ class std::pair < unsigned int, Jet* > +;
-#pragma link C++ class std::map < unsigned int, Jet* > +;
-#endif
+#pragma link C++ class JetMapv1 + ;
 
 #endif /* __CINT__ */


### PR DESCRIPTION
This turned out to be a macro issue, the detector was not set in a module leading to empty node names. phool now picks up invalid names (empty, containing spaces and decimal points) and prints a stacktrace before quitting so we have an idea where this came from.
Unrelated to this - adjusted the include guard names, replaced NULL by nullptr and ran clang-format

Minor change to g4jets: in order for root to be able to call the default ctor, it has to be public, not protected or private