### PR TITLE
Unlimited Projections

### DIFF
--- a/offline/framework/phool/Makefile.am
+++ b/offline/framework/phool/Makefile.am
@@ -21,23 +21,12 @@ ROOTDICTS = \
   PHObject_Dict.cc \
   PHTimeStamp_Dict.cc
 
-if MAKEROOT6
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
   PHObject_Dict_rdict.pcm \
   PHTimeStamp_Dict_rdict.pcm
 
-else
-ROOT5DICTS = \
-  PHMessage_Dict.cc \
-  PHRandomSeed_Dict.cc \
-  PHFlag_Dict.cc \
-  PHTimeServer_Dict.cc \
-  recoConsts_Dict.cc
-endif
-
 libphool_la_SOURCES = \
-  $(ROOT5DICTS) \
   $(ROOTDICTS) \
   PHCompositeNode.cc \
   PHFlag.cc \
@@ -103,7 +92,7 @@ testexternals.cc:
 	echo "}" >> $@
 
 %_Dict.cc: %.h %LinkDef.h
-	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+	rootcint -f $@ @CINTDEFS@ $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
 
 #just to get the dependency
 %_Dict_rdict.pcm: %_Dict.cc ;

--- a/offline/framework/phool/PHFlag.h
+++ b/offline/framework/phool/PHFlag.h
@@ -37,11 +37,16 @@ class PHFlag
   virtual int get_IntFlag(const std::string &name, const int defaultval);
   virtual void set_IntFlag(const std::string &name, const int flag);
 
+  virtual const std::string get_StringFlag(const std::string &name) const {return get_CharFlag(name);}
+  virtual const std::string get_StringFlag(const std::string &name, const std::string &defaultval) {return get_CharFlag(name, defaultval);}
+  virtual void set_StringFlag(const std::string &name, const std::string &flag) {set_CharFlag(name, flag);}
+
   virtual void Print() const;
   virtual void PrintDoubleFlags() const;
   virtual void PrintIntFlags() const;
   virtual void PrintFloatFlags() const;
   virtual void PrintCharFlags() const;
+  virtual void PrintStringFlags() const {PrintCharFlags();}
   virtual void ReadFromFile(const std::string &name);
   virtual void WriteToFile(const std::string &name);
 

--- a/offline/framework/phool/PHFlagLinkDef.h
+++ b/offline/framework/phool/PHFlagLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHFlag - !;
-
-#endif /* __CINT__ */

--- a/offline/framework/phool/PHMessageLinkDef.h
+++ b/offline/framework/phool/PHMessageLinkDef.h
@@ -1,9 +1,0 @@
-#ifdef __CINT__
-
-#include "phool.h"
-#pragma link C++ enum PHMessageType;
-#pragma link C++ enum PHAccessType;
-#pragma link C++ enum PHTreeType;
-#pragma link C++ function PHMessage(const std::string &, int, const std::string &);
-
-#endif /* __CINT__ */

--- a/offline/framework/phool/PHObject.h
+++ b/offline/framework/phool/PHObject.h
@@ -21,15 +21,9 @@ class PHObject : public TObject
   /// Virtual copy constructor.
   virtual PHObject* CloneMe() const;
 
-#if !defined(__CINT__) || defined(__CLING__)
   virtual PHObject* clone() const final;
   virtual PHObject *Clone(const char *newname = "") const final;
   virtual void 	Copy(TObject &object) const final;
-#else
-  virtual PHObject* clone() const;
-  virtual PHObject *Clone(const char *newname = "") const;
-  virtual void 	Copy(TObject &object) const;
-#endif
 
   /** identify Function from PHObject
       @param os Output Stream 

--- a/offline/framework/phool/PHPointerListIterator.h
+++ b/offline/framework/phool/PHPointerListIterator.h
@@ -19,13 +19,7 @@ class PHPointerListIterator
   size_t pos() const { return m_Index; }
 
  private:
-#if defined(__CINT__) && !defined(__CLING__)
-  PHPointerListIterator()
-  {
-  }
-#else
   PHPointerListIterator() = delete;
-#endif
   const PHPointerList<T>& m_List;
   size_t m_Index;
 };

--- a/offline/framework/phool/PHRandomSeedLinkDef.h
+++ b/offline/framework/phool/PHRandomSeedLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHRandomSeed - !;
-
-#endif /* __CINT__ */

