### PR TITLE
Update gain to match gas change from Ne/CF4 90/10 to Ne/CF4 50/50

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -793,8 +793,12 @@ void PHG4TpcPadPlaneReadout::SetDefaultParameters()
 
   set_default_int_param("zigzag_pads", 1);
 
-  set_default_double_param("gem_amplification", 2000); // GEM Gain
-
+  // GEM Gain
+  /*
+  hp (2020/09/04): gain changed from 2000 to 1400, to accomodate gas mixture change 
+  from Ne/CF4 90/10 to Ne/CF4 50/50, and keep the average charge per particle per pad constant
+  */
+  set_default_double_param("gem_amplification", 1400); 
   return;
 }
 


### PR DESCRIPTION
This ensures that the average charge per particle per pad is kept unchanged.
The ratio between old and new gain correspond to the inverse ratio of the average number of primary electron per cm for a MIP