### PR TITLE
Update to Actsv0.30

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -239,7 +239,7 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
     /// This is an arbitrary vector. Doesn't matter in coordinate transformation
     /// in Acts code
     Acts::Vector3D mom(1, 1, 1);
-    meas.referenceSurface().localToGlobal(m_tGeometry->geoContext,
+    meas.referenceObject().localToGlobal(m_tGeometry->geoContext,
                                           local, mom, global);
 
     /// Get measurement covariance
@@ -267,7 +267,7 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
     const float r = sqrt(gx * gx + gy * gy + gz * gz);
     Acts::Vector3D globalTruthUnitDir(gx / r, gy / r, gz / r);
 
-    meas.referenceSurface().globalToLocal(
+    meas.referenceObject().globalToLocal(
         m_tGeometry->geoContext,
         globalTruthPos,
         globalTruthUnitDir,

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -30,6 +30,7 @@ using SourceLink = FW::Data::TrkrClusterSourceLink;
 using FitResult = Acts::KalmanFitterResult<SourceLink>;
 using Trajectory = FW::TrkrClusterMultiTrajectory;
 using Measurement = Acts::Measurement<FW::Data::TrkrClusterSourceLink,
+                                      Acts::BoundParametersIndices,
                                       Acts::ParDef::eLOC_0,
                                       Acts::ParDef::eLOC_1>;
 using Acts::VectorHelpers::eta;

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -298,12 +298,11 @@ void MakeActsGeometry::addActsTpcSurfaces(TGeoVolume *tpc_gas_vol, TGeoManager *
 void MakeActsGeometry::buildActsSurfaces()
 {
   // define int argc and char* argv to provide options to processGeometry
-
   // Can hard code geometry options since the TGeo options are fixed by our detector design
   const int argc = 33;
   char *arg[argc];
   //TPC +mvtx + intt args
-  const std::string argstr[argc]{"-n1", "-l0", "--geo-tgeo-filename=none", "--geo-tgeo-worldvolume=\"World\"", "--geo-subdetectors", "MVTX", "Silicon", "TPC", "--geo-tgeo-nlayers=0", "0", "0", "--geo-tgeo-clayers=1", "1", "1", "--geo-tgeo-players=0", "0", "0", "--geo-tgeo-clayernames", "MVTX", "siactive", "tpc_gas_measurement", "--geo-tgeo-cmodulenames", "MVTXSensor", "siactive", "tpc_gas_measurement","--geo-tgeo-cmoduleaxes", "XZY", "YZX", "YZX", "--bf-values", "0", "0", "1.4"};
+  const std::string argstr[argc]{"-n1", "-l0", "--geo-tgeo-filename=none", "--geo-tgeo-worldvolume=\"World\"", "--geo-detector-volume", "MVTX", "Silicon", "TPC", "--geo-tgeo-nlayers=0", "0", "0", "--geo-tgeo-clayers=1", "1", "1", "--geo-tgeo-players=0", "0", "0", "--geo-tgeo-cvolume-name", "MVTX", "siactive", "tpc_gas_measurement", "--geo-tgeo-cmodule-name", "MVTXSensor", "siactive", "tpc_gas_measurement","--geo-tgeo-cmodule-axes", "XZY", "YZX", "YZX", "--bf-values", "0", "0", "1.4"};
 
 
   // Set vector of chars to arguments needed

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -298,12 +298,15 @@ void MakeActsGeometry::addActsTpcSurfaces(TGeoVolume *tpc_gas_vol, TGeoManager *
 void MakeActsGeometry::buildActsSurfaces()
 {
   // define int argc and char* argv to provide options to processGeometry
-  // Can hard code geometry options since the TGeo options are fixed by our detector design
-  const int argc = 33;
+  const int argc = 7;
   char *arg[argc];
-  //TPC +mvtx + intt args
-  const std::string argstr[argc]{"-n1", "-l0", "--geo-tgeo-filename=none", "--geo-tgeo-worldvolume=\"World\"", "--geo-detector-volume", "MVTX", "Silicon", "TPC", "--geo-tgeo-nlayers=0", "0", "0", "--geo-tgeo-clayers=1", "1", "1", "--geo-tgeo-players=0", "0", "0", "--geo-tgeo-cvolume-name", "MVTX", "siactive", "tpc_gas_measurement", "--geo-tgeo-cmodule-name", "MVTXSensor", "siactive", "tpc_gas_measurement","--geo-tgeo-cmodule-axes", "XZY", "YZX", "YZX", "--bf-values", "0", "0", "1.4"};
 
+  // Response file contains arguments necessary for geometry building
+  const std::string argstr[argc]{
+    "-n1", "-l0", 
+      "--response-file=tgeo-sphenix.response",
+      "--bf-values", "0", "0", "1.4"
+      };
 
   // Set vector of chars to arguments needed
   for (int i = 0; i < argc; ++i)
@@ -311,8 +314,9 @@ void MakeActsGeometry::buildActsSurfaces()
     // need a copy, since .c_str() returns a const char * and process geometry will not take a const
     arg[i] = strdup(argstr[i].c_str());
   }
-
-  // We replicate the relevant functionality of  acts-framework/Examples/Common/src/GeometryExampleBase::ProcessGeometry() in MakeActsGeometry()
+  
+  // We replicate the relevant functionality of  
+  //acts/Examples/Run/Common/src/GeometryExampleBase::ProcessGeometry() in MakeActsGeometry()
   // so we get access to the results. The layer builder magically gets the TGeoManager
 
   makeGeometry(argc, arg, m_detector);
@@ -344,10 +348,6 @@ void MakeActsGeometry::makeGeometry(int argc, char *argv[],
   m_contextDecorators = geometry.second;
 
   m_magneticField = FW::Options::readBField(vm);
-
-  /// The detectors
-  /// "MVTX" and "Silicon" and "TPC"
-  read_strings subDetectors = vm["geo-subdetectors"].as<read_strings>();
 
   size_t ievt = 0;
   size_t ialg = 0;

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -66,7 +66,6 @@
 
 using namespace std;
 
-
 MakeActsGeometry::MakeActsGeometry(const string &name)
   : m_geomContainerMvtx(nullptr)
   , m_geomContainerIntt(nullptr)

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = \
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  -L$(OFFLINE_MAIN)/lib64
+  -L$(MYINSTALL)/lib64
 
 pkginclude_HEADERS = \
   ActsCovarianceRotater.h \

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = \
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  -L$(MYINSTALL)/lib64
+  -L$(OFFLINE_MAIN)/lib64
 
 pkginclude_HEADERS = \
   ActsCovarianceRotater.h \

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -371,7 +371,7 @@ void PHActsTrkFitter::fillSvtxTrackStates(const Trajectory traj, const size_t &t
       /// This is an arbitrary vector. Doesn't matter in coordinate transformation
       /// in Acts code
       Acts::Vector3D mom(1, 1, 1);
-      meas.referenceSurface().localToGlobal(m_tGeometry->geoContext,
+      meas.referenceObject().localToGlobal(m_tGeometry->geoContext,
 					    local, mom, global);
       
       float pathlength = state.pathLength() / Acts::UnitConstants::cm;  

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -45,6 +45,7 @@ using SourceLink = FW::Data::TrkrClusterSourceLink;
 using FitResult = Acts::KalmanFitterResult<SourceLink>;
 using Trajectory = FW::TrkrClusterMultiTrajectory;
 using Measurement = Acts::Measurement<FW::Data::TrkrClusterSourceLink,
+                                      Acts::BoundParametersIndices,
                                       Acts::ParDef::eLOC_0,
                                       Acts::ParDef::eLOC_1>;
 class PHActsTrkFitter : public PHTrackFitting

--- a/offline/packages/trackreco/tgeo-sphenix.response
+++ b/offline/packages/trackreco/tgeo-sphenix.response
@@ -1,0 +1,52 @@
+# Response file to build the sPHENIX detector
+#
+# Screen Output Level for building 
+#--geo-surface-loglevel 3 
+#--geo-layer-loglevel 3
+#--geo-volume-loglevel 3
+#
+# General input
+--geo-tgeo-filename none
+--geo-tgeo-worldvolume "World"
+#
+# Detector : MVTX
+--geo-detector-volume MVTX
+--geo-tgeo-sfbin-r-tolerance 5:5
+--geo-tgeo-sfbin-z-tolerance 5:5
+--geo-tgeo-sfbin-phi-tolerance 0.05:0.05
+--geo-tgeo-clayers 1
+--geo-tgeo-cvolume-name *
+--geo-tgeo-cmodule-name MVTXSensor*
+--geo-tgeo-cmodule-axes XZY
+--geo-tgeo-clayer-r-range 0:500
+--geo-tgeo-clayer-z-range -3000:3000
+--geo-tgeo-clayer-r-split 1. 
+--geo-tgeo-clayer-z-split -1.
+#
+# Detector : Silicon
+--geo-detector-volume Silicon
+--geo-tgeo-sfbin-r-tolerance 5:5
+--geo-tgeo-sfbin-z-tolerance 5:5
+--geo-tgeo-sfbin-phi-tolerance 0.05:0.05
+--geo-tgeo-clayers 1
+--geo-tgeo-cvolume-name *
+--geo-tgeo-cmodule-name siactive*
+--geo-tgeo-cmodule-axes YZX
+--geo-tgeo-clayer-r-range 0:500
+--geo-tgeo-clayer-z-range -3000:3000
+--geo-tgeo-clayer-r-split 1. 
+--geo-tgeo-clayer-z-split -1.
+#
+# Detector : TPC
+--geo-detector-volume TPC
+--geo-tgeo-sfbin-r-tolerance 5:5
+--geo-tgeo-sfbin-z-tolerance 5:5
+--geo-tgeo-sfbin-phi-tolerance 0.01:0.01
+--geo-tgeo-clayers 1
+--geo-tgeo-cvolume-name *
+--geo-tgeo-cmodule-name tpc_gas_measurement*
+--geo-tgeo-cmodule-axes YZX
+--geo-tgeo-clayer-r-range 0:1000
+--geo-tgeo-clayer-z-range -3000:3000
+--geo-tgeo-clayer-r-split 1. 
+--geo-tgeo-clayer-z-split -1.


### PR DESCRIPTION
This PR updates our Acts modules to reflect changes in our Acts builds after updating to Acts v0.30. These changes should be merged together with this [PR](https://github.com/sPHENIX-Collaboration/acts/pull/16) in our Acts fork.

One change worth noting in this PR is that the geometry options required to build the sPHENIX-Acts geometry are now contained in a response file that is read in. This keeps the options archived as a data file and no longer hard coded in `MakeActsGeometry.cc`.