### PR TITLE
Em clusterizer

### DIFF
--- a/offline/packages/CaloReco/BEmcCluster.cc
+++ b/offline/packages/CaloReco/BEmcCluster.cc
@@ -158,9 +158,10 @@ float EmcCluster::GetECore()
     int iy = ixy / fOwner->GetNx();
     int ix = ixy - iy * fOwner->GetNx();
     //      dx = xcg - ix;
-    float dx = fOwner->fTowerDist(float(ix), xcg);
-    float dy = ycg - iy;
-    float et = fOwner->PredictEnergy(dx, dy, energy);
+    //    float dx = fOwner->fTowerDist(float(ix), xcg);
+    //    float dy = ycg - iy;
+    //    float et = fOwner->PredictEnergy(dx, dy, energy);
+    float et = fOwner->PredictEnergy(energy, xcg, ycg, ix, iy);
     if (et > thresh) es += (*ph).amp;
     ++ph;
   }
@@ -504,7 +505,8 @@ int EmcCluster::GetSubClusters(vector<EmcCluster>* PkList, vector<EmcModule>* pp
 
         // predict energy within 2.5 cell square around local peak
         if (ABS(dx) < 2.5 && ABS(dy) < 2.5)
-          a = epk[ipk] * fOwner->PredictEnergy(dx, dy, epk[ipk]);
+	  //          a = epk[ipk] * fOwner->PredictEnergy(dx, dy, epk[ipk]);
+          a = epk[ipk] * fOwner->PredictEnergy(epk[ipk], xpk[ipk], ypk[ipk], ix, iy);
 
         Energy[ipk][in] = a;
         tmpEnergy[in] += a;
@@ -596,7 +598,8 @@ int EmcCluster::GetSubClusters(vector<EmcCluster>* PkList, vector<EmcModule>* pp
           ix = ixy - iy * fOwner->GetNx();
           dx = fOwner->fTowerDist(float(ix), xpk[ig]);
           dy = ypk[ig] - iy;
-          a = epk[ig] * fOwner->PredictEnergy(dx, dy, epk[ig]);
+	  //          a = epk[ig] * fOwner->PredictEnergy(dx, dy, epk[ig]);
+          a = epk[ig] * fOwner->PredictEnergy(epk[ig], xpk[ig], ypk[ig], ix, iy);
           Energy[ipk][in] += a;
           tmpEnergy[in] += a;
         }

--- a/offline/packages/CaloReco/BEmcProfile.cc
+++ b/offline/packages/CaloReco/BEmcProfile.cc
@@ -80,9 +80,11 @@ BEmcProfile::BEmcProfile(const string& fname)
   }
   hmean = new TH1F*[nen * nth * NP];
   hsigma = new TH1F*[nen * nth * NP];
+  hr4 = new TH1F*[nen * nth];
 
   TH1F* hh;
   int ii = 0;
+  int ii2 = 0;
 
   string hname;
   for (int it = 0; it < nth; it++)
@@ -117,6 +119,20 @@ BEmcProfile::BEmcProfile(const string& fname)
 
         ii++;
       }
+
+      hname = boost::str(boost::format("hr4_en%d_t%d") % ie % it);
+      hh = (TH1F*) f->Get(hname.c_str());
+
+      if (!hh)
+      {
+	cout << "BEmcProfile: Error when loading profile data for hr4 it = " 
+	     << it << ", ie = " << ie << endl;
+	f->Close();
+	return;
+      }
+      hr4[ii2] = (TH1F*) hh->Clone();
+      ii2++;
+
     }
   }
 
@@ -137,6 +153,12 @@ BEmcProfile::~BEmcProfile()
     }
     delete[] hmean;
     delete[] hsigma;
+
+    for (int i = 0; i < nth * nen; i++)
+    {
+      delete hr4[i];
+    }
+    delete[] hr4;
   }
 }
 
@@ -487,6 +509,91 @@ void BEmcProfile::PredictEnergy(int ip, float energy, float theta, float phi, fl
   ep = pr;
   err = er;
 }
