### PR TITLE
Associate silicon truth clusters

### DIFF
--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -54,6 +54,7 @@ pkginclude_HEADERS = \
   PHTrackFitting.h \
   PHTrackSetMerging.h \
   PHTruthTrackSeeding.h \
+  PHTruthSiliconAssociation.h \
   PHTruthVertexing.h \
   VertexFitter.h \
   PHRaveVertexing.h \
@@ -91,6 +92,7 @@ else
     PH3DVertexing_Dict.cc \
     PHTruthVertexing_Dict.cc \
     PHTruthTrackSeeding_Dict.cc \
+    PHTruthSiliconAssociation_Dict.cc \
     PHHoughSeeding_Dict.cc \
     PHRTreeSeeding_Dict.cc \
     PHCASeeding_Dict.cc \
@@ -155,6 +157,7 @@ libtrack_reco_la_SOURCES = \
   PH3DVertexing.cc \
   PHTruthVertexing.cc \
   PHTruthTrackSeeding.cc \
+  PHTruthSiliconAssociation.cc \
   PHHoughSeeding.cc \
   PHRTreeSeeding.cc \
   PHCASeeding.cc \

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -1,0 +1,279 @@
+//____________________________________________________________________________..
+//
+// This is a template for a Fun4All SubsysReco module with all methods from the
+// $OFFLINE_MAIN/include/fun4all/SubsysReco.h baseclass
+// You do not have to implement all of them, you can just remove unused methods
+// here and in PHTruthSiliconAssociation.h.
+//
+// PHTruthSiliconAssociation(const std::string &name = "PHTruthSiliconAssociation")
+// everything is keyed to PHTruthSiliconAssociation, duplicate names do work but it makes
+// e.g. finding culprits in logs difficult or getting a pointer to the module
+// from the command line
+//
+// PHTruthSiliconAssociation::~PHTruthSiliconAssociation()
+// this is called when the Fun4AllServer is deleted at the end of running. Be
+// mindful what you delete - you do loose ownership of object you put on the node tree
+//
+// int PHTruthSiliconAssociation::Init(PHCompositeNode *topNode)
+// This method is called when the module is registered with the Fun4AllServer. You
+// can create historgrams here or put objects on the node tree but be aware that
+// modules which haven't been registered yet did not put antyhing on the node tree
+//
+// int PHTruthSiliconAssociation::InitRun(PHCompositeNode *topNode)
+// This method is called when the first event is read (or generated). At
+// this point the run number is known (which is mainly interesting for raw data
+// processing). Also all objects are on the node tree in case your module's action
+// depends on what else is around. Last chance to put nodes under the DST Node
+// We mix events during readback if branches are added after the first event
+//
+// int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
+// called for every event. Return codes trigger actions, you find them in
+// $OFFLINE_MAIN/include/fun4all/Fun4AllReturnCodes.h
+//   everything is good:
+//     return Fun4AllReturnCodes::EVENT_OK
+//   abort event reconstruction, clear everything and process next event:
+//     return Fun4AllReturnCodes::ABORT_EVENT; 
+//   proceed but do not save this event in output (needs output manager setting):
+//     return Fun4AllReturnCodes::DISCARD_EVENT; 
+//   abort processing:
+//     return Fun4AllReturnCodes::ABORT_RUN
+// all other integers will lead to an error and abort of processing
+//
+// int PHTruthSiliconAssociation::ResetEvent(PHCompositeNode *topNode)
+// If you have internal data structures (arrays, stl containers) which needs clearing
+// after each event, this is the place to do that. The nodes under the DST node are cleared
+// by the framework
+//
+// int PHTruthSiliconAssociation::EndRun(const int runnumber)
+// This method is called at the end of a run when an event from a new run is
+// encountered. Useful when analyzing multiple runs (raw data). Also called at
+// the end of processing (before the End() method)
+//
+// int PHTruthSiliconAssociation::End(PHCompositeNode *topNode)
+// This is called at the end of processing. It needs to be called by the macro
+// by Fun4AllServer::End(), so do not forget this in your macro
+//
+// int PHTruthSiliconAssociation::Reset(PHCompositeNode *topNode)
+// not really used - it is called before the dtor is called
+//
+// void PHTruthSiliconAssociation::Print(const std::string &what) const
+// Called from the command line - useful to print information when you need it
+//
+//____________________________________________________________________________..
+
+#include "PHTruthSiliconAssociation.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+/// Tracking includes
+#include <trackbase/TrkrClusterv1.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+
+#include <g4eval/SvtxClusterEval.h>
+#include <g4eval/SvtxEvalStack.h>
+#include <g4eval/SvtxEvaluator.h>
+#include <g4eval/SvtxTrackEval.h>
+
+#include <g4main/PHG4Hit.h>  // for PHG4Hit
+#include <g4main/PHG4Particle.h>  // for PHG4Particle
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4HitDefs.h>  // for keytype
+#include <g4main/PHG4TruthInfoContainer.h>
+
+#include "AssocInfoContainer.h"
+
+using namespace std;
+
+//____________________________________________________________________________..
+PHTruthSiliconAssociation::PHTruthSiliconAssociation(const std::string &name):
+ SubsysReco(name)
+{
+  cout << "PHTruthSiliconAssociation::PHTruthSiliconAssociation(const std::string &name) Calling ctor" << endl;
+}
+
+//____________________________________________________________________________..
+PHTruthSiliconAssociation::~PHTruthSiliconAssociation()
+{
+  cout << "PHTruthSiliconAssociation::~PHTruthSiliconAssociation() Calling dtor" << endl;
+}
+
+//____________________________________________________________________________..
+int PHTruthSiliconAssociation::Init(PHCompositeNode *topNode)
+{
+  cout << "PHTruthSiliconAssociation::Init(PHCompositeNode *topNode) Initializing" << endl;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHTruthSiliconAssociation::InitRun(PHCompositeNode *topNode)
+{
+  cout << "PHTruthSiliconAssociation::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << endl;
+
+  GetNodes(topNode);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
+{
+  cout << "PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode) Processing Event" << endl;
+
+  _svtxEvalStack = new SvtxEvalStack(topNode);
+  _svtxEvalStack->next_event(topNode);
+
+  SvtxTrackEval *trackeval = _svtxEvalStack->get_track_eval();
+  SvtxClusterEval *clustereval = _svtxEvalStack->get_cluster_eval();
+
+  // Loop over all SvtxTracks from the CA seeder
+  // These should contain all TPC clusters already
+
+  for (auto phtrk_iter = _track_map->begin();
+       phtrk_iter != _track_map->end(); 
+       ++phtrk_iter)
+    {
+      _tracklet = phtrk_iter->second;
+      //if (Verbosity() >= 1)
+	{
+	  std::cout
+	    << __LINE__
+	    << ": Processing seed itrack: " << phtrk_iter->first
+	    << ": nhits: " << _tracklet-> size_cluster_keys()
+	    << ": Total tracks: " << _track_map->size()
+	    << endl;
+	}
+
+      _tracklet->identify(); 
+     
+      // Reject short seed tracks
+      if(_tracklet->size_cluster_keys() < _min_clusters_per_track)
+	{
+	  std::cout << " --- reject track  number " << phtrk_iter->first << std::endl;
+	  //continue;
+	}
+
+      // identify the best truth track match for this seed track 
+
+	PHG4Particle *g4particle = trackeval->max_truth_particle_by_nclusters(_tracklet);
+
+	// identify the clusters that are associated with this g4particle
+
+	std::set<TrkrDefs::cluskey> clusters = clustereval->all_clusters_from(g4particle);
+
+	for (std::set<TrkrDefs::cluskey>::iterator jter = clusters.begin();
+	     jter != clusters.end();
+	     ++jter)
+	  {
+	    TrkrDefs::cluskey cluster_key = *jter;
+	    unsigned int layer = TrkrDefs::getLayer(cluster_key);
+	    unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+	    std::cout << "     found cluster with key: " << cluster_key << " in layer " << layer << std::endl;
+	    //TrkrCluster *cluster = clustermap->findCluster(cluster_key);
+	    //cluster->identify();
+	    
+	    // Identify the MVTX and INTT clusters and add them to the SvtxTrack cluster key list
+	    if(trkrid == TrkrDefs::mvtxId)
+	      {
+		std::cout << "            cluster belongs to MVTX, add to track " << std::endl;
+		_tracklet->insert_cluster_key(cluster_key);
+		_assoc_container->SetClusterTrackAssoc(cluster_key, _tracklet->get_id());
+	      }
+	    
+	    if(trkrid == TrkrDefs::inttId)
+	      {
+		std::cout << "            cluster belongs to INTT, add to track " << std::endl;
+		  _tracklet->insert_cluster_key(cluster_key);
+		_assoc_container->SetClusterTrackAssoc(cluster_key, _tracklet->get_id());
+	      }
+	  }
+
+	// the vertex id from the seeder is nonsense, use vertex 0
+	unsigned int ivert = 0;
+	_tracklet->set_vertex_id(ivert);
+
+	_tracklet->identify(); 
+	std::cout << " new cluster keys size " << _tracklet->size_cluster_keys() << endl;
+
+	std::cout << "Done with track " << phtrk_iter->first << std::endl;
+    }
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHTruthSiliconAssociation::ResetEvent(PHCompositeNode *topNode)
+{
+  //cout << "PHTruthSiliconAssociation::ResetEvent(PHCompositeNode *topNode) Resetting internal structures, prepare for next event" << endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHTruthSiliconAssociation::EndRun(const int runnumber)
+{
+  //cout << "PHTruthSiliconAssociation::EndRun(const int runnumber) Ending Run for Run " << runnumber << endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHTruthSiliconAssociation::End(PHCompositeNode *topNode)
+{
+  //cout << "PHTruthSiliconAssociation::End(PHCompositeNode *topNode) This is the End..." << endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHTruthSiliconAssociation::Reset(PHCompositeNode *topNode)
+{
+  //cout << "PHTruthSiliconAssociation::Reset(PHCompositeNode *topNode) being Reset" << endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+void PHTruthSiliconAssociation::Print(const std::string &what) const
+{
+  //cout << "PHTruthSiliconAssociation::Print(const std::string &what) const Printing info for " << what << endl;
+}
+
+int  PHTruthSiliconAssociation::GetNodes(PHCompositeNode* topNode)
+{
+  //---------------------------------
+  // Get Objects off of the Node Tree
+  //---------------------------------
+
+  _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  if (!_cluster_map)
+  {
+    cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  //  _vertex_map = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+  //if (!_vertex_map)
+  //{
+  //cerr << PHWHERE << " ERROR: Can't find SvtxVertexMap." << endl;
+  //return Fun4AllReturnCodes::ABORTEVENT;
+  //}
+
+  _track_map = findNode::getClass<SvtxTrackMap>(topNode,  "SvtxTrackMap");
+  if (!_track_map)
+  {
+    cerr << PHWHERE << " ERROR: Can't find SvtxTrackMap: " << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  _assoc_container = findNode::getClass<AssocInfoContainer>(topNode, "AssocInfoContainer");
+  if (!_assoc_container)
+  {
+    cerr << PHWHERE << " ERROR: Can't find AssocInfoContainer." << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -1,66 +1,3 @@
-//____________________________________________________________________________..
-//
-// This is a template for a Fun4All SubsysReco module with all methods from the
-// $OFFLINE_MAIN/include/fun4all/SubsysReco.h baseclass
-// You do not have to implement all of them, you can just remove unused methods
-// here and in PHTruthSiliconAssociation.h.
-//
-// PHTruthSiliconAssociation(const std::string &name = "PHTruthSiliconAssociation")
-// everything is keyed to PHTruthSiliconAssociation, duplicate names do work but it makes
-// e.g. finding culprits in logs difficult or getting a pointer to the module
-// from the command line
-//
-// PHTruthSiliconAssociation::~PHTruthSiliconAssociation()
-// this is called when the Fun4AllServer is deleted at the end of running. Be
-// mindful what you delete - you do loose ownership of object you put on the node tree
-//
-// int PHTruthSiliconAssociation::Init(PHCompositeNode *topNode)
-// This method is called when the module is registered with the Fun4AllServer. You
-// can create historgrams here or put objects on the node tree but be aware that
-// modules which haven't been registered yet did not put antyhing on the node tree
-//
-// int PHTruthSiliconAssociation::InitRun(PHCompositeNode *topNode)
-// This method is called when the first event is read (or generated). At
-// this point the run number is known (which is mainly interesting for raw data
-// processing). Also all objects are on the node tree in case your module's action
-// depends on what else is around. Last chance to put nodes under the DST Node
-// We mix events during readback if branches are added after the first event
-//
-// int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
-// called for every event. Return codes trigger actions, you find them in
-// $OFFLINE_MAIN/include/fun4all/Fun4AllReturnCodes.h
-//   everything is good:
-//     return Fun4AllReturnCodes::EVENT_OK
-//   abort event reconstruction, clear everything and process next event:
-//     return Fun4AllReturnCodes::ABORT_EVENT; 
-//   proceed but do not save this event in output (needs output manager setting):
-//     return Fun4AllReturnCodes::DISCARD_EVENT; 
-//   abort processing:
-//     return Fun4AllReturnCodes::ABORT_RUN
-// all other integers will lead to an error and abort of processing
-//
-// int PHTruthSiliconAssociation::ResetEvent(PHCompositeNode *topNode)
-// If you have internal data structures (arrays, stl containers) which needs clearing
-// after each event, this is the place to do that. The nodes under the DST node are cleared
-// by the framework
-//
-// int PHTruthSiliconAssociation::EndRun(const int runnumber)
-// This method is called at the end of a run when an event from a new run is
-// encountered. Useful when analyzing multiple runs (raw data). Also called at
-// the end of processing (before the End() method)
-//
-// int PHTruthSiliconAssociation::End(PHCompositeNode *topNode)
-// This is called at the end of processing. It needs to be called by the macro
-// by Fun4AllServer::End(), so do not forget this in your macro
-//
-// int PHTruthSiliconAssociation::Reset(PHCompositeNode *topNode)
-// not really used - it is called before the dtor is called
-//
-// void PHTruthSiliconAssociation::Print(const std::string &what) const
-// Called from the command line - useful to print information when you need it
-//
-//____________________________________________________________________________..
-
 #include "PHTruthSiliconAssociation.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -95,19 +32,18 @@ using namespace std;
 PHTruthSiliconAssociation::PHTruthSiliconAssociation(const std::string &name):
  SubsysReco(name)
 {
-  cout << "PHTruthSiliconAssociation::PHTruthSiliconAssociation(const std::string &name) Calling ctor" << endl;
+  //cout << "PHTruthSiliconAssociation::PHTruthSiliconAssociation(const std::string &name) Calling ctor" << endl;
 }
 
 //____________________________________________________________________________..
 PHTruthSiliconAssociation::~PHTruthSiliconAssociation()
 {
-  cout << "PHTruthSiliconAssociation::~PHTruthSiliconAssociation() Calling dtor" << endl;
+
 }
 
 //____________________________________________________________________________..
 int PHTruthSiliconAssociation::Init(PHCompositeNode *topNode)
 {
-  cout << "PHTruthSiliconAssociation::Init(PHCompositeNode *topNode) Initializing" << endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -115,7 +51,6 @@ int PHTruthSiliconAssociation::Init(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int PHTruthSiliconAssociation::InitRun(PHCompositeNode *topNode)
 {
-  cout << "PHTruthSiliconAssociation::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << endl;
 
   GetNodes(topNode);
 
@@ -125,7 +60,8 @@ int PHTruthSiliconAssociation::InitRun(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 {
-  if (Verbosity() >= 1) cout << "PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode) Processing Event" << endl;
+  if (Verbosity() >= 1) 
+    cout << "PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode) Processing Event" << endl;
 
   _svtxEvalStack = new SvtxEvalStack(topNode);
   _svtxEvalStack->next_event(topNode);
@@ -148,24 +84,26 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 	    << ": Processing seed itrack: " << phtrk_iter->first
 	    << ": nhits: " << _tracklet-> size_cluster_keys()
 	    << ": Total tracks: " << _track_map->size()
+	    << ": phi: " << _tracklet->get_phi()
 	    << endl;
 	}
 
-      _tracklet->identify(); 
-     
-      // Reject short seed tracks
-      if(_tracklet->size_cluster_keys() < _min_clusters_per_track)
-	{
-	  if (Verbosity() >= 1) std::cout << " --- reject track  number " << phtrk_iter->first << std::endl;
-	  //continue;
-	}
+
+      if (Verbosity() >= 1) 
+	_tracklet->identify(); 
 
       // identify the best truth track match for this seed track 
 
 	PHG4Particle *g4particle = trackeval->max_truth_particle_by_nclusters(_tracklet);
 
-	// identify the clusters that are associated with this g4particle
+	if (Verbosity() >= 1)
+	  std::cout << "   g4particleID " << g4particle->get_track_id() 
+		    << " px " <<  g4particle->get_px() 
+		    << " py " <<  g4particle->get_py() 
+		    << " phi " << atan2(g4particle->get_py(), g4particle->get_px() )
+		    << std::endl;
 
+	// identify the clusters that are associated with this g4particle
 	std::set<TrkrDefs::cluskey> clusters = clustereval->all_clusters_from(g4particle);
 
 	for (std::set<TrkrDefs::cluskey>::iterator jter = clusters.begin();
@@ -175,21 +113,19 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 	    TrkrDefs::cluskey cluster_key = *jter;
 	    unsigned int layer = TrkrDefs::getLayer(cluster_key);
 	    unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
-	    std::cout << "     found cluster with key: " << cluster_key << " in layer " << layer << std::endl;
-	    //TrkrCluster *cluster = clustermap->findCluster(cluster_key);
-	    //cluster->identify();
+	     if (Verbosity() >= 1)  std::cout << "     found cluster with key: " << cluster_key << " in layer " << layer << std::endl;
 	    
 	    // Identify the MVTX and INTT clusters and add them to the SvtxTrack cluster key list
 	    if(trkrid == TrkrDefs::mvtxId)
 	      {
-		std::cout << "            cluster belongs to MVTX, add to track " << std::endl;
+		 if (Verbosity() >= 1)  std::cout << "            cluster belongs to MVTX, add to track " << std::endl;
 		_tracklet->insert_cluster_key(cluster_key);
 		_assoc_container->SetClusterTrackAssoc(cluster_key, _tracklet->get_id());
 	      }
 	    
 	    if(trkrid == TrkrDefs::inttId)
 	      {
-		std::cout << "            cluster belongs to INTT, add to track " << std::endl;
+		 if (Verbosity() >= 1) std::cout << "            cluster belongs to INTT, add to track " << std::endl;
 		  _tracklet->insert_cluster_key(cluster_key);
 		_assoc_container->SetClusterTrackAssoc(cluster_key, _tracklet->get_id());
 	      }
@@ -212,10 +148,13 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 	  std::cout << " new cluster keys size " << _tracklet->size_cluster_keys() << endl;
 	}
 
-	      if (Verbosity() >= 1)
-		std::cout << "Done with track " << phtrk_iter->first << std::endl;
+      if (Verbosity() >= 1)
+	std::cout << "Done with track " << phtrk_iter->first << std::endl;
     }
-  
+
+  if (Verbosity() >= 1)
+    cout << "PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;  
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -229,21 +168,18 @@ int PHTruthSiliconAssociation::ResetEvent(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int PHTruthSiliconAssociation::EndRun(const int runnumber)
 {
-  //cout << "PHTruthSiliconAssociation::EndRun(const int runnumber) Ending Run for Run " << runnumber << endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int PHTruthSiliconAssociation::End(PHCompositeNode *topNode)
 {
-  //cout << "PHTruthSiliconAssociation::End(PHCompositeNode *topNode) This is the End..." << endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int PHTruthSiliconAssociation::Reset(PHCompositeNode *topNode)
 {
-  //cout << "PHTruthSiliconAssociation::Reset(PHCompositeNode *topNode) being Reset" << endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -9,14 +9,16 @@
 /// Tracking includes
 #include <trackbase/TrkrClusterv1.h>
 #include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
+#include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxVertexMap.h>
 
-#include <g4eval/SvtxClusterEval.h>
-#include <g4eval/SvtxEvalStack.h>
-#include <g4eval/SvtxEvaluator.h>
-#include <g4eval/SvtxTrackEval.h>
+//#include <g4eval/SvtxClusterEval.h>
+//#include <g4eval/SvtxEvalStack.h>
+//#include <g4eval/SvtxEvaluator.h>
+//#include <g4eval/SvtxTrackEval.h>
 
 #include <g4main/PHG4Hit.h>  // for PHG4Hit
 #include <g4main/PHG4Particle.h>  // for PHG4Particle
@@ -63,11 +65,11 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
   if (Verbosity() >= 1) 
     cout << "PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode) Processing Event" << endl;
 
-  _svtxEvalStack = new SvtxEvalStack(topNode);
-  _svtxEvalStack->next_event(topNode);
+  //  _svtxEvalStack = new SvtxEvalStack(topNode);
+  //_svtxEvalStack->next_event(topNode);
 
-  SvtxTrackEval *trackeval = _svtxEvalStack->get_track_eval();
-  SvtxClusterEval *clustereval = _svtxEvalStack->get_cluster_eval();
+  //SvtxTrackEval *trackeval = _svtxEvalStack->get_track_eval();
+  //SvtxClusterEval *clustereval = _svtxEvalStack->get_cluster_eval();
 
   // Loop over all SvtxTracks from the CA seeder
   // These should contain all TPC clusters already
@@ -88,32 +90,36 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 	    << endl;
 	}
 
-
+      
       if (Verbosity() >= 1) 
 	_tracklet->identify(); 
-
+      
       // identify the best truth track match for this seed track 
-
-	PHG4Particle *g4particle = trackeval->max_truth_particle_by_nclusters(_tracklet);
-
-	if (Verbosity() >= 1)
-	  std::cout << "   g4particleID " << g4particle->get_track_id() 
-		    << " px " <<  g4particle->get_px() 
-		    << " py " <<  g4particle->get_py() 
-		    << " phi " << atan2(g4particle->get_py(), g4particle->get_px() )
-		    << std::endl;
-
-	// identify the clusters that are associated with this g4particle
-	std::set<TrkrDefs::cluskey> clusters = clustereval->all_clusters_from(g4particle);
-
-	for (std::set<TrkrDefs::cluskey>::iterator jter = clusters.begin();
-	     jter != clusters.end();
-	     ++jter)
-	  {
-	    TrkrDefs::cluskey cluster_key = *jter;
-	    unsigned int layer = TrkrDefs::getLayer(cluster_key);
-	    unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
-	     if (Verbosity() >= 1)  std::cout << "     found cluster with key: " << cluster_key << " in layer " << layer << std::endl;
+      
+      PHG4Particle *g4particle = getG4PrimaryParticle(_tracklet);
+      
+      //std::cout << " g4particle " << g4particle->get_track_id() << endl;
+      //PHG4Particle *g4particle = trackeval->max_truth_particle_by_nclusters(_tracklet);
+      
+      if (Verbosity() >= 1)
+	std::cout << "   g4particleID " << g4particle->get_track_id() 
+		  << " px " <<  g4particle->get_px() 
+		  << " py " <<  g4particle->get_py() 
+		  << " phi " << atan2(g4particle->get_py(), g4particle->get_px() )
+		  << std::endl;
+      
+      // identify the clusters that are associated with this g4particle
+      //std::set<TrkrDefs::cluskey> clusters = clustereval->all_clusters_from(g4particle);
+      std::set<TrkrDefs::cluskey> clusters = getSiliconClustersFromParticle(g4particle);
+      
+      for (std::set<TrkrDefs::cluskey>::iterator jter = clusters.begin();
+	   jter != clusters.end();
+	   ++jter)
+	{
+	  TrkrDefs::cluskey cluster_key = *jter;
+	  unsigned int layer = TrkrDefs::getLayer(cluster_key);
+	  unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+	  if (Verbosity() >= 1)  std::cout << "     found cluster with key: " << cluster_key << " in layer " << layer << std::endl;
 	    
 	    // Identify the MVTX and INTT clusters and add them to the SvtxTrack cluster key list
 	    if(trkrid == TrkrDefs::mvtxId)
@@ -223,5 +229,158 @@ int  PHTruthSiliconAssociation::GetNodes(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
+  _hit_truth_map = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
+  if (!_hit_truth_map)
+  {
+    cerr << PHWHERE << " ERROR: Can't find TrkrHitTruthAssoc." << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  _cluster_hit_map = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
+  if (!_cluster_hit_map)
+  {
+    cerr << PHWHERE << " ERROR: Can't find TrkrClusterHitAssoc." << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  _g4hits_tpc = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_TPC");
+  _g4hits_intt = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_INTT");
+  _g4hits_mvtx = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_MVTX");
+
+ _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
+
+PHG4Particle* PHTruthSiliconAssociation::getG4PrimaryParticle(SvtxTrack *track)
+{
+  PHG4Particle* g4part = 0;
+  std::set<int> pid;
+  //std::vector<int> pid_count;
+  std::multimap<int, int> pid_count;
+
+  // loop over associated clusters to get hits
+  for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
+       iter != track->end_cluster_keys();
+       ++iter)
+    {
+      TrkrDefs::cluskey cluster_key = *iter;
+
+      // get all truth hits for this cluster
+      //_cluster_hit_map->identify();
+      TrkrClusterHitAssoc::ConstRange hitrange = _cluster_hit_map->getHits(cluster_key);  // returns range of pairs {cluster key, hit key} for this cluskey
+      for(TrkrClusterHitAssoc::ConstIterator clushititer = hitrange.first; clushititer != hitrange.second; ++clushititer)
+	{
+	  TrkrDefs::hitkey hitkey = clushititer->second;
+	  // TrkrHitTruthAssoc uses a map with (hitsetkey, std::pair(hitkey, g4hitkey)) - get the hitsetkey from the cluskey
+	  TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);	  
+	  
+	  // get all of the g4hits for this hitkey
+	  std::multimap< TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> > temp_map;    
+	  _hit_truth_map->getG4Hits(hitsetkey, hitkey, temp_map); 	  // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
+	  for(std::multimap< TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> >::iterator htiter =  temp_map.begin(); htiter != temp_map.end(); ++htiter) 
+	    {
+	      // extract the g4 hit key 
+	      PHG4HitDefs::keytype g4hitkey = htiter->second.second;
+	      PHG4Hit * g4hit = nullptr;
+	      unsigned int trkrid = TrkrDefs::getTrkrId(hitsetkey);
+	      switch( trkrid )
+		{
+		case TrkrDefs::tpcId: g4hit = _g4hits_tpc->findHit(g4hitkey); break;
+		case TrkrDefs::inttId: g4hit = _g4hits_intt->findHit(g4hitkey); break;
+		case TrkrDefs::mvtxId: g4hit = _g4hits_mvtx->findHit(g4hitkey); break;
+		default: break;
+		}
+	      if( g4hit )
+		{
+		  // get the g4particle for this g4hit
+		  pid.insert(g4hit->get_trkid());
+		  int cnt = 1;
+		  pid_count.insert(std::make_pair(g4hit->get_trkid(), cnt));
+		}
+	    } // end loop over g4hits associated with hitsetkey and hitkey
+	} // end loop over hits associated with cluskey  
+    }  // end loop over clusters associated with this track
+  
+  int maxfound = -1;
+  for( auto it = pid.begin(); it != pid.end(); ++it)
+    {
+      int nfound = 0;
+      std::pair<std::multimap<int, int>::iterator, std::multimap<int,int>::iterator> this_pid = pid_count.equal_range(*it);
+      for(auto it = this_pid.first; it != this_pid.second; ++it)
+	{
+	  //std::cout << " pid = " << it->first << " pid_count " << it->second << endl;	  
+	  nfound++;	  
+	}
+      if(nfound > maxfound)
+	{  
+	  maxfound = nfound;
+	  g4part = _truthinfo->GetParticle(*it);
+	}
+    }
+  //std::cout << " Best g4paricle ID is : " << g4part->get_track_id() << endl;; 
+
+  return g4part;
+  
+}
+
+std::set<TrkrDefs::cluskey> PHTruthSiliconAssociation::getSiliconClustersFromParticle(PHG4Particle* g4particle)
+{
+
+  std::set<TrkrDefs::cluskey> clusters;
+
+  // loop over all the clusters
+  TrkrClusterContainer::ConstRange all_clusters = _cluster_map->getClusters();
+  for (TrkrClusterContainer::ConstIterator iter = all_clusters.first;
+       iter != all_clusters.second;
+       ++iter)
+  {
+    TrkrDefs::cluskey cluster_key = iter->first;
+
+    unsigned int layer = TrkrDefs::getLayer(cluster_key);
+    if(layer > 6) continue;  // silicon layers only
+
+    // get all truth hits for this cluster
+    TrkrClusterHitAssoc::ConstRange hitrange = _cluster_hit_map->getHits(cluster_key);  // returns range of pairs {cluster key, hit key} for this cluskey
+    for(TrkrClusterHitAssoc::ConstIterator clushititer = hitrange.first; clushititer != hitrange.second; ++clushititer)
+      {
+	TrkrDefs::hitkey hitkey = clushititer->second;
+	  // TrkrHitTruthAssoc uses a map with (hitsetkey, std::pair(hitkey, g4hitkey)) - get the hitsetkey from the cluskey
+	  TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);	  
+	  
+	  // get all of the g4hits for this hitkey
+	  std::multimap< TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> > temp_map;    
+	  _hit_truth_map->getG4Hits(hitsetkey, hitkey, temp_map); 	  // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
+	  for(std::multimap< TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> >::iterator htiter =  temp_map.begin(); htiter != temp_map.end(); ++htiter) 
+	    {
+	      // extract the g4 hit key 
+	      PHG4HitDefs::keytype g4hitkey = htiter->second.second;
+	      PHG4Hit * g4hit = nullptr;
+	      unsigned int trkrid = TrkrDefs::getTrkrId(hitsetkey);
+	      switch( trkrid )
+		{
+		case TrkrDefs::mvtxId: g4hit = _g4hits_mvtx->findHit(g4hitkey); break;
+		case TrkrDefs::inttId: g4hit = _g4hits_intt->findHit(g4hitkey); break;
+		default: break;
+		}
+	      if( g4hit )
+		{
+		  // get the g4particle for this g4hit
+		  int trkid = g4hit->get_trkid();	
+		  if(trkid == g4particle->get_track_id())
+		    {
+		      //std::cout << "   layer " << layer << " g4hit trkid " << trkid << " g4particle track_id " << g4particle->get_track_id() << endl;
+		      clusters.insert(cluster_key);
+		      break;
+		    }		    
+		}
+	    } // end loop over g4hits associated with hitsetkey and hitkey
+      } // end loop over hits associated with cluskey  
+    
+    
+  }
+  
+  return clusters;
+  
+}
+

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -1,0 +1,80 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef PHTRUTHSILICONASSOCIATION_H
+#define PHTRUTHSILICONASSOCIATION_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class PHCompositeNode;
+class SvtxTrackMap;
+class SvtxTrack;
+class TrkrClusterContainer;
+class SvtxEvaluator;
+class SvtxEvalStack;
+class SvtxClusterEval;
+class PHG4TruthInfoContainer;
+class AssocInfoContainer;
+
+class PHTruthSiliconAssociation : public SubsysReco
+{
+ public:
+
+  PHTruthSiliconAssociation(const std::string &name = "PHTruthSiliconAssociation");
+
+  virtual ~PHTruthSiliconAssociation();
+
+  /** Called during initialization.
+      Typically this is where you can book histograms, and e.g.
+      register them to Fun4AllServer (so they can be output to file
+      using Fun4AllServer::dumpHistos() method).
+   */
+  int Init(PHCompositeNode *topNode) override;
+
+  /** Called for first event when run number is known.
+      Typically this is where you may want to fetch data from
+      database, because you know the run number. A place
+      to book histograms which have to know the run number.
+   */
+  int InitRun(PHCompositeNode *topNode) override;
+
+  /** Called for each event.
+      This is where you do the real work.
+   */
+  int process_event(PHCompositeNode *topNode) override;
+
+  /// Clean up internals after each event.
+  int ResetEvent(PHCompositeNode *topNode) override;
+
+  /// Called at the end of each run.
+  int EndRun(const int runnumber) override;
+
+  /// Called at the end of all processing.
+  int End(PHCompositeNode *topNode) override;
+
+  /// Reset
+  int Reset(PHCompositeNode * /*topNode*/) override;
+
+  void Print(const std::string &what = "ALL") const override;
+  
+ private:
+
+  int GetNodes(PHCompositeNode* topNode);
+
+  SvtxEvaluator *_svtxEvaluator{nullptr};
+  PHG4TruthInfoContainer *_truthInfo{nullptr};
+  
+  TrkrClusterContainer *_cluster_map;
+  SvtxEvalStack *_svtxEvalStack;
+  SvtxTrackMap *_track_map;
+  AssocInfoContainer *_assoc_container;
+  SvtxTrack *_tracklet;
+
+  int _ntrack = 0;
+  const int  _min_clusters_per_track = 20;
+
+
+};
+
+#endif // PHTRUTHSILICONASSOCIATION_H

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -70,7 +70,7 @@ class PHTruthSiliconAssociation : public SubsysReco
   PHG4Particle* getG4PrimaryParticle(SvtxTrack *track);
   std::set<TrkrDefs::cluskey> getSiliconClustersFromParticle(PHG4Particle* g4particle);
   
-  PHG4TruthInfoContainer *_truthInfo{nullptr};
+  PHG4TruthInfoContainer *_truthinfo{nullptr};
   PHG4HitContainer *_g4hits_tpc{nullptr};
   PHG4HitContainer *_g4hits_mvtx{nullptr};
   PHG4HitContainer *_g4hits_intt{nullptr};
@@ -82,8 +82,6 @@ class PHTruthSiliconAssociation : public SubsysReco
   AssocInfoContainer *_assoc_container{nullptr};
   SvtxTrack *_tracklet{nullptr};
   SvtxVertexMap * _vertex_map{nullptr};
-  PHG4TruthInfoContainer *_truthinfo{nullptr};
-
 };
 
 #endif // PHTRUTHSILICONASSOCIATION_H

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -14,15 +14,13 @@ class SvtxTrackMap;
 class SvtxTrack;
 class SvtxVertexMap;
 class TrkrClusterContainer;
-//class SvtxEvaluator;
-//class SvtxEvalStack;
-class SvtxClusterEval;
+class TrkrClusterHitAssoc;
+class TrkrHitTruthAssoc;
 class PHG4TruthInfoContainer;
 class PHG4HitContainer;
 class PHG4Particle;
 class AssocInfoContainer;
-class TrkrClusterHitAssoc;
-class TrkrHitTruthAssoc;
+
 
 class PHTruthSiliconAssociation : public SubsysReco
 {
@@ -72,21 +70,19 @@ class PHTruthSiliconAssociation : public SubsysReco
   PHG4Particle* getG4PrimaryParticle(SvtxTrack *track);
   std::set<TrkrDefs::cluskey> getSiliconClustersFromParticle(PHG4Particle* g4particle);
   
-  //SvtxEvaluator *_svtxEvaluator{nullptr};
   PHG4TruthInfoContainer *_truthInfo{nullptr};
   PHG4HitContainer *_g4hits_tpc{nullptr};
   PHG4HitContainer *_g4hits_mvtx{nullptr};
   PHG4HitContainer *_g4hits_intt{nullptr};
   
-  TrkrClusterContainer *_cluster_map;
-  TrkrClusterHitAssoc *_cluster_hit_map;
-  TrkrHitTruthAssoc *_hit_truth_map;
-  //SvtxEvalStack *_svtxEvalStack;
-  SvtxTrackMap *_track_map;
-  AssocInfoContainer *_assoc_container;
-  SvtxTrack *_tracklet;
-  SvtxVertexMap * _vertex_map;
-  PHG4TruthInfoContainer *_truthinfo;
+  TrkrClusterContainer *_cluster_map{nullptr};
+  TrkrClusterHitAssoc *_cluster_hit_map{nullptr};
+  TrkrHitTruthAssoc *_hit_truth_map{nullptr};
+  SvtxTrackMap *_track_map{nullptr};
+  AssocInfoContainer *_assoc_container{nullptr};
+  SvtxTrack *_tracklet{nullptr};
+  SvtxVertexMap * _vertex_map{nullptr};
+  PHG4TruthInfoContainer *_truthinfo{nullptr};
 
 };
 

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -72,11 +72,6 @@ class PHTruthSiliconAssociation : public SubsysReco
   AssocInfoContainer *_assoc_container;
   SvtxTrack *_tracklet;
   SvtxVertexMap * _vertex_map;
-
-  int _ntrack = 0;
-  const int  _min_clusters_per_track = 20;
-
-
 };
 
 #endif // PHTRUTHSILICONASSOCIATION_H

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -10,6 +10,7 @@
 class PHCompositeNode;
 class SvtxTrackMap;
 class SvtxTrack;
+class SvtxVertexMap;
 class TrkrClusterContainer;
 class SvtxEvaluator;
 class SvtxEvalStack;
@@ -70,6 +71,7 @@ class PHTruthSiliconAssociation : public SubsysReco
   SvtxTrackMap *_track_map;
   AssocInfoContainer *_assoc_container;
   SvtxTrack *_tracklet;
+  SvtxVertexMap * _vertex_map;
 
   int _ntrack = 0;
   const int  _min_clusters_per_track = 20;

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -4,19 +4,25 @@
 #define PHTRUTHSILICONASSOCIATION_H
 
 #include <fun4all/SubsysReco.h>
+#include <trackbase/TrkrDefs.h>
 
 #include <string>
+#include <set>
 
 class PHCompositeNode;
 class SvtxTrackMap;
 class SvtxTrack;
 class SvtxVertexMap;
 class TrkrClusterContainer;
-class SvtxEvaluator;
-class SvtxEvalStack;
+//class SvtxEvaluator;
+//class SvtxEvalStack;
 class SvtxClusterEval;
 class PHG4TruthInfoContainer;
+class PHG4HitContainer;
+class PHG4Particle;
 class AssocInfoContainer;
+class TrkrClusterHitAssoc;
+class TrkrHitTruthAssoc;
 
 class PHTruthSiliconAssociation : public SubsysReco
 {
@@ -63,15 +69,25 @@ class PHTruthSiliconAssociation : public SubsysReco
 
   int GetNodes(PHCompositeNode* topNode);
 
-  SvtxEvaluator *_svtxEvaluator{nullptr};
+  PHG4Particle* getG4PrimaryParticle(SvtxTrack *track);
+  std::set<TrkrDefs::cluskey> getSiliconClustersFromParticle(PHG4Particle* g4particle);
+  
+  //SvtxEvaluator *_svtxEvaluator{nullptr};
   PHG4TruthInfoContainer *_truthInfo{nullptr};
+  PHG4HitContainer *_g4hits_tpc{nullptr};
+  PHG4HitContainer *_g4hits_mvtx{nullptr};
+  PHG4HitContainer *_g4hits_intt{nullptr};
   
   TrkrClusterContainer *_cluster_map;
-  SvtxEvalStack *_svtxEvalStack;
+  TrkrClusterHitAssoc *_cluster_hit_map;
+  TrkrHitTruthAssoc *_hit_truth_map;
+  //SvtxEvalStack *_svtxEvalStack;
   SvtxTrackMap *_track_map;
   AssocInfoContainer *_assoc_container;
   SvtxTrack *_tracklet;
   SvtxVertexMap * _vertex_map;
+  PHG4TruthInfoContainer *_truthinfo;
+
 };
 
 #endif // PHTRUTHSILICONASSOCIATION_H

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -12,6 +12,11 @@
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
 
+#include <g4eval/SvtxClusterEval.h>
+#include <g4eval/SvtxEvalStack.h>
+#include <g4eval/SvtxEvaluator.h>
+#include <g4eval/SvtxTrackEval.h>
+
 #include <g4main/PHG4Hit.h>  // for PHG4Hit
 #include <g4main/PHG4Particle.h>  // for PHG4Particle
 #include <g4main/PHG4HitContainer.h>


### PR DESCRIPTION
This module uses truth information to add the silicon clusters to seed tracks from PHTpcTracker or PHCASeeding. Those two seeding modules find and fit only TPC clusters. This new module allows PHActsTrkFitter to fully fit tracks from the two CA seeders without running PHGenFitTrkProp in between. Tested and working with either PHTpcTracker of PHCASeeding as input. Performance plots and comparison to the Hough seeding + Genfit propagation and fitting are attached.
[acts_truth_silicon_genfit_comparison_eff.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5178430/acts_truth_silicon_genfit_comparison_eff.pdf)
[acts_truth_silicon_genfit_comparison_ptres.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5178432/acts_truth_silicon_genfit_comparison_ptres.pdf)
[acts_truth_silicon_genfit_comparison_dcaxy.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5178433/acts_truth_silicon_genfit_comparison_dcaxy.pdf)
[acts_truth_silicon_genfit_comparison_dcaz.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5178434/acts_truth_silicon_genfit_comparison_dcaz.pdf)
The poorer resolution of the Acts fitter below 10 GeV/c is believed to be due to Acts not having a correct material map yet (this in the works). The poorer dcaz resolution is mysterious, and needs to be understood.  
 