### PR TITLE
Clangtest

### DIFF
--- a/generators/JETSCAPE/Makefile.am
+++ b/generators/JETSCAPE/Makefile.am
@@ -6,8 +6,6 @@ AM_CPPFLAGS = \
   -I$(OPT_SPHENIX)/JETSCAPE-1.0/include \
   -I/usr/include/openmpi-x86_64
 
-#AM_CXXFLAGS = -Werror -Wno-unused-variable
-
 bin_PROGRAMS = \
   brickTest \
   FinalStateHadrons \

--- a/generators/PHPythia6/Makefile.am
+++ b/generators/PHPythia6/Makefile.am
@@ -5,8 +5,6 @@ AM_CPPFLAGS = \
   -I$(OFFLINE_MAIN)/include \
   -I`root-config --incdir`
 
-AM_CXXFLAGS = -Werror
-
 lib_LTLIBRARIES = libPHPythia6.la
 
 pkginclude_HEADERS = \

--- a/generators/PHPythia6/configure.ac
+++ b/generators/PHPythia6/configure.ac
@@ -14,11 +14,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/generators/PHPythia6/configure.ac
+++ b/generators/PHPythia6/configure.ac
@@ -10,7 +10,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 dnl test for root 6

--- a/generators/PHPythia8/configure.ac
+++ b/generators/PHPythia8/configure.ac
@@ -10,7 +10,7 @@ dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-delete-non-virtual-dtor -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/generators/PHPythia8/configure.ac
+++ b/generators/PHPythia8/configure.ac
@@ -18,11 +18,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/generators/PHSartre/Makefile.am
+++ b/generators/PHSartre/Makefile.am
@@ -6,8 +6,6 @@ AM_CPPFLAGS = \
   -I$(OPT_SPHENIX)/include \
   -I`root-config --incdir` 
 
-AM_CXXFLAGS = -Werror
-
 lib_LTLIBRARIES = libPHSartre.la 
 
 pkginclude_HEADERS = \

--- a/generators/PHSartre/configure.ac
+++ b/generators/PHSartre/configure.ac
@@ -9,7 +9,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 dnl test for root 6

--- a/generators/PHSartre/configure.ac
+++ b/generators/PHSartre/configure.ac
@@ -13,11 +13,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/generators/flowAfterburner/Makefile.am
+++ b/generators/flowAfterburner/Makefile.am
@@ -3,13 +3,14 @@ AUTOMAKE_OPTIONS = foreign
 lib_LTLIBRARIES = \
   libflowafterburner.la
 
-AM_CXXFLAGS = -Werror
-
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-   `geant4-config --libs-without-gui` \
-  -lHepMC -lgsl -lgslcblas -lpthread
+  `geant4-config --libs-without-gui` \
+  -lHepMC \
+  -lgsl \
+  -lgslcblas \
+  -lpthread
 
 AM_CPPFLAGS = \
   -I$(includedir) \

--- a/generators/flowAfterburner/configure.ac
+++ b/generators/flowAfterburner/configure.ac
@@ -11,7 +11,7 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/generators/flowAfterburner/configure.ac
+++ b/generators/flowAfterburner/configure.ac
@@ -7,7 +7,7 @@ AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 dnl test for root 6

--- a/generators/hijing/configure.ac
+++ b/generators/hijing/configure.ac
@@ -7,7 +7,7 @@ AC_PROG_F77(gfortran)
 LT_INIT([disable-static])
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/generators/phhepmc/PHGenIntegralv1.cc
+++ b/generators/phhepmc/PHGenIntegralv1.cc
@@ -14,22 +14,24 @@
 
 #include <cstdlib>
 #include <iostream>
+
 using namespace std;
 
 PHGenIntegralv1::PHGenIntegralv1()
-{
-  Reset();
-}
+  : m_NProcessedEvent(0)
+  , m_NGeneratorAcceptedEvent(0)
+  , m_IntegratedLumi(0.)
+  , m_SumOfWeight(0.)
+  , m_Description("Source Not Provided")
+{}
 
 PHGenIntegralv1::PHGenIntegralv1(const std::string& description)
