### PR TITLE
Mvtx Acts Geometry Update

### DIFF
--- a/offline/packages/PHTpcTracker/externals/kdfinder.hpp
+++ b/offline/packages/PHTpcTracker/externals/kdfinder.hpp
@@ -699,7 +699,7 @@ namespace kdfinder
         T t40 = (-t3 * t38);
         if (t40 < 0.)
         {
-          std::cerr << "t40 < 0." << std::endl;
+          //std::cerr << "t40 < 0." << std::endl;
           return VALUE;
         }
         t40 = std::sqrt(t40);

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -801,7 +801,7 @@ void MakeActsGeometry::makeTGeoNodeMap(PHCompositeNode *topNode)
 
   if (!m_geoManager)
   {
-    cout << PHWHERE << " Did not find TGeoManager, quit! " << endl;
+    std::cout << PHWHERE << " Did not find TGeoManager, quit! " << std::endl;
     return;
   }
   TGeoVolume *topVol = m_geoManager->GetTopVolume();
@@ -813,7 +813,7 @@ void MakeActsGeometry::makeTGeoNodeMap(PHCompositeNode *topNode)
     TGeoNode *node = dynamic_cast<TGeoNode *>(obj);
     std::string node_str = node->GetName();
 
-    std::string mvtx("av_1");
+    std::string mvtx("MVTX_Wrapper");
     std::string intt("ladder");
     std::string intt_ext("ladderext");
     std::string tpc("tpc_envelope");
