### PR TITLE
Multiple vertices, silicon-TPC track stub matching improvements, PHTpcTracker fix

### DIFF
--- a/offline/packages/PHTpcTracker/PHTpcTracker.cc
+++ b/offline/packages/PHTpcTracker/PHTpcTracker.cc
@@ -154,6 +154,11 @@ int PHTpcTracker::Process(PHCompositeNode* topNode)
     TMatrixDSym cov = gtracks[i]->getGenFitTrack()->getCovSeed();
     //cout<< "pt: " << pos.Perp() << endl;
 
+    //double charge =  gtracks[i]->get_charge();
+    double charge =  -gtracks[i]->get_charge();   // kludge to get Acts tracking to work - disagreement about magfield sign?
+
+    svtx_track->set_charge(charge);
+
     for (int k = 0; k < 6; k++)
     {
       for (int j = 0; j < 6; j++)

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -130,9 +130,14 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
                                  track->get_py() * Acts::UnitConstants::GeV,
                                  track->get_pz() * Acts::UnitConstants::GeV);
 
+    // just set to 10 ns for now?
+    const double trackTime = 10 * Acts::UnitConstants::ns;
+    const int trackQ = track->get_charge();
+    
     if(Verbosity() > 0)
       {
 	std::cout << PHWHERE << std::endl;
+	std::cout << " Seed trackQ " << trackQ << std::endl;
 	std::cout << " seedPos " << seedPos[0] << "  " << seedPos[1] << "  " << seedPos[2] << std::endl;
 	std::cout << " seedMom " << seedMom[0] << "  " << seedMom[1] << "  " << seedMom[2] << std::endl;
 	// diagonal track cov is square of (err_x_local, err_y_local,  err_phi, err_theta, err_q/p, err_time) 
@@ -146,10 +151,6 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 	    std::cout << std::endl;
 	  }
       }
-
-    // just set to 10 ns for now?
-    const double trackTime = 10 * Acts::UnitConstants::ns;
-    const int trackQ = track->get_charge();
 
     const ActsExamples::TrackParameters trackSeed(
                                         seedCov, 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -377,6 +377,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
   track->set_py(params.momentum()(1));
   track->set_pz(params.momentum()(2));
   
+  track->set_charge(params.charge());
   track->set_chisq(trajState.chi2Sum);
   track->set_ndf(trajState.NDF);
 

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -240,8 +240,9 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
       svtx_track->set_id(_track_map->size());
       svtx_track->set_truth_track_id(trk_clusters_itr->first);
 
-      // assume vertex 0 for now
-      unsigned int vertexId = 0;
+      // assign truth particle vertex ID to this silicon track stub
+      PHG4Particle* particle = _g4truth_container->GetParticle(trk_clusters_itr->first);
+      int vertexId = particle->get_vtx_id() - 1;  // Geant likes to count from 1
       svtx_track->set_vertex_id(vertexId);
 
       // set the track position to the vertex position
@@ -249,9 +250,14 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
       svtx_track->set_x(svtxVertex->get_x());
       svtx_track->set_y(svtxVertex->get_y());
       svtx_track->set_z(svtxVertex->get_z()); 
-    
+
+      if(Verbosity() > 0)
+	{
+	  std::cout << " truth track vertex id is " << vertexId << " for truth particle " << trk_clusters_itr->first << std::endl;
+	  std::cout << "    track position x,y,z = " << svtxVertex->get_x() << ", " << svtxVertex->get_y() << ", " << svtxVertex->get_z() << std::endl;	  
+	}
+
       // set momentum to the truth value
-      PHG4Particle* particle = _g4truth_container->GetParticle(trk_clusters_itr->first);
       svtx_track->set_px(particle->get_px());
       svtx_track->set_py(particle->get_py());
       svtx_track->set_pz(particle->get_pz());

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -243,7 +243,11 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
       // assign truth particle vertex ID to this silicon track stub
       PHG4Particle* particle = _g4truth_container->GetParticle(trk_clusters_itr->first);
       int vertexId = particle->get_vtx_id() - 1;  // Geant likes to count from 1
+      if(vertexId < 0) vertexId = 0;    // secondary particle, arbitrarily set vertexId to 0
       svtx_track->set_vertex_id(vertexId);
+
+      if(Verbosity() > 0)
+	std::cout << " truth track vertex id is " << vertexId << " for truth particle " << trk_clusters_itr->first << std::endl;
 
       // set the track position to the vertex position
       const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -255,7 +255,10 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
       svtx_track->set_px(particle->get_px());
       svtx_track->set_py(particle->get_py());
       svtx_track->set_pz(particle->get_pz());
-      
+
+      if(Verbosity() > 0)
+	std::cout << PHWHERE << "Truth track ID is " << svtx_track->get_truth_track_id() << " particle ID is " << particle->get_pid() <<  std::endl;
+    
       // add the silicon clusters
       for (TrkrCluster* cluster : trk_clusters_itr->second)
       {


### PR DESCRIPTION
1) PHTpcTracker did not set the charge sign for tracks. They all defaulted to -1. The Genfit chain does not care, but the Acts chain does. For now, the charge sign is set and then reversed, because Acts has a different opinion about the direction of the magnetic field (apparently). Joe is working on that. This was not apparent until now because I was testing with positive muons, which were given the wrong sign by PHTpcTracker, thus making Acts happy (!!).
2) Updated PHSiliconTpcTrackMatching to properly handle the phi bias correction from PHTpcTracker for negative tracks, which bend the other way (duh). This was also not noticed because I was testing with positive muons.
3) Modified PHSiliconTruthTrackSeeding to associate the silicon track stubs with the vertex of the truth particle. Modified PHSiliconTpcTrackMatching so that the combined silicon-tpc track takes the vertex from the silicon track stub. That is the way we will do it for real data - associate silicon track stubs with a vertex, and associate TPC track stubs with the silicon track stubs. This change allows the Acts chain to handle tracks from multiple event vertices. 
