### PR TITLE
- Add hard-coded cluster error scale factors for intt and mvtx so tha…

### DIFF
--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -431,7 +431,7 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
 	float phisize = phibins.size() * pitch;
 	float zsize = zbins.size() * length;
 
-  static constexpr float invsqrt12 = 1./sqrt(12);
+  static const float invsqrt12 = 1./sqrt(12);
 
   // scale factors (phi direction)
   /*

--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -360,7 +360,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
 	double phisize = phibins.size() * pitch;
 	double zsize = zbins.size() * length;
 
-  static constexpr double invsqrt12 = 1./std::sqrt(12);
+  static const double invsqrt12 = 1./std::sqrt(12);
 
   // scale factors (phi direction)
   /*


### PR DESCRIPTION
This PR adds ad-hoc correction factors to the calculation of cluster errors, based on cluster sizes, so that pull distributions at both the cluster level and the track level have a width around unity.
Details on the resulting distributions is at https://www.phenix.bnl.gov/WWW/p/draft/hpereira/sphenix/Software_meeting_2020_05_05/talk.pdf
So far, the impact on the tracking is rather small: chisquare distribution is slightly larger, which is expected since pulls have increased. Momentum resolution is not changed significantly.
For now all factors are hard coded. They will need to be updated whenever upstream simulation parameters are changed or when real data will be available. 
Results are tracked by corresponding QA module (for now for MVTX only. Equivalent QA module for INTT will come soon)