### PR TITLE
Default option to require unique matches for tracking efficiency QA

### DIFF
--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -46,6 +46,7 @@ QAG4SimulationTracking::QAG4SimulationTracking(const std::string &name)
   : SubsysReco(name)
   , _svtxEvalStack(nullptr)
   , m_etaRange(-1, 1)
+  , m_uniqueTrackingMatch(true)
   , _truthContainer(nullptr)
 {
 }
@@ -290,48 +291,81 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
     SvtxTrack *track = trackeval->best_track_from(g4particle);
     if (track)
     {
-      h_nReco_etaGen->Fill(geta);
-      h_nReco_pTGen->Fill(gpt);
+      bool match_found(false);
 
-      double px = track->get_px();
-      double py = track->get_py();
-      double pz = track->get_pz();
-      double pt;
-      TVector3 v(px, py, pz);
-      pt = v.Pt();
-      //        eta = v.Pt();
-      //      phi = v.Pt();
-
-      float pt_ratio = (gpt != 0) ? pt / gpt : 0;
-      h_pTRecoGenRatio->Fill(pt_ratio);
-      h_pTRecoGenRatio_pTGen->Fill(gpt, pt_ratio);
-      h_norm->Fill("Reco Track", 1);
-
-      // tracker hit stat.
-      vector<unsigned int> nhits(3, 0);
-      // cluster stat.
-      for (auto cluster_iter = track->begin_cluster_keys(); cluster_iter != track->end_cluster_keys(); ++cluster_iter)
+      if (m_uniqueTrackingMatch)
       {
-        const auto &cluster_key = *cluster_iter;
+        PHG4Particle *g4particle_mathced = trackeval->max_truth_particle_by_nclusters(track);
 
-        const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
-
-        if (trackerID == TrkrDefs::mvtxId)
-          ++nhits[0];
-        else if (trackerID == TrkrDefs::inttId)
-          ++nhits[1];
-        else if (trackerID == TrkrDefs::tpcId)
-          ++nhits[2];
+        if (g4particle_mathced)
+        {
+          if (g4particle_mathced->get_track_id() == g4particle->get_track_id())
+          {
+            match_found = true;
+            if (Verbosity())
+              cout << "QAG4SimulationTracking::process_event - found unique match for g4 particle " << g4particle->get_track_id() << endl;
+          }
+          else
+          {
+            if (Verbosity())
+              cout << "QAG4SimulationTracking::process_event - none unique match for g4 particle " << g4particle->get_track_id()
+                   << ". The track belong to g4 particle " << g4particle_mathced->get_track_id() << endl;
+          }
+        }  //        if (g4particle_mathced)
         else
         {
           if (Verbosity())
-            cout << "QAG4SimulationTracking::process_event - unkown tracker ID = " << trackerID << " from cluster " << cluster_key << endl;
+            cout << "QAG4SimulationTracking::process_event - none unique match for g4 particle " << g4particle->get_track_id()
+                 << ". The track belong to no g4 particle!" << endl;
         }
-      }  // for
-      h_nMVTX_nReco_pTGen->Fill(gpt, nhits[0]);
-      h_nINTT_nReco_pTGen->Fill(gpt, nhits[1]);
-      h_nTPC_nReco_pTGen->Fill(gpt, nhits[2]);
-    }
+      }
+
+      if ((match_found and m_uniqueTrackingMatch) or (not m_uniqueTrackingMatch))
+      {
+        h_nReco_etaGen->Fill(geta);
+        h_nReco_pTGen->Fill(gpt);
+
+        double px = track->get_px();
+        double py = track->get_py();
+        double pz = track->get_pz();
+        double pt;
+        TVector3 v(px, py, pz);
+        pt = v.Pt();
+        //        eta = v.Pt();
+        //      phi = v.Pt();
+
+        float pt_ratio = (gpt != 0) ? pt / gpt : 0;
+        h_pTRecoGenRatio->Fill(pt_ratio);
+        h_pTRecoGenRatio_pTGen->Fill(gpt, pt_ratio);
+        h_norm->Fill("Reco Track", 1);
+
+        // tracker hit stat.
+        vector<unsigned int> nhits(3, 0);
+        // cluster stat.
+        for (auto cluster_iter = track->begin_cluster_keys(); cluster_iter != track->end_cluster_keys(); ++cluster_iter)
+        {
+          const auto &cluster_key = *cluster_iter;
+
+          const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
+
+          if (trackerID == TrkrDefs::mvtxId)
+            ++nhits[0];
+          else if (trackerID == TrkrDefs::inttId)
+            ++nhits[1];
+          else if (trackerID == TrkrDefs::tpcId)
+            ++nhits[2];
+          else
+          {
+            if (Verbosity())
+              cout << "QAG4SimulationTracking::process_event - unkown tracker ID = " << trackerID << " from cluster " << cluster_key << endl;
+          }
+        }  // for
+        h_nMVTX_nReco_pTGen->Fill(gpt, nhits[0]);
+        h_nINTT_nReco_pTGen->Fill(gpt, nhits[1]);
+        h_nTPC_nReco_pTGen->Fill(gpt, nhits[2]);
+      }  //      if (match_found)
+
+    }  //    if (track)
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -4,8 +4,8 @@
 #include <fun4all/SubsysReco.h>
 
 #include <memory>
