### PR TITLE
New Clusterizer

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -28,7 +28,6 @@
 #include <TMatrixT.h>       // for TMatrixT, ope...
 #include <TMatrixTUtils.h>  // for TMatrixTRow
 
-#include <TNtuple.h>  
 #include <TFile.h>  
 
 #include <cmath>  // for sqrt, cos, sin
@@ -61,8 +60,6 @@ TpcClusterizer::TpcClusterizer(const string &name)
   , NPhiBinsMin(0)
   , NZBinsMax(0)
   , NZBinsMin(0)
-  , hit_nt(nullptr)
-  , cluster_nt(nullptr)
 {
 }
 
@@ -689,14 +686,5 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
 
 int TpcClusterizer::End(PHCompositeNode *topNode)
 {
-  /*
-  if (Verbosity() > 10)
-  {
-    TFile *outf = new TFile("cluster_nt_out.root", "recreate");
-    outf->WriteTObject(hit_nt);
-    outf->WriteTObject(cluster_nt);
-    outf->Close();
-  }
-  */
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -38,12 +38,10 @@
 #include <utility>  // for pair
 #include <vector>
 
-namespace 
-{
-  template<class T> inline constexpr T square( const T& x ) { return x*x; }
-}
-
 using namespace std;
+
+typedef std::pair<int, int> iphiz;
+typedef std::pair<double, iphiz> ihit;
 
 TpcClusterizer::TpcClusterizer(const string &name)
   : SubsysReco(name)
@@ -179,6 +177,359 @@ void TpcClusterizer::get_cluster(int phibin, int zbin, int &phiup, int &phidown,
   }
 }
 
