### PR TITLE
Check trackfastsim statename

### DIFF
--- a/simulation/g4simulation/g4main/EicEventHeaderLinkDef.h
+++ b/simulation/g4simulation/g4main/EicEventHeaderLinkDef.h
@@ -1,5 +1,5 @@
-#if defined(__CINT__) || defined(__CLING__)
+#if defined(__CLING__)
 
 #pragma link C++ class EicEventHeader+;
 
-#endif /* defined(__CINT__) || defined(__CLING__) */
+#endif /* defined(__CLING__) */

--- a/simulation/g4simulation/g4main/EicEventHeaderv1LinkDef.h
+++ b/simulation/g4simulation/g4main/EicEventHeaderv1LinkDef.h
@@ -1,5 +1,5 @@
-#if defined(__CINT__) || defined(__CLING__)
+#if defined(__CLING__)
 
 #pragma link C++ class EicEventHeaderv1+;
 
-#endif /* defined(__CINT__) || defined(__CLING__) */
+#endif /* defined(__CLING__) */

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -5,39 +5,39 @@
 
 #include "Fun4AllDstPileupInputManager.h"
 
+#include "PHG4Hit.h"  // for PHG4Hit
 #include "PHG4HitContainer.h"
-#include "PHG4Hit.h"                     // for PHG4Hit
 #include "PHG4Hitv1.h"
-#include "PHG4Particle.h"                // for PHG4Particle
+#include "PHG4Particle.h"  // for PHG4Particle
 #include "PHG4Particlev3.h"
 #include "PHG4TruthInfoContainer.h"
-#include "PHG4VtxPoint.h"                // for PHG4VtxPoint
+#include "PHG4VtxPoint.h"  // for PHG4VtxPoint
 #include "PHG4VtxPointv1.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
 
+#include <ffaobjects/EventHeader.h>
+#include <ffaobjects/EventHeaderv2.h>
 #include <ffaobjects/RunHeader.h>
 #include <ffaobjects/SyncDefs.h>
 #include <ffaobjects/SyncObject.h>
-#include <ffaobjects/EventHeader.h>
-#include <ffaobjects/EventHeaderv2.h>
 
 #include <frog/FROG.h>
 
+#include <phhepmc/PHHepMCGenEvent.h>  // for PHHepMCGenEvent
 #include <phhepmc/PHHepMCGenEventMap.h>
-#include <phhepmc/PHHepMCGenEvent.h>     // for PHHepMCGenEvent
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>          // for PHIODataNode
-#include <phool/PHNode.h>                // for PHNode
+#include <phool/PHIODataNode.h>  // for PHIODataNode
+#include <phool/PHNode.h>        // for PHNode
 #include <phool/PHNodeIOManager.h>
 #include <phool/PHNodeIntegrate.h>
-#include <phool/PHNodeIterator.h>   // for PHNodeIterator
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/PHNodeOperation.h>
-#include <phool/PHObject.h>         // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>            // for PHWHERE, PHReadOnly, PHRunTree
+#include <phool/phool.h>  // for PHWHERE, PHReadOnly, PHRunTree
 
 #include <TSystem.h>
 
@@ -45,11 +45,11 @@
 
 #include <cassert>
 #include <climits>
-#include <cstdlib>
 #include <cstdint>
-#include <iostream>                 // for operator<<, basic_ostream, endl
-#include <iterator>                      // for reverse_iterator, operator!=
- #include <utility>                  // for pair
+#include <cstdlib>
+#include <iostream>  // for operator<<, basic_ostream, endl
+#include <iterator>  // for reverse_iterator, operator!=
+#include <utility>   // for pair
 
 // convenient aliases for deep copying nodes
 namespace
@@ -59,57 +59,56 @@ namespace
   using PHG4Hit_t = PHG4Hitv1;
 
   //! utility class to find all PHG4Hit container nodes from the DST node
-  class FindG4HitContainer: public PHNodeOperation
+  class FindG4HitContainer : public PHNodeOperation
   {
-
-    public:
-
+   public:
     //! container map alias
-    using ContainerMap = std::map<std::string, PHG4HitContainer*>;
+    using ContainerMap = std::map<std::string, PHG4HitContainer *>;
 
     //! get container map
-    const ContainerMap& containers() const
-    { return m_containers; }
-
-    protected:
-
-    //! iterator action
-    void perform( PHNode* node ) override
+    const ContainerMap &containers() const
     {
-
-      // check type name. Only load PHIODataNode
-      if( node->getType() != "PHIODataNode" ) return;
-
-      // cast to IODataNode and check data
-      auto ionode = static_cast<PHIODataNode<TObject>*>(node);
-      auto data = dynamic_cast<PHG4HitContainer*>( ionode->getData() );
-      if( data )
-      { m_containers.insert( std::make_pair( node->getName(), data ) ); }
+      return m_containers;
     }
 
-    private:
+   protected:
+    //! iterator action
+    void perform(PHNode *node) override
+    {
+      // check type name. Only load PHIODataNode
+      if (node->getType() != "PHIODataNode") return;
 
+      // cast to IODataNode and check data
+      auto ionode = static_cast<PHIODataNode<TObject> *>(node);
+      auto data = dynamic_cast<PHG4HitContainer *>(ionode->getData());
+      if (data)
+      {
+        m_containers.insert(std::make_pair(node->getName(), data));
+      }
+    }
+
+   private:
     //! container map
     ContainerMap m_containers;
   };
 
-}
+}  // namespace
 
 //_____________________________________________________________________________
 Fun4AllDstPileupInputManager::Fun4AllDstPileupInputManager(const std::string &name, const std::string &nodename, const std::string &topnodename)
   : Fun4AllInputManager(name, nodename, topnodename)
