### PR TITLE
Genfit lib64

### DIFF
--- a/offline/packages/PHGenFitPkg/GenFitExp/Makefile.am
+++ b/offline/packages/PHGenFitPkg/GenFitExp/Makefile.am
@@ -5,9 +5,10 @@ AM_CPPFLAGS = \
   -I$(OFFLINE_MAIN)/include \
   -I`root-config --incdir`
 
-libgenfit2exp_la_LDFLAGS = \
+AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
+  -L$(OFFLINE_MAIN)/lib64 \
   `root-config --libs`
 
 lib_LTLIBRARIES = \

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
@@ -84,13 +84,10 @@ Fitter::Fitter(
 
 Fitter::~Fitter()
 {
-  if (_fitter)
-    delete _fitter;
-  if (_tgeo_manager)
-    //delete _tgeo_manager;
-    //_tgeo_manager->Delete();
-    if (_display)
-      delete _display;
+  delete _fitter;
+  //delete _tgeo_manager;
+  //_tgeo_manager->Delete();
+  delete _display;
 }
 
 int Fitter::processTrack(PHGenFit::Track* track, const bool save_to_evt_disp)

--- a/offline/packages/PHGenFitPkg/PHGenFit/Makefile.am
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Makefile.am
@@ -6,9 +6,10 @@ AM_CPPFLAGS = \
   -I`root-config --incdir` \
   -I$(OFFLINE_MAIN)/include/eigen3
 
-libPHGenFit_la_LDFLAGS = \
+AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
+  -L$(OFFLINE_MAIN)/lib64 \
   `root-config --libs`
 
 lib_LTLIBRARIES = \

--- a/simulation/g4simulation/g4trackfastsim/Makefile.am
+++ b/simulation/g4simulation/g4trackfastsim/Makefile.am
@@ -15,8 +15,9 @@ AM_CPPFLAGS = \
 
 AM_LDFLAGS = \
   -L$(libdir) \
-  -L$(ROOTSYS)/lib \
-  -L$(OFFLINE_MAIN)/lib
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(OFFLINE_MAIN)/lib64 \
+  -L$(ROOTSYS)/lib
 
 libg4trackfastsim_la_LIBADD = \
   -lfun4all \


### PR DESCRIPTION
This PR adds $OFFLINE_MAIN/lib64 to the AM_LDFLAGS for packages linking against genfit. The default location of libgenfit2.so has changed from $OFFLINE_MAIN/lib to $OFFLINE_MAIN/lib64. Depending on the build type it is one or the other. With this change both locations are searched for libgenfit2.so