+void TpcClusterizer::remove_hit(double adc, int phibin, int zbin, std::multimap<double, ihit> &all_hit_map, std::vector<std::vector<double>> &adcval)
+{
+  typedef multimap<double, ihit>::iterator hit_iterator;
+  pair<hit_iterator, hit_iterator> iterpair = all_hit_map.equal_range(adc);
+  hit_iterator it = iterpair.first;
+  for (; it != iterpair.second; ++it) {
+    if (it->second.second.first == phibin && it->second.second.second == zbin) { 
+      if(Verbosity()>10) cout << " found it, erasing it "<< endl;
+      all_hit_map.erase(it);
+      break;
+    }
+  }
+  adcval[phibin][zbin] = 0;
+}
+
+void TpcClusterizer::remove_hits(std::vector<ihit> &ihit_list, std::multimap<double, ihit> &all_hit_map,std::vector<std::vector<double>> &adcval )
+{
+  for(auto iter = ihit_list.begin(); iter != ihit_list.end();++iter){
+    double adc = iter->first; 
+    int phibin = iter->second.first;
+    int zbin   = iter->second.second;
+    if(Verbosity()>10) cout << "remove adc: " << adc << " phi: " << phibin << " zbin " << zbin << endl; 
+    remove_hit(adc,phibin,zbin,all_hit_map,adcval);
+
+  }
+}
+
+void TpcClusterizer::calc_cluster_parameter(std::vector<ihit> &ihit_list,int iclus, PHG4CylinderCellGeom *layergeom, TrkrHitSet *hitset)
+{
+
+  ///HERE TODO
+  //cout << "TpcClusterizer: process cluster iclus = " << iclus <<  " in layer " << layer << endl;
+  // loop over the hits in this cluster
+  double zsum = 0.0;
+  double phi_sum = 0.0;
+  double adc_sum = 0.0;
+  double radius = layergeom->get_radius();  // returns center of layer
+    
+  int phibinhi = -1;
+  int phibinlo = 666666;
+  int zbinhi = -1;
+  int zbinlo = 666666;
+  //  int clus_size = ihit_list.size();
+
+  std::vector<TrkrDefs::hitkey> hitkeyvec;
+  for(auto iter = ihit_list.begin(); iter != ihit_list.end();++iter){
+    double adc = iter->first; 
+    int iphi = iter->second.first;
+    int iz   = iter->second.second;
+    if(iphi > phibinhi) phibinhi = iphi;
+    if(iphi < phibinlo) phibinlo = iphi;
+    if(iz > zbinhi) zbinhi = iz;
+    if(iz < zbinlo) zbinlo = iz;
+
+    //    if(Verbosity()>10) cout << "remove adc: " << adc << " phi: " << iphi << " zbin " << iz << endl; 
+
+    double phi_center = layergeom->get_phicenter(iphi);
+    double z = layergeom->get_zcenter(iz);
+	  
+    zsum += z * adc;
+    phi_sum += phi_center * adc;
+    adc_sum += adc;
+    // capture the hitkeys for all non-zero adc values
+    if (adc != 0){
+      TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, iz);
+      hitkeyvec.push_back(hitkey);
+    }
+  }
+  //  if (adc_sum < 10) return;  // skip obvious noise "clusters"
+  
+  // This is the global position
+  double clusphi = phi_sum / adc_sum;
+  double clusz = zsum / adc_sum;
+  
+  // create the cluster entry directly in the node tree
+  TrkrDefs::cluskey ckey = TpcDefs::genClusKey(hitset->getHitSetKey(), iclus);
+  TrkrClusterv1 *clus = static_cast<TrkrClusterv1 *>((m_clusterlist->findOrAddCluster(ckey))->second);
+  
+  //int phi_nsize = phibinhi - phibinlo + 1;
+  //int z_nsize   = zbinhi   - zbinlo + 1;
+  
+  double phi_size = (double) (phibinhi - phibinlo + 1) * radius * layergeom->get_phistep();
+  double z_size = (double) (zbinhi - zbinlo + 1) * layergeom->get_zstep();
+  
+  // Estimate the errors
+  double dphi2_adc = 0.0;
+  double dphi_adc = 0.0;
+  double dz2_adc = 0.0;
+  double dz_adc = 0.0;
+      
+  for(auto iter = ihit_list.begin(); iter != ihit_list.end();++iter){
+    double adc = iter->first; 
+    int iphi = iter->second.first;
+    int iz   = iter->second.second;
+    double dphi = layergeom->get_phicenter(iphi) - clusphi;
+    dphi2_adc += dphi * dphi * adc;
+    dphi_adc += dphi * adc;
+    
+    double dz = layergeom->get_zcenter(iz) - clusz;
+    dz2_adc += dz * dz * adc;
+    dz_adc += dz * adc;
+  }
+  double phi_cov = (dphi2_adc / adc_sum - dphi_adc * dphi_adc / (adc_sum * adc_sum));
+  double z_cov = dz2_adc / adc_sum - dz_adc * dz_adc / (adc_sum * adc_sum);
+  
+  //cout << "   layer " << layer << " z_cov " << z_cov << " dz2_adc " << dz2_adc << " adc_sum " <<  adc_sum << " dz_adc " << dz_adc << endl;
+  
+  // phi_cov = (weighted mean of dphi^2) - (weighted mean of dphi)^2,  which is essentially the weighted mean of dphi^2. The error is then:
+  // e_phi = sigma_dphi/sqrt(N) = sqrt( sigma_dphi^2 / N )  -- where N is the number of samples of the distribution with standard deviation sigma_dphi
+  //    - N is the number of electrons that drift to the readout plane
+  // We have to convert (sum of adc units for all bins in the cluster) to number of ionization electrons N
+  // Conversion gain is 20 mV/fC - relates total charge collected on pad to PEAK voltage out of ADC. The GEM gain is assumed to be 2000
+  // To get equivalent charge per Z bin, so that summing ADC input voltage over all Z bins returns total input charge, divide voltages by 2.4 for 80 ns SAMPA
+  // Equivalent charge per Z bin is then  (ADU x 2200 mV / 1024) / 2.4 x (1/20) fC/mV x (1/1.6e-04) electrons/fC x (1/2000) = ADU x 0.14
+  
+  double phi_err = radius * sqrt(phi_cov / (adc_sum * 0.14));
+  if (phi_err == 0.0)  // a single phi bin will cause this
+    phi_err = radius * layergeom->get_phistep() / sqrt(12.0);
+  
+  double z_err = sqrt(z_cov / (adc_sum * 0.14));
+  if (z_err == 0.0)
+    z_err = layergeom->get_zstep() / sqrt(12.0);
+  
+  // This corrects the bias introduced by the asymmetric SAMPA chip shaping - assumes 80 ns shaping time
+
+  if (clusz < 0)
+    clusz -= zz_shaping_correction;
+  else
+    clusz += zz_shaping_correction;
+  
+  // Fill in the cluster details
+  //================
+  clus->setAdc(adc_sum);
+  clus->setPosition(0, radius * cos(clusphi));
+  clus->setPosition(1, radius * sin(clusphi));
+  clus->setPosition(2, clusz);
+  clus->setGlobal();
+  
+  TMatrixF DIM(3, 3);
+  DIM[0][0] = 0.0;
+  DIM[0][1] = 0.0;
+  DIM[0][2] = 0.0;
+  DIM[1][0] = 0.0;
+  DIM[1][1] = pow(0.5 * phi_size,2);  //cluster_v1 expects 1/2 of actual size
+  DIM[1][2] = 0.0;
+  DIM[2][0] = 0.0;
+  DIM[2][1] = 0.0;
+  DIM[2][2] = pow(0.5 * z_size,2);
+  
+  TMatrixF ERR(3, 3);
+  ERR[0][0] = 0.0;
+  ERR[0][1] = 0.0;
+  ERR[0][2] = 0.0;
+  ERR[1][0] = 0.0;
+  ERR[1][1] = phi_err * phi_err;  //cluster_v1 expects rad, arc, z as elementsof covariance
+  ERR[1][2] = 0.0;
+  ERR[2][0] = 0.0;
+  ERR[2][1] = 0.0;
+  ERR[2][2] = z_err * z_err;
+  
+  TMatrixF ROT(3, 3);
+  ROT[0][0] = cos(clusphi);
+  ROT[0][1] = -sin(clusphi);
+  ROT[0][2] = 0.0;
+  ROT[1][0] = sin(clusphi);
+  ROT[1][1] = cos(clusphi);
+  ROT[1][2] = 0.0;
+  ROT[2][0] = 0.0;
+  ROT[2][1] = 0.0;
+  ROT[2][2] = 1.0;
+  
+  TMatrixF ROT_T(3, 3);
+  ROT_T.Transpose(ROT);
+  
+  TMatrixF COVAR_DIM(3, 3);
+  COVAR_DIM = ROT * DIM * ROT_T;
+  
+  clus->setSize(0, 0, COVAR_DIM[0][0]);
+  clus->setSize(0, 1, COVAR_DIM[0][1]);
+  clus->setSize(0, 2, COVAR_DIM[0][2]);
+  clus->setSize(1, 0, COVAR_DIM[1][0]);
+  clus->setSize(1, 1, COVAR_DIM[1][1]);
+  clus->setSize(1, 2, COVAR_DIM[1][2]);
+  clus->setSize(2, 0, COVAR_DIM[2][0]);
+  clus->setSize(2, 1, COVAR_DIM[2][1]);
+  clus->setSize(2, 2, COVAR_DIM[2][2]);
+  //cout << " covar_dim[2][2] = " <<  COVAR_DIM[2][2] << endl;
+  
+  TMatrixF COVAR_ERR(3, 3);
+  COVAR_ERR = ROT * ERR * ROT_T;
+  
+  clus->setError(0, 0, COVAR_ERR[0][0]);
+  clus->setError(0, 1, COVAR_ERR[0][1]);
+  clus->setError(0, 2, COVAR_ERR[0][2]);
+  clus->setError(1, 0, COVAR_ERR[1][0]);
+  clus->setError(1, 1, COVAR_ERR[1][1]);
+  clus->setError(1, 2, COVAR_ERR[1][2]);
+  clus->setError(2, 0, COVAR_ERR[2][0]);
+  clus->setError(2, 1, COVAR_ERR[2][1]);
+  clus->setError(2, 2, COVAR_ERR[2][2]);
+  
+  // Add the hit associations to the TrkrClusterHitAssoc node
+  // we need the cluster key and all associated hit keys (note: the cluster key includes the hitset key)
+  for (unsigned int i = 0; i < hitkeyvec.size(); i++)
+    {
+      m_clusterhitassoc->addAssoc(ckey, hitkeyvec[i]);
+    }
+
+}
+
+void TpcClusterizer::print_cluster(std::vector<ihit> &ihit_list)
+{
+  for(auto iter = ihit_list.begin(); iter != ihit_list.end();++iter){
+    double adc = iter->first; 
+    int phibin = iter->second.first;
+    int zbin   = iter->second.second;
+    if(Verbosity()>10) cout << "  iz: " << zbin << " iphi: " << phibin << " adc: " << adc << endl;
+  }
+}
+
+void TpcClusterizer::find_z_range(int phibin, int zbin, std::vector<std::vector<double>> &adcval, int& zdown, int& zup){
+
+  int FitRangeZ = 5;
+  zup = 0;
+  zdown = 0;
+  for(int iz=0; iz< FitRangeZ; iz++){
+    int cz = zbin + iz;
+
+    if(Verbosity()>10) cout << " cz " << cz << " adc: " << adcval[phibin][cz] << " phibin: " << phibin << " zbin " << cz << endl;
+    if(cz <= 0 || cz >= NZBinsMax){
+      // zup = iz;
+      break; // truncate edge
+    }
+    
+    //break when below minimum
+    if(adcval[phibin][cz] <= 0) {
+      //zup = iz;
+      if(Verbosity() > 1000) cout << " failed threshold cut, set izup to " << zup << endl;
+      break;
+    }
+    //check local minima and break at minimum.
+    if(cz<NZBinsMax-4){//make sure we stay clear from the edge
+      if(adcval[phibin][cz]+adcval[phibin][cz+1] < 
+	 adcval[phibin][cz+2]+adcval[phibin][cz+3]){//rising again
+	zup = iz+1;
+	break;
+      }
+    }
+    zup = iz;
+  }
+  for(int iz=0; iz< FitRangeZ; iz++){
+    int cz = zbin - iz;
+    if(Verbosity()>10) cout << " cz " << cz << " adc: " << adcval[phibin][cz] << " phibin: " << phibin << " zbin " << cz << endl;
+    if(cz <= 0 || cz >= NZBinsMax){
+      //      zdown = iz;
+      break; // truncate edge
+    }
+    if(adcval[phibin][cz] <= 0) {
+      // zdown = iz;
+      if(Verbosity() > 1000) cout << " failed threshold cut, set izup to " << zup << endl;
+      break;
+    }
+
+    if(cz>4){//make sure we stay clear from the edge
+      if(adcval[phibin][cz]+adcval[phibin][cz-1] < 
+	 adcval[phibin][cz-2]+adcval[phibin][cz-3]){//rising again
+	zdown = iz+1;
+	break;
+      }
+    }
+    zdown = iz;
+  }
+}
+
+void TpcClusterizer::find_phi_range(int phibin, int zbin, std::vector<std::vector<double>> &adcval, int& phidown, int& phiup){
+
+  int FitRangePHI = 3;
+  phidown = 0;
+  phiup = 0;
+  for(int iphi=0; iphi< FitRangePHI; iphi++){
+    int cphi = phibin + iphi;
+    if(Verbosity()>10) cout << " cphi " << cphi << " adc: " << adcval[cphi][zbin] << " phibin: " << phibin << " zbin " << zbin << endl;
+    if(cphi < 0 || cphi >= NPhiBinsMax){
+      // phiup = iphi;
+      break; // truncate edge
+    }
+    // consider only the peak bin in phi when searching for Z limit     
+    
+    //break when below minimum
+    if(adcval[cphi][zbin] <= 0) {
+      // phiup = iphi;
+      if(Verbosity() > 1000) cout << " failed threshold cut, set iphiup to " << phiup << endl;
+      break;
+    }
+    //check local minima and break at minimum.
+    if(cphi<NPhiBinsMax-4){//make sure we stay clear from the edge
+      if(adcval[cphi][zbin]+adcval[cphi+1][zbin] < 
+	 adcval[cphi+2][zbin]+adcval[cphi+3][zbin]){//rising again
+	phiup = iphi+1;
+	break;
+      }
+    }
+    phiup = iphi;
+  }
+  if(Verbosity()>10) cout << " phiup " << phiup << endl; 
+  for(int iphi=0; iphi< FitRangePHI; iphi++){
+    int cphi = phibin - iphi;
+    if(Verbosity()>10) cout << " cphi " << cphi << " adc: " << adcval[cphi][zbin] << " phibin: " << phibin << " zbin " << zbin << endl;
+    if(cphi < 0 || cphi >= NPhiBinsMax){
+      // phidown = iphi;
+      break; // truncate edge
+    }
+    
+    if(adcval[cphi][zbin] <= 0) {
+      //phidown = iphi;
+      if(Verbosity() > 1000) cout << " failed threshold cut, set iphiup to " << phiup << endl;
+      break;
+    }
+
+    if(cphi>4){//make sure we stay clear from the edge
+      if(adcval[cphi][zbin]+adcval[cphi-1][zbin] < 
+	 adcval[cphi-2][zbin]+adcval[cphi-3][zbin]){//rising again
+	phidown = iphi+1;
+	break;
+      }
+    }
+    phidown = iphi;
+  }
+}
+
+void TpcClusterizer::get_cluster2(int phibin, int zbin, std::vector<std::vector<double>> &adcval, std::vector<ihit> &ihit_list)
+{
+  // search along phi at the peak in z
+ 
+  int zup =0;
+  int zdown =0;
+  find_z_range(phibin, zbin, adcval, zdown, zup);
+  if(Verbosity()>10) cout << " zbin: " << zbin << " zdown: " << zdown << " zup: " << zup << " phi " << phibin << endl;
+  //now we have the z extent of the cluster, go find the phi edges
+
+  for(int iz=zbin - zdown ; iz<= zbin + zup; iz++){
+    int phiup = 0;
+    int phidown = 0;
+    find_phi_range(phibin, iz, adcval, phidown, phiup);
+    if(Verbosity()>10) cout << "phibin: " << phibin << " zbin: " << " phidown " << phidown << " phiup " << phiup  << endl;
+    for (int iphi = phibin - phidown; iphi <= (phibin + phiup); iphi++){
+      iphiz iCoord(make_pair(iphi,iz));
+      ihit  thisHit(adcval[iphi][iz],iCoord);
+      ihit_list.push_back(thisHit);
+    }
+  }
+}
+
 int TpcClusterizer::InitRun(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
@@ -226,12 +577,6 @@ int TpcClusterizer::InitRun(PHCompositeNode *topNode)
     PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(clusterhitassoc, "TRKR_CLUSTERHITASSOC", "PHObject");
     DetNode->addNode(newNode);
   }
