### PR TITLE
Fix cellreco

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4Cell.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cell.h
@@ -31,10 +31,6 @@ class PHG4Cell: public PHObject
   typedef std::pair<ShowerEdepIterator, ShowerEdepIterator> ShowerEdepRange;
   typedef std::pair<ShowerEdepConstIterator, ShowerEdepConstIterator> ShowerEdepConstRange;
 
-  typedef std::pair<unsigned short,std::map<int,int>> tpccompress;
-  typedef std::map<unsigned short,tpccompress> tpctod;
-
-
   virtual ~PHG4Cell() {}
 
   virtual void identify(std::ostream& os = std::cout) const;

--- a/simulation/g4simulation/g4detectors/PHG4CellDefs.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CellDefs.cc
@@ -5,6 +5,8 @@
 #include <cstdlib>       // for exit
 #include <iostream>
 
+using namespace std;
+
 unsigned short
 generic_lower_16bit_key(const PHG4CellDefs::keytype key, const PHG4CellDefs::CellBinning binning);
 
@@ -19,8 +21,6 @@ generic_16bit_genkey(const unsigned short detid, const PHG4CellDefs::CellBinning
 
 PHG4CellDefs::keytype
 generic_32bit_genkey(const unsigned short detid, const PHG4CellDefs::CellBinning binning, const unsigned int bit32);
-
-using namespace std;
 
 PHG4CellDefs::keytype
 PHG4CellDefs::SizeBinning::genkey(const unsigned short detid, const unsigned short zbin, const unsigned short iphi)

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.cc
@@ -242,7 +242,7 @@ PHG4Cellv1::Reset()
 
 void PHG4Cellv1::identify(std::ostream& os) const
 {
-  os << "New PHG4Cellv1  0x" << hex << cellid << dec << endl;
+  os << "PHG4Cellv1  0x" << hex << cellid << dec << endl;
 
   os <<"Associated to "<<hitedeps.size()<<" hits"<<endl;
   for (const auto pair :hitedeps)
@@ -255,9 +255,7 @@ void PHG4Cellv1::identify(std::ostream& os) const
   {
     os <<"\t Shower "<<pair.first<<" -> "<<pair.second<<" GeV"<<endl;
   }
-
-//  os <<"Contains to "<<trainOfDigits.size()<<" TPC digitization chain"<<endl;
-
+  os << "Properties:" << endl;
   for (prop_map_t::const_iterator i = prop_map.begin(); i != prop_map.end(); ++i)
   {
     PROPERTY prop_id = static_cast<PROPERTY>(i->first);

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.h
@@ -80,8 +80,6 @@ class PHG4Cellv1: public PHG4Cell
   void set_stave_index(const int i) {set_property(prop_stave_index,i);}
   int get_stave_index() const {return get_property_int(prop_stave_index);}
 
-//  tpctod* get_train_of_digits() {return &trainOfDigits;}
-
   void set_zbin(const int i) {set_property(prop_zbin,i);}
   int get_zbin() const {return get_property_int(prop_zbin);}
 
@@ -106,7 +104,6 @@ class PHG4Cellv1: public PHG4Cell
   PHG4CellDefs::keytype cellid;
   EdepMap hitedeps;
   ShowerEdepMap showeredeps;
-//  tpctod trainOfDigits;
 
   //! storage types for additional property
   typedef uint8_t prop_id_t;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -171,10 +171,21 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
       zmin_max[layer] = make_pair(etamin, etamax);
       double etastepsize = (sizeiter->second).first;
       double d_etabins;
-      double fract = modf((etamax - etamin) / etastepsize, &d_etabins);
-      if (fract != 0)
+// if the eta cell size is larger than the eta range, make one bin
+      if (etastepsize > etamax - etamin)
       {
-        d_etabins++;
+	d_etabins = 1;
+      }
+      else
+      {
+	// it is unlikely that the eta range is a multiple of the eta cell size
+	// then fract is 0, if not - add 1 bin which makes the
+	// cells a tiny bit smaller but makes them fit
+	double fract = modf((etamax - etamin) / etastepsize, &d_etabins);
+	if (fract != 0)
+	{
+	  d_etabins++;
+	}
       }
       etastepsize = (etamax - etamin) / d_etabins;
       (sizeiter->second).first = etastepsize;
@@ -194,10 +205,20 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
       double phimax = M_PI;
       double phistepsize = (sizeiter->second).second;
       double d_phibins;
-      fract = modf((phimax - phimin) / phistepsize, &d_phibins);
-      if (fract != 0)
+      if (phistepsize >= phimax-phimin)
       {
-        d_phibins++;
+	d_phibins = 1;
+      }
+      else
+      {
+	// it is unlikely that the phi range is a multiple of the phi cell size
+	// then fract is 0, if not - add 1 bin which makes the
+	// cells a tiny bit smaller but makes them fit
+	double fract = modf((phimax - phimin) / phistepsize, &d_phibins);
+	if (fract != 0)
+	{
+	  d_phibins++;
+	}
       }
       phistepsize = (phimax - phimin) / d_phibins;
       (sizeiter->second).second = phistepsize;
@@ -230,13 +251,21 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
       double size_z = (sizeiter->second).second;
       double size_r = (sizeiter->second).first;
       double bins_r;
-      // unlikely but if the circumference is a multiple of the cell size
-      // use result of division, if not - add 1 bin which makes the
-      // cells a tiny bit smaller but makes them fit
-      double fract = modf(circumference / size_r, &bins_r);
-      if (fract != 0)
+      // if the size is larger than circumference, make it one bin
+      if (size_r >= circumference)
       {
-        bins_r++;
+	bins_r = 1;
+      }
+      else
+      {
+	// unlikely but if the circumference is a multiple of the cell size
+	// use result of division, if not - add 1 bin which makes the
+	// cells a tiny bit smaller but makes them fit
+	double fract = modf(circumference / size_r, &bins_r);
+	if (fract != 0)
+	{
+	  bins_r++;
+	}
       }
       nbins[0] = bins_r;
       size_r = circumference / bins_r;
@@ -254,13 +283,21 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
         }
         phimax += phistepsize;
       }
-      // unlikely but if the length is a multiple of the cell size
-      // use result of division, if not - add 1 bin which makes the
-      // cells a tiny bit smaller but makes them fit
-      fract = modf(length_in_z / size_z, &bins_r);
-      if (fract != 0)
+      // if the size is larger than length, make it one bin
+      if (size_z >= length_in_z)
       {
-        bins_r++;
+	bins_r = 1;
+      }
+      else
+      {
+	// unlikely but if the length is a multiple of the cell size
+	// use result of division, if not - add 1 bin which makes the
+	// cells a tiny bit smaller but makes them fit
+	double fract = modf(length_in_z / size_z, &bins_r);
+	if (fract != 0)
+	{
+	  bins_r++;
+	}
       }
       nbins[1] = bins_r;
       pair<int, int> phi_z_bin = make_pair(nbins[0], nbins[1]);
@@ -760,7 +797,7 @@ int PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
           {
             if (Verbosity() > 1)
             {
-              cout << "    did not find a previous entry for key = " << key << " create a new one" << endl;
+              cout << "    did not find a previous entry for key = 0x" << hex << key << dec << " create a new one" << endl;
             }
             PHG4CellDefs::keytype cellkey = PHG4CellDefs::SizeBinning::genkey(*layer, izbin, iphibin);
             cell = new PHG4Cellv1(cellkey);
@@ -797,7 +834,7 @@ int PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
         numcells++;
         if (Verbosity() > 1)
         {
-          cout << "Adding cell for key " << it->first << " in bin phi: " << PHG4CellDefs::SizeBinning::get_phibin(it->second->get_cellid())
+          cout << "Adding cell for key " << hex << it->first << dec << " in bin phi: " << PHG4CellDefs::SizeBinning::get_phibin(it->second->get_cellid())
                << " phi: " << geo->get_phicenter(PHG4CellDefs::SizeBinning::get_phibin(it->second->get_cellid())) * 180. / M_PI
                << ", z bin: " << PHG4CellDefs::SizeBinning::get_zbin(it->second->get_cellid())
                << ", z: " << geo->get_zcenter(PHG4CellDefs::SizeBinning::get_zbin(it->second->get_cellid()))

--- a/simulation/g4simulation/g4histos/G4CellNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4CellNtuple.cc
@@ -6,7 +6,7 @@
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
-#include <fun4all/SubsysReco.h>                         // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/getClass.h>
 
@@ -15,10 +15,10 @@
 #include <TNtuple.h>
 
 #include <cassert>
-#include <cmath>                                        // for isfinite
-#include <iostream>                                     // for operator<<
+#include <cmath>     // for isfinite
+#include <iostream>  // for operator<<
 #include <sstream>
-#include <utility>                                      // for pair
+#include <utility>  // for pair
 
 using namespace std;
 
@@ -89,8 +89,8 @@ int G4CellNtuple::process_event(PHCompositeNode *topNode)
           cout << "invalid edep: " << edep << endl;
         }
         esum += cell_iter->second->get_edep();
-	int phibin = ~0x0;
-	int etabin = ~0x0;
+        int phibin = ~0x0;
+        int etabin = ~0x0;
         double phi = NAN;
         double eta = NAN;
         int layer = cell_iter->second->get_layer();
@@ -102,18 +102,18 @@ int G4CellNtuple::process_event(PHCompositeNode *topNode)
         }
         if (cell_iter->second->has_binning(PHG4CellDefs::etaphibinning))
         {
-        phibin = PHG4CellDefs::EtaPhiBinning::get_phibin(cell_iter->second->get_cellid());
-        etabin =  PHG4CellDefs::EtaPhiBinning::get_etabin(cell_iter->second->get_cellid());
-        phi = cellgeom->get_phicenter(phibin);
-        eta = cellgeom->get_etacenter(etabin);
-	}
+          phibin = PHG4CellDefs::EtaPhiBinning::get_phibin(cell_iter->second->get_cellid());
+          etabin = PHG4CellDefs::EtaPhiBinning::get_etabin(cell_iter->second->get_cellid());
+          phi = cellgeom->get_phicenter(phibin);
+          eta = cellgeom->get_etacenter(etabin);
+        }
         else if (cell_iter->second->has_binning(PHG4CellDefs::sizebinning))
         {
-        phibin = PHG4CellDefs::SizeBinning::get_phibin(cell_iter->second->get_cellid());
-        etabin =  PHG4CellDefs::SizeBinning::get_zbin(cell_iter->second->get_cellid());
-        phi = cellgeom->get_phicenter(phibin);
-        eta = cellgeom->get_zcenter(etabin);
-	}
+          phibin = PHG4CellDefs::SizeBinning::get_phibin(cell_iter->second->get_cellid());
+          etabin = PHG4CellDefs::SizeBinning::get_zbin(cell_iter->second->get_cellid());
+          phi = cellgeom->get_phicenter(phibin);
+          eta = cellgeom->get_zcenter(etabin);
+        }
         assert(cellgeom != nullptr);
         ntup->Fill(detid,
                    cell_iter->second->get_layer(),

--- a/simulation/g4simulation/g4histos/G4CellNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4CellNtuple.cc
@@ -1,7 +1,7 @@
 #include "G4CellNtuple.h"
 
-#include <g4detectors/PHG4CylinderCell.h>
-#include <g4detectors/PHG4CylinderCellContainer.h>
+#include <g4detectors/PHG4Cell.h>
+#include <g4detectors/PHG4CellContainer.h>
 #include <g4detectors/PHG4CylinderCellGeom.h>
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
 
@@ -64,13 +64,13 @@ int G4CellNtuple::process_event(PHCompositeNode *topNode)
     nodename << "G4CELL_" << *iter;
     geonodename.str("");
     geonodename << "CYLINDERCELLGEOM_" << *iter;
-    PHG4CylinderCellGeomContainer *cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, geonodename.str().c_str());
+    PHG4CylinderCellGeomContainer *cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, geonodename.str());
     if (!cellgeos)
     {
       cout << "no geometry node " << geonodename.str() << " for " << *iter << endl;
       continue;
     }
