### PR TITLE
add global track fit results to tree

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -177,6 +177,8 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj, PHCompositeNode *top
                          meas.parameters()[Acts::ParDef::eLOC_1]);
     /// Get global position
     Acts::Vector3D global(0, 0, 0);
+    /// This is an arbitrary vector. Doesn't matter in coordinate transformation
+    /// in Acts code
     Acts::Vector3D mom(1, 1, 1);
     meas.referenceSurface().localToGlobal(m_tGeometry->geoContext,
                                           local, mom, global);
@@ -699,6 +701,13 @@ void ActsEvaluator::fillFittedTrackParams(const Trajectory traj)
     m_err_eQOP_fit = sqrt(covariance(Acts::ParDef::eQOP, Acts::ParDef::eQOP));
     m_err_eT_fit = sqrt(covariance(Acts::ParDef::eT, Acts::ParDef::eT));
 
+    m_px_fit = boundParam.momentum()(0);
+    m_py_fit = boundParam.momentum()(1);
+    m_pz_fit = boundParam.momentum()(2);
+    m_x_fit  = boundParam.position()(0);
+    m_y_fit  = boundParam.position()(1);
+    m_z_fit  = boundParam.position()(2);
+
     return;
   }
 
@@ -715,6 +724,12 @@ void ActsEvaluator::fillFittedTrackParams(const Trajectory traj)
   m_err_eTHETA_fit = -9999;
   m_err_eQOP_fit = -9999;
   m_err_eT_fit = -9999;
+  m_px_fit = -9999;
+  m_py_fit = -9999;
+  m_pz_fit = -9999;
+  m_x_fit = -9999;
+  m_y_fit = -9999;
+  m_z_fit = -9999;
 
   return;
 }
@@ -989,6 +1004,26 @@ void ActsEvaluator::initializeTree()
   m_trackTree->Branch("t_eQOP", &m_t_eQOP);
   m_trackTree->Branch("t_eT", &m_t_eT);
 
+  m_trackTree->Branch("hasFittedParams", &m_hasFittedParams);
+  m_trackTree->Branch("eLOC0_fit", &m_eLOC0_fit);
+  m_trackTree->Branch("eLOC1_fit", &m_eLOC1_fit);
+  m_trackTree->Branch("ePHI_fit", &m_ePHI_fit);
+  m_trackTree->Branch("eTHETA_fit", &m_eTHETA_fit);
+  m_trackTree->Branch("eQOP_fit", &m_eQOP_fit);
+  m_trackTree->Branch("eT_fit", &m_eT_fit);
+  m_trackTree->Branch("err_eLOC0_fit", &m_err_eLOC0_fit);
+  m_trackTree->Branch("err_eLOC1_fit", &m_err_eLOC1_fit);
+  m_trackTree->Branch("err_ePHI_fit", &m_err_ePHI_fit);
+  m_trackTree->Branch("err_eTHETA_fit", &m_err_eTHETA_fit);
+  m_trackTree->Branch("err_eQOP_fit", &m_err_eQOP_fit);
+  m_trackTree->Branch("err_eT_fit", &m_err_eT_fit);
+  m_trackTree->Branch("g_px_fit", &m_px_fit);
+  m_trackTree->Branch("g_py_fit", &m_py_fit);
+  m_trackTree->Branch("g_pz_fit", &m_pz_fit);
+  m_trackTree->Branch("g_x_fit" , &m_x_fit);
+  m_trackTree->Branch("g_y_fit" , &m_y_fit);
+  m_trackTree->Branch("g_z_fit" , &m_z_fit);
+
   m_trackTree->Branch("nStates", &m_nStates);
   m_trackTree->Branch("nMeasurements", &m_nMeasurements);
   m_trackTree->Branch("volume_id", &m_volumeID);
@@ -1006,20 +1041,6 @@ void ActsEvaluator::initializeTree()
   m_trackTree->Branch("pull_x_hit", &m_pull_x_hit);
   m_trackTree->Branch("pull_y_hit", &m_pull_y_hit);
   m_trackTree->Branch("dim_hit", &m_dim_hit);
