### PR TITLE
Actsv1.0

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -301,15 +301,15 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
     auto meas = std::get<Measurement>(*state.uncalibrated());
 
     /// Get local position
-    Acts::Vector2D local(meas.parameters()[Acts::ParDef::eLOC_0],
-                         meas.parameters()[Acts::ParDef::eLOC_1]);
+    Acts::Vector2D local(meas.parameters()[Acts::eBoundLoc0],
+                         meas.parameters()[Acts::eBoundLoc1]);
+    
     /// Get global position
-    Acts::Vector3D global(0, 0, 0);
     /// This is an arbitrary vector. Doesn't matter in coordinate transformation
     /// in Acts code
     Acts::Vector3D mom(1, 1, 1);
-    meas.referenceObject().localToGlobal(m_tGeometry->geoContext,
-                                          local, mom, global);
+    Acts::Vector3D global = meas.referenceObject().localToGlobal(m_tGeometry->geoContext,
+                                          local, mom);
 
     /// Get measurement covariance
     auto cov = meas.covariance();
@@ -331,16 +331,13 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
     float gz = globalTruthPos(2);
 
     /// Get local truth position
-    Acts::Vector2D truthlocal;
-
     const float r = sqrt(gx * gx + gy * gy + gz * gz);
     Acts::Vector3D globalTruthUnitDir(gx / r, gy / r, gz / r);
 
-    meas.referenceObject().globalToLocal(
+    auto vecResult = meas.referenceObject().globalToLocal(
         m_tGeometry->geoContext,
         globalTruthPos,
-        globalTruthUnitDir,
-        truthlocal);
+        globalTruthUnitDir);
 
     /// Push the truth hit info
     m_t_x.push_back(gx);
@@ -361,9 +358,19 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
     float momentum = sqrt(m_t_px * m_t_px +
                           m_t_py * m_t_py +
                           m_t_pz * m_t_pz);
+    
+    if(vecResult.ok())
+      {
+	Acts::Vector2D truthLocVec = vecResult.value();
+	truthLOC0 = truthLocVec.x();
+	truthLOC1 = truthLocVec.y();
+      }
+    else
+      {
+	truthLOC0 = -9999.;
+	truthLOC1 = -9999.;
+      }
 
-    truthLOC0 = truthlocal.x();
-    truthLOC1 = truthlocal.y();
     truthPHI = phi(globalTruthUnitDir);
     truthTHETA = theta(globalTruthUnitDir);
     truthQOP =
@@ -384,95 +391,99 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
       predicted = true;
       m_nPredicted++;
       
-      Acts::BoundParameters parameter(
-	        state.referenceSurface().getSharedPtr(),
-		state.predicted(),
-		state.predictedCovariance());
-
+      auto parameters = state.predicted();
       auto covariance = state.predictedCovariance();
 
       /// Local hit residual info
       auto H = meas.projector();
       auto resCov = cov + H * covariance * H.transpose();
-      auto residual = meas.residual(parameter);
-      m_res_x_hit.push_back(residual(Acts::ParDef::eLOC_0));
-      m_res_y_hit.push_back(residual(Acts::ParDef::eLOC_1));
+      auto residual = meas.residual(parameters);
+      m_res_x_hit.push_back(residual(Acts::eBoundLoc0));
+      m_res_y_hit.push_back(residual(Acts::eBoundLoc1));
       m_err_x_hit.push_back(
-          sqrt(resCov(Acts::ParDef::eLOC_0, Acts::ParDef::eLOC_0)));
+          sqrt(resCov(Acts::eBoundLoc0, Acts::eBoundLoc0)));
       m_err_y_hit.push_back(
-          sqrt(resCov(Acts::ParDef::eLOC_1, Acts::ParDef::eLOC_1)));
+          sqrt(resCov(Acts::eBoundLoc1, Acts::eBoundLoc1)));
       m_pull_x_hit.push_back(
-          residual(Acts::ParDef::eLOC_0) /
-          sqrt(resCov(Acts::ParDef::eLOC_0, Acts::ParDef::eLOC_0)));
+          residual(Acts::eBoundLoc0) /
+          sqrt(resCov(Acts::eBoundLoc0, Acts::eBoundLoc0)));
       m_pull_y_hit.push_back(
-          residual(Acts::ParDef::eLOC_1) /
-          sqrt(resCov(Acts::ParDef::eLOC_1, Acts::ParDef::eLOC_1)));
+          residual(Acts::eBoundLoc1) /
+          sqrt(resCov(Acts::eBoundLoc1, Acts::eBoundLoc1)));
       m_dim_hit.push_back(state.calibratedSize());
 
       /// Predicted parameter
-      m_eLOC0_prt.push_back(parameter.parameters()[Acts::ParDef::eLOC_0]);
-      m_eLOC1_prt.push_back(parameter.parameters()[Acts::ParDef::eLOC_1]);
-      m_ePHI_prt.push_back(parameter.parameters()[Acts::ParDef::ePHI]);
-      m_eTHETA_prt.push_back(parameter.parameters()[Acts::ParDef::eTHETA]);
-      m_eQOP_prt.push_back(parameter.parameters()[Acts::ParDef::eQOP]);
-      m_eT_prt.push_back(parameter.parameters()[Acts::ParDef::eT]);
+      m_eLOC0_prt.push_back(parameters[Acts::eBoundLoc0]);
+      m_eLOC1_prt.push_back(parameters[Acts::eBoundLoc1]);
+      m_ePHI_prt.push_back(parameters[Acts::eBoundPhi]);
+      m_eTHETA_prt.push_back(parameters[Acts::eBoundTheta]);
+      m_eQOP_prt.push_back(parameters[Acts::eBoundQOverP]);
+      m_eT_prt.push_back(parameters[Acts::eBoundTime]);
 
       /// Predicted residual
