### PR TITLE
Fix mvtx source link bug

### DIFF
--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -550,9 +550,6 @@ Surface PHActsSourceLinks::getMvtxLocalCoords(Acts::Vector2D &local2D,
 			 local2D);
   
   Acts::Vector3D normal = surface->normal(m_actsGeometry->getGeoContext());
-  // we use our calculation rather than acts for now since there is a discrepancy
-  local2D(0) = local[0];
-  local2D(1) = local[1];
 
   if (Verbosity() > 0)
   {


### PR DESCRIPTION
@adfrawley noticed that we were still using our local calculation for the MVTX source links. The geometry has since been fixed, so we just use the Acts coordinate transformation (which yields the same result as ours, modulo units which were not taken into account here).