### PR TITLE
Tpc cluster error v2

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -466,6 +466,12 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
         for (int iz = zbinlo[iclus]; iz <= zbinhi[iclus]; iz++)
         {
           // skip hits for which weight is non-positive
+          /*
+           * Having negative weights in the calculation of the error might result in negative variance
+           * and thus -nan error, that then propagate through the tracking. Since those hits correspond to
+           * noise anyway and in order to have the error and centroid calculation consistent,
+           * we skip the hit alltogether
+           */
           if( adcval[iphi][iz] <= 0 ) continue;
 
           // update z sums

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -465,22 +465,23 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
       {
         for (int iz = zbinlo[iclus]; iz <= zbinhi[iclus]; iz++)
         {
-          const double phi_center = layergeom->get_phicenter(iphi);
-          const double z = layergeom->get_zcenter(iz);
+          // skip hits for which weight is non-positive
+          if( adcval[iphi][iz] <= 0 ) continue;
 
+          // update z sums
+          const double z = layergeom->get_zcenter(iz);
           z_sum += z*adcval[iphi][iz];
           z2_sum += square(z)*adcval[iphi][iz];
 
+          // update phi sums
+          const double phi_center = layergeom->get_phicenter(iphi);
           phi_sum += phi_center*adcval[iphi][iz];
           phi2_sum += square(phi_center)*adcval[iphi][iz];
           adc_sum += adcval[iphi][iz];
 
           // capture the hitkeys for all non-zero adc values
-          if (adcval[iphi][iz] != 0)
-          {
-            TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, iz);
-            hitkeyvec.push_back(hitkey);
-          }
+          TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, iz);
+          hitkeyvec.push_back(hitkey);
         }
       }
 


### PR DESCRIPTION
This is the second attempt at simplifying the TPC cluster error calculatio code.
First commit is similar to the original attempt, but with better handling of size one cluster. Not identifying size-one cluster due to numerical divergences is the reason why the first attempt lead to a deterioration of the tracking efficiency. The clusters positions and errors after this first commit are identical to what they were before with simpler and more robust code
The second commit remove hits for which adc - pedestal is <0. This fixes cases for which the resulting cluster error square was negative, and the corresponding error -nan. 
This has a bigger impact on all cluster errors, hopefully for the best. This should hopefully lead to either identical or improved performances. If not, this one can always be reverted before pushing. 