### PR TITLE
New DisplayAction

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -268,6 +268,7 @@ libg4detectors_la_SOURCES = \
   PHG4CrystalCalorimeterSteppingAction.cc \
   PHG4CrystalCalorimeterSubsystem.cc \
   PHG4CylinderDetector.cc \
+  PHG4CylinderDisplayAction.cc \
   PHG4CylinderSubsystem.cc \
   PHG4CylinderCellReco.cc \
   PHG4CylinderSteppingAction.cc \

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.cc
@@ -61,7 +61,7 @@ PHG4CEmcTestBeamSubsystem::Init( PHCompositeNode* topNode )
   detector_->SetAbsorberActive(absorberactive);
   detector_->BlackHole(blackhole);
   detector_->SuperDetector(superdetector);
-  detector_->OverlapCheck(overlapcheck);
+  detector_->OverlapCheck(CheckOverlap());
   if (active)
     {
       ostringstream nodename;

--- a/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
@@ -61,7 +61,7 @@ int PHG4ConeSubsystem::Init( PHCompositeNode* topNode )
   detector_->SetMaterial(material);
   detector_->SetActive(active);
   detector_->SuperDetector(superdetector);
-  detector_->OverlapCheck(overlapcheck);
+  detector_->OverlapCheck(CheckOverlap());
   if (active)
     {
   ostringstream nodename;

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
@@ -53,7 +53,7 @@ int PHG4CrystalCalorimeterSubsystem::Init( PHCompositeNode* topNode )
 
   detector_->SetActive(active);
   detector_->SetAbsorberActive(active);
-  detector_->OverlapCheck(overlapcheck);
+  detector_->OverlapCheck(CheckOverlap());
 
   if (active)
     {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -1,4 +1,6 @@
 #include "PHG4CylinderDetector.h"
+#include "PHG4CylinderSubsystem.h"
+#include "PHG4CylinderDisplayAction.h"
 
 #include <phparameter/PHParameters.h>
 
@@ -24,10 +26,11 @@
 using namespace std;
 
 //_______________________________________________________________
-PHG4CylinderDetector::PHG4CylinderDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr)
+PHG4CylinderDetector::PHG4CylinderDetector(PHG4CylinderSubsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr)
   : PHG4Detector(Node, dnam)
   , params(parameters)
   , cylinder_physi(nullptr)
+  , m_MySubSys(subsys)
   , layer(lyr)
 {
 }
@@ -92,4 +95,6 @@ void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
                                      cylinder_logic,
                                      G4String(GetName()),
                                      logicWorld, 0, false, OverlapCheck());
+  PHG4CylinderDisplayAction *action = dynamic_cast<PHG4CylinderDisplayAction *> (m_MySubSys->GetDisplayAction());
+  action->SetMyVolume(cylinder_physi);
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -18,7 +18,6 @@
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4UserLimits.hh>
-#include <Geant4/G4VisAttributes.hh>
 
 #include <cmath>
 #include <sstream>
@@ -56,20 +55,6 @@ void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
     exit(-1);
   }
 
-  G4VisAttributes *siliconVis = new G4VisAttributes();
-  if (params->get_int_param("blackhole"))
-  {
-    PHG4Utils::SetColour(siliconVis, "BlackHole");
-    siliconVis->SetVisibility(false);
-    siliconVis->SetForceSolid(false);
-  }
-  else
-  {
-    PHG4Utils::SetColour(siliconVis, params->get_string_param("material"));
-    siliconVis->SetVisibility(true);
-    siliconVis->SetForceSolid(true);
-  }
-
   // determine length of cylinder using PHENIX's rapidity coverage if flag is true
   double radius = params->get_double_param("radius") * cm;
   double thickness = params->get_double_param("thickness") * cm;
@@ -88,7 +73,6 @@ void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
                                                         TrackerMaterial,
                                                         G4String(GetName()),
                                                         nullptr, nullptr, g4userlimits);
