### PR TITLE
Cluster duplication

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.h
+++ b/offline/packages/tpc/TpcClusterizer.h
@@ -11,6 +11,7 @@ class TrkrHitSetContainer;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class TNtuple;
+class PHG4CylinderCellGeom;
 
 class TpcClusterizer : public SubsysReco
 {
@@ -22,8 +23,12 @@ class TpcClusterizer : public SubsysReco
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
+  void set_sector_fiducial_cut(const double cut){SectorFiducialCut = cut; }
+  void set_search_bins(const int bins){NSearch = bins;}
+
  private:
-  bool is_local_maximum(int nlook, int phi, int z, std::vector<std::vector<double>> &adcval);
+  bool is_local_maximum(int phi, int z, std::vector<std::vector<double>> &adcval);
+  bool is_in_sector_boundary(int phibin, int sector, PHG4CylinderCellGeom *layergeom);
   void get_cluster(int phibin, int zbin, int &phiup, int &phidown, int &zup, int &zdown, std::vector<std::vector<double>> &adcval);
 
   TrkrHitSetContainer *m_hits;
@@ -32,6 +37,9 @@ class TpcClusterizer : public SubsysReco
 
   double zz_shaping_correction;
   double pedestal;
+
+  double SectorFiducialCut;
+  int NSearch;
 
   int NPhiBinsMax;
   int NPhiBinsMin;

--- a/offline/packages/tpc/TpcClusterizer.h
+++ b/offline/packages/tpc/TpcClusterizer.h
@@ -23,7 +23,7 @@ class TpcClusterizer : public SubsysReco
   int End(PHCompositeNode *topNode);
 
  private:
-  bool is_local_maximum(int phi, int z, std::vector<std::vector<double>> &adcval);
+  bool is_local_maximum(int nlook, int phi, int z, std::vector<std::vector<double>> &adcval);
   void get_cluster(int phibin, int zbin, int &phiup, int &phidown, int &zup, int &zdown, std::vector<std::vector<double>> &adcval);
 
   TrkrHitSetContainer *m_hits;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -205,7 +205,7 @@ int SvtxEvaluator::InitRun(PHCompositeNode* topNode)
 
 int SvtxEvaluator::process_event(PHCompositeNode* topNode)
 {
-  if ((Verbosity() > 0) && (_ievent % 100 == 0))
+  if ((Verbosity() > 1) && (_ievent % 100 == 0))
   {
     cout << "SvtxEvaluator::process_event - Event = " << _ievent << endl;
   }
@@ -261,7 +261,7 @@ int SvtxEvaluator::End(PHCompositeNode* topNode)
 
   delete _tfile;
 
-  if (Verbosity() > 0)
+  if (Verbosity() > 1)
   {
     cout << "========================= SvtxEvaluator::End() ============================" << endl;
     cout << " " << _ievent << " events of output written to: " << _filename << endl;
@@ -272,9 +272,9 @@ int SvtxEvaluator::End(PHCompositeNode* topNode)
     {
       _errors += _svtxevalstack->get_errors();
       
-      if (Verbosity() > 0)
+      if (Verbosity() > 1)
 	{
-	  if ((_errors > 0) || (Verbosity() > 0))
+	  if ((_errors > 0) || (Verbosity() > 1))
 	    {
 	      cout << "SvtxEvaluator::End() - Error Count: " << _errors << endl;
 	    }
@@ -381,7 +381,7 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode* topNode)
   // print out some useful stuff for debugging
   //==========================================
 
-  if (Verbosity() > 0)
+  if (Verbosity() > 1)
   {
     SvtxTrackEval* trackeval = _svtxevalstack->get_track_eval();
     SvtxClusterEval* clustereval = _svtxevalstack->get_cluster_eval();
@@ -700,7 +700,7 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode* topNode)
 
 void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 {
-  if (Verbosity() > 0) cout << "SvtxEvaluator::fillOutputNtuples() entered" << endl;
+  if (Verbosity() > 1) cout << "SvtxEvaluator::fillOutputNtuples() entered" << endl;
   
   SvtxVertexEval* vertexeval = _svtxevalstack->get_vertex_eval();
   SvtxClusterEval* clustereval = _svtxevalstack->get_cluster_eval();
@@ -767,7 +767,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
   bool doit = true;
   if (_ntp_vertex && doit)
   {
-    if (Verbosity() > 0)
+    if (Verbosity() > 1)
     {
       cout << "Filling ntp_vertex " << endl;
       cout << "start vertex time:                " << _timer->get_accumulated_time() / 1000. << " sec" << endl;
@@ -1002,7 +1002,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       }
 
     }
-    if (Verbosity() >= 1)
+    if (Verbosity() > 1)
     {
       _timer->stop();
       cout << "vertex time:                " << _timer->get_accumulated_time() / 1000. << " sec" << endl;
@@ -1015,7 +1015,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
   if (_ntp_gpoint)
   {
-    if (Verbosity() > 0)
+    if (Verbosity() > 1)
     {
       cout << "Filling ntp_gpoint " << endl;
       _timer->restart();
@@ -1087,7 +1087,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         }
       }
     }
-    if (Verbosity() >= 1)
+    if (Verbosity() > 1)
     {
       _timer->stop();
       cout << "gpoint time:                " << _timer->get_accumulated_time() / 1000. << " sec" << endl;
@@ -1100,7 +1100,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
   if (_ntp_g4hit)
   {
-    if (Verbosity() > 0)
+    if (Verbosity() > 1)
     {
       cout << "Filling ntp_g4hit " << endl;
       _timer->restart();
@@ -1300,7 +1300,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
       _ntp_g4hit->Fill(g4hit_data);
     }
-    if (Verbosity() >= 1)
+    if (Verbosity() > 1)
     {
       _timer->stop();
       cout << "g4hit time:                " << _timer->get_accumulated_time() / 1000. << " sec" << endl;
@@ -1313,7 +1313,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
   if (_ntp_hit)
   {
-    if (Verbosity() > 0)
+    if (Verbosity() > 1)
     {
       cout << "Filling ntp_hit " << endl;
       _timer->restart();
@@ -1496,7 +1496,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	  }
       }
     }
-    if (Verbosity() >= 1)
+    if (Verbosity() > 1)
     {
       _timer->stop();
       cout << "hit time:                " << _timer->get_accumulated_time() / 1000. << " sec" << endl;
@@ -1507,7 +1507,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
   // fill the Cluster NTuple
   //------------------------
 
-  if (Verbosity() > 0)
+  if (Verbosity() > 1)
   {
     cout << "check for ntp_cluster" << endl;
     _timer->restart();
@@ -1515,7 +1515,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
   if (_ntp_cluster && !_scan_for_embedded)
   {
-    if (Verbosity() > 0) cout << "Filling ntp_cluster (all of them) " << endl;
+    if (Verbosity() > 1) cout << "Filling ntp_cluster (all of them) " << endl;
     // need things off of the DST...
     TrkrClusterContainer* clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
     TrkrClusterHitAssoc* clusterhitmap = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
@@ -1706,7 +1706,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
   }
   else if (_ntp_cluster && _scan_for_embedded)
   {
-    if (Verbosity() > 0) cout << "Filling ntp_cluster (embedded only) " << endl;
+    if (Verbosity() > 1) cout << "Filling ntp_cluster (embedded only) " << endl;
 
     // if only scanning embedded signals, loop over all the tracks from
     // embedded particles and report all of their clusters, including those
@@ -1922,7 +1922,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
   // fill the truth cluster NTuple
   //------------------------
 
-  if (Verbosity() > 0)
+  if (Verbosity() > 1)
   {
     cout << "check for ntp_g4cluster" << endl;
     _timer->restart();
@@ -1930,7 +1930,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
   if (_ntp_g4cluster)
     {
-      if (Verbosity() > 0) cout << "Filling ntp_g4cluster " << endl;
+      if (Verbosity() > 1) cout << "Filling ntp_g4cluster " << endl;
 
       TrkrClusterContainer* clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
       
@@ -1957,7 +1957,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
 	  if(ng4hits == 0)  continue;
 
-	  if(Verbosity() > 0)
+	  if(Verbosity() > 1)
 	    cout << "ntp_g4cluster: new particle with gtrackID " << gtrackID << " gflavor " << gflavor << " ng4hits " << ng4hits << endl;
 
 	  // convert truth hits for this particle to truth clusters in each TPC layer
@@ -1992,7 +1992,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	      float gprimary = NAN;
               gprimary = trutheval->is_primary(g4particle);
 
-	      if(Verbosity() > 0)
+	      if(Verbosity() > 1)
 		cout << "  layer " << layer << " gr " << gr << " gx " << gx << " gy " << gy << " gz " << gz << " gedep " << gedep << endl; 
 
 	      // Estimate the size of the truth cluster
@@ -2028,7 +2028,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
 		  std::set<TrkrDefs::cluskey> clusters = clustereval->all_clusters_from(cont_g4hit);  // this returns clusters from this hit in any layer using TrkrAssoc maps
 
-		  if(Verbosity() > 0)
+		  if(Verbosity() > 1)
 		    cout << "       contributing g4hitID " << cont_g4hit->get_hit_id() << " g4trackID " << cont_g4hit->get_trkid() << " energy " << energy << endl;
 
 		  for (std::set<TrkrDefs::cluskey>::iterator iter = clusters.begin();
@@ -2042,7 +2042,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
 		      reco_clusters.insert(this_cluskey);
 
-		      if(Verbosity() > 0)
+		      if(Verbosity() > 1)
 			cout << "             associated: this_cluskey " << this_cluskey << " clus_layer " << clus_layer << endl;
 
 		      // For now, we assume only one reco cluster matches, if there are multiple matches, keep the last one
@@ -2139,7 +2139,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 		  
 		  adc = cluster->getAdc();
 
-		  if(Verbosity() > 0)
+		  if(Verbosity() > 1)
 		    cout << "             reco cluster r " << r << " x " << x << " y " << y << " z " << z << " phisize " << phisize << " zsize " << zsize << endl;
 
 		}
@@ -2192,7 +2192,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
   //#ifdef FUCKER
   if (_ntp_gtrack)
   {
-    if (Verbosity() > 0)
+    if (Verbosity() > 1)
     {
       cout << "Filling ntp_gtrack " << endl;
       _timer->restart();
@@ -2612,7 +2612,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       }
 
     }
-    if (Verbosity() >= 1)
+    if (Verbosity() > 1)
     {
       _timer->stop();
       cout << "gtrack time:                " << _timer->get_accumulated_time() / 1000. << " sec" << endl;
@@ -2625,7 +2625,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
   if (_ntp_track)
   {
-    if (Verbosity() > 0)
+    if (Verbosity() > 1)
     {
       cout << "Filling ntp_track " << endl;
       _timer->restart();
@@ -2983,7 +2983,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         _ntp_track->Fill(track_data);
       }
     }
-    if (Verbosity() >= 1)
+    if (Verbosity() > 1)
     {
       _timer->stop();
       cout << "track time:                " << _timer->get_accumulated_time() / 1000. << " sec" << endl;
@@ -2996,7 +2996,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
   
   if (_ntp_gseed)
     {
-      if (Verbosity() > 0)
+      if (Verbosity() > 1)
 	{
 	  cout << "Filling ntp_gseed " << endl;
 	  _timer->restart();
@@ -3141,7 +3141,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	    }
 	}
       
-      if (Verbosity() >= 1)
+      if (Verbosity() > 1)
 	{
 	  _timer->stop();
 	  cout << "g4hit time:                " << _timer->get_accumulated_time() / 1000. << " sec" << endl;
@@ -3299,7 +3299,7 @@ void SvtxEvaluator::G4ClusterSize(PHCompositeNode* topNode, unsigned int layer, 
       g4phisize = strip_width;
       g4zsize = strip_length;
 
-      if(Verbosity() > 0)
+      if(Verbosity() > 1)
 	cout << " INTT: layer " << layer << " strips " << strips << " strip pitch " <<  layergeom->get_strip_y_spacing() << " g4phisize "<< g4phisize 
 	     << " columns " << cols << " strip_z_spacing " <<  layergeom->get_strip_z_spacing() << " g4zsize " << g4zsize << endl;
     }
@@ -3350,7 +3350,7 @@ void SvtxEvaluator::G4ClusterSize(PHCompositeNode* topNode, unsigned int layer, 
       unsigned int columns = column_outer - column + 1;
       g4zsize = (double) columns * layergeom->get_pixel_z();
 
-      if(Verbosity() > 0)
+      if(Verbosity() > 1)
 	cout << " MVTX: layer " << layer << " rows " << rows << " pixel x " <<  layergeom->get_pixel_x() << " g4phisize "<< g4phisize 
 	     << " columns " << columns << " pixel_z " <<  layergeom->get_pixel_z() << " g4zsize " << g4zsize << endl;
 


### PR DESCRIPTION
Introduced a fiducial cut to remove clusters close to the TPC sector boundaries. The default value is +/- 0.5 cm around the boundary center. The simulation was previously unrealistic, since it did not contain the 5 mm sector boundary dead gap. There are now no clusters that cross the sector gaps. Also changed the search window in the TPC clusterizer for local maxima to +/- 2 bins in z and phi. This reduces the number of duplicate and split clusters caused by fluctuations in the adc values, which confuse the cluster seeding algorithm. 

The dominant cause of split clusters is now tracks passing through the membrane with charge deposited on both sides of the membrane. I did not address this. 

There is a slight drop in tracking efficiency, but otherwise performance is unaffected - see plots for 100 pion events below. Upsilon resolution is 87 MeV, as previously.
[100pion_efficiency_sector_fiducial_comp.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/4626013/100pion_efficiency_sector_fiducial_comp.pdf)
[100pion_ptres_sector_fiducial_comp.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/4626017/100pion_ptres_sector_fiducial_comp.pdf)
[100pion_dca2d_sector_fiducial_comp.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/4626020/100pion_dca2d_sector_fiducial_comp.pdf)
[100pion_dcaz_sector_fiducial_comp.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/4626021/100pion_dcaz_sector_fiducial_comp.pdf)

Also made some changes to the evaluator classes to improve diagnostics for clusters.
