### PR TITLE
TPC in Acts

### DIFF
--- a/offline/packages/PHGeometry/macros/PHGeom_DSTInspection.C
+++ b/offline/packages/PHGeometry/macros/PHGeom_DSTInspection.C
@@ -8,26 +8,43 @@
  * \date $Date: $
  */
 
+#include <fun4all/SubsysReco.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllDummyInputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllNoSyncDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <phool/recoConsts.h>
+#include <phgeom/PHGeomUtility.h>
+
+#include <TEveManager.h>
+#include <TGLViewer.h>
+#include <TGLUtil.h>
+#include <TGLClip.h>
+#include <TGeoManager.h>
+#include <TROOT.h>
+#include <TGeoManager.h>
+#include <TEveGeoNode.h>
+
 #include <cassert>
+#include <string>
+
+using namespace std;
+
+R__LOAD_LIBRARY(libphgeom.so)
+R__LOAD_LIBRARY(libg4dst.so)
+R__LOAD_LIBRARY(libfun4all.so)
+
 
 //! Quick inspection of PHGeoTGeo object in RUN/GEOMETRY node inside a DST file
 //! Based on abhisek's display macro
 void
-PHGeom_DSTInspection(string DST_file_name = "sPHENIX.root_DST.root",
+PHGeom_DSTInspection(string DST_file_name = "G4sPHENIX.root",
     bool do_clip = true)
 {
   TEveManager::Create();
-
-
-  // main lib
-  gSystem->Load("libphgeom.so");
-
-  // in case DST contains sPHENIX stuff
-  gSystem->Load("libg4calo.so");
-  gSystem->Load("libg4vertex.so");
-  gSystem->Load("libcalotrigger_io.so");
-  gSystem->Load("libg4eval.so");
-
 
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(1);

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -297,7 +297,7 @@ void MakeActsGeometry::buildActsSurfaces()
 void MakeActsGeometry::makeGeometry(int argc, char *argv[], 
 				    FW::IBaseDetector &detector)
 {
-  // setup and parse options
+  /// setup and parse options
   auto desc = FW::Options::makeDefaultOptions();
   FW::Options::addSequencerOptions(desc);
   FW::Options::addGeometryOptions(desc);
@@ -306,13 +306,9 @@ void MakeActsGeometry::makeGeometry(int argc, char *argv[],
   FW::Options::addOutputOptions(desc);
   FW::Options::addBFieldOptions(desc);
 
-  // Add specific options for this geometry
+  /// Add specific options for this geometry
   detector.addOptions(desc);
   auto vm = FW::Options::parse(desc, argc, argv);
-  if (vm.empty())
-  {
-    return EXIT_FAILURE;
-  }
 
   /// Now read the standard options
   auto logLevel = FW::Options::readLogLevel(vm);
@@ -413,7 +409,7 @@ void MakeActsGeometry::makeGeometry(int argc, char *argv[],
   
   makeTpcMapPairs(tpcVolume);
 
-  return 0;
+  return;
 }
 
 void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -231,9 +231,9 @@ void MakeActsGeometry::AddActsTpcSurfaces( TGeoVolume *tpc_gas_vol)
       tpc_gas_measurement_vol[ilayer]->SetFillColor(kYellow);
       tpc_gas_measurement_vol[ilayer]->SetVisibility(kTRUE);
 
-      if(m_verbosity > 2)
+      if(m_verbosity > 30)
 	{
-	  cout << "Made box for layer " << ilayer << " with dx " << m_layerThickness[ilayer] << " dy " 
+	  cout << m_verbosity << " Made box for layer " << ilayer << " with dx " << m_layerThickness[ilayer] << " dy " 
 	       << box_r_phi << " ref arc " << m_surfStepPhi*m_layerRadius[ilayer] << " dz " << m_surfStepZ << endl;
 	  tpc_gas_measurement_vol[ilayer]->Print();
 	}
@@ -270,7 +270,7 @@ void MakeActsGeometry::AddActsTpcSurfaces( TGeoVolume *tpc_gas_vol)
 		  
 		  tpc_gas_vol->AddNode(tpc_gas_measurement_vol[ilayer], copy, tpc_gas_measurement_location);
 		  
-		  if(m_verbosity && ilayer == 30) 
+		  if(m_verbosity > 30 && ilayer == 30) 
 		    {
 		      cout << " Made copy " << copy << " iz " << iz << " imod " << imod << " ilayer " << ilayer << " iphi " << iphi << endl;
 		      cout << "    x_center " << x_center << " y_center " << y_center << " z_center " << z_center << " phi_center_degrees " << phi_center_degrees << endl;

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -6,17 +6,15 @@
  */
 
 /*
-//modularizing:
-
 MakeActsGeometry  
   // Create acts geometry
   // Make (hitsetkey,surface) map and place on node tree
 
-Create acts geometry (makes (hitsetkey,surface) maps)
+  Create acts geometry (makes (hitsetkey,surface) maps)
   BuildSiliconLayers();  
       MakeActsGeometry  // makes (hitsetkey,surface) map for silicon
   BuildTpcSurfaceMap  // makes (hitsetkey,surface) map for silicon
-  MakeTGeoNodeMap(topNode);  // makes cluster-node map - not used?
+  MakeTGeoNodeMap(topNode);  // makes cluster-node map - not used
     isActive  // not used
 */
 
@@ -114,7 +112,6 @@ int MakeActsGeometry::BuildAllGeometry(PHCompositeNode *topNode)
   BuildSiliconLayers();
 
   // create a map of sensor TGeoNode pointers using the TrkrDefs:: hitsetkey as the key
-  cout << " Calling MakeTgeoNodeMap" << endl;
   MakeTGeoNodeMap(topNode);
 
   // TPC continuous readout geometry does not exist within ACTS, so we build our own surfaces
@@ -678,7 +675,7 @@ void MakeActsGeometry::MakeTGeoNodeMap(PHCompositeNode *topNode)
 
     if (node_str.compare(0, mvtx.length(), mvtx) == 0)  // is it in the MVTX?
     {
-      if (m_verbosity > 100) 
+      if (m_verbosity > 2) 
 	cout << " node " << node->GetName() << " is in the MVTX" << endl;
       getMvtxKeyFromNode(node);
     }
@@ -688,13 +685,13 @@ void MakeActsGeometry::MakeTGeoNodeMap(PHCompositeNode *topNode)
       if (node_str.compare(0, intt_ext.length(), intt_ext) == 0)
         continue;
 
-      if (m_verbosity > 100) 
+      if (m_verbosity > 2) 
 	cout << " node " << node->GetName() << " is in the INTT" << endl;
       getInttKeyFromNode(node);
     }
     else if (node_str.compare(0, tpc.length(), tpc) == 0)  // is it in the TPC?
       {
-	if(m_verbosity > 100)
+	if(m_verbosity > 2)
 	  cout << " node " << node->GetName() << " is in the TPC " << endl;
       }
     else
@@ -836,7 +833,7 @@ void MakeActsGeometry::getMvtxKeyFromNode(TGeoNode *gnode)
     std::string dstr = module_node->GetDaughter(i)->GetName();
     if (dstr.compare(0, mvtx_chip.length(), mvtx_chip) == 0)
     {
-      if (m_verbosity > 1)
+      if (m_verbosity > 3)
         cout << "Found MVTX layer " << layer << " stave " << stave << " chip  " << i << " with node name " << module_node->GetDaughter(i)->GetName() << endl;
 
       // Make key for this chip
@@ -847,7 +844,7 @@ void MakeActsGeometry::getMvtxKeyFromNode(TGeoNode *gnode)
       std::pair<TrkrDefs::hitsetkey, TGeoNode *> tmp = make_pair(node_key, sensor_node);
       m_clusterNodeMap.insert(tmp);
 
-      if (m_verbosity > 1)
+      if (m_verbosity > 3)
         std::cout << " MVTX layer " << layer << " stave " << stave << " chip " << chip << " name " << sensor_node->GetName() << std::endl;
     }
   }
@@ -864,6 +861,7 @@ void MakeActsGeometry::isActive(TGeoNode *gnode)
 
   std::string intt_refactive("siactive");
   std::string mvtx_refactive("MVTXSensor");
+  std::string tpc_refactive("tpc_gas_measurement");
 
   if (node_str.compare(0, intt_refactive.length(), intt_refactive) == 0)
   {
@@ -880,8 +878,12 @@ void MakeActsGeometry::isActive(TGeoNode *gnode)
     cout << "          ******* Found MVTX active volume,  node is " << gnode->GetName()
          << " volume name is " << gnode->GetVolume()->GetName() << endl;
 
-    //const TGeoMatrix* tgMatrix = gnode->GetMatrix();
-    //tgMatrix->Print();
+    return;
+  }
+  else if (node_str.compare(0, tpc_refactive.length(), tpc_refactive) == 0)
+  {
+    cout << "          ******* Found TPC  active volume,  node is " << gnode->GetName()
+         << " volume name is " << gnode->GetVolume()->GetName() << endl;
 
     return;
   }

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -75,10 +75,10 @@ class MakeActsGeometry
   std::map<TrkrDefs::hitsetkey,Surface> getSurfaceMapSilicon()
     { return m_clusterSurfaceMapSilicon; }
   
-  std::map<TrkrDefs::cluskey, Surface> getSurfaceMapTpc()
-    { return m_clusterSurfaceMapTpc; }
+  std::map<TrkrDefs::hitsetkey, std::vector<Surface>> getSurfaceMapTpc()
+    { return m_clusterSurfaceMapTpcEdit; }
   
-  std::map<TrkrDefs::hitsetkey, TGeoNode*> getNodeMap()
+  std::map<TrkrDefs::hitsetkey, TGeoNode*> getTGeoNodeMap()
     { return m_clusterNodeMap; }
   
   double getSurfStepZ() { return m_surfStepZ; }
@@ -147,8 +147,6 @@ class MakeActsGeometry
   void isActive(TGeoNode *gnode, int nmax_print);
 
   TrkrDefs::hitsetkey GetTpcHitSetKeyFromCoords(std::vector<double> &world);
-
-  void BuildTpcSurfaceMap();
 
   void MakeTGeoNodeMap(PHCompositeNode*);
 

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -72,11 +72,11 @@ class MakeActsGeometry
   void SetVerbosity(int verbosity)
   { m_verbosity = verbosity; }
 
-  std::map<TrkrDefs::hitsetkey,Surface>* getSurfaceMapSilicon()
-    { return &m_clusterSurfaceMapSilicon; }
+  std::map<TrkrDefs::hitsetkey,Surface> getSurfaceMapSilicon()
+    { return m_clusterSurfaceMapSilicon; }
   
-  std::map<TrkrDefs::cluskey, Surface>* getSurfaceMapTpc()
-    { return &m_clusterSurfaceMapTpc; }
+  std::map<TrkrDefs::cluskey, Surface> getSurfaceMapTpc()
+    { return m_clusterSurfaceMapTpc; }
   
   std::map<TrkrDefs::hitsetkey, TGeoNode*> getNodeMap()
     { return m_clusterNodeMap; }
@@ -99,6 +99,15 @@ class MakeActsGeometry
   Acts::MagneticFieldContext getMagFieldContext() { return m_magFieldContext; }
   Acts::CalibrationContext getCalibContext() { return m_calibContext; }
 
+  /// Gets tpc surface from a cluster coordinate and hitsetkey. Necessary
+  /// since there are many tpc surfaces per read out module
+  Surface GetTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, 
+    std::vector<double> &world);
+
+  Acts::GeometryContext  m_geoCtxt;  
+  FW::Options::BFieldVariant m_magneticField;
+  Acts::CalibrationContext m_calibContext;
+  Acts::MagneticFieldContext m_magFieldContext;
  private:
   
   //! Get all the nodes
@@ -125,7 +134,7 @@ class MakeActsGeometry
   void makeInttMapPairs(TrackingVolumePtr &inttVolume);
   void makeTpcMapPairs(TrackingVolumePtr &tpcVolume);
 
-  Surface GetTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, std::vector<double> &world);
+ 
   
   TrkrDefs::hitsetkey GetMvtxHitSetKeyFromCoords(unsigned int layer, 
 						 std::vector<double> &world);
@@ -149,7 +158,7 @@ class MakeActsGeometry
 
   TGeoManager* m_geoManager;
 
-  Acts::GeometryContext  m_geoCtxt;
+ 
 
   std::vector<std::shared_ptr<FW::IContextDecorator> > m_contextDecorators;
 
@@ -194,9 +203,7 @@ class MakeActsGeometry
   TGeoDetector m_detector;
 
   TrackingGeometry m_tGeometry;
-  FW::Options::BFieldVariant m_magneticField;
-  Acts::CalibrationContext m_calibContext;
-  Acts::MagneticFieldContext m_magFieldContext;
+
 
   int m_verbosity;
 };

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -66,8 +66,8 @@ class MakeActsGeometry
   ~MakeActsGeometry();
 
   int BuildAllGeometry(PHCompositeNode *topNode);
