### PR TITLE
Introduce TPC endcap in simulation

### DIFF
--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -38,6 +38,7 @@ libg4tpc_la_SOURCES = \
   PHG4TpcEndCapDetector.cc \
   PHG4TpcDigitizer.cc \
   PHG4TpcDisplayAction.cc \
+  PHG4TpcEndCapDisplayAction.cc \
   PHG4TpcDistortion.cc \
   PHG4TpcElectronDrift.cc \
   PHG4TpcPadPlane.cc \

--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -32,20 +32,7 @@ pkginclude_HEADERS = \
   PHG4TpcDistortion.h \
   PHG4TpcSpaceChargeDistortion.h 
 
-if MAKEROOT6
-else
-  ROOT5_DICTS = \
-    PHG4TpcElectronDrift_Dict.cc \
-    PHG4TpcPadPlane_Dict.cc \
-    PHG4TpcPadPlaneReadout_Dict.cc \
-    PHG4TpcDigitizer_Dict.cc \
-    PHG4TpcSubsystem_Dict.cc \
-    PHG4TpcDistortion_Dict.cc\
-    PHG4TpcSpaceChargeDistortion_Dict.cc 
-endif
-
 libg4tpc_la_SOURCES = \
-  $(ROOT5_DICTS) \
   PHG4TpcDetector.cc \
   PHG4TpcDigitizer.cc \
   PHG4TpcDisplayAction.cc \

--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -29,11 +29,13 @@ pkginclude_HEADERS = \
   PHG4TpcPadPlaneReadout.h \
   PHG4TpcDigitizer.h \
   PHG4TpcSubsystem.h \
+  PHG4TpcEndCapSubsystem.h \
   PHG4TpcDistortion.h \
   PHG4TpcSpaceChargeDistortion.h 
 
 libg4tpc_la_SOURCES = \
   PHG4TpcDetector.cc \
+  PHG4TpcEndCapDetector.cc \
   PHG4TpcDigitizer.cc \
   PHG4TpcDisplayAction.cc \
   PHG4TpcDistortion.cc \
@@ -42,7 +44,9 @@ libg4tpc_la_SOURCES = \
   PHG4TpcPadPlaneReadout.cc \
   PHG4TpcSpaceChargeDistortion.cc \
   PHG4TpcSteppingAction.cc \
-  PHG4TpcSubsystem.cc
+  PHG4TpcEndCapSteppingAction.cc \
+  PHG4TpcSubsystem.cc \
+  PHG4TpcEndCapSubsystem.cc
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizerLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4TpcDigitizer - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortionLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortionLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4TpcDistortion - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDriftLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDriftLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4TpcElectronDrift - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
@@ -6,14 +6,14 @@
 // Currently this installs a simple G4Box solid, creates a logical volume from it
 // and places it. Put your own detector in place (just make sure all active volumes
 // get inserted into the m_PhysicalVolumesSet)
-// 
+//
 // Rather than using hardcoded values you should consider using the parameter class
 // Parameter names and defaults are set in PHG4TpcEndCapSubsystem::SetDefaultParameters()
 // Only parameters defined there can be used (also to override in the macro)
 // to avoids typos.
 // IMPORTANT: parameters have no inherent units, there is a convention (cm/deg)
-// but in any case you need to multiply them here with the correct CLHEP/G4 unit 
-// 
+// but in any case you need to multiply them here with the correct CLHEP/G4 unit
+//
 // The place where you put your own detector is marked with
 // //begin implement your own here://
 // //end implement your own here://
@@ -21,19 +21,37 @@
 //____________________________________________________________________________..
 
 #include "PHG4TpcEndCapDetector.h"
+#include "PHG4TpcEndCapDisplayAction.h"
 
 #include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4Detector.h>
+#include <g4main/PHG4Subsystem.h>
 
+#include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Color.hh>
+#include <Geant4/G4ExtrudedSolid.hh>
+#include <Geant4/G4IntersectionSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4RotationMatrix.hh>
+#include <Geant4/G4String.hh>
+#include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4ThreeVector.hh>
+#include <Geant4/G4Transform3D.hh>
+#include <Geant4/G4Tubs.hh>
+#include <Geant4/G4TwoVector.hh>
+#include <Geant4/G4UserLimits.hh>
+#include <Geant4/G4VPhysicalVolume.hh>
+#include <Geant4/G4VSolid.hh>
 #include <Geant4/G4VisAttributes.hh>
 
+#include <boost/format.hpp>
+
+#include <cassert>
 #include <cmath>
 #include <iostream>
 
@@ -44,12 +62,28 @@ using namespace std;
 
 //____________________________________________________________________________..
 PHG4TpcEndCapDetector::PHG4TpcEndCapDetector(PHG4Subsystem *subsys,
-                                         PHCompositeNode *Node,
-                                         PHParameters *parameters,
-                                         const std::string &dnam)
+                                             PHCompositeNode *Node,
+                                             PHParameters *parameters,
+                                             const std::string &dnam)
   : PHG4Detector(subsys, Node, dnam)
   , m_Params(parameters)
+  , m_DisplayAction(dynamic_cast<PHG4TpcEndCapDisplayAction *>(subsys->GetDisplayAction()))
+
 {
+}
+
+PHG4TpcEndCapDetector::
+    ~PHG4TpcEndCapDetector()
+{
+  if (m_EndCapAssembly)
+  {
+    if (Verbosity())
+    {
+      cout << __PRETTY_FUNCTION__ << " delete m_EndCapAssembly" << endl;
+    }
+
+    delete m_EndCapAssembly;
+  }
 }
 
 //_______________________________________________________________
@@ -66,32 +100,152 @@ int PHG4TpcEndCapDetector::IsInDetector(G4VPhysicalVolume *volume) const
 //_______________________________________________________________
 void PHG4TpcEndCapDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
- //begin implement your own here://
- // Do not forget to multiply the parameters with their respective CLHEP/G4 unit !
-  double xdim = m_Params->get_double_param("size_x") * cm;
-  double ydim = m_Params->get_double_param("size_y") * cm;
-  double zdim = m_Params->get_double_param("size_z") * cm;
-  G4VSolid *solidbox = new G4Box("PHG4TpcEndCapSolid", xdim / 2., ydim / 2., zdim / 2.);
-  G4LogicalVolume *logical = new G4LogicalVolume(solidbox, G4Material::GetMaterial(m_Params->get_string_param("material")), "PHG4TpcEndCapLogical");
+  //  //begin implement your own here://
+  //  // Do not forget to multiply the parameters with their respective CLHEP/G4 unit !
+  //  double xdim = m_Params->get_double_param("size_x") * cm;
+  //  double ydim = m_Params->get_double_param("size_y") * cm;
+  //  double zdim = m_Params->get_double_param("size_z") * cm;
+  //  G4VSolid *solidbox = new G4Box("PHG4TpcEndCapSolid", xdim / 2., ydim / 2., zdim / 2.);
+  //  G4LogicalVolume *logical = new G4LogicalVolume(solidbox, G4Material::GetMaterial(m_Params->get_string_param("material")), "PHG4TpcEndCapLogical");
+  //
+  //  //  G4VisAttributes *vis = new G4VisAttributes(G4Color(G4Colour::Grey()));  // grey is good to see the tracks in the display
+  //  //  vis->SetForceSolid(true);
+  //  //  logical->SetVisAttributes(vis);
+  //  G4RotationMatrix *rotm = new G4RotationMatrix();
+  //  rotm->rotateX(m_Params->get_double_param("rot_x") * deg);
+  //  rotm->rotateY(m_Params->get_double_param("rot_y") * deg);
+  //  rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
+  //
+  //  G4VPhysicalVolume *phy = new G4PVPlacement(
+  //      rotm,
+  //      G4ThreeVector(m_Params->get_double_param("place_x") * cm,
+  //                    m_Params->get_double_param("place_y") * cm,
+  //                    m_Params->get_double_param("place_z") * cm),
+  //      logical, "PHG4TpcEndCap", logicWorld, 0, false, OverlapCheck());
+  //  // add it to the list of placed volumes so the IsInDetector method
+  //  // picks them up
+  //  m_PhysicalVolumesSet.insert(phy);
+  //  //end implement your own here://
 
-  G4VisAttributes *vis = new G4VisAttributes(G4Color(G4Colour::Grey()));  // grey is good to see the tracks in the display
-  vis->SetForceSolid(true);
-  logical->SetVisAttributes(vis);
-  G4RotationMatrix *rotm = new G4RotationMatrix();
-  rotm->rotateX(m_Params->get_double_param("rot_x") * deg);
-  rotm->rotateY(m_Params->get_double_param("rot_y") * deg);
-  rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
+  assert(m_EndCapAssembly == nullptr);
+  m_EndCapAssembly = ConstructEndCapAssembly();
+  assert(m_EndCapAssembly);
 
