### PR TITLE
Upstream/master error api

### DIFF
--- a/offline/packages/trackbase/TrkrClusterv1.h
+++ b/offline/packages/trackbase/TrkrClusterv1.h
@@ -19,7 +19,7 @@ class PHObject;
  *
  * Note - D. McGlinchey June 2018:
  *   CINT does not like "override", so ignore where CINT
- *   complains. Should be checked with ROOT 6 once 
+ *   complains. Should be checked with ROOT 6 once
  *   migration occurs.
  */
 class TrkrClusterv1 : public TrkrCluster
@@ -40,7 +40,7 @@ class TrkrClusterv1 : public TrkrCluster
   //
   // cluster position
   //
-  virtual float getX() const { return m_pos[0]; } 
+  virtual float getX() const { return m_pos[0]; }
   virtual void setX(float x) { m_pos[0] = x; }
   virtual float getY() const { return m_pos[1]; }
   virtual void setY(float y) { m_pos[1] = y; }
@@ -73,7 +73,6 @@ class TrkrClusterv1 : public TrkrCluster
   virtual float getZError() const;
 
  protected:
-  unsigned int covarIndex(unsigned int i, unsigned int j) const;
 
   TrkrDefs::cluskey m_cluskey;  //< unique identifier within container
   float m_pos[3];               //< mean position x,y,z

--- a/offline/packages/trackbase_historic/SvtxTrackState.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState.h
@@ -53,7 +53,24 @@ class SvtxTrackState : public PHObject
   virtual std::string get_name() { return ""; }
   virtual void set_name(std::string &name) {}
 
- protected:
+  ///@name convenience interface, also found in Trkrcluster
+  //@{
+
+  /// rphi error
+  virtual float get_rphi_error() const
+  { return NAN; }
+
+  /// phi error
+  virtual float get_phi_error() const
+  { return NAN; }
+
+  /// z error
+  virtual float get_z_error() const
+  { return NAN; }
+
+  //@}
+
+  protected:
   SvtxTrackState(float pathlength = 0.0) {}
 
   ClassDef(SvtxTrackState, 1);

--- a/offline/packages/trackbase_historic/SvtxTrackState_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState_v1.h
@@ -56,8 +56,14 @@ class SvtxTrackState_v1 : public SvtxTrackState
   std::string get_name() { return state_name; }
   void set_name(std::string &name) { state_name = name; }
 
- private:
-  unsigned int covar_index(unsigned int i, unsigned int j) const;
+
+  virtual float get_rphi_error() const;
+  virtual float get_phi_error() const;
+  virtual float get_z_error() const;
+
+  //@}
+
+  private:
 
   float _pathlength;
   float _pos[3];


### PR DESCRIPTION
This PR:
- simplifies calculations of errors along phi and size along phi, for TrkrCluster, by doing the math directly rather than using TMatrices to compute the full 3x3 rotated covariance matrix and getting only one element from it. To avoid code duplication between phierror and phisize, the code is moved out in a single function
It was checked that returned values were identical before and after the change

- implement a similar API in SvtxTrackState

Both are needed for space charge distortions in the TPC

Also some cleanup: rather than using a const private method for the covariance index, just use an internal inline function invisible to the outside world.