### PR TITLE
Fix multiple vertex handling

### DIFF
--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -1,31 +1,28 @@
 #include "PHMicromegasTpcTrackMatching.h"
 
-#include <fun4all/Fun4AllReturnCodes.h>
-
-#include <phool/PHCompositeNode.h>
-#include <phool/getClass.h>
-#include <phool/phool.h>
+#include "AssocInfoContainer.h"
+#include "PHTrackPropagating.h"     // for PHTrackPropagating
 
 #include <micromegas/MicromegasDefs.h>
 
 /// Tracking includes
-#include <trackbase/TrkrClusterv1.h>
+
+#include <trackbase/TrkrCluster.h>            // for TrkrCluster
+#include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
-#include <trackbase/TrkrHitTruthAssoc.h>
-#include <trackbase_historic/SvtxTrack_v1.h>
+#include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTrack::C...
 #include <trackbase_historic/SvtxTrackMap.h>
-#include <trackbase_historic/SvtxVertexMap.h>
 
-#include <g4main/PHG4Hit.h>  // for PHG4Hit
-#include <g4main/PHG4Particle.h>  // for PHG4Particle
-#include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4HitDefs.h>  // for keytype
-#include <g4main/PHG4TruthInfoContainer.h>
+#include <fun4all/Fun4AllReturnCodes.h>
 
-#include "AssocInfoContainer.h"
+#include <phool/phool.h>
 
-#include <TF1.h>
+#include <cmath>                              // for sqrt, fabs, atan2, cos
+#include <iostream>                           // for operator<<, basic_ostream
+#include <map>                                // for map
+#include <set>                                // for _Rb_tree_const_iterator
+#include <utility>                            // for pair, make_pair
 
 using namespace std;
 

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -3,28 +3,16 @@
 #ifndef PHMICROMEGASTPCTRACKMATCHING_H
 #define PHMICROMEGASTPCTRACKMATCHING_H
 
-#include <fun4all/SubsysReco.h>
-#include <trackbase/TrkrDefs.h>
+#include <trackreco/PHTrackPropagating.h>
 
 #include <string>
-#include <set>
 #include <vector>
 
 class PHCompositeNode;
-class SvtxTrackMap;
 class SvtxTrack;
-class SvtxVertexMap;
-class TrkrClusterContainer;
 class TrkrCluster;
-class TrkrClusterHitAssoc;
-class TrkrHitTruthAssoc;
-class PHG4TruthInfoContainer;
-class PHG4HitContainer;
-class PHG4Particle;
-class AssocInfoContainer;
 class TF1;
 
