### PR TITLE
fix print formatting

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -46,6 +46,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <iomanip>
 #include <iterator>
 #include <map>
 #include <memory>                                       // for shared_ptr
@@ -898,7 +899,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       int nprim = truthinfo->GetNumPrimaryVertexParticles();
       if (Verbosity() > 0){
 	cout << "EVENTINFO SEED: " << m_fSeed << endl;
-	cout << "EVENTINFO NHIT: " << nhit_tpc_all << endl;
+	cout << "EVENTINFO NHIT: " << setprecision(9) << nhit_tpc_all << endl;
 	cout << "EVENTINFO NTRKGEN: " << nprim << endl;
 	cout << "EVENTINFO NTRKREC: " << ntrk << endl;
        


### PR DESCRIPTION
minor fix to number of hit printout. Avoid it to switch to back and forth to scientific notation. Makes processing the output text easier 