### PR TITLE
Implement input manager to merge hijing events

### DIFF
--- a/generators/phhepmc/PHHepMCGenEvent.cc
+++ b/generators/phhepmc/PHHepMCGenEvent.cc
@@ -34,9 +34,7 @@ PHHepMCGenEvent& PHHepMCGenEvent::operator=(const PHHepMCGenEvent& event)
 
   _embedding_id = event.get_embedding_id();
   _isSimulated = event.is_simulated();
-
-  const HepMC::GenEvent* hepmc = event.getEvent();
-  _theEvt = new HepMC::GenEvent(*(hepmc));
+  _theEvt = new HepMC::GenEvent(*event.getEvent());
 
   return *this;
 }

--- a/offline/framework/ffaobjects/EventHeader.h
+++ b/offline/framework/ffaobjects/EventHeader.h
@@ -14,13 +14,14 @@ class EventHeader: public PHObject
  public:
 
   /// dtor
-  virtual ~EventHeader() {}
+  virtual ~EventHeader() = default;
 
   /// Clear Event
   virtual void Reset();
 
-  /** identify Function from PHObject
-      @param os Output Stream 
+  /*
+   * identify Function from PHObject
+   * @param os Output Stream 
    */
   virtual void identify(std::ostream& os = std::cout) const;
 
@@ -44,10 +45,17 @@ class EventHeader: public PHObject
 
   /// get ATP TimeStamp (unix time, convert with ctime()
   virtual time_t get_TimeStamp() const {return 0;}
+  
   /// set TimeStamp
   virtual void set_TimeStamp(const time_t /*evttime*/) {return;}
 
- private: // prevent doc++ from showing ClassDef
+  //! bunch crossing
+  void set_BunchCrossing( int64_t ) {}
+  
+  //! bunch crossing
+  int64_t get_BunchCrossing() const {return 0;}
+
+  private: // prevent doc++ from showing ClassDef
   ClassDef(EventHeader,1)
 
 };

--- a/offline/framework/ffaobjects/EventHeader.h
+++ b/offline/framework/ffaobjects/EventHeader.h
@@ -50,10 +50,10 @@ class EventHeader: public PHObject
   virtual void set_TimeStamp(const time_t /*evttime*/) {return;}
 
   //! bunch crossing
-  void set_BunchCrossing( int64_t ) {}
+  virtual void set_BunchCrossing( int64_t ) {}
   
   //! bunch crossing
-  int64_t get_BunchCrossing() const {return 0;}
+  virtual int64_t get_BunchCrossing() const {return 0;}
 
   private: // prevent doc++ from showing ClassDef
   ClassDef(EventHeader,1)

--- a/offline/framework/ffaobjects/EventHeaderv2.cc
+++ b/offline/framework/ffaobjects/EventHeaderv2.cc
@@ -2,11 +2,11 @@
 
 #include <iostream>
 
-EventHeaderv2::EventHeaderv2()
-{ Reset(); }
-
 void EventHeaderv2::Reset()
-{ m_bunchCrossing = 0; }
+{ 
+  EventHeaderv1::Reset();
+  m_bunchCrossing = 0; 
+}
 
 void EventHeaderv2::identify(std::ostream& out) const
 {

--- a/offline/framework/ffaobjects/EventHeaderv2.cc
+++ b/offline/framework/ffaobjects/EventHeaderv2.cc
@@ -1,0 +1,23 @@
+#include "EventHeaderv2.h"
+
+#include <iostream>
+
+EventHeaderv2::EventHeaderv2()
+{ Reset(); }
+
+void EventHeaderv2::Reset()
+{ m_bunchCrossing = 0; }
+
+void EventHeaderv2::identify(std::ostream& out) const
+{
+  out << "identify yourself: I am an EventHeaderv2 Object" << std::endl;
+  const auto timestamp( get_TimeStamp() );
+  out 
+    << "Run Number: " << get_RunNumber() 
+    << ", Event no: " << get_EvtSequence() 
+    << ", Type: " << get_EvtType() 
+    << ", DAQ arrival time: " << ctime(&timestamp)
+    << ", bunch crossing: " << m_bunchCrossing
+    << std::endl;
+}
+

--- a/offline/framework/ffaobjects/EventHeaderv2.h
+++ b/offline/framework/ffaobjects/EventHeaderv2.h
@@ -21,7 +21,7 @@ class EventHeaderv2: public EventHeaderv1
  public:
 
   //! ctor
-  EventHeaderv2();
+  EventHeaderv2() = default;
 
   //! dtor
   virtual ~EventHeaderv2() = default;

--- a/offline/framework/ffaobjects/EventHeaderv2.h
+++ b/offline/framework/ffaobjects/EventHeaderv2.h
@@ -1,0 +1,58 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef FFAOBJECTS_EVENTHEADERV2_H
+#define FFAOBJECTS_EVENTHEADERV2_H
+
+/*!
+ * \file EventHeaderv2.h
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include "EventHeaderv1.h"
+
+#include <ctime>         // for time_t
+#include <iostream>       // for cout, ostream
+
+class PHObject;
+
+//! simple event header with ID and time
+class EventHeaderv2: public EventHeaderv1
+{
+ public:
+
+  //! ctor
+  EventHeaderv2();
+
+  //! dtor
+  virtual ~EventHeaderv2() = default;
+
+  //! clone
+  PHObject *CloneMe() const 
+  { return new EventHeaderv2(*this); }
+
+  ///  Clear Event
+  void Reset();
+
+  /*!
+   * identify Function from PHObject
+   * @param os Output Stream 
+   */
+  virtual void identify(std::ostream& os = std::cout) const;
+
+  //! bunch crossing
+  void set_BunchCrossing( int64_t value ) 
+  { m_bunchCrossing = value; }
+  
+  //! bunch crossing
+  int64_t get_BunchCrossing() const
+  { return m_bunchCrossing; }
+  
+  private: 
+
+  //! bunch crossing id
+  int64_t m_bunchCrossing = 0;
+
+  ClassDef(EventHeaderv2,1)
+};
+
+#endif

--- a/offline/framework/ffaobjects/EventHeaderv2LinkDef.h
+++ b/offline/framework/ffaobjects/EventHeaderv2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class EventHeaderv2+;
+
+#endif

--- a/offline/framework/ffaobjects/Makefile.am
+++ b/offline/framework/ffaobjects/Makefile.am
@@ -21,7 +21,8 @@ ROOTDICTS = \
   SyncObject_Dict.cc \
   SyncObjectv1_Dict.cc \
   EventHeader_Dict.cc \
-  EventHeaderv1_Dict.cc
+  EventHeaderv1_Dict.cc \
+  EventHeaderv2_Dict.cc
 
 # for root6 we need pcm and dictionaries but only for
 # i/o classes. For root5 we need only dictionaries but
@@ -38,7 +39,8 @@ nobase_dist_pcm_DATA = \
   SyncObject_Dict_rdict.pcm \
   SyncObjectv1_Dict_rdict.pcm \
   EventHeader_Dict_rdict.pcm \
-  EventHeaderv1_Dict_rdict.pcm
+  EventHeaderv1_Dict_rdict.pcm \
+  EventHeaderv2_Dict_rdict.pcm
 endif
 
 pkginclude_HEADERS = \
@@ -49,7 +51,8 @@ pkginclude_HEADERS = \
   SyncObject.h \
   SyncObjectv1.h \
   EventHeader.h \
-  EventHeaderv1.h
+  EventHeaderv1.h \
+  EventHeaderv2.h
 
 libffaobjects_la_SOURCES = \
   $(ROOTDICTS) \