@@ -821,8 +821,23 @@ void MakeActsGeometry::makeTGeoNodeMap(PHCompositeNode *topNode)
     if (node_str.compare(0, mvtx.length(), mvtx) == 0)  // is it in the MVTX?
     {
       if (m_verbosity > 2) 
-	cout << " node " << node->GetName() << " is in the MVTX" << endl;
-      getMvtxKeyFromNode(node);
+	std::cout << " node " << node->GetName() << " is the MVTX wrapper" 
+		  << std::endl;
+  
+      /// The Mvtx has an additional wrapper that needs to be unpacked
+      TObjArray *mvtxArray = node->GetNodes();
+      TIter mvtxObj(mvtxArray);
+      while(TObject *mvtx = mvtxObj())
+	{
+	  TGeoNode *mvtxNode = dynamic_cast<TGeoNode *>(mvtx);
+	  if(m_verbosity > 2)
+	    std::cout << "mvtx node name is " << mvtxNode->GetName() << std::endl;
+	  std::string mvtxav1("av_1");
+	  std::string mvtxNodeName = mvtxNode->GetName();
+	  /// We only want the av_1 nodes
+	  if(mvtxNodeName.compare(0, mvtxav1.length(), mvtxav1) == 0)
+	    getMvtxKeyFromNode(mvtxNode);
+	}
     }
     else if (node_str.compare(0, intt.length(), intt) == 0)  // is it in the INTT?
     {
@@ -831,7 +846,8 @@ void MakeActsGeometry::makeTGeoNodeMap(PHCompositeNode *topNode)
         continue;
 
       if (m_verbosity > 2) 
-	cout << " node " << node->GetName() << " is in the INTT" << endl;
+	std::cout << " node " << node->GetName() << " is in the INTT" 
+		  << std::endl;
       getInttKeyFromNode(node);
     }
     else if (node_str.compare(0, tpc.length(), tpc) == 0)  // is it in the TPC?

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -654,7 +654,7 @@ void PHActsSourceLinks::addVerticesAsSourceLinks(PHCompositeNode *topNode,
 	for(int j = 0; j < 3; j++)
 	  worldErr(i,j) = vertex->get_error(i, j);
 
-      if(Verbosity() == 0)
+      if(Verbosity() > 1)
 	{
 	  std::cout << "global cov xx, yy, zz: " << worldErr(0,0) 
 		    << ", " << worldErr(1,1) << ", " << worldErr(2,2)

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -81,7 +81,7 @@ int PHActsSourceLinks::InitRun(PHCompositeNode *topNode)
   /// Check if Acts geometry has been built and is on the node tree
   m_actsGeometry = new MakeActsGeometry();
   
-  m_actsGeometry->setVerbosity(0);
+  m_actsGeometry->setVerbosity(Verbosity());
   m_actsGeometry->buildAllGeometry(topNode);
 
   /// Set the tGeometry struct to be put on the node tree

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -95,7 +95,9 @@ class PHActsSourceLinks : public SubsysReco
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
   int ResetEvent(PHCompositeNode *topNode);
-  
+  void useVertexAsMeasurement(bool useVertexMeasurement)
+    {m_useVertexMeasurement = useVertexMeasurement;}
+
  private:
   /**
    * Functions
@@ -148,9 +150,14 @@ class PHActsSourceLinks : public SubsysReco
                             const TrkrCluster *cluster,
                             const TrkrDefs::cluskey clusKey);
 
+  void addVerticesAsSourceLinks(PHCompositeNode *topNode,
+				unsigned int &hitId);
+
   /**
    * Member variables
    */
+
+  bool m_useVertexMeasurement;
 
   /// SvtxCluster node
   TrkrClusterContainer *m_clusterMap;

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -146,7 +146,7 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 
     // just set to 10 ns for now?
     const double trackTime = 10 * Acts::UnitConstants::ns;
-    const int trackQ = -track->get_charge();  // charge is set in PHHoughTrackSeeding, copied over in PHGenFitTrkProp. Sign convention is apparently opposite here. Mag field sign?
+    const int trackQ = track->get_charge();
 
     const FW::TrackParameters trackSeed(seedCov, seedPos, seedMom, 
 					trackQ * Acts::UnitConstants::e, 

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -97,7 +97,12 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
       track->identify();
     }
 
-    const unsigned int vertexId = track->get_vertex_id();
+    unsigned int vertexId = track->get_vertex_id();
+
+    /// hack for now since TPC seeders don't set vertex id
+    if(vertexId == UINT_MAX)
+      vertexId = 0;
+
     const SvtxVertex *svtxVertex = m_vertexMap->get(vertexId);
     Acts::Vector3D vertex = {svtxVertex->get_x() * Acts::UnitConstants::cm, 
 			     svtxVertex->get_y() * Acts::UnitConstants::cm, 

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -204,13 +204,19 @@ int PHActsTrkProp::Process()
 	if(Verbosity() > 0)
 	  std::cout << "PHActsTrkProp : resetting covariance"<<std::endl;
 	Acts::BoundSymMatrix covariance;
-	covariance << 1000 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
-	  0., 1000 * Acts::UnitConstants::um, 0., 0., 0., 0.,
-	  0., 0., 0.01, 0., 0., 0.,
-	  0., 0., 0., 0.01, 0., 0.,
-	  0., 0., 0., 0., 0.0001, 0.,
+
+	/// If we are resetting the covariance and the space point
+	/// to the vertex, the POCA should have the covariance of the
+	/// vertex
+	covariance << 25 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
+	  0., 25 * Acts::UnitConstants::um, 0., 0., 0., 0.,
+	  0., 0., 0.005, 0., 0., 0.,
+	  0., 0., 0., 0.005, 0., 0.,
+	  0., 0., 0., 0., trackSeed.charge() * 0.0001, 0.,
 	  0., 0., 0., 0., 0., 1.;
-	Acts::Vector3D newPos(0.01,-0.01,30.);
+
+	Acts::Vector3D newPos(trackSeed.getVertex());
+
 	FW::TrackParameters trackSeedNewCov(covariance,
 					    newPos,
 					    trackSeed.momentum(),

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -208,14 +208,14 @@ int PHActsTrkProp::Process()
 	/// If we are resetting the covariance and the space point
 	/// to the vertex, the POCA should have the covariance of the
 	/// vertex
-	covariance << 25 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
-	  0., 25 * Acts::UnitConstants::um, 0., 0., 0., 0.,
-	  0., 0., 0.005, 0., 0., 0.,
-	  0., 0., 0., 0.005, 0., 0.,
-	  0., 0., 0., 0., trackSeed.charge() * 0.0001, 0.,
-	  0., 0., 0., 0., 0., 1.;
+	covariance << 1000 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
+	              0., 1000 * Acts::UnitConstants::um, 0., 0., 0., 0.,
+	              0., 0., 0.01, 0., 0., 0.,
+	              0., 0., 0., 0.01, 0., 0.,
+	              0., 0., 0., 0., 0.0001, 0.,
+	              0., 0., 0., 0., 0., 1.;
 
-	Acts::Vector3D newPos(trackSeed.getVertex());
+	Acts::Vector3D newPos(track.getVertex());
 
 	FW::TrackParameters trackSeedNewCov(covariance,
 					    newPos,

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -208,11 +208,11 @@ int PHActsTrkProp::Process()
 	  0., 1000 * Acts::UnitConstants::um, 0., 0., 0., 0.,
 	  0., 0., 0.01, 0., 0., 0.,
 	  0., 0., 0., 0.01, 0., 0.,
-	  0., 0., 0., 0., 0.01, 0.,
+	  0., 0., 0., 0., 0.0001, 0.,
 	  0., 0., 0., 0., 0., 1.;
-	
+	Acts::Vector3D newPos(0.01,-0.01,30.);
 	FW::TrackParameters trackSeedNewCov(covariance,
-					    trackSeed.position(),
+					    newPos,
 					    trackSeed.momentum(),
 					    trackSeed.charge(),
 					    trackSeed.time());

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -91,7 +91,10 @@ class PHActsTrkProp : public PHTrackPropagating
   void setVolumeMaxChi2(const int vol, const float maxChi2);
   void setVolumeLayerMaxChi2(const int vol, const int layer,
 			     const float maxChi2);
+  void resetCovariance(bool resetCovariance){m_resetCovariance = resetCovariance;}
+
  private:
+
   /// Event counter
   int m_event;
 
@@ -133,6 +136,8 @@ class PHActsTrkProp : public PHTrackPropagating
   std::vector<SourceLink> getEventSourceLinks();
 
   ActsTrackingGeometry *m_tGeometry;
+
+  bool m_resetCovariance;
 
   /// Track map with Svtx objects
   SvtxTrackMap *m_trackMap;


### PR DESCRIPTION
This PR implements an update to the MVTX geometry unpacking when constructing the map between `TrkrDef::hitsetkey` and MVTX `TGeoNode`. The MVTX geometry was recently changed to be in a wrapper, so this PR unwraps the wrapper to grab the relevant nodes.

Note - this is branched off of [PR 901](https://github.com/sPHENIX-Collaboration/coresoftware/pull/901). So, the commits that are unrelated to this particular problem that are currently shown at the opening of the PR will go away once 901 is merged.