### PR TITLE
Remove root5 qa

### DIFF
--- a/offline/QA/modules/Makefile.am
+++ b/offline/QA/modules/Makefile.am
@@ -1,71 +1,51 @@
 AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
-	-I$(includedir) \
-	-I$(OFFLINE_MAIN)/include \
-	-I$(OFFLINE_MAIN)/include/eigen3 \
-	-I`root-config --incdir`
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -I$(OFFLINE_MAIN)/include/eigen3 \
+  -I`root-config --incdir`
 
 lib_LTLIBRARIES = \
-	 libqa_modules.la
+   libqa_modules.la
 
 libqa_modules_la_LDFLAGS = \
-	-L$(libdir) \
-	-L$(OFFLINE_MAIN)/lib
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib
 
 libqa_modules_la_LIBADD = \
-	-lfun4all \
-	-lphg4hit \
-	-lg4detectors_io \
-	-lcalo_io -lcalo_util \
-	-lg4jets_io \
-	-ltrackbase_historic_io \
-	-lg4eval
+  -lcalo_io \
+  -lcalo_util \
+  -lfun4all \
+  -lg4detectors_io \
+  -lg4eval \
+  -lg4jets_io \
+  -lphg4hit \
+  -ltrackbase_historic_io
 
 pkginclude_HEADERS = \
-	QAG4SimulationCalorimeter.h \
-	QAG4SimulationCalorimeterSum.h \
-	QAG4SimulationIntt.h \
-	QAG4SimulationJet.h \
-	QAG4SimulationMvtx.h \
-	QAG4SimulationTpc.h \
-	QAG4SimulationTracking.h \
-	QAG4SimulationVertex.h \
-	QAG4SimulationUpsilon.h \
-	QAHistManagerDef.h
-
-if ! MAKEROOT6
-	ROOT5DICTS = \
-		QAG4SimulationCalorimeter_Dict.cc \
-		QAG4SimulationCalorimeterSum_Dict.cc \
-		QAG4SimulationIntt_Dict.cc \
-		QAG4SimulationJet_Dict.cc \
-		QAG4SimulationMvtx_Dict.cc \
-		QAG4SimulationTpc_Dict.cc \
-		QAG4SimulationTracking_Dict.cc \
-		QAG4SimulationUpsilon_Dict.cc \
-		QAHistManagerDef_Dict.cc
-endif
+  QAG4SimulationCalorimeter.h \
+  QAG4SimulationCalorimeterSum.h \
+  QAG4SimulationIntt.h \
+  QAG4SimulationJet.h \
+  QAG4SimulationMvtx.h \
+  QAG4SimulationTpc.h \
+  QAG4SimulationTracking.h \
+  QAG4SimulationVertex.h \
+  QAG4SimulationUpsilon.h \
+  QAHistManagerDef.h
 
 libqa_modules_la_SOURCES = \
-	$(ROOT5DICTS) \
-	QAG4SimulationCalorimeter.cc \
-	QAG4SimulationCalorimeterSum.cc \
-	QAG4SimulationIntt.cc \
-	QAG4SimulationJet.cc \
-	QAG4SimulationMvtx.cc \
-	QAG4SimulationTpc.cc \
-	QAG4SimulationTracking.cc \
-	QAG4SimulationVertex.cc \
-	QAG4SimulationUpsilon.cc \
-	QAHistManagerDef.cc
-
-# Rule for generating table CINT dictionaries.
-%_Dict.cc: %.h %LinkDef.h
-	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
-
-#just to get the dependency
-%_Dict_rdict.pcm: %_Dict.cc ;
+  QAG4SimulationCalorimeter.cc \
+  QAG4SimulationCalorimeterSum.cc \
+  QAG4SimulationIntt.cc \
+  QAG4SimulationJet.cc \
+  QAG4SimulationMvtx.cc \
+  QAG4SimulationTpc.cc \
+  QAG4SimulationTracking.cc \
+  QAG4SimulationVertex.cc \
+  QAG4SimulationUpsilon.cc \
+  QAHistManagerDef.cc
 
 ################################################
 # linking tests

--- a/offline/QA/modules/QAG4SimulationCalorimeter.h
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.h
@@ -3,14 +3,10 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
-#if !defined(__CINT__) || defined(__CLING__)
-#include <cstdint>
-#else
-#include <stdint.h>
-#endif
 
 class CaloEvalStack;
 class PHCompositeNode;
