### PR TITLE
Correct response file

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -307,7 +307,8 @@ void MakeActsGeometry::buildActsSurfaces()
   // Response file contains arguments necessary for geometry building
   const std::string argstr[argc]{
     "-n1", "-l0", 
-      "--response-file=tgeo-sphenix.response",
+      std::string("--response-file=") + std::string(getenv("OFFLINE_MAIN")) 
+      + std::string("/share/tgeo-sphenix.response"),
       "--bf-values", "0", "0", "1.4"
       };
 


### PR DESCRIPTION
Switch the response file grabbing to `OFFLINE_MAIN` rather than the local directory where the macro is run.