### PR TITLE
Fix bug when propagating embed id to merged Hijing events

### DIFF
--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -812,7 +812,7 @@ void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNo
 
     // shift vertex time and store new embed id
     newevent->moveVertex( 0, 0, 0, delta_t );
-    new_embed_id = genevent->get_embedding_id();
+    new_embed_id = newevent->get_embedding_id();
   }
 
   // copy truth container


### PR DESCRIPTION
argh ...
Get new embeded id from new event rather than old one. 
This ensures that the right embedding id is stored in the truth info map
