### PR TITLE
Master optimize tpc electron drift

### DIFF
--- a/offline/packages/trackbase/TrkrHitSetContainer.cc
+++ b/offline/packages/trackbase/TrkrHitSetContainer.cc
@@ -112,14 +112,11 @@ TrkrHitSetContainer::getHitSets(void) const
 TrkrHitSetContainer::Iterator
 TrkrHitSetContainer::findOrAddHitSet(TrkrDefs::hitsetkey key)
 {
-
-  TrkrHitSetContainer::Iterator it = m_hitmap.find(key);
-  if (it == m_hitmap.end())
+  auto it = m_hitmap.lower_bound( key );
+  if( it == m_hitmap.cend() || (key < it->first ) )
   {
-    // add new object and set its key
-    auto ret = m_hitmap.insert(std::make_pair(key, new TrkrHitSet()));
-    (ret.first->second)->setHitSetKey(key);
-    it = ret.first;
+    it = m_hitmap.insert(it, std::make_pair(key, new TrkrHitSet()));
+    it->second->setHitSetKey( key );
   }
   return it;
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -53,7 +53,7 @@
 #include <iostream>
 #include <map>                                          // for _Rb_tree_cons...
 #include <utility>                                      // for pair
-#
+
 using namespace std;
 
 PHG4TpcElectronDrift::PHG4TpcElectronDrift(const std::string &name)

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -130,10 +130,10 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
       PHCompositeNode *DetNode =
         dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
       if (!DetNode)
-	{
-	  DetNode = new PHCompositeNode("TRKR");
-	  dstNode->addNode(DetNode);
-	}
+  {
+    DetNode = new PHCompositeNode("TRKR");
+    dstNode->addNode(DetNode);
+  }
 
       hitsetcontainer = new TrkrHitSetContainer();
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hitsetcontainer, "TRKR_HITSET", "PHObject");
@@ -147,11 +147,11 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
       PHCompositeNode *DetNode =
         dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
       if (!DetNode)
-	{
-	  DetNode = new PHCompositeNode("TRKR");
-	  dstNode->addNode(DetNode);
-	}
-      
+  {
+    DetNode = new PHCompositeNode("TRKR");
+    dstNode->addNode(DetNode);
+  }
+
       hittruthassoc = new TrkrHitTruthAssoc();
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(hittruthassoc, "TRKR_HITTRUTHASSOC", "PHObject");
       DetNode->addNode(newNode);
@@ -276,15 +276,15 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
 
     if (n_electrons <= 0)
       {
-	if (n_electrons < 0)
-	  {
-	    cout << "really bad number of electrons: " << n_electrons
-		 << ", eion: " << eion
-		 << endl;
-	  }
-	continue;
+  if (n_electrons < 0)
+    {
+      cout << "really bad number of electrons: " << n_electrons
+     << ", eion: " << eion
+     << endl;
+    }
+  continue;
       }
