### PR TITLE
Upstream/master qa intt

### DIFF
--- a/offline/QA/modules/Makefile.am
+++ b/offline/QA/modules/Makefile.am
@@ -25,6 +25,7 @@ libqa_modules_la_LIBADD = \
 pkginclude_HEADERS = \
 	QAG4SimulationCalorimeter.h \
 	QAG4SimulationCalorimeterSum.h \
+	QAG4SimulationIntt.h \
 	QAG4SimulationJet.h \
 	QAG4SimulationMvtx.h \
 	QAG4SimulationTracking.h \
@@ -35,6 +36,7 @@ if ! MAKEROOT6
 	ROOT5DICTS = \
 		QAG4SimulationCalorimeter_Dict.cc \
 		QAG4SimulationCalorimeterSum_Dict.cc \
+		QAG4SimulationIntt_Dict.cc \
 		QAG4SimulationJet_Dict.cc \
 		QAG4SimulationMvtx_Dict.cc \
 		QAG4SimulationTracking_Dict.cc \
@@ -46,6 +48,7 @@ libqa_modules_la_SOURCES = \
 	$(ROOT5DICTS) \
 	QAG4SimulationCalorimeter.cc \
 	QAG4SimulationCalorimeterSum.cc \
+	QAG4SimulationIntt.cc \
 	QAG4SimulationJet.cc \
 	QAG4SimulationMvtx.cc \
 	QAG4SimulationTracking.cc \

--- a/offline/QA/modules/QAG4SimulationIntt.cc
+++ b/offline/QA/modules/QAG4SimulationIntt.cc
@@ -42,7 +42,7 @@ int QAG4SimulationIntt::InitRun(PHCompositeNode *topNode)
   const auto range = geom_container->get_begin_end();
   for( auto iter = range.first; iter != range.second; ++iter )
   { m_layers.insert( iter->first ); }