-{
-  Reset();
-  fDescription = description;
-}
-
-PHGenIntegralv1::~PHGenIntegralv1()
-{
-}
+  : m_NProcessedEvent(0)
+  , m_NGeneratorAcceptedEvent(0)
+  , m_IntegratedLumi(0.)
+  , m_SumOfWeight(0.)
+  , m_Description(description)
+{}
 
 PHObject* PHGenIntegralv1::clone() const
 {
@@ -48,11 +50,11 @@ void PHGenIntegralv1::identify(ostream& os) const
 
 void PHGenIntegralv1::Reset()
 {
-  fNProcessedEvent = 0;
-  fNGeneratorAcceptedEvent = 0;
-  fIntegratedLumi = 0;
-  fSumOfWeight = 0;
-  fDescription = "Source Not Provided";
+  m_NProcessedEvent = 0;
+  m_NGeneratorAcceptedEvent = 0;
+  m_IntegratedLumi = 0;
+  m_SumOfWeight = 0;
+  m_Description = "Source Not Provided";
 }
 
 int PHGenIntegralv1::Integrate(PHObject* incoming_object)
@@ -68,21 +70,21 @@ int PHGenIntegralv1::Integrate(PHObject* incoming_object)
     exit(EXIT_FAILURE);
   }
 
-  if (fIntegratedLumi == 0 and fNProcessedEvent == 0)
+  if (m_IntegratedLumi == 0 and m_NProcessedEvent == 0)
   {
-    fDescription = in_gen->get_Description();
+    m_Description = in_gen->get_Description();
   }
-  else if (fDescription != in_gen->get_Description())
+  else if (m_Description != in_gen->get_Description())
   {
-    fDescription = fDescription + ", and " + in_gen->get_Description();
+    m_Description = m_Description + ", and " + in_gen->get_Description();
   }
 
-  fNProcessedEvent += in_gen->get_N_Processed_Event();
-  fNGeneratorAcceptedEvent += in_gen->get_N_Generator_Accepted_Event();
-  fIntegratedLumi += in_gen->get_Integrated_Lumi();
-  fSumOfWeight += in_gen->get_Sum_Of_Weight();
+  m_NProcessedEvent += in_gen->get_N_Processed_Event();
+  m_NGeneratorAcceptedEvent += in_gen->get_N_Generator_Accepted_Event();
+  m_IntegratedLumi += in_gen->get_Integrated_Lumi();
+  m_SumOfWeight += in_gen->get_Sum_Of_Weight();
 
-  return fNProcessedEvent;
+  return m_NProcessedEvent;
 }
 
 void PHGenIntegralv1::CopyContent(PHObject* incoming_object)
@@ -98,9 +100,9 @@ void PHGenIntegralv1::CopyContent(PHObject* incoming_object)
     exit(EXIT_FAILURE);
   }
 
-  fNProcessedEvent = in_gen->get_N_Processed_Event();
-  fNGeneratorAcceptedEvent = in_gen->get_N_Generator_Accepted_Event();
-  fIntegratedLumi = in_gen->get_Integrated_Lumi();
-  fSumOfWeight = in_gen->get_Sum_Of_Weight();
-  fDescription = in_gen->get_Description();
+  m_NProcessedEvent = in_gen->get_N_Processed_Event();
+  m_NGeneratorAcceptedEvent = in_gen->get_N_Generator_Accepted_Event();
+  m_IntegratedLumi = in_gen->get_Integrated_Lumi();
+  m_SumOfWeight = in_gen->get_Sum_Of_Weight();
+  m_Description = in_gen->get_Description();
 }

--- a/generators/phhepmc/PHGenIntegralv1.h
+++ b/generators/phhepmc/PHGenIntegralv1.h
@@ -24,7 +24,7 @@ class PHGenIntegralv1 : public PHGenIntegral
  public:
   PHGenIntegralv1();
   explicit PHGenIntegralv1(const std::string& description);
-  virtual ~PHGenIntegralv1();
+  virtual ~PHGenIntegralv1(){}
 
   virtual PHObject* clone() const;
   virtual int isValid() const { return 1; }
@@ -39,37 +39,37 @@ class PHGenIntegralv1 : public PHGenIntegral
   //! Integrated luminosity in pb^-1
   Double_t get_Integrated_Lumi() const
   {
-    return fIntegratedLumi;
+    return m_IntegratedLumi;
   }
 
   //! Integrated luminosity in pb^-1
   void set_Integrated_Lumi(Double_t integratedLumi)
   {
-    fIntegratedLumi = integratedLumi;
+    m_IntegratedLumi = integratedLumi;
   }
 