-    
+
     if (Verbosity() > 100)
       {
         cout << endl
@@ -367,58 +367,63 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
     // transfer the hits from temp_hitsetcontainer to hitsetcontainer on the node tree
     TrkrHitSetContainer::ConstRange temp_hitset_range = temp_hitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
     for (TrkrHitSetContainer::ConstIterator temp_hitset_iter = temp_hitset_range.first;
-	 temp_hitset_iter != temp_hitset_range.second;
-	 ++temp_hitset_iter)
+   temp_hitset_iter != temp_hitset_range.second;
+   ++temp_hitset_iter)
       {
-	// we have an itrator to one TrkrHitSet for the Tpc from the temp_hitsetcontainer
-	TrkrDefs::hitsetkey node_hitsetkey = temp_hitset_iter->first;
-	const unsigned int layer = TrkrDefs::getLayer(node_hitsetkey);
-	const int sector = TpcDefs::getSectorId(node_hitsetkey);
-	const int side = TpcDefs::getSide(node_hitsetkey);	
-	if(Verbosity()>100)   
-	  cout << "PHG4TpcElectronDrift: temp_hitset with key: " << node_hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << endl;
+  // we have an itrator to one TrkrHitSet for the Tpc from the temp_hitsetcontainer
+  TrkrDefs::hitsetkey node_hitsetkey = temp_hitset_iter->first;
+  const unsigned int layer = TrkrDefs::getLayer(node_hitsetkey);
+  const int sector = TpcDefs::getSectorId(node_hitsetkey);
+  const int side = TpcDefs::getSide(node_hitsetkey);
+  if(Verbosity()>100)
+    cout << "PHG4TpcElectronDrift: temp_hitset with key: " << node_hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << endl;
 
-	// find or add this hitset on the node tree
-	TrkrHitSetContainer::Iterator node_hitsetit = hitsetcontainer->findOrAddHitSet(node_hitsetkey);
-	
-	// get all of the hits from the temporary hitset      
-	TrkrHitSet::ConstRange temp_hit_range = temp_hitset_iter->second->getHits();
-	for(TrkrHitSet::ConstIterator temp_hit_iter = temp_hit_range.first;
-	    temp_hit_iter != temp_hit_range.second;
-	    ++temp_hit_iter)
-	  {
-	    TrkrDefs::hitkey temp_hitkey = temp_hit_iter->first;
-	    TrkrHit *temp_tpchit = temp_hit_iter->second;
+  // find or add this hitset on the node tree
+  TrkrHitSetContainer::Iterator node_hitsetit = hitsetcontainer->findOrAddHitSet(node_hitsetkey);
 
-	    if(Verbosity() > 100)
-	      cout << "      temp_hitkey " << temp_hitkey << " pad " << TpcDefs::getPad(temp_hitkey) << " z bin " << TpcDefs::getTBin(temp_hitkey) 
-		   << "  energy " << temp_tpchit->getEnergy() << endl;
-	    
-	    // find or add this hit to the node tree	    
-	    TrkrHit *node_hit = node_hitsetit->second->getHit(temp_hitkey);
-	    if(!node_hit)
-	      {
-		// Otherwise, create a new one
-		node_hit = new TpcHit();
-		node_hitsetit->second->addHitSpecificKey(temp_hitkey, node_hit);
-	      }
-	    
-	    // Either way, add the energy to it
-	    node_hit->addEnergy(temp_tpchit->getEnergy());
-	    
-	    // Add the hit-g4hit association	    
-	    hittruthassoc->findOrAddAssoc(node_hitsetkey, temp_hitkey, hiter->first);
-	    
-	  }  // end loop over temp hits
+  // get all of the hits from the temporary hitset
+  TrkrHitSet::ConstRange temp_hit_range = temp_hitset_iter->second->getHits();
+  for(TrkrHitSet::ConstIterator temp_hit_iter = temp_hit_range.first;
+      temp_hit_iter != temp_hit_range.second;
+      ++temp_hit_iter)
+    {
+      TrkrDefs::hitkey temp_hitkey = temp_hit_iter->first;
+      TrkrHit *temp_tpchit = temp_hit_iter->second;
+
+      if(Verbosity() > 100)
+        cout << "      temp_hitkey " << temp_hitkey << " pad " << TpcDefs::getPad(temp_hitkey) << " z bin " << TpcDefs::getTBin(temp_hitkey)
+       << "  energy " << temp_tpchit->getEnergy() << endl;
+
+      // find or add this hit to the node tree
+      TrkrHit *node_hit = node_hitsetit->second->getHit(temp_hitkey);
+      if(!node_hit)
+        {
+    // Otherwise, create a new one
+    node_hit = new TpcHit();
+    node_hitsetit->second->addHitSpecificKey(temp_hitkey, node_hit);
+
+    // Add the hit-g4hit association
+    // no need to check for duplicates, since the hit is new
+    hittruthassoc->addAssoc(node_hitsetkey, temp_hitkey, hiter->first);
+        } else {
+    // Add the hit-g4hit association
+    // TODO: check if duplication can happen
+    hittruthassoc->findOrAddAssoc(node_hitsetkey, temp_hitkey, hiter->first);
+        }
+
+      // Either way, add the energy to it
+      node_hit->addEnergy(temp_tpchit->getEnergy());
+
+    }  // end loop over temp hits
       } // end loop over temp hitsets
 
     // erase all entries in the temp hitsetcontainer
     temp_hitsetcontainer->Reset();
-    
-  } // end loop over g4hits
-  
 