-    PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode, nodename.str().c_str());
+    PHG4CellContainer *cells = findNode::getClass<PHG4CellContainer>(topNode, nodename.str());
     if (cells)
     {
       int previouslayer = -1;
@@ -79,8 +79,8 @@ int G4CellNtuple::process_event(PHCompositeNode *topNode)
       //          double numcells = cells->size();
       //          ncells[i]->Fill(numcells);
       //	  cout << "number of cells: " << cells->size() << endl;
-      PHG4CylinderCellContainer::ConstRange cell_range = cells->getCylinderCells();
-      for (PHG4CylinderCellContainer::ConstIterator cell_iter = cell_range.first; cell_iter != cell_range.second; cell_iter++)
+      PHG4CellContainer::ConstRange cell_range = cells->getCells();
+      for (PHG4CellContainer::ConstIterator cell_iter = cell_range.first; cell_iter != cell_range.second; cell_iter++)
 
       {
         double edep = cell_iter->second->get_edep();
@@ -89,8 +89,10 @@ int G4CellNtuple::process_event(PHCompositeNode *topNode)
           cout << "invalid edep: " << edep << endl;
         }
         esum += cell_iter->second->get_edep();
-        int phibin = cell_iter->second->get_binphi();
-        int etabin = cell_iter->second->get_bineta();
+	int phibin = ~0x0;
+	int etabin = ~0x0;
+        double phi = NAN;
+        double eta = NAN;
         int layer = cell_iter->second->get_layer();
         // to search the map fewer times, cache the geom object until the layer changes
         if (layer != previouslayer)
@@ -98,9 +100,21 @@ int G4CellNtuple::process_event(PHCompositeNode *topNode)
           cellgeom = cellgeos->GetLayerCellGeom(layer);
           previouslayer = layer;
         }
