### PR TITLE
do not skip 0 events, just return

### DIFF
--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -1475,10 +1475,13 @@ int Fun4AllServer::run(const int nevnts, const bool require_nevents)
 int Fun4AllServer::skip(const int nevnts)
 {
   int iret = 0;
+  if (nevnts > 0) // do not execute for nevnts == 0
+  {
   vector<Fun4AllSyncManager *>::const_iterator iter;
   for (iter = SyncManagers.begin(); iter != SyncManagers.end(); ++iter)
   {
     iret += (*iter)->skip(nevnts);
+  }
   }
   return iret;
 }


### PR DESCRIPTION
The Fun4AllServer::skip called the syncmanagers even if the number of skipped events = 0 (which is now done in the new Fun4All macros). This lead to problems in the DST input manager when using file lists. This behavior will need fixing since it will also fail if some none zero number of events is skipped in the DSTs. But that's for later