@@ -82,10 +78,7 @@ class QAG4SimulationCalorimeter : public SubsysReco
   int Init_Cluster(PHCompositeNode *topNode);
   int process_event_Cluster(PHCompositeNode *topNode);
 
-#if !defined(__CINT__) || defined(__CLING__)
-  //CINT is not c++11 compatible
   std::shared_ptr<CaloEvalStack> _caloevalstack;
-#endif
 
   std::string _calo_name;
   uint32_t _flags;

--- a/offline/QA/modules/QAG4SimulationCalorimeterLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationCalorimeterLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class QAG4SimulationCalorimeter - !;
-
-#endif /* __CINT__ */

--- a/offline/QA/modules/QAG4SimulationCalorimeterSum.h
+++ b/offline/QA/modules/QAG4SimulationCalorimeterSum.h
@@ -3,14 +3,9 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
-
-#if !defined(__CINT__) || defined(__CLING__)
-#include <cstdint>
-#else
-#include <stdint.h>
-#endif
 
 class PHCompositeNode;
 class PHG4TruthInfoContainer;
@@ -125,13 +120,10 @@ class QAG4SimulationCalorimeterSum : public SubsysReco
   int Init_TrackProj(PHCompositeNode *topNode);
   int process_event_TrackProj(PHCompositeNode *topNode);
 
-#if !defined(__CINT__) || defined(__CLING__)
-  //CINT is not c++11 compatible
   std::shared_ptr<CaloEvalStack> _caloevalstack_cemc;
   std::shared_ptr<CaloEvalStack> _caloevalstack_hcalin;
   std::shared_ptr<CaloEvalStack> _caloevalstack_hcalout;
   std::shared_ptr<SvtxEvalStack> _svtxevalstack;
-#endif
 
   uint32_t _flags;
 

--- a/offline/QA/modules/QAG4SimulationCalorimeterSumLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationCalorimeterSumLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class QAG4SimulationCalorimeterSum - !;
-
-#endif /* __CINT__ */

--- a/offline/QA/modules/QAG4SimulationIntt.cc
+++ b/offline/QA/modules/QAG4SimulationIntt.cc
@@ -12,15 +12,17 @@
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
+#include <trackbase/TrkrDefs.h>  // for getTrkrId, getHit...
 #include <trackbase/TrkrHitTruthAssoc.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
-#include <TH1F.h>
+#include <TH1.h>
 #include <TString.h>  // for Form
 
 #include <cassert>

--- a/offline/QA/modules/QAG4SimulationInttLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationInttLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class QAG4SimulationIntt - !;
-
-#endif /* __CINT__ */

--- a/offline/QA/modules/QAG4SimulationJet.h
+++ b/offline/QA/modules/QAG4SimulationJet.h
@@ -5,17 +5,13 @@
 
 #include <TString.h>
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
 #include <utility>  // std::pair, std::make_pair
 
-#if !defined(__CINT__) || defined(__CLING__)
-#include <cstdint>
-#else
-#include <stdint.h>
-#endif
 
 class JetEvalStack;
 class JetTruthEval;
@@ -146,12 +142,10 @@ class QAG4SimulationJet : public SubsysReco
   get_histo_prefix(const std::string &src_jet_name = "",
                    const std::string &reco_jet_name = "");
 
-#if !defined(__CINT__) || defined(__CLING__)
   //! cache the jet evaluation modules
   typedef std::map<std::string, std::shared_ptr<JetEvalStack>> jetevalstacks_map;
   jetevalstacks_map _jetevalstacks;
   std::shared_ptr<JetTruthEval> _jettrutheval;
-#endif
 
   //! truth jet name
   std::string _truth_jet;

--- a/offline/QA/modules/QAG4SimulationJetLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationJetLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class QAG4SimulationJet - !;
-
-#endif /* __CINT__ */

--- a/offline/QA/modules/QAG4SimulationMvtxLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationMvtxLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class QAG4SimulationMvtx - !;
-
-#endif /* __CINT__ */

--- a/offline/QA/modules/QAG4SimulationTpc.cc
+++ b/offline/QA/modules/QAG4SimulationTpc.cc
@@ -7,7 +7,6 @@
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 
-#include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 
 #include <tpc/TpcDefs.h>
@@ -15,17 +14,22 @@
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
+#include <trackbase/TrkrDefs.h> // for getTrkrId
 #include <trackbase/TrkrHitTruthAssoc.h>
 
