### PR TITLE
Delete tmp file

### DIFF
--- a/generators/PHPythia6/Makefile.am
+++ b/generators/PHPythia6/Makefile.am
@@ -29,17 +29,7 @@ libPHPythia6_la_LIBADD = \
   -lfastjet \
   -lCGAL
 
-if ! MAKEROOT6
-ROOT5_DICTS = \
-  PHPy6ForwardElectronTrig_Dict.cc \
-  PHPy6GenTrigger_Dict.cc \
-  PHPy6JetTrigger_Dict.cc \
-  PHPy6ParticleTrigger_Dict.cc \
-  PHPythia6_Dict.cc 
-endif
-
 libPHPythia6_la_SOURCES = \
-  $(ROOT5_DICTS) \
   PHPythia6.cc \
   PHPy6GenTrigger.cc \
   PHPy6JetTrigger.cc \
@@ -66,9 +56,6 @@ testexternals.cc:
 	echo "  return 0;" >> $@
 	echo "}" >> $@
 
-%_Dict.cc: %.h %LinkDef.h
-	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
-
 clean-local:
-	rm -f *Dict* $(BUILT_SOURCES)
+	rm -f $(BUILT_SOURCES)
 

--- a/generators/PHPythia6/PHPy6ForwardElectronTrig.h
+++ b/generators/PHPythia6/PHPy6ForwardElectronTrig.h
@@ -19,9 +19,7 @@ class PHPy6ForwardElectronTrig : public PHPy6GenTrigger
   //! destructor
   ~PHPy6ForwardElectronTrig(void) {}
 
-#if !defined(__CINT__) || defined(__CLING__)
   bool Apply(const HepMC::GenEvent* evt);
-#endif
 
   void set_electrons_required(int n)
   {

--- a/generators/PHPythia6/PHPy6ForwardElectronTrigLinkDef.h
+++ b/generators/PHPythia6/PHPy6ForwardElectronTrigLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHPy6ForwardElectronTrig - !;
-
-#endif

--- a/generators/PHPythia6/PHPy6GenTrigger.cc
+++ b/generators/PHPythia6/PHPy6GenTrigger.cc
@@ -1,11 +1,10 @@
 #include "PHPy6GenTrigger.h"
 
-using namespace std;
+#include <sstream>
 
 //__________________________________________________________
 PHPy6GenTrigger::PHPy6GenTrigger(const std::string &name)
-  : _verbosity(0)
-  , _name(name)
+  : m_Name(name)
 {
 }
 
@@ -14,8 +13,8 @@ PHPy6GenTrigger::~PHPy6GenTrigger() {}
 
 std::vector<int> PHPy6GenTrigger::convertToInts(std::string s)
 {
-  vector<int> theVec;
-  stringstream ss(s);
+  std::vector<int> theVec;
+  std::stringstream ss(s);
   int i;
   while (ss >> i)
   {

--- a/generators/PHPythia6/PHPy6GenTrigger.h
+++ b/generators/PHPythia6/PHPy6GenTrigger.h
@@ -2,7 +2,6 @@
 #define PHPYTHIA6_PHPY6GENTRIGGER_H
 
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -20,28 +19,25 @@ class PHPy6GenTrigger
  public:
   virtual ~PHPy6GenTrigger();
 
-#if !defined(__CINT__) || defined(__CLING__)
   virtual bool Apply(const HepMC::GenEvent* evt)
   {
-    std::cout << "PHPy8GenTrigger::Apply - in virtual function" << std::endl;
+    std::cout << "PHPy6GenTrigger::Apply - in virtual function" << std::endl;
     return false;
   }
-#endif
 
   virtual std::string GetName()
   {
-    return _name;
+    return m_Name;
   }
 
   std::vector<int> convertToInts(std::string s);
 
-  void Verbosity(int v) { _verbosity = v; }
-
- protected:
-  int _verbosity;
+  void Verbosity(int v) { m_Verbosity = v; }
+  int Verbosity() const {return m_Verbosity;}
 
  private:
-  std::string _name;
+  int m_Verbosity = 0;
+  std::string m_Name;
 };
 
 #endif

--- a/generators/PHPythia6/PHPy6GenTriggerLinkDef.h
+++ b/generators/PHPythia6/PHPy6GenTriggerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHPy6GenTrigger - !;
-
-#endif

--- a/generators/PHPythia6/PHPy6JetTrigger.cc
+++ b/generators/PHPythia6/PHPy6JetTrigger.cc
@@ -22,17 +22,12 @@ using namespace std;
 //__________________________________________________________
 PHPy6JetTrigger::PHPy6JetTrigger(const std::string &name)
   : PHPy6GenTrigger(name)
-  , m_theEtaHigh(4.0)
-  , m_theEtaLow(1.0)
-  , m_minPt(10.0)
-  , m_R(1.0)
-  , m_nconst(0)
 {
 }
 
 PHPy6JetTrigger::~PHPy6JetTrigger()
 {
-  if (_verbosity > 0) PrintConfig();
+  if (Verbosity() > 0) PrintConfig();
 }
 
 bool PHPy6JetTrigger::Apply(const HepMC::GenEvent *evt)
@@ -91,7 +86,7 @@ bool PHPy6JetTrigger::Apply(const HepMC::GenEvent *evt)
     }
   }
 
