### PR TITLE
Fix phpythia8

### DIFF
--- a/generators/PHPythia8/Makefile.am
+++ b/generators/PHPythia8/Makefile.am
@@ -16,15 +16,14 @@ pkginclude_HEADERS = \
 libPHPythia8_la_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  `root-config --libs`
+  `root-config --libs` \
+  `fastjet-config --libs`
 
 libPHPythia8_la_LIBADD = \
   -lSubsysReco \
   -lpythia8 \
   -lphhepmc \
-  -lHepMC \
-  -lfastjet \
-  -lCGAL
+  -lHepMC
 
 if ! MAKEROOT6
 ROOT5_DICTS = \

--- a/generators/PHPythia8/PHPythia8.cc
+++ b/generators/PHPythia8/PHPythia8.cc
@@ -70,6 +70,7 @@ PHPythia8::PHPythia8(const std::string &name)
 PHPythia8::~PHPythia8()
 {
   delete _pythia;
+  delete _pythiaToHepMC;
 }
 
 int PHPythia8::Init(PHCompositeNode *topNode)


### PR DESCRIPTION
This PR fixes a small memory leak. Use fastjet-config --libs to link against fastjet. This will pull in the libraries fastjet needs (boost and CGAL) so we do not need to add them explicitely