### PR TITLE
Upstream/master qa clusters

### DIFF
--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -33,6 +33,7 @@
 #include <TString.h>
 #include <TVector3.h>
 
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <iostream>
@@ -91,17 +92,17 @@ int QAG4SimulationTracking::Init(PHCompositeNode *topNode)
   QAHistManagerDef::useLogBins(h->GetXaxis());
   hm->registerHisto(h);
 
-  // reco pT histogram vs tracker hits
+  // reco pT histogram vs tracker clusters
   h = new TH2F(TString(get_histo_prefix()) + "nMVTX_nReco_pTGen",
-               "Reco tracks at truth p_{T};Truth p_{T} [GeV/c];nHit_{MVTX}", 200, 0.1, 50.5, 6, -.5, 5.5);
+               "Reco tracks at truth p_{T};Truth p_{T} [GeV/c];nCluster_{MVTX}", 200, 0.1, 50.5, 6, -.5, 5.5);
   QAHistManagerDef::useLogBins(h->GetXaxis());
   hm->registerHisto(h);
   h = new TH2F(TString(get_histo_prefix()) + "nINTT_nReco_pTGen",
-               "Reco tracks at truth p_{T};Truth p_{T} [GeV/c];nHit_{INTT}", 200, 0.1, 50.5, 6, -.5, 5.5);
+               "Reco tracks at truth p_{T};Truth p_{T} [GeV/c];nCluster_{INTT}", 200, 0.1, 50.5, 6, -.5, 5.5);
   QAHistManagerDef::useLogBins(h->GetXaxis());
   hm->registerHisto(h);
   h = new TH2F(TString(get_histo_prefix()) + "nTPC_nReco_pTGen",
-               "Reco tracks at truth p_{T};Truth p_{T} [GeV/c];nHit_{TPC}", 200, 0.1, 50.5, 60, -.5, 59.5);
+               "Reco tracks at truth p_{T};Truth p_{T} [GeV/c];nCluster_{TPC}", 200, 0.1, 50.5, 60, -.5, 59.5);
   QAHistManagerDef::useLogBins(h->GetXaxis());
   hm->registerHisto(h);
 
@@ -123,7 +124,7 @@ int QAG4SimulationTracking::Init(PHCompositeNode *topNode)
   hm->registerHisto(h);
 
   // clusters per layer and per track histogram
-  h = new TH1F(TString(get_histo_prefix()) + "nClus_layer", "Reco Clusters per layer per track;Layer;nHit", 64, 0, 64 );
+  h = new TH1F(TString(get_histo_prefix()) + "nClus_layer", "Reco Clusters per layer per track;Layer;nCluster", 64, 0, 64 );
   hm->registerHisto(h);
   
   // n events and n tracks histogram
@@ -342,8 +343,9 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
         h_pTRecoGenRatio_pTGen->Fill(gpt, pt_ratio);
         h_norm->Fill("Reco Track", 1);
 
-        // tracker hit stat.
-        vector<unsigned int> nhits(3, 0);
+        // tracker cluster stat.
+        std::array<unsigned int,3> nclusters = {{0,0,0}};
+
         // cluster stat.
         for (auto cluster_iter = track->begin_cluster_keys(); cluster_iter != track->end_cluster_keys(); ++cluster_iter)
         {
@@ -354,20 +356,20 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
           h_nClus_layer->Fill( layer );
  
           if (trackerID == TrkrDefs::mvtxId)
-            ++nhits[0];
+            ++nclusters[0];
           else if (trackerID == TrkrDefs::inttId)
-            ++nhits[1];
+            ++nclusters[1];
           else if (trackerID == TrkrDefs::tpcId)
-            ++nhits[2];
+            ++nclusters[2];
           else
           {
             if (Verbosity())
               cout << "QAG4SimulationTracking::process_event - unkown tracker ID = " << trackerID << " from cluster " << cluster_key << endl;
           }
         }  // for
