### PR TITLE
make colors for block and cylinder detectors adjustable in macro

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.cc
@@ -15,12 +15,14 @@ PHG4BlockDisplayAction::PHG4BlockDisplayAction(const std::string &name, PHParame
   , m_Params(pars)
   , m_MyVolume(nullptr)
   , m_VisAtt(nullptr)
+  , m_Colour(nullptr)
 {
 }
 
 PHG4BlockDisplayAction::~PHG4BlockDisplayAction()
 {
   delete m_VisAtt;
+  delete m_Colour;
 }
 
 void PHG4BlockDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
@@ -43,6 +45,24 @@ void PHG4BlockDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     m_VisAtt->SetVisibility(true);
     m_VisAtt->SetForceSolid(true);
   }
+  if (m_Colour)
+  {
+    m_VisAtt->SetColour(m_Colour->GetRed(),
+                        m_Colour->GetGreen(),
+                        m_Colour->GetBlue(), 
+                        m_Colour->GetAlpha());
+    m_VisAtt->SetVisibility(true);
+    m_VisAtt->SetForceSolid(true);
+  }
   m_MyVolume->SetVisAttributes(m_VisAtt);
+  return;
+}
+
+void  PHG4BlockDisplayAction::SetColor(const double red, const double green, const double blue, const double alpha)
+{
+  if (isfinite(red) && isfinite(green) && isfinite(blue) && isfinite(alpha))
+  {
+    m_Colour = new G4Colour(red,green,blue,alpha);
+  }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.h
@@ -7,6 +7,7 @@
 
 #include <string>                      // for string
 
+class G4Colour;
 class G4VisAttributes;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
@@ -21,11 +22,13 @@ class PHG4BlockDisplayAction : public PHG4DisplayAction
 
   void ApplyDisplayAction(G4VPhysicalVolume *physvol);
   void SetMyVolume(G4LogicalVolume *vol) { m_MyVolume = vol; }
+  void SetColor(const double red, const double green, const double blue, const double alpha=1.);
 
  private:
   PHParameters *m_Params;
   G4LogicalVolume *m_MyVolume;
   G4VisAttributes *m_VisAtt;
+  G4Colour *m_Colour;
 };
 
 #endif  // G4DETECTORS_PHG4BLOCKDISPLAYACTION_H

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
@@ -50,7 +50,15 @@ int PHG4BlockSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create display settings before detector (detector adds its volumes to it)
-  m_DisplayAction = new PHG4BlockDisplayAction(Name(), GetParams());
+  PHG4BlockDisplayAction *disp_action = new PHG4BlockDisplayAction(Name(), GetParams());
+   if (isfinite(m_ColorArray[0]) &&
+      isfinite(m_ColorArray[1]) &&
+      isfinite(m_ColorArray[2]) &&
+      isfinite(m_ColorArray[3]))
+  {
+    disp_action->SetColor(m_ColorArray[0], m_ColorArray[1],m_ColorArray[2],m_ColorArray[3]);
+  }
+  m_DisplayAction = disp_action;
   // create detector
   m_Detector = new PHG4BlockDetector(this, topNode, GetParams(), Name(), GetLayer());
   m_Detector->SuperDetector(SuperDetector());

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
@@ -44,6 +44,14 @@ class PHG4BlockSubsystem : public PHG4DetectorSubsystem
 
   PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
 
+  void set_color(const double red, const double green, const double blue, const double alpha=1.)
+  {
+    m_ColorArray[0] = red;
+    m_ColorArray[1] = green;
+    m_ColorArray[2] = blue;
+    m_ColorArray[3] = alpha;
+  }
+
  private:
   void SetDefaultParameters();
 
@@ -58,6 +66,12 @@ class PHG4BlockSubsystem : public PHG4DetectorSubsystem
   //! display attribute setting
   /*! derives from PHG4DisplayAction */
   PHG4DisplayAction* m_DisplayAction;
+  //! Color setting if we want to override the default
+#if !defined(__CINT__) || defined(__CLING__)
+  std::array<double,4> m_ColorArray;
+#else
+  double m_ColorArray[4];
+#endif
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
@@ -5,6 +5,7 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <Geant4/G4Colour.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
@@ -17,12 +18,14 @@ PHG4CylinderDisplayAction::PHG4CylinderDisplayAction(const std::string &name, PH
   , m_Params(pars)
   , m_MyVolume(nullptr)
   , m_VisAtt(nullptr)
+  , m_Colour(nullptr)
 {
 }
 
 PHG4CylinderDisplayAction::~PHG4CylinderDisplayAction()
 {
   delete m_VisAtt;
+  delete m_Colour;
 }
 
 void PHG4CylinderDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
@@ -44,6 +47,26 @@ void PHG4CylinderDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     m_VisAtt->SetVisibility(true);
     m_VisAtt->SetForceSolid(true);
   }
