### PR TITLE
G4 qt gui

### DIFF
--- a/simulation/g4simulation/g4main/Fun4AllMessenger.cc
+++ b/simulation/g4simulation/g4main/Fun4AllMessenger.cc
@@ -1,0 +1,34 @@
+#include "Fun4AllMessenger.h"
+
+#include <fun4all/Fun4AllServer.h>
+
+#include <Geant4/G4UIcmdWithAnInteger.hh>
+
+using namespace std;
+
+Fun4AllMessenger::Fun4AllMessenger(Fun4AllServer *ffa):
+  se(ffa)
+{
+  m_Fun4AllDir = new G4UIdirectory("/Fun4All/");
+  m_Fun4AllDir->SetGuidance("UI commands to run Fun4All commands"); 
+  m_RunCmd = new G4UIcmdWithAnInteger("/Fun4All/run",this);
+  m_RunCmd->SetGuidance("Run Event(s)");
+  m_RunCmd->SetParameterName("nEvents",1); 
+  m_RunCmd->AvailableForStates(G4State_Idle);
+}
+
+Fun4AllMessenger::~Fun4AllMessenger()
+{
+  delete m_RunCmd;
+  delete m_Fun4AllDir;
+}
+
+void Fun4AllMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
+{
+
+  if (command == m_RunCmd)
+  {
+    se->run(m_RunCmd->GetNewIntValue(newValue));
+  }
+}
+

--- a/simulation/g4simulation/g4main/Fun4AllMessenger.h
+++ b/simulation/g4simulation/g4main/Fun4AllMessenger.h
@@ -19,12 +19,7 @@ void SetNewValue(G4UIcommand*, G4String);
 private:
 
   G4UIdirectory*             m_Fun4AllDir;
-//  G4UIdirectory*             detDir;
   G4UIcmdWithAnInteger*      m_RunCmd;
-//  G4UIcmdWithAString*        fMaterCmd;
-//  G4UIcmdWithoutParameter*   fUpdateCmd;
-  /* G4UIcmdWithADoubleAndUnit  *outerHcalDPhiCmd, *outerPlateTiltAngleCmd; */
-  /* G4UIcmdWithADoubleAndUnit  *innerHcalDPhiCmd, *innerPlateTiltAngleCmd; */
   Fun4AllServer *se;
 };
 

--- a/simulation/g4simulation/g4main/Fun4AllMessenger.h
+++ b/simulation/g4simulation/g4main/Fun4AllMessenger.h
@@ -1,0 +1,31 @@
+#ifndef G4MAIN_FUN4ALLMESSENGER_H
+#define G4MAIN_FUN4ALLMESSENGER_H
+
+#include <Geant4/G4UImessenger.hh>
+
+#include <Geant4/G4String.hh>       // for G4String
+
+class Fun4AllServer;
+class G4UIcmdWithAnInteger;
+
+class Fun4AllMessenger: public G4UImessenger
+{
+public:
+  Fun4AllMessenger(Fun4AllServer *ffa);
+  virtual ~Fun4AllMessenger();
+
+void SetNewValue(G4UIcommand*, G4String);
+
+private:
+
+  G4UIdirectory*             m_Fun4AllDir;
+//  G4UIdirectory*             detDir;
+  G4UIcmdWithAnInteger*      m_RunCmd;
+//  G4UIcmdWithAString*        fMaterCmd;
+//  G4UIcmdWithoutParameter*   fUpdateCmd;
+  /* G4UIcmdWithADoubleAndUnit  *outerHcalDPhiCmd, *outerPlateTiltAngleCmd; */
+  /* G4UIcmdWithADoubleAndUnit  *innerHcalDPhiCmd, *innerPlateTiltAngleCmd; */
+  Fun4AllServer *se;
+};
+
+#endif

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -50,6 +50,7 @@ libg4testbench_la_LIBADD = \
   -lboost_filesystem \
   -lEICPhysicsList \
   -leicsmear \
+  -lfun4all \
   -lg4decayer \
   -lgsl \
   -lgslcblas \
@@ -155,6 +156,7 @@ libphg4hit_la_SOURCES = \
 
 libg4testbench_la_SOURCES = \
   $(ROOT5TBDICTS) \
+  Fun4AllMessenger.cc \
   G4TBMagneticFieldSetup.cc \
   G4TBFieldMessenger.cc \
   HepMCNodeReader.cc \

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -118,9 +118,6 @@ class PHG4SteppingAction;
 
 using namespace std;
 
-// for the G4 cmd line interface
-G4UImanager *UImanager = nullptr;
-
 //_________________________________________________________________
 PHG4Reco::PHG4Reco(const string &name)
   : SubsysReco(name)
@@ -137,6 +134,7 @@ PHG4Reco::PHG4Reco(const string &name)
   , generatorAction_(nullptr)
   , visManager(nullptr)
   , m_Fun4AllMessenger(new Fun4AllMessenger(Fun4AllServer::instance()))
+  , m_UImanager(nullptr)
   , _eta_coverage(1.0)
   , mapdim(PHFieldConfig::kFieldUniform)
   , fieldmapfile("NONE")
