### PR TITLE
Gcc 8.3

### DIFF
--- a/generators/PHPythia6/configure.ac
+++ b/generators/PHPythia6/configure.ac
@@ -10,7 +10,11 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
+  if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
+   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror -pedantic "
+  else
    CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
+  fi
 fi
 
 dnl test for root 6

--- a/generators/PHPythia8/configure.ac
+++ b/generators/PHPythia8/configure.ac
@@ -20,7 +20,11 @@ dnl  ;;
 dnl esac
 
 if test $ac_cv_prog_gxx = yes; then
+  if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
+   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror -pedantic "
+  else
    CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
+  fi
 fi
 
 dnl test for root 6

--- a/generators/sHijing/Hijing.cxx
+++ b/generators/sHijing/Hijing.cxx
@@ -39,6 +39,7 @@
 #include <vector>
 #include <numeric>
 #include <cmath>
+#include <random>
 
 #define f2cFortran
 #define gFortran

--- a/offline/packages/jetbackground/configure.ac
+++ b/offline/packages/jetbackground/configure.ac
@@ -18,7 +18,11 @@ dnl  ;;
 dnl esac
 
 if test $ac_cv_prog_gxx = yes; then
+  if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
+   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
+  else
    CXXFLAGS="$CXXFLAGS -Wall -Werror"
+  fi
 fi
 
 dnl test for root 6

--- a/offline/packages/trackreco/HelixHoughSpace.h
+++ b/offline/packages/trackreco/HelixHoughSpace.h
@@ -71,11 +71,11 @@ public :
   virtual float get_dzdl_center(unsigned int zoomlevel, std::vector<unsigned int>& v_il) const  {return NAN;}
   virtual float get_z0_center(unsigned int zoomlevel, std::vector<unsigned int>& v_iz) const    {return NAN;}
 */
-  virtual unsigned int get_kappa_bin(unsigned int zoomlevel, float kappa) const {return NAN;} 
-  virtual unsigned int get_phi_bin(unsigned int zoomlevel, float phi) const   {return NAN;}
-  virtual unsigned int get_d_bin(unsigned int zoomlevel, float d) const     {return NAN;} 
-  virtual unsigned int get_dzdl_bin(unsigned int zoomlevel, float dzdl) const  {return NAN;}
-  virtual unsigned int get_z0_bin(unsigned int zoomlevel, float z0) const    {return NAN;}
+  virtual unsigned int get_kappa_bin(unsigned int zoomlevel, float kappa) const {return UINT_MAX;} 
+  virtual unsigned int get_phi_bin(unsigned int zoomlevel, float phi) const   {return UINT_MAX;}
+  virtual unsigned int get_d_bin(unsigned int zoomlevel, float d) const     {return UINT_MAX;} 
+  virtual unsigned int get_dzdl_bin(unsigned int zoomlevel, float dzdl) const  {return UINT_MAX;}
+  virtual unsigned int get_z0_bin(unsigned int zoomlevel, float z0) const    {return UINT_MAX;}
 
 
   virtual unsigned int get_bin(unsigned int zoomlevel, unsigned int* bins) const {return UINT_MAX;}

--- a/offline/packages/trackreco/PHInitZVertexing.cc
+++ b/offline/packages/trackreco/PHInitZVertexing.cc
@@ -2116,7 +2116,7 @@ int PHInitZVertexing::fit_vertex(){
 	  // Note: this gets a twobinspeak even if only bin j or only bin j+1 is filled
 	  bool twobinspeak =  _mult_twobins*(zcounts[j-1]+zcounts[j-2])<(zcounts[j]+zcounts[j+1]) 
 									&& _mult_twobins*(zcounts[j+2]+zcounts[j+3])< (zcounts[j]+zcounts[j+1]);
-	  bool onebinpeak = _mult_onebin*(zcounts[j-1])<zcounts[j] && _mult_onebin*(zcounts[j+1]< zcounts[j]);
+	  bool onebinpeak = (_mult_onebin*(zcounts[j-1])<zcounts[j]) && (_mult_onebin*zcounts[j+1]< zcounts[j]);
 		
 	  // discard if number of tracks <  the minimum
 	  if ((zcounts[j]>=_min_zvtx_tracks && onebinpeak) || ( (zcounts[j]+zcounts[j+1])>= _min_zvtx_tracks && twobinspeak) 

--- a/simulation/g4simulation/g4jets/configure.ac
+++ b/simulation/g4simulation/g4jets/configure.ac
@@ -18,7 +18,11 @@ dnl  ;;
 dnl esac
 
 if test $ac_cv_prog_gxx = yes; then
+  if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
+   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
+  else
    CXXFLAGS="$CXXFLAGS -Wall -Werror"
+  fi
 fi
 
 dnl test for root 6


### PR DESCRIPTION
This PR adds flags to deal with warnings for use of obsolete constructs (e.g. auto_ptr in our 3rd party libs). gcc found a bad bug in PHInitZVertexing (but then coverity found another one which is not fixed yet) as well as a bad return type for unsigned int (NAN, now UNIT_MAX). PHSartre still doesn't build but this should take care of being able to run with gcc 8.3