-  void EditTPCGeometry(const int verbosity = 1);
-  void AddActsTpcSurfaces(TGeoVolume *tpc_gas_vol, int verbosity = 1);
+  void EditTPCGeometry();
+  void AddActsTpcSurfaces(TGeoVolume *tpc_gas_vol);
 
   void SetVerbosity(int verbosity)
   { m_verbosity = verbosity; }
@@ -135,7 +135,6 @@ class MakeActsGeometry
   PHG4CylinderCellGeomContainer* m_geomContainerTpc;
 
   TGeoManager* m_geoManager;
-  TGeoManager* m_geoManagerCopy;
 
   Acts::GeometryContext  m_geoCtxt;
 

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -159,6 +159,13 @@ class MakeActsGeometry
   const unsigned int m_nTpcLayers = 48;
   const unsigned int m_nTpcModulesPerLayer = 12;
   const unsigned int m_nTpcSides = 2;
+  const double m_TpcSecMinRadius[3] = {30.0, 40.0, 60.0};
+  const double m_TpcSecMaxRadius[3] = {40.0, 60.0, 77.0};
+
+  double layer_thickness_sector[3];
+  double layer_radius[48];
+  double layer_thickness[48];
+
 
   int nprint_tpc;
 

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -65,11 +65,14 @@ class MakeActsGeometry
   //! Destructor
   ~MakeActsGeometry();
 
-  int BuildAllGeometry(PHCompositeNode *topNode);
-  void EditTPCGeometry();
-  void AddActsTpcSurfaces(TGeoVolume *tpc_gas_vol);
+  /// Main function to build all acts geometry for use in the fitting modules
+  int buildAllGeometry(PHCompositeNode *topNode);
+  
+  /// Functions to edit TGeoManager to include TPC boxes
+  void editTPCGeometry();
+  void addActsTpcSurfaces(TGeoVolume *tpc_gas_vol);
 
-  void SetVerbosity(int verbosity)
+  void setVerbosity(int verbosity)
   { m_verbosity = verbosity; }
 
   std::map<TrkrDefs::hitsetkey,Surface> getSurfaceMapSilicon()
@@ -80,48 +83,39 @@ class MakeActsGeometry
   
   std::map<TrkrDefs::hitsetkey, TGeoNode*> getTGeoNodeMap()
     { return m_clusterNodeMap; }
-  
-  double getSurfStepZ() { return m_surfStepZ; }
-  double getSurfStepPhi() { return m_surfStepPhi; }
-  double getModuleStepPhi() { return m_moduleStepPhi; }
-  double getModulePhiStart() { return m_modulePhiStart; }
-  Acts::GeometryContext getGeoContext() { return m_geoCtxt; }
-  
+   
   std::vector<std::shared_ptr<FW::IContextDecorator>> getContextDecorators()
     { return m_contextDecorators; }
   