-
-  if(Verbosity() > 10)
-    {
-      hit_nt = new TNtuple("hit_nt", "TPC hits", "phibin:zbin:layer:adc");
-      cluster_nt = new TNtuple("cluster_nt", "TPC hits", "phibin:zbin:layer:adc");
-    }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -294,19 +639,20 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
   {
     TrkrHitSet *hitset = hitsetitr->second;
     int layer = TrkrDefs::getLayer(hitsetitr->first);
-    if (Verbosity() > 1)
-      //if (layer == print_layer)
+    if (Verbosity() > 2)
+      if (layer == print_layer)
       {
 	cout << endl << "TpcClusterizer process hitsetkey " << hitsetitr->first
 	     << " layer " << (int) TrkrDefs::getLayer(hitsetitr->first)
 	     << " side " << (int) TpcDefs::getSide(hitsetitr->first)
 	     << " sector " << (int) TpcDefs::getSectorId(hitsetitr->first)
+	     << " nhits " << (int) hitset->size() 
 	     << endl;
-	if (Verbosity() > 5) hitset->identify();
+	//	if (Verbosity() > 5) hitset->identify();
       }
 
     // we have a single hitset, get the info that identifies the module
-    int sector = TpcDefs::getSectorId(hitsetitr->first);
+    //    int sector = TpcDefs::getSectorId(hitsetitr->first);
     int side = TpcDefs::getSide(hitsetitr->first);
 
     // we will need the geometry object for this layer to get the global position
@@ -330,27 +676,77 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
     // for convenience, create a 2D vector to store adc values in and initialize to zero
     std::vector<std::vector<double>> adcval(NPhiBins, std::vector<double>(NZBins, 0));
 
+    std::multimap<double, ihit> all_hit_map;
+    
+    //put all hits in the all_hit_map (sorted by adc)
+    //start with highest adc hit
+    // -> cluster around it
+    // -> vector of hits
+    // -> calculate cluster parameters
+    // -> add hits to truth association
+    // remove hits from all_hit_map
+    // repeat untill all_hit_map empty
+
     TrkrHitSet::ConstRange hitrangei = hitset->getHits();
+    if(Verbosity()>10) cout << " New Hitset " << endl;
     for (TrkrHitSet::ConstIterator hitr = hitrangei.first;
          hitr != hitrangei.second;
          ++hitr)
     {
+
       int phibin = TpcDefs::getPad(hitr->first);
       int zbin = TpcDefs::getTBin(hitr->first);
+      double adc =  (double) hitr->second->getAdc() - pedestal;
+      
+      if(Verbosity()>10) cout << " iphi: " << phibin << " iz: " << zbin << " adc: "  << adc << endl;
+
       if (hitr->second->getAdc() > 0)
 	{
+	  if(adc>0){
+	    iphiz iCoord(make_pair(phibin,zbin));
+	    ihit  thisHit(adc,iCoord);
+	    all_hit_map.insert(make_pair(adc, thisHit));
+	  }
 	  adcval[phibin][zbin] = (double) hitr->second->getAdc() - pedestal;
 
 	  if (Verbosity() > 2)
 	    if (layer == print_layer)
 	      cout << " add hit in layer " << layer << " with phibin " << phibin << " zbin " << zbin << " adcval " << adcval[phibin][zbin] << endl;
-	  
-	  if(Verbosity() > 10)
-	    //if (layer == print_layer)
-	    hit_nt->Fill(phibin, zbin, layer, adcval[phibin][zbin]);
 	}
+      
     }
+    //put all hits in the all_hit_map (sorted by adc)
 
+    int nclus = 0;
+    while(all_hit_map.size()>0){
+      auto iter = all_hit_map.rbegin();
+      if(iter == all_hit_map.rend()) break;
+
+      ihit hiHit = iter->second;
+      //start with highest adc hit
+      if(Verbosity()>10) cout << "  test entries: " << all_hit_map.size() << " adc: " << hiHit.first << " iphi: " << hiHit. second.first << " iz: " << hiHit.second.second << endl;
+      //      double adc = hiHit.first;
+      int iphi = hiHit.second.first;
+      int iz = hiHit.second.second;
+
+      //put all hits in the all_hit_map (sorted by adc)
+      //start with highest adc hit
+      // -> cluster around it and get vector of hits
+      std::vector<ihit> ihit_list;
+      get_cluster2(iphi, iz, adcval, ihit_list);
+      if(Verbosity()>10) 
+	cout << " cluster size: " << ihit_list.size() << " #clusters: " << nclus<< endl;
+      // -> calculate cluster parameters
+      // -> add hits to truth association
+      // remove hits from all_hit_map
+      // repeat untill all_hit_map empty
+      //      print_cluster(ihit_list);
+      calc_cluster_parameter(ihit_list,nclus++, layergeom, hitset);
+      remove_hits(ihit_list,all_hit_map,adcval);
+    }
+  }
+
+#ifdef ISOLD
     int phibin_last = -1;
     int zbin_last = -1;
     vector<int> phibinlo;
