### PR TITLE
Add Ion gun

### DIFF
--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -115,11 +115,12 @@ else
     PHG4InEventCompress_Dict.cc \
     PHG4InEventReadBack_Dict.cc \
     PHG4InputFilter_Dict.cc \
-    PHG4ParticleGun_Dict.cc \
+    PHG4IonGun_Dict.cc \
     PHG4ParticleGenerator_Dict.cc \
     PHG4ParticleGeneratorBase_Dict.cc \
     PHG4ParticleGeneratorVectorMeson_Dict.cc \
     PHG4ParticleGeneratorD0_Dict.cc \
+    PHG4ParticleGun_Dict.cc \
     PHG4Reco_Dict.cc \
     PHG4ScoringManager_Dict.cc \
     PHG4SimpleEventGenerator_Dict.cc \
@@ -164,27 +165,28 @@ libg4testbench_la_SOURCES = \
   PHG4InEventCompress.cc \
   PHG4InEventReadBack.cc \
   PHG4InputFilter.cc \
-  PHG4PileupGenerator.cc \
-  PHG4SimpleEventGenerator.cc \
-  PHG4ParticleGun.cc \
+  PHG4IonGun.cc \
   PHG4ParticleGeneratorBase.cc \
   PHG4ParticleGenerator.cc \
   PHG4ParticleGeneratorVectorMeson.cc \
   PHG4ParticleGeneratorD0.cc \
+  PHG4ParticleGun.cc \
   PHG4PhenixDetector.cc \
   PHG4PhenixEventAction.cc \
   PHG4PhenixSteppingAction.cc \
   PHG4PhenixTrackingAction.cc \
+  PHG4PileupGenerator.cc \
   PHG4PrimaryGeneratorAction.cc \
   PHG4Reco.cc \
-  PHG4ScoringManager.cc \
   PHG4RegionInformation.cc \
+  PHG4ScoringManager.cc \
+  PHG4SimpleEventGenerator.cc \
+  PHG4SteppingAction.cc \
   PHG4TrackUserInfoV1.cc \
   PHG4TruthEventAction.cc \
   PHG4TruthSteppingAction.cc \
   PHG4TruthSubsystem.cc \
   PHG4TruthTrackingAction.cc \
-  PHG4SteppingAction.cc \
   PHG4UIsession.cc \
   PHG4Utils.cc \
   ReadEICFiles.cc
@@ -206,6 +208,7 @@ pkginclude_HEADERS = \
   PHG4HitEval.h \
   PHG4HitContainer.h \
   PHG4InEvent.h \
+  PHG4IonGun.h \
   PHG4Particle.h \
   PHG4Particlev1.h \
   PHG4Particlev2.h \
@@ -215,6 +218,7 @@ pkginclude_HEADERS = \
   PHG4ParticleGun.h \
   PHG4PhenixDetector.h \
   PHG4PileupGenerator.h \
+  PHG4PrimaryGeneratorAction.h \
   PHG4Reco.h \
   PHG4RegionInformation.h \
   PHG4SimpleEventGenerator.h \

--- a/simulation/g4simulation/g4main/PHG4IonGun.cc
+++ b/simulation/g4simulation/g4main/PHG4IonGun.cc
@@ -12,8 +12,10 @@ using namespace std;
 PHG4IonGun::PHG4IonGun()
   : A(0)
   , Z(0)
+  , ioncharge(0)
   , excitEnergy(0)
 {
+  fill(begin(mom),end(mom),NAN);
 }
 
 void PHG4IonGun::SetCharge(const int c)

--- a/simulation/g4simulation/g4main/PHG4IonGun.cc
+++ b/simulation/g4simulation/g4main/PHG4IonGun.cc
@@ -1,7 +1,5 @@
 #include "PHG4IonGun.h"
 
-#include <phool/PHCompositeNode.h>
-
 #include <Geant4/G4Event.hh>
 #include <Geant4/G4IonTable.hh>
 #include <Geant4/G4PrimaryParticle.hh>
@@ -11,36 +9,33 @@
 
 using namespace std;
 
