### PR TITLE
properly set rnd seed in PHTruthVertexing

### DIFF
--- a/offline/packages/trackreco/PHTruthVertexing.cc
+++ b/offline/packages/trackreco/PHTruthVertexing.cc
@@ -30,6 +30,18 @@ PHTruthVertexing::PHTruthVertexing(const std::string& name)
   , _g4truth_container(nullptr)
   , _vertex_error({0.01, 0.01, 0.01})
 {
+
+  m_RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
+
+  unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
+  //  cout << Name() << " random seed: " << seed << endl;
+  gsl_rng_set(m_RandomGenerator, seed);
+}
+
+
+
+PHTruthVertexing::~PHTruthVertexing() {
+  gsl_rng_free(m_RandomGenerator);
 }
 
 int PHTruthVertexing::Setup(PHCompositeNode* topNode)
@@ -69,16 +81,11 @@ int PHTruthVertexing::Process(PHCompositeNode* topNode)
 
       gembed_set.insert(gembed);
       
-      gsl_rng* RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
-      unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
-      //  cout << Name() << " random seed: " << seed << endl;
-      gsl_rng_set(RandomGenerator, seed);
       
-      pos[0] += _vertex_error[0] * gsl_ran_ugaussian(RandomGenerator);
-      pos[1] += _vertex_error[1] * gsl_ran_ugaussian(RandomGenerator);
-      pos[2] += _vertex_error[2] * gsl_ran_ugaussian(RandomGenerator);
+      pos[0] += _vertex_error[0] * gsl_ran_ugaussian(m_RandomGenerator);
+      pos[1] += _vertex_error[1] * gsl_ran_ugaussian(m_RandomGenerator);
+      pos[2] += _vertex_error[2] * gsl_ran_ugaussian(m_RandomGenerator);
       
-      gsl_rng_free(RandomGenerator);
       
       if (Verbosity() > 0)
 	{

--- a/offline/packages/trackreco/PHTruthVertexing.h
+++ b/offline/packages/trackreco/PHTruthVertexing.h
@@ -7,10 +7,15 @@
 #ifndef TRACKRECO_PHTRUTHVERTEXING_H
 #define TRACKRECO_PHTRUTHVERTEXING_H
 
-#include "PHInitVertexing.h"
 
+// rootcint barfs with this header so we need to hide it
+#if !defined(__CINT__) || defined(__CLING__)
+#include <gsl/gsl_rng.h>
+#endif
 #include <string>             // for string
 #include <vector>
+
+#include "PHInitVertexing.h"
 
 // forward declarations
 class PHCompositeNode;
@@ -25,7 +30,7 @@ class PHTruthVertexing : public PHInitVertexing
 {
  public:
   PHTruthVertexing(const std::string &name = "PHTruthVertexing");
-  virtual ~PHTruthVertexing() {}
+  virtual ~PHTruthVertexing();
 
   void set_vertex_error(const float &x_err, const float &y_err, const float &z_err)
   {
@@ -56,6 +61,10 @@ class PHTruthVertexing : public PHInitVertexing
 
   /// manually assigned vertex error (standard dev), cm
   std::vector<float> _vertex_error;
+
+#if !defined(__CINT__) || defined(__CLING__)
+  gsl_rng *m_RandomGenerator;
+#endif
 };
 
 #endif


### PR DESCRIPTION
Properly set rnd seed in PHTruthVertexing: not to call `PHRandomSeed()` in `PHTruthVertexing::Process(PHCompositeNode* topNode)`