@@ -365,31 +761,9 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
     {
       int phibin = TpcDefs::getPad(hitr->first);
       int zbin = TpcDefs::getTBin(hitr->first);
+
       if (!is_local_maximum(phibin, zbin, adcval)) continue;
 
-      if(Verbosity() > 5)
-	{
-	  cout << "  Local maximum at phibin " << phibin 
-	       << " zbin " << zbin 
-	       << " adcval " << adcval[phibin][zbin] 
-	       << endl; 
-	}
-
-      // eliminate double counting when two identical maxima are found within the search window (both bins will register as local maximum)
-      bool duplicate = false;
-      for (int iz = zbin - NSearch; iz <= zbin + NSearch; iz++)
-	{
-	  if(zbin_last == iz) 	  
-	    for (int iphi = phibin - NSearch; iphi <= phibin + NSearch; iphi++)
-	      {
-		if(phibin_last == iphi)
-		  duplicate = true;
-	      }
-	}
-      if(duplicate) continue;
-
-      // Eliminate local maxima that fall within the fiducial boundary of a sector
-      // This does not prevent full clustering of all accepted local maxima, just eliminates clusters **centered** outside the sector fiducial boundary
       if(is_in_sector_boundary(phibin, sector, layergeom))
 	continue;
 
@@ -415,14 +789,8 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
 	}
 
       // Run a duplicate cluster check here
