### PR TITLE
Acts Track Fitter 

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -74,7 +74,7 @@ MakeActsGeometry::MakeActsGeometry(const string &name)
   , m_geoManager(nullptr)
   , m_minSurfZ(0.0)
   , m_maxSurfZ(105.5)
-  , m_nSurfZ(11)
+  , m_nSurfZ(1)
   , m_nSurfPhi(10)
   , m_verbosity(0)
 {

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -656,7 +656,7 @@ Surface MakeActsGeometry::getTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey,
   
   if(mapIter == m_clusterSurfaceMapTpcEdit.end())
     {
-      cout << PHWHERE << "Error: hitsetkey not found in clusterSrfaceMap, hitsetkey = " << hitsetkey << endl;
+      cout << PHWHERE << "Error: hitsetkey not found in clusterSurfaceMap, hitsetkey = " << hitsetkey << endl;
       return nullptr;
     }
 
@@ -668,10 +668,7 @@ Surface MakeActsGeometry::getTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey,
   for(unsigned int i=0;i<surf_vec.size(); ++i)
     {
       Surface this_surf = surf_vec[i];
-      /*
-      cout << endl << "Stream of surface number " << i << endl;
-      this_surf->toStream(m_geoCtxt, std::cout);   cout << endl;
-  */
+  
       auto vec3d = this_surf->center(m_geoCtxt);
       std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
       double surf_phi = atan2(surf_center[1], surf_center[0]);

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -26,10 +26,12 @@
 #include <phool/phool.h>
 
 /// Acts includes
-#include <ACTFW/Utilities/Options.hpp>
 #include <Acts/Surfaces/PerigeeSurface.hpp>
 #include <Acts/Surfaces/PlaneSurface.hpp>
 #include <Acts/Surfaces/Surface.hpp>
+#include <Acts/Utilities/Units.hpp>
+
+#include <ACTFW/Utilities/Options.hpp>
 
 /// std (and the like) includes
 #include <cmath>
@@ -76,7 +78,7 @@ int PHActsSourceLinks::InitRun(PHCompositeNode *topNode)
   /// Check if Acts geometry has been built and is on the node tree
   m_actsGeometry = new MakeActsGeometry();
   
-  m_actsGeometry->setVerbosity(Verbosity());
+  m_actsGeometry->setVerbosity(0);
   m_actsGeometry->buildAllGeometry(topNode);
 
   /// Set the tGeometry struct to be put on the node tree
@@ -175,10 +177,10 @@ int PHActsSourceLinks::process_event(PHCompositeNode *topNode)
 
     /// Get the 2D location covariance uncertainty for the cluster
     Acts::BoundMatrix cov = Acts::BoundMatrix::Zero();
-    cov(Acts::eLOC_0, Acts::eLOC_0) = localErr[0][0];
-    cov(Acts::eLOC_1, Acts::eLOC_0) = localErr[1][0];
-    cov(Acts::eLOC_0, Acts::eLOC_1) = localErr[0][1];
-    cov(Acts::eLOC_1, Acts::eLOC_1) = localErr[1][1];
+    cov(Acts::eLOC_0, Acts::eLOC_0) = localErr[0][0] * Acts::UnitConstants::cm2;
+    cov(Acts::eLOC_1, Acts::eLOC_0) = localErr[1][0] * Acts::UnitConstants::cm2;
+    cov(Acts::eLOC_0, Acts::eLOC_1) = localErr[0][1] * Acts::UnitConstants::cm2;
+    cov(Acts::eLOC_1, Acts::eLOC_1) = localErr[1][1] * Acts::UnitConstants::cm2;
 
     /// local and localErr contain the position and covariance
     /// matrix in local coords
@@ -197,8 +199,8 @@ int PHActsSourceLinks::process_event(PHCompositeNode *topNode)
 
     /// Cluster positions on GeoObject/Surface
     Acts::BoundVector loc = Acts::BoundVector::Zero();
-    loc[Acts::eLOC_0] = local2D[0];
-    loc[Acts::eLOC_1] = local2D[1];
+    loc[Acts::eLOC_0] = local2D[0] * Acts::UnitConstants::cm;
+    loc[Acts::eLOC_1] = local2D[1] * Acts::UnitConstants::cm;
 
     if (Verbosity() > 0)
     {
@@ -652,6 +654,8 @@ Surface PHActsSourceLinks::getSurfaceFromClusterMap(TrkrDefs::hitsetkey hitSetKe
       std::cout << "Got surface pair " << surface->name()
                 << " surface type " << surface->type()
                 << std::endl;
+      surface->toStream(m_tGeometry->geoContext, std::cout);
+      std::cout<<std::endl;
     }
   }
   else

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -232,9 +232,19 @@ int PHActsSourceLinks::process_event(PHCompositeNode *topNode)
     }
   }
 
