### PR TITLE
Upstream/master qa

### DIFF
--- a/offline/QA/modules/Makefile.am
+++ b/offline/QA/modules/Makefile.am
@@ -1,53 +1,56 @@
 AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
-  -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
-  -I$(OFFLINE_MAIN)/include/eigen3 \
-  -I`root-config --incdir`
+	-I$(includedir) \
+	-I$(OFFLINE_MAIN)/include \
+	-I$(OFFLINE_MAIN)/include/eigen3 \
+	-I`root-config --incdir`
 
 lib_LTLIBRARIES = \
-   libqa_modules.la
+	 libqa_modules.la
 
 libqa_modules_la_LDFLAGS = \
-  -L$(libdir) \
-  -L$(OFFLINE_MAIN)/lib
+	-L$(libdir) \
+	-L$(OFFLINE_MAIN)/lib
 
 libqa_modules_la_LIBADD = \
-  -lfun4all \
-  -lphg4hit \
-  -lg4detectors_io \
-  -lcalo_io -lcalo_util \
-  -lg4jets_io \
-  -ltrackbase_historic_io \
-  -lg4eval
+	-lfun4all \
+	-lphg4hit \
+	-lg4detectors_io \
+	-lcalo_io -lcalo_util \
+	-lg4jets_io \
+	-ltrackbase_historic_io \
+	-lg4eval
 
 pkginclude_HEADERS = \
-  QAG4SimulationCalorimeter.h \
-  QAG4SimulationCalorimeterSum.h \
-  QAG4SimulationTracking.h \
-  QAG4SimulationUpsilon.h \
-  QAG4SimulationJet.h \
-  QAHistManagerDef.h
+	QAG4SimulationCalorimeter.h \
+	QAG4SimulationCalorimeterSum.h \
+	QAG4SimulationJet.h \
+	QAG4SimulationMvtx.h \
+	QAG4SimulationTracking.h \
+	QAG4SimulationUpsilon.h \
+	QAHistManagerDef.h
 
 if ! MAKEROOT6
-  ROOT5DICTS = \
-    QAHistManagerDef_Dict.cc \
-    QAG4SimulationCalorimeter_Dict.cc \
-    QAG4SimulationCalorimeterSum_Dict.cc \
-    QAG4SimulationTracking_Dict.cc \
-    QAG4SimulationUpsilon_Dict.cc \
-    QAG4SimulationJet_Dict.cc 
+	ROOT5DICTS = \
+		QAG4SimulationCalorimeter_Dict.cc \
+		QAG4SimulationCalorimeterSum_Dict.cc \
+		QAG4SimulationJet_Dict.cc \
+		QAG4SimulationMvtx_Dict.cc \
+		QAG4SimulationTracking_Dict.cc \
+		QAG4SimulationUpsilon_Dict.cc \
+		QAHistManagerDef_Dict.cc
 endif
 
 libqa_modules_la_SOURCES = \
-  $(ROOT5DICTS) \
-  QAHistManagerDef.cc \
-  QAG4SimulationCalorimeter.cc \
-  QAG4SimulationCalorimeterSum.cc \
-  QAG4SimulationTracking.cc \
-  QAG4SimulationUpsilon.cc \
-  QAG4SimulationJet.cc
+	$(ROOT5DICTS) \
+	QAG4SimulationCalorimeter.cc \
+	QAG4SimulationCalorimeterSum.cc \
+	QAG4SimulationJet.cc \
+	QAG4SimulationMvtx.cc \
+	QAG4SimulationTracking.cc \
+	QAG4SimulationUpsilon.cc \
+	QAHistManagerDef.cc
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h
@@ -62,13 +65,13 @@ libqa_modules_la_SOURCES = \
 noinst_PROGRAMS = testexternals
 
 BUILT_SOURCES = \
-  testexternals.cc
+	testexternals.cc
 
 testexternals_SOURCES = \
-  testexternals.cc
+	testexternals.cc
 
 testexternals_LDADD = \
-  libqa_modules.la
+	libqa_modules.la
 
 testexternals.cc:
 	echo "//*** this is a generated file. Do not commit, do not edit" > $@

--- a/offline/QA/modules/QAG4SimulationMvtx.cc
+++ b/offline/QA/modules/QAG4SimulationMvtx.cc
@@ -28,7 +28,13 @@ namespace
   template<class T> inline constexpr T get_r( T x, T y ) { return std::sqrt( square(x) + square(y) ); }
 
   /// angle difference between [-pi, pi[