-{}
+{
+}
 
 //_____________________________________________________________________________
 int Fun4AllDstPileupInputManager::fileopen(const std::string &filenam)
 {
-
   Fun4AllServer *se = Fun4AllServer::instance();
   if (IsOpen())
   {
     std::cout << "Closing currently open file "
-         << FileName()
-         << " and opening " << filenam << std::endl;
+              << FileName()
+              << " and opening " << filenam << std::endl;
     fileclose();
   }
   FileName(filenam);
@@ -124,11 +123,11 @@ int Fun4AllDstPileupInputManager::fileopen(const std::string &filenam)
   if (m_IManager)
   {
     std::cout << PHWHERE << " IManager pointer is not nullptr but " << m_IManager.get()
-         << std::endl;
+              << std::endl;
     std::cout << "Send mail to off-l with this printout and the macro you used"
-         << std::endl;
+              << std::endl;
     std::cout << "Trying to execute IManager->print() to display more info"
-         << std::endl;
+              << std::endl;
     std::cout << "Code will probably segfault now" << std::endl;
     m_IManager->print();
     std::cout << "Have someone look into this problem - Exiting now" << std::endl;
@@ -137,7 +136,7 @@ int Fun4AllDstPileupInputManager::fileopen(const std::string &filenam)
   // first read the runnode if not disabled
   if (m_ReadRunTTree)
   {
-    m_IManager.reset( new PHNodeIOManager(m_fullfilename, PHReadOnly, PHRunTree) );
+    m_IManager.reset(new PHNodeIOManager(m_fullfilename, PHReadOnly, PHRunTree));
     if (m_IManager->isFunctional())
     {
       m_runNode = se->getNode(m_RunNode, TopNodeName());
@@ -153,9 +152,9 @@ int Fun4AllDstPileupInputManager::fileopen(const std::string &filenam)
       if (m_runNodeCopy)
       {
         std::cout << PHWHERE
-             << " The impossible happened, we have a valid copy of the run node "
-             << m_runNodeCopy->getName() << " which should be a nullptr"
-             << std::endl;
+                  << " The impossible happened, we have a valid copy of the run node "
+                  << m_runNodeCopy->getName() << " which should be a nullptr"
+                  << std::endl;
         gSystem->Exit(1);
       }
       m_runNodeCopy.reset(new PHCompositeNode("RUNNODECOPY"));
@@ -186,9 +185,9 @@ int Fun4AllDstPileupInputManager::fileopen(const std::string &filenam)
   }
 
   // create internal dst node
-  if( !m_dstNodeInternal )
+  if (!m_dstNodeInternal)
   {
-    m_dstNodeInternal.reset( new PHCompositeNode("DST_INTERNAL") );
+    m_dstNodeInternal.reset(new PHCompositeNode("DST_INTERNAL"));
   }
 
   // update dst node from fun4all server
@@ -204,7 +203,9 @@ int Fun4AllDstPileupInputManager::fileopen(const std::string &filenam)
     setBranches();                // set branch selections
     AddToFileOpened(FileName());  // add file to the list of files which were opened
     return 0;
-  } else {
+  }
+  else
+  {
     std::cout << PHWHERE << ": " << Name() << " Could not open file " << FileName() << std::endl;
     m_IManager.reset();
     m_IManager_background.reset();
@@ -221,7 +222,9 @@ int Fun4AllDstPileupInputManager::run(const int nevents)
     {
       if (Verbosity() > 0) std::cout << Name() << ": No Input file open" << std::endl;
       return -1;
-    } else {
+    }
+    else
+    {
       if (OpenNextFile())
       {
         std::cout << Name() << ": No Input file from filelist opened" << std::endl;
@@ -231,7 +234,9 @@ int Fun4AllDstPileupInputManager::run(const int nevents)
   }
 
   if (Verbosity() > 3)
-  { std::cout << "Getting Event from " << Name() << std::endl; }
+  {
+    std::cout << "Getting Event from " << Name() << std::endl;
+  }
 
 readagain:
 
@@ -248,30 +253,32 @@ readagain:
   if (!dummy)
   {
     fileclose();
-    if (!OpenNextFile()) goto readagain;
-    else return -1;
+    if (!OpenNextFile())
+      goto readagain;
+    else
+      return -1;
   }
 
   m_ievent_total += ncount;
   m_ievent_thisfile += ncount;
-  
+
   // check events consistency
-  if( m_ievent_thisfile != static_cast<int>( m_IManager->getEventNumber() ) )
+  if (m_ievent_thisfile != static_cast<int>(m_IManager->getEventNumber()))
   {
     std::cout << PHWHERE
-      << " inconsistent event counters between inputmanager and ionode manager: " 
-      << " m_ievent_thisfile: " << m_ievent_thisfile
-      << " m_IManager->getEventNumber(): " << m_IManager->getEventNumber()
-      << std::endl;
-    gSystem->Exit(1);    
+              << " inconsistent event counters between inputmanager and ionode manager: "
+              << " m_ievent_thisfile: " << m_ievent_thisfile
+              << " m_IManager->getEventNumber(): " << m_IManager->getEventNumber()
+              << std::endl;
+    gSystem->Exit(1);
   }
-  
+
   // get bunchCrossing  associated to this event
   const size_t ievent = m_ievent_total + m_event_offset - 1;
-  if( ievent >= m_bunchCrossings.size() ) return Fun4AllReturnCodes::ABORTRUN;
+  if (ievent >= m_bunchCrossings.size()) return Fun4AllReturnCodes::ABORTRUN;
 
   const auto bunchCrossing = m_bunchCrossings[ievent];
-  if( m_events_accepted > 0 && bunchCrossing == m_last_bunchCrossing )
+  if (m_events_accepted > 0 && bunchCrossing == m_last_bunchCrossing)
   {
     // reject if event belongs to the same bunch crossing as the last accepted event
     std::cout << "Fun4AllDstPileupInputManager::run - skipped event " << m_ievent_thisfile - 1 << std::endl;
@@ -290,25 +297,25 @@ readagain:
 
   // store bunch crossing both inside the event header and as the last bunch crossing
   load_nodes(m_dstNode);
-  if( m_eventheader ) m_eventheader->set_BunchCrossing( bunchCrossing );
+  if (m_eventheader) m_eventheader->set_BunchCrossing(bunchCrossing);
   m_last_bunchCrossing = bunchCrossing;
 
   // fetch past events falling into the TPC integration time
   int neventspast = 0;
-  for( int ieventpast = ievent-1; ieventpast>=0; ieventpast-- )
+  for (int ieventpast = ievent - 1; ieventpast >= 0; ieventpast--)
   {
     // check time
-    const double delta_t = m_time_between_crossings*(m_bunchCrossings[ieventpast] - bunchCrossing);
-    if( delta_t < m_tmin ) break;
+    const double delta_t = m_time_between_crossings * (m_bunchCrossings[ieventpast] - bunchCrossing);
+    if (delta_t < m_tmin) break;
 
     // get relevant event in file index
-    const int ievent_thisfile = m_ievent_thisfile+ieventpast-ievent-1;
+    const int ievent_thisfile = m_ievent_thisfile + ieventpast - ievent - 1;
 
     // try read
-    if( ievent_thisfile < 0 || !m_IManager_background->read(m_dstNodeInternal.get(), ievent_thisfile) ) break;
+    if (ievent_thisfile < 0 || !m_IManager_background->read(m_dstNodeInternal.get(), ievent_thisfile)) break;
 
     // merge
-    copy_background_event( m_dstNodeInternal.get(), delta_t );
+    copy_background_event(m_dstNodeInternal.get(), delta_t);
 
     // increment number of read events
     std::cout << "Fun4AllDstPileupInputManager::run - merged past event " << ievent_thisfile << std::endl;
@@ -317,20 +324,20 @@ readagain:
 
   // fetch future events falling into the TPC integration time
   int neventsfuture = 0;
-  for( size_t ieventfuture = ievent+1; ieventfuture < m_bunchCrossings.size(); ++ieventfuture )
+  for (size_t ieventfuture = ievent + 1; ieventfuture < m_bunchCrossings.size(); ++ieventfuture)
   {
     // check time
-    const double delta_t = m_time_between_crossings*(m_bunchCrossings[ieventfuture] - bunchCrossing);
-    if( delta_t > m_tmax ) break;
+    const double delta_t = m_time_between_crossings * (m_bunchCrossings[ieventfuture] - bunchCrossing);
+    if (delta_t > m_tmax) break;
 
     // get relevant event in file index
-    const int ievent_thisfile = m_ievent_thisfile+ieventfuture-ievent-1;
+    const int ievent_thisfile = m_ievent_thisfile + ieventfuture - ievent - 1;
 
     // try read
-    if( !m_IManager_background->read(m_dstNodeInternal.get(), ievent_thisfile) ) break;
+    if (!m_IManager_background->read(m_dstNodeInternal.get(), ievent_thisfile)) break;
 
     // merge
-    copy_background_event( m_dstNodeInternal.get(), delta_t );
+    copy_background_event(m_dstNodeInternal.get(), delta_t);
 
     // increment number of read events
     std::cout << "Fun4AllDstPileupInputManager::run - merged future event " << ievent_thisfile << std::endl;
@@ -371,7 +378,7 @@ int Fun4AllDstPileupInputManager::GetSyncObject(SyncObject **mastersync)
   {
     if (m_syncobject)
     {
-      *mastersync = dynamic_cast<SyncObject *> (m_syncobject->CloneMe());
+      *mastersync = dynamic_cast<SyncObject *>(m_syncobject->CloneMe());
       assert(*mastersync);
     }
   }
@@ -392,7 +399,7 @@ int Fun4AllDstPileupInputManager::SyncIt(const SyncObject *mastersync)
     std::cout << "opened by the Fun4AllDstPileupInputManager with Name " << Name() << " has one" << std::endl;
     std::cout << "Change your macro and use the file opened by this input manager as first input" << std::endl;
     std::cout << "and you will be okay. Fun4All will not process the current configuration" << std::endl
-         << std::endl;
+              << std::endl;
     return Fun4AllReturnCodes::SYNC_FAIL;
   }
   int iret = m_syncobject->Different(mastersync);
@@ -408,17 +415,17 @@ int Fun4AllDstPileupInputManager::SyncIt(const SyncObject *mastersync)
       if (Verbosity() > 3)
       {
         std::cout
-          << "Need to Resync, mastersync evt no: " << mastersync->EventNumber()
-          << ", this Event no: " << m_syncobject->EventNumber()
-          << std::endl;
+            << "Need to Resync, mastersync evt no: " << mastersync->EventNumber()
+            << ", this Event no: " << m_syncobject->EventNumber()
+            << std::endl;
         std::cout
-          << "mastersync evt counter: " << mastersync->EventCounter()
-          << ", this Event counter: " << m_syncobject->EventCounter()
-          << std::endl;
+            << "mastersync evt counter: " << mastersync->EventCounter()
+            << ", this Event counter: " << m_syncobject->EventCounter()
+            << std::endl;
         std::cout
-          << "mastersync run number: " << mastersync->RunNumber()
-          << ", this run number: " << m_syncobject->RunNumber()
-          << std::endl;
+            << "mastersync run number: " << mastersync->RunNumber()
+            << ", this run number: " << m_syncobject->RunNumber()
+            << std::endl;
       }
       while (m_syncobject->RunNumber() < mastersync->RunNumber())
       {
@@ -426,14 +433,14 @@ int Fun4AllDstPileupInputManager::SyncIt(const SyncObject *mastersync)
         if (Verbosity() > 2)
         {
           std::cout
-            << Name() << " Run Number: " << m_syncobject->RunNumber()
-            << ", master: " << mastersync->RunNumber()
-            << std::endl;
+              << Name() << " Run Number: " << m_syncobject->RunNumber()
+              << ", master: " << mastersync->RunNumber()
+              << std::endl;
         }
         int iret = ReadNextEventSyncObject();
         if (iret) return iret;
       }
-      bool igood( m_syncobject->RunNumber() == mastersync->RunNumber() );
+      bool igood(m_syncobject->RunNumber() == mastersync->RunNumber());
 
       // only run up the Segment Number if run numbers are identical
       while (igood && m_syncobject->SegmentNumber() < mastersync->SegmentNumber())
@@ -442,8 +449,8 @@ int Fun4AllDstPileupInputManager::SyncIt(const SyncObject *mastersync)
         if (Verbosity() > 2)
         {
           std::cout << Name() << " Segment Number: " << m_syncobject->SegmentNumber()
-               << ", master: " << mastersync->SegmentNumber()
-               << std::endl;
+                    << ", master: " << mastersync->SegmentNumber()
+                    << std::endl;
         }
         int iret = ReadNextEventSyncObject();
         if (iret)
@@ -453,15 +460,15 @@ int Fun4AllDstPileupInputManager::SyncIt(const SyncObject *mastersync)
       }
       // only run up the Event Counter if run number and segment number are identical
       igood = (m_syncobject->SegmentNumber() == mastersync->SegmentNumber() && m_syncobject->RunNumber() == mastersync->RunNumber());
-      while(igood && m_syncobject->EventCounter() < mastersync->EventCounter())
+      while (igood && m_syncobject->EventCounter() < mastersync->EventCounter())
       {
         m_events_skipped_during_sync++;
         if (Verbosity() > 2)
         {
           std::cout << Name()
-               << ", EventCounter: " << m_syncobject->EventCounter()
-               << ", master: " << mastersync->EventCounter()
-               << std::endl;
+                    << ", EventCounter: " << m_syncobject->EventCounter()
+                    << ", master: " << mastersync->EventCounter()
+                    << std::endl;
         }
         int iret = ReadNextEventSyncObject();
         if (iret)
@@ -498,7 +505,7 @@ int Fun4AllDstPileupInputManager::SyncIt(const SyncObject *mastersync)
         return Fun4AllReturnCodes::SYNC_FAIL;
       }
       int iret = m_syncobject->Different(mastersync);  // final check if they really agree
-      if (iret)                                      // if not things are severely wrong
+      if (iret)                                        // if not things are severely wrong
       {
         std::cout << PHWHERE << " MasterSync and SyncObject of " << Name() << " are different" << std::endl;
         std::cout << "This Event will not be processed further, here is some debugging info:" << std::endl;
@@ -538,7 +545,9 @@ readnextsync:
     for (auto bIter = m_IManager->GetBranchMap()->begin(); bIter != m_IManager->GetBranchMap()->end(); ++bIter)
     {
       if (Verbosity() > 2)
-      { std::cout << Name() << ": branch: " << bIter->first << std::endl; }
+      {
+        std::cout << Name() << ": branch: " << bIter->first << std::endl;
+      }
 
       const auto pos = bIter->first.find("/Sync");
       if (pos != std::string::npos)
@@ -553,7 +562,9 @@ readnextsync:
       std::cout << "Please check for it in the following list of branch names and" << std::endl;
       std::cout << "PLEASE NOTIFY PHENIX-OFF-L and post the macro you used" << std::endl;
       for (auto bIter = m_IManager->GetBranchMap()->begin(); bIter != m_IManager->GetBranchMap()->end(); ++bIter)
-      { std::cout << bIter->first << std::endl; }
+      {
+        std::cout << bIter->first << std::endl;
+      }
       return Fun4AllReturnCodes::SYNC_FAIL;
     }
   }
@@ -702,7 +713,7 @@ void Fun4AllDstPileupInputManager::Print(const std::string &what) const
   {
     // loop over the map and print out the content (name and location in memory)
     std::cout << "--------------------------------------" << std::endl
-         << std::endl;
+              << std::endl;
     std::cout << "List of selected branches in Fun4AllDstPileupInputManager " << Name() << ":" << std::endl;
 
     std::map<const std::string, int>::const_iterator iter;
@@ -724,7 +735,7 @@ void Fun4AllDstPileupInputManager::Print(const std::string &what) const
   {
     // loop over the map and print out the content (name and location in memory)
     std::cout << "--------------------------------------" << std::endl
-         << std::endl;
+              << std::endl;
     std::cout << "PHNodeIOManager print in Fun4AllDstPileupInputManager " << Name() << ":" << std::endl;
     m_IManager->print();
   }
@@ -745,17 +756,16 @@ int Fun4AllDstPileupInputManager::PushBackEvents(const int i)
     return 0;
   }
   std::cout << PHWHERE << Name() << ": could not push back events, Imanager is NULL"
-       << " probably the dst is not open yet (you need to call fileopen or run 1 event for lists)" << std::endl;
+            << " probably the dst is not open yet (you need to call fileopen or run 1 event for lists)" << std::endl;
   return -1;
 }
 
 //_____________________________________________________________________________
-void Fun4AllDstPileupInputManager::load_nodes(PHCompositeNode* dstNode )
+void Fun4AllDstPileupInputManager::load_nodes(PHCompositeNode *dstNode)
 {
-
   // event header
   m_eventheader = findNode::getClass<EventHeader>(dstNode, "EventHeader");
-  if(!m_eventheader)
+  if (!m_eventheader)
   {
     std::cout << "Fun4AllDstPileupInputManager::load_nodes - creating EventHeader" << std::endl;
     m_eventheader = new EventHeaderv2();
@@ -764,7 +774,7 @@ void Fun4AllDstPileupInputManager::load_nodes(PHCompositeNode* dstNode )
 
   // hep mc
   m_geneventmap = findNode::getClass<PHHepMCGenEventMap>(dstNode, "PHHepMCGenEventMap");
-  if(!m_geneventmap)
+  if (!m_geneventmap)
   {
     std::cout << "Fun4AllDstPileupInputManager::load_nodes - creating PHHepMCGenEventMap" << std::endl;
     m_geneventmap = new PHHepMCGenEventMap();
@@ -773,22 +783,21 @@ void Fun4AllDstPileupInputManager::load_nodes(PHCompositeNode* dstNode )
 
   // find all G4Hit containers under dstNode
   FindG4HitContainer nodeFinder;
-  PHNodeIterator( dstNode ).forEach( nodeFinder );
+  PHNodeIterator(dstNode).forEach(nodeFinder);
   m_g4hitscontainers = nodeFinder.containers();
 
   // g4 truth info
   m_g4truthinfo = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
-  if( !m_g4truthinfo )
+  if (!m_g4truthinfo)
   {
     std::cout << "Fun4AllDstPileupInputManager::load_nodes - creating node G4TruthInfo" << std::endl;
     m_g4truthinfo = new PHG4TruthInfoContainer();
     dstNode->addNode(new PHIODataNode<PHObject>(m_g4truthinfo, "G4TruthInfo", "PHObject"));
   }
-
 }
 
 //_____________________________________________________________________________
-void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNode, double delta_t )
+void Fun4AllDstPileupInputManager::copy_background_event(PHCompositeNode *dstNode, double delta_t)
 {
   // copy PHHepMCGenEventMap
   const auto map = findNode::getClass<PHHepMCGenEventMap>(dstNode, "PHHepMCGenEventMap");
@@ -796,9 +805,9 @@ void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNo
   // keep track of new embed id, after insertion as background event
   int new_embed_id = 0;
 
-  if( map && m_geneventmap )
+  if (map && m_geneventmap)
   {
-    if( map->size() != 1 )
+    if (map->size() != 1)
     {
       std::cout << "Fun4AllDstPileupInputManager::copy_background_event - cannot merge events that contain more than one PHHepMCGenEventMap" << std::endl;
       return;
@@ -806,42 +815,41 @@ void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNo
 
     // get event and insert in new map
     auto genevent = map->get_map().begin()->second;
-    auto newevent = m_geneventmap->insert_background_event( genevent );
+    auto newevent = m_geneventmap->insert_background_event(genevent);
 
     /*
      * this hack prevents a crash when writting out
      * it boils down to root trying to write deleted items from the HepMC::GenEvent copy if the source has been deleted
      * it does not happen if the source gets written while the copy is deleted
      */
-    newevent->getEvent()->swap( *genevent->getEvent() );
+    newevent->getEvent()->swap(*genevent->getEvent());
 
     // shift vertex time and store new embed id
-    newevent->moveVertex( 0, 0, 0, delta_t );
+    newevent->moveVertex(0, 0, 0, delta_t);
     new_embed_id = newevent->get_embedding_id();
   }
 
   // copy truth container
   // keep track of the correspondance between source index and destination index for vertices, tracks and showers
-  using ConversionMap = std::map<int,int>;
+  using ConversionMap = std::map<int, int>;
   ConversionMap vtxid_map;
   ConversionMap trkid_map;
 
   const auto container = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
-  if( container && m_g4truthinfo )
+  if (container && m_g4truthinfo)
   {
-
     {
       // primary vertices
       auto key = m_g4truthinfo->maxvtxindex();
       const auto range = container->GetPrimaryVtxRange();
-      for( auto iter = range.first; iter != range.second; ++iter )
+      for (auto iter = range.first; iter != range.second; ++iter)
       {
         // clone vertex, insert in map, and add index conversion
-        const auto& sourceVertex = iter->second;
+        const auto &sourceVertex = iter->second;
         auto newVertex = new PHG4VtxPoint_t(sourceVertex);
-        newVertex->set_t( sourceVertex->get_t() + delta_t );
-        m_g4truthinfo->AddVertex( ++key, newVertex );
-        vtxid_map.insert( std::make_pair( sourceVertex->get_id(), key ) );
+        newVertex->set_t(sourceVertex->get_t() + delta_t);
+        m_g4truthinfo->AddVertex(++key, newVertex);
+        vtxid_map.insert(std::make_pair(sourceVertex->get_id(), key));
       }
     }
 
@@ -851,17 +859,17 @@ void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNo
       const auto range = container->GetSecondaryVtxRange();
 
       // loop from last to first to preserve order with respect to the original event
-      for(
-        auto iter = std::reverse_iterator<PHG4TruthInfoContainer::ConstVtxIterator>(range.second);
-        iter != std::reverse_iterator<PHG4TruthInfoContainer::ConstVtxIterator>(range.first);
-        ++iter )
+      for (
+          auto iter = std::reverse_iterator<PHG4TruthInfoContainer::ConstVtxIterator>(range.second);
+          iter != std::reverse_iterator<PHG4TruthInfoContainer::ConstVtxIterator>(range.first);
+          ++iter)
       {
         // clone vertex, shift time, insert in map, and add index conversion
-        const auto& sourceVertex = iter->second;
+        const auto &sourceVertex = iter->second;
         auto newVertex = new PHG4VtxPoint_t(sourceVertex);
-        newVertex->set_t( sourceVertex->get_t() + delta_t );
-        m_g4truthinfo->AddVertex( --key, newVertex );
-        vtxid_map.insert( std::make_pair( sourceVertex->get_id(), key ) );
+        newVertex->set_t(sourceVertex->get_t() + delta_t);
+        m_g4truthinfo->AddVertex(--key, newVertex);
+        vtxid_map.insert(std::make_pair(sourceVertex->get_id(), key));
       }
     }
 
@@ -869,26 +877,28 @@ void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNo
       // primary particles
       auto key = m_g4truthinfo->maxtrkindex();
       const auto range = container->GetPrimaryParticleRange();
-      for( auto iter = range.first; iter != range.second; ++iter )
+      for (auto iter = range.first; iter != range.second; ++iter)
       {
-        const auto& source = iter->second;
-        auto dest = new PHG4Particle_t( source );
-        m_g4truthinfo->AddParticle( ++key, dest );
-        dest->set_track_id( key );
+        const auto &source = iter->second;
+        auto dest = new PHG4Particle_t(source);
+        m_g4truthinfo->AddParticle(++key, dest);
+        dest->set_track_id(key);
 
         // set parent to zero
         dest->set_parent_id(0);
 
         // set primary to itself
-        dest->set_primary_id( dest->get_track_id());
+        dest->set_primary_id(dest->get_track_id());
 
         // update vertex
-        const auto keyiter = vtxid_map.find( source->get_vtx_id() );
-        if( keyiter != vtxid_map.end() ) dest->set_vtx_id( keyiter->second );
-        else std::cout << "Fun4AllDstPileupInputManager::copy_background_event - vertex id " << source->get_vtx_id() << " not found in map" << std::endl;
+        const auto keyiter = vtxid_map.find(source->get_vtx_id());
+        if (keyiter != vtxid_map.end())
+          dest->set_vtx_id(keyiter->second);
+        else
+          std::cout << "Fun4AllDstPileupInputManager::copy_background_event - vertex id " << source->get_vtx_id() << " not found in map" << std::endl;
 
         // insert in map
-        trkid_map.insert( std::make_pair( source->get_track_id(), dest->get_track_id() ) );
+        trkid_map.insert(std::make_pair(source->get_track_id(), dest->get_track_id()));
       }
     }
 
@@ -901,62 +911,71 @@ void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNo
        * loop from last to first to preserve order with respect to the original event
        * also this ensures that for a given particle its parent has already been converted and thus found in the map
        */
-      for( 
-        auto iter = std::reverse_iterator<PHG4TruthInfoContainer::ConstIterator>(range.second); 
-        iter != std::reverse_iterator<PHG4TruthInfoContainer::ConstIterator>(range.first);
-        ++iter )
+      for (
+          auto iter = std::reverse_iterator<PHG4TruthInfoContainer::ConstIterator>(range.second);
+          iter != std::reverse_iterator<PHG4TruthInfoContainer::ConstIterator>(range.first);
+          ++iter)
       {
-        const auto& source = iter->second;
-        auto dest = new PHG4Particle_t( source );
-        m_g4truthinfo->AddParticle( --key, dest );
-        dest->set_track_id( key );
+        const auto &source = iter->second;
+        auto dest = new PHG4Particle_t(source);
+        m_g4truthinfo->AddParticle(--key, dest);
+        dest->set_track_id(key);
 
         // update parent id
-        auto keyiter = trkid_map.find( source->get_parent_id() );
-        if( keyiter != trkid_map.end() ) dest->set_parent_id( keyiter->second );
-        else std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " << source->get_parent_id() << " not found in map" << std::endl;
+        auto keyiter = trkid_map.find(source->get_parent_id());
+        if (keyiter != trkid_map.end())
+          dest->set_parent_id(keyiter->second);
+        else
+          std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " << source->get_parent_id() << " not found in map" << std::endl;
 
         // update primary id
-        keyiter = trkid_map.find( source->get_primary_id() );
-        if( keyiter != trkid_map.end() ) dest->set_primary_id( keyiter->second );
-        else std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " << source->get_primary_id() << " not found in map" << std::endl;
+        keyiter = trkid_map.find(source->get_primary_id());
+        if (keyiter != trkid_map.end())
+          dest->set_primary_id(keyiter->second);
+        else
+          std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " << source->get_primary_id() << " not found in map" << std::endl;
 
         // update vertex
-        keyiter = vtxid_map.find( source->get_vtx_id() );
-        if( keyiter != vtxid_map.end() ) dest->set_vtx_id( keyiter->second );
-        else std::cout << "Fun4AllDstPileupInputManager::copy_background_event - vertex id " << source->get_vtx_id() << " not found in map" << std::endl;
+        keyiter = vtxid_map.find(source->get_vtx_id());
+        if (keyiter != vtxid_map.end())
+          dest->set_vtx_id(keyiter->second);
+        else
+          std::cout << "Fun4AllDstPileupInputManager::copy_background_event - vertex id " << source->get_vtx_id() << " not found in map" << std::endl;
 
         // insert in map
-        trkid_map.insert( std::make_pair( source->get_track_id(), dest->get_track_id() ) );
+        trkid_map.insert(std::make_pair(source->get_track_id(), dest->get_track_id()));
       }
     }
 
     // vertex embed flags
     /* embed flag is stored only for primary vertices, consistently with PHG4TruthEventAction */
-    for( const auto& pair:vtxid_map )
-    { if(pair.first>0) m_g4truthinfo->AddEmbededVtxId(pair.second,new_embed_id); }
+    for (const auto &pair : vtxid_map)
+    {
+      if (pair.first > 0) m_g4truthinfo->AddEmbededVtxId(pair.second, new_embed_id);
+    }
 
     // track embed flags
     /* embed flag is stored only for primary tracks, consistently with PHG4TruthEventAction */
-    for( const auto& pair:trkid_map )
-    { if(pair.first>0) m_g4truthinfo->AddEmbededTrkId(pair.second,new_embed_id); }
-
+    for (const auto &pair : trkid_map)
+    {
+      if (pair.first > 0) m_g4truthinfo->AddEmbededTrkId(pair.second, new_embed_id);
+    }
   }
 
   // copy g4hits
   // loop over registered maps
-  for( const auto& pair:m_g4hitscontainers )
+  for (const auto &pair : m_g4hitscontainers)
   {
     // check destination node
-    if( !pair.second )
+    if (!pair.second)
     {
       std::cout << "Fun4AllDstPileupInputManager::copy_background_event - invalid destination container " << pair.first << std::endl;
       continue;
     }
 
     // find source node
-    auto container = findNode::getClass<PHG4HitContainer>( dstNode, pair.first );
-    if( !container )
+    auto container = findNode::getClass<PHG4HitContainer>(dstNode, pair.first);
+    if (!container)
     {
       std::cout << "Fun4AllDstPileupInputManager::copy_background_event - invalid source container " << pair.first << std::endl;
       continue;
@@ -965,20 +984,22 @@ void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNo
     {
       // hits
       const auto range = container->getHits();
-      for( auto iter = range.first; iter != range.second; ++iter )
+      for (auto iter = range.first; iter != range.second; ++iter)
       {
         // clone hit
-        const auto& sourceHit = iter->second;
-        auto newHit = new PHG4Hit_t( sourceHit );
+        const auto &sourceHit = iter->second;
+        auto newHit = new PHG4Hit_t(sourceHit);
 
         // shift time
-        newHit->set_t(0, sourceHit->get_t(0)+delta_t);
-        newHit->set_t(1, sourceHit->get_t(1)+delta_t);
+        newHit->set_t(0, sourceHit->get_t(0) + delta_t);
+        newHit->set_t(1, sourceHit->get_t(1) + delta_t);
 
         // update track id
-        const auto keyiter = trkid_map.find( sourceHit->get_trkid() );
-        if( keyiter != trkid_map.end() ) newHit->set_trkid( keyiter->second );
-        else std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " <<  sourceHit->get_trkid() << " not found in map" << std::endl;
+        const auto keyiter = trkid_map.find(sourceHit->get_trkid());
+        if (keyiter != trkid_map.end())
+          newHit->set_trkid(keyiter->second);
+        else
+          std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " << sourceHit->get_trkid() << " not found in map" << std::endl;
 
         /*
          * reset shower ids
@@ -991,18 +1012,17 @@ void Fun4AllDstPileupInputManager::copy_background_event( PHCompositeNode* dstNo
          * this will generate a new key for the hit and assign it to the hit
          * this ensures that there is no conflict with the hits from the 'main' event
          */
-        pair.second->AddHit( newHit->get_detid(), newHit );
+        pair.second->AddHit(newHit->get_detid(), newHit);
       }
     }
 
     {
       // layers
       const auto range = container->getLayers();
-      for(auto iter = range.first; iter != range.second; ++iter)
-      { pair.second->AddLayer(*iter); }
+      for (auto iter = range.first; iter != range.second; ++iter)
+      {
+        pair.second->AddLayer(*iter);
+      }
     }
-
   }
-
-
 }

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -6,15 +6,16 @@
 #include "Fun4AllDstPileupInputManager.h"
 
 #include "PHG4HitContainer.h"
+#include "PHG4Hit.h"                     // for PHG4Hit
 #include "PHG4Hitv1.h"
+#include "PHG4Particle.h"                // for PHG4Particle
 #include "PHG4Particlev3.h"
-#include "PHG4Shower.h"
 #include "PHG4TruthInfoContainer.h"
+#include "PHG4VtxPoint.h"                // for PHG4VtxPoint
 #include "PHG4VtxPointv1.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
-#include <fun4all/SubsysReco.h>
 
 #include <ffaobjects/RunHeader.h>
 #include <ffaobjects/SyncDefs.h>
@@ -25,8 +26,11 @@
 #include <frog/FROG.h>
 
 #include <phhepmc/PHHepMCGenEventMap.h>
+#include <phhepmc/PHHepMCGenEvent.h>     // for PHHepMCGenEvent
 
 #include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>          // for PHIODataNode
+#include <phool/PHNode.h>                // for PHNode
 #include <phool/PHNodeIOManager.h>
 #include <phool/PHNodeIntegrate.h>
 #include <phool/PHNodeIterator.h>   // for PHNodeIterator
@@ -40,11 +44,12 @@
 #include <HepMC/GenEvent.h>
 
 #include <cassert>
+#include <climits>
 #include <cstdlib>
+#include <cstdint>
 #include <iostream>                 // for operator<<, basic_ostream, endl
-#include <utility>                  // for pair
-
-class TBranch;
+#include <iterator>                      // for reverse_iterator, operator!=
+ #include <utility>                  // for pair
 
 // convenient aliases for deep copying nodes
 namespace

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -10,16 +10,19 @@
 
 #include <fun4all/Fun4AllInputManager.h>
 
+#include <phool/PHCompositeNode.h>        // for PHCompositeNode
+#include <phool/PHNodeIOManager.h>        // for PHNodeIOManager
+
+#include <cstdint>                        // for int64_t
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>                         // for vector
 
 class EventHeader;
-class PHCompositeNode;
 class PHG4HitContainer;
 class PHG4TruthInfoContainer;
 class PHHepMCGenEventMap;
-class PHNodeIOManager;
 class SyncObject;
 
 class Fun4AllDstPileupInputManager : public Fun4AllInputManager

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -10,14 +10,14 @@
 
 #include <fun4all/Fun4AllInputManager.h>
 
-#include <phool/PHCompositeNode.h>        // for PHCompositeNode
-#include <phool/PHNodeIOManager.h>        // for PHNodeIOManager
+#include <phool/PHCompositeNode.h>  // for PHCompositeNode
+#include <phool/PHNodeIOManager.h>  // for PHNodeIOManager
 
-#include <cstdint>                        // for int64_t
+#include <cstdint>  // for int64_t
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>                         // for vector
+#include <vector>  // for vector
 
 class EventHeader;
 class PHG4HitContainer;
@@ -42,27 +42,29 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
 
   //! store event bunch crossing ids
   /*! bunch crossings are used to decide which pile-up events should be merged to a given "trigger" event */
-  void setBunchCrossingList( const std::vector<int64_t>& value ) { m_bunchCrossings = value; }
+  void setBunchCrossingList(const std::vector<int64_t> &value) { m_bunchCrossings = value; }
 
   //! store event offset
   /*! offste is added to the current event number to look for the corresponding event timestamp */
-  void setEventOffset( int value ) { m_event_offset = value; }
+  void setEventOffset(int value) { m_event_offset = value; }
 
   //! set time window for pileup events (ns)
-  void setPileupTimeWindow( double tmin, double tmax )
-  { m_tmin = tmin; m_tmax = tmax; }
+  void setPileupTimeWindow(double tmin, double tmax)
+  {
+    m_tmin = tmin;
+    m_tmax = tmax;
+  }
 
  protected:
   int ReadNextEventSyncObject();
   void ReadRunTTree(const int i) { m_ReadRunTTree = i; }
 
  private:
-
   //! load nodes
-  void load_nodes(PHCompositeNode*);
+  void load_nodes(PHCompositeNode *);
 
   //! copy background event
-  void copy_background_event(PHCompositeNode*, double delta_t);
+  void copy_background_event(PHCompositeNode *, double delta_t);
 
   //!@name event counters
   //@{
@@ -79,10 +81,10 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   std::string m_syncbranchname;
 
   //! dst node from TopNode
-  PHCompositeNode* m_dstNode = nullptr;
+  PHCompositeNode *m_dstNode = nullptr;
 
   //! run node from TopNode
-  PHCompositeNode* m_runNode = nullptr;
+  PHCompositeNode *m_runNode = nullptr;
 
   //! internal dst node to copy background events
   std::unique_ptr<PHCompositeNode> m_dstNodeInternal;
@@ -125,18 +127,16 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   double m_tmax = 13500;
 
   //! event header
-  EventHeader* m_eventheader = nullptr;
+  EventHeader *m_eventheader = nullptr;
 
   //! hepmc
-  PHHepMCGenEventMap* m_geneventmap = nullptr;
+  PHHepMCGenEventMap *m_geneventmap = nullptr;
 
   //! maps g4hit containers to node names
-  std::map<std::string, PHG4HitContainer*> m_g4hitscontainers;
+  std::map<std::string, PHG4HitContainer *> m_g4hitscontainers;
 
   //! truth information
-  PHG4TruthInfoContainer* m_g4truthinfo = nullptr;
-
-
+  PHG4TruthInfoContainer *m_g4truthinfo = nullptr;
 };
 
 #endif /* __Fun4AllDstPileupInputManager_H__ */

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManagerLinkDef.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManagerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class Fun4AllDstPileupInputManager - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -8,13 +8,13 @@
 #include <phhepmc/PHHepMCGenEvent.h>
 #include <phhepmc/PHHepMCGenEventMap.h>
 
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHDataNode.h>
-#include <phool/PHNode.h>                // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>
 #include <phool/PHRandomSeed.h>
+#include <phool/getClass.h>
 #include <phool/phool.h>
 #include <phool/recoConsts.h>
 
@@ -229,21 +229,23 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
                (*v)->particles_begin(HepMC::children);
            p != (*v)->particles_end(HepMC::children); ++p)
       {
-	if(Verbosity()>1){
-	  cout<<__PRETTY_FUNCTION__<<" : "<<__LINE__<<endl;
-	  (*p)->print();
-	  cout<<"end vertex "<<(*p)->end_vertex()<<endl;
-	}
+        if (Verbosity() > 1)
+        {
+          cout << __PRETTY_FUNCTION__ << " : " << __LINE__ << endl;
+          (*p)->print();
+          cout << "end vertex " << (*p)->end_vertex() << endl;
+        }
         if (isfinal(*p))
         {
-	  if(Verbosity()>1)
-	    cout<<"partile passed "<<endl;
+          if (Verbosity() > 1)
+            cout << "partile passed " << endl;
           finalstateparticles.push_back(*p);
-        }else{
-	  if(Verbosity()>1)
-	    cout<<"partivle failed"<<endl;
-	}
-
+        }
+        else
+        {
+          if (Verbosity() > 1)
+            cout << "partivle failed" << endl;
+        }
       }
 
       if (!finalstateparticles.empty())
@@ -302,7 +304,6 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
              fiter != finalstateparticles.end();
              ++fiter)
         {
-
           if (Verbosity() > 1) (*fiter)->print();
 
           PHG4Particle *particle = new PHG4Particlev1();

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -6,9 +6,7 @@
 #include <fun4all/SubsysReco.h>
 
 // rootcint barfs with this header so we need to hide it
-#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
-#endif
 
 #include <string>
 
@@ -54,6 +52,9 @@ class HepMCNodeReader : public SubsysReco
  private:
   double smeargauss(const double width);
   double smearflat(const double width);
+
+  gsl_rng *RandomGenerator;
+
   int use_seed;
   unsigned int seed;
   double vertex_pos_x;
@@ -64,9 +65,6 @@ class HepMCNodeReader : public SubsysReco
   double width_vy;
   double width_vz;
 
-#if !defined(__CINT__) || defined(__CLING__)
-  gsl_rng *RandomGenerator;
-#endif
 };
 
 #endif

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -64,7 +64,6 @@ class HepMCNodeReader : public SubsysReco
   double width_vx;
   double width_vy;
   double width_vz;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4main/HepMCNodeReaderLinkDef.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReaderLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class HepMCNodeReader-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -87,11 +87,6 @@ ROOTHITDICTS = \
   PHG4VtxPointv1_Dict.cc \
   PHG4TruthInfoContainer_Dict.cc
 
