### PR TITLE
Pileup input manager

### DIFF
--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -36,12 +36,16 @@
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/PHNodeOperation.h>
 #include <phool/PHObject.h>  // for PHObject
+#include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE, PHReadOnly, PHRunTree
 
 #include <TSystem.h>
 
 #include <HepMC/GenEvent.h>
+
+#include <gsl/gsl_randist.h>
+#include <gsl/gsl_rng.h>
 
 #include <cassert>
 #include <climits>
@@ -809,6 +813,59 @@ void Fun4AllDstPileupInputManager::load_nodes(PHCompositeNode *dstNode)
     m_g4truthinfo = new PHG4TruthInfoContainer();
     dstNode->addNode(new PHIODataNode<PHObject>(m_g4truthinfo, "G4TruthInfo", "PHObject"));
   }
+}
+
+//_____________________________________________________________________________
+void Fun4AllDstPileupInputManager::generateBunchCrossingList( int nevents, float collision_rate )
+{
+  std::cout << "Fun4AllDstPileupInputManager::generateBunchCrossingList - nevents: " << nevents << std::endl;
+  std::cout << "Fun4AllDstPileupInputManager::generateBunchCrossingList - collision_rate: " << collision_rate << "Hz" << std::endl;
+
+  // create and initialize random number generator
+  class Deleter
+  {
+    public:
+    void operator() (gsl_rng* rng) const { gsl_rng_free(rng); }
+  };
+
+  std::unique_ptr<gsl_rng, Deleter> rng;
+  {
+    const uint seed = PHRandomSeed();
+    rng.reset( gsl_rng_alloc(gsl_rng_mt19937) );
+    gsl_rng_set( rng.get(), seed );
+  }
+
+  // clear existing bunch crossing
+  m_bunchCrossings.clear();
+  m_bunchCrossings.reserve(nevents);
+
+  // time interval (s) between two bunch crossing
+  /* value copied from generators/phhepmc/Fun4AllHepMCPileupInputManager.cc */
+  static  double deltat_crossing = 106e-9;
+  std::cout << "Fun4AllDstPileupInputManager::generateBunchCrossingList - deltat_crossing: " << deltat_crossing << std::endl;
+
+  // mean number of collision per crossing
+  const double mu = collision_rate*deltat_crossing;
+
+  // running collision time
+  int64_t bunchcrossing = 0;
+  double time = 0;
+
+  // generate triggers
+  for( int ievent = 0; ievent < nevents; )
+  {
+
+    ++bunchcrossing;
+    time += deltat_crossing;
+
+    const auto ntrig = gsl_ran_poisson( rng.get(), mu );
+    for( uint i = 0; i < ntrig; ++i )
+    {
+      m_bunchCrossings.push_back(bunchcrossing);
+      if( Verbosity() ) std::cout << "Fun4AllDstPileupInputManager::generateBunchCrossingList - trigger number: " << ievent << " bunch crossing: " << bunchcrossing << " time: " << time << std::endl;
+    }
+  }
+
 }
 
 //_____________________________________________________________________________

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -859,7 +859,7 @@ void Fun4AllDstPileupInputManager::generateBunchCrossingList( int nevents, float
     time += deltat_crossing;
 
     const auto ntrig = gsl_ran_poisson( rng.get(), mu );
-    for( uint i = 0; i < ntrig; ++i )
+    for( uint i = 0; i < ntrig; ++i, ++ievent )
     {
       m_bunchCrossings.push_back(bunchcrossing);
       if( Verbosity() ) std::cout << "Fun4AllDstPileupInputManager::generateBunchCrossingList - trigger number: " << ievent << " bunch crossing: " << bunchcrossing << " time: " << time << std::endl;

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -40,13 +40,27 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   void Print(const std::string &what = "ALL") const;
   int PushBackEvents(const int i);
 
+  //! generate bunch crossing list
+  /**
+   * @param[in] nevents number of bunch crossing generated. This should match the number of minimum bias Hijing events to be processed
+   * @param[in] collision_rate the collision rate, in Hz
+   * previously set bunch crossing list is erased in the process
+   */
+  void generateBunchCrossingList( int nevents, float collision_rate = 5e4 );
+
   //! store event bunch crossing ids
   /*! bunch crossings are used to decide which pile-up events should be merged to a given "trigger" event */
   void setBunchCrossingList(const std::vector<int64_t> &value) { m_bunchCrossings = value; }
 
+  //! get list of bunch crossing ids
+  const std::vector<int64_t> &getBunchCrossingList() const { return m_bunchCrossings; }
+
   //! store event offset
   /*! offste is added to the current event number to look for the corresponding event timestamp */
   void setEventOffset(int value) { m_event_offset = value; }
+
+  //! event offset
+  int getEventOffset() const { return m_event_offset; }
 
   //! set time window for pileup events (ns)
   void setPileupTimeWindow(double tmin, double tmax)


### PR DESCRIPTION
This PR adds the possibility for the DSTPileupInputManager to generate its own list of bunch crossing ids, needed for merging pileup events into min bias hijing events at a given pile-up rate, rather than getting them from an external file. 
Typicall code would look like: 

  // input manager
  auto in = new Fun4AllDstPileupInputManager("DSTin");
  in->generateBunchCrossingList( 1000, 5e4 );
  in->fileopen(inputFile);
  se->registerInputManager(in);
  ... 
  se->run( 1000 );

Note that the number of events passed to generateBunchCrossingList should be at least as big as the number of events in the inputFile