-      m_res_eLOC0_prt.push_back(parameter.parameters()[Acts::ParDef::eLOC_0] -
+      m_res_eLOC0_prt.push_back(parameters[Acts::eBoundLoc0] -
                                 truthLOC0);
-      m_res_eLOC1_prt.push_back(parameter.parameters()[Acts::ParDef::eLOC_1] -
+      m_res_eLOC1_prt.push_back(parameters[Acts::eBoundLoc1] -
                                 truthLOC1);
-      m_res_ePHI_prt.push_back(parameter.parameters()[Acts::ParDef::ePHI] -
+      m_res_ePHI_prt.push_back(parameters[Acts::eBoundPhi] -
                                truthPHI);
       m_res_eTHETA_prt.push_back(
-          parameter.parameters()[Acts::ParDef::eTHETA] - truthTHETA);
-      m_res_eQOP_prt.push_back(parameter.parameters()[Acts::ParDef::eQOP] -
+          parameters[Acts::eBoundTheta] - truthTHETA);
+      m_res_eQOP_prt.push_back(parameters[Acts::eBoundQOverP] -
                                truthQOP);
-      m_res_eT_prt.push_back(parameter.parameters()[Acts::ParDef::eT] -
+      m_res_eT_prt.push_back(parameters[Acts::eBoundTime] -
                              truthTIME);
 
       /// Predicted parameter Uncertainties
       m_err_eLOC0_prt.push_back(
-          sqrt(covariance(Acts::ParDef::eLOC_0, Acts::ParDef::eLOC_0)));
+          sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0)));
       m_err_eLOC1_prt.push_back(
-          sqrt(covariance(Acts::ParDef::eLOC_1, Acts::ParDef::eLOC_1)));
+          sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1)));
       m_err_ePHI_prt.push_back(
-          sqrt(covariance(Acts::ParDef::ePHI, Acts::ParDef::ePHI)));
+          sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi)));
       m_err_eTHETA_prt.push_back(
-          sqrt(covariance(Acts::ParDef::eTHETA, Acts::ParDef::eTHETA)));
+          sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta)));
       m_err_eQOP_prt.push_back(
-          sqrt(covariance(Acts::ParDef::eQOP, Acts::ParDef::eQOP)));
+          sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)));
       m_err_eT_prt.push_back(
-          sqrt(covariance(Acts::ParDef::eT, Acts::ParDef::eT)));
+          sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
       /// Predicted parameter pulls
       m_pull_eLOC0_prt.push_back(
-          (parameter.parameters()[Acts::ParDef::eLOC_0] - truthLOC0) /
-          sqrt(covariance(Acts::ParDef::eLOC_0, Acts::ParDef::eLOC_0)));
+          (parameters[Acts::eBoundLoc0] - truthLOC0) /
+          sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0)));
       m_pull_eLOC1_prt.push_back(
-          (parameter.parameters()[Acts::ParDef::eLOC_1] - truthLOC1) /
-          sqrt(covariance(Acts::ParDef::eLOC_1, Acts::ParDef::eLOC_1)));
+          (parameters[Acts::eBoundLoc1] - truthLOC1) /
+          sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1)));
       m_pull_ePHI_prt.push_back(
-          (parameter.parameters()[Acts::ParDef::ePHI] - truthPHI) /
-          sqrt(covariance(Acts::ParDef::ePHI, Acts::ParDef::ePHI)));
+          (parameters[Acts::eBoundPhi] - truthPHI) /
+          sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi)));
       m_pull_eTHETA_prt.push_back(
-          (parameter.parameters()[Acts::ParDef::eTHETA] - truthTHETA) /
-          sqrt(covariance(Acts::ParDef::eTHETA, Acts::ParDef::eTHETA)));
+          (parameters[Acts::eBoundTheta] - truthTHETA) /
+          sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta)));
       m_pull_eQOP_prt.push_back(
-          (parameter.parameters()[Acts::ParDef::eQOP] - truthQOP) /
-          sqrt(covariance(Acts::ParDef::eQOP, Acts::ParDef::eQOP)));
+          (parameters[Acts::eBoundQOverP] - truthQOP) /
+          sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)));
       m_pull_eT_prt.push_back(
-          (parameter.parameters()[Acts::ParDef::eT] - truthTIME) /
-          sqrt(covariance(Acts::ParDef::eT, Acts::ParDef::eT)));
+          (parameters[Acts::eBoundTime] - truthTIME) /
+          sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
-      m_x_prt.push_back(parameter.position(m_tGeometry->geoContext).x());
-      m_y_prt.push_back(parameter.position(m_tGeometry->geoContext).y());
-      m_z_prt.push_back(parameter.position(m_tGeometry->geoContext).z());
-      m_px_prt.push_back(parameter.momentum().x());
-      m_py_prt.push_back(parameter.momentum().y());
-      m_pz_prt.push_back(parameter.momentum().z());
-      m_pT_prt.push_back(parameter.pT());
-      m_eta_prt.push_back(eta(parameter.position(m_tGeometry->geoContext)));
+      Acts::FreeVector freeParams = 
+	Acts::detail::transformBoundToFreeParameters(state.referenceSurface(), 
+						     m_tGeometry->geoContext,
+						     parameters);
+
+      m_x_prt.push_back(freeParams[Acts::eFreePos0]);
+      m_y_prt.push_back(freeParams[Acts::eFreePos1]);
+      m_z_prt.push_back(freeParams[Acts::eFreePos2]);
+      auto p = std::abs(1 / freeParams[Acts::eFreeQOverP]);
+      m_px_prt.push_back(p * freeParams[Acts::eFreeDir0]);
+      m_py_prt.push_back(p * freeParams[Acts::eFreeDir1]);
+      m_pz_prt.push_back(p * freeParams[Acts::eFreeDir2]);
+      m_pT_prt.push_back(p * std::hypot(freeParams[Acts::eFreeDir0],
+					freeParams[Acts::eFreeDir1]));
+      m_eta_prt.push_back(
+         Acts::VectorHelpers::eta(freeParams.segment<3>(Acts::eFreeDir0)));
     }
     else
     {
@@ -524,66 +535,66 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
       filtered = true;
       m_nFiltered++;
 
-      Acts::BoundParameters parameter(
+      Acts::BoundTrackParameters parameter(
 	    state.referenceSurface().getSharedPtr(),
 	    state.filtered(),
 	    state.filteredCovariance());
 
       auto covariance = state.filteredCovariance();
 
-      m_eLOC0_flt.push_back(parameter.parameters()[Acts::ParDef::eLOC_0]);
-      m_eLOC1_flt.push_back(parameter.parameters()[Acts::ParDef::eLOC_1]);
-      m_ePHI_flt.push_back(parameter.parameters()[Acts::ParDef::ePHI]);
-      m_eTHETA_flt.push_back(parameter.parameters()[Acts::ParDef::eTHETA]);
-      m_eQOP_flt.push_back(parameter.parameters()[Acts::ParDef::eQOP]);
-      m_eT_flt.push_back(parameter.parameters()[Acts::ParDef::eT]);
+      m_eLOC0_flt.push_back(parameter.parameters()[Acts::eBoundLoc0]);
+      m_eLOC1_flt.push_back(parameter.parameters()[Acts::eBoundLoc1]);
+      m_ePHI_flt.push_back(parameter.parameters()[Acts::eBoundPhi]);
+      m_eTHETA_flt.push_back(parameter.parameters()[Acts::eBoundTheta]);
+      m_eQOP_flt.push_back(parameter.parameters()[Acts::eBoundQOverP]);
+      m_eT_flt.push_back(parameter.parameters()[Acts::eBoundTime]);
 
-      m_res_eLOC0_flt.push_back(parameter.parameters()[Acts::ParDef::eLOC_0] -
+      m_res_eLOC0_flt.push_back(parameter.parameters()[Acts::eBoundLoc0] -
                                 truthLOC0);
-      m_res_eLOC1_flt.push_back(parameter.parameters()[Acts::ParDef::eLOC_1] -
+      m_res_eLOC1_flt.push_back(parameter.parameters()[Acts::eBoundLoc1] -
                                 truthLOC1);
-      m_res_ePHI_flt.push_back(parameter.parameters()[Acts::ParDef::ePHI] -
+      m_res_ePHI_flt.push_back(parameter.parameters()[Acts::eBoundPhi] -
                                truthPHI);
-      m_res_eTHETA_flt.push_back(parameter.parameters()[Acts::ParDef::eTHETA] -
+      m_res_eTHETA_flt.push_back(parameter.parameters()[Acts::eBoundTheta] -
                                  truthTHETA);
-      m_res_eQOP_flt.push_back(parameter.parameters()[Acts::ParDef::eQOP] -
+      m_res_eQOP_flt.push_back(parameter.parameters()[Acts::eBoundQOverP] -
                                truthQOP);
-      m_res_eT_flt.push_back(parameter.parameters()[Acts::ParDef::eT] -
+      m_res_eT_flt.push_back(parameter.parameters()[Acts::eBoundTime] -
                              truthTIME);
 
       /// Filtered parameter uncertainties
       m_err_eLOC0_flt.push_back(
-          sqrt(covariance(Acts::ParDef::eLOC_0, Acts::ParDef::eLOC_0)));
+          sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0)));
       m_err_eLOC1_flt.push_back(
-          sqrt(covariance(Acts::ParDef::eLOC_1, Acts::ParDef::eLOC_1)));
+          sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1)));
       m_err_ePHI_flt.push_back(
-          sqrt(covariance(Acts::ParDef::ePHI, Acts::ParDef::ePHI)));
+          sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi)));
       m_err_eTHETA_flt.push_back(
-          sqrt(covariance(Acts::ParDef::eTHETA, Acts::ParDef::eTHETA)));
+          sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta)));
       m_err_eQOP_flt.push_back(
-          sqrt(covariance(Acts::ParDef::eQOP, Acts::ParDef::eQOP)));
+          sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)));
       m_err_eT_flt.push_back(
-          sqrt(covariance(Acts::ParDef::eT, Acts::ParDef::eT)));
+          sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
       /// Filtered parameter pulls
       m_pull_eLOC0_flt.push_back(
-          (parameter.parameters()[Acts::ParDef::eLOC_0] - truthLOC0) /
-          sqrt(covariance(Acts::ParDef::eLOC_0, Acts::ParDef::eLOC_0)));
+          (parameter.parameters()[Acts::eBoundLoc0] - truthLOC0) /
+          sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0)));
       m_pull_eLOC1_flt.push_back(
-          (parameter.parameters()[Acts::ParDef::eLOC_1] - truthLOC1) /
-          sqrt(covariance(Acts::ParDef::eLOC_1, Acts::ParDef::eLOC_1)));
+          (parameter.parameters()[Acts::eBoundLoc1] - truthLOC1) /
+          sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1)));
       m_pull_ePHI_flt.push_back(
-          (parameter.parameters()[Acts::ParDef::ePHI] - truthPHI) /
-          sqrt(covariance(Acts::ParDef::ePHI, Acts::ParDef::ePHI)));
+          (parameter.parameters()[Acts::eBoundPhi] - truthPHI) /
+          sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi)));
       m_pull_eTHETA_flt.push_back(
-          (parameter.parameters()[Acts::ParDef::eTHETA] - truthTHETA) /
-          sqrt(covariance(Acts::ParDef::eTHETA, Acts::ParDef::eTHETA)));
+          (parameter.parameters()[Acts::eBoundTheta] - truthTHETA) /
+          sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta)));
       m_pull_eQOP_flt.push_back(
-          (parameter.parameters()[Acts::ParDef::eQOP] - truthQOP) /
-          sqrt(covariance(Acts::ParDef::eQOP, Acts::ParDef::eQOP)));
+          (parameter.parameters()[Acts::eBoundQOverP] - truthQOP) /
+          sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)));
       m_pull_eT_flt.push_back(
-          (parameter.parameters()[Acts::ParDef::eT] - truthTIME) /
-          sqrt(covariance(Acts::ParDef::eT, Acts::ParDef::eT)));
+          (parameter.parameters()[Acts::eBoundTime] - truthTIME) /
+          sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
       /// Other filtered parameter info
       m_x_flt.push_back(parameter.position(m_tGeometry->geoContext).x());
