### PR TITLE
Fun4AllOutputManager are private now

### DIFF
--- a/generators/phhepmc/Fun4AllHepMCOutputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCOutputManager.cc
@@ -5,6 +5,7 @@
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
+
 #include <phool/getClass.h>
 
 #include <HepMC/GenEvent.h>
@@ -147,7 +148,7 @@ int Fun4AllHepMCOutputManager::Write(PHCompositeNode *topNode)
   }
   assert(evt);
 
-  nEvents++;
+  IncrementEvents(1);
   ascii_out->write_event(evt);
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.cc
@@ -16,9 +16,8 @@
 using namespace std;
 
 Fun4AllDstOutputManager::Fun4AllDstOutputManager(const string &myname, const string &fname)
-  : Fun4AllOutputManager(myname)
+  : Fun4AllOutputManager(myname, fname)
 {
-  outfilename = fname;
   dstOut = new PHNodeIOManager(fname, PHWrite);
   if (!dstOut->isFunctional())
   {
@@ -75,7 +74,7 @@ void Fun4AllDstOutputManager::Print(const string &what) const
   if (what == "ALL" || what == "WRITENODES")
   {
 //    vector<string>::const_iterator iter;
-    cout << Name() << " writes " << outfilename << endl;
+    cout << Name() << " writes " << OutFileName() << endl;
     if (savenodes.empty())
     {
       if (stripnodes.empty())
@@ -183,7 +182,7 @@ int Fun4AllDstOutputManager::Write(PHCompositeNode *startNode)
 int Fun4AllDstOutputManager::WriteNode(PHCompositeNode *thisNode)
 {
   delete dstOut;
-  dstOut = new PHNodeIOManager(outfilename, PHUpdate, PHRunTree);
+  dstOut = new PHNodeIOManager(OutFileName(), PHUpdate, PHRunTree);
   Fun4AllServer *se = Fun4AllServer::instance();
   se->MakeNodesPersistent(thisNode);
   if (!striprunnodes.empty())

--- a/offline/framework/fun4all/Fun4AllEventOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllEventOutputManager.cc
@@ -1,4 +1,5 @@
 #include "Fun4AllEventOutputManager.h"
+
 #include "Fun4AllServer.h"
 #include "Fun4AllEventOutStream.h"
 #include "Fun4AllRolloverFileOutStream.h"
@@ -123,6 +124,6 @@ Fun4AllEventOutputManager::DropPacketRange(const int ipktmin, const int ipktmax)
 void
 Fun4AllEventOutputManager::SetOutfileName(const std::string &fname)
 {
-  outfilename = fname;
+  OutFileName(fname);
   return ;
 }

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.cc
@@ -1,0 +1,134 @@
+#include "Fun4AllMemoryTracker.h"
+
+#include <TSystem.h>
+
+#include <iostream>
+
+using namespace std;
+
+Fun4AllMemoryTracker *Fun4AllMemoryTracker::mInstance = nullptr;
+
+int Fun4AllMemoryTracker::GetRSSMemory() const
+{
+  ProcInfo_t procinfo;
+  gSystem->GetProcInfo(&procinfo);
+  return procinfo.fMemResident;
+}
+
+Fun4AllMemoryTracker::~Fun4AllMemoryTracker()
+{
+  mMemoryTrackerMap.clear();
+  mStartMem.clear();
+}
+
+void Fun4AllMemoryTracker::Snapshot(const string &trackername, const string &group)
+{
+  string name = CreateFullTrackerName(trackername, group);
+  auto iter = mMemoryTrackerMap.find(name);
+  if (iter != mMemoryTrackerMap.end())
+  {
+    iter->second.push_back(GetRSSMemory());
+  }
+  else
+  {
+    vector<int> mvec;
+    mvec.push_back(GetRSSMemory());
+    mMemoryTrackerMap.insert(make_pair(name, mvec));
+  }
+  cout << "Snapshot name: " << name << ", mem: " << GetRSSMemory() << endl;
+  return;
+}
+
+void Fun4AllMemoryTracker::Start(const string &trackername, const string &group)
+{
+  string name = CreateFullTrackerName(trackername, group);
+  auto iter = mStartMem.find(name);
+  int RSSMemory = GetRSSMemory();
+  if (iter != mStartMem.end())
+  {
+    iter->second = RSSMemory;
+  }
+  else
+  {
+    mStartMem.insert(make_pair(name, RSSMemory));
+  }
+  cout << "Start name: " << name << ", mem: " << RSSMemory << endl;
+}
+
+void Fun4AllMemoryTracker::Stop(const string &trackername, const string &group)
+{
+  string name = CreateFullTrackerName(trackername, group);
+  auto iter = mStartMem.find(name);
+  int RSSMemory = GetRSSMemory();
+  if (iter != mStartMem.end())
+  {
+    int diff = RSSMemory - iter->second;
+    auto iterM = mMemoryTrackerMap.find(name);
+    if (iterM != mMemoryTrackerMap.end())
+    {
+      iterM->second.push_back(diff);
+    }
+    else
+    {
+      vector<int> mvec;
+      mvec.push_back(diff);
+      mMemoryTrackerMap.insert(make_pair(name, mvec));
+    }
+  cout << "Stop name: " << name << ", mem: " << RSSMemory << ", diff: " << diff << endl;
+  }
+  return;
+}
+
+string Fun4AllMemoryTracker::CreateFullTrackerName(const string &trackername, const string &group)
+{
+  string name = trackername;
+  if (! group.empty())
+  {
+    name = group + "_" + name;
+  }
+  return name;
+}
+
+void Fun4AllMemoryTracker::PrintMemoryTracker(const string &name) const
+{
+  map<const string, std::vector<int>>::const_iterator iter;
+  if (name.empty())
+  {
+    for (iter = mMemoryTrackerMap.begin(); iter != mMemoryTrackerMap.end(); ++iter)
+    {
+      cout << "SubsysReco/OutputManager: " << iter->first << endl;
+      vector<int> memvec = iter->second;
+      for (auto vit = memvec.begin(); vit != memvec.end(); ++vit)
+      {
+	cout << *vit << " ";
+      }
+      cout << endl;
+    }
+  }
+  else
+  {
+    iter = mMemoryTrackerMap.find(name);
+    if (iter != mMemoryTrackerMap.end())
+    {
+      cout << "SubsysReco/OutputManager: " << iter->first << endl;
+      vector<int> memvec = iter->second;
+      for (auto vit = memvec.begin(); vit != memvec.end(); ++vit)
+      {
+	cout << *vit << " ";
+      }
+      cout << endl;
+    }
+    else
+    {
+      cout << "No Memory Tracker with name " << name << " found" << endl;
+      cout << "Existing Memory Trackers:" << endl;
+      for (iter = mMemoryTrackerMap.begin(); iter != mMemoryTrackerMap.end(); ++iter)
+      {
+	cout << iter->first << endl;
+      }
+    }
+  }
+  return;
+}
+
+

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.cc
@@ -8,6 +8,10 @@ using namespace std;
 
 Fun4AllMemoryTracker *Fun4AllMemoryTracker::mInstance = nullptr;
 
+Fun4AllMemoryTracker::Fun4AllMemoryTracker():
+  Fun4AllBase("Fun4AllMemoryTracker")
+{}
+
 int Fun4AllMemoryTracker::GetRSSMemory() const
 {
   ProcInfo_t procinfo;
@@ -35,7 +39,10 @@ void Fun4AllMemoryTracker::Snapshot(const string &trackername, const string &gro
     mvec.push_back(GetRSSMemory());
     mMemoryTrackerMap.insert(make_pair(name, mvec));
   }
+  if (Verbosity() > 0)
+  {
   cout << "Snapshot name: " << name << ", mem: " << GetRSSMemory() << endl;
+  }
   return;
 }
 
@@ -52,7 +59,10 @@ void Fun4AllMemoryTracker::Start(const string &trackername, const string &group)
   {
     mStartMem.insert(make_pair(name, RSSMemory));
   }
+  if (Verbosity() > 0)
+  {
   cout << "Start name: " << name << ", mem: " << RSSMemory << endl;
+  }
 }
 
 void Fun4AllMemoryTracker::Stop(const string &trackername, const string &group)
@@ -74,7 +84,10 @@ void Fun4AllMemoryTracker::Stop(const string &trackername, const string &group)
       mvec.push_back(diff);
       mMemoryTrackerMap.insert(make_pair(name, mvec));
     }
+  if (Verbosity() > 0)
+  {
   cout << "Stop name: " << name << ", mem: " << RSSMemory << ", diff: " << diff << endl;
+  }
   }
   return;
 }
@@ -130,5 +143,3 @@ void Fun4AllMemoryTracker::PrintMemoryTracker(const string &name) const
   }
   return;
 }
