### PR TITLE
changed tmin to -20ns in order to catch inbunch pileup hits with negative time offsets.

### DIFF
--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -363,8 +363,12 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
 void PHG4MicromegasHitReco::SetDefaultParameters()
 {
   // default timing window (ns)
-  /* see https://indico.bnl.gov/event/8548/contributions/37753/attachments/28212/43343/2020_05_Proposal_sPhenixMonitoring_update_19052020.pptx slide 10 */
-  set_default_double_param("micromegas_tmin", 0 );
+  /* 
+   * see https://indico.bnl.gov/event/8548/contributions/37753/attachments/28212/43343/2020_05_Proposal_sPhenixMonitoring_update_19052020.pptx slide 10 
+   * small negative time for tmin is set to catch out of time, same-bunch pileup events 
+   * similar value is used in PHG4InttReco
+  */
+  set_default_double_param("micromegas_tmin", -20 );
   set_default_double_param("micromegas_tmax", 800 );
 
   // gas data from

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
@@ -71,7 +71,7 @@ class PHG4MicromegasHitReco : public SubsysReco, public PHParameterInterface
   std::string m_detector;
 
   //! timing window (ns)
-  double m_tmin = 0;
+  double m_tmin = -20;
 
   //! timing window (ns)
   double m_tmax = 800;


### PR DESCRIPTION
Consistently with what is done with INTT
Needed to catch in bunch pileup hits