@@ -592,7 +603,8 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
       m_px_flt.push_back(parameter.momentum().x());
       m_py_flt.push_back(parameter.momentum().y());
       m_pz_flt.push_back(parameter.momentum().z());
-      m_pT_flt.push_back(parameter.pT());
+      m_pT_flt.push_back(sqrt(parameter.momentum().x() * parameter.momentum().x()
+			      + parameter.momentum().y() * parameter.momentum().y()));
       m_eta_flt.push_back(eta(parameter.position(m_tGeometry->geoContext)));
       m_chi2.push_back(state.chi2());
       
@@ -640,66 +652,66 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
       smoothed = true;
       m_nSmoothed++;
 
-      Acts::BoundParameters parameter(
+      Acts::BoundTrackParameters parameter(
 	    state.referenceSurface().getSharedPtr(),
 	    state.smoothed(),
 	    state.smoothedCovariance());
 
       auto covariance = state.smoothedCovariance();
 
-      m_eLOC0_smt.push_back(parameter.parameters()[Acts::ParDef::eLOC_0]);
-      m_eLOC1_smt.push_back(parameter.parameters()[Acts::ParDef::eLOC_1]);
-      m_ePHI_smt.push_back(parameter.parameters()[Acts::ParDef::ePHI]);
-      m_eTHETA_smt.push_back(parameter.parameters()[Acts::ParDef::eTHETA]);
-      m_eQOP_smt.push_back(parameter.parameters()[Acts::ParDef::eQOP]);
-      m_eT_smt.push_back(parameter.parameters()[Acts::ParDef::eT]);
+      m_eLOC0_smt.push_back(parameter.parameters()[Acts::eBoundLoc0]);
+      m_eLOC1_smt.push_back(parameter.parameters()[Acts::eBoundLoc1]);
+      m_ePHI_smt.push_back(parameter.parameters()[Acts::eBoundPhi]);
+      m_eTHETA_smt.push_back(parameter.parameters()[Acts::eBoundTheta]);
+      m_eQOP_smt.push_back(parameter.parameters()[Acts::eBoundQOverP]);
+      m_eT_smt.push_back(parameter.parameters()[Acts::eBoundTime]);
 
-      m_res_eLOC0_smt.push_back(parameter.parameters()[Acts::ParDef::eLOC_0] -
+      m_res_eLOC0_smt.push_back(parameter.parameters()[Acts::eBoundLoc0] -
                                 truthLOC0);
-      m_res_eLOC1_smt.push_back(parameter.parameters()[Acts::ParDef::eLOC_1] -
+      m_res_eLOC1_smt.push_back(parameter.parameters()[Acts::eBoundLoc1] -
                                 truthLOC1);
-      m_res_ePHI_smt.push_back(parameter.parameters()[Acts::ParDef::ePHI] -
+      m_res_ePHI_smt.push_back(parameter.parameters()[Acts::eBoundPhi] -
                                truthPHI);
-      m_res_eTHETA_smt.push_back(parameter.parameters()[Acts::ParDef::eTHETA] -
+      m_res_eTHETA_smt.push_back(parameter.parameters()[Acts::eBoundTheta] -
                                  truthTHETA);
-      m_res_eQOP_smt.push_back(parameter.parameters()[Acts::ParDef::eQOP] -
+      m_res_eQOP_smt.push_back(parameter.parameters()[Acts::eBoundQOverP] -
                                truthQOP);
-      m_res_eT_smt.push_back(parameter.parameters()[Acts::ParDef::eT] -
+      m_res_eT_smt.push_back(parameter.parameters()[Acts::eBoundTime] -
                              truthTIME);
 
       /// Smoothed parameter uncertainties
       m_err_eLOC0_smt.push_back(
-          sqrt(covariance(Acts::ParDef::eLOC_0, Acts::ParDef::eLOC_0)));
+          sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0)));
       m_err_eLOC1_smt.push_back(
-          sqrt(covariance(Acts::ParDef::eLOC_1, Acts::ParDef::eLOC_1)));
+          sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1)));
       m_err_ePHI_smt.push_back(
-          sqrt(covariance(Acts::ParDef::ePHI, Acts::ParDef::ePHI)));
+          sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi)));
       m_err_eTHETA_smt.push_back(
-          sqrt(covariance(Acts::ParDef::eTHETA, Acts::ParDef::eTHETA)));
+          sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta)));
       m_err_eQOP_smt.push_back(
-          sqrt(covariance(Acts::ParDef::eQOP, Acts::ParDef::eQOP)));
+          sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)));
       m_err_eT_smt.push_back(
-          sqrt(covariance(Acts::ParDef::eT, Acts::ParDef::eT)));
+          sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
       /// Smoothed parameter pulls
       m_pull_eLOC0_smt.push_back(
-          (parameter.parameters()[Acts::ParDef::eLOC_0] - truthLOC0) /
-          sqrt(covariance(Acts::ParDef::eLOC_0, Acts::ParDef::eLOC_0)));
+          (parameter.parameters()[Acts::eBoundLoc0] - truthLOC0) /
+          sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0)));
       m_pull_eLOC1_smt.push_back(
-          (parameter.parameters()[Acts::ParDef::eLOC_1] - truthLOC1) /
-          sqrt(covariance(Acts::ParDef::eLOC_1, Acts::ParDef::eLOC_1)));
+          (parameter.parameters()[Acts::eBoundLoc1] - truthLOC1) /
+          sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1)));
       m_pull_ePHI_smt.push_back(
-          (parameter.parameters()[Acts::ParDef::ePHI] - truthPHI) /
-          sqrt(covariance(Acts::ParDef::ePHI, Acts::ParDef::ePHI)));
+          (parameter.parameters()[Acts::eBoundPhi] - truthPHI) /
+          sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi)));
       m_pull_eTHETA_smt.push_back(
-          (parameter.parameters()[Acts::ParDef::eTHETA] - truthTHETA) /
-          sqrt(covariance(Acts::ParDef::eTHETA, Acts::ParDef::eTHETA)));
+          (parameter.parameters()[Acts::eBoundTheta] - truthTHETA) /
+          sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta)));
       m_pull_eQOP_smt.push_back(
-          (parameter.parameters()[Acts::ParDef::eQOP] - truthQOP) /
-          sqrt(covariance(Acts::ParDef::eQOP, Acts::ParDef::eQOP)));
+          (parameter.parameters()[Acts::eBoundQOverP] - truthQOP) /
+          sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)));
       m_pull_eT_smt.push_back(
-          (parameter.parameters()[Acts::ParDef::eT] - truthTIME) /
-          sqrt(covariance(Acts::ParDef::eT, Acts::ParDef::eT)));
+          (parameter.parameters()[Acts::eBoundTime] - truthTIME) /
+          sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
       m_x_smt.push_back(parameter.position(m_tGeometry->geoContext).x());
       m_y_smt.push_back(parameter.position(m_tGeometry->geoContext).y());
