### PR TITLE
Fix parameter ordering issue when using G4GenericTrap for INTT geometry

### DIFF
--- a/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
@@ -903,10 +903,10 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
           }
           else
           {
-          rohatrap[0] = G4TwoVector(0. * cm, 0. * cm);
-          rohatrap[1] = G4TwoVector(Rcmin * cos(dphi_c) - shift, +Rcmin * sin(dphi_c));
-          rohatrap[2] = G4TwoVector(Rcmax * (1. - cos(dphi_c)) - shift, +stave_slant_cooler_y * cos(dphi_c) + Rcmin * sin(dphi_c));
-          rohatrap[3] = G4TwoVector(0. * cm, +stave_slant_cooler_y * cos(dphi_c) + Rcmin * sin(dphi_c));
+          rohatrap[0] = G4TwoVector(0. * cm, +stave_slant_cooler_y * cos(dphi_c) + Rcmin * sin(dphi_c));
+          rohatrap[1] = G4TwoVector(Rcmax * (1. - cos(dphi_c)) - shift, +stave_slant_cooler_y * cos(dphi_c) + Rcmin * sin(dphi_c));
+          rohatrap[2] = G4TwoVector(Rcmin * cos(dphi_c) - shift, +Rcmin * sin(dphi_c));
+          rohatrap[3] = G4TwoVector(0. * cm, 0. * cm);
           }
           rohatrap[4] = rohatrap[0];
           rohatrap[5] = rohatrap[1];


### PR DESCRIPTION
This PR is to fix warning messages on parameter ordering issue when using G4GenericTrap to describe the trapezoidal part of the rohacell foam in the INTT stave geometry. No change in the geometry itself. Shown below is a cut-and-paste from GEANT4 overlap check with the fixed code. 
Now the trapezoidal shapes do not show the warning messages.

++++++++++++++++++++++++++++++++++++++++++++++++++++
Checking overlaps for volume rohacell_trap_0_0_0 ... OK! 
Checking overlaps for volume rohacell_trap_ext_0_0_0 ... OK! 
Checking overlaps for volume rohacell_trap_0_0_1 ... OK! 
Checking overlaps for volume rohacell_trap_ext_0_0_1 ... OK! 
++++++++++++++++++++++++++++++++++++++++++++++++++++