### PR TITLE
Acts covariance

### DIFF
--- a/offline/packages/trackreco/ActsCovarianceRotater.cc
+++ b/offline/packages/trackreco/ActsCovarianceRotater.cc
@@ -1,0 +1,211 @@
+#include "ActsCovarianceRotater.h"
+
+
+Acts::BoundSymMatrix ActsCovarianceRotater::rotateSvtxTrackCovToActs(
+	             const SvtxTrack *track)
+{
+  Acts::BoundSymMatrix matrix = Acts::BoundSymMatrix::Zero();
+
+  const double x = track->get_x();
+  const double y = track->get_y();
+
+  const double px = track->get_px();
+  const double py = track->get_py();
+  const double pz = track->get_pz();
+  const double p = sqrt(px * px + py * py + pz * pz);
+
+  const double phiPos = atan2(y,x);
+  const int charge = track->get_charge();
+
+  Acts::BoundSymMatrix svtxTrackCov = Acts::BoundSymMatrix::Zero();
+  
+  for (int i = 0; i < 6; ++i)
+    {
+      for (int j = 0; j < 6; ++j)
+	{
+	  svtxTrackCov(i,j) = track->get_error(i,j);
+	}
+    }
+
+  printMatrix("Initial covariance :", svtxTrackCov);
+
+  /// Construct the jacobian transformation matrix. Can be determined
+  /// by writing Acts quantities in terms of (x,y,z,px,py,pz) and taking
+  /// derivatives
+  /// Rotation matrix does not need units because everything is defined
+  /// in a unitless way, intentionally
+  Acts::BoundSymMatrix rotation = Acts::BoundSymMatrix::Zero();
+
+  /// Make a unit p vector for the rotation
+  const double uPx = px / p;
+  const double uPy = py / p;
+  const double uPz = pz / p;
+  const double uP = sqrt(uPx * uPx + uPy * uPy + uPz * uPz);
+
+  /// d0 = sqrt(x*x + y*y) when reference point is at (0,0,0)
+  rotation(0,0) = cos(phiPos);
+  rotation(0,1) = sin(phiPos);
+
+  /// z to z0 rotation is trivial
+  rotation(1,2) = 1;
+  
+  /// Rotating px,py,pz to phi, theta, p is just a rotation from cartesian to spherical
+  /// Rotate to phi
+  rotation(2,3) = -1 * uPy / (uPx * uPx + uPy * uPy);
+  rotation(2,4) = uPx / (uPx * uPx + uPy * uPy);
+
+  /// Rotate to theta. Leave uP in for clarity even though it is trivially 1
+  rotation(3,3) = uPx * uPz / (uP* uP * sqrt(uPx * uPx + uPy * uPy));
+  rotation(3,4) = uPy * uPz / (uP * uP * sqrt(uPx * uPx + uPy * uPy));
+  rotation(3,5) = -1 * sqrt(uPx * uPx + uPy * uPy) / (uP * uP);
+
+  /// Rotate to p. Since p is a unit vector it is trivially 1 but leave it
+  /// in for clarity
+  rotation(4,3) = uPx / uP;
+  rotation(4,4) = uPy / uP;
+  rotation(4,5) = uPz / uP;
+
+  /// time component is 0, so we have no entries for rotation(5,j)
+
+  printMatrix("Rotation matrix is : ", rotation);
+
+  matrix = rotation * svtxTrackCov * rotation.transpose();
+
+  printMatrix("Rotated matrix is : ", matrix);
+
+  /// Now rotate to q/p, which is mostly trivial
+  Acts::BoundSymMatrix qprotation = Acts::BoundSymMatrix::Zero();
+  qprotation(0,0) = 1;
+  qprotation(1,1) = 1;
+  qprotation(2,2) = 1;
+  qprotation(3,3) = 1;
+  /// var(q/p) = (d(1/p)/dp)^2 * var(p) = (-1/p^2)^2 * var(p), from acts devel
+  qprotation(4,4) = charge * charge / (p * p * p * p);
+  qprotation(5,5) = 1;
+  
+  matrix = qprotation * matrix * rotation.transpose();
+
+  /// Need to make sure units are what acts expects. Acts defaults to mm and GeV
+  /// so covariance entries with position component must be multiplied by 10
+  for(int i = 0; i < 6; ++i)
+    {
+      for(int j = 0; j < 6; ++j)
+	{
+	  if(i < 2 && j < 2)
+	    matrix(i,j) *= Acts::UnitConstants::cm2;
+	  else if((i < 2 && j < 5) || (i < 5 && j < 2))
+	    matrix(i,j) *= Acts::UnitConstants::cm;	  
+	}
+    }
+
+  return matrix;
+}
+
+
+Acts::BoundSymMatrix ActsCovarianceRotater::rotateActsCovToSvtxTrack(
+                     const Acts::KalmanFitterResult<SourceLink>& fitOutput)
+{
+
+  Acts::BoundSymMatrix matrix = Acts::BoundSymMatrix::Zero();
+  
+  const auto& params = fitOutput.fittedParameters.value();
+  auto covarianceMatrix = *params.covariance();
+  
+  printMatrix("Initial Acts covariance: ", covarianceMatrix);
+
+  const double px = params.momentum()(0);
+  const double py = params.momentum()(1);
+  const double pz = params.momentum()(2);
+  const double p = sqrt(px * px + py * py + pz * pz);
+  
+  const double x = params.position()(0);
+  const double y = params.position()(1);
+
+  const int charge = params.charge();
+  const double phiPos = atan2(x, y);
+
+  /// Return to sPHENIX units of cm
+  for(int i = 0; i < 6; ++i)
+    {
+      for(int j = 0; j < 6; ++j)
+	{
+	  if(i < 2 && j < 2)
+	    matrix(i,j) /= Acts::UnitConstants::cm2;
+	  else if((i < 2 && j < 5) || (i < 5 && j < 2))
+	    matrix(i,j) /= Acts::UnitConstants::cm;	  
+	}
+    }
+
+  /// First rotate the covariance matrix from (d0,z0,phi,theta,q/p,t) 
+  /// to (d0,z0,phi,theta,p,t) since it is easier to work with
+  Acts::BoundSymMatrix qprotation = Acts::BoundSymMatrix::Zero();
+  qprotation(0,0) = 1;
+  qprotation(1,1) = 1;
+  qprotation(2,2) = 1;
+  qprotation(3,3) = 1;
+  /// var(q/p) = (d(1/p)/dp)^2 * var(p) = (-1/p^2)^2 * var(p)
+  qprotation(4,4) = (p * p * p * p) / (charge * charge);
+  qprotation(5,5) = 1;
+
+  covarianceMatrix = qprotation * covarianceMatrix * qprotation.transpose();
+
+  /// Make a unit vector for transformation matrix
+  const double uPx = px / p;
+  const double uPy = py / p;
+  const double uPz = pz / p;
+  const double uP = sqrt(uPx * uPx + uPy * uPy + uPz * uPz);
+
+  const double cosphi = uPx / uP;
+  const double sinphi = uPy / uP;
+  const double rho = sqrt(uP * uP - uPz * uPz);
+  const double sintheta = rho / uP;
+  const double costheta = uPz / uP;
+
+  Acts::BoundSymMatrix rotation = Acts::BoundSymMatrix::Zero();
+  /// Rotate from d0, z0 to x,y,z. Again, assumes reference point of 0,0,0
+  rotation(0,0) = cos(phiPos);
+  rotation(1,0) = sin(phiPos);
+
+  /// z pos trivial
+  rotation(2,1) = 1;
+
+  /// Leave uP in for clarity even though it is trivially 1
+  rotation(3,2) = -1 * uP * sintheta * sinphi;
+  rotation(3,3) = uP * costheta * cosphi;
+  rotation(3,4) = sintheta * cosphi;
+  rotation(4,2) = uP * sintheta * cosphi;
+  rotation(4,3) = uP * costheta * sinphi;
+  rotation(4,4) = sintheta * sinphi;
+  rotation(5,3) = -1 * uP * sintheta;
+  rotation(5,4) = costheta;
+  
+  printMatrix("Rotation matrix is ", rotation);
+
+  matrix = rotation * covarianceMatrix * rotation.transpose();
+
+  printMatrix("Rotated matrix is : ", matrix);
+
+ 
+
+  return matrix;
+}
+
+
+void ActsCovarianceRotater::printMatrix(const std::string message,
+					Acts::BoundSymMatrix matrix)
+{
+ 
+  if(m_verbosity)
+    {
+      std::cout << std::endl << message.c_str() << std::endl;
+      for(int i = 0 ; i < matrix.rows(); ++i)
+	{
+	  std::cout << std::endl;
+	  for(int j = 0; j < matrix.cols(); ++j)
+	    {
+	      std::cout << matrix(i,j) << ", ";
+	    }
+	}
+    }
+
+}

