### PR TITLE
Reorganize svtxeval

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -704,7 +704,7 @@ Acts::Vector3D ActsEvaluator::getGlobalTruthHit(PHCompositeNode *topNode,
 
   TrkrDefs::cluskey clusKey = getClusKey(hitID);
   
-  const TrkrCluster *truth_cluster = clustereval->max_truth_cluster_by_energy(clusKey);
+  std::shared_ptr<TrkrCluster> truth_cluster = clustereval->max_truth_cluster_by_energy(clusKey);
   
   float gx = -9999;
   float gy = -9999;

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -703,7 +703,7 @@ Acts::Vector3D ActsEvaluator::getGlobalTruthHit(PHCompositeNode *topNode,
 
   TrkrDefs::cluskey clusKey = getClusKey(hitID);
   
-  const PHG4Hit *g4hit = clustereval->max_truth_hit_by_energy(clusKey);
+  const TrkrCluster *truth_cluster = clustereval->max_truth_cluster_by_energy(clusKey);
   
   float layer = (float) TrkrDefs::getLayer(clusKey);
   float gx = -9999;
@@ -712,22 +712,12 @@ Acts::Vector3D ActsEvaluator::getGlobalTruthHit(PHCompositeNode *topNode,
   float gt = -9999;
   float gedep = -9999;
   
-  if (g4hit)
+  if (truth_cluster)
     {
-      /// Cluster the associated truth hits within the same layer to get
-      /// the truth cluster position
-      std::set<PHG4Hit *> truth_hits = clustereval->all_truth_hits(clusKey);
-      std::vector<PHG4Hit *> contributing_hits;
-      std::vector<double> contributing_hits_energy;
-      std::vector<std::vector<double>> contributing_hits_entry;
-      std::vector<std::vector<double>> contributing_hits_exit;
-      m_svtxEvaluator->LayerClusterG4Hits(topNode, truth_hits, 
-					  contributing_hits,
-                                          contributing_hits_energy, 
-					  contributing_hits_entry,
-                                          contributing_hits_exit, 
-					  layer, gx, gy, gz, gt,
-                                          gedep);
+      gx = truth_cluster->getX();
+      gy = truth_cluster->getY();
+      gz = truth_cluster->getZ();
+      gedep = truth_cluster->getError(0,0);  // yes, it is a kludge ....
     }
   
   /// Convert to acts units of mm

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -10,6 +10,7 @@
 #include <phool/getClass.h>
 
 /// Tracking includes
+#include <trackbase/TrkrClusterv1.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 
@@ -705,19 +706,16 @@ Acts::Vector3D ActsEvaluator::getGlobalTruthHit(PHCompositeNode *topNode,
   
   const TrkrCluster *truth_cluster = clustereval->max_truth_cluster_by_energy(clusKey);
   
-  float layer = (float) TrkrDefs::getLayer(clusKey);
   float gx = -9999;
   float gy = -9999;
   float gz = -9999;
   float gt = -9999;
-  float gedep = -9999;
   
   if (truth_cluster)
     {
       gx = truth_cluster->getX();
       gy = truth_cluster->getY();
       gz = truth_cluster->getZ();
-      gedep = truth_cluster->getError(0,0);  // yes, it is a kludge ....
     }
   
   /// Convert to acts units of mm

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -138,6 +138,8 @@ TrkrCluster* SvtxClusterEval::max_truth_cluster_by_energy(TrkrDefs::cluskey clus
   unsigned int cluster_layer = TrkrDefs::getLayer(cluster_key);
 
   PHG4Particle* max_particle = max_truth_particle_by_cluster_energy(cluster_key);
+  if(!max_particle)
+    return truth_cluster;
 
   if(_verbosity > 0) 
     cout << "         max truth particle by cluster energy has  trackID  " << max_particle->get_track_id() << endl;      
@@ -232,8 +234,6 @@ TrkrCluster* SvtxClusterEval::reco_cluster_from_truth_cluster(TrkrCluster *gclus
     {
       // Find a matching reco cluster with position inside 4 sigmas, and replace reco_cluskey
       // and do some diagnostics on what went wrong here
-      
-      cout << "         --------  truth_layer " << truth_layer << " found " << nreco << " reco clusters for this g4cluster! " << endl;
       
       for(std::set<TrkrDefs::cluskey>::iterator it = reco_cluskeys.begin(); it != reco_cluskeys.end(); ++it)
 	{

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -174,10 +174,45 @@ TrkrCluster* SvtxClusterEval::max_truth_cluster_by_energy(TrkrDefs::cluskey clus
 	  double drphi = reco_rphi - grphi;
 	  
 	  // approximate 4 sigmas cut
-	  if(fabs(drphi) < 4.0 * 150e-04 &&
-	     fabs(dz) < 4.0 * 550e-04)
+	  if(cluster_layer > 6 && cluster_layer < 23)
 	    {
-	      return candidate_truth_cluster;;
+	      if(fabs(drphi) < 4.0 * sig_tpc_rphi_inner &&
+		 fabs(dz) < 4.0 * sig_tpc_z)
+		{
+		  return candidate_truth_cluster;;
+		}
+	    }
+	  if(cluster_layer > 22 && cluster_layer < 39)
+	    {
+	      if(fabs(drphi) < 4.0 * sig_tpc_rphi_mid &&
+		 fabs(dz) < 4.0 * sig_tpc_z)
+		{
+		  return candidate_truth_cluster;;
+		}
+	    }
+	  if(cluster_layer > 38 && cluster_layer < 55)
+	    {
+	      if(fabs(drphi) < 4.0 * sig_tpc_rphi_outer &&
+		 fabs(dz) < 4.0 * sig_tpc_z)
+		{
+		  return candidate_truth_cluster;;
+		}
+	    }
+	  else if(cluster_layer < 3)
+	    {
+	      if(fabs(drphi) < 4.0 * sig_mvtx_rphi &&
+		 fabs(dz) < 4.0 * sig_mvtx_z)
+		{
+		  return candidate_truth_cluster;;
+		}
+	    }
+	  else
+	    {
+	      if(fabs(drphi) < 4.0 * sig_intt_rphi &&
+		 fabs(dz) < range_intt_z)
+		{
+		  return candidate_truth_cluster;;
+		}
 	    }
 	}
     }
@@ -248,23 +283,75 @@ TrkrCluster* SvtxClusterEval::reco_cluster_from_truth_cluster(TrkrCluster *gclus
 	  // Find the difference in position from the g4cluster
 	  double dz = this_z - gz;
 	  double drphi = this_rphi - grphi;
-	  
-	  
-	  if(_verbosity > 0) 
-	    if(truth_layer > 6)
-	      cout << "        cluster " << *it 
-		   << " this_z " << this_z  << " this_rphi " << this_rphi << " grphi " << grphi 
-		   << " drphi " << drphi << " dz " << dz 
-		   << endl; 
-	  
 
 	  // approximate 4 sigmas cut
-	  if(fabs(drphi) < 4.0 * 150e-04 &&
-	     fabs(dz) < 4.0 * 550e-04)
+	  if(truth_layer > 6 && truth_layer < 23)
 	    {
-	      return this_cluster;;
+	      if(fabs(drphi) < 4.0 * sig_tpc_rphi_inner &&
+		 fabs(dz) < 4.0 * sig_tpc_z)
+		{
+		  return this_cluster;;
+		}
 	    }
-	  
+	  if(truth_layer > 22 && truth_layer < 39)
+	    {
+	      if(fabs(drphi) < 4.0 * sig_tpc_rphi_mid &&
+		 fabs(dz) < 4.0 * sig_tpc_z)
+		{
+		  return this_cluster;;
+		}
+	    }
+	  if(truth_layer > 38 && truth_layer < 55)
+	    {
+	      if(fabs(drphi) < 4.0 * sig_tpc_rphi_outer &&
+		 fabs(dz) < 4.0 * sig_tpc_z)
+		{
+		  return this_cluster;;
+		}
+	    }
+	  else if(truth_layer < 3)
+	    {
+	      if(fabs(drphi) < 4.0 * sig_mvtx_rphi &&
+		 fabs(dz) < 4.0 * sig_mvtx_z)
+		{
+		  return this_cluster;;
+		}
+	    }
+	  else
+	    {
+	      if(fabs(drphi) < 4.0 * sig_intt_rphi &&
+		 fabs(dz) < range_intt_z)
+		{
+		  return this_cluster;;
+		}
+	    }
+	  /*
+	  // approximate 4 sigmas cut
+	  if(truth_layer > 6)
+	    {
+	      if(fabs(drphi) < 4.0 * 150e-04 &&
+		 fabs(dz) < 4.0 * 550e-04)
+		{
+		  return this_cluster;;
+		}
+	    }
+	  else if(truth_layer < 3)
+	    {
+	      if(fabs(drphi) < 4.0 * 10e-04 &&
+		 fabs(dz) < 4.0 * 10e-04)
+		{
+		  return this_cluster;;
+		}
+	    }
+	  else
+	    {
+	      if(fabs(drphi) < 4.0 * 70e-04 &&
+		 fabs(dz) < 2.0)
+		{
+		  return this_cluster;;
+		}
+	    }
+	  */
 	}
     } 
       

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -67,6 +67,7 @@ void SvtxClusterEval::next_event(PHCompositeNode* topNode)
   _cache_all_truth_hits.clear();
   _cache_all_truth_clusters.clear();
   _cache_max_truth_hit_by_energy.clear();
+  _cache_max_truth_cluster_by_energy.clear();
   _cache_all_truth_particles.clear();
   _cache_max_truth_particle_by_energy.clear();
   _cache_max_truth_particle_by_cluster_energy.clear();
@@ -232,10 +233,9 @@ TrkrCluster* SvtxClusterEval::reco_cluster_from_truth_cluster(TrkrCluster *gclus
     }
 
   unsigned int nreco = reco_cluskeys.size();
-  if(nreco > 1)
+  if(nreco > 0)
     {
       // Find a matching reco cluster with position inside 4 sigmas, and replace reco_cluskey
-      // and do some diagnostics on what went wrong here
       
       for(std::set<TrkrDefs::cluskey>::iterator it = reco_cluskeys.begin(); it != reco_cluskeys.end(); ++it)
 	{

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -150,7 +150,8 @@ TrkrCluster* SvtxClusterEval::max_truth_cluster_by_energy(TrkrDefs::cluskey clus
   double reco_y = reco_cluster->getY();
   double reco_z = reco_cluster->getZ();
   double r = sqrt(reco_x*reco_x + reco_y*reco_y);
-  double reco_rphi = r*fast_approx_atan2(reco_y, reco_x);
+  //double reco_rphi = r*fast_approx_atan2(reco_y, reco_x);
+  double reco_rphi = r*atan2(reco_y, reco_x);
   
   std::map<unsigned int, TrkrCluster*> gclusters = get_truth_eval()->all_truth_clusters(max_particle);
   for (std::map<unsigned int, TrkrCluster*>::iterator citer = gclusters.begin();
@@ -159,24 +160,24 @@ TrkrCluster* SvtxClusterEval::max_truth_cluster_by_energy(TrkrDefs::cluskey clus
     {
       if(citer->first == cluster_layer) 
 	{
-	  truth_cluster = citer->second;
+	  TrkrCluster* candidate_truth_cluster = citer->second;
 
-	  double gx = truth_cluster->getX();
-	  double gy = truth_cluster->getY();
-	  double gz = truth_cluster->getZ();
+	  double gx = candidate_truth_cluster->getX();
+	  double gy = candidate_truth_cluster->getY();
+	  double gz = candidate_truth_cluster->getZ();
 	  double gr = sqrt(gx*gx+gy*gy);
-	  //double grphi = gr*atan2(gy, gx);
-	  double grphi = gr*fast_approx_atan2(gy, gx);
-
+	  double grphi = gr*atan2(gy, gx);
+	  //double grphi = gr*fast_approx_atan2(gy, gx);
+	  
 	  // Find the difference in position from the reco cluster
 	  double dz = reco_z - gz;
 	  double drphi = reco_rphi - grphi;
-
+	  
 	  // approximate 4 sigmas cut
 	  if(fabs(drphi) < 4.0 * 150e-04 &&
 	     fabs(dz) < 4.0 * 550e-04)
 	    {
-	      return truth_cluster;;
+	      return candidate_truth_cluster;;
 	    }
 	}
     }
@@ -201,11 +202,11 @@ TrkrCluster* SvtxClusterEval::reco_cluster_from_truth_cluster(TrkrCluster *gclus
   double gy = gclus->getY();
   double gz = gclus->getZ();
   double gr = sqrt(gx*gx+gy*gy);
-  //double grphi = gr*atan2(gy, gx);
-  double grphi = gr*fast_approx_atan2(gy, gx);
+  double grphi = gr*atan2(gy, gx);
+  //double grphi = gr*fast_approx_atan2(gy, gx);
 
-  TrkrCluster *reco_cluster = 0;
   unsigned int truth_layer = TrkrDefs::getLayer(ckey);
+  TrkrCluster *reco_cluster = 0;
 
   std::set<TrkrDefs::cluskey> reco_cluskeys;
   std::set<PHG4Hit*> contributing_hits =  get_truth_eval()->get_truth_hits_from_truth_cluster(ckey);
@@ -226,9 +227,6 @@ TrkrCluster* SvtxClusterEval::reco_cluster_from_truth_cluster(TrkrCluster *gclus
 	  if(clus_layer != truth_layer)  continue;
 	  
 	  reco_cluskeys.insert(*iter);
-
-	  // If there is only one matching cluster, we will keep this
-	  reco_cluster = _clustermap->findCluster(*iter);
 	}
     }
 
@@ -244,8 +242,8 @@ TrkrCluster* SvtxClusterEval::reco_cluster_from_truth_cluster(TrkrCluster *gclus
 	  double this_x = this_cluster->getX();
 	  double this_y = this_cluster->getY();
 	  double this_z = this_cluster->getZ();
-	  //double this_rphi = gr*atan2(this_y, this_x);
-	  double this_rphi = gr*fast_approx_atan2(this_y, this_x);
+	  double this_rphi = gr*atan2(this_y, this_x);
+	  //double this_rphi = gr*fast_approx_atan2(this_y, this_x);
 	  
 	  // Find the difference in position from the g4cluster
 	  double dz = this_z - gz;
@@ -856,7 +854,8 @@ void SvtxClusterEval::fill_cluster_layer_map()
     TrkrDefs::cluskey cluster_key = iter->first;
     unsigned int ilayer = TrkrDefs::getLayer(cluster_key);
     TrkrCluster *cluster = iter->second;
-    float clus_phi = fast_approx_atan2(cluster->getY(), cluster->getX());
+    //float clus_phi = fast_approx_atan2(cluster->getY(), cluster->getX());
+    float clus_phi = atan2(cluster->getY(), cluster->getX());
 
     multimap<unsigned int, innerMap>::iterator it = _clusters_per_layer.find(ilayer);
     if (it == _clusters_per_layer.end())

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -84,11 +84,11 @@ void SvtxClusterEval::next_event(PHCompositeNode* topNode)
   get_node_pointers(topNode);
 } 
 
-std::set<TrkrCluster*> SvtxClusterEval::all_truth_clusters(TrkrDefs::cluskey cluster_key)
+std::set<std::shared_ptr<TrkrCluster> > SvtxClusterEval::all_truth_clusters(TrkrDefs::cluskey cluster_key)
 {
   if (_do_cache)
   {
-    std::map<TrkrDefs::cluskey, std::set<TrkrCluster*> >::iterator iter =
+    std::map<TrkrDefs::cluskey, std::set<std::shared_ptr<TrkrCluster> > >::iterator iter =
         _cache_all_truth_clusters.find(cluster_key);
     if (iter != _cache_all_truth_clusters.end())
     {
@@ -96,7 +96,7 @@ std::set<TrkrCluster*> SvtxClusterEval::all_truth_clusters(TrkrDefs::cluskey clu
     }
   }
 
-  std::set<TrkrCluster*> truth_clusters;
+  std::set<std::shared_ptr<TrkrCluster> > truth_clusters;
 
   unsigned int cluster_layer = TrkrDefs::getLayer(cluster_key);
 
@@ -107,8 +107,8 @@ std::set<TrkrCluster*> SvtxClusterEval::all_truth_clusters(TrkrDefs::cluskey clu
     {
       PHG4Particle* particle = *iter;
       
-      std::map<unsigned int, TrkrCluster*> gclusters = get_truth_eval()->all_truth_clusters(particle);
-      for (std::map<unsigned int, TrkrCluster*>::iterator citer = gclusters.begin();
+      std::map<unsigned int, std::shared_ptr<TrkrCluster> > gclusters = get_truth_eval()->all_truth_clusters(particle);
+      for (std::map<unsigned int, std::shared_ptr<TrkrCluster> >::iterator citer = gclusters.begin();
 	   citer != gclusters.end();
 	   ++citer)
 	{
@@ -122,11 +122,11 @@ std::set<TrkrCluster*> SvtxClusterEval::all_truth_clusters(TrkrDefs::cluskey clu
   return truth_clusters;
 }
 
-TrkrCluster* SvtxClusterEval::max_truth_cluster_by_energy(TrkrDefs::cluskey cluster_key)
+std::shared_ptr<TrkrCluster> SvtxClusterEval::max_truth_cluster_by_energy(TrkrDefs::cluskey cluster_key)
 {
   if (_do_cache)
   {
-    std::map<TrkrDefs::cluskey, TrkrCluster* >::iterator iter =
+    std::map<TrkrDefs::cluskey, std::shared_ptr<TrkrCluster> >::iterator iter =
         _cache_max_truth_cluster_by_energy.find(cluster_key);
     if (iter != _cache_max_truth_cluster_by_energy.end())
     {
@@ -134,7 +134,7 @@ TrkrCluster* SvtxClusterEval::max_truth_cluster_by_energy(TrkrDefs::cluskey clus
     }
   }
 
-  TrkrCluster* truth_cluster = 0;
+  std::shared_ptr<TrkrCluster> truth_cluster = 0;
 
   unsigned int cluster_layer = TrkrDefs::getLayer(cluster_key);
 
@@ -153,14 +153,14 @@ TrkrCluster* SvtxClusterEval::max_truth_cluster_by_energy(TrkrDefs::cluskey clus
   //double reco_rphi = r*fast_approx_atan2(reco_y, reco_x);
   double reco_rphi = r*atan2(reco_y, reco_x);
   
-  std::map<unsigned int, TrkrCluster*> gclusters = get_truth_eval()->all_truth_clusters(max_particle);
-  for (std::map<unsigned int, TrkrCluster*>::iterator citer = gclusters.begin();
+  std::map<unsigned int, std::shared_ptr<TrkrCluster> > gclusters = get_truth_eval()->all_truth_clusters(max_particle);
+  for (std::map<unsigned int, std::shared_ptr<TrkrCluster> >::iterator citer = gclusters.begin();
        citer != gclusters.end();
        ++citer)
     {
       if(citer->first == cluster_layer) 
 	{
-	  TrkrCluster* candidate_truth_cluster = citer->second;
+	  std::shared_ptr<TrkrCluster> candidate_truth_cluster = citer->second;
 
 	  double gx = candidate_truth_cluster->getX();
 	  double gy = candidate_truth_cluster->getY();
@@ -220,11 +220,11 @@ TrkrCluster* SvtxClusterEval::max_truth_cluster_by_energy(TrkrDefs::cluskey clus
   return truth_cluster;
 }
 
-TrkrCluster* SvtxClusterEval::reco_cluster_from_truth_cluster(TrkrCluster *gclus)
+TrkrCluster* SvtxClusterEval::reco_cluster_from_truth_cluster(std::shared_ptr<TrkrCluster> gclus)
 {
   if (_do_cache)
   {
-    std::map<TrkrCluster*, TrkrCluster* >::iterator iter =
+    std::map<std::shared_ptr<TrkrCluster>, TrkrCluster* >::iterator iter =
       _cache_reco_cluster_from_truth_cluster.find(gclus);
     if (iter != _cache_reco_cluster_from_truth_cluster.end())
     {
@@ -325,33 +325,6 @@ TrkrCluster* SvtxClusterEval::reco_cluster_from_truth_cluster(TrkrCluster *gclus
 		  return this_cluster;;
 		}
 	    }
-	  /*
-	  // approximate 4 sigmas cut
-	  if(truth_layer > 6)
-	    {
-	      if(fabs(drphi) < 4.0 * 150e-04 &&
-		 fabs(dz) < 4.0 * 550e-04)
-		{
-		  return this_cluster;;
-		}
-	    }
-	  else if(truth_layer < 3)
-	    {
-	      if(fabs(drphi) < 4.0 * 10e-04 &&
-		 fabs(dz) < 4.0 * 10e-04)
-		{
-		  return this_cluster;;
-		}
-	    }
-	  else
-	    {
-	      if(fabs(drphi) < 4.0 * 70e-04 &&
-		 fabs(dz) < 2.0)
-		{
-		  return this_cluster;;
-		}
-	    }
-	  */
 	}
     } 
       
@@ -529,7 +502,7 @@ PHG4Particle* SvtxClusterEval::max_truth_particle_by_cluster_energy(TrkrDefs::cl
        ++iter)
     {
       PHG4Particle* particle = *iter;
-      std::map<unsigned int, TrkrCluster *> truth_clus = get_truth_eval()->all_truth_clusters(particle);
+      std::map<unsigned int, std::shared_ptr<TrkrCluster> > truth_clus = get_truth_eval()->all_truth_clusters(particle);
       for(auto it = truth_clus.begin(); it != truth_clus.end(); ++it)
 	{	
 	  if(it->first == layer)

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -62,6 +62,7 @@ class SvtxClusterEval
   // backtrace through to PHG4Particles
   std::set<PHG4Particle*> all_truth_particles(TrkrDefs::cluskey);
   PHG4Particle* max_truth_particle_by_energy(TrkrDefs::cluskey);
+  PHG4Particle* max_truth_particle_by_cluster_energy(TrkrDefs::cluskey);
 
   // forwardtrace through to SvtxClusters
   std::set<TrkrDefs::cluskey> all_clusters_from(PHG4Particle* truthparticle);
@@ -108,6 +109,7 @@ class SvtxClusterEval
   std::map<TrkrDefs::cluskey, TrkrCluster* > _cache_max_truth_cluster_by_energy;
   std::map<TrkrDefs::cluskey, std::set<PHG4Particle*> > _cache_all_truth_particles;
   std::map<TrkrDefs::cluskey, PHG4Particle*> _cache_max_truth_particle_by_energy;
+  std::map<TrkrDefs::cluskey, PHG4Particle*> _cache_max_truth_particle_by_cluster_energy;
   std::map<PHG4Particle*, std::set<TrkrDefs::cluskey> > _cache_all_clusters_from_particle;
   std::map<PHG4Hit*, std::set<TrkrDefs::cluskey> > _cache_all_clusters_from_g4hit;
   std::map<PHG4Hit*, TrkrDefs::cluskey> _cache_best_cluster_from_g4hit;

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -17,6 +17,7 @@ class PHG4HitContainer;
 class PHG4Particle;
 class PHG4TruthInfoContainer;
 
+class TrkrCluster;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class TrkrHitTruthAssoc;
@@ -55,6 +56,8 @@ class SvtxClusterEval
   // backtrace through to PHG4Hits
   std::set<PHG4Hit*> all_truth_hits(TrkrDefs::cluskey cluster);
   PHG4Hit* max_truth_hit_by_energy(TrkrDefs::cluskey);
+  std::set<TrkrCluster*> all_truth_clusters(TrkrDefs::cluskey cluster_key);
+  TrkrCluster* max_truth_cluster_by_energy(TrkrDefs::cluskey cluster_key);
 
   // backtrace through to PHG4Particles
   std::set<PHG4Particle*> all_truth_particles(TrkrDefs::cluskey);
@@ -68,6 +71,8 @@ class SvtxClusterEval
   // overlap calculations
   float get_energy_contribution(TrkrDefs::cluskey cluster_key, PHG4Particle* truthparticle);
   float get_energy_contribution(TrkrDefs::cluskey cluster_key, PHG4Hit* truthhit);
+
+  TrkrCluster* reco_cluster_from_truth_cluster(TrkrCluster* gclus);
 
   unsigned int get_errors() { return _errors + _hiteval.get_errors(); }
 
@@ -98,7 +103,9 @@ class SvtxClusterEval
 
   bool _do_cache;
   std::map<TrkrDefs::cluskey, std::set<PHG4Hit*> > _cache_all_truth_hits;
+  std::map<TrkrDefs::cluskey, std::set<TrkrCluster*> > _cache_all_truth_clusters;
   std::map<TrkrDefs::cluskey, PHG4Hit*> _cache_max_truth_hit_by_energy;
+  std::map<TrkrDefs::cluskey, TrkrCluster* > _cache_max_truth_cluster_by_energy;
   std::map<TrkrDefs::cluskey, std::set<PHG4Particle*> > _cache_all_truth_particles;
   std::map<TrkrDefs::cluskey, PHG4Particle*> _cache_max_truth_particle_by_energy;
   std::map<PHG4Particle*, std::set<TrkrDefs::cluskey> > _cache_all_clusters_from_particle;
@@ -106,6 +113,7 @@ class SvtxClusterEval
   std::map<PHG4Hit*, TrkrDefs::cluskey> _cache_best_cluster_from_g4hit;
   std::map<std::pair<TrkrDefs::cluskey, PHG4Particle*>, float> _cache_get_energy_contribution_g4particle;
   std::map<std::pair<TrkrDefs::cluskey, PHG4Hit*>, float> _cache_get_energy_contribution_g4hit;
+  std::map<TrkrCluster*, TrkrCluster* > _cache_reco_cluster_from_truth_cluster;
 
 #if !defined(__CINT__) || defined(__CLING__)
   //! cluster azimuthal searching window in _clusters_per_layer. Unit: rad

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -117,6 +117,17 @@ class SvtxClusterEval
   std::map<std::pair<TrkrDefs::cluskey, PHG4Hit*>, float> _cache_get_energy_contribution_g4hit;
   std::map<TrkrCluster*, TrkrCluster* > _cache_reco_cluster_from_truth_cluster;
 
+  // measured for low occupancy events, all in cm
+  const float sig_tpc_rphi_inner = 205e-04;
+  const float sig_tpc_rphi_mid = 155e-04;
+  const float sig_tpc_rphi_outer = 165e-04;
+  const float sig_tpc_z = 750e-04;
+  const float sig_intt_rphi = 17e-04;
+  const float range_intt_z = 0.9;
+  const float sig_mvtx_rphi = 4.0e-04;
+  const float sig_mvtx_z = 4.7e-04;
+
+
 #if !defined(__CINT__) || defined(__CLING__)
   //! cluster azimuthal searching window in _clusters_per_layer. Unit: rad
   static constexpr float _clusters_searching_window = 0.1f;

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -56,8 +56,8 @@ class SvtxClusterEval
   // backtrace through to PHG4Hits
   std::set<PHG4Hit*> all_truth_hits(TrkrDefs::cluskey cluster);
   PHG4Hit* max_truth_hit_by_energy(TrkrDefs::cluskey);
-  std::set<TrkrCluster*> all_truth_clusters(TrkrDefs::cluskey cluster_key);
-  TrkrCluster* max_truth_cluster_by_energy(TrkrDefs::cluskey cluster_key);
+  std::set<std::shared_ptr<TrkrCluster> > all_truth_clusters(TrkrDefs::cluskey cluster_key);
+  std::shared_ptr<TrkrCluster> max_truth_cluster_by_energy(TrkrDefs::cluskey cluster_key);
 
   // backtrace through to PHG4Particles
   std::set<PHG4Particle*> all_truth_particles(TrkrDefs::cluskey);
@@ -73,7 +73,7 @@ class SvtxClusterEval
   float get_energy_contribution(TrkrDefs::cluskey cluster_key, PHG4Particle* truthparticle);
   float get_energy_contribution(TrkrDefs::cluskey cluster_key, PHG4Hit* truthhit);
 
-  TrkrCluster* reco_cluster_from_truth_cluster(TrkrCluster* gclus);
+  TrkrCluster* reco_cluster_from_truth_cluster(std::shared_ptr<TrkrCluster> gclus);
 
   unsigned int get_errors() { return _errors + _hiteval.get_errors(); }
 
@@ -104,9 +104,9 @@ class SvtxClusterEval
 
   bool _do_cache;
   std::map<TrkrDefs::cluskey, std::set<PHG4Hit*> > _cache_all_truth_hits;
-  std::map<TrkrDefs::cluskey, std::set<TrkrCluster*> > _cache_all_truth_clusters;
+  std::map<TrkrDefs::cluskey, std::set<std::shared_ptr<TrkrCluster> > > _cache_all_truth_clusters;
   std::map<TrkrDefs::cluskey, PHG4Hit*> _cache_max_truth_hit_by_energy;
-  std::map<TrkrDefs::cluskey, TrkrCluster* > _cache_max_truth_cluster_by_energy;
+  std::map<TrkrDefs::cluskey, std::shared_ptr<TrkrCluster> > _cache_max_truth_cluster_by_energy;
   std::map<TrkrDefs::cluskey, std::set<PHG4Particle*> > _cache_all_truth_particles;
   std::map<TrkrDefs::cluskey, PHG4Particle*> _cache_max_truth_particle_by_energy;
   std::map<TrkrDefs::cluskey, PHG4Particle*> _cache_max_truth_particle_by_cluster_energy;
@@ -115,10 +115,10 @@ class SvtxClusterEval
   std::map<PHG4Hit*, TrkrDefs::cluskey> _cache_best_cluster_from_g4hit;
   std::map<std::pair<TrkrDefs::cluskey, PHG4Particle*>, float> _cache_get_energy_contribution_g4particle;
   std::map<std::pair<TrkrDefs::cluskey, PHG4Hit*>, float> _cache_get_energy_contribution_g4hit;
-  std::map<TrkrCluster*, TrkrCluster* > _cache_reco_cluster_from_truth_cluster;
+  std::map<std::shared_ptr<TrkrCluster>, TrkrCluster* > _cache_reco_cluster_from_truth_cluster;
 
   // measured for low occupancy events, all in cm
-  const float sig_tpc_rphi_inner = 205e-04;
+  const float sig_tpc_rphi_inner = 220e-04;
   const float sig_tpc_rphi_mid = 155e-04;
   const float sig_tpc_rphi_outer = 165e-04;
   const float sig_tpc_z = 750e-04;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -162,7 +162,7 @@ int SvtxEvaluator::Init(PHCompositeNode* topNode)
                                                    "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps");
 
   if (_do_g4cluster_eval) _ntp_g4cluster = new TNtuple("ntp_g4cluster", "g4cluster => max truth",
-						       "event:layer:gx:gy:gz:gt:gedep:gr:gphi:geta:gtrackID:gflavor:gembed:gprimary:g4phisize:g4zsize:nreco:x:y:z:r:phi:eta:ex:ey:ez:ephi:phisize:zsize:adc"); 
+						       "event:layer:gx:gy:gz:gt:gedep:gr:gphi:geta:gtrackID:gflavor:gembed:gprimary:gphisize:gzsize:nreco:x:y:z:r:phi:eta:ex:ey:ez:ephi:phisize:zsize:adc"); 
                                                        
   if (_do_gtrack_eval) _ntp_gtrack = new TNtuple("ntp_gtrack", "g4particle => best svtxtrack",
                                                  "event:seed:gntracks:gtrackID:gflavor:gnhits:gnmaps:gnintt:"
@@ -1671,8 +1671,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	TrkrDefs::cluskey cluster_key = iter->first;
 	TrkrCluster *cluster = clustermap->findCluster(cluster_key);
         SvtxTrack* track = trackeval->best_track_from(cluster_key);
-        PHG4Hit* g4hit = clustereval->max_truth_hit_by_energy(cluster_key);
-        PHG4Particle* g4particle = trutheval->get_particle(g4hit);
+        PHG4Particle* g4particle = clustereval->max_truth_particle_by_energy(cluster_key);
 
         float hitID = (float) cluster_key;
         float x = cluster->getX();
@@ -1710,7 +1709,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         float gz = NAN;
         float gr = NAN;
         float gphi = NAN;
-        float gedep = NAN;
+        //float gedep = NAN;
         float geta = NAN;
         float gt = NAN;
         float gtrackID = NAN;
@@ -1733,19 +1732,30 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
         float efromtruth = NAN;
 
-        if (g4hit)
-        {
-	  // cluster the associated truth hits within the same layer to get the truth cluster position
-	   std::set<PHG4Hit*> truth_hits = clustereval->all_truth_hits(cluster_key);
-	   std::vector<PHG4Hit*> contributing_hits;
-	   std::vector<double> contributing_hits_energy;
-	   std::vector<std::vector<double>> contributing_hits_entry;
-	   std::vector<std::vector<double>> contributing_hits_exit;
-	   LayerClusterG4Hits(topNode, truth_hits, contributing_hits, contributing_hits_energy, contributing_hits_entry, contributing_hits_exit, layer, gx, gy, gz, gt, gedep);
+	if(Verbosity() > -1)
+	  {
+	    TrkrDefs::cluskey reco_cluskey = cluster->getClusKey();		  
+	    std::cout << "  ****   reco: layer " << layer << std::endl;
+	    cout << "              reco cluster key " << reco_cluskey << "  r " << r << "  x " << x << "  y " << y << "  z " << z << "  phi " << phi  << " adc " << adc << endl;
+	  }
 
-	    g4hitID = g4hit->get_hit_id();
+	// get best matching truth cluster from clustereval
+	TrkrCluster* truth_cluster = clustereval->max_truth_cluster_by_energy(cluster_key);
+	if(truth_cluster)
+	  {
+	    if(Verbosity() > 0)
+	      {
+		TrkrDefs::cluskey truth_cluskey = truth_cluster->getClusKey();
+		cout << "Found matching truth cluster with key " << truth_cluskey << " for reco cluster key " << cluster_key << " in layer " << layer << endl;
+	      }
+
+	    g4hitID = 0;
+	    gx=truth_cluster->getX();
+	    gy=truth_cluster->getY();
+	    gz=truth_cluster->getZ();
+
 	    TVector3 gpos(gx, gy, gz);
-	    gr = gpos.Perp();  // c ould also be just the center of gthe layer
+	    gr = gpos.Perp();  // could also be just the center of the layer
 	    gphi = gpos.Phi();
 	    geta = gpos.Eta();
 
@@ -1781,13 +1791,19 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
             gembed = trutheval->get_embed(g4particle);
             gprimary = trutheval->is_primary(g4particle);
-
+	    efromtruth = clustereval->get_energy_contribution(cluster_key, g4particle);	    
           }  //   if (g4particle){
-        }    //  if (g4hit) {
+	  
+	  if(Verbosity() > -1)
+	    {
+	      TrkrDefs::cluskey ckey = truth_cluster->getClusKey();		  
+	      cout << "             truth cluster key " << ckey << " gr " << gr << " gx " << gx << " gy " << gy << " gz " << gz << " gphi " << gphi << " efromtruth " << efromtruth << endl;
+	    }
+	  }    //  if (truth_cluster) {
 
         if (g4particle)
         {
-          efromtruth = clustereval->get_energy_contribution(cluster_key, g4particle);
+
         }
 
         float nparticles = clustereval->all_truth_particles(cluster_key).size();
@@ -1850,7 +1866,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
   }
   else if (_ntp_cluster && _scan_for_embedded)
   {
-    if (Verbosity() > 1) cout << "Filling ntp_cluster (embedded only) " << endl;
+    if (Verbosity() > 1) 
+      cout << "Filling ntp_cluster (embedded only) " << endl;
 
     // if only scanning embedded signals, loop over all the tracks from
     // embedded particles and report all of their clusters, including those
@@ -1922,7 +1939,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	  float gz = NAN;
 	  float gr = NAN;
 	  float gphi = NAN;
-	  float gedep = NAN;
+	  //float gedep = NAN;
 	  float geta = NAN;
 	  float gt = NAN;
 	  float gtrackID = NAN;
@@ -1945,17 +1962,23 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	  
           float efromtruth = NAN;
 
-          if (g4hit)
-          {
-	    // cluster truth hits in layer
-	   std::set<PHG4Hit*> truth_hits = clustereval->all_truth_hits(cluster_key);
-	   std::vector<PHG4Hit*> contributing_hits;
-	   std::vector<double> contributing_hits_energy;
-	   std::vector<std::vector<double>> contributing_hits_entry;
-	   std::vector<std::vector<double>> contributing_hits_exit;
-	   LayerClusterG4Hits(topNode, truth_hits, contributing_hits, contributing_hits_energy, contributing_hits_entry, contributing_hits_exit, layer, gx, gy, gz, gt, gedep);
+	  //cout << "Look for truth cluster to match reco cluster " << cluster_key << endl;
 
-	    g4hitID = g4hit->get_hit_id();
+	// get best matching truth cluster from clustereval
+	TrkrCluster* truth_cluster = clustereval->max_truth_cluster_by_energy(cluster_key);
+	if(truth_cluster)
+	  {
+	    if(Verbosity() > 0)
+	      {
+		TrkrDefs::cluskey truth_cluskey = truth_cluster->getClusKey();
+		cout << "    Found matching truth cluster with key " << truth_cluskey << " for reco cluster key " << cluster_key << " in layer " << layer << endl;
+	      }
+
+	    g4hitID = 0;
+	    gx=truth_cluster->getX();
+	    gy=truth_cluster->getY();
+	    gz=truth_cluster->getZ();
+
 	    TVector3 gpos(gx, gy, gz);
 	    gr = gpos.Perp();
 	    gphi = gpos.Phi();
@@ -2077,11 +2100,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
   if (_ntp_g4cluster)
     {
-      if (Verbosity() > 1) cout << "Filling ntp_g4cluster " << endl;
+      if (Verbosity() > 1) 
+	cout << "Filling ntp_g4cluster " << endl;
 
-      TrkrClusterContainer* clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
-      
-      PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");      
+       PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");      
       PHG4TruthInfoContainer::ConstRange range = truthinfo->GetParticleRange();
       for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
            iter != range.second;
@@ -2094,62 +2116,46 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	    {
 	      if (trutheval->get_embed(g4particle) <= 0) continue;
 	    }
-	  
+
 	  float gtrackID = g4particle->get_track_id();
-	  float gflavor = g4particle->get_pid();
-	  
-	  std::set<PHG4Hit*> g4hits = trutheval->all_truth_hits(g4particle);
-	  
-	  float ng4hits = g4hits.size();
+	  float gflavor = g4particle->get_pid();	  
+	  float gembed = trutheval->get_embed(g4particle);
+	  float gprimary = trutheval->is_primary(g4particle);
 
-	  if(ng4hits == 0)  continue;
+	  if(Verbosity() > -1)
+	    cout << "PHG4Particle ID " << gtrackID << " gflavor " << gflavor << " gprimary " << gprimary << endl;
 
-	  if(Verbosity() > 1)
-	    cout << "ntp_g4cluster: new particle with gtrackID " << gtrackID << " gflavor " << gflavor << " ng4hits " << ng4hits << endl;
+	  // Get the truth clusters from this particle
+	  std::map<unsigned int, TrkrCluster*> truth_clusters =   trutheval->all_truth_clusters(g4particle);
 
-	  // convert truth hits for this particle to truth clusters in each TPC layer
-
-	  // loop over layers
-	  for(float layer = 0; layer < _nlayers_maps + _nlayers_intt + _nlayers_tpc; ++layer)
+	  // loop over layers and add to ntuple
+	  for ( auto it = truth_clusters.begin(); it != truth_clusters.end(); ++it  )
 	    {
-	      float gx = NAN;
-	      float gy = NAN;
-	      float gz = NAN;
-	      float gt = NAN;
-	      float gedep = NAN;
+	      unsigned int layer = it->first;
+	      TrkrCluster *gclus = it->second;
 
-	      std::vector<PHG4Hit*> contributing_hits;
-	      std::vector<double> contributing_hits_energy;
-	      std::vector<std::vector<double>> contributing_hits_entry;
-	      std::vector<std::vector<double>> contributing_hits_exit;
-	      LayerClusterG4Hits(topNode, g4hits, contributing_hits, contributing_hits_energy, contributing_hits_entry, contributing_hits_exit, layer, gx, gy, gz, gt, gedep);
-	      if(!(gedep > 0)) continue;
- 
-	      float gr = NAN;
-	      float gphi = NAN;
-	      float geta = NAN;
+	      float gx = gclus->getX();
+	      float gy = gclus->getY();
+	      float gz = gclus->getZ();
+	      float gt = NAN;
+	      float gedep = gclus->getError(0,0);
 
 	      TVector3 gpos(gx, gy, gz);
-	      gr = sqrt(gx*gx+gy*gy);
-	      gphi = gpos.Phi();
-	      geta = gpos.Eta();
+	      float gr = sqrt(gx*gx+gy*gy);
+	      float gphi = gpos.Phi();
+	      float geta = gpos.Eta();
+
+	      if(Verbosity() > -1)
+		{
+		  TrkrDefs::cluskey ckey = gclus->getClusKey();		  
+		  std::cout << "  ****   truth: layer " << layer << std::endl;
+		  cout << "             truth cluster key " << ckey << " gr " << gr << " gx " << gx << " gy " << gy << " gz " << gz << " gphi " << gphi << " gedep " << gedep << endl;
+		}
 	      
-	      float gembed = NAN;
-	      gembed = trutheval->get_embed(g4particle);
-	      float gprimary = NAN;
-              gprimary = trutheval->is_primary(g4particle);
-
-	      if(Verbosity() > 1)
-		cout << "  layer " << layer << " gr " << gr << " gx " << gx << " gy " << gy << " gz " << gz << " gedep " << gedep << endl; 
-
-	      // Estimate the size of the truth cluster
-	      float g4phisize = NAN;
-	      float g4zsize = NAN;
-	      G4ClusterSize( topNode, layer, contributing_hits_entry, contributing_hits_exit, g4phisize, g4zsize);
+	      float gphisize = gclus->getSize(1,1);
+	      float gzsize = gclus->getSize(2,2);
 
 	      // Find the matching TrkrCluster, if it exists
-	      // Presently, this code makes a list of all reco clusters that contain contributions from
-	      // g4hits that contribute to this g4cluster, and chooses the one within 4 sigmas in position
 
 	      float x = NAN;
 	      float y = NAN;
@@ -2165,154 +2171,47 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	      float zsize = NAN;
 	      float adc = NAN;
 
-	      TrkrDefs::cluskey reco_cluskey = 0;
 	      float nreco = 0;
-	      std::set<TrkrDefs::cluskey> reco_clusters;
-	      // loop over all conteributing hits, look up the associated clusters, pick the ones in this layer.
 
-	      for(unsigned int i=0; i< contributing_hits.size(); ++i)
+	      TrkrCluster *reco_cluster = clustereval->reco_cluster_from_truth_cluster(gclus);
+	      if(reco_cluster)
 		{
-
-		  PHG4Hit* cont_g4hit = contributing_hits[i];
-		  double energy = contributing_hits_energy[i];
-
-		  std::set<TrkrDefs::cluskey> clusters = clustereval->all_clusters_from(cont_g4hit);  // this returns clusters from this hit in any layer using TrkrAssoc maps
-
-		  if(Verbosity() > 1)
-		    cout << "       contributing g4hitID " << cont_g4hit->get_hit_id() << " g4trackID " << cont_g4hit->get_trkid() << " energy " << energy << endl;
-
-		  for (std::set<TrkrDefs::cluskey>::iterator iter = clusters.begin();
-		       iter != clusters.end();
-		       ++iter)
-		    {
-		      TrkrDefs::cluskey this_cluskey = *iter;
-		      unsigned int clus_layer = TrkrDefs::getLayer(this_cluskey);
-		      // discard if in the wrong layer
-		      if(clus_layer != layer)  continue;
-
-		      reco_clusters.insert(this_cluskey);
-
-		      if(Verbosity() > 1)
-			cout << "             associated: this_cluskey " << this_cluskey << " clus_layer " << clus_layer << endl;
-
-		      // If there is only one matching cluster, we will keep this
-		      reco_cluskey = this_cluskey;
-		    }
-		}
-	      nreco = reco_clusters.size();
-	      if(nreco > 1)
-		{
-		  // Find a matching reco cluster with position inside 4 sigmas, and replace reco_cluskey
-		  // and do some diagnostics on what went wrong here
-
-		  if(Verbosity() > 0)  
-		  if(gtrackID >= 0 && layer > 6)
-		    cout << "         --------  layer " << layer << " found " << nreco << " reco clusters for this g4cluster! " << endl;
-
-		  int side = -1;
-		  int sector = -1;		  
-		  int gotit = -1;
-		  for(std::set<TrkrDefs::cluskey>::iterator it = reco_clusters.begin(); it != reco_clusters.end(); ++it)
-		    {
-		      TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(*it);
-		      int this_side = TpcDefs::getSide(hitsetkey);
-		      int this_sector = TpcDefs::getSectorId(hitsetkey);
-		      
-		      // get the cluster
-		      TrkrCluster* this_cluster = clustermap->findCluster(*it);
-		      double this_adc = this_cluster->getAdc();
-		      double this_x = this_cluster->getX();
-		      double this_y = this_cluster->getY();
-		      double this_z = this_cluster->getZ();
-		      double this_phi = atan2(this_y, this_x);
-
-		      // Find the difference in position from the g4cluster
-		      double dz = this_z - gz;
-		      double dphi = this_phi - gphi;
-		      double drphi = gr * dphi;
-
-		      if(Verbosity() > 0) 
-		      if(gtrackID >= 0 && layer > 6)
-			cout << "        cluster " << *it << " this_side " << this_side << " this_sector " << this_sector << " this_adc " << this_adc 
-			     << " this_z " << this_z  << " this_phi " << this_phi << " gphi " << gphi 
-			     << " drphi " << drphi << " dz " << dz 
-			     << endl; 
-
-		      // approximate 4 sigmas cut
-		      if(fabs(drphi) < 4.0 * 150e-04 &&
-			fabs(dz) < 4.0 * 550e-04)
-			{
-			  gotit = 1;
-			  reco_cluskey = *it;
-			}
-
-		      if(sector == -1)
-			{
-			  side = this_side;
-			  sector = this_sector;
-			}
-		      else 
-			{
-			  if(this_side != side)
-			    side = 999;
-			  if (this_sector != sector)
-			    sector = 999;
-			}
-		    }			
-
-		  if(gotit == -1)
-		    {
-		      if(Verbosity() > 0)
-			if(gtrackID >= 0 && layer > 6)  
-			  cout << "       Did not get close reco cluster match" << endl;
-
-		      reco_cluskey = 0;
-		    }
-
-		  if(Verbosity() > 0)
-		    if(gtrackID >= 0 && layer > 6)  
-		      {
-			cout << "        best  reco_cluskey = " << reco_cluskey << endl;
-			if(sector == 999) 
-			  cout << "        ***** sector change!" << endl;
-			if(side == 999)
-			  cout << "        ***** side change!" << endl;
-			if( side != 999 && sector != 999)
-			  cout << "     ***** NO sector or side change" << endl;
-		      }
-		}
-	      
-	      if(reco_cluskey)
-		{
-		  TrkrCluster* cluster = clustermap->findCluster(reco_cluskey);
+		  nreco = 1;
 		  
-		  x = cluster->getX();
-		  y = cluster->getY();
-		  z = cluster->getZ();
+		  x = reco_cluster->getX();
+		  y = reco_cluster->getY();
+		  z = reco_cluster->getZ();
 
 		  TVector3 pos(x, y, z);
 		  r = sqrt(x*x+y*y);
 		  phi = pos.Phi();
 		  eta = pos.Eta();
-		  ex = sqrt(cluster->getError(0, 0));
-		  ey = sqrt(cluster->getError(1, 1));
-		  ez = cluster->getZError();		  
-		  ephi = cluster->getRPhiError();
+		  ex = sqrt(reco_cluster->getError(0, 0));
+		  ey = sqrt(reco_cluster->getError(1, 1));
+		  ez = reco_cluster->getZError();		  
+		  ephi = reco_cluster->getRPhiError();
 
-		  phisize = cluster->getPhiSize();  
-		  zsize = cluster->getZSize();   
+		  phisize = reco_cluster->getPhiSize();  
+		  zsize = reco_cluster->getZSize();   
 		  
-		  adc = cluster->getAdc();
+		  adc = reco_cluster->getAdc();
 
-		  if(Verbosity() > 1)
-		    cout << "             reco cluster r " << r << " x " << x << " y " << y << " z " << z << " phisize " << phisize << " zsize " << zsize << endl;
-
+		  if(Verbosity() > -1)
+		    {
+		      TrkrDefs::cluskey reco_cluskey = reco_cluster->getClusKey();		  
+		      cout << "              reco cluster key " << reco_cluskey << "  r " << r << "  x " << x << "  y " << y << "  z " << z << "  phi " << phi  << " adc " << adc << endl;
+		    }
 		}
+	      if(nreco == 0)
+		{
+		  cout << "   ----------- Failed to find matching reco cluster " << endl;
+		}
+
 
 	      // add this cluster to the ntuple
 
 	      float g4cluster_data[] = {(float) _ievent,
-					layer,
+					(float) layer,
 					gx,
 					gy,
 					gz,
@@ -2325,8 +2224,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 					gflavor,
 					gembed,
 					gprimary,
-					g4phisize,
-					g4zsize,
+					gphisize,
+					gzsize,
 					nreco,
 					x,
 					y,
@@ -3378,510 +3277,3 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
 }
 
-void SvtxEvaluator::G4ClusterSize(PHCompositeNode* topNode, unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry,std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize)
-{
-
-  // sort the contributing g4hits in radius
-  double inner_radius = 100.;
-  double inner_x = NAN;
-  double inner_y = NAN;
-  double inner_z = NAN;;
-
-  double outer_radius = 0.;
-  double outer_x = NAN;
-  double outer_y = NAN;
-  double outer_z = NAN;
-
-  for(unsigned int ihit=0;ihit<contributing_hits_entry.size(); ++ihit)
-    {
-      double rad1 = sqrt(pow(contributing_hits_entry[ihit][0], 2) + pow(contributing_hits_entry[ihit][1], 2));      
-      if(rad1 < inner_radius)
-	{
-	  inner_radius = rad1;
-	  inner_x = contributing_hits_entry[ihit][0];
-	  inner_y = contributing_hits_entry[ihit][1];
-	  inner_z = contributing_hits_entry[ihit][2];    
-	}
-
-      double rad2 = sqrt(pow(contributing_hits_exit[ihit][0], 2) + pow(contributing_hits_exit[ihit][1], 2));
-      if(rad2 > outer_radius)
-	{
-	  outer_radius = rad2;
-	  outer_x = contributing_hits_exit[ihit][0];
-	  outer_y = contributing_hits_exit[ihit][1];
-	  outer_z = contributing_hits_exit[ihit][2];    
-	}
-    }
-
-  double inner_phi =  atan2(inner_y, inner_x);
-  double outer_phi =  atan2(outer_y, outer_x);
-  double avge_z = (outer_z + inner_z) / 2.0;
-
-  // Now fold these with the expected diffusion and shaping widths
-  // assume spread is +/- equals this many sigmas times diffusion and shaping when extending the size
-  double sigmas = 2.0;
-
-  double radius = (inner_radius + outer_radius)/2.;
-  if(radius > 28)  // TPC
-    {
-      PHG4CylinderCellGeomContainer* geom_container =
-	findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
-      if (!geom_container)
-	{
-	  std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
-	  return;
-	}
-      PHG4CylinderCellGeom*layergeom = geom_container->GetLayerCellGeom(layer);
-
-      double tpc_length = 211.0;  // cm
-      double drift_velocity = 8.0 / 1000.0;  // cm/ns
-
-      // Phi size
-      //======
-      double diffusion_trans =  0.006;  // cm/SQRT(cm)
-      double phidiffusion = diffusion_trans * sqrt(tpc_length / 2. - fabs(avge_z));
-
-      double added_smear_trans = 0.085; // cm
-      double gem_spread = 0.04;  // 400 microns
-
-      if(outer_phi < inner_phi) swap(outer_phi, inner_phi);
-
-      // convert diffusion from cm to radians
-      double g4max_phi =  outer_phi + sigmas * sqrt(  pow(phidiffusion, 2) + pow(added_smear_trans, 2) + pow(gem_spread, 2) ) / radius;
-      double g4min_phi =  inner_phi - sigmas * sqrt(  pow(phidiffusion, 2) + pow(added_smear_trans, 2) + pow(gem_spread, 2) ) / radius;
-
-      // find the bins containing these max and min z edges
-      unsigned int phibinmin = layergeom->get_phibin(g4min_phi);
-      unsigned int phibinmax = layergeom->get_phibin(g4max_phi);
-      unsigned int phibinwidth = phibinmax - phibinmin + 1;
-      g4phisize = (double) phibinwidth * layergeom->get_phistep() * layergeom->get_radius();
-
-      // Z size
-      //=====
-      double g4max_z = 0;
-      double g4min_z = 0;
- 
-      outer_z = fabs(outer_z);
-      inner_z = fabs(inner_z);
-
-      double diffusion_long = 0.015;  // cm/SQRT(cm)
-      double zdiffusion = diffusion_long * sqrt(tpc_length / 2. - fabs(avge_z)) ;
-      double zshaping_lead = 32.0 * drift_velocity;  // ns * cm/ns = cm
-      double zshaping_tail = 48.0 * drift_velocity;
-      double added_smear_long = 0.105;  // cm
-
-      // largest z reaches gems first, make that the outer z
-      if(outer_z < inner_z) swap(outer_z, inner_z);
-      g4max_z = outer_z  + sigmas*sqrt(pow(zdiffusion,2) + pow(added_smear_long,2) + pow(zshaping_lead, 2));
-      g4min_z = inner_z  -  sigmas*sqrt(pow(zdiffusion,2) + pow(added_smear_long,2) + pow(zshaping_tail, 2));
-
-      // find the bins containing these max and min z edges
-      unsigned int binmin = layergeom->get_zbin(g4min_z);
-      unsigned int binmax = layergeom->get_zbin(g4max_z);
-      if(binmax < binmin) swap(binmax, binmin);
-      unsigned int binwidth = binmax - binmin + 1;
-
-      // multiply total number of bins that include the edges by the bin size
-      g4zsize = (double) binwidth * layergeom->get_zstep();
-    }
-  else if(radius > 5 && radius < 20)  // INTT
-    {
-      // All we have is the position and layer number
-
-      PHG4CylinderGeomContainer *geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
-      CylinderGeomIntt *layergeom = dynamic_cast<CylinderGeomIntt *>(geom_container->GetLayerGeom(layer));
-
-      // inner location
-      double world_inner[3] = {inner_x, inner_y, inner_z};
-      TVector3 world_inner_vec = {inner_x, inner_y, inner_z};
-
-      int segment_z_bin, segment_phi_bin;
-      layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_inner);
-
-      TVector3 local_inner_vec =  layergeom->get_local_from_world_coords(segment_z_bin, segment_phi_bin, world_inner_vec);
-      double yin = local_inner_vec[1];
-      double zin = local_inner_vec[2];
-      int strip_y_index, strip_z_index;
-      layergeom->find_strip_index_values(segment_z_bin, yin, zin, strip_y_index, strip_z_index);
-
-	// outer location
-      double world_outer[3] = {outer_x, outer_y, outer_z};
-      TVector3 world_outer_vec = {outer_x, outer_y, outer_z};
-
-      layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_outer);
-
-      TVector3 local_outer_vec =  layergeom->get_local_from_world_coords(segment_z_bin, segment_phi_bin, world_outer_vec);
-      double yout = local_outer_vec[1];
-      double zout = local_outer_vec[2];
-      int strip_y_index_out, strip_z_index_out;
-      layergeom->find_strip_index_values(segment_z_bin, yout, zout, strip_y_index_out, strip_z_index_out);
- 
-      int strips = abs(strip_y_index_out - strip_y_index) + 1;
-      int cols = abs(strip_z_index_out - strip_z_index) + 1;
-
-
-      double strip_width = (double) strips * layergeom->get_strip_y_spacing(); // cm
-      double strip_length = (double) cols * layergeom->get_strip_z_spacing(); // cm
-
-      g4phisize = strip_width;
-      g4zsize = strip_length;
-
-      if(Verbosity() > 1)
-	cout << " INTT: layer " << layer << " strips " << strips << " strip pitch " <<  layergeom->get_strip_y_spacing() << " g4phisize "<< g4phisize 
-	     << " columns " << cols << " strip_z_spacing " <<  layergeom->get_strip_z_spacing() << " g4zsize " << g4zsize << endl;
-    }
-  else  // MVTX
-    {
-      unsigned int stave, stave_outer;
-      unsigned int chip, chip_outer;
-      int row, row_outer;
-      int column, column_outer;
-
-      // add diffusion to entry and exit locations
-      double max_diffusion_radius = 25.0e-4;  // 25 microns
-      double min_diffusion_radius = 8.0e-4;  // 8 microns
-
-      PHG4CylinderGeomContainer* geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
-      CylinderGeom_Mvtx *layergeom = dynamic_cast<CylinderGeom_Mvtx *>(geom_container->GetLayerGeom(layer));
-
-      TVector3 world_inner = {inner_x, inner_y, inner_z};
-      std::vector<double> world_inner_vec = { world_inner[0], world_inner[1], world_inner[2] };
-      layergeom->get_sensor_indices_from_world_coords(world_inner_vec, stave, chip);
-      TVector3 local_inner = layergeom->get_local_from_world_coords(stave, chip, world_inner);
-
-      TVector3 world_outer = {outer_x, outer_y, outer_z};
-      std::vector<double> world_outer_vec = { world_outer[0], world_outer[1], world_outer[2] };
-      layergeom->get_sensor_indices_from_world_coords(world_outer_vec, stave_outer, chip_outer);
-      TVector3 local_outer = layergeom->get_local_from_world_coords(stave_outer, chip_outer, world_outer);
-
-      double diff =  max_diffusion_radius * 0.6;  // factor of 0.6 gives decent agreement with low occupancy reco clusters
-      if(local_outer[0] < local_inner[0]) 
-	diff = -diff;
-      local_outer[0] += diff;
-      local_inner[0] -= diff;
-
-      double diff_outer = min_diffusion_radius * 0.6;
-      if(local_outer[2] < local_inner[2]) 
-	diff_outer = -diff_outer;
-      local_outer[2] += diff_outer;
-      local_inner[2] -= diff_outer;
-
-      layergeom->get_pixel_from_local_coords(local_inner, row, column);
-      layergeom->get_pixel_from_local_coords(local_outer, row_outer, column_outer);
-
-      if(row_outer < row) swap(row_outer, row);
-      unsigned int rows = row_outer - row + 1;
-      g4phisize = (double) rows * layergeom->get_pixel_x();
-
-      if(column_outer < column) swap(column_outer, column);
-      unsigned int columns = column_outer - column + 1;
-      g4zsize = (double) columns * layergeom->get_pixel_z();
-
-      if(Verbosity() > 1)
-	cout << " MVTX: layer " << layer << " rows " << rows << " pixel x " <<  layergeom->get_pixel_x() << " g4phisize "<< g4phisize 
-	     << " columns " << columns << " pixel_z " <<  layergeom->get_pixel_z() << " g4zsize " << g4zsize << endl;
-
-    }
-
-}
- 
-void SvtxEvaluator::LayerClusterG4Hits(PHCompositeNode* topNode, std::set<PHG4Hit*> truth_hits, std::vector<PHG4Hit*> &contributing_hits, std::vector<double> &contributing_hits_energy, std::vector<std::vector<double>> &contributing_hits_entry, std::vector<std::vector<double>> &contributing_hits_exit, float layer, float &x, float &y, float &z,  float &t, float &e)
-{
-  // Given a set of g4hits, cluster them within a given layer of the TPC
-
-  float gx = 0.0;
-  float gy = 0.0;
-  float gz = 0.0;
-  float gr = 0.0;
-  float gt = 0.0;
-  float gwt = 0.0;
-  
-  if (layer >= _nlayers_maps + _nlayers_intt && layer < _nlayers_maps + _nlayers_intt + _nlayers_tpc)
-    {
-      //cout << "layer = " << layer << " _nlayers_maps " << _nlayers_maps << " _nlayers_intt " << _nlayers_intt << endl;
-
-      // This calculates the truth cluster position for the TPC from all of the contributing g4hits from a g4particle, typically 2-4 for the TPC
-      // Complicated, since only the part of the energy that is collected within a layer contributes to the position
-      //===============================================================================
-      
-      PHG4CylinderCellGeomContainer* geom_container =
-	findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
-      if (!geom_container)
-	{
-	  std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
-	  return;
-	}
-      
-      PHG4CylinderCellGeom* GeoLayer = geom_container->GetLayerCellGeom(layer);
-      // get layer boundaries here for later use
-      // radii of layer boundaries
-      float rbin = GeoLayer->get_radius() - GeoLayer->get_thickness() / 2.0;
-      float rbout = GeoLayer->get_radius() + GeoLayer->get_thickness() / 2.0;
-
-      // we do not assume that the truth hits know what layer they are in            
-      for (std::set<PHG4Hit*>::iterator iter = truth_hits.begin();
-	   iter != truth_hits.end();
-	   ++iter)
-	{
-	  
-	  PHG4Hit* this_g4hit = *iter;
-	  float rbegin = sqrt(this_g4hit->get_x(0) * this_g4hit->get_x(0) + this_g4hit->get_y(0) * this_g4hit->get_y(0));
-	  float rend = sqrt(this_g4hit->get_x(1) * this_g4hit->get_x(1) + this_g4hit->get_y(1) * this_g4hit->get_y(1));
-	  //cout << " Eval: g4hit " << this_g4hit->get_hit_id() <<  " layer " << layer << " rbegin " << rbegin << " rend " << rend << endl;
-	  
-	  // make sure the entry point is at lower radius
-	  float xl[2];
-	  float yl[2];
-	  float zl[2];
-	  
-	  if (rbegin < rend)
-	    {
-	      xl[0] = this_g4hit->get_x(0);
-	      yl[0] = this_g4hit->get_y(0);
-	      zl[0] = this_g4hit->get_z(0);
-	      xl[1] = this_g4hit->get_x(1);
-	      yl[1] = this_g4hit->get_y(1);
-	      zl[1] = this_g4hit->get_z(1);
-	    }
-	  else
-	    {
-	      xl[0] = this_g4hit->get_x(1);
-	      yl[0] = this_g4hit->get_y(1);
-	      zl[0] = this_g4hit->get_z(1);
-	      xl[1] = this_g4hit->get_x(0);
-	      yl[1] = this_g4hit->get_y(0);
-	      zl[1] = this_g4hit->get_z(0);
-	      swap(rbegin, rend);
-	      //cout << "swapped in and out " << endl;
-	    }
-	  
-	  // check that the g4hit is not completely outside the cluster layer. Just skip this g4hit if it is
-	  if (rbegin < rbin && rend < rbin)
-	    continue;
-	  if (rbegin > rbout && rend > rbout)
-	    continue;
-
-	  if(Verbosity() > 3)
-	    {
-	      cout << " Eval: g4hit " << this_g4hit->get_hit_id() <<  " layer " << layer << " rbegin " << rbegin << " rend " << rend << endl;
-	      cout << "   inside layer " << layer << "  with rbin " << rbin << " rbout " << rbout << " keep g4hit with rbegin " << rbegin << " rend " << rend << endl;
-	    }
-
-	  float xin = xl[0];
-	  float yin = yl[0];
-	  float zin = zl[0];
-	  float xout = xl[1];
-	  float yout = yl[1];
-	  float zout = zl[1];
-	  
-	  float t = NAN;
-	  
-	  if (rbegin < rbin)
-	    {
-	      // line segment begins before boundary, find where it crosses
-	      t = line_circle_intersection(xl, yl, zl, rbin);
-	      if (t > 0)
-		{
-		  xin = xl[0] + t * (xl[1] - xl[0]);
-		  yin = yl[0] + t * (yl[1] - yl[0]);
-		  zin = zl[0] + t * (zl[1] - zl[0]);
-		}
-	    }
-	  
-	  if (rend > rbout)
-	    {
-	      // line segment ends after boundary, find where it crosses
-	      t = line_circle_intersection(xl, yl, zl, rbout);
-	      if (t > 0)
-		{
-		  xout = xl[0] + t * (xl[1] - xl[0]);
-		  yout = yl[0] + t * (yl[1] - yl[0]);
-		  zout = zl[0] + t * (zl[1] - zl[0]);
-		}
-	    }
-
-	  double rin = sqrt(xin*xin + yin*yin);
-	  double rout = sqrt(xout*xout + yout*yout);
-
-	  // we want only the fraction of edep inside the layer
-	  double efrac =  this_g4hit->get_edep() * (rout - rin) / (rend - rbegin);
-	  gx += (xin + xout) * 0.5 * efrac;
-	  gy += (yin + yout) * 0.5 * efrac;
-	  gz += (zin + zout) * 0.5 * efrac;
-	  gt += this_g4hit->get_avg_t() * efrac;
-	  gr += (rin + rout) * 0.5 * efrac;
-	  gwt += efrac;
-
-	  if(Verbosity() > 3)
-	    cout << "     rin  " << rin << " rout " << rout << " edep " << this_g4hit->get_edep() 
-		 << " this_edep " <<  efrac << " xavge " << (xin+xout) * 0.5 << " yavge " << (yin+yout) * 0.5 << " zavge " << (zin+zout) * 0.5 << " ravge " << (rin+rout) * 0.5
-		 << endl;
-
-	  // Capture entry and exit points
-	  std::vector<double> entry_loc;
-	  entry_loc.push_back(xin);
-	  entry_loc.push_back(yin);
-	  entry_loc.push_back(zin);
-	  std::vector<double> exit_loc;
-	  exit_loc.push_back(xout);
-	  exit_loc.push_back(yout);
-	  exit_loc.push_back(zout);
-
-	  // this_g4hit is inside the layer, add it to the vectors
-	  contributing_hits.push_back(this_g4hit);
-	  contributing_hits_energy.push_back( this_g4hit->get_edep() * (zout - zin) / (zl[1] - zl[0]) );
-	  contributing_hits_entry.push_back(entry_loc);
-	  contributing_hits_exit.push_back(exit_loc);
-
-	}  // loop over this_g4hit
-
-      if(gwt == 0)
-	{
-	  e = gwt;	  
-	  return;  // will be discarded 
-	}
-
-      gx /= gwt;
-      gy /= gwt;
-      gz /= gwt;
-      gr /= gwt;
-      gt /= gwt;
-
-      // The energy weighted values above have significant scatter due to fluctuations in the energy deposit from Geant
-      // Calculate the geometric mean positions instead
-      float rentry = 999.0;
-      float xentry = 999.0;
-      float yentry = 999.0;
-      float zentry = 999.0;
-      float rexit = - 999.0;
-      float xexit = -999.0;
-      float yexit = -999.0;
-      float zexit = -999.0;
-
-      for(unsigned int ientry = 0; ientry < contributing_hits_entry.size(); ++ientry)
-	{
-	  float tmpx = contributing_hits_entry[ientry][0];
-	  float tmpy = contributing_hits_entry[ientry][1];
-	  float tmpr = sqrt(tmpx*tmpx + tmpy*tmpy);
-
-	  if(tmpr < rentry)
-	    {
-	      rentry =  tmpr;
-	      xentry = contributing_hits_entry[ientry][0];
-	      yentry = contributing_hits_entry[ientry][1];
-	      zentry = contributing_hits_entry[ientry][2];
-	    }
-
-	  tmpx = contributing_hits_exit[ientry][0];
-	  tmpy = contributing_hits_exit[ientry][1];
-	  tmpr = sqrt(tmpx*tmpx + tmpy*tmpy);
-
-	  if(tmpr > rexit)
-	    {
-	      rexit =  tmpr;
-	      xexit = contributing_hits_exit[ientry][0];
-	      yexit = contributing_hits_exit[ientry][1];
-	      zexit = contributing_hits_exit[ientry][2];
-	    }
-	}
-
-      float geo_r = (rentry+rexit)*0.5;
-      float geo_x = (xentry+xexit)*0.5;
-      float geo_y = (yentry+yexit)*0.5;
-      float geo_z = (zentry+zexit)*0.5;
-
-      if(rexit > 0)
-	{
-	  gx = geo_x;
-	  gy = geo_y;
-	  gz = geo_z;
-	  gr = geo_r;
-	}
-
-      if(Verbosity() > 3)
-	{
-	  cout << " weighted means:   gx " << gx << " gy " << gy << " gz " << gz << " gr " << gr << endl;
-	  cout  << " geometric means: geo_x " << geo_x << " geo_y " << geo_y << " geo_z " << geo_z  << " geo r " << geo_r <<  endl;
-	}
-    }  // if TPC
-  else
-    {
-      // not TPC, one g4hit per cluster
-      for (std::set<PHG4Hit*>::iterator iter = truth_hits.begin();
-	   iter != truth_hits.end();
-	   ++iter)
-	{
-	  
-	  PHG4Hit* this_g4hit = *iter;
-
-	  if(this_g4hit->get_layer() != (unsigned int) layer) continue;
-	  
-	  gx = this_g4hit->get_avg_x();
-	  gy = this_g4hit->get_avg_y();
-	  gz = this_g4hit->get_avg_z();
-	  gt = this_g4hit->get_avg_t();
-	  gwt += this_g4hit->get_edep();
-
-	  // Capture entry and exit points
-	  std::vector<double> entry_loc;
-	  entry_loc.push_back(this_g4hit->get_x(0));
-	  entry_loc.push_back(this_g4hit->get_y(0));
-	  entry_loc.push_back(this_g4hit->get_z(0));
-	  std::vector<double> exit_loc;
-	  exit_loc.push_back(this_g4hit->get_x(1));
-	  exit_loc.push_back(this_g4hit->get_y(1));
-	  exit_loc.push_back(this_g4hit->get_z(1));
-
-	  // this_g4hit is inside the layer, add it to the vectors
-	  contributing_hits.push_back(this_g4hit);
-	  contributing_hits_energy.push_back( this_g4hit->get_edep() );
-	  contributing_hits_entry.push_back(entry_loc);
-	  contributing_hits_exit.push_back(exit_loc);
-	}
-    }  // not TPC
-
-  x = gx;
-  y = gy;
-  z = gz;
-  t = gt;
-  e = gwt;
-
-  return;
-}
-
-float SvtxEvaluator::line_circle_intersection(float x[], float y[], float z[], float radius)
-{
-  // parameterize the line in terms of t (distance along the line segment, from 0-1) as
-  // x = x0 + t * (x1-x0); y=y0 + t * (y1-y0); z = z0 + t * (z1-z0)
-  // parameterize the cylinder (centered at x,y = 0,0) as  x^2 + y^2 = radius^2,   then
-  // (x0 + t*(x1-z0))^2 + (y0+t*(y1-y0))^2 = radius^2
-  // (x0^2 + y0^2 - radius^2) + (2x0*(x1-x0) + 2y0*(y1-y0))*t +  ((x1-x0)^2 + (y1-y0)^2)*t^2 = 0 = C + B*t + A*t^2
-  // quadratic with:  A = (x1-x0)^2+(y1-y0)^2 ;  B = 2x0*(x1-x0) + 2y0*(y1-y0);  C = x0^2 + y0^2 - radius^2
-  // solution: t = (-B +/- sqrt(B^2 - 4*A*C)) / (2*A)
-
-  float A = (x[1] - x[0]) * (x[1] - x[0]) + (y[1] - y[0]) * (y[1] - y[0]);
-  float B = 2.0 * x[0] * (x[1] - x[0]) + 2.0 * y[0] * (y[1] - y[0]);
-  float C = x[0] * x[0] + y[0] * y[0] - radius * radius;
-  float tup = (-B + sqrt(B * B - 4.0 * A * C)) / (2.0 * A);
-  float tdn = (-B - sqrt(B * B - 4.0 * A * C)) / (2.0 * A);
-
-  // The limits are 0 and 1, but we allow a little for floating point precision
-  float t;
-  if (tdn >= -0.0e-4 && tdn <= 1.0004)
-    t = tdn;
-  else if (tup >= -0.0e-4 && tup <= 1.0004)
-    t = tup;
-  else
-  {
-    cout << PHWHERE << "   **** Oops! No valid solution for tup or tdn, tdn = " << tdn << " tup = " << tup << endl;
-    cout << "   radius " << radius << " rbegin " << sqrt(x[0] * x[0] + y[0] * y[0]) << " rend " << sqrt(x[1] * x[1] + y[1] * y[1]) << endl;
-    cout << "   x0 " << x[0] << " x1 " << x[1] << endl;
-    cout << "   y0 " << y[0] << " y1 " << y[1] << endl;
-    cout << "   z0 " << z[0] << " z1 " << z[1] << endl;
-    cout << "   A " << A << " B " << B << " C " << C << endl;
-
-    t = -1;
-  }
-
-  return t;
-}

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -1971,62 +1971,58 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	    if(Verbosity() > 0)
 	      {
 		TrkrDefs::cluskey truth_cluskey = truth_cluster->getClusKey();
-		cout << "    Found matching truth cluster with key " << truth_cluskey << " for reco cluster key " << cluster_key << " in layer " << layer << endl;
+		cout << "         Found matching truth cluster with key " << truth_cluskey << " for reco cluster key " << cluster_key << " in layer " << layer << endl;
 	      }
 
 	    g4hitID = 0;
 	    gx=truth_cluster->getX();
 	    gy=truth_cluster->getY();
 	    gz=truth_cluster->getZ();
+	    efromtruth = truth_cluster->getError(0,0);
 
 	    TVector3 gpos(gx, gy, gz);
 	    gr = gpos.Perp();
 	    gphi = gpos.Phi();
 	    geta = gpos.Eta();
 
-	  if (g4particle)
-            {
-              gtrackID = g4particle->get_track_id();
-              gflavor = g4particle->get_pid();
-              gpx = g4particle->get_px();
-              gpy = g4particle->get_py();
-              gpz = g4particle->get_pz();
-
-              PHG4VtxPoint* vtx = trutheval->get_vertex(g4particle);
-              if (vtx)
-              {
-                gvx = vtx->get_x();
-                gvy = vtx->get_y();
-                gvz = vtx->get_z();
-		gvt = vtx->get_t();
-              }
-              PHG4Hit* outerhit = nullptr;
-              if (_do_eval_light == false)
-                outerhit = trutheval->get_outermost_truth_hit(g4particle);
-              if (outerhit)
-              {
-                gfpx = outerhit->get_px(1);
-                gfpy = outerhit->get_py(1);
-                gfpz = outerhit->get_pz(1);
-                gfx = outerhit->get_x(1);
-                gfy = outerhit->get_y(1);
-                gfz = outerhit->get_z(1);
-              }
-
-              gembed = trutheval->get_embed(g4particle);
-              gprimary = trutheval->is_primary(g4particle);
-            }  //   if (g4particle){
+	    if (g4particle)
+	      {
+		gtrackID = g4particle->get_track_id();
+		gflavor = g4particle->get_pid();
+		gpx = g4particle->get_px();
+		gpy = g4particle->get_py();
+		gpz = g4particle->get_pz();
+		
+		PHG4VtxPoint* vtx = trutheval->get_vertex(g4particle);
+		if (vtx)
+		  {
+		    gvx = vtx->get_x();
+		    gvy = vtx->get_y();
+		    gvz = vtx->get_z();
+		    gvt = vtx->get_t();
+		  }
+		PHG4Hit* outerhit = nullptr;
+		if (_do_eval_light == false)
+		  outerhit = trutheval->get_outermost_truth_hit(g4particle);
+		if (outerhit)
+		  {
+		    gfpx = outerhit->get_px(1);
+		    gfpy = outerhit->get_py(1);
+		    gfpz = outerhit->get_pz(1);
+		    gfx = outerhit->get_x(1);
+		    gfy = outerhit->get_y(1);
+		    gfz = outerhit->get_z(1);
+		  }
+		
+		gembed = trutheval->get_embed(g4particle);
+		gprimary = trutheval->is_primary(g4particle);
+	      }  //   if (g4particle){
           }    //  if (g4hit) {
-
-          if (g4particle)
-          {
-            efromtruth = clustereval->get_energy_contribution(cluster_key, g4particle);
-          }
-
-          float nparticles = clustereval->all_truth_particles(cluster_key).size();
-
-          float cluster_data[] = {(float) _ievent,
-				  (float) _iseed,
+	
+	float nparticles = clustereval->all_truth_particles(cluster_key).size();
+	
+	float cluster_data[] = {(float) _ievent,
+				(float) _iseed,
                                 hitID,
                                 x,
                                 y,
@@ -2204,7 +2200,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 		}
 	      if(nreco == 0 && Verbosity() > 0)
 		{
-		  cout << "   ----------- Failed to find matching reco cluster " << endl;
+		  if(Verbosity() > 0)
+		    cout << "   ----------- Failed to find matching reco cluster " << endl;
 		}
 
 

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -1671,7 +1671,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	TrkrDefs::cluskey cluster_key = iter->first;
 	TrkrCluster *cluster = clustermap->findCluster(cluster_key);
         SvtxTrack* track = trackeval->best_track_from(cluster_key);
-        PHG4Particle* g4particle = clustereval->max_truth_particle_by_energy(cluster_key);
+	PHG4Particle* g4particle = clustereval->max_truth_particle_by_cluster_energy(cluster_key);
 
         float hitID = (float) cluster_key;
         float x = cluster->getX();
@@ -1732,7 +1732,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
         float efromtruth = NAN;
 
-	if(Verbosity() > -1)
+	if(Verbosity() > 0)
 	  {
 	    TrkrDefs::cluskey reco_cluskey = cluster->getClusKey();		  
 	    std::cout << "  ****   reco: layer " << layer << std::endl;
@@ -1753,6 +1753,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	    gx=truth_cluster->getX();
 	    gy=truth_cluster->getY();
 	    gz=truth_cluster->getZ();
+	    efromtruth = truth_cluster->getError(0,0);
 
 	    TVector3 gpos(gx, gy, gz);
 	    gr = gpos.Perp();  // could also be just the center of the layer
@@ -1791,10 +1792,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
             gembed = trutheval->get_embed(g4particle);
             gprimary = trutheval->is_primary(g4particle);
-	    efromtruth = clustereval->get_energy_contribution(cluster_key, g4particle);	    
           }  //   if (g4particle){
 	  
-	  if(Verbosity() > -1)
+	  if(Verbosity() > 0)
 	    {
 	      TrkrDefs::cluskey ckey = truth_cluster->getClusKey();		  
 	      cout << "             truth cluster key " << ckey << " gr " << gr << " gx " << gx << " gy " << gy << " gz " << gz << " gphi " << gphi << " efromtruth " << efromtruth << endl;
@@ -2100,7 +2100,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
   if (_ntp_g4cluster)
     {
-      if (Verbosity() > 1) 
+      if (Verbosity() > 0) 
 	cout << "Filling ntp_g4cluster " << endl;
 
        PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");      
@@ -2122,7 +2122,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	  float gembed = trutheval->get_embed(g4particle);
 	  float gprimary = trutheval->is_primary(g4particle);
 
-	  if(Verbosity() > -1)
+	  if(Verbosity() > 0)
 	    cout << "PHG4Particle ID " << gtrackID << " gflavor " << gflavor << " gprimary " << gprimary << endl;
 
 	  // Get the truth clusters from this particle
@@ -2145,7 +2145,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	      float gphi = gpos.Phi();
 	      float geta = gpos.Eta();
 
-	      if(Verbosity() > -1)
+	      if(Verbosity() > 0)
 		{
 		  TrkrDefs::cluskey ckey = gclus->getClusKey();		  
 		  std::cout << "  ****   truth: layer " << layer << std::endl;
@@ -2196,13 +2196,13 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 		  
 		  adc = reco_cluster->getAdc();
 
-		  if(Verbosity() > -1)
+		  if(Verbosity() > 0)
 		    {
 		      TrkrDefs::cluskey reco_cluskey = reco_cluster->getClusKey();		  
 		      cout << "              reco cluster key " << reco_cluskey << "  r " << r << "  x " << x << "  y " << y << "  z " << z << "  phi " << phi  << " adc " << adc << endl;
 		    }
 		}
-	      if(nreco == 0)
+	      if(nreco == 0 && Verbosity() > 0)
 		{
 		  cout << "   ----------- Failed to find matching reco cluster " << endl;
 		}

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -61,8 +61,10 @@ class SvtxEvaluator : public SubsysReco
   void do_eval_light(bool b) { _do_eval_light = b; }
   void scan_for_embedded(bool b) { _scan_for_embedded = b; }
 
+  /*
   /// This is public so that the Acts evaluator can access it
   void LayerClusterG4Hits(PHCompositeNode* topNode, std::set<PHG4Hit*> truth_hits, std::vector<PHG4Hit*> &contributing_hits, std::vector<double> &contributing_hits_energy, std::vector<std::vector<double>> &contributing_hits_entry, std::vector<std::vector<double>> &contributing_hits_exit, float layer, float &gx, float &gy, float &gz,  float &gt, float &gedep);
+  */
 
  private:
   unsigned int _ievent;
@@ -116,12 +118,12 @@ class SvtxEvaluator : public SubsysReco
 
   PHTimer *_timer;
 
+  /*
   //  void LayerClusterG4Particle();
-
   void G4ClusterSize(PHCompositeNode* topNode, unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry, std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize);
-
-  
+   
   float line_circle_intersection(float x[], float y[], float z[], float radius);
+  */
 
   // output subroutines
   void fillOutputNtuples(PHCompositeNode *topNode);  ///< dump the evaluator information into ntuple for external analysis

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -61,11 +61,6 @@ class SvtxEvaluator : public SubsysReco
   void do_eval_light(bool b) { _do_eval_light = b; }
   void scan_for_embedded(bool b) { _scan_for_embedded = b; }
 
-  /*
-  /// This is public so that the Acts evaluator can access it
-  void LayerClusterG4Hits(PHCompositeNode* topNode, std::set<PHG4Hit*> truth_hits, std::vector<PHG4Hit*> &contributing_hits, std::vector<double> &contributing_hits_energy, std::vector<std::vector<double>> &contributing_hits_entry, std::vector<std::vector<double>> &contributing_hits_exit, float layer, float &gx, float &gy, float &gz,  float &gt, float &gedep);
-  */
-
  private:
   unsigned int _ievent;
   unsigned int _iseed;
@@ -117,13 +112,6 @@ class SvtxEvaluator : public SubsysReco
   TFile *_tfile;
 
   PHTimer *_timer;
-
-  /*
-  //  void LayerClusterG4Particle();
-  void G4ClusterSize(PHCompositeNode* topNode, unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry, std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize);
-   
-  float line_circle_intersection(float x[], float y[], float z[], float radius);
-  */
 
   // output subroutines
   void fillOutputNtuples(PHCompositeNode *topNode);  ///< dump the evaluator information into ntuple for external analysis

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -45,11 +45,13 @@ SvtxTruthEval::SvtxTruthEval(PHCompositeNode* topNode)
   , _do_cache(true)
   , _cache_all_truth_hits()
   , _cache_all_truth_hits_g4particle()
+  , _cache_all_truth_clusters_g4particle()
   , _cache_get_innermost_truth_hit()
   , _cache_get_outermost_truth_hit()
   , _cache_get_primary_particle_g4hit()
 {
   get_node_pointers(topNode);
+  iclus = 0;
 }
 
 SvtxTruthEval::~SvtxTruthEval()
@@ -67,6 +69,7 @@ void SvtxTruthEval::next_event(PHCompositeNode* topNode)
 {
   _cache_all_truth_hits.clear();
   _cache_all_truth_hits_g4particle.clear();
+  _cache_all_truth_clusters_g4particle.clear();
   _cache_get_innermost_truth_hit.clear();
   _cache_get_outermost_truth_hit.clear();
   _cache_get_primary_particle_g4hit.clear();
@@ -253,7 +256,7 @@ std::map<unsigned int, TrkrCluster*> SvtxTruthEval::all_truth_clusters(PHG4Parti
 
   // convert truth hits for this particle to truth clusters in each TPC layer
   // loop over layers
-  unsigned int iclus = 0;
+
   for(float layer = 0; layer < _nlayers_maps + _nlayers_intt + _nlayers_tpc; ++layer)
     {
       float gx = NAN;
@@ -315,7 +318,7 @@ std::map<unsigned int, TrkrCluster*> SvtxTruthEval::all_truth_clusters(PHG4Parti
       truth_clusters.insert(make_pair(layer, clus));
 
     }  // end loop over layers for this particle
-  
+
   if (_do_cache) _cache_all_truth_clusters_g4particle.insert(make_pair(particle, truth_clusters));
   
   return truth_clusters;

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -6,7 +6,23 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 
+#include <g4main/PHG4Particle.h>
+
+#include <trackbase/TrkrClusterv1.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrDefs.h>
+#include <tpc/TpcDefs.h>
+
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderGeomContainer.h>
+#include <mvtx/CylinderGeom_Mvtx.h>
+#include <intt/CylinderGeomIntt.h>
+
+
 #include <phool/getClass.h>
+
+#include <TVector3.h>
 
 #include <cassert>
 #include <cfloat>
@@ -197,6 +213,594 @@ std::set<PHG4Hit*> SvtxTruthEval::all_truth_hits(PHG4Particle* particle)
   return truth_hits;
 }
 
+std::map<unsigned int, TrkrCluster*> SvtxTruthEval::all_truth_clusters(PHG4Particle* particle)
+{
+  if (!has_node_pointers())
+  {
+    ++_errors;
+    return std::map<unsigned int, TrkrCluster*>();
+  }
+
+  if (_strict)
+  {
+    assert(particle);
+  }
+  else if (!particle)
+  {
+    ++_errors;
+    return std::map<unsigned int, TrkrCluster*>();
+  }
+
+  if (_do_cache)
+  {
+    std::map<PHG4Particle*, std::map<unsigned int, TrkrCluster*> >::iterator iter =
+        _cache_all_truth_clusters_g4particle.find(particle);
+    if (iter != _cache_all_truth_clusters_g4particle.end())
+    {
+      return iter->second;
+    }
+  }
+
+  // get all g4hits for this particle
+  std::set<PHG4Hit*> g4hits = all_truth_hits(particle);
+	  
+  float ng4hits = g4hits.size();
+  if(ng4hits == 0) 
+    return std::map<unsigned int, TrkrCluster*>();
+
+  // container for storing truth clusters
+  std::map<unsigned int, TrkrCluster*> truth_clusters;
+
+  // convert truth hits for this particle to truth clusters in each TPC layer
+  // loop over layers
+  unsigned int iclus = 0;
+  for(float layer = 0; layer < _nlayers_maps + _nlayers_intt + _nlayers_tpc; ++layer)
+    {
+      float gx = NAN;
+      float gy = NAN;
+      float gz = NAN;
+      float gt = NAN;
+      float gedep = NAN;
+      
+      std::vector<PHG4Hit*> contributing_hits;
+      std::vector<double> contributing_hits_energy;
+      std::vector<std::vector<double>> contributing_hits_entry;
+      std::vector<std::vector<double>> contributing_hits_exit;
+      LayerClusterG4Hits(g4hits, contributing_hits, contributing_hits_energy, contributing_hits_entry, contributing_hits_exit, layer, gx, gy, gz, gt, gedep);
+      if(!(gedep > 0)) continue;
+  
+      // we have the cluster in this layer from this truth particle
+      // add the cluster to a TrkrCluster object
+      
+      unsigned int side = 0;
+      if(gz > 0) side = 1;
+
+      // need sector here
+      unsigned int sector = 0;
+
+      TrkrDefs::cluskey ckey = TpcDefs::genClusKey(layer, sector, side, iclus);
+      TrkrClusterv1 *clus = new TrkrClusterv1();
+      clus->setClusKey(ckey);
+      iclus++;
+
+      //clus->setAdc(gedep);
+      clus->setPosition(0, gx);
+      clus->setPosition(1, gy);
+      clus->setPosition(2, gz);
+      clus->setGlobal();
+
+      // record which g4hits contribute to this truth cluster
+      for(unsigned int i=0; i< contributing_hits.size(); ++i)
+	{
+	  _truth_cluster_truth_hit_map.insert(make_pair(ckey,contributing_hits[i]));      
+	}
+
+      // Estimate the size of the truth cluster
+      float g4phisize = NAN;
+      float g4zsize = NAN;
+      G4ClusterSize(layer, contributing_hits_entry, contributing_hits_exit, g4phisize, g4zsize);
+
+      for(int i1=0;i1<3;++i1)
+	for(int i2=0;i2<3;++i2)
+	{
+	  clus->setSize(i1, i2, 0.0);
+	  clus->setError(i1, i2, 0.0);
+	}
+      clus->setError(0,0,gedep);  // stores truth energy
+      clus->setSize(1, 1, g4phisize);
+      clus->setSize(2, 2, g4zsize);
+      clus->setError(1, 1, g4phisize/sqrt(12));
+      clus->setError(2, 2, g4zsize/sqrt(12.0));
+
+      truth_clusters.insert(make_pair(layer, clus));
+
+    }  // end loop over layers for this particle
+  
+  if (_do_cache) _cache_all_truth_clusters_g4particle.insert(make_pair(particle, truth_clusters));
+  
+  return truth_clusters;
+}
+
+void SvtxTruthEval::LayerClusterG4Hits(std::set<PHG4Hit*> truth_hits, std::vector<PHG4Hit*> &contributing_hits, std::vector<double> &contributing_hits_energy, std::vector<std::vector<double>> &contributing_hits_entry, std::vector<std::vector<double>> &contributing_hits_exit, float layer, float &x, float &y, float &z,  float &t, float &e)
+{
+  // Given a set of g4hits, cluster them within a given layer of the TPC
+
+  float gx = 0.0;
+  float gy = 0.0;
+  float gz = 0.0;
+  float gr = 0.0;
+  float gt = 0.0;
+  float gwt = 0.0;
+  
+  if (layer >= _nlayers_maps + _nlayers_intt && layer < _nlayers_maps + _nlayers_intt + _nlayers_tpc)
+    {
+      //cout << "layer = " << layer << " _nlayers_maps " << _nlayers_maps << " _nlayers_intt " << _nlayers_intt << endl;
+
+      // This calculates the truth cluster position for the TPC from all of the contributing g4hits from a g4particle, typically 2-4 for the TPC
+      // Complicated, since only the part of the energy that is collected within a layer contributes to the position
+      //===============================================================================
+      
+      PHG4CylinderCellGeom* GeoLayer = _tpc_geom_container->GetLayerCellGeom(layer);
+      // get layer boundaries here for later use
+      // radii of layer boundaries
+      float rbin = GeoLayer->get_radius() - GeoLayer->get_thickness() / 2.0;
+      float rbout = GeoLayer->get_radius() + GeoLayer->get_thickness() / 2.0;
+
+      // we do not assume that the truth hits know what layer they are in            
+      for (std::set<PHG4Hit*>::iterator iter = truth_hits.begin();
+	   iter != truth_hits.end();
+	   ++iter)
+	{
+	  
+	  PHG4Hit* this_g4hit = *iter;
+	  float rbegin = sqrt(this_g4hit->get_x(0) * this_g4hit->get_x(0) + this_g4hit->get_y(0) * this_g4hit->get_y(0));
+	  float rend = sqrt(this_g4hit->get_x(1) * this_g4hit->get_x(1) + this_g4hit->get_y(1) * this_g4hit->get_y(1));
+	  //cout << " Eval: g4hit " << this_g4hit->get_hit_id() <<  " layer " << layer << " rbegin " << rbegin << " rend " << rend << endl;
+	  
+	  // make sure the entry point is at lower radius
+	  float xl[2];
+	  float yl[2];
+	  float zl[2];
+	  
+	  if (rbegin < rend)
+	    {
+	      xl[0] = this_g4hit->get_x(0);
+	      yl[0] = this_g4hit->get_y(0);
+	      zl[0] = this_g4hit->get_z(0);
+	      xl[1] = this_g4hit->get_x(1);
+	      yl[1] = this_g4hit->get_y(1);
+	      zl[1] = this_g4hit->get_z(1);
+	    }
+	  else
+	    {
+	      xl[0] = this_g4hit->get_x(1);
+	      yl[0] = this_g4hit->get_y(1);
+	      zl[0] = this_g4hit->get_z(1);
+	      xl[1] = this_g4hit->get_x(0);
+	      yl[1] = this_g4hit->get_y(0);
+	      zl[1] = this_g4hit->get_z(0);
+	      swap(rbegin, rend);
+	      //cout << "swapped in and out " << endl;
+	    }
+	  
+	  // check that the g4hit is not completely outside the cluster layer. Just skip this g4hit if it is
+	  if (rbegin < rbin && rend < rbin)
+	    continue;
+	  if (rbegin > rbout && rend > rbout)
+	    continue;
+
+	  /*
+	  if(Verbosity() > 3)
+	    {
+	      cout << " Eval: g4hit " << this_g4hit->get_hit_id() <<  " layer " << layer << " rbegin " << rbegin << " rend " << rend << endl;
+	      cout << "   inside layer " << layer << "  with rbin " << rbin << " rbout " << rbout << " keep g4hit with rbegin " << rbegin << " rend " << rend << endl;
+	    }
+	  */
+
+	  float xin = xl[0];
+	  float yin = yl[0];
+	  float zin = zl[0];
+	  float xout = xl[1];
+	  float yout = yl[1];
+	  float zout = zl[1];
+	  
+	  float t = NAN;
+	  
+	  if (rbegin < rbin)
+	    {
+	      // line segment begins before boundary, find where it crosses
+	      t = line_circle_intersection(xl, yl, zl, rbin);
+	      if (t > 0)
+		{
+		  xin = xl[0] + t * (xl[1] - xl[0]);
+		  yin = yl[0] + t * (yl[1] - yl[0]);
+		  zin = zl[0] + t * (zl[1] - zl[0]);
+		}
+	    }
+	  
+	  if (rend > rbout)
+	    {
+	      // line segment ends after boundary, find where it crosses
+	      t = line_circle_intersection(xl, yl, zl, rbout);
+	      if (t > 0)
+		{
+		  xout = xl[0] + t * (xl[1] - xl[0]);
+		  yout = yl[0] + t * (yl[1] - yl[0]);
+		  zout = zl[0] + t * (zl[1] - zl[0]);
+		}
+	    }
+
+	  double rin = sqrt(xin*xin + yin*yin);
+	  double rout = sqrt(xout*xout + yout*yout);
+
+	  // we want only the fraction of edep inside the layer
+	  double efrac =  this_g4hit->get_edep() * (rout - rin) / (rend - rbegin);
+	  gx += (xin + xout) * 0.5 * efrac;
+	  gy += (yin + yout) * 0.5 * efrac;
+	  gz += (zin + zout) * 0.5 * efrac;
+	  gt += this_g4hit->get_avg_t() * efrac;
+	  gr += (rin + rout) * 0.5 * efrac;
+	  gwt += efrac;
+
+	  /*
+	  if(Verbosity() > 3)
+	    cout << "     rin  " << rin << " rout " << rout << " edep " << this_g4hit->get_edep() 
+		 << " this_edep " <<  efrac << " xavge " << (xin+xout) * 0.5 << " yavge " << (yin+yout) * 0.5 << " zavge " << (zin+zout) * 0.5 << " ravge " << (rin+rout) * 0.5
+		 << endl;
+	  */
+
+	  // Capture entry and exit points
+	  std::vector<double> entry_loc;
+	  entry_loc.push_back(xin);
+	  entry_loc.push_back(yin);
+	  entry_loc.push_back(zin);
+	  std::vector<double> exit_loc;
+	  exit_loc.push_back(xout);
+	  exit_loc.push_back(yout);
+	  exit_loc.push_back(zout);
+
+	  // this_g4hit is inside the layer, add it to the vectors
+	  contributing_hits.push_back(this_g4hit);
+	  contributing_hits_energy.push_back( this_g4hit->get_edep() * (zout - zin) / (zl[1] - zl[0]) );
+	  contributing_hits_entry.push_back(entry_loc);
+	  contributing_hits_exit.push_back(exit_loc);
+
+	}  // loop over this_g4hit
+
+      if(gwt == 0)
+	{
+	  e = gwt;	  
+	  return;  // will be discarded 
+	}
+
+      gx /= gwt;
+      gy /= gwt;
+      gz /= gwt;
+      gr /= gwt;
+      gt /= gwt;
+
+      // The energy weighted values above have significant scatter due to fluctuations in the energy deposit from Geant
+      // Calculate the geometric mean positions instead
+      float rentry = 999.0;
+      float xentry = 999.0;
+      float yentry = 999.0;
+      float zentry = 999.0;
+      float rexit = - 999.0;
+      float xexit = -999.0;
+      float yexit = -999.0;
+      float zexit = -999.0;
+
+      for(unsigned int ientry = 0; ientry < contributing_hits_entry.size(); ++ientry)
+	{
+	  float tmpx = contributing_hits_entry[ientry][0];
+	  float tmpy = contributing_hits_entry[ientry][1];
+	  float tmpr = sqrt(tmpx*tmpx + tmpy*tmpy);
+
+	  if(tmpr < rentry)
+	    {
+	      rentry =  tmpr;
+	      xentry = contributing_hits_entry[ientry][0];
+	      yentry = contributing_hits_entry[ientry][1];
+	      zentry = contributing_hits_entry[ientry][2];
+	    }
+
+	  tmpx = contributing_hits_exit[ientry][0];
+	  tmpy = contributing_hits_exit[ientry][1];
+	  tmpr = sqrt(tmpx*tmpx + tmpy*tmpy);
+
+	  if(tmpr > rexit)
+	    {
+	      rexit =  tmpr;
+	      xexit = contributing_hits_exit[ientry][0];
+	      yexit = contributing_hits_exit[ientry][1];
+	      zexit = contributing_hits_exit[ientry][2];
+	    }
+	}
+
+      float geo_r = (rentry+rexit)*0.5;
+      float geo_x = (xentry+xexit)*0.5;
+      float geo_y = (yentry+yexit)*0.5;
+      float geo_z = (zentry+zexit)*0.5;
+
+      if(rexit > 0)
+	{
+	  gx = geo_x;
+	  gy = geo_y;
+	  gz = geo_z;
+	  gr = geo_r;
+	}
+
+      /*
+      if(Verbosity() > 3)
+	{
+	  cout << " weighted means:   gx " << gx << " gy " << gy << " gz " << gz << " gr " << gr << endl;
+	  cout  << " geometric means: geo_x " << geo_x << " geo_y " << geo_y << " geo_z " << geo_z  << " geo r " << geo_r <<  endl;
+	}
+      */
+    }  // if TPC
+  else
+    {
+      // not TPC, one g4hit per cluster
+      for (std::set<PHG4Hit*>::iterator iter = truth_hits.begin();
+	   iter != truth_hits.end();
+	   ++iter)
+	{
+	  
+	  PHG4Hit* this_g4hit = *iter;
+
+	  if(this_g4hit->get_layer() != (unsigned int) layer) continue;
+	  
+	  gx = this_g4hit->get_avg_x();
+	  gy = this_g4hit->get_avg_y();
+	  gz = this_g4hit->get_avg_z();
+	  gt = this_g4hit->get_avg_t();
+	  gwt += this_g4hit->get_edep();
+
+	  // Capture entry and exit points
+	  std::vector<double> entry_loc;
+	  entry_loc.push_back(this_g4hit->get_x(0));
+	  entry_loc.push_back(this_g4hit->get_y(0));
+	  entry_loc.push_back(this_g4hit->get_z(0));
+	  std::vector<double> exit_loc;
+	  exit_loc.push_back(this_g4hit->get_x(1));
+	  exit_loc.push_back(this_g4hit->get_y(1));
+	  exit_loc.push_back(this_g4hit->get_z(1));
+
+	  // this_g4hit is inside the layer, add it to the vectors
+	  contributing_hits.push_back(this_g4hit);
+	  contributing_hits_energy.push_back( this_g4hit->get_edep() );
+	  contributing_hits_entry.push_back(entry_loc);
+	  contributing_hits_exit.push_back(exit_loc);
+	}
+    }  // not TPC
+
+  x = gx;
+  y = gy;
+  z = gz;
+  t = gt;
+  e = gwt;
+
+  return;
+}
+
+void SvtxTruthEval::G4ClusterSize(unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry,std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize)
+{
+
+  // sort the contributing g4hits in radius
+  double inner_radius = 100.;
+  double inner_x = NAN;
+  double inner_y = NAN;
+  double inner_z = NAN;;
+
+  double outer_radius = 0.;
+  double outer_x = NAN;
+  double outer_y = NAN;
+  double outer_z = NAN;
+
+  for(unsigned int ihit=0;ihit<contributing_hits_entry.size(); ++ihit)
+    {
+      double rad1 = sqrt(pow(contributing_hits_entry[ihit][0], 2) + pow(contributing_hits_entry[ihit][1], 2));      
+      if(rad1 < inner_radius)
+	{
+	  inner_radius = rad1;
+	  inner_x = contributing_hits_entry[ihit][0];
+	  inner_y = contributing_hits_entry[ihit][1];
+	  inner_z = contributing_hits_entry[ihit][2];    
+	}
+
+      double rad2 = sqrt(pow(contributing_hits_exit[ihit][0], 2) + pow(contributing_hits_exit[ihit][1], 2));
+      if(rad2 > outer_radius)
+	{
+	  outer_radius = rad2;
+	  outer_x = contributing_hits_exit[ihit][0];
+	  outer_y = contributing_hits_exit[ihit][1];
+	  outer_z = contributing_hits_exit[ihit][2];    
+	}
+    }
+
+  double inner_phi =  atan2(inner_y, inner_x);
+  double outer_phi =  atan2(outer_y, outer_x);
+  double avge_z = (outer_z + inner_z) / 2.0;
+
+  // Now fold these with the expected diffusion and shaping widths
+  // assume spread is +/- equals this many sigmas times diffusion and shaping when extending the size
+  double sigmas = 2.0;
+
+  double radius = (inner_radius + outer_radius)/2.;
+  if(radius > 28)  // TPC
+    {
+      PHG4CylinderCellGeom*layergeom = _tpc_geom_container->GetLayerCellGeom(layer);
+
+      double tpc_length = 211.0;  // cm
+      double drift_velocity = 8.0 / 1000.0;  // cm/ns
+
+      // Phi size
+      //======
+      double diffusion_trans =  0.006;  // cm/SQRT(cm)
+      double phidiffusion = diffusion_trans * sqrt(tpc_length / 2. - fabs(avge_z));
+
+      double added_smear_trans = 0.085; // cm
+      double gem_spread = 0.04;  // 400 microns
+
+      if(outer_phi < inner_phi) swap(outer_phi, inner_phi);
+
+      // convert diffusion from cm to radians
+      double g4max_phi =  outer_phi + sigmas * sqrt(  pow(phidiffusion, 2) + pow(added_smear_trans, 2) + pow(gem_spread, 2) ) / radius;
+      double g4min_phi =  inner_phi - sigmas * sqrt(  pow(phidiffusion, 2) + pow(added_smear_trans, 2) + pow(gem_spread, 2) ) / radius;
+
+      // find the bins containing these max and min z edges
+      unsigned int phibinmin = layergeom->get_phibin(g4min_phi);
+      unsigned int phibinmax = layergeom->get_phibin(g4max_phi);
+      unsigned int phibinwidth = phibinmax - phibinmin + 1;
+      g4phisize = (double) phibinwidth * layergeom->get_phistep() * layergeom->get_radius();
+
+      // Z size
+      //=====
+      double g4max_z = 0;
+      double g4min_z = 0;
+ 
+      outer_z = fabs(outer_z);
+      inner_z = fabs(inner_z);
+
+      double diffusion_long = 0.015;  // cm/SQRT(cm)
+      double zdiffusion = diffusion_long * sqrt(tpc_length / 2. - fabs(avge_z)) ;
+      double zshaping_lead = 32.0 * drift_velocity;  // ns * cm/ns = cm
+      double zshaping_tail = 48.0 * drift_velocity;
+      double added_smear_long = 0.105;  // cm
+
+      // largest z reaches gems first, make that the outer z
+      if(outer_z < inner_z) swap(outer_z, inner_z);
+      g4max_z = outer_z  + sigmas*sqrt(pow(zdiffusion,2) + pow(added_smear_long,2) + pow(zshaping_lead, 2));
+      g4min_z = inner_z  -  sigmas*sqrt(pow(zdiffusion,2) + pow(added_smear_long,2) + pow(zshaping_tail, 2));
+
+      // find the bins containing these max and min z edges
+      unsigned int binmin = layergeom->get_zbin(g4min_z);
+      unsigned int binmax = layergeom->get_zbin(g4max_z);
+      if(binmax < binmin) swap(binmax, binmin);
+      unsigned int binwidth = binmax - binmin + 1;
+
+      // multiply total number of bins that include the edges by the bin size
+      g4zsize = (double) binwidth * layergeom->get_zstep();
+    }
+  else if(radius > 5 && radius < 20)  // INTT
+    {
+      // All we have is the position and layer number
+
+      CylinderGeomIntt *layergeom = dynamic_cast<CylinderGeomIntt *>(_intt_geom_container->GetLayerGeom(layer));
+
+      // inner location
+      double world_inner[3] = {inner_x, inner_y, inner_z};
+      TVector3 world_inner_vec = {inner_x, inner_y, inner_z};
+
+      int segment_z_bin, segment_phi_bin;
+      layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_inner);
+
+      TVector3 local_inner_vec =  layergeom->get_local_from_world_coords(segment_z_bin, segment_phi_bin, world_inner_vec);
+      double yin = local_inner_vec[1];
+      double zin = local_inner_vec[2];
+      int strip_y_index, strip_z_index;
+      layergeom->find_strip_index_values(segment_z_bin, yin, zin, strip_y_index, strip_z_index);
+
+	// outer location
+      double world_outer[3] = {outer_x, outer_y, outer_z};
+      TVector3 world_outer_vec = {outer_x, outer_y, outer_z};
+
+      layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_outer);
+
+      TVector3 local_outer_vec =  layergeom->get_local_from_world_coords(segment_z_bin, segment_phi_bin, world_outer_vec);
+      double yout = local_outer_vec[1];
+      double zout = local_outer_vec[2];
+      int strip_y_index_out, strip_z_index_out;
+      layergeom->find_strip_index_values(segment_z_bin, yout, zout, strip_y_index_out, strip_z_index_out);
+ 
+      int strips = abs(strip_y_index_out - strip_y_index) + 1;
+      int cols = abs(strip_z_index_out - strip_z_index) + 1;
+
+
+      double strip_width = (double) strips * layergeom->get_strip_y_spacing(); // cm
+      double strip_length = (double) cols * layergeom->get_strip_z_spacing(); // cm
+
+      g4phisize = strip_width;
+      g4zsize = strip_length;
+
+      /*
+      if(Verbosity() > 1)
+	cout << " INTT: layer " << layer << " strips " << strips << " strip pitch " <<  layergeom->get_strip_y_spacing() << " g4phisize "<< g4phisize 
+	     << " columns " << cols << " strip_z_spacing " <<  layergeom->get_strip_z_spacing() << " g4zsize " << g4zsize << endl;
+      */
+    }
+  else  // MVTX
+    {
+      unsigned int stave, stave_outer;
+      unsigned int chip, chip_outer;
+      int row, row_outer;
+      int column, column_outer;
+
+      // add diffusion to entry and exit locations
+      double max_diffusion_radius = 25.0e-4;  // 25 microns
+      double min_diffusion_radius = 8.0e-4;  // 8 microns
+
+      CylinderGeom_Mvtx *layergeom = dynamic_cast<CylinderGeom_Mvtx *>(_mvtx_geom_container->GetLayerGeom(layer));
+
+      TVector3 world_inner = {inner_x, inner_y, inner_z};
+      std::vector<double> world_inner_vec = { world_inner[0], world_inner[1], world_inner[2] };
+      layergeom->get_sensor_indices_from_world_coords(world_inner_vec, stave, chip);
+      TVector3 local_inner = layergeom->get_local_from_world_coords(stave, chip, world_inner);
+
+      TVector3 world_outer = {outer_x, outer_y, outer_z};
+      std::vector<double> world_outer_vec = { world_outer[0], world_outer[1], world_outer[2] };
+      layergeom->get_sensor_indices_from_world_coords(world_outer_vec, stave_outer, chip_outer);
+      TVector3 local_outer = layergeom->get_local_from_world_coords(stave_outer, chip_outer, world_outer);
+
+      double diff =  max_diffusion_radius * 0.6;  // factor of 0.6 gives decent agreement with low occupancy reco clusters
+      if(local_outer[0] < local_inner[0]) 
+	diff = -diff;
+      local_outer[0] += diff;
+      local_inner[0] -= diff;
+
+      double diff_outer = min_diffusion_radius * 0.6;
+      if(local_outer[2] < local_inner[2]) 
+	diff_outer = -diff_outer;
+      local_outer[2] += diff_outer;
+      local_inner[2] -= diff_outer;
+
+      layergeom->get_pixel_from_local_coords(local_inner, row, column);
+      layergeom->get_pixel_from_local_coords(local_outer, row_outer, column_outer);
+
+      if(row_outer < row) swap(row_outer, row);
+      unsigned int rows = row_outer - row + 1;
+      g4phisize = (double) rows * layergeom->get_pixel_x();
+
+      if(column_outer < column) swap(column_outer, column);
+      unsigned int columns = column_outer - column + 1;
+      g4zsize = (double) columns * layergeom->get_pixel_z();
+
+      /*
+      if(Verbosity() > 1)
+	cout << " MVTX: layer " << layer << " rows " << rows << " pixel x " <<  layergeom->get_pixel_x() << " g4phisize "<< g4phisize 
+	     << " columns " << columns << " pixel_z " <<  layergeom->get_pixel_z() << " g4zsize " << g4zsize << endl;
+      */
+
+    }
+
+}
+
+std::set<PHG4Hit*> SvtxTruthEval::get_truth_hits_from_truth_cluster(TrkrDefs::cluskey ckey)
+{
+  std::set<PHG4Hit *> g4hit_set;
+
+
+  std::pair<std::multimap<TrkrDefs::cluskey, PHG4Hit*>::iterator, 
+	    std::multimap<TrkrDefs::cluskey,PHG4Hit*>::iterator>  ret =   _truth_cluster_truth_hit_map.equal_range(ckey);
+
+  for(std::multimap<TrkrDefs::cluskey, PHG4Hit*>::iterator jter = ret.first; jter != ret.second; ++jter)
+    {
+      g4hit_set.insert(jter->second);      
+    }
+
+  return g4hit_set;
+}
+
 PHG4Hit* SvtxTruthEval::get_innermost_truth_hit(PHG4Particle* particle)
 {
   if (!has_node_pointers())
@@ -380,6 +984,10 @@ void SvtxTruthEval::get_node_pointers(PHCompositeNode* topNode)
   _g4hits_tracker = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_INTT");
   _g4hits_maps = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_MVTX");
 
+  _tpc_geom_container = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  _intt_geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
+  _mvtx_geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
+
   return;
 }
 
@@ -396,4 +1004,41 @@ bool SvtxTruthEval::has_node_pointers()
     return false;
 
   return true;
+}
+
+float SvtxTruthEval::line_circle_intersection(float x[], float y[], float z[], float radius)
+{
+  // parameterize the line in terms of t (distance along the line segment, from 0-1) as
+  // x = x0 + t * (x1-x0); y=y0 + t * (y1-y0); z = z0 + t * (z1-z0)
+  // parameterize the cylinder (centered at x,y = 0,0) as  x^2 + y^2 = radius^2,   then
+  // (x0 + t*(x1-z0))^2 + (y0+t*(y1-y0))^2 = radius^2
+  // (x0^2 + y0^2 - radius^2) + (2x0*(x1-x0) + 2y0*(y1-y0))*t +  ((x1-x0)^2 + (y1-y0)^2)*t^2 = 0 = C + B*t + A*t^2
+  // quadratic with:  A = (x1-x0)^2+(y1-y0)^2 ;  B = 2x0*(x1-x0) + 2y0*(y1-y0);  C = x0^2 + y0^2 - radius^2
+  // solution: t = (-B +/- sqrt(B^2 - 4*A*C)) / (2*A)
+
+  float A = (x[1] - x[0]) * (x[1] - x[0]) + (y[1] - y[0]) * (y[1] - y[0]);
+  float B = 2.0 * x[0] * (x[1] - x[0]) + 2.0 * y[0] * (y[1] - y[0]);
+  float C = x[0] * x[0] + y[0] * y[0] - radius * radius;
+  float tup = (-B + sqrt(B * B - 4.0 * A * C)) / (2.0 * A);
+  float tdn = (-B - sqrt(B * B - 4.0 * A * C)) / (2.0 * A);
+
+  // The limits are 0 and 1, but we allow a little for floating point precision
+  float t;
+  if (tdn >= -0.0e-4 && tdn <= 1.0004)
+    t = tdn;
+  else if (tup >= -0.0e-4 && tup <= 1.0004)
+    t = tup;
+  else
+  {
+    cout << PHWHERE << "   **** Oops! No valid solution for tup or tdn, tdn = " << tdn << " tup = " << tup << endl;
+    cout << "   radius " << radius << " rbegin " << sqrt(x[0] * x[0] + y[0] * y[0]) << " rend " << sqrt(x[1] * x[1] + y[1] * y[1]) << endl;
+    cout << "   x0 " << x[0] << " x1 " << x[1] << endl;
+    cout << "   y0 " << y[0] << " y1 " << y[1] << endl;
+    cout << "   z0 " << z[0] << " z1 " << z[1] << endl;
+    cout << "   A " << A << " B " << B << " C " << C << endl;
+
+    t = -1;
+  }
+
+  return t;
 }

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -20,6 +20,7 @@ class TrkrCluster;
 #include <map>
 #include <set>
 #include <vector>
+#include <memory>
 
 class SvtxTruthEval
 {
@@ -49,7 +50,7 @@ class SvtxTruthEval
   PHG4Particle* get_primary_particle(PHG4Hit* g4hit);
   PHG4Particle* get_primary_particle(PHG4Particle* particle);
 
-  std::map<unsigned int, TrkrCluster*> all_truth_clusters(PHG4Particle* particle);
+  std::map<unsigned int, std::shared_ptr<TrkrCluster> > all_truth_clusters(PHG4Particle* particle);
 
   bool is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle);
   bool are_same_particle(PHG4Particle* p1, PHG4Particle* p2);
@@ -97,7 +98,7 @@ class SvtxTruthEval
   bool _do_cache;
   std::set<PHG4Hit*> _cache_all_truth_hits;
   std::map<PHG4Particle*, std::set<PHG4Hit*> > _cache_all_truth_hits_g4particle;
-  std::map<PHG4Particle*, std::map<unsigned int, TrkrCluster*> > _cache_all_truth_clusters_g4particle;
+  std::map<PHG4Particle*, std::map<unsigned int, std::shared_ptr<TrkrCluster> > > _cache_all_truth_clusters_g4particle;
   std::map<PHG4Particle*, PHG4Hit*> _cache_get_innermost_truth_hit;
   std::map<PHG4Particle*, PHG4Hit*> _cache_get_outermost_truth_hit;
   std::map<PHG4Hit*, PHG4Particle*> _cache_get_primary_particle_g4hit;

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -3,16 +3,23 @@
 
 #include "BaseTruthEval.h"
 
+#include <trackbase/TrkrDefs.h>
+
 class PHCompositeNode;
 
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Particle;
 class PHG4TruthInfoContainer;
+class PHG4CylinderGeomContainer;
+class PHG4CylinderCellGeomContainer;
 class PHG4VtxPoint;
+class TrkrCluster;
+
 
 #include <map>
 #include <set>
+#include <vector>
 
 class SvtxTruthEval
 {
@@ -42,6 +49,8 @@ class SvtxTruthEval
   PHG4Particle* get_primary_particle(PHG4Hit* g4hit);
   PHG4Particle* get_primary_particle(PHG4Particle* particle);
 
+  std::map<unsigned int, TrkrCluster*> all_truth_clusters(PHG4Particle* particle);
+
   bool is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle);
   bool are_same_particle(PHG4Particle* p1, PHG4Particle* p2);
   bool are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2);
@@ -51,9 +60,17 @@ class SvtxTruthEval
 
   unsigned int get_errors() { return _errors + _basetrutheval.get_errors(); }
 
+  std::set<PHG4Hit*> get_truth_hits_from_truth_cluster(TrkrDefs::cluskey ckey);
+
  private:
   void get_node_pointers(PHCompositeNode* topNode);
   bool has_node_pointers();
+
+  void LayerClusterG4Hits(std::set<PHG4Hit*> truth_hits, std::vector<PHG4Hit*> &contributing_hits, std::vector<double> &contributing_hits_energy, std::vector<std::vector<double>> &contributing_hits_entry, std::vector<std::vector<double>> &contributing_hits_exit, float layer, float &x, float &y, float &z,  float &t, float &e);
+
+  float line_circle_intersection(float x[], float y[], float z[], float radius);
+
+  void G4ClusterSize(unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry,std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize);
 
   BaseTruthEval _basetrutheval;
 
@@ -62,16 +79,28 @@ class SvtxTruthEval
   PHG4HitContainer* _g4hits_tracker;
   PHG4HitContainer* _g4hits_maps;
 
+  PHG4CylinderCellGeomContainer* _tpc_geom_container;
+  PHG4CylinderGeomContainer *_intt_geom_container;
+  PHG4CylinderGeomContainer* _mvtx_geom_container;
+
   bool _strict;
   int _verbosity;
   unsigned int _errors;
 
+  const unsigned int _nlayers_maps = 3;
+  const unsigned int _nlayers_intt = 4;
+  const unsigned int _nlayers_tpc = 48;
+
+  std::multimap<TrkrDefs::cluskey, PHG4Hit*> _truth_cluster_truth_hit_map;
+
   bool _do_cache;
   std::set<PHG4Hit*> _cache_all_truth_hits;
   std::map<PHG4Particle*, std::set<PHG4Hit*> > _cache_all_truth_hits_g4particle;
+  std::map<PHG4Particle*, std::map<unsigned int, TrkrCluster*> > _cache_all_truth_clusters_g4particle;
   std::map<PHG4Particle*, PHG4Hit*> _cache_get_innermost_truth_hit;
   std::map<PHG4Particle*, PHG4Hit*> _cache_get_outermost_truth_hit;
   std::map<PHG4Hit*, PHG4Particle*> _cache_get_primary_particle_g4hit;
+
 };
 
 #endif  // G4EVAL_SVTXTRUTHEVAL_H

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -86,7 +86,7 @@ class SvtxTruthEval
   bool _strict;
   int _verbosity;
   unsigned int _errors;
-  unsigned int iclus;
+  unsigned long iclus;
 
   const unsigned int _nlayers_maps = 3;
   const unsigned int _nlayers_intt = 4;

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -86,6 +86,7 @@ class SvtxTruthEval
   bool _strict;
   int _verbosity;
   unsigned int _errors;
+  unsigned int iclus;
 
   const unsigned int _nlayers_maps = 3;
   const unsigned int _nlayers_intt = 4;


### PR DESCRIPTION
Substantially reorganized SvtxEvaluator and friends. Moved the functionality to make TPC truth clusters to SvtxTruthEval and added methods to get them and their associated truth hits. The truth clusters are now returned in a TrkrCluster map. Added some functionality to SvtxClusterEval to get the best matching reco cluster corresponding to a truth cluster, and also the best matching truth cluster corresponding to a reco cluster. Truth/reco cluster matching still uses the cluster/hit/g4hit tracing from the TrkrClusterHitAssoc and TrkrHitTruthAssoc maps, but I also added a 4-sigma cluster position cut. When matching to a reco cluster, only one truth cluster is chosen - the one with the largest truth energ
[cluster_efficiency_reorganization.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/4916248/cluster_efficiency_reorganization.pdf)
y. 
The resulting Cluster efficiency for 100 track muon events is shown here.

