### PR TITLE
Keep zero e hits

### DIFF
--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class BeamLineMagnetSubsystem - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -97,11 +97,6 @@ pkginclude_HEADERS = \
   PHG4SpacalSubsystem.h \
   PHG4StepStatusDecode.h 
 
-# I/O dictionaries have to exist for root5 and root6. For ROOT6 we need
-# pcm files in addition. If someone can figure out how to make a list
-# so this list of dictionaries is transformed into a list of pcm files
-# following a simple naming convention, please change this accordingly and
-# let me know
 ROOT_IO_DICTS = \
   PHG4BlockCellGeom_Dict.cc \
   PHG4BlockCellGeomContainer_Dict.cc \
@@ -132,13 +127,7 @@ ROOT_IO_DICTS = \
   PHG4ScintillatorSlat_Dict.cc \
   PHG4ScintillatorSlatv1_Dict.cc \
   PHG4ScintillatorSlatContainer_Dict.cc
-# for root6 we need pcm and dictionaries but only for
-# i/o classes. For root5 we need only dictionaries but
-# those for i/o and classes available on the cmd line
-# MAKEROOT6 is set in the configure.ac, true for root6
-if MAKEROOT6
-# this is a tweak to install files in $(libdir), automake refuses
-# to install other files in libdir, this construct gets around this
+
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
   PHG4BlockCellGeom_Dict_rdict.pcm \
@@ -170,48 +159,9 @@ nobase_dist_pcm_DATA = \
   PHG4ScintillatorSlat_Dict_rdict.pcm \
   PHG4ScintillatorSlatv1_Dict_rdict.pcm \
   PHG4ScintillatorSlatContainer_Dict_rdict.pcm
-else
-  ROOT5_IO_DICTS = \
-  PHG4CellDefs_Dict.cc \
-  PHG4ScintillatorSlatDefs_Dict.cc
-  ROOT5_DICTS = \
-  BeamLineMagnetSubsystem_Dict.cc \
-  ePHENIXRICHConstruction_Dict.cc \
-  PHG4GDMLSubsystem_Dict.cc \
-  PHG4BeamlineMagnetSubsystem_Dict.cc \
-  PHG4BlockCellReco_Dict.cc \
-  PHG4BlockSubsystem_Dict.cc \
-  PHG4CEmcTestBeamSubsystem_Dict.cc \
-  PHG4ConeSubsystem_Dict.cc \
-  PHG4CrystalCalorimeterSubsystem_Dict.cc \
-  PHG4CylinderSubsystem_Dict.cc \
-  PHG4CylinderCellReco_Dict.cc \
-  PHG4DetectorGroupSubsystem_Dict.cc \
-  PHG4DetectorSubsystem_Dict.cc \
-  PHG4EnvelopeSubsystem_Dict.cc \
-  PHG4FCalSubsystem_Dict.cc \
-  PHG4ForwardEcalSubsystem_Dict.cc \
-  PHG4ForwardHcalSubsystem_Dict.cc \
-  PHG4ForwardCalCellReco_Dict.cc \
-  PHG4FPbScSubsystem_Dict.cc \
-  PHG4GenHit_Dict.cc \
-  PHG4HcalCellReco_Dict.cc \
-  PHG4HcalSubsystem_Dict.cc \
-  PHG4InnerHcalSubsystem_Dict.cc \
-  PHG4OuterHcalSubsystem_Dict.cc \
-  PHG4RICHSubsystem_Dict.cc \
-  PHG4SectorConstructor_Dict.cc \
-  PHG4SectorSubsystem_Dict.cc \
-  PHG4PSTOFSubsystem_Dict.cc \
-  PHG4FullProjSpacalCellReco_Dict.cc \
-  PHG4SpacalSubsystem_Dict.cc \
-  PHG4mRICHSubsystem_Dict.cc
-
-endif
 
 libg4detectors_io_la_SOURCES = \
   $(ROOT_IO_DICTS) \
-  $(ROOT5_IO_DICTS) \
   PHG4BlockCellGeom.cc \
   PHG4BlockCellGeomContainer.cc \
   PHG4BlockGeom.cc \
@@ -244,7 +194,6 @@ libg4detectors_io_la_SOURCES = \
   PHG4ScintillatorSlatContainer.cc
 
 libg4detectors_la_SOURCES = \
-  $(ROOT5_DICTS) \
   BeamLineMagnetDetector.cc \
   BeamLineMagnetDisplayAction.cc \
   BeamLineMagnetSubsystem.cc \
