### PR TITLE
Add any projections capability to kalman

### DIFF
--- a/offline/packages/NodeDump/DumpSvtxTrackMap.cc
+++ b/offline/packages/NodeDump/DumpSvtxTrackMap.cc
@@ -4,6 +4,7 @@
 
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxTrackState.h>
 
 #include <map>
 #include <ostream>
@@ -48,6 +49,27 @@ int DumpSvtxTrackMap::process_Node(PHNode *myNode)
       *fout << "px: " << hiter->second->get_px() << endl;
       *fout << "py: " << hiter->second->get_py() << endl;
       *fout << "pz: " << hiter->second->get_pz() << endl;
+      for (SvtxTrack::ConstStateIter trkstates = hiter->second->begin_states();
+	   trkstates != hiter->second->end_states();
+	   ++trkstates)
+      {
+	*fout << "trackstate path length: " << trkstates->first << endl;
+	*fout << "trackstate name: " << trkstates->second->get_name() << endl;
+	*fout << "trackstate x: " << trkstates->second->get_x() << endl;
+	*fout << "trackstate y: " << trkstates->second->get_y() << endl;
+	*fout << "trackstate z: " << trkstates->second->get_z() << endl;
+	*fout << "trackstate px: " << trkstates->second->get_px() << endl;
+	*fout << "trackstate py: " << trkstates->second->get_py() << endl;
+	*fout << "trackstate pz: " << trkstates->second->get_pz() << endl;
+	for (int i=0; i<5; i++)
+	{
+	  for (int j=0; j<5; j++)
+	  {
+	    *fout <<  "trkstate covar[" << i << ", " << j << "]: "
+		  << trkstates->second->get_error(i,j) << endl;
+	  }
+	}
+      }
     }
   }
   return 0;

--- a/offline/packages/NodeDump/DumpSvtxTrackMap.cc
+++ b/offline/packages/NodeDump/DumpSvtxTrackMap.cc
@@ -61,9 +61,9 @@ int DumpSvtxTrackMap::process_Node(PHNode *myNode)
         *fout << "trackstate px: " << trkstates->second->get_px() << endl;
         *fout << "trackstate py: " << trkstates->second->get_py() << endl;
         *fout << "trackstate pz: " << trkstates->second->get_pz() << endl;
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < 6; i++)
         {
-          for (int j = 0; j < 5; j++)
+          for (int j = 0; j < 6; j++)
           {
             *fout << "trkstate covar[" << i << ", " << j << "]: "
                   << trkstates->second->get_error(i, j) << endl;

--- a/offline/packages/NodeDump/DumpSvtxTrackMap.cc
+++ b/offline/packages/NodeDump/DumpSvtxTrackMap.cc
@@ -50,25 +50,25 @@ int DumpSvtxTrackMap::process_Node(PHNode *myNode)
       *fout << "py: " << hiter->second->get_py() << endl;
       *fout << "pz: " << hiter->second->get_pz() << endl;
       for (SvtxTrack::ConstStateIter trkstates = hiter->second->begin_states();
-	   trkstates != hiter->second->end_states();
-	   ++trkstates)
+           trkstates != hiter->second->end_states();
+           ++trkstates)
       {
-	*fout << "trackstate path length: " << trkstates->first << endl;
-	*fout << "trackstate name: " << trkstates->second->get_name() << endl;
-	*fout << "trackstate x: " << trkstates->second->get_x() << endl;
-	*fout << "trackstate y: " << trkstates->second->get_y() << endl;
-	*fout << "trackstate z: " << trkstates->second->get_z() << endl;
-	*fout << "trackstate px: " << trkstates->second->get_px() << endl;
-	*fout << "trackstate py: " << trkstates->second->get_py() << endl;
-	*fout << "trackstate pz: " << trkstates->second->get_pz() << endl;
-	for (int i=0; i<5; i++)
-	{
-	  for (int j=0; j<5; j++)
-	  {
-	    *fout <<  "trkstate covar[" << i << ", " << j << "]: "
-		  << trkstates->second->get_error(i,j) << endl;
-	  }
-	}
+        *fout << "trackstate path length: " << trkstates->first << endl;
+        *fout << "trackstate name: " << trkstates->second->get_name() << endl;
+        *fout << "trackstate x: " << trkstates->second->get_x() << endl;
+        *fout << "trackstate y: " << trkstates->second->get_y() << endl;
+        *fout << "trackstate z: " << trkstates->second->get_z() << endl;
+        *fout << "trackstate px: " << trkstates->second->get_px() << endl;
+        *fout << "trackstate py: " << trkstates->second->get_py() << endl;
+        *fout << "trackstate pz: " << trkstates->second->get_pz() << endl;
+        for (int i = 0; i < 5; i++)
+        {
+          for (int j = 0; j < 5; j++)
+          {
+            *fout << "trkstate covar[" << i << ", " << j << "]: "
+                  << trkstates->second->get_error(i, j) << endl;
+          }
+        }
       }
     }
   }

--- a/offline/packages/trackbase_historic/SvtxTrackState.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState.h
@@ -58,19 +58,25 @@ class SvtxTrackState : public PHObject
 
   /// rphi error
   virtual float get_rphi_error() const
-  { return NAN; }
+  {
+    return NAN;
+  }
 
   /// phi error
   virtual float get_phi_error() const
-  { return NAN; }
+  {
+    return NAN;
+  }
 
   /// z error
   virtual float get_z_error() const
-  { return NAN; }
+  {
+    return NAN;
+  }
 
   //@}
 
-  protected:
+ protected:
   SvtxTrackState(float pathlength = 0.0) {}
 
   ClassDef(SvtxTrackState, 1);

--- a/offline/packages/trackbase_historic/SvtxTrackState.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState.h
@@ -50,8 +50,8 @@ class SvtxTrackState : public PHObject
   virtual float get_error(unsigned int i, unsigned int j) const { return NAN; }
   virtual void set_error(unsigned int i, unsigned int j, float value) {}
 
-  virtual std::string get_name() { return ""; }
-  virtual void set_name(std::string &name) {}
+  virtual std::string get_name() const { return ""; }
+  virtual void set_name(const std::string &name) {}
 
   ///@name convenience interface, also found in Trkrcluster
   //@{

--- a/offline/packages/trackbase_historic/SvtxTrackState_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState_v1.h
@@ -5,7 +5,7 @@
 
 #include <cmath>
 #include <iostream>
-#include <string>            // for string, basic_string
+#include <string>  // for string, basic_string
 
 class PHObject;
 
@@ -56,15 +56,13 @@ class SvtxTrackState_v1 : public SvtxTrackState
   std::string get_name() const { return state_name; }
   void set_name(const std::string &name) { state_name = name; }
 
-
   virtual float get_rphi_error() const;
   virtual float get_phi_error() const;
   virtual float get_z_error() const;
 
   //@}
 
-  private:
-
+ private:
   float _pathlength;
   float _pos[3];
   float _mom[3];

