### PR TITLE
Deghost for truth vertexing

### DIFF
--- a/offline/packages/trackreco/PHTruthVertexing.cc
+++ b/offline/packages/trackreco/PHTruthVertexing.cc
@@ -1,7 +1,7 @@
 #include "PHTruthVertexing.h"
 
+#include <trackbase_historic/SvtxVertex.h>  // for SvtxVertex
 #include <trackbase_historic/SvtxVertexMap.h>
-#include <trackbase_historic/SvtxVertex.h>     // for SvtxVertex
 #include <trackbase_historic/SvtxVertex_v1.h>
 
 #include <g4main/PHG4TruthInfoContainer.h>
@@ -17,9 +17,11 @@
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>
 
-#include <iostream>                            // for operator<<, basic_ostream
-#include <set>                                 // for _Rb_tree_iterator, set
-#include <utility>                             // for pair
+#include <CLHEP/Vector/ThreeVector.h>
+
+#include <iostream>  // for operator<<, basic_ostream
+#include <set>       // for _Rb_tree_iterator, set
+#include <utility>   // for pair
 
 class PHCompositeNode;
 
@@ -31,7 +33,6 @@ PHTruthVertexing::PHTruthVertexing(const std::string& name)
   , _vertex_error({0.01, 0.01, 0.01})
   , _embed_only(false)
 {
-
   m_RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
 
   unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
@@ -39,9 +40,8 @@ PHTruthVertexing::PHTruthVertexing(const std::string& name)
   gsl_rng_set(m_RandomGenerator, seed);
 }
 
