### PR TITLE
Set tracknode name

### DIFF
--- a/generators/phhepmc/Fun4AllHepMCInputManagerLinkDef.h
+++ b/generators/phhepmc/Fun4AllHepMCInputManagerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class Fun4AllHepMCInputManager - !;
-
-#endif

--- a/generators/phhepmc/Fun4AllHepMCOutputManagerLinkDef.h
+++ b/generators/phhepmc/Fun4AllHepMCOutputManagerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class Fun4AllHepMCOutputManager - !;
-
-#endif

--- a/generators/phhepmc/Fun4AllHepMCPileupInputManagerLinkDef.h
+++ b/generators/phhepmc/Fun4AllHepMCPileupInputManagerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class Fun4AllHepMCPileupInputManager - !;
-
-#endif

--- a/generators/phhepmc/Fun4AllOscarInputManagerLinkDef.h
+++ b/generators/phhepmc/Fun4AllOscarInputManagerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class Fun4AllOscarInputManager - !;
-
-#endif

--- a/generators/phhepmc/HepMCFlowAfterBurnerLinkDef.h
+++ b/generators/phhepmc/HepMCFlowAfterBurnerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class HepMCFlowAfterBurner - !;
-
-#endif

--- a/generators/phhepmc/Makefile.am
+++ b/generators/phhepmc/Makefile.am
@@ -46,7 +46,7 @@ ROOT_DICTS = \
   PHHepMC_io_Dict.cc \
   PHHepMCGenEvent_Dict.cc \
   PHHepMCGenEventMap_Dict.cc
-if MAKEROOT6
+
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
   PHGenIntegral_Dict_rdict.pcm \
@@ -54,20 +54,8 @@ nobase_dist_pcm_DATA = \
   PHHepMC_io_Dict_rdict.pcm \
   PHHepMCGenEvent_Dict_rdict.pcm \
   PHHepMCGenEventMap_Dict_rdict.pcm
-else
-ROOT5_DICTS = \
-  Fun4AllHepMCInputManager_Dict.cc \
-  Fun4AllHepMCPileupInputManager_Dict.cc \
-  Fun4AllHepMCOutputManager_Dict.cc \
-  Fun4AllOscarInputManager_Dict.cc \
-  HepMCFlowAfterBurner_Dict.cc \
-  PHHepMCGenHelper_Dict.cc \
-  PHHepMCParticleSelectorDecayProductChain_Dict.cc
-
-endif
 
 libphhepmc_la_SOURCES = \
-  $(ROOT5_DICTS) \
   Fun4AllHepMCInputManager.cc \
   Fun4AllHepMCPileupInputManager.cc \
   Fun4AllHepMCOutputManager.cc \

--- a/generators/phhepmc/PHHepMCGenHelperLinkDef.h
+++ b/generators/phhepmc/PHHepMCGenHelperLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHHepMCGenHelper - !;
-
-#endif

--- a/generators/phhepmc/PHHepMCParticleSelectorDecayProductChainLinkDef.h
+++ b/generators/phhepmc/PHHepMCParticleSelectorDecayProductChainLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHHepMCParticleSelectorDecayProductChain - !;
-
-#endif

--- a/generators/phhepmc/PHHepMC_ioLinkDef.h
+++ b/generators/phhepmc/PHHepMC_ioLinkDef.h
@@ -21,9 +21,6 @@
 #include <HepMC/TempParticleMap.h>
 #include <HepMC/WeightContainer.h>
 
-using namespace HepMC;
-using namespace std;
-
 #ifdef __CINT__
 typedef long size_type;
 

--- a/generators/phhepmc/configure.ac
+++ b/generators/phhepmc/configure.ac
@@ -9,12 +9,8 @@ if test $ac_cv_prog_gxx = yes; then
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
-fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/QA/modules/Makefile.am
+++ b/offline/QA/modules/Makefile.am
@@ -69,4 +69,4 @@ testexternals.cc:
 	echo "}" >> $@
 
 clean-local:
-	rm -f *Dict* testexternals.cc
+	rm -f $(BUILT_SOURCES)

--- a/offline/QA/modules/QAG4SimulationMvtx.cc
+++ b/offline/QA/modules/QAG4SimulationMvtx.cc
@@ -12,15 +12,18 @@
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
+#include <trackbase/TrkrDefs.h>                     // for getTrkrId, getHit...
 #include <trackbase/TrkrHitTruthAssoc.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>                     // for SubsysReco
 
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
-#include <TH1F.h>
+#include <TAxis.h>                                  // for TAxis
+#include <TH1.h>
 #include <TString.h>  // for Form
 
 #include <cassert>

--- a/offline/QA/modules/QAG4SimulationTpc.cc
+++ b/offline/QA/modules/QAG4SimulationTpc.cc
@@ -39,6 +39,8 @@
 #include <utility>   // for pair, make_pair
 #include <vector>    // for vector
 
+using namespace std;
+
 //________________________________________________________________________
 QAG4SimulationTpc::QAG4SimulationTpc(const std::string& name)
   : SubsysReco(name)