-# for root6 we need pcm and dictionaries but only for
-# i/o classes. For root5 we need only dictionaries but
-# those for i/o and classes available on the cmd line
-# MAKEROOT6 is set in the configure.ac, true for root6
-if MAKEROOT6
 # this is a tweak to install files in $(libdir), automake refuses
 # to install other files in libdir, this construct gets around this
 pcmdir = $(libdir)
@@ -114,37 +109,9 @@ nobase_dist_pcm_DATA = \
   PHG4VtxPoint_Dict_rdict.pcm \
   PHG4VtxPointv1_Dict_rdict.pcm \
   PHG4TruthInfoContainer_Dict_rdict.pcm
-else
-  ROOT5HITDICTS = PHG4HitDefs_Dict.cc
-  ROOT5TBDICTS = \
-    Fun4AllDstPileupInputManager_Dict.cc \
-    HepMCNodeReader_Dict.cc \
-    PHG4ConsistencyCheck_Dict.cc \
-    PHG4HeadReco_Dict.cc \
-    PHG4InEventCompress_Dict.cc \
-    PHG4InEventReadBack_Dict.cc \
-    PHG4InputFilter_Dict.cc \
-    PHG4IonGun_Dict.cc \
-    PHG4ParticleGenerator_Dict.cc \
-    PHG4ParticleGeneratorBase_Dict.cc \
-    PHG4ParticleGeneratorVectorMeson_Dict.cc \
-    PHG4ParticleGeneratorD0_Dict.cc \
-    PHG4ParticleGun_Dict.cc \
-    PHG4Reco_Dict.cc \
-    PHG4ScoringManager_Dict.cc \
-    PHG4SimpleEventGenerator_Dict.cc \
-    PHG4PileupGenerator_Dict.cc \
-    PHG4Subsystem_Dict.cc \
-    PHG4TruthSubsystem_Dict.cc \
-    PHG4Utils_Dict.cc \
-    PHG4VertexSelection_Dict.cc \
-    ReadEICFiles_Dict.cc \
-    PHG4HitReadBack_Dict.cc
-endif
 
 libphg4hit_la_SOURCES = \
   $(ROOTHITDICTS) \