--- a/offline/packages/trackbase_historic/SvtxTrackState_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState_v1.h
@@ -53,8 +53,8 @@ class SvtxTrackState_v1 : public SvtxTrackState
   float get_error(unsigned int i, unsigned int j) const;
   void set_error(unsigned int i, unsigned int j, float value);
 
-  std::string get_name() { return state_name; }
-  void set_name(std::string &name) { state_name = name; }
+  std::string get_name() const { return state_name; }
+  void set_name(const std::string &name) { state_name = name; }
 
 
   virtual float get_rphi_error() const;

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -64,9 +64,9 @@
 #include <TMatrixTSym.h>     // for TMatrixTSym
 #include <TMatrixTUtils.h>   // for TMatrixTRow
 #include <TSystem.h>
-#include <TVector3.h>        // for TVector3, operator*
-#include <TVectorDfwd.h>     // for TVectorD
-#include <TVectorT.h>        // for TVectorT
+#include <TVector3.h>     // for TVector3, operator*
+#include <TVectorDfwd.h>  // for TVectorD
+#include <TVectorT.h>     // for TVectorT
 
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>
@@ -82,7 +82,7 @@ class PHField;
 class TGeoManager;
 namespace genfit
 {
-class AbsTrackRep;
+  class AbsTrackRep;
 }  // namespace genfit
 
 #define LogDebug(exp) \
@@ -147,8 +147,8 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode* topNode)
   PHField* field = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
 
   m_Fitter = PHGenFit::Fitter::getInstance(tgeo_manager,
-                                          field, m_FitAlgoName, "RKTrackRep",
-                                          m_DoEvtDisplayFlag);
+                                           field, m_FitAlgoName, "RKTrackRep",
+                                           m_DoEvtDisplayFlag);
 
   if (!m_Fitter)
   {
@@ -160,7 +160,7 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode* topNode)
 
   // tower geometry for track states
 
-  for (map<string,pair<int,double>>::iterator iter = m_ProjectionsMap.begin(); iter !=  m_ProjectionsMap.end(); ++iter)
+  for (map<string, pair<int, double>>::iterator iter = m_ProjectionsMap.begin(); iter != m_ProjectionsMap.end(); ++iter)
   {
     if (isfinite(iter->second.second))
     {
@@ -174,7 +174,7 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode* topNode)
       RawTowerGeomContainer* geo = findNode::getClass<RawTowerGeomContainer>(topNode, nodename);
       if (geo)
       {
-	iter->second.second=geo->get_radius();
+        iter->second.second = geo->get_radius();
       }
       break;
     }
@@ -195,7 +195,7 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode* topNode)
       RawTowerGeom* temp_geo = twr_iter->second;
 
       //Changed by Barak on 12/10/19
-      iter->second.second=temp_geo->get_center_z();
+      iter->second.second = temp_geo->get_center_z();
       break;
     }
     default:
