### PR TITLE
Upstream/master tpc digitizer

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -43,13 +43,13 @@ using namespace std;
 namespace
 {
 
-  //______________________________________________________________________
-  //! square utility function
-  template<class T> inline constexpr T square( const T& x ) { return x*x; }
+  //! convenient square function
+  template<class T> 
+    inline constexpr T square( const T& x ) { return x*x; }
 
-  //______________________________________________________________________
   //! return normalized gaussian centered on zero and of width sigma
-  template<class T> inline T gaus( const T& x, const T& sigma )
+  template<class T> 
+    inline T gaus( const T& x, const T& sigma )
   { return std::exp( -square(x/sigma)/2 )/(sigma*std::sqrt(2*M_PI)); }
 
 }
@@ -621,7 +621,6 @@ void PHG4TpcPadPlaneReadout::populate_zigzag_phibins(const unsigned int layernum
 
   // use analytic integral
   double sum = 0;
-  static const double sqrt2 = std::sqrt(2.);
   for( int ipad = 0; ipad <= npads; ipad++ )
   {
     const double pitch = pad_parameters[ipad][0];
@@ -634,8 +633,8 @@ void PHG4TpcPadPlaneReadout::populate_zigzag_phibins(const unsigned int layernum
     convoluted with a strip response function, which is triangular from -pitch to +pitch, with a maximum of 1. at stript center
     */
     const double fraction =
-      (pitch - x_loc)*(std::erf(x_loc/(sqrt2*sigma)) - std::erf((x_loc-pitch)/(sqrt2*sigma)))/(pitch*2)
-      + (pitch + x_loc)*(std::erf((x_loc+pitch)/(sqrt2*sigma)) - std::erf(x_loc/(sqrt2*sigma)))/(pitch*2)
+      (pitch - x_loc)*(std::erf(x_loc/(M_SQRT2*sigma)) - std::erf((x_loc-pitch)/(M_SQRT2*sigma)))/(pitch*2)
+      + (pitch + x_loc)*(std::erf((x_loc+pitch)/(M_SQRT2*sigma)) - std::erf(x_loc/(M_SQRT2*sigma)))/(pitch*2)
       + (gaus(x_loc-pitch, sigma) - gaus(x_loc, sigma))*square(sigma)/pitch
       + (gaus(x_loc+pitch, sigma) - gaus(x_loc, sigma))*square(sigma)/pitch;
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -620,7 +620,6 @@ void PHG4TpcPadPlaneReadout::populate_zigzag_phibins(const unsigned int layernum
   std::array<double,10> overlap = {{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }};
 
   // use analytic integral
-  double sum = 0;
   for( int ipad = 0; ipad <= npads; ipad++ )
   {
     const double pitch = pad_parameters[ipad][0];
@@ -632,17 +631,11 @@ void PHG4TpcPadPlaneReadout::populate_zigzag_phibins(const unsigned int layernum
     this corresponds to integrating the charge distribution Gaussian function (centered on rphi and of width cloud_sig_rp), 
     convoluted with a strip response function, which is triangular from -pitch to +pitch, with a maximum of 1. at stript center
     */
-    const double fraction =
+    overlap[ipad] =
       (pitch - x_loc)*(std::erf(x_loc/(M_SQRT2*sigma)) - std::erf((x_loc-pitch)/(M_SQRT2*sigma)))/(pitch*2)
       + (pitch + x_loc)*(std::erf((x_loc+pitch)/(M_SQRT2*sigma)) - std::erf(x_loc/(M_SQRT2*sigma)))/(pitch*2)
       + (gaus(x_loc-pitch, sigma) - gaus(x_loc, sigma))*square(sigma)/pitch
       + (gaus(x_loc+pitch, sigma) - gaus(x_loc, sigma))*square(sigma)/pitch;
-
-    sum += fraction;
-    
-    // multiplicative factors are here for consistency with previous implementation
-    overlap[ipad] = fraction*pitch/sigma;
-
   }
 
   // now we have the overlap for each pad

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -44,7 +44,13 @@ namespace
 {
 
   //______________________________________________________________________
-  template<class T> constexpr T square( const T& x ) { return x*x; }
+  //! square utility function
+  template<class T> inline constexpr T square( const T& x ) { return x*x; }
+
+  //______________________________________________________________________
+  //! return normalized gaussian centered on zero and of width sigma
+  template<class T> inline T gaus( const T& x, const T& sigma )
+  { return std::exp( -square(x/sigma)/2 )/(sigma*std::sqrt(2*M_PI)); }
 
 }
 
@@ -616,13 +622,17 @@ void PHG4TpcPadPlaneReadout::populate_zigzag_phibins(const unsigned int layernum
   // use analytic integral
   double sum = 0;
   static const double sqrt2 = std::sqrt(2.);
-  auto gaus = []( const double x, const double sigma ) { return std::exp( -square(x/sigma)/2 )/(sigma*std::sqrt(2*M_PI)); };
   for( int ipad = 0; ipad <= npads; ipad++ )
   {
     const double pitch = pad_parameters[ipad][0];
     const double x_loc = pad_parameters[ipad][1] - rphi;
     const double sigma  = cloud_sig_rp;
 
+    // calculate fraction of the total charge on this strip
+    /* 
+    this corresponds to integrating the charge distribution Gaussian function (centered on rphi and of width cloud_sig_rp), 
+    convoluted with a strip response function, which is triangular from -pitch to +pitch, with a maximum of 1. at stript center
+    */
     const double fraction =
       (pitch - x_loc)*(std::erf(x_loc/(sqrt2*sigma)) - std::erf((x_loc-pitch)/(sqrt2*sigma)))/(pitch*2)
       + (pitch + x_loc)*(std::erf((x_loc+pitch)/(sqrt2*sigma)) - std::erf(x_loc/(sqrt2*sigma)))/(pitch*2)

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -48,7 +48,7 @@ namespace
 
   //______________________________________________________________________
   double get_pad_response( double position, const std::array<double,2>& par )
-  { return std::get<0>(par)-std::abs(position - std::get<1>(par)); }
+  { return par[0]-std::abs(position - par[1]); }
 
 }
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
@@ -81,8 +81,6 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
 
   // gaussian sampling
   static constexpr double _nsigmas = 5;
-  static constexpr int _ngauss_steps = 100;
-  std::array<double, _ngauss_steps> _gauss_weights;
 
   double averageGEMGain = NAN;
 


### PR DESCRIPTION
This PR uses an analytical formula to calculate the charge deposited on a given zigzag strip, rather than doing the integration manually. 
This is equivalent to what is done for "square" strips (using std::erf)
The new code gives identical result to before (to the extend that analytical integration is more precise than the manual one). It is also speeds up the time spent in PHG4TpcElectronDrift by about 30%
Similar code will also be used for implementing zigzag pads in the Micromegas
