### PR TITLE
Introduce min-layer requirement for truth patter reco

### DIFF
--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -46,7 +46,6 @@ PHTruthTrackSeeding::PHTruthTrackSeeding(const std::string& name)
   , phg4hits_mvtx(nullptr)
   , hittruthassoc(nullptr)
   , clusterhitassoc(nullptr)
-  , _seeding_layers({7, 13, 19, 25, 31, 37, 40})
   , _min_clusters_per_track(3)
 {
 }

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -119,7 +119,6 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
             cout <<__PRETTY_FUNCTION__<<" - validity check failed: missing truth particle with ID of "<<particle_id<<". Exiting..."<<endl;
             exit(1);
           }
-
           const double monentum2 =
               particle->get_px() * particle->get_px()
               +
@@ -127,6 +126,13 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
               +
               particle->get_pz() * particle->get_pz()
               ;
+
+          if (Verbosity() >= 10)
+          {
+            cout <<__PRETTY_FUNCTION__<<" check momentum for particle"<<particle_id<<" -> cluster "<<cluskey
+                <<" = "<<sqrt(monentum2)<<endl;;
+            particle->identify();
+          }
 
           if (monentum2 < _min_momentum * _min_momentum)
           {

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -149,7 +149,7 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
   for (TrkClustersMap::const_iterator trk_clusters_itr = m_trackID_clusters.begin();
        trk_clusters_itr != m_trackID_clusters.end(); ++trk_clusters_itr)
   {
-    if (trk_clusters_itr->second.size() <=  _min_clusters_per_track)
+    if (trk_clusters_itr->second.size() <  _min_clusters_per_track)
       continue;
 
     // check number of layers also pass the _min_clusters_per_track cut to avoid tight loopers
@@ -168,7 +168,7 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
           <<endl;
     }
 
-    if (layers.size() >  _min_clusters_per_track)
+    if (layers.size() >=  _min_clusters_per_track)
     {
 
       std::unique_ptr<SvtxTrack_FastSim> svtx_track(new SvtxTrack_FastSim());

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -43,17 +43,6 @@ class PHTruthTrackSeeding : public PHTrackSeeding
     _min_clusters_per_track = minClustersPerTrack;
   }
 
-  const std::set<unsigned int>& get_seeding_layers() const
-  {
-    return _seeding_layers;
-  }
-
-  void set_seeding_layers(const unsigned int a[], const unsigned int n)
-  {
-    _seeding_layers.clear();
-    for (unsigned int i = 0; i < n; ++i) _seeding_layers.insert(a[i]);
-  }
-
  protected:
   int Setup(PHCompositeNode* topNode);
 
@@ -78,9 +67,6 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   //PHG4CellContainer* cells_svtx;
   //PHG4CellContainer* cells_intt;
   //PHG4CellContainer* cells_maps;
-
-  /// seeding layers
-  std::set<unsigned int> _seeding_layers;
 
   unsigned int _min_clusters_per_track;
 };

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -43,6 +43,18 @@ class PHTruthTrackSeeding : public PHTrackSeeding
     _min_clusters_per_track = minClustersPerTrack;
   }
 
+  //! minimal truth momentum cut
+  double get_min_momentum() const
+  {
+    return _min_momentum;
+  }
+
+  //! minimal truth momentum cut
+  void set_min_momentum(double m)
+  {
+    _min_momentum = m;
+  }
+
  protected:
   int Setup(PHCompositeNode* topNode);
 
@@ -69,6 +81,9 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   //PHG4CellContainer* cells_maps;
 
   unsigned int _min_clusters_per_track;
+
+  //! minimal truth momentum cut
+  double _min_momentum;
 };
 
 #endif


### PR DESCRIPTION
During recent study with truth patter reco by Hugo Pereira Da Costa, rare errors are reported from GenFit fitting module on the GenFit track state's co-variant matrix, which fails the positive definite test. Further debug trace some of the error to tightly coiled delta electron in the TPC volume. They can contribute to many clusters per track but all within few layers. 

This pull request introduce a cut on the minimal layers a track is required to go through to be considered in the truth patter reco. Default cut is set to three, which is the minimal to fit a curve

Nonetheless, this PR does not completely eliminate this error message, as there are still large-radius loopers, which traverse multiple TPC layers. They could still fail in GenFit fit and this error may still be thrown from 
https://github.com/sPHENIX-Collaboration/GenFit/blob/master/core/src/MeasuredStateOnPlane.cc#L148
And print via the ROOT error messaging interface. 
Nonetheless, they are rarer. And for exploratory studies with truth patter reco, it may be useful attempting to fit them anyway. 


