### PR TITLE
Upstream/master micromegas tracking

### DIFF
--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -110,6 +110,9 @@ PHGenFitTrkProp::PHGenFitTrkProp(
   , _nlayers_intt(nlayers_intt)
   , _nlayers_tpc(nlayers_tpc)
   , _nlayers_all(_nlayers_maps + _nlayers_intt + _nlayers_tpc)
+  , _firstlayer_maps(0)
+  , _firstlayer_intt(_firstlayer_maps + _nlayers_maps)
+  , _firstlayer_tpc(_firstlayer_intt + _nlayers_intt)
 {}
 
 int PHGenFitTrkProp::Setup(PHCompositeNode* topNode)
@@ -717,32 +720,24 @@ int PHGenFitTrkProp::OutputPHGenFitTrack(
   Int_t n_intt = 0;
   Int_t n_tpc = 0;
   
-  for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-       iter != track->end_cluster_keys();
-       ++iter)
+  for (auto iter = track->begin_cluster_keys(); iter != track->end_cluster_keys(); ++iter)
+  {
+    TrkrDefs::cluskey cluster_key = *iter;
+    unsigned int layer = TrkrDefs::getLayer(cluster_key);
+    if( is_maps_layer( layer ) )
     {
-      TrkrDefs::cluskey cluster_key = *iter;
-      unsigned int layer = TrkrDefs::getLayer(cluster_key);
-      if (_nlayers_maps > 0 && layer < _nlayers_maps)
-	{
-	  n_maps++;
-	}
-      if (_nlayers_intt > 0 && layer >= _nlayers_maps && layer < _nlayers_maps + _nlayers_intt)
-	{
-	  n_intt++;
-	}
+      n_maps++;
+    } else if( is_intt_layer( layer ) ) {
+      n_intt++;
       if (n_intt > 4)
-	{
-	  cout << PHWHERE << " Can not have more than 4 INTT layers, quit!" << endl;
-	  exit(1);
-	}
-      if (_nlayers_tpc > 0 &&
-	  layer >= (_nlayers_maps + _nlayers_intt) &&
-	  layer < (_nlayers_maps + _nlayers_intt + _nlayers_tpc))
-	{
-	  n_tpc++;
-	}
+      {
+        cout << PHWHERE << " Can not have more than 4 INTT layers, quit!" << endl;
+        exit(1);
+      }
+    } else if( is_tpc_layer( layer ) ) {
+      n_tpc++;
     }
+  }
   
   // Add the cluster-track association to the association table for later use
   for (TrkrDefs::cluskey cluster_key : gftrk_iter->second->get_cluster_keys())
@@ -1242,21 +1237,21 @@ int PHGenFitTrkProp::TrackPropPatRec(
     float phi_window = _search_wins_phi[layer] * sqrt(cov[0][0] + cov[1][1] + cov[0][1] + cov[1][0]) / pos.Perp();
     float theta_window = _search_wins_theta[layer] * sqrt(cov[2][2]) / pos.Perp();
 
-    if (layer < _nlayers_maps)
+    if( is_maps_layer( layer ) )
     {
       if (phi_window > _max_search_win_phi_maps) phi_window = _max_search_win_phi_maps;
       if (phi_window < _min_search_win_phi_maps) phi_window = _min_search_win_phi_maps;
       if (theta_window > _max_search_win_theta_maps) theta_window = _max_search_win_theta_maps;
       if (theta_window < _min_search_win_theta_maps) theta_window = _min_search_win_theta_maps;
     }
-    else if (layer < _nlayers_maps + _nlayers_intt)
+    else if( is_intt_layer( layer ) )
     {
       if (phi_window > _max_search_win_phi_intt[layer - _nlayers_maps]) phi_window = _max_search_win_phi_intt[layer - _nlayers_maps];
       if (phi_window < _min_search_win_phi_intt[layer - _nlayers_maps]) phi_window = _min_search_win_phi_intt[layer - _nlayers_maps];
       if (theta_window > _max_search_win_theta_intt[layer - _nlayers_maps]) theta_window = _max_search_win_theta_intt[layer - _nlayers_maps];
       if (theta_window < _min_search_win_theta_intt[layer - _nlayers_maps]) theta_window = _min_search_win_theta_intt[layer - _nlayers_maps];
     }
-    else
+    else if( is_tpc_layer( layer ) )
     {
       if (phi_window > _max_search_win_phi_tpc) phi_window = _max_search_win_phi_tpc;
       if (phi_window < _min_search_win_phi_tpc) phi_window = _min_search_win_phi_tpc;
@@ -1352,9 +1347,9 @@ int PHGenFitTrkProp::TrackPropPatRec(
         track_iter->first.nhits = tq.nhits + 1;
         track_iter->first.chi2 = tq.chi2 + iter->first;
         track_iter->first.ndf = tq.ndf + 2;
-        track_iter->first.ntpc = tq.ntpc + ((layer >= _nlayers_maps + _nlayers_intt) ? 1 : 0);
-        track_iter->first.nintt = tq.nintt + ((layer >= _nlayers_maps and layer < _nlayers_maps + _nlayers_intt) ? 1 : 0);
-        track_iter->first.nmaps = tq.nmaps + ((layer < _nlayers_maps) ? 1 : 0);
+        track_iter->first.ntpc = tq.ntpc + (is_tpc_layer(layer) ? 1 : 0);
+        track_iter->first.nintt = tq.nintt + (is_intt_layer(layer) ? 1 : 0);
+        track_iter->first.nmaps = tq.nmaps + (is_maps_layer(layer) ? 1 : 0);
 
         track_iter->second = std::shared_ptr<PHGenFit::Track>(iter->second);
 
@@ -1405,10 +1400,10 @@ int PHGenFitTrkProp::TrackPropPatRec(
                     tq.nhits + 1,
                     tq.chi2 + iter->first,
                     tq.ndf + 2,
-                    tq.ntpc + ((layer >= _nlayers_maps + _nlayers_intt) ? 1 : 0),
-                    tq.nintt + ((layer >= _nlayers_maps and layer < _nlayers_maps + _nlayers_intt) ? 1 : 0),
-                    tq.nmaps + ((layer < _nlayers_maps) ? 1 : 0)),
-                std::shared_ptr<PHGenFit::Track>(iter->second)));
+                    tq.ntpc + (is_tpc_layer(layer) ? 1 : 0),
+                    tq.nintt + (is_intt_layer(layer) ? 1 : 0),
+                    tq.nmaps + (is_maps_layer(layer) ? 1 : 0)),
+                    iter->second));
       }
 
 #ifdef _DEBUG_

--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -106,123 +106,11 @@ PHGenFitTrkProp::PHGenFitTrkProp(
     unsigned int nlayers_intt,
     unsigned int nlayers_tpc)
   : PHTrackPropagating(name)
