### PR TITLE
Add Memory tracking

### DIFF
--- a/offline/framework/fun4all/Fun4AllMemoryTracker.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.cc
@@ -1,0 +1,134 @@
+#include "Fun4AllMemoryTracker.h"
+
+#include <TSystem.h>
+
+#include <iostream>
+
+using namespace std;
+
+Fun4AllMemoryTracker *Fun4AllMemoryTracker::mInstance = nullptr;
+
+int Fun4AllMemoryTracker::GetRSSMemory() const
+{
+  ProcInfo_t procinfo;
+  gSystem->GetProcInfo(&procinfo);
+  return procinfo.fMemResident;
+}
+
+Fun4AllMemoryTracker::~Fun4AllMemoryTracker()
+{
+  mMemoryTrackerMap.clear();
+  mStartMem.clear();
+}
+
+void Fun4AllMemoryTracker::Snapshot(const string &trackername, const string &group)
+{
+  string name = CreateFullTrackerName(trackername, group);
+  auto iter = mMemoryTrackerMap.find(name);
+  if (iter != mMemoryTrackerMap.end())
+  {
+    iter->second.push_back(GetRSSMemory());
+  }
+  else
+  {
+    vector<int> mvec;
+    mvec.push_back(GetRSSMemory());
+    mMemoryTrackerMap.insert(make_pair(name, mvec));
+  }
+  cout << "Snapshot name: " << name << ", mem: " << GetRSSMemory() << endl;
+  return;
+}
+
+void Fun4AllMemoryTracker::Start(const string &trackername, const string &group)
+{
+  string name = CreateFullTrackerName(trackername, group);
+  auto iter = mStartMem.find(name);
+  int RSSMemory = GetRSSMemory();
+  if (iter != mStartMem.end())
+  {
+    iter->second = RSSMemory;
+  }
+  else
+  {
+    mStartMem.insert(make_pair(name, RSSMemory));
+  }
+  cout << "Start name: " << name << ", mem: " << RSSMemory << endl;
+}
+
+void Fun4AllMemoryTracker::Stop(const string &trackername, const string &group)
+{
+  string name = CreateFullTrackerName(trackername, group);
+  auto iter = mStartMem.find(name);
+  int RSSMemory = GetRSSMemory();
+  if (iter != mStartMem.end())
+  {
+    int diff = RSSMemory - iter->second;
+    auto iterM = mMemoryTrackerMap.find(name);
+    if (iterM != mMemoryTrackerMap.end())
+    {
+      iterM->second.push_back(diff);
+    }
+    else
+    {
+      vector<int> mvec;
+      mvec.push_back(diff);
+      mMemoryTrackerMap.insert(make_pair(name, mvec));
+    }
+  cout << "Stop name: " << name << ", mem: " << RSSMemory << ", diff: " << diff << endl;
+  }
+  return;
+}
+
+string Fun4AllMemoryTracker::CreateFullTrackerName(const string &trackername, const string &group)
+{
+  string name = trackername;
+  if (! group.empty())
+  {
+    name = group + "_" + name;
+  }
+  return name;
+}
+
+void Fun4AllMemoryTracker::PrintMemoryTracker(const string &name) const
+{
+  map<const string, std::vector<int>>::const_iterator iter;
+  if (name.empty())
+  {
+    for (iter = mMemoryTrackerMap.begin(); iter != mMemoryTrackerMap.end(); ++iter)
+    {
+      cout << "SubsysReco/OutputManager: " << iter->first << endl;
+      vector<int> memvec = iter->second;
+      for (auto vit = memvec.begin(); vit != memvec.end(); ++vit)
+      {
+	cout << *vit << " ";
+      }
+      cout << endl;
+    }
+  }
+  else
+  {
+    iter = mMemoryTrackerMap.find(name);
+    if (iter != mMemoryTrackerMap.end())
+    {
+      cout << "SubsysReco/OutputManager: " << iter->first << endl;
+      vector<int> memvec = iter->second;
+      for (auto vit = memvec.begin(); vit != memvec.end(); ++vit)
+      {
+	cout << *vit << " ";
+      }
+      cout << endl;
+    }
+    else
+    {
+      cout << "No Memory Tracker with name " << name << " found" << endl;
+      cout << "Existing Memory Trackers:" << endl;
+      for (iter = mMemoryTrackerMap.begin(); iter != mMemoryTrackerMap.end(); ++iter)
+      {
+	cout << iter->first << endl;
+      }
+    }
+  }
+  return;
+}
+
+

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.cc
@@ -8,6 +8,10 @@ using namespace std;
 
 Fun4AllMemoryTracker *Fun4AllMemoryTracker::mInstance = nullptr;
 
