### PR TITLE
use # as branch delimeter

### DIFF
--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -427,7 +427,7 @@ PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
   // Loop over all branches in the tree. Each branch-name contains the
   // full 'path' of composite-nodes in the original node tree. We
   // split the name and reconstruct the tree.
-  string delimeters = phooldefs::branchpathdelim + "/";  // add old backslash for backward compat
+  string delimeters = phooldefs::branchpathdelim + phooldefs::legacypathdelims;  // add old backslash for backward compat
   for (i = 0; i < (size_t)(branchArray->GetEntriesFast()); i++)
   {
     string branchname = (*branchArray)[i]->GetName();

--- a/offline/framework/phool/phooldefs.h
+++ b/offline/framework/phool/phooldefs.h
@@ -5,7 +5,8 @@
 
 namespace phooldefs
 {
-  static const std::string branchpathdelim = ".";
+  static const std::string branchpathdelim = "#";
+  static const std::string legacypathdelims = "/.";
   static const std::string nodetreepathdelim = "/";
 }  // namespace phooldefs
 


### PR DESCRIPTION
This PR exchanges the . we have used so far as branch name delimeter by \# The . was interpreted by the TTree->Draw as decimal point which made drawing from the cmd line impossible.
The change is backward compatible, branchnames are still split properly when . is used (or from the really old days /) from previous productions