### PR TITLE
Fixing memory hosted eval NTuple in TPC digitization

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
@@ -20,6 +20,7 @@ class PHG4TpcPadPlane;
 class PHCompositeNode;
 class TH1;
 class TNtuple;
+class TFile;
 class TrkrHitSetContainer;
 class TrkrHitTruthAssoc;
 
@@ -48,6 +49,7 @@ class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
   PHG4TpcPadPlane *padplane;
   TH1 *dlong;
   TH1 *dtrans;
+  TFile *m_outf;
   TNtuple *nt;
   TNtuple *nthit;
   TNtuple *ntfinalhit;

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -24,6 +24,7 @@
 #include <TSystem.h>
 
 #include <cmath>
+#include <cassert>
 #include <climits>                                     // for INT_MAX
 #include <cstdio>                                      // for sprintf
 #include <iostream>
@@ -267,7 +268,10 @@ void PHG4TpcPadPlaneReadout::MapToPadPlane(PHG4CellContainer *g4cells, const dou
 
   // Capture the input values at the gem stack and the quick clustering results, elecron-by-electron
   if (Verbosity() > 0)
+  {
+    assert(ntpad);
     ntpad->Fill(layernum, phi, phi_integral / weight, z_gem, z_integral / weight);
+  }
 
   if (Verbosity() > 100)
     if (layernum == print_layer)
@@ -278,6 +282,7 @@ void PHG4TpcPadPlaneReadout::MapToPadPlane(PHG4CellContainer *g4cells, const dou
       // For a single track event, this captures the distribution of single electron centroids on the pad plane for layer print_layer.
       // The centroid of that should match the cluster centroid found by PHG4TpcClusterizer for layer print_layer, if everything is working
       //   - matches to < .01 cm for a few cases that I checked
+      assert(nthit);
       nthit->Fill(hit, layernum, phi, phi_integral / weight, z_gem, z_integral / weight, weight);
     }
 
@@ -460,14 +465,21 @@ void PHG4TpcPadPlaneReadout::MapToPadPlane(TrkrHitSetContainer *hitsetcontainer,
       // Either way, add the energy to it  -- adc values will be added at digitization
       hit->addEnergy(neffelectrons);
 
-      nthit->Fill(layernum, pad_num, zbin_num, neffelectrons);
+      if (Verbosity() > 0)
+      {
+        assert(nthit);
+        nthit->Fill(layernum, pad_num, zbin_num, neffelectrons);
+      }
 
     }  // end of loop over adc Z bins
   }    // end of loop over zigzag pads
 
   // Capture the input values at the gem stack and the quick clustering results, elecron-by-electron
   if (Verbosity() > 0)
+  {
+    assert(ntpad);
     ntpad->Fill(layernum, phi, phi_integral / weight, z_gem, z_integral / weight);
+  }
 
   if (Verbosity() > 100)
     if (layernum == print_layer)
@@ -478,6 +490,8 @@ void PHG4TpcPadPlaneReadout::MapToPadPlane(TrkrHitSetContainer *hitsetcontainer,
       // For a single track event, this captures the distribution of single electron centroids on the pad plane for layer print_layer.
       // The centroid of that should match the cluster centroid found by PHG4TpcClusterizer for layer print_layer, if everything is working
       //   - matches to < .01 cm for a few cases that I checked
+
+      assert(nthit);
       nthit->Fill(hit, layernum, phi, phi_integral / weight, z_gem, z_integral / weight, weight);
     }
 


### PR DESCRIPTION
This is a emergency fix on the per-event-growing memory usage in the TPC digitization. 
## The problem

In both recent tracking QA and jet-tracking production, the memory usage steadily grow over event number. Specifically, this is massif reported memory usage for tracking-QA macro over 100 events: 
https://github.com/sPHENIX-Collaboration/macros/blob/tracking-low-occupancy-qa/macros/g4simulations/Fun4All_G4_sPHENIX.C

![image](https://user-images.githubusercontent.com/7947083/77670302-64616400-6f5c-11ea-9b9d-b0ec86591c6d.png)

This growth is not a memory leakage as valgrind test is fine. It trace to continued memory usage at this line: 
https://github.com/sPHENIX-Collaboration/coresoftware/blob/b59ecfa403d2e1e8510582ad8933f6f876f4a115/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc#L463

It has three problems:
1. This ntuple supposedly only used in Verbosity debugging mode, but filled in nominal usage nonetheless
2. This ntuple is memory hosted, i.e. not associated with a TFile when filling. In this case, the NTuple content is always in memory and accumulate in size with more events without automatic flushing for TFile hosted ntuple
3. `nthit` is filled with two format, one of them probably is wrong: https://github.com/sPHENIX-Collaboration/coresoftware/blob/b59ecfa403d2e1e8510582ad8933f6f876f4a115/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc#L463  VS https://github.com/sPHENIX-Collaboration/coresoftware/blob/b59ecfa403d2e1e8510582ad8933f6f876f4a115/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc#L481

## The emergency fix

In this pull request, we are fixing problem 1 and 2, which would allow QA and simulation production to continue. 
ATTN @adfrawley 
