### PR TITLE
Truth clustering module

### DIFF
--- a/offline/packages/PHTpcTracker/PHTpcTracker.cc
+++ b/offline/packages/PHTpcTracker/PHTpcTracker.cc
@@ -127,15 +127,15 @@ int PHTpcTracker::Process(PHCompositeNode* topNode)
   }
 
   // ----- Seed finding -----
-  TrkrClusterContainer* cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  //TrkrClusterContainer* cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   std::vector<kdfinder::TrackCandidate<double>*> candidates;
-  candidates = mSeedFinder->findSeeds(cluster_map, mB);
+  candidates = mSeedFinder->findSeeds(_cluster_map, mB);
   LOG_INFO("tracking.PHTpcTracker.process_event") << "SeedFinder produced " << candidates.size() << " track seeds";
 
   // ----- Track Following -----
-  mLookup->init(cluster_map);
+  mLookup->init(_cluster_map);
   std::vector<PHGenFit2::Track*> gtracks;
-  gtracks = mTrackFollower->followTracks(cluster_map, candidates, mField, mLookup, mFitter);
+  gtracks = mTrackFollower->followTracks(_cluster_map, candidates, mField, mLookup, mFitter);
   LOG_INFO("tracking.PHTpcTracker.process_event") << "TrackFollower reconstructed " << gtracks.size() << " tracks";
   // write tracks to fun4all server
   //  cout<<  gtracks[1]->get_vertex_id() << endl;
@@ -179,6 +179,11 @@ int PHTpcTracker::Process(PHCompositeNode* topNode)
       svtx_track->insert_cluster_key(cluster_key);
     }
 
+    if(Verbosity() > 0) 
+      {
+	std::cout << PHWHERE << " track identify: " << std::endl;
+	svtx_track->identify();
+      }
     _track_map->insert(svtx_track.get());
   }
 

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -59,6 +59,7 @@ pkginclude_HEADERS = \
   PHTrackSeeding.h \
   PHTrackFitting.h \
   PHTrackSetMerging.h \
+  PHTruthClustering.h \
   PHTruthTrackSeeding.h \
   PHTruthSiliconAssociation.h \
   PHTruthVertexing.h \
@@ -141,6 +142,7 @@ libtrack_reco_la_SOURCES = \
   PHTrackPropagating.cc \
   PHTrackFitting.cc \
   PH3DVertexing.cc \
+  PHTruthClustering.cc \
   PHTruthVertexing.cc \
   PHSiliconTpcTrackMatching.cc \
   PHMicromegasTpcTrackMatching.cc \