-  //! Number of accepted events in the event generator. This can be higher than fNProcessedEvent depending on trigger on the event generator
+  //! Number of accepted events in the event generator. This can be higher than m_NProcessedEvent depending on trigger on the event generator
   ULong64_t get_N_Generator_Accepted_Event() const
   {
-    return fNGeneratorAcceptedEvent;
+    return m_NGeneratorAcceptedEvent;
   }
 
-  //! Number of accepted events in the event generator. This can be higher than fNProcessedEvent depending on trigger on the event generator
+  //! Number of accepted events in the event generator. This can be higher than m_NProcessedEvent depending on trigger on the event generator
   void set_N_Generator_Accepted_Event(ULong64_t nGeneratorAcceptedEvent)
   {
-    fNGeneratorAcceptedEvent = nGeneratorAcceptedEvent;
+    m_NGeneratorAcceptedEvent = nGeneratorAcceptedEvent;
   }
 
   //! Number of processed events in the Fun4All cycles
   ULong64_t get_N_Processed_Event() const
   {
-    return fNProcessedEvent;
+    return m_NProcessedEvent;
   }
 
   //! Number of processed events in the Fun4All cycles
   void set_N_Processed_Event(ULong64_t nProcessedEvent)
   {
-    fNProcessedEvent = nProcessedEvent;
+    m_NProcessedEvent = nProcessedEvent;
   }
 
   //! Sum of weight assigned to the events by the generators.
@@ -77,7 +77,7 @@ class PHGenIntegralv1 : public PHGenIntegral
   //! However, there are several cases where one may have nontrivial event weights, e.g. using user hooks in Pythia8 generators to reweight the phase space
   Double_t get_Sum_Of_Weight() const
   {
-    return fSumOfWeight;
+    return m_SumOfWeight;
   }
 
   //! Sum of weight assigned to the events by the generators.
@@ -85,38 +85,38 @@ class PHGenIntegralv1 : public PHGenIntegral
   //! However, there are several cases where one may have nontrivial event weights, e.g. using user hooks in Pythia8 generators to reweight the phase space
   void set_Sum_Of_Weight(Double_t sumOfWeight)
   {
-    fSumOfWeight = sumOfWeight;
+    m_SumOfWeight = sumOfWeight;
   }
 
   //! description on the source
   const std::string& get_Description() const
   {
-    return fDescription;
+    return m_Description;
   }
 
   //! description on the source
   void set_Description(const std::string& description)
   {
-    fDescription = description;
+    m_Description = description;
   }
 
  private:
   //! Number of processed events in the Fun4All cycles
-  ULong64_t fNProcessedEvent;
+  ULong64_t m_NProcessedEvent;
 
-  //! Number of accepted events in the event generator. This can be higher than fNProcessedEvent depending on trigger on the event generator
-  ULong64_t fNGeneratorAcceptedEvent;
+  //! Number of accepted events in the event generator. This can be higher than m_NProcessedEvent depending on trigger on the event generator
+  ULong64_t m_NGeneratorAcceptedEvent;
 
   //! Integrated luminosity in pb^-1
-  Double_t fIntegratedLumi;
+  Double_t m_IntegratedLumi;
 
   //! Sum of weight assigned to the events by the generators.
   //! Event weight is normally 1 and thus equal to number of the generated event and is uninteresting.
   //! However, there are several cases where one may have nontrivial event weights, e.g. using user hooks in Pythia8 generators to reweight the phase space
-  Double_t fSumOfWeight;
+  Double_t m_SumOfWeight;
 
   //! description on the source
-  std::string fDescription;
+  std::string m_Description;
 
   ClassDef(PHGenIntegralv1, 1)
 };

--- a/generators/phhepmc/PHHepMCGenEvent.cc
+++ b/generators/phhepmc/PHHepMCGenEvent.cc
@@ -43,7 +43,7 @@ PHHepMCGenEvent& PHHepMCGenEvent::operator=(const PHHepMCGenEvent& event)
 
 PHHepMCGenEvent::~PHHepMCGenEvent()
 {
-  Reset();
+  delete _theEvt;
 }
 
 void PHHepMCGenEvent::Reset()

--- a/generators/phhepmc/configure.ac
+++ b/generators/phhepmc/configure.ac
@@ -10,11 +10,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/generators/sHEPGen/Makefile.am
+++ b/generators/sHEPGen/Makefile.am
@@ -6,8 +6,6 @@ AM_CPPFLAGS = \
   -I`root-config --incdir` \
   -I$(OPT_SPHENIX)/HEPGenPlusPlus/include
 