--- a/offline/QA/modules/QAG4SimulationUpsilon.cc
+++ b/offline/QA/modules/QAG4SimulationUpsilon.cc
@@ -27,6 +27,7 @@
 #include <TVector3.h>
 
 #include <CLHEP/Vector/LorentzVector.h>
+#include <CLHEP/Vector/ThreeVector.h>       // for Hep3Vector
 
 #include <cassert>
 #include <cmath>

--- a/offline/QA/modules/QAG4SimulationVertex.cc
+++ b/offline/QA/modules/QAG4SimulationVertex.cc
@@ -1,4 +1,5 @@
 #include "QAG4SimulationVertex.h"
+
 #include "QAHistManagerDef.h"
 
 #include <g4eval/SvtxEvalStack.h>
@@ -13,6 +14,7 @@
 
 #include <trackbase_historic/SvtxVertex.h>
 #include <trackbase_historic/SvtxVertexMap.h>
+#include <trackbase_historic/SvtxTrack.h>      // for SvtxTrack
 #include <trackbase_historic/SvtxTrackMap.h>
 
 #include <g4main/PHG4Particle.h>
@@ -31,6 +33,7 @@
 #include <cmath>
 #include <iostream>
 #include <map>
+#include <utility>     // for pair
 #include <vector>
 
 using namespace std;

--- a/offline/QA/modules/QAG4SimulationVertex.h
+++ b/offline/QA/modules/QAG4SimulationVertex.h
@@ -13,6 +13,7 @@
 
 class PHCompositeNode;
 class PHG4TruthInfoContainer;