@@ -684,7 +684,7 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
     if (do_smearing)
     {
       const double momSmear = 3. / 180. * M_PI;  // rad
-      const double momMagSmear = 0.1;                   // relative
+      const double momMagSmear = 0.1;            // relative
 
       seed_mom.SetMag(
           True_mom.Mag() + gsl_ran_gaussian(m_RandomGenerator,
@@ -895,27 +895,27 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
       out_track->set_error(i, j, cov[i][j]);
     }
   }
-// the default name is UNKNOWN - let's set this to ORIGIN since it is at pathlength=0
+  // the default name is UNKNOWN - let's set this to ORIGIN since it is at pathlength=0
   out_track->begin_states()->second->set_name("ORIGIN");
 
-// make the projections for all detector types
-  for (map<string,pair<int,double>>::iterator iter = m_ProjectionsMap.begin(); iter !=  m_ProjectionsMap.end(); ++iter)
+  // make the projections for all detector types
+  for (map<string, pair<int, double>>::iterator iter = m_ProjectionsMap.begin(); iter != m_ProjectionsMap.end(); ++iter)
   {
     switch (iter->second.first)
     {
     case DETECTOR_TYPE::Cylinder:
-    pathlenth_from_first_meas = phgf_track->extrapolateToCylinder(*gf_state, iter->second.second, TVector3(0., 0., 0.),
-								  TVector3(0., 0., 1.), 0);
-    break;
-case DETECTOR_TYPE::Vertical_Plane:
-    pathlenth_from_first_meas = phgf_track->extrapolateToPlane(*gf_state, TVector3(0., 0.,iter->second.second),
-							       TVector3(1., 0., iter->second.second), 0);
-    break;
+      pathlenth_from_first_meas = phgf_track->extrapolateToCylinder(*gf_state, iter->second.second, TVector3(0., 0., 0.),
+                                                                    TVector3(0., 0., 1.), 0);
+      break;
+    case DETECTOR_TYPE::Vertical_Plane:
+      pathlenth_from_first_meas = phgf_track->extrapolateToPlane(*gf_state, TVector3(0., 0., iter->second.second),
+                                                                 TVector3(1., 0., iter->second.second), 0);
+      break;
     default:
       cout << "how in the world did you get here??????" << endl;
       gSystem->Exit(1);
     }
-    if ( pathlenth_from_first_meas <  -999990)
+    if (pathlenth_from_first_meas < -999990)
     {
       continue;
     }
@@ -939,7 +939,6 @@ case DETECTOR_TYPE::Vertical_Plane:
     out_track->insert_state(state);
     // the state is cloned on insert_state, so delete this copy here!
     delete state;
-
   }
 
   return static_cast<SvtxTrack*>(out_track);
@@ -961,8 +960,8 @@ PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementVerticalPlane
   double v_smear = 0.;
   if (m_SmearingFlag)
   {
-   u_smear = gsl_ran_gaussian(m_RandomGenerator, phi_resolution);
-   v_smear = gsl_ran_gaussian(m_RandomGenerator, r_resolution);
+    u_smear = gsl_ran_gaussian(m_RandomGenerator, phi_resolution);
+    v_smear = gsl_ran_gaussian(m_RandomGenerator, r_resolution);
   }
   pos.SetX(g4hit->get_avg_x() + u_smear * u.X() + v_smear * v.X());
   pos.SetY(g4hit->get_avg_y() + u_smear * u.Y() + v_smear * v.Y());
@@ -996,8 +995,8 @@ PHGenFit::PlanarMeasurement* PHG4TrackFastSim::PHG4HitToMeasurementCylinder(
   double v_smear = 0.;
   if (m_SmearingFlag)
   {
-  u_smear = gsl_ran_gaussian(m_RandomGenerator, phi_resolution);
-  v_smear = gsl_ran_gaussian(m_RandomGenerator, z_resolution);
+    u_smear = gsl_ran_gaussian(m_RandomGenerator, phi_resolution);
+    v_smear = gsl_ran_gaussian(m_RandomGenerator, z_resolution);
   }
   pos.SetX(g4hit->get_avg_x() + u_smear * u.X());
   pos.SetY(g4hit->get_avg_y() + u_smear * u.Y());
@@ -1046,13 +1045,13 @@ void PHG4TrackFastSim::DisplayEvent() const
 
 void PHG4TrackFastSim::add_state_name(const std::string& stateName)
 {
-    if (stateName == "FEMC" || stateName == "FHCAL" || stateName == "EEMC")
-    {
-      m_ProjectionsMap.insert(make_pair(stateName,make_pair(DETECTOR_TYPE::Vertical_Plane,NAN)));
-    }
-    else if (stateName == "CEMC" || stateName == "HCALIN" || stateName == "HCALOUT")
-    {
-      m_ProjectionsMap.insert(make_pair(stateName,make_pair(DETECTOR_TYPE::Cylinder,NAN)));
-    }
-    return;
+  if (stateName == "FEMC" || stateName == "FHCAL" || stateName == "EEMC")
+  {
+    m_ProjectionsMap.insert(make_pair(stateName, make_pair(DETECTOR_TYPE::Vertical_Plane, NAN)));
+  }
+  else if (stateName == "CEMC" || stateName == "HCALIN" || stateName == "HCALOUT")
+  {
+    m_ProjectionsMap.insert(make_pair(stateName, make_pair(DETECTOR_TYPE::Cylinder, NAN)));
+  }
+  return;
 }

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -160,7 +160,7 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode* topNode)
 
   // tower geometry for track states
 
-  for (map<string,pair<int,double>>::iterator iter = m_StateMap.begin(); iter !=  m_StateMap.end(); ++iter)
+  for (map<string,pair<int,double>>::iterator iter = m_ProjectionsMap.begin(); iter !=  m_ProjectionsMap.end(); ++iter)
   {
     if (isfinite(iter->second.second))
     {
@@ -683,7 +683,7 @@ int PHG4TrackFastSim::PseudoPatternRecognition(const PHG4Particle* particle,
                     particle->get_pz());
     if (do_smearing)
     {
-      const double momSmear = 3. / 180. * TMath::Pi();  // rad
+      const double momSmear = 3. / 180. * M_PI;  // rad
       const double momMagSmear = 0.1;                   // relative
 
       seed_mom.SetMag(
@@ -897,7 +897,7 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
     }
   }
 // make the projections for all detector types
-  for (map<string,pair<int,double>>::iterator iter = m_StateMap.begin(); iter !=  m_StateMap.end(); ++iter)
+  for (map<string,pair<int,double>>::iterator iter = m_ProjectionsMap.begin(); iter !=  m_ProjectionsMap.end(); ++iter)
   {
     switch (iter->second.first)
     {
@@ -939,42 +939,6 @@ case DETECTOR_TYPE::Vertical_Plane:
     delete state;
 
   }
-
-  //  // State Projections
-  //  {
-  //    // Project to a cylinder at fixed r
-  //    pathlenth_from_first_meas = phgf_track->extrapolateToCylinder(*gf_state, 2., TVector3(0., 0., 0.),
-  //                                                                  TVector3(0., 0., 1.), 0, -1);
-  //
-  //    SvtxTrackState* state = new SvtxTrackState_v1(pathlenth_from_first_meas - pathlenth_orig_from_first_meas);
-  //    state->set_x(gf_state->getPos().x());
-  //    state->set_y(gf_state->getPos().y());
-  //    state->set_z(gf_state->getPos().z());
-  //
-  //    state->set_px(gf_state->getMom().x());
-  //    state->set_py(gf_state->getMom().y());
-  //    state->set_pz(gf_state->getMom().z());
-  //
-  //    //    state->set_name(string("BeamPipe"));
-  //
-  //    for (int i = 0; i < 6; i++)
-  //    {
-  //      for (int j = i; j < 6; j++)
-  //      {
-  //        state->set_error(i, j, gf_state->get6DCov()[i][j]);
-  //      }
-  //    }
-  //    out_track->insert_state(state);
-  //
-  //    cout << __PRETTY_FUNCTION__ << __LINE__;
-  //    state->identify();
-  //
-  //    // the state is cloned on insert_state, so delete this copy here!
-  //    delete state;
-  //  }
-  //
-  //  cout << __PRETTY_FUNCTION__ << __LINE__;
-  //  out_track->identify();
 
   return static_cast<SvtxTrack*>(out_track);
 }
@@ -1080,14 +1044,13 @@ void PHG4TrackFastSim::DisplayEvent() const
 
 void PHG4TrackFastSim::add_state_name(const std::string& stateName)
 {
-    _state_names.push_back(stateName);
     if (stateName == "FEMC" || stateName == "FHCAL" || stateName == "EEMC")
     {
-      m_StateMap.insert(make_pair(stateName,make_pair(DETECTOR_TYPE::Vertical_Plane,NAN)));
+      m_ProjectionsMap.insert(make_pair(stateName,make_pair(DETECTOR_TYPE::Vertical_Plane,NAN)));
     }
     else if (stateName == "CEMC" || stateName == "HCALIN" || stateName == "HCALOUT")
     {
-      m_StateMap.insert(make_pair(stateName,make_pair(DETECTOR_TYPE::Cylinder,NAN)));
+      m_ProjectionsMap.insert(make_pair(stateName,make_pair(DETECTOR_TYPE::Cylinder,NAN)));
     }
     return;
 }

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -59,7 +59,6 @@
 #include <GenFit/GFRaveVertexFactory.h>
 #include <GenFit/Track.h>
 
-#include <TMath.h>
 #include <TMatrixDSymfwd.h>  // for TMatrixDSym
 #include <TMatrixTSym.h>     // for TMatrixTSym
 #include <TMatrixTUtils.h>   // for TMatrixTRow

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -888,7 +888,8 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
   out_track->set_x(pos.X());
   out_track->set_y(pos.Y());
   out_track->set_z(pos.Z());
-
+// the default name is UNKNOWN - let's set this to ORIGIN since it is at pathlength=0
+  out_track->begin_states()->second->set_name("ORIGIN");
   for (int i = 0; i < 6; i++)
   {
     for (int j = i; j < 6; j++)

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -204,50 +204,6 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode* topNode)
     }
   }
 
-  for (map<string,double>::iterator iter = m_ZStateMap.begin(); iter != m_ZStateMap.end(); ++iter)
-  {
-// if the plane is given do not look for the geometry object
-    if (isfinite(iter->second))
-    {
-      continue;
-    }
-// this is for the legacy finding of the Babar forward calorimeters which have their geometry on the node tree
-      string towergeonodename = "TOWERGEOM_" + iter->first;
-      RawTowerGeomContainer* towergeo = findNode::getClass<RawTowerGeomContainer>(topNode, towergeonodename);
-      if (!towergeo)
-      {
-        cerr << PHWHERE << " ERROR: Can't find node " << towergeonodename << endl;
-        return Fun4AllReturnCodes::ABORTEVENT;
-      }
-
-      // Grab the first tower, us it to get the
-      // location along the beamline
-      RawTowerGeomContainer::ConstRange twr_range = towergeo->get_tower_geometries();
-      RawTowerGeomContainer::ConstIterator twr_iter = twr_range.first;
-      RawTowerGeom* temp_geo = twr_iter->second;
-
-      //Changed by Barak on 12/10/19
-      _state_location.push_back(temp_geo->get_center_z());
-      iter->second=temp_geo->get_center_z();
-    }
-
-  for (map<string,double>::iterator iter = m_CylinderStateMap.begin(); iter != m_CylinderStateMap.end(); ++iter)
-  {
-    if (isfinite(iter->second))
-    {
-      continue;
-    }
-// this is for the legacy finding of the Babar sPHENIX calorimeters which have their geometry on the node tree
-      string nodename = "TOWERGEOM_" + iter->first;
-      RawTowerGeomContainer* geo = findNode::getClass<RawTowerGeomContainer>(topNode, nodename);
-      if (geo)
-      {
-        _state_location.push_back(geo->get_radius());
-	iter->second=geo->get_radius();
-      }
-  }
-
-
   if (_do_vertexing)
   {
     _vertex_finder = new genfit::GFRaveVertexFactory(Verbosity(), true);
@@ -940,7 +896,7 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
       out_track->set_error(i, j, cov[i][j]);
     }
   }
