### PR TITLE
Put Detector name in histogram title rather than x axis label

### DIFF
--- a/offline/QA/modules/QAG4SimulationIntt.cc
+++ b/offline/QA/modules/QAG4SimulationIntt.cc
@@ -53,43 +53,43 @@ int QAG4SimulationIntt::InitRun(PHCompositeNode *topNode)
     std::cout << PHWHERE << " adding layer " << layer << std::endl;
     {
       // rphi residuals (cluster - truth)
-      auto h = new TH1F( Form( "%sdrphi_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi_{cluster-truth} layer_%i", layer ), 100, -1e-2, 1e-2 );
-      h->GetXaxis()->SetTitle( "INTT r#Delta#phi_{cluster-truth} (cm)" );
+      auto h = new TH1F( Form( "%sdrphi_%i", get_histo_prefix().c_str(), layer ), Form( "INTT r#Delta#phi_{cluster-truth} layer_%i", layer ), 100, -1e-2, 1e-2 );
+      h->GetXaxis()->SetTitle( "r#Delta#phi_{cluster-truth} (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // rphi cluster errors
-      auto h = new TH1F( Form( "%srphi_error_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi error layer_%i", layer ), 100, 0, 1e-2 );
-      h->GetXaxis()->SetTitle( "INTT r#Delta#phi error (cm)" );
+      auto h = new TH1F( Form( "%srphi_error_%i", get_histo_prefix().c_str(), layer ), Form( "INTT r#Delta#phi error layer_%i", layer ), 100, 0, 1e-2 );
+      h->GetXaxis()->SetTitle( "r#Delta#phi error (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // phi pulls (cluster - truth)
-      auto h = new TH1F( Form( "%sphi_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "#Delta#phi_{cluster-truth}/#sigma#phi layer_%i", layer ), 100, -3, 3 );
-      h->GetXaxis()->SetTitle( "INTT #Delta#phi_{cluster-truth}/#sigma#phi (cm)" );
+      auto h = new TH1F( Form( "%sphi_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "INTT #Delta#phi_{cluster-truth}/#sigma#phi layer_%i", layer ), 100, -3, 3 );
+      h->GetXaxis()->SetTitle( "#Delta#phi_{cluster-truth}/#sigma#phi (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z residuals (cluster - truth)
-      auto h = new TH1F( Form( "%sdz_%i", get_histo_prefix().c_str(), layer ), Form( "#Deltaz_{cluster-truth} layer_%i", layer ), 100, -2.5, 2.5 );
-      h->GetXaxis()->SetTitle( "INTT #Delta#z_{cluster-truth} (cm)" );
+      auto h = new TH1F( Form( "%sdz_%i", get_histo_prefix().c_str(), layer ), Form( "INTT #Deltaz_{cluster-truth} layer_%i", layer ), 100, -2.5, 2.5 );
+      h->GetXaxis()->SetTitle( "#Delta#z_{cluster-truth} (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z cluster errors
-      auto h = new TH1F( Form( "%sz_error_%i", get_histo_prefix().c_str(), layer ), Form( "z error layer_%i", layer ), 100, 0, 2.5 );
-      h->GetXaxis()->SetTitle( "INTT z error (cm)" );
+      auto h = new TH1F( Form( "%sz_error_%i", get_histo_prefix().c_str(), layer ), Form( "INTT z error layer_%i", layer ), 100, 0, 2.5 );
+      h->GetXaxis()->SetTitle( "z error (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z pulls (cluster - truth)
-      auto h = new TH1F( Form( "%sz_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "#Deltaz_{cluster-truth}/#sigmaz layer_%i", layer ), 100, -3, 3 );
-      h->GetXaxis()->SetTitle( "INTT #Delta#z_{cluster-truth}/#sigmaz (cm)" );
+      auto h = new TH1F( Form( "%sz_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "INTT #Deltaz_{cluster-truth}/#sigmaz layer_%i", layer ), 100, -3, 3 );
+      h->GetXaxis()->SetTitle( "#Delta#z_{cluster-truth}/#sigmaz (cm)" );
       hm->registerHisto(h);
     }
 

--- a/offline/QA/modules/QAG4SimulationMvtx.cc
+++ b/offline/QA/modules/QAG4SimulationMvtx.cc
@@ -53,43 +53,43 @@ int QAG4SimulationMvtx::InitRun(PHCompositeNode *topNode)
     std::cout << PHWHERE << " adding layer " << layer << std::endl;
     {
       // rphi residuals (cluster - truth)
-      auto h = new TH1F( Form( "%sdrphi_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi_{cluster-truth} layer_%i", layer ), 100, -2e-3, 2e-3 );
-      h->GetXaxis()->SetTitle( "MVTX r#Delta#phi_{cluster-truth} (cm)" );
+      auto h = new TH1F( Form( "%sdrphi_%i", get_histo_prefix().c_str(), layer ), Form( "MVTX r#Delta#phi_{cluster-truth} layer_%i", layer ), 100, -2e-3, 2e-3 );
+      h->GetXaxis()->SetTitle( "r#Delta#phi_{cluster-truth} (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // rphi cluster errors
-      auto h = new TH1F( Form( "%srphi_error_%i", get_histo_prefix().c_str(), layer ), Form( "r#Delta#phi error layer_%i", layer ), 100, 0, 2e-3 );
-      h->GetXaxis()->SetTitle( "MVTX r#Delta#phi error (cm)" );
+      auto h = new TH1F( Form( "%srphi_error_%i", get_histo_prefix().c_str(), layer ), Form( "MVTX r#Delta#phi error layer_%i", layer ), 100, 0, 2e-3 );
+      h->GetXaxis()->SetTitle( "r#Delta#phi error (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // phi pulls (cluster - truth)
-      auto h = new TH1F( Form( "%sphi_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "#Delta#phi_{cluster-truth}/#sigma#phi layer_%i", layer ), 100, -3, 3 );
-      h->GetXaxis()->SetTitle( "MVTX #Delta#phi_{cluster-truth}/#sigma#phi (cm)" );
+      auto h = new TH1F( Form( "%sphi_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "MVTX #Delta#phi_{cluster-truth}/#sigma#phi layer_%i", layer ), 100, -3, 3 );
+      h->GetXaxis()->SetTitle( "#Delta#phi_{cluster-truth}/#sigma#phi (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z residuals (cluster - truth)
-      auto h = new TH1F( Form( "%sdz_%i", get_histo_prefix().c_str(), layer ), Form( "#Deltaz_{cluster-truth} layer_%i", layer ), 100, -3e-3, 3e-3 );
-      h->GetXaxis()->SetTitle( "MVTX #Delta#z_{cluster-truth} (cm)" );
+      auto h = new TH1F( Form( "%sdz_%i", get_histo_prefix().c_str(), layer ), Form( "MVTX #Deltaz_{cluster-truth} layer_%i", layer ), 100, -3e-3, 3e-3 );
+      h->GetXaxis()->SetTitle( "#Delta#z_{cluster-truth} (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z cluster errors
-      auto h = new TH1F( Form( "%sz_error_%i", get_histo_prefix().c_str(), layer ), Form( "z error layer_%i", layer ), 100, 0, 3e-3 );
-      h->GetXaxis()->SetTitle( "MVTX z error (cm)" );
+      auto h = new TH1F( Form( "%sz_error_%i", get_histo_prefix().c_str(), layer ), Form( "MVTX z error layer_%i", layer ), 100, 0, 3e-3 );
+      h->GetXaxis()->SetTitle( "z error (cm)" );
       hm->registerHisto(h);
     }
 
     {
       // z pulls (cluster - truth)
-      auto h = new TH1F( Form( "%sz_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "#Deltaz_{cluster-truth}/#sigmaz layer_%i", layer ), 100, -3, 3 );
-      h->GetXaxis()->SetTitle( "MVTX #Delta#z_{cluster-truth}/#sigmaz (cm)" );
+      auto h = new TH1F( Form( "%sz_pulls_%i", get_histo_prefix().c_str(), layer ), Form( "MVTX #Deltaz_{cluster-truth}/#sigmaz layer_%i", layer ), 100, -3, 3 );
+      h->GetXaxis()->SetTitle( "#Delta#z_{cluster-truth}/#sigmaz (cm)" );
       hm->registerHisto(h);
     }
 


### PR DESCRIPTION
This PR fixes a bug introduced when defining QA histograms for INTT and MVTX.
For clarity, the detector name should be in the histogram title, not on the x axis title. Sorry.