### PR TITLE
Fix clone() call

### DIFF
--- a/offline/framework/phool/PHNodeIntegrate.cc
+++ b/offline/framework/phool/PHNodeIntegrate.cc
@@ -41,7 +41,7 @@ void PHNodeIntegrate::perform(PHNode *node)
           // since this object was also copied to the node tree we only need
           // to store it in case a second file gets opened where this one then
           // serves as the object which contains the sum
-          sumobj = obj->clone();
+          sumobj = obj->CloneMe();
           PHIODataNode<PHObject> *sumobjnode = new PHIODataNode<PHObject>(sumobj, node->getName(), "PHObject");
           runsumnode->addNode(sumobjnode);
         }

--- a/offline/framework/phool/PHObject.cc
+++ b/offline/framework/phool/PHObject.cc
@@ -11,7 +11,7 @@ class TObject;
 PHObject*
 PHObject::CloneMe() const
 {
-  std::cout << PHWHERE << " clone() not implemented by daugther class"
+  std::cout << PHWHERE << " CloneMe() not implemented by daugther class"
             << std::endl;
   return nullptr;
 }


### PR DESCRIPTION
`PHObject::clone()` has retired to use `PHObject::CloneMe()`. Updating `PHNodeIntegrate` to reflect this change. 

Thanks Yuanjing Ji for finding this problem