@@ -58,7 +61,8 @@ libffaobjects_la_SOURCES = \
   SyncObject.cc \
   SyncObjectv1.cc \
   EventHeader.cc \
-  EventHeaderv1.cc
+  EventHeaderv1.cc \
+  EventHeaderv2.cc
 
 BUILT_SOURCES = testexternals.cc
 

--- a/offline/framework/ffaobjects/SyncObject.h
+++ b/offline/framework/ffaobjects/SyncObject.h
@@ -57,6 +57,7 @@ class SyncObject: public PHObject
  private: // prevent doc++ from showing ClassDef
   friend class SyncObjectv1;
   friend class Fun4AllDstInputManager;
+  friend class Fun4AllDstPileupInputManager;
   friend class DumpSyncObject;
   friend class SegmentSelect;
 

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -272,13 +272,8 @@ readagain:
   // load relevant DST nodes to internal pointers
   std::cout << "Fun4AllDstPileupInputManager::run - loaded event " << m_events_thisfile - 1 << std::endl;
 
-  /*
-   * keep track of whether nodes have been loaded
-   * only load nodes if there is at least one background event to merge
-   */
-  bool nodes_loaded = false;
-
   // store bunch crossing both inside the event header and as the last bunch crossing
+  load_nodes(m_dstNode);
   if( m_eventheader ) m_eventheader->set_BunchCrossing( bunchCrossing );
   m_last_bunchCrossing = bunchCrossing;
 
@@ -295,13 +290,6 @@ readagain:
 
     // try read
     if( ievent_thisfile < 0 || !m_IManager_background->read(m_dstNodeInternal.get(), ievent_thisfile) ) break;
-
-    // load nodes
-    if( !nodes_loaded )
-    {
-      load_nodes(m_dstNode);
-      nodes_loaded = true;
-    }
 
     // merge
     copy_background_event( m_dstNodeInternal.get(), delta_t );
@@ -324,13 +312,6 @@ readagain:
 
     // try read
     if( !m_IManager_background->read(m_dstNodeInternal.get(), ievent_thisfile) ) break;
-
-    // load nodes
-    if( !nodes_loaded )
-    {
-      load_nodes(m_dstNode);
-      nodes_loaded = true;
-    }
 
     // merge
     copy_background_event( m_dstNodeInternal.get(), delta_t );

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -850,7 +850,10 @@ void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNo
       const auto range = container->GetSecondaryVtxRange();
 
       // loop from last to first to preserve order with respect to the original event
