### PR TITLE
make coverity happy, set verbosity after pointer was verified

### DIFF
--- a/offline/packages/trackreco/PHGenFitTrackProjection.cc
+++ b/offline/packages/trackreco/PHGenFitTrackProjection.cc
@@ -109,12 +109,13 @@ int PHGenFitTrackProjection::InitRun(PHCompositeNode *topNode) {
 			"DafRef",
 			"RKTrackRep", false);
 
-	_fitter->set_verbosity(Verbosity());
 
 	if (!_fitter) {
 		cerr << PHWHERE << endl;
 		return Fun4AllReturnCodes::ABORTRUN;
 	}
+
+	_fitter->set_verbosity(Verbosity());
 
 	if (Verbosity() > 0) {
 		cout


### PR DESCRIPTION
This PR fixes a simple coverity complaint. Doing this to reduce the noise in coverity and before this code gets copied around more