-  if (_verbosity > 2)
+  if (Verbosity() > 2)
   {
     cout << "PHPy6JetTrigger::Apply - max_pt = " << max_pt << ", and jetFound = " << jetFound << endl;
   }

--- a/generators/PHPythia6/PHPy6JetTrigger.h
+++ b/generators/PHPythia6/PHPy6JetTrigger.h
@@ -16,9 +16,7 @@ class PHPy6JetTrigger : public PHPy6GenTrigger
   PHPy6JetTrigger(const std::string& name = "PHPy6JetTrigger");
   virtual ~PHPy6JetTrigger();
 
-#if !defined(__CINT__) || defined(__CLING__)
   bool Apply(const HepMC::GenEvent* evt);
-#endif
 
   void SetEtaHighLow(double etaHigh, double etaLow);
   void SetMinJetPt(double minPt) { m_minPt = minPt; }
@@ -28,11 +26,11 @@ class PHPy6JetTrigger : public PHPy6GenTrigger
   void PrintConfig();
 
  private:
-  double m_theEtaHigh;
-  double m_theEtaLow;
-  double m_minPt;
-  double m_R;
-  int m_nconst;
+  double m_theEtaHigh = 4.;
+  double m_theEtaLow = 1.;
+  double m_minPt = 10.;
+  double m_R = 1.;
+  int m_nconst = 0;
 };
 
 #endif

--- a/generators/PHPythia6/PHPy6JetTriggerLinkDef.h
+++ b/generators/PHPythia6/PHPy6JetTriggerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHPy6JetTrigger - !;
-
-#endif

--- a/generators/PHPythia6/PHPy6ParticleTrigger.cc
+++ b/generators/PHPythia6/PHPy6ParticleTrigger.cc
@@ -120,7 +120,7 @@ bool PHPy6ParticleTrigger::Apply(const HepMC::GenEvent *evt)
         if (_doPzHighCut && (*p)->momentum().pz() > _thePzHigh) continue;
         if (_doPzLowCut && (*p)->momentum().pz() < _thePzLow) continue;
 
-        if (_verbosity > 5)
+        if (Verbosity() > 5)
         {
           cout << "stable " << (*p)->pdg_id()
                << "  pt: " << p_pT
@@ -141,7 +141,7 @@ bool PHPy6ParticleTrigger::Apply(const HepMC::GenEvent *evt)
             if (abs((*p_parent)->pdg_id()) == abs(_theParents[k]))
             {
               passedParents = true;
-              if (_verbosity > 5) cout << "found parent!" << endl;
+              if (Verbosity() > 5) cout << "found parent!" << endl;
               break;
             }
           }  //moms for loop

--- a/generators/PHPythia6/PHPy6ParticleTrigger.h
+++ b/generators/PHPythia6/PHPy6ParticleTrigger.h
@@ -28,9 +28,7 @@ class PHPy6ParticleTrigger : public PHPy6GenTrigger
   //! destructor
   ~PHPy6ParticleTrigger(void) {}
 
-#if !defined(__CINT__) || defined(__CLING__)
   bool Apply(const HepMC::GenEvent *evt);
-#endif
 
   void AddParticles(const std::string &particles);
   void AddParticles(int particle);

--- a/generators/PHPythia6/PHPy6ParticleTriggerLinkDef.h
+++ b/generators/PHPythia6/PHPy6ParticleTriggerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHPy6ParticleTrigger - !;
-
-#endif

--- a/generators/PHPythia6/PHPythia6.cc
+++ b/generators/PHPythia6/PHPythia6.cc
@@ -26,6 +26,7 @@
 #include <cmath>                        // for fmod
 #include <cstdlib>                      // for exit, abs
 #include <iostream>                      // for operator<<, endl, basic_ostream
+#include <sstream>
 
 class PHHepMCGenEvent;
 

--- a/generators/PHPythia6/PHPythia6LinkDef.h
+++ b/generators/PHPythia6/PHPythia6LinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHPythia6 - !;
-
-#endif

--- a/generators/PHPythia6/configure.ac
+++ b/generators/PHPythia6/configure.ac
@@ -17,12 +17,5 @@ if test $ac_cv_prog_gxx = yes; then
   fi
 fi
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
-AC_SUBST(CINTDEFS)
-fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
-
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/generators/PHPythia8/Makefile.am
+++ b/generators/PHPythia8/Makefile.am
@@ -25,16 +25,7 @@ libPHPythia8_la_LIBADD = \
   -lphhepmc \
   -lHepMC
 
