### PR TITLE
Fix femc truth

### DIFF
--- a/offline/packages/NodeDump/DumpPHG4TruthInfoContainer.cc
+++ b/offline/packages/NodeDump/DumpPHG4TruthInfoContainer.cc
@@ -3,6 +3,7 @@
 #include <phool/PHIODataNode.h>
 
 #include <g4main/PHG4Particle.h>
+#include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <g4main/PHG4VtxPoint.h>
 
@@ -32,7 +33,15 @@ int DumpPHG4TruthInfoContainer::process_Node(PHNode *myNode)
   if (truthcontainer)
   {
     *fout << "number of G4 tracks: " << truthcontainer->size() << endl;
+    *fout << "min trk index: " << truthcontainer->mintrkindex() << endl;
+    *fout << "max trk index: " << truthcontainer->maxtrkindex() << endl;
     *fout << "number of G4 Vertices: " << truthcontainer->GetNumVertices() << endl;
+    *fout << "min vtx index: " << truthcontainer->minvtxindex() << endl;
+    *fout << "max vtx index: " << truthcontainer->maxvtxindex() << endl;
+    *fout << "number of Showers: " << truthcontainer->shower_size() << endl;
+    *fout << "min shower index: " << truthcontainer->minshowerindex() << endl;
+    *fout << "max shower index: " << truthcontainer->maxshowerindex() << endl;
+
     PHG4TruthInfoContainer::ConstVtxIterator vtxiter;
     //      std::pair< std::map<int, PHG4VtxPoint *>::const_iterator, std::map<int, PHG4VtxPoint *>::const_iterator > vtxbegin_end = truthcontainer->GetVtxRange();
     PHG4TruthInfoContainer::ConstVtxRange vtxbegin_end = truthcontainer->GetVtxRange();
@@ -48,6 +57,18 @@ int DumpPHG4TruthInfoContainer::process_Node(PHNode *myNode)
     {
       *fout << "particle number: " << particle_iter->first << endl;
       (particle_iter->second)->identify(*fout);
+    }
+    PHG4TruthInfoContainer::ConstShowerIterator shower_iter;
+    PHG4TruthInfoContainer::ConstShowerRange showerbegin_end = truthcontainer->GetShowerRange();
+    for (shower_iter = showerbegin_end.first; shower_iter != showerbegin_end.second; ++shower_iter)
+    {
+      *fout << "shower " << shower_iter->first << endl;
+      *fout << "get_id(): " << shower_iter->second->get_id() << endl;
+      *fout << "get_parent_particle_id(): " << shower_iter->second->get_parent_particle_id() << endl;
+      *fout << "get_parent_shower_id(): " << shower_iter->second->get_parent_shower_id() << endl;
+      *fout << "get_x(): " << shower_iter->second->get_x() << endl;
+      *fout << "get_y(): " << shower_iter->second->get_y() << endl;
+      *fout << "get_z(): " << shower_iter->second->get_z() << endl;
     }
   }
   return 0;

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -61,16 +61,6 @@ PHG4ScoringManager::PHG4ScoringManager()
 {
 }
 