-  /// Add the data to the nodes that were previously created (?)
 
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHActsSourceLinks::ResetEvent(PHCompositeNode *topNode)
+{
+  /// Clear out the maps for the next event
+  m_hitIdClusKey->clear();
+  m_sourceLinks->clear();
+  
+
+  return Fun4AllReturnCodes::EVENT_OK;
+
 }
 
 int PHActsSourceLinks::End(PHCompositeNode *topNode)

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -94,7 +94,8 @@ class PHActsSourceLinks : public SubsysReco
   int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
-
+  int ResetEvent(PHCompositeNode *topNode);
+  
  private:
   /**
    * Functions

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -40,12 +40,6 @@ PHActsTracks::PHActsTracks(const std::string &name)
 
 int PHActsTracks::End(PHCompositeNode *topNode)
 {
-  outfile->cd();
-  h_x->Write();
-  h_y->Write();
-  h_z->Write();
-  outfile->Write();
-  outfile->Close();
 
   if (Verbosity() > 10)
   {
@@ -57,10 +51,6 @@ int PHActsTracks::End(PHCompositeNode *topNode)
 
 int PHActsTracks::Init(PHCompositeNode *topNode)
 {
-  outfile = new TFile("trackPropAnalysis.root","RECREATE");
-  h_x = new TH1F("h_x",";x [cm]",50,-5,5);
-  h_y = new TH1F("h_y",";y [cm]",50,-5,5);
-  h_z = new TH1F("h_z",";z [cm]",100,-50,50);
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -99,10 +89,6 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
       std::cout << "found SvtxTrack " << trackIter->first << std::endl;
       track->identify();
     }
-
-    h_x->Fill(track->get_x());
-    h_y->Fill(track->get_y());
-    h_z->Fill(track->get_z());
 
     /// Get the necessary parameters and values for the TrackParameters
     const Acts::BoundSymMatrix seedCov = getActsCovMatrix(track);

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -40,6 +40,13 @@ PHActsTracks::PHActsTracks(const std::string &name)
 
 int PHActsTracks::End(PHCompositeNode *topNode)
 {
+  outfile->cd();
+  h_x->Write();
+  h_y->Write();
+  h_z->Write();
+  outfile->Write();
+  outfile->Close();
+
   if (Verbosity() > 10)
   {
     std::cout << "Finished PHActsTracks" << std::endl;
@@ -50,6 +57,10 @@ int PHActsTracks::End(PHCompositeNode *topNode)
 
 int PHActsTracks::Init(PHCompositeNode *topNode)
 {
+  outfile = new TFile("trackPropAnalysis.root","RECREATE");
+  h_x = new TH1F("h_x",";x [cm]",50,-5,5);
+  h_y = new TH1F("h_y",";y [cm]",50,-5,5);
+  h_z = new TH1F("h_z",";z [cm]",100,-50,50);
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -88,6 +99,10 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
       std::cout << "found SvtxTrack " << trackIter->first << std::endl;
       track->identify();
     }
+
+    h_x->Fill(track->get_x());
+    h_y->Fill(track->get_y());
+    h_z->Fill(track->get_z());
 
     /// Get the necessary parameters and values for the TrackParameters
     const Acts::BoundSymMatrix seedCov = getActsCovMatrix(track);
@@ -148,6 +163,13 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+
+int PHActsTracks::ResetEvent(PHCompositeNode *topNode)
+{
+  /// Reset the proto track vector after each event
+  m_actsProtoTracks->clear();
+  return Fun4AllReturnCodes::EVENT_OK;
+}
 Acts::BoundSymMatrix PHActsTracks::getActsCovMatrix(const SvtxTrack *track)
 {
   Acts::BoundSymMatrix matrix = Acts::BoundSymMatrix::Zero();

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -26,12 +26,14 @@
 
 #include <TMatrixDSym.h>
 
+
 PHActsTracks::PHActsTracks(const std::string &name)
   : SubsysReco(name)
   , m_actsProtoTracks(nullptr)
   , m_trackMap(nullptr)
   , m_hitIdClusKey(nullptr)
   , m_sourceLinks(nullptr)
+  , m_tGeometry(nullptr)
 {
   Verbosity(0);
 }
@@ -89,19 +91,20 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 
     /// Get the necessary parameters and values for the TrackParameters
     const Acts::BoundSymMatrix seedCov = getActsCovMatrix(track);
-    const Acts::Vector3D seedPos(track->get_x(),
-                                 track->get_y(),
-                                 track->get_z());
-    const Acts::Vector3D seedMom(track->get_px(),
-                                 track->get_py(),
-                                 track->get_pz());
+    const Acts::Vector3D seedPos(track->get_x()  * Acts::UnitConstants::cm,
+                                 track->get_y()  * Acts::UnitConstants::cm,
+                                 track->get_z()  * Acts::UnitConstants::cm);
+    const Acts::Vector3D seedMom(track->get_px() * Acts::UnitConstants::GeV,
+                                 track->get_py() * Acts::UnitConstants::GeV,
+                                 track->get_pz() * Acts::UnitConstants::GeV);
 
-    // just set to 0 for now?
-    const double trackTime = 0;
+    // just set to 10 ns for now?
+    const double trackTime = 10 * Acts::UnitConstants::ns;
     const int trackQ = track->get_charge();
 
-    const FW::TrackParameters trackSeed(seedCov, seedPos,
-                                        seedMom, trackQ, trackTime);
+    const FW::TrackParameters trackSeed(seedCov, seedPos, seedMom, 
+					trackQ * Acts::UnitConstants::e, 
+					trackTime);
 
     /// Start fresh for this track
     trackSourceLinks.clear();
@@ -112,14 +115,19 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
       const TrkrDefs::cluskey key = *clusIter;
 
       const unsigned int hitId = m_hitIdClusKey->find(key)->second;
-
-      if (Verbosity() > 0)
-      {
-        std::cout << "cluskey " << key
-                  << " has hitid " << hitId
-                  << std::endl;
-      }
+ 
       trackSourceLinks.push_back(m_sourceLinks->find(hitId)->second);
+      
+      if (Verbosity() > 100)
+	{
+
+	  
+	  std::cout << std::endl << "cluskey " << key
+		    << " has hitid " << hitId
+		    << std::endl;
+	  std::cout << "Adding the following surface for this SL" << std::endl;
+	  m_sourceLinks->find(hitId)->second.referenceSurface().toStream(m_tGeometry->geoContext, std::cout);
+	}
     }
 
     if (Verbosity() > 0)
@@ -154,30 +162,80 @@ Acts::BoundSymMatrix PHActsTracks::getActsCovMatrix(const SvtxTrack *track)
   // Get the track seed covariance matrix
   // These are the variances, so the std devs are sqrt(seedCov[i][j])
   Acts::BoundSymMatrix seedCov = Acts::BoundSymMatrix::Zero();
+
   for (int i = 0; i < 6; i++)
   {
     for (int j = 0; j < 6; j++)
     {
       /// Track covariance matrix is in basis (x,y,z,px,py,pz). Need to put
       /// it in form of (x,y,px,py,pz,time) for acts
-      if(i < 2)
-	{
-	  /// get x,y components
-	  seedCov(i, j) = track->get_error(i, j);
-	}
-      else if(i < 5) 
-	{
-	  /// get px,py,pz components 1 row up
-	  seedCov(i,j) = track->get_error(i+1, j);
-	}
-      else if (i == 5) 
-	{
-	  /// convert the global z position covariances to timing covariances
-	  /// TPC z position resolution is 0.05 cm, drift velocity is 8cm/ms
-	  seedCov(i,j) = track->get_error(2, j) * 8. * Acts::UnitConstants::ms; 
-	}
+   int row = -1;
+      int col = -1;
+      if( i < 2)
+	row = i;
+      else if ( i < 5)
+	row = i+1;
+      else if (i == 5)
+	row = 2;
+
+      if( j < 2 )
+	col = j;
+      else if ( j < 5 )
+	col = j+1;
+      else if ( j == 5 )
+	col = 2;
+
+      seedCov(i,j) = track->get_error(row, col);
+      
+      /// get the units right, since acts works in mm
+      /// Don't need to multiply by units of GeV since that is Acts default
+      if(i < 2 && j < 2)
+	seedCov(i,j) *= Acts::UnitConstants::cm2;
+      else if (i < 2 && j < 5 )
+	seedCov(i,j) *= Acts::UnitConstants::cm;
+      else if (i < 5 && j < 2 )
+	seedCov(i,j) *= Acts::UnitConstants::cm;
+
     }
   }
+  
+  /// Set the time column/row to 0
+  for(int i = 5; i< 6; i++)
+    {
+      for(int j = 0; j <6; j++)
+	{
+	  seedCov(i,j) = 0;
+	  seedCov(j,i) = 0;
+	}
+    }
+  /// Just give time a 10 ns covariance for now
+  seedCov(5,5) = 10 * Acts::UnitConstants::ns;
+
+  if(Verbosity() > 10)
+    {
+      std::cout << "Initial covariance: " << std::endl;
+      for(int i =0; i<6; i++)
+	{
+	  std::cout << std::endl;
+	  for(int j= 0; j<6; j++)
+	    {
+	      std::cout << track->get_error(i,j) << ", ";
+	    }
+
+	}
+
+      std::cout << std::endl << "Shifted covariance " << std::endl;
+      for(int i = 0; i < 6; i++)
+	{
+	  std::cout<<std::endl;
+	  for(int j=0; j<6; j++)
+	    {
+	      std::cout << seedCov(i,j) << ", ";
+
+	    }
+	}
+    }
+
 
   /// Need to transform from global to local coordinate frame. 
   /// Amounts to the local transformation as in PHActsSourceLinks as well as
@@ -201,27 +259,82 @@ Acts::BoundSymMatrix PHActsTracks::getActsCovMatrix(const SvtxTrack *track)
 
   /// Momentum vector rotations
   /// phi rotation
-  rotation(2,3) = -1 * uPy / (uPx * uPx + uPy * uPy);
-  rotation(2,4) = -1 * uPx / (uPx * uPx + uPy * uPy);
+  rotation(2,2) = -1 * uPy / (uPx * uPx + uPy * uPy);
+  rotation(2,3) = -1 * uPx / (uPx * uPx + uPy * uPy);
 
   /// theta rotation
   /// Leave uP in for clarity, even though it is trivially unity
-  rotation(3,3) = (uPx * uPz) / (uP * uP * sqrt( uPx * uPx + uPy * uPy) );
-  rotation(3,4) = (uPy * uPz) / (uP * uP * sqrt( uPx * uPx + uPy * uPy) );
-  rotation(3,5) = (-1 * sqrt(uPx * uPx + uPy * uPy)) / (uP * uP);
+  rotation(3,2) = (uPx * uPz) / (uP * uP * sqrt( uPx * uPx + uPy * uPy) );
+  rotation(3,3) = (uPy * uPz) / (uP * uP * sqrt( uPx * uPx + uPy * uPy) );
+  rotation(3,4) = (-1 * sqrt(uPx * uPx + uPy * uPy)) / (uP * uP);
   
-  /// q/p rotation
-  rotation(4,3) = charge / uPx;
-  rotation(4,4) = charge / uPy;
-  rotation(4,5) = charge / uPz;
+  /// p rotation
+  rotation(4,2) = uPx / uP;
+  rotation(4,3) = uPy / uP;
+  rotation(4,4) = uPz / uP;
 
   /// time rotation
   rotation(5,5) = 1;
 
+  if(Verbosity() > 10 )
+    {
+      std::cout << std::endl << "Rotation matrix is : " << std::endl;
+      for(int i = 0; i < 6; i++)
+	{
+	  std::cout << std::endl;
+	  for(int j = 0 ; j < 6 ; j++)
+	    {
+	      std::cout<< rotation(i,j) << ", ";
+	    }
+	}
+
+    }
+
   /// Rotate the covariance matrix by the jacobian rotation matrix
   matrix = rotation * seedCov * rotation.transpose();
 
-  return matrix;
+  if(Verbosity() > 10)
+    {
+      std::cout << std::endl << "Acts rotated covariance " << std::endl;
+      for(int i = 0; i < 6; i++)
+	{
+	  for(int j=0; j<6; j++)
+	    {
+	      std::cout << matrix(i,j) << ", ";
+	      
+	    }
+	  
+	  std::cout << std::endl;
+	}
+    }
+
+  /// Rotate again to get q/p instead of p
+  Acts::BoundSymMatrix qprotation = Acts::BoundSymMatrix::Zero();
+  qprotation(0,0) = 1;
+  qprotation(1,1) = 1;
+  qprotation(2,2) = 1;
+  qprotation(3,3) = 1;
+  qprotation(4,4) = charge * charge / (p * p * p * p);
+  qprotation(5,5) = 1;
+  
+  Acts::BoundSymMatrix finalMatrix = Acts::BoundSymMatrix::Zero();
+  finalMatrix = qprotation * matrix * qprotation.transpose();
+  
+    if(Verbosity() > 10)
+    {
+      std::cout << std::endl << "Acts rotated rotated covariance " << std::endl;
+      for(int i = 0; i < 6; i++)
+	{
+	  std::cout << std::endl;
+	  for(int j=0; j<6; j++)
+	    {
+	      std::cout << finalMatrix(i,j) << ", ";
+	      
+	    }
+	}
+    }
+  
+  return finalMatrix;
 }
 
 void PHActsTracks::createNodes(PHCompositeNode *topNode)
@@ -279,6 +392,15 @@ int PHActsTracks::getNodes(PHCompositeNode *topNode)
 
     return Fun4AllReturnCodes::ABORTEVENT;
   }
+
+  m_tGeometry = findNode::getClass<ActsTrackingGeometry>(topNode, "ActsTrackingGeometry");
+
+  if(!m_tGeometry)
+    {
+      std::cout << PHWHERE << "ActsTrackingGeometry not on node tree, exiting."
+		<< std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
 
   m_hitIdClusKey = findNode::getClass<std::map<TrkrDefs::cluskey, unsigned int>>(topNode, "HitIDClusIDActsMap");
 

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -177,7 +177,7 @@ Acts::BoundSymMatrix PHActsTracks::getActsCovMatrix(const SvtxTrack *track)
     {
       /// Track covariance matrix is in basis (x,y,z,px,py,pz). Need to put
       /// it in form of (x,y,px,py,pz,time) for acts
-   int row = -1;
+      int row = -1;
       int col = -1;
       if( i < 2)
 	row = i;

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -18,10 +18,6 @@
 
 #include "ActsTrack.h"
 
-#include <TFile.h>
-#include <TH1.h>
-#include <TH2.h>
-
 #include <map>
 #include <string>
 #include <vector>
@@ -72,8 +68,6 @@ class PHActsTracks : public SubsysReco
    * Member variables
    */
 
