### PR TITLE
Acts Track Propagation

### DIFF
--- a/offline/packages/trackreco/ActsCovarianceRotater.cc
+++ b/offline/packages/trackreco/ActsCovarianceRotater.cc
@@ -177,7 +177,7 @@ Acts::BoundSymMatrix ActsCovarianceRotater::rotateActsCovToSvtxTrack(
 }
 
 
-void ActsCovarianceRotater::printMatrix(const std::string message,
+void ActsCovarianceRotater::printMatrix(const std::string &message,
 					Acts::BoundSymMatrix matrix)
 {
  

--- a/offline/packages/trackreco/ActsCovarianceRotater.cc
+++ b/offline/packages/trackreco/ActsCovarianceRotater.cc
@@ -90,10 +90,9 @@ Acts::BoundSymMatrix ActsCovarianceRotater::rotateSvtxTrackCovToActs(
 
 
 Acts::BoundSymMatrix ActsCovarianceRotater::rotateActsCovToSvtxTrack(
-                     const Acts::KalmanFitterResult<SourceLink>& fitOutput)
+                     const Acts::BoundParameters params)
 {
 
-  const auto& params = fitOutput.fittedParameters.value();
   auto covarianceMatrix = *params.covariance();
   
   printMatrix("Initial Acts covariance: ", covarianceMatrix);

--- a/offline/packages/trackreco/ActsCovarianceRotater.h
+++ b/offline/packages/trackreco/ActsCovarianceRotater.h
@@ -43,7 +43,7 @@ class ActsCovarianceRotater
   
   /// Same as above, but rotate from Acts basis to global (x,y,z,px,py,pz)
   Acts::BoundSymMatrix rotateActsCovToSvtxTrack(
-	        const Acts::KalmanFitterResult<SourceLink>& fitOutput);
+						const Acts::BoundParameters params);
 
   void setVerbosity(bool verbosity) {m_verbosity = verbosity;}
 

--- a/offline/packages/trackreco/ActsCovarianceRotater.h
+++ b/offline/packages/trackreco/ActsCovarianceRotater.h
@@ -47,7 +47,7 @@ class ActsCovarianceRotater
 
   void setVerbosity(bool verbosity) {m_verbosity = verbosity;}
 
-  void printMatrix(const std::string message, Acts::BoundSymMatrix matrix);
+  void printMatrix(const std::string &message, Acts::BoundSymMatrix matrix);
 
  private:
   bool m_verbosity;

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -76,6 +76,19 @@ int ActsEvaluator::process_event(PHCompositeNode *topNode)
 
   m_svtxEvalStack->next_event(topNode);
 
+  evaluateTrackFits(topNode);
+
+  m_eventNr++;
+
+  if (Verbosity() > 1)
+    std::cout << "Finished ActsEvaluator::process_event" << std::endl;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
+{
+
   SvtxTrackEval *trackeval = m_svtxEvalStack->get_track_eval();
 
   std::map<const unsigned int, Trajectory>::iterator trackIter;
@@ -130,13 +143,9 @@ int ActsEvaluator::process_event(PHCompositeNode *topNode)
     ++iTrack;
   }
 
-  m_eventNr++;
-
-  if (Verbosity() > 1)
-    std::cout << "Finished ActsEvaluator::process_event" << std::endl;
-
-  return Fun4AllReturnCodes::EVENT_OK;
+  return;
 }
+
 
 int ActsEvaluator::End(PHCompositeNode *topNode)
 {

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -126,11 +126,13 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
 	
 	m_nMeasurements = trajState.nMeasurements;
 	m_nStates = trajState.nStates;
+	m_chi2_fit = trajState.chi2Sum;
+	m_ndf_fit = trajState.NDF;
 	
 	fillG4Particle(g4particle);
 	fillProtoTrack(actsProtoTrack, topNode);
-	fillFittedTrackParams(traj);
-	visitTrackStates(traj, topNode);
+	fillFittedTrackParams(traj, trackTip);
+	visitTrackStates(traj,trackTip, topNode);
 	
 	m_trackTree->Fill();
 
@@ -160,11 +162,12 @@ int ActsEvaluator::ResetEvent(PHCompositeNode *topNode)
 }
 
 
-void ActsEvaluator::visitTrackStates(const Trajectory traj, PHCompositeNode *topNode)
+void ActsEvaluator::visitTrackStates(const Trajectory traj, 
+				     const size_t &trackTip,
+				     PHCompositeNode *topNode)
 {
 
   const auto &[trackTips, mj] = traj.trajectory();
-  auto &trackTip = trackTips.front();
 
   mj.visitBackwards(trackTip, [&](const auto &state) {
     /// Only fill the track states with non-outlier measurement
@@ -767,11 +770,10 @@ void ActsEvaluator::fillProtoTrack(ActsTrack track, PHCompositeNode *topNode)
 
 }
 
-void ActsEvaluator::fillFittedTrackParams(const Trajectory traj)
+void ActsEvaluator::fillFittedTrackParams(const Trajectory traj, 
+					  const size_t &trackTip)
 {
   m_hasFittedParams = false;
-  const auto &[trackTips, mj] = traj.trajectory();
-  auto &trackTip = trackTips.front();
 
   /// If it has track parameters, fill the values
   if (traj.hasTrackParameters(trackTip))

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -637,6 +637,7 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj, PHCompositeNode *top
 
   return;
 }
+
 TrkrDefs::cluskey ActsEvaluator::getClusKey(const unsigned int hitID)
 {
   TrkrDefs::cluskey clusKey = 0;

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -89,6 +89,7 @@ class ActsEvaluator : public SubsysReco
   /// Acts tree values
   int m_eventNr{0};
   int m_trajNr{0};
+  int m_trackNr{0};
 
   unsigned long m_t_barcode{0};  /// Truth particle barcode
   int m_t_charge{0};             /// Truth particle charge

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -64,8 +64,10 @@ class ActsEvaluator : public SubsysReco
   void initializeTree();
   void fillG4Particle(PHG4Particle *part);
   void fillProtoTrack(ActsTrack track, PHCompositeNode *topNode);
-  void fillFittedTrackParams(const Trajectory traj);
-  void visitTrackStates(const Trajectory traj, PHCompositeNode *topNode);
+  void fillFittedTrackParams(const Trajectory traj, const size_t &trackTip);
+  void visitTrackStates(const Trajectory traj,
+			const size_t &trackTip, 
+			PHCompositeNode *topNode);
   void clearTrackVariables();
   Acts::Vector3D getGlobalTruthHit(PHCompositeNode *topNode, 
 				   const unsigned int hitID,
@@ -157,7 +159,9 @@ class ActsEvaluator : public SubsysReco
   float m_x_fit{-99.};            /// fitted parameter global PCA x
   float m_y_fit{-99.};            /// fitted parameter global PCA y
   float m_z_fit{-99.};            /// fitted parameter global PCA z
-
+  float m_chi2_fit{-99.};         /// fitted parameter chi2
+  float m_ndf_fit{-99.};         /// fitted parameter ndf
+  
   int m_nPredicted{0};                   /// number of states with predicted parameter
   std::vector<bool> m_prt;               /// predicted status
   std::vector<float> m_eLOC0_prt;        /// predicted parameter eLOC0

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -58,6 +58,9 @@ class ActsEvaluator : public SubsysReco
 
  private:
   int getNodes(PHCompositeNode *topNode);
+  
+  void evaluateTrackFits(PHCompositeNode *topNode);
+
   void initializeTree();
   void fillG4Particle(PHG4Particle *part);
   void fillProtoTrack(ActsTrack track, PHCompositeNode *topNode);

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -130,6 +130,7 @@ ACTS_LIBS = \
   -lActsExamplesCommon \
   -lActsJsonPlugin \
   -lActsExamplesFitting \
+  -lActsExamplesTrackFinding \
   -lActsExamplesDetectorTGeo \
   -lActsExamplesFramework \
   -lActsExamplesIoRoot \

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -78,7 +78,8 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
   std::vector<FW::TrackParameters> trackSeeds;
 
   ActsCovarianceRotater *rotater = new ActsCovarianceRotater();
-  
+  rotater->setVerbosity(Verbosity());
+
   for (SvtxTrackMap::Iter trackIter = m_trackMap->begin();
        trackIter != m_trackMap->end(); ++trackIter)
   {
@@ -103,9 +104,26 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
                                  track->get_py() * Acts::UnitConstants::GeV,
                                  track->get_pz() * Acts::UnitConstants::GeV);
 
+    if(Verbosity() > 0)
+      {
+	std::cout << PHWHERE << std::endl;
+	std::cout << " seedPos " << seedPos[0] << "  " << seedPos[1] << "  " << seedPos[2] << std::endl;
+	std::cout << " seedMom " << seedMom[0] << "  " << seedMom[1] << "  " << seedMom[2] << std::endl;
+	// diagonal track cov is square of (err_x_local, err_y_local,  err_phi, err_theta, err_q/p, err_time) 
+	std::cout << " seedCov: " << std::endl;
+	for(unsigned int irow = 0; irow < seedCov.rows(); ++irow)
+	  {
+	    for(unsigned int icol = 0; icol < seedCov.cols(); ++icol)
+	      {
+		std::cout << seedCov(irow,icol) << "  ";
+	      }
+	    std::cout << std::endl;
+	  }
+      }
+
     // just set to 10 ns for now?
     const double trackTime = 10 * Acts::UnitConstants::ns;
-    const int trackQ = track->get_charge();
+    const int trackQ = -track->get_charge();  // charge is set in PHHoughTrackSeeding, copied over in PHGenFitTrkProp. Sign convention is apparently opposite here. Mag field sign?
 
     const FW::TrackParameters trackSeed(seedCov, seedPos, seedMom, 
 					trackQ * Acts::UnitConstants::e, 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -60,12 +60,15 @@ PHActsTrkFitter::~PHActsTrkFitter()
 
 int PHActsTrkFitter::Setup(PHCompositeNode* topNode)
 {
+  if(Verbosity() > 1)
+    std::cout << "Setup PHActsTrkFitter" << std::endl;
+  
   if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
     return Fun4AllReturnCodes::ABORTEVENT;
   
   if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
     return Fun4AllReturnCodes::ABORTEVENT;
-
+  
   fitCfg.fit = FW::TrkrClusterFittingAlgorithm::makeFitterFunction(
                m_tGeometry->tGeometry,
 	       m_tGeometry->magField,
@@ -76,6 +79,10 @@ int PHActsTrkFitter::Setup(PHCompositeNode* topNode)
       m_timeFile = new TFile("ActsTimeFile.root","RECREATE");
       h_eventTime = new TH1F("h_eventTime",";time [ms]",100,0,100);
     }		 
+  
+  if(Verbosity() > 1)
+    std::cout << "Finish PHActsTrkFitter Setup" << std::endl;
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -312,6 +319,7 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
 
 int PHActsTrkFitter::getNodes(PHCompositeNode* topNode)
 {
+  
   m_actsProtoTracks = findNode::getClass<std::map<unsigned int, ActsTrack>>(topNode, "ActsTrackMap");
 
   if (!m_actsProtoTracks)

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -262,7 +262,7 @@ void PHActsTrkFitter::updateSvtxTrack(const Acts::KalmanFitterResult<SourceLink>
     {
       ActsCovarianceRotater *rotater = new ActsCovarianceRotater();
       Acts::BoundSymMatrix rotatedCov = 
-	rotater->rotateActsCovToSvtxTrack(fitOutput);
+	rotater->rotateActsCovToSvtxTrack(fitOutput.fittedParameters.value());
       
       for(int i = 0; i < 6; i++)
 	{

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -28,6 +28,7 @@
 #include <Acts/Surfaces/PlaneSurface.hpp>
 #include <Acts/Surfaces/Surface.hpp>
 #include <Acts/EventData/MultiTrajectory.hpp>
+#include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 
 #include <ACTFW/EventData/Track.hpp>
 #include <ACTFW/Framework/AlgorithmContext.hpp>
@@ -118,13 +119,16 @@ int PHActsTrkFitter::Process()
     std::vector<SourceLink> sourceLinks = track.getSourceLinks();
     FW::TrackParameters trackSeed = track.getTrackParams();
       
-    if(Verbosity() > 10)
+    if(Verbosity() > 1)
       {
 	std::cout << " Processing proto track with position:" 
 		  << trackSeed.position() << std::endl 
-		  << "momentum: " << trackSeed.momentum() << std::endl;
+		  << "momentum: " << trackSeed.momentum() 
+		  << " corresponding to SvtxTrack key "<< trackKey
+		  << std::endl;
 
       }
+
     /// Call KF now. Have a vector of sourceLinks corresponding to clusters
     /// associated to this track and the corresponding track seed which
     /// corresponds to the PHGenFitTrkProp track seeds
@@ -136,7 +140,6 @@ int PHActsTrkFitter::Process()
       &(*pSurface));
   
     auto result = fitCfg.fit(sourceLinks, trackSeed, kfOptions);
-
 
     /// Check that the track fit result did not return an error
     if (result.ok())
@@ -151,9 +154,6 @@ int PHActsTrkFitter::Process()
 
       if (fitOutput.fittedParameters)
       {
-	/// Get position, momentum from the Acts output. Update the values of
-	/// the proto track
-        updateSvtxTrack(fitOutput, trackKey);
 
 	indexedParams.emplace(fitOutput.trackTip, fitOutput.fittedParameters.value());
 
@@ -165,11 +165,17 @@ int PHActsTrkFitter::Process()
                     << std::endl;
           std::cout << " momentum : " << params.momentum().transpose()
                     << std::endl;
+	  std::cout << "For trackTip == " << fitOutput.trackTip << std::endl;
         }
       }
 
       Trajectory trajectory(fitOutput.fittedStates, trackTips, indexedParams);
-     
+
+      /// Get position, momentum from the Acts output. Update the values of
+      /// the proto track
+      if(fitOutput.fittedParameters)
+	updateSvtxTrack(trajectory, trackKey);
+
       /// Insert a new entry into the map
       m_actsFitResults->insert(
 	   std::pair<const unsigned int, Trajectory>(trackKey, trajectory));
@@ -240,9 +246,16 @@ int PHActsTrkFitter::End(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void PHActsTrkFitter::updateSvtxTrack(const Acts::KalmanFitterResult<SourceLink>& fitOutput, const unsigned int trackKey)
+void PHActsTrkFitter::updateSvtxTrack(Trajectory traj, 
+				      const unsigned int trackKey)
 {
-  const auto& params = fitOutput.fittedParameters.value();
+  const auto &[trackTips, mj] = traj.trajectory();
+  /// only one track tip in the track fit Trajectory
+  auto &trackTip = trackTips.front();
+  auto trajState =
+    Acts::MultiTrajectoryHelpers::trajectoryState(mj, trackTip);
+
+  const auto& params = traj.trackParameters(trackTip);
  
   SvtxTrackMap::Iter trackIter = m_trackMap->find(trackKey);
   SvtxTrack *track = trackIter->second;
@@ -254,15 +267,14 @@ void PHActsTrkFitter::updateSvtxTrack(const Acts::KalmanFitterResult<SourceLink>
   track->set_px(params.momentum()(0));
   track->set_py(params.momentum()(1));
   track->set_pz(params.momentum()(2));
-
-  /// This will contain the chi2/ndf
-  Acts::MultiTrajectory<SourceLink> states = fitOutput.fittedStates;
+  track->set_chisq(trajState.chi2Sum);
+  track->set_ndf(trajState.NDF);
 
   if(params.covariance())
     {
       ActsCovarianceRotater *rotater = new ActsCovarianceRotater();
       Acts::BoundSymMatrix rotatedCov = 
-	rotater->rotateActsCovToSvtxTrack(fitOutput.fittedParameters.value());
+	rotater->rotateActsCovToSvtxTrack(params);
       
       for(int i = 0; i < 6; i++)
 	{

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -78,7 +78,7 @@ class PHActsTrkFitter : public PHTrackFitting
   int createNodes(PHCompositeNode*);
 
   /// Convert the acts track fit result to an svtx track
-  void updateSvtxTrack(const FitResult& fitOutput, const unsigned int trackKey);
+  void updateSvtxTrack(Trajectory traj, const unsigned int trackKey);
 
   /// Map of Acts fit results and track key to be placed on node tree
   std::map<const unsigned int, Trajectory> 

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -54,9 +54,11 @@ PHActsTrkProp::PHActsTrkProp(const std::string& name)
   , m_nBadFits(0)
   , m_tGeometry(nullptr)
   , m_trackMap(nullptr)
+  , m_actsProtoTracks(nullptr)
   , m_actsFitResults(nullptr)
   , m_hitIdClusKey(nullptr)
   , m_sourceLinks(nullptr)
+  , m_topNode(nullptr)
 {
   Verbosity(0);
 }
@@ -151,7 +153,7 @@ int PHActsTrkProp::Process()
     const unsigned int trackKey = trackIter->first;
 
     FW::TrackParameters trackSeed = track.getTrackParams();
-
+  
     /// Construct the options to pass to the CKF.
     /// SourceLinkSelector set in Init()
     Acts::CombinatorialKalmanFilterOptions<SourceLinkSelector> ckfOptions(

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -151,8 +151,8 @@ int PHActsTrkProp::Process()
 				   track->get_py(),
 				   track->get_pz());
       
-      // just set to 40 ns for now?
-      const double trackTime = 40 * Acts::UnitConstants::ns;
+      // just set to 10 ns for now
+      const double trackTime = 10 * Acts::UnitConstants::ns;
       const int trackQ = track->get_charge();
       
       const FW::TrackParameters trackSeed(seedCov, seedPos,

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -67,6 +67,8 @@ PHActsTrkProp::PHActsTrkProp(const std::string& name)
 
 int PHActsTrkProp::Setup(PHCompositeNode* topNode)
 {
+  if(Verbosity() > 1)
+    std::cout << "Setup PHActsTrkProp" << std::endl;
   createNodes(topNode);
   
   if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
@@ -86,9 +88,10 @@ int PHActsTrkProp::Setup(PHCompositeNode* topNode)
   findCfg.finder = FW::TrkrClusterFindingAlgorithm::makeFinderFunction(
                    m_tGeometry->tGeometry,
 		   m_tGeometry->magField,
-		   Acts::Logging::VERBOSE);
+		   Acts::Logging::INFO);
 
-
+  if(Verbosity() > 1)
+    std::cout <<" Finish PHActsTrkProp setup" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -128,6 +131,7 @@ int PHActsTrkProp::Process()
     }
 
   ActsCovarianceRotater *rotater = new ActsCovarianceRotater();
+  rotater->setVerbosity(Verbosity());
 
   for (SvtxTrackMap::Iter trackIter = m_trackMap->begin();
        trackIter != m_trackMap->end(); ++trackIter)
@@ -218,6 +222,9 @@ int PHActsTrkProp::Process()
 	
     }
 
+  if(Verbosity() > 1)
+    std::cout << "Finished process_event for PHActsTrkProp" << std::endl;
+
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -260,14 +267,15 @@ void PHActsTrkProp::createNodes(PHCompositeNode* topNode)
   }
 
 
-  m_actsProtoTracks = findNode::getClass<std::vector<ActsTrack>>(topNode, "ActsProtoTracks");
+  m_actsProtoTracks = findNode::getClass<std::map<unsigned int, ActsTrack>>(topNode, "ActsProtoTracks");
 
   if(!m_actsProtoTracks)
     {
-      m_actsProtoTracks = new std::vector<ActsTrack>;
+      m_actsProtoTracks = new std::map<unsigned int, ActsTrack>;
 
-      PHDataNode<std::vector<ActsTrack>> *protoTrackNode =
-        new PHDataNode<std::vector<ActsTrack>>(m_actsProtoTracks, "ActsProtoTracks");
+      PHDataNode<std::map<unsigned int, ActsTrack>> *protoTrackNode =
+        new PHDataNode<std::map<unsigned int, ActsTrack>>
+	(m_actsProtoTracks, "ActsTrackMap");
       
       svtxNode->addNode(protoTrackNode);
 

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -126,7 +126,6 @@ int PHActsTrkProp::Process()
     }
 
   ActsCovarianceRotater *rotater = new ActsCovarianceRotater();
-  
 
   for (SvtxTrackMap::Iter trackIter = m_trackMap->begin();
        trackIter != m_trackMap->end(); ++trackIter)
@@ -153,7 +152,7 @@ int PHActsTrkProp::Process()
       
       // just set to 10 ns for now
       const double trackTime = 10 * Acts::UnitConstants::ns;
-      const int trackQ = track->get_charge();
+      const int trackQ = -1*track->get_charge();
       
       const FW::TrackParameters trackSeed(seedCov, seedPos,
 					  seedMom, trackQ, trackTime);

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -151,7 +151,7 @@ int PHActsTrkProp::Process()
     const unsigned int trackKey = trackIter->first;
 
     FW::TrackParameters trackSeed = track.getTrackParams();
-    
+
     /// Construct the options to pass to the CKF.
     /// SourceLinkSelector set in Init()
     Acts::CombinatorialKalmanFilterOptions<SourceLinkSelector> ckfOptions(
@@ -168,7 +168,6 @@ int PHActsTrkProp::Process()
       if(result.ok())
 	{
 	  const CKFFitResult& fitOutput = result.value();
-	  auto parameterMap = fitOutput.fittedParameters;
 
 	  Trajectory traj(fitOutput.fittedStates,
 			  fitOutput.trackTips,
@@ -183,7 +182,8 @@ int PHActsTrkProp::Process()
 	  m_actsFitResults->insert(std::pair<const unsigned int, Trajectory>
 				   (trackKey, FW::TrkrClusterMultiTrajectory()));
 
-	  /// Update SvtxTrack to be a bad fit
+	  /// Don't need to update SvtxTrack to be a bad fit since the 
+	  /// track map will get wiped anyway in updateSvtxTrackMap
 	  
 	  m_nBadFits++;
 	}

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -18,6 +18,7 @@
 #include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
 #include <ACTFW/EventData/Track.hpp>
 #include <ACTFW/TrackFinding/TrkrClusterFindingAlgorithm.hpp>
+#include <ACTFW/EventData/TrkrClusterMultiTrajectory.hpp>
 
 #include <memory>
 #include <string>
@@ -48,6 +49,8 @@ using SourceLink = FW::Data::TrkrClusterSourceLink;
 using SourceLinkSelector = Acts::CKFSourceLinkSelector;
 using SourceLinkSelectorConfig = typename SourceLinkSelector::Config;
 
+using Trajectory = FW::TrkrClusterMultiTrajectory;
+
 class PHActsTrkProp : public PHTrackPropagating
 {
  public:
@@ -66,9 +69,15 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Process each event by calling the fitter
   int Process();
 
+  /// Reset maps event by event
+  int ResetEvent(PHCompositeNode *topNode);
+
  private:
   /// Event counter
   int m_event;
+  
+  /// Num bad fit counter
+  int m_nBadFits;
 
   /// Get all the nodes
   int getNodes(PHCompositeNode *topNode);
@@ -83,6 +92,9 @@ class PHActsTrkProp : public PHTrackPropagating
 
   /// Acts proto tracks to be put on the node tree by this module
   std::vector<ActsTrack> *m_actsProtoTracks;
+  
+  /// Acts MultiTrajectories for ActsEvaluator
+  std::map<const unsigned int, Trajectory> *m_actsFitResults;
 
   /// Map of cluster keys to hit ids, for debugging statements
   std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey;
@@ -97,6 +109,7 @@ class PHActsTrkProp : public PHTrackPropagating
  
   /// Configuration containing the finding function instance
   FW::TrkrClusterFindingAlgorithm::Config findCfg;
+
 
 };
 

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -3,6 +3,7 @@
 
 #include "PHTrackPropagating.h"
 #include "PHActsSourceLinks.h"
+#include "ActsTrack.h"
 
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
@@ -89,6 +90,8 @@ class PHActsTrkProp : public PHTrackPropagating
 
   void updateSvtxTrackMap(PHCompositeNode *topNode);
 
+  std::vector<SourceLink> getEventSourceLinks();
+
   void getTrackClusters(const size_t& trackTip, Trajectory traj,
 			SvtxTrack &track);
 
@@ -99,6 +102,8 @@ class PHActsTrkProp : public PHTrackPropagating
 
   /// Track map with Svtx objects
   SvtxTrackMap *m_trackMap;
+
+  std::map<unsigned int, ActsTrack> *m_actsProtoTracks;
   
   /// Acts MultiTrajectories for ActsEvaluator
   std::map<const unsigned int, Trajectory> *m_actsFitResults;
@@ -110,7 +115,7 @@ class PHActsTrkProp : public PHTrackPropagating
   /// SourceLink is defined as TrkrClusterSourceLink elsewhere
   std::map<unsigned int, SourceLink> *m_sourceLinks;
 
-PHCompositeNode *m_topNode;
+  PHCompositeNode *m_topNode;
 
   /// SourceLinkSelector to help the CKF identify which source links 
   /// may belong to a track seed based on geometry considerations

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <map>
 
+class PHCompositeNode;
 class ActsTrack;
 class MakeActsGeometry;
 class SvtxTrack;
@@ -86,7 +87,13 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Create new nodes
   void createNodes(PHCompositeNode *topNode);
 
-  void updateSvtxTrackMap();
+  void updateSvtxTrackMap(PHCompositeNode *topNode);
+
+  void getTrackClusters(const size_t& trackTip, Trajectory traj,
+			SvtxTrack &track);
+
+  /// Return cluster key from hit ID as determined in map from PHActsSourceLinks
+  TrkrDefs::cluskey getClusKey(const unsigned int hitID);
 
   ActsTrackingGeometry *m_tGeometry;
 
@@ -102,6 +109,8 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Acts source links created by PHActsSourceLinks
   /// SourceLink is defined as TrkrClusterSourceLink elsewhere
   std::map<unsigned int, SourceLink> *m_sourceLinks;
+
+PHCompositeNode *m_topNode;
 
   /// SourceLinkSelector to help the CKF identify which source links 
   /// may belong to a track seed based on geometry considerations

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -91,7 +91,7 @@ class PHActsTrkProp : public PHTrackPropagating
   SvtxTrackMap *m_trackMap;
 
   /// Acts proto tracks to be put on the node tree by this module
-  std::vector<ActsTrack> *m_actsProtoTracks;
+  std::map<unsigned int, ActsTrack> *m_actsProtoTracks;
   
   /// Acts MultiTrajectories for ActsEvaluator
   std::map<const unsigned int, Trajectory> *m_actsFitResults;

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -17,7 +17,7 @@
 
 #include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
 #include <ACTFW/EventData/Track.hpp>
-#include <ACTFW/Fitting/TrkrClusterFindingAlgorithm.hpp>
+#include <ACTFW/TrackFinding/TrkrClusterFindingAlgorithm.hpp>
 
 #include <memory>
 #include <string>

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -49,6 +49,7 @@ using SourceLink = FW::Data::TrkrClusterSourceLink;
 using SourceLinkSelector = Acts::CKFSourceLinkSelector;
 using SourceLinkSelectorConfig = typename SourceLinkSelector::Config;
 
+using CKFFitResult = Acts::CombinatorialKalmanFilterResult<SourceLink>;
 using Trajectory = FW::TrkrClusterMultiTrajectory;
 
 class PHActsTrkProp : public PHTrackPropagating
@@ -85,13 +86,12 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Create new nodes
   void createNodes(PHCompositeNode *topNode);
 
+  void updateSvtxTrackMap();
+
   ActsTrackingGeometry *m_tGeometry;
 
   /// Track map with Svtx objects
   SvtxTrackMap *m_trackMap;
-
-  /// Acts proto tracks to be put on the node tree by this module
-  std::map<unsigned int, ActsTrack> *m_actsProtoTracks;
   
   /// Acts MultiTrajectories for ActsEvaluator
   std::map<const unsigned int, Trajectory> *m_actsFitResults;

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -88,10 +88,13 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Create new nodes
   void createNodes(PHCompositeNode *topNode);
 
+  /// Wipe and recreate the SvtxTrackMap with Acts output
   void updateSvtxTrackMap(PHCompositeNode *topNode);
 
+  /// Get all source links in a given event
   std::vector<SourceLink> getEventSourceLinks();
 
+  /// Iterate through the Trajectory to obtain the fitted clusters
   void getTrackClusters(const size_t& trackTip, Trajectory traj,
 			SvtxTrack &track);
 
@@ -103,12 +106,13 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Track map with Svtx objects
   SvtxTrackMap *m_trackMap;
 
+  /// Track map with ActsTracks, created in PHActsTracks
   std::map<unsigned int, ActsTrack> *m_actsProtoTracks;
   
   /// Acts MultiTrajectories for ActsEvaluator
   std::map<const unsigned int, Trajectory> *m_actsFitResults;
 
-  /// Map of cluster keys to hit ids, for debugging statements
+  /// Map of cluster keys to hit ids, for identifying clusters belonging to track
   std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey;
 
   /// Acts source links created by PHActsSourceLinks

--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -658,11 +658,13 @@ int PHGenFitTrkProp::OutputPHGenFitTrack(
   SvtxTrack* track = phtrk_iter->second;
   auto track_id = track->get_id();
   auto vertex_id = track->get_vertex_id();
+  auto track_charge = track->get_charge();
 
   // now reset the track info and rewrite it using info from the Genfit track
   track->Reset();
   track->set_id(track_id);
   track->set_vertex_id(vertex_id);
+  track->set_charge(track_charge);
   
 #ifdef _DO_FULL_FITTING_
   if (Verbosity() >= 1) _t_full_fitting->restart();


### PR DESCRIPTION
This PR updates and really makes the track propagation from Acts runnable in sPHENIX. The CKF track finder in Acts is called from `PHActsTrkProp` and the results are stored in the `SvtxTrackMap` and the `ActsFitResults` for use with the evaluator tools. This needs to be tuned pretty significantly with the source link selector object provided by Acts, as the fits are not that great at the moment.

The PR also fixes a bug in the communication between PHGenFitTrkProp and PHActsTracks which was causing some of the weird behavior we saw with the Acts track fitting previously. Apparently the GenFit track propagation code resets the track charge but does not re-initialize it, and GenFit does not care about this. Acts does and this was part of the reason there were very poor track fits previously.

This PR also corresponds to the [changes](https://github.com/sPHENIX-Collaboration/acts/pull/15) that will be merged shortly into the sPHENIX/Acts repo.