### PR TITLE
Fixed uninitialized variable and modernized

### DIFF
--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -11,21 +11,6 @@
 
 using namespace std;
 
-PHG4Hitv1::PHG4Hitv1():
- hitid(ULONG_LONG_MAX),
- trackid(INT_MIN),
- edep(NAN)
-{
-  for (int i = 0; i<2;i++)
-    {
-      set_x(i,NAN);
-      set_y(i,NAN);
-      set_z(i,NAN);
-      set_t(i,NAN);
-    }
-
-}
-
 PHG4Hitv1::PHG4Hitv1(const PHG4Hit *g4hit)
 {
   CopyFrom(g4hit);
@@ -36,6 +21,7 @@ PHG4Hitv1::Reset()
 {
   hitid = ULONG_LONG_MAX;
   trackid = INT_MIN;
+  showerid = INT_MIN;
   edep = NAN;
   for (int i = 0; i<2;i++)
     {

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -17,9 +17,9 @@
 class PHG4Hitv1 : public PHG4Hit
 {
  public:
-  PHG4Hitv1();
+  PHG4Hitv1() = default;
   explicit PHG4Hitv1(const PHG4Hit *g4hit);
-  virtual ~PHG4Hitv1() {}
+  virtual ~PHG4Hitv1() = default;
   void identify(std::ostream& os  = std::cout) const;
   void Reset();
 
@@ -102,14 +102,14 @@ class PHG4Hitv1 : public PHG4Hit
   void set_property_nocheck(const PROPERTY prop_id,const unsigned int ui) {prop_map[prop_id]=ui;}
   // Store both the entry and exit points of the particle
   // Remember, particles do not always enter on the inner edge!
-  float x[2];
-  float y[2];
-  float z[2];
-  float t[2];
-  PHG4HitDefs::keytype hitid;
-  int trackid;
-  int showerid;
-  float edep;
+  float x[2] = {NAN,NAN};
+  float y[2] = {NAN,NAN};
+  float z[2] = {NAN,NAN};
+  float t[2] = {NAN,NAN};
+  PHG4HitDefs::keytype hitid = ULONG_LONG_MAX;
+  int trackid = INT_MIN;
+  int showerid = INT_MIN;
+  float edep = NAN;
 
   //! storage types for additional property
   typedef uint8_t prop_id_t;


### PR DESCRIPTION
variable showerid was never properly initialized in G4Hitv1 constructor, nor reset in the ::Reset method.
I took the opportunity of fixing this to modernize the code: 
- moved all member initialization to the header (this should help not making the same mistake again)
- marked the constructor (and the destructor) as "default" since they are both empty.