-PHG4ScoringManager::~PHG4ScoringManager()
-{
-}
-
-//_________________________________________________________________
-int PHG4ScoringManager::Init(PHCompositeNode *topNode)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
 int PHG4ScoringManager::InitRun(PHCompositeNode *topNode)
 {
   //1. check G4RunManager
@@ -209,11 +199,6 @@ int PHG4ScoringManager::process_event(PHCompositeNode *topNode)
     }  //          if (_load_all_particle) else
   }
 
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int PHG4ScoringManager::ResetEvent(PHCompositeNode *topNode)
-{
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -16,7 +16,7 @@
 #include <phhepmc/PHHepMCGenEvent.h>
 #include <phhepmc/PHHepMCGenEventMap.h>
 
-#include <fun4all/Fun4AllBase.h>                   // for Fun4AllBase::VERBO...
+#include <fun4all/Fun4AllBase.h>  // for Fun4AllBase::VERBO...
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
@@ -24,35 +24,35 @@
 
 #include <phool/getClass.h>
 
-#include <HepMC/SimpleVector.h>                    // for FourVector
+#include <HepMC/SimpleVector.h>  // for FourVector
 
-#include <TAxis.h>                                 // for TAxis
+#include <TAxis.h>  // for TAxis
 #include <TDatabasePDG.h>
 #include <TH1.h>
-#include <TH3.h>                                   // for TH3, TH3D
-#include <TNamed.h>                                // for TNamed
-#include <TParticlePDG.h>                          // for TParticlePDG
+#include <TH3.h>           // for TH3, TH3D
+#include <TNamed.h>        // for TNamed
+#include <TParticlePDG.h>  // for TParticlePDG
 #include <TVector3.h>
 
 #include <Geant4/G4RunManager.hh>
 #include <Geant4/G4ScoringManager.hh>
-#include <Geant4/G4String.hh>                      // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4THitsMap.hh>                    // for G4THitsMap
-#include <Geant4/G4ThreeVector.hh>                 // for G4ThreeVector
-#include <Geant4/G4Types.hh>                       // for G4int, G4double
+#include <Geant4/G4THitsMap.hh>     // for G4THitsMap
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Types.hh>        // for G4int, G4double
 #include <Geant4/G4UImanager.hh>
-#include <Geant4/G4VScoringMesh.hh>                // for G4VScoringMesh
+#include <Geant4/G4VScoringMesh.hh>  // for G4VScoringMesh
 #include <Geant4/G4Version.hh>
 
 #include <boost/format.hpp>
 
 #include <cassert>
-#include <cmath>                                  // for fabs, M_PI
+#include <cmath>  // for fabs, M_PI
 #include <iostream>
-#include <limits>                                  // for numeric_limits
-#include <map>                                     // for _Rb_tree_const_ite...
-#include <utility>                                 // for pair
+#include <limits>   // for numeric_limits
+#include <map>      // for _Rb_tree_const_ite...
+#include <utility>  // for pair
 
 using namespace std;
 
@@ -277,12 +277,12 @@ void PHG4ScoringManager::makeScoringHistograms()
       //      fDivisionAxisNames[0] = "Z";
       //      fDivisionAxisNames[1] = "PHI";
       //      fDivisionAxisNames[2] = "R";
-//      G4VSolid * tubsSolid = new G4Tubs(tubsName+"0", // name
-//                0.,           // R min
-//                fSize[0],     // R max
-//                fSize[1],     // Dz
-//                0.,           // starting phi
-//                                        twopi*rad);   // segment phi
+      //      G4VSolid * tubsSolid = new G4Tubs(tubsName+"0", // name
+      //                0.,           // R min
+      //                fSize[0],     // R max
+      //                fSize[1],     // Dz
+      //                0.,           // starting phi
+      //                                        twopi*rad);   // segment phi
       meshBoundMin[0] = (-meshSize[1] + meshTranslate[0]) / cm;
       meshBoundMax[0] = (meshSize[1] + meshTranslate[0]) / cm;
       meshBoundMin[1] = 0;
@@ -307,7 +307,7 @@ void PHG4ScoringManager::makeScoringHistograms()
     {
       G4String psname = msMapItr->first;
 #if G4VERSION_NUMBER >= 1040
-      std::map<G4int, G4StatDouble*> &score = *(msMapItr->second->GetMap());
+      std::map<G4int, G4StatDouble *> &score = *(msMapItr->second->GetMap());
 #else
       std::map<G4int, G4double *> &score = *(msMapItr->second->GetMap());
 #endif

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.h
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.h
@@ -33,7 +33,7 @@ class PHG4ScoringManager : public SubsysReco
  public:
   PHG4ScoringManager();
 
-  virtual ~PHG4ScoringManager(){}
+  virtual ~PHG4ScoringManager() {}
 
   //! full initialization
   int InitRun(PHCompositeNode *topNode);
@@ -66,7 +66,6 @@ class PHG4ScoringManager : public SubsysReco
   void G4Command(const std::string &cmd);
 
  private:
-
   Fun4AllHistoManager *getHistoManager();
   void makeScoringHistograms();
 

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.h
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.h
@@ -33,18 +33,13 @@ class PHG4ScoringManager : public SubsysReco
  public:
   PHG4ScoringManager();
 
-  virtual ~PHG4ScoringManager();
+  virtual ~PHG4ScoringManager(){}
 
   //! full initialization
-  int Init(PHCompositeNode *);
-
   int InitRun(PHCompositeNode *topNode);
 
   //! event processing method
   int process_event(PHCompositeNode *);
-
-  //! Clean up after each event.
-  int ResetEvent(PHCompositeNode *);
 
   //! end of run method
   int End(PHCompositeNode *);

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -23,10 +23,10 @@
 
 #include <Eigen/Dense>
 
-#include <cmath>      // for isnan
-#include <cstdlib>    // for abs
-#include <iostream>   // for operator<<, endl
-#include <iterator>   // for reverse_iterator
+#include <cmath>     // for isnan
+#include <cstdlib>   // for abs
+#include <iostream>  // for operator<<, endl
+#include <iterator>  // for reverse_iterator
 #include <map>
 #include <string>   // for operator==
 #include <utility>  // for swap, pair
@@ -71,11 +71,11 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
     std::cout << "PHG4TruthEventAction::EndOfEventAction - unable to find G4TruthInfo node" << std::endl;
     return;
   }
-// First deal with the showers - they do need the info which
-// is removed from the maps in the subsequent cleanup to reduce the
-// output file size
-   PruneShowers();
-   ProcessShowers();
+  // First deal with the showers - they do need the info which
+  // is removed from the maps in the subsequent cleanup to reduce the
+  // output file size
+  PruneShowers();
+  ProcessShowers();
   // construct a list of track ids to preserve in the the output that includes any
   // track designated in the m_WriteSet during processing or its ancestry chain
 

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -71,7 +71,11 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
     std::cout << "PHG4TruthEventAction::EndOfEventAction - unable to find G4TruthInfo node" << std::endl;
     return;
   }
-
+// First deal with the showers - they do need the info which
+// is removed from the maps in the subsequent cleanup to reduce the
+// output file size
+   PruneShowers();
+   ProcessShowers();
   // construct a list of track ids to preserve in the the output that includes any
   // track designated in the writeList_ during processing or its ancestry chain
 
@@ -206,9 +210,6 @@ void PHG4TruthEventAction::EndOfEventAction(const G4Event* evt)
     }
     pvtx = pvtx->GetNext();
   }
-
-  PruneShowers();
-  ProcessShowers();
 
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.h
@@ -5,8 +5,6 @@
 
 #include "PHG4EventAction.h"
 
-#include <Geant4/G4Types.hh>
-
 #include <set>
 #include <map>
 
@@ -21,10 +19,10 @@ class PHG4TruthEventAction: public PHG4EventAction
 public:
 
   //! constructor
