### PR TITLE
Fix makefiles

### DIFF
--- a/offline/framework/frog/Makefile.am
+++ b/offline/framework/frog/Makefile.am
@@ -8,22 +8,20 @@ AM_CPPFLAGS = \
 
 lib_LTLIBRARIES = libFROG.la
 
-libFROG_la_LDFLAGS = \
-  `root-config --libs`
-
 libFROG_la_LIBADD = \
-  -L$(libdir) \
   -L$(OPT_SPHENIX)/lib \
   -lodbc++
 
 noinst_HEADERS = FROGLinkDef.h
 
-pkginclude_HEADERS =    \
+pkginclude_HEADERS = \
   FROG.h
 
 if ! MAKEROOT6
 ROOT5DICTS = \
   FROG_Dict.cc
+libFROG_la_LDFLAGS = \
+  `root-config --libs`
 endif
 
 libFROG_la_SOURCES = \

--- a/offline/framework/fun4all/Makefile.am
+++ b/offline/framework/fun4all/Makefile.am
@@ -93,7 +93,8 @@ libfun4all_la_LIBADD = \
   -lEvent \
   -lFROG \
   -lffaobjects \
-  -lphool
+  -lphool \
+  -lphool_raw
 
 libSubsysReco_la_SOURCES = \
   $(ROOT5_SUBSYSRECODICTS) \

--- a/offline/framework/fun4all/Makefile.am
+++ b/offline/framework/fun4all/Makefile.am
@@ -6,6 +6,10 @@ AM_CPPFLAGS = \
   -I$(ROOTSYS)/include \
   -I$(OPT_SPHENIX)/include
 
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib
+
 if ! MAKEROOT6
 ROOT5_SUBSYSRECODICTS = \
   Fun4AllBase_Dict.cc \
@@ -58,6 +62,9 @@ lib_LTLIBRARIES = \
 libTDirectoryHelper_la_SOURCES = \
   TDirectoryHelper.cc
 
+libTDirectoryHelper_la_LDFLAGS = \
+    `root-config --libs`
+
 libfun4all_la_SOURCES = \
   $(ROOT5_FUN4ALLDICTS) \
   Fun4AllDstInputManager.cc \
@@ -80,8 +87,6 @@ libfun4all_la_SOURCES = \
   PHTFileServer.cc
 
 libfun4all_la_LIBADD = \
-  -L$(libdir) \
-  -L$(OFFLINE_MAIN)/lib \
   libSubsysReco.la \
   libTDirectoryHelper.la \
   -lboost_filesystem \
@@ -105,13 +110,17 @@ BUILT_SOURCES = testexternals.cc
 
 noinst_PROGRAMS = \
   testexternals_fun4all \
-  testexternals_subsysreco
+  testexternals_subsysreco \
+  testexternals_tdirectoryhelper
 
 testexternals_fun4all_SOURCES = testexternals.cc
 testexternals_fun4all_LDADD   = libfun4all.la
 
 testexternals_subsysreco_SOURCES = testexternals.cc
 testexternals_subsysreco_LDADD   = libSubsysReco.la
+
+testexternals_tdirectoryhelper_SOURCES = testexternals.cc
+testexternals_tdirectoryhelper_LDADD = libTDirectoryHelper.la
 
 testexternals.cc:
 	echo "//*** this is a generated file. Do not commit, do not edit" > $@

--- a/offline/framework/phool/Makefile.am
+++ b/offline/framework/phool/Makefile.am
@@ -1,16 +1,26 @@
 AUTOMAKE_OPTIONS = foreign
 
-lib_LTLIBRARIES = libphool.la
+lib_LTLIBRARIES = \
+  libphool.la \
+  libphool_raw.la
+
 
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
   -I`root-config --incdir`
 
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib
+
 libphool_la_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  `root-config --libs` \
+  `root-config --libs`
+
+libphool_raw_la_LIBADD = \
+  libphool.la \
   -lEvent
 
 ROOTDICTS = \
@@ -47,11 +57,14 @@ libphool_la_SOURCES = \
   PHObject.cc \
   PHOperation.cc \
   PHRandomSeed.cc \
-  PHRawOManager.cc \
   PHTimer.cc \
   PHTimeServer.cc \
   PHTimeStamp.cc \
   recoConsts.cc
+
+libphool_raw_la_SOURCES = \
+  PHRawDataNode.cc \
+  PHRawOManager.cc
 
 pkginclude_HEADERS =  \
   getClass.h \
@@ -81,16 +94,21 @@ pkginclude_HEADERS =  \
   PHTypedNodeIterator.h \
   recoConsts.h
 
-noinst_PROGRAMS = \
-  testexternals
-
 BUILT_SOURCES = \
   testexternals.cc
 
-testexternals_SOURCES = testexternals.cc
+noinst_PROGRAMS = \
+  testexternals \
+  testexternals_raw
 
+
+testexternals_SOURCES = testexternals.cc
 testexternals_LDADD = \
   libphool.la
+
+testexternals_raw_SOURCES = testexternals.cc
+testexternals_raw_LDADD = \
+  libphool_raw.la
 
 testexternals.cc:
 	echo "//*** this is a generated file. Do not commit, do not edit" > $@

--- a/offline/framework/phool/PHRawDataNode.cc
+++ b/offline/framework/phool/PHRawDataNode.cc
@@ -2,23 +2,10 @@
 //  Author: Matthias Messer
 
 #include "PHRawDataNode.h"
+
 #include "PHRawOManager.h"
 