@@ -551,7 +549,7 @@ void PHG4Reco::Dump_GDML(const std::string &filename)
 int PHG4Reco::ApplyCommand(const std::string &cmd)
 {
   InitUImanager();
-  int iret = UImanager->ApplyCommand(cmd.c_str());
+  int iret = m_UImanager->ApplyCommand(cmd.c_str());
   return iret;
 }
 //_________________________________________________________________
@@ -564,7 +562,7 @@ int PHG4Reco::StartGui()
   char *args[] = {(char *)("root.exe")};
   G4UIExecutive* ui = new G4UIExecutive(1,args);
   InitUImanager();
-  UImanager->ApplyCommand("/control/execute init_vis.mac");
+  m_UImanager->ApplyCommand("/control/execute init_gui_vis.mac");
   ui->SessionStart();
   delete ui;
   return 0;
@@ -572,13 +570,13 @@ int PHG4Reco::StartGui()
 
 int PHG4Reco::InitUImanager()
 {
-  if (!UImanager)
+  if (!m_UImanager)
   {
     // Get the pointer to the User Interface manager
     // Initialize visualization
     visManager = new G4VisExecutive;
     visManager->Initialize();
-    UImanager = G4UImanager::GetUIpointer();
+    m_UImanager = G4UImanager::GetUIpointer();
   }
   return 0;
 }
@@ -642,12 +640,6 @@ int PHG4Reco::ResetEvent(PHCompositeNode *topNode)
   {
     reco->ResetEvent(topNode);
   }
-  return 0;
-}
-
-//_________________________________________________________________
-int PHG4Reco::End(PHCompositeNode *)
-{
   return 0;
 }
 

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -1,5 +1,6 @@
 #include "PHG4Reco.h"
 
+#include "Fun4AllMessenger.h"
 #include "G4TBMagneticFieldSetup.hh"
 #include "PHG4DisplayAction.h"
 #include "PHG4InEvent.h"
@@ -26,6 +27,7 @@
 #include <phfield/PHFieldUtility.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHDataNode.h>                    // for PHDataNode
@@ -40,7 +42,6 @@
 #include <eicphysicslist/EICPhysicsList.hh>
 
 #include <TSystem.h>                             // for TSystem, gSystem
-#include <TThread.h>
 
 #include <CLHEP/Random/Random.h>
 
@@ -100,6 +101,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
+#include <boost/dll.hpp>
 
 #include <cassert>
 #include <cstdlib>
@@ -116,13 +118,8 @@ class PHG4SteppingAction;
 
 using namespace std;
 
-static TThread *gui_thread = nullptr;
-
 // for the G4 cmd line interface
 G4UImanager *UImanager = nullptr;
-
-// the gui thread
-void g4guithread(void *ptr);
 
 //_________________________________________________________________
 PHG4Reco::PHG4Reco(const string &name)
@@ -139,6 +136,7 @@ PHG4Reco::PHG4Reco(const string &name)
   , m_DisplayAction(nullptr)
   , generatorAction_(nullptr)
   , visManager(nullptr)
+  , m_Fun4AllMessenger(new Fun4AllMessenger(Fun4AllServer::instance()))
   , _eta_coverage(1.0)
   , mapdim(PHFieldConfig::kFieldUniform)
   , fieldmapfile("NONE")
@@ -167,11 +165,11 @@ PHG4Reco::~PHG4Reco(void)
 {
   // one can delete null pointer (it results in a nop), so checking if
   // they are non zero is not needed
-  delete gui_thread;
   delete field_;
   delete runManager_;
   delete uisession_;
   delete visManager;
+  delete  m_Fun4AllMessenger;
   while (subsystems_.begin() != subsystems_.end())
   {
     delete subsystems_.back();
@@ -560,25 +558,16 @@ int PHG4Reco::ApplyCommand(const std::string &cmd)
 
 int PHG4Reco::StartGui()
 {
-  char *args[] = {"/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core/root-6.16.00/bin/root.exe"};
-G4UIExecutive* ui = new G4UIExecutive(1,args);
-  G4VisManager* visManager = new G4VisExecutive;
-  visManager->Initialize();
-  G4UImanager* UImanager = G4UImanager::GetUIpointer();
-    UImanager->ApplyCommand("/control/execute init_vis.mac");
-    ui->SessionStart();
-    delete ui;
-    return 0;
-/*
-  if (!gui_thread)
-  {
-    InitUImanager();
-    gui_thread = new TThread("G4Gui", g4guithread);
-    gui_thread->Run();
-    return 0;
-  }
-  return 1;
-*/
+
+// kludge, using boost::dll::program_location().string().c_str() for the
+// program name and putting it into args lead to invalid reads in G4String
+  char *args[] = {(char *)("root.exe")};
+  G4UIExecutive* ui = new G4UIExecutive(1,args);
+  InitUImanager();
+  UImanager->ApplyCommand("/control/execute init_vis.mac");
+  ui->SessionStart();
+  delete ui;
+  return 0;
 }
 
 int PHG4Reco::InitUImanager()
@@ -597,7 +586,6 @@ int PHG4Reco::InitUImanager()
 //_________________________________________________________________
 int PHG4Reco::process_event(PHCompositeNode *topNode)
 {
-  TThread::Lock();
   // make sure Actions and subsystems have the relevant pointers set
   PHG4InEvent *ineve = findNode::getClass<PHG4InEvent>(topNode, "PHG4INEVENT");
   generatorAction_->SetInEvent(ineve);
@@ -616,7 +604,6 @@ int PHG4Reco::process_event(PHCompositeNode *topNode)
       cout << PHWHERE << " caught exception thrown during process_event from "
            << reco->Name() << endl;
       cout << "error: " << e.what() << endl;
-      TThread::UnLock();
       return Fun4AllReturnCodes::ABORTEVENT;
     }
   }
@@ -643,11 +630,9 @@ int PHG4Reco::process_event(PHCompositeNode *topNode)
       cout << PHWHERE << " caught exception thrown during process_after_geant from "
            << g4sub->Name() << endl;
       cout << "error: " << e.what() << endl;
-      TThread::UnLock();
       return Fun4AllReturnCodes::ABORTEVENT;
     }
   }