-  PHG4TruthEventAction( void );
+  PHG4TruthEventAction();
 
   //! destuctor
-  virtual ~PHG4TruthEventAction( void ) {}
+  virtual ~PHG4TruthEventAction() {}
 
   void BeginOfEventAction(const G4Event*);
 
@@ -36,7 +34,7 @@ public:
   void SetInterfacePointers( PHCompositeNode* );
   
   //! add id into track list
-  void AddTrackidToWritelist( const G4int trackid);
+  void AddTrackidToWritelist( const int trackid);
 
  private:
 
@@ -45,15 +43,15 @@ public:
   void ProcessShowers();
   
   //! set of track ids to be written out
-  std::set<G4int> writeList_;
+  std::set<int> m_WriteSet;
 
   //! pointer to truth information container
-  PHG4TruthInfoContainer* truthInfoList_;
+  PHG4TruthInfoContainer* m_TruthInfoContainer;
   
-  int prev_existing_lower_key;
-  int prev_existing_upper_key;
+  int m_LowerKeyPrevExist;
+  int m_UpperKeyPrevExist;
 
-  std::map<int,PHG4HitContainer*> hitmap_;
+  std::map<int,PHG4HitContainer*> m_HitContainerMap;
 };
 
 

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.h
@@ -5,19 +5,17 @@
 
 #include "PHG4EventAction.h"
 
-#include <set>
 #include <map>
+#include <set>
 
 class G4Event;
 class PHG4HitContainer;
 class PHG4TruthInfoContainer;
 class PHCompositeNode;
 
-class PHG4TruthEventAction: public PHG4EventAction
+class PHG4TruthEventAction : public PHG4EventAction
 {
-
-public:
-
+ public:
   //! constructor
   PHG4TruthEventAction();
 
@@ -27,32 +25,30 @@ public:
   void BeginOfEventAction(const G4Event*);
 
   void EndOfEventAction(const G4Event*);
-  
-  int ResetEvent(PHCompositeNode *);
+
+  int ResetEvent(PHCompositeNode*);
 
   //! get relevant nodes from top node passed as argument
-  void SetInterfacePointers( PHCompositeNode* );
-  
+  void SetInterfacePointers(PHCompositeNode*);
+
   //! add id into track list
-  void AddTrackidToWritelist( const int trackid);
+  void AddTrackidToWritelist(const int trackid);
 
  private:
-
   void SearchNode(PHCompositeNode* topNode);
   void PruneShowers();
   void ProcessShowers();
-  
+
   //! set of track ids to be written out
   std::set<int> m_WriteSet;
 
   //! pointer to truth information container
   PHG4TruthInfoContainer* m_TruthInfoContainer;
-  
+
   int m_LowerKeyPrevExist;
   int m_UpperKeyPrevExist;
 
-  std::map<int,PHG4HitContainer*> m_HitContainerMap;
+  std::map<int, PHG4HitContainer*> m_HitContainerMap;
 };
-
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -7,169 +7,180 @@
 #include <boost/tuple/tuple.hpp>
 
 #include <limits>
-#include <string> 
+#include <string>
 
 using namespace std;
 