-PHRawDataNode::PHRawDataNode()
-  : length(0)
-  , ID(0)
-  , wordLength(0)
-  , hitFormat(0)
-{
-}
-
-PHRawDataNode::~PHRawDataNode()
-{
-  // set the data poitner to 0 so
-  // the dtor of the PHDataNode parent class doesn't try
-  // to delete it
-  setData(nullptr);
-}
+using namespace std;
 
 PHRawDataNode::PHRawDataNode(PHDWORD* d, const string& n,
                              const int l, const int i, const int w, const int h)
@@ -28,6 +15,14 @@ PHRawDataNode::PHRawDataNode(PHDWORD* d, const string& n,
   , wordLength(w)
   , hitFormat(h)
 {
+}
+
+PHRawDataNode::~PHRawDataNode()
+{
+  // set the data poitner to 0 so
+  // the dtor of the PHDataNode parent class doesn't try
+  // to delete it
+  setData(nullptr);
 }
 
 bool PHRawDataNode::write(PHIOManager* IOManager, const string&)

--- a/offline/framework/phool/PHRawDataNode.h
+++ b/offline/framework/phool/PHRawDataNode.h
@@ -14,7 +14,6 @@
 class PHRawDataNode : public PHDataNode<PHDWORD>
 {
  public:
-  PHRawDataNode();
   PHRawDataNode(PHDWORD *, const std::string &, const int, const int, const int, const int);
   virtual ~PHRawDataNode();
 
@@ -31,6 +30,7 @@ class PHRawDataNode : public PHDataNode<PHDWORD>
   void setHitFormat(const int val) { hitFormat = val; }
 
  private:
+  PHRawDataNode() = delete;
   int length;
   int ID;
   int wordLength;

--- a/offline/packages/NodeDump/Makefile.am
+++ b/offline/packages/NodeDump/Makefile.am
@@ -60,10 +60,10 @@ libphnodedump_la_LIBADD = \
   -lffaobjects \
   -lg4detectors_io \
   -lg4hough_io \
-  -ltrackbase_historic_io \
   -lg4jets_io \
-  -lg4testbench \
   -lphg4hit \
+  -lSubsysReco \
+  -ltrackbase_historic_io \
   -lvararray
 
 

--- a/offline/packages/PHGeometry/Makefile.am
+++ b/offline/packages/PHGeometry/Makefile.am
@@ -3,21 +3,17 @@ AUTOMAKE_OPTIONS = foreign
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include \
-  -I$(OPT_SPHENIX)/include \
-  -I`root-config --incdir`
+  -I$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \
    libphgeom_io.la \
    libphgeom.la
 
 pkginclude_HEADERS = \
-  PHGeomTGeo.h \
+  PHGeomFileImport.h \
   PHGeomIOTGeo.h \
+  PHGeomTGeo.h \
   PHGeomUtility.h
-
-noinst_HEADERS = \
-  PHGeomFileImport.h
 
 ROOTDICTS = \
   PHGeomIOTGeo_Dict.cc
@@ -49,8 +45,8 @@ AM_LDFLAGS = \
   -L$(ROOTSYS)/lib
 
 libphgeom_la_LIBADD = \
-  -lSubsysReco \
-  libphgeom_io.la
+  libphgeom_io.la \
+  -lSubsysReco
 
 libphgeom_io_la_LIBADD = \
   -lphool \

--- a/offline/packages/intt/Makefile.am
+++ b/offline/packages/intt/Makefile.am
@@ -47,8 +47,8 @@ libintt_la_SOURCES = \
 libintt_la_LIBADD = \
   libintt_io.la \
   -lCLHEP \
-  -lfun4all \
-  -lphg4hit
+  -lphg4hit \
+  -lSubsysReco
 
 # sources for io library
 libintt_io_la_SOURCES = \

--- a/offline/packages/jetbackground/Makefile.am
+++ b/offline/packages/jetbackground/Makefile.am
@@ -16,14 +16,11 @@ AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib
 
-#  `geant4-config --libs`
-
 libjetbackground_io_la_LIBADD = \
   -lphool
 
 libjetbackground_la_LIBADD = \
   libjetbackground_io.la \
-  -lfun4all \
   -lcalo_io \
   -lcalo_util \
   -lConstituentSubtractor \
@@ -31,7 +28,8 @@ libjetbackground_la_LIBADD = \
   -lCGAL \
   -lfastjet \
   -lfastjettools \
-  -lphg4hit
+  -lphg4hit \
+  -lSubsysReco
 
 pkginclude_HEADERS = \
   DetermineTowerBackground.h \

--- a/offline/packages/mvtx/Makefile.am
+++ b/offline/packages/mvtx/Makefile.am
@@ -47,8 +47,8 @@ libmvtx_la_SOURCES = \
 libmvtx_la_LIBADD = \
   libmvtx_io.la \
   -lCLHEP \
-  -lfun4all \
-  -lphg4hit
+  -lphg4hit \
+  -lSubsysReco
 
 # sources for io library
 libmvtx_io_la_SOURCES = \

--- a/offline/packages/trigger/Makefile.am
+++ b/offline/packages/trigger/Makefile.am
@@ -21,8 +21,8 @@ libcalotrigger_io_la_LIBADD = \
 
 libcalotrigger_la_LIBADD = \
   libcalotrigger_io.la \
-  -lfun4all \
-  -lcalo_io
+  -lcalo_io \
+  -lSubsysReco
 
 pkginclude_HEADERS = \
   CaloTriggerSim.h \


### PR DESCRIPTION
This PR cleans up our libs and Makefiles a bit more. It is rarely necessary to need libfun4all, for most subsysreco modules a dependency on libSubsysReco is enough. Started to split off event libraries, we now have a libphool_raw which contains sources dependent on event libs (we do not make use of them right now, it is the raw data write which in principal can be used to write prdf files)