-  $(ROOT5HITDICTS) \
   EicEventHeader.cc \
   EicEventHeaderv1.cc \
   PHG4EventHeaderv1.cc \
@@ -164,7 +131,6 @@ libphg4hit_la_SOURCES = \
   PHG4VtxPointv1.cc
 
 libg4testbench_la_SOURCES = \
-  $(ROOT5TBDICTS) \
   Fun4AllMessenger.cc \
   G4TBMagneticFieldSetup.cc \
   G4TBFieldMessenger.cc \
@@ -282,7 +248,7 @@ testexternals.cc:
 	echo "}" >> $@
 
 %_Dict.cc: %.h %LinkDef.h
-	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(RINCLUDES) $^
+	rootcint -f $@ @CINTDEFS@ $(DEFAULT_INCLUDES) $(RINCLUDES) $^
 
 #just to get the dependency
 %_Dict_rdict.pcm: %_Dict.cc ;

--- a/simulation/g4simulation/g4main/PHG4ConsistencyCheckLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4ConsistencyCheckLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4ConsistencyCheck-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4EtaPhiParameterization.cc
+++ b/simulation/g4simulation/g4main/PHG4EtaPhiParameterization.cc
@@ -1,120 +1,121 @@
 #include "PHG4EtaPhiParameterization.h"
 
