### PR TITLE
Tracking QA

### DIFF
--- a/offline/QA/modules/Makefile.am
+++ b/offline/QA/modules/Makefile.am
@@ -26,6 +26,7 @@ pkginclude_HEADERS = \
   QAG4SimulationCalorimeter.h \
   QAG4SimulationCalorimeterSum.h \
   QAG4SimulationTracking.h \
+  QAG4SimulationUpsilon.h \
   QAG4SimulationJet.h \
   QAHistManagerDef.h
 
@@ -35,6 +36,7 @@ if ! MAKEROOT6
     QAG4SimulationCalorimeter_Dict.cc \
     QAG4SimulationCalorimeterSum_Dict.cc \
     QAG4SimulationTracking_Dict.cc \
+    QAG4SimulationUpsilon_Dict.cc \
     QAG4SimulationJet_Dict.cc 
 endif
 
@@ -44,6 +46,7 @@ libqa_modules_la_SOURCES = \
   QAG4SimulationCalorimeter.cc \
   QAG4SimulationCalorimeterSum.cc \
   QAG4SimulationTracking.cc \
+  QAG4SimulationUpsilon.cc \
   QAG4SimulationJet.cc
 
 # Rule for generating table CINT dictionaries.

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -16,6 +16,7 @@
 #include <trackbase_historic/SvtxTrack.h>
 
 #include <g4eval/SvtxTrackEval.h>  // for SvtxTrackEval
+#include <g4eval/SvtxTruthEval.h>  // for SvtxTruthEval
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -24,6 +25,7 @@
 #include <phool/getClass.h>
 
 #include <TAxis.h>
+#include <TDatabasePDG.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TNamed.h>
@@ -49,7 +51,7 @@ QAG4SimulationTracking::QAG4SimulationTracking()
 int QAG4SimulationTracking::InitRun(PHCompositeNode *topNode)
 {
   _truthContainer = findNode::getClass<PHG4TruthInfoContainer>(topNode,
-                                                                "G4TruthInfo");
+                                                               "G4TruthInfo");
   if (!_truthContainer)
   {
     cout << "QAG4SimulationTracking::InitRun - Fatal Error - "
@@ -74,25 +76,46 @@ int QAG4SimulationTracking::Init(PHCompositeNode *topNode)
   assert(hm);
 
   // reco pT / gen pT histogram
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "pTRecoGenRatio",
-                             "Reco p_{T}/Truth p_{T}",500, 0, 2));
+  TH1 *h(nullptr);
+
+  h = new TH1F(TString(get_histo_prefix()) + "pTRecoGenRatio",
+               ";Reco p_{T}/Truth p_{T}", 500, 0, 2);
+  hm->registerHisto(h);
+
+  h = new TH2F(TString(get_histo_prefix()) + "pTRecoGenRatio_pTGen",
+               ";Truth p_{T} [GeV/c];Reco p_{T}/Truth p_{T}", 200, 0.1, 50.5, 500, 0, 2);
+  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
+
   // reco pT histogram
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "nReco_pTGen",
-                             "Reco tracks at truth p_{T}",200, -0.5, 50.5));
+  h = new TH1F(TString(get_histo_prefix()) + "nReco_pTGen",
+               "Reco tracks at truth p_{T};Truth p_{T} [GeV/c]", 200, 0.1, 50.5);
+  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
   // reco pT histogram
-  hm->registerHisto(new TH1F(TString(get_histo_prefix()) + "nGen_pTGen",
-                             "Truth p_{T}",200, -0.5, 50.5));
-  
+  h = new TH1F(TString(get_histo_prefix()) + "nGen_pTGen",
+               ";Truth p_{T} [GeV/c];Track count / bin", 200, 0.1, 50.5);
+  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
+
   // n events and n tracks histogram
-  TH1F *h = new TH1F(TString(get_histo_prefix()) + "Normalization",
-                     TString(get_histo_prefix()) + " Normalization;Items;Count", 10, .5, 10.5);
+  h = new TH1F(TString(get_histo_prefix()) + "Normalization",
+               TString(get_histo_prefix()) + " Normalization;Items;Count", 10, .5, 10.5);
   int i = 1;
   h->GetXaxis()->SetBinLabel(i++, "Event");
-  h->GetXaxis()->SetBinLabel(i++, "Track");
+  h->GetXaxis()->SetBinLabel(i++, "Truth Track");
+  h->GetXaxis()->SetBinLabel(i++, "Truth Track+");
+  h->GetXaxis()->SetBinLabel(i++, "Truth Track-");
+  h->GetXaxis()->SetBinLabel(i++, "Reco Track");
   h->GetXaxis()->LabelsOption("v");
   hm->registerHisto(h);
 
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void QAG4SimulationTracking::addEmbeddingID(int embeddingID)
+{
+  m_embeddingIDs.insert(embeddingID);
 }
 
 int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
@@ -109,69 +132,107 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
 
   SvtxTrackEval *trackeval = _svtxEvalStack->get_track_eval();
   assert(trackeval);
+  SvtxTruthEval *trutheval = _svtxEvalStack->get_truth_eval();
+  assert(trutheval);
 
   // reco pT / gen pT histogram
-  TH1F *h_pTRecoGenRatio = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "pTRecoGenRatio"));
+  TH1 *h_pTRecoGenRatio = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "pTRecoGenRatio"));
   assert(h_pTRecoGenRatio);