-AM_CXXFLAGS = -Werror
-
 lib_LTLIBRARIES = libsHEPGen.la
 
 pkginclude_HEADERS = \

--- a/generators/sHEPGen/configure.ac
+++ b/generators/sHEPGen/configure.ac
@@ -9,7 +9,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 dnl test for root 6

--- a/generators/sHEPGen/configure.ac
+++ b/generators/sHEPGen/configure.ac
@@ -13,7 +13,7 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/generators/sHijing/Makefile.am
+++ b/generators/sHijing/Makefile.am
@@ -17,8 +17,7 @@ AM_CPPFLAGS = \
   -isystem$(OFFLINE_MAIN)/include 
 
 AM_FFLAGS="-DFVOIDP=INTEGER*8"
-# turn off warnings about unused functions in cfortran.h
-AM_CXXFLAGS=-Wall -Wno-unused-function -Werror
+
 noinst_HEADERS = \
   HijCrdn.h \
   HijJet1.h \

--- a/generators/sHijing/configure.ac
+++ b/generators/sHijing/configure.ac
@@ -7,6 +7,14 @@ AC_PROG_CXX(CC g++)
 AC_PROG_F77(gfortran)
 LT_INIT([disable-static])
 
+nl   no point in suppressing warnings people should
+dnl   at least see them, so here we go for g++: -Wall
+dnl   make warnings fatal errors: -Werror
+if test $ac_cv_prog_gxx = yes; then
+dnl turn off warnings about unused functions in cfortran.h
+   CXXFLAGS="$CXXFLAGS -Wall  -Wno-unused-function -Werror"
+fi
+
 dnl test for root 6
 if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "

--- a/generators/sHijing/configure.ac
+++ b/generators/sHijing/configure.ac
@@ -8,7 +8,7 @@ AC_PROG_F77(gfortran)
 LT_INIT([disable-static])
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/offline/QA/modules/Makefile.am
+++ b/offline/QA/modules/Makefile.am
@@ -9,8 +9,6 @@ AM_CPPFLAGS = \
 lib_LTLIBRARIES = \
    libqa_modules.la
 
-AM_CXXFLAGS = -Werror 
-
 libqa_modules_la_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/offline/QA/modules/configure.ac
+++ b/offline/QA/modules/configure.ac
@@ -18,11 +18,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/QA/modules/configure.ac
+++ b/offline/QA/modules/configure.ac
@@ -10,7 +10,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/offline/database/PHParameter/configure.ac
+++ b/offline/database/PHParameter/configure.ac
@@ -10,11 +10,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/database/pdbcal/base/configure.ac
+++ b/offline/database/pdbcal/base/configure.ac
@@ -15,11 +15,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/database/pdbcal/pg/configure.ac
+++ b/offline/database/pdbcal/pg/configure.ac
@@ -12,7 +12,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Wno-deprecated-declarations -Wno-undefined-bool-conversion -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/offline/database/pdbcal/pg/configure.ac
+++ b/offline/database/pdbcal/pg/configure.ac
@@ -21,11 +21,11 @@ esac
 
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/framework/ffaobjects/Makefile.am
+++ b/offline/framework/ffaobjects/Makefile.am
@@ -7,7 +7,6 @@ AM_CPPFLAGS = \
   -I$(OFFLINE_MAIN)/include \
   -I$(ROOTSYS)/include
 
-AM_CXXFLAGS = -Wall -Werror
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/offline/framework/ffaobjects/RunHeaderv1.cc
+++ b/offline/framework/ffaobjects/RunHeaderv1.cc
@@ -3,13 +3,11 @@
 using namespace std;
 
 RunHeaderv1::RunHeaderv1()
