### PR TITLE
flow afterburner: adjust parameters

### DIFF
--- a/generators/flowAfterburner/flowAfterburner.cc
+++ b/generators/flowAfterburner/flowAfterburner.cc
@@ -157,7 +157,7 @@ float calc_v2(double b, double eta, double pt)
   // JGL 9/9/2019
   // See JS ToG talk at https://indico.bnl.gov/event/6764/
 
-  v2 = (a4 * (temp1 + temp2) + temp3) * exp(-0.5 * eta * eta / 2.0 / 2.0);
+  v2 = (a4 * (temp1 + temp2) + temp3) * exp(-0.5 * eta * eta / 3.43 / 3.43);
 
   return v2;
 }

--- a/generators/flowAfterburner/main.cc
+++ b/generators/flowAfterburner/main.cc
@@ -59,8 +59,8 @@ int main()
   std::string input = pt.get("FLOWAFTERBURNER.INPUT", "sHijing.dat");
   std::string output = pt.get("FLOWAFTERBURNER.OUTPUT", "flowAfterburner.dat");
 
-  float mineta = pt.get("FLOWAFTERBURNER.CUTS.MINETA", -4.0);
-  float maxeta = pt.get("FLOWAFTERBURNER.CUTS.MAXETA", 4.0);
+  float mineta = pt.get("FLOWAFTERBURNER.CUTS.MINETA", -5.0);
+  float maxeta = pt.get("FLOWAFTERBURNER.CUTS.MAXETA", 5.0);
 
   float minpt = pt.get("FLOWAFTERBURNER.CUTS.MINPT", 0.0);
   float maxpt = pt.get("FLOWAFTERBURNER.CUTS.MAXPT", 100.0);


### PR DESCRIPTION
extend default eta range to cover the entire acceptance of the epd. increase width of v2 vs. eta distribution to better match data [[slides]].

[slides]: https://indico.bnl.gov/event/9997/contributions/43248/attachments/31315/49420/sphenix-js-tg-201106.pdf