-        h_nMVTX_nReco_pTGen->Fill(gpt, nhits[0]);
-        h_nINTT_nReco_pTGen->Fill(gpt, nhits[1]);
-        h_nTPC_nReco_pTGen->Fill(gpt, nhits[2]);
+        h_nMVTX_nReco_pTGen->Fill(gpt, nclusters[0]);
+        h_nINTT_nReco_pTGen->Fill(gpt, nclusters[1]);
+        h_nTPC_nReco_pTGen->Fill(gpt, nclusters[2]);
       }  //      if (match_found)
 
     }  //    if (track)

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -48,21 +48,21 @@ QAG4SimulationTracking::QAG4SimulationTracking(const std::string &name)
 
 int QAG4SimulationTracking::InitRun(PHCompositeNode *topNode)
 {
-  _truthContainer = findNode::getClass<PHG4TruthInfoContainer>(topNode,
+  m_truthContainer = findNode::getClass<PHG4TruthInfoContainer>(topNode,
                                                                "G4TruthInfo");
-  if (!_truthContainer)
+  if (!m_truthContainer)
   {
     cout << "QAG4SimulationTracking::InitRun - Fatal Error - "
          << "unable to find DST node "
          << "G4TruthInfo" << endl;
-    assert(_truthContainer);
+    assert(m_truthContainer);
   }
 
-  if (!_svtxEvalStack)
+  if (!m_svtxEvalStack)
   {
-    _svtxEvalStack.reset(new SvtxEvalStack(topNode));
-    _svtxEvalStack->set_strict(true);
-    _svtxEvalStack->set_verbosity(Verbosity() + 1);
+    m_svtxEvalStack.reset(new SvtxEvalStack(topNode));
+    m_svtxEvalStack->set_strict(true);
+    m_svtxEvalStack->set_verbosity(Verbosity() + 1);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -155,12 +155,12 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);
 
-  if (_svtxEvalStack)
-    _svtxEvalStack->next_event(topNode);
+  if (m_svtxEvalStack)
+    m_svtxEvalStack->next_event(topNode);
 
-  SvtxTrackEval *trackeval = _svtxEvalStack->get_track_eval();
+  SvtxTrackEval *trackeval = m_svtxEvalStack->get_track_eval();
   assert(trackeval);
-  SvtxTruthEval *trutheval = _svtxEvalStack->get_truth_eval();
+  SvtxTruthEval *trutheval = m_svtxEvalStack->get_truth_eval();
   assert(trutheval);
 
   // reco pT / gen pT histogram
@@ -207,13 +207,13 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
   h_norm->Fill("Event", 1);
 
   // fill histograms that need truth information
-  if (!_truthContainer)
+  if (!m_truthContainer)
   {
-    cout << "QAG4SimulationTracking::process_event - fatal error - missing _truthContainer! ";
+    cout << "QAG4SimulationTracking::process_event - fatal error - missing m_truthContainer! ";
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  PHG4TruthInfoContainer::ConstRange range = _truthContainer->GetPrimaryParticleRange();
+  PHG4TruthInfoContainer::ConstRange range = m_truthContainer->GetPrimaryParticleRange();
   for (PHG4TruthInfoContainer::ConstIterator iter = range.first; iter != range.second; ++iter)
   {
     // get the truth particle information

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -225,7 +225,7 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
       g4particle->identify();
     }
 
-    if (m_embeddingIDs.size() > 0)
+    if (!m_embeddingIDs.empty())
     {
       //only analyze subset of particle with proper embedding IDs
       int candidate_embedding_id = trutheval->get_embed(g4particle);

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -44,12 +44,7 @@ using namespace std;
 
 QAG4SimulationTracking::QAG4SimulationTracking(const std::string &name)
   : SubsysReco(name)
-  , _svtxEvalStack(nullptr)
-  , m_etaRange(-1, 1)
-  , m_uniqueTrackingMatch(true)
-  , _truthContainer(nullptr)
-{
-}
+{}
 
 int QAG4SimulationTracking::InitRun(PHCompositeNode *topNode)
 {

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -123,7 +123,7 @@ int QAG4SimulationTracking::Init(PHCompositeNode *topNode)
   hm->registerHisto(h);
 
   // clusters per layer and per track histogram
-  h = new TH1F(TString(get_histo_prefix()) + "nClus_layer", "Reco Clusters per layer per track", 64, 0, 64 );
+  h = new TH1F(TString(get_histo_prefix()) + "nClus_layer", "Reco Clusters per layer per track;Layer;nHit", 64, 0, 64 );
   hm->registerHisto(h);
   
   // n events and n tracks histogram

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -2,6 +2,7 @@
 #define QA_QAG4SimulationTracking_H
 
 #include <fun4all/SubsysReco.h>
+#include <g4eval/SvtxEvalStack.h>
 
 #include <memory>
 #include <set>
@@ -10,9 +11,6 @@
 
 class PHCompositeNode;
 class PHG4TruthInfoContainer;
-class PHG4Particle;
-class CaloEvalStack;
-class SvtxEvalStack;
 class SvtxTrack;
 
 /// \class QAG4SimulationTracking
@@ -20,7 +18,7 @@ class QAG4SimulationTracking : public SubsysReco
 {
  public:
   QAG4SimulationTracking(const std::string &name = "QAG4SimulationTracking");
-  virtual ~QAG4SimulationTracking() {}
+  virtual ~QAG4SimulationTracking() = default;
 
   int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -8,12 +8,6 @@
 #include <string>
 #include <utility>
 
-#if !defined(__CINT__) || defined(__CLING__)
-#include <cstdint>
-#else
-#include <stdint.h>
-#endif
-
 class PHCompositeNode;
 class PHG4TruthInfoContainer;
 class PHG4Particle;
@@ -54,11 +48,9 @@ class QAG4SimulationTracking : public SubsysReco
   }
 
  private:
-#if !defined(__CINT__) || defined(__CLING__)
-  //CINT is not c++11 compatible
+
   std::shared_ptr<SvtxEvalStack> _svtxEvalStack;
   std::set<int> m_embeddingIDs;
-#endif
 
   //! range of the truth track eta to be analyzed
   std::pair<double, double> m_etaRange;

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -49,7 +49,7 @@ class QAG4SimulationTracking : public SubsysReco
 
  private:
 
-  std::unique_ptr<SvtxEvalStack> _svtxEvalStack;
+  std::unique_ptr<SvtxEvalStack> m_svtxEvalStack;
   std::set<int> m_embeddingIDs;
 
   //! range of the truth track eta to be analyzed
@@ -58,7 +58,7 @@ class QAG4SimulationTracking : public SubsysReco
   //! only count unique truth<->reco track pair in tracking efficiency
   bool m_uniqueTrackingMatch = true;
 
-  PHG4TruthInfoContainer *_truthContainer = nullptr;
+  PHG4TruthInfoContainer *m_truthContainer = nullptr;
 };
 
 #endif  // QA_QAG4SimulationTracking_H

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -49,16 +49,16 @@ class QAG4SimulationTracking : public SubsysReco
 
  private:
 
-  std::shared_ptr<SvtxEvalStack> _svtxEvalStack;
+  std::unique_ptr<SvtxEvalStack> _svtxEvalStack;
   std::set<int> m_embeddingIDs;
 
   //! range of the truth track eta to be analyzed
-  std::pair<double, double> m_etaRange;
+  std::pair<double, double> m_etaRange = {-1, 1};
 
   //! only count unique truth<->reco track pair in tracking efficiency
-  bool m_uniqueTrackingMatch;
+  bool m_uniqueTrackingMatch = true;
 
-  PHG4TruthInfoContainer *_truthContainer;
+  PHG4TruthInfoContainer *_truthContainer = nullptr;
 };
 
 #endif  // QA_QAG4SimulationTracking_H


### PR DESCRIPTION
This PR adds a #clusters/layer/track QA histogram in the tracking module, as shown at https://indico.bnl.gov/event/7413/contributions/37321/attachments/27916/42843/talk.pdf slide 10.
The actual normalization to the number of tracks is performed in the plotting macro based on the "Normalization" histogram. 

Resulting plot:
![G4sPHENIX root_qa root_QA_Draw_Tracking_nClus_Layer_QAG4SimulationTracking](https://user-images.githubusercontent.com/22907496/81205828-7507ef80-8f88-11ea-8091-a93fa13acd0e.png)

@blackcathj For consistency with other histograms, I have labelled the y axis "nHit". However these are really clusters, while hits are "something else" (same is true for the other histograms). Is it ok to relabel them all to nCluster (either in this PR or a separate one) ? 

Also performed some cleanup in the tracking module.