-{
-  RunNumber = 0;
-  TimeStart = 0;
-  TimeStop = 0;
-  Bfield = -99999.;
-  return;
-}
+  : RunNumber(0)
+  , TimeStart(0)
+  , TimeStop(0)
+  , Bfield(-99999.)
+{}
 
 void RunHeaderv1::Reset()
 {

--- a/offline/framework/ffaobjects/configure.ac
+++ b/offline/framework/ffaobjects/configure.ac
@@ -7,6 +7,12 @@ LT_INIT([disable-static])
 
 AC_PROG_CXX(CC g++)
 
+dnl   no point in suppressing warnings people should 
+dnl   at least see them, so here we go for g++: -Wall
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+fi
+
 dnl test for root 6
 if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "

--- a/offline/framework/ffaobjects/configure.ac
+++ b/offline/framework/ffaobjects/configure.ac
@@ -8,11 +8,11 @@ LT_INIT([disable-static])
 AC_PROG_CXX(CC g++)
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/framework/frog/configure.ac
+++ b/offline/framework/frog/configure.ac
@@ -11,7 +11,7 @@ dnl   at least see them, so here we go for g++: -Wall
 dnl   treat warnings as errors: -Werror
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Wno-deprecated-declarations -Wno-undefined-bool-conversion -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/offline/framework/frog/configure.ac
+++ b/offline/framework/frog/configure.ac
@@ -19,11 +19,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/framework/fun4all/Fun4AllBase.cc
+++ b/offline/framework/fun4all/Fun4AllBase.cc
@@ -13,9 +13,9 @@ Fun4AllBase::Fun4AllBase(const string& name)
 
 Fun4AllBase::~Fun4AllBase()
 {
-  if (Verbosity() >= VERBOSITY_MORE)
+  if (m_Verbosity >= VERBOSITY_MORE)
   {
-    cout << "Deleting " << Name() << endl;
+    cout << "Deleting " << m_ThisName << endl;
   }
   return;
 }

--- a/offline/framework/fun4all/configure.ac
+++ b/offline/framework/fun4all/configure.ac
@@ -13,11 +13,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/framework/phool/configure.ac
+++ b/offline/framework/phool/configure.ac
@@ -13,11 +13,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/CaloBase/configure.ac
+++ b/offline/packages/CaloBase/configure.ac
@@ -10,11 +10,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/CaloReco/configure.ac
+++ b/offline/packages/CaloReco/configure.ac
@@ -10,11 +10,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/ClusterIso/configure.ac
+++ b/offline/packages/ClusterIso/configure.ac
@@ -15,11 +15,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/ClusterIso/configure.ac
+++ b/offline/packages/ClusterIso/configure.ac
@@ -7,7 +7,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/offline/packages/Half/configure.ac
+++ b/offline/packages/Half/configure.ac
@@ -13,7 +13,7 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/offline/packages/HelixHough/configure.ac
+++ b/offline/packages/HelixHough/configure.ac
@@ -18,7 +18,7 @@ ROOTLIBS=`$ROOTSYS/bin/root-config --libs`
 AC_SUBST(ROOTLIBS)
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/offline/packages/NodeDump/configure.ac
+++ b/offline/packages/NodeDump/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/offline/packages/NodeDump/configure.ac
+++ b/offline/packages/NodeDump/configure.ac
@@ -16,11 +16,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/PHField/Makefile.am
+++ b/offline/packages/PHField/Makefile.am
@@ -9,9 +9,6 @@ lib_LTLIBRARIES = \
    libphfield_io.la \
    libphfield.la
 
-AM_CXXFLAGS = \
- -Werror
-
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/offline/packages/PHField/configure.ac
+++ b/offline/packages/PHField/configure.ac
@@ -11,11 +11,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/PHGenFitPkg/GenFitExp/configure.ac
+++ b/offline/packages/PHGenFitPkg/GenFitExp/configure.ac
@@ -13,7 +13,7 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/offline/packages/PHGenFitPkg/PHGenFit/configure.ac
+++ b/offline/packages/PHGenFitPkg/PHGenFit/configure.ac
@@ -13,7 +13,7 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/offline/packages/PHGeometry/PHGeomIOTGeo.cc
+++ b/offline/packages/PHGeometry/PHGeomIOTGeo.cc
@@ -28,7 +28,7 @@ PHGeomIOTGeo::PHGeomIOTGeo()
 
 PHGeomIOTGeo::~PHGeomIOTGeo()
 {
-  Reset();
+    Data.resize(0);
 }
 
 PHObject*

--- a/offline/packages/PHGeometry/PHGeomTGeo.cc
+++ b/offline/packages/PHGeometry/PHGeomTGeo.cc
@@ -26,7 +26,11 @@ PHGeomTGeo::PHGeomTGeo()
 PHGeomTGeo::~PHGeomTGeo()
 {
   ConsistencyCheck();
-  Reset();
+  if (_fGeom)
+  {
+    _fGeom->UnlockGeometry();
+  }
+    delete _fGeom;
 }
 
 void PHGeomTGeo::SetGeometry(TGeoManager* g)

--- a/offline/packages/PHGeometry/configure.ac
+++ b/offline/packages/PHGeometry/configure.ac
@@ -7,15 +7,15 @@ LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
-  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | gawk '{print $1>=4.8?"1":"0"}'` = 1)
+  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 
 AC_CONFIG_FILES([Makefile])

--- a/offline/packages/intt/configure.ac
+++ b/offline/packages/intt/configure.ac
@@ -13,11 +13,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/jetbackground/Makefile.am
+++ b/offline/packages/jetbackground/Makefile.am
@@ -9,9 +9,6 @@ lib_LTLIBRARIES = \
    libjetbackground_io.la \
    libjetbackground.la
 
-AM_CXXFLAGS = \
- -Werror
-
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/offline/packages/jetbackground/configure.ac
+++ b/offline/packages/jetbackground/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/offline/packages/jetbackground/configure.ac
+++ b/offline/packages/jetbackground/configure.ac
@@ -16,11 +16,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/mvtx/configure.ac
+++ b/offline/packages/mvtx/configure.ac
@@ -13,11 +13,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/tpc/configure.ac
+++ b/offline/packages/tpc/configure.ac
@@ -13,11 +13,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/tpcdaq/Makefile.am
+++ b/offline/packages/tpcdaq/Makefile.am
@@ -12,8 +12,6 @@ lib_LTLIBRARIES = \
    libtpcdaq.la \
    libtpcdaq_io.la
 
-AM_CXXFLAGS = -Werror
-
 libtpcdaq_la_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/offline/packages/tpcdaq/configure.ac
+++ b/offline/packages/tpcdaq/configure.ac
@@ -11,7 +11,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 dnl test for root 6

--- a/offline/packages/tpcdaq/configure.ac
+++ b/offline/packages/tpcdaq/configure.ac
@@ -15,11 +15,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/trackbase/configure.ac
+++ b/offline/packages/trackbase/configure.ac
@@ -13,11 +13,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader"
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/trackbase_historic/configure.ac
+++ b/offline/packages/trackbase_historic/configure.ac
@@ -13,11 +13,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader"
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -16,7 +16,7 @@ AM_CPPFLAGS = \
   -I$(OFFLINE_MAIN)/include/eigen3
 
 AM_CXXFLAGS = \
- -Werror -DRAVE -DRaveDllExport=
+ -DRAVE -DRaveDllExport=
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/offline/packages/trackreco/configure.ac
+++ b/offline/packages/trackreco/configure.ac
@@ -15,11 +15,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/trackreco/configure.ac
+++ b/offline/packages/trackreco/configure.ac
@@ -7,7 +7,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/offline/packages/trigger/Makefile.am
+++ b/offline/packages/trigger/Makefile.am
@@ -9,9 +9,6 @@ lib_LTLIBRARIES = \
    libcalotrigger_io.la \
    libcalotrigger.la
 
-AM_CXXFLAGS = \
- -Werror
-
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/offline/packages/trigger/configure.ac
+++ b/offline/packages/trigger/configure.ac
@@ -13,11 +13,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/trigger/configure.ac
+++ b/offline/packages/trigger/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 dnl test for root 6

--- a/offline/packages/vararray/Makefile.am
+++ b/offline/packages/vararray/Makefile.am
@@ -7,9 +7,6 @@ AM_CPPFLAGS = \
   -I$(OFFLINE_MAIN)/include  \
   -I$(ROOTSYS)/include 
 
-AM_CXXFLAGS = \
- -Werror
-
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/offline/packages/vararray/configure.ac
+++ b/offline/packages/vararray/configure.ac
@@ -12,11 +12,11 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/vararray/configure.ac
+++ b/offline/packages/vararray/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 dnl test for root 6

--- a/simulation/g4simulation/EICPhysicsList/configure.ac
+++ b/simulation/g4simulation/EICPhysicsList/configure.ac
@@ -10,7 +10,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-undefined-var-template -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/EICPhysicsList/configure.ac
+++ b/simulation/g4simulation/EICPhysicsList/configure.ac
@@ -17,11 +17,11 @@ case $CXX in
  ;;
 esac
 
-dnl   AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | gawk '{print $1>=4.8?"1":"0"}'` = 1)
+dnl   AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
 
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/simulation/g4simulation/g4bbc/Makefile.am
+++ b/simulation/g4simulation/g4bbc/Makefile.am
@@ -9,9 +9,6 @@ lib_LTLIBRARIES = \
    libg4bbc_io.la \
    libg4bbc.la
 
