### PR TITLE
add EMCAL_TOPO as a possible input to jet finding

### DIFF
--- a/simulation/g4simulation/g4jets/ClusterJetInput.cc
+++ b/simulation/g4simulation/g4jets/ClusterJetInput.cc
@@ -105,6 +105,14 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       return std::vector<Jet *>();
     }
   }
+  else if (_input == Jet::ECAL_TOPO_CLUSTER)
+  {
+    clusters = findNode::getClass<RawClusterContainer>(topNode, "TOPOCLUSTER_EMCAL");
+    if (!clusters)
+    {
+      return std::vector<Jet *>();
+    }
+  }
   else
   {
     return std::vector<Jet *>();

--- a/simulation/g4simulation/g4jets/ClusterJetInput.cc
+++ b/simulation/g4simulation/g4jets/ClusterJetInput.cc
@@ -14,13 +14,13 @@
 #include <g4vertex/GlobalVertex.h>
 #include <g4vertex/GlobalVertexMap.h>
 
-#include <CLHEP/Vector/ThreeVector.h>        // for Hep3Vector
+#include <CLHEP/Vector/ThreeVector.h>  // for Hep3Vector
 
 // standard includes
 #include <cassert>
 #include <iostream>
-#include <map>                               // for _Rb_tree_const_iterator
-#include <utility>                           // for pair
+#include <map>      // for _Rb_tree_const_iterator
+#include <utility>  // for pair
 #include <vector>
 
 using namespace std;

--- a/simulation/g4simulation/g4jets/FastJetAlgo.cc
+++ b/simulation/g4simulation/g4jets/FastJetAlgo.cc
@@ -19,8 +19,6 @@
 #include <utility>                     // for pair
 #include <vector>
 
-using namespace std;
-
 FastJetAlgo::FastJetAlgo(Jet::ALGO algo, float par, int verbosity)
   : _verbosity(verbosity)
   , _algo(algo)
@@ -36,10 +34,10 @@ FastJetAlgo::FastJetAlgo(Jet::ALGO algo, float par, int verbosity)
   }
   else
   {
-    ostringstream nullstream;
+    std::ostringstream nullstream;
     clusseq.set_fastjet_banner_stream(&nullstream);
     clusseq.print_banner();
-    clusseq.set_fastjet_banner_stream(&cout);
+    clusseq.set_fastjet_banner_stream(&std::cout);
   }
 }
 
@@ -52,12 +50,12 @@ void FastJetAlgo::identify(std::ostream& os)
     os << "KT r=" << _par;
   else if (_algo == Jet::CAMBRIDGE)
     os << "CAMBRIDGE r=" << _par;
-  os << endl;
+  os << std::endl;
 }
 
 std::vector<Jet*> FastJetAlgo::get_jets(std::vector<Jet*> particles)
 {
-  if (_verbosity > 1) cout << "FastJetAlgo::process_event -- entered" << endl;
+  if (_verbosity > 1) std::cout << "FastJetAlgo::process_event -- entered" << std::endl;
 
   // translate to fastjet
   std::vector<fastjet::PseudoJet> pseudojets;
@@ -144,7 +142,7 @@ std::vector<Jet*> FastJetAlgo::get_jets(std::vector<Jet*> particles)
     jets.push_back(jet);
   }
 
-  if (_verbosity > 1) cout << "FastJetAlgo::process_event -- exited" << endl;
+  if (_verbosity > 1) std::cout << "FastJetAlgo::process_event -- exited" << std::endl;
 
   return jets;
 }

--- a/simulation/g4simulation/g4jets/Jet.h
+++ b/simulation/g4simulation/g4jets/Jet.h
@@ -45,8 +45,9 @@ class Jet : public PHObject
     HCALOUT_TOWER_SUB1CS = 19, /* needed for CS subtraction w/ HI jet reco */
     HEPMC_IMPORT = 20,         /*Direct import HEPMC containers, such as sHijing HIJFRG truth jets loaded by JetHepMCLoader*/
     HCAL_TOPO_CLUSTER = 21,    /* I+HOCal 3-D topoCluster input */
-    EEMC_TOWER = 22,
-    EEMC_CLUSTER = 23,
+    ECAL_TOPO_CLUSTER = 22,    /* EMCal 3-D topoCluster input */
+    EEMC_TOWER = 23,
+    EEMC_CLUSTER = 24,
   };
 
   enum PROPERTY

--- a/simulation/g4simulation/g4jets/TowerJetInput.cc
+++ b/simulation/g4simulation/g4jets/TowerJetInput.cc
@@ -14,10 +14,10 @@
 #include <phool/getClass.h>
 
 #include <cassert>
-#include <cmath>                             // for asinh, atan2, cos, cosh
+#include <cmath>  // for asinh, atan2, cos, cosh
 #include <iostream>
-#include <map>                               // for _Rb_tree_const_iterator
-#include <utility>                           // for pair
+#include <map>      // for _Rb_tree_const_iterator
+#include <utility>  // for pair
 #include <vector>
 
 using namespace std;

--- a/simulation/g4simulation/g4jets/TowerJetInput.h
+++ b/simulation/g4simulation/g4jets/TowerJetInput.h
@@ -5,7 +5,7 @@
 
 #include "Jet.h"
 
-#include <iostream>    // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <vector>
 
 // forward declarations

--- a/simulation/g4simulation/g4jets/TrackJetInput.h
+++ b/simulation/g4simulation/g4jets/TrackJetInput.h
@@ -6,6 +6,7 @@
 #include "Jet.h"
 
 #include <iostream>    // for cout, ostream
+#include <string>      // for string
 #include <vector>
 
 class PHCompositeNode;


### PR DESCRIPTION
This PR adds ECAL_TOPO_CLUSTER as a possible input to jet finding. This input can be used in macros/g4simulations/G4_Jets.C. 