-
-  m_trackTree->Branch("hasFittedParams", &m_hasFittedParams);
-  m_trackTree->Branch("eLOC0_fit", &m_eLOC0_fit);
-  m_trackTree->Branch("eLOC1_fit", &m_eLOC1_fit);
-  m_trackTree->Branch("ePHI_fit", &m_ePHI_fit);
-  m_trackTree->Branch("eTHETA_fit", &m_eTHETA_fit);
-  m_trackTree->Branch("eQOP_fit", &m_eQOP_fit);
-  m_trackTree->Branch("eT_fit", &m_eT_fit);
-  m_trackTree->Branch("err_eLOC0_fit", &m_err_eLOC0_fit);
-  m_trackTree->Branch("err_eLOC1_fit", &m_err_eLOC1_fit);
-  m_trackTree->Branch("err_ePHI_fit", &m_err_ePHI_fit);
-  m_trackTree->Branch("err_eTHETA_fit", &m_err_eTHETA_fit);
-  m_trackTree->Branch("err_eQOP_fit", &m_err_eQOP_fit);
-  m_trackTree->Branch("err_eT_fit", &m_err_eT_fit);
 
   m_trackTree->Branch("nPredicted", &m_nPredicted);
   m_trackTree->Branch("predicted", &m_prt);

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -81,175 +81,181 @@ class ActsEvaluator : public SubsysReco
   int m_eventNr{0};
   int m_trajNr{0};
 
-  unsigned long m_t_barcode{0};  ///< Truth particle barcode
-  int m_t_charge{0};             ///< Truth particle charge
-  float m_t_time{0};             ///< Truth particle time
-  float m_t_vx{-99.};            ///< Truth particle vertex x
-  float m_t_vy{-99.};            ///< Truth particle vertex y
-  float m_t_vz{-99.};            ///< Truth particle vertex z
-  float m_t_px{-99.};            ///< Truth particle initial momentum px
-  float m_t_py{-99.};            ///< Truth particle initial momentum py
-  float m_t_pz{-99.};            ///< Truth particle initial momentum pz
-  float m_t_theta{-99.};         ///< Truth particle initial momentum theta
-  float m_t_phi{-99.};           ///< Truth particle initial momentum phi
-  float m_t_pT{-99.};            ///< Truth particle initial momentum pT
-  float m_t_eta{-99.};           ///< Truth particle initial momentum eta
+  unsigned long m_t_barcode{0};  /// Truth particle barcode
+  int m_t_charge{0};             /// Truth particle charge
+  float m_t_time{0};             /// Truth particle time
+  float m_t_vx{-99.};            /// Truth particle vertex x
+  float m_t_vy{-99.};            /// Truth particle vertex y
+  float m_t_vz{-99.};            /// Truth particle vertex z
+  float m_t_px{-99.};            /// Truth particle initial momentum px
+  float m_t_py{-99.};            /// Truth particle initial momentum py
+  float m_t_pz{-99.};            /// Truth particle initial momentum pz
+  float m_t_theta{-99.};         /// Truth particle initial momentum theta
+  float m_t_phi{-99.};           /// Truth particle initial momentum phi
+  float m_t_pT{-99.};            /// Truth particle initial momentum pT
+  float m_t_eta{-99.};           /// Truth particle initial momentum eta
 
-  std::vector<float> m_t_x;  ///< Global truth hit position x
-  std::vector<float> m_t_y;  ///< Global truth hit position y
-  std::vector<float> m_t_z;  ///< Global truth hit position z
-  std::vector<float> m_t_r;  ///< Global truth hit position r
+  std::vector<float> m_t_x;  /// Global truth hit position x
+  std::vector<float> m_t_y;  /// Global truth hit position y
+  std::vector<float> m_t_z;  /// Global truth hit position z
+  std::vector<float> m_t_r;  /// Global truth hit position r
   std::vector<float>
-      m_t_dx;  ///< Truth particle direction x at global hit position
+      m_t_dx;  /// Truth particle direction x at global hit position
   std::vector<float>