-
-#include <Geant4/G4VPhysicalVolume.hh>
 #include <Geant4/G4ThreeVector.hh>
 #include <Geant4/G4Tubs.hh>
-#include <Geant4/G4Types.hh>                   // for G4int
+#include <Geant4/G4Types.hh>  // for G4int
+#include <Geant4/G4VPhysicalVolume.hh>
 
-#include <algorithm>                     // for copy
+#include <algorithm>  // for copy
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <iterator>
 
 PHG4EtaPhiParameterization::PHG4EtaPhiParameterization(
-						 unsigned int neta, // Binning in eta
-						 double minEta,  // "
-						 double maxEta,  // "
-						 unsigned int nphi, // number of phi bins
-						 double startPhi,
-						 double deltaPhi,
-						 double radiusIn,  // Radius of inner face of cylinder
-						 double radiusOut,  // Radius of outer face of cylinder
-						 double centerZ  // Z of center of set
-						 ) :
-  _neta(neta), _minEta(minEta), _maxEta(maxEta), 
-  _nphi(nphi), _startPhi(startPhi), _deltaPhi(deltaPhi),
-  _radiusIn(radiusIn), _radiusOut(radiusOut),
-  _centerZ(centerZ)
+    unsigned int neta,  // Binning in eta
+    double minEta,      // "
+    double maxEta,      // "
+    unsigned int nphi,  // number of phi bins
+    double startPhi,
+    double deltaPhi,
+    double radiusIn,   // Radius of inner face of cylinder
+    double radiusOut,  // Radius of outer face of cylinder
+    double centerZ     // Z of center of set
+    )
+  : _neta(neta)
+  , _minEta(minEta)
+  , _maxEta(maxEta)
+  , _nphi(nphi)
+  , _startPhi(startPhi)
+  , _deltaPhi(deltaPhi)
+  , _radiusIn(radiusIn)
+  , _radiusOut(radiusOut)
+  , _centerZ(centerZ)
 {
-  if ( _maxEta < _minEta )
-    {
-      std::cout << " invalid eta, max<min" 
-	   << " etamin: " << _minEta
-	   << " etamax: " << _maxEta
-           << std::endl;
-      exit(1);
-    }
+  if (_maxEta < _minEta)
+  {
+    std::cout << " invalid eta, max<min"
+              << " etamin: " << _minEta
+              << " etamax: " << _maxEta
+              << std::endl;
+    exit(1);
+  }
 
-  if ( (_radiusIn<0.0) || (_radiusOut<0.0) || (_radiusOut<_radiusIn) )
-    {
-      std::cout << " invalid radius parameters:"
-	   << " radiusIn: "  << radiusIn 
-	   << " radiusOut: "  << radiusOut 
-           << std::endl;
-      exit(1);
-    }
+  if ((_radiusIn < 0.0) || (_radiusOut < 0.0) || (_radiusOut < _radiusIn))
+  {
+    std::cout << " invalid radius parameters:"
+              << " radiusIn: " << radiusIn
+              << " radiusOut: " << radiusOut
+              << std::endl;
+    exit(1);
+  }
 
   double totalEta = _maxEta - _minEta;
   double dEta = totalEta / _neta;
-  for(unsigned int i=0; i<neta; i++)
-    {
-      // Compute the edges of this eta bin
-      double etaMin = _minEta + dEta * i;
-      double etaMax = etaMin + dEta;
-      //double eta = _minEta + dEta * (i + 0.5);
-      // Compute the corresponding Z positions of the edges
-      double zmin = _centerZ + _radiusIn * std::sinh(etaMin);
-      double zmax = _centerZ + _radiusIn * std::sinh(etaMax);
-      // Z positions is halfway between the edges
-      double zpos = (zmin+zmax)/2.0;
-      double zhalf = (zmax-zmin)/2.0;
-      _zpos.push_back(zpos);
-      _zhalf.push_back(zhalf);
-    }
+  for (unsigned int i = 0; i < neta; i++)
+  {
+    // Compute the edges of this eta bin
+    double etaMin = _minEta + dEta * i;
+    double etaMax = etaMin + dEta;
+    //double eta = _minEta + dEta * (i + 0.5);
+    // Compute the corresponding Z positions of the edges
+    double zmin = _centerZ + _radiusIn * std::sinh(etaMin);
+    double zmax = _centerZ + _radiusIn * std::sinh(etaMax);
+    // Z positions is halfway between the edges
+    double zpos = (zmin + zmax) / 2.0;
+    double zhalf = (zmax - zmin) / 2.0;
+    _zpos.push_back(zpos);
+    _zhalf.push_back(zhalf);
+  }
 
-  for(unsigned int i=0; i<_nphi; i++)
-    {
-      _phi0.push_back(_startPhi+i*_deltaPhi);
-      _phi1.push_back(_startPhi+(i+1)*_deltaPhi);
-    }
+  for (unsigned int i = 0; i < _nphi; i++)
+  {
+    _phi0.push_back(_startPhi + i * _deltaPhi);
+    _phi1.push_back(_startPhi + (i + 1) * _deltaPhi);
+  }
 
-  // Build lookup vectors for the copyNo->(ieta, iphi) translation 
+  // Build lookup vectors for the copyNo->(ieta, iphi) translation
   //
-  for(unsigned int i=0; i<_neta*_nphi; i++)
-    {
-      div_t q = div(i,_nphi);
-      int ieta = q.quot;
-      int iphi = q.rem;
-      _ieta.push_back(ieta);
-      _iphi.push_back(iphi);
-    }
+  for (unsigned int i = 0; i < _neta * _nphi; i++)
+  {
+    div_t q = div(i, _nphi);
+    int ieta = q.quot;
+    int iphi = q.rem;
+    _ieta.push_back(ieta);
+    _iphi.push_back(iphi);
+  }
 }
 
 PHG4EtaPhiParameterization::~PHG4EtaPhiParameterization()
 {
   std::cout << "PHG4EtaPhiParameterization::~PHG4EtaPhiParameterization: Alas, poor Yorick! I knew him, Horatio"
-	    << std::endl;
+            << std::endl;
 }
 
-void
-PHG4EtaPhiParameterization::Print(std::ostream& os) const
+void PHG4EtaPhiParameterization::Print(std::ostream& os) const
 {
   os << "PhiEtaPhiParameterization: NETA x NPHI = " << _neta << " x " << _nphi << std::endl;
   os << "Zpos: ";
-  std::copy(_zpos.begin(),_zpos.end(),std::ostream_iterator<double>(os," "));
+  std::copy(_zpos.begin(), _zpos.end(), std::ostream_iterator<double>(os, " "));
   os << std::endl;
   os << "Phi0: ";
-  std::copy(_phi0.begin(),_phi0.end(),std::ostream_iterator<double>(os," "));
+  std::copy(_phi0.begin(), _phi0.end(), std::ostream_iterator<double>(os, " "));
   os << std::endl;
   os << "Phi1: ";
-  std::copy(_phi0.begin(),_phi0.end(),std::ostream_iterator<double>(os," "));
+  std::copy(_phi0.begin(), _phi0.end(), std::ostream_iterator<double>(os, " "));
   os << std::endl;
 }
 
-void
-PHG4EtaPhiParameterization::ComputeTransformation(const G4int copyNo, G4VPhysicalVolume* physVol) const
+void PHG4EtaPhiParameterization::ComputeTransformation(const G4int copyNo, G4VPhysicalVolume* physVol) const
 {
-  int iring = copyNo/_nphi;
-  G4ThreeVector origin(0,0,_zpos.at(iring));
+  int iring = copyNo / _nphi;
+  G4ThreeVector origin(0, 0, _zpos.at(iring));
   physVol->SetTranslation(origin);
   physVol->SetRotation(0);
 }
 