-  cylinder_logic->SetVisAttributes(siliconVis);
   cylinder_physi = new G4PVPlacement(0, G4ThreeVector(params->get_double_param("place_x") * cm,
                                                       params->get_double_param("place_y") * cm,
                                                       params->get_double_param("place_z") * cm),

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
@@ -7,13 +7,14 @@
 
 class G4LogicalVolume;
 class G4VPhysicalVolume;
+class PHG4CylinderSubsystem;
 class PHParameters;
 
 class PHG4CylinderDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4CylinderDetector(PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int layer = 0);
+  PHG4CylinderDetector(PHG4CylinderSubsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int layer = 0);
 
   //! destructor
   virtual ~PHG4CylinderDetector(void)
@@ -31,6 +32,7 @@ class PHG4CylinderDetector : public PHG4Detector
   PHParameters *params;
 
   G4VPhysicalVolume *cylinder_physi;
+  PHG4CylinderSubsystem *m_MySubSys;
 
   int layer;
   std::string superdetector;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
@@ -1,5 +1,7 @@
-#ifndef PHG4CylinderDetector_h
-#define PHG4CylinderDetector_h
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4CYLINDERDETECTOR_H
+#define G4DETECTORS_PHG4CYLINDERDETECTOR_H
 
 #include <g4main/PHG4Detector.h>
 
@@ -17,7 +19,7 @@ class PHG4CylinderDetector : public PHG4Detector
   PHG4CylinderDetector(PHG4CylinderSubsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int layer = 0);
 
   //! destructor
-  virtual ~PHG4CylinderDetector(void)
+  virtual ~PHG4CylinderDetector()
   {
   }
 
@@ -25,17 +27,18 @@ class PHG4CylinderDetector : public PHG4Detector
   void Construct(G4LogicalVolume *world);
 
   bool IsInCylinder(const G4VPhysicalVolume *) const;
-  void SuperDetector(const std::string &name) { superdetector = name; }
-  const std::string SuperDetector() const { return superdetector; }
-  int get_Layer() const { return layer; }
- private:
-  PHParameters *params;
+  void SuperDetector(const std::string &name) { m_SuperDetector = name; }
+  const std::string SuperDetector() const { return m_SuperDetector; }
+  int get_Layer() const { return m_Layer; }
 
-  G4VPhysicalVolume *cylinder_physi;
+ private:
+  PHParameters *m_Params;
+
+  G4VPhysicalVolume *m_CylinderPhysicalVolume;
   PHG4CylinderSubsystem *m_MySubSys;
 
-  int layer;
-  std::string superdetector;
+  int m_Layer;
+  std::string m_SuperDetector;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
@@ -4,45 +4,47 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <Geant4/G4VPhysicalVolume.hh>
-#include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Color.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4VPhysicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
 #include <iostream>
 
 using namespace std;
-PHG4CylinderDisplayAction::PHG4CylinderDisplayAction(const std::string &name, PHParameters *pars):
-  PHG4DisplayAction(name),
-  m_Params(pars),
-  m_VisAtt(nullptr)
-{}
+
+PHG4CylinderDisplayAction::PHG4CylinderDisplayAction(const std::string &name, PHParameters *pars)
+  : PHG4DisplayAction(name)
+  , m_Params(pars)
+  , m_VisAtt(nullptr)
+{
+}
 
 PHG4CylinderDisplayAction::~PHG4CylinderDisplayAction()
 {
   delete m_VisAtt;
 }
 
-void PHG4CylinderDisplayAction::ApplyDisplayAction(G4VPhysicalVolume* physvol)
+void PHG4CylinderDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
-// in our case loop over all volumes and see where ours is
+  // in our case loop over all volumes and see where ours is
   FindVolumes(physvol);
-
 }
 
 int PHG4CylinderDisplayAction::CheckVolume(G4VPhysicalVolume *physvol)
 {
   if (physvol == m_MyVolume)
   {
-    return CheckReturnCodes::ABORT; //
+    //there is only one volume, if found abort search
+    return CheckReturnCodes::ABORT;
   }
   return CheckReturnCodes::FAILED;
 }
 
 void PHG4CylinderDisplayAction::ApplyVisAttributes(G4VPhysicalVolume *physvol)
 {
-  G4LogicalVolume* myvol = physvol->GetLogicalVolume();
-// check if vis attributes exist, if so someone else has set them and we do nothing
+  G4LogicalVolume *myvol = physvol->GetLogicalVolume();
+  // check if vis attributes exist, if so someone else has set them and we do nothing
   if (myvol->GetVisAttributes())
   {
     return;
@@ -63,4 +65,3 @@ void PHG4CylinderDisplayAction::ApplyVisAttributes(G4VPhysicalVolume *physvol)
   myvol->SetVisAttributes(m_VisAtt);
   return;
 }
-

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
@@ -1,5 +1,7 @@
 #include "PHG4CylinderDisplayAction.h"
 
+#include <g4main/PHG4Utils.h>
+
 #include <phparameter/PHParameters.h>
 
 #include <Geant4/G4VPhysicalVolume.hh>
@@ -12,43 +14,53 @@
 using namespace std;
 PHG4CylinderDisplayAction::PHG4CylinderDisplayAction(const std::string &name, PHParameters *pars):
   PHG4DisplayAction(name),
-  m_Params(pars)
+  m_Params(pars),
+  m_VisAtt(nullptr)
 {}
+
+PHG4CylinderDisplayAction::~PHG4CylinderDisplayAction()
+{
+  delete m_VisAtt;
+}
 
 void PHG4CylinderDisplayAction::ApplyDisplayAction(G4VPhysicalVolume* physvol)
 {
-  cout << "applying display action for " << GetName() << " physvol: " 
-       <<  physvol->GetName() << endl;
+// in our case loop over all volumes and see where ours is
   FindVolumes(physvol);
 
 }
 
-bool PHG4CylinderDisplayAction::CheckVolume(G4VPhysicalVolume *physvol)
+int PHG4CylinderDisplayAction::CheckVolume(G4VPhysicalVolume *physvol)
 {
   if (physvol == m_MyVolume)
   {
-    return true;
+    return CheckReturnCodes::ABORT; //
   }
-  return false;
+  return CheckReturnCodes::FAILED;
 }
 
 void PHG4CylinderDisplayAction::ApplyVisAttributes(G4VPhysicalVolume *physvol)
 {
   G4LogicalVolume* myvol = physvol->GetLogicalVolume();
-  G4VisAttributes* visatt = const_cast<G4VisAttributes*> (myvol->GetVisAttributes());
-  if (visatt) 
+// check if vis attributes exist, if so someone else has set them and we do nothing
+  if (myvol->GetVisAttributes())
   {
-    cout << "visibility: " << visatt->IsVisible() 
-	 << " Red: " << visatt->GetColor().GetRed() << endl;
-    visatt->SetColor(G4Colour::Magenta());
+    return;
+  }
+  m_VisAtt = new G4VisAttributes();
+  if (m_Params->get_int_param("blackhole"))
+  {
+    PHG4Utils::SetColour(m_VisAtt, "BlackHole");
+    m_VisAtt->SetVisibility(false);
+    m_VisAtt->SetForceSolid(false);
   }
   else
   {
-    visatt = new G4VisAttributes();
-    visatt->SetVisibility(true);
-    visatt->SetColor(G4Colour::Red());
-    myvol->SetVisAttributes(visatt);
+    PHG4Utils::SetColour(m_VisAtt, m_Params->get_string_param("material"));
+    m_VisAtt->SetVisibility(true);
+    m_VisAtt->SetForceSolid(true);
   }
+  myvol->SetVisAttributes(m_VisAtt);
   return;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
@@ -1,0 +1,54 @@
+#include "PHG4CylinderDisplayAction.h"
+
+#include <phparameter/PHParameters.h>
+
+#include <Geant4/G4VPhysicalVolume.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Color.hh>
+#include <Geant4/G4VisAttributes.hh>
+
+#include <iostream>
+
+using namespace std;
+PHG4CylinderDisplayAction::PHG4CylinderDisplayAction(const std::string &name, PHParameters *pars):
+  PHG4DisplayAction(name),
+  m_Params(pars)
+{}
+
+void PHG4CylinderDisplayAction::ApplyDisplayAction(G4VPhysicalVolume* physvol)
+{
+  cout << "applying display action for " << GetName() << " physvol: " 
+       <<  physvol->GetName() << endl;
+  FindVolumes(physvol);
+
+}
+
+bool PHG4CylinderDisplayAction::CheckVolume(G4VPhysicalVolume *physvol)
+{
+  if (physvol == m_MyVolume)
+  {
+    return true;
+  }
+  return false;
+}
+
+void PHG4CylinderDisplayAction::ApplyVisAttributes(G4VPhysicalVolume *physvol)
+{
+  G4LogicalVolume* myvol = physvol->GetLogicalVolume();
+  G4VisAttributes* visatt = const_cast<G4VisAttributes*> (myvol->GetVisAttributes());
+  if (visatt) 
+  {
+    cout << "visibility: " << visatt->IsVisible() 
+	 << " Red: " << visatt->GetColor().GetRed() << endl;
+    visatt->SetColor(G4Colour::Magenta());
+  }
+  else
+  {
+    visatt = new G4VisAttributes();
+    visatt->SetVisibility(true);
+    visatt->SetColor(G4Colour::Red());
+    myvol->SetVisAttributes(visatt);
+  }
+  return;
+}
+

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
@@ -1,0 +1,35 @@
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
+#ifndef G4MAIN_PHG4CYLINDERDISPLAYACTION_H
+#define G4MAIN_PHG4CYLINDERDISPLAYACTION_H
+
+#include <g4main/PHG4DisplayAction.h>
+
+class G4VPhysicalVolume;
+class PHParameters;
+
+class PHG4CylinderDisplayAction: public PHG4DisplayAction
+{
+public:
+  PHG4CylinderDisplayAction( const std::string &name,  PHParameters *parameters );
+
+  virtual ~PHG4CylinderDisplayAction() {}
+
+  void ApplyDisplayAction(G4VPhysicalVolume* physvol);
+  void SetVolName(const std::string &name) {volname = name;}
+  std::string GetVolName() const {return volname;}
+  void SetMyVolume(G4VPhysicalVolume *vol) {m_MyVolume = vol;}
+
+protected:
+  bool CheckVolume(G4VPhysicalVolume *physvol);
+  void ApplyVisAttributes(G4VPhysicalVolume *vol);
+
+private:
+  std::string volname;
+
+  PHParameters *m_Params;
+  G4VPhysicalVolume *m_MyVolume;
+};
+
+
+#endif // G4MAIN_PHG4CYLINDERDISPLAYACTION_H

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
@@ -9,26 +9,24 @@ class G4VisAttributes;
 class G4VPhysicalVolume;
 class PHParameters;
 
-class PHG4CylinderDisplayAction: public PHG4DisplayAction
+class PHG4CylinderDisplayAction : public PHG4DisplayAction
 {
-public:
-  PHG4CylinderDisplayAction( const std::string &name,  PHParameters *parameters );
+ public:
+  PHG4CylinderDisplayAction(const std::string &name, PHParameters *parameters);
 
   virtual ~PHG4CylinderDisplayAction();
 
-  void ApplyDisplayAction(G4VPhysicalVolume* physvol);
-  void SetMyVolume(G4VPhysicalVolume *vol) {m_MyVolume = vol;}
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void SetMyVolume(G4VPhysicalVolume *vol) { m_MyVolume = vol; }
 
-protected:
+ protected:
   int CheckVolume(G4VPhysicalVolume *physvol);
   void ApplyVisAttributes(G4VPhysicalVolume *vol);
 
-private:
-
+ private:
   PHParameters *m_Params;
   G4VPhysicalVolume *m_MyVolume;
   G4VisAttributes *m_VisAtt;
 };
 
-
-#endif // G4MAIN_PHG4CYLINDERDISPLAYACTION_H
+#endif  // G4MAIN_PHG4CYLINDERDISPLAYACTION_H

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
@@ -5,6 +5,7 @@
 
 #include <g4main/PHG4DisplayAction.h>
 
+class G4VisAttributes;
 class G4VPhysicalVolume;
 class PHParameters;
 
@@ -13,22 +14,20 @@ class PHG4CylinderDisplayAction: public PHG4DisplayAction
 public:
   PHG4CylinderDisplayAction( const std::string &name,  PHParameters *parameters );
 
-  virtual ~PHG4CylinderDisplayAction() {}
+  virtual ~PHG4CylinderDisplayAction();
 
   void ApplyDisplayAction(G4VPhysicalVolume* physvol);
-  void SetVolName(const std::string &name) {volname = name;}
-  std::string GetVolName() const {return volname;}
   void SetMyVolume(G4VPhysicalVolume *vol) {m_MyVolume = vol;}
 
 protected:
-  bool CheckVolume(G4VPhysicalVolume *physvol);
+  int CheckVolume(G4VPhysicalVolume *physvol);
   void ApplyVisAttributes(G4VPhysicalVolume *vol);
 
 private:
-  std::string volname;
 
   PHParameters *m_Params;
   G4VPhysicalVolume *m_MyVolume;
+  G4VisAttributes *m_VisAtt;
 };
 
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
@@ -12,39 +12,34 @@
 
 #include "PHG4CylinderGeomv2.h"
 
-#include <string>
-#include <cmath>
 #include <map>
+#include <string>
 
 class PHParameters;
 
 class PHG4CylinderGeom_Spacalv1 : public PHG4CylinderGeomv2
 {
-public:
-
+ public:
   /** @name Ctor DTor and IDs
    */
   ///@{
   PHG4CylinderGeom_Spacalv1();
 
-  virtual
-  ~PHG4CylinderGeom_Spacalv1()
+  virtual ~PHG4CylinderGeom_Spacalv1()
   {
   }
 
-  virtual
-  void
-  identify(std::ostream& os = std::cout) const;
+  virtual void
+  identify(std::ostream &os = std::cout) const;
 
   virtual void
   Print(Option_t *option = "") const;
 
-  virtual
-  void
+  virtual void
   SetDefault();
 
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHParameters & param);
+  virtual void ImportParameters(const PHParameters &param);
 
   ///@}
 
@@ -110,20 +105,17 @@ public:
   /** @name Azimuthal segments
    */
   ///@{
-  virtual
-  int
+  virtual int
   get_azimuthal_n_sec() const;
 
-  virtual
-  double
+  virtual double
   get_azimuthal_distance() const;
 
-  virtual
-  double
+  virtual double
   get_z_distance() const;
 
   //! sector map sector_ID -> azimuthal rotation.
-  typedef std::map<int,double> sector_map_t;
+  typedef std::map<int, double> sector_map_t;
 
   //! sector map sector_ID -> azimuthal rotation.
   const sector_map_t &
@@ -236,19 +228,6 @@ public:
   /** @name General options
    */
   ///@{
-  //! obsolete as there is no need to limit steps in insentive volumne
-//  double
-//  get_calo_step_size() const
-//  {
-//    return get_fiber_distance() / 10.;
-//  }
-//
-  //! obsolete as there is no need to limit steps in insentive volumne
-//  double
-//  get_fiber_clading_step_size() const
-//  {
-//    return get_fiber_clading_thickness() / 10.;
-//  }
 
   double
   get_fiber_core_step_size() const
@@ -264,11 +243,9 @@ public:
     //! alias of above, more explicit
     k1DProjectiveSpacal = kNonProjective,
 
-
     //! Block constructed with taper in polar direction, non-taper in azimuthal direction.
     //! The final layout is approximately projective in both azimuthal and polar directions.
     kProjective_PolarTaper = 1,
-
 
     //! Fully projective spacal with 2D tapered modules
     kFullProjective_2DTaper = 2,
@@ -276,13 +253,11 @@ public:
     //! Fully projective spacal with 2D tapered modules. To speed up construction, same-length fiber is used cross one tower
     kFullProjective_2DTaper_SameLengthFiberPerTower = 3,
 
-
     //! Fully projective spacal with 2D tapered modules and allow azimuthal tilts
     kFullProjective_2DTaper_Tilted = 4,
 
     //! Fully projective spacal with 2D tapered modules and allow azimuthal tilts. To speed up construction, same-length fiber is used cross one tower
     kFullProjective_2DTaper_Tilted_SameLengthFiberPerTower = 5,
-
 
     //! alias of above, the default 2D-projective SPACAL
     k2DProjectiveSpacal = kFullProjective_2DTaper_Tilted_SameLengthFiberPerTower,
@@ -309,8 +284,7 @@ public:
     return virualize_fiber;
   }
 
