### PR TITLE
Add EEMC to jet reconstruction

### DIFF
--- a/simulation/g4simulation/g4eval/JetRecoEval.cc
+++ b/simulation/g4simulation/g4eval/JetRecoEval.cc
@@ -53,6 +53,8 @@ JetRecoEval::JetRecoEval(PHCompositeNode* topNode,
   , _femcclusters(nullptr)
   , _fhcaltowers(nullptr)
   , _fhcalclusters(nullptr)
+  , _eemctowers(nullptr)
+  , _eemcclusters(nullptr)
   , _strict(false)
   , _verbosity(1)
   , _errors(0)
@@ -193,6 +195,50 @@ std::set<PHG4Shower*> JetRecoEval::all_truth_showers(Jet* recojet)
       }
 
       new_showers = get_cemc_eval_stack()->get_rawcluster_eval()->all_truth_primary_showers(cluster);
+    }
+    else if (source == Jet::EEMC_TOWER)
+    {
+      if (!_eemctowers)
+      {
+        cout << PHWHERE << "ERROR: can't find TOWER_EEMC" << endl;
+        exit(-1);
+      }
+
+      RawTower* tower = _eemctowers->getTower(index);
+
+      if (_strict)
+      {
+        assert(tower);
+      }
+      else if (!tower)
+      {
+        ++_errors;
+        continue;
+      }
+
+      new_showers = get_eemc_eval_stack()->get_rawtower_eval()->all_truth_primary_showers(tower);
+    }
+    else if (source == Jet::EEMC_CLUSTER)
+    {
+      if (!_eemcclusters)
+      {
+        cout << PHWHERE << "ERROR: can't find CLUSTER_EEMC" << endl;
+        exit(-1);
+      }
+
+      RawCluster* cluster = _eemcclusters->getCluster(index);
+
+      if (_strict)
+      {
+        assert(cluster);
+      }
+      else if (!cluster)
+      {
+        ++_errors;
+        continue;
+      }
+
+      new_showers = get_eemc_eval_stack()->get_rawcluster_eval()->all_truth_primary_showers(cluster);
     }
     else if (source == Jet::HCALIN_TOWER)
     {
@@ -485,6 +531,50 @@ std::set<PHG4Particle*> JetRecoEval::all_truth_particles(Jet* recojet)
       }
 
       new_particles = get_cemc_eval_stack()->get_rawcluster_eval()->all_truth_primary_particles(cluster);
+    }
+    else if (source == Jet::EEMC_TOWER)
+    {
+      if (!_eemctowers)
+      {
+        cout << PHWHERE << "ERROR: can't find TOWER_EEMC" << endl;
+        exit(-1);
+      }
+
+      RawTower* tower = _eemctowers->getTower(index);
+
+      if (_strict)
+      {
+        assert(tower);
+      }
+      else if (!tower)
+      {
+        ++_errors;
+        continue;
+      }
+
+      new_particles = get_eemc_eval_stack()->get_rawtower_eval()->all_truth_primary_particles(tower);
+    }
+    else if (source == Jet::EEMC_CLUSTER)
+    {
+      if (!_eemcclusters)
+      {
+        cout << PHWHERE << "ERROR: can't find CLUSTER_EEMC" << endl;
+        exit(-1);
+      }
+
+      RawCluster* cluster = _eemcclusters->getCluster(index);
+
+      if (_strict)
+      {
+        assert(cluster);
+      }
+      else if (!cluster)
+      {
+        ++_errors;
+        continue;
+      }
+
+      new_particles = get_eemc_eval_stack()->get_rawcluster_eval()->all_truth_primary_particles(cluster);
     }
     else if (source == Jet::HCALIN_TOWER)
     {
@@ -1074,6 +1164,38 @@ float JetRecoEval::get_energy_contribution(Jet* recojet, Jet* truthjet)
 
         energy = get_cemc_eval_stack()->get_rawcluster_eval()->get_energy_contribution(cluster, truthparticle);
       }