-PHG4IonGun::PHG4IonGun():
-  A(0),
-  Z(0),
-  excitEnergy(0)
-{}
-
-void
-PHG4IonGun::SetCharge(const int c)
+PHG4IonGun::PHG4IonGun()
+  : A(0)
+  , Z(0)
+  , excitEnergy(0)
 {
-  ioncharge = c*eplus;
-}
-void
-PHG4IonGun::SetMom(const double px, const double py, const double pz) 
-{
-mom[0] = px*GeV; 
-mom[1] = py*GeV; 
-mom[2] = pz*GeV;
 }
 
-void
-PHG4IonGun::GeneratePrimaries(G4Event* anEvent)
+void PHG4IonGun::SetCharge(const int c)
 {
-G4ParticleDefinition* ion = G4IonTable::GetIonTable()->GetIon(Z,A,excitEnergy);
-  G4ThreeVector position(0*cm,0*cm,0*cm);
-  G4PrimaryVertex* vertex = new G4PrimaryVertex(position,0*s);
+  ioncharge = c * eplus;
+}
+void PHG4IonGun::SetMom(const double px, const double py, const double pz)
+{
+  mom[0] = px * GeV;
+  mom[1] = py * GeV;
+  mom[2] = pz * GeV;
+}
+
+void PHG4IonGun::GeneratePrimaries(G4Event* anEvent)
+{
+  G4ParticleDefinition* ion = G4IonTable::GetIonTable()->GetIon(Z, A, excitEnergy);
+  G4ThreeVector position(0 * cm, 0 * cm, 0 * cm);
+  G4PrimaryVertex* vertex = new G4PrimaryVertex(position, 0 * s);
   G4PrimaryParticle* g4part = new G4PrimaryParticle(ion);
   g4part->SetCharge(ioncharge);
-  g4part->SetMomentum(mom[0],mom[1],mom[2]);
-vertex->SetPrimary(g4part);
- anEvent->AddPrimaryVertex(vertex);
- cout << "shot a: " << A << ", z: " << Z << endl;
+  g4part->SetMomentum(mom[0], mom[1], mom[2]);
+  vertex->SetPrimary(g4part);
+  anEvent->AddPrimaryVertex(vertex);
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4IonGun.cc
+++ b/simulation/g4simulation/g4main/PHG4IonGun.cc
@@ -1,0 +1,46 @@
+#include "PHG4IonGun.h"
+
+#include <phool/PHCompositeNode.h>
+
+#include <Geant4/G4Event.hh>
+#include <Geant4/G4IonTable.hh>
+#include <Geant4/G4PrimaryParticle.hh>
+#include <Geant4/G4PrimaryVertex.hh>
+#include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4ThreeVector.hh>
+
+using namespace std;
+
+PHG4IonGun::PHG4IonGun():
+  A(0),
+  Z(0),
+  excitEnergy(0)
+{}
+
+void
+PHG4IonGun::SetCharge(const int c)
+{
+  ioncharge = c*eplus;
+}
+void
+PHG4IonGun::SetMom(const double px, const double py, const double pz) 
+{
+mom[0] = px*GeV; 
+mom[1] = py*GeV; 
+mom[2] = pz*GeV;
+}
+
+void
+PHG4IonGun::GeneratePrimaries(G4Event* anEvent)
+{
+G4ParticleDefinition* ion = G4IonTable::GetIonTable()->GetIon(Z,A,excitEnergy);
+  G4ThreeVector position(0*cm,0*cm,0*cm);
+  G4PrimaryVertex* vertex = new G4PrimaryVertex(position,0*s);
+  G4PrimaryParticle* g4part = new G4PrimaryParticle(ion);
+  g4part->SetCharge(ioncharge);
+  g4part->SetMomentum(mom[0],mom[1],mom[2]);
+vertex->SetPrimary(g4part);
+ anEvent->AddPrimaryVertex(vertex);
+ cout << "shot a: " << A << ", z: " << Z << endl;
+  return;
+}

--- a/simulation/g4simulation/g4main/PHG4IonGun.h
+++ b/simulation/g4simulation/g4main/PHG4IonGun.h
@@ -1,0 +1,33 @@
+#ifndef G4MAIN_PHG4IONGUN_H
+#define G4MAIN_PHG4IONGUN_H
+
+//#include <fun4all/SubsysReco.h>
+
+//#include <Geant4/G4VUserPrimaryGeneratorAction.hh>
+#include "PHG4PrimaryGeneratorAction.h"
+
+//class PHCompositeNode;
+
+class PHG4IonGun : public PHG4PrimaryGeneratorAction
+{
+ public:
+  PHG4IonGun();
+  virtual ~PHG4IonGun() {}
+
+  virtual void GeneratePrimaries(G4Event* anEvent);
+  void SetA(const int a){A=a;}
+  void SetZ(const int z) {Z=z;}
+  void SetCharge(const int c);
+  void ExcitEnergy(const double e) {excitEnergy = e;}
+  void SetMom(const double px, const double py, const double pz);
+
+ protected:
+  int A;
+  int Z;
+  double mom[3];
+  double ioncharge;
+  double excitEnergy; 
+  
+};
+
+#endif

--- a/simulation/g4simulation/g4main/PHG4IonGun.h
+++ b/simulation/g4simulation/g4main/PHG4IonGun.h
@@ -1,12 +1,7 @@
 #ifndef G4MAIN_PHG4IONGUN_H
 #define G4MAIN_PHG4IONGUN_H
 
-//#include <fun4all/SubsysReco.h>
-
-//#include <Geant4/G4VUserPrimaryGeneratorAction.hh>
 #include "PHG4PrimaryGeneratorAction.h"
-
-//class PHCompositeNode;
 
 class PHG4IonGun : public PHG4PrimaryGeneratorAction
 {
@@ -15,10 +10,10 @@ class PHG4IonGun : public PHG4PrimaryGeneratorAction
   virtual ~PHG4IonGun() {}
 
   virtual void GeneratePrimaries(G4Event* anEvent);
-  void SetA(const int a){A=a;}
-  void SetZ(const int z) {Z=z;}
+  void SetA(const int a) { A = a; }
+  void SetZ(const int z) { Z = z; }
   void SetCharge(const int c);
-  void ExcitEnergy(const double e) {excitEnergy = e;}
+  void ExcitEnergy(const double e) { excitEnergy = e; }
   void SetMom(const double px, const double py, const double pz);
 
  protected:
@@ -26,8 +21,7 @@ class PHG4IonGun : public PHG4PrimaryGeneratorAction
   int Z;
   double mom[3];
   double ioncharge;
-  double excitEnergy; 
-  
+  double excitEnergy;
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4IonGunLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4IonGunLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4IonGun-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -664,17 +664,18 @@ int PHG4Reco::setupInputEventNodeReader(PHCompositeNode *topNode)
     PHDataNode<PHObject> *newNode = new PHDataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
     dstNode->addNode(newNode);
   }
-  generatorAction_ = new PHG4PrimaryGeneratorAction();
+// check if we have already registered a generator before creating the default which uses PHG4InEvent Node
+  if (! generatorAction_)
+  {
+    generatorAction_ = new PHG4PrimaryGeneratorAction();
+  }
   runManager_->SetUserAction(generatorAction_);
   return 0;
 }
 