-      m_t_dy;  ///< Truth particle direction y at global hit position
+      m_t_dy;  /// Truth particle direction y at global hit position
   std::vector<float>
-      m_t_dz;  ///< Truth particle direction z at global hit position
+      m_t_dz;  /// Truth particle direction z at global hit position
 
-  std::vector<float> m_t_eLOC0;   ///< truth parameter eLOC_0
-  std::vector<float> m_t_eLOC1;   ///< truth parameter eLOC_1
-  std::vector<float> m_t_ePHI;    ///< truth parameter ePHI
-  std::vector<float> m_t_eTHETA;  ///< truth parameter eTHETA
-  std::vector<float> m_t_eQOP;    ///< truth parameter eQOP
-  std::vector<float> m_t_eT;      ///< truth parameter eT
+  std::vector<float> m_t_eLOC0;   /// truth parameter eLOC_0
+  std::vector<float> m_t_eLOC1;   /// truth parameter eLOC_1
+  std::vector<float> m_t_ePHI;    /// truth parameter ePHI
+  std::vector<float> m_t_eTHETA;  /// truth parameter eTHETA
+  std::vector<float> m_t_eQOP;    /// truth parameter eQOP
+  std::vector<float> m_t_eT;      /// truth parameter eT
 
-  int m_nStates{0};                 ///< number of all states
-  int m_nMeasurements{0};           ///< number of states with measurements
-  std::vector<int> m_volumeID;      ///< volume identifier
-  std::vector<int> m_layerID;       ///< layer identifier
-  std::vector<int> m_moduleID;      ///< surface identifier
-  std::vector<float> m_lx_hit;      ///< uncalibrated measurement local x
-  std::vector<float> m_ly_hit;      ///< uncalibrated measurement local y
-  std::vector<float> m_x_hit;       ///< uncalibrated measurement global x
-  std::vector<float> m_y_hit;       ///< uncalibrated measurement global y
-  std::vector<float> m_z_hit;       ///< uncalibrated measurement global z
-  std::vector<float> m_res_x_hit;   ///< hit residual x
-  std::vector<float> m_res_y_hit;   ///< hit residual y
-  std::vector<float> m_err_x_hit;   ///< hit err x
-  std::vector<float> m_err_y_hit;   ///< hit err y
-  std::vector<float> m_pull_x_hit;  ///< hit pull x
-  std::vector<float> m_pull_y_hit;  ///< hit pull y
-  std::vector<int> m_dim_hit;       ///< dimension of measurement
+  int m_nStates{0};                 /// number of all states
+  int m_nMeasurements{0};           /// number of states with measurements
+  std::vector<int> m_volumeID;      /// volume identifier
+  std::vector<int> m_layerID;       /// layer identifier
+  std::vector<int> m_moduleID;      /// surface identifier
+  std::vector<float> m_lx_hit;      /// uncalibrated measurement local x
+  std::vector<float> m_ly_hit;      /// uncalibrated measurement local y
+  std::vector<float> m_x_hit;       /// uncalibrated measurement global x
+  std::vector<float> m_y_hit;       /// uncalibrated measurement global y
+  std::vector<float> m_z_hit;       /// uncalibrated measurement global z
+  std::vector<float> m_res_x_hit;   /// hit residual x
+  std::vector<float> m_res_y_hit;   /// hit residual y
+  std::vector<float> m_err_x_hit;   /// hit err x
+  std::vector<float> m_err_y_hit;   /// hit err y
+  std::vector<float> m_pull_x_hit;  /// hit pull x
+  std::vector<float> m_pull_y_hit;  /// hit pull y
+  std::vector<int> m_dim_hit;       /// dimension of measurement
 
