### PR TITLE
Add DCA to acts eval

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -21,6 +21,7 @@
 #include <g4main/PHG4VtxPoint.h>
 
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
+#include <Acts/Utilities/Definitions.hpp>
 #include <Acts/Utilities/Units.hpp>
 
 #include <TFile.h>
@@ -838,6 +839,8 @@ void ActsEvaluator::fillFittedTrackParams(const Trajectory traj,
     m_x_fit  = boundParam.position()(0);
     m_y_fit  = boundParam.position()(1);
     m_z_fit  = boundParam.position()(2);
+    
+    calculateDCA(boundParam);
 
     return;
   }
@@ -864,6 +867,52 @@ void ActsEvaluator::fillFittedTrackParams(const Trajectory traj,
 
   return;
 }
+
+void ActsEvaluator::calculateDCA(const Acts::BoundParameters param)
+{
+
+  Acts::Vector3D pos = param.position();
+  Acts::Vector3D mom = param.momentum();
+  Acts::BoundSymMatrix cov = Acts::BoundSymMatrix::Zero();
+  if(param.covariance())
+    cov = param.covariance().value();
+
+  Acts::ActsSymMatrixD<3> posCov;
+  for(int i = 0; i < 3; ++i)
+    {
+      for(int j = 0; j < 3; ++j)
+	{
+	  posCov(i,j) = cov(i,j);
+	} 
+    }
+
+  Acts::Vector3D r = mom.cross(Acts::Vector3D(0.,0.,1.));
+  float phi = atan2(r(1), r(0));
+
+  Acts::RotationMatrix3D rot;
+  Acts::RotationMatrix3D rot_T;
+  rot(0,0) = cos(phi);
+  rot(0,1) = -sin(phi);
+  rot(0,2) = 0;
+  rot(1,0) = sin(phi);
+  rot(1,1) = cos(phi);
+  rot(1,2) = 0;
+  rot(2,0) = 0;
+  rot(2,1) = 0;
+  rot(2,2) = 1;
+  
+  rot_T = rot.transpose();
+
+  Acts::Vector3D pos_R = rot * pos;
+  Acts::ActsSymMatrixD<3> rotCov = rot * posCov * rot_T;
+
+  m_dca3Dxy = pos_R(0);
+  m_dca3Dz = pos_R(2);
+  m_dca3DxyCov = rotCov(0,0);
+  m_dca3DzCov = rotCov(2,2);
+  
+}
+
 void ActsEvaluator::fillG4Particle(PHG4Particle *part)
 {
   SvtxTruthEval *trutheval = m_svtxEvalStack->get_truth_eval();
@@ -1187,6 +1236,10 @@ void ActsEvaluator::initializeTree()
   m_trackTree->Branch("g_x_fit" , &m_x_fit);
   m_trackTree->Branch("g_y_fit" , &m_y_fit);
   m_trackTree->Branch("g_z_fit" , &m_z_fit);
+  m_trackTree->Branch("g_dca3Dxy_fit" , &m_dca3Dxy);
+  m_trackTree->Branch("g_dca3Dz_fit" , &m_dca3Dz);
+  m_trackTree->Branch("g_dca3Dxy_cov" , &m_dca3DxyCov);
+  m_trackTree->Branch("g_dca3Dz_cov" , &m_dca3DzCov);
 
   m_trackTree->Branch("g_protoTrackPx", &m_protoTrackPx);
   m_trackTree->Branch("g_protoTrackPy", &m_protoTrackPy);

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -69,6 +69,9 @@ class ActsEvaluator : public SubsysReco
 			const size_t &trackTip, 
 			PHCompositeNode *topNode);
   void clearTrackVariables();
+  
+  void calculateDCA(const Acts::BoundParameters param);
+
   Acts::Vector3D getGlobalTruthHit(PHCompositeNode *topNode, 
 				   const unsigned int hitID,
 				   float &_gt);
@@ -161,8 +164,12 @@ class ActsEvaluator : public SubsysReco
   float m_y_fit{-99.};            /// fitted parameter global PCA y
   float m_z_fit{-99.};            /// fitted parameter global PCA z
   float m_chi2_fit{-99.};         /// fitted parameter chi2
-  float m_ndf_fit{-99.};         /// fitted parameter ndf
-  
+  float m_ndf_fit{-99.};          /// fitted parameter ndf
+  float m_dca3Dxy{-99.};          /// fitted parameter 3D DCA in xy plane
+  float m_dca3Dz{-99.};           /// fitted parameter 3D DCA in z plane
+  float m_dca3DxyCov{-99.};       /// fitted parameter 3D DCA covariance in xy
+  float m_dca3DzCov{-99.};        /// fitted parameter 3D DCA covariance in z
+
   int m_nPredicted{0};                   /// number of states with predicted parameter
   std::vector<bool> m_prt;               /// predicted status
   std::vector<float> m_eLOC0_prt;        /// predicted parameter eLOC0


### PR DESCRIPTION
This PR adds the 3D DCA to the acts evaluator, following a similar procedure in `PHGenFitTrkFitter`