### PR TITLE
Fix Vertex

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -171,7 +171,9 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
 
 	SvtxTrack *track = m_trackMap->find(trackKey)->second;
 	PHG4Particle *g4particle = trackeval->max_truth_particle_by_nclusters(track);
-	const unsigned int vertexId = track->get_vertex_id();
+	unsigned int vertexId = track->get_vertex_id();
+	if(vertexId == UINT_MAX)
+	  vertexId = 0;
 	const SvtxVertex *svtxVertex = m_vertexMap->get(vertexId);
 	Acts::Vector3D vertex;
 	vertex(0) = svtxVertex->get_x() * Acts::UnitConstants::cm;


### PR DESCRIPTION
The TPC seeders do not associate the track seed to the vertex. This causes a crash in the acts evaluator when it tries to access an unallocated vertex. For now we just set it to the 0th vertex until the track stub matchers are implemented.