-  bool m_hasFittedParams{false};  ///< if the track has fitted parameter
-  float m_eLOC0_fit{-99.};        ///< fitted parameter eLOC_0
-  float m_eLOC1_fit{-99.};        ///< fitted parameter eLOC_1
-  float m_ePHI_fit{-99.};         ///< fitted parameter ePHI
-  float m_eTHETA_fit{-99.};       ///< fitted parameter eTHETA
-  float m_eQOP_fit{-99.};         ///< fitted parameter eQOP
-  float m_eT_fit{-99.};           ///< fitted parameter eT
-  float m_err_eLOC0_fit{-99.};    ///< fitted parameter eLOC_-99.err
-  float m_err_eLOC1_fit{-99.};    ///< fitted parameter eLOC_1 err
-  float m_err_ePHI_fit{-99.};     ///< fitted parameter ePHI err
-  float m_err_eTHETA_fit{-99.};   ///< fitted parameter eTHETA err
-  float m_err_eQOP_fit{-99.};     ///< fitted parameter eQOP err
-  float m_err_eT_fit{-99.};       ///< fitted parameter eT err
+  bool m_hasFittedParams{false};  /// if the track has fitted parameter
+  float m_eLOC0_fit{-99.};        /// fitted parameter eLOC_0
+  float m_eLOC1_fit{-99.};        /// fitted parameter eLOC_1
+  float m_ePHI_fit{-99.};         /// fitted parameter ePHI
+  float m_eTHETA_fit{-99.};       /// fitted parameter eTHETA
+  float m_eQOP_fit{-99.};         /// fitted parameter eQOP
+  float m_eT_fit{-99.};           /// fitted parameter eT
+  float m_err_eLOC0_fit{-99.};    /// fitted parameter eLOC_-99.err
+  float m_err_eLOC1_fit{-99.};    /// fitted parameter eLOC_1 err
+  float m_err_ePHI_fit{-99.};     /// fitted parameter ePHI err
+  float m_err_eTHETA_fit{-99.};   /// fitted parameter eTHETA err
+  float m_err_eQOP_fit{-99.};     /// fitted parameter eQOP err
+  float m_err_eT_fit{-99.};       /// fitted parameter eT err
+  float m_px_fit{-99.};           /// fitted parameter global px
+  float m_py_fit{-99.};           /// fitted parameter global py
+  float m_pz_fit{-99.};           /// fitted parameter global pz
+  float m_x_fit{-99.};            /// fitted parameter global PCA x
+  float m_y_fit{-99.};            /// fitted parameter global PCA y
+  float m_z_fit{-99.};            /// fitted parameter global PCA z
 
