### PR TITLE
Optimize map insertion

### DIFF
--- a/generators/phhepmc/PHHepMCGenEventMap.h
+++ b/generators/phhepmc/PHHepMCGenEventMap.h
@@ -27,7 +27,7 @@ class PHHepMCGenEventMap : public PHObject
   typedef std::map<int, PHHepMCGenEvent*>::const_reverse_iterator ConstReverseIter;
   typedef std::map<int, PHHepMCGenEvent*>::reverse_iterator ReverseIter;
 
-  PHHepMCGenEventMap();
+  PHHepMCGenEventMap() = default;
   PHHepMCGenEventMap(const PHHepMCGenEventMap& eventmap);
   PHHepMCGenEventMap& operator=(const PHHepMCGenEventMap& eventmap);
 

--- a/simulation/g4simulation/g4main/PHG4HitContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4HitContainer.cc
@@ -116,8 +116,7 @@ PHG4HitContainer::AddHit(PHG4Hit *newhit)
   PHG4HitDefs::keytype detidlong = key >>  PHG4HitDefs::hit_idbits;
   unsigned int detid = detidlong;
   layers.insert(detid);
-  hitmap[key] = newhit;
-  return hitmap.find(key);
+  return hitmap.insert( std::make_pair( key, newhit ) ).first;
 }
 
 PHG4HitContainer::ConstIterator
@@ -126,8 +125,7 @@ PHG4HitContainer::AddHit(const unsigned int detid, PHG4Hit *newhit)
   PHG4HitDefs::keytype key = genkey(detid);
   layers.insert(detid);
   newhit->set_hit_id(key);
-  hitmap[key] = newhit;
-  return hitmap.find(key);
+  return hitmap.insert( std::make_pair( key, newhit ) ).first;
 }
 
 PHG4HitContainer::ConstRange PHG4HitContainer::getHits(const unsigned int detid) const


### PR DESCRIPTION
Two optimizations when inserting objects into maps, to avoid multiple unnecessary map lookups 
For PHHepMCGenEventMap, also simplified constructor, copy constructor and assignment operator. 