### PR TITLE
Fix library dependencies

### DIFF
--- a/offline/packages/intt/CylinderGeomINTT.cc
+++ b/offline/packages/intt/CylinderGeomINTT.cc
@@ -1,9 +1,7 @@
 #include "CylinderGeomINTT.h"
 
-#include <g4main/PHG4Detector.h>
-
-#include <Geant4/G4RotationMatrix.hh>
-#include <Geant4/G4Transform3D.hh>
+#include <CLHEP/Vector/ThreeVector.h>
+#include <CLHEP/Vector/Rotation.h>
 
 #include <cmath>
 

--- a/offline/packages/intt/Makefile.am
+++ b/offline/packages/intt/Makefile.am
@@ -10,9 +10,7 @@ lib_LTLIBRARIES = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I$(ROOTSYS)/include \
-  -I$(OPT_SPHENIX)/include \
-  -I$(G4_MAIN)/include
+  -I$(ROOTSYS)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \
@@ -48,8 +46,9 @@ libintt_la_SOURCES = \
 
 libintt_la_LIBADD = \
   libintt_io.la \
+  -lCLHEP \
   -lfun4all \
-  -lg4detectors
+  -lphg4hit
 
 # sources for io library
 libintt_io_la_SOURCES = \

--- a/offline/packages/intt/Makefile.am
+++ b/offline/packages/intt/Makefile.am
@@ -48,7 +48,6 @@ libintt_la_SOURCES = \
 
 libintt_la_LIBADD = \
   libintt_io.la \
-  -lCLHEP \
   -lfun4all \
   -lg4detectors
 
@@ -60,8 +59,9 @@ libintt_io_la_SOURCES = \
   InttHit.cc
 
 libintt_io_la_LIBADD = \
-  -lphool \
+  -lCLHEP \
   -lg4detectors_io \
+  -lphool \
   -ltrack_io \
   -ltrackbase_historic_io
 

--- a/offline/packages/jetbackground/Makefile.am
+++ b/offline/packages/jetbackground/Makefile.am
@@ -3,7 +3,6 @@ AUTOMAKE_OPTIONS = foreign
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I${G4_MAIN}/include \
   -I`root-config --incdir`
 
 lib_LTLIBRARIES = \
@@ -15,23 +14,24 @@ AM_CXXFLAGS = \
 
 AM_LDFLAGS = \
   -L$(libdir) \
-  -L$(OFFLINE_MAIN)/lib \
-  `geant4-config --libs`
+  -L$(OFFLINE_MAIN)/lib
+
+#  `geant4-config --libs`
 
 libjetbackground_io_la_LIBADD = \
   -lphool
 
 libjetbackground_la_LIBADD = \
+  libjetbackground_io.la \
   -lfun4all \
   -lcalo_io \
   -lcalo_util \
-  -lg4jets \
+  -lConstituentSubtractor \
   -lg4jets_io \
   -lCGAL \
   -lfastjet \
   -lfastjettools \
-  -lConstituentSubtractor \
-  libjetbackground_io.la
+  -lphg4hit
 
 pkginclude_HEADERS = \
   DetermineTowerBackground.h \

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -23,14 +23,8 @@ AM_LDFLAGS = \
     -L$(OFFLINE_MAIN)/lib
 
 libg4detectors_io_la_LIBADD = \
-  -L$(ROOTSYS)/lib \
-  -lCLHEP \
   -lphool \
-  -lboost_filesystem \
-  -lboost_system \
-  -lpdbcalBase \
-  -lXMLIO \
-  -lphparameter 
+  -lphparameter
 
 
 libg4detectors_la_LIBADD = \

--- a/simulation/g4simulation/g4dst/Makefile.am
+++ b/simulation/g4simulation/g4dst/Makefile.am
@@ -24,6 +24,7 @@ libg4dst_la_LDFLAGS = \
   -lphg4hit \
   -lphgeom_io \
   -lphhepmc_io \
+  -ltpc_io \
   -ltrack_reco_io \
   -ltrackbase_historic_io
 

--- a/simulation/g4simulation/g4eval/Makefile.am
+++ b/simulation/g4simulation/g4eval/Makefile.am
@@ -4,7 +4,6 @@ AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include/eigen3 \
   -I$(OFFLINE_MAIN)/include \