-  double getMinSurfZ() { return m_minSurfZ; }
-  double getMaxSurfZ() { return m_maxSurfZ; }
-  double getNSurfZ() { return m_nSurfZ; }
-  double getNSurfPhi() { return m_nSurfPhi; }     
+  /// Getters for acts geometry that is needed by fitter functions
   TrackingGeometry getTGeometry(){ return m_tGeometry; }
   FW::Options::BFieldVariant getMagField(){ return m_magneticField; }
   Acts::MagneticFieldContext getMagFieldContext() { return m_magFieldContext; }
   Acts::CalibrationContext getCalibContext() { return m_calibContext; }
-
+  Acts::GeometryContext getGeoContext() { return m_geoCtxt; }
+  
   /// Gets tpc surface from a cluster coordinate and hitsetkey. Necessary
   /// since there are many tpc surfaces per read out module
-  Surface GetTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, 
+  Surface getTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, 
     std::vector<double> &world);
 
  private:
   
   //! Get all the nodes
-  int GetNodes(PHCompositeNode*);
+  int getNodes(PHCompositeNode*);
   
   //!Create New nodes
-  int CreateNodes(PHCompositeNode*);
+  int createNodes(PHCompositeNode*);
   
   /// Silicon layers made by BuildSiliconLayers and its helper functions
-  void BuildActsSurfaces();
+  void buildActsSurfaces();
 
   /// Function that mimics ActsFW::GeometryExampleBase
-  int MakeGeometry(int argc, char* argv[], FW::IBaseDetector& detector);
+  void makeGeometry(int argc, char* argv[], FW::IBaseDetector& detector);
   
+  /// Get hitsetkey from TGeoNode for each detector geometry
   void getInttKeyFromNode(TGeoNode *gnode);
-  
   void getMvtxKeyFromNode(TGeoNode *gnode);
-
   void getTpcKeyFromNode(TGeoNode *gnode);
   
   /// Make the Surface<-->TrkrDef::hitsetkey map pairs for each of 
@@ -129,29 +123,28 @@ class MakeActsGeometry
   void makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume);
   void makeInttMapPairs(TrackingVolumePtr &inttVolume);
   void makeTpcMapPairs(TrackingVolumePtr &tpcVolume);
+  
+  /// Get subdetector hitsetkey from the local sensor unit coordinates
+  TrkrDefs::hitsetkey getMvtxHitSetKeyFromCoords(unsigned int layer, 
+						 std::vector<double> &world);
+  TrkrDefs::hitsetkey getInttHitSetKeyFromCoords(unsigned int layer,
+						 std::vector<double> &world);
+  TrkrDefs::hitsetkey getTpcHitSetKeyFromCoords(std::vector<double> &world);
 
- 
-  
-  TrkrDefs::hitsetkey GetMvtxHitSetKeyFromCoords(unsigned int layer, 
-						 std::vector<double> &world);
-  
-  TrkrDefs::hitsetkey GetInttHitSetKeyFromCoords(unsigned int layer,
-						 std::vector<double> &world);
-  
+  /// Helper diagnostic function for identifying active layers in subdetectors
   void isActive(TGeoNode *gnode, int nmax_print);
 
-  TrkrDefs::hitsetkey GetTpcHitSetKeyFromCoords(std::vector<double> &world);
+  /// Makes map of TrkrHitSetKey<-->TGeoNode
+  void makeTGeoNodeMap(PHCompositeNode *topNode);
 
-  void MakeTGeoNodeMap(PHCompositeNode*);
-
-  PHG4CylinderGeomContainer* m_geomContainerMvtx;
-  
+  /// Subdetector geometry containers for getting layer information
+  PHG4CylinderGeomContainer* m_geomContainerMvtx;  
   PHG4CylinderGeomContainer* m_geomContainerIntt;
-  
   PHG4CylinderCellGeomContainer* m_geomContainerTpc;
 
   TGeoManager* m_geoManager; 
 
+  /// Acts Context decorators, which may contain e.g. calibration information
   std::vector<std::shared_ptr<FW::IContextDecorator> > m_contextDecorators;
 
   /// Several maps that connect Acts world to sPHENIX G4 world 
@@ -160,12 +153,12 @@ class MakeActsGeometry
   std::map<TrkrDefs::hitsetkey, std::vector<Surface>> m_clusterSurfaceMapTpcEdit;
   std::map<TrkrDefs::cluskey, Surface> m_clusterSurfaceMapTpc;
   
-  // these don't change, we are building the tpc this way!
+  /// These don't change, we are building the tpc this way!
   const static unsigned int m_nTpcLayers = 48;
   const unsigned int m_nTpcModulesPerLayer = 12;
   const unsigned int m_nTpcSides = 2;
 
-  // TPC surface subdivisions
+  /// TPC Acts::Surface subdivisions
   double m_minSurfZ;
   double m_maxSurfZ;
   unsigned int m_nSurfZ;
@@ -175,11 +168,11 @@ class MakeActsGeometry
   double m_moduleStepPhi;
   double m_modulePhiStart;
 
+  /// Debugger for printing out tpc active volumes
   int nprint_tpc;
 
-  // New TPC Edit TGeo box surfaces subdivisions
+  /// TPC TGeoManager editing box surfaces subdivisions
   const static int m_nTpcSectors = 3;
-
   const double m_minRadius[m_nTpcSectors] = {30.0, 40.0, 60.0};
   const double m_maxRadius[m_nTpcSectors] = {40.0, 60.0, 77.0};
   double layer_thickness_sector[m_nTpcSectors] = {0};
@@ -191,7 +184,7 @@ class MakeActsGeometry
   const double half_width_clearance_phi = 0.4999;
   const double half_width_clearance_z = 0.4999;
 
-  // The acts geometry object
+  /// The acts geometry object
   TGeoDetector m_detector;
 
   /// Acts geometry objects that are needed to create (for example) the fitter
@@ -201,6 +194,7 @@ class MakeActsGeometry
   Acts::CalibrationContext m_calibContext;
   Acts::MagneticFieldContext m_magFieldContext;
 
+  /// Verbosity value handed from PHActsSourceLinks
   int m_verbosity;
 };
 

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -104,12 +104,6 @@ class MakeActsGeometry
   Surface GetTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, 
     std::vector<double> &world);
 
-  /// These are public so that std::reference_wrapper can access them
-  /// in the KalmanFitterOptions
-  Acts::GeometryContext  m_geoCtxt;  
-  Acts::CalibrationContext m_calibContext;
-  Acts::MagneticFieldContext m_magFieldContext;
-
  private:
   
   //! Get all the nodes
@@ -200,9 +194,12 @@ class MakeActsGeometry
   // The acts geometry object
   TGeoDetector m_detector;
 
+  /// Acts geometry objects that are needed to create (for example) the fitter
   TrackingGeometry m_tGeometry;
-  
   FW::Options::BFieldVariant m_magneticField;
+  Acts::GeometryContext  m_geoCtxt;  
+  Acts::CalibrationContext m_calibContext;
+  Acts::MagneticFieldContext m_magFieldContext;
 
   int m_verbosity;
 };

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -124,6 +124,8 @@ class MakeActsGeometry
   void makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume);
   void makeInttMapPairs(TrackingVolumePtr &inttVolume);
   void makeTpcMapPairs(TrackingVolumePtr &tpcVolume);
+
+  Surface GetTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, std::vector<double> &world);
   
   TrkrDefs::hitsetkey GetMvtxHitSetKeyFromCoords(unsigned int layer, 
 						 std::vector<double> &world);

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -33,6 +33,7 @@ class PHG4CylinderGeomContainer;
 class PHG4CylinderCellGeomContainer;
 class TGeoManager;
 class TGeoNode;
