### PR TITLE
CKF Updates

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -117,7 +117,8 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
     Trajectory traj = trajIter->second;
 
     if(Verbosity() > 2)
-      std::cout << "Starting trajectory " << iTraj << "with trackKey "
+      std::cout << "Starting trajectory " << iTraj 
+		<< "with trackKey corresponding to track seed "
 		<< trackKey << std::endl;
 
     const auto &[trackTips, mj] = traj.trajectory();
@@ -157,6 +158,11 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
 	      }
 	    trackKey = m_actsTrackKeyMap->find(trackTip)->second;
 	  }
+
+	if(Verbosity() > 2)
+	  std::cout<<"Evaluating track key " << trackKey 
+		   << " for track tip " << trackTip << std::endl;
+
 	SvtxTrack *track = m_trackMap->find(trackKey)->second;
 	PHG4Particle *g4particle = trackeval->max_truth_particle_by_nclusters(track);
 	const unsigned int vertexId = track->get_vertex_id();

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -206,6 +206,8 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
 	
 	m_nMeasurements = trajState.nMeasurements;
 	m_nStates = trajState.nStates;
+	m_nOutliers = trajState.nOutliers;
+	m_nHoles = trajState.nHoles;
 	m_chi2_fit = trajState.chi2Sum;
 	m_ndf_fit = trajState.NDF;
 	
@@ -576,6 +578,7 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
       m_pT_flt.push_back(parameter.pT());
       m_eta_flt.push_back(eta(parameter.position()));
       m_chi2.push_back(state.chi2());
+      
     }
     else
     {
@@ -1375,6 +1378,8 @@ void ActsEvaluator::initializeTree()
   m_trackTree->Branch("t_SL_gy", &m_t_SL_gy);
   m_trackTree->Branch("t_SL_gz", &m_t_SL_gz);
 
+  m_trackTree->Branch("nHoles", &m_nHoles);
+  m_trackTree->Branch("nOutliers", &m_nOutliers);
   m_trackTree->Branch("nStates", &m_nStates);
   m_trackTree->Branch("nMeasurements", &m_nMeasurements);
   m_trackTree->Branch("volume_id", &m_volumeID);

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -118,7 +118,7 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
 
     if(Verbosity() > 2)
       std::cout << "Starting trajectory " << iTraj 
-		<< "with trackKey corresponding to track seed "
+		<< " with trackKey corresponding to track seed "
 		<< trackKey << std::endl;
 
     const auto &[trackTips, mj] = traj.trajectory();
@@ -183,7 +183,7 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
 	  }
 	
 	m_trackNr = iTrack;
-        iTrack++;
+  
 	
 	auto trajState =
 	  Acts::MultiTrajectoryHelpers::trajectoryState(mj, trackTip);
@@ -217,6 +217,8 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
 	clearTrackVariables();
 	if(Verbosity() > 1)
 	  std::cout << "Finished track " << iTrack <<std::endl;