+Fun4AllMemoryTracker::Fun4AllMemoryTracker():
+  Fun4AllBase("Fun4AllMemoryTracker")
+{}
+
 int Fun4AllMemoryTracker::GetRSSMemory() const
 {
   ProcInfo_t procinfo;
@@ -35,7 +39,10 @@ void Fun4AllMemoryTracker::Snapshot(const string &trackername, const string &gro
     mvec.push_back(GetRSSMemory());
     mMemoryTrackerMap.insert(make_pair(name, mvec));
   }
+  if (Verbosity() > 0)
+  {
   cout << "Snapshot name: " << name << ", mem: " << GetRSSMemory() << endl;
+  }
   return;
 }
 
@@ -52,7 +59,10 @@ void Fun4AllMemoryTracker::Start(const string &trackername, const string &group)
   {
     mStartMem.insert(make_pair(name, RSSMemory));
   }
+  if (Verbosity() > 0)
+  {
   cout << "Start name: " << name << ", mem: " << RSSMemory << endl;
+  }
 }
 
 void Fun4AllMemoryTracker::Stop(const string &trackername, const string &group)
@@ -74,7 +84,10 @@ void Fun4AllMemoryTracker::Stop(const string &trackername, const string &group)
       mvec.push_back(diff);
       mMemoryTrackerMap.insert(make_pair(name, mvec));
     }
+  if (Verbosity() > 0)
+  {
   cout << "Stop name: " << name << ", mem: " << RSSMemory << ", diff: " << diff << endl;
+  }
   }
   return;
 }
@@ -130,5 +143,3 @@ void Fun4AllMemoryTracker::PrintMemoryTracker(const string &name) const
   }
   return;
 }
-
-

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.cc
@@ -8,9 +8,10 @@ using namespace std;
 
 Fun4AllMemoryTracker *Fun4AllMemoryTracker::mInstance = nullptr;
 
-Fun4AllMemoryTracker::Fun4AllMemoryTracker():
-  Fun4AllBase("Fun4AllMemoryTracker")
-{}
+Fun4AllMemoryTracker::Fun4AllMemoryTracker()
+  : Fun4AllBase("Fun4AllMemoryTracker")
+{
+}
 
 int Fun4AllMemoryTracker::GetRSSMemory() const
 {
@@ -41,7 +42,7 @@ void Fun4AllMemoryTracker::Snapshot(const string &trackername, const string &gro
   }
   if (Verbosity() > 0)
   {
-  cout << "Snapshot name: " << name << ", mem: " << GetRSSMemory() << endl;
+    cout << "Snapshot name: " << name << ", mem: " << GetRSSMemory() << endl;
   }
   return;
 }
@@ -61,7 +62,7 @@ void Fun4AllMemoryTracker::Start(const string &trackername, const string &group)
   }
   if (Verbosity() > 0)
   {
-  cout << "Start name: " << name << ", mem: " << RSSMemory << endl;
+    cout << "Start name: " << name << ", mem: " << RSSMemory << endl;
   }
 }
 
@@ -84,10 +85,10 @@ void Fun4AllMemoryTracker::Stop(const string &trackername, const string &group)
       mvec.push_back(diff);
       mMemoryTrackerMap.insert(make_pair(name, mvec));
     }
-  if (Verbosity() > 0)
-  {
-  cout << "Stop name: " << name << ", mem: " << RSSMemory << ", diff: " << diff << endl;
-  }
+    if (Verbosity() > 0)
+    {
+      cout << "Stop name: " << name << ", mem: " << RSSMemory << ", diff: " << diff << endl;
+    }
   }
   return;
 }
