### PR TITLE
implement skipping for non syncing input managers

### DIFF
--- a/generators/phhepmc/Fun4AllHepMCInputManager.h
+++ b/generators/phhepmc/Fun4AllHepMCInputManager.h
@@ -11,9 +11,7 @@
 
 #include <utility>                                  // for swap
 
-#if !defined(__CINT__) || defined (__CLING__)
 #include <boost/iostreams/filtering_streambuf.hpp>
-#endif
 
 class PHCompositeNode;
 class SyncObject;
@@ -80,6 +78,8 @@ class Fun4AllHepMCInputManager : public Fun4AllInputManager
   //! negative IDs are backgrounds, .e.g out of time pile up collisions
   //! Usually, ID = 0 means the primary Au+Au collision background
   void set_embedding_id(int id) { hepmc_helper.set_embedding_id(id); }
+
+  int SkipForThisManager(const int nevents) {return PushBackEvents(nevents);}
 
  protected:
 

--- a/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
@@ -62,8 +62,11 @@ Fun4AllHepMCPileupInputManager::~Fun4AllHepMCPileupInputManager()
 
 int Fun4AllHepMCPileupInputManager::SkipForThisManager(const int nevents)
 {
-
-  int iret = run(nevents, true);
+  int iret = 0;
+  for (int i=0; i<nevents; ++i)
+  {
+  iret |= run(1, true);
+  }
   return iret;
 }
 
@@ -155,7 +158,8 @@ int Fun4AllHepMCPileupInputManager::run(const int nevents, const bool skip)
           if (Verbosity() > 0)
           {
 	    cout << "Fun4AllHepMCPileupInputManager::run::" << Name();
-            cout << "hepmc evt no: " << evt->event_number() << endl;
+	    if (skip) cout << " skip";
+            cout << " hepmc evt no: " << evt->event_number() << endl;
           }
           events_total++;
           events_thisfile++;

--- a/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
@@ -60,7 +60,14 @@ Fun4AllHepMCPileupInputManager::~Fun4AllHepMCPileupInputManager()
   gsl_rng_free(RandomGenerator);
 }
 
-int Fun4AllHepMCPileupInputManager::run(const int nevents)
+int Fun4AllHepMCPileupInputManager::SkipForThisManager(const int nevents)
+{
+
+  int iret = run(nevents, true);
+  return iret;
+}
+
+int Fun4AllHepMCPileupInputManager::run(const int nevents, const bool skip)
 {
   if (_first_run)
   {
@@ -145,9 +152,9 @@ int Fun4AllHepMCPileupInputManager::run(const int nevents)
         }
         else
         {
-          MySyncManager()->CurrentEvent(evt->event_number());
           if (Verbosity() > 0)
           {
+	    cout << "Fun4AllHepMCPileupInputManager::run::" << Name();
             cout << "hepmc evt no: " << evt->event_number() << endl;
           }
           events_total++;
@@ -164,7 +171,8 @@ int Fun4AllHepMCPileupInputManager::run(const int nevents)
           }
         }
       }  // loop until retrieve a valid event
-
+      if (!skip)
+      {
       PHHepMCGenEventMap *geneventmap = hepmc_helper.get_geneventmap();
       PHHepMCGenEvent *genevent = nullptr;
       if (hepmc_helper.get_embedding_id() > 0)
@@ -185,7 +193,7 @@ int Fun4AllHepMCPileupInputManager::run(const int nevents)
       hepmc_helper.move_vertex(genevent);
       // place to the crossing center in time
       genevent->moveVertex(0, 0, 0, t0);
-
+      }
     }  //    for (int icollision = 0; icollision < ncollisions; ++icollision)
 
   }  //  for (int icrossing = _min_crossing; icrossing <= _max_crossing; ++icrossing)

--- a/generators/phhepmc/Fun4AllHepMCPileupInputManager.h
+++ b/generators/phhepmc/Fun4AllHepMCPileupInputManager.h
@@ -5,9 +5,7 @@
 
 #include <string>
 
-#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
-#endif
 
 //! Generate pile up collisions based on beam parameter
 //! If set_embedding_id(i) with a negative number or 0, the pile up event will be inserted with increasing positive embedding_id. This is the default operation mode.
@@ -20,7 +18,9 @@ class Fun4AllHepMCPileupInputManager : public Fun4AllHepMCInputManager
                                  const std::string &topnodename = "TOP");
   virtual ~Fun4AllHepMCPileupInputManager();
 