--- a/offline/packages/trackreco/ActsCovarianceRotater.cc
+++ b/offline/packages/trackreco/ActsCovarianceRotater.cc
@@ -40,24 +40,36 @@ Acts::BoundSymMatrix ActsCovarianceRotater::rotateSvtxTrackCovToActs(
   const double cosTheta = uPz;
   const double sinTheta = sqrt(uPx * uPx + uPy * uPy);
   const double invSinTheta = 1. / sinTheta;
-  const double cosPhi = uPx * invSinTheta;
-  const double sinPhi = uPy * invSinTheta;
+  const double cosPhi = uPx * invSinTheta; // equivalent to x/r
+  const double sinPhi = uPy * invSinTheta; // equivalent to y/r
     
+  const double x = track->get_x();
+  const double y = track->get_y();
+  const double z = track->get_z();
+  const double r = sqrt(x*x + y*y + z*z);
+  
+  const double posCosTheta = z / r;
+  const double posSinTheta = sqrt(x*x + y*y) / r;
+  const double posInvSinTheta = 1. / posSinTheta;
+  const double posCosPhi = x * posInvSinTheta;
+  const double posSinPhi = y * posInvSinTheta;
+
   /// Position rotation to Acts loc0 and loc1, which are the local points
   /// on a surface centered at the (x,y,z) global position with normal
   /// vector in the direction of the unit momentum vector
-  rotation(0, 0) = -sinPhi;
-  rotation(0, 1) = cosPhi;
-  rotation(1, 0) = -cosPhi * cosTheta;
-  rotation(1, 1) = -sinPhi * cosTheta;
-  rotation(1, 2) = sinTheta;
+ 
+  rotation(0,0) = -posSinPhi;
+  rotation(0,1) = posCosPhi;
+  rotation(1,0) = -posCosPhi * posCosTheta;
+  rotation(1,1) = -posSinPhi * posCosTheta;
+  rotation(1,2) = posSinTheta;
 
   // Directional and momentum parameters for curvilinear
-  rotation(2, 3) = -p*sinPhi * sinTheta;
-  rotation(2, 4) = p*cosPhi * sinTheta;
-  rotation(3, 3) = p*cosPhi * cosTheta;
-  rotation(3, 4) = p*sinPhi * cosTheta;
-  rotation(3, 5) = -p*sinTheta;
+  rotation(2, 3) = -p * sinPhi * sinTheta;
+  rotation(2, 4) = p * cosPhi * sinTheta;
+  rotation(3, 3) = p * cosPhi * cosTheta;
+  rotation(3, 4) = p * sinPhi * cosTheta;
+  rotation(3, 5) = -p * sinTheta;
   
   ///q/p rotaton
   // p_i/p transforms from px -> p, and charge/p^4 transforms from

--- a/offline/packages/trackreco/ActsCovarianceRotater.h
+++ b/offline/packages/trackreco/ActsCovarianceRotater.h
@@ -1,0 +1,59 @@
+#ifndef TRACKRECO_ACTSCOVARIANCEROTATER_H
+#define TRACKRECO_ACTSCOVARIANCEROTATER_H
+
+/// Acts includes to create all necessary definitions
+#include <Acts/Utilities/BinnedArray.hpp>
+#include <Acts/Utilities/Definitions.hpp>
+#include <Acts/Utilities/Logger.hpp>
+
+#include <trackbase_historic/SvtxTrack.h>
+
+#include <ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp>
+#include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
+
+/// std (and the like) includes
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <utility>
+
+using SourceLink = FW::Data::TrkrClusterSourceLink;
+
+
+/**
+ * This is a helper class for rotating track covariance matrices to and from
+ * the basis that Acts expects. The covariance matrix is nominally given in the
+ * global basis (x,y,z,px,py,pz). Acts expects the covariance matrix in a local
+ * basis with respect to the given reference point that is provided as an
+ * option to the KalmanFitter. 
+ */
+class ActsCovarianceRotater
+{
+  public:
+  ActsCovarianceRotater()
+    : m_verbosity(false)
+    {}
+  virtual ~ActsCovarianceRotater(){}
+  
+  /// Rotates an SvtxTrack covariance matrix from (x,y,z,px,py,pz) global
+  /// cartesian coordinates to (d0, z0, phi, theta, q/p, time) coordinates for
+  /// Acts. The track fitter performs the fitting with respect to the nominal
+  /// origin of sPHENIX, so we rotate accordingly
+  Acts::BoundSymMatrix rotateSvtxTrackCovToActs(const SvtxTrack *track);
+  
+  /// Same as above, but rotate from Acts basis to global (x,y,z,px,py,pz)
+  Acts::BoundSymMatrix rotateActsCovToSvtxTrack(
+	        const Acts::KalmanFitterResult<SourceLink>& fitOutput);
+
+  void setVerbosity(bool verbosity) {m_verbosity = verbosity;}
+
+  void printMatrix(const std::string message, Acts::BoundSymMatrix matrix);
+
+ private:
+  bool m_verbosity;
+
+
+};
+
+
+#endif

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -75,7 +75,7 @@ MakeActsGeometry::MakeActsGeometry(const string &name)
   , m_minSurfZ(0.0)
   , m_maxSurfZ(105.5)
   , m_nSurfZ(1)
-  , m_nSurfPhi(10)
+  , m_nSurfPhi(3)
   , m_verbosity(0)
 {
   /// These are arbitrary tpc subdivisions, and may change

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -22,6 +22,7 @@ AM_LDFLAGS = \
   -L$(OFFLINE_MAIN)/lib64
 
 pkginclude_HEADERS = \
+  ActsCovarianceRotater.h \
   ActsTrack.h \
   AssocInfoContainer.h \
   CellularAutomaton.h \
@@ -110,6 +111,7 @@ libtrack_reco_io_la_SOURCES = \
 
 if MAKE_ACTS
 ACTS_SOURCES = \
+  ActsCovarianceRotater.cc \
   MakeActsGeometry.cc \
   PHActsSourceLinks.cc \
   PHActsTracks.cc \

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -78,7 +78,6 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
   std::vector<FW::TrackParameters> trackSeeds;
 
   ActsCovarianceRotater *rotater = new ActsCovarianceRotater();
-  rotater->setVerbosity(true);
   
   for (SvtxTrackMap::Iter trackIter = m_trackMap->begin();
        trackIter != m_trackMap->end(); ++trackIter)

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -1,4 +1,5 @@
 #include "PHActsTracks.h"
+#include "ActsCovarianceRotater.h"
 
 /// Fun4All includes
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -76,6 +77,9 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
   std::vector<SourceLink> trackSourceLinks;
   std::vector<FW::TrackParameters> trackSeeds;
 
+  ActsCovarianceRotater *rotater = new ActsCovarianceRotater();
+  rotater->setVerbosity(true);
+  
   for (SvtxTrackMap::Iter trackIter = m_trackMap->begin();
        trackIter != m_trackMap->end(); ++trackIter)
   {
@@ -91,7 +95,8 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
     }
 
     /// Get the necessary parameters and values for the TrackParameters
-    const Acts::BoundSymMatrix seedCov = getActsCovMatrix(track);
+    const Acts::BoundSymMatrix seedCov = 
+          rotater->rotateSvtxTrackCovToActs(track);
     const Acts::Vector3D seedPos(track->get_x()  * Acts::UnitConstants::cm,
                                  track->get_y()  * Acts::UnitConstants::cm,
                                  track->get_z()  * Acts::UnitConstants::cm);
@@ -156,194 +161,7 @@ int PHActsTracks::ResetEvent(PHCompositeNode *topNode)
   m_actsTrackMap->clear();
   return Fun4AllReturnCodes::EVENT_OK;
 }
-Acts::BoundSymMatrix PHActsTracks::getActsCovMatrix(const SvtxTrack *track)
-{
-  Acts::BoundSymMatrix matrix = Acts::BoundSymMatrix::Zero();
-  
-  const double px = track->get_px();
-  const double py = track->get_py();
-  const double pz = track->get_pz();
-  const double p = sqrt(px * px + py * py + pz * pz);
-  const double phiPos = atan2(track->get_x(), track->get_y());
-  const int charge = track->get_charge();
 
-  // Get the track seed covariance matrix
-  // These are the variances, so the std devs are sqrt(seedCov[i][j])
-  Acts::BoundSymMatrix seedCov = Acts::BoundSymMatrix::Zero();
-
-  for (int i = 0; i < 6; i++)
-  {
-    for (int j = 0; j < 6; j++)
-    {
-      /// Track covariance matrix is in basis (x,y,z,px,py,pz). Need to put
-      /// it in form of (x,y,px,py,pz,time) for acts
-      int row = -1;
-      int col = -1;
-      if( i < 2)
-	row = i;
-      else if ( i < 5)
-	row = i+1;
-      else if (i == 5)
-	row = 2;
-
-      if( j < 2 )
-	col = j;
-      else if ( j < 5 )
-	col = j+1;
-      else if ( j == 5 )
-	col = 2;
-
-      seedCov(i,j) = track->get_error(row, col);
-      
-      /// get the units right, since acts works in mm
-      /// Don't need to multiply by units of GeV since that is Acts default
-      if(i < 2 && j < 2)
-	seedCov(i,j) *= Acts::UnitConstants::cm2;
-      else if (i < 2 && j < 5 )
-	seedCov(i,j) *= Acts::UnitConstants::cm;
-      else if (i < 5 && j < 2 )
-	seedCov(i,j) *= Acts::UnitConstants::cm;
-
-    }
-  }
-  
-  /// Set the time column/row to 0
-  for(int i = 5; i< 6; i++)
-    {
-      for(int j = 0; j <6; j++)
-	{
-	  seedCov(i,j) = 0;
-	  seedCov(j,i) = 0;
-	}
-    }
-  /// Just give time a 10 ns covariance for now
-  seedCov(5,5) = 10 * Acts::UnitConstants::ns;
-
-  if(Verbosity() > 10)
-    {
-      std::cout << "Initial covariance: " << std::endl;
-      for(int i =0; i<6; i++)
-	{
-	  std::cout << std::endl;
-	  for(int j= 0; j<6; j++)
-	    {
-	      std::cout << track->get_error(i,j) << ", ";
-	    }
-
-	}
-
-      std::cout << std::endl << "Shifted covariance " << std::endl;
-      for(int i = 0; i < 6; i++)
-	{
-	  std::cout<<std::endl;
-	  for(int j=0; j<6; j++)
-	    {
-	      std::cout << seedCov(i,j) << ", ";
-
-	    }
-	}
-    }
-
-
-  /// Need to transform from global to local coordinate frame. 
-  /// Amounts to the local transformation as in PHActsSourceLinks as well as
-  /// a rotation from cartesian to spherical coordinates for the momentum
-  /// Rotating from (x_G, y_G, px, py, pz, time) to (x_L, y_L, phi, theta, q/p,time)
-
-  /// Make a unit p vector for the rotation
-  const double uPx = px / p;
-  const double uPy = py / p;
-  const double uPz = pz / p;
-  const double uP = sqrt(uPx * uPx + uPy * uPy + uPz * uPz);
-  
-  /// This needs to rotate to (x_L, y_l, phi, theta, q/p, t)
-  Acts::BoundSymMatrix rotation = Acts::BoundSymMatrix::Zero();
-
-  /// Local position rotations
-  rotation(0,0) = cos(phiPos);
-  rotation(0,1) = sin(phiPos);
-  rotation(1,0) = -1 * sin(phiPos);
-  rotation(1,1) = cos(phiPos);
-
-  /// Momentum vector rotations
-  /// phi rotation
-  rotation(2,2) = -1 * uPy / (uPx * uPx + uPy * uPy);
-  rotation(2,3) = -1 * uPx / (uPx * uPx + uPy * uPy);
-
-  /// theta rotation
-  /// Leave uP in for clarity, even though it is trivially unity
-  rotation(3,2) = (uPx * uPz) / (uP * uP * sqrt( uPx * uPx + uPy * uPy) );
-  rotation(3,3) = (uPy * uPz) / (uP * uP * sqrt( uPx * uPx + uPy * uPy) );
-  rotation(3,4) = (-1 * sqrt(uPx * uPx + uPy * uPy)) / (uP * uP);
-  
-  /// p rotation
-  rotation(4,2) = uPx / uP;
-  rotation(4,3) = uPy / uP;
-  rotation(4,4) = uPz / uP;
-
-  /// time rotation
-  rotation(5,5) = 1;
-
-  if(Verbosity() > 10 )
-    {
-      std::cout << std::endl << "Rotation matrix is : " << std::endl;
-      for(int i = 0; i < 6; i++)
-	{
-	  std::cout << std::endl;
-	  for(int j = 0 ; j < 6 ; j++)
-	    {
-	      std::cout<< rotation(i,j) << ", ";
-	    }
-	}
-
-    }
-
-  /// Rotate the covariance matrix by the jacobian rotation matrix
-  matrix = rotation * seedCov * rotation.transpose();
-
-  if(Verbosity() > 10)
-    {
-      std::cout << std::endl << "Acts rotated covariance " << std::endl;
-      for(int i = 0; i < 6; i++)
-	{
-	  for(int j=0; j<6; j++)
-	    {
-	      std::cout << matrix(i,j) << ", ";
-	      
-	    }
-	  
-	  std::cout << std::endl;
-	}
-    }
-
-  /// Rotate again to get q/p instead of p
-  Acts::BoundSymMatrix qprotation = Acts::BoundSymMatrix::Zero();
-  qprotation(0,0) = 1;
-  qprotation(1,1) = 1;
-  qprotation(2,2) = 1;
-  qprotation(3,3) = 1;
-  qprotation(4,4) = charge * charge / (p * p * p * p);
-  qprotation(5,5) = 1;
-  
-  Acts::BoundSymMatrix finalMatrix = Acts::BoundSymMatrix::Zero();
-  finalMatrix = qprotation * matrix * qprotation.transpose();
-  
-    if(Verbosity() > 10)
-    {
-      std::cout << std::endl << "Acts rotated rotated covariance " << std::endl;
-      for(int i = 0; i < 6; i++)
-	{
-	  std::cout << std::endl;
-	  for(int j=0; j<6; j++)
-	    {
-	      std::cout << finalMatrix(i,j) << ", ";
-	      
-	    }
-	}
-    }
-  
-  return finalMatrix;
-}
 
 void PHActsTracks::createNodes(PHCompositeNode *topNode)
 {

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -62,8 +62,6 @@ class PHActsTracks : public SubsysReco
   /// Get nodes off node tree needed to execute module
   int getNodes(PHCompositeNode *topNode);
 
-  Acts::BoundSymMatrix getActsCovMatrix(const SvtxTrack *track);
-
   /**
    * Member variables
    */

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -81,6 +81,7 @@ class PHActsTracks : public SubsysReco
   /// Map of hitid:SourceLinks created in PHActsSourceLinks
   std::map<unsigned int, SourceLink> *m_sourceLinks;
 
+  /// Acts TrackingGeometry necessary for various contexts
   ActsTrackingGeometry *m_tGeometry;
 };
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -8,6 +8,7 @@
 #include "PHActsTrkFitter.h"
 #include "MakeActsGeometry.h"
 #include "ActsTrack.h"
+#include "ActsCovarianceRotater.h"
 
 /// Tracking includes
 #include <trackbase_historic/SvtxTrack.h>
@@ -57,7 +58,7 @@ int PHActsTrkFitter::Setup(PHCompositeNode* topNode)
   fitCfg.fit = FW::TrkrClusterFittingAlgorithm::makeFitterFunction(
                m_tGeometry->tGeometry,
 	       m_tGeometry->magField,
-	       Acts::Logging::INFO);
+	       Acts::Logging::VERBOSE);
 
   if(m_timeAnalysis)
     {
@@ -79,7 +80,10 @@ int PHActsTrkFitter::Process()
   }
 
 
