### PR TITLE
PHGenFitTrkProp fix

### DIFF
--- a/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.cc
@@ -46,6 +46,16 @@ SpacepointMeasurement::SpacepointMeasurement(const TVector3& pos, const double r
   init(pos, cov);
 }
 
+SpacepointMeasurement::SpacepointMeasurement(const TVector3& pos, const TVector3& resolution)
+{
+  TMatrixDSym cov(3);
+  cov.Zero();
+  cov(0, 0) = resolution.X() * resolution.X();
+  cov(1, 1) = resolution.Y() * resolution.Y();
+  cov(2, 2) = resolution.Z() * resolution.Z();
+  init(pos, cov);
+}
+  
 /*!
  * Ctor
  * \param pos measurement position

--- a/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.h
@@ -24,7 +24,12 @@ class SpacepointMeasurement : public Measurement
 	 * \param resolution standard dev for diagnal elements of the cov, other elements are zero
 	 */
   SpacepointMeasurement(const TVector3& pos, const double resolution);
-
+  /*!
+	 * Ctor
+	 * \param pos measurement position
+	 * \param resolution standard dev for each diagnal element of the cov, other elements are zero
+	 */
+  SpacepointMeasurement(const TVector3& pos, const TVector3& resolution);
   /*!
 	 * Ctor
 	 * \param pos measurement position

--- a/offline/packages/PHTpcTracker/PHTpcTrackFollower.cc
+++ b/offline/packages/PHTpcTracker/PHTpcTrackFollower.cc
@@ -1,3 +1,4 @@
+
 /*!
  *  \file       PHTpcTrackFollower.cc
  *  \brief      
@@ -175,7 +176,6 @@ PHGenFit2::Track* PHTpcTrackFollower::propagateTrack(kdfinder::TrackCandidate<do
     LOG_DEBUG("tracking.PHTpcTrackFollower.propagateTrack") << "Found inconsistent track, skipping";
     return nullptr;
   }
-
   // ----- make initial fit of the track -----
   try
   {

--- a/offline/packages/PHTpcTracker/PHTpcTracker.cc
+++ b/offline/packages/PHTpcTracker/PHTpcTracker.cc
@@ -127,7 +127,7 @@ int PHTpcTracker::Process(PHCompositeNode* topNode)
   }
 
   // ---- timer -----
-  auto tracking_timer_start = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  //  auto tracking_timer_start = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 
   // ----- Seed finding -----
   TrkrClusterContainer* cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
@@ -140,7 +140,7 @@ int PHTpcTracker::Process(PHCompositeNode* topNode)
   std::vector<PHGenFit2::Track*> gtracks;
   gtracks = mTrackFollower->followTracks(cluster_map, candidates, mField, mLookup, mFitter);
   LOG_INFO("tracking.PHTpcTracker.process_event") << "TrackFollower reconstructed " << gtracks.size() << " tracks";
-
+  /*
   // ---- timer -----
   auto tracking_timer_stop = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 
@@ -174,7 +174,7 @@ int PHTpcTracker::Process(PHCompositeNode* topNode)
     mEventExporter->exportEvent(cluster_map, gtracks, mB, filename);
     LOG_INFO("tracking.PHTpcTracker.process_event") << "EventExporter dumped hits and tracks to json file";
   }
-
+  */
   // write tracks to fun4all server
   //  cout<<  gtracks[1]->get_vertex_id() << endl;
   for (int i = 0, ilen = gtracks.size(); i < ilen; i++){
@@ -233,13 +233,13 @@ int PHTpcTracker::Process(PHCompositeNode* topNode)
 
   // hit lookup cleanup
   mLookup->clear();
-
+  /*
   // rave vertices cleanup
   for (auto it = vertices.begin(); it != vertices.end(); ++it)
   {
     delete (*it);
   }
-
+  */
   LOG_INFO("tracking.PHTpcTracker.process_event") << "---- process event finished -----";
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -876,9 +876,11 @@ int PHCASeeding::FindSeedsLayerSkip(double cosTheta_limit, TNtuple* NT, PHTimer 
       // Apply Kalman filter
       if(!trackSeed.Filter(nextCluster_alice_y,nextCluster_z,y2_error,z2_error,_max_sin_phi))
       {
-        LogError("Kalman filter failed for seed " << nseeds << "! Aborting for this seed..." << endl);
+	if (Verbosity() >= 1)
+	  LogError("Kalman filter failed for seed " << nseeds << "! Aborting for this seed..." << endl);
         break;
       }
+      
       x = nextCluster_x;
       y = nextCluster_y;
       #if defined(_DEBUG_)

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -207,7 +207,7 @@ int PHGenFitTrkFitter::InitRun(PHCompositeNode* topNode)
 
   if (_do_eval)
   {
-    if (Verbosity() >= 1)
+    if (Verbosity() > 1)
       cout << PHWHERE << " Openning file: " << _eval_outname << endl;
     PHTFileServer::get().open(_eval_outname, "RECREATE");
     init_eval_tree();
@@ -228,7 +228,7 @@ int PHGenFitTrkFitter::InitRun(PHCompositeNode* topNode)
 int PHGenFitTrkFitter::process_event(PHCompositeNode* topNode)
 {
   _event++;
-
+  
   if (Verbosity() > 1)
     std::cout << PHWHERE << "Events processed: " << _event << std::endl;
   //	if (_event % 1000 == 0)
@@ -241,40 +241,43 @@ int PHGenFitTrkFitter::process_event(PHCompositeNode* topNode)
   //! stands for Refit_GenFit_Tracks
   vector<genfit::Track*> rf_gf_tracks;
   vector<std::shared_ptr<PHGenFit::Track> > rf_phgf_tracks;
-
+  
   map<unsigned int, unsigned int> svtxtrack_genfittrack_map;
-
+  
   if (_trackmap_refit)
     _trackmap_refit->empty();
-
+  
   // _trackmap is SvtxTrackMap from the node tree
   for (SvtxTrackMap::Iter iter = _trackmap->begin(); iter != _trackmap->end();
        ++iter)
-  {
-    SvtxTrack* svtx_track = iter->second;
-    if(Verbosity() > 10)
-      {
-  cout << "   process SVTXTrack " << iter->first << endl;
-  svtx_track->identify();
+    {
+      SvtxTrack* svtx_track = iter->second;
+      if(Verbosity() > 10){
+	cout << "   process SVTXTrack " << iter->first << endl;
+	svtx_track->identify();
       }
-    if (!svtx_track)
-      continue;
-    if (!(svtx_track->get_pt() > _fit_min_pT))
-      continue;
+      if (!svtx_track)
+	continue;
+      if (!(svtx_track->get_pt() > _fit_min_pT))
+	continue;
 
-    // This is the final track (re)fit. It does not include the collision vertex. If fit_primary_track is set, a refit including the vertex is done below.
-    //! rf_phgf_track stands for Refit_PHGenFit_Track
-    std::shared_ptr<PHGenFit::Track> rf_phgf_track = ReFitTrack(topNode, svtx_track);
-    if (rf_phgf_track)
-      {
-  svtxtrack_genfittrack_map[svtx_track->get_id()] =  rf_phgf_tracks.size();
-  rf_phgf_tracks.push_back(rf_phgf_track);
-  if (rf_phgf_track->get_ndf() > _vertex_min_ndf)
-    rf_gf_tracks.push_back(rf_phgf_track->getGenFitTrack());
-  if(Verbosity() > 10) cout << "Done refitting input track" << svtx_track->get_id() << " or rf_phgf_track " <<   rf_phgf_tracks.size() << endl;
+      // This is the final track (re)fit. It does not include the collision vertex. If fit_primary_track is set, a refit including the vertex is done below.
+      //! rf_phgf_track stands for Refit_PHGenFit_Track
+      std::shared_ptr<PHGenFit::Track> rf_phgf_track = ReFitTrack(topNode, svtx_track);
+      if (rf_phgf_track)
+	{
+	  svtxtrack_genfittrack_map[svtx_track->get_id()] =  rf_phgf_tracks.size();
+	  rf_phgf_tracks.push_back(rf_phgf_track);
+	  if (rf_phgf_track->get_ndf() > _vertex_min_ndf)
+	    rf_gf_tracks.push_back(rf_phgf_track->getGenFitTrack());
+	  if(Verbosity() > 10) cout << "Done refitting input track" << svtx_track->get_id() << " or rf_phgf_track " <<   rf_phgf_tracks.size() << endl;
+	}
+      else{
+	if(Verbosity() >= 1) 
+	  cout << "failed refitting input track# " << iter->first << endl;
       }
-
-  }
+      
+    }
 
   /*
    * add tracks to event display
@@ -508,7 +511,7 @@ int PHGenFitTrkFitter::End(PHCompositeNode* topNode)
 {
   if (_do_eval)
   {
-    if (Verbosity() >= 1)
+    if (Verbosity() > 1)
       cout << PHWHERE << " Writing to file: " << _eval_outname << endl;
     PHTFileServer::get().cd(_eval_outname);
     _eval_tree->Write();
@@ -952,8 +955,7 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
   if(Verbosity() > 10)   intrack->identify();
   std::map<float, TrkrDefs::cluskey> m_r_cluster_id;
   for (auto iter = intrack->begin_cluster_keys();
-       iter != intrack->end_cluster_keys(); ++iter)
-  {
+       iter != intrack->end_cluster_keys(); ++iter){
     TrkrDefs::cluskey cluster_key = *iter;
     TrkrCluster* cluster = _clustermap->findCluster(cluster_key);
     float x = cluster->getPosition(0);
@@ -1077,16 +1079,19 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
    *  Fit the track
    *  ret code 0 means 0 error or good status
    */
+
   if (_fitter->processTrack(track.get(), false) != 0)
   {
     if (Verbosity() >= 1)
       {
-  LogWarning("Track fitting failed");
-  cout << " track->getChisq() " << track->get_chi2() << " get_ndf " << track->get_ndf()
-       << " mom.X " << track->get_mom().X()
-       << " mom.Y " << track->get_mom().Y()
-       << " mom.Z " << track->get_mom().Z()
-       << endl;
+	LogWarning("Track fitting failed");
+	/*
+	cout << " track->getChisq() " << track->get_chi2() << " get_ndf " << track->get_ndf()
+	     << " mom.X " << track->get_mom().X()
+	     << " mom.Y " << track->get_mom().Y()
+	     << " mom.Z " << track->get_mom().Z()
+	     << endl;
+	*/
       }
     //delete track;
     return nullptr;
@@ -1489,12 +1494,12 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
     }
     catch (...)
     {
-      if (Verbosity() > 1)
+      if (Verbosity() >= 1)
         LogWarning("Exrapolation failed!");
     }
     if (!gf_state)
     {
-      if (Verbosity() > 1)
+      if (Verbosity() >= 1)
         LogWarning("Exrapolation failed!");
       continue;
     }

--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -108,7 +108,6 @@ PHGenFitTrkProp::PHGenFitTrkProp(
     unsigned int nlayers_tpc,
     unsigned int nlayers_micromegas)
   : PHTrackPropagating(name)
-<<<<<<< HEAD
   , _nlayers_maps(nlayers_maps)
   , _nlayers_intt(nlayers_intt)
   , _nlayers_tpc(nlayers_tpc)
@@ -118,124 +117,10 @@ PHGenFitTrkProp::PHGenFitTrkProp(
   , _firstlayer_intt(_firstlayer_maps + _nlayers_maps)
   , _firstlayer_tpc(_firstlayer_intt + _nlayers_intt)
   , _firstlayer_micromegas(_firstlayer_tpc + _nlayers_tpc)
-{}
-=======
-  , _t_seeds_cleanup(nullptr)
-  , _t_translate_to_PHGenFitTrack(nullptr)
-  , _t_translate1(nullptr)
-  , _t_translate2(nullptr)
-  , _t_translate3(nullptr)
-  , _t_kalman_pat_rec(nullptr)
-  , _t_search_clusters(nullptr)
-  , _t_search_clusters_encoding(nullptr)
-  , _t_search_clusters_map_iter(nullptr)
-  , _t_track_propagation(nullptr)
-  , _t_full_fitting(nullptr)
-  , _t_output_io(nullptr)
-  , _vertex()
-  , _bbc_vertexes(nullptr)
-  , _hit_used_map(nullptr)
-  , _hit_used_map_size(0)
-  , _geom_container_intt(nullptr)
-  , _geom_container_maps(nullptr)
-  , _analyzing_mode(false)
-  , _analyzing_file(nullptr)
-  , _analyzing_ntuple(nullptr)
-  , _max_merging_dphi(0.1)
-  , _max_merging_deta(0.1)
-  , _max_merging_dr(0.1)
-  , _max_merging_dz(0.1)
-  , _max_share_hits(3)
-  , _fitter(nullptr)
-  , _track_fitting_alg_name("KalmanFitter")
-  , _primary_pid_guess(211)
-  , _cut_min_pT(0.2)
-  , _do_evt_display(false)
-  , _nlayers_maps(nlayers_maps)
-  , _nlayers_intt(nlayers_intt)
-  , _nlayers_tpc(nlayers_tpc)
-  , _nlayers_all(_nlayers_maps + _nlayers_intt + _nlayers_tpc)
-  , _layer_ilayer_map_all()
-  , _radii_all()
-  , _max_search_win_phi_tpc(0.0040)
-  , _min_search_win_phi_tpc(0.0000)
-  , _max_search_win_theta_tpc(0.0040)
-  , _min_search_win_theta_tpc(0.0000)
-  , _max_search_win_phi_maps(0.0050)
-  , _min_search_win_phi_maps(0.0000)
-  , _max_search_win_theta_maps(0.0400)
-  , _min_search_win_theta_maps(0.0000)
-  ,
-
-  _search_win_phi(20)
-  , _search_win_theta(20)
-  , _layer_thetaID_phiID_clusterID()
-  ,
-  //_half_max_theta(160),
-  _half_max_theta(3.1416 / 2.)
-  ,
-  //_half_max_phi(252), //80cm * Pi
-  _half_max_phi(3.1416)
-  ,
-  //_layer_thetaID_phiID_clusterID_phiSize(0.1200),
-  _layer_thetaID_phiID_clusterID_phiSize(0.1200 / 30)
-  ,  //rad
-  _layer_thetaID_phiID_clusterID_zSize(0.1700 / 30)
-  , _PHGenFitTracks()
-  , _init_direction(-1)
-  , _blowup_factor(1.)
-  , _max_consecutive_missing_layer(20)
-  , _max_incr_chi2(20.)
-  , _max_splitting_chi2(20.)
-  , _min_good_track_hits(30)
   , _use_beam(false)
 {
   _event = 0;
-  _max_search_win_phi_intt[0] = 0.20;
-  _max_search_win_phi_intt[1] = 0.20;
-  _max_search_win_phi_intt[2] = 0.0050;
-  _max_search_win_phi_intt[3] = 0.0050;
-  _max_search_win_phi_intt[4] = 0.0050;
-  _max_search_win_phi_intt[5] = 0.0050;
-  _max_search_win_phi_intt[6] = 0.0050;
-  _max_search_win_phi_intt[7] = 0.0050;
-
-  _min_search_win_phi_intt[0] = 0.2000;
-  _min_search_win_phi_intt[1] = 0.2000;
-  _min_search_win_phi_intt[2] = 0.0;
-  _min_search_win_phi_intt[3] = 0.0;
-  _min_search_win_phi_intt[4] = 0.0;
-  _min_search_win_phi_intt[5] = 0.0;
-  _min_search_win_phi_intt[6] = 0.0;
-  _min_search_win_phi_intt[7] = 0.0;
-
-  _max_search_win_theta_intt[0] = 0.010;
-  _max_search_win_theta_intt[1] = 0.010;
-  _max_search_win_theta_intt[2] = 0.2000;
-  _max_search_win_theta_intt[3] = 0.2000;
-  _max_search_win_theta_intt[4] = 0.2000;
-  _max_search_win_theta_intt[5] = 0.2000;
-  _max_search_win_theta_intt[6] = 0.2000;
-  _max_search_win_theta_intt[7] = 0.2000;
-
-  _min_search_win_theta_intt[0] = 0.000;
-  _min_search_win_theta_intt[1] = 0.000;
-  _min_search_win_theta_intt[2] = 0.200;
-  _min_search_win_theta_intt[3] = 0.200;
-  _min_search_win_theta_intt[4] = 0.200;
-  _min_search_win_theta_intt[5] = 0.200;
-  _min_search_win_theta_intt[6] = 0.200;
-  _min_search_win_theta_intt[7] = 0.200;
-
-  _vertex_error.clear();
-  //_vertex_error.assign(3, 0.0100);
 }
-
-PHGenFitTrkProp::~PHGenFitTrkProp()
-{
-  delete _fitter;
-}
->>>>>>> 0f076ffe... PHGenFitTrkProp fix
 
 int PHGenFitTrkProp::Setup(PHCompositeNode* topNode)
 {
@@ -908,7 +793,6 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkProp::ReFitTrack(SvtxTrack* intrack)
   PHG4CylinderGeomContainer* geom_container_intt = findNode::getClass<
       PHG4CylinderGeomContainer>(_topNode, "CYLINDERGEOM_INTT");
 
-<<<<<<< HEAD
   PHG4CylinderGeomContainer* geom_container_mvtx = findNode::getClass<
       PHG4CylinderGeomContainer>(_topNode, "CYLINDERGEOM_MVTX");
 
@@ -1071,31 +955,12 @@ int PHGenFitTrkProp::SvtxTrackToPHGenFitTracks(const SvtxTrack* svtxtrack)
   // clean up working array for each event
   _PHGenFitTracks.clear();
 
-  TVector3 seed_mom(1000, 0, 0);
-  TVector3 seed_pos(0, 0, 0);
-  //  const float blowup_factor = 1.;
-  TMatrixDSym seed_cov(6);
-  for (int i = 0; i < 6; i++)
-  {
-    for (int j = 0; j < 6; j++)
-    {
-      seed_cov[i][j] = 100.;
-      //      seed_cov[i][j] = blowup_factor * svtxtrack->get_error(i, j);
-    }
-  }
-
-
-  //Sort hits in r 
-  //  std::multimap<float, TrkrDefs::cluskey> m_r_clusterID;
-  std::map<float, TrkrDefs::cluskey> m_r_clusterID;
-=======
   if(Verbosity() > 10) cout << PHWHERE << "Converting SvtxTrack to PHGenFit track: track ID " << svtxtrack->get_id()
        << " track z " << svtxtrack->get_z()
        << " vertex ID " << svtxtrack->get_vertex_id() 
        << " vertex z " << _vertex[svtxtrack->get_vertex_id()][2]
        << endl;
   //svtxtrack->identify();
-
 
   std::vector<PHGenFit::Measurement*> measurements;
 
@@ -1106,8 +971,11 @@ int PHGenFitTrkProp::SvtxTrackToPHGenFitTracks(const SvtxTrack* svtxtrack)
     beam->set_cluster_key(0);
     measurements.push_back(beam);
   }
-  std::multimap<float, TrkrDefs::cluskey> m_r_clusterID;
->>>>>>> 0f076ffe... PHGenFitTrkProp fix
+
+  //Sort hits in r 
+  //  std::multimap<float, TrkrDefs::cluskey> m_r_clusterID;
+  std::map<float, TrkrDefs::cluskey> m_r_clusterID;
+
   for (auto hit_iter = svtxtrack->begin_cluster_keys();
        hit_iter != svtxtrack->end_cluster_keys(); ++hit_iter)
   {
@@ -1125,10 +993,6 @@ int PHGenFitTrkProp::SvtxTrackToPHGenFitTracks(const SvtxTrack* svtxtrack)
     }
   }
 
-<<<<<<< HEAD
-  // Create measurements
-  std::vector<PHGenFit::Measurement*> measurements;
-=======
   /*
   if (_vertex_map)
   {
@@ -1148,7 +1012,6 @@ int PHGenFitTrkProp::SvtxTrackToPHGenFitTracks(const SvtxTrack* svtxtrack)
   */
   TrkrDefs::cluskey last_cluster_key = 0;
 
->>>>>>> 0f076ffe... PHGenFitTrkProp fix
   for (auto iter = m_r_clusterID.begin();
        iter != m_r_clusterID.end();
        ++iter)
@@ -1159,29 +1022,13 @@ int PHGenFitTrkProp::SvtxTrackToPHGenFitTracks(const SvtxTrack* svtxtrack)
       LogError("No cluster Found!\n");
       continue;
     }
-<<<<<<< HEAD
     //    const int layer = TrkrDefs::getLayer(cluster_key);
-=======
     last_cluster_key = cluster_key;
->>>>>>> 0f076ffe... PHGenFitTrkProp fix
     PHGenFit::Measurement* meas = TrkrClusterToPHGenFitMeasurement(cluster);
-    TVector3 pos(cluster->getPosition(0), cluster->getPosition(1), cluster->getPosition(2));
-    seed_mom.SetPhi(pos.Phi());
-    seed_mom.SetTheta(pos.Theta());
-    /*
-    cout << "Add meas layer " << layer << " cluskey " << cluster_key
-	 << endl
-	 << " pos.X " << pos.X() << " pos.Y " << pos.Y() << " pos.Z " << pos.Z()
-	 << " RPhiErr " << cluster->getRPhiError()
-	 << " ZErr " << cluster->getZError()
-	 << endl;
-    */
     if (meas){
       measurements.push_back(meas);
     }
   }
-<<<<<<< HEAD
-=======
 
   TVector3 seed_pos;
   TVector3 seed_mom;
@@ -1215,13 +1062,6 @@ int PHGenFitTrkProp::SvtxTrackToPHGenFitTracks(const SvtxTrack* svtxtrack)
   std::shared_ptr<PHGenFit::Track> track(
       new PHGenFit::Track(rep, seed_pos, seed_mom, seed_cov));
 
-
-  track->addMeasurements(measurements);
->>>>>>> 0f076ffe... PHGenFitTrkProp fix
-
-  genfit::AbsTrackRep* rep = new genfit::RKTrackRep(_primary_pid_guess);
-  std::shared_ptr<PHGenFit::Track> track(
-      new PHGenFit::Track(rep, seed_pos, seed_mom, seed_cov));
 
   track->addMeasurements(measurements);
   if (Verbosity() >= 1)

--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -49,6 +49,7 @@
 #include <GenFit/MeasuredStateOnPlane.h>
 #include <GenFit/RKTrackRep.h>
 #include <GenFit/Track.h>
+#include <phgenfit/SpacepointMeasurement.h>
 
 #include <phgenfit/Fitter.h>
 #include <phgenfit/Measurement.h>                       // for Measurement
@@ -107,6 +108,7 @@ PHGenFitTrkProp::PHGenFitTrkProp(
     unsigned int nlayers_tpc,
     unsigned int nlayers_micromegas)
   : PHTrackPropagating(name)
+<<<<<<< HEAD
   , _nlayers_maps(nlayers_maps)
   , _nlayers_intt(nlayers_intt)
   , _nlayers_tpc(nlayers_tpc)
@@ -117,6 +119,123 @@ PHGenFitTrkProp::PHGenFitTrkProp(
   , _firstlayer_tpc(_firstlayer_intt + _nlayers_intt)
   , _firstlayer_micromegas(_firstlayer_tpc + _nlayers_tpc)
 {}
+=======
+  , _t_seeds_cleanup(nullptr)
+  , _t_translate_to_PHGenFitTrack(nullptr)
+  , _t_translate1(nullptr)
+  , _t_translate2(nullptr)
+  , _t_translate3(nullptr)
+  , _t_kalman_pat_rec(nullptr)
+  , _t_search_clusters(nullptr)
+  , _t_search_clusters_encoding(nullptr)
+  , _t_search_clusters_map_iter(nullptr)
+  , _t_track_propagation(nullptr)
+  , _t_full_fitting(nullptr)
+  , _t_output_io(nullptr)
+  , _vertex()
+  , _bbc_vertexes(nullptr)
+  , _hit_used_map(nullptr)
+  , _hit_used_map_size(0)
+  , _geom_container_intt(nullptr)
+  , _geom_container_maps(nullptr)
+  , _analyzing_mode(false)
+  , _analyzing_file(nullptr)
+  , _analyzing_ntuple(nullptr)
+  , _max_merging_dphi(0.1)
+  , _max_merging_deta(0.1)
+  , _max_merging_dr(0.1)
+  , _max_merging_dz(0.1)
+  , _max_share_hits(3)
+  , _fitter(nullptr)
+  , _track_fitting_alg_name("KalmanFitter")
+  , _primary_pid_guess(211)
+  , _cut_min_pT(0.2)
+  , _do_evt_display(false)
+  , _nlayers_maps(nlayers_maps)
+  , _nlayers_intt(nlayers_intt)
+  , _nlayers_tpc(nlayers_tpc)
+  , _nlayers_all(_nlayers_maps + _nlayers_intt + _nlayers_tpc)
+  , _layer_ilayer_map_all()
+  , _radii_all()
+  , _max_search_win_phi_tpc(0.0040)
+  , _min_search_win_phi_tpc(0.0000)
+  , _max_search_win_theta_tpc(0.0040)
+  , _min_search_win_theta_tpc(0.0000)
+  , _max_search_win_phi_maps(0.0050)
+  , _min_search_win_phi_maps(0.0000)
+  , _max_search_win_theta_maps(0.0400)
+  , _min_search_win_theta_maps(0.0000)
+  ,
+
+  _search_win_phi(20)
+  , _search_win_theta(20)
+  , _layer_thetaID_phiID_clusterID()
+  ,
+  //_half_max_theta(160),
+  _half_max_theta(3.1416 / 2.)
+  ,
+  //_half_max_phi(252), //80cm * Pi
+  _half_max_phi(3.1416)
+  ,
+  //_layer_thetaID_phiID_clusterID_phiSize(0.1200),
+  _layer_thetaID_phiID_clusterID_phiSize(0.1200 / 30)
+  ,  //rad
+  _layer_thetaID_phiID_clusterID_zSize(0.1700 / 30)
+  , _PHGenFitTracks()
+  , _init_direction(-1)
+  , _blowup_factor(1.)
+  , _max_consecutive_missing_layer(20)
+  , _max_incr_chi2(20.)
+  , _max_splitting_chi2(20.)
+  , _min_good_track_hits(30)
+  , _use_beam(false)
+{
+  _event = 0;
+  _max_search_win_phi_intt[0] = 0.20;
+  _max_search_win_phi_intt[1] = 0.20;
+  _max_search_win_phi_intt[2] = 0.0050;
+  _max_search_win_phi_intt[3] = 0.0050;
+  _max_search_win_phi_intt[4] = 0.0050;
+  _max_search_win_phi_intt[5] = 0.0050;
+  _max_search_win_phi_intt[6] = 0.0050;
+  _max_search_win_phi_intt[7] = 0.0050;
+
+  _min_search_win_phi_intt[0] = 0.2000;
+  _min_search_win_phi_intt[1] = 0.2000;
+  _min_search_win_phi_intt[2] = 0.0;
+  _min_search_win_phi_intt[3] = 0.0;
+  _min_search_win_phi_intt[4] = 0.0;
+  _min_search_win_phi_intt[5] = 0.0;
+  _min_search_win_phi_intt[6] = 0.0;
+  _min_search_win_phi_intt[7] = 0.0;
+
+  _max_search_win_theta_intt[0] = 0.010;
+  _max_search_win_theta_intt[1] = 0.010;
+  _max_search_win_theta_intt[2] = 0.2000;
+  _max_search_win_theta_intt[3] = 0.2000;
+  _max_search_win_theta_intt[4] = 0.2000;
+  _max_search_win_theta_intt[5] = 0.2000;
+  _max_search_win_theta_intt[6] = 0.2000;
+  _max_search_win_theta_intt[7] = 0.2000;
+
+  _min_search_win_theta_intt[0] = 0.000;
+  _min_search_win_theta_intt[1] = 0.000;
+  _min_search_win_theta_intt[2] = 0.200;
+  _min_search_win_theta_intt[3] = 0.200;
+  _min_search_win_theta_intt[4] = 0.200;
+  _min_search_win_theta_intt[5] = 0.200;
+  _min_search_win_theta_intt[6] = 0.200;
+  _min_search_win_theta_intt[7] = 0.200;
+
+  _vertex_error.clear();
+  //_vertex_error.assign(3, 0.0100);
+}
+
+PHGenFitTrkProp::~PHGenFitTrkProp()
+{
+  delete _fitter;
+}
+>>>>>>> 0f076ffe... PHGenFitTrkProp fix
 
 int PHGenFitTrkProp::Setup(PHCompositeNode* topNode)
 {
@@ -499,20 +618,31 @@ int PHGenFitTrkProp::KalmanTrkProp()
 	  std::vector<TrkrDefs::cluskey> clusterkeys = gftrk_iter->second->get_cluster_keys();
 	  
 	  unsigned int init_layer = UINT_MAX;
+	  unsigned int min_layer = UINT_MAX;
+	  unsigned int max_layer = 0;
 	  
+	  for (auto iter = clusterkeys.begin();
+	       iter != clusterkeys.end(); ++iter){
+	    TrkrDefs::cluskey cluster_key = *iter;
+	    if(cluster_key!=0){
+	      unsigned int layer = TrkrDefs::getLayer(cluster_key);
+	      if(layer < min_layer) min_layer = layer;
+	      if(layer > max_layer) max_layer = layer;
+	    }
+	  }
 	  if (!is_splitting_track)
 	    {
 	      if (_init_direction == 1)
 		{
 		  //init_layer = _cluster_map->get(clusterkeys.front())->get_layer();
-		  init_layer = TrkrDefs::getLayer(clusterkeys.front());
+		  init_layer = min_layer;//TrkrDefs::getLayer(clusterkeys.front());
 		  TrackPropPatRec(ivert, gftrk_iter, init_layer, _nlayers_all, true);
 		  TrackPropPatRec(ivert, gftrk_iter, init_layer, 0, false);
 		}
 	      else
 		{
 		  //init_layer = _cluster_map->get(clusterkeys.back())->get_layer();
-		  init_layer = TrkrDefs::getLayer(clusterkeys.back());
+		  init_layer = max_layer;//TrkrDefs::getLayer(clusterkeys.back());
 		  TrackPropPatRec(ivert, gftrk_iter, init_layer, 0, true);
 		  TrackPropPatRec(ivert, gftrk_iter, init_layer, _nlayers_all, false);
 		}
@@ -523,13 +653,13 @@ int PHGenFitTrkProp::KalmanTrkProp()
 	      if (_init_direction == 1)
 		{
 		  //init_layer = _cluster_map->get(clusterkeys.front())->get_layer();
-		  init_layer = TrkrDefs::getLayer(clusterkeys.front());
+		  init_layer = min_layer;//TrkrDefs::getLayer(clusterkeys.front());
 		  TrackPropPatRec(ivert, gftrk_iter, init_layer, _nlayers_all, false);
 		}
 	      else
 		{
 		  //init_layer = _cluster_map->get(clusterkeys.back())->get_layer();
-		  init_layer = TrkrDefs::getLayer(clusterkeys.back());
+		  init_layer = max_layer;//TrkrDefs::getLayer(clusterkeys.back());
 		  TrackPropPatRec(ivert, gftrk_iter, init_layer, 0, false);
 		}
 	    }
@@ -711,6 +841,7 @@ int PHGenFitTrkProp::OutputPHGenFitTrack(
   
   for (TrkrDefs::cluskey cluster_key : gftrk_iter->second->get_cluster_keys())
     {
+      if(cluster_key<=0)continue;
       if(Verbosity() > 10) cout << " track id: " << phtrk_iter->first <<  " adding clusterkey " << cluster_key << endl;
       _gftrk_hitkey_map.insert(std::make_pair(cluster_key, phtrk_iter->first));
       track->insert_cluster_key(cluster_key);
@@ -777,6 +908,7 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkProp::ReFitTrack(SvtxTrack* intrack)
   PHG4CylinderGeomContainer* geom_container_intt = findNode::getClass<
       PHG4CylinderGeomContainer>(_topNode, "CYLINDERGEOM_INTT");
 
+<<<<<<< HEAD
   PHG4CylinderGeomContainer* geom_container_mvtx = findNode::getClass<
       PHG4CylinderGeomContainer>(_topNode, "CYLINDERGEOM_MVTX");
 
@@ -956,6 +1088,26 @@ int PHGenFitTrkProp::SvtxTrackToPHGenFitTracks(const SvtxTrack* svtxtrack)
   //Sort hits in r 
   //  std::multimap<float, TrkrDefs::cluskey> m_r_clusterID;
   std::map<float, TrkrDefs::cluskey> m_r_clusterID;
+=======
+  if(Verbosity() > 10) cout << PHWHERE << "Converting SvtxTrack to PHGenFit track: track ID " << svtxtrack->get_id()
+       << " track z " << svtxtrack->get_z()
+       << " vertex ID " << svtxtrack->get_vertex_id() 
+       << " vertex z " << _vertex[svtxtrack->get_vertex_id()][2]
+       << endl;
+  //svtxtrack->identify();
+
+
+  std::vector<PHGenFit::Measurement*> measurements;
+
+  if(_use_beam){
+    TVector3 posvtx(0.0, 0.0,0.0);
+    TVector3 resvtx(0.015, 0.015,30.0);
+    PHGenFit::SpacepointMeasurement* beam = new PHGenFit::SpacepointMeasurement(posvtx, resvtx);
+    beam->set_cluster_key(0);
+    measurements.push_back(beam);
+  }
+  std::multimap<float, TrkrDefs::cluskey> m_r_clusterID;
+>>>>>>> 0f076ffe... PHGenFitTrkProp fix
   for (auto hit_iter = svtxtrack->begin_cluster_keys();
        hit_iter != svtxtrack->end_cluster_keys(); ++hit_iter)
   {
@@ -973,20 +1125,45 @@ int PHGenFitTrkProp::SvtxTrackToPHGenFitTracks(const SvtxTrack* svtxtrack)
     }
   }
 
+<<<<<<< HEAD
   // Create measurements
   std::vector<PHGenFit::Measurement*> measurements;
+=======
+  /*
+  if (_vertex_map)
+  {
+    TVector3 v(_vertex[0], _vertex[1], _vertex[2]);
+    TMatrixDSym cov(3);
+    cov.Zero();
+    cov(0, 0) = _vertex_error[0] * _vertex_error[0];
+    cov(1, 1) = _vertex_error[1] * _vertex_error[1];
+    cov(2, 2) = _vertex_error[2] * _vertex_error[2];
+    PHGenFit::Measurement* meas = new PHGenFit::SpacepointMeasurement(v, cov);
+    //FIXME re-use the first cluster id
+    //  TrkrDefs::cluskey id = m_r_clusterID.begin()->second;
+    //    meas->set_cluster_key(id);
+    meas->set_cluster_key(0);
+    measurements.push_back(meas);
+  }
+  */
+  TrkrDefs::cluskey last_cluster_key = 0;
+
+>>>>>>> 0f076ffe... PHGenFitTrkProp fix
   for (auto iter = m_r_clusterID.begin();
        iter != m_r_clusterID.end();
        ++iter)
   {
     TrkrDefs::cluskey cluster_key = iter->second;
-
     TrkrCluster *cluster = _cluster_map->findCluster(cluster_key);
     if (!cluster){
       LogError("No cluster Found!\n");
       continue;
     }
+<<<<<<< HEAD
     //    const int layer = TrkrDefs::getLayer(cluster_key);
+=======
+    last_cluster_key = cluster_key;
+>>>>>>> 0f076ffe... PHGenFitTrkProp fix
     PHGenFit::Measurement* meas = TrkrClusterToPHGenFitMeasurement(cluster);
     TVector3 pos(cluster->getPosition(0), cluster->getPosition(1), cluster->getPosition(2));
     seed_mom.SetPhi(pos.Phi());
@@ -1003,6 +1180,44 @@ int PHGenFitTrkProp::SvtxTrackToPHGenFitTracks(const SvtxTrack* svtxtrack)
       measurements.push_back(meas);
     }
   }
+<<<<<<< HEAD
+=======
+
+  TVector3 seed_pos;
+  TVector3 seed_mom;
+  const float blowup_factor = 100.;
+  TMatrixDSym seed_cov(6);
+  
+  if(svtxtrack->get_py()==0&&svtxtrack->get_pz()==0){
+    TrkrCluster *last_cluster = _cluster_map->findCluster(last_cluster_key);
+    TVector3 pos(last_cluster->getPosition(0), last_cluster->getPosition(1), last_cluster->getPosition(2));
+    seed_mom.SetXYZ(100,0,0);
+    seed_mom.SetPhi(pos.Phi());
+    seed_mom.SetTheta(pos.Theta());
+    //    seed_mom.SetPtThetaPhi(pos.Perp(),pos.Theta(),pos.Phi());
+    for (int i = 0; i < 6; i++){
+      for (int j = 0; j < 6; j++){
+	seed_cov[i][j] = 100.;
+      }
+    }
+  }else{
+    seed_pos.SetXYZ(svtxtrack->get_x(),svtxtrack->get_y(),svtxtrack->get_z());
+    seed_mom.SetXYZ(svtxtrack->get_px(),svtxtrack->get_py(),svtxtrack->get_pz());
+    
+    for (int i = 0; i < 6; i++){
+      for (int j = 0; j < 6; j++){
+	seed_cov[i][j] = blowup_factor * svtxtrack->get_error(i, j);
+      }
+    }
+  }
+
+  genfit::AbsTrackRep* rep = new genfit::RKTrackRep(_primary_pid_guess);
+  std::shared_ptr<PHGenFit::Track> track(
+      new PHGenFit::Track(rep, seed_pos, seed_mom, seed_cov));
+
+
+  track->addMeasurements(measurements);
+>>>>>>> 0f076ffe... PHGenFitTrkProp fix
 
   genfit::AbsTrackRep* rep = new genfit::RKTrackRep(_primary_pid_guess);
   std::shared_ptr<PHGenFit::Track> track(
@@ -1077,6 +1292,7 @@ int PHGenFitTrkProp::TrackPropPatRec(
   
   for (unsigned int i = 0; i < clusterkeys.size(); ++i)
     {
+      if(clusterkeys[i]==0)continue;
       unsigned int layer = TrkrDefs::getLayer(clusterkeys[i]);
       layer_occupied[layer] = 1;
       if(layer == init_layer)

--- a/offline/packages/trackreco/PHGenFitTrkProp.h
+++ b/offline/packages/trackreco/PHGenFitTrkProp.h
@@ -455,6 +455,16 @@ class PHGenFitTrkProp : public PHTrackPropagating
     _primary_pid_guess = primaryPidGuess;
   }
 
+<<<<<<< HEAD
+=======
+  void set_beam_constraint(bool beamConstraint)
+  {
+    _use_beam = beamConstraint;
+  }
+
+#if !defined(__CINT__) || defined(__CLING__)
+
+>>>>>>> 0f076ffe... PHGenFitTrkProp fix
  private:
 
   //*@name utility methods
@@ -666,8 +676,13 @@ class PHGenFitTrkProp : public PHTrackPropagating
 
   unsigned int _min_good_track_hits = 30;
 
+<<<<<<< HEAD
   PHCompositeNode* _topNode = nullptr;
   int _ntrack = 0;
+=======
+  bool _use_beam;
+#endif  // __CINT__
+>>>>>>> 0f076ffe... PHGenFitTrkProp fix
 };
 
 #endif

--- a/offline/packages/trackreco/PHGenFitTrkProp.h
+++ b/offline/packages/trackreco/PHGenFitTrkProp.h
@@ -455,16 +455,11 @@ class PHGenFitTrkProp : public PHTrackPropagating
     _primary_pid_guess = primaryPidGuess;
   }
 
-<<<<<<< HEAD
-=======
   void set_beam_constraint(bool beamConstraint)
   {
     _use_beam = beamConstraint;
   }
 
-#if !defined(__CINT__) || defined(__CLING__)
-
->>>>>>> 0f076ffe... PHGenFitTrkProp fix
  private:
 
   //*@name utility methods
@@ -676,13 +671,10 @@ class PHGenFitTrkProp : public PHTrackPropagating
 
   unsigned int _min_good_track_hits = 30;
 
-<<<<<<< HEAD
   PHCompositeNode* _topNode = nullptr;
   int _ntrack = 0;
-=======
   bool _use_beam;
-#endif  // __CINT__
->>>>>>> 0f076ffe... PHGenFitTrkProp fix
+
 };
 
 #endif

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -152,7 +152,7 @@ int SvtxEvaluator::Init(PHCompositeNode* topNode)
                                            "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps");
 
   if (_do_cluster_eval) _ntp_cluster = new TNtuple("ntp_cluster", "svtxcluster => max truth",
-                                                   "event:seed:hitID:x:y:z:r:phi:eta:ex:ey:ez:ephi:"
+                                                   "event:seed:hitID:x:y:z:r:phi:eta:theta:ex:ey:ez:ephi:"
                                                    "e:adc:layer:size:phisize:"
                                                    "zsize:trackID:g4hitID:gx:"
                                                    "gy:gz:gr:gphi:geta:gt:gtrackID:gflavor:"
@@ -1682,7 +1682,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         float r = pos.Perp();
         float phi = pos.Phi();
         float eta = pos.Eta();
-
+        float theta = pos.Theta();
         float ex = sqrt(cluster->getError(0, 0));
         float ey = sqrt(cluster->getError(1, 1));
         float ez = cluster->getZError();
@@ -1791,7 +1791,12 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         }
 
         float nparticles = clustereval->all_truth_particles(cluster_key).size();
+<<<<<<< HEAD
         float cluster_data[] = {(float) _ievent,m_fSeed,
+=======
+        float cluster_data[] = {(float) _ievent,
+				(float) _iseed,
+>>>>>>> 0f076ffe... PHGenFitTrkProp fix
                                 hitID,
                                 x,
                                 y,
@@ -1799,6 +1804,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                                 r,
                                 phi,
                                 eta,
+				theta,
                                 ex,
                                 ey,
                                 ez,
@@ -1890,6 +1896,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           float r = pos.Perp();
           float phi = pos.Phi();
           float eta = pos.Eta();
+	  float theta = pos.Theta();
           float ex = sqrt(cluster->getError(0, 0));
           float ey = sqrt(cluster->getError(1, 1));
           float ez = cluster->getZError();
@@ -2000,13 +2007,15 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           float nparticles = clustereval->all_truth_particles(cluster_key).size();
 
           float cluster_data[] = {(float) _ievent,
+				  (float) _iseed,
                                 hitID,
                                 x,
                                 y,
                                 z,
                                 r,
                                 phi,
-                                eta,
+				  eta,
+				  theta,
                                 ex,
                                 ey,
                                 ez,
@@ -2289,7 +2298,6 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 		  r = sqrt(x*x+y*y);
 		  phi = pos.Phi();
 		  eta = pos.Eta();
-
 		  ex = sqrt(cluster->getError(0, 0));
 		  ey = sqrt(cluster->getError(1, 1));
 		  ez = cluster->getZError();		  

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -1791,12 +1791,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         }
 
         float nparticles = clustereval->all_truth_particles(cluster_key).size();
-<<<<<<< HEAD
-        float cluster_data[] = {(float) _ievent,m_fSeed,
-=======
         float cluster_data[] = {(float) _ievent,
 				(float) _iseed,
->>>>>>> 0f076ffe... PHGenFitTrkProp fix
                                 hitID,
                                 x,
                                 y,
@@ -2014,8 +2010,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                                 z,
                                 r,
                                 phi,
-				  eta,
-				  theta,
+				eta,
+				theta,
                                 ex,
                                 ey,
                                 ez,


### PR DESCRIPTION
Revert PHGenFitTrkProp to working state for ACTS tracking initialisation

Extend SpacepointMeasurement with constructor for asymmetric errors for use as 
beamsport constraint

Minor touchup of PHTpcTracker

Printout controll in PHCASeeding.cc

Fix indention in PHGenFitTrkFitter.cc for better readability

Minor fix of ntuple ordering in SvtxEvaluator. 
Ntuple definition and filling were out of sync when scan_for_embedded is set to false.

<img width="680" alt="ptvsgpt" src="https://user-images.githubusercontent.com/8998644/84920707-d19c1580-b0c3-11ea-8f31-56ff770a1433.png">
<img width="684" alt="nmaps" src="https://user-images.githubusercontent.com/8998644/84920709-d2cd4280-b0c3-11ea-9894-0a934676ee2d.png">