-
+// make the projections for all detector types
   for (map<string,pair<int,double>>::iterator iter = m_StateMap.begin(); iter !=  m_StateMap.end(); ++iter)
   {
     switch (iter->second.first)
@@ -984,124 +940,6 @@ case DETECTOR_TYPE::Vertical_Plane:
 
   }
 
-/*
-  // State Projections
-  map<string,double> state_name_path_map;
-  for (map<string,double>::iterator iter = m_ZStateMap.begin(); iter != m_ZStateMap.end(); ++iter)
-  {
-    // Project to a plane at fixed z
-    cout << "extrapolate to " << iter->second << endl;
-    pathlenth_from_first_meas = phgf_track->extrapolateToPlane(*gf_state, TVector3(0., 0.,iter->second),
-							       TVector3(1., 0., iter->second), 0);
-    if (pathlenth_from_first_meas < -999990) // don't add for failure
-    {
-      continue;
-    }
-//    state_name_path_map.insert(make_pair(iter->first,pathlenth_from_first_meas));
-    SvtxTrackState* state = new SvtxTrackState_v1(pathlenth_from_first_meas - pathlenth_orig_from_first_meas);
-    state->set_x(gf_state->getPos().x());
-    state->set_y(gf_state->getPos().y());
-    state->set_z(gf_state->getPos().z());
-
-    state->set_px(gf_state->getMom().x());
-    state->set_py(gf_state->getMom().y());
-    state->set_pz(gf_state->getMom().z());
-
-    state->set_name(iter->first);
-    for (int i = 0; i < 6; i++)
-    {
-      for (int j = i; j < 6; j++)
-      {
-        state->set_error(i, j, gf_state->get6DCov()[i][j]);
-      }
-    }
-    out_track->insert_state(state);
-    // the state is cloned on insert_state, so delete this copy here!
-    delete state;
-
-  }
-  for (map<string,double>::iterator iter = m_CylinderStateMap.begin(); iter != m_CylinderStateMap.end(); ++iter)
-  {
-    pathlenth_from_first_meas = phgf_track->extrapolateToCylinder(*gf_state, iter->second, TVector3(0., 0., 0.),
-								  TVector3(0., 0., 1.), 0);
-    if (pathlenth_from_first_meas < -999990) // don't add for failure
-    {
-      continue;
-    }
-//    state_name_path_map.insert(make_pair(iter->first,pathlenth_from_first_meas));
-    SvtxTrackState* state = new SvtxTrackState_v1(pathlenth_from_first_meas - pathlenth_orig_from_first_meas);
-    state->set_x(gf_state->getPos().x());
-    state->set_y(gf_state->getPos().y());
-    state->set_z(gf_state->getPos().z());
-
-    state->set_px(gf_state->getMom().x());
-    state->set_py(gf_state->getMom().y());
-    state->set_pz(gf_state->getMom().z());
-
-    state->set_name(iter->first);
-    for (int i = 0; i < 6; i++)
-    {
-      for (int j = i; j < 6; j++)
-      {
-        state->set_error(i, j, gf_state->get6DCov()[i][j]);
-      }
-    }
-    out_track->insert_state(state);
-    // the state is cloned on insert_state, so delete this copy here!
-    delete state;
-  }
-*/
-/*  
-  for (unsigned int i = 0; i < _state_names.size(); i++)
-  {
-    if ((_state_names[i] == "FHCAL") || (_state_names[i] == "FEMC") || (_state_names[i] == "EEMC"))
-    {
-      // Project to a plane at fixed z
-      pathlenth_from_first_meas = phgf_track->extrapolateToPlane(*gf_state, TVector3(0., 0., _state_location[i]),
-                                                                 TVector3(1., 0., _state_location[i]), 0);
-      cout << "extracting path for " << _state_names[i] << " at " << _state_location[i] 
-	   << " : " << pathlenth_from_first_meas << endl;
-    }
-    else if ((_state_names[i] == "CEMC") || (_state_names[i] == "HCALIN") || (_state_names[i] == "OHCAL"))
-    {
-      // Project to a cylinder at fixed r
-      pathlenth_from_first_meas = phgf_track->extrapolateToCylinder(*gf_state, _state_location[i], TVector3(0., 0., 0.),
-                                                                    TVector3(0., 0., 1.), 0);
-      cout << "extracting path for " << _state_names[i] << " at " << _state_location[i] 
-	   << " : " << pathlenth_from_first_meas << endl;
-    }
-    else
-    {
-      LogError("Unrecognized detector name for state projection");
-      continue;
-    }
-*/
-/*
-    // if projection fails, bail out
-  for (map<string,double>::iterator iter = state_name_path_map.begin(); iter != state_name_path_map.end(); ++iter)
-  {
-    SvtxTrackState* state = new SvtxTrackState_v1(iter->second - pathlenth_orig_from_first_meas);
-    state->set_x(gf_state->getPos().x());
-    state->set_y(gf_state->getPos().y());
-    state->set_z(gf_state->getPos().z());
-
-    state->set_px(gf_state->getMom().x());
-    state->set_py(gf_state->getMom().y());
-    state->set_pz(gf_state->getMom().z());
-
-    state->set_name(iter->first);
-    for (int i = 0; i < 6; i++)
-    {
-      for (int j = i; j < 6; j++)
-      {
-        state->set_error(i, j, gf_state->get6DCov()[i][j]);
-      }
-    }
-    out_track->insert_state(state);
-    // the state is cloned on insert_state, so delete this copy here!
-    delete state;
-  }
-*/
   //  // State Projections
   //  {
   //    // Project to a cylinder at fixed r
@@ -1246,12 +1084,10 @@ void PHG4TrackFastSim::add_state_name(const std::string& stateName)
     if (stateName == "FEMC" || stateName == "FHCAL" || stateName == "EEMC")
     {
       m_StateMap.insert(make_pair(stateName,make_pair(DETECTOR_TYPE::Vertical_Plane,NAN)));
-      m_ZStateMap.insert(make_pair(stateName,NAN));
     }
     else if (stateName == "CEMC" || stateName == "HCALIN" || stateName == "HCALOUT")
     {
       m_StateMap.insert(make_pair(stateName,make_pair(DETECTOR_TYPE::Cylinder,NAN)));
-      m_CylinderStateMap.insert(make_pair(stateName,NAN));
     }
     return;
 }

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -168,7 +168,7 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode* topNode)
     }
     switch (iter->second.first)
     {
-    case REFERENCE::cylinder:
+    case DETECTOR_TYPE::Cylinder:
     {
       string nodename = "TOWERGEOM_" + iter->first;
       RawTowerGeomContainer* geo = findNode::getClass<RawTowerGeomContainer>(topNode, nodename);
@@ -178,7 +178,7 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode* topNode)
       }
       break;
     }