-AM_CXXFLAGS = \
- -Werror
-
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/simulation/g4simulation/g4bbc/configure.ac
+++ b/simulation/g4simulation/g4bbc/configure.ac
@@ -15,11 +15,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4bbc/configure.ac
+++ b/simulation/g4simulation/g4bbc/configure.ac
@@ -7,7 +7,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4calo/configure.ac
+++ b/simulation/g4simulation/g4calo/configure.ac
@@ -15,11 +15,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4calo/configure.ac
+++ b/simulation/g4simulation/g4calo/configure.ac
@@ -7,7 +7,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4decayer/configure.ac
+++ b/simulation/g4simulation/g4decayer/configure.ac
@@ -10,7 +10,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-undefined-var-template -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4decayer/configure.ac
+++ b/simulation/g4simulation/g4decayer/configure.ac
@@ -17,11 +17,11 @@ case $CXX in
  ;;
 esac
 
-dnl   AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | gawk '{print $1>=4.8?"1":"0"}'` = 1)
+dnl   AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
 
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/simulation/g4simulation/g4detectors/configure.ac
+++ b/simulation/g4simulation/g4detectors/configure.ac
@@ -15,11 +15,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4detectors/configure.ac
+++ b/simulation/g4simulation/g4detectors/configure.ac
@@ -7,7 +7,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Wno-undefined-var-template -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4dst/configure.ac
+++ b/simulation/g4simulation/g4dst/configure.ac
@@ -13,7 +13,7 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/simulation/g4simulation/g4eval/Makefile.am
+++ b/simulation/g4simulation/g4eval/Makefile.am
@@ -9,8 +9,6 @@ AM_CPPFLAGS = \
 lib_LTLIBRARIES = \
    libg4eval.la
 
-AM_CXXFLAGS = -Werror
-
 libg4eval_la_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/simulation/g4simulation/g4eval/configure.ac
+++ b/simulation/g4simulation/g4eval/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4eval/configure.ac
+++ b/simulation/g4simulation/g4eval/configure.ac
@@ -16,11 +16,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4gdml/configure.ac
+++ b/simulation/g4simulation/g4gdml/configure.ac
@@ -8,11 +8,11 @@ LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
-  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | gawk '{print $1>=4.8?"1":"0"}'` = 1)
+  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
 fi
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi

