### PR TITLE
Cluster key look up

### DIFF
--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -783,7 +783,7 @@ Acts::Vector3D ActsEvaluator::getGlobalTruthHit(PHCompositeNode *topNode,
 {
   SvtxClusterEval *clustereval = m_svtxEvalStack->get_cluster_eval();
 
-  TrkrDefs::cluskey clusKey = m_hitIdClusKey->right.find(hitID)->first;
+  TrkrDefs::cluskey clusKey = m_hitIdClusKey->right.find(hitID)->second;
   
   std::shared_ptr<TrkrCluster> truth_cluster = clustereval->max_truth_cluster_by_energy(clusKey);
   

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -776,27 +776,6 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
   return;
 }
 
-TrkrDefs::cluskey ActsEvaluator::getClusKey(const unsigned int hitID)
-{
-  TrkrDefs::cluskey clusKey = 0;
-  /// Unfortunately the map is backwards for looking up cluster key from
-  /// hit ID. So we need to iterate over it. There won't be duplicates since
-  /// the cluster key and hit id are a one-to-one map
-  std::map<TrkrDefs::cluskey, unsigned int>::iterator
-      hitIter = m_hitIdClusKey->begin();
-  while (hitIter != m_hitIdClusKey->end())
-  {
-    if (hitIter->second == hitID)
-    {
-      clusKey = hitIter->first;
-      break;
-    }
-    ++hitIter;
-  }
-
-  return clusKey;
-}
-
 
 Acts::Vector3D ActsEvaluator::getGlobalTruthHit(PHCompositeNode *topNode, 
 						const unsigned int hitID,
@@ -804,7 +783,7 @@ Acts::Vector3D ActsEvaluator::getGlobalTruthHit(PHCompositeNode *topNode,
 {
   SvtxClusterEval *clustereval = m_svtxEvalStack->get_cluster_eval();
 
-  TrkrDefs::cluskey clusKey = getClusKey(hitID);
+  TrkrDefs::cluskey clusKey = m_hitIdClusKey->right.find(hitID)->first;
   
   std::shared_ptr<TrkrCluster> truth_cluster = clustereval->max_truth_cluster_by_energy(clusKey);
   
@@ -1105,7 +1084,7 @@ int ActsEvaluator::getNodes(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  m_hitIdClusKey = findNode::getClass<std::map<TrkrDefs::cluskey, unsigned int>>(topNode, "HitIDClusIDActsMap");
+  m_hitIdClusKey = findNode::getClass<CluskeyBimap>(topNode, "HitIDClusIDActsMap");
 
   if (!m_hitIdClusKey)
   {

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -13,6 +13,8 @@
 #include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
 #include <ActsExamples/Fitting/TrkrClusterFittingAlgorithm.hpp>
 
+#include <boost/bimap.hpp>
+
 class TTree;
 class TFile;
 class PHG4Particle;
@@ -38,6 +40,9 @@ using Acts::VectorHelpers::eta;
 using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 using Acts::VectorHelpers::theta;
+
+typedef boost::bimap<TrkrDefs::cluskey, unsigned int> CluskeyBimap;
+
 
 /**
  * This class is an analyzing class for the Acts track fitting, and produces
@@ -88,7 +93,6 @@ class ActsEvaluator : public SubsysReco
   Acts::Vector3D getGlobalTruthHit(PHCompositeNode *topNode, 
 				   const unsigned int hitID,
 				   float &_gt);
-  TrkrDefs::cluskey getClusKey(const unsigned int hitID);
 
   SvtxEvaluator *m_svtxEvaluator{nullptr};
   PHG4TruthInfoContainer *m_truthInfo{nullptr};
@@ -97,7 +101,7 @@ class ActsEvaluator : public SubsysReco
   std::map<const unsigned int, std::map<const size_t, 
     const unsigned int>> *m_actsTrackKeyMap{nullptr};
   std::map<const unsigned int, Trajectory> *m_actsFitResults{nullptr};
-  std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey{nullptr};
+  CluskeyBimap *m_hitIdClusKey{nullptr};
   std::map<unsigned int, ActsTrack> *m_actsProtoTrackMap{nullptr};
   ActsTrackingGeometry *m_tGeometry{nullptr};
   SvtxVertexMap *m_vertexMap;

--- a/offline/packages/trackreco/ActsTransformations.cc
+++ b/offline/packages/trackreco/ActsTransformations.cc
@@ -314,7 +314,7 @@ void ActsTransformations::fillSvtxTrackStates(const Trajectory traj,
 
 	  const unsigned int hitId = state.uncalibrated().hitID();
 	  TrkrDefs::cluskey cluskey = 
-	    hitIDCluskeyMap->right.find(hitId)->first;
+	    hitIDCluskeyMap->right.find(hitId)->second;
 	  svtxTrack->insert_cluster_key(cluskey);
 
 	  if(m_verbosity > 20)

--- a/offline/packages/trackreco/ActsTransformations.cc
+++ b/offline/packages/trackreco/ActsTransformations.cc
@@ -1,6 +1,9 @@
 #include "ActsTransformations.h"
 #include <trackbase_historic/SvtxTrackState_v1.h>
 
+#include <chrono>
+using namespace std::chrono;
+
 Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs(
 			        const SvtxTrack *track,
 				Acts::GeometryContext geoCtxt)
@@ -256,7 +259,7 @@ void ActsTransformations::fillSvtxTrackStates(const Trajectory traj,
 					      const size_t &trackTip,
 					      SvtxTrack *svtxTrack,
 					      Acts::GeometryContext geoContext,
-					      std::map<TrkrDefs::cluskey, unsigned int> *hitIDCluskeyMap)
+					      CluskeyBimap *hitIDCluskeyMap)
 {
 
  const auto &[trackTips, mj] = traj.trajectory();
@@ -309,10 +312,15 @@ void ActsTransformations::fillSvtxTrackStates(const Trajectory traj,
 		}
 	    }
 	  	  
-	  const unsigned int hitId = state.uncalibrated().hitID();
-	  TrkrDefs::cluskey cluskey = getClusKey(hitId, hitIDCluskeyMap);
-	  svtxTrack->insert_cluster_key(cluskey);
 	  
+	  auto startTime = high_resolution_clock::now();
+	  const unsigned int hitId = state.uncalibrated().hitID();
+	  TrkrDefs::cluskey cluskey = 
+	    hitIDCluskeyMap->right.find(hitId)->first;
+	  svtxTrack->insert_cluster_key(cluskey);
+	  auto endTime = high_resolution_clock::now();
+	  auto time = duration_cast<microseconds>(endTime - startTime);
+	  std::cout << time.count() / 1000. << std::endl;
 	  if(m_verbosity > 20)
 	    {
 	      std::cout << " inserting state with x,y,z = " << global.x() /  Acts::UnitConstants::cm 

--- a/offline/packages/trackreco/ActsTransformations.cc
+++ b/offline/packages/trackreco/ActsTransformations.cc
@@ -311,16 +311,12 @@ void ActsTransformations::fillSvtxTrackStates(const Trajectory traj,
 		  out.set_error(i, j, globalCov(i,j)); 
 		}
 	    }
-	  	  
-	  
-	  auto startTime = high_resolution_clock::now();
+
 	  const unsigned int hitId = state.uncalibrated().hitID();
 	  TrkrDefs::cluskey cluskey = 
 	    hitIDCluskeyMap->right.find(hitId)->first;
 	  svtxTrack->insert_cluster_key(cluskey);
-	  auto endTime = high_resolution_clock::now();
-	  auto time = duration_cast<microseconds>(endTime - startTime);
-	  std::cout << time.count() / 1000. << std::endl;
+
 	  if(m_verbosity > 20)
 	    {
 	      std::cout << " inserting state with x,y,z = " << global.x() /  Acts::UnitConstants::cm 
@@ -340,26 +336,4 @@ void ActsTransformations::fillSvtxTrackStates(const Trajectory traj,
     );
 
   return;
-}
-
-TrkrDefs::cluskey ActsTransformations::getClusKey(const unsigned int hitID,
-						  std::map<TrkrDefs::cluskey, unsigned int> *hitIDCluskeyMap)
-{
-  TrkrDefs::cluskey clusKey = 0;
-  /// Unfortunately the map is backwards for looking up cluster key from
-  /// hit ID. So we need to iterate over it. There won't be duplicates since
-  /// the cluster key and hit id are a one-to-one map
-  std::map<TrkrDefs::cluskey, unsigned int>::iterator
-      hitIter = hitIDCluskeyMap->begin();
-  while (hitIter != hitIDCluskeyMap->end())
-  {
-    if (hitIter->second == hitID)
-    {
-      clusKey = hitIter->first;
-      break;
-    }
-    ++hitIter;
-  }
-
-  return clusKey;
 }

--- a/offline/packages/trackreco/ActsTransformations.h
+++ b/offline/packages/trackreco/ActsTransformations.h
@@ -14,6 +14,8 @@
 #include <ActsExamples/EventData/TrkrClusterSourceLink.hpp>
 #include <ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp>
 
+#include <boost/bimap.hpp>
+
 /// std (and the like) includes
 #include <cmath>
 #include <iostream>
@@ -27,6 +29,9 @@ using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
                                       Acts::BoundIndices,
                                       Acts::eBoundLoc0,
                                       Acts::eBoundLoc1>;
+
+typedef boost::bimap<TrkrDefs::cluskey, unsigned int> CluskeyBimap;
+
 
 /**
  * This is a helper class for rotating track covariance matrices to and from
@@ -73,7 +78,7 @@ class ActsTransformations
 			   const size_t &trackTip,
 			   SvtxTrack *svtxTrack,
 			   Acts::GeometryContext geoContext,
-			   std::map<TrkrDefs::cluskey, unsigned int> *hitIDCluskeyMap);
+			   CluskeyBimap *hitIDCluskeyMap);
 
  private:
   int m_verbosity;

--- a/offline/packages/trackreco/ActsTransformations.h
+++ b/offline/packages/trackreco/ActsTransformations.h
@@ -83,10 +83,6 @@ class ActsTransformations
  private:
   int m_verbosity;
 
-  /// Get the cluster key for the corresponding hitID from the map 
-  TrkrDefs::cluskey getClusKey(const unsigned int hitID, 
-			       std::map<TrkrDefs::cluskey, unsigned int> *hitIDCluskeyMap);
-
 
 };
 

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -115,8 +115,8 @@ int PHActsSourceLinks::process_event(PHCompositeNode *topNode)
     /// Create the clusKey hitId pair to insert into the map
     const unsigned int trkrId = TrkrDefs::getTrkrId(clusKey);
 
-    m_hitIdClusKey->insert(std::pair<TrkrDefs::cluskey, unsigned int>(clusKey, hitId));
-
+    m_hitIdClusKey->insert(CluskeyBimap::value_type(clusKey, hitId));
+    
     /// Local coordinates and surface to be set by the correct tracking
     /// detector function below
     TMatrixD localErr(3, 3);
@@ -225,10 +225,10 @@ int PHActsSourceLinks::process_event(PHCompositeNode *topNode)
   if (Verbosity() > 10)
   {
     //m_hitIdClusKey
-    std::map<TrkrDefs::cluskey, unsigned int>::iterator it = m_hitIdClusKey->begin();
+    CluskeyBimap::const_iterator it = m_hitIdClusKey->begin();
     while (it != m_hitIdClusKey->end())
     {
-      std::cout << "cluskey " << it->first << " has hitid " << it->second
+      std::cout << "cluskey " << it->left << " has hitid " << it->right
                 << std::endl;
       ++it;
     }
@@ -994,18 +994,17 @@ void PHActsSourceLinks::createNodes(PHCompositeNode *topNode)
   }
 
   /// See if the map is already on the node tree
-  m_hitIdClusKey = findNode::getClass<std::map<TrkrDefs::cluskey, unsigned int>>(topNode, "HitIDClusIDActsMap");
+  m_hitIdClusKey = findNode::getClass<CluskeyBimap>(topNode, "HitIDClusIDActsMap");
 
   /// If not add it
   if (!m_hitIdClusKey)
   {
-    m_hitIdClusKey = new std::map<TrkrDefs::cluskey, unsigned int>;
-    PHDataNode<std::map<TrkrDefs::cluskey, unsigned int>> *hitMapNode =
-        new PHDataNode<std::map<TrkrDefs::cluskey, unsigned int>>(m_hitIdClusKey, "HitIDClusIDActsMap");
+    m_hitIdClusKey = new CluskeyBimap;
+    PHDataNode<CluskeyBimap> *hitMapNode =
+      new PHDataNode<CluskeyBimap>(m_hitIdClusKey, "HitIDClusIDActsMap");
     svtxNode->addNode(hitMapNode);
   }
-
-  /// Do the same for the SourceLink container
+ 
   m_sourceLinks = findNode::getClass<std::map<unsigned int, SourceLink>>(topNode, "TrkrClusterSourceLinks");
 
   if (!m_sourceLinks)

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/bimap.hpp>
+
 /// Acts includes to create all necessary definitions
 #include <Acts/Utilities/BinnedArray.hpp>
 #include <Acts/Utilities/Definitions.hpp>
@@ -47,6 +49,8 @@ namespace Acts
 
 using Surface = std::shared_ptr<const Acts::Surface>;
 using SourceLink = ActsExamples::TrkrClusterSourceLink;
+
+typedef boost::bimap<TrkrDefs::cluskey, unsigned int> CluskeyBimap;
 
 /**
  * This class is responsible for creating Acts TrkrClusterSourceLinks from
@@ -159,7 +163,7 @@ class PHActsSourceLinks : public SubsysReco
 
   /// Map relating arbitrary hitid to TrkrDef::cluskey for SourceLink, to be put
   /// on node tree by this module
-  std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey;
+  CluskeyBimap *m_hitIdClusKey;
 
   /// Map for source hitid:sourcelink, to be put on node tree by this module
   std::map<unsigned int, SourceLink> *m_sourceLinks;

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -185,7 +185,7 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
     {
       const TrkrDefs::cluskey key = *clusIter;
 
-      const unsigned int hitId = m_hitIdClusKey->find(key)->second;
+      const unsigned int hitId = m_hitIdClusKey->left.find(key)->second;
 
       trackSourceLinks.push_back(m_sourceLinks->find(hitId)->second);
       
@@ -306,7 +306,7 @@ int PHActsTracks::getNodes(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-  m_hitIdClusKey = findNode::getClass<std::map<TrkrDefs::cluskey, unsigned int>>(topNode, "HitIDClusIDActsMap");
+  m_hitIdClusKey = findNode::getClass<CluskeyBimap>(topNode, "HitIDClusIDActsMap");
 
   if (!m_hitIdClusKey)
   {

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -17,6 +17,8 @@
 #include "ActsTrack.h"
 #include "ActsTrackingGeometry.h"
 
+#include <boost/bimap.hpp>
+
 #include <map>
 #include <string>
 #include <vector>
@@ -28,6 +30,8 @@ class SvtxVertexMap;
 class MakeActsGeometry;
 
 using SourceLink = ActsExamples::TrkrClusterSourceLink;
+
+typedef boost::bimap<TrkrDefs::cluskey, unsigned int> CluskeyBimap;
 
 
 /**
@@ -79,7 +83,7 @@ class PHActsTracks : public SubsysReco
   SvtxVertexMap *m_vertexMap;
 
   /// Map between cluster key and arbitrary hit id created in PHActsSourceLinks
-  std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey;
+  CluskeyBimap *m_hitIdClusKey;
 
   /// Map of hitid:SourceLinks created in PHActsSourceLinks
   std::map<unsigned int, SourceLink> *m_sourceLinks;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -755,7 +755,7 @@ int PHActsTrkFitter::getNodes(PHCompositeNode* topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-  m_hitIdClusKey = findNode::getClass<std::map<TrkrDefs::cluskey, unsigned int>>(topNode, "HitIDClusIDActsMap");
+  m_hitIdClusKey = findNode::getClass<CluskeyBimap>(topNode, "HitIDClusIDActsMap");
   
   if (!m_hitIdClusKey)
     {

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -24,6 +24,8 @@
 #include <ActsExamples/Fitting/TrkrClusterFittingAlgorithm.hpp>
 #include <ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp>
 
+#include <boost/bimap.hpp>
+
 #include <memory>
 #include <string>
 #include <TFile.h>
@@ -49,6 +51,9 @@ using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
                                       Acts::eBoundLoc1>;
 using SurfacePtrVec = std::vector<const Acts::Surface*>;
 using SourceLinkVec = std::vector<SourceLink>;
+
+typedef boost::bimap<TrkrDefs::cluskey, unsigned int> CluskeyBimap;
+
 
 class PHActsTrkFitter : public PHTrackFitting
 {
@@ -136,7 +141,7 @@ class PHActsTrkFitter : public PHTrackFitting
   SvtxTrackMap *m_trackMap;
 
   // map relating acts hitid's to clusterkeys
-  std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey;
+  CluskeyBimap *m_hitIdClusKey;
 
   /// Number of acts fits that returned an error
   int m_nBadFits;

--- a/offline/packages/trackreco/PHActsTrkProp.cc
+++ b/offline/packages/trackreco/PHActsTrkProp.cc
@@ -698,7 +698,7 @@ int PHActsTrkProp::getNodes(PHCompositeNode* topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-  m_hitIdClusKey = findNode::getClass<std::map<TrkrDefs::cluskey, unsigned int>>(topNode, "HitIDClusIDActsMap");
+  m_hitIdClusKey = findNode::getClass<CluskeyBimap>(topNode, "HitIDClusIDActsMap");
   if(!m_hitIdClusKey)
     {
       std::cout << PHWHERE << "ERROR: Can't find HitIdClusIdActsMap. Exiting."

--- a/offline/packages/trackreco/PHActsTrkProp.h
+++ b/offline/packages/trackreco/PHActsTrkProp.h
@@ -24,6 +24,8 @@
 
 #include <ActsExamples/TrackFinding/TrkrClusterFindingAlgorithm.hpp>
 
+#include <boost/bimap.hpp>
+
 #include <memory>
 #include <string>
 #include <map>
@@ -61,6 +63,8 @@ using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
                                       Acts::BoundIndices,
                                       Acts::eBoundLoc0,
                                       Acts::eBoundLoc1>;
+
+typedef boost::bimap<TrkrDefs::cluskey, unsigned int> CluskeyBimap;
 
 class PHActsTrkProp : public PHTrackPropagating
 {
@@ -155,7 +159,7 @@ class PHActsTrkProp : public PHTrackPropagating
     std::map<const size_t, const unsigned int>> *m_actsTrackKeyMap;
 
   /// Map of cluster keys to hit ids, for identifying clusters belonging to track
-  std::map<TrkrDefs::cluskey, unsigned int> *m_hitIdClusKey;
+  CluskeyBimap *m_hitIdClusKey;
 
   /// Acts source links created by PHActsSourceLinks
   /// SourceLink is defined as TrkrClusterSourceLink elsewhere


### PR DESCRIPTION
This PR changes the hit ID to cluster key map to a `boost::bimap` which is a bijective map that contains the information to go from key to value and vice versa. Since the hit ID is unique to a given clusterkey, this does not change any of the Acts `SourceLink` look up. 

Changing this to a bijective map improves the look up speed of the hit ID to cluster key by an order of magnitude when copying the Acts track state data back to the SvtxTrack object. One can now run the entire Acts track fitting module with the Svtx track update without a major order of magnitude speed loss in the module execution.