### PR TITLE
Acts Tracking Geometry

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -4,7 +4,7 @@
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
 
-#include "PHActsSourceLinks.h"
+#include "ActsTrackingGeometry.h"
 #include "ActsTrack.h"
 
 #include <Acts/Utilities/Helpers.hpp>

--- a/offline/packages/trackreco/ActsTrack.h
+++ b/offline/packages/trackreco/ActsTrack.h
@@ -3,6 +3,7 @@
 
 #include <Acts/EventData/TrackParameters.hpp>
 
+#include <ActsExamples/EventData/Track.hpp>
 #include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
 
 using SourceLink = ActsExamples::TrkrClusterSourceLink;

--- a/offline/packages/trackreco/ActsTrackingGeometry.h
+++ b/offline/packages/trackreco/ActsTrackingGeometry.h
@@ -1,0 +1,45 @@
+#ifndef TRACKRECO_ACTSTRACKINGGEOMETRY_H
+#define TRACKRECO_ACTSTRACKINGGEOMETRY_H
+
+#include <memory>
+#include <Acts/Utilities/BinnedArray.hpp>
+#include <Acts/Utilities/Definitions.hpp>
+#include <Acts/Utilities/Logger.hpp>
+
+#include <Acts/Geometry/TrackingGeometry.hpp>
+#include <Acts/MagneticField/MagneticFieldContext.hpp>
+#include <Acts/Utilities/CalibrationContext.hpp>
+
+#include <ActsExamples/Plugins/BField/BFieldOptions.hpp>
+
+/**
+ * A struct to carry around Acts geometry on node tree, so as to not put 
+ * all of the MakeActsGeometry tree
+ */
+class ActsTrackingGeometry{
+ public:
+  ActsTrackingGeometry(){}
+  ActsTrackingGeometry(std::shared_ptr<const Acts::TrackingGeometry> tGeo,
+		       ActsExamples::Options::BFieldVariant mag,
+		       Acts::CalibrationContext calib,
+		       Acts::GeometryContext geoCtxt,
+		       Acts::MagneticFieldContext magFieldCtxt)
+  : tGeometry(tGeo)
+  , magField(mag)
+  , calibContext(calib)
+  , geoContext(geoCtxt)
+  , magFieldContext(magFieldCtxt)
+  {}
+
+  /// Tracking geometry and magnetic field, for fitter function
+  std::shared_ptr<const Acts::TrackingGeometry> tGeometry;
+  ActsExamples::Options::BFieldVariant magField;
+
+  /// Acts context, for Kalman options
+  Acts::CalibrationContext calibContext;
+  Acts::GeometryContext geoContext;
+  Acts::MagneticFieldContext magFieldContext;
+};
+
+
+#endif

--- a/offline/packages/trackreco/ActsTrackingGeometry.h
+++ b/offline/packages/trackreco/ActsTrackingGeometry.h
@@ -16,8 +16,7 @@
  * A struct to carry around Acts geometry on node tree, so as to not put 
  * all of the MakeActsGeometry tree
  */
