### PR TITLE
Acts track propagation

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -69,11 +69,11 @@ class MakeActsGeometry
   void SetVerbosity(int verbosity)
   { m_verbosity = verbosity; }
 
-  std::map<TrkrDefs::hitsetkey,Surface> getSurfaceMapSilicon()
-    { return m_clusterSurfaceMapSilicon; }
+  std::map<TrkrDefs::hitsetkey,Surface>* getSurfaceMapSilicon()
+    { return &m_clusterSurfaceMapSilicon; }
   
-  std::map<TrkrDefs::cluskey, Surface> getSurfaceMapTpc()
-    { return m_clusterSurfaceMapTpc; }
+  std::map<TrkrDefs::cluskey, Surface>* getSurfaceMapTpc()
+    { return &m_clusterSurfaceMapTpc; }
   
   std::map<TrkrDefs::hitsetkey, TGeoNode*> getNodeMap()
     { return m_clusterNodeMap; }

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -37,6 +37,7 @@ pkginclude_HEADERS = \
   PHGenFitTrkFitter.h \
   PHActsSourceLinks.h \
   PHActsTracks.h \
+  PHActsTrkProp.h \
   PHActsTrkFitter.h \
   PHGenFitTrkProp.h \
   PHHoughSeeding.h \
@@ -111,6 +112,7 @@ ACTS_SOURCES = \
   MakeActsGeometry.cc \
   PHActsSourceLinks.cc \
   PHActsTracks.cc \
+  PHActsTrkProp.cc \
   PHActsTrkFitter.cc
 
 ACTS_LIBS = \

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -324,8 +324,8 @@ Surface PHActsSourceLinks::getTpcLocalCoords(double (&local2D)[2],
                                                         side, iPhiZ);
   std::map<TrkrDefs::cluskey, Surface>::iterator surfIter;
 
-  surfIter = m_clusterSurfaceMapTpc.find(surfkey);
-  if (surfIter == m_clusterSurfaceMapTpc.end())
+  surfIter = m_clusterSurfaceMapTpc->find(surfkey);
+  if (surfIter == m_clusterSurfaceMapTpc->end())
   {
     std::cout << PHWHERE << "Failed to find surface, should be impossible!" << std::endl;
     return nullptr;
@@ -616,6 +616,26 @@ void PHActsSourceLinks::createNodes(PHCompositeNode *topNode)
     svtxNode->addNode(hitMapNode);
   }
 
+  m_clusterSurfaceMap = findNode::getClass<std::map<TrkrDefs::hitsetkey, Surface>>(topNode, "ClusterSurfaceActsMap");
+  
+  if(!m_clusterSurfaceMap)
+    {
+      m_clusterSurfaceMap = new std::map<TrkrDefs::hitsetkey, Surface>;
+      PHDataNode<std::map<TrkrDefs::hitsetkey, Surface>> *keySurfaceNode = 
+	new PHDataNode<std::map<TrkrDefs::hitsetkey, Surface>>(m_clusterSurfaceMap, "HitSetKeySurfaceActsMap");
+      svtxNode->addNode(keySurfaceNode);
+    }
+
+    m_clusterSurfaceMapTpc = findNode::getClass<std::map<TrkrDefs::cluskey, Surface>>(topNode, "ClusterTpcSurfaceActsMap");
+  
+  if(!m_clusterSurfaceMapTpc)
+    {
+      m_clusterSurfaceMapTpc = new std::map<TrkrDefs::cluskey, Surface>;
+      PHDataNode<std::map<TrkrDefs::cluskey, Surface>> *keyTpcSurfaceNode = 
+	new PHDataNode<std::map<TrkrDefs::cluskey, Surface>>(m_clusterSurfaceMapTpc, "ClusKeyTpcSurfaceActsMap");
+      svtxNode->addNode(keyTpcSurfaceNode);
+    }
+
   m_actsGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsFitCfg");
 
   if (!m_actsGeometry)