--- a/offline/framework/phool/PHTimeServer.h
+++ b/offline/framework/phool/PHTimeServer.h
@@ -51,9 +51,8 @@ class PHTimeServer
     }
 
    private:
-#if !defined(__CINT__) || defined(__CLING__)
+
     std::shared_ptr<PHTimer> _timer;
-#endif
     unsigned short _uid;
   };
 
@@ -125,7 +124,7 @@ class PHTimeServer
     //! get PHTimer associated to current iterator position, advance iterator
     PHTimeServer::timer* next()
     {
-      if (_iter == _map.end()) return 0;
+      if (_iter == _map.end()) return nullptr;
       PHTimeServer::timer* out(&_iter->second);
       ++_iter;
       return out;
@@ -134,7 +133,7 @@ class PHTimeServer
     //! get PHTimer associated to current iterator position
     PHTimeServer::timer* current()
     {
-      if (_iter == _map.end()) return 0;
+      if (_iter == _map.end()) return nullptr;
       return &_iter->second;
     }
 

--- a/offline/framework/phool/PHTimeServerLinkDef.h
+++ b/offline/framework/phool/PHTimeServerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHTimeServer - !;
-
-#endif /* __CINT__ */

--- a/offline/framework/phool/configure.ac
+++ b/offline/framework/phool/configure.ac
@@ -12,12 +12,8 @@ if test $ac_cv_prog_gxx = yes; then
   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
 fi
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
-fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/framework/phool/recoConstsLinkDef.h
+++ b/offline/framework/phool/recoConstsLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class recoConsts - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4trackfastsim/Makefile.am
+++ b/simulation/g4simulation/g4trackfastsim/Makefile.am
@@ -3,59 +3,36 @@ AUTOMAKE_OPTIONS = foreign
 lib_LTLIBRARIES = \
   libg4trackfastsim.la 
 
-
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(G4_MAIN)/include \
   -I$(OFFLINE_MAIN)/include  \
   -I$(OFFLINE_MAIN)/include/eigen3  \
-  -I$(ROOTSYS)/include \
-  -I$(OPT_SPHENIX)/include
+  -I$(G4_MAIN)/include \
+  -I$(ROOTSYS)/include
 
 
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  -L$(OFFLINE_MAIN)/lib64 \
   -L$(ROOTSYS)/lib
 
 libg4trackfastsim_la_LIBADD = \
-  -lfun4all \
-  -lphool \
-  -lg4testbench \
-  -lphg4hit \
-  -ltrackbase_historic_io \
   -lcalo_io \
-  -lgenfit2 \
-  -lgenfit2exp \
-  -lPHGenFit 
+  -lgsl \
+  -lgslcblas \
+  -lPHGenFit \
+  -lphgeom \
+  -lphg4hit \
+  -ltrackbase_historic_io
 
 pkginclude_HEADERS = \
   PHG4TrackFastSim.h \
   PHG4TrackFastSimEval.h
 
-
-if MAKEROOT6
-  pcmdir = $(libdir)
-else
-  ROOT5_DICTS = \
-    PHG4TrackFastSim_Dict.cc \
-    PHG4TrackFastSimEval_Dict.cc
-endif
-
 libg4trackfastsim_la_SOURCES = \
-  $(ROOT5_DICTS) \
   PHG4TrackFastSim.cc \
   PHG4TrackFastSimEval.cc
 
-
-
-# Rule for generating table CINT dictionaries.
-%_Dict.cc: %.h %LinkDef.h
-	rootcint -f $@ @CINTDEFS@  -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
-
-#just to get the dependency
-%_Dict_rdict.pcm: %_Dict.cc ;
 
 ################################################
 # linking tests
@@ -78,4 +55,4 @@ testexternals.cc:
 ################################################
 
 clean-local:
-	rm -f *Dict* $(BUILT_SOURCES) *.pcm
+	rm -f $(BUILT_SOURCES)

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -146,28 +146,28 @@ int PHG4TrackFastSimEval::InitRun(PHCompositeNode *topNode)
       string bdef = bname + "/F";
       m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_proj_p_vec[iter->second][i], bdef.c_str());
     }