-#include <trackreco/PHTrackPropagating.h>
 
 class PHMicromegasTpcTrackMatching : public PHTrackPropagating
 {

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -1,29 +1,31 @@
 #include "PHSiliconTpcTrackMatching.h"
 
-#include <fun4all/Fun4AllReturnCodes.h>
-
-#include <phool/PHCompositeNode.h>
-#include <phool/getClass.h>
-#include <phool/phool.h>
+#include "AssocInfoContainer.h"
 
 /// Tracking includes
-#include <trackbase/TrkrClusterv1.h>
-#include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterHitAssoc.h>
-#include <trackbase/TrkrHitTruthAssoc.h>
+#include <trackbase/TrkrDefs.h>                // for cluskey, getTrkrId, tpcId
 #include <trackbase_historic/SvtxTrack_v1.h>
 #include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxVertex.h>     // for SvtxVertex
 #include <trackbase_historic/SvtxVertexMap.h>
 
 #include <g4main/PHG4Hit.h>  // for PHG4Hit
 #include <g4main/PHG4Particle.h>  // for PHG4Particle
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4HitDefs.h>  // for keytype
-#include <g4main/PHG4TruthInfoContainer.h>
 
-#include "AssocInfoContainer.h"
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
 
 #include <TF1.h>
+
+#include <climits>                            // for UINT_MAX
+#include <iostream>                            // for operator<<, basic_ostream
+#include <cmath>                              // for fabs, sqrt
+#include <set>                                 // for _Rb_tree_const_iterator
+#include <utility>                             // for pair
 
 using namespace std;
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -3,27 +3,15 @@
 #ifndef PHSILICONTPCTRACKMATCHING_H
 #define PHSILICONTPCTRACKMATCHING_H
 
-#include <fun4all/SubsysReco.h>
-#include <trackbase/TrkrDefs.h>
+#include <trackreco/PHTrackPropagating.h>
 
 #include <string>
-#include <set>
-#include <vector>
 
 class PHCompositeNode;
 class SvtxTrackMap;
 class SvtxTrack;
-class SvtxVertexMap;
-class TrkrClusterContainer;
-class TrkrClusterHitAssoc;
-class TrkrHitTruthAssoc;
-class PHG4TruthInfoContainer;
-class PHG4HitContainer;
-class PHG4Particle;
-class AssocInfoContainer;
 class TF1;
 
-#include <trackreco/PHTrackPropagating.h>
 
 class PHSiliconTpcTrackMatching : public PHTrackPropagating
 {

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -155,7 +155,7 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
           if (Verbosity() >= 10)
           {
-            cout <<__PRETTY_FUNCTION__<<" check momentum for particle"<<particle_id<<" -> cluster "<<cluskey
+            cout <<__PRETTY_FUNCTION__<<" check momentum for g4particle "<<particle_id<<" -> cluster "<<cluskey
                 <<" = "<<sqrt(monentum2)<<endl;;
             particle->identify();
           }
@@ -164,7 +164,7 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
           {
             if (Verbosity() >= 3)
             {
-              cout <<__PRETTY_FUNCTION__<<" ignore low momentum particle"<<particle_id<<" -> cluster "<<cluskey<<endl;;
+              cout <<__PRETTY_FUNCTION__<<" ignore low momentum g4particle "<<particle_id<<" -> cluster "<<cluskey<<endl;;
               particle->identify();
             }
             continue;
@@ -192,7 +192,7 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
           if (Verbosity() >= 3)
           {
-            cout <<__PRETTY_FUNCTION__<<" new particle"<<particle_id<<" -> cluster "<<cluskey<<endl;;
+            cout <<__PRETTY_FUNCTION__<<" new g4particle "<<particle_id<<" -> cluster "<<cluskey<<endl;;
             cluster->identify();
           }
 
@@ -207,10 +207,12 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
   if (Verbosity() >= 2)
   {
     cout <<__PRETTY_FUNCTION__
-        <<" _track_map->size = "<<_track_map->size()<<endl;
+        <<" Beginning _track_map->size = "<<_track_map->size()<<endl;
+
+    _vertex_map->identify();
   }
 
-  // Build tracks
+  // Build tracks, looping over assembled list of truth track ID's and associated reco clusters
   for (TrkClustersMap::const_iterator trk_clusters_itr = m_trackID_clusters.begin();
        trk_clusters_itr != m_trackID_clusters.end(); ++trk_clusters_itr)
   {
@@ -243,8 +245,8 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
       // assign truth particle vertex ID to this silicon track stub
       PHG4Particle* particle = _g4truth_container->GetParticle(trk_clusters_itr->first);
-      int vertexId = particle->get_vtx_id() - 1;  // Geant likes to count from 1
-      if(vertexId < 0) vertexId = 0;    // secondary particle, arbitrarily set vertexId to 0
+      int vertexId = particle->get_vtx_id() - 1;  // Geant likes to count from 1 for both vertex and g4particle ID, _vertex_map counts from 0
+      if(vertexId < 0) vertexId = 0;    // secondary particle, arbitrarily set vertexId to 1
       svtx_track->set_vertex_id(vertexId);
 
       if(Verbosity() > 0)
@@ -252,6 +254,11 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
       // set the track position to the vertex position
       const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);
+      if(!svtxVertex)
+	{
+	  std::cout << PHWHERE << "Failed to get vertex with ID " << vertexId << " from _vertex_map, cannot proceed - skipping this silicon track" << std::endl;
+	  continue;
+	}
       svtx_track->set_x(svtxVertex->get_x());
       svtx_track->set_y(svtxVertex->get_y());
       svtx_track->set_z(svtxVertex->get_z()); 

--- a/offline/packages/trackreco/PHTrackFitting.h
+++ b/offline/packages/trackreco/PHTrackFitting.h
@@ -11,7 +11,6 @@
 #include <fun4all/SubsysReco.h>
 
 // STL includes
-#include <set>
 #include <string>
 
 // forward declarations

--- a/offline/packages/trackreco/PHTruthVertexing.cc
+++ b/offline/packages/trackreco/PHTruthVertexing.cc
@@ -64,7 +64,7 @@ int PHTruthVertexing::Process(PHCompositeNode* topNode)
       std::cout << "embed only: " << std::boolalpha << _embed_only << std::endl;
     }
   auto vrange =  _g4truth_container->GetPrimaryVtxRange();
-  set<int> gembed_set;
+  //set<int> gembed_set;
   for (auto iter = vrange.first; iter != vrange.second; ++iter)  // process all primary vertexes
     {
       const int point_id = iter->first;
@@ -86,10 +86,10 @@ int PHTruthVertexing::Process(PHCompositeNode* topNode)
       // skip particles that are not primary
       if( sqrt(pos[0]*pos[0]+pos[1]*pos[1])  > 0.1) continue;
 
-      // check to see if we have this vertex already      
-      if(gembed_set.find(gembed) != gembed_set.end()) continue;
+      // We take all primary vertices and copy them to the vertex map, regardless of track embedding ID 
+      //if(gembed_set.find(gembed) != gembed_set.end()) continue;
 
-      gembed_set.insert(gembed);
+      //gembed_set.insert(gembed);
       
       pos[0] += _vertex_error[0] * gsl_ran_ugaussian(m_RandomGenerator);
       pos[1] += _vertex_error[1] * gsl_ran_ugaussian(m_RandomGenerator);


### PR DESCRIPTION
Modifies PHTruthVertexing to copy all primary truth vertices to the SvtxTrackMap, regardless of embedding ID. Modifies PHSiliconTruthTrackSeeding to more gracefully handle not finding a vertex entry in the track map for a truth particle (just skips the truth particle). 