-PHG4TruthInfoContainer::PHG4TruthInfoContainer() :
-  particlemap(),
-  vtxmap(),
-  particle_embed_flags(),
-  vertex_embed_flags() {
+PHG4TruthInfoContainer::PHG4TruthInfoContainer()
+  : particlemap()
+  , vtxmap()
+  , particle_embed_flags()
+  , vertex_embed_flags()
+{
 }
 
-PHG4TruthInfoContainer::~PHG4TruthInfoContainer() {Reset();}
+PHG4TruthInfoContainer::~PHG4TruthInfoContainer() { Reset(); }
 
-void PHG4TruthInfoContainer::Reset() {
-
-  for (Iterator iter = particlemap.begin(); iter != particlemap.end(); ++iter) {
+void PHG4TruthInfoContainer::Reset()
+{
+  for (Iterator iter = particlemap.begin(); iter != particlemap.end(); ++iter)
+  {
     delete iter->second;
   }
   particlemap.clear();
 
-  for (VtxIterator iter = vtxmap.begin(); iter != vtxmap.end(); ++iter) {
+  for (VtxIterator iter = vtxmap.begin(); iter != vtxmap.end(); ++iter)
+  {
     delete iter->second;
   }
   vtxmap.clear();
 
-  for (ShowerIterator iter = showermap.begin(); iter != showermap.end(); ++iter) {
+  for (ShowerIterator iter = showermap.begin(); iter != showermap.end(); ++iter)
+  {
     delete iter->second;
   }
   showermap.clear();
-  
+
   particle_embed_flags.clear();
   vertex_embed_flags.clear();
-  
+
   return;
 }
 
-void PHG4TruthInfoContainer::identify(ostream& os) const {
-
+void PHG4TruthInfoContainer::identify(ostream& os) const
+{
   cout << "---particlemap--------------------------" << endl;
-  for (ConstIterator iter = particlemap.begin(); iter != particlemap.end(); ++iter) {
-    cout << "particle id " <<  iter->first << endl;
+  for (ConstIterator iter = particlemap.begin(); iter != particlemap.end(); ++iter)
+  {
+    cout << "particle id " << iter->first << endl;
     (iter->second)->identify();
   }
 
   cout << "---vtxmap-------------------------------" << endl;
-  for (ConstVtxIterator vter = vtxmap.begin(); vter != vtxmap.end(); ++vter) {
-    cout << "vtx id: " << vter ->first << endl;
-    (vter ->second)->identify();
+  for (ConstVtxIterator vter = vtxmap.begin(); vter != vtxmap.end(); ++vter)
+  {
+    cout << "vtx id: " << vter->first << endl;
+    (vter->second)->identify();
   }
 
   cout << "---showermap-------------------------------" << endl;
-  for (ConstShowerIterator ster = showermap.begin(); ster != showermap.end(); ++ster) {
-    cout << "shower id: " << ster ->first << endl;
-    (ster ->second)->identify();
+  for (ConstShowerIterator ster = showermap.begin(); ster != showermap.end(); ++ster)
+  {
+    cout << "shower id: " << ster->first << endl;
+    (ster->second)->identify();
   }
-  
+
   cout << "---list of embeded track flags-------------------" << endl;
-  for (std::map<int,int>::const_iterator eter = particle_embed_flags.begin();
+  for (std::map<int, int>::const_iterator eter = particle_embed_flags.begin();
        eter != particle_embed_flags.end();
-       ++eter) {
+       ++eter)
+  {
     cout << "embeded track id: " << eter->first
-	 << " flag: " << eter->second << endl;
+         << " flag: " << eter->second << endl;
   }
-  
+
   cout << "---list of embeded vtx flags-------------------" << endl;
-  for (std::map<int,int>::const_iterator eter = vertex_embed_flags.begin();
+  for (std::map<int, int>::const_iterator eter = vertex_embed_flags.begin();
        eter != vertex_embed_flags.end();
-       ++eter) {
+       ++eter)
+  {
     cout << "embeded vertex id: " << eter->first
-	 << " flag: " << eter->second << endl;
+         << " flag: " << eter->second << endl;
   }
 
   cout << "---primary vertex-------------------" << endl;
-  cout <<"Vertex "<<GetPrimaryVertexIndex()<<" is identified as the primary vertex"<<endl;
-   
+  cout << "Vertex " << GetPrimaryVertexIndex() << " is identified as the primary vertex" << endl;
+
   return;
 }
 
 PHG4TruthInfoContainer::ConstIterator
-PHG4TruthInfoContainer::AddParticle(const int trackid, PHG4Particle *newparticle) {
-  
+PHG4TruthInfoContainer::AddParticle(const int trackid, PHG4Particle* newparticle)
+{
   int key = trackid;
   ConstIterator it;
   bool added = false;
-  boost::tie(it,added) = particlemap.insert(std::make_pair(key,newparticle));
-  if ( added ) return it;
-  
+  boost::tie(it, added) = particlemap.insert(std::make_pair(key, newparticle));
+  if (added) return it;
+
   cerr << "PHG4TruthInfoContainer::AddParticle"
        << " - Attempt to add particle with existing trackid "
-       << trackid <<": "<<newparticle ->get_name()<<" id "
+       << trackid << ": " << newparticle->get_name() << " id "
        << newparticle->get_track_id()
-       <<", p = ["<<newparticle->get_px()
-       <<", "<<newparticle->get_py()
-       <<", "<<newparticle->get_pz()<<"], "
-       <<" parent ID "<<newparticle->get_parent_id()
+       << ", p = [" << newparticle->get_px()
+       << ", " << newparticle->get_py()
+       << ", " << newparticle->get_pz() << "], "
+       << " parent ID " << newparticle->get_parent_id()
        << std::endl;
   return particlemap.end();
 }
 
-PHG4Particle* PHG4TruthInfoContainer::GetParticle(const int trackid) {
-  
+PHG4Particle* PHG4TruthInfoContainer::GetParticle(const int trackid)
+{
   int key = trackid;
   Iterator it = particlemap.find(key);
-  if ( it != particlemap.end() ) return it->second;
+  if (it != particlemap.end()) return it->second;
   return nullptr;
 }
 
-PHG4Particle* PHG4TruthInfoContainer::GetPrimaryParticle(const int trackid) {
-  
+PHG4Particle* PHG4TruthInfoContainer::GetPrimaryParticle(const int trackid)
+{
   if (trackid <= 0) return nullptr;
   Iterator it = particlemap.find(trackid);
-  if ( it != particlemap.end() ) return it->second;
+  if (it != particlemap.end()) return it->second;
   return nullptr;
 }
 
-PHG4VtxPoint* PHG4TruthInfoContainer::GetVtx(const int vtxid) {
-  
+PHG4VtxPoint* PHG4TruthInfoContainer::GetVtx(const int vtxid)
+{
   int key = vtxid;
   VtxIterator it = vtxmap.find(key);
-  if ( it != vtxmap.end() ) return it->second;
+  if (it != vtxmap.end()) return it->second;
   return nullptr;
 }
 
-PHG4VtxPoint* PHG4TruthInfoContainer::GetPrimaryVtx(const int vtxid) {
-
+PHG4VtxPoint* PHG4TruthInfoContainer::GetPrimaryVtx(const int vtxid)
+{
   if (vtxid <= 0) return nullptr;
   VtxIterator it = vtxmap.find(vtxid);
-  if ( it != vtxmap.end() ) return it->second;
+  if (it != vtxmap.end()) return it->second;
   return nullptr;
 }
 
-PHG4Shower* PHG4TruthInfoContainer::GetShower(const int showerid) {
-  
+PHG4Shower* PHG4TruthInfoContainer::GetShower(const int showerid)
+{
   int key = showerid;
   ShowerIterator it = showermap.find(key);
-  if ( it != showermap.end() ) return it->second;
+  if (it != showermap.end()) return it->second;
   return nullptr;
 }
 
-PHG4Shower* PHG4TruthInfoContainer::GetPrimaryShower(const int showerid) {
-  
+PHG4Shower* PHG4TruthInfoContainer::GetPrimaryShower(const int showerid)
+{
   if (showerid <= 0) return nullptr;
   ShowerIterator it = showermap.find(showerid);
-  if ( it != showermap.end() ) return it->second;
+  if (it != showermap.end()) return it->second;
   return nullptr;
 }
 
 PHG4TruthInfoContainer::ConstVtxIterator
-PHG4TruthInfoContainer::AddVertex(const int id, PHG4VtxPoint *newvtx) {
-
+PHG4TruthInfoContainer::AddVertex(const int id, PHG4VtxPoint* newvtx)
+{
   int key = id;
   ConstVtxIterator it;
   bool added = false;
 
-  if (vtxmap.find(id) != vtxmap.end()) {
-    cout << "trying to add existing vtx " << id 
-	 << " vtx pos: " << endl;
+  if (vtxmap.find(id) != vtxmap.end())
+  {
+    cout << "trying to add existing vtx " << id
+         << " vtx pos: " << endl;
     (vtxmap.find(id)->second)->identify();
     identify();
   }
-  
-  boost::tie(it,added) = vtxmap.insert(std::make_pair(key,newvtx));
-  if ( added ) {
+
+  boost::tie(it, added) = vtxmap.insert(std::make_pair(key, newvtx));
+  if (added)
+  {
     newvtx->set_id(key);
     return it;
   }
@@ -180,21 +191,23 @@ PHG4TruthInfoContainer::AddVertex(const int id, PHG4VtxPoint *newvtx) {
 }
 
 PHG4TruthInfoContainer::ConstShowerIterator
-PHG4TruthInfoContainer::AddShower(const int id, PHG4Shower *newshower) {
-
+PHG4TruthInfoContainer::AddShower(const int id, PHG4Shower* newshower)
+{
   int key = id;
   ConstShowerIterator it;
   bool added = false;
 
-  if (showermap.find(id) != showermap.end()) {
-    cout << "trying to add existing shower " << id 
-	 << " shower pos: " << endl;
+  if (showermap.find(id) != showermap.end())
+  {
+    cout << "trying to add existing shower " << id
+         << " shower pos: " << endl;
     (showermap.find(id)->second)->identify();
     identify();
   }
-  
-  boost::tie(it,added) = showermap.insert(std::make_pair(key,newshower));
-  if ( added ) {
+
+  boost::tie(it, added) = showermap.insert(std::make_pair(key, newshower));
+  if (added)
+  {
     newshower->set_id(key);
     return it;
   }
@@ -204,103 +217,103 @@ PHG4TruthInfoContainer::AddShower(const int id, PHG4Shower *newshower) {
   return showermap.end();
 }
 
-int PHG4TruthInfoContainer::maxtrkindex() const {
-  
+int PHG4TruthInfoContainer::maxtrkindex() const
+{
   int key = 0;
   if (!particlemap.empty()) key = particlemap.rbegin()->first;
   if (key < 0) key = 0;
   return key;
 }
 
-int PHG4TruthInfoContainer::mintrkindex() const {
-  
+int PHG4TruthInfoContainer::mintrkindex() const
+{
   int key = 0;
   if (!particlemap.empty()) key = particlemap.begin()->first;
   if (key > 0) key = 0;
   return key;
 }
 
-int PHG4TruthInfoContainer::maxvtxindex() const {
-  
+int PHG4TruthInfoContainer::maxvtxindex() const
+{
   int key = 0;
   if (!vtxmap.empty()) key = vtxmap.rbegin()->first;
   if (key < 0) key = 0;
   return key;
 }
 
-int PHG4TruthInfoContainer::minvtxindex() const {
-  
+int PHG4TruthInfoContainer::minvtxindex() const
+{
   int key = 0;
   if (!vtxmap.empty()) key = vtxmap.begin()->first;
   if (key > 0) key = 0;
   return key;
 }
 
-int PHG4TruthInfoContainer::maxshowerindex() const {
-  
+int PHG4TruthInfoContainer::maxshowerindex() const
+{
   int key = 0;
   if (!showermap.empty()) key = showermap.rbegin()->first;
   if (key < 0) key = 0;
   return key;
 }
 
-int PHG4TruthInfoContainer::minshowerindex() const {
-  
+int PHG4TruthInfoContainer::minshowerindex() const
+{
   int key = 0;
   if (!showermap.empty()) key = showermap.begin()->first;
   if (key > 0) key = 0;
   return key;
 }
 
-void PHG4TruthInfoContainer::delete_particle(Iterator piter) {
-  
+void PHG4TruthInfoContainer::delete_particle(Iterator piter)
+{
   delete piter->second;
   particlemap.erase(piter);
   return;
 }
 
-void PHG4TruthInfoContainer::delete_vtx(VtxIterator viter) {
-  
+void PHG4TruthInfoContainer::delete_vtx(VtxIterator viter)
+{
   delete viter->second;
   vtxmap.erase(viter);
   return;
 }
 
-void PHG4TruthInfoContainer::delete_shower(ShowerIterator siter) {
-  
+void PHG4TruthInfoContainer::delete_shower(ShowerIterator siter)
+{
   delete siter->second;
   showermap.erase(siter);
   return;
 }
 
-int PHG4TruthInfoContainer::isEmbeded(const int trackid) const {
-
-  std::map<int,int>::const_iterator iter = particle_embed_flags.find(trackid);
-  if (iter == particle_embed_flags.end()) {
+int PHG4TruthInfoContainer::isEmbeded(const int trackid) const
+{
+  std::map<int, int>::const_iterator iter = particle_embed_flags.find(trackid);
+  if (iter == particle_embed_flags.end())
+  {
     return 0;
   }
-  
+
   return iter->second;
 }
 
-int PHG4TruthInfoContainer::isEmbededVtx(const int vtxid) const {
-
-  std::map<int,int>::const_iterator iter = vertex_embed_flags.find(vtxid);
-  if (iter == vertex_embed_flags.end()) {
+int PHG4TruthInfoContainer::isEmbededVtx(const int vtxid) const
+{
+  std::map<int, int>::const_iterator iter = vertex_embed_flags.find(vtxid);
+  if (iter == vertex_embed_flags.end())
+  {
     return 0;
   }
-  
+
   return iter->second;
 }
 
-bool
-PHG4TruthInfoContainer::is_primary_vtx(const PHG4VtxPoint* v) const
+bool PHG4TruthInfoContainer::is_primary_vtx(const PHG4VtxPoint* v) const
 {
   return (v->get_id() > 0);
 }
 
-bool
-PHG4TruthInfoContainer::is_primary(const PHG4Particle* p) const
+bool PHG4TruthInfoContainer::is_primary(const PHG4Particle* p) const
 {
   return (p->get_track_id() > 0);
 }

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -48,8 +48,8 @@ public:
   ConstIterator AddParticle(const int particleid, PHG4Particle* newparticle);
   void delete_particle(Iterator piter); 
   
-  PHG4Particle* GetParticle(const int particleid);
-  PHG4Particle* GetPrimaryParticle(const int particleid);
+  PHG4Particle* GetParticle(const int trackid);
+  PHG4Particle* GetPrimaryParticle(const int trackid);
 
   bool is_primary(const PHG4Particle* p) const;
   

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -14,23 +14,22 @@ class PHG4Shower;
 class PHG4Particle;
 class PHG4VtxPoint;
 
-class PHG4TruthInfoContainer: public PHObject {
-  
-public:
-
-  typedef std::map<int,PHG4Particle *> Map;
+class PHG4TruthInfoContainer : public PHObject
+{
+ public:
+  typedef std::map<int, PHG4Particle*> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
 
-  typedef std::map<int,PHG4VtxPoint *> VtxMap;
+  typedef std::map<int, PHG4VtxPoint*> VtxMap;
   typedef VtxMap::iterator VtxIterator;
   typedef VtxMap::const_iterator ConstVtxIterator;
   typedef std::pair<VtxIterator, VtxIterator> VtxRange;
   typedef std::pair<ConstVtxIterator, ConstVtxIterator> ConstVtxRange;
 
-  typedef std::map<int,PHG4Shower *> ShowerMap;
+  typedef std::map<int, PHG4Shower*> ShowerMap;
   typedef ShowerMap::iterator ShowerIterator;
   typedef ShowerMap::const_iterator ConstShowerIterator;
   typedef std::pair<ShowerIterator, ShowerIterator> ShowerRange;
@@ -43,35 +42,36 @@ public:
   void identify(std::ostream& os = std::cout) const;
 
   // --- particle storage ------------------------------------------------------
- 
+
   //! Add a particle that the user has created
   ConstIterator AddParticle(const int particleid, PHG4Particle* newparticle);
-  void delete_particle(Iterator piter); 
-  
+  void delete_particle(Iterator piter);
+
   PHG4Particle* GetParticle(const int trackid);
   PHG4Particle* GetPrimaryParticle(const int trackid);
 
   bool is_primary(const PHG4Particle* p) const;
-  
+
   //! Get a range of iterators covering the entire container
-  Range GetParticleRange() {return Range(particlemap.begin(),particlemap.end());}
-  ConstRange GetParticleRange() const {return ConstRange(particlemap.begin(),particlemap.end());}
+  Range GetParticleRange() { return Range(particlemap.begin(), particlemap.end()); }
+  ConstRange GetParticleRange() const { return ConstRange(particlemap.begin(), particlemap.end()); }
 
-  Range GetPrimaryParticleRange() {return Range(particlemap.upper_bound(0),particlemap.end());}
-  ConstRange GetPrimaryParticleRange() const {return ConstRange(particlemap.upper_bound(0),particlemap.end());}
+  Range GetPrimaryParticleRange() { return Range(particlemap.upper_bound(0), particlemap.end()); }
+  ConstRange GetPrimaryParticleRange() const { return ConstRange(particlemap.upper_bound(0), particlemap.end()); }
 
-  Range GetSecondaryParticleRange() {return Range(particlemap.begin(),particlemap.upper_bound(0));}
-  ConstRange GetSecondaryParticleRange() const {return ConstRange(particlemap.begin(),particlemap.upper_bound(0));}
+  Range GetSecondaryParticleRange() { return Range(particlemap.begin(), particlemap.upper_bound(0)); }
+  ConstRange GetSecondaryParticleRange() const { return ConstRange(particlemap.begin(), particlemap.upper_bound(0)); }
 
   //! track -> particle map size
-  unsigned int size( void ) const {return particlemap.size();}
-  int GetNumPrimaryVertexParticles() {
-    return std::distance(particlemap.upper_bound(0),particlemap.end());
+  unsigned int size(void) const { return particlemap.size(); }
+  int GetNumPrimaryVertexParticles()
+  {
+    return std::distance(particlemap.upper_bound(0), particlemap.end());
   }
-  
+
   //! Get the Particle Map storage
-  const Map& GetMap() const {return particlemap;}
-  
+  const Map& GetMap() const { return particlemap; }
+
   int maxtrkindex() const;
   int mintrkindex() const;
 
@@ -79,8 +79,10 @@ public:
   //! positive ID is the embedded event of interest, e.g. jetty event from pythia
   //! negative IDs are backgrounds, .e.g out of time pile up collisions
   //! Usually, ID = 0 means the primary Au+Au collision background
-  std::pair< std::map<int,int>::const_iterator,
-	     std::map<int,int>::const_iterator > GetEmbeddedTrkIds() const {
+  std::pair<std::map<int, int>::const_iterator,
+            std::map<int, int>::const_iterator>
+  GetEmbeddedTrkIds() const
+  {
     return std::make_pair(particle_embed_flags.begin(), particle_embed_flags.end());
   }
 
@@ -88,8 +90,9 @@ public:
   //! positive ID is the embedded event of interest, e.g. jetty event from pythia
   //! negative IDs are backgrounds, .e.g out of time pile up collisions
   //! Usually, ID = 0 means the primary Au+Au collision background
-  void AddEmbededTrkId(const int id, const int flag) {
-    particle_embed_flags.insert(std::make_pair(id,flag));
+  void AddEmbededTrkId(const int id, const int flag)
+  {
+    particle_embed_flags.insert(std::make_pair(id, flag));
   }
 
   //! Retrieve the embedding ID for the HepMC subevent or track to be analyzed.
@@ -97,33 +100,33 @@ public:
   //! negative IDs are backgrounds, .e.g out of time pile up collisions
   //! Usually, ID = 0 means the primary Au+Au collision background
   int isEmbeded(const int trackid) const;
-   
+
   // --- vertex storage --------------------------------------------------------
-  
+
   //! Add a vertex and return an iterator to the user
   ConstVtxIterator AddVertex(const int vtxid, PHG4VtxPoint* vertex);
   void delete_vtx(VtxIterator viter);
-  
+
   PHG4VtxPoint* GetVtx(const int vtxid);
   PHG4VtxPoint* GetPrimaryVtx(const int vtxid);
 
   bool is_primary_vtx(const PHG4VtxPoint* v) const;
-  
+
   //! Get a range of iterators covering the entire vertex container
-  VtxRange GetVtxRange() {return VtxRange(vtxmap.begin(),vtxmap.end());}
-  ConstVtxRange GetVtxRange() const {return ConstVtxRange(vtxmap.begin(),vtxmap.end());}
+  VtxRange GetVtxRange() { return VtxRange(vtxmap.begin(), vtxmap.end()); }
+  ConstVtxRange GetVtxRange() const { return ConstVtxRange(vtxmap.begin(), vtxmap.end()); }
 
-  VtxRange GetPrimaryVtxRange() {return VtxRange(vtxmap.upper_bound(0),vtxmap.end());}
-  ConstVtxRange GetPrimaryVtxRange() const {return ConstVtxRange(vtxmap.upper_bound(0),vtxmap.end());}
+  VtxRange GetPrimaryVtxRange() { return VtxRange(vtxmap.upper_bound(0), vtxmap.end()); }
+  ConstVtxRange GetPrimaryVtxRange() const { return ConstVtxRange(vtxmap.upper_bound(0), vtxmap.end()); }
 
-  VtxRange GetSecondaryVtxRange() {return VtxRange(vtxmap.begin(),vtxmap.upper_bound(0));}
-  ConstVtxRange GetSecondaryVtxRange() const {return ConstVtxRange(vtxmap.begin(),vtxmap.upper_bound(0));}
-  
+  VtxRange GetSecondaryVtxRange() { return VtxRange(vtxmap.begin(), vtxmap.upper_bound(0)); }
+  ConstVtxRange GetSecondaryVtxRange() const { return ConstVtxRange(vtxmap.begin(), vtxmap.upper_bound(0)); }
+
   //! Get the number of vertices stored
-  unsigned int GetNumVertices() const {return vtxmap.size();}
+  unsigned int GetNumVertices() const { return vtxmap.size(); }
 
   //! Get the Vertex Map storage
-  const VtxMap& GetVtxMap() const {return vtxmap;}
+  const VtxMap& GetVtxMap() const { return vtxmap; }
 
   int maxvtxindex() const;
   int minvtxindex() const;
@@ -136,8 +139,10 @@ public:
   //! positive ID is the embedded event of interest, e.g. jetty event from pythia
   //! negative IDs are backgrounds, .e.g out of time pile up collisions
   //! Usually, ID = 0 means the primary Au+Au collision background
-  std::pair< std::map<int,int>::const_iterator,
-	     std::map<int,int>::const_iterator > GetEmbeddedVtxIds() const {
+  std::pair<std::map<int, int>::const_iterator,
+            std::map<int, int>::const_iterator>
+  GetEmbeddedVtxIds() const
+  {
     return std::make_pair(vertex_embed_flags.begin(), vertex_embed_flags.end());
   }
 
@@ -145,8 +150,9 @@ public:
   //! positive ID is the embedded event of interest, e.g. jetty event from pythia
   //! negative IDs are backgrounds, .e.g out of time pile up collisions
   //! Usually, ID = 0 means the primary Au+Au collision background
-  void AddEmbededVtxId(const int id, const int flag) {
-    vertex_embed_flags.insert(std::make_pair(id,flag));
+  void AddEmbededVtxId(const int id, const int flag)
+  {
+    vertex_embed_flags.insert(std::make_pair(id, flag));
   }
 
   //! Retrieve the embedding ID for the HepMC subevent or track to be analyzed.
@@ -156,61 +162,60 @@ public:
   int isEmbededVtx(const int vtxid) const;
 
   // --- shower storage ------------------------------------------------------
- 
+
   //! Add a shower that the user has created
   ConstShowerIterator AddShower(const int showerid, PHG4Shower* newshower);
-  void delete_shower(ShowerIterator piter); 
-  
+  void delete_shower(ShowerIterator piter);
+
   PHG4Shower* GetShower(const int showerid);
   PHG4Shower* GetPrimaryShower(const int showerid);
 
   //! Get a range of iterators covering the entire container
-  ShowerRange GetShowerRange() {return ShowerRange(showermap.begin(),showermap.end());}
-  ConstShowerRange GetShowerRange() const {return ConstShowerRange(showermap.begin(),showermap.end());}
+  ShowerRange GetShowerRange() { return ShowerRange(showermap.begin(), showermap.end()); }
+  ConstShowerRange GetShowerRange() const { return ConstShowerRange(showermap.begin(), showermap.end()); }
 
-  ShowerRange GetPrimaryShowerRange() {return ShowerRange(showermap.upper_bound(0),showermap.end());}
-  ConstShowerRange GetPrimaryShowerRange() const {return ConstShowerRange(showermap.upper_bound(0),showermap.end());}
+  ShowerRange GetPrimaryShowerRange() { return ShowerRange(showermap.upper_bound(0), showermap.end()); }
+  ConstShowerRange GetPrimaryShowerRange() const { return ConstShowerRange(showermap.upper_bound(0), showermap.end()); }
 
-  ShowerRange GetSecondaryShowerRange() {return ShowerRange(showermap.begin(),showermap.upper_bound(0));}
-  ConstShowerRange GetSecondaryShowerRange() const {return ConstShowerRange(showermap.begin(),showermap.upper_bound(0));}
-  
+  ShowerRange GetSecondaryShowerRange() { return ShowerRange(showermap.begin(), showermap.upper_bound(0)); }
+  ConstShowerRange GetSecondaryShowerRange() const { return ConstShowerRange(showermap.begin(), showermap.upper_bound(0)); }
+
   //! shower size
-  unsigned int shower_size( void ) const {return showermap.size();}
-  
+  unsigned int shower_size(void) const { return showermap.size(); }
+
   //! Get the Shower Map storage
-  const ShowerMap& GetShowerMap() const {return showermap;}
-  
+  const ShowerMap& GetShowerMap() const { return showermap; }
+
   int maxshowerindex() const;
   int minshowerindex() const;
 
  private:
-
   /// particle storage map format description:
   /// primary particles are appended in the positive direction
   /// secondary particles are appended in the negative direction
   /// +N   primary particle id => particle*
-  /// +N-1 
+  /// +N-1
   /// ...
   /// +1   primary particle id => particle*
   /// 0    no entry
   /// -1   secondary particle id => particle*
   /// ...
   /// -M+1
-  /// -M   secondary particle id => particle*  
+  /// -M   secondary particle id => particle*
   Map particlemap;
 
   /// vertex storage map format description:
   /// primary vertexes are appended in the positive direction
   /// secondary vertexes are appended in the negative direction
   /// +N   primary vertex id => vertex*
-  /// +N-1 
+  /// +N-1
   /// ...
   /// +1   primary vertex id => vertex*
   /// 0    no entry
   /// -1   secondary vertex id => vertex*
   /// ...
   /// -M+1
-  /// -M   secondary vertex id => vertex*  
+  /// -M   secondary vertex id => vertex*
   VtxMap vtxmap;
 
   /// shower map
@@ -218,10 +223,10 @@ public:
   ShowerMap showermap;
 
   // embed flag storage, will typically be set for only a few entries or none at all
-  std::map< int, int> particle_embed_flags; //< trackid => embed flag
-  std::map< int, int> vertex_embed_flags;   //< vtxid => embed flag
+  std::map<int, int> particle_embed_flags;  //< trackid => embed flag
+  std::map<int, int> vertex_embed_flags;    //< vtxid => embed flag
 
-  ClassDef(PHG4TruthInfoContainer,1)
+  ClassDef(PHG4TruthInfoContainer, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -63,7 +63,7 @@ public:
   Range GetSecondaryParticleRange() {return Range(particlemap.begin(),particlemap.upper_bound(0));}
   ConstRange GetSecondaryParticleRange() const {return ConstRange(particlemap.begin(),particlemap.upper_bound(0));}
 
-  //! particle size
+  //! track -> particle map size
   unsigned int size( void ) const {return particlemap.size();}
   int GetNumPrimaryVertexParticles() {
     return std::distance(particlemap.upper_bound(0),particlemap.end());


### PR DESCRIPTION
This PR fixes the order of actions in the Truth End of Event action. The showers need track information which is scrubbed during the removal of "unused" entries (unused meaning leading to saved hits). Now the showers are handled before the scrubbing so they have the full information available