-void
-PHG4EtaPhiParameterization::ComputeDimensions(G4Tubs& ring, const G4int copyNo, 
-					      const G4VPhysicalVolume*) const
+void PHG4EtaPhiParameterization::ComputeDimensions(G4Tubs& ring, const G4int copyNo,
+                                                   const G4VPhysicalVolume*) const
 {
   int ieta = GetIEta(copyNo);
   int iphi = GetIPhi(copyNo);

--- a/simulation/g4simulation/g4main/PHG4EtaPhiParameterization.cc
+++ b/simulation/g4simulation/g4main/PHG4EtaPhiParameterization.cc
@@ -4,6 +4,7 @@
 #include <Geant4/G4VPhysicalVolume.hh>
 #include <Geant4/G4ThreeVector.hh>
 #include <Geant4/G4Tubs.hh>
+#include <Geant4/G4Types.hh>                   // for G4int
 
 #include <algorithm>                     // for copy
 #include <cmath>

--- a/simulation/g4simulation/g4main/PHG4HeadRecoLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4HeadRecoLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4HeadReco-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4HitDefsLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4HitDefsLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ namespace PHG4HitDefs-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4HitReadBackLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4HitReadBackLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4HitReadBack-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -6,7 +6,7 @@
 #include "PHG4Hit.h"
 #include "PHG4HitDefs.h"
 
-#include <climits>       // for INT_MIN, ULONG_LONG_MAX
+#include <climits>  // for INT_MIN, ULONG_LONG_MAX
 #include <cmath>
 #include <cstdint>
 #include <iostream>
@@ -16,40 +16,40 @@ class PHG4Hitv1 : public PHG4Hit
 {
  public:
   PHG4Hitv1() = default;
-  explicit PHG4Hitv1(const PHG4Hit *g4hit);
+  explicit PHG4Hitv1(const PHG4Hit* g4hit);
   virtual ~PHG4Hitv1() = default;
-  void identify(std::ostream& os  = std::cout) const;
+  void identify(std::ostream& os = std::cout) const;
   void Reset();
 
   // The indices here represent the entry and exit points of the particle
-  float get_x(const int i) const {return x[i];}
-  float get_y(const int i) const {return y[i];}
-  float get_z(const int i) const {return z[i];}
-  float get_t(const int i) const {return t[i];}
-  float get_edep() const {return edep;}
-  PHG4HitDefs::keytype get_hit_id() const {return hitid;}
+  float get_x(const int i) const { return x[i]; }
+  float get_y(const int i) const { return y[i]; }
+  float get_z(const int i) const { return z[i]; }
+  float get_t(const int i) const { return t[i]; }
+  float get_edep() const { return edep; }
+  PHG4HitDefs::keytype get_hit_id() const { return hitid; }
   int get_detid() const;
-  int get_shower_id() const {return showerid;}
-  int get_trkid() const {return trackid;}
-  
-  void set_x(const int i, const float f) {x[i]=f;}
-  void set_y(const int i, const float f) {y[i]=f;}
-  void set_z(const int i, const float f) {z[i]=f;}
-  void set_t(const int i, const float f) {t[i]=f;}
-  void set_edep(const float f) {edep = f;}
-  void set_hit_id(const PHG4HitDefs::keytype i) {hitid=i;}
-  void set_shower_id(const int i) {showerid = i;}
-  void set_trkid(const int i) {trackid=i;}
+  int get_shower_id() const { return showerid; }
+  int get_trkid() const { return trackid; }
+
+  void set_x(const int i, const float f) { x[i] = f; }
+  void set_y(const int i, const float f) { y[i] = f; }
+  void set_z(const int i, const float f) { z[i] = f; }
+  void set_t(const int i, const float f) { t[i] = f; }
+  void set_edep(const float f) { edep = f; }
+  void set_hit_id(const PHG4HitDefs::keytype i) { hitid = i; }
+  void set_shower_id(const int i) { showerid = i; }
+  void set_trkid(const int i) { trackid = i; }
 
   virtual void print() const;
 
-  bool  has_property(const PROPERTY prop_id) const;
+  bool has_property(const PROPERTY prop_id) const;
   float get_property_float(const PROPERTY prop_id) const;
-  int   get_property_int(const PROPERTY prop_id) const;
-  unsigned int   get_property_uint(const PROPERTY prop_id) const;
-  void  set_property(const PROPERTY prop_id, const float value);
-  void  set_property(const PROPERTY prop_id, const int value);
-  void  set_property(const PROPERTY prop_id, const unsigned int value);
+  int get_property_int(const PROPERTY prop_id) const;
+  unsigned int get_property_uint(const PROPERTY prop_id) const;
+  void set_property(const PROPERTY prop_id, const float value);
+  void set_property(const PROPERTY prop_id, const int value);
+  void set_property(const PROPERTY prop_id, const unsigned int value);
 
   virtual float get_px(const int i) const;
   virtual float get_py(const int i) const;
@@ -57,21 +57,21 @@ class PHG4Hitv1 : public PHG4Hit
   virtual float get_local_x(const int i) const;
   virtual float get_local_y(const int i) const;
   virtual float get_local_z(const int i) const;
-  virtual float get_eion() const          {return  get_property_float(prop_eion);}
-  virtual float get_light_yield() const   {return  get_property_float(prop_light_yield);}
-  virtual float get_path_length() const {return  get_property_float(prop_path_length);}
-  virtual unsigned int get_layer() const  {return  get_property_uint(prop_layer);}
-  virtual int get_scint_id() const        {return  get_property_int(prop_scint_id);}
-  virtual int get_row() const {return  get_property_int(prop_row);}
-  virtual int get_strip_z_index() const   {return  get_property_int(prop_strip_z_index);}
-  virtual int get_strip_y_index() const   {return  get_property_int(prop_strip_y_index);}
-  virtual int get_ladder_z_index() const  {return  get_property_int(prop_ladder_z_index);}
-  virtual int get_ladder_phi_index() const{return  get_property_int(prop_ladder_phi_index);}
-  virtual int get_index_i() const {return  get_property_int(prop_index_i);}
-  virtual int get_index_j() const {return  get_property_int(prop_index_j);}
-  virtual int get_index_k() const {return  get_property_int(prop_index_k);}
-  virtual int get_index_l() const {return  get_property_int(prop_index_l);}
-  virtual int get_hit_type() const {return  get_property_int(prop_hit_type);}
+  virtual float get_eion() const { return get_property_float(prop_eion); }
+  virtual float get_light_yield() const { return get_property_float(prop_light_yield); }
+  virtual float get_path_length() const { return get_property_float(prop_path_length); }
+  virtual unsigned int get_layer() const { return get_property_uint(prop_layer); }
+  virtual int get_scint_id() const { return get_property_int(prop_scint_id); }
+  virtual int get_row() const { return get_property_int(prop_row); }
+  virtual int get_strip_z_index() const { return get_property_int(prop_strip_z_index); }
+  virtual int get_strip_y_index() const { return get_property_int(prop_strip_y_index); }
+  virtual int get_ladder_z_index() const { return get_property_int(prop_ladder_z_index); }
+  virtual int get_ladder_phi_index() const { return get_property_int(prop_ladder_phi_index); }
+  virtual int get_index_i() const { return get_property_int(prop_index_i); }
+  virtual int get_index_j() const { return get_property_int(prop_index_j); }
+  virtual int get_index_k() const { return get_property_int(prop_index_k); }
+  virtual int get_index_l() const { return get_property_int(prop_index_l); }
+  virtual int get_hit_type() const { return get_property_int(prop_hit_type); }
 
   virtual void set_px(const int i, const float f);
   virtual void set_py(const int i, const float f);
@@ -79,31 +79,31 @@ class PHG4Hitv1 : public PHG4Hit
   virtual void set_local_x(const int i, const float f);
   virtual void set_local_y(const int i, const float f);
   virtual void set_local_z(const int i, const float f);
-  virtual void set_eion(const float f)            {set_property(prop_eion,f);}
-  virtual void set_light_yield(const float f)           {set_property(prop_light_yield,f);}
-  virtual void set_path_length(const float f)           {set_property(prop_path_length,f);}
-  virtual void set_layer(const unsigned int i)    {set_property(prop_layer,i);}
-  virtual void set_scint_id(const int i)          {set_property(prop_scint_id,i);}
-  virtual void set_row(const int i)          {set_property(prop_row,i);}
-  virtual void set_strip_z_index(const int i)     {set_property(prop_strip_z_index,i);}
-  virtual void set_strip_y_index(const int i)     {set_property(prop_strip_y_index,i);}
-  virtual void set_ladder_z_index(const int i)    {set_property(prop_ladder_z_index,i);}
-  virtual void set_ladder_phi_index(const int i)  {set_property(prop_ladder_phi_index,i);}
-  virtual void set_index_i(const int i)  {set_property(prop_index_i,i);}
-  virtual void set_index_j(const int i)  {set_property(prop_index_j,i);}
-  virtual void set_index_k(const int i)  {set_property(prop_index_k,i);}
-  virtual void set_index_l(const int i)  {set_property(prop_index_l,i);}
-  virtual void set_hit_type(const int i) {set_property(prop_hit_type,i);}
+  virtual void set_eion(const float f) { set_property(prop_eion, f); }
+  virtual void set_light_yield(const float f) { set_property(prop_light_yield, f); }
+  virtual void set_path_length(const float f) { set_property(prop_path_length, f); }
+  virtual void set_layer(const unsigned int i) { set_property(prop_layer, i); }
+  virtual void set_scint_id(const int i) { set_property(prop_scint_id, i); }
+  virtual void set_row(const int i) { set_property(prop_row, i); }
+  virtual void set_strip_z_index(const int i) { set_property(prop_strip_z_index, i); }
+  virtual void set_strip_y_index(const int i) { set_property(prop_strip_y_index, i); }
+  virtual void set_ladder_z_index(const int i) { set_property(prop_ladder_z_index, i); }
+  virtual void set_ladder_phi_index(const int i) { set_property(prop_ladder_phi_index, i); }
+  virtual void set_index_i(const int i) { set_property(prop_index_i, i); }
+  virtual void set_index_j(const int i) { set_property(prop_index_j, i); }
+  virtual void set_index_k(const int i) { set_property(prop_index_k, i); }
+  virtual void set_index_l(const int i) { set_property(prop_index_l, i); }
+  virtual void set_hit_type(const int i) { set_property(prop_hit_type, i); }
 
  protected:
   unsigned int get_property_nocheck(const PROPERTY prop_id) const;
-  void set_property_nocheck(const PROPERTY prop_id,const unsigned int ui) {prop_map[prop_id]=ui;}
+  void set_property_nocheck(const PROPERTY prop_id, const unsigned int ui) { prop_map[prop_id] = ui; }
   // Store both the entry and exit points of the particle
   // Remember, particles do not always enter on the inner edge!
-  float x[2] = {NAN,NAN};
-  float y[2] = {NAN,NAN};
-  float z[2] = {NAN,NAN};
-  float t[2] = {NAN,NAN};
+  float x[2] = {NAN, NAN};
+  float y[2] = {NAN, NAN};
+  float z[2] = {NAN, NAN};
+  float t[2] = {NAN, NAN};
   PHG4HitDefs::keytype hitid = ULONG_LONG_MAX;
   int trackid = INT_MIN;
   int showerid = INT_MIN;
@@ -115,23 +115,35 @@ class PHG4Hitv1 : public PHG4Hit
   typedef std::map<prop_id_t, prop_storage_t> prop_map_t;
 
   //! convert between 32bit inputs and storage type prop_storage_t
-  union u_property{
+  union u_property {
     float fdata;
     int32_t idata;
     uint32_t uidata;
 
-    u_property(int32_t in): idata(in) {}
-    u_property(uint32_t in): uidata(in) {}
-    u_property(float in): fdata(in) {}
-    u_property(): uidata(0) {}
+    u_property(int32_t in)
+      : idata(in)
+    {
+    }
+    u_property(uint32_t in)
+      : uidata(in)
+    {
+    }
+    u_property(float in)
+      : fdata(in)
+    {
+    }
+    u_property()
+      : uidata(0)
+    {
+    }
 
-    prop_storage_t get_storage() const {return uidata;}
+    prop_storage_t get_storage() const { return uidata; }
   };
 
   //! container for additional property
   prop_map_t prop_map;
 
-  ClassDef(PHG4Hitv1,2)
+  ClassDef(PHG4Hitv1, 2)
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -6,11 +6,9 @@
 #include "PHG4Hit.h"
 #include "PHG4HitDefs.h"
 
-#if !defined(__CINT__) || defined (__CLING__)
+#include <climits>       // for INT_MIN, ULONG_LONG_MAX
+#include <cmath>
 #include <cstdint>
-#else
-#include <stdint.h>
-#endif
 #include <iostream>
 #include <map>
 

--- a/simulation/g4simulation/g4main/PHG4InEventCompressLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4InEventCompressLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4InEventCompress-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4InEventReadBackLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4InEventReadBackLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4InEventReadBack-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4InputFilterLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4InputFilterLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4InputFilter-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4IonGunLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4IonGunLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4IonGun-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
@@ -1,6 +1,6 @@
 #include "PHG4ParticleGeneratorBase.h"
 
-#include "PHG4Particle.h"                  // for PHG4Particle
+#include "PHG4Particle.h"  // for PHG4Particle
 #include "PHG4Particlev1.h"
 
 #include "PHG4InEvent.h"
@@ -10,30 +10,30 @@
 #include <phhepmc/PHHepMCGenEvent.h>
 #include <phhepmc/PHHepMCGenEventMap.h>
 
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
-#include <phool/PHDataNode.h>              // for PHDataNode
-#include <phool/PHNode.h>                  // for PHNode
-#include <phool/PHNodeIterator.h>          // for PHNodeIterator
-#include <phool/PHObject.h>                // for PHObject
+#include <phool/PHDataNode.h>      // for PHDataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/PHRandomSeed.h>
-#include <phool/phool.h>                   // for PHWHERE
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
 
 #include <Geant4/G4ParticleDefinition.hh>
 #include <Geant4/G4ParticleTable.hh>
-#include <Geant4/G4String.hh>              // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 
-#include <HepMC/SimpleVector.h>            // for FourVector
+#include <HepMC/SimpleVector.h>  // for FourVector
 
 #include <gsl/gsl_rng.h>
 
 #include <cassert>
-#include <cstdlib>                        // for exit
-#include <iostream>                        // for operator<<, basic_ostream
-#include <iterator>                        // for operator!=, reverse_iterator
-#include <map>                             // for map<>::const_iterator, map
-#include <utility>                         // for pair
+#include <cstdlib>   // for exit
+#include <iostream>  // for operator<<, basic_ostream
+#include <iterator>  // for operator!=, reverse_iterator
+#include <map>       // for map<>::const_iterator, map
+#include <utility>   // for pair
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
@@ -5,10 +5,7 @@
 
 #include <fun4all/SubsysReco.h>
 
-// rootcint barfs with this header so we need to hide it
-#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
-#endif
 
 #include <string>                // for string
 #include <vector>
@@ -55,17 +52,15 @@ class PHG4ParticleGeneratorBase : public SubsysReco
   double get_mass(const int pdgcode) const;
   void CheckAndCreateParticleVector();
   void SetParticleId(PHG4Particle *particle, PHG4InEvent *ineve);
+  gsl_rng *RandomGenerator;
   int embedflag;
   int reuse_existing_vertex;
   double vtx_x;
   double vtx_y;
   double vtx_z;
   double t0;
-  std::vector<PHG4Particle *> particlelist;
   unsigned int seed;
-#if !defined(__CINT__) || defined(__CLING__)
-  gsl_rng *RandomGenerator;
-#endif
+  std::vector<PHG4Particle *> particlelist;
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
@@ -7,7 +7,7 @@
 
 #include <gsl/gsl_rng.h>
 
-#include <string>                // for string
+#include <string>  // for string
 #include <vector>
 
 class PHCompositeNode;

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBaseLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBaseLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4ParticleGeneratorBase - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0LinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0LinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4ParticleGeneratorD0 - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4ParticleGenerator - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMesonLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMesonLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4ParticleGeneratorVectorMeson - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4ParticleGunLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGunLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4ParticleGun - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4Particlev2.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.cc
@@ -1,6 +1,6 @@
 #include "PHG4Particlev2.h"
 
-class PHG4Particle;
+#include "PHG4Particle.h"  // for PHG4Particle
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/PHG4PileupGeneratorLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4PileupGeneratorLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4PileupGenerator-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -960,8 +960,8 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
                                den_G4_CARBON_DIOXIDE / den);
   // cross checked with original implementation made up of Ne,C,F
   // this here is very close but makes more sense since it uses Ne and CF4
-  double G4_Ne_frac = 0.9;
-  double CF4_frac = 0.1;
+  double G4_Ne_frac = 0.5;
+  double CF4_frac = 0.5;
   const double den_G4_Ne = G4Material::GetMaterial("G4_Ne")->GetDensity();
   const double den_CF4_2 = CF4->GetDensity();
   const double den_sphenix_tpc_gas = den_G4_Ne * G4_Ne_frac + den_CF4_2 * CF4_frac;

--- a/simulation/g4simulation/g4main/PHG4RecoLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4RecoLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4Reco-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4ScoringManagerLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4ScoringManagerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4ScoringManager-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGeneratorLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGeneratorLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4SimpleEventGenerator-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4SubsystemLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4SubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4Subsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
@@ -5,159 +5,159 @@
 
 #include <boost/lexical_cast.hpp>
 
-#include <iostream>                // for operator<<, basic_ostream, endl, cout
-#include <string>                  // for string, operator<<
+#include <iostream>  // for operator<<, basic_ostream, endl, cout
+#include <string>    // for string, operator<<
 
 namespace PHG4TrackUserInfo
 {
-void SetUserTrackId(G4Track* track, const int usertrackid)
-{
-  if (G4VUserTrackInformation* p = track->GetUserInformation())
+  void SetUserTrackId(G4Track* track, const int usertrackid)
   {
-    // User info exists, test it for something valid
-    if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+    if (G4VUserTrackInformation* p = track->GetUserInformation())
     {
+      // User info exists, test it for something valid
+      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+      {
+        pp->SetUserTrackId(usertrackid);
+      }
+      else
+      {
+        std::cout << "Unknown UserTrackInformation stored in track number "
+                  << boost::lexical_cast<std::string>(track->GetTrackID())
+                  << std::endl;
+      }
+    }
+    else
+    {
+      // User info does not exist, add it.
+      PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
       pp->SetUserTrackId(usertrackid);
+      track->SetUserInformation(pp);
+    }
+  }
+
+  void SetUserParentId(G4Track* track, const int userparentid)
+  {
+    if (G4VUserTrackInformation* p = track->GetUserInformation())
+    {
+      // User info exists, test it for something valid
+      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+      {
+        pp->SetUserParentId(userparentid);
+      }
+      else
+      {
+        std::cout << "Unknown UserTrackInformation stored in track number "
+                  << boost::lexical_cast<std::string>(track->GetTrackID())
+                  << std::endl;
+      }
     }
     else
     {
-      std::cout << "Unknown UserTrackInformation stored in track number "
-                << boost::lexical_cast<std::string>(track->GetTrackID())
-                << std::endl;
-    }
-  }
-  else
-  {
-    // User info does not exist, add it.
-    PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
-    pp->SetUserTrackId(usertrackid);
-    track->SetUserInformation(pp);
-  }
-}
-
-void SetUserParentId(G4Track* track, const int userparentid)
-{
-  if (G4VUserTrackInformation* p = track->GetUserInformation())
-  {
-    // User info exists, test it for something valid
-    if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
-    {
+      // User info does not exist, add it.
+      PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
       pp->SetUserParentId(userparentid);
+      track->SetUserInformation(pp);
+    }
+  }
+
+  void SetUserPrimaryId(G4Track* track, const int userprimaryid)
+  {
+    if (G4VUserTrackInformation* p = track->GetUserInformation())
+    {
+      // User info exists, test it for something valid
+      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+      {
+        pp->SetUserPrimaryId(userprimaryid);
+      }
+      else
+      {
+        std::cout << "Unknown UserTrackInformation stored in track number "
+                  << boost::lexical_cast<std::string>(track->GetTrackID())
+                  << std::endl;
+      }
     }
     else
     {
-      std::cout << "Unknown UserTrackInformation stored in track number "
-                << boost::lexical_cast<std::string>(track->GetTrackID())
-                << std::endl;
-    }
-  }
-  else
-  {
-    // User info does not exist, add it.
-    PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
-    pp->SetUserParentId(userparentid);
-    track->SetUserInformation(pp);
-  }
-}
-
-void SetUserPrimaryId(G4Track* track, const int userprimaryid)
-{
-  if (G4VUserTrackInformation* p = track->GetUserInformation())
-  {
-    // User info exists, test it for something valid
-    if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
-    {
+      // User info does not exist, add it.
+      PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
       pp->SetUserPrimaryId(userprimaryid);
+      track->SetUserInformation(pp);
+    }
+  }
+
+  void SetWanted(G4Track* track, const int trkid)
+  {
+    if (G4VUserTrackInformation* p = track->GetUserInformation())
+    {
+      // User info exists, test it for something valid
+      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+      {
+        pp->SetWanted(trkid);
+      }
+      else
+      {
+        std::cout << "Unknown UserTrackInformation stored in track number "
+                  << boost::lexical_cast<std::string>(track->GetTrackID())
+                  << std::endl;
+      }
     }
     else
     {
-      std::cout << "Unknown UserTrackInformation stored in track number "
-                << boost::lexical_cast<std::string>(track->GetTrackID())
-                << std::endl;
-    }
-  }
-  else
-  {
-    // User info does not exist, add it.
-    PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
-    pp->SetUserPrimaryId(userprimaryid);
-    track->SetUserInformation(pp);
-  }
-}
-
-void SetWanted(G4Track* track, const int trkid)
-{
-  if (G4VUserTrackInformation* p = track->GetUserInformation())
-  {
-    // User info exists, test it for something valid
-    if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
-    {
+      // User info does not exist, add it.
+      PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
       pp->SetWanted(trkid);
+      track->SetUserInformation(pp);
+    }
+  }
+
+  void SetKeep(G4Track* track, const int trkid)
+  {
+    if (G4VUserTrackInformation* p = track->GetUserInformation())
+    {
+      // User info exists, test it for something valid
+      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+      {
+        pp->SetKeep(trkid);
+      }
+      else
+      {
+        std::cout << "Unknown UserTrackInformation stored in track number "
+                  << boost::lexical_cast<std::string>(track->GetTrackID())
+                  << std::endl;
+      }
     }
     else
     {
-      std::cout << "Unknown UserTrackInformation stored in track number "
-                << boost::lexical_cast<std::string>(track->GetTrackID())
-                << std::endl;
-    }
-  }
-  else
-  {
-    // User info does not exist, add it.
-    PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
-    pp->SetWanted(trkid);
-    track->SetUserInformation(pp);
-  }
-}
-
-void SetKeep(G4Track* track, const int trkid)
-{
-  if (G4VUserTrackInformation* p = track->GetUserInformation())
-  {
-    // User info exists, test it for something valid
-    if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
-    {
+      // User info does not exist, add it.
+      PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
       pp->SetKeep(trkid);
-    }
-    else
-    {
-      std::cout << "Unknown UserTrackInformation stored in track number "
-                << boost::lexical_cast<std::string>(track->GetTrackID())
-                << std::endl;
+      track->SetUserInformation(pp);
     }
   }
-  else
-  {
-    // User info does not exist, add it.
-    PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
-    pp->SetKeep(trkid);
-    track->SetUserInformation(pp);
-  }
-}
 
-void SetShower(G4Track* track, PHG4Shower* shower)
-{
-  if (G4VUserTrackInformation* p = track->GetUserInformation())
+  void SetShower(G4Track* track, PHG4Shower* shower)
   {
-    // User info exists, test it for something valid
-    if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+    if (G4VUserTrackInformation* p = track->GetUserInformation())
     {
-      pp->SetShower(shower);
+      // User info exists, test it for something valid
+      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+      {
+        pp->SetShower(shower);
+      }
+      else
+      {
+        std::cout << "Unknown UserTrackInformation stored in track number "
+                  << boost::lexical_cast<std::string>(track->GetTrackID())
+                  << std::endl;
+      }
     }
     else
     {
-      std::cout << "Unknown UserTrackInformation stored in track number "
-                << boost::lexical_cast<std::string>(track->GetTrackID())
-                << std::endl;
+      // User info does not exist, add it.
+      PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
+      pp->SetShower(shower);
+      track->SetUserInformation(pp);
     }
   }
-  else
-  {
-    // User info does not exist, add it.
-    PHG4TrackUserInfoV1* pp = new PHG4TrackUserInfoV1();
-    pp->SetShower(shower);
-    track->SetUserInformation(pp);
-  }
-}
 
 }  // namespace PHG4TrackUserInfo

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.cc
@@ -1,6 +1,7 @@
 #include "PHG4TrackUserInfoV1.h"
 
 #include <Geant4/G4Track.hh>
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <boost/lexical_cast.hpp>
 

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4TruthSubsystem-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4UtilsLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4UtilsLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4Utils-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/PHG4VertexSelection.cc
+++ b/simulation/g4simulation/g4main/PHG4VertexSelection.cc
@@ -11,7 +11,10 @@
 #include "PHG4VtxPoint.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
+
 #include <phool/getClass.h>
+
+#include <iostream>                      // for operator<<, basic_ostream, endl
 
 //____________________________________________________________________________
 PHG4VertexSelection::PHG4VertexSelection(const std::string &name)

--- a/simulation/g4simulation/g4main/PHG4VertexSelection.cc
+++ b/simulation/g4simulation/g4main/PHG4VertexSelection.cc
@@ -14,13 +14,15 @@
 
 #include <phool/getClass.h>
 
-#include <iostream>                      // for operator<<, basic_ostream, endl
+#include <iostream>  // for operator<<, basic_ostream, endl
 
 //____________________________________________________________________________
 PHG4VertexSelection::PHG4VertexSelection(const std::string &name)
   : SubsysReco(name)
   , PHParameterInterface(name)
-{ InitializeParameters(); }
+{
+  InitializeParameters();
+}
 
 //____________________________________________________________________________
 int PHG4VertexSelection::InitRun(PHCompositeNode *topNode)
@@ -28,34 +30,34 @@ int PHG4VertexSelection::InitRun(PHCompositeNode *topNode)
   UpdateParametersWithMacro();
 
   // load parameters
-  m_vertex_zcut = get_double_param( "vertex_zcut" );
-  
+  m_vertex_zcut = get_double_param("vertex_zcut");
+
   // printout
   std::cout
-    << "PHG4VertexSelection::InitRun\n"
-    << " m_vertex_zcut: " << m_vertex_zcut << " cm\n"
-    << std::endl;
+      << "PHG4VertexSelection::InitRun\n"
+      << " m_vertex_zcut: " << m_vertex_zcut << " cm\n"
+      << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________
 int PHG4VertexSelection::process_event(PHCompositeNode *topNode)
-{  
+{
   // g4 truth info
   auto g4truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
 
   // main vertex
   const auto main_vertex_id = g4truthinfo->GetPrimaryVertexIndex();
-  const auto vertex = g4truthinfo->GetPrimaryVtx( main_vertex_id );
-  if( !vertex ) return false;
+  const auto vertex = g4truthinfo->GetPrimaryVtx(main_vertex_id);
+  if (!vertex) return false;
 
   // check vertex position along the beam
-  return ( m_vertex_zcut > 0 && std::abs( vertex->get_z() ) > m_vertex_zcut ) ?
-    Fun4AllReturnCodes::DISCARDEVENT:
-    Fun4AllReturnCodes::EVENT_OK;
+  return (m_vertex_zcut > 0 && std::abs(vertex->get_z()) > m_vertex_zcut) ? Fun4AllReturnCodes::DISCARDEVENT : Fun4AllReturnCodes::EVENT_OK;
 }
 
 //___________________________________________________________________________
 void PHG4VertexSelection::SetDefaultParameters()
-{ set_default_double_param( "vertex_zcut", 10 ); }
+{
+  set_default_double_param("vertex_zcut", 10);
+}

--- a/simulation/g4simulation/g4main/PHG4VertexSelection.h
+++ b/simulation/g4simulation/g4main/PHG4VertexSelection.h
@@ -12,7 +12,6 @@
 #include <fun4all/SubsysReco.h>
 #include <phparameter/PHParameterInterface.h>
 
-#include <memory>
 #include <string>                              // for string
 
 class PHCompositeNode;

--- a/simulation/g4simulation/g4main/PHG4VertexSelection.h
+++ b/simulation/g4simulation/g4main/PHG4VertexSelection.h
@@ -12,18 +12,17 @@
 #include <fun4all/SubsysReco.h>
 #include <phparameter/PHParameterInterface.h>
 
-#include <string>                              // for string
+#include <string>  // for string
 
 class PHCompositeNode;
 
 class PHG4VertexSelection : public SubsysReco, public PHParameterInterface
 {
-
-  public:
+ public:
   PHG4VertexSelection(const std::string &name = "PHG4VertexSelection");
 
   //! run initialization
-  int InitRun(PHCompositeNode*) override;
+  int InitRun(PHCompositeNode *) override;
 
   //! event processing
   int process_event(PHCompositeNode *topNode) override;
@@ -31,11 +30,9 @@ class PHG4VertexSelection : public SubsysReco, public PHParameterInterface
   //! parameters
   void SetDefaultParameters() override;
 
-  private:
-
+ private:
   // z vertex cut (cm)
   double m_vertex_zcut = 10;
-  
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4VertexSelectionLinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4VertexSelectionLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4SelectionLinkDef-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/ReadEICFilesLinkDef.h
+++ b/simulation/g4simulation/g4main/ReadEICFilesLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class ReadEICFiles-!;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4main/configure.ac
+++ b/simulation/g4simulation/g4main/configure.ac
@@ -24,12 +24,8 @@ fi
 dnl  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
 
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
-fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -1082,6 +1082,11 @@ void PHG4TrackFastSim::add_cylinder_state(const std::string& stateName, const do
     cout << PHWHERE << ": " << stateName << " is a reserved name, used a different name for your cylinder projection" << endl;
     gSystem->Exit(1);
   }
+  if (m_ProjectionsMap.find(stateName) != m_ProjectionsMap.end())
+  {
+    cout << PHWHERE << ": " << stateName << " is already a projection, please rename" << endl;
+    gSystem->Exit(1);
+  }
   m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Cylinder, radius)));
   return;
 }
