### PR TITLE
Move geometry methods to PHG4Utils

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
@@ -41,10 +41,6 @@ class PHG4BlockCellReco : public SubsysReco, public PHParameterContainerInterfac
  protected:
   void set_size(const int i, const double sizeA, const double sizeB, const int what);
   int CheckEnergy(PHCompositeNode *topNode);
-  static std::pair<double, double> get_etaphi(const double x, const double y, const double z);
-  static double get_eta(const double radius, const double z);
-  bool lines_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy, double* rx, double* ry);
-  bool line_and_rectangle_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy, double* rr);
 
   double sum_energy_g4hit;
   std::map<int, int>  binning;

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
@@ -10,45 +10,44 @@
 #include <map>
 #include <set>
 #include <string>
-#include <utility>                                      // for pair
+#include <utility>  // for pair
 
 class PHCompositeNode;
 
 class PHG4BlockCellReco : public SubsysReco, public PHParameterContainerInterface
 {
  public:
-
   PHG4BlockCellReco(const std::string &name = "BLOCKRECO");
 
-  virtual ~PHG4BlockCellReco(){}
-  
+  virtual ~PHG4BlockCellReco() {}
+
   //! module initialization
   int InitRun(PHCompositeNode *topNode);
-  
-    //! event processing
+
+  //! event processing
   int process_event(PHCompositeNode *topNode);
-  
+
   int ResetEvent(PHCompositeNode *topNode);
 
   void SetDefaultParameters();
 
-  void Detector(const std::string &d) {detector = d;}
+  void Detector(const std::string &d) { detector = d; }
   void etaxsize(const int i, const double deltaeta, const double deltax);
-  void checkenergy(const int i=1) {chkenergyconservation = i;}
-  
-  void   set_timing_window(const int detid, const double tmin, const double tmax);
-  
+  void checkenergy(const int i = 1) { chkenergyconservation = i; }
+
+  void set_timing_window(const int detid, const double tmin, const double tmax);
+
  protected:
   void set_size(const int i, const double sizeA, const double sizeB, const int what);
   int CheckEnergy(PHCompositeNode *topNode);
 
   double sum_energy_g4hit;
-  std::map<int, int>  binning;
-  std::map<int, std::pair <double,double> > cell_size; // cell size in x/z
-  std::map<int, std::pair <double,double> > zmin_max; // zmin/zmax for each layer for faster lookup
+  std::map<int, int> binning;
+  std::map<int, std::pair<double, double> > cell_size;  // cell size in x/z
+  std::map<int, std::pair<double, double> > zmin_max;   // zmin/zmax for each layer for faster lookup
   std::map<int, double> xstep;
   std::map<int, double> etastep;
-  std::map<int, std::pair<double,double> > tmin_max;
+  std::map<int, std::pair<double, double> > tmin_max;
   std::set<int> implemented_detid;
   std::string detector;
   std::string hitnodename;
@@ -57,7 +56,6 @@ class PHG4BlockCellReco : public SubsysReco, public PHParameterContainerInterfac
   std::string seggeonodename;
   std::map<int, std::pair<int, int> > n_x_z_bins;
   int chkenergyconservation;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -14,6 +14,7 @@
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4Utils.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>                         // for SubsysReco
@@ -167,8 +168,8 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
 	{
 	  // calculate eta at radius+ thickness (outer radius)
 	  // length via eta coverage is calculated using the outer radius
-	  double etamin = get_eta(layergeom->get_radius() + layergeom->get_thickness(), layergeom->get_zmin());
-	  double etamax = get_eta(layergeom->get_radius() + layergeom->get_thickness(), layergeom->get_zmax());
+	  double etamin = PHG4Utils::get_eta(layergeom->get_radius() + layergeom->get_thickness(), layergeom->get_zmin());
+	  double etamax = PHG4Utils::get_eta(layergeom->get_radius() + layergeom->get_thickness(), layergeom->get_zmax());
 	  zmin_max[layer] = make_pair(etamin, etamax);
 	  double etastepsize = (sizeiter->second).first;
 	  double d_etabins;
@@ -392,7 +393,7 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 	      double etabin[2];
 	      for (int i = 0; i < 2; i++)
 		{
-		  etaphi[i] = get_etaphi(hiter->second->get_x(i), hiter->second->get_y(i), hiter->second->get_z(i));
+		  etaphi[i] = PHG4Utils::get_etaphi(hiter->second->get_x(i), hiter->second->get_y(i), hiter->second->get_z(i));
 		  etabin[i] = geo->get_etabin( etaphi[i].first );
 		  phibin[i] = geo->get_phibin( etaphi[i].second );
 		}
@@ -473,17 +474,17 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 			{
 			  double cy = geo->get_etacenter(ibz) - etastep_half;
 			  double dy = geo->get_etacenter(ibz) + etastep_half;
-			  double rr = 0.;
+
 			  //cout << "##### line: " << ax << " " << ay << " " << bx << " " << by << endl;
 			  //cout << "####### cell: " << cx << " " << cy << " " << dx << " " << dy << endl;
-			  bool yesno = line_and_rectangle_intersect(ax, ay, bx, by, cx, cy, dx, dy, &rr);
-			  if (yesno)
-			    {
-			      if (Verbosity() > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << rr << endl;
-			      vphi.push_back(ibp);
-			      veta.push_back(ibz);
-			      vdedx.push_back(rr);
-			    }
+			pair<bool,double> intersect = PHG4Utils::line_and_rectangle_intersect(ax, ay, bx, by, cx, cy, dx, dy);
+			if (intersect.first)
+			{
+			  if (Verbosity() > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << intersect.second << endl;
+			  vphi.push_back(ibp);
+			  veta.push_back(ibz);
+			  vdedx.push_back(intersect.second);
+			}
 			}
 		    }
 		}
@@ -706,21 +707,20 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 		      double cx = geo->get_phicenter(ibp) - phistep_half;
 		      double dx = geo->get_phicenter(ibp) + phistep_half;
 		      for (int ibz = intzbin; ibz <= intzbinout; ibz++)
+		      {
+			double cy = geo->get_zcenter(ibz) - zstep_half;
+			double dy = geo->get_zcenter(ibz) + zstep_half;
+			//cout << "##### line: " << ax << " " << ay << " " << bx << " " << by << endl;
+			//cout << "####### cell: " << cx << " " << cy << " " << dx << " " << dy << endl;
+			pair<bool,double> intersect = PHG4Utils::line_and_rectangle_intersect(ax, ay, bx, by, cx, cy, dx, dy);
+			if (intersect.first)
 			{
-			  double cy = geo->get_zcenter(ibz) - zstep_half;
-			  double dy = geo->get_zcenter(ibz) + zstep_half;
-			  double rr = 0.;
-			  //cout << "##### line: " << ax << " " << ay << " " << bx << " " << by << endl;
-			  //cout << "####### cell: " << cx << " " << cy << " " << dx << " " << dy << endl;
-			  bool yesno = line_and_rectangle_intersect(ax, ay, bx, by, cx, cy, dx, dy, &rr);
-			  if (yesno)
-			    {
-			      if (Verbosity() > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << rr << endl;
-			      vphi.push_back(ibp);
-			      vz.push_back(ibz);
-			      vdedx.push_back(rr);
-			    }
+			  if (Verbosity() > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << intersect.second << endl;
+			  vphi.push_back(ibp);
+			  vz.push_back(ibz);
+			  vdedx.push_back(intersect.second);
 			}
+		      }
 		    }
 		}
 	      if (Verbosity() > 0) cout << "NUMBER OF FIRED CELLS = " << vz.size() << endl;
@@ -888,191 +888,6 @@ PHG4CylinderCellReco::set_timing_window(const int detid, const double tmin, cons
   set_double_param(detid,"tmax",tmax);
   return;
 }
-
-pair<double, double>
-PHG4CylinderCellReco::get_etaphi(const double x, const double y, const double z)
-{
-  double eta;
-  double phi;
-  double radius;
-  double theta;
-  radius = sqrt(x * x + y * y);
-  phi = atan2(y, x);
-  theta = atan2(radius, z);
-  eta = -log(tan(theta / 2.));
-  return make_pair(eta, phi);
-}
-
-double
-PHG4CylinderCellReco::get_eta(const double radius, const double z)
-{
-  double eta;
-  double theta;
-  theta = atan2(radius, fabs(z));
-  eta = -log(tan(theta / 2.));
-  if (z < 0)
-    {
-      eta = -eta;
-    }
-  return eta;
-}
-
-//---------------------------------------------------------------
-
-bool PHG4CylinderCellReco::lines_intersect(
-					   double ax,
-					   double ay,
-					   double bx,
-					   double by,
-					   double cx,
-					   double cy,
-					   double dx,
-					   double dy,
-					   double* rx, // intersection point (output)
-					   double* ry
-					   )
-{
-
-  // Find if a line segment limited by points A and B
-  // intersects line segment limited by points C and D.
-  // First check if an infinite line defined by A and B intersects
-  // segment (C,D). If h is from 0 to 1 line and line segment intersect
-  // Then check in intersection point is between C and D
-
-  double ex = bx - ax; // E=B-A
-  double ey = by - ay;
-  double fx = dx - cx; // F=D-C
-  double fy = dy - cy;
-  double px = -ey;     // P
-  double py = ex;
-
-  double bottom = fx * px + fy * py; // F*P
-  double gx = ax - cx; // A-C
-  double gy = ay - cy;
-  double top = gx * px + gy * py; // G*P
-
-  double h = 99999.;
-  if (bottom != 0.)
-    {
-      h = top / bottom;
-    }
-
-  //intersection point R = C + F*h
-  if (h > 0. && h < 1.)
-    {
-      *rx = cx + fx * h;
-      *ry = cy + fy * h;
-      //cout << "      line/segment intersection coordinates: " << *rx << " " << *ry << endl;
-      if ((*rx > ax && *rx > bx) || (*rx < ax && *rx < bx) || (*ry < ay && *ry < by) || (*ry > ay && *ry > by))
-	{
-	  //cout << "       NO segment/segment intersection!" << endl;
-	  return false;
-	}
-      else
-	{
-	  //cout << "       segment/segment intersection!" << endl;
-	  return true;
-	}
-    }
-
-  return false;
-}
-
-//---------------------------------------------------------------
-
-bool  PHG4CylinderCellReco::line_and_rectangle_intersect(
-							 double ax,
-							 double ay,
-							 double bx,
-							 double by,
-							 double cx,
-							 double cy,
-							 double dx,
-							 double dy,
-							 double* rr // length of the line segment inside the rectangle (output)
-							 )
-{
-
-  // find if a line isegment limited by points (A,B)
-  // intersects with a rectangle defined by two
-  // corner points (C,D) two other points are E and F
-  //   E--------D
-  //   |        |
-  //   |        |
-  //   C--------F
-
-  if (cx > dx || cy > dy)
-    {
-      cerr << "ERROR: Bad rectangle definition!" << endl;
-      return false;
-    }
-
-  double ex = cx;
-  double ey = dy;
-  double fx = dx;
-  double fy = cy;
-  double rx = 99999.;
-  double ry = 99999.;
-
-  vector<double> vx;
-  vector<double> vy;
-
-  bool i1 = lines_intersect(ax, ay, bx, by, cx, cy, fx, fy, &rx, &ry);
-  if (i1)
-    {
-      vx.push_back(rx);
-      vy.push_back(ry);
-    }
-  bool i2 = lines_intersect(ax, ay, bx, by, fx, fy, dx, dy, &rx, &ry);
-  if (i2)
-    {
-      vx.push_back(rx);
-      vy.push_back(ry);
-    }
-  bool i3 = lines_intersect(ax, ay, bx, by, ex, ey, dx, dy, &rx, &ry);
-  if (i3)
-    {
-      vx.push_back(rx);
-      vy.push_back(ry);
-    }
-  bool i4 = lines_intersect(ax, ay, bx, by, cx, cy, ex, ey, &rx, &ry);
-  if (i4)
-    {
-      vx.push_back(rx);
-      vy.push_back(ry);
-    }
-
-  //cout << "Rectangle intersections: " << i1 << " " << i2 << " " << i3 << " " << i4 << endl;
-  //cout << "Number of intersections = " << vx.size() << endl;
-
-  *rr = 0.;
-  if (vx.size() == 2)
-    {
-      *rr = sqrt( (vx[0] - vx[1]) * (vx[0] - vx[1]) + (vy[0] - vy[1]) * (vy[0] - vy[1]) );
-      //  cout << "Length of intersection = " << *rr << endl;
-    }
-  if (vx.size() == 1)
-    {
-      // find which point (A or B) is within the rectangle
-      if (ax > cx && ay > cy && ax < dx && ay < dy)   // point A is inside the rectangle
-	{
-	  //cout << "Point A is inside the rectangle." << endl;
-	  *rr = sqrt((vx[0] - ax) * (vx[0] - ax) + (vy[0] - ay) * (vy[0] - ay));
-	}
-      if (bx > cx && by > cy && bx < dx && by < dy)   // point B is inside the rectangle
-	{
-	  //cout << "Point B is inside the rectangle." << endl;
-	  *rr = sqrt((vx[0] - bx) * (vx[0] - bx) + (vy[0] - by) * (vy[0] - by));
-	}
-    }
-
-  if (i1 || i2 || i3 || i4)
-    {
-      return true;
-    }
-  return false;
-}
-
 
 int
 PHG4CylinderCellReco::CheckEnergy(PHCompositeNode *topNode)

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -1,55 +1,54 @@
 #include "PHG4CylinderCellReco.h"
-#include "PHG4CylinderGeomContainer.h"
-#include "PHG4CylinderGeom.h"
-#include "PHG4CylinderCellGeomContainer.h"
 #include "PHG4CylinderCellGeom.h"
+#include "PHG4CylinderCellGeomContainer.h"
+#include "PHG4CylinderGeom.h"
+#include "PHG4CylinderGeomContainer.h"
 
-#include "PHG4Cell.h"                                   // for PHG4Cell, PHG...
-#include "PHG4Cellv1.h"
+#include "PHG4Cell.h"  // for PHG4Cell, PHG...
 #include "PHG4CellContainer.h"
 #include "PHG4CellDefs.h"
+#include "PHG4Cellv1.h"
 
-#include <phparameter/PHParametersContainer.h>
 #include <phparameter/PHParameterContainerInterface.h>  // for PHParameterCo...
+#include <phparameter/PHParametersContainer.h>
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Utils.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                         // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
-#include <phool/PHNode.h>                               // for PHNode
-#include <phool/PHNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHObject.h>                             // for PHObject
+#include <phool/PHNode.h>  // for PHNode
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>                                // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <cmath>
 #include <cstdlib>
-#include <cstring>                                     // for memset
+#include <cstring>  // for memset
 #include <iostream>
-#include <iterator>                                     // for reverse_iterator
+#include <iterator>  // for reverse_iterator
 #include <sstream>
-#include <vector>                                       // for vector
+#include <vector>  // for vector
 
 using namespace std;
 
-PHG4CylinderCellReco::PHG4CylinderCellReco(const string &name) :
-  SubsysReco(name),
-  PHParameterContainerInterface(name),
-  chkenergyconservation(0),
-  sum_energy_before_cuts(0.),
-  sum_energy_g4hit(0.)
+PHG4CylinderCellReco::PHG4CylinderCellReco(const string &name)
+  : SubsysReco(name)
+  , PHParameterContainerInterface(name)
+  , chkenergyconservation(0)
+  , sum_energy_before_cuts(0.)
+  , sum_energy_g4hit(0.)
 {
   SetDefaultParameters();
   memset(nbins, 0, sizeof(nbins));
 }
 
-int
-PHG4CylinderCellReco::ResetEvent(PHCompositeNode *topNode)
+int PHG4CylinderCellReco::ResetEvent(PHCompositeNode *topNode)
 {
   sum_energy_before_cuts = 0.;
   sum_energy_g4hit = 0.;
@@ -62,301 +61,298 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
 
   // Looking for the DST node
   PHCompositeNode *dstNode;
-  dstNode = dynamic_cast<PHCompositeNode*>(nodeiter.findFirst("PHCompositeNode", "DST"));
+  dstNode = dynamic_cast<PHCompositeNode *>(nodeiter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
-    {
-      std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
-      exit(1);
-    }
+  {
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+    exit(1);
+  }
   PHCompositeNode *runNode;
-  runNode = dynamic_cast<PHCompositeNode*>(nodeiter.findFirst("PHCompositeNode", "RUN"));
+  runNode = dynamic_cast<PHCompositeNode *>(nodeiter.findFirst("PHCompositeNode", "RUN"));
   if (!runNode)
-    {
-      cout << Name() << "DST Node missing, doing nothing." << endl;
-      exit(1);
-    }
+  {
+    cout << Name() << "DST Node missing, doing nothing." << endl;
+    exit(1);
+  }
   PHNodeIterator runiter(runNode);
   PHCompositeNode *RunDetNode =
-    dynamic_cast<PHCompositeNode*>(runiter.findFirst("PHCompositeNode",
-						     detector));
+      dynamic_cast<PHCompositeNode *>(runiter.findFirst("PHCompositeNode",
+                                                        detector));
   if (!RunDetNode)
-    {
-      RunDetNode = new PHCompositeNode(detector);
-      runNode->addNode(RunDetNode);
-    }
+  {
+    RunDetNode = new PHCompositeNode(detector);
+    runNode->addNode(RunDetNode);
+  }
 
   hitnodename = "G4HIT_" + detector;
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hit)
-    {
-      cout << "Could not locate g4 hit node " << hitnodename << endl;
-      exit(1);
-    }
+  {
+    cout << "Could not locate g4 hit node " << hitnodename << endl;
+    exit(1);
+  }
   cellnodename = "G4CELL_" + outdetector;
-  PHG4CellContainer *cells = findNode::getClass<PHG4CellContainer>(topNode , cellnodename);
+  PHG4CellContainer *cells = findNode::getClass<PHG4CellContainer>(topNode, cellnodename);
   if (!cells)
+  {
+    PHNodeIterator dstiter(dstNode);
+    PHCompositeNode *DetNode =
+        dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode",
+                                                          detector));
+    if (!DetNode)
     {
-      PHNodeIterator dstiter(dstNode);
-      PHCompositeNode *DetNode =
-	dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",
-							 detector));
-      if (!DetNode)
-	{
-	  DetNode = new PHCompositeNode(detector);
-	  dstNode->addNode(DetNode);
-	}
-      cells = new PHG4CellContainer();
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str() , "PHObject");
-      DetNode->addNode(newNode);
+      DetNode = new PHCompositeNode(detector);
+      dstNode->addNode(DetNode);
     }
