### PR TITLE
Mvtx displayaction

### DIFF
--- a/simulation/g4simulation/g4main/PHG4DisplayAction.h
+++ b/simulation/g4simulation/g4main/PHG4DisplayAction.h
@@ -35,6 +35,8 @@ class PHG4DisplayAction
 
   virtual std::string GetName() const { return m_Detector; }
 
+  virtual void Print(const std::string &what="ALL") {}
+
   enum CheckReturnCodes
   {
     ABORT = -1,

--- a/simulation/g4simulation/g4mvtx/Makefile.am
+++ b/simulation/g4simulation/g4mvtx/Makefile.am
@@ -41,6 +41,7 @@ libg4mvtx_la_SOURCES = \
   $(ROOT5_DICTS) \
   PHG4MVTXHitReco.cc \
   PHG4MVTXDetector.cc \
+  PHG4MVTXDisplayAction.cc \
   PHG4MVTXSteppingAction.cc \
   PHG4MVTXSubsystem.cc \
   PHG4MVTXDigitizer.cc

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.cc
@@ -1,5 +1,8 @@
 #include "PHG4MVTXDetector.h"
+
 #include "PHG4MVTXDefs.h"
+#include "PHG4MVTXDisplayAction.h"
+#include "PHG4MVTXSubsystem.h"
 
 #include <mvtx/CylinderGeom_MVTX.h>
 
@@ -36,8 +39,9 @@
 
 using namespace std;
 
-PHG4MVTXDetector::PHG4MVTXDetector(PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam)
+PHG4MVTXDetector::PHG4MVTXDetector(PHG4MVTXSubsystem *subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam)
   : PHG4Detector(Node, dnam)
+  , m_DisplayAction(dynamic_cast<PHG4MVTXDisplayAction *>(subsys->GetDisplayAction()))
   , m_ParamsContainer(_paramsContainer)
   , stave_geometry_file(_paramsContainer->GetParameters(PHG4MVTXDefs::GLOBAL)->get_string_param("stave_geometry_file"))
 {
@@ -314,64 +318,23 @@ void PHG4MVTXDetector::SetDisplayProperty(G4LogicalVolume* lv)
   if (Verbosity() >= 5)
     cout << "SetDisplayProperty - LV " << lv->GetName() << " built with "
          << material_name << endl;
-
-  G4VisAttributes matVis;
-  if (material_name.find("SI") != std::string::npos)
+  vector<string> matname = {"SI","KAPTON", "ALUMINUM", "Carbon", "M60J3K", "WATER"} ;
+  bool found = false;
+  for (string nam : matname)
   {
-    PHG4Utils::SetColour(&matVis, "G4_Si");
-    matVis.SetVisibility(true);
-    matVis.SetForceSolid(true);
+    if (material_name.find(nam)!= std::string::npos)
+    {
+    m_DisplayAction->AddVolume(lv,nam);
     if (Verbosity() >= 5)
-      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with G4_Si" << endl;
+      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with " << nam << endl;
+    found = true;
+    break;
+    }
   }
-  else if (material_name.find("KAPTON") != std::string::npos)
+  if (! found)
   {
-    PHG4Utils::SetColour(&matVis, "G4_KAPTON");
-    matVis.SetVisibility(true);
-    matVis.SetForceSolid(true);
-    if (Verbosity() >= 5)
-      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with G4_KAPTON" << endl;
+    m_DisplayAction->AddVolume(lv,"ANYTHING_ELSE");
   }
-  else if (material_name.find("ALUMINUM") != std::string::npos)
-  {
-    PHG4Utils::SetColour(&matVis, "G4_Al");
-    matVis.SetVisibility(true);
-    matVis.SetForceSolid(true);
-    if (Verbosity() >= 5)
-      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with G4_Al" << endl;
-  }
-  else if (material_name.find("Carbon") != std::string::npos)
-  {
-    matVis.SetColour(0.5, 0.5, 0.5, .25);
-    matVis.SetVisibility(true);
-    matVis.SetForceSolid(true);
-    if (Verbosity() >= 5)
-      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with Gray" << endl;
-  }
-  else if (material_name.find("M60J3K") != std::string::npos)
-  {
-    matVis.SetColour(0.25, 0.25, 0.25, .25);
-    matVis.SetVisibility(true);
-    matVis.SetForceSolid(true);
-    if (Verbosity() >= 5)
-      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with Gray" << endl;
-  }
-  else if (material_name.find("WATER") != std::string::npos)
-  {
-    matVis.SetColour(0.0, 0.5, 0.0, .25);
-    matVis.SetVisibility(true);
-    matVis.SetForceSolid(true);
-    if (Verbosity() >= 5)
-      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with WATER" << endl;
-  }
-  else
-  {
-    matVis.SetColour(.2, .2, .7, .25);
-    matVis.SetVisibility(true);
-    matVis.SetForceSolid(true);
-  }
-  lv->SetVisAttributes(matVis);
-
   int nDaughters = lv->GetNoDaughters();
   for (int i = 0; i < nDaughters; ++i)
   {

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.cc
@@ -31,7 +31,6 @@
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4Colour.hh>
-#include <Geant4/G4VisAttributes.hh>
 
 #include <cmath>
 #include <memory>
@@ -68,10 +67,6 @@ PHG4MVTXDetector::PHG4MVTXDetector(PHG4MVTXSubsystem *subsys, PHCompositeNode* N
   pixel_thickness = alpide_params->get_double_param("pixel_thickness");
   if (Verbosity() > 0)
     cout << "PHG4MVTXDetector constructor: making MVTX detector. " << endl;
-}
-
-PHG4MVTXDetector::~PHG4MVTXDetector()
-{
 }
 
 //_______________________________________________________________

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.h
@@ -32,7 +32,7 @@ class PHG4MVTXDetector : public PHG4Detector
   PHG4MVTXDetector(PHG4MVTXSubsystem *subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam = "MVTX");
 
   //! destructor
-  virtual ~PHG4MVTXDetector();
+  virtual ~PHG4MVTXDetector(){}
 
   //! construct
   virtual void Construct(G4LogicalVolume* world);

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.h
@@ -1,5 +1,7 @@
-#ifndef PHG4MVTXDetector_h
-#define PHG4MVTXDetector_h
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef G4MVTX_PHG4MVTXDETECTOR_H
+#define G4MVTX_PHG4MVTXDETECTOR_H
 
 #include <g4main/PHG4Detector.h>
 
@@ -18,6 +20,8 @@ class G4AssemblyVolume;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4VSolid;
+class PHG4MVTXDisplayAction;
+class PHG4MVTXSubsystem;
 class PHParameters;
 class PHParametersContainer;
 
@@ -25,7 +29,7 @@ class PHG4MVTXDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4MVTXDetector(PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam = "MVTX");
+  PHG4MVTXDetector(PHG4MVTXSubsystem *subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam = "MVTX");
 
   //! destructor
   virtual ~PHG4MVTXDetector();
@@ -58,7 +62,7 @@ class PHG4MVTXDetector : public PHG4Detector
   void SetDisplayProperty(G4LogicalVolume* lv);
   void FillPVArray(G4AssemblyVolume* av);
   void FindSensor(G4LogicalVolume* lv);
-
+  PHG4MVTXDisplayAction *m_DisplayAction;
   const PHParametersContainer* m_ParamsContainer;
   static constexpr int n_Layers = 3;
 

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.cc
@@ -13,7 +13,6 @@ using namespace std;
 
 PHG4MVTXDisplayAction::PHG4MVTXDisplayAction(const std::string &name)
   : PHG4DisplayAction(name)
-  , m_MyVolume(nullptr)
 {
 }
 
@@ -70,19 +69,5 @@ void PHG4MVTXDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     visatt->SetForceSolid(true);
     logvol->SetVisAttributes(visatt);
   }
-  if (! m_MyVolume)
-  {
-    return;
-  }
-  if (m_MyVolume->GetVisAttributes())
-  {
-    return;
-  }
-  G4VisAttributes *visatt = new G4VisAttributes();
-  visatt = new G4VisAttributes();
-  visatt->SetVisibility(true);
-  visatt->SetForceSolid(true);
-  m_MyVolume->SetVisAttributes(visatt);
-  m_VisAttVec.push_back(visatt);
   return;
 }

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.cc
@@ -1,0 +1,88 @@
+#include "PHG4MVTXDisplayAction.h"
+
+#include <g4main/PHG4Utils.h>
+
+#include <Geant4/G4Color.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4VPhysicalVolume.hh>
+#include <Geant4/G4VisAttributes.hh>
+
+#include <iostream>
+
+using namespace std;
+
+PHG4MVTXDisplayAction::PHG4MVTXDisplayAction(const std::string &name)
+  : PHG4DisplayAction(name)
+  , m_MyVolume(nullptr)
+{
+}
+
+PHG4MVTXDisplayAction::~PHG4MVTXDisplayAction()
+{
+  for (auto &it : m_VisAttVec)
+  {
+    delete it;
+  }
+  m_VisAttVec.clear();
+}
+
+void PHG4MVTXDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
+{
+  // check if vis attributes exist, if so someone else has set them and we do nothing
+  for (auto it : m_LogicalVolumeMap)
+  {
+    G4LogicalVolume *logvol = it.first;
+    if (logvol->GetVisAttributes())
+    {
+      continue;
+    }
+    G4VisAttributes *visatt = new G4VisAttributes();
+    m_VisAttVec.push_back(visatt); // for later deletion
+    if (it.second == "Carbon")
+    {
+      visatt->SetColour(0.5, 0.5, 0.5, .25);
+    }
+    else if (it.second == "M60J3K")
+    {
+      visatt->SetColour(0.25, 0.25, 0.25, .25);
+    }
+    else if (it.second == "WATER")
+    {
+      visatt->SetColour(0.0, 0.5, 0.0, .25);
+    }
+    else if (it.second == "SI")
+    {
+      PHG4Utils::SetColour(visatt,"G4_Si");
+    }
+    else if (it.second == "KAPTON")
+    {
+      PHG4Utils::SetColour(visatt,"G4_KAPTON");
+    }
+    else if (it.second == "ALUMINUM")
+    {
+      PHG4Utils::SetColour(visatt,"G4_Al");
+    }
+    else
+    {
+      visatt->SetColour(.2, .2, .7, .25);
+    }
+    visatt->SetVisibility(true);
+    visatt->SetForceSolid(true);
+    logvol->SetVisAttributes(visatt);
+  }
+  if (! m_MyVolume)
+  {
+    return;
+  }
+  if (m_MyVolume->GetVisAttributes())
+  {
+    return;
+  }
+  G4VisAttributes *visatt = new G4VisAttributes();
+  visatt = new G4VisAttributes();
+  visatt->SetVisibility(true);
+  visatt->SetForceSolid(true);
+  m_MyVolume->SetVisAttributes(visatt);
+  m_VisAttVec.push_back(visatt);
+  return;
+}

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.h
@@ -21,11 +21,9 @@ PHG4MVTXDisplayAction(const std::string &name);
   virtual ~PHG4MVTXDisplayAction();
 
   void ApplyDisplayAction(G4VPhysicalVolume *physvol);
-  void SetMyVolume(G4LogicalVolume *vol) { m_MyVolume = vol; }
 void AddVolume(G4LogicalVolume *logvol, const std::string &mat) {m_LogicalVolumeMap[logvol] = mat;}
 
  private:
-  G4LogicalVolume *m_MyVolume;
   std::map<G4LogicalVolume *, std::string> m_LogicalVolumeMap;
   std::vector<G4VisAttributes *> m_VisAttVec;
 };

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.h
@@ -1,0 +1,33 @@
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4MVTXDISPLAYACTION_H
+#define G4DETECTORS_PHG4MVTXDISPLAYACTION_H
+
+#include <g4main/PHG4DisplayAction.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+class G4VisAttributes;
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+
+class PHG4MVTXDisplayAction : public PHG4DisplayAction
+{
+ public:
+PHG4MVTXDisplayAction(const std::string &name);
+
+  virtual ~PHG4MVTXDisplayAction();
+
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void SetMyVolume(G4LogicalVolume *vol) { m_MyVolume = vol; }
+void AddVolume(G4LogicalVolume *logvol, const std::string &mat) {m_LogicalVolumeMap[logvol] = mat;}
+
+ private:
+  G4LogicalVolume *m_MyVolume;
+  std::map<G4LogicalVolume *, std::string> m_LogicalVolumeMap;
+  std::vector<G4VisAttributes *> m_VisAttVec;
+};
+
+#endif  // G4DETECTORS_PHG4MVTXDISPLAYACTION_H

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.h
@@ -1,5 +1,7 @@
-#ifndef PHG4VMVTXSteppingAction_h
-#define PHG4VMVTXSteppingAction_h
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef G4MVTX_PHG4VMVTXSTEPPINGACTION_H
+#define G4MVTX_PHG4VMVTXSTEPPINGACTION_H
 
 #include <g4main/PHG4SteppingAction.h>
 
