### PR TITLE
Acts vertex fitting

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -1005,7 +1005,7 @@ int ActsEvaluator::getNodes(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  m_actsFitResults = findNode::getClass<std::map<const unsigned int, Trajectory>>(topNode, "ActsFitResults");
+  m_actsFitResults = findNode::getClass<std::map<const unsigned int, Trajectory>>(topNode, "ActsTrajectories");
 
   if (!m_actsFitResults)
   {

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = \
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  -L$(OFFLINE_MAIN)/lib64
+  -L$(MYINSTALL)/lib64
 
 pkginclude_HEADERS = \
   ActsCovarianceRotater.h \

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = \
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  -L$(MYINSTALL)/lib64
+  -L$(OFFLINE_MAIN)/lib64
 
 pkginclude_HEADERS = \
   ActsCovarianceRotater.h \

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -42,6 +42,7 @@ pkginclude_HEADERS = \
   PHActsTracks.h \
   PHActsTrkProp.h \
   PHActsTrkFitter.h \
+  PHActsVertexFitter.h \
   PHGenFitTrkProp.h \
   PHHoughSeeding.h \
   PHRTreeSeeding.h \
@@ -118,7 +119,8 @@ ACTS_SOURCES = \
   PHActsSourceLinks.cc \
   PHActsTracks.cc \
   PHActsTrkProp.cc \
-  PHActsTrkFitter.cc
+  PHActsTrkFitter.cc \
+  PHActsVertexFitter.cc
 
 AM_CPPFLAGS += -I$(OFFLINE_MAIN)/include/ActsFatras
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -535,7 +535,7 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
 			  Trajectory>> *fitNode = 
 		 new PHDataNode<std::map<const unsigned int, 
 				    Trajectory>>
-		 (m_actsFitResults, "ActsFitResults");
+		 (m_actsFitResults, "ActsTrajectories");
 
       svtxNode->addNode(fitNode);
       

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -39,6 +39,7 @@
 #include <iostream>
 #include <vector>
 #include <chrono>
+
 using namespace std::chrono;
 
 PHActsTrkFitter::PHActsTrkFitter(const std::string& name)

--- a/offline/packages/trackreco/PHActsVertexFitter.cc
+++ b/offline/packages/trackreco/PHActsVertexFitter.cc
@@ -57,8 +57,8 @@ int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
 {
 
 
-  std::vector<Acts::BoundParameters> tracks =
-    getTracks();
+  std::vector<const Acts::BoundParameters*> tracks = getTracks();
+
 
   /// Determine the input mag field type from the initial geometry created in
   /// MakeActsGeometry
@@ -82,11 +82,17 @@ int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
       
       typename VertexFitter::Config vertexFitterCfg;
       VertexFitter fitter(vertexFitterCfg);
-      //VertexFitter::State(state(m_tGeometry->magFieldContext));
-      /*
-      Linearizer::Config linConfig(bField, propagator);
+      typename VertexFitter::State state(m_tGeometry->magFieldContext);
+      
+      typename Linearizer::Config linConfig(bField, propagator);
       Linearizer linearizer(linConfig);
-      */
+
+      VertexFitterOptions vfOptions(m_tGeometry->geoContext,
+				    m_tGeometry->magFieldContext);
+
+      auto fitRes = fitter.fit(tracks,linearizer,
+      		       vfOptions, state);
+      
     }
     , m_tGeometry->magField
     );
@@ -95,10 +101,11 @@ int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
 }
 
 
-std::vector<Acts::BoundParameters> PHActsVertexFitter::getTracks()
+std::vector<const Acts::BoundParameters*> PHActsVertexFitter::getTracks()
 {
+ 
+  std::vector<const Acts::BoundParameters*> trackPtrs;
 
-  std::vector<Acts::BoundParameters> tracks;
   std::map<const unsigned int, Trajectory>::iterator trackIter;
 
   for (trackIter = m_actsFitResults->begin();
@@ -114,13 +121,13 @@ std::vector<Acts::BoundParameters> PHActsVertexFitter::getTracks()
       {
 	if(traj.hasTrackParameters(trackTip))
 	  {
-	    tracks.push_back(traj.trackParameters(trackTip));
+	    trackPtrs.push_back(&traj.trackParameters(trackTip));
 	  }
 
       }
   }
 
-  return tracks;
+  return trackPtrs;
 
 }
 