+    cells = new PHG4CellContainer();
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str(), "PHObject");
+    DetNode->addNode(newNode);
+  }
 
   geonodename = "CYLINDERGEOM_" + detector;
-  PHG4CylinderGeomContainer *geo =  findNode::getClass<PHG4CylinderGeomContainer>(topNode , geonodename.c_str());
+  PHG4CylinderGeomContainer *geo = findNode::getClass<PHG4CylinderGeomContainer>(topNode, geonodename.c_str());
   if (!geo)
-    {
-      cout << "Could not locate geometry node " << geonodename << endl;
-      exit(1);
-
-    }
+  {
+    cout << "Could not locate geometry node " << geonodename << endl;
+    exit(1);
+  }
   if (Verbosity() > 0)
-    {
-      geo->identify();
-    }
+  {
+    geo->identify();
+  }
   seggeonodename = "CYLINDERCELLGEOM_" + outdetector;
-  PHG4CylinderCellGeomContainer *seggeo = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode , seggeonodename.c_str());
+  PHG4CylinderCellGeomContainer *seggeo = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, seggeonodename.c_str());
   if (!seggeo)
-    {
-      seggeo = new PHG4CylinderCellGeomContainer();
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(seggeo, seggeonodename.c_str() , "PHObject");
-      runNode->addNode(newNode);
-    }
+  {
+    seggeo = new PHG4CylinderCellGeomContainer();
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(seggeo, seggeonodename.c_str(), "PHObject");
+    runNode->addNode(newNode);
+  }
 
   GetParamsContainerModify()->set_name(detector);
 
   UpdateParametersWithMacro();
 
   map<int, PHG4CylinderGeom *>::const_iterator miter;
-  pair <map<int, PHG4CylinderGeom *>::const_iterator, map<int, PHG4CylinderGeom *>::const_iterator> begin_end = geo->get_begin_end();
-  map<int, std::pair <double, double> >::iterator sizeiter;
+  pair<map<int, PHG4CylinderGeom *>::const_iterator, map<int, PHG4CylinderGeom *>::const_iterator> begin_end = geo->get_begin_end();
+  map<int, std::pair<double, double> >::iterator sizeiter;
   for (miter = begin_end.first; miter != begin_end.second; ++miter)
+  {
+    PHG4CylinderGeom *layergeom = miter->second;
+    int layer = layergeom->get_layer();
+    if (!ExistDetid(layer))
     {
-      PHG4CylinderGeom *layergeom = miter->second;
-      int layer = layergeom->get_layer();
-      if (!ExistDetid(layer))
-	{
-	  cout << Name() << ": No parameters for detid/layer " << layer 
-	       << ", hits from this detid/layer will not be accumulated into cells" << endl;
-	  continue;
-	}
-      implemented_detid.insert(layer);
-      set_size(layer,get_double_param(layer,"size_long"),get_double_param(layer,"size_perp"));
-      tmin_max.insert(std::make_pair(layer, std::make_pair(get_double_param(layer, "tmin"), get_double_param(layer, "tmax"))));
-      double circumference = layergeom->get_radius() * 2 * M_PI;
-      double length_in_z = layergeom->get_zmax() - layergeom->get_zmin();
-      sizeiter = cell_size.find(layer);
-      if (sizeiter == cell_size.end())
-	{
-	  cout << "no cell sizes for layer " << layer << endl;
-	  exit(1);
-	}
-      // create geo object and fill with variables common to all binning methods
-      PHG4CylinderCellGeom *layerseggeo = new PHG4CylinderCellGeom();
-      layerseggeo->set_layer(layergeom->get_layer());
-      layerseggeo->set_radius(layergeom->get_radius());
-      layerseggeo->set_thickness(layergeom->get_thickness());
-      if (binning[layer] == PHG4CellDefs::etaphibinning)
-	{
-	  // calculate eta at radius+ thickness (outer radius)
-	  // length via eta coverage is calculated using the outer radius
-	  double etamin = PHG4Utils::get_eta(layergeom->get_radius() + layergeom->get_thickness(), layergeom->get_zmin());
-	  double etamax = PHG4Utils::get_eta(layergeom->get_radius() + layergeom->get_thickness(), layergeom->get_zmax());
-	  zmin_max[layer] = make_pair(etamin, etamax);
-	  double etastepsize = (sizeiter->second).first;
-	  double d_etabins;
-	  double fract = modf((etamax - etamin) / etastepsize, &d_etabins);
-	  if (fract != 0)
-	    {
-	      d_etabins++;
-	    }
-	  etastepsize = (etamax - etamin) / d_etabins;
-	  (sizeiter->second).first = etastepsize;
-	  int etabins = d_etabins;
-	  double etalow = etamin;
-	  double etahi = etalow + etastepsize;
-	  for (int i = 0; i < etabins; i++)
-	    {
-	      if (etahi > (etamax + 1.e-6)) // etahi is a tiny bit larger due to numerical uncertainties
-		{
-		  cout << "etahi: " << etahi << ", etamax: " << etamax << endl;
-		}
-	      etahi +=  etastepsize;
-	    }
-
-	  double phimin = -M_PI;
-	  double phimax = M_PI;
-	  double phistepsize = (sizeiter->second).second;
-	  double d_phibins;
-	  fract = modf((phimax - phimin) / phistepsize, &d_phibins);
-	  if (fract != 0)
-	    {
-	      d_phibins++;
-	    }
-	  phistepsize = (phimax - phimin) / d_phibins;
-	  (sizeiter->second).second = phistepsize;
-	  int phibins = d_phibins;
-	  double philow = phimin;
-	  double phihi = philow + phistepsize;
-	  for (int i = 0; i < phibins; i++)
-	    {
-	      if (phihi > phimax)
-		{
-		  cout << "phihi: " << phihi << ", phimax: " << phimax << endl;
-		}
-	      phihi +=  phistepsize;
-	    }
-	  pair<int, int> phi_z_bin = make_pair(phibins, etabins);
-	  n_phi_z_bins[layer] = phi_z_bin;
-	  layerseggeo->set_binning(PHG4CellDefs::etaphibinning);
-	  layerseggeo->set_etabins(etabins);
-	  layerseggeo->set_etamin(etamin);
-	  layerseggeo->set_etastep(etastepsize);
-	  layerseggeo->set_phimin(phimin);
-	  layerseggeo->set_phibins(phibins);
-	  layerseggeo->set_phistep(phistepsize);
-	  phistep[layer] = phistepsize;
-	  etastep[layer] = etastepsize;
-	}
-      else if (binning[layer] == PHG4CellDefs::sizebinning)
-	{
-	  zmin_max[layer] = make_pair(layergeom->get_zmin(), layergeom->get_zmax());
-	  double size_z = (sizeiter->second).second;
-	  double size_r = (sizeiter->second).first;
-	  double bins_r;
-	  // unlikely but if the circumference is a multiple of the cell size
-	  // use result of division, if not - add 1 bin which makes the
-	  // cells a tiny bit smaller but makes them fit
-	  double fract = modf(circumference / size_r, &bins_r);
-	  if (fract != 0)
-	    {
-	      bins_r++;
-	    }
-	  nbins[0] = bins_r;
-	  size_r = circumference / bins_r;
-	  (sizeiter->second).first = size_r;
-	  double phistepsize = 2 * M_PI / bins_r;
-	  double phimin = -M_PI;
-	  double phimax = phimin + phistepsize;
-	  phistep[layer] = phistepsize;
-	  for (int i = 0 ; i < nbins[0]; i++)
-	    {
-	      if (phimax > (M_PI + 1e-9))
-		{
-		  cout << "phimax: " << phimax << ", M_PI: " << M_PI
-		       << "phimax-M_PI: " << phimax - M_PI << endl;
-		}
-	      phimax += phistepsize;
-	    }
-	  // unlikely but if the length is a multiple of the cell size
-	  // use result of division, if not - add 1 bin which makes the
-	  // cells a tiny bit smaller but makes them fit
-	  fract = modf(length_in_z / size_z, &bins_r);
-	  if (fract != 0)
-	    {
-	      bins_r++;
-	    }
-	  nbins[1] = bins_r;
-	  pair<int, int> phi_z_bin = make_pair(nbins[0], nbins[1]);
-	  n_phi_z_bins[layer] = phi_z_bin;
-	  // update our map with the new sizes
-	  size_z = length_in_z / bins_r;
-	  (sizeiter->second).second = size_z;
-	  double zlow = layergeom->get_zmin();
-	  double zhigh = zlow + size_z;;
-	  for (int i = 0 ; i < nbins[1]; i++)
-	    {
-	      if (zhigh > (layergeom->get_zmax() + 1e-9))
-		{
-		  cout << "zhigh: " << zhigh << ", zmax "
-		       << layergeom->get_zmax()
-		       << ", zhigh-zmax: " <<  zhigh - layergeom->get_zmax()
-		       << endl;
-		}
-	      zhigh += size_z;
-	    }
-	  layerseggeo->set_binning(PHG4CellDefs::sizebinning);
-	  layerseggeo->set_zbins(nbins[1]);
-	  layerseggeo->set_zmin(layergeom->get_zmin());
-	  layerseggeo->set_zstep(size_z);
-	  layerseggeo->set_phibins(nbins[0]);
-	  layerseggeo->set_phistep(phistepsize);
-	}
-      // add geo object filled by different binning methods
-      seggeo->AddLayerCellGeom(layerseggeo);
-      if (Verbosity() > 1)
-	{
-	  layerseggeo->identify();
-	}
+      cout << Name() << ": No parameters for detid/layer " << layer
+           << ", hits from this detid/layer will not be accumulated into cells" << endl;
+      continue;
     }
+    implemented_detid.insert(layer);
+    set_size(layer, get_double_param(layer, "size_long"), get_double_param(layer, "size_perp"));
+    tmin_max.insert(std::make_pair(layer, std::make_pair(get_double_param(layer, "tmin"), get_double_param(layer, "tmax"))));
+    double circumference = layergeom->get_radius() * 2 * M_PI;
+    double length_in_z = layergeom->get_zmax() - layergeom->get_zmin();
+    sizeiter = cell_size.find(layer);
+    if (sizeiter == cell_size.end())
+    {
+      cout << "no cell sizes for layer " << layer << endl;
+      exit(1);
+    }
+    // create geo object and fill with variables common to all binning methods
+    PHG4CylinderCellGeom *layerseggeo = new PHG4CylinderCellGeom();
+    layerseggeo->set_layer(layergeom->get_layer());
+    layerseggeo->set_radius(layergeom->get_radius());
+    layerseggeo->set_thickness(layergeom->get_thickness());
+    if (binning[layer] == PHG4CellDefs::etaphibinning)
+    {
+      // calculate eta at radius+ thickness (outer radius)
+      // length via eta coverage is calculated using the outer radius
+      double etamin = PHG4Utils::get_eta(layergeom->get_radius() + layergeom->get_thickness(), layergeom->get_zmin());
+      double etamax = PHG4Utils::get_eta(layergeom->get_radius() + layergeom->get_thickness(), layergeom->get_zmax());
+      zmin_max[layer] = make_pair(etamin, etamax);
+      double etastepsize = (sizeiter->second).first;
+      double d_etabins;
+      double fract = modf((etamax - etamin) / etastepsize, &d_etabins);
+      if (fract != 0)
+      {
+        d_etabins++;
+      }
+      etastepsize = (etamax - etamin) / d_etabins;
+      (sizeiter->second).first = etastepsize;
+      int etabins = d_etabins;
+      double etalow = etamin;
+      double etahi = etalow + etastepsize;
+      for (int i = 0; i < etabins; i++)
+      {
+        if (etahi > (etamax + 1.e-6))  // etahi is a tiny bit larger due to numerical uncertainties
+        {
+          cout << "etahi: " << etahi << ", etamax: " << etamax << endl;
+        }
+        etahi += etastepsize;
+      }
+
+      double phimin = -M_PI;
+      double phimax = M_PI;
+      double phistepsize = (sizeiter->second).second;
+      double d_phibins;
+      fract = modf((phimax - phimin) / phistepsize, &d_phibins);
+      if (fract != 0)
+      {
+        d_phibins++;
+      }
+      phistepsize = (phimax - phimin) / d_phibins;
+      (sizeiter->second).second = phistepsize;
+      int phibins = d_phibins;
+      double philow = phimin;
+      double phihi = philow + phistepsize;
+      for (int i = 0; i < phibins; i++)
+      {
+        if (phihi > phimax)
+        {
+          cout << "phihi: " << phihi << ", phimax: " << phimax << endl;
+        }
+        phihi += phistepsize;
+      }
+      pair<int, int> phi_z_bin = make_pair(phibins, etabins);
+      n_phi_z_bins[layer] = phi_z_bin;
+      layerseggeo->set_binning(PHG4CellDefs::etaphibinning);
+      layerseggeo->set_etabins(etabins);
+      layerseggeo->set_etamin(etamin);
+      layerseggeo->set_etastep(etastepsize);
+      layerseggeo->set_phimin(phimin);
+      layerseggeo->set_phibins(phibins);
+      layerseggeo->set_phistep(phistepsize);
+      phistep[layer] = phistepsize;
+      etastep[layer] = etastepsize;
+    }
+    else if (binning[layer] == PHG4CellDefs::sizebinning)
+    {
+      zmin_max[layer] = make_pair(layergeom->get_zmin(), layergeom->get_zmax());
+      double size_z = (sizeiter->second).second;
+      double size_r = (sizeiter->second).first;
+      double bins_r;
+      // unlikely but if the circumference is a multiple of the cell size
+      // use result of division, if not - add 1 bin which makes the
+      // cells a tiny bit smaller but makes them fit
+      double fract = modf(circumference / size_r, &bins_r);
+      if (fract != 0)
+      {
+        bins_r++;
+      }
+      nbins[0] = bins_r;
+      size_r = circumference / bins_r;
+      (sizeiter->second).first = size_r;
+      double phistepsize = 2 * M_PI / bins_r;
+      double phimin = -M_PI;
+      double phimax = phimin + phistepsize;
+      phistep[layer] = phistepsize;
+      for (int i = 0; i < nbins[0]; i++)
+      {
+        if (phimax > (M_PI + 1e-9))
+        {
+          cout << "phimax: " << phimax << ", M_PI: " << M_PI
+               << "phimax-M_PI: " << phimax - M_PI << endl;
+        }
+        phimax += phistepsize;
+      }
+      // unlikely but if the length is a multiple of the cell size
+      // use result of division, if not - add 1 bin which makes the
+      // cells a tiny bit smaller but makes them fit
+      fract = modf(length_in_z / size_z, &bins_r);
+      if (fract != 0)
+      {
+        bins_r++;
+      }
+      nbins[1] = bins_r;
+      pair<int, int> phi_z_bin = make_pair(nbins[0], nbins[1]);
+      n_phi_z_bins[layer] = phi_z_bin;
+      // update our map with the new sizes
+      size_z = length_in_z / bins_r;
+      (sizeiter->second).second = size_z;
+      double zlow = layergeom->get_zmin();
+      double zhigh = zlow + size_z;
+      ;
+      for (int i = 0; i < nbins[1]; i++)
+      {
+        if (zhigh > (layergeom->get_zmax() + 1e-9))
+        {
+          cout << "zhigh: " << zhigh << ", zmax "
+               << layergeom->get_zmax()
+               << ", zhigh-zmax: " << zhigh - layergeom->get_zmax()
+               << endl;
+        }
+        zhigh += size_z;
+      }
+      layerseggeo->set_binning(PHG4CellDefs::sizebinning);
+      layerseggeo->set_zbins(nbins[1]);
+      layerseggeo->set_zmin(layergeom->get_zmin());
+      layerseggeo->set_zstep(size_z);
+      layerseggeo->set_phibins(nbins[0]);
+      layerseggeo->set_phistep(phistepsize);
+    }
+    // add geo object filled by different binning methods
+    seggeo->AddLayerCellGeom(layerseggeo);
+    if (Verbosity() > 1)
+    {
+      layerseggeo->identify();
+    }
+  }
 
   // print out settings
   if (Verbosity() > 0)