-      // Can get clusters that are formed around different maxima that are separated by more than NSearch bins in z and/or phi
-      // 
-
-
-
-
-
-
+      // Can get clusters that are formed around different 
+      // maxima that are separated by more than NSearch bins in z and/or phi
 
       // Add this cluster to a vector of clusters for later analysis
       phibinlo.push_back(phibin - phidown);
@@ -430,86 +798,81 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
       zbinlo.push_back(zbin - zdown);
       zbinhi.push_back(zbin + zup);
 
-      if(Verbosity() > 10) 
-	//if (layer == print_layer)
-	cluster_nt->Fill(phibin, zbin, layer, adcval[phibin][zbin]);
-
       if (Verbosity() > 2)
         //if (layer == print_layer)
-          cout << "   cluster in layer " << layer << " around hitkey " << hitr->first << " with zbin " << zbin << " zup " << zup << " zdown " << zdown
-               << " phibin " << phibin << " phiup " << phiup << " phidown " << phidown << endl;
+	cout << "   cluster in layer " << layer << " around hitkey " << hitr->first << " with zbin " << zbin << " zup " << zup << " zdown " << zdown
+	     << " phibin " << phibin << " phiup " << phiup << " phidown " << phidown << endl;
     }  // end loop over hits in this hitset
-
+ 
     // Now we analyze the clusters to get their parameters
     for (unsigned int iclus = 0; iclus < phibinlo.size(); iclus++)
     {
       //cout << "TpcClusterizer: process cluster iclus = " << iclus <<  " in layer " << layer << endl;
       // loop over the hits in this cluster
-      double z_sum = 0.0;
+      double zsum = 0.0;
       double phi_sum = 0.0;
       double adc_sum = 0.0;
-
-      double z2_sum = 0.0;
-      double phi2_sum = 0.0;
-
       double radius = layergeom->get_radius();  // returns center of layer
-      if (Verbosity() > 2)
-        if (layer == print_layer)
-        {
-          cout << "iclus " << iclus << " layer " << layer << " radius " << radius << endl;
-          cout << "    z bin range " << zbinlo[iclus] << " to " << zbinhi[iclus] << " phibin range " << phibinlo[iclus] << " to " << phibinhi[iclus] << endl;
-        }
+    
 
       std::vector<TrkrDefs::hitkey> hitkeyvec;
       for (int iphi = phibinlo[iclus]; iphi <= phibinhi[iclus]; iphi++)
       {
         for (int iz = zbinlo[iclus]; iz <= zbinhi[iclus]; iz++)
         {
-          // skip hits for which weight is non-positive
-          /*
-           * Having negative weights in the calculation of the error might result in negative variance
-           * and thus -nan error, that then propagate through the tracking. Since those hits correspond to
-           * noise anyway and in order to have the error and centroid calculation consistent,
-           * we skip the hit alltogether
-           */
-          if( adcval[iphi][iz] <= 0 ) continue;
+          double phi_center = layergeom->get_phicenter(iphi);
+          double z = layergeom->get_zcenter(iz);
 
-          // update z sums
-          const double z = layergeom->get_zcenter(iz);
-          z_sum += z*adcval[iphi][iz];
-          z2_sum += square(z)*adcval[iphi][iz];
-
-          // update phi sums
-          const double phi_center = layergeom->get_phicenter(iphi);
-          phi_sum += phi_center*adcval[iphi][iz];
-          phi2_sum += square(phi_center)*adcval[iphi][iz];
+          zsum += z * adcval[iphi][iz];
+          phi_sum += phi_center * adcval[iphi][iz];
           adc_sum += adcval[iphi][iz];
 
           // capture the hitkeys for all non-zero adc values
-          TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, iz);
-          hitkeyvec.push_back(hitkey);
+          if (adcval[iphi][iz] != 0)
+          {
+            TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, iz);
+            hitkeyvec.push_back(hitkey);
+          }
         }
       }
 
       if (adc_sum < 10) continue;  // skip obvious noise "clusters"
 
       // This is the global position
