### PR TITLE
Improve hierarchy

### DIFF
--- a/offline/packages/trackbase/TrkrHitCellAssoc.cc
+++ b/offline/packages/trackbase/TrkrHitCellAssoc.cc
@@ -9,7 +9,6 @@
 
 #include <g4detectors/PHG4CellDefs.h>  // for keytype
 
-#include <iosfwd>                      // for ostream
 #include <type_traits>                 // for __decay_and_strip<>::__type
 
 TrkrHitCellAssoc::TrkrHitCellAssoc()

--- a/offline/packages/trackreco/CellularAutomaton_v1.cc
+++ b/offline/packages/trackreco/CellularAutomaton_v1.cc
@@ -3,12 +3,16 @@
 #include "HelixHoughSpace.h"    // for HelixHoughSpace
 #include "HelixKalmanFilter.h"  // for HelixKalmanFilter
 
+#include <HelixHough/HelixKalmanState.h>  // for HelixKalmanState
+#include <HelixHough/SimpleHit3D.h>       // for SimpleHit3D
 
+#include <phool/PHObject.h>               // for PHObject
 #include <phool/phool.h>        // for PHWHERE
 
 #include <Eigen/Core>
 
 #include <algorithm>            // for sort
+#include <cassert>
 #include <cfloat>
 #include <cmath>
 #include <cstdlib>             // for exit, NULL

--- a/offline/packages/trackreco/HelixHoughBin_v1.h
+++ b/offline/packages/trackreco/HelixHoughBin_v1.h
@@ -7,6 +7,8 @@
 #include <stddef.h>           // for size_t
 #include <iostream>           // for cout, ostream
 