+  {
+    cout << "===================== PHG4CylinderCellReco::InitRun() =====================" << endl;
+    cout << " " << outdetector << " Segmentation Description: " << endl;
+    for (std::map<int, int>::iterator iter = binning.begin();
+         iter != binning.end(); ++iter)
     {
-      cout << "===================== PHG4CylinderCellReco::InitRun() =====================" << endl;
-      cout << " " << outdetector << " Segmentation Description: " << endl;
-      for (std::map<int, int>::iterator iter = binning.begin();
-	   iter != binning.end(); ++iter)
-	{
-	  int layer = iter->first;
+      int layer = iter->first;
 
-	  if (binning[layer] == PHG4CellDefs::etaphibinning)
-	    {
-	      // phi & eta bin is usually used to make projective towers
-	      // so just print the first layer
-	      cout << " Layer #" << binning.begin()->first << "-" << binning.rbegin()->first << endl;
-	      cout << "   Nbins (phi,eta): (" << n_phi_z_bins[layer].first << ", " << n_phi_z_bins[layer].second << ")" << endl;
-	      cout << "   Cell Size (phi,eta): (" << cell_size[layer].first << " rad, " << cell_size[layer].second << " units)" << endl;
-	      break;
-	    }
-	  else if (binning[layer] == PHG4CellDefs::sizebinning)
-	    {
-	      cout << " Layer #" << layer << endl;
-	      cout << "   Nbins (phi,z): (" << n_phi_z_bins[layer].first << ", " << n_phi_z_bins[layer].second << ")" << endl;
-	      cout << "   Cell Size (phi,z): (" << cell_size[layer].first << " cm, " << cell_size[layer].second << " cm)" << endl;
-	    }
-	}
-      cout << "===========================================================================" << endl;
+      if (binning[layer] == PHG4CellDefs::etaphibinning)
+      {
+        // phi & eta bin is usually used to make projective towers
+        // so just print the first layer
+        cout << " Layer #" << binning.begin()->first << "-" << binning.rbegin()->first << endl;
+        cout << "   Nbins (phi,eta): (" << n_phi_z_bins[layer].first << ", " << n_phi_z_bins[layer].second << ")" << endl;
+        cout << "   Cell Size (phi,eta): (" << cell_size[layer].first << " rad, " << cell_size[layer].second << " units)" << endl;
+        break;
+      }
+      else if (binning[layer] == PHG4CellDefs::sizebinning)
+      {
+        cout << " Layer #" << layer << endl;
+        cout << "   Nbins (phi,z): (" << n_phi_z_bins[layer].first << ", " << n_phi_z_bins[layer].second << ")" << endl;
+        cout << "   Cell Size (phi,z): (" << cell_size[layer].first << " cm, " << cell_size[layer].second << " cm)" << endl;
+      }
     }
+    cout << "===========================================================================" << endl;
+  }
   string nodename = "G4CELLPARAM_" + GetParamsContainer()->Name();
-  SaveToNodeTree(RunDetNode,nodename);
+  SaveToNodeTree(RunDetNode, nodename);
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-
-int
-PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
+int PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
 {
-
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hit)
-    {
-      cout << "Could not locate g4 hit node " << hitnodename << endl;
-      exit(1);
-    }
+  {
+    cout << "Could not locate g4 hit node " << hitnodename << endl;
+    exit(1);
+  }
   PHG4CellContainer *cells = findNode::getClass<PHG4CellContainer>(topNode, cellnodename);
-  if (! cells)
-    {
-      cout << "could not locate cell node " << cellnodename << endl;
-      exit(1);
-    }
+  if (!cells)
+  {
+    cout << "could not locate cell node " << cellnodename << endl;
+    exit(1);
+  }
 
-  PHG4CylinderCellGeomContainer *seggeo = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode , seggeonodename.c_str());
-  if (! seggeo)
-    {
-      cout << "could not locate geo node " << seggeonodename << endl;
-      exit(1);
-    }
+  PHG4CylinderCellGeomContainer *seggeo = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, seggeonodename.c_str());
+  if (!seggeo)
+  {
+    cout << "could not locate geo node " << seggeonodename << endl;
+    exit(1);
+  }
 
-  map<int, std::pair <double, double> >::iterator sizeiter;
+  map<int, std::pair<double, double> >::iterator sizeiter;
   PHG4HitContainer::LayerIter layer;
   pair<PHG4HitContainer::LayerIter, PHG4HitContainer::LayerIter> layer_begin_end = g4hit->getLayers();
   //   cout << "number of layers: " << g4hit->num_layers() << endl;
@@ -366,531 +362,519 @@ PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
   //       cout << "layer number: " << *layer << endl;
   //     }
   for (layer = layer_begin_end.first; layer != layer_begin_end.second; layer++)
