### PR TITLE
put include back - ubuntu container need this

### DIFF
--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -15,6 +15,11 @@
 #include <TMatrixDSymfwd.h>  // for TMatrixDSym
 #include <TVector3.h>
 
+// #include <phgenfit/Track.h> is needed, it crashes on Ubuntu using 
+// singularity with local cvmfs install
+// shared pointer later on uses this, forward declaration does not cut it
+#include <phgenfit/Track.h>
+
 #include <gsl/gsl_rng.h>
 
 #include <climits>  // for UINT_MAX
@@ -42,7 +47,6 @@ namespace genfit
 {
   class GFRaveVertex;
   class GFRaveVertexFactory;
-  class Track;
 } /* namespace genfit */
 
 class PHG4TrackFastSim : public SubsysReco


### PR DESCRIPTION
This PR puts an include back which is needed to run the container. I accidentally removed this in the last cleanup