### PR TITLE
Standalone acts geometry

### DIFF
--- a/offline/packages/trackreco/ActsSurfaceMaps.h
+++ b/offline/packages/trackreco/ActsSurfaceMaps.h
@@ -1,0 +1,25 @@
+#ifndef TRACKRECO_ACTSSURFACEMAPS_H
+#define TRACKRECO_ACTSSURFACEMAPS_H
+
+#include <trackbase/TrkrDefs.h>
+#include <TGeoNode.h>
+
+#include <map>
+#include <vector>
+
+using Surface = std::shared_ptr<const Acts::Surface>;
+using SurfaceVec = std::vector<Surface>;
+
+
+struct ActsSurfaceMaps
+{
+
+  ActsSurfaceMaps(){};
+  std::map<TrkrDefs::hitsetkey, Surface> siliconSurfaceMap;
+  std::map<TrkrDefs::hitsetkey, SurfaceVec> tpcSurfaceMap;
+  std::map<TrkrDefs::hitsetkey, SurfaceVec> mmSurfaceMap;
+  std::map<TrkrDefs::hitsetkey, TGeoNode*> tGeoNodeMap;
+ 
+};
+
+#endif

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -709,7 +709,6 @@ void MakeActsGeometry::unpackVolumes()
       auto mvtxVolumes = siliconVolume->arrayObjects().at(0);
       auto mvtxConfinedVolumes = mvtxVolumes->confinedVolumes();
       auto mvtxBarrel = mvtxConfinedVolumes->arrayObjects().at(1);
-      
       makeMvtxMapPairs(mvtxBarrel);
       
       /// INTT only has one volume, so there is not an added volume extraction
@@ -720,6 +719,7 @@ void MakeActsGeometry::unpackVolumes()
       /// Same for the TPC - only one volume. Buried under silicon
       /// volume array
       auto tpcVolume = siliconVolumes->arrayObjects().at(1);
+
       makeTpcMapPairs(tpcVolume);
     }
 