+      else if (source == Jet::EEMC_TOWER)
+      {
+        RawTower* tower = _eemctowers->getTower(index);
+
+        if (_strict)
+        {
+          assert(tower);
+        }
+        else if (!tower)
+        {
+          ++_errors;
+          continue;
+        }
+
+        energy = get_eemc_eval_stack()->get_rawtower_eval()->get_energy_contribution(tower, truthparticle);
+      }
+      else if (source == Jet::EEMC_CLUSTER)
+      {
+        RawCluster* cluster = _eemcclusters->getCluster(index);
+
+        if (_strict)
+        {
+          assert(cluster);
+        }
+        else if (!cluster)
+        {
+          ++_errors;
+          continue;
+        }
+
+        energy = get_eemc_eval_stack()->get_rawcluster_eval()->get_energy_contribution(cluster, truthparticle);
+      }
       else if (source == Jet::HCALIN_TOWER)
       {
         RawTower* tower = _hcalintowers->getTower(index);
@@ -1270,6 +1392,38 @@ float JetRecoEval::get_energy_contribution(Jet* recojet, Jet::SRC src)
     else if (source == Jet::CEMC_CLUSTER)
     {
       RawCluster* cluster = _cemcclusters->getCluster(index);
+
+      if (_strict)
+      {
+        assert(cluster);
+      }
+      else if (!cluster)
+      {
+        ++_errors;
+        continue;
+      }
+
+      energy += cluster->get_energy();
+    }
+    else if (source == Jet::EEMC_TOWER)
+    {
+      RawTower* tower = _eemctowers->getTower(index);
+
+      if (_strict)
+      {
+        assert(tower);
+      }
+      else if (!tower)
+      {
+        ++_errors;
+        continue;
+      }
+
+      energy += tower->get_energy();
+    }
+    else if (source == Jet::EEMC_CLUSTER)
+    {
+      RawCluster* cluster = _eemcclusters->getCluster(index);
 
       if (_strict)
       {
@@ -1521,6 +1675,50 @@ std::set<PHG4Hit*> JetRecoEval::all_truth_hits(Jet* recojet)
 
       new_hits = get_cemc_eval_stack()->get_rawcluster_eval()->all_truth_hits(cluster);
     }
+    else if (source == Jet::EEMC_TOWER)
+    {
+      if (!_eemctowers)
+      {
+        cout << PHWHERE << "ERROR: can't find TOWER_EEMC" << endl;
+        exit(-1);
+      }
+
+      RawTower* tower = _eemctowers->getTower(index);
+
+      if (_strict)
+      {
+        assert(tower);
+      }
+      else if (!tower)
+      {
+        ++_errors;
+        continue;
+      }
+
+      new_hits = get_eemc_eval_stack()->get_rawtower_eval()->all_truth_hits(tower);
+    }
+    else if (source == Jet::EEMC_CLUSTER)
+    {
+      if (!_eemcclusters)
+      {
+        cout << PHWHERE << "ERROR: can't find CLUSTER_EEMC" << endl;
+        exit(-1);
+      }
+
+      RawCluster* cluster = _eemcclusters->getCluster(index);
+
+      if (_strict)
+      {
+        assert(cluster);
+      }
+      else if (!cluster)
+      {
+        ++_errors;
+        continue;
+      }
+
+      new_hits = get_eemc_eval_stack()->get_rawcluster_eval()->all_truth_hits(cluster);
+    }
     else if (source == Jet::HCALIN_TOWER)
     {
       if (!_hcalintowers)
@@ -1734,11 +1932,13 @@ void JetRecoEval::get_node_pointers(PHCompositeNode* topNode)
   _hcalouttowers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALOUT");
   _femctowers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_FEMC");
   _fhcaltowers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_FHCAL");
+  _eemctowers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_EEMC");
   _cemcclusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_CEMC");
   _hcalinclusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_HCALIN");
   _hcaloutclusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_HCALOUT");
   _femcclusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_FEMC");
   _fhcalclusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_FHCAL");
+  _eemcclusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_EEMC");
 
   return;
 }

--- a/simulation/g4simulation/g4eval/JetRecoEval.h
+++ b/simulation/g4simulation/g4eval/JetRecoEval.h
@@ -85,6 +85,8 @@ class JetRecoEval
   /// get a copy of the lower level eval and its memory cache
   CaloEvalStack* get_fhcal_eval_stack() { return _jettrutheval.get_fhcal_eval_stack(); }
 
+  /// get a copy of the lower level eval and its memory cache
+  CaloEvalStack* get_eemc_eval_stack() { return _jettrutheval.get_eemc_eval_stack(); }
   // ---reduced sim node or better----------------------------------------------
 
   /// what truth showers contributed to this reconstructed jet?
@@ -145,6 +147,8 @@ class JetRecoEval
   RawClusterContainer* _femcclusters;
   RawTowerContainer* _fhcaltowers;
   RawClusterContainer* _fhcalclusters;
+  RawTowerContainer* _eemctowers;
+  RawClusterContainer* _eemcclusters;
 
   bool _strict;
   int _verbosity;

--- a/simulation/g4simulation/g4eval/JetTruthEval.cc
+++ b/simulation/g4simulation/g4eval/JetTruthEval.cc
@@ -28,6 +28,7 @@ JetTruthEval::JetTruthEval(PHCompositeNode* topNode,
   , _hcaloutevalstack(topNode, "HCALOUT")
   , _femcevalstack(topNode, "FEMC")
   , _fhcalevalstack(topNode, "FHCAL")
+  , _eemcevalstack(topNode, "EEMC")
   , _truthinfo(nullptr)
   , _truthjets(nullptr)
   , _strict(false)

--- a/simulation/g4simulation/g4eval/JetTruthEval.h
+++ b/simulation/g4simulation/g4eval/JetTruthEval.h
@@ -39,6 +39,7 @@ class JetTruthEval
     _hcaloutevalstack.do_caching(do_cache);
     _femcevalstack.do_caching(do_cache);
     _fhcalevalstack.do_caching(do_cache);
+    _eemcevalstack.do_caching(do_cache);
   }
 
   /// strict mode will assert when an error is detected
@@ -52,12 +53,13 @@ class JetTruthEval
     _hcaloutevalstack.set_strict(strict);
     _femcevalstack.set_strict(strict);
     _fhcalevalstack.set_strict(strict);
+    _eemcevalstack.set_strict(strict);
   }
 
   /// get a count of the errors discovered thus far
   unsigned int get_errors()
   {
-    return _errors + _svtxevalstack.get_errors() + _cemcevalstack.get_errors() + _hcalinevalstack.get_errors() + _hcaloutevalstack.get_errors() + _femcevalstack.get_errors() + _fhcalevalstack.get_errors();
+    return _errors + _svtxevalstack.get_errors() + _cemcevalstack.get_errors() + _hcalinevalstack.get_errors() + _hcaloutevalstack.get_errors() + _femcevalstack.get_errors() + _fhcalevalstack.get_errors() + _eemcevalstack.get_errors();
   }
 
   /// adjust the messaging from the evalutaion module
@@ -70,6 +72,7 @@ class JetTruthEval
     _hcaloutevalstack.set_verbosity(verbosity);
     _femcevalstack.set_verbosity(verbosity);
     _fhcalevalstack.set_verbosity(verbosity);
+    _eemcevalstack.set_verbosity(verbosity);
   }
 
   /// get a copy of the lower level eval and its memory cache