-  G4VPhysicalVolume *phy = new G4PVPlacement(
-      rotm,
-      G4ThreeVector(m_Params->get_double_param("place_x") * cm,
-                    m_Params->get_double_param("place_y") * cm,
-                    m_Params->get_double_param("place_z") * cm),
-      logical, "PHG4TpcEndCap", logicWorld, 0, false, OverlapCheck());
-  // add it to the list of placed volumes so the IsInDetector method
-  // picks them up
-  m_PhysicalVolumesSet.insert(phy);
- //end implement your own here://
+  G4TranslateZ3D g4vec_front_z(
+      m_Params->get_double_param("envelop_front_surface_z") * cm);
+
+  G4RotateY3D rotm_otherside(180 * deg);
+
+  G4ThreeVector g4vec_center(m_Params->get_double_param("place_x") * cm,
+                             m_Params->get_double_param("place_y") * cm,
+                             m_Params->get_double_param("place_z") * cm);
+  G4RotationMatrix rotm_center;
+  rotm_center.rotateX(m_Params->get_double_param("rot_x") * deg);
+  rotm_center.rotateY(m_Params->get_double_param("rot_y") * deg);
+  rotm_center.rotateZ(m_Params->get_double_param("rot_z") * deg);
+  G4Transform3D transform_center(rotm_center, g4vec_center);
+
+  int i = 0;
+  //  G4Transform3D transform_side1 = g4vec_front_z * transform_center;
+  G4Transform3D transform_side1 = transform_center * g4vec_front_z;
+  m_EndCapAssembly->MakeImprint(logicWorld, transform_side1, i++, OverlapCheck());
+  // the other side
+  G4Transform3D transform_side2 = transform_center * rotm_otherside * g4vec_front_z;
+  m_EndCapAssembly->MakeImprint(logicWorld, transform_side2, i++, OverlapCheck());
+
+  return;
+}
+
+G4AssemblyVolume *PHG4TpcEndCapDetector::ConstructEndCapAssembly()
+{
+  G4AssemblyVolume *assmeblyvol = new G4AssemblyVolume();
+  G4double starting_z(0);
+
+  // Internal HBD structure
+  // From doi:10.1016/j.nima.2011.04.015
+  // Component Material X0 (cm) Thickness (cm) Area (%) Rad. Length (%)
+  //  Mesh SS 1.67 0.003 11.5 0.021  <- not used for GEMs trackers
+  //  AddLayer("Mesh", "Steel",
+  //          0.003 * cm, false, 11.5);
+
+  //  //  GEM frames FR4 17.1 0.15x4 6.5 0.228 <- not used for GEMs trackers
+  //  AddLayer("Frame0", "G10",
+  //          0.15 * cm, false, 6.5);
+  const int n_GEM_layers = m_Params->get_int_param("n_GEM_layers");
+
+  for (int gem = 1; gem <= n_GEM_layers; gem++)
+  {
+    stringstream sid;
+    sid << gem;
+
+    //  GEM Copper 1.43 0.0005x6 64 0.134
+    AddLayer(assmeblyvol, starting_z, G4String("GEMFrontCu") + G4String(sid.str()), "G4_Cu",
+             0.0005 * cm, 64);
+
+    //  GEM Kapton 28.6 0.005x3 64 0.034
+    AddLayer(assmeblyvol, starting_z, G4String("GEMKapton") + G4String(sid.str()), "G4_KAPTON",
+             0.005 * cm, 64);
+
+    //  GEM Copper 1.43 0.0005x6 64 0.134
+    AddLayer(assmeblyvol, starting_z, G4String("GEMBackCu") + G4String(sid.str()), "G4_Cu",
+             0.0005 * cm, 64);
+
+    //  GEM frames FR4 17.1 0.15x4 6.5 0.228
+    //    AddLayer(assmeblyvol,starting_z,G4String("Frame") + G4String(sid.str()), "G10", 0.15 * cm,
+    //             6.5);
+    // sPHENIX TPC air gap
+    starting_z += 0.2 * cm;
+  }
+
+  //  PCB Kapton 28.6 0.005 100 0.017
+  AddLayer(assmeblyvol, starting_z, G4String("PCBKapton"), "G4_KAPTON", 0.005 * cm, 100);
+
+  //  PCB Copper 1.43 0.0005 80 0.028
+  AddLayer(assmeblyvol, starting_z, G4String("PCBCu"), "G4_Cu", 0.0005 * cm, 80);
+
+  //  Facesheet FR4 17.1 0.025x2 100 0.292
+  AddLayer(assmeblyvol, starting_z, "Facesheet", "G10", 0.025 * 2 * cm, 100);
+
+  return assmeblyvol;
+}
+
+void PHG4TpcEndCapDetector ::AddLayer(  //
+    G4AssemblyVolume *assmeblyvol,
+    G4double &z_start,
+    std::string _name,         //! name base for this layer
+    std::string _material,     //! material name in G4
+    G4double _depth,           //! depth in G4 units
+    double _percentage_filled  //! percentage filled//
+)
+{
+  z_start += _depth / 2;
+  G4ThreeVector g4vec(0, 0, z_start);
+  z_start += _depth / 2;
+
+  string name_base =
+      boost::str(boost::format("%1%_Layer_%2%") % GetName() % _name);
+
+  G4VSolid *solid_grid = new G4Tubs(
+      name_base,
+      m_Params->get_double_param("envelop_r_min") * cm,
+      m_Params->get_double_param("envelop_r_max") * cm,
+      _depth * _percentage_filled / 2,
+      0, CLHEP::twopi);
+
+  auto material = G4Material::GetMaterial(_material);
+  if (material == nullptr)
+  {
+    cout << __PRETTY_FUNCTION__ << " Fatal Error: missing material " << _material << endl;
+    assert(material);
+  }
+
+  G4LogicalVolume *logical_grid = new G4LogicalVolume(solid_grid, material, name_base);
+
+  assmeblyvol->AddPlacedVolume(logical_grid, g4vec, nullptr);
+
+  assert(m_DisplayAction);
+  m_DisplayAction->AddVolume(logical_grid, _material);
+
   return;
 }
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
@@ -1,0 +1,109 @@
+//____________________________________________________________________________..
+//
+// This is a working template for the G4 Construct() method which needs to be implemented
+// We wedge a method between the G4 Construct() to enable volume hierarchies on the macro
+// so here it is called ConstructMe() but there is no functional difference
+// Currently this installs a simple G4Box solid, creates a logical volume from it
+// and places it. Put your own detector in place (just make sure all active volumes
+// get inserted into the m_PhysicalVolumesSet)
+// 
+// Rather than using hardcoded values you should consider using the parameter class
+// Parameter names and defaults are set in PHG4TpcEndCapSubsystem::SetDefaultParameters()
+// Only parameters defined there can be used (also to override in the macro)
+// to avoids typos.
+// IMPORTANT: parameters have no inherent units, there is a convention (cm/deg)
+// but in any case you need to multiply them here with the correct CLHEP/G4 unit 
+// 
+// The place where you put your own detector is marked with
+// //begin implement your own here://
+// //end implement your own here://
+// Do not forget to include the G4 includes for your volumes
+//____________________________________________________________________________..
+
+#include "PHG4TpcEndCapDetector.h"
+
+#include <phparameter/PHParameters.h>
+
+#include <g4main/PHG4Detector.h>
+
+#include <Geant4/G4Box.hh>
+#include <Geant4/G4Color.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
+#include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4VisAttributes.hh>
+
+#include <cmath>
+#include <iostream>
+
+class G4VSolid;
+class PHCompositeNode;
+
+using namespace std;
+
+//____________________________________________________________________________..
+PHG4TpcEndCapDetector::PHG4TpcEndCapDetector(PHG4Subsystem *subsys,
+                                         PHCompositeNode *Node,
+                                         PHParameters *parameters,
+                                         const std::string &dnam)
+  : PHG4Detector(subsys, Node, dnam)
+  , m_Params(parameters)
+{
+}
+
+//_______________________________________________________________
+int PHG4TpcEndCapDetector::IsInDetector(G4VPhysicalVolume *volume) const
+{
+  set<G4VPhysicalVolume *>::const_iterator iter = m_PhysicalVolumesSet.find(volume);
+  if (iter != m_PhysicalVolumesSet.end())
+  {
+    return 1;
+  }
+  return 0;
+}
+
+//_______________________________________________________________
+void PHG4TpcEndCapDetector::ConstructMe(G4LogicalVolume *logicWorld)
+{
+ //begin implement your own here://
+ // Do not forget to multiply the parameters with their respective CLHEP/G4 unit !
+  double xdim = m_Params->get_double_param("size_x") * cm;
+  double ydim = m_Params->get_double_param("size_y") * cm;
+  double zdim = m_Params->get_double_param("size_z") * cm;
+  G4VSolid *solidbox = new G4Box("PHG4TpcEndCapSolid", xdim / 2., ydim / 2., zdim / 2.);
+  G4LogicalVolume *logical = new G4LogicalVolume(solidbox, G4Material::GetMaterial(m_Params->get_string_param("material")), "PHG4TpcEndCapLogical");
+
+  G4VisAttributes *vis = new G4VisAttributes(G4Color(G4Colour::Grey()));  // grey is good to see the tracks in the display
+  vis->SetForceSolid(true);
+  logical->SetVisAttributes(vis);
+  G4RotationMatrix *rotm = new G4RotationMatrix();
+  rotm->rotateX(m_Params->get_double_param("rot_x") * deg);
+  rotm->rotateY(m_Params->get_double_param("rot_y") * deg);
+  rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
+
+  G4VPhysicalVolume *phy = new G4PVPlacement(
+      rotm,
+      G4ThreeVector(m_Params->get_double_param("place_x") * cm,
+                    m_Params->get_double_param("place_y") * cm,
+                    m_Params->get_double_param("place_z") * cm),
+      logical, "PHG4TpcEndCap", logicWorld, 0, false, OverlapCheck());
+  // add it to the list of placed volumes so the IsInDetector method
+  // picks them up
+  m_PhysicalVolumesSet.insert(phy);
+ //end implement your own here://
+  return;
+}
+
+//_______________________________________________________________
+void PHG4TpcEndCapDetector::Print(const std::string &what) const
+{
+  cout << "PHG4TpcEndCap Detector:" << endl;
+  if (what == "ALL" || what == "VOLUME")
+  {
+    cout << "Version 0.1" << endl;
+    cout << "Parameters:" << endl;
+    m_Params->Print();
+  }
+  return;
+}

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
@@ -183,7 +183,7 @@ G4AssemblyVolume *PHG4TpcEndCapDetector::ConstructEndCapAssembly()
   // 35 um / layer Cu
   AddLayer(assmeblyvol, starting_z, G4String("PCBCu"), "G4_Cu", 0.0035 * cm * n_PCB_layers, 80);
   // 7 mil / layer board