+class SvtxTrackMap;
 
 class QAG4SimulationVertex : public SubsysReco
 {

--- a/offline/packages/CaloReco/PHMakeGroups.h
+++ b/offline/packages/CaloReco/PHMakeGroups.h
@@ -13,7 +13,6 @@
 #include <map>
 #include <vector>
 
-//#define BOOST_NO_HASH // Our version of boost.graph is incompatible with GCC-4.3 w/o this flag
 #include <boost/bind.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/connected_components.hpp>
@@ -22,8 +21,7 @@ template <class Hit>
 int PHMakeGroups(std::vector<Hit>& hits,
                  std::multimap<int, Hit>& groups)
 {
-  using namespace boost;
-  typedef adjacency_list<vecS, vecS, undirectedS> Graph;
+  typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS> Graph;
 
   Graph G;
 

--- a/simulation/g4simulation/g4eval/CaloEvaluator.cc
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.cc
@@ -29,6 +29,7 @@
 
 #include <TFile.h>
 #include <TNtuple.h>
+#include <TTree.h>
 
 #include <CLHEP/Vector/ThreeVector.h>
 

--- a/simulation/g4simulation/g4eval/CaloEvaluator.cc
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.cc
@@ -1,7 +1,7 @@
 #include "CaloEvaluator.h"
 
-#include "CaloRawClusterEval.h"
 #include "CaloEvalStack.h"
+#include "CaloRawClusterEval.h"
 #include "CaloRawTowerEval.h"
 #include "CaloTruthEval.h"
 
@@ -45,15 +45,15 @@ CaloEvaluator::CaloEvaluator(const string& name, const string& caloname, const s
   : SubsysReco(name)
   , _caloname(caloname)
   , _ievent(0)
-  ,_towerID_debug(0)
-  ,_ieta_debug(0)
-  ,_iphi_debug(0)
-  ,_eta_debug(0)
-  ,_phi_debug(0)
-  ,_e_debug(0)
-  ,_x_debug(0)
-  ,_y_debug(0)
-  ,_z_debug(0)
+  , _towerID_debug(0)
+  , _ieta_debug(0)
+  , _iphi_debug(0)
+  , _eta_debug(0)
+  , _phi_debug(0)
+  , _e_debug(0)
+  , _x_debug(0)
+  , _y_debug(0)
+  , _z_debug(0)
   , _truth_trace_embed_flags()
   , _truth_e_threshold(0.0)
   ,  // 0 GeV before reco is traced
@@ -89,32 +89,32 @@ int CaloEvaluator::Init(PHCompositeNode* topNode)
                                                    "event:gparticleID:gflavor:gnhits:"
                                                    "geta:gphi:ge:gpt:gvx:gvy:gvz:gembed:gedep:"
                                                    "clusterID:ntowers:eta:x:y:z:phi:e:efromtruth");
-  
+
   //Barak: Added TTree to will allow the TowerID to be set correctly as integer
-  if (_do_tower_eval){
+  if (_do_tower_eval)
+  {
     _ntp_tower = new TNtuple("ntp_tower", "tower => max truth primary",
-                                               "event:towerID:ieta:iphi:eta:phi:e:x:y:z:"
-                                               "gparticleID:gflavor:gnhits:"
-                                               "geta:gphi:ge:gpt:gvx:gvy:gvz:"
-                                               "gembed:gedep:"
-                                               "efromtruth");
+                             "event:towerID:ieta:iphi:eta:phi:e:x:y:z:"
+                             "gparticleID:gflavor:gnhits:"
+                             "geta:gphi:ge:gpt:gvx:gvy:gvz:"
+                             "gembed:gedep:"
+                             "efromtruth");
 
     //Make Tree
-    _tower_debug = new TTree("tower_debug","tower => max truth primary");
+    _tower_debug = new TTree("tower_debug", "tower => max truth primary");
 
-    _tower_debug->Branch("event",&_ievent,"event/I");
-    _tower_debug->Branch("towerID",&_towerID_debug,"towerID/I");
-    _tower_debug->Branch("ieta",&_ieta_debug,"ieta/I");
-    _tower_debug->Branch("iphi",&_iphi_debug,"iphi/I");
-    _tower_debug->Branch("eta",&_eta_debug,"eta/F");
-    _tower_debug->Branch("phi",&_phi_debug,"phi/F");
-    _tower_debug->Branch("e",&_e_debug,"e/F");
-    _tower_debug->Branch("x",&_x_debug,"x/F");
-    _tower_debug->Branch("y",&_y_debug,"y/F");
-    _tower_debug->Branch("z",&_z_debug,"z/F");
-
+    _tower_debug->Branch("event", &_ievent, "event/I");
+    _tower_debug->Branch("towerID", &_towerID_debug, "towerID/I");
+    _tower_debug->Branch("ieta", &_ieta_debug, "ieta/I");
+    _tower_debug->Branch("iphi", &_iphi_debug, "iphi/I");
+    _tower_debug->Branch("eta", &_eta_debug, "eta/F");
+    _tower_debug->Branch("phi", &_phi_debug, "phi/F");
+    _tower_debug->Branch("e", &_e_debug, "e/F");
+    _tower_debug->Branch("x", &_x_debug, "x/F");
+    _tower_debug->Branch("y", &_y_debug, "y/F");
+    _tower_debug->Branch("z", &_z_debug, "z/F");
   }
-  
+
   if (_do_cluster_eval) _ntp_cluster = new TNtuple("ntp_cluster", "cluster => max truth primary",
                                                    "event:clusterID:ntowers:eta:x:y:z:phi:e:"
                                                    "gparticleID:gflavor:gnhits:"
@@ -167,7 +167,11 @@ int CaloEvaluator::End(PHCompositeNode* topNode)
 
   if (_do_gpoint_eval) _ntp_gpoint->Write();
   if (_do_gshower_eval) _ntp_gshower->Write();
-  if (_do_tower_eval) { _ntp_tower->Write();_tower_debug->Write();}
+  if (_do_tower_eval)
+  {
+    _ntp_tower->Write();
+    _tower_debug->Write();
+  }
   if (_do_cluster_eval) _ntp_cluster->Write();
 
   _tfile->Close();
@@ -352,8 +356,8 @@ void CaloEvaluator::printOutputInfo(PHCompositeNode* topNode)
         RawCluster* cluster = (*clusiter);
 
         float ntowers = cluster->getNTowers();
-	float x = cluster->get_x();
-	float y = cluster->get_y();
+        float x = cluster->get_x();
+        float y = cluster->get_y();
         float z = cluster->get_z();
         float phi = cluster->get_phi();
         float e = cluster->get_energy();
@@ -362,11 +366,11 @@ void CaloEvaluator::printOutputInfo(PHCompositeNode* topNode)
 
         cout << " => #" << cluster->get_id() << " (x,y,z,phi,e) = (";
         cout.width(5);
-	cout << x;
-	cout << ",";
+        cout << x;
+        cout << ",";
         cout.width(5);
-	cout << y;
-	cout << ",";
+        cout << y;
+        cout << ",";
         cout.width(5);
         cout << z;
         cout << ",";
@@ -516,7 +520,7 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       {
         clusterID = cluster->get_id();
         ntowers = cluster->getNTowers();
-	x = cluster->get_x();
+        x = cluster->get_x();
         y = cluster->get_y();
         z = cluster->get_z();
         phi = cluster->get_phi();
@@ -555,8 +559,8 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                              clusterID,
                              ntowers,
                              eta,
-			     x,
-			     y,
+                             x,
+                             y,
                              z,
                              phi,
                              e,
@@ -686,31 +690,31 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       }
 
       float tower_data[] = {(float) _ievent,
-			    towerid,
-			    ieta,
-			    iphi,
-			    eta,
-			    phi,
-			    e,
-			    x,
-			    y,
-			    z,
-			    gparticleID,
-			    gflavor,
-			    gnhits,
-			    geta,
-			    gphi,
-			    ge,
-			    gpt,
-			    gvx,
-			    gvy,
-			    gvz,
-			    gembed,
-			    gedep,
-			    efromtruth};
+                            towerid,
+                            ieta,
+                            iphi,
+                            eta,
+                            phi,
+                            e,
+                            x,
+                            y,
+                            z,
+                            gparticleID,
+                            gflavor,
+                            gnhits,
+                            geta,
+                            gphi,
+                            ge,
+                            gpt,
+                            gvx,
+                            gvy,
+                            gvz,
+                            gembed,
+                            gedep,
+                            efromtruth};
 
       _ntp_tower->Fill(tower_data);
-      _tower_debug->Fill(); //Added by Barak (see above for explanation)
+      _tower_debug->Fill();  //Added by Barak (see above for explanation)
     }
   }
 