-  /// Construct a perigee surface as the target surface (?)
+  /// Construct a perigee surface as the target surface
+  /// This surface is what Acts fits with respect to. So we put it
+  /// at 0 so that the fitter is fitting with respect to the global 
+  /// position. Presumably we could put this as the zvertex
   auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
 	          Acts::Vector3D{0., 0., 0.});
 
@@ -186,144 +190,22 @@ void PHActsTrkFitter::updateSvtxTrack(const Acts::KalmanFitterResult<SourceLink>
 
   if(params.covariance())
     {
-   
-      Acts::BoundSymMatrix rotatedCov = rotateCovarianceLocalToGlobal(fitOutput);
+      ActsCovarianceRotater *rotater = new ActsCovarianceRotater();
+      rotater->setVerbosity(true);
+      Acts::BoundSymMatrix rotatedCov = 
+	rotater->rotateActsCovToSvtxTrack(fitOutput);
+      
       for(int i = 0; i < 6; i++)
-	for(int j = 0; j < 6; j++)
-	  track->set_error(i,j, rotatedCov(i,j));
+	{
+	  for(int j = 0; j < 6; j++)
+	    {
+	      track->set_error(i,j, rotatedCov(i,j));
+	    }
+	}
     }
  
   return;
 
-}
-
-Acts::BoundSymMatrix PHActsTrkFitter::rotateCovarianceLocalToGlobal(
-                     const Acts::KalmanFitterResult<SourceLink>& fitOutput)
-{
-  Acts::BoundSymMatrix matrix = Acts::BoundSymMatrix::Zero();
-  
-  const auto& params = fitOutput.fittedParameters.value();
-  auto covarianceMatrix = *params.covariance();
-
-  const double px = params.momentum()(0);
-  const double py = params.momentum()(1);
-  const double pz = params.momentum()(2);
-  const double p = sqrt(px * px + py * py + pz * pz);
-  
-  const double x = params.position()(0);
-  const double y = params.position()(1);
-
-  const int charge = params.charge();
-  const double phiPos = atan2(x, y);
-
-  /// We need to rotate the opposite of what was done in PHActsTracks.
-  /// So first rotate from (x_l, y_l, phi, theta, q/p, time) to 
-  /// (x_l, y_l, phi, theta, p, time)
-
-  Acts::BoundSymMatrix qprotation = Acts::BoundSymMatrix::Zero();
-  qprotation(0,0) = 1;
-  qprotation(1,1) = 1;
-  qprotation(2,2) = 1;
-  qprotation(3,3) = 1;
-  qprotation(4,4) = charge * charge / (p * p * p * p);
-  qprotation(5,5) = 1;
-  
-  /// Want the inverse of the rotation matrix from PHActsTracks 
-  /// because we are rotating back from local to global. So we do R^TCR 
-  /// rather than RCR^T
-  matrix = qprotation.transpose() * covarianceMatrix * qprotation;
-
-  /// Now rotate to (x_g, y_g, px, py, pz, t)
-  /// Make a unit p vector for the rotation
-  const double uPx = px / p;
-  const double uPy = py / p;
-  const double uPz = pz / p;
-  const double uP = sqrt(uPx * uPx + uPy * uPy + uPz * uPz);
-  
-  Acts::BoundSymMatrix rotation = Acts::BoundSymMatrix::Zero();
-  /// Local position rotations
-  rotation(0,0) = cos(phiPos);
-  rotation(0,1) = sin(phiPos);
-  rotation(1,0) = -1 * sin(phiPos);
-  rotation(1,1) = cos(phiPos);
-
-  /// Momentum vector rotations
-  /// phi rotation
-  rotation(2,2) = -1 * uPy / (uPx * uPx + uPy * uPy);
-  rotation(2,3) = -1 * uPx / (uPx * uPx + uPy * uPy);
-
-  /// theta rotation
-  /// Leave uP in for clarity, even though it is trivially unity
-  rotation(3,2) = (uPx * uPz) / (uP * uP * sqrt( uPx * uPx + uPy * uPy) );
-  rotation(3,3) = (uPy * uPz) / (uP * uP * sqrt( uPx * uPx + uPy * uPy) );
-  rotation(3,4) = (-1 * sqrt(uPx * uPx + uPy * uPy)) / (uP * uP);
-  
-  /// p rotation
-  rotation(4,2) = uPx / uP;
-  rotation(4,3) = uPy / uP;
-  rotation(4,4) = uPz / uP;
-
-  /// time rotation
-  rotation(5,5) = 1;
-  /// Undoing the rotation, so R^TCR instead of RCR^T
-  matrix = rotation.transpose() * matrix * rotation;
-  
-  if(Verbosity() > 20)
-    {
-      std::cout<<"Rotated Matrix"<<std::endl;
-      for(int i =0;i<6; i++)
-	{
-	  for(int j =0; j<6; j++)
-	    std::cout<<matrix(i,j)<<", ";
-	  std::cout<<std::endl;
-	}
-    }
-
-  /// Now matrix is in basis (x_g, y_g, px, py, pz, t)
-  /// Shift rows and columns to get like (x_g, y_g, z, px, py, pz)
-  Acts::BoundSymMatrix svtxCovariance = Acts::BoundSymMatrix::Zero();
-  for(int i = 0; i < 6; i++ )
-    {
-      for(int j = 0; j < 6; j++ )
-	{
-	  int row = -1;
-	  int col = -1;
-	  if( i < 2)
-	    row = i;
-	  else if ( i < 5)
-	    row = i+1;
-	  else if (i == 5)
-	    row = 2;
-	  
-	  if( j < 2 )
-	    col = j;
-	  else if ( j < 5 )
-	    col = j+1;
-	  else if ( j == 5 )
-	    col = 2;
-	  
-	  svtxCovariance(row,col) = matrix(i, j);
-	  
-	  if(row < 2 && col < 2)
-	    svtxCovariance(row,col) /= Acts::UnitConstants::cm2;
-	  else if(row < 2 && col < 5)
-	    svtxCovariance(row,col) /= Acts::UnitConstants::cm;
-	  else if (row < 5 && col < 2)
-	    svtxCovariance(row,col) /= Acts::UnitConstants::cm;
-	}
-    }
-  if(Verbosity() > 20)
-    {
-      std::cout << "shiftd matrix"<<std::endl;
-      for(int i =0;i<6;i++)
-	{
-	  for(int j =0;j<6; j++)
-	    std::cout<<svtxCovariance(i,j)<<", ";
-	  std::cout<<std::endl;
-	}
-    }
-
-  return svtxCovariance;
 }
 
 int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -58,7 +58,7 @@ int PHActsTrkFitter::Setup(PHCompositeNode* topNode)
   fitCfg.fit = FW::TrkrClusterFittingAlgorithm::makeFitterFunction(
                m_tGeometry->tGeometry,
 	       m_tGeometry->magField,
-	       Acts::Logging::VERBOSE);
+	       Acts::Logging::INFO);
 
   if(m_timeAnalysis)
     {
@@ -191,7 +191,6 @@ void PHActsTrkFitter::updateSvtxTrack(const Acts::KalmanFitterResult<SourceLink>
   if(params.covariance())
     {
       ActsCovarianceRotater *rotater = new ActsCovarianceRotater();
-      rotater->setVerbosity(true);
       Acts::BoundSymMatrix rotatedCov = 
 	rotater->rotateActsCovToSvtxTrack(fitOutput);
       

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -71,10 +71,6 @@ class PHActsTrkFitter : public PHTrackFitting
   /// Create new nodes
   int createNodes(PHCompositeNode*);
 
-  /// Rotate the covariance from Acts local coordinates back to 
-  /// sPHENIX global coordinates
-  Acts::BoundSymMatrix rotateCovarianceLocalToGlobal(const Acts::KalmanFitterResult<SourceLink>& fitOutput);
-
   /// Convert the acts track fit result to an svtx track
   void updateSvtxTrack(const Acts::KalmanFitterResult<SourceLink>& fitOutput, const unsigned int trackKey);
 

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -76,8 +76,6 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Create new nodes
   void createNodes(PHCompositeNode *topNode);
 
-  Acts::BoundSymMatrix getActsCovMatrix(const SvtxTrack *track);
-
   ActsTrackingGeometry *m_tGeometry;
 
   /// Track map with Svtx objects


### PR DESCRIPTION
This is (yet another) PR for the Acts covariance matrix. Introducing it now because it is at least a step in the right direction, but there is still clearly something incorrect with the fitting. Many fits fail within Acts, and many return values that are not what one would expect. However, there were several changes to the covariance code design, so I thought they should be put into the repository.

These plots show a 5 pion event thrown between 1 and 6 GeV in pT within the nominal eta and phi acceptance. The plots show improvement as they are roughly centered at 1 or 0, but clearly there is still something that is not correct as the tails to these distributions are far too large. Regardless the width of the central gaussian is too large for what should be expected for the tracking. 

[px.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/4669603/px.pdf)
[py.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/4669604/py.pdf)
[pz.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/4669605/pz.pdf)
[x.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/4669606/x.pdf)
[y.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/4669607/y.pdf)
[z.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/4669608/z.pdf)