+  {
+    // only handle layers/detector ids which have parameters set
+    if (implemented_detid.find(*layer) == implemented_detid.end())
     {
-      // only handle layers/detector ids which have parameters set
-      if (implemented_detid.find(*layer) == implemented_detid.end())
-	{
-	  continue;
-	}
-      PHG4HitContainer::ConstIterator hiter;
-      PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits(*layer);
-      PHG4CylinderCellGeom *geo = seggeo->GetLayerCellGeom(*layer);
-      int nphibins = n_phi_z_bins[*layer].first;
-      int nzbins = n_phi_z_bins[*layer].second;
-
-      // ------- eta/phi binning ------------------------------------------------------------------------
-      if (binning[*layer] == PHG4CellDefs::etaphibinning)
-	{
-	  for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
-	    {
-	      sum_energy_before_cuts += hiter->second->get_edep();
-	      // checking ADC timing integration window cut
-	      if (hiter->second->get_t(0) > tmin_max[*layer].second) continue;
-	      if (hiter->second->get_t(1) < tmin_max[*layer].first) continue;
-
-	      pair<double, double> etaphi[2];
-	      double phibin[2];
-	      double etabin[2];
-	      for (int i = 0; i < 2; i++)
-		{
-		  etaphi[i] = PHG4Utils::get_etaphi(hiter->second->get_x(i), hiter->second->get_y(i), hiter->second->get_z(i));
-		  etabin[i] = geo->get_etabin( etaphi[i].first );
-		  phibin[i] = geo->get_phibin( etaphi[i].second );
-		}
-	      // check bin range
-	      if (phibin[0] < 0 || phibin[0] >= nphibins || phibin[1] < 0 || phibin[1] >= nphibins)
-		{
-		  continue;
-		}
-	      if (etabin[0] < 0 || etabin[0] >= nzbins   || etabin[1] < 0 || etabin[1] >= nzbins)
-		{
-		  continue;
-		}
-
-	      if (etabin[0] < 0)
-		{
-		  if (Verbosity() > 0)
-		    {
-		      hiter->second->identify();
-		    }
-		  continue;
-		}
-	      sum_energy_g4hit += hiter->second->get_edep();
-	      int intphibin = phibin[0];
-	      int intetabin = etabin[0];
-	      int intphibinout = phibin[1];
-	      int intetabinout = etabin[1];
-
-	      // Determine all fired cells
-
-	      double ax = (etaphi[0]).second; // phi
-	      double ay = (etaphi[0]).first;  // eta
-	      double bx = (etaphi[1]).second;
-	      double by = (etaphi[1]).first;
-	      if (intphibin > intphibinout)
-		{
-		  int tmp = intphibin;
-		  intphibin = intphibinout;
-		  intphibinout = tmp;
-		}
-	      if (intetabin > intetabinout)
-		{
-		  int tmp = intetabin;
-		  intetabin = intetabinout;
-		  intetabinout = tmp;
-		}
-
-	      double trklen = sqrt((ax - bx) * (ax - bx) + (ay - by) * (ay - by));
-	      // if entry and exit hit are the same (seems to happen rarely), trklen = 0
-	      // which leads to a 0/0 and an NaN in edep later on
-	      // this code does for particles in the same cell a trklen/trklen (vdedx[ii]/trklen)
-	      // so setting this to any non zero number will do just fine
-	      // I just pick -1 here to flag those strange hits in case I want t oanalyze them
-	      // later on
-	      if (trklen == 0)
-		{
-		  trklen = -1.;
-		}
-	      vector<int> vphi;
-	      vector<int> veta;
-	      vector<double> vdedx;
-
-	      if (intphibin == intphibinout && intetabin == intetabinout)   // single cell fired
-		{
-		  if (Verbosity() > 0) cout << "SINGLE CELL FIRED: " << intphibin << " " << intetabin << endl;
-		  vphi.push_back(intphibin);
-		  veta.push_back(intetabin);
-		  vdedx.push_back(trklen);
-		}
-	      else
-		{
-                  double phistep_half = geo->get_phistep() / 2.;
-		  double etastep_half = geo->get_etastep() / 2.;
-		  for (int ibp = intphibin; ibp <= intphibinout; ibp++)
-		    {
-		      double cx = geo->get_phicenter(ibp) - phistep_half;
-		      double dx = geo->get_phicenter(ibp) + phistep_half;
-		      for (int ibz = intetabin; ibz <= intetabinout; ibz++)
-			{
-			  double cy = geo->get_etacenter(ibz) - etastep_half;
-			  double dy = geo->get_etacenter(ibz) + etastep_half;
-
-			  //cout << "##### line: " << ax << " " << ay << " " << bx << " " << by << endl;
-			  //cout << "####### cell: " << cx << " " << cy << " " << dx << " " << dy << endl;
-			pair<bool,double> intersect = PHG4Utils::line_and_rectangle_intersect(ax, ay, bx, by, cx, cy, dx, dy);
-			if (intersect.first)
-			{
-			  if (Verbosity() > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << intersect.second << endl;
-			  vphi.push_back(ibp);
-			  veta.push_back(ibz);
-			  vdedx.push_back(intersect.second);
-			}
-			}
-		    }
-		}
-	      if (Verbosity() > 0) cout << "NUMBER OF FIRED CELLS = " << vphi.size() << endl;
-
-	      double tmpsum = 0.;
-	      for (unsigned int ii = 0; ii < vphi.size(); ii++)
-		{
-		  tmpsum += vdedx[ii];
-		  vdedx[ii] = vdedx[ii] / trklen;
-		  if (Verbosity() > 0) cout << "  CELL " << ii << "  dE/dX = " <<  vdedx[ii] << endl;
-		}
-	      if (Verbosity() > 0) cout << "    TOTAL TRACK LENGTH = " << tmpsum << " " << trklen << endl;
-
-	      for (unsigned int i1 = 0; i1 < vphi.size(); i1++)   // loop over all fired cells
-		{
-
-		  int iphibin = vphi[i1];
-		  int ietabin = veta[i1];
-
-		  // This is the key for cellptmap
-		  // It is constructed using the phi and z (or eta) bin index values
-		  // It will be unique for a given phi and z (or eta) bin combination
-		  unsigned long long tmp = iphibin;
-		  unsigned long long key = tmp << 32;
-		  key += ietabin;
-		  if(Verbosity() > 1)
-		    {
-		      cout << " iphibin " << iphibin << " ietabin " << ietabin << " key 0x" << hex << key << dec << endl;
-		    }
-		  PHG4Cell *cell = nullptr;
-		  it = cellptmap.find(key);
-		  if (it != cellptmap.end())
-		    {
-		      cell = it->second;
-		    }
-		  else
-		    {
-		      PHG4CellDefs::keytype cellkey = PHG4CellDefs::EtaPhiBinning::genkey(*layer, ietabin, iphibin);
-		      cell = new PHG4Cellv1(cellkey);
-		      cellptmap[key] = cell;
-		    }
-		  if (! isfinite(hiter->second->get_edep()*vdedx[i1]))
-		    {
-		      cout << "hit 0x" << hex <<  hiter->first << dec << " not finite, edep: "
-			   << hiter->second->get_edep() << " weight " << vdedx[i1] << endl;
-		    }
-		  cell->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1]); // add hit with edep to g4hit list
-                  cell->add_edep(hiter->second->get_edep()*vdedx[i1]); // add edep to cell
-		  if (hiter->second->has_property(PHG4Hit::prop_light_yield))
-		    {
-		      cell->add_light_yield(hiter->second->get_light_yield()*vdedx[i1]);
-		    }
-		  cell->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep()*vdedx[i1]);
-		  // just a sanity check - we don't want to mess up by having Nan's or Infs in our energy deposition
-		  if (! isfinite(hiter->second->get_edep()*vdedx[i1]))
-		    {
-		      cout << PHWHERE << " invalid energy dep " << hiter->second->get_edep()
-			   << " or path length: " << vdedx[i1] << endl;
-		    }
-		}
-	      vphi.clear();
-	      veta.clear();
-
-	    } // end loop over g4hits
-
-	  int numcells = 0;
-
-	  for(it = cellptmap.begin(); it != cellptmap.end(); ++it)
-	    {
-	      cells->AddCell(it->second);
-	      numcells++;
-	      if (Verbosity() > 1)
-		{
-		  cout << "Adding cell in bin phi: " << PHG4CellDefs::EtaPhiBinning::get_phibin(it->second->get_cellid())
-		       << " phi: " << geo->get_phicenter(PHG4CellDefs::EtaPhiBinning::get_phibin(it->second->get_cellid())) * 180. / M_PI
-		       << ", eta bin: " << PHG4CellDefs::EtaPhiBinning::get_etabin(it->second->get_cellid())
-		       << ", eta: " <<  geo->get_etacenter(PHG4CellDefs::EtaPhiBinning::get_etabin(it->second->get_cellid()))
-		       << ", energy dep: " << it->second->get_edep()
-		       << endl;
-		}
-	    }
-
-	  if (Verbosity() > 0)
-	    {
-	      cout << Name() << ": found " << numcells << " eta/phi cells with energy deposition" << endl;
-	    }
-	}
-
-
-
-      else // ------ size binning ---------------------------------------------------------------
-	{
-	  sizeiter = cell_size.find(*layer);
-	  if (sizeiter == cell_size.end())
-	    {
-	      cout << "logical screwup!!! no sizes for layer " << *layer << endl;
-	      exit(1);
-	    }
-	  double zstepsize = (sizeiter->second).second;
-	  double phistepsize = phistep[*layer];
-
-	  for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
-	    {
-	      sum_energy_before_cuts += hiter->second->get_edep();
-	      // checking ADC timing integration window cut
-	      if (hiter->second->get_t(0) > tmin_max[*layer].second) continue;
-	      if (hiter->second->get_t(1) < tmin_max[*layer].first) continue;
-
-	      double xinout[2];
-	      double yinout[2];
-	      double px[2];
-	      double py[2];
-	      double phi[2];
-	      double z[2];
-	      double phibin[2];
-	      double zbin[2];
-	      if (Verbosity() > 0) cout << "--------- new hit in layer # " << *layer << endl;
-
-	      for (int i = 0; i < 2; i++)
-		{
-		  xinout[i] = hiter->second->get_x(i);
-		  yinout[i] = hiter->second->get_y(i);
-		  px[i] = hiter->second->get_px(i);
-		  py[i] = hiter->second->get_py(i);
-		  phi[i] = atan2(hiter->second->get_y(i), hiter->second->get_x(i));
-		  z[i] =  hiter->second->get_z(i);
-		  phibin[i] = geo->get_phibin( phi[i] );
-		  zbin[i] = geo->get_zbin( hiter->second->get_z(i) );
-
-		  if (Verbosity() > 0) cout << " " << i << "  phibin: " << phibin[i] << ", phi: " << phi[i] << ", stepsize: " << phistepsize << endl;
-		  if (Verbosity() > 0) cout << " " << i << "  zbin: " << zbin[i] << ", z = " << hiter->second->get_z(i) << ", stepsize: " << zstepsize << " offset: " <<  zmin_max[*layer].first << endl;
-		}
-	      // check bin range
-	      if (phibin[0] < 0 || phibin[0] >= nphibins || phibin[1] < 0 || phibin[1] >= nphibins)
-		{
-		  continue;
-		}
-	      if (zbin[0] < 0 || zbin[0] >= nzbins   || zbin[1] < 0 || zbin[1] >= nzbins)
-		{
-		  continue;
-		}
-
-
-	      if (zbin[0] < 0)
-		{
-		  hiter->second->identify();
-		  continue;
-		}
-	      sum_energy_g4hit += hiter->second->get_edep();
-
-	      int intphibin = phibin[0];
-	      int intzbin = zbin[0];
-	      int intphibinout = phibin[1];
-	      int intzbinout = zbin[1];
-
-	      if (Verbosity() > 0)
-		{
-		  cout << "    phi bin range: " << intphibin << " to " << intphibinout << " phi: " << phi[0] << " to " << phi[1] << endl;
-		  cout << "    Z bin range: " << intzbin << " to " << intzbinout << " Z: " << z[0] << " to " << z[1] << endl;
-		  cout << "    phi difference: " << (phi[1] - phi[0]) * 1000. << " milliradians." << endl;
-		  cout << "    phi difference: " << 2.5 * (phi[1] - phi[0]) * 10000. << " microns." << endl;
-		  cout << "    path length = " << sqrt((xinout[1] - xinout[0]) * (xinout[1] - xinout[0]) + (yinout[1] - yinout[0]) * (yinout[1] - yinout[0])) << endl;
-		  cout << "       px = " << px[0] << " " << px[1] << endl;
-		  cout << "       py = " << py[0] << " " << py[1] << endl;
-		  cout << "       x = " << xinout[0] << " " << xinout[1] << endl;
-		  cout << "       y = " << yinout[0] << " " << yinout[1] << endl;
-		}
-
-	      // Determine all fired cells
-
-	      double ax = phi[0];
-	      double ay = z[0];
-	      double bx = phi[1];
-	      double by = z[1];
-	      if (intphibin > intphibinout)
-		{
-		  int tmp = intphibin;
-		  intphibin = intphibinout;
-		  intphibinout = tmp;
-		}
-	      if (intzbin > intzbinout)
-		{
-		  int tmp = intzbin;
-		  intzbin = intzbinout;
-		  intzbinout = tmp;
-		}
-
-	      double trklen = sqrt((ax - bx) * (ax - bx) + (ay - by) * (ay - by));
-	      // if entry and exit hit are the same (seems to happen rarely), trklen = 0
-	      // which leads to a 0/0 and an NaN in edep later on
-	      // this code does for particles in the same cell a trklen/trklen (vdedx[ii]/trklen)
-	      // so setting this to any non zero number will do just fine
-	      // I just pick -1 here to flag those strange hits in case I want to analyze them
-	      // later on
-	      if (trklen == 0)
-		{
-		  trklen = -1.;
-		}
-	      vector<int> vphi;
-	      vector<int> vz;
-	      vector<double> vdedx;
-
-	      if (intphibin == intphibinout && intzbin == intzbinout)   // single cell fired
-		{
-		  if (Verbosity() > 0)
-		    {
-		      cout << "SINGLE CELL FIRED: " << intphibin << " " << intzbin << endl;
-		    }
-		  vphi.push_back(intphibin);
-		  vz.push_back(intzbin);
-		  vdedx.push_back(trklen);
-		}
-	      else
-		{
-                  double phistep_half = geo->get_phistep() / 2.;
-		  double zstep_half = geo->get_zstep() / 2.;
-		  for (int ibp = intphibin; ibp <= intphibinout; ibp++)
-		    {
-		      double cx = geo->get_phicenter(ibp) - phistep_half;
-		      double dx = geo->get_phicenter(ibp) + phistep_half;
-		      for (int ibz = intzbin; ibz <= intzbinout; ibz++)
-		      {
-			double cy = geo->get_zcenter(ibz) - zstep_half;
-			double dy = geo->get_zcenter(ibz) + zstep_half;
-			//cout << "##### line: " << ax << " " << ay << " " << bx << " " << by << endl;
-			//cout << "####### cell: " << cx << " " << cy << " " << dx << " " << dy << endl;
-			pair<bool,double> intersect = PHG4Utils::line_and_rectangle_intersect(ax, ay, bx, by, cx, cy, dx, dy);
-			if (intersect.first)
-			{
-			  if (Verbosity() > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << intersect.second << endl;
-			  vphi.push_back(ibp);
-			  vz.push_back(ibz);
-			  vdedx.push_back(intersect.second);
-			}
-		      }
-		    }
-		}
-	      if (Verbosity() > 0) cout << "NUMBER OF FIRED CELLS = " << vz.size() << endl;
-
-	      double tmpsum = 0.;
-	      for (unsigned int ii = 0; ii < vz.size(); ii++)
-		{
-		  tmpsum += vdedx[ii];
-		  vdedx[ii] = vdedx[ii] / trklen;
-		  if (Verbosity() > 0) cout << "  CELL " << ii << "  dE/dX = " <<  vdedx[ii] << endl;
-		}
-	      if (Verbosity() > 0) cout << "    TOTAL TRACK LENGTH = " << tmpsum << " " << trklen << endl;
-
-	      for (unsigned int i1 = 0; i1 < vphi.size(); i1++)   // loop over all fired cells
-		{
-		  int iphibin = vphi[i1];
-		  int izbin = vz[i1];
-
-		  unsigned long long tmp = iphibin;
-		  unsigned long long key = tmp << 32;
-		  key += izbin;
-		  if(Verbosity() > 1)
-		    {
-		      cout << " iphibin " << iphibin << " izbin " << izbin << " key 0x" << hex << key << dec << endl;
-		    }
-		  // check to see if there is already an entry for this cell
-		  PHG4Cell *cell = nullptr;
-		  it = cellptmap.find(key);
-
-		  if(it != cellptmap.end())
-		    {
-		      cell = it->second;
-		      if(Verbosity() > 1)
-			{
-			  cout << "  add energy to existing cell for key = " << cellptmap.find(key)->first << endl;
-			}
-
-		      if(Verbosity() > 1 && hiter->second->has_property(PHG4Hit::prop_light_yield) && std::isnan(hiter->second->get_light_yield()*vdedx[i1]))
-			{
-
-			  cout << "    NAN lighy yield with vdedx[i1] = " << vdedx[i1]
-			       << " and hiter->second->get_light_yield() = " << hiter->second->get_light_yield() << endl;
-
-			}
-		    }
-		  else
-		    {
-		      if(Verbosity() > 1)
-			{
-			  cout << "    did not find a previous entry for key = " << key << " create a new one" << endl;
-			}
-		      PHG4CellDefs::keytype cellkey = PHG4CellDefs::SizeBinning::genkey(*layer, izbin, iphibin);
-		      cell = new PHG4Cellv1(cellkey);
-		      cellptmap[key] = cell;
-		    }
-		  if (! isfinite(hiter->second->get_edep()*vdedx[i1]))
-		    {
-		      cout << "hit 0x" << hex <<  hiter->first << dec << " not finite, edep: "
-			   << hiter->second->get_edep() << " weight " << vdedx[i1] << endl;
-		    }
-		  cell->add_edep(hiter->first, hiter->second->get_edep()*vdedx[i1]);
-                  cell->add_edep(hiter->second->get_edep()*vdedx[i1]); // add edep to cell
-		  if (hiter->second->has_property(PHG4Hit::prop_light_yield))
-		    {
-		      cell->add_light_yield(hiter->second->get_light_yield()*vdedx[i1]);
-		      if(Verbosity() > 1 && !std::isfinite(hiter->second->get_light_yield()*vdedx[i1]))
-			{
-			  cout << "    NAN lighy yield with vdedx[i1] = " << vdedx[i1]
-			       << " and hiter->second->get_light_yield() = " << hiter->second->get_light_yield() << endl;
-			}
-		    }
-		  cell->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep()*vdedx[i1]);
-
-		}
-	      vphi.clear();
-	      vz.clear();
-
-	    } // end loop over hits
-
-	  int numcells = 0;
-
-	  for(it = cellptmap.begin(); it != cellptmap.end(); ++it)
-	    {
-	      cells->AddCell(it->second);
-	      numcells++;
-	      if (Verbosity() > 1)
-		{
-		  cout << "Adding cell for key " << it->first << " in bin phi: " << PHG4CellDefs::SizeBinning::get_phibin(it->second->get_cellid())
-		       << " phi: " << geo->get_phicenter(PHG4CellDefs::SizeBinning::get_phibin(it->second->get_cellid())) * 180. / M_PI
-		       << ", z bin: " << PHG4CellDefs::SizeBinning::get_zbin(it->second->get_cellid())
-		       << ", z: " <<  geo->get_zcenter(PHG4CellDefs::SizeBinning::get_zbin(it->second->get_cellid()))
-		       << ", energy dep: " << it->second->get_edep()
-		       << endl;
-		}
-	    }
-
-	  if (Verbosity() > 0)
-	    {
-	      cout << "found " << numcells << " z/phi cells with energy deposition" << endl;
-	    }
-	}
-
-      //==========================================================
-      // now reset the cell map before moving on to the next layer
-      if(Verbosity() > 1)
-	{
-	  cout << "cellptmap for layer " << *layer << " has final length " << cellptmap.size();
-	}
-      while(cellptmap.begin() != cellptmap.end())
-	{
-	  // Assumes that memmory is freed by the cylinder cell container when it is destroyed
-	  cellptmap.erase(cellptmap.begin());
-	}
-      if(Verbosity() > 1)
-	{
-	  cout << " reset it to " << cellptmap.size() << endl;
-	}
+      continue;
     }
