### PR TITLE
Mvtx Eventaction replacement

### DIFF
--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.cc
@@ -19,6 +19,7 @@
 
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4Box.hh>
+#include <Geant4/G4Colour.hh>
 #include <Geant4/G4ExtrudedSolid.hh>
 #include <Geant4/G4GDMLParser.hh>
 #include <Geant4/G4IntersectionSolid.hh>
@@ -30,7 +31,6 @@
 #include <Geant4/G4Trap.hh>
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4TwoVector.hh>
-#include <Geant4/G4Colour.hh>
 
 #include <cmath>
 #include <memory>
@@ -38,9 +38,9 @@
 
 using namespace std;
 
-PHG4MVTXDetector::PHG4MVTXDetector(PHG4MVTXSubsystem *subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam)
+PHG4MVTXDetector::PHG4MVTXDetector(PHG4MVTXSubsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam)
   : PHG4Detector(Node, dnam)
-  , m_DisplayAction(dynamic_cast<PHG4MVTXDisplayAction *>(subsys->GetDisplayAction()))
+  , m_DisplayAction(dynamic_cast<PHG4MVTXDisplayAction*>(subsys->GetDisplayAction()))
   , m_ParamsContainer(_paramsContainer)
   , stave_geometry_file(_paramsContainer->GetParameters(PHG4MVTXDefs::GLOBAL)->get_string_param("stave_geometry_file"))
 {
@@ -54,12 +54,12 @@ PHG4MVTXDetector::PHG4MVTXDetector(PHG4MVTXSubsystem *subsys, PHCompositeNode* N
   for (int ilayer = 0; ilayer < n_Layers; ++ilayer)
   {
     const PHParameters* params = m_ParamsContainer->GetParameters(ilayer);
-    m_IsLayerActive[ilayer]         = params->get_int_param("active");
+    m_IsLayerActive[ilayer] = params->get_int_param("active");
     m_IsLayerAbsorberActive[ilayer] = params->get_int_param("absorberactive");
-    m_IsBlackHole[ilayer]           = params->get_int_param("blackhole");
-    m_N_staves[ilayer]              = params->get_int_param("N_staves");
-    m_nominal_radius[ilayer]        = params->get_double_param("layer_nominal_radius");
-    m_nominal_phitilt[ilayer]       = params->get_double_param("phitilt");
+    m_IsBlackHole[ilayer] = params->get_int_param("blackhole");
+    m_N_staves[ilayer] = params->get_int_param("N_staves");
+    m_nominal_radius[ilayer] = params->get_double_param("layer_nominal_radius");
+    m_nominal_phitilt[ilayer] = params->get_double_param("phitilt");
   }
   const PHParameters* alpide_params = m_ParamsContainer->GetParameters(PHG4MVTXDefs::ALPIDE_SEGMENTATION);
   pixel_x = alpide_params->get_double_param("pixel_x");
@@ -95,7 +95,7 @@ int PHG4MVTXDetector::IsInMVTX(G4VPhysicalVolume* volume, int& layer, int& stave
   // Since the Assembly volume read from GDML does not give unique pointers
   // to sensors, we need to check the stave, which is unique
   auto iter = m_StavePV.find(volume);
-  if ( iter != m_StavePV.end())
+  if (iter != m_StavePV.end())
   {
     tie(layer, stave) = iter->second;
     if (Verbosity() > 0)
@@ -118,7 +118,7 @@ int PHG4MVTXDetector::get_layer(int index) const
   // Get MVTX layer from stave index in the MVTX
   // MVTX stave index start from 0, i.e index = 0 for stave 0 in layer 0
   int lay = 0;
-  while ( !(index < m_N_staves[lay]) )
+  while (!(index < m_N_staves[lay]))
   {
     index -= m_N_staves[lay];
     lay++;
@@ -130,7 +130,7 @@ int PHG4MVTXDetector::get_stave(int index) const
 {
   // Get stave index in the layer from stave index in the MVTX
   int lay = 0;
-  while ( !(index < m_N_staves[lay]) )
+  while (!(index < m_N_staves[lay]))
   {
     index -= m_N_staves[lay];
     lay++;
@@ -230,7 +230,7 @@ int PHG4MVTXDetector::ConstructMVTX_Layer(int layer, G4AssemblyVolume* av_ITSUSt
     }
   }
 
-  G4double phistep = get_phistep(layer); // this produces even stave spacing
+  G4double phistep = get_phistep(layer);  // this produces even stave spacing
   double z_location = 0.0;
 
   if (Verbosity() > 0)
@@ -313,22 +313,22 @@ void PHG4MVTXDetector::SetDisplayProperty(G4LogicalVolume* lv)
   if (Verbosity() >= 5)
     cout << "SetDisplayProperty - LV " << lv->GetName() << " built with "
          << material_name << endl;
-  vector<string> matname = {"SI","KAPTON", "ALUMINUM", "Carbon", "M60J3K", "WATER"} ;
+  vector<string> matname = {"SI", "KAPTON", "ALUMINUM", "Carbon", "M60J3K", "WATER"};
   bool found = false;
   for (string nam : matname)
   {
-    if (material_name.find(nam)!= std::string::npos)
+    if (material_name.find(nam) != std::string::npos)
     {
-    m_DisplayAction->AddVolume(lv,nam);
-    if (Verbosity() >= 5)
-      cout << "SetDisplayProperty - LV " << lv->GetName() << " display with " << nam << endl;
-    found = true;
-    break;
+      m_DisplayAction->AddVolume(lv, nam);
+      if (Verbosity() >= 5)
+        cout << "SetDisplayProperty - LV " << lv->GetName() << " display with " << nam << endl;
+      found = true;
+      break;
     }
   }
-  if (! found)
+  if (!found)
   {
-    m_DisplayAction->AddVolume(lv,"ANYTHING_ELSE");
+    m_DisplayAction->AddVolume(lv, "ANYTHING_ELSE");
   }
   int nDaughters = lv->GetNoDaughters();
   for (int i = 0; i < nDaughters; ++i)
@@ -345,7 +345,7 @@ void PHG4MVTXDetector::SetDisplayProperty(G4LogicalVolume* lv)
 void PHG4MVTXDetector::AddGeometryNode()
 {
   int active = 0;
-  for ( auto& isAct: m_IsLayerActive)
+  for (auto& isAct : m_IsLayerActive)
     active |= isAct;
 
   if (active)
@@ -375,13 +375,13 @@ void PHG4MVTXDetector::AddGeometryNode()
                                                         pixel_z,
                                                         pixel_thickness);
       geo->AddLayerGeom(ilayer, mygeom);
-    } // loop per layers
+    }  // loop per layers
     if (Verbosity())
     {
       geo->identify();
     }
-  } //is active
-} // AddGeometryNode
+  }  //is active
+}  // AddGeometryNode
 
 void PHG4MVTXDetector::FillPVArray(G4AssemblyVolume* av)
 {
@@ -415,7 +415,7 @@ void PHG4MVTXDetector::FillPVArray(G4AssemblyVolume* av)
 
       FindSensor(worldLogical);
     }
