### PR TITLE
Count and print EMCal block density

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -819,7 +819,11 @@ PHG4FullProjTiltedSpacalDetector::Construct_Tower(
       cout << "PHG4FullProjTiltedSpacalDetector::Construct_Tower::" << GetName()
            << " - constructed tower ID " << g_tower.id << " with "
            << fiber_count
-           << " fibers using Construct_Fibers_SameLengthFiberPerTower" << endl;
+           << " fibers using Construct_Fibers_SameLengthFiberPerTower."
+           << "V = "<<block_solid->GetCubicVolume()/(cm3)<<"cm3, "
+           << "m = "<<block_logic->GetMass()/gram<<"gram, "
+           << "Density = "<< (block_logic->GetMass()/gram) / (block_solid->GetCubicVolume()/cm3)<<"g/cm3"
+           << endl;
   }
   else
   {


### PR DESCRIPTION
For the EMCal block density studies, enabling print out of the block size and density statistics if verbosity flag is turned on. 

To enable the output, please set `construction_verbose` = 2 or higher in `G4_CEmc_Spacal.C` following this example: https://github.com/sPHENIX-Collaboration/macros/commit/33b878b30c43dbeb10569dc96bd68fa46e166403

Example print for one of the block are
`
PHG4FullProjTiltedSpacalDetector::Construct_Tower::CEMC_0 - constructed tower ID 1010 with 2668 fibers using Construc
t_Fibers_SameLengthFiberPerTower. V = 348.577cm3, m = 3525.35gram, Density = 10.1135g/cm3
`