### PR TITLE
Few adjustment used in EIC beam pipe importing

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
@@ -15,6 +15,8 @@
 #include <g4main/PHG4Utils.h>
 
 #include <phparameter/PHParameters.h>
+#include <g4gdml/PHG4GDMLConfig.hh>
+#include <g4gdml/PHG4GDMLUtility.hh>
 
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4GDMLParser.hh>
@@ -48,7 +50,14 @@ PHG4GDMLDetector::PHG4GDMLDetector(PHG4Subsystem* subsys, PHCompositeNode* Node,
   , m_rotationX(parameters->get_double_param("rot_x") * degree)
   , m_rotationY(parameters->get_double_param("rot_y") * degree)
   , m_rotationZ(parameters->get_double_param("rot_z") * degree)
+  , m_skipDSTGeometryExport(parameters->get_int_param("skip_DST_geometry_export"))
+  , gdml_config(nullptr)
 {
+  if (m_skipDSTGeometryExport)
+  {
+    gdml_config = PHG4GDMLUtility::GetOrMakeConfigNode(Node);
+    assert(gdml_config);
+  }
 }
 
 PHG4GDMLDetector::~PHG4GDMLDetector()
@@ -98,7 +107,7 @@ void PHG4GDMLDetector::ConstructMe(G4LogicalVolume* logicWorld)
     Print();
     exit(121);
   }
-  PHG4Subsystem *mysys = GetMySubsystem();
+  PHG4Subsystem* mysys = GetMySubsystem();
   mysys->SetLogicalVolume(vol);
 
   G4RotationMatrix* rotm = new G4RotationMatrix();
@@ -109,11 +118,18 @@ void PHG4GDMLDetector::ConstructMe(G4LogicalVolume* logicWorld)
 
   //  av_ITSUStave->MakeImprint(trackerenvelope, Tr, 0, OverlapCheck());
 
-  new G4PVPlacement(rotm, placeVec,
-                    vol,
-                    G4String(GetName().c_str()),
-                    logicWorld, false, 0, OverlapCheck());
+  G4PVPlacement* gdml_phys =
+      new G4PVPlacement(rotm, placeVec,
+                        vol,
+                        G4String(GetName().c_str()),
+                        logicWorld, false, 0, OverlapCheck());
   SetDisplayProperty(vol);
+
+  if (m_skipDSTGeometryExport)
+  {
+    assert(gdml_config);
+    gdml_config->exclude_physical_vol(gdml_phys);
+  }
 }
 
 void PHG4GDMLDetector::SetDisplayProperty(G4AssemblyVolume* av)

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
@@ -25,6 +25,7 @@ class G4UserSteppingAction;
 class PHCompositeNode;
 class PHG4Subsystem;
 class PHParameters;