-    case REFERENCE::zplane:
+    case DETECTOR_TYPE::Vertical_Plane:
     {
       string towergeonodename = "TOWERGEOM_" + iter->first;
       RawTowerGeomContainer* towergeo = findNode::getClass<RawTowerGeomContainer>(topNode, towergeonodename);
@@ -592,8 +592,12 @@ bool PHG4TrackFastSim::FillSvtxVertexMap(
     svtx_vtx->set_position(2, rave_vtx->getPos().Z());
 
     for (int i = 0; i < 3; i++)
+    {
       for (int j = 0; j < 3; j++)
+      {
         svtx_vtx->set_error(i, j, rave_vtx->getCov()[i][j]);
+      }
+    }
 
     for (unsigned int i = 0; i < rave_vtx->getNTracks(); i++)
     {
@@ -1242,12 +1246,12 @@ void PHG4TrackFastSim::add_state_name(const std::string& stateName)
     _state_names.push_back(stateName);
     if (stateName == "FEMC" || stateName == "FHCAL" || stateName == "EEMC")
     {
-      m_StateMap.insert(make_pair(stateName,make_pair(REFERENCE::zplane,NAN)));
+      m_StateMap.insert(make_pair(stateName,make_pair(DETECTOR_TYPE::Vertical_Plane,NAN)));
       m_ZStateMap.insert(make_pair(stateName,NAN));
     }
     else if (stateName == "CEMC" || stateName == "HCALIN" || stateName == "HCALOUT")
     {
-      m_StateMap.insert(make_pair(stateName,make_pair(REFERENCE::cylinder,NAN)));
+      m_StateMap.insert(make_pair(stateName,make_pair(DETECTOR_TYPE::Cylinder,NAN)));
       m_CylinderStateMap.insert(make_pair(stateName,NAN));
     }
     return;

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -15,18 +15,8 @@
 #include <TMatrixDSymfwd.h>  // for TMatrixDSym
 #include <TVector3.h>
 
-// rootcint barfs with this header so we need to hide it
-#if !defined(__CINT__) || defined(__CLING__)
-// needed, it crashes on Ubuntu using singularity with local cvmfs install
-// shared pointer later on uses this, forward declaration does not cut it
 #include <gsl/gsl_rng.h>
 #include <phgenfit/Track.h>
-#else
-namespace PHGenFit
-{
-class Track;
-} /* namespace PHGenFit */
-#endif
 
 #include <climits>  // for UINT_MAX
 #include <iostream>
@@ -139,12 +129,12 @@ class PHG4TrackFastSim : public SubsysReco
 // add saving of state at plane in z
   void add_zplane_state(const std::string& stateName, const double zplane)
   {
-    m_StateMap.insert(std::make_pair(stateName,std::make_pair(DETECTOR_TYPE::Vertical_Plane,zplane)));
+    m_ProjectionsMap.insert(std::make_pair(stateName,std::make_pair(DETECTOR_TYPE::Vertical_Plane,zplane)));
   }
 
   void add_cylinder_state(const std::string& stateName, const double radius)
   {
-    m_StateMap.insert(std::make_pair(stateName,std::make_pair(DETECTOR_TYPE::Cylinder,radius)));
+    m_ProjectionsMap.insert(std::make_pair(stateName,std::make_pair(DETECTOR_TYPE::Cylinder,radius)));
   }
 
   const std::string& get_trackmap_out_name() const
@@ -288,7 +278,6 @@ class PHG4TrackFastSim : public SubsysReco
   int _event;
 
   bool m_SmearingFlag;
-  //  DETECTOR_TYPE _detector_type;  // deprecated
 
   //! Input Node pointers
   PHG4TruthInfoContainer* _truth_container;
@@ -349,16 +338,11 @@ class PHG4TrackFastSim : public SubsysReco
   //!
   int _primary_tracking;
 
-  //!
-  std::vector<std::string> _state_names;
-  std::vector<double> _state_location;
+  //! 
+  std::map<std::string, std::pair<int, double>> m_ProjectionsMap;
 
-  std::map<std::string, std::pair<int, double>> m_StateMap;
-
-#if !defined(__CINT__) || defined(__CLING__)
   //! random generator that conform with sPHENIX standard
   gsl_rng* m_RandomGenerator;
-#endif
 };
 
 #endif /*__PHG4TrackFastSim_H__*/

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -62,8 +62,8 @@ class PHG4TrackFastSim : public SubsysReco
  public:
   enum DETECTOR_TYPE
   {
-    Vertical_Plane,
-    Cylinder
+    Vertical_Plane = 0,
+    Cylinder = 1
   };
 
   //! Default constructor
@@ -140,13 +140,13 @@ class PHG4TrackFastSim : public SubsysReco
   void add_zplane_state(const std::string& stateName, const double zplane)
   {
     m_ZStateMap.insert(std::make_pair(stateName,zplane));
-    m_StateMap.insert(std::make_pair(stateName,std::make_pair(REFERENCE::zplane,zplane)));
+    m_StateMap.insert(std::make_pair(stateName,std::make_pair(DETECTOR_TYPE::Vertical_Plane,zplane)));
   }
 
   void add_cylinder_state(const std::string& stateName, const double radius)
   {
     m_CylinderStateMap.insert(std::make_pair(stateName,radius));
-    m_StateMap.insert(std::make_pair(stateName,std::make_pair(REFERENCE::cylinder,radius)));
+    m_StateMap.insert(std::make_pair(stateName,std::make_pair(DETECTOR_TYPE::Cylinder,radius)));
   }
 
   const std::string& get_trackmap_out_name() const
@@ -247,11 +247,6 @@ class PHG4TrackFastSim : public SubsysReco
 
  private:
 
-  enum REFERENCE
-  {
-    zplane = 0,
-    cylinder = 1,
-  };
   /*!
 	 * Create needed nodes.
 	 */

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -93,7 +93,7 @@ class PHG4TrackFastSim : public SubsysReco
 
   const std::vector<std::string>& get_phg4hits_names() const
   {
-    return _phg4hits_names;
+    return m_PHG4HitsNames;
   }
 
   //! adding hits from a PHG4Hit node, which usually belong to one detector or a sub group of detectors
@@ -114,7 +114,7 @@ class PHG4TrackFastSim : public SubsysReco
       const float eff,
       const float noise)
   {
-    _phg4hits_names.push_back(phg4hitsNames);
+    m_PHG4HitsNames.push_back(phg4hitsNames);
     _phg4_detector_type.push_back(phg4dettype);
     _phg4_detector_radres.push_back(radres);
     _phg4_detector_phires.push_back(phires);
@@ -235,6 +235,8 @@ class PHG4TrackFastSim : public SubsysReco
 
  private:
 
+  typedef std::map<const genfit::Track*, unsigned int> GenFitTrackMap;
+
   /*!
 	 * Create needed nodes.
 	 */
@@ -249,8 +251,11 @@ class PHG4TrackFastSim : public SubsysReco
 	 *
 	 */
   int PseudoPatternRecognition(const PHG4Particle* particle,
-                               std::vector<PHGenFit::Measurement*>& meas_out, TVector3& seed_pos,
-                               TVector3& seed_mom, TMatrixDSym& seed_cov, const bool do_smearing = true);
+                               std::vector<PHGenFit::Measurement*>& meas_out, 
+			       TVector3& seed_pos,
+                               TVector3& seed_mom,
+			       TMatrixDSym& seed_cov,
+			       const bool do_smearing = true);
 
   PHGenFit::PlanarMeasurement* PHG4HitToMeasurementVerticalPlane(const PHG4Hit* g4hit, const double phi_resolution, const double r_resolution);
 
@@ -265,25 +270,23 @@ class PHG4TrackFastSim : public SubsysReco
                            const unsigned int truth_track_id = UINT_MAX,
                            const unsigned int nmeas = 0, const TVector3& vtx = TVector3(0.0, 0.0, 0.0));
 