-void PHG4Reco::setGeneratorAction(G4VUserPrimaryGeneratorAction *action)
+void PHG4Reco::setGeneratorAction(PHG4PrimaryGeneratorAction *action)
 {
-  if (runManager_)
-  {
-    runManager_->SetUserAction(action);
-  }
+  generatorAction_ = action;
   return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -116,12 +116,10 @@ class PHG4Reco : public SubsysReco
 
   static void G4Seed(const unsigned int i);
 
-  // this is an ugly hack to get Au ions working for CAD
+  // this is a hack to get ions working for CAD and NSRL
   // our particle generators have pdg build in which doesn't work
-  // with ions, so the generator action has to be replaced
-  // which is hardcoded in PHG4Reco (it has to be created after
-  // the physics lists are instantiated
-  void setGeneratorAction(G4VUserPrimaryGeneratorAction *action);
+  // with ions, so the default generator action has to be replaced
+  void setGeneratorAction(PHG4PrimaryGeneratorAction *action);
 
   PHG4Subsystem *getSubsystem(const std::string &name);
 
@@ -185,7 +183,6 @@ class PHG4Reco : public SubsysReco
 
   bool save_DST_geometry_;
   bool m_disableUserActions;
-
 };
 
 #endif


### PR DESCRIPTION
NSRL and CAD need ions but our particle generator infra structure needs to look the particles up in pdg. This PR creates a back door to feed particles into our G4 simulations. Caveat: this cannot be used in conjunction with our particle generators. A new class PHG4IonGun is used to generate ions. So far it uses 0/0/0 as vertex - I don't think it is necessary to add vertex displacement or smearing for this