### PR TITLE
Upstream/master micromegas

### DIFF
--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -184,6 +184,7 @@ void CylinderGeomMicromegas::identify( std::ostream& out ) const
   out << "CylinderGeomMicromegas" << std::endl;
   out << "layer: " << m_layer << std::endl;
   out << "segmentation_type: " << (m_segmentation_type == MicromegasDefs::SegmentationType::SEGMENTATION_PHI ? "SEGMENTATION_PHI":"SEGMENTATION_Z") << std::endl;
+  out << "drift_direction: " << (m_drift_direction == MicromegasDefs::DriftDirection::INWARD ? "INWARD":"OUTWARD") << std::endl;
   out << "radius: " << m_radius << "cm" << std::endl;
   out << "thickness: " << m_thickness << "cm" << std::endl;
   out << "zmin: " << m_zmin << "cm" << std::endl;

--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -27,15 +27,37 @@ namespace
 }
 
 //________________________________________________________________________________
-std::pair<int,int> CylinderGeomMicromegas::find_strip( const TVector3& world_location ) const
+int CylinderGeomMicromegas::find_tile( const TVector3& world_location ) const
 {
+  // check radius
+  if( !check_radius(world_location) ) return -1;
 
   // convert to polar coordinates
-  const auto radius = std::sqrt( square( world_location.x() ) + square( world_location.y() ) );
   const auto phi = std::atan2( world_location.y(), world_location.x() );
   const auto z = world_location.z();
 
-  if( std::abs( radius - m_radius ) > m_thickness/2 ) return std::make_pair( -1, -1 );
+  for( size_t itile = 0; itile < m_tiles.size(); ++itile )
+  {
+    const auto& tile = m_tiles.at(itile);
+
+    if( std::abs( z - tile.m_centerZ ) > tile.m_sizeZ/2 ) continue;
+    if( std::abs( bind_angle( phi - tile.m_centerPhi ) ) > tile.m_sizePhi/2 ) continue;
+
+    return itile;
+  }
+
+  return -1;
+}
+
+//________________________________________________________________________________
+std::pair<int,int> CylinderGeomMicromegas::find_strip( const TVector3& world_location ) const
+{
+  // check radius
+  if( !check_radius(world_location) ) return std::make_pair(-1,-1);
+
+  // convert to polar coordinates
+  const auto phi = std::atan2( world_location.y(), world_location.x() );
+  const auto z = world_location.z();
 
   for( size_t itile = 0; itile < m_tiles.size(); ++itile )
   {
@@ -59,7 +81,37 @@ std::pair<int,int> CylinderGeomMicromegas::find_strip( const TVector3& world_loc
 
   // no tile found
   return  std::make_pair( -1, -1 );
+}
 
+//________________________________________________________________________________
+int CylinderGeomMicromegas::find_strip( uint tileid, const TVector3& world_location ) const
+{
+  // check radius
+  if( !check_radius(world_location) ) return -1;
+
+  // convert to polar coordinates
+  const auto phi = std::atan2( world_location.y(), world_location.x() );
+  const auto z = world_location.z();
+
+  // get tile
+  const auto& tile = m_tiles.at(tileid);
+
+  if( std::abs( z - tile.m_centerZ ) > tile.m_sizeZ/2 ) return -1;
+  if( std::abs( bind_angle( phi - tile.m_centerPhi ) ) > tile.m_sizePhi/2 ) return -1;
+
+  // we found a tile to which the hit belong
+  // calculate strip index, depending on cylinder direction
+  switch( m_segmentation_type )
+  {
+    case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
+    return (int) std::floor( (bind_angle( phi - tile.m_centerPhi ) + tile.m_sizePhi/2)*m_radius/m_pitch );
+
+    case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
+    return (int) std::floor( (z - tile.m_centerZ + tile.m_sizeZ/2)/m_pitch );
+  }
+
+  // unreachable
+  return -1;
 }
 
 //________________________________________________________________________________
@@ -124,7 +176,6 @@ TVector3 CylinderGeomMicromegas::get_world_coordinate( uint tileid, uint stripnu
 
     // unreachable
     return TVector3();
-
 }
 
 //________________________________________________________________________________
@@ -139,4 +190,11 @@ void CylinderGeomMicromegas::identify( std::ostream& out ) const
   out << "zmax: " << m_zmax << "cm" << std::endl;
   out << "pitch: " << m_pitch << "cm" << std::endl;
   out << std::endl;
+}
+
+//________________________________________________________________________________
+bool  CylinderGeomMicromegas::check_radius( const TVector3& world_location ) const
+{
+  const auto radius = std::sqrt( square( world_location.x() ) + square( world_location.y() ) );
+  return std::abs( radius - m_radius ) <= m_thickness/2;
 }

--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -80,6 +80,23 @@ double CylinderGeomMicromegas::get_strip_length( uint tileid ) const
 }
 
 //________________________________________________________________________________