-  int m_nPredicted{0};                   ///< number of states with predicted parameter
-  std::vector<bool> m_prt;               ///< predicted status
-  std::vector<float> m_eLOC0_prt;        ///< predicted parameter eLOC0
-  std::vector<float> m_eLOC1_prt;        ///< predicted parameter eLOC1
-  std::vector<float> m_ePHI_prt;         ///< predicted parameter ePHI
-  std::vector<float> m_eTHETA_prt;       ///< predicted parameter eTHETA
-  std::vector<float> m_eQOP_prt;         ///< predicted parameter eQOP
-  std::vector<float> m_eT_prt;           ///< predicted parameter eT
-  std::vector<float> m_res_eLOC0_prt;    ///< predicted parameter eLOC0 residual
-  std::vector<float> m_res_eLOC1_prt;    ///< predicted parameter eLOC1 residual
-  std::vector<float> m_res_ePHI_prt;     ///< predicted parameter ePHI residual
-  std::vector<float> m_res_eTHETA_prt;   ///< predicted parameter eTHETA residual
-  std::vector<float> m_res_eQOP_prt;     ///< predicted parameter eQOP residual
-  std::vector<float> m_res_eT_prt;       ///< predicted parameter eT residual
-  std::vector<float> m_err_eLOC0_prt;    ///< predicted parameter eLOC0 error
-  std::vector<float> m_err_eLOC1_prt;    ///< predicted parameter eLOC1 error
-  std::vector<float> m_err_ePHI_prt;     ///< predicted parameter ePHI error
-  std::vector<float> m_err_eTHETA_prt;   ///< predicted parameter eTHETA error
-  std::vector<float> m_err_eQOP_prt;     ///< predicted parameter eQOP error
-  std::vector<float> m_err_eT_prt;       ///< predicted parameter eT error
-  std::vector<float> m_pull_eLOC0_prt;   ///< predicted parameter eLOC0 pull
-  std::vector<float> m_pull_eLOC1_prt;   ///< predicted parameter eLOC1 pull
-  std::vector<float> m_pull_ePHI_prt;    ///< predicted parameter ePHI pull
-  std::vector<float> m_pull_eTHETA_prt;  ///< predicted parameter eTHETA pull
-  std::vector<float> m_pull_eQOP_prt;    ///< predicted parameter eQOP pull
-  std::vector<float> m_pull_eT_prt;      ///< predicted parameter eT pull
-  std::vector<float> m_x_prt;            ///< predicted global x
-  std::vector<float> m_y_prt;            ///< predicted global y
-  std::vector<float> m_z_prt;            ///< predicted global z
-  std::vector<float> m_px_prt;           ///< predicted momentum px
-  std::vector<float> m_py_prt;           ///< predicted momentum py
-  std::vector<float> m_pz_prt;           ///< predicted momentum pz
-  std::vector<float> m_eta_prt;          ///< predicted momentum eta
-  std::vector<float> m_pT_prt;           ///< predicted momentum pT
+  int m_nPredicted{0};                   /// number of states with predicted parameter
+  std::vector<bool> m_prt;               /// predicted status
+  std::vector<float> m_eLOC0_prt;        /// predicted parameter eLOC0
+  std::vector<float> m_eLOC1_prt;        /// predicted parameter eLOC1
+  std::vector<float> m_ePHI_prt;         /// predicted parameter ePHI
+  std::vector<float> m_eTHETA_prt;       /// predicted parameter eTHETA
+  std::vector<float> m_eQOP_prt;         /// predicted parameter eQOP
+  std::vector<float> m_eT_prt;           /// predicted parameter eT
+  std::vector<float> m_res_eLOC0_prt;    /// predicted parameter eLOC0 residual
+  std::vector<float> m_res_eLOC1_prt;    /// predicted parameter eLOC1 residual
+  std::vector<float> m_res_ePHI_prt;     /// predicted parameter ePHI residual
+  std::vector<float> m_res_eTHETA_prt;   /// predicted parameter eTHETA residual
+  std::vector<float> m_res_eQOP_prt;     /// predicted parameter eQOP residual
+  std::vector<float> m_res_eT_prt;       /// predicted parameter eT residual
+  std::vector<float> m_err_eLOC0_prt;    /// predicted parameter eLOC0 error
+  std::vector<float> m_err_eLOC1_prt;    /// predicted parameter eLOC1 error
+  std::vector<float> m_err_ePHI_prt;     /// predicted parameter ePHI error
+  std::vector<float> m_err_eTHETA_prt;   /// predicted parameter eTHETA error
+  std::vector<float> m_err_eQOP_prt;     /// predicted parameter eQOP error
+  std::vector<float> m_err_eT_prt;       /// predicted parameter eT error
+  std::vector<float> m_pull_eLOC0_prt;   /// predicted parameter eLOC0 pull
+  std::vector<float> m_pull_eLOC1_prt;   /// predicted parameter eLOC1 pull
+  std::vector<float> m_pull_ePHI_prt;    /// predicted parameter ePHI pull
+  std::vector<float> m_pull_eTHETA_prt;  /// predicted parameter eTHETA pull
+  std::vector<float> m_pull_eQOP_prt;    /// predicted parameter eQOP pull
+  std::vector<float> m_pull_eT_prt;      /// predicted parameter eT pull
+  std::vector<float> m_x_prt;            /// predicted global x
+  std::vector<float> m_y_prt;            /// predicted global y
+  std::vector<float> m_z_prt;            /// predicted global z
+  std::vector<float> m_px_prt;           /// predicted momentum px
+  std::vector<float> m_py_prt;           /// predicted momentum py
+  std::vector<float> m_pz_prt;           /// predicted momentum pz
+  std::vector<float> m_eta_prt;          /// predicted momentum eta
+  std::vector<float> m_pT_prt;           /// predicted momentum pT
 