-      const double clusphi = phi_sum / adc_sum;
-      double clusz = z_sum / adc_sum;
-
-      const double phi_cov = phi2_sum/adc_sum - square(clusphi);
-      const double z_cov = z2_sum/adc_sum - square(clusz);
+      double clusphi = phi_sum / adc_sum;
+      double clusz = zsum / adc_sum;
 
       // create the cluster entry directly in the node tree
       TrkrDefs::cluskey ckey = TpcDefs::genClusKey(hitset->getHitSetKey(), iclus);
       TrkrClusterv1 *clus = static_cast<TrkrClusterv1 *>((m_clusterlist->findOrAddCluster(ckey))->second);
 
-      const double phi_size = (double) (phibinhi[iclus] - phibinlo[iclus] + 1) * radius * layergeom->get_phistep();
-      const double z_size = (double) (zbinhi[iclus] - zbinlo[iclus] + 1) * layergeom->get_zstep();
+      double phi_size = (double) (phibinhi[iclus] - phibinlo[iclus] + 1) * radius * layergeom->get_phistep();
+      double z_size = (double) (zbinhi[iclus] - zbinlo[iclus] + 1) * layergeom->get_zstep();
 
-      //cout << "   layer " << layer << " z_cov " << z_cov << " dz2_adc " << dz2_adc << " adc_sum " <<  adc_sum << endl;
+      // Estimate the errors
+      double dphi2_adc = 0.0;
+      double dphi_adc = 0.0;
+      double dz2_adc = 0.0;
+      double dz_adc = 0.0;
+      for (int iz = zbinlo[iclus]; iz <= zbinhi[iclus]; iz++)
+      {
+        for (int iphi = phibinlo[iclus]; iphi <= phibinhi[iclus]; iphi++)
+        {
+          double dphi = layergeom->get_phicenter(iphi) - clusphi;
+          dphi2_adc += dphi * dphi * adcval[iphi][iz];
+          dphi_adc += dphi * adcval[iphi][iz];
 
-      // phi_cov = (weighted mean of dphi^2). The error is then:
+          double dz = layergeom->get_zcenter(iz) - clusz;
+          dz2_adc += dz * dz * adcval[iphi][iz];
+          dz_adc += dz * adcval[iphi][iz];
+        }
+      }
+      double phi_cov = (dphi2_adc / adc_sum - dphi_adc * dphi_adc / (adc_sum * adc_sum));
+      double z_cov = dz2_adc / adc_sum - dz_adc * dz_adc / (adc_sum * adc_sum);
+
+      //cout << "   layer " << layer << " z_cov " << z_cov << " dz2_adc " << dz2_adc << " adc_sum " <<  adc_sum << " dz_adc " << dz_adc << endl;
+
+      // phi_cov = (weighted mean of dphi^2) - (weighted mean of dphi)^2,  which is essentially the weighted mean of dphi^2. The error is then:
       // e_phi = sigma_dphi/sqrt(N) = sqrt( sigma_dphi^2 / N )  -- where N is the number of samples of the distribution with standard deviation sigma_dphi
       //    - N is the number of electrons that drift to the readout plane
       // We have to convert (sum of adc units for all bins in the cluster) to number of ionization electrons N