@@ -95,7 +96,7 @@ void Fun4AllMemoryTracker::Stop(const string &trackername, const string &group)
 string Fun4AllMemoryTracker::CreateFullTrackerName(const string &trackername, const string &group)
 {
   string name = trackername;
-  if (! group.empty())
+  if (!group.empty())
   {
     name = group + "_" + name;
   }
@@ -113,7 +114,7 @@ void Fun4AllMemoryTracker::PrintMemoryTracker(const string &name) const
       vector<int> memvec = iter->second;
       for (auto vit = memvec.begin(); vit != memvec.end(); ++vit)
       {
-	cout << *vit << " ";
+        cout << *vit << " ";
       }
       cout << endl;
     }
@@ -127,7 +128,7 @@ void Fun4AllMemoryTracker::PrintMemoryTracker(const string &name) const
       vector<int> memvec = iter->second;
       for (auto vit = memvec.begin(); vit != memvec.end(); ++vit)
       {
-	cout << *vit << " ";
+        cout << *vit << " ";
       }
       cout << endl;
     }
@@ -137,7 +138,7 @@ void Fun4AllMemoryTracker::PrintMemoryTracker(const string &name) const
       cout << "Existing Memory Trackers:" << endl;
       for (iter = mMemoryTrackerMap.begin(); iter != mMemoryTrackerMap.end(); ++iter)
       {
-	cout << iter->first << endl;
+        cout << iter->first << endl;
       }
     }
   }

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.h
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.h
@@ -1,11 +1,13 @@
 #ifndef FUN4ALL_FUN4ALLMEMORYTRACKER_H
 #define FUN4ALL_FUN4ALLMEMORYTRACKER_H
 
+#include "Fun4AllBase.h"
+
 #include <map>
 #include <string>
 #include <vector>
 
