### PR TITLE
Fix up ifndef __CINT__

### DIFF
--- a/generators/phhepmc/Fun4AllHepMCInputManager.h
+++ b/generators/phhepmc/Fun4AllHepMCInputManager.h
@@ -103,7 +103,7 @@ class Fun4AllHepMCInputManager : public Fun4AllInputManager
   //! helper for insert HepMC event to DST node and add vertex smearing
   PHHepMCGenHelper hepmc_helper;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   boost::iostreams::filtering_streambuf<boost::iostreams::input> zinbuffer;
 #endif
 };

--- a/generators/phhepmc/Fun4AllHepMCPileupInputManager.h
+++ b/generators/phhepmc/Fun4AllHepMCPileupInputManager.h
@@ -5,7 +5,7 @@
 
 #include <string>
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
 #endif
 
@@ -50,7 +50,7 @@ class Fun4AllHepMCPileupInputManager : public Fun4AllHepMCInputManager
 
   bool _first_run;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *RandomGenerator;
 #endif
 };

--- a/generators/phhepmc/PHGenEventListv1.h
+++ b/generators/phhepmc/PHGenEventListv1.h
@@ -40,7 +40,7 @@ class PHGenEventListv1 : public PHGenEventList
 
   std::vector<PHGenEventVersion> _genevents;
 
-#ifndef __CINT____                                                     // hide from dictionary generation
+#if !defined(__CINT__) || defined(__CLING__)
   mutable bool _stale;                                                 //! exclude from ROOT I/O
   mutable std::map<unsigned int, const PHGenEvent*> _id_genevent_map;  //! exclude from ROOT I/O
 #endif                                                                 // __CINT__

--- a/generators/phhepmc/PHGenEventv1.h
+++ b/generators/phhepmc/PHGenEventv1.h
@@ -54,7 +54,7 @@ class PHGenEventv1 : public PHGenEvent
   // from there. This might make better use of space and ROOT compression.
   TString _event_record;
 
-#ifndef __CINT____                  // hide from dictionary generation
+#if !defined(__CINT__) || defined(__CLING__)
   mutable bool _stale;              //! exclude from ROOT I/O
   mutable HepMC::GenEvent* _event;  //! exclude from ROOT I/O
 #endif                              // __CINT__

--- a/generators/phhepmc/PHHepMCGenHelper.h
+++ b/generators/phhepmc/PHHepMCGenHelper.h
@@ -90,7 +90,7 @@ class PHHepMCGenHelper
     return _geneventmap;
   }
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *get_random_generator()
   {
     return RandomGenerator;
@@ -103,7 +103,7 @@ class PHHepMCGenHelper
   }
 
  protected:
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *RandomGenerator;
 #endif
 

--- a/generators/sHEPGen/sHEPGen.h
+++ b/generators/sHEPGen/sHEPGen.h
@@ -4,7 +4,7 @@
 #include <fun4all/SubsysReco.h>
 #include <phhepmc/PHHepMCGenHelper.h>
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
 #endif
 

--- a/offline/framework/phool/PHTimeServer.h
+++ b/offline/framework/phool/PHTimeServer.h
@@ -51,7 +51,7 @@ class PHTimeServer
     }
 
    private:
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
     std::shared_ptr<PHTimer> _timer;
 #endif
     unsigned short _uid;

--- a/offline/framework/phool/phool.h
+++ b/offline/framework/phool/phool.h
@@ -28,7 +28,7 @@ enum PHTreeType
 // General purpose functions
 void PHMessage(const std::string&, int, const std::string&);
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #define PHWHERE __FILE__ << ":" << __LINE__ << ": "
 #define PHMESSAGE(x)                          \
   do                                          \

--- a/offline/packages/CaloBase/RawTowerDefs.h
+++ b/offline/packages/CaloBase/RawTowerDefs.h
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <string>
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 #include <cstdlib>
 #else
 #include <stdlib.h>

