### PR TITLE
Truth silicon track seeding and TPC-silicon track stub matching module

### DIFF
--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -50,6 +50,7 @@ pkginclude_HEADERS = \
   PHCASeeding.h \
   PHInitVertexing.h \
   PHInitZVertexing.h \
+  PHSiliconTruthTrackSeeding.h \
   PHTrackPropagating.h \
   PHTrackSeeding.h \
   PHTrackFitting.h \
@@ -93,6 +94,7 @@ else
     PH3DVertexing_Dict.cc \
     PHTruthVertexing_Dict.cc \
     PHTruthTrackSeeding_Dict.cc \
+    PHSiliconTruthTrackSeeding_Dict.cc \
     PHTruthSiliconAssociation_Dict.cc \
     PHHoughSeeding_Dict.cc \
     PHRTreeSeeding_Dict.cc \
@@ -159,6 +161,7 @@ libtrack_reco_la_SOURCES = \
   PH3DVertexing.cc \
   PHTruthVertexing.cc \
   PHTruthTrackSeeding.cc \
+  PHSiliconTruthTrackSeeding.cc \
   PHTruthSiliconAssociation.cc \
   PHHoughSeeding.cc \
   PHRTreeSeeding.cc \

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -50,6 +50,7 @@ pkginclude_HEADERS = \
   PHCASeeding.h \
   PHInitVertexing.h \
   PHInitZVertexing.h \
+  PHSiliconTpcTrackMatching.h \
   PHSiliconTruthTrackSeeding.h \
   PHTrackPropagating.h \
   PHTrackSeeding.h \
@@ -94,6 +95,7 @@ else
     PH3DVertexing_Dict.cc \
     PHTruthVertexing_Dict.cc \
     PHTruthTrackSeeding_Dict.cc \
+    PHSikiconTpcTrackMatching_Dict.cc \
     PHSiliconTruthTrackSeeding_Dict.cc \
     PHTruthSiliconAssociation_Dict.cc \
     PHHoughSeeding_Dict.cc \
@@ -160,6 +162,7 @@ libtrack_reco_la_SOURCES = \
   PHTrackFitting.cc \
   PH3DVertexing.cc \
   PHTruthVertexing.cc \