@@ -830,8 +834,8 @@ void CaloEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                               clusterID,
                               ntowers,
                               eta,
-			      x,
-			      y,
+                              x,
+                              y,
                               z,
                               phi,
                               e,

--- a/simulation/g4simulation/g4eval/CaloEvaluator.h
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.h
@@ -16,7 +16,7 @@ class CaloEvalStack;
 class PHCompositeNode;
 class TFile;
 class TNtuple;
-class TTree; //Added by Barak
+class TTree;  //Added by Barak
 
 /// \class CaloEvaluator
 ///
@@ -112,7 +112,7 @@ class CaloEvaluator : public SubsysReco
   TNtuple *_ntp_gpoint;
   TNtuple *_ntp_gshower;
   TNtuple *_ntp_tower;
-  TTree *_tower_debug; //Added by Barak
+  TTree *_tower_debug;  //Added by Barak
   TNtuple *_ntp_cluster;
 
   // evaluator output file

--- a/simulation/g4simulation/g4eval/Makefile.am
+++ b/simulation/g4simulation/g4eval/Makefile.am
@@ -93,4 +93,4 @@ testexternals.cc:
 	echo "}" >> $@
 
 clean-local:
-	rm -f *Dict* $(BUILT_SOURCES) *.pcm
+	rm -f $(BUILT_SOURCES)

--- a/simulation/g4simulation/g4eval/PHG4DSTReader.h
+++ b/simulation/g4simulation/g4eval/PHG4DSTReader.h
@@ -12,11 +12,7 @@
 
 #include <fun4all/SubsysReco.h>
 
-#if !defined(__CINT__) || defined(__CLING__)
-
 #include <boost/smart_ptr.hpp>
-
-#endif
 
 #include <set>
 #include <string>
@@ -122,8 +118,6 @@ class PHG4DSTReader : public SubsysReco
   //  std::vector<std::string> _node_name;
   int nblocks;
 
-#if !defined(__CINT__) || defined(__CLING__)
-
   typedef boost::shared_ptr<TClonesArray> arr_ptr;
 
   struct record
@@ -145,7 +139,6 @@ class PHG4DSTReader : public SubsysReco
   };
   typedef std::vector<record> records_t;
   records_t _records;
-#endif
 
   int _event;
 
@@ -173,13 +166,9 @@ class PHG4DSTReader : public SubsysReco
   //! zero suppression for all calorimeters
   double _tower_zero_sup;
 
-#if !defined(__CINT__) || defined(__CLING__)
-
   //! add a particle and associated vertex if _save_vertex
   void
   add_particle(record &rec, PHG4Particle *part);
-
-#endif
 
   void
   build_tree();

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -6,6 +6,7 @@
 #include <trackbase/TrkrDefs.h>
 
 #include <map>
+#include <memory>                // for shared_ptr, less
 #include <set>
 #include <utility>
 
@@ -23,8 +24,7 @@ class TrkrClusterHitAssoc;
 class TrkrHitTruthAssoc;
 class SvtxTruthEval;
 
-using namespace std;
-typedef multimap<float, TrkrDefs::cluskey> innerMap;
+typedef std::multimap<float, TrkrDefs::cluskey> innerMap;
 
 class SvtxClusterEval
 {

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -128,12 +128,10 @@ class SvtxClusterEval
   const float sig_mvtx_z = 4.7e-04;
 
 
-#if !defined(__CINT__) || defined(__CLING__)
   //! cluster azimuthal searching window in _clusters_per_layer. Unit: rad
   static constexpr float _clusters_searching_window = 0.1f;
   std::multimap<unsigned int, innerMap> _clusters_per_layer;
 //  std::multimap<unsigned int, PHG4Hit*> _g4hits_per_layer;
-#endif
 };
 
 #endif  // G4EVAL_SVTXCLUSTEREVAL_H

--- a/simulation/g4simulation/g4eval/SvtxEvalStack.h
+++ b/simulation/g4simulation/g4eval/SvtxEvalStack.h
@@ -25,7 +25,7 @@ class SvtxEvalStack
   void do_caching(bool do_cache) { _vertexeval.do_caching(do_cache); }
   void set_strict(bool strict) { _vertexeval.set_strict(strict); }
   //void set_over_write_vertexmap(bool over_write) {_vertexeval.set_over_write_vertexmap(over_write);}