-  unsigned int print_layer = 47;  
+  } // end loop over g4hits
+
+
+  unsigned int print_layer = 47;
 
   if(Verbosity() > 2)
     {
@@ -426,32 +431,32 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       // We want all hitsets for the Tpc
       TrkrHitSetContainer::ConstRange hitset_range = hitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
       for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range.first;
-	   hitset_iter != hitset_range.second;
-	   ++hitset_iter)
-	{
-	  // we have an itrator to one TrkrHitSet for the Tpc from the trkrHitSetContainer
-	  TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
-	  const unsigned int layer = TrkrDefs::getLayer(hitsetkey);
-	  if(layer != print_layer)  continue;
-	  const int sector = TpcDefs::getSectorId(hitsetkey);
-	  const int side = TpcDefs::getSide(hitsetkey);
-	  
-	  cout << "PHG4TpcElectronDrift: hitset with key: " << hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << endl;
-	  
-	  // get all of the hits from this hitset      
-	  TrkrHitSet *hitset = hitset_iter->second;
-	  TrkrHitSet::ConstRange hit_range = hitset->getHits();
-	  for(TrkrHitSet::ConstIterator hit_iter = hit_range.first;
-	      hit_iter != hit_range.second;
-	      ++hit_iter)
-	    {
-	      TrkrDefs::hitkey hitkey = hit_iter->first;
-	      TrkrHit *tpchit = hit_iter->second;
+     hitset_iter != hitset_range.second;
+     ++hitset_iter)
+  {
+    // we have an itrator to one TrkrHitSet for the Tpc from the trkrHitSetContainer
+    TrkrDefs::hitsetkey hitsetkey = hitset_iter->first;
+    const unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+    if(layer != print_layer)  continue;
+    const int sector = TpcDefs::getSectorId(hitsetkey);
+    const int side = TpcDefs::getSide(hitsetkey);
 
-	      cout << "      hitkey " << hitkey << " pad " << TpcDefs::getPad(hitkey) << " z bin " << TpcDefs::getTBin(hitkey) 
-		   << "  energy " << tpchit->getEnergy() << " adc " << tpchit->getAdc() << endl;
-	    }
-	}
+    cout << "PHG4TpcElectronDrift: hitset with key: " << hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << endl;
+
+    // get all of the hits from this hitset
+    TrkrHitSet *hitset = hitset_iter->second;
+    TrkrHitSet::ConstRange hit_range = hitset->getHits();
+    for(TrkrHitSet::ConstIterator hit_iter = hit_range.first;
+        hit_iter != hit_range.second;
+        ++hit_iter)
+      {
+        TrkrDefs::hitkey hitkey = hit_iter->first;
+        TrkrHit *tpchit = hit_iter->second;
+
+        cout << "      hitkey " << hitkey << " pad " << TpcDefs::getPad(hitkey) << " z bin " << TpcDefs::getTBin(hitkey)
+       << "  energy " << tpchit->getEnergy() << " adc " << tpchit->getAdc() << endl;
+      }
+  }
     }
 
   if(Verbosity() > 2)

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
@@ -5,6 +5,9 @@
 
 #include <g4main/PHG4HitContainer.h>
 
+#include <array>
+#include <climits>
+#include <cmath>
 #include <string>                     // for string
 #include <vector>
 
