### PR TITLE
Actsv1.1

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -325,10 +325,10 @@ void MakeActsGeometry::buildActsSurfaces()
       + std::string("/share/tgeo-sphenix.response"),
       "--bf-values","0","0",m_magField,
       "--bf-bscalor", std::to_string(m_magFieldRescale),
-      "--mat-input-type","file",
-      "--mat-input-file",
-      std::string(getenv("CALIBRATIONROOT"))
-      + std::string("/ACTS/sphenix-material.json")
+      //"--mat-input-type","file",
+      //"--mat-input-file",
+      //std::string(getenv("CALIBRATIONROOT"))
+      //+ std::string("/ACTS/sphenix-material.json")
       };
 
   // Set vector of chars to arguments needed
@@ -542,7 +542,7 @@ void MakeActsGeometry::makeInttMapPairs(TrackingVolumePtr &inttVolume)
 
       auto vec3d = surf->center(m_geoCtxt);
 
-      double ref_rad[4] = {8.987, 9.545, 10.835, 11.361};
+      double ref_rad[4] = {7.188, 7.732, 9.680, 10.262};
 
       std::vector<double> world_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
       /// The Acts geometry builder combines layers 4 and 5 together, 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -325,10 +325,10 @@ void MakeActsGeometry::buildActsSurfaces()
       + std::string("/share/tgeo-sphenix.response"),
       "--bf-values","0","0",m_magField,
       "--bf-bscalor", std::to_string(m_magFieldRescale),
-      //"--mat-input-type","file",
-      //"--mat-input-file",
-      //std::string(getenv("CALIBRATIONROOT"))
-      //+ std::string("/ACTS/sphenix-material.json")
+      "--mat-input-type","file",
+      "--mat-input-file",
+      std::string(getenv("CALIBRATIONROOT"))
+      + std::string("/ACTS/sphenix-material.json")
       };
 
   // Set vector of chars to arguments needed

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -358,15 +358,9 @@ Surface PHActsSourceLinks::getTpcLocalCoords(Acts::Vector2D &local2D,
     }
   else
     {
-      /*
-      std::cout << PHWHERE 
-		<< "Global to local ACTS transformation failed... skipping this cluster" 
-		<< vecResult.error() 
-		<< std::endl;
-      */
+      /// Otherwise use manual calculation, which is the same as Acts
       local2D(0) = rClusPhi - surfRphiCenter;
       local2D(1) = zTpc - surfZCenter;
-      //return nullptr;
     }
 
   /// Test that Acts surface transforms correctly back
@@ -493,9 +487,9 @@ Surface PHActsSourceLinks::getInttLocalCoords(Acts::Vector2D &local2D,
     }
   else
     {
-      std::cout << PHWHERE << "Global to local ACTS transformation failed... skipping this cluster" 
-		<< std::endl;
-      return nullptr;
+      /// Otherwise use manual calculation, same as Acts
+      local2D(0) = local[1] * Acts::UnitConstants::cm;
+      local2D(1) = local[2] * Acts::UnitConstants::cm;
     }
 
   /// Test that Acts surface transforms correctly back
@@ -515,8 +509,8 @@ Surface PHActsSourceLinks::getInttLocalCoords(Acts::Vector2D &local2D,
               << " " << segcent[1] << " " << segcent[2] << std::endl;
     std::cout << "   world; " << world[0] << " " << world[1]
               << " " << world[2] << std::endl;
-    std::cout << "   local; " << local[0] << " " << local[1]
-              << " " << local[2] << std::endl;
+    std::cout << "   local; " << local[0] * 10.<< " " << local[1] * 10.
+              << " " << local[2] * 10. << std::endl;
     std::cout << " acts local " << local2D(0) << "  " << local2D(1) << std::endl;
     std::cout << " sPHENIX global : " << x * 10 << "  " << y * 10 << "  " 
 	      << z * 10 << "  " << std::endl;
@@ -615,11 +609,9 @@ Surface PHActsSourceLinks::getMvtxLocalCoords(Acts::Vector2D &local2D,
     }
   else
     {
+      /// Otherwise use our by hand calculation - they are the same as Acts
       local2D(0) = local[0] * Acts::UnitConstants::cm;
       local2D(1) = local[2] * Acts::UnitConstants::cm;
-      //std::cout << PHWHERE << "Global to local ACTS transformation failed... skipping this cluster" << vecResult.error()
-      //<< std::endl;
-      //return nullptr;
     }
 
   /// Test that Acts surface transforms correctly back

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -358,9 +358,15 @@ Surface PHActsSourceLinks::getTpcLocalCoords(Acts::Vector2D &local2D,
     }
   else
     {
-      std::cout << PHWHERE << "Global to local ACTS transformation failed... skipping this cluster"
+      /*
+      std::cout << PHWHERE 
+		<< "Global to local ACTS transformation failed... skipping this cluster" 
+		<< vecResult.error() 
 		<< std::endl;
-      return nullptr;
+      */
+      local2D(0) = rClusPhi - surfRphiCenter;
+      local2D(1) = zTpc - surfZCenter;
+      //return nullptr;
     }
 
   /// Test that Acts surface transforms correctly back
@@ -596,7 +602,6 @@ Surface PHActsSourceLinks::getMvtxLocalCoords(Acts::Vector2D &local2D,
 						 chipId,
 						 world);
 
-
   Acts::Vector3D globalPos(x * Acts::UnitConstants::cm,
 			   y * Acts::UnitConstants::cm,
 			   z * Acts::UnitConstants::cm);
@@ -610,9 +615,11 @@ Surface PHActsSourceLinks::getMvtxLocalCoords(Acts::Vector2D &local2D,
     }
   else
     {
-      std::cout << PHWHERE << "Global to local ACTS transformation failed... skipping this cluster"
-		<< std::endl;
-      return nullptr;
+      local2D(0) = local[0] * Acts::UnitConstants::cm;
+      local2D(1) = local[2] * Acts::UnitConstants::cm;
+      //std::cout << PHWHERE << "Global to local ACTS transformation failed... skipping this cluster" << vecResult.error()
+      //<< std::endl;
+      //return nullptr;
     }
 
   /// Test that Acts surface transforms correctly back

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -285,7 +285,9 @@ int PHActsTrkFitter::Process()
 	      << std::endl;
 
   // put this in the output file
-  std::cout << " SvtxTrackMap size is now " << m_trackMap->size() << std::endl;
+  if(Verbosity() > 0)
+    std::cout << " SvtxTrackMap size is now " << m_trackMap->size() 
+	      << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }


### PR DESCRIPTION
This PR updates the previous Acts update PR, which evidently only worked for me locally due to some library mixups with the previous Acts version. 

This PR fixes two things:

1. It updates the INTT reference radii to match that in the current INTT macro.

2. It uses our local transformation calculation for the measurements rather than the Acts version. There is ongoing discussion with the Acts developers to modify this function to have better user functionality. We can return to this at a later time; however, our transformation calculations match that of Acts.