### PR TITLE
Accumulated fixes to get the TPC prototype simulation going

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -3,12 +3,12 @@
 #include "TpcDefs.h"
 
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterv1.h>
-#include <trackbase/TrkrDefs.h>                         // for hitkey, getLayer
-#include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHit.h>
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
+#include <trackbase/TrkrClusterv1.h>
+#include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
+#include <trackbase/TrkrHit.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -18,18 +18,18 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/getClass.h>
-#include <phool/phool.h>                                // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <TMatrixF.h>
-#include <TMatrixFfwd.h>                                // for TMatrixF
-#include <TMatrixT.h>                                   // for TMatrixT, ope...
-#include <TMatrixTUtils.h>                              // for TMatrixTRow
+#include <TMatrixFfwd.h>    // for TMatrixF
+#include <TMatrixT.h>       // for TMatrixT, ope...
+#include <TMatrixTUtils.h>  // for TMatrixTRow
 
-#include <cmath>                                       // for sqrt, cos, sin
+#include <cmath>  // for sqrt, cos, sin
 #include <iostream>
-#include <map>                                          // for _Rb_tree_cons...
+#include <map>  // for _Rb_tree_cons...
 #include <string>
-#include <utility>                                      // for pair
+#include <utility>  // for pair
 #include <vector>
 
 using namespace std;
@@ -55,86 +55,85 @@ bool TpcClusterizer::is_local_maximum(int phibin, int zbin, std::vector<std::vec
   double centval = adcval[phibin][zbin];
   //cout << "enter is_local_maximum for phibin " << phibin << " zbin " << zbin << " adcval " << centval <<  endl;
 
-
   // search contiguous adc values for a larger signal
-  for(int iz = zbin - 4; iz <= zbin+4;iz++)
-    for(int iphi = phibin -2; iphi <= phibin + 2; iphi++)
+  for (int iz = zbin - 4; iz <= zbin + 4; iz++)
+    for (int iphi = phibin - 2; iphi <= phibin + 2; iphi++)
+    {
+      //cout << " is_local_maximum: iphi " <<  iphi << " iz " << iz << " adcval " << adcval[iphi][iz] << endl;
+      if (iz >= NZBinsMax) continue;
+      if (iz < NZBinsMin) continue;
+
+      if (iphi >= NPhiBinsMax) continue;
+      if (iphi < NPhiBinsMin) continue;
+
+      if (adcval[iphi][iz] > centval)
       {
-	//cout << " is_local_maximum: iphi " <<  iphi << " iz " << iz << " adcval " << adcval[iphi][iz] << endl;
-	if(iz >= NZBinsMax) continue;
-	if(iz < NZBinsMin) continue;
-
-	if(iphi >= NPhiBinsMax) continue;
-	if(iphi < NPhiBinsMin) continue;
-
-	if(adcval[iphi][iz] > centval)
-	  {
-	    retval = false;
-	  }
+        retval = false;
       }
+    }
 
-	//if(retval)  cout << "**********************   success: returning " << retval << endl;
+  //if(retval)  cout << "**********************   success: returning " << retval << endl;
 
   return retval;
 }
 
-void TpcClusterizer::get_cluster(int phibin, int zbin, int &phiup, int &phidown, int &zup, int &zdown,  std::vector<std::vector<double>> &adcval)
+void TpcClusterizer::get_cluster(int phibin, int zbin, int &phiup, int &phidown, int &zup, int &zdown, std::vector<std::vector<double>> &adcval)
 {
   // search along phi at the peak in z
 
-  for(int iphi = phibin+1; iphi<phibin+4; iphi++)
-    {
-      if(iphi >= NPhiBinsMax) continue;
+  for (int iphi = phibin + 1; iphi < phibin + 4; iphi++)
+  {
+    if (iphi >= NPhiBinsMax) continue;
 
-      if(adcval[iphi][zbin] <= 0)
-	break;
+    if (adcval[iphi][zbin] <= 0)
+      break;
 
-      if( adcval[iphi][zbin] <= adcval[iphi-1][zbin] )
-	phiup++;
-      else
-	break;
-    }
+    if (adcval[iphi][zbin] <= adcval[iphi - 1][zbin])
+      phiup++;
+    else
+      break;
+  }
 
-  for(int iphi = phibin-1; iphi>phibin-4; iphi--)
-    {
-      if(iphi < NPhiBinsMin) continue;
+  for (int iphi = phibin - 1; iphi > phibin - 4; iphi--)
+  {
+    if (iphi < NPhiBinsMin) continue;
 
-      if(adcval[iphi][zbin] <= 0)
-	break;
+    if (adcval[iphi][zbin] <= 0)
+      break;
 
-      if(adcval[iphi][zbin] <= adcval[iphi+1][zbin])
-	phidown++;
-      else
-	break;
-    }
+    if (adcval[iphi][zbin] <= adcval[iphi + 1][zbin])
+      phidown++;
+    else
+      break;
+  }
 
   // search along z at the peak in phi
 
-  for(int iz = zbin+1; iz<zbin+10; iz++)
-    {
-      if(iz >= NZBinsMax)  continue;
+  for (int iz = zbin + 1; iz < zbin + 10; iz++)
+  {
+    if (iz >= NZBinsMax) continue;
 
-      if(adcval[phibin][iz] <= 0)
-	break;
+    if (adcval[phibin][iz] <= 0)
+      break;
 
-      if(adcval[phibin][iz] <= adcval[phibin][iz-1])
-	zup++;
-      else
-	break;
-    }
+    if (adcval[phibin][iz] <= adcval[phibin][iz - 1])
+      zup++;
+    else
+      break;
+  }
 
-  for(int iz =zbin-1; iz>zbin-10; iz--)
-    {
-      if(iz < NZBinsMin)  continue;
+  for (int iz = zbin - 1; iz > zbin - 10; iz--)
+  {
+    if (iz < NZBinsMin) continue;
 
-      if(adcval[phibin][iz] <= 0)
-	break;
+    if (adcval[phibin][iz] <= 0)
+      break;
 
-      if(adcval[phibin][iz] <= adcval[phibin][iz+1])
-	zdown++;
-      else
-	break;
-    }
+    if (adcval[phibin][iz] <= adcval[phibin][iz + 1])
+      zdown++;
+    else
+      break;
+  }
 }
 
 int TpcClusterizer::InitRun(PHCompositeNode *topNode)