-
-

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.cc
@@ -8,9 +8,10 @@ using namespace std;
 
 Fun4AllMemoryTracker *Fun4AllMemoryTracker::mInstance = nullptr;
 
-Fun4AllMemoryTracker::Fun4AllMemoryTracker():
-  Fun4AllBase("Fun4AllMemoryTracker")
-{}
+Fun4AllMemoryTracker::Fun4AllMemoryTracker()
+  : Fun4AllBase("Fun4AllMemoryTracker")
+{
+}
 
 int Fun4AllMemoryTracker::GetRSSMemory() const
 {
@@ -41,7 +42,7 @@ void Fun4AllMemoryTracker::Snapshot(const string &trackername, const string &gro
   }
   if (Verbosity() > 0)
   {
-  cout << "Snapshot name: " << name << ", mem: " << GetRSSMemory() << endl;
+    cout << "Snapshot name: " << name << ", mem: " << GetRSSMemory() << endl;
   }
   return;
 }
@@ -61,7 +62,7 @@ void Fun4AllMemoryTracker::Start(const string &trackername, const string &group)
   }
   if (Verbosity() > 0)
   {
-  cout << "Start name: " << name << ", mem: " << RSSMemory << endl;
+    cout << "Start name: " << name << ", mem: " << RSSMemory << endl;
   }
 }
 