@@ -517,16 +880,13 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
       // To get equivalent charge per Z bin, so that summing ADC input voltage over all Z bins returns total input charge, divide voltages by 2.4 for 80 ns SAMPA
       // Equivalent charge per Z bin is then  (ADU x 2200 mV / 1024) / 2.4 x (1/20) fC/mV x (1/1.6e-04) electrons/fC x (1/2000) = ADU x 0.14
 
-      // square errors are calculated, since this is what enters the error matrix below
-      // also need to include special handling for size one clusters, for which the RMS calculated above is automatically zero
+      double phi_err = radius * sqrt(phi_cov / (adc_sum * 0.14));
+      if (phi_err == 0.0)  // a single phi bin will cause this
+        phi_err = radius * layergeom->get_phistep() / sqrt(12.0);
 
-      const double phi_err_square = (phibinhi[iclus] == phibinlo[iclus]) ?
-        square(radius*layergeom->get_phistep())/12:
-        square(radius)*phi_cov/(adc_sum*0.14);
-
-      const double z_err_square = (zbinhi[iclus] == zbinlo[iclus]) ?
-        square(layergeom->get_zstep())/12:
-        z_cov/(adc_sum*0.14);
+      double z_err = sqrt(z_cov / (adc_sum * 0.14));
+      if (z_err == 0.0)
+        z_err = layergeom->get_zstep() / sqrt(12.0);
 
       // This corrects the bias introduced by the asymmetric SAMPA chip shaping - assumes 80 ns shaping time
       if (clusz < 0)
@@ -547,22 +907,22 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
       DIM[0][1] = 0.0;
       DIM[0][2] = 0.0;
       DIM[1][0] = 0.0;
-      DIM[1][1] = square(0.5*phi_size);  //cluster_v1 expects 1/2 of actual size
+      DIM[1][1] = pow(0.5 * phi_size,2);  //cluster_v1 expects 1/2 of actual size
       DIM[1][2] = 0.0;
       DIM[2][0] = 0.0;
       DIM[2][1] = 0.0;
-      DIM[2][2] = square(0.5*z_size);
+      DIM[2][2] = pow(0.5 * z_size,2);
 
       TMatrixF ERR(3, 3);
       ERR[0][0] = 0.0;
       ERR[0][1] = 0.0;
       ERR[0][2] = 0.0;
       ERR[1][0] = 0.0;
-      ERR[1][1] = phi_err_square;  //cluster_v1 expects rad, arc, z as elementsof covariance
+      ERR[1][1] = phi_err * phi_err;  //cluster_v1 expects rad, arc, z as elementsof covariance
       ERR[1][2] = 0.0;
       ERR[2][0] = 0.0;
       ERR[2][1] = 0.0;
-      ERR[2][2] = z_err_square;
+      ERR[2][2] = z_err * z_err;
 
       TMatrixF ROT(3, 3);
       ROT[0][0] = cos(clusphi);
@@ -633,12 +993,13 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
     cout << "Dump cluster hit associations after TpcClusterizer" << endl;
     m_clusterhitassoc->identify();
   }