@@ -707,7 +719,8 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
       m_px_smt.push_back(parameter.momentum().x());
       m_py_smt.push_back(parameter.momentum().y());
       m_pz_smt.push_back(parameter.momentum().z());
-      m_pT_smt.push_back(parameter.pT());
+      m_pT_smt.push_back(sqrt(parameter.momentum().x() * parameter.momentum().x() 
+			      + parameter.momentum().y() * parameter.momentum().y()));
       m_eta_smt.push_back(eta(parameter.position(m_tGeometry->geoContext)));
     }
     else
@@ -849,13 +862,13 @@ void ActsEvaluator::fillProtoTrack(ActsTrack track, PHCompositeNode *topNode)
       /// Get source link global position
       Acts::Vector2D loc(sourceLinks.at(i).location()(0),
 			 sourceLinks.at(i).location()(1));
-      Acts::Vector3D globalPos(0,0,0);
+   
       Acts::Vector3D mom(0,0,0);
       
-      sourceLinks.at(i).referenceSurface().localToGlobal(
+      Acts::Vector3D globalPos = sourceLinks.at(i).referenceSurface().localToGlobal(
                                             m_tGeometry->geoContext,
 					    loc,
-					    mom, globalPos);
+					    mom);
 
       m_SLx.push_back(globalPos(0));
       m_SLy.push_back(globalPos(1));
@@ -872,23 +885,31 @@ void ActsEvaluator::fillProtoTrack(ActsTrack track, PHCompositeNode *topNode)
       float gz = globalTruthPos(2);
       
       /// Get local truth position
-      Acts::Vector2D truthlocal;
-      
       const float r = sqrt(gx * gx + gy * gy + gz * gz);
       Acts::Vector3D globalTruthUnitDir(gx / r, gy / r, gz / r);
       
-      sourceLinks.at(i).referenceSurface().globalToLocal(
+      auto truthLocal = sourceLinks.at(i).referenceSurface().globalToLocal(
 					    m_tGeometry->geoContext,
 					    globalTruthPos,
-					    globalTruthUnitDir,
-					    truthlocal);
-      m_t_SL_lx.push_back(truthlocal(0));
-      m_t_SL_ly.push_back(truthlocal(1));
-      m_t_SL_gx.push_back(gx);
-      m_t_SL_gy.push_back(gy);
-      m_t_SL_gz.push_back(gz);
-      
-  
+					    globalTruthUnitDir);
+      if(truthLocal.ok())
+	{
+	  Acts::Vector2D truthLocalVec = truthLocal.value();
+	  
+	  m_t_SL_lx.push_back(truthLocalVec(0));
+	  m_t_SL_ly.push_back(truthLocalVec(1));
+	  m_t_SL_gx.push_back(gx);
+	  m_t_SL_gy.push_back(gy);
+	  m_t_SL_gz.push_back(gz);   
+	} 
+      else
+	{
+	  m_t_SL_lx.push_back(-9999.);
+	  m_t_SL_ly.push_back(-9999.);
+	  m_t_SL_gx.push_back(-9999.);
+	  m_t_SL_gy.push_back(-9999.);
+	  m_t_SL_gz.push_back(-9999.);
+	}
     }
 
   if(Verbosity() > 2)
@@ -913,21 +934,21 @@ void ActsEvaluator::fillFittedTrackParams(const Trajectory traj,
     const auto &parameter = boundParam.parameters();
     const auto &covariance = *boundParam.covariance();
     m_charge_fit = boundParam.charge();
-    m_eLOC0_fit = parameter[Acts::ParDef::eLOC_0];
-    m_eLOC1_fit = parameter[Acts::ParDef::eLOC_1];
-    m_ePHI_fit = parameter[Acts::ParDef::ePHI];
-    m_eTHETA_fit = parameter[Acts::ParDef::eTHETA];
-    m_eQOP_fit = parameter[Acts::ParDef::eQOP];
-    m_eT_fit = parameter[Acts::ParDef::eT];
+    m_eLOC0_fit = parameter[Acts::eBoundLoc0];
+    m_eLOC1_fit = parameter[Acts::eBoundLoc1];
+    m_ePHI_fit = parameter[Acts::eBoundPhi];
+    m_eTHETA_fit = parameter[Acts::eBoundTheta];
+    m_eQOP_fit = parameter[Acts::eBoundQOverP];
+    m_eT_fit = parameter[Acts::eBoundTime];
     m_err_eLOC0_fit =
-        sqrt(covariance(Acts::ParDef::eLOC_0, Acts::ParDef::eLOC_0));
+        sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0));
     m_err_eLOC1_fit =
-        sqrt(covariance(Acts::ParDef::eLOC_1, Acts::ParDef::eLOC_1));
-    m_err_ePHI_fit = sqrt(covariance(Acts::ParDef::ePHI, Acts::ParDef::ePHI));
+        sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1));
+    m_err_ePHI_fit = sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi));
     m_err_eTHETA_fit =
-        sqrt(covariance(Acts::ParDef::eTHETA, Acts::ParDef::eTHETA));
-    m_err_eQOP_fit = sqrt(covariance(Acts::ParDef::eQOP, Acts::ParDef::eQOP));
-    m_err_eT_fit = sqrt(covariance(Acts::ParDef::eT, Acts::ParDef::eT));
+        sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta));
+    m_err_eQOP_fit = sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP));
+    m_err_eT_fit = sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime));
 
     m_px_fit = boundParam.momentum()(0);
     m_py_fit = boundParam.momentum()(1);
@@ -968,7 +989,7 @@ void ActsEvaluator::fillFittedTrackParams(const Trajectory traj,
   return;
 }
 