-      for( auto iter = std::reverse_iterator(range.second); iter != std::reverse_iterator(range.first); ++iter )
+      for(
+        auto iter = std::reverse_iterator<PHG4TruthInfoContainer::ConstVtxIterator>(range.second);
+        iter != std::reverse_iterator<PHG4TruthInfoContainer::ConstVtxIterator>(range.first);
+        ++iter )
       {
         // clone vertex, shift time, insert in map, and add index conversion
         const auto& sourceVertex = iter->second;

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -900,7 +900,10 @@ void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNo
        * loop from last to first to preserve order with respect to the original event
        * also this ensures that for a given particle its parent has already been converted and thus found in the map
        */
-      for( auto iter = std::reverse_iterator(range.second); iter != std::reverse_iterator(range.first); ++iter )
+      for( 
+        auto iter = std::reverse_iterator<PHG4TruthInfoContainer::ConstIterator>(range.second); 
+        iter != std::reverse_iterator<PHG4TruthInfoContainer::ConstIterator>(range.first);
+        ++iter )
       {
         const auto& source = iter->second;
         auto dest = new PHG4Particle_t( source );

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -840,7 +840,7 @@ void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNo
         auto newVertex = new PHG4VtxPoint_t(sourceVertex);
         newVertex->set_t( sourceVertex->get_t() + delta_t );
         m_g4truthinfo->AddVertex( ++key, newVertex );
-        vtxid_map.insert( std::make_pair( sourceVertex->get_id(), key ) ).first;
+        vtxid_map.insert( std::make_pair( sourceVertex->get_id(), key ) );
       }
     }
 

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -1,0 +1,999 @@
+/*!
+ * \file Fun4AllDstPileupInputManager.cc
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include "Fun4AllDstPileupInputManager.h"
+
+#include "PHG4HitContainer.h"
+#include "PHG4Hitv1.h"
+#include "PHG4Particlev3.h"
+#include "PHG4Shower.h"
+#include "PHG4TruthInfoContainer.h"
+#include "PHG4VtxPointv1.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/SubsysReco.h>
+
+#include <ffaobjects/RunHeader.h>
+#include <ffaobjects/SyncDefs.h>
+#include <ffaobjects/SyncObject.h>
+#include <ffaobjects/EventHeader.h>
+#include <ffaobjects/EventHeaderv2.h>
+
+#include <frog/FROG.h>
+
+#include <phhepmc/PHHepMCGenEventMap.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHNodeIOManager.h>
+#include <phool/PHNodeIntegrate.h>
+#include <phool/PHNodeIterator.h>   // for PHNodeIterator
+#include <phool/PHNodeOperation.h>
+#include <phool/PHObject.h>         // for PHObject
+#include <phool/getClass.h>
+#include <phool/phool.h>            // for PHWHERE, PHReadOnly, PHRunTree
+
+#include <TSystem.h>
+
+#include <HepMC/GenEvent.h>
+
+#include <cassert>
+#include <cstdlib>
+#include <iostream>                 // for operator<<, basic_ostream, endl
+#include <utility>                  // for pair
+
+class TBranch;
+
+// convenient aliases for deep copying nodes
+namespace
+{
+  using PHG4Particle_t = PHG4Particlev3;
+  using PHG4VtxPoint_t = PHG4VtxPointv1;
+  using PHG4Hit_t = PHG4Hitv1;
+
+  //! utility class to find all PHG4Hit container nodes from the DST node
+  class FindG4HitContainer: public PHNodeOperation
+  {
+
+    public:
+
+    //! container map alias
+    using ContainerMap = std::map<std::string, PHG4HitContainer*>;
+
+    //! get container map
+    const ContainerMap& containers() const
+    { return m_containers; }
+
+    protected:
+
+    //! iterator action
+    void perform( PHNode* node ) override
+    {
+
+      // check type name. Only load PHIODataNode
+      if( node->getType() != "PHIODataNode" ) return;
+
+      // cast to IODataNode and check data
+      auto ionode = static_cast<PHIODataNode<TObject>*>(node);
+      auto data = dynamic_cast<PHG4HitContainer*>( ionode->getData() );
+      if( data )
+      { m_containers.insert( std::make_pair( node->getName(), data ) ); }
+    }
+
+    private:
+
+    //! container map
+    ContainerMap m_containers;
+  };
+
+}
+
+//_____________________________________________________________________________
+Fun4AllDstPileupInputManager::Fun4AllDstPileupInputManager(const std::string &name, const std::string &nodename, const std::string &topnodename)
+  : Fun4AllInputManager(name, nodename, topnodename)
+{}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::fileopen(const std::string &filenam)
+{
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  if (IsOpen())
+  {
+    std::cout << "Closing currently open file "
+         << FileName()
+         << " and opening " << filenam << std::endl;
+    fileclose();
+  }
+  FileName(filenam);
+  FROG frog;
+  m_fullfilename = frog.location(FileName());
+  if (Verbosity() > 0)
+  {
+    std::cout << Name() << ": opening file " << m_fullfilename << std::endl;
+  }
+  // sanity check - the IManager must be nullptr when this method is executed
+  // if not something is very very wrong and we must not continue
+  if (m_IManager)
+  {
+    std::cout << PHWHERE << " IManager pointer is not nullptr but " << m_IManager.get()
+         << std::endl;
+    std::cout << "Send mail to off-l with this printout and the macro you used"
+         << std::endl;
+    std::cout << "Trying to execute IManager->print() to display more info"
+         << std::endl;
+    std::cout << "Code will probably segfault now" << std::endl;
+    m_IManager->print();
+    std::cout << "Have someone look into this problem - Exiting now" << std::endl;
+    exit(1);
+  }
+  // first read the runnode if not disabled
+  if (m_ReadRunTTree)
+  {
+    m_IManager.reset( new PHNodeIOManager(m_fullfilename, PHReadOnly, PHRunTree) );
+    if (m_IManager->isFunctional())
+    {
+      m_runNode = se->getNode(m_RunNode, TopNodeName());
+      m_IManager->read(m_runNode);
+
+      // get the current run number
+      RunHeader *runheader = findNode::getClass<RunHeader>(m_runNode, "RunHeader");
+      if (runheader)
+      {
+        SetRunNumber(runheader->get_RunNumber());
+      }
+      // delete our internal copy of the runnode when opening subsequent files
+      if (m_runNodeCopy)
+      {
+        std::cout << PHWHERE
+             << " The impossible happened, we have a valid copy of the run node "
+             << m_runNodeCopy->getName() << " which should be a nullptr"
+             << std::endl;
+        gSystem->Exit(1);
+      }
+      m_runNodeCopy.reset(new PHCompositeNode("RUNNODECOPY"));
+      if (!m_runNodeSum)
+      {
+        m_runNodeSum.reset(new PHCompositeNode("RUNNODESUM"));
+      }
+
+      {
+        std::unique_ptr<PHNodeIOManager> tmpIman(new PHNodeIOManager(m_fullfilename, PHReadOnly, PHRunTree));
+        tmpIman->read(m_runNodeCopy.get());
+      }
+
+      PHNodeIntegrate integrate;
+      integrate.RunNode(m_runNode);
+      integrate.RunSumNode(m_runNodeSum.get());
+      // run recursively over internal run node copy and integrate objects
+      PHNodeIterator mainIter(m_runNodeCopy.get());
+      mainIter.forEach(integrate);
+      // we do not need to keep the internal copy, keeping it would crate
+      // problems in case a subsequent file does not contain all the
+      // runwise objects from the previous file. Keeping this copy would then
+      // integrate the missing object again with the old copy
+      m_runNodeCopy.reset();
+    }
+    // DLW: move the delete outside the if block to cover the case where isFunctional() fails
+    m_IManager.reset();
+  }
+
+  // create internal dst node
+  if( !m_dstNodeInternal )
+  {
+    m_dstNodeInternal.reset( new PHCompositeNode("DST_INTERNAL") );
+  }
+
+  // update dst node from fun4all server
+  m_dstNode = se->getNode(InputNode(), TopNodeName());
+
+  // open file in both active and background input manager
+  m_IManager.reset(new PHNodeIOManager(m_fullfilename, PHReadOnly));
+  m_IManager_background.reset(new PHNodeIOManager(m_fullfilename, PHReadOnly));
+  if (m_IManager->isFunctional())
+  {
+    IsOpen(1);
+    m_events_thisfile = 0;
+    setBranches();                // set branch selections
+    AddToFileOpened(FileName());  // add file to the list of files which were opened
+    return 0;
+  } else {
+    std::cout << PHWHERE << ": " << Name() << " Could not open file " << FileName() << std::endl;
+    m_IManager.reset();
+    m_IManager_background.reset();
+    return -1;
+  }
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::run(const int nevents)
+{
+  if (!IsOpen())
+  {
+    if (FileListEmpty())
+    {
+      if (Verbosity() > 0) std::cout << Name() << ": No Input file open" << std::endl;
+      return -1;
+    } else {
+      if (OpenNextFile())
+      {
+        std::cout << Name() << ": No Input file from filelist opened" << std::endl;
+        return -1;
+      }
+    }
+  }
+
+  if (Verbosity() > 3)
+  { std::cout << "Getting Event from " << Name() << std::endl; }
+
+readagain:
+
+  // read main event to dstNode
+  auto dummy = m_IManager->read(m_dstNode);
+  int ncount = 0;
+  while (dummy)
+  {
+    ++ncount;
+    if (nevents > 0 && ncount >= nevents) break;
+    dummy = m_IManager->read(m_dstNode);
+  }
+
+  if (!dummy)
+  {
+    fileclose();
+    if (!OpenNextFile()) goto readagain;
+    else return -1;
+  }
+
+  m_events_total += ncount;
+  m_events_thisfile += ncount;
+
+  // get bunchCrossing  associated to this event
+  const size_t ievent = m_events_total + m_event_offset - 1;
+  if( ievent >= m_bunchCrossings.size() ) return Fun4AllReturnCodes::ABORTRUN;
+
+  const auto bunchCrossing = m_bunchCrossings[ievent];
+  if( m_events_accepted > 0 && bunchCrossing == m_last_bunchCrossing )
+  {
+    // reject if event belongs to the same bunch crossing as the last accepted event
+    std::cout << "Fun4AllDstPileupInputManager::run - skipped event " << m_events_thisfile - 1 << std::endl;
+    goto readagain;
+  }
+
+  // check if the local SubsysReco discards this event
+  if (RejectEvent() != Fun4AllReturnCodes::EVENT_OK)
+  {
+    std::cout << "Fun4AllDstPileupInputManager::run - skipped event " << m_events_thisfile - 1 << std::endl;
+    goto readagain;
+  }
+
+  // load relevant DST nodes to internal pointers
+  std::cout << "Fun4AllDstPileupInputManager::run - loaded event " << m_events_thisfile - 1 << std::endl;
+
+  /*
+   * keep track of whether nodes have been loaded
+   * only load nodes if there is at least one background event to merge
+   */
+  bool nodes_loaded = false;
+
+  // store bunch crossing both inside the event header and as the last bunch crossing
+  if( m_eventheader ) m_eventheader->set_BunchCrossing( bunchCrossing );
+  m_last_bunchCrossing = bunchCrossing;
+
+  // fetch past events falling into the TPC integration time
+  int neventspast = 0;
+  for( int ieventpast = ievent-1; ieventpast>=0; ieventpast-- )
+  {
+    // check time
+    const double delta_t = m_time_between_crossings*(m_bunchCrossings[ieventpast] - bunchCrossing);
+    if( delta_t < m_tmin ) break;
+
+    // get relevant event in file index
+    const int ievent_thisfile = m_events_thisfile+ieventpast-ievent-1;
+
+    // try read
+    if( ievent_thisfile < 0 || !m_IManager_background->read(m_dstNodeInternal.get(), ievent_thisfile) ) break;
+
+    // load nodes
+    if( !nodes_loaded )
+    {
+      load_nodes(m_dstNode);
+      nodes_loaded = true;
+    }
+
+    // merge
+    copy_background_event( m_dstNodeInternal.get(), delta_t );
+
+    // increment number of read events
+    std::cout << "Fun4AllDstPileupInputManager::run - merged past event " << ievent_thisfile << std::endl;
+    ++neventspast;
+  }
+
+  // fetch future events falling into the TPC integration time
+  int neventsfuture = 0;
+  for( size_t ieventfuture = ievent+1; ieventfuture < m_bunchCrossings.size(); ++ieventfuture )
+  {
+    // check time
+    const double delta_t = m_time_between_crossings*(m_bunchCrossings[ieventfuture] - bunchCrossing);
+    if( delta_t > m_tmax ) break;
+
+    // get relevant event in file index
+    const int ievent_thisfile = m_events_thisfile+ieventfuture-ievent-1;
+
+    // try read
+    if( !m_IManager_background->read(m_dstNodeInternal.get(), ievent_thisfile) ) break;
+
+    // load nodes
+    if( !nodes_loaded )
+    {
+      load_nodes(m_dstNode);
+      nodes_loaded = true;
+    }
+
+    // merge
+    copy_background_event( m_dstNodeInternal.get(), delta_t );
+
+    // increment number of read events
+    std::cout << "Fun4AllDstPileupInputManager::run - merged future event " << ievent_thisfile << std::endl;
+    ++neventsfuture;
+  }
+
+  // update event counter
+  ++m_events_accepted;
+
+  // update syncobject
+  m_syncobject = findNode::getClass<SyncObject>(m_dstNode, "Sync");
+  return 0;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::fileclose()
+{
+  if (!IsOpen())
+  {
+    std::cout << Name() << ": fileclose: No Input file open" << std::endl;
+    return -1;
+  }
+  m_IManager.reset();
+  m_IManager_background.reset();
+  IsOpen(0);
+  UpdateFileList();
+  return 0;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::GetSyncObject(SyncObject **mastersync)
+{
+  // here we copy the sync object from the current file to the
+  // location pointed to by mastersync. If mastersync is a 0 pointer
+  // the syncobject is cloned. If mastersync allready exists the content
+  // of syncobject is copied
+  if (!(*mastersync))
+  {
+    if (m_syncobject)
+    {
+      *mastersync = dynamic_cast<SyncObject *> (m_syncobject->CloneMe());
+      assert(*mastersync);
+    }
+  }
+  else
+  {
+    *(*mastersync) = *m_syncobject;  // copy syncobject content
+  }
+  return Fun4AllReturnCodes::SYNC_OK;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::SyncIt(const SyncObject *mastersync)
+{
+  if (!mastersync)
+  {
+    std::cout << PHWHERE << Name() << " No MasterSync object, cannot perform synchronization" << std::endl;
+    std::cout << "Most likely your first file does not contain a SyncObject and the file" << std::endl;
+    std::cout << "opened by the Fun4AllDstPileupInputManager with Name " << Name() << " has one" << std::endl;
+    std::cout << "Change your macro and use the file opened by this input manager as first input" << std::endl;
+    std::cout << "and you will be okay. Fun4All will not process the current configuration" << std::endl
+         << std::endl;
+    return Fun4AllReturnCodes::SYNC_FAIL;
+  }
+  int iret = m_syncobject->Different(mastersync);
+  if (iret)  // what to do if files are not in sync
+  {
+    if (mastersync->EventNumber() == -999999)  // first file does not contain sync object
+    {
+      std::cout << PHWHERE << " Mastersync not filled, your first file does not contain a SyncObject" << std::endl;
+      std::cout << "This Event will not be processed further" << std::endl;
+    }
+    else  // okay try to resync here
+    {
+      if (Verbosity() > 3)
+      {
+        std::cout
+          << "Need to Resync, mastersync evt no: " << mastersync->EventNumber()
+          << ", this Event no: " << m_syncobject->EventNumber()
+          << std::endl;
+        std::cout
+          << "mastersync evt counter: " << mastersync->EventCounter()
+          << ", this Event counter: " << m_syncobject->EventCounter()
+          << std::endl;
+        std::cout
+          << "mastersync run number: " << mastersync->RunNumber()
+          << ", this run number: " << m_syncobject->RunNumber()
+          << std::endl;
+      }
+      while (m_syncobject->RunNumber() < mastersync->RunNumber())
+      {
+        m_events_skipped_during_sync++;
+        if (Verbosity() > 2)
+        {
+          std::cout
+            << Name() << " Run Number: " << m_syncobject->RunNumber()
+            << ", master: " << mastersync->RunNumber()
+            << std::endl;
+        }
+        int iret = ReadNextEventSyncObject();
+        if (iret) return iret;
+      }
+      bool igood( m_syncobject->RunNumber() == mastersync->RunNumber() );
+
+      // only run up the Segment Number if run numbers are identical
+      while (igood && m_syncobject->SegmentNumber() < mastersync->SegmentNumber())
+      {
+        m_events_skipped_during_sync++;
+        if (Verbosity() > 2)
+        {
+          std::cout << Name() << " Segment Number: " << m_syncobject->SegmentNumber()
+               << ", master: " << mastersync->SegmentNumber()
+               << std::endl;
+        }
+        int iret = ReadNextEventSyncObject();
+        if (iret)
+        {
+          return iret;
+        }
+      }
+      // only run up the Event Counter if run number and segment number are identical
+      igood = (m_syncobject->SegmentNumber() == mastersync->SegmentNumber() && m_syncobject->RunNumber() == mastersync->RunNumber());
+      while(igood && m_syncobject->EventCounter() < mastersync->EventCounter())
+      {
+        m_events_skipped_during_sync++;
+        if (Verbosity() > 2)
+        {
+          std::cout << Name()
+               << ", EventCounter: " << m_syncobject->EventCounter()
+               << ", master: " << mastersync->EventCounter()
+               << std::endl;
+        }
+        int iret = ReadNextEventSyncObject();
+        if (iret)
+        {
+          return iret;
+        }
+      }
+      // Since up to here we only read the sync object we need to push
+      // the current event back inot the root file (subtract one from the
+      // local root file event counter) so we can read the full event
+      // if it syncs, if it does not sync we also read one event too many
+      // (otherwise we cannot determine that we are "too far")
+      // and also have to push this one back
+      PushBackEvents(1);
+      if (m_syncobject->RunNumber() > mastersync->RunNumber() ||        // check if run number too large
+          m_syncobject->EventCounter() > mastersync->EventCounter() ||  // check if event counter too large
+          m_syncobject->SegmentNumber() > mastersync->SegmentNumber())  // check segment number too large
+      {
+        // the event from first file which determines the mastersync
+        // and which we are trying to find on this file does not exist on this file
+        // so: return failure. This will cause the input managers to read
+        // the next event from the input files file
+        return Fun4AllReturnCodes::SYNC_FAIL;
+      }
+      // Here the event counter and segment number and run number do agree - we found the right match
+      // now read the full event (previously we only read the sync object)
+      PHCompositeNode *dummy;
+      dummy = m_IManager->read(m_dstNode);
+      if (!dummy)
+      {
+        std::cout << PHWHERE << " " << Name() << " Could not read full Event" << std::endl;
+        std::cout << "PLEASE NOTIFY PHENIX-OFF-L and post the macro you used" << std::endl;
+        fileclose();
+        return Fun4AllReturnCodes::SYNC_FAIL;
+      }
+      int iret = m_syncobject->Different(mastersync);  // final check if they really agree
+      if (iret)                                      // if not things are severely wrong
+      {
+        std::cout << PHWHERE << " MasterSync and SyncObject of " << Name() << " are different" << std::endl;
+        std::cout << "This Event will not be processed further, here is some debugging info:" << std::endl;
+        std::cout << "PLEASE NOTIFY PHENIX-OFF-L and post the macro you used" << std::endl;
+        std::cout << "MasterSync->identify:" << std::endl;
+        mastersync->identify();
+        std::cout << Name() << ": SyncObject->identify:" << std::endl;
+        m_syncobject->identify();
+        return Fun4AllReturnCodes::SYNC_FAIL;
+      }
+      else if (Verbosity() > 3)
+      {
+        std::cout << PHWHERE << " Resynchronization successfull for " << Name() << std::endl;
+        std::cout << "MasterSync->identify:" << std::endl;
+        mastersync->identify();
+        std::cout << Name() << ": SyncObject->identify:" << std::endl;
+        m_syncobject->identify();
+      }
+    }
+  }
+  return Fun4AllReturnCodes::SYNC_OK;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::ReadNextEventSyncObject()
+{
+readnextsync:
+  static int readfull = 0;
+  if (!m_IManager)
+  {
+    // in case the old file was exhausted and there is no new file opened
+    return Fun4AllReturnCodes::SYNC_FAIL;
+  }
+  if (m_syncbranchname.empty())
+  {
+    readfull = 1;  // we need to read a full events to set the root branches to phool nodes right for a new file
+    for (auto bIter = m_IManager->GetBranchMap()->begin(); bIter != m_IManager->GetBranchMap()->end(); ++bIter)
+    {
+      if (Verbosity() > 2)
+      { std::cout << Name() << ": branch: " << bIter->first << std::endl; }
+
+      const auto pos = bIter->first.find("/Sync");
+      if (pos != std::string::npos)
+      {
+        m_syncbranchname = bIter->first;
+        break;
+      }
+    }
+    if (m_syncbranchname.empty())
+    {
+      std::cout << PHWHERE << "Could not locate Sync Branch" << std::endl;
+      std::cout << "Please check for it in the following list of branch names and" << std::endl;
+      std::cout << "PLEASE NOTIFY PHENIX-OFF-L and post the macro you used" << std::endl;
+      for (auto bIter = m_IManager->GetBranchMap()->begin(); bIter != m_IManager->GetBranchMap()->end(); ++bIter)
+      { std::cout << bIter->first << std::endl; }
+      return Fun4AllReturnCodes::SYNC_FAIL;
+    }
+  }
+  size_t EventOnDst = 0;
+  int itest = 0;
+  if (!readfull)
+  {
+    // if all files are exhausted, the IManager is deleted and set to nullptr
+    // so check if IManager is valid before getting a new event
+    if (m_IManager)
+    {
+      EventOnDst = m_IManager->getEventNumber();  // this returns the next number of the event
+      itest = m_IManager->readSpecific(EventOnDst, m_syncbranchname.c_str());
+    }
+    else
+    {
+      if (Verbosity() > 2)
+      {
+        std::cout << Name() << ": File exhausted while resyncing" << std::endl;
+      }
+      return Fun4AllReturnCodes::SYNC_FAIL;
+    }
+  }
+  else
+  {
+    if (m_IManager->read(m_dstNode))
+    {
+      itest = 1;
+    }
+    else
+    {
+      itest = 0;
+    }
+  }
+  if (!itest)
+  {
+    if (Verbosity() > 2)
+    {
+      std::cout << Name() << ": File exhausted while resyncing" << std::endl;
+    }
+    fileclose();
+    if (OpenNextFile())
+    {
+      return Fun4AllReturnCodes::SYNC_FAIL;
+    }
+    m_syncbranchname.clear();  // clear the sync branch name, who knows - it might be different on new file
+    goto readnextsync;
+  }
+  if (!readfull)
+  {
+    EventOnDst++;
+    m_IManager->setEventNumber(EventOnDst);  // update event number in phool io manager
+  }
+  else
+  {
+    readfull = 0;
+  }
+  return 0;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::BranchSelect(const std::string &branch, const int iflag)
+{
+  int myflag = iflag;
+  // if iflag > 0 the branch is set to read
+  // if iflag = 0, the branch is set to NOT read
+  // if iflag < 0 the branchname is erased from our internal branch read map
+  // this does not have any effect on phool yet
+  if (myflag < 0)
+  {
+    std::map<const std::string, int>::iterator branchiter;
+    branchiter = m_branchread.find(branch);
+    if (branchiter != m_branchread.end())
+    {
+      m_branchread.erase(branchiter);
+    }
+    return 0;
+  }
+
+  if (myflag > 0)
+  {
+    if (Verbosity() > 1)
+    {
+      std::cout << "Setting Root Tree Branch: " << branch << " to read" << std::endl;
+    }
+    myflag = 1;
+  }
+  else
+  {
+    if (Verbosity() > 1)
+    {
+      std::cout << "Setting Root Tree Branch: " << branch << " to NOT read" << std::endl;
+    }
+  }
+  m_branchread[branch] = myflag;
+  return 0;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::setBranches()
+{
+  if (m_IManager)
+  {
+    if (!m_branchread.empty())
+    {
+      std::map<const std::string, int>::const_iterator branchiter;
+      for (branchiter = m_branchread.begin(); branchiter != m_branchread.end(); ++branchiter)
+      {
+        m_IManager->selectObjectToRead(branchiter->first.c_str(), branchiter->second);
+        if (Verbosity() > 0)
+        {
+          std::cout << branchiter->first << " set to " << branchiter->second << std::endl;
+        }
+      }
+      // protection against switching off the sync variables
+      // only implemented in the Sync Manager
+      setSyncBranches(m_IManager.get());
+    }
+  }
+  else
+  {
+    std::cout << PHWHERE << " " << Name() << ": You can only call this function after a file has been opened" << std::endl;
+    std::cout << "Do not worry, the branches will be set as soon as you open a file" << std::endl;
+    return -1;
+  }
+  return 0;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::setSyncBranches(PHNodeIOManager *IManager)
+{
+  // protection against switching off the sync variables
+  for (int i = 0; i < syncdefs::NUM_SYNC_VARS; i++)
+  {
+    IManager->selectObjectToRead(syncdefs::SYNCVARS[i], 1);
+  }
+  return 0;
+}
+
+//_____________________________________________________________________________
+void Fun4AllDstPileupInputManager::Print(const std::string &what) const
+{
+  if (what == "ALL" || what == "BRANCH")
+  {
+    // loop over the map and print out the content (name and location in memory)
+    std::cout << "--------------------------------------" << std::endl
+         << std::endl;
+    std::cout << "List of selected branches in Fun4AllDstPileupInputManager " << Name() << ":" << std::endl;
+
+    std::map<const std::string, int>::const_iterator iter;
+    for (iter = m_branchread.begin(); iter != m_branchread.end(); ++iter)
+    {
+      std::cout << iter->first << " is switched ";
+      if (iter->second)
+      {
+        std::cout << "ON";
+      }
+      else
+      {
+        std::cout << "OFF";
+      }
+      std::cout << std::endl;
+    }
+  }
+  if ((what == "ALL" || what == "PHOOL") && m_IManager)
+  {
+    // loop over the map and print out the content (name and location in memory)
+    std::cout << "--------------------------------------" << std::endl
+         << std::endl;
+    std::cout << "PHNodeIOManager print in Fun4AllDstPileupInputManager " << Name() << ":" << std::endl;
+    m_IManager->print();
+  }
+  Fun4AllInputManager::Print(what);
+  return;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::PushBackEvents(const int i)
+{
+  if (m_IManager)
+  {
+    unsigned EventOnDst = m_IManager->getEventNumber();
+    EventOnDst -= static_cast<unsigned>(i);
+    m_IManager->setEventNumber(EventOnDst);
+    return 0;
+  }
+  std::cout << PHWHERE << Name() << ": could not push back events, Imanager is NULL"
+       << " probably the dst is not open yet (you need to call fileopen or run 1 event for lists)" << std::endl;
+  return -1;
+}
+
+//_____________________________________________________________________________
+void Fun4AllDstPileupInputManager::load_nodes(PHCompositeNode* dstNode )
+{
+
+  // event header
+  m_eventheader = findNode::getClass<EventHeader>(dstNode, "EventHeader");
+  if(!m_eventheader)
+  {
+    std::cout << "Fun4AllDstPileupInputManager::load_nodes - creating EventHeader" << std::endl;
+    m_eventheader = new EventHeaderv2();
+    dstNode->addNode(new PHIODataNode<PHObject>(m_eventheader, "EventHeader", "PHObject"));
+  }
+
+  // hep mc
+  m_geneventmap = findNode::getClass<PHHepMCGenEventMap>(dstNode, "PHHepMCGenEventMap");
+  if(!m_geneventmap)
+  {
+    std::cout << "Fun4AllDstPileupInputManager::load_nodes - creating PHHepMCGenEventMap" << std::endl;
+    m_geneventmap = new PHHepMCGenEventMap();
+    dstNode->addNode(new PHIODataNode<PHObject>(m_geneventmap, "PHHepMCGenEventMap", "PHObject"));
+  }
+
+  // find all G4Hit containers under dstNode
+  FindG4HitContainer nodeFinder;
+  PHNodeIterator( dstNode ).forEach( nodeFinder );
+  m_g4hitscontainers = nodeFinder.containers();
+
+  // g4 truth info
+  m_g4truthinfo = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
+  if( !m_g4truthinfo )
+  {
+    std::cout << "Fun4AllDstPileupInputManager::load_nodes - creating node G4TruthInfo" << std::endl;
+    m_g4truthinfo = new PHG4TruthInfoContainer();
+    dstNode->addNode(new PHIODataNode<PHObject>(m_g4truthinfo, "G4TruthInfo", "PHObject"));
+  }
+
+}
+
+//_____________________________________________________________________________
+void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNode, double delta_t )
+{
+  // copy PHHepMCGenEventMap
+  const auto map = findNode::getClass<PHHepMCGenEventMap>(dstNode, "PHHepMCGenEventMap");
+
+  // keep track of new embed id, after insertion as background event
+  int new_embed_id = 0;
+
+  if( map && m_geneventmap )
+  {
+    if( map->size() != 1 )
+    {
+      std::cout << "Fun4AllDstPileupInputManager::copy_background_event - cannot merge events that contain more than one PHHepMCGenEventMap" << std::endl;
+      return;
+    }
+
+    // get event and insert in new map
+    auto genevent = map->get_map().begin()->second;
+    auto newevent = m_geneventmap->insert_background_event( genevent );
+
+    /*
+     * this hack prevents a crash when writting out
+     * it boils down to root trying to write deleted items from the HepMC::GenEvent copy if the source has been deleted
+     * it does not happen if the source gets written while the copy is deleted
+     */
+    newevent->getEvent()->swap( *genevent->getEvent() );
+
+    // shift vertex time and store new embed id
+    newevent->moveVertex( 0, 0, 0, delta_t );
+    new_embed_id = genevent->get_embedding_id();
+  }
+
+  // copy truth container
+  // keep track of the correspondance between source index and destination index for vertices, tracks and showers
+  using ConversionMap = std::map<int,int>;
+  ConversionMap vtxid_map;
+  ConversionMap trkid_map;
+
+  const auto container = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
+  if( container && m_g4truthinfo )
+  {
+
+    {
+      // primary vertices
+      auto key = m_g4truthinfo->maxvtxindex();
+      const auto range = container->GetPrimaryVtxRange();
+      for( auto iter = range.first; iter != range.second; ++iter )
+      {
+        // clone vertex, insert in map, and add index conversion
+        const auto& sourceVertex = iter->second;
+        auto newVertex = new PHG4VtxPoint_t(sourceVertex);
+        newVertex->set_t( sourceVertex->get_t() + delta_t );
+        m_g4truthinfo->AddVertex( ++key, newVertex );
+        vtxid_map.insert( std::make_pair( sourceVertex->get_id(), key ) ).first;
+      }
+    }
+
+    {
+      // secondary vertices
+      auto key = m_g4truthinfo->minvtxindex();
+      const auto range = container->GetSecondaryVtxRange();
+
+      // loop from last to first to preserve order with respect to the original event
+      for( auto iter = std::reverse_iterator(range.second); iter != std::reverse_iterator(range.first); ++iter )
+      {
+        // clone vertex, shift time, insert in map, and add index conversion
+        const auto& sourceVertex = iter->second;
+        auto newVertex = new PHG4VtxPoint_t(sourceVertex);
+        newVertex->set_t( sourceVertex->get_t() + delta_t );
+        m_g4truthinfo->AddVertex( --key, newVertex );
+        vtxid_map.insert( std::make_pair( sourceVertex->get_id(), key ) );
+      }
+    }
+
+    {
+      // primary particles
+      auto key = m_g4truthinfo->maxtrkindex();
+      const auto range = container->GetPrimaryParticleRange();
+      for( auto iter = range.first; iter != range.second; ++iter )
+      {
+        const auto& source = iter->second;
+        auto dest = new PHG4Particle_t( source );
+        m_g4truthinfo->AddParticle( ++key, dest );
+        dest->set_track_id( key );
+
+        // set parent to zero
+        dest->set_parent_id(0);
+
+        // set primary to itself
+        dest->set_primary_id( dest->get_track_id());
+
+        // update vertex
+        const auto keyiter = vtxid_map.find( source->get_vtx_id() );
+        if( keyiter != vtxid_map.end() ) dest->set_vtx_id( keyiter->second );
+        else std::cout << "Fun4AllDstPileupInputManager::copy_background_event - vertex id " << source->get_vtx_id() << " not found in map" << std::endl;
+
+        // insert in map
+        trkid_map.insert( std::make_pair( source->get_track_id(), dest->get_track_id() ) );
+      }
+    }
+
+    {
+      // secondary particles
+      auto key = m_g4truthinfo->mintrkindex();
+      const auto range = container->GetSecondaryParticleRange();
+
+      /*
+       * loop from last to first to preserve order with respect to the original event
+       * also this ensures that for a given particle its parent has already been converted and thus found in the map
+       */
+      for( auto iter = std::reverse_iterator(range.second); iter != std::reverse_iterator(range.first); ++iter )
+      {
+        const auto& source = iter->second;
+        auto dest = new PHG4Particle_t( source );
+        m_g4truthinfo->AddParticle( --key, dest );
+        dest->set_track_id( key );
+
+        // update parent id
+        auto keyiter = trkid_map.find( source->get_parent_id() );
+        if( keyiter != trkid_map.end() ) dest->set_parent_id( keyiter->second );
+        else std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " << source->get_parent_id() << " not found in map" << std::endl;
+
+        // update primary id
+        keyiter = trkid_map.find( source->get_primary_id() );
+        if( keyiter != trkid_map.end() ) dest->set_primary_id( keyiter->second );
+        else std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " << source->get_primary_id() << " not found in map" << std::endl;
+
+        // update vertex
+        keyiter = vtxid_map.find( source->get_vtx_id() );
+        if( keyiter != vtxid_map.end() ) dest->set_vtx_id( keyiter->second );
+        else std::cout << "Fun4AllDstPileupInputManager::copy_background_event - vertex id " << source->get_vtx_id() << " not found in map" << std::endl;
+
+        // insert in map
+        trkid_map.insert( std::make_pair( source->get_track_id(), dest->get_track_id() ) );
+      }
+    }
+
+    // vertex embed flags
+    for( const auto& pair:vtxid_map )
+    { m_g4truthinfo->AddEmbededVtxId(pair.second,new_embed_id); }
+
+    // track embed flags
+    for( const auto& pair:trkid_map )
+    { m_g4truthinfo->AddEmbededTrkId(pair.second,new_embed_id); }
+
+  }
+
+  // copy g4hits
+  // loop over registered maps
+  for( const auto& pair:m_g4hitscontainers )
+  {
+    // check destination node
+    if( !pair.second )
+    {
+      std::cout << "Fun4AllDstPileupInputManager::copy_background_event - invalid destination container " << pair.first << std::endl;
+      continue;
+    }
+
+    // find source node
+    auto container = findNode::getClass<PHG4HitContainer>( dstNode, pair.first );
+    if( !container )
+    {
+      std::cout << "Fun4AllDstPileupInputManager::copy_background_event - invalid source container " << pair.first << std::endl;
+      continue;
+    }
+
+    {
+      // hits
+      const auto range = container->getHits();
+      for( auto iter = range.first; iter != range.second; ++iter )
+      {
+        // clone hit
+        const auto& sourceHit = iter->second;
+        auto newHit = new PHG4Hit_t( sourceHit );
+
+        // shift time
+        newHit->set_t(0, sourceHit->get_t(0)+delta_t);
+        newHit->set_t(1, sourceHit->get_t(1)+delta_t);
+
+        // update track id
+        const auto keyiter = trkid_map.find( sourceHit->get_trkid() );
+        if( keyiter != trkid_map.end() ) newHit->set_trkid( keyiter->second );
+        else std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " <<  sourceHit->get_trkid() << " not found in map" << std::endl;
+
+        /*
+         * reset shower ids
+         * it was decided that showers from the background events will not be copied to the merged event
+         * as such we just reset the hits shower id
+         */
+        newHit->set_shower_id(INT_MIN);
+
+        /*
+         * this will generate a new key for the hit and assign it to the hit
+         * this ensures that there is no conflict with the hits from the 'main' event
+         */
+        pair.second->AddHit( newHit->get_detid(), newHit );
+      }
+    }
+
+    {
+      // layers
+      const auto range = container->getLayers();
+      for(auto iter = range.first; iter != range.second; ++iter)
+      { pair.second->AddLayer(*iter); }
+    }
+
+  }
+
+
+}

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -1,0 +1,141 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef FUN4ALL_FUN4ALLDSTPILEUPINPUTMANAGER_H
+#define FUN4ALL_FUN4ALLDSTPILEUPINPUTMANAGER_H
+
+/*!
+ * \file Fun4AllDstPileupInputManager.h
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include <fun4all/Fun4AllInputManager.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+class EventHeader;
+class PHCompositeNode;
+class PHG4HitContainer;
+class PHG4TruthInfoContainer;
+class PHHepMCGenEventMap;
+class PHNodeIOManager;
+class SyncObject;
+
+class Fun4AllDstPileupInputManager : public Fun4AllInputManager
+{
+ public:
+  Fun4AllDstPileupInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
+  int fileopen(const std::string &filenam);
+  int fileclose();
+  int run(const int nevents = 0);
+  int GetSyncObject(SyncObject **mastersync);
+  int SyncIt(const SyncObject *mastersync);
+  int BranchSelect(const std::string &branch, const int iflag);
+  int setBranches();
+  virtual int setSyncBranches(PHNodeIOManager *IManager);
+  void Print(const std::string &what = "ALL") const;
+  int PushBackEvents(const int i);
+
+  //! store event bunch crossing ids
+  /*! bunch crossings are used to decide which pile-up events should be merged to a given "trigger" event */
+  void setBunchCrossingList( const std::vector<int64_t>& value ) { m_bunchCrossings = value; }
+
+  //! store event offset
+  /*! offste is added to the current event number to look for the corresponding event timestamp */
+  void setEventOffset( int value ) { m_event_offset = value; }
+
+  //! set time window for pileup events (ns)
+  void setPileupTimeWindow( double tmin, double tmax )
+  { m_tmin = tmin; m_tmax = tmax; }
+
+ protected:
+  int ReadNextEventSyncObject();
+  void ReadRunTTree(const int i) { m_ReadRunTTree = i; }
+
+ private:
+
+  //! load nodes
+  void load_nodes(PHCompositeNode*);
+
+  //! copy background event
+  void copy_background_event(PHCompositeNode*, double delta_t);
+
+  int m_InitRun = 0;
+
+  //!@name event counters
+  //@{
+  int m_ReadRunTTree = 1;
+  int m_events_total = 0;
+  int m_events_thisfile = 0;
+  int m_events_skipped_during_sync = 0;
+  int m_events_accepted = 0;
+  //@}
+
+  std::string m_fullfilename;
+  std::string m_RunNode = "RUN";
+  std::map<const std::string, int> m_branchread;
+  std::string m_syncbranchname;
+
+  //! dst node from TopNode
+  PHCompositeNode* m_dstNode = nullptr;
+
+  //! run node from TopNode
+  PHCompositeNode* m_runNode = nullptr;
+
+  //! internal dst node to copy background events
+  std::unique_ptr<PHCompositeNode> m_dstNodeInternal;
+
+  //!@name internal runnodes to perform the summation over multiple runs
+  //@{
+  std::unique_ptr<PHCompositeNode> m_runNodeCopy;
+  std::unique_ptr<PHCompositeNode> m_runNodeSum;
+  //@}
+
+  //! input manager for active (trigger) events
+  /*! corresponding nodes are copied directly to the topNode */
+  std::unique_ptr<PHNodeIOManager> m_IManager;
+
+  //! input manager for background (pileup) events
+  /*! corresponding nodes are copied to the internal dst node, then merged to the top node */
+  std::unique_ptr<PHNodeIOManager> m_IManager_background;
+
+  //! synchronization object
+  SyncObject *m_syncobject = nullptr;
+
+  //! collisions bunch crossing ids
+  std::vector<int64_t> m_bunchCrossings;
+
+  //! time between crossings. This is a RHIC constant (ns)
+  static constexpr double m_time_between_crossings = 106;
+
+  //! keep track of last accepted event bunch crossing
+  /*! it is needed in order not to accept two consecutive events belonging to the same bunch crossing */
+  int64_t m_last_bunchCrossing = 0;
+
+  //! event offset
+  /*! it is added to the current event number to look for the corresponding timestamp */
+  int m_event_offset = 0;
+
+  //! min integration time for pileup in the TPC (ns)
+  double m_tmin = -13500;
+
+  //! max integration time for pileup in the TPC (ns)
+  double m_tmax = 13500;
+
+  //! event header
+  EventHeader* m_eventheader = nullptr;
+
+  //! hepmc
+  PHHepMCGenEventMap* m_geneventmap = nullptr;
+
+  //! maps g4hit containers to node names
+  std::map<std::string, PHG4HitContainer*> m_g4hitscontainers;
+
+  //! truth information
+  PHG4TruthInfoContainer* m_g4truthinfo = nullptr;
+
+
+};
+
+#endif /* __Fun4AllDstPileupInputManager_H__ */

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -61,8 +61,6 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   //! copy background event
   void copy_background_event(PHCompositeNode*, double delta_t);
 
-  int m_InitRun = 0;
-
   //!@name event counters
   //@{
   int m_ReadRunTTree = 1;

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -64,8 +64,8 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   //!@name event counters
   //@{
   int m_ReadRunTTree = 1;
-  int m_events_total = 0;
-  int m_events_thisfile = 0;
+  int m_ievent_total = 0;
+  int m_ievent_thisfile = 0;
   int m_events_skipped_during_sync = 0;
   int m_events_accepted = 0;
   //@}

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManagerLinkDef.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManagerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class Fun4AllDstPileupInputManager - !;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -117,6 +117,7 @@ nobase_dist_pcm_DATA = \
 else
   ROOT5HITDICTS = PHG4HitDefs_Dict.cc
   ROOT5TBDICTS = \
+    Fun4AllDstPileupInputManager_Dict.cc \
     HepMCNodeReader_Dict.cc \
     PHG4ConsistencyCheck_Dict.cc \
     PHG4HeadReco_Dict.cc \
@@ -167,6 +168,7 @@ libg4testbench_la_SOURCES = \
   Fun4AllMessenger.cc \
   G4TBMagneticFieldSetup.cc \
   G4TBFieldMessenger.cc \
+  Fun4AllDstPileupInputManager.cc \
   HepMCNodeReader.cc \
   PHG4ConsistencyCheck.cc \
   PHG4DisplayAction.cc \
@@ -213,6 +215,7 @@ libg4testbench_la_SOURCES = \
 
 pkginclude_HEADERS = \
   EicEventHeader.h \
+  Fun4AllDstPileupInputManager.h \
   HepMCNodeReader.h \
   PHBBox.h \
   PHG4ColorDefs.h \

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -230,6 +230,7 @@ pkginclude_HEADERS = \
   PHG4Particle.h \
   PHG4Particlev1.h \
   PHG4Particlev2.h \
+  PHG4Particlev3.h \
   PHG4ParticleGenerator.h \
   PHG4ParticleGeneratorBase.h \
   PHG4ParticleGeneratorVectorMeson.h \

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -59,6 +59,7 @@ libg4testbench_la_LIBADD = \
   -lphgeom \
   -lphg4gdml \
   -lphhepmc \
+  -lphparameter \
   -lvararray
 
 # I/O dictionaries have to exist for root5 and root6. For ROOT6 we need
@@ -135,6 +136,7 @@ else
     PHG4Subsystem_Dict.cc \
     PHG4TruthSubsystem_Dict.cc \
     PHG4Utils_Dict.cc \
+    PHG4VertexSelection_Dict.cc \
     ReadEICFiles_Dict.cc \
     PHG4HitReadBack_Dict.cc
 endif
@@ -202,6 +204,7 @@ libg4testbench_la_SOURCES = \
   PHG4TruthTrackingAction.cc \
   PHG4UIsession.cc \
   PHG4Utils.cc \
+  PHG4VertexSelection.cc \
   ReadEICFiles.cc
 
 
@@ -247,6 +250,7 @@ pkginclude_HEADERS = \
   PHG4TruthSubsystem.h \
   PHG4Units.h \
   PHG4Utils.h \
+  PHG4VertexSelection.h \
   PHG4VtxPoint.h \
   PHG4VtxPointv1.h \
   ReadEICFiles.h

--- a/simulation/g4simulation/g4main/PHG4VertexSelection.cc
+++ b/simulation/g4simulation/g4main/PHG4VertexSelection.cc
@@ -1,0 +1,58 @@
+// This is the new trackbase container version
+
+/*!
+ * \file PHG4VertexSelection.cc
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include "PHG4VertexSelection.h"
+
+#include "PHG4TruthInfoContainer.h"
+#include "PHG4VtxPoint.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/getClass.h>
+
+//____________________________________________________________________________
+PHG4VertexSelection::PHG4VertexSelection(const std::string &name)
+  : SubsysReco(name)
+  , PHParameterInterface(name)
+{ InitializeParameters(); }
+
+//____________________________________________________________________________
+int PHG4VertexSelection::InitRun(PHCompositeNode *topNode)
+{
+  UpdateParametersWithMacro();
+
+  // load parameters
+  m_vertex_zcut = get_double_param( "vertex_zcut" );
+  
+  // printout
+  std::cout
+    << "PHG4VertexSelection::InitRun\n"
+    << " m_vertex_zcut: " << m_vertex_zcut << " cm\n"
+    << std::endl;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________
+int PHG4VertexSelection::process_event(PHCompositeNode *topNode)
+{  
+  // g4 truth info
+  auto g4truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+
+  // main vertex
+  const auto main_vertex_id = g4truthinfo->GetPrimaryVertexIndex();
+  const auto vertex = g4truthinfo->GetPrimaryVtx( main_vertex_id );
+  if( !vertex ) return false;
+
+  // check vertex position along the beam
+  return ( m_vertex_zcut > 0 && std::abs( vertex->get_z() ) > m_vertex_zcut ) ?
+    Fun4AllReturnCodes::DISCARDEVENT:
+    Fun4AllReturnCodes::EVENT_OK;
+}
+
+//___________________________________________________________________________
+void PHG4VertexSelection::SetDefaultParameters()
+{ set_default_double_param( "vertex_zcut", 10 ); }

--- a/simulation/g4simulation/g4main/PHG4VertexSelection.h
+++ b/simulation/g4simulation/g4main/PHG4VertexSelection.h
@@ -1,0 +1,42 @@
+// Tell emacs that this is a C++ source
+// -*- C++ -*-.
+
+#ifndef G4MAIN_PHG4VERTEXSELECTION_H
+#define G4MAIN_PHG4VERTEXSELECTION_H
+
+/*!
+ * \file PHG4VertexSelection.h
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include <fun4all/SubsysReco.h>
+#include <phparameter/PHParameterInterface.h>
+
+#include <memory>
+#include <string>                              // for string
+
+class PHCompositeNode;
+
+class PHG4VertexSelection : public SubsysReco, public PHParameterInterface
+{
+
+  public:
+  PHG4VertexSelection(const std::string &name = "PHG4VertexSelection");
+
+  //! run initialization
+  int InitRun(PHCompositeNode*) override;
+
+  //! event processing
+  int process_event(PHCompositeNode *topNode) override;
+
+  //! parameters
+  void SetDefaultParameters() override;
+
+  private:
+
+  // z vertex cut (cm)
+  double m_vertex_zcut = 10;
+  
+};
+
+#endif

--- a/simulation/g4simulation/g4main/PHG4VertexSelectionLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4VertexSelectionLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4SelectionLinkDef-!;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
This pull request implements a DST input manager that is capable of merging multiple single collision Hijing events according to a timestamp (== bunch crossing ids) sequence, to form full events (signal + pileup). The timestamp sequence must be provided externally. 
in details:
- added EventHeaderv2 class that derives from v1 and includes the bunchcrossing id
- added a subsysreco (PHG4VertexSelection) used to select HIJING events with vertex withing +/-10cm. Those events are used as "trigger" events to which pileup events are added 
- added Fun4AllDstPileupInputManager that does all the heavy lifting. 
It is duplicated from Fun4AllDstInputManager. The merging of the events is achieved using two PHNodeIOManagers, one for the signal event and one for the pile-up events that are merged to the signal. 
The relevant method where the merging is done is ::run and ::copy_background_event

Code compiles locally and was tested on existing HIJING events. 
Please do not merge yet. It has not been tested for memleaks against valgrind, and will not be by Jenkins, since it is not included in any running macro. I will test it on valgrind during the weekend using small size input files. 