@@ -21,7 +24,6 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
 {
  public:
   PHG4TpcPadPlaneReadout(const std::string &name = "PHG4TpcPadPlaneReadout");
-  virtual ~PHG4TpcPadPlaneReadout();
 
   int CreateReadoutGeometry(PHCompositeNode *topNode, PHG4CylinderCellGeomContainer *seggeo);
 
@@ -29,48 +31,50 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
 
   void MapToPadPlane(TrkrHitSetContainer *hitsetcontainer, TrkrHitTruthAssoc *hittruthassoc, const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit);
 
-  void populate_rectangular_phibins(const unsigned int layernum, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share);
-  void populate_zigzag_phibins(const unsigned int layernum, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share);
-  void populate_zbins(const double z, const double cloud_sig_zz[2], std::vector<int> &adc_zbin, std::vector<double> &adc_zbin_share);
-
   void SetDefaultParameters();
   void UpdateInternalParameters();
 
- protected:
+  private:
+
+  void populate_rectangular_phibins(const unsigned int layernum, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share);
+  void populate_zigzag_phibins(const unsigned int layernum, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share);
+  void populate_zbins(const double z, const std::array<double,2>& cloud_sig_zz, std::vector<int> &adc_zbin, std::vector<double> &adc_zbin_share);
+
   std::string seggeonodename;
 
-  TF1 *fcharge;
-  TF1 *fpad[10];
+  PHG4CylinderCellGeomContainer *GeomContainer = nullptr;
+  PHG4CylinderCellGeom *LayerGeom = nullptr;
 
-  PHG4CylinderCellGeomContainer *GeomContainer;
-  PHG4CylinderCellGeom *LayerGeom;
+  double rad_gem = NAN;
+  double output_radius = 0;
 
-  double rad_gem;
-  double output_radius;
+  double neffelectrons_threshold = NAN;
 
-  double neffelectrons_threshold;
+  std::array<int,3> MinLayer;
+  std::array<int,3> MaxLayer;
+  std::array<double,3> MinRadius;
+  std::array<double,3> MaxRadius;
+  std::array<double,3> Thickness;
+  double MinZ = NAN;
+  double MaxZ = NAN;
+  double sigmaT = NAN;
+  std::array<double,2> sigmaL;
+  std::array<double,3> PhiBinWidth;
+  double ZBinWidth = NAN;
+  double tpc_drift_velocity = NAN;
+  double tpc_adc_clock = NAN;
 
-  int MinLayer[3];
-  int MaxLayer[3];
-  double MinRadius[3];
-  double MaxRadius[3];
-  double Thickness[3];
-  double MinZ;
-  double MaxZ;
-  double sigmaT;
-  double sigmaL[2];
-  double PhiBinWidth[3];
-  double ZBinWidth;
-  double tpc_drift_velocity;
-  double tpc_adc_clock;
+  int NZBins = INT_MAX;
+  std::array<int,3> NPhiBins;
+  std::array<int,3> NTpcLayers;
+  int tpc_region = INT_MAX;
+  int zigzag_pads = INT_MAX;
+  int hit = 0;
 
-  int NZBins;
-  int NPhiBins[3];
-
-  int NTpcLayers[3];
-  int tpc_region;
-  int zigzag_pads;
-  int hit;
+  // gaussian sampling
+  static constexpr double _nsigmas = 5;
+  static constexpr int _ngauss_steps = 100;
+  std::array<double, _ngauss_steps> _gauss_weights;
 
   std::vector<int> adc_zbin;
   std::vector<int> pad_phibin;

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
@@ -55,7 +55,6 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   double neffelectrons_threshold = NAN;
 
   std::array<int,3> MinLayer;
-  std::array<int,3> MaxLayer;
   std::array<double,3> MinRadius;
   std::array<double,3> MaxRadius;
   std::array<double,3> Thickness;
@@ -71,7 +70,6 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   int NZBins = INT_MAX;
   std::array<int,3> NPhiBins;
   std::array<int,3> NTpcLayers;
-  int tpc_region = INT_MAX;
   int zigzag_pads = INT_MAX;
   int hit = 0;
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
@@ -5,7 +5,10 @@
 
 #include <g4main/PHG4HitContainer.h>
 
+#if !defined(__CINT__) || defined(__CLING__)
 #include <array>
+#endif
+
 #include <climits>
 #include <cmath>
 #include <string>                     // for string
@@ -40,6 +43,7 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   void populate_zigzag_phibins(const unsigned int layernum, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share);
   void populate_zbins(const double z, const std::array<double,2>& cloud_sig_zz, std::vector<int> &adc_zbin, std::vector<double> &adc_zbin_share);
 
+#if !defined(__CINT__) || defined(__CLING__)
   std::string seggeonodename;
 
   PHG4CylinderCellGeomContainer *GeomContainer = nullptr;
@@ -75,6 +79,7 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   static constexpr double _nsigmas = 5;
   static constexpr int _ngauss_steps = 100;
   std::array<double, _ngauss_steps> _gauss_weights;
+#endif
 
   std::vector<int> adc_zbin;
   std::vector<int> pad_phibin;


### PR DESCRIPTION
This pull request improves the efficiency of the PHG4TPCElectronDrift subsysreco, which is the largest contributor to the time spend in digitizing and clustering G4Hits. 
Improvements in terms of cpu time vary from a factor two for high-mult events, and a factor five for low-multiplicity events.

First set of commits implement a known trick for efficiently filling maps and not do the search twice (find, then insert). This part dominates the high-multiplicity  digitization/clustering, and results in the x2 improvement above.  

Second set of commits get rid of using TF1 for calculating functions, and use direct implementation instead. It also uses a lookup table for gaussian calculation. This is what gives the x5 improvement for low multiplicity events.

All in all running digit+clustering on the hijing files at "/sphenix/sim/sim01/sphnxpro/Geant4-10.05.p01/fm_0-12/FTFP_BERT_HP/" is now twice faster (~15 minutes per events instead of 30 on rcas2061), with identical output.