--- a/offline/packages/trackreco/PHActsSourceLinks.cc
+++ b/offline/packages/trackreco/PHActsSourceLinks.cc
@@ -204,7 +204,7 @@ int PHActsSourceLinks::process_event(PHCompositeNode *topNode)
 
     if (Verbosity() > 1)
     {
-      if(layer > 54)
+      //if(layer > 54)
 	std::cout << "Layer " << layer
 		  << " create measurement for trkrid " << trkrId
 		  << " cluskey " << clusKey
@@ -300,15 +300,24 @@ Surface PHActsSourceLinks::getTpcLocalCoords(Acts::Vector2D &local2D,
   /// a given readout module
   Surface surface = getTpcSurfaceFromCoords(tpcHitSetKey,
 					    worldVec);
-
   /// If surface can't be found (shouldn't happen) return nullptr and skip this cluster
   if(!surface)
     {
       std::cout << PHWHERE
 		<< "Failed to find associated surface element - should be impossible! Skipping measurement."
 		<< std::endl;
+      std::cout << "  tpcHitSetKey " << tpcHitSetKey << " layer " << layer << " sector " << sectorId
+		<< " worldVec[0] " << worldVec[0] << " worldVec[1] " << worldVec [1] << " worldVec[2] " << worldVec[2] << std::endl;
       return nullptr;
     }
+  /*
+  std::cout << PHWHERE
+	    << "Found associated surface element"
+	    << std::endl;
+  std::cout << "  tpcHitSetKey " << tpcHitSetKey << " layer " << layer << " sector " << sectorId
+	    << " worldVec[0] " << worldVec[0] << " worldVec[1] " << worldVec [1] << " worldVec[2] " << worldVec[2] << std::endl;
+  */
+
   if(Verbosity() > 10)
     {
       std::cout << "Stream of found TPC surface: " << std::endl;
@@ -929,7 +938,11 @@ int PHActsSourceLinks::getNodes(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-  m_clusterMap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  if(_use_truth_clusters)
+    m_clusterMap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER_TRUTH");
+  else
+    m_clusterMap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+
   if (!m_clusterMap)
   {
     std::cout << PHWHERE

--- a/offline/packages/trackreco/PHActsSourceLinks.h
+++ b/offline/packages/trackreco/PHActsSourceLinks.h
@@ -78,6 +78,7 @@ class PHActsSourceLinks : public SubsysReco
   void setMagFieldRescale(double magFieldRescale)
     {m_magFieldRescale = magFieldRescale;}
 
+  void SetUseTruthClusters(bool setit){_use_truth_clusters = setit;}
  
  private:
   /**
@@ -153,6 +154,7 @@ class PHActsSourceLinks : public SubsysReco
    */
 
   bool m_useVertexMeasurement = false;
+  bool _use_truth_clusters = false;
 
   /// SvtxCluster node
   TrkrClusterContainer *m_clusterMap = nullptr;

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -186,7 +186,6 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
       const TrkrDefs::cluskey key = *clusIter;
 
       const unsigned int hitId = m_hitIdClusKey->find(key)->second;
-
       trackSourceLinks.push_back(m_sourceLinks->find(hitId)->second);
       
       if (Verbosity() > 0)

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -187,14 +187,23 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 
       const unsigned int hitId = m_hitIdClusKey->left.find(key)->second;
 
+      if(Verbosity() > 0)
+	{	  
+	  unsigned int lay = TrkrDefs::getLayer(key);
+	  
+	  std::cout << PHWHERE << " layer " << lay << " cluskey " << key
+		    << " has hitid " << hitId
+		    << std::endl;
+	}
+
       trackSourceLinks.push_back(m_sourceLinks->find(hitId)->second);
       
-      if (Verbosity() > 0)
+      if (Verbosity() > 3)
 	{
 	  std::cout << PHWHERE << " lookup gave hitid " << hitId 
 		    << " for cluskey " << key << std::endl; 
 	  unsigned int layer = TrkrDefs::getLayer(key);
-	  if(layer > 54)
+	  if(Verbosity() > 3)
 	    {	  
 	      std::cout << std::endl << PHWHERE << std::endl << " layer " << layer << " cluskey " << key
 			<< " has hitid " << hitId
@@ -206,7 +215,7 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 	}
     }
     
-    if (Verbosity() > 0)
+    if (Verbosity() > 3)
       {
 	for (unsigned int i = 0; i < trackSourceLinks.size(); ++i)
       {

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -469,8 +469,7 @@ int PHCASeeding::Process(PHCompositeNode *topNode)
   int numberofseeds = 0;
   numberofseeds += FindSeedsWithMerger(NT,t_seed);
   t_seed->stop();
-  //if(Verbosity()>0) 
-    cout << "number of seeds " << numberofseeds << endl;
+  if(Verbosity()>0)  cout << "number of seeds " << numberofseeds << endl;
   if(Verbosity()>0) cout << "Kalman filtering time: " << t_seed->get_accumulated_time() / 1000 << " s" << endl;
 //  fpara.cd();
 //  NT->Write();
@@ -541,8 +540,7 @@ int PHCASeeding::FindSeedsWithMerger(TNtuple* NT,PHTimer* t_seed)
   pair<vector<unordered_set<keylink>>,vector<unordered_set<keylink>>> links = CreateLinks(fromPointKey(allClusters),t_seed);
   vector<vector<keylink>> biLinks = FindBiLinks(links.first,links.second,t_seed);
   vector<keylist> trackSeedKeyLists = FollowBiLinks(biLinks,t_seed);
-  if(Verbosity()>0) 
-    std::cout << "seeds before merge: " << trackSeedKeyLists.size() << "\n";
+  if(Verbosity()>0)  std::cout << "seeds before merge: " << trackSeedKeyLists.size() << "\n";
   vector<keylist> mergedSeedKeyLists = MergeSeeds(trackSeedKeyLists,t_seed);
   if(Verbosity()>0) std::cout << "seeds after merge round 1: " << mergedSeedKeyLists.size() << "\n";
   mergedSeedKeyLists = MergeSeeds(mergedSeedKeyLists,t_seed);

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -346,17 +346,21 @@ void PHCASeeding::FillTree()
     TrkrDefs::cluskey ckey = iter->first;
     unsigned int layer = TrkrDefs::getLayer(ckey);
     if (layer < _start_layer || layer >= _end_layer) continue;
-    
-    TrkrClusterHitAssoc::ConstRange hitrange = _cluster_hit_map->getHits(ckey);
-    unsigned int nhits = std::distance(hitrange.first,hitrange.second);
-    if(nhits<_min_nhits_per_cluster) continue;
-    TVector3 vec(cluster->getPosition(0)-_vertex->get_x(), cluster->getPosition(1)-_vertex->get_y(), cluster->getPosition(2)-_vertex->get_z());
 
+    if(!_use_truth_clusters)
+      {
+	TrkrClusterHitAssoc::ConstRange hitrange = _cluster_hit_map->getHits(ckey);
+	unsigned int nhits = std::distance(hitrange.first,hitrange.second);
+	if(nhits<_min_nhits_per_cluster) continue;
+      }
+
+    TVector3 vec(cluster->getPosition(0)-_vertex->get_x(), cluster->getPosition(1)-_vertex->get_y(), cluster->getPosition(2)-_vertex->get_z());
     double clus_phi = vec.Phi();
     if(clus_phi<0) clus_phi = 2*M_PI + clus_phi;
     //clus_phi -= 2 * M_PI * floor(clus_phi / (2 * M_PI));
     double clus_eta = vec.Eta();
     double clus_l = layer;  // _radii_all[layer];
+    if(Verbosity() > 0) std::cout << "Found cluster " << ckey << " in layer " << layer << std::endl;
 
     vector<pointKey> testduplicate;
     QueryTree(_rtree, clus_phi - 0.00001, clus_eta - 0.00001, layer - 0.5, clus_phi + 0.00001, clus_eta + 0.00001, layer + 0.5, testduplicate);

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -366,6 +366,19 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
 int PHSiliconTruthTrackSeeding::GetNodes(PHCompositeNode* topNode)
 {
+  /*
+  // If the _use_truth_clusters flag is set, the cluster map now points to the truth clusters
+  // in this module we want to use the reco silicon clusters instead, so we move the pointer
+  if(_use_truth_clusters)
+    _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+
+  if (!_cluster_map)
+  {
+    cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  */
+
   _g4truth_container = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
   if (!_g4truth_container)
   {

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -97,7 +97,7 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
     if (Verbosity() >= 3)
     {
-      cout <<__PRETTY_FUNCTION__<<" process cluster ";
+      cout << PHWHERE <<" process cluster ";
       cluster->identify();
     }
 
@@ -109,6 +109,11 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
       // TrkrHitTruthAssoc uses a map with (hitsetkey, std::pair(hitkey, g4hitkey)) - get the hitsetkey from the cluskey
       TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
 
+      if (Verbosity() >= 3)
+	{
+	  cout << PHWHERE <<"      --- process hit with hitkey  " << hitkey << "  hitsetkey " << hitsetkey  << std::endl;
+	}
+
       // get all of the g4hits for this hitkey
       std::multimap<TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> > temp_map;
       hittruthassoc->getG4Hits(hitsetkey, hitkey, temp_map);  // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
@@ -116,6 +121,12 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
       {
         // extract the g4 hit key here and add the hits to the set
         PHG4HitDefs::keytype g4hitkey = htiter->second.second;
+
+	if (Verbosity() >= 3)
+	  {
+	    cout << PHWHERE <<"           --- process g4hit with key  " << g4hitkey << std::endl;
+	  }
+
         PHG4Hit* phg4hit = nullptr;
         switch( trkrid )
         {
@@ -142,7 +153,7 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
           PHG4Particle* particle = _g4truth_container->GetParticle(particle_id);
           if (!particle)
           {
-            cout <<__PRETTY_FUNCTION__<<" - validity check failed: missing truth particle with ID of "<<particle_id<<". Exiting..."<<endl;
+            cout << PHWHERE <<" - validity check failed: missing truth particle with ID of "<<particle_id<<". Exiting..."<<endl;
             exit(1);
           }
           const double monentum2 =
@@ -155,7 +166,7 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
           if (Verbosity() >= 10)
           {
-            cout <<__PRETTY_FUNCTION__<<" check momentum for g4particle "<<particle_id<<" -> cluster "<<cluskey
+            cout << PHWHERE <<"             --- check momentum for g4particle "<<particle_id<<" -> cluster "<<cluskey
                 <<" = "<<sqrt(monentum2)<<endl;;
             particle->identify();
           }
@@ -164,7 +175,7 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
           {
             if (Verbosity() >= 3)
             {
-              cout <<__PRETTY_FUNCTION__<<" ignore low momentum g4particle "<<particle_id<<" -> cluster "<<cluskey<<endl;;
+              cout << PHWHERE <<" ignore low momentum g4particle "<<particle_id<<" -> cluster "<<cluskey<<endl;;
               particle->identify();
             }
             continue;
@@ -176,11 +187,12 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
         if (it != m_trackID_clusters.end())
         {
+	  // the clusters are stored in a set, no need to check if it is in there already
           it->second.insert(cluster);
           if (Verbosity() >= 3)
           {
-            cout <<__PRETTY_FUNCTION__<<" append particle"<<particle_id<<" -> cluster "<<cluskey<<endl;;
-            cluster->identify();
+            cout << PHWHERE <<"                  --- appended to g4particle"<<particle_id<<" new cluster "<<cluskey<<endl;;
+            //cluster->identify();
           }
         }
         else
@@ -192,8 +204,8 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
           if (Verbosity() >= 3)
           {
-            cout <<__PRETTY_FUNCTION__<<" new g4particle "<<particle_id<<" -> cluster "<<cluskey<<endl;;
-            cluster->identify();
+            cout << PHWHERE <<"                  --- added new g4particle "<<particle_id<<" and inserted cluster "<<cluskey<<endl;;
+            //cluster->identify();
           }
 
         }

--- a/offline/packages/trackreco/PHTrackPropagating.cc
+++ b/offline/packages/trackreco/PHTrackPropagating.cc
@@ -57,9 +57,11 @@ int PHTrackPropagating::GetNodes(PHCompositeNode* topNode)
   // Get Objects off of the Node Tree
   //---------------------------------
 
+  if(_use_truth_clusters)
+    _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER_TRUTH");
+  else
+    _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
 
-  //_cluster_map = findNode::getClass<SvtxClusterMap>(topNode, "SvtxClusterMap");
-  _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if (!_cluster_map)
   {
     cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << endl;

--- a/offline/packages/trackreco/PHTrackPropagating.h
+++ b/offline/packages/trackreco/PHTrackPropagating.h
@@ -35,6 +35,7 @@ class PHTrackPropagating : public SubsysReco
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
   void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
+  void SetUseTruthClusters(bool setit){_use_truth_clusters = setit;}
 
  protected:
   /// setup interface for trackers, called in InitRun, setup things like pointers to nodes.
@@ -56,6 +57,8 @@ class PHTrackPropagating : public SubsysReco
   AssocInfoContainer *_assoc_container;
 
   std::string _track_map_name;
+
+  bool _use_truth_clusters = false;
 
  private:
   /// fetch node pointers

--- a/offline/packages/trackreco/PHTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTrackSeeding.cc
@@ -113,8 +113,11 @@ int PHTrackSeeding::GetNodes(PHCompositeNode* topNode)
   //---------------------------------
   // Get Objects off of the Node Tree
   //---------------------------------
+  if(_use_truth_clusters)
+    _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER_TRUTH");
+  else
+    _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
 
-  _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if (!_cluster_map)
   {
     cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << endl;

--- a/offline/packages/trackreco/PHTrackSeeding.h
+++ b/offline/packages/trackreco/PHTrackSeeding.h
@@ -37,10 +37,7 @@ class PHTrackSeeding : public SubsysReco
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
   void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
-
-  //virtual const std::set<unsigned int>& get_seeding_layers() const = 0;
-
-  //virtual void set_seeding_layers(const unsigned int a[], const unsigned int n) = 0;
+  void SetUseTruthClusters(bool setit){_use_truth_clusters = setit;}
 
  protected:
   /// setup interface for trackers, called in InitRun, setup things like pointers to nodes.
@@ -62,7 +59,10 @@ class PHTrackSeeding : public SubsysReco
 
   std::string _track_map_name = "SvtxTrackMap";
 
+  bool _use_truth_clusters = false;
+
  private:
+
   /// create new node output pointers
   int CreateNodes(PHCompositeNode *topNode);
 

--- a/offline/packages/trackreco/PHTruthClustering.cc
+++ b/offline/packages/trackreco/PHTruthClustering.cc
@@ -1,0 +1,929 @@
+#include "PHTruthClustering.h"
+
+#include <trackbase_historic/SvtxVertexMap.h>
+#include <trackbase_historic/SvtxVertex.h>     // for SvtxVertex
+#include <trackbase_historic/SvtxVertex_v1.h>
+
+
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
+#include <trackbase/TrkrClusterv1.h>
+#include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
+#include <trackbase/TrkrHit.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContainer.h>
+
+#include <tpc/TpcDefs.h>
+#include <intt/InttDefs.h>
+#include <mvtx/MvtxDefs.h>
+#include <micromegas/MicromegasDefs.h>
+
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4VtxPoint.h>
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
+
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderGeom.h>               // for PHG4CylinderGeom
+#include <g4detectors/PHG4CylinderGeomContainer.h>
+
+#include <mvtx/CylinderGeom_Mvtx.h>
+#include <intt/CylinderGeomIntt.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>                         // for PHIODataNode
+#include <phool/PHNode.h>                               // for PHNode
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>                             // for PHObject
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
+#include <phool/PHRandomSeed.h>
+#include <phool/getClass.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+// gsl
+#include <gsl/gsl_randist.h>
+#include <gsl/gsl_rng.h>
+
+#include <TVector3.h>
+
+#include <iostream>                            // for operator<<, basic_ostream
+#include <set>                                 // for _Rb_tree_iterator, set
+#include <utility>                             // for pair
+
+class PHCompositeNode;
+
+using namespace std;
+
+PHTruthClustering::PHTruthClustering(const std::string& name)
+  : SubsysReco(name)
+{
+}
+
+PHTruthClustering::~PHTruthClustering() 
+{
+
+}
+
+int PHTruthClustering::InitRun(PHCompositeNode* topNode)
+{
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHTruthClustering::process_event(PHCompositeNode* topNode)
+{
+  if (Verbosity() > 0) 
+    cout << "Filling truth cluster node " << endl;
+
+  // get node for writing truth clusters
+  TrkrClusterContainer *m_clusterlist = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER_TRUTH");
+  if (!m_clusterlist)
+  {
+    cout << PHWHERE << " ERROR: Can't find TRKR_CLUSTER_TRUTH" << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  
+  PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");      
+  PHG4TruthInfoContainer::ConstRange range = truthinfo->GetParticleRange();
+  for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
+       iter != range.second;
+       ++iter)
+    {
+      PHG4Particle* g4particle = iter->second;
+      
+      float gtrackID = g4particle->get_track_id();
+      float gflavor = g4particle->get_pid();	  
+
+      int gembed = 0;
+      bool is_primary = false;
+      if (g4particle->get_parent_id() == 0)
+	{
+	  // primary particle
+	  is_primary = true;
+	  gembed = truthinfo->isEmbeded(g4particle->get_track_id());
+	}
+      else
+	{
+	  PHG4Particle* primary = truthinfo->GetPrimaryParticle(g4particle->get_primary_id());
+	  gembed = truthinfo->isEmbeded(primary->get_track_id());
+	}
+      
+      if(Verbosity() > 0)
+	cout << PHWHERE << " PHG4Particle ID " << gtrackID << " gflavor " << gflavor << " is_primary " << is_primary << " gembed " << gembed << endl;
+
+      // Get the truth clusters from this particle
+      std::map<unsigned int, TrkrCluster* > truth_clusters =  all_truth_clusters(g4particle);
+
+      // output the results
+      for ( auto it = truth_clusters.begin(); it != truth_clusters.end(); ++it  )
+	{
+	  unsigned int layer = it->first;
+	  TrkrCluster *gclus = it->second;
+	  
+	  float gx = gclus->getX();
+	  float gy = gclus->getY();
+	  float gz = gclus->getZ();
+	  float gedep = gclus->getError(0,0);
+	  float ng4hits = gclus->getAdc();
+	  
+	  TVector3 gpos(gx, gy, gz);
+	  float gr = sqrt(gx*gx+gy*gy);
+	  float gphi = gpos.Phi();
+	  float geta = gpos.Eta();
+	  
+	  float gphisize = gclus->getSize(1,1);
+	  float gzsize = gclus->getSize(2,2);
+
+	  TrkrDefs::cluskey ckey = gclus->getClusKey();		  
+	  if(Verbosity() > 0)
+	    {
+	      std::cout << PHWHERE << "  ****   truth: layer " << layer << "  truth cluster key " << ckey << " ng4hits " << ng4hits << std::endl;
+	      std::cout << " gr " << gr << " gx " << gx << " gy " << gy << " gz " << gz 
+			<< " gphi " << gphi << " geta " << geta << " gedep " << gedep << " gphisize " << gphisize << " gzsize " << gzsize << endl;
+	    }
+
+	  // add the filled out cluster to the truth cluster node
+	  TrkrClusterContainer::ConstIterator iter = m_clusterlist->addCluster(gclus);
+	  if(iter->first != ckey)
+	    std::cout << PHWHERE << " -------  Problem:  ckey = " << ckey<< " returned key " << iter->first << std::endl;
+	}
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+std::map<unsigned int, TrkrCluster* > PHTruthClustering::all_truth_clusters(PHG4Particle* particle)
+{
+  if(Verbosity() > 0)
+    cout << PHWHERE << " Truth clustering for particle " << particle->get_track_id() << endl;;
+
+  // get all g4hits for this particle
+  std::set<PHG4Hit*> g4hits = all_truth_hits(particle);
+	  
+  float ng4hits = g4hits.size();
+  if(ng4hits == 0) 
+    return std::map<unsigned int, TrkrCluster* >();
+
+  // container for storing truth clusters
+  //std::map<unsigned int, TrkrCluster*> truth_clusters;
+  std::map<unsigned int, TrkrCluster*> truth_clusters;
+
+  // convert truth hits for this particle to truth clusters in each layer
+  // loop over layers
+  unsigned int layer;
+  for(layer = 0; layer < _nlayers_maps + _nlayers_intt + _nlayers_tpc +_nlayers_mms; ++layer)
+    {
+      float gx = NAN;
+      float gy = NAN;
+      float gz = NAN;
+      float gt = NAN;
+      float gedep = NAN;
+      
+      std::vector<PHG4Hit*> contributing_hits;
+      std::vector<double> contributing_hits_energy;
+      std::vector<std::vector<double>> contributing_hits_entry;
+      std::vector<std::vector<double>> contributing_hits_exit;
+      LayerClusterG4Hits(g4hits, contributing_hits, contributing_hits_energy, contributing_hits_entry, contributing_hits_exit, layer, gx, gy, gz, gt, gedep);
+      if(!(gedep > 0)) continue;
+  
+      // we have the cluster in this layer from this truth particle
+      // add the cluster to a TrkrCluster object
+      TrkrDefs::cluskey ckey;
+      if(layer >= _nlayers_maps + _nlayers_intt && layer < _nlayers_maps + _nlayers_intt + _nlayers_tpc)  // in TPC
+	{      
+	  unsigned int side = 0;
+	  if(gz > 0) side = 1;	  
+	  // need dummy sector here
+	  unsigned int sector = 0;
+	  ckey = TpcDefs::genClusKey(layer, sector, side, iclus);
+	}
+      else if(layer < _nlayers_maps)  // in MVTX
+	{
+	  unsigned int stave = 0;
+	  unsigned int chip = 0;
+	  ckey = MvtxDefs::genClusKey(layer, stave, chip, iclus);
+	}
+      else if(layer >= _nlayers_maps && layer < _nlayers_maps  + _nlayers_intt)  // in INTT
+	{
+	  // dummy ladder and phi ID
+	  unsigned int ladderzid = 0;
+	  unsigned int ladderphiid = 0;
+	  ckey = InttDefs::genClusKey(layer, ladderzid, ladderphiid,iclus); 
+	}
+      else if(layer >= _nlayers_maps + _nlayers_intt + _nlayers_tpc)    // in MICROMEGAS
+	{
+	  unsigned int tile = 0;
+	  MicromegasDefs::SegmentationType segtype;
+	  segtype  =  MicromegasDefs::SegmentationType::SEGMENTATION_PHI;
+	  TrkrDefs::hitsetkey hkey = MicromegasDefs::genHitSetKey(layer, segtype, tile);
+  	  ckey = MicromegasDefs::genClusterKey(hkey, iclus);
+	}
+      else
+	{
+	  std::cout << PHWHERE << "Bad layer number: " << layer << std::endl;
+	  continue;
+	}
+      
+      TrkrClusterv1 *clus(new TrkrClusterv1());
+      clus->setClusKey(ckey);
+      iclus++;
+
+      clus->setAdc(contributing_hits.size());
+      clus->setPosition(0, gx);
+      clus->setPosition(1, gy);
+      clus->setPosition(2, gz);
+      clus->setGlobal();
+
+      /*
+      // record which g4hits contribute to this truth cluster
+      for(unsigned int i=0; i< contributing_hits.size(); ++i)
+	{
+	  _truth_cluster_truth_hit_map.insert(make_pair(ckey,contributing_hits[i]));      
+	}
+      */
+
+      // Estimate the size of the truth cluster
+      float g4phisize = NAN;
+      float g4zsize = NAN;
+      G4ClusterSize(layer, contributing_hits_entry, contributing_hits_exit, g4phisize, g4zsize);
+
+      for(int i1=0;i1<3;++i1)
+	for(int i2=0;i2<3;++i2)
+	{
+	  clus->setSize(i1, i2, 0.0);
+	  clus->setError(i1, i2, 0.0);
+	}
+      clus->setError(0,0,gedep);  // stores truth energy
+      clus->setSize(1, 1, g4phisize);
+      clus->setSize(2, 2, g4zsize);
+
+      // make an estimate of the errors
+      // We expect roughly 150 microns in r-phi and 700 microns in z
+      // we have to rotate the errors into (x,y,z) coords 
+      clus->setError(1, 1, g4phisize/sqrt(12));
+      clus->setError(2, 2, g4zsize/sqrt(12.0));
+
+      truth_clusters.insert(make_pair(layer, clus));
+
+    }  // end loop over layers for this particle
+
+  return truth_clusters;
+}
+
+void PHTruthClustering::LayerClusterG4Hits(std::set<PHG4Hit*> truth_hits, std::vector<PHG4Hit*> &contributing_hits, std::vector<double> &contributing_hits_energy, std::vector<std::vector<double>> &contributing_hits_entry, std::vector<std::vector<double>> &contributing_hits_exit, float layer, float &x, float &y, float &z,  float &t, float &e)
+{
+  bool use_geo = true;
+
+  // Given a set of g4hits, cluster them within a given layer of the TPC
+
+  float gx = 0.0;
+  float gy = 0.0;
+  float gz = 0.0;
+  float gr = 0.0;
+  float gt = 0.0;
+  float gwt = 0.0;
+
+  if (layer >= _nlayers_maps + _nlayers_intt && layer < _nlayers_maps + _nlayers_intt + _nlayers_tpc)   // in TPC
+    {
+      //cout << "layer = " << layer << " _nlayers_maps " << _nlayers_maps << " _nlayers_intt " << _nlayers_intt << endl;
+
+      // This calculates the truth cluster position for the TPC from all of the contributing g4hits from a g4particle, typically 2-4 for the TPC
+      // Complicated, since only the part of the energy that is collected within a layer contributes to the position
+      //===============================================================================
+      
+      PHG4CylinderCellGeom* GeoLayer = _tpc_geom_container->GetLayerCellGeom(layer);
+      // get layer boundaries here for later use
+      // radii of layer boundaries
+      float rbin = GeoLayer->get_radius() - GeoLayer->get_thickness() / 2.0;
+      float rbout = GeoLayer->get_radius() + GeoLayer->get_thickness() / 2.0;
+
+      if(Verbosity() > 0)
+	cout << " TruthEval::LayerCluster hits for layer  " << layer << " with rbin " << rbin << " rbout " << rbout << endl;  
+
+      // we do not assume that the truth hits know what layer they are in            
+      for (std::set<PHG4Hit*>::iterator iter = truth_hits.begin();
+	   iter != truth_hits.end();
+	   ++iter)
+	{
+	  
+	  PHG4Hit* this_g4hit = *iter;
+	  float rbegin = sqrt(this_g4hit->get_x(0) * this_g4hit->get_x(0) + this_g4hit->get_y(0) * this_g4hit->get_y(0));
+	  float rend = sqrt(this_g4hit->get_x(1) * this_g4hit->get_x(1) + this_g4hit->get_y(1) * this_g4hit->get_y(1));
+	  //cout << " Eval: g4hit " << this_g4hit->get_hit_id() <<  " layer " << layer << " rbegin " << rbegin << " rend " << rend << endl;
+	  
+	  // make sure the entry point is at lower radius
+	  float xl[2];
+	  float yl[2];
+	  float zl[2];
+	  
+	  if (rbegin < rend)
+	    {
+	      xl[0] = this_g4hit->get_x(0);
+	      yl[0] = this_g4hit->get_y(0);
+	      zl[0] = this_g4hit->get_z(0);
+	      xl[1] = this_g4hit->get_x(1);
+	      yl[1] = this_g4hit->get_y(1);
+	      zl[1] = this_g4hit->get_z(1);
+	    }
+	  else
+	    {
+	      xl[0] = this_g4hit->get_x(1);
+	      yl[0] = this_g4hit->get_y(1);
+	      zl[0] = this_g4hit->get_z(1);
+	      xl[1] = this_g4hit->get_x(0);
+	      yl[1] = this_g4hit->get_y(0);
+	      zl[1] = this_g4hit->get_z(0);
+	      swap(rbegin, rend);
+	      //cout << "swapped in and out " << endl;
+	    }
+	  
+	  // check that the g4hit is not completely outside the cluster layer. Just skip this g4hit if it is
+	  if (rbegin < rbin && rend < rbin)
+	    continue;
+	  if (rbegin > rbout && rend > rbout)
+	    continue;
+
+
+	  if(Verbosity() > 0)
+	    {
+	      cout << "     keep g4hit with rbegin " << rbegin << " rend " << rend  
+		   << "         xbegin " <<  xl[0] << " xend " << xl[1]
+		   << " ybegin " << yl[0] << " yend " << yl[1]
+		   << " zbegin " << zl[0] << " zend " << zl[1]
+		   << endl;
+	    }
+
+
+	  float xin = xl[0];
+	  float yin = yl[0];
+	  float zin = zl[0];
+	  float xout = xl[1];
+	  float yout = yl[1];
+	  float zout = zl[1];
+	  
+	  float t = NAN;
+	  
+	  if (rbegin < rbin)
+	    {
+	      // line segment begins before boundary, find where it crosses
+	      t = line_circle_intersection(xl, yl, zl, rbin);
+	      if (t > 0)
+		{
+		  xin = xl[0] + t * (xl[1] - xl[0]);
+		  yin = yl[0] + t * (yl[1] - yl[0]);
+		  zin = zl[0] + t * (zl[1] - zl[0]);
+		}
+	    }
+	  
+	  if (rend > rbout)
+	    {
+	      // line segment ends after boundary, find where it crosses
+	      t = line_circle_intersection(xl, yl, zl, rbout);
+	      if (t > 0)
+		{
+		  xout = xl[0] + t * (xl[1] - xl[0]);
+		  yout = yl[0] + t * (yl[1] - yl[0]);
+		  zout = zl[0] + t * (zl[1] - zl[0]);
+		}
+	    }
+
+	  double rin = sqrt(xin*xin + yin*yin);
+	  double rout = sqrt(xout*xout + yout*yout);
+
+	  // we want only the fraction of edep inside the layer
+	  double efrac =  this_g4hit->get_edep() * (rout - rin) / (rend - rbegin);
+	  gx += (xin + xout) * 0.5 * efrac;
+	  gy += (yin + yout) * 0.5 * efrac;
+	  gz += (zin + zout) * 0.5 * efrac;
+	  gt += this_g4hit->get_avg_t() * efrac;
+	  gr += (rin + rout) * 0.5 * efrac;
+	  gwt += efrac;
+
+	  if(Verbosity() > 0)
+	    {
+	      cout << "      rin  " << rin << " rout " << rout 
+		   << " xin " << xin << " xout " << xout << " yin " << yin << " yout " << yout << " zin " << zin << " zout " << zout 
+		   << " edep " << this_g4hit->get_edep() 
+		   << " this_edep " <<  efrac << endl;
+	      cout << "              xavge " << (xin+xout) * 0.5 << " yavge " << (yin+yout) * 0.5 << " zavge " << (zin+zout) * 0.5 << " ravge " << (rin+rout) * 0.5
+		   << endl;
+	    }
+
+	  // Capture entry and exit points
+	  std::vector<double> entry_loc;
+	  entry_loc.push_back(xin);
+	  entry_loc.push_back(yin);
+	  entry_loc.push_back(zin);
+	  std::vector<double> exit_loc;
+	  exit_loc.push_back(xout);
+	  exit_loc.push_back(yout);
+	  exit_loc.push_back(zout);
+
+	  // this_g4hit is inside the layer, add it to the vectors
+	  contributing_hits.push_back(this_g4hit);
+	  contributing_hits_energy.push_back( this_g4hit->get_edep() * (zout - zin) / (zl[1] - zl[0]) );
+	  contributing_hits_entry.push_back(entry_loc);
+	  contributing_hits_exit.push_back(exit_loc);
+
+	}  // loop over contributing hits
+
+      if(gwt == 0)
+	{
+	  e = gwt;	  
+	  return;  // will be discarded 
+	}
+
+      gx /= gwt;
+      gy /= gwt;
+      gz /= gwt;
+      gr = (rbin + rbout) * 0.5;
+      gt /= gwt;
+
+      if(Verbosity() > 0)
+	{
+	  cout << " weighted means:   gx " << gx << " gy " << gy << " gz " << gz << " gr " << gr << " e " << gwt << endl;
+	}
+
+      if(use_geo)
+	{
+	  // The energy weighted values above have significant scatter due to fluctuations in the energy deposit from Geant
+	  // Calculate the geometric mean positions instead
+	  float rentry = 999.0;
+	  float xentry = 999.0;
+	  float yentry = 999.0;
+	  float zentry = 999.0;
+	  float rexit = - 999.0;
+	  float xexit = -999.0;
+	  float yexit = -999.0;
+	  float zexit = -999.0;
+	  
+	  for(unsigned int ientry = 0; ientry < contributing_hits_entry.size(); ++ientry)
+	    {
+	      float tmpx = contributing_hits_entry[ientry][0];
+	      float tmpy = contributing_hits_entry[ientry][1];
+	      float tmpr = sqrt(tmpx*tmpx + tmpy*tmpy);
+	      
+	      if(tmpr < rentry)
+		{
+		  rentry =  tmpr;
+		  xentry = contributing_hits_entry[ientry][0];
+		  yentry = contributing_hits_entry[ientry][1];
+		  zentry = contributing_hits_entry[ientry][2];
+		}
+	      
+	      tmpx = contributing_hits_exit[ientry][0];
+	      tmpy = contributing_hits_exit[ientry][1];
+	      tmpr = sqrt(tmpx*tmpx + tmpy*tmpy);
+	      
+	      if(tmpr > rexit)
+		{
+		  rexit =  tmpr;
+		  xexit = contributing_hits_exit[ientry][0];
+		  yexit = contributing_hits_exit[ientry][1];
+		  zexit = contributing_hits_exit[ientry][2];
+		}
+	    }
+	  
+	  float geo_r = (rentry+rexit)*0.5;
+	  float geo_x = (xentry+xexit)*0.5;
+	  float geo_y = (yentry+yexit)*0.5;
+	  float geo_z = (zentry+zexit)*0.5;
+	  
+	  if(rexit > 0)
+	    {
+	      gx = geo_x;
+	      gy = geo_y;
+	      gz = geo_z;
+	      gr = geo_r;
+	    }
+
+
+	  if(Verbosity() > 0)
+	    {
+	      cout << "      rentry  " << rentry << " rexit " << rexit 
+		   << " xentry " << xentry << " xexit " << xexit << " yentry " << yentry << " yexit " << yexit << " zentry " << zentry << " zexit " << zexit << endl;
+	      
+	      cout  << " geometric means: geo_x " << geo_x << " geo_y " << geo_y << " geo_z " << geo_z  << " geo r " << geo_r <<  " e " << gwt << endl << endl;
+	    }
+	}
+
+    }  // if TPC
+  else
+    {
+      // not TPC, one g4hit per cluster
+      for (std::set<PHG4Hit*>::iterator iter = truth_hits.begin();
+	   iter != truth_hits.end();
+	   ++iter)
+	{
+	  
+	  PHG4Hit* this_g4hit = *iter;
+
+	  if(this_g4hit->get_layer() != (unsigned int) layer) continue;
+	  
+	  gx = this_g4hit->get_avg_x();
+	  gy = this_g4hit->get_avg_y();
+	  gz = this_g4hit->get_avg_z();
+	  gt = this_g4hit->get_avg_t();
+	  gwt += this_g4hit->get_edep();
+
+	  // Capture entry and exit points
+	  std::vector<double> entry_loc;
+	  entry_loc.push_back(this_g4hit->get_x(0));
+	  entry_loc.push_back(this_g4hit->get_y(0));
+	  entry_loc.push_back(this_g4hit->get_z(0));
+	  std::vector<double> exit_loc;
+	  exit_loc.push_back(this_g4hit->get_x(1));
+	  exit_loc.push_back(this_g4hit->get_y(1));
+	  exit_loc.push_back(this_g4hit->get_z(1));
+
+	  // this_g4hit is inside the layer, add it to the vectors
+	  contributing_hits.push_back(this_g4hit);
+	  contributing_hits_energy.push_back( this_g4hit->get_edep() );
+	  contributing_hits_entry.push_back(entry_loc);
+	  contributing_hits_exit.push_back(exit_loc);
+	}
+    }  // not TPC
+
+  x = gx;
+  y = gy;
+  z = gz;
+  t = gt;
+  e = gwt;
+
+  return;
+}
+
+void PHTruthClustering::G4ClusterSize(unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry,std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize)
+{
+
+  // sort the contributing g4hits in radius
+  double inner_radius = 100.;
+  double inner_x = NAN;
+  double inner_y = NAN;
+  double inner_z = NAN;;
+
+  double outer_radius = 0.;
+  double outer_x = NAN;
+  double outer_y = NAN;
+  double outer_z = NAN;
+
+  for(unsigned int ihit=0;ihit<contributing_hits_entry.size(); ++ihit)
+    {
+      double rad1 = sqrt(pow(contributing_hits_entry[ihit][0], 2) + pow(contributing_hits_entry[ihit][1], 2));      
+      if(rad1 < inner_radius)
+	{
+	  inner_radius = rad1;
+	  inner_x = contributing_hits_entry[ihit][0];
+	  inner_y = contributing_hits_entry[ihit][1];
+	  inner_z = contributing_hits_entry[ihit][2];    
+	}
+
+      double rad2 = sqrt(pow(contributing_hits_exit[ihit][0], 2) + pow(contributing_hits_exit[ihit][1], 2));
+      if(rad2 > outer_radius)
+	{
+	  outer_radius = rad2;
+	  outer_x = contributing_hits_exit[ihit][0];
+	  outer_y = contributing_hits_exit[ihit][1];
+	  outer_z = contributing_hits_exit[ihit][2];    
+	}
+    }
+
+  double inner_phi =  atan2(inner_y, inner_x);
+  double outer_phi =  atan2(outer_y, outer_x);
+  double avge_z = (outer_z + inner_z) / 2.0;
+
+  // Now fold these with the expected diffusion and shaping widths
+  // assume spread is +/- equals this many sigmas times diffusion and shaping when extending the size
+  double sigmas = 2.0;
+
+  double radius = (inner_radius + outer_radius)/2.;
+  if(radius > 28 && radius < 80)  // TPC
+    {
+      PHG4CylinderCellGeom*layergeom = _tpc_geom_container->GetLayerCellGeom(layer);
+
+      double tpc_length = 211.0;  // cm
+      double drift_velocity = 8.0 / 1000.0;  // cm/ns
+
+      // Phi size
+      //======
+      double diffusion_trans =  0.006;  // cm/SQRT(cm)
+      double phidiffusion = diffusion_trans * sqrt(tpc_length / 2. - fabs(avge_z));
+
+      double added_smear_trans = 0.085; // cm
+      double gem_spread = 0.04;  // 400 microns
+
+      if(outer_phi < inner_phi) swap(outer_phi, inner_phi);
+
+      // convert diffusion from cm to radians
+      double g4max_phi =  outer_phi + sigmas * sqrt(  pow(phidiffusion, 2) + pow(added_smear_trans, 2) + pow(gem_spread, 2) ) / radius;
+      double g4min_phi =  inner_phi - sigmas * sqrt(  pow(phidiffusion, 2) + pow(added_smear_trans, 2) + pow(gem_spread, 2) ) / radius;
+
+      // find the bins containing these max and min z edges
+      unsigned int phibinmin = layergeom->get_phibin(g4min_phi);
+      unsigned int phibinmax = layergeom->get_phibin(g4max_phi);
+      unsigned int phibinwidth = phibinmax - phibinmin + 1;
+      g4phisize = (double) phibinwidth * layergeom->get_phistep() * layergeom->get_radius();
+
+      // Z size
+      //=====
+      double g4max_z = 0;
+      double g4min_z = 0;
+ 
+      outer_z = fabs(outer_z);
+      inner_z = fabs(inner_z);
+
+      double diffusion_long = 0.015;  // cm/SQRT(cm)
+      double zdiffusion = diffusion_long * sqrt(tpc_length / 2. - fabs(avge_z)) ;
+      double zshaping_lead = 32.0 * drift_velocity;  // ns * cm/ns = cm
+      double zshaping_tail = 48.0 * drift_velocity;
+      double added_smear_long = 0.105;  // cm
+
+      // largest z reaches gems first, make that the outer z
+      if(outer_z < inner_z) swap(outer_z, inner_z);
+      g4max_z = outer_z  + sigmas*sqrt(pow(zdiffusion,2) + pow(added_smear_long,2) + pow(zshaping_lead, 2));
+      g4min_z = inner_z  -  sigmas*sqrt(pow(zdiffusion,2) + pow(added_smear_long,2) + pow(zshaping_tail, 2));
+
+      // find the bins containing these max and min z edges
+      unsigned int binmin = layergeom->get_zbin(g4min_z);
+      unsigned int binmax = layergeom->get_zbin(g4max_z);
+      if(binmax < binmin) swap(binmax, binmin);
+      unsigned int binwidth = binmax - binmin + 1;
+
+      // multiply total number of bins that include the edges by the bin size
+      g4zsize = (double) binwidth * layergeom->get_zstep();
+    }
+  else if(radius > 5 && radius < 20)  // INTT
+    {
+      // All we have is the position and layer number
+
+      CylinderGeomIntt *layergeom = dynamic_cast<CylinderGeomIntt *>(_intt_geom_container->GetLayerGeom(layer));
+
+      // inner location
+      double world_inner[3] = {inner_x, inner_y, inner_z};
+      TVector3 world_inner_vec = {inner_x, inner_y, inner_z};
+
+      int segment_z_bin, segment_phi_bin;
+      layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_inner);
+
+      TVector3 local_inner_vec =  layergeom->get_local_from_world_coords(segment_z_bin, segment_phi_bin, world_inner_vec);
+      double yin = local_inner_vec[1];
+      double zin = local_inner_vec[2];
+      int strip_y_index, strip_z_index;
+      layergeom->find_strip_index_values(segment_z_bin, yin, zin, strip_y_index, strip_z_index);
+
+	// outer location
+      double world_outer[3] = {outer_x, outer_y, outer_z};
+      TVector3 world_outer_vec = {outer_x, outer_y, outer_z};
+
+      layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_outer);
+
+      TVector3 local_outer_vec =  layergeom->get_local_from_world_coords(segment_z_bin, segment_phi_bin, world_outer_vec);
+      double yout = local_outer_vec[1];
+      double zout = local_outer_vec[2];
+      int strip_y_index_out, strip_z_index_out;
+      layergeom->find_strip_index_values(segment_z_bin, yout, zout, strip_y_index_out, strip_z_index_out);
+ 
+      int strips = abs(strip_y_index_out - strip_y_index) + 1;
+      int cols = abs(strip_z_index_out - strip_z_index) + 1;
+
+
+      double strip_width = (double) strips * layergeom->get_strip_y_spacing(); // cm
+      double strip_length = (double) cols * layergeom->get_strip_z_spacing(); // cm
+
+      g4phisize = strip_width;
+      g4zsize = strip_length;
+
+      /*
+      if(Verbosity() > 1)
+	cout << " INTT: layer " << layer << " strips " << strips << " strip pitch " <<  layergeom->get_strip_y_spacing() << " g4phisize "<< g4phisize 
+	     << " columns " << cols << " strip_z_spacing " <<  layergeom->get_strip_z_spacing() << " g4zsize " << g4zsize << endl;
+      */
+    }
+  else if(radius > 80)  // MICROMEGAS
+    {
+      // made up for now
+      g4phisize = 300e-04;
+      g4zsize = 300e-04;
+    }
+  else  // MVTX
+    {
+      unsigned int stave, stave_outer;
+      unsigned int chip, chip_outer;
+      int row, row_outer;
+      int column, column_outer;
+
+      // add diffusion to entry and exit locations
+      double max_diffusion_radius = 25.0e-4;  // 25 microns
+      double min_diffusion_radius = 8.0e-4;  // 8 microns
+
+      CylinderGeom_Mvtx *layergeom = dynamic_cast<CylinderGeom_Mvtx *>(_mvtx_geom_container->GetLayerGeom(layer));
+
+      TVector3 world_inner = {inner_x, inner_y, inner_z};
+      std::vector<double> world_inner_vec = { world_inner[0], world_inner[1], world_inner[2] };
+      layergeom->get_sensor_indices_from_world_coords(world_inner_vec, stave, chip);
+      TVector3 local_inner = layergeom->get_local_from_world_coords(stave, chip, world_inner);
+
+      TVector3 world_outer = {outer_x, outer_y, outer_z};
+      std::vector<double> world_outer_vec = { world_outer[0], world_outer[1], world_outer[2] };
+      layergeom->get_sensor_indices_from_world_coords(world_outer_vec, stave_outer, chip_outer);
+      TVector3 local_outer = layergeom->get_local_from_world_coords(stave_outer, chip_outer, world_outer);
+
+      double diff =  max_diffusion_radius * 0.6;  // factor of 0.6 gives decent agreement with low occupancy reco clusters
+      if(local_outer[0] < local_inner[0]) 
+	diff = -diff;
+      local_outer[0] += diff;
+      local_inner[0] -= diff;
+
+      double diff_outer = min_diffusion_radius * 0.6;
+      if(local_outer[2] < local_inner[2]) 
+	diff_outer = -diff_outer;
+      local_outer[2] += diff_outer;
+      local_inner[2] -= diff_outer;
+
+      layergeom->get_pixel_from_local_coords(local_inner, row, column);
+      layergeom->get_pixel_from_local_coords(local_outer, row_outer, column_outer);
+
+      if(row_outer < row) swap(row_outer, row);
+      unsigned int rows = row_outer - row + 1;
+      g4phisize = (double) rows * layergeom->get_pixel_x();
+
+      if(column_outer < column) swap(column_outer, column);
+      unsigned int columns = column_outer - column + 1;
+      g4zsize = (double) columns * layergeom->get_pixel_z();
+
+      /*
+      if(Verbosity() > 1)
+	cout << " MVTX: layer " << layer << " rows " << rows << " pixel x " <<  layergeom->get_pixel_x() << " g4phisize "<< g4phisize 
+	     << " columns " << columns << " pixel_z " <<  layergeom->get_pixel_z() << " g4zsize " << g4zsize << endl;
+      */
+
+    }
+}
+
+std::set<PHG4Hit*> PHTruthClustering::all_truth_hits(PHG4Particle* particle)
+{
+  std::set<PHG4Hit*> truth_hits;
+
+  // loop over all the g4hits in the cylinder layers
+  if (_g4hits_svtx)
+    {
+      for (PHG4HitContainer::ConstIterator g4iter = _g4hits_svtx->getHits().first;
+	   g4iter != _g4hits_svtx->getHits().second;
+	   ++g4iter)
+	{
+	  PHG4Hit* g4hit = g4iter->second;
+	  if (g4hit->get_trkid() == particle->get_track_id())
+	    {
+	      truth_hits.insert(g4hit);
+	    }
+	}
+    }
+  
+  // loop over all the g4hits in the ladder layers
+  if (_g4hits_tracker)
+  {
+    for (PHG4HitContainer::ConstIterator g4iter = _g4hits_tracker->getHits().first;
+         g4iter != _g4hits_tracker->getHits().second;
+         ++g4iter)
+    {
+      PHG4Hit* g4hit = g4iter->second;
+      if (g4hit->get_trkid() == particle->get_track_id())
+	{
+	  truth_hits.insert(g4hit);
+	}
+    }
+  }
+
+  // loop over all the g4hits in the maps ladder layers
+  if (_g4hits_maps)
+  {
+    for (PHG4HitContainer::ConstIterator g4iter = _g4hits_maps->getHits().first;
+         g4iter != _g4hits_maps->getHits().second;
+         ++g4iter)
+    {
+      PHG4Hit* g4hit = g4iter->second;
+      if (g4hit->get_trkid() == particle->get_track_id())
+	{
+	  truth_hits.insert(g4hit);
+	}
+    }
+  }
+
+  // loop over all the g4hits in the micromegas layers
+  if (_g4hits_mms)
+  {
+    for (PHG4HitContainer::ConstIterator g4iter = _g4hits_mms->getHits().first;
+         g4iter != _g4hits_mms->getHits().second;
+         ++g4iter)
+    {
+      PHG4Hit* g4hit = g4iter->second;
+      if (g4hit->get_trkid() == particle->get_track_id())
+	{
+	  truth_hits.insert(g4hit);
+	}
+    }
+  }
+
+  return truth_hits;
+}
+
+float PHTruthClustering::line_circle_intersection(float x[], float y[], float z[], float radius)
+{
+  // parameterize the line in terms of t (distance along the line segment, from 0-1) as
+  // x = x0 + t * (x1-x0); y=y0 + t * (y1-y0); z = z0 + t * (z1-z0)
+  // parameterize the cylinder (centered at x,y = 0,0) as  x^2 + y^2 = radius^2,   then
+  // (x0 + t*(x1-z0))^2 + (y0+t*(y1-y0))^2 = radius^2
+  // (x0^2 + y0^2 - radius^2) + (2x0*(x1-x0) + 2y0*(y1-y0))*t +  ((x1-x0)^2 + (y1-y0)^2)*t^2 = 0 = C + B*t + A*t^2
+  // quadratic with:  A = (x1-x0)^2+(y1-y0)^2 ;  B = 2x0*(x1-x0) + 2y0*(y1-y0);  C = x0^2 + y0^2 - radius^2
+  // solution: t = (-B +/- sqrt(B^2 - 4*A*C)) / (2*A)
+
+  float A = (x[1] - x[0]) * (x[1] - x[0]) + (y[1] - y[0]) * (y[1] - y[0]);
+  float B = 2.0 * x[0] * (x[1] - x[0]) + 2.0 * y[0] * (y[1] - y[0]);
+  float C = x[0] * x[0] + y[0] * y[0] - radius * radius;
+  float tup = (-B + sqrt(B * B - 4.0 * A * C)) / (2.0 * A);
+  float tdn = (-B - sqrt(B * B - 4.0 * A * C)) / (2.0 * A);
+
+  // The limits are 0 and 1, but we allow a little for floating point precision
+  float t;
+  if (tdn >= -0.0e-4 && tdn <= 1.0004)
+    t = tdn;
+  else if (tup >= -0.0e-4 && tup <= 1.0004)
+    t = tup;
+  else
+  {
+    cout << PHWHERE << "   **** Oops! No valid solution for tup or tdn, tdn = " << tdn << " tup = " << tup << endl;
+    cout << "   radius " << radius << " rbegin " << sqrt(x[0] * x[0] + y[0] * y[0]) << " rend " << sqrt(x[1] * x[1] + y[1] * y[1]) << endl;
+    cout << "   x0 " << x[0] << " x1 " << x[1] << endl;
+    cout << "   y0 " << y[0] << " y1 " << y[1] << endl;
+    cout << "   z0 " << z[0] << " z1 " << z[1] << endl;
+    cout << "   A " << A << " B " << B << " C " << C << endl;
+
+    t = -1;
+  }
+
+  return t;
+}
+
+
+int PHTruthClustering::GetNodes(PHCompositeNode* topNode)
+{
+  _g4truth_container = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  if (!_g4truth_container)
+  {
+    cerr << PHWHERE << " ERROR: Can't find node G4TruthInfo" << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  _g4hits_mms = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_MICROMEGAS");
+  _g4hits_svtx = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_TPC");
+  _g4hits_tracker = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_INTT");
+  _g4hits_maps = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_MVTX");
+
+  _mms_geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS");
+  _tpc_geom_container = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  _intt_geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
+  _mvtx_geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
+
+  // Create the truth cluster node if required
+  PHNodeIterator iter(topNode);
+  // Looking for the DST node
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    cout << PHWHERE << "DST Node missing, doing nothing." << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  TrkrClusterContainer *trkrclusters = findNode::getClass<TrkrClusterContainer>(dstNode, "TRKR_CLUSTER_TRUTH");
+  if (!trkrclusters)
+  {
+    PHNodeIterator dstiter(dstNode);
+    PHCompositeNode *DetNode =
+        dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+    if (!DetNode)
+    {
+      DetNode = new PHCompositeNode("TRKR");
+      dstNode->addNode(DetNode);
+    }
+
+    trkrclusters = new TrkrClusterContainer();
+    PHIODataNode<PHObject> *TrkrClusterContainerNode =
+        new PHIODataNode<PHObject>(trkrclusters, "TRKR_CLUSTER_TRUTH", "PHObject");
+    DetNode->addNode(TrkrClusterContainerNode);
+  }
+
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHTruthClustering::End(PHCompositeNode * /*topNode*/)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/trackreco/PHTruthClustering.cc
+++ b/offline/packages/trackreco/PHTruthClustering.cc
@@ -96,7 +96,7 @@ int PHTruthClustering::InitRun(PHCompositeNode* topNode)
       clus_err_rphi[layer] = tpc_outer_clus_err_rphi;
       clus_err_z[layer] = tpc_outer_clus_err_z;
     }
-  for(unsignmed int layer = _nlayers_maps + _nlayers_intt +_nlayers_tpc; layer <  _nlayers_maps + _nlayers_intt +_nlayers_tpc + 1; ++layer) 
+  for(unsigned int layer = _nlayers_maps + _nlayers_intt +_nlayers_tpc; layer <  _nlayers_maps + _nlayers_intt +_nlayers_tpc + 1; ++layer) 
     {
       clus_err_rphi[layer] = mms_layer55_clus_err_rphi;
       clus_err_z[layer] = mms_layer55_clus_err_z;

--- a/offline/packages/trackreco/PHTruthClustering.cc
+++ b/offline/packages/trackreco/PHTruthClustering.cc
@@ -76,33 +76,33 @@ int PHTruthClustering::InitRun(PHCompositeNode* topNode)
   int ret = GetNodes(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
 
-  for(int layer = 0; layer < _nlayers_maps; ++layer)
+  for(unsigned int layer = 0; layer < _nlayers_maps; ++layer)
     {
       clus_err_rphi[layer] = mvtx_clus_err_rphi;
       clus_err_z[layer] = mvtx_clus_err_z;
     }
-  for(int layer = _nlayers_maps; layer < _nlayers_maps + _nlayers_intt; ++layer) 
+  for(unsigned int layer = _nlayers_maps; layer < _nlayers_maps + _nlayers_intt; ++layer) 
     {
       clus_err_rphi[layer] = intt_clus_err_rphi;
       clus_err_z[layer] = intt_clus_err_z;
     }
-  for(int layer = _nlayers_maps + _nlayers_intt; layer < _nlayers_maps + _nlayers_intt + 16; ++layer) 
+  for(unsigned int layer = _nlayers_maps + _nlayers_intt; layer < _nlayers_maps + _nlayers_intt + 16; ++layer) 
     {
       clus_err_rphi[layer] = tpc_inner_clus_err_rphi;
       clus_err_z[layer] = tpc_inner_clus_err_z;
     }
-  for(int layer = _nlayers_maps + _nlayers_intt + 16; layer < _nlayers_maps + _nlayers_intt +_nlayers_tpc; ++layer) 
+  for(unsigned int layer = _nlayers_maps + _nlayers_intt + 16; layer < _nlayers_maps + _nlayers_intt +_nlayers_tpc; ++layer) 
     {
       clus_err_rphi[layer] = tpc_outer_clus_err_rphi;
       clus_err_z[layer] = tpc_outer_clus_err_z;
     }
-  for(int layer = _nlayers_maps + _nlayers_intt +_nlayers_tpc; layer <  _nlayers_maps + _nlayers_intt +_nlayers_tpc + 1; ++layer) 
+  for(unsignmed int layer = _nlayers_maps + _nlayers_intt +_nlayers_tpc; layer <  _nlayers_maps + _nlayers_intt +_nlayers_tpc + 1; ++layer) 
     {
       clus_err_rphi[layer] = mms_layer55_clus_err_rphi;
       clus_err_z[layer] = mms_layer55_clus_err_z;
     }
 
-for(int layer = _nlayers_maps + _nlayers_intt +_nlayers_tpc + 1; layer <  _nlayers_maps + _nlayers_intt +_nlayers_tpc + 2; ++layer) 
+for(unsigned int layer = _nlayers_maps + _nlayers_intt +_nlayers_tpc + 1; layer <  _nlayers_maps + _nlayers_intt +_nlayers_tpc + 2; ++layer) 
   {
     clus_err_rphi[layer] = mms_layer56_clus_err_rphi;
     clus_err_z[layer] = mms_layer56_clus_err_z;
@@ -110,7 +110,7 @@ for(int layer = _nlayers_maps + _nlayers_intt +_nlayers_tpc + 1; layer <  _nlaye
  
  if(Verbosity() > 3)
    {
-     for(int layer = 0; layer <  _nlayers_maps + _nlayers_intt +_nlayers_tpc + 2; ++layer)
+     for(unsigned int layer = 0; layer <  _nlayers_maps + _nlayers_intt +_nlayers_tpc + 2; ++layer)
        std::cout << " layer " << layer << " clus_err _rphi " << clus_err_rphi[layer] << " clus_err_z " << clus_err_z[layer] << std::endl;
    }
  

--- a/offline/packages/trackreco/PHTruthClustering.h
+++ b/offline/packages/trackreco/PHTruthClustering.h
@@ -1,0 +1,80 @@
+/*!
+ *  \file		PHTruthClustering.h
+ *  \brief		Clustering using truth info
+ *  \author		Tony Frawley <afrawley@fsu.edu>
+ */
+
+#ifndef TRACKRECO_PHTRUTHCLUSTERING_H
+#define TRACKRECO_PHTRUTHCLUSTERING_H
+
+#include <fun4all/SubsysReco.h>
+
+// rootcint barfs with this header so we need to hide it
+#include <gsl/gsl_rng.h>
+
+class PHG4Hit;
+class PHG4HitContainer;
+class PHG4Particle;
+class PHG4TruthInfoContainer;
+class PHG4CylinderGeomContainer;
+class PHG4CylinderCellGeomContainer;
+//class PHG4VtxPoint;
+class TrkrCluster;
+
+
+#include <string>             // for string
+#include <vector>
+#include <map>
+#include <set>
+#include <memory>
+
+// forward declarations
+class PHCompositeNode;
+class PHG4TruthInfoContainer;
+
+class PHTruthClustering  : public SubsysReco
+{
+public:
+  PHTruthClustering(const std::string &name = "PHTruthClustering");
+  virtual ~PHTruthClustering();
+
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+
+private:
+/// fetch node pointers
+int GetNodes(PHCompositeNode *topNode);
+
+std::map<unsigned int, TrkrCluster* > all_truth_clusters(PHG4Particle* particle);
+std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);
+
+  void LayerClusterG4Hits(std::set<PHG4Hit*> truth_hits, std::vector<PHG4Hit*> &contributing_hits, std::vector<double> &contributing_hits_energy, std::vector<std::vector<double>> &contributing_hits_entry, std::vector<std::vector<double>> &contributing_hits_exit, float layer, float &x, float &y, float &z,  float &t, float &e);
+  
+  void G4ClusterSize(unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry,std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize);
+
+  float line_circle_intersection(float x[], float y[], float z[], float radius);
+
+  int iclus = 0;
+
+PHG4TruthInfoContainer *_g4truth_container{nullptr};
+
+  PHG4HitContainer* _g4hits_svtx{nullptr};
+  PHG4HitContainer* _g4hits_mms{nullptr};
+  PHG4HitContainer* _g4hits_tracker{nullptr};
+  PHG4HitContainer* _g4hits_maps{nullptr};
+
+  PHG4CylinderCellGeomContainer* _tpc_geom_container{nullptr};
+  PHG4CylinderGeomContainer *_intt_geom_container{nullptr};
+  PHG4CylinderGeomContainer* _mvtx_geom_container{nullptr};
+  PHG4CylinderGeomContainer* _mms_geom_container{nullptr};
+
+ const unsigned int _nlayers_maps = 3;
+  const unsigned int _nlayers_intt = 4;
+  const unsigned int _nlayers_tpc = 48;
+  const unsigned int _nlayers_mms = 2;
+
+};
+
+#endif

--- a/offline/packages/trackreco/PHTruthClustering.h
+++ b/offline/packages/trackreco/PHTruthClustering.h
@@ -75,6 +75,21 @@ PHG4TruthInfoContainer *_g4truth_container{nullptr};
   const unsigned int _nlayers_tpc = 48;
   const unsigned int _nlayers_mms = 2;
 
+  double clus_err_rphi[57] = {0};
+  double clus_err_z[57] = {0};
+
+  double mvtx_clus_err_rphi = 5e-04;
+  double mvtx_clus_err_z = 5e-04;
+  double intt_clus_err_rphi = 25e-04;
+  double intt_clus_err_z = 1.0;
+  double tpc_inner_clus_err_rphi = 200e-04;
+  double tpc_inner_clus_err_z = 750e-04;
+  double tpc_outer_clus_err_rphi = 150e-04;
+  double tpc_outer_clus_err_z = 500e-04;
+  double mms_layer55_clus_err_rphi = 100e-04;
+  double mms_layer55_clus_err_z = 25.0;
+  double mms_layer56_clus_err_rphi = 12.5;
+  double mms_layer56_clus_err_z = 200e-04;
 };
 
 #endif

--- a/offline/packages/trackreco/PHTruthClustering.h
+++ b/offline/packages/trackreco/PHTruthClustering.h
@@ -42,6 +42,7 @@ public:
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
+  void UsePrimaryTrackClustersOnly(bool flag) {_primary_clusters_only = flag;}
 
 private:
 /// fetch node pointers
@@ -56,6 +57,8 @@ std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);
 
   float line_circle_intersection(float x[], float y[], float z[], float radius);
   unsigned int getTpcSector(double x, double y);
+
+  unsigned int getAdcValue(double gedep);
 
   int iclus = 0;
 
@@ -93,6 +96,9 @@ std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);
   double mms_layer55_clus_err_z = 25.0;
   double mms_layer56_clus_err_rphi = 12.5;
   double mms_layer56_clus_err_z = 200e-04;
+
+  bool _primary_clusters_only= false;
+
 };
 
 #endif

--- a/offline/packages/trackreco/PHTruthClustering.h
+++ b/offline/packages/trackreco/PHTruthClustering.h
@@ -18,8 +18,8 @@ class PHG4Particle;
 class PHG4TruthInfoContainer;
 class PHG4CylinderGeomContainer;
 class PHG4CylinderCellGeomContainer;
-//class PHG4VtxPoint;
 class TrkrCluster;
+class TrkrClusterContainer;
 
 
 #include <string>             // for string
@@ -55,10 +55,13 @@ std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);
   void G4ClusterSize(unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry,std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize);
 
   float line_circle_intersection(float x[], float y[], float z[], float radius);
+  unsigned int getTpcSector(double x, double y);
 
   int iclus = 0;
 
-PHG4TruthInfoContainer *_g4truth_container{nullptr};
+  TrkrClusterContainer *_reco_cluster_map{nullptr};
+
+  PHG4TruthInfoContainer *_g4truth_container{nullptr};
 
   PHG4HitContainer* _g4hits_svtx{nullptr};
   PHG4HitContainer* _g4hits_mms{nullptr};

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -163,7 +163,7 @@ int SvtxEvaluator::Init(PHCompositeNode* topNode)
                                                    "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
 
   if (_do_g4cluster_eval) _ntp_g4cluster = new TNtuple("ntp_g4cluster", "g4cluster => max truth",
-						       "event:layer:gx:gy:gz:gt:gedep:gr:gphi:geta:ng4hits:gtrackID:gflavor:gembed:gprimary:gphisize:gzsize:nreco:x:y:z:r:phi:eta:ex:ey:ez:ephi:phisize:zsize:adc"); 
+						       "event:layer:gx:gy:gz:gt:gedep:gr:gphi:geta:gtrackID:gflavor:gembed:gprimary:gphisize:gzsize:gadc:nreco:x:y:z:r:phi:eta:ex:ey:ez:ephi:phisize:zsize:adc"); 
                                                        
   if (_do_gtrack_eval) _ntp_gtrack = new TNtuple("ntp_gtrack", "g4particle => best svtxtrack",
                                                  "event:seed:gntracks:gtrackID:gflavor:gnhits:gnmaps:gnintt:gnmms:"
@@ -2149,7 +2149,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	      float gz = gclus->getZ();
 	      float gt = NAN;
 	      float gedep = gclus->getError(0,0);
-	      float ng4hits = gclus->getAdc();
+	      float gadc = (float) gclus->getAdc();
 
 	      TVector3 gpos(gx, gy, gz);
 	      float gr = sqrt(gx*gx+gy*gy);
@@ -2160,8 +2160,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 		{
 		  TrkrDefs::cluskey ckey = gclus->getClusKey();		  
 		  std::cout << PHWHERE << "  ****   truth: layer " << layer << std::endl;
-		  cout << "             truth cluster key " << ckey << " ng4hits " << ng4hits << " gr " << gr << " gx " << gx << " gy " << gy << " gz " << gz 
-		       << " gphi " << gphi << " gedep " << gedep << endl;
+		  cout << "             truth cluster key " << ckey << " gr " << gr << " gx " << gx << " gy " << gy << " gz " << gz 
+		       << " gphi " << gphi << " gedep " << gedep << " gadc " << gadc << endl;
 		}
 	      
 	      float gphisize = gclus->getSize(1,1);
@@ -2233,13 +2233,13 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 					gr,
 					gphi,
 					geta,
-					ng4hits,
 					gtrackID,
 					gflavor,
 					gembed,
 					gprimary,
 					gphisize,
 					gzsize,
+					gadc,
 					nreco,
 					x,
 					y,

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -2160,7 +2160,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 		{
 		  TrkrDefs::cluskey ckey = gclus->getClusKey();		  
 		  std::cout << PHWHERE << "  ****   truth: layer " << layer << std::endl;
-		  cout << "             truth cluster key " << ckey << " hg4hits " << ng4hits << " gr " << gr << " gx " << gx << " gy " << gy << " gz " << gz 
+		  cout << "             truth cluster key " << ckey << " ng4hits " << ng4hits << " gr " << gr << " gx " << gx << " gy " << gy << " gz " << gz 
 		       << " gphi " << gphi << " gedep " << gedep << endl;
 		}
 	      

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -212,6 +212,8 @@ int SvtxEvaluator::Init(PHCompositeNode* topNode)
 
 int SvtxEvaluator::InitRun(PHCompositeNode* topNode)
 {
+  //clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -266,7 +268,7 @@ int SvtxEvaluator::process_event(PHCompositeNode* topNode)
   // Print out the ancestry information for this event
   //--------------------------------------------------
 
-  printOutputInfo(topNode);
+  //printOutputInfo(topNode);
 
   ++_ievent;
   return Fun4AllReturnCodes::EVENT_OK;
@@ -411,7 +413,7 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode* topNode)
   // print out some useful stuff for debugging
   //==========================================
 
-  if (Verbosity() > 1)
+  if (Verbosity() > 100)
   {
     SvtxTrackEval* trackeval = _svtxevalstack->get_track_eval();
     SvtxClusterEval* clustereval = _svtxevalstack->get_cluster_eval();
@@ -505,13 +507,12 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode* topNode)
 
     PHG4CylinderCellGeomContainer* geom_container =
       findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
-    if (!geom_container)
       {
-	std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
+	if (!geom_container)
+	  std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
 	return;
       }
     
-
 
     for (unsigned int ilayer = 0; ilayer < _nlayers_maps + _nlayers_intt + _nlayers_tpc; ++ilayer)
     {
@@ -2556,16 +2557,21 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
               {
                 tpc[layer - (_nlayers_maps + _nlayers_intt)] = 1;
                 ntpc++;
-		if((layer - (_nlayers_maps + _nlayers_intt))<16){
-		  ntpc1++;
-		}
+
 		if((layer - (_nlayers_maps + _nlayers_intt))<8){
 		  ntpc11++;
 		}
+
+		if((layer - (_nlayers_maps + _nlayers_intt))<16){
+		  //std::cout << " tpc1: layer " << layer << std::endl;
+		  ntpc1++;
+		}
 		else if((layer - (_nlayers_maps + _nlayers_intt))<32){
+		  //std::cout << " tpc2: layer " << layer << std::endl;
 		  ntpc2++;
 		}
 		else if((layer - (_nlayers_maps + _nlayers_intt))<48){
+		  //std::cout << " tpc3: layer " << layer << std::endl;
 		  ntpc3++;
 		}
               }
@@ -2857,11 +2863,12 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           {
             tpc[layer - (_nlayers_maps + _nlayers_intt)] = 1;
             ntpc++;
-	    if((layer - (_nlayers_maps + _nlayers_intt))<16){
-	      ntpc1++;
-	    }
 	    if((layer - (_nlayers_maps + _nlayers_intt))<8){
 	      ntpc11++;
+	    }
+
+	    if((layer - (_nlayers_maps + _nlayers_intt))<16){
+	      ntpc1++;
 	    }
 	    else if((layer - (_nlayers_maps + _nlayers_intt))<32){
 	      ntpc2++;
@@ -3189,17 +3196,17 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                               nhit_tpc_mid,
                               nhit_tpc_out, nclus_all, nclus_tpc, nclus_intt, nclus_maps, nclus_mms};
 
-        /*
-	cout << "ievent " << _ievent
-	     << " trackID " << trackID
-	     << " nhits " << nhits
-	     << " px " << px
-	     << " py " << py
-	     << " pz " << pz
-	     << " gembed " << gembed
-	     << " gprimary " << gprimary 
-	     << endl;
-	*/
+	if(Verbosity() > 0)
+	  cout << "ievent " << _ievent
+	       << " trackID " << trackID
+	       << " nhits " << nhits
+	       << " px " << px
+	       << " py " << py
+	       << " pz " << pz
+	       << " gembed " << gembed
+	       << " gprimary " << gprimary 
+	       << endl;
+	
         _ntp_track->Fill(track_data);
       }
     }

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -16,6 +16,7 @@ class PHTimer;
 class SvtxEvalStack;
 class TFile;
 class TNtuple;
+//class TrkrClusterContainer;
 
 /// \class SvtxEvaluator
 ///
@@ -66,6 +67,8 @@ class SvtxEvaluator : public SubsysReco
   // eval stack
   SvtxEvalStack *_svtxevalstack;
 
+  //TrkrClusterContainer *cluster_map{nullptr};
+
   //----------------------------------
   // evaluator output ntuples
 
@@ -89,7 +92,7 @@ class SvtxEvaluator : public SubsysReco
   bool _scan_for_embedded;
 
   unsigned int _nlayers_maps = 3;
-  unsigned int _nlayers_intt = 8;
+  unsigned int _nlayers_intt = 4;
   unsigned int _nlayers_tpc = 48;
   unsigned int _nlayers_mms = 2;
 

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -73,6 +73,8 @@ class SvtxTruthEval
 
   void G4ClusterSize(unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry,std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize);
 
+  unsigned int getAdcValue(double gedep);
+
   BaseTruthEval _basetrutheval;
 
   PHG4TruthInfoContainer* _truthinfo{nullptr};


### PR DESCRIPTION
Adds a module to do truth clustering and put clusters in the TRKR_CLUSTER_TRUTH node. Includes flags for downstream modules so that tracking can use truth clusters instead of reco clusters. Updates SvtxEvaluator truth clusters with an estimate of the ADC value. Everything defaults to normal tracking. 