@@ -188,7 +187,7 @@ int TpcClusterizer::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int TpcClusterizer::process_event(PHCompositeNode* topNode)
+int TpcClusterizer::process_event(PHCompositeNode *topNode)
 {
   int print_layer = 47;
 
@@ -196,7 +195,7 @@ int TpcClusterizer::process_event(PHCompositeNode* topNode)
     std::cout << "TpcClusterizer::Process_Event" << std::endl;
 
   PHNodeIterator iter(topNode);
-  PHCompositeNode* dstNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  PHCompositeNode *dstNode = static_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
   {
     cout << PHWHERE << "DST Node missing, doing nothing." << endl;
@@ -227,7 +226,7 @@ int TpcClusterizer::process_event(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  PHG4CylinderCellGeomContainer* geom_container =
+  PHG4CylinderCellGeomContainer *geom_container =
       findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
   if (!geom_container)
   {
@@ -239,285 +238,285 @@ int TpcClusterizer::process_event(PHCompositeNode* topNode)
   // The TPC clustering is more complicated than for the silicon, because we have to deal with overlapping clusters
 
   // loop over the TPC HitSet objects
-  TrkrHitSetContainer::ConstRange hitsetrange =  m_hits->getHitSets(TrkrDefs::TrkrId::tpcId);
+  TrkrHitSetContainer::ConstRange hitsetrange = m_hits->getHitSets(TrkrDefs::TrkrId::tpcId);
   for (TrkrHitSetContainer::ConstIterator hitsetitr = hitsetrange.first;
        hitsetitr != hitsetrange.second;
        ++hitsetitr)
+  {
+    TrkrHitSet *hitset = hitsetitr->second;
+    if (Verbosity() > 1)
+      cout << "TpcClusterizer process hitsetkey " << hitsetitr->first << endl;
+    if (Verbosity() > 2) hitset->identify();
+
+    // we have a single hitset, get the info that identifies the module
+    int layer = TrkrDefs::getLayer(hitsetitr->first);
+    // int sector = TpcDefs::getSectorId(hitsetitr->first);
+    int side = TpcDefs::getSide(hitsetitr->first);
+
+    // we will need the geometry object for this layer to get the global position
+    PHG4CylinderCellGeom *layergeom = geom_container->GetLayerCellGeom(layer);
+    int NPhiBins = layergeom->get_phibins();
+    NPhiBinsMin = 0;
+    NPhiBinsMax = NPhiBins;
+
+    int NZBins = layergeom->get_zbins();
+    if (side == 0)
     {
-      TrkrHitSet *hitset = hitsetitr->second;
-      if(Verbosity() > 1)
-	cout << "TpcClusterizer process hitsetkey " << hitsetitr->first << endl;
-      if (Verbosity() > 2) hitset->identify();
+      NZBinsMin = 0;
+      NZBinsMax = NZBins / 2;
+    }
+    else
+    {
+      NZBinsMin = NZBins / 2 + 1;
+      NZBinsMax = NZBins;
+    }
 
-      // we have a single hitset, get the info that identifies the module
-      int layer = TrkrDefs::getLayer(hitsetitr->first);
-      // int sector = TpcDefs::getSectorId(hitsetitr->first);
-      int side = TpcDefs::getSide(hitsetitr->first);
+    // for convenience, create a 2D vector to store adc values in and initialize to zero
+    std::vector<std::vector<double>> adcval(NPhiBins, std::vector<double>(NZBins, 0));
 
-      // we will need the geometry object for this layer to get the global position
-      PHG4CylinderCellGeom* layergeom = geom_container->GetLayerCellGeom(layer);
-      int NPhiBins = layergeom->get_phibins();
-      NPhiBinsMin = 0;
-      NPhiBinsMax = NPhiBins;
+    TrkrHitSet::ConstRange hitrangei = hitset->getHits();
+    for (TrkrHitSet::ConstIterator hitr = hitrangei.first;
+         hitr != hitrangei.second;
+         ++hitr)
+    {
+      int phibin = TpcDefs::getPad(hitr->first);
+      int zbin = TpcDefs::getTBin(hitr->first);
+      if (hitr->second->getAdc() > 0)
+        adcval[phibin][zbin] = (double) hitr->second->getAdc() - pedestal;
 
-      int NZBins = layergeom->get_zbins();
-      if(side == 0)
-	{
-	  NZBinsMin = 0;
-	  NZBinsMax = NZBins/2;
-	}
+      if (Verbosity() > 2)
+        if (layer == print_layer)
+          cout << " add hit in layer " << layer << " with phibin " << phibin << " zbin " << zbin << " adcval " << adcval[phibin][zbin] << endl;
+    }
+
+    vector<int> phibinlo;
+    vector<int> phibinhi;
+    vector<int> zbinlo;
+    vector<int> zbinhi;
+    // we want to search the hit list for local maxima in phi-z space and cluster around them
+    for (TrkrHitSet::ConstIterator hitr = hitrangei.first;
+         hitr != hitrangei.second;
+         ++hitr)
+    {
+      int phibin = TpcDefs::getPad(hitr->first);
+      int zbin = TpcDefs::getTBin(hitr->first);
+      if (!is_local_maximum(phibin, zbin, adcval)) continue;
+
+      int phiup = 0;
+      int phidown = 0;
+      int zup = 0;
+      int zdown = 0;
+      // cluster the hits around this local maximum
+      get_cluster(phibin, zbin, phiup, phidown, zup, zdown, adcval);
+
+      if (phiup == 0 && phidown == 0 && zup == 0 and zdown == 0) continue;  // ignore isolated noise hit
+
+      // Add this cluster to a vector of clusters for later analysis
+      phibinlo.push_back(phibin - phidown);
+      phibinhi.push_back(phibin + phiup);
+      zbinlo.push_back(zbin - zdown);
+      zbinhi.push_back(zbin + zup);
+
+      if (Verbosity() > 2)
+        if (layer == print_layer)
+          cout << " cluster found in layer " << layer << " around hitkey " << hitr->first << " with zbin " << zbin << " zup " << zup << " zdown " << zdown
+               << " phibin " << phibin << " phiup " << phiup << " phidown " << phidown << endl;
+    }  // end loop over hits in this hitset
+
+    // Now we analyze the clusters to get their parameters
+    for (unsigned int iclus = 0; iclus < phibinlo.size(); iclus++)
+    {
+      //cout << "TpcClusterizer: process cluster iclus = " << iclus <<  " in layer " << layer << endl;
+      // loop over the hits in this cluster
+      double zsum = 0.0;
+      double phi_sum = 0.0;
+      double adc_sum = 0.0;
+      double radius = layergeom->get_radius();  // returns center of layer
+      if (Verbosity() > 2)
+        if (layer == print_layer)
+        {
+          cout << "iclus " << iclus << " layer " << layer << " radius " << radius << endl;
+          cout << "    z bin range " << zbinlo[iclus] << " to " << zbinhi[iclus] << " phibin range " << phibinlo[iclus] << " to " << phibinhi[iclus] << endl;
+        }
+
+      std::vector<TrkrDefs::hitkey> hitkeyvec;
+      for (int iphi = phibinlo[iclus]; iphi <= phibinhi[iclus]; iphi++)
+      {
+        for (int iz = zbinlo[iclus]; iz <= zbinhi[iclus]; iz++)
+        {
+          double phi_center = layergeom->get_phicenter(iphi);
+          double z = layergeom->get_zcenter(iz);
+
+          zsum += z * adcval[iphi][iz];
+          phi_sum += phi_center * adcval[iphi][iz];
+          adc_sum += adcval[iphi][iz];
+
+          // capture the hitkeys for all non-zero adc values
+          if (adcval[iphi][iz] != 0)
+          {
+            TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, iz);
+            hitkeyvec.push_back(hitkey);
+          }
+        }
+      }
+
+      if (adc_sum < 10) continue;  // skip obvious noise "clusters"
+
+      // This is the global position
+      double clusphi = phi_sum / adc_sum;
+      double clusz = zsum / adc_sum;
+
+      // create the cluster entry directly in the node tree
+      TrkrDefs::cluskey ckey = TpcDefs::genClusKey(hitset->getHitSetKey(), iclus);
+      TrkrClusterv1 *clus = static_cast<TrkrClusterv1 *>((m_clusterlist->findOrAddCluster(ckey))->second);
+
+      double phi_size = (double) (phibinhi[iclus] - phibinlo[iclus] + 1) * radius * layergeom->get_phistep();
+      double z_size = (double) (zbinhi[iclus] - zbinlo[iclus] + 1) * layergeom->get_zstep();
+
+      // Estimate the errors
+      double dphi2_adc = 0.0;
+      double dphi_adc = 0.0;
+      double dz2_adc = 0.0;
+      double dz_adc = 0.0;
+      for (int iz = zbinlo[iclus]; iz <= zbinhi[iclus]; iz++)
+      {
+        for (int iphi = phibinlo[iclus]; iphi <= phibinhi[iclus]; iphi++)
+        {
+          double dphi = layergeom->get_phicenter(iphi) - clusphi;
+          dphi2_adc += dphi * dphi * adcval[iphi][iz];
+          dphi_adc += dphi * adcval[iphi][iz];
+
+          double dz = layergeom->get_zcenter(iz) - clusz;
+          dz2_adc += dz * dz * adcval[iphi][iz];
+          dz_adc += dz * adcval[iphi][iz];
+        }
+      }
+      double phi_cov = (dphi2_adc / adc_sum - dphi_adc * dphi_adc / (adc_sum * adc_sum));
+      double z_cov = dz2_adc / adc_sum - dz_adc * dz_adc / (adc_sum * adc_sum);
+
+      //cout << " layer " << layer << " z_cov " << z_cov << " dz2_adc " << dz2_adc << " adc_sum " <<  adc_sum << " dz_adc " << dz_adc << endl;
+
+      // phi_cov = (weighted mean of dphi^2) - (weighted mean of dphi)^2,  which is essentially the weighted mean of dphi^2. The error is then:
+      // e_phi = sigma_dphi/sqrt(N) = sqrt( sigma_dphi^2 / N )  -- where N is the number of samples of the distribution with standard deviation sigma_dphi
+      //    - N is the number of electrons that drift to the readout plane
+      // We have to convert (sum of adc units for all bins in the cluster) to number of ionization electrons N
+      // Conversion gain is 20 mV/fC - relates total charge collected on pad to PEAK voltage out of ADC. The GEM gain is assumed to be 2000
+      // To get equivalent charge per Z bin, so that summing ADC input voltage over all Z bins returns total input charge, divide voltages by 2.4 for 80 ns SAMPA
+      // Equivalent charge per Z bin is then  (ADU x 2200 mV / 1024) / 2.4 x (1/20) fC/mV x (1/1.6e-04) electrons/fC x (1/2000) = ADU x 0.14
+
+      double phi_err = radius * sqrt(phi_cov / (adc_sum * 0.14));
+      if (phi_err == 0.0)  // a single phi bin will cause this
+        phi_err = radius * layergeom->get_phistep() / sqrt(12.0);
+
+      double z_err = sqrt(z_cov / (adc_sum * 0.14));
+      if (z_err == 0.0)
+        z_err = layergeom->get_zstep() / sqrt(12.0);
+
+      // This corrects the bias introduced by the asymmetric SAMPA chip shaping - assumes 80 ns shaping time
+      if (clusz < 0)
+        clusz -= zz_shaping_correction;
       else
-	{
-	  NZBinsMin = NZBins/2 + 1;
-	  NZBinsMax = NZBins;
-	}
+        clusz += zz_shaping_correction;
 
-      // for convenience, create a 2D vector to store adc values in and initialize to zero
-      std::vector<std::vector<double>> adcval (NPhiBins, std::vector<double>(NZBins, 0) );
+      // Fill in the cluster details
+      //================
+      clus->setAdc(adc_sum);
+      clus->setPosition(0, radius * cos(clusphi));
+      clus->setPosition(1, radius * sin(clusphi));
+      clus->setPosition(2, clusz);
+      clus->setGlobal();
 
-      TrkrHitSet::ConstRange hitrangei = hitset->getHits();
-      for (TrkrHitSet::ConstIterator hitr = hitrangei.first;
-	   hitr != hitrangei.second;
-	   ++hitr)
-	{
-	  int phibin = TpcDefs::getPad(hitr->first);
-	  int zbin = TpcDefs::getTBin(hitr->first);
-	  if(hitr->second->getAdc() > 0)
-	    adcval[phibin][zbin] = (double) hitr->second->getAdc() - pedestal;
+      TMatrixF DIM(3, 3);
+      DIM[0][0] = 0.0;
+      DIM[0][1] = 0.0;
+      DIM[0][2] = 0.0;
+      DIM[1][0] = 0.0;
+      DIM[1][1] = phi_size / radius * phi_size / radius;  //cluster_v1 expects polar coordinates covariance
+      DIM[1][2] = 0.0;
+      DIM[2][0] = 0.0;
+      DIM[2][1] = 0.0;
+      DIM[2][2] = z_size * z_size;
 
-	  if(Verbosity() > 2)
-	    if(layer == print_layer)
-	      cout << " add hit in layer " << layer << " with phibin " << phibin << " zbin " << zbin << " adcval " << adcval[phibin][zbin] << endl;
-	}
+      TMatrixF ERR(3, 3);
+      ERR[0][0] = 0.0;
+      ERR[0][1] = 0.0;
+      ERR[0][2] = 0.0;
+      ERR[1][0] = 0.0;
+      ERR[1][1] = phi_err * phi_err;  //cluster_v1 expects rad, arc, z as elementsof covariance
+      ERR[1][2] = 0.0;
+      ERR[2][0] = 0.0;
+      ERR[2][1] = 0.0;
+      ERR[2][2] = z_err * z_err;
 
-      vector<int> phibinlo;
-      vector<int> phibinhi;
-      vector<int> zbinlo;
-      vector<int> zbinhi;
-      // we want to search the hit list for local maxima in phi-z space and cluster around them
-      for (TrkrHitSet::ConstIterator hitr = hitrangei.first;
-	   hitr != hitrangei.second;
-	   ++hitr)
-	{
-	  int phibin = TpcDefs::getPad(hitr->first);
-	  int zbin = TpcDefs::getTBin(hitr->first);
-	  if(!is_local_maximum(phibin, zbin, adcval)) continue;
+      TMatrixF ROT(3, 3);
+      ROT[0][0] = cos(clusphi);
+      ROT[0][1] = -sin(clusphi);
+      ROT[0][2] = 0.0;
+      ROT[1][0] = sin(clusphi);
+      ROT[1][1] = cos(clusphi);
+      ROT[1][2] = 0.0;
+      ROT[2][0] = 0.0;
+      ROT[2][1] = 0.0;
+      ROT[2][2] = 1.0;
 
-	  int phiup= 0;
-	  int phidown = 0;
-	  int zup= 0;
-	  int zdown = 0;
-	  // cluster the hits around this local maximum
-	  get_cluster(phibin, zbin, phiup, phidown, zup, zdown, adcval);
+      TMatrixF ROT_T(3, 3);
+      ROT_T.Transpose(ROT);
 
-	  if(phiup == 0 && phidown == 0 && zup == 0 and zdown == 0) continue;   // ignore isolated noise hit
+      TMatrixF COVAR_DIM(3, 3);
+      COVAR_DIM = ROT * DIM * ROT_T;
 
-	  // Add this cluster to a vector of clusters for later analysis
-	  phibinlo.push_back(phibin - phidown);
-	  phibinhi.push_back(phibin + phiup);
-	  zbinlo.push_back(zbin - zdown);
-	  zbinhi.push_back(zbin + zup);
+      clus->setSize(0, 0, COVAR_DIM[0][0]);
+      clus->setSize(0, 1, COVAR_DIM[0][1]);
+      clus->setSize(0, 2, COVAR_DIM[0][2]);
+      clus->setSize(1, 0, COVAR_DIM[1][0]);
+      clus->setSize(1, 1, COVAR_DIM[1][1]);
+      clus->setSize(1, 2, COVAR_DIM[1][2]);
+      clus->setSize(2, 0, COVAR_DIM[2][0]);
+      clus->setSize(2, 1, COVAR_DIM[2][1]);
+      clus->setSize(2, 2, COVAR_DIM[2][2]);
+      //cout << " covar_dim[2][2] = " <<  COVAR_DIM[2][2] << endl;
 
-	  if(Verbosity() > 2)
-	    if(layer == print_layer)
-	      cout << " cluster found in layer " << layer << " around hitkey " << hitr->first << " with zbin " << zbin << " zup " << zup << " zdown " << zdown
-		   << " phibin " << phibin << " phiup " << phiup << " phidown " << phidown << endl;
-	}  // end loop over hits in this hitset
+      TMatrixF COVAR_ERR(3, 3);
+      COVAR_ERR = ROT * ERR * ROT_T;
 
-      // Now we analyze the clusters to get their parameters
-      for(unsigned int iclus = 0; iclus < phibinlo.size(); iclus++)
-	{
-	  //cout << "TpcClusterizer: process cluster iclus = " << iclus <<  " in layer " << layer << endl;
-	  // loop over the hits in this cluster
-	  double zsum = 0.0;
-	  double phi_sum = 0.0;
-	  double adc_sum = 0.0;
-	  double radius = layergeom->get_radius();  // returns center of layer
-	  if(Verbosity() > 2)
-	    if(layer == print_layer)
-	      {
-		cout << "iclus " << iclus << " layer " << layer << " radius " << radius << endl;
-		cout << "    z bin range " << zbinlo[iclus] << " to " << zbinhi[iclus] << " phibin range " << phibinlo[iclus] << " to " << phibinhi[iclus] << endl;
-	      }
+      clus->setError(0, 0, COVAR_ERR[0][0]);
+      clus->setError(0, 1, COVAR_ERR[0][1]);
+      clus->setError(0, 2, COVAR_ERR[0][2]);
+      clus->setError(1, 0, COVAR_ERR[1][0]);
+      clus->setError(1, 1, COVAR_ERR[1][1]);
+      clus->setError(1, 2, COVAR_ERR[1][2]);
+      clus->setError(2, 0, COVAR_ERR[2][0]);
+      clus->setError(2, 1, COVAR_ERR[2][1]);
+      clus->setError(2, 2, COVAR_ERR[2][2]);
 
-	  std::vector<TrkrDefs::hitkey> hitkeyvec;
-	  for(int iphi = phibinlo[iclus]; iphi <= phibinhi[iclus]; iphi++)
-	    {
-	      for(int iz = zbinlo[iclus]; iz <= zbinhi[iclus]; iz++)
-		{
-		  double phi_center = layergeom->get_phicenter(iphi);
-		  double z = layergeom->get_zcenter(iz);
-
-		  zsum += z * adcval[iphi][iz];
-		  phi_sum += phi_center * adcval[iphi][iz];
-		  adc_sum += adcval[iphi][iz];
-
-		  // capture the hitkeys for all non-zero adc values
-		  if(adcval[iphi][iz] != 0)
-		    {
-		      TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, iz);
-		      hitkeyvec.push_back(hitkey);
-		    }
-		}
-	    }
-
-	  if(adc_sum < 10) continue;   // skip obvious noise "clusters"
-
-	  // This is the global position
-	  double clusphi = phi_sum / adc_sum;
-	  double clusz = zsum /  adc_sum;
-
-	  // create the cluster entry directly in the node tree
-	  TrkrDefs::cluskey ckey = TpcDefs::genClusKey(hitset->getHitSetKey(), iclus);
-	  TrkrClusterv1 *clus = static_cast<TrkrClusterv1 *>((m_clusterlist->findOrAddCluster(ckey))->second);
-
-	  double phi_size = (double) (phibinhi[iclus] - phibinlo[iclus] + 1) * radius * layergeom->get_phistep();
-	  double z_size = (double) (zbinhi[iclus] - zbinlo[iclus] + 1) * layergeom->get_zstep();
-
-	  // Estimate the errors
-	  double dphi2_adc = 0.0;
-	  double dphi_adc = 0.0;
-	  double dz2_adc = 0.0;
-	  double dz_adc = 0.0;
-	  for(int iz = zbinlo[iclus]; iz <= zbinhi[iclus]; iz++)
-	    {
-	      for(int iphi = phibinlo[iclus]; iphi <= phibinhi[iclus]; iphi++)
-		{
-		  double dphi = layergeom->get_phicenter(iphi) - clusphi;
-		  dphi2_adc += dphi*dphi*adcval[iphi][iz];
-		  dphi_adc += dphi*adcval[iphi][iz];
-
-		  double dz = layergeom->get_zcenter(iz) - clusz;
-		  dz2_adc += dz*dz*adcval[iphi][iz];
-		  dz_adc += dz*adcval[iphi][iz];
-		}
-	    }
-	  double phi_cov = ( dphi2_adc / adc_sum - dphi_adc * dphi_adc / (adc_sum*adc_sum) );
-	  double z_cov =  dz2_adc / adc_sum - dz_adc*dz_adc / (adc_sum*adc_sum);
-
-	  //cout << " layer " << layer << " z_cov " << z_cov << " dz2_adc " << dz2_adc << " adc_sum " <<  adc_sum << " dz_adc " << dz_adc << endl;
-
-	  // phi_cov = (weighted mean of dphi^2) - (weighted mean of dphi)^2,  which is essentially the weighted mean of dphi^2. The error is then:
-	  // e_phi = sigma_dphi/sqrt(N) = sqrt( sigma_dphi^2 / N )  -- where N is the number of samples of the distribution with standard deviation sigma_dphi
-	  //    - N is the number of electrons that drift to the readout plane
-	  // We have to convert (sum of adc units for all bins in the cluster) to number of ionization electrons N
-	  // Conversion gain is 20 mV/fC - relates total charge collected on pad to PEAK voltage out of ADC. The GEM gain is assumed to be 2000
-	  // To get equivalent charge per Z bin, so that summing ADC input voltage over all Z bins returns total input charge, divide voltages by 2.4 for 80 ns SAMPA
-	  // Equivalent charge per Z bin is then  (ADU x 2200 mV / 1024) / 2.4 x (1/20) fC/mV x (1/1.6e-04) electrons/fC x (1/2000) = ADU x 0.14
-
-	  double phi_err = radius * sqrt(phi_cov / (adc_sum * 0.14));
-	  if(phi_err == 0.0)   // a single phi bin will cause this
-	    phi_err = radius *  layergeom->get_phistep() / sqrt(12.0);
-
-	  double z_err = sqrt(z_cov / (adc_sum * 0.14)) ;
-	  if(z_err == 0.0)
-	    z_err = layergeom->get_zstep() / sqrt(12.0);
-
-	  // This corrects the bias introduced by the asymmetric SAMPA chip shaping - assumes 80 ns shaping time
-	  if (clusz < 0)
-	    clusz -= zz_shaping_correction;
-	  else
-	    clusz += zz_shaping_correction;
-
-	  // Fill in the cluster details
-	  //================
-	  clus->setAdc(adc_sum);
-	  clus->setPosition(0, radius * cos(clusphi));
-	  clus->setPosition(1, radius * sin(clusphi));
-	  clus->setPosition(2, clusz);
-	  clus->setGlobal();
-
-	  TMatrixF DIM(3, 3);
-	  DIM[0][0] = 0.0;
-	  DIM[0][1] = 0.0;
-	  DIM[0][2] = 0.0;
-	  DIM[1][0] = 0.0;
-	  DIM[1][1] = phi_size / radius * phi_size / radius;  //cluster_v1 expects polar coordinates covariance
-	  DIM[1][2] = 0.0;
-	  DIM[2][0] = 0.0;
-	  DIM[2][1] = 0.0;
-	  DIM[2][2] = z_size * z_size;
-
-	  TMatrixF ERR(3, 3);
-	  ERR[0][0] = 0.0;
-	  ERR[0][1] = 0.0;
-	  ERR[0][2] = 0.0;
-	  ERR[1][0] = 0.0;
-	  ERR[1][1] = phi_err   * phi_err;  //cluster_v1 expects rad, arc, z as elementsof covariance
-	  ERR[1][2] = 0.0;
-	  ERR[2][0] = 0.0;
-	  ERR[2][1] = 0.0;
-	  ERR[2][2] = z_err * z_err;
-
-	  TMatrixF ROT(3, 3);
-	  ROT[0][0] = cos(clusphi);
-	  ROT[0][1] = -sin(clusphi);
-	  ROT[0][2] = 0.0;
-	  ROT[1][0] = sin(clusphi);
-	  ROT[1][1] = cos(clusphi);
-	  ROT[1][2] = 0.0;
-	  ROT[2][0] = 0.0;
-	  ROT[2][1] = 0.0;
-	  ROT[2][2] = 1.0;
-
-	  TMatrixF ROT_T(3, 3);
-	  ROT_T.Transpose(ROT);
-
-	  TMatrixF COVAR_DIM(3, 3);
-	  COVAR_DIM = ROT * DIM * ROT_T;
-
-	  clus->setSize(0, 0, COVAR_DIM[0][0]);
-	  clus->setSize(0, 1, COVAR_DIM[0][1]);
-	  clus->setSize(0, 2, COVAR_DIM[0][2]);
-	  clus->setSize(1, 0, COVAR_DIM[1][0]);
-	  clus->setSize(1, 1, COVAR_DIM[1][1]);
-	  clus->setSize(1, 2, COVAR_DIM[1][2]);
-	  clus->setSize(2, 0, COVAR_DIM[2][0]);
-	  clus->setSize(2, 1, COVAR_DIM[2][1]);
-	  clus->setSize(2, 2, COVAR_DIM[2][2]);
-	  //cout << " covar_dim[2][2] = " <<  COVAR_DIM[2][2] << endl;
-
-	  TMatrixF COVAR_ERR(3, 3);
-	  COVAR_ERR = ROT * ERR * ROT_T;
-
-	  clus->setError(0, 0, COVAR_ERR[0][0]);
-	  clus->setError(0, 1, COVAR_ERR[0][1]);
-	  clus->setError(0, 2, COVAR_ERR[0][2]);
-	  clus->setError(1, 0, COVAR_ERR[1][0]);
-	  clus->setError(1, 1, COVAR_ERR[1][1]);
-	  clus->setError(1, 2, COVAR_ERR[1][2]);
-	  clus->setError(2, 0, COVAR_ERR[2][0]);
-	  clus->setError(2, 1, COVAR_ERR[2][1]);
-	  clus->setError(2, 2, COVAR_ERR[2][2]);
-
-	  /*
+      /*
 	  for(int i=0;i<3;i++)
 	    for(int j=0;j<3;j++)
 	      cout << "    i " << i << " j " << j << " clusphi " << clusphi << " clus error " << clus->getError(i,j) 
 		   << " clus size " << clus->getSize(i,j) << " ROT " << ROT[i][j] << " ROT_T " << ROT_T[i][j] << " COVAR_ERR " << COVAR_ERR[i][j] << endl;
 	  */
 
-	  // Add the hit associations to the TrkrClusterHitAssoc node
-	  // we need the cluster key and all associated hit keys (note: the cluster key includes the hitset key)
-	  for(unsigned int i=0;i<hitkeyvec.size();i++)
-	    {
-	      m_clusterhitassoc->addAssoc(ckey, hitkeyvec[i]);
-	    }
+      // Add the hit associations to the TrkrClusterHitAssoc node
+      // we need the cluster key and all associated hit keys (note: the cluster key includes the hitset key)
+      for (unsigned int i = 0; i < hitkeyvec.size(); i++)
+      {
+        m_clusterhitassoc->addAssoc(ckey, hitkeyvec[i]);
+      }
 
-	} // end loop over clusters for this hitset
-    }  // end loop over hitsets
+    }  // end loop over clusters for this hitset
+  }    // end loop over hitsets
 
-  if(Verbosity() > 2)
-    {
-      cout << "Dump clusters after TpcClusterizer" << endl;
-      m_clusterlist->identify();
-    }
+  if (Verbosity() > 2)
+  {
+    cout << "Dump clusters after TpcClusterizer" << endl;
+    m_clusterlist->identify();
+  }
 
-  if(Verbosity() > 2)
-    {
-      cout << "Dump cluster hit associations after TpcClusterizer" << endl;
-      m_clusterhitassoc->identify();
-    }
+  if (Verbosity() > 2)
+  {
+    cout << "Dump cluster hit associations after TpcClusterizer" << endl;
+    m_clusterhitassoc->identify();
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -245,7 +245,11 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
   {
     TrkrHitSet *hitset = hitsetitr->second;
     if (Verbosity() > 1)
-      cout << "TpcClusterizer process hitsetkey " << hitsetitr->first << endl;
+      cout << "TpcClusterizer process hitsetkey " << hitsetitr->first
+           << " layer " << (int) TrkrDefs::getLayer(hitsetitr->first)
+           << " side " << (int) TpcDefs::getSide(hitsetitr->first)
+           << " sector " << (int) TpcDefs::getSectorId(hitsetitr->first)
+           << endl;
     if (Verbosity() > 2) hitset->identify();
 
     // we have a single hitset, get the info that identifies the module

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -2,19 +2,19 @@
 
 #include "AssocInfoContainer.h"
 
-#include <trackbase_historic/SvtxTrack.h>          // for SvtxTrack, SvtxTra...
-#include <trackbase_historic/SvtxTrackMap.h>       // for SvtxTrackMap, Svtx...
+#include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTra...
+#include <trackbase_historic/SvtxTrackMap.h>  // for SvtxTrackMap, Svtx...
 #include <trackbase_historic/SvtxTrack_FastSim.h>
 
 #include <trackbase/TrkrCluster.h>
-#include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
+#include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
 
-#include <g4main/PHG4Hit.h>                        // for PHG4Hit
-#include <g4main/PHG4HitDefs.h>                    // for keytype
+#include <g4main/PHG4Hit.h>  // for PHG4Hit
 #include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4HitDefs.h>  // for keytype
 #include <g4main/PHG4TruthInfoContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -22,11 +22,11 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
-#include <cstdlib>                                // for exit
-#include <iostream>                                // for operator<<, endl
-#include <map>                                     // for multimap, map<>::c...
+#include <cstdlib>   // for exit
+#include <iostream>  // for operator<<, endl
+#include <map>       // for multimap, map<>::c...
 #include <memory>
-#include <utility>                                 // for pair
+#include <utility>  // for pair
 
 #define LogDebug(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
 #define LogError(exp) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
@@ -64,118 +64,116 @@ int PHTruthTrackSeeding::Setup(PHCompositeNode* topNode)
 
 int PHTruthTrackSeeding::Process()
 {
-
   typedef std::map<int, std::set<TrkrCluster*> > TrkClustersMap;
   TrkClustersMap m_trackID_clusters;
-  
+
   // loop over all clusters
   TrkrClusterContainer::ConstRange clusrange = _cluster_map->getClusters();
-  for(TrkrClusterContainer::ConstIterator clusiter = clusrange.first; clusiter != clusrange.second; ++clusiter)
+  for (TrkrClusterContainer::ConstIterator clusiter = clusrange.first; clusiter != clusrange.second; ++clusiter)
+  {
+    TrkrCluster* cluster = clusiter->second;
+    TrkrDefs::cluskey cluskey = clusiter->first;
+    unsigned int trkrid = TrkrDefs::getTrkrId(cluskey);
+
+    // get the hits for this cluster
+    TrkrClusterHitAssoc::ConstRange hitrange = clusterhitassoc->getHits(cluskey);  // returns range of pairs {cluster key, hit key} for this cluskey
+    for (TrkrClusterHitAssoc::ConstIterator clushititer = hitrange.first; clushititer != hitrange.second; ++clushititer)
     {
-      TrkrCluster *cluster = clusiter->second;
-      TrkrDefs::cluskey cluskey = clusiter->first;
-      unsigned int trkrid = TrkrDefs::getTrkrId(cluskey);
+      TrkrDefs::hitkey hitkey = clushititer->second;
+      // TrkrHitTruthAssoc uses a map with (hitsetkey, std::pair(hitkey, g4hitkey)) - get the hitsetkey from the cluskey
+      TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
 
-      // get the hits for this cluster
-     TrkrClusterHitAssoc::ConstRange hitrange = clusterhitassoc->getHits(cluskey);  // returns range of pairs {cluster key, hit key} for this cluskey
-      for(TrkrClusterHitAssoc::ConstIterator clushititer = hitrange.first; clushititer != hitrange.second; ++clushititer)
-	{
-	  TrkrDefs::hitkey hitkey = clushititer->second;
-	  // TrkrHitTruthAssoc uses a map with (hitsetkey, std::pair(hitkey, g4hitkey)) - get the hitsetkey from the cluskey
-	  TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);	  
+      // get all of the g4hits for this hitkey
+      std::multimap<TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> > temp_map;
+      hittruthassoc->getG4Hits(hitsetkey, hitkey, temp_map);  // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
+      for (std::multimap<TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> >::iterator htiter = temp_map.begin(); htiter != temp_map.end(); ++htiter)
+      {
+        // extract the g4 hit key here and add the hits to the set
+        PHG4HitDefs::keytype g4hitkey = htiter->second.second;
+        PHG4Hit* phg4hit;
+        if (trkrid == TrkrDefs::tpcId)
+          phg4hit = phg4hits_tpc->findHit(g4hitkey);
+        else if (trkrid == TrkrDefs::inttId)
+          phg4hit = phg4hits_intt->findHit(g4hitkey);
+        else
+          phg4hit = phg4hits_mvtx->findHit(g4hitkey);
 
-	  // get all of the g4hits for this hitkey
-	  std::multimap< TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> > temp_map;    
-	  hittruthassoc->getG4Hits(hitsetkey, hitkey, temp_map); 	  // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
-	  for(std::multimap< TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> >::iterator htiter =  temp_map.begin(); htiter != temp_map.end(); ++htiter) 
-	    {
-	      // extract the g4 hit key here and add the hits to the set
-	      PHG4HitDefs::keytype g4hitkey = htiter->second.second;
-	      PHG4Hit * phg4hit;
-	      if(trkrid == TrkrDefs::tpcId)
-		phg4hit = phg4hits_tpc->findHit(g4hitkey);
-	      else if(trkrid == TrkrDefs::inttId)
-		phg4hit = phg4hits_intt->findHit(g4hitkey);
-	      else
-		phg4hit = phg4hits_mvtx->findHit(g4hitkey);
+        int particle_id = phg4hit->get_trkid();
 
-	      int particle_id = phg4hit->get_trkid();
+        TrkClustersMap::iterator it = m_trackID_clusters.find(particle_id);
 
-	      TrkClustersMap::iterator it = m_trackID_clusters.find(particle_id);
-	      
-	      if (it != m_trackID_clusters.end())
-		{
-		  it->second.insert(cluster);
-		}
-	      else
-		{
-		  std::set<TrkrCluster*> clusters;
-		  clusters.insert(cluster);
-		  m_trackID_clusters.insert(std::pair<int, std::set<TrkrCluster*> >(particle_id, clusters));
-		}
-	    }  // loop over g4hits associated with hit
-	}  // loop over hits associated with cluster
-    }  // loop over clusters
-
+        if (it != m_trackID_clusters.end())
+        {
+          it->second.insert(cluster);
+        }
+        else
+        {
+          std::set<TrkrCluster*> clusters;
+          clusters.insert(cluster);
+          m_trackID_clusters.insert(std::pair<int, std::set<TrkrCluster*> >(particle_id, clusters));
+        }
+      }  // loop over g4hits associated with hit
+    }    // loop over hits associated with cluster
+  }      // loop over clusters
 
   //==================================
 
   // Build track
   for (TrkClustersMap::const_iterator trk_clusters_itr = m_trackID_clusters.begin();
        trk_clusters_itr != m_trackID_clusters.end(); ++trk_clusters_itr)
+  {
+    if (trk_clusters_itr->second.size() > _min_clusters_per_track)
     {
-      if (trk_clusters_itr->second.size() > _min_clusters_per_track)
-	{
-	  std::unique_ptr<SvtxTrack_FastSim> svtx_track(new SvtxTrack_FastSim());
+      std::unique_ptr<SvtxTrack_FastSim> svtx_track(new SvtxTrack_FastSim());
 
-	  svtx_track->set_id(_track_map->size());
-	  svtx_track->set_truth_track_id(trk_clusters_itr->first);
+      svtx_track->set_id(_track_map->size());
+      svtx_track->set_truth_track_id(trk_clusters_itr->first);
 
-	  // dummy values, set px to make it through the minimum pT cut
-	  svtx_track->set_px(10.);
-	  svtx_track->set_py(0.);
-	  svtx_track->set_pz(0.);
-	  for (TrkrCluster* cluster : trk_clusters_itr->second)
-	    {
-	      svtx_track->insert_cluster_key(cluster->getClusKey());
-	      _assoc_container->SetClusterTrackAssoc(cluster->getClusKey(), svtx_track->get_id());
-	    }
-	  _track_map->insert(svtx_track.get());
-	}
+      // dummy values, set px to make it through the minimum pT cut
+      svtx_track->set_px(10.);
+      svtx_track->set_py(0.);
+      svtx_track->set_pz(0.);
+      for (TrkrCluster* cluster : trk_clusters_itr->second)
+      {
+        svtx_track->insert_cluster_key(cluster->getClusKey());
+        _assoc_container->SetClusterTrackAssoc(cluster->getClusKey(), svtx_track->get_id());
+      }
+      _track_map->insert(svtx_track.get());
     }
-  
+  }
+
   if (Verbosity() >= 2)
+  {
+    cout << "Loop over SvtxTrackMap entries " << endl;
+    for (SvtxTrackMap::Iter iter = _track_map->begin();
+         iter != _track_map->end(); ++iter)
     {
-      cout << "Loop over SvtxTrackMap entries " << endl;
-      for (SvtxTrackMap::Iter iter = _track_map->begin();
-	   iter != _track_map->end(); ++iter)
-	{
-	  SvtxTrack* svtx_track = iter->second;
+      SvtxTrack* svtx_track = iter->second;
 
-	  //svtx_track->identify();
-	  //continue;
+      //svtx_track->identify();
+      //continue;
 
-	  cout << "Track ID: " << svtx_track->get_id() << ", Dummy Track pT: "
-	       << svtx_track->get_pt() << ", Truth Track/Particle ID: "
-	       << svtx_track->get_truth_track_id() << endl;
-	    
-	  //Print associated clusters;
-	  for (SvtxTrack::ConstClusterKeyIter iter =
-		 svtx_track->begin_cluster_keys();
-	       iter != svtx_track->end_cluster_keys(); ++iter)
-	    {
-	      TrkrDefs::cluskey cluster_key = *iter;
-	      TrkrCluster* cluster = _cluster_map->findCluster(cluster_key);
-	      float radius = sqrt(
-				  cluster->getX() * cluster->getX() + cluster->getY() * cluster->getY());
-	      cout << "       cluster ID: "
-		   << cluster->getClusKey() << ", cluster radius: " << radius
-		   << endl;
-	    }
-	}
+      cout << "Track ID: " << svtx_track->get_id() << ", Dummy Track pT: "
+           << svtx_track->get_pt() << ", Truth Track/Particle ID: "
+           << svtx_track->get_truth_track_id() << endl;
+
+      //Print associated clusters;
+      for (SvtxTrack::ConstClusterKeyIter iter =
+               svtx_track->begin_cluster_keys();
+           iter != svtx_track->end_cluster_keys(); ++iter)
+      {
+        TrkrDefs::cluskey cluster_key = *iter;
+        TrkrCluster* cluster = _cluster_map->findCluster(cluster_key);
+        float radius = sqrt(
+            cluster->getX() * cluster->getX() + cluster->getY() * cluster->getY());
+        cout << "       cluster ID: "
+             << cluster->getClusKey() << ", cluster radius: " << radius
+             << endl;
+      }
     }
+  }
   //==================================
-  
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -188,19 +186,19 @@ int PHTruthTrackSeeding::GetNodes(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  clusterhitassoc = findNode::getClass<TrkrClusterHitAssoc>(topNode,"TRKR_CLUSTERHITASSOC");
-  if(!clusterhitassoc) 
-    {
-      cout << PHWHERE << "Failed to find TRKR_CLUSTERHITASSOC node, quit!" << endl;
-      exit(1);
-    }
-  
-  hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode,"TRKR_HITTRUTHASSOC");
-  if(!hittruthassoc) 
-    {
-      cout << PHWHERE << "Failed to find TRKR_HITTRUTHASSOC node, quit!" << endl;
-      exit(1);
-    }
+  clusterhitassoc = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
+  if (!clusterhitassoc)
+  {
+    cout << PHWHERE << "Failed to find TRKR_CLUSTERHITASSOC node, quit!" << endl;
+    exit(1);
+  }
+
+  hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
+  if (!hittruthassoc)
+  {
+    cout << PHWHERE << "Failed to find TRKR_HITTRUTHASSOC node, quit!" << endl;
+    exit(1);
+  }
 
   phg4hits_tpc = findNode::getClass<PHG4HitContainer>(
       topNode, "G4HIT_TPC");

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -75,6 +75,13 @@ int PHTruthTrackSeeding::Process()
     TrkrDefs::cluskey cluskey = clusiter->first;
     unsigned int trkrid = TrkrDefs::getTrkrId(cluskey);
 
+
+    if (Verbosity() >= 3)
+    {
+      cout <<__PRETTY_FUNCTION__<<" process cluster ";
+      cluster->identify();
+    }
+
     // get the hits for this cluster
     TrkrClusterHitAssoc::ConstRange hitrange = clusterhitassoc->getHits(cluskey);  // returns range of pairs {cluster key, hit key} for this cluskey
     for (TrkrClusterHitAssoc::ConstIterator clushititer = hitrange.first; clushititer != hitrange.second; ++clushititer)
@@ -105,18 +112,37 @@ int PHTruthTrackSeeding::Process()
         if (it != m_trackID_clusters.end())
         {
           it->second.insert(cluster);
+          if (Verbosity() >= 3)
+          {
+            cout <<__PRETTY_FUNCTION__<<" append particle"<<particle_id<<" -> cluster "<<cluskey<<endl;;
+            cluster->identify();
+          }
         }
         else
         {
           std::set<TrkrCluster*> clusters;
           clusters.insert(cluster);
           m_trackID_clusters.insert(std::pair<int, std::set<TrkrCluster*> >(particle_id, clusters));
+
+
+          if (Verbosity() >= 3)
+          {
+            cout <<__PRETTY_FUNCTION__<<" new particle"<<particle_id<<" -> cluster "<<cluskey<<endl;;
+            cluster->identify();
+          }
+
         }
       }  // loop over g4hits associated with hit
     }    // loop over hits associated with cluster
   }      // loop over clusters
 
   //==================================
