### PR TITLE
Clusterizer

### DIFF
--- a/offline/packages/CaloReco/BEmcCluster.cc
+++ b/offline/packages/CaloReco/BEmcCluster.cc
@@ -524,7 +524,10 @@ void EmcCluster::GetErrors(float* pde, float* pdx, float* pdy, float* pdz)
 
 float EmcCluster::GetProb(float& chi2, int& ndf)
 {
-  return fOwner->GetProb(fHitList, chi2, ndf);
+  float e, xg, yg, zg;
+  e = GetTotalEnergy();
+  GetGlobalPos(xg,yg,zg);
+  return fOwner->GetProb(fHitList, e,xg,yg,zg, chi2, ndf);
 }
 
 // ///////////////////////////////////////////////////////////////////////////

--- a/offline/packages/CaloReco/BEmcProfile.cc
+++ b/offline/packages/CaloReco/BEmcProfile.cc
@@ -141,7 +141,7 @@ float BEmcProfile::GetProb(std::vector<EmcModule>* plist, int NX, float en, floa
   // z coordinate below means x coordinate
 
   float ee;
-  int ich;
+  int ich, iy, iz;
 
   int iy0 = -1, iz0 = -1;
   float emax = 0;
@@ -165,8 +165,8 @@ float BEmcProfile::GetProb(std::vector<EmcModule>* plist, int NX, float en, floa
   {
     ee = (*plist)[i].amp;
     ich = (*plist)[i].ich;
-    int iy = ich / NX;
-    int iz = ich % NX;
+    iy = ich / NX;
+    iz = ich % NX;
     if (ee > thresh && abs(iz - iz0) <= 3 && abs(iy - iy0) <= 3)
     {
       etot += ee;
@@ -363,10 +363,10 @@ void BEmcProfile::PredictEnergy(int ip, float energy, float theta, float ddz, fl
   }
 
   // Safety margin (slightly away from bin edge)
-  if (ddz < 0.021) ddz = 0.021;
-  if (ddz > 0.489) ddz = 0.489;
-  if (ddy < 0.021) ddy = 0.021;
-  if (ddy > 0.489) ddy = 0.489;
+  //  if (ddz < 0.021) ddz = 0.021;
+  //  if (ddz > 0.489) ddz = 0.489;
+  //  if (ddy < 0.021) ddy = 0.021;
+  //  if (ddy > 0.489) ddy = 0.489;
 
   // Energy bin
   int ie2 = 0;
@@ -439,6 +439,18 @@ void BEmcProfile::PredictEnergy(int ip, float energy, float theta, float ddz, fl
   if (pr < 0) pr = 0;
   float er = ert1 + (ert2 - ert1) / (pow(th2, 2) - pow(th1, 2)) * (pow(theta, 2) - pow(th1, 2));
   if (er < 0) er = 0;
+
+  // Additional error due to binning in xx
+  //
+  int ibin1 = ibin;
+  if( ibin>1 ) ibin1 = ibin-1;
+  int ibin2 = ibin;
+  if( ibin < hmean[ii11]->GetNbinsX() )
+    if( hmean[ii11]->GetBinContent(ibin+1) > 0 ) ibin2 = ibin+1;
+  float dd = (hmean[ii11]->GetBinContent(ibin2) -
+              hmean[ii11]->GetBinContent(ibin1) ) / 2.;
+  //  if( fabs(dd)>er ) printf("ie=%d it=%d bin=%d: %f %f\n",ie1,it1,ibin,er,dd);
+  er = sqrt(er*er + dd*dd);
 
   ep = pr;
   err = er;

--- a/offline/packages/CaloReco/BEmcRecCEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecCEMC.cc
@@ -1,15 +1,224 @@
 #include "BEmcRecCEMC.h"
 #include "BEmcCluster.h"
+#include "BEmcProfile.h"
+
+#include <TMath.h>
 
 #include <cmath>
 #include <cstdio>
 
-void BEmcRecCEMC::Tower2Global(float E, float xC, float yC,
-                               float& xA, float& yA, float& zA)
+using namespace std;
+
+BEmcRecCEMC::BEmcRecCEMC() : _emcprof(nullptr) 
 {
-  xA = 0;
-  yA = 0;
-  zA = 0;
+  SetCylindricalGeometry();
+}
+
+BEmcRecCEMC::~BEmcRecCEMC()
+{
+  if (_emcprof) delete _emcprof;
+}
+
+
+void BEmcRecCEMC::LoadProfile(const char *fname) 
+{
+  //  printf("Infor from BEmcRecCEMC::LoadProfile(): no external file used for shower profile evaluation in CEMC\n");
+  _emcprof = new BEmcProfile(fname); 
+}
+
+
+float BEmcRecCEMC::GetProb(vector<EmcModule> HitList, float ecl, float xg, float yg, float zg, float& chi2, int& ndf)
+{
+  chi2 = 0;
+  ndf = 0;
+  float prob = -1;
+
+  //  float theta = atan(sqrt(xg*xg + yg*yg)/fabs(zg-fVz));
+  float rg = sqrt(xg*xg+yg*yg);
+  float theta_twr;
+  if( fabs(zg)<=15 ) theta_twr = 0;
+  else if( zg>15 )   theta_twr = atan2(zg-15,rg);
+  else               theta_twr = atan2(zg+15,rg);
+  float theta_tr = atan2(zg-fVz,rg);
+  float theta = fabs(theta_tr - theta_twr);
+
+  if( _emcprof != nullptr ) prob = _emcprof->GetProb(&HitList,fNx,ecl,theta);
+
+  return prob;
+}
+
+/*
+float BEmcRecCEMC::GetProb(vector<EmcModule> HitList, float et, float xg, float yg, float zg, float& chi2, int& ndf)
+// et, xg, yg, zg not used here
+{
+  const float thresh = 0.01;
+  const int DXY = 3;  // 2 is for 5x5 matrix; 3 for 7x7 matrix
+  const int Nmax = 1000;
+  float ee[Nmax];
+  int iyy[Nmax];
+  int izz[Nmax];
+
+  int ich;
+  vector<EmcModule>::iterator ph = HitList.begin();
+
+  chi2 = 0;
+  ndf = 0;
+
+  int nn = 0;
+
+  while (ph != HitList.end())
+  {
+    ee[nn] = ph->amp;
+    if (ee[nn] > thresh)
+    {
+      ich = ph->ich;
+      izz[nn] = ich % fNx;
+      iyy[nn] = ich / fNx;
+      nn++;
+      if (nn >= Nmax)
+      {
+        printf("BEmcRec::GetProb: Cluster size is too big. Skipping the rest of the towers\n");
+        break;
+      }
+    }  // if( ee[nn]
+    ++ph;
+  }  // while( ph
+
+  if (nn <= 0) return -1;
+
+  int iy0 = -1, iz0 = -1;
+  float emax = 0;
+
+  for (int i = 0; i < nn; i++)
+  {
+    if (ee[i] > emax)
+    {
+      emax = ee[i];
+      iy0 = iyy[i];
+      iz0 = izz[i];
+    }
+  }
+
+  if (emax <= 0) return -1;
+
+  int id;
+  float etot = 0;
+  float sz = 0;
+  float sy = 0;
+
+  for (int idz = -DXY; idz <= DXY; idz++)
+  {
+    for (int idy = -DXY; idy <= DXY; idy++)
+    {
+      id = GetTowerID(iy0 + idy, iz0 + idz, nn, iyy, izz, ee);
+      if (id >= 0)
+      {
+        etot += ee[id];
+        sz += ee[id] * (iz0 + idz);
+        sy += ee[id] * (iy0 + idy);
+      }
+    }
+  }
+  float zcg = sz / etot;  // Here cg allowed to be out of range
+  float ycg = sy / etot;
+  int iz0cg = int(zcg + 0.5);
+  int iy0cg = int(ycg + 0.5);
+  float ddz = fabs(zcg - iz0cg);
+  float ddy = fabs(ycg - iy0cg);
+
+  int isz = 1;
+  if (zcg - iz0cg < 0) isz = -1;
+  int isy = 1;
+  if (ycg - iy0cg < 0) isy = -1;
+
+  // 4 central towers: 43
+  //                   12
+  // Tower 1 - central one
+  float e1, e2, e3, e4;
+  e1 = e2 = e3 = e4 = 0;
+  id = GetTowerID(iy0cg, iz0cg, nn, iyy, izz, ee);
+  if (id >= 0) e1 = ee[id];
+  id = GetTowerID(iy0cg, iz0cg + isz, nn, iyy, izz, ee);
+  if (id >= 0) e2 = ee[id];
+  id = GetTowerID(iy0cg + isy, iz0cg + isz, nn, iyy, izz, ee);
+  if (id >= 0) e3 = ee[id];
+  id = GetTowerID(iy0cg + isy, iz0cg, nn, iyy, izz, ee);
+  if (id >= 0) e4 = ee[id];
+
+  float e1t = (e1 + e2 + e3 + e4) / etot;
+  float e2t = (e1 + e2 - e3 - e4) / etot;
+  float e3t = (e1 - e2 - e3 + e4) / etot;
+  float e4t = (e3) / etot;
+  //  float e5t = (e2+e4)/etot;
+
+  float rr = sqrt((0.5 - ddz) * (0.5 - ddz) + (0.5 - ddy) * (0.5 - ddy));
+
+  float c1, c2, c11;
+
+  float logE = log(etot);
+
+  // e1 energy is the most effective for PID if properly tuned !
+  // Discrimination power is very sensitive to paramter c1: the bigger it is
+  // the better discrimination;
+  c1 = 0.95;
+  c2 = 0.0066364 * logE + 0.00466667;
+  if (c2 < 0) c2 = 0;
+  float e1p = c1 - c2 * rr * rr;
+  c1 = 0.034 - 0.01523 * logE + 0.0029 * logE * logE;
+  float err1 = c1;
+
+  // For e2
+  c1 = 0.00844086 + 0.00645359 * logE - 0.00119381 * logE * logE;
+  if (etot > 15) c1 = 0.00844086 + 0.00645359 * log(15.) - 0.00119381 * log(15.) * log(15.);  // Const at etot>15GeV
+  if (c1 < 0) c1 = 0;
+  c2 = 3.9;                                                      // Fixed
+  float e2p = sqrt(c1 + 0.25 * c2) - sqrt(c1 + c2 * ddy * ddy);  // =0 at ddy=0.5
+
+  c1 = 0.0212333 + 0.0420473 / etot;
+  c2 = 0.090;  // Fixed
+  float err2 = c1 + c2 * ddy;
+  if (ddy > 0.3) err2 = c1 + c2 * 0.3;  // Const at ddy>0.3
+
+  // For e3
+  c1 = 0.0107857 + 0.0056801 * logE - 0.000892016 * logE * logE;
+  if (etot > 15) c1 = 0.0107857 + 0.0056801 * log(15.) - 0.000892016 * log(15.) * log(15.);  // Const at etot>15GeV
+  if (c1 < 0) c1 = 0;
+  c2 = 3.9;                                                      // Fixed
+  float e3p = sqrt(c1 + 0.25 * c2) - sqrt(c1 + c2 * ddz * ddz);  // =0 at ddz=0.5
+
+  //  c1 = 0.0200 + 0.042/etot;
+  c1 = 0.0167 + 0.058 / etot;
+  c2 = 0.090;  // Fixed
+  float err3 = c1 + c2 * ddz;
+  if (ddz > 0.3) err3 = c1 + c2 * 0.3;  // Const at ddz>0.3
+
+  // For e4
+  float e4p = 0.25 - 0.668 * rr + 0.460 * rr * rr;
+  c11 = 0.171958 + 0.0142421 * logE - 0.00214827 * logE * logE;
+  //  c11 = 0.171085 + 0.0156215*logE - -0.0025809*logE*logE;
+  float err4 = 0.102 - 1.43 * c11 * rr + c11 * rr * rr;  // Min is set to x=1.43/2.
+  err4 *= 1.1;
+
+  chi2 = 0.;
+  chi2 += (e1p - e1t) * (e1p - e1t) / err1 / err1;
+  chi2 += (e2p - e2t) * (e2p - e2t) / err2 / err2;
+  chi2 += (e3p - e3t) * (e3p - e3t) / err3 / err3;
+  chi2 += (e4p - e4t) * (e4p - e4t) / err4 / err4;
+  ndf = 4;
+
+  //  chi2 /= 1.1;
+  float prob = TMath::Prob(chi2, ndf);
+
+  return prob;
+}
+*/
+
+void BEmcRecCEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, float& xC, float& yC, float& zC )
+{
+  xC = xA;
+  yC = yA;
+  zC = zA;
+  return;
 }
 
 void BEmcRecCEMC::CorrectEnergy(float Energy, float x, float y,
@@ -35,6 +244,7 @@ void BEmcRecCEMC::CorrectEnergy(float Energy, float x, float y,
   corr = leak*att;
   *Ecorr = Energy/corr;
   */
+  *Ecorr = Energy;
 }
 
 void BEmcRecCEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
@@ -48,6 +258,91 @@ void BEmcRecCEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
   *Ecorr = Ecore / c0;
 }
 
+
+void BEmcRecCEMC::CorrectPosition(float Energy, float x, float y,
+                                  float* pxc, float* pyc)
+{
+  // Corrects the Shower Center of Gravity for the systematic shift due to
+  // limited tower size
+  //
+  // Everything here is in tower units.
+  // (x,y) - CG position, (*pxc,*pyc) - corrected position
+
+  float xZero, yZero, bx, by;
+  float t, x0, y0;
+  int ix0, iy0;
+
+  *pxc = x;
+  *pyc = y;
+
+  if (Energy < 0.01) return;
+  /*
+  float xA, yA, zA;
+  Tower2Global(Energy, x, y, xA, yA, zA);
+  zA -= fVz;
+  float sinTx = xA / sqrt(xA * xA + zA * zA);
+  float sinTy = yA / sqrt(yA * yA + zA * zA);
+  */
+  float sinTx = 0;
+  float sinTy = 0;
+
+  float sin2Tx = sinTx * sinTx;
+  float sin2Ty = sinTy * sinTy;
+
+  if (sinTx > 0)
+    xZero = -0.417 * sinTx - 1.500 * sin2Tx;
+  else
+    xZero = -0.417 * sinTx + 1.500 * sin2Tx;
+
+  if (sinTy > 0)
+    yZero = -0.417 * sinTy - 1.500 * sin2Ty;
+  else
+    yZero = -0.417 * sinTy + 1.500 * sin2Ty;
+
+  t = 0.98 + 0.98 * sqrt(Energy);
+  bx = 0.15 + t * sin2Tx;
+  by = 0.15 + t * sin2Ty;
+
+  x0 = x + xZero;
+  ix0 = EmcCluster::lowint(x0 + 0.5);
+
+  if (EmcCluster::ABS(x0 - ix0) <= 0.5)
+  {
+    x0 = (ix0 - xZero) + bx * asinh(2. * (x0 - ix0) * sinh(0.5 / bx));
+  }
+  else
+  {
+    x0 = x;
+    printf("????? Something wrong in BEmcRecCEMC::CorrectPosition: x=%f  dx=%f\n", x, x0 - ix0);
+  }
+
+  // Correct for phi bias within module of 8 towers
+  int ix8 = int(x+0.5)/8;
+  float x8 = x+0.5-ix8*8-4; // from -4 to +4
+  float dx = 0.10 * x8 / 4.;
+  if( fabs(x8)>3.3 ) dx=0; // Don't correct near the module edge
+  //  dx = 0;
+
+  *pxc = x0-dx;
+
+  y0 = y + yZero;
+  iy0 = EmcCluster::lowint(y0 + 0.5);
+
+  if (EmcCluster::ABS(y0 - iy0) <= 0.5)
+  {
+    y0 = (iy0 - yZero) + by * asinh(2. * (y0 - iy0) * sinh(0.5 / by));
+  }
+  else
+  {
+    y0 = y;
+    printf("????? Something wrong in BEmcRecCEMC::CorrectPosition: y=%f  dy=%f\n", y, y0 - iy0);
+  }
+  *pyc = y0;
+
+}
+
+
+/*
 void BEmcRecCEMC::CorrectPosition(float Energy, float x, float y,
                                   float* pxc, float* pyc)
 {
@@ -64,6 +359,10 @@ void BEmcRecCEMC::CorrectPosition(float Energy, float x, float y,
 
   const float Xrad = 0.3;  // !!!!! Need to put correct value
   const float Remc = 90.;  // EMCal inner radius. !!!!! Should be obtained from geometry container
+
+  *pxc = x;
+  *pyc = y;
+  //  return;
 
   SetProfileParameters(0, Energy, x, y);
   // if( fSinTx >= 0 ) signx =  1;
@@ -110,3 +409,4 @@ void BEmcRecCEMC::CorrectPosition(float Energy, float x, float y,
     printf("????? Something wrong in CorrectPosition: y=%f  dy=%f\n", y, y0 - iy0);
   }
 }
+*/

--- a/offline/packages/CaloReco/BEmcRecCEMC.h
+++ b/offline/packages/CaloReco/BEmcRecCEMC.h
@@ -3,15 +3,23 @@
 
 #include "BEmcRec.h"
 
+class BEmcProfile;
+
 class BEmcRecCEMC : public BEmcRec
 {
  public:
-  BEmcRecCEMC(){};
-  ~BEmcRecCEMC() {}
+  BEmcRecCEMC();
+  ~BEmcRecCEMC();
   void CorrectEnergy(float energy, float x, float y, float *ecorr);
-  void CorrectPosition(float energy, float x, float y, float *xcorr, float *ycorr);
   void CorrectECore(float ecore, float x, float y, float *ecorecorr);
-  void Tower2Global(float E, float xC, float yC, float &xA, float &yA, float &zA);
+  void CorrectPosition(float energy, float x, float y, float *xcorr, float *ycorr);
+  void CorrectShowerDepth(float energy, float x, float y, float z, float& xc, float& yc, float& zc );
+
+  void LoadProfile(const char *fname);
+  float GetProb(std::vector<EmcModule> HitList, float e, float xg, float yg, float zg, float &chi2, int &ndf);
+
+ private:
+  BEmcProfile *_emcprof;
 };
 
 #endif

--- a/offline/packages/CaloReco/BEmcRecEEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecEEMC.cc
@@ -1,107 +1,69 @@
 #include "BEmcRecEEMC.h"
 #include "BEmcCluster.h"
+#include "BEmcProfile.h"
 
 #include <cmath>
 #include <cstdio>
 
-void BEmcRecEEMC::Tower2Global(float E, float xC, float yC,
-                               float& xA, float& yA, float& zA)
-// With shower depth correction reflected in zA
+using namespace std;
+
+BEmcRecEEMC::BEmcRecEEMC() : _emcprof(nullptr) 
+{
+  SetPlanarGeometry();
+}
+
+BEmcRecEEMC::~BEmcRecEEMC()
+{
+  if (_emcprof) delete _emcprof;
+}
+
+void BEmcRecEEMC::LoadProfile(const char *fname)
+{
+  printf("Infor from BEmcRecEEMC::LoadProfile(): no shower profile evaluation is defined yet for EEMC\n");
+}
+
+float BEmcRecEEMC::GetProb(vector<EmcModule> HitList, float et, float xg, float yg, float zg, float& chi2, int& ndf)
+// et, xg, yg, zg not used here
+{
+  chi2 = 0;
+  ndf = 0;
+  float prob = -1;
+  return prob;
+}
+
+void BEmcRecEEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, float& xC, float& yC, float& zC )
 {
   // DZ, D and X0 should be negative for -Z direction
   const float DZ = -9;     // in cm, tower half length
   const float D = -6.1;    // in cm, shower depth at 1 GeV relative to tower face; obtained from GEANT
   const float X0 = -0.91;  // in cm; obtained from GEANT (should be ~ rad length)
 
-  xA = yA = zA = 0;
-
-  int ix = xC + 0.5;  // tower #
-  if (ix < 0 || ix >= fNx)
-  {
-    printf("Error in BEmcRecEEMC::SectorToGlobal: wrong input x: %d\n", ix);
-    return;
-  }
-
-  int iy = yC + 0.5;  // tower #
-  if (iy < 0 || iy >= fNy)
-  {
-    printf("Error in BEmcRecEEMC::SectorToGlobal: wrong input y: %d\n", iy);
-    return;
-  }
-
-  // Next tower in x
-  TowerGeom geomx;
-  int idx = 0;
-  if (ix < fNx / 2)
-  {
-    idx += 1;
-    while (!GetTowerGeometry(ix + idx, iy, geomx) && idx < fNx / 2) idx += 1;
-  }
-  else
-  {
-    idx -= 1;
-    while (!GetTowerGeometry(ix + idx, iy, geomx) && idx > -fNx / 2) idx -= 1;
-  }
-  if (idx >= fNx / 2 || idx <= -fNx / 2)
-  {
-    printf("Error in BEmcRecEEMC::Tower2Global: Error in geometery extraction for x= %f (y=%f)\n", xC, yC);
-    return;
-  }
-
-  // Next tower in y
-  TowerGeom geomy;
-  int idy = 0;
-  if (iy < fNy / 2)
-  {
-    idy += 1;
-    while (!GetTowerGeometry(ix, iy + idy, geomy) && idy < fNy / 2) idy += 1;
-  }
-  else
-  {
-    idy -= 1;
-    while (!GetTowerGeometry(ix, iy + idy, geomy) && idy > -fNy / 2) idy -= 1;
-  }
-  if (idy >= fNy / 2 || idy <= -fNy / 2)
-  {
-    printf("Error in BEmcRecEEMC::Tower2Global: Error in geometery extraction for y= %f (x=%f)\n", yC, xC);
-    return;
-  }
-
-  float dx, dy;
-  float Zcenter;
-
-  TowerGeom geom0;
-  if (GetTowerGeometry(ix, iy, geom0))
-  {  // Found; this is for normal case
-    dx = (geomx.Xcenter - geom0.Xcenter) / float(idx);
-    dy = (geomy.Ycenter - geom0.Ycenter) / float(idy);
-    xA = geom0.Xcenter + (xC - ix) * dx;
-    yA = geom0.Ycenter + (yC - iy) * dy;
-    Zcenter = geom0.Zcenter;
-  }
-  else
-  {  // Not found; weird case (cluster center of gravity outside the EMCal)
-    dx = (geomx.Xcenter - geomy.Xcenter) / float(idx);
-    dy = (geomy.Ycenter - geomx.Ycenter) / float(idy);
-    xA = geomx.Xcenter + (xC - ix) * dx - dx * idx;
-    yA = geomx.Ycenter + (yC - iy) * dy;  // Here I take Ycenter from geomx!
-    Zcenter = geomx.Zcenter;
-    //    printf("BEmcRecEEMC::Tower2Global: CG outside EMCal: input=(%f,%f), tower ind=(%d,%d); dd=(%d,%d); global=(%f,%f)\n",xC,yC,ix,iy,idx,idy,xA,yA);
-  }
-
   float logE = log(0.1);
   if (E > 0.1) logE = log(E);
-  float ZcenterV = Zcenter - fVz;
-  float cosT = fabs(ZcenterV) / sqrt(xA * xA + yA * yA + ZcenterV * ZcenterV);
-  zA = (Zcenter - DZ) + (D + X0 * logE) * cosT;
+  float zV = zA - fVz;
+  float cosT = fabs(zV) / sqrt(xA * xA + yA * yA + zV * zV);
 
-  //  zA = Zcenter; //!!!!!
+  zC = (zA - DZ) + (D + X0 * logE) * cosT;
+  //  zC = zA; // !!!!!
+
+  xC = xA;
+  yC = yA;
 }
 
 void BEmcRecEEMC::CorrectEnergy(float Energy, float x, float y,
                                 float* Ecorr)
 {
   *Ecorr = Energy;
+}
+
+void BEmcRecEEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
+{
+  // Corrects the EM Shower Core Energy for attenuation in fibers,
+  // long energy leakage and angle dependance
+  //
+  // (x,y) - shower CG in tower units (not projected anywhere!)
+
+  *Ecorr = Ecore;
 }
 
 float BEmcRecEEMC::GetImpactAngle(float e, float x, float y)
@@ -119,16 +81,6 @@ float BEmcRecEEMC::GetImpactAngle(float e, float x, float y)
   *sinT = sqrt((vx*vx+vy*vy)/(vx*vx+vy*vy+vz*vz));
   */
   return 0;
-}
-
-void BEmcRecEEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
-{
-  // Corrects the EM Shower Core Energy for attenuation in fibers,
-  // long energy leakage and angle dependance
-  //
-  // (x,y) - shower CG in tower units (not projected anywhere!)
-
-  *Ecorr = Ecore;
 }
 
 void BEmcRecEEMC::CorrectPosition(float Energy, float x, float y,
@@ -153,8 +105,10 @@ void BEmcRecEEMC::CorrectPosition(float Energy, float x, float y,
   float xA, yA, zA;
   Tower2Global(Energy, x, y, xA, yA, zA);
   zA -= fVz;
-  float sinTx = xA / sqrt(xA * xA + zA * zA);
-  float sinTy = yA / sqrt(yA * yA + zA * zA);
+  //  float sinTx = xA / sqrt(xA * xA + zA * zA);
+  //  float sinTy = yA / sqrt(yA * yA + zA * zA);
+  float sinTy = xA / sqrt(xA * xA + zA * zA); // x is second index in here
+  float sinTx = yA / sqrt(yA * yA + zA * zA);
   float sin2Tx = sinTx * sinTx;
   float sin2Ty = sinTy * sinTy;
 
@@ -163,12 +117,12 @@ void BEmcRecEEMC::CorrectPosition(float Energy, float x, float y,
   else
     xZero = -0.6 * sinTx + 1.500 * sin2Tx;
 
-  xZero = -xZero;  // Because tower index in X decreases with increasing X in EEMC
-
   if (sinTy > 0)
     yZero = -0.6 * sinTy - 1.5 * sin2Ty;
   else
     yZero = -0.6 * sinTy + 1.5 * sin2Ty;
+
+  yZero = -yZero;  // Because tower index in X decreases with increasing X in EEMC (y is actually x here!)
 
   t = 0.98 + 0.98 * sqrt(Energy);
   t *= 0.7;  // Temp correction

--- a/offline/packages/CaloReco/BEmcRecEEMC.h
+++ b/offline/packages/CaloReco/BEmcRecEEMC.h
@@ -3,16 +3,24 @@
 
 #include "BEmcRec.h"
 
+class BEmcProfile;
+
 class BEmcRecEEMC : public BEmcRec
 {
  public:
-  BEmcRecEEMC(){};
-  ~BEmcRecEEMC() {}
+  BEmcRecEEMC();
+  ~BEmcRecEEMC();
   void CorrectEnergy(float energy, float x, float y, float *ecorr);
-  static float GetImpactAngle(float e, float x, float y);
-  void CorrectPosition(float energy, float x, float y, float *xcorr, float *ycorr);
   void CorrectECore(float ecore, float x, float y, float *ecorecorr);
-  void Tower2Global(float E, float xC, float yC, float &xA, float &yA, float &zA);
+  void CorrectPosition(float energy, float x, float y, float *xcorr, float *ycorr);
+  void CorrectShowerDepth(float energy, float x, float y, float z, float& xc, float& yc, float& zc );
+  static float GetImpactAngle(float e, float x, float y);
+
+  void LoadProfile(const char *fname);
+  float GetProb(std::vector<EmcModule> HitList, float e, float xg, float yg, float zg, float &chi2, int &ndf);
+
+ private:
+  BEmcProfile *_emcprof;
 };
 
 #endif

--- a/offline/packages/CaloReco/BEmcRecFEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecFEMC.cc
@@ -1,102 +1,63 @@
 #include "BEmcRecFEMC.h"
 #include "BEmcCluster.h"
+#include "BEmcProfile.h"
 
 #include <cmath>
 #include <cstdio>
 
-void BEmcRecFEMC::Tower2Global(float E, float xC, float yC,
-                               float& xA, float& yA, float& zA)
-// With shower depth correction reflected in zA
+using namespace std;
+
+BEmcRecFEMC::BEmcRecFEMC() : _emcprof(nullptr) 
 {
+  SetPlanarGeometry();
+}
+
+BEmcRecFEMC::~BEmcRecFEMC()
+{
+  if (_emcprof) delete _emcprof;
+}
+
+
+void BEmcRecFEMC::LoadProfile(const char *fname) 
+{
+  _emcprof = new BEmcProfile(fname); 
+}
+
+float BEmcRecFEMC::GetProb(vector<EmcModule> HitList, float ecl, float xg, float yg, float zg, float& chi2, int& ndf)
+{
+  chi2 = 0;
+  ndf = 0;
+  float prob = -1;
+
+  float theta = atan(sqrt(xg*xg + yg*yg)/fabs(zg-fVz));
+  if( _emcprof != nullptr ) prob = _emcprof->GetProb(&HitList,fNx,ecl,theta);
+
+  return prob;
+}
+
+void BEmcRecFEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, float& xC, float& yC, float& zC )
+{
+  // For ala PHENIX PbSc modules
+  /*
   const float DZ = 18;   // in cm, tower half length
   const float D = 13.3;  // in cm, shower depth at 1 GeV relative to tower face; obtained from GEANT
   const float X0 = 2.2;  // in cm; obtained from GEANT (should be ~ rad length)
-
-  xA = 0;
-  yA = 0;
-  zA = 0;
-
-  int ix = xC + 0.5;  // tower #
-  if (ix < 0 || ix >= fNx)
-  {
-    printf("Error in BEmcRecFEMC::SectorToGlobal: wrong input x: %d\n", ix);
-    return;
-  }
-
-  int iy = yC + 0.5;  // tower #
-  if (iy < 0 || iy >= fNy)
-  {
-    printf("Error in BEmcRecFEMC::SectorToGlobal: wrong input y: %d\n", iy);
-    return;
-  }
-
-  // Next tower in x
-  TowerGeom geomx;
-  int idx = 0;
-  if (ix < fNx / 2)
-  {
-    idx += 1;
-    while (!GetTowerGeometry(ix + idx, iy, geomx) && idx < fNx / 2) idx += 1;
-  }
-  else
-  {
-    idx -= 1;
-    while (!GetTowerGeometry(ix + idx, iy, geomx) && idx > -fNx / 2) idx -= 1;
-  }
-  if (idx >= fNx / 2 || idx <= -fNx / 2)
-  {
-    printf("Error in BEmcRecFEMC::Tower2Global: Error in geometry extraction for x= %f (ix,iy)=(%d,%d)\n", xC, ix, iy);
-    return;
-  }
-
-  // Next tower in y
-  TowerGeom geomy;
-  int idy = 0;
-  if (iy < fNy / 2)
-  {
-    idy += 1;
-    while (!GetTowerGeometry(ix, iy + idy, geomy) && idy < fNy / 2) idy += 1;
-  }
-  else
-  {
-    idy -= 1;
-    while (!GetTowerGeometry(ix, iy + idy, geomy) && idy > -fNy / 2) idy -= 1;
-  }
-  if (idy >= fNy / 2 || idy <= -fNy / 2)
-  {
-    printf("Error in BEmcRecFEMC::Tower2Global: Error in geometry extraction for y= %f (ix,iy)=(%d,%d)\n", yC, ix, iy);
-    return;
-  }
-
-  float dx, dy;
-  float Zcenter;
-
-  TowerGeom geom0;
-  if (GetTowerGeometry(ix, iy, geom0))
-  {  // Found; this is for normal case
-    dx = (geomx.Xcenter - geom0.Xcenter) / float(idx);
-    dy = (geomy.Ycenter - geom0.Ycenter) / float(idy);
-    xA = geom0.Xcenter + (xC - ix) * dx;
-    yA = geom0.Ycenter + (yC - iy) * dy;
-    Zcenter = geom0.Zcenter;
-  }
-  else
-  {  // Not found; weird case (cluster center of gravity outside the EMCal)
-    dx = (geomx.Xcenter - geomy.Xcenter) / float(idx);
-    dy = (geomy.Ycenter - geomx.Ycenter) / float(idy);
-    xA = geomx.Xcenter + (xC - ix) * dx - dx * idx;
-    yA = geomx.Ycenter + (yC - iy) * dy;  // Here I take Ycenter from geomx!
-    Zcenter = geomx.Zcenter;
-    //    printf("BEmcRecFEMC::Tower2Global: CG outside EMCal: input=(%f,%f), tower ind=(%d,%d); dd=(%d,%d); global=(%f,%f)\n",xC,yC,ix,iy,idx,idy,xA,yA);
-  }
+  */
+  // For E684-based modules
+  const float DZ = 8;   // in cm, tower half length
+  const float D = 4.6;  // in cm, shower depth at 1 GeV relative to tower face; obtained from GEANT
+  const float X0 = 0.8;  // in cm; obtained from GEANT (should be ~ rad length)
 
   float logE = log(0.1);
   if (E > 0.1) logE = log(E);
-  float ZcenterV = Zcenter - fVz;
-  float cosT = fabs(ZcenterV) / sqrt(xA * xA + yA * yA + ZcenterV * ZcenterV);
-  zA = (Zcenter - DZ) + (D + X0 * logE) * cosT;
+  float zV = zA - fVz;
+  float cosT = fabs(zV) / sqrt(xA * xA + yA * yA + zV * zV);
 
-  //  zA = Zcenter; //!!!!!
+  zC = (zA - DZ) + (D + X0 * logE) * cosT;
+  //  zC = zA; // !!!!!
+
+  xC = xA;
+  yC = yA;
 }
 
 void BEmcRecFEMC::CorrectEnergy(float Energy, float x, float y,
@@ -152,8 +113,8 @@ void BEmcRecFEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
 void BEmcRecFEMC::CorrectPosition(float Energy, float x, float y,
                                   float* pxc, float* pyc)
 {
-  // Corrects the Shower Center of Gravity for the systematic error due to
-  // the limited tower size
+  // Corrects the Shower Center of Gravity for the systematic shift due to
+  // limited tower size
   //
   // Everything here is in tower units.
   // (x,y) - CG position, (*pxc,*pyc) - corrected position
@@ -171,8 +132,10 @@ void BEmcRecFEMC::CorrectPosition(float Energy, float x, float y,
   float xA, yA, zA;
   Tower2Global(Energy, x, y, xA, yA, zA);
   zA -= fVz;
-  float sinTx = xA / sqrt(xA * xA + zA * zA);
-  float sinTy = yA / sqrt(yA * yA + zA * zA);
+  //  float sinTx = xA / sqrt(xA * xA + zA * zA);
+  //  float sinTy = yA / sqrt(yA * yA + zA * zA);
+  float sinTy = xA / sqrt(xA * xA + zA * zA); // x is second index in here
+  float sinTx = yA / sqrt(yA * yA + zA * zA);
   float sin2Tx = sinTx * sinTx;
   float sin2Ty = sinTy * sinTy;
 

--- a/offline/packages/CaloReco/BEmcRecFEMC.h
+++ b/offline/packages/CaloReco/BEmcRecFEMC.h
@@ -3,16 +3,24 @@
 
 #include "BEmcRec.h"
 
+class BEmcProfile;
+
 class BEmcRecFEMC : public BEmcRec
 {
  public:
-  BEmcRecFEMC(){};
-  ~BEmcRecFEMC() {}
+  BEmcRecFEMC();
+  ~BEmcRecFEMC();
   void CorrectEnergy(float energy, float x, float y, float *ecorr);
-  static float GetImpactAngle(float e, float x, float y);
-  void CorrectPosition(float energy, float x, float y, float *xcorr, float *ycorr);
   void CorrectECore(float ecore, float x, float y, float *ecorecorr);
-  void Tower2Global(float E, float xC, float yC, float &xA, float &yA, float &zA);
+  void CorrectPosition(float energy, float x, float y, float *xcorr, float *ycorr);
+  void CorrectShowerDepth(float energy, float x, float y, float z, float& xc, float& yc, float& zc );
+  static float GetImpactAngle(float e, float x, float y);
+
+  void LoadProfile(const char *fname);
+  float GetProb(std::vector<EmcModule> HitList, float e, float xg, float yg, float zg, float &chi2, int &ndf);
+
+ private:
+  BEmcProfile *_emcprof;
 };
 
 #endif

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.h
@@ -10,31 +10,38 @@ class RawCluster;
 class RawClusterContainer;
 class RawTowerContainer;
 class RawTowerGeomContainer;
-class BEmcRecCEMC;
+class BEmcRec;
+//class BEmcProfile;
 
 class RawClusterBuilderTemplate : public SubsysReco
 {
  public:
-  RawClusterBuilderTemplate(const std::string& name = "RawClusterBuilderGraph");
+  RawClusterBuilderTemplate(const std::string& name = "RawClusterBuilderTemplate");
   virtual ~RawClusterBuilderTemplate();
 
   int InitRun(PHCompositeNode* topNode);
   int process_event(PHCompositeNode* topNode);
   int End(PHCompositeNode* topNode);
-  void Detector(const std::string& d) { detector = d; }
+  void Detector(const std::string& d);
+
+  void SetCylindricalGeometry();
+  void SetPlanarGeometry();
+  void PrintGeometry() { bPrintGeom = true; } // Prints it at InitRun time
+  void PrintCylGeom(RawTowerGeomContainer *towergeom, const char* fname);
 
   void set_threshold_energy(const float e) { _min_tower_e = e; }
   void setEnergyNorm(float norm) { fEnergyNorm = norm; }
   void checkenergy(const int i = 1) { chkenergyconservation = i; }
+  void LoadProfile(const char *fname);
 
  private:
   void CreateNodes(PHCompositeNode* topNode);
-  bool CorrectPhi(RawCluster* cluster, RawTowerContainer* towers, RawTowerGeomContainer* towergemom);
   bool Cell2Abs(RawTowerGeomContainer* towergeom, float phiC, float etaC, float& phi, float& eta);
 
   RawClusterContainer* _clusters;
+  //  BEmcProfile *_emcprof;
 
-  BEmcRecCEMC* bemc;
+  BEmcRec* bemc;
   float fEnergyNorm;
 
   float _min_tower_e;
@@ -42,6 +49,13 @@ class RawClusterBuilderTemplate : public SubsysReco
 
   std::string detector;
   std::string ClusterNodeName;
+
+  int BINX0;
+  int NBINX;
+  int BINY0;
+  int NBINY;
+
+  bool bPrintGeom;
 };
 
 #endif /* RawClusterBuilderTemplate_H__ */

--- a/offline/packages/CaloReco/RawClusterBuilderTemplateEEMC.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplateEEMC.cc
@@ -56,7 +56,7 @@ RawClusterBuilderTemplateEEMC::RawClusterBuilderTemplateEEMC(const std::string &
   //
   // Some initial values for clustering
   //
-  bemc->SetPlaneGeometry();
+  bemc->SetPlanarGeometry();
   // Configuration: number of towers in Phi and Eta, and tower dimension (here still in angle units and eta units)
   bemc->SetGeometry(64, 64, 1.0, 1.0);
   // Define vertex ... not used now

--- a/offline/packages/CaloReco/RawClusterBuilderTemplateFEMC.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplateFEMC.cc
@@ -1,8 +1,8 @@
 #include "RawClusterBuilderTemplateFEMC.h"
 
 #include "BEmcCluster.h"
-#include "BEmcProfile.h"
 #include "BEmcRecFEMC.h"
+#include "BEmcProfile.h"
 
 #include <calobase/RawCluster.h>
 #include <calobase/RawClusterContainer.h>
@@ -14,13 +14,13 @@
 #include <calobase/RawTowerGeomContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>  // for SubsysReco
+#include <fun4all/SubsysReco.h>              // for SubsysReco
 
+#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>
-#include <phool/getClass.h>
 #include <phool/phool.h>
 
 #include <cmath>
@@ -37,7 +37,6 @@ using namespace std;
 RawClusterBuilderTemplateFEMC::~RawClusterBuilderTemplateFEMC()
 {
   delete bemc;
-  delete _emcprof;
 }
 
 RawClusterBuilderTemplateFEMC::RawClusterBuilderTemplateFEMC(const std::string &name)
@@ -59,7 +58,7 @@ RawClusterBuilderTemplateFEMC::RawClusterBuilderTemplateFEMC(const std::string &
   //
   // Some initial values for clustering
   //
-  bemc->SetPlaneGeometry();
+  bemc->SetPlanarGeometry();
   // Configuration: number of towers in Phi and Eta, and tower dimension (here still in angle units and eta units)
   bemc->SetGeometry(64, 64, 1.0, 1.0);
   // Define vertex ... not used now
@@ -69,9 +68,9 @@ RawClusterBuilderTemplateFEMC::RawClusterBuilderTemplateFEMC(const std::string &
   bemc->SetTowerThreshold(0);
 }
 
-void RawClusterBuilderTemplateFEMC::LoadProfile(const char *fname)
-{
-  _emcprof = new BEmcProfile(fname);
+void RawClusterBuilderTemplateFEMC::LoadProfile(const char *fname) 
+{ 
+  _emcprof = new BEmcProfile(fname); 
 }
 
 int RawClusterBuilderTemplateFEMC::InitRun(PHCompositeNode *topNode)
@@ -333,13 +332,13 @@ int RawClusterBuilderTemplateFEMC::process_event(PHCompositeNode *topNode)
       pp->GetGlobalPos(xout, yout, zout);
 
       hlist = pp->GetHitList();
-      float zVert = 0;  // !!!!! In future it should take actual zVert
-      theta = atan(sqrt(xout * xout + yout * yout) / fabs(zout - zVert));
+      float zVert = 0; // !!!!! In future it should take actual zVert
+      theta = atan(sqrt(xout * xout + yout * yout)/fabs(zout-zVert));
 
       //      prob = pp->GetProb(chi2,ndf);
       prob = -1;
       ndf = 0;
-      if (_emcprof != nullptr) prob = _emcprof->GetProb(&hlist, NBINX, ecl, theta);
+      if( _emcprof != nullptr ) prob = _emcprof->GetProb(&hlist,NBINX,ecl,theta);
 
       cluster = new RawClusterv1();
       cluster->set_energy(ecl);


### PR DESCRIPTION
Overall reorganization to have the only interface RawClusterBuilderTemplate for all calorimeter clustering purposes (and get rid of any specific interfaces like RawClusterBuilderTemplateFEMC etc.). All detector specific code is now included in BEmcRec<CalName> modules, which now exist for CEMC, FEMC and EEMC. It includes energy and position correction and shower profile evaluation ("prob" variable). If BEmcRec<CalName> is not defined for a particular calorimeter <CalName>, clustering will be called through the base class BEmcRec, which doesn't correct energy for any effects (e.g. Ecore), position (just give a straight center of gravity), and doesn't evaluate shower profile parameter. In addition: 
1. BEmcProfile is slight modified to include additional uncertainty due to binning used in profile hists
2. BEmcCluster  is slight modified to include more arguments in BEmcRec->GetProb() call, needed to evaluate the impact angle
3. RawClusterBuilderTemplate<CalName> modules are not yet removed for safety. I'll do it in the next pull request session