### PR TITLE
Move MVTX outer shell from INTT and include beta version for EndWheels

### DIFF
--- a/simulation/g4simulation/g4intt/PHG4InttDetector.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttDetector.cc
@@ -1004,7 +1004,7 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
     The rails run along the entire length of the TPC and even stick out of the TPC, but I think for the moment you don't have to put the parts that stick out in the simulation.
     An inner skin with a ID at 62.416 mm and a thickness of 0.250 mm.
     An outer skin with a ID at 120.444 mm and a sandwich of 0.25 mm cfc, 1.5 mm foam and 0.25 mm cfc.
-    
+
     All of the above are carbon fiber.
   */
   const PHParameters *supportparams = m_ParamsContainer->GetParameters(PHG4InttDefs::SUPPORTPARAMS);
@@ -1191,42 +1191,6 @@ int PHG4InttDetector::ConstructIntt(G4LogicalVolume *trackerenvelope)
     }
   }
 
-  //=======================================================
-  // Add an outer shell for the MVTX - move this to the MVTX detector module
-  //=======================================================
-  // A Rohacell foam sandwich made of 0.1 mm thick CFRP skin and 1.8 mm Rohacell 110 foam core, it has a density of 110 kg/m**3.
-  double skin_thickness = supportparams->get_double_param("mvtx_shell_skin_thickness") * cm;
-  double foam_core_thickness = supportparams->get_double_param("mvtx_shell_foam_core_thickness") * cm;
-  double mvtx_shell_length = supportparams->get_double_param("mvtx_shell_length") * cm;
-
-  double mvtx_shell_inner_skin_inner_radius = supportparams->get_double_param("mvtx_shell_inner_skin_inner_radius") * cm;
-
-  double mvtx_shell_foam_core_inner_radius = mvtx_shell_inner_skin_inner_radius + skin_thickness;
-  double mvtx_shell_outer_skin_inner_radius = mvtx_shell_foam_core_inner_radius + foam_core_thickness;
-
-  G4Tubs *mvtx_shell_inner_skin_tube = new G4Tubs("mvtx_shell_inner_skin",
-                                                  mvtx_shell_inner_skin_inner_radius, mvtx_shell_inner_skin_inner_radius + skin_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
-  G4LogicalVolume *mvtx_shell_inner_skin_volume = new G4LogicalVolume(mvtx_shell_inner_skin_tube, G4Material::GetMaterial("CFRP_INTT"),
-                                                                      "mvtx_shell_inner_skin_volume", 0, 0, 0);
-  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_inner_skin_volume,
-                    "mvtx_shell_inner_skin", trackerenvelope, false, 0, OverlapCheck());
-  m_DisplayAction->AddVolume(mvtx_shell_inner_skin_volume, "Rail");
-
-  G4Tubs *mvtx_shell_foam_core_tube = new G4Tubs("mvtx_shell_foam_core",
-                                                 mvtx_shell_foam_core_inner_radius, mvtx_shell_foam_core_inner_radius + foam_core_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
-  G4LogicalVolume *mvtx_shell_foam_core_volume = new G4LogicalVolume(mvtx_shell_foam_core_tube, G4Material::GetMaterial("ROHACELL_FOAM_110"),
-                                                                     "mvtx_shell_foam_core_volume", 0, 0, 0);
-  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_foam_core_volume,
-                    "mvtx_shell_foam_core", trackerenvelope, false, 0, OverlapCheck());
-  m_DisplayAction->AddVolume(mvtx_shell_foam_core_volume, "Rail");
-
-  G4Tubs *mvtx_shell_outer_skin_tube = new G4Tubs("mvtx_shell_outer_skin",
-                                                  mvtx_shell_outer_skin_inner_radius, mvtx_shell_outer_skin_inner_radius + skin_thickness, mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
-  G4LogicalVolume *mvtx_shell_outer_skin_volume = new G4LogicalVolume(mvtx_shell_outer_skin_tube, G4Material::GetMaterial("CFRP_INTT"),
-                                                                      "mvtx_shell_outer_skin_volume", 0, 0, 0);
-  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_outer_skin_volume,
-                    "mvtx_shell_outer_skin", trackerenvelope, false, 0, OverlapCheck());
-  m_DisplayAction->AddVolume(mvtx_shell_outer_skin_volume, "Rail");
   return 0;
 }
 

--- a/simulation/g4simulation/g4intt/PHG4InttSubsystem.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttSubsystem.cc
@@ -301,11 +301,6 @@ void PHG4InttSubsystem::SetDefaultParameters()
     set_default_double_param(SUPPORTPARAMS, "endcap_CPring_outer_radius", 11.43);
     set_default_double_param(SUPPORTPARAMS, "endcap_CPring_length", 0.6370);
 
-    set_default_double_param(SUPPORTPARAMS, "mvtx_shell_foam_core_thickness", 0.18);
-    set_default_double_param(SUPPORTPARAMS, "mvtx_shell_inner_skin_inner_radius", 4.8);
-    set_default_double_param(SUPPORTPARAMS, "mvtx_shell_length", 42.);
-    set_default_double_param(SUPPORTPARAMS, "mvtx_shell_skin_thickness", 0.01);
-
     set_default_double_param(SUPPORTPARAMS, "rail_dphi", 90.);  // deg
     set_default_double_param(SUPPORTPARAMS, "rail_inner_radius", 0.45);
     set_default_double_param(SUPPORTPARAMS, "rail_length", 410);  // tpc length

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
@@ -53,6 +53,10 @@ class PHG4MvtxDetector : public PHG4Detector
   void AddGeometryNode();
   int ConstructMvtx(G4LogicalVolume* sandwich);
   int ConstructMvtx_Layer(int layer, G4AssemblyVolume* stave, G4LogicalVolume*& trackerenvelope);
+  int ConstructMvtxPassiveVol(G4LogicalVolume*& lv);
+
+  G4LogicalVolume* GetMvtxOuterShell(G4LogicalVolume*& trackerenvelope);
+
   void SetDisplayProperty(G4AssemblyVolume* av);
   void SetDisplayProperty(G4LogicalVolume* lv);
   void FillPVArray(G4AssemblyVolume* av);
@@ -80,6 +84,8 @@ class PHG4MvtxDetector : public PHG4Detector
   std::string m_Detector;
   std::string m_SuperDetector;
   std::string m_StaveGeometryFile;
+  std::string m_EndWheelsSideS;
+  std::string m_EndWheelsSideN;
 };
 
 #endif

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
@@ -213,6 +213,10 @@ void PHG4MvtxSubsystem::SetDefaultParameters()
   }
 
   set_default_string_param(GLOBAL, "stave_geometry_file", "ITS.gdml");  // default - almost nothing
+  set_default_string_param(GLOBAL, "end_wheels_sideS",
+                           string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/ITS_ibEndWheelSideA_mod_PEEK.gdml"));
+  set_default_string_param(GLOBAL, "end_wheels_sideN",
+                           string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/ITS_ibEndWheelSideC_PEEK.gdml"));
   /*
   set_default_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_x", NAN);
   set_default_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_z", NAN);


### PR DESCRIPTION
In this PR we moved the cylinder mvtx outer shell volume implemented by the INTT's group to MVTX detector. We also introduced a beta MVTX EndWheels (an ALICE ITS like) of Carbon PEEK. EndWheel volumes are shifted by 2-3 cm to avoid overlaps.