--- a/offline/packages/intt/InttDefs.h
+++ b/offline/packages/intt/InttDefs.h
@@ -19,7 +19,7 @@
  */
 namespace InttDefs
 {
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 // hitsetkey layout:
 //  Intt specific lower 16 bits
 //   24 - 32  tracker id

--- a/offline/packages/mvtx/MvtxDefs.h
+++ b/offline/packages/mvtx/MvtxDefs.h
@@ -19,7 +19,7 @@
  */
 namespace MvtxDefs
 {
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 // hitsetkey layout:
 //  Mvtx specific lower 16 bits
 //   24 - 32  tracker id

--- a/offline/packages/tpc/TpcDefs.h
+++ b/offline/packages/tpc/TpcDefs.h
@@ -19,7 +19,7 @@
  */
 namespace TpcDefs
 {
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 // hitsetkey layout:
 //  Tpc specific lower 16 bits
 //   24 - 32  tracker id

--- a/offline/packages/tpcdaq/TPCDataStreamEmulator.h
+++ b/offline/packages/tpcdaq/TPCDataStreamEmulator.h
@@ -58,7 +58,7 @@ class TPCDataStreamEmulator : public SubsysReco
   }
 
  private:
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
   Fun4AllHistoManager *getHistoManager();
   int writeWavelet(int layer, int side, int phibin, int hittime, const std::vector<unsigned int> &wavelet);
@@ -87,7 +87,7 @@ class TPCDataStreamEmulator : public SubsysReco
   TH2 *m_hLayerSumHit;
   TH2 *m_hLayerSumDataSize;
 
-#endif  // #ifndef __CINT__
+#endif  // #if !defined(__CINT__) || defined(__CLING__)
 };
 
 #endif /* TPCDATASTREAMEMULATOR_H_ */

--- a/offline/packages/tpcdaq/TPCFEETestRecov1.h
+++ b/offline/packages/tpcdaq/TPCFEETestRecov1.h
@@ -115,7 +115,7 @@ class TPCFEETestRecov1 : public SubsysReco
     //! 3-D Graph clustering based on PHMakeGroups()
     void Clustering(int zero_suppression, bool verbosity = false);
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
     const std::vector<std::vector<std::vector<int>>> &getData() const
     {
@@ -133,7 +133,7 @@ class TPCFEETestRecov1 : public SubsysReco
 
     std::multimap<int, SampleID> m_groups;
 
-#endif  // #ifndef __CINT__
+#endif  // #if !defined(__CINT__) || defined(__CLING__)
   };
 
   //! buffer for a cluster's data
@@ -157,11 +157,11 @@ class TPCFEETestRecov1 : public SubsysReco
     std::set<int> padys;
     std::set<int> samples;
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
     std::map<int, std::vector<double>> padx_samples;
     std::map<int, std::vector<double>> pady_samples;
     std::vector<double> sum_samples;
-#endif  // #ifndef __CINT__
+#endif  // #if !defined(__CINT__) || defined(__CLING__)
 
     int min_sample;
     int max_sample;
@@ -225,7 +225,7 @@ class TPCFEETestRecov1 : public SubsysReco
   };
 
  private:
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
   // IO stuff
 
@@ -258,7 +258,7 @@ class TPCFEETestRecov1 : public SubsysReco
   //! Clustering then prepare IOs
   void Clustering(void);
 
-#endif  // #ifndef __CINT__
+#endif  // #if !defined(__CINT__) || defined(__CLING__)
 
   int m_clusteringZeroSuppression;
   int m_nPreSample;

--- a/offline/packages/tpcdaq/TPCIntegratedCharge.h
+++ b/offline/packages/tpcdaq/TPCIntegratedCharge.h
@@ -25,7 +25,7 @@ class TPCIntegratedCharge : public SubsysReco
   int End(PHCompositeNode *topNode);
 
  private:
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
   Fun4AllHistoManager *getHistoManager();
 
@@ -34,7 +34,7 @@ class TPCIntegratedCharge : public SubsysReco
   unsigned int m_minLayer;
   unsigned int m_maxLayer;
 
-#endif  // #ifndef __CINT__
+#endif  // #if !defined(__CINT__) || defined(__CLING__)
 };
 
 #endif  // __CALOEVALUATOR_H__

--- a/offline/packages/trackbase/TrkrDefs.h
+++ b/offline/packages/trackbase/TrkrDefs.h
@@ -25,7 +25,7 @@ namespace TrkrDefs
   typedef uint64_t cluskey;     // 64 but TrkrCluster id type
   typedef uint32_t clushitkey;  // 32 bit hit id type in TrkrCluster
   
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   
   /// Max values for keys (used as defaults or invalid values)
   static hitkey HITKEYMAX __attribute__((unused)) = UINT32_MAX;

--- a/offline/packages/trackbase/TrkrDefsLinkDef.h
+++ b/offline/packages/trackbase/TrkrDefsLinkDef.h
@@ -1,4 +1,4 @@
-#ifndef __CINT__
+#ifdef __CINT__
 
 #pragma link C++ namespace TrkrDefs-!;
 

--- a/offline/packages/trackreco/PHGenFitTrkProp.h
+++ b/offline/packages/trackreco/PHGenFitTrkProp.h
@@ -127,7 +127,7 @@ class PHGenFitTrkProp : public PHTrackPropagating
     }
   };
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
   typedef std::list<std::pair<TrackQuality, std::shared_ptr<PHGenFit::Track> > > MapPHGenFitTrack;
 #endif
 
@@ -423,7 +423,7 @@ class PHGenFitTrkProp : public PHTrackPropagating
     _primary_pid_guess = primaryPidGuess;
   }
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
  private:
   //--------------

--- a/offline/packages/trackreco/PHHoughSeeding.h
+++ b/offline/packages/trackreco/PHHoughSeeding.h
@@ -342,7 +342,7 @@ class PHHoughSeeding : public PHTrackSeeding
     _min_combo_hits = minNlayersSeeding;
   }
 
-#ifndef __CINT__
+#if !defined(__CINT__) || defined(__CLING__)
 
  private:
   //--------------

--- a/offline/packages/trackreco/PHPatternReco.h
+++ b/offline/packages/trackreco/PHPatternReco.h
@@ -144,7 +144,6 @@ public:
 	void reset_zooms() {zooms_vec.clear();}
 
 #if !defined(__CINT__) || defined(__CLING__)
-//#ifndef __CINT__
 
 private:
 


### PR DESCRIPTION
This PR makes all headers accessible to rootcling by just excluding rootcint from some parts. rootcling defines __CINT__ and __CLING__ so requiring !__CINT__ || __CLING__ lets rootcling see those. This was already done for most sources, thie PR fixes all of our headers so the old ifndef __CINT__ hopefully stops spreading from now on