-  int run(const int nevents = 0);
+  int run(const int nevents = 0) {return run(nevents,false);}
+
+  int run(const int nevents, const bool skip);
 
   /// past times are negative, future times are positive
   void set_time_window(double past_nsec, double future_nsec)
@@ -33,6 +33,8 @@ class Fun4AllHepMCPileupInputManager : public Fun4AllHepMCInputManager
   void set_collision_rate(double Hz) { _collision_rate = Hz; }
   /// time between bunch crossing in ns
   void set_time_between_crossings(double nsec) { _time_between_crossings = nsec; }
+
+  int SkipForThisManager(const int nevents);
 
  private:
   /// past times are negative, future times are positive
@@ -50,9 +52,7 @@ class Fun4AllHepMCPileupInputManager : public Fun4AllHepMCInputManager
 
   bool _first_run;
 
-#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *RandomGenerator;
-#endif
 };
 
 #endif /* PHHEPMC_FUN4ALLHEPMCINPUTMANAGER_H */

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -57,6 +57,7 @@ class Fun4AllInputManager : public Fun4AllBase
   std::string TopNodeName() const { return m_TopNodeName; }
   bool FileListEmpty() const { return m_FileList.empty(); }
   virtual int IsOpen() const { return m_IsOpen; }
+  virtual int SkipForThisManager(const int nevents) {return 0;}
 
  protected:
   Fun4AllInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");

--- a/offline/framework/fun4all/Fun4AllNoSyncDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllNoSyncDstInputManager.h
@@ -29,6 +29,8 @@ class Fun4AllNoSyncDstInputManager : public Fun4AllDstInputManager
 
   // turn off reading of the runwise TTree to make run mixing for embedding possible
   int NoRunTTree();
+
+  int SkipForThisManager(const int nevents) {return PushBackEvents(nevents);}
 };
 
 #endif /* __FUN4ALLNOSYNCDSTINPUTMANAGER_H__ */

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -500,15 +500,10 @@ TNamed *Fun4AllServer::getHisto(const string &hname) const
   return (ServerHistoManager->getHisto(hname));
 }
 
-int Fun4AllServer::process_event(PHCompositeNode * /*topNode*/)
-{
-  int iret = process_event();
-  return iret;
-}
 
 int Fun4AllServer::process_event()
 {
-  vector<pair<SubsysReco *, PHCompositeNode *> >::iterator iter;
+  vector<pair<SubsysReco *, PHCompositeNode *>>::iterator iter;
   unsigned icnt = 0;
   int eventbad = 0;
   if (ScreamEveryEvent)
@@ -1423,7 +1418,6 @@ int Fun4AllServer::run(const int nevnts, const bool require_nevents)
         BeginRun(runnumber);
       }
     }
-
     if (Verbosity() >= VERBOSITY_SOME)
     {
       // print event cycle counter in log scale if VERBOSITY_SOME

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -56,7 +56,6 @@ class Fun4AllServer : public Fun4AllBase
   void InitAll();
   int BeginRunTimeStamp(PHTimeStamp &TimeStp);
   int dumpHistos(const std::string &filename, const std::string &openmode = "RECREATE");
-  int process_event(PHCompositeNode *topNode);
   int Reset();
   virtual int BeginRun(const int runno);
   virtual int EndRun(const int runno = 0);

--- a/offline/framework/fun4all/Fun4AllSyncManager.cc
+++ b/offline/framework/fun4all/Fun4AllSyncManager.cc
@@ -242,6 +242,10 @@ int Fun4AllSyncManager::skip(const int nevnts)
     // giving it a negative argument will skip events
     // this is much faster than actually reading the events in
     int iret = m_InManager[0]->PushBackEvents(Npushback);
+    for (unsigned int i=1; i<m_InManager.size(); ++i)
+    {
+      iret += m_InManager[i]->SkipForThisManager(nevnts);
+    }
     if (!iret)
     {
       return 0;


### PR DESCRIPTION
This PR is a quick (but reasonable) fix to skip events in the pileup manager properly so skipping will preserve the event ordering one would see when just running. The same change was applied to the nosync manager, so it will also advance its event counter. The mechanics need some more cleanup to get event numbers right and pushing back the previous events in case of reread. This will take a bit longer and will come in a later PR.