-          string nodename = "G4HIT_" + iter->first;
-          PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
-	  if (hits)
-	  {
-    for (int i = 0; i < 3; i++)
+    string nodename = "G4HIT_" + iter->first;
+    PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
+    if (hits)
     {
-      string bname = iter->first + "_" + xyz[i];
-      string bdef = bname + "/F";
-      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_vec[iter->second][i], bdef.c_str());
-    }
-    for (int i = 0; i < 3; i++)
-    {
-      string bname = iter->first + "_p" + xyz[i];
-      string bdef = bname + "/F";
+      for (int i = 0; i < 3; i++)
+      {
+        string bname = iter->first + "_" + xyz[i];
+        string bdef = bname + "/F";
+        m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_vec[iter->second][i], bdef.c_str());
+      }
+      for (int i = 0; i < 3; i++)
+      {
+        string bname = iter->first + "_p" + xyz[i];
+        string bdef = bname + "/F";
 
-      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_p_vec[iter->second][i], bdef.c_str());
+        m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_p_vec[iter->second][i], bdef.c_str());
+      }
     }
-	  }
-	  if (! hits)
-	  {
-	    cout << "InitRun: could not find " << nodename << endl;
-	  }
+    if (!hits)
+    {
+      cout << "InitRun: could not find " << nodename << endl;
+    }
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -263,7 +263,7 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
       if (!temp)
       {
         if (Verbosity())
-        {  
+        {
           std::cout << "PHG4TrackFastSimEval::fill_track_tree - ignore track that is not a SvtxTrack_FastSim:";
           track_itr->second->identify();
         }
@@ -330,17 +330,17 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
         {
           //	  cout << "found " << trkstates->second->get_name() << endl;
           // setting the projection (xyz and pxpypz)
-	  for (int i=0; i<3; i++)
-	  {
-m_TTree_proj_vec[iter->second][i] = trkstates->second->get_pos(i);
-m_TTree_proj_p_vec[iter->second][i] = trkstates->second->get_mom(i);
-	  }
+          for (int i = 0; i < 3; i++)
+          {
+            m_TTree_proj_vec[iter->second][i] = trkstates->second->get_pos(i);
+            m_TTree_proj_p_vec[iter->second][i] = trkstates->second->get_mom(i);
+          }
 
           string nodename = "G4HIT_" + trkstates->second->get_name();
           PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
           if (!hits)
           {
-//            cout << "could not find " << nodename << endl;
+            //            cout << "could not find " << nodename << endl;
             continue;
           }
           //	  cout << "number of hits: " << hits->size() << endl;
@@ -356,12 +356,12 @@ m_TTree_proj_p_vec[iter->second][i] = trkstates->second->get_mom(i);
                 cout << "bad index: " << iter->second << endl;
                 gSystem->Exit(1);
               }
-m_TTree_ref_vec[iter->second][0] = hit_iter->second->get_x(0);
-m_TTree_ref_vec[iter->second][1] = hit_iter->second->get_y(0);
-m_TTree_ref_vec[iter->second][2] = hit_iter->second->get_z(0);
-m_TTree_ref_p_vec[iter->second][0] = hit_iter->second->get_px(0);
-m_TTree_ref_p_vec[iter->second][1] = hit_iter->second->get_py(0);
-m_TTree_ref_p_vec[iter->second][2] = hit_iter->second->get_pz(0);
+              m_TTree_ref_vec[iter->second][0] = hit_iter->second->get_x(0);
+              m_TTree_ref_vec[iter->second][1] = hit_iter->second->get_y(0);
+              m_TTree_ref_vec[iter->second][2] = hit_iter->second->get_z(0);
+              m_TTree_ref_p_vec[iter->second][0] = hit_iter->second->get_px(0);
+              m_TTree_ref_p_vec[iter->second][1] = hit_iter->second->get_py(0);
+              m_TTree_ref_p_vec[iter->second][2] = hit_iter->second->get_pz(0);
             }
           }
         }