+    PHG4HitContainer::ConstIterator hiter;
+    PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits(*layer);
+    PHG4CylinderCellGeom *geo = seggeo->GetLayerCellGeom(*layer);
+    int nphibins = n_phi_z_bins[*layer].first;
+    int nzbins = n_phi_z_bins[*layer].second;
+
+    // ------- eta/phi binning ------------------------------------------------------------------------
+    if (binning[*layer] == PHG4CellDefs::etaphibinning)
+    {
+      for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
+      {
+        sum_energy_before_cuts += hiter->second->get_edep();
+        // checking ADC timing integration window cut
+        if (hiter->second->get_t(0) > tmin_max[*layer].second) continue;
+        if (hiter->second->get_t(1) < tmin_max[*layer].first) continue;
+
+        pair<double, double> etaphi[2];
+        double phibin[2];
+        double etabin[2];
+        for (int i = 0; i < 2; i++)
+        {
+          etaphi[i] = PHG4Utils::get_etaphi(hiter->second->get_x(i), hiter->second->get_y(i), hiter->second->get_z(i));
+          etabin[i] = geo->get_etabin(etaphi[i].first);
+          phibin[i] = geo->get_phibin(etaphi[i].second);
+        }
+        // check bin range
+        if (phibin[0] < 0 || phibin[0] >= nphibins || phibin[1] < 0 || phibin[1] >= nphibins)
+        {
+          continue;
+        }
+        if (etabin[0] < 0 || etabin[0] >= nzbins || etabin[1] < 0 || etabin[1] >= nzbins)
+        {
+          continue;
+        }
+
+        if (etabin[0] < 0)
+        {
+          if (Verbosity() > 0)
+          {
+            hiter->second->identify();
+          }
+          continue;
+        }
+        sum_energy_g4hit += hiter->second->get_edep();
+        int intphibin = phibin[0];
+        int intetabin = etabin[0];
+        int intphibinout = phibin[1];
+        int intetabinout = etabin[1];
+
+        // Determine all fired cells
+
+        double ax = (etaphi[0]).second;  // phi
+        double ay = (etaphi[0]).first;   // eta
+        double bx = (etaphi[1]).second;
+        double by = (etaphi[1]).first;
+        if (intphibin > intphibinout)
+        {
+          int tmp = intphibin;
+          intphibin = intphibinout;
+          intphibinout = tmp;
+        }
+        if (intetabin > intetabinout)
+        {
+          int tmp = intetabin;
+          intetabin = intetabinout;
+          intetabinout = tmp;
+        }
+
+        double trklen = sqrt((ax - bx) * (ax - bx) + (ay - by) * (ay - by));
+        // if entry and exit hit are the same (seems to happen rarely), trklen = 0
+        // which leads to a 0/0 and an NaN in edep later on
+        // this code does for particles in the same cell a trklen/trklen (vdedx[ii]/trklen)
+        // so setting this to any non zero number will do just fine
+        // I just pick -1 here to flag those strange hits in case I want t oanalyze them
+        // later on
+        if (trklen == 0)
+        {
+          trklen = -1.;
+        }
+        vector<int> vphi;
+        vector<int> veta;
+        vector<double> vdedx;
+
+        if (intphibin == intphibinout && intetabin == intetabinout)  // single cell fired
+        {
+          if (Verbosity() > 0) cout << "SINGLE CELL FIRED: " << intphibin << " " << intetabin << endl;
+          vphi.push_back(intphibin);
+          veta.push_back(intetabin);
+          vdedx.push_back(trklen);
+        }
+        else
+        {
+          double phistep_half = geo->get_phistep() / 2.;
+          double etastep_half = geo->get_etastep() / 2.;
+          for (int ibp = intphibin; ibp <= intphibinout; ibp++)
+          {
+            double cx = geo->get_phicenter(ibp) - phistep_half;
+            double dx = geo->get_phicenter(ibp) + phistep_half;
+            for (int ibz = intetabin; ibz <= intetabinout; ibz++)
+            {
+              double cy = geo->get_etacenter(ibz) - etastep_half;
+              double dy = geo->get_etacenter(ibz) + etastep_half;
+
+              //cout << "##### line: " << ax << " " << ay << " " << bx << " " << by << endl;
+              //cout << "####### cell: " << cx << " " << cy << " " << dx << " " << dy << endl;
+              pair<bool, double> intersect = PHG4Utils::line_and_rectangle_intersect(ax, ay, bx, by, cx, cy, dx, dy);
+              if (intersect.first)
+              {
+                if (Verbosity() > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << intersect.second << endl;
+                vphi.push_back(ibp);
+                veta.push_back(ibz);
+                vdedx.push_back(intersect.second);
+              }
+            }
+          }
+        }
+        if (Verbosity() > 0) cout << "NUMBER OF FIRED CELLS = " << vphi.size() << endl;
+
+        double tmpsum = 0.;
+        for (unsigned int ii = 0; ii < vphi.size(); ii++)
+        {
+          tmpsum += vdedx[ii];
+          vdedx[ii] = vdedx[ii] / trklen;
+          if (Verbosity() > 0) cout << "  CELL " << ii << "  dE/dX = " << vdedx[ii] << endl;
+        }
+        if (Verbosity() > 0) cout << "    TOTAL TRACK LENGTH = " << tmpsum << " " << trklen << endl;
+
+        for (unsigned int i1 = 0; i1 < vphi.size(); i1++)  // loop over all fired cells
+        {
+          int iphibin = vphi[i1];
+          int ietabin = veta[i1];
+
+          // This is the key for cellptmap
+          // It is constructed using the phi and z (or eta) bin index values
+          // It will be unique for a given phi and z (or eta) bin combination
+          unsigned long long tmp = iphibin;
+          unsigned long long key = tmp << 32;
+          key += ietabin;
+          if (Verbosity() > 1)
+          {
+            cout << " iphibin " << iphibin << " ietabin " << ietabin << " key 0x" << hex << key << dec << endl;
+          }
+          PHG4Cell *cell = nullptr;
+          it = cellptmap.find(key);
+          if (it != cellptmap.end())
+          {
+            cell = it->second;
+          }
+          else
+          {
+            PHG4CellDefs::keytype cellkey = PHG4CellDefs::EtaPhiBinning::genkey(*layer, ietabin, iphibin);
+            cell = new PHG4Cellv1(cellkey);
+            cellptmap[key] = cell;
+          }
+          if (!isfinite(hiter->second->get_edep() * vdedx[i1]))
+          {
+            cout << "hit 0x" << hex << hiter->first << dec << " not finite, edep: "
+                 << hiter->second->get_edep() << " weight " << vdedx[i1] << endl;
+          }
+          cell->add_edep(hiter->first, hiter->second->get_edep() * vdedx[i1]);  // add hit with edep to g4hit list
+          cell->add_edep(hiter->second->get_edep() * vdedx[i1]);                // add edep to cell
+          if (hiter->second->has_property(PHG4Hit::prop_light_yield))
+          {
+            cell->add_light_yield(hiter->second->get_light_yield() * vdedx[i1]);
+          }
+          cell->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep() * vdedx[i1]);
+          // just a sanity check - we don't want to mess up by having Nan's or Infs in our energy deposition
+          if (!isfinite(hiter->second->get_edep() * vdedx[i1]))
+          {
+            cout << PHWHERE << " invalid energy dep " << hiter->second->get_edep()
+                 << " or path length: " << vdedx[i1] << endl;
+          }
+        }
+        vphi.clear();
+        veta.clear();
+
+      }  // end loop over g4hits
+
+      int numcells = 0;
+
+      for (it = cellptmap.begin(); it != cellptmap.end(); ++it)
+      {
+        cells->AddCell(it->second);
+        numcells++;
+        if (Verbosity() > 1)
+        {
+          cout << "Adding cell in bin phi: " << PHG4CellDefs::EtaPhiBinning::get_phibin(it->second->get_cellid())
+               << " phi: " << geo->get_phicenter(PHG4CellDefs::EtaPhiBinning::get_phibin(it->second->get_cellid())) * 180. / M_PI
+               << ", eta bin: " << PHG4CellDefs::EtaPhiBinning::get_etabin(it->second->get_cellid())
+               << ", eta: " << geo->get_etacenter(PHG4CellDefs::EtaPhiBinning::get_etabin(it->second->get_cellid()))
+               << ", energy dep: " << it->second->get_edep()
+               << endl;
+        }
+      }
+
+      if (Verbosity() > 0)
+      {
+        cout << Name() << ": found " << numcells << " eta/phi cells with energy deposition" << endl;
+      }
+    }
+
+    else  // ------ size binning ---------------------------------------------------------------
+    {
+      sizeiter = cell_size.find(*layer);
+      if (sizeiter == cell_size.end())
+      {
+        cout << "logical screwup!!! no sizes for layer " << *layer << endl;
+        exit(1);
+      }
+      double zstepsize = (sizeiter->second).second;
+      double phistepsize = phistep[*layer];
+
+      for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; hiter++)
+      {
+        sum_energy_before_cuts += hiter->second->get_edep();
+        // checking ADC timing integration window cut
+        if (hiter->second->get_t(0) > tmin_max[*layer].second) continue;
+        if (hiter->second->get_t(1) < tmin_max[*layer].first) continue;
+
+        double xinout[2];
+        double yinout[2];
+        double px[2];
+        double py[2];
+        double phi[2];
+        double z[2];
+        double phibin[2];
+        double zbin[2];
+        if (Verbosity() > 0) cout << "--------- new hit in layer # " << *layer << endl;
+
+        for (int i = 0; i < 2; i++)
+        {
+          xinout[i] = hiter->second->get_x(i);
+          yinout[i] = hiter->second->get_y(i);
+          px[i] = hiter->second->get_px(i);
+          py[i] = hiter->second->get_py(i);
+          phi[i] = atan2(hiter->second->get_y(i), hiter->second->get_x(i));
+          z[i] = hiter->second->get_z(i);
+          phibin[i] = geo->get_phibin(phi[i]);
+          zbin[i] = geo->get_zbin(hiter->second->get_z(i));
+
+          if (Verbosity() > 0) cout << " " << i << "  phibin: " << phibin[i] << ", phi: " << phi[i] << ", stepsize: " << phistepsize << endl;
+          if (Verbosity() > 0) cout << " " << i << "  zbin: " << zbin[i] << ", z = " << hiter->second->get_z(i) << ", stepsize: " << zstepsize << " offset: " << zmin_max[*layer].first << endl;
+        }
+        // check bin range
+        if (phibin[0] < 0 || phibin[0] >= nphibins || phibin[1] < 0 || phibin[1] >= nphibins)
+        {
+          continue;
+        }
+        if (zbin[0] < 0 || zbin[0] >= nzbins || zbin[1] < 0 || zbin[1] >= nzbins)
+        {
+          continue;
+        }
+
+        if (zbin[0] < 0)
+        {
+          hiter->second->identify();
+          continue;
+        }
+        sum_energy_g4hit += hiter->second->get_edep();
+
+        int intphibin = phibin[0];
+        int intzbin = zbin[0];
+        int intphibinout = phibin[1];
+        int intzbinout = zbin[1];
+
+        if (Verbosity() > 0)
+        {
+          cout << "    phi bin range: " << intphibin << " to " << intphibinout << " phi: " << phi[0] << " to " << phi[1] << endl;
+          cout << "    Z bin range: " << intzbin << " to " << intzbinout << " Z: " << z[0] << " to " << z[1] << endl;
+          cout << "    phi difference: " << (phi[1] - phi[0]) * 1000. << " milliradians." << endl;
+          cout << "    phi difference: " << 2.5 * (phi[1] - phi[0]) * 10000. << " microns." << endl;
+          cout << "    path length = " << sqrt((xinout[1] - xinout[0]) * (xinout[1] - xinout[0]) + (yinout[1] - yinout[0]) * (yinout[1] - yinout[0])) << endl;
+          cout << "       px = " << px[0] << " " << px[1] << endl;
+          cout << "       py = " << py[0] << " " << py[1] << endl;
+          cout << "       x = " << xinout[0] << " " << xinout[1] << endl;
+          cout << "       y = " << yinout[0] << " " << yinout[1] << endl;
+        }
+
+        // Determine all fired cells
+
+        double ax = phi[0];
+        double ay = z[0];
+        double bx = phi[1];
+        double by = z[1];
+        if (intphibin > intphibinout)
+        {
+          int tmp = intphibin;
+          intphibin = intphibinout;
+          intphibinout = tmp;
+        }
+        if (intzbin > intzbinout)
+        {
+          int tmp = intzbin;
+          intzbin = intzbinout;
+          intzbinout = tmp;
+        }
+
+        double trklen = sqrt((ax - bx) * (ax - bx) + (ay - by) * (ay - by));
+        // if entry and exit hit are the same (seems to happen rarely), trklen = 0
+        // which leads to a 0/0 and an NaN in edep later on
+        // this code does for particles in the same cell a trklen/trklen (vdedx[ii]/trklen)
+        // so setting this to any non zero number will do just fine
+        // I just pick -1 here to flag those strange hits in case I want to analyze them
+        // later on
+        if (trklen == 0)
+        {
+          trklen = -1.;
+        }
+        vector<int> vphi;
+        vector<int> vz;
+        vector<double> vdedx;
+
+        if (intphibin == intphibinout && intzbin == intzbinout)  // single cell fired
+        {
+          if (Verbosity() > 0)
+          {
+            cout << "SINGLE CELL FIRED: " << intphibin << " " << intzbin << endl;
+          }
+          vphi.push_back(intphibin);
+          vz.push_back(intzbin);
+          vdedx.push_back(trklen);
+        }
+        else
+        {
+          double phistep_half = geo->get_phistep() / 2.;
+          double zstep_half = geo->get_zstep() / 2.;
+          for (int ibp = intphibin; ibp <= intphibinout; ibp++)
+          {
+            double cx = geo->get_phicenter(ibp) - phistep_half;
+            double dx = geo->get_phicenter(ibp) + phistep_half;
+            for (int ibz = intzbin; ibz <= intzbinout; ibz++)
+            {
+              double cy = geo->get_zcenter(ibz) - zstep_half;
+              double dy = geo->get_zcenter(ibz) + zstep_half;
+              //cout << "##### line: " << ax << " " << ay << " " << bx << " " << by << endl;
+              //cout << "####### cell: " << cx << " " << cy << " " << dx << " " << dy << endl;
+              pair<bool, double> intersect = PHG4Utils::line_and_rectangle_intersect(ax, ay, bx, by, cx, cy, dx, dy);
+              if (intersect.first)
+              {
+                if (Verbosity() > 0) cout << "CELL FIRED: " << ibp << " " << ibz << " " << intersect.second << endl;
+                vphi.push_back(ibp);
+                vz.push_back(ibz);
+                vdedx.push_back(intersect.second);
+              }
+            }
+          }
+        }
+        if (Verbosity() > 0) cout << "NUMBER OF FIRED CELLS = " << vz.size() << endl;
+
+        double tmpsum = 0.;
+        for (unsigned int ii = 0; ii < vz.size(); ii++)
+        {
+          tmpsum += vdedx[ii];
+          vdedx[ii] = vdedx[ii] / trklen;
+          if (Verbosity() > 0) cout << "  CELL " << ii << "  dE/dX = " << vdedx[ii] << endl;
+        }
+        if (Verbosity() > 0) cout << "    TOTAL TRACK LENGTH = " << tmpsum << " " << trklen << endl;
+
+        for (unsigned int i1 = 0; i1 < vphi.size(); i1++)  // loop over all fired cells
+        {
+          int iphibin = vphi[i1];
+          int izbin = vz[i1];
+
+          unsigned long long tmp = iphibin;
+          unsigned long long key = tmp << 32;
+          key += izbin;
+          if (Verbosity() > 1)
+          {
+            cout << " iphibin " << iphibin << " izbin " << izbin << " key 0x" << hex << key << dec << endl;
+          }
+          // check to see if there is already an entry for this cell
+          PHG4Cell *cell = nullptr;
+          it = cellptmap.find(key);
+
+          if (it != cellptmap.end())
+          {
+            cell = it->second;
+            if (Verbosity() > 1)
+            {
+              cout << "  add energy to existing cell for key = " << cellptmap.find(key)->first << endl;
+            }
+
+            if (Verbosity() > 1 && hiter->second->has_property(PHG4Hit::prop_light_yield) && std::isnan(hiter->second->get_light_yield() * vdedx[i1]))
+            {
+              cout << "    NAN lighy yield with vdedx[i1] = " << vdedx[i1]
+                   << " and hiter->second->get_light_yield() = " << hiter->second->get_light_yield() << endl;
+            }
+          }
+          else
+          {
+            if (Verbosity() > 1)
+            {
+              cout << "    did not find a previous entry for key = " << key << " create a new one" << endl;
+            }
+            PHG4CellDefs::keytype cellkey = PHG4CellDefs::SizeBinning::genkey(*layer, izbin, iphibin);
+            cell = new PHG4Cellv1(cellkey);
+            cellptmap[key] = cell;
+          }
+          if (!isfinite(hiter->second->get_edep() * vdedx[i1]))
+          {
+            cout << "hit 0x" << hex << hiter->first << dec << " not finite, edep: "
+                 << hiter->second->get_edep() << " weight " << vdedx[i1] << endl;
+          }
+          cell->add_edep(hiter->first, hiter->second->get_edep() * vdedx[i1]);
+          cell->add_edep(hiter->second->get_edep() * vdedx[i1]);  // add edep to cell
+          if (hiter->second->has_property(PHG4Hit::prop_light_yield))
+          {
+            cell->add_light_yield(hiter->second->get_light_yield() * vdedx[i1]);
+            if (Verbosity() > 1 && !std::isfinite(hiter->second->get_light_yield() * vdedx[i1]))
+            {
+              cout << "    NAN lighy yield with vdedx[i1] = " << vdedx[i1]
+                   << " and hiter->second->get_light_yield() = " << hiter->second->get_light_yield() << endl;
+            }
+          }
+          cell->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep() * vdedx[i1]);
+        }
+        vphi.clear();
+        vz.clear();
+
+      }  // end loop over hits
+
+      int numcells = 0;
+
+      for (it = cellptmap.begin(); it != cellptmap.end(); ++it)
+      {
+        cells->AddCell(it->second);
+        numcells++;
+        if (Verbosity() > 1)
+        {
+          cout << "Adding cell for key " << it->first << " in bin phi: " << PHG4CellDefs::SizeBinning::get_phibin(it->second->get_cellid())
+               << " phi: " << geo->get_phicenter(PHG4CellDefs::SizeBinning::get_phibin(it->second->get_cellid())) * 180. / M_PI
+               << ", z bin: " << PHG4CellDefs::SizeBinning::get_zbin(it->second->get_cellid())
+               << ", z: " << geo->get_zcenter(PHG4CellDefs::SizeBinning::get_zbin(it->second->get_cellid()))
+               << ", energy dep: " << it->second->get_edep()
+               << endl;
+        }
+      }
+
+      if (Verbosity() > 0)
+      {
+        cout << "found " << numcells << " z/phi cells with energy deposition" << endl;
+      }
+    }
+
+    //==========================================================
+    // now reset the cell map before moving on to the next layer
+    if (Verbosity() > 1)
+    {
+      cout << "cellptmap for layer " << *layer << " has final length " << cellptmap.size();
+    }
+    while (cellptmap.begin() != cellptmap.end())
+    {
+      // Assumes that memmory is freed by the cylinder cell container when it is destroyed
+      cellptmap.erase(cellptmap.begin());
+    }
+    if (Verbosity() > 1)
+    {
+      cout << " reset it to " << cellptmap.size() << endl;
+    }
+  }
   if (chkenergyconservation)
