### PR TITLE
Adding SourceLink class for PHActsTrkFitter

### DIFF
--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -47,6 +47,7 @@ pkginclude_HEADERS = \
   PHTrackSetMerging.h \
   PHTruthTrackSeeding.h \
   PHTruthVertexing.h \
+  TrkrClusterSourceLink.hpp \
   VertexFitter.h \
   PHRaveVertexing.h \
   GPUTPCBaseTrackParam.h \

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -35,6 +35,7 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
+
 // Acts classes
 #include <Acts/Geometry/GeometryContext.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
@@ -49,6 +50,10 @@
 #include <Acts/Utilities/Definitions.hpp>
 #include <Acts/Utilities/BinnedArray.hpp>                       // for Binne...
 #include <Acts/Utilities/Logger.hpp>                            // for getDe...
+
+// This needs to stay after these other Acts includes
+#include "TrkrClusterSourceLink.hpp"
+
 
 #include <ACTFW/Detector/IBaseDetector.hpp>
 
@@ -83,6 +88,8 @@
 
 using namespace std;
 
+
+
 /*
  * Constructor
  */
@@ -100,7 +107,7 @@ PHActsTrkFitter::PHActsTrkFitter(const string& name)
   , NSurfPhi(10)
 {
   Verbosity(0);
-  
+
   // These are arbitrary subdivisions, and may change
   SurfStepZ = (MaxSurfZ - MinSurfZ) / (double) NSurfZ;
   ModuleStepPhi = 2.0 * M_PI / 12.0;
@@ -1002,30 +1009,31 @@ int PHActsTrkFitter::Process()
 	  std::cout << "    local covariance matrix:" << std::endl;
 	  std::cout << cov << std::endl;
 	}
-
-      const Acts::MinimalSourceLink  id;    	   // Acts identifier 
-      std::vector<Acts::DigitizationCell> hits;    // define hits - empty vector OK?
-
-      // cluster positions on surface
-      double xlocal = local_2D[0];
-      double ylocal = local_2D[1];
-      double time = 0;
+ 
+      // Cluster positions on GeoObject/Surface
+      Acts::BoundVector loc = Acts::BoundVector::Zero();     
+      loc[Acts::eLOC_0]     = local_2D[0];  
+      loc[Acts::eLOC_1]     = local_2D[1];
 
       if(Verbosity() > 0)
 	{      
 	  std::cout << "    Layer " << layer << " create measurement for trkrid " << trkrid 
 		    << " surface " << surf->name() << " surface type " << surf->type() 
-		    << " local x " << xlocal << " local y " << ylocal
+		    << " local x " << loc[Acts::eLOC_0] << " local y " << loc[Acts::eLOC_1]
 		    << endl;
 	}
 
       if(trkrid == TrkrDefs::mvtxId || trkrid == TrkrDefs::inttId || trkrid == TrkrDefs::tpcId)
 	{
-	  Acts::PlanarModuleCluster acts_meas(surf, id, cov, xlocal, ylocal, time, hits);
-
+	  // TrkrClusterSourceLink takes care of creating an Acts::FittableMeasurement
+	  TrkrClusterSourceLink sourceLink(cluskey,surf,loc,cov);
+	  // Can obtain the measurement like this
+	  auto measurement = *sourceLink;
 	  // Have to store this in a container 
 	  // DigitizationAlgorithm.cpp makes a map
 	  // what does tracking need?
+	  // KF tracking needs SourceLinks, track seeds (I think), and options for how
+	  // to run KF tracking
 	  // Does TGeoNode come into it?
 	  
 	}
@@ -1145,7 +1153,7 @@ PHActsTrkFitter::~PHActsTrkFitter()
 
 int PHActsTrkFitter::CreateNodes(PHCompositeNode* topNode)
 {
-
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -1208,6 +1216,7 @@ int PHActsTrkFitter::GetNodes(PHCompositeNode* topNode)
          << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
+
 
   /*
   // Input Svtx Vertices

--- a/offline/packages/trackreco/TrkrClusterSourceLink.hpp
+++ b/offline/packages/trackreco/TrkrClusterSourceLink.hpp
@@ -1,0 +1,80 @@
+#include <Acts/EventData/Measurement.hpp>
+#include <Acts/EventData/MeasurementHelpers.hpp>
+#include <Acts/EventData/SourceLinkConcept.hpp>
+#include <Acts/EventData/detail/fittable_type_generator.hpp>
+
+
+/**
+ * This class creates an Acts::SourceLink that relates TrkrClusters to the
+ * surface they were measured on. The source link is needed for the fitting
+ */
+class TrkrClusterSourceLink
+{
+public:
+
+  /// Instantiate with a cluskey, associated surface, and values that actually
+  /// make the measurement. Acts requires the surface be available in this class
+  TrkrClusterSourceLink(TrkrDefs::cluskey cluskey,
+			std::shared_ptr<const Acts::Surface> surface,
+			Acts::BoundVector loc,
+			Acts::ActsSymMatrixD<3> cov)
+    : m_cluskey(cluskey)
+    , m_surface(surface)
+    , m_loc(loc)
+    , m_cov(cov)
+{
+}
+
+  /// Must be default constructible to satisfy SourceLinkConcept
+  TrkrClusterSourceLink()    = default;
+  TrkrClusterSourceLink(TrkrClusterSourceLink&&)      = default;
+  TrkrClusterSourceLink(const TrkrClusterSourceLink&) = default;
+
+  /// Needs equality operators defined to satisfy SourceLinkConcept
+  TrkrClusterSourceLink& operator=(TrkrClusterSourceLink&&)      = default;
+  TrkrClusterSourceLink& operator=(const TrkrClusterSourceLink&) = default;
+  
+  /// Needs referenceSurface function to satisfy SourceLinkConcept
+  const Acts::Surface& referenceSurface() const 
+  {
+    return *m_surface;
+  }
+  
+  /// Create Acts::FittableMeasurement from information in SourceLink
+  Acts::FittableMeasurement<TrkrClusterSourceLink> operator*() const
+  {
+
+    return Acts::Measurement<TrkrClusterSourceLink, 
+			     Acts::ParDef::eLOC_0,
+			     Acts::ParDef::eLOC_1>
+      {
+	m_surface,
+	  *this,
+	  m_cov.topLeftCorner<2, 2>(),
+	  m_loc[0],
+	  m_loc[1]};
+  }
+
+private:
+  /// Clusterkey and the corresponding surface to which it belongs to
+  TrkrDefs::cluskey m_cluskey;
+  std::shared_ptr<const Acts::Surface> m_surface;
+  /// Local x and y position for cluster
+  Acts::BoundVector m_loc;
+  /// Cluster covariance matrix
+  Acts::ActsSymMatrixD<3> m_cov;
+
+  /// Needs equality operator defined to satisfy SourceLinkConcept
+  /// Equate the cluster keys
+  friend constexpr bool
+  operator==(const TrkrClusterSourceLink& lhs, const TrkrClusterSourceLink& rhs)
+  {
+    return lhs.m_cluskey == rhs.m_cluskey;
+  }
+
+};
+
+
+/// Ensure that the SourceLink class satisfies SourceLinkConcept conditions
+static_assert(Acts::SourceLinkConcept<TrkrClusterSourceLink>, 
+	      "TrkrClusterSourceLink does not fulfill SourceLinkConcept");


### PR DESCRIPTION
This PR implements a source link class that relates Acts::Measurements to the source that created them. In this case, we just use the clusterkey since this uniquely defines a cluster and the corresponding geometry it came from. TrkrClusterSourceLink can return a FittableMeasurement to be used by the fitting.