-  int m_nFiltered{0};                    ///< number of states with filtered parameter
-  std::vector<bool> m_flt;               ///< filtered status
-  std::vector<float> m_eLOC0_flt;        ///< filtered parameter eLOC0
-  std::vector<float> m_eLOC1_flt;        ///< filtered parameter eLOC1
-  std::vector<float> m_ePHI_flt;         ///< filtered parameter ePHI
-  std::vector<float> m_eTHETA_flt;       ///< filtered parameter eTHETA
-  std::vector<float> m_eQOP_flt;         ///< filtered parameter eQOP
-  std::vector<float> m_eT_flt;           ///< filtered parameter eT
-  std::vector<float> m_res_eLOC0_flt;    ///< filtered parameter eLOC0 residual
-  std::vector<float> m_res_eLOC1_flt;    ///< filtered parameter eLOC1 residual
-  std::vector<float> m_res_ePHI_flt;     ///< filtered parameter ePHI residual
-  std::vector<float> m_res_eTHETA_flt;   ///< filtered parameter eTHETA residual
-  std::vector<float> m_res_eQOP_flt;     ///< filtered parameter eQOP residual
-  std::vector<float> m_res_eT_flt;       ///< filtered parameter eT residual
-  std::vector<float> m_err_eLOC0_flt;    ///< filtered parameter eLOC0 error
-  std::vector<float> m_err_eLOC1_flt;    ///< filtered parameter eLOC1 error
-  std::vector<float> m_err_ePHI_flt;     ///< filtered parameter ePHI error
-  std::vector<float> m_err_eTHETA_flt;   ///< filtered parameter eTHETA error
-  std::vector<float> m_err_eQOP_flt;     ///< filtered parameter eQOP error
-  std::vector<float> m_err_eT_flt;       ///< filtered parameter eT error
-  std::vector<float> m_pull_eLOC0_flt;   ///< filtered parameter eLOC0 pull
-  std::vector<float> m_pull_eLOC1_flt;   ///< filtered parameter eLOC1 pull
-  std::vector<float> m_pull_ePHI_flt;    ///< filtered parameter ePHI pull
-  std::vector<float> m_pull_eTHETA_flt;  ///< filtered parameter eTHETA pull
-  std::vector<float> m_pull_eQOP_flt;    ///< filtered parameter eQOP pull
-  std::vector<float> m_pull_eT_flt;      ///< filtered parameter eT pull
-  std::vector<float> m_x_flt;            ///< filtered global x
-  std::vector<float> m_y_flt;            ///< filtered global y
-  std::vector<float> m_z_flt;            ///< filtered global z
-  std::vector<float> m_px_flt;           ///< filtered momentum px
-  std::vector<float> m_py_flt;           ///< filtered momentum py
-  std::vector<float> m_pz_flt;           ///< filtered momentum pz
-  std::vector<float> m_eta_flt;          ///< filtered momentum eta
-  std::vector<float> m_pT_flt;           ///< filtered momentum pT
-  std::vector<float> m_chi2;             ///< chisq from filtering
+  int m_nFiltered{0};                    /// number of states with filtered parameter
+  std::vector<bool> m_flt;               /// filtered status
+  std::vector<float> m_eLOC0_flt;        /// filtered parameter eLOC0
+  std::vector<float> m_eLOC1_flt;        /// filtered parameter eLOC1
+  std::vector<float> m_ePHI_flt;         /// filtered parameter ePHI
+  std::vector<float> m_eTHETA_flt;       /// filtered parameter eTHETA
+  std::vector<float> m_eQOP_flt;         /// filtered parameter eQOP
+  std::vector<float> m_eT_flt;           /// filtered parameter eT
+  std::vector<float> m_res_eLOC0_flt;    /// filtered parameter eLOC0 residual
+  std::vector<float> m_res_eLOC1_flt;    /// filtered parameter eLOC1 residual
+  std::vector<float> m_res_ePHI_flt;     /// filtered parameter ePHI residual
+  std::vector<float> m_res_eTHETA_flt;   /// filtered parameter eTHETA residual
+  std::vector<float> m_res_eQOP_flt;     /// filtered parameter eQOP residual
+  std::vector<float> m_res_eT_flt;       /// filtered parameter eT residual
+  std::vector<float> m_err_eLOC0_flt;    /// filtered parameter eLOC0 error
+  std::vector<float> m_err_eLOC1_flt;    /// filtered parameter eLOC1 error
+  std::vector<float> m_err_ePHI_flt;     /// filtered parameter ePHI error
+  std::vector<float> m_err_eTHETA_flt;   /// filtered parameter eTHETA error
+  std::vector<float> m_err_eQOP_flt;     /// filtered parameter eQOP error
+  std::vector<float> m_err_eT_flt;       /// filtered parameter eT error
+  std::vector<float> m_pull_eLOC0_flt;   /// filtered parameter eLOC0 pull
+  std::vector<float> m_pull_eLOC1_flt;   /// filtered parameter eLOC1 pull
+  std::vector<float> m_pull_ePHI_flt;    /// filtered parameter ePHI pull
+  std::vector<float> m_pull_eTHETA_flt;  /// filtered parameter eTHETA pull
+  std::vector<float> m_pull_eQOP_flt;    /// filtered parameter eQOP pull
+  std::vector<float> m_pull_eT_flt;      /// filtered parameter eT pull
+  std::vector<float> m_x_flt;            /// filtered global x
+  std::vector<float> m_y_flt;            /// filtered global y
+  std::vector<float> m_z_flt;            /// filtered global z
+  std::vector<float> m_px_flt;           /// filtered momentum px
+  std::vector<float> m_py_flt;           /// filtered momentum py
+  std::vector<float> m_pz_flt;           /// filtered momentum pz
+  std::vector<float> m_eta_flt;          /// filtered momentum eta
+  std::vector<float> m_pT_flt;           /// filtered momentum pT
+  std::vector<float> m_chi2;             /// chisq from filtering
 
