### PR TITLE
Displayaction intt

### DIFF
--- a/simulation/g4simulation/g4intt/Makefile.am
+++ b/simulation/g4simulation/g4intt/Makefile.am
@@ -66,7 +66,7 @@ libg4intt_la_SOURCES = \
   PHG4INTTDisplayAction.cc \
   PHG4InttDigitizer.cc \
   PHG4INTTHitReco.cc \
-  PHG4INTTParameterisation.cc \
+  PHG4INTTFPHXParameterisation.cc \
   PHG4INTTSteppingAction.cc \
   PHG4INTTSubsystem.cc
 

--- a/simulation/g4simulation/g4intt/Makefile.am
+++ b/simulation/g4simulation/g4intt/Makefile.am
@@ -30,12 +30,12 @@ libg4intt_la_LIBADD = \
   -lintt_io
 
 pkginclude_HEADERS = \
-  PHG4INTTHitReco.h \
-  PHG4INTTDefs.h \
   INTTDeadMap.h \
   INTTDeadMapv1.h \
-  PHG4INTTSubsystem.h \
-  PHG4InttDigitizer.h 
+  PHG4InttDigitizer.h  \
+  PHG4INTTDefs.h \
+  PHG4INTTHitReco.h \
+  PHG4INTTSubsystem.h
 
 ROOTDICTS = \
   INTTDeadMap_Dict.cc \
@@ -62,12 +62,13 @@ libg4intt_io_la_SOURCES = \
 libg4intt_la_SOURCES = \
   $(ROOT5_DICTS) \
   PHG4INTTDeadMapLoader.cc \
+  PHG4INTTDetector.cc \
+  PHG4INTTDisplayAction.cc \
   PHG4InttDigitizer.cc \
   PHG4INTTHitReco.cc \
-  PHG4INTTDetector.cc \
+  PHG4INTTParameterisation.cc \
   PHG4INTTSteppingAction.cc \
-  PHG4INTTSubsystem.cc \
-  PHG4INTTParameterisation.cc
+  PHG4INTTSubsystem.cc
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h

--- a/simulation/g4simulation/g4intt/Makefile.am
+++ b/simulation/g4simulation/g4intt/Makefile.am
@@ -32,7 +32,7 @@ libg4intt_la_LIBADD = \
 pkginclude_HEADERS = \
   INTTDeadMap.h \
   INTTDeadMapv1.h \
-  PHG4InttDigitizer.h  \
+  PHG4INTTDigitizer.h  \
   PHG4INTTDefs.h \
   PHG4INTTHitReco.h \
   PHG4INTTSubsystem.h
@@ -49,7 +49,7 @@ else
   ROOT5_DICTS = \
     PHG4INTTDeadMapLoader_Dict.cc \
     PHG4INTTDefs_Dict.cc \
-    PHG4InttDigitizer_Dict.cc \
+    PHG4INTTDigitizer_Dict.cc \
     PHG4INTTHitReco_Dict.cc \
     PHG4INTTSubsystem_Dict.cc
 endif
@@ -64,7 +64,7 @@ libg4intt_la_SOURCES = \
   PHG4INTTDeadMapLoader.cc \
   PHG4INTTDetector.cc \
   PHG4INTTDisplayAction.cc \
-  PHG4InttDigitizer.cc \
+  PHG4INTTDigitizer.cc \
   PHG4INTTHitReco.cc \
   PHG4INTTFPHXParameterisation.cc \
   PHG4INTTSteppingAction.cc \

--- a/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
@@ -30,7 +30,6 @@
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4GenericTrap.hh>
-#include <Geant4/G4VisAttributes.hh>
 
 #include <array>
 #include <boost/foreach.hpp>
@@ -185,11 +184,6 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       {
         m_ActiveLogVols.insert(siactive_volume);
       }
-      // G4VisAttributes siactive_vis;
-      // siactive_vis.SetVisibility(true);
-      // siactive_vis.SetForceSolid(true);
-      // siactive_vis.SetColour(G4Colour::White());
-      // siactive_volume->SetVisAttributes(siactive_vis);
       m_DisplayAction->AddVolume(siactive_volume,"SiActive");
       // We do not subdivide the sensor in G4. We will assign hits to strips in the stepping action, using the geometry object
 
@@ -209,12 +203,7 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       {
         m_PassiveVolumeTuple.insert(make_pair(siinactive_volume, make_tuple(inttlayer, PHG4INTTDefs::SI_INACTIVE)));
       }
-      G4VisAttributes siinactive_vis;
-      siinactive_vis.SetVisibility(true);
-      siinactive_vis.SetForceSolid(true);
-      siinactive_vis.SetColour(G4Colour::Red());
-      siinactive_volume->SetVisAttributes(siinactive_vis);
-
+      m_DisplayAction->AddVolume(siinactive_volume,"SiInActive");
       // Make the HDI Kapton and copper volumes
 
       // This makes HDI volumes that matche this sensor in Z length
@@ -254,18 +243,8 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       {
         m_PassiveVolumeTuple.insert(make_pair(hdiext_copper_volume, make_tuple(inttlayer, PHG4INTTDefs::HDIEXT_COPPER)));
       }
-      G4VisAttributes hdi_kapton_vis;
-      hdi_kapton_vis.SetVisibility(true);
-      hdi_kapton_vis.SetForceSolid(true);
-      hdi_kapton_vis.SetColour(G4Colour::Yellow());
-      hdi_kapton_volume->SetVisAttributes(hdi_kapton_vis);
-      hdiext_kapton_volume->SetVisAttributes(hdi_kapton_vis);
-      G4VisAttributes hdi_copper_vis;
-      hdi_copper_vis.SetVisibility(true);
-      hdi_copper_vis.SetForceSolid(true);
-      hdi_copper_vis.SetColour(G4Colour::White());
-      hdi_copper_volume->SetVisAttributes(hdi_copper_vis);
-      hdiext_copper_volume->SetVisAttributes(hdi_copper_vis);
+      m_DisplayAction->AddVolume(hdiext_kapton_volume,"HdiKapton");
+      m_DisplayAction->AddVolume(hdiext_copper_volume,"HdiCopper");
 
       // FPHX
       G4VSolid *fphx_box = new G4Box((boost::format("fphx_box_%d_%d") % inttlayer % itype).str(), fphx_x / 2., fphx_y / 2., fphx_z / 2.);
@@ -275,12 +254,7 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       {
         m_PassiveVolumeTuple.insert(make_pair(fphx_volume, make_tuple(inttlayer, PHG4INTTDefs::FPHX)));
       }
-
-      G4VisAttributes fphx_vis;
-      fphx_vis.SetVisibility(true);
-      fphx_vis.SetForceSolid(true);
-      fphx_vis.SetColour(G4Colour::Blue());
-      fphx_volume->SetVisAttributes(fphx_vis);
+      m_DisplayAction->AddVolume(fphx_volume,"FPHX");
 
       const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx") * cm;
 
@@ -341,13 +315,8 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       {
         m_PassiveVolumeTuple.insert(make_pair(pgsext_volume, make_tuple(inttlayer, PHG4INTTDefs::PGSEXT)));
       }
-      G4VisAttributes pgs_vis;
-      pgs_vis.SetVisibility(true);
-      pgs_vis.SetForceSolid(true);
-      pgs_vis.SetColour(G4Colour::Red());
-      pgs_volume->SetVisAttributes(pgs_vis);
-      pgsext_volume->SetVisAttributes(pgs_vis);
-
+      m_DisplayAction->AddVolume(pgs_volume,"PGS");
+      m_DisplayAction->AddVolume(pgsext_volume,"PGS");
       double stave_x = 0.;  // we do not include the PGS in the stave volume
       double stave_y = 0.;
       G4LogicalVolume *stave_volume = NULL;
@@ -401,12 +370,8 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
         {
           m_PassiveVolumeTuple.insert(make_pair(stave_curve_ext_volume[i], make_tuple(inttlayer, PHG4INTTDefs::STAVEEXT_CURVE)));
         }
-        G4VisAttributes stave_curve_vis;
-        stave_curve_vis.SetVisibility(true);
-        stave_curve_vis.SetForceSolid(true);
-        stave_curve_vis.SetColour(G4Colour::Grey());
-        stave_curve_volume[i]->SetVisAttributes(stave_curve_vis);
-        stave_curve_ext_volume[i]->SetVisAttributes(stave_curve_vis);
+        m_DisplayAction->AddVolume(stave_curve_volume[i],"StaveCurve");
+        m_DisplayAction->AddVolume(stave_curve_ext_volume[i],"StaveCurve");
       }
 
       // we will need the length in y of the curved section as it is installed in the stave box
@@ -468,22 +433,18 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
         m_PassiveVolumeTuple.insert(make_pair(stave_straight_cooler_ext_volume, make_tuple(inttlayer, PHG4INTTDefs::STAVEEXT_STRAIGHT_COOLER)));
       }
 
-      G4VisAttributes stave_vis;
-      stave_vis.SetVisibility(true);
-      stave_vis.SetForceSolid(true);
-      stave_vis.SetColour(G4Colour::Grey());
-      stave_straight_cooler_volume->SetVisAttributes(stave_vis);
-      stave_straight_cooler_ext_volume->SetVisAttributes(stave_vis);
+      m_DisplayAction->AddVolume(stave_straight_cooler_volume, "StaveCooler");
+      m_DisplayAction->AddVolume(stave_straight_cooler_ext_volume, "StaveCooler");
       if (laddertype == PHG4INTTDefs::SEGMENTATION_PHI)
       {
-        stave_straight_inner_volume->SetVisAttributes(stave_vis);
+	m_DisplayAction->AddVolume(stave_straight_inner_volume,"StaveStraightInner");
       }
       if (laddertype == PHG4INTTDefs::SEGMENTATION_PHI)
       {
-        stave_straight_inner_ext_volume->SetVisAttributes(stave_vis);
+	m_DisplayAction->AddVolume(stave_straight_inner_ext_volume,"StaveStraightInner");
       }
-      stave_straight_outer_volume->SetVisAttributes(stave_vis);
-      stave_straight_outer_ext_volume->SetVisAttributes(stave_vis);
+	m_DisplayAction->AddVolume(stave_straight_outer_volume,"StaveStraightOuter");
+	m_DisplayAction->AddVolume(stave_straight_outer_ext_volume,"StaveStraightOuter");
 
       // Now we combine the elements of a stave defined above into a stave
       // Create a stave volume to install the stave sections into. The volume has to be big enouigh to contain the cooling tube
@@ -523,12 +484,8 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"),
                                            (boost::format("staveext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
 
-      G4VisAttributes stave_box_vis;
-      stave_box_vis.SetVisibility(false);
-      stave_box_vis.SetForceSolid(false);
-      stave_volume->SetVisAttributes(stave_box_vis);
-      staveext_volume->SetVisAttributes(stave_box_vis);
-
+      m_DisplayAction->AddVolume(stave_volume,"StaveBox");
+      m_DisplayAction->AddVolume(staveext_volume,"StaveBox");
       // Assemble the elements into the stave volume and the stave extension volume
       // They are place relative to the center of the stave box. Thus the offset of the center of the segment is relative to the center of the satev box.
       // But we want the segment to be located relative to the lowest x limit of the stave box.
@@ -729,12 +686,8 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
         {
           m_PassiveVolumeTuple.insert(make_pair(stave_curve_ext_volume[i], make_tuple(inttlayer, PHG4INTTDefs::STAVEEXT_CURVE)));
         }
-        G4VisAttributes stave_curve_vis;
-        stave_curve_vis.SetVisibility(true);
-        stave_curve_vis.SetForceSolid(true);
-        stave_curve_vis.SetColour(G4Colour::Grey());
-        stave_curve_volume[i]->SetVisAttributes(stave_curve_vis);
-        stave_curve_ext_volume[i]->SetVisAttributes(stave_curve_vis);
+        m_DisplayAction->AddVolume(stave_curve_volume[i],"StaveCurve");
+        m_DisplayAction->AddVolume(stave_curve_ext_volume[i],"StaveCurve");
       }
 
       // we will need the length in y of the curved section as it is installed in the stave box
@@ -801,16 +754,12 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
         m_PassiveVolumeTuple.insert(make_pair(stave_slant_cooler_ext_volume, make_tuple(inttlayer, PHG4INTTDefs::STAVEEXT_STRAIGHT_COOLER)));
       }
 
-      G4VisAttributes stave_vis;
-      stave_vis.SetVisibility(true);
-      stave_vis.SetForceSolid(true);
-      stave_vis.SetColour(G4Colour::Grey());
-      stave_straight_cooler_volume->SetVisAttributes(stave_vis);
-      stave_straight_cooler_ext_volume->SetVisAttributes(stave_vis);
-      stave_straight_outer_volume->SetVisAttributes(stave_vis);
-      stave_straight_outer_ext_volume->SetVisAttributes(stave_vis);
-      stave_slant_cooler_volume->SetVisAttributes(stave_vis);
-      stave_slant_cooler_ext_volume->SetVisAttributes(stave_vis);
+      m_DisplayAction->AddVolume(stave_straight_cooler_volume,"StaveCooler");
+      m_DisplayAction->AddVolume(stave_straight_cooler_ext_volume,"StaveCooler");
+      m_DisplayAction->AddVolume(stave_straight_outer_volume,"StaveStraightOuter");
+      m_DisplayAction->AddVolume(stave_straight_outer_ext_volume,"StaveStraightOuter");
+      m_DisplayAction->AddVolume(stave_slant_cooler_volume,"StaveCooler");
+      m_DisplayAction->AddVolume(stave_slant_cooler_ext_volume,"StaveCooler");
 
       // cooling pipe + water inside + glue outside
       G4VSolid *stave_glue_box = new G4Box((boost::format("stave_glue_box_%d_%d") % inttlayer % itype).str(), 3./2, 3./2., stave_z / 2.);