@@ -676,10 +696,10 @@ Surface PHActsSourceLinks::getSurfaceFromClusterMap(TrkrDefs::hitsetkey hitSetKe
   std::map<TrkrDefs::hitsetkey, Surface>::iterator
       surfaceIter;
 
-  surfaceIter = m_clusterSurfaceMap.find(hitSetKey);
+  surfaceIter = m_clusterSurfaceMap->find(hitSetKey);
 
   /// Check to make sure we found the surface in the map
-  if (surfaceIter != m_clusterSurfaceMap.end())
+  if (surfaceIter != m_clusterSurfaceMap->end())
   {
     surface = surfaceIter->second;
     if (Verbosity() > 0)

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -48,7 +48,7 @@ PHActsSourceLinks::PHActsSourceLinks(const std::string &name)
   , m_clusterMap(nullptr)
   , m_hitIdClusKey(nullptr)
   , m_sourceLinks(nullptr)
-  , m_fitCfgOptions(nullptr)
+  , m_actsGeometry(nullptr)
   , m_geomContainerMvtx(nullptr)
   , m_geomContainerIntt(nullptr)
   , m_geomContainerTpc(nullptr)
@@ -97,11 +97,11 @@ int PHActsSourceLinks::InitRun(PHCompositeNode *topNode)
   m_clusterNodeMap = actsGeometry->getNodeMap();
   m_clusterSurfaceMap = actsGeometry->getSurfaceMapSilicon();
   m_clusterSurfaceMapTpc = actsGeometry->getSurfaceMapTpc();
-  m_fitCfgOptions->tGeometry = actsGeometry->getTGeometry();
-  m_fitCfgOptions->magField = actsGeometry->getMagField();
-  m_fitCfgOptions->geoContext = actsGeometry->getGeoContext();
-  m_fitCfgOptions->magFieldContext = actsGeometry->getMagFieldContext();
-  m_fitCfgOptions->calibContext = actsGeometry->getCalibContext();
+  m_actsGeometry->tGeometry = actsGeometry->getTGeometry();
+  m_actsGeometry->magField = actsGeometry->getMagField();
+  m_actsGeometry->geoContext = actsGeometry->getGeoContext();
+  m_actsGeometry->magFieldContext = actsGeometry->getMagFieldContext();
+  m_actsGeometry->calibContext = actsGeometry->getCalibContext();
 
   if (Verbosity() > 10)
   {
@@ -336,7 +336,7 @@ Surface PHActsSourceLinks::getTpcLocalCoords(double (&local2D)[2],
   /// Transformation of cluster to local surface coords
   /// Coords are r*phi relative to surface r-phi center, and z
   /// relative to surface z center
-  Acts::Vector3D center = surface->center(m_fitCfgOptions->geoContext);
+  Acts::Vector3D center = surface->center(m_actsGeometry->geoContext);
   double surfRphiCenter = atan2(center[1], center[0]) * radius;
   double surfZCenter = center[2];
   if (Verbosity() > 0)
@@ -616,12 +616,12 @@ void PHActsSourceLinks::createNodes(PHCompositeNode *topNode)
     svtxNode->addNode(hitMapNode);
   }
 
-  m_fitCfgOptions = findNode::getClass<FitCfgOptions>(topNode, "ActsFitCfg");
+  m_actsGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsFitCfg");
 
-  if (!m_fitCfgOptions)
+  if (!m_actsGeometry)
   {
-    m_fitCfgOptions = new FitCfgOptions();
-    PHDataNode<FitCfgOptions> *fitNode = new PHDataNode<FitCfgOptions>(m_fitCfgOptions, "ActsFitCfg");
+    m_actsGeometry = new ActsGeometry();
+    PHDataNode<ActsGeometry> *fitNode = new PHDataNode<ActsGeometry>(m_actsGeometry, "ActsGeometry");
     svtxNode->addNode(fitNode);
   }
 

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -49,20 +49,20 @@ using SourceLink = FW::Data::TrkrClusterSourceLink;
  * A struct that contains the necessary geometry objects that the fitter
  * needs in PHActsTrkFitter. To be put on the node tree
  */
-struct FitCfgOptions
+struct ActsGeometry
 {
   /// Two constructor options
-  FitCfgOptions() {}
-  FitCfgOptions(std::shared_ptr<const Acts::TrackingGeometry> tGeo,
-                FW::Options::BFieldVariant mag,
-                Acts::CalibrationContext calib,
-                Acts::GeometryContext geo,
-                Acts::MagneticFieldContext magField)
-    : tGeometry(tGeo)
-    , magField(mag)
-    , calibContext(calib)
-    , geoContext(geo)
-    , magFieldContext(magField)
+  ActsGeometry() {}
+  ActsGeometry(std::shared_ptr<const Acts::TrackingGeometry> tGeo,
+	       FW::Options::BFieldVariant mag,
+	       Acts::CalibrationContext calib,
+	       Acts::GeometryContext geo,
+	       Acts::MagneticFieldContext magField)
+  : tGeometry(tGeo)
+  , magField(mag)
+  , calibContext(calib)
+  , geoContext(geo)
+  , magFieldContext(magField)
   {
   }
 
@@ -179,7 +179,7 @@ class PHActsSourceLinks : public SubsysReco
 
   /// The fit cfg options, created in MakeActsGeometry, to be put on node tree
   /// for PHActsTrkFitter
-  FitCfgOptions *m_fitCfgOptions;
+  ActsGeometry *m_actsGeometry;
 
   /// Tracking geometry objects
   PHG4CylinderGeomContainer *m_geomContainerMvtx;

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -169,13 +169,13 @@ class PHActsSourceLinks : public SubsysReco
   std::map<unsigned int, SourceLink> *m_sourceLinks;
 
   /// Map relating hit set keys to TGeoNodes
-  std::map<TrkrDefs::hitsetkey, TGeoNode *> m_clusterNodeMap;
+  std::map<TrkrDefs::hitsetkey, TGeoNode*> m_clusterNodeMap;
 
   /// Map relating hit set keys to Acts::Surfaces
-  std::map<TrkrDefs::hitsetkey, Surface> m_clusterSurfaceMap;
+  std::map<TrkrDefs::hitsetkey, Surface> *m_clusterSurfaceMap;
 
   /// Get the TPC surface cluster map
-  std::map<TrkrDefs::cluskey, Surface> m_clusterSurfaceMapTpc;
+  std::map<TrkrDefs::cluskey, Surface> *m_clusterSurfaceMapTpc;
 
   /// The fit cfg options, created in MakeActsGeometry, to be put on node tree
   /// for PHActsTrkFitter

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -76,14 +76,15 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
        trackIter != m_trackMap->end(); ++trackIter)
   {
     const SvtxTrack *track = trackIter->second;
+
+    if (!track)
+      continue;
+
     if (Verbosity() > 1)
     {
       std::cout << "found SvtxTrack " << trackIter->first << std::endl;
       track->identify();
     }
-
-    if (!track)
-      continue;
 
     /// Get the necessary parameters and values for the TrackParameters
     const Acts::BoundSymMatrix seedCov = getActsCovMatrix(track);
@@ -161,11 +162,7 @@ Acts::BoundSymMatrix PHActsTracks::getActsCovMatrix(const SvtxTrack *track)
 
   // Need to convert seed_cov from x,y,z,px,py,pz basis to Acts basis of
   // x,y,phi/theta of p, qoverp, time
-  double phi = atan(py / px);
-  if (phi < -1 * M_PI)
-    phi += 2. * M_PI;
-  else if (phi > M_PI)
-    phi -= 2. * M_PI;
+  double phi = track->get_phi();
 
   const double pxfracerr = seed_cov[3][3] / (px * px);
   const double pyfracerr = seed_cov[4][4] / (py * py);

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -35,14 +35,14 @@ struct ActsTrack
 {
   /// Default constructor. There is not a no argument constructor
   /// as source links don't have a no argument constructor
-  ActsTrack(FW::TrackParameters seed, const std::vector<SourceLink> &links)
-    : trackSeed(seed)
+  ActsTrack(FW::TrackParameters params, const std::vector<SourceLink> &links)
+    : trackParams(params)
     , sourceLinks(links)
   {
   }
 
   /// The acts track parameters for this track
-  FW::TrackParameters trackSeed;
+  FW::TrackParameters trackParams;
 
   /// The corresponding source links that are associated to the above track
   std::vector<SourceLink> sourceLinks;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -35,6 +35,10 @@ PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   Verbosity(0);
 }
 
+PHActsTrkFitter::~PHActsTrkFitter()
+{
+}
+
 int PHActsTrkFitter::Setup(PHCompositeNode* topNode)
 {
   if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
@@ -119,10 +123,6 @@ int PHActsTrkFitter::End(PHCompositeNode* topNode)
     std::cout << "Finished PHActsTrkFitter" << std::endl;
   }
   return Fun4AllReturnCodes::EVENT_OK;
-}
-
-PHActsTrkFitter::~PHActsTrkFitter()
-{
 }
 
 int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -54,7 +54,7 @@ int PHActsTrkFitter::Process()
   if (Verbosity() > 1)
   {
     std::cout << PHWHERE << "Events processed: " << m_event << std::endl;
-    std::cout << "Start PHActsTrkfitter::process_event" << std::endl;
+    std::cout << "Start PHActsTrkFitter::process_event" << std::endl;
   }
 
   /// Construct a perigee surface as the target surface (?)

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -26,7 +26,7 @@ class TrkrClusterSourceLink;
 }  // namespace FW
 
 struct ActsTrack;
-struct FitCfgOptions;
+struct ActsGeometry;
 
 using SourceLink = FW::Data::TrkrClusterSourceLink;
 
@@ -62,7 +62,7 @@ class PHActsTrkFitter : public PHTrackFitting
   std::vector<ActsTrack>* m_actsProtoTracks;
 
   /// Options that Acts::Fitter needs to run from MakeActsGeometry
-  FitCfgOptions* m_fitCfgOptions;
+  ActsGeometry* m_actsGeometry;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -1,0 +1,226 @@
+
+#include "PHActsTrkProp.h"
+#include "PHActsTracks.h"
+
+/// Fun4All includes
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+/// Tracking includes
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+
+#include <Acts/EventData/TrackParameters.hpp>
+#include <Acts/Surfaces/PerigeeSurface.hpp>
+#include <Acts/Surfaces/PlaneSurface.hpp>
+#include <Acts/Surfaces/Surface.hpp>
+
+#include <ACTFW/EventData/Track.hpp>
+#include <ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp>
+#include <ACTFW/Framework/AlgorithmContext.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+#include <utility>
+#include <TMatrixDSym.h>
+
+PHActsTrkProp::PHActsTrkProp(const std::string& name)
+  : PHTrackPropagating(name)
+  , m_event(0)
+  , m_fitCfgOptions(nullptr)
+
+{
+  Verbosity(0);
+}
+
+ PHActsTrkProp::~PHActsTrkProp()
+{
+}
+
+int PHActsTrkProp::Setup(PHCompositeNode* topNode)
+{
+  if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+    return Fun4AllReturnCodes::ABORTEVENT;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHActsTrkProp::Process()
+{
+  m_event++;
+
+  if (Verbosity() > 1)
+  {
+    std::cout << PHWHERE << "Events processed: " << m_event << std::endl;
+    std::cout << "Start PHActsTrkfitter::process_event" << std::endl;
+  }
+
+  PerigeeSurface surface = Acts::Surface::makeShared<Acts::PerigeeSurface>
+    (Acts::Vector3D(0., 0., 0.));
+
+
+  for(SvtxTrackMap::Iter trackIter = _track_map->begin();
+      trackIter != _track_map->end(); ++trackIter)
+    {
+      const SvtxTrack *track = trackIter->second;
+
+      if(!track) 
+	continue;
+
+      if(Verbosity() > 1)
+	{
+	  std::cout << "Found SvtxTrack " << trackIter->first << std::endl;
+	  track->identify();
+	}
+
+      const double x = track->get_x();
+      const double y = track->get_y();
+      const double d0 = sqrt(x*x + y*y);
+      const double z0 = track->get_z();
+      const double phi = track->get_phi();
+      const double theta = 2.*atan(exp(-1*track->get_eta()));
+      const int charge = track->get_charge();
+      const double qop = (double)charge / track->get_p();
+      /// Just set to 0 for now?
+      const double time = 0;
+
+      Acts::BoundSymMatrix cov = getActsCovMatrix(track);
+
+      Acts::BoundVector pars;
+      pars << d0, z0, phi, theta, qop, time;
+
+      Acts::Vector3D sPosition(0., 0., 0.);
+      Acts::Vector3D sMomentum(0., 0., 0.);
+      Acts::BoundParameters startParameters(
+          m_fitCfgOptions->geoContext, 
+	  std::move(cov), std::move(pars), surface);
+      sPosition = startParameters.position();
+      sMomentum = startParameters.momentum();
+
+
+    }
+
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHActsTrkProp::End(PHCompositeNode* topNode)
+{
+  if (Verbosity() > 10)
+  {
+    std::cout << "Finished PHActsTrkProp" << std::endl;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+
+
+Acts::BoundSymMatrix PHActsTrkProp::getActsCovMatrix(const SvtxTrack *track)
+{
+  Acts::BoundSymMatrix matrix = Acts::BoundSymMatrix::Zero();
+  const double px = track->get_px();
+  const double py = track->get_py();
+  const double pz = track->get_pz();
+  const double p = sqrt(px * px + py * py + pz * pz);
+  const double x = track->get_x();
+  const double y = track->get_y();
+
+  const double d = sqrt(x*x + y*y);
+  
+  // Get the track seed covariance matrix
+  // These are the variances, so the std devs are sqrt(seed_cov[i][j])
+  TMatrixDSym cov(6);
+  for (int i = 0; i < 6; i++)
+  {
+    for (int j = 0; j < 6; j++)
+    {
+      cov[i][j] = track->get_error(i, j);
+    }
+  }
+  const double sigmad = (1./d) * sqrt( x*x*cov[0][0] + y*y*cov[1][1]);
+  const double sigmap = sqrt(px * px * cov[3][3] + py * py * cov[4][4] + pz * pz * cov[5][5]) / p;
+
+  // Need to convert cov from x,y,z,px,py,pz basis to Acts basis of
+  // x,y,phi/theta of p, qoverp, time
+  double phi = track->get_phi();
+
+  const double pxfracerr = cov[3][3] / (px * px);
+  const double pyfracerr = cov[4][4] / (py * py);
+  const double phiPrefactor = fabs(py) / (fabs(px) * (1 + (py / px) * (py / px)));
+  const double sigmaPhi = phi * phiPrefactor * sqrt(pxfracerr + pyfracerr);
+  const double theta = acos(pz / p);
+  const double thetaPrefactor = ((fabs(pz)) / (p * sqrt(1 - (pz / p) * (pz / p))));
+  const double sigmaTheta = thetaPrefactor * sqrt(sigmap * sigmap / (p * p) + cov[5][5] / (pz * pz));
+  const double sigmaQOverP = sigmap / (p * p);
+
+  // Just set to 0 for now?
+  const double sigmaTime = 0;
+
+  if (Verbosity() > 10)
+  {
+    std::cout << "Track (px,py,pz,p) = (" << px << "," << py
+              << "," << pz << "," << p << ")" << std::endl;
+    std::cout << "Track covariance matrix: " << std::endl;
+
+    for (int i = 0; i < 6; i++)
+    {
+      for (int j = 0; j < 6; j++)
+      {
+        std::cout << cov[i][j] << ", ";
+      }
+      std::cout << std::endl;
+    }
+    std::cout << "Corresponding uncertainty calculations: " << std::endl;
+    std::cout << "d: " << d << " +/- " << sigmad << std::endl;
+    std::cout << "perr: " << sigmap << std::endl;
+    std::cout << "phi: " << phi << std::endl;
+    std::cout << "pxfracerr: " << pxfracerr << std::endl;
+    std::cout << "pyfracerr: " << pyfracerr << std::endl;
+    std::cout << "phiPrefactor: " << phiPrefactor << std::endl;
+    std::cout << "sigmaPhi: " << sigmaPhi << std::endl;
+    std::cout << "theta: " << theta << std::endl;
+    std::cout << "thetaPrefactor: " << thetaPrefactor << std::endl;
+    std::cout << "sigmaTheta: " << sigmaTheta << std::endl;
+    std::cout << "sigmaQOverP: " << sigmaQOverP << std::endl;
+  }
+
+  /// Seed covariances are already variances, so don't need to square them
+  /// Rest are std devs, so need to square them
+  matrix(Acts::eLOC_0, Acts::eLOC_0) = sigmad * sigmad;
+  matrix(Acts::eLOC_1, Acts::eLOC_1) = cov[2][2]; // z
+  matrix(Acts::ePHI, Acts::ePHI) = sigmaPhi * sigmaPhi;
+  matrix(Acts::eTHETA, Acts::eTHETA) = sigmaTheta * sigmaTheta;
+  matrix(Acts::eQOP, Acts::eQOP) = sigmaQOverP * sigmaQOverP;
+  matrix(Acts::eT, Acts::eT) = sigmaTime;
+
+  return matrix;
+}
+
+
+int PHActsTrkProp::createNodes(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHActsTrkProp::getNodes(PHCompositeNode* topNode)
+{
+
+  m_fitCfgOptions = findNode::getClass<FitCfgOptions>(topNode, "ActsFitCfg");
+
+  if (!m_fitCfgOptions)
+  {
+    std::cout << "Acts FitCfgOptions not on node tree. Exiting."
+              << std::endl;
+
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -1,0 +1,62 @@
+
+#ifndef TRACKRECO_ACTSTRKPROP_H
+#define TRACKRECO_ACTSTRKPROP_H
+
+#include "PHTrackPropagating.h"
+#include "PHActsSourceLinks.h"
+
+#include <Acts/Utilities/BinnedArray.hpp>
+#include <Acts/Utilities/Definitions.hpp>
+#include <Acts/Utilities/Logger.hpp>
+
+#include <memory>
+#include <string>
+
+namespace FW
+{
+  namespace Data
+  {
+    class TrkrClusterSourceLink;
+  }
+}
+
+class SvtxTrack;
+
+using PerigeeSurface = std::shared_ptr<const Acts::PerigeeSurface>;
+using SourceLink = FW::Data::TrkrClusterSourceLink;
+
+class PHActsTrkProp : public PHTrackPropagating
+{
+ public:
+  /// Default constructor
+  PHActsTrkProp(const std::string& name = "PHActsTrkProp");
+
+  /// Destructor
+  ~PHActsTrkProp();
+
+  /// End, write and close files
+  int End(PHCompositeNode*);
+
+  /// Get and create nodes
+  int Setup(PHCompositeNode* topNode);
+
+  /// Process each event by calling the fitter
+  int Process();
+
+ private:
+  /// Event counter
+  int m_event;
+
+  /// Get all the nodes
+  int getNodes(PHCompositeNode*);
+
+  /// Create new nodes
+  int createNodes(PHCompositeNode*);
+
+  Acts::BoundSymMatrix getActsCovMatrix(const SvtxTrack *track);
+
+  FitCfgOptions *m_fitCfgOptions;
+
+};
+
+#endif

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -1,6 +1,5 @@
-
-#ifndef TRACKRECO_ACTSTRKPROP_H
-#define TRACKRECO_ACTSTRKPROP_H
+#ifndef TRACKRECO_PHACTSTRKPROP_H
+#define TRACKRECO_PHACTSTRKPROP_H
 
 #include "PHTrackPropagating.h"
 #include "PHActsSourceLinks.h"
@@ -8,7 +7,7 @@
 #include <Acts/Utilities/BinnedArray.hpp>
 #include <Acts/Utilities/Definitions.hpp>
 #include <Acts/Utilities/Logger.hpp>
-#include <Acts/Propagator/Propagator.hpp>
+
 #include <Acts/Propagator/detail/DebugOutputActor.hpp>
 #include <Acts/Propagator/detail/StandardAborters.hpp>
 #include <Acts/Propagator/detail/SteppingLogger.hpp>
@@ -17,18 +16,14 @@
 #include <memory>
 #include <string>
 
-namespace Acts {
-}
-
 struct ActsTrack;
-
 class SvtxTrack;
+
 using RecordedMaterial = Acts::MaterialInteractor::result_type;
 using PropagationOutput
     = std::pair<std::vector<Acts::detail::Step>, RecordedMaterial>;
 
 using PerigeeSurface = std::shared_ptr<const Acts::PerigeeSurface>;
-using SourceLink = FW::Data::TrkrClusterSourceLink;
 
 class PHActsTrkProp : public PHTrackPropagating
 {
@@ -40,7 +35,7 @@ class PHActsTrkProp : public PHTrackPropagating
   ~PHActsTrkProp();
 
   /// End, write and close files
-  int End(PHCompositeNode*);
+  int End();
 
   /// Get and create nodes
   int Setup(PHCompositeNode* topNode);
@@ -58,14 +53,19 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Create new nodes
   int createNodes(PHCompositeNode*);
 
-  Acts::BoundSymMatrix getActsCovMatrix(const SvtxTrack *track);
-
+  /// Run the propagation algorithm in acts. Returns result of propagation
   PropagationOutput propagate(FW::TrackParameters parameters);
 
+  /// The acts geometry constructed in MakeActsGeometry
   ActsGeometry *m_actsGeometry;
 
+  /// Minimum track pT to propagate, for acts propagator, units of GeV
   double m_minTrackPt;
 
+  /// Propagation step size, units of mm
+  double m_maxStepSize; 
+
+  /// List of acts track fits, created by PHActsTrkFitter
   std::vector<ActsTrack>* m_actsTracks;
 
 };

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -8,19 +8,24 @@
 #include <Acts/Utilities/BinnedArray.hpp>
 #include <Acts/Utilities/Definitions.hpp>
 #include <Acts/Utilities/Logger.hpp>
+#include <Acts/Propagator/Propagator.hpp>
+#include <Acts/Propagator/detail/DebugOutputActor.hpp>
+#include <Acts/Propagator/detail/StandardAborters.hpp>
+#include <Acts/Propagator/detail/SteppingLogger.hpp>
+#include <Acts/Propagator/MaterialInteractor.hpp>
 
 #include <memory>
 #include <string>
 
-namespace FW
-{
-  namespace Data
-  {
-    class TrkrClusterSourceLink;
-  }
+namespace Acts {
 }
 
+struct ActsTrack;
+
 class SvtxTrack;
+using RecordedMaterial = Acts::MaterialInteractor::result_type;
+using PropagationOutput
+    = std::pair<std::vector<Acts::detail::Step>, RecordedMaterial>;
 
 using PerigeeSurface = std::shared_ptr<const Acts::PerigeeSurface>;
 using SourceLink = FW::Data::TrkrClusterSourceLink;
@@ -55,7 +60,13 @@ class PHActsTrkProp : public PHTrackPropagating
 
   Acts::BoundSymMatrix getActsCovMatrix(const SvtxTrack *track);
 
-  FitCfgOptions *m_fitCfgOptions;
+  PropagationOutput propagate(FW::TrackParameters parameters);
+
+  ActsGeometry *m_actsGeometry;
+
+  double m_minTrackPt;
+
+  std::vector<ActsTrack>* m_actsTracks;
 
 };
 

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -18,12 +18,14 @@
 
 struct ActsTrack;
 class SvtxTrack;
+class SvtxTrackMap;
 
 using RecordedMaterial = Acts::MaterialInteractor::result_type;
 using PropagationOutput
     = std::pair<std::vector<Acts::detail::Step>, RecordedMaterial>;
 
 using PerigeeSurface = std::shared_ptr<const Acts::PerigeeSurface>;
+using Surface = std::shared_ptr<const Acts::Surface>;
 
 class PHActsTrkProp : public PHTrackPropagating
 {
@@ -53,6 +55,8 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Create new nodes
   int createNodes(PHCompositeNode*);
 
+  Acts::BoundSymMatrix getActsCovMatrix(const SvtxTrack *track);
+
   /// Run the propagation algorithm in acts. Returns result of propagation
   PropagationOutput propagate(FW::TrackParameters parameters);
 
@@ -65,9 +69,12 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Propagation step size, units of mm
   double m_maxStepSize; 
 
-  /// List of acts track fits, created by PHActsTrkFitter
-  std::vector<ActsTrack>* m_actsTracks;
+  /// Track map with Svtx objects
+  SvtxTrackMap *m_trackMap;
 
+  /// Cluster-surface association maps created in MakeActsGeometry
+  std::map<TrkrDefs::hitsetkey, Surface> *m_clusterSurfaceMap;
+  std::map<TrkrDefs::cluskey, Surface> *m_clusterSurfaceTpcMap;
 };
 
 #endif


### PR DESCRIPTION
This PR introduces a module for Acts track propagation. Right now it does not actually do anything other than take prototracks and run the default acts track propagator on them. This will be changed once we actually have the appropriate things to put on the node tree when we have the updated acts code.

Tested with local Fun4All acts macro. Runs propagator and seems to function well. Will need to debug acts propagator once we update to acts master.