### PR TITLE
Track Momentum Covariance Bug fix

### DIFF
--- a/offline/packages/trackreco/ActsCovarianceRotater.cc
+++ b/offline/packages/trackreco/ActsCovarianceRotater.cc
@@ -75,9 +75,9 @@ Acts::BoundSymMatrix ActsCovarianceRotater::rotateSvtxTrackCovToActs(
   // p -> q/p
   // d(p)/dpx = px/p
   // var(q/p) = (d(1/p)/dp)^2 * var(p) = (-1/p^2)^2 * var(p)
-  rotation(4,3) = charge * px / pow(p,5);
-  rotation(4,4) = charge * py / pow(p,5);
-  rotation(4,5) = charge * pz / pow(p,5);
+  rotation(4,3) = charge * px / pow(p,1.5);
+  rotation(4,4) = charge * py / pow(p,1.5);
+  rotation(4,5) = charge * pz / pow(p,1.5);
 
   /// time is left as 0
   printMatrix("Unit-ed svtxCov is : " , svtxCovariance);
@@ -146,9 +146,9 @@ Acts::BoundSymMatrix ActsCovarianceRotater::rotateActsCovToSvtxTrack(
   rotation(3, 5) = -p * sinTheta;
   
   ///q/p rotaton
-  rotation(4,3) = charge * px / pow(p,5);
-  rotation(4,4) = charge * py / pow(p,5);
-  rotation(4,5) = charge * pz / pow(p,5);
+  rotation(4,3) = charge * px / pow(p,1.5);
+  rotation(4,4) = charge * py / pow(p,1.5);
+  rotation(4,5) = charge * pz / pow(p,1.5);
 
   printMatrix("Rotating back to global with : ", rotation.transpose());
 

--- a/offline/packages/trackreco/ActsCovarianceRotater.cc
+++ b/offline/packages/trackreco/ActsCovarianceRotater.cc
@@ -65,19 +65,16 @@ Acts::BoundSymMatrix ActsCovarianceRotater::rotateSvtxTrackCovToActs(
 
   // Directional and momentum parameters for curvilinear
   rotation(2, 3) = -p * sinPhi * sinTheta;
-  rotation(2, 4) = p * cosPhi * sinTheta;
-  rotation(3, 3) = p * cosPhi * cosTheta;
-  rotation(3, 4) = p * sinPhi * cosTheta;
+  rotation(2, 4) =  p * cosPhi * sinTheta;
+  rotation(3, 3) =  p * cosPhi * cosTheta;
+  rotation(3, 4) =  p * sinPhi * cosTheta;
   rotation(3, 5) = -p * sinTheta;
   
-  ///q/p rotaton
-  // p_i/p transforms from px -> p, and charge/p^4 transforms from
-  // p -> q/p
-  // d(p)/dpx = px/p
-  // var(q/p) = (d(1/p)/dp)^2 * var(p) = (-1/p^2)^2 * var(p)
-  rotation(4,3) = charge * px / pow(p,1.5);
-  rotation(4,4) = charge * py / pow(p,1.5);
-  rotation(4,5) = charge * pz / pow(p,1.5);
+  /// q/p rotaton
+  /// d(q/p)/dp_i = -q * p_i / p^(3/2)
+  rotation(4,3) = -1*charge * px / pow(p,1.5);
+  rotation(4,4) = -1*charge * py / pow(p,1.5);
+  rotation(4,5) = -1*charge * pz / pow(p,1.5);
 
   /// time is left as 0
   printMatrix("Unit-ed svtxCov is : " , svtxCovariance);

--- a/offline/packages/trackreco/ActsCovarianceRotater.cc
+++ b/offline/packages/trackreco/ActsCovarianceRotater.cc
@@ -65,16 +65,19 @@ Acts::BoundSymMatrix ActsCovarianceRotater::rotateSvtxTrackCovToActs(
 
   // Directional and momentum parameters for curvilinear
   rotation(2, 3) = -p * sinPhi * sinTheta;
-  rotation(2, 4) =  p * cosPhi * sinTheta;
-  rotation(3, 3) =  p * cosPhi * cosTheta;
-  rotation(3, 4) =  p * sinPhi * cosTheta;
+  rotation(2, 4) = p * cosPhi * sinTheta;
+  rotation(3, 3) = p * cosPhi * cosTheta;
+  rotation(3, 4) = p * sinPhi * cosTheta;
   rotation(3, 5) = -p * sinTheta;
   
-  /// q/p rotaton
-  /// d(q/p)/dp_i = -q * p_i / p^(3/2)
-  rotation(4,3) = -1*charge * px / pow(p,1.5);
-  rotation(4,4) = -1*charge * py / pow(p,1.5);
-  rotation(4,5) = -1*charge * pz / pow(p,1.5);
+  ///q/p rotaton
+  // p_i/p transforms from px -> p, and charge/p^4 transforms from
+  // p -> q/p
+  // d(p)/dpx = px/p
+  // var(q/p) = (d(1/p)/dp)^2 * var(p) = (-1/p^2)^2 * var(p)
+  rotation(4,3) = charge * px / pow(p,1.5);
+  rotation(4,4) = charge * py / pow(p,1.5);
+  rotation(4,5) = charge * pz / pow(p,1.5);
 
   /// time is left as 0
   printMatrix("Unit-ed svtxCov is : " , svtxCovariance);

--- a/offline/packages/trackreco/ActsCovarianceRotater.cc
+++ b/offline/packages/trackreco/ActsCovarianceRotater.cc
@@ -6,7 +6,7 @@ Acts::BoundSymMatrix ActsCovarianceRotater::rotateSvtxTrackCovToActs(
 {
   Acts::BoundSymMatrix rotation = Acts::BoundSymMatrix::Zero();
   Acts::BoundSymMatrix svtxCovariance = Acts::BoundSymMatrix::Zero();
-  
+
   for(int i = 0; i < 6; ++i)
     {
       for(int j = 0; j < 6; ++j)
@@ -181,7 +181,7 @@ void ActsCovarianceRotater::printMatrix(const std::string &message,
 					Acts::BoundSymMatrix matrix)
 {
  
-  if(m_verbosity)
+  if(m_verbosity > 0)
     {
       std::cout << std::endl << message.c_str() << std::endl;
       for(int i = 0 ; i < matrix.rows(); ++i)

--- a/offline/packages/trackreco/ActsCovarianceRotater.cc
+++ b/offline/packages/trackreco/ActsCovarianceRotater.cc
@@ -65,19 +65,16 @@ Acts::BoundSymMatrix ActsCovarianceRotater::rotateSvtxTrackCovToActs(
 
   // Directional and momentum parameters for curvilinear
   rotation(2, 3) = -p * sinPhi * sinTheta;
-  rotation(2, 4) = p * cosPhi * sinTheta;
-  rotation(3, 3) = p * cosPhi * cosTheta;
-  rotation(3, 4) = p * sinPhi * cosTheta;
+  rotation(2, 4) =  p * cosPhi * sinTheta;
+  rotation(3, 3) =  p * cosPhi * cosTheta;
+  rotation(3, 4) =  p * sinPhi * cosTheta;
   rotation(3, 5) = -p * sinTheta;
   
   ///q/p rotaton
-  // p_i/p transforms from px -> p, and charge/p^4 transforms from
-  // p -> q/p
-  // d(p)/dpx = px/p
-  // var(q/p) = (d(1/p)/dp)^2 * var(p) = (-1/p^2)^2 * var(p)
-  rotation(4,3) = charge * px / pow(p,1.5);
-  rotation(4,4) = charge * py / pow(p,1.5);
-  rotation(4,5) = charge * pz / pow(p,1.5);
+  // d(q/p)/dp_i = pq * p_i / p^(3/2)
+  rotation(4,3) = -charge * px / pow(p,1.5);
+  rotation(4,4) = -charge * py / pow(p,1.5);
+  rotation(4,5) = -charge * pz / pow(p,1.5);
 
   /// time is left as 0
   printMatrix("Unit-ed svtxCov is : " , svtxCovariance);
@@ -140,15 +137,15 @@ Acts::BoundSymMatrix ActsCovarianceRotater::rotateActsCovToSvtxTrack(
 
   // Directional and momentum parameters for curvilinear
   rotation(2, 3) = -p * sinPhi * sinTheta;
-  rotation(2, 4) = p * cosPhi * sinTheta;
-  rotation(3, 3) = p * cosPhi * cosTheta;
-  rotation(3, 4) = p * sinPhi * cosTheta;
+  rotation(2, 4) =  p * cosPhi * sinTheta;
+  rotation(3, 3) =  p * cosPhi * cosTheta;
+  rotation(3, 4) =  p * sinPhi * cosTheta;
   rotation(3, 5) = -p * sinTheta;
   
   ///q/p rotaton
-  rotation(4,3) = charge * px / pow(p,1.5);
-  rotation(4,4) = charge * py / pow(p,1.5);
-  rotation(4,5) = charge * pz / pow(p,1.5);
+  rotation(4,3) = -charge * px / pow(p,1.5);
+  rotation(4,4) = -charge * py / pow(p,1.5);
+  rotation(4,5) = -charge * pz / pow(p,1.5);
 
   printMatrix("Rotating back to global with : ", rotation.transpose());
 

--- a/offline/packages/trackreco/ActsCovarianceRotater.h
+++ b/offline/packages/trackreco/ActsCovarianceRotater.h
@@ -42,15 +42,14 @@ class ActsCovarianceRotater
   Acts::BoundSymMatrix rotateSvtxTrackCovToActs(const SvtxTrack *track);
   
   /// Same as above, but rotate from Acts basis to global (x,y,z,px,py,pz)
-  Acts::BoundSymMatrix rotateActsCovToSvtxTrack(
-						const Acts::BoundParameters params);
+  Acts::BoundSymMatrix rotateActsCovToSvtxTrack(const Acts::BoundParameters params);
 
-  void setVerbosity(bool verbosity) {m_verbosity = verbosity;}
+  void setVerbosity(int verbosity) {m_verbosity = verbosity;}
 
   void printMatrix(const std::string &message, Acts::BoundSymMatrix matrix);
 
  private:
-  bool m_verbosity;
+  int m_verbosity;
 
 
 };

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -685,7 +685,7 @@ Surface MakeActsGeometry::getTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey,
     }
   if(surf_index == 999)
     {
-      cout << PHWHERE << "Error: surface index not defined, can't go on!" << endl;
+      cout << PHWHERE << "Error: TPC surface index not defined, skipping cluster!" << endl;
       return nullptr;
     }
  

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -299,7 +299,7 @@ Surface PHActsSourceLinks::getTpcLocalCoords(Acts::Vector2D &local2D,
   if(!surface)
     {
       std::cout << PHWHERE
-		<< "Failed to find associated surface element - should be impossible!"
+		<< "Failed to find associated surface element - should be impossible! Skipping measurement."
 		<< std::endl;
       return nullptr;
     }

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -122,11 +122,13 @@ int PHActsTrkFitter::Process()
 	std::cout << " Processing proto track with position:" 
 		  << trackSeed.position() << std::endl 
 		  << "momentum: " << trackSeed.momentum() << std::endl
-		  << "charge : "<<trackSeed.charge()
+		  << "charge : "<<trackSeed.charge() << std::endl
 		  << "initial vertex : "<<track.getVertex()
 		  << " corresponding to SvtxTrack key "<< trackKey
 		  << std::endl;
-
+	std::cout << "proto track covariance " << std::endl
+		  << trackSeed.covariance().value() << std::endl;
+     
       }
 
     /// Call KF now. Have a vector of sourceLinks corresponding to clusters


### PR DESCRIPTION
This PR fixes a bug in the track seed covariance rotation. Previously rotating to q/p was causing the covariance to be too small, which is why the track fit seemed to just copy the input track seed. This fix improves the track pT resolution to something that is at least the right shape. The resolution is still on the high side, though.