### PR TITLE
Upstream/master evaluator

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -123,7 +123,7 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(TrkrDefs::cluskey cluster_key
 
 	  // extract the g4 hit key here and add the hits to the set
 	  PHG4HitDefs::keytype g4hitkey = htiter->second.second;
-	  PHG4Hit * g4hit;
+	  PHG4Hit * g4hit = nullptr;
 	  unsigned int trkrid = TrkrDefs::getTrkrId(hitsetkey);
 	  if(trkrid == TrkrDefs::tpcId)
 	    g4hit = _g4hits_tpc->findHit(g4hitkey);
@@ -131,7 +131,7 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(TrkrDefs::cluskey cluster_key
 	    g4hit = _g4hits_intt->findHit(g4hitkey);
 	  else
 	    g4hit = _g4hits_mvtx->findHit(g4hitkey);
-	  truth_hits.insert(g4hit);	      
+	  if( g4hit ) truth_hits.insert(g4hit);	      
 	} // end loop over g4hits associated with hitsetkey and hitkey
     } // end loop over hits associated with cluskey  
 

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -125,12 +125,13 @@ std::set<PHG4Hit*> SvtxClusterEval::all_truth_hits(TrkrDefs::cluskey cluster_key
 	  PHG4HitDefs::keytype g4hitkey = htiter->second.second;
 	  PHG4Hit * g4hit = nullptr;
 	  unsigned int trkrid = TrkrDefs::getTrkrId(hitsetkey);
-	  if(trkrid == TrkrDefs::tpcId)
-	    g4hit = _g4hits_tpc->findHit(g4hitkey);
-	  else if(trkrid == TrkrDefs::inttId)
-	    g4hit = _g4hits_intt->findHit(g4hitkey);
-	  else
-	    g4hit = _g4hits_mvtx->findHit(g4hitkey);
+   switch( trkrid )
+   {
+    case TrkrDefs::tpcId: g4hit = _g4hits_tpc->findHit(g4hitkey); break;
+    case TrkrDefs::inttId: g4hit = _g4hits_intt->findHit(g4hitkey); break;
+    case TrkrDefs::mvtxId: g4hit = _g4hits_mvtx->findHit(g4hitkey); break;
+    default: break;
+   }
 	  if( g4hit ) truth_hits.insert(g4hit);	      
 	} // end loop over g4hits associated with hitsetkey and hitkey
     } // end loop over hits associated with cluskey  

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -3596,7 +3596,7 @@ void SvtxEvaluator::LayerClusterG4Hits(PHCompositeNode* topNode, std::set<PHG4Hi
   float gt = 0.0;
   float gwt = 0.0;
   
-  if (layer >= _nlayers_maps + _nlayers_intt && layer <= _nlayers_maps + _nlayers_intt + _nlayers_tpc)
+  if (layer >= _nlayers_maps + _nlayers_intt && layer < _nlayers_maps + _nlayers_intt + _nlayers_tpc)
     {
       //cout << "layer = " << layer << " _nlayers_maps " << _nlayers_maps << " _nlayers_intt " << _nlayers_intt << endl;
 

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -1504,7 +1504,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	    float phi = NAN;
 	    float z = NAN;
 	    
-	    if (layer >= _nlayers_maps + _nlayers_intt)
+	    if (layer >= _nlayers_maps + _nlayers_intt && layer < _nlayers_maps + _nlayers_intt + _nlayers_tpc )
 	      {
 		PHG4CylinderCellGeom* GeoLayer = geom_container->GetLayerCellGeom(layer);
 		phibin = (float) TpcDefs::getPad(hit_key);
@@ -3596,7 +3596,7 @@ void SvtxEvaluator::LayerClusterG4Hits(PHCompositeNode* topNode, std::set<PHG4Hi
   float gt = 0.0;
   float gwt = 0.0;
   
-  if (layer >= _nlayers_maps + _nlayers_intt)
+  if (layer >= _nlayers_maps + _nlayers_intt && layer <= _nlayers_maps + _nlayers_intt + _nlayers_tpc)
     {
       //cout << "layer = " << layer << " _nlayers_maps " << _nlayers_maps << " _nlayers_intt " << _nlayers_intt << endl;
 

--- a/simulation/g4simulation/g4eval/SvtxHitEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.cc
@@ -218,7 +218,7 @@ std::set<PHG4Hit*> SvtxHitEval::all_truth_hits(TrkrDefs::hitkey hit_key)
 	      // extract the g4 hit key here and add the g4hit to the set
 	      PHG4HitDefs::keytype g4hitkey = htiter->second.second;
 	      //cout << "           hitkey " << hitkey <<  " g4hitkey " << g4hitkey << endl;	  
-	      PHG4Hit * g4hit;
+	      PHG4Hit * g4hit = nullptr;
 	      if(trkrid == TrkrDefs::tpcId)
 		g4hit = _g4hits_tpc->findHit(g4hitkey);
 	      else if(trkrid == TrkrDefs::inttId)
@@ -227,7 +227,7 @@ std::set<PHG4Hit*> SvtxHitEval::all_truth_hits(TrkrDefs::hitkey hit_key)
 		g4hit = _g4hits_mvtx->findHit(g4hitkey);
 
 	      // fill output set
-	      truth_hits.insert(g4hit);
+	      if( g4hit ) truth_hits.insert(g4hit);
 	    }
 	}
     }

--- a/simulation/g4simulation/g4eval/SvtxHitEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.cc
@@ -219,13 +219,13 @@ std::set<PHG4Hit*> SvtxHitEval::all_truth_hits(TrkrDefs::hitkey hit_key)
 	      PHG4HitDefs::keytype g4hitkey = htiter->second.second;
 	      //cout << "           hitkey " << hitkey <<  " g4hitkey " << g4hitkey << endl;	  
 	      PHG4Hit * g4hit = nullptr;
-	      if(trkrid == TrkrDefs::tpcId)
-		g4hit = _g4hits_tpc->findHit(g4hitkey);
-	      else if(trkrid == TrkrDefs::inttId)
-		g4hit = _g4hits_intt->findHit(g4hitkey);
-	      else
-		g4hit = _g4hits_mvtx->findHit(g4hitkey);
-
+       switch( trkrid )
+       {
+        case TrkrDefs::tpcId: g4hit = _g4hits_tpc->findHit(g4hitkey); break;
+        case TrkrDefs::inttId: g4hit = _g4hits_intt->findHit(g4hitkey); break;
+        case TrkrDefs::mvtxId: g4hit = _g4hits_mvtx->findHit(g4hitkey); break;
+        default: break;
+       }
 	      // fill output set
 	      if( g4hit ) truth_hits.insert(g4hit);
 	    }


### PR DESCRIPTION
This PR prevents crash of the evaluators when enabling micromegas detectors, by adding more sanity checks when looking for G4Hits and trying to identify tpc layers (nothing in there is actually specific to the micromegas code itself)
