### PR TITLE
Fix g4dst

### DIFF
--- a/simulation/g4simulation/g4dst/Makefile.am
+++ b/simulation/g4simulation/g4dst/Makefile.am
@@ -24,7 +24,8 @@ libg4dst_la_LDFLAGS = \
   -lphg4hit \
   -lphgeom_io \
   -lphhepmc_io \
-  -ltrack_reco_io
+  -ltrack_reco_io \
+  -ltrackbase_historic_io
 
 libg4dst_la_SOURCES = \
    g4dst.cc

--- a/simulation/g4simulation/g4dst/Makefile.am
+++ b/simulation/g4simulation/g4dst/Makefile.am
@@ -10,23 +10,26 @@ lib_LTLIBRARIES = \
 libg4dst_la_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  -lphg4hit \
-  -lg4detectors_io \
-  -lg4hough_io \
   -lcalo_io \
-  -lg4vertex_io \
-  -lg4jets_io \
-  -lphgeom_io \
-  -lphhepmc_io \
-  -lphfield_io \
   -lcalotrigger_io \
   -lg4bbc_io \
-  -ljetbackground_io
+  -lg4detectors_io \
+  -lg4hough_io \
+  -lg4intt_io \
+  -lg4jets_io \
+  -lg4mvtx_io \
+  -lg4vertex_io \
+  -ljetbackground_io \
+  -lphfield_io \
+  -lphg4hit \
+  -lphgeom_io \
+  -lphhepmc_io \
+  -ltrack_reco_io
 
 libg4dst_la_SOURCES = \
-   g4dst.C
+   g4dst.cc
 
-g4dst.C:
+g4dst.cc:
 	echo "//*** this is a generated empty file. Do not commit, do not edit" > $@
 
 ################################################
@@ -35,13 +38,16 @@ g4dst.C:
 noinst_PROGRAMS = testexternals
 
 BUILT_SOURCES = \
-  testexternals.C \
-  g4dst.C
+  testexternals.cc \
+  g4dst.cc
+
+testexternals_SOURCES = \
+  testexternals.cc
 
 testexternals_LDADD = \
   libg4dst.la
 
-testexternals.C:
+testexternals.cc:
 	echo "//*** this is a generated file. Do not commit, do not edit" > $@
 	echo "int main()" >> $@
 	echo "{" >> $@

--- a/simulation/g4simulation/g4eval/Makefile.am
+++ b/simulation/g4simulation/g4eval/Makefile.am
@@ -17,9 +17,13 @@ libg4eval_la_LDFLAGS = \
   -L$(OFFLINE_MAIN)/lib
 
 libg4eval_la_LIBADD = \
+  -lcalo_io \
   -lfun4all \
+  -lg4detectors_io \
+  -lg4jets_io \
+  -lg4vertex_io \
   -ltrackbase_historic_io \
-  -lg4dst 
+  -lphg4hit
 
 pkginclude_HEADERS = \
   BaseTruthEval.h \

--- a/simulation/g4simulation/g4mvtx/Makefile.am
+++ b/simulation/g4simulation/g4mvtx/Makefile.am
@@ -58,13 +58,13 @@ libg4mvtx_la_SOURCES = \
   PHG4MVTXDetector.cc \
   PHG4MVTXSteppingAction.cc \
   PHG4MVTXSubsystem.cc \
-  PHG4CylinderGeom_MVTX.cc \
   PHG4MVTXDigitizer.cc
 
 
 libg4mvtx_io_la_SOURCES = \
   $(ROOTDICTS) \
-  PHG4CylinderCell_MVTX.cc
+  PHG4CylinderCell_MVTX.cc \
+  PHG4CylinderGeom_MVTX.cc
 
 
 # Rule for generating table CINT dictionaries.
@@ -80,10 +80,18 @@ libg4mvtx_io_la_SOURCES = \
 BUILT_SOURCES = testexternals.cc
 
 noinst_PROGRAMS = \
-  testexternals_tracker
+  testexternals_io \
+  testexternals
 
-testexternals_tracker_SOURCES = testexternals.cc
-testexternals_tracker_LDADD = libg4mvtx.la
+testexternals_io_SOURCES = \
+  testexternals.cc
+testexternals_io_LDADD = \
+  libg4mvtx_io.la
+
+testexternals_SOURCES = \
+  testexternals.cc
+testexternals_LDADD = \
+  libg4mvtx.la
 
 testexternals.cc:
 	echo "//*** this is a generated file. Do not commit, do not edit" > $@

--- a/simulation/g4simulation/g4mvtx/PHG4CylinderGeom_MVTX.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4CylinderGeom_MVTX.cc
@@ -1,11 +1,14 @@
 #include "PHG4CylinderGeom_MVTX.h"
+
+
+#include <Math/GenVector/Translation3D.h>
+#include <Math/Rotation3D.h>
+#include <Math/Translation3D.h>
+#include <Math/Vector3D.h>
+#include <TRotation.h>
+#include <TVector3.h>
+
 #include <cmath>
-#include "Math/GenVector/Translation3D.h"
-#include "Math/Rotation3D.h"
-#include "Math/Translation3D.h"
-#include "Math/Vector3D.h"
-#include "TRotation.h"
-#include "TVector3.h"
 
 using namespace ROOT::Math;
 using namespace std;

--- a/simulation/g4simulation/g4mvtx/PHG4CylinderGeom_MVTX.h
+++ b/simulation/g4simulation/g4mvtx/PHG4CylinderGeom_MVTX.h
@@ -4,8 +4,10 @@
 #include <g4detectors/PHG4CylinderGeom.h>
 
 #include <phool/phool.h>
+
+#include <TVector3.h>
+
 #include <cmath>
-#include "TVector3.h"
 
 class PHG4CylinderGeom_MVTX : public PHG4CylinderGeom
 {


### PR DESCRIPTION
This PR updates the libraries which need loading when opening a DST. The g4mvtx package had the sources mixed, the mvtx_geo ended up in libg4mvtx rather than in libg4mvtx_io. Added test linking of both libs, not just libg4mvtx which would have picked this up