### PR TITLE
Acts v0.32

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -199,7 +199,7 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
 	    if(traj.hasTrackParameters(trackTip))
 	      {
 		std::cout << "Fitted params : " 
-			  << traj.trackParameters(trackTip).position() 
+			  << traj.trackParameters(trackTip).position(m_tGeometry->geoContext) 
 			  << std::endl << traj.trackParameters(trackTip).momentum()
 			  << std::endl;
 		std::cout << "Track has " << trajState.nMeasurements
@@ -285,7 +285,7 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
     }
 
     /// Get the geometry ID
-    auto geoID = state.referenceSurface().geoID();
+    auto geoID = state.referenceSurface().geometryId();
     m_volumeID.push_back(geoID.volume());
     m_layerID.push_back(geoID.layer());
     m_moduleID.push_back(geoID.sensitive());
@@ -380,11 +380,12 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
     {
       predicted = true;
       m_nPredicted++;
+      
       Acts::BoundParameters parameter(
-          m_tGeometry->geoContext,
-          state.predictedCovariance(),
-          state.predicted(),
-          state.referenceSurface().getSharedPtr());
+	        state.referenceSurface().getSharedPtr(),
+		state.predicted(),
+		state.predictedCovariance());
+
       auto covariance = state.predictedCovariance();
 
       /// Local hit residual info
@@ -461,14 +462,14 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
           (parameter.parameters()[Acts::ParDef::eT] - truthTIME) /
           sqrt(covariance(Acts::ParDef::eT, Acts::ParDef::eT)));
 
-      m_x_prt.push_back(parameter.position().x());
-      m_y_prt.push_back(parameter.position().y());
-      m_z_prt.push_back(parameter.position().z());
+      m_x_prt.push_back(parameter.position(m_tGeometry->geoContext).x());
+      m_y_prt.push_back(parameter.position(m_tGeometry->geoContext).y());
+      m_z_prt.push_back(parameter.position(m_tGeometry->geoContext).z());
       m_px_prt.push_back(parameter.momentum().x());
       m_py_prt.push_back(parameter.momentum().y());
       m_pz_prt.push_back(parameter.momentum().z());
       m_pT_prt.push_back(parameter.pT());
-      m_eta_prt.push_back(eta(parameter.position()));
+      m_eta_prt.push_back(eta(parameter.position(m_tGeometry->geoContext)));
     }
     else
     {
@@ -519,10 +520,12 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
     {
       filtered = true;
       m_nFiltered++;
+
       Acts::BoundParameters parameter(
-          m_tGeometry->geoContext,
-          state.filteredCovariance(), state.filtered(),
-          state.referenceSurface().getSharedPtr());
+	    state.referenceSurface().getSharedPtr(),
+	    state.filtered(),
+	    state.filteredCovariance());
+
       auto covariance = state.filteredCovariance();
 
       m_eLOC0_flt.push_back(parameter.parameters()[Acts::ParDef::eLOC_0]);
@@ -580,14 +583,14 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
           sqrt(covariance(Acts::ParDef::eT, Acts::ParDef::eT)));
 
       /// Other filtered parameter info
-      m_x_flt.push_back(parameter.position().x());
-      m_y_flt.push_back(parameter.position().y());
-      m_z_flt.push_back(parameter.position().z());
+      m_x_flt.push_back(parameter.position(m_tGeometry->geoContext).x());
+      m_y_flt.push_back(parameter.position(m_tGeometry->geoContext).y());
+      m_z_flt.push_back(parameter.position(m_tGeometry->geoContext).z());
       m_px_flt.push_back(parameter.momentum().x());
       m_py_flt.push_back(parameter.momentum().y());
       m_pz_flt.push_back(parameter.momentum().z());
       m_pT_flt.push_back(parameter.pT());
-      m_eta_flt.push_back(eta(parameter.position()));
+      m_eta_flt.push_back(eta(parameter.position(m_tGeometry->geoContext)));
       m_chi2.push_back(state.chi2());
       
     }
@@ -633,10 +636,12 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
     {
       smoothed = true;
       m_nSmoothed++;
+
       Acts::BoundParameters parameter(
-          m_tGeometry->geoContext,
-          state.smoothedCovariance(), state.smoothed(),
-          state.referenceSurface().getSharedPtr());
+	    state.referenceSurface().getSharedPtr(),
+	    state.smoothed(),
+	    state.smoothedCovariance());
+
       auto covariance = state.smoothedCovariance();
 
       m_eLOC0_smt.push_back(parameter.parameters()[Acts::ParDef::eLOC_0]);
@@ -693,14 +698,14 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
           (parameter.parameters()[Acts::ParDef::eT] - truthTIME) /
           sqrt(covariance(Acts::ParDef::eT, Acts::ParDef::eT)));
 
