### PR TITLE
Remove hardcoded tracknode name

### DIFF
--- a/simulation/g4simulation/g4jets/JetInput.h
+++ b/simulation/g4simulation/g4jets/JetInput.h
@@ -24,11 +24,14 @@ class JetInput
   {
     return std::vector<Jet*>();
   }
+  virtual int Verbosity() const {return m_Verbosity;}
+  virtual void Verbosity(int i) {m_Verbosity = i;}
 
  protected:
-  JetInput() {}
+JetInput(): m_Verbosity(0) {}
 
  private:
+  int m_Verbosity;
 };
 
 #endif

--- a/simulation/g4simulation/g4jets/TowerJetInput.cc
+++ b/simulation/g4simulation/g4jets/TowerJetInput.cc
@@ -23,8 +23,7 @@
 using namespace std;
 
 TowerJetInput::TowerJetInput(Jet::SRC input)
-  : _verbosity(0)
-  , _input(input)
+  : _input(input)
 {
 }
 
@@ -46,7 +45,7 @@ void TowerJetInput::identify(std::ostream &os)
 
 std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 {
-  if (_verbosity > 0) cout << "TowerJetInput::process_event -- entered" << endl;
+  if (Verbosity() > 0) cout << "TowerJetInput::process_event -- entered" << endl;
 
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexmap)
@@ -233,7 +232,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     pseudojets.push_back(jet);
   }
 
-  if (_verbosity > 0) cout << "TowerJetInput::process_event -- exited" << endl;
+  if (Verbosity() > 0) cout << "TowerJetInput::process_event -- exited" << endl;
 
   return pseudojets;
 }

--- a/simulation/g4simulation/g4jets/TowerJetInput.h
+++ b/simulation/g4simulation/g4jets/TowerJetInput.h
@@ -24,7 +24,6 @@ class TowerJetInput : public JetInput
   std::vector<Jet*> get_input(PHCompositeNode* topNode);
 
  private:
-  int _verbosity;
   Jet::SRC _input;
 };
 

--- a/simulation/g4simulation/g4jets/TrackJetInput.cc
+++ b/simulation/g4simulation/g4jets/TrackJetInput.cc
@@ -16,8 +16,8 @@
 
 using namespace std;
 
-TrackJetInput::TrackJetInput(Jet::SRC input)
-  : _verbosity(0)
+TrackJetInput::TrackJetInput(Jet::SRC input, const string &nodename)
+  : m_NodeName(nodename)
   , _input(input)
 {
 }
@@ -29,10 +29,10 @@ void TrackJetInput::identify(std::ostream &os)
 
 std::vector<Jet *> TrackJetInput::get_input(PHCompositeNode *topNode)
 {
-  if (_verbosity > 0) cout << "TrackJetInput::process_event -- entered" << endl;
+  if (Verbosity() > 0) cout << "TrackJetInput::process_event -- entered" << endl;
 
   // Pull the reconstructed track information off the node tree...
-  SvtxTrackMap *trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  SvtxTrackMap *trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_NodeName);
   if (!trackmap)
   {
     return std::vector<Jet *>();
@@ -54,7 +54,7 @@ std::vector<Jet *> TrackJetInput::get_input(PHCompositeNode *topNode)
     pseudojets.push_back(jet);
   }
 
-  if (_verbosity > 0) cout << "TrackJetInput::process_event -- exited" << endl;
+  if (Verbosity() > 0) cout << "TrackJetInput::process_event -- exited" << endl;
 
   return pseudojets;
 }

--- a/simulation/g4simulation/g4jets/TrackJetInput.h
+++ b/simulation/g4simulation/g4jets/TrackJetInput.h
@@ -13,7 +13,7 @@ class PHCompositeNode;
 class TrackJetInput : public JetInput
 {
  public:
-  TrackJetInput(Jet::SRC input);
+  TrackJetInput(Jet::SRC input, const std::string &name = "SvtxTrackMap");
   virtual ~TrackJetInput() {}
 
   void identify(std::ostream& os = std::cout);
@@ -23,7 +23,7 @@ class TrackJetInput : public JetInput
   std::vector<Jet*> get_input(PHCompositeNode* topNode);
 
  private:
-  int _verbosity;
+  std::string m_NodeName;
   Jet::SRC _input;
 };
 

--- a/simulation/g4simulation/g4jets/TruthJetInput.cc
+++ b/simulation/g4simulation/g4jets/TruthJetInput.cc
@@ -22,8 +22,7 @@
 using namespace std;
 
 TruthJetInput::TruthJetInput(Jet::SRC input)
-  : _verbosity(0)
-  , _input(input)
+  : _input(input)
   , _eta_min(-4.0)
   , _eta_max(+4.0)
 {
@@ -45,7 +44,7 @@ void TruthJetInput::identify(std::ostream &os)
 
 std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
 {
-  if (_verbosity > 0) cout << "TruthJetInput::process_event -- entered" << endl;
+  if (Verbosity() > 0) cout << "TruthJetInput::process_event -- entered" << endl;
 
   // Pull the reconstructed track information off the node tree...
   PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
@@ -96,7 +95,7 @@ std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
     pseudojets.push_back(jet);
   }
 
-  if (_verbosity > 0) cout << "TruthJetInput::process_event -- exited" << endl;
+  if (Verbosity() > 0) cout << "TruthJetInput::process_event -- exited" << endl;
 
   return pseudojets;
 }

--- a/simulation/g4simulation/g4jets/TruthJetInput.h
+++ b/simulation/g4simulation/g4jets/TruthJetInput.h
@@ -38,7 +38,6 @@ class TruthJetInput : public JetInput
   }
 
  private:
-  int _verbosity;
   Jet::SRC _input;
   float _eta_min;
   float _eta_max;

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -324,11 +324,10 @@ int PHG4TruthInfoContainer::GetPrimaryVertexIndex() const
 
   int highest_embedding_ID = numeric_limits<int>::min();
   int vtx_id_for_highest_embedding_ID = 0;
-
   for (auto iter = vrange.first; iter != vrange.second; ++iter)
   {
-    //    cout <<"PHG4TruthInfoContainer::GetPrimaryVertexIndex - vertex ID "<<iter->first<<" embedding ID "<< g4truth->isEmbededVtx(iter->first) <<": "
-    //         ; iter->second->identify();
+    //        cout <<"PHG4TruthInfoContainer::GetPrimaryVertexIndex - vertex ID "<<iter->first<<" embedding ID "<< isEmbededVtx(iter->first) <<": ";
+    // iter->second->identify();
     const int embedding_ID = isEmbededVtx(iter->first);
 
     if (embedding_ID >= highest_embedding_ID)


### PR DESCRIPTION
This PR replaces the hardcoded Track Node Name by an argument to the ctor of TrackJetInput. This should help getting rid of these svtxtrack maps. It defaults to SvtxTrackMap so it does not break old code/macros