@@ -513,10 +513,10 @@ void PHG4TrackFastSimEval::reset_variables()
   m_TTree_DeltaVz = NAN;
   m_TTree_nTracks = -9999;
   m_TTree_nFromTruth = -9999;
-for(auto &elem : m_TTree_proj_vec) std::fill(elem.begin(), elem.end(), -9999);
-for(auto &elem : m_TTree_proj_p_vec) std::fill(elem.begin(), elem.end(), -9999);
-for(auto &elem : m_TTree_ref_vec) std::fill(elem.begin(), elem.end(), -9999);
-for(auto &elem : m_TTree_ref_p_vec) std::fill(elem.begin(), elem.end(), -9999);
+  for (auto &elem : m_TTree_proj_vec) std::fill(elem.begin(), elem.end(), -9999);
+  for (auto &elem : m_TTree_proj_p_vec) std::fill(elem.begin(), elem.end(), -9999);
+  for (auto &elem : m_TTree_ref_vec) std::fill(elem.begin(), elem.end(), -9999);
+  for (auto &elem : m_TTree_ref_p_vec) std::fill(elem.begin(), elem.end(), -9999);
 }
 
 //----------------------------------------------------------------------------//
@@ -560,13 +560,13 @@ int PHG4TrackFastSimEval::GetNodes(PHCompositeNode *topNode)
 
 void PHG4TrackFastSimEval::AddProjection(const string &name)
 {
-    vector<float> floatvec {-9999,-9999,-9999};
-    m_TTree_proj_vec.push_back(floatvec);
-    m_TTree_proj_p_vec.push_back(floatvec);
-    m_TTree_ref_vec.push_back(floatvec);
-    m_TTree_ref_p_vec.push_back(floatvec);
-// using m_ProjectionNameMap.size() makes sure it starts with 0 and then increments by 1
-// for each additional projection
+  vector<float> floatvec{-9999, -9999, -9999};
+  m_TTree_proj_vec.push_back(floatvec);
+  m_TTree_proj_p_vec.push_back(floatvec);
+  m_TTree_ref_vec.push_back(floatvec);
+  m_TTree_ref_p_vec.push_back(floatvec);
+  // using m_ProjectionNameMap.size() makes sure it starts with 0 and then increments by 1
+  // for each additional projection
   m_ProjectionNameMap.insert(make_pair(name, m_ProjectionNameMap.size()));
   return;
 }

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -43,6 +43,8 @@
 
 using namespace std;
 
+const string xyz[3] = {"x", "y", "z"};
+
 //----------------------------------------------------------------------------//
 //-- Constructor:
 //--  simple initialization
@@ -94,37 +96,6 @@ int PHG4TrackFastSimEval::Init(PHCompositeNode *topNode)
   m_TracksEvalTree->Branch("pcay", &m_TTree_pcay, "pcay/F");
   m_TracksEvalTree->Branch("pcaz", &m_TTree_pcaz, "pcaz/F");
   m_TracksEvalTree->Branch("dca2d", &m_TTree_dca2d, "dca2d/F");
