### PR TITLE
Fix cylinder

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -9,6 +9,7 @@ class G4Step;
 class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4CylinderDetector;
+class PHG4CylinderSubsystem;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
@@ -18,7 +19,7 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  PHG4CylinderSteppingAction(PHG4CylinderDetector *, const PHParameters *parameters);
+  PHG4CylinderSteppingAction(PHG4CylinderSubsystem *subsys, PHG4CylinderDetector *detector, const PHParameters *parameters);
 
   //! destructor
   virtual ~PHG4CylinderSteppingAction();
@@ -31,10 +32,17 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
 
   void SaveLightYield(const int i = 1) { m_SaveLightYieldFlag = i; }
 
+// needed for hit position crosschecks, if this volume is inside
+// another volume the absolut hit coordinates in our G4Hits and
+// the local coordinates differ, so checking against our place in z
+// goes wrong
+  bool hasMotherSubsystem() const;
+
  private:
+  //! pointer to the Subsystem
+  PHG4CylinderSubsystem *m_Subsystem;
   //! pointer to the detector
   PHG4CylinderDetector *m_Detector;
-
   const PHParameters *m_Params;
 
   //! pointer to hit container

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -126,11 +126,11 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     }
     PHG4CylinderGeom *mygeom = new PHG4CylinderGeomv1(GetParams()->get_double_param("radius"), GetParams()->get_double_param("place_z") - detlength / 2., GetParams()->get_double_param("place_z") + detlength / 2., GetParams()->get_double_param("thickness"));
     geo->AddLayerGeom(GetLayer(), mygeom);
-    m_SteppingAction = new PHG4CylinderSteppingAction(m_Detector, GetParams());
+    m_SteppingAction = new PHG4CylinderSteppingAction(this, m_Detector, GetParams());
   }
   else if (GetParams()->get_int_param("blackhole"))
   {
-    m_SteppingAction = new PHG4CylinderSteppingAction(m_Detector, GetParams());
+    m_SteppingAction = new PHG4CylinderSteppingAction(this, m_Detector, GetParams());
   }
   return 0;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -5,10 +5,7 @@
 
 #include "PHG4DetectorSubsystem.h"
 
-#if !defined(__CINT__) || defined(__CLING__)
 #include <array>  // for array
-#endif
-
 #include <string>  // for string
 
 class PHCompositeNode;
@@ -77,11 +74,7 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
   PHG4DisplayAction* m_DisplayAction;
 
   //! Color setting if we want to override the default
-#if !defined(__CINT__) || defined(__CLING__)
   std::array<double, 4> m_ColorArray;
-#else
-  double m_ColorArray[4];
-#endif
 };
 
 #endif  // G4DETECTORS_PHG4CYLINDERSUBSYSTEM_H

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
@@ -24,14 +24,8 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
 
   virtual ~PHG4DetectorSubsystem() {}
 
-  // stupid rootcint does not support final keyword
-#if !defined(__CINT__) || defined(__CLING__)
   int Init(PHCompositeNode *) final;
   int InitRun(PHCompositeNode *) final;
-#else
-  int Init(PHCompositeNode *);
-  int InitRun(PHCompositeNode *);
-#endif
 
   virtual int InitRunSubsystem(PHCompositeNode *)
   {


### PR DESCRIPTION
This PR fixes a hit position check in the cylinder stepping action (the hit z-position is compared to the z-position of the cylinder). This is valid if the cylinder is put into the world volume. If the cylinder is put into a mother volume which is shifted in z this check fails since it uses the world coordinates from our g4hits.
I don't want to remove this check (you never know) so I added a bool hasMotherSubsystem() method to the stepping action (which uses the GetMotherSubsystem() method in PHG4Subsystem). This needed adding a pointer to the subsystem which creates the stepping action.
Also removed obsolete CINT checks and defines which made root5 happy