### PR TITLE
Change lengthviarapidity default

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -7,6 +7,8 @@
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4Subsystem.h>
 
+#include <phool/phool.h>
+
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
@@ -62,10 +64,19 @@ void PHG4CylinderDetector::ConstructMe(G4LogicalVolume *logicWorld)
   // determine length of cylinder using PHENIX's rapidity coverage if flag is true
   double radius = m_Params->get_double_param("radius") * cm;
   double thickness = m_Params->get_double_param("thickness") * cm;
+  double length = m_Params->get_double_param("length") * cm;
+  if (!isfinite(radius) || !isfinite(thickness) || !isfinite(length))
+  {
+    cout << PHWHERE << ": Bad Parameters for " << GetName() << endl;
+    cout << "Radius: " << radius << endl;
+    cout << "Thickness: " << thickness << endl;
+    cout << "Length: " << length << endl;
+    gSystem->Exit(1);
+  }
   G4VSolid *cylinder_solid = new G4Tubs(G4String(GetName()),
                                         radius,
                                         radius + thickness,
-                                        m_Params->get_double_param("length") * cm / 2., 0, twopi);
+                                        length / 2., 0, twopi);
   double steplimits = m_Params->get_double_param("steplimits") * cm;
   G4UserLimits *g4userlimits = nullptr;
   if (isfinite(steplimits))

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -155,7 +155,7 @@ void PHG4CylinderSubsystem::SetDefaultParameters()
   set_default_double_param("tmin", NAN);
   set_default_double_param("tmax", NAN);
 
-  set_default_int_param("lengthviarapidity", 1);
+  set_default_int_param("lengthviarapidity", 0);
   set_default_int_param("lightyield", 0);
   set_default_int_param("use_g4steps", 0);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -19,8 +19,6 @@
 #include <phool/PHObject.h>              // for PHObject
 #include <phool/getClass.h>
 
-#include <Geant4/G4Types.hh>             // for G4double
-
 #include <cmath>                        // for NAN
 #include <iostream>                      // for operator<<, basic_ostream, endl
 #include <sstream>
@@ -50,9 +48,15 @@ PHG4CylinderSubsystem::~PHG4CylinderSubsystem()
 int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
   // create hit list only for active layers
-  if (GetParams()->get_int_param("lengthviarapidity"))
+  double detlength = GetParams()->get_double_param("length");
+  if (!isfinite(detlength) && GetParams()->get_int_param("lengthviarapidity"))
   {
     GetParams()->set_double_param("length", PHG4Utils::GetLengthForRapidityCoverage(GetParams()->get_double_param("radius") + GetParams()->get_double_param("thickness")) * 2);
+    detlength = GetParams()->get_double_param("length");
+  }
+  else
+  {
+    GetParams()->set_double_param("lengthviarapidity",0);
   }
   // create display settings before detector
   PHG4CylinderDisplayAction *disp_action = new PHG4CylinderDisplayAction(Name(), GetParams());
@@ -67,7 +71,6 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 
   // create detector
   m_Detector = new PHG4CylinderDetector(this, topNode, GetParams(), Name(), GetLayer());
-  G4double detlength = GetParams()->get_double_param("length");
   m_Detector->SuperDetector(SuperDetector());
   m_Detector->OverlapCheck(CheckOverlap());
   if (GetParams()->get_int_param("active"))
@@ -145,17 +148,17 @@ int PHG4CylinderSubsystem::process_event(PHCompositeNode *topNode)
 
 void PHG4CylinderSubsystem::SetDefaultParameters()
 {
-  set_default_double_param("length", 100);
+  set_default_double_param("length", NAN);
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);
   set_default_double_param("place_z", 0.);
-  set_default_double_param("radius", 100);
+  set_default_double_param("radius", NAN);
   set_default_double_param("steplimits", NAN);
-  set_default_double_param("thickness", 100);
+  set_default_double_param("thickness", NAN);
   set_default_double_param("tmin", NAN);
   set_default_double_param("tmax", NAN);
 
-  set_default_int_param("lengthviarapidity", 0);
+  set_default_int_param("lengthviarapidity", 1);
   set_default_int_param("lightyield", 0);
   set_default_int_param("use_g4steps", 0);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -7,20 +7,20 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4DisplayAction.h>    // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>   // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4Utils.h>
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>          // for PHIODataNode
-#include <phool/PHNode.h>                // for PHNode
-#include <phool/PHNodeIterator.h>        // for PHNodeIterator
-#include <phool/PHObject.h>              // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
-#include <cmath>                        // for NAN
-#include <iostream>                      // for operator<<, basic_ostream, endl
+#include <cmath>     // for NAN
+#include <iostream>  // for operator<<, basic_ostream, endl
 #include <sstream>
 
 class PHG4CylinderGeom;
@@ -56,7 +56,7 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   }
   else
   {
-    GetParams()->set_double_param("lengthviarapidity",0);
+    GetParams()->set_double_param("lengthviarapidity", 0);
   }
   // create display settings before detector
   PHG4CylinderDisplayAction *disp_action = new PHG4CylinderDisplayAction(Name(), GetParams());
@@ -65,7 +65,7 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
       isfinite(m_ColorArray[2]) &&
       isfinite(m_ColorArray[3]))
   {
-    disp_action->SetColor(m_ColorArray[0], m_ColorArray[1],m_ColorArray[2],m_ColorArray[3]);
+    disp_action->SetColor(m_ColorArray[0], m_ColorArray[1], m_ColorArray[2], m_ColorArray[3]);
   }
   m_DisplayAction = disp_action;
 


### PR DESCRIPTION
This PR was long overdue - so far one had to set lengthviarapidity explicitly to zero if one set the length, otherwise the length was silently set to +- 1.1 rapidity coverage. That just confused everybody. Now if the length is set it is used and the lengthviarapidity flag is set to zero. If the length is not set the rapidity coverage is chosen, so the old default behavior is preserved. The length, thickness and radius are initialized to NAN, before the cylinder is created those values are checked to be finite 