### PR TITLE
Fix berbosity in multiple vertexing code

### DIFF
--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -389,7 +389,7 @@ int PHGenFitTrkFitter::process_event(PHCompositeNode* topNode)
     }
   }
 
-  if(rave_vertices.size() == 0)
+  if(Verbosity() > 10 && rave_vertices.size() == 0)
     {
       cout << PHWHERE << " Rave found no vertices - SvtxVertexMapRefit will be empty" << endl;
     }


### PR DESCRIPTION
Tweaked the diagnostic output from tracking so that you have to turn on a non-zero verbosity level to get them.