### PR TITLE
remove g4hough remnants

### DIFF
--- a/offline/QA/modules/Makefile.am
+++ b/offline/QA/modules/Makefile.am
@@ -17,8 +17,6 @@ libqa_modules_la_LIBADD = \
   -lfun4all \
   -lphg4hit \
   -lg4detectors_io \
-  -lg4hough_io \
-  -lg4hough \
   -lcalo_io -lcalo_util \
   -lg4jets_io \
   -ltrackbase_historic_io \

--- a/offline/QA/modules/QAG4SimulationCalorimeterSum.cc
+++ b/offline/QA/modules/QAG4SimulationCalorimeterSum.cc
@@ -14,7 +14,7 @@
 #include <calobase/RawTowerContainer.h>
 #include <calobase/RawTowerGeomContainer.h>
 
-#include <g4hough/PHG4HoughTransform.h>
+//#include <g4hough/PHG4HoughTransform.h>
 
 #include <trackbase_historic/SvtxTrack.h>
 
@@ -327,8 +327,6 @@ bool QAG4SimulationCalorimeterSum::eval_trk_proj(const string &detector, SvtxTra
       topNode, towergeonodename.c_str());
   assert(towergeo);
 
-  const double radius = towergeo->get_radius() + towergeo->get_thickness() * 0.5;
-
   if (Verbosity() > 2)
   {
     towergeo->identify();
@@ -351,15 +349,19 @@ bool QAG4SimulationCalorimeterSum::eval_trk_proj(const string &detector, SvtxTra
 
   // curved tracks inside mag field
   // straight projections thereafter
+
   std::vector<double> point;
   point.assign(3, NAN);
-  PHG4HoughTransform::projectToRadius(track, _magField, radius, point);
+
+//  const double radius = towergeo->get_radius() + towergeo->get_thickness() * 0.5;
+
+//  PHG4HoughTransform::projectToRadius(track, _magField, radius, point);
 
   if (std::isnan(point[0]) or std::isnan(point[1]) or std::isnan(point[2]))
   {
-    cout << __PRETTY_FUNCTION__ << "::" << Name()
-         << " - Error - track extrapolation failure:";
-    track->identify();
+    // cout << __PRETTY_FUNCTION__ << "::" << Name()
+    //      << " - Error - track extrapolation failure:";
+    // track->identify();
     return false;
   }
 

--- a/offline/packages/NodeDump/Makefile.am
+++ b/offline/packages/NodeDump/Makefile.am
@@ -61,7 +61,6 @@ libphnodedump_la_LIBADD = \
   -lcalotrigger_io \
   -lffaobjects \
   -lg4detectors_io \
-  -lg4hough_io \
   -lg4jets_io \
   -lphg4hit \
   -lSubsysReco \

--- a/simulation/g4simulation/g4dst/Makefile.am
+++ b/simulation/g4simulation/g4dst/Makefile.am
@@ -14,7 +14,6 @@ libg4dst_la_LDFLAGS = \
   -lcalotrigger_io \
   -lg4bbc_io \
   -lg4detectors_io \
-  -lg4hough_io \
   -lg4intt_io \
   -lg4jets_io \
   -lg4vertex_io \

--- a/simulation/g4simulation/g4histos/Makefile.am
+++ b/simulation/g4simulation/g4histos/Makefile.am
@@ -14,7 +14,6 @@ libg4histos_la_LDFLAGS = \
    -lfun4all \
    -lphg4hit \
    -lg4detectors \
-   -lg4hough \
    -lg4testbench
 
 AM_CPPFLAGS = \

--- a/simulation/g4simulation/g4jets/Makefile.am
+++ b/simulation/g4simulation/g4jets/Makefile.am
@@ -21,7 +21,6 @@ libg4jets_la_LIBADD = \
   libg4jets_io.la \
   -lfun4all \
   -lphg4hit \
-  -lg4hough_io \
   -lcalo_io \
   -lcalo_util \
   -lg4vertex_io \

--- a/simulation/g4simulation/g4vertex/Makefile.am
+++ b/simulation/g4simulation/g4vertex/Makefile.am
@@ -21,7 +21,6 @@ libg4vertex_la_LIBADD = \
   -lg4detectors \
   -lfun4all \
   -lg4bbc_io \
-  -lg4hough_io \
   -ltrackbase_historic_io \
   libg4vertex_io.la
 


### PR DESCRIPTION
This PR removes the g4hough from the Makefiles.  The only code which used a method from g4hough is offline/QA/modules/QAG4SimulationCalorimeterSum.cc for projections to the front of the emc. I commented this code out - that needs to be reimplemented with our current versions.
