### PR TITLE
Enable Volume hierarchy

### DIFF
--- a/offline/QA/modules/QAG4SimulationCalorimeter.cc
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.cc
@@ -15,7 +15,6 @@
 
 #include <g4eval/CaloEvalStack.h>
 #include <g4eval/CaloRawClusterEval.h>
-#include <g4eval/SvtxEvalStack.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -33,9 +32,12 @@
 #include <TString.h>
 #include <TVector3.h>
 
+#include <CLHEP/Vector/ThreeVector.h>        // for Hep3Vector
+
 #include <cassert>
 #include <cstdlib>
 #include <iostream>
+#include <iterator>                          // for reverse_iterator
 #include <map>
 #include <utility>
 
@@ -44,26 +46,18 @@ using namespace std;
 QAG4SimulationCalorimeter::QAG4SimulationCalorimeter(const string &calo_name,
                                                      QAG4SimulationCalorimeter::enu_flags flags)
   : SubsysReco("QAG4SimulationCalorimeter_" + calo_name)
-  ,  //
-  _calo_name(calo_name)
+  , _calo_name(calo_name)
   , _flags(flags)
-  ,  //
-  _calo_hit_container(nullptr)
+  , _calo_hit_container(nullptr)
   , _calo_abs_hit_container(nullptr)
-  , _truth_container(
-        nullptr)
-{
-}
-
-QAG4SimulationCalorimeter::~QAG4SimulationCalorimeter()
+  , _truth_container(nullptr)
 {
 }
 
 int QAG4SimulationCalorimeter::InitRun(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
-  PHCompositeNode *dstNode = static_cast<PHCompositeNode *>(iter.findFirst(
-      "PHCompositeNode", "DST"));
+  PHCompositeNode *dstNode = static_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   assert(dstNode);
 
   if (flag(kProcessG4Hit))
@@ -113,11 +107,6 @@ int QAG4SimulationCalorimeter::InitRun(PHCompositeNode *topNode)
       _caloevalstack->next_event(topNode);
     }
   }
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int QAG4SimulationCalorimeter::End(PHCompositeNode *topNode)
-{
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/QA/modules/QAG4SimulationCalorimeter.h
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <string>
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <cstdint>
 #else
 #include <stdint.h>
@@ -32,12 +32,11 @@ class QAG4SimulationCalorimeter : public SubsysReco
 
   QAG4SimulationCalorimeter(const std::string &calo_name, enu_flags flags =
                                                               kDefaultFlag);
-  virtual ~QAG4SimulationCalorimeter();
+  virtual ~QAG4SimulationCalorimeter(){}
 
   int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
 
   uint32_t
   get_flags() const
@@ -83,7 +82,7 @@ class QAG4SimulationCalorimeter : public SubsysReco
   int Init_Cluster(PHCompositeNode *topNode);
   int process_event_Cluster(PHCompositeNode *topNode);
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   //CINT is not c++11 compatible
   std::shared_ptr<CaloEvalStack> _caloevalstack;
 #endif

--- a/offline/QA/modules/QAG4SimulationCalorimeterSum.cc
+++ b/offline/QA/modules/QAG4SimulationCalorimeterSum.cc
@@ -9,14 +9,14 @@
 #include <g4main/PHG4TruthInfoContainer.h>
 
 #include <calobase/RawCluster.h>
-#include <calobase/RawClusterContainer.h>
 #include <calobase/RawTower.h>
 #include <calobase/RawTowerContainer.h>
 #include <calobase/RawTowerGeomContainer.h>
 
-//#include <g4hough/PHG4HoughTransform.h>
-
 #include <trackbase_historic/SvtxTrack.h>
+
+#include <g4eval/SvtxTrackEval.h>            // for SvtxTrackEval
+
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllHistoManager.h>
@@ -33,6 +33,8 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
+#include <iterator>                          // for reverse_iterator
+#include <utility>                           // for pair
 #include <vector>
 
 using namespace std;
@@ -40,20 +42,12 @@ using namespace std;
 QAG4SimulationCalorimeterSum::QAG4SimulationCalorimeterSum(
     QAG4SimulationCalorimeterSum::enu_flags flags)
   : SubsysReco("QAG4SimulationCalorimeterSum")
-  ,  //
-  _flags(flags)
-  ,  //
-  _calo_name_cemc("CEMC")
+  , _flags(flags)
+  , _calo_name_cemc("CEMC")
   , _calo_name_hcalin("HCALIN")
-  ,  //
-  _calo_name_hcalout("HCALOUT")
-  ,  //
-  _truth_container(nullptr)
+  , _calo_name_hcalout("HCALOUT")
+  , _truth_container(nullptr)
   , _magField(+1.4)
-{
-}
-
-QAG4SimulationCalorimeterSum::~QAG4SimulationCalorimeterSum()
 {
 }
 
@@ -103,11 +97,6 @@ int QAG4SimulationCalorimeterSum::InitRun(PHCompositeNode *topNode)
       _svtxevalstack->set_verbosity(Verbosity() + 1);
     }
   }
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int QAG4SimulationCalorimeterSum::End(PHCompositeNode *topNode)
-{
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/QA/modules/QAG4SimulationCalorimeterSum.h
+++ b/offline/QA/modules/QAG4SimulationCalorimeterSum.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <string>
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <cstdint>
 #else
 #include <stdint.h>
@@ -34,12 +34,11 @@ class QAG4SimulationCalorimeterSum : public SubsysReco
 
   QAG4SimulationCalorimeterSum(enu_flags flags = kDefaultFlag);
 
-  virtual ~QAG4SimulationCalorimeterSum();
+  virtual ~QAG4SimulationCalorimeterSum(){}
 
   int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
 
   uint32_t
   get_flags() const
@@ -126,7 +125,7 @@ class QAG4SimulationCalorimeterSum : public SubsysReco
   int Init_TrackProj(PHCompositeNode *topNode);
   int process_event_TrackProj(PHCompositeNode *topNode);
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   //CINT is not c++11 compatible
   std::shared_ptr<CaloEvalStack> _caloevalstack_cemc;
   std::shared_ptr<CaloEvalStack> _caloevalstack_hcalin;

--- a/offline/QA/modules/QAG4SimulationJet.cc
+++ b/offline/QA/modules/QAG4SimulationJet.cc
@@ -13,6 +13,7 @@
 #include <fun4all/Fun4AllBase.h>
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>           // for SubsysReco
 
 #include <phool/getClass.h>
 
@@ -20,6 +21,7 @@
 #include <TH1.h>
 #include <TH2.h>
 #include <TNamed.h>
+#include <TString.h>                      // for operator+, TString, Form
 
 #include <cassert>
 #include <cmath>
@@ -32,22 +34,14 @@ using namespace std;
 QAG4SimulationJet::QAG4SimulationJet(const std::string& truth_jet,
                                      enu_flags flags)
   : SubsysReco("QAG4SimulationJet_" + truth_jet)
-  ,  //
-  _jetevalstacks()
-  ,  //
-  _truth_jet(truth_jet)
+  , _jetevalstacks()
+  , _truth_jet(truth_jet)
   , _reco_jets()
   , _flags(flags)
-  ,  //
-  eta_range(-1, 1)
-  ,  //
-  _jet_match_dEta(.1)
+  , eta_range(-1, 1)
+  , _jet_match_dEta(.1)
   , _jet_match_dPhi(.1)
   , _jet_match_dE_Ratio(.5)
-{
-}
-
-QAG4SimulationJet::~QAG4SimulationJet()
 {
 }
 
@@ -87,11 +81,6 @@ int QAG4SimulationJet::InitRun(PHCompositeNode* topNode)
     _jettrutheval->set_verbosity(Verbosity() + 1);
   }
 
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int QAG4SimulationJet::End(PHCompositeNode* topNode)
-{
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/QA/modules/QAG4SimulationJet.h
+++ b/offline/QA/modules/QAG4SimulationJet.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <utility>  // std::pair, std::make_pair
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <cstdint>
 #else
 #include <stdint.h>
@@ -43,7 +43,7 @@ class QAG4SimulationJet : public SubsysReco
 
   QAG4SimulationJet(const std::string &truth_jet, enu_flags flags =
                                                       kDefaultFlag);
-  virtual ~QAG4SimulationJet();
+  virtual ~QAG4SimulationJet(){}
 
   //! add reco jet to the process list
   //! @return number of reco jet on list
@@ -132,7 +132,6 @@ class QAG4SimulationJet : public SubsysReco
   int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
 
  private:
   int Init_Spectrum(PHCompositeNode *topNode, const std::string &jet_name);
@@ -147,7 +146,7 @@ class QAG4SimulationJet : public SubsysReco
   get_histo_prefix(const std::string &src_jet_name = "",
                    const std::string &reco_jet_name = "");
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   //! cache the jet evaluation modules
   typedef std::map<std::string, std::shared_ptr<JetEvalStack>> jetevalstacks_map;
   jetevalstacks_map _jetevalstacks;

--- a/offline/packages/CaloReco/BEmcProfile.cc
+++ b/offline/packages/CaloReco/BEmcProfile.cc
@@ -1,8 +1,17 @@
 #include "BEmcProfile.h"
+#include "BEmcCluster.h"
 
-#include "TROOT.h"
-#include "TMath.h"
-#include "TFile.h"
+#include <TFile.h>
+#include <TH1.h>     // for TH1F
+#include <TMath.h>
+#include <TROOT.h>
+
+#include <cmath>    // for sqrt, log, pow, fabs
+#include <cstdio>   // for printf, sprintf
+#include <cstdlib>  // for abs
+#include <memory>    // for allocator_traits<>::value_type
+
+//class EmcModule;
 
 const int NP = 4; // Number of profiles in a bin
 

--- a/offline/packages/CaloReco/BEmcProfile.h
+++ b/offline/packages/CaloReco/BEmcProfile.h
@@ -1,13 +1,14 @@
-#include "TH1F.h"
+#include <vector>  // for vector
 
-#include "BEmcCluster.h"
+class EmcModule;
+class TH1F;
 
 class BEmcProfile
 {
 
 public:
   BEmcProfile(const char* fname);
-  ~BEmcProfile();
+  virtual ~BEmcProfile();
 
   float GetProb(std::vector<EmcModule>* plist, int NX, float en, float theta);
   float GetTowerEnergy( int iy, int iz, std::vector<EmcModule>* plist, int nx );

--- a/offline/packages/CaloReco/RawClusterBuilderTemplateEEMC.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplateEEMC.cc
@@ -13,6 +13,7 @@
 #include <calobase/RawTowerGeomContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>              // for SubsysReco
 
 #include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>

--- a/offline/packages/CaloReco/RawClusterBuilderTemplateFEMC.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplateFEMC.cc
@@ -14,6 +14,7 @@
 #include <calobase/RawTowerGeomContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>              // for SubsysReco
 
 #include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>

--- a/offline/packages/CaloReco/RawClusterDeadAreaMask.cc
+++ b/offline/packages/CaloReco/RawClusterDeadAreaMask.cc
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>                           // for pair
 #include <vector>
 
 using namespace std;

--- a/offline/packages/CaloReco/RawClusterPositionCorrection.cc
+++ b/offline/packages/CaloReco/RawClusterPositionCorrection.cc
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>                           // for pair
 
 using namespace std;
 

--- a/offline/packages/CaloReco/RawTowerDeadMapLoader.cc
+++ b/offline/packages/CaloReco/RawTowerDeadMapLoader.cc
@@ -28,6 +28,7 @@
 
 // boost headers
 #include <boost/tokenizer.hpp>
+#include <boost/token_iterator.hpp>            // for token_iterator
 // this is an ugly hack, the gcc optimizer has a bug which
 // triggers the uninitialized variable warning which
 // stops compilation because of our -Werror

--- a/simulation/g4simulation/g4bbc/BbcVertexFastSimReco.h
+++ b/simulation/g4simulation/g4bbc/BbcVertexFastSimReco.h
@@ -10,7 +10,7 @@
 #include <fun4all/SubsysReco.h>
 
 // rootcint barfs with this header so we need to hide it
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
 #endif
 
@@ -42,7 +42,7 @@ class BbcVertexFastSimReco : public SubsysReco
   float m_T_Smear;
   float m_Z_Smear;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *RandomGenerator;
 #endif
 };

--- a/simulation/g4simulation/g4calo/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4calo/RawTowerDigitizer.h
@@ -13,7 +13,7 @@ class RawTowerDeadMap;
 class RawTower;
 
 // rootcint barfs with this header so we need to hide it
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
 #endif
 
@@ -197,7 +197,7 @@ class RawTowerDigitizer : public SubsysReco
   // ! SiPM effective pixel per tower, only used with kSiPM_photon_digitalization
   unsigned int m_SiPMEffectivePixel;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *m_RandomGenerator;
 #endif
 };

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
@@ -3,6 +3,7 @@
 #include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Detector.h>           // for PHG4Detector
+#include <g4main/PHG4Subsystem.h>
 #include <g4main/PHG4Utils.h>
 
 #include <phool/phool.h>
@@ -38,8 +39,8 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________
-PHG4BeamlineMagnetDetector::PHG4BeamlineMagnetDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam, const int lyr ):
-  PHG4Detector(Node,dnam),
+PHG4BeamlineMagnetDetector::PHG4BeamlineMagnetDetector(PHG4Subsystem *subsys, PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam, const int lyr ):
+						       PHG4Detector(subsys, Node,dnam),
   params(parameters),
   magnet_physi(nullptr),
   cylinder_physi(nullptr),
@@ -58,7 +59,7 @@ bool PHG4BeamlineMagnetDetector::IsInBeamlineMagnet(const G4VPhysicalVolume * vo
 
 
 //_______________________________________________________________
-void PHG4BeamlineMagnetDetector::Construct( G4LogicalVolume* logicWorld )
+void PHG4BeamlineMagnetDetector::ConstructMe( G4LogicalVolume* logicMother )
 {
   G4Material *TrackerMaterial = G4Material::GetMaterial(params->get_string_param("material"));
 
@@ -172,7 +173,7 @@ void PHG4BeamlineMagnetDetector::Construct( G4LogicalVolume* logicWorld )
                                                                params->get_double_param("place_z")*cm) ),
                                    magnet_logic,
                                    G4String(GetName().c_str()),
-                                   logicWorld, 0, false, OverlapCheck());
+                                   logicMother, 0, false, OverlapCheck());
 
 
   /* Add volume with solid magnet material */

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
@@ -2,7 +2,7 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4Detector.h>           // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 #include <g4main/PHG4Subsystem.h>
 #include <g4main/PHG4Utils.h>
 
@@ -12,26 +12,26 @@
 #include <Geant4/G4ClassicalRK4.hh>
 #include <Geant4/G4FieldManager.hh>
 #include <Geant4/G4LogicalVolume.hh>
-#include <Geant4/G4MagneticField.hh>
 #include <Geant4/G4Mag_UsualEqRhs.hh>
+#include <Geant4/G4MagneticField.hh>
 #include <Geant4/G4Material.hh>
-#include <Geant4/G4PhysicalConstants.hh>
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4PhysicalConstants.hh>
 #include <Geant4/G4QuadrupoleMagField.hh>
 #include <Geant4/G4RotationMatrix.hh>
-#include <Geant4/G4String.hh>              // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>         // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>         // for G4Transform3D
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D
 #include <Geant4/G4Tubs.hh>
-#include <Geant4/G4Types.hh>               // for G4double, G4bool
+#include <Geant4/G4Types.hh>  // for G4double, G4bool
 #include <Geant4/G4UniformMagField.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#include <CLHEP/Units/SystemOfUnits.h>     // for cm, deg, tesla, twopi, meter
+#include <CLHEP/Units/SystemOfUnits.h>  // for cm, deg, tesla, twopi, meter
 
-#include <cstdlib>                        // for exit
-#include <iostream>                        // for operator<<, basic_ostream
+#include <cstdlib>   // for exit
+#include <iostream>  // for operator<<, basic_ostream
 
 class G4VSolid;
 class PHCompositeNode;
@@ -39,157 +39,153 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________
-PHG4BeamlineMagnetDetector::PHG4BeamlineMagnetDetector(PHG4Subsystem *subsys, PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam, const int lyr ):
-						       PHG4Detector(subsys, Node,dnam),
-  params(parameters),
-  magnet_physi(nullptr),
-  cylinder_physi(nullptr),
-  layer(lyr)
-{}
+PHG4BeamlineMagnetDetector::PHG4BeamlineMagnetDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr)
+  : PHG4Detector(subsys, Node, dnam)
+  , params(parameters)
+  , magnet_physi(nullptr)
+  , cylinder_physi(nullptr)
+  , layer(lyr)
+{
+}
 
 //_______________________________________________________________
-bool PHG4BeamlineMagnetDetector::IsInBeamlineMagnet(const G4VPhysicalVolume * volume) const
+bool PHG4BeamlineMagnetDetector::IsInBeamlineMagnet(const G4VPhysicalVolume *volume) const
 {
   if (volume == magnet_physi)
-    {
-      return true;
-    }
+  {
+    return true;
+  }
   return false;
 }
 
-
 //_______________________________________________________________
-void PHG4BeamlineMagnetDetector::ConstructMe( G4LogicalVolume* logicMother )
+void PHG4BeamlineMagnetDetector::ConstructMe(G4LogicalVolume *logicMother)
 {
   G4Material *TrackerMaterial = G4Material::GetMaterial(params->get_string_param("material"));
 
-  if ( ! TrackerMaterial)
-    {
-      std::cout << "Error: Can not set material" << std::endl;
-      exit(-1);
-    }
+  if (!TrackerMaterial)
+  {
+    std::cout << "Error: Can not set material" << std::endl;
+    exit(-1);
+  }
 
-  G4VisAttributes* fieldVis= new G4VisAttributes();
+  G4VisAttributes *fieldVis = new G4VisAttributes();
   PHG4Utils::SetColour(fieldVis, "BlackHole");
   fieldVis->SetVisibility(false);
   fieldVis->SetForceSolid(false);
 
-  G4VisAttributes* siliconVis= new G4VisAttributes();
+  G4VisAttributes *siliconVis = new G4VisAttributes();
   if (params->get_int_param("blackhole"))
-    {
-      PHG4Utils::SetColour(siliconVis, "BlackHole");
-      siliconVis->SetVisibility(false);
-      siliconVis->SetForceSolid(false);
-    }
+  {
+    PHG4Utils::SetColour(siliconVis, "BlackHole");
+    siliconVis->SetVisibility(false);
+    siliconVis->SetForceSolid(false);
+  }
   else
-    {
-      PHG4Utils::SetColour(siliconVis, params->get_string_param("material"));
-      siliconVis->SetVisibility(true);
-      siliconVis->SetForceSolid(true);
-    }
+  {
+    PHG4Utils::SetColour(siliconVis, params->get_string_param("material"));
+    siliconVis->SetVisibility(true);
+    siliconVis->SetForceSolid(true);
+  }
 
   /* Define origin vector (center of magnet) */
-  G4ThreeVector origin(params->get_double_param("place_x")*cm,
-                       params->get_double_param("place_y")*cm,
-                       params->get_double_param("place_z")*cm);
+  G4ThreeVector origin(params->get_double_param("place_x") * cm,
+                       params->get_double_param("place_y") * cm,
+                       params->get_double_param("place_z") * cm);
 
   /* Define magnet rotation matrix */
   G4RotationMatrix *rotm = new G4RotationMatrix();
-  rotm->rotateX(params->get_double_param("rot_x")*deg);
-  rotm->rotateY(params->get_double_param("rot_y")*deg);
-  rotm->rotateZ(params->get_double_param("rot_z")*deg);
+  rotm->rotateX(params->get_double_param("rot_x") * deg);
+  rotm->rotateY(params->get_double_param("rot_y") * deg);
+  rotm->rotateZ(params->get_double_param("rot_z") * deg);
 
   /* Creating a magnetic field */
-  G4MagneticField* magField = nullptr;
+  G4MagneticField *magField = nullptr;
 
   string magnettype = params->get_string_param("magtype");
-  if ( magnettype == "dipole" )
-    {
-      G4double fieldValue = params->get_double_param("field_y")*tesla;
-      magField = new G4UniformMagField(G4ThreeVector(0.,fieldValue,0.));
+  if (magnettype == "dipole")
+  {
+    G4double fieldValue = params->get_double_param("field_y") * tesla;
+    magField = new G4UniformMagField(G4ThreeVector(0., fieldValue, 0.));
 
-      if ( Verbosity() > 0 )
-        cout << "Creating DIPOLE with field " << fieldValue << " and name " << GetName() << endl;
-    }
-  else if ( magnettype == "quadrupole" )
-    {
-      G4double fieldGradient = params->get_double_param("fieldgradient")*tesla/meter;
+    if (Verbosity() > 0)
+      cout << "Creating DIPOLE with field " << fieldValue << " and name " << GetName() << endl;
+  }
+  else if (magnettype == "quadrupole")
+  {
+    G4double fieldGradient = params->get_double_param("fieldgradient") * tesla / meter;
 
-      /* G4MagneticField::GetFieldValue( pos*, B* ) uses GLOBAL coordinates, not local.
+    /* G4MagneticField::GetFieldValue( pos*, B* ) uses GLOBAL coordinates, not local.
        * Therefore, place magnetic field center at the correct location and angle for the
        * magnet AND do the same transformations for the logical volume (see below). */
-      magField = new G4QuadrupoleMagField ( fieldGradient, origin, rotm );
-      //      magField = new PHG4QuadrupoleMagField ( fieldGradient, origin, rotm );
+    magField = new G4QuadrupoleMagField(fieldGradient, origin, rotm);
+    //      magField = new PHG4QuadrupoleMagField ( fieldGradient, origin, rotm );
 
-      if ( Verbosity() > 0 )
-        {
-          cout << "Creating QUADRUPOLE with gradient " << fieldGradient << " and name " << GetName() << endl;
-          cout << "at x, y, z = " << origin.x() << " , " << origin.y() << " , " << origin.z() << endl;
-          cout << "with rotation around x, y, z axis  by: " << rotm->phiX() << ", " << rotm->phiY() << ", " << rotm->phiZ() << endl;
-        }
-    }
-
-  if ( !magField )
+    if (Verbosity() > 0)
     {
-      cout << PHWHERE << " Aborting, no magnetic field specified for " << GetName() << endl;
-      exit(1);
+      cout << "Creating QUADRUPOLE with gradient " << fieldGradient << " and name " << GetName() << endl;
+      cout << "at x, y, z = " << origin.x() << " , " << origin.y() << " , " << origin.z() << endl;
+      cout << "with rotation around x, y, z axis  by: " << rotm->phiX() << ", " << rotm->phiY() << ", " << rotm->phiZ() << endl;
     }
+  }
+
+  if (!magField)
+  {
+    cout << PHWHERE << " Aborting, no magnetic field specified for " << GetName() << endl;
+    exit(1);
+  }
 
   /* Set up Geant4 field manager */
-  G4Mag_UsualEqRhs* localEquation = new G4Mag_UsualEqRhs(magField);
-  G4ClassicalRK4* localStepper = new G4ClassicalRK4( localEquation );
-  G4double minStep = 0.25*mm; // minimal step, 1 mm is default
-  G4ChordFinder* localChordFinder = new G4ChordFinder( magField, minStep, localStepper );
+  G4Mag_UsualEqRhs *localEquation = new G4Mag_UsualEqRhs(magField);
+  G4ClassicalRK4 *localStepper = new G4ClassicalRK4(localEquation);
+  G4double minStep = 0.25 * mm;  // minimal step, 1 mm is default
+  G4ChordFinder *localChordFinder = new G4ChordFinder(magField, minStep, localStepper);
 
-  G4FieldManager* fieldMgr = new G4FieldManager();
+  G4FieldManager *fieldMgr = new G4FieldManager();
   fieldMgr->SetDetectorField(magField);
-  fieldMgr->SetChordFinder( localChordFinder );
+  fieldMgr->SetChordFinder(localChordFinder);
 
   /* Add volume with magnetic field */
-  double radius = params->get_double_param("radius")*cm;
-  double thickness = params->get_double_param("thickness")*cm;
+  double radius = params->get_double_param("radius") * cm;
+  double thickness = params->get_double_param("thickness") * cm;
 
   G4VSolid *magnet_solid = new G4Tubs(G4String(GetName().c_str()),
                                       0,
-                                      radius+thickness,
-                                      params->get_double_param("length")*cm/2. ,0,twopi);
+                                      radius + thickness,
+                                      params->get_double_param("length") * cm / 2., 0, twopi);
 
   G4LogicalVolume *magnet_logic = new G4LogicalVolume(magnet_solid,
                                                       G4Material::GetMaterial("G4_Galactic"),
                                                       G4String(GetName().c_str()),
-                                                      0,0,0);
+                                                      0, 0, 0);
   magnet_logic->SetVisAttributes(fieldVis);
 
   /* Set field manager for logical volume */
   G4bool allLocal = true;
-  magnet_logic->SetFieldManager(fieldMgr,allLocal);
-
-
+  magnet_logic->SetFieldManager(fieldMgr, allLocal);
 
   /* create magnet physical volume */
   magnet_physi = new G4PVPlacement(G4Transform3D(*rotm,
-                                                 G4ThreeVector(params->get_double_param("place_x")*cm,
-                                                               params->get_double_param("place_y")*cm,
-                                                               params->get_double_param("place_z")*cm) ),
+                                                 G4ThreeVector(params->get_double_param("place_x") * cm,
+                                                               params->get_double_param("place_y") * cm,
+                                                               params->get_double_param("place_z") * cm)),
                                    magnet_logic,
                                    G4String(GetName().c_str()),
                                    logicMother, 0, false, OverlapCheck());
-
 
   /* Add volume with solid magnet material */
   G4VSolid *cylinder_solid = new G4Tubs(G4String(GetName().append("_Solid").c_str()),
                                         radius,
                                         radius + thickness,
-                                        params->get_double_param("length")*cm/2. ,0,twopi);
+                                        params->get_double_param("length") * cm / 2., 0, twopi);
   G4LogicalVolume *cylinder_logic = new G4LogicalVolume(cylinder_solid,
                                                         TrackerMaterial,
                                                         G4String(GetName().c_str()),
-                                                        0,0,0);
+                                                        0, 0, 0);
   cylinder_logic->SetVisAttributes(siliconVis);
 
-  cylinder_physi = new G4PVPlacement(0, G4ThreeVector(0,0,0),
+  cylinder_physi = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
                                      cylinder_logic,
                                      G4String(GetName().append("_Solid").c_str()),
                                      magnet_logic, 0, false, OverlapCheck());
-
 }

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.h
@@ -18,14 +18,14 @@ class PHG4BeamlineMagnetDetector: public PHG4Detector
   public:
 
   //! constructor
-  PHG4BeamlineMagnetDetector( PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam, const int layer = 0 );
+  PHG4BeamlineMagnetDetector(PHG4Subsystem *subsys, PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam, const int layer = 0 );
 
   //! destructor
   virtual ~PHG4BeamlineMagnetDetector( void )
   {}
 
   //! construct
-  void Construct( G4LogicalVolume* world );
+  void ConstructMe( G4LogicalVolume* world );
 
   bool IsInBeamlineMagnet(const G4VPhysicalVolume*) const;
   void SuperDetector(const std::string &name) {superdetector = name;}

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.h
@@ -12,32 +12,30 @@ class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHParameters;
 
-class PHG4BeamlineMagnetDetector: public PHG4Detector
+class PHG4BeamlineMagnetDetector : public PHG4Detector
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4BeamlineMagnetDetector(PHG4Subsystem *subsys, PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam, const int layer = 0 );
+  PHG4BeamlineMagnetDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int layer = 0);
 
   //! destructor
-  virtual ~PHG4BeamlineMagnetDetector( void )
-  {}
+  virtual ~PHG4BeamlineMagnetDetector(void)
+  {
+  }
 
   //! construct
-  void ConstructMe( G4LogicalVolume* world );
+  void ConstructMe(G4LogicalVolume *world);
 
-  bool IsInBeamlineMagnet(const G4VPhysicalVolume*) const;
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return layer;}
+  bool IsInBeamlineMagnet(const G4VPhysicalVolume *) const;
+  void SuperDetector(const std::string &name) { superdetector = name; }
+  const std::string SuperDetector() const { return superdetector; }
+  int get_Layer() const { return layer; }
 
-  private:
-
+ private:
   PHParameters *params;
 
-  G4VPhysicalVolume* magnet_physi;
-  G4VPhysicalVolume* cylinder_physi;
+  G4VPhysicalVolume *magnet_physi;
+  G4VPhysicalVolume *cylinder_physi;
 
   int layer;
   std::string superdetector;

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
@@ -3,8 +3,8 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <cmath>                        // for NAN
-#include <iostream>                      // for operator<<, endl, basic_ostream
+#include <cmath>     // for NAN
+#include <iostream>  // for operator<<, endl, basic_ostream
 
 class PHCompositeNode;
 class PHG4Detector;
@@ -12,45 +12,42 @@ class PHG4Detector;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4BeamlineMagnetSubsystem::PHG4BeamlineMagnetSubsystem( const std::string &na, const int lyr):
-  PHG4DetectorSubsystem(na,lyr),
-  detector_( nullptr )
+PHG4BeamlineMagnetSubsystem::PHG4BeamlineMagnetSubsystem(const std::string& na, const int lyr)
+  : PHG4DetectorSubsystem(na, lyr)
+  , detector_(nullptr)
 {
   InitializeParameters();
 }
 
 //_______________________________________________________________________
-int PHG4BeamlineMagnetSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
+int PHG4BeamlineMagnetSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
 {
-
   /* create magnet */
   detector_ = new PHG4BeamlineMagnetDetector(this, topNode, GetParams(), Name(), GetLayer());
 
   return 0;
-
 }
 
 //_______________________________________________________________________
-int PHG4BeamlineMagnetSubsystem::process_event( PHCompositeNode* topNode )
+int PHG4BeamlineMagnetSubsystem::process_event(PHCompositeNode* topNode)
 {
   return 0;
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4BeamlineMagnetSubsystem::GetDetector( void ) const
+PHG4Detector* PHG4BeamlineMagnetSubsystem::GetDetector(void) const
 {
   return detector_;
 }
 
-void
-PHG4BeamlineMagnetSubsystem::SetDefaultParameters()
+void PHG4BeamlineMagnetSubsystem::SetDefaultParameters()
 {
   set_default_string_param("magtype", "");
 
   set_default_double_param("field_y", NAN);
   set_default_double_param("fieldgradient", NAN);
 
-  set_default_double_param("length",100);
+  set_default_double_param("length", 100);
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);
   set_default_double_param("place_z", 0.);
@@ -58,30 +55,29 @@ PHG4BeamlineMagnetSubsystem::SetDefaultParameters()
   set_default_double_param("rot_y", 0.);
   set_default_double_param("rot_z", 0.);
   set_default_double_param("radius", 100);
-  set_default_double_param("thickness",100);
-  set_default_double_param("tmin",NAN);
-  set_default_double_param("tmax",NAN);
+  set_default_double_param("thickness", 100);
+  set_default_double_param("tmin", NAN);
+  set_default_double_param("tmax", NAN);
 
-  set_default_int_param("lengthviarapidity",1);
+  set_default_int_param("lengthviarapidity", 1);
 
   set_default_string_param("material", "G4_Galactic");
 }
 
-void
-PHG4BeamlineMagnetSubsystem::Print(const string &what) const
+void PHG4BeamlineMagnetSubsystem::Print(const string& what) const
 {
   cout << Name() << " Parameters: " << endl;
-  if (! BeginRunExecuted())
-    {
-      cout << "Need to execute BeginRun() before parameter printout is meaningful" << endl;
-      cout << "To do so either run one or more events or on the command line execute: " << endl;
-      cout << "Fun4AllServer *se = Fun4AllServer::instance();" << endl;
-      cout << "PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");" << endl;
-      cout << "g4->InitRun(se->topNode());" << endl;
-      cout << "PHG4BeamlineMagnetSubsystem *cyl = (PHG4BeamlineMagnetSubsystem *) g4->getSubsystem(\"" << Name() << "\");" << endl;
-      cout << "cyl->Print()" << endl;
-      return;
-    }
+  if (!BeginRunExecuted())
+  {
+    cout << "Need to execute BeginRun() before parameter printout is meaningful" << endl;
+    cout << "To do so either run one or more events or on the command line execute: " << endl;
+    cout << "Fun4AllServer *se = Fun4AllServer::instance();" << endl;
+    cout << "PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");" << endl;
+    cout << "g4->InitRun(se->topNode());" << endl;
+    cout << "PHG4BeamlineMagnetSubsystem *cyl = (PHG4BeamlineMagnetSubsystem *) g4->getSubsystem(\"" << Name() << "\");" << endl;
+    cout << "cyl->Print()" << endl;
+    return;
+  }
   GetParams()->Print();
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
@@ -24,7 +24,7 @@ int PHG4BeamlineMagnetSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 {
 
   /* create magnet */
-  detector_ = new PHG4BeamlineMagnetDetector(topNode, GetParams(), Name(), GetLayer());
+  detector_ = new PHG4BeamlineMagnetDetector(this, topNode, GetParams(), Name(), GetLayer());
 
   return 0;
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -31,8 +31,8 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________
-PHG4BlockDetector::PHG4BlockDetector(PHG4BlockSubsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr)
-  : PHG4Detector(Node, dnam)
+PHG4BlockDetector::PHG4BlockDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr)
+  : PHG4Detector(subsys, Node, dnam)
   , m_Params(parameters)
   , m_BlockPhysi(nullptr)
   , m_DisplayAction(dynamic_cast<PHG4BlockDisplayAction *>(subsys->GetDisplayAction()))
@@ -51,7 +51,7 @@ bool PHG4BlockDetector::IsInBlock(G4VPhysicalVolume *volume) const
 }
 
 //_______________________________________________________________
-void PHG4BlockDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4BlockDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   G4Material *TrackerMaterial = G4Material::GetMaterial(m_Params->get_string_param("material"));
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -5,24 +5,24 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4Detector.h>         // for PHG4Detector
-#include <g4main/PHG4DisplayAction.h>    // for PHG4DisplayAction
+#include <g4main/PHG4Detector.h>       // for PHG4Detector
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>    // for G4RotationMatrix
-#include <Geant4/G4String.hh>            // for G4String
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>       // for G4ThreeVector
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4UserLimits.hh>
 
-#include <CLHEP/Units/SystemOfUnits.h>   // for cm, deg
+#include <CLHEP/Units/SystemOfUnits.h>  // for cm, deg
 
-#include <cmath>                         // for isfinite
-#include <cstdlib>                      // for exit
-#include <iostream>                      // for operator<<, endl, basic_ostream
+#include <cmath>     // for isfinite
+#include <cstdlib>   // for exit
+#include <iostream>  // for operator<<, endl, basic_ostream
 #include <sstream>
 
 class G4VSolid;

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
@@ -5,7 +5,7 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <string>                 // for string
+#include <string>  // for string
 
 class G4LogicalVolume;
 class G4VPhysicalVolume;

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
@@ -13,12 +13,13 @@ class PHCompositeNode;
 class PHG4BlockDisplayAction;
 class PHG4BlockSubsystem;
 class PHParameters;
+class PHG4Subsystem;
 
 class PHG4BlockDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4BlockDetector(PHG4BlockSubsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam = "BLOCK", const int lyr = 0);
+  PHG4BlockDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr = 0);
 
   //! destructor
   virtual ~PHG4BlockDetector(void)
@@ -26,7 +27,7 @@ class PHG4BlockDetector : public PHG4Detector
   }
 
   //! construct
-  virtual void Construct(G4LogicalVolume *world);
+  virtual void ConstructMe(G4LogicalVolume *world);
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.cc
@@ -5,11 +5,11 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <Geant4/G4Colour.hh>          // for G4Colour
+#include <Geant4/G4Colour.hh>  // for G4Colour
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#include <cmath>                       // for isfinite
+#include <cmath>  // for isfinite
 
 using namespace std;
 
@@ -52,7 +52,7 @@ void PHG4BlockDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
   {
     m_VisAtt->SetColour(m_Colour->GetRed(),
                         m_Colour->GetGreen(),
-                        m_Colour->GetBlue(), 
+                        m_Colour->GetBlue(),
                         m_Colour->GetAlpha());
     m_VisAtt->SetVisibility(true);
     m_VisAtt->SetForceSolid(true);
@@ -61,11 +61,11 @@ void PHG4BlockDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
   return;
 }
 
-void  PHG4BlockDisplayAction::SetColor(const double red, const double green, const double blue, const double alpha)
+void PHG4BlockDisplayAction::SetColor(const double red, const double green, const double blue, const double alpha)
 {
   if (isfinite(red) && isfinite(green) && isfinite(blue) && isfinite(alpha))
   {
-    m_Colour = new G4Colour(red,green,blue,alpha);
+    m_Colour = new G4Colour(red, green, blue, alpha);
   }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.cc
@@ -5,8 +5,11 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <Geant4/G4Colour.hh>          // for G4Colour
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
+
+#include <cmath>                       // for isfinite
 
 using namespace std;
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
@@ -5,7 +5,10 @@
 
 #include "PHG4DetectorSubsystem.h"
 
+#if !defined(__CINT__) || defined(__CLING__)
 #include <array>   // for array
+#endif
+
 #include <string>  // for string
 
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
@@ -5,6 +5,7 @@
 
 #include "PHG4DetectorSubsystem.h"
 
+#include <array>                    // for array
 #include <string>                   // for string
 
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
@@ -5,8 +5,8 @@
 
 #include "PHG4DetectorSubsystem.h"
 
-#include <array>                    // for array
-#include <string>                   // for string
+#include <array>   // for array
+#include <string>  // for string
 
 class PHCompositeNode;
 class PHG4Detector;
@@ -45,7 +45,7 @@ class PHG4BlockSubsystem : public PHG4DetectorSubsystem
 
   PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
 
-  void set_color(const double red, const double green, const double blue, const double alpha=1.)
+  void set_color(const double red, const double green, const double blue, const double alpha = 1.)
   {
     m_ColorArray[0] = red;
     m_ColorArray[1] = green;
@@ -69,7 +69,7 @@ class PHG4BlockSubsystem : public PHG4DetectorSubsystem
   PHG4DisplayAction* m_DisplayAction;
   //! Color setting if we want to override the default
 #if !defined(__CINT__) || defined(__CLING__)
-  std::array<double,4> m_ColorArray;
+  std::array<double, 4> m_ColorArray;
 #else
   double m_ColorArray[4];
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.cc
@@ -28,8 +28,8 @@ using namespace std;
 
 static double no_overlap = 0.0001 * cm; // added safety margin against overlaps by using same boundary between volumes
 
-PHG4CEmcTestBeamDetector::PHG4CEmcTestBeamDetector( PHCompositeNode *Node, const std::string &dnam, const int lyr  ):
-  PHG4Detector(Node, dnam),
+PHG4CEmcTestBeamDetector::PHG4CEmcTestBeamDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr  ):
+  PHG4Detector(subsys,Node, dnam),
   gap(0.25 * mm),
   place_in_x(0 * cm),
   place_in_y(0 * cm),
@@ -86,7 +86,7 @@ PHG4CEmcTestBeamDetector::IsInCEmcTestBeam(G4VPhysicalVolume * volume) const
 }
 
 void
-PHG4CEmcTestBeamDetector::Construct( G4LogicalVolume* logicWorld )
+PHG4CEmcTestBeamDetector::ConstructMe( G4LogicalVolume* logicWorld )
 {
   CalculateGeometry();
   G4Material* Air = G4Material::GetMaterial("G4_AIR");

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.cc
@@ -1,24 +1,24 @@
 #include "PHG4CEmcTestBeamDetector.h"
 
-#include <g4main/PHG4Detector.h>           // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>      // for G4RotationMatrix
-#include <Geant4/G4String.hh>              // for G4String
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>         // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>         // for G4Transform3D
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D
 #include <Geant4/G4Tubs.hh>
-#include <Geant4/G4Types.hh>               // for G4double
+#include <Geant4/G4Types.hh>  // for G4double
 #include <Geant4/G4VisAttributes.hh>
 
-#include <algorithm>                       // for copy
-#include <cmath>                          // for cos, sin, NAN, acos, atan
-#include <iostream>                        // for operator<<, ostringstream
+#include <algorithm>  // for copy
+#include <cmath>      // for cos, sin, NAN, acos, atan
+#include <iostream>   // for operator<<, ostringstream
 #include <sstream>
 
 class G4VSolid;
@@ -26,72 +26,71 @@ class PHCompositeNode;
 
 using namespace std;
 
-static double no_overlap = 0.0001 * cm; // added safety margin against overlaps by using same boundary between volumes
+static double no_overlap = 0.0001 * cm;  // added safety margin against overlaps by using same boundary between volumes
 
-PHG4CEmcTestBeamDetector::PHG4CEmcTestBeamDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr  ):
-  PHG4Detector(subsys,Node, dnam),
-  gap(0.25 * mm),
-  place_in_x(0 * cm),
-  place_in_y(0 * cm),
-  place_in_z(0 * cm),
-  plate_x(135 * mm),
-  plate_z(135 * mm),
-  x_rot(0),
-  y_rot(0),
-  z_rot(0),
-  alpha(NAN),
-  inner_radius(NAN),
-  outer_radius(NAN),
-  tower_angular_coverage(NAN),
-  cemc_angular_coverage(NAN),
-  active_scinti_fraction(0.78),
-  sandwiches_per_tower(12), // 12 tungsten/scintillator fiber snadwiches per tower
-  num_towers(7),
-  active(0),
-  absorberactive(0),
-  layer(lyr),
-  blackhole(0)
+PHG4CEmcTestBeamDetector::PHG4CEmcTestBeamDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam, const int lyr)
+  : PHG4Detector(subsys, Node, dnam)
+  , gap(0.25 * mm)
+  , place_in_x(0 * cm)
+  , place_in_y(0 * cm)
+  , place_in_z(0 * cm)
+  , plate_x(135 * mm)
+  , plate_z(135 * mm)
+  , x_rot(0)
+  , y_rot(0)
+  , z_rot(0)
+  , alpha(NAN)
+  , inner_radius(NAN)
+  , outer_radius(NAN)
+  , tower_angular_coverage(NAN)
+  , cemc_angular_coverage(NAN)
+  , active_scinti_fraction(0.78)
+  , sandwiches_per_tower(12)
+  ,  // 12 tungsten/scintillator fiber snadwiches per tower
+  num_towers(7)
+  , active(0)
+  , absorberactive(0)
+  , layer(lyr)
+  , blackhole(0)
 {
   w_dimension[0] = plate_x;
   w_dimension[1] = 0.5 * mm;
   w_dimension[2] = plate_z;
-  sc_dimension[0] =  plate_x;
+  sc_dimension[0] = plate_x;
   sc_dimension[1] = 1 * mm;
   sc_dimension[2] = plate_z;
-  sandwich_thickness = 2*w_dimension[1] + sc_dimension[1]; // two tungsten plats, one scintillator
-  for (int i=0; i<4; i++)
-    {
-      sandwich_vol.push_back(nullptr);
-    }
+  sandwich_thickness = 2 * w_dimension[1] + sc_dimension[1];  // two tungsten plats, one scintillator
+  for (int i = 0; i < 4; i++)
+  {
+    sandwich_vol.push_back(nullptr);
+  }
 }
 
 //_______________________________________________________________
 //_______________________________________________________________
-int 
-PHG4CEmcTestBeamDetector::IsInCEmcTestBeam(G4VPhysicalVolume * volume) const
+int PHG4CEmcTestBeamDetector::IsInCEmcTestBeam(G4VPhysicalVolume* volume) const
 {
   if (active && volume == sandwich_vol[2])
-    {
-      return 1;
-    }
+  {
+    return 1;
+  }
   if (absorberactive && (volume == sandwich_vol[0] || volume == sandwich_vol[1]))
-    {
-      return -1;
-    }
+  {
+    return -1;
+  }
   if (absorberactive && sandwich_vol[3] && volume == sandwich_vol[3])
-    {
-      return -1;
-    }
+  {
+    return -1;
+  }
   return 0;
 }
 
-void
-PHG4CEmcTestBeamDetector::ConstructMe( G4LogicalVolume* logicWorld )
+void PHG4CEmcTestBeamDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   CalculateGeometry();
   G4Material* Air = G4Material::GetMaterial("G4_AIR");
-  G4VSolid* cemc_tub =  new  G4Tubs("CEmcTub", inner_radius - 2 * no_overlap, outer_radius + 2 * no_overlap,  (w_dimension[2] + 2 * no_overlap) / 2., 0, cemc_angular_coverage);
-  G4LogicalVolume* cemc_log =  new G4LogicalVolume(cemc_tub, Air, G4String("CEmc"), 0, 0, 0);
+  G4VSolid* cemc_tub = new G4Tubs("CEmcTub", inner_radius - 2 * no_overlap, outer_radius + 2 * no_overlap, (w_dimension[2] + 2 * no_overlap) / 2., 0, cemc_angular_coverage);
+  G4LogicalVolume* cemc_log = new G4LogicalVolume(cemc_tub, Air, G4String("CEmc"), 0, 0, 0);
   //  G4VisAttributes* cemcVisAtt = new G4VisAttributes();
   // cemcVisAtt->SetVisibility(true);
   // cemcVisAtt->SetForceSolid(true);
@@ -99,14 +98,14 @@ PHG4CEmcTestBeamDetector::ConstructMe( G4LogicalVolume* logicWorld )
   // cemc_log->SetVisAttributes(cemcVisAtt);
   G4RotationMatrix cemc_rotm;
   // put our cemc at center displacement in x
-  double radius_at_center =  inner_radius + (outer_radius - inner_radius)/2.;
-  double xcenter = radius_at_center * cos(cemc_angular_coverage/2.);
-  double ycenter = radius_at_center * sin(cemc_angular_coverage/2.);
+  double radius_at_center = inner_radius + (outer_radius - inner_radius) / 2.;
+  double xcenter = radius_at_center * cos(cemc_angular_coverage / 2.);
+  double ycenter = radius_at_center * sin(cemc_angular_coverage / 2.);
   cemc_rotm.rotateX(x_rot);
   cemc_rotm.rotateY(y_rot);
   cemc_rotm.rotateZ(z_rot);
-  new G4PVPlacement(G4Transform3D(cemc_rotm, G4ThreeVector(place_in_x-xcenter, place_in_y-ycenter, place_in_z)), cemc_log, "CEmc", logicWorld, 0, false, OverlapCheck());
-  G4VSolid* tower_tub = new  G4Tubs("TowerTub", inner_radius - no_overlap, outer_radius + no_overlap,  (w_dimension[2] + no_overlap) / 2., 0, tower_angular_coverage);
+  new G4PVPlacement(G4Transform3D(cemc_rotm, G4ThreeVector(place_in_x - xcenter, place_in_y - ycenter, place_in_z)), cemc_log, "CEmc", logicWorld, 0, false, OverlapCheck());
+  G4VSolid* tower_tub = new G4Tubs("TowerTub", inner_radius - no_overlap, outer_radius + no_overlap, (w_dimension[2] + no_overlap) / 2., 0, tower_angular_coverage);
   G4LogicalVolume* tower_log = new G4LogicalVolume(tower_tub, Air, G4String("CEmcTower"), 0, 0, 0);
   //  G4VisAttributes* towerVisAtt = new G4VisAttributes();
   // towerVisAtt->SetVisibility(true);
@@ -116,31 +115,29 @@ PHG4CEmcTestBeamDetector::ConstructMe( G4LogicalVolume* logicWorld )
 
   ostringstream tower_vol_name;
   for (int i = 0; i < 7; i++)
-    {
-      tower_vol_name << "CEmcTower_" << i;
-      double phi = -i * tower_angular_coverage;
-      G4RotationMatrix *tower_rotm  = new G4RotationMatrix();
-      tower_rotm->rotateZ(phi * rad);
-      new G4PVPlacement(tower_rotm, G4ThreeVector(0, 0, 0), tower_log, tower_vol_name.str().c_str(), cemc_log, 0, i , OverlapCheck());
-      tower_vol_name.str("");
-    }
+  {
+    tower_vol_name << "CEmcTower_" << i;
+    double phi = -i * tower_angular_coverage;
+    G4RotationMatrix* tower_rotm = new G4RotationMatrix();
+    tower_rotm->rotateZ(phi * rad);
+    new G4PVPlacement(tower_rotm, G4ThreeVector(0, 0, 0), tower_log, tower_vol_name.str().c_str(), cemc_log, 0, i, OverlapCheck());
+    tower_vol_name.str("");
+  }
   ConstructTowerVolume(tower_log);
   return;
 }
 
 // here we build up the tower from the sandwichs (tungsten + scintillator)
-int
-PHG4CEmcTestBeamDetector::ConstructTowerVolume( G4LogicalVolume* tower_log )
+int PHG4CEmcTestBeamDetector::ConstructTowerVolume(G4LogicalVolume* tower_log)
 {
-
   G4Material* Air = G4Material::GetMaterial("G4_AIR");
-  G4VSolid* sandwich_box =  new G4Box("Sandwich_box",
-				      w_dimension[0] / 2., sandwich_thickness / 2., w_dimension[2] / 2.);
+  G4VSolid* sandwich_box = new G4Box("Sandwich_box",
+                                     w_dimension[0] / 2., sandwich_thickness / 2., w_dimension[2] / 2.);
 
   G4LogicalVolume* sandwich_log = new G4LogicalVolume(sandwich_box,
-						      Air,
-						      G4String("CEmcSandwich"),
-						      0, 0, 0);
+                                                      Air,
+                                                      G4String("CEmcSandwich"),
+                                                      0, 0, 0);
   G4VisAttributes* sandwichVisAtt = new G4VisAttributes();
   sandwichVisAtt->SetVisibility(true);
   sandwichVisAtt->SetForceSolid(true);
@@ -148,59 +145,57 @@ PHG4CEmcTestBeamDetector::ConstructTowerVolume( G4LogicalVolume* tower_log )
   sandwich_log->SetVisAttributes(sandwichVisAtt);
   ostringstream sandwich_name;
   for (int i = 0; i < 12; i++)
-    {
-      G4RotationMatrix *sandwich_rotm  = new G4RotationMatrix();
-      double phi =  -i * alpha;
-      sandwich_rotm->rotateZ(phi * rad);
-      sandwich_name << "CEmcSandwich_" << i;
-      double xshift = cos(phi) * (inner_radius + (outer_radius - inner_radius) / 2.);
-      double yshift = -sin(phi) * (inner_radius + (outer_radius - inner_radius) / 2.);
-      // we need to shift everything up by sandwich_thickness/2, calculate the shift in x
-      // if we push the sandwich up by sandwich_thickness/2
-      double xcorr = atan(phi) * sandwich_thickness / 2.;
-      double ycorr = sandwich_thickness / 2.;
+  {
+    G4RotationMatrix* sandwich_rotm = new G4RotationMatrix();
+    double phi = -i * alpha;
+    sandwich_rotm->rotateZ(phi * rad);
+    sandwich_name << "CEmcSandwich_" << i;
+    double xshift = cos(phi) * (inner_radius + (outer_radius - inner_radius) / 2.);
+    double yshift = -sin(phi) * (inner_radius + (outer_radius - inner_radius) / 2.);
+    // we need to shift everything up by sandwich_thickness/2, calculate the shift in x
+    // if we push the sandwich up by sandwich_thickness/2
+    double xcorr = atan(phi) * sandwich_thickness / 2.;
+    double ycorr = sandwich_thickness / 2.;
 
-      new G4PVPlacement(sandwich_rotm, G4ThreeVector(xshift + xcorr, yshift + ycorr , 0),
-					       sandwich_log,
-					       sandwich_name.str().c_str(),
-					       tower_log, false, i, OverlapCheck());
-      sandwich_name.str("");
-    }
-  ConstructSandwichVolume(sandwich_log); // put W and scinti into sandwich
+    new G4PVPlacement(sandwich_rotm, G4ThreeVector(xshift + xcorr, yshift + ycorr, 0),
+                      sandwich_log,
+                      sandwich_name.str().c_str(),
+                      tower_log, false, i, OverlapCheck());
+    sandwich_name.str("");
+  }
+  ConstructSandwichVolume(sandwich_log);  // put W and scinti into sandwich
   return 0;
 }
 
 // here we put a single tungsten + scintillator sandwich together
-int
-PHG4CEmcTestBeamDetector::ConstructSandwichVolume(G4LogicalVolume* sandwich)
+int PHG4CEmcTestBeamDetector::ConstructSandwichVolume(G4LogicalVolume* sandwich)
 {
   vector<G4LogicalVolume*> block_logic;
   G4Material* AbsorberMaterial = G4Material::GetMaterial("G4_W");
   G4Material* ScintiMaterial = G4Material::GetMaterial("G4_POLYSTYRENE");
 
   if (active_scinti_fraction > 1 || active_scinti_fraction < 0)
-    {
-      cout << "invalid active scintillator fraction " << active_scinti_fraction
-	   << " try between 0 and 1" << endl;
-    }
+  {
+    cout << "invalid active scintillator fraction " << active_scinti_fraction
+         << " try between 0 and 1" << endl;
+  }
 
-  double sc_active_thickness = sc_dimension[1]*active_scinti_fraction;
-  double sc_passive_thickness = sc_dimension[1]-sc_active_thickness;
+  double sc_active_thickness = sc_dimension[1] * active_scinti_fraction;
+  double sc_passive_thickness = sc_dimension[1] - sc_active_thickness;
 
-
-  G4VSolid*  block_w = new G4Box("Tungsten_box",
-				 w_dimension[0] / 2., w_dimension[1] / 2., w_dimension[2] / 2.);
-  G4VSolid*  block_sc = new G4Box("Scinti_box",
-				  sc_dimension[0] / 2., sc_active_thickness / 2., sc_dimension[2] / 2.);
-  G4VSolid*  block_passive_sc = nullptr;
+  G4VSolid* block_w = new G4Box("Tungsten_box",
+                                w_dimension[0] / 2., w_dimension[1] / 2., w_dimension[2] / 2.);
+  G4VSolid* block_sc = new G4Box("Scinti_box",
+                                 sc_dimension[0] / 2., sc_active_thickness / 2., sc_dimension[2] / 2.);
+  G4VSolid* block_passive_sc = nullptr;
   block_logic.push_back(new G4LogicalVolume(block_w,
-					    AbsorberMaterial,
-					    "Plate_log_W",
-					    0, 0, 0));
+                                            AbsorberMaterial,
+                                            "Plate_log_W",
+                                            0, 0, 0));
   block_logic.push_back(new G4LogicalVolume(block_sc,
-					     ScintiMaterial,
-					     "Plate_log_Sc",
-					     0, 0, 0));
+                                            ScintiMaterial,
+                                            "Plate_log_Sc",
+                                            0, 0, 0));
   G4VisAttributes* matVis = new G4VisAttributes();
   G4VisAttributes* matVis1 = new G4VisAttributes();
   matVis->SetVisibility(true);
@@ -222,17 +217,17 @@ PHG4CEmcTestBeamDetector::ConstructSandwichVolume(G4LogicalVolume* sandwich)
   // -w/2 -sc_a/2 -sc_p/2 -w/2 + w/2 = -w/2 -sc_a/2 -sc_p/2 = -(w+sc)/2
   // where sc_a+sc_p = sc = scintillator thickness (sc_dimension[1])
 
-  sandwich_vol[0] =  new G4PVPlacement(0, G4ThreeVector(0, -(w_dimension[1]+sc_dimension[1])/ 2., 0),
-						  block_logic[0],
-						  "CEmc_W_plate_down",
-						  sandwich, 0, 0, OverlapCheck());
+  sandwich_vol[0] = new G4PVPlacement(0, G4ThreeVector(0, -(w_dimension[1] + sc_dimension[1]) / 2., 0),
+                                      block_logic[0],
+                                      "CEmc_W_plate_down",
+                                      sandwich, 0, 0, OverlapCheck());
 
   // top of the sandwich - starting at the bottom and add the tungsten and scintillator layer and half tungsten
   // -w/2 -sc/2 -w/2 + w + sc + w/2 = +sc/2 +w/2 = (w+sc)/2
-  sandwich_vol[1] =  new G4PVPlacement(0, G4ThreeVector(0, (w_dimension[1]+sc_dimension[1])/ 2., 0),
-						  block_logic[0],
-						  "CEmc_W_plate_up",
-						  sandwich, 0, 0, OverlapCheck());
+  sandwich_vol[1] = new G4PVPlacement(0, G4ThreeVector(0, (w_dimension[1] + sc_dimension[1]) / 2., 0),
+                                      block_logic[0],
+                                      "CEmc_W_plate_up",
+                                      sandwich, 0, 0, OverlapCheck());
 
   // since we split the scintillator into an active and passive part to accomodate
   // for the scintillator fibers not occupying 100% of the volume.
@@ -242,42 +237,40 @@ PHG4CEmcTestBeamDetector::ConstructSandwichVolume(G4LogicalVolume* sandwich)
   // -(w + sc_a + sc_p + w)/2, adding the w layer and half of the sc_a to get to the middle of the sc_a layer:
   // -w/2 -sc_a/2 - sc_p/2 -w/2 + w + sc_a/2 = -sc_p/2
   // if fraction of active sc is 1, sc_passive_thickness is zero
-  sandwich_vol[2] =  new G4PVPlacement(0, G4ThreeVector(0, -sc_passive_thickness/ 2., 0),
-				block_logic[1],
-				"CEmc_Scinti_plate",
-				sandwich, 0, 0, OverlapCheck());
-
+  sandwich_vol[2] = new G4PVPlacement(0, G4ThreeVector(0, -sc_passive_thickness / 2., 0),
+                                      block_logic[1],
+                                      "CEmc_Scinti_plate",
+                                      sandwich, 0, 0, OverlapCheck());
 
   if (sc_passive_thickness > 0)
-    {
-      G4VisAttributes* matVis2 = new G4VisAttributes();
-      matVis1->SetVisibility(true);
-      matVis1->SetForceSolid(true);
-      matVis1->SetColour(G4Colour::Blue());
-      block_passive_sc = new G4Box("Passive_Scinti_box",
-				   sc_dimension[0] / 2., sc_passive_thickness / 2., sc_dimension[2] / 2.);
-      block_logic.push_back( new G4LogicalVolume(block_passive_sc,
-						 ScintiMaterial,
-						 "Plate_log_Passive_Sc",
-						 0, 0, 0));
-      block_logic[2]->SetVisAttributes(matVis2);
-      // here we go again - bottome of sandwich box is
-      //  -(w + sc_a + sc_p +w)/2, now add w and sc_a and half of sc_p:
-      //  -w/2 -sc_a/2 - sc_p/2 -w/2 + w + sc_a + sc_p/2 = sc_a/2
-      sandwich_vol[3] =  new G4PVPlacement(0, G4ThreeVector(0, sc_active_thickness / 2., 0),
-                                             block_logic[2],
-                                             "CEmc_Passive_Si_plate",
-						  sandwich, 0, 0, OverlapCheck());
-    }
+  {
+    G4VisAttributes* matVis2 = new G4VisAttributes();
+    matVis1->SetVisibility(true);
+    matVis1->SetForceSolid(true);
+    matVis1->SetColour(G4Colour::Blue());
+    block_passive_sc = new G4Box("Passive_Scinti_box",
+                                 sc_dimension[0] / 2., sc_passive_thickness / 2., sc_dimension[2] / 2.);
+    block_logic.push_back(new G4LogicalVolume(block_passive_sc,
+                                              ScintiMaterial,
+                                              "Plate_log_Passive_Sc",
+                                              0, 0, 0));
+    block_logic[2]->SetVisAttributes(matVis2);
+    // here we go again - bottome of sandwich box is
+    //  -(w + sc_a + sc_p +w)/2, now add w and sc_a and half of sc_p:
+    //  -w/2 -sc_a/2 - sc_p/2 -w/2 + w + sc_a + sc_p/2 = sc_a/2
+    sandwich_vol[3] = new G4PVPlacement(0, G4ThreeVector(0, sc_active_thickness / 2., 0),
+                                        block_logic[2],
+                                        "CEmc_Passive_Si_plate",
+                                        sandwich, 0, 0, OverlapCheck());
+  }
   else
-    {
-      sandwich_vol[3] = nullptr;
-    }
+  {
+    sandwich_vol[3] = nullptr;
+  }
   return 0;
 }
 
-void
-PHG4CEmcTestBeamDetector::CalculateGeometry()
+void PHG4CEmcTestBeamDetector::CalculateGeometry()
 {
   // calculate the inner/outer radius of the g4tub using the test setup numbers
   // 1mm scintillator, 0.5mm tungsten, 0.25 mm gap at the back of the detector
@@ -285,18 +278,18 @@ PHG4CEmcTestBeamDetector::CalculateGeometry()
   // https://www.phenix.bnl.gov/WWW/offline/wikioff/index.php/CEmc
   // get the alpha angle via law of cos (a is the 0.25 mm gap):
   // a^2 = b^2+c^2 - 2bc*cos(alpha)
-    // cos(alpha) =  (b^2+c^2 - a^2)/2bc
-    // with b=c
-    // cos(alpha) = 1-(a^2/2b^2)
-    alpha = acos(1 - (gap * gap) / (2 * plate_x * plate_x));
-    // inner radius
-    inner_radius = sandwich_thickness / tan(alpha);
-    outer_radius = sqrt((inner_radius + plate_x) * (inner_radius + plate_x) + sandwich_thickness * sandwich_thickness);
+  // cos(alpha) =  (b^2+c^2 - a^2)/2bc
+  // with b=c
+  // cos(alpha) = 1-(a^2/2b^2)
+  alpha = acos(1 - (gap * gap) / (2 * plate_x * plate_x));
+  // inner radius
+  inner_radius = sandwich_thickness / tan(alpha);
+  outer_radius = sqrt((inner_radius + plate_x) * (inner_radius + plate_x) + sandwich_thickness * sandwich_thickness);
 
-    // twice no_overlap to apply safety margin also for towers
-    // angular coverage of 1 tower is 12 sandwiches = sandwiches_per_tower*alpha
-    tower_angular_coverage =  sandwiches_per_tower * alpha + 0.00005 * deg; // safety margin added to remove 142 nm overlap
-    // cemc prototype has 7 towers
-    cemc_angular_coverage = num_towers * tower_angular_coverage;
-    return;
+  // twice no_overlap to apply safety margin also for towers
+  // angular coverage of 1 tower is 12 sandwiches = sandwiches_per_tower*alpha
+  tower_angular_coverage = sandwiches_per_tower * alpha + 0.00005 * deg;  // safety margin added to remove 142 nm overlap
+  // cemc prototype has 7 towers
+  cemc_angular_coverage = num_towers * tower_angular_coverage;
+  return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.h
@@ -7,7 +7,7 @@
 
 #include <Geant4/G4Types.hh>
 
-#include <string>                 // for string
+#include <string>  // for string
 #include <vector>
 
 class G4LogicalVolume;
@@ -15,52 +15,49 @@ class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4Subsystem;
 
-class PHG4CEmcTestBeamDetector: public PHG4Detector
+class PHG4CEmcTestBeamDetector : public PHG4Detector
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4CEmcTestBeamDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr = 0 );
+  PHG4CEmcTestBeamDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr = 0);
 
   //! destructor
-  virtual ~PHG4CEmcTestBeamDetector( void )
-  {}
+  virtual ~PHG4CEmcTestBeamDetector(void)
+  {
+  }
 
   //! construct
-  virtual void ConstructMe( G4LogicalVolume* world );
+  virtual void ConstructMe(G4LogicalVolume *world);
 
   //!@name volume accessors
   //@{
-  int IsInCEmcTestBeam(G4VPhysicalVolume*) const;
+  int IsInCEmcTestBeam(G4VPhysicalVolume *) const;
   //@}
 
-  void SetPlaceZ(const G4double place_z) {place_in_z = place_z;}
+  void SetPlaceZ(const G4double place_z) { place_in_z = place_z; }
   void SetPlace(const G4double place_x, const G4double place_y, const G4double place_z)
   {
     place_in_x = place_x;
     place_in_y = place_y;
     place_in_z = place_z;
   }
-  void SetXRot(const G4double angle) {x_rot = angle;}
-  void SetYRot(const G4double angle) {y_rot = angle;}
-  void SetZRot(const G4double angle) {z_rot = angle;}
-  void SetActive(const int i = 1) {active = i;}
-  void SetAbsorberActive(const int i = 1) {absorberactive = i;}
-  int IsActive() const {return active;}
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return layer;}
+  void SetXRot(const G4double angle) { x_rot = angle; }
+  void SetYRot(const G4double angle) { y_rot = angle; }
+  void SetZRot(const G4double angle) { z_rot = angle; }
+  void SetActive(const int i = 1) { active = i; }
+  void SetAbsorberActive(const int i = 1) { absorberactive = i; }
+  int IsActive() const { return active; }
+  void SuperDetector(const std::string &name) { superdetector = name; }
+  const std::string SuperDetector() const { return superdetector; }
+  int get_Layer() const { return layer; }
 
-  void BlackHole(const int i=1) {blackhole = i;}
-  int IsBlackHole() const {return blackhole;}
+  void BlackHole(const int i = 1) { blackhole = i; }
+  int IsBlackHole() const { return blackhole; }
 
-  private:
-
+ private:
   void CalculateGeometry();
-  int ConstructTowerVolume(G4LogicalVolume* tower);
-  int ConstructSandwichVolume(G4LogicalVolume* sandwich);
-
+  int ConstructTowerVolume(G4LogicalVolume *tower);
+  int ConstructSandwichVolume(G4LogicalVolume *sandwich);
 
   std::vector<G4VPhysicalVolume *> sandwich_vol;
   G4double w_dimension[3];
@@ -90,7 +87,6 @@ class PHG4CEmcTestBeamDetector: public PHG4Detector
   int blackhole;
   std::string detector_type;
   std::string superdetector;
-  
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.h
@@ -13,6 +13,7 @@
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
+class PHG4Subsystem;
 
 class PHG4CEmcTestBeamDetector: public PHG4Detector
 {
@@ -20,14 +21,14 @@ class PHG4CEmcTestBeamDetector: public PHG4Detector
   public:
 
   //! constructor
-  PHG4CEmcTestBeamDetector( PHCompositeNode *Node, const std::string &dnam="BLOCK", const int lyr = 0 );
+  PHG4CEmcTestBeamDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr = 0 );
 
   //! destructor
   virtual ~PHG4CEmcTestBeamDetector( void )
   {}
 
   //! construct
-  virtual void Construct( G4LogicalVolume* world );
+  virtual void ConstructMe( G4LogicalVolume* world );
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.cc
@@ -1,23 +1,23 @@
 #include "PHG4CEmcTestBeamSubsystem.h"
 #include "PHG4CEmcTestBeamDetector.h"
 
-#include "PHG4EventActionClearZeroEdep.h"
 #include "PHG4CEmcTestBeamSteppingAction.h"
+#include "PHG4EventActionClearZeroEdep.h"
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4Subsystem.h>            // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>  // for PHG4Subsystem
 
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>              // for PHIODataNode
-#include <phool/PHNode.h>                    // for PHNode
-#include <phool/PHNodeIterator.h>            // for PHNodeIterator
-#include <phool/PHObject.h>                  // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
+#include <phool/getClass.h>
 
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4Types.hh>                 // for G4double
+#include <Geant4/G4Types.hh>  // for G4double
 
-#include <cstddef>                          // for NULL
+#include <cstddef>  // for NULL
 #include <sstream>
 
 class PHG4Detector;
@@ -26,42 +26,40 @@ class PHG4SteppingAction;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4CEmcTestBeamSubsystem::PHG4CEmcTestBeamSubsystem( const std::string &name, const int lyr ):
-  PHG4Subsystem( name ),
-  detector_( 0 ),
-  steppingAction_( nullptr ),
-  eventAction_(nullptr),
-  place_in_x(0),
-  place_in_y(0),
-  place_in_z(0),
-  rot_in_x(0),
-  rot_in_y(0),
-  rot_in_z(0),
-  active(0),
-  absorberactive(0),
-  layer(lyr),
-  blackhole(0),
-  detector_type(name),
-  superdetector("NONE")
+PHG4CEmcTestBeamSubsystem::PHG4CEmcTestBeamSubsystem(const std::string& name, const int lyr)
+  : PHG4Subsystem(name)
+  , detector_(0)
+  , steppingAction_(nullptr)
+  , eventAction_(nullptr)
+  , place_in_x(0)
+  , place_in_y(0)
+  , place_in_z(0)
+  , rot_in_x(0)
+  , rot_in_y(0)
+  , rot_in_z(0)
+  , active(0)
+  , absorberactive(0)
+  , layer(lyr)
+  , blackhole(0)
+  , detector_type(name)
+  , superdetector("NONE")
 {
-
   // put the layer into the name so we get unique names
   // for multiple layers
   ostringstream nam;
   nam << name << "_" << lyr;
   Name(nam.str().c_str());
   for (int i = 0; i < 3; i++)
-    {
-      dimension[i] = 100.0 * cm;
-    }
+  {
+    dimension[i] = 100.0 * cm;
+  }
 }
 
 //_______________________________________________________________________
-int
-PHG4CEmcTestBeamSubsystem::Init( PHCompositeNode* topNode )
+int PHG4CEmcTestBeamSubsystem::Init(PHCompositeNode* topNode)
 {
-  PHNodeIterator iter( topNode );
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
   detector_ = new PHG4CEmcTestBeamDetector(this, topNode, Name(), layer);
@@ -75,110 +73,98 @@ PHG4CEmcTestBeamSubsystem::Init( PHCompositeNode* topNode )
   detector_->SuperDetector(superdetector);
   detector_->OverlapCheck(CheckOverlap());
   if (active)
+  {
+    ostringstream nodename;
+    if (superdetector != "NONE")
     {
-      ostringstream nodename;
+      nodename << "G4HIT_" << superdetector;
+    }
+    else
+    {
+      nodename << "G4HIT_" << detector_type << "_" << layer;
+    }
+    // create hit list
+    PHG4HitContainer* block_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+    if (!block_hits)
+    {
+      dstNode->addNode(new PHIODataNode<PHObject>(block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject"));
+    }
+    if (absorberactive)
+    {
+      nodename.str("");
       if (superdetector != "NONE")
-	{
-	  nodename <<  "G4HIT_" << superdetector;
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << superdetector;
+      }
       else
-	{
-	  nodename <<  "G4HIT_" << detector_type << "_" << layer;
-	}
-      // create hit list
-      PHG4HitContainer* block_hits =  findNode::getClass<PHG4HitContainer>( topNode , nodename.str().c_str());
-      if ( !block_hits )
-	{
-
-	  dstNode->addNode( new PHIODataNode<PHObject>( block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject" ));
-
-	}
-      if (absorberactive)
-	{
-	  nodename.str("");
-	  if (superdetector != "NONE")
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << superdetector;
-	    }
-	  else
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << detector_type << "_" << layer;
-	    }
-	}
-      block_hits =  findNode::getClass<PHG4HitContainer>( topNode , nodename.str().c_str());
-      if ( !block_hits )
-	{
-
-	  dstNode->addNode( new PHIODataNode<PHObject>( block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject" ));
-
-	}
-      // create stepping action
-      steppingAction_ = new PHG4CEmcTestBeamSteppingAction(detector_);
-
-      eventAction_ = new PHG4EventActionClearZeroEdep(topNode, nodename.str());
+      {
+        nodename << "G4HIT_ABSORBER_" << detector_type << "_" << layer;
+      }
     }
-  if (blackhole && !active)
+    block_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+    if (!block_hits)
     {
-      steppingAction_ = new PHG4CEmcTestBeamSteppingAction(detector_);
+      dstNode->addNode(new PHIODataNode<PHObject>(block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject"));
     }
-  return 0;
+    // create stepping action
+    steppingAction_ = new PHG4CEmcTestBeamSteppingAction(detector_);
 
+    eventAction_ = new PHG4EventActionClearZeroEdep(topNode, nodename.str());
+  }
+  if (blackhole && !active)
+  {
+    steppingAction_ = new PHG4CEmcTestBeamSteppingAction(detector_);
+  }
+  return 0;
 }
 
 //_______________________________________________________________________
-int
-PHG4CEmcTestBeamSubsystem::process_event( PHCompositeNode * topNode )
+int PHG4CEmcTestBeamSubsystem::process_event(PHCompositeNode* topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
   if (steppingAction_)
-    {
-      steppingAction_->SetInterfacePointers( topNode );
-    }
+  {
+    steppingAction_->SetInterfacePointers(topNode);
+  }
   return 0;
 }
 
-
 //_______________________________________________________________________
-PHG4Detector* PHG4CEmcTestBeamSubsystem::GetDetector( void ) const
+PHG4Detector* PHG4CEmcTestBeamSubsystem::GetDetector(void) const
 {
   return detector_;
 }
 
 //_______________________________________________________________________
-PHG4SteppingAction* PHG4CEmcTestBeamSubsystem::GetSteppingAction( void ) const
+PHG4SteppingAction* PHG4CEmcTestBeamSubsystem::GetSteppingAction(void) const
 {
   return steppingAction_;
 }
 
-void
-PHG4CEmcTestBeamSubsystem::SetPlace(const G4double place_x, const G4double place_y, const G4double place_z)
+void PHG4CEmcTestBeamSubsystem::SetPlace(const G4double place_x, const G4double place_y, const G4double place_z)
 {
   place_in_x = place_x * cm;
   place_in_y = place_y * cm;
   place_in_z = place_z * cm;
 }
 
-void
-PHG4CEmcTestBeamSubsystem::SetPlaceZ(const G4double dbl)
+void PHG4CEmcTestBeamSubsystem::SetPlaceZ(const G4double dbl)
 {
   place_in_z = dbl * cm;
 }
 
-void
-PHG4CEmcTestBeamSubsystem::SetXRot(const G4double dbl)
+void PHG4CEmcTestBeamSubsystem::SetXRot(const G4double dbl)
 {
   rot_in_x = dbl * deg;
 }
 
-void
-PHG4CEmcTestBeamSubsystem::SetYRot(const G4double dbl)
+void PHG4CEmcTestBeamSubsystem::SetYRot(const G4double dbl)
 {
   rot_in_y = dbl * deg;
 }
 
-void
-PHG4CEmcTestBeamSubsystem::SetZRot(const G4double dbl)
+void PHG4CEmcTestBeamSubsystem::SetZRot(const G4double dbl)
 {
   rot_in_z = dbl * deg;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.cc
@@ -64,7 +64,7 @@ PHG4CEmcTestBeamSubsystem::Init( PHCompositeNode* topNode )
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
 
   // create detector
-  detector_ = new PHG4CEmcTestBeamDetector(topNode, Name(), layer);
+  detector_ = new PHG4CEmcTestBeamDetector(this, topNode, Name(), layer);
   detector_->SetPlace(place_in_x, place_in_y, place_in_z);
   detector_->SetXRot(rot_in_x);
   detector_->SetYRot(rot_in_y);

--- a/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
@@ -2,94 +2,92 @@
 
 #include <g4main/PHG4Utils.h>
 
-#include <Geant4/G4Material.hh>
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4LogicalVolume.hh>
-#include <Geant4/G4RotationMatrix.hh>    // for G4RotationMatrix
-#include <Geant4/G4SystemOfUnits.hh>     // for cm
-#include <Geant4/G4ThreeVector.hh>       // for G4ThreeVector
+#include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4SystemOfUnits.hh>   // for cm
+#include <Geant4/G4ThreeVector.hh>     // for G4ThreeVector
 #include <Geant4/G4VisAttributes.hh>
 
-#include <cmath>                        // for M_PI
-#include <cstdlib>                      // for exit
-#include <iostream>                      // for operator<<, endl, basic_ostream
+#include <cmath>     // for M_PI
+#include <cstdlib>   // for exit
+#include <iostream>  // for operator<<, endl, basic_ostream
 #include <sstream>
 
 using namespace std;
 
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4ConeDetector::PHG4ConeDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam,const int lyr  ):
-  PHG4Detector(subsys,Node, dnam),
-  TrackerMaterial(nullptr),
-  block_solid(nullptr),
-  block_logic(nullptr),
-  block_physi(nullptr),
-  place_in_x(0*cm),
-  place_in_y(0*cm),
-  place_in_z(300*cm),
-  rMin1(5*cm),
-  rMax1(100*cm),
-  rMin2(5*cm),
-  rMax2(200*cm),
-  dZ(100*cm),
-  sPhi(0),
-  dPhi(2*M_PI),
-  z_rot(0),
-  _region(nullptr),
-  active(0),
-  layer(lyr)
-{}
+PHG4ConeDetector::PHG4ConeDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr)
+  : PHG4Detector(subsys, Node, dnam)
+  , TrackerMaterial(nullptr)
+  , block_solid(nullptr)
+  , block_logic(nullptr)
+  , block_physi(nullptr)
+  , place_in_x(0 * cm)
+  , place_in_y(0 * cm)
+  , place_in_z(300 * cm)
+  , rMin1(5 * cm)
+  , rMax1(100 * cm)
+  , rMin2(5 * cm)
+  , rMax2(200 * cm)
+  , dZ(100 * cm)
+  , sPhi(0)
+  , dPhi(2 * M_PI)
+  , z_rot(0)
+  , _region(nullptr)
+  , active(0)
+  , layer(lyr)
+{
+}
 
 //_______________________________________________________________
 //_______________________________________________________________
-bool PHG4ConeDetector::IsInConeActive(G4VPhysicalVolume * volume)
+bool PHG4ConeDetector::IsInConeActive(G4VPhysicalVolume *volume)
 {
   if (volume == block_physi)
-    {
-      return true;
-    }
+  {
+    return true;
+  }
   return false;
 }
 
 //_______________________________________________________________
-bool PHG4ConeDetector::IsInConeInactive(G4VPhysicalVolume * volume)
+bool PHG4ConeDetector::IsInConeInactive(G4VPhysicalVolume *volume)
 {
   return false;
 }
 
 //_______________________________________________________________
-void PHG4ConeDetector::ConstructMe( G4LogicalVolume* logicWorld )
+void PHG4ConeDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
-
   TrackerMaterial = G4Material::GetMaterial(material.c_str());
 
-
-  if ( ! TrackerMaterial )
-    {
-      std::cout << "Error: Can not set material" << std::endl;
-      exit(-1);
-    }
+  if (!TrackerMaterial)
+  {
+    std::cout << "Error: Can not set material" << std::endl;
+    exit(-1);
+  }
 
   block_solid = new G4Cons(G4String(GetName().c_str()),
-			   rMin1, rMax1, rMin2, rMax2, dZ, sPhi, dPhi);
+                           rMin1, rMax1, rMin2, rMax2, dZ, sPhi, dPhi);
 
   block_logic = new G4LogicalVolume(block_solid,
                                     TrackerMaterial,
                                     G4String(GetName().c_str()),
                                     0, 0, 0);
-  G4VisAttributes* matVis = new G4VisAttributes();
-  PHG4Utils::SetColour(matVis,material);
+  G4VisAttributes *matVis = new G4VisAttributes();
+  PHG4Utils::SetColour(matVis, material);
   matVis->SetVisibility(true);
   matVis->SetForceSolid(true);
   block_logic->SetVisAttributes(matVis);
 
-  G4RotationMatrix *rotm  = new G4RotationMatrix();
+  G4RotationMatrix *rotm = new G4RotationMatrix();
   rotm->rotateZ(z_rot);
   block_physi = new G4PVPlacement(rotm, G4ThreeVector(place_in_x, place_in_y, place_in_z),
                                   block_logic,
                                   G4String(GetName().c_str()),
                                   logicWorld, 0, false, OverlapCheck());
-
 }

--- a/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
@@ -20,8 +20,8 @@ using namespace std;
 
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4ConeDetector::PHG4ConeDetector( PHCompositeNode *Node, const std::string &dnam,const int lyr  ):
-  PHG4Detector(Node, dnam),
+PHG4ConeDetector::PHG4ConeDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam,const int lyr  ):
+  PHG4Detector(subsys,Node, dnam),
   TrackerMaterial(nullptr),
   block_solid(nullptr),
   block_logic(nullptr),
@@ -60,7 +60,7 @@ bool PHG4ConeDetector::IsInConeInactive(G4VPhysicalVolume * volume)
 }
 
 //_______________________________________________________________
-void PHG4ConeDetector::Construct( G4LogicalVolume* logicWorld )
+void PHG4ConeDetector::ConstructMe( G4LogicalVolume* logicWorld )
 {
 
   TrackerMaterial = G4Material::GetMaterial(material.c_str());

--- a/simulation/g4simulation/g4detectors/PHG4ConeDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDetector.h
@@ -19,6 +19,7 @@ class G4Material;
 class G4UserSteppingAction;
 class G4VPhysicalVolume;
 class PHCompositeNode;
+class PHG4Subsystem;
 
 class PHG4ConeDetector: public PHG4Detector
 {
@@ -26,14 +27,14 @@ class PHG4ConeDetector: public PHG4Detector
   public:
 
   //! constructor
-  PHG4ConeDetector( PHCompositeNode *Node, const std::string &dnam="BLOCK", const int lyr = 0 );
+  PHG4ConeDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr = 0 );
 
   //! destructor
   virtual ~PHG4ConeDetector( void )
   {}
 
   //! construct
-  virtual void Construct( G4LogicalVolume* world );
+  virtual void ConstructMe( G4LogicalVolume* world );
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4detectors/PHG4ConeDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDetector.h
@@ -6,12 +6,11 @@
 #include "g4main/PHG4Detector.h"
 
 #include <Geant4/G4Region.hh>
-#include <Geant4/G4String.hh>           // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Types.hh>
 
-#include <string>                       // for string
-
+#include <string>  // for string
 
 class G4Cons;
 class G4LogicalVolume;
@@ -21,20 +20,19 @@ class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4Subsystem;
 
-class PHG4ConeDetector: public PHG4Detector
+class PHG4ConeDetector : public PHG4Detector
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4ConeDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr = 0 );
+  PHG4ConeDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam, const int lyr = 0);
 
   //! destructor
-  virtual ~PHG4ConeDetector( void )
-  {}
+  virtual ~PHG4ConeDetector(void)
+  {
+  }
 
   //! construct
-  virtual void ConstructMe( G4LogicalVolume* world );
+  virtual void ConstructMe(G4LogicalVolume* world);
 
   //!@name volume accessors
   //@{
@@ -44,49 +42,58 @@ class PHG4ConeDetector: public PHG4Detector
 
   //!set inner and outter radius1
   void SetR1(const G4double min, const G4double max)
-  {rMin1 = min*cm; rMax1=max*cm;}
+  {
+    rMin1 = min * cm;
+    rMax1 = max * cm;
+  }
 
   //!set inner and outter radius2
   void SetR2(const G4double min, const G4double max)
-  {rMin2 = min*cm; rMax2=max*cm;}
+  {
+    rMin2 = min * cm;
+    rMax2 = max * cm;
+  }
 
   //! set length in Z
   void SetZlength(const G4double a)
-  {dZ = a*cm;}
+  {
+    dZ = a * cm;
+  }
 
   //! set phi offset and extention
   void SetPhi(const G4double a, const G4double b)
-  {sPhi = a; dPhi = g;}
+  {
+    sPhi = a;
+    dPhi = g;
+  }
 
-  void SetMaterial(const std::string &mat) {material = mat;}
-  void SetPlaceZ(const G4double place_z) {place_in_z = place_z*cm;}
+  void SetMaterial(const std::string& mat) { material = mat; }
+  void SetPlaceZ(const G4double place_z) { place_in_z = place_z * cm; }
   void SetPlace(const G4double place_x, const G4double place_y, const G4double place_z)
   {
-    place_in_x = place_x*cm;
-    place_in_y = place_y*cm;
-    place_in_z = place_z*cm;
+    place_in_x = place_x * cm;
+    place_in_y = place_y * cm;
+    place_in_z = place_z * cm;
   }
-  void SetZRot(const G4double z_angle) {z_rot = z_angle*rad;}
-  virtual G4UserSteppingAction* GetSteppingAction() 
-  { 
-    if ( _region )
+  void SetZRot(const G4double z_angle) { z_rot = z_angle * rad; }
+  virtual G4UserSteppingAction* GetSteppingAction()
+  {
+    if (_region)
       return _region->GetRegionalSteppingAction();
-    else return 0;
+    else
+      return 0;
   }
-  void SetActive(const int i = 1) {active = i;}
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return layer;}
+  void SetActive(const int i = 1) { active = i; }
+  void SuperDetector(const std::string& name) { superdetector = name; }
+  const std::string SuperDetector() const { return superdetector; }
+  int get_Layer() const { return layer; }
 
-  private:
-
- 
+ private:
   G4Material* TrackerMaterial;
 
   G4Cons* block_solid;
   G4LogicalVolume* block_logic;
   G4VPhysicalVolume* block_physi;
-
 
   G4String material;
   G4double place_in_x;
@@ -105,7 +112,6 @@ class PHG4ConeDetector: public PHG4Detector
   int active;
   int layer;
   std::string superdetector;
-  
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
@@ -1,22 +1,22 @@
 #include "PHG4ConeSubsystem.h"
 #include "PHG4ConeDetector.h"
-#include "PHG4EventActionClearZeroEdep.h"
 #include "PHG4ConeSteppingAction.h"
+#include "PHG4EventActionClearZeroEdep.h"
 
 #include <g4main/PHG4HitContainer.h>
 
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>            // for PHIODataNode
-#include <phool/PHNode.h>                  // for PHNode
-#include <phool/PHNodeIterator.h>          // for PHNodeIterator
-#include <phool/PHObject.h>                // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
+#include <phool/getClass.h>
 
-#include <Geant4/G4String.hh>              // for G4String
-#include <Geant4/G4SystemOfUnits.hh>       // for cm
-#include <Geant4/G4Types.hh>               // for G4double
+#include <Geant4/G4String.hh>         // for G4String
+#include <Geant4/G4SystemOfUnits.hh>  // for cm
+#include <Geant4/G4Types.hh>          // for G4double
 
-#include <cmath>                          // for tan, atan, exp, M_PI
+#include <cmath>  // for tan, atan, exp, M_PI
 #include <sstream>
 
 class PHG4Detector;
@@ -25,29 +25,28 @@ class PHG4SteppingAction;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4ConeSubsystem::PHG4ConeSubsystem( const std::string &name, const int lyr ):
-  PHG4Subsystem( name ),
-  detector_( 0 ),
-  steppingAction_( nullptr ),
-  eventAction_(nullptr),
-  place_in_x(0),
-  place_in_y(0),
-  place_in_z(0),
-  rot_in_z(0),
-  rMin1(5*cm),
-  rMax1(100*cm),
-  rMin2(5*cm),
-  rMax2(200*cm),
-  dZ(100*cm),
-  sPhi(0),
-  dPhi(2*M_PI),
-  material("Silicon"),
-  active(0),
-  layer(lyr),
-  detector_type(name),
-  superdetector("NONE")
+PHG4ConeSubsystem::PHG4ConeSubsystem(const std::string& name, const int lyr)
+  : PHG4Subsystem(name)
+  , detector_(0)
+  , steppingAction_(nullptr)
+  , eventAction_(nullptr)
+  , place_in_x(0)
+  , place_in_y(0)
+  , place_in_z(0)
+  , rot_in_z(0)
+  , rMin1(5 * cm)
+  , rMax1(100 * cm)
+  , rMin2(5 * cm)
+  , rMax2(200 * cm)
+  , dZ(100 * cm)
+  , sPhi(0)
+  , dPhi(2 * M_PI)
+  , material("Silicon")
+  , active(0)
+  , layer(lyr)
+  , detector_type(name)
+  , superdetector("NONE")
 {
-  
   // put the layer into the name so we get unique names
   // for multiple layers
   ostringstream nam;
@@ -56,13 +55,13 @@ PHG4ConeSubsystem::PHG4ConeSubsystem( const std::string &name, const int lyr ):
 }
 
 //_______________________________________________________________________
-int PHG4ConeSubsystem::Init( PHCompositeNode* topNode )
+int PHG4ConeSubsystem::Init(PHCompositeNode* topNode)
 {
-    PHNodeIterator iter( topNode );
-    PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","DST" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-    detector_ = new PHG4ConeDetector(this,topNode, Name(), layer);
+  detector_ = new PHG4ConeDetector(this, topNode, Name(), layer);
   detector_->SetR1(rMin1, rMax1);
   detector_->SetR2(rMin2, rMax2);
   detector_->SetZlength(dZ);
@@ -74,69 +73,66 @@ int PHG4ConeSubsystem::Init( PHCompositeNode* topNode )
   detector_->SuperDetector(superdetector);
   detector_->OverlapCheck(CheckOverlap());
   if (active)
-    {
-  ostringstream nodename;
-  if (superdetector != "NONE")
-    {
-  nodename <<  "G4HIT_" << superdetector; 
-    }
-  else
-    {
-          nodename <<  "G4HIT_" << detector_type << "_" << layer;
-    }
-  // create hit list
-  PHG4HitContainer* block_hits =  findNode::getClass<PHG4HitContainer>( topNode ,nodename.str().c_str());
-  if ( !block_hits )
   {
-
-    dstNode->addNode( new PHIODataNode<PHObject>( block_hits = new PHG4HitContainer(nodename.str()),nodename.str().c_str(),"PHObject" ));
-
-  }
-  // create stepping action
-  steppingAction_ = new PHG4ConeSteppingAction(detector_);
-
-  eventAction_ = new PHG4EventActionClearZeroEdep(topNode, nodename.str());
+    ostringstream nodename;
+    if (superdetector != "NONE")
+    {
+      nodename << "G4HIT_" << superdetector;
     }
-  return 0;
+    else
+    {
+      nodename << "G4HIT_" << detector_type << "_" << layer;
+    }
+    // create hit list
+    PHG4HitContainer* block_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+    if (!block_hits)
+    {
+      dstNode->addNode(new PHIODataNode<PHObject>(block_hits = new PHG4HitContainer(nodename.str()), nodename.str().c_str(), "PHObject"));
+    }
+    // create stepping action
+    steppingAction_ = new PHG4ConeSteppingAction(detector_);
 
+    eventAction_ = new PHG4EventActionClearZeroEdep(topNode, nodename.str());
+  }
+  return 0;
 }
 
 //_______________________________________________________________________
-int 
-PHG4ConeSubsystem::process_event( PHCompositeNode* topNode )
+int PHG4ConeSubsystem::process_event(PHCompositeNode* topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
   if (steppingAction_)
-    {
-      steppingAction_->SetInterfacePointers( topNode );
-    }
+  {
+    steppingAction_->SetInterfacePointers(topNode);
+  }
   return 0;
 }
 
-
 //_______________________________________________________________________
-PHG4Detector* PHG4ConeSubsystem::GetDetector( void ) const
-{ return detector_; }
-
-//_______________________________________________________________________
-PHG4SteppingAction* PHG4ConeSubsystem::GetSteppingAction( void ) const
-{ return steppingAction_; }
-
-
-//_______________________________________________________________________
-void 
-PHG4ConeSubsystem::Set_eta_range(G4double etaMin, G4double etaMax)
+PHG4Detector* PHG4ConeSubsystem::GetDetector(void) const
 {
-  G4double thetaMin = 2*atan(exp(-etaMax));
-  G4double thetaMax = 2*atan(exp(-etaMin));
+  return detector_;
+}
+
+//_______________________________________________________________________
+PHG4SteppingAction* PHG4ConeSubsystem::GetSteppingAction(void) const
+{
+  return steppingAction_;
+}
+
+//_______________________________________________________________________
+void PHG4ConeSubsystem::Set_eta_range(G4double etaMin, G4double etaMax)
+{
+  G4double thetaMin = 2 * atan(exp(-etaMax));
+  G4double thetaMax = 2 * atan(exp(-etaMin));
 
   G4double z1 = place_in_z - dZ;
   G4double z2 = place_in_z + dZ;
 
-  rMin1 = z1*tan(thetaMin);
-  rMax1 = z1*tan(thetaMax);
+  rMin1 = z1 * tan(thetaMin);
+  rMax1 = z1 * tan(thetaMax);
 
-  rMin2 = z2*tan(thetaMin);
-  rMax2 = z2*tan(thetaMax);
+  rMin2 = z2 * tan(thetaMin);
+  rMax2 = z2 * tan(thetaMax);
 }

--- a/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
@@ -62,7 +62,7 @@ int PHG4ConeSubsystem::Init( PHCompositeNode* topNode )
     PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","DST" ));
 
   // create detector
-  detector_ = new PHG4ConeDetector(topNode, Name(), layer);
+    detector_ = new PHG4ConeDetector(this,topNode, Name(), layer);
   detector_->SetR1(rMin1, rMax1);
   detector_->SetR2(rMin2, rMax2);
   detector_->SetZlength(dZ);

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
@@ -30,8 +30,8 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4CrystalCalorimeterDetector::PHG4CrystalCalorimeterDetector(PHG4CrystalCalorimeterSubsystem* subsys, PHCompositeNode* Node, const std::string& dnam)
-  : PHG4Detector(Node, dnam)
+PHG4CrystalCalorimeterDetector::PHG4CrystalCalorimeterDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , _place_in_x(0.0 * mm)
   , _place_in_y(0.0 * mm)
   , _place_in_z(-1080.0 * mm)
@@ -84,7 +84,7 @@ int PHG4CrystalCalorimeterDetector::IsInCrystalCalorimeter(G4VPhysicalVolume* vo
 }
 
 //_______________________________________________________________________
-void PHG4CrystalCalorimeterDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4CrystalCalorimeterDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   if (Verbosity() > 0)
   {

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
@@ -2,28 +2,28 @@
 #include "PHG4CrystalCalorimeterDisplayAction.h"
 #include "PHG4CrystalCalorimeterSubsystem.h"
 
-#include <g4main/PHG4Detector.h>                  // for PHG4Detector
-#include <g4main/PHG4DisplayAction.h>             // for PHG4DisplayAction
+#include <g4main/PHG4Detector.h>       // for PHG4Detector
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Cons.hh>
-#include <Geant4/G4Element.hh>                    // for G4Element
+#include <Geant4/G4Element.hh>  // for G4Element
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>             // for G4RotationMatrix
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
 #include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>                // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>                // for G4Transform3D
-#include <Geant4/G4Types.hh>                      // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>            // for G4VPhysicalVolume
+#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>      // for G4Transform3D
+#include <Geant4/G4Types.hh>            // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
-#include <utility>                                // for pair, make_pair
+#include <utility>  // for pair, make_pair
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
@@ -15,7 +15,7 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4CrystalCalorimeterDisplayAction;
-class PHG4CrystalCalorimeterSubsystem;
+class PHG4Subsystem;
 
 /**
  * \file ${file_name}
@@ -27,13 +27,13 @@ class PHG4CrystalCalorimeterDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4CrystalCalorimeterDetector(PHG4CrystalCalorimeterSubsystem *subsys, PHCompositeNode *Node, const std::string &dnam = "BLOCK");
+  PHG4CrystalCalorimeterDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4CrystalCalorimeterDetector() {}
 
   //! construct
-  virtual void Construct(G4LogicalVolume *world);
+  virtual void ConstructMe(G4LogicalVolume *world);
 
   //! check if volume is in this calorimeter
   virtual int IsInCrystalCalorimeter(G4VPhysicalVolume *) const;

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
@@ -5,7 +5,7 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/G4String.hh>     // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4Types.hh>
 
 #include <map>

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -4,21 +4,21 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4Detector.h>          // for PHG4Detector
-#include <g4main/PHG4DisplayAction.h>     // for PHG4DisplayAction
+#include <g4main/PHG4Detector.h>       // for PHG4Detector
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4PhysicalConstants.hh>
-#include <Geant4/G4String.hh>             // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>        // for G4ThreeVector
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4UserLimits.hh>
 
 #include <cmath>
-#include <iostream>                       // for operator<<, endl, basic_ost...
+#include <iostream>  // for operator<<, endl, basic_ost...
 #include <sstream>
 
 class G4VSolid;
@@ -79,5 +79,5 @@ void PHG4CylinderDetector::ConstructMe(G4LogicalVolume *logicWorld)
                                                cylinder_logic,
                                                G4String(GetName()),
                                                logicWorld, 0, false, OverlapCheck());
-   m_DisplayAction->SetMyVolume(cylinder_logic);
+  m_DisplayAction->SetMyVolume(cylinder_logic);
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -27,8 +27,8 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________
-PHG4CylinderDetector::PHG4CylinderDetector(PHG4CylinderSubsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr)
-  : PHG4Detector(Node, dnam)
+PHG4CylinderDetector::PHG4CylinderDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr)
+  : PHG4Detector(subsys, Node, dnam)
   , m_Params(parameters)
   , m_CylinderPhysicalVolume(nullptr)
   , m_DisplayAction(dynamic_cast<PHG4CylinderDisplayAction *>(subsys->GetDisplayAction()))
@@ -47,7 +47,7 @@ bool PHG4CylinderDetector::IsInCylinder(const G4VPhysicalVolume *volume) const
 }
 
 //_______________________________________________________________
-void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4CylinderDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   G4Material *TrackerMaterial = G4Material::GetMaterial(m_Params->get_string_param("material"));
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
@@ -11,14 +11,14 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4CylinderDisplayAction;
-class PHG4CylinderSubsystem;
+class PHG4Subsystem;
 class PHParameters;
 
 class PHG4CylinderDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4CylinderDetector(PHG4CylinderSubsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int layer = 0);
+  PHG4CylinderDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int layer = 0);
 
   //! destructor
   virtual ~PHG4CylinderDetector()
@@ -26,7 +26,7 @@ class PHG4CylinderDetector : public PHG4Detector
   }
 
   //! construct
-  void Construct(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world);
 
   bool IsInCylinder(const G4VPhysicalVolume *) const;
   void SuperDetector(const std::string &name) { m_SuperDetector = name; }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.h
@@ -5,40 +5,41 @@
 
 #include "PHG4CylinderGeom.h"
 
-#include <iostream>            // for cout, ostream
+#include <iostream>  // for cout, ostream
 
 class PHParameters;
 
-class PHG4CylinderGeomv1: public PHG4CylinderGeom
+class PHG4CylinderGeomv1 : public PHG4CylinderGeom
 {
  public:
   PHG4CylinderGeomv1();
-  PHG4CylinderGeomv1(const double r, const double zmi, const double zma, const double thickn):
-    layer(-1),
-    radius(r),
-    zmin(zmi),
-    zmax(zma),
-    thickness(thickn)
-      {}
+  PHG4CylinderGeomv1(const double r, const double zmi, const double zma, const double thickn)
+    : layer(-1)
+    , radius(r)
+    , zmin(zmi)
+    , zmax(zma)
+    , thickness(thickn)
+  {
+  }
 
   virtual ~PHG4CylinderGeomv1() {}
 
   void identify(std::ostream& os = std::cout) const;
-  int get_layer() const {return layer;}
-  double get_radius() const {return radius;}
-  double get_thickness() const {return thickness;}
-  double get_zmin() const {return zmin;}
-  double get_zmax() const {return zmax;}
+  int get_layer() const { return layer; }
+  double get_radius() const { return radius; }
+  double get_thickness() const { return thickness; }
+  double get_zmin() const { return zmin; }
+  double get_zmax() const { return zmax; }
 
-  void set_layer(const int i) {layer = i;}
-  void set_radius(const double r) {radius = r;}
-  void set_thickness(const double t) {thickness = t;}
-  void set_zmin(const double z) {zmin = z;}
-  void set_zmax(const double z) {zmax = z;}
+  void set_layer(const int i) { layer = i; }
+  void set_radius(const double r) { radius = r; }
+  void set_thickness(const double t) { thickness = t; }
+  void set_zmin(const double z) { zmin = z; }
+  void set_zmax(const double z) { zmax = z; }
 
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHParameters & param);
-  
+  virtual void ImportParameters(const PHParameters& param);
+
  protected:
   int layer;
   double radius;
@@ -46,7 +47,7 @@ class PHG4CylinderGeomv1: public PHG4CylinderGeom
   double zmax;
   double thickness;
 
-  ClassDef(PHG4CylinderGeomv1,1)
+  ClassDef(PHG4CylinderGeomv1, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.h
@@ -7,6 +7,8 @@
 
 #include <iostream>            // for cout, ostream
 
+class PHParameters;
+
 class PHG4CylinderGeomv1: public PHG4CylinderGeom
 {
  public:

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -5,7 +5,10 @@
 
 #include "PHG4DetectorSubsystem.h"
 
+#if !defined(__CINT__) || defined(__CLING__)
 #include <array>   // for array
+#endif
+
 #include <string>  // for string
 
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -5,8 +5,8 @@
 
 #include "PHG4DetectorSubsystem.h"
 
-#include <array>                    // for array
-#include <string>                   // for string
+#include <array>   // for array
+#include <string>  // for string
 
 class PHCompositeNode;
 class PHG4CylinderDetector;
@@ -46,7 +46,7 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
   PHG4SteppingAction* GetSteppingAction(void) const { return m_SteppingAction; }
 
   PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
-  void set_color(const double red, const double green, const double blue, const double alpha=1.)
+  void set_color(const double red, const double green, const double blue, const double alpha = 1.)
   {
     m_ColorArray[0] = red;
     m_ColorArray[1] = green;
@@ -71,11 +71,10 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
 
   //! Color setting if we want to override the default
 #if !defined(__CINT__) || defined(__CLING__)
-  std::array<double,4> m_ColorArray;
+  std::array<double, 4> m_ColorArray;
 #else
   double m_ColorArray[4];
 #endif
-
 };
 
 #endif  // G4DETECTORS_PHG4CYLINDERSUBSYSTEM_H

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -5,6 +5,7 @@
 
 #include "PHG4DetectorSubsystem.h"
 
+#include <array>                    // for array
 #include <string>                   // for string
 
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.h
@@ -25,7 +25,7 @@ class PHG4DetectorGroupSubsystem : public PHG4Subsystem
 
   virtual ~PHG4DetectorGroupSubsystem() {}
 // stupid rootcint does not support final keyword
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   int Init(PHCompositeNode *) final;
   int InitRun(PHCompositeNode *) final;
 #else

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
@@ -21,7 +21,7 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
   virtual ~PHG4DetectorSubsystem() {}
 
   // stupid rootcint does not support final keyword
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   int Init(PHCompositeNode *) final;
   int InitRun(PHCompositeNode *) final;
 #else

--- a/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.cc
@@ -1,6 +1,6 @@
 #include "PHG4EICForwardEcalDetector.h"
 
-#include "PHG4ForwardEcalDetector.h"       // for PHG4ForwardEcalDetector
+#include "PHG4ForwardEcalDetector.h"  // for PHG4ForwardEcalDetector
 #include "PHG4ForwardEcalDisplayAction.h"
 
 #include <Geant4/G4Box.hh>
@@ -8,17 +8,17 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>      // for G4RotationMatrix
-#include <Geant4/G4SystemOfUnits.hh>       // for cm, mm
-#include <Geant4/G4ThreeVector.hh>         // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>         // for G4Transform3D
-#include <Geant4/G4Types.hh>               // for G4double, G4int
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4SystemOfUnits.hh>   // for cm, mm
+#include <Geant4/G4ThreeVector.hh>     // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>     // for G4Transform3D
+#include <Geant4/G4Types.hh>           // for G4double, G4int
 
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <utility>                         // for pair, make_pair
+#include <utility>  // for pair, make_pair
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.cc
@@ -25,7 +25,7 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4EICForwardEcalDetector::PHG4EICForwardEcalDetector(PHG4ForwardEcalSubsystem* subsys, PHCompositeNode* Node, const std::string& dnam)
+PHG4EICForwardEcalDetector::PHG4EICForwardEcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam)
   : PHG4ForwardEcalDetector(subsys, Node, dnam)
   , _tower_dx(30 * mm)
   , _tower_dy(30 * mm)
@@ -41,7 +41,7 @@ PHG4EICForwardEcalDetector::~PHG4EICForwardEcalDetector()
 }
 
 //_______________________________________________________________________
-void PHG4EICForwardEcalDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4EICForwardEcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   if (Verbosity() > 0)
   {

--- a/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.h
@@ -13,7 +13,7 @@
 
 class G4LogicalVolume;
 class PHCompositeNode;
-class PHG4ForwardEcalSubsystem;
+class PHG4Subsystem;
 
 /**
  * \file ${file_name}
@@ -25,13 +25,13 @@ class PHG4EICForwardEcalDetector : public PHG4ForwardEcalDetector
 {
  public:
   //! constructor
-  PHG4EICForwardEcalDetector(PHG4ForwardEcalSubsystem* subsys, PHCompositeNode* Node, const std::string& dnam = "BLOCK");
+  PHG4EICForwardEcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam);
 
   //! destructor
   virtual ~PHG4EICForwardEcalDetector();
 
   //! construct
-  virtual void Construct(G4LogicalVolume* world);
+  virtual void ConstructMe(G4LogicalVolume* world);
 
   void SetTowerDimensions(G4double dx, G4double dy, G4double dz)
   {

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
@@ -26,8 +26,8 @@ class PHCompositeNode;
 using namespace std;
 
 //___________________________________________________________________________________
-PHG4EnvelopeDetector::PHG4EnvelopeDetector(  PHCompositeNode *Node, const std::string &dnam ):
-	PHG4Detector(Node, dnam),
+PHG4EnvelopeDetector::PHG4EnvelopeDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam ):
+	PHG4Detector(subsys, Node, dnam),
 	_placeInX(0.0*mm),
 	_placeInY(0.0*mm),
 	_placeInZ(2.0*m),
@@ -63,7 +63,7 @@ PHG4EnvelopeDetector::IsInEnvelope(G4VPhysicalVolume * volume) const
 }
 
 void
-PHG4EnvelopeDetector::Construct( G4LogicalVolume* logicWorld )
+PHG4EnvelopeDetector::ConstructMe( G4LogicalVolume* logicWorld )
 {
 
 

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
@@ -1,23 +1,22 @@
 #include "PHG4EnvelopeDetector.h"
 
-#include <g4main/PHG4Detector.h>           // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>      // for G4RotationMatrix
-#include <Geant4/G4SystemOfUnits.hh>       // for mm, m
-#include <Geant4/G4ThreeVector.hh>         // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>         // for G4Transform3D
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4SystemOfUnits.hh>   // for mm, m
+#include <Geant4/G4ThreeVector.hh>     // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>     // for G4Transform3D
 #include <Geant4/G4Tubs.hh>
-#include <Geant4/G4Types.hh>               // for G4double
+#include <Geant4/G4Types.hh>            // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 #include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4VPhysicalVolume.hh>     // for G4VPhysicalVolume
 
-
-#include <cmath>                          // for M_PI
+#include <cmath>  // for M_PI
 #include <iostream>
 
 class G4VSolid;
@@ -26,136 +25,130 @@ class PHCompositeNode;
 using namespace std;
 
 //___________________________________________________________________________________
-PHG4EnvelopeDetector::PHG4EnvelopeDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam ):
-	PHG4Detector(subsys, Node, dnam),
-	_placeInX(0.0*mm),
-	_placeInY(0.0*mm),
-	_placeInZ(2.0*m),
-	_innerRadius(0.0*m),
-	_outerRadius(1.0*m),
-	_dZ(1.0*mm),
-	_dZ_cyl(2.0*m),
-	_sPhi(0),
-	_dPhi(2*M_PI),
-	_materialCrystal( "G4_PbWO4" ),
-	_active(1),
-	_layer(0),
-	_superdetector("NONE")
+PHG4EnvelopeDetector::PHG4EnvelopeDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam)
+  : PHG4Detector(subsys, Node, dnam)
+  , _placeInX(0.0 * mm)
+  , _placeInY(0.0 * mm)
+  , _placeInZ(2.0 * m)
+  , _innerRadius(0.0 * m)
+  , _outerRadius(1.0 * m)
+  , _dZ(1.0 * mm)
+  , _dZ_cyl(2.0 * m)
+  , _sPhi(0)
+  , _dPhi(2 * M_PI)
+  , _materialCrystal("G4_PbWO4")
+  , _active(1)
+  , _layer(0)
+  , _superdetector("NONE")
 {
-	
 }
 
 //_______________________________________________________________________________________
 PHG4EnvelopeDetector::~PHG4EnvelopeDetector()
-{}
-
-bool
-PHG4EnvelopeDetector::IsInEnvelope(G4VPhysicalVolume * volume) const
 {
-	if ( volume->GetName().find("arbage") != string::npos )
-	{
-		return true;	
-	}
-	else
-	{
-		return false;
-	}
 }
 
-void
-PHG4EnvelopeDetector::ConstructMe( G4LogicalVolume* logicWorld )
+bool PHG4EnvelopeDetector::IsInEnvelope(G4VPhysicalVolume* volume) const
 {
+  if (volume->GetName().find("arbage") != string::npos)
+  {
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
 
+void PHG4EnvelopeDetector::ConstructMe(G4LogicalVolume* logicWorld)
+{
+  //***************
+  //Backward Endcap
+  //***************
 
-	//***************
-	//Backward Endcap
-	//***************
+  G4double placeInZ = _placeInZ;
+  G4double placeInY = _placeInY;
+  G4double placeInX = _placeInX;
 
-	G4double placeInZ = _placeInZ;
-	G4double placeInY = _placeInY;
-	G4double placeInX = _placeInX;
+  G4double rMin1 = _innerRadius;
+  G4double rMax1 = _outerRadius;
+  G4double rMin2 = rMin1;
+  G4double rMax2 = rMax1;
+  G4double dZ = _dZ;
+  G4double sPhi = _sPhi;
+  G4double dPhi = _dPhi;
 
-	G4double rMin1 = _innerRadius;
-	G4double rMax1 = _outerRadius;
-	G4double rMin2 = rMin1;
-	G4double rMax2 = rMax1;
-	G4double dZ = _dZ;
-	G4double sPhi = _sPhi;
-	G4double dPhi = _dPhi;
+  G4Material* material_crystal = G4Material::GetMaterial("G4_PbWO4");
 
-	G4Material* material_crystal = G4Material::GetMaterial("G4_PbWO4");
+  G4VSolid* GarbageCollector_solid = new G4Cons("GarbageCollector_solid",
+                                                rMin1, rMax1,
+                                                rMin2, rMax2,
+                                                dZ / 2.,
+                                                sPhi, dPhi);
 
-	G4VSolid* GarbageCollector_solid = new G4Cons("GarbageCollector_solid",
-		rMin1, rMax1,
-		rMin2, rMax2,
-		dZ/2.,
-		sPhi, dPhi );
-	
-	G4LogicalVolume* GarbageCollector_logical =  new G4LogicalVolume(GarbageCollector_solid, material_crystal, G4String("GarbageCollector"), 0, 0, 0);
+  G4LogicalVolume* GarbageCollector_logical = new G4LogicalVolume(GarbageCollector_solid, material_crystal, G4String("GarbageCollector"), 0, 0, 0);
 
-	G4VisAttributes* ecalVisAtt = new G4VisAttributes();
-		ecalVisAtt->SetVisibility(true);
-		ecalVisAtt->SetForceSolid(false);
-		ecalVisAtt->SetColour(G4Colour::Magenta());
-	GarbageCollector_logical->SetVisAttributes(ecalVisAtt);
+  G4VisAttributes* ecalVisAtt = new G4VisAttributes();
+  ecalVisAtt->SetVisibility(true);
+  ecalVisAtt->SetForceSolid(false);
+  ecalVisAtt->SetColour(G4Colour::Magenta());
+  GarbageCollector_logical->SetVisAttributes(ecalVisAtt);
 
-	G4RotationMatrix ecal_rotm;
-		ecal_rotm.rotateX(0);
-		ecal_rotm.rotateY(0);
-		ecal_rotm.rotateZ(0);
+  G4RotationMatrix ecal_rotm;
+  ecal_rotm.rotateX(0);
+  ecal_rotm.rotateY(0);
+  ecal_rotm.rotateZ(0);
 
-	new G4PVPlacement( G4Transform3D(ecal_rotm, G4ThreeVector(placeInX, placeInY, placeInZ) ),
-		GarbageCollector_logical,
-		"GarbageCollector",   
-		logicWorld, 
-		0, 
-		false, 
-		OverlapCheck());
+  new G4PVPlacement(G4Transform3D(ecal_rotm, G4ThreeVector(placeInX, placeInY, placeInZ)),
+                    GarbageCollector_logical,
+                    "GarbageCollector",
+                    logicWorld,
+                    0,
+                    false,
+                    OverlapCheck());
 
-	//**************
-	//Forward Endcap
-	//**************
+  //**************
+  //Forward Endcap
+  //**************
 
-	new G4PVPlacement( G4Transform3D(ecal_rotm, G4ThreeVector(placeInX, placeInY, -1*placeInZ) ),
-		GarbageCollector_logical,
-		"GarbageCollector_front",
-		logicWorld,
-		0,
-		false,
-		OverlapCheck());
+  new G4PVPlacement(G4Transform3D(ecal_rotm, G4ThreeVector(placeInX, placeInY, -1 * placeInZ)),
+                    GarbageCollector_logical,
+                    "GarbageCollector_front",
+                    logicWorld,
+                    0,
+                    false,
+                    OverlapCheck());
 
-	//*****************************
-	//Cylinder Surrounding Detector
-	//*****************************
+  //*****************************
+  //Cylinder Surrounding Detector
+  //*****************************
 
-	G4double cyl_place = 0*mm;
-	G4double r_min = _outerRadius + (1)*mm;
-	G4double r_max = r_min + 1*mm;
-	G4double dZ_cyl = _dZ_cyl;
+  G4double cyl_place = 0 * mm;
+  G4double r_min = _outerRadius + (1) * mm;
+  G4double r_max = r_min + 1 * mm;
+  G4double dZ_cyl = _dZ_cyl;
 
+  G4VSolid* GarbageCollector_cyl_solid = new G4Tubs("GarbageCollector_cyl_solid",
+                                                    r_min,
+                                                    r_max,
+                                                    dZ_cyl,
+                                                    sPhi,
+                                                    dPhi);
 
-	G4VSolid* GarbageCollector_cyl_solid = new G4Tubs("GarbageCollector_cyl_solid",
-		r_min,
-		r_max,
-		dZ_cyl,
-		sPhi,
-		dPhi);
+  G4LogicalVolume* GarbageCollector_cyl_logical = new G4LogicalVolume(GarbageCollector_cyl_solid,
+                                                                      material_crystal,
+                                                                      G4String("GarbageCollector_cyl"),
+                                                                      0,
+                                                                      0,
+                                                                      0);
 
-	G4LogicalVolume* GarbageCollector_cyl_logical = new G4LogicalVolume(GarbageCollector_cyl_solid,
-		material_crystal,
-		G4String("GarbageCollector_cyl"),
-		0,
-		0,
-		0);
+  GarbageCollector_cyl_logical->SetVisAttributes(ecalVisAtt);
 
-	GarbageCollector_cyl_logical->SetVisAttributes(ecalVisAtt);
-
-	new G4PVPlacement( G4Transform3D(ecal_rotm, G4ThreeVector(0, 0, cyl_place) ),
-		GarbageCollector_cyl_logical,
-		"GarbageCollector_cyl",
-		logicWorld,
-		0,
-		false,
-		OverlapCheck());
-	
+  new G4PVPlacement(G4Transform3D(ecal_rotm, G4ThreeVector(0, 0, cyl_place)),
+                    GarbageCollector_cyl_logical,
+                    "GarbageCollector_cyl",
+                    logicWorld,
+                    0,
+                    false,
+                    OverlapCheck());
 }

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.h
@@ -5,7 +5,7 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/G4String.hh>     // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4Types.hh>
 
 #include <string>
@@ -15,40 +15,40 @@ class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4Subsystem;
 
-class PHG4EnvelopeDetector: public PHG4Detector
+class PHG4EnvelopeDetector : public PHG4Detector
 {
  public:
   //Constructor
   PHG4EnvelopeDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam);
-	
+
   //Destructor
   virtual ~PHG4EnvelopeDetector();
-	
+
   //Construct
-  virtual void ConstructMe( G4LogicalVolume* world );
-	
+  virtual void ConstructMe(G4LogicalVolume *world);
+
   //Volume accessors
-  bool IsInEnvelope(G4VPhysicalVolume*) const;
-	
-  void SetPlace( G4double place_in_x, G4double place_in_y, G4double place_in_z) 
+  bool IsInEnvelope(G4VPhysicalVolume *) const;
+
+  void SetPlace(G4double place_in_x, G4double place_in_y, G4double place_in_z)
   {
     _placeInX = place_in_x;
     _placeInY = place_in_y;
     _placeInZ = place_in_z;
   }
-	
-  void SetInnerRadius( G4double radius ) { _innerRadius = radius; }
-  void SetOuterRadius( G4double radius ) { _outerRadius = radius; }
-  void SetCylinderLength (G4double length) {_dZ_cyl = length; }
 
-  void SetActive(const int i = 1) {_active = i;}
-  int IsActive() const {return _active;}
+  void SetInnerRadius(G4double radius) { _innerRadius = radius; }
+  void SetOuterRadius(G4double radius) { _outerRadius = radius; }
+  void SetCylinderLength(G4double length) { _dZ_cyl = length; }
 
-  void SuperDetector(const std::string &name) {_superdetector = name;}
-  const std::string SuperDetector() const {return _superdetector;}
+  void SetActive(const int i = 1) { _active = i; }
+  int IsActive() const { return _active; }
 
-  int get_Layer() const {return _layer;}
-	
+  void SuperDetector(const std::string &name) { _superdetector = name; }
+  const std::string SuperDetector() const { return _superdetector; }
+
+  int get_Layer() const { return _layer; }
+
  private:
   G4double _placeInX;
   G4double _placeInY;
@@ -59,12 +59,12 @@ class PHG4EnvelopeDetector: public PHG4Detector
   G4double _dZ_cyl;
   G4double _sPhi;
   G4double _dPhi;
-		
+
   G4String _materialCrystal;
-		
+
   int _active;
-  int _layer;	
-	
+  int _layer;
+
   std::string _superdetector;
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.h
@@ -13,18 +13,19 @@
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
+class PHG4Subsystem;
 
 class PHG4EnvelopeDetector: public PHG4Detector
 {
  public:
   //Constructor
-  PHG4EnvelopeDetector(  PHCompositeNode *Node, const std::string &dnam="BLOCK" );
+  PHG4EnvelopeDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam);
 	
   //Destructor
   virtual ~PHG4EnvelopeDetector();
 	
   //Construct
-  virtual void Construct( G4LogicalVolume* world );
+  virtual void ConstructMe( G4LogicalVolume* world );
 	
   //Volume accessors
   bool IsInEnvelope(G4VPhysicalVolume*) const;

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
@@ -4,85 +4,80 @@
 #include "PHG4EnvelopeSteppingAction.h"
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4Subsystem.h>        // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>  // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>          // for PHIODataNode
-#include <phool/PHNode.h>                // for PHNode
-#include <phool/PHNodeIterator.h>        // for PHNodeIterator
-#include <phool/PHObject.h>              // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <sstream>
 
 using namespace std;
 
-PHG4EnvelopeSubsystem::PHG4EnvelopeSubsystem( const std::string &name, const int lyr ):
-	PHG4Subsystem( name ),
-	detector_( nullptr ),
-	steppingAction_( nullptr ),
-	material("G4_PbWO4"),  // default - lead tungstate crystal
-	active(1),
-	detector_type(name)
+PHG4EnvelopeSubsystem::PHG4EnvelopeSubsystem(const std::string& name, const int lyr)
+  : PHG4Subsystem(name)
+  , detector_(nullptr)
+  , steppingAction_(nullptr)
+  , material("G4_PbWO4")
+  ,  // default - lead tungstate crystal
+  active(1)
+  , detector_type(name)
 {
-
 }
 
-int PHG4EnvelopeSubsystem::Init( PHCompositeNode* topNode )
+int PHG4EnvelopeSubsystem::Init(PHCompositeNode* topNode)
 {
-	PHNodeIterator iter( topNode );
-	PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
 
-	// create detector
-	detector_ = new PHG4EnvelopeDetector(this, topNode, Name());
-	detector_->SetActive(active);
-	detector_->OverlapCheck(CheckOverlap());
-	
-	if (active)
-	{
-		// create hit output node
-		ostringstream nodename;
-		nodename <<  "G4HIT_ENVELOPE_" << detector_type;
-		
-		PHG4HitContainer* crystal_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
-		if (!crystal_hits)
-		{
-		  crystal_hits = new PHG4HitContainer(nodename.str());
-		  PHIODataNode<PHObject> *hitNode = new PHIODataNode<PHObject>(crystal_hits, nodename.str().c_str(), "PHObject");
-		  dstNode->addNode(hitNode);
-		}
+  // create detector
+  detector_ = new PHG4EnvelopeDetector(this, topNode, Name());
+  detector_->SetActive(active);
+  detector_->OverlapCheck(CheckOverlap());
 
-		// create stepping action
-		steppingAction_ = new PHG4EnvelopeSteppingAction(detector_);
-	}
-	return 0;
+  if (active)
+  {
+    // create hit output node
+    ostringstream nodename;
+    nodename << "G4HIT_ENVELOPE_" << detector_type;
+
+    PHG4HitContainer* crystal_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+    if (!crystal_hits)
+    {
+      crystal_hits = new PHG4HitContainer(nodename.str());
+      PHIODataNode<PHObject>* hitNode = new PHIODataNode<PHObject>(crystal_hits, nodename.str().c_str(), "PHObject");
+      dstNode->addNode(hitNode);
+    }
+
+    // create stepping action
+    steppingAction_ = new PHG4EnvelopeSteppingAction(detector_);
+  }
+  return 0;
 }
-
 
 //_______________________________________________________________________
-int
-PHG4EnvelopeSubsystem::process_event( PHCompositeNode * topNode )
+int PHG4EnvelopeSubsystem::process_event(PHCompositeNode* topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
   if (steppingAction_)
-    {
-      steppingAction_->SetInterfacePointers( topNode );
-    }
+  {
+    steppingAction_->SetInterfacePointers(topNode);
+  }
   return 0;
 }
 
-
 //_______________________________________________________________________
-PHG4Detector* PHG4EnvelopeSubsystem::GetDetector( void ) const
+PHG4Detector* PHG4EnvelopeSubsystem::GetDetector(void) const
 {
   return detector_;
 }
 
-
 //_______________________________________________________________________
-PHG4SteppingAction* PHG4EnvelopeSubsystem::GetSteppingAction( void ) const
+PHG4SteppingAction* PHG4EnvelopeSubsystem::GetSteppingAction(void) const
 {
   return steppingAction_;
 }
-

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
@@ -19,7 +19,7 @@ using namespace std;
 
 PHG4EnvelopeSubsystem::PHG4EnvelopeSubsystem( const std::string &name, const int lyr ):
 	PHG4Subsystem( name ),
-	detector_( 0 ),
+	detector_( nullptr ),
 	steppingAction_( nullptr ),
 	material("G4_PbWO4"),  // default - lead tungstate crystal
 	active(1),
@@ -34,7 +34,7 @@ int PHG4EnvelopeSubsystem::Init( PHCompositeNode* topNode )
 	PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
 
 	// create detector
-	detector_ = new PHG4EnvelopeDetector(topNode, Name());
+	detector_ = new PHG4EnvelopeDetector(this, topNode, Name());
 	detector_->SetActive(active);
 	detector_->OverlapCheck(CheckOverlap());
 	

--- a/simulation/g4simulation/g4detectors/PHG4FCalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FCalDetector.cc
@@ -8,174 +8,169 @@
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4NistManager.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4Region.hh>            // for G4Region
+#include <Geant4/G4Region.hh>  // for G4Region
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>       // for G4ThreeVector
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4Types.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#include <cstdlib>                      // for NULL, exit
-#include <iostream>                      // for stringstream, operator<<
+#include <cstdlib>   // for NULL, exit
+#include <iostream>  // for stringstream, operator<<
 #include <map>
 #include <sstream>
-#include <utility>                       // for pair
-
+#include <utility>  // for pair
 
 class PHCompositeNode;
 
 using namespace std;
 
-
-PHG4FCalDetector::PHG4FCalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const string &name ) :
-  PHG4Detector(subsys, Node, name),
-  length(1.0 * m),
-  absorber_thickness(5.0 * mm),
-  scintillator_thickness(5.0 * cm),
-  nlayers(4),
-  segments_per_column(20),
-  segments_per_thickness(1),
-  z_position(100.0 * cm),
-  layer_separation(1.0 * mm),
-  AbsorberMaterial(nullptr),
-  ScintillatorMaterial(nullptr),
-  _region(nullptr)
+PHG4FCalDetector::PHG4FCalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const string& name)
+  : PHG4Detector(subsys, Node, name)
+  , length(1.0 * m)
+  , absorber_thickness(5.0 * mm)
+  , scintillator_thickness(5.0 * cm)
+  , nlayers(4)
+  , segments_per_column(20)
+  , segments_per_thickness(1)
+  , z_position(100.0 * cm)
+  , layer_separation(1.0 * mm)
+  , AbsorberMaterial(nullptr)
+  , ScintillatorMaterial(nullptr)
+  , _region(nullptr)
 {
-  
 }
 
-
-G4Material*  PHG4FCalDetector::SetMaterial(G4String material)
+G4Material* PHG4FCalDetector::SetMaterial(G4String material)
 {
-  
   // search the material by its name and assign if found
-  if( G4Material* material_ptr = G4Material::GetMaterial( material ) )
-  { return material_ptr; }
-  else 
+  if (G4Material* material_ptr = G4Material::GetMaterial(material))
+  {
+    return material_ptr;
+  }
+  else
     return 0;
 }
 
-
 unsigned int PHG4FCalDetector::computeIndex(unsigned int layer, G4double x, G4double y, G4double z, G4double& xcenter, G4double& ycenter, G4double& zcenter)
 {
-  double z_start = z_position + absorber_thickness*(((double)layer) + 1.) + layer_separation*(((double)layer) + 1.) + scintillator_thickness*(((double)layer));
-  double z_width = scintillator_thickness/((double)segments_per_thickness);
-  unsigned int z_index = (unsigned int)((z - z_start)/z_width);
-  
-  double xy_start = -0.5*length;
-  double xy_width = length/((double)segments_per_column);
-  
-  unsigned int x_index = (unsigned int)((x - xy_start)/xy_width);
-  unsigned int y_index = (unsigned int)((y - xy_start)/xy_width);
-  
-  zcenter = z_start + z_index*z_width + 0.5*z_width;
-  xcenter = xy_start + x_index*xy_width + 0.5*xy_width;
-  ycenter = xy_start + y_index*xy_width + 0.5*xy_width;
-  
-  return (z_index*(segments_per_column*segments_per_column) + y_index*segments_per_column + x_index);
+  double z_start = z_position + absorber_thickness * (((double) layer) + 1.) + layer_separation * (((double) layer) + 1.) + scintillator_thickness * (((double) layer));
+  double z_width = scintillator_thickness / ((double) segments_per_thickness);
+  unsigned int z_index = (unsigned int) ((z - z_start) / z_width);
+
+  double xy_start = -0.5 * length;
+  double xy_width = length / ((double) segments_per_column);
+
+  unsigned int x_index = (unsigned int) ((x - xy_start) / xy_width);
+  unsigned int y_index = (unsigned int) ((y - xy_start) / xy_width);
+
+  zcenter = z_start + z_index * z_width + 0.5 * z_width;
+  xcenter = xy_start + x_index * xy_width + 0.5 * xy_width;
+  ycenter = xy_start + y_index * xy_width + 0.5 * xy_width;
+
+  return (z_index * (segments_per_column * segments_per_column) + y_index * segments_per_column + x_index);
 }
 
-
-void PHG4FCalDetector::ConstructMe( G4LogicalVolume* logicWorld )
+void PHG4FCalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
-//   const G4MaterialTable* mattab = G4Material::GetMaterialTable();
-//   for(unsigned int i=0;i<mattab->size();i++)
-//   {
-//     cout<<mattab->at(i)->GetName()<<endl;
-//   }
-  
+  //   const G4MaterialTable* mattab = G4Material::GetMaterialTable();
+  //   for(unsigned int i=0;i<mattab->size();i++)
+  //   {
+  //     cout<<mattab->at(i)->GetName()<<endl;
+  //   }
+
   G4NistManager* man = G4NistManager::Instance();
   ScintillatorMaterial = man->FindOrBuildMaterial("G4_POLYSTYRENE");
   AbsorberMaterial = man->FindOrBuildMaterial("G4_Pb");
-  
-  if ( ! ScintillatorMaterial ||
-    ! AbsorberMaterial )
+
+  if (!ScintillatorMaterial ||
+      !AbsorberMaterial)
   {
     std::cout << "PHG4SvxDetector::Construct - Error: Can not set material" << std::endl;
     exit(-1);
   }
-  
-  G4VisAttributes* polystyreneVis= new G4VisAttributes(G4Colour(0.0,1.0,1.0));
+
+  G4VisAttributes* polystyreneVis = new G4VisAttributes(G4Colour(0.0, 1.0, 1.0));
   polystyreneVis->SetVisibility(true);
   polystyreneVis->SetForceSolid(true);
-  
-  G4VisAttributes* leadVis= new G4VisAttributes(G4Colour(0.925, 0.345, 0));
+
+  G4VisAttributes* leadVis = new G4VisAttributes(G4Colour(0.925, 0.345, 0));
   leadVis->SetVisibility(true);
   leadVis->SetForceSolid(true);
-  
+
   _region = new G4Region("FCALREGION");
   _region->SetRegionalSteppingAction(new PHG4FCalSteppingAction(this));
-  
+
   G4double current_center_position = z_position;
-  for(unsigned int layer=0;layer<nlayers;layer++)
+  for (unsigned int layer = 0; layer < nlayers; layer++)
   {
     stringstream ss;
-    
-    ss.clear();ss.str("");
-    ss<<"FCalAbsSolid_"<<layer;
-    absorber_solid_[layer] = new G4Box(G4String(ss.str()), 0.5*length, 0.5*length, 0.5*absorber_thickness);
-    
-    ss.clear();ss.str("");
-    ss<<"FCalAbsLogical_"<<layer;
-    absorber_logic_[layer] = new G4LogicalVolume(absorber_solid_[layer], AbsorberMaterial, G4String(ss.str()),0,0,0);
+
+    ss.clear();
+    ss.str("");
+    ss << "FCalAbsSolid_" << layer;
+    absorber_solid_[layer] = new G4Box(G4String(ss.str()), 0.5 * length, 0.5 * length, 0.5 * absorber_thickness);
+
+    ss.clear();
+    ss.str("");
+    ss << "FCalAbsLogical_" << layer;
+    absorber_logic_[layer] = new G4LogicalVolume(absorber_solid_[layer], AbsorberMaterial, G4String(ss.str()), 0, 0, 0);
     absorber_logic_[layer]->SetVisAttributes(leadVis);
     _region->AddRootLogicalVolume(absorber_logic_[layer]);
-    
-    ss.clear();ss.str("");
-    ss<<"FCalAbsPhysical_"<<layer;
-    
-    absorber_physi_[layer] = new G4PVPlacement(0, G4ThreeVector(0.*cm, 0.*cm, current_center_position), absorber_logic_[layer], G4String(ss.str()), logicWorld, false, 0, false);
-    
-    current_center_position += 0.5*absorber_thickness;
-    current_center_position += 0.5*scintillator_thickness;
+
+    ss.clear();
+    ss.str("");
+    ss << "FCalAbsPhysical_" << layer;
+
+    absorber_physi_[layer] = new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, current_center_position), absorber_logic_[layer], G4String(ss.str()), logicWorld, false, 0, false);
+
+    current_center_position += 0.5 * absorber_thickness;
+    current_center_position += 0.5 * scintillator_thickness;
     current_center_position += layer_separation;
-    
-    ss.clear();ss.str("");
-    ss<<"FCalScintSolid_"<<layer;
-    scintillator_solid_[layer] = new G4Box(G4String(ss.str()), 0.5*length, 0.5*length, 0.5*scintillator_thickness);
-    
-    ss.clear();ss.str("");
-    ss<<"FCalScintLogical_"<<layer;
-    scintillator_logic_[layer] = new G4LogicalVolume(scintillator_solid_[layer], ScintillatorMaterial, G4String(ss.str()),0,0,0);
+
+    ss.clear();
+    ss.str("");
+    ss << "FCalScintSolid_" << layer;
+    scintillator_solid_[layer] = new G4Box(G4String(ss.str()), 0.5 * length, 0.5 * length, 0.5 * scintillator_thickness);
+
+    ss.clear();
+    ss.str("");
+    ss << "FCalScintLogical_" << layer;
+    scintillator_logic_[layer] = new G4LogicalVolume(scintillator_solid_[layer], ScintillatorMaterial, G4String(ss.str()), 0, 0, 0);
     scintillator_logic_[layer]->SetVisAttributes(polystyreneVis);
     _region->AddRootLogicalVolume(scintillator_logic_[layer]);
-    
-    ss.clear();ss.str("");
-    ss<<"FCalScintPhysical_"<<layer;
-    
-    scintillator_physi_[layer] = new G4PVPlacement(0, G4ThreeVector(0.*cm, 0.*cm, current_center_position), scintillator_logic_[layer], G4String(ss.str()), logicWorld, false, 0, false);
-    
-    current_center_position += 0.5*absorber_thickness;
-    current_center_position += 0.5*scintillator_thickness;
+
+    ss.clear();
+    ss.str("");
+    ss << "FCalScintPhysical_" << layer;
+
+    scintillator_physi_[layer] = new G4PVPlacement(0, G4ThreeVector(0. * cm, 0. * cm, current_center_position), scintillator_logic_[layer], G4String(ss.str()), logicWorld, false, 0, false);
+
+    current_center_position += 0.5 * absorber_thickness;
+    current_center_position += 0.5 * scintillator_thickness;
     current_center_position += layer_separation;
   }
 }
 
-
-bool PHG4FCalDetector::isInScintillator(G4VPhysicalVolume * volume)
+bool PHG4FCalDetector::isInScintillator(G4VPhysicalVolume* volume)
 {
   //loop over the physical volumes and see if this is a match
   std::map<unsigned int, G4VPhysicalVolume*>::iterator vol_iter = scintillator_physi_.begin();
-  for ( ; vol_iter != scintillator_physi_.end(); ++vol_iter )
+  for (; vol_iter != scintillator_physi_.end(); ++vol_iter)
   {
-    if ( vol_iter->second == volume )
+    if (vol_iter->second == volume)
       return true;
-    
   }
   return false;
 }
 
-
-int PHG4FCalDetector::getScintillatorLayer(G4VPhysicalVolume * volume)
+int PHG4FCalDetector::getScintillatorLayer(G4VPhysicalVolume* volume)
 {
   //loop over the physical volumes and see if this is a match
   std::map<unsigned int, G4VPhysicalVolume*>::iterator vol_iter = scintillator_physi_.begin();
-  for ( ; vol_iter != scintillator_physi_.end(); ++vol_iter )
+  for (; vol_iter != scintillator_physi_.end(); ++vol_iter)
   {
-    if ( vol_iter->second == volume )
+    if (vol_iter->second == volume)
       return vol_iter->first;
-    
   }
   return -1;
 }
-
-

--- a/simulation/g4simulation/g4detectors/PHG4FCalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FCalDetector.cc
@@ -26,8 +26,8 @@ class PHCompositeNode;
 using namespace std;
 
 
-PHG4FCalDetector::PHG4FCalDetector( PHCompositeNode *Node ) :
-  PHG4Detector(Node),
+PHG4FCalDetector::PHG4FCalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const string &name ) :
+  PHG4Detector(subsys, Node, name),
   length(1.0 * m),
   absorber_thickness(5.0 * mm),
   scintillator_thickness(5.0 * cm),
@@ -75,7 +75,7 @@ unsigned int PHG4FCalDetector::computeIndex(unsigned int layer, G4double x, G4do
 }
 
 
-void PHG4FCalDetector::Construct( G4LogicalVolume* logicWorld )
+void PHG4FCalDetector::ConstructMe( G4LogicalVolume* logicWorld )
 {
 //   const G4MaterialTable* mattab = G4Material::GetMaterialTable();
 //   for(unsigned int i=0;i<mattab->size();i++)

--- a/simulation/g4simulation/g4detectors/PHG4FCalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FCalDetector.h
@@ -18,16 +18,17 @@ class G4LogicalVolume;
 class G4UserSteppingAction;
 class G4VPhysicalVolume;
 class PHCompositeNode;
+class PHG4Subsystem;
 
 class PHG4FCalDetector: public PHG4Detector
 {
   public:
     
-    PHG4FCalDetector( PHCompositeNode *Node );
+  PHG4FCalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &name );
     
     virtual ~PHG4FCalDetector( void ){}
     
-    virtual void Construct( G4LogicalVolume* world );
+    virtual void ConstructMe( G4LogicalVolume* world );
     
     virtual G4UserSteppingAction* GetSteppingAction() 
     { 

--- a/simulation/g4simulation/g4detectors/PHG4FCalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FCalDetector.h
@@ -6,11 +6,10 @@
 #include <g4main/PHG4Detector.h>
 
 #include <Geant4/G4Region.hh>
-#include <Geant4/G4String.hh>     // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4Types.hh>
 
 #include <map>
-
 
 class G4Material;
 class G4Box;
@@ -20,49 +19,47 @@ class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4Subsystem;
 
-class PHG4FCalDetector: public PHG4Detector
+class PHG4FCalDetector : public PHG4Detector
 {
-  public:
-    
-  PHG4FCalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &name );
-    
-    virtual ~PHG4FCalDetector( void ){}
-    
-    virtual void ConstructMe( G4LogicalVolume* world );
-    
-    virtual G4UserSteppingAction* GetSteppingAction() 
-    { 
-      if ( _region )
-        return _region->GetRegionalSteppingAction();
-      else return nullptr;
-    }
-    
-    bool isInScintillator(G4VPhysicalVolume * volume);
-    int getScintillatorLayer(G4VPhysicalVolume * volume);
-    unsigned int computeIndex(unsigned int layer, G4double x, G4double y, G4double z, G4double& xcenter, G4double& ycenter, G4double& zcenter);
-    
-  private:
-    
-    G4double length, absorber_thickness, scintillator_thickness;
-    unsigned int nlayers, segments_per_column, segments_per_thickness;
-    G4double z_position;
-    G4double layer_separation;
-    
-    G4Material* SetMaterial(G4String);
-    
-    G4Material* AbsorberMaterial;
-    G4Material* ScintillatorMaterial;
-    
-    std::map<unsigned int, G4Box* > absorber_solid_;
-    std::map<unsigned int, G4LogicalVolume* > absorber_logic_;
-    std::map<unsigned int, G4VPhysicalVolume* > absorber_physi_;
-    
-    std::map<unsigned int, G4Box* > scintillator_solid_;
-    std::map<unsigned int, G4LogicalVolume* > scintillator_logic_;
-    std::map<unsigned int, G4VPhysicalVolume* > scintillator_physi_;
-    
-    G4Region* _region;
-};
+ public:
+  PHG4FCalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& name);
 
+  virtual ~PHG4FCalDetector(void) {}
+
+  virtual void ConstructMe(G4LogicalVolume* world);
+
+  virtual G4UserSteppingAction* GetSteppingAction()
+  {
+    if (_region)
+      return _region->GetRegionalSteppingAction();
+    else
+      return nullptr;
+  }
+
+  bool isInScintillator(G4VPhysicalVolume* volume);
+  int getScintillatorLayer(G4VPhysicalVolume* volume);
+  unsigned int computeIndex(unsigned int layer, G4double x, G4double y, G4double z, G4double& xcenter, G4double& ycenter, G4double& zcenter);
+
+ private:
+  G4double length, absorber_thickness, scintillator_thickness;
+  unsigned int nlayers, segments_per_column, segments_per_thickness;
+  G4double z_position;
+  G4double layer_separation;
+
+  G4Material* SetMaterial(G4String);
+
+  G4Material* AbsorberMaterial;
+  G4Material* ScintillatorMaterial;
+
+  std::map<unsigned int, G4Box*> absorber_solid_;
+  std::map<unsigned int, G4LogicalVolume*> absorber_logic_;
+  std::map<unsigned int, G4VPhysicalVolume*> absorber_physi_;
+
+  std::map<unsigned int, G4Box*> scintillator_solid_;
+  std::map<unsigned int, G4LogicalVolume*> scintillator_logic_;
+  std::map<unsigned int, G4VPhysicalVolume*> scintillator_physi_;
+
+  G4Region* _region;
+};
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4FCalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FCalSubsystem.cc
@@ -39,7 +39,7 @@ int PHG4FCalSubsystem::Init( PHCompositeNode* topNode )
   }
   
   // create detector
-  detector_ = new PHG4FCalDetector(topNode);
+  detector_ = new PHG4FCalDetector(this, topNode, Name());
   detector_->Verbosity(Verbosity());
   
   // create stepping action

--- a/simulation/g4simulation/g4detectors/PHG4FCalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FCalSubsystem.cc
@@ -5,60 +5,56 @@
 
 #include <g4main/PHG4HitContainer.h>
 
-#include <phool/PHIODataNode.h>            // for PHIODataNode
-#include <phool/PHNode.h>                  // for PHNode
-#include <phool/PHNodeIterator.h>          // for PHNodeIterator
-#include <phool/PHObject.h>                // for PHObject
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
+#include <phool/getClass.h>
 
 #include <Geant4/G4UserSteppingAction.hh>  // for G4UserSteppingAction
 
 class PHG4Detector;
 
 //_______________________________________________________________________
-PHG4FCalSubsystem::PHG4FCalSubsystem( const char* name ):
-PHG4Subsystem( name ),
-detector_( 0 )
+PHG4FCalSubsystem::PHG4FCalSubsystem(const char* name)
+  : PHG4Subsystem(name)
+  , detector_(0)
 {
 }
 
 //_______________________________________________________________________
-int PHG4FCalSubsystem::Init( PHCompositeNode* topNode )
+int PHG4FCalSubsystem::Init(PHCompositeNode* topNode)
 {
-  
   // create hit list
-  PHG4HitContainer* fcal_hits =  findNode::getClass<PHG4HitContainer>( topNode , "G4HIT_FCAL" );
-  if ( !fcal_hits )
+  PHG4HitContainer* fcal_hits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_FCAL");
+  if (!fcal_hits)
   {
-    
-    PHNodeIterator iter( topNode );
-    PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","DST" ));
-    dstNode->addNode( new PHIODataNode<PHObject>( fcal_hits = new PHG4HitContainer("G4HIT_FCAL"), "G4HIT_FCAL","PHObject" ));
-    
+    PHNodeIterator iter(topNode);
+    PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+    dstNode->addNode(new PHIODataNode<PHObject>(fcal_hits = new PHG4HitContainer("G4HIT_FCAL"), "G4HIT_FCAL", "PHObject"));
   }
-  
+
   // create detector
   detector_ = new PHG4FCalDetector(this, topNode, Name());
   detector_->Verbosity(Verbosity());
-  
+
   // create stepping action
-  
+
   return 9;
-  
 }
 
 //_______________________________________________________________________
-int PHG4FCalSubsystem::process_event( PHCompositeNode* topNode )
+int PHG4FCalSubsystem::process_event(PHCompositeNode* topNode)
 {
-  if ( PHG4FCalSteppingAction* p = dynamic_cast<PHG4FCalSteppingAction*>(detector_->GetSteppingAction()) )
-    p->SetInterfacePointers( topNode );
-  
+  if (PHG4FCalSteppingAction* p = dynamic_cast<PHG4FCalSteppingAction*>(detector_->GetSteppingAction()))
+    p->SetInterfacePointers(topNode);
+
   return 0;
-  
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4FCalSubsystem::GetDetector( void ) const
-{ return detector_; }
-
+PHG4Detector* PHG4FCalSubsystem::GetDetector(void) const
+{
+  return detector_;
+}

--- a/simulation/g4simulation/g4detectors/PHG4FPbScDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScDetector.cc
@@ -6,192 +6,191 @@
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4NistManager.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4Region.hh>            // for G4Region
-#include <Geant4/G4SystemOfUnits.hh>     // for cm
-#include <Geant4/G4ThreeVector.hh>       // for G4ThreeVector
+#include <Geant4/G4Region.hh>         // for G4Region
+#include <Geant4/G4SystemOfUnits.hh>  // for cm
+#include <Geant4/G4ThreeVector.hh>    // for G4ThreeVector
 #include <Geant4/G4Types.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#include <cstdlib>                      // for NULL, exit
-#include <iostream>                      // for stringstream, operator<<
+#include <cstdlib>   // for NULL, exit
+#include <iostream>  // for stringstream, operator<<
 #include <map>
 #include <sstream>
-#include <utility>                       // for pair
+#include <utility>  // for pair
 
 class PHCompositeNode;
 
 using namespace std;
 
-PHG4FPbScDetector::PHG4FPbScDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &nam  ) :
-  PHG4Detector(subsys, Node, nam),
-  tower_cross_section(5.535 * cm),
-  segments_per_column(12*6),
-  segments_per_height(12*3),
-  length(tower_cross_section * segments_per_column),
-  height(tower_cross_section * segments_per_height),
-  absorber_thickness(0.15 * cm),
-  scintillator_thickness(0.4 * cm),
-  nlayers(66),
-  x_position(0.0 * cm),
-  y_position(0.0 * cm),
-  z_position(400.0 * cm),
-  layer_separation(0.0),
-  AbsorberMaterial(nullptr),
-  ScintillatorMaterial(nullptr),
-  _region(nullptr)
+PHG4FPbScDetector::PHG4FPbScDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& nam)
+  : PHG4Detector(subsys, Node, nam)
+  , tower_cross_section(5.535 * cm)
+  , segments_per_column(12 * 6)
+  , segments_per_height(12 * 3)
+  , length(tower_cross_section * segments_per_column)
+  , height(tower_cross_section * segments_per_height)
+  , absorber_thickness(0.15 * cm)
+  , scintillator_thickness(0.4 * cm)
+  , nlayers(66)
+  , x_position(0.0 * cm)
+  , y_position(0.0 * cm)
+  , z_position(400.0 * cm)
+  , layer_separation(0.0)
+  , AbsorberMaterial(nullptr)
+  , ScintillatorMaterial(nullptr)
+  , _region(nullptr)
 {
-  
 }
 
-
-G4Material*  PHG4FPbScDetector::SetMaterial(G4String material)
-{  
+G4Material* PHG4FPbScDetector::SetMaterial(G4String material)
+{
   // search the material by its name and assign if found
-  if( G4Material* material_ptr = G4Material::GetMaterial( material ) )
-  { return material_ptr; }
-  else 
+  if (G4Material* material_ptr = G4Material::GetMaterial(material))
+  {
+    return material_ptr;
+  }
+  else
     return 0;
 }
 
-
 unsigned int PHG4FPbScDetector::computeIndex(unsigned int layer, G4double x, G4double y, G4double z, G4double& xcenter, G4double& ycenter, G4double& zcenter)
 {
-  double z_start = z_position + absorber_thickness*(((double)layer) + 1.) + layer_separation*(((double)layer) + 1.) + scintillator_thickness*(((double)layer));
+  double z_start = z_position + absorber_thickness * (((double) layer) + 1.) + layer_separation * (((double) layer) + 1.) + scintillator_thickness * (((double) layer));
   double z_width = scintillator_thickness;
-  unsigned int z_index = (unsigned int)((z - z_start)/z_width);
-  
-  double x_start = x_position -0.5*length;
-  double y_start = y_position -0.5*height;
+  unsigned int z_index = (unsigned int) ((z - z_start) / z_width);
+
+  double x_start = x_position - 0.5 * length;
+  double y_start = y_position - 0.5 * height;
   double xy_width = tower_cross_section;
-  
-  unsigned int x_index = (unsigned int)((x - x_start)/xy_width);
-  unsigned int y_index = (unsigned int)((y - y_start)/xy_width);
-  
-  zcenter = z;//z_start + z_index*z_width + 0.5*z_width;
-  xcenter = x;//x_start + x_index*xy_width + 0.5*xy_width;
-  ycenter = y;//y_start + y_index*xy_width + 0.5*xy_width;
-  
-  return (z_index*(segments_per_column*segments_per_height) + y_index*segments_per_column + x_index);
+
+  unsigned int x_index = (unsigned int) ((x - x_start) / xy_width);
+  unsigned int y_index = (unsigned int) ((y - y_start) / xy_width);
+
+  zcenter = z;  //z_start + z_index*z_width + 0.5*z_width;
+  xcenter = x;  //x_start + x_index*xy_width + 0.5*xy_width;
+  ycenter = y;  //y_start + y_index*xy_width + 0.5*xy_width;
+
+  return (z_index * (segments_per_column * segments_per_height) + y_index * segments_per_column + x_index);
 }
 
-
-void PHG4FPbScDetector::ConstructMe( G4LogicalVolume* logicWorld )
+void PHG4FPbScDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
-//   const G4MaterialTable* mattab = G4Material::GetMaterialTable();
-//   for(unsigned int i=0;i<mattab->size();i++)
-//   {
-//     cout<<mattab->at(i)->GetName()<<endl;
-//   }
-  
+  //   const G4MaterialTable* mattab = G4Material::GetMaterialTable();
+  //   for(unsigned int i=0;i<mattab->size();i++)
+  //   {
+  //     cout<<mattab->at(i)->GetName()<<endl;
+  //   }
+
   G4NistManager* man = G4NistManager::Instance();
   ScintillatorMaterial = man->FindOrBuildMaterial("G4_POLYSTYRENE");
   AbsorberMaterial = man->FindOrBuildMaterial("G4_Pb");
-  
-  if ( ! ScintillatorMaterial ||
-    ! AbsorberMaterial )
+
+  if (!ScintillatorMaterial ||
+      !AbsorberMaterial)
   {
     std::cout << "PHG4FPbScDetector::Construct - Error: Can not set material" << std::endl;
     exit(-1);
   }
-  
-  G4VisAttributes* polystyreneVis= new G4VisAttributes(G4Colour::Blue());
+
+  G4VisAttributes* polystyreneVis = new G4VisAttributes(G4Colour::Blue());
   polystyreneVis->SetVisibility(true);
   polystyreneVis->SetForceSolid(true);
-  
-  G4VisAttributes* leadVis= new G4VisAttributes(G4Colour(0.925, 0.345, 0));
+
+  G4VisAttributes* leadVis = new G4VisAttributes(G4Colour(0.925, 0.345, 0));
   leadVis->SetVisibility(true);
   leadVis->SetForceSolid(true);
-  
+
   _region = new G4Region("FPBSCREGION");
   //  _region->SetRegionalSteppingAction(new PHG4FPbScSteppingAction(this));
-  
+
   G4double current_center_position = z_position;
-  for(unsigned int layer=0;layer<nlayers;layer++)
+  for (unsigned int layer = 0; layer < nlayers; layer++)
   {
     stringstream ss;
-    
-    ss.clear();ss.str("");
-    ss<<"FPbScAbsSolid_"<<layer;
-    absorber_solid_[layer] = new G4Box(G4String(ss.str()), 
-				       0.5*length,
-				       0.5*height, 
-				       0.5*absorber_thickness);
-    
-    ss.clear();ss.str("");
-    ss<<"FPbScAbsLogical_"<<layer;
+
+    ss.clear();
+    ss.str("");
+    ss << "FPbScAbsSolid_" << layer;
+    absorber_solid_[layer] = new G4Box(G4String(ss.str()),
+                                       0.5 * length,
+                                       0.5 * height,
+                                       0.5 * absorber_thickness);
+
+    ss.clear();
+    ss.str("");
+    ss << "FPbScAbsLogical_" << layer;
     absorber_logic_[layer] = new G4LogicalVolume(absorber_solid_[layer],
-						 AbsorberMaterial,
-						 G4String(ss.str()),0,0,0);
+                                                 AbsorberMaterial,
+                                                 G4String(ss.str()), 0, 0, 0);
     absorber_logic_[layer]->SetVisAttributes(leadVis);
     //    _region->AddRootLogicalVolume(absorber_logic_[layer]);
-    
-    ss.clear();ss.str("");
-    ss<<"FPbScAbsPhysical_"<<layer;
-    
-    absorber_physi_[layer] = new G4PVPlacement(0, 
-					       G4ThreeVector(x_position, y_position,
-							     current_center_position),
-					       absorber_logic_[layer],
-					       G4String(ss.str()),
-					       logicWorld, false, 0, false);
-    
-    current_center_position += 0.5*absorber_thickness;
-    current_center_position += 0.5*scintillator_thickness;
-    
-    ss.clear();ss.str("");
-    ss<<"FPbScScintSolid_"<<layer;
-    scintillator_solid_[layer] = new G4Box(G4String(ss.str()), 
-					   0.5*length, 0.5*height, 
-					   0.5*scintillator_thickness);
-    
-    ss.clear();ss.str("");
-    ss<<"FPbScScintLogical_"<<layer;
-    scintillator_logic_[layer] = new G4LogicalVolume(scintillator_solid_[layer], 
-						     ScintillatorMaterial, G4String(ss.str()),0,0,0);
+
+    ss.clear();
+    ss.str("");
+    ss << "FPbScAbsPhysical_" << layer;
+
+    absorber_physi_[layer] = new G4PVPlacement(0,
+                                               G4ThreeVector(x_position, y_position,
+                                                             current_center_position),
+                                               absorber_logic_[layer],
+                                               G4String(ss.str()),
+                                               logicWorld, false, 0, false);
+
+    current_center_position += 0.5 * absorber_thickness;
+    current_center_position += 0.5 * scintillator_thickness;
+
+    ss.clear();
+    ss.str("");
+    ss << "FPbScScintSolid_" << layer;
+    scintillator_solid_[layer] = new G4Box(G4String(ss.str()),
+                                           0.5 * length, 0.5 * height,
+                                           0.5 * scintillator_thickness);
+
+    ss.clear();
+    ss.str("");
+    ss << "FPbScScintLogical_" << layer;
+    scintillator_logic_[layer] = new G4LogicalVolume(scintillator_solid_[layer],
+                                                     ScintillatorMaterial, G4String(ss.str()), 0, 0, 0);
     scintillator_logic_[layer]->SetVisAttributes(polystyreneVis);
     //    _region->AddRootLogicalVolume(scintillator_logic_[layer]);
-    
-    ss.clear();ss.str("");
-    ss<<"FPbScScintPhysical_"<<layer;
-    
+
+    ss.clear();
+    ss.str("");
+    ss << "FPbScScintPhysical_" << layer;
+
     scintillator_physi_[layer] = new G4PVPlacement(0, G4ThreeVector(x_position, y_position, current_center_position),
-						   scintillator_logic_[layer],
-						   G4String(ss.str()),
-						   logicWorld, false, 0, false);
-    
-    current_center_position += 0.5*scintillator_thickness;
+                                                   scintillator_logic_[layer],
+                                                   G4String(ss.str()),
+                                                   logicWorld, false, 0, false);
+
+    current_center_position += 0.5 * scintillator_thickness;
     current_center_position += layer_separation;
-    current_center_position += 0.5*absorber_thickness;
+    current_center_position += 0.5 * absorber_thickness;
   }
 }
 
-
-bool PHG4FPbScDetector::isInScintillator(G4VPhysicalVolume * volume)
+bool PHG4FPbScDetector::isInScintillator(G4VPhysicalVolume* volume)
 {
   //loop over the physical volumes and see if this is a match
   std::map<unsigned int, G4VPhysicalVolume*>::iterator vol_iter = scintillator_physi_.begin();
-  for ( ; vol_iter != scintillator_physi_.end(); ++vol_iter )
+  for (; vol_iter != scintillator_physi_.end(); ++vol_iter)
   {
-    if ( vol_iter->second == volume )
-      {
-	return true;
-      }
+    if (vol_iter->second == volume)
+    {
+      return true;
+    }
   }
   return false;
 }
 
-
-int PHG4FPbScDetector::getScintillatorLayer(G4VPhysicalVolume * volume)
+int PHG4FPbScDetector::getScintillatorLayer(G4VPhysicalVolume* volume)
 {
   //loop over the physical volumes and see if this is a match
   std::map<unsigned int, G4VPhysicalVolume*>::iterator vol_iter = scintillator_physi_.begin();
-  for ( ; vol_iter != scintillator_physi_.end(); ++vol_iter )
+  for (; vol_iter != scintillator_physi_.end(); ++vol_iter)
   {
-    if ( vol_iter->second == volume )
+    if (vol_iter->second == volume)
       return vol_iter->first;
-    
   }
   return -1;
 }
-
-

--- a/simulation/g4simulation/g4detectors/PHG4FPbScDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScDetector.cc
@@ -22,8 +22,8 @@ class PHCompositeNode;
 
 using namespace std;
 
-PHG4FPbScDetector::PHG4FPbScDetector( PHCompositeNode *Node, const std::string &nam  ) :
-  PHG4Detector(Node, nam),
+PHG4FPbScDetector::PHG4FPbScDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &nam  ) :
+  PHG4Detector(subsys, Node, nam),
   tower_cross_section(5.535 * cm),
   segments_per_column(12*6),
   segments_per_height(12*3),
@@ -75,7 +75,7 @@ unsigned int PHG4FPbScDetector::computeIndex(unsigned int layer, G4double x, G4d
 }
 
 
-void PHG4FPbScDetector::Construct( G4LogicalVolume* logicWorld )
+void PHG4FPbScDetector::ConstructMe( G4LogicalVolume* logicWorld )
 {
 //   const G4MaterialTable* mattab = G4Material::GetMaterialTable();
 //   for(unsigned int i=0;i<mattab->size();i++)

--- a/simulation/g4simulation/g4detectors/PHG4FPbScDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScDetector.h
@@ -6,14 +6,13 @@
 #include "g4main/PHG4Detector.h"
 
 #include <Geant4/G4Region.hh>
-#include <Geant4/G4String.hh>           // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Types.hh>
 
-#include <cstddef>                     // for size_t
+#include <cstddef>  // for size_t
 #include <map>
-#include <string>                       // for string
-
+#include <string>  // for string
 
 class G4Material;
 class G4Box;
@@ -23,58 +22,56 @@ class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4Subsystem;
 
-class PHG4FPbScDetector: public PHG4Detector
+class PHG4FPbScDetector : public PHG4Detector
 {
-  public:
-    
-  PHG4FPbScDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &nam );
-    
-    virtual ~PHG4FPbScDetector( void ){}
-    
-    virtual void ConstructMe( G4LogicalVolume* world );
-    
-    virtual G4UserSteppingAction* GetSteppingAction() 
-    { 
-      if ( _region )
-        return _region->GetRegionalSteppingAction();
-      else return 0;
-    }
-    
-    bool isInScintillator(G4VPhysicalVolume * volume);
-    int getScintillatorLayer(G4VPhysicalVolume * volume);
-    // compute tower index
-    unsigned int computeIndex(unsigned int layer, G4double x, G4double y, G4double z, G4double& xcenter, G4double& ycenter, G4double& zcenter);
-    void set_Place(G4double x, G4double y, G4double z)
-    {
-      x_position = x * cm;
-      y_position = y * cm;
-      z_position = z * cm;
-    }
+ public:
+  PHG4FPbScDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& nam);
 
-  private:
-    
-    G4double tower_cross_section;
-    size_t segments_per_column, segments_per_height;
-    G4double length, height, absorber_thickness, scintillator_thickness;
-    unsigned int nlayers;//, segments_per_thickness;
-    G4double x_position, y_position, z_position;
-    G4double layer_separation;
-    
-    G4Material* SetMaterial(G4String);
-    
-    G4Material* AbsorberMaterial;
-    G4Material* ScintillatorMaterial;
-    
-    std::map<unsigned int, G4Box* > absorber_solid_;
-    std::map<unsigned int, G4LogicalVolume* > absorber_logic_;
-    std::map<unsigned int, G4VPhysicalVolume* > absorber_physi_;
-    
-    std::map<unsigned int, G4Box* > scintillator_solid_;
-    std::map<unsigned int, G4LogicalVolume* > scintillator_logic_;
-    std::map<unsigned int, G4VPhysicalVolume* > scintillator_physi_;
-    
-    G4Region* _region;
+  virtual ~PHG4FPbScDetector(void) {}
+
+  virtual void ConstructMe(G4LogicalVolume* world);
+
+  virtual G4UserSteppingAction* GetSteppingAction()
+  {
+    if (_region)
+      return _region->GetRegionalSteppingAction();
+    else
+      return 0;
+  }
+
+  bool isInScintillator(G4VPhysicalVolume* volume);
+  int getScintillatorLayer(G4VPhysicalVolume* volume);
+  // compute tower index
+  unsigned int computeIndex(unsigned int layer, G4double x, G4double y, G4double z, G4double& xcenter, G4double& ycenter, G4double& zcenter);
+  void set_Place(G4double x, G4double y, G4double z)
+  {
+    x_position = x * cm;
+    y_position = y * cm;
+    z_position = z * cm;
+  }
+
+ private:
+  G4double tower_cross_section;
+  size_t segments_per_column, segments_per_height;
+  G4double length, height, absorber_thickness, scintillator_thickness;
+  unsigned int nlayers;  //, segments_per_thickness;
+  G4double x_position, y_position, z_position;
+  G4double layer_separation;
+
+  G4Material* SetMaterial(G4String);
+
+  G4Material* AbsorberMaterial;
+  G4Material* ScintillatorMaterial;
+
+  std::map<unsigned int, G4Box*> absorber_solid_;
+  std::map<unsigned int, G4LogicalVolume*> absorber_logic_;
+  std::map<unsigned int, G4VPhysicalVolume*> absorber_physi_;
+
+  std::map<unsigned int, G4Box*> scintillator_solid_;
+  std::map<unsigned int, G4LogicalVolume*> scintillator_logic_;
+  std::map<unsigned int, G4VPhysicalVolume*> scintillator_physi_;
+
+  G4Region* _region;
 };
-
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4FPbScDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScDetector.h
@@ -21,16 +21,17 @@ class G4LogicalVolume;
 class G4UserSteppingAction;
 class G4VPhysicalVolume;
 class PHCompositeNode;
+class PHG4Subsystem;
 
 class PHG4FPbScDetector: public PHG4Detector
 {
   public:
     
-  PHG4FPbScDetector( PHCompositeNode *Node, const std::string &nam );
+  PHG4FPbScDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &nam );
     
     virtual ~PHG4FPbScDetector( void ){}
     
-    virtual void Construct( G4LogicalVolume* world );
+    virtual void ConstructMe( G4LogicalVolume* world );
     
     virtual G4UserSteppingAction* GetSteppingAction() 
     { 

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSteppingAction.cc
@@ -1,17 +1,17 @@
 #include "PHG4FPbScSteppingAction.h"
 #include "PHG4FPbScDetector.h"
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>        // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
 
 #include <Geant4/G4Step.hh>
 #include <Geant4/G4StepPoint.hh>              // for G4StepPoint
-#include <Geant4/G4SystemOfUnits.hh>     // for cm
+#include <Geant4/G4SystemOfUnits.hh>          // for cm
 #include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
 #include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
 #include <Geant4/G4Track.hh>                  // for G4Track
@@ -19,74 +19,80 @@
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
-#include <iostream>                           // for operator<<, endl, basic...
-#include <map>                                // for _Rb_tree_iterator
-#include <string>                             // for operator+, string, char...
-#include <utility>                            // for pair
+#include <iostream>  // for operator<<, endl, basic...
+#include <map>       // for _Rb_tree_iterator
+#include <string>    // for operator+, string, char...
+#include <utility>   // for pair
 
 class G4VPhysicalVolume;
 
 using namespace std;
 
-
-PHG4FPbScSteppingAction::PHG4FPbScSteppingAction( PHG4FPbScDetector* detector) :
-    PHG4SteppingAction(detector->GetName()), detector_( detector ), hits_(nullptr)
+PHG4FPbScSteppingAction::PHG4FPbScSteppingAction(PHG4FPbScDetector* detector)
+  : PHG4SteppingAction(detector->GetName())
+  , detector_(detector)
+  , hits_(nullptr)
 {
 }
 
-
-bool PHG4FPbScSteppingAction::UserSteppingAction( const G4Step* aStep, bool)
+bool PHG4FPbScSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
   G4VPhysicalVolume* volume = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
-  
+
   int layer_id = 0;
-  
-  if((detector_->isInScintillator(volume)) == false){return false;}
-  
-  if((aStep->GetTotalEnergyDeposit()/GeV) == 0.){return false;}
-  
+
+  if ((detector_->isInScintillator(volume)) == false)
+  {
+    return false;
+  }
+
+  if ((aStep->GetTotalEnergyDeposit() / GeV) == 0.)
+  {
+    return false;
+  }
+
   layer_id = detector_->getScintillatorLayer(volume);
 
   G4StepPoint* prePoint = aStep->GetPreStepPoint();
   G4StepPoint* postPoint = aStep->GetPostStepPoint();
   G4Track* aTrack = aStep->GetTrack();
-  
+
   G4double x_center, y_center, z_center;
 
-  int hit_index = detector_->computeIndex(layer_id, 
-				      prePoint->GetPosition().x() / cm, 
-				      prePoint->GetPosition().y() / cm, 
-				      prePoint->GetPosition().z() / cm, 
-				      x_center, y_center, z_center);
+  int hit_index = detector_->computeIndex(layer_id,
+                                          prePoint->GetPosition().x() / cm,
+                                          prePoint->GetPosition().y() / cm,
+                                          prePoint->GetPosition().z() / cm,
+                                          x_center, y_center, z_center);
 
   PHG4HitContainer::Iterator it = hits_->findOrAddHit(hit_index);
-  
+
   PHG4Hit* mhit = it->second;
   mhit->set_x(0, x_center);
   mhit->set_y(0, y_center);
   mhit->set_z(0, z_center);
   mhit->set_edep(0);
-  
-  hit_index = detector_->computeIndex(layer_id, 
-				      postPoint->GetPosition().x() / cm, 
-				      postPoint->GetPosition().y() / cm, 
-				      postPoint->GetPosition().z() / cm, 
-				      x_center, y_center, z_center);
-  
+
+  hit_index = detector_->computeIndex(layer_id,
+                                      postPoint->GetPosition().x() / cm,
+                                      postPoint->GetPosition().y() / cm,
+                                      postPoint->GetPosition().z() / cm,
+                                      x_center, y_center, z_center);
+
   it = hits_->findOrAddHit(hit_index);
 
   mhit = it->second;
   mhit->set_x(1, x_center);
   mhit->set_y(1, y_center);
   mhit->set_z(1, z_center);
-  mhit->set_edep((aStep->GetTotalEnergyDeposit()/GeV) + it->second->get_edep());
-  
+  mhit->set_edep((aStep->GetTotalEnergyDeposit() / GeV) + it->second->get_edep());
+
   // Also store the flag that we want to keep this track on output
   //
-  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+  if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
   {
     // Do nothing; was assume this flag has already been set
-    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+    if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
     {
       pp->SetWanted(true);
     }
@@ -105,41 +111,38 @@ bool PHG4FPbScSteppingAction::UserSteppingAction( const G4Step* aStep, bool)
   //set the track ID
   {
     mhit->set_trkid(aTrack->GetTrackID());
-    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+    if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+    {
+      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
       {
-	if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-	  {
-	    mhit->set_trkid(pp->GetUserTrackId());
-	    mhit->set_shower_id(pp->GetShower()->get_id());
-	  }
+        mhit->set_trkid(pp->GetUserTrackId());
+        mhit->set_shower_id(pp->GetShower()->get_id());
       }
+    }
   }
-  
+
   {
-    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+    if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+    {
+      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
       {
-	if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-	  {
-	    pp->GetShower()->add_g4hit_id(hits_->GetID(),mhit->get_hit_id());
-	  }
+        pp->GetShower()->add_g4hit_id(hits_->GetID(), mhit->get_hit_id());
       }
+    }
   }
-  
+
   return true;
 }
 
-
-void PHG4FPbScSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+void PHG4FPbScSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
   string hitnodename = "G4HIT_" + detector_->GetName();
   //now look for the map and grab a pointer to it.
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
-  
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+
   // if we do not find the node we need to make it.
-  if ( ! hits_ )
-    { std::cout << "PHG4FPbScSteppingAction::SetTopNode - unable to find " << hitnodename.c_str() << std::endl; }
-  
+  if (!hits_)
+  {
+    std::cout << "PHG4FPbScSteppingAction::SetTopNode - unable to find " << hitnodename.c_str() << std::endl;
+  }
 }
-
-
-

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSteppingAction.cc
@@ -4,6 +4,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Shower.h>
+#include <g4main/PHG4SteppingAction.h>        // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
@@ -18,7 +19,6 @@
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
-#include <cstddef>                           // for NULL
 #include <iostream>                           // for operator<<, endl, basic...
 #include <map>                                // for _Rb_tree_iterator
 #include <string>                             // for operator+, string, char...

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
@@ -6,6 +6,7 @@
 #include "PHG4FPbScSteppingAction.h"
 
 #include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4SteppingAction.h>      // for PHG4SteppingAction
 #include <g4main/PHG4Subsystem.h>  // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
@@ -20,7 +21,6 @@
 #include <sstream>
 
 class PHG4Detector;
-class PHG4SteppingAction;
 
 using namespace std;
 

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
@@ -1,21 +1,21 @@
 #include "PHG4FPbScSubsystem.h"
 
-#include "PHG4FPbScDetector.h"
-#include "PHG4FPbScSteppingAction.h"
-#include "PHG4FPbScRegionSteppingAction.h"
 #include "PHG4EventActionClearZeroEdep.h"
+#include "PHG4FPbScDetector.h"
+#include "PHG4FPbScRegionSteppingAction.h"
+#include "PHG4FPbScSteppingAction.h"
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4Subsystem.h>           // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>  // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>             // for PHIODataNode
-#include <phool/PHNode.h>                   // for PHNode
-#include <phool/PHNodeIterator.h>           // for PHNodeIterator
-#include <phool/PHObject.h>                 // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
-#include <Geant4/G4UserSteppingAction.hh>   // for G4UserSteppingAction
+#include <Geant4/G4UserSteppingAction.hh>  // for G4UserSteppingAction
 
 #include <sstream>
 
@@ -25,60 +25,64 @@ class PHG4SteppingAction;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4FPbScSubsystem::PHG4FPbScSubsystem( const string &name ):
-PHG4Subsystem( name ),
-detector_( nullptr ), steppingAction_(nullptr), eventAction_(nullptr), x_position(0), y_position(0), z_position(0)
+PHG4FPbScSubsystem::PHG4FPbScSubsystem(const string& name)
+  : PHG4Subsystem(name)
+  , detector_(nullptr)
+  , steppingAction_(nullptr)
+  , eventAction_(nullptr)
+  , x_position(0)
+  , y_position(0)
+  , z_position(0)
 {
 }
 
 //_______________________________________________________________________
-int PHG4FPbScSubsystem::Init( PHCompositeNode* topNode )
+int PHG4FPbScSubsystem::Init(PHCompositeNode* topNode)
 {
- 
   std::ostringstream hitnodename;
-  hitnodename <<  "G4HIT_" << Name(); 
- 
+  hitnodename << "G4HIT_" << Name();
+
   // create hit list
-  PHG4HitContainer* fcal_hits =  findNode::getClass<PHG4HitContainer>( topNode , ("G4HIT_"+Name()).c_str() );
-  if ( !fcal_hits )
+  PHG4HitContainer* fcal_hits = findNode::getClass<PHG4HitContainer>(topNode, ("G4HIT_" + Name()).c_str());
+  if (!fcal_hits)
   {
-    
-    PHNodeIterator iter( topNode );
-    PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode","DST" ));
-    dstNode->addNode( new PHIODataNode<PHObject>( fcal_hits = new PHG4HitContainer(("G4HIT_"+Name())), ("G4HIT_"+Name()),"PHObject" ));
+    PHNodeIterator iter(topNode);
+    PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+    dstNode->addNode(new PHIODataNode<PHObject>(fcal_hits = new PHG4HitContainer(("G4HIT_" + Name())), ("G4HIT_" + Name()), "PHObject"));
   }
-  
+
   // create detector
   detector_ = new PHG4FPbScDetector(this, topNode, Name());
   detector_->set_Place(x_position, y_position, z_position);
   detector_->Verbosity(Verbosity());
-  
+
   // create stepping action
   steppingAction_ = new PHG4FPbScSteppingAction(detector_);
 
   eventAction_ = new PHG4EventActionClearZeroEdep(topNode, hitnodename.str());
 
   return 0;
-  
 }
 
 //_______________________________________________________________________
-int PHG4FPbScSubsystem::process_event( PHCompositeNode* topNode )
+int PHG4FPbScSubsystem::process_event(PHCompositeNode* topNode)
 {
-  if ( PHG4FPbScRegionSteppingAction* p = dynamic_cast<PHG4FPbScRegionSteppingAction*>(detector_->GetSteppingAction()) )
-    p->SetInterfacePointers( topNode );
+  if (PHG4FPbScRegionSteppingAction* p = dynamic_cast<PHG4FPbScRegionSteppingAction*>(detector_->GetSteppingAction()))
+    p->SetInterfacePointers(topNode);
   else
-    steppingAction_->SetInterfacePointers( topNode );
+    steppingAction_->SetInterfacePointers(topNode);
 
   return 0;
-  
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4FPbScSubsystem::GetDetector( void ) const
-{ return detector_; }
+PHG4Detector* PHG4FPbScSubsystem::GetDetector(void) const
+{
+  return detector_;
+}
 
 //_______________________________________________________________________
-PHG4SteppingAction* PHG4FPbScSubsystem::GetSteppingAction( void ) const
-{ return steppingAction_; }
-
+PHG4SteppingAction* PHG4FPbScSubsystem::GetSteppingAction(void) const
+{
+  return steppingAction_;
+}

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
@@ -6,8 +6,8 @@
 #include "PHG4FPbScSteppingAction.h"
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>      // for PHG4SteppingAction
-#include <g4main/PHG4Subsystem.h>  // for PHG4Subsystem
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
+#include <g4main/PHG4Subsystem.h>       // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>    // for PHIODataNode

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSubsystem.cc
@@ -49,7 +49,7 @@ int PHG4FPbScSubsystem::Init( PHCompositeNode* topNode )
   }
   
   // create detector
-  detector_ = new PHG4FPbScDetector(topNode, Name());
+  detector_ = new PHG4FPbScDetector(this, topNode, Name());
   detector_->set_Place(x_position, y_position, z_position);
   detector_->Verbosity(Verbosity());
   

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
@@ -6,24 +6,22 @@
 #include <g4gdml/PHG4GDMLConfig.hh>
 #include <g4gdml/PHG4GDMLUtility.hh>
 
-#include <g4main/PHG4Detector.h>           // for PHG4Detector
-#include <g4main/PHG4DisplayAction.h>      // for PHG4DisplayAction
+#include <g4main/PHG4Detector.h>       // for PHG4Detector
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
-#include <Geant4/G4PhysicalConstants.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>      // for G4RotationMatrix
-#include <Geant4/G4String.hh>              // for G4String
+#include <Geant4/G4PhysicalConstants.hh>
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>         // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>         // for G4Transform3D
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D
 #include <Geant4/G4Tubs.hh>
-#include <Geant4/G4VPhysicalVolume.hh>     // for G4VPhysicalVolume
-
-
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 
 #include <cassert>
 #include <cmath>
@@ -31,7 +29,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <utility>                         // for pair, make_pair
+#include <utility>  // for pair, make_pair
 
 class G4VSolid;
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
@@ -39,8 +39,8 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4ForwardEcalDetector::PHG4ForwardEcalDetector(PHG4ForwardEcalSubsystem* subsys, PHCompositeNode* Node, const std::string& dnam)
-  : PHG4Detector(Node, dnam)
+PHG4ForwardEcalDetector::PHG4ForwardEcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , m_DisplayAction(dynamic_cast<PHG4ForwardEcalDisplayAction*>(subsys->GetDisplayAction()))
   , _tower0_dx(30 * mm)
   , _tower0_dy(30 * mm)
@@ -123,7 +123,7 @@ int PHG4ForwardEcalDetector::IsInForwardEcal(G4VPhysicalVolume* volume) const
 }
 
 //_______________________________________________________________________
-void PHG4ForwardEcalDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4ForwardEcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   //if ( Verbosity() > 0 )
   {

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
@@ -14,7 +14,7 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4ForwardEcalDisplayAction;
-class PHG4ForwardEcalSubsystem;
+class PHG4Subsystem;
 class PHG4GDMLConfig;
 
 /**
@@ -27,13 +27,13 @@ class PHG4ForwardEcalDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4ForwardEcalDetector(PHG4ForwardEcalSubsystem *subsys, PHCompositeNode *Node, const std::string &dnam = "BLOCK");
+  PHG4ForwardEcalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4ForwardEcalDetector();
 
   //! construct
-  virtual void Construct(G4LogicalVolume *world);
+  virtual void ConstructMe(G4LogicalVolume *world);
 
   //!@name volume accessors
   int IsInForwardEcal(G4VPhysicalVolume *) const;

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.h
@@ -5,7 +5,7 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/G4Types.hh>      // for G4double
+#include <Geant4/G4Types.hh>  // for G4double
 
 #include <map>
 #include <string>

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.cc
@@ -29,8 +29,8 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4ForwardHcalDetector::PHG4ForwardHcalDetector(PHG4ForwardHcalSubsystem* subsys, PHCompositeNode* Node, const std::string& dnam)
-  : PHG4Detector(Node, dnam)
+PHG4ForwardHcalDetector::PHG4ForwardHcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , m_DisplayAction(dynamic_cast<PHG4ForwardHcalDisplayAction*>(subsys->GetDisplayAction()))
   , _place_in_x(0.0 * mm)
   , _place_in_y(0.0 * mm)
@@ -90,7 +90,7 @@ int PHG4ForwardHcalDetector::IsInForwardHcal(G4VPhysicalVolume* volume) const
 }
 
 //_______________________________________________________________________
-void PHG4ForwardHcalDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4ForwardHcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   if (Verbosity() > 0)
   {

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.cc
@@ -2,26 +2,26 @@
 #include "PHG4ForwardHcalDisplayAction.h"
 #include "PHG4ForwardHcalSubsystem.h"
 
-#include <g4main/PHG4Detector.h>           // for PHG4Detector
-#include <g4main/PHG4DisplayAction.h>      // for PHG4DisplayAction
+#include <g4main/PHG4Detector.h>       // for PHG4Detector
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>      // for G4RotationMatrix
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>         // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>         // for G4Transform3D
-#include <Geant4/G4VPhysicalVolume.hh>     // for G4VPhysicalVolume
+#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>      // for G4Transform3D
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 #
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <utility>                         // for pair, make_pair
+#include <utility>  // for pair, make_pair
 
 class G4VSolid;
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.h
@@ -15,7 +15,7 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4ForwardHcalDisplayAction;
-class PHG4ForwardHcalSubsystem;
+class PHG4Subsystem;
 
 /**
  * \file ${file_name}
@@ -27,13 +27,13 @@ class PHG4ForwardHcalDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4ForwardHcalDetector(PHG4ForwardHcalSubsystem *subsys, PHCompositeNode *Node, const std::string &dnam = "BLOCK");
+  PHG4ForwardHcalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4ForwardHcalDetector() {}
 
   //! construct
-  virtual void Construct(G4LogicalVolume *world);
+  virtual void ConstructMe(G4LogicalVolume *world);
 
   //!@name volume accessors
   int IsInForwardHcal(G4VPhysicalVolume *) const;

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.h
@@ -5,8 +5,8 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/G4String.hh>     // for G4String
-#include <Geant4/G4Types.hh>      // for G4double
+#include <Geant4/G4String.hh>  // for G4String
+#include <Geant4/G4Types.hh>   // for G4double
 
 #include <map>
 #include <string>

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -47,7 +47,7 @@ using namespace std;
 
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4FullProjSpacalDetector::PHG4FullProjSpacalDetector(PHG4SpacalSubsystem* subsys, PHCompositeNode* Node,
+PHG4FullProjSpacalDetector::PHG4FullProjSpacalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node,
                                                        const std::string& dnam, PHParameters* parameters, const int lyr)
   : PHG4SpacalDetector(subsys, Node, dnam, parameters, lyr, false)
 {
@@ -73,7 +73,7 @@ PHG4FullProjSpacalDetector::PHG4FullProjSpacalDetector(PHG4SpacalSubsystem* subs
 }
 
 //_______________________________________________________________
-void PHG4FullProjSpacalDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4FullProjSpacalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   if (get_geom_v3()->get_construction_verbose() >= 1)
   {

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -13,18 +13,18 @@
 #include <g4gdml/PHG4GDMLConfig.hh>
 
 #include <Geant4/G4Box.hh>
-#include <Geant4/G4ExceptionSeverity.hh>   // for FatalException
+#include <Geant4/G4ExceptionSeverity.hh>  // for FatalException
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4PhysicalConstants.hh>
-#include <Geant4/G4String.hh>              // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Trap.hh>
 #include <Geant4/G4Tubs.hh>
-#include <Geant4/G4Types.hh>               // for G4double
+#include <Geant4/G4Types.hh>  // for G4double
 #include <Geant4/G4Vector3D.hh>
-#include <Geant4/globals.hh>               // for G4Exception, G4ExceptionDe...
+#include <Geant4/globals.hh>  // for G4Exception, G4ExceptionDe...
 
 #include <TSystem.h>
 
@@ -33,13 +33,13 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <cstdlib>                        // for exit, NULL
-#include <iostream>                        // for operator<<, basic_ostream
-#include <map>                             // for allocator, map<>::value_type
-#include <numeric>  // std::accumulate
+#include <cstdlib>   // for exit, NULL
+#include <iostream>  // for operator<<, basic_ostream
+#include <map>       // for allocator, map<>::value_type
+#include <numeric>   // std::accumulate
 #include <sstream>
 #include <string>  // std::string, std::to_string
-#include <vector>                          // for vector
+#include <vector>  // for vector
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -33,7 +33,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <cstdlib>   // for exit, NULL
 #include <iostream>  // for operator<<, basic_ostream
 #include <map>       // for allocator, map<>::value_type
 #include <numeric>   // std::accumulate
@@ -81,7 +80,7 @@ void PHG4FullProjSpacalDetector::ConstructMe(G4LogicalVolume* logicWorld)
          << " - start with PHG4SpacalDetector::Construct()." << endl;
   }
 
-  PHG4SpacalDetector::Construct(logicWorld);
+  PHG4SpacalDetector::ConstructMe(logicWorld);
 
   if (get_geom_v3()->get_construction_verbose() >= 1)
   {

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.h
@@ -24,7 +24,7 @@
 class G4LogicalVolume;
 class PHCompositeNode;
 class PHG4CylinderGeom;
-class PHG4SpacalSubsystem;
+class PHG4Subsystem;
 class PHParameters;
 
 //! Fully projective SPACAL built from 2D tapered modules.
@@ -35,14 +35,14 @@ class PHG4FullProjSpacalDetector : public PHG4SpacalDetector
  public:
   typedef PHG4CylinderGeom_Spacalv3 SpacalGeom_t;
 
-  PHG4FullProjSpacalDetector(PHG4SpacalSubsystem* subsys,
+  PHG4FullProjSpacalDetector(PHG4Subsystem* subsys,
                              PHCompositeNode* Node, const std::string& dnam,
                              PHParameters* parameters, const int layer = 0);
 
   // empty dtor, step limits are deleted in base class
   virtual ~PHG4FullProjSpacalDetector(void) {}
   virtual void
-  Construct(G4LogicalVolume* world);
+  ConstructMe(G4LogicalVolume* world);
 
   virtual std::pair<G4LogicalVolume*, G4Transform3D>
   Construct_AzimuthalSeg();

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.h
@@ -15,11 +15,11 @@
 #include "PHG4CylinderGeom_Spacalv3.h"
 #include "PHG4SpacalDetector.h"
 
-#include <Geant4/G4Transform3D.hh>      // for G4Transform3D
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D
 
 #include <cassert>
-#include <string>                       // for string
-#include <utility>                      // for pair
+#include <string>   // for string
+#include <utility>  // for pair
 
 class G4LogicalVolume;
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -52,7 +52,7 @@ using namespace std;
 
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4FullProjTiltedSpacalDetector::PHG4FullProjTiltedSpacalDetector(PHG4SpacalSubsystem* subsys, PHCompositeNode* Node,
+PHG4FullProjTiltedSpacalDetector::PHG4FullProjTiltedSpacalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node,
                                                                    const std::string& dnam, PHParameters* parameters, const int lyr)
   : PHG4SpacalDetector(subsys, Node, dnam, parameters, lyr, false)
 {
@@ -75,7 +75,7 @@ PHG4FullProjTiltedSpacalDetector::PHG4FullProjTiltedSpacalDetector(PHG4SpacalSub
 }
 
 //_______________________________________________________________
-void PHG4FullProjTiltedSpacalDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4FullProjTiltedSpacalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   if (get_geom_v3()->get_construction_verbose() >= 1)
   {

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -37,7 +37,7 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>  // for operator<<, basic_ostream
-#include <limits>                          // for numeric_limits
+#include <limits>    // for numeric_limits
 #include <map>       // for map<>::value_type, map
 #include <memory>    // for allocator_traits<>::value_...
 #include <numeric>   // std::accumulate

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -15,19 +15,19 @@
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4DisplacedSolid.hh>
-#include <Geant4/G4ExceptionSeverity.hh>   // for FatalException
+#include <Geant4/G4ExceptionSeverity.hh>  // for FatalException
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4PhysicalConstants.hh>
-#include <Geant4/G4String.hh>              // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>         // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>         // for G4Transform3D, G4TranslateY3D
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D, G4TranslateY3D
 #include <Geant4/G4Trap.hh>
-#include <Geant4/G4Types.hh>               // for G4double
+#include <Geant4/G4Types.hh>  // for G4double
 #include <Geant4/G4Vector3D.hh>
-#include <Geant4/globals.hh>               // for G4Exception, G4ExceptionDe...
+#include <Geant4/globals.hh>  // for G4Exception, G4ExceptionDe...
 
 #include <TSystem.h>
 
@@ -35,15 +35,15 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cmath>
-#include <iostream>                        // for operator<<, basic_ostream
 #include <climits>
-#include <map>                             // for map<>::value_type, map
-#include <memory>                          // for allocator_traits<>::value_...
-#include <numeric>  // std::accumulate
+#include <cmath>
+#include <iostream>  // for operator<<, basic_ostream
+#include <map>       // for map<>::value_type, map
+#include <memory>    // for allocator_traits<>::value_...
+#include <numeric>   // std::accumulate
 #include <sstream>
 #include <string>  // std::string, std::to_string
-#include <vector>                          // for vector
+#include <vector>  // for vector
 
 class G4VSolid;
 class PHCompositeNode;
@@ -820,9 +820,9 @@ PHG4FullProjTiltedSpacalDetector::Construct_Tower(
            << " - constructed tower ID " << g_tower.id << " with "
            << fiber_count
            << " fibers using Construct_Fibers_SameLengthFiberPerTower."
-           << "V = "<<block_solid->GetCubicVolume()/(cm3)<<"cm3, "
-           << "m = "<<block_logic->GetMass()/gram<<"gram, "
-           << "Density = "<< (block_logic->GetMass()/gram) / (block_solid->GetCubicVolume()/cm3)<<"g/cm3"
+           << "V = " << block_solid->GetCubicVolume() / (cm3) << "cm3, "
+           << "m = " << block_logic->GetMass() / gram << "gram, "
+           << "Density = " << (block_logic->GetMass() / gram) / (block_solid->GetCubicVolume() / cm3) << "g/cm3"
            << endl;
   }
   else

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -35,9 +35,9 @@
 
 #include <algorithm>
 #include <cassert>
-#include <climits>
 #include <cmath>
 #include <iostream>  // for operator<<, basic_ostream
+#include <limits>                          // for numeric_limits
 #include <map>       // for map<>::value_type, map
 #include <memory>    // for allocator_traits<>::value_...
 #include <numeric>   // std::accumulate
@@ -83,7 +83,7 @@ void PHG4FullProjTiltedSpacalDetector::ConstructMe(G4LogicalVolume* logicWorld)
          << " - start with PHG4SpacalDetector::Construct()." << endl;
   }
 
-  PHG4SpacalDetector::Construct(logicWorld);
+  PHG4SpacalDetector::ConstructMe(logicWorld);
 
   if (get_geom_v3()->get_construction_verbose() >= 1)
   {

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
@@ -18,8 +18,8 @@
 #include <Geant4/G4Transform3D.hh>
 
 #include <cassert>
-#include <string>                       // for string
-#include <utility>                      // for pair
+#include <string>   // for string
+#include <utility>  // for pair
 
 class G4LogicalVolume;
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
@@ -24,7 +24,7 @@
 class G4LogicalVolume;
 class PHCompositeNode;
 class PHG4CylinderGeom;
-class PHG4SpacalSubsystem;
+class PHG4Subsystem;
 class PHParameters;
 
 //! Fully projective SPACAL built from 2D tapered modules and allow azimuthal tilts
@@ -33,13 +33,14 @@ class PHG4FullProjTiltedSpacalDetector : public PHG4SpacalDetector
  public:
   typedef PHG4CylinderGeom_Spacalv3 SpacalGeom_t;
 
-  PHG4FullProjTiltedSpacalDetector(PHG4SpacalSubsystem* subsys, PHCompositeNode* Node, const std::string& dnam,
+  PHG4FullProjTiltedSpacalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam,
                                    PHParameters* parameters, const int layer = 0);
 
   // empty dtor, step limits are deleted in base class
   virtual ~PHG4FullProjTiltedSpacalDetector(void) {}
+
   virtual void
-  Construct(G4LogicalVolume* world);
+  ConstructMe(G4LogicalVolume* world);
 
   virtual std::pair<G4LogicalVolume*, G4Transform3D>
   Construct_AzimuthalSeg();

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
@@ -12,6 +12,7 @@
 
 #include <g4main/PHG4Utils.h>
 #include <g4main/PHG4Detector.h>          // for PHG4Detector
+#include <g4main/PHG4Subsystem.h>
 
 #include <phparameter/PHParameters.h>
 
@@ -38,8 +39,8 @@
 
 using namespace std;
 
-PHG4GDMLDetector::PHG4GDMLDetector(PHCompositeNode* Node, const std::string& dnam, PHParameters* parameters)
-  : PHG4Detector(Node, dnam)
+PHG4GDMLDetector::PHG4GDMLDetector(PHG4Subsystem *subsys, PHCompositeNode* Node, const std::string& dnam, PHParameters* parameters)
+  : PHG4Detector(subsys, Node, dnam)
   , m_GDMPath(parameters->get_string_param("GDMPath"))
   , m_TopVolName(parameters->get_string_param("TopVolName"))
   , m_placeX(parameters->get_double_param("place_x") * cm)
@@ -68,7 +69,7 @@ PHG4GDMLDetector::Print(const std::string& what) const
        << m_rotationZ << "rad" << endl;
 }
 
-void PHG4GDMLDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4GDMLDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   if (Verbosity() > 0)
   {

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
@@ -10,9 +10,9 @@
 
 #include "PHG4GDMLDetector.h"
 
-#include <g4main/PHG4Utils.h>
-#include <g4main/PHG4Detector.h>          // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 #include <g4main/PHG4Subsystem.h>
+#include <g4main/PHG4Utils.h>
 
 #include <phparameter/PHParameters.h>
 
@@ -22,24 +22,23 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>     // for G4RotationMatrix
-#include <Geant4/G4String.hh>             // for G4String
-#include <Geant4/G4ThreeVector.hh>        // for G4ThreeVector
-#include <Geant4/G4VPhysicalVolume.hh>    // for G4VPhysicalVolume
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 #include <Geant4/G4VisAttributes.hh>
 
+#include <CLHEP/Units/SystemOfUnits.h>  // for cm, degree
 
-#include <CLHEP/Units/SystemOfUnits.h>    // for cm, degree
-
-#include <cstdlib>                       // for exit
-#include <iostream>                       // for operator<<, basic_ostream
+#include <cstdlib>   // for exit
+#include <iostream>  // for operator<<, basic_ostream
 #include <memory>
-#include <vector>                         // for vector, vector<>::iterator
+#include <vector>  // for vector, vector<>::iterator
 
 using namespace std;
 
-PHG4GDMLDetector::PHG4GDMLDetector(PHG4Subsystem *subsys, PHCompositeNode* Node, const std::string& dnam, PHParameters* parameters)
+PHG4GDMLDetector::PHG4GDMLDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam, PHParameters* parameters)
   : PHG4Detector(subsys, Node, dnam)
   , m_GDMPath(parameters->get_string_param("GDMPath"))
   , m_TopVolName(parameters->get_string_param("TopVolName"))
@@ -86,7 +85,7 @@ void PHG4GDMLDetector::ConstructMe(G4LogicalVolume* logicWorld)
   unique_ptr<G4GDMLReadStructure> reader(new G4GDMLReadStructure());
   G4GDMLParser gdmlParser(reader.get());
   gdmlParser.SetOverlapCheck(OverlapCheck());
-//  gdmlParser.Read(m_GDMPath, false);
+  //  gdmlParser.Read(m_GDMPath, false);
   gdmlParser.Read(m_GDMPath, OverlapCheck());
 
   //  G4AssemblyVolume* av_ITSUStave = reader->GetAssembly(assemblyname);

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
@@ -15,7 +15,6 @@
 
 #include <g4main/PHG4Detector.h>
 
-
 #include <Geant4/G4Types.hh>
 
 #include <string>
@@ -33,7 +32,7 @@ class PHParameters;
 class PHG4GDMLDetector : public PHG4Detector
 {
  public:
-  PHG4GDMLDetector(PHG4Subsystem *subsys, PHCompositeNode* Node, const std::string& dnam, PHParameters* parameters);
+  PHG4GDMLDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam, PHParameters* parameters);
 
   virtual ~PHG4GDMLDetector();
 
@@ -48,8 +47,8 @@ class PHG4GDMLDetector : public PHG4Detector
   void Print(const std::string& what = "ALL") const;
 
  private:
-  void SetDisplayProperty( G4AssemblyVolume* av);
-  void SetDisplayProperty( G4LogicalVolume* lv);
+  void SetDisplayProperty(G4AssemblyVolume* av);
+  void SetDisplayProperty(G4LogicalVolume* lv);
 
   std::string m_GDMPath;
   std::string m_TopVolName;

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
@@ -24,6 +24,7 @@ class G4AssemblyVolume;
 class G4LogicalVolume;
 class G4UserSteppingAction;
 class PHCompositeNode;
+class PHG4Subsystem;
 class PHParameters;
 
 /*!
@@ -32,12 +33,12 @@ class PHParameters;
 class PHG4GDMLDetector : public PHG4Detector
 {
  public:
-  PHG4GDMLDetector(PHCompositeNode* Node, const std::string& dnam, PHParameters* parameters);
+  PHG4GDMLDetector(PHG4Subsystem *subsys, PHCompositeNode* Node, const std::string& dnam, PHParameters* parameters);
 
   virtual ~PHG4GDMLDetector();
 
   //! construct
-  void Construct(G4LogicalVolume* world);
+  void ConstructMe(G4LogicalVolume* world);
 
   G4UserSteppingAction* GetSteppingAction()
   {

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
@@ -14,7 +14,7 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <iostream>                    // for operator<<, basic_ostream, endl
+#include <iostream>  // for operator<<, basic_ostream, endl
 
 class PHCompositeNode;
 class PHG4Detector;
@@ -35,8 +35,8 @@ PHG4GDMLSubsystem::~PHG4GDMLSubsystem()
 //_______________________________________________________________________
 int PHG4GDMLSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
-//  PHNodeIterator iter(topNode);
-//  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  //  PHNodeIterator iter(topNode);
+  //  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
   m_Detector = new PHG4GDMLDetector(this, topNode, Name(), GetParams());

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
@@ -39,7 +39,7 @@ int PHG4GDMLSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 //  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  m_Detector = new PHG4GDMLDetector(topNode, Name(), GetParams());
+  m_Detector = new PHG4GDMLDetector(this, topNode, Name(), GetParams());
   m_Detector->OverlapCheck(CheckOverlap());
 
   //  set<string> nodes;

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
@@ -12,7 +12,7 @@
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
-#include <Geant4/G4Colour.hh>              // for G4Colour
+#include <Geant4/G4Colour.hh>  // for G4Colour
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4ExtrudedSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
@@ -47,7 +47,7 @@ using namespace std;
 int PHG4HcalDetector::INACTIVE = -100;
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4HcalDetector::PHG4HcalDetector(PHG4Subsystem *subsys, PHCompositeNode* Node, const std::string& dnam, const int lyr)
+PHG4HcalDetector::PHG4HcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam, const int lyr)
   : PHG4Detector(subsys, Node, dnam)
   , TrackerMaterial(nullptr)
   , TrackerThickness(100 * cm)
@@ -102,7 +102,7 @@ void PHG4HcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
                                        length / 2.0, 0, twopi);
   double innerlength = PHG4Utils::GetLengthForRapidityCoverage(radius) * 2;
   double deltalen = (length - innerlength) / 2.;  // length difference on one side
-  double cone_size_multiplier = 1.01;  // 1 % larger
+  double cone_size_multiplier = 1.01;             // 1 % larger
   double cone_thickness = TrackerThickness * cone_size_multiplier;
   double inner_cone_radius = radius - ((cone_thickness - TrackerThickness) / 2.);
   double cone_length = deltalen * cone_size_multiplier;

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
@@ -47,8 +47,8 @@ using namespace std;
 int PHG4HcalDetector::INACTIVE = -100;
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4HcalDetector::PHG4HcalDetector(PHCompositeNode* Node, const std::string& dnam, const int lyr)
-  : PHG4Detector(Node, dnam)
+PHG4HcalDetector::PHG4HcalDetector(PHG4Subsystem *subsys, PHCompositeNode* Node, const std::string& dnam, const int lyr)
+  : PHG4Detector(subsys, Node, dnam)
   , TrackerMaterial(nullptr)
   , TrackerThickness(100 * cm)
   , cylinder_logic(nullptr)
@@ -86,7 +86,7 @@ int PHG4HcalDetector::IsInCylinderActive(const G4VPhysicalVolume* volume)
 }
 
 //_______________________________________________________________
-void PHG4HcalDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4HcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   TrackerMaterial = G4Material::GetMaterial(material);
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
@@ -12,6 +12,7 @@
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
+#include <Geant4/G4Colour.hh>              // for G4Colour
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4ExtrudedSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.h
@@ -17,12 +17,13 @@ class G4LogicalVolume;
 class G4UserSteppingAction;
 class G4VPhysicalVolume;
 class PHCompositeNode;
+class PHG4Subsystem;
 
 class PHG4HcalDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4HcalDetector(PHCompositeNode* Node, const std::string& dnam, const int layer = 0);
+  PHG4HcalDetector(PHG4Subsystem *subsys, PHCompositeNode* Node, const std::string& dnam, const int layer = 0);
 
   //! destructor
   virtual ~PHG4HcalDetector(void)
@@ -30,7 +31,7 @@ class PHG4HcalDetector : public PHG4Detector
   }
 
   //! construct
-  void Construct(G4LogicalVolume* world);
+  void ConstructMe(G4LogicalVolume* world);
 
   void SetRadius(const G4double dbl) { radius = dbl * cm; }
   void SetLength(const G4double dbl) { length = dbl * cm; }

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.h
@@ -23,7 +23,7 @@ class PHG4HcalDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4HcalDetector(PHG4Subsystem *subsys, PHCompositeNode* Node, const std::string& dnam, const int layer = 0);
+  PHG4HcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam, const int layer = 0);
 
   //! destructor
   virtual ~PHG4HcalDetector(void)

--- a/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
@@ -5,22 +5,22 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
+#include <g4main/PHG4SteppingAction.h>        // for PHG4SteppingAction
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
 
-#include <Geant4/G4IonisParamMat.hh>  // for G4IonisParamMat
-#include <Geant4/G4Material.hh>       // for G4Material
-#include <Geant4/G4MaterialCutsCouple.hh>
 #include <Geant4/G4ParticleDefinition.hh>  // for G4ParticleDefinition
 #include <Geant4/G4Step.hh>
 #include <Geant4/G4StepPoint.hh>              // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>             // for fGeomBoundary, fAtRestD...
 #include <Geant4/G4String.hh>                 // for G4String
 #include <Geant4/G4SystemOfUnits.hh>          // for cm, GeV, nanosecond
 #include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
 #include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
 #include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
 #include <Geant4/G4Types.hh>                  // for G4double
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation

--- a/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
@@ -5,7 +5,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>        // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
@@ -68,7 +68,7 @@ int PHG4HcalSubsystem::InitRun(PHCompositeNode* topNode)
   PHNodeIterator iter(topNode);
   PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
   // create detector
-  detector_ = new PHG4HcalDetector(topNode, Name(), layer);
+  detector_ = new PHG4HcalDetector(this, topNode, Name(), layer);
   detector_->SetRadius(radius);
   G4double detlength = length;
   if (lengthViaRapidityCoverage)

--- a/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
@@ -13,9 +13,9 @@
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
-#include <Geant4/G4String.hh>  // for G4String
-#include <Geant4/G4SystemOfUnits.hh>    // for cm
-#include <Geant4/G4Types.hh>   // for G4double
+#include <Geant4/G4String.hh>         // for G4String
+#include <Geant4/G4SystemOfUnits.hh>  // for cm
+#include <Geant4/G4Types.hh>          // for G4double
 
 #include <cmath>     // for asin, cos, sin, sqrt, M_PI
 #include <cstdlib>   // for NULL, exit

--- a/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
@@ -14,6 +14,7 @@
 #include <phool/getClass.h>
 
 #include <Geant4/G4String.hh>  // for G4String
+#include <Geant4/G4SystemOfUnits.hh>    // for cm
 #include <Geant4/G4Types.hh>   // for G4double
 
 #include <cmath>     // for asin, cos, sin, sqrt, M_PI

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -62,8 +62,8 @@ using namespace std;
 // scintilator length takes care of this
 static double subtract_from_scinti_x = 0.1 * mm;
 
-PHG4InnerHcalDetector::PHG4InnerHcalDetector(PHG4InnerHcalSubsystem *subsys,PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
-  : PHG4Detector(Node, dnam)
+PHG4InnerHcalDetector::PHG4InnerHcalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , m_DisplayAction(dynamic_cast<PHG4InnerHcalDisplayAction *>(subsys->GetDisplayAction()))
   , m_Params(parameters)
   , m_ScintiMotherAssembly(nullptr)
@@ -405,7 +405,7 @@ void PHG4InnerHcalDetector::ShiftSecantToTangent(Point_2 &lowleft, Point_2 &uple
 
 // Construct the envelope and the call the
 // actual inner hcal construction
-void PHG4InnerHcalDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4InnerHcalDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   G4Material *Air = G4Material::GetMaterial("G4_AIR");
   G4VSolid *hcal_envelope_cylinder = new G4Tubs("InnerHcal_envelope_solid", m_EnvelopeInnerRadius, m_EnvelopeOuterRadius, m_EnvelopeZ / 2., 0, 2 * M_PI);

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -1,8 +1,8 @@
 #include "PHG4InnerHcalDetector.h"
 
+#include "PHG4HcalDefs.h"
 #include "PHG4InnerHcalDisplayAction.h"
 #include "PHG4InnerHcalSubsystem.h"
-#include "PHG4HcalDefs.h"
 
 #include <phparameter/PHParameters.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -13,9 +13,9 @@
 
 #include <map>
 #include <set>
-#include <string>                          // for string
+#include <string>   // for string
+#include <utility>  // for pair
 #include <vector>
-#include <utility>                         // for pair
 
 class G4AssemblyVolume;
 class G4LogicalVolume;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -23,8 +23,8 @@ class G4VPhysicalVolume;
 class G4VSolid;
 class PHCompositeNode;
 class PHG4InnerHcalDisplayAction;
-class PHG4InnerHcalSubsystem;
 class PHParameters;
+class PHG4Subsystem;
 
 class PHG4InnerHcalDetector : public PHG4Detector
 {
@@ -33,13 +33,13 @@ class PHG4InnerHcalDetector : public PHG4Detector
   typedef CGAL::Point_2<Circular_k> Point_2;
 
   //! constructor
-  PHG4InnerHcalDetector(PHG4InnerHcalSubsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
+  PHG4InnerHcalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4InnerHcalDetector();
 
   //! construct
-  virtual void Construct(G4LogicalVolume *world);
+  virtual void ConstructMe(G4LogicalVolume *world);
 
   virtual void Print(const std::string &what = "ALL") const;
 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -1,9 +1,9 @@
 #include "PHG4OuterHcalDetector.h"
 
+#include "PHG4HcalDefs.h"
 #include "PHG4OuterHcalDisplayAction.h"
 #include "PHG4OuterHcalFieldSetup.h"
 #include "PHG4OuterHcalSubsystem.h"
-#include "PHG4HcalDefs.h"
 
 #include <phparameter/PHParameters.h>
 
@@ -151,7 +151,7 @@ PHG4OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_upperedge.x()))
       {
@@ -185,7 +185,7 @@ PHG4OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > minx)
       {
@@ -229,7 +229,7 @@ PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > 0)
       {
@@ -250,7 +250,7 @@ PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
       {
@@ -289,7 +289,7 @@ PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
     for (iter = res.begin(); iter != res.end(); ++iter)
     {
       CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
+      if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
       {
         if (CGAL::to_double(point->first.x()) > pxmax)
         {
@@ -310,7 +310,7 @@ PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
     for (iter = res.begin(); iter != res.end(); ++iter)
     {
       CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
+      if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
       {
         if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
         {
@@ -384,7 +384,7 @@ void PHG4OuterHcalDetector::ShiftSecantToTangent(PHG4OuterHcalDetector::Point_2 
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > pxmax)
       {
@@ -502,8 +502,8 @@ int PHG4OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume *hcalenvelope)
   // of crossings is given
   m_FieldSetup = new PHG4OuterHcalFieldSetup(
       m_NumScintiPlates, /*G4int steelPlates*/
-      m_ScintiGap,      /*G4double scintiGap*/
-      m_TiltAngle);     /*G4double tiltAngle*/
+      m_ScintiGap,       /*G4double scintiGap*/
+      m_TiltAngle);      /*G4double tiltAngle*/
 
   m_ScintiMotherAssembly = ConstructHcalScintillatorAssembly(hcalenvelope);
 #ifdef SCINTITEST
@@ -729,10 +729,10 @@ void PHG4OuterHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
   }
   G4TwoVector zero(0, 0);
   m_SteelCutoutForMagnetG4Solid = new G4ExtrudedSolid("ScintillatorTile",
-                                                vertexes,
-                                                m_ScintiTileThickness + 20 * cm,
-                                                zero, 1.0,
-                                                zero, 1.0);
+                                                      vertexes,
+                                                      m_ScintiTileThickness + 20 * cm,
+                                                      zero, 1.0,
+                                                      zero, 1.0);
   return;
 }
 
@@ -855,8 +855,8 @@ void PHG4OuterHcalDetector::SetTiltViaNcross()
   int ncross = m_Params->get_int_param("ncross");
   if (!ncross || isfinite(m_TiltAngle))
   {
-// mark ncross parameter as not used
-    m_Params->set_int_param("ncross",0);
+    // mark ncross parameter as not used
+    m_Params->set_int_param("ncross", 0);
     return;
   }
   if ((isfinite(m_TiltAngle)) && (Verbosity() > 0))
@@ -883,7 +883,7 @@ void PHG4OuterHcalDetector::SetTiltViaNcross()
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > 0)
       {
@@ -904,7 +904,7 @@ void PHG4OuterHcalDetector::SetTiltViaNcross()
   for (iter = res.begin(); iter != res.end(); ++iter)
   {
     CGAL::Object obj = *iter;
-    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> >(&obj))
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
     {
       if (CGAL::to_double(point->first.x()) > 0)
       {

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -66,8 +66,8 @@ using namespace std;
 // scintilator length takes care of this
 static double subtract_from_scinti_x = 0.1 * mm;
 
-PHG4OuterHcalDetector::PHG4OuterHcalDetector(PHG4OuterHcalSubsystem *subsys, PHCompositeNode *Node, PHParameters *parames, const std::string &dnam)
-  : PHG4Detector(Node, dnam)
+PHG4OuterHcalDetector::PHG4OuterHcalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parames, const std::string &dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , m_DisplayAction(dynamic_cast<PHG4OuterHcalDisplayAction *>(subsys->GetDisplayAction()))
   , m_FieldSetup(nullptr)
   , m_Params(parames)
@@ -412,7 +412,7 @@ void PHG4OuterHcalDetector::ShiftSecantToTangent(PHG4OuterHcalDetector::Point_2 
   return;
 }
 
-void PHG4OuterHcalDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4OuterHcalDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
 #ifdef SCINTITEST
   ConstructOuterHcal(logicWorld);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
@@ -5,15 +5,15 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/G4Types.hh>               // for G4double
+#include <Geant4/G4Types.hh>  // for G4double
 
 #include <CGAL/Exact_circular_kernel_2.h>
 #include <CGAL/point_generators_2.h>
 
 #include <map>
 #include <set>
-#include <string>                          // for string
-#include <utility>                         // for pair
+#include <string>   // for string
+#include <utility>  // for pair
 #include <vector>
 
 class G4AssemblyVolume;

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
@@ -5,8 +5,6 @@
 
 #include <g4main/PHG4Detector.h>
 
-// cannot fwd declare G4RotationMatrix, it is a typedef pointing to clhep
-//#include <Geant4/G4RotationMatrix.hh>
 #include <Geant4/G4Types.hh>               // for G4double
 
 #include <CGAL/Exact_circular_kernel_2.h>
@@ -25,8 +23,8 @@ class G4VSolid;
 class PHCompositeNode;
 class PHG4OuterHcalDisplayAction;
 class PHG4OuterHcalFieldSetup;
-class PHG4OuterHcalSubsystem;
 class PHParameters;
+class PHG4Subsystem;
 
 class PHG4OuterHcalDetector : public PHG4Detector
 {
@@ -34,13 +32,13 @@ class PHG4OuterHcalDetector : public PHG4Detector
   typedef CGAL::Exact_circular_kernel_2 Circular_k;
   typedef CGAL::Point_2<Circular_k> Point_2;
   //! constructor
-  PHG4OuterHcalDetector(PHG4OuterHcalSubsystem *subsys, PHCompositeNode *Node, PHParameters *params, const std::string &dnam = "HCALOUT");
+  PHG4OuterHcalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *params, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4OuterHcalDetector();
 
   //! construct
-  virtual void Construct(G4LogicalVolume *world);
+  virtual void ConstructMe(G4LogicalVolume *world);
 
   virtual void Print(const std::string &what = "ALL") const;
 

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.cc
@@ -24,8 +24,8 @@ class PHCompositeNode;
 
 using namespace std;
 
-PHG4PSTOFDetector::PHG4PSTOFDetector(PHCompositeNode *Node, PHParametersContainer *params, const std::string &dnam)
-  : PHG4Detector(Node, dnam)
+PHG4PSTOFDetector::PHG4PSTOFDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParametersContainer *params, const std::string &dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , paramscontainer(params)
 {
   const PHParameters *par = paramscontainer->GetParameters(-1);
@@ -50,7 +50,7 @@ int PHG4PSTOFDetector::IsInPSTOF(G4VPhysicalVolume *volume) const
   return 0;
 }
 
-void PHG4PSTOFDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4PSTOFDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   G4Material *Glass = G4Material::GetMaterial("G4_GLASS_PLATE");
   G4Box *pstof_box = new G4Box("pstof_box", 0.8 * cm, 6 * cm, 5 * cm);

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.cc
@@ -3,28 +3,28 @@
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
 
-#include <g4main/PHG4Detector.h>                // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>           // for G4RotationMatrix
-#include <Geant4/G4String.hh>                   // for G4String
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>              // for G4ThreeVector
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4VisAttributes.hh>
 
 #include <cmath>
-#include <iostream>                             // for operator<<, endl, bas...
-#include <utility>                              // for pair
+#include <iostream>  // for operator<<, endl, bas...
+#include <utility>   // for pair
 
 class PHCompositeNode;
 
 using namespace std;
 
-PHG4PSTOFDetector::PHG4PSTOFDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParametersContainer *params, const std::string &dnam)
+PHG4PSTOFDetector::PHG4PSTOFDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParametersContainer *params, const std::string &dnam)
   : PHG4Detector(subsys, Node, dnam)
   , paramscontainer(params)
 {
@@ -98,8 +98,8 @@ void PHG4PSTOFDetector::ConstructMe(G4LogicalVolume *logicWorld)
       G4VPhysicalVolume *vol = new G4PVPlacement(rotm, G4ThreeVector(x, y, z), pstof_log_vol, "PSTOF", logicWorld, false, modnum, OverlapCheck());
       if (IsActive)
       {
-	active_phys_vols[vol] = modnum;
-//        active_phys_vols.insert(vol);
+        active_phys_vols[vol] = modnum;
+        //        active_phys_vols.insert(vol);
       }
     }
   }

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.h
@@ -6,7 +6,7 @@
 #include <g4main/PHG4Detector.h>
 
 #include <map>
-#include <string>                 // for string
+#include <string>  // for string
 
 class G4LogicalVolume;
 class G4VPhysicalVolume;
@@ -18,10 +18,10 @@ class PHG4PSTOFDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4PSTOFDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParametersContainer *params_array, const std::string &dnam);
+  PHG4PSTOFDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParametersContainer *params_array, const std::string &dnam);
 
   //! destructor
-  virtual ~PHG4PSTOFDetector(){}
+  virtual ~PHG4PSTOFDetector() {}
 
   //! construct
   virtual void ConstructMe(G4LogicalVolume *world);
@@ -35,8 +35,8 @@ class PHG4PSTOFDetector : public PHG4Detector
 
   void SuperDetector(const std::string &name) { superdetector = name; }
   const std::string SuperDetector() const { return superdetector; }
- 
-protected:
+
+ protected:
   int IsActive;
   int IsAbsorberActive;
   int nmod;

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.h
@@ -12,18 +12,19 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHParametersContainer;
+class PHG4Subsystem;
 
 class PHG4PSTOFDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4PSTOFDetector(PHCompositeNode *Node, PHParametersContainer *params_array, const std::string &dnam = "PSTOF");
+  PHG4PSTOFDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParametersContainer *params_array, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4PSTOFDetector(){}
 
   //! construct
-  virtual void Construct(G4LogicalVolume *world);
+  virtual void ConstructMe(G4LogicalVolume *world);
 
   virtual void Print(const std::string &what = "ALL") const;
 

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.cc
@@ -50,7 +50,7 @@ int PHG4PSTOFSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create detector
-  detector_ = new PHG4PSTOFDetector(topNode, GetParamsContainer(), Name());
+  detector_ = new PHG4PSTOFDetector(this, topNode, GetParamsContainer(), Name());
   detector_->SuperDetector(SuperDetector());
   detector_->OverlapCheck(CheckOverlap());
 

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.cc
@@ -16,18 +16,18 @@
 #include <phparameter/PHParametersContainer.h>
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>          // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>                 // for PHIODataNode
-#include <phool/PHNode.h>                       // for PHNode
-#include <phool/PHNodeIterator.h>               // for PHNodeIterator
-#include <phool/PHObject.h>                     // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <boost/foreach.hpp>
 
-#include <set>                                  // for set
+#include <set>  // for set
 #include <sstream>
 
 using namespace std;

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
@@ -31,7 +31,7 @@ class PHG4CrystalCalorimeterSubsystem;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4ProjCrystalCalorimeterDetector::PHG4ProjCrystalCalorimeterDetector(PHG4CrystalCalorimeterSubsystem *subsys, PHCompositeNode *Node, const std::string &dnam)
+PHG4ProjCrystalCalorimeterDetector::PHG4ProjCrystalCalorimeterDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam)
   : PHG4CrystalCalorimeterDetector(subsys, Node, dnam)
   ,
   //  _dx_front(50.19*mm),		//****************************************************************//
@@ -74,7 +74,7 @@ int PHG4ProjCrystalCalorimeterDetector::IsInCrystalCalorimeter(G4VPhysicalVolume
 }
 
 //_______________________________________________________________________
-void PHG4ProjCrystalCalorimeterDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4ProjCrystalCalorimeterDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   if (Verbosity() > 0)
   {

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
@@ -4,25 +4,25 @@
 #include "PHG4CrystalCalorimeterDisplayAction.h"
 
 #include <Geant4/G4Cons.hh>
-#include <Geant4/G4Element.hh>                    // for G4Element
+#include <Geant4/G4Element.hh>  // for G4Element
 #include <Geant4/G4GenericTrap.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>             // for G4RotationMatrix
-#include <Geant4/G4String.hh>                     // for G4String
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>                // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>                // for G4Transform3D
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D
 #include <Geant4/G4Trd.hh>
 #include <Geant4/G4TwoVector.hh>
-#include <Geant4/G4VPhysicalVolume.hh>            // for G4VPhysicalVolume
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
-#include <vector>                                 // for vector
+#include <vector>  // for vector
 
 class G4VSolid;
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
@@ -5,9 +5,9 @@
 
 #include "PHG4CrystalCalorimeterDetector.h"
 
-#include <Geant4/G4Types.hh>                 // for G4double, G4int
+#include <Geant4/G4Types.hh>  // for G4double, G4int
 
-#include <string>                            // for string
+#include <string>  // for string
 
 class G4LogicalVolume;
 class G4VPhysicalVolume;

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
@@ -12,7 +12,7 @@
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
-class PHG4CrystalCalorimeterSubsystem;
+class PHG4Subsystem;
 
 /**
  * \file ${file_name}
@@ -24,13 +24,13 @@ class PHG4ProjCrystalCalorimeterDetector : public PHG4CrystalCalorimeterDetector
 {
  public:
   //! constructor
-  PHG4ProjCrystalCalorimeterDetector(PHG4CrystalCalorimeterSubsystem* subsys, PHCompositeNode* Node, const std::string& dnam = "BLOCK");
+  PHG4ProjCrystalCalorimeterDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam);
 
   //! destructor
   virtual ~PHG4ProjCrystalCalorimeterDetector();
 
   //! construct
-  virtual void Construct(G4LogicalVolume* world);
+  virtual void ConstructMe(G4LogicalVolume* world);
 
   //!@name volume accessors
   virtual int IsInCrystalCalorimeter(G4VPhysicalVolume*) const;

--- a/simulation/g4simulation/g4detectors/PHG4RICHDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHDetector.cc
@@ -25,21 +25,21 @@ class PHCompositeNode;
 using namespace std;
 using namespace ePHENIXRICH;
 
-PHG4RICHDetector::PHG4RICHDetector(PHG4RICHSubsystem *subsys, PHCompositeNode *Node, const RICH_Geometry &g)
-  : PHG4Detector(Node)
+PHG4RICHDetector::PHG4RICHDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const string &dnam,  const RICH_Geometry &g)
+  : PHG4Detector(subsys, Node, dnam)
   , ePHENIXRICHConstruction(subsys, g)
   , _region(nullptr)
 {
 }
 
-PHG4RICHDetector::PHG4RICHDetector(PHG4RICHSubsystem *subsys, PHCompositeNode *Node)
-  : PHG4Detector(Node)
+PHG4RICHDetector::PHG4RICHDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const string &dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , ePHENIXRICHConstruction(subsys)
   , _region(nullptr)
 {
 }
 
-void PHG4RICHDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4RICHDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   _region = new G4Region("FCALREGION");
   _region->SetRegionalSteppingAction(new PHG4RICHSteppingAction(this));

--- a/simulation/g4simulation/g4detectors/PHG4RICHDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHDetector.cc
@@ -11,9 +11,9 @@
 #include "PHG4RICHDetector.h"
 #include "PHG4RICHSteppingAction.h"
 
-#include <g4main/PHG4Detector.h>     // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 
-#include <Geant4/G4Region.hh>        // for G4Region
+#include <Geant4/G4Region.hh>  // for G4Region
 
 #include <boost/foreach.hpp>
 
@@ -25,7 +25,7 @@ class PHCompositeNode;
 using namespace std;
 using namespace ePHENIXRICH;
 
-PHG4RICHDetector::PHG4RICHDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const string &dnam,  const RICH_Geometry &g)
+PHG4RICHDetector::PHG4RICHDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const string &dnam, const RICH_Geometry &g)
   : PHG4Detector(subsys, Node, dnam)
   , ePHENIXRICHConstruction(subsys, g)
   , _region(nullptr)

--- a/simulation/g4simulation/g4detectors/PHG4RICHDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4RICHDetector.h
@@ -21,7 +21,7 @@
 class G4LogicalVolume;
 class G4UserSteppingAction;
 class PHCompositeNode;
-class PHG4RICHSubsystem;
+class PHG4Subsystem;
 
 /**
    * \brief This class creates the ePHENIX RICH volumes for Geant4 within Fun4All via
@@ -39,15 +39,15 @@ class PHG4RICHDetector : public PHG4Detector,
                          public ePHENIXRICH::ePHENIXRICHConstruction
 {
  public:
-  PHG4RICHDetector(PHG4RICHSubsystem* subsys, PHCompositeNode* Node, const ePHENIXRICH::RICH_Geometry& g);
-  PHG4RICHDetector(PHG4RICHSubsystem* subsys, PHCompositeNode* Node);
+  PHG4RICHDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string &dname, const ePHENIXRICH::RICH_Geometry& g);
+  PHG4RICHDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string &dname);
 
   virtual ~PHG4RICHDetector(void)
   {
   }
 
   virtual void
-  Construct(G4LogicalVolume* world);
+  ConstructMe(G4LogicalVolume* world);
 
   virtual G4UserSteppingAction*
   GetSteppingAction()

--- a/simulation/g4simulation/g4detectors/PHG4RICHDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4RICHDetector.h
@@ -39,8 +39,8 @@ class PHG4RICHDetector : public PHG4Detector,
                          public ePHENIXRICH::ePHENIXRICHConstruction
 {
  public:
-  PHG4RICHDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string &dname, const ePHENIXRICH::RICH_Geometry& g);
-  PHG4RICHDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string &dname);
+  PHG4RICHDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dname, const ePHENIXRICH::RICH_Geometry& g);
+  PHG4RICHDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dname);
 
   virtual ~PHG4RICHDetector(void)
   {
@@ -65,7 +65,6 @@ class PHG4RICHDetector : public PHG4Detector,
   }
 
  private:
-
   G4Region* _region;
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4RICHSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHSubsystem.cc
@@ -13,15 +13,15 @@
 #include "PHG4RICHDisplayAction.h"
 #include "PHG4RICHSteppingAction.h"
 
-#include <g4main/PHG4DisplayAction.h>      // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4Subsystem.h>          // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>  // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>            // for PHIODataNode
-#include <phool/PHNode.h>                  // for PHNode
-#include <phool/PHNodeIterator.h>          // for PHNodeIterator
-#include <phool/PHObject.h>                // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <Geant4/G4UserSteppingAction.hh>  // for G4UserSteppingAction

--- a/simulation/g4simulation/g4detectors/PHG4RICHSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHSubsystem.cc
@@ -60,7 +60,7 @@ int PHG4RICHSubsystem::Init(PHCompositeNode* topNode)
   // create display settings before detector
   m_DisplayAction = new PHG4RICHDisplayAction(Name());
   // create detector
-  m_Detector = new PHG4RICHDetector(this, topNode, geom);
+  m_Detector = new PHG4RICHDetector(this, topNode, Name(), geom);
   m_Detector->Verbosity(Verbosity());
   m_Detector->OverlapCheck(CheckOverlap());
 

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
@@ -38,7 +38,7 @@
 using namespace PHG4Sector;
 using namespace std;
 
-PHG4SectorConstructor::PHG4SectorConstructor(const std::string &name, PHG4SectorSubsystem *subsys)
+PHG4SectorConstructor::PHG4SectorConstructor(const std::string &name, PHG4Subsystem *subsys)
   : overlapcheck_sector(false)
   , name_base(name)
   , m_DisplayAction(dynamic_cast<PHG4SectorDisplayAction *>(subsys->GetDisplayAction()))

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
@@ -10,7 +10,7 @@
 #include "PHG4SectorDisplayAction.h"
 #include "PHG4SectorSubsystem.h"
 
-#include <g4main/PHG4DisplayAction.h>     // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4DisplacedSolid.hh>     // for G4DisplacedSolid
@@ -18,18 +18,18 @@
 #include <Geant4/G4IntersectionSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
-#include <Geant4/G4MaterialTable.hh>      // for G4MaterialTable
-#include <Geant4/G4PhysicalConstants.hh>  // for pi
+#include <Geant4/G4MaterialTable.hh>  // for G4MaterialTable
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4PhysicalConstants.hh>  // for pi
 #include <Geant4/G4Sphere.hh>
-#include <Geant4/G4SystemOfUnits.hh>      // for cm, um, perCent
-#include <Geant4/G4ThreeVector.hh>        // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>        // for G4Transform3D, G4RotateX3D
+#include <Geant4/G4SystemOfUnits.hh>  // for cm, um, perCent
+#include <Geant4/G4ThreeVector.hh>    // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>    // for G4Transform3D, G4RotateX3D
 #include <Geant4/G4Tubs.hh>
-#include <Geant4/G4ios.hh>                // for G4cout, G4endl
-#include <Geant4/globals.hh>              // for G4Exception
+#include <Geant4/G4ios.hh>    // for G4cout, G4endl
+#include <Geant4/globals.hh>  // for G4Exception
 
-#include <algorithm>                      // for max
+#include <algorithm>  // for max
 #include <cassert>
 #include <cmath>
 #include <iostream>

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
@@ -12,12 +12,12 @@
 #ifndef G4DETECTORS_PHG4SECTORCONSTRUCTOR_H
 #define G4DETECTORS_PHG4SECTORCONSTRUCTOR_H
 
-#include <Geant4/G4String.hh>             // for G4String
-#include <Geant4/G4Types.hh>              // for G4int
+#include <Geant4/G4String.hh>  // for G4String
+#include <Geant4/G4Types.hh>   // for G4int
 
 #if !defined(__CINT__) || defined(__CLING__)
-#include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4PhysicalConstants.hh>
+#include <Geant4/G4SystemOfUnits.hh>
 #endif
 
 class G4LogicalVolume;
@@ -364,7 +364,7 @@ class PHG4SectorConstructor
 {
  public:
   PHG4SectorConstructor(const std::string &name, PHG4Subsystem *subsys);
-  virtual ~PHG4SectorConstructor(){}
+  virtual ~PHG4SectorConstructor() {}
 
   void
   Construct_Sectors(G4LogicalVolume *WorldLog);

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
@@ -24,7 +24,7 @@ class G4LogicalVolume;
 class G4PVPlacement;
 class G4VSolid;
 class PHG4SectorDisplayAction;
-class PHG4SectorSubsystem;
+class PHG4Subsystem;
 
 #include <map>
 #include <utility>
@@ -363,7 +363,7 @@ class Sector_Geometry
 class PHG4SectorConstructor
 {
  public:
-  PHG4SectorConstructor(const std::string &name, PHG4SectorSubsystem *subsys);
+  PHG4SectorConstructor(const std::string &name, PHG4Subsystem *subsys);
   virtual ~PHG4SectorConstructor(){}
 
   void

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
@@ -99,7 +99,7 @@ class Sector_Geometry
     return N_Sector;
   }
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   std::vector<Layer> &
   get_layer_list()
   {
@@ -145,7 +145,7 @@ class Sector_Geometry
     N_Sector = sector;
   }
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   void
   set_layer_list(const std::vector<Layer> &layerList)
   {
@@ -225,7 +225,7 @@ class Sector_Geometry
 
   // layer descriptions
  public:
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
   typedef std::vector<Layer> t_layer_list;
   t_layer_list layer_list;
@@ -357,7 +357,7 @@ class Sector_Geometry
   std::string material;
 };
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
 //! \brief Generalized detector which use sectors of flat panels to cover full azimuthal acceptance
 class PHG4SectorConstructor
@@ -412,6 +412,6 @@ class PHG4SectorConstructor
   map_phy_vol_t map_active_phy_vol;  //! active physics volume
 };
 
-#endif  // #ifndef __CINT__
+#endif  // #if !defined(__CINT__) || defined(__CLING__)
 }  // namespace PHG4Sector
 #endif /* PHG4SectorConstructor_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4SectorDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDetector.cc
@@ -6,11 +6,11 @@
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4String.hh>          // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 
-#include <map>                         // for _Rb_tree_iterator, _Rb_tree_co...
+#include <map>  // for _Rb_tree_iterator, _Rb_tree_co...
 #include <sstream>
-#include <utility>                     // for pair
+#include <utility>  // for pair
 
 class G4VPhysicalVolume;
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4SectorDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDetector.cc
@@ -20,8 +20,8 @@ using namespace PHG4Sector;
 
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4SectorDetector::PHG4SectorDetector(PHG4SectorSubsystem *subsys, PHCompositeNode *Node, const std::string &dnam)
-  : PHG4Detector(Node, dnam)
+PHG4SectorDetector::PHG4SectorDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , PHG4SectorConstructor(dnam, subsys)
   , m_DisplayAction(dynamic_cast<PHG4SectorDisplayAction *>(subsys->GetDisplayAction()))
 {
@@ -44,7 +44,7 @@ bool PHG4SectorDetector::IsInSectorActive(G4VPhysicalVolume *physvol)
 }
 
 //_______________________________________________________________
-void PHG4SectorDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4SectorDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   Construct_Sectors(logicWorld);
 

--- a/simulation/g4simulation/g4detectors/PHG4SectorDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDetector.h
@@ -7,7 +7,7 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <string>                   // for string
+#include <string>  // for string
 
 class G4LogicalVolume;
 class G4VPhysicalVolume;

--- a/simulation/g4simulation/g4detectors/PHG4SectorDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDetector.h
@@ -13,13 +13,13 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4SectorDisplayAction;
-class PHG4SectorSubsystem;
+class PHG4Subsystem;
 
 class PHG4SectorDetector : public PHG4Detector, public PHG4Sector::PHG4SectorConstructor
 {
  public:
   //! constructor
-  PHG4SectorDetector(PHG4SectorSubsystem *subsys, PHCompositeNode *Node, const std::string &dnam = "SECTOR");
+  PHG4SectorDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4SectorDetector(void)
@@ -27,7 +27,7 @@ class PHG4SectorDetector : public PHG4Detector, public PHG4Sector::PHG4SectorCon
   }
 
   //! construct
-  virtual void Construct(G4LogicalVolume *world);
+  virtual void ConstructMe(G4LogicalVolume *world);
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -49,13 +49,13 @@ using namespace std;
 
 //_______________________________________________________________
 //note this inactive thickness is ~1.5% of a radiation length
-PHG4SpacalDetector::PHG4SpacalDetector(PHG4SpacalSubsystem *subsys,
+PHG4SpacalDetector::PHG4SpacalDetector(PHG4Subsystem *subsys,
                                        PHCompositeNode *Node,
                                        const std::string &dnam,
                                        PHParameters *parameters,
                                        const int lyr,
                                        bool init_geom)
-  : PHG4Detector(Node, dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , m_DisplayAction(dynamic_cast<PHG4SpacalDisplayAction *>(subsys->GetDisplayAction()))
   , cylinder_solid(nullptr)
   , cylinder_logic(nullptr)
@@ -116,7 +116,7 @@ int PHG4SpacalDetector::IsInCylinderActive(const G4VPhysicalVolume *volume)
 }
 
 //_______________________________________________________________
-void PHG4SpacalDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4SpacalDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   assert(_geom);
 

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -11,14 +11,14 @@
 #include "PHG4SpacalDisplayAction.h"
 #include "PHG4SpacalSubsystem.h"
 
-#include <g4main/PHG4Detector.h>          // for PHG4Detector
-#include <g4main/PHG4DisplayAction.h>     // for PHG4DisplayAction
+#include <g4main/PHG4Detector.h>       // for PHG4Detector
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                 // for PHNode
-#include <phool/PHNodeIterator.h>         // for PHNodeIterator
-#include <phool/PHObject.h>               // for PHObject
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <g4gdml/PHG4GDMLConfig.hh>
@@ -30,17 +30,17 @@
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4PhysicalConstants.hh>
-#include <Geant4/G4String.hh>             // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>        // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>        // for G4Transform3D, G4RotateZ3D
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D, G4RotateZ3D
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4UserLimits.hh>
 
 #include <boost/foreach.hpp>
 
 #include <cassert>
-#include <iostream>                       // for operator<<, basic_ostream
+#include <iostream>  // for operator<<, basic_ostream
 #include <sstream>
 
 class PHG4CylinderGeom;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
@@ -17,11 +17,11 @@
 #include <g4main/PHG4Detector.h>
 
 #include <Geant4/G4Transform3D.hh>
-#include <Geant4/G4Types.hh>            // for G4double
+#include <Geant4/G4Types.hh>  // for G4double
 
 #include <map>
-#include <string>                       // for string
-#include <utility>                      // for pair
+#include <string>   // for string
+#include <utility>  // for pair
 
 class G4Tubs;
 class G4LogicalVolume;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
@@ -31,21 +31,21 @@ class PHCompositeNode;
 class PHG4CylinderGeom;
 class PHG4GDMLConfig;
 class PHG4SpacalDisplayAction;
-class PHG4SpacalSubsystem;
 class PHParameters;
+class PHG4Subsystem;
 
 class PHG4SpacalDetector : public PHG4Detector
 {
  public:
   typedef PHG4CylinderGeom_Spacalv1 SpacalGeom_t;
 
-  PHG4SpacalDetector(PHG4SpacalSubsystem* subsys, PHCompositeNode* Node, const std::string& dnam,
+  PHG4SpacalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam,
                      PHParameters* parameters, const int layer = 0, bool init_geom = true);
 
   virtual ~PHG4SpacalDetector(void);
 
   virtual void
-  Construct(G4LogicalVolume* world);
+  ConstructMe(G4LogicalVolume* world);
 
   virtual std::pair<G4LogicalVolume*, G4Transform3D>
   Construct_AzimuthalSeg();

--- a/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
@@ -55,8 +55,8 @@ using namespace std;
 using namespace CLHEP;
 
 //_______________________________________________________________
-PHG4mRICHDetector::PHG4mRICHDetector(PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam, const int lyr)
-  : PHG4Detector(Node, dnam)
+PHG4mRICHDetector::PHG4mRICHDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam, const int lyr)
+  : PHG4Detector(subsys, Node, dnam)
   , params(parameters)
   ,
   //block_physi(nullptr),
@@ -87,7 +87,7 @@ int PHG4mRICHDetector::IsInmRICH(G4VPhysicalVolume* volume) const
   return INACTIVE;
 }
 //______________________________________________________________
-void PHG4mRICHDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4mRICHDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   int subsystemSetup = params->get_int_param("subsystemSetup");
   // -1: single module

--- a/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
@@ -42,7 +42,7 @@
 #include <Geant4/G4ios.hh>  // for G4cout, G4endl
 
 #include <algorithm>  // for fill, max
-#include <cmath>  // for floor, sqrt, acos, asin
+#include <cmath>      // for floor, sqrt, acos, asin
 #include <cstdio>
 #include <iostream>  // for operator<<, basic_os...
 #include <iterator>  // for begin, end

--- a/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
@@ -46,7 +46,6 @@
 #include <cstdio>
 #include <iostream>  // for operator<<, basic_os...
 #include <iterator>  // for begin, end
-#include <set>       // for _Rb_tree_const_iterator
 #include <string>
 
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4mRICHDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHDetector.h
@@ -11,9 +11,9 @@
 
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4ThreeVector.hh>
-#include <Geant4/G4Types.hh>        // for G4double, G4int
+#include <Geant4/G4Types.hh>  // for G4double, G4int
 
-#include <map>                      // for map
+#include <map>  // for map
 #include <string>
 
 class G4LogicalVolume;
@@ -24,20 +24,18 @@ class PHCompositeNode;
 class PHG4Subsystem;
 
 //___________________________________________________________________________
-class PHG4mRICHDetector: public PHG4Detector
+class PHG4mRICHDetector : public PHG4Detector
 {
-
  public:
-  
   //! constructor
-  PHG4mRICHDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr = 0);
-  
+  PHG4mRICHDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam, const int lyr = 0);
+
   //! destructor
   virtual ~PHG4mRICHDetector();
-  
+
   //! construct
-  virtual void ConstructMe( G4LogicalVolume* world );
-  
+  virtual void ConstructMe(G4LogicalVolume* world);
+
   //name volume accessors
   //bool IsInBlock(G4VPhysicalVolume*) const;
   int IsInmRICH(G4VPhysicalVolume*) const;
@@ -55,9 +53,9 @@ class PHG4mRICHDetector: public PHG4Detector
     absorberactive = i;
   }
 
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() const {return superdetector;}
-  int get_Layer() const {return layer;}
+  void SuperDetector(const std::string& name) { superdetector = name; }
+  const std::string SuperDetector() const { return superdetector; }
+  int get_Layer() const { return layer; }
 
   enum
   {
@@ -82,33 +80,33 @@ class PHG4mRICHDetector: public PHG4Detector
   class PolyPar;
   class LensPar;
 
-  PHParameters *params;
-  
+  PHParameters* params;
+
   G4VPhysicalVolume* build_box(BoxPar* par, G4LogicalVolume* motherLV);
   G4VPhysicalVolume* build_polyhedra(PolyPar* par, G4LogicalVolume* motherLV);
 
-  G4LogicalVolume* Construct_a_mRICH(G4LogicalVolume* logicWorld);//, int detectorSetup);    //single mRICH
-  G4VPhysicalVolume* build_holderBox(mRichParameter* detectorParameter,G4LogicalVolume* motherLV);
-  void build_foamHolder(mRichParameter* detectorParameter,G4LogicalVolume* motherLV);
-  void build_aerogel(mRichParameter* detectorParameter,G4VPhysicalVolume* motherPV);
+  G4LogicalVolume* Construct_a_mRICH(G4LogicalVolume* logicWorld);  //, int detectorSetup);    //single mRICH
+  G4VPhysicalVolume* build_holderBox(mRichParameter* detectorParameter, G4LogicalVolume* motherLV);
+  void build_foamHolder(mRichParameter* detectorParameter, G4LogicalVolume* motherLV);
+  void build_aerogel(mRichParameter* detectorParameter, G4VPhysicalVolume* motherPV);
   void build_lens(LensPar* par, G4LogicalVolume* motherLV);
-  void build_mirror(mRichParameter* detectorParameter,G4VPhysicalVolume* motherPV);
-  void build_sensor(mRichParameter* detectorParameter,G4LogicalVolume* motherLV);
+  void build_mirror(mRichParameter* detectorParameter, G4VPhysicalVolume* motherPV);
+  void build_sensor(mRichParameter* detectorParameter, G4LogicalVolume* motherLV);
 
   void build_mRICH_wall_hside(G4LogicalVolume* space);
   void build_mRICH_wall_eside(G4LogicalVolume* space);
   void build_mRICH_sector(G4LogicalVolume* logicWorld, int numSector);
-  
+
   int layer;
   int active;
   int absorberactive;
   //int blackhole;
   std::string superdetector;
-  G4VPhysicalVolume *mRICH_PV;         //physical volume of detector box of single module  
-  G4VPhysicalVolume *sensor_PV[4];     //physical volume of sensors the sensitive components
+  G4VPhysicalVolume* mRICH_PV;      //physical volume of detector box of single module
+  G4VPhysicalVolume* sensor_PV[4];  //physical volume of sensors the sensitive components
 
-  std::map<const G4VPhysicalVolume*, int> sensor_vol; // physical volume of senseors
-  std::map<const G4VPhysicalVolume*, int> aerogel_vol; // physical volume of senseors
+  std::map<const G4VPhysicalVolume*, int> sensor_vol;   // physical volume of senseors
+  std::map<const G4VPhysicalVolume*, int> aerogel_vol;  // physical volume of senseors
 };
 //___________________________________________________________________________
 class PHG4mRICHDetector::mRichParameter
@@ -134,7 +132,6 @@ class PHG4mRICHDetector::mRichParameter
   BoxPar* GetBoxPar(std::string componentName);
   LensPar* GetLensPar(std::string componentName);
   PolyPar* GetPolyPar(std::string componentName);
-
 };
 //___________________________________________________________________________
 class PHG4mRICHDetector::BoxPar
@@ -164,7 +161,7 @@ class PHG4mRICHDetector::PolyPar
   G4double theta;
   G4int numSide;
   G4int num_zLayer;
-  G4double z[4];                      //max. layer is 4                                                                                                     
+  G4double z[4];  //max. layer is 4
   G4double rinner[4];
   G4double router[4];
   G4Material* material;
@@ -176,7 +173,7 @@ class PHG4mRICHDetector::PolyPar
   bool surface;
 
   PolyPar();
-  ~PolyPar(){}
+  ~PolyPar() {}
 };
 //___________________________________________________________________________
 class PHG4mRICHDetector::LensPar
@@ -199,13 +196,12 @@ class PHG4mRICHDetector::LensPar
   bool visibility;
   bool wireframe;
   bool surface;
-  
+
   LensPar();
-  ~LensPar(){}
+  ~LensPar() {}
 
-  void Set_halfXYZ(G4double halfX,G4double grooveDensity);
+  void Set_halfXYZ(G4double halfX, G4double grooveDensity);
   G4double GetSagita(G4double r);
-
 };
 //___________________________________________________________________________
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4mRICHDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHDetector.h
@@ -21,6 +21,7 @@ class G4Material;
 class G4VPhysicalVolume;
 class PHParameters;
 class PHCompositeNode;
+class PHG4Subsystem;
 
 //___________________________________________________________________________
 class PHG4mRICHDetector: public PHG4Detector
@@ -29,13 +30,13 @@ class PHG4mRICHDetector: public PHG4Detector
  public:
   
   //! constructor
-  PHG4mRICHDetector( PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam="BLOCK", const int lyr = 0);
+  PHG4mRICHDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr = 0);
   
   //! destructor
   virtual ~PHG4mRICHDetector();
   
   //! construct
-  virtual void Construct( G4LogicalVolume* world );
+  virtual void ConstructMe( G4LogicalVolume* world );
   
   //name volume accessors
   //bool IsInBlock(G4VPhysicalVolume*) const;

--- a/simulation/g4simulation/g4detectors/PHG4mRICHSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHSubsystem.cc
@@ -62,7 +62,7 @@ int PHG4mRICHSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
   //---------------------------------
   // create detector
   //---------------------------------
-  _detector = new PHG4mRICHDetector(topNode, GetParams(), Name(), GetLayer());
+  _detector = new PHG4mRICHDetector(this, topNode, GetParams(), Name(), GetLayer());
   _detector->SuperDetector(SuperDetector());
   _detector->OverlapCheck(CheckOverlap());
   _detector->SetActive(GetParams()->get_int_param("active"));

--- a/simulation/g4simulation/g4detectors/PHG4mRICHSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHSubsystem.cc
@@ -3,26 +3,26 @@
  *         mRICH Subsystem created by Cheuk-Ping Wong @GSU       *
  *===============================================================*/
 #include "PHG4mRICHSubsystem.h"
-#include "PHG4mRICHDetector.h"
 #include "PHG4EventActionClearZeroEdep.h"
+#include "PHG4mRICHDetector.h"
 #include "PHG4mRICHSteppingAction.h"
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4EventAction.h>        // for PHG4EventAction
+#include <g4main/PHG4EventAction.h>  // for PHG4EventAction
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>     // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>            // for PHIODataNode
-#include <phool/PHNode.h>                  // for PHNode
-#include <phool/PHNodeIterator.h>          // for PHNodeIterator
-#include <phool/PHObject.h>                // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <boost/foreach.hpp>
 
-#include <set>                             // for set
+#include <set>  // for set
 #include <sstream>
 
 class PHG4Detector;
@@ -30,34 +30,34 @@ class PHG4Detector;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4mRICHSubsystem::PHG4mRICHSubsystem( const std::string &name, const int lyr):
-  PHG4DetectorSubsystem( name, lyr ),
-  _detector( nullptr ),
-  _detectorName(name),
-  _steppingAction(nullptr),
-  _eventAction(nullptr)
+PHG4mRICHSubsystem::PHG4mRICHSubsystem(const std::string& name, const int lyr)
+  : PHG4DetectorSubsystem(name, lyr)
+  , _detector(nullptr)
+  , _detectorName(name)
+  , _steppingAction(nullptr)
+  , _eventAction(nullptr)
 {
   InitializeParameters();
 }
 
 //_______________________________________________________________________
-int PHG4mRICHSubsystem::InitSubsystem( PHCompositeNode* topNode )
+int PHG4mRICHSubsystem::InitSubsystem(PHCompositeNode* topNode)
 {
   // kludge until the phg4parameters are sorted out (adding layers)
   GetParams()->set_name(Name());
-  GetParams()->set_int_param("active",1);
-  GetParams()->set_int_param("absorberactive",1);
-  GetParams()->set_int_param("blackhole",0);
-  GetParams()->set_string_param("superdetector","NONE");
-  GetParams()->set_string_param("detectorname","mRICH");
+  GetParams()->set_int_param("active", 1);
+  GetParams()->set_int_param("absorberactive", 1);
+  GetParams()->set_int_param("blackhole", 0);
+  GetParams()->set_string_param("superdetector", "NONE");
+  GetParams()->set_string_param("detectorname", "mRICH");
   return 0;
 }
 
 //_______________________________________________________________________
-int PHG4mRICHSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
+int PHG4mRICHSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
 {
-  PHNodeIterator iter( topNode );
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
 
   //---------------------------------
   // create detector
@@ -67,45 +67,51 @@ int PHG4mRICHSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
   _detector->OverlapCheck(CheckOverlap());
   _detector->SetActive(GetParams()->get_int_param("active"));
   _detector->SetAbsorberActive(GetParams()->get_int_param("absorberactive"));
-  
+
   //---------------------------------
   // create hit node and stepping action
   //---------------------------------
-  if (GetParams()->get_int_param("active")) {
+  if (GetParams()->get_int_param("active"))
+  {
     set<string> nodes;
-    
+
     // create hit output node
     ostringstream nodename;
-    nodename <<  "G4HIT_" << GetParams()->get_string_param("detectorname");
-    
+    nodename << "G4HIT_" << GetParams()->get_string_param("detectorname");
+
     PHG4HitContainer* mRICH_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
-    if (!mRICH_hits) {
+    if (!mRICH_hits)
+    {
       mRICH_hits = new PHG4HitContainer(nodename.str());
-      PHIODataNode<PHObject> *hitNode = new PHIODataNode<PHObject>(mRICH_hits, nodename.str().c_str(), "PHObject");
+      PHIODataNode<PHObject>* hitNode = new PHIODataNode<PHObject>(mRICH_hits, nodename.str().c_str(), "PHObject");
       dstNode->addNode(hitNode);
       nodes.insert(nodename.str());
     }
-    
+
     ostringstream absnodename;
     absnodename << "G4HIT_ABSORBER_" << GetParams()->get_string_param("detectorname");
-    
+
     PHG4HitContainer* absorber_hits = findNode::getClass<PHG4HitContainer>(topNode, absnodename.str().c_str());
-    if (!absorber_hits) {
+    if (!absorber_hits)
+    {
       absorber_hits = new PHG4HitContainer(absnodename.str());
-      PHIODataNode<PHObject> *abshitNode = new PHIODataNode<PHObject>(absorber_hits, absnodename.str().c_str(), "PHObject");
+      PHIODataNode<PHObject>* abshitNode = new PHIODataNode<PHObject>(absorber_hits, absnodename.str().c_str(), "PHObject");
       dstNode->addNode(abshitNode);
       nodes.insert(nodename.str());
     }
-    
+
     // create stepping action
-    _steppingAction = new PHG4mRICHSteppingAction(_detector,GetParams());
-    
+    _steppingAction = new PHG4mRICHSteppingAction(_detector, GetParams());
+
     // event actions
-    BOOST_FOREACH(string node, nodes) {
-      if (!_eventAction) _eventAction = new PHG4EventActionClearZeroEdep(topNode, node);
-      else {
-	PHG4EventActionClearZeroEdep *evtact = dynamic_cast<PHG4EventActionClearZeroEdep *>(_eventAction);
-	evtact->AddNode(node);
+    BOOST_FOREACH (string node, nodes)
+    {
+      if (!_eventAction)
+        _eventAction = new PHG4EventActionClearZeroEdep(topNode, node);
+      else
+      {
+        PHG4EventActionClearZeroEdep* evtact = dynamic_cast<PHG4EventActionClearZeroEdep*>(_eventAction);
+        evtact->AddNode(node);
       }
     }
   }
@@ -114,34 +120,33 @@ int PHG4mRICHSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
 }
 
 //_______________________________________________________________________
-int PHG4mRICHSubsystem::process_event( PHCompositeNode* topNode )
+int PHG4mRICHSubsystem::process_event(PHCompositeNode* topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
-  if(_steppingAction)  _steppingAction->SetInterfacePointers( topNode );
+  if (_steppingAction) _steppingAction->SetInterfacePointers(topNode);
   return 0;
 }
 
-
 //_______________________________________________________________________
 PHG4Detector*
-PHG4mRICHSubsystem::GetDetector( void ) const
+PHG4mRICHSubsystem::GetDetector(void) const
 {
   return _detector;
 }
 //_______________________________________________________________________
 void PHG4mRICHSubsystem::SetDefaultParameters()
 {
-  set_default_int_param("detectorSetup", 1);   //1 for full setup
-                                               //0 for skeleton setup: detector box, aerogel, and sensor for quick check
+  set_default_int_param("detectorSetup", 1);  //1 for full setup
+                                              //0 for skeleton setup: detector box, aerogel, and sensor for quick check
 
   set_default_int_param("subsystemSetup", 0);  //-1: single module
                                                //0 : build hemispheric wall
                                                //>0: mRICH wall as sector. "subsystemSetup" becomes num. of sector (max is 8)
 
-  set_default_double_param("r_inner", 3);      //inner radius of mRICH wall, default=3m;
-  set_default_double_param("eta_min", 1.1);    //limits of rapidity
+  set_default_double_param("r_inner", 3);    //inner radius of mRICH wall, default=3m;
+  set_default_double_param("eta_min", 1.1);  //limits of rapidity
   set_default_double_param("eta_max", 1.9);
 
-  set_default_int_param("use_g4steps",0);        //for stepping function
+  set_default_int_param("use_g4steps", 0);  //for stepping function
 }

--- a/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.cc
+++ b/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.cc
@@ -13,35 +13,35 @@
 #include "PHG4RICHDisplayAction.h"
 #include "PHG4RICHSubsystem.h"
 
-#include <g4main/PHG4DisplayAction.h>            // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <Geant4/G4Cons.hh>
-#include <Geant4/G4DisplacedSolid.hh>            // for G4DisplacedSolid
+#include <Geant4/G4DisplacedSolid.hh>  // for G4DisplacedSolid
 #include <Geant4/G4IntersectionSolid.hh>
 #include <Geant4/G4LogicalSkinSurface.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
-#include <Geant4/G4MaterialPropertiesTable.hh>   // for G4MaterialProperties...
+#include <Geant4/G4MaterialPropertiesTable.hh>  // for G4MaterialProperties...
 #include <Geant4/G4OpticalSurface.hh>
 #include <Geant4/G4Orb.hh>
-#include <Geant4/G4PhysicalConstants.hh>         // for pi
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4PhysicalConstants.hh>  // for pi
 #include <Geant4/G4Sphere.hh>
-#include <Geant4/G4String.hh>                    // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/G4SurfaceProperty.hh>           // for dielectric_metal
-#include <Geant4/G4SystemOfUnits.hh>             // for cm, eV, um
-#include <Geant4/G4ThreeVector.hh>               // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>               // for G4RotateX3D, G4Rotat...
+#include <Geant4/G4SurfaceProperty.hh>  // for dielectric_metal
+#include <Geant4/G4SystemOfUnits.hh>    // for cm, eV, um
+#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>      // for G4RotateX3D, G4Rotat...
 #include <Geant4/G4Tubs.hh>
-#include <Geant4/G4VPhysicalVolume.hh>           // for G4VPhysicalVolume
-#include <Geant4/G4ios.hh>                       // for G4cout, G4endl
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
+#include <Geant4/G4ios.hh>              // for G4cout, G4endl
 
 #include <cassert>
 #include <cmath>
 #include <iostream>
 #include <sstream>
-#include <string>                                // for operator+, operator<<
+#include <string>  // for operator+, operator<<
 
 class G4VSolid;
 

--- a/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.cc
+++ b/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.cc
@@ -48,13 +48,13 @@ class G4VSolid;
 using namespace std;
 using namespace ePHENIXRICH;
 
-ePHENIXRICHConstruction::ePHENIXRICHConstruction(PHG4RICHSubsystem *subsys)
+ePHENIXRICHConstruction::ePHENIXRICHConstruction(PHG4Subsystem *subsys)
   : m_DisplayAction(dynamic_cast<PHG4RICHDisplayAction *>(subsys->GetDisplayAction()))
   , overlapcheck_rich(false)
 
 {
 }
-ePHENIXRICHConstruction::ePHENIXRICHConstruction(PHG4RICHSubsystem *subsys, const RICH_Geometry &g)
+ePHENIXRICHConstruction::ePHENIXRICHConstruction(PHG4Subsystem *subsys, const RICH_Geometry &g)
   : geom(g)
   , m_DisplayAction(dynamic_cast<PHG4RICHDisplayAction *>(subsys->GetDisplayAction()))
   , overlapcheck_rich(false)

--- a/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.h
+++ b/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.h
@@ -13,7 +13,7 @@
 #define G4DETECTORS_EPHENIXRICHCONSTRUCTION_H
 
 #include <Geant4/G4String.hh>
-#include <Geant4/G4Types.hh>            // for G4int
+#include <Geant4/G4Types.hh>  // for G4int
 
 #if !defined(__CINT__) || defined(__CLING__)
 #include <Geant4/G4SystemOfUnits.hh>
@@ -21,7 +21,7 @@
 
 #include <map>
 #include <set>
-#include <utility>                      // for pair
+#include <utility>  // for pair
 
 class G4VPhysicalVolume;
 class G4LogicalVolume;

--- a/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.h
+++ b/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.h
@@ -358,7 +358,7 @@ class RICH_Geometry
   G4OpticalSurface* RICH_Photocathode_OpticalSurface;
 };
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
 /**
    * \brief This class creates the ePHENIX RICH volumes for Geant4 based on the geometry
@@ -426,8 +426,8 @@ class ePHENIXRICHConstruction
   std::set<G4VPhysicalVolume*> sector_vec;
 };
 
-#endif
+#endif // #if !defined(__CINT__) || defined(__CLING__)
 
 }  //namespace ePHENIXRICH
 
-#endif /* EPHENIXRICHCONSTRUCTION_H_ */
+#endif // G4DETECTORS_EPHENIXRICHCONSTRUCTION_H

--- a/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.h
+++ b/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.h
@@ -28,7 +28,7 @@ class G4LogicalVolume;
 class G4OpticalSurface;
 class G4PVPlacement;
 class PHG4RICHDisplayAction;
-class PHG4RICHSubsystem;
+class PHG4Subsystem;
 
 namespace ePHENIXRICH
 {
@@ -375,8 +375,8 @@ class ePHENIXRICHConstruction
 {
  public:
   virtual ~ePHENIXRICHConstruction() {}
-  ePHENIXRICHConstruction(PHG4RICHSubsystem* subsys);
-  ePHENIXRICHConstruction(PHG4RICHSubsystem* subsys, const RICH_Geometry& g);
+  ePHENIXRICHConstruction(PHG4Subsystem* subsys);
+  ePHENIXRICHConstruction(PHG4Subsystem* subsys, const RICH_Geometry& g);
 
   virtual void
   OverlapCheck(bool check)

--- a/simulation/g4simulation/g4eval/JetRecoEval.cc
+++ b/simulation/g4simulation/g4eval/JetRecoEval.cc
@@ -3,6 +3,7 @@
 #include "JetTruthEval.h"
 #include "CaloEvalStack.h"
 #include "CaloRawClusterEval.h"
+#include "CaloRawTowerEval.h"                 // for CaloRawTowerEval
 #include "SvtxTrackEval.h"
 #include "SvtxEvalStack.h"
 

--- a/simulation/g4simulation/g4eval/JetRecoEval.h
+++ b/simulation/g4simulation/g4eval/JetRecoEval.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <utility>
 
+class CaloEvalStack;
+
 class JetMap;
 
 class PHCompositeNode;
@@ -21,6 +23,7 @@ class PHG4Shower;
 class RawClusterContainer;
 class RawTowerContainer;
 
+class SvtxEvalStack;
 class SvtxTrackMap;
 
 class JetRecoEval

--- a/simulation/g4simulation/g4eval/JetTruthEval.h
+++ b/simulation/g4simulation/g4eval/JetTruthEval.h
@@ -4,12 +4,11 @@
 #include "CaloEvalStack.h"
 #include "SvtxEvalStack.h"
 
-#include <g4jets/Jet.h>
-
 #include <map>
 #include <set>
 #include <string>
 
+class Jet;
 class JetMap;
 
 class PHCompositeNode;

--- a/simulation/g4simulation/g4eval/PHG4DSTReader.h
+++ b/simulation/g4simulation/g4eval/PHG4DSTReader.h
@@ -12,7 +12,7 @@
 
 #include <fun4all/SubsysReco.h>
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
 #include <boost/smart_ptr.hpp>
 
@@ -122,7 +122,7 @@ class PHG4DSTReader : public SubsysReco
   //  std::vector<std::string> _node_name;
   int nblocks;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
   typedef boost::shared_ptr<TClonesArray> arr_ptr;
 
@@ -173,7 +173,7 @@ class PHG4DSTReader : public SubsysReco
   //! zero suppression for all calorimeters
   double _tower_zero_sup;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
   //! add a particle and associated vertex if _save_vertex
   void

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <cfloat>
 #include <cmath>
+#include <iostream>                          // for operator<<, basic_ostream
 #include <map>
 #include <set>
 
@@ -27,7 +28,6 @@ using namespace std;
 SvtxClusterEval::SvtxClusterEval(PHCompositeNode* topNode)
   : _hiteval(topNode)
   , _clustermap(nullptr)
-    //  , _hitmap(nullptr)
   , _truthinfo(nullptr)
   , _strict(false)
   , _verbosity(1)

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -107,7 +107,7 @@ class SvtxClusterEval
   std::map<std::pair<TrkrDefs::cluskey, PHG4Particle*>, float> _cache_get_energy_contribution_g4particle;
   std::map<std::pair<TrkrDefs::cluskey, PHG4Hit*>, float> _cache_get_energy_contribution_g4hit;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   //! cluster azimuthal searching window in _clusters_per_layer. Unit: rad
   static constexpr float _clusters_searching_window = 0.1f;
   std::multimap<unsigned int, innerMap> _clusters_per_layer;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -341,7 +341,7 @@ void SvtxEvaluator::printInputInfo(PHCompositeNode* topNode)
     }
 
     cout << "---SVXVERTEXES-------------" << endl;
-    SvtxVertexMap* vertexmap = NULL;
+    SvtxVertexMap* vertexmap = nullptr;
     if(_use_initial_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
     else
@@ -395,7 +395,7 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode* topNode)
     float vy = NAN;
     float vz = NAN;
 
-    SvtxVertexMap* vertexmap = NULL;
+    SvtxVertexMap* vertexmap = nullptr;
     if(_use_initial_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
     else
@@ -766,7 +766,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       _timer->restart();
     }
 
-    SvtxVertexMap* vertexmap = NULL;
+    SvtxVertexMap* vertexmap = nullptr;
     if(_use_initial_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
     else

--- a/simulation/g4simulation/g4eval/SvtxHitEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.cc
@@ -18,8 +18,11 @@
 #include <cassert>
 #include <cfloat>
 #include <cmath>
+#include <iostream>                          // for operator<<, endl, basic_...
 #include <map>
 #include <set>
+
+class TrkrHit;
 
 using namespace std;
 

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -5,6 +5,8 @@
 
 #include <g4main/PHG4Hit.h>
 
+#include <trackbase/TrkrDefs.h>               // for cluskey, getLayer
+
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 

--- a/simulation/g4simulation/g4intt/PHG4InttDefs.h
+++ b/simulation/g4simulation/g4intt/PHG4InttDefs.h
@@ -14,7 +14,7 @@ static const int SUPPORTPARAMS = -3;
 // this set only exists so we can iterate over the enum
 // yes it can be made more fancy but this will do
 // and yes stupid CINT does not understand C++11
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 static std::set<int> m_SensorSegmentationSet{SEGMENTATION_Z, SEGMENTATION_PHI};
 #endif
 // passive volume indices

--- a/simulation/g4simulation/g4intt/PHG4InttDetector.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttDetector.cc
@@ -56,8 +56,8 @@ class G4VSolid;
 
 using namespace std;
 
-PHG4InttDetector::PHG4InttDetector(PHG4InttSubsystem* subsys, PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const pair<vector<pair<int, int>>::const_iterator, vector<pair<int, int>>::const_iterator> &layer_b_e)
-  : PHG4Detector(Node, dnam)
+PHG4InttDetector::PHG4InttDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const pair<vector<pair<int, int>>::const_iterator, vector<pair<int, int>>::const_iterator> &layer_b_e)
+  : PHG4Detector(subsys, Node, dnam)
   , m_DisplayAction(dynamic_cast<PHG4InttDisplayAction*>(subsys->GetDisplayAction()))
   , m_ParamsContainer(parameters)
   , m_IsSupportActive(0)
@@ -101,7 +101,7 @@ int PHG4InttDetector::IsInIntt(G4VPhysicalVolume *volume) const
   return 0;
 }
 
-void PHG4InttDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4InttDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   if (Verbosity() > 0)
   {

--- a/simulation/g4simulation/g4intt/PHG4InttDetector.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttDetector.cc
@@ -1,6 +1,6 @@
 #include "PHG4InttDetector.h"
 
-#include "PHG4InttDefs.h"                           // for SEGMENTATION_Z
+#include "PHG4InttDefs.h"  // for SEGMENTATION_Z
 #include "PHG4InttDisplayAction.h"
 #include "PHG4InttFPHXParameterisation.h"
 #include "PHG4InttSubsystem.h"
@@ -12,16 +12,16 @@
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
 
-#include <g4main/PHG4Detector.h>                    // for PHG4Detector
-#include <g4main/PHG4DisplayAction.h>               // for PHG4DisplayAction
+#include <g4main/PHG4Detector.h>       // for PHG4Detector
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                           // for PHNode
-#include <phool/PHNodeIterator.h>                   // for PHNodeIterator
-#include <phool/PHObject.h>                         // for PHObject
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>                            // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <TSystem.h>
 
@@ -31,34 +31,34 @@
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVParameterised.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>               // for G4RotationMatrix
-#include <Geant4/G4String.hh>                       // for G4String
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>                  // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>                  // for G4Transform3D
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D
 #include <Geant4/G4Tubs.hh>
-#include <Geant4/G4TwoVector.hh>                    // for G4TwoVector
-#include <Geant4/G4VPhysicalVolume.hh>              // for G4VPhysicalVolume
-#include <Geant4/geomdefs.hh>                       // for kZAxis
+#include <Geant4/G4TwoVector.hh>        // for G4TwoVector
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
+#include <Geant4/geomdefs.hh>           // for kZAxis
 
 #include <boost/format.hpp>
 
-#include <algorithm>                                // for fill_n
+#include <algorithm>  // for fill_n
 #include <array>
-#include <cassert>                                 // for assert
+#include <cassert>  // for assert
 #include <cmath>
-#include <cstdlib>                                 // for exit, NULL
-#include <iostream>                                 // for operator<<, basic...
+#include <cstdlib>   // for exit, NULL
+#include <iostream>  // for operator<<, basic...
 
 class G4VPVParameterisation;
 class G4VSolid;
 
 using namespace std;
 
-PHG4InttDetector::PHG4InttDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const pair<vector<pair<int, int>>::const_iterator, vector<pair<int, int>>::const_iterator> &layer_b_e)
+PHG4InttDetector::PHG4InttDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const pair<vector<pair<int, int>>::const_iterator, vector<pair<int, int>>::const_iterator> &layer_b_e)
   : PHG4Detector(subsys, Node, dnam)
-  , m_DisplayAction(dynamic_cast<PHG4InttDisplayAction*>(subsys->GetDisplayAction()))
+  , m_DisplayAction(dynamic_cast<PHG4InttDisplayAction *>(subsys->GetDisplayAction()))
   , m_ParamsContainer(parameters)
   , m_IsSupportActive(0)
   , m_IsEndcapActive(0)
@@ -202,7 +202,7 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
       {
         m_ActiveLogVols.insert(siactive_volume);
       }
-      m_DisplayAction->AddVolume(siactive_volume,"SiActive");
+      m_DisplayAction->AddVolume(siactive_volume, "SiActive");
       // We do not subdivide the sensor in G4. We will assign hits to strips in the stepping action, using the geometry object
 
       // Si-sensor full (active+inactive) area
@@ -221,7 +221,7 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
       {
         m_PassiveVolumeTuple.insert(make_pair(siinactive_volume, make_tuple(inttlayer, PHG4InttDefs::SI_INACTIVE)));
       }
-      m_DisplayAction->AddVolume(siinactive_volume,"SiInActive");
+      m_DisplayAction->AddVolume(siinactive_volume, "SiInActive");
       // Make the HDI Kapton and copper volumes
 
       // This makes HDI volumes that matche this sensor in Z length
@@ -261,8 +261,8 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
       {
         m_PassiveVolumeTuple.insert(make_pair(hdiext_copper_volume, make_tuple(inttlayer, PHG4InttDefs::HDIEXT_COPPER)));
       }
-      m_DisplayAction->AddVolume(hdiext_kapton_volume,"HdiKapton");
-      m_DisplayAction->AddVolume(hdiext_copper_volume,"HdiCopper");
+      m_DisplayAction->AddVolume(hdiext_kapton_volume, "HdiKapton");
+      m_DisplayAction->AddVolume(hdiext_copper_volume, "HdiCopper");
 
       // FPHX
       G4VSolid *fphx_box = new G4Box((boost::format("fphx_box_%d_%d") % inttlayer % itype).str(), fphx_x / 2., fphx_y / 2., fphx_z / 2.);
@@ -272,7 +272,7 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
       {
         m_PassiveVolumeTuple.insert(make_pair(fphx_volume, make_tuple(inttlayer, PHG4InttDefs::FPHX)));
       }
-      m_DisplayAction->AddVolume(fphx_volume,"FPHX");
+      m_DisplayAction->AddVolume(fphx_volume, "FPHX");
 
       const double gap_sensor_fphx = params->get_double_param("gap_sensor_fphx") * cm;
 
@@ -332,819 +332,814 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
       {
         m_PassiveVolumeTuple.insert(make_pair(pgsext_volume, make_tuple(inttlayer, PHG4InttDefs::PGSEXT)));
       }
-      m_DisplayAction->AddVolume(pgs_volume,"PGS");
-      m_DisplayAction->AddVolume(pgsext_volume,"PGS");
+      m_DisplayAction->AddVolume(pgs_volume, "PGS");
+      m_DisplayAction->AddVolume(pgsext_volume, "PGS");
       double stave_x = 0.;  // we do not include the PGS in the stave volume
       double stave_y = 0.;
       G4LogicalVolume *stave_volume = NULL;
       G4LogicalVolume *staveext_volume = NULL;
 
-      if(params->get_int_param("carbon_stave_type")==0)  // carbon stave without water cooling
+      if (params->get_int_param("carbon_stave_type") == 0)  // carbon stave without water cooling
       {
-      // Carbon stave. This is the formed sheet that sits on the PGS and completes the cooling tube
-      // Formed from straight sections and sections of a tube of radius 2.3 mm. All have wall thickness of 0.3 mm.
-      // These are different for laddertype PHG4InttDefs::SEGMENTATION_Z  and
-      // PHG4InttDefs::SEGMENTATION_PHI, but they use some common elements.
+        // Carbon stave. This is the formed sheet that sits on the PGS and completes the cooling tube
+        // Formed from straight sections and sections of a tube of radius 2.3 mm. All have wall thickness of 0.3 mm.
+        // These are different for laddertype PHG4InttDefs::SEGMENTATION_Z  and
+        // PHG4InttDefs::SEGMENTATION_PHI, but they use some common elements.
 
-      // The curved section is made from a G4Tubs, which is a generalized section of a cylinder
-      // Two curved sections combined should move the inner wall to be 2.0 mm away from the PGS, then 2 more sections bring it back
-      // For 1 of these tube sections,starting at 90 degrees, take decrease in y=1 mm at avge R.
-      // If avge R = 2.15 mm, dtheta = invcos( (R - y)/R ) = invcos(1.15/2.15) = 53.49 deg
-      // The extent along the x axis is then R*sin(dtheta) = 1.728 mm, so two sections combined have dx = 3.456 mm length in y
-      double stave_straight_outer_y = params->get_double_param("stave_straight_outer_y") * cm;
-      double stave_straight_inner_y = params->get_double_param("stave_straight_inner_y") * cm;
-      double stave_straight_cooler_y = params->get_double_param("stave_straight_cooler_y") * cm;
-      const double Rcmin = 0.20 * cm;  // mm inner radius of curved section, same at both ends
-      const double Rcmax = 0.23 * cm;  // mm outer radius of curved section, same at both ends
-      double Rcavge = (Rcmax + Rcmin) / 2.0;
-      double dphi_c = acos((Rcavge - Rcmin / 2.) / Rcavge);
-      const double stave_z = pgs_z;
+        // The curved section is made from a G4Tubs, which is a generalized section of a cylinder
+        // Two curved sections combined should move the inner wall to be 2.0 mm away from the PGS, then 2 more sections bring it back
+        // For 1 of these tube sections,starting at 90 degrees, take decrease in y=1 mm at avge R.
+        // If avge R = 2.15 mm, dtheta = invcos( (R - y)/R ) = invcos(1.15/2.15) = 53.49 deg
+        // The extent along the x axis is then R*sin(dtheta) = 1.728 mm, so two sections combined have dx = 3.456 mm length in y
+        double stave_straight_outer_y = params->get_double_param("stave_straight_outer_y") * cm;
+        double stave_straight_inner_y = params->get_double_param("stave_straight_inner_y") * cm;
+        double stave_straight_cooler_y = params->get_double_param("stave_straight_cooler_y") * cm;
+        const double Rcmin = 0.20 * cm;  // mm inner radius of curved section, same at both ends
+        const double Rcmax = 0.23 * cm;  // mm outer radius of curved section, same at both ends
+        double Rcavge = (Rcmax + Rcmin) / 2.0;
+        double dphi_c = acos((Rcavge - Rcmin / 2.) / Rcavge);
+        const double stave_z = pgs_z;
 
-      // makecurved sections for cooler tube
-      const double phic_begin[4] = {M_PI - dphi_c, -dphi_c, 0.0, M_PI};
-      const double dphic[4] = {dphi_c, dphi_c, dphi_c, dphi_c};
+        // makecurved sections for cooler tube
+        const double phic_begin[4] = {M_PI - dphi_c, -dphi_c, 0.0, M_PI};
+        const double dphic[4] = {dphi_c, dphi_c, dphi_c, dphi_c};
 
-      G4Tubs *stave_curve_cons[4];
-      G4Tubs *stave_curve_ext_cons[4];
-      G4LogicalVolume *stave_curve_volume[4];
-      G4LogicalVolume *stave_curve_ext_volume[4];
-
-      for (int i = 0; i < 4; i++)
-      {
-        stave_curve_cons[i] = new G4Tubs((boost::format("stave_curve_cons_%d_%d_%d") % inttlayer % itype % i).str(),
-                                         Rcmin, Rcmax, stave_z / 2., phic_begin[i], dphic[i]);
-        stave_curve_volume[i] = new G4LogicalVolume(stave_curve_cons[i], G4Material::GetMaterial("CFRP_INTT"),
-                                                    (boost::format("stave_curve_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
-        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-        {
-          m_PassiveVolumeTuple.insert(make_pair(stave_curve_volume[i], make_tuple(inttlayer, PHG4InttDefs::STAVE_CURVE)));
-        }
-        stave_curve_ext_cons[i] = new G4Tubs((boost::format("stave_curve_ext_cons_%d_%d_%d") % inttlayer % itype % i).str(),
-                                             Rcmin, Rcmax, hdiext_z / 2., phic_begin[i], dphic[i]);
-        stave_curve_ext_volume[i] = new G4LogicalVolume(stave_curve_ext_cons[i], G4Material::GetMaterial("CFRP_INTT"),
-                                                        (boost::format("stave_curve_ext_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
-        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-        {
-          m_PassiveVolumeTuple.insert(make_pair(stave_curve_ext_volume[i], make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_CURVE)));
-        }
-        m_DisplayAction->AddVolume(stave_curve_volume[i],"StaveCurve");
-        m_DisplayAction->AddVolume(stave_curve_ext_volume[i],"StaveCurve");
-      }
-
-      // we will need the length in y of the curved section as it is installed in the stave box
-      double curve_length_y = Rcavge * sin(dphi_c);
-
-      // Make several straight sections for use in making the stave
-
-      // Outer straight sections of stave
-      double stave_wall_thickness = 0.03 * cm;
-      G4VSolid *stave_straight_outer_box = new G4Box((boost::format("stave_straight_outer_box_%d_%d") % inttlayer % itype).str(),
-                                                     stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
-      G4LogicalVolume *stave_straight_outer_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                         (boost::format("stave_straight_outer_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_straight_outer_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_OUTER)));
-      }
-      G4VSolid *stave_straight_outer_ext_box = new G4Box((boost::format("stave_straight_outer_ext_box_%d_%s") % inttlayer % itype).str(),
-                                                         stave_wall_thickness / 2., stave_straight_outer_y / 2., hdiext_z / 2.);
-      G4LogicalVolume *stave_straight_outer_ext_volume = new G4LogicalVolume(stave_straight_outer_ext_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                             (boost::format("stave_straight_outer_ext_volume_%d_%s") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_straight_outer_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_OUTER)));
-      }
-      // connects cooling tubes together, only needed for laddertype PHG4InttDefs::SEGMENTATION_PHI, for laddertype PHG4InttDefs::SEGMENTATION_Z we just make a dummy
-      G4VSolid *stave_straight_inner_box = new G4Box((boost::format("stave_straight_inner_box_%d_%d") % inttlayer % itype).str(),
-                                                     stave_wall_thickness / 2., stave_straight_inner_y / 2., stave_z / 2.);
-      G4LogicalVolume *stave_straight_inner_volume = new G4LogicalVolume(stave_straight_inner_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                         (boost::format("stave_straight_inner_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_straight_inner_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_INNER)));
-      }
-      G4VSolid *stave_straight_inner_ext_box = new G4Box((boost::format("stave_straight_inner_ext_box_%d_%d") % inttlayer % itype).str(),
-                                                         stave_wall_thickness / 2., stave_straight_inner_y / 2., hdiext_z / 2.);
-      G4LogicalVolume *stave_straight_inner_ext_volume = new G4LogicalVolume(stave_straight_inner_ext_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                             (boost::format("stave_straight_inner_ext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_straight_inner_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_INNER)));
-      }
-
-      //Top surface of cooler tube
-      G4VSolid *stave_straight_cooler_box = new G4Box((boost::format("stave_straight_cooler_box_%d_%d") % inttlayer % itype).str(),
-                                                      stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
-      G4LogicalVolume *stave_straight_cooler_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                          (boost::format("stave_straight_cooler_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_straight_cooler_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_COOLER)));
-      }
-      G4VSolid *stave_straight_cooler_ext_box = new G4Box((boost::format("stave_straight_cooler_ext_box_%d_%d") % inttlayer % itype).str(),
-                                                          stave_wall_thickness / 2., stave_straight_cooler_y / 2., hdiext_z / 2.);
-      G4LogicalVolume *stave_straight_cooler_ext_volume = new G4LogicalVolume(stave_straight_cooler_ext_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                              (boost::format("stave_straight_cooler_ext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_straight_cooler_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_COOLER)));
-      }
-
-      m_DisplayAction->AddVolume(stave_straight_cooler_volume, "StaveCooler");
-      m_DisplayAction->AddVolume(stave_straight_cooler_ext_volume, "StaveCooler");
-      if (laddertype == PHG4InttDefs::SEGMENTATION_PHI)
-      {
-	m_DisplayAction->AddVolume(stave_straight_inner_volume,"StaveStraightInner");
-	m_DisplayAction->AddVolume(stave_straight_inner_ext_volume,"StaveStraightInner");
-      }
-	m_DisplayAction->AddVolume(stave_straight_outer_volume,"StaveStraightOuter");
-	m_DisplayAction->AddVolume(stave_straight_outer_ext_volume,"StaveStraightOuter");
-
-      // Now we combine the elements of a stave defined above into a stave
-      // Create a stave volume to install the stave sections into. The volume has to be big enouigh to contain the cooling tube
-      double cooler_gap_x = 0.2 * cm;  // id of cooling tube in cm
-      double cooler_wall = 0.03 * cm;  // outer wall thickness of cooling tube
-      double cooler_x = cooler_gap_x + cooler_wall;
-      stave_x = cooler_x;  // we do not include the PGS in the stave volume
-      stave_y = hdi_y; 
-
-      // Make stave volume. Drop two corners in positive x to prevent ladder_volume overlapping
-      // with neighbouring ladders because of small clearance in the latest configuration
-      G4RotationMatrix* stv_rot_pos = new G4RotationMatrix();
-      stv_rot_pos->rotateZ(-15. * M_PI / 180.);
-      G4ThreeVector stvTranspos(stave_x / 2., stave_y /2., 0.);
-
-      G4RotationMatrix* stv_rot_neg = new G4RotationMatrix();
-      stv_rot_neg->rotateZ(+15. * M_PI / 180.);
-      G4ThreeVector stvTransneg(stave_x / 2., -stave_y /2., 0.);
-
-      G4VSolid* stave_basebox = new G4Box((boost::format("stave_basebox_%d_%d") % inttlayer % itype).str(), stave_x / 2., stave_y / 2., stave_z / 2.);
-      G4VSolid* stave_subtbox = new G4Box((boost::format("stave_subtbox_%d_%d") % inttlayer % itype ).str(),stave_x / 1.5, stave_y / 1.5, stave_z / 1.); // has to be longer in z to avoid coincident surface
-
-      G4VSolid *stave_box1 = new G4SubtractionSolid((boost::format("stave_box1_%d_%d") % inttlayer % itype).str(), stave_basebox, stave_subtbox, stv_rot_pos, stvTranspos);
-
-      G4VSolid *stave_box = new G4SubtractionSolid((boost::format("stave_box_%d_%d") % inttlayer % itype).str(), stave_box1, stave_subtbox, stv_rot_neg, stvTransneg);
-
-      stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_AIR"),
-                                        (boost::format("stave_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-
-      G4VSolid* staveext_basebox = new G4Box((boost::format("staveext_basebox_%d_%d") % inttlayer % itype).str(), stave_x / 2., stave_y / 2., hdiext_z / 2.);
-      G4VSolid* staveext_subtbox = new G4Box((boost::format("staveext_subtbox_%d_%d") % inttlayer % itype ).str(),stave_x / 1.5, stave_y / 1.5, hdiext_z / 1.); // has to be longer in z to avoid coincident surface
-
-      G4VSolid *staveext_box1 = new G4SubtractionSolid((boost::format("staveext_box1_%d_%d") % inttlayer % itype).str(), staveext_basebox, staveext_subtbox, stv_rot_pos, stvTranspos);
-
-      G4VSolid *staveext_box = new G4SubtractionSolid((boost::format("staveext_box_%d_%d") % inttlayer % itype).str(), staveext_box1, staveext_subtbox, stv_rot_neg, stvTransneg);
-
-      staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"),
-                                           (boost::format("staveext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-
-      m_DisplayAction->AddVolume(stave_volume,"StaveBox");
-      m_DisplayAction->AddVolume(staveext_volume,"StaveBox");
-      // Assemble the elements into the stave volume and the stave extension volume
-      // They are place relative to the center of the stave box. Thus the offset of the center of the segment is relative to the center of the satev box.
-      // But we want the segment to be located relative to the lowest x limit of the stave box.
-      if (laddertype == PHG4InttDefs::SEGMENTATION_Z)
-      {
-        // only one cooling tube in laddertype 0
-        // Place the straight sections. We add the middle, then above x axis, then below x axis
-        double x_off_str[3] =
-            {
-                Rcavge - stave_x / 2.,
-                (Rcmax - Rcmin) / 2. - stave_x / 2.,
-                (Rcmax - Rcmin) / 2. - stave_x / 2.};
-        double y_off_str[3] =
-            {
-                0.0,
-                stave_straight_cooler_y / 2. + 2.0 * curve_length_y + stave_straight_outer_y / 2.0,
-                -stave_straight_cooler_y / 2. - 2.0 * curve_length_y - stave_straight_outer_y / 2.0};
-
-        for (int i = 0; i < 3; i++)
-        {
-          if (i == 0)
-          {
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume,
-                              (boost::format("stave_straight_cooler_%d_%d_%d") % i % inttlayer % itype).str(), stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume,
-                              (boost::format("stave_straight_cooler_ext_%d_%d_%d") % i % inttlayer % itype).str(), staveext_volume, false, 0, OverlapCheck());
-          }
-          else
-          {
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume,
-                              (boost::format("stave_straight_outer_%d_%d_%d") % i % inttlayer % itype).str(), stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume,
-                              (boost::format("stave_straight_outer_ext_%d_%d_%d") % i % inttlayer % itype).str(), staveext_volume, false, 0, OverlapCheck());
-          }
-        }
-        // The cooler curved sections are made using 2 curved sections in a recurve on each side of the cooler straight section
-        // The tube sections used here have the origin of their volume at their center of rotation. Rcavge
-        //      Each curve section is moved to the center of the stave volume by a translation of +/- Rcavge
-        //      Then it is moved to the outside or the inside of the stave volume by a translation of +/-  cooler_gap_x / 2.
-        // we start at lowest y and work up in y
-
-        double x_off_cooler[4] =
-            {
-                Rcavge - cooler_gap_x / 2.,
-                -Rcavge + cooler_gap_x / 2.,
-                -Rcavge + cooler_gap_x / 2.,
-                Rcavge - cooler_gap_x / 2.};
-        double y_off_cooler[4] =
-            {
-                -stave_straight_cooler_y / 2. - 2. * curve_length_y,
-                -stave_straight_cooler_y / 2.,
-                stave_straight_cooler_y / 2.,
-                stave_straight_cooler_y / 2. + 2. * curve_length_y};
+        G4Tubs *stave_curve_cons[4];
+        G4Tubs *stave_curve_ext_cons[4];
+        G4LogicalVolume *stave_curve_volume[4];
+        G4LogicalVolume *stave_curve_ext_volume[4];
 
         for (int i = 0; i < 4; i++)
         {
-          new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_volume[i],
-                            (boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
-          new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_ext_volume[i],
-                            (boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+          stave_curve_cons[i] = new G4Tubs((boost::format("stave_curve_cons_%d_%d_%d") % inttlayer % itype % i).str(),
+                                           Rcmin, Rcmax, stave_z / 2., phic_begin[i], dphic[i]);
+          stave_curve_volume[i] = new G4LogicalVolume(stave_curve_cons[i], G4Material::GetMaterial("CFRP_INTT"),
+                                                      (boost::format("stave_curve_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
+          if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+          {
+            m_PassiveVolumeTuple.insert(make_pair(stave_curve_volume[i], make_tuple(inttlayer, PHG4InttDefs::STAVE_CURVE)));
+          }
+          stave_curve_ext_cons[i] = new G4Tubs((boost::format("stave_curve_ext_cons_%d_%d_%d") % inttlayer % itype % i).str(),
+                                               Rcmin, Rcmax, hdiext_z / 2., phic_begin[i], dphic[i]);
+          stave_curve_ext_volume[i] = new G4LogicalVolume(stave_curve_ext_cons[i], G4Material::GetMaterial("CFRP_INTT"),
+                                                          (boost::format("stave_curve_ext_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
+          if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+          {
+            m_PassiveVolumeTuple.insert(make_pair(stave_curve_ext_volume[i], make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_CURVE)));
+          }
+          m_DisplayAction->AddVolume(stave_curve_volume[i], "StaveCurve");
+          m_DisplayAction->AddVolume(stave_curve_ext_volume[i], "StaveCurve");
         }
-      }
-      else if (laddertype == PHG4InttDefs::SEGMENTATION_PHI)  // The type PHG4InttDefs::SEGMENTATION_PHI ladder has two cooling tubes
-      {
-        // First place the straight sections, do the extension at the same time
-        // we alternate  positive and negative y values here
-        double x_off_str[5] =
-            {
-                (Rcmax - Rcmin) / 2. - stave_x / 2.,  // against the PGS
-                (Rcmax + Rcmin) / 2. - stave_x / 2.,  // top of cooler
-                (Rcmax + Rcmin) / 2. - stave_x / 2.,  // top of cooler
-                (Rcmax - Rcmin) / 2. - stave_x / 2.,
-                (Rcmax - Rcmin) / 2 - stave_x / 2.};
-        double y_off_str[5] =
-            {
-                0.0,                                                                                // center section against PGS
-                stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y / 2.,   // top of cooler
-                -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y / 2.,  // top of cooler
-                stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y + 2. * curve_length_y + stave_straight_outer_y / 2.,
-                -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y - 2. * curve_length_y - stave_straight_outer_y / 2.,
-            };
 
-        for (int i = 0; i < 5; i++)
+        // we will need the length in y of the curved section as it is installed in the stave box
+        double curve_length_y = Rcavge * sin(dphi_c);
+
+        // Make several straight sections for use in making the stave
+
+        // Outer straight sections of stave
+        double stave_wall_thickness = 0.03 * cm;
+        G4VSolid *stave_straight_outer_box = new G4Box((boost::format("stave_straight_outer_box_%d_%d") % inttlayer % itype).str(),
+                                                       stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
+        G4LogicalVolume *stave_straight_outer_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                           (boost::format("stave_straight_outer_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
         {
+          m_PassiveVolumeTuple.insert(make_pair(stave_straight_outer_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_OUTER)));
+        }
+        G4VSolid *stave_straight_outer_ext_box = new G4Box((boost::format("stave_straight_outer_ext_box_%d_%s") % inttlayer % itype).str(),
+                                                           stave_wall_thickness / 2., stave_straight_outer_y / 2., hdiext_z / 2.);
+        G4LogicalVolume *stave_straight_outer_ext_volume = new G4LogicalVolume(stave_straight_outer_ext_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                               (boost::format("stave_straight_outer_ext_volume_%d_%s") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+        {
+          m_PassiveVolumeTuple.insert(make_pair(stave_straight_outer_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_OUTER)));
+        }
+        // connects cooling tubes together, only needed for laddertype PHG4InttDefs::SEGMENTATION_PHI, for laddertype PHG4InttDefs::SEGMENTATION_Z we just make a dummy
+        G4VSolid *stave_straight_inner_box = new G4Box((boost::format("stave_straight_inner_box_%d_%d") % inttlayer % itype).str(),
+                                                       stave_wall_thickness / 2., stave_straight_inner_y / 2., stave_z / 2.);
+        G4LogicalVolume *stave_straight_inner_volume = new G4LogicalVolume(stave_straight_inner_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                           (boost::format("stave_straight_inner_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+        {
+          m_PassiveVolumeTuple.insert(make_pair(stave_straight_inner_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_INNER)));
+        }
+        G4VSolid *stave_straight_inner_ext_box = new G4Box((boost::format("stave_straight_inner_ext_box_%d_%d") % inttlayer % itype).str(),
+                                                           stave_wall_thickness / 2., stave_straight_inner_y / 2., hdiext_z / 2.);
+        G4LogicalVolume *stave_straight_inner_ext_volume = new G4LogicalVolume(stave_straight_inner_ext_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                               (boost::format("stave_straight_inner_ext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+        {
+          m_PassiveVolumeTuple.insert(make_pair(stave_straight_inner_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_INNER)));
+        }
+
+        //Top surface of cooler tube
+        G4VSolid *stave_straight_cooler_box = new G4Box((boost::format("stave_straight_cooler_box_%d_%d") % inttlayer % itype).str(),
+                                                        stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
+        G4LogicalVolume *stave_straight_cooler_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                            (boost::format("stave_straight_cooler_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+        {
+          m_PassiveVolumeTuple.insert(make_pair(stave_straight_cooler_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_COOLER)));
+        }
+        G4VSolid *stave_straight_cooler_ext_box = new G4Box((boost::format("stave_straight_cooler_ext_box_%d_%d") % inttlayer % itype).str(),
+                                                            stave_wall_thickness / 2., stave_straight_cooler_y / 2., hdiext_z / 2.);
+        G4LogicalVolume *stave_straight_cooler_ext_volume = new G4LogicalVolume(stave_straight_cooler_ext_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                                (boost::format("stave_straight_cooler_ext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+        {
+          m_PassiveVolumeTuple.insert(make_pair(stave_straight_cooler_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_COOLER)));
+        }
+
+        m_DisplayAction->AddVolume(stave_straight_cooler_volume, "StaveCooler");
+        m_DisplayAction->AddVolume(stave_straight_cooler_ext_volume, "StaveCooler");
+        if (laddertype == PHG4InttDefs::SEGMENTATION_PHI)
+        {
+          m_DisplayAction->AddVolume(stave_straight_inner_volume, "StaveStraightInner");
+          m_DisplayAction->AddVolume(stave_straight_inner_ext_volume, "StaveStraightInner");
+        }
+        m_DisplayAction->AddVolume(stave_straight_outer_volume, "StaveStraightOuter");
+        m_DisplayAction->AddVolume(stave_straight_outer_ext_volume, "StaveStraightOuter");
+
+        // Now we combine the elements of a stave defined above into a stave
+        // Create a stave volume to install the stave sections into. The volume has to be big enouigh to contain the cooling tube
+        double cooler_gap_x = 0.2 * cm;  // id of cooling tube in cm
+        double cooler_wall = 0.03 * cm;  // outer wall thickness of cooling tube
+        double cooler_x = cooler_gap_x + cooler_wall;
+        stave_x = cooler_x;  // we do not include the PGS in the stave volume
+        stave_y = hdi_y;
+
+        // Make stave volume. Drop two corners in positive x to prevent ladder_volume overlapping
+        // with neighbouring ladders because of small clearance in the latest configuration
+        G4RotationMatrix *stv_rot_pos = new G4RotationMatrix();
+        stv_rot_pos->rotateZ(-15. * M_PI / 180.);
+        G4ThreeVector stvTranspos(stave_x / 2., stave_y / 2., 0.);
+
+        G4RotationMatrix *stv_rot_neg = new G4RotationMatrix();
+        stv_rot_neg->rotateZ(+15. * M_PI / 180.);
+        G4ThreeVector stvTransneg(stave_x / 2., -stave_y / 2., 0.);
+
+        G4VSolid *stave_basebox = new G4Box((boost::format("stave_basebox_%d_%d") % inttlayer % itype).str(), stave_x / 2., stave_y / 2., stave_z / 2.);
+        G4VSolid *stave_subtbox = new G4Box((boost::format("stave_subtbox_%d_%d") % inttlayer % itype).str(), stave_x / 1.5, stave_y / 1.5, stave_z / 1.);  // has to be longer in z to avoid coincident surface
+
+        G4VSolid *stave_box1 = new G4SubtractionSolid((boost::format("stave_box1_%d_%d") % inttlayer % itype).str(), stave_basebox, stave_subtbox, stv_rot_pos, stvTranspos);
+
+        G4VSolid *stave_box = new G4SubtractionSolid((boost::format("stave_box_%d_%d") % inttlayer % itype).str(), stave_box1, stave_subtbox, stv_rot_neg, stvTransneg);
+
+        stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_AIR"),
+                                           (boost::format("stave_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+
+        G4VSolid *staveext_basebox = new G4Box((boost::format("staveext_basebox_%d_%d") % inttlayer % itype).str(), stave_x / 2., stave_y / 2., hdiext_z / 2.);
+        G4VSolid *staveext_subtbox = new G4Box((boost::format("staveext_subtbox_%d_%d") % inttlayer % itype).str(), stave_x / 1.5, stave_y / 1.5, hdiext_z / 1.);  // has to be longer in z to avoid coincident surface
+
+        G4VSolid *staveext_box1 = new G4SubtractionSolid((boost::format("staveext_box1_%d_%d") % inttlayer % itype).str(), staveext_basebox, staveext_subtbox, stv_rot_pos, stvTranspos);
+
+        G4VSolid *staveext_box = new G4SubtractionSolid((boost::format("staveext_box_%d_%d") % inttlayer % itype).str(), staveext_box1, staveext_subtbox, stv_rot_neg, stvTransneg);
+
+        staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"),
+                                              (boost::format("staveext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+
+        m_DisplayAction->AddVolume(stave_volume, "StaveBox");
+        m_DisplayAction->AddVolume(staveext_volume, "StaveBox");
+        // Assemble the elements into the stave volume and the stave extension volume
+        // They are place relative to the center of the stave box. Thus the offset of the center of the segment is relative to the center of the satev box.
+        // But we want the segment to be located relative to the lowest x limit of the stave box.
+        if (laddertype == PHG4InttDefs::SEGMENTATION_Z)
+        {
+          // only one cooling tube in laddertype 0
+          // Place the straight sections. We add the middle, then above x axis, then below x axis
+          double x_off_str[3] =
+              {
+                  Rcavge - stave_x / 2.,
+                  (Rcmax - Rcmin) / 2. - stave_x / 2.,
+                  (Rcmax - Rcmin) / 2. - stave_x / 2.};
+          double y_off_str[3] =
+              {
+                  0.0,
+                  stave_straight_cooler_y / 2. + 2.0 * curve_length_y + stave_straight_outer_y / 2.0,
+                  -stave_straight_cooler_y / 2. - 2.0 * curve_length_y - stave_straight_outer_y / 2.0};
+
+          for (int i = 0; i < 3; i++)
+          {
+            if (i == 0)
+            {
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume,
+                                (boost::format("stave_straight_cooler_%d_%d_%d") % i % inttlayer % itype).str(), stave_volume, false, 0, OverlapCheck());
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume,
+                                (boost::format("stave_straight_cooler_ext_%d_%d_%d") % i % inttlayer % itype).str(), staveext_volume, false, 0, OverlapCheck());
+            }
+            else
+            {
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume,
+                                (boost::format("stave_straight_outer_%d_%d_%d") % i % inttlayer % itype).str(), stave_volume, false, 0, OverlapCheck());
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume,
+                                (boost::format("stave_straight_outer_ext_%d_%d_%d") % i % inttlayer % itype).str(), staveext_volume, false, 0, OverlapCheck());
+            }
+          }
+          // The cooler curved sections are made using 2 curved sections in a recurve on each side of the cooler straight section
+          // The tube sections used here have the origin of their volume at their center of rotation. Rcavge
+          //      Each curve section is moved to the center of the stave volume by a translation of +/- Rcavge
+          //      Then it is moved to the outside or the inside of the stave volume by a translation of +/-  cooler_gap_x / 2.
+          // we start at lowest y and work up in y
+
+          double x_off_cooler[4] =
+              {
+                  Rcavge - cooler_gap_x / 2.,
+                  -Rcavge + cooler_gap_x / 2.,
+                  -Rcavge + cooler_gap_x / 2.,
+                  Rcavge - cooler_gap_x / 2.};
+          double y_off_cooler[4] =
+              {
+                  -stave_straight_cooler_y / 2. - 2. * curve_length_y,
+                  -stave_straight_cooler_y / 2.,
+                  stave_straight_cooler_y / 2.,
+                  stave_straight_cooler_y / 2. + 2. * curve_length_y};
+
+          for (int i = 0; i < 4; i++)
+          {
+            new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_volume[i],
+                              (boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_ext_volume[i],
+                              (boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+          }
+        }
+        else if (laddertype == PHG4InttDefs::SEGMENTATION_PHI)  // The type PHG4InttDefs::SEGMENTATION_PHI ladder has two cooling tubes
+        {
+          // First place the straight sections, do the extension at the same time
+          // we alternate  positive and negative y values here
+          double x_off_str[5] =
+              {
+                  (Rcmax - Rcmin) / 2. - stave_x / 2.,  // against the PGS
+                  (Rcmax + Rcmin) / 2. - stave_x / 2.,  // top of cooler
+                  (Rcmax + Rcmin) / 2. - stave_x / 2.,  // top of cooler
+                  (Rcmax - Rcmin) / 2. - stave_x / 2.,
+                  (Rcmax - Rcmin) / 2 - stave_x / 2.};
+          double y_off_str[5] =
+              {
+                  0.0,                                                                                // center section against PGS
+                  stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y / 2.,   // top of cooler
+                  -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y / 2.,  // top of cooler
+                  stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y + 2. * curve_length_y + stave_straight_outer_y / 2.,
+                  -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y - 2. * curve_length_y - stave_straight_outer_y / 2.,
+              };
+
+          for (int i = 0; i < 5; i++)
+          {
+            if (i == 0)
+            {
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_volume,
+                                (boost::format("stave_straight_inner_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_ext_volume,
+                                (boost::format("stave_straight_inner_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+            }
+            else if (i == 1 || i == 2)
+            {
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume,
+                                (boost::format("stave_straight_cooler_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume,
+                                (boost::format("stave_straight_cooler_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+            }
+            else
+            {
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume,
+                                (boost::format("stave_straight_outer_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume,
+                                (boost::format("stave_straight_outer_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+            }
+          }
+
+          // Place the curved sections
+          // here we do all above the x axis, then all below the x axis, each in order of increasing y
+
+          double x_off_curve[8] =
+              {
+                  // below x axis, increasing in y
+                  Rcavge - cooler_gap_x / 2.,
+                  -Rcavge + cooler_gap_x / 2.,
+                  -Rcavge + cooler_gap_x / 2.,
+                  Rcavge - cooler_gap_x / 2.,
+                  // above x axis, increasing in y
+                  Rcavge - cooler_gap_x / 2.,
+                  -Rcavge + cooler_gap_x / 2.,
+                  -Rcavge + cooler_gap_x / 2.,
+                  Rcavge - cooler_gap_x / 2.};
+          double y_off_curve[8] =
+              {
+                  // below the x axis, increasing in y
+                  -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y - 2. * curve_length_y,
+                  -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y,
+                  -stave_straight_inner_y / 2. - 2. * curve_length_y,
+                  -stave_straight_inner_y / 2.,
+                  // above the x axis, increasing in y
+                  stave_straight_inner_y / 2.,
+                  stave_straight_inner_y / 2. + 2. * curve_length_y,
+                  stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y,
+                  stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y + 2. * curve_length_y};
+
+          for (int i = 0; i < 8; i++)
+          {
+            // initially this was ivol = i; if (ivol > 3) ivol = i -4;
+            // but that triggered a false positive in coverity
+            // this should make it happy and reduce the noise in the coverity reports
+            int ivol;
+            if (i > 3)
+            {
+              ivol = i - 4;
+            }
+            else
+            {
+              ivol = i;
+            }
+            new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_volume[ivol], (boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_ext_volume[ivol], (boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+          }
+        }
+        else
+        {
+          cout << PHWHERE << "invalid laddertype " << laddertype << endl;
+          gSystem->Exit(1);
+        }
+      }                                                          // stave type 0
+      else if (params->get_int_param("carbon_stave_type") == 1)  // carbon stave without water cooling
+      {
+        // Carbon stave. This is the formed sheet that sits on the PGS and completes the outer shell surrounds
+        // Rohacel foam and cooling water pipe inside. Formed from straight sections and sections of a tube of
+        // radius 3.1905 mm. All have wall thickness of 0.1905 mm.
+        const double Rcmin = 0.30 * cm;     // mm inner radius of curved section, same at both ends
+        const double Rcmax = 0.31905 * cm;  // mm outer radius of curved section, same at both ends
+        const double Rpmin = 0.10 * cm;     // inner radius of cooling pipe section, same at both ends
+        const double Rpmax = 0.15 * cm;     // outer radius of cooling pipe section, same at both ends
+        double Rcavge = (Rcmax + Rcmin) / 2.0;
+        double dphi_c = 23.19859051 * M_PI / 180.;  // phi of the curved section
+        const double stave_z = pgs_z;
+
+        // Make CFC structure
+        //// Make curved sections
+        const double phic_begin[4] = {M_PI - dphi_c, -dphi_c, 0.0, M_PI};
+        const double dphic[4] = {dphi_c, dphi_c, dphi_c, dphi_c};
+
+        G4Tubs *stave_curve_cons[4];
+        G4Tubs *stave_curve_ext_cons[4];
+        G4LogicalVolume *stave_curve_volume[4];
+        G4LogicalVolume *stave_curve_ext_volume[4];
+
+        for (int i = 0; i < 4; i++)
+        {
+          stave_curve_cons[i] = new G4Tubs((boost::format("stave_curve_cons_%d_%d_%d") % inttlayer % itype % i).str(),
+                                           Rcmin, Rcmax, stave_z / 2., phic_begin[i], dphic[i]);
+          stave_curve_volume[i] = new G4LogicalVolume(stave_curve_cons[i], G4Material::GetMaterial("CFRP_INTT"),
+                                                      (boost::format("stave_curve_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
+          if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+          {
+            m_PassiveVolumeTuple.insert(make_pair(stave_curve_volume[i], make_tuple(inttlayer, PHG4InttDefs::STAVE_CURVE)));
+          }
+          stave_curve_ext_cons[i] = new G4Tubs((boost::format("stave_curve_ext_cons_%d_%d_%d") % inttlayer % itype % i).str(),
+                                               Rcmin, Rcmax, hdiext_z / 2., phic_begin[i], dphic[i]);
+          stave_curve_ext_volume[i] = new G4LogicalVolume(stave_curve_ext_cons[i], G4Material::GetMaterial("CFRP_INTT"),
+                                                          (boost::format("stave_curve_ext_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
+          if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+          {
+            m_PassiveVolumeTuple.insert(make_pair(stave_curve_ext_volume[i], make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_CURVE)));
+          }
+          m_DisplayAction->AddVolume(stave_curve_volume[i], "StaveCurve");
+          m_DisplayAction->AddVolume(stave_curve_ext_volume[i], "StaveCurve");
+        }
+
+        // we will need the length in y of the curved section as it is installed in the stave box
+        double curve_length_y = Rcavge * sin(dphi_c);
+
+        // Make several straight sections for use in making the stave
+        double stave_straight_outer_y = params->get_double_param("waterstave_straight_outer_y") * cm;
+        double stave_straight_cooler_y = params->get_double_param("waterstave_straight_cooler_y") * cm;
+        double rohacell_straight_y = params->get_double_param("waterstave_straight_rohacell_y") * cm;
+
+        // Outer straight sections of stave
+        double stave_wall_thickness = 0.01905 * cm;
+        G4VSolid *stave_straight_outer_box = new G4Box((boost::format("stave_straight_outer_box_%d_%d") % inttlayer % itype).str(),
+                                                       stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
+        G4LogicalVolume *stave_straight_outer_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                           (boost::format("stave_straight_outer_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+        {
+          m_PassiveVolumeTuple.insert(make_pair(stave_straight_outer_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_OUTER)));
+        }
+        G4VSolid *stave_straight_outer_ext_box = new G4Box((boost::format("stave_straight_outer_ext_box_%d_%s") % inttlayer % itype).str(),
+                                                           stave_wall_thickness / 2., stave_straight_outer_y / 2., hdiext_z / 2.);
+        G4LogicalVolume *stave_straight_outer_ext_volume = new G4LogicalVolume(stave_straight_outer_ext_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                               (boost::format("stave_straight_outer_ext_volume_%d_%s") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+        {
+          m_PassiveVolumeTuple.insert(make_pair(stave_straight_outer_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_OUTER)));
+        }
+
+        //Top surface of stave
+        G4VSolid *stave_straight_cooler_box = new G4Box((boost::format("stave_straight_cooler_box_%d_%d") % inttlayer % itype).str(),
+                                                        stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
+        G4LogicalVolume *stave_straight_cooler_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                            (boost::format("stave_straight_cooler_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+        {
+          m_PassiveVolumeTuple.insert(make_pair(stave_straight_cooler_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_COOLER)));
+        }
+        G4VSolid *stave_straight_cooler_ext_box = new G4Box((boost::format("stave_straight_cooler_ext_box_%d_%d") % inttlayer % itype).str(),
+                                                            stave_wall_thickness / 2., stave_straight_cooler_y / 2., hdiext_z / 2.);
+        G4LogicalVolume *stave_straight_cooler_ext_volume = new G4LogicalVolume(stave_straight_cooler_ext_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                                (boost::format("stave_straight_cooler_ext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+        {
+          m_PassiveVolumeTuple.insert(make_pair(stave_straight_cooler_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_COOLER)));
+        }
+
+        // Slant straight sections of stave
+        double stave_slant_cooler_y = params->get_double_param("waterstave_slant_cooler_y") * cm;
+        G4VSolid *stave_slant_cooler_box = new G4Box((boost::format("stave_slant_cooler_box_%d_%d") % inttlayer % itype).str(),
+                                                     stave_wall_thickness / 2., stave_slant_cooler_y / 2., stave_z / 2.);
+        G4LogicalVolume *stave_slant_cooler_volume = new G4LogicalVolume(stave_slant_cooler_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                         (boost::format("stave_slant_cooler_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+        {
+          m_PassiveVolumeTuple.insert(make_pair(stave_slant_cooler_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_COOLER)));
+        }
+        G4VSolid *stave_slant_cooler_ext_box = new G4Box((boost::format("stave_lant_cooler_ext_box_%d_%d") % inttlayer % itype).str(),
+                                                         stave_wall_thickness / 2., stave_slant_cooler_y / 2., hdiext_z / 2.);
+        G4LogicalVolume *stave_slant_cooler_ext_volume = new G4LogicalVolume(stave_slant_cooler_ext_box, G4Material::GetMaterial("CFRP_INTT"),
+                                                                             (boost::format("stave_slant_cooler_ext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
+        {
+          m_PassiveVolumeTuple.insert(make_pair(stave_slant_cooler_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_COOLER)));
+        }
+
+        m_DisplayAction->AddVolume(stave_straight_cooler_volume, "StaveCooler");
+        m_DisplayAction->AddVolume(stave_straight_cooler_ext_volume, "StaveCooler");
+        m_DisplayAction->AddVolume(stave_straight_outer_volume, "StaveStraightOuter");
+        m_DisplayAction->AddVolume(stave_straight_outer_ext_volume, "StaveStraightOuter");
+        m_DisplayAction->AddVolume(stave_slant_cooler_volume, "StaveCooler");
+        m_DisplayAction->AddVolume(stave_slant_cooler_ext_volume, "StaveCooler");
+
+        // cooling pipe + water inside + glue outside
+        G4VSolid *stave_glue_box = new G4Box((boost::format("stave_glue_box_%d_%d") % inttlayer % itype).str(), 3. / 2, 3. / 2., stave_z / 2.);
+        G4LogicalVolume *stave_glue_volume = new G4LogicalVolume(stave_glue_box, G4Material::GetMaterial("Epoxy"),
+                                                                 (boost::format("stave_glue_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        G4VSolid *staveext_glue_box = new G4Box((boost::format("staveext_glue_box_%d_%d") % inttlayer % itype).str(), 3. / 2., 3. / 2., hdiext_z / 2.);
+        G4LogicalVolume *staveext_glue_volume = new G4LogicalVolume(staveext_glue_box, G4Material::GetMaterial("Epoxy"),
+                                                                    (boost::format("staveext_glue_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+
+        m_DisplayAction->AddVolume(stave_glue_volume, "StaveGlueBox");
+        m_DisplayAction->AddVolume(staveext_glue_volume, "StaveGlueBox");
+
+        G4VSolid *stave_pipe_cons = new G4Tubs((boost::format("stave_pipe_cons_%d_%d") % inttlayer % itype).str(),
+                                               Rpmin, Rpmax, stave_z / 2., -M_PI, 2.0 * M_PI);
+        G4LogicalVolume *stave_pipe_volume = new G4LogicalVolume(stave_pipe_cons, G4Material::GetMaterial("CFRP_INTT"),
+                                                                 (boost::format("stave_pipe_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+
+        G4VSolid *staveext_pipe_cons = new G4Tubs((boost::format("staveext_pipe_cons_%d_%d") % inttlayer % itype).str(),
+                                                  Rpmin, Rpmax, hdiext_z / 2., -M_PI, 2.0 * M_PI);
+        G4LogicalVolume *staveext_pipe_volume = new G4LogicalVolume(staveext_pipe_cons, G4Material::GetMaterial("CFRP_INTT"),
+                                                                    (boost::format("staveext_pipe_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+
+        m_DisplayAction->AddVolume(stave_pipe_volume, "StavePipe");
+        m_DisplayAction->AddVolume(staveext_pipe_volume, "StavePipe");
+
+        G4VSolid *stave_water_cons = new G4Tubs((boost::format("stave_water_cons_%d_%d") % inttlayer % itype).str(),
+                                                0., Rpmin, stave_z / 2., -M_PI, 2.0 * M_PI);
+        G4LogicalVolume *stave_water_volume = new G4LogicalVolume(stave_water_cons, G4Material::GetMaterial("G4_WATER"),
+                                                                  (boost::format("stave_water_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+
+        G4VSolid *staveext_water_cons = new G4Tubs((boost::format("staveext_water_cons_%d_%d") % inttlayer % itype).str(),
+                                                   0., Rpmin, hdiext_z / 2., -M_PI, 2.0 * M_PI);
+        G4LogicalVolume *staveext_water_volume = new G4LogicalVolume(staveext_water_cons, G4Material::GetMaterial("G4_WATER"),
+                                                                     (boost::format("staveext_water_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+
+        m_DisplayAction->AddVolume(stave_water_volume, "StaveWater");
+        m_DisplayAction->AddVolume(staveext_water_volume, "StaveWater");
+
+        //rohacell foam
+        //straight boxes
+        G4VSolid *rohacell_straight_cons = new G4Box((boost::format("rohacell_straight_cons_%d_%d") % inttlayer % itype).str(), 3. / 2, rohacell_straight_y / 2., stave_z / 2.);
+        G4LogicalVolume *rohacell_straight_volume = new G4LogicalVolume(rohacell_straight_cons, G4Material::GetMaterial("ROHACELL_FOAM_51"),
+                                                                        (boost::format("rohacell_straight_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+
+        G4VSolid *rohacellext_straight_cons = new G4Box((boost::format("rohacellext_straight_cons_%d_%d") % inttlayer % itype).str(), 3. / 2, rohacell_straight_y / 2., hdiext_z / 2.);
+        G4LogicalVolume *rohacellext_straight_volume = new G4LogicalVolume(rohacellext_straight_cons, G4Material::GetMaterial("ROHACELL_FOAM_51"),
+                                                                           (boost::format("rohacellext_straight_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+
+        // make curved sections for rohacell foam
+        const double rh_phic_begin[2] = {-dphi_c, 0.0};
+        const double rh_dphic[2] = {dphi_c, dphi_c};
+        G4Tubs *rohacell_curve_cons[2];
+        G4LogicalVolume *rohacell_curve_volume[2];
+        G4Tubs *rohacellext_curve_cons[2];
+        G4LogicalVolume *rohacellext_curve_volume[2];
+        for (int i = 0; i < 2; i++)
+        {
+          rohacell_curve_cons[i] = new G4Tubs((boost::format("rohacell_curve_cons_%d_%d_%d") % inttlayer % itype % i).str(),
+                                              0., Rcmin, stave_z / 2., rh_phic_begin[i], rh_dphic[i]);
+          rohacell_curve_volume[i] = new G4LogicalVolume(rohacell_curve_cons[i], G4Material::GetMaterial("ROHACELL_FOAM_51"),
+                                                         (boost::format("rohacell_curve_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
+          rohacellext_curve_cons[i] = new G4Tubs((boost::format("rohacellext_curve_cons_%d_%d_%d") % inttlayer % itype % i).str(),
+                                                 0., Rcmin, hdiext_z / 2., rh_phic_begin[i], rh_dphic[i]);
+          rohacellext_curve_volume[i] = new G4LogicalVolume(rohacellext_curve_cons[i], G4Material::GetMaterial("ROHACELL_FOAM_51"),
+                                                            (boost::format("rohacellext_curve_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
+        }
+
+        // make trapezoidal sections for rohacell foam
+        G4GenericTrap *rohacell_trap_cons[2];
+        G4LogicalVolume *rohacell_trap_volume[2];
+        G4GenericTrap *rohacellext_trap_cons[2];
+        G4LogicalVolume *rohacellext_trap_volume[2];
+        for (int i = 0; i < 2; i++)
+        {
+          double shift = 1.e-5;  // To mitigate fm order level overlaps reported by GEANT4...
+          std::vector<G4TwoVector> rohatrap(8);
           if (i == 0)
           {
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_volume,
-                              (boost::format("stave_straight_inner_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_inner_ext_volume,
-                              (boost::format("stave_straight_inner_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
-          }
-          else if (i == 1 || i == 2)
-          {
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume,
-                              (boost::format("stave_straight_cooler_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume,
-                              (boost::format("stave_straight_cooler_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+            rohatrap[0] = G4TwoVector(0. * cm, 0. * cm);
+            rohatrap[1] = G4TwoVector(Rcmin * cos(dphi_c) - shift, -Rcmin * sin(dphi_c));
+            rohatrap[2] = G4TwoVector(Rcmin * (1. - cos(dphi_c)) - shift, -stave_slant_cooler_y * cos(dphi_c) - Rcmin * sin(dphi_c));
+            rohatrap[3] = G4TwoVector(0. * cm, -stave_slant_cooler_y * cos(dphi_c) - Rcmin * sin(dphi_c));
           }
           else
           {
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume,
-                              (boost::format("stave_straight_outer_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume,
-                              (boost::format("stave_straight_outer_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
-          }
-        }
-
-        // Place the curved sections
-        // here we do all above the x axis, then all below the x axis, each in order of increasing y
-
-        double x_off_curve[8] =
-            {
-                // below x axis, increasing in y
-                Rcavge - cooler_gap_x / 2.,
-                -Rcavge + cooler_gap_x / 2.,
-                -Rcavge + cooler_gap_x / 2.,
-                Rcavge - cooler_gap_x / 2.,
-                // above x axis, increasing in y
-                Rcavge - cooler_gap_x / 2.,
-                -Rcavge + cooler_gap_x / 2.,
-                -Rcavge + cooler_gap_x / 2.,
-                Rcavge - cooler_gap_x / 2.};
-        double y_off_curve[8] =
-            {
-                // below the x axis, increasing in y
-                -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y - 2. * curve_length_y,
-                -stave_straight_inner_y / 2. - 2. * curve_length_y - stave_straight_cooler_y,
-                -stave_straight_inner_y / 2. - 2. * curve_length_y,
-                -stave_straight_inner_y / 2.,
-                // above the x axis, increasing in y
-                stave_straight_inner_y / 2.,
-                stave_straight_inner_y / 2. + 2. * curve_length_y,
-                stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y,
-                stave_straight_inner_y / 2. + 2. * curve_length_y + stave_straight_cooler_y + 2. * curve_length_y};
-
-        for (int i = 0; i < 8; i++)
-        {
-          // initially this was ivol = i; if (ivol > 3) ivol = i -4;
-          // but that triggered a false positive in coverity
-          // this should make it happy and reduce the noise in the coverity reports
-          int ivol;
-          if (i > 3)
-          {
-            ivol = i - 4;
-          }
-          else
-          {
-            ivol = i;
-          }
-          new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_volume[ivol], (boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
-          new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_ext_volume[ivol], (boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
-        }
-      }
-      else
-      {
-        cout << PHWHERE << "invalid laddertype " << laddertype << endl;
-        gSystem->Exit(1);
-      }
-      } // stave type 0
-      else if(params->get_int_param("carbon_stave_type")==1)  // carbon stave without water cooling
-      {
-      // Carbon stave. This is the formed sheet that sits on the PGS and completes the outer shell surrounds
-      // Rohacel foam and cooling water pipe inside. Formed from straight sections and sections of a tube of 
-      // radius 3.1905 mm. All have wall thickness of 0.1905 mm.
-      const double Rcmin = 0.30 * cm;     // mm inner radius of curved section, same at both ends
-      const double Rcmax = 0.31905 * cm;  // mm outer radius of curved section, same at both ends
-      const double Rpmin = 0.10 * cm;  // inner radius of cooling pipe section, same at both ends
-      const double Rpmax = 0.15 * cm;  // outer radius of cooling pipe section, same at both ends
-      double Rcavge = (Rcmax + Rcmin) / 2.0;
-      double dphi_c = 23.19859051 * M_PI / 180.; // phi of the curved section
-      const double stave_z = pgs_z;
-
-      // Make CFC structure
-      //// Make curved sections
-      const double phic_begin[4] = {M_PI - dphi_c, -dphi_c, 0.0, M_PI};
-      const double dphic[4] = {dphi_c, dphi_c, dphi_c, dphi_c};
-
-      G4Tubs *stave_curve_cons[4];
-      G4Tubs *stave_curve_ext_cons[4];
-      G4LogicalVolume *stave_curve_volume[4];
-      G4LogicalVolume *stave_curve_ext_volume[4];
-
-      for (int i = 0; i < 4; i++)
-      {
-        stave_curve_cons[i] = new G4Tubs((boost::format("stave_curve_cons_%d_%d_%d") % inttlayer % itype % i).str(),
-                                         Rcmin, Rcmax, stave_z / 2., phic_begin[i], dphic[i]);
-        stave_curve_volume[i] = new G4LogicalVolume(stave_curve_cons[i], G4Material::GetMaterial("CFRP_INTT"),
-                                                    (boost::format("stave_curve_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
-        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-        {
-          m_PassiveVolumeTuple.insert(make_pair(stave_curve_volume[i], make_tuple(inttlayer, PHG4InttDefs::STAVE_CURVE)));
-        }
-        stave_curve_ext_cons[i] = new G4Tubs((boost::format("stave_curve_ext_cons_%d_%d_%d") % inttlayer % itype % i).str(),
-                                             Rcmin, Rcmax, hdiext_z / 2., phic_begin[i], dphic[i]);
-        stave_curve_ext_volume[i] = new G4LogicalVolume(stave_curve_ext_cons[i], G4Material::GetMaterial("CFRP_INTT"),
-                                                        (boost::format("stave_curve_ext_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
-        if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-        {
-          m_PassiveVolumeTuple.insert(make_pair(stave_curve_ext_volume[i], make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_CURVE)));
-        }
-        m_DisplayAction->AddVolume(stave_curve_volume[i],"StaveCurve");
-        m_DisplayAction->AddVolume(stave_curve_ext_volume[i],"StaveCurve");
-      }
-
-      // we will need the length in y of the curved section as it is installed in the stave box
-      double curve_length_y = Rcavge * sin(dphi_c);
-
-      // Make several straight sections for use in making the stave
-      double stave_straight_outer_y  = params->get_double_param("waterstave_straight_outer_y") * cm;
-      double stave_straight_cooler_y = params->get_double_param("waterstave_straight_cooler_y") * cm;
-      double rohacell_straight_y  = params->get_double_param("waterstave_straight_rohacell_y") * cm;
-
-      // Outer straight sections of stave
-      double stave_wall_thickness = 0.01905 * cm;
-      G4VSolid *stave_straight_outer_box = new G4Box((boost::format("stave_straight_outer_box_%d_%d") % inttlayer % itype).str(),
-                                                     stave_wall_thickness / 2., stave_straight_outer_y / 2., stave_z / 2.);
-      G4LogicalVolume *stave_straight_outer_volume = new G4LogicalVolume(stave_straight_outer_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                         (boost::format("stave_straight_outer_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_straight_outer_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_OUTER)));
-      }
-      G4VSolid *stave_straight_outer_ext_box = new G4Box((boost::format("stave_straight_outer_ext_box_%d_%s") % inttlayer % itype).str(),
-                                                         stave_wall_thickness / 2., stave_straight_outer_y / 2., hdiext_z / 2.);
-      G4LogicalVolume *stave_straight_outer_ext_volume = new G4LogicalVolume(stave_straight_outer_ext_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                             (boost::format("stave_straight_outer_ext_volume_%d_%s") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_straight_outer_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_OUTER)));
-      }
-
-      //Top surface of stave
-      G4VSolid *stave_straight_cooler_box = new G4Box((boost::format("stave_straight_cooler_box_%d_%d") % inttlayer % itype).str(),
-                                                      stave_wall_thickness / 2., stave_straight_cooler_y / 2., stave_z / 2.);
-      G4LogicalVolume *stave_straight_cooler_volume = new G4LogicalVolume(stave_straight_cooler_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                          (boost::format("stave_straight_cooler_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_straight_cooler_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_COOLER)));
-      }
-      G4VSolid *stave_straight_cooler_ext_box = new G4Box((boost::format("stave_straight_cooler_ext_box_%d_%d") % inttlayer % itype).str(),
-                                                          stave_wall_thickness / 2., stave_straight_cooler_y / 2., hdiext_z / 2.);
-      G4LogicalVolume *stave_straight_cooler_ext_volume = new G4LogicalVolume(stave_straight_cooler_ext_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                              (boost::format("stave_straight_cooler_ext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_straight_cooler_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_COOLER)));
-      }
-
-      // Slant straight sections of stave
-      double stave_slant_cooler_y    = params->get_double_param("waterstave_slant_cooler_y") * cm;
-      G4VSolid *stave_slant_cooler_box = new G4Box((boost::format("stave_slant_cooler_box_%d_%d") % inttlayer % itype).str(),
-                                                      stave_wall_thickness / 2., stave_slant_cooler_y / 2., stave_z / 2.);
-      G4LogicalVolume *stave_slant_cooler_volume = new G4LogicalVolume(stave_slant_cooler_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                          (boost::format("stave_slant_cooler_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_slant_cooler_volume, make_tuple(inttlayer, PHG4InttDefs::STAVE_STRAIGHT_COOLER)));
-      }
-      G4VSolid *stave_slant_cooler_ext_box = new G4Box((boost::format("stave_lant_cooler_ext_box_%d_%d") % inttlayer % itype).str(),
-                                                          stave_wall_thickness / 2., stave_slant_cooler_y / 2., hdiext_z / 2.);
-      G4LogicalVolume *stave_slant_cooler_ext_volume = new G4LogicalVolume(stave_slant_cooler_ext_box, G4Material::GetMaterial("CFRP_INTT"),
-                                                                              (boost::format("stave_slant_cooler_ext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      if ((m_IsAbsorberActiveMap.find(inttlayer))->second > 0)
-      {
-        m_PassiveVolumeTuple.insert(make_pair(stave_slant_cooler_ext_volume, make_tuple(inttlayer, PHG4InttDefs::STAVEEXT_STRAIGHT_COOLER)));
-      }
-
-      m_DisplayAction->AddVolume(stave_straight_cooler_volume,"StaveCooler");
-      m_DisplayAction->AddVolume(stave_straight_cooler_ext_volume,"StaveCooler");
-      m_DisplayAction->AddVolume(stave_straight_outer_volume,"StaveStraightOuter");
-      m_DisplayAction->AddVolume(stave_straight_outer_ext_volume,"StaveStraightOuter");
-      m_DisplayAction->AddVolume(stave_slant_cooler_volume,"StaveCooler");
-      m_DisplayAction->AddVolume(stave_slant_cooler_ext_volume,"StaveCooler");
-
-      // cooling pipe + water inside + glue outside
-      G4VSolid *stave_glue_box = new G4Box((boost::format("stave_glue_box_%d_%d") % inttlayer % itype).str(), 3./2, 3./2., stave_z / 2.);
-      G4LogicalVolume *stave_glue_volume = new G4LogicalVolume(stave_glue_box, G4Material::GetMaterial("Epoxy"),
-                                                          (boost::format("stave_glue_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-      G4VSolid *staveext_glue_box = new G4Box((boost::format("staveext_glue_box_%d_%d") % inttlayer % itype).str(), 3./2., 3./2., hdiext_z / 2.);
-      G4LogicalVolume *staveext_glue_volume = new G4LogicalVolume(staveext_glue_box, G4Material::GetMaterial("Epoxy"),
-                                                          (boost::format("staveext_glue_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-
-      m_DisplayAction->AddVolume(stave_glue_volume,"StaveGlueBox");
-      m_DisplayAction->AddVolume(staveext_glue_volume,"StaveGlueBox");
-
-      G4VSolid *stave_pipe_cons = new G4Tubs((boost::format("stave_pipe_cons_%d_%d") % inttlayer % itype).str(),
-                                              Rpmin, Rpmax, stave_z / 2., -M_PI, 2.0 * M_PI);
-      G4LogicalVolume *stave_pipe_volume = new G4LogicalVolume(stave_pipe_cons, G4Material::GetMaterial("CFRP_INTT"),
-                                                        (boost::format("stave_pipe_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-
-      G4VSolid *staveext_pipe_cons = new G4Tubs((boost::format("staveext_pipe_cons_%d_%d") % inttlayer % itype).str(),
-                                                 Rpmin, Rpmax, hdiext_z / 2., -M_PI, 2.0 * M_PI);
-      G4LogicalVolume *staveext_pipe_volume = new G4LogicalVolume(staveext_pipe_cons, G4Material::GetMaterial("CFRP_INTT"),
-                                                        (boost::format("staveext_pipe_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-
-      m_DisplayAction->AddVolume(stave_pipe_volume,"StavePipe");
-      m_DisplayAction->AddVolume(staveext_pipe_volume,"StavePipe");
-
-      G4VSolid *stave_water_cons = new G4Tubs((boost::format("stave_water_cons_%d_%d") % inttlayer % itype ).str(),
-                                              0., Rpmin, stave_z / 2., -M_PI, 2.0 * M_PI);
-      G4LogicalVolume *stave_water_volume = new G4LogicalVolume(stave_water_cons, G4Material::GetMaterial("G4_WATER"),
-                                                        (boost::format("stave_water_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-
-      G4VSolid *staveext_water_cons = new G4Tubs((boost::format("staveext_water_cons_%d_%d") % inttlayer % itype ).str(),
-                                                 0., Rpmin, hdiext_z / 2., -M_PI, 2.0 * M_PI);
-      G4LogicalVolume *staveext_water_volume = new G4LogicalVolume(staveext_water_cons, G4Material::GetMaterial("G4_WATER"),
-                                                        (boost::format("staveext_water_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-
-      m_DisplayAction->AddVolume(stave_water_volume,"StaveWater");
-      m_DisplayAction->AddVolume(staveext_water_volume,"StaveWater");
-
-      //rohacell foam
-      //straight boxes
-      G4VSolid *rohacell_straight_cons = new G4Box((boost::format("rohacell_straight_cons_%d_%d") % inttlayer % itype ).str(), 3./2, rohacell_straight_y / 2., stave_z / 2.);
-      G4LogicalVolume *rohacell_straight_volume = new G4LogicalVolume(rohacell_straight_cons, G4Material::GetMaterial("ROHACELL_FOAM_51"),
-                                                          (boost::format("rohacell_straight_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-
-      G4VSolid *rohacellext_straight_cons = new G4Box((boost::format("rohacellext_straight_cons_%d_%d") % inttlayer % itype ).str(), 3./2, rohacell_straight_y / 2., hdiext_z / 2.);
-      G4LogicalVolume *rohacellext_straight_volume = new G4LogicalVolume(rohacellext_straight_cons, G4Material::GetMaterial("ROHACELL_FOAM_51"),
-                                                          (boost::format("rohacellext_straight_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-
-      // make curved sections for rohacell foam
-      const double rh_phic_begin[2] = {-dphi_c, 0.0};
-      const double rh_dphic[2] = {dphi_c, dphi_c};
-      G4Tubs *rohacell_curve_cons[2];
-      G4LogicalVolume *rohacell_curve_volume[2];
-      G4Tubs *rohacellext_curve_cons[2];
-      G4LogicalVolume *rohacellext_curve_volume[2];
-      for(int i=0; i<2; i++)
-      {
-      rohacell_curve_cons[i] = new G4Tubs((boost::format("rohacell_curve_cons_%d_%d_%d") % inttlayer % itype  % i).str(),
-                                                     0. , Rcmin, stave_z / 2., rh_phic_begin[i], rh_dphic[i] );
-      rohacell_curve_volume[i] = new G4LogicalVolume(rohacell_curve_cons[i], G4Material::GetMaterial("ROHACELL_FOAM_51"),
-                                                         (boost::format("rohacell_curve_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
-      rohacellext_curve_cons[i] = new G4Tubs((boost::format("rohacellext_curve_cons_%d_%d_%d") % inttlayer % itype  % i).str(),
-                                                        0. , Rcmin, hdiext_z / 2., rh_phic_begin[i], rh_dphic[i] );
-      rohacellext_curve_volume[i] = new G4LogicalVolume(rohacellext_curve_cons[i], G4Material::GetMaterial("ROHACELL_FOAM_51"),
-                                                         (boost::format("rohacellext_curve_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
-      }
-
-      // make trapezoidal sections for rohacell foam
-      G4GenericTrap *rohacell_trap_cons[2];
-      G4LogicalVolume *rohacell_trap_volume[2];
-      G4GenericTrap *rohacellext_trap_cons[2];
-      G4LogicalVolume *rohacellext_trap_volume[2];
-      for(int i=0; i<2; i++)
-      {
-        double shift = 1.e-5; // To mitigate fm order level overlaps reported by GEANT4...
-          std::vector<G4TwoVector> rohatrap(8);
-          if(i==0)
-          {
-          rohatrap[0] = G4TwoVector(0. * cm, 0. * cm);
-          rohatrap[1] = G4TwoVector(Rcmin * cos(dphi_c) - shift, -Rcmin * sin(dphi_c));
-          rohatrap[2] = G4TwoVector(Rcmin * (1. - cos(dphi_c)) - shift, -stave_slant_cooler_y * cos(dphi_c) - Rcmin * sin(dphi_c));
-          rohatrap[3] = G4TwoVector(0. * cm, -stave_slant_cooler_y * cos(dphi_c) - Rcmin * sin(dphi_c));
-          }
-          else
-          {
-          rohatrap[0] = G4TwoVector(0. * cm, +stave_slant_cooler_y * cos(dphi_c) + Rcmin * sin(dphi_c));
-          rohatrap[1] = G4TwoVector(Rcmax * (1. - cos(dphi_c)) - shift, +stave_slant_cooler_y * cos(dphi_c) + Rcmin * sin(dphi_c));
-          rohatrap[2] = G4TwoVector(Rcmin * cos(dphi_c) - shift, +Rcmin * sin(dphi_c));
-          rohatrap[3] = G4TwoVector(0. * cm, 0. * cm);
+            rohatrap[0] = G4TwoVector(0. * cm, +stave_slant_cooler_y * cos(dphi_c) + Rcmin * sin(dphi_c));
+            rohatrap[1] = G4TwoVector(Rcmax * (1. - cos(dphi_c)) - shift, +stave_slant_cooler_y * cos(dphi_c) + Rcmin * sin(dphi_c));
+            rohatrap[2] = G4TwoVector(Rcmin * cos(dphi_c) - shift, +Rcmin * sin(dphi_c));
+            rohatrap[3] = G4TwoVector(0. * cm, 0. * cm);
           }
           rohatrap[4] = rohatrap[0];
           rohatrap[5] = rohatrap[1];
           rohatrap[6] = rohatrap[2];
           rohatrap[7] = rohatrap[3];
 
-          rohacell_trap_cons[i] = new G4GenericTrap((boost::format("rohacell_trap_cons_%d_%d_%d") % inttlayer % itype  % i).str(), stave_z / 2., rohatrap );
+          rohacell_trap_cons[i] = new G4GenericTrap((boost::format("rohacell_trap_cons_%d_%d_%d") % inttlayer % itype % i).str(), stave_z / 2., rohatrap);
           rohacell_trap_volume[i] = new G4LogicalVolume(rohacell_trap_cons[i], G4Material::GetMaterial("ROHACELL_FOAM_51"),
-                                                         (boost::format("rohacell_trap_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
+                                                        (boost::format("rohacell_trap_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
 
-          rohacellext_trap_cons[i] = new G4GenericTrap((boost::format("rohacellext_trap_cons_%d_%d_%d") % inttlayer % itype  % i).str(), hdiext_z / 2., rohatrap );
+          rohacellext_trap_cons[i] = new G4GenericTrap((boost::format("rohacellext_trap_cons_%d_%d_%d") % inttlayer % itype % i).str(), hdiext_z / 2., rohatrap);
           rohacellext_trap_volume[i] = new G4LogicalVolume(rohacellext_trap_cons[i], G4Material::GetMaterial("ROHACELL_FOAM_51"),
-                                                         (boost::format("rohacellext_trap_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
-      }
-
-      m_DisplayAction->AddVolume(rohacell_straight_volume,"RohaCell");
-      m_DisplayAction->AddVolume(rohacellext_straight_volume,"RohaCell");
-      for(int i=0; i<2; i++)
-      {
-      m_DisplayAction->AddVolume(rohacell_curve_volume[i],"RohaCell");
-      m_DisplayAction->AddVolume(rohacellext_curve_volume[i],"RohaCell");
-      m_DisplayAction->AddVolume(rohacell_trap_volume[i],"RohaCell");
-      m_DisplayAction->AddVolume(rohacellext_trap_volume[i],"RohaCell");
-      }
-
-      // Now we combine the elements of a stave defined above into a stave
-      // Create a stave volume to install the stave sections into. The volume has to be big enouigh to contain the cooling tube
-      double cooler_gap_x = 0.3 * cm;  // id of cooling tube in cm
-      double cooler_wall = 0.01905 * cm;  // outer wall thickness of cooling tube
-      double cooler_x = cooler_gap_x + cooler_wall;
-      stave_x = cooler_x;  // we do not include the PGS in the stave volume
-      stave_y = hdi_y;
-
-      // Make stave volume. Drop two corners in positive x to prevent ladder_volume overlapping
-      // with neighbouring ladders because of small clearance in the latest configuration
-      G4RotationMatrix* stv_rot_pos = new G4RotationMatrix();
-      stv_rot_pos->rotateZ(-15. * M_PI / 180.);
-      G4ThreeVector stvTranspos(stave_x / 2., stave_y /2., 0.);
-
-      G4RotationMatrix* stv_rot_neg = new G4RotationMatrix();
-      stv_rot_neg->rotateZ(+15. * M_PI / 180.);
-      G4ThreeVector stvTransneg(stave_x / 2., -stave_y /2., 0.);
-
-      G4VSolid* stave_basebox = new G4Box((boost::format("stave_basebox_%d_%d") % inttlayer % itype).str(), stave_x / 2., stave_y / 2., stave_z / 2.);
-      G4VSolid* stave_subtbox = new G4Box((boost::format("stave_subtbox_%d_%d") % inttlayer % itype ).str(),stave_x / 1.5, stave_y / 1.5, stave_z / 1.); // has to be longer in z to avoid coincident surface
-
-      G4VSolid *stave_box1 = new G4SubtractionSolid((boost::format("stave_box1_%d_%d") % inttlayer % itype).str(), stave_basebox, stave_subtbox, stv_rot_pos, stvTranspos);
-
-      G4VSolid *stave_box = new G4SubtractionSolid((boost::format("stave_box_%d_%d") % inttlayer % itype).str(), stave_box1, stave_subtbox, stv_rot_neg, stvTransneg);
-
-      stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_AIR"),
-                                        (boost::format("stave_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-
-      G4VSolid* staveext_basebox = new G4Box((boost::format("staveext_basebox_%d_%d") % inttlayer % itype).str(), stave_x / 2., stave_y / 2., hdiext_z / 2.);
-      G4VSolid* staveext_subtbox = new G4Box((boost::format("staveext_subtbox_%d_%d") % inttlayer % itype ).str(),stave_x / 1.5, stave_y / 1.5, hdiext_z / 1.); // has to be longer in z to avoid coincident surface
-
-      G4VSolid *staveext_box1 = new G4SubtractionSolid((boost::format("staveext_box1_%d_%d") % inttlayer % itype).str(), staveext_basebox, staveext_subtbox, stv_rot_pos, stvTranspos);
-
-      G4VSolid *staveext_box = new G4SubtractionSolid((boost::format("staveext_box_%d_%d") % inttlayer % itype).str(), staveext_box1, staveext_subtbox, stv_rot_neg, stvTransneg);
-
-      staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"),
-                                           (boost::format("staveext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-// the rotation matrices are just used by G4VSolid, ownership is not taken over
-      delete stv_rot_pos;
-      delete stv_rot_neg;
-
-      m_DisplayAction->AddVolume(stave_volume,"StaveBox");
-      m_DisplayAction->AddVolume(staveext_volume,"StaveBox");
-
-      // Assemble the elements into the stave volume and the stave extension volume
-      // They are place relative to the center of the stave box. Thus the offset of the center of the segment is relative to the center of the satev box.
-      // But we want the segment to be located relative to the lowest x limit of the stave box.
-      if (laddertype == PHG4InttDefs::SEGMENTATION_Z) // Obsolete!!
-      {
-        // only one cooling tube in laddertype 0
-        // Place the straight sections. We add the middle, then above x axis, then below x axis
-        double x_off_str[3] =
-            {
-                Rcavge - stave_x / 2.,
-                (Rcmax - Rcmin) / 2. - stave_x / 2.,
-                (Rcmax - Rcmin) / 2. - stave_x / 2.};
-        double y_off_str[3] =
-            {
-                0.0,
-                +stave_straight_cooler_y / 2. + 2. * curve_length_y + stave_straight_outer_y / 2.,
-                -stave_straight_cooler_y / 2. - 2. * curve_length_y - stave_straight_outer_y / 2.};
-
-        for (int i = 0; i < 3; i++)
-        {
-          if (i == 0)
-          {
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume,
-                              (boost::format("stave_straight_cooler_%d_%d_%d") % i % inttlayer % itype).str(), stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume,
-                              (boost::format("stave_straight_cooler_ext_%d_%d_%d") % i % inttlayer % itype).str(), staveext_volume, false, 0, OverlapCheck());
-          }
-          else
-          {
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume,
-                              (boost::format("stave_straight_outer_%d_%d_%d") % i % inttlayer % itype).str(), stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume,
-                              (boost::format("stave_straight_outer_ext_%d_%d_%d") % i % inttlayer % itype).str(), staveext_volume, false, 0, OverlapCheck());
-          }
-        }
-        // The cooler curved sections are made using 2 curved sections in a recurve on each side of the cooler straight section
-        // The tube sections used here have the origin of their volume at their center of rotation. Rcavge
-        //      Each curve section is moved to the center of the stave volume by a translation of +/- Rcavge
-        //      Then it is moved to the outside or the inside of the stave volume by a translation of +/-  cooler_gap_x / 2.
-        // we start at lowest y and work up in y
-
-        double x_off_cooler[4] =
-            {
-                Rcavge - cooler_gap_x / 2.,
-                -Rcavge + cooler_gap_x / 2.,
-                -Rcavge + cooler_gap_x / 2.,
-                Rcavge - cooler_gap_x / 2.};
-        double y_off_cooler[4] =
-            {
-                -stave_straight_cooler_y / 2. - 2. * curve_length_y,
-                -stave_straight_cooler_y / 2.,                
-                +stave_straight_cooler_y / 2.,                
-                +stave_straight_cooler_y / 2. + 2. * curve_length_y};
-
-        for (int i = 0; i < 4; i++)
-        {
-          new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_volume[i],
-                            (boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
-          new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_ext_volume[i],
-                            (boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
-        }
-      }
-      else if (laddertype == PHG4InttDefs::SEGMENTATION_PHI)  // The type PHG4InttDefs::SEGMENTATION_PHI ladder
-      {
-        // First place the straight sections, do the extension at the same time
-        // we alternate  positive and negative y values here
-        double x_off_str[5] =
-            {
-                (Rcmax + Rcmin) / 2. - stave_x / 2.,  // inner straight section // against the PGS
-                (Rcmax + Rcmax) / 4. - stave_x / 2.,  // slant section
-                (Rcmax + Rcmax) / 4. - stave_x / 2.,  // slant section
-                (Rcmax - Rcmin) / 2. - stave_x / 2.,  // outer straight section
-                (Rcmax - Rcmin) / 2. - stave_x / 2.   // outer straight section
-            };
-        double y_off_str[5] =
-            {
-                0.0,  // inner straight section
-                -stave_straight_cooler_y / 2. -1. * curve_length_y  - cos(dphi_c) * stave_slant_cooler_y / 2.,  // slant section
-                +stave_straight_cooler_y / 2. +1. * curve_length_y  + cos(dphi_c) * stave_slant_cooler_y / 2.,  // slant section
-                -stave_straight_cooler_y / 2. -2. * curve_length_y  - cos(dphi_c) * stave_slant_cooler_y - stave_straight_outer_y / 2.,  // outer straight section
-                +stave_straight_cooler_y / 2. +2. * curve_length_y  + cos(dphi_c) * stave_slant_cooler_y + stave_straight_outer_y / 2.   // outer straight section
-            };
-
-        for (int i = 0; i < 5; i++)
-        {
-          if (i == 0) // inner straight section
-          {
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume,
-                              (boost::format("stave_straight_cooler_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume,
-                              (boost::format("stave_straight_cooler_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
-          }
-          else if (i == 1 || i == 2) // slant section
-          {
-            G4RotationMatrix rotation;
-            if(i==1)     rotation.rotateZ(-1.*dphi_c);
-            else if(i==2)rotation.rotateZ(dphi_c);
-            new G4PVPlacement(G4Transform3D(rotation,G4ThreeVector(x_off_str[i], y_off_str[i], 0.0)), stave_slant_cooler_volume,
-                              (boost::format("stave_slant_cooler_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(G4Transform3D(rotation,G4ThreeVector(x_off_str[i], y_off_str[i], 0.0)), stave_slant_cooler_ext_volume,
-                              (boost::format("stave_slant_cooler_ext_%d_%d_%d") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
-          }
-          else // outer straight section
-          {
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume,
-                              (boost::format("stave_straight_outer_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume,
-                              (boost::format("stave_straight_outer_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
-          }
+                                                           (boost::format("rohacellext_trap_volume_%d_%d_%d") % inttlayer % itype % i).str(), 0, 0, 0);
         }
 
-        //// Place the curved sections
-        //// here we do in order of increasing y
-
-        double x_off_curve[4] =
-            {
-                // increasing in y
-                +Rcavge - cooler_gap_x / 2.,
-                -Rcavge + cooler_gap_x / 2.,
-                -Rcavge + cooler_gap_x / 2.,
-                +Rcavge - cooler_gap_x / 2.};
-        double y_off_curve[4] =
-            {
-                // increasing in y
-                 -stave_straight_cooler_y / 2. - 2. * curve_length_y - cos(dphi_c) * stave_slant_cooler_y,
-                 -stave_straight_cooler_y / 2., 
-                 +stave_straight_cooler_y / 2.,
-                 +stave_straight_cooler_y / 2. + 2. * curve_length_y + cos(dphi_c) * stave_slant_cooler_y};
-
-        for (int i = 0; i < 4; i++)
-        {
-          new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_volume[i], (boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
-          new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_ext_volume[i], (boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
-        }
-
-        // Place the rohacell foam
-        // straight box section
-        double x_off_roha_str[2] =
-            {
-                // increasing in y
-                -cooler_wall / 2.,
-                -cooler_wall / 2.
-            };
-        double y_off_roha_str[2] =
-            {
-                // increasing in y
-                -3. / 2. - rohacell_straight_y / 2.,
-                +3. / 2. + rohacell_straight_y / 2.
-            };
-
+        m_DisplayAction->AddVolume(rohacell_straight_volume, "RohaCell");
+        m_DisplayAction->AddVolume(rohacellext_straight_volume, "RohaCell");
         for (int i = 0; i < 2; i++)
         {
-            new G4PVPlacement(0, G4ThreeVector(x_off_roha_str[i] , y_off_roha_str[i] , 0.0), rohacell_straight_volume   , (boost::format("rohacell_straight_%d_%d_%d") % inttlayer % itype % i).str()    , stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_roha_str[i] , y_off_roha_str[i] , 0.0), rohacellext_straight_volume, (boost::format("rohacell_straight_ext_%d_%d_%d") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+          m_DisplayAction->AddVolume(rohacell_curve_volume[i], "RohaCell");
+          m_DisplayAction->AddVolume(rohacellext_curve_volume[i], "RohaCell");
+          m_DisplayAction->AddVolume(rohacell_trap_volume[i], "RohaCell");
+          m_DisplayAction->AddVolume(rohacellext_trap_volume[i], "RohaCell");
         }
 
-        //// curve section
-        double x_off_roha_curve[2] =
-            {
-                // increasing in y
-                -Rcavge + cooler_gap_x / 2.,
-                -Rcavge + cooler_gap_x / 2. 
-            };
-        double y_off_roha_curve[2] =
-            {
-                // increasing in y
-                -3. / 2. - rohacell_straight_y,
-                +3. / 2. + rohacell_straight_y
-            };
+        // Now we combine the elements of a stave defined above into a stave
+        // Create a stave volume to install the stave sections into. The volume has to be big enouigh to contain the cooling tube
+        double cooler_gap_x = 0.3 * cm;     // id of cooling tube in cm
+        double cooler_wall = 0.01905 * cm;  // outer wall thickness of cooling tube
+        double cooler_x = cooler_gap_x + cooler_wall;
+        stave_x = cooler_x;  // we do not include the PGS in the stave volume
+        stave_y = hdi_y;
 
-        for (int i = 0; i < 2; i++)
+        // Make stave volume. Drop two corners in positive x to prevent ladder_volume overlapping
+        // with neighbouring ladders because of small clearance in the latest configuration
+        G4RotationMatrix *stv_rot_pos = new G4RotationMatrix();
+        stv_rot_pos->rotateZ(-15. * M_PI / 180.);
+        G4ThreeVector stvTranspos(stave_x / 2., stave_y / 2., 0.);
+
+        G4RotationMatrix *stv_rot_neg = new G4RotationMatrix();
+        stv_rot_neg->rotateZ(+15. * M_PI / 180.);
+        G4ThreeVector stvTransneg(stave_x / 2., -stave_y / 2., 0.);
+
+        G4VSolid *stave_basebox = new G4Box((boost::format("stave_basebox_%d_%d") % inttlayer % itype).str(), stave_x / 2., stave_y / 2., stave_z / 2.);
+        G4VSolid *stave_subtbox = new G4Box((boost::format("stave_subtbox_%d_%d") % inttlayer % itype).str(), stave_x / 1.5, stave_y / 1.5, stave_z / 1.);  // has to be longer in z to avoid coincident surface
+
+        G4VSolid *stave_box1 = new G4SubtractionSolid((boost::format("stave_box1_%d_%d") % inttlayer % itype).str(), stave_basebox, stave_subtbox, stv_rot_pos, stvTranspos);
+
+        G4VSolid *stave_box = new G4SubtractionSolid((boost::format("stave_box_%d_%d") % inttlayer % itype).str(), stave_box1, stave_subtbox, stv_rot_neg, stvTransneg);
+
+        stave_volume = new G4LogicalVolume(stave_box, G4Material::GetMaterial("G4_AIR"),
+                                           (boost::format("stave_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+
+        G4VSolid *staveext_basebox = new G4Box((boost::format("staveext_basebox_%d_%d") % inttlayer % itype).str(), stave_x / 2., stave_y / 2., hdiext_z / 2.);
+        G4VSolid *staveext_subtbox = new G4Box((boost::format("staveext_subtbox_%d_%d") % inttlayer % itype).str(), stave_x / 1.5, stave_y / 1.5, hdiext_z / 1.);  // has to be longer in z to avoid coincident surface
+
+        G4VSolid *staveext_box1 = new G4SubtractionSolid((boost::format("staveext_box1_%d_%d") % inttlayer % itype).str(), staveext_basebox, staveext_subtbox, stv_rot_pos, stvTranspos);
+
+        G4VSolid *staveext_box = new G4SubtractionSolid((boost::format("staveext_box_%d_%d") % inttlayer % itype).str(), staveext_box1, staveext_subtbox, stv_rot_neg, stvTransneg);
+
+        staveext_volume = new G4LogicalVolume(staveext_box, G4Material::GetMaterial("G4_AIR"),
+                                              (boost::format("staveext_volume_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
+        // the rotation matrices are just used by G4VSolid, ownership is not taken over
+        delete stv_rot_pos;
+        delete stv_rot_neg;
+
+        m_DisplayAction->AddVolume(stave_volume, "StaveBox");
+        m_DisplayAction->AddVolume(staveext_volume, "StaveBox");
+
+        // Assemble the elements into the stave volume and the stave extension volume
+        // They are place relative to the center of the stave box. Thus the offset of the center of the segment is relative to the center of the satev box.
+        // But we want the segment to be located relative to the lowest x limit of the stave box.
+        if (laddertype == PHG4InttDefs::SEGMENTATION_Z)  // Obsolete!!
         {
-            new G4PVPlacement(0, G4ThreeVector(x_off_roha_curve[i] , y_off_roha_curve[i] , 0.0), rohacell_curve_volume[i]   , (boost::format("rohacell_curve_%d_%d_%d") % inttlayer % itype % i).str()    , stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_roha_curve[i] , y_off_roha_curve[i] , 0.0), rohacellext_curve_volume[i]   , (boost::format("rohacell_curve_ext_%d_%d_%d") % inttlayer % itype % i).str()    , staveext_volume, false, 0, OverlapCheck());
+          // only one cooling tube in laddertype 0
+          // Place the straight sections. We add the middle, then above x axis, then below x axis
+          double x_off_str[3] =
+              {
+                  Rcavge - stave_x / 2.,
+                  (Rcmax - Rcmin) / 2. - stave_x / 2.,
+                  (Rcmax - Rcmin) / 2. - stave_x / 2.};
+          double y_off_str[3] =
+              {
+                  0.0,
+                  +stave_straight_cooler_y / 2. + 2. * curve_length_y + stave_straight_outer_y / 2.,
+                  -stave_straight_cooler_y / 2. - 2. * curve_length_y - stave_straight_outer_y / 2.};
+
+          for (int i = 0; i < 3; i++)
+          {
+            if (i == 0)
+            {
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume,
+                                (boost::format("stave_straight_cooler_%d_%d_%d") % i % inttlayer % itype).str(), stave_volume, false, 0, OverlapCheck());
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume,
+                                (boost::format("stave_straight_cooler_ext_%d_%d_%d") % i % inttlayer % itype).str(), staveext_volume, false, 0, OverlapCheck());
+            }
+            else
+            {
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume,
+                                (boost::format("stave_straight_outer_%d_%d_%d") % i % inttlayer % itype).str(), stave_volume, false, 0, OverlapCheck());
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume,
+                                (boost::format("stave_straight_outer_ext_%d_%d_%d") % i % inttlayer % itype).str(), staveext_volume, false, 0, OverlapCheck());
+            }
+          }
+          // The cooler curved sections are made using 2 curved sections in a recurve on each side of the cooler straight section
+          // The tube sections used here have the origin of their volume at their center of rotation. Rcavge
+          //      Each curve section is moved to the center of the stave volume by a translation of +/- Rcavge
+          //      Then it is moved to the outside or the inside of the stave volume by a translation of +/-  cooler_gap_x / 2.
+          // we start at lowest y and work up in y
+
+          double x_off_cooler[4] =
+              {
+                  Rcavge - cooler_gap_x / 2.,
+                  -Rcavge + cooler_gap_x / 2.,
+                  -Rcavge + cooler_gap_x / 2.,
+                  Rcavge - cooler_gap_x / 2.};
+          double y_off_cooler[4] =
+              {
+                  -stave_straight_cooler_y / 2. - 2. * curve_length_y,
+                  -stave_straight_cooler_y / 2.,
+                  +stave_straight_cooler_y / 2.,
+                  +stave_straight_cooler_y / 2. + 2. * curve_length_y};
+
+          for (int i = 0; i < 4; i++)
+          {
+            new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_volume[i],
+                              (boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_cooler[i], y_off_cooler[i], 0.0), stave_curve_ext_volume[i],
+                              (boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+          }
         }
-
-        // trapezoidal section
-        double x_off_roha_trap[2] =
-            {
-                // increasing in y
-                -Rcmin -cooler_wall / 2. + cooler_gap_x / 2.,
-                -Rcmin -cooler_wall / 2. + cooler_gap_x / 2.
-            };
-        double y_off_roha_trap[2] =
-            {
-                // increasing in y
-                -3. / 2. - rohacell_straight_y,
-                +3. / 2. + rohacell_straight_y
-            };
-
-        for (int i = 0; i < 2; i++)
+        else if (laddertype == PHG4InttDefs::SEGMENTATION_PHI)  // The type PHG4InttDefs::SEGMENTATION_PHI ladder
         {
-            new G4PVPlacement(0, G4ThreeVector(x_off_roha_trap[i] , y_off_roha_trap[i] , 0.0), rohacell_trap_volume[i]   , (boost::format("rohacell_trap_%d_%d_%d") % inttlayer % itype % i).str()    , stave_volume, false, 0, OverlapCheck());
-            new G4PVPlacement(0, G4ThreeVector(x_off_roha_trap[i] , y_off_roha_trap[i] , 0.0), rohacellext_trap_volume[i]   , (boost::format("rohacell_trap_ext_%d_%d_%d") % inttlayer % itype % i).str()    , staveext_volume, false, 0, OverlapCheck());
+          // First place the straight sections, do the extension at the same time
+          // we alternate  positive and negative y values here
+          double x_off_str[5] =
+              {
+                  (Rcmax + Rcmin) / 2. - stave_x / 2.,  // inner straight section // against the PGS
+                  (Rcmax + Rcmax) / 4. - stave_x / 2.,  // slant section
+                  (Rcmax + Rcmax) / 4. - stave_x / 2.,  // slant section
+                  (Rcmax - Rcmin) / 2. - stave_x / 2.,  // outer straight section
+                  (Rcmax - Rcmin) / 2. - stave_x / 2.   // outer straight section
+              };
+          double y_off_str[5] =
+              {
+                  0.0,                                                                                                                     // inner straight section
+                  -stave_straight_cooler_y / 2. - 1. * curve_length_y - cos(dphi_c) * stave_slant_cooler_y / 2.,                           // slant section
+                  +stave_straight_cooler_y / 2. + 1. * curve_length_y + cos(dphi_c) * stave_slant_cooler_y / 2.,                           // slant section
+                  -stave_straight_cooler_y / 2. - 2. * curve_length_y - cos(dphi_c) * stave_slant_cooler_y - stave_straight_outer_y / 2.,  // outer straight section
+                  +stave_straight_cooler_y / 2. + 2. * curve_length_y + cos(dphi_c) * stave_slant_cooler_y + stave_straight_outer_y / 2.   // outer straight section
+              };
+
+          for (int i = 0; i < 5; i++)
+          {
+            if (i == 0)  // inner straight section
+            {
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_volume,
+                                (boost::format("stave_straight_cooler_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_cooler_ext_volume,
+                                (boost::format("stave_straight_cooler_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+            }
+            else if (i == 1 || i == 2)  // slant section
+            {
+              G4RotationMatrix rotation;
+              if (i == 1)
+                rotation.rotateZ(-1. * dphi_c);
+              else if (i == 2)
+                rotation.rotateZ(dphi_c);
+              new G4PVPlacement(G4Transform3D(rotation, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0)), stave_slant_cooler_volume,
+                                (boost::format("stave_slant_cooler_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+              new G4PVPlacement(G4Transform3D(rotation, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0)), stave_slant_cooler_ext_volume,
+                                (boost::format("stave_slant_cooler_ext_%d_%d_%d") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+            }
+            else  // outer straight section
+            {
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_volume,
+                                (boost::format("stave_straight_outer_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+              new G4PVPlacement(0, G4ThreeVector(x_off_str[i], y_off_str[i], 0.0), stave_straight_outer_ext_volume,
+                                (boost::format("stave_straight_outer_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+            }
+          }
+
+          //// Place the curved sections
+          //// here we do in order of increasing y
+
+          double x_off_curve[4] =
+              {
+                  // increasing in y
+                  +Rcavge - cooler_gap_x / 2.,
+                  -Rcavge + cooler_gap_x / 2.,
+                  -Rcavge + cooler_gap_x / 2.,
+                  +Rcavge - cooler_gap_x / 2.};
+          double y_off_curve[4] =
+              {
+                  // increasing in y
+                  -stave_straight_cooler_y / 2. - 2. * curve_length_y - cos(dphi_c) * stave_slant_cooler_y,
+                  -stave_straight_cooler_y / 2.,
+                  +stave_straight_cooler_y / 2.,
+                  +stave_straight_cooler_y / 2. + 2. * curve_length_y + cos(dphi_c) * stave_slant_cooler_y};
+
+          for (int i = 0; i < 4; i++)
+          {
+            new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_volume[i], (boost::format("stave_curve_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_curve[i], y_off_curve[i], 0.0), stave_curve_ext_volume[i], (boost::format("stave_curve_ext_%d_%d_%s") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+          }
+
+          // Place the rohacell foam
+          // straight box section
+          double x_off_roha_str[2] =
+              {
+                  // increasing in y
+                  -cooler_wall / 2.,
+                  -cooler_wall / 2.};
+          double y_off_roha_str[2] =
+              {
+                  // increasing in y
+                  -3. / 2. - rohacell_straight_y / 2.,
+                  +3. / 2. + rohacell_straight_y / 2.};
+
+          for (int i = 0; i < 2; i++)
+          {
+            new G4PVPlacement(0, G4ThreeVector(x_off_roha_str[i], y_off_roha_str[i], 0.0), rohacell_straight_volume, (boost::format("rohacell_straight_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_roha_str[i], y_off_roha_str[i], 0.0), rohacellext_straight_volume, (boost::format("rohacell_straight_ext_%d_%d_%d") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+          }
+
+          //// curve section
+          double x_off_roha_curve[2] =
+              {
+                  // increasing in y
+                  -Rcavge + cooler_gap_x / 2.,
+                  -Rcavge + cooler_gap_x / 2.};
+          double y_off_roha_curve[2] =
+              {
+                  // increasing in y
+                  -3. / 2. - rohacell_straight_y,
+                  +3. / 2. + rohacell_straight_y};
+
+          for (int i = 0; i < 2; i++)
+          {
+            new G4PVPlacement(0, G4ThreeVector(x_off_roha_curve[i], y_off_roha_curve[i], 0.0), rohacell_curve_volume[i], (boost::format("rohacell_curve_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_roha_curve[i], y_off_roha_curve[i], 0.0), rohacellext_curve_volume[i], (boost::format("rohacell_curve_ext_%d_%d_%d") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+          }
+
+          // trapezoidal section
+          double x_off_roha_trap[2] =
+              {
+                  // increasing in y
+                  -Rcmin - cooler_wall / 2. + cooler_gap_x / 2.,
+                  -Rcmin - cooler_wall / 2. + cooler_gap_x / 2.};
+          double y_off_roha_trap[2] =
+              {
+                  // increasing in y
+                  -3. / 2. - rohacell_straight_y,
+                  +3. / 2. + rohacell_straight_y};
+
+          for (int i = 0; i < 2; i++)
+          {
+            new G4PVPlacement(0, G4ThreeVector(x_off_roha_trap[i], y_off_roha_trap[i], 0.0), rohacell_trap_volume[i], (boost::format("rohacell_trap_%d_%d_%d") % inttlayer % itype % i).str(), stave_volume, false, 0, OverlapCheck());
+            new G4PVPlacement(0, G4ThreeVector(x_off_roha_trap[i], y_off_roha_trap[i], 0.0), rohacellext_trap_volume[i], (boost::format("rohacell_trap_ext_%d_%d_%d") % inttlayer % itype % i).str(), staveext_volume, false, 0, OverlapCheck());
+          }
+
+          // place glue box, cooling pipe and water inside
+          new G4PVPlacement(0, G4ThreeVector(0.0, 0.0, 0.0), stave_pipe_volume, (boost::format("stave_pipe_%d_%d") % inttlayer % itype).str(), stave_glue_volume, false, 0, OverlapCheck());
+          new G4PVPlacement(0, G4ThreeVector(0.0, 0.0, 0.0), staveext_pipe_volume, (boost::format("stave_pipe_ext_%d_%d") % inttlayer % itype).str(), staveext_glue_volume, false, 0, OverlapCheck());
+          new G4PVPlacement(0, G4ThreeVector(0.0, 0.0, 0.0), stave_water_volume, (boost::format("stave_water_%d_%d") % inttlayer % itype).str(), stave_glue_volume, false, 0, OverlapCheck());
+          new G4PVPlacement(0, G4ThreeVector(0.0, 0.0, 0.0), staveext_water_volume, (boost::format("stave_water_ext_%d_%d") % inttlayer % itype).str(), staveext_glue_volume, false, 0, OverlapCheck());
+
+          new G4PVPlacement(0, G4ThreeVector(-cooler_wall / 2., 0.0, 0.0), stave_glue_volume, (boost::format("stave_glue_%d_%d") % inttlayer % itype).str(), stave_volume, false, 0, OverlapCheck());
+          new G4PVPlacement(0, G4ThreeVector(-cooler_wall / 2., 0.0, 0.0), staveext_glue_volume, (boost::format("stave_glue_ext_%d_%d") % inttlayer % itype).str(), staveext_volume, false, 0, OverlapCheck());
+        }
+        else
+        {
+          cout << PHWHERE << "invalid laddertype " << laddertype << endl;
+          gSystem->Exit(1);
         }
 
-      // place glue box, cooling pipe and water inside
-      new G4PVPlacement(0, G4ThreeVector(0.0, 0.0, 0.0), stave_pipe_volume    , (boost::format("stave_pipe_%d_%d") % inttlayer % itype ).str()    , stave_glue_volume, false, 0, OverlapCheck());
-      new G4PVPlacement(0, G4ThreeVector(0.0, 0.0, 0.0), staveext_pipe_volume , (boost::format("stave_pipe_ext_%d_%d") % inttlayer % itype ).str(), staveext_glue_volume, false, 0, OverlapCheck());
-      new G4PVPlacement(0, G4ThreeVector(0.0, 0.0, 0.0), stave_water_volume   , (boost::format("stave_water_%d_%d") % inttlayer % itype ).str()    , stave_glue_volume, false, 0, OverlapCheck());
-      new G4PVPlacement(0, G4ThreeVector(0.0, 0.0, 0.0), staveext_water_volume, (boost::format("stave_water_ext_%d_%d") % inttlayer % itype ).str(), staveext_glue_volume, false, 0, OverlapCheck());
-      
-      new G4PVPlacement(0, G4ThreeVector(-cooler_wall / 2., 0.0, 0.0), stave_glue_volume   , (boost::format("stave_glue_%d_%d") % inttlayer % itype ).str()    , stave_volume, false, 0, OverlapCheck());
-      new G4PVPlacement(0, G4ThreeVector(-cooler_wall / 2., 0.0, 0.0), staveext_glue_volume, (boost::format("stave_glue_ext_%d_%d") % inttlayer % itype ).str(), staveext_volume, false, 0, OverlapCheck());
-
-      }
-      else
-      {
-        cout << PHWHERE << "invalid laddertype " << laddertype << endl;
-        gSystem->Exit(1);
-      }
-
-      } //stave type 1 
+      }  //stave type 1
       else
       {
         cout << PHWHERE << "invalid stavetype " << params->get_int_param("carbon_stave_type") << endl;
@@ -1161,16 +1156,16 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
       double ladder_y = hdi_y;
 
       // Make ladder volume. Drop two corners in positive x as done for stave volume
-      G4RotationMatrix* lad_box_rotpos = new G4RotationMatrix();
+      G4RotationMatrix *lad_box_rotpos = new G4RotationMatrix();
       lad_box_rotpos->rotateZ(-15. * M_PI / 180.);
-      G4ThreeVector ladTranspos(ladder_x / 2., ladder_y /2., 0.);
+      G4ThreeVector ladTranspos(ladder_x / 2., ladder_y / 2., 0.);
 
-      G4RotationMatrix* lad_box_rotneg = new G4RotationMatrix();
+      G4RotationMatrix *lad_box_rotneg = new G4RotationMatrix();
       lad_box_rotneg->rotateZ(+15. * M_PI / 180.);
-      G4ThreeVector ladTransneg(ladder_x / 2., -ladder_y /2., 0.);
+      G4ThreeVector ladTransneg(ladder_x / 2., -ladder_y / 2., 0.);
 
-      G4VSolid* ladder_basebox = new G4Box((boost::format("ladder_basebox_%d_%d") % inttlayer % itype).str(), ladder_x / 2., ladder_y / 2., hdi_z / 2.);
-      G4VSolid* ladder_subtbox = new G4Box((boost::format("ladder_subtbox_%d_%d") % inttlayer % itype ).str(), stave_x / 1.5, ladder_y / 1.5, hdi_z / 1.); // has to be longer in z to avoid coincident surface
+      G4VSolid *ladder_basebox = new G4Box((boost::format("ladder_basebox_%d_%d") % inttlayer % itype).str(), ladder_x / 2., ladder_y / 2., hdi_z / 2.);
+      G4VSolid *ladder_subtbox = new G4Box((boost::format("ladder_subtbox_%d_%d") % inttlayer % itype).str(), stave_x / 1.5, ladder_y / 1.5, hdi_z / 1.);  // has to be longer in z to avoid coincident surface
 
       G4VSolid *ladder_box1 = new G4SubtractionSolid((boost::format("ladder_box1_%d_%d") % inttlayer % itype).str(), ladder_basebox, ladder_subtbox, lad_box_rotpos, ladTranspos);
 
@@ -1178,19 +1173,19 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
 
       G4LogicalVolume *ladder_volume = new G4LogicalVolume(ladder_box, G4Material::GetMaterial("G4_AIR"), (boost::format("ladder_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
 
-      G4VSolid* ladderext_basebox = new G4Box((boost::format("ladderext_basebox_%d_%d") % inttlayer % itype).str(), ladder_x / 2., ladder_y / 2., hdiext_z / 2.);
-      G4VSolid* ladderext_subtbox = new G4Box((boost::format("ladderext_subtbox_%d_%d") % inttlayer % itype ).str(), stave_x / 1.5, ladder_y / 1.5, hdiext_z / 1.); // has to be longer in z to avoid coincident surface
+      G4VSolid *ladderext_basebox = new G4Box((boost::format("ladderext_basebox_%d_%d") % inttlayer % itype).str(), ladder_x / 2., ladder_y / 2., hdiext_z / 2.);
+      G4VSolid *ladderext_subtbox = new G4Box((boost::format("ladderext_subtbox_%d_%d") % inttlayer % itype).str(), stave_x / 1.5, ladder_y / 1.5, hdiext_z / 1.);  // has to be longer in z to avoid coincident surface
 
       G4VSolid *ladderext_box1 = new G4SubtractionSolid((boost::format("ladderext_box1_%d_%d") % inttlayer % itype).str(), ladderext_basebox, ladderext_subtbox, lad_box_rotpos, ladTranspos);
 
       G4VSolid *ladderext_box = new G4SubtractionSolid((boost::format("ladderext_box_%d_%d") % inttlayer % itype).str(), ladderext_box1, ladderext_subtbox, lad_box_rotneg, ladTransneg);
 
       G4LogicalVolume *ladderext_volume = new G4LogicalVolume(ladderext_box, G4Material::GetMaterial("G4_AIR"), (boost::format("ladderext_%d_%d") % inttlayer % itype).str(), 0, 0, 0);
-// the rotation matrices are just used by G4VSolid, ownership is not taken over
+      // the rotation matrices are just used by G4VSolid, ownership is not taken over
       delete lad_box_rotpos;
       delete lad_box_rotneg;
-      m_DisplayAction->AddVolume(ladder_volume,"Ladder");
-      m_DisplayAction->AddVolume(ladderext_volume,"Ladder");
+      m_DisplayAction->AddVolume(ladder_volume, "Ladder");
+      m_DisplayAction->AddVolume(ladderext_volume, "Ladder");
 
       // Now add the components of the ladder to the ladder volume
       // The sensor is closest to the beam pipe, the stave cooler is furthest away
@@ -1297,12 +1292,12 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
 
         // this placement version rotates the ladder in its own frame by fRotate, then translates the center to posx, posy, +/- m_PosZ
         auto pointer_negz = new G4PVPlacement(G4Transform3D(ladderrotation, G4ThreeVector(posx, posy, -m_PosZ[inttlayer][itype])), ladder_volume,
-                                            (boost::format("ladder_%d_%d_%d_negz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
+                                              (boost::format("ladder_%d_%d_%d_negz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
         auto pointer_posz = new G4PVPlacement(G4Transform3D(ladderrotation, G4ThreeVector(posx, posy, +m_PosZ[inttlayer][itype])), ladder_volume,
                                               (boost::format("ladder_%d_%d_%d_posz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
         if (m_IsActiveMap.find(inttlayer) != m_IsActiveMap.end())
         {
-        m_ActiveVolumeTuple.insert(make_pair(pointer_negz, make_tuple(inttlayer, itype, icopy, -1)));
+          m_ActiveVolumeTuple.insert(make_pair(pointer_negz, make_tuple(inttlayer, itype, icopy, -1)));
           m_ActiveVolumeTuple.insert(make_pair(pointer_posz, make_tuple(inttlayer, itype, icopy, 1)));
         }
 
@@ -1314,10 +1309,10 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
           // We have added the outer sensor above, now we add the HDI extension tab to the end of the outer sensor HDI
           const double posz_ext = (hdi_z_arr[inttlayer][0] + hdi_z) + hdiext_z / 2.;
 
-           new G4PVPlacement(G4Transform3D(ladderrotation, G4ThreeVector(posx, posy, -posz_ext)), ladderext_volume,
-                             (boost::format("ladderext_%d_%d_%d_negz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
-           new G4PVPlacement(G4Transform3D(ladderrotation, G4ThreeVector(posx, posy, +posz_ext)), ladderext_volume,
-                             (boost::format("ladderext_%d_%d_%d_posz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
+          new G4PVPlacement(G4Transform3D(ladderrotation, G4ThreeVector(posx, posy, -posz_ext)), ladderext_volume,
+                            (boost::format("ladderext_%d_%d_%d_negz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
+          new G4PVPlacement(G4Transform3D(ladderrotation, G4ThreeVector(posx, posy, +posz_ext)), ladderext_volume,
+                            (boost::format("ladderext_%d_%d_%d_posz") % inttlayer % itype % icopy).str(), trackerenvelope, false, 0, OverlapCheck());
         }
 
         if (Verbosity() > 100)
@@ -1354,7 +1349,7 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
   {
     m_PassiveVolumeTuple.insert(make_pair(rail_volume, make_tuple(PHG4InttDefs::SUPPORT_DETID, PHG4InttDefs::SUPPORT_RAIL)));
   }
-  m_DisplayAction->AddVolume(rail_volume,"Rail");
+  m_DisplayAction->AddVolume(rail_volume, "Rail");
 
   double rail_dphi = supportparams->get_double_param("rail_dphi") * deg / rad;
   double rail_phi_start = supportparams->get_double_param("rail_phi_start") * deg / rad;
@@ -1373,37 +1368,37 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
 
   // Outer skin
   G4Tubs *outer_skin_cfcin_tube = new G4Tubs("si_outer_skin_cfcin",
-                                       supportparams->get_double_param("outer_skin_cfcin_inner_radius") * cm,
-                                       supportparams->get_double_param("outer_skin_cfcin_outer_radius") * cm,
-                                       supportparams->get_double_param("outer_skin_cfcin_length") * cm / 2.,
-                                       -M_PI, 2.0 * M_PI);
+                                             supportparams->get_double_param("outer_skin_cfcin_inner_radius") * cm,
+                                             supportparams->get_double_param("outer_skin_cfcin_outer_radius") * cm,
+                                             supportparams->get_double_param("outer_skin_cfcin_length") * cm / 2.,
+                                             -M_PI, 2.0 * M_PI);
   G4LogicalVolume *outer_skin_cfcin_volume = new G4LogicalVolume(outer_skin_cfcin_tube, G4Material::GetMaterial("CFRP_INTT"),
-                                                           "outer_skin_cfcin_volume", 0, 0, 0);
+                                                                 "outer_skin_cfcin_volume", 0, 0, 0);
 
   G4Tubs *outer_skin_foam_tube = new G4Tubs("si_outer_skin_foam",
-                                       supportparams->get_double_param("outer_skin_foam_inner_radius") * cm,
-                                       supportparams->get_double_param("outer_skin_foam_outer_radius") * cm,
-                                       supportparams->get_double_param("outer_skin_foam_length") * cm / 2.,
-                                       -M_PI, 2.0 * M_PI);
+                                            supportparams->get_double_param("outer_skin_foam_inner_radius") * cm,
+                                            supportparams->get_double_param("outer_skin_foam_outer_radius") * cm,
+                                            supportparams->get_double_param("outer_skin_foam_length") * cm / 2.,
+                                            -M_PI, 2.0 * M_PI);
   G4LogicalVolume *outer_skin_foam_volume = new G4LogicalVolume(outer_skin_foam_tube, G4Material::GetMaterial("ROHACELL_FOAM_110"),
-                                                           "outer_skin_foam_volume", 0, 0, 0);
+                                                                "outer_skin_foam_volume", 0, 0, 0);
 
   G4Tubs *outer_skin_cfcout_tube = new G4Tubs("si_outer_skin_cfcout",
-                                       supportparams->get_double_param("outer_skin_cfcout_inner_radius") * cm,
-                                       supportparams->get_double_param("outer_skin_cfcout_outer_radius") * cm,
-                                       supportparams->get_double_param("outer_skin_cfcout_length") * cm / 2.,
-                                       -M_PI, 2.0 * M_PI);
+                                              supportparams->get_double_param("outer_skin_cfcout_inner_radius") * cm,
+                                              supportparams->get_double_param("outer_skin_cfcout_outer_radius") * cm,
+                                              supportparams->get_double_param("outer_skin_cfcout_length") * cm / 2.,
+                                              -M_PI, 2.0 * M_PI);
   G4LogicalVolume *outer_skin_cfcout_volume = new G4LogicalVolume(outer_skin_cfcout_tube, G4Material::GetMaterial("CFRP_INTT"),
-                                                           "outer_skin_cfcout_volume", 0, 0, 0);
+                                                                  "outer_skin_cfcout_volume", 0, 0, 0);
   if (m_IsSupportActive > 0)
   {
     m_PassiveVolumeTuple.insert(make_pair(outer_skin_cfcin_volume, make_tuple(PHG4InttDefs::SUPPORT_DETID, PHG4InttDefs::INTT_OUTER_SKIN)));
     m_PassiveVolumeTuple.insert(make_pair(outer_skin_foam_volume, make_tuple(PHG4InttDefs::SUPPORT_DETID, PHG4InttDefs::INTT_OUTER_SKIN)));
     m_PassiveVolumeTuple.insert(make_pair(outer_skin_cfcout_volume, make_tuple(PHG4InttDefs::SUPPORT_DETID, PHG4InttDefs::INTT_OUTER_SKIN)));
   }
-  m_DisplayAction->AddVolume(outer_skin_cfcin_volume,"Rail");
-  m_DisplayAction->AddVolume(outer_skin_foam_volume,"Rail");
-  m_DisplayAction->AddVolume(outer_skin_cfcout_volume,"Rail");
+  m_DisplayAction->AddVolume(outer_skin_cfcin_volume, "Rail");
+  m_DisplayAction->AddVolume(outer_skin_foam_volume, "Rail");
+  m_DisplayAction->AddVolume(outer_skin_cfcout_volume, "Rail");
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), outer_skin_cfcin_volume,
                     "si_support_outer_skin_cfcin", trackerenvelope, false, 0, OverlapCheck());
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), outer_skin_foam_volume,
@@ -1424,22 +1419,22 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
   {
     m_PassiveVolumeTuple.insert(make_pair(inner_skin_volume, make_tuple(PHG4InttDefs::SUPPORT_DETID, PHG4InttDefs::INTT_INNER_SKIN)));
   }
-  m_DisplayAction->AddVolume(inner_skin_volume,"Rail");
+  m_DisplayAction->AddVolume(inner_skin_volume, "Rail");
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), inner_skin_volume,
                     "si_support_inner_skin", trackerenvelope, false, 0, OverlapCheck());
 
-  // Endcap ring in simulations = Endcap rings + endcap staves 
-  
+  // Endcap ring in simulations = Endcap rings + endcap staves
+
   // Aluminum ring
   G4Tubs *endcap_Al_ring = new G4Tubs("endcap_Al_ring",
-                                       supportparams->get_double_param("endcap_Alring_inner_radius") * cm,
-                                       supportparams->get_double_param("endcap_Alring_outer_radius") * cm,
-                                       supportparams->get_double_param("endcap_Alring_length") * cm / 2.,
-                                       -M_PI, 2.0 * M_PI);
+                                      supportparams->get_double_param("endcap_Alring_inner_radius") * cm,
+                                      supportparams->get_double_param("endcap_Alring_outer_radius") * cm,
+                                      supportparams->get_double_param("endcap_Alring_length") * cm / 2.,
+                                      -M_PI, 2.0 * M_PI);
 
   G4LogicalVolume *endcap_Al_ring_volume = new G4LogicalVolume(endcap_Al_ring, G4Material::GetMaterial("Al6061T6"),
                                                                "endcap_Al_ring_volume", 0, 0, 0);
-  
+
   // Stainlees steal ring
   G4Tubs *endcap_SS_ring = new G4Tubs("endcap_SS_ring",
                                       supportparams->get_double_param("endcap_SSring_inner_radius") * cm,
@@ -1449,85 +1444,80 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
 
   G4LogicalVolume *endcap_SS_ring_volume = new G4LogicalVolume(endcap_SS_ring, G4Material::GetMaterial("SS316"),
                                                                "endcap_SS_ring_volume", 0, 0, 0);
-  
+
   // Water Glycol ring
   G4Tubs *endcap_WG_ring = new G4Tubs("endcap_WG_ring",
-                                       supportparams->get_double_param("endcap_WGring_inner_radius") * cm,
-                                       supportparams->get_double_param("endcap_WGring_outer_radius") * cm,
-                                       supportparams->get_double_param("endcap_WGring_length") * cm / 2.,
-                                       -M_PI, 2.0 * M_PI);
+                                      supportparams->get_double_param("endcap_WGring_inner_radius") * cm,
+                                      supportparams->get_double_param("endcap_WGring_outer_radius") * cm,
+                                      supportparams->get_double_param("endcap_WGring_length") * cm / 2.,
+                                      -M_PI, 2.0 * M_PI);
 
   G4LogicalVolume *endcap_WG_ring_volume = new G4LogicalVolume(endcap_WG_ring, G4Material::GetMaterial("WaterGlycol_INTT"),
                                                                "endcap_WG_ring_volume", 0, 0, 0);
   // Carbon PEEK ring
   G4Tubs *endcap_CP_ring = new G4Tubs("endcap_CP_ring",
-                                       supportparams->get_double_param("endcap_CPring_inner_radius") * cm,
-                                       supportparams->get_double_param("endcap_CPring_outer_radius") * cm,
-                                       supportparams->get_double_param("endcap_CPring_length") * cm / 2.,
-                                       -M_PI, 2.0 * M_PI);
+                                      supportparams->get_double_param("endcap_CPring_inner_radius") * cm,
+                                      supportparams->get_double_param("endcap_CPring_outer_radius") * cm,
+                                      supportparams->get_double_param("endcap_CPring_length") * cm / 2.,
+                                      -M_PI, 2.0 * M_PI);
 
   G4LogicalVolume *endcap_CP_ring_volume = new G4LogicalVolume(endcap_CP_ring, G4Material::GetMaterial("CF30_PEEK70"),
                                                                "endcap_CP_ring_volume", 0, 0, 0);
 
-   if(m_IsEndcapActive)
-   {
-     if(supportparams->get_int_param("endcap_ring_type")==0) // Place Al endcap rings
-     {
-       double endcap_ring_z = supportparams->get_double_param("endcap_ring_z") * cm; 
-       for(int i = 0; i < 2; i++) // i=0 : positive z, i=1 negative z
-       {
+  if (m_IsEndcapActive)
+  {
+    if (supportparams->get_int_param("endcap_ring_type") == 0)  // Place Al endcap rings
+    {
+      double endcap_ring_z = supportparams->get_double_param("endcap_ring_z") * cm;
+      for (int i = 0; i < 2; i++)  // i=0 : positive z, i=1 negative z
+      {
+        endcap_ring_z = (i == 0) ? endcap_ring_z : -1.0 * endcap_ring_z;
 
-         endcap_ring_z = (i==0) ?  endcap_ring_z : -1.0 * endcap_ring_z;
+        double width_WGring_z = supportparams->get_double_param("endcap_WGring_length") * cm;
+        double width_SSring_z = supportparams->get_double_param("endcap_SSring_length") * cm;
+        double width_Alring_z = supportparams->get_double_param("endcap_Alring_length") * cm;
 
-         double width_WGring_z = supportparams->get_double_param("endcap_WGring_length") * cm;
-         double width_SSring_z = supportparams->get_double_param("endcap_SSring_length") * cm;
-         double width_Alring_z = supportparams->get_double_param("endcap_Alring_length") * cm;
+        for (int j = 0; j < 2; j++)  // j=0 : positive side z, j=1 negative side z
+        {
+          width_WGring_z = (j == 0) ? width_WGring_z : -1.0 * width_WGring_z;
+          width_SSring_z = (j == 0) ? width_SSring_z : -1.0 * width_SSring_z;
+          width_Alring_z = (j == 0) ? width_Alring_z : -1.0 * width_Alring_z;
 
-         for(int j = 0; j < 2; j++) // j=0 : positive side z, j=1 negative side z
-         {
-           width_WGring_z = (j==0) ? width_WGring_z : -1.0 * width_WGring_z; 
-           width_SSring_z = (j==0) ? width_SSring_z : -1.0 * width_SSring_z;
-           width_Alring_z = (j==0) ? width_Alring_z : -1.0 * width_Alring_z;
+          double cent_WGring_z = endcap_ring_z + width_WGring_z / 2.;
+          double cent_SSring_z = endcap_ring_z + width_WGring_z + width_SSring_z / 2.;
+          double cent_Alring_z = endcap_ring_z + width_WGring_z + width_SSring_z + width_Alring_z / 2.;
 
-           double cent_WGring_z = endcap_ring_z + width_WGring_z / 2.;
-           double cent_SSring_z = endcap_ring_z + width_WGring_z + width_SSring_z / 2.;
-           double cent_Alring_z = endcap_ring_z + width_WGring_z + width_SSring_z + width_Alring_z / 2.;
+          new G4PVPlacement(0, G4ThreeVector(0, 0, cent_WGring_z),
+                            endcap_WG_ring_volume,
+                            (boost::format("endcap_WG_ring_pv_%d_%d") % i % j).str(),
+                            trackerenvelope, false, 0, OverlapCheck());
 
+          new G4PVPlacement(0, G4ThreeVector(0, 0, cent_SSring_z),
+                            endcap_SS_ring_volume,
+                            (boost::format("endcap_SS_ring_pv_%d_%d") % i % j).str(),
+                            trackerenvelope, false, 0, OverlapCheck());
 
-           new G4PVPlacement(0, G4ThreeVector(0, 0, cent_WGring_z),
-               endcap_WG_ring_volume,
-               (boost::format("endcap_WG_ring_pv_%d_%d") %i %j).str(),
-               trackerenvelope, false, 0, OverlapCheck());
+          new G4PVPlacement(0, G4ThreeVector(0, 0, cent_Alring_z),
+                            endcap_Al_ring_volume,
+                            (boost::format("endcap_Al_ring_pv_%d_%d") % i % j).str(),
+                            trackerenvelope, false, 0, OverlapCheck());
+        }
+      }
+    }
+    else if (supportparams->get_int_param("endcap_ring_type") == 1)  // Place CP endcap rings
+    {
+      double endcap_ring_z = supportparams->get_double_param("endcap_CPring_z") * cm;
+      for (int i = 0; i < 2; i++)  // i=0 : positive z, i=1 negative z
+      {
+        endcap_ring_z = (i == 0) ? endcap_ring_z : -1.0 * endcap_ring_z;
 
-           new G4PVPlacement(0, G4ThreeVector(0, 0, cent_SSring_z),
-               endcap_SS_ring_volume,
-               (boost::format("endcap_SS_ring_pv_%d_%d") %i %j).str(),
-               trackerenvelope, false, 0, OverlapCheck());
-
-           new G4PVPlacement(0, G4ThreeVector(0, 0, cent_Alring_z),
-               endcap_Al_ring_volume,
-               (boost::format("endcap_Al_ring_pv_%d_%d") %i %j).str(),
-               trackerenvelope, false, 0, OverlapCheck());
-         }
-       }
-     }
-     else if(supportparams->get_int_param("endcap_ring_type")==1) // Place CP endcap rings
-     {
-       double endcap_ring_z = supportparams->get_double_param("endcap_CPring_z") * cm; 
-       for(int i = 0; i < 2; i++) // i=0 : positive z, i=1 negative z
-       {
-
-         endcap_ring_z = (i==0) ?  endcap_ring_z : -1.0 * endcap_ring_z;
-
-         new G4PVPlacement(0, G4ThreeVector(0, 0, endcap_ring_z),
-             endcap_CP_ring_volume,
-             (boost::format("endcap_CP_ring_pv_%d") %i).str(),
-             trackerenvelope, false, 0, OverlapCheck());
-       }
-     }
-   }
-
-
+        new G4PVPlacement(0, G4ThreeVector(0, 0, endcap_ring_z),
+                          endcap_CP_ring_volume,
+                          (boost::format("endcap_CP_ring_pv_%d") % i).str(),
+                          trackerenvelope, false, 0, OverlapCheck());
+      }
+    }
+  }
 
   //=======================================================
   // Add an outer shell for the MVTX - move this to the MVTX detector module
@@ -1548,7 +1538,7 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
                                                                       "mvtx_shell_inner_skin_volume", 0, 0, 0);
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_inner_skin_volume,
                     "mvtx_shell_inner_skin", trackerenvelope, false, 0, OverlapCheck());
-  m_DisplayAction->AddVolume(mvtx_shell_inner_skin_volume,"Rail");
+  m_DisplayAction->AddVolume(mvtx_shell_inner_skin_volume, "Rail");
 
   G4Tubs *mvtx_shell_foam_core_tube = new G4Tubs("mvtx_shell_foam_core",
                                                  mvtx_shell_foam_core_inner_radius, mvtx_shell_foam_core_inner_radius + foam_core_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
@@ -1556,7 +1546,7 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
                                                                      "mvtx_shell_foam_core_volume", 0, 0, 0);
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_foam_core_volume,
                     "mvtx_shell_foam_core", trackerenvelope, false, 0, OverlapCheck());
-  m_DisplayAction->AddVolume(mvtx_shell_foam_core_volume,"Rail");
+  m_DisplayAction->AddVolume(mvtx_shell_foam_core_volume, "Rail");
 
   G4Tubs *mvtx_shell_outer_skin_tube = new G4Tubs("mvtx_shell_outer_skin",
                                                   mvtx_shell_outer_skin_inner_radius, mvtx_shell_outer_skin_inner_radius + skin_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
@@ -1564,14 +1554,14 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
                                                                       "mvtx_shell_outer_skin_volume", 0, 0, 0);
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_outer_skin_volume,
                     "mvtx_shell_outer_skin", trackerenvelope, false, 0, OverlapCheck());
-  m_DisplayAction->AddVolume(mvtx_shell_outer_skin_volume,"Rail");
+  m_DisplayAction->AddVolume(mvtx_shell_outer_skin_volume, "Rail");
   return 0;
 }
 
 void PHG4InttDetector::AddGeometryNode()
 {
   int active = 0;
-//  map<int, int>::const_iterator iter;
+  //  map<int, int>::const_iterator iter;
   for (auto iter = m_IsActiveMap.begin(); iter != m_IsActiveMap.end(); ++iter)
   {
     if (iter->second > 0)

--- a/simulation/g4simulation/g4intt/PHG4InttDetector.h
+++ b/simulation/g4simulation/g4intt/PHG4InttDetector.h
@@ -15,19 +15,19 @@
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHG4InttDisplayAction;
-class PHG4InttSubsystem;
+class PHG4Subsystem;
 class PHParametersContainer;
 
 class PHG4InttDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4InttDetector(PHG4InttSubsystem* subsys, PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::vector<std::pair<int, int>>::const_iterator, std::vector<std::pair<int, int>>::const_iterator> &layer_b_e);
+  PHG4InttDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::vector<std::pair<int, int>>::const_iterator, std::vector<std::pair<int, int>>::const_iterator> &layer_b_e);
 
   //! destructor
   virtual ~PHG4InttDetector() {}
   //! construct
-  virtual void Construct(G4LogicalVolume *world);
+  virtual void ConstructMe(G4LogicalVolume *world);
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4intt/PHG4InttDetector.h
+++ b/simulation/g4simulation/g4intt/PHG4InttDetector.h
@@ -7,9 +7,9 @@
 
 #include <map>
 #include <set>
-#include <string>                 // for string
+#include <string>  // for string
 #include <tuple>
-#include <utility>                // for pair
+#include <utility>  // for pair
 #include <vector>
 
 class G4LogicalVolume;
@@ -22,7 +22,7 @@ class PHG4InttDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4InttDetector(PHG4Subsystem* subsys, PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::vector<std::pair<int, int>>::const_iterator, std::vector<std::pair<int, int>>::const_iterator> &layer_b_e);
+  PHG4InttDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::vector<std::pair<int, int>>::const_iterator, std::vector<std::pair<int, int>>::const_iterator> &layer_b_e);
 
   //! destructor
   virtual ~PHG4InttDetector() {}
@@ -58,7 +58,7 @@ class PHG4InttDetector : public PHG4Detector
   void AddGeometryNode();
   int ConstructIntt(G4LogicalVolume *sandwich);
 
-  PHG4InttDisplayAction* m_DisplayAction;
+  PHG4InttDisplayAction *m_DisplayAction;
   PHParametersContainer *m_ParamsContainer;
 
   std::string m_DetectorType;

--- a/simulation/g4simulation/g4intt/PHG4InttDigitizer.h
+++ b/simulation/g4simulation/g4intt/PHG4InttDigitizer.h
@@ -6,7 +6,7 @@
 #include <fun4all/SubsysReco.h>
 
 // rootcint barfs with this header so we need to hide it
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
 #endif
 
@@ -64,7 +64,7 @@ class PHG4InttDigitizer : public SubsysReco, public PHParameterInterface
   unsigned int m_nCells;
   unsigned int m_nDeadCells;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   //! random generator that conform with sPHENIX standard
   gsl_rng *RandomGenerator;
 #endif

--- a/simulation/g4simulation/g4jets/JetMapv1.cc
+++ b/simulation/g4simulation/g4jets/JetMapv1.cc
@@ -2,10 +2,11 @@
 
 #include "Jet.h"
 
+#include <phool/PHObject.h>  // for PHObject
+
 #include <cassert>
 #include <cmath>
 #include <iterator>  // for reverse_iterator
-#include <map>       // for _Rb_tree_const_iterator, _Rb_tree_iterator
 #include <ostream>   // for operator<<, endl, ostream, basic_ostream::operat...
 #include <utility>   // for pair, make_pair
 

--- a/simulation/g4simulation/g4jets/JetMapv1.h
+++ b/simulation/g4simulation/g4jets/JetMapv1.h
@@ -9,6 +9,8 @@
 #include <iostream>
 #include <set>
 
+class PHObject;
+
 class JetMapv1 : public JetMap
 {
  public:

--- a/simulation/g4simulation/g4jets/Jetv1.cc
+++ b/simulation/g4simulation/g4jets/Jetv1.cc
@@ -11,6 +11,8 @@
 #include <cmath>
 #include <iostream>
 
+class PHObject;
+
 using namespace std;
 
 Jetv1::Jetv1()

--- a/simulation/g4simulation/g4jets/Jetv1.h
+++ b/simulation/g4simulation/g4jets/Jetv1.h
@@ -16,6 +16,8 @@
 #include <map>
 #include <utility>   // for pair, make_pair
 
+class PHObject;
+
 /*!
  * \brief Jetv1
  */

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -6,7 +6,7 @@
 #include <fun4all/SubsysReco.h>
 
 // rootcint barfs with this header so we need to hide it
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
 #endif
 
@@ -64,7 +64,7 @@ class HepMCNodeReader : public SubsysReco
   double width_vy;
   double width_vz;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *RandomGenerator;
 #endif
 };

--- a/simulation/g4simulation/g4main/PHG4Detector.cc
+++ b/simulation/g4simulation/g4main/PHG4Detector.cc
@@ -2,11 +2,11 @@
 
 #include "PHG4Subsystem.h"
 
-#include <Geant4/G4Colour.hh>            // for G4Colour
+#include <Geant4/G4Colour.hh>  // for G4Colour
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4ThreeVector.hh>       // for G4ThreeVector
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4VisAttributes.hh>
 
 PHG4Detector::PHG4Detector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &nam)

--- a/simulation/g4simulation/g4main/PHG4Detector.cc
+++ b/simulation/g4simulation/g4main/PHG4Detector.cc
@@ -1,5 +1,7 @@
 #include "PHG4Detector.h"
 
+#include "PHG4Subsystem.h"
+
 #include <Geant4/G4Colour.hh>            // for G4Colour
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
@@ -7,13 +9,28 @@
 #include <Geant4/G4ThreeVector.hh>       // for G4ThreeVector
 #include <Geant4/G4VisAttributes.hh>
 
-PHG4Detector::PHG4Detector(PHCompositeNode *Node, const std::string &nam)
+PHG4Detector::PHG4Detector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &nam)
   : m_topNode(Node)
+  , m_MySubsystem(subsys)
   , m_Verbosity(0)
   , m_OverlapCheck(false)
   , m_ColorIndex(0)
   , m_Name(nam)
 {
+}
+
+void PHG4Detector::Construct(G4LogicalVolume *world)
+{
+  PHG4Subsystem *MyMotherSubsystem = m_MySubsystem->GetMotherSubsystem();
+  if (MyMotherSubsystem)
+  {
+    ConstructMe(MyMotherSubsystem->GetLogicalVolume());
+  }
+  else
+  {
+    ConstructMe(world);
+  }
+  return;
 }
 
 int PHG4Detector::DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm)

--- a/simulation/g4simulation/g4main/PHG4Detector.h
+++ b/simulation/g4simulation/g4main/PHG4Detector.h
@@ -12,6 +12,7 @@ class G4LogicalVolume;
 class G4UserSteppingAction;
 class G4VSolid;
 class PHCompositeNode;
+class PHG4Subsystem;
 
 //! base class for phenix detector creation
 /*! derived classes must implement construct method, which takes the "world" logical volume as argument */
@@ -22,7 +23,7 @@ class PHG4Detector
   // delete default ctor, nobody should use it
   PHG4Detector() = delete;
   // this is the ctor we use
-  PHG4Detector(PHCompositeNode *Node, const std::string &nam = "NONE");
+  explicit PHG4Detector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &nam);
 
   //! destructor
   virtual ~PHG4Detector(void)
@@ -34,7 +35,9 @@ class PHG4Detector
   construct all logical and physical volumes relevant for given detector and place them
   inside the world logical volume
   */
-  virtual void Construct(G4LogicalVolume *world) = 0;
+  virtual void Construct(G4LogicalVolume *world);
+
+  virtual void ConstructMe(G4LogicalVolume *mothervolume) {return;}
 
   virtual void Verbosity(const int v) { m_Verbosity = v; }
 
@@ -53,6 +56,7 @@ class PHG4Detector
 
  private:
   PHCompositeNode *m_topNode;
+  PHG4Subsystem *m_MySubsystem;
   int m_Verbosity;
   bool m_OverlapCheck;
   int m_ColorIndex;

--- a/simulation/g4simulation/g4main/PHG4Detector.h
+++ b/simulation/g4simulation/g4main/PHG4Detector.h
@@ -35,9 +35,9 @@ class PHG4Detector
   construct all logical and physical volumes relevant for given detector and place them
   inside the world logical volume
   */
-  virtual void Construct(G4LogicalVolume *world);
+  virtual void Construct(G4LogicalVolume *world) final;
 
-  virtual void ConstructMe(G4LogicalVolume *mothervolume) { return; }
+  virtual void ConstructMe(G4LogicalVolume *mothervolume) = 0;
 
   virtual void Verbosity(const int v) { m_Verbosity = v; }
 

--- a/simulation/g4simulation/g4main/PHG4Detector.h
+++ b/simulation/g4simulation/g4main/PHG4Detector.h
@@ -37,7 +37,7 @@ class PHG4Detector
   */
   virtual void Construct(G4LogicalVolume *world);
 
-  virtual void ConstructMe(G4LogicalVolume *mothervolume) {return;}
+  virtual void ConstructMe(G4LogicalVolume *mothervolume) { return; }
 
   virtual void Verbosity(const int v) { m_Verbosity = v; }
 
@@ -52,7 +52,7 @@ class PHG4Detector
   }
   virtual int DisplayVolume(G4VSolid *volume, G4LogicalVolume *logvol, G4RotationMatrix *rotm = nullptr);
   virtual int DisplayVolume(G4LogicalVolume *checksolid, G4LogicalVolume *logvol, G4RotationMatrix *rotm = nullptr);
-  virtual PHCompositeNode *topNode() {return m_topNode;}
+  virtual PHCompositeNode *topNode() { return m_topNode; }
 
  private:
   PHCompositeNode *m_topNode;

--- a/simulation/g4simulation/g4main/PHG4HitEval.cc
+++ b/simulation/g4simulation/g4main/PHG4HitEval.cc
@@ -10,6 +10,10 @@
 
 #include "PHG4HitEval.h"
 
+#include "PHG4Hit.h"         // for PHG4Hit
+
+#include <phool/PHObject.h>  // for PHObject
+
 #include <cassert>
 #include <cmath>
 

--- a/simulation/g4simulation/g4main/PHG4HitEval.h
+++ b/simulation/g4simulation/g4main/PHG4HitEval.h
@@ -15,6 +15,9 @@
 
 #include "PHG4Hitv1.h"
 
+class PHG4Hit;
+class PHObject;
+
 /*!
  * \brief PHG4HitEval for evaluating PHG4Hitv1 in CINT readable evaluation trees
  */

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -6,10 +6,10 @@
 #include "PHG4Hit.h"
 #include "PHG4HitDefs.h"
 
-#ifdef __CINT__
-#include <stdint.h>
-#else
+#if !defined(__CINT__) || defined (__CLING__)
 #include <cstdint>
+#else
+#include <stdint.h>
 #endif
 #include <iostream>
 #include <map>

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
@@ -63,7 +63,7 @@ class PHG4ParticleGeneratorBase : public SubsysReco
   double t0;
   std::vector<PHG4Particle *> particlelist;
   unsigned int seed;
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *RandomGenerator;
 #endif
 };

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -22,6 +22,7 @@
 #include <gsl/gsl_rng.h>            // for gsl_rng_uniform, gsl_rng_uniform_pos
 
 #include <cmath>                   // for sin, sqrt, cos, M_PI
+#include <cstdlib>                 // for exit
 #include <iostream>                 // for operator<<, basic_ostream, basic_...
 #include <utility>                  // for pair
 #include <vector>                   // for vector, vector<>::const_iterator

--- a/simulation/g4simulation/g4main/PHG4Subsystem.h
+++ b/simulation/g4simulation/g4main/PHG4Subsystem.h
@@ -3,8 +3,8 @@
 #ifndef G4MAIN_PHG4SUBSYSTEM_H
 #define G4MAIN_PHG4SUBSYSTEM_H
 
-#include <fun4all/SubsysReco.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>
 
 #include <iostream>
 #include <string>
@@ -16,61 +16,71 @@ class PHG4EventAction;
 class PHG4SteppingAction;
 class PHG4TrackingAction;
 
-class PHG4Subsystem: public SubsysReco
+class PHG4Subsystem : public SubsysReco
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4Subsystem( const std::string &name = "Generic Subsystem" ): 
-SubsysReco(name),
-  m_MyMotherSubsystem(nullptr),
-m_MyLogicalVolume(nullptr),
-overlapcheck(false)
-  {}
+  PHG4Subsystem(const std::string &name = "Generic Subsystem")
+    : SubsysReco(name)
+    , m_MyMotherSubsystem(nullptr)
+    , m_MyLogicalVolume(nullptr)
+    , overlapcheck(false)
+  {
+  }
 
   //! destructor
-  virtual ~PHG4Subsystem( void ) {}
+  virtual ~PHG4Subsystem(void) {}
 
   //! event processing
   virtual int process_after_geant(PHCompositeNode *)
-  { return Fun4AllReturnCodes::EVENT_OK; }
+  {
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
 
   //! return pointer to created detector object
-  virtual PHG4Detector* GetDetector( void ) const
-  { return nullptr; }
+  virtual PHG4Detector *GetDetector(void) const
+  {
+    return nullptr;
+  }
 
   //! return pointer to this subsystem event action
-  virtual PHG4EventAction* GetEventAction( void ) const
-  { return nullptr; }
+  virtual PHG4EventAction *GetEventAction(void) const
+  {
+    return nullptr;
+  }
 
   //! return pointer to this subsystem stepping action
-  virtual PHG4SteppingAction* GetSteppingAction( void ) const
-  { return nullptr; }
+  virtual PHG4SteppingAction *GetSteppingAction(void) const
+  {
+    return nullptr;
+  }
 
   //! return pointer to this subsystem stepping action
-  virtual PHG4TrackingAction* GetTrackingAction( void ) const
-  { return nullptr; }
+  virtual PHG4TrackingAction *GetTrackingAction(void) const
+  {
+    return nullptr;
+  }
 
   //! return pointer to this subsystem display setting
   virtual PHG4DisplayAction *GetDisplayAction() const
-  {return nullptr;}
+  {
+    return nullptr;
+  }
 
-  void OverlapCheck(const bool chk = true) {overlapcheck = chk;}
+  void OverlapCheck(const bool chk = true) { overlapcheck = chk; }
 
-  bool CheckOverlap() const {return overlapcheck;}
+  bool CheckOverlap() const { return overlapcheck; }
 
-  void SetMotherSubsystem(PHG4Subsystem *subsys) {m_MyMotherSubsystem = subsys;}
-  PHG4Subsystem *GetMotherSubsystem() const {return m_MyMotherSubsystem;}
+  void SetMotherSubsystem(PHG4Subsystem *subsys) { m_MyMotherSubsystem = subsys; }
+  PHG4Subsystem *GetMotherSubsystem() const { return m_MyMotherSubsystem; }
 
-  void SetLogicalVolume(G4LogicalVolume *vol) {m_MyLogicalVolume = vol;}
-  G4LogicalVolume *GetLogicalVolume() const {return m_MyLogicalVolume;}
+  void SetLogicalVolume(G4LogicalVolume *vol) { m_MyLogicalVolume = vol; }
+  G4LogicalVolume *GetLogicalVolume() const { return m_MyLogicalVolume; }
 
  private:
   PHG4Subsystem *m_MyMotherSubsystem;
   G4LogicalVolume *m_MyLogicalVolume;
   bool overlapcheck;
-
 };
 
-#endif // G4MAIN_PHG4SUBSYSTEM_H
+#endif  // G4MAIN_PHG4SUBSYSTEM_H

--- a/simulation/g4simulation/g4main/PHG4Subsystem.h
+++ b/simulation/g4simulation/g4main/PHG4Subsystem.h
@@ -4,10 +4,12 @@
 #define G4MAIN_PHG4SUBSYSTEM_H
 
 #include <fun4all/SubsysReco.h>
+#include <fun4all/Fun4AllReturnCodes.h>
 
 #include <iostream>
 #include <string>
 
+class G4LogicalVolume;
 class PHG4Detector;
 class PHG4DisplayAction;
 class PHG4EventAction;
@@ -20,7 +22,10 @@ class PHG4Subsystem: public SubsysReco
   public:
 
   //! constructor
-  PHG4Subsystem( const std::string &name = "Generic Subsystem" ): SubsysReco(name),
+  PHG4Subsystem( const std::string &name = "Generic Subsystem" ): 
+SubsysReco(name),
+  m_MyMotherSubsystem(nullptr),
+m_MyLogicalVolume(nullptr),
 overlapcheck(false)
   {}
 
@@ -29,7 +34,7 @@ overlapcheck(false)
 
   //! event processing
   virtual int process_after_geant(PHCompositeNode *)
-  { return 0; }
+  { return Fun4AllReturnCodes::EVENT_OK; }
 
   //! return pointer to created detector object
   virtual PHG4Detector* GetDetector( void ) const
@@ -55,7 +60,15 @@ overlapcheck(false)
 
   bool CheckOverlap() const {return overlapcheck;}
 
+  void SetMotherSubsystem(PHG4Subsystem *subsys) {m_MyMotherSubsystem = subsys;}
+  PHG4Subsystem *GetMotherSubsystem() const {return m_MyMotherSubsystem;}
+
+  void SetLogicalVolume(G4LogicalVolume *vol) {m_MyLogicalVolume = vol;}
+  G4LogicalVolume *GetLogicalVolume() const {return m_MyLogicalVolume;}
+
  private:
+  PHG4Subsystem *m_MyMotherSubsystem;
+  G4LogicalVolume *m_MyLogicalVolume;
   bool overlapcheck;
 
 };

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
@@ -44,8 +44,8 @@
 
 using namespace std;
 
-PHG4MvtxDetector::PHG4MvtxDetector(PHG4MvtxSubsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam)
-  : PHG4Detector(Node, dnam)
+PHG4MvtxDetector::PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , m_DisplayAction(dynamic_cast<PHG4MvtxDisplayAction*>(subsys->GetDisplayAction()))
   , m_ParamsContainer(_paramsContainer)
   , m_StaveGeometryFile(_paramsContainer->GetParameters(PHG4MvtxDefs::GLOBAL)->get_string_param("stave_geometry_file"))
@@ -72,7 +72,9 @@ PHG4MvtxDetector::PHG4MvtxDetector(PHG4MvtxSubsystem* subsys, PHCompositeNode* N
   m_PixelZ = alpide_params->get_double_param("pixel_z");
   m_PixelThickness = alpide_params->get_double_param("pixel_thickness");
   if (Verbosity() > 0)
+  {
     cout << "PHG4MvtxDetector constructor: making Mvtx detector. " << endl;
+  }
 }
 
 //_______________________________________________________________
@@ -144,14 +146,15 @@ int PHG4MvtxDetector::get_stave(int index) const
   return index;
 }
 
-void PHG4MvtxDetector::Construct(G4LogicalVolume* logicWorld)
+void PHG4MvtxDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   // This is called from PHG4PhenixDetector::Construct()
 
   if (Verbosity() > 0)
+  {
     cout << endl
          << "PHG4MvtxDetector::Construct called for Mvtx " << endl;
-
+  }
   // the tracking layers are placed directly in the world volume, since some layers are (touching) double layers
   // this reads in the ITS stave geometry from a file and constructs the layer from it
   ConstructMvtx(logicWorld);
@@ -182,7 +185,9 @@ int PHG4MvtxDetector::ConstructMvtx(G4LogicalVolume* trackerenvelope)
   sprintf(assemblyname, "MVTXStave");
 
   if (Verbosity() > 0)
+  {
     cout << "Geting the stave assembly named " << assemblyname << endl;
+  }
   G4AssemblyVolume* av_ITSUStave = reader->GetAssembly(assemblyname);
 
   for (unsigned short ilayer = 0; ilayer < n_Layers; ++ilayer)
@@ -264,8 +269,9 @@ int PHG4MvtxDetector::ConstructMvtx_Layer(int layer, G4AssemblyVolume* av_ITSUSt
     G4ThreeVector Ta;
 
     if (Verbosity() > 0)
+    {
       cout << "phi_offset = " << phi_offset << " iphi " << iphi << " phi_rotation = " << phi_rotation << " phitilt " << phitilt << endl;
-
+    }
     // It  is first rotated in phi by the azimuthal angle phi_rotation, plus the 90 degrees needed to point the face of the sensor  at the origin,  plus the tilt (if a tilt is appropriate)
 
     Ra.rotateZ(phi_rotation + phi_offset + phitilt);  // note - if this is layer 0-2, phitilt is the additional tilt for clearance. Otherwise it is zero
@@ -276,20 +282,22 @@ int PHG4MvtxDetector::ConstructMvtx_Layer(int layer, G4AssemblyVolume* av_ITSUSt
     Ta.setZ(z_location);
 
     if (Verbosity() > 0)
+    {
       cout << " iphi " << iphi << " phi_rotation " << phi_rotation
            << " x " << layer_nominal_radius * cos(phi_rotation)
            << " y " << layer_nominal_radius * sin(phi_rotation)
            << " z " << z_location
            << endl;
-
+    }
     G4Transform3D Tr(Ra, Ta);
 
     av_ITSUStave->MakeImprint(trackerenvelope, Tr, 0, OverlapCheck());
   }
 
   if (Verbosity() > 0)
+  {
     cout << "This layer has a total of " << N_staves << " staves" << endl;
-
+  }
   return 0;
 }
 
@@ -313,12 +321,13 @@ void PHG4MvtxDetector::SetDisplayProperty(G4AssemblyVolume* av)
 
 void PHG4MvtxDetector::SetDisplayProperty(G4LogicalVolume* lv)
 {
-  string material_name(
-      lv->GetMaterial()->GetName());
+  string material_name(lv->GetMaterial()->GetName());
 
   if (Verbosity() >= 5)
+  {
     cout << "SetDisplayProperty - LV " << lv->GetName() << " built with "
          << material_name << endl;
+  }
   vector<string> matname = {"SI", "KAPTON", "ALUMINUM", "Carbon", "M60J3K", "WATER"};
   bool found = false;
   for (string nam : matname)
@@ -327,7 +336,9 @@ void PHG4MvtxDetector::SetDisplayProperty(G4LogicalVolume* lv)
     {
       m_DisplayAction->AddVolume(lv, nam);
       if (Verbosity() >= 5)
+      {
         cout << "SetDisplayProperty - LV " << lv->GetName() << " display with " << nam << endl;
+      }
       found = true;
       break;
     }
@@ -352,8 +363,9 @@ void PHG4MvtxDetector::AddGeometryNode()
 {
   int active = 0;
   for (auto& isAct : m_IsLayerActive)
+  {
     active |= isAct;
-
+  }
   if (active)
   {
     ostringstream geonode;
@@ -392,8 +404,9 @@ void PHG4MvtxDetector::AddGeometryNode()
 void PHG4MvtxDetector::FillPVArray(G4AssemblyVolume* av)
 {
   if (Verbosity() > 0)
+  {
     cout << "-- FillPVArray --" << endl;
-
+  }
   std::vector<G4VPhysicalVolume*>::iterator it = av->GetVolumesIterator();
 
   int nDaughters = av->TotalImprintedVolumes();
@@ -439,21 +452,25 @@ void PHG4MvtxDetector::FindSensor(G4LogicalVolume* lv)
   {
     G4VPhysicalVolume* pv = lv->GetDaughter(i);
     if (Verbosity() > 0)
+    {
       cout << "                 PV[" << i << "]: " << pv->GetName() << endl;
-
+    }
     if (pv->GetName().find("MVTXSensor_") != string::npos)
     {
       m_SensorPV.insert(pv);
 
       if (Verbosity() > 0)
+      {
         cout << "                      Adding Sensor Vol <" << pv->GetName() << " (" << m_SensorPV.size() << ")>" << endl;
+      }
     }
 
     G4LogicalVolume* worldLogical = pv->GetLogicalVolume();
 
     if (Verbosity() > 0)
+    {
       cout << "                 LV[" << i << "]: " << worldLogical->GetName() << endl;
-
+    }
     FindSensor(worldLogical);
   }
 }

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
@@ -11,36 +11,36 @@
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
 
-#include <g4main/PHG4Detector.h>                    // for PHG4Detector
-#include <g4main/PHG4DisplayAction.h>               // for PHG4DisplayAction
+#include <g4main/PHG4Detector.h>       // for PHG4Detector
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                           // for PHNode
-#include <phool/PHNodeIterator.h>                   // for PHNodeIterator
-#include <phool/PHObject.h>                         // for PHObject
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4GDMLParser.hh>
-#include <Geant4/G4GDMLReadStructure.hh>            // for G4GDMLReadStructure
+#include <Geant4/G4GDMLReadStructure.hh>  // for G4GDMLReadStructure
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
-#include <Geant4/G4RotationMatrix.hh>               // for G4RotationMatrix
-#include <Geant4/G4String.hh>                       // for G4String
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>                  // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>                  // for G4Transform3D
-#include <Geant4/G4Types.hh>                        // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>              // for G4VPhysicalVolume
+#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>      // for G4Transform3D
+#include <Geant4/G4Types.hh>            // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 
 #include <cmath>
-#include <cstdio>                                  // for sprintf
-#include <iostream>                                 // for operator<<, basic...
+#include <cstdio>    // for sprintf
+#include <iostream>  // for operator<<, basic...
 #include <memory>
 #include <sstream>
-#include <utility>                                  // for pair, make_pair
-#include <vector>                                   // for vector, vector<>:...
+#include <utility>  // for pair, make_pair
+#include <vector>   // for vector, vector<>:...
 
 using namespace std;
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
@@ -6,11 +6,11 @@
 #include <g4main/PHG4Detector.h>
 
 #include <array>
-#include <cmath>                 // for M_PI
+#include <cmath>  // for M_PI
 #include <map>
 #include <set>
 #include <string>
-#include <tuple>                  // for tuple
+#include <tuple>  // for tuple
 
 class G4AssemblyVolume;
 class G4LogicalVolume;
@@ -58,7 +58,7 @@ class PHG4MvtxDetector : public PHG4Detector
   void FillPVArray(G4AssemblyVolume* av);
   void FindSensor(G4LogicalVolume* lv);
   // calculated quantities
-  double get_phistep(int lay) const { return 2.0 * M_PI /  m_N_staves[lay]; }
+  double get_phistep(int lay) const { return 2.0 * M_PI / m_N_staves[lay]; }
 
   static constexpr int n_Layers = 3;
   PHG4MvtxDisplayAction* m_DisplayAction;
@@ -79,7 +79,6 @@ class PHG4MvtxDetector : public PHG4Detector
   double m_PixelX;
   double m_PixelZ;
   double m_PixelThickness;
-
 
   std::string m_Detector;
   std::string m_SuperDetector;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
@@ -24,13 +24,13 @@ class PHG4MvtxDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4MvtxDetector(PHG4MvtxSubsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam = "MVTX");
+  PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam);
 
   //! destructor
   virtual ~PHG4MvtxDetector() {}
 
   //! construct
-  virtual void Construct(G4LogicalVolume* world);
+  virtual void ConstructMe(G4LogicalVolume* world);
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.h
@@ -7,7 +7,7 @@
 #include <fun4all/SubsysReco.h>
 
 // rootcint barfs with this header so we need to hide it
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
 #endif
 
@@ -54,7 +54,7 @@ class PHG4MvtxDigitizer : public SubsysReco
   std::map<int, unsigned int> _max_adc;
   std::map<int, float> _energy_scale;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   //! random generator that conform with sPHENIX standard
   gsl_rng *RandomGenerator;
 #endif

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -3,24 +3,24 @@
 #include "PHG4TpcDisplayAction.h"
 #include "PHG4TpcSubsystem.h"
 
-#include <g4main/PHG4Detector.h>         // for PHG4Detector
-#include <g4main/PHG4DisplayAction.h>    // for PHG4DisplayAction
+#include <g4main/PHG4Detector.h>       // for PHG4Detector
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 
 #include <phparameter/PHParameters.h>
 
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4String.hh>            // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>       // for G4ThreeVector
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4UserLimits.hh>
-#include <Geant4/G4VPhysicalVolume.hh>   // for G4VPhysicalVolume
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 
 #include <cmath>
-#include <iostream>                      // for basic_ostream::operator<<
-#include <map>                           // for map
+#include <iostream>  // for basic_ostream::operator<<
+#include <map>       // for map
 #include <sstream>
 
 class G4VSolid;
@@ -113,11 +113,11 @@ int PHG4TpcDetector::ConstructTpcGasVolume(G4LogicalVolume *tpc_envelope)
                                                           G4Material::GetMaterial(params->get_string_param("window_surface1_material")),
                                                           "tpc_window");
 
-//  G4VisAttributes *visatt = new G4VisAttributes();
-//  visatt->SetVisibility(true);
-//  visatt->SetForceSolid(true);
-//  visatt->SetColor(PHG4TPCColorDefs::tpc_cu_color);
-//  tpc_window_logic->SetVisAttributes(visatt);
+  //  G4VisAttributes *visatt = new G4VisAttributes();
+  //  visatt->SetVisibility(true);
+  //  visatt->SetForceSolid(true);
+  //  visatt->SetColor(PHG4TPCColorDefs::tpc_cu_color);
+  //  tpc_window_logic->SetVisAttributes(visatt);
 
   m_DisplayAction->AddVolume(tpc_window_logic, "TpcWindow");
   G4VPhysicalVolume *tpc_window_phys = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
@@ -136,21 +136,20 @@ int PHG4TpcDetector::ConstructTpcGasVolume(G4LogicalVolume *tpc_envelope)
       new G4Tubs("tpc_window_surface2_core", params->get_double_param("gas_inner_radius") * cm, params->get_double_param("gas_outer_radius") * cm,
                  tpc_window_surface2_core_thickness / 2., 0., 2 * M_PI);
   G4LogicalVolume *tpc_window_surface2_core_logic = new G4LogicalVolume(tpc_window_surface2_core,
-                                                               G4Material::GetMaterial(params->get_string_param("window_surface2_material")),
-                                                               "tpc_window_surface2_core");
+                                                                        G4Material::GetMaterial(params->get_string_param("window_surface2_material")),
+                                                                        "tpc_window_surface2_core");
 
   m_DisplayAction->AddVolume(tpc_window_surface2_core_logic, "TpcWindow");
-//  visatt = new G4VisAttributes();
-//  visatt->SetVisibility(true);
-//  visatt->SetForceSolid(true);
-//  visatt->SetColor(PHG4TPCColorDefs::tpc_pcb_color);
-//  tpc_window_surface2_core_logic->SetVisAttributes(visatt);
+  //  visatt = new G4VisAttributes();
+  //  visatt->SetVisibility(true);
+  //  visatt->SetForceSolid(true);
+  //  visatt->SetColor(PHG4TPCColorDefs::tpc_pcb_color);
+  //  tpc_window_surface2_core_logic->SetVisAttributes(visatt);
   G4VPhysicalVolume *tpc_window_surface2_core_phys = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
-                                                              tpc_window_surface2_core_logic, "tpc_window_surface2_core",
-                                                              tpc_window_logic, false, PHG4TpcDefs::WindowCore, OverlapCheck());
+                                                                       tpc_window_surface2_core_logic, "tpc_window_surface2_core",
+                                                                       tpc_window_logic, false, PHG4TpcDefs::WindowCore, OverlapCheck());
 
   absorbervols.insert(tpc_window_surface2_core_phys);
-
 
   G4VSolid *tpc_window_core =
       new G4Tubs("tpc_window", params->get_double_param("gas_inner_radius") * cm, params->get_double_param("gas_outer_radius") * cm,
@@ -165,7 +164,6 @@ int PHG4TpcDetector::ConstructTpcGasVolume(G4LogicalVolume *tpc_envelope)
                                                               tpc_window_surface2_core_logic, false, PHG4TpcDefs::WindowCore, OverlapCheck());
 
   absorbervols.insert(tpc_window_core_phys);
-
 
   // Gas
   G4VSolid *tpc_gas = new G4Tubs("tpc_gas", params->get_double_param("gas_inner_radius") * cm, params->get_double_param("gas_outer_radius") * cm, tpc_half_length / 2., 0., 2 * M_PI);

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -29,8 +29,8 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________
-PHG4TpcDetector::PHG4TpcDetector(PHG4TpcSubsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
-  : PHG4Detector(Node, dnam)
+PHG4TpcDetector::PHG4TpcDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
+  : PHG4Detector(subsys, Node, dnam)
   , m_DisplayAction(dynamic_cast<PHG4TpcDisplayAction *>(subsys->GetDisplayAction()))
   , params(parameters)
   , g4userlimits(nullptr)
@@ -63,7 +63,7 @@ int PHG4TpcDetector::IsInTpc(G4VPhysicalVolume *volume) const
 }
 
 //_______________________________________________________________
-void PHG4TpcDetector::Construct(G4LogicalVolume *logicWorld)
+void PHG4TpcDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   // create Tpc envelope
   // tpc consists of (from inside to gas volume, outside is reversed up to now)

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
@@ -16,14 +16,14 @@ class G4UserLimits;
 class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4TpcDisplayAction;
-class PHG4TpcSubsystem;
+class PHG4Subsystem;
 class PHParameters;
 
 class PHG4TpcDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4TpcDetector(PHG4TpcSubsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
+  PHG4TpcDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4TpcDetector(void)
@@ -31,7 +31,7 @@ class PHG4TpcDetector : public PHG4Detector
   }
 
   //! construct
-  void Construct(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world);
 
   int IsInTpc(G4VPhysicalVolume *) const;
   void SuperDetector(const std::string &name) { superdetector = name; }

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
@@ -74,7 +74,7 @@ class PHG4TpcDigitizer : public SubsysReco
   std::map<int, unsigned int> _max_adc;
   std::map<int, float> _energy_scale;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   //! random generator that conform with sPHENIX standard
   gsl_rng *RandomGenerator;
 #endif

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
@@ -12,7 +12,7 @@
 #define G4TPC_PHG4TPCDISTORTION_H
 
 // rootcint barfs with this header so we need to hide it
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
 #endif
 
@@ -58,7 +58,7 @@ class PHG4TpcDistortion
   //! The verbosity level. 0 means not verbose at all.
   int verbosity;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   //! random generator that conform with sPHENIX standard
   gsl_rng *RandomGenerator;
 #endif

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
@@ -10,7 +10,7 @@
 #include <phparameter/PHParameterInterface.h>
 
 // rootcint barfs with this header so we need to hide it
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
 #endif
 
@@ -67,7 +67,7 @@ class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
   double min_time;
   double max_time;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *RandomGenerator;
 #endif
 };

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
@@ -24,7 +24,7 @@ class PHG4TpcPadPlane : public SubsysReco, public PHParameterInterface
 
   virtual ~PHG4TpcPadPlane() {}
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   int process_event(PHCompositeNode *) final
   {
     return 0;

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -16,7 +16,7 @@
 #include <TVector3.h>
 
 // rootcint barfs with this header so we need to hide it
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
 #endif
 
@@ -322,7 +322,7 @@ class PHG4TrackFastSim : public SubsysReco
   std::vector<std::string> _state_names;
   std::vector<double> _state_location;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   //! random generator that conform with sPHENIX standard
   gsl_rng* m_RandomGenerator;
 #endif

--- a/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.h
@@ -47,7 +47,7 @@ class GlobalVertexFastSimReco : public SubsysReco
   float _y_smear;
   float _z_smear;
   float _t_smear;
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *RandomGenerator;
 #endif
 };


### PR DESCRIPTION
This PR enables hierarchies of volumes on the macro level (e.g. cylindrical magnetic field inside an iron cylinger == beam magnet). A change in the PHG4Detector and PHG4Subsystem base class makes this transparently possible. The main change in the detector classes is that the respective PHG4Subsystem needs to be added to the PHG4Detector ctor and the Construct() method is now ConstructMe(). The Construct() method is now implemented in PHG4Detecor and declared final. ConstructMe is now called for the detector implementations, the G4LogicalVolume is set to the mother volume (if set)