### PR TITLE
Simplify vmeson gen

### DIFF
--- a/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.cc
@@ -44,7 +44,7 @@ BeamLineMagnetDetector::BeamLineMagnetDetector(PHG4Subsystem *subsys, PHComposit
   , magnet_physi(nullptr)
   , magnet_iron_physi(nullptr)
   , m_DisplayAction(dynamic_cast<BeamLineMagnetDisplayAction *>(subsys->GetDisplayAction()))
-  ,  m_MagnetId(magnet_id)
+  , m_MagnetId(magnet_id)
 {
 }
 

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.cc
@@ -6,7 +6,6 @@
 #include <g4main/PHG4Detector.h>       // for PHG4Detector
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4Subsystem.h>
-#include <g4main/PHG4Utils.h>
 
 #include <phool/phool.h>
 
@@ -28,16 +27,13 @@
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4Types.hh>  // for G4double, G4bool
 #include <Geant4/G4UniformMagField.hh>
-#include <Geant4/G4VisAttributes.hh>
 
 #include <CLHEP/Units/SystemOfUnits.h>  // for cm, deg, tesla, twopi, meter
 
-#include <cstdlib>   // for exit
 #include <iostream>  // for operator<<, basic_ostream
 
 class G4VSolid;
 class PHCompositeNode;
-class PHG4Subsystem;
 
 using namespace std;
 

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.cc
@@ -19,7 +19,7 @@
 #include <phool/getClass.h>
 
 #include <iostream>  // for operator<<, endl, basic_ostream
-#include <set>                                  // for set
+#include <set>       // for set
 
 class PHG4Detector;
 

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.cc
@@ -3,6 +3,8 @@
 #include "BeamLineMagnetDisplayAction.h"
 #include "BeamLineMagnetSteppingAction.h"
 
+#include <g4detectors/PHG4DetectorSubsystem.h>  // for PHG4DetectorSubsystem
+
 #include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
@@ -16,10 +18,9 @@
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
-#include <cmath>     // for NAN
 #include <iostream>  // for operator<<, endl, basic_ostream
+#include <set>                                  // for set
 
-class PHCompositeNode;
 class PHG4Detector;
 
 using namespace std;

--- a/simulation/g4simulation/g4main/EicEventHeader.cc
+++ b/simulation/g4simulation/g4main/EicEventHeader.cc
@@ -3,7 +3,6 @@
 #include <TSystem.h>
 
 #include <cassert>
-#include <cmath>
 #include <cstdlib>
 
 using namespace std;

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
@@ -161,7 +161,7 @@ int PHG4ParticleGeneratorD0::process_event(PHCompositeNode *topNode)
 
   // Get the pseudorapidity, eta, from the rapidity, mass and pt
 
-  double mt = sqrt(pow(mnow, 2) + pow(pt, 2));
+  double mt = sqrt(mnow*mnow + pt*pt);
   double eta = asinh(sinh(y) * mt / pt);
 
   // Put it in a TLorentzVector
@@ -192,8 +192,9 @@ int PHG4ParticleGeneratorD0::process_event(PHCompositeNode *topNode)
   // Now decay it
   // Get the decay energy and momentum in the frame of the D0 - this correctly handles decay particles of any mass.
 
-  double E1 = (pow(mnow, 2) - pow(m2, 2) + pow(m1, 2)) / (2.0 * mnow);
-  double p1 = sqrt((pow(mnow, 2) - pow(m1 + m2, 2)) * (pow(mnow, 2) - pow(m1 - m2, 2))) / (2.0 * mnow);
+  double E1 = (mnow*mnow - m2*m2 + m1*m1) / (2.0 * mnow);
+  double p1 = sqrt((mnow*mnow - (m1 + m2)*(m1 + m2)) * (mnow*mnow - (m1 - m2)*(m1 - m2))) / (2.0 * mnow);
+
 
   // In the frame of the D0, get a random theta and phi angle for particle 1
   // Assume angular distribution in the frame of the decaying D0 that is uniform in phi and goes as sin(theta) in theta

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -40,7 +40,6 @@ PHG4ParticleGeneratorVectorMeson::PHG4ParticleGeneratorVectorMeson(const string 
   , _vertex_func_x(Uniform)
   , _vertex_func_y(Uniform)
   , _vertex_func_z(Uniform)
-  , _t0(0.0)
   , _vertex_x(0.0)
   , _vertex_y(0.0)
   , _vertex_z(0.0)

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -328,7 +328,7 @@ int PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
 
   // Get the pseudorapidity, eta, from the rapidity, mass and pt
 
-  double mt = sqrt(pow(mnow, 2) + pow(pt, 2));
+  double mt = sqrt(mnow*mnow + pt*pt);
   double eta = asinh(sinh(y) * mt / pt);
 
   // Put it in a TLorentzVector
@@ -376,7 +376,7 @@ int PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
     // 3D Randomized vertex
     if ((_vertex_size_width > 0.0) || (_vertex_size_mean != 0.0))
     {
-      _vertex_size_mean = sqrt(pow(vtx_x, 2) + pow(vtx_y, 2) + pow(vtx_z, 2));
+      _vertex_size_mean = sqrt(vtx_x*vtx_x + vtx_y*vtx_y + vtx_z*vtx_z);
       double r = smearvtx(_vertex_size_mean, _vertex_size_width, _vertex_size_func_r);
       double x1 = 0.0;
       double y1 = 0.0;
@@ -395,8 +395,8 @@ int PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
     // Now decay it
     // Get the decay energy and momentum in the frame of the vector meson - this correctly handles decay particles of any mass.
 
-    double E1 = (pow(mnow, 2) - pow(m2, 2) + pow(m1, 2)) / (2.0 * mnow);
-    double p1 = sqrt((pow(mnow, 2) - pow(m1 + m2, 2)) * (pow(mnow, 2) - pow(m1 - m2, 2))) / (2.0 * mnow);
+    double E1 = (mnow*mnow - m2*m2 + m1*m1) / (2.0 * mnow);
+    double p1 = sqrt((mnow*mnow - (m1 + m2)*(m1 + m2)) * (mnow*mnow - (m1 + m2)*(m1 + m2))) / (2.0 * mnow);
 
     // In the frame of the vector meson, get a random theta and phi angle for particle 1
     // Assume angular distribution in the frame of the decaying meson that is uniform in phi and goes as sin(theta) in theta

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -73,7 +73,7 @@ PHG4ParticleGeneratorVectorMeson::PHG4ParticleGeneratorVectorMeson(const string 
   , trand(nullptr)
   , ineve(nullptr)
 {
-  set_upsilon_1s(); // make mass and width of 1S default
+  set_upsilon_1s();  // make mass and width of 1S default
   return;
 }
 
@@ -87,11 +87,11 @@ void PHG4ParticleGeneratorVectorMeson::add_decay_particles(const std::string &na
 {
   if (name1.compare("e") == 0)
   {
-    add_decay_particles("e+","e-",decay_id);
+    add_decay_particles("e+", "e-", decay_id);
   }
   else if (name1.compare("mu") == 0)
   {
-    add_decay_particles("mu+","mu-",decay_id);
+    add_decay_particles("mu+", "mu-", decay_id);
   }
   else
   {
@@ -103,22 +103,21 @@ void PHG4ParticleGeneratorVectorMeson::add_decay_particles(const std::string &na
 
 void PHG4ParticleGeneratorVectorMeson::add_decay_particles(const std::string &name1, const std::string &name2, const unsigned int decay_id)
 {
-// check for valid select ion (e+,e- or mu+,mu-)
-  if ((name1.compare("e-") == 0 && name2.compare("e+") == 0 ) ||
-      (name1.compare("e+") == 0  && name2.compare("e-") == 0 ) ||
-      (name1.compare("mu+") == 0  && name2.compare("mu-") == 0 ) ||
-      (name1.compare("mu-") == 0  && name2.compare("mu+") == 0 ))
+  // check for valid select ion (e+,e- or mu+,mu-)
+  if ((name1.compare("e-") == 0 && name2.compare("e+") == 0) ||
+      (name1.compare("e+") == 0 && name2.compare("e-") == 0) ||
+      (name1.compare("mu+") == 0 && name2.compare("mu-") == 0) ||
+      (name1.compare("mu-") == 0 && name2.compare("mu+") == 0))
   {
-
-  decay1_names.insert(std::pair<unsigned int, std::string>(decay_id, name1));
-  decay2_names.insert(std::pair<unsigned int, std::string>(decay_id, name2));
-  decay_vtx_offset_x.insert(std::pair<unsigned int, double>(decay_id, 0.));
-  decay_vtx_offset_y.insert(std::pair<unsigned int, double>(decay_id, 0.));
-  decay_vtx_offset_z.insert(std::pair<unsigned int, double>(decay_id, 0.));
-  return;
+    decay1_names.insert(std::pair<unsigned int, std::string>(decay_id, name1));
+    decay2_names.insert(std::pair<unsigned int, std::string>(decay_id, name2));
+    decay_vtx_offset_x.insert(std::pair<unsigned int, double>(decay_id, 0.));
+    decay_vtx_offset_y.insert(std::pair<unsigned int, double>(decay_id, 0.));
+    decay_vtx_offset_z.insert(std::pair<unsigned int, double>(decay_id, 0.));
+    return;
   }
-    cout << "invalid decay channel Y --> " << name1 << " + " << name2 << endl;
-    gSystem->Exit(1); 
+  cout << "invalid decay channel Y --> " << name1 << " + " << name2 << endl;
+  gSystem->Exit(1);
 }
 
 void PHG4ParticleGeneratorVectorMeson::set_decay_vertex_offset(double dx, double dy, double dz, const unsigned int decay_id)
@@ -204,10 +203,10 @@ void PHG4ParticleGeneratorVectorMeson::set_vertex_size_parameters(const double m
 
 void PHG4ParticleGeneratorVectorMeson::set_decay_types(const std::string &name1, const std::string &name2)
 {
-//http://pdg.lbl.gov/2020/listings/rpp2020-list-muon.pdf
-  static const double mmuon = 105.6583745e-3; //+-0.0000024e-3
-// http://pdg.lbl.gov/2020/listings/rpp2020-list-electron.pdf
-  static const double melectron = 0.5109989461e-3; //+-0.0000000031e-3
+  //http://pdg.lbl.gov/2020/listings/rpp2020-list-muon.pdf
+  static const double mmuon = 105.6583745e-3;       //+-0.0000024e-3
+                                                    // http://pdg.lbl.gov/2020/listings/rpp2020-list-electron.pdf
+  static const double melectron = 0.5109989461e-3;  //+-0.0000000031e-3
 
   decay1 = name1;
   if (decay1.compare("e+") == 0 || decay1.compare("e-") == 0)
@@ -221,7 +220,7 @@ void PHG4ParticleGeneratorVectorMeson::set_decay_types(const std::string &name1,
   else
   {
     cout << "Do not recognize the decay type " << decay1 << endl;
-    gSystem->Exit(1); 
+    gSystem->Exit(1);
   }
 
   decay2 = name2;
@@ -236,7 +235,7 @@ void PHG4ParticleGeneratorVectorMeson::set_decay_types(const std::string &name1,
   else
   {
     cout << "Do not recognize the decay type " << decay2 << endl;
-    gSystem->Exit(1); 
+    gSystem->Exit(1);
   }
 
   return;
@@ -328,7 +327,7 @@ int PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
 
   // Get the pseudorapidity, eta, from the rapidity, mass and pt
 
-  double mt = sqrt(mnow*mnow + pt*pt);
+  double mt = sqrt(mnow * mnow + pt * pt);
   double eta = asinh(sinh(y) * mt / pt);
 
   // Put it in a TLorentzVector
@@ -376,7 +375,7 @@ int PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
     // 3D Randomized vertex
     if ((_vertex_size_width > 0.0) || (_vertex_size_mean != 0.0))
     {
-      _vertex_size_mean = sqrt(vtx_x*vtx_x + vtx_y*vtx_y + vtx_z*vtx_z);
+      _vertex_size_mean = sqrt(vtx_x * vtx_x + vtx_y * vtx_y + vtx_z * vtx_z);
       double r = smearvtx(_vertex_size_mean, _vertex_size_width, _vertex_size_func_r);
       double x1 = 0.0;
       double y1 = 0.0;
@@ -395,8 +394,8 @@ int PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
     // Now decay it
     // Get the decay energy and momentum in the frame of the vector meson - this correctly handles decay particles of any mass.
 
-    double E1 = (mnow*mnow - m2*m2 + m1*m1) / (2.0 * mnow);
-    double p1 = sqrt((mnow*mnow - (m1 + m2)*(m1 + m2)) * (mnow*mnow - (m1 - m2)*(m1 - m2))) / (2.0 * mnow);
+    double E1 = (mnow * mnow - m2 * m2 + m1 * m1) / (2.0 * mnow);
+    double p1 = sqrt((mnow * mnow - (m1 + m2) * (m1 + m2)) * (mnow * mnow - (m1 - m2) * (m1 - m2))) / (2.0 * mnow);
 
     // In the frame of the vector meson, get a random theta and phi angle for particle 1
     // Assume angular distribution in the frame of the decaying meson that is uniform in phi and goes as sin(theta) in theta
@@ -535,22 +534,21 @@ PHG4ParticleGeneratorVectorMeson::smearvtx(const double position, const double w
 
 void PHG4ParticleGeneratorVectorMeson::set_upsilon_1s()
 {
-// http://pdg.lbl.gov/2020/listings/rpp2020-list-upsilon-1S.pdf
-  set_mass(9.4603); //+- 0.00026
-  set_width(54.02e-6); // +- 1.25e-6
+  // http://pdg.lbl.gov/2020/listings/rpp2020-list-upsilon-1S.pdf
+  set_mass(9.4603);     //+- 0.00026
+  set_width(54.02e-6);  // +- 1.25e-6
 }
 
 void PHG4ParticleGeneratorVectorMeson::set_upsilon_2s()
 {
-// http://pdg.lbl.gov/2020/listings/rpp2020-list-upsilon-2S.pdf
-  set_mass(10.02326); // +- 0.00031
-  set_width(31.98e-6); // +- 2.63e-6
+  // http://pdg.lbl.gov/2020/listings/rpp2020-list-upsilon-2S.pdf
+  set_mass(10.02326);   // +- 0.00031
+  set_width(31.98e-6);  // +- 2.63e-6
 }
 
 void PHG4ParticleGeneratorVectorMeson::set_upsilon_3s()
 {
-//http://pdg.lbl.gov/2020/listings/rpp2020-list-upsilon-3S.pdf
-  set_mass(10.3552); // +- 0.0005
-  set_width(20.32e-6); // +- 1.85e-6
+  //http://pdg.lbl.gov/2020/listings/rpp2020-list-upsilon-3S.pdf
+  set_mass(10.3552);    // +- 0.0005
+  set_width(20.32e-6);  // +- 1.85e-6
 }
-

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -396,7 +396,7 @@ int PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
     // Get the decay energy and momentum in the frame of the vector meson - this correctly handles decay particles of any mass.
 
     double E1 = (mnow*mnow - m2*m2 + m1*m1) / (2.0 * mnow);
-    double p1 = sqrt((mnow*mnow - (m1 + m2)*(m1 + m2)) * (mnow*mnow - (m1 + m2)*(m1 + m2))) / (2.0 * mnow);
+    double p1 = sqrt((mnow*mnow - (m1 + m2)*(m1 + m2)) * (mnow*mnow - (m1 - m2)*(m1 - m2))) / (2.0 * mnow);
 
     // In the frame of the vector meson, get a random theta and phi angle for particle 1
     // Assume angular distribution in the frame of the decaying meson that is uniform in phi and goes as sin(theta) in theta

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
@@ -58,8 +58,8 @@ class PHG4ParticleGeneratorVectorMeson : public PHG4ParticleGeneratorBase
 
   void set_read_vtx_from_hepmc(bool read_vtx) { read_vtx_from_hepmc = read_vtx; }
 
-  void set_mass(const double mass_in) {mass = mass_in;}
-  void set_width(const double width_in) {m_Width = width_in;}
+  void set_mass(const double mass_in) { mass = mass_in; }
+  void set_width(const double width_in) { m_Width = width_in; }
   void set_decay_types(const std::string &decay1, const std::string &decay2);
   void set_histrand_init(const int initflag) { _histrand_init = initflag; }
   void set_upsilon_1s();
@@ -76,7 +76,7 @@ class PHG4ParticleGeneratorVectorMeson : public PHG4ParticleGeneratorBase
   std::map<unsigned int, double> decay_vtx_offset_y;
   std::map<unsigned int, double> decay_vtx_offset_z;
 
-// protected:
+  // protected:
   FUNCTION _vertex_func_x;
   FUNCTION _vertex_func_y;
   FUNCTION _vertex_func_z;

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
@@ -76,11 +76,9 @@ class PHG4ParticleGeneratorVectorMeson : public PHG4ParticleGeneratorBase
   std::map<unsigned int, double> decay_vtx_offset_y;
   std::map<unsigned int, double> decay_vtx_offset_z;
 
-  // protected:
   FUNCTION _vertex_func_x;
   FUNCTION _vertex_func_y;
   FUNCTION _vertex_func_z;
-  double _t0;
   double _vertex_x;         // primary vertex (or mean) x component, cf. vtx_x = track-by-track vertex x component
   double _vertex_y;         // primary vertex (or mean) y component, cf. vtx_y = track-by-track vertex y component
   double _vertex_z;         // primary vertex (or mean)z component, cf. vtx_z = track-by-track vertex z component

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
@@ -26,8 +26,8 @@ class PHG4ParticleGeneratorVectorMeson : public PHG4ParticleGeneratorBase
   explicit PHG4ParticleGeneratorVectorMeson(const std::string &name = "VMESON");
   virtual ~PHG4ParticleGeneratorVectorMeson();
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   //! interface for adding particles by name
   void add_decay_particles(const std::string &name1, const std::string &name2, const unsigned int decay_id);

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
@@ -31,6 +31,7 @@ class PHG4ParticleGeneratorVectorMeson : public PHG4ParticleGeneratorBase
 
   //! interface for adding particles by name
   void add_decay_particles(const std::string &name1, const std::string &name2, const unsigned int decay_id);
+  void add_decay_particles(const std::string &name, const unsigned int decay_id);
 
   void set_decay_vertex_offset(double dx, double dy, double dz, const unsigned int decay_id);
   void set_eta_range(const double eta_min, const double eta_max);
@@ -57,10 +58,13 @@ class PHG4ParticleGeneratorVectorMeson : public PHG4ParticleGeneratorBase
 
   void set_read_vtx_from_hepmc(bool read_vtx) { read_vtx_from_hepmc = read_vtx; }
 
-  void set_mass(const double mass);
-  void set_width(const double width);
+  void set_mass(const double mass_in) {mass = mass_in;}
+  void set_width(const double width_in) {m_Width = width_in;}
   void set_decay_types(const std::string &decay1, const std::string &decay2);
   void set_histrand_init(const int initflag) { _histrand_init = initflag; }
+  void set_upsilon_1s();
+  void set_upsilon_2s();
+  void set_upsilon_3s();
 
  private:
   double smearvtx(const double position, const double width, FUNCTION dist) const;
@@ -72,7 +76,7 @@ class PHG4ParticleGeneratorVectorMeson : public PHG4ParticleGeneratorBase
   std::map<unsigned int, double> decay_vtx_offset_y;
   std::map<unsigned int, double> decay_vtx_offset_z;
 
- protected:
+// protected:
   FUNCTION _vertex_func_x;
   FUNCTION _vertex_func_y;
   FUNCTION _vertex_func_z;

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -523,7 +523,7 @@ void PHG4TruthEventAction::ProcessShowers()
     }
 
     // weighted covariance matrix
-    prefactor = sumw / (pow(sumw, 2) - sumw2);  // effectivelly 1/(N-1) when w_i = 1.0
+    prefactor = sumw / (sumw*sumw - sumw2);  // effectivelly 1/(N-1) when w_i = 1.0
     Eigen::Matrix<double, 3, 3> covar = prefactor * (X.transpose() * W.asDiagonal() * X);
 
     shower->set_x(mean(0, 0));

--- a/simulation/g4simulation/g4main/ReadEICFiles.cc
+++ b/simulation/g4simulation/g4main/ReadEICFiles.cc
@@ -10,7 +10,6 @@
 #include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>  // for PHObject
-#include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
@@ -30,13 +29,11 @@
 // General Root and C++ classes
 #include <TBranch.h>  // for TBranch
 #include <TChain.h>
-#include <TROOT.h>
 #include <TVector3.h>  // for TVector3
 
 #include <iostream>  // for operator<<, endl, basic_ostream
 #include <vector>    // for vector
 
-class PHCompositeNode;
 class PHHepMCGenEvent;
 
 using namespace std;


### PR DESCRIPTION
This PR makes some minor mods to the upsilon generator: added simplified interface to select decay (just electron or muon), checks for only valid decays (e+ & e-, mu+ & mu-), use x*x instead of pow(x,2), declare protected datamembers private, Some include what you use suggestions were added for good measure 