+class TGeoVolume;
 
 namespace FW {
   class IBaseDetector;
@@ -65,7 +66,9 @@ class MakeActsGeometry
   ~MakeActsGeometry();
 
   int BuildAllGeometry(PHCompositeNode *topNode);
-  
+  void EditTPCGeometry(const int verbosity = 1);
+  void AddActsTpcSurfaces(TGeoVolume *tpc_gas_vol, int verbosity = 1);
+
   void SetVerbosity(int verbosity)
   { m_verbosity = verbosity; }
 
@@ -132,6 +135,7 @@ class MakeActsGeometry
   PHG4CylinderCellGeomContainer* m_geomContainerTpc;
 
   TGeoManager* m_geoManager;
+  TGeoManager* m_geoManagerCopy;
 
   Acts::GeometryContext  m_geoCtxt;
 

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -122,7 +122,7 @@ class MakeActsGeometry
   TrkrDefs::hitsetkey GetInttHitSetKeyFromCoords(unsigned int layer,
 						 std::vector<double> &world);
   
-  void isActive(TGeoNode *gnode);
+  void isActive(TGeoNode *gnode, int nmax_print);
 
   void BuildTpcSurfaceMap();
 
@@ -159,6 +159,8 @@ class MakeActsGeometry
   const unsigned int m_nTpcLayers = 48;
   const unsigned int m_nTpcModulesPerLayer = 12;
   const unsigned int m_nTpcSides = 2;
+
+  int nprint_tpc;
 
   // The acts geometry object
   TGeoDetector m_detector;

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -104,10 +104,12 @@ class MakeActsGeometry
   Surface GetTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, 
     std::vector<double> &world);
 
+  /// These are public so that std::reference_wrapper can access them
+  /// in the KalmanFitterOptions
   Acts::GeometryContext  m_geoCtxt;  
-  FW::Options::BFieldVariant m_magneticField;
   Acts::CalibrationContext m_calibContext;
   Acts::MagneticFieldContext m_magFieldContext;
+
  private:
   
   //! Get all the nodes
@@ -156,9 +158,7 @@ class MakeActsGeometry
   
   PHG4CylinderCellGeomContainer* m_geomContainerTpc;
 
-  TGeoManager* m_geoManager;
-
- 
+  TGeoManager* m_geoManager; 
 
   std::vector<std::shared_ptr<FW::IContextDecorator> > m_contextDecorators;
 
@@ -203,7 +203,8 @@ class MakeActsGeometry
   TGeoDetector m_detector;
 
   TrackingGeometry m_tGeometry;
-
+  
+  FW::Options::BFieldVariant m_magneticField;
 
   int m_verbosity;
 };

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -46,20 +46,13 @@
 PHActsSourceLinks::PHActsSourceLinks(const std::string &name)
   : SubsysReco(name)
   , m_clusterMap(nullptr)
+  , m_actsGeometry(nullptr)
   , m_hitIdClusKey(nullptr)
   , m_sourceLinks(nullptr)
-  , m_actsGeometry(nullptr)
   , m_geomContainerMvtx(nullptr)
   , m_geomContainerIntt(nullptr)
   , m_geomContainerTpc(nullptr)
-  , m_minSurfZ(0.0)  /// Initialize these to 0, get from MakeActsGeometry
-  , m_maxSurfZ(0.0)
-  , m_nSurfZ(0)
-  , m_nSurfPhi(0)
-  , m_surfStepPhi(0.0)
-  , m_surfStepZ(0.0)
-  , m_moduleStepPhi(0.0)
-  , m_modulePhiStart(0.0)
+ 
 {
   Verbosity(0);
 }
@@ -80,29 +73,11 @@ int PHActsSourceLinks::InitRun(PHCompositeNode *topNode)
   createNodes(topNode);
 
   /// Check if Acts geometry has been built and is on the node tree
-  MakeActsGeometry *actsGeometry = new MakeActsGeometry();
-  actsGeometry->SetVerbosity(Verbosity());
-  actsGeometry->BuildAllGeometry(topNode);
+  m_actsGeometry = new MakeActsGeometry();
+  m_actsGeometry->SetVerbosity(Verbosity());
+  m_actsGeometry->BuildAllGeometry(topNode);
 
-  m_minSurfZ = actsGeometry->getMinSurfZ();
-  m_maxSurfZ = actsGeometry->getMaxSurfZ();
-  m_nSurfZ = actsGeometry->getNSurfZ();
-  m_nSurfPhi = actsGeometry->getNSurfPhi();
 