+
+	iTrack++;
       }
     
     ++iTraj;

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -44,6 +44,7 @@ ActsEvaluator::ActsEvaluator(const std::string &name,
   , m_actsProtoTrackMap(nullptr)
   , m_tGeometry(nullptr)
   , m_vertexMap(nullptr)
+  , m_evalCKF(false)
 {
 }
 
@@ -128,8 +129,17 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
    
     iTrack = 0;
     /// For the KF this iterates once. For the CKF it may iterate several times
+    std::cout<<"Track key going in ActsEvaluator" << trackKey<<std::endl;
     for(const size_t &trackTip : trackTips)
       {
+
+	/// The CKF has a trackTip == trackKey correspondence, rather
+	/// than a trajectory == trackKey correspondence. So need to
+	/// grab the correct key from the map
+	if(m_evalCKF)
+	  trackKey = m_actsTrackKeyMap->find(trackTip)->second;
+
+	std::cout<<"Track key for track tip " << trackKey << "   "<<trackTip<<std::endl;
 	SvtxTrackMap::Iter svtxTrackIter = m_trackMap->find(trackKey);
 	SvtxTrack *track = svtxTrackIter->second;
 	PHG4Particle *g4particle = trackeval->max_truth_particle_by_nclusters(track);

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -147,11 +147,18 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
 	/// than a trajectory == trackKey correspondence. So need to
 	/// grab the correct key from the extra map
 	if(m_evalCKF)
-	  trackKey = m_actsTrackKeyMap->find(trackTip)->second;
-
+	  {
+	    std::map<const size_t, const unsigned int>::iterator ckfiter = m_actsTrackKeyMap->find(trackTip);
+	    if(ckfiter == m_actsTrackKeyMap->end())
+	      {
+		std::cout << "Couldn't find track tip, continuing"
+			  << std::endl;
+		continue;
+	      }
+	    trackKey = m_actsTrackKeyMap->find(trackTip)->second;
+	  }
 	SvtxTrack *track = m_trackMap->find(trackKey)->second;
 	PHG4Particle *g4particle = trackeval->max_truth_particle_by_nclusters(track);
-
 	const unsigned int vertexId = track->get_vertex_id();
 	const SvtxVertex *svtxVertex = m_vertexMap->get(vertexId);
 	Acts::Vector3D vertex;

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -58,6 +58,7 @@ class ActsEvaluator : public SubsysReco
   int process_event(PHCompositeNode *topNode);
   int ResetEvent(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
+  void setEvalCKF(bool evalCKF) {m_evalCKF = evalCKF;}
 
  private:
   int getNodes(PHCompositeNode *topNode);

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -94,7 +94,8 @@ class ActsEvaluator : public SubsysReco
   PHG4TruthInfoContainer *m_truthInfo{nullptr};
   SvtxTrackMap *m_trackMap{nullptr};
   SvtxEvalStack *m_svtxEvalStack{nullptr};
-  std::map<const size_t, const unsigned int> *m_actsTrackKeyMap{nullptr};
+  std::map<const unsigned int, std::map<const size_t, 
+    const unsigned int>> *m_actsTrackKeyMap{nullptr};
   std::map<const unsigned int, Trajectory> *m_actsFitResults{nullptr};
   std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey{nullptr};
   std::map<unsigned int, ActsTrack> *m_actsProtoTrackMap{nullptr};

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -147,6 +147,8 @@ class ActsEvaluator : public SubsysReco
   std::vector<float> m_t_eQOP;    /// truth parameter eQOP
   std::vector<float> m_t_eT;      /// truth parameter eT
 
+  int m_nHoles{0};                  /// number of holes in the track fit
+  int m_nOutliers{0};               /// number of outliers in the track fit
   int m_nStates{0};                 /// number of all states
   int m_nMeasurements{0};           /// number of states with measurements
   std::vector<int> m_volumeID;      /// volume identifier

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -100,6 +100,11 @@ class ActsEvaluator : public SubsysReco
   ActsTrackingGeometry *m_tGeometry{nullptr};
   SvtxVertexMap *m_vertexMap;
 
+  /// boolean indicating whether or not to evaluate the CKF or
+  /// the KF. Must correspond with what was run to do fitting
+  /// i.e. PHActsTrkFitter or PHActsTrkProp
+  bool m_evalCKF;
+
   TFile *m_trackFile{nullptr};
   TTree *m_trackTree{nullptr};
 

--- a/offline/packages/trackreco/ActsTransformations.cc
+++ b/offline/packages/trackreco/ActsTransformations.cc
@@ -1,5 +1,5 @@
 #include "ActsTransformations.h"
-
+#include <trackbase_historic/SvtxTrackState_v1.h>
 
 Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs(
 	             const SvtxTrack *track)
@@ -245,4 +245,110 @@ void ActsTransformations::calculateDCA(const Acts::BoundParameters param,
   dca3DxyCov = rotCov(0,0);
   dca3DzCov = rotCov(2,2);
   
+}
+
+
+
+void ActsTransformations::fillSvtxTrackStates(const Trajectory traj,
+					      const size_t &trackTip,
+					      SvtxTrack *svtxTrack,
+					      Acts::GeometryContext geoContext,
+					      std::map<TrkrDefs::cluskey, unsigned int> *hitIDCluskeyMap)
+{
+
+ const auto &[trackTips, mj] = traj.trajectory();
+  
+  mj.visitBackwards(trackTip, [&](const auto &state) {
+      /// Only fill the track states with non-outlier measurement
+      auto typeFlags = state.typeFlags();
+      if (not typeFlags.test(Acts::TrackStateFlag::MeasurementFlag))
+	{
+	  return true;
+	}
+      
+      auto meas = std::get<Measurement>(*state.uncalibrated());
+
+      /// Get local position
+      Acts::Vector2D local(meas.parameters()[Acts::ParDef::eLOC_0],
+			   meas.parameters()[Acts::ParDef::eLOC_1]);
+      /// Get global position
+      Acts::Vector3D global(0., 0., 0.);
+      /// This is an arbitrary vector. Doesn't matter in coordinate transformation
+      /// in Acts code
+      Acts::Vector3D mom(1., 1., 1.);
+      meas.referenceObject().localToGlobal(geoContext,
+					    local, mom, global);
+      
+      float pathlength = state.pathLength() / Acts::UnitConstants::cm;  
+      SvtxTrackState_v1 out( pathlength );
+      out.set_x(global.x() / Acts::UnitConstants::cm);
+      out.set_y(global.y() / Acts::UnitConstants::cm);
+      out.set_z(global.z() / Acts::UnitConstants::cm);
+    
+      if (state.hasSmoothed())
+	{
+	  Acts::BoundParameters parameter(geoContext,
+					  state.smoothedCovariance(), state.smoothed(),
+					  state.referenceSurface().getSharedPtr());
+	  
+	  out.set_px(parameter.momentum().x());
+	  out.set_py(parameter.momentum().y());
+	  out.set_pz(parameter.momentum().z());
+
+	  /// Get measurement covariance    
+
+	  Acts::BoundSymMatrix globalCov = rotateActsCovToSvtxTrack(parameter);
+	  for (int i = 0; i < 6; i++)
+	    {
+	      for (int j = 0; j < 6; j++)
+		{ 
+		  out.set_error(i, j, globalCov(i,j)); 
+		}
+	    }
+	  	  
+	  const unsigned int hitId = state.uncalibrated().hitID();
+	  TrkrDefs::cluskey cluskey = getClusKey(hitId, hitIDCluskeyMap);
+	  svtxTrack->insert_cluster_key(cluskey);
+	  
+	  if(m_verbosity > 2)
+	    {
+	      std::cout << " inserting state with x,y,z = " << global.x() /  Acts::UnitConstants::cm 
+			<< "  " << global.y() /  Acts::UnitConstants::cm << "  " 
+			<< global.z() /  Acts::UnitConstants::cm 
+			<< " pathlength " << pathlength
+			<< " momentum px,py,pz = " <<  parameter.momentum().x() << "  " <<  parameter.momentum().y() << "  " << parameter.momentum().y()  
+			<< " cluskey " << cluskey << std::endl
+			<< "covariance " << globalCov << std::endl; 
+	    }
+	  
+	  svtxTrack->insert_state(&out);      
+	}
+  
+      return true;      
+    }
+    );
+
+  return;
+}
+
+TrkrDefs::cluskey ActsTransformations::getClusKey(const unsigned int hitID,
+						  std::map<TrkrDefs::cluskey, unsigned int> *hitIDCluskeyMap)
+{
+  TrkrDefs::cluskey clusKey = 0;
+  /// Unfortunately the map is backwards for looking up cluster key from
+  /// hit ID. So we need to iterate over it. There won't be duplicates since
+  /// the cluster key and hit id are a one-to-one map
+  std::map<TrkrDefs::cluskey, unsigned int>::iterator
+      hitIter = hitIDCluskeyMap->begin();
+  while (hitIter != hitIDCluskeyMap->end())
+  {
+    if (hitIter->second == hitID)
+    {
+      clusKey = hitIter->first;
+      break;
+    }
+    ++hitIter;
+  }
+
+  return clusKey;
 }

--- a/offline/packages/trackreco/ActsTransformations.cc
+++ b/offline/packages/trackreco/ActsTransformations.cc
@@ -176,7 +176,7 @@ void ActsTransformations::printMatrix(const std::string &message,
 					Acts::BoundSymMatrix matrix)
 {
  
-  if(m_verbosity > 0)
+  if(m_verbosity > 10)
     {
       std::cout << std::endl << message.c_str() << std::endl;
       for(int i = 0 ; i < matrix.rows(); ++i)

--- a/offline/packages/trackreco/ActsTransformations.h
+++ b/offline/packages/trackreco/ActsTransformations.h
@@ -1,6 +1,8 @@
 #ifndef TRACKRECO_ACTSTRANSFORMATIONS_H
 #define TRACKRECO_ACTSTRANSFORMATIONS_H
 
+#include <trackbase/TrkrDefs.h>
+
 /// Acts includes to create all necessary definitions
 #include <Acts/Utilities/BinnedArray.hpp>
 #include <Acts/Utilities/Definitions.hpp>
@@ -10,6 +12,7 @@
 
 #include <ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp>
 #include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
+#include <ACTFW/EventData/TrkrClusterMultiTrajectory.hpp>
 
 /// std (and the like) includes
 #include <cmath>
@@ -19,6 +22,11 @@
 
 using SourceLink = FW::Data::TrkrClusterSourceLink;
 
+using Trajectory = FW::TrkrClusterMultiTrajectory;
+using Measurement = Acts::Measurement<FW::Data::TrkrClusterSourceLink,
+                                      Acts::BoundParametersIndices,
+                                      Acts::ParDef::eLOC_0,
+                                      Acts::ParDef::eLOC_1>;
 
 /**
  * This is a helper class for rotating track covariance matrices to and from
@@ -57,8 +65,18 @@ class ActsTransformations
 		    float &dca3DxyCov,
 		    float &dca3DzCov);
 
+  void fillSvtxTrackStates(const Trajectory traj, 
+			   const size_t &trackTip,
+			   SvtxTrack *svtxTrack,
+			   Acts::GeometryContext geoContext,
+			   std::map<TrkrDefs::cluskey, unsigned int> *hitIDCluskeyMap);
+
  private:
   int m_verbosity;
+
+  /// Get the cluster key for the corresponding hitID from the map 
+  TrkrDefs::cluskey getClusKey(const unsigned int hitID, 
+			       std::map<TrkrDefs::cluskey, unsigned int> *hitIDCluskeyMap);
 
 
 };

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -47,7 +47,6 @@ PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   , m_event(0)
   , m_actsFitResults(nullptr)
   , m_actsProtoTracks(nullptr)
-  , m_actsTrackKeyMap(nullptr)
   , m_tGeometry(nullptr)
   , m_trackMap(nullptr)
   , m_hitIdClusKey(nullptr)
@@ -257,7 +256,6 @@ int PHActsTrkFitter::ResetEvent(PHCompositeNode *topNode)
 {
 
   m_actsFitResults->clear();
-  m_actsTrackKeyMap->clear();
 
   if(Verbosity() > 1)
     {
@@ -293,9 +291,6 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
   const auto &[trackTips, mj] = traj.trajectory();
   /// only one track tip in the track fit Trajectory
   auto &trackTip = trackTips.front();
-
-  m_actsTrackKeyMap->insert(std::pair<const size_t, const unsigned int>
-			    (trackTip, trackKey));
 
   SvtxTrackMap::Iter trackIter = m_trackMap->find(trackKey);
   SvtxTrack *track = trackIter->second;
@@ -526,15 +521,6 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
       
     }
 
-  m_actsTrackKeyMap = findNode::getClass<std::map<const size_t, const unsigned int>>(topNode, "ActsTrackKeys");
-  if(!m_actsTrackKeyMap)
-    {
-      m_actsTrackKeyMap = new std::map<const size_t, const unsigned int>;
-      PHDataNode<std::map<const size_t, const unsigned int>> *fitNode = 
-	new PHDataNode<std::map<const size_t, const unsigned int>>(m_actsTrackKeyMap, "ActsTrackKeys");
-      svtxNode->addNode(fitNode);
-    }
-  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -240,7 +240,7 @@ int PHActsTrkFitter::Process()
   }
 
   auto stopTime = high_resolution_clock::now();
-  auto eventTime = duration_cast<milliseconds>(stopTime - startTime);
+  auto eventTime = duration_cast<microseconds>(stopTime - startTime);
 
   if(m_timeAnalysis)
     h_eventTime->Fill(eventTime.count());

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -100,10 +100,6 @@ class PHActsTrkFitter : public PHTrackFitting
   /// Map of acts tracks and track key created by PHActsTracks
   std::map<unsigned int, ActsTrack>* m_actsProtoTracks;
 
-  /// Map that correlates track key with track tip for ActsEvaluator
-  std::map<const size_t, const unsigned int> *m_actsTrackKeyMap;
-
-
   /// Options that Acts::Fitter needs to run from MakeActsGeometry
   ActsTrackingGeometry *m_tGeometry;
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -68,7 +68,7 @@ class PHActsTrkFitter : public PHTrackFitting
 
   int ResetEvent(PHCompositeNode *topNode);
 
-  void setTimeAnalysis(bool time){m_timeAnalysis = time;}
+  void doTimeAnalysis(bool timeAnalysis){m_timeAnalysis = timeAnalysis;}
 
  private:
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -72,14 +72,6 @@ class PHActsTrkFitter : public PHTrackFitting
 
  private:
 
-  /// Reset the SvtxTrack states with the new track fit states
-  void fillSvtxTrackStates(const Trajectory traj, 
-			   const size_t &trackTip,
-			   SvtxTrack *svtx_track);
-
-  /// Get the cluster key for the corresponding hitID from the map 
-  TrkrDefs::cluskey getClusKey(const unsigned int hitID);
-
   /// Event counter
   int m_event;
 

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -51,6 +51,7 @@
 PHActsTrkProp::PHActsTrkProp(const std::string& name)
   : PHTrackPropagating(name)
   , m_event(0)
+  , m_qopCov(0.01)
   , m_nBadFits(0)
   , m_tGeometry(nullptr)
   , m_trackMap(nullptr)
@@ -163,7 +164,7 @@ int PHActsTrkProp::Process()
                   0., 1000 * Acts::UnitConstants::um, 0., 0., 0., 0.,
                   0., 0., 0.05, 0., 0., 0.,
                   0., 0., 0., 0.05, 0., 0.,
-                  0., 0., 0., 0., 0.0001, 0.,
+                  0., 0., 0., 0., m_qopCov, 0.,
                   0., 0., 0., 0., 0., 1.;
     
     FW::TrackParameters trackSeedNewCov(covariance,

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -277,10 +277,6 @@ void PHActsTrkProp::updateSvtxTrack(Trajectory traj,
   /// the same track seed
   const unsigned int vertexId = origTrack->get_vertex_id();
   
-  /// Get the last track key so that we can add new tracks if needed
-
-  unsigned int lastTrackKey = m_trackMap->end()->first;
-  
   origTrack->Reset();
   
   /// This gets the track indexer and associated tracks 
@@ -378,20 +374,25 @@ void PHActsTrkProp::updateSvtxTrack(Trajectory traj,
 	  origTrack->set_dca3d_z(DCA3Dz / Acts::UnitConstants::cm);
 	  origTrack->set_dca3d_xy_error(DCA3DxyCov / Acts::UnitConstants::cm);
 	  origTrack->set_dca3d_z_error(DCA3DzCov / Acts::UnitConstants::cm);
-
+        
 	  m_actsTrackKeyMap->insert(std::pair<const size_t, const unsigned int>
 				    (trackTip,trackKey));
 	}
       else
 	{
+	  /// Get the last track key so that we can add new tracks if needed
+	  
+	  const unsigned int lastTrackKey = m_trackMap->end()->first + 1;
+
 	  /// Otherwise make a new track
 	  if(Verbosity() > 3)
-	    std::cout << "Creating new SvtxTrack with trackKey " << lastTrackKey++
+	    std::cout << "Creating new SvtxTrack with trackKey " << lastTrackKey
 		      << " corresponding to trackTip " << trackTip << std::endl;
 
+	
 	  SvtxTrack_v1 newTrack;
 	  /// Needs to be a new track id
-	  newTrack.set_id(lastTrackKey++);
+	  newTrack.set_id(lastTrackKey);
 	  newTrack.set_vertex_id(vertexId);
 	  newTrack.set_chisq(chi2sum);
 	  newTrack.set_ndf(NDF);
@@ -421,7 +422,7 @@ void PHActsTrkProp::updateSvtxTrack(Trajectory traj,
 	    }
 	  
 	  m_actsTrackKeyMap->insert(std::pair<const size_t, const unsigned int>
-				    (trackTip, lastTrackKey++));
+				    (trackTip, lastTrackKey));
 	  m_trackMap->insert(&newTrack);
 	}
       

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -47,6 +47,9 @@
 #include <iostream>
 #include <vector>
 #include <utility>
+#include <chrono>
+
+using namespace std::chrono;
 
 PHActsTrkProp::PHActsTrkProp(const std::string& name)
   : PHTrackPropagating(name)
@@ -136,7 +139,8 @@ std::vector<SourceLink> PHActsTrkProp::getEventSourceLinks()
 
 int PHActsTrkProp::Process()
 {
-
+  auto startTime = high_resolution_clock::now();
+  
   m_event++;
 
   if (Verbosity() > 0)
@@ -232,6 +236,9 @@ int PHActsTrkProp::Process()
 
   if(Verbosity() > 0)
     std::cout << "Finished process_event for PHActsTrkProp" << std::endl;
+
+  auto stopTime = high_resolution_clock::now();
+  auto eventTime = duration_cast<microseconds>(stopTime - startTime);
 
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -89,19 +89,26 @@ int PHActsTrkProp::Setup(PHCompositeNode* topNode)
   /// SLs to the track. The selections can be added like
   /// {makeId(volId, layerId), {maxChi2, numSourceLinks}}
   /// We'll just put the max chi2 to 10 
+
   m_sourceLinkSelectorConfig = {
     /// global default values
-    {makeId(), {10.0, 55}},
+    {makeId(), {100., 55}},
 
     /// MVTX volume should have max 3 SLs
-    {makeId(7), {10.0, 3}},
+    {makeId(7), {m_volMaxChi2.find(7)->second, 3}},
     
     /// INTT volume should have max 2 SLs
-    {makeId(9), {10.0, 2}},
+    {makeId(9), {m_volMaxChi2.find(9)->second, 2}},
     
     /// TPC volume should have max 50 (?) SLs
-    {makeId(11), {10.0,50}}
+    {makeId(11), {m_volMaxChi2.find(11)->second,50}}
   };
+
+  if(Verbosity() > 2)
+    std::cout << "Set measurement max chi 2 to :" << std::endl
+	      << "MVTX : " << m_volMaxChi2.find(7)->second << std::endl
+	      << "INTT : " << m_volMaxChi2.find(9)->second << std::endl
+	      << "TPC  : " << m_volMaxChi2.find(11)->second << std::endl;
 
   auto logger = Acts::Logging::INFO;
   if(Verbosity() > 5)
@@ -498,6 +505,10 @@ Acts::GeometryID PHActsTrkProp::makeId(int volume,
                            .setSensitive(sensitive);
 }
 
+void PHActsTrkProp::setVolumeMaxChi2(const int vol, const float maxChi2)
+{
+  m_volMaxChi2.insert(std::make_pair(vol, maxChi2));
+}
 
 void PHActsTrkProp::createNodes(PHCompositeNode* topNode)
 {

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -265,8 +265,6 @@ void PHActsTrkProp::updateSvtxTrack(Trajectory traj,
   ActsTransformations *rotater = new ActsTransformations();
   rotater->setVerbosity(0);
 
-  /// Iterate over the Trajectories and add them to the SvtxTrackMap
-  std::map<const unsigned int, Trajectory>::iterator trajIter;
   int iTrack = 0;
 
   /// There could be multiple tracks per trajectory found from the CKF

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -51,7 +51,6 @@
 PHActsTrkProp::PHActsTrkProp(const std::string& name)
   : PHTrackPropagating(name)
   , m_event(0)
-  , m_qopCov(0.01)
   , m_nBadFits(0)
   , m_tGeometry(nullptr)
   , m_trackMap(nullptr)
@@ -164,7 +163,7 @@ int PHActsTrkProp::Process()
                   0., 1000 * Acts::UnitConstants::um, 0., 0., 0., 0.,
                   0., 0., 0.05, 0., 0., 0.,
                   0., 0., 0., 0.05, 0., 0.,
-                  0., 0., 0., 0., m_qopCov, 0.,
+                  0., 0., 0., 0., 0.001, 0.,
                   0., 0., 0., 0., 0., 1.;
     
     FW::TrackParameters trackSeedNewCov(covariance,

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -83,9 +83,13 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Reset maps event by event
   int ResetEvent(PHCompositeNode *topNode);
 
+  void setQopCov(float qopCov){m_qopCov = qopCov;}
+
  private:
   /// Event counter
   int m_event;
+
+  float m_qopCov;
   
   /// Num bad fit counter
   int m_nBadFits;

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -102,7 +102,9 @@ class PHActsTrkProp : public PHTrackPropagating
 			  int sensitive = 0);
 
   /// Wipe and recreate the SvtxTrackMap with Acts output
-  void updateSvtxTrack(Trajectory traj, const unsigned int trackKey, Acts::Vector3D vertex);
+  void updateSvtxTrack(Trajectory traj, 
+		       const unsigned int trackKey, 
+		       Acts::Vector3D vertex);
 
   /// Get all source links in a given event
   std::vector<SourceLink> getEventSourceLinks();
@@ -119,7 +121,10 @@ class PHActsTrkProp : public PHTrackPropagating
   std::map<const unsigned int, Trajectory> *m_actsFitResults;
 
   /// Map that correlates track key with track tip for ActsEvaluator
-  std::map<const size_t, const unsigned int> *m_actsTrackKeyMap;
+  /// Identifiers are <TrajNum, <trackTip, SvtxTrackKey>> where 
+  /// TrajNum has a one-to-one map to the original seed SvtxTrackKey
+  std::map<const unsigned int, 
+    std::map<const size_t, const unsigned int>> *m_actsTrackKeyMap;
 
   /// Map of cluster keys to hit ids, for identifying clusters belonging to track
   std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey;

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -83,14 +83,10 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Reset maps event by event
   int ResetEvent(PHCompositeNode *topNode);
 
-  void setQopCov(float qopCov){m_qopCov = qopCov;}
-
  private:
   /// Event counter
   int m_event;
 
-  float m_qopCov;
-  
   /// Num bad fit counter
   int m_nBadFits;
 

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -88,14 +88,19 @@ class PHActsTrkProp : public PHTrackPropagating
 
   void doTimeAnalysis(bool timeAnalysis) { m_timeAnalysis = timeAnalysis;}
 
+  void setVolumeMaxChi2(const int vol, const float maxChi2);
+
  private:
   /// Event counter
   int m_event;
 
-  bool m_timeAnalysis;
-  
+  bool m_timeAnalysis; 
   TFile *m_timeFile;
   TH1 *h_eventTime;
+
+  /// Map to hold maximum allowable measurement chi2 in each
+  /// volume identifier in Acts
+  std::map<const int, const float> m_volMaxChi2;
 
   /// Num bad fit counter
   int m_nBadFits;

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -16,8 +16,7 @@
 
 #include <Acts/TrackFinder/CKFSourceLinkSelector.hpp>
 
-#include <Acts/Propagator/detail/SteppingLogger.hpp>
-#include <Acts/Propagator/MaterialInteractor.hpp>
+#include <Acts/EventData/MeasurementHelpers.hpp>
 
 #include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
 #include <ACTFW/EventData/Track.hpp>
@@ -57,6 +56,11 @@ using SourceLinkSelectorConfig = typename SourceLinkSelector::Config;
 
 using CKFFitResult = Acts::CombinatorialKalmanFilterResult<SourceLink>;
 using Trajectory = FW::TrkrClusterMultiTrajectory;
+
+using Measurement = Acts::Measurement<FW::Data::TrkrClusterSourceLink,
+                                      Acts::BoundParametersIndices,
+                                      Acts::ParDef::eLOC_0,
+                                      Acts::ParDef::eLOC_1>;
 
 class PHActsTrkProp : public PHTrackPropagating
 {
@@ -102,13 +106,6 @@ class PHActsTrkProp : public PHTrackPropagating
 
   /// Get all source links in a given event
   std::vector<SourceLink> getEventSourceLinks();
-
-  /// Iterate through the Trajectory to obtain the fitted clusters
-  void getTrackClusters(const size_t& trackTip, Trajectory traj,
-			SvtxTrack *track);
-
-  /// Return cluster key from hit ID as determined in map from PHActsSourceLinks
-  TrkrDefs::cluskey getClusKey(const unsigned int hitID);
 
   ActsTrackingGeometry *m_tGeometry;
 

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -34,6 +34,9 @@ class MakeActsGeometry;
 class SvtxTrack;
 class SvtxTrackMap;
 
+class TFile;
+class TH1;
+
 namespace FW
 {
   namespace Data
@@ -83,9 +86,16 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Reset maps event by event
   int ResetEvent(PHCompositeNode *topNode);
 
+  void doTimeAnalysis(bool timeAnalysis) { m_timeAnalysis = timeAnalysis;}
+
  private:
   /// Event counter
   int m_event;
+
+  bool m_timeAnalysis;
+  
+  TFile *m_timeFile;
+  TH1 *h_eventTime;
 
   /// Num bad fit counter
   int m_nBadFits;


### PR DESCRIPTION
This PR updates the CKF module and ActsEvaluator for running the Acts CKF track finding + fitting and performing subsequent analysis on the results. The main updates are filling the SvtxTrack objects with the output from the CKF, and constructing a truth-reco track matching map so that the ActsEvaluator can properly evaluate the fit results.