### PR TITLE
replace namespace PHGenFit{class Track} by include to make ubuntu happy

### DIFF
--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
@@ -8,7 +8,16 @@
 #ifndef PHGENFIT_FITTER_H
 #define PHGENFIT_FITTER_H
 
-//STL
+#if !defined(__CINT__) || defined(__CLING__)
+// needed, it crashes on Ubuntu using singularity with local cvmfs install
+// shared pointer later on uses this, forward declaration does not cut it
+#include <phgenfit/Track.h> 
+#else
+namespace PHGenFit
+{
+  class Track;
+} /* namespace PHGenFit */
+#endif
 
 #include <GenFit/EventDisplay.h>
 #include "GenFit/Exception.h"
@@ -32,7 +41,6 @@ class AbsBField;
 
 namespace PHGenFit
 {
-class Track;
 
 class Fitter
 {

--- a/offline/packages/trackreco/PHGenFitTrkProp.h
+++ b/offline/packages/trackreco/PHGenFitTrkProp.h
@@ -16,6 +16,15 @@
 
 #if !defined(__CINT__) || defined(__CLING__)
 #include <Eigen/Core>                         // for Matrix
+// needed, it crashes on Ubuntu using singularity with local cvmfs install
+// shared pointer later on uses this, forward declaration does not cut it
+#include <phgenfit/Track.h> 
+#include <gsl/gsl_rng.h>
+#else
+namespace PHGenFit
+{
+  class Track;
+} /* namespace PHGenFit */
 #endif
 
 // standard includes
@@ -41,7 +50,6 @@ class TNtuple;
 namespace PHGenFit
 {
 class Fitter;
-class Track;
 class Measurement;
 } /* namespace PHGenFit */
 

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -17,7 +17,15 @@
 
 // rootcint barfs with this header so we need to hide it
 #if !defined(__CINT__) || defined(__CLING__)
+// needed, it crashes on Ubuntu using singularity with local cvmfs install
+// shared pointer later on uses this, forward declaration does not cut it
+#include <phgenfit/Track.h> 
 #include <gsl/gsl_rng.h>
+#else
+namespace PHGenFit
+{
+  class Track;
+} /* namespace PHGenFit */
 #endif
 
 #include <climits>  // for UINT_MAX


### PR DESCRIPTION
This PR fixes more of those ubuntu crashes. Now all namespace PHGenFit{class Track;} are replaced by the include file