### PR TITLE
test include what you use to weed out not needed include files

### DIFF
--- a/offline/database/PHParameter/PHParameterContainerInterface.cc
+++ b/offline/database/PHParameter/PHParameterContainerInterface.cc
@@ -7,7 +7,10 @@
 
 #include <TSystem.h>
 
+#include <cmath>
+#include <iostream>
 #include <sstream>
+#include <utility>
 
 using namespace std;
 

--- a/offline/database/PHParameter/PHParameterInterface.cc
+++ b/offline/database/PHParameter/PHParameterInterface.cc
@@ -6,6 +6,9 @@
 
 #include <TSystem.h>
 
+#include <iostream>
+#include <utility>
+
 using namespace std;
 
 PHParameterInterface::PHParameterInterface(const std::string &name):

--- a/offline/database/PHParameter/PHParameters.cc
+++ b/offline/database/PHParameter/PHParameters.cc
@@ -2,20 +2,22 @@
 
 #include <pdbcalbase/PdbBankManager.h>
 #include <pdbcalbase/PdbApplication.h>
-#include <pdbcalbase/PdbBankList.h>
+//#include <pdbcalbase/PdbBankList.h>
 #include <pdbcalbase/PdbCalBank.h>
 #include <pdbcalbase/PdbParameterMap.h>
 #include <pdbcalbase/PdbParameterMapContainer.h>
+#include <pdbcalbase/PdbBankID.h>
 
 #include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHTimeStamp.h>
+#include <phool/phool.h>
 
 #include <TBufferXML.h>
 #include <TFile.h>
 #include <TSystem.h>
-#include <TBufferFile.h>
+//#include <TBufferFile.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
@@ -35,12 +37,15 @@
 #include <boost/lexical_cast.hpp>
 #endif
 
-#include <cassert>
 #include <algorithm>
-#include <cmath>
+#include <cassert>
+#include <cctype>
+//#include <cmath>
 #include <cstdlib>
+#include <ctime>
 #include <iostream>
 #include <sstream>
+#include <unistd.h>
 
 using namespace std;
 
@@ -130,7 +135,7 @@ PHParameters::exist_double_param(const std::string &name) const
 
 
 void
