### PR TITLE
TrkrHitSetContainer::Reset() did not properly free memory allocated t…

### DIFF
--- a/offline/packages/trackbase/TrkrHitSet.cc
+++ b/offline/packages/trackbase/TrkrHitSet.cc
@@ -55,6 +55,27 @@ void TrkrHitSet::identify(std::ostream& os) const
   }
 }
 
+
+void TrkrHitSet::removeHit(TrkrDefs::hitkey key)
+{
+
+  TrkrHitSet::ConstIterator it = m_hits.find(key);
+
+  if (it != m_hits.end())
+  {
+    delete it->second;
+    m_hits.erase(key);
+  }
+  else
+  {
+    identify();
+    std::cout << "TrkrHitSet::removeHit: deleting a nonexist key: " << key << " exiting now" << std::endl;
+    exit(1);
+  }
+}
+
+
+
 TrkrHitSet::ConstIterator
 TrkrHitSet::addHitSpecificKey(const TrkrDefs::hitkey key, TrkrHit* hit)
 {

--- a/offline/packages/trackbase/TrkrHitSet.h
+++ b/offline/packages/trackbase/TrkrHitSet.h
@@ -67,10 +67,7 @@ class TrkrHitSet : public TObject
    * @brief Remove a hit using its key
    * @param[in] key to be removed
    */
-  void removeHit(TrkrDefs::hitkey key)
-  {
-    m_hits.erase(key);
-  }
+  void removeHit(TrkrDefs::hitkey key);
 
   /**
    * @brief Get a specific hit based on its index.

--- a/offline/packages/trackbase/TrkrHitSet.h
+++ b/offline/packages/trackbase/TrkrHitSet.h
@@ -35,7 +35,7 @@ class TrkrHitSet : public TObject
   //! ctor
   TrkrHitSet();
   //! dtor
-  ~TrkrHitSet();
+  virtual ~TrkrHitSet();
   //! TObject functions
   void identify(std::ostream& os = std::cout) const;
   void Reset();

--- a/offline/packages/trackbase/TrkrHitSetContainer.cc
+++ b/offline/packages/trackbase/TrkrHitSetContainer.cc
@@ -15,11 +15,16 @@ TrkrHitSetContainer::TrkrHitSetContainer()
 {
 }
 
+TrkrHitSetContainer::~TrkrHitSetContainer()
+{
+  Reset();
+}
+
 void TrkrHitSetContainer::Reset()
 {
   while (m_hitmap.begin() != m_hitmap.end())
   {
-    delete m_hitmap.begin()->second;
+    m_hitmap.begin()->second->Reset();    // frees up memory for TrkrHit objects
     m_hitmap.erase(m_hitmap.begin());
   }
   return;

--- a/offline/packages/trackbase/TrkrHitSetContainer.cc
+++ b/offline/packages/trackbase/TrkrHitSetContainer.cc
@@ -24,7 +24,7 @@ void TrkrHitSetContainer::Reset()
 {
   while (m_hitmap.begin() != m_hitmap.end())
   {
-    m_hitmap.begin()->second->Reset();    // frees up memory for TrkrHit objects
+    delete m_hitmap.begin()->second;   // frees up memory for TrkrHit objects
     m_hitmap.erase(m_hitmap.begin());
   }
   return;

--- a/offline/packages/trackbase/TrkrHitSetContainer.h
+++ b/offline/packages/trackbase/TrkrHitSetContainer.h
@@ -24,7 +24,7 @@ class TrkrHitSetContainer : public PHObject
   TrkrHitSetContainer();
 
   //! dtor
-  ~TrkrHitSetContainer();
+  virtual ~TrkrHitSetContainer();
   //! PHObject functions
   void Reset();
   void identify(std::ostream &os = std::cout) const;

--- a/offline/packages/trackbase/TrkrHitSetContainer.h
+++ b/offline/packages/trackbase/TrkrHitSetContainer.h
@@ -24,7 +24,7 @@ class TrkrHitSetContainer : public PHObject
   TrkrHitSetContainer();
 
   //! dtor
-  virtual ~TrkrHitSetContainer() {}
+  ~TrkrHitSetContainer();
   //! PHObject functions
   void Reset();
   void identify(std::ostream &os = std::cout) const;

--- a/offline/packages/trackbase_historic/SvtxVertexMap.h
+++ b/offline/packages/trackbase_historic/SvtxVertexMap.h
@@ -33,7 +33,7 @@ class SvtxVertexMap : public PHObject
   virtual SvtxVertex* get(unsigned int idkey) { return NULL; }
 
   //! Add vertex to container. Note the container take to ownership
-  virtual SvtxVertex* insert(const SvtxVertex* cluster) { return NULL; }
+  virtual SvtxVertex* insert(SvtxVertex* cluster) { return NULL; }
   //! legacy interface. Add vertex to container. Note the container does not take ownership
   virtual SvtxVertex* insert_clone(const SvtxVertex* vertex) { return NULL; }
 

--- a/offline/packages/trackbase_historic/SvtxVertexMap.h
+++ b/offline/packages/trackbase_historic/SvtxVertexMap.h
@@ -31,7 +31,12 @@ class SvtxVertexMap : public PHObject
 
   virtual const SvtxVertex* get(unsigned int idkey) const { return NULL; }
   virtual SvtxVertex* get(unsigned int idkey) { return NULL; }
+
+  //! Add vertex to container. Note the container take to ownership
   virtual SvtxVertex* insert(const SvtxVertex* cluster) { return NULL; }
+  //! legacy interface. Add vertex to container. Note the container does not take ownership
+  virtual SvtxVertex* insert_clone(const SvtxVertex* vertex) { return NULL; }
+
   virtual size_t erase(unsigned int idkey) { return 0; }
 
   virtual ConstIter begin() const { return VertexMap().end(); }

--- a/offline/packages/trackbase_historic/SvtxVertexMap_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxVertexMap_v1.cc
@@ -71,7 +71,7 @@ SvtxVertex* SvtxVertexMap_v1::get(unsigned int id)
   return iter->second;
 }
 
-SvtxVertex* SvtxVertexMap_v1::insert(const SvtxVertex* vertex)
+SvtxVertex* SvtxVertexMap_v1::insert(SvtxVertex* vertex)
 {
   unsigned int index = 0;
   if (!_map.empty()) index = _map.rbegin()->first + 1;

--- a/offline/packages/trackbase_historic/SvtxVertexMap_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxVertexMap_v1.cc
@@ -75,7 +75,12 @@ SvtxVertex* SvtxVertexMap_v1::insert(const SvtxVertex* vertex)
 {
   unsigned int index = 0;
   if (!_map.empty()) index = _map.rbegin()->first + 1;
-  _map.insert(make_pair(index, vertex->Clone()));
+  _map.insert(make_pair(index, vertex));
   _map[index]->set_id(index);
   return _map[index];
+}
+
+SvtxVertex* SvtxVertexMap_v1::insert_clone(const SvtxVertex* vertex)
+{
+  return insert(vertex->Clone());
 }

--- a/offline/packages/trackbase_historic/SvtxVertexMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxVertexMap_v1.h
@@ -30,7 +30,7 @@ class SvtxVertexMap_v1 : public SvtxVertexMap
   SvtxVertex* get(unsigned int idkey);
 
   //! Add vertex to container. Note the container takes ownership
-  SvtxVertex* insert(const SvtxVertex* vertex);
+  SvtxVertex* insert(SvtxVertex* vertex);
   //! legacy interface. Add vertex to container. Note the container does not take ownership
   SvtxVertex* insert_clone(const SvtxVertex* vertex);
   size_t erase(unsigned int idkey)

--- a/offline/packages/trackbase_historic/SvtxVertexMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxVertexMap_v1.h
@@ -28,7 +28,11 @@ class SvtxVertexMap_v1 : public SvtxVertexMap
 
   const SvtxVertex* get(unsigned int idkey) const;
   SvtxVertex* get(unsigned int idkey);
+
+  //! Add vertex to container. Note the container takes ownership
   SvtxVertex* insert(const SvtxVertex* vertex);
+  //! legacy interface. Add vertex to container. Note the container does not take ownership
+  SvtxVertex* insert_clone(const SvtxVertex* vertex);
   size_t erase(unsigned int idkey)
   {
     delete _map[idkey];

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -1650,7 +1650,7 @@ bool PHGenFitTrkFitter::FillSvtxVertexMap(
     {
       if (_vertexmap)
       {
-        _vertexmap->insert(svtx_vtx.get());
+        _vertexmap->insert_clone(svtx_vtx.get());
       }
       else
       {
@@ -1661,7 +1661,7 @@ bool PHGenFitTrkFitter::FillSvtxVertexMap(
     {
       if (_vertexmap_refit)
       {
-        _vertexmap_refit->insert(svtx_vtx.get());
+        _vertexmap_refit->insert_clone(svtx_vtx.get());
       }
       else
       {

--- a/offline/packages/trackreco/PHHoughAllInOne.cc
+++ b/offline/packages/trackreco/PHHoughAllInOne.cc
@@ -1969,7 +1969,7 @@ int PHHoughAllInOne::export_output()
     }
   }  // track loop
 
-  SvtxVertex* vtxptr = _vertex_map->insert(&vertex);
+  SvtxVertex* vtxptr = _vertex_map->insert_clone(&vertex);
   if (Verbosity() > 5)
     vtxptr->identify();
 

--- a/offline/packages/trackreco/PHHoughSeeding.cc
+++ b/offline/packages/trackreco/PHHoughSeeding.cc
@@ -1715,7 +1715,7 @@ int PHHoughSeeding::export_output()
     }
 #endif
 
-  SvtxVertex* vtxptr = _vertex_map->insert(&vertex);
+  SvtxVertex* vtxptr = _vertex_map->insert_clone(&vertex);
   if (Verbosity() > 5)
     vtxptr->identify();
 

--- a/offline/packages/trackreco/PHRaveVertexing.cc
+++ b/offline/packages/trackreco/PHRaveVertexing.cc
@@ -395,7 +395,7 @@ bool PHRaveVertexing::FillSvtxVertexMap(
     {
       if (_vertexmap)
       {
-        _vertexmap->insert(svtx_vtx.get());
+        _vertexmap->insert_clone(svtx_vtx.get());
       }
       else
       {
@@ -406,7 +406,7 @@ bool PHRaveVertexing::FillSvtxVertexMap(
     {
       if (_vertexmap_refit)
       {
-        _vertexmap_refit->insert(svtx_vtx.get());
+        _vertexmap_refit->insert_clone(svtx_vtx.get());
       }
       else
       {

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -549,10 +549,10 @@ float SvtxClusterEval::get_energy_contribution(TrkrDefs::cluskey cluster_key, PH
 
   if (_strict)
   {
-    assert(cluster_key);
+//    assert(cluster_key);
     assert(g4hit);
   }
-  else if (!cluster_key || !g4hit)
+  else if ( !g4hit)
   {
     ++_errors;
     return NAN;

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -90,15 +90,15 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(TrkrDefs::cluskey cluster_key
       return std::set<PHG4Hit*>();
     }
   
-  if (_strict)
-    {
-      assert(cluster_key);
-    }
-  else if (!cluster_key)
-    {
-      ++_errors;
-      return std::set<PHG4Hit*>();
-    }
+//  if (_strict)
+//    {
+//      assert(cluster_key);
+//    }
+//  else if (!cluster_key)
+//    {
+//      ++_errors;
+//      return std::set<PHG4Hit*>();
+//    }
   
   if (_do_cache)
     {
@@ -154,15 +154,15 @@ PHG4Hit* SvtxClusterEval::max_truth_hit_by_energy(TrkrDefs::cluskey cluster_key)
       return nullptr;
     }
   
-  if (_strict)
-    {
-      assert(cluster_key);
-    }
-  else if (!cluster_key)
-    {
-      ++_errors;
-      return nullptr;
-    }
+//  if (_strict)
+//    {
+//      assert(cluster_key);
+//    }
+//  else if (!cluster_key)
+//    {
+//      ++_errors;
+//      return nullptr;
+//    }
   
   if (_do_cache)
     {
@@ -202,15 +202,15 @@ std::set<PHG4Particle*> SvtxClusterEval::all_truth_particles(TrkrDefs::cluskey c
       return std::set<PHG4Particle*>();
     }
   
-  if (_strict)
-    {
-      assert(cluster_key);
-    }
-  else if (!cluster_key)
-    {
-      ++_errors;
-      return std::set<PHG4Particle*>();
-    }
+//  if (_strict)
+//    {
+//      assert(cluster_key);
+//    }
+//  else if (!cluster_key)
+//    {
+//      ++_errors;
+//      return std::set<PHG4Particle*>();
+//    }
   
   if (_do_cache)
     {
@@ -259,15 +259,15 @@ PHG4Particle* SvtxClusterEval::max_truth_particle_by_energy(TrkrDefs::cluskey cl
       return nullptr;
     }
   
-  if (_strict)
-    {
-      assert(cluster_key);
-    }
-  else if (!cluster_key)
-    {
-      ++_errors;
-      return nullptr;
-    }
+//  if (_strict)
+//    {
+//      assert(cluster_key);
+//    }
+//  else if (!cluster_key)
+//    {
+//      ++_errors;
+//      return nullptr;
+//    }
   
   if (_do_cache)
     {
@@ -502,10 +502,10 @@ float SvtxClusterEval::get_energy_contribution(TrkrDefs::cluskey cluster_key, PH
 
   if (_strict)
   {
-    assert(cluster_key);
+//    assert(cluster_key);
     assert(particle);
   }
-  else if (!cluster_key || !particle)
+  else if ( !particle)
   {
     ++_errors;
     return NAN;

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -105,15 +105,15 @@ std::set<PHG4Hit*> SvtxTrackEval::all_truth_hits(SvtxTrack* track)
   {
     TrkrDefs::cluskey cluster_key = *iter;
 
-    if (_strict)
-    {
-      assert(cluster_key);
-    }
-    else if (!cluster_key)
-    {
-      ++_errors;
-      continue;
-    }
+//    if (_strict)
+//    {
+//      assert(cluster_key);
+//    }
+//    else if (!cluster_key)
+//    {
+//      ++_errors;
+//      continue;
+//    }
 
     std::set<PHG4Hit*> new_hits = _clustereval.all_truth_hits(cluster_key);
 
@@ -163,15 +163,15 @@ std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track)
   {
     TrkrDefs::cluskey cluster_key = *iter;
 
-    if (_strict)
-    {
-      assert(cluster_key);
-    }
-    else if (!cluster_key)
-    {
-      ++_errors;
-      continue;
-    }
+//    if (_strict)
+//    {
+//      assert(cluster_key);
+//    }
+//    else if (!cluster_key)
+//    {
+//      ++_errors;
+//      continue;
+//    }
 
     std::set<PHG4Particle*> new_particles = _clustereval.all_truth_particles(cluster_key);
 
@@ -348,15 +348,15 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Hit* truthhit)
     {
       TrkrDefs::cluskey cluster_key = *iter;
 
-      if (_strict)
-      {
-        assert(cluster_key);
-      }
-      else if (!cluster_key)
-      {
-        ++_errors;
-        continue;
-      }
+//      if (_strict)
+//      {
+//        assert(cluster_key);
+//      }
+//      else if (!cluster_key)
+//      {
+//        ++_errors;
+//        continue;
+//      }
 
       // loop over all hits
       std::set<PHG4Hit*> hits = _clustereval.all_truth_hits(cluster_key);
@@ -450,15 +450,15 @@ void SvtxTrackEval::create_cache_track_from_cluster()
     {
       TrkrDefs::cluskey candidate_key = *iter;
 
-      if (_strict)
-      {
-        assert(candidate_key);
-      }
-      else if (!candidate_key)
-      {
-        ++_errors;
-        continue;
-      }
+//      if (_strict)
+//      {
+//        assert(candidate_key);
+//      }
+//      else if (!candidate_key)
+//      {
+//        ++_errors;
+//        continue;
+//      }
 
       //check if cluster has an entry in cache
       std::map<TrkrDefs::cluskey, std::set<SvtxTrack*> >::iterator cliter =
@@ -488,15 +488,15 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(TrkrDefs::cluskey cluster_ke
     return std::set<SvtxTrack*>();
   }
 
-  if (_strict)
-  {
-    assert(cluster_key);
-  }
-  else if (!cluster_key)
-  {
-    ++_errors;
-    return std::set<SvtxTrack*>();
-  }
+//  if (_strict)
+//  {
+//    assert(cluster_key);
+//  }
+//  else if (!cluster_key)
+//  {
+//    ++_errors;
+//    return std::set<SvtxTrack*>();
+//  }
 
   std::set<SvtxTrack*> tracks;
 
@@ -529,15 +529,15 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(TrkrDefs::cluskey cluster_ke
     {
       TrkrDefs::cluskey candidate = *iter;
 
-      if (_strict)
-      {
-        assert(candidate);
-      }
-      else if (!candidate)
-      {
-        ++_errors;
-        continue;
-      }
+//      if (_strict)
+//      {
+//        assert(candidate);
+//      }
+//      else if (!candidate)
+//      {
+//        ++_errors;
+//        continue;
+//      }
 
       if (cluster_key == candidate)
       {
@@ -559,15 +559,15 @@ SvtxTrack* SvtxTrackEval::best_track_from(TrkrDefs::cluskey cluster_key)
     return nullptr;
   }
 
-  if (_strict)
-  {
-    assert(cluster_key);
-  }
-  else if (!cluster_key)
-  {
-    ++_errors;
-    return nullptr;
-  }
+//  if (_strict)
+//  {
+//    assert(cluster_key);
+//  }
+//  else if (!cluster_key)
+//  {
+//    ++_errors;
+//    return nullptr;
+//  }
 
   if (_do_cache)
   {
@@ -704,15 +704,15 @@ void SvtxTrackEval::calc_cluster_contribution(SvtxTrack* track, PHG4Particle* pa
   {
     TrkrDefs::cluskey cluster_key = *iter;
 
-    if (_strict)
-    {
-      assert(cluster_key);
-    }
-    else if (!cluster_key)
-    {
-      ++_errors;
-      continue;
-    }
+//    if (_strict)
+//    {
+//      assert(cluster_key);
+//    }
+//    else if (!cluster_key)
+//    {
+//      ++_errors;
+//      continue;
+//    }
     int matched = 0;
     // loop over all particles
     std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster_key);
@@ -775,15 +775,15 @@ unsigned int SvtxTrackEval::get_nclusters_contribution_by_layer(SvtxTrack* track
     TrkrDefs::cluskey cluster_key = *iter;
     unsigned int cluster_layer = TrkrDefs::getLayer(cluster_key);
 
-    if (_strict)
-    {
-      assert(cluster_key);
-    }
-    else if (!cluster_key)
-    {
-      ++_errors;
-      continue;
-    }
+//    if (_strict)
+//    {
+//      assert(cluster_key);
+//    }
+//    else if (!cluster_key)
+//    {
+//      ++_errors;
+//      continue;
+//    }
 
     // loop over all particles
     std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster_key);
@@ -841,15 +841,15 @@ unsigned int SvtxTrackEval::get_layer_range_contribution(SvtxTrack* track, PHG4P
     if (cluster_layer >= end_layer) continue;
     if (cluster_layer < start_layer) continue;
 
-    if (_strict)
-    {
-      assert(cluster_key);
-    }
-    else if (!cluster_key)
-    {
-      ++_errors;
-      continue;
-    }
+//    if (_strict)
+//    {
+//      assert(cluster_key);
+//    }
+//    else if (!cluster_key)
+//    {
+//      ++_errors;
+//      continue;
+//    }
 
     // loop over all particles
     std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster_key);

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -273,15 +273,16 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
     {
       TrkrDefs::cluskey cluster_key = *iter;
 
-      if (_strict)
-      {
-        assert(cluster_key);
-      }
-      else if (!cluster_key)
-      {
-        ++_errors;
-        continue;
-      }
+      // remove this check as cluster key = 0 is MVTX layer 0 cluster #0.
+//      if (_strict)
+//      {
+//        assert(cluster_key);
+//      }
+//      else if (!cluster_key)
+//      {
+//        ++_errors;
+//        continue;
+//      }
 
       // loop over all particles
       std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster_key);

--- a/simulation/g4simulation/g4hough/PHG4HoughTransform.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransform.C
@@ -1352,7 +1352,7 @@ int PHG4HoughTransform::export_output() {
     }
   }  // track loop
 
-  SvtxVertex *vtxptr = _g4vertexes->insert(&vertex);
+  SvtxVertex *vtxptr = _g4vertexes->insert_clone(&vertex);
   if (Verbosity() > 5) vtxptr->identify();
 
   if (Verbosity() > 0) {

--- a/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
+++ b/simulation/g4simulation/g4hough/PHG4HoughTransformTPC.C
@@ -1373,7 +1373,7 @@ int PHG4HoughTransformTPC::export_output() {
     }
   }  // track loop
 
-  SvtxVertex *vtxptr = _g4vertexes->insert(&vertex);
+  SvtxVertex *vtxptr = _g4vertexes->insert_clone(&vertex);
   if (Verbosity() > 5) vtxptr->identify();
 
   if (Verbosity() > 0) {

--- a/simulation/g4simulation/g4hough/PHG4InitZVertexing.C
+++ b/simulation/g4simulation/g4hough/PHG4InitZVertexing.C
@@ -938,7 +938,7 @@ int PHG4InitZVertexing::export_output(){
 
 //	cout<<"track loop"<<endl;
 	for (unsigned int vid = 0; vid < _vertex_list.size(); ++vid ){
-        SvtxVertex *vtxptr = _vertexmap->insert(&svtx_vertex_list[vid]);
+        SvtxVertex *vtxptr = _vertexmap->insert_clone(&svtx_vertex_list[vid]);
         if (Verbosity() > 5) vtxptr->identify();
 	}
 

--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.C
@@ -3124,7 +3124,7 @@ int PHG4KalmanPatRec::export_output()
     }
   }  // track loop
 
-  SvtxVertex* vtxptr = _g4vertexes->insert(&vertex);
+  SvtxVertex* vtxptr = _g4vertexes->insert_clone(&vertex);
   if (Verbosity() > 5)
     vtxptr->identify();
 

--- a/simulation/g4simulation/g4hough/PHG4PatternReco.C
+++ b/simulation/g4simulation/g4hough/PHG4PatternReco.C
@@ -986,7 +986,7 @@ int PHG4PatternReco::export_output(){
 
 /*	
 	for (unsigned int vid = 0; vid < _vertex_list.size(); ++vid ){
-        SvtxVertex *vtxptr = _vertexmap->insert(&svtx_vertex_list[vid]);
+        SvtxVertex *vtxptr = _vertexmap->insert_clone(&svtx_vertex_list[vid]);
         if (Verbosity() > 5) vtxptr->identify();
 	}
 */

--- a/simulation/g4simulation/g4hough/PHG4PatternReco.C
+++ b/simulation/g4simulation/g4hough/PHG4PatternReco.C
@@ -981,7 +981,7 @@ int PHG4PatternReco::export_output(){
         }  // track loop
 
 //	do not repeat saving vertices this time, add only fake vertex
- 	SvtxVertex *vtxptr = _vertexmap->insert(&fake_vertex);
+ 	SvtxVertex *vtxptr = _vertexmap->insert_clone(&fake_vertex);
 	if (Verbosity() > 5) vtxptr->identify();
 
 /*	

--- a/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackKalmanFitter.C
@@ -1635,13 +1635,13 @@ bool PHG4TrackKalmanFitter::FillSvtxVertexMap(
 
 		if (_over_write_svtxvertexmap) {
 			if (_vertexmap) {
-				_vertexmap->insert(svtx_vtx.get());
+				_vertexmap->insert_clone(svtx_vtx.get());
 			} else {
 				LogError("!_vertexmap");
 			}
 		} else {
 			if (_vertexmap_refit) {
-				_vertexmap_refit->insert(svtx_vtx.get());
+				_vertexmap_refit->insert_clone(svtx_vtx.get());
 			} else {
 				LogError("!_vertexmap_refit");
 			}

--- a/simulation/g4simulation/g4hough/PHRaveVertexing.C
+++ b/simulation/g4simulation/g4hough/PHRaveVertexing.C
@@ -369,13 +369,13 @@ bool PHRaveVertexing::FillSvtxVertexMap(
 
 		if (_over_write_svtxvertexmap) {
 			if (_vertexmap) {
-				_vertexmap->insert(svtx_vtx.get());
+				_vertexmap->insert_clone(svtx_vtx.get());
 			} else {
 				LogError("!_vertexmap");
 			}
 		} else {
 			if (_vertexmap_refit) {
-				_vertexmap_refit->insert(svtx_vtx.get());
+				_vertexmap_refit->insert_clone(svtx_vtx.get());
 			} else {
 				LogError("!_vertexmap_refit");
 			}


### PR DESCRIPTION
…o TrkrHit's. Fixed by calling TrkrHitSet::Reset().
TrkrHitSet::Reset() frees the TrkrHit memory before erasing the entries.
I also added a destructor that calls the Reset() method.