### PR TITLE
Fix lib deps

### DIFF
--- a/offline/packages/mvtx/Makefile.am
+++ b/offline/packages/mvtx/Makefile.am
@@ -10,9 +10,7 @@ lib_LTLIBRARIES = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I$(ROOTSYS)/include \
-  -I$(OPT_SPHENIX)/include \
-  -I$(G4_MAIN)/include
+  -I$(ROOTSYS)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \
@@ -50,7 +48,7 @@ libmvtx_la_LIBADD = \
   libmvtx_io.la \
   -lCLHEP \
   -lfun4all \
-  -lg4detectors
+  -lphg4hit
 
 # sources for io library
 libmvtx_io_la_SOURCES = \

--- a/offline/packages/tpc/Makefile.am
+++ b/offline/packages/tpc/Makefile.am
@@ -44,9 +44,7 @@ libtpc_la_SOURCES = \
 libtpc_la_LIBADD = \
   libtpc_io.la \
   -lfun4all \
-  -lg4detectors \
   -lSpectrum
-
 
 # sources for io library
 libtpc_io_la_SOURCES = \

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -9,13 +9,11 @@ lib_LTLIBRARIES = \
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include  \
-  -I$(ROOTSYS)/include \
-  -I$(OPT_SPHENIX)/include
+  -I$(OFFLINE_MAIN)/include \
+  -I$(ROOTSYS)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \
-  -L$(ROOTSYS)/lib \
   -L$(OFFLINE_MAIN)/lib
 
 pkginclude_HEADERS = \
@@ -77,10 +75,6 @@ libtrack_io_la_SOURCES = \
   TrkrHit.cc \
   TrkrHitSet.cc \
   TrkrHitSetContainer.cc
-
-libtrack_io_la_LDFLAGS = \
-  -L$(libdir) \
-  -L$(OFFLINE_MAIN)/lib
 
 libtrack_io_la_LIBADD = \
   -lphool

--- a/simulation/g4simulation/g4intt/Makefile.am
+++ b/simulation/g4simulation/g4intt/Makefile.am
@@ -6,12 +6,10 @@ lib_LTLIBRARIES = \
     libg4intt.la
 
 AM_CPPFLAGS = \
-    -DCGAL_DISABLE_ROUNDING_MATH_CHECK \
     -I$(includedir) \
     -I$(OFFLINE_MAIN)/include \
     -I$(ROOTSYS)/include \
-    -I$(G4_MAIN)/include \
-    -I$(OPT_SPHENIX)/include
+    -I$(G4_MAIN)/include
 
 # set in configure.in to check if gcc version >= 4.8
 #if GCC_GE_48
@@ -29,7 +27,7 @@ libg4intt_io_la_LIBADD = \
 libg4intt_la_LIBADD = \
   libg4intt_io.la \
   -lg4detectors \
-  -lintt
+  -lintt_io
 
 pkginclude_HEADERS = \
   PHG4INTTHitReco.h \

--- a/simulation/g4simulation/g4mvtx/Makefile.am
+++ b/simulation/g4simulation/g4mvtx/Makefile.am
@@ -7,16 +7,15 @@ lib_LTLIBRARIES = \
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(G4_MAIN)/include \
   -I$(OFFLINE_MAIN)/include  \
   -I$(ROOTSYS)/include \
-  -I$(OPT_SPHENIX)/include
+  -I$(G4_MAIN)/include
 
 
 AM_LDFLAGS = \
   -L$(libdir) \
-  -L$(ROOTSYS)/lib \
-  -L$(OFFLINE_MAIN)/lib
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(ROOTSYS)/lib
 
 libg4mvtx_io_la_LIBADD = \
   -lg4detectors_io 
@@ -24,13 +23,10 @@ libg4mvtx_io_la_LIBADD = \
 libg4mvtx_la_LIBADD = \
   libg4mvtx_io.la \
   -lfun4all \
-  -lphool \
-  -lg4testbench \
   -lphg4hit \
   -lg4detectors \
-  -ltrackbase_historic_io \
   -ltrack_io \
-  -lmvtx
+  -lmvtx_io
 
 pkginclude_HEADERS = \
   PHG4MVTXHitReco.h \
@@ -57,8 +53,8 @@ else
 endif
 
 libg4mvtx_la_SOURCES = \
-  PHG4MVTXHitReco.cc \
   $(ROOT5_DICTS) \
+  PHG4MVTXHitReco.cc \
   PHG4MVTXCellReco.cc \
   PHG4MVTXDetector.cc \
   PHG4MVTXSteppingAction.cc \

--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -8,8 +8,7 @@ AM_CPPFLAGS = \
     -I$(includedir) \
     -I$(OFFLINE_MAIN)/include \
     -I$(G4_MAIN)/include \
-    -I$(ROOTSYS)/include \
-    -I$(OPT_SPHENIX)/include
+    -I$(ROOTSYS)/include
 
 AM_LDFLAGS = \
     -L$(libdir) \
@@ -18,13 +17,14 @@ AM_LDFLAGS = \
 libg4tpc_la_LIBADD = \
   libg4tpc_io.la \
   -lphool \
-  -lg4testbench \
-  -lphg4hit \
   -lg4detectors \
+  -lphg4hit \
   -lphparameter \
-  -ltrackbase_historic_io \
-  -ltrack_io \
-  -ltpc
+  -ltpc_io
+
+libg4tpc_io_la_LIBADD = \
+  -lphool \
+  -lg4detectors_io
 
 pkginclude_HEADERS = \
   PHG4CellTPCv1.h \
@@ -88,9 +88,14 @@ libg4tpc_io_la_SOURCES = \
 # linking tests
 
 noinst_PROGRAMS = \
-  testexternals
+  testexternals \
+  testexternals_io
+
 
 BUILT_SOURCES = testexternals.cc
+
+testexternals_io_SOURCES = testexternals.cc
+testexternals_io_LDADD = libg4tpc_io.la
 
 testexternals_SOURCES = testexternals.cc
 testexternals_LDADD = libg4tpc.la


### PR DESCRIPTION
This PR reduces the lib dependencies of the new tracking even more. This should get rid of G4 propagating into our reconstruction libraries