+  PHSiliconTpcTrackMatching.cc \
   PHTruthTrackSeeding.cc \
   PHSiliconTruthTrackSeeding.cc \
   PHTruthSiliconAssociation.cc \

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -1,0 +1,269 @@
+#include "PHSiliconTpcTrackMatching.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+/// Tracking includes
+#include <trackbase/TrkrClusterv1.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
+#include <trackbase/TrkrHitTruthAssoc.h>
+#include <trackbase_historic/SvtxTrack_v1.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxVertexMap.h>
+
+#include <g4main/PHG4Hit.h>  // for PHG4Hit
+#include <g4main/PHG4Particle.h>  // for PHG4Particle
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4HitDefs.h>  // for keytype
+#include <g4main/PHG4TruthInfoContainer.h>
+
+#include "AssocInfoContainer.h"
+
+using namespace std;
+
+//____________________________________________________________________________..
+PHSiliconTpcTrackMatching::PHSiliconTpcTrackMatching(const std::string &name):
+ PHTrackPropagating(name)
+ , _track_map_name_silicon("SvtxSiliconTrackMap")
+{
+  //cout << "PHSiliconTpcTrackMatching::PHSiliconTpcTrackMatching(const std::string &name) Calling ctor" << endl;
+}
+
+//____________________________________________________________________________..
+PHSiliconTpcTrackMatching::~PHSiliconTpcTrackMatching()
+{
+
+}
+
+//____________________________________________________________________________..
+int PHSiliconTpcTrackMatching::Setup(PHCompositeNode *topNode)
+{
+
+  int ret = PHTrackPropagating::Setup(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  return ret;
+}
+
+//____________________________________________________________________________..
+int PHSiliconTpcTrackMatching::Process()
+{
+  if (Verbosity() >= 1) 
+    cout << "PHSiliconTpcTrackMatching::process() started " << endl;
+
+  // _track_map contains the TPC seed track stubs
+  // _track_map_silicon contains the silicon seed track stubs
+
+  // We will add the silicon clusters to the TPC tracks already on the node tree
+  // We will have to expand the number of tracks whenever we find multiple matches to the silicon
+
+  cout << " TPC track map size " << _track_map->size() << endl;
+  cout << " Silicon track map size " << _track_map->size() << endl;
+
+ // We remember the original size of the TPC track map here
+  const unsigned int original_track_map_lastkey = _track_map->end()->first;
+  //std::cout << " track map last key = " <<  original_track_map_lastkey << std::endl;
+
+  // loop over the original TPC tracks
+  for (auto phtrk_iter = _track_map->begin();
+       phtrk_iter != _track_map->end(); 
+       ++phtrk_iter)
+    {
+      // we may add tracks to the map, so we stop at the last original track
+      if(phtrk_iter->first >= original_track_map_lastkey)  break;
+      
+      _tracklet_tpc = phtrk_iter->second;
+      
+      //if (Verbosity() >= 1)
+	{
+	  std::cout
+	    << __LINE__
+	    << ": Processing seed itrack: " << phtrk_iter->first
+	    << ": nhits: " << _tracklet_tpc-> size_cluster_keys()
+	    << ": Total tracks: " << _track_map->size()
+	    << ": phi: " << _tracklet_tpc->get_phi()
+	    << endl;
+	}
+
+      // if the vertex id from the seeder is nonsense, use vertex 0
+      unsigned int vertexId = _tracklet_tpc->get_vertex_id();
+      if(vertexId == UINT_MAX)
+	vertexId = 0;
+      _tracklet_tpc->set_vertex_id(vertexId);
+
+      // set the track position to the vertex position
+      const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);
+      
+      _tracklet_tpc->set_x(svtxVertex->get_x());
+      _tracklet_tpc->set_y(svtxVertex->get_y());
+      _tracklet_tpc->set_z(svtxVertex->get_z());
+
+      double tpc_phi = atan2(_tracklet_tpc->get_py(), _tracklet_tpc->get_px());
+      double tpc_eta = _tracklet_tpc->get_eta();
+
+      if(Verbosity() > 3)
+	{
+	  cout << "Original TPC tracklet:" << endl;
+	  _tracklet_tpc->identify();
+	}
+
+      // Now search the silicon track list for a match in eta and phi
+      // NOTE: what about tracks from different vertex locations? This should be done vertex by vertex, right?
+
+      std::set<unsigned int> si_matches;
+      for (auto phtrk_iter_si = _track_map_silicon->begin();
+	   phtrk_iter_si != _track_map_silicon->end(); 
+	   ++phtrk_iter_si)
+	{
+	  _tracklet_si = phtrk_iter_si->second;	  
+
+	  double si_phi = atan2(_tracklet_si->get_py(), _tracklet_si->get_px());
+	  double si_eta = _tracklet_si->get_eta();
+
+	  if(Verbosity() >= 1)
+	    {
+	      cout << " testing for a match for TPC track " << _tracklet_tpc->get_id() << " with Si track " << _tracklet_si->get_id() << endl;	  
+	      cout << "      tpc_phi " << tpc_phi << " si_phi " << si_phi << " tpc_eta " << tpc_eta << " si_eta " << si_eta << endl;
+	    }
+
+	  // NOTE: have to guard against change of sign at +/- pi
+	  if( fabs(tpc_eta - si_eta) < _eta_search_win )
+	    if( fabs(tpc_phi - si_phi) < _phi_search_win || fabs(tpc_phi - si_phi) - 2.0*M_PI < _phi_search_win) 
+	      {
+		// got a match, add to the list
+		//if(Verbosity() >= 1)  
+		  cout << " found a match for TPC track " << _tracklet_tpc->get_id() << " with Si track " << _tracklet_si->get_id() << endl;
+		  cout << "          tpc_phi " << tpc_phi << " si_phi " << si_phi << " tpc_eta " << tpc_eta << " si_eta " << si_eta << endl;
+		si_matches.insert(_tracklet_si->get_id());
+	      }
+	  
+	}
+      // if we did not get a match, sound the alarm
+      if(si_matches.size() == 0)
+	cout << "Did not find a silicon track stub to match TPC seed track " << _tracklet_tpc->get_id() << endl;
+ 
+      // Add the silicon clusters to the track
+      unsigned int isi = 0;
+      for(auto si_it = si_matches.begin(); si_it != si_matches.end(); ++si_it)
+	{
+	  // get the si tracklet for this id
+	  _tracklet_si = _track_map_silicon->get(*si_it);
+
+	  // get the silicon clusters
+	  std::set<TrkrDefs::cluskey> si_clusters;
+	  for (SvtxTrack::ConstClusterKeyIter key_iter = _tracklet_si->begin_cluster_keys();
+	       key_iter != _tracklet_si->end_cluster_keys();
+	       ++key_iter)
+	    {
+	      TrkrDefs::cluskey cluster_key = *key_iter;
+	      if(Verbosity() >=1) cout << "   inserting cluster key " << cluster_key << " into list " << endl;
+	      si_clusters.insert(cluster_key);
+	    }
+
+	  if(isi == 0)
+	    {
+	      // update the original track on the node tree
+	      for(auto clus_iter=si_clusters.begin(); clus_iter != si_clusters.end(); ++clus_iter)
+		{
+		  if(Verbosity() >= 1) cout << "   inserting cluster key " << *clus_iter << " into track " << _tracklet_tpc->get_id() << endl;
+		  _tracklet_tpc->insert_cluster_key(*clus_iter);
+		  _assoc_container->SetClusterTrackAssoc(*clus_iter, _tracklet_tpc->get_id());
+		}
+	    }
+	  else
+	    {
+	      // more than one si stub matches
+	      // make a copy of the TPC track, update it and add it to the end of the node tree 
+	      cout << "Extra match, add a new track to node tree" << endl;
+	      
+	      SvtxTrack *newTrack = new SvtxTrack_v1();
+	      const unsigned int lastTrackKey = _track_map->end()->first + isi - 1; 
+	      std::cout << "   extra track key " << lastTrackKey << std::endl;
+	      
+	      newTrack->set_id(lastTrackKey);
+	      newTrack->set_vertex_id(vertexId);
+	      
+	      newTrack->set_charge(_tracklet_tpc->get_charge());
+	      newTrack->set_px(_tracklet_tpc->get_px());
+	      newTrack->set_py(_tracklet_tpc->get_py());
+	      newTrack->set_pz(_tracklet_tpc->get_pz());
+	      newTrack->set_x(_tracklet_tpc->get_x());
+	      newTrack->set_y(_tracklet_tpc->get_y());
+	      newTrack->set_z(_tracklet_tpc->get_z());
+	      for(int i = 0; i < 6; ++i)
+		{
+		  for(int j = 0; j < 6; ++j)
+		    {
+		      newTrack->set_error(i,j, _tracklet_tpc->get_error(i,j));
+		    }
+		}
+	      
+	      // loop over associated clusters to get hits for TPC only
+	      for (SvtxTrack::ConstClusterKeyIter iter = _tracklet_tpc->begin_cluster_keys();
+		   iter != _tracklet_tpc->end_cluster_keys();
+		   ++iter)
+		{
+		  TrkrDefs::cluskey cluster_key = *iter;
+		  unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+		  if(trkrid == TrkrDefs::tpcId)
+		    newTrack->insert_cluster_key(cluster_key);
+		}
+	      
+	      // now add the new si clusters
+	      for(auto clus_iter=si_clusters.begin(); clus_iter != si_clusters.end(); ++clus_iter)
+		{
+		  cout << "   inserting cluster key " << *clus_iter << " into new track " << newTrack->get_id() << endl;
+		  newTrack->insert_cluster_key(*clus_iter);
+		  _assoc_container->SetClusterTrackAssoc(*clus_iter, newTrack->get_id());
+		}
+
+	      _track_map->insert(newTrack);
+
+	      std::cout << "  added new copy of track " << lastTrackKey << std::endl;
+	    }
+	  
+	  isi++;
+	}
+      if(Verbosity() > 3)
+	{
+	  cout << " updated track:" << endl;
+	  _tracklet_tpc->identify();
+	}
+    }
+  
+  cout << " Final track map size " << _track_map->size() << endl;
+  
+  if (Verbosity() >= 1)
+    cout << "PHSiliconTpcTrackMatching::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;  
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHSiliconTpcTrackMatching::End()
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int  PHSiliconTpcTrackMatching::GetNodes(PHCompositeNode* topNode)
+{
+  //---------------------------------
+  // Get additional objects off the Node Tree
+  //---------------------------------
+
+  _track_map_silicon = findNode::getClass<SvtxTrackMap>(topNode,  "SvtxSiliconTrackMap");
+  if (!_track_map_silicon)
+  {
+    cerr << PHWHERE << " ERROR: Can't find SvtxSiliconTrackMap: " << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -44,14 +44,13 @@ PHSiliconTpcTrackMatching::~PHSiliconTpcTrackMatching()
 //____________________________________________________________________________..
 int PHSiliconTpcTrackMatching::Setup(PHCompositeNode *topNode)
 {
-  cout << "Enter PHSiliconTpcTrackMatching::Setup " << endl;
-
-  cout << "       Search windows: phi " << _phi_search_win << " eta " << _eta_search_win << endl;
+  // put these in the output file
+  cout << PHWHERE << " p0 " << _par0 << " p1 " << _par1 << " p2 " << _par2 << " Search windows: phi " << _phi_search_win << " eta " << _eta_search_win << endl;
 
   fdphi = new TF1("f1", "[0] + [1]/x^[2]");
-  fdphi->SetParameter(0, par0);
-  fdphi->SetParameter(1, par1);
-  fdphi->SetParameter(2, par2);
+  fdphi->SetParameter(0, _par0);
+  fdphi->SetParameter(1, _par1);
+  fdphi->SetParameter(2, _par2);
 		  
   int ret = PHTrackPropagating::Setup(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
@@ -65,20 +64,16 @@ int PHSiliconTpcTrackMatching::Setup(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int PHSiliconTpcTrackMatching::Process()
 {
-  if (Verbosity() >= 1) 
-    cout << "PHSiliconTpcTrackMatching::process() started " << endl;
-
   // _track_map contains the TPC seed track stubs
   // _track_map_silicon contains the silicon seed track stubs
   // We will add the silicon clusters to the TPC tracks already on the node tree
   // We will have to expand the number of tracks whenever we find multiple matches to the silicon
 
-  cout << " TPC track map size " << _track_map->size() << endl;
-  cout << " Silicon track map size " << _track_map->size() << endl;
+  if(Verbosity() >= 0)
+    cout << PHWHERE << " TPC track map size " << _track_map->size() << " Silicon track map size " << _track_map->size() << endl;
 
  // We remember the original size of the TPC track map here
   const unsigned int original_track_map_lastkey = _track_map->end()->first;
-  //std::cout << " track map last key = " <<  original_track_map_lastkey << std::endl;
 
   // loop over the original TPC tracks
   for (auto phtrk_iter = _track_map->begin();
@@ -275,8 +270,9 @@ int PHSiliconTpcTrackMatching::Process()
 	  isi++;
 	}
     }
-  
-  cout << " Final track map size " << _track_map->size() << endl;
+
+  if(Verbosity() >= 0)  
+    cout << " Final track map size " << _track_map->size() << endl;
   
   if (Verbosity() >= 1)
     cout << "PHSiliconTpcTrackMatching::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;  

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -1,0 +1,74 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef PHSILICONTPCTRACKMATCHING_H
+#define PHSILICONTPCTRACKMATCHING_H
+
+#include <fun4all/SubsysReco.h>
+#include <trackbase/TrkrDefs.h>
+
+#include <string>
+#include <set>
+#include <vector>
+
+class PHCompositeNode;
+class SvtxTrackMap;
+class SvtxTrack;
+class SvtxVertexMap;
+class TrkrClusterContainer;
+class TrkrClusterHitAssoc;
+class TrkrHitTruthAssoc;
+class PHG4TruthInfoContainer;
+class PHG4HitContainer;
+class PHG4Particle;
+class AssocInfoContainer;
+
+#include <trackreco/PHTrackPropagating.h>
+
+class PHSiliconTpcTrackMatching : public PHTrackPropagating
+{
+ public:
+
+  PHSiliconTpcTrackMatching(const std::string &name = "PHSiliconTpcTrackMatching");
+
+  virtual ~PHSiliconTpcTrackMatching();
+
+  void set_track_map_name_silicon(const std::string &map_name) { _track_map_name_silicon = map_name; }
+
+ protected:
+  int Setup(PHCompositeNode* topNode) override;
+
+  int Process() override;
+
+  int End() override;
+
+  //int Init(PHCompositeNode *topNode) override;
+  //int InitRun(PHCompositeNode *topNode) override;
+  //int process_event(PHCompositeNode *topNode) override;
+  //int ResetEvent(PHCompositeNode *topNode) override;
+  //int EndRun(const int runnumber) override;
+  //int End(PHCompositeNode *topNode) override;
+  //int Reset(PHCompositeNode * /*topNode*/) override;
+  //void Print(const std::string &what = "ALL") const override;
+  
+ private:
+
+  int GetNodes(PHCompositeNode* topNode);
+
+  //std::vector<PHG4Particle*> getG4PrimaryParticle(SvtxTrack *track);
+  //std::set<TrkrDefs::cluskey> getSiliconClustersFromParticle(PHG4Particle* g4particle);
+  
+  //PHG4TruthInfoContainer *_truthinfo{nullptr};
+  //PHG4HitContainer *_g4hits_tpc{nullptr};
+  //PHG4HitContainer *_g4hits_mvtx{nullptr};
+  //PHG4HitContainer *_g4hits_intt{nullptr};
+
+  std::string _track_map_name_silicon;
+  double _phi_search_win = 0.02;
+  double _eta_search_win = 0.01;
+  
+  SvtxTrackMap *_track_map_silicon{nullptr};
+  SvtxTrack *_tracklet_tpc{nullptr};
+  SvtxTrack *_tracklet_si{nullptr};
+};
+
+#endif // PHTRUTHSILICONASSOCIATION_H

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -36,7 +36,7 @@ class PHSiliconTpcTrackMatching : public PHTrackPropagating
   void set_track_map_name_silicon(const std::string &map_name) { _track_map_name_silicon = map_name; }
   void set_phi_search_window(const double win){_phi_search_win = win;}
   void set_eta_search_window(const double win){_eta_search_win = win;}
-  void set_search_par_values(const double p0, const double p1, const double p2){   ;}
+  void set_search_par_values(const double p0, const double p1, const double p2){_par0 = p0; _par1 = p1; _par2 = p2; }
 
  protected:
   int Setup(PHCompositeNode* topNode) override;
@@ -50,7 +50,9 @@ class PHSiliconTpcTrackMatching : public PHTrackPropagating
   int GetNodes(PHCompositeNode* topNode);
 
   std::string _track_map_name_silicon;
-  double _phi_search_win = 0.03;
+
+  // default values, can be replaced from the macro
+  double _phi_search_win = 0.02;
   double _eta_search_win = 0.02;
   
   SvtxTrackMap *_track_map_silicon{nullptr};
@@ -58,9 +60,10 @@ class PHSiliconTpcTrackMatching : public PHTrackPropagating
   SvtxTrack *_tracklet_si{nullptr};
 
   TF1 *fdphi{nullptr};
-  double par0 =  -0.000650;
-  double par1 =  0.13373;
-  double par2 =  0.98298;
+  // default values, can be replaced from the macro
+  double _par0 =  -0.000650;
+  double _par1 =  0.13373;
+  double _par2 =  0.98298;
 
 };
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -40,31 +40,14 @@ class PHSiliconTpcTrackMatching : public PHTrackPropagating
   int Process() override;
 
   int End() override;
-
-  //int Init(PHCompositeNode *topNode) override;
-  //int InitRun(PHCompositeNode *topNode) override;
-  //int process_event(PHCompositeNode *topNode) override;
-  //int ResetEvent(PHCompositeNode *topNode) override;
-  //int EndRun(const int runnumber) override;
-  //int End(PHCompositeNode *topNode) override;
-  //int Reset(PHCompositeNode * /*topNode*/) override;
-  //void Print(const std::string &what = "ALL") const override;
   
  private:
 
   int GetNodes(PHCompositeNode* topNode);
 
-  //std::vector<PHG4Particle*> getG4PrimaryParticle(SvtxTrack *track);
-  //std::set<TrkrDefs::cluskey> getSiliconClustersFromParticle(PHG4Particle* g4particle);
-  
-  //PHG4TruthInfoContainer *_truthinfo{nullptr};
-  //PHG4HitContainer *_g4hits_tpc{nullptr};
-  //PHG4HitContainer *_g4hits_mvtx{nullptr};
-  //PHG4HitContainer *_g4hits_intt{nullptr};
-
   std::string _track_map_name_silicon;
-  double _phi_search_win = 0.02;
-  double _eta_search_win = 0.01;
+  double _phi_search_win = 0.05;
+  double _eta_search_win = 0.02;
   
   SvtxTrackMap *_track_map_silicon{nullptr};
   SvtxTrack *_tracklet_tpc{nullptr};

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -21,6 +21,7 @@ class PHG4TruthInfoContainer;
 class PHG4HitContainer;
 class PHG4Particle;
 class AssocInfoContainer;
+class TF1;
 
 #include <trackreco/PHTrackPropagating.h>
 
@@ -33,6 +34,9 @@ class PHSiliconTpcTrackMatching : public PHTrackPropagating
   virtual ~PHSiliconTpcTrackMatching();
 
   void set_track_map_name_silicon(const std::string &map_name) { _track_map_name_silicon = map_name; }
+  void set_phi_search_window(const double win){_phi_search_win = win;}
+  void set_eta_search_window(const double win){_eta_search_win = win;}
+  void set_search_par_values(const double p0, const double p1, const double p2){   ;}
 
  protected:
   int Setup(PHCompositeNode* topNode) override;
@@ -46,12 +50,18 @@ class PHSiliconTpcTrackMatching : public PHTrackPropagating
   int GetNodes(PHCompositeNode* topNode);
 
   std::string _track_map_name_silicon;
-  double _phi_search_win = 0.05;
+  double _phi_search_win = 0.03;
   double _eta_search_win = 0.02;
   
   SvtxTrackMap *_track_map_silicon{nullptr};
   SvtxTrack *_tracklet_tpc{nullptr};
   SvtxTrack *_tracklet_si{nullptr};
+
+  TF1 *fdphi{nullptr};
+  double par0 =  -0.000650;
+  double par1 =  0.13373;
+  double par2 =  0.98298;
+
 };
 
 #endif // PHTRUTHSILICONASSOCIATION_H

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatchingLinkDef.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatchingLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHSiliconTpcTrackMatching - !;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -1,0 +1,360 @@
+#include "PHSiliconTruthTrackSeeding.h"
+
+#include "AssocInfoContainer.h"
+
+#include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTra...
+#include <trackbase_historic/SvtxTrackMap.h>  // for SvtxTrackMap, Svtx...
+#include <trackbase_historic/SvtxTrack_FastSim.h>
+#include <trackbase_historic/SvtxVertexMap.h>
+
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase/TrkrHitTruthAssoc.h>
+
+#include <g4eval/SvtxClusterEval.h>
+#include <g4eval/SvtxEvalStack.h>
+#include <g4eval/SvtxEvaluator.h>
+#include <g4eval/SvtxTrackEval.h>
+
+#include <g4main/PHG4Hit.h>  // for PHG4Hit
+#include <g4main/PHG4Particle.h>  // for PHG4Particle
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4HitDefs.h>  // for keytype
+#include <g4main/PHG4TruthInfoContainer.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <cstdlib>   // for exit
+#include <iostream>  // for operator<<, endl
+#include <map>       // for multimap, map<>::c...
+#include <memory>
+#include <utility>  // for pair
+#include <cassert>
+#include <set>
+
+#define LogDebug(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
+#define LogError(exp) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
+#define LogWarning(exp) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
+
+class PHCompositeNode;
+
+using namespace std;
+
+PHSiliconTruthTrackSeeding::PHSiliconTruthTrackSeeding(const std::string& name)
+  : PHTrackSeeding(name)
+{}
+
+int PHSiliconTruthTrackSeeding::Setup(PHCompositeNode* topNode)
+{
+  cout << "Enter PHSiliconTruthTrackSeeding:: Setup" << endl;
+
+  // we use a separate track map node for the silicon track stubs
+  std::string track_map_node_name = {"SvtxSiliconTrackMap"};
+  set_track_map_name(track_map_node_name);
+
+  int ret = PHTrackSeeding::Setup(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
+{
+  // We start with all reco clusters in the silicon layers
+  // get the associated truth g4hits and from that the g4particle
+  // make a map of <g4particle, clusters>
+  // Make an SvtxTrack in silicon from g4particle
+  // get momentum from truth
+  // get position from vertex
+  // add clusters to it 
+ // Add the track to SvtxSiliconTrackMap
+
+  typedef std::map<int, std::set<TrkrCluster*> > TrkClustersMap;
+  TrkClustersMap m_trackID_clusters;
+
+  // loop over all clusters
+  TrkrClusterContainer::ConstRange clusrange = _cluster_map->getClusters();
+  for (TrkrClusterContainer::ConstIterator clusiter = clusrange.first; clusiter != clusrange.second; ++clusiter)
+  {
+    TrkrCluster* cluster = clusiter->second;
+    TrkrDefs::cluskey cluskey = clusiter->first;
+    unsigned int trkrid = TrkrDefs::getTrkrId(cluskey);
+
+    if(trkrid != TrkrDefs::mvtxId && trkrid != TrkrDefs::inttId)  continue;
+
+    unsigned int layer = TrkrDefs::getLayer(cluskey);
+    if(layer > 6)
+      std::cout << PHWHERE << " Warning: layer is screwed up - layer = " << layer << std::endl;
+
+    if (Verbosity() >= 3)
+    {
+      cout <<__PRETTY_FUNCTION__<<" process cluster ";
+      cluster->identify();
+    }
+
+    // get the hits for this cluster
+    TrkrClusterHitAssoc::ConstRange hitrange = clusterhitassoc->getHits(cluskey);  // returns range of pairs {cluster key, hit key} for this cluskey
+    for (TrkrClusterHitAssoc::ConstIterator clushititer = hitrange.first; clushititer != hitrange.second; ++clushititer)
+    {
+      TrkrDefs::hitkey hitkey = clushititer->second;
+      // TrkrHitTruthAssoc uses a map with (hitsetkey, std::pair(hitkey, g4hitkey)) - get the hitsetkey from the cluskey
+      TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
+
+      // get all of the g4hits for this hitkey
+      std::multimap<TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> > temp_map;
+      hittruthassoc->getG4Hits(hitsetkey, hitkey, temp_map);  // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
+      for (std::multimap<TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> >::iterator htiter = temp_map.begin(); htiter != temp_map.end(); ++htiter)
+      {
+        // extract the g4 hit key here and add the hits to the set
+        PHG4HitDefs::keytype g4hitkey = htiter->second.second;
+        PHG4Hit* phg4hit = nullptr;
+        switch( trkrid )
+        {
+          case TrkrDefs::mvtxId:
+          if (phg4hits_mvtx) phg4hit = phg4hits_mvtx->findHit( g4hitkey );
+          break;
+
+          case TrkrDefs::inttId:
+          if (phg4hits_intt) phg4hit = phg4hits_intt->findHit( g4hitkey );
+          break;
+        }
+   
+        if( !phg4hit )
+        {
+          std::cout<<PHWHERE<<" unable to find g4hit from key " << g4hitkey << std::endl;
+          continue;
+        }
+     
+        int particle_id = phg4hit->get_trkid();
+
+        // momentum cut-off
+        if (_min_momentum>0)
+        {
+          PHG4Particle* particle = _g4truth_container->GetParticle(particle_id);
+          if (!particle)
+          {
+            cout <<__PRETTY_FUNCTION__<<" - validity check failed: missing truth particle with ID of "<<particle_id<<". Exiting..."<<endl;
+            exit(1);
+          }
+          const double monentum2 =
+              particle->get_px() * particle->get_px()
+              +
+              particle->get_py() * particle->get_py()
+              +
+              particle->get_pz() * particle->get_pz()
+              ;
+
+          if (Verbosity() >= 10)
+          {
+            cout <<__PRETTY_FUNCTION__<<" check momentum for particle"<<particle_id<<" -> cluster "<<cluskey
+                <<" = "<<sqrt(monentum2)<<endl;;
+            particle->identify();
+          }
+
+          if (monentum2 < _min_momentum * _min_momentum)
+          {
+            if (Verbosity() >= 3)
+            {
+              cout <<__PRETTY_FUNCTION__<<" ignore low momentum particle"<<particle_id<<" -> cluster "<<cluskey<<endl;;
+              particle->identify();
+            }
+            continue;
+          }
+        }
+
+	// add or append this particle/cluster combination to the map
+        TrkClustersMap::iterator it = m_trackID_clusters.find(particle_id);
+
+        if (it != m_trackID_clusters.end())
+        {
+          it->second.insert(cluster);
+          if (Verbosity() >= 3)
+          {
+            cout <<__PRETTY_FUNCTION__<<" append particle"<<particle_id<<" -> cluster "<<cluskey<<endl;;
+            cluster->identify();
+          }
+        }
+        else
+        {
+          std::set<TrkrCluster*> clusters;
+          clusters.insert(cluster);
+          m_trackID_clusters.insert(std::pair<int, std::set<TrkrCluster*> >(particle_id, clusters));
+
+
+          if (Verbosity() >= 3)
+          {
+            cout <<__PRETTY_FUNCTION__<<" new particle"<<particle_id<<" -> cluster "<<cluskey<<endl;;
+            cluster->identify();
+          }
+
+        }
+      }  // loop over g4hits associated with hit
+    }    // loop over hits associated with cluster
+  }      // loop over clusters
+
+  //==================================
+  // make the tracks
+
+  if (Verbosity() >= 2)
+  {
+    cout <<__PRETTY_FUNCTION__
+        <<" _track_map->size = "<<_track_map->size()<<endl;
+  }
+
+  // Build tracks
+  for (TrkClustersMap::const_iterator trk_clusters_itr = m_trackID_clusters.begin();
+       trk_clusters_itr != m_trackID_clusters.end(); ++trk_clusters_itr)
+  {
+    if (trk_clusters_itr->second.size() <  _min_clusters_per_track)
+      continue;
+
+    // check number of layers also pass the _min_clusters_per_track cut to avoid tight loopers
+    set<uint8_t> layers;
+    for (TrkrCluster* cluster : trk_clusters_itr->second)
+    {
+      assert(cluster);
+      const uint8_t layer = TrkrDefs::getLayer(cluster->getClusKey());
+      layers.insert(layer);
+    }
+    if (Verbosity()>2)
+    {
+      cout <<__PRETTY_FUNCTION__<<" particle "<<trk_clusters_itr->first<<" -> "
+          <<trk_clusters_itr->second.size()<<" clusters covering "<<layers.size()<<" layers."
+          <<" Layer/clusters cuts are > "<<_min_clusters_per_track
+          <<endl;
+    }
+
+    if (layers.size() >=  _min_clusters_per_track)
+    {
+
+      std::unique_ptr<SvtxTrack_FastSim> svtx_track(new SvtxTrack_FastSim());
+
+      svtx_track->set_id(_track_map->size());
+      svtx_track->set_truth_track_id(trk_clusters_itr->first);
+
+      // assume vertex 0 for now
+      unsigned int vertexId = 0;
+      svtx_track->set_vertex_id(vertexId);
+
+      // set the track position to the vertex position
+      const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);
+      svtx_track->set_x(svtxVertex->get_x());
+      svtx_track->set_y(svtxVertex->get_y());
+      svtx_track->set_z(svtxVertex->get_z()); 
+    
+      // set momentum to the truth value
+      PHG4Particle* particle = _g4truth_container->GetParticle(trk_clusters_itr->first);
+      svtx_track->set_px(particle->get_px());
+      svtx_track->set_py(particle->get_py());
+      svtx_track->set_pz(particle->get_pz());
+      
+      // add the silicon clusters
+      for (TrkrCluster* cluster : trk_clusters_itr->second)
+      {
+        svtx_track->insert_cluster_key(cluster->getClusKey());
+        _assoc_container->SetClusterTrackAssoc(cluster->getClusKey(), svtx_track->get_id());
+      }
+
+      _track_map->insert(svtx_track.get());
+
+      if (Verbosity() >= 2)
+      {
+        cout <<__PRETTY_FUNCTION__<<" particle "<<trk_clusters_itr->first<<" -> "
+            <<trk_clusters_itr->second.size()<<" clusters"
+            <<" _track_map->size = "<< (_track_map->size()) <<": ";
+        _track_map->identify();
+      }
+    }
+  }
+
+  if (Verbosity() >= 2)
+  {
+    cout << "Loop over SvtxSiliconTrackMap entries " << endl;
+    for (SvtxTrackMap::Iter iter = _track_map->begin();
+         iter != _track_map->end(); ++iter)
+    {
+      SvtxTrack* svtx_track = iter->second;
+
+      //svtx_track->identify();
+      //continue;
+
+      cout << "Track ID: " << svtx_track->get_id() << ", Track pT: "
+           << svtx_track->get_pt() << ", Truth Track/Particle ID: "
+           << svtx_track->get_truth_track_id() 
+	   << " vertex ID: " << svtx_track->get_vertex_id() << endl;
+      cout << "   (px, py, pz) = " << "("<< svtx_track->get_px() << ", " << svtx_track->get_py() << ", " << svtx_track->get_pz() << ")" << endl;
+      cout << "   (x, y, z) = " << "("<< svtx_track->get_x() << ", " << svtx_track->get_y() << ", " << svtx_track->get_z() << ")" << endl;
+
+      //Print associated clusters;
+      for (SvtxTrack::ConstClusterKeyIter iter =
+               svtx_track->begin_cluster_keys();
+           iter != svtx_track->end_cluster_keys(); ++iter)
+      {
+        TrkrDefs::cluskey cluster_key = *iter;
+        TrkrCluster* cluster = _cluster_map->findCluster(cluster_key);
+        float radius = sqrt(
+            cluster->getX() * cluster->getX() + cluster->getY() * cluster->getY());
+        cout << "       cluster ID: "
+             << cluster->getClusKey() << ", cluster radius: " << radius
+             << endl;
+      }
+    }
+  }
+  //==================================
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHSiliconTruthTrackSeeding::GetNodes(PHCompositeNode* topNode)
+{
+  _g4truth_container = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  if (!_g4truth_container)
+  {
+    cerr << PHWHERE << " ERROR: Can't find node G4TruthInfo" << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  clusterhitassoc = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
+  if (!clusterhitassoc)
+  {
+    cout << PHWHERE << "Failed to find TRKR_CLUSTERHITASSOC node, quit!" << endl;
+    exit(1);
+  }
+
+  hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
+  if (!hittruthassoc)
+  {
+    cout << PHWHERE << "Failed to find TRKR_HITTRUTHASSOC node, quit!" << endl;
+    exit(1);
+  }
+
+  using nodePair = std::pair<std::string, PHG4HitContainer*&>;
+  std::initializer_list<nodePair> nodes =
+  {
+    { "G4HIT_TPC", phg4hits_tpc },
+    { "G4HIT_INTT", phg4hits_intt },
+    { "G4HIT_MVTX", phg4hits_mvtx },
+    { "G4HIT_MICROMEGAS", phg4hits_micromegas }
+  };
+  
+  for( auto&& node: nodes )
+  {
+    if( !( node.second = findNode::getClass<PHG4HitContainer>( topNode, node.first ) ) )
+    { std::cerr << PHWHERE << " PHG4HitContainer " << node.first << " not found" << std::endl; }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHSiliconTruthTrackSeeding::End()
+{
+  return 0;
+}

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.h
@@ -1,0 +1,95 @@
+/*!
+ *  \file		PHSiliconTruthTrackSeeding.h
+ *  \brief		Vertexing using truth info
+ *  \author		Tony Frawley <afrawley@fsu.edu>
+ */
+
+#ifndef TRACKRECO_PHSILICONTRUTHTRACKSEEDING_H
+#define TRACKRECO_PHSILICONTRUTHTRACKSEEDING_H
+
+#include "PHTrackSeeding.h"
+
+#include <string>  // for string
+
+// forward declarations
+class PHCompositeNode;
+class PHG4TruthInfoContainer;
+class PHG4HitContainer;
+class TrkrClusterHitAssoc;
+class TrkrHitTruthAssoc;
+
+//class SvtxHitMap;
+//class PHG4CellContainer;
+
+/// \class PHSiliconTruthTrackSeeding
+///
+/// \brief Vertexing using truth info
+///
+
+class PHSiliconTruthTrackSeeding : public PHTrackSeeding
+{
+ public:
+  PHSiliconTruthTrackSeeding(const std::string& name = "PHSiliconTruthTrackSeeding");
+
+  unsigned int get_min_clusters_per_track() const
+  {
+    return _min_clusters_per_track;
+  }
+
+  void set_min_clusters_per_track(unsigned int minClustersPerTrack)
+  {
+    _min_clusters_per_track = minClustersPerTrack;
+  }
+
+  void set_min_layer(unsigned int minLayer)
+  {
+    _min_layer = minLayer;
+  }
+
+  void set_max_layer(unsigned int maxLayer)
+  {
+    _max_layer = maxLayer;
+  }
+
+  //! minimal truth momentum cut
+  double get_min_momentum() const
+  {
+    return _min_momentum;
+  }
+
+  //! minimal truth momentum cut
+  void set_min_momentum(double m)
+  {
+    _min_momentum = m;
+  }
+
+ protected:
+  int Setup(PHCompositeNode* topNode) override;
+
+  int Process(PHCompositeNode* topNode) override;
+
+  int End() override;
+
+ private:
+  /// fetch node pointers
+  int GetNodes(PHCompositeNode* topNode);
+
+  PHG4TruthInfoContainer* _g4truth_container = nullptr;
+
+  PHG4HitContainer* phg4hits_tpc = nullptr;
+  PHG4HitContainer* phg4hits_intt = nullptr;
+  PHG4HitContainer* phg4hits_mvtx = nullptr;
+  PHG4HitContainer* phg4hits_micromegas = nullptr;
+
+  TrkrHitTruthAssoc* hittruthassoc = nullptr;
+  TrkrClusterHitAssoc* clusterhitassoc = nullptr;
+
+  unsigned int _min_clusters_per_track = 2;
+  unsigned int _min_layer = 0;
+  unsigned int _max_layer = 6;
+
+  //! minimal truth momentum cut (GeV)
+  double _min_momentum = 50e-3;
+};
+
+#endif

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeedingLinkDef.h
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeedingLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHSiliconTruthTrackSeeding - !;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -103,6 +103,30 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 
       if(g4particle_vec.size() < 1) continue;
 
+      bool test_phi_matching = false;   // normally false
+      if(test_phi_matching)
+	{
+	  // for getting the pT dependence of dphi  to eliminate the bias in phi from PHTpcTracker
+	  if(g4particle_vec.size() == 1)
+	    {
+	      // print out the eta and phi values for analysis in case where match is unique
+	      
+	      double si_phi = atan2(g4particle_vec[0]->get_py(), g4particle_vec[0]->get_px());
+	      double si_eta = asinh(g4particle_vec[0]->get_pz() / sqrt( pow(g4particle_vec[0]->get_px(),2)+pow( g4particle_vec[0]->get_py(),2)));
+	      double si_pt = sqrt(pow(g4particle_vec[0]->get_px(),2)+pow( g4particle_vec[0]->get_py(),2));
+	      
+	      double tpc_phi = atan2(_tracklet->get_py(), _tracklet->get_px());
+	      double tpc_eta = _tracklet->get_eta();
+	      
+	      int phi_match = 0;
+	      int eta_match = 0;
+	      
+	      cout << "         Try: " << "  pt " << si_pt << " tpc_phi " << tpc_phi << " si_phi " <<  si_phi << " phi_match " << phi_match
+		   << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " eta_match " << eta_match << endl;
+	      
+	    }
+	}
+      
       // make copies of the original track for later use
       std::vector<SvtxTrack*> extraTrack; 
       for(int ig4=0;ig4 < g4particle_vec.size()-1; ++ig4)
@@ -130,7 +154,7 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 		}
 	    }
 
-	  // loop over associated clusters to get hits
+	  // loop over associated clusters to get hits for original TPC track, copy to new track
 	  for (SvtxTrack::ConstClusterKeyIter iter = _tracklet->begin_cluster_keys();
 	       iter != _tracklet->end_cluster_keys();
 	       ++iter)

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -11,7 +11,7 @@
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
-#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrack_v1.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxVertexMap.h>
 
@@ -62,10 +62,16 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
   // Loop over all SvtxTracks from the CA seeder
   // These should contain all TPC clusters already
 
+  const unsigned int original_track_map_lastkey = _track_map->end()->first;
+  std::cout << " track map last key = " <<  original_track_map_lastkey << std::endl;
+
   for (auto phtrk_iter = _track_map->begin();
        phtrk_iter != _track_map->end(); 
        ++phtrk_iter)
     {
+      // we may add tracks to the map, so we stop at the last original track
+      if(phtrk_iter->first >= original_track_map_lastkey)  break;
+
       _tracklet = phtrk_iter->second;
       if (Verbosity() >= 1)
 	{
@@ -78,23 +84,78 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 	    << endl;
 	}
 
+      unsigned int vertexId = _tracklet->get_vertex_id();
+      // if the vertex id from the seeder is nonsense, use vertex 0
+      if(vertexId == UINT_MAX)
+	vertexId = 0;
+      _tracklet->set_vertex_id(vertexId);
+
+      // set the track position to the vertex position
+      const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);
+      
+      _tracklet->set_x(svtxVertex->get_x());
+      _tracklet->set_y(svtxVertex->get_y());
+      _tracklet->set_z(svtxVertex->get_z());
+      
+      // identify the best truth track match(es) for this seed track       
+      std::vector<PHG4Particle*> g4particle_vec = getG4PrimaryParticle(_tracklet);
+      //std::cout << " g4particle_vec.size() " << g4particle_vec.size() << std::endl;
+
+      if(g4particle_vec.size() < 1) continue;
+
+      // make copies of the original track for later use
+      std::vector<SvtxTrack*> extraTrack; 
+      for(int ig4=0;ig4 < g4particle_vec.size()-1; ++ig4)
+	{      
+	  SvtxTrack *newTrack = new SvtxTrack_v1();
+	  // Not the first g4particle in the list, we need to add a new copy of the track to the track map and add the silicon clusters to that
+	  const unsigned int lastTrackKey = _track_map->end()->first + ig4;
+	  //std::cout << "   extra track key " << lastTrackKey << std::endl;
+	 	  
+	  newTrack->set_id(lastTrackKey);
+	  newTrack->set_vertex_id(vertexId);
+
+	  newTrack->set_charge(_tracklet->get_charge());
+	  newTrack->set_px(_tracklet->get_px());
+	  newTrack->set_py(_tracklet->get_py());
+	  newTrack->set_pz(_tracklet->get_pz());
+	  newTrack->set_x(_tracklet->get_x());
+	  newTrack->set_y(_tracklet->get_y());
+	  newTrack->set_z(_tracklet->get_z());
+	  for(int i = 0; i < 6; ++i)
+	    {
+	      for(int j = 0; j < 6; ++j)
+		{
+		  newTrack->set_error(i,j, _tracklet->get_error(i,j));
+		}
+	    }
+
+	  // loop over associated clusters to get hits
+	  for (SvtxTrack::ConstClusterKeyIter iter = _tracklet->begin_cluster_keys();
+	       iter != _tracklet->end_cluster_keys();
+	       ++iter)
+	    {
+	      TrkrDefs::cluskey cluster_key = *iter;
+	      newTrack->insert_cluster_key(cluster_key);
+	    }
+	  
+	  extraTrack.push_back(newTrack);
+	  //std::cout << "  added new copy of track " << lastTrackKey << " g4particle_vec.zize " << g4particle_vec.size() << std::endl;
+	  //extraTrack[ig4]->identify();
+	}
+
+      // we just add the silicon clusters to the original track for the first returned g4particle
       
       if (Verbosity() >= 1) 
-	_tracklet->identify(); 
-      
-      // identify the best truth track match for this seed track       
-      PHG4Particle *g4particle = getG4PrimaryParticle(_tracklet);
-      
-      if (Verbosity() >= 1)
-	std::cout << "   g4particleID " << g4particle->get_track_id() 
-		  << " px " <<  g4particle->get_px() 
-		  << " py " <<  g4particle->get_py() 
-		  << " phi " << atan2(g4particle->get_py(), g4particle->get_px() )
-		  << std::endl;
+	{
+	  std::cout << "  original track:" << endl;
+	  _tracklet->identify(); 
+	}
       
       // identify the clusters that are associated with this g4particle
+      PHG4Particle* g4particle = g4particle_vec[0];
       std::set<TrkrDefs::cluskey> clusters = getSiliconClustersFromParticle(g4particle);
-      
+
       for (std::set<TrkrDefs::cluskey>::iterator jter = clusters.begin();
 	   jter != clusters.end();
 	   ++jter)
@@ -103,48 +164,87 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 	  unsigned int layer = TrkrDefs::getLayer(cluster_key);
 	  unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
 	  if (Verbosity() >= 1)  std::cout << "     found cluster with key: " << cluster_key << " in layer " << layer << std::endl;
-	    
-	    // Identify the MVTX and INTT clusters and add them to the SvtxTrack cluster key list
-	    if(trkrid == TrkrDefs::mvtxId)
-	      {
-		 if (Verbosity() >= 1)  std::cout << "            cluster belongs to MVTX, add to track " << std::endl;
-		_tracklet->insert_cluster_key(cluster_key);
-		_assoc_container->SetClusterTrackAssoc(cluster_key, _tracklet->get_id());
-	      }
-	    
-	    if(trkrid == TrkrDefs::inttId)
-	      {
-		 if (Verbosity() >= 1) std::cout << "            cluster belongs to INTT, add to track " << std::endl;
-		  _tracklet->insert_cluster_key(cluster_key);
-		_assoc_container->SetClusterTrackAssoc(cluster_key, _tracklet->get_id());
-	      }
-	  }
-
-      unsigned int vertexId = _tracklet->get_vertex_id();
-      // if the vertex id from the seeder is nonsense, use vertex 0
-      if(vertexId == UINT_MAX)
-	  vertexId = 0;
-
-      _tracklet->set_vertex_id(vertexId);
-
-	// set the track position to the vertex position
-	const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);
-	
-	_tracklet->set_x(svtxVertex->get_x());
-	_tracklet->set_y(svtxVertex->get_y());
-	_tracklet->set_z(svtxVertex->get_z());
- 
+	  
+	  // Identify the MVTX and INTT clusters and add them to the SvtxTrack cluster key list
+	  if(trkrid == TrkrDefs::mvtxId || trkrid == TrkrDefs::inttId)
+	    {
+	      if (Verbosity() >= 1)  std::cout << "            cluster belongs to MVTX or INTT, add to track " << std::endl;
+	      _tracklet->insert_cluster_key(cluster_key);
+	      _assoc_container->SetClusterTrackAssoc(cluster_key, _tracklet->get_id());
+	    }
+	}
+      
       if (Verbosity() >= 1)
 	{
+	  std::cout << " updated original track:" << std::endl;
 	  _tracklet->identify(); 
 	  std::cout << " new cluster keys size " << _tracklet->size_cluster_keys() << endl;
-	  std::cout << "Done with track " << phtrk_iter->first << std::endl;
+	  std::cout << "Done with original track " << phtrk_iter->first << std::endl;
+	}
+      
+      // now add any extra copies of the track      
+      if(g4particle_vec.size() > 1)
+	{
+	  for(int ig4=0;ig4 < g4particle_vec.size()-1; ++ ig4)
+	    {      
+	      PHG4Particle* g4particle = g4particle_vec[ig4];
+	      
+	      if (Verbosity() >= 1)
+		std::cout << "   ig4  " << ig4 << " g4particleID " << g4particle->get_track_id() 
+			  << " px " <<  g4particle->get_px() 
+			  << " py " <<  g4particle->get_py() 
+			  << " phi " << atan2(g4particle->get_py(), g4particle->get_px() )
+			  << std::endl;
+	      
+	      // identify the clusters that are associated with this g4particle
+	      std::set<TrkrDefs::cluskey> clusters = getSiliconClustersFromParticle(g4particle);
+	      	
+	      // Not the first g4particle in the list, we need to add a new copy of the track to the track map and add the silicon clusters to that
+	      const unsigned int lastTrackKey = _track_map->end()->first;
+	      //std::cout << "   lastTrackKey " << lastTrackKey << std::endl;
+	      
+	      extraTrack[ig4]->set_id(lastTrackKey);
+	      
+	      if (Verbosity() >= 1) 
+		{
+		  std::cout << "  original (copy) track:" << endl;
+		  extraTrack[ig4]->identify(); 
+		}
+	      
+	      _track_map->insert(extraTrack[ig4]);
+	      
+	      for (std::set<TrkrDefs::cluskey>::iterator jter = clusters.begin();
+		   jter != clusters.end();
+		   ++jter)
+		{
+		  TrkrDefs::cluskey cluster_key = *jter;
+		  unsigned int layer = TrkrDefs::getLayer(cluster_key);
+		  unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+		  if (Verbosity() >= 1)  std::cout << "     found cluster with key: " << cluster_key << " in layer " << layer << std::endl;
+		  
+		  // Identify the MVTX and INTT clusters and add them to the SvtxTrack cluster key list
+		  if(trkrid == TrkrDefs::mvtxId || trkrid == TrkrDefs::inttId)
+		    {
+		      if (Verbosity() >= 1)  std::cout << "            cluster belongs to MVTX or INTT, add to track " << std::endl;
+		      extraTrack[ig4]->insert_cluster_key(cluster_key);
+		      _assoc_container->SetClusterTrackAssoc(cluster_key, extraTrack[ig4]->get_id());
+		    }
+		}
+	      
+	      if (Verbosity() >= 1)
+		{
+		  std::cout << " updated additional track:" << std::endl;
+		  extraTrack[ig4]->identify(); 
+		  std::cout << " new cluster keys size " << extraTrack[ig4]->size_cluster_keys() << endl;
+		  std::cout << "Done with extra track " << extraTrack[ig4]->get_id()  << std::endl;
+		}
+	    }
 	}
     }
-
+  
   if (Verbosity() >= 1)
     cout << "PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;  
-
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -235,13 +335,14 @@ int  PHTruthSiliconAssociation::GetNodes(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-PHG4Particle* PHTruthSiliconAssociation::getG4PrimaryParticle(SvtxTrack *track)
+std::vector<PHG4Particle*> PHTruthSiliconAssociation::getG4PrimaryParticle(SvtxTrack *track)
 {
   // Find the best g4particle match to the clusters associated with this reco track
 
-  PHG4Particle* g4part = 0;
+  std::vector<PHG4Particle*> g4part_vec;
   std::set<int> pid;
   std::multimap<int, int> pid_count;
+  int minfound = 200;  // require at least this many hits to be put on the list of contributing particles
 
   // loop over associated clusters to get hits
   for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
@@ -250,7 +351,7 @@ PHG4Particle* PHTruthSiliconAssociation::getG4PrimaryParticle(SvtxTrack *track)
     {
       TrkrDefs::cluskey cluster_key = *iter;
 
-      // get all truth hits for this cluster
+      // get all reco hits for this cluster
       TrkrClusterHitAssoc::ConstRange hitrange = _cluster_hit_map->getHits(cluster_key);  // returns range of pairs {cluster key, hit key} for this cluskey
       for(TrkrClusterHitAssoc::ConstIterator clushititer = hitrange.first; clushititer != hitrange.second; ++clushititer)
 	{
@@ -285,24 +386,28 @@ PHG4Particle* PHTruthSiliconAssociation::getG4PrimaryParticle(SvtxTrack *track)
 	    } // end loop over g4hits associated with hitsetkey and hitkey
 	} // end loop over hits associated with cluskey  
     }  // end loop over clusters associated with this track
-  
-  int maxfound = -1;
+
+
+  // loop over the particle id's, and count the number for each one
   for( auto it = pid.begin(); it != pid.end(); ++it)
     {
+      if(*it < 0) continue;   // ignore secondary particles
+
       int nfound = 0;
       std::pair<std::multimap<int, int>::iterator, std::multimap<int,int>::iterator> this_pid = pid_count.equal_range(*it);
-      for(auto it = this_pid.first; it != this_pid.second; ++it)
+      for(auto cnt_it = this_pid.first; cnt_it != this_pid.second; ++cnt_it)
 	{
 	  nfound++;	  
 	}
-      if(nfound > maxfound)
+
+      if(Verbosity() >= 1) std::cout << "    pid: " << *it << "  nfound " << nfound << std::endl;
+      if(nfound > minfound)
 	{  
-	  maxfound = nfound;
-	  g4part = _truthinfo->GetParticle(*it);
+	  g4part_vec.push_back(_truthinfo->GetParticle(*it));
 	}
     }
 
-  return g4part;
+  return g4part_vec;
   
 }
 

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -327,7 +327,7 @@ int  PHTruthSiliconAssociation::GetNodes(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  _g4hits_tpc = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_TPC");
+   _g4hits_tpc = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_TPC");
   _g4hits_intt = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_INTT");
   _g4hits_mvtx = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_MVTX");
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -129,7 +129,7 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
       
       // make copies of the original track for later use
       std::vector<SvtxTrack*> extraTrack; 
-      for(int ig4=0;ig4 < g4particle_vec.size()-1; ++ig4)
+      for(unsigned int ig4=0;ig4 < g4particle_vec.size()-1; ++ig4)
 	{      
 	  SvtxTrack *newTrack = new SvtxTrack_v1();
 	  // Not the first g4particle in the list, we need to add a new copy of the track to the track map and add the silicon clusters to that
@@ -209,7 +209,7 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
       // now add any extra copies of the track      
       if(g4particle_vec.size() > 1)
 	{
-	  for(int ig4=0;ig4 < g4particle_vec.size()-1; ++ ig4)
+	  for(unsigned int ig4=0;ig4 < g4particle_vec.size()-1; ++ ig4)
 	    {      
 	      PHG4Particle* g4particle = g4particle_vec[ig4];
 	      

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <set>
+#include <vector>
 
 class PHCompositeNode;
 class SvtxTrackMap;
@@ -67,7 +68,7 @@ class PHTruthSiliconAssociation : public SubsysReco
 
   int GetNodes(PHCompositeNode* topNode);
 
-  PHG4Particle* getG4PrimaryParticle(SvtxTrack *track);
+  std::vector<PHG4Particle*> getG4PrimaryParticle(SvtxTrack *track);
   std::set<TrkrDefs::cluskey> getSiliconClustersFromParticle(PHG4Particle* g4particle);
   
   PHG4TruthInfoContainer *_truthinfo{nullptr};


### PR DESCRIPTION
Introduces two modules that are intended to replace PHGenFitTrkProp. 
**PHSiliconTruthTrackSeeding** uses truth information to assemble silicon detector clusters into track stubs, and puts them on the node tree in a separate map. It will eventually be replaced with a real silicon track stub finder.
**PHSiliconTpcTrackMatching** reads the silicon track stubs from the node tree, and the TPC track stubs from the CA TPC track seeder(s). It associates them into full tracks. No truth information is used. All associations falling within the matching windows are accepted, duplicating the TPC track stubs as needed. The search windows used for matching have been optimized to reproduce the truth silicon association results from the PHTruthSiliconAssociation module. 
The reconstruction chain used for testing this is:
PHTpcTracker + PHSiliconTruthTrackSeeding + PHSiliconTpcTrackMatching + PHActsTrkFitter
This plot shows a comparison of the track finding efficiency for tracks that are associated with the MVTX for this track stub matching code, truth silicon association with TPC tracks from the PHTruthSiliconAssociation module, and the Hough + Genfit reconstruction chain. They were made using high occupancy events with 400 muons thrown into 0.2 units of eta (equivalent to 4K muons into full acceptance).  
[tuned_stub_truth_genfit_combeff_occ4k.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5247048/tuned_stub_truth_genfit_combeff_occ4k.pdf)
