### PR TITLE
epd: make z position of detector configurable

### DIFF
--- a/simulation/g4simulation/g4epd/PHG4EPDSubsystem.cc
+++ b/simulation/g4simulation/g4epd/PHG4EPDSubsystem.cc
@@ -86,4 +86,5 @@ PHG4SteppingAction* PHG4EPDSubsystem::GetSteppingAction() const
 void PHG4EPDSubsystem::SetDefaultParameters()
 {
   set_default_int_param(-1, "active", 1);
+  set_default_double_param(-1, "z_position", 300.);
 }

--- a/simulation/g4simulation/g4epd/PHG4EPDetector.cc
+++ b/simulation/g4simulation/g4epd/PHG4EPDetector.cc
@@ -4,6 +4,9 @@
 
 #include <g4main/PHG4Detector.h>
 
+#include <phparameter/PHParameters.h>
+#include <phparameter/PHParametersContainer.h>
+
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4ExtrudedSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>
@@ -26,6 +29,8 @@ PHG4EPDetector::PHG4EPDetector(PHG4Subsystem* subsys,
                                std::string const& name)
   : PHG4Detector(subsys, node, name)
 {
+  PHParameters const* pars = params->GetParameters(-1);
+  m_z_position = pars->get_double_param("z_position");
 }
 
 void PHG4EPDetector::ConstructMe(G4LogicalVolume* world)
@@ -38,8 +43,8 @@ void PHG4EPDetector::ConstructMe(G4LogicalVolume* world)
   attrs->SetForceSolid(true);
   attrs->SetColour(G4Colour::Red());
 
-  G4ThreeVector positive(0., 0., 300. * cm);
-  G4ThreeVector negative(0., 0., -300. * cm);
+  G4ThreeVector positive(0., 0., m_z_position * cm);
+  G4ThreeVector negative(0., 0., -m_z_position * cm);
 
   constexpr int32_t ntiles = 31;
   constexpr int32_t nslices = 12;

--- a/simulation/g4simulation/g4epd/PHG4EPDetector.h
+++ b/simulation/g4simulation/g4epd/PHG4EPDetector.h
@@ -42,6 +42,8 @@ class PHG4EPDetector : public PHG4Detector
   std::map<G4VPhysicalVolume*, uint32_t> m_volumes;
 
   std::string superdetector;
+
+  double m_z_position;
 };
 
 #endif /* G4EPD_PHG4EPDETECTOR_H */


### PR DESCRIPTION
default position remains at +/- 300 cm.

checked that the position can be configured by `epd->set_double_param(-1, "z_position", 100.);` in `macros/common/G4_EPD.C`