-
-
-PHTruthVertexing::~PHTruthVertexing() {
+PHTruthVertexing::~PHTruthVertexing()
+{
   gsl_rng_free(m_RandomGenerator);
 }
 
@@ -58,78 +58,139 @@ int PHTruthVertexing::Setup(PHCompositeNode* topNode)
 
 int PHTruthVertexing::Process(PHCompositeNode* topNode)
 {
+  if (Verbosity() > 1)
+  {
+    std::cout << "embed only: " << std::boolalpha << _embed_only << std::endl;
+  }
 
-  if(Verbosity() > 1)
-    {
-      std::cout << "embed only: " << std::boolalpha << _embed_only << std::endl;
-    }
-  auto vrange =  _g4truth_container->GetPrimaryVtxRange();
+  set<CLHEP::Hep3Vector> existing_vertex_set;
+  auto vrange = _g4truth_container->GetPrimaryVtxRange();
   set<int> gembed_set;
   for (auto iter = vrange.first; iter != vrange.second; ++iter)  // process all primary vertexes
+  {
+    const int point_id = iter->first;
+    int gembed = _g4truth_container->isEmbededVtx(point_id);
+
+    std::vector<float> pos;
+    pos.clear();
+    pos.assign(3, 0.0);
+
+    pos[0] = iter->second->get_x();
+    pos[1] = iter->second->get_y();
+    pos[2] = iter->second->get_z();
+
+    if (Verbosity() > 1)
     {
-      const int point_id = iter->first;
-      int gembed =  _g4truth_container->isEmbededVtx(point_id);
+      cout << " gembed: " << gembed << " vz " << iter->second->get_z() << endl;
+    }
 
-      std::vector<float> pos;
-      pos.clear();
-      pos.assign(3, 0.0);
-            
-      pos[0] = iter->second->get_x();
-      pos[1] = iter->second->get_y();
-      pos[2] = iter->second->get_z();
+    // skip particles that are not primary
+    if (sqrt(pos[0] * pos[0] + pos[1] * pos[1]) > 0.1) continue;
 
-      if(Verbosity() > 1)
-	{
-	  cout << " gembed: " << gembed << " vz " << iter->second->get_z() << endl;
-	}
+    // check to see if we have this vertex already
+    if (gembed_set.find(gembed) != gembed_set.end()) continue;
 
-      // skip particles that are not primary
-      if( sqrt(pos[0]*pos[0]+pos[1]*pos[1])  > 0.1) continue;
+    gembed_set.insert(gembed);
 
-      // check to see if we have this vertex already      
-      if(gembed_set.find(gembed) != gembed_set.end()) continue;
+    // Check whether this vertex has already been inserted
+    const CLHEP::Hep3Vector new_vertex(pos[0], pos[1], pos[2]);
+    bool duplicated_vertex = false;
+    for (const auto& existing_vertex : existing_vertex_set)
+    {
+      const CLHEP::Hep3Vector vertex_diff = existing_vertex - new_vertex;
 
-      gembed_set.insert(gembed);
-      
-      pos[0] += _vertex_error[0] * gsl_ran_ugaussian(m_RandomGenerator);
-      pos[1] += _vertex_error[1] * gsl_ran_ugaussian(m_RandomGenerator);
-      pos[2] += _vertex_error[2] * gsl_ran_ugaussian(m_RandomGenerator);
-      
-      
-      if (Verbosity() > 0)
-	{
-	  cout << __LINE__ << " PHTruthVertexing::Process: point_id " << point_id << " gembed " << gembed << "   {" << pos[0]
-	       << ", " << pos[1] << ", " << pos[2] << "} +- {"
-	       << _vertex_error[0] << ", " << _vertex_error[1] << ", "
-	       << _vertex_error[2] << "}" << endl;
-	}
-      
-      SvtxVertex* vertex = new SvtxVertex_v1();
-      
-      vertex->set_x(pos[0]);
-      vertex->set_y(pos[1]);
-      vertex->set_z(pos[2]);
-      
-      for (int j = 0; j < 3; ++j)
-	{
-	  for (int i = j; i < 3; ++i)
-	    {
-	      vertex->set_error(i, j,
-				(i == j ? _vertex_error[i] * _vertex_error[i] : 0));
-	    }
-	}
-      
-      vertex->set_id(0);
-      vertex->set_t0(0);
-      vertex->set_chisq(0);
-      vertex->set_ndof(1);
-      if(_embed_only){
-	if(gembed>0)_vertex_map->insert(vertex);
-      }else{
-	_vertex_map->insert(vertex);
+      const double epsilon = 1e-6;
+      const CLHEP::Hep3Vector invert_vertex_error(
+          1 / (_vertex_error[0] + epsilon),
+          1 / (_vertex_error[1] + epsilon),
+          1 / (_vertex_error[2] + epsilon));
+
+      const double sigma_separation = CLHEP::Hep3Vector(
+                                          fabs(vertex_diff.x()) * invert_vertex_error.x(),
+                                          fabs(vertex_diff.y()) * invert_vertex_error.y(),
+                                          fabs(vertex_diff.z()) * invert_vertex_error.z())
+                                          .r();
+
+      if (sigma_separation < 1)
+      {
+        if (Verbosity() > 1)
+        {
+          cout << __PRETTY_FUNCTION__ << " - matched new vertex with " << sigma_separation << " sigma separation from existing vertex: "
+               << " new vertex = " << new_vertex << ", existing vertex = " << existing_vertex << " difference = " << vertex_diff << endl;
+        }
+
+        duplicated_vertex = true;
+        break;
+      }
+      else
+      {
+        if (Verbosity() > 1)
+        {
+          cout << __PRETTY_FUNCTION__ << " - unmatched new vertex with " << sigma_separation << " sigma separation from existing vertex: "
+               << " new vertex = " << new_vertex << ", existing vertex = " << existing_vertex << " difference = " << vertex_diff << endl;
+        }
       }
     }
-  
+    if (duplicated_vertex)
+    {
+      if (Verbosity() > 1)
+      {
+        cout << __PRETTY_FUNCTION__ << " - ignore duplicated vertex = " << new_vertex << endl;
+      }
+
+      break;
+    }
+    else
+    {
+      if (Verbosity() > 1)
+      {
+        cout << __PRETTY_FUNCTION__ << " - accept and add new vertex = " << new_vertex << endl;
+      }
+
+      existing_vertex_set.insert(new_vertex);
+    }
+
+    pos[0] += _vertex_error[0] * gsl_ran_ugaussian(m_RandomGenerator);
+    pos[1] += _vertex_error[1] * gsl_ran_ugaussian(m_RandomGenerator);
+    pos[2] += _vertex_error[2] * gsl_ran_ugaussian(m_RandomGenerator);
+
+    if (Verbosity() > 0)
+    {
+      cout << __LINE__ << " PHTruthVertexing::Process: point_id " << point_id << " gembed " << gembed << "   {" << pos[0]
+           << ", " << pos[1] << ", " << pos[2] << "} +- {"
+           << _vertex_error[0] << ", " << _vertex_error[1] << ", "
+           << _vertex_error[2] << "}" << endl;
+    }
+
+    SvtxVertex* vertex = new SvtxVertex_v1();
+
+    vertex->set_x(pos[0]);
+    vertex->set_y(pos[1]);
+    vertex->set_z(pos[2]);
+
+    for (int j = 0; j < 3; ++j)
+    {
+      for (int i = j; i < 3; ++i)
+      {
+        vertex->set_error(i, j,
+                          (i == j ? _vertex_error[i] * _vertex_error[i] : 0));
+      }
+    }
+
+    vertex->set_id(0);
+    vertex->set_t0(0);
+    vertex->set_chisq(0);
+    vertex->set_ndof(1);
+    if (_embed_only)
+    {
+      if (gembed > 0) _vertex_map->insert(vertex);
+    }
+    else
+    {
+      _vertex_map->insert(vertex);
+    }
+  }
+
   if (Verbosity() > 0)
     _vertex_map->identify();
 
@@ -202,7 +263,7 @@ int PHTruthVertexing::GetNodes(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHTruthVertexing::End(PHCompositeNode * /*topNode*/)
+int PHTruthVertexing::End(PHCompositeNode* /*topNode*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHTruthVertexing.h
+++ b/offline/packages/trackreco/PHTruthVertexing.h
@@ -7,12 +7,11 @@
 #ifndef TRACKRECO_PHTRUTHVERTEXING_H
 #define TRACKRECO_PHTRUTHVERTEXING_H
 
-
 // rootcint barfs with this header so we need to hide it
 #if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
 #endif
-#include <string>             // for string
+#include <string>  // for string
 #include <vector>
 
 #include "PHInitVertexing.h"
@@ -51,7 +50,6 @@ class PHTruthVertexing : public PHInitVertexing
   }
 
  protected:
-
   int Setup(PHCompositeNode *topNode);
 
   int Process(PHCompositeNode *topNode);


### PR DESCRIPTION
The truth vertex seeding is run by default to provide the seed vertex at the current stage. When two truth event has vertex close or identical to each other, e.g. during single track embedding to a p+p event, two vertex seed that is very close to each other is generated. 

This leads to duplicated tracks in the pattern recognition and track fitting stages. 

This PR enforce if two truth vertex come within 1-sigma 3D separation, then the duplicated truth vertex is not recorded as vertex seed. 

Thanks to Fernando Torales and Reynier Cruz Torres for reporting this debug. 