+class PHObject;
+
 class HelixHoughBin_v1 : public HelixHoughBin {
 
 public:

--- a/offline/packages/trackreco/HelixHoughFuncs_v1.h
+++ b/offline/packages/trackreco/HelixHoughFuncs_v1.h
@@ -7,6 +7,7 @@
 #include <vector>             // for vector
 
 class HelixHoughSpace;
+class PHObject;
 
 class HelixHoughFuncs_v1 : public HelixHoughFuncs {
 

--- a/offline/packages/trackreco/HelixHoughSpace_v1.h
+++ b/offline/packages/trackreco/HelixHoughSpace_v1.h
@@ -6,6 +6,8 @@
 #include <iostream>           // for cout, ostream
 #include <vector>             // for vector
 
+class PHObject;
+
 class HelixHoughSpace_v1 : public HelixHoughSpace {
 
 public:

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -85,6 +85,7 @@
 #include <TVector3.h>
 #include <TMath.h>                                  // for ATan2
 #include <TMatrixDSymfwd.h>                         // for TMatrixDSym
+#include <TMatrixFfwd.h>                            // for TMatrixF
 #include <TMatrixT.h>                               // for TMatrixT, operator*
 #include <TMatrixTSym.h>                            // for TMatrixTSym
 #include <TMatrixTUtils.h>                          // for TMatrixTRow

--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -11,6 +11,7 @@
 
 #include <trackbase/TrkrCluster.h>                      // for TrkrCluster
 #include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrDefs.h>                         // for cluskey, getL...
 
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
@@ -52,7 +53,6 @@
 #include <phgenfit/Fitter.h>
 #include <phgenfit/Measurement.h>                       // for Measurement
 #include <phgenfit/PlanarMeasurement.h>
-#include <phgenfit/SpacepointMeasurement.h>
 #include <phgenfit/Track.h>
 
 //ROOT includes for debugging
@@ -484,7 +484,7 @@ int PHGenFitTrkProp::check_track_exists(MapPHGenFitTrack::iterator iter, SvtxTra
       cout << " trk map size: " << _gftrk_hitkey_map.count(iCluId) << endl;
       cout << "n: " << n << "#Clu_g = " << iCluId << " ntrack match: "  << _assoc_container->GetTracksFromCluster(cluster_ID).size()
 	   << " layer: " << (float)TrkrDefs::getLayer(cluster_ID)
-	   << " r: " << TMath::Sqrt(_cluster_map->findCluster(cluster_ID)->getX()*_cluster_map->findCluster(cluster_ID)->getX() +_cluster_map->findCluster(cluster_ID)->getY()*_cluster_map->findCluster(cluster_ID)->getY() )
+	   << " r: " << sqrt(_cluster_map->findCluster(cluster_ID)->getX()*_cluster_map->findCluster(cluster_ID)->getX() +_cluster_map->findCluster(cluster_ID)->getY()*_cluster_map->findCluster(cluster_ID)->getY() )
 	   << " used: " << n_clu_used
 	   << endl;
       n++;

--- a/offline/packages/trackreco/PHHoughSeeding.cc
+++ b/offline/packages/trackreco/PHHoughSeeding.cc
@@ -15,7 +15,6 @@
 #include <HelixHough/SimpleHit3D.h>
 #include <HelixHough/SimpleTrack3D.h>
 #include <HelixHough/sPHENIXSeedFinder.h>               // for sPHENIXSeedFi...
-#include <HelixHough/VertexFinder.h>
 
 
 // trackbase_historic includes
@@ -43,6 +42,7 @@
 
 #include <phool/PHTimer.h>                              // for PHTimer
 #include <phool/getClass.h>
+#include <phool/phool.h>                                // for PHWHERE
 
 #include <Eigen/Core>                  // for Matrix
 #include <Eigen/Dense>

--- a/offline/packages/trackreco/PHHoughSeeding.h
+++ b/offline/packages/trackreco/PHHoughSeeding.h
@@ -15,7 +15,6 @@
 #include <HelixHough/SimpleHit3D.h>
 #include <HelixHough/SimpleTrack3D.h>
 #include <HelixHough/VertexFinder.h>
-#include <HelixHough/sPHENIXSeedFinder.h>
 #include <Eigen/Core>                  // for Matrix
 #endif
 
@@ -30,22 +29,11 @@
 // forward declarations
 class BbcVertexMap;
 class PHCompositeNode;
-class PHG4CellContainer;
 class PHG4CylinderGeomContainer;
-class PHG4HitContainer;
 class PHTimer;
 class sPHENIXSeedFinder;
-class SvtxTrackMap;
-class SvtxTrack;
-class SvtxVertexMap;
-class SvtxVertex;
 class TNtuple;
 class TFile;
-
-namespace genfit
-{
-class GFRaveVertexFactory;
-} /* namespace genfit */
 
 /// \class PHHoughSeeding
 ///

--- a/offline/packages/trackreco/PHInitZVertexing.cc
+++ b/offline/packages/trackreco/PHInitZVertexing.cc
@@ -1,6 +1,5 @@
 #include "PHInitZVertexing.h"
 
-#include "CellularAutomaton.h"                          // for CellularAutom...
 #include "CellularAutomaton_v1.h"
 #include "HelixHoughBin.h"                              // for HelixHoughBin
 #include "HelixHoughBin_v1.h"                           // for HelixHoughBin_v1
@@ -13,14 +12,12 @@
 #include <trackbase_historic/SvtxVertexMap_v1.h>
 #include <trackbase_historic/SvtxVertex.h>
 #include <trackbase_historic/SvtxVertex_v1.h>
-#include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxTrackMap_v1.h>
 #include <trackbase_historic/SvtxTrack_v1.h>
+#include <trackbase_historic/SvtxVertexMap_v1.h>
 
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrCluster.h>
-
-#include <g4bbc/BbcVertexMap.h>
 
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4detectors/PHG4CylinderGeom.h>
@@ -29,7 +26,6 @@
 
 // sPHENIX includes
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                         // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
@@ -44,7 +40,6 @@
 #include <TNtuple.h>
 
 #include <algorithm>                                    // for find
-#include <climits>                                     // for UINT_MAX
 #include <cmath>
 #include <cstdlib>                                     // for NULL, exit
 #include <iostream>

--- a/offline/packages/trackreco/PHInitZVertexing.h
+++ b/offline/packages/trackreco/PHInitZVertexing.h
@@ -32,9 +32,7 @@ class HelixHoughFuncs;
 class PHCompositeNode;
 class PHTimer;
 
-class TrkrClusterContainer;
 class SvtxTrackMap;
-class SvtxVertexMap;
 
 class TFile;
 class TH2D;

--- a/offline/packages/trackreco/PHTrackSetMerging.cc
+++ b/offline/packages/trackreco/PHTrackSetMerging.cc
@@ -2,21 +2,24 @@
 
 #include "AssocInfoContainer.h"
 
-//#include <trackbase_historic/SvtxClusterMap.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxTrackMap_v1.h>
 #include <trackbase_historic/SvtxVertexMap.h>
-#include <trackbase_historic/SvtxVertexMap_v1.h>
 
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterv1.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>                  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
+#include <phool/PHNode.h>                        // for PHNode
 #include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>                      // for PHObject
 #include <phool/getClass.h>
+#include <phool/phool.h>                         // for PHWHERE
+
+#include <iostream>                              // for operator<<, basic_os...
 
 using namespace std;
 

--- a/offline/packages/trackreco/PHTrackSetMerging.h
+++ b/offline/packages/trackreco/PHTrackSetMerging.h
@@ -7,13 +7,10 @@
 #ifndef TRACKRECO_PHTRACKSETMERGING_H
 #define TRACKRECO_PHTRACKSETMERGING_H
 
-#include "AssocInfoContainer.h"
-
 // PHENIX includes
 #include <fun4all/SubsysReco.h>
 
 // STL includes
-#include <set>
 #include <string>
 
 // forward declarations

--- a/offline/packages/trackreco/PHTruthVertexing.cc
+++ b/offline/packages/trackreco/PHTruthVertexing.cc
@@ -18,6 +18,8 @@
 #include <gsl/gsl_rng.h>
 
 #include <iostream>                            // for operator<<, basic_ostream
+#include <set>                                 // for _Rb_tree_iterator, set
+#include <utility>                             // for pair
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
@@ -158,9 +158,6 @@ void PHG4BeamlineMagnetDetector::ConstructMe(G4LogicalVolume *logicMother)
                                                       G4Material::GetMaterial("G4_Galactic"),
                                                       G4String(GetName().c_str()),
                                                       0, 0, 0);
-  PHG4Subsystem *mysys = GetMySubsystem();
-  mysys->SetLogicalVolume(magnet_logic);
-
   magnet_logic->SetVisAttributes(fieldVis);
 
   /* Set field manager for logical volume */

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -1,7 +1,6 @@
 #include "PHG4BlockDetector.h"
 
 #include "PHG4BlockDisplayAction.h"
-#include "PHG4BlockSubsystem.h"
 
 #include <phparameter/PHParameters.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
@@ -11,9 +11,8 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4BlockDisplayAction;
-class PHG4BlockSubsystem;
-class PHParameters;
 class PHG4Subsystem;
+class PHParameters;
 
 class PHG4BlockDetector : public PHG4Detector
 {

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
@@ -55,6 +55,10 @@ class PHG4BlockSubsystem : public PHG4DetectorSubsystem
     m_ColorArray[2] = blue;
     m_ColorArray[3] = alpha;
   }
+// this method is used to check if it can be used as mothervolume
+// Subsystems which can be mothervolume need to implement this 
+// and return true
+  virtual bool CanBeMotherSubsystem() const {return true;}
 
  private:
   void SetDefaultParameters();

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.cc
@@ -93,9 +93,6 @@ void PHG4CEmcTestBeamDetector::ConstructMe(G4LogicalVolume* logicWorld)
   G4VSolid* cemc_tub = new G4Tubs("CEmcTub", inner_radius - 2 * no_overlap, outer_radius + 2 * no_overlap, (w_dimension[2] + 2 * no_overlap) / 2., 0, cemc_angular_coverage);
   G4LogicalVolume* cemc_log = new G4LogicalVolume(cemc_tub, Air, G4String("CEmc"), 0, 0, 0);
 
-  PHG4Subsystem *mysys = GetMySubsystem();
-  mysys->SetLogicalVolume(cemc_log);
-
   G4RotationMatrix cemc_rotm;
   // put our cemc at center displacement in x
   double radius_at_center = inner_radius + (outer_radius - inner_radius) / 2.;

--- a/simulation/g4simulation/g4detectors/PHG4Cell.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cell.h
@@ -16,10 +16,6 @@
 #include <string>                // for string
 #include <utility>               // for pair, make_pair
 
-#if !defined(__CINT__) || defined(__CLING__)
-#include <type_traits>           // for __decay_and_strip<>::__type
-#endif
-
 class PHG4Cell: public PHObject
 {
  public:

--- a/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.h
@@ -80,6 +80,11 @@ class PHG4ConeSubsystem: public PHG4Subsystem
   void SetActive(const int i = 1) {active = i;}
   void SuperDetector(const std::string &name) {superdetector = name;}
 
+// this method is used to check if it can be used as mothervolume
+// Subsystems which can be mothervolume need to implement this 
+// and return true
+  virtual bool CanBeMotherSubsystem() const {return true;}
+
   private:
 
   //! detector geometry

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
@@ -113,9 +113,6 @@ void PHG4CrystalCalorimeterDetector::ConstructMe(G4LogicalVolume* logicWorld)
 
   G4LogicalVolume* eemc_envelope_log = new G4LogicalVolume(eemc_envelope_solid, Air, G4String("eemc_envelope"), 0, 0, 0);
 
-  PHG4Subsystem *mysys = GetMySubsystem();
-  mysys->SetLogicalVolume(eemc_envelope_log);
-
   GetDisplayAction()->AddVolume(eemc_envelope_log, "Envelope");
   /* Define rotation attributes for envelope cone */
   G4RotationMatrix eemc_rotm;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -56,6 +56,10 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
     m_ColorArray[2] = blue;
     m_ColorArray[3] = alpha;
   }
+// this method is used to check if it can be used as mothervolume
+// Subsystems which can be mothervolume need to implement this 
+// and return true
+  virtual bool CanBeMotherSubsystem() const {return true;}
 
  private:
   void SetDefaultParameters();

--- a/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EICForwardEcalDetector.cc
@@ -66,9 +66,6 @@ void PHG4EICForwardEcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 
   G4LogicalVolume* ecal_envelope_log = new G4LogicalVolume(ecal_envelope_solid, Air, G4String("hEcal_envelope"), 0, 0, 0);
 
-  PHG4Subsystem *mysys = GetMySubsystem();
-  mysys->SetLogicalVolume(ecal_envelope_log);
-
   /* Define visualization attributes for envelope cone */
   GetDisplayAction()->AddVolume(ecal_envelope_log, "Envelope");
 

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
@@ -85,9 +85,6 @@ void PHG4EnvelopeDetector::ConstructMe(G4LogicalVolume* logicWorld)
 
   G4LogicalVolume* GarbageCollector_logical = new G4LogicalVolume(GarbageCollector_solid, material_crystal, G4String("GarbageCollector"), 0, 0, 0);
 
-  PHG4Subsystem *mysys = GetMySubsystem();
-  mysys->SetLogicalVolume(GarbageCollector_logical);
-
   G4VisAttributes* ecalVisAtt = new G4VisAttributes();
   ecalVisAtt->SetVisibility(true);
   ecalVisAtt->SetForceSolid(false);

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSteppingAction.h
@@ -8,7 +8,6 @@
 class G4Step;
 class PHCompositeNode;
 class PHG4FPbScDetector;
-class PHG4Hit;
 class PHG4HitContainer;
 
 class PHG4FPbScSteppingAction : public PHG4SteppingAction

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalDetector.cc
@@ -145,8 +145,6 @@ void PHG4ForwardEcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 
   G4LogicalVolume* ecal_envelope_log = new G4LogicalVolume(ecal_envelope_solid, Air, G4String("hEcal_envelope"), 0, 0, 0);
 
-  PHG4Subsystem *mysys = GetMySubsystem();
-  mysys->SetLogicalVolume(ecal_envelope_log);
   /* Define visualization attributes for envelope cone */
   GetDisplayAction()->AddVolume(ecal_envelope_log, "Envelope");
 

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalDetector.cc
@@ -119,9 +119,6 @@ void PHG4ForwardHcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 
   G4LogicalVolume* hcal_envelope_log = new G4LogicalVolume(hcal_envelope_solid, Air, G4String("hHcal_envelope"), 0, 0, 0);
 
-  PHG4Subsystem *mysys = GetMySubsystem();
-  mysys->SetLogicalVolume(hcal_envelope_log);
-
   m_DisplayAction->AddVolume(hcal_envelope_log, "FHcalEnvelope");
 
   /* Define rotation attributes for envelope cone */

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
@@ -128,8 +128,6 @@ void PHG4HcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
                                        G4String(GetName().c_str()),
                                        0, 0, 0);
   PHG4Subsystem *mysys = GetMySubsystem();
-  mysys->SetLogicalVolume(cylinder_logic);
-  G4VisAttributes* VisAtt = new G4VisAttributes();
   VisAtt->SetColour(G4Colour::Grey());
   VisAtt->SetVisibility(true);
   VisAtt->SetForceSolid(true);

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
@@ -127,7 +127,7 @@ void PHG4HcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
                                        TrackerMaterial,
                                        G4String(GetName().c_str()),
                                        0, 0, 0);
-  PHG4Subsystem *mysys = GetMySubsystem();
+  G4VisAttributes* VisAtt = new G4VisAttributes();
   VisAtt->SetColour(G4Colour::Grey());
   VisAtt->SetVisibility(true);
   VisAtt->SetForceSolid(true);

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -413,9 +413,6 @@ void PHG4InnerHcalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   m_VolumeEnvelope = hcal_envelope_cylinder->GetCubicVolume();
   G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("Hcal_envelope"), 0, 0, 0);
 