@@ -728,7 +728,9 @@ void MakeActsGeometry::unpackVolumes()
 
 void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
 {
-
+  if(Verbosity() > 1)
+    std::cout << "Building TPC with " << tpcVolume->volumeName() << std::endl;
+   
   auto tpcLayerArray = tpcVolume->confinedLayers();
   auto tpcLayerVector = tpcLayerArray->arrayObjects();
 
@@ -781,6 +783,11 @@ void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
 
 void MakeActsGeometry::makeMmMapPairs(TrackingVolumePtr &mmVolume)
 {
+
+  if(Verbosity() > 1)
+    std::cout << "Building MMs with " << mmVolume->volumeName() << std::endl;
+    
+
   auto mmLayerArray = mmVolume->confinedLayers();
   auto mmLayerVector = mmLayerArray->arrayObjects();
 
@@ -844,8 +851,6 @@ void MakeActsGeometry::makeInttMapPairs(TrackingVolumePtr &inttVolume)
   // inttLayerVector is a std::vector<LayerPtr>
   for (unsigned int i = 0; i < inttLayerVector.size(); i++)
   {
-    //auto vol = inttLayerVector.at(i)->trackingVolume();
-
     // Get the ACTS::SurfaceArray from each INTT LayerPtr being iterated over
     auto surfaceArray = inttLayerVector.at(i)->surfaceArray();
     if (surfaceArray == NULL)
@@ -890,9 +895,7 @@ void MakeActsGeometry::makeInttMapPairs(TrackingVolumePtr &inttVolume)
 
         std::cout << "Layer radius " << layer_rad << " layer " << layer << " ladderPhi " << ladderPhi << " ladderZ " << ladderZ
                   << " recover surface from m_clusterSurfaceMapSilicon " << std::endl;
-        std::map<TrkrDefs::hitsetkey, Surface>::iterator surf_iter = m_clusterSurfaceMapSilicon.find(hitsetkey);
         std::cout << " surface type " << surf->type() << std::endl;
-        surf_iter->second->toStream(m_geoCtxt, std::cout);
         auto assoc_layer = surf->associatedLayer();
         std::cout << std::endl
                   << " Layer type " << assoc_layer->layerType() << std::endl;
@@ -978,7 +981,6 @@ void MakeActsGeometry::makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume)
         std::map<TrkrDefs::hitsetkey, Surface>::iterator surf_iter = m_clusterSurfaceMapSilicon.find(hitsetkey);
         std::cout << " surface type " << surf_iter->second->type() 
 		  << std::endl;
-        surf_iter->second->toStream(m_geoCtxt, std::cout);
         auto assoc_layer = surf->associatedLayer();
         std::cout << std::endl << " Layer type " 
 		  << assoc_layer->layerType() << std::endl;
@@ -1501,7 +1503,6 @@ void MakeActsGeometry::setPlanarSurfaceDivisions()
   m_moduleStepPhi = 2.0 * M_PI / 12.0;
   m_modulePhiStart = -M_PI;
   m_surfStepPhi = 2.0 * M_PI / (double) (m_nSurfPhi * m_nTpcModulesPerLayer);
-
   for(unsigned int isector = 0; isector < 3; ++isector)
     {
       layer_thickness_sector[isector] = 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -29,7 +29,11 @@
 #include <phgeom/PHGeomTGeo.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
@@ -68,7 +72,8 @@
 #include <vector>
 
 MakeActsGeometry::MakeActsGeometry(const std::string &name)
-  : m_geomContainerMvtx(nullptr)
+: SubsysReco(name)
+  , m_geomContainerMvtx(nullptr)
   , m_geomContainerIntt(nullptr)
   , m_geomContainerTpc(nullptr)
   , m_geoManager(nullptr)
@@ -76,7 +81,6 @@ MakeActsGeometry::MakeActsGeometry(const std::string &name)
   , m_maxSurfZ(105.5)
   , m_nSurfZ(1)
   , m_nSurfPhi(12)
-  , m_verbosity(0)
   , m_magField("1.4")
   , m_magFieldRescale(-1.0)
   , m_buildMMs(false)
@@ -88,6 +92,42 @@ MakeActsGeometry::MakeActsGeometry(const std::string &name)
 MakeActsGeometry::~MakeActsGeometry()
 {}
 
+int MakeActsGeometry::Init(PHCompositeNode *topNode)
+{  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
+{
+
+  if(buildAllGeometry(topNode) != Fun4AllReturnCodes::EVENT_OK)
+    return Fun4AllReturnCodes::ABORTEVENT;
+
+  /// Set the actsGeometry struct to be put on the node tree
+  m_actsGeometry->tGeometry = m_tGeometry;
+  m_actsGeometry->magField = m_magneticField;
+  m_actsGeometry->calibContext = m_calibContext;
+  m_actsGeometry->magFieldContext = m_magFieldContext;
+  m_actsGeometry->geoContext = m_geoCtxt;
+
+  /// Same for the surface maps
+  m_surfMaps->siliconSurfaceMap = m_clusterSurfaceMapSilicon;
+  m_surfMaps->tpcSurfaceMap = m_clusterSurfaceMapTpcEdit;
+  m_surfMaps->tGeoNodeMap = m_clusterNodeMap;
+  m_surfMaps->mmSurfaceMap = m_clusterSurfaceMapMmEdit;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+
+}
+
+int MakeActsGeometry::process_event(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+int MakeActsGeometry::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
 int MakeActsGeometry::buildAllGeometry(PHCompositeNode *topNode)
 {
 
@@ -96,9 +136,11 @@ int MakeActsGeometry::buildAllGeometry(PHCompositeNode *topNode)
   // Do this before anything else, so that the geometry is finalized
   editTPCGeometry(topNode);
 
-  getNodes(topNode);  
-
-  createNodes(topNode);
+  if(getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+    return Fun4AllReturnCodes::ABORTEVENT;  
+  
+  if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+    return Fun4AllReturnCodes::ABORTEVENT;
 
   /// Run Acts layer builder
   buildActsSurfaces();
@@ -107,7 +149,7 @@ int MakeActsGeometry::buildAllGeometry(PHCompositeNode *topNode)
   makeTGeoNodeMap(topNode);
 
   /// Export the new geometry to a root file for examination
-  if(m_verbosity > 3)
+  if(Verbosity() > 3)
     {
       PHGeomUtility::ExportGeomtry(topNode, "sPHENIXActsGeom.root"); 
       PHGeomUtility::ExportGeomtry(topNode, "sPHENIXActsGeom.gdml");
@@ -145,7 +187,7 @@ void MakeActsGeometry::editTPCGeometry(PHCompositeNode *topNode)
   TGeoNode *tpc_gas_north_node = nullptr;
 
   // find tpc north gas volume at path of World*/tpc_envelope*
-  if (m_verbosity)
+  if (Verbosity())
   {
     std::cout << "EditTPCGeometry - searching under volume: ";
     World_vol->Print();
@@ -156,7 +198,7 @@ void MakeActsGeometry::editTPCGeometry(PHCompositeNode *topNode)
 
     if (node_name.BeginsWith("tpc_envelope"))
     {
-      if (m_verbosity)
+      if (Verbosity())
         std::cout << "EditTPCGeometry - found " << node_name << std::endl;
 
       tpc_envelope_node = World_vol->GetNode(i);
@@ -168,7 +210,7 @@ void MakeActsGeometry::editTPCGeometry(PHCompositeNode *topNode)
   // find tpc north gas volume at path of World*/tpc_envelope*/tpc_gas_north*
   TGeoVolume *tpc_envelope_vol = tpc_envelope_node->GetVolume();
   assert(tpc_envelope_vol);
-  if (m_verbosity)
+  if (Verbosity())
     {
       std::cout << "EditTPCGeometry - searching under volume: ";
       tpc_envelope_vol->Print();
@@ -180,7 +222,7 @@ void MakeActsGeometry::editTPCGeometry(PHCompositeNode *topNode)
       
       if (node_name.BeginsWith("tpc_gas_north"))
 	{
-	  if (m_verbosity)
+	  if (Verbosity())
 	    std::cout << "EditTPCGeometry - found " << node_name << std::endl;
 	  
 	  tpc_gas_north_node = tpc_envelope_vol->GetNode(i);
@@ -192,7 +234,7 @@ void MakeActsGeometry::editTPCGeometry(PHCompositeNode *topNode)
   TGeoVolume *tpc_gas_north_vol = tpc_gas_north_node->GetVolume();
   assert(tpc_gas_north_vol);
 
-  if (m_verbosity)
+  if (Verbosity())
   {
     std::cout << "EditTPCGeometry - gas volume: ";
     tpc_gas_north_vol->Print();
@@ -219,7 +261,7 @@ void MakeActsGeometry::editTPCGeometry(PHCompositeNode *topNode)
 
     if (node_name.BeginsWith("MICROMEGAS"))
     {
-      if (m_verbosity)
+      if (Verbosity())
         std::cout << "EditTPCGeometry - found micromegas node " << node_name << std::endl;
 
       micromegas_envelope_node = World_vol->GetNode(i);
@@ -243,7 +285,7 @@ void MakeActsGeometry::editTPCGeometry(PHCompositeNode *topNode)
 	  // this gets both inner and outer
 	  if (node_name.BeginsWith("MICROMEGAS_55_Gas2"))
 	    {
-	      if (m_verbosity)
+	      if (Verbosity())
 		std::cout << "EditTPCGeometry - found Micromegas node " << node_name << std::endl;
 	      
 	      TGeoNode *micromegas_node = nullptr;
@@ -311,9 +353,9 @@ void MakeActsGeometry::addActsMicromegasSurfaces(int mm_layer,
   micromegas_measurement_vol->SetFillColor(kYellow);
   micromegas_measurement_vol->SetVisibility(kTRUE);
   
-  if(m_verbosity > 1)
+  if(Verbosity() > 1)
     {
-      std::cout << m_verbosity << " Made box for Micromegas layer " 
+      std::cout << Verbosity() << " Made box for Micromegas layer " 
 		<< mm_layer << " with dx " << box_thickness << " dy " 
 		<< box_r_phi << " ref arc " 
 		<< m_surfStepPhi * m_mmLayerRadius[mm_layer] << " dz " 
@@ -358,7 +400,7 @@ void MakeActsGeometry::addActsMicromegasSurfaces(int mm_layer,
 	      micromegas_vol->AddNode(micromegas_measurement_vol, copy, 
 				      micromegas_measurement_location);
 	      
-	      if(m_verbosity > 10) 
+	      if(Verbosity() > 10) 
 		{
 		  std::cout << " Made copy " << copy << mm_layer << " iphi " 
 			    << iphi << std::endl;
@@ -402,9 +444,9 @@ void MakeActsGeometry::addActsTpcSurfaces(TGeoVolume *tpc_gas_vol,
       tpc_gas_measurement_vol[ilayer]->SetFillColor(kYellow);
       tpc_gas_measurement_vol[ilayer]->SetVisibility(kTRUE);
 
-      if(m_verbosity > 30)
+      if(Verbosity() > 30)
 	{
-	  std::cout << m_verbosity << " Made box for layer " << ilayer 
+	  std::cout << Verbosity() << " Made box for layer " << ilayer 
 		    << " with dx " << m_layerThickness[ilayer] << " dy " 
 		    << box_r_phi << " ref arc " 
 		    << m_surfStepPhi * m_layerRadius[ilayer] << " dz " 
@@ -450,7 +492,7 @@ void MakeActsGeometry::addActsTpcSurfaces(TGeoVolume *tpc_gas_vol,
 		  tpc_gas_vol->AddNode(tpc_gas_measurement_vol[ilayer], 
 				       copy, tpc_gas_measurement_location);
 		  
-		  if(m_verbosity > 30 && ilayer == 30) 
+		  if(Verbosity() > 30 && ilayer == 30) 
 		    {
 		      std::cout << " Made copy " << copy << " iz " << iz 
 				<< " imod " << imod << " ilayer " << ilayer
@@ -476,7 +518,7 @@ void MakeActsGeometry::buildActsSurfaces()
   const int argc = 14;
   char *arg[argc];
  
-  if(m_verbosity > 0)
+  if(Verbosity() > 0)
     std::cout << PHWHERE << "Magnetic field " << m_magField 
 	      << " with rescale " << m_magFieldRescale << std::endl;
   
@@ -513,7 +555,7 @@ void MakeActsGeometry::buildActsSurfaces()
 	std::string("/ACTS/sphenix-material.json");
     }
   
-  if(m_verbosity > 4)
+  if(Verbosity() > 4)
     {
       std::cout << "using material file : " << materialFile 
 		<< std::endl;
@@ -598,7 +640,7 @@ void MakeActsGeometry::unpackVolumes()
   /// vol is a TrackingVolume pointer  
   auto vol = m_tGeometry->highestTrackingVolume();
 
-  if(m_verbosity > 10 )
+  if(Verbosity() > 10 )
     std::cout << "Highest Tracking Volume is "
 	      << vol->volumeName() << std::endl;
 
@@ -615,7 +657,7 @@ void MakeActsGeometry::unpackVolumes()
   auto firstVolumes = volumeVector.at(0)->confinedVolumes();
   auto topVolumesVector = firstVolumes->arrayObjects();
   
-  if(m_verbosity > 10 )
+  if(Verbosity() > 10 )
     {
       for(long unsigned int i = 0; i<topVolumesVector.size(); i++)
 	{
@@ -627,7 +669,7 @@ void MakeActsGeometry::unpackVolumes()
 
   auto siliconVolumes = topVolumesVector.at(1)->confinedVolumes();
   auto siliconVolumesVector = siliconVolumes->arrayObjects();
-  if(m_verbosity > 10 )
+  if(Verbosity() > 10 )
     {
       for(long unsigned int i =0; i<siliconVolumes->arrayObjects().size(); i++){
 	std::cout << "SiliconVolumeName: " 
@@ -790,7 +832,7 @@ void MakeActsGeometry::makeMmMapPairs(TrackingVolumePtr &mmVolume)
 void MakeActsGeometry::makeInttMapPairs(TrackingVolumePtr &inttVolume)
 {
   
-  if(m_verbosity > 10)
+  if(Verbosity() > 10)
     {
       std::cout << "intt volume name: "  << inttVolume->volumeName()
 		<< std::endl;
@@ -840,7 +882,7 @@ void MakeActsGeometry::makeInttMapPairs(TrackingVolumePtr &inttVolume)
       std::pair<TrkrDefs::hitsetkey, Surface> tmp = make_pair(hitsetkey, surf);
       m_clusterSurfaceMapSilicon.insert(tmp);
 
-      if (m_verbosity > 10)
+      if (Verbosity() > 10)
       {
         // check it is in there
         unsigned int ladderPhi = InttDefs::getLadderPhiId(hitsetkey);
@@ -876,7 +918,7 @@ void MakeActsGeometry::makeInttMapPairs(TrackingVolumePtr &inttVolume)
 void MakeActsGeometry::makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume)
 {
   
-  if(m_verbosity > 10)
+  if(Verbosity() > 10)
     {
       std::cout << "MVTX Barrel name to step surfaces through is " 
 	      << mvtxVolume->volumeName() << std::endl;
@@ -922,7 +964,7 @@ void MakeActsGeometry::makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume)
 
       m_clusterSurfaceMapSilicon.insert(tmp);
 
-      if (m_verbosity > 10)
+      if (Verbosity() > 10)
       {
         unsigned int stave = MvtxDefs::getStaveId(hitsetkey);
         unsigned int chip = MvtxDefs::getChipId(hitsetkey);
@@ -957,104 +999,6 @@ void MakeActsGeometry::makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume)
     }
   }
 }
-
-Surface MakeActsGeometry::getTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, std::vector<double> &world)
-{
-  std::map<TrkrDefs::hitsetkey, std::vector<Surface>>::iterator mapIter;
-  mapIter = m_clusterSurfaceMapTpcEdit.find(hitsetkey);
-  
-  if(mapIter == m_clusterSurfaceMapTpcEdit.end())
-    {
-      std::cout << PHWHERE << "Error: hitsetkey not found in clusterSurfaceMap, hitsetkey = " << hitsetkey << std::endl;
-      return nullptr;
-    }
-
-  double world_phi = atan2(world[1], world[0]);
-  double world_z = world[2];
-  
-  std::vector<Surface> surf_vec = mapIter->second;
-  unsigned int surf_index = 999;
-  for(unsigned int i=0;i<surf_vec.size(); ++i)
-    {
-      Surface this_surf = surf_vec[i];
-  
-      auto vec3d = this_surf->center(m_geoCtxt);
-      std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
-      double surf_phi = atan2(surf_center[1], surf_center[0]);
-      double surf_z = surf_center[2];
-      if( (world_phi > surf_phi - m_surfStepPhi / 2.0 && world_phi < surf_phi + m_surfStepPhi / 2.0 ) &&
-	  (world_z > surf_z -m_surfStepZ / 2.0 && world_z < surf_z + m_surfStepZ / 2.0) )
-	{
-	  surf_index = i;	  
-	  break;
-	}
-    }
-  if(surf_index == 999)
-    {
-      std::cout << PHWHERE 
-		<< "Error: TPC surface index not defined, skipping cluster!" 
-		<< std::endl;
-      return nullptr;
-    }
- 
-  return surf_vec[surf_index];
-
-}
-
-Surface MakeActsGeometry::getMmSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, 
-						 std::vector<double> &world)
-{
-  std::map<TrkrDefs::hitsetkey, std::vector<Surface>>::iterator mapIter;
-  mapIter = m_clusterSurfaceMapMmEdit.find(hitsetkey);
-  
-  if(mapIter == m_clusterSurfaceMapMmEdit.end())
-    {
-      std::cout << PHWHERE 
-		<< "Error: hitsetkey not found in clusterSurfaceMap, hitsetkey = " 
-		<< hitsetkey << std::endl;
-      return nullptr;
-    }
-
-  double world_phi = atan2(world[1], world[0]);
-  double world_z = world[2];
-  
-  std::vector<Surface> surf_vec = mapIter->second;
-  unsigned int surf_index = 999;
-  for(unsigned int i=0;i<surf_vec.size(); ++i)
-    {
-      Surface this_surf = surf_vec[i];
-  
-      auto vec3d = this_surf->center(m_geoCtxt);
-      std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
-      double surf_phi = atan2(surf_center[1], surf_center[0]);
-      double surf_z = surf_center[2];
-
-      /// Check if the cluster is geometrically within the surface boundaries
-      /// The MMs surfaces span the entire length in z, so we don't divide
-      /// by 2 in the z direction since the center of the surface is z=0
-      bool withinPhi = world_phi >= surf_phi - m_surfStepPhi / 2.0
-	&& world_phi < surf_phi + m_surfStepPhi / 2.0;
-      bool withinZ = world_z > surf_z - m_surfStepZ 
-	&& world_z < surf_z + m_surfStepZ;
-      if( withinPhi && withinZ )
-	{
-	  surf_index = i;	  
-	  break;
-	}
-    }
-  if(surf_index == 999)
-    {
-      std::cout << PHWHERE 
-		<< "Error: Micromegas surface index not defined, skipping cluster!" 
-		<< std::endl;
-    
-      return nullptr;
-    }
- 
-  return surf_vec[surf_index];
-
-}
-
 
 TrkrDefs::hitsetkey MakeActsGeometry::getTpcHitSetKeyFromCoords(std::vector<double> &world)
 {
@@ -1115,7 +1059,7 @@ TrkrDefs::hitsetkey MakeActsGeometry::getTpcHitSetKeyFromCoords(std::vector<doub
     }
 
   TrkrDefs::hitsetkey hitset_key = TpcDefs::genHitSetKey(layer, readout_mod, side);
-  if(m_verbosity > 3)
+  if(Verbosity() > 3)
     if(layer == 30)
       std::cout << "   world = " << world[0] << "  " << world[1] 
 		<< "  " << world[2] << " phi_world " 
@@ -1166,7 +1110,7 @@ TrkrDefs::hitsetkey MakeActsGeometry::getMmHitSetKeyFromCoords(std::vector<doubl
   /// Get the surface key to find the surface from the map
   TrkrDefs::hitsetkey hitset_key = MicromegasDefs::genHitSetKey(layer, segtype, tile);
 
-  if(m_verbosity > 3)
+  if(Verbosity() > 3)
     std::cout << PHWHERE << "    micromegas layer " << layer 
 	      << " hitsetkey " << hitset_key<< std::endl;
   
@@ -1249,7 +1193,7 @@ void MakeActsGeometry::makeTGeoNodeMap(PHCompositeNode *topNode)
 
     if (node_str.compare(0, mvtx.length(), mvtx) == 0)  // is it in the MVTX?
     {
-      if (m_verbosity > 2) 
+      if (Verbosity() > 2) 
 	std::cout << " node " << node->GetName() << " is the MVTX wrapper" 
 		  << std::endl;
   
@@ -1259,7 +1203,7 @@ void MakeActsGeometry::makeTGeoNodeMap(PHCompositeNode *topNode)
       while(TObject *mvtx = mvtxObj())
 	{
 	  TGeoNode *mvtxNode = dynamic_cast<TGeoNode *>(mvtx);
-	  if(m_verbosity > 2)
+	  if(Verbosity() > 2)
 	    std::cout << "mvtx node name is " << mvtxNode->GetName() 
 		      << std::endl;
 	  std::string mvtxav1("av_1");
@@ -1276,7 +1220,7 @@ void MakeActsGeometry::makeTGeoNodeMap(PHCompositeNode *topNode)
       if (node_str.compare(0, intt_ext.length(), intt_ext) == 0)
         continue;
 
-      if (m_verbosity > 2) 
+      if (Verbosity() > 2) 
 	std::cout << " node " << node->GetName() << " is in the INTT" 
 		  << std::endl;
       getInttKeyFromNode(node);
@@ -1285,13 +1229,13 @@ void MakeActsGeometry::makeTGeoNodeMap(PHCompositeNode *topNode)
     /// within TGeoVolume, we don't need a mapping to the TGeoNode
     else if (node_str.compare(0, tpc.length(), tpc) == 0)  // is it in the TPC?
       {
-	if(m_verbosity > 2)
+	if(Verbosity() > 2)
 	  std::cout << " node " << node->GetName() 
 		    << " is in the TPC " << std::endl;
       }
     else if (node_str.compare(0, micromegas.length(), micromegas) == 0)  // is it in the Micromegas?
       {
-	if(m_verbosity > 2)
+	if(Verbosity() > 2)
 	  std::cout << " node " << node->GetName() 
 		    << " is in the MMs " << std::endl;
       }
@@ -1377,7 +1321,7 @@ void MakeActsGeometry::getInttKeyFromNode(TGeoNode *gnode)
 					         node_key, sensor_node);
   m_clusterNodeMap.insert(tmp);
 
-  if (m_verbosity > 1)
+  if (Verbosity() > 1)
     std::cout << " INTT layer " << layer << " ladder_phi " << ladder_phi 
 	      << " itype " << itype << " zposneg " << zposneg 
 	      << " ladder_z " << ladder_z << " name " 
@@ -1444,7 +1388,7 @@ void MakeActsGeometry::getMvtxKeyFromNode(TGeoNode *gnode)
     std::string dstr = module_node->GetDaughter(i)->GetName();
     if (dstr.compare(0, mvtx_chip.length(), mvtx_chip) == 0)
     {
-      if (m_verbosity > 3)
+      if (Verbosity() > 3)
         std::cout << "Found MVTX layer " << layer << " stave " << stave 
 		  << " chip  " << i << " with node name " 
 		  << module_node->GetDaughter(i)->GetName() << std::endl;
@@ -1459,7 +1403,7 @@ void MakeActsGeometry::getMvtxKeyFromNode(TGeoNode *gnode)
 						       node_key, sensor_node);
       m_clusterNodeMap.insert(tmp);
 
-      if (m_verbosity > 3)
+      if (Verbosity() > 3)
         std::cout << " MVTX layer " << layer << " stave " << stave 
 		  << " chip " << chip << " name " 
 		  << sensor_node->GetName() << std::endl;
@@ -1577,6 +1521,49 @@ void MakeActsGeometry::setPlanarSurfaceDivisions()
 
 int MakeActsGeometry::createNodes(PHCompositeNode *topNode)
 {
+  PHNodeIterator iter(topNode);
+
+  /// Get the DST Node
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  
+  /// Check that it is there
+  if (!dstNode)
+    {
+      std::cerr << "DST Node missing, quitting" << std::endl;
+      throw std::runtime_error("failed to find DST node in PHActsSourceLinks::createNodes");
+    }
+  
+  /// Get the tracking subnode
+  PHCompositeNode *svtxNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SVTX"));
+  
+  /// Check that it is there
+  if (!svtxNode)
+    {
+      svtxNode = new PHCompositeNode("SVTX");
+      dstNode->addNode(svtxNode);
+    }
+
+  m_surfMaps = findNode::getClass<ActsSurfaceMaps>(topNode,
+						   "ActsSurfaceMaps");
+  if(!m_surfMaps)
+    {
+      m_surfMaps = new ActsSurfaceMaps();
+      PHDataNode<ActsSurfaceMaps> *node
+	= new PHDataNode<ActsSurfaceMaps>(m_surfMaps, "ActsSurfaceMaps");
+      svtxNode->addNode(node);
+
+    }
+
+  m_actsGeometry = findNode::getClass<ActsTrackingGeometry>(topNode,
+							    "ActsTrackingGeometry");
+  if(!m_actsGeometry)
+    {
+      m_actsGeometry = new ActsTrackingGeometry();
+      PHDataNode<ActsTrackingGeometry> *tGeoNode 
+	= new PHDataNode<ActsTrackingGeometry>(m_actsGeometry, "ActsTrackingGeometry");
+      svtxNode->addNode(tGeoNode);
+    }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -73,17 +73,6 @@
 
 MakeActsGeometry::MakeActsGeometry(const std::string &name)
 : SubsysReco(name)
-  , m_geomContainerMvtx(nullptr)
-  , m_geomContainerIntt(nullptr)
-  , m_geomContainerTpc(nullptr)
-  , m_geoManager(nullptr)
-  , m_minSurfZ(0.0)
-  , m_maxSurfZ(105.5)
-  , m_nSurfZ(1)
-  , m_nSurfPhi(12)
-  , m_magField("1.4")
-  , m_magFieldRescale(-1.0)
-  , m_buildMMs(false)
 {
   setPlanarSurfaceDivisions();
   nprint_tpc = 0;

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -142,7 +142,7 @@ class MakeActsGeometry : public SubsysReco
 
   /// Subdetector geometry containers for getting layer information
   PHG4CylinderGeomContainer* m_geomContainerMvtx = nullptr;
-  PHG4CylinderGeomContainer* m_geomContainerInt = nullptrt;
+  PHG4CylinderGeomContainer* m_geomContainerIntt = nullptr;
   PHG4CylinderCellGeomContainer* m_geomContainerTpc = nullptr;
 
   TGeoManager* m_geoManager = nullptr;

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -141,11 +141,11 @@ class MakeActsGeometry : public SubsysReco
   void unpackVolumes();
 
   /// Subdetector geometry containers for getting layer information
-  PHG4CylinderGeomContainer* m_geomContainerMvtx;  
-  PHG4CylinderGeomContainer* m_geomContainerIntt;
-  PHG4CylinderCellGeomContainer* m_geomContainerTpc;
+  PHG4CylinderGeomContainer* m_geomContainerMvtx = nullptr;
+  PHG4CylinderGeomContainer* m_geomContainerInt = nullptrt;
+  PHG4CylinderCellGeomContainer* m_geomContainerTpc = nullptr;
 
-  TGeoManager* m_geoManager; 
+  TGeoManager* m_geoManager = nullptr;
 
   /// Acts Context decorators, which may contain e.g. calibration information
   std::vector<std::shared_ptr<ActsExamples::IContextDecorator> > 
@@ -163,10 +163,10 @@ class MakeActsGeometry : public SubsysReco
   const unsigned int m_nTpcSides = 2;
 
   /// TPC Acts::Surface subdivisions
-  double m_minSurfZ;
-  double m_maxSurfZ;
-  unsigned int m_nSurfZ;
-  unsigned int m_nSurfPhi;
+  double m_minSurfZ = 0.;
+  double m_maxSurfZ = 105.5;
+  unsigned int m_nSurfZ = 1;
+  unsigned int m_nSurfPhi = 12;
   double m_surfStepPhi;
   double m_surfStepZ;
   double m_moduleStepPhi;
@@ -205,17 +205,17 @@ class MakeActsGeometry : public SubsysReco
   Acts::MagneticFieldContext m_magFieldContext;
 
   /// Structs to put on the node tree which carry around ActsGeom info
-  ActsTrackingGeometry *m_actsGeometry;
-  ActsSurfaceMaps *m_surfMaps;
+  ActsTrackingGeometry *m_actsGeometry = nullptr;
+  ActsSurfaceMaps *m_surfMaps = nullptr;
 
   /// Verbosity value handed from PHActsSourceLinks
-  int m_verbosity;
+  int m_verbosity = 0;
 
   /// Magnetic field components to set Acts magnetic field
-  std::string m_magField;
-  double m_magFieldRescale;
+  std::string m_magField ="1.4" ;
+  double m_magFieldRescale = -1.;
 
-  bool m_buildMMs;
+  bool m_buildMMs = false;
 
 };
 

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -83,8 +83,8 @@ class MakeActsGeometry : public SubsysReco
   void setMagFieldRescale(double magFieldRescale)
     {m_magFieldRescale = magFieldRescale;}
 
-  int getSurfStepPhi() {return m_surfStepPhi;}
-  int getSurfStepZ() {return m_surfStepZ;}
+  double getSurfStepPhi() {return m_surfStepPhi;}
+  double getSurfStepZ() {return m_surfStepZ;}
 
  private:
   /// Main function to build all acts geometry for use in the fitting modules

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -11,6 +11,9 @@
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
 
+#include "ActsTrackingGeometry.h"
+#include "ActsSurfaceMaps.h"
+
 #include <Acts/Utilities/Definitions.hpp>
 #include <Acts/Utilities/BinnedArray.hpp>                      
 #include <Acts/Utilities/Logger.hpp>                           
@@ -35,12 +38,14 @@ class TGeoManager;
 class TGeoNode;
 class TGeoVolume;
 
-namespace ActsExamples {
+namespace ActsExamples 
+{
   class IBaseDetector;
   class IContextDecorator;
 }
 
-namespace Acts {
+namespace Acts 
+{
   class Surface;
 }
 
@@ -55,7 +60,7 @@ using TrackingVolumePtr = std::shared_ptr<const Acts::TrackingVolume>;
  * This class puts several nodes on the node tree which relate Acts::Surfaces
  * to sPHENIX TGeo objects, for use in building Acts SourceLinks.
  */
-class MakeActsGeometry
+class MakeActsGeometry : public SubsysReco
 {
  public:
 
@@ -65,50 +70,26 @@ class MakeActsGeometry
   //! Destructor
   ~MakeActsGeometry();
 
-  /// Main function to build all acts geometry for use in the fitting modules
-  int buildAllGeometry(PHCompositeNode *topNode);
- 
-  void setVerbosity(int verbosity)
-    { m_verbosity = verbosity; }
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
 
-  std::map<TrkrDefs::hitsetkey,Surface> getSurfaceMapSilicon()
-    { return m_clusterSurfaceMapSilicon; }
-  
-  std::map<TrkrDefs::hitsetkey, std::vector<Surface>> getSurfaceMapTpc()
-    { return m_clusterSurfaceMapTpcEdit; }
-  
-  std::map<TrkrDefs::hitsetkey, TGeoNode*> getTGeoNodeMap()
-    { return m_clusterNodeMap; }
-   
   std::vector<std::shared_ptr<ActsExamples::IContextDecorator>> getContextDecorators()
     { return m_contextDecorators; }
-  
-  /// Getters for acts geometry that is needed by fitter functions
-  TrackingGeometry getTGeometry(){ return m_tGeometry; }
-  ActsExamples::Options::BFieldVariant getMagField()
-    { return m_magneticField; }
-  Acts::MagneticFieldContext getMagFieldContext() 
-    { return m_magFieldContext; }
-  Acts::CalibrationContext getCalibContext() 
-    { return m_calibContext; }
-  Acts::GeometryContext getGeoContext() 
-    { return m_geoCtxt; }
-  
-  /// Gets tpc surface from a cluster coordinate and hitsetkey. Necessary
-  /// since there are many tpc surfaces per read out module
-  Surface getTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, 
-    std::vector<double> &world);
-
-  Surface getMmSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, 
-    std::vector<double> &world);
 
   void setMagField(const std::string &magField)
     {m_magField = magField;}
   void setMagFieldRescale(double magFieldRescale)
     {m_magFieldRescale = magFieldRescale;}
 
+  int getSurfStepPhi() {return m_surfStepPhi;}
+  int getSurfStepZ() {return m_surfStepZ;}
+
  private:
-  
+  /// Main function to build all acts geometry for use in the fitting modules
+  int buildAllGeometry(PHCompositeNode *topNode);
+ 
   //! Get all the nodes
   int getNodes(PHCompositeNode*);
   
@@ -222,6 +203,10 @@ class MakeActsGeometry
   Acts::GeometryContext  m_geoCtxt;  
   Acts::CalibrationContext m_calibContext;
   Acts::MagneticFieldContext m_magFieldContext;
+
+  /// Structs to put on the node tree which carry around ActsGeom info
+  ActsTrackingGeometry *m_actsGeometry;
+  ActsSurfaceMaps *m_surfMaps;
 
   /// Verbosity value handed from PHActsSourceLinks
   int m_verbosity;

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -25,6 +25,7 @@ pkginclude_HEADERS = \
   ActsTransformations.h \
   ActsTrack.h \
   ActsTrackingGeometry.h \
+  ActsSurfaceMaps.h \
   ActsEvaluator.h \
   AssocInfoContainer.h \
   CellularAutomaton.h \

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -52,6 +52,8 @@
 
 PHActsSourceLinks::PHActsSourceLinks(const std::string &name)
   : SubsysReco(name)
+  , m_hitIdClusKey(nullptr)
+  , m_sourceLinks(nullptr)
 {
   Verbosity(0);
 }

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -52,16 +52,6 @@
 
 PHActsSourceLinks::PHActsSourceLinks(const std::string &name)
   : SubsysReco(name)
-  , m_useVertexMeasurement(false)
-  , m_clusterMap(nullptr)
-  , m_hitIdClusKey(nullptr)
-  , m_sourceLinks(nullptr)
-  , m_magField("1.4")
-  , m_magFieldRescale(-1.0)
-  , m_geomContainerMvtx(nullptr)
-  , m_geomContainerIntt(nullptr)
-  , m_geomContainerTpc(nullptr)
-  , m_tGeometry(nullptr)
 {
   Verbosity(0);
 }

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -1228,8 +1228,8 @@ Surface PHActsSourceLinks::getMmSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey,
 
   /// Get some geometry values from the geom builder for parsing surfaces
   MakeActsGeometry *geom = new MakeActsGeometry();
-  int surfStepPhi = geom->getSurfStepPhi();
-  int surfStepZ = geom->getSurfStepZ();
+  double surfStepPhi = geom->getSurfStepPhi();
+  double surfStepZ = geom->getSurfStepZ();
 
   for(unsigned int i=0;i<surf_vec.size(); ++i)
     {
@@ -1287,8 +1287,8 @@ Surface PHActsSourceLinks::getTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey
   unsigned int surf_index = 999;
 
   MakeActsGeometry *geom = new MakeActsGeometry();
-  int surfStepPhi = geom->getSurfStepPhi();
-  int surfStepZ = geom->getSurfStepZ();
+  double surfStepPhi = geom->getSurfStepPhi();
+  double surfStepZ = geom->getSurfStepZ();
 
   for(unsigned int i=0;i<surf_vec.size(); ++i)
     {
@@ -1298,6 +1298,7 @@ Surface PHActsSourceLinks::getTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey
       std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
       double surf_phi = atan2(surf_center[1], surf_center[0]);
       double surf_z = surf_center[2];
+ 
       if( (world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 ) &&
 	  (world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0) )
 	{

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -1,6 +1,8 @@
-
 #ifndef TRACKRECO_PHACTSSOURCELINKS_H
 #define TRACKRECO_PHACTSSOURCELINKS_H
+
+#include "ActsTrackingGeometry.h"
+#include "ActsSurfaceMaps.h"
 
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
@@ -24,8 +26,6 @@
 #include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
 #include <ActsExamples/Plugins/BField/BFieldOptions.hpp>
 
-#include "ActsTrackingGeometry.h"
-#include "ActsSurfaceMaps.h"
 
 class PHCompositeNode;
 class TrkrClusterContainer;
@@ -159,10 +159,10 @@ class PHActsSourceLinks : public SubsysReco
 
   /// Map relating arbitrary hitid to TrkrDef::cluskey for SourceLink, to be put
   /// on node tree by this module
-  std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey = nullptr;
+  std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey;
 
   /// Map for source hitid:sourcelink, to be put on node tree by this module
-  std::map<unsigned int, SourceLink> *m_sourceLinks = nullptr;
+  std::map<unsigned int, SourceLink> *m_sourceLinks;
 
   /// Magnetic field components to set Acts magnetic field
   std::string m_magField = "1.4";

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -152,29 +152,29 @@ class PHActsSourceLinks : public SubsysReco
    * Member variables
    */
 
-  bool m_useVertexMeasurement;
+  bool m_useVertexMeasurement = false;
 
   /// SvtxCluster node
-  TrkrClusterContainer *m_clusterMap;
+  TrkrClusterContainer *m_clusterMap = nullptr;
 
   /// Map relating arbitrary hitid to TrkrDef::cluskey for SourceLink, to be put
   /// on node tree by this module
-  std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey;
+  std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey = nullptr;
 
   /// Map for source hitid:sourcelink, to be put on node tree by this module
-  std::map<unsigned int, SourceLink> *m_sourceLinks;
+  std::map<unsigned int, SourceLink> *m_sourceLinks = nullptr;
 
   /// Magnetic field components to set Acts magnetic field
-  std::string m_magField;
-  double m_magFieldRescale;
+  std::string m_magField = "1.4";
+  double m_magFieldRescale = -1.;
 
   /// Tracking geometry objects
-  PHG4CylinderGeomContainer *m_geomContainerMvtx;
-  PHG4CylinderGeomContainer *m_geomContainerIntt;
-  PHG4CylinderCellGeomContainer *m_geomContainerTpc;
+  PHG4CylinderGeomContainer *m_geomContainerMvtx = nullptr;
+  PHG4CylinderGeomContainer *m_geomContainerIntt = nullptr;
+  PHG4CylinderCellGeomContainer *m_geomContainerTpc = nullptr;
 
-  ActsTrackingGeometry *m_tGeometry;
-  ActsSurfaceMaps *m_surfMaps;
+  ActsTrackingGeometry *m_tGeometry = nullptr;
+  ActsSurfaceMaps *m_surfMaps = nullptr;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -25,6 +25,7 @@
 #include <ActsExamples/Plugins/BField/BFieldOptions.hpp>
 
 #include "ActsTrackingGeometry.h"
+#include "ActsSurfaceMaps.h"
 
 class PHCompositeNode;
 class TrkrClusterContainer;
@@ -32,7 +33,6 @@ class TrkrCluster;
 class TGeoNode;
 class PHG4CylinderGeomContainer;
 class PHG4CylinderCellGeomContainer;
-class MakeActsGeometry;
 
 
 namespace ActsExamples
@@ -139,6 +139,15 @@ class PHActsSourceLinks : public SubsysReco
   void addVerticesAsSourceLinks(PHCompositeNode *topNode,
 				unsigned int &hitId);
 
+  /// Gets tpc surface from a cluster coordinate and hitsetkey. Necessary
+  /// since there are many tpc surfaces per read out module
+  Surface getTpcSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, 
+    std::vector<double> &world);
+
+  Surface getMmSurfaceFromCoords(TrkrDefs::hitsetkey hitsetkey, 
+    std::vector<double> &world);
+
+
   /**
    * Member variables
    */
@@ -147,9 +156,6 @@ class PHActsSourceLinks : public SubsysReco
 
   /// SvtxCluster node
   TrkrClusterContainer *m_clusterMap;
-
-  /// Geometry object to create all acts geometry
-  MakeActsGeometry *m_actsGeometry;
 
   /// Map relating arbitrary hitid to TrkrDef::cluskey for SourceLink, to be put
   /// on node tree by this module
@@ -168,7 +174,7 @@ class PHActsSourceLinks : public SubsysReco
   PHG4CylinderCellGeomContainer *m_geomContainerTpc;
 
   ActsTrackingGeometry *m_tGeometry;
-
+  ActsSurfaceMaps *m_surfMaps;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -6,7 +6,6 @@
  */
 
 #include "PHActsTrkFitter.h"
-#include "MakeActsGeometry.h"
 #include "ActsTrack.h"
 #include "ActsTransformations.h"
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -196,7 +196,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     ActsExamples::TrackParameters trackSeed = track.getTrackParams();
 
     /// If using directed navigation, collect surface list to navigate
-    SurfaceVec surfaces;
+    SurfacePtrVec surfaces;
     if(m_fitSiliconMMs)
       {	
 	sourceLinks = getSurfaceVector(sourceLinks, surfaces);
@@ -369,7 +369,7 @@ ActsExamples::TrkrClusterFittingAlgorithm::FitterResult PHActsTrkFitter::fitTrac
 	  const ActsExamples::TrackParameters& seed,
 	  const Acts::KalmanFitterOptions<Acts::VoidOutlierFinder>& 
 	         kfOptions, 
-	  const SurfaceVec& surfSequence)
+	  const SurfacePtrVec& surfSequence)
 {
   if(m_fitSiliconMMs) 
     return m_fitCfg.dFit(sourceLinks, seed, kfOptions, surfSequence);  
@@ -378,7 +378,7 @@ ActsExamples::TrkrClusterFittingAlgorithm::FitterResult PHActsTrkFitter::fitTrac
 }
 
 SourceLinkVec PHActsTrkFitter::getSurfaceVector(SourceLinkVec sourceLinks,
-						SurfaceVec& surfaces)
+						SurfacePtrVec& surfaces)
 {
    SourceLinkVec siliconMMSls;
 
@@ -411,7 +411,7 @@ SourceLinkVec PHActsTrkFitter::getSurfaceVector(SourceLinkVec sourceLinks,
 }
 
 
-void PHActsTrkFitter::checkSurfaceVec(SurfaceVec &surfaces)
+void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec &surfaces)
 {
   for(int i = 0; i < surfaces.size() - 1; i++)
     {

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -47,7 +47,7 @@ using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
                                       Acts::BoundIndices,
                                       Acts::eBoundLoc0,
                                       Acts::eBoundLoc1>;
-using SurfaceVec = std::vector<const Acts::Surface*>;
+using SurfacePtrVec = std::vector<const Acts::Surface*>;
 using SourceLinkVec = std::vector<SourceLink>;
 
 class PHActsTrkFitter : public PHTrackFitting
@@ -99,13 +99,13 @@ class PHActsTrkFitter : public PHTrackFitting
 		     const ActsExamples::TrackParameters& seed,
 		     const Acts::KalmanFitterOptions<Acts::VoidOutlierFinder>& 
 		           kfOptions,
-		     const SurfaceVec& surfSequence);
+		     const SurfacePtrVec& surfSequence);
 
   /// Functions to get list of sorted surfaces for direct navigation, if
   /// applicable
   SourceLinkVec getSurfaceVector(SourceLinkVec sourceLinks, 
-				 SurfaceVec& surfaces);
-  void checkSurfaceVec(SurfaceVec& surfaces);
+				 SurfacePtrVec& surfaces);
+  void checkSurfaceVec(SurfacePtrVec& surfaces);
 
   /// Map of Acts fit results and track key to be placed on node tree
   std::map<const unsigned int, Trajectory> 


### PR DESCRIPTION
This PR makes the `MakeActsGeometry` module a standalone `SubsysReco` subclass so that it can be called on its own in the G4_Tracking macro. This way if we need to build the geometry before any other part of the reconstruction chain, it can be done.

There is a corresponding [PR](https://github.com/sPHENIX-Collaboration/macros/pull/313/) in the macros repository that should be merged with this PR to reflect the change to the acts tracking chain.