-  , _t_seeds_cleanup(nullptr)
-  , _t_translate_to_PHGenFitTrack(nullptr)
-  , _t_translate1(nullptr)
-  , _t_translate2(nullptr)
-  , _t_translate3(nullptr)
-  , _t_kalman_pat_rec(nullptr)
-  , _t_search_clusters(nullptr)
-  , _t_search_clusters_encoding(nullptr)
-  , _t_search_clusters_map_iter(nullptr)
-  , _t_track_propagation(nullptr)
-  , _t_full_fitting(nullptr)
-  , _t_output_io(nullptr)
-  , _vertex()
-  , _bbc_vertexes(nullptr)
-  , _hit_used_map(nullptr)
-  , _hit_used_map_size(0)
-  , _geom_container_intt(nullptr)
-  , _geom_container_maps(nullptr)
-  , _analyzing_mode(false)
-  , _analyzing_file(nullptr)
-  , _analyzing_ntuple(nullptr)
-  , _max_merging_dphi(0.1)
-  , _max_merging_deta(0.1)
-  , _max_merging_dr(0.1)
-  , _max_merging_dz(0.1)
-  , _max_share_hits(3)
-  , _fitter(nullptr)
-  , _track_fitting_alg_name("DafRef")//KalmanFitter
-  , _primary_pid_guess(211)
-  , _cut_min_pT(0.2)
-  , _do_evt_display(false)
   , _nlayers_maps(nlayers_maps)
   , _nlayers_intt(nlayers_intt)
   , _nlayers_tpc(nlayers_tpc)
   , _nlayers_all(_nlayers_maps + _nlayers_intt + _nlayers_tpc)