-  PHG4Subsystem *mysys = GetMySubsystem();
-  mysys->SetLogicalVolume(hcal_envelope_log);
-
   G4RotationMatrix hcal_rotm;
   hcal_rotm.rotateX(m_Params->get_double_param("rot_x") * deg);
   hcal_rotm.rotateY(m_Params->get_double_param("rot_y") * deg);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -423,8 +423,6 @@ void PHG4OuterHcalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4VSolid *hcal_envelope_cylinder = new G4Tubs("OuterHcal_envelope_solid", m_EnvelopeInnerRadius, m_EnvelopeOuterRadius, m_EnvelopeZ / 2., 0, 2 * M_PI);
   m_VolumeEnvelope = hcal_envelope_cylinder->GetCubicVolume();
   G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("OuterHcal_envelope"), 0, 0, 0);
-  PHG4Subsystem *mysys =  GetMySubsystem();
-  mysys->SetLogicalVolume(hcal_envelope_log);
   G4RotationMatrix hcal_rotm;
   hcal_rotm.rotateX(m_Params->get_double_param("rot_x") * deg);
   hcal_rotm.rotateY(m_Params->get_double_param("rot_y") * deg);

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
@@ -96,7 +96,6 @@ void PHG4ProjCrystalCalorimeterDetector::ConstructMe(G4LogicalVolume *logicWorld
                                             _sPhi, _dPhi);
 
   G4LogicalVolume *ecal_envelope_log = new G4LogicalVolume(ecal_envelope_cone, Air, G4String("eEcal_envelope"), 0, 0, 0);