-  TFile *outfile;
-  TH1F *h_x, *h_y, *h_z;
   /// A vector to hold the source links corresponding to a particular SvtxTrack
   std::vector<SourceLink> m_trackSourceLinks;
 

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -71,9 +71,8 @@ class PHActsTracks : public SubsysReco
   /// A vector to hold the source links corresponding to a particular SvtxTrack
   std::vector<SourceLink> m_trackSourceLinks;
 
-  /// A map of an Acts track seed and Acts-sPHENIX source links corresponding
-  /// to that track seed
-  std::vector<ActsTrack> *m_actsProtoTracks;
+  /// A map corresponding the ActsTrack instance to the SvtxTrack key
+  std::map<unsigned int , ActsTrack> *m_actsTrackMap;
 
   /// Trackmap that contains SvtxTracks
   SvtxTrackMap *m_trackMap;

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -1,6 +1,8 @@
 #ifndef TRACKRECO_PHACTSTRACKS_H
 #define TRACKRECO_PHACTSTRACKS_H
 
+#include "PHActsSourceLinks.h" 
+
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
 
@@ -23,6 +25,7 @@
 class PHCompositeNode;
 class SvtxTrackMap;
 class SvtxTrack;
+class MakeActsGeometry;
 
 using SourceLink = FW::Data::TrkrClusterSourceLink;
 