-void ActsEvaluator::calculateDCA(const Acts::BoundParameters param,
+void ActsEvaluator::calculateDCA(const Acts::BoundTrackParameters param,
 				 const Acts::Vector3D vertex)
 {
 

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -31,9 +31,9 @@ using SourceLink = ActsExamples::TrkrClusterSourceLink;
 using FitResult = Acts::KalmanFitterResult<SourceLink>;
 using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
 using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
-                                      Acts::BoundParametersIndices,
-                                      Acts::ParDef::eBoundLoc0,
-                                      Acts::ParDef::eBoundLoc1>;
+                                      Acts::BoundIndices,
+                                      Acts::eBoundLoc0,
+                                      Acts::eBoundLoc1>;
 using Acts::VectorHelpers::eta;
 using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
@@ -82,7 +82,7 @@ class ActsEvaluator : public SubsysReco
 
   void clearTrackVariables();
   
-  void calculateDCA(const Acts::BoundParameters param, 
+  void calculateDCA(const Acts::BoundTrackParameters param, 
 		    const Acts::Vector3D vertex);
 
   Acts::Vector3D getGlobalTruthHit(PHCompositeNode *topNode, 

--- a/offline/packages/trackreco/ActsTransformations.cc
+++ b/offline/packages/trackreco/ActsTransformations.cc
@@ -85,7 +85,7 @@ Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs(
 
 
 Acts::BoundSymMatrix ActsTransformations::rotateActsCovToSvtxTrack(
-			        const Acts::BoundParameters params,
+			        const Acts::BoundTrackParameters params,
 				Acts::GeometryContext geoCtxt)
 {
 
@@ -196,7 +196,7 @@ void ActsTransformations::printMatrix(const std::string &message,
 
 
 
-void ActsTransformations::calculateDCA(const Acts::BoundParameters param,
+void ActsTransformations::calculateDCA(const Acts::BoundTrackParameters param,
 				   Acts::Vector3D vertex,
 				   Acts::GeometryContext geoCtxt,
 				   float &dca3Dxy,
@@ -272,17 +272,15 @@ void ActsTransformations::fillSvtxTrackStates(const Trajectory traj,
       auto meas = std::get<Measurement>(*state.uncalibrated());
 
       /// Get local position
-      Acts::Vector2D local(meas.parameters()[Acts::ParDef::eLOC_0],
-			   meas.parameters()[Acts::ParDef::eLOC_1]);
-
-      /// Get global position
-      Acts::Vector3D global(0., 0., 0.);
+      Acts::Vector2D local(meas.parameters()[Acts::eBoundLoc0],
+			   meas.parameters()[Acts::eBoundLoc1]);
 
       /// This is an arbitrary vector. Doesn't matter in coordinate transformation
       /// in Acts code
       Acts::Vector3D mom(1., 1., 1.);
-      meas.referenceObject().localToGlobal(geoContext,
-					    local, mom, global);
+      Acts::Vector3D global = meas.referenceObject().localToGlobal(
+					    geoContext,
+					    local, mom);
       
       float pathlength = state.pathLength() / Acts::UnitConstants::cm;  
       SvtxTrackState_v1 out( pathlength );
@@ -292,7 +290,7 @@ void ActsTransformations::fillSvtxTrackStates(const Trajectory traj,
     
       if (state.hasSmoothed())
 	{
-	  Acts::BoundParameters parameter(state.referenceSurface().getSharedPtr(),
+	  Acts::BoundTrackParameters parameter(state.referenceSurface().getSharedPtr(),
 					  state.smoothed(),
 					  state.smoothedCovariance());
 	  out.set_px(parameter.momentum().x());

--- a/offline/packages/trackreco/ActsTransformations.h
+++ b/offline/packages/trackreco/ActsTransformations.h
@@ -24,9 +24,9 @@ using SourceLink = ActsExamples::TrkrClusterSourceLink;
 
 using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
 using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
-                                      Acts::BoundParametersIndices,
-                                      Acts::ParDef::eBoundLoc0,
-                                      Acts::ParDef::eBoundLoc1>;
+                                      Acts::BoundIndices,
+                                      Acts::eBoundLoc0,
+                                      Acts::eBoundLoc1>;
 
 /**
  * This is a helper class for rotating track covariance matrices to and from
@@ -51,8 +51,9 @@ class ActsTransformations
 						Acts::GeometryContext geoCtxt);
   
   /// Same as above, but rotate from Acts basis to global (x,y,z,px,py,pz)
-  Acts::BoundSymMatrix rotateActsCovToSvtxTrack(const Acts::BoundParameters params,
-						Acts::GeometryContext geoCtxt);
+  Acts::BoundSymMatrix rotateActsCovToSvtxTrack(
+                       const Acts::BoundTrackParameters params,
+		       Acts::GeometryContext geoCtxt);
 
   void setVerbosity(int verbosity) {m_verbosity = verbosity;}
 
@@ -60,7 +61,7 @@ class ActsTransformations
 
   /// Calculate the DCA for a given Acts fitted track parameters and 
   /// vertex
-  void calculateDCA(const Acts::BoundParameters param,
+  void calculateDCA(const Acts::BoundTrackParameters param,
 		    Acts::Vector3D vertex,
 		    Acts::GeometryContext geoCtxt,
 		    float &dca3Dxy,

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = \
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  -L$(MYINSTALL)/lib64
+  -L$(OFFLINE_MAIN)/lib64
 
 pkginclude_HEADERS = \
   ActsTransformations.h \

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = \
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  -L$(OFFLINE_MAIN)/lib64
+  -L$(MYINSTALL)/lib64
 
 pkginclude_HEADERS = \
   ActsTransformations.h \
@@ -140,9 +140,9 @@ ACTS_LIBS = \
   -lg4eval \
   -lActsCore \
   -lActsFatras \
-  -lActsTGeoPlugin \
+  -lActsPluginTGeo \
   -lActsExamplesCommon \
-  -lActsJsonPlugin \
+  -lActsPluginJson \
   -lActsExamplesFitting \
   -lActsExamplesTrackFinding \
   -lActsExamplesDetectorTGeo \

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -206,16 +206,16 @@ if(m_useVertexMeasurement){
 
     /// Cluster positions on GeoObject/Surface
     Acts::BoundVector loc = Acts::BoundVector::Zero();
-    loc[Acts::eLOC_0] = local2D[0];
-    loc[Acts::eLOC_1] = local2D[1];
+    loc[Acts::eBoundLoc0] = local2D[0];
+    loc[Acts::eBoundLoc1] = local2D[1];
 
     if (Verbosity() > 0)
     {
       std::cout << "Layer " << layer
                 << " create measurement for trkrid " << trkrId
                 << " surface " << surface->name() << " surface type "
-                << surface->type() << " local x " << loc[Acts::eLOC_0]
-                << " local y " << loc[Acts::eLOC_1] << std::endl << std::endl;
+                << surface->type() << " local x " << loc[Acts::eBoundLoc0]
+                << " local y " << loc[Acts::eBoundLoc1] << std::endl << std::endl;
     }
 
     /// TrkrClusterSourceLink creates an Acts::FittableMeasurement
@@ -348,14 +348,25 @@ Surface PHActsSourceLinks::getTpcLocalCoords(Acts::Vector2D &local2D,
 			   y * Acts::UnitConstants::cm,
 			   z * Acts::UnitConstants::cm);
   
-  surface->globalToLocal(m_actsGeometry->getGeoContext(), globalPos,
-			 surface->normal(m_actsGeometry->getGeoContext()),
-			 local2D);
-  
+  auto vecResult = surface->globalToLocal(m_actsGeometry->getGeoContext(), 
+		        globalPos,
+		        surface->normal(m_actsGeometry->getGeoContext()));
+
+  if(vecResult.ok())
+    {
+      local2D = vecResult.value();
+    }
+  else
+    {
+      std::cout << PHWHERE << "Global to local ACTS transformation failed... skipping this cluster"
+		<< std::endl;
+      return nullptr;
+    }
+
   /// Test that Acts surface transforms correctly back
-  Acts::Vector3D actsGlobal(0,0,0);
-  surface->localToGlobal(m_actsGeometry->getGeoContext(), local2D, 
-			 Acts::Vector3D(1,1,1), actsGlobal);
+  Acts::Vector3D actsGlobal = surface->localToGlobal(m_actsGeometry->getGeoContext(), 
+						     local2D, 
+						     Acts::Vector3D(1,1,1));
 
   if (Verbosity() > 0)
   {
@@ -375,13 +386,13 @@ Surface PHActsSourceLinks::getTpcLocalCoords(Acts::Vector2D &local2D,
   TMatrixD sPhenixLocalErr = transformCovarToLocal(clusPhi, worldErr);
 
   /// Get the 2D location covariance uncertainty for the cluster (y and z)
-  localErr(Acts::eLOC_0, Acts::eLOC_0) = 
+  localErr(Acts::eBoundLoc0, Acts::eBoundLoc0) = 
     sPhenixLocalErr[1][1] * Acts::UnitConstants::cm2;
-  localErr(Acts::eLOC_1, Acts::eLOC_0) = 
+  localErr(Acts::eBoundLoc1, Acts::eBoundLoc0) = 
     sPhenixLocalErr[2][1] * Acts::UnitConstants::cm2;
-  localErr(Acts::eLOC_0, Acts::eLOC_1) = 
+  localErr(Acts::eBoundLoc0, Acts::eBoundLoc1) = 
     sPhenixLocalErr[1][2] * Acts::UnitConstants::cm2;
-  localErr(Acts::eLOC_1, Acts::eLOC_1) = 
+  localErr(Acts::eBoundLoc1, Acts::eBoundLoc1) = 
     sPhenixLocalErr[2][2] * Acts::UnitConstants::cm2;
 
 
@@ -468,14 +479,23 @@ Surface PHActsSourceLinks::getInttLocalCoords(Acts::Vector2D &local2D,
 			   y * Acts::UnitConstants::cm,
 			   z * Acts::UnitConstants::cm);
   
-  surface->globalToLocal(m_actsGeometry->getGeoContext(), globalPos,
-			 surface->normal(m_actsGeometry->getGeoContext()),
-			 local2D);
+  auto vecResult = surface->globalToLocal(m_actsGeometry->getGeoContext(), globalPos,
+			 surface->normal(m_actsGeometry->getGeoContext()));
+  if(vecResult.ok())
+    {
+      local2D = vecResult.value();
+    }
+  else
+    {
+      std::cout << PHWHERE << "Global to local ACTS transformation failed... skipping this cluster" 
+		<< std::endl;
+      return nullptr;
+    }
 
   /// Test that Acts surface transforms correctly back
-  Acts::Vector3D actsGlobal(0,0,0);
-  surface->localToGlobal(m_actsGeometry->getGeoContext(), local2D, 
-			 Acts::Vector3D(1,1,1), actsGlobal);
+  Acts::Vector3D actsGlobal = surface->localToGlobal(m_actsGeometry->getGeoContext(), 
+						     local2D, 
+						     Acts::Vector3D(1,1,1));
 
   Acts::Vector3D normal = surface->normal(m_actsGeometry->getGeoContext());
   
@@ -581,14 +601,24 @@ Surface PHActsSourceLinks::getMvtxLocalCoords(Acts::Vector2D &local2D,
 			   y * Acts::UnitConstants::cm,
 			   z * Acts::UnitConstants::cm);
   
-  surface->globalToLocal(m_actsGeometry->getGeoContext(), globalPos,
-			 surface->normal(m_actsGeometry->getGeoContext()),
-			 local2D);
+  auto vecResult = surface->globalToLocal(m_actsGeometry->getGeoContext(), globalPos,
+			 surface->normal(m_actsGeometry->getGeoContext()));
+
+  if(vecResult.ok())
+    {
+      local2D = vecResult.value();
+    }
+  else
+    {
+      std::cout << PHWHERE << "Global to local ACTS transformation failed... skipping this cluster"
+		<< std::endl;
+      return nullptr;
+    }
 
   /// Test that Acts surface transforms correctly back
-  Acts::Vector3D actsGlobal(0,0,0);
-  surface->localToGlobal(m_actsGeometry->getGeoContext(), local2D, 
-			 Acts::Vector3D(1,1,1), actsGlobal);
+  Acts::Vector3D actsGlobal = surface->localToGlobal(m_actsGeometry->getGeoContext(), 
+						     local2D, 
+						     Acts::Vector3D(1,1,1));
 
   Acts::Vector3D normal = surface->normal(m_actsGeometry->getGeoContext());
 
@@ -648,10 +678,20 @@ void PHActsSourceLinks::addVerticesAsSourceLinks(PHCompositeNode *topNode,
       Acts::Vector2D loc(0,0); 
       Acts::BoundMatrix cov = Acts::BoundMatrix::Zero();
 
-      pSurface->globalToLocal(m_actsGeometry->getGeoContext(),
+      auto vecResult = pSurface->globalToLocal(m_actsGeometry->getGeoContext(),
 			      globalPos,
-			      pSurface->normal(m_actsGeometry->getGeoContext()),
-			      loc);
+			      pSurface->normal(m_actsGeometry->getGeoContext()));
+
+      if(vecResult.ok())
+	{
+	  loc = vecResult.value();
+	}
+      else
+	{
+	  std::cout << PHWHERE << "Can't add this vertex as a source link... skipping"
+		    << std::endl;
+	  continue;
+	}
 
       TMatrixD worldErr(3,3);
       for(int i = 0; i < 3; i++)
@@ -677,16 +717,16 @@ void PHActsSourceLinks::addVerticesAsSourceLinks(PHCompositeNode *topNode,
 	}
 
       Acts::BoundVector location = Acts::BoundVector::Zero();
-      location[Acts::eLOC_0] = loc(0);
-      location[Acts::eLOC_1] = loc(1);
+      location[Acts::eBoundLoc0] = loc(0);
+      location[Acts::eBoundLoc1] = loc(1);
       
-      cov(Acts::eLOC_0, Acts::eLOC_0) =
+      cov(Acts::eBoundLoc0, Acts::eBoundLoc0) =
 	localErr[0][0] * Acts::UnitConstants::cm2;
-      cov(Acts::eLOC_1, Acts::eLOC_0) =
+      cov(Acts::eBoundLoc1, Acts::eBoundLoc0) =
 	localErr[2][0] * Acts::UnitConstants::cm2;
-      cov(Acts::eLOC_0, Acts::eLOC_1) =
+      cov(Acts::eBoundLoc0, Acts::eBoundLoc1) =
 	localErr[0][2] * Acts::UnitConstants::cm2;
-      cov(Acts::eLOC_1, Acts::eLOC_1) =
+      cov(Acts::eBoundLoc1, Acts::eBoundLoc1) =
 	localErr[2][2] * Acts::UnitConstants::cm2;
       
       if(Verbosity() > 1)
@@ -917,13 +957,13 @@ Acts::BoundMatrix PHActsSourceLinks::getMvtxCovarLocal(const unsigned int layer,
   Acts::BoundMatrix matrix = Acts::BoundMatrix::Zero();
 
   /// Get the 2D location covariance uncertainty for the cluster (x and z) 
-  matrix(Acts::eLOC_0, Acts::eLOC_0) = 
+  matrix(Acts::eBoundLoc0, Acts::eBoundLoc0) = 
     localErr[0][0] * Acts::UnitConstants::cm2;
-  matrix(Acts::eLOC_1, Acts::eLOC_0) = 
+  matrix(Acts::eBoundLoc1, Acts::eBoundLoc0) = 
     localErr[2][0] * Acts::UnitConstants::cm2;
-  matrix(Acts::eLOC_0, Acts::eLOC_1) = 
+  matrix(Acts::eBoundLoc0, Acts::eBoundLoc1) = 
     localErr[0][2] * Acts::UnitConstants::cm2;
-  matrix(Acts::eLOC_1, Acts::eLOC_1) = 
+  matrix(Acts::eBoundLoc1, Acts::eBoundLoc1) = 
     localErr[2][2] * Acts::UnitConstants::cm2;
 
   return matrix;
@@ -957,13 +997,13 @@ Acts::BoundMatrix PHActsSourceLinks::getInttCovarLocal(const unsigned int layer,
 
   Acts::BoundMatrix matrix = Acts::BoundMatrix::Zero();
   /// Get the 2D location covariance uncertainty for the cluster (y and z)
-  matrix(Acts::eLOC_0, Acts::eLOC_0) = 
+  matrix(Acts::eBoundLoc0, Acts::eBoundLoc0) = 
     localErr[1][1] * Acts::UnitConstants::cm2;
-  matrix(Acts::eLOC_1, Acts::eLOC_0) = 
+  matrix(Acts::eBoundLoc1, Acts::eBoundLoc0) = 
     localErr[2][1] * Acts::UnitConstants::cm2;
-  matrix(Acts::eLOC_0, Acts::eLOC_1) = 
+  matrix(Acts::eBoundLoc0, Acts::eBoundLoc1) = 
     localErr[1][2] * Acts::UnitConstants::cm2;
-  matrix(Acts::eLOC_1, Acts::eLOC_1) = 
+  matrix(Acts::eBoundLoc1, Acts::eBoundLoc1) = 
     localErr[2][2] * Acts::UnitConstants::cm2;
 
   return matrix;

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -11,7 +11,6 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
-#include <Acts/EventData/ChargePolicy.hpp>
 #include <Acts/EventData/SingleCurvilinearTrackParameters.hpp>
 #include <Acts/Utilities/Units.hpp>
 

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -122,24 +122,28 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
       rotater->rotateSvtxTrackCovToActs(track,
 					m_tGeometry->geoContext);
 
-    const Acts::Vector3D seedPos(track->get_x()  * Acts::UnitConstants::cm,
-                                 track->get_y()  * Acts::UnitConstants::cm,
-                                 track->get_z()  * Acts::UnitConstants::cm);
-    
-    const Acts::Vector3D seedMom(track->get_px() * Acts::UnitConstants::GeV,
-                                 track->get_py() * Acts::UnitConstants::GeV,
-                                 track->get_pz() * Acts::UnitConstants::GeV);
-
-    // just set to 10 ns for now?
+    /// just set to 10 ns for now. Time isn't needed by Acts, only if TOF is present
     const double trackTime = 10 * Acts::UnitConstants::ns;
-    const int trackQ = track->get_charge();
+
+    const Acts::Vector4D seed4Vec(track->get_x()  * Acts::UnitConstants::cm,
+				  track->get_y()  * Acts::UnitConstants::cm,
+				  track->get_z()  * Acts::UnitConstants::cm,
+				  trackTime);
+    
+    const Acts::Vector3D seedMomVec(track->get_px() * Acts::UnitConstants::GeV,
+				    track->get_py() * Acts::UnitConstants::GeV,
+				    track->get_pz() * Acts::UnitConstants::GeV);
+
+    const double p = track->get_p();
+    
+    const double trackQ = track->get_charge();
     
     if(Verbosity() > 0)
       {
 	std::cout << PHWHERE << std::endl;
 	std::cout << " Seed trackQ " << trackQ << std::endl;
-	std::cout << " seedPos " << seedPos[0] << "  " << seedPos[1] << "  " << seedPos[2] << std::endl;
-	std::cout << " seedMom " << seedMom[0] << "  " << seedMom[1] << "  " << seedMom[2] << std::endl;
+	std::cout << " seed4Vec " << seed4Vec[0] << "  " << seed4Vec[1] << "  " << seed4Vec[2] << std::endl;
+	std::cout << " seedMomVec " << seedMomVec[0] << "  " << seedMomVec[1] << "  " << seedMomVec[2] << std::endl;
 	// diagonal track cov is square of (err_x_local, err_y_local,  err_phi, err_theta, err_q/p, err_time) 
 	std::cout << " seedCov: " << std::endl;
 	for(unsigned int irow = 0; irow < seedCov.rows(); ++irow)
@@ -151,12 +155,11 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 	    std::cout << std::endl;
 	  }
       }
-
-    const ActsExamples::TrackParameters trackSeed(
-                                        seedCov, 
-					seedPos, seedMom, 
-					trackQ * Acts::UnitConstants::e, 
-					trackTime);
+    
+    const ActsExamples::TrackParameters trackSeed(seed4Vec, 
+						  seedMomVec, p,
+						  trackQ * Acts::UnitConstants::e,
+						  seedCov);
 
     /// Start fresh for this track
     trackSourceLinks.clear();

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -146,11 +146,12 @@ int PHActsTrkFitter::Process()
            0., 0., 0., 0., 0.00005 , 0.,
            0., 0., 0., 0., 0., 1.;
 
-    ActsExamples::TrackParameters newTrackSeed(cov,
-					       trackSeed.position(),
-					       trackSeed.momentum(),
-					       trackSeed.charge(),
-					       trackSeed.time());
+    ActsExamples::TrackParameters newTrackSeed(
+                  trackSeed.fourPosition(m_tGeometry->geoContext),
+		  trackSeed.momentum(),
+		  trackSeed.absoluteMomentum(),
+		  trackSeed.charge(),
+		  cov);
 
     /// Construct a perigee surface as the target surface
     /// This surface is what Acts fits with respect to, so we set it to
@@ -161,7 +162,7 @@ int PHActsTrkFitter::Process()
     if(Verbosity() > 0)
       {
 	std::cout << " Processing proto track with position:" 
-		  << trackSeed.position() << std::endl 
+		  << trackSeed.position(m_tGeometry->geoContext) << std::endl 
 		  << "momentum: " << trackSeed.momentum() << std::endl
 		  << "charge : " << trackSeed.charge() << std::endl
 		  << "initial vertex : " << track.getVertex()
@@ -181,10 +182,13 @@ int PHActsTrkFitter::Process()
       m_tGeometry->calibContext,
       Acts::VoidOutlierFinder(),
       Acts::LoggerWrapper(*logger),
+      Acts::PropagatorPlainOptions(),
       &(*pSurface));
 
     auto startTime = high_resolution_clock::now();
+    
     auto result = fitCfg.fit(sourceLinks, newTrackSeed, kfOptions);
+    
     auto stopTime = high_resolution_clock::now();
     auto fitTime = duration_cast<microseconds>(stopTime - startTime);
  

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -317,10 +317,10 @@ int PHActsTrkFitter::End(PHCompositeNode *topNode)
       m_timeFile->Close();
     } 
 
-  std::cout<<"The Acts track fitter had " << m_nBadFits <<" fits return an error"<<std::endl;
-
   if (Verbosity() > 0)
   {
+    std::cout<<"The Acts track fitter had " << m_nBadFits <<" fits return an error"<<std::endl;
+
     std::cout << "Finished PHActsTrkFitter" << std::endl;
   }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -43,9 +43,9 @@ using SourceLink = ActsExamples::TrkrClusterSourceLink;
 using FitResult = Acts::KalmanFitterResult<SourceLink>;
 using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
 using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
-                                      Acts::BoundParametersIndices,
-                                      Acts::ParDef::eBoundLoc0,
-                                      Acts::ParDef::eBoundLoc1>;
+                                      Acts::BoundIndices,
+                                      Acts::eBoundLoc0,
+                                      Acts::eBoundLoc1>;
 class PHActsTrkFitter : public PHTrackFitting
 {
  public:

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -20,7 +20,6 @@
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxTrackState_v1.h>
 
-#include <Acts/EventData/ChargePolicy.hpp>
 #include <Acts/EventData/SingleCurvilinearTrackParameters.hpp>
 #include <Acts/EventData/TrackParameters.hpp>
 #include <Acts/Surfaces/Surface.hpp>

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -12,9 +12,9 @@
 #include <Acts/Utilities/Definitions.hpp>
 #include <Acts/Utilities/Logger.hpp>
 
-#include <Acts/Geometry/GeometryID.hpp>
+#include <Acts/Geometry/GeometryIdentifier.hpp>
 
-#include <Acts/TrackFinder/CKFSourceLinkSelector.hpp>
+#include <Acts/TrackFinding/CKFSourceLinkSelector.hpp>
 
 #include <Acts/EventData/MeasurementHelpers.hpp>
 
@@ -58,9 +58,9 @@ using CKFFitResult = Acts::CombinatorialKalmanFilterResult<SourceLink>;
 using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
 
 using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
-                                      Acts::BoundParametersIndices,
-                                      Acts::ParDef::eBoundLoc0,
-                                      Acts::ParDef::eBoundLoc1>;
+                                      Acts::BoundIndices,
+                                      Acts::eBoundLoc0,
+                                      Acts::eBoundLoc1>;
 
 class PHActsTrkProp : public PHTrackPropagating
 {
@@ -120,9 +120,9 @@ class PHActsTrkProp : public PHTrackPropagating
   void createNodes(PHCompositeNode *topNode);
 
   /// Helper function to make an Acts::GeometryID for SL selection
-  Acts::GeometryID makeId(int volume = 0, 
-			  int layer = 0, 
-			  int sensitive = 0);
+  Acts::GeometryIdentifier makeId(int volume = 0, 
+				  int layer = 0, 
+				  int sensitive = 0);
 
   /// Wipe and recreate the SvtxTrackMap with Acts output
   void updateSvtxTrack(Trajectory traj, 
@@ -131,6 +131,9 @@ class PHActsTrkProp : public PHTrackPropagating
 
   /// Get all source links in a given event
   std::vector<SourceLink> getEventSourceLinks();
+
+  /// Setup the source link selector criteria
+  void setupSourceLinkSelection();
 
   ActsTrackingGeometry *m_tGeometry;
 
@@ -167,7 +170,7 @@ class PHActsTrkProp : public PHTrackPropagating
   /// Configuration containing the finding function instance
   ActsExamples::TrkrClusterFindingAlgorithm::Config findCfg;
 
-
+  Acts::PropagatorPlainOptions m_actsPropPlainOptions;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsVertexFinder.cc
@@ -43,9 +43,7 @@ PHActsVertexFinder::PHActsVertexFinder(const std::string &name)
   , m_maxVertices(50)
   , m_tGeometry(nullptr)
 {
-
 }
-
 
 int PHActsVertexFinder::Setup(PHCompositeNode *topNode)
 {
@@ -74,7 +72,7 @@ int PHActsVertexFinder::Process(PHCompositeNode *topNode)
     logLevel = Acts::Logging::VERBOSE;
 
   /// Get the list of tracks in Acts form
-  std::vector<const Acts::BoundParameters*> trackPointers = getTracks();
+  std::vector<const Acts::BoundTrackParameters*> trackPointers = getTracks();
 
   auto logger = Acts::getDefaultLogger("PHActsVertexFinder", logLevel);
 
@@ -89,7 +87,7 @@ int PHActsVertexFinder::Process(PHCompositeNode *topNode)
       using Stepper = Acts::EigenStepper<MagneticField>;
       using Propagator = Acts::Propagator<Stepper>;
       using PropagatorOptions = Acts::PropagatorOptions<>;
-      using TrackParameters = Acts::BoundParameters;
+      using TrackParameters = Acts::BoundTrackParameters;
       using Linearizer = Acts::HelicalTrackLinearizer<Propagator>;
       using VertexFitter = 
 	Acts::FullBilloirVertexFitter<TrackParameters,Linearizer>;
@@ -182,10 +180,10 @@ int PHActsVertexFinder::End(PHCompositeNode *topNode)
 
 
 
-std::vector<const Acts::BoundParameters*> PHActsVertexFinder::getTracks()
+std::vector<const Acts::BoundTrackParameters*> PHActsVertexFinder::getTracks()
 {
  
-  std::vector<const Acts::BoundParameters*> trackPtrs;
+  std::vector<const Acts::BoundTrackParameters*> trackPtrs;
 
   std::map<const unsigned int, Trajectory>::iterator trackIter;
 
@@ -200,7 +198,7 @@ std::vector<const Acts::BoundParameters*> PHActsVertexFinder::getTracks()
       {
 	if(traj.hasTrackParameters(trackTip))
 	  {
-	    const Acts::BoundParameters *param = new Acts::BoundParameters(traj.trackParameters(trackTip));
+	    const Acts::BoundTrackParameters *param = new Acts::BoundTrackParameters(traj.trackParameters(trackTip));
 	 
 	    trackPtrs.push_back(param);
 	  }
@@ -214,10 +212,10 @@ std::vector<const Acts::BoundParameters*> PHActsVertexFinder::getTracks()
 		<< trackPtrs.size()
 		<< std::endl;
       
-      for(std::vector<const Acts::BoundParameters*>::iterator it = trackPtrs.begin();
+      for(std::vector<const Acts::BoundTrackParameters*>::iterator it = trackPtrs.begin();
 	  it != trackPtrs.end(); ++it)
 	{
-	  const Acts::BoundParameters* param = *it;
+	  const Acts::BoundTrackParameters* param = *it;
 	  std::cout << "Track position: (" 
 		    << param->position(m_tGeometry->geoContext)(0)
 		    <<", " << param->position(m_tGeometry->geoContext)(1) << ", "

--- a/offline/packages/trackreco/PHActsVertexFinder.h
+++ b/offline/packages/trackreco/PHActsVertexFinder.h
@@ -37,7 +37,7 @@ class PHActsVertexFinder: public PHInitVertexing
   
   int createNodes(PHCompositeNode *topNode);
   int getNodes(PHCompositeNode *topNode);
-  std::vector<const Acts::BoundParameters*> getTracks();
+  std::vector<const Acts::BoundTrackParameters*> getTracks();
   std::map<const unsigned int, Trajectory> *m_actsFitResults;
 
   int m_event;

--- a/offline/packages/trackreco/PHActsVertexFitter.cc
+++ b/offline/packages/trackreco/PHActsVertexFitter.cc
@@ -72,7 +72,7 @@ int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
       logLevel = Acts::Logging::VERBOSE;
     }
   
-  std::vector<const Acts::BoundParameters*> tracks = getTracks();
+  std::vector<const Acts::BoundTrackParameters*> tracks = getTracks();
   
   auto logger = Acts::getDefaultLogger("PHActsVertexFitter", logLevel);
 
@@ -87,7 +87,7 @@ int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
       using Stepper = Acts::EigenStepper<MagneticField>;
       using Propagator = Acts::Propagator<Stepper>;
       using PropagatorOptions = Acts::PropagatorOptions<>;
-      using TrackParameters = Acts::BoundParameters;
+      using TrackParameters = Acts::BoundTrackParameters;
       using Linearizer = Acts::HelicalTrackLinearizer<Propagator>;
       using VertexFitter =
 	Acts::FullBilloirVertexFitter<TrackParameters, Linearizer>;
@@ -153,10 +153,10 @@ int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
 }
 
 
-std::vector<const Acts::BoundParameters*> PHActsVertexFitter::getTracks()
+std::vector<const Acts::BoundTrackParameters*> PHActsVertexFitter::getTracks()
 {
  
-  std::vector<const Acts::BoundParameters*> trackPtrs;
+  std::vector<const Acts::BoundTrackParameters*> trackPtrs;
 
   std::map<const unsigned int, Trajectory>::iterator trackIter;
 
@@ -171,7 +171,7 @@ std::vector<const Acts::BoundParameters*> PHActsVertexFitter::getTracks()
       {
 	if(traj.hasTrackParameters(trackTip))
 	  {
-	    const Acts::BoundParameters *param = new Acts::BoundParameters(traj.trackParameters(trackTip));
+	    const Acts::BoundTrackParameters *param = new Acts::BoundTrackParameters(traj.trackParameters(trackTip));
 	 
 	    trackPtrs.push_back(param);
 	  }
@@ -185,10 +185,10 @@ std::vector<const Acts::BoundParameters*> PHActsVertexFitter::getTracks()
 		<< trackPtrs.size()
 		<< std::endl;
       
-      for(std::vector<const Acts::BoundParameters*>::iterator it = trackPtrs.begin();
+      for(std::vector<const Acts::BoundTrackParameters*>::iterator it = trackPtrs.begin();
 	  it != trackPtrs.end(); ++it)
 	{
-	  const Acts::BoundParameters* param = *it;
+	  const Acts::BoundTrackParameters* param = *it;
 	  std::cout << "Track position: (" 
 		    << param->position(m_tGeometry->geoContext)(0)
 		    <<", " << param->position(m_tGeometry->geoContext)(1) << ", "

--- a/offline/packages/trackreco/PHActsVertexFitter.h
+++ b/offline/packages/trackreco/PHActsVertexFitter.h
@@ -30,7 +30,7 @@ class PHActsVertexFitter : public SubsysReco
  private:
   
   int getNodes(PHCompositeNode *topNode);
-  std::vector<const Acts::BoundParameters*> getTracks();  
+  std::vector<const Acts::BoundTrackParameters*> getTracks();  
   std::map<const unsigned int, Trajectory> *m_actsFitResults;
 
   int m_event;


### PR DESCRIPTION
This PR updates `coresoftware` to be compatible with Acts version 1.0, which was just merged into the sPHENIX-Acts fork. This gives us a few new feature capabilities from Acts. Additionally, since tagging v1.0, the Acts developers are hoping to make less frequent major outward API breaking changes.

Tested with a short simulation job with 100 muons. Performance parameters (e.g. resolutions) look similarly to before the update.