--- a/simulation/g4simulation/g4histos/configure.ac
+++ b/simulation/g4simulation/g4histos/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4histos/configure.ac
+++ b/simulation/g4simulation/g4histos/configure.ac
@@ -19,11 +19,11 @@ ROOTLIBS=`root-config --libs`
 AC_SUBST(ROOTLIBS)
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4hough/Makefile.am
+++ b/simulation/g4simulation/g4hough/Makefile.am
@@ -12,7 +12,7 @@ lib_LTLIBRARIES = \
    libg4hough.la
 
 AM_CXXFLAGS = \
- -Werror -DRAVE -DRaveDllExport=
+ -DRAVE -DRaveDllExport=
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/simulation/g4simulation/g4hough/PHG4KalmanPatRec.cc
+++ b/simulation/g4simulation/g4hough/PHG4KalmanPatRec.cc
@@ -2265,7 +2265,7 @@ int PHG4KalmanPatRec::combi_seeding(int start_layer)
     if (search_values.size() == 0) continue;
 
     for (std::vector<pointId>::iterator second_point = search_values.begin();
-         second_point != search_values.end(); second_point++)
+         second_point != search_values.end(); ++second_point)
     {
       if (do_print) cout << "#seed " << n_seed++ << " (" << n_start << ") : " << search_values.size() << endl;
       if (search_values.size() > 1)
@@ -2493,7 +2493,7 @@ int PHG4KalmanPatRec::combi_seeding(int start_layer)
                               point(phi_prediction2 + search_window3, eta_prediction2 + search_window3, _radii_all[iLayer - 1] + 0.3));
               bgi::query(rtree, bgi::within(search_box3), std::back_inserter(candidates3));
               for (std::vector<pointId>::iterator check_point3 = candidates3.begin();
-                   check_point3 != candidates3.end(); check_point3++)
+                   check_point3 != candidates3.end(); ++check_point3)
               {
                 if (do_print) cout << "      check #" << iLayer << "id: " << check_point3->second << " phi: " << check_point3->first.get<0>() << " eta: " << check_point3->first.get<1>() << " r: " << check_point3->first.get<2>() << endl;
               }