-  GetMySubsystem()->SetLogicalVolume(ecal_envelope_log);
   GetDisplayAction()->AddVolume(ecal_envelope_log, "Envelope");
   /* Define rotation attributes for envelope cone */
   G4RotationMatrix ecal_rotm;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -159,8 +159,6 @@ void PHG4SpacalDetector::ConstructMe(G4LogicalVolume *logicWorld)
 
   cylinder_logic = new G4LogicalVolume(cylinder_solid, cylinder_mat,
                                        G4String(GetName()), 0, 0, 0);
-  PHG4Subsystem *mysys = GetMySubsystem();
-  mysys->SetLogicalVolume(cylinder_logic);
   GetDisplayAction()->AddVolume(cylinder_logic, "SpacalCylinder");
 
   cylinder_physi = new G4PVPlacement(0,

--- a/simulation/g4simulation/g4eval/JetTruthEval.cc
+++ b/simulation/g4simulation/g4eval/JetTruthEval.cc
@@ -5,12 +5,9 @@
 
 #include <g4jets/Jet.h>
 #include <g4jets/JetMap.h>
-#include <g4main/PHG4Hit.h>
-#include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4Particle.h>
+
 #include <g4main/PHG4TruthInfoContainer.h>
 
-#include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
 

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -14,7 +14,6 @@ class PHCompositeNode;
 class PHG4Hit;
 class PHG4Particle;
 
-class TrkrClusterContainer;
 class SvtxHitEval;
 class SvtxTrack;
 class SvtxTrackMap;

--- a/simulation/g4simulation/g4jleic/G4JLeicDIRCSteppingAction.cc
+++ b/simulation/g4simulation/g4jleic/G4JLeicDIRCSteppingAction.cc
@@ -11,7 +11,6 @@
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
-#include <phool/phool.h>  // for PHWHERE
 
 #include <TSystem.h>
 

--- a/simulation/g4simulation/g4jleic/G4JLeicVTXSteppingAction.cc
+++ b/simulation/g4simulation/g4jleic/G4JLeicVTXSteppingAction.cc
@@ -11,7 +11,6 @@
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
-#include <phool/phool.h>  // for PHWHERE
 
 #include <TSystem.h>
 

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -187,6 +187,7 @@ libg4testbench_la_SOURCES = \
   PHG4ScoringManager.cc \
   PHG4SimpleEventGenerator.cc \
   PHG4SteppingAction.cc \
+  PHG4Subsystem.cc \
   PHG4TrackUserInfoV1.cc \
   PHG4TruthEventAction.cc \
   PHG4TruthSubsystem.cc \

--- a/simulation/g4simulation/g4main/PHG4HitEval.cc
+++ b/simulation/g4simulation/g4main/PHG4HitEval.cc
@@ -17,8 +17,6 @@
 #include <cassert>
 #include <cmath>
 
-class PHG4Hit;
-
 PHG4HitEval::PHG4HitEval() :
     eion(NAN), scint_id(-9999), light_yield(NAN), path_length(NAN)
 

--- a/simulation/g4simulation/g4main/PHG4PhenixDetector.h
+++ b/simulation/g4simulation/g4main/PHG4PhenixDetector.h
@@ -10,7 +10,6 @@
 #include <string>                                 // for string
 
 class G4LogicalVolume;
-class G4Material;
 class G4VPhysicalVolume;
 class PHG4Detector;
 class PHG4PhenixDisplayAction;

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -48,9 +48,9 @@
 #include <boost/format.hpp>
 
 #include <cassert>
-#include <climits>                                  // for numeric_limits
 #include <cmath>                                  // for fabs, M_PI
 #include <iostream>
+#include <limits>                                  // for numeric_limits
 #include <map>                                     // for _Rb_tree_const_ite...
 #include <utility>                                 // for pair
 

--- a/simulation/g4simulation/g4main/PHG4Showerv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Showerv1.cc
@@ -2,8 +2,10 @@
 
 #include "PHG4HitDefs.h"
 
+#include <algorithm>      // for fill
 #include <cmath>
 #include <iostream>
+#include <iterator>       // for begin, end
 #include <utility>
 
 using namespace std;

--- a/simulation/g4simulation/g4main/PHG4Showerv1.h
+++ b/simulation/g4simulation/g4main/PHG4Showerv1.h
@@ -7,6 +7,7 @@
 
 #include "PHG4HitDefs.h"
 
+#include <cstddef>       // for size_t
 #include <iostream>
 #include <map>
 #include <set>

--- a/simulation/g4simulation/g4main/PHG4Subsystem.cc
+++ b/simulation/g4simulation/g4main/PHG4Subsystem.cc
@@ -1,0 +1,20 @@
+#include "PHG4Subsystem.h"
+
+#include <TSystem.h>
+
+#include <iostream>
+
+using namespace std;
+
+void PHG4Subsystem::SetMotherSubsystem(PHG4Subsystem *subsys)
+{
+  if (subsys->CanBeMotherSubsystem())
+  {
+     m_MyMotherSubsystem = subsys;
+     return;
+  }
+  cout << "PHG4Subsystem::SetMotherSubsystem: "
+       << subsys->Name() << " is not implemented as a mother subsystem"
+       << endl;
+  gSystem->Exit(1);
+}

--- a/simulation/g4simulation/g4main/PHG4Subsystem.h
+++ b/simulation/g4simulation/g4main/PHG4Subsystem.h
@@ -71,11 +71,16 @@ class PHG4Subsystem : public SubsysReco
 
   bool CheckOverlap() const { return overlapcheck; }
 
-  void SetMotherSubsystem(PHG4Subsystem *subsys) { m_MyMotherSubsystem = subsys; }
+  void SetMotherSubsystem(PHG4Subsystem *subsys);
   PHG4Subsystem *GetMotherSubsystem() const { return m_MyMotherSubsystem; }
 
   void SetLogicalVolume(G4LogicalVolume *vol) { m_MyLogicalVolume = vol; }
   G4LogicalVolume *GetLogicalVolume() const { return m_MyLogicalVolume; }
+
+// this method is used to check if it can be used as mothervolume
+// Subsystems which can be mothervolume need to implement this 
+// and return true
+  virtual bool CanBeMotherSubsystem() const {return false;}
 
  private:
   PHG4Subsystem *m_MyMotherSubsystem;

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.h
@@ -5,7 +5,7 @@
 
 #include "PHG4EventAction.h"
 
-#include <Geant4/globals.hh>
+#include <Geant4/G4Types.hh>
 
 #include <set>
 #include <map>

--- a/simulation/g4simulation/g4main/PHG4Utils.cc
+++ b/simulation/g4simulation/g4main/PHG4Utils.cc
@@ -4,8 +4,10 @@
 #include <Geant4/G4Colour.hh>  // for G4Colour
 #include <Geant4/G4VisAttributes.hh>
 
+#include <algorithm>                  // for copy
 #include <cmath>
 #include <iostream>  // for operator<<, endl, basic_ostream
+#include <vector>                     // for vector
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/ReadEICFiles.cc
+++ b/simulation/g4simulation/g4main/ReadEICFiles.cc
@@ -23,6 +23,7 @@
 #include <vector>                        // for vector
 
 class PHCompositeNode;
+class PHHepMCGenEvent;
 
 using namespace std;
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
@@ -2,7 +2,6 @@
 
 #include "PHG4MvtxDefs.h"
 #include "PHG4MvtxDisplayAction.h"
-#include "PHG4MvtxSubsystem.h"
 
 #include <mvtx/CylinderGeom_Mvtx.h>
 
@@ -13,6 +12,7 @@
 
 #include <g4main/PHG4Detector.h>       // for PHG4Detector
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
+#include <g4main/PHG4Subsystem.h>                   // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
@@ -17,7 +17,7 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4MvtxDisplayAction;
-class PHG4MvtxSubsystem;
+class PHG4Subsystem;
 class PHParametersContainer;
 
 class PHG4MvtxDetector : public PHG4Detector

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -29,8 +29,6 @@
 #include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>      // for PHObject
-#include <phool/PHTimeServer.h>  // for PHTimeServer
-#include <phool/PHTimer.h>       // for PHTimer
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
@@ -38,7 +36,6 @@
 
 #include <cmath>
 #include <cstdlib>
-#include <cstring>  // for memset
 #include <iostream>
 #include <memory>  // for allocator_tra...
 #include <vector>  // for vector

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -1,7 +1,6 @@
 #include "PHG4TpcDetector.h"
 #include "PHG4TpcDefs.h"
 #include "PHG4TpcDisplayAction.h"
-#include "PHG4TpcSubsystem.h"
 
 #include <g4main/PHG4Detector.h>       // for PHG4Detector
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -89,9 +89,6 @@ void PHG4TpcDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4LogicalVolume *tpc_envelope_logic = new G4LogicalVolume(tpc_envelope,
                                                             G4Material::GetMaterial("G4_AIR"),
                                                             "tpc_envelope");
-  PHG4Subsystem *mysys = GetMySubsystem();
-  mysys->SetLogicalVolume(tpc_envelope_logic);
-
   m_DisplayAction->AddVolume(tpc_envelope_logic, "TpcEnvelope");
 
   ConstructTpcCageVolume(tpc_envelope_logic);

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
@@ -5,9 +5,6 @@
 
 #include <g4main/PHG4Detector.h>
 
-// cannot fwd declare G4RotationMatrix, it is a typedef pointing to clhep
-#include <Geant4/G4RotationMatrix.hh>
-
 #include <set>
 #include <string>
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
@@ -19,7 +19,6 @@
 #endif
 
 class PHCompositeNode;
-class SvtxHitMap;
 
 class PHG4TpcDigitizer : public SubsysReco
 {

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -57,14 +57,10 @@
 #include <GenFit/GFRaveTrackParameters.h>  // for GFRaveTrackParameters
 #include <GenFit/GFRaveVertex.h>
 #include <GenFit/GFRaveVertexFactory.h>
-#include <GenFit/KalmanFittedStateOnPlane.h>  // for KalmanFittedStateOn...
-#include <GenFit/KalmanFitterInfo.h>
-#include <GenFit/MeasuredStateOnPlane.h>
-#include <GenFit/RKTrackRep.h>
 #include <GenFit/Track.h>
-#include <GenFit/TrackPoint.h>
 
 #include <TMath.h>
+#include <TMatrixDSymfwd.h>                        // for TMatrixDSym
 #include <TMatrixTSym.h>    // for TMatrixTSym
 #include <TMatrixTUtils.h>  // for TMatrixTRow
 #include <TVector3.h>       // for TVector3, operator*
@@ -86,7 +82,6 @@ class TGeoManager;
 namespace genfit
 {
 class AbsTrackRep;
-class Track;
 }  // namespace genfit
 
 #define LogDebug(exp) \

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -10,6 +10,7 @@
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxTrack_FastSim.h>
+#include <trackbase_historic/SvtxVertex.h>         // for SvtxVertex
 #include <trackbase_historic/SvtxVertexMap.h>
 
 #include <g4main/PHG4Particle.h>

--- a/simulation/g4simulation/g4vertex/GlobalVertexv1.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexv1.h
@@ -10,6 +10,8 @@
 #include <map>
 #include <utility>         // for pair, make_pair
 
+class PHObject;
+
 class GlobalVertexv1 : public GlobalVertex
 {
  public:


### PR DESCRIPTION
This PR adds some safety to the new mother/daughter volume constructs. Most of our advanced detectors cannot serve as a mother volume, basically only blocks cylinders, cones and the generic gdml detector are candidates for this. The PHG4Subsys base class has now a boolean method CanBeMotherSubsystem() which returns by default false and has to be overridden by subsystems suitable to be mother volumes. This is checked when the mother volume is assigned in the macro followed by a hard exit if it fails.
Also included in this PR is another round of include file cleanups.