### PR TITLE
Enable printing of random seeds for rare problem debugging

### DIFF
--- a/offline/framework/phool/PHRandomSeed.cc
+++ b/offline/framework/phool/PHRandomSeed.cc
@@ -13,7 +13,7 @@ static std::uniform_int_distribution<unsigned int> fDistribution;
 
 bool PHRandomSeed::fInitialized(false);
 bool PHRandomSeed::fFixed(false);
-int PHRandomSeed::verbose(0);
+int PHRandomSeed::verbose(1);
 
 unsigned int PHRandomSeed::GetSeed()
 {


### PR DESCRIPTION
Following the discussion in the last meeting, enable printing of random seeds for rare problem debugging, such as the on-going debug for rare non-initialized variable in the tracking evaluator.