-    {
-      CheckEnergy(topNode);
-    }
+  {
+    CheckEnergy(topNode);
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void
-PHG4CylinderCellReco::cellsize(const int detid, const double sr, const double sz)
+void PHG4CylinderCellReco::cellsize(const int detid, const double sr, const double sz)
 {
   if (binning.find(detid) != binning.end())
-    {
-      cout << "size for layer " << detid << " already set" << endl;
-      return;
-    }
+  {
+    cout << "size for layer " << detid << " already set" << endl;
+    return;
+  }
   binning[detid] = PHG4CellDefs::sizebinning;
-  set_double_param(detid,"size_long",sz);
-  set_double_param(detid,"size_perp",sr);
+  set_double_param(detid, "size_long", sz);
+  set_double_param(detid, "size_perp", sr);
 }
 
-void
-PHG4CylinderCellReco::etaphisize(const int detid, const double deltaeta, const double deltaphi)
+void PHG4CylinderCellReco::etaphisize(const int detid, const double deltaeta, const double deltaphi)
 {
   if (binning.find(detid) != binning.end())
-    {
-      cout << "size for layer " << detid << " already set" << endl;
-      return;
-    }
+  {
+    cout << "size for layer " << detid << " already set" << endl;
+    return;
+  }
   binning[detid] = PHG4CellDefs::etaphibinning;
-  set_double_param(detid,"size_long",deltaeta);
-  set_double_param(detid,"size_perp",deltaphi);
+  set_double_param(detid, "size_long", deltaeta);
+  set_double_param(detid, "size_perp", deltaphi);
   return;
 }
 
-void
-PHG4CylinderCellReco::set_size(const int i, const double sizeA, const double sizeB)
+void PHG4CylinderCellReco::set_size(const int i, const double sizeA, const double sizeB)
 {
   cell_size[i] = std::make_pair(sizeA, sizeB);
   return;
 }
 
-void
-PHG4CylinderCellReco::set_timing_window(const int detid, const double tmin, const double tmax)
+void PHG4CylinderCellReco::set_timing_window(const int detid, const double tmin, const double tmax)
 {
-  set_double_param(detid,"tmin",tmin);
-  set_double_param(detid,"tmax",tmax);
+  set_double_param(detid, "tmin", tmin);
+  set_double_param(detid, "tmax", tmax);
   return;
 }
 
-int
-PHG4CylinderCellReco::CheckEnergy(PHCompositeNode *topNode)
+int PHG4CylinderCellReco::CheckEnergy(PHCompositeNode *topNode)
 {
   PHG4CellContainer *cells = findNode::getClass<PHG4CellContainer>(topNode, cellnodename);
   double sum_energy_cells = 0.;
@@ -899,85 +883,83 @@ PHG4CylinderCellReco::CheckEnergy(PHCompositeNode *topNode)
   PHG4CellContainer::ConstRange cell_begin_end = cells->getCells();
   PHG4CellContainer::ConstIterator citer;
   for (citer = cell_begin_end.first; citer != cell_begin_end.second; ++citer)
+  {
+    sum_energy_cells += citer->second->get_edep();
+    PHG4Cell::EdepConstRange cellrange = citer->second->get_g4hits();
+    for (PHG4Cell::EdepConstIterator iter = cellrange.first; iter != cellrange.second; ++iter)
     {
-      sum_energy_cells += citer->second->get_edep();
-      PHG4Cell::EdepConstRange cellrange = citer->second->get_g4hits();
-      for (PHG4Cell::EdepConstIterator iter = cellrange.first; iter != cellrange.second; ++iter)
-	{
-	  sum_energy_stored_hits += iter->second;
-	}
-      PHG4Cell::ShowerEdepConstRange shwrrange = citer->second->get_g4showers();
-      for (PHG4Cell::ShowerEdepConstIterator iter = shwrrange.first; iter != shwrrange.second; ++iter)
-	{
-	  sum_energy_stored_showers += iter->second;
-	}
+      sum_energy_stored_hits += iter->second;
     }
+    PHG4Cell::ShowerEdepConstRange shwrrange = citer->second->get_g4showers();
+    for (PHG4Cell::ShowerEdepConstIterator iter = shwrrange.first; iter != shwrrange.second; ++iter)
+    {
+      sum_energy_stored_showers += iter->second;
+    }
+  }
   // the fractional eloss for particles traversing eta bins leads to minute rounding errors
   if (sum_energy_stored_hits > 0)
+  {
+    if (fabs(sum_energy_cells - sum_energy_stored_hits) / sum_energy_cells > 1e-6)
     {
-      if (fabs(sum_energy_cells-sum_energy_stored_hits)/sum_energy_cells > 1e-6)
-	{
-	  cout << "energy mismatch between cell energy " << sum_energy_cells
-	       << " and stored hit energies " << sum_energy_stored_hits
-	       << endl;
-	}
+      cout << "energy mismatch between cell energy " << sum_energy_cells
+           << " and stored hit energies " << sum_energy_stored_hits
+           << endl;
     }
+  }
   if (sum_energy_stored_showers > 0)
+  {
+    if (fabs(sum_energy_cells - sum_energy_stored_showers) / sum_energy_cells > 1e-6)
     {
-      if (fabs(sum_energy_cells-sum_energy_stored_showers)/sum_energy_cells > 1e-6)
-	{
-	  cout << "energy mismatch between cell energy " << sum_energy_cells
-	       << " and stored shower energies " << sum_energy_stored_showers
-	       << endl;
-	}
+      cout << "energy mismatch between cell energy " << sum_energy_cells
+           << " and stored shower energies " << sum_energy_stored_showers
+           << endl;
     }
+  }
   if (fabs(sum_energy_cells - sum_energy_g4hit) / sum_energy_g4hit > 1e-6)
-    {
-      cout << "energy mismatch between cells: " << sum_energy_cells
-	   << " and hits: " << sum_energy_g4hit
-	   << " diff sum(cells) - sum(hits): " << sum_energy_cells - sum_energy_g4hit
-	   << " cut val " << fabs(sum_energy_cells - sum_energy_g4hit) / sum_energy_g4hit
-	   << endl;
-	  cout << Name() << ":total energy for this event: " << sum_energy_g4hit << " GeV" << endl;
-	  cout << Name() << ": sum cell energy: " << sum_energy_cells << " GeV" << endl;
-	  cout << Name() << ": sum shower energy: " << sum_energy_stored_showers << " GeV" << endl;
-	  cout << Name() << ": sum stored hit energy: " << sum_energy_stored_hits << " GeV" << endl;
-	  cout << Name() << ": hit energy before cuts: " <<sum_energy_before_cuts  << " GeV" << endl;
-      return -1;
-    }
+  {
+    cout << "energy mismatch between cells: " << sum_energy_cells
+         << " and hits: " << sum_energy_g4hit
+         << " diff sum(cells) - sum(hits): " << sum_energy_cells - sum_energy_g4hit
+         << " cut val " << fabs(sum_energy_cells - sum_energy_g4hit) / sum_energy_g4hit
+         << endl;
+    cout << Name() << ":total energy for this event: " << sum_energy_g4hit << " GeV" << endl;
+    cout << Name() << ": sum cell energy: " << sum_energy_cells << " GeV" << endl;
+    cout << Name() << ": sum shower energy: " << sum_energy_stored_showers << " GeV" << endl;
+    cout << Name() << ": sum stored hit energy: " << sum_energy_stored_hits << " GeV" << endl;
+    cout << Name() << ": hit energy before cuts: " << sum_energy_before_cuts << " GeV" << endl;
+    return -1;
+  }
   else
+  {
+    if (Verbosity() > 0)
     {
-      if (Verbosity() > 0)
-	{
-	  cout << Name() << ":total energy for this event: " << sum_energy_g4hit << " GeV" << endl;
-	  cout << Name() << ": sum cell energy: " << sum_energy_cells << " GeV" << endl;
-	  cout << Name() << ": sum shower energy: " << sum_energy_stored_showers << " GeV" << endl;
-	  cout << Name() << ": sum stored hit energy: " << sum_energy_stored_hits << " GeV" << endl;
-	  cout << Name() << ": hit energy before cuts: " <<sum_energy_before_cuts  << " GeV" << endl;
-	}
+      cout << Name() << ":total energy for this event: " << sum_energy_g4hit << " GeV" << endl;
+      cout << Name() << ": sum cell energy: " << sum_energy_cells << " GeV" << endl;
+      cout << Name() << ": sum shower energy: " << sum_energy_stored_showers << " GeV" << endl;
+      cout << Name() << ": sum stored hit energy: " << sum_energy_stored_hits << " GeV" << endl;
+      cout << Name() << ": hit energy before cuts: " << sum_energy_before_cuts << " GeV" << endl;
     }
+  }
   return 0;
 }
 
-void
-PHG4CylinderCellReco::Detector(const std::string &d)
+void PHG4CylinderCellReco::Detector(const std::string &d)
 {
   detector = d;
   // only set the outdetector nodename if it wasn't set already
   // in case the order in the macro is outdetector(); detector();
   if (outdetector.size() == 0)
-    {
-      OutputDetector(d);
-    }
+  {
+    OutputDetector(d);
+  }
   return;
 }
 
-void
-PHG4CylinderCellReco::SetDefaultParameters()
+void PHG4CylinderCellReco::SetDefaultParameters()
 {
-  set_default_double_param("size_long",NAN);
-  set_default_double_param("size_perp",NAN);
-  set_default_double_param("tmax",60.0);
-  set_default_double_param("tmin",-20.0); // collision has a timing spread around the triggered event. Accepting negative time too.
+  set_default_double_param("size_long", NAN);
+  set_default_double_param("size_perp", NAN);
+  set_default_double_param("tmax", 60.0);
+  set_default_double_param("tmin", -20.0);  // collision has a timing spread around the triggered event. Accepting negative time too.
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
@@ -47,10 +47,6 @@ class PHG4CylinderCellReco : public SubsysReco, public PHParameterContainerInter
  protected:
   void set_size(const int i, const double sizeA, const double sizeB);
   int CheckEnergy(PHCompositeNode *topNode);
-  static std::pair<double, double> get_etaphi(const double x, const double y, const double z);
-  static double get_eta(const double radius, const double z);
-  bool lines_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy, double* rx, double* ry);
-  bool line_and_rectangle_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy, double* rr);
 
   std::map<int, int>  binning;
   std::map<int, std::pair <double,double> > cell_size; // cell size in phi/z

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
@@ -3,7 +3,6 @@
 #ifndef G4DETECTORS_PHG4CYLINDERCELLRECO_H
 #define G4DETECTORS_PHG4CYLINDERCELLRECO_H
 
-
 #include <phparameter/PHParameterContainerInterface.h>
 
 #include <fun4all/SubsysReco.h>
@@ -11,7 +10,7 @@
 #include <map>
 #include <set>
 #include <string>
-#include <utility>                                      // for pair
+#include <utility>  // for pair
 
 class PHCompositeNode;
 class PHG4Cell;
@@ -19,15 +18,14 @@ class PHG4Cell;
 class PHG4CylinderCellReco : public SubsysReco, public PHParameterContainerInterface
 {
  public:
-
   explicit PHG4CylinderCellReco(const std::string &name = "CYLINDERRECO");
 
-  virtual ~PHG4CylinderCellReco(){}
-  
+  virtual ~PHG4CylinderCellReco() {}
+
   //! module initialization
   int InitRun(PHCompositeNode *topNode);
-  
-    //! event processing
+
+  //! event processing
   int process_event(PHCompositeNode *topNode);
 
   int ResetEvent(PHCompositeNode *topNode);
@@ -37,20 +35,20 @@ class PHG4CylinderCellReco : public SubsysReco, public PHParameterContainerInter
   void Detector(const std::string &d);
   void cellsize(const int i, const double sr, const double sz);
   void etaphisize(const int i, const double deltaeta, const double deltaphi);
-  void checkenergy(const int i=1) {chkenergyconservation = i;}
-  void OutputDetector(const std::string &d) {outdetector = d;}
+  void checkenergy(const int i = 1) { chkenergyconservation = i; }
+  void OutputDetector(const std::string &d) { outdetector = d; }
 
-  double get_timing_window_min(const int i) {return tmin_max[i].first;}
-  double get_timing_window_max(const int i) {return tmin_max[i].second;}
-  void   set_timing_window(const int detid, const double tmin, const double tmax);
+  double get_timing_window_min(const int i) { return tmin_max[i].first; }
+  double get_timing_window_max(const int i) { return tmin_max[i].second; }
+  void set_timing_window(const int detid, const double tmin, const double tmax);
 
  protected:
   void set_size(const int i, const double sizeA, const double sizeB);
   int CheckEnergy(PHCompositeNode *topNode);
 
-  std::map<int, int>  binning;
-  std::map<int, std::pair <double,double> > cell_size; // cell size in phi/z
-  std::map<int, std::pair <double,double> > zmin_max; // zmin/zmax for each layer for faster lookup
+  std::map<int, int> binning;
+  std::map<int, std::pair<double, double> > cell_size;  // cell size in phi/z
+  std::map<int, std::pair<double, double> > zmin_max;   // zmin/zmax for each layer for faster lookup
   std::map<int, double> phistep;
   std::map<int, double> etastep;
   std::set<int> implemented_detid;
@@ -61,9 +59,9 @@ class PHG4CylinderCellReco : public SubsysReco, public PHParameterContainerInter
   std::string geonodename;
   std::string seggeonodename;
   std::map<int, std::pair<int, int> > n_phi_z_bins;
-  std::map<unsigned long long, PHG4Cell*> cellptmap;  // This map holds the hit cells
-  std::map<unsigned long long, PHG4Cell*>::iterator it;
-  std::map<int, std::pair<double,double> > tmin_max;
+  std::map<unsigned long long, PHG4Cell *> cellptmap;  // This map holds the hit cells
+  std::map<unsigned long long, PHG4Cell *>::iterator it;
+  std::map<int, std::pair<double, double> > tmin_max;
 
   int nbins[2];
   int chkenergyconservation;

--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
@@ -2,16 +2,16 @@
 
 #include <intt/CylinderGeomIntt.h>
 
-#include <g4detectors/PHG4CylinderGeom.h>           // for PHG4CylinderGeom
+#include <g4detectors/PHG4CylinderGeom.h>  // for PHG4CylinderGeom
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
 #include <trackbase/TrkrDefs.h>
-#include <trackbase/TrkrHit.h>                      // for TrkrHit
+#include <trackbase/TrkrHit.h>  // for TrkrHit
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
 
-#include <phparameter/PHParameterInterface.h>       // for PHParameterInterface
+#include <phparameter/PHParameterInterface.h>  // for PHParameterInterface
 
 #include <intt/InttDefs.h>
 #include <intt/InttHit.h>
@@ -21,25 +21,25 @@
 #include <g4main/PHG4Utils.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                     // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                           // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>                         // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>                            // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <TSystem.h>
 
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
-#include <map>                                      // for _Rb_tree_const_it...
-#include <memory>                                   // for allocator_traits<...
-#include <utility>                                  // for pair, swap, make_...
-#include <vector>                                   // for vector
+#include <map>      // for _Rb_tree_const_it...
+#include <memory>   // for allocator_traits<...
+#include <utility>  // for pair, swap, make_...
+#include <vector>   // for vector
 
 using namespace std;
 
@@ -115,39 +115,39 @@ int PHG4InttHitReco::InitRun(PHCompositeNode *topNode)
     exit(1);
   }
 
-TrkrHitSetContainer *hitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if(!hitsetcontainer)
-    {
-      PHNodeIterator dstiter(dstNode);
-      PHCompositeNode *DetNode =
+  TrkrHitSetContainer *hitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
+  if (!hitsetcontainer)
+  {
+    PHNodeIterator dstiter(dstNode);
+    PHCompositeNode *DetNode =
         dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
-      if (!DetNode)
-	{
-	  DetNode = new PHCompositeNode("TRKR");
-	  dstNode->addNode(DetNode);
-	}
-
-      hitsetcontainer = new TrkrHitSetContainer();
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hitsetcontainer, "TRKR_HITSET", "PHObject");
-      DetNode->addNode(newNode);
+    if (!DetNode)
+    {
+      DetNode = new PHCompositeNode("TRKR");
+      dstNode->addNode(DetNode);
     }
 
- TrkrHitTruthAssoc *hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode,"TRKR_HITTRUTHASSOC");
-  if(!hittruthassoc)
-    {
-      PHNodeIterator dstiter(dstNode);
-      PHCompositeNode *DetNode =
-        dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
-      if (!DetNode)
-	{
-	  DetNode = new PHCompositeNode("TRKR");
-	  dstNode->addNode(DetNode);
-	}
+    hitsetcontainer = new TrkrHitSetContainer();
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hitsetcontainer, "TRKR_HITSET", "PHObject");
+    DetNode->addNode(newNode);
+  }
 
-      hittruthassoc = new TrkrHitTruthAssoc();
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hittruthassoc, "TRKR_HITTRUTHASSOC", "PHObject");
-      DetNode->addNode(newNode);
+  TrkrHitTruthAssoc *hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
+  if (!hittruthassoc)
+  {
+    PHNodeIterator dstiter(dstNode);
+    PHCompositeNode *DetNode =
+        dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+    if (!DetNode)
+    {
+      DetNode = new PHCompositeNode("TRKR");
+      dstNode->addNode(DetNode);
     }
+
+    hittruthassoc = new TrkrHitTruthAssoc();
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hittruthassoc, "TRKR_HITTRUTHASSOC", "PHObject");
+    DetNode->addNode(newNode);
+  }
 
   PHG4CylinderGeomContainer *geo = findNode::getClass<PHG4CylinderGeomContainer>(topNode, m_GeoNodeName);
   if (!geo)
