### PR TITLE
add include to resolve phgenfit::Track

### DIFF
--- a/offline/packages/trackreco/PHGenFitTrkFitter.h
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.h
@@ -10,6 +10,10 @@
 
 #include <fun4all/SubsysReco.h>
 
+// needed, it crashes on Ubuntu using singularity with local cvmfs install
+// shared pointer later on uses this, forward declaration does not cut it
+#include <phgenfit/Track.h> 
+
 #include <TMatrixFfwd.h>         // for TMatrixF
 #include <TVector3.h>            // for TVector3
 
@@ -20,11 +24,6 @@
 #include <map>
 
 class TClonesArray;
-
-namespace PHGenFit
-{
-class Track;
-} /* namespace PHGenFit */
 
 namespace genfit
 {


### PR DESCRIPTION
This should take care of the  weird behavior under singularity with local cvmfs copies. phgenfit::Track was forward declared but used in a shared pointer. No idea why it behaved this way but including the declaration fixed this. This include has a comment now to ignore the recommendations from include checkers to remove this