### PR TITLE
Fix certain crash if !rf_track && !_over_write_svtxtrackmap

### DIFF
--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -296,13 +296,13 @@ int PHGenFitTrkFitter::process_event(PHCompositeNode* topNode)
 
   if (rf_gf_tracks.size() >= 2)
   {
-    if(Verbosity() > 10) 
+    if(Verbosity() > 10)
       {cout << "Call Rave vertex finder" << endl;
-	cout << " rf_gf_tracks size " << rf_gf_tracks.size() << endl;
-	for(long unsigned int i=0;i<rf_gf_tracks.size();++i)
-	  {
-	    cout << "   track " << i << " num points " << rf_gf_tracks[i]->getNumPointsWithMeasurement() << endl;
-	  }
+  cout << " rf_gf_tracks size " << rf_gf_tracks.size() << endl;
+  for(long unsigned int i=0;i<rf_gf_tracks.size();++i)
+    {
+      cout << "   track " << i << " num points " << rf_gf_tracks[i]->getNumPointsWithMeasurement() << endl;
+    }
       }
     try
     {
@@ -373,6 +373,9 @@ int PHGenFitTrkFitter::process_event(PHCompositeNode* topNode)
         auto key = iter->first;
         ++iter;
         _trackmap->erase(key);
+        continue;
+      } else {
+        ++iter;
         continue;
       }
   }


### PR DESCRIPTION
While tracking down a crash in trkreco (still unresolved) I stumbled across this potential one.
Without the added "else" condition, the null rf_track is inserted (unchecked) few lines below in the refit map