### PR TITLE
Track propagation

### DIFF
--- a/offline/packages/trackreco/ActsTrack.h
+++ b/offline/packages/trackreco/ActsTrack.h
@@ -1,0 +1,41 @@
+#ifndef ACTSTRACK_H
+#define ACTSTRACK_H
+
+#include <Acts/EventData/TrackParameters.hpp>
+
+#include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
+
+using SourceLink = FW::Data::TrkrClusterSourceLink;
+
+
+/**
+ * A struct that contains an Acts track seed and the corresponding source links.
+ * Used by a variety of the Acts track fitting classes.
+ */
+class ActsTrack
+{
+
+ public:
+  ActsTrack(FW::TrackParameters params, const std::vector<SourceLink> &links)
+    : m_trackParams(params)
+    , m_sourceLinks(links)
+    {}
+
+  ~ActsTrack(){}
+
+  FW::TrackParameters getTrackParams(){ return m_trackParams; }
+  void setTrackParams(FW::TrackParameters params) { m_trackParams = params; }
+
+  std::vector<SourceLink> getSourceLinks(){ return m_sourceLinks; }
+  void setSourceLinks(std::vector<SourceLink> srcLinks)
+  { m_sourceLinks = srcLinks; }
+  
+
+ private:
+  
+  FW::TrackParameters m_trackParams;
+  std::vector<SourceLink> m_sourceLinks;
+
+};
+
+#endif

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -22,6 +22,7 @@ AM_LDFLAGS = \
   -L$(OFFLINE_MAIN)/lib64
 
 pkginclude_HEADERS = \
+  ActsTrack.h \
   AssocInfoContainer.h \
   CellularAutomaton.h \
   CellularAutomaton_v1.h \

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -14,6 +14,8 @@
 #include <ACTFW/EventData/Track.hpp>
 #include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
 
+#include "ActsTrack.h"
+
 #include <map>
 #include <string>
 #include <vector>
@@ -24,29 +26,6 @@ class SvtxTrack;
 
 using SourceLink = FW::Data::TrkrClusterSourceLink;
 
