### PR TITLE
Fix tutorials

### DIFF
--- a/offline/framework/fun4all/Fun4AllMemoryTracker.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.cc
@@ -144,3 +144,14 @@ void Fun4AllMemoryTracker::PrintMemoryTracker(const string &name) const
   }
   return;
 }
+
+vector<int> Fun4AllMemoryTracker::GetMemoryVector(const std::string &name) const
+{
+  vector<int> memvec;
+  auto iter =  mMemoryTrackerMap.find(name);
+  if (iter != mMemoryTrackerMap.end())
+  {
+    memvec = iter->second;
+  }
+  return memvec;
+}

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.h
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.h
@@ -23,6 +23,7 @@ class Fun4AllMemoryTracker : public Fun4AllBase
 
   int GetRSSMemory() const;
   void PrintMemoryTracker(const std::string &name = "") const;
+  std::vector<int> GetMemoryVector(const std::string &name) const;
 
  private:
   Fun4AllMemoryTracker();

--- a/simulation/g4simulation/g4histos/Makefile.am
+++ b/simulation/g4simulation/g4histos/Makefile.am
@@ -27,7 +27,6 @@ noinst_HEADERS = \
   G4CellNtuple.h \
   G4EdepNtuple.h \
   G4EvtTree.h \
-  G4HitTTree.h \
   G4RawTowerTTree.h \
   G4RootHitContainer.h \
   G4RootRawTower.h \
@@ -36,7 +35,8 @@ noinst_HEADERS = \
   G4SnglTree.h
 
 pkginclude_HEADERS = \
-  G4HitNtuple.h
+  G4HitNtuple.h \
+  G4HitTTree.h
 
 ROOTDICTS = \
   G4RootHitContainer_Dict.cc \


### PR DESCRIPTION
This PR installs G4HitTTree.h which is needed by the block and cylinder tutorials. Added return of vector<int> for memory tracker to be used in plotting macros 