### PR TITLE
Add Acts TGeo Response File

### DIFF
--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -120,6 +120,10 @@ ACTS_SOURCES = \
   PHActsTrkProp.cc \
   PHActsTrkFitter.cc
 
+$OFFLINE_MAIN/share:
+dist_data_DATA = \
+  tgeo-sphenix.response
+
 AM_CPPFLAGS += -I$(OFFLINE_MAIN)/include/ActsFatras
 
 ACTS_LIBS = \


### PR DESCRIPTION
This PR adds the Acts TGeo response file into the Makefile so that it is installed into `$OFFLINE_MAIN/share` for access by the Fun4All macros.