@@ -1092,6 +1097,11 @@ void PHG4TrackFastSim::add_zplane_state(const std::string& stateName, const doub
       reserved_zplane_projection_names.find(stateName) != reserved_zplane_projection_names.end())
   {
     cout << PHWHERE << ": " << stateName << " is  a reserved name, used different name for your zplane projection" << endl;
+    gSystem->Exit(1);
+  }
+  if (m_ProjectionsMap.find(stateName) != m_ProjectionsMap.end())
+  {
+    cout << PHWHERE << ": " << stateName << " is already a projection, please rename" << endl;
     gSystem->Exit(1);
   }
  m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Vertical_Plane, zplane)));

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -96,8 +96,8 @@ using namespace std;
 // names of our implemented calorimeters where the projections are done
 // at 1/2 of their depth, not at the surface
 // this is used to avoid user added projections with identical names
-set<string> reserved_cylinder_projection_names {"CEMC", "HCALIN", "HCALOUT"};
-set<string> reserved_zplane_projection_names {"FEMC","FHCAL","EEMC"};
+set<string> reserved_cylinder_projection_names{"CEMC", "HCALIN", "HCALOUT"};
+set<string> reserved_zplane_projection_names{"FEMC", "FHCAL", "EEMC"};
 
 PHG4TrackFastSim::PHG4TrackFastSim(const std::string& name)
   : SubsysReco(name)