-  AddLayer(assmeblyvol, starting_z, "PCBBase", "G10", 0.00254 * cm * 7 * n_PCB_layers, 100);
+  AddLayer(assmeblyvol, starting_z, "PCBBase", "FR4", 0.00254 * cm * 7 * n_PCB_layers, 100);
 
   ConstructWagonWheel(assmeblyvol, starting_z);
   ConstructElectronics(assmeblyvol, starting_z);
@@ -548,7 +548,7 @@ void PHG4TpcEndCapDetector::ConstructElectronics(G4AssemblyVolume *assmeblyvol,
           electronics_assemly_thickness;
       const int nFEE =
           m_Params->get_int_param(
-              boost::str(boost::format("electronics_nFEE_R2%1%") % (ring_id)));
+              boost::str(boost::format("electronics_nFEE_R%1%") % (ring_id)));
 
       if (nFEE <= 0)
       {
@@ -565,12 +565,34 @@ void PHG4TpcEndCapDetector::ConstructElectronics(G4AssemblyVolume *assmeblyvol,
       {
         if (Verbosity())
         {
+          cout << __PRETTY_FUNCTION__ << " - electronics G4_PCB z_start = " << z_start
+               << " starting_electronics = " << starting_electronics << endl;
+        }
+        starting_electronics -= electronics_FEE_PCB_thickness / 2.;
+        G4ThreeVector g4vec_electronics(starting_electronics, (Rout + Rin) * .5, z_start + electronics_FEE_depth / 2.);
+        starting_electronics -= electronics_FEE_PCB_thickness / 2.;
+
+        G4VSolid *solid_electronics = new G4Box(name_base + "_PCB",
+                                                electronics_FEE_PCB_thickness / 2.,
+                                                (Rout - Rin) / 2.,
+                                                electronics_FEE_depth / 2.);
+
+        G4LogicalVolume *log_electronics = new G4LogicalVolume(solid_electronics,
+                                                               G4Material::GetMaterial("FR4"), name_base + "_PCB");
+
+        assmeblyvol_electronics->AddPlacedVolume(log_electronics,
+                                                 g4vec_electronics, nullptr);
+        m_DisplayAction->AddVolume(log_electronics, "FR4");
+      }
+      {
+        if (Verbosity())
+        {
           cout << __PRETTY_FUNCTION__ << " - electronics G4_Cu z_start = " << z_start
                << " starting_electronics = " << starting_electronics << endl;
         }
-        starting_electronics += electronics_FEE_Cu_thickness / 2.;
+        starting_electronics -= electronics_FEE_Cu_thickness / 2.;
         G4ThreeVector g4vec_electronics(starting_electronics, (Rout + Rin) * .5, z_start + electronics_FEE_depth / 2.);
-        starting_electronics += electronics_FEE_Cu_thickness / 2.;
+        starting_electronics -= electronics_FEE_Cu_thickness / 2.;
 
         G4VSolid *solid_electronics = new G4Box(name_base + "_Cu",
                                                 electronics_FEE_Cu_thickness / 2.,
@@ -587,34 +609,12 @@ void PHG4TpcEndCapDetector::ConstructElectronics(G4AssemblyVolume *assmeblyvol,
       {
         if (Verbosity())
         {
-          cout << __PRETTY_FUNCTION__ << " - electronics G4_PCB z_start = " << z_start
-               << " starting_electronics = " << starting_electronics << endl;
-        }
-        starting_electronics += electronics_FEE_PCB_thickness / 2.;
-        G4ThreeVector g4vec_electronics(starting_electronics, (Rout + Rin) * .5, z_start + electronics_FEE_depth / 2.);
-        starting_electronics += electronics_FEE_PCB_thickness / 2.;
-
-        G4VSolid *solid_electronics = new G4Box(name_base + "_PCB",
-                                                electronics_FEE_PCB_thickness / 2.,
-                                                (Rout - Rin) / 2.,
-                                                electronics_FEE_depth / 2.);
-
-        G4LogicalVolume *log_electronics = new G4LogicalVolume(solid_electronics,
-                                                               G4Material::GetMaterial("G10"), name_base + "_PCB");
-
-        assmeblyvol_electronics->AddPlacedVolume(log_electronics,
-                                                 g4vec_electronics, nullptr);
-        m_DisplayAction->AddVolume(log_electronics, "G10");
-      }
-      {
-        if (Verbosity())
-        {
           cout << __PRETTY_FUNCTION__ << " - electronics Al z_start = " << z_start
                << " starting_electronics = " << starting_electronics << endl;
         }
-        starting_electronics += electronics_FEE_Al_thickness / 2.;
+        starting_electronics -= electronics_FEE_Al_thickness / 2.;
         G4ThreeVector g4vec_electronics(starting_electronics, (Rout + Rin) * .5, z_start + electronics_FEE_depth / 2.);
-        starting_electronics += electronics_FEE_Al_thickness / 2.;
+        starting_electronics -= electronics_FEE_Al_thickness / 2.;
 
         G4VSolid *solid_electronics = new G4Box(name_base + "_Al",
                                                 electronics_FEE_Al_thickness / 2.,

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
@@ -16,6 +16,7 @@ class PHG4Subsystem;
 class PHParameters;
 class G4AssemblyVolume;
 class PHG4TpcEndCapDisplayAction;
+class G4VSolid;
 
 class PHG4TpcEndCapDetector : public PHG4Detector
 {
@@ -51,6 +52,8 @@ class PHG4TpcEndCapDetector : public PHG4Detector
   G4AssemblyVolume *m_EndCapAssembly = nullptr;
 
   G4AssemblyVolume *ConstructEndCapAssembly();
+  void ConstructWagonWheel(G4AssemblyVolume *assmeblyvol,
+      G4double &z_start);
 
   void
   AddLayer(                            //

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
@@ -4,6 +4,7 @@
 #define PHG4TPCENDCAPDETECTOR_H
 
 #include <g4main/PHG4Detector.h>
+#include <Geant4/G4Types.hh>
 
 #include <set>
 #include <string>  // for string
@@ -13,6 +14,8 @@ class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4Subsystem;
 class PHParameters;
+class G4AssemblyVolume;
+class PHG4TpcEndCapDisplayAction;
 
 class PHG4TpcEndCapDetector : public PHG4Detector
 {
@@ -21,7 +24,7 @@ class PHG4TpcEndCapDetector : public PHG4Detector
   PHG4TpcEndCapDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
-  virtual ~PHG4TpcEndCapDetector() {}
+  virtual ~PHG4TpcEndCapDetector();
 
   //! construct
   void ConstructMe(G4LogicalVolume *world) override;
@@ -38,11 +41,26 @@ class PHG4TpcEndCapDetector : public PHG4Detector
 
  private:
   PHParameters *m_Params;
+  PHG4TpcEndCapDisplayAction *m_DisplayAction;
 
   // active volumes
   std::set<G4VPhysicalVolume *> m_PhysicalVolumesSet;
 
   std::string m_SuperDetector;
+
+  G4AssemblyVolume *m_EndCapAssembly = nullptr;
+
+  G4AssemblyVolume *ConstructEndCapAssembly();
+
+  void
+  AddLayer(                            //
+      G4AssemblyVolume * assmeblyvol,
+      G4double & z_start,
+      std::string _name,               //! name base for this layer
+      std::string _material,           //! material name in G4
+      G4double _depth,                   //! depth in G4 units
+      double _percentage_filled = 100  //! percentage filled//
+  );
 };
 
-#endif // PHG4TPCENDCAPDETECTOR_H
+#endif  // PHG4TPCENDCAPDETECTOR_H

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
@@ -52,7 +52,11 @@ class PHG4TpcEndCapDetector : public PHG4Detector
   G4AssemblyVolume *m_EndCapAssembly = nullptr;
 
   G4AssemblyVolume *ConstructEndCapAssembly();
+
   void ConstructWagonWheel(G4AssemblyVolume *assmeblyvol,
+      G4double &z_start);
+
+  void ConstructElectronics(G4AssemblyVolume *assmeblyvol,
       G4double &z_start);
 
   void

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
@@ -54,18 +54,18 @@ class PHG4TpcEndCapDetector : public PHG4Detector
   G4AssemblyVolume *ConstructEndCapAssembly();
 
   void ConstructWagonWheel(G4AssemblyVolume *assmeblyvol,
-      G4double &z_start);
+                           G4double &z_start);
 
   void ConstructElectronics(G4AssemblyVolume *assmeblyvol,
-      G4double &z_start);
+                            G4double &z_start);
 
   void
-  AddLayer(                            //
-      G4AssemblyVolume * assmeblyvol,
-      G4double & z_start,
+  AddLayer(  //
+      G4AssemblyVolume *assmeblyvol,
+      G4double &z_start,
       std::string _name,               //! name base for this layer
       std::string _material,           //! material name in G4
-      G4double _depth,                   //! depth in G4 units
+      G4double _depth,                 //! depth in G4 units
       double _percentage_filled = 100  //! percentage filled//
   );
 };

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
@@ -1,0 +1,48 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef PHG4TPCENDCAPDETECTOR_H
+#define PHG4TPCENDCAPDETECTOR_H
+
+#include <g4main/PHG4Detector.h>
+
+#include <set>
+#include <string>  // for string
+
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+class PHCompositeNode;
+class PHG4Subsystem;
+class PHParameters;
+
+class PHG4TpcEndCapDetector : public PHG4Detector
+{
+ public:
+  //! constructor
+  PHG4TpcEndCapDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
+
+  //! destructor
+  virtual ~PHG4TpcEndCapDetector() {}
+
+  //! construct
+  void ConstructMe(G4LogicalVolume *world) override;
+
+  void Print(const std::string &what = "ALL") const override;
+
+  //!@name volume accessors
+  //@{
+  int IsInDetector(G4VPhysicalVolume *) const;
+  //@}
+
+  void SuperDetector(const std::string &name) { m_SuperDetector = name; }
+  const std::string SuperDetector() const { return m_SuperDetector; }
+
+ private:
+  PHParameters *m_Params;
+
+  // active volumes
+  std::set<G4VPhysicalVolume *> m_PhysicalVolumesSet;
+
+  std::string m_SuperDetector;
+};
+
+#endif // PHG4TPCENDCAPDETECTOR_H

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
@@ -40,25 +40,24 @@ void PHG4TpcEndCapDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     {
       continue;
     }
+
     G4VisAttributes *visatt = new G4VisAttributes();
     visatt->SetVisibility(true);
     visatt->SetForceSolid(true);
     m_VisAttVec.push_back(visatt);  // for later deletion
-                                    //    if (it.second == "SectorDetector")
-                                    //    {
-    PHG4Utils::SetColour(visatt, it.first->GetMaterial()->GetName());
-    //    }
-    //    else if (it.second == "DetectorBox")
-    //    {
-    //      visatt->SetColour(G4Colour::White());
-    //      visatt->SetForceWireframe(true);
-    //      visatt->SetForceLineSegmentsPerCircle(50);
-    //    }
-    //    else
-    //    {
-    //      cout << "unknown logical volume " << it.second << endl;
-    //      gSystem->Exit(1);
-    //    }
+
+    if (it.second == "G10")
+    {
+      visatt->SetColour(G4Colour(0.0, .8, 0.0));
+    }
+    else if (it.second == "wagon_wheel")
+    {
+      visatt->SetColour(G4Colour(.8, 0.0, 0.0));
+    }
+    else
+    {
+      PHG4Utils::SetColour(visatt, it.first->GetMaterial()->GetName());
+    }
     logvol->SetVisAttributes(visatt);
   }
   return;

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
@@ -53,6 +53,12 @@ void PHG4TpcEndCapDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     else if (it.second == "wagon_wheel")
     {
       visatt->SetColour(G4Colour(.8, 0.0, 0.0));
+      visatt->SetForceLineSegmentsPerCircle(100);
+    }
+    else if (it.second == "cooling_block")
+    {
+      visatt->SetColour(G4Colour(.8, .8, .8));
+      visatt->SetForceLineSegmentsPerCircle(100);
     }
     else
     {

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
@@ -48,7 +48,7 @@ void PHG4TpcEndCapDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 
     if (it.second == "G10" or it.second == "FR4")
     {
-      visatt->SetColour(G4Colour(0.0, .8, 0.0));
+      visatt->SetColour(G4Colour(0.0, .5, 0.0));
     }
     else if (it.second == "wagon_wheel")
     {

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
@@ -1,0 +1,65 @@
+#include "PHG4TpcEndCapDisplayAction.h"
+
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
+#include <g4main/PHG4Utils.h>
+
+#include <Geant4/G4Colour.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
+#include <Geant4/G4String.hh>  // for G4String
+#include <Geant4/G4VisAttributes.hh>
+
+#include <TSystem.h>
+
+#include <iostream>
+#include <utility>  // for pair
+
+using namespace std;
+
+PHG4TpcEndCapDisplayAction::PHG4TpcEndCapDisplayAction(const std::string &name)
+  : PHG4DisplayAction(name)
+{
+}
+
+PHG4TpcEndCapDisplayAction::~PHG4TpcEndCapDisplayAction()
+{
+  for (auto &it : m_VisAttVec)
+  {
+    delete it;
+  }
+  m_VisAttVec.clear();
+}
+
+void PHG4TpcEndCapDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
+{
+  // check if vis attributes exist, if so someone else has set them and we do nothing
+  for (auto it : m_LogicalVolumeMap)
+  {
+    G4LogicalVolume *logvol = it.first;
+    if (logvol->GetVisAttributes())
+    {
+      continue;
+    }
+    G4VisAttributes *visatt = new G4VisAttributes();
+    visatt->SetVisibility(true);
+    visatt->SetForceSolid(true);
+    m_VisAttVec.push_back(visatt);  // for later deletion
+                                    //    if (it.second == "SectorDetector")
+                                    //    {
+    PHG4Utils::SetColour(visatt, it.first->GetMaterial()->GetName());
+    //    }
+    //    else if (it.second == "DetectorBox")
+    //    {
+    //      visatt->SetColour(G4Colour::White());
+    //      visatt->SetForceWireframe(true);
+    //      visatt->SetForceLineSegmentsPerCircle(50);
+    //    }
+    //    else
+    //    {
+    //      cout << "unknown logical volume " << it.second << endl;
+    //      gSystem->Exit(1);
+    //    }
+    logvol->SetVisAttributes(visatt);
+  }
+  return;
+}

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
@@ -46,7 +46,7 @@ void PHG4TpcEndCapDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     visatt->SetForceSolid(true);
     m_VisAttVec.push_back(visatt);  // for later deletion
 
-    if (it.second == "G10")
+    if (it.second == "G10" or it.second == "FR4")
     {
       visatt->SetColour(G4Colour(0.0, .8, 0.0));
     }

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.h
@@ -1,0 +1,31 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4TpcEndCapDisplayAction_H
+#define G4DETECTORS_PHG4TpcEndCapDisplayAction_H
+
+#include <g4main/PHG4DisplayAction.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+class G4VisAttributes;
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+
+class PHG4TpcEndCapDisplayAction : public PHG4DisplayAction
+{
+ public:
+  PHG4TpcEndCapDisplayAction(const std::string &name);
+
+  virtual ~PHG4TpcEndCapDisplayAction();
+
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
+
+ private:
+  std::map<G4LogicalVolume *, std::string> m_LogicalVolumeMap;
+  std::vector<G4VisAttributes *> m_VisAttVec;
+};
+
+#endif  // G4DETECTORS_PHG4TpcEndCapDisplayAction_H

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSteppingAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSteppingAction.cc
@@ -1,0 +1,358 @@
+//____________________________________________________________________________..
+//
+// This is a working template for the Stepping Action which needs to be implemented
+// for active detectors. Most of the code is error handling and access to the G4 objects
+// and our data structures. It does not need any adjustment. The only thing you need to
+// do is to add the properties of the G4Hits you want to save for later analysis
+// This needs to be done in 2 places, G4Hits are generated when a G4 track enters a new
+// volume (or is created). Here you give it an initial value. When the G4 track leaves
+// the volume the final value needs to be set.
+// The places to do this is marked by //implement your own here//
+//
+// As guidance you can look at the total (integrated over all steps in a volume) energy
+// deposit which should always be saved.
+// Additionally the total ionization energy is saved - this can be removed if you are not
+// interested in this. Naturally you may want remove these comments in your version
+//
+//____________________________________________________________________________..
+
+#include "PHG4TpcEndCapSteppingAction.h"
+
+#include "PHG4TpcEndCapDetector.h"
+
+#include <phparameter/PHParameters.h>
+
+#include <g4detectors/PHG4StepStatusDecode.h>
+
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
+#include <g4main/PHG4SteppingAction.h>
+#include <g4main/PHG4TrackUserInfoV1.h>
+
+#include <phool/getClass.h>
+
+#include <TSystem.h>
+
+#include <Geant4/G4ParticleDefinition.hh> 
+#include <Geant4/G4ReferenceCountedHandle.hh>
+#include <Geant4/G4Step.hh>
+#include <Geant4/G4StepPoint.hh> 
+#include <Geant4/G4StepStatus.hh>
+#include <Geant4/G4String.hh> 
+#include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4ThreeVector.hh>
+#include <Geant4/G4TouchableHandle.hh>
+#include <Geant4/G4Track.hh>
+#include <Geant4/G4TrackStatus.hh>
+#include <Geant4/G4Types.hh>
+#include <Geant4/G4VPhysicalVolume.hh>
+#include <Geant4/G4VTouchable.hh>
+#include <Geant4/G4VUserTrackInformation.hh>
+
+#include <cmath>
+#include <iostream>
+#include <string>
+
+class PHCompositeNode;
+
+using namespace std;
+
+//____________________________________________________________________________..
+PHG4TpcEndCapSteppingAction::PHG4TpcEndCapSteppingAction(PHG4TpcEndCapDetector *detector, const PHParameters *parameters)
+  : PHG4SteppingAction(detector->GetName())
+  , m_Detector(detector)
+  , m_Params(parameters)
+  , m_HitContainer(nullptr)
+  , m_Hit(nullptr)
+  , m_SaveHitContainer(nullptr)
+  , m_SaveVolPre(nullptr)
+  , m_SaveVolPost(nullptr)
+  , m_SaveTrackId(-1)
+  , m_SavePreStepStatus(-1)
+  , m_SavePostStepStatus(-1)
+  , m_ActiveFlag(m_Params->get_int_param("active"))
+  , m_BlackHoleFlag(m_Params->get_int_param("blackhole"))
+  , m_EdepSum(0)
+  , m_EionSum(0)
+{
+}
+
+//____________________________________________________________________________..
+PHG4TpcEndCapSteppingAction::~PHG4TpcEndCapSteppingAction()
+{
+  // if the last hit was a zero energie deposit hit, it is just reset
+  // and the memory is still allocated, so we need to delete it here
+  // if the last hit was saved, hit is a nullptr pointer which are
+  // legal to delete (it results in a no operation)
+  delete m_Hit;
+}
+
+//____________________________________________________________________________..
+// This is the implementation of the G4 UserSteppingAction
+bool PHG4TpcEndCapSteppingAction::UserSteppingAction(const G4Step *aStep,bool was_used)
+{
+  G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
+  G4TouchableHandle touchpost = aStep->GetPostStepPoint()->GetTouchableHandle();
+  // get volume of the current step
+  G4VPhysicalVolume *volume = touch->GetVolume();
+  // IsInDetector(volume) returns
+  //  == 0 outside of detector
+  //   > 0 for hits in active volume
+  //  < 0 for hits in passive material
+  int whichactive = m_Detector->IsInDetector(volume);
+  if (!whichactive)
+  {
+    return false;
+  }
+  // collect energy and track length step by step
+  G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
+  G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
+  const G4Track *aTrack = aStep->GetTrack();
+  // if this detector stops everything, just put all kinetic energy into edep
+  if (m_BlackHoleFlag)
+  {
+    edep = aTrack->GetKineticEnergy() / GeV;
+    G4Track *killtrack = const_cast<G4Track *>(aTrack);
+    killtrack->SetTrackStatus(fStopAndKill);
+  }
+  // we use here only one detector in this simple example
+  // if you deal with multiple detectors in this stepping action
+  // the detector id can be used to distinguish between them
+  // hits can easily be analyzed later according to their detector id
+  int detector_id = 0;  // we use here only one detector in this simple example
+  bool geantino = false;
+  // the check for the pdg code speeds things up, I do not want to make
+  // an expensive string compare for every track when we know
+  // geantino or chargedgeantino has pid=0
+  if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
+      aTrack->GetParticleDefinition()->GetParticleName().find("geantino") !=
+          string::npos)  // this also accounts for "chargedgeantino"
+  {
+    geantino = true;
+  }
+  G4StepPoint *prePoint = aStep->GetPreStepPoint();
+  G4StepPoint *postPoint = aStep->GetPostStepPoint();
+
+// Here we have to decide if we need to create a new hit.  Normally this should 
+// only be neccessary if a G4 Track enters a new volume or is freshly created
+// For this we look at the step status of the prePoint (beginning of the G4 Step).
+// This should be either fGeomBoundary (G4 Track crosses into volume) or 
+// fUndefined (G4 Track newly created)
+// Sadly over the years with different G4 versions we have observed cases where
+// G4 produces "impossible hits" which we try to catch here
+// These errors were always rare and it is not clear if they still exist but we
+// still check for them for safety. We can reproduce G4 runs identically (if given
+// the sequence of random number seeds you find in the log), the printouts help
+// us giving the G4 support information about those failures
+// 
+  switch (prePoint->GetStepStatus())
+  {
+  case fPostStepDoItProc:
+    if (m_SavePostStepStatus != fGeomBoundary)
+    {
+      // this is the okay case, fPostStepDoItProc called in a volume, not first thing inside
+      // a new volume, just proceed here
+      break;
+    }
+    else
+    {
+      // this is an impossible G4 Step print out diagnostic to help debug, not sure if
+      // this is still with us
+      cout << GetName() << ": New Hit for  " << endl;
+      cout << "prestep status: "
+           << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+           << ", poststep status: "
+           << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+           << ", last pre step status: "
+           << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+           << ", last post step status: "
+           << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << endl;
+      cout << "last track: " << m_SaveTrackId
+           << ", current trackid: " << aTrack->GetTrackID() << endl;
+      cout << "phys pre vol: " << volume->GetName()
+           << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+      cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+           << " previous phys post vol: " << m_SaveVolPost->GetName() << endl;
+    }
+// These are the normal cases
+  case fGeomBoundary:
+  case fUndefined:
+    if (!m_Hit)
+    {
+      m_Hit = new PHG4Hitv1();
+    }
+    m_Hit->set_layer(detector_id);
+    // here we set the entrance values in cm
+    m_Hit->set_x(0, prePoint->GetPosition().x() / cm);
+    m_Hit->set_y(0, prePoint->GetPosition().y() / cm);
+    m_Hit->set_z(0, prePoint->GetPosition().z() / cm);
+    // time in ns
+    m_Hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+    // set the track ID
+    m_Hit->set_trkid(aTrack->GetTrackID());
+    m_SaveTrackId = aTrack->GetTrackID();
+    // set the initial energy deposit
+    m_EdepSum = 0;
+    // implement your own here://
+    // add the properties you are interested in via set_XXX methods
+    // you can find existing set methods in $OFFLINE_MAIN/include/g4main/PHG4Hit.h
+    // this is initialization of your value. This is not needed you can just set the final
+    // value at the last step in this volume later one
+    if (whichactive > 0)
+    {
+      m_EionSum = 0;  // assuming the ionization energy is only needed for active
+                      // volumes (scintillators)
+      m_Hit->set_eion(0);
+      m_SaveHitContainer = m_HitContainer;
+    }
+    else
+    {
+      cout << "implement stuff for whichactive < 0 (inactive volumes)" << endl;
+      gSystem->Exit(1);
+    }
+    // this is for the tracking of the truth info
+    if (G4VUserTrackInformation *p = aTrack->GetUserInformation())
+    {
+      if (PHG4TrackUserInfoV1 *pp = dynamic_cast<PHG4TrackUserInfoV1 *>(p))
+      {
+        m_Hit->set_trkid(pp->GetUserTrackId());
+        pp->GetShower()->add_g4hit_id(m_SaveHitContainer->GetID(), m_Hit->get_hit_id());
+      }
+    }
+    break;
+  default:
+    break;
+  }
+
+  // This section is called for every step
+  // some sanity checks for inconsistencies (aka bugs) we have seen over the years
+  // check if this hit was created, if not print out last post step status
+  if (!m_Hit || !isfinite(m_Hit->get_x(0)))
+  {
+    cout << GetName() << ": hit was not created" << endl;
+    cout << "prestep status: "
+         << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+         << ", poststep status: "
+         << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+         << ", last pre step status: "
+         << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+         << ", last post step status: "
+         << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << endl;
+    cout << "last track: " << m_SaveTrackId
+         << ", current trackid: " << aTrack->GetTrackID() << endl;
+    cout << "phys pre vol: " << volume->GetName()
+         << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+    cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+         << " previous phys post vol: " << m_SaveVolPost->GetName() << endl;
+    // This is fatal - a hit from nowhere. This needs to be looked at and fixed
+    gSystem->Exit(1);
+  }
+  // check if track id matches the initial one when the hit was created
+  if (aTrack->GetTrackID() != m_SaveTrackId)
+  {
+    cout << GetName() << ": hits do not belong to the same track" << endl;
+    cout << "saved track: " << m_SaveTrackId
+         << ", current trackid: " << aTrack->GetTrackID()
+         << ", prestep status: " << prePoint->GetStepStatus()
+         << ", previous post step status: " << m_SavePostStepStatus << endl;
+    // This is fatal - a hit from nowhere. This needs to be looked at and fixed
+    gSystem->Exit(1);
+  }
+
+// We need to cache a few things from one step to the next
+// to identify impossible hits and subsequent debugging printout
+  m_SavePreStepStatus = prePoint->GetStepStatus();
+  m_SavePostStepStatus = postPoint->GetStepStatus();
+  m_SaveVolPre = volume;
+  m_SaveVolPost = touchpost->GetVolume();
+  // here we just update the exit values, it will be overwritten
+  // for every step until we leave the volume or the particle
+  // ceases to exist
+  // sum up the energy to get total deposited
+  m_EdepSum += edep;
+  if (whichactive > 0)
+  {
+    m_EionSum += eion;
+  }
+  // if any of these conditions is true this is the last step in
+  // this volume and we need to save the hit
+  // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
+  // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
+  // (happens when your detector goes outside world volume)
+  // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
+  // aTrack->GetTrackStatus() == fStopAndKill is also set)
+  // aTrack->GetTrackStatus() == fStopAndKill: track ends
+  if (postPoint->GetStepStatus() == fGeomBoundary ||
+      postPoint->GetStepStatus() == fWorldBoundary ||
+      postPoint->GetStepStatus() == fAtRestDoItProc ||
+      aTrack->GetTrackStatus() == fStopAndKill)
+  {
+    // save only hits with energy deposit (or geantino)
+    if (m_EdepSum > 0 || geantino)
+    {
+      // update values at exit coordinates and set keep flag
+      // of track to keep
+      m_Hit->set_x(1, postPoint->GetPosition().x() / cm);
+      m_Hit->set_y(1, postPoint->GetPosition().y() / cm);
+      m_Hit->set_z(1, postPoint->GetPosition().z() / cm);
+      m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+      if (G4VUserTrackInformation *p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1 *pp = dynamic_cast<PHG4TrackUserInfoV1 *>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
+      }
+      if (geantino)
+      {
+ //implement your own here://
+ // if you want to do something special for geantinos (normally you do not)
+        m_Hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way
+                              // geantinos survive the g4hit compression
+        if (whichactive > 0)
+        {
+          m_Hit->set_eion(-1);
+        }
+      }
+      else
+      {
+        m_Hit->set_edep(m_EdepSum);
+      }
+ //implement your own here://
+ // what you set here will be saved in the output
+      if (whichactive > 0)
+      {
+        m_Hit->set_eion(m_EionSum);
+      }
+      m_SaveHitContainer->AddHit(detector_id, m_Hit);
+      // ownership has been transferred to container, set to null
+      // so we will create a new hit for the next track
+      m_Hit = nullptr;
+    }
+    else
+    {
+      // if this hit has no energy deposit, just reset it for reuse
+      // this means we have to delete it in the dtor. If this was
+      // the last hit we processed the memory is still allocated
+      m_Hit->Reset();
+    }
+  }
+  // return true to indicate the hit was used
+  return true;
+}
+
+//____________________________________________________________________________..
+void PHG4TpcEndCapSteppingAction::SetInterfacePointers(PHCompositeNode *topNode)
+{
+  string hitnodename = "G4HIT_" + m_Detector->GetName();
+  // now look for the map and grab a pointer to it.
+  m_HitContainer = findNode::getClass<PHG4HitContainer>(topNode, hitnodename);
+  // if we do not find the node we need to make it.
+  if (!m_HitContainer)
+  {
+    std::cout << "PHG4TpcEndCapSteppingAction::SetTopNode - unable to find "
+              << hitnodename << std::endl;
+  }
+}

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSteppingAction.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSteppingAction.h
@@ -1,0 +1,52 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef PHG4TPCENDCAPSTEPPINGACTION_H
+#define PHG4TPCENDCAPSTEPPINGACTION_H
+
+#include <g4main/PHG4SteppingAction.h>
+
+class PHG4TpcEndCapDetector;
+
+class G4Step;
+class G4VPhysicalVolume;
+class PHCompositeNode;
+class PHG4Hit;
+class PHG4HitContainer;
+class PHParameters;
+
+class PHG4TpcEndCapSteppingAction : public PHG4SteppingAction
+{
+ public:
+  //! constructor
+  PHG4TpcEndCapSteppingAction(PHG4TpcEndCapDetector*, const PHParameters* parameters);
+
+  //! destructor
+  virtual ~PHG4TpcEndCapSteppingAction();
+
+  //! stepping action
+  virtual bool UserSteppingAction(const G4Step*, bool);
+
+  //! reimplemented from base class
+  virtual void SetInterfacePointers(PHCompositeNode*);
+
+ private:
+  //! pointer to the detector
+  PHG4TpcEndCapDetector* m_Detector;
+  const PHParameters* m_Params;
+  //! pointer to hit container
+  PHG4HitContainer* m_HitContainer;
+  PHG4Hit* m_Hit;
+  PHG4HitContainer* m_SaveHitContainer;
+  G4VPhysicalVolume* m_SaveVolPre;
+  G4VPhysicalVolume* m_SaveVolPost;
+
+  int m_SaveTrackId;
+  int m_SavePreStepStatus;
+  int m_SavePostStepStatus;
+  int m_ActiveFlag;
+  int m_BlackHoleFlag;
+  double m_EdepSum;
+  double m_EionSum;
+};
+
+#endif // PHG4TPCENDCAPSTEPPINGACTION_H

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
@@ -1,0 +1,117 @@
+//____________________________________________________________________________..
+//
+// This is the interface to the framework. You only need to define the parameters
+// you use for your detector in the SetDefaultParameters() method here
+// The place to do this is marked by //implement your own here//
+// The parameters have no units, they need to be converted in the
+// PHG4TpcEndCapDetector::ConstructMe() method
+// but the convention is as mentioned cm and deg
+//____________________________________________________________________________..
+//
+#include "PHG4TpcEndCapSubsystem.h"
+
+#include "PHG4TpcEndCapDetector.h"
+#include "PHG4TpcEndCapSteppingAction.h"
+
+#include <phparameter/PHParameters.h>
+
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4SteppingAction.h> 
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNode.h> 
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/getClass.h>
+
+using namespace std;
+
+//_______________________________________________________________________
+PHG4TpcEndCapSubsystem::PHG4TpcEndCapSubsystem(const std::string &name)
+  : PHG4DetectorSubsystem(name)
+  , m_Detector(nullptr)
+  , m_SteppingAction(nullptr)
+{
+  // call base class method which will set up parameter infrastructure
+  // and call our SetDefaultParameters() method
+  InitializeParameters();
+}
+//_______________________________________________________________________
+int PHG4TpcEndCapSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  PHNodeIterator dstIter(dstNode);
+  if (GetParams()->get_int_param("active"))
+  {
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", Name()));
+    if (!DetNode)
+    {
+      DetNode = new PHCompositeNode(Name());
+      dstNode->addNode(DetNode);
+    }
+    string g4hitnodename = "G4HIT_" + Name();
+    PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(DetNode, g4hitnodename);
+    if (!g4_hits)
+    {
+      g4_hits = new PHG4HitContainer(g4hitnodename);
+      DetNode->addNode(new PHIODataNode<PHObject>(g4_hits, g4hitnodename, "PHObject"));
+    }
+  }
+  // create detector
+  m_Detector = new PHG4TpcEndCapDetector(this, topNode, GetParams(), Name());
+  m_Detector->OverlapCheck(CheckOverlap());
+  // create stepping action if detector is active
+  if (GetParams()->get_int_param("active"))
+  {
+    m_SteppingAction = new PHG4TpcEndCapSteppingAction(m_Detector, GetParams());
+  }
+  return 0;
+}
+//_______________________________________________________________________
+int PHG4TpcEndCapSubsystem::process_event(PHCompositeNode *topNode)
+{
+  // pass top node to stepping action so that it gets
+  // relevant nodes needed internally
+  if (m_SteppingAction)
+  {
+    m_SteppingAction->SetInterfacePointers(topNode);
+  }
+  return 0;
+}
+//_______________________________________________________________________
+void PHG4TpcEndCapSubsystem::Print(const string &what) const
+{
+  if (m_Detector)
+  {
+    m_Detector->Print(what);
+  }
+  return;
+}
+
+//_______________________________________________________________________
+PHG4Detector *PHG4TpcEndCapSubsystem::GetDetector(void) const
+{
+  return m_Detector;
+}
+
+//_______________________________________________________________________
+void PHG4TpcEndCapSubsystem::SetDefaultParameters()
+{
+  // sizes are in cm
+  // angles are in deg
+  // units should be converted to G4 units when used
+  //implement your own here//
+  set_default_double_param("place_x", 0.);
+  set_default_double_param("place_y", 0.);
+  set_default_double_param("place_z", 0.);
+  set_default_double_param("rot_x", 0.);
+  set_default_double_param("rot_y", 0.);
+  set_default_double_param("rot_z", 0.);
+  set_default_double_param("size_x", 20.);
+  set_default_double_param("size_y", 20.);
+  set_default_double_param("size_z", 20.);
+
+  set_default_string_param("material", "G4_Cu");
+}

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
@@ -112,6 +112,7 @@ PHG4Detector *PHG4TpcEndCapSubsystem::GetDetector(void) const
 //_______________________________________________________________________
 void PHG4TpcEndCapSubsystem::SetDefaultParameters()
 {
+  set_default_int_param("construction_verbosity", 0);
   // sizes are in cm
   // angles are in deg
   // units should be converted to G4 units when used
@@ -125,7 +126,7 @@ void PHG4TpcEndCapSubsystem::SetDefaultParameters()
 
   set_default_double_param("envelop_r_min", 20.);
   set_default_double_param("envelop_r_max", 79.);
-  set_default_double_param("envelop_front_surface_z", 211./2.);
+  set_default_double_param("envelop_front_surface_z", 211. / 2.);
 
   set_default_int_param("n_GEM_layers", 4);
 
@@ -145,7 +146,7 @@ void PHG4TpcEndCapSubsystem::SetDefaultParameters()
   set_default_double_param("wagon_wheel_front_frame_R_outer", inch_to_cm * 30.7);
 
   set_default_double_param("wagon_wheel_front_frame_R_R1_inner", inch_to_cm * 9.81);
-  set_default_double_param("wagon_wheel_front_frame_R_R1_outer", inch_to_cm * 15.74);
+  set_default_double_param("wagon_wheel_front_frame_R_R1_outer", inch_to_cm * 15.47);
 
   set_default_double_param("wagon_wheel_front_frame_R_R2_inner", inch_to_cm * 16.59);
   set_default_double_param("wagon_wheel_front_frame_R_R2_outer", inch_to_cm * 22.24);
@@ -154,6 +155,36 @@ void PHG4TpcEndCapSubsystem::SetDefaultParameters()
   set_default_double_param("wagon_wheel_front_frame_R_R3_outer", inch_to_cm * 29.02);
 
   set_default_double_param("wagon_wheel_rim_outer_Rin", inch_to_cm * 29.58);
-  set_default_double_param("wagon_wheel_rim_outer_Rout", inch_to_cm * 60.49/2.);
+  set_default_double_param("wagon_wheel_rim_outer_Rout", inch_to_cm * 60.49 / 2.);
   set_default_double_param("wagon_wheel_rim_outer_thickness", inch_to_cm * (4.5 - .38));
+
+  set_default_double_param("wagon_wheel_spoke_width", inch_to_cm * .36);
+  set_default_double_param("wagon_wheel_spoke_height_inner", inch_to_cm * (1.715 - .38));
+  set_default_double_param("wagon_wheel_spoke_height_outer", inch_to_cm * (4.5 - .38));
+  set_default_double_param("wagon_wheel_spoke_R_inner", inch_to_cm * 9);
+  set_default_double_param("wagon_wheel_spoke_R_outer", inch_to_cm * 29.5);
+
+  set_default_int_param("electronics_nFEE_R1", 6);
+  set_default_int_param("electronics_nFEE_R2", 8);
+  set_default_int_param("electronics_nFEE_R3", 12);
+
+  set_default_double_param("electronics_FEE_depth", inch_to_cm * 15.74 / 2.);
+  set_default_double_param("electronics_FEE_Cu_thickness", 35e-4);
+  set_default_double_param("electronics_FEE_PCB_thickness", 0.2);
+  set_default_double_param("electronics_FEE_Al_thickness", 0.2);
+
+  set_default_string_param("electronics_cooling_block_material", "G4_Al");
+  set_default_double_param("electronics_cooling_block_thickness", inch_to_cm * 3.5);
+
+  set_default_double_param("electronics_cooling_block_R_inner", inch_to_cm * 9.26);
+  set_default_double_param("electronics_cooling_block_R_outer", inch_to_cm * 29.57);
+
+  set_default_double_param("electronics_cooling_block_R_R1_inner", inch_to_cm * 9.81);
+  set_default_double_param("electronics_cooling_block_R_R1_outer", inch_to_cm * 15.47);
+
+  set_default_double_param("electronics_cooling_block_R_R2_inner", inch_to_cm * 16.59);
+  set_default_double_param("electronics_cooling_block_R_R2_outer", inch_to_cm * 22.24);
+
+  set_default_double_param("electronics_cooling_block_R_R3_inner", inch_to_cm * 23.36);
+  set_default_double_param("electronics_cooling_block_R_R3_outer", inch_to_cm * 29.02);
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
@@ -11,16 +11,17 @@
 #include "PHG4TpcEndCapSubsystem.h"
 
 #include "PHG4TpcEndCapDetector.h"
+#include "PHG4TpcEndCapDisplayAction.h"
 #include "PHG4TpcEndCapSteppingAction.h"
 
 #include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h> 
+#include <g4main/PHG4SteppingAction.h>
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h> 
+#include <phool/PHNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>
 #include <phool/getClass.h>
@@ -32,17 +33,29 @@ PHG4TpcEndCapSubsystem::PHG4TpcEndCapSubsystem(const std::string &name)
   : PHG4DetectorSubsystem(name)
   , m_Detector(nullptr)
   , m_SteppingAction(nullptr)
+  , m_DisplayAction(nullptr)
 {
   // call base class method which will set up parameter infrastructure
   // and call our SetDefaultParameters() method
   InitializeParameters();
 }
+
+PHG4TpcEndCapSubsystem::~PHG4TpcEndCapSubsystem()
+{
+  if (m_DisplayAction)
+    delete m_DisplayAction;
+}
+
 //_______________________________________________________________________
 int PHG4TpcEndCapSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   PHNodeIterator dstIter(dstNode);
+
+  // create display settings before detector (detector adds its volumes to it)
+  m_DisplayAction = new PHG4TpcEndCapDisplayAction(Name());
+
   if (GetParams()->get_int_param("active"))
   {
     PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", Name()));
@@ -109,9 +122,12 @@ void PHG4TpcEndCapSubsystem::SetDefaultParameters()
   set_default_double_param("rot_x", 0.);
   set_default_double_param("rot_y", 0.);
   set_default_double_param("rot_z", 0.);
-  set_default_double_param("size_x", 20.);
-  set_default_double_param("size_y", 20.);
-  set_default_double_param("size_z", 20.);
+
+  set_default_double_param("envelop_r_min", 20.);
+  set_default_double_param("envelop_r_max", 80.);
+  set_default_double_param("envelop_front_surface_z", 105.);
+
+  set_default_int_param("n_GEM_layers", 4);
 
   set_default_string_param("material", "G4_Cu");
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
@@ -132,10 +132,14 @@ void PHG4TpcEndCapSubsystem::SetDefaultParameters()
   const double inch_to_cm = 2.54;
 
   set_default_int_param("n_sectors", 12);
+  set_default_int_param("n_radial_modules", 3);
 
   set_default_string_param("wagon_wheel_material", "G4_Al");
 
+  set_default_double_param("wagon_wheel_sector_phi_offset_degree", 0);
+
   set_default_double_param("wagon_wheel_front_frame_thickness", inch_to_cm * .38);
+  set_default_double_param("wagon_wheel_front_frame_spoke_width", inch_to_cm * 1.12);
 
   set_default_double_param("wagon_wheel_front_frame_R_inner", inch_to_cm * 15.74 / 2.);
   set_default_double_param("wagon_wheel_front_frame_R_outer", inch_to_cm * 30.7);
@@ -148,4 +152,8 @@ void PHG4TpcEndCapSubsystem::SetDefaultParameters()
 
   set_default_double_param("wagon_wheel_front_frame_R_R3_inner", inch_to_cm * 23.36);
   set_default_double_param("wagon_wheel_front_frame_R_R3_outer", inch_to_cm * 29.02);
+
+  set_default_double_param("wagon_wheel_rim_outer_Rin", inch_to_cm * 29.58);
+  set_default_double_param("wagon_wheel_rim_outer_Rout", inch_to_cm * 60.49/2.);
+  set_default_double_param("wagon_wheel_rim_outer_thickness", inch_to_cm * (4.5 - .38));
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
@@ -124,10 +124,28 @@ void PHG4TpcEndCapSubsystem::SetDefaultParameters()
   set_default_double_param("rot_z", 0.);
 
   set_default_double_param("envelop_r_min", 20.);
-  set_default_double_param("envelop_r_max", 80.);
+  set_default_double_param("envelop_r_max", 79.);
   set_default_double_param("envelop_front_surface_z", 105.);
 
   set_default_int_param("n_GEM_layers", 4);
 
-  set_default_string_param("material", "G4_Cu");
+  const double inch_to_cm = 2.54;
+
+  set_default_int_param("n_sectors", 12);
+
+  set_default_string_param("wagon_wheel_material", "G4_Al");
+
+  set_default_double_param("wagon_wheel_front_frame_thickness", inch_to_cm * .38);
+
+  set_default_double_param("wagon_wheel_front_frame_R_inner", inch_to_cm * 15.74 / 2.);
+  set_default_double_param("wagon_wheel_front_frame_R_outer", inch_to_cm * 30.7);
+
+  set_default_double_param("wagon_wheel_front_frame_R_R1_inner", inch_to_cm * 9.81);
+  set_default_double_param("wagon_wheel_front_frame_R_R1_outer", inch_to_cm * 15.74);
+
+  set_default_double_param("wagon_wheel_front_frame_R_R2_inner", inch_to_cm * 16.59);
+  set_default_double_param("wagon_wheel_front_frame_R_R2_outer", inch_to_cm * 22.24);
+
+  set_default_double_param("wagon_wheel_front_frame_R_R3_inner", inch_to_cm * 23.36);
+  set_default_double_param("wagon_wheel_front_frame_R_R3_outer", inch_to_cm * 29.02);
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
@@ -125,7 +125,7 @@ void PHG4TpcEndCapSubsystem::SetDefaultParameters()
 
   set_default_double_param("envelop_r_min", 20.);
   set_default_double_param("envelop_r_max", 79.);
-  set_default_double_param("envelop_front_surface_z", 105.);
+  set_default_double_param("envelop_front_surface_z", 211./2.);
 
   set_default_int_param("n_GEM_layers", 4);
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
@@ -169,10 +169,11 @@ void PHG4TpcEndCapSubsystem::SetDefaultParameters()
   set_default_int_param("electronics_nFEE_R2", 8);
   set_default_int_param("electronics_nFEE_R3", 12);
 
-  set_default_double_param("electronics_FEE_depth", inch_to_cm * 15.74 / 2.);
-  set_default_double_param("electronics_FEE_Cu_thickness", 35e-4);
-  set_default_double_param("electronics_FEE_PCB_thickness", 0.2);
-  set_default_double_param("electronics_FEE_Al_thickness", 0.2);
+  // 10 layer PCB: https://indico.bnl.gov/event/8332/
+  set_default_double_param("electronics_FEE_depth", inch_to_cm * 5.57);
+  set_default_double_param("electronics_FEE_Cu_thickness", 35e-4 * 10 * .8);  // 1.4mil Copper 80% filling factor
+  set_default_double_param("electronics_FEE_PCB_thickness", inch_to_cm * 0.07);
+  set_default_double_param("electronics_FEE_Al_thickness", inch_to_cm * .13);
 
   set_default_string_param("electronics_cooling_block_material", "G4_Al");
   set_default_double_param("electronics_cooling_block_thickness", inch_to_cm * 3.5);

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
@@ -164,6 +164,7 @@ void PHG4TpcEndCapSubsystem::SetDefaultParameters()
   set_default_double_param("wagon_wheel_spoke_R_inner", inch_to_cm * 9);
   set_default_double_param("wagon_wheel_spoke_R_outer", inch_to_cm * 29.5);
 
+  set_default_int_param("electronics_enable", 1);
   set_default_int_param("electronics_nFEE_R1", 6);
   set_default_int_param("electronics_nFEE_R2", 8);
   set_default_int_param("electronics_nFEE_R3", 12);

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.cc
@@ -137,7 +137,7 @@ void PHG4TpcEndCapSubsystem::SetDefaultParameters()
 
   set_default_string_param("wagon_wheel_material", "G4_Al");
 
-  set_default_double_param("wagon_wheel_sector_phi_offset_degree", 0);
+  set_default_double_param("wagon_wheel_sector_phi_offset_degree", 360./12./2.);
 
   set_default_double_param("wagon_wheel_front_frame_thickness", inch_to_cm * .38);
   set_default_double_param("wagon_wheel_front_frame_spoke_width", inch_to_cm * 1.12);

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.h
@@ -9,6 +9,7 @@ class PHCompositeNode;
 class PHG4Detector;
 class PHG4TpcEndCapDetector;
 class PHG4SteppingAction;
+class PHG4DisplayAction;
 
 /**
    * \brief Detector Subsystem module
@@ -27,7 +28,7 @@ class PHG4TpcEndCapSubsystem : public PHG4DetectorSubsystem
   PHG4TpcEndCapSubsystem(const std::string& name = "PHG4TpcEndCap");
 
   //! destructor
-  virtual ~PHG4TpcEndCapSubsystem() {}
+  virtual ~PHG4TpcEndCapSubsystem() ;
 
   /*!
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
@@ -55,11 +56,15 @@ class PHG4TpcEndCapSubsystem : public PHG4DetectorSubsystem
  private:
   //! detector construction
   /*! derives from PHG4Detector */
-  PHG4TpcEndCapDetector  *m_Detector;
+  PHG4TpcEndCapDetector* m_Detector;
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
-  PHG4SteppingAction *m_SteppingAction;
+  PHG4SteppingAction* m_SteppingAction;
+
+  //! display attribute setting
+  /*! derives from PHG4DisplayAction */
+  PHG4DisplayAction *m_DisplayAction;
 };
 
-#endif // PHG4TPCENDCAPSUBSYSTEM_H
+#endif  // PHG4TPCENDCAPSUBSYSTEM_H

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.h
@@ -49,6 +49,8 @@ class PHG4TpcEndCapSubsystem : public PHG4DetectorSubsystem
   //! Print info (from SubsysReco)
   void Print(const std::string& what = "ALL") const override;
 
+  PHG4DisplayAction *GetDisplayAction()   const override { return m_DisplayAction; }
+
  protected:
   // \brief Set default parameter values
   void SetDefaultParameters() override;

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.h
@@ -1,0 +1,65 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef PHG4TPCENDCAPSUBSYSTEM_H
+#define PHG4TPCENDCAPSUBSYSTEM_H
+
+#include <g4detectors/PHG4DetectorSubsystem.h>
+
+class PHCompositeNode;
+class PHG4Detector;
+class PHG4TpcEndCapDetector;
+class PHG4SteppingAction;
+
+/**
+   * \brief Detector Subsystem module
+   *
+   * The detector is constructed and registered via PHG4TpcEndCapDetector
+   *
+   *
+   * \see PHG4TpcEndCapDetector
+   * \see PHG4TpcEndCapSubsystem
+   *
+   */
+class PHG4TpcEndCapSubsystem : public PHG4DetectorSubsystem
+{
+ public:
+  //! constructor
+  PHG4TpcEndCapSubsystem(const std::string& name = "PHG4TpcEndCap");
+
+  //! destructor
+  virtual ~PHG4TpcEndCapSubsystem() {}
+
+  /*!
+  creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
+  */
+  int InitRunSubsystem(PHCompositeNode*) override;
+
+  //! event processing
+  /*!
+  get all relevant nodes from top nodes (namely hit list)
+  and pass that to the stepping action
+  */
+  int process_event(PHCompositeNode*) override;
+
+  //! accessors (reimplemented)
+  PHG4Detector* GetDetector() const override;
+
+  PHG4SteppingAction* GetSteppingAction() const override { return m_SteppingAction; }
+  //! Print info (from SubsysReco)
+  void Print(const std::string& what = "ALL") const override;
+
+ protected:
+  // \brief Set default parameter values
+  void SetDefaultParameters() override;
+
+ private:
+  //! detector construction
+  /*! derives from PHG4Detector */
+  PHG4TpcEndCapDetector  *m_Detector;
+
+  //! particle tracking "stepping" action
+  /*! derives from PHG4SteppingActions */
+  PHG4SteppingAction *m_SteppingAction;
+};
+
+#endif // PHG4TPCENDCAPSUBSYSTEM_H

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4TpcPadPlane - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadoutLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadoutLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4TpcPadPlaneReadout - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneSimpleLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneSimpleLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4TpcPadPlaneSimple - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4tpc/PHG4TpcSpaceChargeDistortionLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSpaceChargeDistortionLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4TpcSpaceChargeDistortion - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystemLinkDef.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystemLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHG4TpcSubsystem - !;
-
-#endif /* __CINT__ */

--- a/simulation/g4simulation/g4tpc/configure.ac
+++ b/simulation/g4simulation/g4tpc/configure.ac
@@ -14,12 +14,8 @@ case $CXX in
  ;;
 esac
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
-fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
TPC endcap in the current engineering model added into in simulation, for forward detector simulations at both sPHENIX and EIC.

Direct importing the CAD model is slow to run and incompatible with the Kalman filter (TGeoGeometry). Therefore, this PR introduce a simplified model coded in Geant4.

## TPC with endcap

### CAD
![image](https://user-images.githubusercontent.com/7947083/93162986-fc5a3200-f6e3-11ea-87bd-70247ea1cefe.png)

### Simulation
![image](https://user-images.githubusercontent.com/7947083/93163004-0a0fb780-f6e4-11ea-899c-039ba7bbb626.png)


## End-cap zoom in

### CAD
![image](https://user-images.githubusercontent.com/7947083/93163242-9a4dfc80-f6e4-11ea-9830-dd3ee46657d5.png)

### Simulation
![image](https://user-images.githubusercontent.com/7947083/93163206-84403c00-f6e4-11ea-9787-b354a55018fe.png)
![image](https://user-images.githubusercontent.com/7947083/93163270-ae91f980-f6e4-11ea-89cb-44c447160431.png)


## Wagon wheel

### CAD
![image](https://user-images.githubusercontent.com/7947083/93163307-ca959b00-f6e4-11ea-9aa5-2a57fd10a545.png)

### Simulation
![image](https://user-images.githubusercontent.com/7947083/93163285-b8b3f800-f6e4-11ea-81ce-17da2e1bd5ad.png)