-  virtual
-  bool is_azimuthal_seg_visible() const
+  virtual bool is_azimuthal_seg_visible() const
   {
     return false;
   }
@@ -321,8 +295,7 @@ public:
     virualize_fiber = virualizeFiber;
   }
 
-  int
-  get_construction_verbose() const
+  int get_construction_verbose() const
   {
     return construction_verbose;
   }
@@ -335,7 +308,7 @@ public:
 
   ///@}
 
-protected:
+ protected:
   std::string absorber_mat;
   std::string fiber_core_mat;
   std::string fiber_clading_mat;
@@ -352,9 +325,7 @@ protected:
   //! sector map sector_ID -> azimuthal rotation.
   sector_map_t sector_map;
 
-
-ClassDef(PHG4CylinderGeom_Spacalv1,2)
-
+  ClassDef(PHG4CylinderGeom_Spacalv1, 2)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
@@ -7,10 +7,11 @@
  * \version $$Revision: 1.2 $$
  * \date $$Date: 2014/08/12 03:49:12 $$
  */
-#ifndef PHG4CylinderGeom_Spacalv1_H__
-#define PHG4CylinderGeom_Spacalv1_H__
+#ifndef G4DETECTORS_PHG4CYLINDERGEOMSPACALV1_H
+#define G4DETECTORS_PHG4CYLINDERGEOMSPACALV1_H
 
 #include "PHG4CylinderGeomv2.h"
+
 #include <string>
 #include <cmath>
 #include <map>

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -18,34 +18,35 @@
 #include <Geant4/G4UserLimits.hh>
 
 #include <boost/io/ios_state.hpp>
+
 #include <iomanip>
 #include <iostream>
 
 using namespace std;
 //____________________________________________________________________________..
 PHG4CylinderSteppingAction::PHG4CylinderSteppingAction(PHG4CylinderDetector* detector, const PHParameters* parameters)
-  : detector_(detector)
-  , params(parameters)
-  , hits_(nullptr)
-  , hit(nullptr)
-  , saveshower(nullptr)
-  , savevolpre(nullptr)
-  , savevolpost(nullptr)
-  , save_light_yield(params->get_int_param("lightyield"))
-  , savetrackid(-1)
-  , saveprestepstatus(-1)
-  , savepoststepstatus(-1)
-  , active(params->get_int_param("active"))
-  , IsBlackHole(params->get_int_param("blackhole"))
-  , use_g4_steps(params->get_int_param("use_g4steps"))
-  , zmin(params->get_double_param("place_z") * cm - params->get_double_param("length") * cm / 2.)
-  , zmax(params->get_double_param("place_z") * cm + params->get_double_param("length") * cm / 2.)
-  , tmin(params->get_double_param("tmin") * ns)
-  , tmax(params->get_double_param("tmax") * ns)
+  : m_Detector(detector)
+  , m_Params(parameters)
+  , m_HitContainer(nullptr)
+  , m_Hit(nullptr)
+  , m_SaveShower(nullptr)
+  , m_SaveVolPre(nullptr)
+  , m_SaveVolPost(nullptr)
+  , m_SaveLightYieldFlag(m_Params->get_int_param("lightyield"))
+  , m_SaveTrackId(-1)
+  , m_SavePreStepStatus(-1)
+  , m_SavePostStepStatus(-1)
+  , m_ActiveFlag(m_Params->get_int_param("active"))
+  , m_BlackHoleFlag(m_Params->get_int_param("blackhole"))
+  , m_UseG4StepsFlag(m_Params->get_int_param("use_g4steps"))
+  , m_Zmin(m_Params->get_double_param("place_z") * cm - m_Params->get_double_param("length") * cm / 2.)
+  , m_Zmax(m_Params->get_double_param("place_z") * cm + m_Params->get_double_param("length") * cm / 2.)
+  , m_Tmin(m_Params->get_double_param("tmin") * ns)
+  , m_Tmax(m_Params->get_double_param("tmax") * ns)
 {
   // G4 seems to have issues in the um range
-  zmin -= copysign(zmin, 1. / 1e6 * cm);
-  zmax += copysign(zmax, 1. / 1e6 * cm);
+  m_Zmin -= copysign(m_Zmin, 1. / 1e6 * cm);
+  m_Zmax += copysign(m_Zmax, 1. / 1e6 * cm);
 }
 
 PHG4CylinderSteppingAction::~PHG4CylinderSteppingAction()
@@ -54,7 +55,7 @@ PHG4CylinderSteppingAction::~PHG4CylinderSteppingAction()
   // and the memory is still allocated, so we need to delete it here
   // if the last hit was saved, hit is a nullptr pointer which are
   // legal to delete (it results in a no operation)