@@ -909,7 +909,7 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
     switch (iter->second.first)
     {
     case DETECTOR_TYPE::Cylinder:
-      pathlenth_from_first_meas = phgf_track->extrapolateToCylinder(*gf_state, iter->second.second, TVector3(0., 0., 0.),TVector3(0., 0., 1.), 0);
+      pathlenth_from_first_meas = phgf_track->extrapolateToCylinder(*gf_state, iter->second.second, TVector3(0., 0., 0.), TVector3(0., 0., 1.), 0);
       break;
     case DETECTOR_TYPE::Vertical_Plane:
       pathlenth_from_first_meas = phgf_track->extrapolateToPlane(*gf_state, TVector3(0., 0., iter->second.second), TVector3(0, 0., 1.), 0);
@@ -1059,13 +1059,15 @@ void PHG4TrackFastSim::add_state_name(const std::string& stateName)
   else
   {
     cout << PHWHERE << " Invalid stateName " << stateName << endl;
-    cout << endl << "These are implemented for cylinders" << endl;
-    for (auto iter :  reserved_cylinder_projection_names)
+    cout << endl
+         << "These are implemented for cylinders" << endl;
+    for (auto iter : reserved_cylinder_projection_names)
     {
       cout << iter << endl;
     }
-    cout << endl << "These are implemented are for zplanes" << endl;
-    for (auto iter :  reserved_zplane_projection_names)
+    cout << endl
+         << "These are implemented are for zplanes" << endl;
+    for (auto iter : reserved_zplane_projection_names)
     {
       cout << iter << endl;
     }
@@ -1104,6 +1106,6 @@ void PHG4TrackFastSim::add_zplane_state(const std::string& stateName, const doub
     cout << PHWHERE << ": " << stateName << " is already a projection, please rename" << endl;
     gSystem->Exit(1);
   }
- m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Vertical_Plane, zplane)));
+  m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Vertical_Plane, zplane)));
   return;
 }

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -1059,16 +1059,17 @@ void PHG4TrackFastSim::add_state_name(const std::string& stateName)
   else
   {
     cout << PHWHERE << " Invalid stateName " << stateName << endl;
-    cout << "implemented are for cylinders" << endl;
+    cout << endl << "These are implemented for cylinders" << endl;
     for (auto iter :  reserved_cylinder_projection_names)
     {
       cout << iter << endl;
     }
-    cout << "implemented are for zplanes" << endl;
+    cout << endl << "These are implemented are for zplanes" << endl;
     for (auto iter :  reserved_zplane_projection_names)
     {
       cout << iter << endl;
     }
+    gSystem->Exit(1);
   }
   return;
 }
@@ -1078,8 +1079,8 @@ void PHG4TrackFastSim::add_cylinder_state(const std::string& stateName, const do
   if (reserved_cylinder_projection_names.find(stateName) != reserved_cylinder_projection_names.end() ||
       reserved_zplane_projection_names.find(stateName) != reserved_zplane_projection_names.end())
   {
-    cout << PHWHERE << ": " << stateName << " is reserved, used different name" << endl;
-    return;
+    cout << PHWHERE << ": " << stateName << " is a reserved name, used a different name for your cylinder projection" << endl;
+    gSystem->Exit(1);
   }
   m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Cylinder, radius)));
   return;
@@ -1090,8 +1091,8 @@ void PHG4TrackFastSim::add_zplane_state(const std::string& stateName, const doub
   if (reserved_cylinder_projection_names.find(stateName) != reserved_cylinder_projection_names.end() ||
       reserved_zplane_projection_names.find(stateName) != reserved_zplane_projection_names.end())
   {
-    cout << PHWHERE << ": " << stateName << " is reserved, used different name" << endl;
-    return;
+    cout << PHWHERE << ": " << stateName << " is  a reserved name, used different name for your zplane projection" << endl;
+    gSystem->Exit(1);
   }
  m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Vertical_Plane, zplane)));
   return;

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -93,6 +93,12 @@ namespace genfit
 
 using namespace std;
 
+// names of our implemented calorimeters where the projections are done
+// at 1/2 of their depth, not at the surface
+// this is used to avoid user added projections with identical names
+set<string> reserved_cylinder_projection_names {"CEMC", "HCALIN", "HCALOUT"};
+set<string> reserved_zplane_projection_names {"FEMC","FHCAL","EEMC"};
+
 PHG4TrackFastSim::PHG4TrackFastSim(const std::string& name)
   : SubsysReco(name)
   , m_Fitter(nullptr)
@@ -903,12 +909,10 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
     switch (iter->second.first)
     {
     case DETECTOR_TYPE::Cylinder:
-      pathlenth_from_first_meas = phgf_track->extrapolateToCylinder(*gf_state, iter->second.second, TVector3(0., 0., 0.),
-                                                                    TVector3(0., 0., 1.), 0);
+      pathlenth_from_first_meas = phgf_track->extrapolateToCylinder(*gf_state, iter->second.second, TVector3(0., 0., 0.),TVector3(0., 0., 1.), 0);
       break;
     case DETECTOR_TYPE::Vertical_Plane:
-      pathlenth_from_first_meas = phgf_track->extrapolateToPlane(*gf_state, TVector3(0., 0., iter->second.second),
-                                                                 TVector3(1., 0., iter->second.second), 0);
+      pathlenth_from_first_meas = phgf_track->extrapolateToPlane(*gf_state, TVector3(0., 0., iter->second.second), TVector3(0, 0., 1.), 0);
       break;
     default:
       cout << "how in the world did you get here??????" << endl;
@@ -1044,13 +1048,51 @@ void PHG4TrackFastSim::DisplayEvent() const
 
 void PHG4TrackFastSim::add_state_name(const std::string& stateName)
 {
-  if (stateName == "FEMC" || stateName == "FHCAL" || stateName == "EEMC")
+  if (reserved_zplane_projection_names.find(stateName) != reserved_zplane_projection_names.end())
   {
     m_ProjectionsMap.insert(make_pair(stateName, make_pair(DETECTOR_TYPE::Vertical_Plane, NAN)));
   }
-  else if (stateName == "CEMC" || stateName == "HCALIN" || stateName == "HCALOUT")
+  else if (reserved_cylinder_projection_names.find(stateName) != reserved_cylinder_projection_names.end())
   {
     m_ProjectionsMap.insert(make_pair(stateName, make_pair(DETECTOR_TYPE::Cylinder, NAN)));
   }
+  else
+  {
+    cout << PHWHERE << " Invalid stateName " << stateName << endl;
+    cout << "implemented are for cylinders" << endl;
+    for (auto iter :  reserved_cylinder_projection_names)
+    {
+      cout << iter << endl;
+    }
+    cout << "implemented are for zplanes" << endl;
+    for (auto iter :  reserved_zplane_projection_names)
+    {
+      cout << iter << endl;
+    }
+  }
+  return;
+}
+
+void PHG4TrackFastSim::add_cylinder_state(const std::string& stateName, const double radius)
+{
+  if (reserved_cylinder_projection_names.find(stateName) != reserved_cylinder_projection_names.end() ||
+      reserved_zplane_projection_names.find(stateName) != reserved_zplane_projection_names.end())
+  {
+    cout << PHWHERE << ": " << stateName << " is reserved, used different name" << endl;
+    return;
+  }
+  m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Cylinder, radius)));
+  return;
+}
+
+void PHG4TrackFastSim::add_zplane_state(const std::string& stateName, const double zplane)
+{
+  if (reserved_cylinder_projection_names.find(stateName) != reserved_cylinder_projection_names.end() ||
+      reserved_zplane_projection_names.find(stateName) != reserved_zplane_projection_names.end())
+  {
+    cout << PHWHERE << ": " << stateName << " is reserved, used different name" << endl;
+    return;
+  }
+ m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Vertical_Plane, zplane)));
   return;
 }

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -15,7 +15,7 @@
 #include <TMatrixDSymfwd.h>  // for TMatrixDSym
 #include <TVector3.h>
 
-// #include <phgenfit/Track.h> is needed, it crashes on Ubuntu using 
+// #include <phgenfit/Track.h> is needed, it crashes on Ubuntu using
 // singularity with local cvmfs install
 // shared pointer later on uses this, forward declaration does not cut it
 #include <phgenfit/Track.h>

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -129,15 +129,9 @@ class PHG4TrackFastSim : public SubsysReco
   void add_state_name(const std::string& stateName);
 
   // add saving of state at plane in z
-  void add_zplane_state(const std::string& stateName, const double zplane)
-  {
-    m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Vertical_Plane, zplane)));
-  }
+  void add_zplane_state(const std::string& stateName, const double zplane);
 
-  void add_cylinder_state(const std::string& stateName, const double radius)
-  {
-    m_ProjectionsMap.insert(std::make_pair(stateName, std::make_pair(DETECTOR_TYPE::Cylinder, radius)));
-  }
+  void add_cylinder_state(const std::string& stateName, const double radius);
 
   const std::string& get_trackmap_out_name() const
   {


### PR DESCRIPTION
This PR fixes a bug in the zplane projections for the fast tracking which lead to a few percent errors. Adds a few checks to the projection name parsing (no duplicates or reserved names).

The sPHENIX tpc gas was changed to 50:50 Ne/CF4, 
include what you use and removed root5 remnants 

clang-format for a bunch of files