@@ -344,7 +293,7 @@ bin_SCRIPTS = \
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h
-	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+	rootcint -f $@ @CINTDEFS@ $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
 
 #just to get the dependency
 %_Dict_rdict.pcm: %_Dict.cc ;

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4BeamlineMagnetSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4BlockSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4CEmcTestBeamSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4ConeSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4ConeSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4CrystalCalorimeterSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -57,7 +57,7 @@ void PHG4CylinderDetector::ConstructMe(G4LogicalVolume *logicWorld)
 
   if (!TrackerMaterial)
   {
-    std::cout << "Error: Can not set material" << std::endl;
+    cout << "Error: Can not set material " << m_Params->get_string_param("material") << endl;
     gSystem->Exit(1);
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -298,8 +298,8 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         aTrack->GetTrackStatus() == fStopAndKill ||
         m_UseG4StepsFlag > 0)
     {
-      // save only hits with energy deposit (or -1 for geantino)
-      if (m_Hit->get_edep())
+      // save only hits with energy deposit (or -1 for geantino) or if save all hits flag is set
+      if (m_Hit->get_edep() || m_SaveAllHitsFlag)
       {
         m_HitContainer->AddHit(layer_id, m_Hit);
         if (m_SaveShower)

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -10,7 +10,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 
@@ -19,33 +19,33 @@
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fPostSt...
-#include <Geant4/G4String.hh>                  // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fPostSt...
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>         // for G4VPhysicalVolume
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <boost/io/ios_state.hpp>
 
-#include <cmath>                               // for isfinite, copysign
-#include <cstdlib>                            // for exit
+#include <cmath>    // for isfinite, copysign
+#include <cstdlib>  // for exit
 #include <iomanip>
 #include <iostream>
-#include <string>                              // for operator<<, char_traits
+#include <string>  // for operator<<, char_traits
 
 class PHCompositeNode;
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4CylinderSteppingAction::PHG4CylinderSteppingAction(PHG4CylinderSubsystem *subsys, PHG4CylinderDetector* detector, const PHParameters* parameters)
-  :  PHG4SteppingAction(detector->GetName())
+PHG4CylinderSteppingAction::PHG4CylinderSteppingAction(PHG4CylinderSubsystem* subsys, PHG4CylinderDetector* detector, const PHParameters* parameters)
+  : PHG4SteppingAction(detector->GetName())
   , m_Subsystem(subsys)
   , m_Detector(detector)
   , m_Params(parameters)

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -32,17 +32,16 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
 
   void SaveLightYield(const int i = 1) { m_SaveLightYieldFlag = i; }
 
-// needed for hit position crosschecks, if this volume is inside
-// another volume the absolut hit coordinates in our G4Hits and
-// the local coordinates differ, so checking against our place in z
-// goes wrong
+  // needed for hit position crosschecks, if this volume is inside
+  // another volume the absolut hit coordinates in our G4Hits and
+  // the local coordinates differ, so checking against our place in z
+  // goes wrong
   bool hasMotherSubsystem() const;
 
-// this is just needed for use as reference plane for projections
-// this is the only detector using this - there is no need to add
-// this to our parameters
-  void SaveAllHits(bool i = true) {m_SaveAllHitsFlag = i;}
-
+  // this is just needed for use as reference plane for projections
+  // this is the only detector using this - there is no need to add
+  // this to our parameters
+  void SaveAllHits(bool i = true) { m_SaveAllHitsFlag = i; }
 
  private:
   //! pointer to the Subsystem

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -38,6 +38,12 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
 // goes wrong
   bool hasMotherSubsystem() const;
 
+// this is just needed for use as reference plane for projections
+// this is the only detector using this - there is no need to add
+// this to our parameters
+  void SaveAllHits(bool i = true) {m_SaveAllHitsFlag = i;}
+
+
  private:
   //! pointer to the Subsystem
   PHG4CylinderSubsystem *m_Subsystem;
@@ -51,6 +57,7 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
   PHG4Shower *m_SaveShower;
   G4VPhysicalVolume *m_SaveVolPre;
   G4VPhysicalVolume *m_SaveVolPost;
+  bool m_SaveAllHitsFlag = false;
   int m_SaveLightYieldFlag;
   int m_SaveTrackId;
   int m_SavePreStepStatus;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -18,6 +18,7 @@
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
+#include <phool/recoConsts.h>
 
 #include <cmath>     // for NAN
 #include <iostream>  // for operator<<, basic_ostream, endl
@@ -58,6 +59,12 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   else
   {
     GetParams()->set_int_param("lengthviarapidity", 0);
+  }
+// use world material if material was not set so far
+  if (GetParams()->get_string_param("material") == "WorldMaterial")
+  {
+    recoConsts *rc = recoConsts::instance();
+    GetParams()->set_string_param("material",rc->get_StringFlag("WorldMaterial"));
   }
   // create display settings before detector
   PHG4CylinderDisplayAction *disp_action = new PHG4CylinderDisplayAction(Name(), GetParams());
@@ -163,7 +170,8 @@ void PHG4CylinderSubsystem::SetDefaultParameters()
   set_default_int_param("lightyield", 0);
   set_default_int_param("use_g4steps", 0);
 
-  set_default_string_param("material", "G4_Galactic");
+// place holder, will be replaced by world material if not set by other means (macro)
+  set_default_string_param("material", "WorldMaterial");
 }
 
 PHG4Detector *

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -57,11 +57,11 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   {
     GetParams()->set_int_param("lengthviarapidity", 0);
   }
-// use world material if material was not set so far
+  // use world material if material was not set so far
   if (GetParams()->get_string_param("material") == "WorldMaterial")
   {
     recoConsts *rc = recoConsts::instance();
-    GetParams()->set_string_param("material",rc->get_StringFlag("WorldMaterial"));
+    GetParams()->set_string_param("material", rc->get_StringFlag("WorldMaterial"));
   }
   // create display settings before detector
   PHG4CylinderDisplayAction *disp_action = new PHG4CylinderDisplayAction(Name(), GetParams());
@@ -171,7 +171,7 @@ void PHG4CylinderSubsystem::SetDefaultParameters()
   set_default_int_param("lightyield", 0);
   set_default_int_param("use_g4steps", 0);
 
-// place holder, will be replaced by world material if not set by other means (macro)
+  // place holder, will be replaced by world material if not set by other means (macro)
   set_default_string_param("material", "WorldMaterial");
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -32,9 +32,6 @@ using namespace std;
 //_______________________________________________________________________
 PHG4CylinderSubsystem::PHG4CylinderSubsystem(const std::string &na, const int lyr)
   : PHG4DetectorSubsystem(na, lyr)
-  , m_Detector(nullptr)
-  , m_SteppingAction(nullptr)
-  , m_DisplayAction(nullptr)
 {
   m_ColorArray.fill(NAN);
   InitializeParameters();
@@ -138,6 +135,10 @@ int PHG4CylinderSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   else if (GetParams()->get_int_param("blackhole"))
   {
     m_SteppingAction = new PHG4CylinderSteppingAction(this, m_Detector, GetParams());
+  }
+  if (m_SteppingAction)
+  {
+    (dynamic_cast<PHG4CylinderSteppingAction *>(m_SteppingAction))->SaveAllHits(m_SaveAllHitsFlag);
   }
   return 0;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -29,23 +29,23 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
   creates the stepping action
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode*);
+  int InitRunSubsystem(PHCompositeNode*) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //! Print info (from SubsysReco)
-  void Print(const std::string& what = "ALL") const;
+  void Print(const std::string& what = "ALL") const override;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector(void) const;
-  PHG4SteppingAction* GetSteppingAction(void) const { return m_SteppingAction; }
+  PHG4Detector* GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction(void) const  override { return m_SteppingAction; }
 
-  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+  PHG4DisplayAction* GetDisplayAction() const  override { return m_DisplayAction; }
   void set_color(const double red, const double green, const double blue, const double alpha = 1.)
   {
     m_ColorArray[0] = red;
@@ -56,23 +56,29 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
   // this method is used to check if it can be used as mothervolume
   // Subsystems which can be mothervolume need to implement this
   // and return true
-  virtual bool CanBeMotherSubsystem() const { return true; }
+  virtual bool CanBeMotherSubsystem() const  override { return true; }
+
+// this is just needed for use as reference plane for projections
+// this is the only detector using this - there is no need to add
+// this to our parameters
+  void SaveAllHits(bool i = true) {m_SaveAllHitsFlag = i;}
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   //! detector geometry
   /*! derives from PHG4Detector */
-  PHG4CylinderDetector* m_Detector;
+  PHG4CylinderDetector* m_Detector = nullptr;
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
-  PHG4SteppingAction* m_SteppingAction;
+  PHG4SteppingAction* m_SteppingAction = nullptr;
 
   //! display attribute setting
   /*! derives from PHG4DisplayAction */
-  PHG4DisplayAction* m_DisplayAction;
+  PHG4DisplayAction* m_DisplayAction = nullptr;
 
+  bool m_SaveAllHitsFlag = false;
   //! Color setting if we want to override the default
   std::array<double, 4> m_ColorArray;
 };

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -5,7 +5,7 @@
 
 #include "PHG4DetectorSubsystem.h"
 
-#include <array>  // for array
+#include <array>   // for array
 #include <string>  // for string
 
 class PHCompositeNode;
@@ -43,9 +43,9 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
 
   //! accessors (reimplemented)
   PHG4Detector* GetDetector(void) const override;
-  PHG4SteppingAction* GetSteppingAction(void) const  override { return m_SteppingAction; }
+  PHG4SteppingAction* GetSteppingAction(void) const override { return m_SteppingAction; }
 
-  PHG4DisplayAction* GetDisplayAction() const  override { return m_DisplayAction; }
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
   void set_color(const double red, const double green, const double blue, const double alpha = 1.)
   {
     m_ColorArray[0] = red;
@@ -56,12 +56,12 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
   // this method is used to check if it can be used as mothervolume
   // Subsystems which can be mothervolume need to implement this
   // and return true
-  virtual bool CanBeMotherSubsystem() const  override { return true; }
+  virtual bool CanBeMotherSubsystem() const override { return true; }
 
-// this is just needed for use as reference plane for projections
-// this is the only detector using this - there is no need to add
-// this to our parameters
-  void SaveAllHits(bool i = true) {m_SaveAllHitsFlag = i;}
+  // this is just needed for use as reference plane for projections
+  // this is the only detector using this - there is no need to add
+  // this to our parameters
+  void SaveAllHits(bool i = true) { m_SaveAllHitsFlag = i; }
 
  private:
   void SetDefaultParameters() override;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4CylinderSubsystem - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4DetectorGroupSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4DetectorSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4EnvelopeSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4FCalSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4FCalSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4FCalSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4FPbScSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4FPbScSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4FPbScSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4ForwardEcalSubsystem - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4ForwardHcalSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4GDMLSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4HcalSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4HcalSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4InnerHcalSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4OuterHcalSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4PSTOFSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4RICHSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4RICHSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4RICHSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4SectorSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4SectorSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4SpacalSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4mRICHSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4mRICHSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/configure.ac
+++ b/simulation/g4simulation/g4detectors/configure.ac
@@ -14,12 +14,8 @@ case $CXX in
  ;;
 esac
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
-fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4detectors/ePHENIXRICHConstructionLinkDef.h
+++ b/simulation/g4simulation/g4detectors/ePHENIXRICHConstructionLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class ePHENIXRICH::RICH_Geometry-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -318,7 +318,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
 {
   // this is a dumb protection against executing this twice.
   // we have cases (currently detector display or material scan) where
-  // we need the detector bu have not run any events (who wants to wait
+  // we need the detector but have not run any events (who wants to wait
   // for processing an event if you just want a detector display?).
   // Then the InitRun is executed from a macro. But if you decide to run events
   // afterwards, the InitRun is executed by the framework together with all
@@ -336,6 +336,12 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   }
 
   recoConsts *rc = recoConsts::instance();
+
+  rc->set_StringFlag("WorldMaterial", m_WorldMaterial);
+
+  rc->set_FloatFlag("WorldSizex", m_WorldSize[0]);
+  rc->set_FloatFlag("WorldSizey", m_WorldSize[1]);
+  rc->set_FloatFlag("WorldSizez", m_WorldSize[2]);
 
   //setup the global field
   const int field_ret = InitField(topNode);
@@ -367,9 +373,6 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   m_Detector->SetWorldShape(m_WorldShape);
   m_Detector->SetWorldMaterial(m_WorldMaterial);
 
-  rc->set_FloatFlag("WorldSizex", m_WorldSize[0]);
-  rc->set_FloatFlag("WorldSizey", m_WorldSize[1]);
-  rc->set_FloatFlag("WorldSizez", m_WorldSize[2]);
 
   BOOST_FOREACH (PHG4Subsystem *g4sub, m_SubsystemList)
   {

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -164,7 +164,7 @@ int PHG4TrackFastSimEval::InitRun(PHCompositeNode *topNode)
         m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_p_vec[iter->second][i], bdef.c_str());
       }
     }
-    if (!hits)
+    if (!hits && Verbosity() > 0)
     {
       cout << "InitRun: could not find " << nodename << endl;
     }


### PR DESCRIPTION
This PR adds a switch to the cylinder subsystem which keeps zero energy hits. This is needed for reference cylinders for projections where we want to look at the actual G4 hit position.

Added override keyword to the PHG4CylinderSubsystem mathods

This adds a recoConst flag for the world material, so we can change it consistently (right now you'll find G4_AIR all over the place which then messes with the material scans where we use G4_Galactic.

Farewell to root5 in simulation/g4simulation/g4detectors