-  
+
+  // reco pT / gen pT histogram
+  TH2 *h_pTRecoGenRatio_pTGen = dynamic_cast<TH2 *>(hm->getHisto(get_histo_prefix() + "pTRecoGenRatio_pTGen"));
+  assert(h_pTRecoGenRatio);
+
   // reco histogram plotted at gen pT
-  TH1F *h_nReco_pTGen = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "nReco_pTGen"));
+  TH1 *h_nReco_pTGen = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "nReco_pTGen"));
   assert(h_nReco_pTGen);
-  
+
   // gen pT histogram
-  TH1F *h_nGen_pTGen = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "nGen_pTGen"));
+  TH1 *h_nGen_pTGen = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "nGen_pTGen"));
   assert(h_nGen_pTGen);
-  
+
   // n events and n tracks histogram
-  TH1F *h_norm = dynamic_cast<TH1F *>(hm->getHisto(get_histo_prefix() + "Normalization"));
+  TH1 *h_norm = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "Normalization"));
   assert(h_norm);
   h_norm->Fill("Event", 1);
-  
+
   // fill histograms that need truth information
-  if(_truthContainer)
+  if (_truthContainer)
   {
     PHG4TruthInfoContainer::ConstRange range = _truthContainer->GetPrimaryParticleRange();
     for (PHG4TruthInfoContainer::ConstIterator iter = range.first; iter != range.second; ++iter)
     {
       // get the truth particle information
-      PHG4Particle* g4particle = iter->second;
-      
-      // is this needed? what does it mean?
-//      if (_scan_for_embedded)
-//      {
-//        if (trutheval->get_embed(g4particle) <= 0) continue;
-//      }
-      
-      float gpx = g4particle->get_px();
-      float gpy = g4particle->get_py();
-      float gpz = g4particle->get_px();
-      float gpt = 0;
+      PHG4Particle *g4particle = iter->second;
 
-      if (gpx != 0 && gpy != 0) {
-        TVector3 gv(gpx,gpy,gpz);
+      if (m_embeddingIDs.size() > 0)
+      {
+        //only analyze subset of particle with proper embedding IDs
+        int candidate_embedding_id = trutheval->get_embed(g4particle);
+        if (candidate_embedding_id < 0) candidate_embedding_id = -1;
+
+        // skip if no match
+        if (m_embeddingIDs.find(candidate_embedding_id) == m_embeddingIDs.end()) continue;
+      }
+
+      const int pid = g4particle->get_pid();
+      TParticlePDG *pdg_p = TDatabasePDG::Instance()->GetParticle(pid);
+      if (!pdg_p)
+      {
+        cout << "QAG4SimulationTracking::process_event - Error - invalid particle ID = " << pid << endl;
+        continue;
+      }
+
+      const double gcharge = pdg_p->Charge() / 3;
+      if (gcharge > 0)
+      {
+        h_norm->Fill("Truth Track+", 1);
+      }
+      else if (gcharge < 0)
+      {
+        h_norm->Fill("Truth Track-", 1);
+      }
+      else
+      {
+        if (Verbosity())
+          cout << "QAG4SimulationTracking::process_event - invalid particle ID = " << pid << endl;
+        continue;
+      }
+      h_norm->Fill("Truth Track", 1);
+
+      double gpx = g4particle->get_px();
+      double gpy = g4particle->get_py();
+      double gpz = g4particle->get_px();
+      double gpt = 0;
+
+      if (gpx != 0 && gpy != 0)
+      {
+        TVector3 gv(gpx, gpy, gpz);
         gpt = gv.Pt();
-  //      geta = gv.Pt();
-  //      gphi = gv.Pt();
+        //      geta = gv.Pt();
+        //      gphi = gv.Pt();
       }
       h_nGen_pTGen->Fill(gpt);
 
       // look for best matching track in reco data & get its information
-      SvtxTrack* track = trackeval->best_track_from(g4particle);
-      if(track) {
+      SvtxTrack *track = trackeval->best_track_from(g4particle);
+      if (track)
+      {
         h_nReco_pTGen->Fill(gpt);
-        
-        float px = track->get_px();
-        float py = track->get_py();
-        float pz = track->get_pz();
-        float pt;
-        TVector3 v(px,py,pz);
+
+        double px = track->get_px();
+        double py = track->get_py();
+        double pz = track->get_pz();
+        double pt;
+        TVector3 v(px, py, pz);
         pt = v.Pt();
-  //      eta = v.Pt();
-  //      phi = v.Pt();
-        
-        float pt_ratio = (gpt != 0) ? pt/gpt : 0;
+        //      eta = v.Pt();
+        //      phi = v.Pt();
+
+        float pt_ratio = (gpt != 0) ? pt / gpt : 0;
         h_pTRecoGenRatio->Fill(pt_ratio);
-        h_norm->Fill("Track", 1);
+        h_pTRecoGenRatio_pTGen->Fill(gpt, pt_ratio);
+        h_norm->Fill("Reco Track", 1);
       }
     }
   }

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -211,8 +211,8 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
       {
         TVector3 gv(gpx, gpy, gpz);
         gpt = gv.Pt();
-        geta = gv.Pt();
-        //      gphi = gv.Pt();
+        geta = gv.Eta();
+        //      gphi = gv.Phi();
       }
       if (m_etaRange.first < geta and geta < m_etaRange.second)
       {

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -203,7 +203,7 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
 
       double gpx = g4particle->get_px();
       double gpy = g4particle->get_py();
-      double gpz = g4particle->get_px();
+      double gpz = g4particle->get_pz();
       double gpt = 0;
       double geta = NAN;
 
@@ -286,5 +286,5 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
 string
 QAG4SimulationTracking::get_histo_prefix()
 {
-  return "h_QAG4Sim_Tracking_";
+  return string("h_") + Name() + string("_");
 }

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <set>
+#include <utility>
 
 #if !defined(__CINT__) || defined(__CLING__)
 #include <cstdint>
@@ -39,14 +40,19 @@ class QAG4SimulationTracking : public SubsysReco
   //! For EmbeddingID<0, all negative embedding IDs are accepted for pile up events.
   void addEmbeddingID(int embeddingID);
 
+  void setEtaRange(double low, double high)
+  {
+    m_etaRange.first = low;
+    m_etaRange.second = high;
+  }
 
  private:
 #if !defined(__CINT__) || defined(__CLING__)
   //CINT is not c++11 compatible
   std::shared_ptr<SvtxEvalStack> _svtxEvalStack;
   std::set<int> m_embeddingIDs;
-
 #endif
+  std::pair<double, double> m_etaRange;
 
   PHG4TruthInfoContainer *_truthContainer;
 };

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -25,7 +25,7 @@ class SvtxTrack;
 class QAG4SimulationTracking : public SubsysReco
 {
  public:
-  QAG4SimulationTracking();
+  QAG4SimulationTracking(const std::string & name = "QAG4SimulationTracking");
   virtual ~QAG4SimulationTracking() {}
 
   int Init(PHCompositeNode *topNode);

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <string>
+#include <set>
 
 #if !defined(__CINT__) || defined(__CLING__)
 #include <cstdint>
@@ -24,7 +25,7 @@ class QAG4SimulationTracking : public SubsysReco
 {
  public:
   QAG4SimulationTracking();
-  virtual ~QAG4SimulationTracking(){}
+  virtual ~QAG4SimulationTracking() {}
 
   int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);
@@ -32,11 +33,20 @@ class QAG4SimulationTracking : public SubsysReco
 
   // common prefix for QA histograms
   std::string get_histo_prefix();
+
+  //! If added, only process truth particle associated with the selected list of EmbeddingIDs
+  //! Call multiple times to add multiple EmbeddingIDs
+  //! For EmbeddingID<0, all negative embedding IDs are accepted for pile up events.
+  void addEmbeddingID(int embeddingID);
+
+
  private:
-  #if !defined(__CINT__) || defined(__CLING__)
-    //CINT is not c++11 compatible
-    std::shared_ptr<SvtxEvalStack> _svtxEvalStack;
-  #endif
+#if !defined(__CINT__) || defined(__CLING__)
+  //CINT is not c++11 compatible
+  std::shared_ptr<SvtxEvalStack> _svtxEvalStack;
+  std::set<int> m_embeddingIDs;
+
+#endif
 
   PHG4TruthInfoContainer *_truthContainer;
 };

--- a/offline/QA/modules/QAG4SimulationUpsilon.cc
+++ b/offline/QA/modules/QAG4SimulationUpsilon.cc
@@ -32,6 +32,8 @@
 #include <TString.h>
 #include <TVector3.h>
 
+#include <CLHEP/Vector/LorentzVector.h>
+
 #include <cassert>
 #include <cmath>
 #include <iostream>
@@ -41,8 +43,8 @@
 
 using namespace std;
 
-QAG4SimulationUpsilon::QAG4SimulationUpsilon()
-  : SubsysReco("QAG4SimulationUpsilon")
+QAG4SimulationUpsilon::QAG4SimulationUpsilon(const std::string &name)
+  : SubsysReco(name)
   , _svtxEvalStack(nullptr)
   , m_etaRange(-1, 1)
   , _truthContainer(nullptr)
@@ -110,14 +112,24 @@ int QAG4SimulationUpsilon::Init(PHCompositeNode *topNode)
   //  QAHistManagerDef::useLogBins(h->GetXaxis());
   hm->registerHisto(h);
 
+  h = new TH1F(TString(get_histo_prefix()) + "nGen_Pair_InvMassGen",
+               ";Truth Invariant Mass [GeV/c^2];Pair count / bin", 200, 0, 15);
+  //  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
+  h = new TH1F(TString(get_histo_prefix()) + "nReco_Pair_InvMassReco",
+               ";Reco Invariant Mass [GeV/c^2];Pair count / bin", 200, 0, 15);
+  //  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
+
   // n events and n tracks histogram
   h = new TH1F(TString(get_histo_prefix()) + "Normalization",
                TString(get_histo_prefix()) + " Normalization;Items;Count", 10, .5, 10.5);
   int i = 1;
   h->GetXaxis()->SetBinLabel(i++, "Event");
-  h->GetXaxis()->SetBinLabel(i++, "Truth Upsilon");
   h->GetXaxis()->SetBinLabel(i++, "Truth Track+");
   h->GetXaxis()->SetBinLabel(i++, "Truth Track-");
+  h->GetXaxis()->SetBinLabel(i++, "Reco Track");
+  h->GetXaxis()->SetBinLabel(i++, "Truth Upsilon");
   h->GetXaxis()->SetBinLabel(i++, "Truth Upsilon in Acc.");
   h->GetXaxis()->SetBinLabel(i++, "Reco Upsilon");
   h->GetXaxis()->LabelsOption("v");
@@ -172,117 +184,228 @@ int QAG4SimulationUpsilon::process_event(PHCompositeNode *topNode)
   TH1 *h_nGen_etaGen = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "nGen_etaGen"));
   assert(h_nGen_etaGen);
 
