### PR TITLE
Fermi motion afterburner

### DIFF
--- a/generators/FermiMotionAfterburner/FermiMotion.cc
+++ b/generators/FermiMotionAfterburner/FermiMotion.cc
@@ -1,0 +1,151 @@
+// Discribtion:Thie code is used to add Fermimotion p_F to spectator neutrons
+//Modified from the flowafterburner code, thx!
+//
+//AuthorList:
+// initial code 2020
+
+//include the header file here
+#include "FermiMotion.h"
+#include <gsl/gsl_errno.h>
+#include <gsl/gsl_math.h>
+#include <gsl/gsl_roots.h>
+
+
+#include <HepMC/GenEvent.h>
+#include <HepMC/GenParticle.h>  // for GenParticle
+#include <HepMC/GenRanges.h>
+#include <HepMC/GenVertex.h>      // for GenVertex, GenVertex::part...
+#include <HepMC/HeavyIon.h>       // for HeavyIon
+#include <HepMC/IteratorRange.h>  // for children, descendants
+#include <HepMC/SimpleVector.h>   // for FourVector
+
+#include <CLHEP/Random/RandFlat.h>
+#include <CLHEP/Vector/LorentzVector.h>
+
+#include <cmath>
+#include <map>  // for map
+#include <iostream>
+#include <iterator>                           // for operator!=, reverse_ite...
+#include <set>                                // for set, _Rb_tree_const_ite...
+#include <string>
+#include <utility>
+
+
+//____________________________________________________________________________..
+
+
+using namespace HepMC;
+namespace CLHEP
+{
+class HepRandomEngine;
+}
+namespace HepMC { class GenEvent; }
+//this method is use to find out the spectator neutron loss prob
+//using the parameterization in the PHENIX Glauber
+//Monte Carlo code written by Klaus Reygers to model 
+//the loss of forward
+//neutrons into the ZDC due to larger fragments
+
+//Assume Au for now
+//make sure b is in fm
+double ploss(double b){
+  // para
+  double p0 = 0.3305;
+  double p1 = 0.0127;
+  double p2 = 17.;
+  double p3 = 2.;
+  double ploss = p0+b*p1+exp((b-p2)/p3);
+  
+  return ploss;
+}
+
+//this method is use to generate and random p_F
+//along a random direction and add it to the momentum
+//assume Au for now
+CLHEP::HepLorentzVector pwithpF(CLHEP::HepLorentzVector p,CLHEP::HepRandomEngine *engine, int id){
+  //id should be either 2112 or 2212
+  if( ! ( (id == 2112)||(id==2212) ) ){
+    std::cout<<"wrong pid"<<std::endl;
+    return p;
+  }
+  //find pF max using Thomas-Fermi model, assume using Au.
+  float pFmax=0.28315;
+  if(id==2212) pFmax=0.23276;
+  //now generate the random p assuming probability is propotional to p^2dp
+  //CLHEP::RandGeneral seems to be a better way to do it
+  float pF=pFmax*pow(CLHEP::RandFlat::shoot(engine),1.0/3.0);
+  float cotheta=(CLHEP::RandFlat::shoot(engine)-0.5) * 2;
+  float phi=CLHEP::RandFlat::shoot(engine) * 2 * M_PI;
+  float pFx=pF * sqrt(1-cotheta * cotheta) * cos(phi);
+  float pFy=pF * sqrt(1-cotheta * cotheta) * sin(phi);
+  float pFz=pF * cotheta;
+  //now add the pF to p
+  float px=p.px()+pFx;
+  float py=p.py()+pFy;
+  float pz=p.pz()+pFz;
+  //calculate the total energy
+  float const nrm=0.938;
+  float e=sqrt(px*px+py*py+pz*pz + nrm*nrm);
+
+  CLHEP::HepLorentzVector pwithpF(px,py,pz,e);
+  return pwithpF;
+}
+
+
+int FermiMotion (HepMC::GenEvent *event, CLHEP::HepRandomEngine *engine){
+  //find ploss
+  //std::cout<<"getting b"<<std::endl;
+  HepMC::HeavyIon *hi = event->heavy_ion();
+  double b = hi->impact_parameter();
+  double pnl=ploss(b);
+  //now loop over all particles and find spectators
+
+ std::cout<<"looping over particles"<<std::endl;
+ for ( GenEvent::particle_const_iterator p = event->particles_begin(),prev=event->particles_end();  p != event->particles_end(); prev=p, ++p ){
+    int id=(*p)->pdg_id();
+    bool havedelete=false;
+    //if not neutron or proton, skip
+    if( ! ( (id == 2112)||(id==2212) ) ) continue;
+
+    //spectator neutron&protons should have px==0&&py==0
+    HepMC::GenParticle *n = (*p);
+    float p_x=n->momentum().px();
+    float p_y=n->momentum().py();
+    if(!(p_x==0&&p_y==0 )) continue;
+  
+    //remove neutrons bound to large fragment    
+    if(id==2112){
+
+      if(pnl>CLHEP::RandFlat::shoot(engine)){
+	//remove particle here
+	
+	((*p)->production_vertex())->remove_particle(*p);
+	
+	havedelete=true;
+      }
+      
+    }
+    
+    //add pF to the remaining
+    
+   CLHEP::HepLorentzVector p0(n->momentum().px(),n->momentum().py(),n->momentum().pz(),n->momentum().e());
+   CLHEP::HepLorentzVector newp= pwithpF( p0, engine, id);
+   (*p)->set_momentum(newp );   
+   //remember the index go down one after remove
+   
+   if(havedelete){
+     if(prev != event->particles_end()) p=prev;
+   } 
+ }
+ 
+ 
+ return 0;
+}
+
+
+
+
+
+
+
+