+
+
+float BEmcProfile::PredictEnergyR(float energy, float theta, float phi, float rr)
+{
+
+  if (!bloaded)
+  {
+    //    cout << "Error in BEmcProfile::PredictEnergyR: profiles not loaded" << endl;
+    return 0;
+  }
+
+  if (energy <= 0)
+  {
+    cout << "Error in BEmcProfile::PredictEnergyR: energy = " << energy 
+	 << " but should be >0" << endl;
+    return 0;
+  }
+  if (theta < 0)
+  {
+    cout << "Error in BEmcProfile::PredictEnergyR: theta = " << theta 
+	 << " but should be >=0" << endl;
+    return 0;
+  }
+
+  if (rr < 1 )
+  {
+    cout << "Error in BEmcProfile::PredictEnergyR: rr = " << rr 
+	 << " but should be >1" << endl;
+  }
+
+  // Energy bin
+  int ie2 = 0;
+  while (ie2 < nen && energy > energy_array[ie2]) ie2++;
+  if (ie2 == 0)
+    ie2 = 1;
+  else if (ie2 >= nen)
+    ie2 = nen - 1;
+  int ie1 = ie2 - 1;
+  //  int ie1 = ie2-2; // For a test()
+
+  // Theta bin
+  int it2 = 0;
+  while (it2 < nth && theta > theta_array[it2]) it2++;
+  if (it2 == 0)
+    it2 = 1;
+  else if (it2 >= nth)
+    it2 = nth - 1;
+  int it1 = it2 - 1;
+  //  int it1 = it2-2; // For a test()
+
+  //  printf("Energy bin= %d %d (%f)  Theta bin= %d %d (%f)\n",ie1,ie2,energy,it1,it2,theta);
+
+  float en1 = energy_array[ie1];
+  float en2 = energy_array[ie2];
+  float th1 = theta_array[it1];
+  float th2 = theta_array[it2];
+
+  // 1st index - ie, second index - it
+  int ii11 = ie1 + it1 * nen;
+  int ii21 = ie2 + it1 * nen;
+  int ii12 = ie1 + it2 * nen;
+  int ii22 = ie2 + it2 * nen;
+
+  int ibin = hr4[ii11]->FindBin(rr);
+
+  // Log (1/sqrt) energy dependence of mean (sigma)
+  //
+  float pr11 = hr4[ii11]->GetBinContent(ibin);
+  float pr21 = hr4[ii21]->GetBinContent(ibin);
+  float prt1 = pr11 + (pr21 - pr11) / (log(en2) - log(en1)) * (log(energy) - log(en1));
+  if (prt1 < 0) prt1 = 0;
+
+  float pr12 = hr4[ii12]->GetBinContent(ibin);
+  float pr22 = hr4[ii22]->GetBinContent(ibin);
+  float prt2 = pr12 + (pr22 - pr12) / (log(en2) - log(en1)) * (log(energy) - log(en1));
+  if (prt2 < 0) prt2 = 0;
+
+  // Quadratic theta dependence of mean and sigma
+  //
+  float pr = prt1 + (prt2 - prt1) / (pow(th2, 2) - pow(th1, 2)) * (pow(theta, 2) - pow(th1, 2));
+  if (pr < 0) pr = 0;
+
+  return pr;
+}
+
 
 float BEmcProfile::GetTowerEnergy(int iy, int iz, std::vector<EmcModule>* plist, int NX)
 {

--- a/offline/packages/CaloReco/BEmcProfile.h
+++ b/offline/packages/CaloReco/BEmcProfile.h
@@ -13,7 +13,9 @@ class BEmcProfile
   float GetProb(std::vector<EmcModule>* plist, int NX, float en, float theta, float phi);
   float GetTowerEnergy(int iy, int iz, std::vector<EmcModule>* plist, int nx);
   void PredictEnergy(int ip, float en, float theta, float phi, float ddz, float ddy, float& ep, float& err);
+  float PredictEnergyR(float energy, float theta, float phi, float rr);
   //  float GetProbTest(std::vector<EmcModule>* plist, int NX, float en, float theta, float& test_rr, float& test_et, float& test_ep, float& test_err);
+  bool IsLoaded() { return bloaded; }
   int Verbosity() const { return m_Verbosity; }
   void Verbosity(const int i) { m_Verbosity = i; }
 
@@ -29,6 +31,7 @@ class BEmcProfile
 
   TH1F** hmean;
   TH1F** hsigma;
+  TH1F* *hr4;
 
  private:
   int m_Verbosity;

--- a/offline/packages/CaloReco/BEmcRec.cc
+++ b/offline/packages/CaloReco/BEmcRec.cc
@@ -8,6 +8,9 @@
 
 #include "BEmcRec.h"
 #include "BEmcCluster.h"
+#include "BEmcProfile.h"
+
+#include <TMath.h>
 
 #include <cstdlib>
 #include <fstream>
@@ -26,6 +29,7 @@ int const BEmcRec::fgMaxLen = 1000;
 
 BEmcRec::BEmcRec()
   : bCYL(true)
+  , bProfileProb(false)
   , fNx(-1)
   , fNy(-1)
   , fVx(0)
@@ -33,8 +37,8 @@ BEmcRec::BEmcRec()
   , fVz(0)
   , fgTowerThresh(0.01)
   , fgMinPeakEnergy(0.08)
+  , _emcprof(nullptr)
   , m_ThisName("NOTSET")
-//  , _emcprof(nullptr)
 {
   fTowerGeom.clear();
   fModules = new vector<EmcModule>;
@@ -58,6 +62,8 @@ BEmcRec::~BEmcRec()
     fClusters->clear();
     delete fClusters;
   }
+
+  if (_emcprof) delete _emcprof;
 }
 
 // ///////////////////////////////////////////////////////////////////////////
