### PR TITLE
Upstream/master qa clusters

### DIFF
--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -244,10 +244,10 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
         { 
           iter->second.insert( key ); 
         } else {        
-          g4particle_map.insert( iter, std::make_pair( trkid, KeySet( {key} ) ) );        
+          g4particle_map.insert( iter, std::make_pair( trkid, KeySet({key}) ) );        
         }      
-      } // loop over g4hits
-    }   // loop over clusters
+      }
+    }
   }
   
   PHG4TruthInfoContainer::ConstRange range = m_truthContainer->GetPrimaryParticleRange();
@@ -334,7 +334,7 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
       {
         for( const auto& cluster_key:mapIter->second )
         { h_nClus_layerGen->Fill( TrkrDefs::getLayer(cluster_key) ); }
-      } else {
+      } else if( Verbosity() ) {
         std::cout << "QAG4SimulationTracking::process_event - could nof find clusters associated to G4Particle " << iter->first << std::endl;
       }
     }

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -10,8 +10,12 @@
 #include <utility>
 
 class PHCompositeNode;
+class PHG4HitContainer;
 class PHG4TruthInfoContainer;
 class SvtxTrack;
+class TrkrClusterContainer;
+class TrkrClusterHitAssoc;
+class TrkrHitTruthAssoc;
 
 /// \class QAG4SimulationTracking
 class QAG4SimulationTracking : public SubsysReco
@@ -47,6 +51,13 @@ class QAG4SimulationTracking : public SubsysReco
 
  private:
 
+  /// load nodes
+  int load_nodes( PHCompositeNode* );
+  
+  // get geant hits associated to a cluster
+  using G4HitSet = std::set<PHG4Hit*>;
+  G4HitSet find_g4hits( TrkrDefs::cluskey ) const;
+  
   std::unique_ptr<SvtxEvalStack> m_svtxEvalStack;
   std::set<int> m_embeddingIDs;
 
@@ -57,6 +68,15 @@ class QAG4SimulationTracking : public SubsysReco
   bool m_uniqueTrackingMatch = true;
 
   PHG4TruthInfoContainer *m_truthContainer = nullptr;
+  
+  TrkrClusterContainer* m_cluster_map = nullptr;
+  TrkrClusterHitAssoc* m_cluster_hit_map = nullptr;
+  TrkrHitTruthAssoc* m_hit_truth_map = nullptr;
+
+  PHG4HitContainer *m_g4hits_tpc = nullptr;
+  PHG4HitContainer *m_g4hits_intt = nullptr;
+  PHG4HitContainer *m_g4hits_mvtx = nullptr;
+
 };
 
 #endif  // QA_QAG4SimulationTracking_H


### PR DESCRIPTION
This PR adds an histogram to get the number of clusters/layer/truth_track
Association from cluster to truth track is done in the same way as in PHTruthTrackSeeding: clusters->hit->g4hits->g4particle
(and in fact it was checked that this histogram is identical to the clusters/layer/reco_track, when running truth track finding).
Resulting histogram is left panel of: 

![G4sPHENIX root_qa root_QA_Draw_Tracking_nClus_Layer_QAG4SimulationTracking](https://user-images.githubusercontent.com/22907496/81346638-de1a6080-9077-11ea-870f-ab7340eb0d69.png)

It is similar to that shown at https://indico.bnl.gov/event/7413/contributions/37321/attachments/27916/42843/talk.pdf, slide 10. (differences are due to less strict track selection in the former case)