-  delete hit;
+  delete m_Hit;
 }
 
 //____________________________________________________________________________..
@@ -67,7 +68,7 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
   G4VPhysicalVolume* volume = touch->GetVolume();
   // G4 just calls  UserSteppingAction for every step (and we loop then over all our
   // steppingactions. First we have to check if we are actually in our volume
-  if (!detector_->IsInCylinder(volume))
+  if (!m_Detector->IsInCylinder(volume))
   {
     return false;
   }
@@ -78,11 +79,11 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
   const G4Track* aTrack = aStep->GetTrack();
 
   // if this cylinder stops everything, just put all kinetic energy into edep
-  if (IsBlackHole)
+  if (m_BlackHoleFlag)
   {
-    if ((!isfinite(tmin) && !isfinite(tmax)) ||
-        aTrack->GetGlobalTime() < tmin ||
-        aTrack->GetGlobalTime() > tmax)
+    if ((!isfinite(m_Tmin) && !isfinite(m_Tmax)) ||
+        aTrack->GetGlobalTime() < m_Tmin ||
+        aTrack->GetGlobalTime() > m_Tmax)
     {
       edep = aTrack->GetKineticEnergy() / GeV;
       G4Track* killtrack = const_cast<G4Track*>(aTrack);
@@ -90,9 +91,9 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     }
   }
 
-  int layer_id = detector_->get_Layer();
+  int layer_id = m_Detector->get_Layer();
   // test if we are active
-  if (active)
+  if (m_ActiveFlag)
   {
     bool geantino = false;
     // the check for the pdg code speeds things up, I do not want to make
@@ -113,72 +114,72 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     int prepointstatus = prePoint->GetStepStatus();
     if (prepointstatus == fGeomBoundary ||
         prepointstatus == fUndefined ||
-        (prepointstatus == fPostStepDoItProc && savepoststepstatus == fGeomBoundary) ||
-        use_g4_steps > 0)
+        (prepointstatus == fPostStepDoItProc && m_SavePostStepStatus == fGeomBoundary) ||
+        m_UseG4StepsFlag > 0)
     {
-      if (prepointstatus == fPostStepDoItProc && savepoststepstatus == fGeomBoundary)
+      if (prepointstatus == fPostStepDoItProc && m_SavePostStepStatus == fGeomBoundary)
       {
-	cout << GetName() << ": New Hit for  " << endl;
-	cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-	     << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-	     << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
-	     << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
-	cout << "last track: " << savetrackid
-	     << ", current trackid: " << aTrack->GetTrackID() << endl;
-	cout << "phys pre vol: " << volume->GetName()
-	     << " post vol : " << touchpost->GetVolume()->GetName() << endl;
-	cout << " previous phys pre vol: " << savevolpre->GetName()
-	     << " previous phys post vol: " << savevolpost->GetName() << endl;
+        cout << GetName() << ": New Hit for  " << endl;
+        cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+             << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+             << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+             << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << endl;
+        cout << "last track: " << m_SaveTrackId
+             << ", current trackid: " << aTrack->GetTrackID() << endl;
+        cout << "phys pre vol: " << volume->GetName()
+             << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+        cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+             << " previous phys post vol: " << m_SaveVolPost->GetName() << endl;
       }
 
-      if (!hit)
+      if (!m_Hit)
       {
-        hit = new PHG4Hitv1();
+        m_Hit = new PHG4Hitv1();
       }
 
-      hit->set_layer((unsigned int) layer_id);
+      m_Hit->set_layer((unsigned int) layer_id);
 
       //here we set the entrance values in cm
-      hit->set_x(0, prePoint->GetPosition().x() / cm);
-      hit->set_y(0, prePoint->GetPosition().y() / cm);
-      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      m_Hit->set_x(0, prePoint->GetPosition().x() / cm);
+      m_Hit->set_y(0, prePoint->GetPosition().y() / cm);
+      m_Hit->set_z(0, prePoint->GetPosition().z() / cm);
 
-      hit->set_px(0, prePoint->GetMomentum().x() / GeV);
-      hit->set_py(0, prePoint->GetMomentum().y() / GeV);
-      hit->set_pz(0, prePoint->GetMomentum().z() / GeV);
+      m_Hit->set_px(0, prePoint->GetMomentum().x() / GeV);
+      m_Hit->set_py(0, prePoint->GetMomentum().y() / GeV);
+      m_Hit->set_pz(0, prePoint->GetMomentum().z() / GeV);
 
       // time in ns
-      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      m_Hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
       //set and save the track ID
-      hit->set_trkid(aTrack->GetTrackID());
-      savetrackid = aTrack->GetTrackID();
+      m_Hit->set_trkid(aTrack->GetTrackID());
+      m_SaveTrackId = aTrack->GetTrackID();
       //set the initial energy deposit
-      hit->set_edep(0);
-      if (!geantino && !IsBlackHole)
+      m_Hit->set_edep(0);
+      if (!geantino && !m_BlackHoleFlag)
       {
-        hit->set_eion(0);
+        m_Hit->set_eion(0);
       }
-      if (save_light_yield)
+      if (m_SaveLightYieldFlag)
       {
-        hit->set_light_yield(0);
+        m_Hit->set_light_yield(0);
       }
       if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {
         if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
-          hit->set_trkid(pp->GetUserTrackId());
-          hit->set_shower_id(pp->GetShower()->get_id());
-          saveshower = pp->GetShower();
+          m_Hit->set_trkid(pp->GetUserTrackId());
+          m_Hit->set_shower_id(pp->GetShower()->get_id());
+          m_SaveShower = pp->GetShower();
         }
       }
 
-      if (hit->get_z(0) * cm > zmax || hit->get_z(0) * cm < zmin)
+      if (m_Hit->get_z(0) * cm > m_Zmax || m_Hit->get_z(0) * cm < m_Zmin)
       {
-	boost::io::ios_precision_saver ips(cout);
-        cout << detector_->SuperDetector() << std::setprecision(9)
-             << "PHG4CylinderSteppingAction: Entry hit z " << hit->get_z(0) * cm
-             << " outside acceptance,  zmin " << zmin
-             << ", zmax " << zmax << ", layer: " << layer_id << endl;
+        boost::io::ios_precision_saver ips(cout);
+        cout << m_Detector->SuperDetector() << std::setprecision(9)
+             << "PHG4CylinderSteppingAction: Entry hit z " << m_Hit->get_z(0) * cm
+             << " outside acceptance,  zmin " << m_Zmin
+             << ", zmax " << m_Zmax << ", layer: " << layer_id << endl;
       }
     }
     // here we just update the exit values, it will be overwritten
@@ -186,70 +187,70 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     // ceases to exist
     // some sanity checks for inconsistencies
     // check if this hit was created, if not print out last post step status
-    if (!hit || !isfinite(hit->get_x(0)))
+    if (!m_Hit || !isfinite(m_Hit->get_x(0)))
     {
       cout << GetName() << ": hit was not created" << endl;
       cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
            << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
-           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
-      cout << "last track: " << savetrackid
+           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << endl;
+      cout << "last track: " << m_SaveTrackId
            << ", current trackid: " << aTrack->GetTrackID() << endl;
       cout << "phys pre vol: " << volume->GetName()
            << " post vol : " << touchpost->GetVolume()->GetName() << endl;
-      cout << " previous phys pre vol: " << savevolpre->GetName()
-           << " previous phys post vol: " << savevolpost->GetName() << endl;
+      cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+           << " previous phys post vol: " << m_SaveVolPost->GetName() << endl;
       exit(1);
     }
-    savepoststepstatus = postPoint->GetStepStatus();
+    m_SavePostStepStatus = postPoint->GetStepStatus();
     // check if track id matches the initial one when the hit was created
-    if (aTrack->GetTrackID() != savetrackid)
+    if (aTrack->GetTrackID() != m_SaveTrackId)
     {
       cout << "hits do not belong to the same track" << endl;
-      cout << "saved track: " << savetrackid
+      cout << "saved track: " << m_SaveTrackId
            << ", current trackid: " << aTrack->GetTrackID()
            << endl;
       exit(1);
     }