@@ -442,7 +448,8 @@ int BEmcRec::FindClusters()
 // ///////////////////////////////////////////////////////////////////////////
 
 void BEmcRec::Momenta(vector<EmcModule>* phit, float& pe, float& px,
-                      float& py, float& pxx, float& pyy, float& pyx)
+                      float& py, float& pxx, float& pyy, float& pyx,
+		      float thresh)
 {
   // First and second momenta calculation
 
@@ -489,16 +496,18 @@ void BEmcRec::Momenta(vector<EmcModule>* phit, float& pe, float& px,
   while (ph != phit->end())
   {
     a = ph->amp;
-    int iy = ph->ich / fNx;
-    int ix = ph->ich - iy * fNx;
-    int idx = iTowerDist(ixmax, ix);
-    int idy = iy - iymax;
-    e += a;
-    x += idx * a;
-    y += idy * a;
-    xx += a * idx * idx;
-    yy += a * idy * idy;
-    yx += a * idx * idy;
+    if( a>thresh ) {
+      int iy = ph->ich / fNx;
+      int ix = ph->ich - iy * fNx;
+      int idx = iTowerDist(ixmax, ix);
+      int idy = iy - iymax;
+      e += a;
+      x += idx * a;
+      y += idy * a;
+      xx += a * idx * idx;
+      yy += a * idy * idy;
+      yx += a * idx * idy;
+    }
     ph++;
   }
   pe = e;
@@ -527,7 +536,16 @@ void BEmcRec::Momenta(vector<EmcModule>* phit, float& pe, float& px,
 
 // ///////////////////////////////////////////////////////////////////////////
 
-float BEmcRec::PredictEnergy(float xc, float yc, float en)
+float BEmcRec::PredictEnergy(float en, float xcg, float ycg, int ix, int iy)
+{
+  if( _emcprof != nullptr && bProfileProb )  return PredictEnergyProb(en, xcg, ycg, ix, iy);
+
+  float dx = fabs(fTowerDist(float(ix), xcg));
+  float dy = ycg - iy;
+  return PredictEnergyParam(en,dx,dy);
+}
+
+float BEmcRec::PredictEnergyParam(float en, float xc, float yc)
 {
   // Calculates the energy deposited in the tower, the distance between
   // its center and shower Center of Gravity being (xc,yc)
@@ -579,14 +597,169 @@ float BEmcRec::PredictEnergy(float xc, float yc, float en)
   return e;
 }
 
+float BEmcRec::PredictEnergyProb(float en, float xcg, float ycg, int ix, int iy)
+// Predict tower energy from profiles used in GetProb()
+// This is expected to be used in BEmcCluster::GetSubClusters
+{
+  if ( _emcprof == nullptr ) return -1;
+
+  while (xcg < -0.5) xcg += float(fNx);
+  while (xcg >= fNx - 0.5) xcg -= float(fNx);
+
+  int ixcg = int(xcg + 0.5);
+  int iycg = int(ycg + 0.5);
+  float ddx = fabs(xcg - ixcg);
+  float ddy = fabs(ycg - iycg);
+
+  float xg, yg, zg;
+  Tower2Global(en, xcg, ycg, xg, yg, zg);
+
+  float theta, phi;
+  GetImpactThetaPhi(xg, yg, zg, theta, phi);
+
+  int isx = 1;
+  if (xcg - ixcg < 0) isx = -1;
+  int isy = 1;
+  if (ycg - iycg < 0) isy = -1;
+
+  int idx = iTowerDist(ixcg, ix) * isx;
+  int idy = (iy-iycg) * isy;
+
+  int id = -1;
+  if(      idx == 0 && idy == 0 ) id = 0;
+  else if( idx == 1 && idy == 0 ) id = 1;
+  else if( idx == 1 && idy == 1 ) id = 2;
+  else if( idx == 0 && idy == 1 ) id = 3;
+
+  if( id < 0 ) {
+    float dx = fabs(fTowerDist(xcg, float(ix)));
+    float dy = fabs(iy-ycg);
+    float rr = sqrt(dx * dx + dy * dy);
+    //    return PredictEnergyParam(en, dx, dy);
+    return _emcprof->PredictEnergyR(en, theta, phi, rr);
+  }
+
+  float ep[4], err[4];
+  for( int ip=0; ip<4; ip++ ) {
+    _emcprof->PredictEnergy(ip, en, theta, phi, ddx, ddy, ep[ip], err[ip]);
+  }
+
+  float eout;
+
+  if(      id==0 ) eout = (ep[1]+ep[2])/2. + ep[3];
+  else if( id==1 ) eout = (ep[0]-ep[2])/2. - ep[3];
+  else if( id==3 ) eout = (ep[0]-ep[1])/2. - ep[3];
+  else             eout = ep[3];
+
+  //  if( eout<0 ) printf("id=%d eout=%f: ep= %f %f %f %f Input: E=%f xcg=%f ycg=%f\n",id,eout,ep[0],ep[1],ep[2],ep[3],en,xcg,ycg);
+  if( eout<0 ) eout = 1e-6;
+
+  return eout;
+}
+
 // ///////////////////////////////////////////////////////////////////////////
 
-float BEmcRec::GetProb(vector<EmcModule> HitList, float et, float xg, float yg, float zg, float& chi2, int& ndf)
+float BEmcRec::GetTowerEnergy(int iy, int iz, std::vector<EmcModule>* plist)
+{
+  int nn = plist->size();
+  if (nn <= 0) return 0;
+
+  for (int i = 0; i < nn; i++)
+  {
+    int ich = (*plist)[i].ich;
+    int iyt = ich / fNx;
+    int izt = ich % fNx;
+    if (iy == iyt && iz == izt)
+    {
+      return (*plist)[i].amp;
+    }
+  }
+  return 0;
+}
+
+// !!!!! Change here to a ponter to HitList
+float BEmcRec::GetProb(vector<EmcModule> HitList, float en, float xg, float yg, float zg, float& chi2, int& ndf)
 // Do nothing; should be defined in a detector specific module BEmcRec{Name}
 {
+  float enoise = 0.01;  // 10 MeV per tower
+  //  float thresh = 0.01;
+  float thresh = GetTowerThreshold();
+
   chi2 = 0;
   ndf = 0;
-  return -1;
+  if ( _emcprof == nullptr ) return -1;
+
+  if ( !(_emcprof->IsLoaded()) )
+  {
+    return -1;
+  }
+
+  int nn = HitList.size();
+  if (nn <= 0) return -1;
+
+  float theta, phi;
+  GetImpactThetaPhi(xg, yg, zg, theta, phi);
+
+  // z coordinate below means x coordinate
+
+  float etot;
+  float zcg, ycg;
+  float zz, yy, yz;
+  Momenta(&HitList, etot, zcg, ycg, zz, yy, yz, thresh);
+
+  int iz0cg = int(zcg + 0.5);
+  int iy0cg = int(ycg + 0.5);
+  float ddz = fabs(zcg - iz0cg);
+  float ddy = fabs(ycg - iy0cg);
+
+  int isz = 1;
+  if (zcg - iz0cg < 0) isz = -1;
+  int isy = 1;
+  if (ycg - iy0cg < 0) isy = -1;
+
+  // 4 central towers: 43
+  //                   12
+  // Tower 1 - central one
+  float e1, e2, e3, e4;
+  e1 = GetTowerEnergy(iy0cg, iz0cg, &HitList);
+  e2 = GetTowerEnergy(iy0cg, iz0cg + isz, &HitList);
+  e3 = GetTowerEnergy(iy0cg + isy, iz0cg + isz, &HitList);
+  e4 = GetTowerEnergy(iy0cg + isy, iz0cg, &HitList);
+  if (e1 < thresh) e1 = 0;
+  if (e2 < thresh) e2 = 0;
+  if (e3 < thresh) e3 = 0;
+  if (e4 < thresh) e4 = 0;
+
+  float e1t = (e1 + e2 + e3 + e4) / etot;
+  float e2t = (e1 + e2 - e3 - e4) / etot;
+  float e3t = (e1 - e2 - e3 + e4) / etot;
+  float e4t = (e3) / etot;
+  //  float rr = sqrt((0.5-ddz)*(0.5-ddz)+(0.5-ddy)*(0.5-ddy));
+
+  // Predicted values
+  const int NP = 4; // From BEmcProfile
+  float ep[NP];
+  float err[NP];
+  for (int ip = 0; ip < NP; ip++)
+  {
+    _emcprof->PredictEnergy(ip, en, theta, phi, ddz, ddy, ep[ip], err[ip]);
+    if (ep[ip] < 0) return -1;
+    if (ip < 3)
+      err[ip] = sqrt(err[ip] * err[ip] + 4 * enoise * enoise / etot / etot);
+    else
+      err[ip] = sqrt(err[ip] * err[ip] + 1 * enoise * enoise / etot / etot);
+  }
+
+  chi2 = 0.;
+  chi2 += (ep[0] - e1t) * (ep[0] - e1t) / err[0] / err[0];
+  chi2 += (ep[1] - e2t) * (ep[1] - e2t) / err[1] / err[1];
+  chi2 += (ep[2] - e3t) * (ep[2] - e3t) / err[2] / err[2];
+  chi2 += (ep[3] - e4t) * (ep[3] - e4t) / err[3] / err[3];
+  ndf = 4;
+
+  float prob = TMath::Prob(chi2, ndf);
+
+  return prob;
 }
 
 // ///////////////////////////////////////////////////////////////////////////

--- a/offline/packages/CaloReco/BEmcRec.h
+++ b/offline/packages/CaloReco/BEmcRec.h
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+class BEmcProfile;
+
 typedef struct TowerGeom
 {
   float Xcenter;  // Tower center position
@@ -51,6 +53,8 @@ class BEmcRec
   void SetCylindricalGeometry() { bCYL = true; }
   bool isCylindrical() const { return bCYL; }
 
+  void SetProfileProb(bool bprob) { bProfileProb = bprob; }
+
   int GetNx() const { return fNx; }
   int GetNy() const { return fNy; }
   float GetVx() const { return fVx; }
@@ -71,11 +75,14 @@ class BEmcRec
   int FindClusters();
 
   void Momenta(std::vector<EmcModule> *, float &, float &, float &, float &, float &,
-               float &);
+               float &, float thresh=0);
 
   void Tower2Global(float E, float xC, float yC, float &xA, float &yA, float &zA);
+  float GetTowerEnergy(int iy, int iz, std::vector<EmcModule>* plist);
 
-  virtual float PredictEnergy(float, float, float);
+  float PredictEnergy(float, float, float, int, int);
+  float PredictEnergyProb(float en, float xcg, float ycg, int ix, int iy);
+  virtual float PredictEnergyParam(float, float, float);
 
   // Calorimeter specific functions to be specified in respective inherited object
   virtual void CorrectEnergy(float energy, float x, float y, float *ecorr) { *ecorr = energy; }
@@ -92,7 +99,9 @@ class BEmcRec
     zc = z;
   }
   virtual void LoadProfile(const std::string &fname);
-  virtual float GetProb(std::vector<EmcModule> HitList, float e, float xg, float yg, float zg, float &chi2, int &ndf);
+  virtual void GetImpactThetaPhi(float xg, float yg, float zg, float& theta, float& phi) {theta=0; phi=0;}
+
+  float GetProb(std::vector<EmcModule> HitList, float e, float xg, float yg, float zg, float &chi2, int &ndf);
   virtual std::string Name() const { return m_ThisName; }
   virtual void Name(const std::string &name) { m_ThisName = name; }
 
@@ -108,6 +117,7 @@ class BEmcRec
  protected:
   // Geometry
   bool bCYL;  // Cylindrical?
+  bool bProfileProb;
   int fNx;    // length in X direction
   int fNy;    // length in Y direction
   std::map<int, TowerGeom> fTowerGeom;
@@ -123,7 +133,7 @@ class BEmcRec
   //  static float const fgMinShowerEnergy;
   static int const fgMaxLen;
 
-  //  BEmcProfile *_emcprof;
+  BEmcProfile *_emcprof;
 
  private:
   std::string m_ThisName;

--- a/offline/packages/CaloReco/BEmcRecCEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecCEMC.cc
@@ -9,7 +9,7 @@
 using namespace std;
 
 BEmcRecCEMC::BEmcRecCEMC()
-  : _emcprof(nullptr)
+//  : _emcprof(nullptr)
 {
   Name("BEmcRecCEMC");
   SetCylindricalGeometry();
@@ -18,7 +18,7 @@ BEmcRecCEMC::BEmcRecCEMC()
 BEmcRecCEMC::~BEmcRecCEMC()
 {
   // you can delete null pointers
-  delete _emcprof;
+  //  delete _emcprof;
 }
 
 void BEmcRecCEMC::LoadProfile(const string& fname)
@@ -27,6 +27,24 @@ void BEmcRecCEMC::LoadProfile(const string& fname)
   _emcprof = new BEmcProfile(fname);
 }
 
+
+void BEmcRecCEMC::GetImpactThetaPhi(float xg, float yg, float zg, float& theta, float& phi)
+{
+  theta = 0;
+  phi = 0;
+
+  //  float theta = atan(sqrt(xg*xg + yg*yg)/fabs(zg-fVz));
+  float rg = sqrt(xg*xg+yg*yg);
+  float theta_twr;
+  if( fabs(zg)<=15 ) theta_twr = 0;
+  else if( zg>15 )   theta_twr = atan2(zg-15,rg);
+  else               theta_twr = atan2(zg+15,rg);
+  float theta_tr = atan2(zg-fVz,rg);
+  theta = fabs(theta_tr - theta_twr);
+  //  phi = atan2(yg,xg);
+}
+
+/*
 float BEmcRecCEMC::GetProb(vector<EmcModule> HitList, float ecl, float xg, float yg, float zg, float& chi2, int& ndf)
 {
   chi2 = 0;
@@ -50,7 +68,7 @@ float BEmcRecCEMC::GetProb(vector<EmcModule> HitList, float ecl, float xg, float
 
   return prob;
 }
-
+*/
 /*
 float BEmcRecCEMC::GetProb(vector<EmcModule> HitList, float et, float xg, float yg, float zg, float& chi2, int& ndf)
 // et, xg, yg, zg not used here

--- a/offline/packages/CaloReco/BEmcRecCEMC.h
+++ b/offline/packages/CaloReco/BEmcRecCEMC.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-class BEmcProfile;
+//class BEmcProfile;
 class EmcModule;
 
 class BEmcRecCEMC : public BEmcRec
@@ -20,10 +20,11 @@ class BEmcRecCEMC : public BEmcRec
   void CorrectShowerDepth(float energy, float x, float y, float z, float &xc, float &yc, float &zc) override;
 
   void LoadProfile(const std::string &fname) override;
-  float GetProb(std::vector<EmcModule> HitList, float e, float xg, float yg, float zg, float &chi2, int &ndf) override;
+  //  float GetProb(std::vector<EmcModule> HitList, float e, float xg, float yg, float zg, float &chi2, int &ndf) override;
+  void GetImpactThetaPhi(float xg, float yg, float zg, float& theta, float& phi) override;
 
  private:
-  BEmcProfile *_emcprof;
+  //  BEmcProfile *_emcprof;
 };
 
 #endif

--- a/offline/packages/CaloReco/BEmcRecEEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecEEMC.cc
@@ -9,7 +9,7 @@
 using namespace std;
 
 BEmcRecEEMC::BEmcRecEEMC()
-  : _emcprof(nullptr)
+//  : _emcprof(nullptr)
 {
   Name("BEmcRecEEMC");
   SetPlanarGeometry();
@@ -18,22 +18,36 @@ BEmcRecEEMC::BEmcRecEEMC()
 BEmcRecEEMC::~BEmcRecEEMC()
 {
   // you can delete null pointers
-  delete _emcprof;
+  //  delete _emcprof;
 }
 
 void BEmcRecEEMC::LoadProfile(const std::string& fname)
 {
-  cout << "Info from BEmcRecEEMC::LoadProfile(): no shower profile evaluation is defined yet for EEMC" << endl;
+  //  cout << "Info from BEmcRecEEMC::LoadProfile(): no shower profile evaluation is defined yet for EEMC" << endl;
+  _emcprof = new BEmcProfile(fname);
 }
 
-float BEmcRecEEMC::GetProb(vector<EmcModule> HitList, float et, float xg, float yg, float zg, float& chi2, int& ndf)
-// et, xg, yg, zg not used here
+void BEmcRecEEMC::GetImpactThetaPhi(float xg, float yg, float zg, float& theta, float& phi)
+{
+  theta = atan(sqrt(xg*xg + yg*yg)/fabs(zg-fVz));
+  phi = atan2(yg,xg);
+}
+
+/*
+float BEmcRecEEMC::GetProb(vector<EmcModule> HitList, float ecl, float xg, float yg, float zg, float& chi2, int& ndf)
+// ecl, xg, yg, zg not used here
 {
   chi2 = 0;
   ndf = 0;
   float prob = -1;
+
+  float theta = atan(sqrt(xg*xg + yg*yg)/fabs(zg-fVz));
+  float phi = atan2(yg,xg);
+  if( _emcprof != nullptr ) prob = _emcprof->GetProb(&HitList,fNx,ecl,theta,phi);
+
   return prob;
 }
+*/
 
 void BEmcRecEEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, float& xC, float& yC, float& zC)
 {

--- a/offline/packages/CaloReco/BEmcRecEEMC.h
+++ b/offline/packages/CaloReco/BEmcRecEEMC.h
@@ -6,7 +6,7 @@
 #include <string>  // for string
 #include <vector>  // for vector
 
-class BEmcProfile;
+//class BEmcProfile;
 class EmcModule;
 
 class BEmcRecEEMC : public BEmcRec
@@ -21,10 +21,11 @@ class BEmcRecEEMC : public BEmcRec
   static float GetImpactAngle(float e, float x, float y);
 
   void LoadProfile(const std::string &fname) override;
-  float GetProb(std::vector<EmcModule> HitList, float e, float xg, float yg, float zg, float &chi2, int &ndf) override;
+  //  float GetProb(std::vector<EmcModule> HitList, float e, float xg, float yg, float zg, float &chi2, int &ndf) override;
+  void GetImpactThetaPhi(float xg, float yg, float zg, float& theta, float& phi) override;
 
  private:
-  BEmcProfile *_emcprof;
+  //  BEmcProfile *_emcprof;
 };
 
 #endif

--- a/offline/packages/CaloReco/BEmcRecFEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecFEMC.cc
@@ -8,7 +8,7 @@
 using namespace std;
 
 BEmcRecFEMC::BEmcRecFEMC()
-  : _emcprof(nullptr)
+//  : _emcprof(nullptr)
 {
   Name("BEmcRecFEMC");
   SetPlanarGeometry();
@@ -17,7 +17,7 @@ BEmcRecFEMC::BEmcRecFEMC()
 BEmcRecFEMC::~BEmcRecFEMC()
 {
   // one can delete null pointers
-  delete _emcprof;
+  //  delete _emcprof;
 }
 
 void BEmcRecFEMC::LoadProfile(const string& fname)
@@ -25,6 +25,13 @@ void BEmcRecFEMC::LoadProfile(const string& fname)
   _emcprof = new BEmcProfile(fname);
 }
 
+void BEmcRecFEMC::GetImpactThetaPhi(float xg, float yg, float zg, float& theta, float& phi)
+{
+  theta = atan(sqrt(xg*xg + yg*yg)/fabs(zg-fVz));
+  phi = atan2(yg,xg);
+}
+
+/*
 float BEmcRecFEMC::GetProb(vector<EmcModule> HitList, float ecl, float xg, float yg, float zg, float& chi2, int& ndf)
 {
   chi2 = 0;
@@ -37,6 +44,7 @@ float BEmcRecFEMC::GetProb(vector<EmcModule> HitList, float ecl, float xg, float
 
   return prob;
 }
+*/
 
 void BEmcRecFEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, float& xC, float& yC, float& zC)
 {

--- a/offline/packages/CaloReco/BEmcRecFEMC.h
+++ b/offline/packages/CaloReco/BEmcRecFEMC.h
@@ -7,7 +7,7 @@
 #include <vector>  // for vector
 
 class EmcModule;
-class BEmcProfile;
+//class BEmcProfile;
 
 class BEmcRecFEMC : public BEmcRec
 {
@@ -21,10 +21,11 @@ class BEmcRecFEMC : public BEmcRec
   static float GetImpactAngle(float e, float x, float y);
 
   void LoadProfile(const std::string &fname) override;
-  float GetProb(std::vector<EmcModule> HitList, float e, float xg, float yg, float zg, float &chi2, int &ndf) override;
+  //  float GetProb(std::vector<EmcModule> HitList, float e, float xg, float yg, float zg, float &chi2, int &ndf) override;
+  void GetImpactThetaPhi(float xg, float yg, float zg, float& theta, float& phi) override;
 
  private:
-  BEmcProfile *_emcprof;
+  //  BEmcProfile *_emcprof;
 };
 
 #endif

--- a/offline/packages/CaloReco/Makefile.am
+++ b/offline/packages/CaloReco/Makefile.am
@@ -16,6 +16,7 @@ libcalo_reco_la_LIBADD = \
   -lSubsysReco \
   -lgsl \
   -lgslcblas \
+  -lg4vertex_io \
   -lcalo_io \
   -lcalo_util  \
   -lphparameter

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
@@ -6,6 +6,9 @@
 #include "BEmcRecEEMC.h"
 #include "BEmcRecFEMC.h"
 
+#include <g4vertex/GlobalVertex.h>
+#include <g4vertex/GlobalVertexMap.h>
+
 #include <calobase/RawCluster.h>
 #include <calobase/RawClusterContainer.h>
 #include <calobase/RawClusterv1.h>
@@ -50,6 +53,7 @@ RawClusterBuilderTemplate::RawClusterBuilderTemplate(const std::string &name)
   , BINY0(0)
   , NBINY(0)
   , bPrintGeom(false)
+  , bProfProb(false)
 {
 }
 
@@ -85,10 +89,10 @@ void RawClusterBuilderTemplate::Detector(const std::string &d)
     bemc = new BEmcRec();
   }
 
