### PR TITLE
Change TPC Azimuthal Surfaces

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -75,7 +75,7 @@ MakeActsGeometry::MakeActsGeometry(const string &name)
   , m_minSurfZ(0.0)
   , m_maxSurfZ(105.5)
   , m_nSurfZ(1)
-  , m_nSurfPhi(3)
+  , m_nSurfPhi(12)
   , m_verbosity(0)
 {
   /// These are arbitrary tpc subdivisions, and may change

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -140,8 +140,8 @@ int PHActsSourceLinks::process_event(PHCompositeNode *topNode)
       /// Make sure things returned appropriately
       if (!surface)
       {
-        /// Error message already printed in function, return abort
-        return Fun4AllReturnCodes::ABORTEVENT;
+        /// if we couldn't find the surface (shouldn't happen) just skip this hit
+	continue;
       }
     }
     else if (trkrId == TrkrDefs::inttId)
@@ -149,8 +149,8 @@ int PHActsSourceLinks::process_event(PHCompositeNode *topNode)
       surface = getInttLocalCoords(local2D, cov, cluster, clusKey);
       if (!surface)
       {
-        /// Error message already printed in function, return abort
-        return Fun4AllReturnCodes::ABORTEVENT;
+	/// if we couldn't find the surface (shouldn't happen) just skip this hit
+	continue;
       }
     }
     else if (trkrId == TrkrDefs::tpcId)
@@ -159,8 +159,8 @@ int PHActsSourceLinks::process_event(PHCompositeNode *topNode)
 
       if (!surface)
       {
-        /// Error message already printed in function, return abort
-        return Fun4AllReturnCodes::ABORTEVENT;
+        /// if we couldn't find the surface (shouldn't happen) just skip this hit
+	continue;
       }
     }
     else