-  /// These are arbitrary TPC Surface subdivisions, set in MakeActsGeometry
-  m_surfStepZ = actsGeometry->getSurfStepZ();
-  m_moduleStepPhi = actsGeometry->getModuleStepPhi();
-  m_modulePhiStart = actsGeometry->getModulePhiStart();
-  m_surfStepPhi = actsGeometry->getSurfStepPhi();
-
-  m_clusterNodeMap = actsGeometry->getNodeMap();
-  m_clusterSurfaceMap = actsGeometry->getSurfaceMapSilicon();
-  m_clusterSurfaceMapTpc = actsGeometry->getSurfaceMapTpc();
-  m_actsGeometry->tGeometry = actsGeometry->getTGeometry();
-  m_actsGeometry->magField = actsGeometry->getMagField();
-  m_actsGeometry->geoContext = actsGeometry->getGeoContext();
-  m_actsGeometry->magFieldContext = actsGeometry->getMagFieldContext();
-  m_actsGeometry->calibContext = actsGeometry->getCalibContext();
 
   if (Verbosity() > 10)
   {
@@ -296,16 +271,19 @@ Surface PHActsSourceLinks::getTpcLocalCoords(double (&local2D)[2],
   const unsigned int sectorId = TpcDefs::getSectorId(clusKey);
   const unsigned int side = TpcDefs::getSide(clusKey);
 
-  const double modulePhiLow = m_modulePhiStart + (double) sectorId * m_moduleStepPhi;
+  const double modulePhiLow = m_actsGeometry->getModulePhiStart() + (double) sectorId *  m_actsGeometry->getModuleStepPhi();
 
-  const unsigned int iPhi = (clusPhi - modulePhiLow) / m_surfStepPhi;
-  const unsigned int iZ = fabs(zTpc) / m_surfStepZ;
+  const double surfStepPhi = m_actsGeometry->getSurfStepPhi();
+  const double surfStepZ = m_actsGeometry->getSurfStepZ();
+  
+  const unsigned int iPhi = (clusPhi - modulePhiLow) / surfStepPhi;
+  const unsigned int iZ = fabs(zTpc) / surfStepZ;
   const unsigned int iPhiZ = iPhi + 100. * iZ;  /// for making a map key
 
   if (Verbosity() > 0)
   {
-    const double checkSurfRphiCenter = radius * (modulePhiLow + (double) iPhi * m_surfStepPhi + m_surfStepPhi / 2.0);
-    double checkSurfZCenter = (double) iZ * m_surfStepZ + m_surfStepZ / 2.0;
+    const double checkSurfRphiCenter = radius * (modulePhiLow + (double) iPhi * surfStepPhi + surfStepPhi / 2.0);
+    double checkSurfZCenter = (double) iZ * surfStepZ + surfStepZ / 2.0;
     if (side == 0)
       checkSurfZCenter = -checkSurfZCenter;
 
@@ -323,10 +301,14 @@ Surface PHActsSourceLinks::getTpcLocalCoords(double (&local2D)[2],
   /// Get the surface key to find the surface from the map
   const TrkrDefs::cluskey surfkey = TpcDefs::genClusKey(layer, sectorId,
                                                         side, iPhiZ);
+ 
+    std::map<TrkrDefs::cluskey, Surface> clusterSurfaceMapTpc = 
+      m_actsGeometry->getSurfaceMapTpc();
+
   std::map<TrkrDefs::cluskey, Surface>::iterator surfIter;
 
-  surfIter = m_clusterSurfaceMapTpc->find(surfkey);
-  if (surfIter == m_clusterSurfaceMapTpc->end())
+  surfIter = clusterSurfaceMapTpc.find(surfkey);
+  if (surfIter == clusterSurfaceMapTpc.end())
   {
     std::cout << PHWHERE << "Failed to find surface, should be impossible!" << std::endl;
     return nullptr;
@@ -337,7 +319,7 @@ Surface PHActsSourceLinks::getTpcLocalCoords(double (&local2D)[2],
   /// Transformation of cluster to local surface coords
   /// Coords are r*phi relative to surface r-phi center, and z
   /// relative to surface z center
-  Acts::Vector3D center = surface->center(m_actsGeometry->geoContext);
+  Acts::Vector3D center = surface->center(m_actsGeometry->getGeoContext());
   double surfRphiCenter = atan2(center[1], center[0]) * radius;
   double surfZCenter = center[2];
   if (Verbosity() > 0)
@@ -617,33 +599,14 @@ void PHActsSourceLinks::createNodes(PHCompositeNode *topNode)
     svtxNode->addNode(hitMapNode);
   }
 
-  m_clusterSurfaceMap = findNode::getClass<std::map<TrkrDefs::hitsetkey, Surface>>(topNode, "ClusterSurfaceActsMap");
-  
-  if(!m_clusterSurfaceMap)
-    {
-      m_clusterSurfaceMap = new std::map<TrkrDefs::hitsetkey, Surface>;
-      PHDataNode<std::map<TrkrDefs::hitsetkey, Surface>> *keySurfaceNode = 
-	new PHDataNode<std::map<TrkrDefs::hitsetkey, Surface>>(m_clusterSurfaceMap, "HitSetKeySurfaceActsMap");
-      svtxNode->addNode(keySurfaceNode);
-    }
 
-    m_clusterSurfaceMapTpc = findNode::getClass<std::map<TrkrDefs::cluskey, Surface>>(topNode, "ClusterTpcSurfaceActsMap");
-  
-  if(!m_clusterSurfaceMapTpc)
-    {
-      m_clusterSurfaceMapTpc = new std::map<TrkrDefs::cluskey, Surface>;
-      PHDataNode<std::map<TrkrDefs::cluskey, Surface>> *keyTpcSurfaceNode = 
-	new PHDataNode<std::map<TrkrDefs::cluskey, Surface>>(m_clusterSurfaceMapTpc, "ClusKeyTpcSurfaceActsMap");
-      svtxNode->addNode(keyTpcSurfaceNode);
-    }
-
-  m_actsGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsFitCfg");
+  m_actsGeometry = findNode::getClass<MakeActsGeometry>(topNode, "MakeActsGeometry");
 
   if (!m_actsGeometry)
   {
-    m_actsGeometry = new ActsGeometry();
-    PHDataNode<ActsGeometry> *fitNode = new PHDataNode<ActsGeometry>(m_actsGeometry, "ActsGeometry");
-    svtxNode->addNode(fitNode);
+    m_actsGeometry = new MakeActsGeometry();
+    PHDataNode<MakeActsGeometry> *geomNode = new PHDataNode<MakeActsGeometry>(m_actsGeometry, "MakeActsGeometry");
+    svtxNode->addNode(geomNode);
   }
 
   /// Do the same for the SourceLink container
@@ -663,18 +626,20 @@ void PHActsSourceLinks::createNodes(PHCompositeNode *topNode)
 
 TGeoNode *PHActsSourceLinks::getNodeFromClusterMap(TrkrDefs::hitsetkey hitSetKey)
 {
+  std::map<TrkrDefs::hitsetkey, TGeoNode*> clusterNodeMap = m_actsGeometry->getNodeMap();
+
   /// Get the TGeoNode for this hit set key
   std::map<TrkrDefs::hitsetkey, TGeoNode *>::iterator mapIter;
-  mapIter = m_clusterNodeMap.find(hitSetKey);
+  mapIter = clusterNodeMap.find(hitSetKey);
   TGeoNode *sensorNode;
 
   /// Make sure we found it
-  if (mapIter != m_clusterNodeMap.end())
+  if (mapIter != clusterNodeMap.end())
   {
     sensorNode = mapIter->second;
     if (Verbosity() > 0)
     {
-      std::cout << "Found TGeoNode in m_clusterNodeMap for hitsetkey "
+      std::cout << "Found TGeoNode in clusterNodeMap for hitsetkey "
                 << hitSetKey
                 << " node " << sensorNode->GetName()
                 << std::endl;
@@ -693,14 +658,17 @@ TGeoNode *PHActsSourceLinks::getNodeFromClusterMap(TrkrDefs::hitsetkey hitSetKey
 Surface PHActsSourceLinks::getSurfaceFromClusterMap(TrkrDefs::hitsetkey hitSetKey)
 {
   Surface surface;
+  std::map<TrkrDefs::hitsetkey, Surface> clusterSurfaceMap = 
+    m_actsGeometry->getSurfaceMapSilicon();
 
   std::map<TrkrDefs::hitsetkey, Surface>::iterator
       surfaceIter;
 
-  surfaceIter = m_clusterSurfaceMap->find(hitSetKey);
+  
+  surfaceIter = clusterSurfaceMap.find(hitSetKey);
 
   /// Check to make sure we found the surface in the map
-  if (surfaceIter != m_clusterSurfaceMap->end())
+  if (surfaceIter != clusterSurfaceMap.end())
   {
     surface = surfaceIter->second;
     if (Verbosity() > 0)

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -52,6 +52,7 @@ PHActsSourceLinks::PHActsSourceLinks(const std::string &name)
   , m_geomContainerMvtx(nullptr)
   , m_geomContainerIntt(nullptr)
   , m_geomContainerTpc(nullptr)
+  , m_context(nullptr)
  
 {
   Verbosity(0);
@@ -74,10 +75,15 @@ int PHActsSourceLinks::InitRun(PHCompositeNode *topNode)
 
   /// Check if Acts geometry has been built and is on the node tree
   m_actsGeometry = new MakeActsGeometry();
+  
   m_actsGeometry->SetVerbosity(Verbosity());
   m_actsGeometry->BuildAllGeometry(topNode);
 
-
+  m_context->geoContext = m_actsGeometry->getGeoContext();
+  m_context->calibContext = m_actsGeometry->getCalibContext();
+  m_context->magFieldContext = m_actsGeometry->getMagFieldContext();
+  m_context->tGeometry = m_actsGeometry->getTGeometry();
+  m_context->magField = m_actsGeometry->getMagField();
 
   if (Verbosity() > 10)
   {
@@ -620,6 +626,16 @@ void PHActsSourceLinks::createNodes(PHCompositeNode *topNode)
 
     svtxNode->addNode(sourceLinkNode);
   }
+
+  m_context = findNode::getClass<Context>(topNode,"ActsContext");
+  if(!m_context)
+    {
+      m_context = new Context();
+      PHDataNode<Context> *contextNode = new PHDataNode<Context>(m_context,
+								 "ActsContext");
+      svtxNode->addNode(contextNode);
+    }
+
 
   return;
 }

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -76,8 +76,8 @@ int PHActsSourceLinks::InitRun(PHCompositeNode *topNode)
   /// Check if Acts geometry has been built and is on the node tree
   m_actsGeometry = new MakeActsGeometry();
   
-  m_actsGeometry->SetVerbosity(Verbosity());
-  m_actsGeometry->BuildAllGeometry(topNode);
+  m_actsGeometry->setVerbosity(Verbosity());
+  m_actsGeometry->buildAllGeometry(topNode);
 
   /// Set the tGeometry struct to be put on the node tree
   m_tGeometry->tGeometry = m_actsGeometry->getTGeometry();
@@ -283,7 +283,7 @@ Surface PHActsSourceLinks::getTpcLocalCoords(double (&local2D)[2],
   std::vector<double> worldVec = {world[0], world[1], world[2]};
   /// MakeActsGeometry has a helper function since many surfaces can exist on
   /// a given readout module
-  Surface surface = m_actsGeometry->GetTpcSurfaceFromCoords(tpcHitSetKey,
+  Surface surface = m_actsGeometry->getTpcSurfaceFromCoords(tpcHitSetKey,
 							    worldVec);
   assert(surface);
   

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -52,7 +52,7 @@ PHActsSourceLinks::PHActsSourceLinks(const std::string &name)
   , m_geomContainerMvtx(nullptr)
   , m_geomContainerIntt(nullptr)
   , m_geomContainerTpc(nullptr)
-  , m_context(nullptr)
+  , m_tGeometry(nullptr)
  
 {
   Verbosity(0);
@@ -79,11 +79,8 @@ int PHActsSourceLinks::InitRun(PHCompositeNode *topNode)
   m_actsGeometry->SetVerbosity(Verbosity());
   m_actsGeometry->BuildAllGeometry(topNode);
 
-  m_context->geoContext = m_actsGeometry->getGeoContext();
-  m_context->calibContext = m_actsGeometry->getCalibContext();
-  m_context->magFieldContext = m_actsGeometry->getMagFieldContext();
-  m_context->tGeometry = m_actsGeometry->getTGeometry();
-  m_context->magField = m_actsGeometry->getMagField();
+  m_tGeometry->tGeometry = m_actsGeometry->getTGeometry();
+  m_tGeometry->magField = m_actsGeometry->getMagField();
 
   if (Verbosity() > 10)
   {
@@ -627,13 +624,13 @@ void PHActsSourceLinks::createNodes(PHCompositeNode *topNode)
     svtxNode->addNode(sourceLinkNode);
   }
 
-  m_context = findNode::getClass<Context>(topNode,"ActsContext");
-  if(!m_context)
+  m_tGeometry = findNode::getClass<ActsTrackingGeometry>(topNode,"ActsTrackingGeometry");
+  if(!m_tGeometry)
     {
-      m_context = new Context();
-      PHDataNode<Context> *contextNode = new PHDataNode<Context>(m_context,
-								 "ActsContext");
-      svtxNode->addNode(contextNode);
+      m_tGeometry = new ActsTrackingGeometry();
+      PHDataNode<ActsTrackingGeometry> *tGeoNode = new PHDataNode<ActsTrackingGeometry>(m_tGeometry,
+								 "ActsTrackingGeometry");
+      svtxNode->addNode(tGeoNode);
     }
 
 

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -79,8 +79,12 @@ int PHActsSourceLinks::InitRun(PHCompositeNode *topNode)
   m_actsGeometry->SetVerbosity(Verbosity());
   m_actsGeometry->BuildAllGeometry(topNode);
 
+  /// Set the tGeometry struct to be put on the node tree
   m_tGeometry->tGeometry = m_actsGeometry->getTGeometry();
   m_tGeometry->magField = m_actsGeometry->getMagField();
+  m_tGeometry->calibContext = m_actsGeometry->getCalibContext();
+  m_tGeometry->magFieldContext = m_actsGeometry->getMagFieldContext();
+  m_tGeometry->geoContext = m_actsGeometry->getGeoContext();
 
   if (Verbosity() > 10)
   {
@@ -286,7 +290,7 @@ Surface PHActsSourceLinks::getTpcLocalCoords(double (&local2D)[2],
   if(Verbosity() > 10)
     {
       std::cout << "Stream of found TPC surface: " << std::endl;
-      surface->toStream(m_actsGeometry->m_geoCtxt, std::cout);
+      surface->toStream(m_tGeometry->geoContext, std::cout);
     }
 
   /// Transformation of cluster to local surface coords
@@ -570,16 +574,6 @@ void PHActsSourceLinks::createNodes(PHCompositeNode *topNode)
     PHDataNode<std::map<TrkrDefs::cluskey, unsigned int>> *hitMapNode =
         new PHDataNode<std::map<TrkrDefs::cluskey, unsigned int>>(m_hitIdClusKey, "HitIDClusIDActsMap");
     svtxNode->addNode(hitMapNode);
-  }
-
-
-  m_actsGeometry = findNode::getClass<MakeActsGeometry>(topNode, "MakeActsGeometry");
-
-  if (!m_actsGeometry)
-  {
-    m_actsGeometry = new MakeActsGeometry();
-    PHDataNode<MakeActsGeometry> *geomNode = new PHDataNode<MakeActsGeometry>(m_actsGeometry, "MakeActsGeometry");
-    svtxNode->addNode(geomNode);
   }
 
   /// Do the same for the SourceLink container

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -45,15 +45,28 @@ class Surface;
 using Surface = std::shared_ptr<const Acts::Surface>;
 using SourceLink = FW::Data::TrkrClusterSourceLink;
 
+/**
+ * A struct to carry around Acts geometry, so as to not put all of the
+ * MakeActsGeometry memory footprint on the node tree
+ */
 struct ActsTrackingGeometry{
   ActsTrackingGeometry(){}
   ActsTrackingGeometry(std::shared_ptr<const Acts::TrackingGeometry> tGeo,
-	  FW::Options::BFieldVariant mag)
+		       FW::Options::BFieldVariant mag,
+		       Acts::CalibrationContext calib,
+		       Acts::GeometryContext geoCtxt,
+		       Acts::MagneticFieldContext magFieldCtxt)
   : tGeometry(tGeo)
   , magField(mag)
+  , calibContext(calib)
+  , geoContext(geoCtxt)
+  , magFieldContext(magFieldCtxt)
   {}
   std::shared_ptr<const Acts::TrackingGeometry> tGeometry;
   FW::Options::BFieldVariant magField;
+  Acts::CalibrationContext calibContext;
+  Acts::GeometryContext geoContext;
+  Acts::MagneticFieldContext magFieldContext;
 };
 
 /**

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -20,7 +20,6 @@
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/Utilities/CalibrationContext.hpp>
 
-
 #include <ACTFW/EventData/Track.hpp>
 #include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
 #include <ACTFW/Plugins/BField/BFieldOptions.hpp>
@@ -46,6 +45,26 @@ class Surface;
 using Surface = std::shared_ptr<const Acts::Surface>;
 using SourceLink = FW::Data::TrkrClusterSourceLink;
 
+struct Context{
+  Context(){}
+  Context(std::shared_ptr<const Acts::TrackingGeometry> tGeo,
+	  FW::Options::BFieldVariant mag,
+	  Acts::CalibrationContext calib,
+	  Acts::GeometryContext geo,
+	  Acts::MagneticFieldContext magField)
+  : tGeometry(tGeo)
+  , magField(mag)
+  , calibContext(calib)
+  , geoContext(geo)
+  , magFieldContext(magField)
+  {}
+  std::shared_ptr<const Acts::TrackingGeometry> tGeometry;
+  FW::Options::BFieldVariant magField;
+  Acts::CalibrationContext calibContext;
+  Acts::GeometryContext geoContext;
+  Acts::MagneticFieldContext magFieldContext;
+
+};
 
 /**
  * This class is responsible for creating Acts TrkrClusterSourceLinks from
@@ -140,7 +159,7 @@ class PHActsSourceLinks : public SubsysReco
   PHG4CylinderGeomContainer *m_geomContainerIntt;
   PHG4CylinderCellGeomContainer *m_geomContainerTpc;
 
-
+  Context *m_context;
 
 };
 

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -31,6 +31,7 @@ class TrkrCluster;
 class TGeoNode;
 class PHG4CylinderGeomContainer;
 class PHG4CylinderCellGeomContainer;
+class MakeActsGeometry;
 
 namespace FW
 {
@@ -45,42 +46,6 @@ class Surface;
 using Surface = std::shared_ptr<const Acts::Surface>;
 using SourceLink = FW::Data::TrkrClusterSourceLink;
 
-/**
- * A struct that contains the necessary geometry objects that the fitter
- * needs in PHActsTrkFitter. To be put on the node tree
- */
-struct ActsGeometry
-{
-  /// Two constructor options
-  ActsGeometry() {}
-  ActsGeometry(std::shared_ptr<const Acts::TrackingGeometry> tGeo,
-	       FW::Options::BFieldVariant mag,
-	       Acts::CalibrationContext calib,
-	       Acts::GeometryContext geo,
-	       Acts::MagneticFieldContext magField)
-  : tGeometry(tGeo)
-  , magField(mag)
-  , calibContext(calib)
-  , geoContext(geo)
-  , magFieldContext(magField)
-  {
-  }
-
-  /// Acts tracking geometry
-  std::shared_ptr<const Acts::TrackingGeometry> tGeometry;
-
-  /// Acts magnetic field
-  FW::Options::BFieldVariant magField;
-
-  /// Acts calibration context, grabbed from geometry building
-  Acts::CalibrationContext calibContext;
-
-  /// Acts geometry context, grabbed from geometry building
-  Acts::GeometryContext geoContext;
-
-  /// Acts magnetic field context, grabbed from geometry building
-  Acts::MagneticFieldContext magFieldContext;
-};
 
 /**
  * This class is responsible for creating Acts TrkrClusterSourceLinks from
@@ -161,6 +126,8 @@ class PHActsSourceLinks : public SubsysReco
   /// SvtxCluster node
   TrkrClusterContainer *m_clusterMap;
 
+  MakeActsGeometry *m_actsGeometry;
+
   /// Map relating arbitrary hitid to TrkrDef::cluskey for SourceLink, to be put
   /// on node tree by this module
   std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey;
@@ -168,38 +135,13 @@ class PHActsSourceLinks : public SubsysReco
   /// Map for source hitid:sourcelink, to be put on node tree by this module
   std::map<unsigned int, SourceLink> *m_sourceLinks;
 
-  /// Map relating hit set keys to TGeoNodes
-  std::map<TrkrDefs::hitsetkey, TGeoNode*> m_clusterNodeMap;
-
-  /// Map relating hit set keys to Acts::Surfaces
-  std::map<TrkrDefs::hitsetkey, Surface> *m_clusterSurfaceMap;
-
-  /// Get the TPC surface cluster map
-  std::map<TrkrDefs::cluskey, Surface> *m_clusterSurfaceMapTpc;
-
-  /// The fit cfg options, created in MakeActsGeometry, to be put on node tree
-  /// for PHActsTrkFitter
-  ActsGeometry *m_actsGeometry;
-
   /// Tracking geometry objects
   PHG4CylinderGeomContainer *m_geomContainerMvtx;
   PHG4CylinderGeomContainer *m_geomContainerIntt;
   PHG4CylinderCellGeomContainer *m_geomContainerTpc;
 
-  /// These don't change, we are building the tpc this way!
-  const unsigned int m_nTpcLayers = 48;
-  const unsigned int m_nTpcModulesPerLayer = 12;
-  const unsigned int m_nTpcSides = 2;
 
-  /// TPC surface subdivisions. These come from MakeActsGeometry
-  double m_minSurfZ;
-  double m_maxSurfZ;
-  unsigned int m_nSurfZ;
-  unsigned int m_nSurfPhi;
-  double m_surfStepPhi;
-  double m_surfStepZ;
-  double m_moduleStepPhi;
-  double m_modulePhiStart;
+
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -46,8 +46,8 @@ using Surface = std::shared_ptr<const Acts::Surface>;
 using SourceLink = FW::Data::TrkrClusterSourceLink;
 
 /**
- * A struct to carry around Acts geometry, so as to not put all of the
- * MakeActsGeometry memory footprint on the node tree
+ * A struct to carry around Acts geometry on node tree, so as to not put 
+ * all of the MakeActsGeometry tree
  */
 struct ActsTrackingGeometry{
   ActsTrackingGeometry(){}
@@ -62,8 +62,11 @@ struct ActsTrackingGeometry{
   , geoContext(geoCtxt)
   , magFieldContext(magFieldCtxt)
   {}
+  /// Tracking geometry and magnetic field, for fitter function
   std::shared_ptr<const Acts::TrackingGeometry> tGeometry;
   FW::Options::BFieldVariant magField;
+
+  /// Acts context, for Kalman options
   Acts::CalibrationContext calibContext;
   Acts::GeometryContext geoContext;
   Acts::MagneticFieldContext magFieldContext;
@@ -148,6 +151,7 @@ class PHActsSourceLinks : public SubsysReco
   /// SvtxCluster node
   TrkrClusterContainer *m_clusterMap;
 
+  /// Geometry object to create all acts geometry
   MakeActsGeometry *m_actsGeometry;
 
   /// Map relating arbitrary hitid to TrkrDef::cluskey for SourceLink, to be put

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -45,25 +45,15 @@ class Surface;
 using Surface = std::shared_ptr<const Acts::Surface>;
 using SourceLink = FW::Data::TrkrClusterSourceLink;
 
-struct Context{
-  Context(){}
-  Context(std::shared_ptr<const Acts::TrackingGeometry> tGeo,
-	  FW::Options::BFieldVariant mag,
-	  Acts::CalibrationContext calib,
-	  Acts::GeometryContext geo,
-	  Acts::MagneticFieldContext magField)
+struct ActsTrackingGeometry{
+  ActsTrackingGeometry(){}
+  ActsTrackingGeometry(std::shared_ptr<const Acts::TrackingGeometry> tGeo,
+	  FW::Options::BFieldVariant mag)
   : tGeometry(tGeo)
   , magField(mag)
-  , calibContext(calib)
-  , geoContext(geo)
-  , magFieldContext(magField)
   {}
   std::shared_ptr<const Acts::TrackingGeometry> tGeometry;
   FW::Options::BFieldVariant magField;
-  Acts::CalibrationContext calibContext;
-  Acts::GeometryContext geoContext;
-  Acts::MagneticFieldContext magFieldContext;
-
 };
 
 /**
@@ -159,7 +149,7 @@ class PHActsSourceLinks : public SubsysReco
   PHG4CylinderGeomContainer *m_geomContainerIntt;
   PHG4CylinderCellGeomContainer *m_geomContainerTpc;
 
-  Context *m_context;
+  ActsTrackingGeometry *m_tGeometry;
 
 };
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -31,7 +31,7 @@ PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   , m_event(0)
   , m_actsProtoTracks(nullptr)
   , m_actsGeometry(nullptr)
-  , m_context(nullptr)
+  , m_tGeometry(nullptr)
 {
   Verbosity(0);
 }
@@ -66,8 +66,8 @@ int PHActsTrkFitter::Process()
   /// FitCfg created by MakeActsGeometry
   FW::TrkrClusterFittingAlgorithm::Config fitCfg;
 
-  fitCfg.fit = FW::TrkrClusterFittingAlgorithm::makeFitterFunction(m_context->tGeometry,
-								   m_context->magField,
+  fitCfg.fit = FW::TrkrClusterFittingAlgorithm::makeFitterFunction(m_tGeometry->tGeometry,
+								   m_tGeometry->magField,
                                                                    Acts::Logging::VERBOSE);
 
   std::vector<ActsTrack>::iterator trackIter;
@@ -84,9 +84,9 @@ int PHActsTrkFitter::Process()
     /// Call KF now. Have a vector of sourceLinks corresponding to clusters
     /// associated to this track and the corresponding track seed which
     /// corresponds to the PHGenFitTrkProp track seeds
-    Acts::KalmanFitterOptions kfOptions(m_context->geoContext,
-					m_context->magFieldContext,
-					m_context->calibContext,
+    Acts::KalmanFitterOptions kfOptions(m_actsGeometry->m_geoCtxt,
+					m_actsGeometry->m_magFieldContext,
+					m_actsGeometry->m_calibContext,
 					&(*pSurface));
 
   
@@ -152,8 +152,8 @@ int PHActsTrkFitter::getNodes(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  m_context = findNode::getClass<Context>(topNode, "ActsContext");
-  if(!m_context)
+  m_tGeometry = findNode::getClass<ActsTrackingGeometry>(topNode, "ActsTrackingGeometry");
+  if(!m_tGeometry)
     {
       std::cout << "ActsContext not on node tree. Exiting."
 		<< std::endl;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -30,7 +30,6 @@ PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   : PHTrackFitting(name)
   , m_event(0)
   , m_actsProtoTracks(nullptr)
-  , m_actsGeometry(nullptr)
   , m_tGeometry(nullptr)
 {
   Verbosity(0);
@@ -84,9 +83,9 @@ int PHActsTrkFitter::Process()
     /// Call KF now. Have a vector of sourceLinks corresponding to clusters
     /// associated to this track and the corresponding track seed which
     /// corresponds to the PHGenFitTrkProp track seeds
-    Acts::KalmanFitterOptions kfOptions(m_actsGeometry->m_geoCtxt,
-					m_actsGeometry->m_magFieldContext,
-					m_actsGeometry->m_calibContext,
+    Acts::KalmanFitterOptions kfOptions(m_tGeometry->geoContext,
+					m_tGeometry->magFieldContext,
+					m_tGeometry->calibContext,
 					&(*pSurface));
 
   
@@ -139,16 +138,6 @@ int PHActsTrkFitter::getNodes(PHCompositeNode* topNode)
   {
     std::cout << "Acts proto tracks not on node tree. Exiting."
               << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
-  m_actsGeometry = findNode::getClass<MakeActsGeometry>(topNode, "MakeActsGeometry");
-
-  if (!m_actsGeometry)
-  {
-    std::cout << "ActsGeometry not on node tree. Exiting."
-              << std::endl;
-
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -68,7 +68,6 @@ class PHActsTrkFitter : public PHTrackFitting
   std::vector<ActsTrack>* m_actsProtoTracks;
 
   /// Options that Acts::Fitter needs to run from MakeActsGeometry
-  MakeActsGeometry* m_actsGeometry;
   ActsTrackingGeometry *m_tGeometry;
 };
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -14,21 +14,44 @@
 #include <Acts/Utilities/Definitions.hpp>
 #include <Acts/Utilities/Logger.hpp>
 
+#include <Acts/EventData/MeasurementHelpers.hpp>
+#include <Acts/Geometry/TrackingGeometry.hpp>
+#include <Acts/MagneticField/MagneticFieldContext.hpp>
+#include <Acts/Utilities/CalibrationContext.hpp>
+
 #include <memory>
 #include <string>
 
 namespace FW
 {
-namespace Data
-{
-class TrkrClusterSourceLink;
-}
+  namespace Data
+  {
+    class TrkrClusterSourceLink;
+  }
 }  // namespace FW
 
 class ActsTrack;
-struct ActsGeometry;
+class MakeActsGeometry;
 
 using SourceLink = FW::Data::TrkrClusterSourceLink;
+
+
+struct Context{
+  Context(){}
+  Context(Acts::CalibrationContext calib,
+	  Acts::GeometryContext geo,
+	  Acts::MagneticFieldContext magField)
+  : calibContext(calib)
+  , geoContext(geo)
+    , magFieldContext(magField)
+  {}
+
+  Acts::CalibrationContext calibContext;
+  Acts::GeometryContext geoContext;
+  Acts::MagneticFieldContext magFieldContext;
+
+};
+
 
 class PHActsTrkFitter : public PHTrackFitting
 {
@@ -62,7 +85,7 @@ class PHActsTrkFitter : public PHTrackFitting
   std::vector<ActsTrack>* m_actsProtoTracks;
 
   /// Options that Acts::Fitter needs to run from MakeActsGeometry
-  ActsGeometry* m_actsGeometry;
+  MakeActsGeometry* m_actsGeometry;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -69,7 +69,7 @@ class PHActsTrkFitter : public PHTrackFitting
 
   /// Options that Acts::Fitter needs to run from MakeActsGeometry
   MakeActsGeometry* m_actsGeometry;
-  Context *m_context;
+  ActsTrackingGeometry *m_tGeometry;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -9,6 +9,7 @@
 #define TRACKRECO_ACTSTRKFITTER_H
 
 #include "PHTrackFitting.h"
+#include "PHActsSourceLinks.h"
 
 #include <Acts/Utilities/BinnedArray.hpp>
 #include <Acts/Utilities/Definitions.hpp>
@@ -34,24 +35,6 @@ class ActsTrack;
 class MakeActsGeometry;
 
 using SourceLink = FW::Data::TrkrClusterSourceLink;
-
-
-struct Context{
-  Context(){}
-  Context(Acts::CalibrationContext calib,
-	  Acts::GeometryContext geo,
-	  Acts::MagneticFieldContext magField)
-  : calibContext(calib)
-  , geoContext(geo)
-    , magFieldContext(magField)
-  {}
-
-  Acts::CalibrationContext calibContext;
-  Acts::GeometryContext geoContext;
-  Acts::MagneticFieldContext magFieldContext;
-
-};
-
 
 class PHActsTrkFitter : public PHTrackFitting
 {
@@ -86,6 +69,7 @@ class PHActsTrkFitter : public PHTrackFitting
 
   /// Options that Acts::Fitter needs to run from MakeActsGeometry
   MakeActsGeometry* m_actsGeometry;
+  Context *m_context;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -2,7 +2,9 @@
 #define TRACKRECO_PHACTSTRKPROP_H
 
 #include "PHTrackPropagating.h"
-#include "PHActsSourceLinks.h"
+
+#include <fun4all/SubsysReco.h>
+#include <trackbase/TrkrDefs.h>
 
 #include <Acts/Utilities/BinnedArray.hpp>
 #include <Acts/Utilities/Definitions.hpp>
@@ -13,13 +15,27 @@
 #include <Acts/Propagator/detail/SteppingLogger.hpp>
 #include <Acts/Propagator/MaterialInteractor.hpp>
 
+#include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
+#include <ACTFW/EventData/Track.hpp>
+
 #include <memory>
 #include <string>
+#include <map>
 
 struct ActsTrack;
+
+class MakeActsGeometry;
 class SvtxTrack;
 class SvtxTrackMap;
-class TrkrClusterSourceLink; 
+
+namespace Acts
+{
+  class Surface;
+  class PerigeeSurface;
+}
+
+
+
 
 using RecordedMaterial = Acts::MaterialInteractor::result_type;
 using PropagationOutput
@@ -27,6 +43,7 @@ using PropagationOutput
 
 using PerigeeSurface = std::shared_ptr<const Acts::PerigeeSurface>;
 using Surface = std::shared_ptr<const Acts::Surface>;
+using SourceLink = FW::Data::TrkrClusterSourceLink;
 
 class PHActsTrkProp : public PHTrackPropagating
 {
@@ -62,7 +79,7 @@ class PHActsTrkProp : public PHTrackPropagating
   PropagationOutput propagate(FW::TrackParameters parameters);
 
   /// The acts geometry constructed in MakeActsGeometry
-  ActsGeometry *m_actsGeometry;
+  MakeActsGeometry *m_actsGeometry;
 
   /// Minimum track pT to propagate, for acts propagator, units of GeV
   double m_minTrackPt;


### PR DESCRIPTION
This PR introduces a major change in the way the TPC is implemented in the Acts track fitting. 

Previously, the `Acts::Surfaces` for the TPC were built by us in `MakeActsGeometry`, and then clusters were connected to those surfaces via a map as with the other silicon geometries. The TPC geometry was not actually included in the Acts FW geometry building code; only the silicon was explicitly built within Acts.

This PR introduces a change to modify the `TGeoManager` to include boxes for the TPC. The `TGeoManager` is then passed to Acts (as before) to build all of the Acts tracking geometry straight from the `TGeoManager`. Now, the Acts FW code actually keeps track of the TPC boxes (rather than just us building them and passing them to Acts as plane surfaces) in the `TrackingGeometryPtr` object. This is better than before as the Acts world now has memory of the silicon and TPC boxes to do the tracking with, rather than us just passing Acts the surfaces in the fitting. Acts will now be able to take into account (e.g.) material interaction effects with the TPC since it will actually be performing the track fitting through some `Acts::Surfaces` that contain material as provided in the `TGeoManager` description.

One note to make is that GenFit and Acts should not be run simultaneously at the moment. Because there are now O(10,000) TGeo boxes for the TPC that are added, GenFit is dramatically slowed down from this addition. This isn't a problem for the general user as the macros have not yet been updated to run the Acts track fitting, but in the future we will have to run either GenFit or Acts, but not both.

One other comment in this PR is that the TrackPropagation code was removed. After discussion with the Acts developers, there is a combinatorial kalman filter that can be used as a track finder/propagator currently in the PR state of the acts repository. Once it is merged, we will update our track propagator to conform to the CKF - the setup will be very similar to the current Kalman Fitter code in `PHActsTrkFitter`.

For fun, the below image shows all of the tracking surfaces now as registered within the `Acts::TrackingGeometryPtr`. The black boxes, are the TPC surfaces, the green flat surfaces are the INTT, and the purple flat surfaces are the MVTX layers.
![snapshotzoom01](https://user-images.githubusercontent.com/53052717/79576313-10482c00-8091-11ea-9fd3-32b8d6a68927.png)