+
+  if (Verbosity() >= 2)
+  {
+    cout <<__PRETTY_FUNCTION__
+        <<" _track_map->size = "<<_track_map->size()<<endl;
+  }
 
   // Build track
   for (TrkClustersMap::const_iterator trk_clusters_itr = m_trackID_clusters.begin();
@@ -138,7 +164,16 @@ int PHTruthTrackSeeding::Process()
         svtx_track->insert_cluster_key(cluster->getClusKey());
         _assoc_container->SetClusterTrackAssoc(cluster->getClusKey(), svtx_track->get_id());
       }
+
       _track_map->insert(svtx_track.get());
+
+      if (Verbosity() >= 2)
+      {
+        cout <<__PRETTY_FUNCTION__<<" particle "<<trk_clusters_itr->first<<" -> "
+            <<trk_clusters_itr->second.size()<<" clusters"
+            <<" _track_map->size = "<< (_track_map->size()) <<": ";
+        _track_map->identify();
+      }
     }
   }
 

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -10,7 +10,7 @@
 #include "PHTrackSeeding.h"
 
 #include <set>
-#include <string>            // for string
+#include <string>  // for string
 
 // forward declarations
 class PHCompositeNode;
@@ -71,8 +71,8 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   PHG4HitContainer* phg4hits_intt;
   PHG4HitContainer* phg4hits_mvtx;
 