@@ -34,4 +36,4 @@ class PHG4MVTXSteppingAction : public PHG4SteppingAction
   PHG4Hit* hit;
 };
 
-#endif  // PHG4MVTXSteppingAction_h
+#endif  // G4MVTX_PHG4VMVTXSTEPPINGACTION_H

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.cc
@@ -24,7 +24,7 @@ using namespace std;
 //_______________________________________________________________________
 PHG4MVTXSubsystem::PHG4MVTXSubsystem(const std::string& name, const int _n_layers)
   : PHG4DetectorGroupSubsystem(name)
-  , detector_(nullptr)
+  , m_Detector(nullptr)
   , steppingAction_(nullptr)
   , m_DisplayAction(nullptr)
   , eventAction_(nullptr)
@@ -65,11 +65,11 @@ int PHG4MVTXSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   {
     cout << "    create MVTX detector with " << n_layers << " layers."  << endl;
   }
-  detector_ = new PHG4MVTXDetector(this, topNode, GetParamsContainer(), Name()/*, n_layers*/);
-  detector_->Verbosity(Verbosity());
-  detector_->SuperDetector(SuperDetector());
-  detector_->Detector(detector_type);
-  detector_->OverlapCheck(CheckOverlap());
+  m_Detector = new PHG4MVTXDetector(this, topNode, GetParamsContainer(), Name());
+  m_Detector->Verbosity(Verbosity());
+  m_Detector->SuperDetector(SuperDetector());
+  m_Detector->Detector(detector_type);
+  m_Detector->OverlapCheck(CheckOverlap());
   if (Verbosity())
   {
     cout << "    ------ created detector " << Name() << endl;
@@ -147,13 +147,13 @@ int PHG4MVTXSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
 
     eventAction_ = dynamic_cast<PHG4EventAction*>(eventaction);
     // create stepping action
-    steppingAction_ = new PHG4MVTXSteppingAction(detector_);
+    steppingAction_ = new PHG4MVTXSteppingAction(m_Detector);
   }
   else
   {
     if (blackhole)
     {
-      steppingAction_ = new PHG4MVTXSteppingAction(detector_);
+      steppingAction_ = new PHG4MVTXSteppingAction(m_Detector);
     }
   }
   return 0;
