### PR TITLE
G4hit-based fast tracking tuning

### DIFF
--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -698,6 +698,9 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
               << "searching for hits from  " << _phg4hits.size() << " PHG4Hit nodes" << endl;
   }
 
+  // order measurement with g4hit time via stl multimap
+  multimap<double, PHGenFit::Measurement*> ordered_measurements;
+
   for (unsigned int ilayer = 0; ilayer < _phg4hits.size(); ilayer++)
   {
     if (!_phg4hits[ilayer])
@@ -772,7 +775,8 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
               LogError("Type not implemented!");
               return Fun4AllReturnCodes::ABORTEVENT;
             }
-            meas_out.push_back(meas);
+            //            meas_out.push_back(meas);
+            ordered_measurements.insert(make_pair(hit->get_avg_t(), meas));
 
             //meas->getMeasurement()->Print(); //DEBUG
           }
@@ -780,6 +784,17 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
       }
     } /*Loop layers within one detector layer*/
   }   /*Loop detector layers*/
+
+  for (auto& pair : ordered_measurements)
+  {
+    meas_out.push_back(pair.second);
+
+    if (Verbosity())
+    {
+      std::cout << "PHG4TrackFastSim::PseudoPatternRecognition - measruement at t =  " << pair.first << " ns: ";
+      pair.second->getMeasurement()->Print();
+    }
+  }
 
   if (Verbosity())
   {

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -106,6 +106,15 @@ class PHG4TrackFastSim : public SubsysReco
     return _phg4hits_names;
   }
 
+  //! adding hits from a PHG4Hit node, which usually belong to one detector or a sub group of detectors
+  //! Orders of adding detectors do not matter as the hits are internally assembled in the time order
+  //! \param[in] phg4hitsNames node name such as "G4HIT_SVTX"
+  //! \param[in] PHG4TrackFastSim::Vertical_Plane or PHG4TrackFastSim::Cylinder
+  //! \param[in] radres radial resolution [cm], not used for PHG4TrackFastSim::Cylinder
+  //! \param[in] phires azimuthal resolution [cm]
+  //! \param[in] lonres z-resolution [cm], not used for PHG4TrackFastSim::Vertical_Plane
+  //! \param[in] eff    Efficiency [0-1] for a existing hit to be included in the tracking
+  //! \param[in] noise  Noise hit propability [0-1]
   void add_phg4hits(
       const std::string& phg4hitsNames,
       const DETECTOR_TYPE phg4dettype,


### PR DESCRIPTION
`PHG4TrackFastSim` is used to string `PHG4Hit` from various detectors to make fast digitization and tracking pattern recognition, which is followed up with a Kalman filter fit via GenFit2. This pull request order the `PHG4Hit` by their G4 truth time order, which relax the requirement of inserting the detectors in the order of track traversing. It also allow processing multiple hits in the same layer in a proper order. 

Thanks discussion with Chris Pinkenburg and Reynier Cruz Torres 