### PR TITLE
Add vertex reconstruction in the EIC fast tracking module

### DIFF
--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -33,7 +33,8 @@ pkginclude_HEADERS = \
   PHTrackSeeding.h \
   PHTrackSetMerging.h \
   PHTruthTrackSeeding.h \
-  PHTruthVertexing.h
+  PHTruthVertexing.h \
+  PHRaveVertexing.h
 
 ROOTDICTS = \
   AssocInfoContainer_Dict.cc

--- a/offline/packages/trackreco/PHRaveVertexing.cc
+++ b/offline/packages/trackreco/PHRaveVertexing.cc
@@ -200,6 +200,8 @@ int PHRaveVertexing::process_event(PHCompositeNode* topNode)
 
   if (Verbosity() > 1)
   {
+    _vertexmap->identify();
+
     std::cout << "=============== Timers: ===============" << std::endl;
     std::cout << "Event: " << _event << std::endl;
     std::cout << "Translate:                " << _t_translate->get_accumulated_time() / 1000. << " sec" << std::endl;
@@ -412,8 +414,31 @@ genfit::Track* PHRaveVertexing::TranslateSvtxToGenFitTrack(SvtxTrack* svtx_track
   try
   {
     // The first state is extracted to PCA, second one is the one with measurement
-    SvtxTrackState* svtx_state = (++(svtx_track->begin_states()))->second;
+    SvtxTrackState* svtx_state(nullptr);
     //SvtxTrackState* svtx_state = (svtx_track->begin_states())->second;
+
+    if (svtx_track->begin_states() == svtx_track->end_states())
+    {
+      LogDebug("TranslateSvtxToGenFitTrack no state in track!");
+      return nullptr;
+    }
+    else if (++(svtx_track->begin_states()) == svtx_track->end_states())
+    {
+      // only one state in track
+      svtx_state = (svtx_track->begin_states())->second;
+    }
+    else
+    {
+      // multiple state in track
+      // The first state is extracted to PCA, second one is the one with measurement
+      svtx_state = (++(svtx_track->begin_states()))->second;
+    }
+
+    if (!svtx_state)
+    {
+      LogDebug("TranslateSvtxToGenFitTrack invalid state found on track!");
+      return nullptr;
+    }
 
     TVector3 pos(svtx_state->get_x(), svtx_state->get_y(), svtx_state->get_z());
     TVector3 mom(svtx_state->get_px(), svtx_state->get_py(), svtx_state->get_pz());

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -383,7 +383,8 @@ int PHG4TrackFastSim::process_event(PHCompositeNode* topNode)
     SvtxTrack* svtx_track_out = MakeSvtxTrack(track,
                                               particle->get_track_id(),
                                               measurements.size(), vtx);
-    svtx_track_out->identify();
+    if (Verbosity() > 1)
+      svtx_track_out->identify();
 
     if (svtx_track_out)
     {
@@ -823,7 +824,8 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
   double pathlenth_orig_from_first_meas = phgf_track->extrapolateToLine(*gf_state, vtx,
                                                                         TVector3(0., 0., 1.));
 
-  cout << __PRETTY_FUNCTION__ << __LINE__ << " pathlenth_orig_from_first_meas = " << pathlenth_orig_from_first_meas << endl;
+  if (Verbosity() > 1)
+    cout << __PRETTY_FUNCTION__ << __LINE__ << " pathlenth_orig_from_first_meas = " << pathlenth_orig_from_first_meas << endl;
   if (pathlenth_orig_from_first_meas < -999990)
   {
     LogError("Extraction faild!");

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -8,7 +8,7 @@
 #include "PHG4TrackFastSim.h"
 
 #include <phgenfit/Fitter.h>
-#include <phgenfit/Measurement.h>                  // for Measurement
+#include <phgenfit/Measurement.h>  // for Measurement
 #include <phgenfit/PlanarMeasurement.h>
 #include <phgenfit/SpacepointMeasurement.h>
 #include <phgenfit/Track.h>
@@ -20,6 +20,10 @@
 #include <trackbase_historic/SvtxTrackState.h>
 #include <trackbase_historic/SvtxTrackState_v1.h>
 #include <trackbase_historic/SvtxTrack_FastSim.h>
+#include <trackbase_historic/SvtxVertex.h>     // for SvtxVertex
+#include <trackbase_historic/SvtxVertexMap.h>  // for SvtxVertexMap
+#include <trackbase_historic/SvtxVertexMap_v1.h>
+#include <trackbase_historic/SvtxVertex_v1.h>
 
 #include <calobase/RawTowerGeom.h>
 #include <calobase/RawTowerGeomContainer.h>
@@ -27,19 +31,19 @@
 #include <phfield/PHFieldUtility.h>
 
 #include <g4main/PHG4Hit.h>
-#include <g4main/PHG4HitContainer.h>               // for PHG4HitContainer
+#include <g4main/PHG4HitContainer.h>  // for PHG4HitContainer
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <g4main/PHG4VtxPoint.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                    // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                          // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>                        // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
@@ -49,30 +53,41 @@
 #include <GenFit/MeasuredStateOnPlane.h>
 #include <GenFit/RKTrackRep.h>
 
+#include <GenFit/FitStatus.h>              // for FitStatus
+#include <GenFit/GFRaveTrackParameters.h>  // for GFRaveTrackParameters
+#include <GenFit/GFRaveVertex.h>
+#include <GenFit/GFRaveVertexFactory.h>
+#include <GenFit/KalmanFittedStateOnPlane.h>  // for KalmanFittedStateOn...
+#include <GenFit/KalmanFitterInfo.h>
+#include <GenFit/MeasuredStateOnPlane.h>
+#include <GenFit/RKTrackRep.h>
+#include <GenFit/Track.h>
+#include <GenFit/TrackPoint.h>
+
 #include <TMath.h>
-#include <TMatrixTSym.h>                           // for TMatrixTSym
-#include <TMatrixTUtils.h>                         // for TMatrixTRow
-#include <TVector3.h>                              // for TVector3, operator*
-#include <TVectorDfwd.h>                           // for TVectorD
-#include <TVectorT.h>                              // for TVectorT
+#include <TMatrixTSym.h>    // for TMatrixTSym
+#include <TMatrixTUtils.h>  // for TMatrixTRow
+#include <TVector3.h>       // for TVector3, operator*
+#include <TVectorDfwd.h>    // for TVectorD
+#include <TVectorT.h>       // for TVectorT
 
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>
 
-#include <cassert>                                // for assert
+#include <cassert>  // for assert
 #include <cmath>
-#include <iostream>                                // for operator<<, basic_...
-#include <memory>                                  // for unique_ptr, alloca...
+#include <iostream>  // for operator<<, basic_...
 #include <map>
+#include <memory>  // for unique_ptr, alloca...
 #include <utility>
 
 class PHField;
 class TGeoManager;
-namespace genfit 
+namespace genfit
 {
 class AbsTrackRep;
 class Track;
-}
+}  // namespace genfit
 
 #define LogDebug(exp) \
   if (Verbosity()) std::cout << "PHG4TrackFastSim (DEBUG): " << __FILE__ << ": " << __LINE__ << ": " << exp << "\n"
@@ -90,7 +105,12 @@ PHG4TrackFastSim::PHG4TrackFastSim(const std::string& name)
   , _sub_top_node_name("SVTX")
   , /*_clustermap_out_name("SvtxClusterMap"),*/ _trackmap_out_name("SvtxTrackMap")
   , /*_clustermap_out(nullptr),*/ _trackmap_out(nullptr)
+  , _vertexmap(nullptr)
   , _fitter(nullptr)
+  , _vertex_finder(nullptr)
+  , _vertexing_method("kalman-smoothing:1")
+  , _vertex_min_ndf(10)
+  , _do_vertexing(false)
   , _fit_alg_name("DafRef")  // was ("KalmanFitterRefTrack")
   , _primary_assumption_pid(211)
   , _do_evt_display(false)
@@ -109,7 +129,10 @@ PHG4TrackFastSim::PHG4TrackFastSim(const std::string& name)
 
 PHG4TrackFastSim::~PHG4TrackFastSim()
 {
-  delete _fitter;
+  if (_fitter)
+    delete _fitter;
+  if (_vertex_finder)
+    delete _vertex_finder;
   gsl_rng_free(m_RandomGenerator);
 }
 
@@ -194,6 +217,22 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode* topNode)
     }
   }
 
+  if (_do_vertexing)
+  {
+    _vertex_finder = new genfit::GFRaveVertexFactory(Verbosity(), true);
+    //_vertex_finder->setMethod("kalman-smoothing:1"); //! kalman-smoothing:1 is the defaul method
+    _vertex_finder->setMethod(_vertexing_method.data());
+    //_vertex_finder->setBeamspot();
+
+    //_vertex_finder = new PHRaveVertexFactory(Verbosity());
+
+    if (!_vertex_finder)
+    {
+      cerr << PHWHERE << endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -249,6 +288,7 @@ int PHG4TrackFastSim::process_event(PHCompositeNode* topNode)
     itr_range = _truth_container->GetParticleRange();
   }
 
+  GenFitTrackMap gf_track_map;
   // Now we can loop over the particles
 
   for (PHG4TruthInfoContainer::ConstIterator itr = itr_range.first;
@@ -343,14 +383,76 @@ int PHG4TrackFastSim::process_event(PHCompositeNode* topNode)
     SvtxTrack* svtx_track_out = MakeSvtxTrack(track,
                                               particle->get_track_id(),
                                               measurements.size(), vtx);
+    svtx_track_out->identify();
 
     if (svtx_track_out)
     {
-      _trackmap_out->insert(svtx_track_out);
+      //      track -> output container
+
+      const unsigned int track_id = _trackmap_out->insert(svtx_track_out)->get_id();
+      gf_track_map.insert({track->getGenFitTrack(), track_id});
+
       delete svtx_track_out;  // insert makes a clone
     }
 
   }  // Loop all primary particles
+
+  //vertex finding
+  if (_do_vertexing)
+  {
+    if (!_vertex_finder)
+    {
+      cout << __PRETTY_FUNCTION__ << "Failed to init vertex finder" << endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+    if (!_vertexmap)
+    {
+      cout << __PRETTY_FUNCTION__ << "Failed to init vertex map" << endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+
+    //    genfit::GFRaveVertexFactory* _vertex_finder = new genfit::GFRaveVertexFactory(10, true);
+    //    _vertex_finder->setMethod("kalman-smoothing:1");
+    //    _vertex_finder->setBeamspot();
+
+    vector<genfit::GFRaveVertex*> rave_vertices;
+    if (rf_tracks.size() >= 2)
+    {
+      try
+      {
+        vector<genfit::Track*> rf_gf_tracks;
+        for (std::vector<PHGenFit::Track*>::iterator it = rf_tracks.begin(); it != rf_tracks.end(); ++it)
+        {
+          genfit::Track* track = (*it)->getGenFitTrack();
+
+          if (Verbosity())
+          {
+            TVector3 pos, mom;
+            TMatrixDSym cov;
+
+            track->getFittedState().getPosMomCov(pos, mom, cov);
+
+            cout << "Track getCharge = " << track->getFitStatus()->getCharge() << " getChi2 = " << track->getFitStatus()->getChi2() << " getNdf = " << track->getFitStatus()->getNdf() << endl;
+            pos.Print();
+            mom.Print();
+            cov.Print();
+          }
+          if (track->getFitStatus()->getNdf() > _vertex_min_ndf)
+            rf_gf_tracks.push_back(track);
+        }
+        _vertex_finder->findVertices(&rave_vertices, rf_gf_tracks);
+      }
+      catch (...)
+      {
+        if (Verbosity() > 1)
+          std::cout << PHWHERE << "GFRaveVertexFactory::findVertices failed!";
+      }
+    }
+
+    if (Verbosity())
+      cout << __PRETTY_FUNCTION__ << __LINE__ << " rf_tracks = " << rf_tracks.size() << " rave_vertices = " << rave_vertices.size() << endl;
+    FillSvtxVertexMap(rave_vertices, gf_track_map);
+  }
 
   //! add tracks to event display
   if (_do_evt_display)
@@ -374,6 +476,61 @@ int PHG4TrackFastSim::process_event(PHCompositeNode* topNode)
   //	}
 
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+/*
+ * Fill SvtxVertexMap from GFRaveVertexes and Tracks
+ */
+bool PHG4TrackFastSim::FillSvtxVertexMap(
+    const std::vector<genfit::GFRaveVertex*>& rave_vertices,
+    const GenFitTrackMap& gf_track_map)
+{
+  for (genfit::GFRaveVertex* rave_vtx : rave_vertices)
+  {
+    if (!rave_vtx)
+    {
+      cerr << PHWHERE << endl;
+      return false;
+    }
+
+    std::shared_ptr<SvtxVertex> svtx_vtx(new SvtxVertex_v1());
+
+    svtx_vtx->set_chisq(rave_vtx->getChi2());
+    svtx_vtx->set_ndof(rave_vtx->getNdf());
+    svtx_vtx->set_position(0, rave_vtx->getPos().X());
+    svtx_vtx->set_position(1, rave_vtx->getPos().Y());
+    svtx_vtx->set_position(2, rave_vtx->getPos().Z());
+
+    for (int i = 0; i < 3; i++)
+      for (int j = 0; j < 3; j++)
+        svtx_vtx->set_error(i, j, rave_vtx->getCov()[i][j]);
+
+    for (unsigned int i = 0; i < rave_vtx->getNTracks(); i++)
+    {
+      //TODO improve speed
+      const genfit::Track* rave_track =
+          rave_vtx->getParameters(i)->getTrack();
+      //      for(auto iter : gf_track_map) {
+      //        if (iter.second == rave_track)
+      //          svtx_vtx->insert_track(iter.first);
+      //      }
+      auto iter = gf_track_map.find(rave_track);
+      if (iter != gf_track_map.end())
+        svtx_vtx->insert_track(iter->second);
+    }
+
+    if (_vertexmap)
+    {
+      _vertexmap->insert_clone(svtx_vtx.get());
+    }
+    else
+    {
+      LogError("!_vertexmap");
+    }
+
+  }  //loop over RAVE vertices
+
+  return true;
 }
 
 int PHG4TrackFastSim::CreateNodes(PHCompositeNode* topNode)
@@ -416,6 +573,16 @@ int PHG4TrackFastSim::CreateNodes(PHCompositeNode* topNode)
   tb_node->addNode(tracks_node);
   if (Verbosity() > 0)
     cout << _trackmap_out_name.c_str() << " node added" << endl;
+
+  if (_do_vertexing)
+  {
+    _vertexmap = new SvtxVertexMap_v1;
+    PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(
+        _vertexmap, "SvtxVertexMap", "PHObject");
+    tb_node->addNode(vertexes_node);
+    if (Verbosity() > 0)
+      cout << "Svtx/SvtxVertexMap node added" << endl;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -656,6 +823,7 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
   double pathlenth_orig_from_first_meas = phgf_track->extrapolateToLine(*gf_state, vtx,
                                                                         TVector3(0., 0., 1.));
 
+  cout << __PRETTY_FUNCTION__ << __LINE__ << " pathlenth_orig_from_first_meas = " << pathlenth_orig_from_first_meas << endl;
   if (pathlenth_orig_from_first_meas < -999990)
   {
     LogError("Extraction faild!");
@@ -748,6 +916,42 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
     // the state is cloned on insert_state, so delete this copy here!
     delete state;
   }
+
+  //  // State Projections
+  //  {
+  //    // Project to a cylinder at fixed r
+  //    pathlenth_from_first_meas = phgf_track->extrapolateToCylinder(*gf_state, 2., TVector3(0., 0., 0.),
+  //                                                                  TVector3(0., 0., 1.), 0, -1);
+  //
+  //    SvtxTrackState* state = new SvtxTrackState_v1(pathlenth_from_first_meas - pathlenth_orig_from_first_meas);
+  //    state->set_x(gf_state->getPos().x());
+  //    state->set_y(gf_state->getPos().y());
+  //    state->set_z(gf_state->getPos().z());
+  //
+  //    state->set_px(gf_state->getMom().x());
+  //    state->set_py(gf_state->getMom().y());
+  //    state->set_pz(gf_state->getMom().z());
+  //
+  //    //    state->set_name(string("BeamPipe"));
+  //
+  //    for (int i = 0; i < 6; i++)
+  //    {
+  //      for (int j = i; j < 6; j++)
+  //      {
+  //        state->set_error(i, j, gf_state->get6DCov()[i][j]);
+  //      }
+  //    }
+  //    out_track->insert_state(state);
+  //
+  //    cout << __PRETTY_FUNCTION__ << __LINE__;
+  //    state->identify();
+  //
+  //    // the state is cloned on insert_state, so delete this copy here!
+  //    delete state;
+  //  }
+  //
+  //  cout << __PRETTY_FUNCTION__ << __LINE__;
+  //  out_track->identify();
 
   return static_cast<SvtxTrack*>(out_track);
 }

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -270,11 +270,12 @@ int PHG4TrackFastSim::process_event(PHCompositeNode* topNode)
 
   vector<PHGenFit::Track*> rf_tracks;
 
-  PHG4VtxPoint* vtxPoint = _truth_container->GetPrimaryVtx(_truth_container->GetPrimaryVertexIndex());
+  PHG4VtxPoint * truthVtx = _truth_container->GetPrimaryVtx(_truth_container->GetPrimaryVertexIndex());
+  TVector3 vtxPoint (truthVtx->get_x(), truthVtx->get_y(), truthVtx->get_z());
   // Smear the vertex ONCE for all particles in the event
-  vtxPoint->set_x(vtxPoint->get_x() + gsl_ran_gaussian(m_RandomGenerator, _vertex_xy_resolution));
-  vtxPoint->set_y(vtxPoint->get_y() + gsl_ran_gaussian(m_RandomGenerator, _vertex_xy_resolution));
-  vtxPoint->set_z(vtxPoint->get_z() + gsl_ran_gaussian(m_RandomGenerator, _vertex_z_resolution));
+  vtxPoint.SetX(vtxPoint.x() + gsl_ran_gaussian(m_RandomGenerator, _vertex_xy_resolution));
+  vtxPoint.SetY(vtxPoint.y() + gsl_ran_gaussian(m_RandomGenerator, _vertex_xy_resolution));
+  vtxPoint.SetZ(vtxPoint.z() + gsl_ran_gaussian(m_RandomGenerator, _vertex_z_resolution));
 
   PHG4TruthInfoContainer::ConstRange itr_range;
   if (_primary_tracking)
@@ -296,7 +297,7 @@ int PHG4TrackFastSim::process_event(PHCompositeNode* topNode)
   {
     PHG4Particle* particle = itr->second;
 
-    TVector3 seed_pos(vtxPoint->get_x(), vtxPoint->get_y(), vtxPoint->get_z());
+    TVector3 seed_pos(vtxPoint.x(), vtxPoint.y(), vtxPoint.z());
     TVector3 seed_mom(0, 0, 0);
     TMatrixDSym seed_cov(6);
 
@@ -307,9 +308,9 @@ int PHG4TrackFastSim::process_event(PHCompositeNode* topNode)
 
     if (_use_vertex_in_fitting)
     {
-      vtx_meas = VertexMeasurement(TVector3(vtxPoint->get_x(),
-                                            vtxPoint->get_y(),
-                                            vtxPoint->get_z()),
+      vtx_meas = VertexMeasurement(TVector3(vtxPoint.x(),
+                                            vtxPoint.y(),
+                                            vtxPoint.z()),
                                    _vertex_xy_resolution,
                                    _vertex_z_resolution);
       measurements.push_back(vtx_meas);
@@ -379,7 +380,7 @@ int PHG4TrackFastSim::process_event(PHCompositeNode* topNode)
       continue;
     }
 
-    TVector3 vtx(vtxPoint->get_x(), vtxPoint->get_y(), vtxPoint->get_z());
+    TVector3 vtx(vtxPoint.x(), vtxPoint.y(), vtxPoint.z());
     SvtxTrack* svtx_track_out = MakeSvtxTrack(track,
                                               particle->get_track_id(),
                                               measurements.size(), vtx);

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -12,7 +12,7 @@
 
 #include <fun4all/SubsysReco.h>
 
-#include <TMatrixDSymfwd.h>      // for TMatrixDSym
+#include <TMatrixDSymfwd.h>  // for TMatrixDSym
 #include <TVector3.h>
 
 // rootcint barfs with this header so we need to hide it
@@ -20,16 +20,18 @@
 #include <gsl/gsl_rng.h>
 #endif
 
+#include <climits>  // for UINT_MAX
 #include <iostream>
+#include <map>
 #include <string>
 #include <vector>
-#include <climits>              // for UINT_MAX
 
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Particle;
 class SvtxTrack;
 class SvtxTrackMap;
+class SvtxVertexMap;
 class PHCompositeNode;
 class PHG4TruthInfoContainer;
 
@@ -40,6 +42,12 @@ class Measurement;
 class PlanarMeasurement;
 class Track;
 } /* namespace PHGenFit */
+namespace genfit
+{
+class GFRaveVertex;
+class GFRaveVertexFactory;
+class Track;
+} /* namespace genfit */
 
 class PHG4TrackFastSim : public SubsysReco
 {
@@ -181,6 +189,31 @@ class PHG4TrackFastSim : public SubsysReco
     _primary_tracking = pTrk;
   }
 
+  //! https://rave.hepforge.org/trac/wiki/RaveMethods
+  const std::string& get_vertexing_method() const
+  {
+    return _vertexing_method;
+  }
+
+  //! https://rave.hepforge.org/trac/wiki/RaveMethods
+  void set_vertexing_method(const std::string& vertexingMethod)
+  {
+    _vertexing_method = vertexingMethod;
+  }
+
+  double get_vertex_min_ndf() const {
+    return _vertex_min_ndf;
+  }
+
+  void set_vertex_min_ndf(double vertexMinPT) {
+    _vertex_min_ndf = vertexMinPT;
+  }
+
+  void enable_vertexing(const bool& b = true)
+  {
+    _do_vertexing = b;
+  }
+
  private:
   /*!
 	 * Create needed nodes.
@@ -212,6 +245,15 @@ class PHG4TrackFastSim : public SubsysReco
                            const unsigned int truth_track_id = UINT_MAX,
                            const unsigned int nmeas = 0, const TVector3& vtx = TVector3(0.0, 0.0, 0.0));
 
+  typedef std::map<const genfit::Track*, unsigned int> GenFitTrackMap;
+
+  /*
+  * Fill SvtxVertexMap from GFRaveVertexes and Tracks
+  */
+  bool FillSvtxVertexMap(
+      const std::vector<genfit::GFRaveVertex*>& rave_vertices,
+      const GenFitTrackMap& gf_tracks);
+
   //! Event counter
   int _event;
 
@@ -238,11 +280,17 @@ class PHG4TrackFastSim : public SubsysReco
   //	SvtxClusterMap* _clustermap_out;
 
   SvtxTrackMap* _trackmap_out;
+  SvtxVertexMap* _vertexmap;
 
   /*!
 	 *	GenFit fitter interface
 	 */
   PHGenFit::Fitter* _fitter;
+  genfit::GFRaveVertexFactory* _vertex_finder;
+  //! https://rave.hepforge.org/trac/wiki/RaveMethods
+  std::string _vertexing_method;
+  double _vertex_min_ndf;
+  bool _do_vertexing;
 
   /*!
 	 * Available choices:
@@ -267,22 +315,6 @@ class PHG4TrackFastSim : public SubsysReco
 
   double _vertex_xy_resolution;
   double _vertex_z_resolution;
-
-  //  double _phi_resolution;  //deprecated
-  //
-  //  double _r_resolution;  //deprecated
-  //
-  //  double _z_resolution;  //deprecated
-  //
-  //  //!
-  //  double _pat_rec_hit_finding_eff;  //deprecated
-  //
-  //  //!
-  //  double _pat_rec_noise_prob;  //deprecated
-
-  //!
-//  int _N_DETECTOR_LAYER; //deprecated
-
   //!
   int _primary_tracking;
 
@@ -290,10 +322,9 @@ class PHG4TrackFastSim : public SubsysReco
   std::vector<std::string> _state_names;
   std::vector<double> _state_location;
 
-
 #ifndef __CINT__
   //! random generator that conform with sPHENIX standard
-  gsl_rng *m_RandomGenerator;
+  gsl_rng* m_RandomGenerator;
 #endif
 };
 

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -443,7 +443,7 @@ int PHG4TrackFastSimEval::GetNodes(PHCompositeNode *topNode)
   }
 
   _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
-  if (!_vertexmap && _event < 2)
+  if (!_vertexmap && Verbosity())
   {
     cout << PHWHERE << "SvtxTrackMap node with name SvtxVertexMap not found on node tree. Will not build the vertex eval tree"
          << endl;

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -362,10 +362,10 @@ void PHG4TrackFastSimEval::fill_vertex_tree(PHCompositeNode *topNode)
       n_from_truth = best_n_match;
       gtrackID = best_vtx->get_id();
     }
+    _eval_tree_vertex->Fill();
   }
   //std::cout << "B3" << std::endl;
 
-  _eval_tree_vertex->Fill();
   return;
 }
 
@@ -408,8 +408,8 @@ void PHG4TrackFastSimEval::reset_variables()
   deltavx = NAN;
   deltavy = NAN;
   deltavz = NAN;
-  ntracks = 0;
-  n_from_truth = 0;
+  ntracks = -9999;
+  n_from_truth = -9999;
 }
 
 //----------------------------------------------------------------------------//

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -102,6 +102,7 @@ int PHG4TrackFastSimEval::Init(PHCompositeNode *topNode)
 
   // create TTree - vertex
   _eval_tree_vertex = new TTree("vertex", "FastSim Eval => vertces");
+  _eval_tree_vertex->Branch("event", &event, "event/I");
   _eval_tree_vertex->Branch("gvx", &gvx, "gvx/F");
   _eval_tree_vertex->Branch("gvy", &gvy, "gvy/F");
   _eval_tree_vertex->Branch("gvz", &gvz, "gvz/F");

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -12,11 +12,12 @@
 #include <trackbase_historic/SvtxTrack_FastSim.h>
 
 #include <g4main/PHG4Particle.h>
+#include <g4main/PHG4VtxPoint.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/PHTFileServer.h>
-#include <fun4all/SubsysReco.h>                    // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/getClass.h>
 #include <phool/phool.h>
@@ -26,9 +27,9 @@
 #include <TVector3.h>
 
 #include <cmath>
-#include <map>                                     // for _Rb_tree_const_ite...
 #include <iostream>
-#include <utility>                                 // for pair
+#include <map>      // for _Rb_tree_const_ite...
+#include <utility>  // for pair
 
 #define LogDebug(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << exp << "\n"
 #define LogError(exp) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << exp << "\n"
@@ -56,12 +57,16 @@ PHG4TrackFastSimEval::PHG4TrackFastSimEval(const string &name, const string &fil
   , gvx(NAN)
   , gvy(NAN)
   , gvz(NAN)
+  , gvt(NAN)
   , trackID(-1)
   , charge(0)
   , nhits(-1)
   , px(NAN)
   , py(NAN)
   , pz(NAN)
+  , pcax(NAN)
+  , pcay(NAN)
+  , pcaz(NAN)
   , dca2d(NAN)
   , _h2d_Delta_mom_vs_truth_mom(nullptr)
   , _h2d_Delta_mom_vs_truth_eta(nullptr)
@@ -90,12 +95,16 @@ int PHG4TrackFastSimEval::Init(PHCompositeNode *topNode)
   _eval_tree_tracks->Branch("gvx", &gvx, "gvx/F");
   _eval_tree_tracks->Branch("gvy", &gvy, "gvy/F");
   _eval_tree_tracks->Branch("gvz", &gvz, "gvz/F");
+  _eval_tree_tracks->Branch("gvt", &gvt, "gvt/F");
   _eval_tree_tracks->Branch("trackID", &trackID, "trackID/I");
   _eval_tree_tracks->Branch("charge", &charge, "charge/I");
   _eval_tree_tracks->Branch("nhits", &nhits, "nhits/I");
   _eval_tree_tracks->Branch("px", &px, "px/F");
   _eval_tree_tracks->Branch("py", &py, "py/F");
   _eval_tree_tracks->Branch("pz", &pz, "pz/F");
+  _eval_tree_tracks->Branch("pcax", &pcax, "pcax/F");
+  _eval_tree_tracks->Branch("pcay", &pcay, "pcay/F");
+  _eval_tree_tracks->Branch("pcaz", &pcaz, "pcaz/F");
   _eval_tree_tracks->Branch("dca2d", &dca2d, "dca2d/F");
 
   _h2d_Delta_mom_vs_truth_eta = new TH2D("_h2d_Delta_mom_vs_truth_eta",
@@ -215,6 +224,15 @@ void PHG4TrackFastSimEval::fill_tree(PHCompositeNode *topNode)
     gpy = g4particle->get_py();
     gpz = g4particle->get_pz();
 
+    PHG4VtxPoint *vtx = _truth_container->GetVtx(g4particle->get_vtx_id());
+    if (vtx)
+    {
+      gvx = vtx->get_x();
+      gvy = vtx->get_y();
+      gvz = vtx->get_z();
+      gvt = vtx->get_t();
+    }
+
     if (track)
     {
       //std::cout << "C1" << std::endl;
@@ -225,6 +243,9 @@ void PHG4TrackFastSimEval::fill_tree(PHCompositeNode *topNode)
       px = track->get_px();
       py = track->get_py();
       pz = track->get_pz();
+      pcax = track->get_x();
+      pcay = track->get_y();
+      pcaz = track->get_z();
       dca2d = track->get_dca2d();
 
       TVector3 truth_mom(gpx, gpy, gpz);

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
@@ -93,6 +93,7 @@ class PHG4TrackFastSimEval : public SubsysReco
   float gvx;
   float gvy;
   float gvz;
+  float gvt;
 
   //-- reco
   int trackID;
@@ -101,6 +102,9 @@ class PHG4TrackFastSimEval : public SubsysReco
   float px;
   float py;
   float pz;
+  float pcax;
+  float pcay;
+  float pcaz;
   float dca2d;
 
   //Histos

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
@@ -17,6 +17,7 @@
 class PHCompositeNode;
 class PHG4TruthInfoContainer;
 class SvtxTrackMap;
+class SvtxVertexMap;
 class TTree;
 class TH2D;
 
@@ -62,10 +63,12 @@ class PHG4TrackFastSimEval : public SubsysReco
   }
 
   //User modules
-  void fill_tree(PHCompositeNode*);
   void reset_variables();
 
  private:
+  void fill_track_tree(PHCompositeNode*);
+  void fill_vertex_tree(PHCompositeNode*);
+
   //output filename
   std::string _outfile_name;
 
@@ -83,6 +86,7 @@ class PHG4TrackFastSimEval : public SubsysReco
 
   //TTrees
   TTree* _eval_tree_tracks;
+  TTree* _eval_tree_vertex;
   int event;
   //-- truth
   int gtrackID;
@@ -107,6 +111,16 @@ class PHG4TrackFastSimEval : public SubsysReco
   float pcaz;
   float dca2d;
 
+  //vertex
+  float vx;
+  float vy;
+  float vz;
+  float deltavx;
+  float deltavy;
+  float deltavz;
+  int ntracks;
+  int n_from_truth;
+
   //Histos
   TH2D* _h2d_Delta_mom_vs_truth_mom;
   TH2D* _h2d_Delta_mom_vs_truth_eta;
@@ -114,6 +128,7 @@ class PHG4TrackFastSimEval : public SubsysReco
   //Node pointers
   PHG4TruthInfoContainer* _truth_container;
   SvtxTrackMap* _trackmap;
+  SvtxVertexMap* _vertexmap;
 };
 
 #endif  //* __PHG4TrackFastSimEval_H__ *//


### PR DESCRIPTION
EIC detector use fast pattern recognition + Kalman filter fit. With recent need in secondary vertex studies (https://indico.in2p3.fr/event/18281/contributions/71617/), this pull request add option to reconstruct vertexes with RAVE using the tracks after the fitting stage. Evaluation module are also modified to support the reconstructed vertexes too.  