-  typedef std::map<const genfit::Track*, unsigned int> GenFitTrackMap;
 
   /*
   * Fill SvtxVertexMap from GFRaveVertexes and Tracks
   */
-  bool FillSvtxVertexMap(
-      const std::vector<genfit::GFRaveVertex*>& rave_vertices,
-      const GenFitTrackMap& gf_tracks);
+  bool FillSvtxVertexMap(const std::vector<genfit::GFRaveVertex*>& rave_vertices,
+			 const GenFitTrackMap& gf_tracks);
 
   //! Event counter
-  int _event;
+  int m_EventCnt;
 
   bool m_SmearingFlag;
 
   //! Input Node pointers
-  PHG4TruthInfoContainer* _truth_container;
+  PHG4TruthInfoContainer* m_TruthContainer;
 
-  std::vector<PHG4HitContainer*> _phg4hits;
-  std::vector<std::string> _phg4hits_names;
+  std::vector<PHG4HitContainer*> m_PHG4HitContainer;
+  std::vector<std::string> m_PHG4HitsNames;
   std::vector<DETECTOR_TYPE> _phg4_detector_type;
   std::vector<float> _phg4_detector_radres;
   std::vector<float> _phg4_detector_phires;

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -16,10 +16,8 @@
 #include <TVector3.h>
 
 #include <gsl/gsl_rng.h>
-#include <phgenfit/Track.h>
 
 #include <climits>  // for UINT_MAX
-#include <iostream>
 #include <map>
 #include <string>
 #include <vector>

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -83,12 +83,12 @@ class PHG4TrackFastSim : public SubsysReco
 
   const std::string& get_fit_alg_name() const
   {
-    return _fit_alg_name;
+    return m_FitAlgoName;
   }
 
   void set_fit_alg_name(const std::string& fitAlgName)
   {
-    _fit_alg_name = fitAlgName;
+    m_FitAlgoName = fitAlgName;
   }
 
   const std::vector<std::string>& get_phg4hits_names() const
@@ -115,12 +115,12 @@ class PHG4TrackFastSim : public SubsysReco
       const float noise)
   {
     m_PHG4HitsNames.push_back(phg4hitsNames);
-    _phg4_detector_type.push_back(phg4dettype);
-    _phg4_detector_radres.push_back(radres);
-    _phg4_detector_phires.push_back(phires);
-    _phg4_detector_lonres.push_back(lonres);
-    _phg4_detector_hitfindeff.push_back(eff);
-    _phg4_detector_noise.push_back(noise);
+    m_phg4_detector_type.push_back(phg4dettype);
+    m_phg4_detector_radres.push_back(radres);
+    m_phg4_detector_phires.push_back(phires);
+    m_phg4_detector_lonres.push_back(lonres);
+    m_phg4_detector_hitfindeff.push_back(eff);
+    m_phg4_detector_noise.push_back(noise);
   }
 
 // legacy interface for Babar calorimeter projections
@@ -139,94 +139,94 @@ class PHG4TrackFastSim : public SubsysReco
 
   const std::string& get_trackmap_out_name() const
   {
-    return _trackmap_out_name;
+    return m_TrackmapOutNodeName;
   }
 
   void set_trackmap_out_name(const std::string& trackmapOutName)
   {
-    _trackmap_out_name = trackmapOutName;
+    m_TrackmapOutNodeName = trackmapOutName;
   }
 
   const std::string& get_sub_top_node_name() const
   {
-    return _sub_top_node_name;
+    return m_SubTopnodeName;
   }
 
   void set_sub_top_node_name(const std::string& subTopNodeName)
   {
-    _sub_top_node_name = subTopNodeName;
+    m_SubTopnodeName = subTopNodeName;
   }
 
   bool is_use_vertex_in_fitting() const
   {
-    return _use_vertex_in_fitting;
+    return m_UseVertexInFittingFlag;
   }
 
   void set_use_vertex_in_fitting(bool useVertexInFitting)
   {
-    _use_vertex_in_fitting = useVertexInFitting;
+    m_UseVertexInFittingFlag = useVertexInFitting;
   }
 
   double get_vertex_xy_resolution() const
   {
-    return _vertex_xy_resolution;
+    return m_VertexXYResolution;
   }
 
   void set_vertex_xy_resolution(double vertexXyResolution)
   {
-    _vertex_xy_resolution = vertexXyResolution;
+    m_VertexXYResolution = vertexXyResolution;
   }
 
   double get_vertex_z_resolution() const
   {
-    return _vertex_z_resolution;
+    return m_VertexZResolution;
   }
 
   void set_vertex_z_resolution(double vertexZResolution)
   {
-    _vertex_z_resolution = vertexZResolution;
+    m_VertexZResolution = vertexZResolution;
   }
 
   int get_primary_assumption_pid() const
   {
-    return _primary_assumption_pid;
+    return m_PrimaryAssumptionPid;
   }
 
   void set_primary_assumption_pid(int primaryAssumptionPid)
   {
-    _primary_assumption_pid = primaryAssumptionPid;
+    m_PrimaryAssumptionPid = primaryAssumptionPid;
   }
 
   void set_primary_tracking(int pTrk)
   {
-    _primary_tracking = pTrk;
+    m_PrimaryTrackingFlag = pTrk;
   }
 
   //! https://rave.hepforge.org/trac/wiki/RaveMethods
   const std::string& get_vertexing_method() const
   {
-    return _vertexing_method;
+    return m_VertexingMethod;
   }
 
   //! https://rave.hepforge.org/trac/wiki/RaveMethods
   void set_vertexing_method(const std::string& vertexingMethod)
   {
-    _vertexing_method = vertexingMethod;
+    m_VertexingMethod = vertexingMethod;
   }
 
   double get_vertex_min_ndf() const
   {
-    return _vertex_min_ndf;
+    return m_VertexMinNdf;
   }
 