-#include<g4eval/SvtxEvalStack.h>
+#include <g4eval/SvtxClusterEval.h>  // for SvtxClusterEval
+#include <g4eval/SvtxEvalStack.h>
+#include <g4eval/SvtxTruthEval.h>   // for SvtxTruthEval
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
-#include <TH1F.h>
+#include <TAxis.h>  // for TAxis
+#include <TH1.h>
 #include <TString.h>  // for Form
 
 #include <cassert>
@@ -33,6 +37,7 @@
 #include <iterator>  // for distance
 #include <map>       // for map
 #include <utility>   // for pair, make_pair
+#include <vector>    // for vector
 
 //________________________________________________________________________
 QAG4SimulationTpc::QAG4SimulationTpc(const std::string& name)

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -20,7 +20,6 @@ class PHG4TruthInfoContainer;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class TrkrHitTruthAssoc;
-class SvtxEvalStack;
 
 /// \class QAG4SimulationTracking
 class QAG4SimulationTracking : public SubsysReco

--- a/offline/QA/modules/QAG4SimulationTrackingLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationTrackingLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class QAG4SimulationTracking - !;
-
-#endif /* __CINT__ */

--- a/offline/QA/modules/QAG4SimulationUpsilon.h
+++ b/offline/QA/modules/QAG4SimulationUpsilon.h
@@ -48,11 +48,9 @@ class QAG4SimulationUpsilon : public SubsysReco
   }
 
  private:
-#if !defined(__CINT__) || defined(__CLING__)
-  //CINT is not c++11 compatible
+
   std::shared_ptr<SvtxEvalStack> _svtxEvalStack;
   std::set<int> m_embeddingIDs;
-#endif
   std::pair<double, double> m_etaRange;
 
   PHG4TruthInfoContainer *_truthContainer;

--- a/offline/QA/modules/QAG4SimulationUpsilonLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationUpsilonLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class QAG4SimulationUpsilon - !;
-
-#endif /* __CINT__ */

--- a/offline/QA/modules/QAG4SimulationVertex.cc
+++ b/offline/QA/modules/QAG4SimulationVertex.cc
@@ -2,8 +2,6 @@
 #include "QAHistManagerDef.h"
 
 #include <g4eval/SvtxEvalStack.h>
-#include <g4eval/SvtxTrackEval.h>
-#include <g4eval/SvtxTruthEval.h>
 #include <g4eval/SvtxClusterEval.h>
 #include <g4eval/SvtxVertexEval.h>
 
@@ -11,40 +9,28 @@
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>
 
-#include <trackbase/TrkrCluster.h>
-#include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrDefs.h> // for cluskey
 
 #include <trackbase_historic/SvtxVertex.h>
 #include <trackbase_historic/SvtxVertexMap.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 
-#include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <g4main/PHG4VtxPoint.h>
 
-#include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 
-#include <TFile.h>
-#include <TNtuple.h>
 #include <TVector3.h>
-#include <TAxis.h>
-#include <TDatabasePDG.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TNamed.h>
-#include <TParticlePDG.h>  // for TParticlePDG
 #include <TString.h>
 
-#include <array>
 #include <cassert>
 #include <cmath>
 #include <iostream>
-#include <iterator>
 #include <map>
-#include <utility>
 #include <vector>
 
 using namespace std;

--- a/offline/QA/modules/QAG4SimulationVertex.h
+++ b/offline/QA/modules/QAG4SimulationVertex.h
@@ -10,9 +10,9 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <utility>
 
 class PHCompositeNode;
+class PHG4TruthInfoContainer;
 
 class QAG4SimulationVertex : public SubsysReco
 {

--- a/offline/QA/modules/QAG4SimulationVertexLinkDef.h
+++ b/offline/QA/modules/QAG4SimulationVertexLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class QAG4SimulationVertex - !;
-
-#endif /* __CINT__ */

--- a/offline/QA/modules/QAHistManagerDefLinkDef.h
+++ b/offline/QA/modules/QAHistManagerDefLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ namespace QAHistManagerDef - !;
-
-#endif /* __CINT__ */

--- a/offline/QA/modules/configure.ac
+++ b/offline/QA/modules/configure.ac
@@ -23,12 +23,5 @@ if test $ac_cv_prog_gxx = yes; then
    CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
-AC_SUBST(CINTDEFS)
-fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
-
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
This PR removes the root5 remnants from the qa. It will be a model for the eic - we might as well start with root6 only