@@ -294,8 +294,15 @@ Surface PHActsSourceLinks::getTpcLocalCoords(Acts::Vector2D &local2D,
   /// a given readout module
   Surface surface = m_actsGeometry->getTpcSurfaceFromCoords(tpcHitSetKey,
 							    worldVec);
-  assert(surface);
-  
+
+  /// If surface can't be found (shouldn't happen) return nullptr and skip this cluster
+  if(!surface)
+    {
+      std::cout << PHWHERE
+		<< "Failed to find associated surface element - should be impossible!"
+		<< std::endl;
+      return nullptr;
+    }
   if(Verbosity() > 0)
     {
       std::cout << "Stream of found TPC surface: " << std::endl;

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -333,6 +333,11 @@ Surface PHActsSourceLinks::getTpcLocalCoords(Acts::Vector2D &local2D,
   surface->globalToLocal(m_actsGeometry->getGeoContext(), globalPos,
 			 surface->normal(m_actsGeometry->getGeoContext()),
 			 local2D);
+  
+  /// Test that Acts surface transforms correctly back
+  Acts::Vector3D actsGlobal(0,0,0);
+  surface->localToGlobal(m_actsGeometry->getGeoContext(), local2D, 
+			 Acts::Vector3D(1,1,1), actsGlobal);
 
   if (Verbosity() > 0)
   {
@@ -342,7 +347,11 @@ Surface PHActsSourceLinks::getTpcLocalCoords(Acts::Vector2D &local2D,
     std::cout << " local phi " << clusPhi - surfPhiCenter
               << " local rphi " << rClusPhi-surfRphiCenter 
  	      << " local z " << zTpc - surfZCenter  << std::endl;
-      std::cout << " acts local : " <<local2D(0) <<"  "<<local2D(1) << std::endl;
+    std::cout << " acts local : " <<local2D(0) <<"  "<<local2D(1) << std::endl;
+    std::cout << " sPHENIX global : " << x * 10 << "  " << y * 10 << "  " 
+	      << z * 10 << "  " << std::endl;
+    std::cout << " acts global : " << actsGlobal(0) << "  " << actsGlobal(1) 
+	      << "  " << actsGlobal(2) << std::endl;
   }
 
   TMatrixD sPhenixLocalErr = transformCovarToLocal(clusPhi, worldErr);
@@ -444,7 +453,12 @@ Surface PHActsSourceLinks::getInttLocalCoords(Acts::Vector2D &local2D,
   surface->globalToLocal(m_actsGeometry->getGeoContext(), globalPos,
 			 surface->normal(m_actsGeometry->getGeoContext()),
 			 local2D);
-  
+
+  /// Test that Acts surface transforms correctly back
+  Acts::Vector3D actsGlobal(0,0,0);
+  surface->localToGlobal(m_actsGeometry->getGeoContext(), local2D, 
+			 Acts::Vector3D(1,1,1), actsGlobal);
+
   Acts::Vector3D normal = surface->normal(m_actsGeometry->getGeoContext());
   
   if (Verbosity() > 0)
@@ -459,7 +473,11 @@ Surface PHActsSourceLinks::getInttLocalCoords(Acts::Vector2D &local2D,
               << " " << world[2] << std::endl;
     std::cout << "   local; " << local[0] << " " << local[1]
               << " " << local[2] << std::endl;
-    std::cout << " acts local "<<local2D(0)<<"  "<<local2D(1)<<std::endl;
+    std::cout << " acts local " << local2D(0) << "  " << local2D(1) << std::endl;
+    std::cout << " sPHENIX global : " << x * 10 << "  " << y * 10 << "  " 
+	      << z * 10 << "  " << std::endl;
+    std::cout << " acts global : " << actsGlobal(0) << "  " << actsGlobal(1) 
+	      << "  " << actsGlobal(2) << std::endl;
   }
 
   /// Get the local covariance error
@@ -548,7 +566,12 @@ Surface PHActsSourceLinks::getMvtxLocalCoords(Acts::Vector2D &local2D,
   surface->globalToLocal(m_actsGeometry->getGeoContext(), globalPos,
 			 surface->normal(m_actsGeometry->getGeoContext()),
 			 local2D);
-  
+
+  /// Test that Acts surface transforms correctly back
+  Acts::Vector3D actsGlobal(0,0,0);
+  surface->localToGlobal(m_actsGeometry->getGeoContext(), local2D, 
+			 Acts::Vector3D(1,1,1), actsGlobal);
+
   Acts::Vector3D normal = surface->normal(m_actsGeometry->getGeoContext());
 
   if (Verbosity() > 0)
@@ -561,9 +584,13 @@ Surface PHActsSourceLinks::getMvtxLocalCoords(Acts::Vector2D &local2D,
               << segcent[1] << " " << segcent[2] << std::endl;
     std::cout << "   world; " << world[0] << " "
               << world[1] << " " << world[2] << std::endl;
-    std::cout << "   our local; " << local[0] << " "
-              << local[1] << " " << local[2] << std::endl;
-    std::cout<<" acts local "<<local2D(0)<<"  "<<local2D(1)<<std::endl;
+    std::cout << "   our local; " << local[0] * 10 << " "
+              << local[1] * 10<< " " << local[2] * 10 << std::endl;
+    std::cout << " acts local " << local2D(0) << "  " << local2D(1) << std::endl;
+    std::cout << "Our global : " << x * 10 << "  " << y * 10 << "   " << z * 10 
+	      << std::endl;
+    std::cout << "Acts transform global : " << actsGlobal(0) << "  " << actsGlobal(1)
+	      << "   " << actsGlobal(2) << std::endl;
   }
 
   // transform covariance matrix back to local coords on chip


### PR DESCRIPTION
This PR introduces some additional verbosity checks for the TPC cluster position transforms. It also changes the default number of azimuthal TPC surfaces per sector in Acts to 12. This ensures that there is not a mismatch between the global -> local -> global position transforms for the TPC clusters that are introduced by the fact that we are approximating the TPC with flat surfaces.