### PR TITLE
INTT new endcap ring geometry using Carbon-PEEK

### DIFF
--- a/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
@@ -941,44 +941,69 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
 
   G4LogicalVolume *endcap_WG_ring_volume = new G4LogicalVolume(endcap_WG_ring, G4Material::GetMaterial("WaterGlycol_INTT"),
                                                                "endcap_WG_ring_volume", 0, 0, 0);
+  // Carbon PEEK ring
+  G4Tubs *endcap_CP_ring = new G4Tubs("endcap_CP_ring",
+                                       supportparams->get_double_param("endcap_CPring_inner_radius") * cm,
+                                       supportparams->get_double_param("endcap_CPring_outer_radius") * cm,
+                                       supportparams->get_double_param("endcap_CPring_length") * cm / 2.,
+                                       -M_PI, 2.0 * M_PI);
+
+  G4LogicalVolume *endcap_CP_ring_volume = new G4LogicalVolume(endcap_CP_ring, G4Material::GetMaterial("CF30_PEEK70"),
+                                                               "endcap_CP_ring_volume", 0, 0, 0);
 
   if(m_IsEndcapActive)
   {
-    // Place endcap rings
-    double endcap_ring_z = supportparams->get_double_param("endcap_ring_z") * cm; 
-    for(int i = 0; i < 2; i++) // i=0 : positive z, i=1 negative z
+    if(supportparams->get_int_param("endcap_ring_type")==0) // Place Al endcap rings
     {
-
-      endcap_ring_z = (i==0) ?  endcap_ring_z : -1.0 * endcap_ring_z;
-
-      double width_WGring_z = supportparams->get_double_param("endcap_WGring_length") * cm;
-      double width_SSring_z = supportparams->get_double_param("endcap_SSring_length") * cm;
-      double width_Alring_z = supportparams->get_double_param("endcap_Alring_length") * cm;
-
-      for(int j = 0; j < 2; j++) // j=0 : positive side z, j=1 negative side z
+      double endcap_ring_z = supportparams->get_double_param("endcap_ring_z") * cm; 
+      for(int i = 0; i < 2; i++) // i=0 : positive z, i=1 negative z
       {
-        width_WGring_z = (j==0) ? width_WGring_z : -1.0 * width_WGring_z; 
-        width_SSring_z = (j==0) ? width_SSring_z : -1.0 * width_SSring_z;
-        width_Alring_z = (j==0) ? width_Alring_z : -1.0 * width_Alring_z;
 
-        double cent_WGring_z = endcap_ring_z + width_WGring_z / 2.;
-        double cent_SSring_z = endcap_ring_z + width_WGring_z + width_SSring_z / 2.;
-        double cent_Alring_z = endcap_ring_z + width_WGring_z + width_SSring_z + width_Alring_z / 2.;
+        endcap_ring_z = (i==0) ?  endcap_ring_z : -1.0 * endcap_ring_z;
+
+        double width_WGring_z = supportparams->get_double_param("endcap_WGring_length") * cm;
+        double width_SSring_z = supportparams->get_double_param("endcap_SSring_length") * cm;
+        double width_Alring_z = supportparams->get_double_param("endcap_Alring_length") * cm;
+
+        for(int j = 0; j < 2; j++) // j=0 : positive side z, j=1 negative side z
+        {
+          width_WGring_z = (j==0) ? width_WGring_z : -1.0 * width_WGring_z; 
+          width_SSring_z = (j==0) ? width_SSring_z : -1.0 * width_SSring_z;
+          width_Alring_z = (j==0) ? width_Alring_z : -1.0 * width_Alring_z;
+
+          double cent_WGring_z = endcap_ring_z + width_WGring_z / 2.;
+          double cent_SSring_z = endcap_ring_z + width_WGring_z + width_SSring_z / 2.;
+          double cent_Alring_z = endcap_ring_z + width_WGring_z + width_SSring_z + width_Alring_z / 2.;
 
 
-        new G4PVPlacement(0, G4ThreeVector(0, 0, cent_WGring_z),
-            endcap_WG_ring_volume,
-            (boost::format("endcap_WG_ring_pv_%d_%d") %i %j).str(),
-            trackerenvelope, false, 0, OverlapCheck());
+          new G4PVPlacement(0, G4ThreeVector(0, 0, cent_WGring_z),
+              endcap_WG_ring_volume,
+              (boost::format("endcap_WG_ring_pv_%d_%d") %i %j).str(),
+              trackerenvelope, false, 0, OverlapCheck());
 
-        new G4PVPlacement(0, G4ThreeVector(0, 0, cent_SSring_z),
-            endcap_SS_ring_volume,
-            (boost::format("endcap_SS_ring_pv_%d_%d") %i %j).str(),
-            trackerenvelope, false, 0, OverlapCheck());
+          new G4PVPlacement(0, G4ThreeVector(0, 0, cent_SSring_z),
+              endcap_SS_ring_volume,
+              (boost::format("endcap_SS_ring_pv_%d_%d") %i %j).str(),
+              trackerenvelope, false, 0, OverlapCheck());
 
-        new G4PVPlacement(0, G4ThreeVector(0, 0, cent_Alring_z),
-            endcap_Al_ring_volume,
-            (boost::format("endcap_Al_ring_pv_%d_%d") %i %j).str(),
+          new G4PVPlacement(0, G4ThreeVector(0, 0, cent_Alring_z),
+              endcap_Al_ring_volume,
+              (boost::format("endcap_Al_ring_pv_%d_%d") %i %j).str(),
+              trackerenvelope, false, 0, OverlapCheck());
+        }
+      }
+    }
+    else if(supportparams->get_int_param("endcap_ring_type")==1) // Place CP endcap rings
+    {
+      double endcap_ring_z = supportparams->get_double_param("endcap_CPring_z") * cm; 
+      for(int i = 0; i < 2; i++) // i=0 : positive z, i=1 negative z
+      {
+
+        endcap_ring_z = (i==0) ?  endcap_ring_z : -1.0 * endcap_ring_z;
+
+        new G4PVPlacement(0, G4ThreeVector(0, 0, endcap_ring_z),
+            endcap_CP_ring_volume,
+            (boost::format("endcap_CP_ring_pv_%d") %i).str(),
             trackerenvelope, false, 0, OverlapCheck());
       }
     }

--- a/simulation/g4simulation/g4intt/PHG4INTTSubsystem.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTSubsystem.cc
@@ -182,7 +182,7 @@ void PHG4INTTSubsystem::SetDefaultParameters()
     set_default_double_param(SEGMENTATION_Z, "fphx_offset_z", 0.005);
     set_default_double_param(SEGMENTATION_Z, "gap_sensor_fphx", 0.1);
     set_default_double_param(SEGMENTATION_Z, "halfladder_z", 40.00);
-    set_default_double_param(SEGMENTATION_Z, "halfladder_inside_z", 23.9622); 
+    set_default_double_param(SEGMENTATION_Z, "halfladder_inside_z", 23.9622);
     set_default_double_param(SEGMENTATION_Z, "hdi_copper_x", 0.0052);
     set_default_double_param(SEGMENTATION_Z, "hdi_edge_z", 0.);
     set_default_double_param(SEGMENTATION_Z, "hdi_kapton_x", 0.038);
@@ -209,7 +209,7 @@ void PHG4INTTSubsystem::SetDefaultParameters()
     set_default_double_param(SEGMENTATION_PHI, "fphx_offset_z", 0.005);
     set_default_double_param(SEGMENTATION_PHI, "gap_sensor_fphx", 0.1);
     set_default_double_param(SEGMENTATION_PHI, "halfladder_z", 40.00);
-    set_default_double_param(SEGMENTATION_PHI, "halfladder_inside_z", 23.9622); 
+    set_default_double_param(SEGMENTATION_PHI, "halfladder_inside_z", 23.9622);
     set_default_double_param(SEGMENTATION_PHI, "hdi_copper_x", 0.0052);
     set_default_double_param(SEGMENTATION_PHI, "hdi_edge_z", 0.);
     set_default_double_param(SEGMENTATION_PHI, "hdi_kapton_x", 0.038);
@@ -246,31 +246,31 @@ void PHG4INTTSubsystem::SetDefaultParameters()
 
     // Endcap ring flag
     set_default_int_param(SUPPORTPARAMS, "endcap_ring_enabled", 1);
-    set_default_int_param(SUPPORTPARAMS, "endcap_ring_type", 0); // 0: Al+SS+WG, 1 : CarbonPEEK
+    set_default_int_param(SUPPORTPARAMS, "endcap_ring_type", 1);  // 0: Al+SS+WG, 1 : CarbonPEEK
 
     // Aluminum endcap ring position
-    set_default_double_param(SUPPORTPARAMS, "endcap_ring_z", 24.35);  
+    set_default_double_param(SUPPORTPARAMS, "endcap_ring_z", 24.35);
 
     // Aluminum endcap ring
-    set_default_double_param(SUPPORTPARAMS, "endcap_Alring_inner_radius", 6.267);  
+    set_default_double_param(SUPPORTPARAMS, "endcap_Alring_inner_radius", 6.267);
     set_default_double_param(SUPPORTPARAMS, "endcap_Alring_outer_radius", 12.0444);
     set_default_double_param(SUPPORTPARAMS, "endcap_Alring_length", 0.3645);
 
     // Stainless steel endcap ring
-    set_default_double_param(SUPPORTPARAMS, "endcap_SSring_inner_radius", 6.267);  
+    set_default_double_param(SUPPORTPARAMS, "endcap_SSring_inner_radius", 6.267);
     set_default_double_param(SUPPORTPARAMS, "endcap_SSring_outer_radius", 12.0444);
     set_default_double_param(SUPPORTPARAMS, "endcap_SSring_length", 0.0047);
 
     // Water Glycol endcap ring
-    set_default_double_param(SUPPORTPARAMS, "endcap_WGring_inner_radius", 6.267);  
+    set_default_double_param(SUPPORTPARAMS, "endcap_WGring_inner_radius", 6.267);
     set_default_double_param(SUPPORTPARAMS, "endcap_WGring_outer_radius", 12.0444);
     set_default_double_param(SUPPORTPARAMS, "endcap_WGring_length", 0.0186);
 
     // CarbonPEEK endcap ring position
-    set_default_double_param(SUPPORTPARAMS, "endcap_CPring_z", 24.4185);  
+    set_default_double_param(SUPPORTPARAMS, "endcap_CPring_z", 24.4185);
 
     // CarbonPEEK endcap ring position
-    set_default_double_param(SUPPORTPARAMS, "endcap_CPring_inner_radius", 6.6675);  
+    set_default_double_param(SUPPORTPARAMS, "endcap_CPring_inner_radius", 6.6675);
     set_default_double_param(SUPPORTPARAMS, "endcap_CPring_outer_radius", 11.43);
     set_default_double_param(SUPPORTPARAMS, "endcap_CPring_length", 0.6370);
 

--- a/simulation/g4simulation/g4intt/PHG4INTTSubsystem.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTSubsystem.cc
@@ -246,8 +246,9 @@ void PHG4INTTSubsystem::SetDefaultParameters()
 
     // Endcap ring flag
     set_default_int_param(SUPPORTPARAMS, "endcap_ring_enabled", 1);
+    set_default_int_param(SUPPORTPARAMS, "endcap_ring_type", 0); // 0: Al+SS+WG, 1 : CarbonPEEK
 
-    // Endcap ring position
+    // Aluminum endcap ring position
     set_default_double_param(SUPPORTPARAMS, "endcap_ring_z", 24.35);  
 
     // Aluminum endcap ring
@@ -264,6 +265,14 @@ void PHG4INTTSubsystem::SetDefaultParameters()
     set_default_double_param(SUPPORTPARAMS, "endcap_WGring_inner_radius", 6.267);  
     set_default_double_param(SUPPORTPARAMS, "endcap_WGring_outer_radius", 12.0444);
     set_default_double_param(SUPPORTPARAMS, "endcap_WGring_length", 0.0186);
+
+    // CarbonPEEK endcap ring position
+    set_default_double_param(SUPPORTPARAMS, "endcap_CPring_z", 24.4185);  
+
+    // CarbonPEEK endcap ring position
+    set_default_double_param(SUPPORTPARAMS, "endcap_CPring_inner_radius", 6.6675);  
+    set_default_double_param(SUPPORTPARAMS, "endcap_CPring_outer_radius", 11.43);
+    set_default_double_param(SUPPORTPARAMS, "endcap_CPring_length", 0.6370);
 
     set_default_double_param(SUPPORTPARAMS, "mvtx_shell_foam_core_thickness", 0.18);
     set_default_double_param(SUPPORTPARAMS, "mvtx_shell_inner_skin_inner_radius", 4.8);

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -771,7 +771,7 @@ void PHG4Reco::DefineMaterials()
 
   // making Carbon PEEK : 30 - 70 Vf.
   // https://www.quantum-polymers.com/wp-content/uploads/2017/03/QuantaPEEK-CF30.pdf
-  G4Material *peek = new G4Material("PEEK", density = 1.32 * g / cm3, ncomponents = 4);
+  G4Material *peek = new G4Material("PEEK", density = 1.32 * g / cm3, ncomponents = 3);
   peek->AddElement(G4Element::GetElement("C"),19);
   peek->AddElement(G4Element::GetElement("H"),12);
   peek->AddElement(G4Element::GetElement("O"), 3);

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -769,6 +769,20 @@ void PHG4Reco::DefineMaterials()
   rohacell_foam_51->AddElement(G4Element::GetElement("O"), 2);
   rohacell_foam_51->AddElement(G4Element::GetElement("N"), 1);
 
+  // making Carbon PEEK : 30 - 70 Vf.
+  // https://www.quantum-polymers.com/wp-content/uploads/2017/03/QuantaPEEK-CF30.pdf
+  G4Material *peek = new G4Material("PEEK", density = 1.32 * g / cm3, ncomponents = 4);
+  peek->AddElement(G4Element::GetElement("C"),19);
+  peek->AddElement(G4Element::GetElement("H"),12);
+  peek->AddElement(G4Element::GetElement("O"), 3);
+
+  G4Material *cf = new G4Material("CF", density = 1.62 * g / cm3, ncomponents = 1);
+  cf->AddElement(G4Element::GetElement("C"),1.);
+
+  G4Material *cf30_peek70 = new G4Material("CF30_PEEK70", density = (1.32 * 0.7 + 1.62 * 0.3) * g / cm3, ncomponents = 2);
+  cf30_peek70->AddMaterial(cf  , fractionmass = 0.34468085);
+  cf30_peek70->AddMaterial(peek, fractionmass = 0.65531915);
+
 
   // gas mixture for the MuID in fsPHENIX. CLS 02-25-14
   G4Material *IsoButane = new G4Material("Isobutane", 0.00265 * g / cm3, 2);


### PR DESCRIPTION
This is a PR to implement the new INTT endcap ring geometry using Carbon-PEEK (CP) proposed by Rachid at the simulation meeting 3/12/2019. Defined the CP material in the "PHG4Reco.cc". Introduced a parameter in the "PHG4INTTSubsystem.cc" to select either the aluminum(Al) or CP endcap rings. The Al endcap ring option remains as default for now. The new geometry in "PHG4INTTDetector.cc"  successfully passed the overlap check.

![Ring  EC CP](https://user-images.githubusercontent.com/29286848/54455119-5f56bb80-4731-11e9-89e5-0cc4b1839c5b.png)