-  void set_use_initial_vertex(bool use_init_vtx) {_vertexeval.set_use_initial_vertex(use_init_vtx); }
+  void set_use_initial_vertex(bool use_init_vtx) { _vertexeval.set_use_initial_vertex(use_init_vtx); }
   void set_verbosity(int verbosity) { _vertexeval.set_verbosity(verbosity); }
 
   SvtxVertexEval* get_vertex_eval() { return &_vertexeval; }
@@ -36,7 +36,7 @@ class SvtxEvalStack
 
   unsigned int get_errors() { return _vertexeval.get_errors(); }
 
-  void set_track_nodename(const std::string &name) {_vertexeval.set_track_nodename(name);}
+  void set_track_nodename(const std::string& name) { _vertexeval.set_track_nodename(name); }
 
  private:
   SvtxVertexEval _vertexeval;  // right now this is the top-level eval

--- a/simulation/g4simulation/g4eval/SvtxEvalStack.h
+++ b/simulation/g4simulation/g4eval/SvtxEvalStack.h
@@ -36,6 +36,8 @@ class SvtxEvalStack
 
   unsigned int get_errors() { return _vertexeval.get_errors(); }
 
+  void set_track_nodename(const std::string &name) {_vertexeval.set_track_nodename(name);}
+
  private:
   SvtxVertexEval _vertexeval;  // right now this is the top-level eval
 };

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -31,9 +31,6 @@
 
 #include <g4detectors/PHG4CylinderCellGeom.h>
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
-#include <g4detectors/PHG4CylinderGeomContainer.h>
-#include <mvtx/CylinderGeom_Mvtx.h>
-#include <intt/CylinderGeomIntt.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>
@@ -51,6 +48,8 @@
 #include <iostream>
 #include <iterator>
 #include <map>
+#include <memory>                                       // for shared_ptr
+#include <set>                                          // for _Rb_tree_cons...
 #include <utility>
 #include <vector>
 

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -10,15 +10,12 @@
 #include <fun4all/SubsysReco.h>
 
 #include <string>
-#include <set>
-#include <vector>
 
 class PHCompositeNode;
 class PHTimer;
 class SvtxEvalStack;
 class TFile;
 class TNtuple;
-class PHG4Hit;
 
 /// \class SvtxEvaluator
 ///

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -1,11 +1,11 @@
 #include "SvtxTrackEval.h"
 
-#include "SvtxTruthEval.h"
 #include "SvtxClusterEval.h"
+#include "SvtxTruthEval.h"
 
 #include <g4main/PHG4Hit.h>
 
-#include <trackbase/TrkrDefs.h>               // for cluskey, getLayer
+#include <trackbase/TrkrDefs.h>  // for cluskey, getLayer
 
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
@@ -27,7 +27,7 @@ SvtxTrackEval::SvtxTrackEval(PHCompositeNode* topNode)
   , _errors(0)
   , _do_cache(true)
   , _cache_track_from_cluster_exists(false)
-  , m_TrackNodeName("SvtxTrackMap") // typically set upstream by SvtxVertexEval
+  , m_TrackNodeName("SvtxTrackMap")  // typically set upstream by SvtxVertexEval
 {
   get_node_pointers(topNode);
 }
@@ -94,15 +94,15 @@ std::set<PHG4Hit*> SvtxTrackEval::all_truth_hits(SvtxTrack* track)
   {
     TrkrDefs::cluskey cluster_key = *iter;
 
-//    if (_strict)
-//    {
-//      assert(cluster_key);
-//    }
-//    else if (!cluster_key)
-//    {
-//      ++_errors;
-//      continue;
-//    }
+    //    if (_strict)
+    //    {
+    //      assert(cluster_key);
+    //    }
+    //    else if (!cluster_key)
+    //    {
+    //      ++_errors;
+    //      continue;
+    //    }
 
     std::set<PHG4Hit*> new_hits = _clustereval.all_truth_hits(cluster_key);
 
@@ -152,15 +152,15 @@ std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track)
   {
     TrkrDefs::cluskey cluster_key = *iter;
 
-//    if (_strict)
-//    {
-//      assert(cluster_key);
-//    }
-//    else if (!cluster_key)
-//    {
-//      ++_errors;
-//      continue;
-//    }
+    //    if (_strict)
+    //    {
+    //      assert(cluster_key);
+    //    }
+    //    else if (!cluster_key)
+    //    {
+    //      ++_errors;
+    //      continue;
+    //    }
 
     std::set<PHG4Particle*> new_particles = _clustereval.all_truth_particles(cluster_key);
 
@@ -263,15 +263,15 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
       TrkrDefs::cluskey cluster_key = *iter;
 
       // remove this check as cluster key = 0 is MVTX layer 0 cluster #0.
-//      if (_strict)
-//      {
-//        assert(cluster_key);
-//      }
-//      else if (!cluster_key)
-//      {
-//        ++_errors;
-//        continue;
-//      }
+      //      if (_strict)
+      //      {
+      //        assert(cluster_key);
+      //      }
+      //      else if (!cluster_key)
+      //      {
+      //        ++_errors;
+      //        continue;
+      //      }
 
       // loop over all particles
       std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster_key);