-/**
- * A struct that contains an Acts track seed and the corresponding source links,
- * to be put on the node tree by this module.
- * Need to use a struct instead of a std::map because the Acts classes do not 
- * have defined operators for "<", which means they can't be used as keys
- * according to stl libraries
- */
-struct ActsTrack
-{
-  /// Default constructor. There is not a no argument constructor
-  /// as source links don't have a no argument constructor
-  ActsTrack(FW::TrackParameters params, const std::vector<SourceLink> &links)
-    : trackParams(params)
-    , sourceLinks(links)
-  {
-  }
-
-  /// The acts track parameters for this track
-  FW::TrackParameters trackParams;
-
-  /// The corresponding source links that are associated to the above track
-  std::vector<SourceLink> sourceLinks;
-};
 
 /**
  * This class is responsible for taking SvtxTracks and converting them to track

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -7,7 +7,7 @@
 
 #include "PHActsTrkFitter.h"
 #include "PHActsSourceLinks.h"
-#include "PHActsTracks.h"
+#include "ActsTrack.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/getClass.h>
@@ -76,8 +76,8 @@ int PHActsTrkFitter::Process()
   {
     ActsTrack track = *trackIter;
 
-    std::vector<SourceLink> sourceLinks = track.sourceLinks;
-    FW::TrackParameters trackSeed = track.trackParams;
+    std::vector<SourceLink> sourceLinks = track.getSourceLinks();
+    FW::TrackParameters trackSeed = track.getTrackParams();
 
     /// Call KF now. Have a vector of sourceLinks corresponding to clusters
     /// associated to this track and the corresponding track seed which

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -25,7 +25,7 @@ class TrkrClusterSourceLink;
 }
 }  // namespace FW
 
-struct ActsTrack;
+class ActsTrack;
 struct ActsGeometry;
 
 using SourceLink = FW::Data::TrkrClusterSourceLink;

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -1,6 +1,6 @@
 
 #include "PHActsTrkProp.h"
-#include "PHActsTracks.h"
+#include "ActsTrack.h"
 
 /// Fun4All includes
 #include <fun4all/Fun4AllReturnCodes.h>

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -76,6 +76,8 @@ PHActsTrkProp::PHActsTrkProp(const std::string& name)
 
 int PHActsTrkProp::Setup(PHCompositeNode* topNode)
 {
+  createNodes(topNode);
+  
   if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
     return Fun4AllReturnCodes::ABORTEVENT;
 
@@ -144,12 +146,14 @@ int PHActsTrkProp::Process()
 
       std::vector<Acts::detail::Step> steps = pOutput.first;
       for (auto& step : steps){
-	
 	auto surface = step.surface;
+	if(!surface)
+	  continue;
+
 	Acts::Vector3D stepSurfNorm = surface.get()->normal(m_actsGeometry->geoContext);
 	Acts::Vector3D srcLinkSurfNorm;
-
 	std::map<unsigned int, SourceLink>::iterator srcLinkIter = m_sourceLinks->begin();
+
 	while(srcLinkIter != m_sourceLinks->end())
 	  {
 	    
@@ -166,7 +170,6 @@ int PHActsTrkProp::Process()
 	      }
 	    ++srcLinkIter;
 	  }
-	/// associate surface to sphenix clusters with cluster-surface maps
 
 	/// Get kinematic information of steps
 	/// global x,y,z
@@ -188,6 +191,11 @@ int PHActsTrkProp::Process()
 		      << ", " << dy << ", " << dz << std::endl;
 	  }
       }
+
+      if(Verbosity() > 1)
+	{
+	  std::cout<<"Found "<<sourceLinks.size() <<" SrcLinks"<<std::endl;
+	}
 
       /// Add the track with the found sourcelinks to the prototrack list
       /// to be put on the node tree
@@ -273,7 +281,7 @@ PropagationOutput PHActsTrkProp::propagate(FW::TrackParameters parameters)
  
 }
 
-int PHActsTrkProp::createNodes(PHCompositeNode* topNode)
+void PHActsTrkProp::createNodes(PHCompositeNode* topNode)
 {
   PHNodeIterator iter(topNode);
 
@@ -308,7 +316,7 @@ int PHActsTrkProp::createNodes(PHCompositeNode* topNode)
     }
 
 
-  return Fun4AllReturnCodes::EVENT_OK;
+  return;
 }
 
 int PHActsTrkProp::getNodes(PHCompositeNode* topNode)

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -51,10 +51,10 @@ class PHActsTrkProp : public PHTrackPropagating
   int m_event;
 
   /// Get all the nodes
-  int getNodes(PHCompositeNode*);
+  int getNodes(PHCompositeNode *topNode);
 
   /// Create new nodes
-  int createNodes(PHCompositeNode*);
+  void createNodes(PHCompositeNode *topNode);
 
   Acts::BoundSymMatrix getActsCovMatrix(const SvtxTrack *track);
 

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -19,6 +19,7 @@
 struct ActsTrack;
 class SvtxTrack;
 class SvtxTrackMap;
+class TrkrClusterSourceLink; 
 
 using RecordedMaterial = Acts::MaterialInteractor::result_type;
 using PropagationOutput
@@ -75,6 +76,15 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Cluster-surface association maps created in MakeActsGeometry
   std::map<TrkrDefs::hitsetkey, Surface> *m_clusterSurfaceMap;
   std::map<TrkrDefs::cluskey, Surface> *m_clusterSurfaceTpcMap;
+
+  /// Acts proto tracks to be put on the node tree by this module
+  std::vector<ActsTrack> *m_actsProtoTracks;
+
+  /// Acts source links created by PHActsSourceLinks
+  /// SourceLink is defined as TrkrClusterSourceLink elsewhere
+  std::map<unsigned int, SourceLink> *m_sourceLinks;
+
+ 
 };
 
 #endif


### PR DESCRIPTION
Follow up PR to yesterday's that puts proto tracks from track propagation onto node tree. 

Also moved `struct ActsTrack` to it's own header file class, so that additional code can be added to it if needed and so that other classes which need it don't need to include an entire class (e.g. PHActsTracks) which is unnecessary extra code to include.

Will follow this PR with additional code once TPC Surfaces are added into the TGeo object and thus Acts builds them by default.