@@ -84,10 +85,10 @@ void Fun4AllMemoryTracker::Stop(const string &trackername, const string &group)
       mvec.push_back(diff);
       mMemoryTrackerMap.insert(make_pair(name, mvec));
     }
-  if (Verbosity() > 0)
-  {
-  cout << "Stop name: " << name << ", mem: " << RSSMemory << ", diff: " << diff << endl;
-  }
+    if (Verbosity() > 0)
+    {
+      cout << "Stop name: " << name << ", mem: " << RSSMemory << ", diff: " << diff << endl;
+    }
   }
   return;
 }
@@ -95,7 +96,7 @@ void Fun4AllMemoryTracker::Stop(const string &trackername, const string &group)
 string Fun4AllMemoryTracker::CreateFullTrackerName(const string &trackername, const string &group)
 {
   string name = trackername;
-  if (! group.empty())
+  if (!group.empty())
   {
     name = group + "_" + name;
   }
@@ -113,7 +114,7 @@ void Fun4AllMemoryTracker::PrintMemoryTracker(const string &name) const
       vector<int> memvec = iter->second;
       for (auto vit = memvec.begin(); vit != memvec.end(); ++vit)
       {
-	cout << *vit << " ";
+        cout << *vit << " ";
       }
       cout << endl;
     }
@@ -127,7 +128,7 @@ void Fun4AllMemoryTracker::PrintMemoryTracker(const string &name) const
       vector<int> memvec = iter->second;
       for (auto vit = memvec.begin(); vit != memvec.end(); ++vit)
       {
-	cout << *vit << " ";
+        cout << *vit << " ";
       }
       cout << endl;
     }
@@ -137,7 +138,7 @@ void Fun4AllMemoryTracker::PrintMemoryTracker(const string &name) const
       cout << "Existing Memory Trackers:" << endl;
       for (iter = mMemoryTrackerMap.begin(); iter != mMemoryTrackerMap.end(); ++iter)
       {
-	cout << iter->first << endl;
+        cout << iter->first << endl;
       }
     }
   }

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.h
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.h
@@ -1,11 +1,13 @@
 #ifndef FUN4ALL_FUN4ALLMEMORYTRACKER_H
 #define FUN4ALL_FUN4ALLMEMORYTRACKER_H
 
+#include "Fun4AllBase.h"
+
 #include <map>
 #include <string>
 #include <vector>
 