+  if (m_Colour)
+  {
+    m_VisAtt->SetColour(m_Colour->GetRed(),
+                        m_Colour->GetGreen(),
+                        m_Colour->GetBlue(),
+                        m_Colour->GetAlpha());
+    m_VisAtt->SetVisibility(true);
+    m_VisAtt->SetForceSolid(true);
+  }
+// drawing 200 segments per circle makes it look smoother than default
+  m_VisAtt->SetForceLineSegmentsPerCircle(200);
   m_MyVolume->SetVisAttributes(m_VisAtt);
+  return;
+}
+
+void  PHG4CylinderDisplayAction::SetColor(const double red, const double green, const double blue, const double alpha)
+{
+  if (isfinite(red) && isfinite(green) && isfinite(blue) && isfinite(alpha))
+  {
+    m_Colour = new G4Colour(red,green,blue,alpha);
+  }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
@@ -7,6 +7,7 @@
 
 #include <string>                      // for string
 
+class G4Colour;
 class G4LogicalVolume;
 class G4VisAttributes;
 class G4VPhysicalVolume;
@@ -21,12 +22,13 @@ class PHG4CylinderDisplayAction : public PHG4DisplayAction
 
   void ApplyDisplayAction(G4VPhysicalVolume *physvol);
   void SetMyVolume(G4LogicalVolume *vol) { m_MyVolume = vol; }
-
+  void SetColor(const double red, const double green, const double blue, const double alpha=1.);
 
  private:
   PHParameters *m_Params;
   G4LogicalVolume *m_MyVolume;
   G4VisAttributes *m_VisAtt;
+  G4Colour *m_Colour;
 };
 
 #endif  // G4DETECTORS_PHG4CYLINDERDISPLAYACTION_H

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -37,6 +37,7 @@ PHG4CylinderSubsystem::PHG4CylinderSubsystem(const std::string &na, const int ly
   , m_SteppingAction(nullptr)
   , m_DisplayAction(nullptr)
 {
+  m_ColorArray.fill(NAN);
   InitializeParameters();
 }
 
@@ -54,7 +55,16 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     GetParams()->set_double_param("length", PHG4Utils::GetLengthForRapidityCoverage(GetParams()->get_double_param("radius") + GetParams()->get_double_param("thickness")) * 2);
   }
   // create display settings before detector
-  m_DisplayAction = new PHG4CylinderDisplayAction(Name(), GetParams());
+  PHG4CylinderDisplayAction *disp_action = new PHG4CylinderDisplayAction(Name(), GetParams());
+  if (isfinite(m_ColorArray[0]) &&
+      isfinite(m_ColorArray[1]) &&
+      isfinite(m_ColorArray[2]) &&
+      isfinite(m_ColorArray[3]))
+  {
+    disp_action->SetColor(m_ColorArray[0], m_ColorArray[1],m_ColorArray[2],m_ColorArray[3]);
+  }
+  m_DisplayAction = disp_action;
+
   // create detector
   m_Detector = new PHG4CylinderDetector(this, topNode, GetParams(), Name(), GetLayer());
   G4double detlength = GetParams()->get_double_param("length");

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -45,6 +45,13 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
   PHG4SteppingAction* GetSteppingAction(void) const { return m_SteppingAction; }
 
   PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+  void set_color(const double red, const double green, const double blue, const double alpha=1.)
+  {
+    m_ColorArray[0] = red;
+    m_ColorArray[1] = green;
+    m_ColorArray[2] = blue;
+    m_ColorArray[3] = alpha;
+  }
 
  private:
   void SetDefaultParameters();
@@ -60,6 +67,14 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
   //! display attribute setting
   /*! derives from PHG4DisplayAction */
   PHG4DisplayAction* m_DisplayAction;
+
+  //! Color setting if we want to override the default
+#if !defined(__CINT__) || defined(__CLING__)
+  std::array<double,4> m_ColorArray;
+#else
+  double m_ColorArray[4];
+#endif
+
 };
 
 #endif  // G4DETECTORS_PHG4CYLINDERSUBSYSTEM_H


### PR DESCRIPTION
This PR makes it possible to set the color of generic blocks and cylinders in the macro. Up to now it was based on the material which is not really what we want