-  const string xyz[3] = {"x", "y", "z"};
-  for (map<string, int>::const_iterator iter = m_ProjectionNameMap.begin(); iter != m_ProjectionNameMap.end(); ++iter)
-  {
-    string bname;
-    string bdef;
-    for (int i = 0; i < 3; i++)
-    {
-      bname = iter->first + "_" + xyz[i];
-      bdef = bname +"/F";
-      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref[i][iter->second], bdef.c_str());
-    }
-    for (int i = 0; i < 3; i++)
-    {
-      bname = iter->first + "_p" + xyz[i];
-      bdef = bname +"/F";
-
-      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_p[i][iter->second], bdef.c_str());
-    }
-    for (int i = 0; i < 3; i++)
-    {
-      bname = iter->first + "_proj_" + xyz[i];
-      bdef = bname +"/F";
-      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_proj[i][iter->second], bdef.c_str());
-    }
-    for (int i = 0; i < 3; i++)
-    {
-      bname = iter->first + "_proj_p" + xyz[i];
-      bdef = bname +"/F";
-      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_proj_p[i][iter->second], bdef.c_str());
-    }
-  }
 
   m_H2D_DeltaMomVsTruthEta = new TH2D("DeltaMomVsTruthEta",
                                       "#frac{#Delta p}{truth p} vs. truth #eta", 54, -4.5, +4.5, 1000, -1,
@@ -152,6 +123,52 @@ int PHG4TrackFastSimEval::Init(PHCompositeNode *topNode)
   m_VertexEvalTree->Branch("ntracks", &m_TTree_nTracks, "ntracks/I");
   m_VertexEvalTree->Branch("n_from_truth", &m_TTree_nFromTruth, "n_from_truth/I");
 
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//----------------------------------------------------------------------------//
+//-- InitRun():
+//--   add related hit object
+//----------------------------------------------------------------------------//
+int PHG4TrackFastSimEval::InitRun(PHCompositeNode *topNode)
+{
+  for (map<string, unsigned int>::const_iterator iter = m_ProjectionNameMap.begin(); iter != m_ProjectionNameMap.end(); ++iter)
+  {
+    for (int i = 0; i < 3; i++)
+    {
+      string bname = iter->first + "_proj_" + xyz[i];
+      string bdef = bname + "/F";
+      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_proj_vec[iter->second][i], bdef.c_str());
+    }
+    for (int i = 0; i < 3; i++)
+    {
+      string bname = iter->first + "_proj_p" + xyz[i];
+      string bdef = bname + "/F";
+      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_proj_p_vec[iter->second][i], bdef.c_str());
+    }
+          string nodename = "G4HIT_" + iter->first;
+          PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
+	  if (hits)
+	  {
+    for (int i = 0; i < 3; i++)
+    {
+      string bname = iter->first + "_" + xyz[i];
+      string bdef = bname + "/F";
+      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_vec[iter->second][i], bdef.c_str());
+    }
+    for (int i = 0; i < 3; i++)
+    {
+      string bname = iter->first + "_p" + xyz[i];
+      string bdef = bname + "/F";
+
+      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_p_vec[iter->second][i], bdef.c_str());
+    }
+	  }
+	  if (! hits)
+	  {
+	    cout << "InitRun: could not find " << nodename << endl;
+	  }
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -308,23 +325,22 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
            ++trkstates)
       {
         //	cout << "checking " << trkstates->second->get_name() << endl;
-        map<string, int>::const_iterator iter = m_ProjectionNameMap.find(trkstates->second->get_name());
+        map<string, unsigned int>::const_iterator iter = m_ProjectionNameMap.find(trkstates->second->get_name());
         if (iter != m_ProjectionNameMap.end())
         {
           //	  cout << "found " << trkstates->second->get_name() << endl;
           // setting the projection (xyz and pxpypz)
-          m_TTree_proj[0][iter->second] = trkstates->second->get_x();
-          m_TTree_proj[1][iter->second] = trkstates->second->get_y();
-          m_TTree_proj[2][iter->second] = trkstates->second->get_z();
-          m_TTree_proj_p[0][iter->second] = trkstates->second->get_px();
-          m_TTree_proj_p[1][iter->second] = trkstates->second->get_py();
-          m_TTree_proj_p[2][iter->second] = trkstates->second->get_pz();
+	  for (int i=0; i<3; i++)
+	  {
+m_TTree_proj_vec[iter->second][i] = trkstates->second->get_pos(i);
+m_TTree_proj_p_vec[iter->second][i] = trkstates->second->get_mom(i);
+	  }
 
           string nodename = "G4HIT_" + trkstates->second->get_name();
           PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
           if (!hits)
           {
-            cout << "could not find " << nodename << endl;
+//            cout << "could not find " << nodename << endl;
             continue;
           }
           //	  cout << "number of hits: " << hits->size() << endl;
@@ -335,17 +351,17 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
             if (hit_iter->second->get_trkid() - track->get_truth_track_id() == 0)
             {
               //	      cout << "found hit with id " << hit_iter->second->get_trkid() << endl;
-              if (iter->second >= m_MaxNumberProjections)
+              if (iter->second > m_ProjectionNameMap.size())
               {
                 cout << "bad index: " << iter->second << endl;
                 gSystem->Exit(1);
               }
-              m_TTree_ref[0][iter->second] = hit_iter->second->get_x(0);
-              m_TTree_ref[1][iter->second] = hit_iter->second->get_y(0);
-              m_TTree_ref[2][iter->second] = hit_iter->second->get_z(0);
-              m_TTree_ref_p[0][iter->second] = hit_iter->second->get_px(0);
-              m_TTree_ref_p[1][iter->second] = hit_iter->second->get_py(0);
-              m_TTree_ref_p[2][iter->second] = hit_iter->second->get_pz(0);
+m_TTree_ref_vec[iter->second][0] = hit_iter->second->get_x(0);
+m_TTree_ref_vec[iter->second][1] = hit_iter->second->get_y(0);
+m_TTree_ref_vec[iter->second][2] = hit_iter->second->get_z(0);
+m_TTree_ref_p_vec[iter->second][0] = hit_iter->second->get_px(0);
+m_TTree_ref_p_vec[iter->second][1] = hit_iter->second->get_py(0);
+m_TTree_ref_p_vec[iter->second][2] = hit_iter->second->get_pz(0);
             }
           }
         }