-      m_x_smt.push_back(parameter.position().x());
-      m_y_smt.push_back(parameter.position().y());
-      m_z_smt.push_back(parameter.position().z());
+      m_x_smt.push_back(parameter.position(m_tGeometry->geoContext).x());
+      m_y_smt.push_back(parameter.position(m_tGeometry->geoContext).y());
+      m_z_smt.push_back(parameter.position(m_tGeometry->geoContext).z());
       m_px_smt.push_back(parameter.momentum().x());
       m_py_smt.push_back(parameter.momentum().y());
       m_pz_smt.push_back(parameter.momentum().z());
       m_pT_smt.push_back(parameter.pT());
-      m_eta_smt.push_back(eta(parameter.position()));
+      m_eta_smt.push_back(eta(parameter.position(m_tGeometry->geoContext)));
     }
     else
     {
@@ -816,10 +821,10 @@ void ActsEvaluator::fillProtoTrack(ActsTrack track, PHCompositeNode *topNode)
   if(Verbosity() > 2)
     std::cout << "Filling proto track seed quantities" << std::endl;
   
-  FW::TrackParameters params = track.getTrackParams();
+  ActsExamples::TrackParameters params = track.getTrackParams();
   std::vector<SourceLink> sourceLinks = track.getSourceLinks();
   
-  Acts::Vector3D position = params.position();
+  Acts::Vector3D position = params.position(m_tGeometry->geoContext);
   Acts::Vector3D momentum = params.momentum();
   m_protoTrackPx = momentum(0);
   m_protoTrackPy = momentum(1);
@@ -924,9 +929,9 @@ void ActsEvaluator::fillFittedTrackParams(const Trajectory traj,
     m_px_fit = boundParam.momentum()(0);
     m_py_fit = boundParam.momentum()(1);
     m_pz_fit = boundParam.momentum()(2);
-    m_x_fit  = boundParam.position()(0);
-    m_y_fit  = boundParam.position()(1);
-    m_z_fit  = boundParam.position()(2);
+    m_x_fit  = boundParam.position(m_tGeometry->geoContext)(0);
+    m_y_fit  = boundParam.position(m_tGeometry->geoContext)(1);
+    m_z_fit  = boundParam.position(m_tGeometry->geoContext)(2);
     
     calculateDCA(boundParam, vertex);
 
@@ -964,7 +969,7 @@ void ActsEvaluator::calculateDCA(const Acts::BoundParameters param,
 				 const Acts::Vector3D vertex)
 {
 
-  Acts::Vector3D pos = param.position();
+  Acts::Vector3D pos = param.position(m_tGeometry->geoContext);
   Acts::Vector3D mom = param.momentum();
   
   /// Correct for vertex position

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -9,9 +9,9 @@
 
 #include <Acts/Utilities/Helpers.hpp>
 
-#include <ACTFW/EventData/TrkrClusterMultiTrajectory.hpp>
-#include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
-#include <ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp>
+#include <ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp>
+#include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
+#include <ActsExamples/Fitting/TrkrClusterFittingAlgorithm.hpp>
 
 class TTree;
 class TFile;
@@ -27,13 +27,13 @@ class SvtxEvaluator;
 #include <string>
 #include <vector>
 
-using SourceLink = FW::Data::TrkrClusterSourceLink;
+using SourceLink = ActsExamples::TrkrClusterSourceLink;
 using FitResult = Acts::KalmanFitterResult<SourceLink>;
-using Trajectory = FW::TrkrClusterMultiTrajectory;
-using Measurement = Acts::Measurement<FW::Data::TrkrClusterSourceLink,
+using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
+using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
                                       Acts::BoundParametersIndices,
-                                      Acts::ParDef::eLOC_0,
-                                      Acts::ParDef::eLOC_1>;
+                                      Acts::ParDef::eBoundLoc0,
+                                      Acts::ParDef::eBoundLoc1>;
 using Acts::VectorHelpers::eta;
 using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;

--- a/offline/packages/trackreco/ActsTrack.h
+++ b/offline/packages/trackreco/ActsTrack.h
@@ -3,9 +3,9 @@
 
 #include <Acts/EventData/TrackParameters.hpp>
 
-#include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
+#include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
 
-using SourceLink = FW::Data::TrkrClusterSourceLink;
+using SourceLink = ActsExamples::TrkrClusterSourceLink;
 
 
 /**
@@ -20,7 +20,7 @@ class ActsTrack
  public:
   ActsTrack();
 
-  ActsTrack(FW::TrackParameters params, 
+  ActsTrack(ActsExamples::TrackParameters params, 
 	    const std::vector<SourceLink> &links,
 	    Acts::Vector3D vertex)
     : m_trackParams(params)
@@ -30,8 +30,8 @@ class ActsTrack
 
   ~ActsTrack(){}
 
-  FW::TrackParameters getTrackParams(){ return m_trackParams; }
-  void setTrackParams(FW::TrackParameters params) { m_trackParams = params; }
+  ActsExamples::TrackParameters getTrackParams(){ return m_trackParams; }
+  void setTrackParams(ActsExamples::TrackParameters params) { m_trackParams = params; }
 
   std::vector<SourceLink> getSourceLinks(){ return m_sourceLinks; }
   void setSourceLinks(std::vector<SourceLink> srcLinks)
@@ -42,7 +42,7 @@ class ActsTrack
 
  private:
   /// Initial track seed parameters
-  FW::TrackParameters m_trackParams;
+  ActsExamples::TrackParameters m_trackParams;
 
   /// SourceLinks associated to this track
   std::vector<SourceLink> m_sourceLinks;

--- a/offline/packages/trackreco/ActsTransformations.cc
+++ b/offline/packages/trackreco/ActsTransformations.cc
@@ -2,7 +2,8 @@
 #include <trackbase_historic/SvtxTrackState_v1.h>
 
 Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs(
-	             const SvtxTrack *track)
+			        const SvtxTrack *track,
+				Acts::GeometryContext geoCtxt)
 {
   Acts::BoundSymMatrix rotation = Acts::BoundSymMatrix::Zero();
   Acts::BoundSymMatrix svtxCovariance = Acts::BoundSymMatrix::Zero();
@@ -84,7 +85,8 @@ Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs(
 
 
 Acts::BoundSymMatrix ActsTransformations::rotateActsCovToSvtxTrack(
-                     const Acts::BoundParameters params)
+			        const Acts::BoundParameters params,
+				Acts::GeometryContext geoCtxt)
 {
 
   auto covarianceMatrix = *params.covariance();
@@ -96,9 +98,9 @@ Acts::BoundSymMatrix ActsTransformations::rotateActsCovToSvtxTrack(
   const double pz = params.momentum()(2);
   const double p = sqrt(px * px + py * py + pz * pz);
   
-  const double x = params.position()(0);
-  const double y = params.position()(1);
-  const double z = params.position()(2);
+  const double x = params.position(geoCtxt)(0);
+  const double y = params.position(geoCtxt)(1);
+  const double z = params.position(geoCtxt)(2);
   const double r = sqrt(x*x + y*y + z*z);
 
   const double posCosTheta = z / r;
@@ -196,12 +198,13 @@ void ActsTransformations::printMatrix(const std::string &message,
 
 void ActsTransformations::calculateDCA(const Acts::BoundParameters param,
 				   Acts::Vector3D vertex,
+				   Acts::GeometryContext geoCtxt,
 				   float &dca3Dxy,
 				   float &dca3Dz,
 				   float &dca3DxyCov,
 				   float &dca3DzCov)
 {
-  Acts::Vector3D pos = param.position();
+  Acts::Vector3D pos = param.position(geoCtxt);
   Acts::Vector3D mom = param.momentum();
 
   /// Correct for initial vertex estimation
@@ -271,8 +274,10 @@ void ActsTransformations::fillSvtxTrackStates(const Trajectory traj,
       /// Get local position
       Acts::Vector2D local(meas.parameters()[Acts::ParDef::eLOC_0],
 			   meas.parameters()[Acts::ParDef::eLOC_1]);
+
       /// Get global position
       Acts::Vector3D global(0., 0., 0.);
+
       /// This is an arbitrary vector. Doesn't matter in coordinate transformation
       /// in Acts code
       Acts::Vector3D mom(1., 1., 1.);
@@ -287,17 +292,17 @@ void ActsTransformations::fillSvtxTrackStates(const Trajectory traj,
     
       if (state.hasSmoothed())
 	{
-	  Acts::BoundParameters parameter(geoContext,
-					  state.smoothedCovariance(), state.smoothed(),
-					  state.referenceSurface().getSharedPtr());
-	  
+	  Acts::BoundParameters parameter(state.referenceSurface().getSharedPtr(),
+					  state.smoothed(),
+					  state.smoothedCovariance());
 	  out.set_px(parameter.momentum().x());
 	  out.set_py(parameter.momentum().y());
 	  out.set_pz(parameter.momentum().z());
 
 	  /// Get measurement covariance    
 
-	  Acts::BoundSymMatrix globalCov = rotateActsCovToSvtxTrack(parameter);
+	  Acts::BoundSymMatrix globalCov = rotateActsCovToSvtxTrack(parameter,
+								    geoContext);
 	  for (int i = 0; i < 6; i++)
 	    {
 	      for (int j = 0; j < 6; j++)

--- a/offline/packages/trackreco/ActsTransformations.h
+++ b/offline/packages/trackreco/ActsTransformations.h
@@ -10,9 +10,9 @@
 
 #include <trackbase_historic/SvtxTrack.h>
 
-#include <ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp>
-#include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
-#include <ACTFW/EventData/TrkrClusterMultiTrajectory.hpp>
+#include <ActsExamples/Fitting/TrkrClusterFittingAlgorithm.hpp>
+#include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
+#include <ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp>
 
 /// std (and the like) includes
 #include <cmath>
@@ -20,13 +20,13 @@
 #include <memory>
 #include <utility>
 
-using SourceLink = FW::Data::TrkrClusterSourceLink;
+using SourceLink = ActsExamples::TrkrClusterSourceLink;
 
-using Trajectory = FW::TrkrClusterMultiTrajectory;
-using Measurement = Acts::Measurement<FW::Data::TrkrClusterSourceLink,
+using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
+using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
                                       Acts::BoundParametersIndices,
-                                      Acts::ParDef::eLOC_0,
-                                      Acts::ParDef::eLOC_1>;
+                                      Acts::ParDef::eBoundLoc0,
+                                      Acts::ParDef::eBoundLoc1>;
 
 /**
  * This is a helper class for rotating track covariance matrices to and from
@@ -37,20 +37,22 @@ using Measurement = Acts::Measurement<FW::Data::TrkrClusterSourceLink,
  */
 class ActsTransformations
 {
-  public:
-  ActsTransformations()
-    : m_verbosity(false)
-    {}
+ public:
+ ActsTransformations()
+   : m_verbosity(false)
+  {}
   virtual ~ActsTransformations(){}
   
   /// Rotates an SvtxTrack covariance matrix from (x,y,z,px,py,pz) global
   /// cartesian coordinates to (d0, z0, phi, theta, q/p, time) coordinates for
   /// Acts. The track fitter performs the fitting with respect to the nominal
   /// origin of sPHENIX, so we rotate accordingly
-  Acts::BoundSymMatrix rotateSvtxTrackCovToActs(const SvtxTrack *track);
+  Acts::BoundSymMatrix rotateSvtxTrackCovToActs(const SvtxTrack *track,
+						Acts::GeometryContext geoCtxt);
   
   /// Same as above, but rotate from Acts basis to global (x,y,z,px,py,pz)
-  Acts::BoundSymMatrix rotateActsCovToSvtxTrack(const Acts::BoundParameters params);
+  Acts::BoundSymMatrix rotateActsCovToSvtxTrack(const Acts::BoundParameters params,
+						Acts::GeometryContext geoCtxt);
 
   void setVerbosity(int verbosity) {m_verbosity = verbosity;}
 
@@ -60,6 +62,7 @@ class ActsTransformations
   /// vertex
   void calculateDCA(const Acts::BoundParameters param,
 		    Acts::Vector3D vertex,
+		    Acts::GeometryContext geoCtxt,
 		    float &dca3Dxy,
 		    float &dca3Dz,
 		    float &dca3DxyCov,

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -40,15 +40,15 @@
 #include <Acts/Surfaces/Surface.hpp>
 #include <Acts/Utilities/CalibrationContext.hpp>
 
-#include <ACTFW/Detector/IBaseDetector.hpp>
-#include <ACTFW/EventData/Track.hpp>
-#include <ACTFW/Framework/AlgorithmContext.hpp>
-#include <ACTFW/Framework/IContextDecorator.hpp>
-#include <ACTFW/Framework/WhiteBoard.hpp>
-#include <ACTFW/Geometry/CommonGeometry.hpp>
-#include <ACTFW/Options/CommonOptions.hpp>
-#include <ACTFW/Plugins/Obj/ObjWriterOptions.hpp>
-#include <ACTFW/Utilities/Options.hpp>
+#include <ActsExamples/Detector/IBaseDetector.hpp>
+#include <ActsExamples/EventData/Track.hpp>
+#include <ActsExamples/Framework/AlgorithmContext.hpp>
+#include <ActsExamples/Framework/IContextDecorator.hpp>
+#include <ActsExamples/Framework/WhiteBoard.hpp>
+#include <ActsExamples/Geometry/CommonGeometry.hpp>
+#include <ActsExamples/Options/CommonOptions.hpp>
+#include <ActsExamples/Plugins/Obj/ObjWriterOptions.hpp>
+#include <ActsExamples/Utilities/Options.hpp>
 
 #include <TGeoManager.h>
 #include <TMatrixT.h>
@@ -326,41 +326,41 @@ void MakeActsGeometry::buildActsSurfaces()
 }
 
 void MakeActsGeometry::makeGeometry(int argc, char *argv[], 
-				    FW::IBaseDetector &detector)
+				    ActsExamples::IBaseDetector &detector)
 {
   /// setup and parse options
-  auto desc = FW::Options::makeDefaultOptions();
-  FW::Options::addSequencerOptions(desc);
-  FW::Options::addGeometryOptions(desc);
-  FW::Options::addMaterialOptions(desc);
-  FW::Options::addObjWriterOptions(desc);
-  FW::Options::addOutputOptions(desc);
-  FW::Options::addBFieldOptions(desc);
+  auto desc = ActsExamples::Options::makeDefaultOptions();
+  ActsExamples::Options::addSequencerOptions(desc);
+  ActsExamples::Options::addGeometryOptions(desc);
+  ActsExamples::Options::addMaterialOptions(desc);
+  ActsExamples::Options::addObjWriterOptions(desc);
+  ActsExamples::Options::addOutputOptions(desc);
+  ActsExamples::Options::addBFieldOptions(desc);
 
   /// Add specific options for this geometry
   detector.addOptions(desc);
-  auto vm = FW::Options::parse(desc, argc, argv);
+  auto vm = ActsExamples::Options::parse(desc, argc, argv);
 
   /// Now read the standard options
-  auto logLevel = FW::Options::readLogLevel(vm);
+  auto logLevel = ActsExamples::Options::readLogLevel(vm);
 
   /// The geometry, material and decoration
-  auto geometry = FW::Geometry::build(vm, detector);
+  auto geometry = ActsExamples::Geometry::build(vm, detector);
   /// Geometry is a pair of (tgeoTrackingGeometry, tgeoContextDecorators)
   m_tGeometry = geometry.first;
   m_contextDecorators = geometry.second;
 
-  m_magneticField = FW::Options::readBField(vm);
+  m_magneticField = ActsExamples::Options::readBField(vm);
 
   size_t ievt = 0;
   size_t ialg = 0;
 
   /// Setup the event and algorithm context
-  FW::WhiteBoard eventStore(Acts::getDefaultLogger("EventStore#" + std::to_string(ievt),
+  ActsExamples::WhiteBoard eventStore(Acts::getDefaultLogger("EventStore#" + std::to_string(ievt),
                                                    logLevel));
 
   /// The geometry context
-  FW::AlgorithmContext context(ialg, ievt, eventStore);
+  ActsExamples::AlgorithmContext context(ialg, ievt, eventStore);
 
   m_calibContext = context.calibContext;
   m_magFieldContext = context.magFieldContext;
@@ -369,7 +369,7 @@ void MakeActsGeometry::makeGeometry(int argc, char *argv[],
   /// Decorate the context
   for (auto &cdr : m_contextDecorators)
   {
-    if (cdr->decorate(context) != FW::ProcessCode::SUCCESS)
+    if (cdr->decorate(context) != ActsExamples::ProcessCode::SUCCESS)
       throw std::runtime_error("Failed to decorate event context");
   }
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -120,8 +120,12 @@ int MakeActsGeometry::buildAllGeometry(PHCompositeNode *topNode)
   makeTGeoNodeMap(topNode);
 
   /// Export the new geometry to a root file for examination
-  if(m_verbosity)
-    PHGeomUtility::ExportGeomtry(topNode, "sPHENIXexport.root");
+  if(m_verbosity){
+    /// Export as root file
+    PHGeomUtility::ExportGeomtry(topNode, "sPHENIXActsGeom.root");
+    /// Export as gdml file for material mapping
+    PHGeomUtility::ExportGeomtry(topNode, "sPHENIXActsGeom.gdml");
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -19,9 +19,9 @@
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/Utilities/CalibrationContext.hpp>
 
-#include <ACTFW/TGeoDetector/TGeoDetector.hpp>
-#include <ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp>
-#include <ACTFW/Plugins/BField/BFieldOptions.hpp>
+#include <ActsExamples/TGeoDetector/TGeoDetector.hpp>
+#include <ActsExamples/Fitting/TrkrClusterFittingAlgorithm.hpp>
+#include <ActsExamples/Plugins/BField/BFieldOptions.hpp>
 
 #include <map>
 #include <memory>            
@@ -35,7 +35,7 @@ class TGeoManager;
 class TGeoNode;
 class TGeoVolume;
 
-namespace FW {
+namespace ActsExamples {
   class IBaseDetector;
   class IContextDecorator;
 }
@@ -84,12 +84,12 @@ class MakeActsGeometry
   std::map<TrkrDefs::hitsetkey, TGeoNode*> getTGeoNodeMap()
     { return m_clusterNodeMap; }
    
-  std::vector<std::shared_ptr<FW::IContextDecorator>> getContextDecorators()
+  std::vector<std::shared_ptr<ActsExamples::IContextDecorator>> getContextDecorators()
     { return m_contextDecorators; }
   
   /// Getters for acts geometry that is needed by fitter functions
   TrackingGeometry getTGeometry(){ return m_tGeometry; }
-  FW::Options::BFieldVariant getMagField(){ return m_magneticField; }
+  ActsExamples::Options::BFieldVariant getMagField(){ return m_magneticField; }
   Acts::MagneticFieldContext getMagFieldContext() { return m_magFieldContext; }
   Acts::CalibrationContext getCalibContext() { return m_calibContext; }
   Acts::GeometryContext getGeoContext() { return m_geoCtxt; }
@@ -111,7 +111,8 @@ class MakeActsGeometry
   void buildActsSurfaces();
 
   /// Function that mimics ActsFW::GeometryExampleBase
-  void makeGeometry(int argc, char* argv[], FW::IBaseDetector& detector);
+  void makeGeometry(int argc, char* argv[], 
+		    ActsExamples::IBaseDetector& detector);
   
   /// Get hitsetkey from TGeoNode for each detector geometry
   void getInttKeyFromNode(TGeoNode *gnode);
@@ -145,7 +146,8 @@ class MakeActsGeometry
   TGeoManager* m_geoManager; 
 
   /// Acts Context decorators, which may contain e.g. calibration information
-  std::vector<std::shared_ptr<FW::IContextDecorator> > m_contextDecorators;
+  std::vector<std::shared_ptr<ActsExamples::IContextDecorator> > 
+    m_contextDecorators;
 
   /// Several maps that connect Acts world to sPHENIX G4 world 
   std::map<TrkrDefs::hitsetkey, TGeoNode*> m_clusterNodeMap;
@@ -189,7 +191,7 @@ class MakeActsGeometry
 
   /// Acts geometry objects that are needed to create (for example) the fitter
   TrackingGeometry m_tGeometry;
-  FW::Options::BFieldVariant m_magneticField;
+  ActsExamples::Options::BFieldVariant m_magneticField;
   Acts::GeometryContext  m_geoCtxt;  
   Acts::CalibrationContext m_calibContext;
   Acts::MagneticFieldContext m_magFieldContext;

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = \
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  -L$(MYINSTALL)/lib64
+  -L$(OFFLINE_MAIN)/lib64
 
 pkginclude_HEADERS = \
   ActsTransformations.h \

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = \
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  -L$(OFFLINE_MAIN)/lib64
+  -L$(MYINSTALL)/lib64
 
 pkginclude_HEADERS = \
   ActsTransformations.h \

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -33,7 +33,7 @@
 #include <Acts/Surfaces/Surface.hpp>
 #include <Acts/Utilities/Units.hpp>
 
-#include <ACTFW/Utilities/Options.hpp>
+#include <ActsExamples/Utilities/Options.hpp>
 
 /// std (and the like) includes
 #include <cmath>

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -20,9 +20,9 @@
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/Utilities/CalibrationContext.hpp>
 
-#include <ACTFW/EventData/Track.hpp>
-#include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
-#include <ACTFW/Plugins/BField/BFieldOptions.hpp>
+#include <ActsExamples/EventData/Track.hpp>
+#include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
+#include <ActsExamples/Plugins/BField/BFieldOptions.hpp>
 
 class PHCompositeNode;
 class TrkrClusterContainer;
@@ -32,18 +32,18 @@ class PHG4CylinderGeomContainer;
 class PHG4CylinderCellGeomContainer;
 class MakeActsGeometry;
 
-namespace FW
+namespace ActsExamples
 {
-class IBaseDetector;
+  class IBaseDetector;
 }
 
 namespace Acts
 {
-class Surface;
+  class Surface;
 }
 
 using Surface = std::shared_ptr<const Acts::Surface>;
-using SourceLink = FW::Data::TrkrClusterSourceLink;
+using SourceLink = ActsExamples::TrkrClusterSourceLink;
 
 /**
  * A struct to carry around Acts geometry on node tree, so as to not put 
@@ -52,7 +52,7 @@ using SourceLink = FW::Data::TrkrClusterSourceLink;
 struct ActsTrackingGeometry{
   ActsTrackingGeometry(){}
   ActsTrackingGeometry(std::shared_ptr<const Acts::TrackingGeometry> tGeo,
-		       FW::Options::BFieldVariant mag,
+		       ActsExamples::Options::BFieldVariant mag,
 		       Acts::CalibrationContext calib,
 		       Acts::GeometryContext geoCtxt,
 		       Acts::MagneticFieldContext magFieldCtxt)
@@ -64,7 +64,7 @@ struct ActsTrackingGeometry{
   {}
   /// Tracking geometry and magnetic field, for fitter function
   std::shared_ptr<const Acts::TrackingGeometry> tGeometry;
-  FW::Options::BFieldVariant magField;
+  ActsExamples::Options::BFieldVariant magField;
 
   /// Acts context, for Kalman options
   Acts::CalibrationContext calibContext;

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -78,7 +78,7 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 
   /// Vector to hold source links for a particular track
   std::vector<SourceLink> trackSourceLinks;
-  std::vector<FW::TrackParameters> trackSeeds;
+  std::vector<ActsExamples::TrackParameters> trackSeeds;
 
   ActsTransformations *rotater = new ActsTransformations();
   rotater->setVerbosity(Verbosity());
@@ -119,10 +119,13 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 
     /// Get the necessary parameters and values for the TrackParameters
     const Acts::BoundSymMatrix seedCov = 
-          rotater->rotateSvtxTrackCovToActs(track);
+      rotater->rotateSvtxTrackCovToActs(track,
+					m_tGeometry->geoContext);
+
     const Acts::Vector3D seedPos(track->get_x()  * Acts::UnitConstants::cm,
                                  track->get_y()  * Acts::UnitConstants::cm,
                                  track->get_z()  * Acts::UnitConstants::cm);
+    
     const Acts::Vector3D seedMom(track->get_px() * Acts::UnitConstants::GeV,
                                  track->get_py() * Acts::UnitConstants::GeV,
                                  track->get_pz() * Acts::UnitConstants::GeV);
@@ -148,7 +151,9 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
     const double trackTime = 10 * Acts::UnitConstants::ns;
     const int trackQ = track->get_charge();
 
-    const FW::TrackParameters trackSeed(seedCov, seedPos, seedMom, 
+    const ActsExamples::TrackParameters trackSeed(
+                                        seedCov, 
+					seedPos, seedMom, 
 					trackQ * Acts::UnitConstants::e, 
 					trackTime);
 
@@ -172,7 +177,8 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 		    << " has hitid " << hitId
 		    << std::endl;
 	  std::cout << "Adding the following surface for this SL" << std::endl;
-	  m_sourceLinks->find(hitId)->second.referenceSurface().toStream(m_tGeometry->geoContext, std::cout);
+	  m_sourceLinks->find(hitId)->second.referenceSurface().toStream(
+				    m_tGeometry->geoContext, std::cout);
 	}
     }
 

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -13,8 +13,8 @@
 
 #include <Acts/EventData/TrackParameters.hpp>
 
-#include <ACTFW/EventData/Track.hpp>
-#include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
+#include <ActsExamples/EventData/Track.hpp>
+#include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
 
 #include "ActsTrack.h"
 
@@ -28,7 +28,7 @@ class SvtxTrack;
 class SvtxVertexMap;
 class MakeActsGeometry;
 
-using SourceLink = FW::Data::TrkrClusterSourceLink;
+using SourceLink = ActsExamples::TrkrClusterSourceLink;
 
 
 /**

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -20,34 +20,31 @@
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/Utilities/CalibrationContext.hpp>
 
-#include <ACTFW/Fitting/TrkrClusterFittingAlgorithm.hpp>
-#include <ACTFW/EventData/TrkrClusterMultiTrajectory.hpp>
+#include <ActsExamples/Fitting/TrkrClusterFittingAlgorithm.hpp>
+#include <ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp>
 
 #include <memory>
 #include <string>
 #include <TFile.h>
 #include <TH1.h>
 
-namespace FW
+namespace ActsExamples
 {
-  namespace Data
-  {
-    class TrkrClusterSourceLink;
-  }
-}  // namespace FW
+  class TrkrClusterSourceLink;
+}
 
 class ActsTrack;
 class MakeActsGeometry;
 class SvtxTrack;
 class SvtxTrackMap;
 
-using SourceLink = FW::Data::TrkrClusterSourceLink;
+using SourceLink = ActsExamples::TrkrClusterSourceLink;
 using FitResult = Acts::KalmanFitterResult<SourceLink>;
-using Trajectory = FW::TrkrClusterMultiTrajectory;
-using Measurement = Acts::Measurement<FW::Data::TrkrClusterSourceLink,
+using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
+using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
                                       Acts::BoundParametersIndices,
-                                      Acts::ParDef::eLOC_0,
-                                      Acts::ParDef::eLOC_1>;
+                                      Acts::ParDef::eBoundLoc0,
+                                      Acts::ParDef::eBoundLoc1>;
 class PHActsTrkFitter : public PHTrackFitting
 {
  public:
@@ -96,7 +93,7 @@ class PHActsTrkFitter : public PHTrackFitting
   ActsTrackingGeometry *m_tGeometry;
 
   /// Configuration containing the fitting function instance
-  FW::TrkrClusterFittingAlgorithm::Config fitCfg;
+  ActsExamples::TrkrClusterFittingAlgorithm::Config fitCfg;
 
   /// TrackMap containing SvtxTracks
   SvtxTrackMap *m_trackMap;

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -18,11 +18,11 @@
 
 #include <Acts/EventData/MeasurementHelpers.hpp>
 
-#include <ACTFW/EventData/TrkrClusterSourceLink.hpp>
-#include <ACTFW/EventData/Track.hpp>
-#include <ACTFW/EventData/TrkrClusterMultiTrajectory.hpp>
+#include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
+#include <ActsExamples/EventData/Track.hpp>
+#include <ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp>
 
-#include <ACTFW/TrackFinding/TrkrClusterFindingAlgorithm.hpp>
+#include <ActsExamples/TrackFinding/TrkrClusterFindingAlgorithm.hpp>
 
 #include <memory>
 #include <string>
@@ -37,12 +37,9 @@ class SvtxTrackMap;
 class TFile;
 class TH1;
 
-namespace FW
+namespace ActsExamples
 {
-  namespace Data
-  {
-    class TrkrClusterSourceLink;
-  }
+  class TrkrClusterSourceLink;  
 }
 namespace Acts
 {
@@ -52,18 +49,18 @@ namespace Acts
 
 using PerigeeSurface = std::shared_ptr<const Acts::PerigeeSurface>;
 using Surface = std::shared_ptr<const Acts::Surface>;
-using SourceLink = FW::Data::TrkrClusterSourceLink;
+using SourceLink = ActsExamples::TrkrClusterSourceLink;
 
 using SourceLinkSelector = Acts::CKFSourceLinkSelector;
 using SourceLinkSelectorConfig = typename SourceLinkSelector::Config;
 
 using CKFFitResult = Acts::CombinatorialKalmanFilterResult<SourceLink>;
-using Trajectory = FW::TrkrClusterMultiTrajectory;
+using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
 
-using Measurement = Acts::Measurement<FW::Data::TrkrClusterSourceLink,
+using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
                                       Acts::BoundParametersIndices,
-                                      Acts::ParDef::eLOC_0,
-                                      Acts::ParDef::eLOC_1>;
+                                      Acts::ParDef::eBoundLoc0,
+                                      Acts::ParDef::eBoundLoc1>;
 
 class PHActsTrkProp : public PHTrackPropagating
 {
@@ -168,7 +165,7 @@ class PHActsTrkProp : public PHTrackPropagating
   SourceLinkSelectorConfig m_sourceLinkSelectorConfig;
  
   /// Configuration containing the finding function instance
-  FW::TrkrClusterFindingAlgorithm::Config findCfg;
+  ActsExamples::TrkrClusterFindingAlgorithm::Config findCfg;
 
 
 };

--- a/offline/packages/trackreco/PHActsVertexFitter.h
+++ b/offline/packages/trackreco/PHActsVertexFitter.h
@@ -4,7 +4,7 @@
 #include <fun4all/SubsysReco.h>
 #include "PHActsSourceLinks.h"
 
-#include <ACTFW/EventData/TrkrClusterMultiTrajectory.hpp>
+#include <ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp>
 
 class PHCompositeNode;
 class SvtxTrack;
@@ -15,7 +15,7 @@ namespace Acts
 class TrackParameters;
 }
 
-using Trajectory = FW::TrkrClusterMultiTrajectory;
+using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
 
 class PHActsVertexFitter : public SubsysReco
 {


### PR DESCRIPTION
This PR introduces necessary changes to run the tracking with the new version of Acts v0.32. The outward API changed significantly in the last few versions of Acts, so there are a lot of changes to our code that reflect these API changes. Some plots to demonstrate performance in 100 muon events with hough seeding + PHGenFitTrkProp + PHActsTrkFitter:

[dcarphi.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5195598/dcarphi.pdf)
[dcaz.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5195599/dcaz.pdf)
[eff.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5195600/eff.pdf)
[pt2d.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5195601/pt2d.pdf)
[ptscale.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5195602/ptscale.pdf)
[ptwidth.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5195603/ptwidth.pdf)

Updating is necessary to be able to run the material mapping, since a recent commit to the Acts repository allows the material mapping to be run with GDML files instead of only DD4Hep files.