@@ -174,7 +174,7 @@ int PHG4MVTXSubsystem::process_event(PHCompositeNode* topNode)
 //_______________________________________________________________________
 PHG4Detector* PHG4MVTXSubsystem::GetDetector(void) const
 {
-  return detector_;
+  return m_Detector;
 }
 
 //_______________________________________________________________________

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.cc
@@ -1,6 +1,8 @@
 #include "PHG4MVTXSubsystem.h"
+
 #include "PHG4MVTXDefs.h"
 #include "PHG4MVTXDetector.h"
+#include "PHG4MVTXDisplayAction.h"
 #include "PHG4MVTXSteppingAction.h"
 
 #include <g4detectors/PHG4EventActionClearZeroEdep.h>
@@ -22,9 +24,10 @@ using namespace std;
 //_______________________________________________________________________
 PHG4MVTXSubsystem::PHG4MVTXSubsystem(const std::string& name, const int _n_layers)
   : PHG4DetectorGroupSubsystem(name)
-  , detector_(NULL)
-  , steppingAction_(NULL)
-  , eventAction_(NULL)
+  , detector_(nullptr)
+  , steppingAction_(nullptr)
+  , m_DisplayAction(nullptr)
+  , eventAction_(nullptr)
   , n_layers(_n_layers)
   , detector_type(name)
 {
@@ -40,6 +43,12 @@ PHG4MVTXSubsystem::PHG4MVTXSubsystem(const std::string& name, const int _n_layer
 }
 
 //_______________________________________________________________________
+PHG4MVTXSubsystem::~PHG4MVTXSubsystem()
+{
+  delete m_DisplayAction;
+}
+
+//_______________________________________________________________________
 int PHG4MVTXSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
 {
   if (Verbosity() > 0)
@@ -48,13 +57,15 @@ int PHG4MVTXSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   PHNodeIterator iter(topNode);
   PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
 
+  // create display settings before detector (detector adds its volumes to it)
+  m_DisplayAction = new PHG4MVTXDisplayAction(Name());
   // create detector
   // These values are set from the calling macro using the setters defined in the .h file
   if (Verbosity())
   {
     cout << "    create MVTX detector with " << n_layers << " layers."  << endl;
   }
-  detector_ = new PHG4MVTXDetector(topNode, GetParamsContainer(), Name()/*, n_layers*/);
+  detector_ = new PHG4MVTXDetector(this, topNode, GetParamsContainer(), Name()/*, n_layers*/);
   detector_->Verbosity(Verbosity());
   detector_->SuperDetector(SuperDetector());
   detector_->Detector(detector_type);

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.h
@@ -1,13 +1,15 @@
-#ifndef PHG4MVTXSubsystem_h
-#define PHG4MVTXSubsystem_h
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4MVTX_PHG4MVTXSUBSYSTEM_H
+#define G4MVTX_PHG4MVTXSUBSYSTEM_H
 
 #include <g4detectors/PHG4DetectorGroupSubsystem.h>
 
-#include <Geant4/G4String.hh>
 #include <Geant4/G4Types.hh>
 
 class PHG4MVTXDetector;
 class PHG4MVTXSteppingAction;
+class PHG4DisplayAction;
 class PHG4EventAction;
 
 class PHG4MVTXSubsystem : public PHG4DetectorGroupSubsystem
@@ -17,14 +19,13 @@ class PHG4MVTXSubsystem : public PHG4DetectorGroupSubsystem
   PHG4MVTXSubsystem(const std::string& name = "MVTX", const int _n_layers = 3);
 
   //! destructor
-  virtual ~PHG4MVTXSubsystem(void)
-  {
-  }
+  virtual ~PHG4MVTXSubsystem();
 
-  //! init
+  //! InitRunSubsystem
   /*!
-  creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
-  reates the stepping action and place it on the node tree, under "ACTIONS" node
+  called during InitRun (the original InitRun does common setup and calls this one)
+  creates the detector object 
+  ceates the stepping action 
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
   int InitRunSubsystem(PHCompositeNode*);
@@ -40,6 +41,8 @@ class PHG4MVTXSubsystem : public PHG4DetectorGroupSubsystem
   virtual PHG4Detector* GetDetector(void) const;
   virtual PHG4SteppingAction* GetSteppingAction(void) const;
 
+  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+
   PHG4EventAction* GetEventAction() const { return eventAction_; }
 
  private:
@@ -52,6 +55,11 @@ class PHG4MVTXSubsystem : public PHG4DetectorGroupSubsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
   PHG4MVTXSteppingAction* steppingAction_;
+
+  //! display attribute setting
+  /*! derives from PHG4DisplayAction */
+  PHG4DisplayAction* m_DisplayAction;
+
   PHG4EventAction* eventAction_;
 
   // These are passed on to the detector class

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.h
@@ -5,8 +5,6 @@
 
 #include <g4detectors/PHG4DetectorGroupSubsystem.h>
 
-#include <Geant4/G4Types.hh>
-
 class PHG4MVTXDetector;
 class PHG4MVTXSteppingAction;
 class PHG4DisplayAction;
@@ -50,7 +48,7 @@ class PHG4MVTXSubsystem : public PHG4DetectorGroupSubsystem
 
   //! detector geometry
   /*! defives from PHG4Detector */
-  PHG4MVTXDetector* detector_;
+  PHG4MVTXDetector* m_Detector;
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
@@ -63,7 +61,6 @@ class PHG4MVTXSubsystem : public PHG4DetectorGroupSubsystem
   PHG4EventAction* eventAction_;
 
   // These are passed on to the detector class
-  G4double layer_nominal_radius;
   unsigned int n_layers;
 
   std::string detector_type;


### PR DESCRIPTION
This PR implements the DisplayAction for the mvtx. It mimics what was done for the mvtx in terms of color selections. This fixes also some memory leaks. The mvtx code still uses the event action to drop zero energy hits which wastes memory and cpu. That will be tackled seperately in some subsequent PR