### PR TITLE
Update params nodetree

### DIFF
--- a/offline/database/PHParameter/PHParameters.cc
+++ b/offline/database/PHParameter/PHParameters.cc
@@ -367,6 +367,27 @@ void PHParameters::SaveToNodeTree(PHCompositeNode *topNode, const string &nodena
   return;
 }
 
+void PHParameters::UpdateNodeTree(PHCompositeNode *topNode, const string &nodename, const int detid)
+{
+  // write itself since this class is fine with saving by root
+  PdbParameterMapContainer *nodeparamcontainer = findNode::getClass<PdbParameterMapContainer>(topNode, nodename);
+  if (!nodeparamcontainer)
+  {
+    cout << PHWHERE << " could not find PdbParameterMapContainer " << nodename
+	 << " which must exist" << endl;
+    gSystem->Exit(1);
+  }
+  PdbParameterMap *nodeparams = nodeparamcontainer->GetParametersToModify(detid);
+  if (! nodeparams)
+  {
+    cout << PHWHERE << " could not find PdbParameterMap for detector " << detid
+	 << " which must exist" << endl;
+    gSystem->Exit(1);
+  }
+  CopyToPdbParameterMap(nodeparams);
+  return;
+}
+
 int PHParameters::WriteToDB()
 {
   PdbBankManager *bankManager = PdbBankManager::instance();

--- a/offline/database/PHParameter/PHParameters.cc
+++ b/offline/database/PHParameter/PHParameters.cc
@@ -76,6 +76,7 @@ int PHParameters::get_int_param(const std::string &name) const
        << " does not exist (forgot to set?)" << endl;
   cout << "Here is the stacktrace: " << endl;
   cout << boost::stacktrace::stacktrace();
+  cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
   cout << "Check the stacktrace for the guilty party (typically #2)" << endl;
   gSystem->Exit(1);
   exit(1);
@@ -117,6 +118,7 @@ PHParameters::get_double_param(const std::string &name) const
        << " does not exist (forgot to set?)" << endl;
   cout << "Here is the stacktrace: " << endl;
   cout << boost::stacktrace::stacktrace();
+  cout <<  endl << "DO NOT PANIC - this is not a segfault" << endl;
   cout << "Check the stacktrace for the guilty party (typically #2)" << endl;
 
   gSystem->Exit(1);
@@ -203,6 +205,7 @@ PHParameters::get_string_param(const std::string &name) const
        << " does not exist (forgot to set?)" << endl;
   cout << "Here is the stacktrace: " << endl;
   cout << boost::stacktrace::stacktrace();
+  cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
   cout << "Check the stacktrace for the guilty party (typically #2)" << endl;
   gSystem->Exit(1);
   exit(1);
@@ -342,6 +345,20 @@ void PHParameters::SaveToNodeTree(PHCompositeNode *topNode, const string &nodena
   return;
 }
 
+void PHParameters::UpdateNodeTree(PHCompositeNode *topNode, const string &nodename)
+{
+  PdbParameterMap *nodeparams = findNode::getClass<PdbParameterMap>(topNode,
+                                                                    nodename);
+  if (!nodeparams)
+  {
+    cout << PHWHERE << " could not find PdbParameterMap " << nodename
+	 << " which must exist" << endl;
+    gSystem->Exit(1);
+  }
+  CopyToPdbParameterMap(nodeparams);
+  return;
+}
+
 void PHParameters::SaveToNodeTree(PHCompositeNode *topNode, const string &nodename, const int detid)
 {
   // write itself since this class is fine with saving by root
@@ -369,7 +386,6 @@ void PHParameters::SaveToNodeTree(PHCompositeNode *topNode, const string &nodena
 
 void PHParameters::UpdateNodeTree(PHCompositeNode *topNode, const string &nodename, const int detid)
 {
-  // write itself since this class is fine with saving by root
   PdbParameterMapContainer *nodeparamcontainer = findNode::getClass<PdbParameterMapContainer>(topNode, nodename);
   if (!nodeparamcontainer)
   {

--- a/offline/database/PHParameter/PHParameters.cc
+++ b/offline/database/PHParameter/PHParameters.cc
@@ -76,7 +76,8 @@ int PHParameters::get_int_param(const std::string &name) const
        << " does not exist (forgot to set?)" << endl;
   cout << "Here is the stacktrace: " << endl;
   cout << boost::stacktrace::stacktrace();
-  cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
+  cout << endl
+       << "DO NOT PANIC - this is not a segfault" << endl;
   cout << "Check the stacktrace for the guilty party (typically #2)" << endl;
   gSystem->Exit(1);
   exit(1);
@@ -118,7 +119,8 @@ PHParameters::get_double_param(const std::string &name) const
        << " does not exist (forgot to set?)" << endl;
   cout << "Here is the stacktrace: " << endl;
   cout << boost::stacktrace::stacktrace();
-  cout <<  endl << "DO NOT PANIC - this is not a segfault" << endl;
+  cout << endl
+       << "DO NOT PANIC - this is not a segfault" << endl;
   cout << "Check the stacktrace for the guilty party (typically #2)" << endl;
 
   gSystem->Exit(1);
@@ -205,7 +207,8 @@ PHParameters::get_string_param(const std::string &name) const
        << " does not exist (forgot to set?)" << endl;
   cout << "Here is the stacktrace: " << endl;
   cout << boost::stacktrace::stacktrace();
-  cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
+  cout << endl
+       << "DO NOT PANIC - this is not a segfault" << endl;
   cout << "Check the stacktrace for the guilty party (typically #2)" << endl;
   gSystem->Exit(1);
   exit(1);
@@ -352,7 +355,7 @@ void PHParameters::UpdateNodeTree(PHCompositeNode *topNode, const string &nodena
   if (!nodeparams)
   {
     cout << PHWHERE << " could not find PdbParameterMap " << nodename
-	 << " which must exist" << endl;
+         << " which must exist" << endl;
     gSystem->Exit(1);
   }
   CopyToPdbParameterMap(nodeparams);
@@ -390,14 +393,14 @@ void PHParameters::UpdateNodeTree(PHCompositeNode *topNode, const string &nodena
   if (!nodeparamcontainer)
   {
     cout << PHWHERE << " could not find PdbParameterMapContainer " << nodename
-	 << " which must exist" << endl;
+         << " which must exist" << endl;
     gSystem->Exit(1);
   }
   PdbParameterMap *nodeparams = nodeparamcontainer->GetParametersToModify(detid);
-  if (! nodeparams)
+  if (!nodeparams)
   {
     cout << PHWHERE << " could not find PdbParameterMap for detector " << detid
-	 << " which must exist" << endl;
+         << " which must exist" << endl;
     gSystem->Exit(1);
   }
   CopyToPdbParameterMap(nodeparams);

--- a/offline/database/PHParameter/PHParameters.h
+++ b/offline/database/PHParameter/PHParameters.h
@@ -65,8 +65,11 @@ class PHParameters : public PHObject
   void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename);
   // save parameters in container on node tree
   void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename, const int layer);
+
 // update parameters on node tree (in case the subsystem modified them)
+  void UpdateNodeTree(PHCompositeNode *topNode, const std::string &nodename);
   void UpdateNodeTree(PHCompositeNode *topNode, const std::string &nodename, const int layer);
+
   int WriteToDB();
   int ReadFromDB();
   int ReadFromDB(const std::string &name, const int layer);

--- a/offline/database/PHParameter/PHParameters.h
+++ b/offline/database/PHParameter/PHParameters.h
@@ -65,6 +65,8 @@ class PHParameters : public PHObject
   void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename);
   // save parameters in container on node tree
   void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename, const int layer);
+// update parameters on node tree (in case the subsystem modified them)
+  void UpdateNodeTree(PHCompositeNode *topNode, const std::string &nodename, const int layer);
   int WriteToDB();
   int ReadFromDB();
   int ReadFromDB(const std::string &name, const int layer);

--- a/offline/database/PHParameter/PHParameters.h
+++ b/offline/database/PHParameter/PHParameters.h
@@ -66,7 +66,7 @@ class PHParameters : public PHObject
   // save parameters in container on node tree
   void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename, const int layer);
 
-// update parameters on node tree (in case the subsystem modified them)
+  // update parameters on node tree (in case the subsystem modified them)
   void UpdateNodeTree(PHCompositeNode *topNode, const std::string &nodename);
   void UpdateNodeTree(PHCompositeNode *topNode, const std::string &nodename, const int layer);
 

--- a/offline/database/PHParameter/PHParametersContainer.cc
+++ b/offline/database/PHParameter/PHParametersContainer.cc
@@ -103,7 +103,8 @@ PHParametersContainer::GetParameters(const int detid) const
          << endl;
     cout << "Here is the stacktrace: " << endl;
     cout << boost::stacktrace::stacktrace();
-    cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
+    cout << endl
+         << "DO NOT PANIC - this is not a segfault" << endl;
     cout << "Check the stacktrace for the guilty party (typically #2)" << endl;
     gSystem->Exit(1);
     exit(1);
@@ -203,7 +204,6 @@ void PHParametersContainer::CopyToPdbParameterMapContainer(PdbParameterMapContai
   std::map<int, PHParameters *>::const_iterator iter;
   for (iter = parametermap.begin(); iter != parametermap.end(); ++iter)
   {
-
     PdbParameterMap *myparm = new PdbParameterMap();
     iter->second->CopyToPdbParameterMap(myparm);
     myparmap->AddPdbParameterMap(iter->first, myparm);
@@ -258,7 +258,7 @@ void PHParametersContainer::UpdateNodeTree(PHCompositeNode *topNode, const strin
   if (!myparmap)
   {
     cout << PHWHERE << " could not find PdbParameterMapContainer " << nodename
-	 << " which must exist" << endl;
+         << " which must exist" << endl;
     gSystem->Exit(1);
   }
   UpdatePdbParameterMapContainer(myparmap);

--- a/offline/database/PHParameter/PHParametersContainer.cc
+++ b/offline/database/PHParameter/PHParametersContainer.cc
@@ -103,6 +103,7 @@ PHParametersContainer::GetParameters(const int detid) const
          << endl;
     cout << "Here is the stacktrace: " << endl;
     cout << boost::stacktrace::stacktrace();
+    cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
     cout << "Check the stacktrace for the guilty party (typically #2)" << endl;
     gSystem->Exit(1);
     exit(1);
@@ -202,9 +203,21 @@ void PHParametersContainer::CopyToPdbParameterMapContainer(PdbParameterMapContai
   std::map<int, PHParameters *>::const_iterator iter;
   for (iter = parametermap.begin(); iter != parametermap.end(); ++iter)
   {
+
     PdbParameterMap *myparm = new PdbParameterMap();
     iter->second->CopyToPdbParameterMap(myparm);
     myparmap->AddPdbParameterMap(iter->first, myparm);
+  }
+  return;
+}
+
+void PHParametersContainer::UpdatePdbParameterMapContainer(PdbParameterMapContainer *myparmap)
+{
+  std::map<int, PHParameters *>::const_iterator iter;
+  for (iter = parametermap.begin(); iter != parametermap.end(); ++iter)
+  {
+    PdbParameterMap *nodeparams = myparmap->GetParametersToModify(iter->first);
+    iter->second->CopyToPdbParameterMap(nodeparams);
   }
   return;
 }
@@ -236,6 +249,19 @@ void PHParametersContainer::SaveToNodeTree(PHCompositeNode *topNode, const strin
     myparmap->Reset();
   }
   CopyToPdbParameterMapContainer(myparmap);
+  return;
+}
+
+void PHParametersContainer::UpdateNodeTree(PHCompositeNode *topNode, const string &nodename)
+{
+  PdbParameterMapContainer *myparmap = findNode::getClass<PdbParameterMapContainer>(topNode, nodename);
+  if (!myparmap)
+  {
+    cout << PHWHERE << " could not find PdbParameterMapContainer " << nodename
+	 << " which must exist" << endl;
+    gSystem->Exit(1);
+  }
+  UpdatePdbParameterMapContainer(myparmap);
   return;
 }
 

--- a/offline/database/PHParameter/PHParametersContainer.h
+++ b/offline/database/PHParameter/PHParametersContainer.h
@@ -37,13 +37,15 @@ class PHParametersContainer : public PHObject
   ConstRange GetAllParameters() const { return std::make_pair(parametermap.begin(), parametermap.end()); }
   void Print(Option_t *option = "") const;
   void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename);
+  void UpdateNodeTree(PHCompositeNode *topNode, const std::string &nodename);
   int ExistDetid(const int detid) const;
   void clear() { parametermap.clear(); }
   void FillFrom(const PdbParameterMapContainer *saveparamcontainer);
   void CreateAndFillFrom(const PdbParameterMapContainer *saveparamcontainer, const std::string &name);
 
- protected:
+ private:
   void CopyToPdbParameterMapContainer(PdbParameterMapContainer *myparm);
+  void UpdatePdbParameterMapContainer(PdbParameterMapContainer *myparm);
   std::string superdetectorname;
   std::map<int, PHParameters *> parametermap;
 };

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.cc
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.cc
@@ -9,6 +9,8 @@
 #include <TFile.h>
 #include <TSystem.h>
 
+#include <boost/stacktrace.hpp>
+
 #include <algorithm>
 #include <cctype>
 #include <ctime>
@@ -53,6 +55,10 @@ void PdbParameterMapContainer::AddPdbParameterMap(const int layer, PdbParameterM
   if (parametermap.find(layer) != parametermap.end())
   {
     cout << PHWHERE << " layer " << layer << " already exists" << endl;
+    cout << "Here is the stacktrace: " << endl;
+    cout << boost::stacktrace::stacktrace();
+    cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
+    cout << "Check the stacktrace for the guilty party (typically #2)" << endl;
     gSystem->Exit(1);
   }
   parametermap[layer] = params;

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.cc
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.cc
@@ -11,12 +11,12 @@
 
 #include <boost/stacktrace.hpp>
 
+#include <unistd.h>
 #include <algorithm>
 #include <cctype>
 #include <ctime>
 #include <iostream>
 #include <sstream>
-#include <unistd.h>
 
 using namespace std;
 
@@ -57,7 +57,8 @@ void PdbParameterMapContainer::AddPdbParameterMap(const int layer, PdbParameterM
     cout << PHWHERE << " layer " << layer << " already exists" << endl;
     cout << "Here is the stacktrace: " << endl;
     cout << boost::stacktrace::stacktrace();
-    cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
+    cout << endl
+         << "DO NOT PANIC - this is not a segfault" << endl;
     cout << "Check the stacktrace for the guilty party (typically #2)" << endl;
     gSystem->Exit(1);
   }

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.h
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.h
@@ -9,10 +9,9 @@
 
 class PdbParameterMap;
 
-class PdbParameterMapContainer: public PdbCalChan
+class PdbParameterMapContainer : public PdbCalChan
 {
  public:
-
   typedef std::map<int, PdbParameterMap *> parMap;
   typedef parMap::const_iterator parIter;
   typedef std::pair<parIter, parIter> parConstRange;
@@ -27,7 +26,7 @@ class PdbParameterMapContainer: public PdbCalChan
   void AddPdbParameterMap(const int layer, PdbParameterMap *params);
   const PdbParameterMap *GetParameters(const int layer) const;
   PdbParameterMap *GetParametersToModify(const int layer);
-  parConstRange get_ParameterMaps() const {return make_pair(parametermap.begin(), parametermap.end());}
+  parConstRange get_ParameterMaps() const { return make_pair(parametermap.begin(), parametermap.end()); }
 
   //! write PdbParameterMapContainer to an external file with root or xml extension.
   int WriteToFile(const std::string &detector_name, const std::string &extension, const std::string &dir = ".");
@@ -35,7 +34,7 @@ class PdbParameterMapContainer: public PdbCalChan
  protected:
   std::map<int, PdbParameterMap *> parametermap;
 
-  ClassDef(PdbParameterMapContainer,1)
+  ClassDef(PdbParameterMapContainer, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -57,7 +57,7 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   }
   else
   {
-    GetParams()->set_int_param("lengthviarapidity",0);
+    GetParams()->set_int_param("lengthviarapidity", 0);
   }
   // create display settings before detector
   PHG4CylinderDisplayAction *disp_action = new PHG4CylinderDisplayAction(Name(), GetParams());

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -39,6 +39,7 @@ PHG4CylinderSubsystem::PHG4CylinderSubsystem(const std::string &na, const int ly
   InitializeParameters();
 }
 
+//_______________________________________________________________________
 PHG4CylinderSubsystem::~PHG4CylinderSubsystem()
 {
   delete m_DisplayAction;
@@ -56,7 +57,7 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   }
   else
   {
-    GetParams()->set_double_param("lengthviarapidity", 0);
+    GetParams()->set_int_param("lengthviarapidity",0);
   }
   // create display settings before detector
   PHG4CylinderDisplayAction *disp_action = new PHG4CylinderDisplayAction(Name(), GetParams());

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -6,7 +6,7 @@
 #include "PHG4DetectorSubsystem.h"
 
 #if !defined(__CINT__) || defined(__CLING__)
-#include <array>   // for array
+#include <array>  // for array
 #endif
 
 #include <string>  // for string
@@ -56,10 +56,10 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
     m_ColorArray[2] = blue;
     m_ColorArray[3] = alpha;
   }
-// this method is used to check if it can be used as mothervolume
-// Subsystems which can be mothervolume need to implement this 
-// and return true
-  virtual bool CanBeMotherSubsystem() const {return true;}
+  // this method is used to check if it can be used as mothervolume
+  // Subsystems which can be mothervolume need to implement this
+  // and return true
+  virtual bool CanBeMotherSubsystem() const { return true; }
 
  private:
   void SetDefaultParameters();

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -28,8 +28,8 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
 
   //! init runwise stuff
   /*!
-  creates the m_Detector object and place it on the node tree, under "DETECTORS" node (or whatever)
-  reates the stepping action and place it on the node tree, under "ACTIONS" node
+  creates the m_Detector object
+  creates the stepping action
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
   int InitRunSubsystem(PHCompositeNode*);

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -17,6 +17,7 @@
 #include <TSystem.h>
 
 #include <boost/format.hpp>
+#include <boost/stacktrace.hpp>
 
 #include <cassert>                                // for assert
 #include <cstdlib>                                // for exit
@@ -146,6 +147,7 @@ int PHG4DetectorGroupSubsystem::InitRun(PHCompositeNode *topNode)
   }
   m_ParamsContainer->SaveToNodeTree(RunDetNode, paramnodename);
   int iret = InitRunSubsystem(topNode);
+  m_ParamsContainer->UpdateNodeTree(RunDetNode, paramnodename);
   if (Verbosity() > 0)
   {
     PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode, paramnodename);
@@ -507,9 +509,13 @@ int PHG4DetectorGroupSubsystem::ReadParamsFromDB(const string &name, const int i
   //     iret = params->ReadFromDB();
   //   }
 //  if (iret)
+  cout << boost::stacktrace::stacktrace();
+  cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
+  cout << "This method is a dummy, tell the offline gurus about it and give this stack trace" << endl;
   {
     cout << "problem reading from DB" << endl;
   }
+  gSystem->Exit(1);
   return iret;
 }
 
@@ -556,9 +562,12 @@ int PHG4DetectorGroupSubsystem::ReadParamsFromFile(const string &name, const PHG
   int iret = 1;
   //  int iret = params->ReadFromFile(name, extension, layer, issuper, m_CalibFileDir);
 //  if (iret)
-  {
-    cout << "problem reading from " << extension << " file " << endl;
-  }
+  cout << boost::stacktrace::stacktrace();
+  cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
+  cout << "This method is a dummy, tell the offline gurus about it and give this stack trace" << endl;
+  cout << "problem reading from " << extension << " file " << endl;
+  cout << "problem reading from DB" << endl;
+  gSystem->Exit(1);
   return iret;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -1,6 +1,6 @@
 #include "PHG4DetectorGroupSubsystem.h"
 
-#include <g4main/PHG4Subsystem.h>                  // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>  // for PHG4Subsystem
 
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
@@ -9,7 +9,7 @@
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHDataNode.h>
-#include <phool/PHNode.h>                          // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
@@ -19,8 +19,8 @@
 #include <boost/format.hpp>
 #include <boost/stacktrace.hpp>
 
-#include <cassert>                                // for assert
-#include <cstdlib>                                // for exit
+#include <cassert>  // for assert
+#include <cstdlib>  // for exit
 #include <iostream>
 #include <sstream>
 
@@ -508,9 +508,10 @@ int PHG4DetectorGroupSubsystem::ReadParamsFromDB(const string &name, const int i
   //   {
   //     iret = params->ReadFromDB();
   //   }
-//  if (iret)
+  //  if (iret)
   cout << boost::stacktrace::stacktrace();
-  cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
+  cout << endl
+       << "DO NOT PANIC - this is not a segfault" << endl;
   cout << "This method is a dummy, tell the offline gurus about it and give this stack trace" << endl;
   {
     cout << "problem reading from DB" << endl;
@@ -561,9 +562,10 @@ int PHG4DetectorGroupSubsystem::ReadParamsFromFile(const string &name, const PHG
   }
   int iret = 1;
   //  int iret = params->ReadFromFile(name, extension, layer, issuper, m_CalibFileDir);
-//  if (iret)
+  //  if (iret)
   cout << boost::stacktrace::stacktrace();
-  cout << endl << "DO NOT PANIC - this is not a segfault" << endl;
+  cout << endl
+       << "DO NOT PANIC - this is not a segfault" << endl;
   cout << "This method is a dummy, tell the offline gurus about it and give this stack trace" << endl;
   cout << "problem reading from " << extension << " file " << endl;
   cout << "problem reading from DB" << endl;

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.h
@@ -8,7 +8,7 @@
 #include <map>
 #include <set>
 #include <string>
-#include <utility>                 // for make_pair, pair
+#include <utility>  // for make_pair, pair
 
 class PHCompositeNode;
 class PHParametersContainer;
@@ -72,7 +72,8 @@ class PHG4DetectorGroupSubsystem : public PHG4Subsystem
   const std::string SuperDetector() const { return m_SuperDetector; }
   int GetLayer() const { return m_Layer; }
   virtual void SetDefaultParameters() = 0;  // this one has to be implemented by the daughter
- protected:                                 // those cannot be executed on the cmd line
+
+ protected:  // those cannot be executed on the cmd line
   PHG4DetectorGroupSubsystem(const std::string &name = "GenericSubsystem", const int lyr = 0);
   // these initialize the defaults and add new entries to the
   // list of variables. This should not be possible from the macro to

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
@@ -131,8 +131,12 @@ PHG4DetectorSubsystem::InitRun( PHCompositeNode* topNode )
 	  runNode->addNode(RunDetNode);
 	}
     }
+// put parameters on the node tree so the subsystem can read them from there (it does not have to)
   params->SaveToNodeTree(RunDetNode,paramnodename,layer);
   int iret = InitRunSubsystem(topNode);
+// update parameters on node tree in case the subsystem has changed them
+// In the end the parameters on the node tree must reflect what was actually used
+  params->UpdateNodeTree(RunDetNode,paramnodename,layer);
   if (Verbosity() > 0)
     {
       PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,paramnodename);

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
@@ -5,34 +5,34 @@
 
 #include <pdbcalbase/PdbParameterMapContainer.h>
 
-#include <g4main/PHG4Subsystem.h>                 // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>  // for PHG4Subsystem
 
-#include <phool/getClass.h>
-#include <phool/phool.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHDataNode.h>
-#include <phool/PHNode.h>                         // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
 
-#include <cstdlib>                               // for exit, NULL
+#include <cstdlib>  // for exit, NULL
 #include <iostream>
 #include <sstream>
-#include <utility>                                // for pair
+#include <utility>  // for pair
 
 using namespace std;
 
-PHG4DetectorSubsystem::PHG4DetectorSubsystem(const std::string &name, const int lyr): 
-  PHG4Subsystem(name),
-  params(new PHParameters(Name())),
-  paramscontainer(nullptr),
-  savetopNode(nullptr),
-  overlapcheck(false),
-  layer(lyr),
-  usedb(0),
-  beginrunexecuted(0),
-  filetype(PHG4DetectorSubsystem::none),
-  superdetector("NONE"),
-  calibfiledir("./")
+PHG4DetectorSubsystem::PHG4DetectorSubsystem(const std::string &name, const int lyr)
+  : PHG4Subsystem(name)
+  , params(new PHParameters(Name()))
+  , paramscontainer(nullptr)
+  , savetopNode(nullptr)
+  , overlapcheck(false)
+  , layer(lyr)
+  , usedb(0)
+  , beginrunexecuted(0)
+  , filetype(PHG4DetectorSubsystem::none)
+  , superdetector("NONE")
+  , calibfiledir("./")
 {
   // put the layer into the name so we get unique names
   // for multiple layers
@@ -41,8 +41,7 @@ PHG4DetectorSubsystem::PHG4DetectorSubsystem(const std::string &name, const int 
   Name(nam.str());
 }
 
-int 
-PHG4DetectorSubsystem::Init(PHCompositeNode* topNode)
+int PHG4DetectorSubsystem::Init(PHCompositeNode *topNode)
 {
   savetopNode = topNode;
   params->set_name(Name());
@@ -50,47 +49,44 @@ PHG4DetectorSubsystem::Init(PHCompositeNode* topNode)
   return iret;
 }
 
-int 
-PHG4DetectorSubsystem::InitRun( PHCompositeNode* topNode )
+int PHG4DetectorSubsystem::InitRun(PHCompositeNode *topNode)
 {
-  PHNodeIterator iter( topNode );
-  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "PAR" ));
-  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "PAR"));
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
 
   string g4geonodename = "G4GEO_";
   string paramnodename = "G4GEOPARAM_";
   string calibdetname;
   int isSuperDetector = 0;
   if (superdetector != "NONE")
+  {
+    g4geonodename += SuperDetector();
+    paramscontainer = findNode::getClass<PHParametersContainer>(parNode, g4geonodename);
+    if (!paramscontainer)
     {
-      g4geonodename += SuperDetector();
-      paramscontainer = findNode::getClass<PHParametersContainer>(parNode,g4geonodename);
-      if (! paramscontainer)
-	{
-	  PHNodeIterator parIter(parNode);
-          PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(parIter.findFirst("PHCompositeNode",SuperDetector()));
-	  if (! DetNode)
-	    {
-	      DetNode = new PHCompositeNode(SuperDetector());
-	      parNode->addNode(DetNode);
-	    }
-	  paramscontainer = new PHParametersContainer(superdetector);
-	  DetNode->addNode(new PHDataNode<PHParametersContainer>(paramscontainer,g4geonodename));
-	}
-      paramscontainer->AddPHParameters(layer,params);
-      paramnodename += superdetector;
-      calibdetname = superdetector;
-      isSuperDetector = 1;
+      PHNodeIterator parIter(parNode);
+      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(parIter.findFirst("PHCompositeNode", SuperDetector()));
+      if (!DetNode)
+      {
+        DetNode = new PHCompositeNode(SuperDetector());
+        parNode->addNode(DetNode);
+      }
+      paramscontainer = new PHParametersContainer(superdetector);
+      DetNode->addNode(new PHDataNode<PHParametersContainer>(paramscontainer, g4geonodename));
     }
+    paramscontainer->AddPHParameters(layer, params);
+    paramnodename += superdetector;
+    calibdetname = superdetector;
+    isSuperDetector = 1;
+  }
   else
-    {
-      g4geonodename += params->Name();
-      parNode->addNode(new PHDataNode<PHParameters>(params,g4geonodename));
-      paramnodename += params->Name();
-      calibdetname = params->Name();
-    }
-
-
+  {
+    g4geonodename += params->Name();
+    parNode->addNode(new PHDataNode<PHParameters>(params, g4geonodename));
+    paramnodename += params->Name();
+    calibdetname = params->Name();
+  }
 
   // ASSUMPTION: if we read from DB and/or file we don't want the stuff from
   // the node tree
@@ -98,75 +94,73 @@ PHG4DetectorSubsystem::InitRun( PHCompositeNode* topNode )
   // those in the object read from the DB or file
   // Order: read first DB, then calib file if both are enabled
   if (ReadDB() || get_filetype() != PHG4DetectorSubsystem::none)
+  {
+    if (ReadDB())
     {
-      if (ReadDB())
-	{
-	   ReadParamsFromDB(calibdetname,isSuperDetector);
-	}
-      if (get_filetype() != PHG4DetectorSubsystem::none)
-	{
-	  ReadParamsFromFile(calibdetname, get_filetype(),isSuperDetector );
-	}
+      ReadParamsFromDB(calibdetname, isSuperDetector);
     }
+    if (get_filetype() != PHG4DetectorSubsystem::none)
+    {
+      ReadParamsFromFile(calibdetname, get_filetype(), isSuperDetector);
+    }
+  }
   else
+  {
+    PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode, paramnodename);
+    if (nodeparams)
     {
-      PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,paramnodename);
-      if (nodeparams)
-	{
-	  params->FillFrom(nodeparams, layer);
-	}
+      params->FillFrom(nodeparams, layer);
     }
+  }
   // parameters set in the macro always override whatever is read from
   // the node tree, DB or file
   UpdateParametersWithMacro();
   // save updated persistant copy on node tree
   PHCompositeNode *RunDetNode = runNode;
   if (superdetector != "NONE")
+  {
+    PHNodeIterator runIter(runNode);
+    RunDetNode = dynamic_cast<PHCompositeNode *>(runIter.findFirst("PHCompositeNode", SuperDetector()));
+    if (!RunDetNode)
     {
-      PHNodeIterator runIter(runNode);
-      RunDetNode = dynamic_cast<PHCompositeNode*>(runIter.findFirst("PHCompositeNode",SuperDetector()));
-      if (! RunDetNode)
-	{
-	  RunDetNode = new PHCompositeNode(SuperDetector());
-	  runNode->addNode(RunDetNode);
-	}
+      RunDetNode = new PHCompositeNode(SuperDetector());
+      runNode->addNode(RunDetNode);
     }
-// put parameters on the node tree so the subsystem can read them from there (it does not have to)
-  params->SaveToNodeTree(RunDetNode,paramnodename,layer);
+  }
+  // put parameters on the node tree so the subsystem can read them from there (it does not have to)
+  params->SaveToNodeTree(RunDetNode, paramnodename, layer);
   int iret = InitRunSubsystem(topNode);
-// update parameters on node tree in case the subsystem has changed them
-// In the end the parameters on the node tree must reflect what was actually used
-  params->UpdateNodeTree(RunDetNode,paramnodename,layer);
+  // update parameters on node tree in case the subsystem has changed them
+  // In the end the parameters on the node tree must reflect what was actually used
+  params->UpdateNodeTree(RunDetNode, paramnodename, layer);
   if (Verbosity() > 0)
-    {
-      PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode,paramnodename);
-      cout << Name() << endl;
-      nodeparams->print();
-    }
+  {
+    PdbParameterMapContainer *nodeparams = findNode::getClass<PdbParameterMapContainer>(topNode, paramnodename);
+    cout << Name() << endl;
+    nodeparams->print();
+  }
   beginrunexecuted = 1;
   return iret;
 }
 
-void
-PHG4DetectorSubsystem::SuperDetector(const std::string &name)
+void PHG4DetectorSubsystem::SuperDetector(const std::string &name)
 {
   superdetector = name;
   return;
 }
 
-void
-PHG4DetectorSubsystem::set_double_param(const std::string &name, const double dval)
+void PHG4DetectorSubsystem::set_double_param(const std::string &name, const double dval)
 {
   if (default_double.find(name) == default_double.end())
+  {
+    cout << "double parameter " << name << " not implemented" << endl;
+    cout << "implemented double parameters are:" << endl;
+    for (map<const string, double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
     {
-      cout << "double parameter " << name << " not implemented" << endl;
-      cout << "implemented double parameters are:" << endl;
-      for (map<const string, double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
-	{
-	  cout << iter->first << endl;
-	}
-      return;
+      cout << iter->first << endl;
     }
+    return;
+  }
   dparams[name] = dval;
 }
 
@@ -176,41 +170,38 @@ PHG4DetectorSubsystem::get_double_param(const std::string &name) const
   return params->get_double_param(name);
 }
 
-void
-PHG4DetectorSubsystem::set_int_param(const std::string &name, const int ival)
+void PHG4DetectorSubsystem::set_int_param(const std::string &name, const int ival)
 {
   if (default_int.find(name) == default_int.end())
+  {
+    cout << "integer parameter " << name << " not implemented" << endl;
+    cout << "implemented integer parameters are:" << endl;
+    for (map<const string, int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
     {
-      cout << "integer parameter " << name << " not implemented" << endl;
-      cout << "implemented integer parameters are:" << endl;
-      for (map<const string, int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
-	{
-	  cout << iter->first << endl;
-	}
-      return;
+      cout << iter->first << endl;
     }
+    return;
+  }
   iparams[name] = ival;
 }
 
-int
-PHG4DetectorSubsystem::get_int_param(const std::string &name) const
+int PHG4DetectorSubsystem::get_int_param(const std::string &name) const
 {
   return params->get_int_param(name);
 }
 
-void
-PHG4DetectorSubsystem::set_string_param(const std::string &name, const string &sval)
+void PHG4DetectorSubsystem::set_string_param(const std::string &name, const string &sval)
 {
   if (default_string.find(name) == default_string.end())
+  {
+    cout << "string parameter " << name << " not implemented" << endl;
+    cout << "implemented string parameters are:" << endl;
+    for (map<const string, string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
     {
-      cout << "string parameter " << name << " not implemented" << endl;
-      cout << "implemented string parameters are:" << endl;
-      for (map<const string, string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
-	{
-	  cout << iter->first << endl;
-	}
-      return;
+      cout << iter->first << endl;
     }
+    return;
+  }
   cparams[name] = sval;
 }
 
@@ -220,211 +211,197 @@ PHG4DetectorSubsystem::get_string_param(const std::string &name) const
   return params->get_string_param(name);
 }
 
-void
-PHG4DetectorSubsystem::UpdateParametersWithMacro()
+void PHG4DetectorSubsystem::UpdateParametersWithMacro()
 {
-  for (map<const string,double>::const_iterator iter = dparams.begin(); iter != dparams.end(); ++iter)
-    {
-      params->set_double_param(iter->first,iter->second);
-    }
-  for (map<const string,int>::const_iterator iter = iparams.begin(); iter != iparams.end(); ++iter)
-    {
-      params->set_int_param(iter->first,iter->second);
-    }
-  for (map<const string,string>::const_iterator iter = cparams.begin(); iter != cparams.end(); ++iter)
-    {
-      params->set_string_param(iter->first,iter->second);
-    }
+  for (map<const string, double>::const_iterator iter = dparams.begin(); iter != dparams.end(); ++iter)
+  {
+    params->set_double_param(iter->first, iter->second);
+  }
+  for (map<const string, int>::const_iterator iter = iparams.begin(); iter != iparams.end(); ++iter)
+  {
+    params->set_int_param(iter->first, iter->second);
+  }
+  for (map<const string, string>::const_iterator iter = cparams.begin(); iter != cparams.end(); ++iter)
+  {
+    params->set_string_param(iter->first, iter->second);
+  }
   return;
 }
 
-void
-PHG4DetectorSubsystem::set_default_double_param( const std::string &name, const double dval)
+void PHG4DetectorSubsystem::set_default_double_param(const std::string &name, const double dval)
 {
   if (default_double.find(name) == default_double.end())
-    {
-      default_double[name] = dval;
-    }
+  {
+    default_double[name] = dval;
+  }
   else
-    {
-      cout << "trying to overwrite default double " << name << " " 
-	   << default_double[name] << " with " << dval << endl;
-      exit(1);
-    }
+  {
+    cout << "trying to overwrite default double " << name << " "
+         << default_double[name] << " with " << dval << endl;
+    exit(1);
+  }
   return;
 }
 
-void
-PHG4DetectorSubsystem::set_default_int_param( const std::string &name, const int ival)
+void PHG4DetectorSubsystem::set_default_int_param(const std::string &name, const int ival)
 {
   if (default_int.find(name) == default_int.end())
-    {
-      default_int[name] = ival;
-    }
+  {
+    default_int[name] = ival;
+  }
   else
-    {
-      cout << "trying to overwrite default int " << name << " " 
-	   << default_int[name] << " with " << ival << endl;
-      exit(1);
-    }
+  {
+    cout << "trying to overwrite default int " << name << " "
+         << default_int[name] << " with " << ival << endl;
+    exit(1);
+  }
   return;
 }
 
-void
-PHG4DetectorSubsystem::set_default_string_param( const std::string &name, const string &sval)
+void PHG4DetectorSubsystem::set_default_string_param(const std::string &name, const string &sval)
 {
   if (default_string.find(name) == default_string.end())
-    {
-      default_string[name] = sval;
-    }
+  {
+    default_string[name] = sval;
+  }
   else
-    {
-      cout << "trying to overwrite default string " << name << " " 
-	   << default_string[name] << " with " << sval << endl;
-      exit(1);
-    }
+  {
+    cout << "trying to overwrite default string " << name << " "
+         << default_string[name] << " with " << sval << endl;
+    exit(1);
+  }
   return;
 }
 
-void
-PHG4DetectorSubsystem::InitializeParameters()
+void PHG4DetectorSubsystem::InitializeParameters()
 {
   set_default_int_param("absorberactive", 0);
   set_default_int_param("absorbertruth", 0);
   set_default_int_param("active", 0);
   set_default_int_param("blackhole", 0);
 
-  SetDefaultParameters(); // call method from specific subsystem
+  SetDefaultParameters();  // call method from specific subsystem
   // now load those parameters to our params class
-  for (map<const string,double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
-    {
-      params->set_double_param(iter->first,iter->second);
-    }
-  for (map<const string,int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
-    {
-      params->set_int_param(iter->first,iter->second);
-    }
-  for (map<const string,string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
-    {
-      params->set_string_param(iter->first,iter->second);
-    }
+  for (map<const string, double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
+  {
+    params->set_double_param(iter->first, iter->second);
+  }
+  for (map<const string, int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
+  {
+    params->set_int_param(iter->first, iter->second);
+  }
+  for (map<const string, string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
+  {
+    params->set_string_param(iter->first, iter->second);
+  }
 }
 
-int
-PHG4DetectorSubsystem::SaveParamsToDB()
+int PHG4DetectorSubsystem::SaveParamsToDB()
 {
   int iret = 0;
   if (paramscontainer)
-    {
-      iret = paramscontainer->WriteToDB();
-    }
+  {
+    iret = paramscontainer->WriteToDB();
+  }
   else
-    {
-      iret = params->WriteToDB();
-    }
+  {
+    iret = params->WriteToDB();
+  }
   if (iret)
-    {
-      cout << "problem committing to DB" << endl;
-    }
+  {
+    cout << "problem committing to DB" << endl;
+  }
   return iret;
 }
 
-int
-PHG4DetectorSubsystem::ReadParamsFromDB(const string &name, const int issuper)
+int PHG4DetectorSubsystem::ReadParamsFromDB(const string &name, const int issuper)
 {
   int iret = 0;
   if (issuper)
-    {
-      iret = params->ReadFromDB(name,layer);
-    }
+  {
+    iret = params->ReadFromDB(name, layer);
+  }
   else
-    {
-      iret = params->ReadFromDB();
-    }
+  {
+    iret = params->ReadFromDB();
+  }
   if (iret)
-    {
-      cout << "problem reading from DB" << endl;
-    }
+  {
+    cout << "problem reading from DB" << endl;
+  }
   return iret;
 }
 
-int
-PHG4DetectorSubsystem::SaveParamsToFile(const PHG4DetectorSubsystem::FILE_TYPE ftyp)
+int PHG4DetectorSubsystem::SaveParamsToFile(const PHG4DetectorSubsystem::FILE_TYPE ftyp)
 {
   string extension;
-  switch(ftyp)
-    {
-    case xml:
-      extension = "xml";
-      break;
-    case root:
-      extension = "root";
-      break;
-    default:
-      cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
-      exit(1);
-    }
+  switch (ftyp)
+  {
+  case xml:
+    extension = "xml";
+    break;
+  case root:
+    extension = "root";
+    break;
+  default:
+    cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
+    exit(1);
+  }
   int iret = 0;
   if (paramscontainer)
-    {
-      iret = paramscontainer->WriteToFile(extension,calibfiledir);
-    }
+  {
+    iret = paramscontainer->WriteToFile(extension, calibfiledir);
+  }
   else
-    {
-      iret = params->WriteToFile(extension,calibfiledir);
-    }
+  {
+    iret = params->WriteToFile(extension, calibfiledir);
+  }
   if (iret)
-    {
-      cout << "problem saving to " << extension << " file " << endl;
-    }
+  {
+    cout << "problem saving to " << extension << " file " << endl;
+  }
   return iret;
 }
 
-int
-PHG4DetectorSubsystem::ReadParamsFromFile(const string &name, const PHG4DetectorSubsystem::FILE_TYPE ftyp, const int issuper)
+int PHG4DetectorSubsystem::ReadParamsFromFile(const string &name, const PHG4DetectorSubsystem::FILE_TYPE ftyp, const int issuper)
 {
   string extension;
-  switch(ftyp)
-    {
-    case xml:
-      extension = "xml";
-      break;
-    case root:
-      extension = "root";
-      break;
-    default:
-      cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
-      exit(1);
-    }
+  switch (ftyp)
+  {
+  case xml:
+    extension = "xml";
+    break;
+  case root:
+    extension = "root";
+    break;
+  default:
+    cout << PHWHERE << "filetype " << ftyp << " not implemented" << endl;
+    exit(1);
+  }
   int iret = params->ReadFromFile(name, extension, layer, issuper, calibfiledir);
   if (iret)
-    {
-      cout << "problem reading from " << extension << " file " << endl;
-    }
+  {
+    cout << "problem reading from " << extension << " file " << endl;
+  }
   return iret;
 }
 
-void
-PHG4DetectorSubsystem::SetActive(const int i)
+void PHG4DetectorSubsystem::SetActive(const int i)
 {
   iparams["active"] = i;
 }
 
-void
-PHG4DetectorSubsystem::SetAbsorberActive(const int i)
+void PHG4DetectorSubsystem::SetAbsorberActive(const int i)
 {
   iparams["absorberactive"] = i;
 }
 
-void
-PHG4DetectorSubsystem::BlackHole(const int i)
+void PHG4DetectorSubsystem::BlackHole(const int i)
 {
   iparams["blackhole"] = i;
 }
 
-void
-PHG4DetectorSubsystem::SetAbsorberTruth(const int i)
+void PHG4DetectorSubsystem::SetAbsorberTruth(const int i)
 {
   iparams["absorbertruth"] = i;
 }
-

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
@@ -15,8 +15,12 @@ class PHParametersContainer;
 class PHG4DetectorSubsystem : public PHG4Subsystem
 {
  public:
-
-  enum FILE_TYPE {none = 0, xml = 1, root = 2};
+  enum FILE_TYPE
+  {
+    none = 0,
+    xml = 1,
+    root = 2
+  };
 
   virtual ~PHG4DetectorSubsystem() {}
 
@@ -29,15 +33,18 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
   int InitRun(PHCompositeNode *);
 #endif
 
-  virtual int InitRunSubsystem(PHCompositeNode *) {return 0;}
-  virtual int InitSubsystem(PHCompositeNode *) {return 0;}
+  virtual int InitRunSubsystem(PHCompositeNode *)
+  {
+    return 0;
+  }
+  virtual int InitSubsystem(PHCompositeNode *) { return 0; }
 
-  void OverlapCheck(const bool chk = true) {overlapcheck = chk;}
-  bool CheckOverlap() const {return overlapcheck;}
+  void OverlapCheck(const bool chk = true) { overlapcheck = chk; }
+  bool CheckOverlap() const { return overlapcheck; }
 
-  PHParameters *GetParams() const {return params;} 
+  PHParameters *GetParams() const { return params; }
 
- // Get/Set parameters from macro
+  // Get/Set parameters from macro
   void set_double_param(const std::string &name, const double dval);
   double get_double_param(const std::string &name) const;
   void set_int_param(const std::string &name, const int ival);
@@ -45,39 +52,38 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
   void set_string_param(const std::string &name, const std::string &sval);
   std::string get_string_param(const std::string &name) const;
 
-  void UseDB(const int i = 1) {usedb = i;}
-  int ReadDB() const {return usedb;}
-  FILE_TYPE get_filetype() const {return filetype;}
+  void UseDB(const int i = 1) { usedb = i; }
+  int ReadDB() const { return usedb; }
+  FILE_TYPE get_filetype() const { return filetype; }
 
-  void UseCalibFiles(const FILE_TYPE ftyp) {filetype = ftyp;}
+  void UseCalibFiles(const FILE_TYPE ftyp) { filetype = ftyp; }
   int SaveParamsToDB();
   int ReadParamsFromDB(const std::string &name, const int issuper);
   int SaveParamsToFile(const FILE_TYPE ftyp);
   int ReadParamsFromFile(const std::string &name, const FILE_TYPE ftyp, const int issuper);
-  void SetCalibrationFileDir(const std::string &calibdir) {calibfiledir = calibdir;}
+  void SetCalibrationFileDir(const std::string &calibdir) { calibfiledir = calibdir; }
 
   void UpdateParametersWithMacro();
 
   void SetActive(const int i = 1);
   void SetAbsorberActive(const int i = 1);
   void SetAbsorberTruth(const int i = 1);
-  void BlackHole(const int i=1);
+  void BlackHole(const int i = 1);
   void SuperDetector(const std::string &name);
-  const std::string SuperDetector() const {return superdetector;}
+  const std::string SuperDetector() const { return superdetector; }
 
-  int GetLayer() const {return layer;}
-  virtual void SetDefaultParameters() = 0; // this one has to be implemented by the daughter
- protected: // those cannot be executed on the cmd line 
-
+  int GetLayer() const { return layer; }
+  virtual void SetDefaultParameters() = 0;  // this one has to be implemented by the daughter
+ protected:                                 // those cannot be executed on the cmd line
   PHG4DetectorSubsystem(const std::string &name = "GenericSubsystem", const int lyr = 0);
   // these initialize the defaults and add new entries to the
   // list of variables. This should not be possible from the macro to
   // prevent abuse (this makes the list of possible parameters deterministic)
   void InitializeParameters();
-  void set_default_double_param( const std::string &name, const double dval);
-  void set_default_int_param( const std::string &name, const int ival);
-  void set_default_string_param( const std::string &name, const std::string &sval);
-  int BeginRunExecuted() const {return beginrunexecuted;}
+  void set_default_double_param(const std::string &name, const double dval);
+  void set_default_int_param(const std::string &name, const int ival);
+  void set_default_string_param(const std::string &name, const std::string &sval);
+  int BeginRunExecuted() const { return beginrunexecuted; }
 
  private:
   PHParameters *params;
@@ -98,7 +104,6 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
   std::map<const std::string, double> default_double;
   std::map<const std::string, int> default_int;
   std::map<const std::string, std::string> default_string;
-
 };
 
 #endif


### PR DESCRIPTION
We had a hole in the logic saving the parameters on the node tree (and subsequent DST). It is possible for a subsystem to change the parameters. E.g. the cylinders do that to pass the length calculated from the rapidity coverage or set the lengthviarapidity to 0 (defaults to 1, bad idea to begin with) if the length is set in the macro.
Now the parameters on the node tree are updated with changes done by the subsystem. This is implemented for the PHG4DetectorSubsystem as well as for the PHG4DetectorGroupSubsystem (the later one only being used by the PSTOF)