### PR TITLE
Fixed copy-from-baseclass constructor

### DIFF
--- a/simulation/g4simulation/g4main/PHG4Particlev2.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.cc
@@ -26,11 +26,11 @@ PHG4Particlev2::PHG4Particlev2(const string &name, const int pid, const double p
 
 PHG4Particlev2::PHG4Particlev2(const PHG4Particle *in)
   : PHG4Particlev1(in)
-  , trkid(0)
-  , vtxid(0)
-  , parentid(0)
-  , primaryid(0xFFFFFFFF)
-  , fe(0.0)
+  , trkid(in->get_track_id())
+  , vtxid(in->get_vtx_id())
+  , parentid(in->get_parent_id())
+  , primaryid(in->get_primary_id())
+  , fe(in->get_e())
 {
 }
 


### PR DESCRIPTION
It appears that PHG4Particlev2 constructor from pointer to base class was not propagating the track id, vertex id, primary id and energy, resulting in having the values being reset when doing a deep copy of the object. I don't think this is intentinal.
This PR fixes that. 