### PR TITLE
Added minimum number of constituents option to PYTHIA jet trigger

### DIFF
--- a/generators/PHPythia6/PHPy6JetTrigger.cc
+++ b/generators/PHPythia6/PHPy6JetTrigger.cc
@@ -2,20 +2,20 @@
 #include "PHPy6GenTrigger.h"
 
 #include <HepMC/GenEvent.h>
-#include <HepMC/GenParticle.h>         // for GenParticle
-#include <HepMC/SimpleVector.h>        // for FourVector
+#include <HepMC/GenParticle.h>   // for GenParticle
+#include <HepMC/SimpleVector.h>  // for FourVector
 
 // fastjet includes
 #include <fastjet/ClusterSequence.hh>
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/PseudoJet.hh>
 
-#include <cmath>                      // for sqrt
-#include <cstdlib>                    // for abs
-#include <iostream>                    // for operator<<, endl, basic_ostream
-#include <memory>                      // for allocator_traits<>::value_type
-#include <utility>                     // for swap
-#include <vector>                      // for vector
+#include <cmath>     // for sqrt
+#include <cstdlib>   // for abs
+#include <iostream>  // for operator<<, endl, basic_ostream
+#include <memory>    // for allocator_traits<>::value_type
+#include <utility>   // for swap
+#include <vector>    // for vector
 
 using namespace std;
 
@@ -26,6 +26,7 @@ PHPy6JetTrigger::PHPy6JetTrigger(const std::string &name)
   , m_theEtaLow(1.0)
   , m_minPt(10.0)
   , m_R(1.0)
+  , m_nconst(0)
 {
 }
 
@@ -80,7 +81,10 @@ bool PHPy6JetTrigger::Apply(const HepMC::GenEvent *evt)
 
     if (pt > max_pt) max_pt = pt;
 
-    if (pt > m_minPt)
+    vector<fastjet::PseudoJet> constituents = fastjets[ijet].constituents();
+    const int nconst = constituents.size();
+
+    if (pt > m_minPt && nconst >= m_nconst)
     {
       jetFound = true;
       break;

--- a/generators/PHPythia6/PHPy6JetTrigger.h
+++ b/generators/PHPythia6/PHPy6JetTrigger.h
@@ -7,7 +7,7 @@
 
 namespace HepMC
 {
-  class GenEvent;
+class GenEvent;
 }
 
 class PHPy6JetTrigger : public PHPy6GenTrigger
@@ -23,6 +23,7 @@ class PHPy6JetTrigger : public PHPy6GenTrigger
   void SetEtaHighLow(double etaHigh, double etaLow);
   void SetMinJetPt(double minPt) { m_minPt = minPt; }
   void SetJetR(double R) { m_R = R; }
+  void SetMinNumConstituents(int nconst) { m_nconst = nconst; }
 
   void PrintConfig();
 
@@ -31,6 +32,7 @@ class PHPy6JetTrigger : public PHPy6GenTrigger
   double m_theEtaLow;
   double m_minPt;
   double m_R;
+  int m_nconst;
 };
 
 #endif

--- a/generators/PHPythia8/PHPy8JetTrigger.cc
+++ b/generators/PHPythia8/PHPy8JetTrigger.cc
@@ -1,6 +1,6 @@
 #include "PHPy8JetTrigger.h"
 
-#include <Pythia8/Event.h>             // for Event, Particle
+#include <Pythia8/Event.h>  // for Event, Particle
 #include <Pythia8/Pythia.h>
 
 // fastjet includes
@@ -8,12 +8,12 @@
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/PseudoJet.hh>
 
-#include <cmath>                      // for sqrt
-#include <cstdlib>                    // for abs
-#include <iostream>                    // for operator<<, endl, basic_ostream
-#include <memory>                      // for allocator_traits<>::value_type
-#include <utility>                     // for swap
-#include <vector>                      // for vector
+#include <cmath>     // for sqrt
+#include <cstdlib>   // for abs
+#include <iostream>  // for operator<<, endl, basic_ostream
+#include <memory>    // for allocator_traits<>::value_type
+#include <utility>   // for swap
+#include <vector>    // for vector
 
 using namespace std;
 
