### PR TITLE
Fix gcc 8.3

### DIFF
--- a/offline/database/pdbcal/pg/configure.ac
+++ b/offline/database/pdbcal/pg/configure.ac
@@ -16,7 +16,7 @@ dnl odbc++ has issues
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations -Wno-overloaded-virtual"
  ;;
  g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations"
  ;;
 esac
 

--- a/offline/framework/frog/configure.ac
+++ b/offline/framework/frog/configure.ac
@@ -15,7 +15,7 @@ dnl odbc++ uses auto_ptr
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations"
  ;;
  g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wno-deprecated-declarations"
  ;;
 esac
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
@@ -497,9 +497,10 @@ void PHG4TpcDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode)
 
   //======================================================  
   if(Verbosity() > 2) 
+  {
     cout << "From PHG4TpcDigitizer: hitsetcontainer dump at end before cleaning:" << endl;
-
-    std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> delete_hitkey_list;
+  }
+  std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> delete_hitkey_list;
 
   // Clean up undigitized hits - we want all hitsets for the Tpc
   TrkrHitSetContainer::ConstRange hitset_range_now = trkrhitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
@@ -13,10 +13,7 @@
 #include <utility>                 // for pair, make_pair
 #include <vector>
 
-// rootcint barfs with this header so we need to hide it
-#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
-#endif
 
 class PHCompositeNode;
 
@@ -73,10 +70,8 @@ class PHG4TpcDigitizer : public SubsysReco
   std::map<int, unsigned int> _max_adc;
   std::map<int, float> _energy_scale;
 
-#if !defined(__CINT__) || defined(__CLING__)
   //! random generator that conform with sPHENIX standard
   gsl_rng *RandomGenerator;
-#endif
 };
 
 #endif

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
@@ -11,10 +11,7 @@
 #ifndef G4TPC_PHG4TPCDISTORTION_H
 #define G4TPC_PHG4TPCDISTORTION_H
 
-// rootcint barfs with this header so we need to hide it
-#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
-#endif
 
 /*!
  * \brief PHG4TpcDistortion is a virtual interface to apply distortion to a primary ionization in Tpc
@@ -58,10 +55,8 @@ class PHG4TpcDistortion
   //! The verbosity level. 0 means not verbose at all.
   int verbosity;
 
-#if !defined(__CINT__) || defined(__CLING__)
   //! random generator that conform with sPHENIX standard
   gsl_rng *RandomGenerator;
-#endif
 };
 
 #endif /* G4TPC_PHG4TPCDISTORTION_H */

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
@@ -9,10 +9,7 @@
 
 #include <phparameter/PHParameterInterface.h>
 
-// rootcint barfs with this header so we need to hide it
-#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
-#endif
 
 #include <string>                              // for string
 
@@ -70,9 +67,7 @@ class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
   double min_time;
   double max_time;
 
-#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *RandomGenerator;
-#endif
 };
 
 #endif  // G4TPC_PHG4TPCELECTRONDRIFT_H

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
@@ -24,17 +24,10 @@ class PHG4TpcPadPlane : public SubsysReco, public PHParameterInterface
 
   virtual ~PHG4TpcPadPlane() {}
 
-#if !defined(__CINT__) || defined(__CLING__)
   int process_event(PHCompositeNode *) final
   {
     return 0;
   }
-#else
-  int process_event(PHCompositeNode *)
-  {
-    return 0;
-  }
-#endif
   int InitRun(PHCompositeNode *topNode);
   virtual int CreateReadoutGeometry(PHCompositeNode *topNode, PHG4CylinderCellGeomContainer *seggeo) { return 0; }
   virtual void UpdateInternalParameters() { return; }

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
@@ -5,12 +5,9 @@
 
 #include <g4main/PHG4HitContainer.h>
 
-// rootcint barfs with this header so we need to hide it
-#if !defined(__CINT__) || defined(__CLING__)
 #include <gsl/gsl_rng.h>
-#include <array>
-#endif
 
+#include <array>
 #include <climits>
 #include <cmath>
 #include <string>                     // for string
@@ -47,7 +44,6 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   void populate_zigzag_phibins(const unsigned int layernum, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share);
   void populate_zbins(const double z, const std::array<double,2>& cloud_sig_zz, std::vector<int> &adc_zbin, std::vector<double> &adc_zbin_share);
 
-#if !defined(__CINT__) || defined(__CLING__)
   std::string seggeonodename;
 
   PHG4CylinderCellGeomContainer *GeomContainer = nullptr;
@@ -84,8 +80,6 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
 
   double averageGEMGain = NAN;
 
-#endif
-
   std::vector<int> adc_zbin;
   std::vector<int> pad_phibin;
   std::vector<double> pad_phibin_share;
@@ -93,9 +87,8 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
 
   // return random distribution of number of electrons after amplification of GEM for each initial ionizing electron
   double getSingleEGEMAmplification();
-#if !defined(__CINT__) || defined(__CLING__)
   gsl_rng *RandomGenerator;
-#endif
+
 };
 
 #endif


### PR DESCRIPTION
This PR should enable us to use ccache. The gcc 8.3 setup scripts sets CXX and CC to the respective compiler. This overrules ccache which is not called. Building without those variables set gave a few more compiler warnings which this fixes.
Also ifdef CINT removed from trackreco includes