-PHParameters::Print() const
+PHParameters::Print(Option_t *option) const
 {
   cout << "Parameters for " << m_Detector  << endl;
   printint();

--- a/offline/database/PHParameter/PHParameters.h
+++ b/offline/database/PHParameter/PHParameters.h
@@ -5,8 +5,10 @@
 
 #include <phool/PHObject.h>
 
+#include <cstddef>
 #include <map>
 #include <string>
+#include <utility>
 
 class PdbParameterMap;
 class PdbParameterMapContainer;
@@ -31,7 +33,7 @@ class PHParameters: public PHObject
 
   virtual ~PHParameters();
 
-  void Print() const;
+  void Print(Option_t *option="") const;
 
   //! hash of binary information for checking purpose
   size_t get_hash() const;

--- a/offline/database/PHParameter/PHParametersContainer.cc
+++ b/offline/database/PHParameter/PHParametersContainer.cc
@@ -1,24 +1,30 @@
 #include "PHParametersContainer.h"
 #include "PHParameters.h"
 
-#include <pdbcalbase/PdbBankManager.h>
 #include <pdbcalbase/PdbApplication.h>
-#include <pdbcalbase/PdbBankList.h>
+#include <pdbcalbase/PdbBankManager.h>
+#include <pdbcalbase/PdbBankID.h>
 #include <pdbcalbase/PdbCalBank.h>
 #include <pdbcalbase/PdbParameterMap.h>
 #include <pdbcalbase/PdbParameterMapContainer.h>
 
 #include <phool/phool.h>
 #include <phool/getClass.h>
-
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHTimeStamp.h>
 
 #include <TBufferXML.h>
 #include <TFile.h>
 #include <TSystem.h>
 
 #include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <ctime>
 #include <iostream>
 #include <sstream>
+#include <unistd.h>
 
 using namespace std;
 
@@ -203,7 +209,7 @@ PHParametersContainer::CopyToPdbParameterMapContainer(PdbParameterMapContainer *
 }
 
 void
-PHParametersContainer::Print() const
+PHParametersContainer::Print(Option_t *option) const
 {
   cout << "Name: " << Name() << endl;
   map<int, PHParameters *>::const_iterator iter;

--- a/offline/database/PHParameter/PHParametersContainer.h
+++ b/offline/database/PHParameter/PHParametersContainer.h
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 
 class PHParameters;
 class PdbParameterMapContainer;
@@ -32,7 +33,7 @@ class PHParametersContainer : public PHObject
   std::string Name() const { return superdetectorname; }
   //  std::pair<std::map<int, PHParameters *>::const_iterator,  std::map<int, PHParameters *>::const_iterator> GetAllParameters() {return std::make_pair(parametermap.begin(),parametermap.end());}
   ConstRange GetAllParameters() const { return std::make_pair(parametermap.begin(), parametermap.end()); }
-  void Print() const;
+  void Print(Option_t *option="") const;
   void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename);
   int ExistDetid(const int detid) const;
   void clear() { parametermap.clear(); }

--- a/offline/database/pdbcal/base/PdbApplication.cc
+++ b/offline/database/pdbcal/base/PdbApplication.cc
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <memory>
 
-std::auto_ptr<PdbApplication> PdbApplication::__instance;
+std::unique_ptr<PdbApplication> PdbApplication::__instance;
 
 PdbApplication *PdbApplication::instance()
 {

--- a/offline/database/pdbcal/base/PdbApplication.h
+++ b/offline/database/pdbcal/base/PdbApplication.h
@@ -3,21 +3,20 @@
 
 #include "Pdb.h"
 
-#include <memory>  // for auto_ptr
+#include <memory>  // for unique_ptr
 #include <string>
 
 class PdbCalBank;
-class PHTimeStamp;
 
 class PdbApplication
 {
 
 protected:
   PdbApplication() {}
-  virtual ~PdbApplication() {}
 
 public:
   static PdbApplication *instance();
+  virtual ~PdbApplication() {}
 
 
   virtual PdbStatus startUpdate() = 0;
@@ -35,13 +34,13 @@ public:
   virtual int DisconnectDB() = 0;
 
 protected:
-  // Wrap the singleton object in an auto_ptr so it gets cleaned up.
-  // Even though auto_ptr is often a horrible choice, here it should be ok
+  // Wrap the singleton object in an unique_ptr so it gets cleaned up.
+  // Even though unique_ptr is often a horrible choice, here it should be ok
   // since __instance will never be copied. If this wouldn't be visible for
   // CINT a good choice would have been boost::scoped_ptr, or in C++11
   // std::unique_ptr.
-  friend class std::auto_ptr<PdbApplication>;
-  static std::auto_ptr<PdbApplication> __instance;
+  friend class std::unique_ptr<PdbApplication>;
+  static std::unique_ptr<PdbApplication> __instance;
 };
 
 #endif /* PDBCAL_BASE_PDBAPPLICATION_H */

--- a/offline/database/pdbcal/base/PdbBankManager.cc
+++ b/offline/database/pdbcal/base/PdbBankManager.cc
@@ -10,11 +10,9 @@
 //-----------------------------------------------------------------------------
 #include "PdbBankManager.h"
 
-PdbBankManager *PdbBankManager::__instance = nullptr;
+#include <iostream>
 
-PdbBankManager::PdbBankManager()
-{
-}
+PdbBankManager *PdbBankManager::__instance = nullptr;
 
 PdbBankManager::~PdbBankManager()
 {

--- a/offline/database/pdbcal/base/PdbBankManager.h
+++ b/offline/database/pdbcal/base/PdbBankManager.h
@@ -16,7 +16,6 @@
 
 class PdbCalBank;
 class PdbApplication;
-class PdbBankList;
 class PdbCalBankIterator;
 
 class PdbBankManager 
@@ -24,7 +23,7 @@ class PdbBankManager
 
 protected:
 
-  PdbBankManager();
+  PdbBankManager(){}
   virtual ~PdbBankManager();
 
 public:

--- a/offline/database/pdbcal/base/PdbParameterError.h
+++ b/offline/database/pdbcal/base/PdbParameterError.h
@@ -7,6 +7,8 @@
 
 #include "PdbParameter.h"
 
+#include <string> 
+
 class PdbParameterError : public PdbParameter 
 {
  public:

--- a/offline/database/pdbcal/base/PdbParameterMap.h
+++ b/offline/database/pdbcal/base/PdbParameterMap.h
@@ -3,8 +3,10 @@
 
 #include "PdbCalChan.h"
 
+#include <cstddef>
 #include <map>
 #include <string>
+#include <utility>
 
 class PdbParameterMap: public PdbCalChan
 {

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.cc
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.cc
@@ -10,10 +10,11 @@
 #include <TSystem.h>
 
 #include <algorithm>
-#include <cmath>
-#include <cstdlib>
+#include <cctype>
+#include <ctime>
 #include <iostream>
 #include <sstream>
+#include <unistd.h>
 
 using namespace std;
 

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.h
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.h
@@ -4,6 +4,8 @@
 #include "PdbCalChan.h"
 
 #include <map>
+#include <string>
+#include <utility>
 
 class PdbParameterMap;
 

--- a/offline/database/pdbcal/pg/PgPostApplication.cc
+++ b/offline/database/pdbcal/pg/PgPostApplication.cc
@@ -3,10 +3,18 @@
 #include "PgPostBankWrapperManager.h"
 
 #include <pdbcalbase/PdbApplicationFactory.h>
+#include <pdbcalbase/PHGenericFactoryT.h>
+#include <pdbcalbase/Pdb.h>
+#include <pdbcalbase/PdbApplication.h>
+#include <pdbcalbase/PdbCalBank.h>
 
-#include <RDBC/TSQL.h>
+#include <phool/phool.h>
+
 #include <RDBC/TSQLDriverManager.h>
+#include <RDBC/TSQLConnection.h>
 
+#include <iostream>
+#include <memory>
 #include <sstream>
 
 using namespace std;

--- a/offline/database/pdbcal/pg/PgPostApplication.h
+++ b/offline/database/pdbcal/pg/PgPostApplication.h
@@ -6,9 +6,10 @@
 
 #include <phool/phool.h>
 
-#include <RDBC/TSQLConnection.h>
-
 #include <string>
+
+class PdbCalBank;
+class TSQLConnection;
 
 class PgPostApplication : public PdbApplication
 {

--- a/offline/database/pdbcal/pg/PgPostBankBackupLog.cc
+++ b/offline/database/pdbcal/pg/PgPostBankBackupLog.cc
@@ -1,42 +1,18 @@
 #include "PgPostBankBackupLog.h"
-#include "PgPostApplication.h"
-#include "PgPostBankManager.h"
-#include "PgPostBankWrapper.h"
-#include "PgPostCalBank.h"
-#include "PgPostCalBankIterator.h"
-#include "RunToTimePg.h"
-
-#include <pdbcalbase/PdbBankID.h>
-#include <pdbcalbase/PdbBankList.h>
-#include <pdbcalbase/PdbBankManagerFactory.h>
-#include <pdbcalbase/PdbCalBank.h>
-#include <pdbcalbase/PdbClassMap.h>
-
-#include <phool/PHPointerList.h>
-#include <phool/PHTimeServer.h>
 
 #include <RDBC/TSQL.h>
 #include <RDBC/TSQLConnection.h>
-#include <RDBC/TSQLDatabaseMetaData.h>
 #include <RDBC/TSQLDriverManager.h>
 #include <RDBC/TSQLPreparedStatement.h>
-#include <RDBC/TSQLResultSet.h>
-#include <RDBC/TSQLResultSetMetaData.h>
 
-#include <TBufferFile.h>
-#include <TFile.h>
-#include <TList.h>
 #include <TString.h>
 
-#include <algorithm>
+#include <cassert>
 #include <cstdlib>
-#include <ctime>
+#include <exception>
 #include <fstream>
 #include <iostream>
-#include <map>
-#include <memory>
 #include <sstream>
-#include <vector>
 
 using namespace std;
 

--- a/offline/database/pdbcal/pg/PgPostBankBackupLog.h
+++ b/offline/database/pdbcal/pg/PgPostBankBackupLog.h
@@ -11,18 +11,10 @@
 #ifndef PDBCAL_PG_PGPOSTBANKBACKUPLOG_H
 #define PDBCAL_PG_PGPOSTBANKBACKUPLOG_H
 
-#include <pdbcalbase/PdbCalChan.h>
-#include <phool/PHTimeStamp.h>
-
-#include <iostream>
 #include <string>
-#include <vector>
 
 class TSQLConnection;
-class TSQLStatement;
-class ODBCPreparedStatement;
 class TSQLPreparedStatement;
-class TSQLResultSet;
 
 /*!
  * \brief PgPostBankBackupLog

--- a/offline/database/pdbcal/pg/PgPostBankBackupManager.h
+++ b/offline/database/pdbcal/pg/PgPostBankBackupManager.h
@@ -11,16 +11,15 @@
 #ifndef PDBCAL_PG_PGPOSTBANKBACKUPMANAGER_H
 #define PDBCAL_PG_PGPOSTBANKBACKUPMANAGER_H
 
-#include <pdbcalbase/PdbCalChan.h>
 #include <phool/PHTimeStamp.h>
 
 #include <iostream>
 #include <string>
 #include <vector>
 
+class PdbCalChan;
 class PgPostBankBackupStorage;
 class TSQLStatement;
-class ODBCPreparedStatement;
 class TSQLPreparedStatement;
 class TSQLResultSet;
 

--- a/offline/database/pdbcal/pg/PgPostBankBackupStorage.cc
+++ b/offline/database/pdbcal/pg/PgPostBankBackupStorage.cc
@@ -8,17 +8,19 @@
 
 #include "PgPostBankBackupStorage.h"
 
-#include "PgPostApplication.h"
-#include "PgPostBankManager.h"
 #include "PgPostBankWrapper.h"
 #include "PgPostCalBank.h"
-#include "PgPostCalBankIterator.h"
 
+#include <pdbcalbase/PdbBankID.h>
 #include <pdbcalbase/PdbCalBank.h>
+#include <pdbcalbase/PdbClassMap.h>
+
+#include <TNamed.h>
 
 #include <cassert>
 #include <cstdlib>
 #include <iostream>
+#include <map>
 #include <sstream>
 #include <string>
 

--- a/offline/database/pdbcal/pg/PgPostBankBackupStorage.h
+++ b/offline/database/pdbcal/pg/PgPostBankBackupStorage.h
@@ -10,14 +10,13 @@
 #define PDBCAL_PG_PGPOSTBANKBACKUPSTORAGE_H
 
 #include <pdbcalbase/PdbCalChan.h>
-#include <pdbcalbase/PdbClassMap.h>
 
 #include <phool/PHTimeStamp.h>
 
-#include <TClonesArray.h>
 #include <TNamed.h>
 
 #include <cassert>
+#include <cstddef>
 #include <string>
 
 class PgPostCalBank;

--- a/offline/database/pdbcal/pg/PgPostBankManager.cc
+++ b/offline/database/pdbcal/pg/PgPostBankManager.cc
@@ -1,30 +1,32 @@
 #include "PgPostBankManager.h"
 #include "PgPostApplication.h"
 #include "PgPostBankWrapper.h"
-#include "PgPostCalBank.h"
 #include "PgPostCalBankIterator.h"
-#include "RunToTimePg.h"
 
 #include <pdbcalbase/PdbBankID.h>
-#include <pdbcalbase/PdbBankList.h>
 #include <pdbcalbase/PdbBankManagerFactory.h>
 #include <pdbcalbase/PdbCalBank.h>
 #include <pdbcalbase/PdbClassMap.h>
+#include <pdbcalbase/PHGenericFactoryT.h>
+#include <pdbcalbase/RunToTime.h>
+#include <pdbcalbase/PdbBankManager.h>
 
-#include <phool/PHPointerList.h>
+#include <phool/phool.h>
 
 #include <RDBC/TSQLConnection.h>
-#include <RDBC/TSQLDatabaseMetaData.h>
-#include <RDBC/TSQLDriverManager.h>
-#include <RDBC/TSQLPreparedStatement.h>
 #include <RDBC/TSQLResultSet.h>
-#include <RDBC/TSQLResultSetMetaData.h>
+#include <RDBC/TSQLStatement.h>
+
+#include <TString.h>
 
 #include <cstdlib>
 #include <ctime>
 #include <iostream>
 #include <memory>
 #include <sstream>
+
+class PdbApplication;
+class PdbCalBankIterator;
 
 using namespace std;
 

--- a/offline/database/pdbcal/pg/PgPostBankManager.h
+++ b/offline/database/pdbcal/pg/PgPostBankManager.h
@@ -4,9 +4,16 @@
 #include <pdbcalbase/PdbBankID.h>
 #include <pdbcalbase/PdbBankManager.h>
 
+#include <phool/PHTimeStamp.h>
+
 #include <map>
 #include <set>
 #include <string>
+#include <ctime> 
+
+class PdbApplication;
+class PdbCalBank;
+class PdbCalBankIterator;
 
 class PgPostBankManager : public PdbBankManager
 {

--- a/offline/database/pdbcal/pg/PgPostBankWrapper.cc
+++ b/offline/database/pdbcal/pg/PgPostBankWrapper.cc
@@ -3,14 +3,10 @@
 #include "PgPostBankWrapperManager.h"
 
 #include <phool/phool.h>
+#include <phool/PHTimeStamp.h>
 
 #include <RDBC/TSQLConnection.h>
-#include <RDBC/TSQLDriverManager.h>
 #include <RDBC/TSQLPreparedStatement.h>
-#include <RDBC/TSQLResultSet.h>
-#include <RDBC/TSQLResultSetMetaData.h>
-
-#include <RDBC/TSQLDatabaseMetaData.h>
 
 #include <unistd.h>  // for sleep
 #include <cstdlib>

--- a/offline/database/pdbcal/pg/PgPostBankWrapper.h
+++ b/offline/database/pdbcal/pg/PgPostBankWrapper.h
@@ -3,10 +3,15 @@
 
 #include "PgPostCalBank.h"
 
+#include <pdbcalbase/PdbBankID.h>
+#include <pdbcalbase/PdbCalBank.h>
+
 #include <phool/PHTimeStamp.h>
 
-#include <iostream>
+#include <cstddef>
 #include <string>
+
+class PdbCalChan;
 
 class PgPostBankWrapper : public PgPostCalBank
 {

--- a/offline/database/pdbcal/pg/PgPostBankWrapperManager.cc
+++ b/offline/database/pdbcal/pg/PgPostBankWrapperManager.cc
@@ -1,16 +1,15 @@
 #include "PgPostBankWrapperManager.h"
 #include "PgPostBankWrapper.h"
 
+#include <pdbcalbase/PdbBankID.h>
+
 #include <phool/phool.h>
 
 #include <algorithm>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
-
-//_____________________________________________________________________________
-PgPostBankWrapperManager::PgPostBankWrapperManager()
-{
-}
+#include <string>
 
 //_____________________________________________________________________________
 PgPostBankWrapperManager&

--- a/offline/database/pdbcal/pg/PgPostBankWrapperManager.h
+++ b/offline/database/pdbcal/pg/PgPostBankWrapperManager.h
@@ -21,7 +21,7 @@ class PgPostBankWrapperManager
   bool unregisterWrapper(PgPostBankWrapper* wrapper);
 
  private:
-  PgPostBankWrapperManager();
+  PgPostBankWrapperManager(){}
 
   typedef std::vector<PgPostBankWrapper*> WVECTOR;
 

--- a/offline/database/pdbcal/pg/PgPostCalBankIterator.cc
+++ b/offline/database/pdbcal/pg/PgPostCalBankIterator.cc
@@ -3,15 +3,23 @@
 #include "PgPostBankManager.h"
 #include "PgPostBankWrapper.h"
 
+#include <pdbcalbase/PdbApplication.h>
 #include <pdbcalbase/PdbBankID.h>
+#include <pdbcalbase/PdbCalBank.h>
+
+#include <phool/phool.h>
 
 #include <RDBC/TSQLConnection.h>
 #include <RDBC/TSQLResultSet.h>
 #include <RDBC/TSQLStatement.h>
 
+#include <TString.h>
+
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <utility>
+
 
 using namespace std;
 

--- a/offline/database/pdbcal/pg/PgPostCalBankIterator.h
+++ b/offline/database/pdbcal/pg/PgPostCalBankIterator.h
@@ -4,11 +4,16 @@
 #include <pdbcalbase/PdbBankID.h>
 #include <pdbcalbase/PdbCalBankIterator.h>
 
+#include <phool/PHTimeStamp.h>
+
+#include <ctime>
 #include <map>
+#include <iostream>
 #include <string>
 
-class PgPostBankManager;
+class PdbCalBank;
 class PgPostApplication;
+class PgPostBankManager;
 class TSQLResultSet;
 class TSQLStatement;
 

--- a/offline/framework/phool/PHCompositeNode.h
+++ b/offline/framework/phool/PHCompositeNode.h
@@ -7,8 +7,9 @@
 #include "PHNode.h"
 #include "PHPointerList.h"
 
+#include <string>
+
 class PHIOManager;
-class PHNodeIterator;
 
 class PHCompositeNode : public PHNode
 {

--- a/offline/framework/phool/PHFlag.cc
+++ b/offline/framework/phool/PHFlag.cc
@@ -1,9 +1,8 @@
 #include "PHFlag.h"
 
-#include <cstring>
 #include <fstream>
 #include <iostream>
-#include <sstream>
+#include <map>
 
 using namespace std;
 

--- a/offline/framework/phool/PHIOManager.h
+++ b/offline/framework/phool/PHIOManager.h
@@ -5,6 +5,7 @@
 //  Purpose: Abstract base class for file IO
 //  Author: Matthias Messer
 
+#include <cstddef>
 #include <string>
 
 class PHCompositeNode;

--- a/offline/framework/phool/PHNode.cc
+++ b/offline/framework/phool/PHNode.cc
@@ -8,7 +8,6 @@
 
 #include <boost/stacktrace.hpp>
 
-#include <cstdlib>
 #include <iostream>
 
 using namespace std;

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -27,8 +27,11 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <iostream>
 #include <sstream>
 #include <string>
+#include <utility>
+#include <vector>
 
 using namespace std;
 

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -9,13 +9,15 @@
 
 #include "phool.h"
 
+#include <cstddef>
 #include <map>
 #include <string>
 
-class TObject;
-class TFile;
-class TTree;
+class PHCompositeNode;
 class TBranch;
+class TFile;
+class TObject;
+class TTree;
 
 class PHNodeIOManager : public PHIOManager
 {

--- a/offline/framework/phool/PHNodeIntegrate.cc
+++ b/offline/framework/phool/PHNodeIntegrate.cc
@@ -3,10 +3,12 @@
 #include "PHCompositeNode.h"
 #include "PHDataNode.h"
 #include "PHIODataNode.h"
+#include "PHNode.h"
 #include "PHObject.h"
 #include "getClass.h"
 
 #include <iostream>
+#include <string>
 
 using namespace std;
 

--- a/offline/framework/phool/PHNodeIterator.cc
+++ b/offline/framework/phool/PHNodeIterator.cc
@@ -8,13 +8,16 @@
 //  Author: Matthias Messer
 //-----------------------------------------------------------------------------
 #include "PHNodeIterator.h"
+
+#include "PHCompositeNode.h" 
+#include "PHNode.h"
 #include "PHNodeOperation.h"
 #include "PHPointerListIterator.h"
 #include "phooldefs.h"
 
 #include <boost/algorithm/string.hpp>
 
-#include <iostream>
+#include <utility> 
 #include <vector>
 
 using namespace std;

--- a/offline/framework/phool/PHNodeIterator.h
+++ b/offline/framework/phool/PHNodeIterator.h
@@ -5,9 +5,13 @@
 //  Purpose: iterator to navigate a node tree
 //  Author: Matthias Messer
 
-#include "PHCompositeNode.h"
+//#include "PHCompositeNode.h"
 #include "PHPointerList.h"
 
+#include <string> 
+
+class PHCompositeNode;
+class PHNode;
 class PHNodeOperation;
 
 class PHNodeIterator

--- a/offline/framework/phool/PHNodeReset.cc
+++ b/offline/framework/phool/PHNodeReset.cc
@@ -4,10 +4,11 @@
 #include "PHNodeReset.h"
 
 #include "PHDataNode.h"
-#include "PHIODataNode.h"
+#include "PHNode.h"
 #include "PHObject.h"
 
 #include <iostream>
+#include <string>
 
 using namespace std;
 

--- a/offline/framework/phool/PHRandomSeed.cc
+++ b/offline/framework/phool/PHRandomSeed.cc
@@ -1,7 +1,6 @@
 #include "PHRandomSeed.h"
 #include "recoConsts.h"
 
-#include <cstdlib>
 #include <iostream>
 #include <queue>
 #include <random>

--- a/offline/framework/phool/PHRawDataNode.cc
+++ b/offline/framework/phool/PHRawDataNode.cc
@@ -3,7 +3,10 @@
 
 #include "PHRawDataNode.h"
 
+#include "PHIOManager.h"
 #include "PHRawOManager.h"
+
+#include <Event/phenixTypes.h>
 
 using namespace std;
 

--- a/offline/framework/phool/PHRawDataNode.h
+++ b/offline/framework/phool/PHRawDataNode.h
@@ -11,6 +11,8 @@
 
 #include <string>
 
+class PHIOManager;
+
 class PHRawDataNode : public PHDataNode<PHDWORD>
 {
  public:

--- a/offline/framework/phool/PHRawOManager.cc
+++ b/offline/framework/phool/PHRawOManager.cc
@@ -13,13 +13,13 @@
 #include "phool.h"
 
 #include <Event/EventTypes.h>
+#include <Event/oBuffer.h>
 #include <Event/ogzBuffer.h>
-#include <Event/packetConstants.h>
+#include <Event/phenixTypes.h>
 
 #include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <iostream>
+#include <sys/stat.h>
 
 using namespace std;
 
@@ -65,8 +65,8 @@ void PHRawOManager::closeFile()
   {
     delete memBuffer;
   }
-  fileBuffer = 0;
-  memBuffer = 0;
+  fileBuffer = nullptr;
+  memBuffer = nullptr;
   if (filedesc >= 0)
   {
     close(filedesc);

--- a/offline/framework/phool/PHTimeServer.cc
+++ b/offline/framework/phool/PHTimeServer.cc
@@ -9,7 +9,7 @@
 */
 
 #include "PHTimeServer.h"
-#include <algorithm>
+
 #include <cstdio>
 #include <stdexcept>
 

--- a/offline/framework/phool/PHTimeServer.h
+++ b/offline/framework/phool/PHTimeServer.h
@@ -15,10 +15,8 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 
-#ifndef __CINT__
-#include <boost/smart_ptr.hpp>
-#endif
 /*!
 \class	 PHTimeServer
 \brief	 PHTimer server for accessing external information

--- a/offline/framework/phool/PHTimeStamp.cc
+++ b/offline/framework/phool/PHTimeStamp.cc
@@ -11,6 +11,7 @@
 
 #include <climits>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 
 using namespace std;

--- a/offline/framework/phool/PHTimeStamp.h
+++ b/offline/framework/phool/PHTimeStamp.h
@@ -13,6 +13,7 @@
 #include "PHObject.h"
 
 #include <ctime>
+#include <iosfwd> 
 
 typedef unsigned long long phtime_t;
 

--- a/offline/framework/phool/PHTimer.cc
+++ b/offline/framework/phool/PHTimer.cc
@@ -12,6 +12,7 @@
 
 #include <climits>
 #include <cmath>
+#include <cstddef>
 #include <fstream>
 #include <stdexcept>
 

--- a/offline/framework/phool/PHTimer.h
+++ b/offline/framework/phool/PHTimer.h
@@ -10,7 +10,9 @@
 */
 
 #include <unistd.h>
+#include <exception>
 #include <iostream>
+#include <string>
 #include <sstream>
 
 #define rdtsc(low, high)       \

--- a/offline/packages/NodeDump/Dumper.cc
+++ b/offline/packages/NodeDump/Dumper.cc
@@ -1,6 +1,7 @@
 #include "Dumper.h"
 #include "PHNodeDump.h"
 
+#include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHPointerListIterator.h>
 

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.h
@@ -5,7 +5,7 @@
  */
 
 #ifndef PHGENFIT_TRACK_H
-#define PHGENFIT_TRACK_K
+#define PHGENFIT_TRACK_H
 
 #include <GenFit/Track.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
@@ -12,6 +12,7 @@
 #include <g4main/PHG4Utils.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.cc
@@ -4,7 +4,9 @@
 #include "PHG4CEmcTestBeamSteppingAction.h"
 
 #include <g4main/PHG4HitContainer.h>
+
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 #include <Geant4/G4SystemOfUnits.hh>

--- a/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
@@ -5,7 +5,9 @@
 #include "PHG4ConeSteppingAction.h"
 
 #include <g4main/PHG4HitContainer.h>
+
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
@@ -7,6 +7,7 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <sstream>
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -12,6 +12,7 @@
 #include <g4main/PHG4Utils.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
@@ -3,7 +3,9 @@
 #include "PHG4EnvelopeSteppingAction.h"
 
 #include <g4main/PHG4HitContainer.h>
+
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4FCalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FCalSubsystem.cc
@@ -3,7 +3,9 @@
 #include "PHG4FCalSteppingAction.h"
 
 #include <g4main/PHG4HitContainer.h>
+
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 //_______________________________________________________________________
 PHG4FCalSubsystem::PHG4FCalSubsystem( const char* name ):

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
@@ -5,7 +5,9 @@
 #include "PHG4EventActionClearZeroEdep.h"
 
 #include <g4main/PHG4HitContainer.h>
+
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.cc
@@ -7,6 +7,7 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystem.cc
@@ -6,6 +6,7 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <sstream>
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalPrototypeSubsystem.cc
@@ -7,7 +7,9 @@
 #include "PHG4HcalPrototypeSteppingAction.h"
 
 #include <g4main/PHG4HitContainer.h>
+
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
@@ -8,6 +8,7 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -11,6 +11,7 @@
 #include <pdbcalbase/PdbParameterMap.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -12,6 +12,7 @@
 #include <pdbcalbase/PdbParameterMap.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.cc
@@ -20,6 +20,7 @@
 #include <pdbcalbase/PdbParameterMap.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2InnerHcalSubsystem.cc
@@ -8,6 +8,7 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype2OuterHcalSubsystem.cc
@@ -8,6 +8,7 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Prototype3InnerHcalSubsystem.cc
@@ -8,6 +8,7 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4RICHSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHSubsystem.cc
@@ -16,6 +16,7 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 using namespace ePHENIXRICH;
 using namespace std;

--- a/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.cc
@@ -6,6 +6,7 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalPrototypeSubsystem.cc
@@ -15,7 +15,9 @@
 #include <g4main/PHG4HitContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
+
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <pdbcalbase/PdbParameterMap.h>
 #include <pdbcalbase/PdbParameterMapContainer.h>

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -24,6 +24,7 @@
 #include <g4main/PHG4Utils.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4detectors/PHG4mRICHSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHSubsystem.cc
@@ -13,11 +13,13 @@
 #include <g4main/PHG4Utils.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
-#include <sstream>
+
 #include <boost/foreach.hpp>
-//#include <string>
+
+#include <sstream>
 
 using namespace std;
 

--- a/simulation/g4simulation/g4intt/PHG4InttSubsystem.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttSubsystem.cc
@@ -8,7 +8,9 @@
 #include <phparameter/PHParametersContainer.h>
 
 #include <g4main/PHG4HitContainer.h>
+
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4main/G4TBFieldMessenger.cc
+++ b/simulation/g4simulation/g4main/G4TBFieldMessenger.cc
@@ -32,12 +32,16 @@
 #include "G4TBFieldMessenger.hh"
 
 #include "G4TBMagneticFieldSetup.hh"
+
+#include <Geant4/G4ApplicationState.hh>
+#include <Geant4/G4String.hh>
 #include <Geant4/G4UIdirectory.hh>
 #include <Geant4/G4UIcmdWithAString.hh>
 #include <Geant4/G4UIcmdWithAnInteger.hh>
-#include <Geant4/G4UIcmdWithADouble.hh>
 #include <Geant4/G4UIcmdWithADoubleAndUnit.hh>
 #include <Geant4/G4UIcmdWithoutParameter.hh>
+
+class G4UIcommand;
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/simulation/g4simulation/g4main/G4TBFieldMessenger.hh
+++ b/simulation/g4simulation/g4main/G4TBFieldMessenger.hh
@@ -32,17 +32,17 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-#ifndef G4TBFieldMessenger_h
-#define G4TBFieldMessenger_h 1
+#ifndef G4MAIN_G4TBFIELDMESSENGER_H
+#define G4MAIN_G4TBFIELDMESSENGER_H
 
-#include <Geant4/globals.hh>
+#include <Geant4/G4String.hh>
+#include <Geant4/G4Types.hh>
 #include <Geant4/G4UImessenger.hh>
 
 class G4TBMagneticFieldSetup;
 class G4UIdirectory;
 class G4UIcmdWithAString;
 class G4UIcmdWithAnInteger;
-class G4UIcmdWithADouble;
 class G4UIcmdWithADoubleAndUnit;
 class G4UIcmdWithoutParameter;
 

--- a/simulation/g4simulation/g4main/G4TBMagneticFieldSetup.cc
+++ b/simulation/g4simulation/g4main/G4TBMagneticFieldSetup.cc
@@ -35,39 +35,28 @@
 #include "G4TBFieldMessenger.hh"
 #include "PHG4MagneticField.h"
 
-#include <fun4all/Fun4AllServer.h>
-#include <phool/getClass.h>
 
-#include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>
-#include <phool/PHNodeIterator.h>
-
-#include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4UniformMagField.hh>
 #include <Geant4/G4MagneticField.hh>
 #include <Geant4/G4FieldManager.hh>
 #include <Geant4/G4TransportationManager.hh>
-#include <Geant4/G4EquationOfMotion.hh>
-#include <Geant4/G4EqMagElectricField.hh>
 #include <Geant4/G4Mag_UsualEqRhs.hh>
 #include <Geant4/G4MagIntegratorStepper.hh>
 #include <Geant4/G4MagIntegratorDriver.hh>
 #include <Geant4/G4ChordFinder.hh>
-
 #include <Geant4/G4ExplicitEuler.hh>
 #include <Geant4/G4ImplicitEuler.hh>
 #include <Geant4/G4SimpleRunge.hh>
 #include <Geant4/G4SimpleHeum.hh>
 #include <Geant4/G4ClassicalRK4.hh>
-#include <Geant4/G4HelixExplicitEuler.hh>
-#include <Geant4/G4HelixImplicitEuler.hh>
-#include <Geant4/G4HelixSimpleRunge.hh>
 #include <Geant4/G4CashKarpRKF45.hh>
-#include <Geant4/G4RKG3_Stepper.hh>
+#include <Geant4/G4ThreeVector.hh>
+#include <Geant4/G4SystemOfUnits.hh>
 
-
-#include <sstream>
 #include <cassert>
+#include <iostream>
+#include <sstream>
+#include <string>
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/G4TBMagneticFieldSetup.hh
+++ b/simulation/g4simulation/g4main/G4TBMagneticFieldSetup.hh
@@ -33,22 +33,18 @@
 //  It is simply a 'setup' class that creates the field and necessary other parts
 //
 
+#ifndef G4MAIN_G4TBELECTRICFIELDSETUP_H
+#define G4MAIN_G4TBELECTRICFIELDSETUP_H
 
-#ifndef G4TBElectricFieldSetup_H
-#define G4TBElectricFieldSetup_H
-
-#include <Geant4/G4MagneticField.hh>
-#include <Geant4/G4UniformMagField.hh>
-
-#include <string>
+#include <Geant4/G4ThreeVector.hh>
+#include <Geant4/G4Types.hh>
 
 class G4FieldManager;
 class G4ChordFinder;
-class G4EquationOfMotion;
-class G4Mag_EqRhs;
 class G4Mag_UsualEqRhs;
 class G4MagIntegratorStepper;
 class G4MagInt_Driver; 
+class G4MagneticField;
 class G4TBFieldMessenger;
 class PHField;
 

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -1,28 +1,40 @@
 #include "HepMCNodeReader.h"
 #include "PHG4InEvent.h"
+#include "PHG4Particle.h"
 #include "PHG4Particlev1.h"
-#include "PHG4Particlev2.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
 #include <phhepmc/PHHepMCGenEvent.h>
 #include <phhepmc/PHHepMCGenEventMap.h>
 
-#include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/PHRandomSeed.h>
+#include <phool/phool.h>
 #include <phool/recoConsts.h>
 
-#include <Geant4/G4ParticleDefinition.hh>
-#include <Geant4/G4ParticleTable.hh>
-
 #include <HepMC/GenEvent.h>
+#include <HepMC/GenParticle.h>
+#include <HepMC/GenVertex.h>
+#include <HepMC/IteratorRange.h>
+#include <HepMC/SimpleVector.h>
+#include <HepMC/Units.h>
 
 #include <gsl/gsl_const.h>
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>
 
 #include <cassert>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <iterator>
 #include <list>
+#include <utility>
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -1,5 +1,5 @@
-#ifndef HEPMCNODEREADER_H__
-#define HEPMCNODEREADER_H__
+#ifndef G4MAIN_HEPMCNODEREADER_H
+#define G4MAIN_HEPMCNODEREADER_H
 
 #include <fun4all/SubsysReco.h>
 
@@ -10,7 +10,6 @@
 
 #include <string>
 
-class PHHepMCGenEvent;
 class PHCompositeNode;
 
 //! HepMCNodeReader take input from all subevents from PHHepMCGenEventMap and send them to simulation in Geant4

--- a/simulation/g4simulation/g4main/PHG4EventHeaderv1.cc
+++ b/simulation/g4simulation/g4main/PHG4EventHeaderv1.cc
@@ -1,5 +1,7 @@
 #include "PHG4EventHeaderv1.h"
 
+#include <cmath>
+
 using namespace std;
 
 PHG4EventHeaderv1::PHG4EventHeaderv1():

--- a/simulation/g4simulation/g4main/PHG4EventHeaderv1.h
+++ b/simulation/g4simulation/g4main/PHG4EventHeaderv1.h
@@ -1,11 +1,8 @@
-#ifndef PHG4EVENTHEADERV1_H
-#define PHG4EVENTHEADERV1_H
+#ifndef G4MAIN_PHG4EVENTHEADERV1_H
+#define G4MAIN_PHG4EVENTHEADERV1_H
 
 #include "PHG4EventHeader.h"
 
-#include <phool/phool.h>
-
-#include <cmath>
 #include <iostream>
 
 ///
@@ -51,6 +48,3 @@ class PHG4EventHeaderv1: public PHG4EventHeader
 };
 
 #endif
-
-
-

--- a/simulation/g4simulation/g4main/PHG4HeadReco.cc
+++ b/simulation/g4simulation/g4main/PHG4HeadReco.cc
@@ -5,8 +5,9 @@
 #include <ffaobjects/FlagSavev1.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/getClass.h>
 
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 #include <phool/phool.h>
 
 #include <TSystem.h>

--- a/simulation/g4simulation/g4main/PHG4Hit.cc
+++ b/simulation/g4simulation/g4main/PHG4Hit.cc
@@ -1,6 +1,7 @@
 #include "PHG4Hit.h"
 
 #include <cstdlib>
+#include <type_traits>
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -1,10 +1,15 @@
-#ifndef PHG4Hit_H__
-#define PHG4Hit_H__
+#ifndef G4MAIN_PHG4Hit_H
+#define G4MAIN_PHG4Hit_H
 
 #include "PHG4HitDefs.h"
+
 #include <phool/PHObject.h>
+
 #include <cmath>
 #include <climits>
+#include <iostream> 
+#include <string>
+#include <utility>
 
 class PHG4Hit: public PHObject
 {

--- a/simulation/g4simulation/g4main/PHG4HitContainer.h
+++ b/simulation/g4simulation/g4main/PHG4HitContainer.h
@@ -1,12 +1,16 @@
-#ifndef PHG4HITCONTAINER_H__
-#define PHG4HITCONTAINER_H__
+#ifndef G4MAIN_PHG4HITCONTAINER_H
+#define G4MAIN_PHG4HITCONTAINER_H
 
 #include "PHG4HitDefs.h"
 
 #include <phool/PHObject.h>
+
+#include <iostream>
 #include <map>
 #include <set>
 #include <string>
+#include <utility>
+
 class PHG4Hit;
 
 class PHG4HitContainer: public PHObject

--- a/simulation/g4simulation/g4main/PHG4HitDefs.cc
+++ b/simulation/g4simulation/g4main/PHG4HitDefs.cc
@@ -1,7 +1,6 @@
 #include "PHG4HitDefs.h"
 
-#include <tr1/functional_hash.h>
-#include <cstdlib>
+#include <tr1/functional>
 
 namespace PHG4HitDefs
 {

--- a/simulation/g4simulation/g4main/PHG4HitEval.cc
+++ b/simulation/g4simulation/g4main/PHG4HitEval.cc
@@ -10,17 +10,16 @@
 
 #include "PHG4HitEval.h"
 
+#include <cmath>
+
+class PHG4Hit;
+
 PHG4HitEval::PHG4HitEval() :
     eion(NAN), scint_id(-9999), light_yield(NAN), path_length(NAN)
 
 {
   // TODO Auto-generated constructor stub
 
-}
-
-PHG4HitEval::~PHG4HitEval()
-{
-  // TODO Auto-generated destructor stub
 }
 
 PHG4HitEval::PHG4HitEval(PHG4Hit const &g4hit)

--- a/simulation/g4simulation/g4main/PHG4HitEval.h
+++ b/simulation/g4simulation/g4main/PHG4HitEval.h
@@ -8,8 +8,8 @@
  * \date $Date: $
  */
 
-#ifndef PHG4HITEVAL_H_
-#define PHG4HITEVAL_H_
+#ifndef G4MAIN_PHG4HITEVAL_H
+#define G4MAIN_PHG4HITEVAL_H
 
 #include "PHG4Hitv1.h"
 
@@ -24,7 +24,7 @@ public:
   PHG4HitEval(const PHG4Hit& g4hit);
 
   virtual
-  ~PHG4HitEval();
+    ~PHG4HitEval(){}
 
   virtual void Copy(PHG4Hit const &g4hit);
 

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -3,7 +3,11 @@
 
 #include <phool/phool.h>
 
+#include <climits>
+#include <cmath>
 #include <cstdlib>
+#include <string>
+#include <utility>
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/PHG4InEvent.cc
+++ b/simulation/g4simulation/g4main/PHG4InEvent.cc
@@ -1,10 +1,10 @@
 #include "PHG4InEvent.h"
 
 #include "PHG4Particle.h"
+#include "PHG4VtxPoint.h"
 #include "PHG4VtxPointv1.h"
 
-#include <phool/phool.h>
-
+#include <cmath>
 #include <cstdlib>
 
 using namespace std;

--- a/simulation/g4simulation/g4main/PHG4InEvent.h
+++ b/simulation/g4simulation/g4main/PHG4InEvent.h
@@ -1,10 +1,11 @@
-#ifndef PHG4InEvent_H__
-#define PHG4InEvent_H__
+#ifndef G4MAIN_PHG4InEvent_H
+#define G4MAIN_PHG4InEvent_H
 
 #include <phool/PHObject.h>
 
+#include <iostream>
 #include <map>
-#include <set>
+#include <utility>
 
 class PHG4Particle;
 class PHG4VtxPoint;

--- a/simulation/g4simulation/g4main/PHG4Particle.h
+++ b/simulation/g4simulation/g4main/PHG4Particle.h
@@ -4,6 +4,8 @@
 #include <phool/PHObject.h>
 
 #include <cmath>
+#include <iostream>
+#include <string>
 
 class PHG4Particle : public PHObject
 {

--- a/simulation/g4simulation/g4main/PHG4Particlev1.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev1.cc
@@ -1,5 +1,7 @@
 #include "PHG4Particlev1.h"
 
+#include <ostream>
+
 using namespace std;
 
 PHG4Particlev1::PHG4Particlev1()

--- a/simulation/g4simulation/g4main/PHG4Particlev1.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev1.h
@@ -3,6 +3,9 @@
 
 #include "PHG4Particle.h"
 
+#include <iostream>
+#include <string>
+
 class PHG4Particlev1 : public PHG4Particle
 {
  public:

--- a/simulation/g4simulation/g4main/PHG4Particlev2.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.cc
@@ -1,5 +1,9 @@
 #include "PHG4Particlev2.h"
 
+#include <ostream>
+
+class PHG4Particle;
+
 using namespace std;
 
 PHG4Particlev2::PHG4Particlev2()

--- a/simulation/g4simulation/g4main/PHG4Particlev2.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.h
@@ -3,6 +3,11 @@
 
 #include "PHG4Particlev1.h"
 
+#include <iostream>
+#include <string>
+
+class PHG4Particle;
+
 class PHG4Particlev2 : public PHG4Particlev1
 {
  public:

--- a/simulation/g4simulation/g4main/PHG4Particlev3.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev3.cc
@@ -1,6 +1,11 @@
 #include "PHG4Particlev3.h"
+#include "PHG4Particle.h"
 
 #include <Geant4/G4SystemOfUnits.hh>
+
+#include <cmath>
+#include <ostream>
+#include <string>
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/PHG4Particlev3.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev3.h
@@ -1,7 +1,11 @@
-#ifndef PHG4PARTICLEV3_H__
-#define PHG4PARTICLEV3_H__
+#ifndef G4MAIN_PHG4PARTICLEV3_H
+#define G4MAIN_PHG4PARTICLEV3_H
 
 #include "PHG4Particlev2.h"
+
+#include <iostream>
+
+class PHG4Particle;
 
 class PHG4Particlev3 : public PHG4Particlev2
 {

--- a/simulation/g4simulation/g4main/PHG4Showerv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Showerv1.cc
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <utility>
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/PHG4Showerv1.h
+++ b/simulation/g4simulation/g4main/PHG4Showerv1.h
@@ -1,11 +1,11 @@
-#ifndef __PHG4SHOWER_V1_H__
-#define __PHG4SHOWER_V1_H__
+#ifndef G4MAIN_PHG4SHOWERV1_H
+#define G4MAIN_PHG4SHOWERV1_H
 
 #include "PHG4Shower.h"
 
 #include "PHG4HitDefs.h"
 
-#include <phool/PHObject.h>
+#include <cstddef>
 #include <map>
 #include <set>
 #include <iostream>
@@ -97,7 +97,7 @@ public:
   PHG4Shower::HitIdConstIter find_g4hit_id(int volume) const {return _g4hit_ids.find(volume);}
   PHG4Shower::HitIdIter      end_g4hit_id() {return _g4hit_ids.end();}
   PHG4Shower::HitIdConstIter end_g4hit_id() const {return _g4hit_ids.end();}
-  size_t                     remove_g4hit_id(int volume,int id) {return _g4hit_ids[volume].erase(id);}
+  size_t                     remove_g4hit_id(int volume, PHG4HitDefs::keytype id) {return _g4hit_ids[volume].erase(id);}
   size_t                     remove_g4hit_volume(int volume) {return _g4hit_ids.erase(volume);}
   void                       clear_g4hit_id() {return _g4hit_ids.clear();}
   

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -13,6 +13,7 @@
 #include <phool/getClass.h>
 #include <phool/PHPointerListIterator.h>
 #include <phool/PHNode.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/G4Event.hh>
 #include <Geant4/G4TrajectoryContainer.hh>

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -2,17 +2,12 @@
 
 #include "PHG4Particle.h"
 #include "PHG4Shower.h"
-#include "PHG4VtxPointv1.h"
+#include "PHG4VtxPoint.h"
 
-#include <phool/phool.h>
-
-#include <boost/foreach.hpp>
 #include <boost/tuple/tuple.hpp>
 
-#include <algorithm>
-#include <stdexcept>
 #include <limits>
-#include <cstdlib>
+#include <string> 
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -1,10 +1,12 @@
-#ifndef PHG4TRUTHINFOCONTAINER_H__
-#define PHG4TRUTHINFOCONTAINER_H__
+#ifndef G4MAIN_PHG4TRUTHINFOCONTAINER_H
+#define G4MAIN_PHG4TRUTHINFOCONTAINER_H
 
 #include <phool/PHObject.h>
 
+#include <iostream>
+#include <iterator>  // for distance
 #include <map>
-#include <set>
+#include <utility>
 
 class PHG4Shower;
 class PHG4Particle;

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.cc
@@ -11,6 +11,8 @@
 #include "PHG4InEvent.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 
 #include <Geant4/G4ParticleDefinition.hh>

--- a/simulation/g4simulation/g4main/PHG4VtxPoint.cc
+++ b/simulation/g4simulation/g4main/PHG4VtxPoint.cc
@@ -1,5 +1,6 @@
 #include "PHG4VtxPoint.h"
 
+#include <ostream>
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/PHG4VtxPoint.h
+++ b/simulation/g4simulation/g4main/PHG4VtxPoint.h
@@ -1,10 +1,11 @@
-#ifndef PHG4VTXPOINT_H__
-#define PHG4VTXPOINT_H__
+#ifndef G4MAIN_PHG4VTXPOINT_H
+#define G4MAIN_PHG4VTXPOINT_H
 
 #include <phool/PHObject.h>
+
 #include <cmath>
 #include <climits>
-
+#include <iostream>
 
 class PHG4VtxPoint: public PHObject
 {

--- a/simulation/g4simulation/g4main/PHG4VtxPointv1.cc
+++ b/simulation/g4simulation/g4main/PHG4VtxPointv1.cc
@@ -1,5 +1,6 @@
 #include "PHG4VtxPointv1.h"
 
+#include <ostream>  // for operator<<, basic_ostream, basic_ostream<>::__ost...
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/PHG4VtxPointv1.h
+++ b/simulation/g4simulation/g4main/PHG4VtxPointv1.h
@@ -1,8 +1,11 @@
-#ifndef PHG4VTXPOINTV1_H__
-#define PHG4VTXPOINTV1_H__
+#ifndef G4MAIN_PHG4VTXPOINTV1_H
+#define G4MAIN_PHG4VTXPOINTV1_H
 
 #include "PHG4VtxPoint.h"
+
+#include <climits> // for INT_MIN
 #include <cmath> // def of NAN
+#include <iostream>   // for cout, ostream
 
 class PHG4VtxPointv1: public PHG4VtxPoint
 {

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
@@ -11,7 +11,9 @@
 #include <Geant4/G4GDMLParser.hh>
 
 #include <g4main/PHG4HitContainer.h>
+
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -10,6 +10,7 @@
 #include <pdbcalbase/PdbParameterMap.h>
 
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 #include <Geant4/globals.hh>
 


### PR DESCRIPTION
This PR is from a test of the new "Include What You Use" tool which checks if all symbols are resolved by includes. It is based on clang which behaves slightly different from gcc when it comes to system includes, so one cannot just blindly use its recommendations. But it did find a few things. This PR also checks if the valgrind suppression is updated correctly and the changed EIC macro runs now