@@ -79,6 +82,8 @@ class PHActsTracks : public SubsysReco
 
   /// Map of hitid:SourceLinks created in PHActsSourceLinks
   std::map<unsigned int, SourceLink> *m_sourceLinks;
+
+  ActsTrackingGeometry *m_tGeometry;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -18,6 +18,10 @@
 
 #include "ActsTrack.h"
 
+#include <TFile.h>
+#include <TH1.h>
+#include <TH2.h>
+
 #include <map>
 #include <string>
 #include <vector>
@@ -49,6 +53,7 @@ class PHActsTracks : public SubsysReco
   int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
+  int ResetEvent(PHCompositeNode *topNode);
 
  private:
   /** 
@@ -67,6 +72,8 @@ class PHActsTracks : public SubsysReco
    * Member variables
    */
 
+  TFile *outfile;
+  TH1F *h_x, *h_y, *h_z;
   /// A vector to hold the source links corresponding to a particular SvtxTrack
   std::vector<SourceLink> m_trackSourceLinks;
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -46,7 +46,7 @@ int PHActsTrkFitter::Setup(PHCompositeNode* topNode)
   fitCfg.fit = FW::TrkrClusterFittingAlgorithm::makeFitterFunction(
                m_tGeometry->tGeometry,
 	       m_tGeometry->magField,
-	       Acts::Logging::VERBOSE);
+	       Acts::Logging::INFO);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -77,6 +77,13 @@ int PHActsTrkFitter::Process()
     std::vector<SourceLink> sourceLinks = track.getSourceLinks();
     FW::TrackParameters trackSeed = track.getTrackParams();
       