@@ -91,7 +91,6 @@ bool PHPy8JetTrigger::Apply(Pythia8::Pythia *pythia)
 
     if (pt > _minPt && ijet_nconst >= _nconst)
     {
- 
       if (_minZ > 0.0)
       {
         // Loop over constituents, calculate the z of the leading particle
@@ -102,7 +101,7 @@ bool PHPy8JetTrigger::Apply(Pythia8::Pythia *pythia)
                                fastjets[ijet].py() * fastjets[ijet].py() +
                                fastjets[ijet].pz() * fastjets[ijet].pz());
 
-       for (unsigned int j = 0; j < constituents.size(); j++)
+        for (unsigned int j = 0; j < constituents.size(); j++)
         {
           double con_ptot = sqrt(constituents[j].px() * constituents[j].px() +
                                  constituents[j].py() * constituents[j].py() +

--- a/generators/PHPythia8/PHPy8JetTrigger.cc
+++ b/generators/PHPythia8/PHPy8JetTrigger.cc
@@ -25,6 +25,7 @@ PHPy8JetTrigger::PHPy8JetTrigger(const std::string &name)
   , _minPt(10.0)
   , _minZ(0.0)
   , _R(1.0)
+  , _nconst(0)
 {
 }
 
@@ -85,8 +86,12 @@ bool PHPy8JetTrigger::Apply(Pythia8::Pythia *pythia)
 
     if (pt > max_pt) max_pt = pt;
 
-    if (pt > _minPt)
+    vector<fastjet::PseudoJet> constituents = fastjets[ijet].constituents();
+    int ijet_nconst = constituents.size();
+
+    if (pt > _minPt && ijet_nconst >= _nconst)
     {
+ 
       if (_minZ > 0.0)
       {
         // Loop over constituents, calculate the z of the leading particle
@@ -97,8 +102,7 @@ bool PHPy8JetTrigger::Apply(Pythia8::Pythia *pythia)
                                fastjets[ijet].py() * fastjets[ijet].py() +
                                fastjets[ijet].pz() * fastjets[ijet].pz());
 
-        vector<fastjet::PseudoJet> constituents = fastjets[ijet].constituents();
-        for (unsigned int j = 0; j < constituents.size(); j++)
+       for (unsigned int j = 0; j < constituents.size(); j++)
         {
           double con_ptot = sqrt(constituents[j].px() * constituents[j].px() +
                                  constituents[j].py() * constituents[j].py() +
@@ -160,6 +164,11 @@ void PHPy8JetTrigger::SetMinLeadingZ(double minZ)
 void PHPy8JetTrigger::SetJetR(double R)
 {
   _R = R;
+}
+
+void PHPy8JetTrigger::SetMinNumConstituents(int nconst)
+{
+  _nconst = nconst;
 }
 
 void PHPy8JetTrigger::PrintConfig()

--- a/generators/PHPythia8/PHPy8JetTrigger.h
+++ b/generators/PHPythia8/PHPy8JetTrigger.h
@@ -7,7 +7,7 @@
 
 namespace Pythia8
 {
-  class Pythia;
+class Pythia;
 }
 
 class PHPy8JetTrigger : public PHPy8GenTrigger
@@ -32,7 +32,7 @@ class PHPy8JetTrigger : public PHPy8GenTrigger
   double _minPt;
   double _minZ;
   double _R;
-  int    _nconst;
+  int _nconst;
 };
 
 #endif

--- a/generators/PHPythia8/PHPy8JetTrigger.h
+++ b/generators/PHPythia8/PHPy8JetTrigger.h
@@ -22,6 +22,7 @@ class PHPy8JetTrigger : public PHPy8GenTrigger
   void SetMinJetPt(double minPt);
   void SetJetR(double R);
   void SetMinLeadingZ(double minZ);
+  void SetMinNumConstituents(int nconst);
 
   void PrintConfig();
 
@@ -31,6 +32,7 @@ class PHPy8JetTrigger : public PHPy8GenTrigger
   double _minPt;
   double _minZ;
   double _R;
+  int    _nconst;
 };
 
 #endif


### PR DESCRIPTION
Added simple functionality to the PYTHIA jet trigger class for users to require the jet has a minimum number of constituents. Tested by running default pythia jet macro while requiring a large number of constituents (14) at RHIC energies - each event had at least one jet with 14 or more constituents.

Useful for e.g. photon-jet events where one would like to trigger on a high pT photon and a high pT jet that isn't just composed of (for example) the prompt photon.