+  // inv mass
+  TH1 *h_nGen_Pair_InvMassGen = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "nGen_Pair_InvMassGen"));
+  assert(h_nGen_etaGen);
+  // inv mass
+  TH1 *h_nReco_Pair_InvMassReco = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "nReco_Pair_InvMassReco"));
+  assert(h_nGen_etaGen);
+
   // n events and n tracks histogram
   TH1 *h_norm = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "Normalization"));
   assert(h_norm);
   h_norm->Fill("Event", 1);
 
-  // fill histograms that need truth information
-  if (_truthContainer)
-  {
-    PHG4TruthInfoContainer::ConstRange range = _truthContainer->GetPrimaryParticleRange();
-    for (PHG4TruthInfoContainer::ConstIterator iter = range.first; iter != range.second; ++iter)
-    {
-      // get the truth particle information
-      PHG4Particle *g4particle = iter->second;
+  //buffer for daugther particles
+  typedef set<pair<PHG4Particle *, SvtxTrack *>> truth_reco_set_t;
+  truth_reco_set_t truth_reco_set_pos;
+  truth_reco_set_t truth_reco_set_neg;
 
+  // fill histograms that need truth information
+  if (!_truthContainer)
+  {
+    cout << "QAG4SimulationUpsilon::process_event - fatal error - missing _truthContainer! ";
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  PHG4TruthInfoContainer::ConstRange range = _truthContainer->GetPrimaryParticleRange();
+  for (PHG4TruthInfoContainer::ConstIterator iter = range.first; iter != range.second; ++iter)
+  {
+    // get the truth particle information
+    PHG4Particle *g4particle = iter->second;
+
+    if (Verbosity())
+    {
+      cout << "QAG4SimulationUpsilon::process_event - processing ";
+      g4particle->identify();
+    }
+
+    if (m_embeddingIDs.size() > 0)
+    {
+      //only analyze subset of particle with proper embedding IDs
+      int candidate_embedding_id = trutheval->get_embed(g4particle);
+      if (candidate_embedding_id < 0) candidate_embedding_id = -1;
+
+      // skip if no match
+      if (m_embeddingIDs.find(candidate_embedding_id) == m_embeddingIDs.end()) continue;
+    }
+
+    double gpx = g4particle->get_px();
+    double gpy = g4particle->get_py();
+    double gpz = g4particle->get_pz();
+    double gpt = 0;
+    double geta = NAN;
+
+    if (gpx != 0 && gpy != 0)
+    {
+      TVector3 gv(gpx, gpy, gpz);
+      gpt = gv.Pt();
+      geta = gv.Eta();
+      //      gphi = gv.Phi();
+    }
+    if (m_etaRange.first < geta and geta < m_etaRange.second)
+    {
       if (Verbosity())
       {
-        cout << "QAG4SimulationUpsilon::process_event - processing ";
-        g4particle->identify();
-      }
-
-      if (m_embeddingIDs.size() > 0)
-      {
-        //only analyze subset of particle with proper embedding IDs
-        int candidate_embedding_id = trutheval->get_embed(g4particle);
-        if (candidate_embedding_id < 0) candidate_embedding_id = -1;
-
-        // skip if no match
-        if (m_embeddingIDs.find(candidate_embedding_id) == m_embeddingIDs.end()) continue;
-      }
-
-      {
-
-        double gpx = g4particle->get_px();
-        double gpy = g4particle->get_py();
-        double gpz = g4particle->get_pz();
-        double gpt = 0;
-        double geta = NAN;
-
-        if (gpx != 0 && gpy != 0)
-        {
-          TVector3 gv(gpx, gpy, gpz);
-          gpt = gv.Pt();
-          geta = gv.Eta();
-          //      gphi = gv.Phi();
-        }
-        if (m_etaRange.first < geta and geta < m_etaRange.second)
-        {
-          if (Verbosity())
-          {
-            cout << "QAG4SimulationUpsilon::process_event - accept particle eta = " << geta << endl;
-          }
-        }
-        else
-        {
-          if (Verbosity())
-            cout << "QAG4SimulationUpsilon::process_event - ignore particle eta = " << geta << endl;
-          continue;
-        }
-
-        const int pid = g4particle->get_pid();
-        TParticlePDG *pdg_p = TDatabasePDG::Instance()->GetParticle(pid);
-        if (!pdg_p)
-        {
-          cout << "QAG4SimulationUpsilon::process_event - Error - invalid particle ID = " << pid << endl;
-          continue;
-        }
-
-        const double gcharge = pdg_p->Charge() / 3;
-        if (gcharge > 0)
-        {
-          h_norm->Fill("Truth Track+", 1);
-        }
-        else if (gcharge < 0)
-        {
-          h_norm->Fill("Truth Track-", 1);
-        }
-        else
-        {
-          if (Verbosity())
-            cout << "QAG4SimulationUpsilon::process_event - invalid particle ID = " << pid << endl;
-          continue;
-        }
-        h_norm->Fill("Truth Track", 1);
-
-        h_nGen_pTGen->Fill(gpt);
-        h_nGen_etaGen->Fill(geta);
-
-        // look for best matching track in reco data & get its information
-        SvtxTrack *track = trackeval->best_track_from(g4particle);
-        if (track)
-        {
-          h_nReco_etaGen->Fill(geta);
-          h_nReco_pTGen->Fill(gpt);
-
-          double px = track->get_px();
-          double py = track->get_py();
-          double pz = track->get_pz();
-          double pt;
-          TVector3 v(px, py, pz);
-          pt = v.Pt();
-          //        eta = v.Pt();
-          //      phi = v.Pt();
-
-          float pt_ratio = (gpt != 0) ? pt / gpt : 0;
-          h_pTRecoGenRatio->Fill(pt_ratio);
-          h_pTRecoGenRatio_pTGen->Fill(gpt, pt_ratio);
-          h_norm->Fill("Reco Track", 1);
-        }
+        cout << "QAG4SimulationUpsilon::process_event - accept particle eta = " << geta << endl;
       }
     }
+    else
+    {
+      if (Verbosity())
+        cout << "QAG4SimulationUpsilon::process_event - ignore particle eta = " << geta << endl;
+      continue;
+    }
+
+    const int pid = g4particle->get_pid();
+
+    if (abs(pid) != abs(m_daughterAbsPID))
+    {
+      if (Verbosity())
+        cout << "QAG4SimulationUpsilon::process_event - ignore particle PID = " << pid << " as m_daughterAbsPID = " << m_daughterAbsPID << endl;
+      continue;
+    }
+
+    TParticlePDG *pdg_p = TDatabasePDG::Instance()->GetParticle(pid);
+    if (!pdg_p)
+    {
+      cout << "QAG4SimulationUpsilon::process_event - Error - invalid particle ID = " << pid << endl;
+      continue;
+    }
+
+    const double gcharge = pdg_p->Charge() / 3;
+    if (gcharge > 0)
+    {
+      h_norm->Fill("Truth Track+", 1);
+    }
+    else if (gcharge < 0)
+    {
+      h_norm->Fill("Truth Track-", 1);
+    }
+    else
+    {
+      if (Verbosity())
+        cout << "QAG4SimulationUpsilon::process_event - invalid neutral decay particle ID = " << pid << endl;
+      continue;
+    }
+    //        h_norm->Fill("Truth Track", 1);
+
+    h_nGen_pTGen->Fill(gpt);
+    h_nGen_etaGen->Fill(geta);
+
+    // look for best matching track in reco data & get its information
+    SvtxTrack *track = trackeval->best_track_from(g4particle);
+    if (track)
+    {
+      h_nReco_etaGen->Fill(geta);
+      h_nReco_pTGen->Fill(gpt);
+
+      double px = track->get_px();
+      double py = track->get_py();
+      double pz = track->get_pz();
+      double pt;
+      TVector3 v(px, py, pz);
+      pt = v.Pt();
+      //        eta = v.Pt();
+      //      phi = v.Pt();
+
+      float pt_ratio = (gpt != 0) ? pt / gpt : 0;
+      h_pTRecoGenRatio->Fill(pt_ratio);
+      h_pTRecoGenRatio_pTGen->Fill(gpt, pt_ratio);
+      h_norm->Fill("Reco Track", 1);
+    }
+
+    if (gcharge > 0)
+    {
+      truth_reco_set_pos.insert(make_pair(g4particle, track));
+    }
+    else if (gcharge < 0)
+    {
+      truth_reco_set_neg.insert(make_pair(g4particle, track));
+    }
+  }  //  for (PHG4TruthInfoContainer::ConstIterator iter = range.first; iter != range.second; ++iter)
+
+  //building pairs with buffer for daugter particles
+  TParticlePDG *pdg_p = TDatabasePDG::Instance()->GetParticle(m_quarkoniaPID);
+  if (!pdg_p)
+  {
+    cout << "QAG4SimulationUpsilon::process_event - Fatal Error - invalid particle ID m_quarkoniaPID = " << m_quarkoniaPID << endl;
+
+    return Fun4AllReturnCodes::ABORTRUN;
   }
+  const double quarkonium_mass = pdg_p->Mass();
+  TParticlePDG *pdg_d = TDatabasePDG::Instance()->GetParticle(m_daughterAbsPID);
+  if (!pdg_d)
+  {
+    cout << "QAG4SimulationUpsilon::process_event - Fatal Error - invalid particle ID m_daughterAbsPID = " << m_daughterAbsPID << endl;
+
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  const double daughter_mass = pdg_d->Mass();
+
+  for (const auto &pair_pos : truth_reco_set_pos)
+    for (const auto &pair_neg : truth_reco_set_neg)
+    {
+      assert(pair_pos.first);
+      assert(pair_neg.first);
+
+      const CLHEP::HepLorentzVector gv_pos(
+          pair_pos.first->get_px(),
+          pair_pos.first->get_py(),
+          pair_pos.first->get_pz(),
+          pair_pos.first->get_e());
+
+      const CLHEP::HepLorentzVector gv_neg(
+          pair_neg.first->get_px(),
+          pair_neg.first->get_py(),
+          pair_neg.first->get_pz(),
+          pair_neg.first->get_e());
+
+      const CLHEP::HepLorentzVector gv_quakonium = gv_pos + gv_neg;
+
+      if (fabs(quarkonium_mass - gv_quakonium.m()) > 1e-3)
+      {
+        if (Verbosity())
+        {
+          cout << "QAG4SimulationUpsilon::process_event - invalid pair with in compativle mass with " << quarkonium_mass << "GeV for PID = " << m_quarkoniaPID << ": " << endl;
+          pair_pos.first->identify();
+          pair_neg.first->identify();
+        }
+        continue;
+      }
+
+      h_nGen_Pair_InvMassGen->Fill(gv_quakonium.m());
+      h_norm->Fill("Truth Upsilon in Acc.", 1);
+
+      if (pair_pos.second and pair_neg.second)
+      {
+        CLHEP::HepLorentzVector v_pos;
+        CLHEP::HepLorentzVector v_neg;
+
+        v_pos.setVectM(
+            CLHEP::Hep3Vector(
+                pair_pos.second->get_px(),
+                pair_pos.second->get_py(),
+                pair_pos.second->get_pz()),
+            daughter_mass);
+        v_neg.setVectM(
+            CLHEP::Hep3Vector(
+                pair_neg.second->get_px(),
+                pair_neg.second->get_py(),
+                pair_neg.second->get_pz()),
+            daughter_mass);
+
+
+        const CLHEP::HepLorentzVector v_quakonium = v_pos + v_neg;
+
+
+        h_nReco_Pair_InvMassReco->Fill(v_quakonium.m());
+        h_norm->Fill("Reco Upsilon", 1);
+
+      }//      if (pair_pos.second and pair_neg.second)
+
+
+    }  //    for (const auto &pair_neg : truth_reco_set_neg)
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/QA/modules/QAG4SimulationUpsilon.cc
+++ b/offline/QA/modules/QAG4SimulationUpsilon.cc
@@ -1,0 +1,294 @@
+#include "QAG4SimulationUpsilon.h"
+#include "QAHistManagerDef.h"
+
+#include <g4eval/CaloEvalStack.h>
+#include <g4eval/CaloRawClusterEval.h>
+#include <g4eval/SvtxEvalStack.h>
+
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+
+#include <calobase/RawCluster.h>
+#include <calobase/RawTower.h>
+#include <calobase/RawTowerContainer.h>
+#include <calobase/RawTowerGeomContainer.h>
+
+#include <trackbase_historic/SvtxTrack.h>
+
+#include <g4eval/SvtxTrackEval.h>  // for SvtxTrackEval
+#include <g4eval/SvtxTruthEval.h>  // for SvtxTruthEval
+
+#include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>
+
+#include <phool/getClass.h>
+
+#include <TAxis.h>
+#include <TDatabasePDG.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TNamed.h>
+#include <TString.h>
+#include <TVector3.h>
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <iterator>  // for reverse_iterator
+#include <utility>   // for pair
+#include <vector>
+
+using namespace std;
+
+QAG4SimulationUpsilon::QAG4SimulationUpsilon()
+  : SubsysReco("QAG4SimulationUpsilon")
+  , _svtxEvalStack(nullptr)
+  , m_etaRange(-1, 1)
+  , _truthContainer(nullptr)
+{
+}
+
+int QAG4SimulationUpsilon::InitRun(PHCompositeNode *topNode)
+{
+  _truthContainer = findNode::getClass<PHG4TruthInfoContainer>(topNode,
+                                                               "G4TruthInfo");
+  if (!_truthContainer)
+  {
+    cout << "QAG4SimulationUpsilon::InitRun - Fatal Error - "
+         << "unable to find DST node "
+         << "G4TruthInfo" << endl;
+    assert(_truthContainer);
+  }
+
+  if (!_svtxEvalStack)
+  {
+    _svtxEvalStack.reset(new SvtxEvalStack(topNode));
+    _svtxEvalStack->set_strict(true);
+    _svtxEvalStack->set_verbosity(Verbosity() + 1);
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int QAG4SimulationUpsilon::Init(PHCompositeNode *topNode)
+{
+  Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  // reco pT / gen pT histogram
+  TH1 *h(nullptr);
+
+  h = new TH1F(TString(get_histo_prefix()) + "pTRecoGenRatio",
+               ";Reco p_{T}/Truth p_{T}", 500, 0, 2);
+  hm->registerHisto(h);
+
+  h = new TH2F(TString(get_histo_prefix()) + "pTRecoGenRatio_pTGen",
+               ";Truth p_{T} [GeV/c];Reco p_{T}/Truth p_{T}", 200, 0, 50, 500, 0, 2);
+  //  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
+
+  // reco pT histogram
+  h = new TH1F(TString(get_histo_prefix()) + "nReco_pTGen",
+               "Reco tracks at truth p_{T};Truth p_{T} [GeV/c]", 200, 0.1, 50.5);
+  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
+  // reco pT histogram
+  h = new TH1F(TString(get_histo_prefix()) + "nGen_pTGen",
+               ";Truth p_{T} [GeV/c];Track count / bin", 200, 0.1, 50.5);
+  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
+
+  // reco pT histogram
+  h = new TH1F(TString(get_histo_prefix()) + "nReco_etaGen",
+               "Reco tracks at truth  #eta;Truth  #eta", 200, -2, 2);
+  //  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
+  // reco pT histogram
+  h = new TH1F(TString(get_histo_prefix()) + "nGen_etaGen",
+               ";Truth #eta;Track count / bin", 200, -2, 2);
+  //  QAHistManagerDef::useLogBins(h->GetXaxis());
+  hm->registerHisto(h);
+
+  // n events and n tracks histogram
+  h = new TH1F(TString(get_histo_prefix()) + "Normalization",
+               TString(get_histo_prefix()) + " Normalization;Items;Count", 10, .5, 10.5);
+  int i = 1;
+  h->GetXaxis()->SetBinLabel(i++, "Event");
+  h->GetXaxis()->SetBinLabel(i++, "Truth Upsilon");
+  h->GetXaxis()->SetBinLabel(i++, "Truth Track+");
+  h->GetXaxis()->SetBinLabel(i++, "Truth Track-");
+  h->GetXaxis()->SetBinLabel(i++, "Truth Upsilon in Acc.");
+  h->GetXaxis()->SetBinLabel(i++, "Reco Upsilon");
+  h->GetXaxis()->LabelsOption("v");
+  hm->registerHisto(h);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void QAG4SimulationUpsilon::addEmbeddingID(int embeddingID)
+{
+  m_embeddingIDs.insert(embeddingID);
+}
+
+int QAG4SimulationUpsilon::process_event(PHCompositeNode *topNode)
+{
+  if (Verbosity() > 2)
+    cout << "QAG4SimulationUpsilon::process_event() entered" << endl;
+
+  // histogram manager
+  Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  if (_svtxEvalStack)
+    _svtxEvalStack->next_event(topNode);
+
+  SvtxTrackEval *trackeval = _svtxEvalStack->get_track_eval();
+  assert(trackeval);
+  SvtxTruthEval *trutheval = _svtxEvalStack->get_truth_eval();
+  assert(trutheval);
+
+  // reco pT / gen pT histogram
+  TH1 *h_pTRecoGenRatio = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "pTRecoGenRatio"));
+  assert(h_pTRecoGenRatio);
+
+  // reco pT / gen pT histogram
+  TH2 *h_pTRecoGenRatio_pTGen = dynamic_cast<TH2 *>(hm->getHisto(get_histo_prefix() + "pTRecoGenRatio_pTGen"));
+  assert(h_pTRecoGenRatio);
+
+  // reco histogram plotted at gen pT
+  TH1 *h_nReco_pTGen = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "nReco_pTGen"));
+  assert(h_nReco_pTGen);
+
+  // gen pT histogram
+  TH1 *h_nGen_pTGen = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "nGen_pTGen"));
+  assert(h_nGen_pTGen);
+
+  // reco histogram plotted at gen eta
+  TH1 *h_nReco_etaGen = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "nReco_etaGen"));
+  assert(h_nReco_etaGen);
+
+  // gen eta histogram
+  TH1 *h_nGen_etaGen = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "nGen_etaGen"));
+  assert(h_nGen_etaGen);
+
+  // n events and n tracks histogram
+  TH1 *h_norm = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "Normalization"));
+  assert(h_norm);
+  h_norm->Fill("Event", 1);
+
+  // fill histograms that need truth information
+  if (_truthContainer)
+  {
+    PHG4TruthInfoContainer::ConstRange range = _truthContainer->GetPrimaryParticleRange();
+    for (PHG4TruthInfoContainer::ConstIterator iter = range.first; iter != range.second; ++iter)
+    {
+      // get the truth particle information
+      PHG4Particle *g4particle = iter->second;
+
+      if (Verbosity())
+      {
+        cout << "QAG4SimulationUpsilon::process_event - processing ";
+        g4particle->identify();
+      }
+
+      if (m_embeddingIDs.size() > 0)
+      {
+        //only analyze subset of particle with proper embedding IDs
+        int candidate_embedding_id = trutheval->get_embed(g4particle);
+        if (candidate_embedding_id < 0) candidate_embedding_id = -1;
+
+        // skip if no match
+        if (m_embeddingIDs.find(candidate_embedding_id) == m_embeddingIDs.end()) continue;
+      }
+
+      {
+
+        double gpx = g4particle->get_px();
+        double gpy = g4particle->get_py();
+        double gpz = g4particle->get_pz();
+        double gpt = 0;
+        double geta = NAN;
+
+        if (gpx != 0 && gpy != 0)
+        {
+          TVector3 gv(gpx, gpy, gpz);
+          gpt = gv.Pt();
+          geta = gv.Eta();
+          //      gphi = gv.Phi();
+        }
+        if (m_etaRange.first < geta and geta < m_etaRange.second)
+        {
+          if (Verbosity())
+          {
+            cout << "QAG4SimulationUpsilon::process_event - accept particle eta = " << geta << endl;
+          }
+        }
+        else
+        {
+          if (Verbosity())
+            cout << "QAG4SimulationUpsilon::process_event - ignore particle eta = " << geta << endl;
+          continue;
+        }
+
+        const int pid = g4particle->get_pid();
+        TParticlePDG *pdg_p = TDatabasePDG::Instance()->GetParticle(pid);
+        if (!pdg_p)
+        {
+          cout << "QAG4SimulationUpsilon::process_event - Error - invalid particle ID = " << pid << endl;
+          continue;
+        }
+
+        const double gcharge = pdg_p->Charge() / 3;
+        if (gcharge > 0)
+        {
+          h_norm->Fill("Truth Track+", 1);
+        }
+        else if (gcharge < 0)
+        {
+          h_norm->Fill("Truth Track-", 1);
+        }
+        else
+        {
+          if (Verbosity())
+            cout << "QAG4SimulationUpsilon::process_event - invalid particle ID = " << pid << endl;
+          continue;
+        }
+        h_norm->Fill("Truth Track", 1);
+
+        h_nGen_pTGen->Fill(gpt);
+        h_nGen_etaGen->Fill(geta);
+
+        // look for best matching track in reco data & get its information
+        SvtxTrack *track = trackeval->best_track_from(g4particle);
+        if (track)
+        {
+          h_nReco_etaGen->Fill(geta);
+          h_nReco_pTGen->Fill(gpt);
+
+          double px = track->get_px();
+          double py = track->get_py();
+          double pz = track->get_pz();
+          double pt;
+          TVector3 v(px, py, pz);
+          pt = v.Pt();
+          //        eta = v.Pt();
+          //      phi = v.Pt();
+
+          float pt_ratio = (gpt != 0) ? pt / gpt : 0;
+          h_pTRecoGenRatio->Fill(pt_ratio);
+          h_pTRecoGenRatio_pTGen->Fill(gpt, pt_ratio);
+          h_norm->Fill("Reco Track", 1);
+        }
+      }
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+string
+QAG4SimulationUpsilon::get_histo_prefix()
+{
+  return string("h_") + Name() + string("_");
+}

--- a/offline/QA/modules/QAG4SimulationUpsilon.h
+++ b/offline/QA/modules/QAG4SimulationUpsilon.h
@@ -1,0 +1,60 @@
+#ifndef QA_QAG4SimulationUpsilon_H
+#define QA_QAG4SimulationUpsilon_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <memory>
+#include <string>
+#include <set>
+#include <utility>
+
+#if !defined(__CINT__) || defined(__CLING__)
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
+class PHCompositeNode;
+class PHG4TruthInfoContainer;
+class PHG4Particle;
+class CaloEvalStack;
+class SvtxEvalStack;
+class SvtxTrack;
+
+/// \class QAG4SimulationUpsilon
+class QAG4SimulationUpsilon : public SubsysReco
+{
+ public:
+  QAG4SimulationUpsilon();
+  virtual ~QAG4SimulationUpsilon() {}
+
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+
+  // common prefix for QA histograms
+  std::string get_histo_prefix();
+
+  //! If added, only process truth particle associated with the selected list of EmbeddingIDs
+  //! Call multiple times to add multiple EmbeddingIDs
+  //! For EmbeddingID<0, all negative embedding IDs are accepted for pile up events.
+  void addEmbeddingID(int embeddingID);
+
+  void setEtaRange(double low, double high)
+  {
+    m_etaRange.first = low;
+    m_etaRange.second = high;
+  }
+
+ private:
+#if !defined(__CINT__) || defined(__CLING__)
+  //CINT is not c++11 compatible
+  std::shared_ptr<SvtxEvalStack> _svtxEvalStack;
+  std::set<int> m_embeddingIDs;
+#endif
+  std::pair<double, double> m_etaRange;
+
+  PHG4TruthInfoContainer *_truthContainer;
+};
+
+#endif  // QA_QAG4SimulationUpsilon_H

--- a/offline/QA/modules/QAG4SimulationUpsilon.h
+++ b/offline/QA/modules/QAG4SimulationUpsilon.h
@@ -25,7 +25,7 @@ class SvtxTrack;
 class QAG4SimulationUpsilon : public SubsysReco
 {
  public:
-  QAG4SimulationUpsilon();
+  QAG4SimulationUpsilon(const std::string & name = "QAG4SimulationUpsilon");
   virtual ~QAG4SimulationUpsilon() {}
 
   int Init(PHCompositeNode *topNode);
@@ -46,6 +46,17 @@ class QAG4SimulationUpsilon : public SubsysReco
     m_etaRange.second = high;
   }
 
+
+  void setQuarkoniaPID(const int pid)
+  {
+    m_quarkoniaPID = pid;
+  }
+
+  void setDaughterAbsPID(const int pid)
+  {
+    m_daughterAbsPID = pid;
+  }
+
  private:
 #if !defined(__CINT__) || defined(__CLING__)
   //CINT is not c++11 compatible
@@ -55,6 +66,9 @@ class QAG4SimulationUpsilon : public SubsysReco
   std::pair<double, double> m_etaRange;
 
   PHG4TruthInfoContainer *_truthContainer;
+
+  int m_quarkoniaPID = 553;
+  int m_daughterAbsPID = 11;
 };
 
 #endif  // QA_QAG4SimulationUpsilon_H

--- a/offline/QA/modules/QAG4SimulationUpsilonLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationUpsilonLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class QAG4SimulationUpsilon - !;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
Following @mitaylor ' #734, this pull request add a few more functions to tracking QA as below. 

The driving macro for plotting is here: 
* simulation: https://github.com/sPHENIX-Collaboration/macros/blob/master/macros/g4simulations/Fun4All_G4_sPHENIX.C 
* plotting: https://github.com/sPHENIX-Collaboration/macros/tree/tracking-low-occupancy-qa/macros/QA/tracking
Integration to Jenkins CI will start after merging. 

## plots

Events simulated are tracking only 40 pions 0.1-50 GeV/c with emphasize on the 0-2 GeV/c region + one Upsilon embedded. 

### Pion overview

![image](https://user-images.githubusercontent.com/7947083/76779632-0f666680-6782-11ea-879c-bfbdb1c87db0.png)


### Pion lineshape for pT
![image](https://user-images.githubusercontent.com/7947083/76779575-f78ee280-6781-11ea-92c3-361ebf8ca71c.png)


### Upsilon lineshape

![image](https://user-images.githubusercontent.com/7947083/76779596-ff4e8700-6781-11ea-8696-63140b60abfb.png)