+    if(Verbosity() > 10)
+      {
+	std::cout << " Processing proto track with position:" 
+		  << trackSeed.position() << std::endl 
+		  << "momentum: " << trackSeed.momentum() << std::endl;
+
+      }
     /// Call KF now. Have a vector of sourceLinks corresponding to clusters
     /// associated to this track and the corresponding track seed which
     /// corresponds to the PHGenFitTrkProp track seeds
@@ -92,9 +99,11 @@ int PHActsTrkFitter::Process()
     /// Check that the result is okay
     if (result.ok())
     {
+      std::cout<<"Result is okay"<<std::endl;
       const auto& fitOutput = result.value();
       if (fitOutput.fittedParameters)
       {
+	std::cout<<"got fitted parameters"<<std::endl;
         const auto& params = fitOutput.fittedParameters.value();
         /// Get position, momentum from params
         if (Verbosity() > 10)
@@ -142,7 +151,7 @@ int PHActsTrkFitter::getNodes(PHCompositeNode* topNode)
   m_tGeometry = findNode::getClass<ActsTrackingGeometry>(topNode, "ActsTrackingGeometry");
   if(!m_tGeometry)
     {
-      std::cout << "ActsContext not on node tree. Exiting."
+      std::cout << "ActsTrackingGeometry not on node tree. Exiting."
 		<< std::endl;
       
       return Fun4AllReturnCodes::ABORTEVENT;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -110,13 +110,12 @@ int PHActsTrkFitter::Process()
       const Acts::KalmanFitterResult<SourceLink>& fitOutput = result.value();
       if (fitOutput.fittedParameters)
       {
-	SvtxTrack *track = convertActsToSvtx(fitOutput, trackKey);
-	if(!track)
-	  std::cout<<std::endl;
-        const auto& params = fitOutput.fittedParameters.value();
+	convertActsToSvtx(fitOutput, trackKey);
+
         /// Get position, momentum from params
         if (Verbosity() > 10)
         {
+	  const auto& params = fitOutput.fittedParameters.value();
           std::cout << "Fitted parameters for track" << std::endl;
           std::cout << " position : " << params.position().transpose()
                     << std::endl;
@@ -125,10 +124,7 @@ int PHActsTrkFitter::Process()
         }
       }
     }
-
-    /// Update the acts track node on the node tree
     
-
 
   }
 
@@ -144,12 +140,139 @@ int PHActsTrkFitter::End(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-SvtxTrack* PHActsTrkFitter::convertActsToSvtx(const Acts::KalmanFitterResult<SourceLink>& fitOutput, const unsigned int trackKey)
+void PHActsTrkFitter::convertActsToSvtx(const Acts::KalmanFitterResult<SourceLink>& fitOutput, const unsigned int trackKey)
 {
+  const auto& params = fitOutput.fittedParameters.value();
+ 
+  SvtxTrackMap::Iter trackIter = m_trackMap->find(trackKey);
+  SvtxTrack *track = trackIter->second;
 
-  return nullptr;
+  track->set_x(params.position()(0));
+  track->set_y(params.position()(1));
+  track->set_z(params.position()(2));
+  track->set_px(params.momentum()(0));
+  track->set_py(params.momentum()(1));
+  track->set_pz(params.momentum()(2));
+  
+
+  if(params.covariance())
+    {
+   
+      Acts::BoundSymMatrix rotatedCov = rotateCovarianceLocalToGlobal(fitOutput);
+      for(int i = 0; i < 6; i++)
+	{
+	  for(int j = 0; j < 6; j++)
+	    {
+	      track->set_error(i,j, rotatedCov(i,j));
+	    }
+	}
+    }
+ 
+
+
 }
 
+Acts::BoundSymMatrix PHActsTrkFitter::rotateCovarianceLocalToGlobal(
+                     const Acts::KalmanFitterResult<SourceLink>& fitOutput)
+{
+  Acts::BoundSymMatrix matrix = Acts::BoundSymMatrix::Zero();
+  
+  const auto& params = fitOutput.fittedParameters.value();
+  auto covarianceMatrix = *params.covariance();
+
+  const double px = params.momentum()(0);
+  const double py = params.momentum()(1);
+  const double pz = params.momentum()(2);
+  const double p = sqrt(px * px + py * py + pz * pz);
+  
+  const double x = params.position()(0);
+  const double y = params.position()(1);
+
+  const int charge = params.charge();
+  const double phiPos = atan2(x, y);
+
+  /// We need to rotate the opposite of what was done in PHActsTracks.
+  /// So first rotate from (x_l, y_l, phi, theta, q/p, time) to 
+  /// (x_l, y_l, phi, theta, p, time)
+
+  Acts::BoundSymMatrix qprotation = Acts::BoundSymMatrix::Zero();
+  qprotation(0,0) = 1;
+  qprotation(1,1) = 1;
+  qprotation(2,2) = 1;
+  qprotation(3,3) = 1;
+  qprotation(4,4) = charge * charge / (p * p * p * p);
+  qprotation(5,5) = 1;
+  
+  /// Want the inverse of the rotation matrix from PHActsTracks 
+  /// because we are rotating back from local to global. So we do R^TCR 
+  /// rather than RCR^T
+  matrix = qprotation.transpose() * covarianceMatrix * qprotation;
+
+  /// Now rotate to (x_g, y_g, px, py, pz, t)
+  /// Make a unit p vector for the rotation
+  const double uPx = px / p;
+  const double uPy = py / p;
+  const double uPz = pz / p;
+  const double uP = sqrt(uPx * uPx + uPy * uPy + uPz * uPz);
+  
+  Acts::BoundSymMatrix rotation = Acts::BoundSymMatrix::Zero();
+  /// Local position rotations
+  rotation(0,0) = cos(phiPos);
+  rotation(0,1) = sin(phiPos);
+  rotation(1,0) = -1 * sin(phiPos);
+  rotation(1,1) = cos(phiPos);
+
+  /// Momentum vector rotations
+  /// phi rotation
+  rotation(2,2) = -1 * uPy / (uPx * uPx + uPy * uPy);
+  rotation(2,3) = -1 * uPx / (uPx * uPx + uPy * uPy);
+
+  /// theta rotation
+  /// Leave uP in for clarity, even though it is trivially unity
+  rotation(3,2) = (uPx * uPz) / (uP * uP * sqrt( uPx * uPx + uPy * uPy) );
+  rotation(3,3) = (uPy * uPz) / (uP * uP * sqrt( uPx * uPx + uPy * uPy) );
+  rotation(3,4) = (-1 * sqrt(uPx * uPx + uPy * uPy)) / (uP * uP);
+  
+  /// p rotation
+  rotation(4,2) = uPx / uP;
+  rotation(4,3) = uPy / uP;
+  rotation(4,4) = uPz / uP;
+
+  /// time rotation
+  rotation(5,5) = 1;
+  /// Undoing the rotation, so R^TCR instead of RCR^T
+  matrix = rotation.transpose() * matrix * rotation;
+  
+  /// Now matrix is in basis (x_g, y_g, px, py, pz, t)
+  /// Shift rows and columns to get like (x_g, y_g, z, px, py, pz)
+  Acts::BoundSymMatrix svtxCovariance = Acts::BoundSymMatrix::Zero();
+  for(int i = 0; i < 6; i++ )
+    {
+      for(int j = 0; j < 6; j++ )
+	{
+	  int row = -1;
+	  int col = -1;
+	  if( i < 2)
+	    row = i;
+	  else if ( i < 5)
+	    row = i+1;
+	  else if (i == 5)
+	    row = 2;
+	  
+	  if( j < 2 )
+	    col = j;
+	  else if ( j < 5 )
+	    col = j+1;
+	  else if ( j == 5 )
+	    col = 2;
+	  
+	  svtxCovariance(row,col) = matrix(i, j);
+	}
+    }
+
+
+  return svtxCovariance;
+}
 
 int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
 {
@@ -173,6 +296,15 @@ int PHActsTrkFitter::getNodes(PHCompositeNode* topNode)
       std::cout << "ActsTrackingGeometry not on node tree. Exiting."
 		<< std::endl;
       
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  
+  if(!m_trackMap)
+    {
+      std::cout << PHWHERE << "SvtxTrackMap not found on node tree. Exiting."
+		<< std::endl;
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -21,6 +21,7 @@
 #include <Acts/Surfaces/PerigeeSurface.hpp>
 #include <Acts/Surfaces/PlaneSurface.hpp>
 #include <Acts/Surfaces/Surface.hpp>
+#include <Acts/EventData/MultiTrajectory.hpp>
 
 #include <ACTFW/EventData/Track.hpp>
 #include <ACTFW/Framework/AlgorithmContext.hpp>
@@ -153,7 +154,9 @@ void PHActsTrkFitter::updateSvtxTrack(const Acts::KalmanFitterResult<SourceLink>
   track->set_px(params.momentum()(0));
   track->set_py(params.momentum()(1));
   track->set_pz(params.momentum()(2));
-  
+
+  /// This will contain the chi2/ndf
+  Acts::MultiTrajectory<SourceLink> states = fitOutput.fittedStates;
 
   if(params.covariance())
     {

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -59,8 +59,7 @@ int PHActsTrkFitter::Process()
 {
 
   m_event++;
-  if(m_event % 10 == 0)
-    std::cout << "Processed " << m_event << " events " << std::endl;
+
   if (Verbosity() > 1)
   {
     std::cout << PHWHERE << "Events processed: " << m_event << std::endl;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -37,10 +37,10 @@ PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   , m_event(0)
   , m_actsProtoTracks(nullptr)
   , m_tGeometry(nullptr)
+  , m_trackMap(nullptr)
   , m_timeAnalysis(false)
-  , m_trackMap(null)
-  , m_timeFile(null)
-  , h_eventTime(null)
+  , m_timeFile(nullptr)
+  , h_eventTime(nullptr)
 {
   Verbosity(0);
 }

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -38,6 +38,9 @@ PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   , m_actsProtoTracks(nullptr)
   , m_tGeometry(nullptr)
   , m_timeAnalysis(false)
+  , m_trackMap(null)
+  , m_timeFile(null)
+  , h_eventTime(null)
 {
   Verbosity(0);
 }
@@ -58,7 +61,7 @@ int PHActsTrkFitter::Setup(PHCompositeNode* topNode)
 
   if(m_timeAnalysis)
     {
-      timeFile = new TFile("ActsTimeFile.root","RECREATE");
+      m_timeFile = new TFile("ActsTimeFile.root","RECREATE");
       h_eventTime = new TH1F("h_eventTime",";time [ms]",100,0,100);
     }		 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -150,10 +153,10 @@ int PHActsTrkFitter::End(PHCompositeNode* topNode)
 {
   if(m_timeAnalysis)
     {
-      timeFile->cd();
+      m_timeFile->cd();
       h_eventTime->Write();
-      timeFile->Write();
-      timeFile->Close();
+      m_timeFile->Write();
+      m_timeFile->Close();
     } 
 
   if (Verbosity() > 10)

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -24,6 +24,8 @@
 
 #include <memory>
 #include <string>
+#include <TFile.h>
+#include <TH1.h>
 
 namespace FW
 {
@@ -57,6 +59,8 @@ class PHActsTrkFitter : public PHTrackFitting
   /// Process each event by calling the fitter
   int Process();
 
+  void setTimeAnalysis(bool time){m_timeAnalysis = time;}
+
  private:
   /// Event counter
   int m_event;
@@ -67,6 +71,8 @@ class PHActsTrkFitter : public PHTrackFitting
   /// Create new nodes
   int createNodes(PHCompositeNode*);
 
+  /// Rotate the covariance from Acts local coordinates back to 
+  /// sPHENIX global coordinates
   Acts::BoundSymMatrix rotateCovarianceLocalToGlobal(const Acts::KalmanFitterResult<SourceLink>& fitOutput);
 
   /// Convert the acts track fit result to an svtx track
@@ -84,6 +90,11 @@ class PHActsTrkFitter : public PHTrackFitting
   /// TrackMap containing SvtxTracks
   SvtxTrackMap *m_trackMap;
 
+  /// Variables for doing event time execution analysis
+  bool m_timeAnalysis;
+  TFile *timeFile;
+  TH1 *h_eventTime;
+  
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -67,8 +67,10 @@ class PHActsTrkFitter : public PHTrackFitting
   /// Create new nodes
   int createNodes(PHCompositeNode*);
 
+  Acts::BoundSymMatrix rotateCovarianceLocalToGlobal(const Acts::KalmanFitterResult<SourceLink>& fitOutput);
+
   /// Convert the acts track fit result to an svtx track
-  SvtxTrack* convertActsToSvtx(const Acts::KalmanFitterResult<SourceLink>& fitOutput, const unsigned int trackKey);
+  void convertActsToSvtx(const Acts::KalmanFitterResult<SourceLink>& fitOutput, const unsigned int trackKey);
 
   /// Map of acts tracks and track key created by PHActsTracks
   std::map<unsigned int, ActsTrack>* m_actsProtoTracks;
@@ -79,6 +81,8 @@ class PHActsTrkFitter : public PHTrackFitting
   /// Configuration containing the fitting function instance
   FW::TrkrClusterFittingAlgorithm::Config fitCfg;
 
+  /// TrackMap containing SvtxTracks
+  SvtxTrackMap *m_trackMap;
 
 };
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -35,7 +35,8 @@ namespace FW
 
 class ActsTrack;
 class MakeActsGeometry;
-
+class SvtxTrack;
+class SvtxTrackMap;
 using SourceLink = FW::Data::TrkrClusterSourceLink;
 
 class PHActsTrkFitter : public PHTrackFitting
@@ -66,8 +67,11 @@ class PHActsTrkFitter : public PHTrackFitting
   /// Create new nodes
   int createNodes(PHCompositeNode*);
 
-  /// Vector of acts tracks created by PHActsTracks
-  std::vector<ActsTrack>* m_actsProtoTracks;
+  /// Convert the acts track fit result to an svtx track
+  SvtxTrack* convertActsToSvtx(const Acts::KalmanFitterResult<SourceLink>& fitOutput, const unsigned int trackKey);
+
+  /// Map of acts tracks and track key created by PHActsTracks
+  std::map<unsigned int, ActsTrack>* m_actsProtoTracks;
 
   /// Options that Acts::Fitter needs to run from MakeActsGeometry
   ActsTrackingGeometry *m_tGeometry;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -70,7 +70,7 @@ class PHActsTrkFitter : public PHTrackFitting
   Acts::BoundSymMatrix rotateCovarianceLocalToGlobal(const Acts::KalmanFitterResult<SourceLink>& fitOutput);
 
   /// Convert the acts track fit result to an svtx track
-  void convertActsToSvtx(const Acts::KalmanFitterResult<SourceLink>& fitOutput, const unsigned int trackKey);
+  void updateSvtxTrack(const Acts::KalmanFitterResult<SourceLink>& fitOutput, const unsigned int trackKey);
 
   /// Map of acts tracks and track key created by PHActsTracks
   std::map<unsigned int, ActsTrack>* m_actsProtoTracks;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -92,7 +92,7 @@ class PHActsTrkFitter : public PHTrackFitting
 
   /// Variables for doing event time execution analysis
   bool m_timeAnalysis;
-  TFile *timeFile;
+  TFile *m_timeFile;
   TH1 *h_eventTime;
   
 };

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -146,8 +146,8 @@ int PHActsTrkProp::Process()
 				   track->get_py(),
 				   track->get_pz());
       
-      // just set to 0 for now?
-      const double trackTime = 0;
+      // just set to 40 ns for now?
+      const double trackTime = 40 * Acts::UnitConstants::ns;
       const int trackQ = track->get_charge();
       
       const FW::TrackParameters trackSeed(seedCov, seedPos,


### PR DESCRIPTION
This PR introduces the code that actually runs the Acts track fitter. It updates the `SvtxTrack` associated with the Acts track so that subsequent analysis can be performed with the `SvtxEvaluator`. 

The PR also changes the default number of z TPC surfaces from 11 to 1, which decreases the single track fit time by an order of magnitude. This is approximately what Acts has advertised for a single muon track in ATLAS.

The track fitter is still not ready for production (e.g. public macro) use as the covariance matrix rotation is still not correct. We are waiting for some guidance from Andi on what Acts expects. Nonetheless, this PR puts a functional version of the Acts track fitting into the repository.