-  , _layer_ilayer_map_all()
-  , _radii_all()
-  , _max_search_win_phi_tpc(0.0040)
-  , _min_search_win_phi_tpc(0.0000)
-  , _max_search_win_theta_tpc(0.0040)
-  , _min_search_win_theta_tpc(0.0000)
-  , _max_search_win_phi_maps(0.0050)
-  , _min_search_win_phi_maps(0.0000)
-  , _max_search_win_theta_maps(0.0400)
-  , _min_search_win_theta_maps(0.0000)
-  ,
-
-  _search_win_phi(20)
-  , _search_win_theta(20)
-  , _layer_thetaID_phiID_clusterID()
-  ,
-  //_half_max_theta(160),
-  _half_max_theta(3.1416 / 2.)
-  ,
-  //_half_max_phi(252), //80cm * Pi
-  _half_max_phi(3.1416)
-  ,
-  //_layer_thetaID_phiID_clusterID_phiSize(0.1200),
-  _layer_thetaID_phiID_clusterID_phiSize(0.1200 / 30)
-  ,  //rad
-  _layer_thetaID_phiID_clusterID_zSize(0.1700 / 30)
-  , _PHGenFitTracks()
-  , _init_direction(-1)
-  , _blowup_factor(1.)
-  , _max_consecutive_missing_layer(20)
-  , _max_incr_chi2(20.)
-  , _max_splitting_chi2(20.)
-  , _min_good_track_hits(30)
-  , _topNode(nullptr)
-  , _ntrack(0)
-{
-  _event = 0;
-
-  _max_search_win_phi_intt[0] = 0.20;
-  _max_search_win_phi_intt[1] = 0.20;
-  _max_search_win_phi_intt[2] = 0.0050;
-  _max_search_win_phi_intt[3] = 0.0050;
-  _max_search_win_phi_intt[4] = 0.0050;
-  _max_search_win_phi_intt[5] = 0.0050;
-  _max_search_win_phi_intt[6] = 0.0050;
-  _max_search_win_phi_intt[7] = 0.0050;
-
-  _min_search_win_phi_intt[0] = 0.2000;
-  _min_search_win_phi_intt[1] = 0.2000;
-  _min_search_win_phi_intt[2] = 0.0;
-  _min_search_win_phi_intt[3] = 0.0;
-  _min_search_win_phi_intt[4] = 0.0;
-  _min_search_win_phi_intt[5] = 0.0;
-  _min_search_win_phi_intt[6] = 0.0;
-  _min_search_win_phi_intt[7] = 0.0;
-
-  _max_search_win_theta_intt[0] = 0.010;
-  _max_search_win_theta_intt[1] = 0.010;
-  _max_search_win_theta_intt[2] = 0.2000;
-  _max_search_win_theta_intt[3] = 0.2000;
-  _max_search_win_theta_intt[4] = 0.2000;
-  _max_search_win_theta_intt[5] = 0.2000;
-  _max_search_win_theta_intt[6] = 0.2000;
-  _max_search_win_theta_intt[7] = 0.2000;
-
-  _min_search_win_theta_intt[0] = 0.000;
-  _min_search_win_theta_intt[1] = 0.000;
-  _min_search_win_theta_intt[2] = 0.200;
-  _min_search_win_theta_intt[3] = 0.200;
-  _min_search_win_theta_intt[4] = 0.200;
-  _min_search_win_theta_intt[5] = 0.200;
-  _min_search_win_theta_intt[6] = 0.200;
-  _min_search_win_theta_intt[7] = 0.200;
-
-  _vertex_error.clear();
-  //_vertex_error.assign(3, 0.0100);
-}
-
-PHGenFitTrkProp::~PHGenFitTrkProp()
-{
-  delete _fitter;
-}
+{}
 
 int PHGenFitTrkProp::Setup(PHCompositeNode* topNode)
 {
@@ -424,9 +312,7 @@ int PHGenFitTrkProp::InitializePHGenFit(PHCompositeNode* topNode)
 
   PHField* field = PHFieldUtility::GetFieldMapNode(nullptr, topNode);
 
-  //_fitter = new PHGenFit::Fitter("sPHENIX_Geo.root","sPHENIX.2d.root", 1.4 / 1.5);
-  _fitter = PHGenFit::Fitter::getInstance(tgeo_manager, field, _track_fitting_alg_name,
-                                          "RKTrackRep", _do_evt_display);
+  _fitter.reset( PHGenFit::Fitter::getInstance(tgeo_manager, field, _track_fitting_alg_name, "RKTrackRep", _do_evt_display) ); 
 
   if (!_fitter)
   {

--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -104,15 +104,18 @@ PHGenFitTrkProp::PHGenFitTrkProp(
     const string& name,
     unsigned int nlayers_maps,
     unsigned int nlayers_intt,
-    unsigned int nlayers_tpc)
+    unsigned int nlayers_tpc,
+    unsigned int nlayers_micromegas)
   : PHTrackPropagating(name)
   , _nlayers_maps(nlayers_maps)
   , _nlayers_intt(nlayers_intt)
   , _nlayers_tpc(nlayers_tpc)
-  , _nlayers_all(_nlayers_maps + _nlayers_intt + _nlayers_tpc)
+  , _nlayers_micromegas(nlayers_micromegas)
+  , _nlayers_all(_nlayers_maps + _nlayers_intt + _nlayers_tpc + _nlayers_micromegas)
   , _firstlayer_maps(0)
   , _firstlayer_intt(_firstlayer_maps + _nlayers_maps)
   , _firstlayer_tpc(_firstlayer_intt + _nlayers_intt)
+  , _firstlayer_micromegas(_firstlayer_tpc + _nlayers_tpc)
 {}
 
 int PHGenFitTrkProp::Setup(PHCompositeNode* topNode)
@@ -719,7 +722,8 @@ int PHGenFitTrkProp::OutputPHGenFitTrack(
   Int_t n_maps = 0;
   Int_t n_intt = 0;
   Int_t n_tpc = 0;
-  
+  Int_t n_micromegas = 0;
+
   for (auto iter = track->begin_cluster_keys(); iter != track->end_cluster_keys(); ++iter)
   {
     TrkrDefs::cluskey cluster_key = *iter;
@@ -736,6 +740,8 @@ int PHGenFitTrkProp::OutputPHGenFitTrack(
       }
     } else if( is_tpc_layer( layer ) ) {
       n_tpc++;
+    } else if( is_micromegas_layer( layer ) ) {
+      n_micromegas++;
     }
   }
   
@@ -749,7 +755,7 @@ int PHGenFitTrkProp::OutputPHGenFitTrack(
   if (Verbosity() > 10)
     {
       cout << "Output propagared track " << track->get_id() << " vertex " << track->get_vertex_id()<< " quality = " << track->get_quality()
-	   << " clusters: mvtx " << n_maps << " intt " << n_intt << " tpc  " << n_tpc 
+	   << " clusters mvtx: " << n_maps << " intt: " << n_intt << " tpc:  " << n_tpc << " micromegas: " << n_micromegas
 	   << endl;
       cout << "px = " << track->get_px() << " py = " << track->get_py()
 	   << " pz = " << track->get_pz() << endl;
@@ -1022,7 +1028,7 @@ int PHGenFitTrkProp::SvtxTrackToPHGenFitTracks(const SvtxTrack* svtxtrack)
   {
     _PHGenFitTracks.push_back(
         MapPHGenFitTrack::value_type(
-            PHGenFitTrkProp::TrackQuality(nhits, chi2, ndf, nhits, 0, 0), track));
+            TrackQuality(nhits, chi2, ndf, 0, nhits, 0, 0), track));
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -1258,14 +1264,14 @@ int PHGenFitTrkProp::TrackPropPatRec(
       if (phi_window < _min_search_win_phi_tpc) phi_window = _min_search_win_phi_tpc;
       if (theta_window > _max_search_win_theta_tpc) theta_window = _max_search_win_theta_tpc;
       if (theta_window < _min_search_win_theta_tpc) theta_window = _min_search_win_theta_tpc;
+    } 
+    else if( is_micromegas_layer( layer ) ) 
+    {
+      if (phi_window > _max_search_win_phi_micromegas) phi_window = _max_search_win_phi_micromegas;
+      if (phi_window < _min_search_win_phi_micromegas) phi_window = _min_search_win_phi_micromegas;
+      if (theta_window > _max_search_win_theta_micromegas) theta_window = _max_search_win_theta_micromegas;
+      if (theta_window < _min_search_win_theta_micromegas) theta_window = _min_search_win_theta_micromegas;
     }
-
-    //FIXME optimize this
-    //		if(layer == _nlayers_maps + _nlayers_intt -1) {
-    //			phi_window = 0.02;
-    //			theta_window = 0.04;
-    //		}
-
 #endif
 
 #ifdef _DEBUG_
@@ -1348,6 +1354,7 @@ int PHGenFitTrkProp::TrackPropPatRec(
         track_iter->first.nhits = tq.nhits + 1;
         track_iter->first.chi2 = tq.chi2 + iter->first;
         track_iter->first.ndf = tq.ndf + 2;
+        track_iter->first.nmicromegas = tq.nmicromegas + (is_micromegas_layer( layer ) ? 1 : 0);
         track_iter->first.ntpc = tq.ntpc + (is_tpc_layer(layer) ? 1 : 0);
         track_iter->first.nintt = tq.nintt + (is_intt_layer(layer) ? 1 : 0);
         track_iter->first.nmaps = tq.nmaps + (is_maps_layer(layer) ? 1 : 0);
@@ -1397,10 +1404,11 @@ int PHGenFitTrkProp::TrackPropPatRec(
 	iter->second->set_vertex_id(ivert);
         _PHGenFitTracks.push_back(
             MapPHGenFitTrack::value_type(
-                PHGenFitTrkProp::TrackQuality(
+                TrackQuality(
                     tq.nhits + 1,
                     tq.chi2 + iter->first,
                     tq.ndf + 2,
+                    tq.nmicromegas + (is_micromegas_layer( layer ) ? 1 : 0),
                     tq.ntpc + (is_tpc_layer(layer) ? 1 : 0),
                     tq.nintt + (is_intt_layer(layer) ? 1 : 0),
                     tq.nmaps + (is_maps_layer(layer) ? 1 : 0)),
@@ -1482,8 +1490,7 @@ PHGenFit::Measurement* PHGenFitTrkProp::TrkrClusterToPHGenFitMeasurement(
       int chip_index = MvtxDefs::getChipId(cluster_id);
       
       double ladder_location[3] = {0.0, 0.0, 0.0};
-      CylinderGeom_Mvtx* geom =
-	dynamic_cast<CylinderGeom_Mvtx*>(_geom_container_maps->GetLayerGeom(layer));
+      auto geom = dynamic_cast<CylinderGeom_Mvtx*>(_geom_container_maps->GetLayerGeom(layer));
       // returns the center of the sensor in world coordinates - used to get the ladder phi location
       geom->find_sensor_center(stave_index, 0,
 			       0, chip_index, ladder_location);
@@ -1493,8 +1500,7 @@ PHGenFit::Measurement* PHGenFitTrkProp::TrkrClusterToPHGenFitMeasurement(
     }
   else if(trkrid == TrkrDefs::inttId)
     {
-      CylinderGeomIntt* geom =
-	dynamic_cast<CylinderGeomIntt*>(_geom_container_intt->GetLayerGeom(layer));
+      auto geom = dynamic_cast<CylinderGeomIntt*>(_geom_container_intt->GetLayerGeom(layer));
       double hit_location[3] = {0.0, 0.0, 0.0};
       geom->find_segment_center(InttDefs::getLadderZId(cluster_id),
 				InttDefs::getLadderPhiId(cluster_id), hit_location);
@@ -1742,17 +1748,26 @@ unsigned int PHGenFitTrkProp::encode_cluster_index(const unsigned int layer,
 
 int PHGenFitTrkProp::InitializeGeometry(PHCompositeNode* topNode)
 {
-  PHG4CylinderCellGeomContainer* cellgeos = findNode::getClass<
-      PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
-  PHG4CylinderGeomContainer* laddergeos = findNode::getClass<
-      PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
-  PHG4CylinderGeomContainer* mapsladdergeos = findNode::getClass<
-      PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
+
+  auto micromegasgeos = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS");
+  auto cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  auto laddergeos = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
+  auto mapsladdergeos = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
 
   map<float, int> radius_layer_map;
 
   _radii_all.assign(_nlayers_all, 0.0);
   _layer_ilayer_map_all.clear();
+
+  // micromegas
+  if (micromegasgeos)
+  {
+    const auto range = micromegasgeos->get_begin_end();
+    for (auto layeriter = range.first; layeriter != range.second; ++layeriter)
+    { radius_layer_map.insert( std::make_pair(layeriter->second->get_radius(), layeriter->second->get_layer())); }
+  }
+
+  // tpc
   if (cellgeos)
   {
     PHG4CylinderCellGeomContainer::ConstRange layerrange =
@@ -1767,6 +1782,7 @@ int PHGenFitTrkProp::InitializeGeometry(PHCompositeNode* topNode)
     }
   }
 
+  // intt
   if (laddergeos)
   {
     PHG4CylinderGeomContainer::ConstRange layerrange =
@@ -1781,6 +1797,7 @@ int PHGenFitTrkProp::InitializeGeometry(PHCompositeNode* topNode)
     }
   }
 
+  // mvtx
   if (mapsladdergeos)
   {
     PHG4CylinderGeomContainer::ConstRange layerrange =
@@ -1802,6 +1819,18 @@ int PHGenFitTrkProp::InitializeGeometry(PHCompositeNode* topNode)
   }
 
   // now we extract the information from the cellgeos first
+  // micromegas
+  if (micromegasgeos)
+  {
+    const auto range = micromegasgeos->get_begin_end();
+    for( auto iter = range.first; iter != range.second; iter++)
+    {
+      auto geo = iter->second;
+      _radii_all[_layer_ilayer_map_all[geo->get_layer()]] = geo->get_radius() + 0.5 * geo->get_thickness();
+    }
+  }
+
+  // tpc
   if (cellgeos)
   {
     PHG4CylinderCellGeomContainer::ConstRange begin_end =
@@ -1816,6 +1845,7 @@ int PHGenFitTrkProp::InitializeGeometry(PHCompositeNode* topNode)
     }
   }
 
+  // intt
   if (laddergeos)
   {
     PHG4CylinderGeomContainer::ConstRange begin_end =
@@ -1830,6 +1860,7 @@ int PHGenFitTrkProp::InitializeGeometry(PHCompositeNode* topNode)
     }
   }
 
+  // mvtx
   if (mapsladdergeos)
   {
     PHG4CylinderGeomContainer::ConstRange begin_end =

--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -1246,10 +1246,11 @@ int PHGenFitTrkProp::TrackPropPatRec(
     }
     else if( is_intt_layer( layer ) )
     {
-      if (phi_window > _max_search_win_phi_intt[layer - _nlayers_maps]) phi_window = _max_search_win_phi_intt[layer - _nlayers_maps];
-      if (phi_window < _min_search_win_phi_intt[layer - _nlayers_maps]) phi_window = _min_search_win_phi_intt[layer - _nlayers_maps];
-      if (theta_window > _max_search_win_theta_intt[layer - _nlayers_maps]) theta_window = _max_search_win_theta_intt[layer - _nlayers_maps];
-      if (theta_window < _min_search_win_theta_intt[layer - _nlayers_maps]) theta_window = _min_search_win_theta_intt[layer - _nlayers_maps];
+      const auto layer_intt = layer - _firstlayer_intt;
+      if (phi_window > _max_search_win_phi_intt[layer_intt]) phi_window = _max_search_win_phi_intt[layer_intt];
+      if (phi_window < _min_search_win_phi_intt[layer_intt]) phi_window = _min_search_win_phi_intt[layer_intt];
+      if (theta_window > _max_search_win_theta_intt[layer_intt]) theta_window = _max_search_win_theta_intt[layer_intt];
+      if (theta_window < _min_search_win_theta_intt[layer_intt]) theta_window = _min_search_win_theta_intt[layer_intt];
     }
     else if( is_tpc_layer( layer ) )
     {

--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -1267,10 +1267,11 @@ int PHGenFitTrkProp::TrackPropPatRec(
     } 
     else if( is_micromegas_layer( layer ) ) 
     {
-      if (phi_window > _max_search_win_phi_micromegas) phi_window = _max_search_win_phi_micromegas;
-      if (phi_window < _min_search_win_phi_micromegas) phi_window = _min_search_win_phi_micromegas;
-      if (theta_window > _max_search_win_theta_micromegas) theta_window = _max_search_win_theta_micromegas;
-      if (theta_window < _min_search_win_theta_micromegas) theta_window = _min_search_win_theta_micromegas;
+      const auto layer_micromegas = layer - _firstlayer_micromegas;
+      if (phi_window > _max_search_win_phi_micromegas[layer_micromegas]) phi_window = _max_search_win_phi_micromegas[layer_micromegas];
+      if (phi_window < _min_search_win_phi_micromegas[layer_micromegas]) phi_window = _min_search_win_phi_micromegas[layer_micromegas];
+      if (theta_window > _max_search_win_theta_micromegas[layer_micromegas]) theta_window = _max_search_win_theta_micromegas[layer_micromegas];
+      if (theta_window < _min_search_win_theta_micromegas[layer_micromegas]) theta_window = _min_search_win_theta_micromegas[layer_micromegas];
     }
 #endif
 

--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -671,7 +671,7 @@ int PHGenFitTrkProp::OutputPHGenFitTrack(
   std::unique_ptr<genfit::MeasuredStateOnPlane> gf_state_vertex_ca = nullptr;
   try
     {
-      gf_state_vertex_ca = std::unique_ptr<genfit::MeasuredStateOnPlane>(gftrk_iter->second->extrapolateToPoint(vertex_position));
+      gf_state_vertex_ca.reset(gftrk_iter->second->extrapolateToPoint(vertex_position));
     }
   catch (...)
     {
@@ -1182,7 +1182,7 @@ int PHGenFitTrkProp::TrackPropPatRec(
     std::unique_ptr<genfit::MeasuredStateOnPlane> state = nullptr;
     try
     {
-      state = std::unique_ptr<genfit::MeasuredStateOnPlane>(track->extrapolateToCylinder(layer_r, TVector3(0, 0, 0),
+      state.reset(track->extrapolateToCylinder(layer_r, TVector3(0, 0, 0),
                                                                                          TVector3(0, 0, 1), extrapolate_base_TP_id, direction));
       //		genfit::MeasuredStateOnPlane *state = track->extrapolateToCylinder(
       //				layer_r, TVector3(0, 0, 0), TVector3(0, 0, 1), 0);

--- a/offline/packages/trackreco/PHGenFitTrkProp.h
+++ b/offline/packages/trackreco/PHGenFitTrkProp.h
@@ -58,7 +58,8 @@ class PHGenFitTrkProp : public PHTrackPropagating
       const std::string& name = "PHGenFitTrkProp",
       unsigned int nlayers_maps = 3,
       unsigned int nlayers_intt = 8,
-      unsigned int nlayers_tpc = 60);
+      unsigned int nlayers_tpc = 60,
+      unsigned int nlayers_micromegas = 0);
 
  protected:
   int Setup(PHCompositeNode* topNode) override;
@@ -81,28 +82,26 @@ class PHGenFitTrkProp : public PHTrackPropagating
 
   struct TrackQuality
   {
-    int nhits;
-    float chi2;
-    int ndf;
-
-    int ntpc;
-    int nintt;
-    int nmaps;
+    int nhits = 0;
+    float chi2 = 0;
+    int ndf = 0;
+    int nmicromegas = 0;
+    int ntpc = 0;
+    int nintt = 0;
+    int nmaps = 0;
 
     TrackQuality(int nhits_, float chi2_, int ndf_)
       : nhits(nhits_)
       , chi2(chi2_)
       , ndf(ndf_)
-      , ntpc(0)
-      , nintt(0)
-      , nmaps(0)
     {
     }
 
-    TrackQuality(int nhits_, float chi2_, int ndf_, int ntpc_, int nintt_, int nmaps_)
+    TrackQuality(int nhits_, float chi2_, int ndf_, int nmicromegas_, int ntpc_, int nintt_, int nmaps_)
       : nhits(nhits_)
       , chi2(chi2_)
       , ndf(ndf_)
+      , nmicromegas(nmicromegas_)
       , ntpc(ntpc_)
       , nintt(nintt_)
       , nmaps(nmaps_)
@@ -122,7 +121,7 @@ class PHGenFitTrkProp : public PHTrackPropagating
       os
           << tq.nhits << ", "
           << tq.chi2 << ", " << tq.ndf << ", "
-          << tq.ntpc << ", " << tq.nintt << ", " << tq.nmaps
+          << tq.nmicromegas << ", " << tq.ntpc << ", " << tq.nintt << ", " << tq.nmaps
           << std::endl;
 
       return os;
@@ -296,6 +295,25 @@ class PHGenFitTrkProp : public PHTrackPropagating
   {
     _max_search_win_theta_tpc = maxSearchWinZ;
   }
+  float get_max_search_win_phi_micromegas() const
+  {
+    return _max_search_win_phi_micromegas;
+  }
+
+  void set_max_search_win_phi_micromegas(float maxSearchWinPhi)
+  {
+    _max_search_win_phi_micromegas = maxSearchWinPhi;
+  }
+
+  float get_max_search_win_theta_micromegas() const
+  {
+    return _max_search_win_theta_micromegas;
+  }
+
+  void set_max_search_win_theta_micromegas(float maxSearchWinZ)
+  {
+    _max_search_win_theta_micromegas = maxSearchWinZ;
+  }
 
   float get_blowup_factor() const
   {
@@ -377,6 +395,16 @@ class PHGenFitTrkProp : public PHTrackPropagating
     _min_search_win_phi_tpc = minSearchWinPhiTpc;
   }
 
+  float get_min_search_win_phi_micromegas() const
+  {
+    return _min_search_win_phi_micromegas;
+  }
+
+  void set_min_search_win_phi_micromegas(float minSearchWinPhimicromegas)
+  {
+    _min_search_win_phi_micromegas = minSearchWinPhimicromegas;
+  }
+
   float get_min_search_win_theta_intt(int inttlayer) const
   {
     return _min_search_win_theta_intt[inttlayer];
@@ -407,10 +435,14 @@ class PHGenFitTrkProp : public PHTrackPropagating
     _min_search_win_theta_tpc = minSearchWinThetaTpc;
   }
 
-  void set_vertex_error(const float a)
+  float get_min_search_win_theta_micromegas() const
   {
-    _vertex_error.clear();
-    // _vertex_error.assign(3, a);
+    return _min_search_win_theta_micromegas;
+  }
+
+  void set_min_search_win_theta_micromegas(float minSearchWinThetamicromegas)
+  {
+    _min_search_win_theta_micromegas = minSearchWinThetamicromegas;
   }
 
   int get_primary_pid_guess() const
@@ -435,6 +467,9 @@ class PHGenFitTrkProp : public PHTrackPropagating
 
   inline bool is_tpc_layer( unsigned int layer ) const
   { return layer >= _firstlayer_tpc && layer < _firstlayer_tpc + _nlayers_tpc; }
+
+  inline bool is_micromegas_layer( unsigned int layer ) const
+  { return layer >= _firstlayer_micromegas && layer < _firstlayer_micromegas + _nlayers_micromegas; }
   //@}
 
   //--------------
@@ -573,15 +608,23 @@ class PHGenFitTrkProp : public PHTrackPropagating
   unsigned int _nlayers_maps = 3;
   unsigned int _nlayers_intt = 4;
   unsigned int _nlayers_tpc = 48;
+  unsigned int _nlayers_micromegas = 0;
 
   int _nlayers_all = 55;
 
   unsigned int _firstlayer_maps = 0;
   unsigned int _firstlayer_intt = 3;
   unsigned int _firstlayer_tpc = 7;
+  unsigned int _firstlayer_micromegas = 55;
 
   std::map<int, unsigned int> _layer_ilayer_map_all;
   std::vector<float> _radii_all;
+
+  // TODO: might need to use layer dependent windows because micromegas are 1D measurements
+  float _max_search_win_phi_micromegas = 0.004;
+  float _min_search_win_phi_micromegas = 0;
+  float _max_search_win_theta_micromegas = 0.004;
+  float _min_search_win_theta_micromegas = 0;
 
   float _max_search_win_phi_tpc = 0.004;
   float _min_search_win_phi_tpc = 0;

--- a/offline/packages/trackreco/PHGenFitTrkProp.h
+++ b/offline/packages/trackreco/PHGenFitTrkProp.h
@@ -621,10 +621,10 @@ class PHGenFitTrkProp : public PHTrackPropagating
   std::vector<float> _radii_all;
 
   // TODO: might need to use layer dependent windows because micromegas are 1D measurements
-  std::array<float,2> _max_search_win_phi_micromegas = {{ 0.004, 0.004}};
-  std::array<float,2> _min_search_win_phi_micromegas = {{ 0, 0 }};
-  std::array<float,2> _max_search_win_theta_micromegas = {{ 0.004, 0.004}};
-  std::array<float,2> _min_search_win_theta_micromegas = {{ 0, 0}};
+  std::array<float,2> _max_search_win_phi_micromegas = {{ 0.004, 0.62}};
+  std::array<float,2> _min_search_win_phi_micromegas = {{ 0, 0.31 }};
+  std::array<float,2> _max_search_win_theta_micromegas = {{ 1.24, 0.004}};
+  std::array<float,2> _min_search_win_theta_micromegas = {{ 0.62, 0}};
 
   float _max_search_win_phi_tpc = 0.004;
   float _min_search_win_phi_tpc = 0;

--- a/offline/packages/trackreco/PHGenFitTrkProp.h
+++ b/offline/packages/trackreco/PHGenFitTrkProp.h
@@ -424,6 +424,19 @@ class PHGenFitTrkProp : public PHTrackPropagating
   }
 
  private:
+
+  //*@name utility methods
+  //@{
+  inline bool is_maps_layer( unsigned int layer ) const
+  { return layer >= _firstlayer_maps && layer < _firstlayer_maps + _nlayers_maps; }
+
+  inline bool is_intt_layer( unsigned int layer ) const
+  { return layer >= _firstlayer_intt && layer < _firstlayer_intt + _nlayers_intt; }
+
+  inline bool is_tpc_layer( unsigned int layer ) const
+  { return layer >= _firstlayer_tpc && layer < _firstlayer_tpc + _nlayers_tpc; }
+  //@}
+
   //--------------
   // InitRun Calls
   //--------------
@@ -529,11 +542,6 @@ class PHGenFitTrkProp : public PHTrackPropagating
   // node pointers
   BbcVertexMap* _bbc_vertexes = nullptr;
 
-  //nodes to get norm vector
-  //SvtxHitMap* _svtxhitsmap;
-
-  int* _hit_used_map = nullptr;
-  int _hit_used_map_size = 0;
   std::multimap<TrkrDefs::cluskey, unsigned int> _gftrk_hitkey_map;
 
   PHG4CylinderGeomContainer* _geom_container_intt = nullptr;
@@ -567,6 +575,10 @@ class PHGenFitTrkProp : public PHTrackPropagating
   unsigned int _nlayers_tpc = 48;
 
   int _nlayers_all = 55;
+
+  unsigned int _firstlayer_maps = 0;
+  unsigned int _firstlayer_intt = 3;
+  unsigned int _firstlayer_tpc = 7;
 
   std::map<int, unsigned int> _layer_ilayer_map_all;
   std::vector<float> _radii_all;

--- a/offline/packages/trackreco/PHGenFitTrkProp.h
+++ b/offline/packages/trackreco/PHGenFitTrkProp.h
@@ -588,10 +588,10 @@ class PHGenFitTrkProp : public PHTrackPropagating
   float _max_search_win_theta_tpc = 0.004;
   float _min_search_win_theta_tpc = 0;
 
-  std::array<float,8> _max_search_win_phi_intt = {{ 0.2, 0.2, 0.005, 0.005, 0.005, 0.005, 0.005, 0.005 }};
-  std::array<float,8> _min_search_win_phi_intt = {{ 0.2, 0.2, 0, 0, 0, 0, 0, 0 }};
-  std::array<float,8> _max_search_win_theta_intt = {{ 0.01, 0.01, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2 }};
-  std::array<float,8> _min_search_win_theta_intt = {{ 0, 0, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2 }};
+  std::array<float,4> _max_search_win_phi_intt = {{ 0.2, 0.2, 0.005, 0.005 }};
+  std::array<float,4> _min_search_win_phi_intt = {{ 0.2, 0.2, 0, 0 }};
+  std::array<float,4> _max_search_win_theta_intt = {{ 0.01, 0.01, 0.2, 0.2 }};
+  std::array<float,4> _min_search_win_theta_intt = {{ 0, 0, 0.2, 0.2 }};
 
   float _max_search_win_phi_maps = 0.005;
   float _min_search_win_phi_maps = 0;

--- a/offline/packages/trackreco/PHGenFitTrkProp.h
+++ b/offline/packages/trackreco/PHGenFitTrkProp.h
@@ -295,24 +295,24 @@ class PHGenFitTrkProp : public PHTrackPropagating
   {
     _max_search_win_theta_tpc = maxSearchWinZ;
   }
-  float get_max_search_win_phi_micromegas() const
+  float get_max_search_win_phi_micromegas(int layer) const
   {
-    return _max_search_win_phi_micromegas;
+    return _max_search_win_phi_micromegas[layer];
   }
 
-  void set_max_search_win_phi_micromegas(float maxSearchWinPhi)
+  void set_max_search_win_phi_micromegas(int layer, float maxSearchWinPhi)
   {
-    _max_search_win_phi_micromegas = maxSearchWinPhi;
+    _max_search_win_phi_micromegas[layer] = maxSearchWinPhi;
   }
 
-  float get_max_search_win_theta_micromegas() const
+  float get_max_search_win_theta_micromegas(int layer) const
   {
-    return _max_search_win_theta_micromegas;
+    return _max_search_win_theta_micromegas[layer];
   }
 
-  void set_max_search_win_theta_micromegas(float maxSearchWinZ)
+  void set_max_search_win_theta_micromegas(int layer, float maxSearchWinZ)
   {
-    _max_search_win_theta_micromegas = maxSearchWinZ;
+    _max_search_win_theta_micromegas[layer] = maxSearchWinZ;
   }
 
   float get_blowup_factor() const
@@ -395,14 +395,14 @@ class PHGenFitTrkProp : public PHTrackPropagating
     _min_search_win_phi_tpc = minSearchWinPhiTpc;
   }
 
-  float get_min_search_win_phi_micromegas() const
+  float get_min_search_win_phi_micromegas(int layer) const
   {
-    return _min_search_win_phi_micromegas;
+    return _min_search_win_phi_micromegas[layer];
   }
 
-  void set_min_search_win_phi_micromegas(float minSearchWinPhimicromegas)
+  void set_min_search_win_phi_micromegas(int layer, float minSearchWinPhimicromegas)
   {
-    _min_search_win_phi_micromegas = minSearchWinPhimicromegas;
+    _min_search_win_phi_micromegas[layer] = minSearchWinPhimicromegas;
   }
 
   float get_min_search_win_theta_intt(int inttlayer) const
@@ -435,14 +435,14 @@ class PHGenFitTrkProp : public PHTrackPropagating
     _min_search_win_theta_tpc = minSearchWinThetaTpc;
   }
 
-  float get_min_search_win_theta_micromegas() const
+  float get_min_search_win_theta_micromegas(int layer) const
   {
-    return _min_search_win_theta_micromegas;
+    return _min_search_win_theta_micromegas[layer];
   }
 
-  void set_min_search_win_theta_micromegas(float minSearchWinThetamicromegas)
+  void set_min_search_win_theta_micromegas(int layer, float minSearchWinThetamicromegas)
   {
-    _min_search_win_theta_micromegas = minSearchWinThetamicromegas;
+    _min_search_win_theta_micromegas[layer] = minSearchWinThetamicromegas;
   }
 
   int get_primary_pid_guess() const
@@ -621,10 +621,10 @@ class PHGenFitTrkProp : public PHTrackPropagating
   std::vector<float> _radii_all;
 
   // TODO: might need to use layer dependent windows because micromegas are 1D measurements
-  float _max_search_win_phi_micromegas = 0.004;
-  float _min_search_win_phi_micromegas = 0;
-  float _max_search_win_theta_micromegas = 0.004;
-  float _min_search_win_theta_micromegas = 0;
+  std::array<float,2> _max_search_win_phi_micromegas = {{ 0.004, 0.004}};
+  std::array<float,2> _min_search_win_phi_micromegas = {{ 0, 0 }};
+  std::array<float,2> _max_search_win_theta_micromegas = {{ 0.004, 0.004}};
+  std::array<float,2> _min_search_win_theta_micromegas = {{ 0, 0}};
 
   float _max_search_win_phi_tpc = 0.004;
   float _min_search_win_phi_tpc = 0;

--- a/offline/packages/trackreco/PHGenFitTrkProp.h
+++ b/offline/packages/trackreco/PHGenFitTrkProp.h
@@ -14,20 +14,14 @@
 
 #include <trackbase/TrkrDefs.h>               // for cluskey
 
-#if !defined(__CINT__) || defined(__CLING__)
 #include <Eigen/Core>                         // for Matrix
 // needed, it crashes on Ubuntu using singularity with local cvmfs install
 // shared pointer later on uses this, forward declaration does not cut it
 #include <phgenfit/Track.h> 
 #include <gsl/gsl_rng.h>
-#else
-namespace PHGenFit
-{
-  class Track;
-} /* namespace PHGenFit */
-#endif
 
 // standard includes
+#include <array>
 #include <list>
 #include <map>
 #include <memory>
@@ -66,14 +60,12 @@ class PHGenFitTrkProp : public PHTrackPropagating
       unsigned int nlayers_intt = 8,
       unsigned int nlayers_tpc = 60);
 
-  virtual ~PHGenFitTrkProp();
-
  protected:
-  int Setup(PHCompositeNode* topNode);
+  int Setup(PHCompositeNode* topNode) override;
 
-  int Process();
+  int Process() override;
 
-  int End();
+  int End() override;
 
  private:
   /// fetch node pointers
@@ -137,9 +129,7 @@ class PHGenFitTrkProp : public PHTrackPropagating
     }
   };
 
-#if !defined(__CINT__) || defined(__CLING__)
   typedef std::list<std::pair<TrackQuality, std::shared_ptr<PHGenFit::Track> > > MapPHGenFitTrack;
-#endif
 
   float get_search_win_phi() const
   {
@@ -433,8 +423,6 @@ class PHGenFitTrkProp : public PHTrackPropagating
     _primary_pid_guess = primaryPidGuess;
   }
 
-#if !defined(__CINT__) || defined(__CLING__)
-
  private:
   //--------------
   // InitRun Calls
@@ -519,120 +507,112 @@ class PHGenFitTrkProp : public PHTrackPropagating
   /// translate the clusters, tracks, and vertex from one origin to another
   void shift_coordinate_system(double dx, double dy, double dz);
 
-  int _event;
-  PHTimer* _t_seeds_cleanup;
-  PHTimer* _t_translate_to_PHGenFitTrack;
-  PHTimer* _t_translate1;
-  PHTimer* _t_translate2;
-  PHTimer* _t_translate3;
-  PHTimer* _t_kalman_pat_rec;
-  PHTimer* _t_search_clusters;
-  PHTimer* _t_search_clusters_encoding;
-  PHTimer* _t_search_clusters_map_iter;
-  PHTimer* _t_track_propagation;
-  PHTimer* _t_full_fitting;
-  PHTimer* _t_output_io;
-
+  int _event = 0;
+  PHTimer* _t_seeds_cleanup = nullptr;
+  PHTimer* _t_translate_to_PHGenFitTrack = nullptr;
+  PHTimer* _t_translate1 = nullptr;
+  PHTimer* _t_translate2 = nullptr;
+  PHTimer* _t_translate3 = nullptr;
+  PHTimer* _t_kalman_pat_rec = nullptr;
+  PHTimer* _t_search_clusters = nullptr;
+  PHTimer* _t_search_clusters_encoding = nullptr;
+  PHTimer* _t_search_clusters_map_iter = nullptr;
+  PHTimer* _t_track_propagation = nullptr;
+  PHTimer* _t_full_fitting = nullptr;
+  PHTimer* _t_output_io = nullptr;
+  
   // object storage
 
   std::vector<std::vector<float>> _vertex;        ///< working array for collision vertex list
   std::vector<std::vector<float>> _vertex_error;  ///< sqrt(cov)
-  
-  //  std::vector<float> _vertex;        ///< working array for collision vertex
-  // std::vector<float> _vertex_error;  ///< sqrt(cov)
-  
+    
   // node pointers
-  BbcVertexMap* _bbc_vertexes;
+  BbcVertexMap* _bbc_vertexes = nullptr;
 
   //nodes to get norm vector
   //SvtxHitMap* _svtxhitsmap;
 
-  int* _hit_used_map;
-  int _hit_used_map_size;
+  int* _hit_used_map = nullptr;
+  int _hit_used_map_size = 0;
   std::multimap<TrkrDefs::cluskey, unsigned int> _gftrk_hitkey_map;
-  // PHG4CellContainer* _cells_svtx;
-  // PHG4CellContainer* _cells_intt;
-  //PHG4CellContainer* _cells_maps;
 
-  PHG4CylinderGeomContainer* _geom_container_intt;
-  PHG4CylinderGeomContainer* _geom_container_maps;
+  PHG4CylinderGeomContainer* _geom_container_intt = nullptr;
+  PHG4CylinderGeomContainer* _geom_container_maps = nullptr;
 
-  bool _analyzing_mode;
-  TFile* _analyzing_file;
-  TNtuple* _analyzing_ntuple;
+  bool _analyzing_mode = false;
+  TFile* _analyzing_file = nullptr;
+  TNtuple* _analyzing_ntuple = nullptr;
 
   //! Cleanup Seeds
-  float _max_merging_dphi;
-  float _max_merging_deta;
-  float _max_merging_dr;
-  float _max_merging_dz;
+  float _max_merging_dphi = 0.1;
+  float _max_merging_deta = 0.1;
+  float _max_merging_dr = 0.1;
+  float _max_merging_dz = 0.1;
 
   //! if two seeds have common hits more than this number, merge them
-  unsigned int _max_share_hits;
+  unsigned int _max_share_hits = 3;
 
-  PHGenFit::Fitter* _fitter;
+  std::unique_ptr<PHGenFit::Fitter> _fitter;
 
   //! KalmanFitterRefTrack, KalmanFitter, DafSimple, DafRef
-  //PHGenFit::Fitter::FitterType _track_fitting_alg_name;
-  std::string _track_fitting_alg_name;
+  std::string _track_fitting_alg_name = "DafRef";
 
-  int _primary_pid_guess;
-  double _cut_min_pT;
+  int _primary_pid_guess = 211;
+  double _cut_min_pT = 0.2;
 
-  bool _do_evt_display;
+  bool _do_evt_display = false;
 
-  unsigned int _nlayers_maps;
-  unsigned int _nlayers_intt;
-  unsigned int _nlayers_tpc;
+  unsigned int _nlayers_maps = 3;
+  unsigned int _nlayers_intt = 4;
+  unsigned int _nlayers_tpc = 48;
 
-  int _nlayers_all;
+  int _nlayers_all = 55;
 
   std::map<int, unsigned int> _layer_ilayer_map_all;
   std::vector<float> _radii_all;
 
-  float _max_search_win_phi_tpc;
-  float _min_search_win_phi_tpc;
-  float _max_search_win_theta_tpc;
-  float _min_search_win_theta_tpc;
+  float _max_search_win_phi_tpc = 0.004;
+  float _min_search_win_phi_tpc = 0;
+  float _max_search_win_theta_tpc = 0.004;
+  float _min_search_win_theta_tpc = 0;
 
-  float _max_search_win_phi_intt[8];
-  float _min_search_win_phi_intt[8];
-  float _max_search_win_theta_intt[8];
-  float _min_search_win_theta_intt[8];
+  std::array<float,8> _max_search_win_phi_intt = {{ 0.2, 0.2, 0.005, 0.005, 0.005, 0.005, 0.005, 0.005 }};
+  std::array<float,8> _min_search_win_phi_intt = {{ 0.2, 0.2, 0, 0, 0, 0, 0, 0 }};
+  std::array<float,8> _max_search_win_theta_intt = {{ 0.01, 0.01, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2 }};
+  std::array<float,8> _min_search_win_theta_intt = {{ 0, 0, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2 }};
 
-  float _max_search_win_phi_maps;
-  float _min_search_win_phi_maps;
-  float _max_search_win_theta_maps;
-  float _min_search_win_theta_maps;
+  float _max_search_win_phi_maps = 0.005;
+  float _min_search_win_phi_maps = 0;
+  float _max_search_win_theta_maps = 0.04;
+  float _min_search_win_theta_maps = 0;
 
-  float _search_win_phi;
-  float _search_win_theta;
+  float _search_win_phi = 20;
+  float _search_win_theta = 20;
   std::map<int, float> _search_wins_phi;
   std::map<int, float> _search_wins_theta;
 
   std::vector<std::multimap<unsigned int, TrkrDefs::cluskey>> _layer_thetaID_phiID_clusterID;
 
-  float _half_max_theta;
-  float _half_max_phi;
-  float _layer_thetaID_phiID_clusterID_phiSize;
-  float _layer_thetaID_phiID_clusterID_zSize;
+  float _half_max_theta = M_PI/2;
+  float _half_max_phi = M_PI;
+  float _layer_thetaID_phiID_clusterID_phiSize = 0.12/30;
+  float _layer_thetaID_phiID_clusterID_zSize = 0.17/30;
 
   MapPHGenFitTrack _PHGenFitTracks;
   //! +1: inside out; -1: outside in
-  int _init_direction;
-  float _blowup_factor;
+  int _init_direction = -1;
+  float _blowup_factor = 1;
 
-  unsigned int _max_consecutive_missing_layer;
-  float _max_incr_chi2;
+  unsigned int _max_consecutive_missing_layer = 20;
+  float _max_incr_chi2 = 20;
   std::map<int, float> _max_incr_chi2s;
 
-  float _max_splitting_chi2;
+  float _max_splitting_chi2 = 20;
 
-  unsigned int _min_good_track_hits;
+  unsigned int _min_good_track_hits = 30;
 
-  PHCompositeNode* _topNode;
-  int _ntrack;
-#endif  // __CINT__
+  PHCompositeNode* _topNode = nullptr;
+  int _ntrack = 0;
 };
 
 #endif

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -93,14 +93,32 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
       {
         // extract the g4 hit key here and add the hits to the set
         PHG4HitDefs::keytype g4hitkey = htiter->second.second;
-        PHG4Hit* phg4hit;
-        if (trkrid == TrkrDefs::tpcId)
-          phg4hit = phg4hits_tpc->findHit(g4hitkey);
-        else if (trkrid == TrkrDefs::inttId)
-          phg4hit = phg4hits_intt->findHit(g4hitkey);
-        else
-          phg4hit = phg4hits_mvtx->findHit(g4hitkey);
+        PHG4Hit* phg4hit = nullptr;
+        switch( trkrid )
+        {
+          case TrkrDefs::mvtxId:
+          if (phg4hits_mvtx) phg4hit = phg4hits_mvtx->findHit( g4hitkey );
+          break;
 
+          case TrkrDefs::inttId:
+          if (phg4hits_intt) phg4hit = phg4hits_intt->findHit( g4hitkey );
+          break;
+
+          case TrkrDefs::tpcId:
+          if (phg4hits_tpc) phg4hit = phg4hits_tpc->findHit( g4hitkey );
+          break;
+
+          case TrkrDefs::micromegasId:
+          if (phg4hits_micromegas) phg4hit = phg4hits_micromegas->findHit( g4hitkey );
+          break;
+        }
+   
+        if( !phg4hit )
+        {
+          std::cout<<PHWHERE<<" unable to find g4hit from key " << g4hitkey << std::endl;
+          continue;
+        }
+     
         int particle_id = phg4hit->get_trkid();
 
         // monentum cut-off
@@ -287,22 +305,19 @@ int PHTruthTrackSeeding::GetNodes(PHCompositeNode* topNode)
     exit(1);
   }
 
-  phg4hits_tpc = findNode::getClass<PHG4HitContainer>(
-      topNode, "G4HIT_TPC");
-
-  phg4hits_intt = findNode::getClass<PHG4HitContainer>(
-      topNode, "G4HIT_INTT");
-
-  phg4hits_mvtx = findNode::getClass<PHG4HitContainer>(
-      topNode, "G4HIT_MVTX");
-
-  if (!phg4hits_tpc and phg4hits_intt and !phg4hits_mvtx)
+  using nodePair = std::pair<std::string, PHG4HitContainer*&>;
+  std::initializer_list<nodePair> nodes =
   {
-    if (Verbosity() >= 0)
-    {
-      cerr << PHWHERE << " ERROR: No PHG4HitContainer found!" << endl;
-    }
-    return Fun4AllReturnCodes::ABORTRUN;
+    { "G4HIT_TPC", phg4hits_tpc },
+    { "G4HIT_INTT", phg4hits_intt },
+    { "G4HIT_MVTX", phg4hits_mvtx },
+    { "G4HIT_MICROMEGAS", phg4hits_micromegas }
+  };
+  
+  for( auto&& node: nodes )
+  {
+    if( !( node.second = findNode::getClass<PHG4HitContainer>( topNode, node.first ) ) )
+    { std::cerr << PHWHERE << " PHG4HitContainer " << node.first << " not found" << std::endl; }
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -41,18 +41,7 @@ using namespace std;
 
 PHTruthTrackSeeding::PHTruthTrackSeeding(const std::string& name)
   : PHTrackSeeding(name)
-  , _g4truth_container(nullptr)
-  , phg4hits_tpc(nullptr)
-  , phg4hits_intt(nullptr)
-  , phg4hits_mvtx(nullptr)
-  , hittruthassoc(nullptr)
-  , clusterhitassoc(nullptr)
-  , _min_clusters_per_track(3)
-  , _min_layer(0)
-  , _max_layer(10000)
-  , _min_momentum(50e-3)  // default to p > 50 MeV
-{
-}
+{}
 
 int PHTruthTrackSeeding::Setup(PHCompositeNode* topNode)
 {

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -30,7 +30,6 @@ class PHTruthTrackSeeding : public PHTrackSeeding
 {
  public:
   PHTruthTrackSeeding(const std::string& name = "PHTruthTrackSeeding");
-  virtual ~PHTruthTrackSeeding() {}
 
   unsigned int get_min_clusters_per_track() const
   {
@@ -65,36 +64,31 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   }
 
  protected:
-  int Setup(PHCompositeNode* topNode);
+  int Setup(PHCompositeNode* topNode) override;
 
-  int Process(PHCompositeNode* topNode);
+  int Process(PHCompositeNode* topNode) override;
 
-  int End();
+  int End() override;
 
  private:
   /// fetch node pointers
   int GetNodes(PHCompositeNode* topNode);
 
-  PHG4TruthInfoContainer* _g4truth_container;
+  PHG4TruthInfoContainer* _g4truth_container = nullptr;
 
-  PHG4HitContainer* phg4hits_tpc;
-  PHG4HitContainer* phg4hits_intt;
-  PHG4HitContainer* phg4hits_mvtx;
+  PHG4HitContainer* phg4hits_tpc = nullptr;
+  PHG4HitContainer* phg4hits_intt = nullptr;
+  PHG4HitContainer* phg4hits_mvtx = nullptr;
 
-  TrkrHitTruthAssoc* hittruthassoc;
-  TrkrClusterHitAssoc* clusterhitassoc;
+  TrkrHitTruthAssoc* hittruthassoc = nullptr;
+  TrkrClusterHitAssoc* clusterhitassoc = nullptr;
 
-  //SvtxHitMap* hitsmap;
-  //PHG4CellContainer* cells_svtx;
-  //PHG4CellContainer* cells_intt;
-  //PHG4CellContainer* cells_maps;
+  unsigned int _min_clusters_per_track = 3;
+  unsigned int _min_layer = 0;
+  unsigned int _max_layer = 10000;
 
-  unsigned int _min_clusters_per_track;
-  unsigned int _min_layer;
-  unsigned int _max_layer;
-
-  //! minimal truth momentum cut
-  double _min_momentum;
+  //! minimal truth momentum cut (GeV)
+  double _min_momentum = 50e-3;
 };
 
 #endif

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -79,6 +79,7 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   PHG4HitContainer* phg4hits_tpc = nullptr;
   PHG4HitContainer* phg4hits_intt = nullptr;
   PHG4HitContainer* phg4hits_mvtx = nullptr;
+  PHG4HitContainer* phg4hits_micromegas = nullptr;
 
   TrkrHitTruthAssoc* hittruthassoc = nullptr;
   TrkrClusterHitAssoc* clusterhitassoc = nullptr;


### PR DESCRIPTION
This PR includes the micromegas detector in the GenFit track finding (PHGenFitTrkProp) and truth track finding (PHTruthTrackSeeding).
Some code cleanup happened while doing so such as: 
- moving member default initialization to header file rather than constructor (this is less error prone, makes sure there is no issue with member declaration order, avoid duplication in case there are multiple constructors, etc.) 
- adding convenient functions "is_layer_intt", "is_layer_mvtx" etc. instead of duplicating the math multiple times
- use std::unique_ptr whenever possible in order not to have to deal with deletion. 
- use bound_check std::array instead of c-style arrays
By default the number of micromegas layers is zero, and the code behaves identically as before