-    saveprestepstatus = prePoint->GetStepStatus();
-    savepoststepstatus = postPoint->GetStepStatus();
-    savevolpre = volume;
-    savevolpost = touchpost->GetVolume();
- 
-    hit->set_x(1, postPoint->GetPosition().x() / cm);
-    hit->set_y(1, postPoint->GetPosition().y() / cm);
-    hit->set_z(1, postPoint->GetPosition().z() / cm);
+    m_SavePreStepStatus = prePoint->GetStepStatus();
+    m_SavePostStepStatus = postPoint->GetStepStatus();
+    m_SaveVolPre = volume;
+    m_SaveVolPost = touchpost->GetVolume();
 
-    hit->set_px(1, postPoint->GetMomentum().x() / GeV);
-    hit->set_py(1, postPoint->GetMomentum().y() / GeV);
-    hit->set_pz(1, postPoint->GetMomentum().z() / GeV);
+    m_Hit->set_x(1, postPoint->GetPosition().x() / cm);
+    m_Hit->set_y(1, postPoint->GetPosition().y() / cm);
+    m_Hit->set_z(1, postPoint->GetPosition().z() / cm);
 
-    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+    m_Hit->set_px(1, postPoint->GetMomentum().x() / GeV);
+    m_Hit->set_py(1, postPoint->GetMomentum().y() / GeV);
+    m_Hit->set_pz(1, postPoint->GetMomentum().z() / GeV);
+
+    m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
     //sum up the energy to get total deposited
-    hit->set_edep(hit->get_edep() + edep);
-    if (hit->get_z(1) * cm > zmax || hit->get_z(1) * cm < zmin)
+    m_Hit->set_edep(m_Hit->get_edep() + edep);
+    if (m_Hit->get_z(1) * cm > m_Zmax || m_Hit->get_z(1) * cm < m_Zmin)
     {
-      cout << detector_->SuperDetector() << std::setprecision(9)
-           << " PHG4CylinderSteppingAction: Exit hit z " << hit->get_z(1) * cm
-           << " outside acceptance zmin " << zmin
-           << ", zmax " << zmax << ", layer: " << layer_id << endl;
+      cout << m_Detector->SuperDetector() << std::setprecision(9)
+           << " PHG4CylinderSteppingAction: Exit hit z " << m_Hit->get_z(1) * cm
+           << " outside acceptance zmin " << m_Zmin
+           << ", zmax " << m_Zmax << ", layer: " << layer_id << endl;
     }
     if (geantino)
     {
-      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      m_Hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
     }
     else
     {
-      if (!IsBlackHole)
+      if (!m_BlackHoleFlag)
       {
         double eion = edep - aStep->GetNonIonizingEnergyDeposit() / GeV;
-        hit->set_eion(hit->get_eion() + eion);
+        m_Hit->set_eion(m_Hit->get_eion() + eion);
       }
     }
-    if (save_light_yield)
+    if (m_SaveLightYieldFlag)
     {
       double light_yield = GetVisibleEnergyDeposition(aStep);
-      hit->set_light_yield(hit->get_light_yield() + light_yield);
+      m_Hit->set_light_yield(m_Hit->get_light_yield() + light_yield);
     }
     if (edep > 0)
     {
@@ -273,26 +274,26 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         postPoint->GetStepStatus() == fWorldBoundary ||
         postPoint->GetStepStatus() == fAtRestDoItProc ||
         aTrack->GetTrackStatus() == fStopAndKill ||
-        use_g4_steps > 0)
+        m_UseG4StepsFlag > 0)
     {
       // save only hits with energy deposit (or -1 for geantino)
-      if (hit->get_edep())
+      if (m_Hit->get_edep())
       {
-        hits_->AddHit(layer_id, hit);
-        if (saveshower)
+        m_HitContainer->AddHit(layer_id, m_Hit);
+        if (m_SaveShower)
         {
-          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+          m_SaveShower->add_g4hit_id(m_HitContainer->GetID(), m_Hit->get_hit_id());
         }
         // ownership has been transferred to container, set to null
         // so we will create a new hit for the next track
-        hit = nullptr;
+        m_Hit = nullptr;
       }
       else
       {
         // if this hit has no energy deposit, just reset it for reuse
         // this means we have to delete it in the dtor. If this was
         // the last hit we processed the memory is still allocated
-        hit->Reset();
+        m_Hit->Reset();
       }
     }
     // return true to indicate the hit was used
@@ -308,20 +309,20 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 void PHG4CylinderSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
   string hitnodename;
-  if (detector_->SuperDetector() != "NONE")
+  if (m_Detector->SuperDetector() != "NONE")
   {
-    hitnodename = "G4HIT_" + detector_->SuperDetector();
+    hitnodename = "G4HIT_" + m_Detector->SuperDetector();
   }
   else
   {
-    hitnodename = "G4HIT_" + detector_->GetName();
+    hitnodename = "G4HIT_" + m_Detector->GetName();
   }
 
   //now look for the map and grab a pointer to it.
-  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  m_HitContainer = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
 
   // if we do not find the node we need to make it.
-  if (!hits_ && !IsBlackHole)
+  if (!m_HitContainer && !m_BlackHoleFlag)
   {
     std::cout << "PHG4CylinderSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
   }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -1,5 +1,7 @@
-#ifndef PHG4CylinderSteppingAction_h
-#define PHG4CylinderSteppingAction_h
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4CYLINDERSTEPPINGACTION_H
+#define G4DETECTORS_PHG4CYLINDERSTEPPINGACTION_H
 
 #include <g4main/PHG4SteppingAction.h>
 
@@ -27,30 +29,31 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
   //! reimplemented from base class
   void SetInterfacePointers(PHCompositeNode *);
 
-  void SaveLightYield(const int i = 1) { save_light_yield = i; }
+  void SaveLightYield(const int i = 1) { m_SaveLightYieldFlag = i; }
+
  private:
   //! pointer to the detector
-  PHG4CylinderDetector *detector_;
+  PHG4CylinderDetector *m_Detector;
 
-  const PHParameters *params;
+  const PHParameters *m_Params;
 
   //! pointer to hit container
-  PHG4HitContainer *hits_;
-  PHG4Hit *hit;
-  PHG4Shower *saveshower;
-  G4VPhysicalVolume *savevolpre;
-  G4VPhysicalVolume *savevolpost;
-  int save_light_yield;
-  int savetrackid;
-  int saveprestepstatus;
-  int savepoststepstatus;
-  int active;
-  int IsBlackHole;
-  int use_g4_steps;
-  double zmin;
-  double zmax;
-  double tmin;
-  double tmax;
+  PHG4HitContainer *m_HitContainer;
+  PHG4Hit *m_Hit;
+  PHG4Shower *m_SaveShower;
+  G4VPhysicalVolume *m_SaveVolPre;
+  G4VPhysicalVolume *m_SaveVolPost;
+  int m_SaveLightYieldFlag;
+  int m_SaveTrackId;
+  int m_SavePreStepStatus;
+  int m_SavePostStepStatus;
+  int m_ActiveFlag;
+  int m_BlackHoleFlag;
+  int m_UseG4StepsFlag;
+  double m_Zmin;
+  double m_Zmax;
+  double m_Tmin;
+  double m_Tmax;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -22,8 +22,8 @@ using namespace std;
 //_______________________________________________________________________
 PHG4CylinderSubsystem::PHG4CylinderSubsystem(const std::string &na, const int lyr)
   : PHG4DetectorSubsystem(na, lyr)
-  , detector_(nullptr)
-  , steppingAction_(nullptr)
+  , m_Detector(nullptr)
+  , m_SteppingAction(nullptr)
   , m_DisplayAction(nullptr)
 {
   InitializeParameters();
@@ -43,10 +43,10 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     GetParams()->set_double_param("length", PHG4Utils::GetLengthForRapidityCoverage(GetParams()->get_double_param("radius") + GetParams()->get_double_param("thickness")) * 2);
   }
   // create detector
-  detector_ = new PHG4CylinderDetector(this, topNode, GetParams(), Name(), GetLayer());
+  m_Detector = new PHG4CylinderDetector(this, topNode, GetParams(), Name(), GetLayer());
   G4double detlength = GetParams()->get_double_param("length");
-  detector_->SuperDetector(SuperDetector());
-  detector_->OverlapCheck(CheckOverlap());
+  m_Detector->SuperDetector(SuperDetector());
+  m_Detector->OverlapCheck(CheckOverlap());
   if (GetParams()->get_int_param("active"))
   {
     PHNodeIterator iter(topNode);
@@ -99,14 +99,14 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     }
     PHG4CylinderGeom *mygeom = new PHG4CylinderGeomv1(GetParams()->get_double_param("radius"), GetParams()->get_double_param("place_z") - detlength / 2., GetParams()->get_double_param("place_z") + detlength / 2., GetParams()->get_double_param("thickness"));
     geo->AddLayerGeom(GetLayer(), mygeom);