-  // Define vertex ... not used now
+  // Set vertex
   float vertex[3] = {0, 0, 0};
   bemc->SetVertex(vertex);
-  // Define threshold ... not used now
+  // Set threshold
   bemc->SetTowerThreshold(0);
 }
 
@@ -262,6 +266,30 @@ int RawClusterBuilderTemplate::process_event(PHCompositeNode *topNode)
     cout << PHWHERE << ": Could not find node " << towergeomnodename << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
+
+  // Get vertex
+  float vx = 0;
+  float vy = 0;
+  float vz = 0;
+  GlobalVertexMap* vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");  
+  if (vertexmap)
+  {
+    if (!vertexmap->empty())
+    {
+      GlobalVertex* vertex = (vertexmap->begin()->second);
+      vx = vertex->get_x();
+      vy = vertex->get_y();
+      vz = vertex->get_z();
+    }
+  }
+
+  // Set vertex
+  float vertex[3] = {vx, vy, vz};
+  bemc->SetVertex(vertex);
+  // Set threshold
+  bemc->SetTowerThreshold(_min_tower_e);
+
+  bemc->SetProfileProb(bProfProb);
 
   // _clusters->Reset(); // !!! Not sure if it is necessarry to do it - ask Chris
 

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
@@ -200,7 +200,6 @@ int RawClusterBuilderTemplate::InitRun(PHCompositeNode *topNode)
     ix -= BINX0;
     iy -= BINY0;
     bemc->SetTowerGeometry(ix, iy, towerg->get_center_x(), towerg->get_center_y(), towerg->get_center_z());
