### PR TITLE
Mvtx energy threshold

### DIFF
--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
@@ -30,7 +30,7 @@ using namespace std;
 
 PHG4MvtxDigitizer::PHG4MvtxDigitizer(const string &name)
   : SubsysReco(name)
-  , _energy_threshold(0.0)
+  , _energy_threshold(0.95e-6)
 {
   unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
   cout << Name() << " random seed: " << seed << endl;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
@@ -25,6 +25,7 @@
 
 #include <cstdlib>                                 // for exit
 #include <iostream>
+#include <set>
 
 using namespace std;
 
@@ -168,6 +169,7 @@ void PHG4MvtxDigitizer::DigitizeMvtxLadderCells(PHCompositeNode *topNode)
     // get all of the hits from this hitset
     TrkrHitSet *hitset = hitset_iter->second;
     TrkrHitSet::ConstRange hit_range = hitset->getHits();
+    std::set<TrkrDefs::hitkey> hits_rm;
     for (TrkrHitSet::ConstIterator hit_iter = hit_range.first;
          hit_iter != hit_range.second;
          ++hit_iter)
@@ -182,10 +184,19 @@ void PHG4MvtxDigitizer::DigitizeMvtxLadderCells(PHCompositeNode *topNode)
       // Remove the hits with energy under threshold
       bool rm_hit = false;
       if (hit->getEnergy() < _energy_threshold) rm_hit = true;
-      if (Verbosity() > 0) cout << "    PHG4MvtxDigitizer: found hit with key: " << hit_iter->first << " and signal " << hit->getEnergy() << " and adc " << adc << " on layer " << layer << ", remove hit " << rm_hit << endl;
+      if (Verbosity() > 0) cout << "    PHG4MvtxDigitizer: found hit with key: " << hit_iter->first << " and signal " << hit->getEnergy() << " and adc " << adc << " on layer " << layer << ", to remove hit " << rm_hit << endl;
 
-      if (rm_hit) hitset->removeHit(hit_iter->first);
+      if (rm_hit) hits_rm.insert(hit_iter->first);
     }
+
+    for (std::set<TrkrDefs::hitkey>::iterator hits_rm_iter = hits_rm.begin();
+         hits_rm_iter != hits_rm.end();
+         ++hits_rm_iter)
+    {
+      if (Verbosity() > 0) cout << "    PHG4MvtxDigitizer: remove hit with key: " << *hits_rm_iter << endl;
+      hitset->removeHit(*hits_rm_iter);
+    }
+
   }
 
   // end new containers

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
@@ -30,6 +30,7 @@ using namespace std;
 
 PHG4MvtxDigitizer::PHG4MvtxDigitizer(const string &name)
   : SubsysReco(name)
+  , _energy_threshold(0.0)
 {
   unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
   cout << Name() << " random seed: " << seed << endl;
@@ -178,7 +179,12 @@ void PHG4MvtxDigitizer::DigitizeMvtxLadderCells(PHCompositeNode *topNode)
       if (adc > _max_adc[layer]) adc = _max_adc[layer];
       hit->setAdc(adc);
 
-      if (Verbosity() > 0) cout << "    PHG4MvtxDigitizer: found hit with key: " << hit_iter->first << " and signal " << hit->getEnergy() << " and adc " << adc << endl;
+      // Remove the hits with energy under threshold
+      bool rm_hit = false;
+      if (hit->getEnergy() < _energy_threshold) rm_hit = true;
+      if (Verbosity() > 0) cout << "    PHG4MvtxDigitizer: found hit with key: " << hit_iter->first << " and signal " << hit->getEnergy() << " and adc " << adc << " on layer " << layer << ", remove hit " << rm_hit << endl;
+
+      if (rm_hit) hitset->removeHit(hit_iter->first);
     }
   }
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.h
@@ -43,6 +43,13 @@ class PHG4MvtxDigitizer : public SubsysReco
     _energy_scale.insert(std::make_pair(layer, energy_per_adc));
   }
 
+  void set_energy_threshold(const float threshold)
+  {
+    _energy_threshold = threshold;
+  }
+
+  float get_energy_threshold() { return _energy_threshold; }
+
  private:
   void CalculateMvtxLadderCellADCScale(PHCompositeNode *topNode);
   void DigitizeMvtxLadderCells(PHCompositeNode *topNode);
@@ -53,6 +60,7 @@ class PHG4MvtxDigitizer : public SubsysReco
   // settings
   std::map<int, unsigned int> _max_adc;
   std::map<int, float> _energy_scale;
+  float _energy_threshold;
 
 #if !defined(__CINT__) || defined(__CLING__)
   //! random generator that conform with sPHENIX standard


### PR DESCRIPTION
Add a pixel energy threshold for each mvtx hit. 
Hits with energy under threshold will be removed.
This change is to match the cluster size distribution in simulation with those from test beam data.