-  TThread::UnLock();
   return 0;
 }
 
@@ -717,23 +702,6 @@ void PHG4Reco::set_rapidity_coverage(const double eta)
 void PHG4Reco::G4Seed(const unsigned int i)
 {
   CLHEP::HepRandom::setTheSeed(i);
-  return;
-}
-
-void g4guithread(void *ptr)
-{
-  TThread::Lock();
-  G4UIExecutive *ui = new G4UIExecutive(0, nullptr, "Xm");
-  if (ui->IsGUI() && boost::filesystem::exists("gui.mac"))
-  {
-    UImanager->ApplyCommand("/control/execute gui.mac");
-  }
-  TThread::UnLock();
-  ui->SessionStart();
-  TThread::Lock();
-  delete ui;
-  TThread::UnLock();
-  gui_thread = nullptr;
   return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -560,6 +560,16 @@ int PHG4Reco::ApplyCommand(const std::string &cmd)
 
 int PHG4Reco::StartGui()
 {
+  char *args[] = {"/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core/root-6.16.00/bin/root.exe"};
+G4UIExecutive* ui = new G4UIExecutive(1,args);
+  G4VisManager* visManager = new G4VisExecutive;
+  visManager->Initialize();
+  G4UImanager* UImanager = G4UImanager::GetUIpointer();
+    UImanager->ApplyCommand("/control/execute init_vis.mac");
+    ui->SessionStart();
+    delete ui;
+    return 0;
+/*
   if (!gui_thread)
   {
     InitUImanager();
@@ -568,6 +578,7 @@ int PHG4Reco::StartGui()
     return 0;
   }
   return 1;
+*/
 }
 
 int PHG4Reco::InitUImanager()

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -16,6 +16,7 @@
 // Forward declerations
 class G4RunManager;
 class G4TBMagneticFieldSetup;
+class G4UImanager;
 class G4UImessenger;
 class G4VisManager;
 class PHCompositeNode;
@@ -52,9 +53,6 @@ class PHG4Reco : public SubsysReco
 
   //! Clean up after each event.
   int ResetEvent(PHCompositeNode *);
-
-  //! end of run method
-  int End(PHCompositeNode *);
 
   //! print info
   void Print(const std::string &what = std::string()) const;
@@ -178,6 +176,8 @@ class PHG4Reco : public SubsysReco
 // Message interface to Fun4All
   G4UImessenger *m_Fun4AllMessenger;
 
+// for the G4 cmd line interface
+  G4UImanager *m_UImanager;
   double _eta_coverage;
   PHFieldConfig::FieldConfigTypes mapdim;
   std::string fieldmapfile;

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -9,12 +9,14 @@
 
 #include <phfield/PHFieldConfig.h>
 
+
 #include <list>
 #include <string>                   // for string
 
 // Forward declerations
 class G4RunManager;
 class G4TBMagneticFieldSetup;
+class G4UImessenger;
 class G4VisManager;
 class PHCompositeNode;
 class PHG4DisplayAction;
@@ -130,6 +132,7 @@ class PHG4Reco : public SubsysReco
   void ApplyDisplayAction();
 
  private:
+  static void g4guithread(void *ptr);
   int InitUImanager();
   void DefineMaterials();
   void DefineRegions();
@@ -171,6 +174,9 @@ class PHG4Reco : public SubsysReco
 
   // visualization
   G4VisManager *visManager;
+
+// Message interface to Fun4All
+  G4UImessenger *m_Fun4AllMessenger;
 
   double _eta_coverage;
   PHFieldConfig::FieldConfigTypes mapdim;


### PR DESCRIPTION
This PR adds the G4 qt based command menu. When started with PHG4Reco::StartGui() it takes over and Fun4All commands need to be added to the Fun4AllMessenger. Currently only /Fun4All/run is implemented. The gui can be closed, the control goes back to the Fun4All prompt