### PR TITLE
Remove pai

### DIFF
--- a/offline/framework/fun4all/Fun4AllDstOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.cc
@@ -192,6 +192,11 @@ int Fun4AllDstOutputManager::Write(PHCompositeNode *startNode)
 int Fun4AllDstOutputManager::WriteNode(PHCompositeNode *thisNode)
 {
   delete dstOut;
+  if (! m_SaveRunNodeFlag)
+  {
+    dstOut = nullptr;
+    return 0;
+  }
   dstOut = new PHNodeIOManager(OutFileName(), PHUpdate, PHRunTree);
   Fun4AllServer *se = Fun4AllServer::instance();
   PHNodeIterator nodeiter(thisNode);

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.h
@@ -21,6 +21,7 @@ class Fun4AllDstOutputManager : public Fun4AllOutputManager
   int AddRunNode(const std::string &nodename);
   int StripNode(const std::string &nodename);
   int StripRunNode(const std::string &nodename);
+  void SaveRunNode(const int i) {m_SaveRunNodeFlag = i;}
   int outfileopen(const std::string &fname);
 
   void Print(const std::string &what = "ALL") const;
@@ -29,11 +30,12 @@ class Fun4AllDstOutputManager : public Fun4AllOutputManager
   int WriteNode(PHCompositeNode *thisNode);
 
  private:
+  PHNodeIOManager *dstOut = nullptr;
+  int m_SaveRunNodeFlag = 1;
   std::set<std::string> savenodes;
   std::set<std::string> saverunnodes;
   std::set<std::string> stripnodes;
   std::set<std::string> striprunnodes;
-  PHNodeIOManager *dstOut = nullptr;
 };
 
 #endif

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -46,6 +46,8 @@ class Fun4AllOutputManager : public Fun4AllBase
     return 0;
   }
 
+  virtual void SaveRunNode(const int i) {return;}
+
   /*! \brief
     add an event selector to the outputmanager.
     event will get written only if all event selectors process_event method

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -1383,8 +1383,8 @@ void PHG4Reco::DefineRegions()
   // add the PAI model to the TPCGAS region
   // undocumented, painfully digged out with debugger by tracing what
   // is done for command "/process/em/AddPAIRegion all TPCGAS PAI"
-  G4EmParameters *g4emparams = G4EmParameters::Instance();
-  g4emparams->AddPAIModel("all", "REGION_TPCGAS", "PAI");
+//  G4EmParameters *g4emparams = G4EmParameters::Instance();
+//  g4emparams->AddPAIModel("all", "REGION_TPCGAS", "PAI");
 #endif
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -371,11 +371,11 @@ void PHG4TruthEventAction::PruneShowers()
 void PHG4TruthEventAction::ProcessShowers()
 {
   PHG4TruthInfoContainer::ShowerRange range = m_TruthInfoContainer->GetShowerRange();
-  for (PHG4TruthInfoContainer::ShowerIterator iter = range.first;
-       iter != range.second;
-       ++iter)
+  for (PHG4TruthInfoContainer::ShowerIterator shwiter = range.first;
+       shwiter != range.second;
+       ++shwiter)
   {
-    PHG4Shower* shower = iter->second;
+    PHG4Shower* shower = shwiter->second;
 
     // Data structures to hold weighted pca
     std::vector<std::vector<float> > points;


### PR DESCRIPTION
The use of the PAI model which worked in G4 10.03 crashes G4 10.06.p02 when enabling the micromega sim. Commented out for the time being - we need to verify the TPC and micromegas gas simulations. The PAI model was supposed to make the eloss more independent on the step length.