### PR TITLE
add use of geant4-config --cflags to compile with MT GEANT4

### DIFF
--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -5,6 +5,8 @@ lib_LTLIBRARIES = \
     libg4detectors_io.la \
     libg4detectors.la
 
+AM_CXXFLAGS = `geant4-config --cflags  | sed s/-Woverloaded-virtual// | sed s/-pedantic// | sed s/-Wshadow// | sed s/-W\ //`
+
 AM_CPPFLAGS = \
     -DCGAL_DISABLE_ROUNDING_MATH_CHECK \
     -I$(includedir) \


### PR DESCRIPTION
the g4detectors needs the MT flags from G4 to build