-    else // in case of stave structure
+    else  // in case of stave structure
     {
       if (Verbosity() > 0)
       {
@@ -440,7 +440,7 @@ void PHG4MVTXDetector::FindSensor(G4LogicalVolume* lv)
       m_SensorPV.insert(pv);
 
       if (Verbosity() > 0)
-        cout << "                      Adding Sensor Vol <" << pv->GetName() << " (" << m_SensorPV.size() << ")>"<< endl;
+        cout << "                      Adding Sensor Vol <" << pv->GetName() << " (" << m_SensorPV.size() << ")>" << endl;
     }
 
     G4LogicalVolume* worldLogical = pv->GetLogicalVolume();

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.h
@@ -5,11 +5,6 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/G4RotationMatrix.hh>
-#include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4Types.hh>
-#include <Geant4/globals.hh>
-
 #include <array>
 #include <map>
 #include <set>
@@ -46,10 +41,10 @@ class PHG4MVTXDetector : public PHG4Detector
   int IsActive(int lyr) const { return m_IsLayerActive[lyr]; }
   int IsAbsorberActive(int lyr) const { return m_IsLayerAbsorberActive[lyr]; }
   int IsBlackHole(int lyr) const { return m_IsBlackHole[lyr]; }
-  void SuperDetector(const std::string& name) { superdetector = name; }
-  const std::string SuperDetector() const { return superdetector; }
-  void Detector(const std::string& name) { detector_type = name; }
-  const std::string Detector() const { return detector_type; }
+  void SuperDetector(const std::string& name) { m_SuperDetector = name; }
+  const std::string SuperDetector() const { return m_SuperDetector; }
+  void Detector(const std::string& name) { m_Detector = name; }
+  const std::string Detector() const { return m_Detector; }
 
   int get_layer(int stv_index) const;
   int get_stave(int stv_index) const;
@@ -62,9 +57,12 @@ class PHG4MVTXDetector : public PHG4Detector
   void SetDisplayProperty(G4LogicalVolume* lv);
   void FillPVArray(G4AssemblyVolume* av);
   void FindSensor(G4LogicalVolume* lv);
+  // calculated quantities
+  double get_phistep(int lay) const { return 2.0 * M_PI /  m_N_staves[lay]; }
+
+  static constexpr int n_Layers = 3;
   PHG4MVTXDisplayAction* m_DisplayAction;
   const PHParametersContainer* m_ParamsContainer;
-  static constexpr int n_Layers = 3;
 
   // map of sensor physical volume pointers
   std::set<G4VPhysicalVolume*> m_SensorPV;
@@ -75,19 +73,17 @@ class PHG4MVTXDetector : public PHG4Detector
   std::array<int, n_Layers> m_IsLayerAbsorberActive;
   std::array<int, n_Layers> m_IsBlackHole;
   std::array<int, n_Layers> m_N_staves;
-  std::array<G4double, n_Layers> m_nominal_radius;
-  std::array<G4double, n_Layers> m_nominal_phitilt;
+  std::array<double, n_Layers> m_nominal_radius;
+  std::array<double, n_Layers> m_nominal_phitilt;
   // sensor parameters
-  double pixel_x;
-  double pixel_z;
-  double pixel_thickness;
+  double m_PixelX;
+  double m_PixelZ;
+  double m_PixelThickness;
 
-  // calculated quantities
-  G4double get_phistep(int lay) const { return 2.0 * M_PI / (double) m_N_staves[lay]; }
 
-  std::string detector_type;
-  std::string superdetector;
-  std::string stave_geometry_file;
+  std::string m_Detector;
+  std::string m_SuperDetector;
+  std::string m_StaveGeometryFile;
 };
 
 #endif

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDetector.h
@@ -29,10 +29,10 @@ class PHG4MVTXDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4MVTXDetector(PHG4MVTXSubsystem *subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam = "MVTX");
+  PHG4MVTXDetector(PHG4MVTXSubsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam = "MVTX");
 
   //! destructor