@@ -89,6 +92,9 @@ class JetTruthEval
 
   /// get a copy of the lower level eval and its memory cache
   CaloEvalStack* get_fhcal_eval_stack() { return &_fhcalevalstack; }
+
+  /// get a copy of the lower level eval and its memory cache
+  CaloEvalStack* get_eemc_eval_stack() { return &_eemcevalstack; }
 
   // ---reduced sim node or better----------------------------------------------
 
@@ -116,7 +122,8 @@ class JetTruthEval
   CaloEvalStack _hcaloutevalstack;
   CaloEvalStack _femcevalstack;
   CaloEvalStack _fhcalevalstack;
-
+  CaloEvalStack _eemcevalstack;
+  
   PHG4TruthInfoContainer* _truthinfo;
   JetMap* _truthjets;
 

--- a/simulation/g4simulation/g4jets/ClusterJetInput.cc
+++ b/simulation/g4simulation/g4jets/ClusterJetInput.cc
@@ -36,6 +36,8 @@ void ClusterJetInput::identify(std::ostream &os)
   os << "   ClusterJetInput: ";
   if (_input == Jet::CEMC_CLUSTER)
     os << "CLUSTER_CEMC to Jet::CEMC_CLUSTER";
+  if (_input == Jet::EEMC_CLUSTER)
+    os << "CLUSTER_EEMC to Jet::EEMC_CLUSTER";
   else if (_input == Jet::HCALIN_CLUSTER)
     os << "CLUSTER_HCALIN to Jet::HCALIN_CLUSTER";
   else if (_input == Jet::HCALOUT_CLUSTER)