-  void set_vertex_min_ndf(double vertexMinPT)
+  void set_vertex_min_ndf(double vertexMinNdf)
   {
-    _vertex_min_ndf = vertexMinPT;
+    m_VertexMinNdf = vertexMinNdf;
   }
 
   void enable_vertexing(const bool& b = true)
   {
-    _do_vertexing = b;
+    m_DoVertexingFlag = b;
   }
 
   void DisplayEvent() const;
@@ -277,43 +277,43 @@ class PHG4TrackFastSim : public SubsysReco
   bool FillSvtxVertexMap(const std::vector<genfit::GFRaveVertex*>& rave_vertices,
 			 const GenFitTrackMap& gf_tracks);
 
-  //! Event counter
-  int m_EventCnt;
 
-  bool m_SmearingFlag;
-
-  //! Input Node pointers
-  PHG4TruthInfoContainer* m_TruthContainer;
-
-  std::vector<PHG4HitContainer*> m_PHG4HitContainer;
-  std::vector<std::string> m_PHG4HitsNames;
-  std::vector<DETECTOR_TYPE> _phg4_detector_type;
-  std::vector<float> _phg4_detector_radres;
-  std::vector<float> _phg4_detector_phires;
-  std::vector<float> _phg4_detector_lonres;
-  std::vector<float> _phg4_detector_hitfindeff;
-  std::vector<float> _phg4_detector_noise;
-
-  //! Output Node pointers
-
-  std::string _sub_top_node_name;
-  //	std::string _clustermap_out_name;
-  std::string _trackmap_out_name;
-
-  //	SvtxClusterMap* _clustermap_out;
-
-  SvtxTrackMap* _trackmap_out;
-  SvtxVertexMap* _vertexmap;
+// Pointers first
+  //! random generator that conform with sPHENIX standard
+  gsl_rng* m_RandomGenerator;
 
   /*!
 	 *	GenFit fitter interface
 	 */
-  PHGenFit::Fitter* _fitter;
-  genfit::GFRaveVertexFactory* _vertex_finder;
+  PHGenFit::Fitter* m_Fitter;
+  genfit::GFRaveVertexFactory* m_RaveVertexFactory;
+
+  //! Input Node pointers
+  PHG4TruthInfoContainer* m_TruthContainer;
+
+  SvtxTrackMap* m_SvtxTrackMapOut;
+  SvtxVertexMap* m_SvtxVertexMap;
+
+
+
+  std::vector<PHG4HitContainer*> m_PHG4HitContainer;
+  std::vector<std::string> m_PHG4HitsNames;
+  std::vector<DETECTOR_TYPE> m_phg4_detector_type;
+  std::vector<float> m_phg4_detector_radres;
+  std::vector<float> m_phg4_detector_phires;
+  std::vector<float> m_phg4_detector_lonres;
+  std::vector<float> m_phg4_detector_hitfindeff;
+  std::vector<float> m_phg4_detector_noise;
+
+  //! 
+  std::map<std::string, std::pair<int, double>> m_ProjectionsMap;
+
+
+  std::string m_SubTopnodeName;
+  std::string m_TrackmapOutNodeName;
   //! https://rave.hepforge.org/trac/wiki/RaveMethods
-  std::string _vertexing_method;
-  double _vertex_min_ndf;
-  bool _do_vertexing;
+  std::string m_VertexingMethod;
+
 
   /*!
 	 * Available choices:
@@ -322,10 +322,18 @@ class PHG4TrackFastSim : public SubsysReco
 	 * DafSimple
 	 * DafRef
 	 */
-  std::string _fit_alg_name;
+  std::string m_FitAlgoName;
 
-  //!
-  int _primary_assumption_pid;
+  double m_VertexMinNdf;
+  double m_VertexXYResolution;
+  double m_VertexZResolution;
+
+  //! Event counter
+  int m_EventCnt;
+
+  int m_PrimaryAssumptionPid;
+
+  bool m_SmearingFlag;
 
   //!
   bool m_DoEvtDisplayFlag;
@@ -334,18 +342,12 @@ class PHG4TrackFastSim : public SubsysReco
 	 * For PseudoPatternRecognition function.
 	 */
 
-  bool _use_vertex_in_fitting;
+  bool m_UseVertexInFittingFlag;
 
-  double _vertex_xy_resolution;
-  double _vertex_z_resolution;
   //!
-  int _primary_tracking;
+  int m_PrimaryTrackingFlag;
 
-  //! 
-  std::map<std::string, std::pair<int, double>> m_ProjectionsMap;
-
-  //! random generator that conform with sPHENIX standard
-  gsl_rng* m_RandomGenerator;
+  bool m_DoVertexingFlag;
 };
 
 #endif /*__PHG4TrackFastSim_H__*/

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -133,9 +133,18 @@ class PHG4TrackFastSim : public SubsysReco
     _phg4_detector_noise.push_back(noise);
   }
 
-  void add_state_name(const std::string& stateName)
+// legacy interface for Babar calorimeter projections
+  void add_state_name(const std::string& stateName);
+
+// add saving of state at plane in z
+  void add_zplane_state(const std::string& stateName, const double zplane)
   {
-    _state_names.push_back(stateName);
+    m_ZStateMap.insert(std::make_pair(stateName,zplane));
+  }
+
+  void add_cylinder_state(const std::string& stateName, const double radius)
+  {
+    m_CylinderStateMap.insert(std::make_pair(stateName,radius));
   }
 
   const std::string& get_trackmap_out_name() const
@@ -232,6 +241,8 @@ class PHG4TrackFastSim : public SubsysReco
 
   void DisplayEvent() const;
 
+  void Smearing(const bool b) {m_SmearingFlag = b;}
+
  private:
   /*!
 	 * Create needed nodes.
@@ -275,6 +286,7 @@ class PHG4TrackFastSim : public SubsysReco
   //! Event counter
   int _event;
 
+  bool m_SmearingFlag;
   //  DETECTOR_TYPE _detector_type;  // deprecated
 
   //! Input Node pointers
@@ -339,6 +351,9 @@ class PHG4TrackFastSim : public SubsysReco
   //!
   std::vector<std::string> _state_names;
   std::vector<double> _state_location;
+
+  std::map<std::string, double> m_CylinderStateMap;
+  std::map<std::string, double> m_ZStateMap;
 
 #if !defined(__CINT__) || defined(__CLING__)
   //! random generator that conform with sPHENIX standard

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -140,11 +140,13 @@ class PHG4TrackFastSim : public SubsysReco
   void add_zplane_state(const std::string& stateName, const double zplane)
   {
     m_ZStateMap.insert(std::make_pair(stateName,zplane));
+    m_StateMap.insert(std::make_pair(stateName,std::make_pair(REFERENCE::zplane,zplane)));
   }
 
   void add_cylinder_state(const std::string& stateName, const double radius)
   {
     m_CylinderStateMap.insert(std::make_pair(stateName,radius));
+    m_StateMap.insert(std::make_pair(stateName,std::make_pair(REFERENCE::cylinder,radius)));
   }
 
   const std::string& get_trackmap_out_name() const
@@ -244,6 +246,12 @@ class PHG4TrackFastSim : public SubsysReco
   void Smearing(const bool b) {m_SmearingFlag = b;}
 
  private:
+
+  enum REFERENCE
+  {
+    zplane = 0,
+    cylinder = 1,
+  };
   /*!
 	 * Create needed nodes.
 	 */