-class Fun4AllMemoryTracker
+class Fun4AllMemoryTracker: public Fun4AllBase
 {
 public:
   static Fun4AllMemoryTracker *instance()
@@ -20,10 +22,10 @@ public:
   void Stop(const std::string &trackername, const std::string &group = "");
 
   int GetRSSMemory() const;
-  void PrintMemoryTracker(const std::string &name) const;
+  void PrintMemoryTracker(const std::string &name = "") const;
 
 private:
-  Fun4AllMemoryTracker() {}
+  Fun4AllMemoryTracker();
   std::string CreateFullTrackerName(const std::string &trackername, const std::string &group = "");
   static Fun4AllMemoryTracker *mInstance;
   std::map<std::string, std::vector<int>> mMemoryTrackerMap;

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.h
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.h
@@ -1,0 +1,33 @@
+#ifndef FUN4ALL_FUN4ALLMEMORYTRACKER_H
+#define FUN4ALL_FUN4ALLMEMORYTRACKER_H
+
+#include <map>
+#include <string>
+#include <vector>
+
+class Fun4AllMemoryTracker
+{
+public:
+  static Fun4AllMemoryTracker *instance()
+  {
+    if (mInstance) return mInstance;
+    mInstance = new Fun4AllMemoryTracker();
+    return mInstance;
+  }
+  ~Fun4AllMemoryTracker();
+  void Snapshot(const std::string &trackername, const std::string &group = "");
+  void Start(const std::string &trackername, const std::string &group = "");
+  void Stop(const std::string &trackername, const std::string &group = "");
+
+  int GetRSSMemory() const;
+  void PrintMemoryTracker(const std::string &name) const;
+
+private:
+  Fun4AllMemoryTracker() {}
+  std::string CreateFullTrackerName(const std::string &trackername, const std::string &group = "");
+  static Fun4AllMemoryTracker *mInstance;
+  std::map<std::string, std::vector<int>> mMemoryTrackerMap;
+  std::map<std::string, int> mStartMem;
+};
+
+#endif

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -40,7 +40,7 @@
 
 using namespace std;
 
-Fun4AllServer *Fun4AllServer::__instance = 0;
+Fun4AllServer *Fun4AllServer::__instance = nullptr;
 
 Fun4AllServer *Fun4AllServer::instance()
 {
@@ -54,15 +54,15 @@ Fun4AllServer *Fun4AllServer::instance()
 
 Fun4AllServer::Fun4AllServer(const std::string &name)
   : Fun4AllBase(name)
+  , ffamemtracker(Fun4AllMemoryTracker::instance())
+  , beginruntimestamp(nullptr)
   , OutNodeCount(0)
   , bortime_override(0)
   , ScreamEveryEvent(0)
   , unregistersubsystem(0)
   , runnumber(0)
   , eventnumber(0)
-  , beginruntimestamp(nullptr)
   , keep_db_connected(0)
-  , ffamemtracker(Fun4AllMemoryTracker::instance())
 {
   InitAll();
   return;

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -1,6 +1,8 @@
 #include "Fun4AllServer.h"
+
 #include "Fun4AllHistoBinDefs.h"
 #include "Fun4AllInputManager.h"
+#include "Fun4AllMemoryTracker.h"
 #include "Fun4AllOutputManager.h"
 #include "Fun4AllReturnCodes.h"
 #include "Fun4AllSyncManager.h"
@@ -60,6 +62,7 @@ Fun4AllServer::Fun4AllServer(const std::string &name)
   , eventnumber(0)
   , beginruntimestamp(nullptr)
   , keep_db_connected(0)
+  , ffamemtracker(Fun4AllMemoryTracker::instance())
 {
   InitAll();
   return;
@@ -118,6 +121,7 @@ Fun4AllServer::~Fun4AllServer()
   }
   recoConsts *rc = recoConsts::instance();
   delete rc;
+  delete ffamemtracker;
   __instance = nullptr;
   return;
 }
@@ -181,6 +185,8 @@ int Fun4AllServer::isHistoRegistered(const string &name) const
 int Fun4AllServer::registerSubsystem(SubsysReco *subsystem, const string &topnodename)
 {
   Fun4AllServer *se = Fun4AllServer::instance();
+
+
   // if somebody opens a TFile (or changes the gDirectory) in the ctor
   // we need to set it to a "known" directory
   gROOT->cd(default_Tdirectory.c_str());
@@ -220,7 +226,10 @@ int Fun4AllServer::registerSubsystem(SubsysReco *subsystem, const string &topnod
   int iret = 0;
   try
   {
+    string memory_tracker_name = subsystem->Name() + "_" + topnodename;
+    ffamemtracker->Start(memory_tracker_name,"SubsysReco");
     iret = subsystem->Init(subsystopNode);
+    ffamemtracker->Stop(memory_tracker_name,"SubsysReco");
   }
   catch (const exception &e)
   {
@@ -255,12 +264,12 @@ int Fun4AllServer::registerSubsystem(SubsysReco *subsystem, const string &topnod
     cout << "Registering Subsystem " << subsystem->Name() << endl;
   }
   Subsystems.push_back(newsubsyspair);
-  ostringstream timer_name;
-  timer_name << subsystem->Name() << "_" << topnodename;
-  PHTimer timer(timer_name.str());
-  if (timer_map.find(timer_name.str()) == timer_map.end())
+  string timer_name;
+  timer_name = subsystem->Name() + "_" + topnodename;
+  PHTimer timer(timer_name);
+  if (timer_map.find(timer_name) == timer_map.end())
   {
-    timer_map[timer_name.str()] = timer;
+    timer_map.insert(make_pair(timer_name,timer));
   }
   RetCodes.push_back(iret);  // vector with return codes
   return 0;
@@ -552,9 +561,9 @@ int Fun4AllServer::process_event()
 
     try
     {
-      ostringstream timer_name;
-      timer_name << (*iter).first->Name() << "_" << (*iter).second->getName();
-      std::map<const std::string, PHTimer>::iterator titer = timer_map.find(timer_name.str());
+      string timer_name;
+      timer_name = (*iter).first->Name() + "_" + (*iter).second->getName();
+      std::map<const std::string, PHTimer>::iterator titer = timer_map.find(timer_name);
       bool timer_found = false;
       if (titer != timer_map.end())
       {
@@ -565,7 +574,10 @@ int Fun4AllServer::process_event()
       {
 	cout << "could not find timer for " << timer_name << endl;
       }
+      ffamemtracker->Start(timer_name,"SubsysReco");
+      ffamemtracker->Snapshot("Fun4AllServerProcessEvent");
       int retcode = (*iter).first->process_event((*iter).second);
+      ffamemtracker->Snapshot("Fun4AllServerProcessEvent");
 // we have observed an index overflow in RetCodes. I assume it is some
 // memory corruption elsewhere which hits the icnt variable. Rather than
 // the previous [], use at() which does bounds checking and throws an 
@@ -585,6 +597,7 @@ int Fun4AllServer::process_event()
       {
 	titer->second.stop();
       }
+      ffamemtracker->Stop(timer_name,"SubsysReco");
     }
     catch (const exception &e)
     {
@@ -681,7 +694,11 @@ int Fun4AllServer::process_event()
           {
             cout << "Writing Event for " << (*iterOutMan)->Name() << endl;
           }
+          ffamemtracker->Snapshot("Fun4AllServerOutputManager");
+	  ffamemtracker->Start((*iterOutMan)->Name(),"OutputManager");
           (*iterOutMan)->WriteGeneric(dstNode);
+	  ffamemtracker->Stop((*iterOutMan)->Name(),"OutputManager");
+          ffamemtracker->Snapshot("Fun4AllServerOutputManager");
         }
         else
         {
@@ -768,6 +785,7 @@ int Fun4AllServer::BeginRunTimeStamp(PHTimeStamp &TimeStp)
 
 int Fun4AllServer::BeginRun(const int runno)
 {
+  ffamemtracker->Snapshot("Fun4AllServerBeginRun");
   if (!bortime_override)
   {
     if (beginruntimestamp)
@@ -830,7 +848,9 @@ int Fun4AllServer::BeginRun(const int runno)
     }
     try
     {
+      ffamemtracker->Start((*iter).first->Name(),"SubsysReco");
       iret = (*iter).first->InitRun((*iter).second);
+      ffamemtracker->Stop((*iter).first->Name(),"SubsysReco");
     }
     catch (const exception &e)
     {
@@ -876,6 +896,7 @@ int Fun4AllServer::BeginRun(const int runno)
   }
   // print out all node trees
   Print("NODETREE");
+  ffamemtracker->Snapshot("Fun4AllServerBeginRun");
   return 0;
 }
 
@@ -1686,5 +1707,11 @@ void Fun4AllServer::PrintTimer(const string &name)
       }
     }
   }
+  return;
+}
+
+void Fun4AllServer::PrintMemoryTracker(const string &name) const
+{
+  ffamemtracker->PrintMemoryTracker(name);
   return;
 }

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -1,7 +1,8 @@
-#ifndef FUN4ALLSERVER_H
-#define FUN4ALLSERVER_H
+#ifndef FUN4ALL_FUN4ALLSERVER_H
+#define FUN4ALL_FUN4ALLSERVER_H
 
 #include "Fun4AllBase.h"
+
 #include "Fun4AllHistoManager.h"
 
 #include <phool/PHTimer.h>
@@ -115,31 +116,33 @@ class Fun4AllServer : public Fun4AllBase
   int unregisterSubsystemsNow();
   int setRun(const int runnumber);
   static Fun4AllServer *__instance;
+  TH1 *FrameWorkVars;
+  Fun4AllMemoryTracker *ffamemtracker;
+  Fun4AllHistoManager *ServerHistoManager;
+  PHTimeStamp *beginruntimestamp;
+  PHCompositeNode *TopNode;
+  Fun4AllSyncManager *defaultSyncManager;
+
   int OutNodeCount;
   int bortime_override;
   int ScreamEveryEvent;
   int unregistersubsystem;
   int runnumber;
   int eventnumber;
+  int keep_db_connected;
+
   std::vector<std::string> ComplaintList;
-  PHCompositeNode *TopNode;
   std::vector<std::pair<SubsysReco *, PHCompositeNode *> > Subsystems;
   std::vector<std::pair<SubsysReco *, PHCompositeNode *> > DeleteSubsystems;
   std::vector<int> RetCodes;
   std::vector<Fun4AllOutputManager *> OutputManager;
   std::vector<TDirectory *> TDirCollection;
-  Fun4AllHistoManager *ServerHistoManager;
   std::vector<Fun4AllHistoManager *> HistoManager;
   std::map<std::string, PHCompositeNode *> topnodemap;
-  PHTimeStamp *beginruntimestamp;
   std::string default_Tdirectory;
-  Fun4AllSyncManager *defaultSyncManager;
   std::vector<Fun4AllSyncManager *> SyncManagers;
   std::map<int, int> retcodesmap;
   std::map<const std::string, PHTimer> timer_map;
-  TH1 *FrameWorkVars;
-  int keep_db_connected;
-  Fun4AllMemoryTracker *ffamemtracker;
 };
 
-#endif /* __FUN4ALLSERVER_H */
+#endif

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 class Fun4AllInputManager;
+class Fun4AllMemoryTracker;
 class Fun4AllSyncManager;
 class Fun4AllOutputManager;
 class PHCompositeNode;
@@ -103,6 +104,7 @@ class Fun4AllServer : public Fun4AllBase
   void NodeIdentify(const std::string &name);
   void KeepDBConnection(const int i = 1) { keep_db_connected = i; }
   void PrintTimer(const std::string &name = "");
+  void PrintMemoryTracker(const std::string &name = "") const;
 
  protected:
   Fun4AllServer(const std::string &name = "Fun4AllServer");
@@ -137,6 +139,7 @@ class Fun4AllServer : public Fun4AllBase
   std::map<const std::string, PHTimer> timer_map;
   TH1 *FrameWorkVars;
   int keep_db_connected;
+  Fun4AllMemoryTracker *ffamemtracker;
 };
 
 #endif /* __FUN4ALLSERVER_H */

--- a/offline/framework/fun4all/Makefile.am
+++ b/offline/framework/fun4all/Makefile.am
@@ -36,6 +36,7 @@ pkginclude_HEADERS = \
   Fun4AllHistoBinDefs.h \
   Fun4AllHistoManager.h \
   Fun4AllInputManager.h \
+  Fun4AllMemoryTracker.h \
   Fun4AllNoSyncDstInputManager.h \
   Fun4AllOutputManager.h \
   Fun4AllPrdfInputManager.h \
@@ -67,13 +68,14 @@ libfun4all_la_SOURCES = \
   Fun4AllFileOutStream.cc \
   Fun4AllHistoManager.cc \
   Fun4AllInputManager.cc \
-  Fun4AllSyncManager.cc \
+  Fun4AllMemoryTracker.cc \
   Fun4AllNoSyncDstInputManager.cc \
   Fun4AllOutputManager.cc \
   Fun4AllPrdfInputManager.cc \
   Fun4AllPrdfOutputManager.cc \
   Fun4AllRolloverFileOutStream.cc \
   Fun4AllServer.cc \
+  Fun4AllSyncManager.cc \
   Fun4AllUtils.cc \
   PHTFileServer.cc
 


### PR DESCRIPTION
This PR adds a singleton which can be used to track memory. Snapshots and Start/Stop are supported, the memory tracking uses a name and a group to identify a given tracker. It has been added to monitor the memory for each module for each process_event call as well as the output managers when writing out. To print out the values use:
Fun4AllServer *se = Fun4AllServer::instance()
se->PrintMemoryTracker();

you can instrument any code by using
#include <fun4all/Fun4AllMemoryTracker.h>

ffamemtrk = Fun4AllMemoryTracker::instance();
ffamemtrk->AddSnapshot("MYmodule");
or
ffamemtrk->Start("Mymodule");
do something
ffamemtrk->Stop("Mymodule");
ffamemtrk->PrintMemoryTracker("Mymodule");
to see the memory growth
Also sorted the data members of the Fun4AllServer according to type to make their alignment easier.