-if ! MAKEROOT6
-ROOT5_DICTS = \
-  PHPythia8_Dict.cc \
-  PHPy8GenTrigger_Dict.cc \
-  PHPy8JetTrigger_Dict.cc \
-  PHPy8ParticleTrigger_Dict.cc
-endif
-
 libPHPythia8_la_SOURCES = \
-  $(ROOT5_DICTS) \
   PHPythia8.cc \
   PHPy8GenTrigger.cc \
   PHPy8ParticleTrigger.cc \
@@ -59,9 +50,5 @@ testexternals.cc:
 	echo "  return 0;" >> $@
 	echo "}" >> $@
 
-%_Dict.cc: %.h %LinkDef.h
-	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
-
-
 clean-local:
-	rm -f *Dict* $(BUILT_SOURCES)
+	rm -f $(BUILT_SOURCES)

--- a/generators/PHPythia8/PHPy8GenTriggerLinkDef.h
+++ b/generators/PHPythia8/PHPy8GenTriggerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHPy8GenTrigger - !;
-
-#endif

--- a/generators/PHPythia8/PHPy8JetTriggerLinkDef.h
+++ b/generators/PHPythia8/PHPy8JetTriggerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHPy8JetTrigger - !;
-
-#endif

--- a/generators/PHPythia8/PHPy8ParticleTriggerLinkDef.h
+++ b/generators/PHPythia8/PHPy8ParticleTriggerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHPy8ParticleTrigger - !;
-
-#endif

--- a/generators/PHPythia8/PHPythia8LinkDef.h
+++ b/generators/PHPythia8/PHPythia8LinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHPythia8 - !;
-
-#endif

--- a/generators/PHPythia8/configure.ac
+++ b/generators/PHPythia8/configure.ac
@@ -27,12 +27,5 @@ if test $ac_cv_prog_gxx = yes; then
   fi
 fi
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
-AC_SUBST(CINTDEFS)
-fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
-
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/generators/PHSartre/Makefile.am
+++ b/generators/PHSartre/Makefile.am
@@ -29,15 +29,7 @@ libPHSartre_la_LIBADD = \
   -lEG \
   -lMathMore
 
-if ! MAKEROOT6
-ROOT5_DICTS = \
-  PHSartre_Dict.cc \
-  PHSartreGenTrigger_Dict.cc \
-  PHSartreParticleTrigger_Dict.cc
-endif
-
 libPHSartre_la_SOURCES = \
-  $(ROOT5_DICTS) \
   PHSartre.cc \
   PHSartreGenTrigger.cc \
   PHSartreParticleTrigger.cc
@@ -61,8 +53,5 @@ testexternals.cc:
 	echo "  return 0;" >> $@
 	echo "}" >> $@
 
-%_Dict.cc: %.h %LinkDef.h
-	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
-
 clean-local:
-	rm -f *Dict* $(BUILT_SOURCES)
+	rm -f $(BUILT_SOURCES)

--- a/generators/PHSartre/PHSartreGenTriggerLinkDef.h
+++ b/generators/PHSartre/PHSartreGenTriggerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHSartreGenTrigger - !;
-
-#endif

--- a/generators/PHSartre/PHSartreLinkDef.h
+++ b/generators/PHSartre/PHSartreLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHSartre - !;
-
-#endif

--- a/generators/PHSartre/PHSartreParticleTriggerLinkDef.h
+++ b/generators/PHSartre/PHSartreParticleTriggerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class PHSartreParticleTrigger - !;
-
-#endif

--- a/generators/PHSartre/configure.ac
+++ b/generators/PHSartre/configure.ac
@@ -12,12 +12,5 @@ if test $ac_cv_prog_gxx = yes; then
    CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
 fi
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
-CINTDEFS=" -noIncludePaths  -inlineInputHeader "
-AC_SUBST(CINTDEFS)
-fi
-AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1])
-
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/generators/phhepmc/Fun4AllHepMCInputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCInputManager.cc
@@ -71,7 +71,11 @@ Fun4AllHepMCInputManager::Fun4AllHepMCInputManager(const std::string &name, cons
 Fun4AllHepMCInputManager::~Fun4AllHepMCInputManager()
 {
   fileclose();
-
+  if (!m_HepMCTmpFile.empty())
+  {
+    // okay if the file does not exist
+    remove(m_HepMCTmpFile.c_str());
+  }
   delete ascii_in;
   delete filestream;
   delete unzipstream;


### PR DESCRIPTION
This PR adds the deletion of the temporary hepmc file in the dtor. If an input manager is exhausted the others push back their latest event which in the HepMC input manager case creates those temporary files which then need to be cleaned up in the dtor.