-#include <string>
 #include <set>
+#include <string>
 #include <utility>
 
 #if !defined(__CINT__) || defined(__CLING__)
@@ -25,7 +25,7 @@ class SvtxTrack;
 class QAG4SimulationTracking : public SubsysReco
 {
  public:
-  QAG4SimulationTracking(const std::string & name = "QAG4SimulationTracking");
+  QAG4SimulationTracking(const std::string &name = "QAG4SimulationTracking");
   virtual ~QAG4SimulationTracking() {}
 
   int Init(PHCompositeNode *topNode);
@@ -40,10 +40,17 @@ class QAG4SimulationTracking : public SubsysReco
   //! For EmbeddingID<0, all negative embedding IDs are accepted for pile up events.
   void addEmbeddingID(int embeddingID);
 
+  //! range of the truth track eta to be analyzed
   void setEtaRange(double low, double high)
   {
     m_etaRange.first = low;
     m_etaRange.second = high;
+  }
+
+  //! only count unique truth<->reco track pair in tracking efficiency
+  void setUniqueTrackingMatch(bool b)
+  {
+    m_uniqueTrackingMatch = b;
   }
 
  private:
@@ -52,7 +59,12 @@ class QAG4SimulationTracking : public SubsysReco
   std::shared_ptr<SvtxEvalStack> _svtxEvalStack;
   std::set<int> m_embeddingIDs;
 #endif
+
+  //! range of the truth track eta to be analyzed
   std::pair<double, double> m_etaRange;
+
+  //! only count unique truth<->reco track pair in tracking efficiency
+  bool m_uniqueTrackingMatch;
 
   PHG4TruthInfoContainer *_truthContainer;
 };

--- a/offline/QA/modules/QAG4SimulationUpsilon.cc
+++ b/offline/QA/modules/QAG4SimulationUpsilon.cc
@@ -395,15 +395,12 @@ int QAG4SimulationUpsilon::process_event(PHCompositeNode *topNode)
                 pair_neg.second->get_pz()),
             daughter_mass);
 
-
         const CLHEP::HepLorentzVector v_quakonium = v_pos + v_neg;
-
 
         h_nReco_Pair_InvMassReco->Fill(v_quakonium.m());
         h_norm->Fill("Reco Upsilon", 1);
 
-      }//      if (pair_pos.second and pair_neg.second)
-
+      }  //      if (pair_pos.second and pair_neg.second)
 
     }  //    for (const auto &pair_neg : truth_reco_set_neg)
 

--- a/offline/QA/modules/QAG4SimulationUpsilon.h
+++ b/offline/QA/modules/QAG4SimulationUpsilon.h
@@ -4,8 +4,8 @@
 #include <fun4all/SubsysReco.h>
 
 #include <memory>
-#include <string>
 #include <set>
+#include <string>
 #include <utility>
 
 #if !defined(__CINT__) || defined(__CLING__)
@@ -25,7 +25,7 @@ class SvtxTrack;
 class QAG4SimulationUpsilon : public SubsysReco
 {
  public:
-  QAG4SimulationUpsilon(const std::string & name = "QAG4SimulationUpsilon");
+  QAG4SimulationUpsilon(const std::string &name = "QAG4SimulationUpsilon");
   virtual ~QAG4SimulationUpsilon() {}
 
   int Init(PHCompositeNode *topNode);
@@ -45,7 +45,6 @@ class QAG4SimulationUpsilon : public SubsysReco
     m_etaRange.first = low;
     m_etaRange.second = high;
   }
-
 
   void setQuarkoniaPID(const int pid)
   {


### PR DESCRIPTION
In high occupancy simulation, almost all g4track is matched with a reconstructed track via `track = trackeval->best_track_from(g4particle);`. However this only require the reco track used some of the hits from the g4track, and the reco track may also use many hits from other g4tracks.  This leads to arbitrarily high tracking efficiency. 

This PR change the matching to by default requiring both `track = trackeval->best_track_from(g4particle);` and `g4particle == trackeval->max_truth_particle_by_nclusters(track)`, ensuring most of the reco track's cluster comes from the g4track in study.  This requirement can also be turned off via a setter. 

This pull request will also be used in testing the new high-multiplicity tracking QA tests. 