--- a/generators/FermiMotionAfterburner/FermiMotion.cc
+++ b/generators/FermiMotionAfterburner/FermiMotion.cc
@@ -6,38 +6,25 @@
 
 //include the header file here
 #include "FermiMotion.h"
-#include <gsl/gsl_errno.h>
-#include <gsl/gsl_math.h>
-#include <gsl/gsl_roots.h>
-#include <gsl/gsl_randist.h>
+
 #include <gsl/gsl_rng.h> 
 
 #include <HepMC/GenEvent.h>
 #include <HepMC/GenParticle.h>  // for GenParticle
-#include <HepMC/GenRanges.h>
 #include <HepMC/GenVertex.h>      // for GenVertex, GenVertex::part...
 #include <HepMC/HeavyIon.h>       // for HeavyIon
-#include <HepMC/IteratorRange.h>  // for children, descendants
 #include <HepMC/SimpleVector.h>   // for FourVector
 
 
 #include <CLHEP/Vector/LorentzVector.h>
 
 #include <cmath>
-#include <map>  // for map
 #include <iostream>
-#include <iterator>                           // for operator!=, reverse_ite...
-#include <set>                                // for set, _Rb_tree_const_ite...
-#include <string>
-#include <utility>
 
 
 //____________________________________________________________________________..
 
 
-using namespace HepMC;
-
-namespace HepMC { class GenEvent; }
 //this method is use to find out the spectator neutron loss prob
 //using the parameterization in the PHENIX Glauber
 //Monte Carlo code written by Klaus Reygers to model 
