### PR TITLE
Source Link Selection

### DIFF
--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -105,20 +105,21 @@ int PHActsTrkProp::Setup(PHCompositeNode* topNode)
   sourceLinkSelectors.push_back({makeId(11), {m_volMaxChi2.find(11)->second, 48}});
   
   /// Set individual layer criteria (e.g. for first layer of TPC)
+  /// Individual layers should only have one SL per layer
   for(int vol = 0; vol < m_volLayerMaxChi2.size(); ++vol)
     for(std::pair<const int, const float> element : m_volLayerMaxChi2.at(vol))
       sourceLinkSelectors.push_back({makeId(vol*2.+7, element.first),
-	                            {element.second, 2}});
+	                            {element.second, 1}});
 	      
   m_sourceLinkSelectorConfig = SourceLinkSelectorConfig(sourceLinkSelectors);
 
-  if(Verbosity() > 2)
+  if(Verbosity() > 1)
     {
       std::cout << "The source link selection criteria were set to: " << std::endl;
       for(int i = 0; i < sourceLinkSelectors.size(); i++)
 	{
 	  std::cout << "GeoID : " << sourceLinkSelectors.at(i).first
-		    << " has selection " 
+		    << " has chi sq selection " 
 		    << sourceLinkSelectors.at(i).second.chi2CutOff
 		    << std::endl;
 	}

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -89,7 +89,8 @@ class PHActsTrkProp : public PHTrackPropagating
   void doTimeAnalysis(bool timeAnalysis) { m_timeAnalysis = timeAnalysis;}
 
   void setVolumeMaxChi2(const int vol, const float maxChi2);
-
+  void setVolumeLayerMaxChi2(const int vol, const int layer,
+			     const float maxChi2);
  private:
   /// Event counter
   int m_event;
@@ -98,9 +99,16 @@ class PHActsTrkProp : public PHTrackPropagating
   TFile *m_timeFile;
   TH1 *h_eventTime;
 
+  void initializeLayerSelector();
+
   /// Map to hold maximum allowable measurement chi2 in each
   /// volume identifier in Acts
   std::map<const int, const float> m_volMaxChi2;
+
+  /// array of maps to hold maximum allowable measurement chi 2
+  /// in a particular layer of a particular volume id in acts
+  /// Entries are 0 - MVTX, 1 - INTT, 2 - TPC
+  std::vector<std::map<const int, const float>> m_volLayerMaxChi2;
 
   /// Num bad fit counter
   int m_nBadFits;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -1595,6 +1595,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	    
 	    float hit_data[] = {
 	      event,
+              (float) _iseed,
 	      hitID,
 	      e,
 	      adc,


### PR DESCRIPTION
This PR modifies the source link selection criteria for the CKF. The module now has setters which can be used to test different "search windows" for the CKF. It also adds a layer modifier so that chi2 criteria can be set for a given layer in the silicon or TPC.