### PR TITLE
Fix phtpctracker memleak

### DIFF
--- a/offline/packages/PHTpcTracker/Makefile.am
+++ b/offline/packages/PHTpcTracker/Makefile.am
@@ -22,6 +22,9 @@ pkginclude_HEADERS = \
   PHTpcTracker.h
 
 
+##############################################
+# please add new classes in alphabetical order
+
 libPHTpcTracker_la_SOURCES = \
   Fitter.cc \
   PHTpcEventExporter.cc \
@@ -46,14 +49,6 @@ libPHTpcTracker_la_LIBADD = \
   -ltrack_reco \
   -ltrack_io
 
-# Rule for generating table CINT dictionaries.
-%_Dict.cc: %.h %LinkDef.h
-	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
-
-#just to get the dependency
-%_Dict_rdict.pcm: %_Dict.cc ;
-
-
 ################################################
 # linking tests
 
@@ -74,8 +69,5 @@ testexternals.cc:
 	echo "  return 0;" >> $@
 	echo "}" >> $@
 
-##############################################
-# please add new classes in alphabetical order
-
 clean-local:
-	rm -f *Dict* $(BUILT_SOURCES) *.pcm
+	rm -f $(BUILT_SOURCES)

--- a/offline/packages/PHTpcTracker/PHTpcTrackFollower.cc
+++ b/offline/packages/PHTpcTracker/PHTpcTrackFollower.cc
@@ -487,7 +487,7 @@ std::pair<genfit::MeasuredStateOnPlane*, double> PHTpcTrackFollower::get_project
 {
   // project from last fitted point to radius
   double pathlength = 0;
-  genfit::MeasuredStateOnPlane* state = 0;
+  genfit::MeasuredStateOnPlane* state = nullptr;
 
   try
   {
@@ -560,10 +560,8 @@ int PHTpcTrackFollower::followTrack(PHGenFit2::Track* track, PHTpcLookup* lookup
     {
       break;
     }  // can't project to cylinder, likely curler track
-    genfit::MeasuredStateOnPlane* state = p.first;
-    TVector3 pos = state->getPos();
-    delete state;
-    state = 0;
+    TVector3 pos = p.first->getPos();
+    delete p.first;
 
     LOG_DEBUG("tracking.PHTpcTrackFollower.followTrack") << "projected position: " << pos.X() << ", " << pos.Y() << ", " << pos.Z() << ", radius: " << pos.Perp();
 
@@ -586,8 +584,8 @@ int PHTpcTrackFollower::followTrack(PHGenFit2::Track* track, PHTpcLookup* lookup
           LOG_DEBUG("tracking.PHTpcTrackFollower.followTrack") << "cannot project to point, skipping";
           break;
         }
-        state = p2.first;
-        TVector3 pos2 = state->getPos();
+        TVector3 pos2 = p2.first->getPos();
+	delete p2.first;
         LOG_DEBUG("tracking.PHTpcTrackFollower.followTrack") << "projected point: " << pos2.X() << ", " << pos2.Y() << ", " << pos2.Z() << ", radius: " << pos.Perp();
         LOG_DEBUG("tracking.PHTpcTrackFollower.followTrack") << "distance to hit: " << std::sqrt(std::pow(pos2.X() - (*hit)[0], 2) + std::pow(pos2.Y() - (*hit)[1], 2) + std::pow(pos2.Z() - (*hit)[2], 2));
 
@@ -633,8 +631,8 @@ int PHTpcTrackFollower::followTrack(PHGenFit2::Track* track, PHTpcLookup* lookup
           {
             continue;
           }
-          state = p2.first;
-          TVector3 pos2 = state->getPos();
+          TVector3 pos2 = p2.first->getPos();
+	  delete p2.first;
           double dist2 = std::sqrt(std::pow(pos2.X() - (*hit)[0], 2) + std::pow(pos2.Y() - (*hit)[1], 2) + std::pow(pos2.Z() - (*hit)[2], 2));
           LOG_DEBUG("tracking.PHTpcTrackFollower.followTrack") << "projected point: " << pos2.X() << ", " << pos2.Y() << ", " << pos2.Z() << ", radius: " << pos.Perp();
           LOG_DEBUG("tracking.PHTpcTrackFollower.followTrack") << "distance to hit: " << dist2;
@@ -673,8 +671,6 @@ int PHTpcTrackFollower::followTrack(PHGenFit2::Track* track, PHTpcLookup* lookup
         }
       }
     }  // else => no hits, scan next layer
-
-    delete state;
 
     layer += dir;
     if (layer < 0 || layer >= PHTpcConst::TPC_LAYERS_MAX)

--- a/offline/packages/PHTpcTracker/PHTpcTrackFollower.cc
+++ b/offline/packages/PHTpcTracker/PHTpcTrackFollower.cc
@@ -585,7 +585,7 @@ int PHTpcTrackFollower::followTrack(PHGenFit2::Track* track, PHTpcLookup* lookup
           break;
         }
         TVector3 pos2 = p2.first->getPos();
-	delete p2.first;
+        delete p2.first;
         LOG_DEBUG("tracking.PHTpcTrackFollower.followTrack") << "projected point: " << pos2.X() << ", " << pos2.Y() << ", " << pos2.Z() << ", radius: " << pos.Perp();
         LOG_DEBUG("tracking.PHTpcTrackFollower.followTrack") << "distance to hit: " << std::sqrt(std::pow(pos2.X() - (*hit)[0], 2) + std::pow(pos2.Y() - (*hit)[1], 2) + std::pow(pos2.Z() - (*hit)[2], 2));
 
@@ -632,7 +632,7 @@ int PHTpcTrackFollower::followTrack(PHGenFit2::Track* track, PHTpcLookup* lookup
             continue;
           }
           TVector3 pos2 = p2.first->getPos();
-	  delete p2.first;
+          delete p2.first;
           double dist2 = std::sqrt(std::pow(pos2.X() - (*hit)[0], 2) + std::pow(pos2.Y() - (*hit)[1], 2) + std::pow(pos2.Z() - (*hit)[2], 2));
           LOG_DEBUG("tracking.PHTpcTrackFollower.followTrack") << "projected point: " << pos2.X() << ", " << pos2.Y() << ", " << pos2.Z() << ", radius: " << pos.Perp();
           LOG_DEBUG("tracking.PHTpcTrackFollower.followTrack") << "distance to hit: " << dist2;

--- a/offline/packages/PHTpcTracker/PHTpcTracker.cc
+++ b/offline/packages/PHTpcTracker/PHTpcTracker.cc
@@ -23,10 +23,10 @@
 #include <phgeom/PHGeomUtility.h>
 
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrDefs.h>               // for cluskey
+#include <trackbase/TrkrDefs.h>  // for cluskey
 
-#include <trackbase_historic/SvtxTrack_v1.h>
 #include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxTrack_v1.h>
 
 #include <trackreco/PHTrackSeeding.h>
 
@@ -39,17 +39,17 @@
 
 #include <CLHEP/Units/SystemOfUnits.h>
 
-#include <TMatrixDSymfwd.h>                   // for TMatrixDSym
-#include <TMatrixTSym.h>                      // for TMatrixTSym
-#include <TMatrixTUtils.h>                    // for TMatrixTRow
-#include <TVectorDfwd.h>                      // for TVectorD
-#include <TVectorT.h>                         // for TVectorT
-#include <TVector3.h>  // for TVector3
+#include <TMatrixDSymfwd.h>  // for TMatrixDSym
+#include <TMatrixTSym.h>     // for TMatrixTSym
+#include <TMatrixTUtils.h>   // for TMatrixTRow
+#include <TVector3.h>        // for TVector3
+#include <TVectorDfwd.h>     // for TVectorD
+#include <TVectorT.h>        // for TVectorT
 
-#include <iostream>                           // for operator<<, endl, basic...
-#include <limits>  // for numeric_limits
-#include <memory>                             // for shared_ptr, __shared_ptr
-#include <vector>  // for vector
+#include <iostream>  // for operator<<, endl, basic...
+#include <limits>    // for numeric_limits
+#include <memory>    // for shared_ptr, __shared_ptr
+#include <vector>    // for vector
 
 class PHCompositeNode;
 
@@ -97,7 +97,6 @@ PHTpcTracker::~PHTpcTracker()
 
 int PHTpcTracker::Setup(PHCompositeNode* topNode)
 {
-
   int ret = PHTrackSeeding::Setup(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
 
@@ -140,9 +139,10 @@ int PHTpcTracker::Process(PHCompositeNode* topNode)
   LOG_INFO("tracking.PHTpcTracker.process_event") << "TrackFollower reconstructed " << gtracks.size() << " tracks";
   // write tracks to fun4all server
   //  cout<<  gtracks[1]->get_vertex_id() << endl;
-  for (int i = 0, ilen = gtracks.size(); i < ilen; i++){
+  for (int i = 0, ilen = gtracks.size(); i < ilen; i++)
+  {
     //  for (auto it = gtracks.begin(); it != gtracks.end(); ++it)
-    std::shared_ptr<SvtxTrack_v1> svtx_track( new SvtxTrack_v1() );
+    std::shared_ptr<SvtxTrack_v1> svtx_track(new SvtxTrack_v1());
     ////// from here:
 
     svtx_track->Reset();
@@ -154,25 +154,27 @@ int PHTpcTracker::Process(PHCompositeNode* topNode)
     TMatrixDSym cov = gtracks[i]->getGenFitTrack()->getCovSeed();
     //cout<< "pt: " << pos.Perp() << endl;
 
-    for(int k=0; k<6; k++){
-      for(int j=0; j<6; j++){
-	svtx_track->set_error(k, j, cov[k][j]);
+    for (int k = 0; k < 6; k++)
+    {
+      for (int j = 0; j < 6; j++)
+      {
+        svtx_track->set_error(k, j, cov[k][j]);
       }
     }
-    
+
     svtx_track->set_px(mom.Px());
     svtx_track->set_py(mom.Py());
     svtx_track->set_pz(mom.Pz());
-    
+
     svtx_track->set_x(pos.X());
     svtx_track->set_y(pos.Y());
     svtx_track->set_z(pos.Z());
-    
+
     for (TrkrDefs::cluskey cluster_key : gtracks[i]->get_cluster_keys())
-      {
-	svtx_track->insert_cluster_key(cluster_key);
-      }
-  
+    {
+      svtx_track->insert_cluster_key(cluster_key);
+    }
+
     _track_map->insert(svtx_track.get());
   }
 
@@ -197,7 +199,6 @@ int PHTpcTracker::Process(PHCompositeNode* topNode)
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
-
 
 PHField* PHTpcTracker::getMagField(PHCompositeNode* topNode, double& B)
 {

--- a/offline/packages/PHTpcTracker/PHTpcTracker.h
+++ b/offline/packages/PHTpcTracker/PHTpcTracker.h
@@ -58,6 +58,8 @@ class PHTpcTracker : public PHTrackSeeding
 
   int Process(PHCompositeNode* topNode);
 
+  int End() {return 0;}
+
   PHField* getMagField(PHCompositeNode* topNode, double& B);
 
  private:

--- a/offline/packages/PHTpcTracker/PHTpcTracker.h
+++ b/offline/packages/PHTpcTracker/PHTpcTracker.h
@@ -7,8 +7,8 @@
 #ifndef PHTPCTRACKER_H_
 #define PHTPCTRACKER_H_
 
-// PHENIX includes
-//#include <fun4all/SubsysReco.h>
+// sPHENIX includes
+
 #include <trackreco/PHTrackSeeding.h>
 
 #include <cmath>    // for M_PI
@@ -39,8 +39,6 @@ class PHTpcTracker : public PHTrackSeeding
   PHTpcTracker(const std::string& name = "PHTpcTracker");
   ~PHTpcTracker();
 
-  // int process_event(PHCompositeNode* topNode);
-
   void set_seed_finder_options(double maxdistance1 = 3.0, double tripletangle1 = M_PI / 8, size_t minhits1 = 10,
                                double maxdistance2 = 6.0, double tripletangle2 = M_PI / 8, size_t minhits2 = 5, size_t nthreads = 1);
   void set_seed_finder_optimization_remove_loopers(bool opt = false, double minr = 10.0, double maxr = 70.0);
@@ -59,8 +57,6 @@ class PHTpcTracker : public PHTrackSeeding
   int Setup(PHCompositeNode* topNode);
 
   int Process(PHCompositeNode* topNode);
-
-  int End();
 
   PHField* getMagField(PHCompositeNode* topNode, double& B);
 

--- a/offline/packages/PHTpcTracker/Track.h
+++ b/offline/packages/PHTpcTracker/Track.h
@@ -136,13 +136,7 @@ namespace PHGenFit2
     //SMART(genfit::Track) getGenFitTrack() {return _track;}
 
    private:
-#if defined(__CINT__) && !defined(__CLING__)
-    Track operator=(Track& trk)
-    {
-    }
-#else
     Track operator=(Track& trk) = delete;
-#endif
 
     int verbosity;
 

--- a/offline/packages/PHTpcTracker/Track.h
+++ b/offline/packages/PHTpcTracker/Track.h
@@ -133,20 +133,17 @@ namespace PHGenFit2
       this->verbosity = verbosity;
     }
 
-    //SMART(genfit::Track) getGenFitTrack() {return _track;}
-
    private:
     Track operator=(Track& trk) = delete;
 
     int verbosity;
 
     genfit::Track* _track;
-    //std::vector<PHGenFit::Measurement*> _measurements;
+
     std::vector<unsigned int> _clusterIDs;
     std::vector<TrkrDefs::cluskey> _clusterkeys;
     unsigned int _vertex_id;
 
-    //SMART(genfit::Track) _track;
   };
 }  // namespace PHGenFit2
 

--- a/offline/packages/PHTpcTracker/configure.ac
+++ b/offline/packages/PHTpcTracker/configure.ac
@@ -20,12 +20,5 @@ if test $ac_cv_prog_gxx = yes; then
      CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
-AC_SUBST(CINTDEFS)
-fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
-
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
This PR fixes a memory leak in PHTpcTracker which has been bothering us for a long time. The reason was a problem in the handling of >1 matches where the genfit track was cloned each time but only deleted once at the end of the loop. This happens only very rarely for our single particle events which is why this only cropped up occasionally. Using a variable of that scope wasn't necessary, keeping everything local and deleting the cloned track right after use fixed that leak. The results did not change.