-    steppingAction_ = new PHG4CylinderSteppingAction(detector_, GetParams());
+    m_SteppingAction = new PHG4CylinderSteppingAction(m_Detector, GetParams());
   }
   if (GetParams()->get_int_param("blackhole"))
   {
-    steppingAction_ = new PHG4CylinderSteppingAction(detector_, GetParams());
+    m_SteppingAction = new PHG4CylinderSteppingAction(m_Detector, GetParams());
   }
-// create display settings
-  m_DisplayAction = new PHG4CylinderDisplayAction(Name(),GetParams());
+  // create display settings
+  m_DisplayAction = new PHG4CylinderDisplayAction(Name(), GetParams());
   return 0;
 }
 
@@ -115,9 +115,9 @@ int PHG4CylinderSubsystem::process_event(PHCompositeNode *topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
-  if (steppingAction_)
+  if (m_SteppingAction)
   {
-    steppingAction_->SetInterfacePointers(topNode);
+    m_SteppingAction->SetInterfacePointers(topNode);
   }
   return 0;
 }
@@ -144,7 +144,7 @@ void PHG4CylinderSubsystem::SetDefaultParameters()
 PHG4Detector *
 PHG4CylinderSubsystem::GetDetector(void) const
 {
-  return detector_;
+  return m_Detector;
 }
 
 void PHG4CylinderSubsystem::Print(const string &what) const
@@ -162,9 +162,9 @@ void PHG4CylinderSubsystem::Print(const string &what) const
     return;
   }
   GetParams()->Print();
-  if (steppingAction_)
+  if (m_SteppingAction)
   {
-    steppingAction_->Print(what);
+    m_SteppingAction->Print(what);
   }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -1,5 +1,6 @@
 #include "PHG4CylinderSubsystem.h"
 #include "PHG4CylinderDetector.h"
+#include "PHG4CylinderDisplayAction.h"
 #include "PHG4CylinderGeomContainer.h"
 #include "PHG4CylinderGeomv1.h"
 #include "PHG4CylinderSteppingAction.h"
@@ -23,8 +24,14 @@ PHG4CylinderSubsystem::PHG4CylinderSubsystem(const std::string &na, const int ly
   : PHG4DetectorSubsystem(na, lyr)
   , detector_(nullptr)
   , steppingAction_(nullptr)
+  , m_DisplayAction(nullptr)
 {
   InitializeParameters();
+}
+
+PHG4CylinderSubsystem::~PHG4CylinderSubsystem()
+{
+  delete m_DisplayAction;
 }
 
 //_______________________________________________________________________
@@ -36,7 +43,7 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     GetParams()->set_double_param("length", PHG4Utils::GetLengthForRapidityCoverage(GetParams()->get_double_param("radius") + GetParams()->get_double_param("thickness")) * 2);
   }
   // create detector
-  detector_ = new PHG4CylinderDetector(topNode, GetParams(), Name(), GetLayer());
+  detector_ = new PHG4CylinderDetector(this, topNode, GetParams(), Name(), GetLayer());
   G4double detlength = GetParams()->get_double_param("length");
   detector_->SuperDetector(SuperDetector());
   detector_->OverlapCheck(CheckOverlap());
@@ -98,6 +105,8 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   {
     steppingAction_ = new PHG4CylinderSteppingAction(detector_, GetParams());
   }
+// create display settings
+  m_DisplayAction = new PHG4CylinderDisplayAction(Name(),GetParams());
   return 0;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -1,5 +1,7 @@
-#ifndef PHG4CylinderSubsystem_h
-#define PHG4CylinderSubsystem_h
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4CYLINDERSUBSYSTEM_H
+#define G4DETECTORS_PHG4CYLINDERSUBSYSTEM_H
 
 #include "PHG4DetectorSubsystem.h"
 
@@ -7,6 +9,7 @@
 #include <Geant4/G4Types.hh>
 
 class PHG4CylinderDetector;
+class PHG4DisplayAction;
 class PHG4SteppingAction;
 
 class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
@@ -16,9 +19,7 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
   PHG4CylinderSubsystem(const std::string& name = "CYLINDER", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4CylinderSubsystem(void)
-  {
-  }
+  virtual ~PHG4CylinderSubsystem(void);
 
   //! init runwise stuff
   /*!
@@ -41,16 +42,23 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
   //! accessors (reimplemented)
   PHG4Detector* GetDetector(void) const;
   PHG4SteppingAction* GetSteppingAction(void) const { return steppingAction_; }
+
+  PHG4DisplayAction *GetDisplayAction() const {return m_DisplayAction;}
+
  private:
   void SetDefaultParameters();
 
   //! detector geometry
-  /*! defives from PHG4Detector */
+  /*! derives from PHG4Detector */
   PHG4CylinderDetector* detector_;
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
   PHG4SteppingAction* steppingAction_;
+
+  //! display attribute setting
+  /*! derives from PHG4DisplayAction */
+  PHG4DisplayAction *m_DisplayAction;
 };
 
-#endif
+#endif // G4DETECTORS_PHG4CYLINDERSUBSYSTEM_H

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -5,9 +5,6 @@
 
 #include "PHG4DetectorSubsystem.h"
 
-#include <Geant4/G4String.hh>
-#include <Geant4/G4Types.hh>
-
 class PHG4CylinderDetector;
 class PHG4DisplayAction;
 class PHG4SteppingAction;
@@ -23,7 +20,7 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
 
   //! init runwise stuff
   /*!
-  creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
+  creates the m_Detector object and place it on the node tree, under "DETECTORS" node (or whatever)
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
@@ -41,24 +38,24 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
 
   //! accessors (reimplemented)
   PHG4Detector* GetDetector(void) const;
-  PHG4SteppingAction* GetSteppingAction(void) const { return steppingAction_; }
+  PHG4SteppingAction* GetSteppingAction(void) const { return m_SteppingAction; }
 
-  PHG4DisplayAction *GetDisplayAction() const {return m_DisplayAction;}
+  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
 
  private:
   void SetDefaultParameters();
 
   //! detector geometry
   /*! derives from PHG4Detector */
-  PHG4CylinderDetector* detector_;
+  PHG4CylinderDetector* m_Detector;
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
-  PHG4SteppingAction* steppingAction_;
+  PHG4SteppingAction* m_SteppingAction;
 
   //! display attribute setting
   /*! derives from PHG4DisplayAction */
-  PHG4DisplayAction *m_DisplayAction;
+  PHG4DisplayAction* m_DisplayAction;
 };
 
-#endif // G4DETECTORS_PHG4CYLINDERSUBSYSTEM_H
+#endif  // G4DETECTORS_PHG4CYLINDERSUBSYSTEM_H

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
@@ -31,7 +31,7 @@ int PHG4EnvelopeSubsystem::Init( PHCompositeNode* topNode )
 	// create detector
 	detector_ = new PHG4EnvelopeDetector(topNode, Name());
 	detector_->SetActive(active);