-  TrkrHitTruthAssoc *hittruthassoc;
-  TrkrClusterHitAssoc *clusterhitassoc;
+  TrkrHitTruthAssoc* hittruthassoc;
+  TrkrClusterHitAssoc* clusterhitassoc;
 
   //SvtxHitMap* hitsmap;
   //PHG4CellContainer* cells_svtx;

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -799,9 +799,9 @@ void PHG4TpcPadPlaneReadout::UpdateInternalParameters()
   MaxRadius[1] = get_double_param("tpc_maxradius_mid");
   MaxRadius[2] = get_double_param("tpc_maxradius_outer");
 
-  Thickness[0] = (MaxRadius[0] - MinRadius[0]) / NTpcLayers[0];
-  Thickness[1] = (MaxRadius[1] - MinRadius[1]) / NTpcLayers[1];
-  Thickness[2] = (MaxRadius[2] - MinRadius[2]) / NTpcLayers[2];
+  Thickness[0] = NTpcLayers[0]<=0 ? 0 : (MaxRadius[0] - MinRadius[0]) / NTpcLayers[0];
+  Thickness[1] = NTpcLayers[1]<=0 ? 0 : (MaxRadius[1] - MinRadius[1]) / NTpcLayers[1];
+  Thickness[2] = NTpcLayers[2]<=0 ? 0 : (MaxRadius[2] - MinRadius[2]) / NTpcLayers[2];
 
   MaxRadius[0] = get_double_param("tpc_maxradius_inner");
   MaxRadius[1] = get_double_param("tpc_maxradius_mid");


### PR DESCRIPTION
Few fixes to get the TPC prototype simulation going
1. Implement `TpcClusterizer::InitRun(PHCompositeNode *topNode)` to build containers in DST, which are needed to run TPC simulation alone without silicon trackers. 
2. Allow zero layers in modules for the TPC readout plane in 242942c. This is due to test beam only use module 2 with module 1 and module 3 = 0 layers. 
3. clang-format to sPHENIX code style. Adding a few more verbosity prints. 