@@ -820,12 +769,8 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       G4LogicalVolume *staveext_glue_volume = new G4LogicalVolume(staveext_glue_box, G4Material::GetMaterial("Epoxy"),
                                                           (boost::format("staveext_glue_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
 
-      G4VisAttributes stave_glue_box_vis;
-      stave_glue_box_vis.SetVisibility(true);
-      stave_glue_box_vis.SetForceSolid(true);
-      stave_glue_box_vis.SetColour(G4Colour::Cyan());
-      stave_glue_volume->SetVisAttributes(stave_glue_box_vis);
-      staveext_glue_volume->SetVisAttributes(stave_glue_box_vis);
+      m_DisplayAction->AddVolume(stave_glue_volume,"StaveGlueBox");
+      m_DisplayAction->AddVolume(staveext_glue_volume,"StaveGlueBox");
 
       G4VSolid *stave_pipe_cons = new G4Tubs((boost::format("stave_pipe_cons_%d_%d") % inttlayer % itype).str(),
                                               Rpmin, Rpmax, stave_z / 2., -M_PI, 2.0 * M_PI);
@@ -837,12 +782,8 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       G4LogicalVolume *staveext_pipe_volume = new G4LogicalVolume(staveext_pipe_cons, G4Material::GetMaterial("CFRP_INTT"),
                                                         (boost::format("staveext_pipe_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
 
-      G4VisAttributes stave_pipe_vis;
-      stave_pipe_vis.SetVisibility(true);
-      stave_pipe_vis.SetForceSolid(true);
-      stave_pipe_vis.SetColour(G4Colour::White());
-      stave_pipe_volume->SetVisAttributes(stave_pipe_vis);
-      staveext_pipe_volume->SetVisAttributes(stave_pipe_vis);
+      m_DisplayAction->AddVolume(stave_pipe_volume,"StavePipe");
+      m_DisplayAction->AddVolume(staveext_pipe_volume,"StavePipe");
 
       G4VSolid *stave_water_cons = new G4Tubs((boost::format("stave_water_cons_%d_%d") % inttlayer % itype ).str(),
                                               0., Rpmin, stave_z / 2., -M_PI, 2.0 * M_PI);
@@ -854,12 +795,8 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       G4LogicalVolume *staveext_water_volume = new G4LogicalVolume(staveext_water_cons, G4Material::GetMaterial("G4_WATER"),
                                                         (boost::format("staveext_water_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
 
-      G4VisAttributes stave_water_vis;
-      stave_water_vis.SetVisibility(true);
-      stave_water_vis.SetForceSolid(true);
-      stave_water_vis.SetColour(G4Colour::Blue());
-      stave_water_volume->SetVisAttributes(stave_water_vis);
-      staveext_water_volume->SetVisAttributes(stave_water_vis);
+      m_DisplayAction->AddVolume(stave_water_volume,"StaveWater");
+      m_DisplayAction->AddVolume(staveext_water_volume,"StaveWater");
 
       //rohacell foam
       //straight boxes
@@ -927,19 +864,14 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
                                                          (boost::format("rohacellext_trap_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
       }
 
-      G4VisAttributes stave_rohacell_vis;
-      stave_rohacell_vis.SetVisibility(true);
-      stave_rohacell_vis.SetForceSolid(true);
-      stave_rohacell_vis.SetColour(G4Colour::White());
-
-      rohacell_straight_volume->SetVisAttributes(stave_rohacell_vis);
-      rohacellext_straight_volume->SetVisAttributes(stave_rohacell_vis);
+      m_DisplayAction->AddVolume(rohacell_straight_volume,"RohaCell");
+      m_DisplayAction->AddVolume(rohacellext_straight_volume,"RohaCell");
       for(int i=0; i<2; i++)
       {
-      rohacell_curve_volume[i]->SetVisAttributes(stave_rohacell_vis);
-      rohacellext_curve_volume[i]->SetVisAttributes(stave_rohacell_vis);
-      rohacell_trap_volume[i]->SetVisAttributes(stave_rohacell_vis);
-      rohacellext_trap_volume[i]->SetVisAttributes(stave_rohacell_vis);
+      m_DisplayAction->AddVolume(rohacell_curve_volume[i],"RohaCell");
+      m_DisplayAction->AddVolume(rohacellext_curve_volume[i],"RohaCell");
+      m_DisplayAction->AddVolume(rohacell_trap_volume[i],"RohaCell");
+      m_DisplayAction->AddVolume(rohacellext_trap_volume[i],"RohaCell");
       }
 
       // Now we combine the elements of a stave defined above into a stave
@@ -980,11 +912,8 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"),
                                            (boost::format("staveext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
 
-      G4VisAttributes stave_box_vis;
-      stave_box_vis.SetVisibility(false);
-      stave_box_vis.SetForceSolid(false);
-      stave_volume->SetVisAttributes(stave_box_vis);
-      staveext_volume->SetVisAttributes(stave_box_vis);
+      m_DisplayAction->AddVolume(stave_volume,"StaveBox");
+      m_DisplayAction->AddVolume(staveext_volume,"StaveBox");
 
       // Assemble the elements into the stave volume and the stave extension volume
       // They are place relative to the center of the stave box. Thus the offset of the center of the segment is relative to the center of the satev box.
@@ -1241,12 +1170,8 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
 
       G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), (boost::format("ladderext_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
 
-      G4VisAttributes ladder_vis;
-      ladder_vis.SetVisibility(false);
-      ladder_vis.SetForceSolid(false);
-      ladder_vis.SetColour(G4Colour::Cyan());
-      ladder_volume->SetVisAttributes(ladder_vis);
-      ladderext_volume->SetVisAttributes(ladder_vis);
+      m_DisplayAction->AddVolume(ladder_volume,"Ladder");
+      m_DisplayAction->AddVolume(ladderext_volume,"Ladder");
 
       // Now add the components of the ladder to the ladder volume
       // The sensor is closest to the beam pipe, the stave cooler is furthest away
@@ -1410,11 +1335,7 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
   {
     m_PassiveVolumeTuple.insert(make_pair(rail_volume, make_tuple(PHG4INTTDefs::SUPPORT_DETID, PHG4INTTDefs::SUPPORT_RAIL)));
   }
-  G4VisAttributes rail_vis;
-  rail_vis.SetVisibility(true);
-  rail_vis.SetForceSolid(true);
-  rail_vis.SetColour(G4Colour::Cyan());
-  rail_volume->SetVisAttributes(rail_vis);
+  m_DisplayAction->AddVolume(rail_volume,"Rail");
 
   double rail_dphi = supportparams->get_double_param("rail_dphi") * deg / rad;
   double rail_phi_start = supportparams->get_double_param("rail_phi_start") * deg / rad;
@@ -1461,9 +1382,9 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
     m_PassiveVolumeTuple.insert(make_pair(outer_skin_foam_volume, make_tuple(PHG4INTTDefs::SUPPORT_DETID, PHG4INTTDefs::INTT_OUTER_SKIN)));
     m_PassiveVolumeTuple.insert(make_pair(outer_skin_cfcout_volume, make_tuple(PHG4INTTDefs::SUPPORT_DETID, PHG4INTTDefs::INTT_OUTER_SKIN)));
   }
-  outer_skin_cfcin_volume->SetVisAttributes(rail_vis);
-  outer_skin_foam_volume->SetVisAttributes(rail_vis);
-  outer_skin_cfcout_volume->SetVisAttributes(rail_vis);
+  m_DisplayAction->AddVolume(outer_skin_cfcin_volume,"Rail");
+  m_DisplayAction->AddVolume(outer_skin_foam_volume,"Rail");
+  m_DisplayAction->AddVolume(outer_skin_cfcout_volume,"Rail");
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), outer_skin_cfcin_volume,
                     "si_support_outer_skin_cfcin", trackerenvelope, false, 0, OverlapCheck());
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), outer_skin_foam_volume,
@@ -1484,7 +1405,7 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
   {
     m_PassiveVolumeTuple.insert(make_pair(inner_skin_volume, make_tuple(PHG4INTTDefs::SUPPORT_DETID, PHG4INTTDefs::INTT_INNER_SKIN)));
   }
-  inner_skin_volume->SetVisAttributes(rail_vis);
+  m_DisplayAction->AddVolume(inner_skin_volume,"Rail");
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), inner_skin_volume,
                     "si_support_inner_skin", trackerenvelope, false, 0, OverlapCheck());
 
@@ -1608,7 +1529,7 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
                                                                       "mvtx_shell_inner_skin_volume", 0, 0, 0);
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_inner_skin_volume,
                     "mvtx_shell_inner_skin", trackerenvelope, false, 0, OverlapCheck());
-  mvtx_shell_inner_skin_volume->SetVisAttributes(rail_vis);
+  m_DisplayAction->AddVolume(mvtx_shell_inner_skin_volume,"Rail");
 
   G4Tubs *mvtx_shell_foam_core_tube = new G4Tubs("mvtx_shell_foam_core",
                                                  mvtx_shell_foam_core_inner_radius, mvtx_shell_foam_core_inner_radius + foam_core_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
@@ -1616,7 +1537,7 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
                                                                      "mvtx_shell_foam_core_volume", 0, 0, 0);
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_foam_core_volume,
                     "mvtx_shell_foam_core", trackerenvelope, false, 0, OverlapCheck());
-  mvtx_shell_foam_core_volume->SetVisAttributes(rail_vis);
+  m_DisplayAction->AddVolume(mvtx_shell_foam_core_volume,"Rail");
 
   G4Tubs *mvtx_shell_outer_skin_tube = new G4Tubs("mvtx_shell_outer_skin",
                                                   mvtx_shell_outer_skin_inner_radius, mvtx_shell_outer_skin_inner_radius + skin_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
@@ -1624,7 +1545,7 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
                                                                       "mvtx_shell_outer_skin_volume", 0, 0, 0);
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_outer_skin_volume,
                     "mvtx_shell_outer_skin", trackerenvelope, false, 0, OverlapCheck());
-  mvtx_shell_outer_skin_volume->SetVisAttributes(rail_vis);
+  m_DisplayAction->AddVolume(mvtx_shell_outer_skin_volume,"Rail");
   return 0;
 }
 

--- a/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
@@ -1,7 +1,7 @@
 #include "PHG4INTTDetector.h"
 
 #include "PHG4INTTDisplayAction.h"
-#include "PHG4INTTParameterisation.h"
+#include "PHG4INTTFPHXParameterisation.h"
 #include "PHG4INTTSubsystem.h"
 
 #include <intt/CylinderGeomINTT.h>

--- a/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
@@ -295,7 +295,7 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       G4VPVParameterisation *fphxparam = new PHG4INTTFPHXParameterisation(offsetx, +offsety, offsetz, 2. * cell_length_z / 2., ncopy);
       new G4PVParameterised((boost::format("fphxcontainer_%d_%d") % inttlayer % itype).str(),
                             fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, OverlapCheck());
-
+//      delete fphxparam;
       // PGS   - this is the carbon sheet that the HDI sits on. It forms the wall of the cooling tube that cools the HDI
 
       const double pgs_y = hdi_y;
@@ -911,6 +911,9 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
 
       staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"),
                                            (boost::format("staveext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+// the rotation matrices are just used by G4VSolid, ownership is not taken over
+      delete stv_rot_pos;
+      delete stv_rot_neg;
 
       m_DisplayAction->AddVolume(stave_volume,"StaveBox");
       m_DisplayAction->AddVolume(staveext_volume,"StaveBox");
@@ -1169,7 +1172,9 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       G4VSolid *ladderext_box = new G4SubtractionSolid((boost::format("ladderext_box_%d_%d") % inttlayer % itype).str(), ladderext_box1, ladderext_subtbox, lad_box_rotneg, ladTransneg);
 
       G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), (boost::format("ladderext_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-
+// the rotation matrices are just used by G4VSolid, ownership is not taken over
+      delete lad_box_rotpos;
+      delete lad_box_rotneg;
       m_DisplayAction->AddVolume(ladder_volume,"Ladder");
       m_DisplayAction->AddVolume(ladderext_volume,"Ladder");
 

--- a/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
@@ -295,7 +295,6 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       G4VPVParameterisation *fphxparam = new PHG4INTTFPHXParameterisation(offsetx, +offsety, offsetz, 2. * cell_length_z / 2., ncopy);
       new G4PVParameterised((boost::format("fphxcontainer_%d_%d") % inttlayer % itype).str(),
                             fphx_volume, fphxcontainer_volume, kZAxis, ncopy, fphxparam, OverlapCheck());
-//      delete fphxparam;
       // PGS   - this is the carbon sheet that the HDI sits on. It forms the wall of the cooling tube that cools the HDI
 
       const double pgs_y = hdi_y;

--- a/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTDetector.cc
@@ -1,5 +1,8 @@
 #include "PHG4INTTDetector.h"
+
+#include "PHG4INTTDisplayAction.h"
 #include "PHG4INTTParameterisation.h"
+#include "PHG4INTTSubsystem.h"
 
 #include <intt/CylinderGeomINTT.h>
 
@@ -36,8 +39,9 @@
 
 using namespace std;
 
-PHG4INTTDetector::PHG4INTTDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const pair<vector<pair<int, int>>::const_iterator, vector<pair<int, int>>::const_iterator> &layer_b_e)
+PHG4INTTDetector::PHG4INTTDetector(PHG4INTTSubsystem* subsys, PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const pair<vector<pair<int, int>>::const_iterator, vector<pair<int, int>>::const_iterator> &layer_b_e)
   : PHG4Detector(Node, dnam)
+  , m_DisplayAction(dynamic_cast<PHG4INTTDisplayAction*>(subsys->GetDisplayAction()))
   , m_ParamsContainer(parameters)
   , m_IsSupportActive(0)
   , m_IsEndcapActive(0)
@@ -181,12 +185,12 @@ int PHG4INTTDetector::ConstructINTT(G4LogicalVolume *trackerenvelope)
       {
         m_ActiveLogVols.insert(siactive_volume);
       }
-      G4VisAttributes siactive_vis;
-      siactive_vis.SetVisibility(true);
-      siactive_vis.SetForceSolid(true);
-      siactive_vis.SetColour(G4Colour::White());
-      siactive_volume->SetVisAttributes(siactive_vis);
-
+      // G4VisAttributes siactive_vis;
+      // siactive_vis.SetVisibility(true);
+      // siactive_vis.SetForceSolid(true);
+      // siactive_vis.SetColour(G4Colour::White());
+      // siactive_volume->SetVisAttributes(siactive_vis);
+      m_DisplayAction->AddVolume(siactive_volume,"SiActive");
       // We do not subdivide the sensor in G4. We will assign hits to strips in the stepping action, using the geometry object
 
       // Si-sensor full (active+inactive) area

--- a/simulation/g4simulation/g4intt/PHG4INTTDetector.h
+++ b/simulation/g4simulation/g4intt/PHG4INTTDetector.h
@@ -14,13 +14,15 @@
 
 class G4LogicalVolume;
 class G4VPhysicalVolume;
+class PHG4INTTDisplayAction;
+class PHG4INTTSubsystem;
 class PHParametersContainer;
 
 class PHG4INTTDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4INTTDetector(PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::vector<std::pair<int, int>>::const_iterator, std::vector<std::pair<int, int>>::const_iterator> &layer_b_e);
+  PHG4INTTDetector(PHG4INTTSubsystem* subsys, PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::vector<std::pair<int, int>>::const_iterator, std::vector<std::pair<int, int>>::const_iterator> &layer_b_e);
 
   //! destructor
   virtual ~PHG4INTTDetector() {}
@@ -56,6 +58,7 @@ class PHG4INTTDetector : public PHG4Detector
   void AddGeometryNode();
   int ConstructINTT(G4LogicalVolume *sandwich);
 
+  PHG4INTTDisplayAction* m_DisplayAction;
   PHParametersContainer *m_ParamsContainer;
 
   std::string m_DetectorType;

--- a/simulation/g4simulation/g4intt/PHG4INTTDigitizer.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTDigitizer.cc
@@ -1,0 +1,339 @@
+// This is the new trackbase container version
+
+#include "PHG4INTTDigitizer.h"
+
+#include "INTTDeadMap.h"
+
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderGeom.h>
+#include <g4detectors/PHG4CylinderGeomContainer.h>
+
+// Move to new storage containers
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContainer.h>
+#include <trackbase/TrkrHitTruthAssoc.h>
+#include <trackbase/TrkrDefs.h>
+#include <intt/InttDefs.h>
+#include <intt/InttHit.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHRandomSeed.h>
+#include <phool/getClass.h>
+
+#include <TSystem.h>
+
+#include <gsl/gsl_randist.h>
+
+#include <cfloat>
+#include <cmath>
+#include <iostream>
+#include <cassert>
+
+using namespace std;
+
+PHG4INTTDigitizer::PHG4INTTDigitizer(const string &name)
+  : SubsysReco(name)
+  , PHParameterInterface(name)
+  , detector("INTT")
+  , mNoiseMean(457.2)
+  , mNoiseSigma(166.6)
+  , mEnergyPerPair(3.62e-9)  // GeV/e-h
+  , m_nCells(0)
+  , m_nDeadCells(0)
+{
+  InitializeParameters();
+  unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
+  cout << Name() << " random seed: " << seed << endl;
+  RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
+  gsl_rng_set(RandomGenerator, seed);
+}
+
+PHG4INTTDigitizer::~PHG4INTTDigitizer()
+{
+  gsl_rng_free(RandomGenerator);
+}
+
+int PHG4INTTDigitizer::InitRun(PHCompositeNode *topNode)
+{
+  cout << "PHG4INTTDigitizer::InitRun: detector = " << detector << endl;
+
+  //-------------
+  // Add Hit Node
+  //-------------
+
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    cout << PHWHERE << "DST Node missing, doing nothing." << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  CalculateLadderCellADCScale(topNode);
+
+  // Create the run and par nodes
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "PAR"));
+
+  string paramnodename = "G4CELLPARAM_" + detector;
+  string geonodename = "G4CELLGEO_" + detector;
+
+  UpdateParametersWithMacro();
+  // save this to the run wise tree to store on DST
+  PHNodeIterator runIter(runNode);
+  PHCompositeNode *RunDetNode = dynamic_cast<PHCompositeNode *>(runIter.findFirst("PHCompositeNode", detector));
+  if (!RunDetNode)
+  {
+    RunDetNode = new PHCompositeNode(detector);
+    runNode->addNode(RunDetNode);
+  }
+  SaveToNodeTree(RunDetNode, paramnodename);
+  // save this to the parNode for use
+  PHNodeIterator parIter(parNode);
+  PHCompositeNode *ParDetNode = dynamic_cast<PHCompositeNode *>(parIter.findFirst("PHCompositeNode", detector));
+  if (!ParDetNode)
+  {
+    ParDetNode = new PHCompositeNode(detector);
+    parNode->addNode(ParDetNode);
+  }
+  PutOnParNode(ParDetNode, geonodename);
+  mNoiseMean = get_double_param("NoiseMean");
+  mNoiseSigma = get_double_param("NoiseSigma");
+  mEnergyPerPair = get_double_param("EnergyPerPair");
+
+  //----------------
+  // Report Settings
+  //----------------
+
+  if (Verbosity() > 0)
+  {
+    cout << "====================== PHG4INTTDigitizer::InitRun() =====================" << endl;
+    for (std::map<int, unsigned int>::iterator iter = _max_adc.begin();
+         iter != _max_adc.end();
+         ++iter)
+    {
+      cout << " Max ADC in Layer #" << iter->first << " = " << iter->second << endl;
+    }
+    for (std::map<int, float>::iterator iter = _energy_scale.begin();
+         iter != _energy_scale.end();
+         ++iter)
+    {
+      cout << " Energy per ADC in Layer #" << iter->first << " = " << 1.0e6 * iter->second << " keV" << endl;
+    }
+    cout << "===========================================================================" << endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4INTTDigitizer::process_event(PHCompositeNode *topNode)
+{
+  DigitizeLadderCells(topNode);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void PHG4INTTDigitizer::CalculateLadderCellADCScale(PHCompositeNode *topNode)
+{
+  // FPHX 3-bit ADC, thresholds are set in "set_fphx_adc_scale".
+
+  //PHG4CellContainer *cells = findNode::getClass<PHG4CellContainer>(topNode, "G4CELL_INTT");
+  PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
+
+  //if (!geom_container || !cells) return;
+  if (!geom_container) return;
+
+  PHG4CylinderGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
+  for (PHG4CylinderGeomContainer::ConstIterator layeriter = layerrange.first;
+       layeriter != layerrange.second;
+       ++layeriter)
+  {
+    int layer = layeriter->second->get_layer();
+    if (_max_fphx_adc.find(layer) == _max_fphx_adc.end())
+    {
+      cout << "Error: _max_fphx_adc is not available." << endl;
+      gSystem->Exit(1);
+    }
+    float thickness = (layeriter->second)->get_thickness();  // cm
+    float mip_e = 0.003876 * thickness;                      // GeV
+    _energy_scale.insert(std::make_pair(layer, mip_e));
+  }
+
+  return;
+}
+
+void PHG4INTTDigitizer::DigitizeLadderCells(PHCompositeNode *topNode)
+{
+  //---------------------------
+  // Get common Nodes
+  //---------------------------
+  const INTTDeadMap *deadmap = findNode::getClass<INTTDeadMap>(topNode, "DEADMAP_INTT");
+  if (Verbosity() >= VERBOSITY_MORE)
+  {
+    if (deadmap)
+    {
+      cout << "PHG4INTTDigitizer::DigitizeLadderCells - Use deadmap ";
+      deadmap->identify();
+    }
+    else
+    {
+      cout << "PHG4INTTDigitizer::DigitizeLadderCells - Can not find deadmap, all channels enabled " << endl;
+    }
+  }
+
+  // Get the TrkrHitSetContainer node
+  TrkrHitSetContainer *trkrhitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
+  if(!trkrhitsetcontainer)
+    {
+      cout << "Could not locate TRKR_HITSET node, quit! " << endl;
+      exit(1);
+    }
+
+ //-------------
+  // Digitization
+  //-------------
+
+  // We want all hitsets for the INTT
+  TrkrHitSetContainer::ConstRange hitset_range = trkrhitsetcontainer->getHitSets(TrkrDefs::TrkrId::inttId);
+  for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range.first;
+       hitset_iter != hitset_range.second;
+       ++hitset_iter)
+    {
+     // we have an itrator to one TrkrHitSet for the intt from the trkrHitSetContainer
+      // get the hitset key so we can find the layer
+      TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
+      const int layer = TrkrDefs::getLayer(hitsetkey);
+      const int ladder_phi = InttDefs::getLadderPhiId(hitsetkey);
+      const int ladder_z = InttDefs::getLadderZId(hitsetkey);
+
+      if(Verbosity() > 1) 
+	cout << "PHG4INTTDigitizer: found hitset with key: " << hitsetkey << " in layer " << layer << endl;
+
+      // get all of the hits from this hitset      
+      TrkrHitSet *hitset = hitset_iter->second;
+      TrkrHitSet::ConstRange hit_range = hitset->getHits();
+      for(TrkrHitSet::ConstIterator hit_iter = hit_range.first;
+	  hit_iter != hit_range.second;
+	  ++hit_iter)
+	{
+	  ++m_nCells;
+
+	  TrkrHit *hit = (InttHit*) hit_iter->second;
+	  TrkrDefs::hitkey hitkey = hit_iter->first;
+	  int strip_col =  InttDefs::getCol(hitkey);  // strip z index
+	  int strip_row =   InttDefs::getRow(hitkey);  // strip phi index
+
+	  // Apply deadmap here if desired
+	  if (deadmap)
+	    {
+	      if (deadmap->isDeadChannelINTT(
+					     layer, 
+					     ladder_phi,
+					     ladder_z,
+					     strip_col,
+					     strip_row
+					     ))
+		{
+		  ++m_nDeadCells;
+		  if (Verbosity() >= VERBOSITY_MORE)
+		    {
+		      cout << "PHG4INTTDigitizer::DigitizeLadderCells - dead strip at layer " << layer << ": ";
+		      hit->identify();
+		    }
+		  continue;
+		}
+	    }  //    if (deadmap)
+
+	  if (_energy_scale.count(layer) > 1)
+	    assert(!"Error: _energy_scale has two or more keys.");
+
+	  const float mip_e = _energy_scale[layer];
+
+	  std::vector<std::pair<double, double> > vadcrange = _max_fphx_adc[layer];
+
+	  int adc = -1;
+	  for (unsigned int irange = 0; irange < vadcrange.size(); ++irange)
+	    if (hit->getEnergy() >= vadcrange[irange].first * (double) mip_e && hit->getEnergy() < vadcrange[irange].second * (double) mip_e)
+	      adc = (int) irange;
+
+	  if(adc == -1)
+	    // how do we specify underflow or overflow?
+	    adc = 0;
+	  
+	  hit->setAdc(adc);	      
+
+	  if(Verbosity() > 2)
+	    cout << "PHG4INTTDigitizer: found hit with layer "  << layer << " ladder_z " << ladder_z << " ladder_phi " << ladder_phi 
+		 << " strip_col " << strip_col << " strip_row " << strip_row << " adc " << adc << endl;
+ 
+	} // end loop over hits in this hitset
+    } // end loop over hitsets
+  
+  return;
+}
+
+//! end of process
+int PHG4INTTDigitizer::End(PHCompositeNode *topNode)
+{
+  if (Verbosity() >= VERBOSITY_SOME)
+  {
+    cout << "PHG4INTTDigitizer::End - processed "
+         << m_nCells << " cell with "
+         << m_nDeadCells << " dead cells masked"
+         << " (" << 100. * m_nDeadCells / m_nCells << "%)" << endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void PHG4INTTDigitizer::SetDefaultParameters()
+{
+  set_default_double_param("NoiseMean", 457.2);
+  set_default_double_param("NoiseSigma", 166.6);
+  set_default_double_param("EnergyPerPair", 3.62e-9);  // GeV/e-h
+  return;
+}
+
+float PHG4INTTDigitizer::added_noise()
+{
+//  float noise = gsl_ran_gaussian(RandomGenerator, mNoiseSigma) + mNoiseMean;
+//  noise = (noise < 0) ? 0 : noise;
+
+  // Note the noise is bi-polar, i.e. can make ths signal fluctuate up and down.
+  // Much of the mNoiseSigma as extracted in https://github.com/sPHENIX-Collaboration/coresoftware/pull/580
+  // is statistical fluctuation from the limited calibration data. They does not directly apply here.
+  float noise = gsl_ran_gaussian(RandomGenerator, mNoiseMean);
+
+  return noise;
+}
+
+void PHG4INTTDigitizer::set_adc_scale(const int &layer, const std::vector<double> &userrange)
+{
+  if (userrange.size() != nadcbins)
+  {
+    cout << "Error: vector in set_fphx_adc_scale(vector) must have eight elements." << endl;
+    gSystem->Exit(1);
+  }
+  //sort(userrange.begin(), userrange.end()); // TODO, causes GLIBC error
+
+  std::vector<std::pair<double, double> > vadcrange;
+  for (unsigned int irange = 0; irange < userrange.size(); ++irange)
+  {
+    if (irange == userrange.size() - 1)
+    {
+      vadcrange.push_back(std::make_pair(userrange[irange], FLT_MAX));
+    }
+    else
+    {
+      vadcrange.push_back(std::make_pair(userrange[irange], userrange[irange + 1]));
+    }
+  }
+  _max_fphx_adc.insert(std::make_pair(layer, vadcrange));
+}

--- a/simulation/g4simulation/g4intt/PHG4INTTDigitizer.h
+++ b/simulation/g4simulation/g4intt/PHG4INTTDigitizer.h
@@ -1,0 +1,69 @@
+#ifndef G4INTT_PHG4INTTDIGITIZER_H
+#define G4INTT_PHG4INTTDIGITIZER_H
+
+#include <phparameter/PHParameterInterface.h>
+
+#include <fun4all/SubsysReco.h>
+
+#include <map>
+#include <vector>
+
+// rootcint barfs with this header so we need to hide it
+#ifndef __CINT__
+#include <gsl/gsl_rng.h>
+#endif
+
+class PHG4INTTDigitizer : public SubsysReco, public PHParameterInterface
+{
+ public:
+  PHG4INTTDigitizer(const std::string &name = "PHG4INTTDigitizer");
+  virtual ~PHG4INTTDigitizer();
+
+  //! run initialization
+  int InitRun(PHCompositeNode *topNode);
+
+  //! event processing
+  int process_event(PHCompositeNode *topNode);
+
+  //! end of process
+  int End(PHCompositeNode *topNode);
+
+  void SetDefaultParameters();
+
+  void Detector(const std::string &d) { detector = d; }
+
+  void set_adc_scale(const int &layer, const std::vector<double> &userrange);
+
+ private:
+  void CalculateLadderCellADCScale(PHCompositeNode *topNode);
+
+  void DigitizeLadderCells(PHCompositeNode *topNode);
+
+  std::string detector;
+  // noise electrons
+  float added_noise();
+
+  float mNoiseMean;      // Mean of noise electron distribution
+  float mNoiseSigma;     // Sigma of noise electron distribution
+  float mEnergyPerPair;  // GeV/e-h pair
+
+  // settings
+  std::map<int, unsigned int> _max_adc;
+  std::map<int, float> _energy_scale;
+
+  // storage
+  //SvtxHitMap *_hitmap;
+
+  const unsigned int nadcbins = 8;
+  std::map<int, std::vector<std::pair<double, double> > > _max_fphx_adc;
+
+  unsigned int m_nCells;
+  unsigned int m_nDeadCells;
+
+#ifndef __CINT__
+  //! random generator that conform with sPHENIX standard
+  gsl_rng *RandomGenerator;
+#endif
+};
+
+#endif

--- a/simulation/g4simulation/g4intt/PHG4INTTDigitizerLinkDef.h
+++ b/simulation/g4simulation/g4intt/PHG4INTTDigitizerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4INTTDigitizer - !;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4intt/PHG4INTTDisplayAction.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTDisplayAction.cc
@@ -2,6 +2,8 @@
 
 #include <g4main/PHG4Utils.h>
 
+#include <TSystem.h>
+
 #include <Geant4/G4Color.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VPhysicalVolume.hh>
@@ -36,37 +38,85 @@ void PHG4INTTDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
       continue;
     }
     G4VisAttributes *visatt = new G4VisAttributes();
+    visatt->SetVisibility(true);
+    visatt->SetForceSolid(true);
     m_VisAttVec.push_back(visatt);  // for later deletion
-    if (it.second == "Carbon")
+    if (it.second == "FPHX")
     {
-      visatt->SetColour(0.5, 0.5, 0.5, .25);
+      visatt->SetColour(G4Colour::Blue());
     }
-    else if (it.second == "M60J3K")
+    else if (it.second == "HdiCopper")
     {
-      visatt->SetColour(0.25, 0.25, 0.25, .25);
+      visatt->SetColour(G4Colour::White());
     }
-    else if (it.second == "WATER")
+    else if (it.second == "HdiKapton")
     {
-      visatt->SetColour(0.0, 0.5, 0.0, .25);
+      visatt->SetColour(G4Colour::Yellow());
     }
-    else if (it.second == "SI")
+    else if (it.second == "Ladder")
     {
-      PHG4Utils::SetColour(visatt, "G4_Si");
+      visatt->SetVisibility(false);
+      visatt->SetForceSolid(false);
     }
-    else if (it.second == "KAPTON")
+    else if (it.second == "PGS")
     {
-      PHG4Utils::SetColour(visatt, "G4_KAPTON");
+      visatt->SetColour(G4Colour::Red());
     }
-    else if (it.second == "ALUMINUM")
+    else if (it.second == "Rail")
     {
-      PHG4Utils::SetColour(visatt, "G4_Al");
+      visatt->SetColour(G4Colour::Cyan());
+    }
+    else if (it.second == "RohaCell")
+    {
+      visatt->SetColour(G4Colour::White());
+    }
+    else if (it.second == "SiActive")
+    {
+      visatt->SetColour(G4Colour::White());
+    }
+    else if (it.second == "SiInActive")
+    {
+      visatt->SetColour(G4Colour::Red());
+    }
+    else if (it.second == "StaveBox")
+    {
+      visatt->SetVisibility(false);
+      visatt->SetForceSolid(false);
+    }
+    else if (it.second == "StaveCooler")
+    {
+      visatt->SetColour(G4Colour::Grey());
+    }
+    else if (it.second == "StaveCurve")
+    {
+      visatt->SetColour(G4Colour::Grey());
+    }
+    else if (it.second == "StaveGlueBox")
+    {
+      visatt->SetColour(G4Colour::Cyan());
+    }
+    else if (it.second == "StavePipe")
+    {
+      visatt->SetColour(G4Colour::White());
+    }
+    else if (it.second == "StaveStraightInner")
+    {
+      visatt->SetColour(G4Colour::Grey());
+    }
+    else if (it.second == "StaveStraightOuter")
+    {
+      visatt->SetColour(G4Colour::Grey());
+    }
+    else if (it.second == "StaveWater")
+    {
+      visatt->SetColour(G4Colour::Blue());
     }
     else
     {
-      visatt->SetColour(.2, .2, .7, .25);
+      cout << "did not assing color to " << it.first->GetName()
+	   << " under " << it.second << endl;
+      gSystem->Exit(1);
     }
-    visatt->SetVisibility(true);
-    visatt->SetForceSolid(true);
     logvol->SetVisAttributes(visatt);
   }
   return;

--- a/simulation/g4simulation/g4intt/PHG4INTTDisplayAction.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTDisplayAction.cc
@@ -1,0 +1,73 @@
+#include "PHG4INTTDisplayAction.h"
+
+#include <g4main/PHG4Utils.h>
+
+#include <Geant4/G4Color.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4VPhysicalVolume.hh>
+#include <Geant4/G4VisAttributes.hh>
+
+#include <iostream>
+
+using namespace std;
+
+PHG4INTTDisplayAction::PHG4INTTDisplayAction(const std::string &name)
+  : PHG4DisplayAction(name)
+{
+}
+
+PHG4INTTDisplayAction::~PHG4INTTDisplayAction()
+{
+  for (auto &it : m_VisAttVec)
+  {
+    delete it;
+  }
+  m_VisAttVec.clear();
+}
+
+void PHG4INTTDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
+{
+  // check if vis attributes exist, if so someone else has set them and we do nothing
+  for (auto it : m_LogicalVolumeMap)
+  {
+    G4LogicalVolume *logvol = it.first;
+    if (logvol->GetVisAttributes())
+    {
+      continue;
+    }
+    G4VisAttributes *visatt = new G4VisAttributes();
+    m_VisAttVec.push_back(visatt);  // for later deletion
+    if (it.second == "Carbon")
+    {
+      visatt->SetColour(0.5, 0.5, 0.5, .25);
+    }
+    else if (it.second == "M60J3K")
+    {
+      visatt->SetColour(0.25, 0.25, 0.25, .25);
+    }
+    else if (it.second == "WATER")
+    {
+      visatt->SetColour(0.0, 0.5, 0.0, .25);
+    }
+    else if (it.second == "SI")
+    {
+      PHG4Utils::SetColour(visatt, "G4_Si");
+    }
+    else if (it.second == "KAPTON")
+    {
+      PHG4Utils::SetColour(visatt, "G4_KAPTON");
+    }
+    else if (it.second == "ALUMINUM")
+    {
+      PHG4Utils::SetColour(visatt, "G4_Al");
+    }
+    else
+    {
+      visatt->SetColour(.2, .2, .7, .25);
+    }
+    visatt->SetVisibility(true);
+    visatt->SetForceSolid(true);
+    logvol->SetVisAttributes(visatt);
+  }
+  return;
+}

--- a/simulation/g4simulation/g4intt/PHG4INTTDisplayAction.h
+++ b/simulation/g4simulation/g4intt/PHG4INTTDisplayAction.h
@@ -1,0 +1,31 @@
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4INTTDISPLAYACTION_H
+#define G4DETECTORS_PHG4INTTDISPLAYACTION_H
+
+#include <g4main/PHG4DisplayAction.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+class G4VisAttributes;
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+
+class PHG4INTTDisplayAction : public PHG4DisplayAction
+{
+ public:
+  PHG4INTTDisplayAction(const std::string &name);
+
+  virtual ~PHG4INTTDisplayAction();
+
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
+
+ private:
+  std::map<G4LogicalVolume *, std::string> m_LogicalVolumeMap;
+  std::vector<G4VisAttributes *> m_VisAttVec;
+};
+
+#endif  // G4DETECTORS_PHG4INTTDISPLAYACTION_H

--- a/simulation/g4simulation/g4intt/PHG4INTTFPHXParameterisation.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTFPHXParameterisation.cc
@@ -1,0 +1,31 @@
+#include "PHG4INTTFPHXParameterisation.h"
+
+#include <Geant4/G4ThreeVector.hh>
+#include <Geant4/G4VPhysicalVolume.hh>
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+PHG4INTTFPHXParameterisation::PHG4INTTFPHXParameterisation(const double offsetx, const double offsety, const double offsetz, const double dz, const int ncopy)
+{
+  for (G4int icopy = 0; icopy < ncopy; icopy++)
+  {
+    fXFPHX[icopy] = offsetx;
+    fYFPHX[icopy] = offsety;
+    fZFPHX[icopy] = offsetz + icopy * dz;
+    /*
+    std::cout << "      icopy " << icopy
+	      << " offsety " << offsety
+	      << " offsetz " << offsetz
+	      << " dz " << dz
+	      << " fXFPHX[icopy] " << fXFPHX[icopy]
+	      << " fYFPHX[icopy] " << fYFPHX[icopy]
+	      << " fZFPHX[icopy] " << fZFPHX[icopy]
+	      << std::endl;
+    */
+  }
+}
+
+void PHG4INTTFPHXParameterisation::ComputeTransformation(const G4int icopy, G4VPhysicalVolume *physVol) const
+{
+  physVol->SetTranslation(G4ThreeVector(fXFPHX[icopy], fYFPHX[icopy], fZFPHX[icopy]));
+}

--- a/simulation/g4simulation/g4intt/PHG4INTTFPHXParameterisation.h
+++ b/simulation/g4simulation/g4intt/PHG4INTTFPHXParameterisation.h
@@ -1,0 +1,26 @@
+// Tell emacs that this is a C++ source
+// This file is really -*- C++ -*-.
+#ifndef G4INTT_PHG4INTTPARAMETERISATION_H
+#define G4INTT_PHG4INTTPARAMETERISATION_H
+
+#include <Geant4/G4VPVParameterisation.hh>
+
+class G4VPhysicalVolume;
+
+/*
+ * FPHX location
+ */
+class PHG4INTTFPHXParameterisation : public G4VPVParameterisation
+{
+ public:
+  PHG4INTTFPHXParameterisation(const double offsetx, const double offsety, const double offsetz, const double dz, const int ncopy);
+  virtual ~PHG4INTTFPHXParameterisation() {}
+  virtual void ComputeTransformation(const G4int icopy, G4VPhysicalVolume *physVol) const;
+
+ private:
+  G4double fXFPHX[20];
+  G4double fYFPHX[20];
+  G4double fZFPHX[20];
+};
+
+#endif

--- a/simulation/g4simulation/g4intt/PHG4INTTSubsystem.cc
+++ b/simulation/g4simulation/g4intt/PHG4INTTSubsystem.cc
@@ -1,6 +1,7 @@
 #include "PHG4INTTSubsystem.h"
 #include "PHG4INTTDefs.h"
 #include "PHG4INTTDetector.h"
+#include "PHG4INTTDisplayAction.h"
 #include "PHG4INTTSteppingAction.h"
 
 #include <phparameter/PHParameters.h>
@@ -22,6 +23,7 @@ PHG4INTTSubsystem::PHG4INTTSubsystem(const std::string &detectorname, const vpai
   : PHG4DetectorGroupSubsystem(detectorname)
   , m_Detector(nullptr)
   , m_SteppingAction(nullptr)
+  , m_DisplayAction(nullptr)
   , m_LayerConfigVector(layerconfig)
   , m_DetectorType(detectorname)
 {
@@ -37,6 +39,11 @@ PHG4INTTSubsystem::PHG4INTTSubsystem(const std::string &detectorname, const vpai
   SuperDetector(detectorname);
 }
 
+PHG4INTTSubsystem::~PHG4INTTSubsystem()
+{
+  delete m_DisplayAction;
+}
+
 //_______________________________________________________________________
 int PHG4INTTSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
@@ -48,9 +55,11 @@ int PHG4INTTSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHNodeIterator iter(topNode);
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
+  // create display settings before detector (detector adds its volumes to it)
+  m_DisplayAction = new PHG4INTTDisplayAction(Name());
   // create detector
   pair<vector<pair<int, int>>::const_iterator, vector<pair<int, int>>::const_iterator> layer_begin_end = make_pair(m_LayerConfigVector.begin(), m_LayerConfigVector.end());
-  m_Detector = new PHG4INTTDetector(topNode, GetParamsContainer(), Name(), layer_begin_end);
+  m_Detector = new PHG4INTTDetector(this, topNode, GetParamsContainer(), Name(), layer_begin_end);
   m_Detector->SuperDetector(SuperDetector());
   m_Detector->Detector(m_DetectorType);
   m_Detector->OverlapCheck(CheckOverlap());

--- a/simulation/g4simulation/g4intt/PHG4INTTSubsystem.h
+++ b/simulation/g4simulation/g4intt/PHG4INTTSubsystem.h
@@ -9,6 +9,7 @@
 
 class PHG4INTTDetector;
 class PHG4INTTSteppingAction;
+class PHG4DisplayAction;
 
 class PHG4INTTSubsystem : public PHG4DetectorGroupSubsystem
 {
@@ -19,14 +20,13 @@ class PHG4INTTSubsystem : public PHG4DetectorGroupSubsystem
   PHG4INTTSubsystem(const std::string &name = "INTT", const vpair &layerconfig = vpair(0));
 
   //! destructor
-  virtual ~PHG4INTTSubsystem(void)
-  {
-  }
+  virtual ~PHG4INTTSubsystem();
 
   //! init
   /*!
-  creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
-  reates the stepping action and place it on the node tree, under "ACTIONS" node
+  called during InitRun (the original InitRun does common setup and calls this one)
+  creates the detector object 
+  ceates the stepping action 
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
   int InitRunSubsystem(PHCompositeNode *);
@@ -40,7 +40,11 @@ class PHG4INTTSubsystem : public PHG4DetectorGroupSubsystem
 
   //! accessors (reimplemented)
   PHG4Detector *GetDetector(void) const;
+
   PHG4SteppingAction *GetSteppingAction(void) const { return m_SteppingAction; }
+
+  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+
   void Print(const std::string &what = "ALL") const;
 
  private:
@@ -53,6 +57,10 @@ class PHG4INTTSubsystem : public PHG4DetectorGroupSubsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
   PHG4SteppingAction *m_SteppingAction;
+
+  //! display attribute setting
+  /*! derives from PHG4DisplayAction */
+  PHG4DisplayAction* m_DisplayAction;
 
   vpair m_LayerConfigVector;
   std::string m_DetectorType;

--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -24,10 +24,10 @@ libg4tpc_la_LIBADD = \
   -ltpc_io
 
 pkginclude_HEADERS = \
-  PHG4TpcElectronDrift.h \
+  PHG4TPCElectronDrift.h \
   PHG4TPCPadPlane.h \
   PHG4TPCPadPlaneReadout.h \
-  PHG4TpcDigitizer.h \
+  PHG4TPCDigitizer.h \
   PHG4TPCSubsystem.h \
   PHG4TPCDistortion.h \
   PHG4TPCSpaceChargeDistortion.h 
@@ -35,10 +35,10 @@ pkginclude_HEADERS = \
 if MAKEROOT6
 else
   ROOT5_DICTS = \
-    PHG4TpcElectronDrift_Dict.cc \
+    PHG4TPCElectronDrift_Dict.cc \
     PHG4TPCPadPlane_Dict.cc \
     PHG4TPCPadPlaneReadout_Dict.cc \
-    PHG4TpcDigitizer_Dict.cc \
+    PHG4TPCDigitizer_Dict.cc \
     PHG4TPCSubsystem_Dict.cc \
     PHG4TPCDistortion_Dict.cc\
     PHG4TPCSpaceChargeDistortion_Dict.cc 
@@ -47,11 +47,11 @@ endif
 libg4tpc_la_SOURCES = \
   $(ROOT5_DICTS) \
   PHG4TPCDetector.cc \
-  PHG4TpcElectronDrift.cc \
+  PHG4TPCElectronDrift.cc \
   PHG4TPCPadPlane.cc \
   PHG4TPCPadPlaneReadout.cc \
   PHG4TPCSteppingAction.cc \
-  PHG4TpcDigitizer.cc \
+  PHG4TPCDigitizer.cc \
   PHG4TPCSubsystem.cc \
   PHG4TPCDistortion.cc \
   PHG4TPCSpaceChargeDistortion.cc

--- a/simulation/g4simulation/g4tpc/PHG4TPCDigitizer.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCDigitizer.cc
@@ -1,0 +1,607 @@
+#include "PHG4TPCDigitizer.h"
+
+#include <g4main/PHG4Hit.h>
+
+
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContainer.h>
+#include <trackbase/TrkrHitTruthAssoc.h>
+#include <trackbase/TrkrDefs.h>
+
+#include <tpc/TpcDefs.h>
+#include <tpc/TpcHit.h>
+
+
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderGeom.h>
+#include <g4detectors/PHG4CylinderGeomContainer.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/getClass.h>
+#include <phool/PHRandomSeed.h>
+
+#include <gsl/gsl_randist.h>
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+
+using namespace std;
+
+PHG4TPCDigitizer::PHG4TPCDigitizer(const string &name)
+  : SubsysReco(name)
+  , TPCMinLayer(7)
+  , ADCThreshold(2700)
+  ,  // electrons
+  TPCEnc(670)
+  ,  // electrons
+  Pedestal(50000)
+  ,  // electrons
+  ChargeToPeakVolts(20)
+  ,  // mV/fC
+  ADCSignalConversionGain(numeric_limits<float>::signaling_NaN())
+  ,  // will be assigned in PHG4TPCDigitizer::InitRun
+  ADCNoiseConversionGain(numeric_limits<float>::signaling_NaN())
+  ,  // will be assigned in PHG4TPCDigitizer::InitRun
+  _hitmap(nullptr)
+{
+  unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
+  cout << Name() << " random seed: " << seed << endl;
+  RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
+  gsl_rng_set(RandomGenerator, seed);
+
+  if (Verbosity() > 0)
+    cout << "Creating PHG4TPCDigitizer with name = " << name << endl;
+}
+
+PHG4TPCDigitizer::~PHG4TPCDigitizer()
+{
+  gsl_rng_free(RandomGenerator);
+}
+
+int PHG4TPCDigitizer::InitRun(PHCompositeNode *topNode)
+{
+  ADCThreshold += Pedestal;
+
+  // Factor that convertes the charge in each z bin into a voltage in each z bin
+  // ChargeToPeakVolts relates TOTAL charge collected to peak voltage, while the cell maker actually distributes the signal
+  // GEM output charge in Z bins using the shaper time response. For 80 ns shaping, the scaleup factor of 2.4 gets the peak voltage right.
+  ADCSignalConversionGain = ChargeToPeakVolts * 1.60e-04 * 2.4;  // 20 (or 30) mV/fC * fC/electron * scaleup factor
+  // The noise is by definition the RMS noise width voltage divided by ChargeToPeakVolts
+  ADCNoiseConversionGain = ChargeToPeakVolts * 1.60e-04;  // 20 (or 30) mV/fC * fC/electron
+
+  //-------------
+  // Add Hit Node
+  //-------------
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    cout << PHWHERE << "DST Node missing, doing nothing." << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  PHNodeIterator iter_dst(dstNode);
+
+  CalculateCylinderCellADCScale(topNode);
+
+  //----------------
+  // Report Settings
+  //----------------
+
+  if (Verbosity() > 0)
+  {
+    cout << "====================== PHG4TPCDigitizer::InitRun() =====================" << endl;
+    for (std::map<int, unsigned int>::iterator iter = _max_adc.begin();
+         iter != _max_adc.end();
+         ++iter)
+    {
+      cout << " Max ADC in Layer #" << iter->first << " = " << iter->second << endl;
+    }
+    for (std::map<int, float>::iterator iter = _energy_scale.begin();
+         iter != _energy_scale.end();
+         ++iter)
+    {
+      cout << " Energy per ADC in Layer #" << iter->first << " = " << 1.0e6 * iter->second << " keV" << endl;
+    }
+    cout << "===========================================================================" << endl;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4TPCDigitizer::process_event(PHCompositeNode *topNode)
+{
+
+  DigitizeCylinderCells(topNode);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void PHG4TPCDigitizer::CalculateCylinderCellADCScale(PHCompositeNode *topNode)
+{
+  // defaults to 8-bit ADC, short-axis MIP placed at 1/4 dynamic range
+
+  PHG4CylinderCellGeomContainer *geom_container = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+
+  if (!geom_container) return;
+
+  PHG4CylinderCellGeomContainer::ConstRange layerrange = geom_container->get_begin_end();
+  for (PHG4CylinderCellGeomContainer::ConstIterator layeriter = layerrange.first;
+       layeriter != layerrange.second;
+       ++layeriter)
+  {
+    int layer = layeriter->second->get_layer();
+    float thickness = (layeriter->second)->get_thickness();
+    float pitch = (layeriter->second)->get_phistep() * (layeriter->second)->get_radius();
+    float length = (layeriter->second)->get_zstep();
+
+    float minpath = pitch;
+    if (length < minpath) minpath = length;
+    if (thickness < minpath) minpath = thickness;
+    float mip_e = 0.003876 * minpath;
+
+    if (_max_adc.find(layer) == _max_adc.end())
+    {
+      _max_adc[layer] = 255;
+      _energy_scale[layer] = mip_e / 64;
+    }
+  }
+
+  return;
+}
+
+void PHG4TPCDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode)
+{
+  unsigned int print_layer = 47;  // to print diagnostic output for layer 47
+
+  // Digitizes the TPC cells that were created in PHG4CylinderCellTPCReco
+  // These contain as edep the number of electrons out of the GEM stack, distributed between Z bins by shaper response and ADC clock window
+  // - i.e. all of the phi and Z bins in a cluster have edep values that add up to the primary charge in the layer times 2000
+
+  // NOTES:
+  // Modified by ADF June 2018 to do the following:
+  //   Add noise to cells before digitizing
+  //   Digitize the first adc time bin to exceed the threshold, and the 4 bins after that
+  //   If the adc value is still above the threshold after 5 bins, repeat for the next 5 bins
+
+  // Electron production:
+  // A MIP produces 32 electrons in 1.25 cm of Ne:CF4 gas
+  // The nominal GEM gain is 2000 => 64,000 electrons per MIP through 1.25 cm gas
+  // Thus a MIP produces a charge value out of the GEM stack of 64000/6.242x10^18 = 10.2 fC
+
+  // SAMPA:
+  // See https://indico.cern.ch/event/489996/timetable/#all.detailed "SAMPA Chip: the New ASIC for the ALICE TPC and MCH Upgrades", M Bregant
+  // The SAMPA has a maximum output voltage of 2200 mV (but the pedestal is about 200 mV)
+  // The SAMPA shaper is set to 80 ns peaking time
+  // The ADC Digitizes the SAMPA shaper output into 1024 channels
+  // Conversion gains of 20 mV/fC or 30 mV/fC are possible - 1 fC charge input produces a peak volatge out of the shaper of 20 or 30 mV
+  //   At 30 mV/fC, the input signal saturates at 2.2 V / 30 mV/fC = 73 fC (say 67 with pedestal not at zero)
+  //   At 20 mV/fC, the input signal saturates at 2.2 V / 20 mV/fC = 110 fC (say 100 fC with pedestal not at zero) - assume 20 mV/fC
+  // The equivalent noise charge RMS at 20 mV/fC was measured (w/o detector capacitance) at 490 electrons
+  //      - note: this appears to be just the pedestal RMS voltage spread divided by the conversion gain, so it is a bit of a funny number (see below)
+  //      - it is better to think of noise and signal in terms of voltage at the input of the ADC
+  // Bregant's slides say 670 electrons ENC for the full chip with 18 pf detector, as in ALICE - should use that number
+
+  // Signal:
+  // To normalize the signal in each cell, take the entire charge on the pad and multiply by 20 mV/fC to get the adc input AT THE PEAK of the shaper
+  // The cell contents should thus be multipied by the normalization given by:
+  // V_peak = Q_pad (electrons) * 1.6e-04 fC/electron * 20 mV/fC
+  // From the sims, for 80 ns and 18.8 MHz, if we take the input charge and spread it a across the shaping time (which is how it has always been done, and is
+  // not the best way to think about it, because the ADC does not see charge it sees voltage out of a charge integrating preamp followed by a shaper), to get
+  // the voltage at the ADC input right, then the values of Q_(pad,z) have to be scaled up by 2.4
+  // V_(pad,z) = 2.4 * Q_(pad,z) (electrons) * 1.6e-04 fC/electron * 20 mV/fC = Q_(pad,z) * 7.68e-03 (in mV)
+  // ADU_(pad,z) = V_(pad,z) * (1024 ADU / 2200 mV) = V_(pad,z) * 0.465
+  // Remember that Q_(pad,z) is the GEM output charge
+
+  // Noise:
+  // The ENC is defined as the RMS spread of the ADC pedestal distribution coming out from the SAMPA divided by the corresponding conversion gain.
+  // The full range of the ADC input is 2.2V (which will become 1024 adc counts, i.e. 1024 ADU's).
+  // If you see the RMS of the pedestal in adc counts as 1 at the gain of 20mV/fC, the ENC would be defined by:
+  //             (2200 [mV]) * (1/1024) / (20[mV/fC]) / (1.6*10^-4 [fC]) = 671 [electrons]
+  // The RMS noise voltage would be: V_RMS = ENC (electrons) *1.6e-04 fC/electron * 20 mV/fC = ENC (electrons) * 3.2e-03 (in mV)
+  // The ADC readout would be:  ADU = V_RMS * (1024 ADU / 2200 mV) = V_RMS * 0.465
+
+  // The cells that we need to digitize here contain as the energy "edep", which is the number of electrons out of the GEM stack
+  // distributed over the pads and ADC time bins according to the output time distribution of the SAMPA shaper - not what really happens, see above
+  // We convert to volts at the input to the ADC and add noise generated with the RMS value of the noise voltage at the ADC input
+  // We assume the pedestal is zero, for simplicity, so the noise fluctuates above and below zero
+
+  // Note that zbin = 0 corresponds to -100.5 cm, zbin 248 corresponds to 0 cm, and zbin 497 corresponds to +100.5 cm
+  // increasing time should be bins (497 -> 249) and (0 -> 248)
+
+  //----------
+  // Get Nodes
+  //----------
+
+  PHG4CylinderCellGeomContainer *geom_container =
+    findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  if (!geom_container)
+    {
+      std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
+    }
+
+
+  // Get the TrkrHitSetContainer node
+  TrkrHitSetContainer *trkrhitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
+  if(!trkrhitsetcontainer)
+    {
+      cout << "Could not locate TRKR_HITSET node, quit! " << endl;
+      exit(1);
+    }
+
+  TrkrHitTruthAssoc *hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
+  if(!hittruthassoc)
+    {
+      cout << PHWHERE << " Could not locate TRKR_HITTRUTHASSOC node, quit! " << endl;
+      exit(1);
+    }
+
+
+  //-------------
+  // Digitization
+  //-------------
+
+  // Loop over all hitsets for the TPC
+  TrkrHitSetContainer::ConstRange hitset_range = trkrhitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
+  for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range.first;
+       hitset_iter != hitset_range.second;
+       ++hitset_iter)
+    {
+      // we have an itrator to one TrkrHitSet for the TPC from the trkrHitSetContainer
+      // get the hitset key so we can find the layer
+      TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
+      const unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+
+      if(Verbosity() > 2)
+	if(layer == print_layer) 
+	  cout << "new: PHG4TPCDigitizer:  processing hits for layer " << layer << " hitsetkey " << hitsetkey << endl;
+
+      // we need the geometry object for this layer
+      PHG4CylinderCellGeom *layergeom = geom_container->GetLayerCellGeom(layer);
+      if (!layergeom)
+	exit(1);
+
+      // for this hitset, make a vector of a vector of cells for each phibin
+      phi_sorted_hits.clear();
+      
+      // start with an empty vector of cells for each phibin      
+      int nphibins = layergeom->get_phibins();
+      for (int iphi = 0; iphi < nphibins; iphi++)
+	{
+	  phi_sorted_hits.push_back(std::vector<TrkrHitSet::ConstIterator>());
+	}      
+      
+      // get all of the hits from this hitset      
+      TrkrHitSet *hitset = hitset_iter->second;
+      TrkrHitSet::ConstRange hit_range = hitset->getHits();
+      for(TrkrHitSet::ConstIterator hit_iter = hit_range.first;
+	  hit_iter != hit_range.second;
+	  ++hit_iter)
+	{
+	  // Fill the vector of hits for each phibin
+	  unsigned int phibin = TpcDefs::getPad(hit_iter->first);
+	  phi_sorted_hits[phibin].push_back(hit_iter);
+	}
+	  	  
+      // For this hitset we have the hits sorted into vectors for each phi
+      // process these vectors one phi bin at a time
+      for (unsigned int iphi = 0; iphi < phi_sorted_hits.size(); iphi++)
+	{
+	  if (phi_sorted_hits[iphi].size() == 0)
+	    continue;
+	  
+	  // Populate a vector of hits ordered by Z for each phibin
+	  int nzbins = layergeom->get_zbins();
+	  is_populated.clear();
+	  is_populated.assign(nzbins, 2);  // mark all as noise only for now
+	  z_sorted_hits.clear();
+	      
+	  // add an empty vector for each z bin
+	  for (int iz = 0; iz < nzbins; iz++)
+	    z_sorted_hits.push_back(std::vector<TrkrHitSet::ConstIterator>());
+
+	  if(Verbosity() > 2)
+	    if(layer == print_layer) cout << endl;	  
+
+	  // add a hit for each z bin that has one
+	  for (unsigned int iz = 0; iz < phi_sorted_hits[iphi].size(); iz++)
+	    {
+	      int zbin = TpcDefs::getTBin(phi_sorted_hits[iphi][iz]->first);
+	      is_populated[zbin] = 1;  // this bin is a associated with a hit
+	      z_sorted_hits[zbin].push_back(phi_sorted_hits[iphi][iz]);
+
+	      if(Verbosity() > 2)
+		if(layer == print_layer)  
+		  {
+		    TrkrDefs::hitkey hitkey =  phi_sorted_hits[iphi][iz]->first ;
+		    cout << "Adding hit to z vector for zbin " << zbin << "  hitkey " << hitkey << " pad " << TpcDefs::getPad(hitkey) 
+			 << " z bin " << TpcDefs::getTBin(hitkey)   << "  energy " <<( phi_sorted_hits[iphi][iz]->second)->getEnergy() 
+			 << " adc " << (phi_sorted_hits[iphi][iz]->second)->getAdc() << endl;
+		  }
+	    }
+	      
+	  adc_input.clear();
+	  adc_hitid.clear();
+	  // Now for this phibin we process all bins ordered by Z into hits with noise
+	  //======================================================
+	  // For this step we take the edep value and convert it to mV at the ADC input
+	  // See comments above for how to do this for signal and noise
+	      
+	  for (int iz = 0; iz < nzbins; iz++)
+	    {
+	      if (is_populated[iz] == 1)
+		{
+		  // This zbin has a hit, add noise
+		  float noise = added_noise();                                                                                       // in electrons
+		  float noise_voltage = (Pedestal + noise) * ADCNoiseConversionGain;                      // mV - from definition of noise charge and pedestal charge
+		  float adc_input_voltage = (z_sorted_hits[iz][0]->second)->getEnergy() * ADCSignalConversionGain;  // mV, see comments above
+		  
+		  adc_input.push_back(adc_input_voltage + noise_voltage);
+		  adc_hitid.push_back(z_sorted_hits[iz][0]->first);
+
+		  if(Verbosity() > 2)
+		    if(layer == print_layer) 
+		      cout << "new: iphi " << iphi  << " iz " << iz << " edep " <<  (z_sorted_hits[iz][0]->second)->getEnergy() 
+			   << " adc gain " << ADCSignalConversionGain << " adc_input " << adc_input[iz] << endl;
+		}
+	      else if (is_populated[iz] == 2)
+		{
+		  // This z bin does not have a filled cell, add noise
+		  float noise = added_noise();                                        // returns "electrons"
+		  float noise_voltage = (Pedestal + noise) * ADCNoiseConversionGain;  // mV - noise "electrons" x conversion gain
+		  
+		  adc_input.push_back(noise_voltage);  // mV
+		  adc_hitid.push_back(0);             // there is no hit, just add a placeholder in the vector for now, replace it later
+		}
+	      else
+		{
+		  // Cannot happen
+		  cout << "Impossible value of is_populated, iz = " << iz << " is_populated = " << is_populated[iz] << endl;
+		  exit(-1);
+		}
+	    }
+	  
+	  // Now we can digitize the entire stream of z bins for this phi bin
+	      
+	  // start with negative z, the first to arrive is bin 0
+	  //================================
+	  int binpointer = 0;
+	  for (int iz = 0; iz < nzbins / 2; iz++)  // 0-247
+	    {
+	      if (iz < binpointer) continue;
+
+	      if (adc_input[iz] > ADCThreshold * ADCNoiseConversionGain)  // convert threshold in "equivalent electrons" to mV
+		{
+		  // digitize this bin and the following 4 bins
+		  
+		  if (Verbosity() > 100)
+		    if (layer == print_layer) cout << endl
+						   << "new:   (neg z) Above threshold of " << ADCThreshold * ADCNoiseConversionGain << " for phibin " << iphi
+						   << " iz " << iz << " with adc_input " << adc_input[iz] << " digitize this and 4 following bins: " << endl;
+		  
+		  for (int izup = 0; izup < 5; izup++)
+		    {
+		      if (iz + izup < nzbins / 2 && iz + izup >= 0)   // stay within the bin limits for negative z
+			{
+			  unsigned int adc_output = (unsigned int) (adc_input[iz + izup] * 1024.0 / 2200.0);  // input voltage x 1024 channels over 2200 mV max range
+			  if (adc_input[iz + izup] < 0) adc_output = 0;
+			  if (adc_output > 1023) adc_output = 1023;
+			  
+			  if (Verbosity() > 100)
+			  if (layer == print_layer) cout << "new:  iphi " << iphi << "  (neg z) iz+izup " << iz + izup << " adc_hitid " << adc_hitid[iz + izup]
+							   << "  adc_input " << adc_input[iz + izup] << " ADCThreshold " << ADCThreshold * ADCNoiseConversionGain
+							   << " adc_output " << adc_output << endl;
+			  
+			  // Get the hitkey
+			  TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, iz+izup);
+			  TrkrHit *hit = nullptr;
+			  hit = hitset_iter->second->getHit(hitkey);
+			  
+			  // noise bins do not have TrkrHits associated with them, have to make one
+			  if(!hit)
+			    {
+			      hit = new TpcHit();
+			      hitset_iter->second->addHitSpecificKey(hitkey, hit);
+			      hit->addEnergy(adc_input[iz+izup]);
+			      
+			      if (Verbosity() > 100)
+				if (layer == print_layer) cout << "new:  adding noise hit for iphi " << iphi << " zbin " << iz + izup
+							       << " created new hit with hitkey " << hitkey
+							       << " energy " << adc_input[iz + izup] << " adc " << adc_output << endl;
+			    }
+
+			  hit->setAdc(adc_output);
+			  
+			}  // end boundary check
+		      binpointer++;   // skip this bin in future
+		    }    // end izup loop
+		  
+		}  //  adc threshold if
+	      else
+		{
+		  // below threshold, move on
+		  binpointer++;
+		}  // end adc threshold if/else
+	      
+	    }  // end iz loop for negative z
+	  
+	  // now positive z, the first to arrive is bin 497
+	  //===============================
+	  binpointer = nzbins - 1;
+	  for (int iz = nzbins - 1; iz >= nzbins / 2; iz--)  // 495 - 248
+	    {
+	      if (iz > binpointer) continue;
+	      
+	      if (adc_input[iz] > ADCThreshold * ADCNoiseConversionGain)  // convert threshold in electrons to mV
+		{
+		  // digitize this bin and the following 4 bins
+		  
+		  if (Verbosity() > 100)
+		    if (layer == print_layer) cout << endl
+						   << "new:  (pos z) Above threshold  of " << ADCThreshold * ADCNoiseConversionGain << " for iphi " << iphi << "  iz " << iz
+						   << " with adc_input " << adc_input[iz] << " digitize this and 4 following bins: " << endl;
+		  
+		  for (int izup = 0; izup < 5; izup++)
+		    {
+		      if (iz - izup < nzbins && iz - izup >= nzbins / 2)
+			{
+			  unsigned int adc_output = (unsigned int) (adc_input[iz - izup] * 1024.0 / 2200.0);  // input voltage x 1024 channels over 2200 mV max range
+			  if (adc_input[iz - izup] < 0) adc_output = 0;
+			  if (adc_output > 1023) adc_output = 1023;
+			  
+			  if (Verbosity() > 100)
+			  if (layer == print_layer) cout << "new:  iphi " << iphi << "  (pos z) iz-izup " << iz - izup << " adc_hitid " << adc_hitid[iz - izup]
+							   << "  adc_input " << adc_input[iz - izup] << " ADCThreshold " << ADCThreshold * ADCNoiseConversionGain
+							   << " adc_output " << adc_output << endl;
+
+			  // Get the hitkey
+			  TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, iz-izup);
+			  TrkrHit *hit = nullptr;
+			  hit = hitset_iter->second->getHit(hitkey);
+			  
+			  // noise bins do not have TrkrHits associated with them, have to make one
+			  if(!hit)
+			    {
+			      hit = new TpcHit();
+			      hitset_iter->second->addHitSpecificKey(hitkey, hit);
+			      hit->addEnergy(adc_input[iz+izup]);
+			      
+			      if (Verbosity() > 100)
+				if (layer == print_layer) cout << "new:  adding noise hit for iphi " << iphi << " zbin " << iz + izup
+							       << " created new hit with hitkey " << hitkey
+							       << " energy " << adc_input[iz + izup] << " adc " << adc_output << endl;
+			    }
+
+			  hit->setAdc(adc_output);
+			} // end boundary check
+			  binpointer--;
+		    } // end izup loop
+		  
+		}  //  adc threshold if
+	      else
+		{
+		  // below threshold, move on
+		  binpointer--;
+		}  // end adc threshold if/else
+
+	    }  // end iz loop for positive z
+			      
+	}  // end phibins loop
+      
+    }  // end loop over hitsets
+
+  //======================================================  
+  if(Verbosity() > 2) 
+    cout << "From PHG4TPCDigitizer: hitsetcontainer dump at end before cleaning:" << endl;
+
+    std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> delete_hitkey_list;
+
+  // Clean up undigitized hits - we want all hitsets for the TPC
+  TrkrHitSetContainer::ConstRange hitset_range_now = trkrhitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
+  for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range_now.first;
+       hitset_iter != hitset_range_now.second;
+       ++hitset_iter)
+    {
+     // we have an iterator to one TrkrHitSet for the TPC from the trkrHitSetContainer
+      TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
+      const unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+      const int sector = TpcDefs::getSectorId(hitsetkey);
+      const int side = TpcDefs::getSide(hitsetkey);
+      if(Verbosity() > 2) 
+	cout << "PHG4TPCDigitizer: hitset with key: " << hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << endl;
+
+      // get all of the hits from this hitset      
+      TrkrHitSet *hitset = hitset_iter->second;
+      TrkrHitSet::ConstRange hit_range = hitset->getHits();
+      for(TrkrHitSet::ConstIterator hit_iter = hit_range.first;
+	  hit_iter != hit_range.second;
+	  ++hit_iter)
+	{
+	  TrkrDefs::hitkey hitkey = hit_iter->first;
+	  TrkrHit *tpchit = hit_iter->second;
+	  if(Verbosity() > 2)
+	    cout << "      hitkey " << hitkey << " pad " << TpcDefs::getPad(hitkey) << " z bin " << TpcDefs::getTBin(hitkey) 
+		 << "  energy " << tpchit->getEnergy() << " adc " << tpchit->getAdc() << endl;
+
+	  if(tpchit->getAdc() == 0)
+	    {
+	      if(Verbosity() > 2) 
+		cout << "                       --   this hit not digitized - delete it" << endl;
+	      // screws up the iterator to delete it here, store the hitkey for later deletion
+		delete_hitkey_list.push_back(std::make_pair(hitsetkey, hitkey));
+	    }
+	}
+    }
+
+  // delete all undigitized hits
+  for(unsigned int i=0; i<delete_hitkey_list.size(); i++)
+    {
+      TrkrHitSet *hitset = trkrhitsetcontainer->findHitSet(delete_hitkey_list[i].first);
+      const unsigned int layer = TrkrDefs::getLayer(delete_hitkey_list[i].first);
+      hitset->removeHit(delete_hitkey_list[i].second);
+      if(Verbosity() > 2) 
+	if (layer == print_layer)
+	  cout << "removed hit with hitsetkey " << delete_hitkey_list[i].first << " and hitkey " << delete_hitkey_list[i].second << endl; 
+
+      // should also delete all entries with this hitkey from the TrkrHitTruthAssoc map
+      hittruthassoc->removeAssoc(delete_hitkey_list[i].first, delete_hitkey_list[i].second);
+    }
+
+
+
+  // Final hitset dump
+  if(Verbosity() > 2) 
+    cout << "From PHG4TPCDigitizer: hitsetcontainer dump at end after cleaning:" << endl;
+ // We want all hitsets for the TPC
+  TrkrHitSetContainer::ConstRange hitset_range_final = trkrhitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
+  for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range_final.first;
+       hitset_iter != hitset_range_now.second;
+       ++hitset_iter)
+    {
+     // we have an itrator to one TrkrHitSet for the TPC from the trkrHitSetContainer
+      TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
+      const unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+      if (layer != print_layer)  continue;
+      const int sector = TpcDefs::getSectorId(hitsetkey);
+      const int side = TpcDefs::getSide(hitsetkey);
+      if(Verbosity() > 2) 
+	cout << "PHG4TPCDigitizer: hitset with key: " << hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << endl;
+
+      // get all of the hits from this hitset      
+      TrkrHitSet *hitset = hitset_iter->second;
+      TrkrHitSet::ConstRange hit_range = hitset->getHits();
+      for(TrkrHitSet::ConstIterator hit_iter = hit_range.first;
+	  hit_iter != hit_range.second;
+	  ++hit_iter)
+	{
+	  TrkrDefs::hitkey hitkey = hit_iter->first;
+	  TrkrHit *tpchit = hit_iter->second;
+	  if(Verbosity() > 2)
+	    cout << "      hitkey " << hitkey << " pad " << TpcDefs::getPad(hitkey) << " z bin " << TpcDefs::getTBin(hitkey) 
+		 << "  energy " << tpchit->getEnergy() << " adc " << tpchit->getAdc() << endl;
+
+	  if(tpchit->getAdc() == 0)
+	    {
+		cout << "   Oops!                    --   this hit not digitized and not deleted!" << endl;
+	    }
+	}
+    }
+
+  //hittruthassoc->identify();
+
+  return;
+}
+
+float PHG4TPCDigitizer::added_noise()
+{
+  float noise = gsl_ran_gaussian(RandomGenerator, TPCEnc);
+
+  return noise;
+}

--- a/simulation/g4simulation/g4tpc/PHG4TPCDigitizer.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCDigitizer.h
@@ -1,0 +1,85 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4TPC_PHG4TPCDIGITIZER_H
+#define G4TPC_PHG4TPCDIGITIZER_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <trackbase/TrkrDefs.h>
+#include <trackbase/TrkrHitSet.h>
+
+#include <map>
+#include <vector>
+
+// rootcint barfs with this header so we need to hide it
+#ifndef __CINT__
+#include <gsl/gsl_rng.h>
+#endif
+
+class SvtxHitMap;
+class PHG4Cell;
+class TrkrHit;
+
+class PHG4TPCDigitizer : public SubsysReco
+{
+ public:
+  PHG4TPCDigitizer(const std::string &name = "PHG4TPCDigitizer");
+  virtual ~PHG4TPCDigitizer();
+
+  //! module initialization
+  int Init(PHCompositeNode *topNode) { return 0; }
+
+  //! run initialization
+  int InitRun(PHCompositeNode *topNode);
+
+  //! event processing
+  int process_event(PHCompositeNode *topNode);
+
+  //! end of process
+  int End(PHCompositeNode *topNode) { return 0; };
+
+  void set_adc_scale(const int layer, const unsigned int max_adc, const float energy_per_adc)
+  {
+    _max_adc.insert(std::make_pair(layer, max_adc));
+    _energy_scale.insert(std::make_pair(layer, energy_per_adc));
+  }
+
+  void SetTPCMinLayer(const int minlayer) { TPCMinLayer = minlayer; };
+  void SetADCThreshold(const float thresh) { ADCThreshold = thresh; };
+  void SetENC(const float enc) { TPCEnc = enc; };
+
+ private:
+  void CalculateCylinderCellADCScale(PHCompositeNode *topNode);
+  void DigitizeCylinderCells(PHCompositeNode *topNode);
+  float added_noise();
+
+  unsigned int TPCMinLayer;
+  float ADCThreshold;
+  float TPCEnc;
+  float Pedestal;
+  float ChargeToPeakVolts;
+
+  float ADCSignalConversionGain;
+  float ADCNoiseConversionGain;
+
+  std::vector<std::vector<TrkrHitSet::ConstIterator> > phi_sorted_hits;
+  std::vector<std::vector<TrkrHitSet::ConstIterator> > z_sorted_hits;
+
+  std::vector<float> adc_input;
+  std::vector<TrkrDefs::hitkey> adc_hitid;
+  std::vector<int> is_populated;
+
+  // settings
+  std::map<int, unsigned int> _max_adc;
+  std::map<int, float> _energy_scale;
+
+  // storage
+  SvtxHitMap *_hitmap;
+
+#ifndef __CINT__
+  //! random generator that conform with sPHENIX standard
+  gsl_rng *RandomGenerator;
+#endif
+};
+
+#endif

--- a/simulation/g4simulation/g4tpc/PHG4TPCDigitizerLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCDigitizerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4TPCDigitizer - !;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.cc
@@ -1,0 +1,525 @@
+// this is the new containers version
+// it uses the same MapToPadPlane as the old containers version
+
+#include "PHG4TPCElectronDrift.h"
+#include "PHG4TPCPadPlaneReadout.h"
+
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
+
+#include <trackbase/TrkrHit.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContainer.h>
+#include <trackbase/TrkrHitTruthAssoc.h>
+#include <trackbase/TrkrDefs.h>
+#include <tpc/TpcDefs.h>
+#include <tpc/TpcHit.h>
+
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+
+#include <phparameter/PHParameters.h>
+#include <phparameter/PHParametersContainer.h>
+
+#include <pdbcalbase/PdbParameterMapContainer.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHRandomSeed.h>
+#include <phool/getClass.h>
+
+#include <TFile.h>
+#include <TH1.h>
+#include <TNtuple.h>
+#include <TSystem.h>
+
+#include <Geant4/G4SystemOfUnits.hh>
+
+#include <gsl/gsl_randist.h>
+
+#include <cassert>
+#include <iostream>
+
+using namespace std;
+
+PHG4TPCElectronDrift::PHG4TPCElectronDrift(const std::string &name)
+  : SubsysReco(name)
+  , PHParameterInterface(name)
+    //  , g4cells(nullptr)
+  , hitsetcontainer(nullptr)
+  , hittruthassoc(nullptr)
+  , dlong(nullptr)
+  , dtrans(nullptr)
+  , diffusion_trans(NAN)
+  , diffusion_long(NAN)
+  , drift_velocity(NAN)
+  , electrons_per_gev(NAN)
+  , min_active_radius(NAN)
+  , max_active_radius(NAN)
+  , min_time(NAN)
+  , max_time(NAN)
+  , temp_hitsetcontainer(nullptr)
+  , padplane(nullptr)
+{
+  //cout << "Constructor of PHG4TPCElectronDrift" << endl;
+  InitializeParameters();
+  RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
+  set_seed(PHRandomSeed());  // fixed seed is handled in this funtcion
+
+  // this is used as a buffer for charge collection from a single g4hit
+  temp_hitsetcontainer = new TrkrHitSetContainer();
+
+  return;
+}
+
+PHG4TPCElectronDrift::~PHG4TPCElectronDrift()
+{
+  gsl_rng_free(RandomGenerator);
+  delete padplane;
+}
+
+int PHG4TPCElectronDrift::Init(PHCompositeNode *topNode)
+{
+  padplane->Init(topNode);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4TPCElectronDrift::InitRun(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+    exit(1);
+  }
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "PAR"));
+  string paramnodename = "G4CELLPARAM_" + detector;
+  string geonodename = "G4CELLPAR_" + detector;
+  string tpcgeonodename = "G4GEO_" + detector;
+  hitnodename = "G4HIT_" + detector;
+  PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  if (!g4hit)
+  {
+    cout << Name() << " Could not locate G4HIT node " << hitnodename << endl;
+    topNode->print();
+    gSystem->Exit(1);
+    exit(1);
+  }
+
+  // new containers
+  hitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
+  if(!hitsetcontainer)
+    {
+      PHNodeIterator dstiter(dstNode);
+      PHCompositeNode *DetNode =
+        dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+      if (!DetNode)
+	{
+	  DetNode = new PHCompositeNode("TRKR");
+	  dstNode->addNode(DetNode);
+	}
+
+      hitsetcontainer = new TrkrHitSetContainer();
+      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hitsetcontainer, "TRKR_HITSET", "PHObject");
+      DetNode->addNode(newNode);
+    }
+
+  hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode,"TRKR_HITTRUTHASSOC");
+  if(!hittruthassoc)
+    {
+      PHNodeIterator dstiter(dstNode);
+      PHCompositeNode *DetNode =
+        dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+      if (!DetNode)
+	{
+	  DetNode = new PHCompositeNode("TRKR");
+	  dstNode->addNode(DetNode);
+	}
+      
+      hittruthassoc = new TrkrHitTruthAssoc();
+      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hittruthassoc, "TRKR_HITTRUTHASSOC", "PHObject");
+      DetNode->addNode(newNode);
+    }
+
+  seggeonodename = "CYLINDERCELLGEOM_SVTX";  // + detector;
+  PHG4CylinderCellGeomContainer *seggeo = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, seggeonodename.c_str());
+  if (!seggeo)
+  {
+    seggeo = new PHG4CylinderCellGeomContainer();
+    PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(seggeo, seggeonodename.c_str(), "PHObject");
+    runNode->addNode(newNode);
+  }
+
+  UpdateParametersWithMacro();
+  PHNodeIterator runIter(runNode);
+  PHCompositeNode *RunDetNode = dynamic_cast<PHCompositeNode *>(runIter.findFirst("PHCompositeNode", detector));
+  if (!RunDetNode)
+  {
+    RunDetNode = new PHCompositeNode(detector);
+    runNode->addNode(RunDetNode);
+  }
+  SaveToNodeTree(RunDetNode, paramnodename);
+
+  // save this to the parNode for use
+  PHNodeIterator parIter(parNode);
+  PHCompositeNode *ParDetNode = dynamic_cast<PHCompositeNode *>(parIter.findFirst("PHCompositeNode", detector));
+  if (!ParDetNode)
+  {
+    ParDetNode = new PHCompositeNode(detector);
+    parNode->addNode(ParDetNode);
+  }
+  PutOnParNode(ParDetNode, geonodename);
+
+  // find TPC Geo
+  PHNodeIterator tpcpariter(ParDetNode);
+  PHParametersContainer *tpcparams = findNode::getClass<PHParametersContainer>(ParDetNode, tpcgeonodename);
+  if (!tpcparams)
+  {
+    string runparamname = "G4GEOPARAM_" + detector;
+    PdbParameterMapContainer *tpcpdbparams = findNode::getClass<PdbParameterMapContainer>(RunDetNode, runparamname);
+    if (tpcpdbparams)
+    {
+      tpcparams = new PHParametersContainer(detector);
+      if (Verbosity()) tpcpdbparams->print();
+      tpcparams->CreateAndFillFrom(tpcpdbparams, detector);
+      ParDetNode->addNode(new PHDataNode<PHParametersContainer>(tpcparams, tpcgeonodename));
+    }
+    else
+    {
+      cout << "PHG4TPCElectronDrift::InitRun - failed to find " << runparamname << " in order to initialize " << tpcgeonodename << ". Aborting run ..." << endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+  }
+  assert(tpcparams);
+
+  if (Verbosity()) tpcparams->Print();
+  const PHParameters *tpcparam = tpcparams->GetParameters(0);
+  assert(tpcparam);
+  tpc_length = tpcparam->get_double_param("tpc_length");
+
+  diffusion_long = get_double_param("diffusion_long");
+  added_smear_sigma_long = get_double_param("added_smear_long");
+  diffusion_trans = get_double_param("diffusion_trans");
+  added_smear_sigma_trans = get_double_param("added_smear_trans");
+  drift_velocity = get_double_param("drift_velocity");
+  min_time = 0.0;
+  max_time = (tpc_length / 2.) / drift_velocity;
+  electrons_per_gev = get_double_param("electrons_per_gev");
+  min_active_radius = get_double_param("min_active_radius");
+  max_active_radius = get_double_param("max_active_radius");
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  dlong = new TH1F("difflong", "longitudinal diffusion", 100, diffusion_long - diffusion_long / 2., diffusion_long + diffusion_long / 2.);
+  se->registerHisto(dlong);
+  dtrans = new TH1F("difftrans", "transversal diffusion", 100, diffusion_trans - diffusion_trans / 2., diffusion_trans + diffusion_trans / 2.);
+  se->registerHisto(dtrans);
+  nt = new TNtuple("nt", "electron drift stuff", "hit:ts:tb:tsig:rad:zstart:zfinal");
+  nthit = new TNtuple("nthit", "hit stuff", "hit:layer:phi:phicenter:z_gem:zcenter:weight");
+  ntpad = new TNtuple("ntpad", "electron by electron pad centroid", "layer:phigem:phiclus:zgem:zclus");
+  se->registerHisto(nt);
+  se->registerHisto(nthit);
+  se->registerHisto(ntpad);
+  padplane->InitRun(topNode);
+  padplane->CreateReadoutGeometry(topNode, seggeo);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHG4TPCElectronDrift::process_event(PHCompositeNode *topNode)
+{
+  PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  if (!g4hit)
+  {
+    cout << "Could not locate g4 hit node " << hitnodename << endl;
+    gSystem->Exit(1);
+  }
+
+  PHG4HitContainer::ConstIterator hiter;
+  PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
+
+  double ihit = 0;
+  for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
+  {
+    double t0 = fmax(hiter->second->get_t(0), hiter->second->get_t(1));
+    if (t0 > max_time)
+    {
+      continue;
+    }
+
+    // for very high occupancy events, accessing the TrkrHitsets on the node tree for every drifted electron seems to be very slow
+    // Instead, use a temporary map to accumulate the charge from all drifted electrons, then copy to the node tree later
+
+    double eion = hiter->second->get_eion();
+    unsigned int n_electrons = gsl_ran_poisson(RandomGenerator, eion * electrons_per_gev);
+    if (Verbosity() > 100)
+      cout << "  new hit with t0, " << t0 << " g4hitid " << hiter->first
+           << " eion " << eion << " n_electrons " << n_electrons
+           << " entry z " << hiter->second->get_z(0) << " exit z " << hiter->second->get_z(1) << " avg z" << (hiter->second->get_z(0) + hiter->second->get_z(1)) / 2.0
+           << endl;
+
+    if (n_electrons <= 0)
+      {
+	if (n_electrons < 0)
+	  {
+	    cout << "really bad number of electrons: " << n_electrons
+		 << ", eion: " << eion
+		 << endl;
+	  }
+	continue;
+      }
+    
+    if (Verbosity() > 100)
+      {
+        cout << endl
+             << "electron drift: g4hit " << hiter->first << " created electrons: " << n_electrons
+             << " from " << eion * 1000000 << " keV" << endl;
+        cout << " entry x,y,z = " << hiter->second->get_x(0) << "  " << hiter->second->get_y(0) << "  " << hiter->second->get_z(0)
+             << " radius " << sqrt(pow(hiter->second->get_x(0), 2) + pow(hiter->second->get_y(0), 2)) << endl;
+        cout << " exit x,y,z = " << hiter->second->get_x(1) << "  " << hiter->second->get_y(1) << "  " << hiter->second->get_z(1)
+             << " radius " << sqrt(pow(hiter->second->get_x(1), 2) + pow(hiter->second->get_y(1), 2)) << endl;
+    }
+
+    for (unsigned int i = 0; i < n_electrons; i++)
+    {
+      // We choose the electron starting position at random from a flat distribution along the path length
+      // the parameter t is the fraction of the distance along the path betwen entry and exit points, it has values between 0 and 1
+      double f = gsl_ran_flat(RandomGenerator, 0.0, 1.0);
+
+      double x_start = hiter->second->get_x(0) + f * (hiter->second->get_x(1) - hiter->second->get_x(0));
+      double y_start = hiter->second->get_y(0) + f * (hiter->second->get_y(1) - hiter->second->get_y(0));
+      double z_start = hiter->second->get_z(0) + f * (hiter->second->get_z(1) - hiter->second->get_z(0));
+      double t_start = hiter->second->get_t(0) + f * (hiter->second->get_t(1) - hiter->second->get_t(0));
+
+      double radstart = sqrt(x_start * x_start + y_start * y_start);
+      double r_sigma = diffusion_trans * sqrt(tpc_length / 2. - fabs(z_start));
+      double rantrans = gsl_ran_gaussian(RandomGenerator, r_sigma);
+      rantrans += gsl_ran_gaussian(RandomGenerator, added_smear_sigma_trans);
+
+      double t_path = (tpc_length / 2. - fabs(z_start)) / drift_velocity;
+      double t_sigma = diffusion_long * sqrt(tpc_length / 2. - fabs(z_start)) / drift_velocity;
+      double rantime = gsl_ran_gaussian(RandomGenerator, t_sigma);
+      rantime += gsl_ran_gaussian(RandomGenerator, added_smear_sigma_long) / drift_velocity;
+      double t_final = t_start + t_path + rantime;
+
+      double z_final;
+      if (z_start < 0)
+        z_final = -tpc_length / 2. + t_final * drift_velocity;
+      else
+        z_final = tpc_length / 2. - t_final * drift_velocity;
+
+      if (t_final < min_time || t_final > max_time)
+      {
+        //cout << "skip this, t_final = " << t_final << " is out of range " << min_time <<  " to " << max_time << endl;
+        continue;
+      }
+      double ranphi = gsl_ran_flat(RandomGenerator, -M_PI, M_PI);
+      double x_final = x_start + rantrans * cos(ranphi);
+      double y_final = y_start + rantrans * sin(ranphi);
+      double rad_final = sqrt(x_final * x_final + y_final * y_final);
+      // remove electrons outside of our acceptance. Careful though, electrons from just inside 30 cm can contribute in the 1st active layer readout, so leave a little margin
+      if (rad_final < min_active_radius - 2.0 || rad_final > max_active_radius + 1.0)
+      {
+        continue;
+      }
+
+      if (Verbosity() > 1000)
+      {
+        cout << "electron " << i << " g4hitid " << hiter->first << " f " << f << endl;
+        cout << "radstart " << radstart << " x_start: " << x_start
+             << ", y_start: " << y_start
+             << ",z_start: " << z_start
+             << " t_start " << t_start
+             << " t_path " << t_path
+             << " t_sigma " << t_sigma
+             << " rantime " << rantime
+             << endl;
+
+        //if( sqrt(x_start*x_start+y_start*y_start) > 68.0 && sqrt(x_start*x_start+y_start*y_start) < 72.0)
+        cout << "       rad_final " << rad_final << " x_final " << x_final << " y_final " << y_final
+             << " z_final " << z_final << " t_final " << t_final << " zdiff " << z_final - z_start << endl;
+      }
+
+      if (Verbosity() > 0)
+        nt->Fill(ihit, t_start, t_final, t_sigma, rad_final, z_start, z_final);
+
+      // this fills the cells and updates the hits in temp_hitsetcontainer for this drifted electron hitting the GEM stack
+      MapToPadPlane(x_final, y_final, z_final, hiter, ntpad, nthit);
+    }  // end loop over electrons for this g4hit
+    ihit++;
+
+    // transfer the hits from temp_hitsetcontainer to hitsetcontainer on the node tree
+    TrkrHitSetContainer::ConstRange temp_hitset_range = temp_hitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
+    for (TrkrHitSetContainer::ConstIterator temp_hitset_iter = temp_hitset_range.first;
+	 temp_hitset_iter != temp_hitset_range.second;
+	 ++temp_hitset_iter)
+      {
+	// we have an itrator to one TrkrHitSet for the TPC from the temp_hitsetcontainer
+	TrkrDefs::hitsetkey node_hitsetkey = temp_hitset_iter->first;
+	const unsigned int layer = TrkrDefs::getLayer(node_hitsetkey);
+	const int sector = TpcDefs::getSectorId(node_hitsetkey);
+	const int side = TpcDefs::getSide(node_hitsetkey);	
+	if(Verbosity()>100)   
+	  cout << "PHG4TPCElectronDrift: temp_hitset with key: " << node_hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << endl;
+
+	// find or add this hitset on the node tree
+	TrkrHitSetContainer::Iterator node_hitsetit = hitsetcontainer->findOrAddHitSet(node_hitsetkey);
+	
+	// get all of the hits from the temporary hitset      
+	TrkrHitSet::ConstRange temp_hit_range = temp_hitset_iter->second->getHits();
+	for(TrkrHitSet::ConstIterator temp_hit_iter = temp_hit_range.first;
+	    temp_hit_iter != temp_hit_range.second;
+	    ++temp_hit_iter)
+	  {
+	    TrkrDefs::hitkey temp_hitkey = temp_hit_iter->first;
+	    TrkrHit *temp_tpchit = temp_hit_iter->second;
+
+	    if(Verbosity() > 100)
+	      cout << "      temp_hitkey " << temp_hitkey << " pad " << TpcDefs::getPad(temp_hitkey) << " z bin " << TpcDefs::getTBin(temp_hitkey) 
+		   << "  energy " << temp_tpchit->getEnergy() << endl;
+	    
+	    // find or add this hit to the node tree	    
+	    TrkrHit *node_hit = node_hitsetit->second->getHit(temp_hitkey);
+	    if(!node_hit)
+	      {
+		// Otherwise, create a new one
+		node_hit = new TpcHit();
+		node_hitsetit->second->addHitSpecificKey(temp_hitkey, node_hit);
+	      }
+	    
+	    // Either way, add the energy to it
+	    node_hit->addEnergy(temp_tpchit->getEnergy());
+	    
+	    // Add the hit-g4hit association	    
+	    hittruthassoc->findOrAddAssoc(node_hitsetkey, temp_hitkey, hiter->first);
+	    
+	  }  // end loop over temp hits
+      } // end loop over temp hitsets
+
+    // erase all entries in the temp hitsetcontainer
+    temp_hitsetcontainer->Reset();
+    
+  } // end loop over g4hits
+  
+
+  unsigned int print_layer = 47;  
+
+  if(Verbosity() > 2)
+    {
+      cout << "From PHG4TPCElectronDrift: hitsetcontainer printout at end:" << endl;
+      // We want all hitsets for the TPC
+      TrkrHitSetContainer::ConstRange hitset_range = hitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
+      for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range.first;
+	   hitset_iter != hitset_range.second;
+	   ++hitset_iter)
+	{
+	  // we have an itrator to one TrkrHitSet for the TPC from the trkrHitSetContainer
+	  TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
+	  const unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+	  if(layer != print_layer)  continue;
+	  const int sector = TpcDefs::getSectorId(hitsetkey);
+	  const int side = TpcDefs::getSide(hitsetkey);
+	  
+	  cout << "PHG4TPCElectronDrift: hitset with key: " << hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << endl;
+	  
+	  // get all of the hits from this hitset      
+	  TrkrHitSet *hitset = hitset_iter->second;
+	  TrkrHitSet::ConstRange hit_range = hitset->getHits();
+	  for(TrkrHitSet::ConstIterator hit_iter = hit_range.first;
+	      hit_iter != hit_range.second;
+	      ++hit_iter)
+	    {
+	      TrkrDefs::hitkey hitkey = hit_iter->first;
+	      TrkrHit *tpchit = hit_iter->second;
+
+	      cout << "      hitkey " << hitkey << " pad " << TpcDefs::getPad(hitkey) << " z bin " << TpcDefs::getTBin(hitkey) 
+		   << "  energy " << tpchit->getEnergy() << " adc " << tpchit->getAdc() << endl;
+	    }
+	}
+    }
+
+  if(Verbosity() > 2)
+    {
+      cout << "From PHG4TPCElectronDrift: hittruthassoc dump:" << endl;
+      hittruthassoc->identify();
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void PHG4TPCElectronDrift::MapToPadPlane(const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit)
+{
+  padplane->MapToPadPlane(temp_hitsetcontainer, hittruthassoc, x_gem, y_gem, t_gem, hiter, ntpad, nthit);
+
+  return;
+}
+
+int PHG4TPCElectronDrift::End(PHCompositeNode *topNode)
+{
+  if (Verbosity() > 0)
+  {
+    TFile *outf = new TFile("nt_out.root", "recreate");
+    outf->WriteTObject(nt);
+    outf->WriteTObject(ntpad);
+    outf->WriteTObject(nthit);
+    outf->Close();
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void PHG4TPCElectronDrift::set_seed(const unsigned int iseed)
+{
+  seed = iseed;
+  gsl_rng_set(RandomGenerator, seed);
+}
+
+void PHG4TPCElectronDrift::SetDefaultParameters()
+{
+  // Data on gasses @20 C and 760 Torr from the following source:
+  // http://www.slac.stanford.edu/pubs/icfa/summer98/paper3/paper3.pdf
+  // diffusion and drift velocity for 400kV for NeCF4 90/10 from calculations:
+  // https://www.phenix.bnl.gov/WWW/p/draft/prakhar/tpc/HTML_Gas_Linear/Ne_CF4_90_10.html
+  double Ne_dEdx = 1.56;   // keV/cm
+  double CF4_dEdx = 7.00;  // keV/cm
+  // double Ne_NPrimary = 12;    // Number/cm
+  // double CF4_NPrimary = 51;   // Number/cm
+  double Ne_NTotal = 43;    // Number/cm
+  double CF4_NTotal = 100;  // Number/cm
+  double TPC_NTot = 0.9 * Ne_NTotal + 0.1 * CF4_NTotal;
+  double TPC_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
+  double TPC_ElectronsPerKeV = TPC_NTot / TPC_dEdx;
+  set_default_double_param("diffusion_long", 0.015);   // cm/SQRT(cm)
+  set_default_double_param("diffusion_trans", 0.006);  // cm/SQRT(cm)
+  set_default_double_param("electrons_per_gev", TPC_ElectronsPerKeV * 1000000.);
+  set_default_double_param("min_active_radius", 30.);        // cm
+  set_default_double_param("max_active_radius", 78.);        // cm
+  set_default_double_param("drift_velocity", 8.0 / 1000.0);  // cm/ns
+
+  // These are purely fudge factors, used to increase the resolution to 150 microns and 500 microns, respectively
+  // override them from the macro to get a different resolution
+  set_default_double_param("added_smear_trans", 0.12);  // cm
+  set_default_double_param("added_smear_long", 0.15);   // cm
+
+  return;
+}
+
+void PHG4TPCElectronDrift::registerPadPlane(PHG4TPCPadPlane *inpadplane)
+{
+  cout << "Registering padplane " << endl;
+  padplane = inpadplane;
+  padplane->Detector(Detector());
+  padplane->UpdateInternalParameters();
+  cout << "padplane registered and parameters updated" << endl;
+
+  return;
+}

--- a/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCElectronDrift.h
@@ -1,0 +1,80 @@
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+
+#ifndef G4TPC_PHG4TPCELECTRONDRIFT_H
+#define G4TPC_PHG4TPCELECTRONDRIFT_H
+
+#include <fun4all/SubsysReco.h>
+#include <g4main/PHG4HitContainer.h>
+
+#include <phparameter/PHParameterInterface.h>
+
+// rootcint barfs with this header so we need to hide it
+#ifndef __CINT__
+#include <gsl/gsl_rng.h>
+#endif
+
+#include <vector>
+
+class TrkrHitSetContainer;
+class TrkrHitTruthAssoc;
+
+class PHG4TPCPadPlane;
+class PHG4TPCPadPlaneReadout;
+class PHCompositeNode;
+class TH1;
+class TNtuple;
+
+class PHG4TPCElectronDrift : public SubsysReco, public PHParameterInterface
+{
+ public:
+  PHG4TPCElectronDrift(const std::string &name = "PHG4TPCElectronDrift");
+  virtual ~PHG4TPCElectronDrift();
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  void SetDefaultParameters();
+
+  void Detector(const std::string &d) { detector = d; }
+  std::string Detector() const { return detector; }
+  void set_seed(const unsigned int iseed);
+  //  void Amplify(const double x, const double y, const double z);
+  void MapToPadPlane(const double x, const double y, const double z, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit);
+  //void registerPadPlane(PHG4TPCPadPlaneReadout *padplane);
+  void registerPadPlane(PHG4TPCPadPlane *padplane);
+
+ private:
+  TrkrHitSetContainer *hitsetcontainer;
+  TrkrHitTruthAssoc *hittruthassoc;
+  TH1 *dlong;
+  TH1 *dtrans;
+  TNtuple *nt;
+  TNtuple *nthit;
+  TNtuple *ntpad;
+  std::string detector;
+  std::string hitnodename;
+  std::string cellnodename;
+  std::string seggeonodename;
+  unsigned int seed;
+  double diffusion_trans;
+  double added_smear_sigma_trans;
+  double diffusion_long;
+  double added_smear_sigma_long;
+  double drift_velocity;
+  double tpc_length;
+  double electrons_per_gev;
+  double min_active_radius;
+  double max_active_radius;
+  double min_time;
+  double max_time;
+  TrkrHitSetContainer *temp_hitsetcontainer;
+  PHG4TPCPadPlane *padplane;
+
+#ifndef __CINT__
+  gsl_rng *RandomGenerator;
+#endif
+};
+
+#endif  // G4TPC_PHG4TPCELECTRONDRIFT_H

--- a/simulation/g4simulation/g4tpc/PHG4TPCElectronDriftLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TPCElectronDriftLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4TPCElectronDrift - !;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
This PR moves the setting of the G4VisAttributes to the DisplayAction so we only allocate the needed memory when an event display is made. It also makes the source/class names uniform in the g4intt and g4tpc package. They are still different between the intt/tpc and g4intt/g4tpc, I guess this should be discussed so we can change it before it gets out of hand