-
+  
   // histogram manager
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
@@ -53,14 +53,14 @@ int QAG4SimulationIntt::InitRun(PHCompositeNode *topNode)
     std::cout << PHWHERE << " adding layer " << layer << std::endl;
     {
       // rphi residuals (cluster - truth)
-      auto h = new TH1F( Form( "%sdrphi_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi_{cluster-truth} layer_%i", layer ), 100, -2e-3, 2e-3 );
+      auto h = new TH1F( Form( "%sdrphi_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi_{cluster-truth} layer_%i", layer ), 100, -1e-2, 1e-2 );
       h->GetXaxis()->SetTitle( "r#Delta#phi_{cluster-truth} (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // rphi cluster errors
-      auto h = new TH1F( Form( "%srphi_error_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi error layer_%i", layer ), 100, 0, 2e-3 );
+      auto h = new TH1F( Form( "%srphi_error_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi error layer_%i", layer ), 100, 0, 1e-2 );
       h->GetXaxis()->SetTitle( "r#Delta#phi error (cm)" );
       hm->registerHisto(h);
     }
@@ -74,14 +74,14 @@ int QAG4SimulationIntt::InitRun(PHCompositeNode *topNode)
 
     {
       // z residuals (cluster - truth)
-      auto h = new TH1F( Form( "%sdz_%i", get_histo_prefix().c_str(), layer ), Form( "#Deltaz_{cluster-truth} layer_%i", layer ), 100, -3e-3, 3e-3 );
+      auto h = new TH1F( Form( "%sdz_%i", get_histo_prefix().c_str(), layer ), Form( "#Deltaz_{cluster-truth} layer_%i", layer ), 100, -2.5, 2.5 );
       h->GetXaxis()->SetTitle( "#Delta#z_{cluster-truth} (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z cluster errors
-      auto h = new TH1F( Form( "%sz_error_%i", get_histo_prefix().c_str(), layer ), Form( "z error layer_%i", layer ), 100, 0, 3e-3 );
+      auto h = new TH1F( Form( "%sz_error_%i", get_histo_prefix().c_str(), layer ), Form( "z error layer_%i", layer ), 100, 0, 2.5 );
       h->GetXaxis()->SetTitle( "z error (cm)" );
       hm->registerHisto(h);
     }

--- a/offline/QA/modules/QAG4SimulationIntt.cc
+++ b/offline/QA/modules/QAG4SimulationIntt.cc
@@ -1,4 +1,4 @@
-#include "QAG4SimulationMvtx.h"
+#include "QAG4SimulationIntt.h"
 #include "QAG4Util.h"
 #include "QAHistManagerDef.h"
 
@@ -18,27 +18,27 @@
 #include <cassert>
 
 //________________________________________________________________________
-QAG4SimulationMvtx::QAG4SimulationMvtx(const std::string &name)
+QAG4SimulationIntt::QAG4SimulationIntt(const std::string &name)
   : SubsysReco(name)
 {}
 
 //________________________________________________________________________
-int QAG4SimulationMvtx::InitRun(PHCompositeNode *topNode)
+int QAG4SimulationIntt::InitRun(PHCompositeNode *topNode)
 {
 
   // prevent multiple creations of histograms
   if( m_initialized ) return Fun4AllReturnCodes::EVENT_OK;
   else m_initialized = true;
 
-  // find mvtx geometry
-  auto geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
+  // find intt geometry
+  auto geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
   if (!geom_container)
   {
-    std::cout << PHWHERE << " unable to find DST node CYLINDERGEOM_MVTX" << std::endl;
+    std::cout << PHWHERE << " unable to find DST node CYLINDERGEOM_INTT" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  // get layers from mvtx geometry
+  // get layers from intt geometry
   const auto range = geom_container->get_begin_end();
   for( auto iter = range.first; iter != range.second; ++iter )
   { m_layers.insert( iter->first ); }
@@ -100,7 +100,7 @@ int QAG4SimulationMvtx::InitRun(PHCompositeNode *topNode)
 }
 
 //_____________________________________________________________________
-int QAG4SimulationMvtx::process_event(PHCompositeNode* topNode)
+int QAG4SimulationIntt::process_event(PHCompositeNode* topNode)
 {
   // load nodes
   auto res =  load_nodes(topNode);
@@ -112,11 +112,11 @@ int QAG4SimulationMvtx::process_event(PHCompositeNode* topNode)
 }
 
 //________________________________________________________________________
-std::string QAG4SimulationMvtx::get_histo_prefix() const
+std::string QAG4SimulationIntt::get_histo_prefix() const
 { return std::string("h_") + Name() + std::string("_"); }
 
 //________________________________________________________________________
-int QAG4SimulationMvtx::load_nodes( PHCompositeNode* topNode )
+int QAG4SimulationIntt::load_nodes( PHCompositeNode* topNode )
 {
   m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if( !m_cluster_map )
@@ -139,10 +139,10 @@ int QAG4SimulationMvtx::load_nodes( PHCompositeNode* topNode )
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  m_g4hits_mvtx = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_MVTX");
-  if( !m_g4hits_mvtx )
+  m_g4hits_intt = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_INTT");
+  if( !m_g4hits_intt )
   {
-    std::cout << PHWHERE << " unable to find DST node G4HIT_MVTX" << std::endl;
+    std::cout << PHWHERE << " unable to find DST node G4HIT_INTT" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -150,7 +150,7 @@ int QAG4SimulationMvtx::load_nodes( PHCompositeNode* topNode )
 }
 
 //________________________________________________________________________
-void QAG4SimulationMvtx::evaluate_clusters()
+void QAG4SimulationIntt::evaluate_clusters()
 {
 
   // histogram manager
@@ -193,7 +193,7 @@ void QAG4SimulationMvtx::evaluate_clusters()
     // get cluster key, detector id and check
     const auto& key = clusterIter->first;
     const auto detId = TrkrDefs::getTrkrId( key );
-    if( detId != TrkrDefs::mvtxId ) continue;
+    if( detId != TrkrDefs::inttId ) continue;
 
     // get cluster
     const auto& cluster = clusterIter->second;
@@ -236,7 +236,7 @@ void QAG4SimulationMvtx::evaluate_clusters()
 }
 
 //_____________________________________________________________________
-QAG4SimulationMvtx::G4HitSet QAG4SimulationMvtx::find_g4hits( TrkrDefs::cluskey cluster_key ) const
+QAG4SimulationIntt::G4HitSet QAG4SimulationIntt::find_g4hits( TrkrDefs::cluskey cluster_key ) const
 {
 
   // check maps
@@ -266,8 +266,8 @@ QAG4SimulationMvtx::G4HitSet QAG4SimulationMvtx::find_g4hits( TrkrDefs::cluskey 
       const auto g4hit_key = truth_iter->second.second;
 
       // g4 hit
-      PHG4Hit* g4hit = ( TrkrDefs::getTrkrId( hitset_key ) == TrkrDefs::mvtxId ) ?
-        m_g4hits_mvtx->findHit( g4hit_key ):nullptr;
+      PHG4Hit* g4hit = ( TrkrDefs::getTrkrId( hitset_key ) == TrkrDefs::inttId ) ?
+        m_g4hits_intt->findHit( g4hit_key ):nullptr;
 
       // insert in set
       if( g4hit ) out.insert( g4hit );

--- a/offline/QA/modules/QAG4SimulationIntt.cc
+++ b/offline/QA/modules/QAG4SimulationIntt.cc
@@ -54,42 +54,42 @@ int QAG4SimulationIntt::InitRun(PHCompositeNode *topNode)
     {
       // rphi residuals (cluster - truth)
       auto h = new TH1F( Form( "%sdrphi_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi_{cluster-truth} layer_%i", layer ), 100, -1e-2, 1e-2 );
-      h->GetXaxis()->SetTitle( "r#Delta#phi_{cluster-truth} (cm)" );
+      h->GetXaxis()->SetTitle( "INTT r#Delta#phi_{cluster-truth} (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // rphi cluster errors
       auto h = new TH1F( Form( "%srphi_error_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi error layer_%i", layer ), 100, 0, 1e-2 );
-      h->GetXaxis()->SetTitle( "r#Delta#phi error (cm)" );
+      h->GetXaxis()->SetTitle( "INTT r#Delta#phi error (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // phi pulls (cluster - truth)
       auto h = new TH1F( Form( "%sphi_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "#Delta#phi_{cluster-truth}/#sigma#phi layer_%i", layer ), 100, -3, 3 );
-      h->GetXaxis()->SetTitle( "#Delta#phi_{cluster-truth}/#sigma#phi (cm)" );
+      h->GetXaxis()->SetTitle( "INTT #Delta#phi_{cluster-truth}/#sigma#phi (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z residuals (cluster - truth)
       auto h = new TH1F( Form( "%sdz_%i", get_histo_prefix().c_str(), layer ), Form( "#Deltaz_{cluster-truth} layer_%i", layer ), 100, -2.5, 2.5 );
-      h->GetXaxis()->SetTitle( "#Delta#z_{cluster-truth} (cm)" );
+      h->GetXaxis()->SetTitle( "INTT #Delta#z_{cluster-truth} (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z cluster errors
       auto h = new TH1F( Form( "%sz_error_%i", get_histo_prefix().c_str(), layer ), Form( "z error layer_%i", layer ), 100, 0, 2.5 );
-      h->GetXaxis()->SetTitle( "z error (cm)" );
+      h->GetXaxis()->SetTitle( "INTT z error (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z pulls (cluster - truth)
       auto h = new TH1F( Form( "%sz_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "#Deltaz_{cluster-truth}/#sigmaz layer_%i", layer ), 100, -3, 3 );
-      h->GetXaxis()->SetTitle( "#Delta#z_{cluster-truth}/#sigmaz (cm)" );
+      h->GetXaxis()->SetTitle( "INTT #Delta#z_{cluster-truth}/#sigmaz (cm)" );
       hm->registerHisto(h);
     }
 

--- a/offline/QA/modules/QAG4SimulationIntt.h
+++ b/offline/QA/modules/QAG4SimulationIntt.h
@@ -1,0 +1,66 @@
+#ifndef QA_QAG4SIMULATIONINTT_H
+#define QA_QAG4SIMULATIONINTT_H
+
+#include <fun4all/SubsysReco.h>
+#include <trackbase/TrkrDefs.h>
+
+#include <memory>
+#include <string>
+#include <set>
+#include <utility>
+
+class PHG4Hit;
+class PHG4HitContainer;
+class TrkrClusterContainer;
+class TrkrClusterHitAssoc;
+class TrkrHitTruthAssoc;
+
+/// \class QAG4SimulationIntt
+class QAG4SimulationIntt : public SubsysReco
+{
+
+  public:
+
+  /// constructor
+  QAG4SimulationIntt(const std::string & name = "QAG4SimulationIntt");
+
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+
+  private:
+
+  /// common prefix for QA histograms
+  std::string get_histo_prefix() const;
+
+  /// load nodes
+  int load_nodes( PHCompositeNode* );
+
+  /// evaluate clusters
+  void evaluate_clusters();
+
+  // get geant hits associated to a cluster
+  using G4HitSet = std::set<PHG4Hit*>;
+  G4HitSet find_g4hits( TrkrDefs::cluskey ) const;
+
+  /// true if histograms are initialized
+  bool m_initialized = false;
+
+  /// cluster map
+  TrkrClusterContainer* m_cluster_map = nullptr;
+
+  /// clusters to hit association
+  TrkrClusterHitAssoc* m_cluster_hit_map = nullptr;
+
+  /// hit to g4hit association
+  TrkrHitTruthAssoc* m_hit_truth_map = nullptr;
+
+  /// g4 hits
+  PHG4HitContainer* m_g4hits_intt = nullptr;
+
+  /// list of relevant layers
+  /* it is filled at Init stage. It should not change for the full run */
+  std::set<int> m_layers;
+
+};
+
+#endif

--- a/offline/QA/modules/QAG4SimulationInttLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationInttLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class QAG4SimulationIntt - !;
+
+#endif /* __CINT__ */

--- a/offline/QA/modules/QAG4SimulationMvtx.cc
+++ b/offline/QA/modules/QAG4SimulationMvtx.cc
@@ -54,42 +54,42 @@ int QAG4SimulationMvtx::InitRun(PHCompositeNode *topNode)
     {
       // rphi residuals (cluster - truth)
       auto h = new TH1F( Form( "%sdrphi_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi_{cluster-truth} layer_%i", layer ), 100, -2e-3, 2e-3 );
-      h->GetXaxis()->SetTitle( "r#Delta#phi_{cluster-truth} (cm)" );
+      h->GetXaxis()->SetTitle( "MVTX r#Delta#phi_{cluster-truth} (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // rphi cluster errors
       auto h = new TH1F( Form( "%srphi_error_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi error layer_%i", layer ), 100, 0, 2e-3 );
-      h->GetXaxis()->SetTitle( "r#Delta#phi error (cm)" );
+      h->GetXaxis()->SetTitle( "MVTX r#Delta#phi error (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // phi pulls (cluster - truth)
       auto h = new TH1F( Form( "%sphi_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "#Delta#phi_{cluster-truth}/#sigma#phi layer_%i", layer ), 100, -3, 3 );
-      h->GetXaxis()->SetTitle( "#Delta#phi_{cluster-truth}/#sigma#phi (cm)" );
+      h->GetXaxis()->SetTitle( "MVTX #Delta#phi_{cluster-truth}/#sigma#phi (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z residuals (cluster - truth)
       auto h = new TH1F( Form( "%sdz_%i", get_histo_prefix().c_str(), layer ), Form( "#Deltaz_{cluster-truth} layer_%i", layer ), 100, -3e-3, 3e-3 );
-      h->GetXaxis()->SetTitle( "#Delta#z_{cluster-truth} (cm)" );
+      h->GetXaxis()->SetTitle( "MVTX #Delta#z_{cluster-truth} (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z cluster errors
       auto h = new TH1F( Form( "%sz_error_%i", get_histo_prefix().c_str(), layer ), Form( "z error layer_%i", layer ), 100, 0, 3e-3 );
-      h->GetXaxis()->SetTitle( "z error (cm)" );
+      h->GetXaxis()->SetTitle( "MVTX z error (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z pulls (cluster - truth)
       auto h = new TH1F( Form( "%sz_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "#Deltaz_{cluster-truth}/#sigmaz layer_%i", layer ), 100, -3, 3 );
-      h->GetXaxis()->SetTitle( "#Delta#z_{cluster-truth}/#sigmaz (cm)" );
+      h->GetXaxis()->SetTitle( "MVTX #Delta#z_{cluster-truth}/#sigmaz (cm)" );
       hm->registerHisto(h);
     }
 

--- a/offline/QA/modules/QAG4Util.h
+++ b/offline/QA/modules/QAG4Util.h
@@ -1,0 +1,79 @@
+#ifndef QA_QAG4UTIL_H
+#define QA_QAG4UTIL_H
+
+/*!
+ * \file QAG4Util.h
+ * \brief some common utility functions used in detector specific evaluation modules
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include <g4main/PHG4Hit.h>
+
+#include <cmath>
+
+// utility functions
+namespace QAG4Util
+{
+
+  /// square
+  template<class T> inline constexpr T square( T x ) { return x*x; }
+
+  /// radius
+  template<class T> inline constexpr T get_r( T x, T y ) { return std::sqrt( square(x) + square(y) ); }
+
+  /// angle difference between [-pi, pi[
+  template<class T> inline const T delta_phi( T phi1, T phi2 )
+  {
+    auto out = phi1-phi2;
+    while( out >= M_PI ) out -= 2*M_PI;
+    while( out < -M_PI ) out += 2*M_PI;
+    return out;
+  }
+
+  /// calculate the best average of member function called on all members in collection, extrapolated at a given radius
+  /** each hit is weighted by its deposited energy */
+  template< float (PHG4Hit::*accessor)(int) const>
+  float interpolate( std::set<PHG4Hit*> hits, float rextrap )
+  {
+    // calculate all terms needed for the interpolation
+    // need to use double everywhere here due to numerical divergences
+    double sw = 0;
+    double swr = 0;
+    double swr2 = 0;
+    double swx = 0;
+    double swrx = 0;
+
+    bool valid( false );
+    for( const auto& hit:hits )
+    {
+
+      const double x0 = (hit->*accessor)(0);
+      const double x1 = (hit->*accessor)(1);
+      if( std::isnan( x0 ) || std::isnan( x1 ) ) continue;
+
+      const double w = hit->get_edep();
+      if( w < 0 ) continue;
+
+      valid = true;
+      const double r0 = get_r( hit->get_x(0), hit->get_y(0) );
+      const double r1 = get_r( hit->get_x(1), hit->get_y(1) );
+
+      sw += w*2;
+      swr += w*(r0 + r1);
+      swr2 += w*(square(r0) + square(r1));
+      swx += w*(x0 + x1);
+      swrx += w*(r0*x0 + r1*x1);
+    }
+
+    if( !valid ) return NAN;
+
+    const auto alpha = (sw*swrx - swr*swx);
+    const auto beta = (swr2*swx - swr*swrx);
+    const auto denom = (sw*swr2 - square(swr));
+
+    return ( alpha*rextrap + beta )/denom;
+  }
+
+}
+
+#endif


### PR DESCRIPTION
This PR adds a QA module for INTT cluster residuals and pulls, similar to that of the MVTX.
Utility functions that are common to both modules have been moved to a separater (header only) file: QAG4Util.h. Finally, detector name has been added to histogram titles, for clarity.  