### PR TITLE
Fit WRT Initial Vertex Estimate

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -817,6 +817,7 @@ void ActsEvaluator::fillFittedTrackParams(const Trajectory traj,
     const auto &boundParam = traj.trackParameters(trackTip);
     const auto &parameter = boundParam.parameters();
     const auto &covariance = *boundParam.covariance();
+    m_charge_fit = boundParam.charge();
     m_eLOC0_fit = parameter[Acts::ParDef::eLOC_0];
     m_eLOC1_fit = parameter[Acts::ParDef::eLOC_1];
     m_ePHI_fit = parameter[Acts::ParDef::ePHI];
@@ -852,6 +853,7 @@ void ActsEvaluator::fillFittedTrackParams(const Trajectory traj,
   m_eTHETA_fit = -9999;
   m_eQOP_fit = -9999;
   m_eT_fit = -9999;
+  m_charge_fit = -9999;
   m_err_eLOC0_fit = -9999;
   m_err_eLOC1_fit = -9999;
   m_err_ePHI_fit = -9999;
@@ -1201,7 +1203,7 @@ void ActsEvaluator::initializeTree()
   m_trackTree->Branch("t_phi", &m_t_phi);
   m_trackTree->Branch("t_eta", &m_t_eta);
   m_trackTree->Branch("t_pT", &m_t_pT);
-
+  
   m_trackTree->Branch("t_x", &m_t_x);
   m_trackTree->Branch("t_y", &m_t_y);
   m_trackTree->Branch("t_z", &m_t_z);
@@ -1224,6 +1226,7 @@ void ActsEvaluator::initializeTree()
   m_trackTree->Branch("eTHETA_fit", &m_eTHETA_fit);
   m_trackTree->Branch("eQOP_fit", &m_eQOP_fit);
   m_trackTree->Branch("eT_fit", &m_eT_fit);
+  m_trackTree->Branch("charge_fit", &m_charge_fit);
   m_trackTree->Branch("err_eLOC0_fit", &m_err_eLOC0_fit);
   m_trackTree->Branch("err_eLOC1_fit", &m_err_eLOC1_fit);
   m_trackTree->Branch("err_ePHI_fit", &m_err_ePHI_fit);

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -169,6 +169,7 @@ class ActsEvaluator : public SubsysReco
   float m_dca3Dz{-99.};           /// fitted parameter 3D DCA in z plane
   float m_dca3DxyCov{-99.};       /// fitted parameter 3D DCA covariance in xy
   float m_dca3DzCov{-99.};        /// fitted parameter 3D DCA covariance in z
+  int m_charge_fit{-99};          /// fitted parameter charge
 
   int m_nPredicted{0};                   /// number of states with predicted parameter
   std::vector<bool> m_prt;               /// predicted status

--- a/offline/packages/trackreco/ActsTrack.h
+++ b/offline/packages/trackreco/ActsTrack.h
@@ -9,16 +9,21 @@ using SourceLink = FW::Data::TrkrClusterSourceLink;
 
 
 /**
- * A struct that contains an Acts track seed and the corresponding source links.
+ * Aclass that contains an Acts track seed and the corresponding source links.
+ * Also contains a vertex id corresponding to the original track seed
+ * vertex id.
  * Used by a variety of the Acts track fitting classes.
  */
 class ActsTrack
 {
 
  public:
-  ActsTrack(FW::TrackParameters params, const std::vector<SourceLink> &links)
+  ActsTrack(FW::TrackParameters params, 
+	    const std::vector<SourceLink> &links,
+	    unsigned int vertexId)
     : m_trackParams(params)
     , m_sourceLinks(links)
+    , m_vertexId(vertexId)
     {}
 
   ~ActsTrack(){}
@@ -30,11 +35,13 @@ class ActsTrack
   void setSourceLinks(std::vector<SourceLink> srcLinks)
   { m_sourceLinks = srcLinks; }
   
+  unsigned int getVertexId() { return m_vertexId;}
+  void setVertexId(unsigned int id){m_vertexId = id;}
 
  private:
-  
   FW::TrackParameters m_trackParams;
   std::vector<SourceLink> m_sourceLinks;
+  unsigned int m_vertexId;
 
 };
 

--- a/offline/packages/trackreco/ActsTrack.h
+++ b/offline/packages/trackreco/ActsTrack.h
@@ -9,7 +9,7 @@ using SourceLink = FW::Data::TrkrClusterSourceLink;
 
 
 /**
- * Aclass that contains an Acts track seed and the corresponding source links.
+ * A class that contains an Acts track seed and the corresponding source links.
  * Also contains a vertex id corresponding to the original track seed
  * vertex id.
  * Used by a variety of the Acts track fitting classes.

--- a/offline/packages/trackreco/ActsTrack.h
+++ b/offline/packages/trackreco/ActsTrack.h
@@ -20,10 +20,10 @@ class ActsTrack
  public:
   ActsTrack(FW::TrackParameters params, 
 	    const std::vector<SourceLink> &links,
-	    unsigned int vertexId)
+	    const std::vector<float> vertex)
     : m_trackParams(params)
     , m_sourceLinks(links)
-    , m_vertexId(vertexId)
+    , m_vertex(vertex)
     {}
 
   ~ActsTrack(){}
@@ -35,13 +35,18 @@ class ActsTrack
   void setSourceLinks(std::vector<SourceLink> srcLinks)
   { m_sourceLinks = srcLinks; }
   
-  unsigned int getVertexId() { return m_vertexId;}
-  void setVertexId(unsigned int id){m_vertexId = id;}
+  std::vector<float> getVertexId() { return m_vertex;}
+  void setVertexId(std::vector<float> vertex){m_vertex = vertex;}
 
  private:
+  /// Initial track seed parameters
   FW::TrackParameters m_trackParams;
+
+  /// SourceLinks associated to this track
   std::vector<SourceLink> m_sourceLinks;
-  unsigned int m_vertexId;
+
+  /// Initial x,y,z vertex estimate
+  std::vector<float> m_vertex;
 
 };
 

--- a/offline/packages/trackreco/ActsTrack.h
+++ b/offline/packages/trackreco/ActsTrack.h
@@ -20,7 +20,7 @@ class ActsTrack
  public:
   ActsTrack(FW::TrackParameters params, 
 	    const std::vector<SourceLink> &links,
-	    const std::vector<float> vertex)
+	    Acts::Vector3D vertex)
     : m_trackParams(params)
     , m_sourceLinks(links)
     , m_vertex(vertex)
@@ -35,8 +35,8 @@ class ActsTrack
   void setSourceLinks(std::vector<SourceLink> srcLinks)
   { m_sourceLinks = srcLinks; }
   
-  std::vector<float> getVertexId() { return m_vertex;}
-  void setVertexId(std::vector<float> vertex){m_vertex = vertex;}
+  Acts::Vector3D  getVertex() { return m_vertex;}
+  void setVertex(Acts::Vector3D vertex){m_vertex = vertex;}
 
  private:
   /// Initial track seed parameters
@@ -46,7 +46,7 @@ class ActsTrack
   std::vector<SourceLink> m_sourceLinks;
 
   /// Initial x,y,z vertex estimate
-  std::vector<float> m_vertex;
+  Acts::Vector3D m_vertex;
 
 };
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -686,7 +686,7 @@ Surface MakeActsGeometry::getTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey,
   if(surf_index == 999)
     {
       cout << PHWHERE << "Error: surface index not defined, can't go on!" << endl;
-      exit(1);
+      return nullptr;
     }
  
   return surf_vec[surf_index];

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -99,10 +99,17 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 
     const unsigned int vertexId = track->get_vertex_id();
     const SvtxVertex *svtxVertex = m_vertexMap->get(vertexId);
-    std::vector<float> vertex = {svtxVertex->get_x(), 
-				 svtxVertex->get_y(), 
-				 svtxVertex->get_z()};
+    Acts::Vector3D vertex = {svtxVertex->get_x() * Acts::UnitConstants::cm, 
+			     svtxVertex->get_y() * Acts::UnitConstants::cm, 
+			     svtxVertex->get_z() * Acts::UnitConstants::cm};
     
+    if(Verbosity() > 4)
+      {
+	std::cout << "Vertex estimate : ("; 
+	for(int i = 0; i < vertex.size(); i++)
+	  std::cout<<vertex(i)<<", ";
+	std::cout << ")" << std::endl;
+      }
 
 
     /// Get the necessary parameters and values for the TrackParameters

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -25,6 +25,7 @@
 class PHCompositeNode;
 class SvtxTrackMap;
 class SvtxTrack;
+class SvtxVertexMap;
 class MakeActsGeometry;
 
 using SourceLink = FW::Data::TrkrClusterSourceLink;
@@ -74,6 +75,9 @@ class PHActsTracks : public SubsysReco
 
   /// Trackmap that contains SvtxTracks
   SvtxTrackMap *m_trackMap;
+
+  /// VertexMap that contains the initial vertexing estimates
+  SvtxVertexMap *m_vertexMap;
 
   /// Map between cluster key and arbitrary hit id created in PHActsSourceLinks
   std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -73,7 +73,7 @@ int PHActsTrkFitter::Setup(PHCompositeNode* topNode)
   fitCfg.fit = FW::TrkrClusterFittingAlgorithm::makeFitterFunction(
                m_tGeometry->tGeometry,
 	       m_tGeometry->magField,
-	       Acts::Logging::VERBOSE);
+	       Acts::Logging::INFO);
 
   if(m_timeAnalysis)
     {

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -104,7 +104,7 @@ int PHActsTrkFitter::Process()
   /// at 0 so that the fitter is fitting with respect to the global 
   /// position. Presumably we could put this as the zvertex
   auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
-	          Acts::Vector3D{0., 0., 0.});
+	          Acts::Vector3D{0., 0., 10.});
 
   std::map<unsigned int, ActsTrack>::iterator trackIter;
 
@@ -123,7 +123,8 @@ int PHActsTrkFitter::Process()
       {
 	std::cout << " Processing proto track with position:" 
 		  << trackSeed.position() << std::endl 
-		  << "momentum: " << trackSeed.momentum() 
+		  << "momentum: " << trackSeed.momentum() << std::endl
+		  << "charge : "<<trackSeed.charge()
 		  << " corresponding to SvtxTrack key "<< trackKey
 		  << std::endl;
 
@@ -163,6 +164,7 @@ int PHActsTrkFitter::Process()
           std::cout << "Fitted parameters for track" << std::endl;
           std::cout << " position : " << params.position().transpose()
                     << std::endl;
+	  std::cout << "charge: "<<params.charge()<<std::endl;
           std::cout << " momentum : " << params.momentum().transpose()
                     << std::endl;
 	  std::cout << "For trackTip == " << fitOutput.trackTip << std::endl;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -73,7 +73,7 @@ int PHActsTrkFitter::Setup(PHCompositeNode* topNode)
   fitCfg.fit = FW::TrkrClusterFittingAlgorithm::makeFitterFunction(
                m_tGeometry->tGeometry,
 	       m_tGeometry->magField,
-	       Acts::Logging::INFO);
+	       Acts::Logging::VERBOSE);
 
   if(m_timeAnalysis)
     {
@@ -98,14 +98,6 @@ int PHActsTrkFitter::Process()
     std::cout << "Start PHActsTrkFitter::process_event" << std::endl;
   }
 
-
-  /// Construct a perigee surface as the target surface
-  /// This surface is what Acts fits with respect to. So we put it
-  /// at 0 so that the fitter is fitting with respect to the global 
-  /// position. Presumably we could put this as the zvertex
-  auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
-	          Acts::Vector3D{0., 0., 10.});
-
   std::map<unsigned int, ActsTrack>::iterator trackIter;
 
   for (trackIter = m_actsProtoTracks->begin();
@@ -118,13 +110,20 @@ int PHActsTrkFitter::Process()
 
     std::vector<SourceLink> sourceLinks = track.getSourceLinks();
     FW::TrackParameters trackSeed = track.getTrackParams();
-      
+    
+    /// Construct a perigee surface as the target surface
+    /// This surface is what Acts fits with respect to, so we set it to
+    /// the initial vertex estimation
+    auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
+		          track.getVertex());
+   
     if(Verbosity() > 1)
       {
 	std::cout << " Processing proto track with position:" 
 		  << trackSeed.position() << std::endl 
 		  << "momentum: " << trackSeed.momentum() << std::endl
 		  << "charge : "<<trackSeed.charge()
+		  << "initial vertex : "<<track.getVertex()
 		  << " corresponding to SvtxTrack key "<< trackKey
 		  << std::endl;
 

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -135,9 +135,6 @@ int PHActsTrkProp::Process()
     std::cout << "Start PHActsTrkProp::process_event" << std::endl;
   }
 
-  PerigeeSurface pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>
-    (Acts::Vector3D(0., 0., 0.));
-
   /// Collect all source links for the CKF
   std::vector<SourceLink> sourceLinks = getEventSourceLinks();
 
@@ -153,7 +150,13 @@ int PHActsTrkProp::Process()
     const unsigned int trackKey = trackIter->first;
 
     FW::TrackParameters trackSeed = track.getTrackParams();
-  
+
+    /// Construct a perigee surface as the target surface
+    /// This surface is what Acts fits with respect to, so we set it to
+    /// the initial vertex estimation
+    auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
+	                           track.getVertex());
+
     /// Construct the options to pass to the CKF.
     /// SourceLinkSelector set in Init()
     Acts::CombinatorialKalmanFilterOptions<SourceLinkSelector> ckfOptions(


### PR DESCRIPTION
This PR changes the Acts track fitting/propagation to fit with respect to the initial track vertex estimate given by the `PHInitVertexing` that is used (either `PHTruthVertexing` or `PHInitZVertexing`). Previously we were just fitting wrt to the global origin (0,0,0), which in discussion with the Acts developers is not the intended use of the fitter.

This PR also introduces a small change in commit `ee2f314` to return a `nullptr` instead of `exit` in the event an appropriate surface for a TPC cluster isn't found. This way the cluster is just skipped and not added to the fitting procedure rather than causing the whole code to exit. 