### PR TITLE
tune flow rapidity dependence to better match RHIC 200GeV AuAu

### DIFF
--- a/generators/flowAfterburner/flowAfterburner.cc
+++ b/generators/flowAfterburner/flowAfterburner.cc
@@ -151,8 +151,14 @@ calc_v2(double b, double eta, double pt)
   float temp2 = pow (pt + 0.1, -a2) / (1 + exp (-(pt - 4.5) / a3));
   float temp3 = 0.01 / (1 + exp (-(pt - 4.5) / a3));
 
-  v2 = (a4 * (temp1 + temp2) + temp3) * exp (-0.5 * eta * eta / 6.27 / 6.27);
+  //v2 = (a4 * (temp1 + temp2) + temp3) * exp (-0.5 * eta * eta / 6.27 / 6.27);
   
+  // Adjust flow rapidity dependence to better match PHOBOS 200 GeV Au+Au data
+  // JGL 9/9/2019
+  // See JS ToG talk at https://indico.bnl.gov/event/6764/ 
+
+  v2 = (a4 * (temp1 + temp2) + temp3) * exp (-0.5 * eta * eta / 2.0 / 2.0);
+ 
   return v2;
 }
   


### PR DESCRIPTION
Minor change to the rapidity dependence of the flow function to be a better match to 200 GeV AuAu at RHIC, as determined by a comparison with PHOBOS data. The PHOBOS comparison is outlined in a Jet Structure ToG talk at:

https://indico.bnl.gov/event/6764/

With this change the flowAfterburner is a fair representation of the flow measured by PHOBOS at RHIC 200 GeV AuAu, not perfect, but good enough for detector studies. 