-  virtual ~PHG4MVTXDetector(){}
+  virtual ~PHG4MVTXDetector() {}
 
   //! construct
   virtual void Construct(G4LogicalVolume* world);
@@ -62,7 +62,7 @@ class PHG4MVTXDetector : public PHG4Detector
   void SetDisplayProperty(G4LogicalVolume* lv);
   void FillPVArray(G4AssemblyVolume* av);
   void FindSensor(G4LogicalVolume* lv);
-  PHG4MVTXDisplayAction *m_DisplayAction;
+  PHG4MVTXDisplayAction* m_DisplayAction;
   const PHParametersContainer* m_ParamsContainer;
   static constexpr int n_Layers = 3;
 

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.cc
@@ -36,7 +36,7 @@ void PHG4MVTXDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
       continue;
     }
     G4VisAttributes *visatt = new G4VisAttributes();
-    m_VisAttVec.push_back(visatt); // for later deletion
+    m_VisAttVec.push_back(visatt);  // for later deletion
     if (it.second == "Carbon")
     {
       visatt->SetColour(0.5, 0.5, 0.5, .25);
@@ -51,15 +51,15 @@ void PHG4MVTXDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     }
     else if (it.second == "SI")
     {
-      PHG4Utils::SetColour(visatt,"G4_Si");
+      PHG4Utils::SetColour(visatt, "G4_Si");
     }
     else if (it.second == "KAPTON")
     {
-      PHG4Utils::SetColour(visatt,"G4_KAPTON");
+      PHG4Utils::SetColour(visatt, "G4_KAPTON");
     }
     else if (it.second == "ALUMINUM")
     {
-      PHG4Utils::SetColour(visatt,"G4_Al");
+      PHG4Utils::SetColour(visatt, "G4_Al");
     }
     else
     {

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXDisplayAction.h
@@ -16,12 +16,12 @@ class G4VPhysicalVolume;
 class PHG4MVTXDisplayAction : public PHG4DisplayAction
 {
  public:
-PHG4MVTXDisplayAction(const std::string &name);
+  PHG4MVTXDisplayAction(const std::string &name);
 
   virtual ~PHG4MVTXDisplayAction();
 
   void ApplyDisplayAction(G4VPhysicalVolume *physvol);
-void AddVolume(G4LogicalVolume *logvol, const std::string &mat) {m_LogicalVolumeMap[logvol] = mat;}
+  void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
 
  private:
   std::map<G4LogicalVolume *, std::string> m_LogicalVolumeMap;

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.cc
@@ -12,6 +12,7 @@
 
 #include <Geant4/G4NavigationHistory.hh>
 #include <Geant4/G4Step.hh>
+#include <Geant4/G4SystemOfUnits.hh>
 
 #include <boost/foreach.hpp>
 #include <boost/tokenizer.hpp>

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.cc
@@ -130,7 +130,7 @@ bool PHG4MVTXSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
   if (Verbosity() > 0)
     cout << endl
-    << "  UserSteppingAction: layer " << layer_id;
+         << "  UserSteppingAction: layer " << layer_id;
   boost::char_separator<char> sep("_");
   boost::tokenizer<boost::char_separator<char> >::const_iterator tokeniter;
 
@@ -217,9 +217,9 @@ bool PHG4MVTXSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     {
     case fGeomBoundary:
     case fUndefined:
-      if (! m_Hit)
+      if (!m_Hit)
       {
-	m_Hit = new PHG4Hitv1();
+        m_Hit = new PHG4Hitv1();
       }
       m_Hit->set_layer((unsigned int) layer_id);
 
@@ -258,16 +258,16 @@ bool PHG4MVTXSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       // time in ns
       m_Hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
       //set the track ID
-        m_Hit->set_trkid(aTrack->GetTrackID());
-        if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      m_Hit->set_trkid(aTrack->GetTrackID());
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
-          if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
-          {
-            m_Hit->set_trkid(pp->GetUserTrackId());
-            m_Hit->set_shower_id(pp->GetShower()->get_id());
-            m_SaveShower = pp->GetShower();
-          }
+          m_Hit->set_trkid(pp->GetUserTrackId());
+          m_Hit->set_shower_id(pp->GetShower()->get_id());
+          m_SaveShower = pp->GetShower();
         }
+      }
       //set the initial energy deposit
       m_Hit->set_edep(0);
 

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.cc
@@ -14,7 +14,6 @@
 #include <Geant4/G4Step.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 
-#include <boost/foreach.hpp>
 #include <boost/tokenizer.hpp>
 // this is an ugly hack, the gcc optimizer has a bug which
 // triggers the uninitialized variable warning which

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.h
@@ -14,16 +14,16 @@ class PHG4MVTXSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  PHG4MVTXSteppingAction(PHG4MVTXDetector*);
+  PHG4MVTXSteppingAction(PHG4MVTXDetector *);
 
   //! destroctor
   virtual ~PHG4MVTXSteppingAction();
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  virtual bool UserSteppingAction(const G4Step *, bool);
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode*);
+  virtual void SetInterfacePointers(PHCompositeNode *);
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSteppingAction.h
@@ -8,6 +8,7 @@
 class PHG4MVTXDetector;
 class PHG4Hit;
 class PHG4HitContainer;