-class ActsTrackingGeometry{
- public:
+struct ActsTrackingGeometry{
   ActsTrackingGeometry(){}
   ActsTrackingGeometry(std::shared_ptr<const Acts::TrackingGeometry> tGeo,
 		       ActsExamples::Options::BFieldVariant mag,

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -57,6 +57,7 @@
 #include <TObject.h>
 #include <TSystem.h>
 #include <TVector3.h>
+
 #include <cmath>
 #include <cstddef>
 #include <cstdlib>
@@ -66,9 +67,7 @@
 #include <utility>
 #include <vector>
 
-using namespace std;
-
-MakeActsGeometry::MakeActsGeometry(const string &name)
+MakeActsGeometry::MakeActsGeometry(const std::string &name)
   : m_geomContainerMvtx(nullptr)
   , m_geomContainerIntt(nullptr)
   , m_geomContainerTpc(nullptr)
@@ -493,7 +492,7 @@ void MakeActsGeometry::buildActsSurfaces()
   std::string materialFile = "sphenix-material.json";
 
   /// Check to see if files exist locally - if not, use defaults
-  ifstream file;
+  std::ifstream file;
 
   file.open(responseFile);
   if(!file)
@@ -1371,8 +1370,8 @@ void MakeActsGeometry::getInttKeyFromNode(TGeoNode *gnode)
   TrkrDefs::hitsetkey node_key = InttDefs::genHitSetKey(layer, ladder_z, 
 							ladder_phi);
 
-  std::pair<TrkrDefs::hitsetkey, TGeoNode *> tmp = make_pair(node_key, 
-							     sensor_node);
+  std::pair<TrkrDefs::hitsetkey, TGeoNode *> tmp = std::make_pair(
+					         node_key, sensor_node);
   m_clusterNodeMap.insert(tmp);
 
   if (m_verbosity > 1)
@@ -1453,8 +1452,8 @@ void MakeActsGeometry::getMvtxKeyFromNode(TGeoNode *gnode)
 
       // add sensor node to map
       TGeoNode *sensor_node = module_node->GetDaughter(i)->GetDaughter(0);
-      std::pair<TrkrDefs::hitsetkey, TGeoNode *> tmp = make_pair(node_key,
-								 sensor_node);
+      std::pair<TrkrDefs::hitsetkey, TGeoNode *> tmp = std::make_pair(
+						       node_key, sensor_node);
       m_clusterNodeMap.insert(tmp);
 
       if (m_verbosity > 3)

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -24,6 +24,7 @@ AM_LDFLAGS = \
 pkginclude_HEADERS = \
   ActsTransformations.h \
   ActsTrack.h \
+  ActsTrackingGeometry.h \
   ActsEvaluator.h \
   AssocInfoContainer.h \
   CellularAutomaton.h \

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -24,6 +24,8 @@
 #include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
 #include <ActsExamples/Plugins/BField/BFieldOptions.hpp>
 
+#include "ActsTrackingGeometry.h"
+
 class PHCompositeNode;
 class TrkrClusterContainer;
 class TrkrCluster;
@@ -45,33 +47,6 @@ namespace Acts
 
 using Surface = std::shared_ptr<const Acts::Surface>;
 using SourceLink = ActsExamples::TrkrClusterSourceLink;
-
-/**
- * A struct to carry around Acts geometry on node tree, so as to not put 
- * all of the MakeActsGeometry tree
- */
-struct ActsTrackingGeometry{
-  ActsTrackingGeometry(){}
-  ActsTrackingGeometry(std::shared_ptr<const Acts::TrackingGeometry> tGeo,
-		       ActsExamples::Options::BFieldVariant mag,
-		       Acts::CalibrationContext calib,
-		       Acts::GeometryContext geoCtxt,
-		       Acts::MagneticFieldContext magFieldCtxt)
-  : tGeometry(tGeo)
-  , magField(mag)
-  , calibContext(calib)
-  , geoContext(geoCtxt)
-  , magFieldContext(magFieldCtxt)
-  {}
-  /// Tracking geometry and magnetic field, for fitter function
-  std::shared_ptr<const Acts::TrackingGeometry> tGeometry;
-  ActsExamples::Options::BFieldVariant magField;
-
-  /// Acts context, for Kalman options
-  Acts::CalibrationContext calibContext;
-  Acts::GeometryContext geoContext;
-  Acts::MagneticFieldContext magFieldContext;
-};
 
 /**
  * This class is responsible for creating Acts TrkrClusterSourceLinks from

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -1,8 +1,6 @@
 #ifndef TRACKRECO_PHACTSTRACKS_H
 #define TRACKRECO_PHACTSTRACKS_H
 
-#include "PHActsSourceLinks.h" 
-
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
 
@@ -17,6 +15,7 @@
 #include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
 
 #include "ActsTrack.h"
+#include "ActsTrackingGeometry.h"
 
 #include <map>
 #include <string>

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -15,6 +15,7 @@
 #include <trackbase_historic/SvtxTrackState_v1.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 
+
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -9,7 +9,8 @@
 #define TRACKRECO_ACTSTRKFITTER_H
 
 #include "PHTrackFitting.h"
-#include "PHActsSourceLinks.h"
+#include "ActsTrackingGeometry.h"
+#include <trackbase/TrkrDefs.h>
 
 #include <Acts/Utilities/BinnedArray.hpp>
 #include <Acts/Utilities/Definitions.hpp>

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -2,7 +2,7 @@
 #define TRACKRECO_PHACTSTRKPROP_H
 
 #include "PHTrackPropagating.h"
-#include "PHActsSourceLinks.h"
+#include "ActsTrackingGeometry.h"
 #include "ActsTrack.h"
 
 #include <fun4all/SubsysReco.h>

--- a/offline/packages/trackreco/PHActsVertexFinder.h
+++ b/offline/packages/trackreco/PHActsVertexFinder.h
@@ -2,7 +2,7 @@
 #define TRACKRECO_PHACTSVERTEXFINDER_H
 
 #include "PHInitVertexing.h"
-#include "PHActsSourceLinks.h"
+#include "ActsTrackingGeometry.h"
 
 #include <trackbase/TrkrDefs.h>
 

--- a/offline/packages/trackreco/PHActsVertexFitter.h
+++ b/offline/packages/trackreco/PHActsVertexFitter.h
@@ -2,7 +2,7 @@
 #define TRACKRECO_PHACTSVERTEXFITTER_H
 
 #include <fun4all/SubsysReco.h>
-#include "PHActsSourceLinks.h"
+#include "ActsTrackingGeometry.h"
 
 #include <ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp>
 


### PR DESCRIPTION
This PR refactors the ActsTrackingGeometry struct and puts it into it's own header file so that PHActsSourceLinks.h is not carried around in a bunch of different modules.