### PR TITLE
add eigen include dir to include path

### DIFF
--- a/simulation/g4simulation/g4trackfastsim/Makefile.am
+++ b/simulation/g4simulation/g4trackfastsim/Makefile.am
@@ -8,6 +8,7 @@ AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(G4_MAIN)/include \
   -I$(OFFLINE_MAIN)/include  \
+  -I$(OFFLINE_MAIN)/include/eigen3  \
   -I$(ROOTSYS)/include \
   -I$(OPT_SPHENIX)/include
 


### PR DESCRIPTION
the new genfit version uses eigen - so we need to add the eigne include dir to the include search path ($OFFLINE_MAIN/include/eigen3)