### PR TITLE
suppress cppcheck warnings

### DIFF
--- a/offline/packages/PHTpcTracker/externals/nanoflann.hpp
+++ b/offline/packages/PHTpcTracker/externals/nanoflann.hpp
@@ -521,6 +521,7 @@ namespace nanoflann
     /**
 		    Default constructor. Initializes a new pool.
 		 */
+// cppcheck-suppress *
     PooledAllocator()
     {
       internal_init();
@@ -727,6 +728,7 @@ namespace nanoflann
     T* data() { return elems; }
     // assignment with type conversion
     template <typename T2>
+// cppcheck-suppress *
     CArray<T, N>& operator=(const CArray<T2, N>& rhs)
     {
       std::copy(rhs.begin(), rhs.end(), begin());


### PR DESCRIPTION
This adds
// cppcheck-suppress *
before the line with the warning which suppresses all warnings (sadly I cannot find docs with the actual names of the warnings to be used for the suppression so this suppresses all