-    //    }
   }
 
   if (!bemc->CompleteTowerGeometry()) return Fun4AllReturnCodes::ABORTEVENT;

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.h
@@ -24,6 +24,7 @@ class RawClusterBuilderTemplate : public SubsysReco
   void SetPlanarGeometry();
   void PrintGeometry() { bPrintGeom = true; }  // Prints it at InitRun time
   void PrintCylGeom(RawTowerGeomContainer* towergeom, const std::string& fname);
+  void SetProfileProb(bool pprob) { bProfProb = pprob; }
 
   void set_threshold_energy(const float e) { _min_tower_e = e; }
   void setEnergyNorm(float norm) { fEnergyNorm = norm; }
@@ -52,6 +53,7 @@ class RawClusterBuilderTemplate : public SubsysReco
   int NBINY;
 
   bool bPrintGeom;
+  bool bProfProb;
 };
 
 #endif /* RawClusterBuilderTemplate_H__ */


### PR DESCRIPTION
Modifications to RawClusterBuilderTemplate framework which should not change anything in clustering itself, and will slightly change the output value of "prob" parameter: 
1. RawClusterBuilderTemplate.h,cc: Get collision vertex from g4vertex/GlobalVertex and pass it to clustering (output cluster "prob" parameter is affected); reserve a switch to alternative way for shower profile prediction (for future use)
2. BEmcProfile.h,cc: Introduce an alternative way for shower profile prediction (for future use)
3. BEmcRec{CEMC,EEMC,FEMC}.h,cc: some restructuring between base class and inherited classes; reserve a switch to alternative way for shower profile prediction (for future use)
4. BEmcCluster.cc: Minor modification to be aligned with modifications in BEmcRec (more parameters in BEmcRec::PredictEnergy(...))   