-  -I$(G4_MAIN)/include \
   -I`root-config --incdir`
 
 lib_LTLIBRARIES = \
@@ -18,6 +17,7 @@ libg4eval_la_LDFLAGS = \
 
 libg4eval_la_LIBADD = \
   -lcalo_io \
+  -lCLHEP \
   -lfun4all \
   -lg4detectors_io \
   -lg4jets_io \

--- a/simulation/g4simulation/g4hough/Makefile.am
+++ b/simulation/g4simulation/g4hough/Makefile.am
@@ -30,25 +30,19 @@ libg4hough_la_LDFLAGS = \
   `root-config --libs`
 
 libg4hough_la_LIBADD = \
+  libg4hough_io.la \
+  -lcalo_io \
   -lg4detectors \
-  -lfun4all \
-  -lHelixHough \
   -lFitNewton \
-  -lSeamstress \
+  -lfun4all \
   -lg4bbc_io \
-  -lcalo_io -lcalo_util \
-  -lgenfit2 \
+  -lHelixHough \
+  -lintt_io \
+  -lmvtx_io \
   -lphfield \
-  -lgenfit2exp \
   -lPHGenFit \
-  -lSpectrum \
-  -lg4tpc \
-  -lg4intt \
-  -lg4mvtx \
-  -lmvtx \
-  -lintt \
-  -ltrackbase_historic_io \
-  libg4hough_io.la
+  -lSeamstress \
+  -ltrackbase_historic_io
 
 pkginclude_HEADERS = \
   CellularAutomaton.h \

--- a/simulation/g4simulation/g4hough/Makefile.am
+++ b/simulation/g4simulation/g4hough/Makefile.am
@@ -22,8 +22,8 @@ AM_LDFLAGS = \
 libg4hough_io_la_LIBADD = \
   -lphool \
   -lg4detectors_io \
-  -lintt \
-  -lmvtx
+  -lintt_io \
+  -lmvtx_io
 
 libg4hough_la_LDFLAGS = \
   `geant4-config --libs`\

--- a/simulation/g4simulation/g4intt/Makefile.am
+++ b/simulation/g4simulation/g4intt/Makefile.am
@@ -23,26 +23,12 @@ AM_LDFLAGS = \
     -L$(OFFLINE_MAIN)/lib
 
 libg4intt_io_la_LIBADD = \
-  -L$(ROOTSYS)/lib \
-  -lCLHEP \
   -lphool \
-  -lboost_filesystem \
-  -lboost_system \
-  -lpdbcalBase \
-  -lXMLIO \
-  -lphparameter \
   -lg4detectors_io 
 
 libg4intt_la_LIBADD = \
   libg4intt_io.la \
-  -lphg4gdml \
-  -lphool  \
-  -lCGAL \
-  -lSubsysReco \
-  -lg4testbench \
   -lg4detectors \
-  -ltrackbase_historic_io \
-  -ltrack_io \
   -lintt
 
 pkginclude_HEADERS = \

--- a/simulation/g4simulation/g4jets/Makefile.am
+++ b/simulation/g4simulation/g4jets/Makefile.am
@@ -15,23 +15,23 @@ AM_CXXFLAGS = \
 
 AM_LDFLAGS = \
   -L$(libdir) \
-  -L$(OFFLINE_MAIN)/lib \
-  `geant4-config --libs`
+  -L$(OFFLINE_MAIN)/lib
 
 libg4jets_io_la_LIBADD = \
   -lphool
 
 libg4jets_la_LIBADD = \
+  libg4jets_io.la \
   -lfun4all \
   -lphg4hit \
   -lg4hough_io \
-  -lcalo_io -lcalo_util \
+  -lcalo_io \
+  -lcalo_util \
   -lg4vertex_io \
   -lCGAL \
   -lfastjet \
   -lphhepmc_io \
-  -ltrackbase_historic_io \
-  libg4jets_io.la
+  -ltrackbase_historic_io
 
 pkginclude_HEADERS = \
   Jet.h \


### PR DESCRIPTION
this PR fixes up some library dependencies. The more or less random adding of libraries is hurting us in the meantime - if your DST objects need the geant4 installation you know something is not right (or for that matter your simulation libraries need the online libs). This will probably an iterative process, this is the first step