+class PHG4Shower;
 
 class PHG4MVTXSteppingAction : public PHG4SteppingAction
 {
@@ -16,9 +17,7 @@ class PHG4MVTXSteppingAction : public PHG4SteppingAction
   PHG4MVTXSteppingAction(PHG4MVTXDetector*);
 
   //! destroctor
-  virtual ~PHG4MVTXSteppingAction()
-  {
-  }
+  virtual ~PHG4MVTXSteppingAction();
 
   //! stepping action
   virtual bool UserSteppingAction(const G4Step*, bool);
@@ -28,12 +27,13 @@ class PHG4MVTXSteppingAction : public PHG4SteppingAction
 
  private:
   //! pointer to the detector
-  PHG4MVTXDetector* detector_;
+  PHG4MVTXDetector *m_Detector;
 
   //! pointer to hit container
-  PHG4HitContainer* hits_;
-  PHG4HitContainer* absorberhits_;
-  PHG4Hit* hit;
+  PHG4HitContainer *m_HitContainer;
+  PHG4HitContainer *m_AbsorberhitContainer;
+  PHG4Hit *m_Hit;
+  PHG4Shower *m_SaveShower;
 };
 
 #endif  // G4MVTX_PHG4VMVTXSTEPPINGACTION_H

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.cc
@@ -60,7 +60,7 @@ int PHG4MVTXSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   // These values are set from the calling macro using the setters defined in the .h file
   if (Verbosity())
   {
-    cout << "    create MVTX detector with " << n_layers << " layers."  << endl;
+    cout << "    create MVTX detector with " << n_layers << " layers." << endl;
   }
   m_Detector = new PHG4MVTXDetector(this, topNode, GetParamsContainer(), Name());
   m_Detector->Verbosity(Verbosity());