@@ -337,15 +337,15 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Hit* truthhit)
     {
       TrkrDefs::cluskey cluster_key = *iter;
 
-//      if (_strict)
-//      {
-//        assert(cluster_key);
-//      }
-//      else if (!cluster_key)
-//      {
-//        ++_errors;
-//        continue;
-//      }
+      //      if (_strict)
+      //      {
+      //        assert(cluster_key);
+      //      }
+      //      else if (!cluster_key)
+      //      {
+      //        ++_errors;
+      //        continue;
+      //      }
 
       // loop over all hits
       std::set<PHG4Hit*> hits = _clustereval.all_truth_hits(cluster_key);
@@ -439,15 +439,15 @@ void SvtxTrackEval::create_cache_track_from_cluster()
     {
       TrkrDefs::cluskey candidate_key = *iter;
 
-//      if (_strict)
-//      {
-//        assert(candidate_key);
-//      }
-//      else if (!candidate_key)
-//      {
-//        ++_errors;
-//        continue;
-//      }
+      //      if (_strict)
+      //      {
+      //        assert(candidate_key);
+      //      }
+      //      else if (!candidate_key)
+      //      {
+      //        ++_errors;
+      //        continue;
+      //      }
 
       //check if cluster has an entry in cache
       std::map<TrkrDefs::cluskey, std::set<SvtxTrack*> >::iterator cliter =
@@ -477,15 +477,15 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(TrkrDefs::cluskey cluster_ke
     return std::set<SvtxTrack*>();
   }
 
-//  if (_strict)
-//  {
-//    assert(cluster_key);
-//  }
-//  else if (!cluster_key)
-//  {
-//    ++_errors;
-//    return std::set<SvtxTrack*>();
-//  }
+  //  if (_strict)
+  //  {
+  //    assert(cluster_key);
+  //  }
+  //  else if (!cluster_key)
+  //  {
+  //    ++_errors;
+  //    return std::set<SvtxTrack*>();
+  //  }
 
   std::set<SvtxTrack*> tracks;
 
@@ -518,15 +518,15 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(TrkrDefs::cluskey cluster_ke
     {
       TrkrDefs::cluskey candidate = *iter;
 
-//      if (_strict)
-//      {
-//        assert(candidate);
-//      }
-//      else if (!candidate)
-//      {
-//        ++_errors;
-//        continue;
-//      }
+      //      if (_strict)
+      //      {
+      //        assert(candidate);
+      //      }
+      //      else if (!candidate)
+      //      {
+      //        ++_errors;
+      //        continue;
+      //      }
 
       if (cluster_key == candidate)
       {
@@ -548,15 +548,15 @@ SvtxTrack* SvtxTrackEval::best_track_from(TrkrDefs::cluskey cluster_key)
     return nullptr;
   }
 
-//  if (_strict)
-//  {
-//    assert(cluster_key);
-//  }
-//  else if (!cluster_key)
-//  {
-//    ++_errors;
-//    return nullptr;
-//  }
+  //  if (_strict)
+  //  {
+  //    assert(cluster_key);
+  //  }
+  //  else if (!cluster_key)
+  //  {
+  //    ++_errors;
+  //    return nullptr;
+  //  }
 
   if (_do_cache)
   {
@@ -693,15 +693,15 @@ void SvtxTrackEval::calc_cluster_contribution(SvtxTrack* track, PHG4Particle* pa
   {
     TrkrDefs::cluskey cluster_key = *iter;
 
-//    if (_strict)
-//    {
-//      assert(cluster_key);
-//    }
-//    else if (!cluster_key)
-//    {
-//      ++_errors;
-//      continue;
-//    }
+    //    if (_strict)
+    //    {
+    //      assert(cluster_key);
+    //    }
+    //    else if (!cluster_key)
+    //    {
+    //      ++_errors;
+    //      continue;
+    //    }
     int matched = 0;
     // loop over all particles
     std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster_key);
@@ -756,7 +756,7 @@ unsigned int SvtxTrackEval::get_nclusters_contribution_by_layer(SvtxTrack* track
 
   unsigned int nclusters_by_layer = 0;
   int layer_occupied[100];
-  for(int i = 0;i<100;i++) layer_occupied[i] = 0;
+  for (int i = 0; i < 100; i++) layer_occupied[i] = 0;
 
   // loop over all clusters
   for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
@@ -766,15 +766,15 @@ unsigned int SvtxTrackEval::get_nclusters_contribution_by_layer(SvtxTrack* track
     TrkrDefs::cluskey cluster_key = *iter;
     unsigned int cluster_layer = TrkrDefs::getLayer(cluster_key);
 
-//    if (_strict)
-//    {
-//      assert(cluster_key);
-//    }
-//    else if (!cluster_key)
-//    {
-//      ++_errors;
-//      continue;
-//    }
+    //    if (_strict)
+    //    {
+    //      assert(cluster_key);
+    //    }
+    //    else if (!cluster_key)
+    //    {
+    //      ++_errors;
+    //      continue;
+    //    }
 
     // loop over all particles
     std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster_key);
@@ -786,12 +786,13 @@ unsigned int SvtxTrackEval::get_nclusters_contribution_by_layer(SvtxTrack* track
       PHG4Particle* candidate = *jter;
       if (get_truth_eval()->are_same_particle(candidate, particle))
       {
-	layer_occupied[cluster_layer]++;
+        layer_occupied[cluster_layer]++;
       }
     }
   }
-  for(int i = 0;i<100;i++){
-    if(layer_occupied[i]>0) nclusters_by_layer++;
+  for (int i = 0; i < 100; i++)
+  {
+    if (layer_occupied[i] > 0) nclusters_by_layer++;
   }
   if (_do_cache) _cache_get_nclusters_contribution_by_layer.insert(make_pair(make_pair(track, particle), nclusters_by_layer));
 
@@ -835,15 +836,15 @@ unsigned int SvtxTrackEval::get_layer_range_contribution(SvtxTrack* track, PHG4P
     if (cluster_layer >= end_layer) continue;
     if (cluster_layer < start_layer) continue;
 
-//    if (_strict)
-//    {
-//      assert(cluster_key);
-//    }
-//    else if (!cluster_key)
-//    {
-//      ++_errors;
-//      continue;
-//    }
+    //    if (_strict)
+    //    {
+    //      assert(cluster_key);
+    //    }
+    //    else if (!cluster_key)
+    //    {
+    //      ++_errors;
+    //      continue;
+    //    }
 
     // loop over all particles
     std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster_key);
@@ -870,7 +871,7 @@ unsigned int SvtxTrackEval::get_layer_range_contribution(SvtxTrack* track, PHG4P
 void SvtxTrackEval::get_node_pointers(PHCompositeNode* topNode)
 {
   // need things off of the DST...
-  _trackmap = findNode::getClass<SvtxTrackMap>(topNode,  m_TrackNodeName);
+  _trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_TrackNodeName);
 
   return;
 }

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -27,17 +27,7 @@ SvtxTrackEval::SvtxTrackEval(PHCompositeNode* topNode)
   , _errors(0)
   , _do_cache(true)
   , _cache_track_from_cluster_exists(false)
-  , _cache_all_truth_hits()
-  , _cache_all_truth_particles()
-  , _cache_max_truth_particle_by_nclusters()
-  , _cache_all_tracks_from_particle()
-  , _cache_best_track_from_particle()
-  , _cache_all_tracks_from_g4hit()
-  , _cache_all_tracks_from_cluster()
-  , _cache_best_track_from_cluster()
-  , _cache_get_nclusters_contribution()
-  , _cache_get_nclusters_contribution_by_layer()
-  , _cache_get_nwrongclusters_contribution()
+  , m_TrackNodeName("SvtxTrackMap") // typically set upstream by SvtxVertexEval
 {
   get_node_pointers(topNode);
 }
@@ -880,7 +870,7 @@ unsigned int SvtxTrackEval::get_layer_range_contribution(SvtxTrack* track, PHG4P
 void SvtxTrackEval::get_node_pointers(PHCompositeNode* topNode)
 {
   // need things off of the DST...
-  _trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  _trackmap = findNode::getClass<SvtxTrackMap>(topNode,  m_TrackNodeName);
 
   return;
 }

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -70,6 +70,8 @@ class SvtxTrackEval
   unsigned int get_nwrongclusters_contribution(SvtxTrack* svtxtrack, PHG4Particle* truthparticle);
   unsigned int get_errors() { return _errors + _clustereval.get_errors(); }
 
+  void set_track_nodename(const std::string &name) {m_TrackNodeName = name;}
+
  private:
   void get_node_pointers(PHCompositeNode* topNode);
   bool has_node_pointers();
@@ -94,6 +96,7 @@ class SvtxTrackEval
   std::map<std::pair<SvtxTrack*, PHG4Particle*>, unsigned int> _cache_get_nclusters_contribution;
   std::map<std::pair<SvtxTrack*, PHG4Particle*>, unsigned int> _cache_get_nclusters_contribution_by_layer;
   std::map<std::pair<SvtxTrack*, PHG4Particle*>, unsigned int> _cache_get_nwrongclusters_contribution;
+  std::string m_TrackNodeName;
 };
 
 #endif  // G4EVAL_SVTXTRACKEVAL_H

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -70,7 +70,7 @@ class SvtxTrackEval
   unsigned int get_nwrongclusters_contribution(SvtxTrack* svtxtrack, PHG4Particle* truthparticle);
   unsigned int get_errors() { return _errors + _clustereval.get_errors(); }
 
-  void set_track_nodename(const std::string &name) {m_TrackNodeName = name;}
+  void set_track_nodename(const std::string& name) { m_TrackNodeName = name; }
 
  private:
   void get_node_pointers(PHCompositeNode* topNode);

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -9,23 +9,28 @@
 #include <g4main/PHG4Particle.h>
 
 #include <trackbase/TrkrClusterv1.h>
-#include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrDefs.h>
+
 #include <tpc/TpcDefs.h>
 
 #include <g4detectors/PHG4CylinderCellGeom.h>
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderGeom.h>               // for PHG4CylinderGeom
 #include <g4detectors/PHG4CylinderGeomContainer.h>
+
 #include <mvtx/CylinderGeom_Mvtx.h>
+
 #include <intt/CylinderGeomIntt.h>
 
 
 #include <phool/getClass.h>
+#include <phool/phool.h>                                // for PHWHERE
 
 #include <TVector3.h>
 
 #include <cassert>
-#include <cfloat>
+#include <cmath>                                       // for sqrt, NAN, fabs
+#include <cstdlib>                                     // for abs
 #include <iostream>
 #include <map>
 #include <set>

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.cc
@@ -403,15 +403,15 @@ void SvtxVertexEval::get_node_pointers(PHCompositeNode* topNode)
 {
   // need things off the DST...
 
-  if( _use_initial_vertex)
-    {
-      _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");  // always there, initial vertices
-    }
+  if (_use_initial_vertex)
+  {
+    _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");  // always there, initial vertices
+  }
   else
-    {
-      _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");  // Rave vertices
-    }
-  
+  {
+    _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");  // Rave vertices
+  }
+
   _trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_TrackNodeName);
 
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
@@ -439,8 +439,8 @@ bool SvtxVertexEval::has_node_pointers()
   return true;
 }
 
-void SvtxVertexEval::set_track_nodename(const std::string &name)
- {
-m_TrackNodeName = name;
-_trackeval.set_track_nodename(name);
+void SvtxVertexEval::set_track_nodename(const std::string& name)
+{
+  m_TrackNodeName = name;
+  _trackeval.set_track_nodename(name);
 }

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.cc
@@ -29,13 +29,8 @@ SvtxVertexEval::SvtxVertexEval(PHCompositeNode* topNode)
   , _verbosity(0)
   , _errors(0)
   , _do_cache(true)
-  , _cache_all_truth_particles()
-  , _cache_all_truth_points()
-  , _cache_max_truth_point_by_ntracks()
-  , _cache_all_vertexes_from_point()
-  , _cache_best_vertex_from_point()
-  , _cache_get_ntracks_contribution()
 {
+  set_track_nodename("SvtxTrackMap");
   get_node_pointers(topNode);
 }
 
@@ -417,7 +412,7 @@ void SvtxVertexEval::get_node_pointers(PHCompositeNode* topNode)
       _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");  // Rave vertices
     }
   
-  _trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  _trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_TrackNodeName);
 
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
 
@@ -442,4 +437,10 @@ bool SvtxVertexEval::has_node_pointers()
     return false;
 
   return true;
+}
+
+void SvtxVertexEval::set_track_nodename(const std::string &name)
+ {
+m_TrackNodeName = name;
+_trackeval.set_track_nodename(name);
 }

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.h
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.h
@@ -65,9 +65,9 @@ class SvtxVertexEval
 
   unsigned int get_errors() { return _errors + _trackeval.get_errors(); }
 
-  void set_use_initial_vertex(bool use_init_vertex) {_use_initial_vertex= use_init_vertex;}
+  void set_use_initial_vertex(bool use_init_vertex) { _use_initial_vertex = use_init_vertex; }
 
-  void set_track_nodename(const std::string &name);
+  void set_track_nodename(const std::string& name);
 
  private:
   void get_node_pointers(PHCompositeNode* topNode);

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.h
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.h
@@ -67,6 +67,8 @@ class SvtxVertexEval
 
   void set_use_initial_vertex(bool use_init_vertex) {_use_initial_vertex= use_init_vertex;}
 
+  void set_track_nodename(const std::string &name);
+
  private:
   void get_node_pointers(PHCompositeNode* topNode);
   bool has_node_pointers();
@@ -88,6 +90,7 @@ class SvtxVertexEval
   std::map<PHG4VtxPoint*, std::set<SvtxVertex*> > _cache_all_vertexes_from_point;
   std::map<PHG4VtxPoint*, SvtxVertex*> _cache_best_vertex_from_point;
   std::map<std::pair<SvtxVertex*, PHG4VtxPoint*>, unsigned int> _cache_get_ntracks_contribution;
+  std::string m_TrackNodeName;
 };
 
 #endif  // G4EVAL_SVTXVERTEXEVAL_H


### PR DESCRIPTION
We need to be able to set the tracknode name, svtxtrack is not really appropriate anymore and the fast truth based tracking has it now as a configurable parameter. It was still hardcoded in the svtx evaluator which crashed the eic detector qa.
Minor cleanups - please no "using namespace" in header files, this influences the behavior of any code which includes this file. Include what you use got rid of a few not needed includes