### PR TITLE
Track efficiency

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -763,6 +763,7 @@ void ActsEvaluator::fillProtoTrack(ActsTrack track, PHCompositeNode *topNode)
 
   if(Verbosity() > 2)
     std::cout << "Filling proto track seed quantities" << std::endl;
+  
   FW::TrackParameters params = track.getTrackParams();
   std::vector<SourceLink> sourceLinks = track.getSourceLinks();
   
@@ -774,6 +775,14 @@ void ActsEvaluator::fillProtoTrack(ActsTrack track, PHCompositeNode *topNode)
   m_protoTrackX  = position(0);
   m_protoTrackY  = position(1);
   m_protoTrackZ  = position(2);
+
+  auto cov = params.covariance().value();
+  m_protoD0Cov = cov(0,0);
+  m_protoZ0Cov = cov(1,1);
+  m_protoPhiCov = cov(2,2);
+  m_protoThetaCov = cov(3,3);
+  m_protoQopCov = cov(4,4);
+  
 
   for(int i = 0; i < sourceLinks.size(); ++i)
     {
@@ -1229,7 +1238,11 @@ void ActsEvaluator::clearTrackVariables()
   m_protoTrackX  = -9999.;
   m_protoTrackY  = -9999.;
   m_protoTrackZ  = -9999.;
-
+  m_protoD0Cov   = -9999.;
+  m_protoZ0Cov   = -9999.;
+  m_protoPhiCov  = -9999.;
+  m_protoThetaCov= -9999.;
+  m_protoQopCov  = -9999.;
 
   return;
 }
@@ -1303,6 +1316,11 @@ void ActsEvaluator::initializeTree()
   m_trackTree->Branch("g_protoTrackX", &m_protoTrackX);
   m_trackTree->Branch("g_protoTrackY", &m_protoTrackY);
   m_trackTree->Branch("g_protoTrackZ", &m_protoTrackZ);
+  m_trackTree->Branch("g_protoTrackD0Cov", &m_protoD0Cov);
+  m_trackTree->Branch("g_protoTrackZ0Cov", &m_protoZ0Cov);
+  m_trackTree->Branch("g_protoTrackPhiCov", &m_protoPhiCov);
+  m_trackTree->Branch("g_protoTrackThetaCov", &m_protoThetaCov);
+  m_trackTree->Branch("g_protoTrackQopCov", &m_protoQopCov);
   m_trackTree->Branch("g_SLx", &m_SLx);
   m_trackTree->Branch("g_SLy", &m_SLy);
   m_trackTree->Branch("g_SLz", &m_SLz);

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -297,6 +297,12 @@ class ActsEvaluator : public SubsysReco
   float m_protoTrackX{-9999.};           /// Proto track PCA x
   float m_protoTrackY{-9999.};           /// Proto track PCA y
   float m_protoTrackZ{-9999.};           /// Proto track PCA z
+  float m_protoD0Cov{-9999.};            /// Proto track loc0 covariance
+  float m_protoZ0Cov{-9999.};            /// Proto track loc1 covariance
+  float m_protoPhiCov{-9999.};           /// Proto track phi covariance
+  float m_protoThetaCov{-9999.};         /// Proto track theta covariance
+  float m_protoQopCov{-9999.};           /// Proto track q/p covariance
+  
   
   std::vector<float> m_SL_lx;            /// Proto track source link local x pos
   std::vector<float> m_SL_ly;            /// Proto track source link local y pos

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -70,8 +70,11 @@ class PHActsTrkFitter : public PHTrackFitting
 
   void setTimeAnalysis(bool time){m_timeAnalysis = time;}
 
+  void setMomentumCovariance(float cov){m_momCov = cov;}
+
  private:
 
+  float m_momCov;
 
   /// Reset the SvtxTrack states with the new track fit states
   void fillSvtxTrackStates(const Trajectory traj, 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -70,11 +70,7 @@ class PHActsTrkFitter : public PHTrackFitting
 
   void setTimeAnalysis(bool time){m_timeAnalysis = time;}
 
-  void setMomentumCovariance(float cov){m_momCov = cov;}
-
  private:
-
-  float m_momCov;
 
   /// Reset the SvtxTrack states with the new track fit states
   void fillSvtxTrackStates(const Trajectory traj, 


### PR DESCRIPTION
This PR improves the tracking efficiency at high pT by resetting the covariance matrix before it goes into the Acts KF. Acts (evidently) relies heavily on the covariance being something that is large enough that it has room to work within but also small enough such that it can actually find the propagation steps. 

Previously the covariance was too large and thus at high pT Acts would quit the propagation after a couple of steps as it had too much room to work within. This PR sets the covariance to almost the same value used in the Acts unit tests, and it improves the fit quality and the tracking efficiency at high pT substantially (previously the track efficiency would drop to ~70% at high pT, see here 
[ptEff.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5069951/ptEff.pdf) as an example). Some QA plots for future reference, made with 100 muon events in full azimuth/eta:

[dcarphiwidth.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5069925/dcarphiwidth.pdf)
[dcazwidth.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5069926/dcazwidth.pdf)
[eff.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5069927/eff.pdf)
[h_dcarphi.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5069928/h_dcarphi.pdf)
[h_dcaz.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5069929/h_dcaz.pdf)
[h_ptpt.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5069930/h_ptpt.pdf)
[ptres.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5069931/ptres.pdf)