+uint CylinderGeomMicromegas::get_strip_count( uint tileid ) const
+{
+  assert( tileid < m_tiles.size() );
+  switch( m_segmentation_type )
+  {
+    case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
+    return std::floor( m_tiles[tileid].m_sizePhi*m_radius/m_pitch );
+
+    case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
+    return std::floor( m_tiles[tileid].m_sizeZ/m_pitch );
+  }
+
+  // unreachable
+  return 0;
+}
+
+//________________________________________________________________________________
 TVector3 CylinderGeomMicromegas::get_world_coordinate( uint tileid, uint stripnum ) const
 {
     assert( tileid < m_tiles.size() );

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -43,8 +43,14 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! segmentation type
   MicromegasDefs::SegmentationType get_segmentation_type() const {return m_segmentation_type;}
 
+  //! get tile for a given world location
+  int find_tile( const TVector3& ) const;
+
   //! get tile and strip for a give world location
   std::pair<int,int> find_strip( const TVector3& ) const;
+
+  //! get strip for a give world location and tile
+  int find_strip( uint tileid, const TVector3& ) const;
 
   //! get strip length for a given tile
   double get_strip_length( uint tileid ) const;
@@ -76,14 +82,28 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
 
   private:
 
+  // check if hit radius matches this cylinder
+  bool check_radius( const TVector3& ) const;
+
+  //! layer id
   int m_layer = 0;
+
+  //! segmentation type
   MicromegasDefs::SegmentationType m_segmentation_type = MicromegasDefs::SegmentationType::SEGMENTATION_PHI;
+
+  //! layer radius
   double m_radius = 0;
+
+  //! layer thickness
   double m_thickness = 0;
+
+  //! layer z extend
   double m_zmin = 0;
+
+  //! layer z extend
   double m_zmax = 0;
 
-  // 1mm pitch by default
+  //! 1mm pitch by default
   double m_pitch = 0.1;
 
   //! tiles

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -49,6 +49,9 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! get strip length for a given tile
   double get_strip_length( uint tileid ) const;
 
+  //! get number of strips
+  uint get_strip_count( uint tileid ) const;
+
   //! get world location for a given tile and strip
   TVector3 get_world_coordinate( uint tileid, uint stripnum ) const;
 

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -43,6 +43,9 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! segmentation type
   MicromegasDefs::SegmentationType get_segmentation_type() const {return m_segmentation_type;}
 
+  //! drift direction
+  MicromegasDefs::DriftDirection get_drift_direction() const {return m_drift_direction;}
+
   //! get tile for a given world location
   int find_tile( const TVector3& ) const;
 
@@ -76,8 +79,13 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   void set_pitch( double value ) { m_pitch = value; }
 
   //! tiles
-  void set_tiles( const MicromegasTile::List& tiles ) { m_tiles = tiles; }
+  void set_tiles( const MicromegasTile::List& tiles ) {m_tiles = tiles;}
+
+  //! segmentation
   void set_segmentation_type( MicromegasDefs::SegmentationType value ) {m_segmentation_type = value;}
+
+  //! drift direction
+  void set_drift_direction( MicromegasDefs::DriftDirection value ) {m_drift_direction = value;}
   //@}
 
   private:
@@ -90,6 +98,9 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
 
   //! segmentation type
   MicromegasDefs::SegmentationType m_segmentation_type = MicromegasDefs::SegmentationType::SEGMENTATION_PHI;
+
+  //! drift direction
+  MicromegasDefs::DriftDirection m_drift_direction = MicromegasDefs::DriftDirection::OUTWARD;
 
   //! layer radius
   double m_radius = 0;

--- a/offline/packages/micromegas/MicromegasDefs.cc
+++ b/offline/packages/micromegas/MicromegasDefs.cc
@@ -5,17 +5,42 @@
 
 #include "MicromegasDefs.h"
 
+namespace
+{
+   //* converninece trait for underlying type
+  template<class T>
+    using underlying_type_t = typename std::underlying_type<T>::type;
+
+  //* convert an strong type enum to integral type
+  template<class T>
+    constexpr underlying_type_t<T>
+    to_underlying_type(T value) noexcept
+  { return static_cast<underlying_type_t<T>>(value);}
+ 
+}
 
 namespace MicromegasDefs
 {
 
   //________________________________________________________________
-  TrkrDefs::hitsetkey genHitSetKey(uint8_t layer, uint8_t tile )
+  TrkrDefs::hitsetkey genHitSetKey(uint8_t layer, SegmentationType type, uint8_t tile )
   {
     TrkrDefs::hitsetkey key = TrkrDefs::genHitSetKey(TrkrDefs::TrkrId::micromegasId, layer);
-    TrkrDefs::hitsetkey tmp = tile;
+    
+    TrkrDefs::hitsetkey tmp = to_underlying_type(type);
+    key |= (tmp << kBitShiftSegmentation);
+
+    tmp = tile;
     key |= (tmp << kBitShiftTileId);
+        
     return key;
+  }
+
+  //________________________________________________________________
+  SegmentationType getSegmentationType(TrkrDefs::hitsetkey key)
+  {
+    TrkrDefs::hitsetkey tmp = (key >> kBitShiftSegmentation);
+    return static_cast<SegmentationType>(tmp);
   }
 
   //________________________________________________________________
@@ -46,6 +71,20 @@ namespace MicromegasDefs
     TrkrDefs::cluskey key = (tmp << TrkrDefs::kBitShiftClusId);
     key |= clusid;
     return key;
+  }
+
+  //________________________________________________________________
+  SegmentationType getSegmentationType(TrkrDefs::cluskey key)
+  {
+    TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+    return getSegmentationType( tmp );
+  }
+
+  //________________________________________________________________
+  uint8_t getTileId(TrkrDefs::cluskey key)
+  {
+    TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+    return getTileId( tmp );
   }
 
 }