@@ -351,7 +359,7 @@ class PHG4TrackFastSim : public SubsysReco
   //!
   std::vector<std::string> _state_names;
   std::vector<double> _state_location;
-
+  std::map<std::string, std::pair<int, double>> m_StateMap;
   std::map<std::string, double> m_CylinderStateMap;
   std::map<std::string, double> m_ZStateMap;
 

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -139,13 +139,11 @@ class PHG4TrackFastSim : public SubsysReco
 // add saving of state at plane in z
   void add_zplane_state(const std::string& stateName, const double zplane)
   {
-    m_ZStateMap.insert(std::make_pair(stateName,zplane));
     m_StateMap.insert(std::make_pair(stateName,std::make_pair(DETECTOR_TYPE::Vertical_Plane,zplane)));
   }
 
   void add_cylinder_state(const std::string& stateName, const double radius)
   {
-    m_CylinderStateMap.insert(std::make_pair(stateName,radius));
     m_StateMap.insert(std::make_pair(stateName,std::make_pair(DETECTOR_TYPE::Cylinder,radius)));
   }
 
@@ -354,9 +352,8 @@ class PHG4TrackFastSim : public SubsysReco
   //!
   std::vector<std::string> _state_names;
   std::vector<double> _state_location;
+
   std::map<std::string, std::pair<int, double>> m_StateMap;
-  std::map<std::string, double> m_CylinderStateMap;
-  std::map<std::string, double> m_ZStateMap;
 
 #if !defined(__CINT__) || defined(__CLING__)
   //! random generator that conform with sPHENIX standard

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -35,16 +35,16 @@ class PHG4TruthInfoContainer;
 
 namespace PHGenFit
 {
-class Fitter;
-class Measurement;
-class PlanarMeasurement;
-class Track;
+  class Fitter;
+  class Measurement;
+  class PlanarMeasurement;
+  class Track;
 } /* namespace PHGenFit */
 namespace genfit
 {
-class GFRaveVertex;
-class GFRaveVertexFactory;
-class Track;
+  class GFRaveVertex;
+  class GFRaveVertexFactory;
+  class Track;
 } /* namespace genfit */
 
 class PHG4TrackFastSim : public SubsysReco
@@ -123,18 +123,18 @@ class PHG4TrackFastSim : public SubsysReco
     m_phg4_detector_noise.push_back(noise);
   }
 
-// legacy interface for Babar calorimeter projections
+  // legacy interface for Babar calorimeter projections
   void add_state_name(const std::string& stateName);
 
-// add saving of state at plane in z
+  // add saving of state at plane in z
   void add_zplane_state(const std::string& stateName, const double zplane)
   {
-    m_ProjectionsMap.insert(std::make_pair(stateName,std::make_pair(DETECTOR_TYPE::Vertical_Plane,zplane)));
+    m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Vertical_Plane, zplane)));
   }
 
   void add_cylinder_state(const std::string& stateName, const double radius)
   {
-    m_ProjectionsMap.insert(std::make_pair(stateName,std::make_pair(DETECTOR_TYPE::Cylinder,radius)));
+    m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Cylinder, radius)));
   }
 
   const std::string& get_trackmap_out_name() const
@@ -231,10 +231,9 @@ class PHG4TrackFastSim : public SubsysReco
 
   void DisplayEvent() const;
 
-  void Smearing(const bool b) {m_SmearingFlag = b;}
+  void Smearing(const bool b) { m_SmearingFlag = b; }
 
  private:
-
   typedef std::map<const genfit::Track*, unsigned int> GenFitTrackMap;
 
   /*!
@@ -251,11 +250,11 @@ class PHG4TrackFastSim : public SubsysReco
 	 *
 	 */
   int PseudoPatternRecognition(const PHG4Particle* particle,
-                               std::vector<PHGenFit::Measurement*>& meas_out, 
-			       TVector3& seed_pos,
+                               std::vector<PHGenFit::Measurement*>& meas_out,
+                               TVector3& seed_pos,
                                TVector3& seed_mom,
-			       TMatrixDSym& seed_cov,
-			       const bool do_smearing = true);
+                               TMatrixDSym& seed_cov,
+                               const bool do_smearing = true);
 
   PHGenFit::PlanarMeasurement* PHG4HitToMeasurementVerticalPlane(const PHG4Hit* g4hit, const double phi_resolution, const double r_resolution);
 
@@ -270,15 +269,13 @@ class PHG4TrackFastSim : public SubsysReco
                            const unsigned int truth_track_id = UINT_MAX,
                            const unsigned int nmeas = 0, const TVector3& vtx = TVector3(0.0, 0.0, 0.0));
 
-
   /*
   * Fill SvtxVertexMap from GFRaveVertexes and Tracks
   */
   bool FillSvtxVertexMap(const std::vector<genfit::GFRaveVertex*>& rave_vertices,
-			 const GenFitTrackMap& gf_tracks);
+                         const GenFitTrackMap& gf_tracks);
 
-
-// Pointers first
+  // Pointers first
   //! random generator that conform with sPHENIX standard
   gsl_rng* m_RandomGenerator;
 
@@ -294,8 +291,6 @@ class PHG4TrackFastSim : public SubsysReco
   SvtxTrackMap* m_SvtxTrackMapOut;
   SvtxVertexMap* m_SvtxVertexMap;
 
-
-
   std::vector<PHG4HitContainer*> m_PHG4HitContainer;
   std::vector<std::string> m_PHG4HitsNames;
   std::vector<DETECTOR_TYPE> m_phg4_detector_type;
@@ -305,15 +300,13 @@ class PHG4TrackFastSim : public SubsysReco
   std::vector<float> m_phg4_detector_hitfindeff;
   std::vector<float> m_phg4_detector_noise;
 
-  //! 
+  //!
   std::map<std::string, std::pair<int, double>> m_ProjectionsMap;
-
 
   std::string m_SubTopnodeName;
   std::string m_TrackmapOutNodeName;
   //! https://rave.hepforge.org/trac/wiki/RaveMethods
   std::string m_VertexingMethod;
-
 
   /*!
 	 * Available choices:


### PR DESCRIPTION
This PR adds the capability to add any cylinder and vertical plane as projection point to the fast tracking. The first track state (by default at the origin at pathlength=0) had the default name "UNKNOWN", that was changed to ORIGIN. Smearing with the detector resolution can be disabled for debugging purposes via a flag (default is smearing=on). sPHENIX naming conventions were applied. This needed an adjustment of the svtxtrackstate interface (set_name from string & to const string &). Remove uses of .c_str() (node methods take strings as arguments)