### PR TITLE
Fix micromega readback

### DIFF
--- a/offline/packages/micromegas/Makefile.am
+++ b/offline/packages/micromegas/Makefile.am
@@ -11,7 +11,7 @@ AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
   -I$(ROOTSYS)/include \
-  	-I$(OFFLINE_MAIN)/include/eigen3
+  -I$(OFFLINE_MAIN)/include/eigen3
 
 AM_LDFLAGS = \
   -L$(libdir) \
@@ -19,17 +19,19 @@ AM_LDFLAGS = \
   -L$(OFFLINE_MAIN)/lib
 
 pkginclude_HEADERS = \
-  	CylinderGeomMicromegas.h \
+  CylinderGeomMicromegas.h \
   MicromegasClusterizer.h \
   MicromegasDefs.h \
- 	 MicromegasTile.h
+  MicromegasTile.h
 
 ROOTDICTS = \
-  CylinderGeomMicromegas_Dict.cc
+  CylinderGeomMicromegas_Dict.cc \
+  MicromegasTile_Dict.cc
 
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
-  CylinderGeomMicromegas_Dict_rdict.pcm
+  CylinderGeomMicromegas_Dict_rdict.pcm \
+  MicromegasTile_Dict_rdict.pcm
 
 # sources for io library
 libmicromegas_io_la_SOURCES = \

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -8,30 +8,39 @@
 #include "CylinderGeomMicromegas.h"
 
 #include <g4detectors/PHG4CylinderGeomContainer.h>
+#include <g4detectors/PHG4CylinderGeom.h>           // for PHG4CylinderGeom
 
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterv1.h>
+#include <trackbase/TrkrCluster.h>                  // for TrkrCluster
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 
+
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>                     // for SubsysReco
 
 #include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
-#include <phool/phool.h>
+#include <phool/PHIODataNode.h>                     // for PHIODataNode
+#include <phool/PHNode.h>                           // for PHNode
+#include <phool/PHNodeIterator.h>                   // for PHNodeIterator
+#include <phool/PHObject.h>                         // for PHObject
 
 #include <Eigen/Dense>
 
 #include <TVector3.h>
 
-#include <array>
 #include <cassert>
 #include <cmath>
+#include <cstdint>                                 // for uint16_t
+#include <iterator>                                 // for distance
+#include <map>                                      // for _Rb_tree_const_it...
+#include <utility>                                  // for pair, make_pair
 #include <vector>