@@ -497,17 +513,10 @@ void PHG4TrackFastSimEval::reset_variables()
   m_TTree_DeltaVz = NAN;
   m_TTree_nTracks = -9999;
   m_TTree_nFromTruth = -9999;
-  // projections
-  for (int k = 0; k < 3; k++)
-  {
-    for (int j = 0; j < m_MaxNumberProjections; j++)
-    {
-      m_TTree_proj[k][j] = -9999;
-      m_TTree_proj_p[k][j] = -9999;
-      m_TTree_ref[k][j] = -9999;
-      m_TTree_ref_p[k][j] = -9999;
-    }
-  }
+for(auto &elem : m_TTree_proj_vec) std::fill(elem.begin(), elem.end(), -9999);
+for(auto &elem : m_TTree_proj_p_vec) std::fill(elem.begin(), elem.end(), -9999);
+for(auto &elem : m_TTree_ref_vec) std::fill(elem.begin(), elem.end(), -9999);
+for(auto &elem : m_TTree_ref_p_vec) std::fill(elem.begin(), elem.end(), -9999);
 }
 
 //----------------------------------------------------------------------------//
@@ -551,15 +560,13 @@ int PHG4TrackFastSimEval::GetNodes(PHCompositeNode *topNode)
 
 void PHG4TrackFastSimEval::AddProjection(const string &name)
 {
-  unsigned int size = m_ProjectionNameMap.size();
-  if (size >= m_MaxNumberProjections)
-  {
-    cout << "Too many projections in evaluator, maximum number is "
-         << m_MaxNumberProjections << endl;
-    cout << "Cannot add " << name << endl;
-    cout << "increase m_MaxNumberProjections in PHG4TrackFastSimEval, recompile and rerun" << endl;
-    gSystem->Exit(1);
-  }
+    vector<float> floatvec {-9999,-9999,-9999};
+    m_TTree_proj_vec.push_back(floatvec);
+    m_TTree_proj_p_vec.push_back(floatvec);
+    m_TTree_ref_vec.push_back(floatvec);
+    m_TTree_ref_p_vec.push_back(floatvec);
+// using m_ProjectionNameMap.size() makes sure it starts with 0 and then increments by 1
+// for each additional projection
   m_ProjectionNameMap.insert(make_pair(name, m_ProjectionNameMap.size()));
   return;
 }

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
@@ -128,10 +128,10 @@ class PHG4TrackFastSimEval : public SubsysReco
 
   // names and index of projections
   std::map<std::string, unsigned int> m_ProjectionNameMap;