@@ -99,7 +86,7 @@ int FermiMotion (HepMC::GenEvent *event, gsl_rng *RandomGenerator){
   //now loop over all particles and find spectator neutrons
 
  std::cout<<"looping over particles"<<std::endl;
- for ( GenEvent::particle_const_iterator p = event->particles_begin(),prev=event->particles_end();  p != event->particles_end(); prev=p, ++p ){
+ for ( HepMC::GenEvent::particle_const_iterator p = event->particles_begin(),prev=event->particles_end();  p != event->particles_end(); prev=p, ++p ){
     int id=(*p)->pdg_id();
     bool havedelete=false;
     //if not neutron, skip
@@ -139,15 +126,6 @@ int FermiMotion (HepMC::GenEvent *event, gsl_rng *RandomGenerator){
      if(prev != event->particles_end()) p=prev;
    } 
  }
- 
 
   return 0;
 }
-
-
-
-
-
-
-
-

--- a/generators/FermiMotionAfterburner/FermiMotion.cc
+++ b/generators/FermiMotionAfterburner/FermiMotion.cc
@@ -7,125 +7,123 @@
 //include the header file here
 #include "FermiMotion.h"
 
-#include <gsl/gsl_rng.h> 
+#include <gsl/gsl_rng.h>
 
 #include <HepMC/GenEvent.h>
-#include <HepMC/GenParticle.h>  // for GenParticle
-#include <HepMC/GenVertex.h>      // for GenVertex, GenVertex::part...
-#include <HepMC/HeavyIon.h>       // for HeavyIon
-#include <HepMC/SimpleVector.h>   // for FourVector
-
+#include <HepMC/GenParticle.h>   // for GenParticle
+#include <HepMC/GenVertex.h>     // for GenVertex, GenVertex::part...
+#include <HepMC/HeavyIon.h>      // for HeavyIon
+#include <HepMC/SimpleVector.h>  // for FourVector
 
 #include <CLHEP/Vector/LorentzVector.h>
 
 #include <cmath>
 #include <iostream>
 
-
 //____________________________________________________________________________..
-
 
 //this method is use to find out the spectator neutron loss prob
 //using the parameterization in the PHENIX Glauber
-//Monte Carlo code written by Klaus Reygers to model 
+//Monte Carlo code written by Klaus Reygers to model
 //the loss of forward
 //neutrons into the ZDC due to larger fragments
 
 //Assume Au for now
 //make sure b is in fm
-double ploss(double b){
+double ploss(double b)
+{
   // para
   double p0 = 0.3305;
   double p1 = 0.0127;
   double p2 = 17.;
   double p3 = 2.;
-  double ploss = p0+b*p1+exp((b-p2)/p3);
-  
+  double ploss = p0 + b * p1 + exp((b - p2) / p3);
+
   return ploss;
 }
 
 //this method is use to generate and random p_F
 //along a random direction and add it to the momentum
 //assume Au for now
-CLHEP::HepLorentzVector pwithpF(CLHEP::HepLorentzVector p,gsl_rng *RandomGenerator, int id){
+CLHEP::HepLorentzVector pwithpF(CLHEP::HepLorentzVector p, gsl_rng *RandomGenerator, int id)
+{
   //id should be either 2112 or 2212
-  if( ! ( (id == 2112)||(id==2212) ) ){
-    std::cout<<"wrong pid"<<std::endl;
+  if (!((id == 2112) || (id == 2212)))
+  {
+    std::cout << "wrong pid" << std::endl;
     return p;
   }
   //find pF max using Thomas-Fermi model, assume using Au.
-  float pFmax=0.28315;
-  if(id==2212) pFmax=0.23276;
+  float pFmax = 0.28315;
+  if (id == 2212) pFmax = 0.23276;
   //now generate the random p assuming probability is propotional to p^2dp
   //CLHEP::RandGeneral seems to be a better way to do it
-  float pF=pFmax*pow(gsl_rng_uniform_pos(RandomGenerator),1.0/3.0);
-  float cotheta=(gsl_rng_uniform_pos(RandomGenerator)-0.5) * 2;
-  float phi=gsl_rng_uniform_pos(RandomGenerator) * 2 * M_PI;
-  float pFx=pF * sqrt(1-cotheta * cotheta) * cos(phi);
-  float pFy=pF * sqrt(1-cotheta * cotheta) * sin(phi);
-  float pFz=pF * cotheta;
+  float pF = pFmax * pow(gsl_rng_uniform_pos(RandomGenerator), 1.0 / 3.0);
+  float cotheta = (gsl_rng_uniform_pos(RandomGenerator) - 0.5) * 2;
+  float phi = gsl_rng_uniform_pos(RandomGenerator) * 2 * M_PI;
+  float pFx = pF * sqrt(1 - cotheta * cotheta) * cos(phi);
+  float pFy = pF * sqrt(1 - cotheta * cotheta) * sin(phi);
+  float pFz = pF * cotheta;
   //now add the pF to p
-  float px=p.px()+pFx;
-  float py=p.py()+pFy;
-  float pz=p.pz()+pFz;
+  float px = p.px() + pFx;
+  float py = p.py() + pFy;
+  float pz = p.pz() + pFz;
   //calculate the total energy
-  float const nrm=0.938;
-  float e=sqrt(px*px+py*py+pz*pz + nrm*nrm);
+  float const nrm = 0.938;
+  float e = sqrt(px * px + py * py + pz * pz + nrm * nrm);
 
-  CLHEP::HepLorentzVector pwithpF(px,py,pz,e);
+  CLHEP::HepLorentzVector pwithpF(px, py, pz, e);
   return pwithpF;
 }
 
-
-int FermiMotion (HepMC::GenEvent *event, gsl_rng *RandomGenerator){
+int FermiMotion(HepMC::GenEvent *event, gsl_rng *RandomGenerator)
+{
   //find ploss
   //std::cout<<"getting b"<<std::endl;
   HepMC::HeavyIon *hi = event->heavy_ion();
   double b = hi->impact_parameter();
-  double pnl=ploss(b);
+  double pnl = ploss(b);
   //now loop over all particles and find spectator neutrons
 
- std::cout<<"looping over particles"<<std::endl;
- for ( HepMC::GenEvent::particle_const_iterator p = event->particles_begin(),prev=event->particles_end();  p != event->particles_end(); prev=p, ++p ){
-    int id=(*p)->pdg_id();
-    bool havedelete=false;
+  std::cout << "looping over particles" << std::endl;
+  for (HepMC::GenEvent::particle_const_iterator p = event->particles_begin(), prev = event->particles_end(); p != event->particles_end(); prev = p, ++p)
+  {
+    int id = (*p)->pdg_id();
+    bool havedelete = false;
     //if not neutron, skip
-    if( ! ( (id == 2112)||(id==2212) ) ) continue;
+    if (!((id == 2112) || (id == 2212))) continue;
 
     //spectator neutron should have px==0&&py==0
     HepMC::GenParticle *n = (*p);
-    float p_x=n->momentum().px();
-    float p_y=n->momentum().py();
-    if(!(p_x==0&&p_y==0 )) continue;
-   
+    float p_x = n->momentum().px();
+    float p_y = n->momentum().py();
+    if (!(p_x == 0 && p_y == 0)) continue;
 
+    if (id == 2112)
+    {
+      //std::cout<<"after: "<<n->barcode()<<std::endl;
+      if (pnl > gsl_rng_uniform_pos(RandomGenerator))
+      {
+        //remove particle here
 
-    
-   if(id==2112){
-     //std::cout<<"after: "<<n->barcode()<<std::endl;
-       if(pnl>gsl_rng_uniform_pos(RandomGenerator)){
-	//remove particle here
-	
-	((*p)->production_vertex())->remove_particle(*p);
-	//std::cout<<"removing: "<<n->barcode()<<std::endl;
-	
-	havedelete=true;
+        ((*p)->production_vertex())->remove_particle(*p);
+        //std::cout<<"removing: "<<n->barcode()<<std::endl;
+
+        havedelete = true;
       }
-
-
     }
-    
-    
+
     //add pF to the remaining
-   
-   CLHEP::HepLorentzVector p0(n->momentum().px(),n->momentum().py(),n->momentum().pz(),n->momentum().e());
-   CLHEP::HepLorentzVector newp= pwithpF( p0, RandomGenerator, id);
-   (*p)->set_momentum(newp );   
-   //remember the index go down one after remove
-   if(havedelete){
-     if(prev != event->particles_end()) p=prev;
-   } 
- }
+
+    CLHEP::HepLorentzVector p0(n->momentum().px(), n->momentum().py(), n->momentum().pz(), n->momentum().e());
+    CLHEP::HepLorentzVector newp = pwithpF(p0, RandomGenerator, id);
+    (*p)->set_momentum(newp);
+    //remember the index go down one after remove
+    if (havedelete)
+    {
+      if (prev != event->particles_end()) p = prev;
+    }
+  }
 
   return 0;
 }

--- a/generators/FermiMotionAfterburner/FermiMotion.cc
+++ b/generators/FermiMotionAfterburner/FermiMotion.cc
@@ -9,7 +9,8 @@
 #include <gsl/gsl_errno.h>
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_roots.h>
-
+#include <gsl/gsl_randist.h>
+#include <gsl/gsl_rng.h> 
 
 #include <HepMC/GenEvent.h>
 #include <HepMC/GenParticle.h>  // for GenParticle
@@ -19,7 +20,7 @@
 #include <HepMC/IteratorRange.h>  // for children, descendants
 #include <HepMC/SimpleVector.h>   // for FourVector
 
-#include <CLHEP/Random/RandFlat.h>
+
 #include <CLHEP/Vector/LorentzVector.h>
 
 #include <cmath>
@@ -35,10 +36,7 @@
 
 
 using namespace HepMC;
-namespace CLHEP
-{
-class HepRandomEngine;
-}
+
 namespace HepMC { class GenEvent; }
 //this method is use to find out the spectator neutron loss prob
 //using the parameterization in the PHENIX Glauber
@@ -62,7 +60,7 @@ double ploss(double b){
 //this method is use to generate and random p_F
 //along a random direction and add it to the momentum
 //assume Au for now
-CLHEP::HepLorentzVector pwithpF(CLHEP::HepLorentzVector p,CLHEP::HepRandomEngine *engine, int id){
+CLHEP::HepLorentzVector pwithpF(CLHEP::HepLorentzVector p,gsl_rng *RandomGenerator, int id){
   //id should be either 2112 or 2212
   if( ! ( (id == 2112)||(id==2212) ) ){
     std::cout<<"wrong pid"<<std::endl;
@@ -73,9 +71,9 @@ CLHEP::HepLorentzVector pwithpF(CLHEP::HepLorentzVector p,CLHEP::HepRandomEngine
   if(id==2212) pFmax=0.23276;
   //now generate the random p assuming probability is propotional to p^2dp
   //CLHEP::RandGeneral seems to be a better way to do it
-  float pF=pFmax*pow(CLHEP::RandFlat::shoot(engine),1.0/3.0);
-  float cotheta=(CLHEP::RandFlat::shoot(engine)-0.5) * 2;
-  float phi=CLHEP::RandFlat::shoot(engine) * 2 * M_PI;
+  float pF=pFmax*pow(gsl_rng_uniform_pos(RandomGenerator),1.0/3.0);
+  float cotheta=(gsl_rng_uniform_pos(RandomGenerator)-0.5) * 2;
+  float phi=gsl_rng_uniform_pos(RandomGenerator) * 2 * M_PI;
   float pFx=pF * sqrt(1-cotheta * cotheta) * cos(phi);
   float pFy=pF * sqrt(1-cotheta * cotheta) * sin(phi);
   float pFz=pF * cotheta;
@@ -92,54 +90,58 @@ CLHEP::HepLorentzVector pwithpF(CLHEP::HepLorentzVector p,CLHEP::HepRandomEngine
 }
 
 
-int FermiMotion (HepMC::GenEvent *event, CLHEP::HepRandomEngine *engine){
+int FermiMotion (HepMC::GenEvent *event, gsl_rng *RandomGenerator){
   //find ploss
   //std::cout<<"getting b"<<std::endl;
   HepMC::HeavyIon *hi = event->heavy_ion();
   double b = hi->impact_parameter();
   double pnl=ploss(b);
-  //now loop over all particles and find spectators
+  //now loop over all particles and find spectator neutrons
 
  std::cout<<"looping over particles"<<std::endl;
  for ( GenEvent::particle_const_iterator p = event->particles_begin(),prev=event->particles_end();  p != event->particles_end(); prev=p, ++p ){
     int id=(*p)->pdg_id();
     bool havedelete=false;
-    //if not neutron or proton, skip
+    //if not neutron, skip
     if( ! ( (id == 2112)||(id==2212) ) ) continue;
 
-    //spectator neutron&protons should have px==0&&py==0
+    //spectator neutron should have px==0&&py==0
     HepMC::GenParticle *n = (*p);
     float p_x=n->momentum().px();
     float p_y=n->momentum().py();
     if(!(p_x==0&&p_y==0 )) continue;
-  
-    //remove neutrons bound to large fragment    
-    if(id==2112){
+   
 
-      if(pnl>CLHEP::RandFlat::shoot(engine)){
+
+    
+   if(id==2112){
+     //std::cout<<"after: "<<n->barcode()<<std::endl;
+       if(pnl>gsl_rng_uniform_pos(RandomGenerator)){
 	//remove particle here
 	
 	((*p)->production_vertex())->remove_particle(*p);
+	//std::cout<<"removing: "<<n->barcode()<<std::endl;
 	
 	havedelete=true;
       }
-      
+
+
     }
     
-    //add pF to the remaining
     
+    //add pF to the remaining
+   
    CLHEP::HepLorentzVector p0(n->momentum().px(),n->momentum().py(),n->momentum().pz(),n->momentum().e());
-   CLHEP::HepLorentzVector newp= pwithpF( p0, engine, id);
+   CLHEP::HepLorentzVector newp= pwithpF( p0, RandomGenerator, id);
    (*p)->set_momentum(newp );   
    //remember the index go down one after remove
-   
    if(havedelete){
      if(prev != event->particles_end()) p=prev;
    } 
  }
  
- 
- return 0;
+
+  return 0;
 }
 
 

--- a/generators/FermiMotionAfterburner/FermiMotion.h
+++ b/generators/FermiMotionAfterburner/FermiMotion.h
@@ -1,14 +1,8 @@
 #ifndef FERMIMOTION_FERMIMOTION_H
 #define FERMIMOTION_FERMIMOTION_H
 
-#include <string>
 #include <gsl/gsl_rng.h>
 
-
-namespace CLHEP
-{
-  class HepRandomEngine;
-}
 namespace HepMC { 
 class GenEvent; 
 }

--- a/generators/FermiMotionAfterburner/FermiMotion.h
+++ b/generators/FermiMotionAfterburner/FermiMotion.h
@@ -3,14 +3,11 @@
 
 #include <gsl/gsl_rng.h>
 
-namespace HepMC { 
-class GenEvent; 
+namespace HepMC
+{
+  class GenEvent;
 }
 
-
-
-
-  int FermiMotion (HepMC::GenEvent *event, gsl_rng *RandomGenerator);
-
+int FermiMotion(HepMC::GenEvent *event, gsl_rng *RandomGenerator);
 
 #endif

--- a/generators/FermiMotionAfterburner/FermiMotion.h
+++ b/generators/FermiMotionAfterburner/FermiMotion.h
@@ -1,0 +1,22 @@
+#ifndef FERMIMOTION_FERMIMOTION_H
+#define FERMIMOTION_FERMIMOTION_H
+
+#include <string>
+
+
+
+namespace CLHEP
+{
+  class HepRandomEngine;
+}
+namespace HepMC { 
+class GenEvent; 
+}
+
+
+
+
+  int FermiMotion (HepMC::GenEvent *event, CLHEP::HepRandomEngine *engine);
+
+
+#endif

--- a/generators/FermiMotionAfterburner/FermiMotion.h
+++ b/generators/FermiMotionAfterburner/FermiMotion.h
@@ -2,7 +2,7 @@
 #define FERMIMOTION_FERMIMOTION_H
 
 #include <string>
-
+#include <gsl/gsl_rng.h>
 
 
 namespace CLHEP
@@ -16,7 +16,7 @@ class GenEvent;
 
 
 
-  int FermiMotion (HepMC::GenEvent *event, CLHEP::HepRandomEngine *engine);
+  int FermiMotion (HepMC::GenEvent *event, gsl_rng *RandomGenerator);
 
 
 #endif

--- a/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
+++ b/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
@@ -14,9 +14,6 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
-#include <CLHEP/Random/MTwistEngine.h>
-#include <CLHEP/Random/RandomEngine.h>
-
 #include <iostream>
 #include <iterator>                           // for operator!=, reverse_ite...
 #include <set>                                // for set, _Rb_tree_const_ite...
@@ -26,7 +23,7 @@
 #include <gsl/gsl_errno.h>
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_roots.h>
-
+#include <gsl/gsl_rng.h> 
 
 #include <HepMC/GenEvent.h>
 #include <HepMC/GenParticle.h>  // for GenParticle
@@ -44,41 +41,38 @@
 
 using namespace std;
 using namespace HepMC;
-namespace CLHEP
-{
-class HepRandomEngine;
-}
+
 namespace HepMC { class GenEvent; }
 CLHEP::HepRandomEngine *engine = nullptr;
 //____________________________________________________________________________..
 FermimotionAfterburner::FermimotionAfterburner(const std::string &name):
   SubsysReco(name)
-  , seed(0)
-  , randomSeed(11793)
+  
 {
-
-
+  
+  RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
 }
 
 //____________________________________________________________________________..
 FermimotionAfterburner::~FermimotionAfterburner()
 {
-  
+  gsl_rng_free(RandomGenerator);
 }
 
 //____________________________________________________________________________..
 int FermimotionAfterburner::Init(PHCompositeNode *topNode)
 {
- 
-  engine = new CLHEP::MTwistEngine(randomSeed);
-
+  
+  unsigned int seed = PHRandomSeed();  
+  gsl_rng_set(RandomGenerator, seed);
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int FermimotionAfterburner::InitRun(PHCompositeNode *topNode)
 {
- 
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -91,7 +85,7 @@ int FermimotionAfterburner::process_event(PHCompositeNode *topNode)
    
   return Fun4AllReturnCodes::EVENT_OK;
   
-   
+  
 }
 
 //____________________________________________________________________________..
@@ -149,7 +143,7 @@ PHHepMCGenEventMap *genevtmap = findNode::getClass<PHHepMCGenEventMap>(topNode, 
 	  cout << PHWHERE << " no evt pointer under HEPMC Node found" << endl;
 	}
       cout<<"applying fermimotion"<<std::endl;
-      FermiMotion(evt,engine);
+      FermiMotion(evt,RandomGenerator);
    
     }
   

--- a/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
+++ b/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
@@ -6,7 +6,7 @@
 #include <phhepmc/PHHepMCGenEventMap.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>               // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
@@ -15,18 +15,20 @@
 #include <gsl/gsl_rng.h>
 
 #include <iostream>
-#include <set>                                // for set, _Rb_tree_const_ite...
+#include <set>  // for set, _Rb_tree_const_ite...
 #include <string>
-#include <utility>   
+#include <utility>
 
-namespace HepMC { class GenEvent; }
+namespace HepMC
+{
+  class GenEvent;
+}
 
 //____________________________________________________________________________..
-FermimotionAfterburner::FermimotionAfterburner(const std::string &name):
-  SubsysReco(name)
-  
+FermimotionAfterburner::FermimotionAfterburner(const std::string &name)
+  : SubsysReco(name)
+
 {
-  
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
 }
 
@@ -39,17 +41,15 @@ FermimotionAfterburner::~FermimotionAfterburner()
 //____________________________________________________________________________..
 int FermimotionAfterburner::Init(PHCompositeNode *topNode)
 {
-  
-  unsigned int seed = PHRandomSeed();  
+  unsigned int seed = PHRandomSeed();
   gsl_rng_set(RandomGenerator, seed);
-  
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int FermimotionAfterburner::InitRun(PHCompositeNode *topNode)
 {
-  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -58,71 +58,57 @@ int FermimotionAfterburner::process_event(PHCompositeNode *topNode)
 {
   std::cout << "process_event(PHCompositeNode *topNode) Processing Event Shuhang testing" << std::endl;
   AddpF(topNode);
-  
-   
+
   return Fun4AllReturnCodes::EVENT_OK;
-  
-  
 }
 
 //____________________________________________________________________________..
 int FermimotionAfterburner::ResetEvent(PHCompositeNode *topNode)
 {
-  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int FermimotionAfterburner::EndRun(const int runnumber)
 {
-  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int FermimotionAfterburner::End(PHCompositeNode *topNode)
 {
-  
-  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int FermimotionAfterburner::Reset(PHCompositeNode *topNode)
 {
-  
- 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 void FermimotionAfterburner::Print(const std::string &what) const
 {
- 
 }
 
 //____________________________________________________________________________..
 
-
 void FermimotionAfterburner::AddpF(PHCompositeNode *topNode)
 
 {
-PHHepMCGenEventMap *genevtmap = findNode::getClass<PHHepMCGenEventMap>(topNode, "PHHepMCGenEventMap");
- std::cout<<"looping over events"<<std::endl;
- for (PHHepMCGenEventMap::Iter iter = genevtmap->begin(); iter != genevtmap->end(); ++iter)
+  PHHepMCGenEventMap *genevtmap = findNode::getClass<PHHepMCGenEventMap>(topNode, "PHHepMCGenEventMap");
+  std::cout << "looping over events" << std::endl;
+  for (PHHepMCGenEventMap::Iter iter = genevtmap->begin(); iter != genevtmap->end(); ++iter)
+  {
+    std::cout << "getting event" << std::endl;
+    PHHepMCGenEvent *genevt = iter->second;
+    HepMC::GenEvent *evt = genevt->getEvent();
+    std::cout << "done" << std::endl;
+    if (!evt)
     {
-      std::cout<<"getting event"<<std::endl;
-      PHHepMCGenEvent *genevt = iter->second;
-      HepMC::GenEvent *evt = genevt->getEvent();
-      std::cout<<"done"<<std::endl;
-      if (!evt)
-	{
-	  std::cout << PHWHERE << " no evt pointer under HEPMC Node found" << std::endl;
-	}
-      std::cout<<"applying fermimotion"<<std::endl;
-      FermiMotion(evt,RandomGenerator);
-   
+      std::cout << PHWHERE << " no evt pointer under HEPMC Node found" << std::endl;
     }
-  
- 
+    std::cout << "applying fermimotion" << std::endl;
+    FermiMotion(evt, RandomGenerator);
+  }
 }

--- a/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
+++ b/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
@@ -94,7 +94,6 @@ void FermimotionAfterburner::Print(const std::string &what) const
 //____________________________________________________________________________..
 
 void FermimotionAfterburner::AddpF(PHCompositeNode *topNode)
-
 {
   PHHepMCGenEventMap *genevtmap = findNode::getClass<PHHepMCGenEventMap>(topNode, "PHHepMCGenEventMap");
   std::cout << "looping over events" << std::endl;

--- a/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
+++ b/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
@@ -1,11 +1,9 @@
 #include "FermimotionAfterburner.h"
+
 #include "FermiMotion.h"
 
 #include <phhepmc/PHHepMCGenEvent.h>
 #include <phhepmc/PHHepMCGenEventMap.h>
-#include <fun4all/Fun4AllReturnCodes.h>
-
-#include <phool/PHCompositeNode.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>               // for SubsysReco
@@ -14,36 +12,15 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
+#include <gsl/gsl_rng.h>
+
 #include <iostream>
-#include <iterator>                           // for operator!=, reverse_ite...
 #include <set>                                // for set, _Rb_tree_const_ite...
 #include <string>
 #include <utility>   
 
-#include <gsl/gsl_errno.h>
-#include <gsl/gsl_math.h>
-#include <gsl/gsl_roots.h>
-#include <gsl/gsl_rng.h> 
-
-#include <HepMC/GenEvent.h>
-#include <HepMC/GenParticle.h>  // for GenParticle
-#include <HepMC/GenRanges.h>
-#include <HepMC/GenVertex.h>      // for GenVertex, GenVertex::part...
-#include <HepMC/HeavyIon.h>       // for HeavyIon
-#include <HepMC/IteratorRange.h>  // for children, descendants
-#include <HepMC/SimpleVector.h>   // for FourVector
-
-#include <CLHEP/Random/RandFlat.h>
-#include <CLHEP/Vector/LorentzVector.h>
-
-#include <cmath>
-#include <map>  // for map
-
-using namespace std;
-using namespace HepMC;
-
 namespace HepMC { class GenEvent; }
-CLHEP::HepRandomEngine *engine = nullptr;
+
 //____________________________________________________________________________..
 FermimotionAfterburner::FermimotionAfterburner(const std::string &name):
   SubsysReco(name)
@@ -79,7 +56,7 @@ int FermimotionAfterburner::InitRun(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int FermimotionAfterburner::process_event(PHCompositeNode *topNode)
 {
-  cout << "process_event(PHCompositeNode *topNode) Processing Event Shuhang testing" << endl;
+  std::cout << "process_event(PHCompositeNode *topNode) Processing Event Shuhang testing" << std::endl;
   AddpF(topNode);
   
    
@@ -131,18 +108,18 @@ void FermimotionAfterburner::AddpF(PHCompositeNode *topNode)
 
 {
 PHHepMCGenEventMap *genevtmap = findNode::getClass<PHHepMCGenEventMap>(topNode, "PHHepMCGenEventMap");
- cout<<"looping over events"<<endl; 
+ std::cout<<"looping over events"<<std::endl;
  for (PHHepMCGenEventMap::Iter iter = genevtmap->begin(); iter != genevtmap->end(); ++iter)
     {
-      cout<<"getting event"<<endl;
+      std::cout<<"getting event"<<std::endl;
       PHHepMCGenEvent *genevt = iter->second;
       HepMC::GenEvent *evt = genevt->getEvent();
-      cout<<"done"<<endl;
+      std::cout<<"done"<<std::endl;
       if (!evt)
 	{
-	  cout << PHWHERE << " no evt pointer under HEPMC Node found" << endl;
+	  std::cout << PHWHERE << " no evt pointer under HEPMC Node found" << std::endl;
 	}
-      cout<<"applying fermimotion"<<std::endl;
+      std::cout<<"applying fermimotion"<<std::endl;
       FermiMotion(evt,RandomGenerator);
    
     }

--- a/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
+++ b/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
@@ -1,0 +1,157 @@
+#include "FermimotionAfterburner.h"
+#include "FermiMotion.h"
+
+#include <phhepmc/PHHepMCGenEvent.h>
+#include <phhepmc/PHHepMCGenEventMap.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>               // for SubsysReco
+
+#include <phool/PHRandomSeed.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <CLHEP/Random/MTwistEngine.h>
+#include <CLHEP/Random/RandomEngine.h>
+
+#include <iostream>
+#include <iterator>                           // for operator!=, reverse_ite...
+#include <set>                                // for set, _Rb_tree_const_ite...
+#include <string>
+#include <utility>   
+
+#include <gsl/gsl_errno.h>
+#include <gsl/gsl_math.h>
+#include <gsl/gsl_roots.h>
+
+
+#include <HepMC/GenEvent.h>
+#include <HepMC/GenParticle.h>  // for GenParticle
+#include <HepMC/GenRanges.h>
+#include <HepMC/GenVertex.h>      // for GenVertex, GenVertex::part...
+#include <HepMC/HeavyIon.h>       // for HeavyIon
+#include <HepMC/IteratorRange.h>  // for children, descendants
+#include <HepMC/SimpleVector.h>   // for FourVector
+
+#include <CLHEP/Random/RandFlat.h>
+#include <CLHEP/Vector/LorentzVector.h>
+
+#include <cmath>
+#include <map>  // for map
+
+using namespace std;
+using namespace HepMC;
+namespace CLHEP
+{
+class HepRandomEngine;
+}
+namespace HepMC { class GenEvent; }
+CLHEP::HepRandomEngine *engine = nullptr;
+//____________________________________________________________________________..
+FermimotionAfterburner::FermimotionAfterburner(const std::string &name):
+  SubsysReco(name)
+  , seed(0)
+  , randomSeed(11793)
+{
+
+
+}
+
+//____________________________________________________________________________..
+FermimotionAfterburner::~FermimotionAfterburner()
+{
+  
+}
+
+//____________________________________________________________________________..
+int FermimotionAfterburner::Init(PHCompositeNode *topNode)
+{
+ 
+  engine = new CLHEP::MTwistEngine(randomSeed);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int FermimotionAfterburner::InitRun(PHCompositeNode *topNode)
+{
+ 
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int FermimotionAfterburner::process_event(PHCompositeNode *topNode)
+{
+  cout << "process_event(PHCompositeNode *topNode) Processing Event Shuhang testing" << endl;
+  AddpF(topNode);
+  
+   
+  return Fun4AllReturnCodes::EVENT_OK;
+  
+   
+}
+
+//____________________________________________________________________________..
+int FermimotionAfterburner::ResetEvent(PHCompositeNode *topNode)
+{
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int FermimotionAfterburner::EndRun(const int runnumber)
+{
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int FermimotionAfterburner::End(PHCompositeNode *topNode)
+{
+  
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int FermimotionAfterburner::Reset(PHCompositeNode *topNode)
+{
+  
+ 
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+void FermimotionAfterburner::Print(const std::string &what) const
+{
+ 
+}
+
+//____________________________________________________________________________..
+
+
+void FermimotionAfterburner::AddpF(PHCompositeNode *topNode)
+
+{
+PHHepMCGenEventMap *genevtmap = findNode::getClass<PHHepMCGenEventMap>(topNode, "PHHepMCGenEventMap");
+ cout<<"looping over events"<<endl; 
+ for (PHHepMCGenEventMap::Iter iter = genevtmap->begin(); iter != genevtmap->end(); ++iter)
+    {
+      cout<<"getting event"<<endl;
+      PHHepMCGenEvent *genevt = iter->second;
+      HepMC::GenEvent *evt = genevt->getEvent();
+      cout<<"done"<<endl;
+      if (!evt)
+	{
+	  cout << PHWHERE << " no evt pointer under HEPMC Node found" << endl;
+	}
+      cout<<"applying fermimotion"<<std::endl;
+      FermiMotion(evt,engine);
+   
+    }
+  
+ 
+}

--- a/generators/FermiMotionAfterburner/FermimotionAfterburner.h
+++ b/generators/FermiMotionAfterburner/FermimotionAfterburner.h
@@ -6,10 +6,9 @@
 #include <fun4all/SubsysReco.h>
 
 #include <string>
-
+#include <gsl/gsl_rng.h>
 class Fun4AllHistoManager;
 class PHCompositeNode;
-class TFile;
 class PHHepMCGenEventMap;
 
 
@@ -52,16 +51,15 @@ class FermimotionAfterburner : public SubsysReco
   /// Reset
   int Reset(PHCompositeNode * /*topNode*/) override;
 
-  void Print(const std::string &what = "ALL") const override;
+void Print(const std::string &what = "ALL") const override;
  
  private:
  
 
   void AddpF(PHCompositeNode *);
  
-
-  long seed;
-  long randomSeed;
+ 
+  gsl_rng *RandomGenerator;
 
 };
 

--- a/generators/FermiMotionAfterburner/FermimotionAfterburner.h
+++ b/generators/FermiMotionAfterburner/FermimotionAfterburner.h
@@ -5,11 +5,11 @@
 
 #include <fun4all/SubsysReco.h>
 
-#include <string>
 #include <gsl/gsl_rng.h>
-class Fun4AllHistoManager;
+
+#include <string>
+
 class PHCompositeNode;
-class PHHepMCGenEventMap;
 
 
 class FermimotionAfterburner : public SubsysReco

--- a/generators/FermiMotionAfterburner/FermimotionAfterburner.h
+++ b/generators/FermiMotionAfterburner/FermimotionAfterburner.h
@@ -11,11 +11,9 @@
 
 class PHCompositeNode;
 
-
 class FermimotionAfterburner : public SubsysReco
 {
  public:
-
   FermimotionAfterburner(const std::string &name = "FermimotionAfterburner");
 
   virtual ~FermimotionAfterburner();
@@ -51,16 +49,12 @@ class FermimotionAfterburner : public SubsysReco
   /// Reset
   int Reset(PHCompositeNode * /*topNode*/) override;
 
-void Print(const std::string &what = "ALL") const override;
- 
+  void Print(const std::string &what = "ALL") const override;
+
  private:
- 
-
   void AddpF(PHCompositeNode *);
- 
- 
-  gsl_rng *RandomGenerator;
 
+  gsl_rng *RandomGenerator;
 };
 
-#endif // FERMIMOTIONAFTERBURNER_H
+#endif  // FERMIMOTIONAFTERBURNER_H

--- a/generators/FermiMotionAfterburner/FermimotionAfterburner.h
+++ b/generators/FermiMotionAfterburner/FermimotionAfterburner.h
@@ -1,0 +1,68 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef FERMIMOTIONAFTERBURNER_H
+#define FERMIMOTIONAFTERBURNER_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class Fun4AllHistoManager;
+class PHCompositeNode;
+class TFile;
+class PHHepMCGenEventMap;
+
+
+class FermimotionAfterburner : public SubsysReco
+{
+ public:
+
+  FermimotionAfterburner(const std::string &name = "FermimotionAfterburner");
+
+  virtual ~FermimotionAfterburner();
+
+  /** Called during initialization.
+      Typically this is where you can book histograms, and e.g.
+      register them to Fun4AllServer (so they can be output to file
+      using Fun4AllServer::dumpHistos() method).
+   */
+  int Init(PHCompositeNode *topNode) override;
+
+  /** Called for first event when run number is known.
+      Typically this is where you may want to fetch data from
+      database, because you know the run number. A place
+      to book histograms which have to know the run number.
+   */
+  int InitRun(PHCompositeNode *topNode) override;
+
+  /** Called for each event.
+      This is where you do the real work.
+   */
+  int process_event(PHCompositeNode *topNode) override;
+
+  /// Clean up internals after each event.
+  int ResetEvent(PHCompositeNode *topNode) override;
+
+  /// Called at the end of each run.
+  int EndRun(const int runnumber) override;
+
+  /// Called at the end of all processing.
+  int End(PHCompositeNode *topNode) override;
+
+  /// Reset
+  int Reset(PHCompositeNode * /*topNode*/) override;
+
+  void Print(const std::string &what = "ALL") const override;
+ 
+ private:
+ 
+
+  void AddpF(PHCompositeNode *);
+ 
+
+  long seed;
+  long randomSeed;
+
+};
+
+#endif // FERMIMOTIONAFTERBURNER_H

--- a/generators/FermiMotionAfterburner/Makefile.am
+++ b/generators/FermiMotionAfterburner/Makefile.am
@@ -1,0 +1,43 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -I$(ROOTSYS)/include
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib
+
+pkginclude_HEADERS = \
+  FermimotionAfterburner.h
+
+lib_LTLIBRARIES = \
+  libFermimotionAfterburner.la
+
+libFermimotionAfterburner_la_SOURCES = \
+  FermimotionAfterburner.cc \
+  FermiMotion.cc
+
+libFermimotionAfterburner_la_LIBADD = \
+  -lphool \
+  -lSubsysReco \
+  -lphhepmc
+
+BUILT_SOURCES = testexternals.cc
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_SOURCES = testexternals.cc
+testexternals_LDADD   = libFermimotionAfterburner.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f $(BUILT_SOURCES)

--- a/generators/FermiMotionAfterburner/autogen.sh
+++ b/generators/FermiMotionAfterburner/autogen.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"

--- a/generators/FermiMotionAfterburner/configure.ac
+++ b/generators/FermiMotionAfterburner/configure.ac
@@ -1,0 +1,16 @@
+AC_INIT(,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+AC_PROG_CXX(CC g++)
+
+LT_INIT([disable-static])
+
+dnl   no point in suppressing warnings people should 
+dnl   at least see them, so here we go for g++: -Wall
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+fi
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
Draft of Fermimotion afterburner. The Fermimotion method will take in a hepmc event, find all spectator neutrons and protons, randomly remove neutrons that bound to larger charge fragments, then apply Fermi motions to the remaining spectators. 
Only works for Au+Au so far.