@@ -187,21 +187,21 @@ int PHG4InttHitReco::process_event(PHCompositeNode *topNode)
     exit(1);
   }
 
- // Get the TrkrHitSetContainer node
+  // Get the TrkrHitSetContainer node
   TrkrHitSetContainer *hitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if(!hitsetcontainer)
-    {
-      cout << "Could not locate TRKR_HITSET node, quit! " << endl;
-      exit(1);
-    }
+  if (!hitsetcontainer)
+  {
+    cout << "Could not locate TRKR_HITSET node, quit! " << endl;
+    exit(1);
+  }
 
   // Get the TrkrHitTruthAssoc node
   TrkrHitTruthAssoc *hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
-  if(!hittruthassoc)
-    {
-      cout << "Could not locate TRKR_HITTRUTHASSOC node, quit! " << endl;
-      exit(1);
-    }
+  if (!hittruthassoc)
+  {
+    cout << "Could not locate TRKR_HITTRUTHASSOC node, quit! " << endl;
+    exit(1);
+  }
 
   PHG4CylinderGeomContainer *geo = findNode::getClass<PHG4CylinderGeomContainer>(topNode, m_GeoNodeName);
   if (!geo)
@@ -390,40 +390,39 @@ int PHG4InttHitReco::process_event(PHCompositeNode *topNode)
       TrkrDefs::hitsetkey hitsetkey = InttDefs::genHitSetKey(sphxlayer, ladder_z_index, ladder_phi_index);
       // Use existing hitset or add new one if needed
       TrkrHitSetContainer::Iterator hitsetit = hitsetcontainer->findOrAddHitSet(hitsetkey);
-      
+
       // generate the key for this hit
       TrkrDefs::hitkey hitkey = InttDefs::genHitKey(vzbin[i1], vybin[i1]);
       // See if this hit already exists
       TrkrHit *hit = hitsetit->second->getHit(hitkey);
-      if(!hit)
-	{
-	  // Otherwise, create a new one
-	  hit = new InttHit();
-	  hitsetit->second->addHitSpecificKey(hitkey, hit);
-	}
-      
+      if (!hit)
+      {
+        // Otherwise, create a new one
+        hit = new InttHit();
+        hitsetit->second->addHitSpecificKey(hitkey, hit);
+      }
+
       // Either way, add the energy to it
-      if(Verbosity() > 2) 
-	cout << "add energy " << venergy[i1].first << " to intthit " << endl;
+      if (Verbosity() > 2)
+        cout << "add energy " << venergy[i1].first << " to intthit " << endl;
       hit->addEnergy(venergy[i1].first);
 
       // Add this hit to the association map
       hittruthassoc->addAssoc(hitsetkey, hitkey, hiter->first);
 
-      if(Verbosity() > 2)
-	cout << "PHG4InttHitReco: added hit wirh hitsetkey " << hitsetkey << " hitkey " << hitkey << " g4hitkey " << hiter->first << endl;      
+      if (Verbosity() > 2)
+        cout << "PHG4InttHitReco: added hit wirh hitsetkey " << hitsetkey << " hitkey " << hitkey << " g4hitkey " << hiter->first << endl;
     }
 
   }  // end loop over g4hits
 
-
   // print the list of entries in the association table
-  if(Verbosity() > 0)
-    {
-      cout << "From PHG4InttHitReco: " << endl;
-      hitsetcontainer->identify();
-      hittruthassoc->identify();
-    }
+  if (Verbosity() > 0)
+  {
+    cout << "From PHG4InttHitReco: " << endl;
+    hitsetcontainer->identify();
+    hittruthassoc->identify();
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.h
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.h
@@ -8,7 +8,7 @@
 #include <fun4all/SubsysReco.h>
 
 #if !defined(__CINT__) || defined(__CLING__)
-#include <gsl/gsl_vector.h>             // for gsl_vector
+#include <gsl/gsl_vector.h>  // for gsl_vector
 #endif
 
 #include <string>

--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.h
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.h
@@ -31,19 +31,12 @@ class PHG4InttHitReco : public SubsysReco, public PHParameterInterface
   void SetDefaultParameters();
 
   void Detector(const std::string &d) { m_Detector = d; }
-  void checkenergy(const int i = 1) { m_ChkEnergyConservationFlag = i; }
-
-  double circle_rectangle_intersection(double x1, double y1, double x2, double y2, double mx, double my, double r) const;
-  double sA(double r, double x, double y) const;
 
  protected:
-  int CheckEnergy(PHCompositeNode *topNode);
   std::string m_Detector;
   std::string m_HitNodeName;
   std::string m_CellNodeName;
   std::string m_GeoNodeName;
-
-  int m_ChkEnergyConservationFlag;
 
   double m_Tmin;
   double m_Tmax;

--- a/simulation/g4simulation/g4main/PHG4Utils.cc
+++ b/simulation/g4simulation/g4main/PHG4Utils.cc
@@ -323,3 +323,70 @@ std::pair<bool, double> PHG4Utils::line_and_rectangle_intersect(
     }
   return make_pair(false,NAN);
 }
+
+double PHG4Utils::sA(double r, double x, double y)
+{
+  // Uses analytic formula for the integral of a circle between limits set by the corner of a rectangle
+  // It is called repeatedly to find the overlap area between the circle and rectangle
+  // I found this code implementing the integral on a web forum called "ars technica",
+  // https://arstechnica.com/civis/viewtopic.php?t=306492
+  // posted by "memp"
+
+  double a;
+
+  if (x < 0)
+  {
+    return -sA(r, -x, y);
+  }
+
+  if (y < 0)
+  {
+    return -sA(r, x, -y);
+  }
+
+  if (x > r)
+  {
+    x = r;
+  }
+
+  if (y > r)
+  {
+    y = r;
+  }
+
+  if (x * x + y * y > r * r)
+  {
+    a = r * r * asin(x / r) + x * sqrt(r * r - x * x) + r * r * asin(y / r) + y * sqrt(r * r - y * y) - r * r * M_PI_2;
+
+    a *= 0.5;
+  }
+  else
+  {
+    a = x * y;
+  }
+
+  return a;
+}
+
+double PHG4Utils::circle_rectangle_intersection(double x1, double y1, double x2, double y2, double mx, double my, double r)
+{
+  // Find the area of overlap of a circle and rectangle
+  // Calls sA, which uses an analytic formula to determine the integral of the circle between limits set by the corners of the rectangle
+
+  // move the rectangle to the frame where the circle is at (0,0)
+  x1 -= mx;
+  x2 -= mx;
+  y1 -= my;
+  y2 -= my;
+
+  // {
+  //   cout << " mx " << mx << " my " << my << " r " << r << " x1 " << x1 << " x2 " << x2 << " y1 " << y1 << " y2 " << y2 << endl;
+  //   cout << " sA21 " << sA(r, x2, y1)
+  //        << " sA11 " << sA(r, x1, y1)
+  //        << " sA22 " << sA(r, x2, y2)
+  //        << " sA12 " << sA(r, x1, y2)
+  //        << endl;
+  // }
+
+  return sA(r, x2, y1) - sA(r, x1, y1) - sA(r, x2, y2) + sA(r, x1, y2);
+}

--- a/simulation/g4simulation/g4main/PHG4Utils.cc
+++ b/simulation/g4simulation/g4main/PHG4Utils.cc
@@ -1,11 +1,11 @@
 #include "PHG4Utils.h"
 
 #include <phool/phool.h>
-#include <Geant4/G4Colour.hh>          // for G4Colour
+#include <Geant4/G4Colour.hh>  // for G4Colour
 #include <Geant4/G4VisAttributes.hh>
 
 #include <cmath>
-#include <iostream>                    // for operator<<, endl, basic_ostream
+#include <iostream>  // for operator<<, endl, basic_ostream
 
 using namespace std;
 
@@ -172,18 +172,16 @@ void PHG4Utils::SetColour(G4VisAttributes* att, const string& material)
   return;
 }
 // returns success/failure and intersection point (x/y)
-std::pair<bool,std::pair<double,double>> PHG4Utils::lines_intersect(
-					   double ax,
-					   double ay,
-					   double bx,
-					   double by,
-					   double cx,
-					   double cy,
-					   double dx,
-					   double dy
-					   )
+std::pair<bool, std::pair<double, double>> PHG4Utils::lines_intersect(
+    double ax,
+    double ay,
+    double bx,
+    double by,
+    double cx,
+    double cy,
+    double dx,
+    double dy)
 {
-
   // Find if a line segment limited by points A and B
   // intersects line segment limited by points C and D.
   // First check if an infinite line defined by A and B intersects
@@ -191,58 +189,56 @@ std::pair<bool,std::pair<double,double>> PHG4Utils::lines_intersect(
   // Then check in intersection point is between C and D
   double rx = NAN;
   double ry = NAN;
-  double ex = bx - ax; // E=B-A
+  double ex = bx - ax;  // E=B-A
   double ey = by - ay;
-  double fx = dx - cx; // F=D-C
+  double fx = dx - cx;  // F=D-C
   double fy = dy - cy;
-  double px = -ey;     // P
+  double px = -ey;  // P
   double py = ex;
 
-  double bottom = fx * px + fy * py; // F*P
-  double gx = ax - cx; // A-C
+  double bottom = fx * px + fy * py;  // F*P
+  double gx = ax - cx;                // A-C
   double gy = ay - cy;
-  double top = gx * px + gy * py; // G*P
+  double top = gx * px + gy * py;  // G*P
 
   double h = 99999.;
   if (bottom != 0.)
-    {
-      h = top / bottom;
-    }
+  {
+    h = top / bottom;
+  }
 
   //intersection point R = C + F*h
   if (h > 0. && h < 1.)
+  {
+    rx = cx + fx * h;
+    ry = cy + fy * h;
+    //cout << "      line/segment intersection coordinates: " << *rx << " " << *ry << endl;
+    if ((rx > ax && rx > bx) || (rx < ax && rx < bx) || (ry < ay && ry < by) || (ry > ay && ry > by))
     {
-      rx = cx + fx * h;
-      ry = cy + fy * h;
-      //cout << "      line/segment intersection coordinates: " << *rx << " " << *ry << endl;
-      if ((rx > ax && rx > bx) || (rx < ax && rx < bx) || (ry < ay && ry < by) || (ry > ay && ry > by))
-	{
-	  //cout << "       NO segment/segment intersection!" << endl;
-	  return make_pair(false,make_pair(NAN,NAN));
-	}
-      else
-	{
-	  //cout << "       segment/segment intersection!" << endl;
-	  return make_pair(true,make_pair(rx,ry));
-	}
+      //cout << "       NO segment/segment intersection!" << endl;
+      return make_pair(false, make_pair(NAN, NAN));
     }
+    else
+    {
+      //cout << "       segment/segment intersection!" << endl;
+      return make_pair(true, make_pair(rx, ry));
+    }
+  }
 
-  return make_pair(false,make_pair(NAN,NAN));
+  return make_pair(false, make_pair(NAN, NAN));
 }
 
 // returns success/failure and length of the line segment inside the rectangle (output)
 std::pair<bool, double> PHG4Utils::line_and_rectangle_intersect(
-							 double ax,
-							 double ay,
-							 double bx,
-							 double by,
-							 double cx,
-							 double cy,
-							 double dx,
-							 double dy
-							 )
+    double ax,
+    double ay,
+    double bx,
+    double by,
+    double cx,
+    double cy,
+    double dx,
+    double dy)
 {
-
   // find if a line isegment limited by points (A,B)
   // intersects with a rectangle defined by two
   // corner points (C,D) two other points are E and F
@@ -252,10 +248,10 @@ std::pair<bool, double> PHG4Utils::line_and_rectangle_intersect(
   //   C--------F
 
   if (cx > dx || cy > dy)
-    {
-      cout << PHWHERE << "ERROR: Bad rectangle definition!" << endl;
-      return make_pair(false,NAN);
-    }
+  {
+    cout << PHWHERE << "ERROR: Bad rectangle definition!" << endl;
+    return make_pair(false, NAN);
+  }
 
   double ex = cx;
   double ey = dy;
@@ -264,64 +260,64 @@ std::pair<bool, double> PHG4Utils::line_and_rectangle_intersect(
 
   vector<double> vx;
   vector<double> vy;
-  pair<bool,pair<double,double>> intersect1 = lines_intersect(ax, ay, bx, by, cx, cy, fx, fy);
-//  bool i1 = lines_intersect(ax, ay, bx, by, cx, cy, fx, fy, &rx, &ry);
+  pair<bool, pair<double, double>> intersect1 = lines_intersect(ax, ay, bx, by, cx, cy, fx, fy);
+  //  bool i1 = lines_intersect(ax, ay, bx, by, cx, cy, fx, fy, &rx, &ry);
   if (intersect1.first)
-    {
-      vx.push_back(intersect1.second.first);
-      vy.push_back(intersect1.second.second);
-    }
-  pair<bool,pair<double,double>> intersect2  = lines_intersect(ax, ay, bx, by, fx, fy, dx, dy);
-//  bool i2 = lines_intersect(ax, ay, bx, by, fx, fy, dx, dy, &rx, &ry);
+  {
+    vx.push_back(intersect1.second.first);
+    vy.push_back(intersect1.second.second);
+  }
+  pair<bool, pair<double, double>> intersect2 = lines_intersect(ax, ay, bx, by, fx, fy, dx, dy);
+  //  bool i2 = lines_intersect(ax, ay, bx, by, fx, fy, dx, dy, &rx, &ry);
   if (intersect2.first)
-    {
-      vx.push_back(intersect2.second.first);
-      vy.push_back(intersect2.second.second);
-    }
-  pair<bool,pair<double,double>> intersect3  = lines_intersect(ax, ay, bx, by, ex, ey, dx, dy);
-//  bool i3 = lines_intersect(ax, ay, bx, by, ex, ey, dx, dy, &rx, &ry);
+  {
+    vx.push_back(intersect2.second.first);
+    vy.push_back(intersect2.second.second);
+  }
+  pair<bool, pair<double, double>> intersect3 = lines_intersect(ax, ay, bx, by, ex, ey, dx, dy);
+  //  bool i3 = lines_intersect(ax, ay, bx, by, ex, ey, dx, dy, &rx, &ry);
   if (intersect3.first)
-    {
-      vx.push_back(intersect3.second.first);
-      vy.push_back(intersect3.second.second);
-    }
-  pair<bool,pair<double,double>> intersect4  = lines_intersect(ax, ay, bx, by, cx, cy, ex, ey);
-//  bool i4 = lines_intersect(ax, ay, bx, by, cx, cy, ex, ey, &rx, &ry);
+  {
+    vx.push_back(intersect3.second.first);
+    vy.push_back(intersect3.second.second);
+  }
+  pair<bool, pair<double, double>> intersect4 = lines_intersect(ax, ay, bx, by, cx, cy, ex, ey);
+  //  bool i4 = lines_intersect(ax, ay, bx, by, cx, cy, ex, ey, &rx, &ry);
   if (intersect4.first)
-    {
-      vx.push_back(intersect4.second.first);
-      vy.push_back(intersect4.second.second);
-    }
+  {
+    vx.push_back(intersect4.second.first);
+    vy.push_back(intersect4.second.second);
+  }
 
   //cout << "Rectangle intersections: " << i1 << " " << i2 << " " << i3 << " " << i4 << endl;
   //cout << "Number of intersections = " << vx.size() << endl;
 
   double rr = 0.;
   if (vx.size() == 2)
-    {
-      rr = sqrt( (vx[0] - vx[1]) * (vx[0] - vx[1]) + (vy[0] - vy[1]) * (vy[0] - vy[1]) );
-      //  cout << "Length of intersection = " << *rr << endl;
-    }
+  {
+    rr = sqrt((vx[0] - vx[1]) * (vx[0] - vx[1]) + (vy[0] - vy[1]) * (vy[0] - vy[1]));
+    //  cout << "Length of intersection = " << *rr << endl;
+  }
   if (vx.size() == 1)
+  {
+    // find which point (A or B) is within the rectangle
+    if (ax > cx && ay > cy && ax < dx && ay < dy)  // point A is inside the rectangle
     {
-      // find which point (A or B) is within the rectangle
-      if (ax > cx && ay > cy && ax < dx && ay < dy)   // point A is inside the rectangle
-	{
-	  //cout << "Point A is inside the rectangle." << endl;
-	  rr = sqrt((vx[0] - ax) * (vx[0] - ax) + (vy[0] - ay) * (vy[0] - ay));
-	}
-      if (bx > cx && by > cy && bx < dx && by < dy)   // point B is inside the rectangle
-	{
-	  //cout << "Point B is inside the rectangle." << endl;
-	  rr = sqrt((vx[0] - bx) * (vx[0] - bx) + (vy[0] - by) * (vy[0] - by));
-	}
+      //cout << "Point A is inside the rectangle." << endl;
+      rr = sqrt((vx[0] - ax) * (vx[0] - ax) + (vy[0] - ay) * (vy[0] - ay));
     }
+    if (bx > cx && by > cy && bx < dx && by < dy)  // point B is inside the rectangle
+    {
+      //cout << "Point B is inside the rectangle." << endl;
+      rr = sqrt((vx[0] - bx) * (vx[0] - bx) + (vy[0] - by) * (vy[0] - by));
+    }
+  }
 
   if (intersect1.first || intersect2.first || intersect3.first || intersect4.first)
-    {
-      return make_pair(true,rr);
-    }
-  return make_pair(false,NAN);
+  {
+    return make_pair(true, rr);
+  }
+  return make_pair(false, NAN);
 }
 
 double PHG4Utils::sA(double r, double x, double y)

--- a/simulation/g4simulation/g4main/PHG4Utils.h
+++ b/simulation/g4simulation/g4main/PHG4Utils.h
@@ -19,10 +19,10 @@ class PHG4Utils
   static double get_eta(const double theta);
   static std::pair<double, double> get_etaphi(const double x, const double y, const double z);
   static double get_eta(const double radius, const double z);
-  static std::pair<bool,double> line_and_rectangle_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy);
-  static std::pair<bool, std::pair<double,double>> lines_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy);
+  static std::pair<bool, double> line_and_rectangle_intersect(double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy);
+  static std::pair<bool, std::pair<double, double>> lines_intersect(double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy);
   static double circle_rectangle_intersection(double x1, double y1, double x2, double y2, double mx, double my, double r);