-#include <iostream>
+
 
 namespace
 {

--- a/offline/packages/micromegas/MicromegasClusterizer.h
+++ b/offline/packages/micromegas/MicromegasClusterizer.h
@@ -10,16 +10,10 @@
  */
 
 #include <fun4all/SubsysReco.h>
-#include <trackbase/TrkrDefs.h>
 
 #include <string>                // for string
-#include <utility>
 
 class PHCompositeNode;
-class TrkrHit;
-class TrkrHitSetContainer;
-class TrkrClusterContainer;
-class TrkrClusterHitAssoc;
 
 //! micromegas clusterizer
 class MicromegasClusterizer : public SubsysReco

--- a/offline/packages/micromegas/MicromegasTile.h
+++ b/offline/packages/micromegas/MicromegasTile.h
@@ -9,12 +9,14 @@
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  */
 
+#include <phool/PHObject.h>
+
 #include <array>
 #include <cassert>
 #include <vector>
 
 //! header only class that contains information about a given Tile location inside CylinderGeom
-class MicromegasTile
+class MicromegasTile: public PHObject
 {
 
   public:
@@ -24,6 +26,9 @@ class MicromegasTile
   //! default constructor
   MicromegasTile()
   {}
+
+// ROOT wants a virtual dtor
+  virtual ~MicromegasTile() {}
 
   //! constructor
   MicromegasTile( std::array<double, 4> values )
@@ -46,6 +51,7 @@ class MicromegasTile
   double m_sizePhi = 0;
   double m_sizeZ = 0;
 
+  ClassDef(MicromegasTile,1)
 };
 
 #endif

--- a/offline/packages/micromegas/MicromegasTileLinkDef.h
+++ b/offline/packages/micromegas/MicromegasTileLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class MicromegasTile + ;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4dst/Makefile.am
+++ b/simulation/g4simulation/g4dst/Makefile.am
@@ -19,6 +19,7 @@ libg4dst_la_LDFLAGS = \
   -lg4vertex_io \
   -lintt_io \
   -ljetbackground_io \
+  -lmicromegas_io \
   -lmvtx_io \
   -lparticleflow_io \
   -lphfield_io \

--- a/simulation/g4simulation/g4micromegas/Makefile.am
+++ b/simulation/g4simulation/g4micromegas/Makefile.am
@@ -3,7 +3,7 @@ AUTOMAKE_OPTIONS = foreign
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include\
+  -I$(ROOTSYS)/include \
   -I$(G4_MAIN)/include
 
 AM_LDFLAGS = \
@@ -11,25 +11,25 @@ AM_LDFLAGS = \
   -L$(OFFLINE_MAIN)/lib
 
 pkginclude_HEADERS = \
-  PHG4MicromegasDigitizer.h\
-  PHG4MicromegasHitReco.h\
+  PHG4MicromegasDigitizer.h \
+  PHG4MicromegasHitReco.h \
   PHG4MicromegasSubsystem.h
 
 lib_LTLIBRARIES = \
   libg4micromegas.la
 
 libg4micromegas_la_SOURCES = \
-  PHG4MicromegasSubsystem.cc\
-  PHG4MicromegasDetector.cc\
-  PHG4MicromegasDigitizer.cc\
-  PHG4MicromegasHitReco.cc\
+  PHG4MicromegasSubsystem.cc \
+  PHG4MicromegasDetector.cc \
+  PHG4MicromegasDigitizer.cc \
+  PHG4MicromegasHitReco.cc \
   PHG4MicromegasSteppingAction.cc
 
 libg4micromegas_la_LIBADD = \
   -lphool \
-  -lSubsysReco\
-  -lg4detectors\
-  -lg4testbench\
+  -lSubsysReco \
+  -lg4detectors \
+  -lg4testbench \
   -lmicromegas_io
 
 BUILT_SOURCES = testexternals.cc

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.cc
@@ -9,16 +9,18 @@
 #include <phparameter/PHParameters.h>
 
 #include <g4detectors/PHG4CylinderGeomContainer.h>
+
 #include <g4main/PHG4Detector.h>
-#include <g4main/PHG4Subsystem.h>
+
 #include <micromegas/CylinderGeomMicromegas.h>
-#include <micromegas/MicromegasDefs.h>
+
 #include <phool/getClass.h>
-#include <phool/phool.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
+#include <phool/PHNode.h>                           // for PHNode
+#include <phool/PHNodeIterator.h>                   // for PHNodeIterator
+#include <phool/PHObject.h>                         // for PHObject
 
-#include <Geant4/G4Box.hh>
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4Color.hh>
 #include <Geant4/G4LogicalVolume.hh>
@@ -26,14 +28,18 @@
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4VisAttributes.hh>
+#include <Geant4/G4String.hh>                       // for G4String
+#include <Geant4/G4ThreeVector.hh>                  // for G4ThreeVector
+#include <Geant4/G4Types.hh>                        // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>              // for G4VPhysicalVolume
+#include <Geant4/G4VSolid.hh>                       // for G4VSolid
 
-#include <array>
 #include <cmath>
 #include <iostream>
 #include <numeric>
-
-class G4VSolid;
-class PHCompositeNode;
+#include <tuple>                                    // for make_tuple, tuple
+#include <utility>                                  // for pair, make_pair
+#include <vector>                                   // for vector
 
 //____________________________________________________________________________..
 PHG4MicromegasDetector::PHG4MicromegasDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDigitizer.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDigitizer.cc
@@ -14,20 +14,21 @@
 #include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
 
-#include <g4detectors/PHG4CylinderGeom.h>
-#include <g4detectors/PHG4CylinderGeomContainer.h>
+#include <phparameter/PHParameterInterface.h>  // for PHParameterInterface
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>
 
-#include <phool/PHCompositeNode.h>
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
 
 #include <gsl/gsl_randist.h>
-#include <algorithm>
+#include <gsl/gsl_rng.h>                       // for gsl_rng_alloc, gsl_rng...
+
 #include <cassert>
+#include <iostream>                            // for operator<<, basic_ostream
 #include <set>
+#include <utility>                             // for pair
 
 namespace
 {

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDigitizer.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDigitizer.h
@@ -14,7 +14,9 @@
 #include <phparameter/PHParameterInterface.h>
 
 #include <gsl/gsl_rng.h>
+
 #include <memory>
+#include <string>                              // for string
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -19,9 +19,11 @@
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4Utils.h>
+
+#include <phparameter/PHParameterInterface.h>       // for PHParameterInterface
 
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>                     // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
@@ -30,11 +32,19 @@
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
+#include <phool/PHObject.h>                         // for PHObject
+
 
 #include <TVector3.h>
 
 #include <gsl/gsl_randist.h>
+#include <gsl/gsl_rng.h>                            // for gsl_rng_alloc
+
 #include <cassert>
+#include <cmath>                                   // for atan2, sqrt, M_PI
+#include <cstdlib>                                 // for exit
+#include <iostream>                                 // for operator<<, basic...
+#include <map>                                      // for _Rb_tree_const_it...
 #include <numeric>
 
 namespace

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasSteppingAction.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasSteppingAction.h
@@ -9,6 +9,7 @@
  */
 
 #include <g4main/PHG4SteppingAction.h>
+
 #include <memory>
 
 class PHG4MicromegasDetector;

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.h
@@ -11,6 +11,8 @@
 
 #include <g4detectors/PHG4DetectorSubsystem.h>
 
+#include <string>                               // for string
+
 class PHCompositeNode;
 class PHG4Detector;
 class PHG4MicromegasDetector;


### PR DESCRIPTION
The micromega geometry gave readback warnings since its helper class MicromegasTile did not have a Streamer. Added the micromega io lib to libg4dst, fixed includes according to include what you use. Enabling the micromegas crashes the tracking evaluator (g4hit null pointer dereference)