### PR TITLE
Add bad track seed diagnostic

### DIFF
--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -140,9 +140,12 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
     if(Verbosity() > 0)
       {
 	std::cout << PHWHERE << std::endl;
+	std::cout << "Seed track momentum " << p << std::endl;
 	std::cout << " Seed trackQ " << trackQ << std::endl;
-	std::cout << " seed4Vec " << seed4Vec[0] << "  " << seed4Vec[1] << "  " << seed4Vec[2] << std::endl;
-	std::cout << " seedMomVec " << seedMomVec[0] << "  " << seedMomVec[1] << "  " << seedMomVec[2] << std::endl;
+	std::cout << " seed Pos " << seed4Vec(0) << "  " << seed4Vec(1) 
+		  << "  " << seed4Vec(2) << std::endl;
+	std::cout << " seedMomVec " << seedMomVec(0) << "  " 
+		  << seedMomVec(1) << "  " << seedMomVec(2) << std::endl;
 	// diagonal track cov is square of (err_x_local, err_y_local,  err_phi, err_theta, err_q/p, err_time) 
 	std::cout << " seedCov: " << std::endl;
 	for(unsigned int irow = 0; irow < seedCov.rows(); ++irow)
@@ -155,6 +158,19 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 	  }
       }
     
+    /// Skip this track seed if the seed somehow got screwed up
+    if(std::isnan(p))
+      {
+	std::cout << PHWHERE << "Bad track seed got passed to ACTS... diagnostic:"
+		  << std::endl << "Seed 4vec: (" << seed4Vec(0) << ", " 
+		  << seed4Vec(1) << ", " << seed4Vec(2) << ", " 
+		  << seed4Vec(3) << ")" << std::endl 
+		  << "Seed momentum vec: (" << seedMomVec(0) << ", "
+		  << seedMomVec(1) << ", " << seedMomVec(2) << ")"
+		  << std::endl << "Seed charge " << trackQ << std::endl;
+		  
+	continue;
+      }
     const ActsExamples::TrackParameters trackSeed(seed4Vec, 
 						  seedMomVec, p,
 						  trackQ * Acts::UnitConstants::e,


### PR DESCRIPTION
This PR adds a diagnostic and check for track seeds that are passed to Acts with nan entries. Christof found this error in embedded HIJING events, and we will have to understand where it is coming from in the tracking chain. This PR allows these bad track seeds to be skipped, thus Acts does not crash.

