### PR TITLE
Update configuration defaults

### DIFF
--- a/generators/flowAfterburner/main.cc
+++ b/generators/flowAfterburner/main.cc
@@ -54,13 +54,13 @@ main ()
   std::string input = pt.get("FLOWAFTERBURNER.INPUT", "sHijing.dat");
   std::string output = pt.get("FLOWAFTERBURNER.OUTPUT", "flowAfterburner.dat");
 
-  float mineta = pt.get("FLOWAFTERBURNER.CUTS.MINETA", -1.0);
-  float maxeta = pt.get("FLOWAFTERBURNER.CUTS.MAXETA", 1.0);
+  float mineta = pt.get("FLOWAFTERBURNER.CUTS.MINETA", -4.0);
+  float maxeta = pt.get("FLOWAFTERBURNER.CUTS.MAXETA", 4.0);
 
   float minpt = pt.get("FLOWAFTERBURNER.CUTS.MINPT", 0.0);
   float maxpt = pt.get("FLOWAFTERBURNER.CUTS.MAXPT", 100.0);
 
-  std::string algorithmName = pt.get("FLOWAFTERBURNER.ALGORITHM", "JJNEW");
+  std::string algorithmName = pt.get("FLOWAFTERBURNER.ALGORITHM", "MINBIAS");
 
   // Open input file.
   HepMC::IO_GenEvent ascii_in (input.c_str(), std::ios::in);


### PR DESCRIPTION
At the request of the JS TWG I have updated the code defaults to extend the eta range over which the flow afterburner is applied to include coverage for the forward region, allowing for studies of future forward  detectors. There was confusion after the last collaboration meeting as to how the afterburner was actually applied if run w/o a configuration file. The MINBIAS configuration has an eta-dependent model for v2, although I haven't compared it to RHIC data yet (has anyone?). 

I also explicitly updated the code to use the configuration name MINBIAS which is one of the three defined in flowAfterburner.cc rather than rely on some obscure behavior of the STL map to select the right thing. The code is less confusing this way if anyone tries to read it. 

There is a corresponding pull request to update the xml configuration file in the macros area. 

Below is a picture of the reaction plane truth angle from the afterburner compared to the reaction plane angle extracted from primary particles in 1.4<eta<4.0, using a derivative of the STAR EPD event plane software converted for sPHENIX. 

![fpcorr](https://user-images.githubusercontent.com/3042746/64200210-9fca0300-ce51-11e9-9f4b-7fb3d0229c30.png)
 