### PR TITLE
Add projection variable output for TOF analysis

### DIFF
--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -261,7 +261,7 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
 
     SvtxTrack_FastSim *track = nullptr;
 
-    //std::cout << "TRACKmap size " << m_TrackMap->size() << std::endl;
+    if (Verbosity()) cout << __PRETTY_FUNCTION__ << "TRACKmap size " << m_TrackMap->size() << std::endl;
     for (SvtxTrackMap::ConstIter track_itr = m_TrackMap->begin();
          track_itr != m_TrackMap->end();
          track_itr++)
@@ -277,7 +277,7 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
         }
         continue;
       }
-      //std::cout << " PARTICLE!" << std::endl;
+      if (Verbosity()) cout << __PRETTY_FUNCTION__ << " PARTICLE!" << std::endl;
 
       if ((temp->get_truth_track_id() - g4particle->get_track_id()) == 0)
       {
@@ -332,11 +332,11 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
            trkstates != track->end_states();
            ++trkstates)
       {
-        //	cout << "checking " << trkstates->second->get_name() << endl;
+        if (Verbosity()) cout << __PRETTY_FUNCTION__ << " checking " << trkstates->second->get_name() << endl;
         map<string, unsigned int>::const_iterator iter = m_ProjectionNameMap.find(trkstates->second->get_name());
         if (iter != m_ProjectionNameMap.end())
         {
-          //	  cout << "found " << trkstates->second->get_name() << endl;
+          if (Verbosity()) cout << __PRETTY_FUNCTION__ << " found " << trkstates->second->get_name() << endl;
           // setting the projection (xyz and pxpypz)
           for (int i = 0; i < 3; i++)
           {
@@ -350,17 +350,17 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
           PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
           if (!hits)
           {
-            //            cout << "could not find " << nodename << endl;
+            if (Verbosity()) cout << __PRETTY_FUNCTION__ << " could not find " << nodename << endl;
             continue;
           }
-          //	  cout << "number of hits: " << hits->size() << endl;
+          if (Verbosity()) cout << __PRETTY_FUNCTION__ << " number of hits: " << hits->size() << endl;
           PHG4HitContainer::ConstRange hit_range = hits->getHits();
           for (PHG4HitContainer::ConstIterator hit_iter = hit_range.first; hit_iter != hit_range.second; hit_iter++)
           {
-            //	    cout << "checking hit id " << hit_iter->second->get_trkid() << " against " << track->get_truth_track_id() << endl;
+            if (Verbosity()) cout << __PRETTY_FUNCTION__ << " checking hit id " << hit_iter->second->get_trkid() << " against " << track->get_truth_track_id() << endl;
             if (hit_iter->second->get_trkid() - track->get_truth_track_id() == 0)
             {
-              //	      cout << "found hit with id " << hit_iter->second->get_trkid() << endl;
+              if (Verbosity()) cout << __PRETTY_FUNCTION__ << " found hit with id " << hit_iter->second->get_trkid() << endl;
               if (iter->second > m_ProjectionNameMap.size())
               {
                 cout << "bad index: " << iter->second << endl;

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -43,7 +43,7 @@
 
 using namespace std;
 
-const string xyz[3] = {"x", "y", "z"};
+const string xyzt[] = {"x", "y", "z", "t"};
 
 //----------------------------------------------------------------------------//
 //-- Constructor:
@@ -134,15 +134,23 @@ int PHG4TrackFastSimEval::InitRun(PHCompositeNode *topNode)
 {
   for (map<string, unsigned int>::const_iterator iter = m_ProjectionNameMap.begin(); iter != m_ProjectionNameMap.end(); ++iter)
   {
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 4; i++)
     {
-      string bname = iter->first + "_proj_" + xyz[i];
+      string bname = iter->first + "_proj_" + xyzt[i];
       string bdef = bname + "/F";
+
+      // fourth element is the path length
+      if (i == 3)
+      {
+        bdef = iter->first + "_proj_path_length" + "/F";
+      }
+
       m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_proj_vec[iter->second][i], bdef.c_str());
     }
+
     for (int i = 0; i < 3; i++)
     {
-      string bname = iter->first + "_proj_p" + xyz[i];
+      string bname = iter->first + "_proj_p" + xyzt[i];
       string bdef = bname + "/F";
       m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_proj_p_vec[iter->second][i], bdef.c_str());
     }
@@ -150,15 +158,15 @@ int PHG4TrackFastSimEval::InitRun(PHCompositeNode *topNode)
     PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
     if (hits)
     {
-      for (int i = 0; i < 3; i++)
+      for (int i = 0; i < 4; i++)
       {
-        string bname = iter->first + "_" + xyz[i];
+        string bname = iter->first + "_" + xyzt[i];
         string bdef = bname + "/F";
         m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_vec[iter->second][i], bdef.c_str());
       }
       for (int i = 0; i < 3; i++)
       {
-        string bname = iter->first + "_p" + xyz[i];
+        string bname = iter->first + "_p" + xyzt[i];
         string bdef = bname + "/F";
 
         m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_p_vec[iter->second][i], bdef.c_str());
@@ -335,6 +343,8 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
             m_TTree_proj_vec[iter->second][i] = trkstates->second->get_pos(i);
             m_TTree_proj_p_vec[iter->second][i] = trkstates->second->get_mom(i);
           }
+          // fourth element is the path length
+          m_TTree_proj_vec[iter->second][3] = trkstates->first;
 
           string nodename = "G4HIT_" + trkstates->second->get_name();
           PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
@@ -359,6 +369,8 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
               m_TTree_ref_vec[iter->second][0] = hit_iter->second->get_x(0);
               m_TTree_ref_vec[iter->second][1] = hit_iter->second->get_y(0);
               m_TTree_ref_vec[iter->second][2] = hit_iter->second->get_z(0);
+              m_TTree_ref_vec[iter->second][3] = hit_iter->second->get_t(0);
+
               m_TTree_ref_p_vec[iter->second][0] = hit_iter->second->get_px(0);
               m_TTree_ref_p_vec[iter->second][1] = hit_iter->second->get_py(0);
               m_TTree_ref_p_vec[iter->second][2] = hit_iter->second->get_pz(0);
@@ -560,7 +572,7 @@ int PHG4TrackFastSimEval::GetNodes(PHCompositeNode *topNode)
 
 void PHG4TrackFastSimEval::AddProjection(const string &name)
 {
-  vector<float> floatvec{-9999, -9999, -9999};
+  vector<float> floatvec{-9999, -9999, -9999, -9999};
   m_TTree_proj_vec.push_back(floatvec);
   m_TTree_proj_p_vec.push_back(floatvec);
   m_TTree_ref_vec.push_back(floatvec);


### PR DESCRIPTION
In the EIC fast tracking module, add projection variable output for TOF analysis:

1. truth hit time from Geant4: `<detector>_t`
2. reconstructed path length from the vertex PCA: `<detector>_proj_path_length`

Quick test taking FST_5 as LGAD TOF: 
https://github.com/sPHENIX-Collaboration/macros/compare/master...blackcathj:EIC-TOF-Projection?expand=1 
and output looks like this:
```
root G4EICDetector_g4tracking_eval.root                                 
root [0] 
Attaching file G4EICDetector_g4tracking_eval.root as _file0...
(TFile *) 0x152cb40
root [1] tracks->Show(3)
 event           = 1
 gtrackID        = 4
 gflavor         = -211
...
 FST_5_proj_x    = 0.283821
 FST_5_proj_y    = -32.3717
 FST_5_proj_z    = 280
 **FST_5_proj_path_length** = 282.679
...
 FST_5_x         = 0.283815
 FST_5_y         = -32.3705
 FST_5_z         = 280
 **FST_5_t**         = 9.42792
```