-class Fun4AllMemoryTracker
+class Fun4AllMemoryTracker: public Fun4AllBase
 {
 public:
   static Fun4AllMemoryTracker *instance()
@@ -20,10 +22,10 @@ public:
   void Stop(const std::string &trackername, const std::string &group = "");
 
   int GetRSSMemory() const;
-  void PrintMemoryTracker(const std::string &name) const;
+  void PrintMemoryTracker(const std::string &name = "") const;
 
 private:
-  Fun4AllMemoryTracker() {}
+  Fun4AllMemoryTracker();
   std::string CreateFullTrackerName(const std::string &trackername, const std::string &group = "");
   static Fun4AllMemoryTracker *mInstance;
   std::map<std::string, std::vector<int>> mMemoryTrackerMap;

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.h
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.h
@@ -1,0 +1,33 @@
+#ifndef FUN4ALL_FUN4ALLMEMORYTRACKER_H
+#define FUN4ALL_FUN4ALLMEMORYTRACKER_H
+
+#include <map>
+#include <string>
+#include <vector>
+
+class Fun4AllMemoryTracker
+{
+public:
+  static Fun4AllMemoryTracker *instance()
+  {
+    if (mInstance) return mInstance;
+    mInstance = new Fun4AllMemoryTracker();
+    return mInstance;
+  }
+  ~Fun4AllMemoryTracker();
+  void Snapshot(const std::string &trackername, const std::string &group = "");
+  void Start(const std::string &trackername, const std::string &group = "");
+  void Stop(const std::string &trackername, const std::string &group = "");
+
+  int GetRSSMemory() const;
+  void PrintMemoryTracker(const std::string &name) const;
+
+private:
+  Fun4AllMemoryTracker() {}
+  std::string CreateFullTrackerName(const std::string &trackername, const std::string &group = "");
+  static Fun4AllMemoryTracker *mInstance;
+  std::map<std::string, std::vector<int>> mMemoryTrackerMap;
+  std::map<std::string, int> mStartMem;
+};
+
+#endif

--- a/offline/framework/fun4all/Fun4AllOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllOutputManager.cc
@@ -53,8 +53,6 @@ void Fun4AllOutputManager::Print(const string &what) const
   {
     unsigned icnt = 0;
     for (string evtsel : m_EventSelectorsVector)
-
-//    for (vector<string>::const_iterator iter = EventSelectors.begin(); iter != EventSelectors.end(); ++iter)
     {
       cout << Name() << ": Reco Module " << evtsel << " select Events" << endl;
       cout << Name() << ": Reco Module Index: " << m_RecoModuleIndexVector[icnt] << endl;
@@ -72,11 +70,8 @@ void Fun4AllOutputManager::Print(const string &what) const
 int Fun4AllOutputManager::DoNotWriteEvent(vector<int> *retcodes) const
 {
   int iret = 0;
-  for (unsigned int index: m_RecoModuleIndexVector)
-
-//  for (vector<unsigned>::const_iterator iter = recomoduleindex.begin(); iter != recomoduleindex.end(); ++iter)
+  for (unsigned int index : m_RecoModuleIndexVector)
   {
-//    const unsigned index = *iter;
     iret += (*retcodes)[index];
   }
   return iret;

--- a/offline/framework/fun4all/Fun4AllOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllOutputManager.cc
@@ -1,4 +1,5 @@
 #include "Fun4AllOutputManager.h"
+
 #include "Fun4AllServer.h"
 
 #include <iostream>
@@ -9,7 +10,14 @@ using namespace std;
 
 Fun4AllOutputManager::Fun4AllOutputManager(const string &name)
   : Fun4AllBase(name)
-  , nEvents(0)
+  , m_NEvents(0)
+{
+}
+
+Fun4AllOutputManager::Fun4AllOutputManager(const string &name, const string &outfname)
+  : Fun4AllBase(name)
+  , m_NEvents(0)
+  , m_OutFileName(outfname)
 {
 }
 
@@ -17,24 +25,23 @@ Fun4AllOutputManager::Fun4AllOutputManager(const string &name)
 int Fun4AllOutputManager::AddEventSelector(const string &recomodule)
 {
   string newselector = recomodule;
-  vector<string>::iterator iter;
-
-  for (iter = EventSelectors.begin(); iter != EventSelectors.end(); ++iter)
-    if (*iter == newselector)
+  for (string evtsel : m_EventSelectorsVector)
+  {
+    if (evtsel == newselector)
     {
       cout << "Event Selector " << newselector << " allready in list" << endl;
       return -1;
     }
-
-  cout << "EventSelector: " << &EventSelectors << endl;
-  EventSelectors.push_back(newselector);
+  }
+  cout << "EventSelector: " << &m_EventSelectorsVector << endl;
+  m_EventSelectorsVector.push_back(newselector);
   return 0;
 }
 
 //___________________________________________________________________
 int Fun4AllOutputManager::WriteGeneric(PHCompositeNode *startNode)
 {
-  nEvents++;
+  m_NEvents++;
   int iret = Write(startNode);
   return iret;
 }
@@ -45,10 +52,12 @@ void Fun4AllOutputManager::Print(const string &what) const
   if (what == "ALL" || what == "EVENTSELECTOR")
   {
     unsigned icnt = 0;
-    for (vector<string>::const_iterator iter = EventSelectors.begin(); iter != EventSelectors.end(); ++iter)
+    for (string evtsel : m_EventSelectorsVector)
+
+//    for (vector<string>::const_iterator iter = EventSelectors.begin(); iter != EventSelectors.end(); ++iter)
     {
-      cout << Name() << ": Reco Module " << *iter << " select Events" << endl;
-      cout << Name() << ": Reco Module Index: " << recomoduleindex[icnt] << endl;
+      cout << Name() << ": Reco Module " << evtsel << " select Events" << endl;
+      cout << Name() << ": Reco Module Index: " << m_RecoModuleIndexVector[icnt] << endl;
       icnt++;
     }
   }
@@ -63,9 +72,11 @@ void Fun4AllOutputManager::Print(const string &what) const
 int Fun4AllOutputManager::DoNotWriteEvent(vector<int> *retcodes) const
 {
   int iret = 0;
-  for (vector<unsigned>::const_iterator iter = recomoduleindex.begin(); iter != recomoduleindex.end(); ++iter)
+  for (unsigned int index: m_RecoModuleIndexVector)
+
+//  for (vector<unsigned>::const_iterator iter = recomoduleindex.begin(); iter != recomoduleindex.end(); ++iter)
   {
-    const unsigned index = *iter;
+//    const unsigned index = *iter;
     iret += (*retcodes)[index];
   }
   return iret;

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -82,6 +82,8 @@ class Fun4AllOutputManager : public Fun4AllBase
 
   //! get number of Events
   virtual size_t EventsWritten() const { return m_NEvents; }
+  //! increment number of events
+  virtual void IncrementEvents(const unsigned int i) {m_NEvents += i;}
   //! get output file name
   virtual std::string OutFileName() const { return m_OutFileName; }
   void OutFileName(const std::string &name) { m_OutFileName = name; }
@@ -96,7 +98,7 @@ class Fun4AllOutputManager : public Fun4AllBase
 
  private:
   //! Number of Events
-  size_t m_NEvents;
+  unsigned int m_NEvents;
 
   //! output file name
   std::string m_OutFileName;

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -84,7 +84,7 @@ class Fun4AllOutputManager : public Fun4AllBase
   virtual size_t EventsWritten() const { return m_NEvents; }
   //! get output file name
   virtual std::string OutFileName() const { return m_OutFileName; }
-  void OutFileName(const std::string &name) {m_OutFileName = name;}
+  void OutFileName(const std::string &name) { m_OutFileName = name; }
 
  protected:
   /*! 
@@ -106,7 +106,6 @@ class Fun4AllOutputManager : public Fun4AllBase
 
   //! vector of associated module indexes
   std::vector<unsigned> m_RecoModuleIndexVector;
-
 };
 
 #endif

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -1,5 +1,5 @@
-#ifndef FUN4ALLOUTPUTMANAGER_H__
-#define FUN4ALLOUTPUTMANAGER_H__
+#ifndef FUN4ALL_FUN4ALLOUTPUTMANAGER_H
+#define FUN4ALL_FUN4ALLOUTPUTMANAGER_H
 
 #include "Fun4AllBase.h"
 
@@ -68,40 +68,45 @@ class Fun4AllOutputManager : public Fun4AllBase
   //! retrieves pointer to vector of event selector module names
   virtual std::vector<std::string> *EventSelector()
   {
-    return &EventSelectors;
+    return &m_EventSelectorsVector;
   }
 
   //! retrieves pointer to vector of event selector module ids
   virtual std::vector<unsigned> *RecoModuleIndex()
   {
-    return &recomoduleindex;
+    return &m_RecoModuleIndexVector;
   }
 
   //! decides if event is to be written or not
   virtual int DoNotWriteEvent(std::vector<int> *retcodes) const;
 
   //! get number of Events
-  virtual size_t EventsWritten() const { return nEvents; }
+  virtual size_t EventsWritten() const { return m_NEvents; }
   //! get output file name
-  virtual std::string OutFileName() const { return outfilename; }
+  virtual std::string OutFileName() const { return m_OutFileName; }
+  void OutFileName(const std::string &name) {m_OutFileName = name;}
+
  protected:
   /*! 
     constructor.
     is protected since we do not want the  class to be created in root macros
   */
   Fun4AllOutputManager(const std::string &myname);
+  Fun4AllOutputManager(const std::string &myname, const std::string &outfname);
 
+ private:
   //! Number of Events
-  size_t nEvents;
-
-  //! vector of event selectors modules
-  std::vector<std::string> EventSelectors;
-
-  //! vector of associated module indexes
-  std::vector<unsigned> recomoduleindex;
+  size_t m_NEvents;
 
   //! output file name
-  std::string outfilename;
+  std::string m_OutFileName;
+
+  //! vector of event selectors modules
+  std::vector<std::string> m_EventSelectorsVector;
+
+  //! vector of associated module indexes
+  std::vector<unsigned> m_RecoModuleIndexVector;
+
 };
 
-#endif /* __FUN4ALLOUTPUTMANAGER_H__ */
+#endif

--- a/offline/framework/fun4all/Fun4AllPrdfOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllPrdfOutputManager.cc
@@ -1,6 +1,6 @@
 #include "Fun4AllPrdfOutputManager.h"
-#include <phool/recoConsts.h>
 
+#include <phool/recoConsts.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHRawOManager.h>
@@ -13,11 +13,10 @@ using namespace std;
 
 //______________________________________________________
 Fun4AllPrdfOutputManager::Fun4AllPrdfOutputManager( const string &myname, const string &fname):
-  Fun4AllOutputManager( myname ),
-  prdfNode( 0 ),
-  prdfOut( 0 )
+  Fun4AllOutputManager( myname, fname ),
+  prdfNode( nullptr ),
+  prdfOut( nullptr )
 {
-  outfilename = fname;
   return ;
 }
 
@@ -54,13 +53,13 @@ int Fun4AllPrdfOutputManager::InitPrdfNode( PHCompositeNode* top_node, const str
 int Fun4AllPrdfOutputManager::outfileopen(const string &fname)
 {
   if( prdfOut ) {
-    if( Verbosity() ) cout << "Fun4AllPrdfOutputManager::outfileopen - closing file \"" << outfilename << "\"" << endl;
+    if( Verbosity() ) cout << "Fun4AllPrdfOutputManager::outfileopen - closing file \"" << OutFileName() << "\"" << endl;
     delete prdfOut;
-    prdfOut = 0;
+    prdfOut = nullptr;
   }
 
-  outfilename = fname;
-  if( Verbosity() ) cout << "Fun4AllPrdfOutputManager::outfileopen - writing to file \"" << outfilename << "\"" << endl;
+  OutFileName(fname);
+  if( Verbosity() ) cout << "Fun4AllPrdfOutputManager::outfileopen - writing to file \"" << OutFileName() << "\"" << endl;
 
   return 0;
   
@@ -108,7 +107,7 @@ int Fun4AllPrdfOutputManager::InitPrdfManager( void )
   static const int buffer_length( 8*1024*1024/4 );
   
   // create output manager
-  prdfOut = new PHRawOManager( outfilename.c_str() , run_number , buffer_length);
+  prdfOut = new PHRawOManager( OutFileName() , run_number , buffer_length);
   return 0;
 
 }

--- a/offline/framework/fun4all/Fun4AllPrdfOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllPrdfOutputManager.h
@@ -1,7 +1,8 @@
-#ifndef __FUN4ALLPRDFOUTPUTMANAGER_H__
-#define __FUN4ALLPRDFOUTPUTMANAGER_H__
+#ifndef FUN4ALL_FUN4ALLPRDFOUTPUTMANAGER_H
+#define FUN4ALL_FUN4ALLPRDFOUTPUTMANAGER_H
 
 #include "Fun4AllOutputManager.h"
+
 #include <string>
 
 class PHRawOManager;
@@ -41,5 +42,5 @@ class Fun4AllPrdfOutputManager: public Fun4AllOutputManager
   PHRawOManager *prdfOut;
 };
 
-#endif /* __FUN4ALLPRDFOUTPUTMANAGER_H__ */
+#endif
   

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -40,7 +40,7 @@
 
 using namespace std;
 
-Fun4AllServer *Fun4AllServer::__instance = 0;
+Fun4AllServer *Fun4AllServer::__instance = nullptr;
 
 Fun4AllServer *Fun4AllServer::instance()
 {
@@ -54,15 +54,15 @@ Fun4AllServer *Fun4AllServer::instance()
 
 Fun4AllServer::Fun4AllServer(const std::string &name)
   : Fun4AllBase(name)
+  , ffamemtracker(Fun4AllMemoryTracker::instance())
+  , beginruntimestamp(nullptr)
   , OutNodeCount(0)
   , bortime_override(0)
   , ScreamEveryEvent(0)
   , unregistersubsystem(0)
   , runnumber(0)
   , eventnumber(0)
-  , beginruntimestamp(nullptr)
   , keep_db_connected(0)
-  , ffamemtracker(Fun4AllMemoryTracker::instance())
 {
   InitAll();
   return;

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -1,6 +1,8 @@
 #include "Fun4AllServer.h"
+
 #include "Fun4AllHistoBinDefs.h"
 #include "Fun4AllInputManager.h"
+#include "Fun4AllMemoryTracker.h"
 #include "Fun4AllOutputManager.h"
 #include "Fun4AllReturnCodes.h"
 #include "Fun4AllSyncManager.h"
@@ -60,6 +62,7 @@ Fun4AllServer::Fun4AllServer(const std::string &name)
   , eventnumber(0)
   , beginruntimestamp(nullptr)
   , keep_db_connected(0)
+  , ffamemtracker(Fun4AllMemoryTracker::instance())
 {
   InitAll();
   return;
@@ -118,6 +121,7 @@ Fun4AllServer::~Fun4AllServer()
   }
   recoConsts *rc = recoConsts::instance();
   delete rc;
+  delete ffamemtracker;
   __instance = nullptr;
   return;
 }
@@ -181,6 +185,8 @@ int Fun4AllServer::isHistoRegistered(const string &name) const
 int Fun4AllServer::registerSubsystem(SubsysReco *subsystem, const string &topnodename)
 {
   Fun4AllServer *se = Fun4AllServer::instance();
+
+
   // if somebody opens a TFile (or changes the gDirectory) in the ctor
   // we need to set it to a "known" directory
   gROOT->cd(default_Tdirectory.c_str());
@@ -220,7 +226,10 @@ int Fun4AllServer::registerSubsystem(SubsysReco *subsystem, const string &topnod
   int iret = 0;
   try
   {
+    string memory_tracker_name = subsystem->Name() + "_" + topnodename;
+    ffamemtracker->Start(memory_tracker_name,"SubsysReco");
     iret = subsystem->Init(subsystopNode);
+    ffamemtracker->Stop(memory_tracker_name,"SubsysReco");
   }
   catch (const exception &e)
   {
@@ -255,12 +264,12 @@ int Fun4AllServer::registerSubsystem(SubsysReco *subsystem, const string &topnod
     cout << "Registering Subsystem " << subsystem->Name() << endl;
   }
   Subsystems.push_back(newsubsyspair);
-  ostringstream timer_name;
-  timer_name << subsystem->Name() << "_" << topnodename;
-  PHTimer timer(timer_name.str());
-  if (timer_map.find(timer_name.str()) == timer_map.end())
+  string timer_name;
+  timer_name = subsystem->Name() + "_" + topnodename;
+  PHTimer timer(timer_name);
+  if (timer_map.find(timer_name) == timer_map.end())
   {
-    timer_map[timer_name.str()] = timer;
+    timer_map.insert(make_pair(timer_name,timer));
   }
   RetCodes.push_back(iret);  // vector with return codes
   return 0;
@@ -552,9 +561,9 @@ int Fun4AllServer::process_event()
 
     try
     {
-      ostringstream timer_name;
-      timer_name << (*iter).first->Name() << "_" << (*iter).second->getName();
-      std::map<const std::string, PHTimer>::iterator titer = timer_map.find(timer_name.str());
+      string timer_name;
+      timer_name = (*iter).first->Name() + "_" + (*iter).second->getName();
+      std::map<const std::string, PHTimer>::iterator titer = timer_map.find(timer_name);
       bool timer_found = false;
       if (titer != timer_map.end())
       {
@@ -565,7 +574,10 @@ int Fun4AllServer::process_event()
       {
 	cout << "could not find timer for " << timer_name << endl;
       }
+      ffamemtracker->Start(timer_name,"SubsysReco");
+      ffamemtracker->Snapshot("Fun4AllServerProcessEvent");
       int retcode = (*iter).first->process_event((*iter).second);
+      ffamemtracker->Snapshot("Fun4AllServerProcessEvent");
 // we have observed an index overflow in RetCodes. I assume it is some
 // memory corruption elsewhere which hits the icnt variable. Rather than
 // the previous [], use at() which does bounds checking and throws an 
@@ -585,6 +597,7 @@ int Fun4AllServer::process_event()
       {
 	titer->second.stop();
       }
+      ffamemtracker->Stop(timer_name,"SubsysReco");
     }
     catch (const exception &e)
     {
@@ -681,7 +694,11 @@ int Fun4AllServer::process_event()
           {
             cout << "Writing Event for " << (*iterOutMan)->Name() << endl;
           }
+          ffamemtracker->Snapshot("Fun4AllServerOutputManager");
+	  ffamemtracker->Start((*iterOutMan)->Name(),"OutputManager");
           (*iterOutMan)->WriteGeneric(dstNode);
+	  ffamemtracker->Stop((*iterOutMan)->Name(),"OutputManager");
+          ffamemtracker->Snapshot("Fun4AllServerOutputManager");
         }
         else
         {
@@ -768,6 +785,7 @@ int Fun4AllServer::BeginRunTimeStamp(PHTimeStamp &TimeStp)
 
 int Fun4AllServer::BeginRun(const int runno)
 {
+  ffamemtracker->Snapshot("Fun4AllServerBeginRun");
   if (!bortime_override)
   {
     if (beginruntimestamp)
@@ -830,7 +848,9 @@ int Fun4AllServer::BeginRun(const int runno)
     }
     try
     {
+      ffamemtracker->Start((*iter).first->Name(),"SubsysReco");
       iret = (*iter).first->InitRun((*iter).second);
+      ffamemtracker->Stop((*iter).first->Name(),"SubsysReco");
     }
     catch (const exception &e)
     {
@@ -876,6 +896,7 @@ int Fun4AllServer::BeginRun(const int runno)
   }
   // print out all node trees
   Print("NODETREE");
+  ffamemtracker->Snapshot("Fun4AllServerBeginRun");
   return 0;
 }
 
@@ -1686,5 +1707,11 @@ void Fun4AllServer::PrintTimer(const string &name)
       }
     }
   }
+  return;
+}
+
+void Fun4AllServer::PrintMemoryTracker(const string &name) const
+{
+  ffamemtracker->PrintMemoryTracker(name);
   return;
 }

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -1,7 +1,8 @@
-#ifndef FUN4ALLSERVER_H
-#define FUN4ALLSERVER_H
+#ifndef FUN4ALL_FUN4ALLSERVER_H
+#define FUN4ALL_FUN4ALLSERVER_H
 
 #include "Fun4AllBase.h"
+
 #include "Fun4AllHistoManager.h"
 
 #include <phool/PHTimer.h>
@@ -115,31 +116,33 @@ class Fun4AllServer : public Fun4AllBase
   int unregisterSubsystemsNow();
   int setRun(const int runnumber);
   static Fun4AllServer *__instance;
+  TH1 *FrameWorkVars;
+  Fun4AllMemoryTracker *ffamemtracker;
+  Fun4AllHistoManager *ServerHistoManager;
+  PHTimeStamp *beginruntimestamp;
+  PHCompositeNode *TopNode;
+  Fun4AllSyncManager *defaultSyncManager;
+
   int OutNodeCount;
   int bortime_override;
   int ScreamEveryEvent;
   int unregistersubsystem;
   int runnumber;
   int eventnumber;
+  int keep_db_connected;
+
   std::vector<std::string> ComplaintList;
-  PHCompositeNode *TopNode;
   std::vector<std::pair<SubsysReco *, PHCompositeNode *> > Subsystems;
   std::vector<std::pair<SubsysReco *, PHCompositeNode *> > DeleteSubsystems;
   std::vector<int> RetCodes;
   std::vector<Fun4AllOutputManager *> OutputManager;
   std::vector<TDirectory *> TDirCollection;
-  Fun4AllHistoManager *ServerHistoManager;
   std::vector<Fun4AllHistoManager *> HistoManager;
   std::map<std::string, PHCompositeNode *> topnodemap;
-  PHTimeStamp *beginruntimestamp;
   std::string default_Tdirectory;
-  Fun4AllSyncManager *defaultSyncManager;
   std::vector<Fun4AllSyncManager *> SyncManagers;
   std::map<int, int> retcodesmap;
   std::map<const std::string, PHTimer> timer_map;
-  TH1 *FrameWorkVars;
-  int keep_db_connected;
-  Fun4AllMemoryTracker *ffamemtracker;
 };
 
-#endif /* __FUN4ALLSERVER_H */
+#endif

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 class Fun4AllInputManager;
+class Fun4AllMemoryTracker;
 class Fun4AllSyncManager;
 class Fun4AllOutputManager;
 class PHCompositeNode;
@@ -103,6 +104,7 @@ class Fun4AllServer : public Fun4AllBase
   void NodeIdentify(const std::string &name);
   void KeepDBConnection(const int i = 1) { keep_db_connected = i; }
   void PrintTimer(const std::string &name = "");
+  void PrintMemoryTracker(const std::string &name = "") const;
 
  protected:
   Fun4AllServer(const std::string &name = "Fun4AllServer");
@@ -137,6 +139,7 @@ class Fun4AllServer : public Fun4AllBase
   std::map<const std::string, PHTimer> timer_map;
   TH1 *FrameWorkVars;
   int keep_db_connected;
+  Fun4AllMemoryTracker *ffamemtracker;
 };
 
 #endif /* __FUN4ALLSERVER_H */

--- a/offline/framework/fun4all/Makefile.am
+++ b/offline/framework/fun4all/Makefile.am
@@ -36,6 +36,7 @@ pkginclude_HEADERS = \
   Fun4AllHistoBinDefs.h \
   Fun4AllHistoManager.h \
   Fun4AllInputManager.h \
+  Fun4AllMemoryTracker.h \
   Fun4AllNoSyncDstInputManager.h \
   Fun4AllOutputManager.h \
   Fun4AllPrdfInputManager.h \
@@ -67,13 +68,14 @@ libfun4all_la_SOURCES = \
   Fun4AllFileOutStream.cc \
   Fun4AllHistoManager.cc \
   Fun4AllInputManager.cc \
-  Fun4AllSyncManager.cc \
+  Fun4AllMemoryTracker.cc \
   Fun4AllNoSyncDstInputManager.cc \
   Fun4AllOutputManager.cc \
   Fun4AllPrdfInputManager.cc \
   Fun4AllPrdfOutputManager.cc \
   Fun4AllRolloverFileOutStream.cc \
   Fun4AllServer.cc \
+  Fun4AllSyncManager.cc \
   Fun4AllUtils.cc \
   PHTFileServer.cc
 


### PR DESCRIPTION
This PR is part of a long term cleanup of fun4all. Datamembers should not be exposed to derived classes but private and access methods should be used. This PR makes the datamembers of the Fun4AllOutputManager base class private