### PR TITLE
Buffer Size and Split Level now feature of PHIODataNode

### DIFF
--- a/offline/framework/phool/PHIODataNode.h
+++ b/offline/framework/phool/PHIODataNode.h
@@ -25,15 +25,21 @@ class PHIODataNode : public PHDataNode<T>
   PHIODataNode(T *, const std::string &, const std::string &);
   virtual ~PHIODataNode() {}
   typedef PHTypedNodeIterator<T> iterator;
+  void BufferSize(int size) {buffersize = size;}
+  void SplitLevel(int split) {splitlevel = split;}
 
  protected:
   virtual bool write(PHIOManager *, const std::string & = "");
   PHIODataNode() = delete;
+  int buffersize;
+  int splitlevel;
 };
 
 template <class T>
 PHIODataNode<T>::PHIODataNode(T *d, const std::string &name)
   : PHDataNode<T>(d, name)
+  , buffersize(32000)
+  , splitlevel(99)
 {
   this->type = "PHIODataNode";
   TObject *TO = static_cast<TObject *>(d);
@@ -44,6 +50,8 @@ template <class T>
 PHIODataNode<T>::PHIODataNode(T *d, const std::string &name,
                               const std::string &objtype)
   : PHDataNode<T>(d, name, objtype)
+  , buffersize(32000)
+  , splitlevel(99)
 {
   this->type = "PHIODataNode";
   TObject *TO = static_cast<TObject *>(d);
@@ -62,7 +70,7 @@ bool PHIODataNode<T>::write(PHIOManager *IOManager, const std::string &path)
       bool bret = false;
       if (dynamic_cast<TObject *>(this->data.data))
       {
-        bret = np->write(&(this->data.tobj), newPath);
+        bret = np->write(&(this->data.tobj), newPath, buffersize, splitlevel);
       }
       return bret;
     }
@@ -70,4 +78,4 @@ bool PHIODataNode<T>::write(PHIOManager *IOManager, const std::string &path)
   return true;
 }
 
-#endif /* __PHIODATANODE_H__ */
+#endif /* PHOOL_PHIODATANODE_H */

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -39,8 +39,6 @@ PHNodeIOManager::PHNodeIOManager()
   : file(nullptr)
   , tree(nullptr)
   , TreeName("T")
-  , bufSize(0)
-  , split(0)
   , accessMode(PHReadOnly)
   , CompressionLevel(3)
   , isFunctionalFlag(0)
@@ -86,10 +84,6 @@ PHNodeIOManager::PHNodeIOManager(const string& f, const PHAccessType a,
 PHNodeIOManager::~PHNodeIOManager()
 {
   closeFile();
-  //   if (tree)
-  //     {
-  //       tree->Delete();
-  //     }
   delete file;
 }
 
@@ -109,8 +103,6 @@ bool PHNodeIOManager::setFile(const string& f, const string& title,
                               const PHAccessType a)
 {
   filename = f;
-  bufSize = 32000;
-  split = 0;
   accessMode = a;
   if (file)
   {
@@ -185,7 +177,7 @@ bool PHNodeIOManager::write(PHCompositeNode* topNode)
   return false;
 }
 
-bool PHNodeIOManager::write(TObject** data, const string& path)
+bool PHNodeIOManager::write(TObject** data, const string& path, int buffersize, int splitlevel)
 {
   if (file && tree)
   {
@@ -200,15 +192,19 @@ bool PHNodeIOManager::write(TObject** data, const string& path)
       // split = 1 they cannot be read back.  The new PHObjects
       // can be saved either way, but split = 1 makes interactive
       // display possible.
-      split = 99;
+//      split = 99;
+/*
       if ((*data)->InheritsFrom("PHObject"))
       {
         PHObject* phob = dynamic_cast<PHObject*>(*data);
         split = phob->SplitLevel();
         bufSize = phob->BufferSize();
       }
+*/
+      cout << "branch " << path << ", bufsize: " << buffersize
+	   << ", split: " << splitlevel << endl;
       tree->Branch(path.c_str(), (*data)->ClassName(),
-                   data, bufSize, split);
+                   data, buffersize, splitlevel);
     }
     else
     {

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -184,25 +184,9 @@ bool PHNodeIOManager::write(TObject** data, const string& path, int buffersize, 
     TBranch* thisBranch = tree->GetBranch(path.c_str());
     if (!thisBranch)
     {
-      // Here is were we decide how to save the data in the root
-      // tree. split=0(prior to Root3.01/05; needs -1 afterwards
-      // for classes with custom streamers, as our old PHTable(s))
-      // means data are hidden, interactive T->draw() will not
-      // work. The old wrapped tables seem to need that, with
-      // split = 1 they cannot be read back.  The new PHObjects
-      // can be saved either way, but split = 1 makes interactive
-      // display possible.
-//      split = 99;
-/*
-      if ((*data)->InheritsFrom("PHObject"))
-      {
-        PHObject* phob = dynamic_cast<PHObject*>(*data);
-        split = phob->SplitLevel();
-        bufSize = phob->BufferSize();
-      }
-*/
-      cout << "branch " << path << ", bufsize: " << buffersize
-	   << ", split: " << splitlevel << endl;
+      // the buffersize and splitlevel are set on the first call
+      // when the branch is created, the values come from the caller
+      // which is the node which writes itself
       tree->Branch(path.c_str(), (*data)->ClassName(),
                    data, buffersize, splitlevel);
     }

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -54,8 +54,6 @@ class PHNodeIOManager : public PHIOManager
   TFile *file;
   TTree *tree;
   std::string TreeName;
-//  int bufSize;
-//  int split;
   int accessMode;
   int CompressionLevel;
   std::map<std::string, TBranch *> fBranches;

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -28,7 +28,6 @@ class PHNodeIOManager : public PHIOManager
   PHNodeIOManager(const std::string &, const PHAccessType, const PHTreeType);
   virtual ~PHNodeIOManager();
 
- public:
   virtual void closeFile();
   virtual bool write(PHCompositeNode *);
   virtual void print() const;
@@ -44,8 +43,7 @@ class PHNodeIOManager : public PHIOManager
   double GetBytesWritten();
   std::map<std::string, TBranch *> *GetBranchMap();
 
- public:
-  bool write(TObject **, const std::string &);
+  bool write(TObject **, const std::string &, int buffersize, int splitlevel);
 
  private:
   int FillBranchMap();
@@ -56,8 +54,8 @@ class PHNodeIOManager : public PHIOManager
   TFile *file;
   TTree *tree;
   std::string TreeName;
-  int bufSize;
-  int split;
+//  int bufSize;
+//  int split;
   int accessMode;
   int CompressionLevel;
   std::map<std::string, TBranch *> fBranches;

--- a/offline/framework/phool/PHObject.h
+++ b/offline/framework/phool/PHObject.h
@@ -44,9 +44,6 @@ class PHObject : public TObject
   virtual int Integrate(PHObject* obj) { return -1; }
   virtual void CopyContent(PHObject* obj);
 
-  int SplitLevel() const { return 99; }
-  int BufferSize() const { return 32000; }
-
  private:
   ClassDef(PHObject, 0)  // no I/O
 };


### PR DESCRIPTION
This PR moves the source of those parameters for the TBranch from PHObject to the PHIODataNode so it can be set separately on a node by node level