-
+#endif
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int TpcClusterizer::End(PHCompositeNode *topNode)
 {
+  /*
   if (Verbosity() > 10)
   {
     TFile *outf = new TFile("cluster_nt_out.root", "recreate");
@@ -646,5 +1007,6 @@ int TpcClusterizer::End(PHCompositeNode *topNode)
     outf->WriteTObject(cluster_nt);
     outf->Close();
   }
+  */
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/tpc/TpcClusterizer.h
+++ b/offline/packages/tpc/TpcClusterizer.h
@@ -2,16 +2,20 @@
 #define TPC_TPCCLUSTERIZER_H
 
 #include <fun4all/SubsysReco.h>
-
+#include <map> 
 #include <vector>
 #include <string>
 
 class PHCompositeNode;
+class TrkrHitSet;
 class TrkrHitSetContainer;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class TNtuple;
 class PHG4CylinderCellGeom;
+
+typedef std::pair<int, int> iphiz;
+typedef std::pair<double, iphiz> ihit;
 
 class TpcClusterizer : public SubsysReco
 {
@@ -30,6 +34,13 @@ class TpcClusterizer : public SubsysReco
   bool is_local_maximum(int phi, int z, std::vector<std::vector<double>> &adcval);
   bool is_in_sector_boundary(int phibin, int sector, PHG4CylinderCellGeom *layergeom);
   void get_cluster(int phibin, int zbin, int &phiup, int &phidown, int &zup, int &zdown, std::vector<std::vector<double>> &adcval);
+  void get_cluster2(int phibin, int zbin, std::vector<std::vector<double>> &adcval, std::vector<ihit> &ihit_list);
+  void find_z_range(int phibin, int zbin, std::vector<std::vector<double>> &adcval, int& zdown, int& zup);
+  void find_phi_range(int phibin, int zbin, std::vector<std::vector<double>> &adcval, int& phidown, int& phiup);
+  void remove_hit(double adc, int phibin, int zbin, std::multimap<double, ihit> &all_hit_map, std::vector<std::vector<double>> &adcval );
+  void remove_hits(std::vector<ihit> &ihit_list, std::multimap<double, ihit> &all_hit_map, std::vector<std::vector<double>> &adcval);
+  void calc_cluster_parameter(std::vector<ihit> &ihit_list, int iclus, PHG4CylinderCellGeom *layergeom, TrkrHitSet *hitset);
+  void print_cluster(std::vector<ihit> &ihit_list);
 
   TrkrHitSetContainer *m_hits;
   TrkrClusterContainer *m_clusterlist;

--- a/offline/packages/tpc/TpcClusterizer.h
+++ b/offline/packages/tpc/TpcClusterizer.h
@@ -11,7 +11,6 @@ class TrkrHitSet;
 class TrkrHitSetContainer;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
-class TNtuple;
 class PHG4CylinderCellGeom;
 
 typedef std::pair<int, int> iphiz;
@@ -56,8 +55,6 @@ class TpcClusterizer : public SubsysReco
   int NZBinsMax;
   int NZBinsMin;
 
-  TNtuple *hit_nt;
-  TNtuple *cluster_nt;
 };
 
 #endif

--- a/offline/packages/tpc/TpcClusterizer.h
+++ b/offline/packages/tpc/TpcClusterizer.h
@@ -33,8 +33,7 @@ class TpcClusterizer : public SubsysReco
  private:
   bool is_local_maximum(int phi, int z, std::vector<std::vector<double>> &adcval);
   bool is_in_sector_boundary(int phibin, int sector, PHG4CylinderCellGeom *layergeom);
-  void get_cluster(int phibin, int zbin, int &phiup, int &phidown, int &zup, int &zdown, std::vector<std::vector<double>> &adcval);
-  void get_cluster2(int phibin, int zbin, std::vector<std::vector<double>> &adcval, std::vector<ihit> &ihit_list);
+  void get_cluster(int phibin, int zbin, std::vector<std::vector<double>> &adcval, std::vector<ihit> &ihit_list);
   void find_z_range(int phibin, int zbin, std::vector<std::vector<double>> &adcval, int& zdown, int& zup);
   void find_phi_range(int phibin, int zbin, std::vector<std::vector<double>> &adcval, int& phidown, int& phiup);
   void remove_hit(double adc, int phibin, int zbin, std::multimap<double, ihit> &all_hit_map, std::vector<std::vector<double>> &adcval );


### PR DESCRIPTION
Eliminates duplicates and should provide better cluster splitting capability

TpcTracker tpc only reconstruction efficiency is veru high in high multiplicity qa events:
<img width="883" alt="tpceff_nuclus" src="https://user-images.githubusercontent.com/8998644/91857033-9e4f3880-ec67-11ea-8c4c-0e876df04704.png">

Obvious cluster splitting issues should be fixed:

<img width="118" alt="clu_split_match2_zoom_nu" src="https://user-images.githubusercontent.com/8998644/91857589-61377600-ec68-11ea-8f92-e53be4e168a5.png">

Before:
![clu_split_match2_zoom](https://user-images.githubusercontent.com/8998644/91857620-68f71a80-ec68-11ea-8920-df1e9d7dd868.png)