@@ -2506,7 +2506,7 @@ int PHG4KalmanPatRec::combi_seeding(int start_layer)
               int min_index = 666;
               float min_dphi = 666.6;
               for (std::vector<pointId>::iterator check_point = candidates2.begin();
-                   check_point != candidates2.end(); check_point++)
+                   check_point != candidates2.end(); ++check_point)
               {
                 float check_dphi = check_point->first.get<0>() - phi_prediction;
                 if (check_dphi < min_dphi)
@@ -2532,7 +2532,7 @@ int PHG4KalmanPatRec::combi_seeding(int start_layer)
             int min_index = 666;
             float min_dphi = 666.6;
             for (std::vector<pointId>::iterator check_point = candidates.begin();
-                 check_point != candidates.end(); check_point++)
+                 check_point != candidates.end(); ++check_point)
             {
               float check_dphi = check_point->first.get<0>() - phi_prediction;
               if (check_dphi < min_dphi)

--- a/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.cc
+++ b/simulation/g4simulation/g4hough/PHG4TrackGhostRejection.cc
@@ -152,7 +152,7 @@ int PHG4TrackGhostRejection::process_event(PHCompositeNode *topNode)
   //----------------------
 
   std::multimap<unsigned,unsigned int>::iterator iter;
-  for (iter = _overlapping.begin(); iter != _overlapping.end(); iter++) {
+  for (iter = _overlapping.begin(); iter != _overlapping.end(); ++iter) {
 
     unsigned int key = iter->first;
     unsigned int value = iter->second;

--- a/simulation/g4simulation/g4hough/configure.ac
+++ b/simulation/g4simulation/g4hough/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Wno-tautological-compare -Wno-unused-private-field -Wno-switch-bool -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4hough/configure.ac
+++ b/simulation/g4simulation/g4hough/configure.ac
@@ -16,11 +16,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4intt/configure.ac
+++ b/simulation/g4simulation/g4intt/configure.ac
@@ -15,11 +15,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4intt/configure.ac
+++ b/simulation/g4simulation/g4intt/configure.ac
@@ -7,7 +7,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Wno-undefined-var-template -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4jets/Makefile.am
+++ b/simulation/g4simulation/g4jets/Makefile.am
@@ -10,9 +10,6 @@ lib_LTLIBRARIES = \
    libg4jets_io.la \
    libg4jets.la
 
-AM_CXXFLAGS = \
- -Wall -Werror
-
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/simulation/g4simulation/g4jets/configure.ac
+++ b/simulation/g4simulation/g4jets/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4jets/configure.ac
+++ b/simulation/g4simulation/g4jets/configure.ac
@@ -16,11 +16,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4main/configure.ac
+++ b/simulation/g4simulation/g4main/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4main/configure.ac
+++ b/simulation/g4simulation/g4main/configure.ac
@@ -14,15 +14,15 @@ case $CXX in
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
-dnl  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | gawk '{print $1>=4.8?"1":"0"}'` = 1)
+dnl  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
 
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4mvtx/configure.ac
+++ b/simulation/g4simulation/g4mvtx/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Wno-undefined-var-template -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4mvtx/configure.ac
+++ b/simulation/g4simulation/g4mvtx/configure.ac
@@ -16,11 +16,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4tpc/configure.ac
+++ b/simulation/g4simulation/g4tpc/configure.ac
@@ -15,11 +15,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4trackfastsim/configure.ac
+++ b/simulation/g4simulation/g4trackfastsim/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4trackfastsim/configure.ac
+++ b/simulation/g4simulation/g4trackfastsim/configure.ac
@@ -16,11 +16,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4vertex/Makefile.am
+++ b/simulation/g4simulation/g4vertex/Makefile.am
@@ -9,9 +9,6 @@ lib_LTLIBRARIES = \
    libg4vertex_io.la \
    libg4vertex.la
 
-AM_CXXFLAGS = \
- -Werror
-
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/simulation/g4simulation/g4vertex/configure.ac
+++ b/simulation/g4simulation/g4vertex/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Wno-overloaded-virtual -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall"
  ;;
  g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"

--- a/simulation/g4simulation/g4vertex/configure.ac
+++ b/simulation/g4simulation/g4vertex/configure.ac
@@ -16,11 +16,11 @@ case $CXX in
 esac
 
 dnl test for root 6
-if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
Thie PR fixes a few cppcheck warnings and enables all clang warnings. In the configure.ac's gawk was replaced by awk since gawk is not installed by default (Martins suggestion, Thanks)