--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -15,7 +15,7 @@ namespace MicromegasDefs
 {
 
   //* tells the direction along which a given cylinder is segmented
-  enum class SegmentationType
+  enum class SegmentationType: uint8_t
   {
     SEGMENTATION_Z,
     SEGMENTATION_PHI
@@ -26,8 +26,10 @@ namespace MicromegasDefs
    * Micromegas specific lower 16 bits
    * 24 - 32  tracker id
    * 16 - 24  layer
-   * 0 - 16 tile id
+   * 8 - 16 segmentation type
+   * 0 - 8 tile id
    */
+  static constexpr unsigned int kBitShiftSegmentation __attribute__((unused)) = 8;
   static constexpr unsigned int kBitShiftTileId __attribute__((unused)) = 0;
 
   //! bit shift for hit key
@@ -42,12 +44,19 @@ namespace MicromegasDefs
    * Generate a hitsetkey for the mvtx. The tracker id is known
    * implicitly and used in the function.
    */
-  TrkrDefs::hitsetkey genHitSetKey(uint8_t layer, uint8_t tile );
+  TrkrDefs::hitsetkey genHitSetKey(uint8_t layer, SegmentationType segmentation, uint8_t tile );
 
   /*!
-   * @brief Get the stave id from hitsetkey
+   * @brief Get the segmentation type from hitsetkey
    * @param[in] hitsetkey
-   * @param[out] stave id
+   * @param[out] segmentation
+   s*/
+  SegmentationType getSegmentationType(TrkrDefs::hitsetkey);
+
+  /*!
+   * @brief Get the tile id from hitsetkey
+   * @param[in] hitsetkey
+   * @param[out] tile id
    s*/
   uint8_t getTileId(TrkrDefs::hitsetkey);
 
@@ -67,6 +76,21 @@ namespace MicromegasDefs
    * @param[out] cluskey
    */
   TrkrDefs::cluskey genClusterKey(TrkrDefs::hitsetkey hskey, uint32_t clusid);
+  
+  /*!
+   * @brief Get the segmentation type from cluster key
+   * @param[in] cluskey
+   * @param[out] segmentation
+   s*/
+  SegmentationType getSegmentationType(TrkrDefs::cluskey);
+
+  /*!
+   * @brief Get the tile id from cluster key
+   * @param[in] cluskey
+   * @param[out] tile id
+   s*/
+  uint8_t getTileId(TrkrDefs::cluskey);
+
 }
 
 #endif

--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -14,11 +14,19 @@
 namespace MicromegasDefs
 {
 
-  //* tells the direction along which a given cylinder is segmented
+  //! tells the direction along which a given cylinder is segmented
   enum class SegmentationType: uint8_t
   {
     SEGMENTATION_Z,
     SEGMENTATION_PHI
+  };
+
+  //! tells the drift direction for a given micromegas layer
+  /*! this is needed for properly implementing transverse diffusion in the layer */
+  enum class DriftDirection: uint8_t
+  {
+    INWARD,
+    OUTWARD
   };
 
   /*!
@@ -76,7 +84,7 @@ namespace MicromegasDefs
    * @param[out] cluskey
    */
   TrkrDefs::cluskey genClusterKey(TrkrDefs::hitsetkey hskey, uint32_t clusid);
-  
+
   /*!
    * @brief Get the segmentation type from cluster key
    * @param[in] cluskey

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDigitizer.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDigitizer.cc
@@ -28,6 +28,15 @@
 #include <cassert>
 #include <set>
 
+namespace 
+{
+   
+  // local version of std::clamp, which is only available for c++17
+  template<class T>
+    constexpr const T& clamp( const T& v, const T& lo, const T& hi )
+  { return (v < lo) ? lo : (hi < v) ? hi : v; }
+ 
+}
 //____________________________________________________________________________
 PHG4MicromegasDigitizer::PHG4MicromegasDigitizer(const std::string &name)
   : SubsysReco(name)
@@ -118,7 +127,7 @@ int PHG4MicromegasDigitizer::process_event(PHCompositeNode *topNode)
       if( voltage > m_adc_threshold*m_volt_per_electron_noise )
       {
         // keep hit, update adc
-        hit->setAdc( std::clamp<uint>( voltage*m_adc_per_volt, 0, 1023 ) );        
+        hit->setAdc( clamp<uint>( voltage*m_adc_per_volt, 0, 1023 ) );        
       } else {
         // mark hit as removable
         removed_keys.insert( key );

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDigitizer.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDigitizer.h
@@ -11,12 +11,14 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <phparameter/PHParameterInterface.h>
+
 #include <gsl/gsl_rng.h>
 #include <memory>
 
 class PHCompositeNode;
 
-class PHG4MicromegasDigitizer : public SubsysReco
+class PHG4MicromegasDigitizer : public SubsysReco, public PHParameterInterface
 {
 
   public:
@@ -28,31 +30,42 @@ class PHG4MicromegasDigitizer : public SubsysReco
   //! event processing
   int process_event(PHCompositeNode *topNode) override;
 
-  //! adc parameters
-  void set_adc_scale(unsigned int max_adc, double energy_scale)
-  {
-    m_max_adc  = max_adc;
-    m_energy_scale = energy_scale;
-  }
-
-  //! threshold
-  void set_energy_threshold(double value)
-  { m_energy_threshold = value; }
+  //! parameters
+  void SetDefaultParameters() override;
 
   private:
 
-  // settings
-  unsigned int m_max_adc = 0;
-  double m_energy_scale = 1;
-  double m_energy_threshold = 0;
+  //! add noise to a measurement
+  double add_noise() const;
 
+  //! threshold (electrons)
+  double m_adc_threshold = 2700;
+
+  //! noise (electrons)
+  double m_enc = 670;
+  
+  //! pedestal (electrons)
+  double m_pedestal = 50000;
+  
+  //! conversion factor mv/fc
+  double m_volts_per_charge = 20;
+
+  //! conversion factor (mv/electron)
+  double m_volt_per_electron_signal = 0;
+
+  //! conversion factor (mv/electron)
+  double m_volt_per_electron_noise = 0;
+
+  //! conversion factor (adc/mv)
+  /*! this is a fixed parameter, from SAMPA */
+  static constexpr double m_adc_per_volt = 1024./2200;
+  
   //! rng de-allocator
   class Deleter
   {
     public:
     //! deletion operator
-    void operator() (gsl_rng* rng) const
-    { gsl_rng_free(rng); }
+    void operator() (gsl_rng* rng) const { gsl_rng_free(rng); }
   };
 
   //! random generator that conform with sPHENIX standard

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -257,7 +257,7 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
       const auto nelectrons = get_electrons( g4hit );
 
       // create hitset
-      TrkrDefs::hitsetkey hitsetkey = MicromegasDefs::genHitSetKey( layer, tileid );
+      TrkrDefs::hitsetkey hitsetkey = MicromegasDefs::genHitSetKey( layer, layergeom->get_segmentation_type(), tileid );
       auto hitset_it = trkrhitsetcontainer->findOrAddHitSet(hitsetkey);
 
       // generate the key for this hit

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -266,7 +266,7 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
       {
         // get strip and bound check
         const int strip = pair.first;
-        if( strip < 0 || strip >= layergeom->get_strip_count( tileid ) ) continue;
+        if( strip < 0 || strip >= (int) layergeom->get_strip_count( tileid ) ) continue;
 
         // get hit from hitset
         TrkrDefs::hitkey hitkey = MicromegasDefs::genHitKey(strip);

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -56,7 +56,12 @@ namespace
     else if( angle < -M_PI ) return angle + 2*M_PI;
     else return angle;
   }
-
+  
+  // local version of std::clamp, which is only available for c++17
+  template<class T>
+    constexpr const T& clamp( const T& v, const T& lo, const T& hi )
+  { return (v < lo) ? lo : (hi < v) ? hi : v; }
+  
   // this corresponds to integrating a gaussian centered on zero and of width sigma from xloc - pitch/2 to xloc+pitch/2
   template<class T>
     inline T get_rectangular_fraction( const T& xloc, const T& sigma, const T& pitch )
@@ -400,8 +405,8 @@ PHG4MicromegasHitReco::charge_info_t PHG4MicromegasHitReco::distribute_charge(
 
   // find relevant strip indices
   const auto strip_count = layergeom->get_strip_count( tileid );
-  const auto stripnum_min = std::clamp<int>( stripnum - 5.*sigma/pitch - 1, 0, strip_count );
-  const auto stripnum_max = std::clamp<int>( stripnum + 5*sigma/pitch + 1, 0, strip_count );
+  const auto stripnum_min = clamp<int>( stripnum - 5.*sigma/pitch - 1, 0, strip_count );
+  const auto stripnum_max = clamp<int>( stripnum + 5*sigma/pitch + 1, 0, strip_count );
 
   // prepare charge list
   charge_list_t charge_list;

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
@@ -15,10 +15,10 @@
 #include <fun4all/SubsysReco.h>
 
 #include <gsl/gsl_rng.h>
-#include <map>
 #include <memory>
 #include <string>
-#include <utility>  // for pair
+#include <utility>  
+#include <vector>
 
 class CylinderGeomMicromegas;
 class PHCompositeNode;
@@ -51,21 +51,21 @@ class PHG4MicromegasHitReco : public SubsysReco, public PHParameterInterface
   //! setup tiles definition in CylinderGeom
   void setup_tiles(PHCompositeNode*);
 
-  //! stores strip number and corresponding charge fraciton
-  using charge_pair_t = std::pair<int, double>;
-
-  //! list of charge fractions
-  using charge_list_t = std::vector<charge_pair_t>;
-
-  //! tile and list of charge fractions
-  using charge_info_t = std::pair<int, charge_list_t>;
-
   //! get total number of electrons collected for a give g4hit
   /*! this accounts for the number of primary electrons, the detector gain, and fluctuations */
-  uint get_electrons( PHG4Hit* ) const;
+  uint get_primary_electrons( PHG4Hit* ) const;
+
+  //! get single electron amplification
+  uint get_single_electron_amplification() const;
+
+  //! stores strip number and corresponding charge fraction
+  using charge_pair_t = std::pair<int, double>;
   
+  //! map strip number to charge fraction
+  using charge_list_t = std::vector<charge_pair_t>;
+
   //! distribute a Gaussian charge across adjacent strips
-  charge_info_t distribute_charge( CylinderGeomMicromegas*, const TVector3& position, double sigma ) const;
+  charge_list_t distribute_charge( CylinderGeomMicromegas*, uint tileid, const TVector3& position, double sigma ) const;
 
   //! detector name
   std::string m_detector;

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
@@ -85,6 +85,9 @@ class PHG4MicromegasHitReco : public SubsysReco, public PHParameterInterface
   //! electron cloud sigma (cm) after avalanche
   double m_cloud_sigma = 0.04;
 
+  //! electron transverse diffusion (cm/sqrt(cm))
+  double m_diffusion_trans = 0.03;
+  
   //! use zig zag pads
   bool m_zigzag_strips = true;
   

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
@@ -85,6 +85,9 @@ class PHG4MicromegasHitReco : public SubsysReco, public PHParameterInterface
   //! electron cloud sigma (cm) after avalanche
   double m_cloud_sigma = 0.04;
 
+  //! use zig zag pads
+  bool m_zigzag_strips = true;
+  
   //! micromegas tiles
   MicromegasTile::List m_tiles;
 

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
@@ -14,11 +14,16 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <gsl/gsl_rng.h>
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>  // for pair
 
+class CylinderGeomMicromegas;
 class PHCompositeNode;
+class PHG4Hit;
+class TVector3;
 
 class PHG4MicromegasHitReco : public SubsysReco, public PHParameterInterface
 {
@@ -28,14 +33,11 @@ class PHG4MicromegasHitReco : public SubsysReco, public PHParameterInterface
     const std::string &name = "PHG4MicromegasHitReco",
     const std::string &detector = "MICROMEGAS");
 
-  //! module initialization
+  //! run initialization
   int InitRun(PHCompositeNode*) override;
 
   //! event processing
   int process_event(PHCompositeNode*) override;
-
-  //!@name modifiers
-  //@{
 
   //! parameters
   void SetDefaultParameters() override;
@@ -44,22 +46,59 @@ class PHG4MicromegasHitReco : public SubsysReco, public PHParameterInterface
   void set_tiles( const MicromegasTile::List& tiles )
   { m_tiles = tiles; }
 
-  //@}
-
   private:
 
   //! setup tiles definition in CylinderGeom
   void setup_tiles(PHCompositeNode*);
+
+  //! stores strip number and corresponding charge fraciton
+  using charge_pair_t = std::pair<int, double>;
+
+  //! list of charge fractions
+  using charge_list_t = std::vector<charge_pair_t>;
+
+  //! tile and list of charge fractions
+  using charge_info_t = std::pair<int, charge_list_t>;
+
+  //! get total number of electrons collected for a give g4hit
+  /*! this accounts for the number of primary electrons, the detector gain, and fluctuations */
+  uint get_electrons( PHG4Hit* ) const;
+  
+  //! distribute a Gaussian charge across adjacent strips
+  charge_info_t distribute_charge( CylinderGeomMicromegas*, const TVector3& position, double sigma ) const;
 
   //! detector name
   std::string m_detector;
 
   //! timing window (ns)
   double m_tmin = 0;
+
+  //! timing window (ns)
   double m_tmax = 0;
+
+  //! number of primary electrons per GeV
+  double m_electrons_per_gev = 0;
+  
+  //! min gain
+  double m_gain = 0;
+  
+  //! electron cloud sigma (cm) after avalanche
+  double m_cloud_sigma = 0.04;
 
   //! micromegas tiles
   MicromegasTile::List m_tiles;
+
+  //! rng de-allocator
+  class Deleter
+  {
+    public:
+    //! deletion operator
+    void operator() (gsl_rng* rng) const { gsl_rng_free(rng); }
+  };
+
+  //! random generator that conform with sPHENIX standard
+  /*! using a unique_ptr with custom Deleter ensures that the structure is properly freed when parent object is destroyed */
+  std::unique_ptr<gsl_rng, Deleter> m_rng;
 
 };
 

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasSteppingAction.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasSteppingAction.cc
@@ -140,7 +140,8 @@ bool PHG4MicromegasSteppingAction::UserSteppingAction(const G4Step *aStep,bool w
 
       // reset the initial energy deposit
       m_EdepSum = 0;
-      m_EionSum = 0;  // assuming the ionization energy is only needed for active
+      m_EionSum = 0;
+      m_hit->set_edep(0);
       m_hit->set_eion(0);
       m_SaveHitContainer = m_hitContainer;
 


### PR DESCRIPTION
This PR introduces a more realistic reconstruction chain for the micromegas detector
- HitReco: tracks single primary electrons individually, adding transverse diffusion; include fluctuations on both the number of primary electrons and the single electron amplification factor; share the resulting avalanche electron cloud on neighboring strips using zigzag pattern similar to the TPC's GEM

- Digitization: implements conversion from incomming electrons into ADC counts with noise, pedestal and threshold values identical to the ones used for the TPC's GEM

- Clustering: simple clustering using weighted centroid of fired adjacent hits, with a weight being ADC-pedestal

This results in residuals (clusters - truth) in the micromegas detectors ranging from 70 to 90um depending on the configuration
 