-// projections to cylinders and planes
+  // projections to cylinders and planes
   std::vector<std::vector<float>> m_TTree_proj_vec;
   std::vector<std::vector<float>> m_TTree_proj_p_vec;
-// hits on reference cylinders and planes
+  // hits on reference cylinders and planes
   std::vector<std::vector<float>> m_TTree_ref_vec;
   std::vector<std::vector<float>> m_TTree_ref_p_vec;
 };

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
@@ -14,6 +14,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 //Forward declarations
 class PHCompositeNode;
@@ -34,6 +35,9 @@ class PHG4TrackFastSimEval : public SubsysReco
 
   //Initialization, called for initialization
   int Init(PHCompositeNode*);
+
+  //Initialization, called for initialization
+  int InitRun(PHCompositeNode*);
 
   //Process Event, called for each event
   int process_event(PHCompositeNode*);
@@ -106,14 +110,6 @@ class PHG4TrackFastSimEval : public SubsysReco
   float m_TTree_pcaz;
   float m_TTree_dca2d;
 
-  static const int m_MaxNumberProjections = 3;
-  // projections hits/mom
-  float m_TTree_proj[3][m_MaxNumberProjections];
-  float m_TTree_proj_p[3][m_MaxNumberProjections];
-  // hits/mom at reference
-  float m_TTree_ref[3][m_MaxNumberProjections];
-  float m_TTree_ref_p[3][m_MaxNumberProjections];
-
   //vertex
   float m_TTree_vx;
   float m_TTree_vy;
@@ -131,7 +127,13 @@ class PHG4TrackFastSimEval : public SubsysReco
   std::string m_TrackMapName;
 
   // names and index of projections
-  std::map<std::string, int> m_ProjectionNameMap;
+  std::map<std::string, unsigned int> m_ProjectionNameMap;
+// projections to cylinders and planes
+  std::vector<std::vector<float>> m_TTree_proj_vec;
+  std::vector<std::vector<float>> m_TTree_proj_p_vec;
+// hits on reference cylinders and planes
+  std::vector<std::vector<float>> m_TTree_ref_vec;
+  std::vector<std::vector<float>> m_TTree_ref_p_vec;
 };
 
 #endif  //* G4TRACKFASTSIM_PHG4TRACKFASTSIMEVAL_H *//

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEvalLinkDef.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEvalLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4TrackFastSimEval-!;
-
-#endif

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimLinkDef.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4TrackFastSim-!;
-
-#endif

--- a/simulation/g4simulation/g4trackfastsim/configure.ac
+++ b/simulation/g4simulation/g4trackfastsim/configure.ac
@@ -21,12 +21,5 @@ if test $ac_cv_prog_gxx = yes; then
    CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
-AC_SUBST(CINTDEFS)
-fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
-
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
This PR removes the limit on the number of projections in the evaluator. It now uses vector<vector<float>> instead of hardcoded arrays. It also only adds existing g4 hits to the branches of the output ttree (now done in InitRun() where the g4hit nodes are settled and we know their names)

Added StringFlag methods to PHFlag to stay with more modern times. Internally they just call the old CharFlags

Removed root5 remnants from packages offline/framework/phool and simulation/g4simulation/g4trackfastsim