--- a/offline/packages/trackreco/PHActsVertexFitter.cc
+++ b/offline/packages/trackreco/PHActsVertexFitter.cc
@@ -36,6 +36,7 @@
 
 PHActsVertexFitter::PHActsVertexFitter(const std::string& name) 
 : SubsysReco(name)
+  , m_actsFitResults(nullptr)
   , m_event(0)
 {
 }

--- a/offline/packages/trackreco/PHActsVertexFitter.cc
+++ b/offline/packages/trackreco/PHActsVertexFitter.cc
@@ -38,6 +38,7 @@ PHActsVertexFitter::PHActsVertexFitter(const std::string& name)
 : SubsysReco(name)
   , m_actsFitResults(nullptr)
   , m_event(0)
+  , m_tGeometry(nullptr)
 {
 }
 

--- a/offline/packages/trackreco/PHActsVertexFitter.cc
+++ b/offline/packages/trackreco/PHActsVertexFitter.cc
@@ -1,0 +1,76 @@
+
+
+
+#include "PHActsVertexFitter.h"
+
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHObject.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+/// Tracking includes
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxVertexMap.h>
+#include <trackbase_historic/SvtxVertex.h>
+
+#include "Acts/MagneticField/ConstantBField.hpp"
+#include "Acts/MagneticField/InterpolatedBFieldMap.hpp"
+#include "Acts/MagneticField/SharedBField.hpp"
+
+#include <iostream>
+
+PHActsVertexFitter::PHActsVertexFitter()
+{
+
+}
+
+
+int PHActsVertexFitter::Init(PHCompositeNode *topNode)
+{
+  if(getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+    return Fun4AllReturnCodes::ABORTRUN;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHActsVertexFitter::End(PHCompositeNode *topNode)
+{
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
+{
+  
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+int PHActsVertexFitter::getNodes(PHCompositeNode *topNode)
+{
+
+  m_svtxTrackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  
+  if(!m_svtxTrackMap)
+    {
+      std::cout << PHWHERE << "Unable to find SvtxTrackMap. Exiting." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+      
+    }
+
+  m_tGeometry = findNode::getClass<ActsTrackingGeometry>(topNode, "ActsTrackingGeometry");
+  if(!m_tGeometry)
+    {
+      std::cout << PHWHERE << "ActsTrackingGeometry not on node tree. Exiting"
+		<< std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+
+}

--- a/offline/packages/trackreco/PHActsVertexFitter.cc
+++ b/offline/packages/trackreco/PHActsVertexFitter.cc
@@ -17,9 +17,21 @@
 #include <trackbase_historic/SvtxVertexMap.h>
 #include <trackbase_historic/SvtxVertex.h>
 
-#include "Acts/MagneticField/ConstantBField.hpp"
-#include "Acts/MagneticField/InterpolatedBFieldMap.hpp"
-#include "Acts/MagneticField/SharedBField.hpp"
+#include <Acts/MagneticField/ConstantBField.hpp>
+#include <Acts/MagneticField/InterpolatedBFieldMap.hpp>
+#include <Acts/MagneticField/SharedBField.hpp>
+#include <Acts/EventData/TrackParameters.hpp>
+#include <Acts/MagneticField/ConstantBField.hpp>
+#include <Acts/Propagator/EigenStepper.hpp>
+#include <Acts/Propagator/Propagator.hpp>
+#include <Acts/Surfaces/PerigeeSurface.hpp>
+#include <Acts/Utilities/Definitions.hpp>
+#include <Acts/Utilities/Helpers.hpp>
+#include <Acts/Vertexing/FullBilloirVertexFitter.hpp>
+#include <Acts/Vertexing/HelicalTrackLinearizer.hpp>
+#include <Acts/Vertexing/LinearizedTrack.hpp>
+#include <Acts/Vertexing/Vertex.hpp>
+#include <Acts/Vertexing/VertexingOptions.hpp>
 
 #include <iostream>
 
@@ -45,7 +57,18 @@ int PHActsVertexFitter::End(PHCompositeNode *topNode)
 
 int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
 {
-  
+
+  /// Determine the input mag field type from the initial geometry created in
+  /// MakeActsGeometry
+  std::visit([](auto&& inputField) {
+      using InputMagneticField = typename std::decay_t<decltype(inputField)>::element_type;
+      using MagneticField = Acts::SharedBField<InputMagneticField>;
+      MagneticField bField(std::move(inputField));
+    }
+    , m_tGeometry->magField
+    );
+
+  //using Stepper = Acts::EigenStepper<MagneticField>;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHActsVertexFitter.h
+++ b/offline/packages/trackreco/PHActsVertexFitter.h
@@ -4,11 +4,18 @@
 #include <fun4all/SubsysReco.h>
 #include "PHActsSourceLinks.h"
 
+#include <ACTFW/EventData/TrkrClusterMultiTrajectory.hpp>
+
 class PHCompositeNode;
 class SvtxTrack;
 class SvtxTrackMap;
 
+namespace Acts
+{
+class TrackParameters;
+}
 
+using Trajectory = FW::TrkrClusterMultiTrajectory;
 
 class PHActsVertexFitter : public SubsysReco
 {
@@ -23,8 +30,9 @@ class PHActsVertexFitter : public SubsysReco
  private:
 
   int getNodes(PHCompositeNode *topNode);
-  
-  SvtxTrackMap *m_svtxTrackMap;
+std::vector<Acts::BoundParameters> getTracks();  
+  std::map<const unsigned int, Trajectory> *m_actsFitResults;
+
   ActsTrackingGeometry *m_tGeometry;
 };
 

--- a/offline/packages/trackreco/PHActsVertexFitter.h
+++ b/offline/packages/trackreco/PHActsVertexFitter.h
@@ -20,7 +20,7 @@ using Trajectory = FW::TrkrClusterMultiTrajectory;
 class PHActsVertexFitter : public SubsysReco
 {
  public:
-  PHActsVertexFitter();
+  PHActsVertexFitter(const std::string& name = "PHActsVertexFitter");
   virtual ~PHActsVertexFitter(){}
   int process_event(PHCompositeNode *topNode);
   int Init(PHCompositeNode *topNode);
@@ -28,11 +28,12 @@ class PHActsVertexFitter : public SubsysReco
 
 
  private:
-
+  
   int getNodes(PHCompositeNode *topNode);
   std::vector<const Acts::BoundParameters*> getTracks();  
   std::map<const unsigned int, Trajectory> *m_actsFitResults;
 
+  int m_event;
   ActsTrackingGeometry *m_tGeometry;
 };
 

--- a/offline/packages/trackreco/PHActsVertexFitter.h
+++ b/offline/packages/trackreco/PHActsVertexFitter.h
@@ -1,0 +1,31 @@
+#ifndef TRACKRECO_PHACTSVERTEXFITTER_H
+#define TRACKRECO_PHACTSVERTEXFITTER_H
+
+#include <fun4all/SubsysReco.h>
+#include "PHActsSourceLinks.h"
+
+class PHCompositeNode;
+class SvtxTrack;
+class SvtxTrackMap;
+
+
+
+class PHActsVertexFitter : public SubsysReco
+{
+ public:
+  PHActsVertexFitter();
+  virtual ~PHActsVertexFitter(){}
+  int process_event(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode);
+  int End (PHCompositeNode *topNode);
+
+
+ private:
+
+  int getNodes(PHCompositeNode *topNode);
+  
+  SvtxTrackMap *m_svtxTrackMap;
+  ActsTrackingGeometry *m_tGeometry;
+};
+
+#endif //TRACKRECO_PHACTSVERTEXFITTER_H 

--- a/offline/packages/trackreco/PHActsVertexFitter.h
+++ b/offline/packages/trackreco/PHActsVertexFitter.h
@@ -30,7 +30,7 @@ class PHActsVertexFitter : public SubsysReco
  private:
 
   int getNodes(PHCompositeNode *topNode);
-std::vector<Acts::BoundParameters> getTracks();  
+  std::vector<const Acts::BoundParameters*> getTracks();  
   std::map<const unsigned int, Trajectory> *m_actsFitResults;
 
   ActsTrackingGeometry *m_tGeometry;


### PR DESCRIPTION
This PR introduces a final acts vertex fitting module. Provided a list of tracks, the vertex fitter will return a single fitted vertex. No analysis has been performed to determine how good the vertex fit actually is, given the input tracks.