@@ -137,7 +137,6 @@ int PHG4MVTXSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
       }
       if (Verbosity())
         cout << PHWHERE << "creating hits node " << nodename.str() << endl;
-
     }
 
     // create stepping action
@@ -181,24 +180,26 @@ void PHG4MVTXSubsystem::SetDefaultParameters()
 {
   //TODO: Move to defMVTX at some point
   const int kNLr = 3;
-  enum { kRmn,
-         kRmd,
-         kRmx,
-         kNModPerStave,
-         kPhi0,
-         kNStave,
-         kNPar };
+  enum
+  {
+    kRmn,
+    kRmd,
+    kRmx,
+    kNModPerStave,
+    kPhi0,
+    kNStave,
+    kNPar
+  };
   // Radii are from last TDR (ALICE-TDR-017.pdf Tab. 1.1, rMid is mean value)
   const double mvtxdat[kNLr][kNPar] = {
-    { 22.4, 23.4, 26.7, 9., 0., 12. }, // for each layer: rMin,rMid,rMax,NChip/Stave, phi0, nStaves
-    { 30.1, 31.5, 34.6, 9., 0., 16. },
-    { 37.8, 39.3, 42.1, 9., 0., 20. }
-  };
+      {22.4, 23.4, 26.7, 9., 0., 12.},  // for each layer: rMin,rMid,rMax,NChip/Stave, phi0, nStaves
+      {30.1, 31.5, 34.6, 9., 0., 16.},
+      {37.8, 39.3, 42.1, 9., 0., 20.}};
 
   for (set<int>::const_iterator lyr_it = GetDetIds().first; lyr_it != GetDetIds().second; ++lyr_it)
   {
     const int& ilyr = *lyr_it;
-    set_default_int_param(ilyr, "active", 1); //non-automatic initialization in PHG4DetectorGroupSubsystem
+    set_default_int_param(ilyr, "active", 1);  //non-automatic initialization in PHG4DetectorGroupSubsystem
     set_default_int_param(ilyr, "layer", ilyr);
     set_default_int_param(ilyr, "N_staves", mvtxdat[ilyr][kNStave]);
 

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.cc
@@ -5,8 +5,6 @@
 #include "PHG4MVTXDisplayAction.h"
 #include "PHG4MVTXSteppingAction.h"
 
-#include <g4detectors/PHG4EventActionClearZeroEdep.h>
-
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
 
@@ -27,7 +25,6 @@ PHG4MVTXSubsystem::PHG4MVTXSubsystem(const std::string& name, const int _n_layer
   , m_Detector(nullptr)
   , steppingAction_(nullptr)
   , m_DisplayAction(nullptr)
-  , eventAction_(nullptr)
   , n_layers(_n_layers)
   , detector_type(name)
 {
@@ -122,7 +119,6 @@ int PHG4MVTXSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
     if (Verbosity())
       cout << PHWHERE << "creating hits node " << nodename.str() << endl;
 
-    PHG4EventActionClearZeroEdep* eventaction = new PHG4EventActionClearZeroEdep(topNode, nodename.str());
     if (absorberactive)
     {
       nodename.str("");
@@ -142,10 +138,8 @@ int PHG4MVTXSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
       if (Verbosity())
         cout << PHWHERE << "creating hits node " << nodename.str() << endl;
 
-      eventaction->AddNode(nodename.str());
     }
 
-    eventAction_ = dynamic_cast<PHG4EventAction*>(eventaction);
     // create stepping action
     steppingAction_ = new PHG4MVTXSteppingAction(m_Detector);
   }

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.h
@@ -8,7 +8,6 @@
 class PHG4MVTXDetector;
 class PHG4MVTXSteppingAction;
 class PHG4DisplayAction;
-class PHG4EventAction;
 
 class PHG4MVTXSubsystem : public PHG4DetectorGroupSubsystem
 {
@@ -41,7 +40,6 @@ class PHG4MVTXSubsystem : public PHG4DetectorGroupSubsystem
 
   PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
 
-  PHG4EventAction* GetEventAction() const { return eventAction_; }
 
  private:
   void SetDefaultParameters();
@@ -57,8 +55,6 @@ class PHG4MVTXSubsystem : public PHG4DetectorGroupSubsystem
   //! display attribute setting
   /*! derives from PHG4DisplayAction */
   PHG4DisplayAction* m_DisplayAction;
-
-  PHG4EventAction* eventAction_;
 
   // These are passed on to the detector class
   unsigned int n_layers;

--- a/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MVTXSubsystem.h
@@ -40,7 +40,6 @@ class PHG4MVTXSubsystem : public PHG4DetectorGroupSubsystem
 
   PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
 
-
  private:
   void SetDefaultParameters();
 


### PR DESCRIPTION
This PR replaces the old event action which was used to remove zero energy hits. This functionality is now done in the steppingaction where we pick up the last step in a volume and add the hit only if it has some energy loss. Not sure if the entry condition is up to date (we have a few more condition to start a hit in others). Also the mvtx does not provide for the creation and saving of absorber/support structure hits