+        if (cell_iter->second->has_binning(PHG4CellDefs::etaphibinning))
+        {
+        phibin = PHG4CellDefs::EtaPhiBinning::get_phibin(cell_iter->second->get_cellid());
+        etabin =  PHG4CellDefs::EtaPhiBinning::get_etabin(cell_iter->second->get_cellid());
+        phi = cellgeom->get_phicenter(phibin);
+        eta = cellgeom->get_etacenter(etabin);
+	}
+        else if (cell_iter->second->has_binning(PHG4CellDefs::sizebinning))
+        {
+        phibin = PHG4CellDefs::SizeBinning::get_phibin(cell_iter->second->get_cellid());
+        etabin =  PHG4CellDefs::SizeBinning::get_zbin(cell_iter->second->get_cellid());
+        phi = cellgeom->get_phicenter(phibin);
+        eta = cellgeom->get_zcenter(etabin);
+	}
         assert(cellgeom != nullptr);
-        double phi = cellgeom->get_phicenter(phibin);
-        double eta = cellgeom->get_etacenter(etabin);
         ntup->Fill(detid,
                    cell_iter->second->get_layer(),
                    phi,


### PR DESCRIPTION
This PR fixes the case where the size of the cell exceeds the available range (basically giving a large value since you want only one bin). The G4CellNtuple code was updated to use the new PHG4Cells instead of the old PHG4CylinderCells.