-	detector_->OverlapCheck(overlapcheck);
+	detector_->OverlapCheck(CheckOverlap());
 	
 	if (active)
 	{

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.cc
@@ -5,6 +5,7 @@
 #include "PHG4EventActionClearZeroEdep.h"
 
 #include <g4main/PHG4HitContainer.h>
+
 #include <phool/getClass.h>
 
 #include <Geant4/globals.hh>
@@ -19,8 +20,8 @@ using namespace std;
 PHG4ForwardEcalSubsystem::PHG4ForwardEcalSubsystem( const std::string &name, const int lyr ):
   PHG4Subsystem( name ),
   detector_( 0 ),
-  steppingAction_( NULL ),
-  eventAction_(NULL),
+  steppingAction_( nullptr ),
+  eventAction_(nullptr),
   active(1),
   absorber_active(0),
   blackhole(0),
@@ -47,7 +48,7 @@ int PHG4ForwardEcalSubsystem::Init( PHCompositeNode* topNode )
   detector_->SetActive(active);
   detector_->SetAbsorberActive(absorber_active);
   detector_->BlackHole(blackhole);
-  detector_->OverlapCheck(overlapcheck);
+  detector_->OverlapCheck(CheckOverlap());
   detector_->Verbosity(Verbosity());
   detector_->SetTowerMappingFile( mappingfile_ );
 

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystem.cc
@@ -41,7 +41,7 @@ int PHG4ForwardHcalSubsystem::Init( PHCompositeNode* topNode )
   detector_->SetActive(active);
   detector_->SetAbsorberActive(absorber_active);
   detector_->BlackHole(blackhole);
-  detector_->OverlapCheck(overlapcheck);
+  detector_->OverlapCheck(CheckOverlap());
   detector_->Verbosity(Verbosity());
   detector_->SetTowerMappingFile( mappingfile_ );
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSubsystem.cc
@@ -63,7 +63,7 @@ int PHG4HcalPrototypeSubsystem::Init( PHCompositeNode* topNode )
   detector_->SetAbsorberActive(absorberactive);
   detector_->BlackHole(blackhole);
   detector_->SuperDetector(superdetector);
-  detector_->OverlapCheck(overlapcheck);
+  detector_->OverlapCheck(CheckOverlap());
   if (active)
     {
       ostringstream nodename;

--- a/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
@@ -76,7 +76,7 @@ int PHG4HcalSubsystem::InitRun( PHCompositeNode* topNode )
   detector_->SetActive(active);
   detector_->SetAbsorberActive(absorberactive);
   detector_->SuperDetector(superdetector);
-  detector_->OverlapCheck(overlapcheck);
+  detector_->OverlapCheck(CheckOverlap());
   if (active)
     {
       ostringstream nodename;

--- a/simulation/g4simulation/g4detectors/PHG4RICHSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHSubsystem.cc
@@ -42,7 +42,7 @@ int PHG4RICHSubsystem::Init( PHCompositeNode* topNode )
   // create detector
   detector_ = new PHG4RICHDetector(topNode, geom);
   detector_->Verbosity(Verbosity());
-  detector_->OverlapCheck(overlapcheck);
+  detector_->OverlapCheck(CheckOverlap());
   
   // create stepping action
   

--- a/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.cc
@@ -32,7 +32,7 @@ PHG4SectorSubsystem::Init(PHCompositeNode* topNode)
   detector_ = new PHG4SectorDetector(topNode, Name());
   detector_->geom = geom;
   detector_->SuperDetector(superdetector);
-  detector_->OverlapCheck(overlapcheck);
+  detector_->OverlapCheck(CheckOverlap());
 
   if (geom.GetNumActiveLayers())
     {

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -157,9 +157,9 @@ libg4testbench_la_SOURCES = \
   $(ROOT5TBDICTS) \
   G4TBMagneticFieldSetup.cc \
   G4TBFieldMessenger.cc \
-  PHG4MagneticField.cc \
   HepMCNodeReader.cc \
   PHG4ConsistencyCheck.cc \
+  PHG4DisplayAction.cc \
   PHG4Detector.cc \
   PHG4HitReadBack.cc \
   PHG4EtaParameterization.cc \
@@ -169,6 +169,7 @@ libg4testbench_la_SOURCES = \
   PHG4InEventReadBack.cc \
   PHG4InputFilter.cc \
   PHG4IonGun.cc \
+  PHG4MagneticField.cc \
   PHG4ParticleGeneratorBase.cc \
   PHG4ParticleGenerator.cc \
   PHG4ParticleGeneratorVectorMeson.cc \
@@ -203,6 +204,7 @@ pkginclude_HEADERS = \
   PHBBox.h \
   PHG4ColorDefs.h \
   PHG4Detector.h \
+  PHG4DisplayAction.h \
   PHG4EventAction.h \
   PHG4EventHeader.h \
   PHG4HitDefs.h \

--- a/simulation/g4simulation/g4main/PHG4DisplayAction.cc
+++ b/simulation/g4simulation/g4main/PHG4DisplayAction.cc
@@ -1,11 +1,11 @@
 #include "PHG4DisplayAction.h"
 
-#include <Geant4/G4VPhysicalVolume.hh>
 #include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4VPhysicalVolume.hh>
 
 using namespace std;
 
-int PHG4DisplayAction::FindVolumes(G4VPhysicalVolume *physvol)
+int PHG4DisplayAction::FindVolumes(G4VPhysicalVolume* physvol)
 {
   int iret = 0;
   if (int chk = CheckVolume(physvol))
@@ -21,11 +21,11 @@ int PHG4DisplayAction::FindVolumes(G4VPhysicalVolume *physvol)
   int nDaughters = logvol->GetNoDaughters();
   if (nDaughters > 0)
   {
-    for (int i = 0; i<nDaughters; ++i)
+    for (int i = 0; i < nDaughters; ++i)
     {
       G4VPhysicalVolume* daughtervol = logvol->GetDaughter(i);
       //G4LogicalVolume* logicdaughter = daughtervol->GetLogicalVolume();
-    
+
       if (FindVolumes(daughtervol))
       {
         iret = -1;

--- a/simulation/g4simulation/g4main/PHG4DisplayAction.cc
+++ b/simulation/g4simulation/g4main/PHG4DisplayAction.cc
@@ -5,11 +5,17 @@
 
 using namespace std;
 
-void PHG4DisplayAction::FindVolumes(G4VPhysicalVolume *physvol)
+int PHG4DisplayAction::FindVolumes(G4VPhysicalVolume *physvol)
 {
-  if (CheckVolume(physvol))
+  int iret = 0;
+  if (int chk = CheckVolume(physvol))
   {
     ApplyVisAttributes(physvol);
+    if (chk == CheckReturnCodes::ABORT)
+    {
+      iret = -1;
+      return iret;
+    }
   }
   G4LogicalVolume* logvol = physvol->GetLogicalVolume();
   int nDaughters = logvol->GetNoDaughters();
@@ -20,7 +26,12 @@ void PHG4DisplayAction::FindVolumes(G4VPhysicalVolume *physvol)
       G4VPhysicalVolume* daughtervol = logvol->GetDaughter(i);
       //G4LogicalVolume* logicdaughter = daughtervol->GetLogicalVolume();
     
-      FindVolumes(daughtervol);
+      if (FindVolumes(daughtervol))
+      {
+        iret = -1;
+        return iret;
+      }
     }
   }
+  return iret;
 }

--- a/simulation/g4simulation/g4main/PHG4DisplayAction.cc
+++ b/simulation/g4simulation/g4main/PHG4DisplayAction.cc
@@ -1,0 +1,26 @@
+#include "PHG4DisplayAction.h"
+
+#include <Geant4/G4VPhysicalVolume.hh>
+#include <Geant4/G4LogicalVolume.hh>
+
+using namespace std;
+
+void PHG4DisplayAction::FindVolumes(G4VPhysicalVolume *physvol)
+{
+  if (CheckVolume(physvol))
+  {
+    ApplyVisAttributes(physvol);
+  }
+  G4LogicalVolume* logvol = physvol->GetLogicalVolume();
+  int nDaughters = logvol->GetNoDaughters();
+  if (nDaughters > 0)
+  {
+    for (int i = 0; i<nDaughters; ++i)
+    {
+      G4VPhysicalVolume* daughtervol = logvol->GetDaughter(i);
+      //G4LogicalVolume* logicdaughter = daughtervol->GetLogicalVolume();
+    
+      FindVolumes(daughtervol);
+    }
+  }
+}

--- a/simulation/g4simulation/g4main/PHG4DisplayAction.h
+++ b/simulation/g4simulation/g4main/PHG4DisplayAction.h
@@ -9,12 +9,15 @@ class G4VPhysicalVolume;
 
 class PHG4DisplayAction
 {
-public:
+ public:
   //! constructor
   // delete default ctor, nobody should use it
   PHG4DisplayAction() = delete;
   // this is the ctor we use
-  PHG4DisplayAction( const std::string &name ): m_Detector(name) {}
+  PHG4DisplayAction(const std::string &name)
+    : m_Detector(name)
+  {
+  }
 
   //! destructor
   virtual ~PHG4DisplayAction() {}
@@ -26,39 +29,40 @@ public:
    @param[in] physvol starting volume in hierarchy (typically world volume)
   */
 
-  virtual void ApplyDisplayAction(G4VPhysicalVolume* physvol) = 0;
+  virtual void ApplyDisplayAction(G4VPhysicalVolume *physvol) = 0;
 
-  virtual void SetName(const std::string &name) { m_Detector = name;}
+  virtual void SetName(const std::string &name) { m_Detector = name; }
 
-  virtual std::string GetName() const { return m_Detector;}
+  virtual std::string GetName() const { return m_Detector; }
 
-  enum CheckReturnCodes {ABORT = -1, FAILED = 0, ACCEPT = 1};
+  enum CheckReturnCodes
+  {
+    ABORT = -1,
+    FAILED = 0,
+    ACCEPT = 1
+  };
 
-protected:
-
-//! find FindVolume method
-/*
+ protected:
+  //! find FindVolume method
+  /*
  * @param[in] starting volume
  */
   int FindVolumes(G4VPhysicalVolume *physvol);
 
-//! find CheckVolume method
-/*
+  //! find CheckVolume method
+  /*
  * @param[in] physical volume to be checked
  */
-  virtual int CheckVolume(G4VPhysicalVolume *physvol) {return 0;}
+  virtual int CheckVolume(G4VPhysicalVolume *physvol) { return 0; }
 
   //! ApplyVisAttributes method
-/**
+  /**
  *@param[in] physvol selected physical volume
  */
-  virtual void ApplyVisAttributes(G4VPhysicalVolume *physvol) {return;}
+  virtual void ApplyVisAttributes(G4VPhysicalVolume *physvol) { return; }
 
-private:
-  
+ private:
   std::string m_Detector;
-
 };
 
-
-#endif // G4MAIN_PHG4DISPLAYACTION_H
+#endif  // G4MAIN_PHG4DISPLAYACTION_H

--- a/simulation/g4simulation/g4main/PHG4DisplayAction.h
+++ b/simulation/g4simulation/g4main/PHG4DisplayAction.h
@@ -1,0 +1,64 @@
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
+#ifndef G4MAIN_PHG4DISPLAYACTION_H
+#define G4MAIN_PHG4DISPLAYACTION_H
+
+#include <string>
+
+class G4VPhysicalVolume;
+
+class PHG4DisplayAction
+{
+public:
+  //! constructor
+  // delete default ctor, nobody should use it
+  PHG4DisplayAction() = delete;
+  // this is the ctor we use
+  PHG4DisplayAction( const std::string &name ): m_Detector(name) {}
+
+  //! destructor
+  virtual ~PHG4DisplayAction() {}
+
+  //! ApplyDisplayAction method
+  /**
+   pure virtual - has to be implemented by derived class
+   creates and set VisAttributes for volumes
+   @param[in] physvol starting volume in hierarchy (typically world volume)
+  */
+
+  virtual void ApplyDisplayAction(G4VPhysicalVolume* physvol) = 0;
+
+  virtual void SetName(const std::string &name) { m_Detector = name;}
+
+  virtual std::string GetName() const { return m_Detector;}
+
+
+
+protected:
+
+//! find FindVolume method
+/*
+ * @param[in] starting volume
+ */
+  void FindVolumes(G4VPhysicalVolume *physvol);
+
+//! find CheckVolume method
+/*
+ * @param[in] physical volume to be checked
+ */
+  virtual bool CheckVolume(G4VPhysicalVolume *physvol) {return false;}
+
+  //! ApplyVisAttributes method
+/**
+ *@param[in] physvol selected physical volume
+ */
+  virtual void ApplyVisAttributes(G4VPhysicalVolume *physvol) {return;}
+
+private:
+  
+  std::string m_Detector;
+
+};
+
+
+#endif // G4MAIN_PHG4DISPLAYACTION_H

--- a/simulation/g4simulation/g4main/PHG4DisplayAction.h
+++ b/simulation/g4simulation/g4main/PHG4DisplayAction.h
@@ -32,7 +32,7 @@ public:
 
   virtual std::string GetName() const { return m_Detector;}
 
-
+  enum CheckReturnCodes {ABORT = -1, FAILED = 0, ACCEPT = 1};
 
 protected:
 
@@ -40,13 +40,13 @@ protected:
 /*
  * @param[in] starting volume
  */
-  void FindVolumes(G4VPhysicalVolume *physvol);
+  int FindVolumes(G4VPhysicalVolume *physvol);
 
 //! find CheckVolume method
 /*
  * @param[in] physical volume to be checked
  */
-  virtual bool CheckVolume(G4VPhysicalVolume *physvol) {return false;}
+  virtual int CheckVolume(G4VPhysicalVolume *physvol) {return 0;}
 
   //! ApplyVisAttributes method
 /**

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -2,6 +2,7 @@
 
 #include "G4TBMagneticFieldSetup.hh"
 #include "PHG4InEvent.h"
+#include "PHG4DisplayAction.h"
 #include "PHG4PhenixDetector.h"
 #include "PHG4PhenixEventAction.h"
 #include "PHG4PhenixSteppingAction.h"
@@ -1400,5 +1401,26 @@ PHG4Reco::G4Verbosity(const int i)
   if (runManager_) 
   {
     runManager_->SetVerboseLevel(i);
+  }
+}
+
+void PHG4Reco::ApplyDisplayAction()
+{
+  if (! detector_)
+  {
+    return;
+  }
+  G4VPhysicalVolume* physworld = detector_->GetPhysicalVolume();
+  BOOST_FOREACH (PHG4Subsystem *g4sub, subsystems_) //for (PHG4Subsystem g4sub: subsystems_)
+  {
+    PHG4DisplayAction *action = g4sub->GetDisplayAction();
+    if (action)
+    {
+      if (Verbosity() > 1)
+      {
+        cout << "Adding steppingaction for " << g4sub->Name() << endl;
+      }
+      action->ApplyDisplayAction(physworld);
+    }
   }
 }

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -11,6 +11,8 @@
 
 // Forward declerations
 class PHCompositeNode;
+class G4LogicalVolume;
+class G4VPhysicalVolume;
 class G4RunManager;
 class PHG4PrimaryGeneratorAction;
 class PHG4PhenixDetector;
@@ -129,6 +131,7 @@ class PHG4Reco : public SubsysReco
 
   //! disable event/track/stepping actions to reduce resource consumption for G4 running only. E.g. dose analysis
   void setDisableUserActions(bool b = true) {m_disableUserActions = b;}
+  void ApplyDisplayAction();
 
  protected:
   int InitUImanager();

--- a/simulation/g4simulation/g4main/PHG4Subsystem.h
+++ b/simulation/g4simulation/g4main/PHG4Subsystem.h
@@ -1,5 +1,7 @@
-#ifndef PHG4Subsystem_h
-#define PHG4Subsystem_h
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
+#ifndef G4MAIN_PHG4SUBSYSTEM_H
+#define G4MAIN_PHG4SUBSYSTEM_H
 
 #include <fun4all/SubsysReco.h>
 
@@ -7,6 +9,7 @@
 #include <string>
 
 class PHG4Detector;
+class PHG4DisplayAction;
 class PHG4EventAction;
 class PHG4SteppingAction;
 class PHG4TrackingAction;
@@ -30,27 +33,31 @@ overlapcheck(false)
 
   //! return pointer to created detector object
   virtual PHG4Detector* GetDetector( void ) const
-  { return 0; }
+  { return nullptr; }
 
   //! return pointer to this subsystem event action
   virtual PHG4EventAction* GetEventAction( void ) const
-  { return 0; }
+  { return nullptr; }
 
   //! return pointer to this subsystem stepping action
   virtual PHG4SteppingAction* GetSteppingAction( void ) const
-  { return 0; }
+  { return nullptr; }
 
   //! return pointer to this subsystem stepping action
   virtual PHG4TrackingAction* GetTrackingAction( void ) const
-  { return 0; }
+  { return nullptr; }
+
+  //! return pointer to this subsystem display setting
+  virtual PHG4DisplayAction *GetDisplayAction() const
+  {return nullptr;}
 
   void OverlapCheck(const bool chk = true) {overlapcheck = chk;}
 
   bool CheckOverlap() const {return overlapcheck;}
 
- protected:
+ private:
   bool overlapcheck;
 
 };
 
-#endif
+#endif // G4MAIN_PHG4SUBSYSTEM_H


### PR DESCRIPTION
This PR introduces the PHG4DisplayAction which sets the G4VisAttributes on demand (when the detector is displayed), thus saving the memory those attributes waste when running normally. This is the first test implementation for the PHG4CylinderSubsystem. The DisplayOn.C macro needs to be adjusted to call this. If you forget you just get a wireframe when displaying the detector (better than nothing).
Also included - making 