+class PHG4GDMLConfig;
 
 /*!
  * \brief PHG4GDMLDetector is a generic detector built from a GDML import
@@ -60,6 +61,11 @@ class PHG4GDMLDetector : public PHG4Detector
   G4double m_rotationX;
   G4double m_rotationY;
   G4double m_rotationZ;
+
+  int m_skipDSTGeometryExport;
+
+  //! registry for volumes that should not be exported, i.e. fibers
+  PHG4GDMLConfig* gdml_config;
 };
 
 #endif /* PHG4GDMLDetector_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
@@ -135,4 +135,6 @@ void PHG4GDMLSubsystem::SetDefaultParameters()
 
   set_default_string_param("GDMPath", "DefaultParameters-InvadPath");
   set_default_string_param("TopVolName", "DefaultParameters-InvadVol");
+
+  set_default_int_param("skip_DST_geometry_export", 0.);
 }

--- a/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.cc
+++ b/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.cc
@@ -121,9 +121,9 @@ ePHENIXRICHConstruction::Construct_RICH(G4LogicalVolume *WorldLog)
                                                                                geom.get_z_shift() * geom.get_frontwindow_DisplaceRatio()));
 
   G4VSolid *RICHConeBoundary = new G4Cons("RICHConeBoundary",  //
-                                          geom.get_R_beam_pipe(),
+                                          geom.get_R_beam_pipe_front(),
                                           geom.get_z_shift() / 2 * std::tan(2 * std::atan(std::exp(-geom.get_min_eta()))),  //            G4double pRmin1, G4double pRmax1,
-                                          geom.get_R_beam_pipe(),
+                                          geom.get_R_beam_pipe_back(),
                                           geom.get_cone_size_z() * std::tan(2 * std::atan(std::exp(-geom.get_min_eta()))),  //            G4double pRmin2, G4double pRmax2,
                                           (geom.get_cone_size_z() - (geom.get_z_shift() / 2)) / 2,                          //            G4double pDz,
                                           0, 2 * pi                                                                         //            G4double pSPhi, G4double pDPhi
@@ -137,7 +137,7 @@ ePHENIXRICHConstruction::Construct_RICH(G4LogicalVolume *WorldLog)
                                                               (geom.get_cone_size_z() - (geom.get_z_shift() / 2)) / 2 + (geom.get_z_shift() / 2)));
 
   G4VSolid *RICHSecBoundary = new G4Tubs("RICHSecBoundary",                       //
-                                         geom.get_R_beam_pipe(),                  //            G4double pRMin,
+                                         0,                  //            G4double pRMin,
                                          geom.get_cone_size_z(),                  //            G4double pRMax,
                                          geom.get_cone_size_z(),                  //            G4double pDz,
                                          pi / 2 - pi / geom.get_N_RICH_Sector(),  //            G4double pSPhi,
@@ -420,7 +420,8 @@ void RICH_Geometry::SetDefault()
 {
   N_RICH_Sector = 8;
   min_eta = 1;
-  R_beam_pipe = 3 * cm;
+  R_beam_pipe_front = 3 * cm;
+  R_beam_pipe_back = 3 * cm;
   z_shift = 100 * cm;
   R_shift = 40 * cm;
   frontwindow_DisplaceRatio = .85;  // Displace R,Z and radius simultainously

--- a/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.h
+++ b/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.h
@@ -111,9 +111,19 @@ class RICH_Geometry
   get_Rotation_HBD() const;
 
   double
-  get_R_beam_pipe() const
+  get_R_beam_pipe_front() const
   {
-    return R_beam_pipe;
+    return R_beam_pipe_front;
+  }
+  double
+  get_R_beam_pipe_back() const
+  {
+    return R_beam_pipe_back;
+  }
+  double
+  get_R_beam_pipe_min() const
+  {
+    return R_beam_pipe_front<R_beam_pipe_back ? R_beam_pipe_front : R_beam_pipe_back;
   }
 
   double
@@ -228,9 +238,19 @@ class RICH_Geometry
      */
   ///@{
   void
-  set_R_beam_pipe(double beamPipe)
+  set_R_beam_pipe_front(double beamPipe)
   {
-    R_beam_pipe = beamPipe;
+    R_beam_pipe_front = beamPipe;
+  }
+
+  /** @name Set Parameters
+     *  Group of functions to set parameters.
+     */
+  ///@{
+  void
+  set_R_beam_pipe_back(double beamPipe)
+  {
+    R_beam_pipe_back = beamPipe;
   }
 
   void
@@ -334,7 +354,8 @@ class RICH_Geometry
   int N_RICH_Sector;
 
   double min_eta;
-  double R_beam_pipe;
+  double R_beam_pipe_front;
+  double R_beam_pipe_back;
 
   double z_shift;
   double R_shift;

--- a/simulation/g4simulation/g4main/PHG4Utils.cc
+++ b/simulation/g4simulation/g4main/PHG4Utils.cc
@@ -114,7 +114,7 @@ void PHG4Utils::SetColour(G4VisAttributes* att, const string& material)
   }
   else if (material == "G4_Al")
   {
-    att->SetColour(G4Colour::Blue());
+    att->SetColour(G4Colour::Gray());
   }
   else if (material == "G4_Au")
   {


### PR DESCRIPTION
1. Use gray color for Al material in G4 display

2. Allow GDML import detector to determine whether to include its Geant4 simulation geometry in the DST geometry for offline. The default behavior does not change (do export for offline use)

The driving factor is beam pipe extension's CAD model can not be exported to offline (tessellated object) and not useful for Kaman filter anyway. The central pipe in acceptance is exported separately. 

3. Allow gas RICH's beam pipe opening to follow the beam pipe extension's contour. 
Note this change require an update to the G4_RICH.C macro. 

See below the macros pull request for use