### PR TITLE
Tpc tracker interface and Vertex SL

### DIFF
--- a/offline/packages/PHTpcTracker/externals/kdfinder.hpp
+++ b/offline/packages/PHTpcTracker/externals/kdfinder.hpp
@@ -699,7 +699,7 @@ namespace kdfinder
         T t40 = (-t3 * t38);
         if (t40 < 0.)
         {
-          std::cerr << "t40 < 0." << std::endl;
+          //std::cerr << "t40 < 0." << std::endl;
           return VALUE;
         }
         t40 = std::sqrt(t40);

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -654,7 +654,7 @@ void PHActsSourceLinks::addVerticesAsSourceLinks(PHCompositeNode *topNode,
 	for(int j = 0; j < 3; j++)
 	  worldErr(i,j) = vertex->get_error(i, j);
 
-      if(Verbosity() == 0)
+      if(Verbosity() > 1)
 	{
 	  std::cout << "global cov xx, yy, zz: " << worldErr(0,0) 
 		    << ", " << worldErr(1,1) << ", " << worldErr(2,2)

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -95,7 +95,9 @@ class PHActsSourceLinks : public SubsysReco
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
   int ResetEvent(PHCompositeNode *topNode);
-  
+  void useVertexAsMeasurement(bool useVertexMeasurement)
+    {m_useVertexMeasurement = useVertexMeasurement;}
+
  private:
   /**
    * Functions
@@ -148,9 +150,14 @@ class PHActsSourceLinks : public SubsysReco
                             const TrkrCluster *cluster,
                             const TrkrDefs::cluskey clusKey);
 
+  void addVerticesAsSourceLinks(PHCompositeNode *topNode,
+				unsigned int &hitId);
+
   /**
    * Member variables
    */
+
+  bool m_useVertexMeasurement;
 
   /// SvtxCluster node
   TrkrClusterContainer *m_clusterMap;

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -146,7 +146,7 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 
     // just set to 10 ns for now?
     const double trackTime = 10 * Acts::UnitConstants::ns;
-    const int trackQ = -track->get_charge();  // charge is set in PHHoughTrackSeeding, copied over in PHGenFitTrkProp. Sign convention is apparently opposite here. Mag field sign?
+    const int trackQ = track->get_charge();
 
     const FW::TrackParameters trackSeed(seedCov, seedPos, seedMom, 
 					trackQ * Acts::UnitConstants::e, 

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -97,7 +97,12 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
       track->identify();
     }
 
-    const unsigned int vertexId = track->get_vertex_id();
+    unsigned int vertexId = track->get_vertex_id();
+
+    /// hack for now since TPC seeders don't set vertex id
+    if(vertexId == UINT_MAX)
+      vertexId = 0;
+
     const SvtxVertex *svtxVertex = m_vertexMap->get(vertexId);
     Acts::Vector3D vertex = {svtxVertex->get_x() * Acts::UnitConstants::cm, 
 			     svtxVertex->get_y() * Acts::UnitConstants::cm, 

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -204,13 +204,19 @@ int PHActsTrkProp::Process()
 	if(Verbosity() > 0)
 	  std::cout << "PHActsTrkProp : resetting covariance"<<std::endl;
 	Acts::BoundSymMatrix covariance;
-	covariance << 1000 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
-	  0., 1000 * Acts::UnitConstants::um, 0., 0., 0., 0.,
-	  0., 0., 0.01, 0., 0., 0.,
-	  0., 0., 0., 0.01, 0., 0.,
-	  0., 0., 0., 0., 0.0001, 0.,
+
+	/// If we are resetting the covariance and the space point
+	/// to the vertex, the POCA should have the covariance of the
+	/// vertex
+	covariance << 25 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
+	  0., 25 * Acts::UnitConstants::um, 0., 0., 0., 0.,
+	  0., 0., 0.005, 0., 0., 0.,
+	  0., 0., 0., 0.005, 0., 0.,
+	  0., 0., 0., 0., trackSeed.charge() * 0.0001, 0.,
 	  0., 0., 0., 0., 0., 1.;
-	Acts::Vector3D newPos(0.01,-0.01,30.);
+
+	Acts::Vector3D newPos(trackSeed.getVertex());
+
 	FW::TrackParameters trackSeedNewCov(covariance,
 					    newPos,
 					    trackSeed.momentum(),

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -208,14 +208,14 @@ int PHActsTrkProp::Process()
 	/// If we are resetting the covariance and the space point
 	/// to the vertex, the POCA should have the covariance of the
 	/// vertex
-	covariance << 25 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
-	  0., 25 * Acts::UnitConstants::um, 0., 0., 0., 0.,
-	  0., 0., 0.005, 0., 0., 0.,
-	  0., 0., 0., 0.005, 0., 0.,
-	  0., 0., 0., 0., trackSeed.charge() * 0.0001, 0.,
-	  0., 0., 0., 0., 0., 1.;
+	covariance << 1000 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
+	              0., 1000 * Acts::UnitConstants::um, 0., 0., 0., 0.,
+	              0., 0., 0.01, 0., 0., 0.,
+	              0., 0., 0., 0.01, 0., 0.,
+	              0., 0., 0., 0., 0.0001, 0.,
+	              0., 0., 0., 0., 0., 1.;
 
-	Acts::Vector3D newPos(trackSeed.getVertex());
+	Acts::Vector3D newPos(track.getVertex());
 
 	FW::TrackParameters trackSeedNewCov(covariance,
 					    newPos,

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -208,8 +208,8 @@ int PHActsTrkProp::Process()
 	/// If we are resetting the covariance and the space point
 	/// to the vertex, the POCA should have the covariance of the
 	/// vertex
-	covariance << 1000 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
-	              0., 1000 * Acts::UnitConstants::um, 0., 0., 0., 0.,
+	covariance << 50 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
+	              0., 25 * Acts::UnitConstants::um, 0., 0., 0., 0.,
 	              0., 0., 0.01, 0., 0., 0.,
 	              0., 0., 0., 0.01, 0., 0.,
 	              0., 0., 0., 0., 0.0001, 0.,

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -208,11 +208,11 @@ int PHActsTrkProp::Process()
 	  0., 1000 * Acts::UnitConstants::um, 0., 0., 0., 0.,
 	  0., 0., 0.01, 0., 0., 0.,
 	  0., 0., 0., 0.01, 0., 0.,
-	  0., 0., 0., 0., 0.01, 0.,
+	  0., 0., 0., 0., 0.0001, 0.,
 	  0., 0., 0., 0., 0., 1.;
-	
+	Acts::Vector3D newPos(0.01,-0.01,30.);
 	FW::TrackParameters trackSeedNewCov(covariance,
-					    trackSeed.position(),
+					    newPos,
 					    trackSeed.momentum(),
 					    trackSeed.charge(),
 					    trackSeed.time());

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -91,7 +91,10 @@ class PHActsTrkProp : public PHTrackPropagating
   void setVolumeMaxChi2(const int vol, const float maxChi2);
   void setVolumeLayerMaxChi2(const int vol, const int layer,
 			     const float maxChi2);
+  void resetCovariance(bool resetCovariance){m_resetCovariance = resetCovariance;}
+
  private:
+
   /// Event counter
   int m_event;
 
@@ -133,6 +136,8 @@ class PHActsTrkProp : public PHTrackPropagating
   std::vector<SourceLink> getEventSourceLinks();
 
   ActsTrackingGeometry *m_tGeometry;
+
+  bool m_resetCovariance;
 
   /// Track map with Svtx objects
   SvtxTrackMap *m_trackMap;


### PR DESCRIPTION
This PR implements changes to have the Acts CKF run with the TpcTracker seeder. The fitting produces good fits in momentum but not in track position, which probably is related to the poor TpcTracker seed position. This is a problem we will have to discuss with all of the TPC seeders.

This PR also implements the option to add the event vertex as a measurement to add to the fitting procedure. The measurement is added and the CKF recognizes this; however, we will have to iterate with the ACTS developers on how to force the propagator to "see" this measurement as it is not part of the `Acts::TrackingGeometry`. Currently the CKF only visits surfaces associated to the geometry and not isolated surfaces (e.g. the one associated to the vertex measurement).

One other issue with TPC seeders that will need to be addressed is that they currently don't associate a vertex to the track seed. Acts requires that the track seed be associated to a vertex estimate already before going into the CKF. Currently, if the track seed vertex has not been set, this PR just resets it to the first `SvtxVertex` available.

This PR also makes the Hough seeder functionality obsolete with Acts tracking, since the hough seeding has a mismatch in the track sign. For future reference, in case we need to come back....