-  int m_nSmoothed{0};                    ///< number of states with smoothed parameter
-  std::vector<bool> m_smt;               ///< smoothed status
-  std::vector<float> m_eLOC0_smt;        ///< smoothed parameter eLOC0
-  std::vector<float> m_eLOC1_smt;        ///< smoothed parameter eLOC1
-  std::vector<float> m_ePHI_smt;         ///< smoothed parameter ePHI
-  std::vector<float> m_eTHETA_smt;       ///< smoothed parameter eTHETA
-  std::vector<float> m_eQOP_smt;         ///< smoothed parameter eQOP
-  std::vector<float> m_eT_smt;           ///< smoothed parameter eT
-  std::vector<float> m_res_eLOC0_smt;    ///< smoothed parameter eLOC0 residual
-  std::vector<float> m_res_eLOC1_smt;    ///< smoothed parameter eLOC1 residual
-  std::vector<float> m_res_ePHI_smt;     ///< smoothed parameter ePHI residual
-  std::vector<float> m_res_eTHETA_smt;   ///< smoothed parameter eTHETA residual
-  std::vector<float> m_res_eQOP_smt;     ///< smoothed parameter eQOP residual
-  std::vector<float> m_res_eT_smt;       ///< smoothed parameter eT residual
-  std::vector<float> m_err_eLOC0_smt;    ///< smoothed parameter eLOC0 error
-  std::vector<float> m_err_eLOC1_smt;    ///< smoothed parameter eLOC1 error
-  std::vector<float> m_err_ePHI_smt;     ///< smoothed parameter ePHI error
-  std::vector<float> m_err_eTHETA_smt;   ///< smoothed parameter eTHETA error
-  std::vector<float> m_err_eQOP_smt;     ///< smoothed parameter eQOP error
-  std::vector<float> m_err_eT_smt;       ///< smoothed parameter eT error
-  std::vector<float> m_pull_eLOC0_smt;   ///< smoothed parameter eLOC0 pull
-  std::vector<float> m_pull_eLOC1_smt;   ///< smoothed parameter eLOC1 pull
-  std::vector<float> m_pull_ePHI_smt;    ///< smoothed parameter ePHI pull
-  std::vector<float> m_pull_eTHETA_smt;  ///< smoothed parameter eTHETA pull
-  std::vector<float> m_pull_eQOP_smt;    ///< smoothed parameter eQOP pull
-  std::vector<float> m_pull_eT_smt;      ///< smoothed parameter eT pull
-  std::vector<float> m_x_smt;            ///< smoothed global x
-  std::vector<float> m_y_smt;            ///< smoothed global y
-  std::vector<float> m_z_smt;            ///< smoothed global z
-  std::vector<float> m_px_smt;           ///< smoothed momentum px
-  std::vector<float> m_py_smt;           ///< smoothed momentum py
-  std::vector<float> m_pz_smt;           ///< smoothed momentum pz
-  std::vector<float> m_eta_smt;          ///< smoothed momentum eta
-  std::vector<float> m_pT_smt;           ///< smoothed momentum pT
+  int m_nSmoothed{0};                    /// number of states with smoothed parameter
+  std::vector<bool> m_smt;               /// smoothed status
+  std::vector<float> m_eLOC0_smt;        /// smoothed parameter eLOC0
+  std::vector<float> m_eLOC1_smt;        /// smoothed parameter eLOC1
+  std::vector<float> m_ePHI_smt;         /// smoothed parameter ePHI
+  std::vector<float> m_eTHETA_smt;       /// smoothed parameter eTHETA
+  std::vector<float> m_eQOP_smt;         /// smoothed parameter eQOP
+  std::vector<float> m_eT_smt;           /// smoothed parameter eT
+  std::vector<float> m_res_eLOC0_smt;    /// smoothed parameter eLOC0 residual
+  std::vector<float> m_res_eLOC1_smt;    /// smoothed parameter eLOC1 residual
+  std::vector<float> m_res_ePHI_smt;     /// smoothed parameter ePHI residual
+  std::vector<float> m_res_eTHETA_smt;   /// smoothed parameter eTHETA residual
+  std::vector<float> m_res_eQOP_smt;     /// smoothed parameter eQOP residual
+  std::vector<float> m_res_eT_smt;       /// smoothed parameter eT residual
+  std::vector<float> m_err_eLOC0_smt;    /// smoothed parameter eLOC0 error
+  std::vector<float> m_err_eLOC1_smt;    /// smoothed parameter eLOC1 error
+  std::vector<float> m_err_ePHI_smt;     /// smoothed parameter ePHI error
+  std::vector<float> m_err_eTHETA_smt;   /// smoothed parameter eTHETA error
+  std::vector<float> m_err_eQOP_smt;     /// smoothed parameter eQOP error
+  std::vector<float> m_err_eT_smt;       /// smoothed parameter eT error
+  std::vector<float> m_pull_eLOC0_smt;   /// smoothed parameter eLOC0 pull
+  std::vector<float> m_pull_eLOC1_smt;   /// smoothed parameter eLOC1 pull
+  std::vector<float> m_pull_ePHI_smt;    /// smoothed parameter ePHI pull
+  std::vector<float> m_pull_eTHETA_smt;  /// smoothed parameter eTHETA pull
+  std::vector<float> m_pull_eQOP_smt;    /// smoothed parameter eQOP pull
+  std::vector<float> m_pull_eT_smt;      /// smoothed parameter eT pull
+  std::vector<float> m_x_smt;            /// smoothed global x
+  std::vector<float> m_y_smt;            /// smoothed global y
+  std::vector<float> m_z_smt;            /// smoothed global z
+  std::vector<float> m_px_smt;           /// smoothed momentum px
+  std::vector<float> m_py_smt;           /// smoothed momentum py
+  std::vector<float> m_pz_smt;           /// smoothed momentum pz
+  std::vector<float> m_eta_smt;          /// smoothed momentum eta
+  std::vector<float> m_pT_smt;           /// smoothed momentum pT
 };
 
 #endif


### PR DESCRIPTION
This PR adds the global track fit results to the ActsEvaluator tree for further analysis. I also fixed the comments in the header to be doxygen style.