@@ -66,6 +68,14 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
   if (_input == Jet::CEMC_CLUSTER)
   {
     clusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_CEMC");
+    if (!clusters)
+    {
+      return std::vector<Jet *>();
+    }
+  }
+  else if (_input == Jet::EEMC_CLUSTER)
+  {
+    clusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_EEMC");
     if (!clusters)
     {
       return std::vector<Jet *>();

--- a/simulation/g4simulation/g4jets/Jet.h
+++ b/simulation/g4simulation/g4jets/Jet.h
@@ -45,6 +45,8 @@ class Jet : public PHObject
     HCALOUT_TOWER_SUB1CS = 19, /* needed for CS subtraction w/ HI jet reco */
     HEPMC_IMPORT = 20,         /*Direct import HEPMC containers, such as sHijing HIJFRG truth jets loaded by JetHepMCLoader*/
     HCAL_TOPO_CLUSTER = 21,    /* I+HOCal 3-D topoCluster input */
+    EEMC_TOWER = 22,
+    EEMC_CLUSTER = 23,
   };
 
   enum PROPERTY

--- a/simulation/g4simulation/g4jets/TowerJetInput.cc
+++ b/simulation/g4simulation/g4jets/TowerJetInput.cc
@@ -32,6 +32,8 @@ void TowerJetInput::identify(std::ostream &os)
   os << "   TowerJetInput: ";
   if (_input == Jet::CEMC_TOWER)
     os << "TOWER_CEMC to Jet::CEMC_TOWER";
+  if (_input == Jet::EEMC_TOWER)
+    os << "TOWER_EEMC to Jet::EEMC_TOWER";
   else if (_input == Jet::HCALIN_TOWER)
     os << "TOWER_HCALIN to Jet::HCALIN_TOWER";
   else if (_input == Jet::HCALOUT_TOWER)
@@ -68,6 +70,15 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   {
     towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC");
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
+    if (!towers || !geom)
+    {
+      return std::vector<Jet *>();
+    }
+  }
+  else if (_input == Jet::EEMC_TOWER)
+  {
+    towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_EEMC");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_EEMC");
     if (!towers || !geom)
     {
       return std::vector<Jet *>();


### PR DESCRIPTION
Adding electron-going electromagnetic calorimeter, or "EEMC", as on option for tower and cluster jet reconstruction.

With these edits, one can now use the line: `towerjetreco->add_input(new TowerJetInput(Jet::EEMC_TOWER));` in G4_Jets.C to add the EEMC as an in put for reconstructed jets.