-  template<class T> inline constexpr T delta_phi( T phi1, T phi2 ) { return std::fmod( phi1 - phi2, 2*M_PI )-M_PI; }
+  template<class T> inline const T delta_phi( T phi1, T phi2 )
+  {
+    auto out = phi1-phi2;
+    while( out >= M_PI ) out -= 2*M_PI;
+    while( out < -M_PI ) out += 2*M_PI;
+    return out;
+  }
 
   /// get radius from g4hit at either entrance or exit point
   float get_r( PHG4Hit* hit, int i )
@@ -88,6 +94,11 @@ QAG4SimulationMvtx::QAG4SimulationMvtx(const std::string &name)
 //________________________________________________________________________
 int QAG4SimulationMvtx::InitRun(PHCompositeNode *topNode)
 {
+
+  // prevent multiple creations of histograms
+  if( m_initialized ) return Fun4AllReturnCodes::EVENT_OK;
+  else m_initialized = true;
+
   // find mvtx geometry
   auto geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
   if (!geom_container)

--- a/offline/QA/modules/QAG4SimulationMvtx.h
+++ b/offline/QA/modules/QAG4SimulationMvtx.h
@@ -1,0 +1,63 @@
+#ifndef QA_QAG4SIMULATIONMVTX_H
+#define QA_QAG4SIMULATIONMVTX_H
+
+#include <fun4all/SubsysReco.h>
+#include <trackbase/TrkrDefs.h>
+
+#include <memory>
+#include <string>
+#include <set>
+#include <utility>
+
+class PHG4Hit;
+class PHG4HitContainer;
+class TrkrClusterContainer;
+class TrkrClusterHitAssoc;
+class TrkrHitTruthAssoc;
+
+/// \class QAG4SimulationMvtx
+class QAG4SimulationMvtx : public SubsysReco
+{
+
+  public:
+
+  /// constructor
+  QAG4SimulationMvtx(const std::string & name = "QAG4SimulationMvtx");
+
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+
+  private:
+
+  /// common prefix for QA histograms
+  std::string get_histo_prefix() const;
+
+  /// load nodes
+  int load_nodes( PHCompositeNode* );
+
+  /// evaluate clusters
+  void evaluate_clusters();
+
+  // get geant hits associated to a cluster
+  using G4HitSet = std::set<PHG4Hit*>;
+  G4HitSet find_g4hits( TrkrDefs::cluskey ) const;
+
+  /// cluster map
+  TrkrClusterContainer* m_cluster_map = nullptr;
+
+  /// clusters to hit association
+  TrkrClusterHitAssoc* m_cluster_hit_map = nullptr;
+
+  /// hit to g4hit association
+  TrkrHitTruthAssoc* m_hit_truth_map = nullptr;
+
+  /// g4 hits
+  PHG4HitContainer* m_g4hits_mvtx = nullptr;
+
+  /// list of relevant layers
+  /* it is filled at Init stage. It should not change for the full run */
+  std::set<int> m_layers;
+
+};
+
+#endif

--- a/offline/QA/modules/QAG4SimulationMvtx.h
+++ b/offline/QA/modules/QAG4SimulationMvtx.h
@@ -24,7 +24,7 @@ class QAG4SimulationMvtx : public SubsysReco
   /// constructor
   QAG4SimulationMvtx(const std::string & name = "QAG4SimulationMvtx");
 
-  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
 
   private:

--- a/offline/QA/modules/QAG4SimulationMvtx.h
+++ b/offline/QA/modules/QAG4SimulationMvtx.h
@@ -42,6 +42,9 @@ class QAG4SimulationMvtx : public SubsysReco
   using G4HitSet = std::set<PHG4Hit*>;
   G4HitSet find_g4hits( TrkrDefs::cluskey ) const;
 
+  /// true if histograms are initialized
+  bool m_initialized = false;
+
   /// cluster map
   TrkrClusterContainer* m_cluster_map = nullptr;
 

--- a/offline/QA/modules/QAG4SimulationMvtxLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationMvtxLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class QAG4SimulationMvtx - !;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
Per discussion with Jin, this PR adds a QA module for monitoring cluster distributions in the MVTX
For each MVTX layer 3 histograms are added for the phi direction and 3 for the z direction. They are: 
- the residuals (cluster - truth)
- the cluster error distribution
- the pull distribution (cluster - truth)/error
Ideally this last distribution should be centered on zero and with a RMS of unity

To get the truth information associated to a given cluster one
- gets the associated hits
- gets the G4Hits associated to these hits
- calculate a weighted average of the found set of G4Hits at the same radius as the original cluster. The used weight is the energy deposited by the G4Hit.

TODO: should double-check that this is consistent with what is done in g4eval.
Similar modules could easily be added to handle clusters in 
- INTT
- TPC

Additionally, one could consider adding cluster-track residuals, that could also be monitored in data.