-  static double  sA(double r, double x, double y);
+  static double sA(double r, double x, double y);
 
  private:
   static double _eta_coverage;

--- a/simulation/g4simulation/g4main/PHG4Utils.h
+++ b/simulation/g4simulation/g4main/PHG4Utils.h
@@ -21,6 +21,8 @@ class PHG4Utils
   static double get_eta(const double radius, const double z);
   static std::pair<bool,double> line_and_rectangle_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy);
   static std::pair<bool, std::pair<double,double>> lines_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy);
+  static double circle_rectangle_intersection(double x1, double y1, double x2, double y2, double mx, double my, double r);
+  static double  sA(double r, double x, double y);
 
  private:
   static double _eta_coverage;

--- a/simulation/g4simulation/g4main/PHG4Utils.h
+++ b/simulation/g4simulation/g4main/PHG4Utils.h
@@ -19,6 +19,8 @@ class PHG4Utils
   static double get_eta(const double theta);
   static std::pair<double, double> get_etaphi(const double x, const double y, const double z);
   static double get_eta(const double radius, const double z);
+  static std::pair<bool,double> line_and_rectangle_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy);
+  static std::pair<bool, std::pair<double,double>> lines_intersect( double ax, double ay, double bx, double by, double cx, double cy, double dx, double dy);
 
  private:
   static double _eta_coverage;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -1,4 +1,4 @@
-// this is the new trackbase version 
+// this is the new trackbase version
 
 #include "PHG4MvtxHitReco.h"
 
@@ -7,12 +7,12 @@
 #include <mvtx/MvtxHit.h>
 
 #include <trackbase/TrkrDefs.h>
-#include <trackbase/TrkrHit.h>                          // for TrkrHit
+#include <trackbase/TrkrHit.h>  // for TrkrHit
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
 
-#include <g4detectors/PHG4CylinderGeom.h>               // for PHG4CylinderGeom
+#include <g4detectors/PHG4CylinderGeom.h>  // for PHG4CylinderGeom
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
 #include <phparameter/PHParameterContainerInterface.h>
@@ -22,26 +22,26 @@
 #include <g4main/PHG4Utils.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                         // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                               // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>                             // for PHObject
-#include <phool/PHTimeServer.h>                         // for PHTimeServer
-#include <phool/PHTimer.h>                              // for PHTimer
+#include <phool/PHObject.h>      // for PHObject
+#include <phool/PHTimeServer.h>  // for PHTimeServer
+#include <phool/PHTimer.h>       // for PHTimer
 #include <phool/getClass.h>
-#include <phool/phool.h>                                // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
-#include <TVector3.h>                                   // for TVector3, ope...
+#include <TVector3.h>  // for TVector3, ope...
 
 #include <cmath>
 #include <cstdlib>
-#include <cstring>                                     // for memset
+#include <cstring>  // for memset
 #include <iostream>
-#include <memory>                                       // for allocator_tra...
-#include <vector>                                       // for vector
+#include <memory>  // for allocator_tra...
+#include <vector>  // for vector
 
 using namespace std;
 
@@ -88,38 +88,38 @@ int PHG4MvtxHitReco::InitRun(PHCompositeNode *topNode)
   }
 
   TrkrHitSetContainer *hitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if(!hitsetcontainer)
-    {
-      PHNodeIterator dstiter(dstNode);
-      PHCompositeNode *DetNode =
+  if (!hitsetcontainer)
+  {
+    PHNodeIterator dstiter(dstNode);
+    PHCompositeNode *DetNode =
         dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
-      if (!DetNode)
-	{
-	  DetNode = new PHCompositeNode("TRKR");
-	  dstNode->addNode(DetNode);
-	}
-
-      hitsetcontainer = new TrkrHitSetContainer();
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hitsetcontainer, "TRKR_HITSET", "PHObject");
-      DetNode->addNode(newNode);
+    if (!DetNode)
+    {
+      DetNode = new PHCompositeNode("TRKR");
+      dstNode->addNode(DetNode);
     }
 
-  TrkrHitTruthAssoc *hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode,"TRKR_HITTRUTHASSOC");
-  if(!hittruthassoc)
-    {
-      PHNodeIterator dstiter(dstNode);
-      PHCompositeNode *DetNode =
-        dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
-      if (!DetNode)
-	{
-	  DetNode = new PHCompositeNode("TRKR");
-	  dstNode->addNode(DetNode);
-	}
+    hitsetcontainer = new TrkrHitSetContainer();
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hitsetcontainer, "TRKR_HITSET", "PHObject");
+    DetNode->addNode(newNode);
+  }
 
-      hittruthassoc = new TrkrHitTruthAssoc();
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hittruthassoc, "TRKR_HITTRUTHASSOC", "PHObject");
-      DetNode->addNode(newNode);
+  TrkrHitTruthAssoc *hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
+  if (!hittruthassoc)
+  {
+    PHNodeIterator dstiter(dstNode);
+    PHCompositeNode *DetNode =
+        dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+    if (!DetNode)
+    {
+      DetNode = new PHCompositeNode("TRKR");
+      dstNode->addNode(DetNode);
     }
+
+    hittruthassoc = new TrkrHitTruthAssoc();
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hittruthassoc, "TRKR_HITTRUTHASSOC", "PHObject");
+    DetNode->addNode(newNode);
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -144,19 +144,19 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
 
   // Get the TrkrHitSetContainer node
   TrkrHitSetContainer *trkrhitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if(!trkrhitsetcontainer)
-    {
-      cout << "Could not locate TRKR_HITSET node, quit! " << endl;
-      exit(1);
-    }
+  if (!trkrhitsetcontainer)
+  {
+    cout << "Could not locate TRKR_HITSET node, quit! " << endl;
+    exit(1);
+  }
 
   // Get the TrkrHitTruthAssoc node
   TrkrHitTruthAssoc *hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
-  if(!hittruthassoc)
-    {
-      cout << "Could not locate TRKR_HITTRUTHASSOC node, quit! " << endl;
-      exit(1);
-    }
+  if (!hittruthassoc)
+  {
+    cout << "Could not locate TRKR_HITTRUTHASSOC node, quit! " << endl;
+    exit(1);
+  }
 
   // loop over all of the layers in the g4hit container
   PHG4HitContainer::LayerIter layer;
@@ -505,44 +505,44 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
       // loop over all fired cells for this g4hit and add them to the TrkrHitSet
       for (unsigned int i1 = 0; i1 < vpixel.size(); i1++)  // loop over all fired cells
       {
-	// This is the new storage object version
-	//====================================
+        // This is the new storage object version
+        //====================================
 
-	// We need to create the TrkrHitSet if not already made - each TrkrHitSet should correspond to a chip for the Mvtx	
-	TrkrDefs::hitsetkey hitsetkey = MvtxDefs::genHitSetKey(*layer, stave_number, chip_number);
-	// Use existing hitset or add new one if needed
-	TrkrHitSetContainer::Iterator hitsetit = trkrhitsetcontainer->findOrAddHitSet(hitsetkey);
+        // We need to create the TrkrHitSet if not already made - each TrkrHitSet should correspond to a chip for the Mvtx
+        TrkrDefs::hitsetkey hitsetkey = MvtxDefs::genHitSetKey(*layer, stave_number, chip_number);
+        // Use existing hitset or add new one if needed
+        TrkrHitSetContainer::Iterator hitsetit = trkrhitsetcontainer->findOrAddHitSet(hitsetkey);
 
-	// generate the key for this hit
-	TrkrDefs::hitkey hitkey = MvtxDefs::genHitKey(vzbin[i1], vxbin[i1]);
-	// See if this hit already exists
-	TrkrHit *hit = nullptr;
-	hit = hitsetit->second->getHit(hitkey);
-	if(!hit)
-	  {
-	    // Otherwise, create a new one
-	    hit = new MvtxHit();
-	    hitsetit->second->addHitSpecificKey(hitkey, hit);
-	  }
+        // generate the key for this hit
+        TrkrDefs::hitkey hitkey = MvtxDefs::genHitKey(vzbin[i1], vxbin[i1]);
+        // See if this hit already exists
+        TrkrHit *hit = nullptr;
+        hit = hitsetit->second->getHit(hitkey);
+        if (!hit)
+        {
+          // Otherwise, create a new one
+          hit = new MvtxHit();
+          hitsetit->second->addHitSpecificKey(hitkey, hit);
+        }
 
-	// Either way, add the energy to it
-	hit->addEnergy(venergy[i1].first);
-	
-	// now we update the TrkrHitTruthAssoc map - the map contains <hitsetkey, std::pair <hitkey, g4hitkey> >
-	// There is only one TrkrHit per pixel, but there may be multiple g4hits
-	// How do we know how much energy from PHG4Hit went into TrkrHit? We don't, have to sort it out in evaluator to save memory
+        // Either way, add the energy to it
+        hit->addEnergy(venergy[i1].first);
 
-	// How do we check if this association already exists?
-	//cout << "PHG4MvtxHitReco: adding association entry for hitkey " << hitkey << " and g4hitkey " << hiter->first << endl; 
-	hittruthassoc->addAssoc(hitsetkey, hitkey, hiter->first);
-	
-      } // end loop over hit cells
-    }  // end loop over g4hits for this layer
+        // now we update the TrkrHitTruthAssoc map - the map contains <hitsetkey, std::pair <hitkey, g4hitkey> >
+        // There is only one TrkrHit per pixel, but there may be multiple g4hits
+        // How do we know how much energy from PHG4Hit went into TrkrHit? We don't, have to sort it out in evaluator to save memory
 
-  } // end loop over layers
+        // How do we check if this association already exists?
+        //cout << "PHG4MvtxHitReco: adding association entry for hitkey " << hitkey << " and g4hitkey " << hiter->first << endl;
+        hittruthassoc->addAssoc(hitsetkey, hitkey, hiter->first);
+
+      }  // end loop over hit cells
+    }    // end loop over g4hits for this layer
+
+  }  // end loop over layers
 
   // print the list of entries in the association table
-  if(Verbosity() > 2)
+  if (Verbosity() > 2)
   {
     cout << "From PHG4MvtxHitReco: " << endl;
     hittruthassoc->identify();

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -34,21 +34,10 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterContainerInterface
 
  protected:
 
-  double circle_rectangle_intersection(double x1, double y1, double x2, double y2, double mx, double my, double r);
-  double sA(double r, double x, double y);
-
-  std::map<int, int> binning;
-  std::map<int, std::pair<double, double> > zmin_max;  // zmin/zmax for each layer for faster lookup
-  std::map<int, double> etastep;
   std::string detector;
   std::string hitnodename;
-  std::string cellnodename;
   std::string geonodename;
-  std::string seggeonodename;
-  int nbins[2];
-  int chkenergyconservation;
   std::map<int, std::pair<double, double> > tmin_max;
-  //std::map<unsigned long long, PHG4Cell *> celllist;  // This map holds the hit cells
 };
 
 #endif

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -4,7 +4,6 @@
 #include <phparameter/PHParameterContainerInterface.h>
 
 #include <fun4all/SubsysReco.h>
-#include <phool/PHTimeServer.h>
 
 #include <map>
 #include <string>
@@ -25,11 +24,7 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterContainerInterface
   //! event processing
   int process_event(PHCompositeNode *topNode);
 
-  //! end of process
-  int End(PHCompositeNode *topNode);
-
   void Detector(const std::string &d) { detector = d; }
-  void checkenergy(const int i = 1) { chkenergyconservation = i; }
 
   double get_timing_window_min(const int i) { return tmin_max[i].first; }
   double get_timing_window_max(const int i) { return tmin_max[i].second; }
@@ -38,37 +33,10 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterContainerInterface
   void SetDefaultParameters();
 
  protected:
-  bool lines_intersect(
-      double ax,
-      double ay,
-      double bx,
-      double by,
-      double cx,
-      double cy,
-      double dx,
-      double dy,
-      double *rx,  // intersection point (output)
-      double *ry);
-
-  bool line_and_rectangle_intersect(
-      double ax,
-      double ay,
-      double bx,
-      double by,
-      double cx,
-      double cy,
-      double dx,
-      double dy,
-      double *rr  // length of the line segment inside the rectangle (output)
-  );
 
   double circle_rectangle_intersection(double x1, double y1, double x2, double y2, double mx, double my, double r);
   double sA(double r, double x, double y);
 
-  //void set_size(const int i, const double sizeA, const int sizeB, const int what);
-  int CheckEnergy(PHCompositeNode *topNode);
-  static std::pair<double, double> get_etaphi(const double x, const double y, const double z);
-  static double get_eta(const double radius, const double z);
   std::map<int, int> binning;
   std::map<int, std::pair<double, double> > zmin_max;  // zmin/zmax for each layer for faster lookup
   std::map<int, double> etastep;
@@ -77,7 +45,6 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterContainerInterface
   std::string cellnodename;
   std::string geonodename;
   std::string seggeonodename;
-  PHTimeServer::timer _timer;
   int nbins[2];
   int chkenergyconservation;
   std::map<int, std::pair<double, double> > tmin_max;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -7,7 +7,7 @@
 
 #include <map>
 #include <string>
-#include <utility>                                      // for pair
+#include <utility>  // for pair
 
 class PHCompositeNode;
 
@@ -33,7 +33,6 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterContainerInterface
   void SetDefaultParameters();
 
  protected:
-
   std::string detector;
   std::string hitnodename;
   std::string geonodename;


### PR DESCRIPTION
we had multiple identical copies of intersection of lines with rectangles and circles floating around, they live now as static methods in PHG4Utils. Also cleanup of identical get_eta and get_etaphi methods. Removal of unused variables and empty methods. Basically some sources are now 1/2 of their original size while still doing the same