### PR TITLE
Return calogeo theta

### DIFF
--- a/offline/packages/CaloBase/RawTowerGeom.h
+++ b/offline/packages/CaloBase/RawTowerGeom.h
@@ -6,6 +6,7 @@
 #include <phool/PHObject.h>
 #include <phool/phool.h>
 
+#include <cmath>
 #include <iostream>
 
 class RawTowerGeom : public PHObject
@@ -16,6 +17,7 @@ class RawTowerGeom : public PHObject
   virtual void identify(std::ostream& os = std::cout) const;
 
   virtual void set_id(RawTowerDefs::keytype key) { PHOOL_VIRTUAL_WARN("set_id()"); }
+
   virtual RawTowerDefs::keytype get_id() const
   {
     PHOOL_VIRTUAL_WARN("get_id()");
@@ -27,16 +29,19 @@ class RawTowerGeom : public PHObject
     PHOOL_VIRTUAL_WARN("get_ieta()");
     return -1;
   }
+
   virtual int get_binphi() const
   {
     PHOOL_VIRTUAL_WARN("get_iphi()");
     return -1;
   }
+
   virtual int get_column() const
   {
     PHOOL_VIRTUAL_WARN("get_column()");
     return -1;
   }
+
   virtual int get_row() const
   {
     PHOOL_VIRTUAL_WARN("get_row()");
@@ -48,11 +53,13 @@ class RawTowerGeom : public PHObject
     PHOOL_VIRTUAL_WARN("set_center_x()");
     return;
   }
+
   virtual void set_center_y(double)
   {
     PHOOL_VIRTUAL_WARN("set_center_y()");
     return;
   }
+
   virtual void set_center_z(double)
   {
     PHOOL_VIRTUAL_WARN("set_center_z()");
@@ -64,11 +71,13 @@ class RawTowerGeom : public PHObject
     PHOOL_VIRTUAL_WARN("set_size_x()");
     return;
   }
+
   virtual void set_size_y(double)
   {
     PHOOL_VIRTUAL_WARN("set_size_y()");
     return;
   }
+
   virtual void set_size_z(double)
   {
     PHOOL_VIRTUAL_WARN("set_size_z()");
@@ -78,54 +87,67 @@ class RawTowerGeom : public PHObject
   virtual double get_center_x() const
   {
     PHOOL_VIRTUAL_WARN("get_center_x()");
-    return -1;
+    return NAN;
   }
+
   virtual double get_center_y() const
   {
     PHOOL_VIRTUAL_WARN("get_center_y()");
-    return -1;
+    return NAN;
   }
+
   virtual double get_center_z() const
   {
     PHOOL_VIRTUAL_WARN("get_center_z()");
-    return -1;
+    return NAN;
   }
 
   virtual double get_size_x() const
   {
     PHOOL_VIRTUAL_WARN("get_size_x()");
-    return -1;
+    return NAN;
   }
+
   virtual double get_size_y() const
   {
     PHOOL_VIRTUAL_WARN("get_size_y()");
-    return -1;
+    return NAN;
   }
+
   virtual double get_size_z() const
   {
     PHOOL_VIRTUAL_WARN("get_size_z()");
-    return -1;
+    return NAN;
   }
+
   virtual double get_volume() const
   {
     PHOOL_VIRTUAL_WARN("get_volume()");
-    return -1;
+    return NAN;
   }
 
   virtual double get_center_radius() const
   {
     PHOOL_VIRTUAL_WARN("get_center_radius()");
-    return -1;
+    return NAN;
   }
+
   virtual double get_eta() const
   {
     PHOOL_VIRTUAL_WARN("get_eta()");
-    return -1;
+    return NAN;
   }
+
+  virtual double get_theta() const
+  {
+    PHOOL_VIRTUAL_WARN("get_theta()");
+    return NAN;
+  }
+
   virtual double get_phi() const
   {
     PHOOL_VIRTUAL_WARN("get_phi()");
-    return -1;
+    return NAN;
   }
 
   virtual void set_tower_type(int)
@@ -138,6 +160,7 @@ class RawTowerGeom : public PHObject
     PHOOL_VIRTUAL_WARN("get_tower_type()");
     return -1;
   }
+
 
  protected:
   RawTowerGeom() {}

--- a/offline/packages/CaloBase/RawTowerGeomContainer.h
+++ b/offline/packages/CaloBase/RawTowerGeomContainer.h
@@ -120,12 +120,6 @@ class RawTowerGeomContainer : public PHObject
     PHOOL_VIRTUAL_WARN("get_etacenter(const int)");
     return NAN;
   }
-  virtual double get_thetacenter(const int ibin) const
-  {
-    identify();
-    PHOOL_VIRTUAL_WARN("get_thetacenter(const int)");
-    return NAN;
-  }
   virtual double get_phicenter(const int ibin) const
   {
     PHOOL_VIRTUAL_WARN("get_phicenter(const int)");

--- a/offline/packages/CaloBase/RawTowerGeomContainer_Cylinderv1.cc
+++ b/offline/packages/CaloBase/RawTowerGeomContainer_Cylinderv1.cc
@@ -200,14 +200,6 @@ RawTowerGeomContainer_Cylinderv1::get_etacenter(const int ibin) const
   return (eta_bound_map[ibin].first + eta_bound_map[ibin].second) / 2.;
 }
 
-double
-RawTowerGeomContainer_Cylinderv1::get_thetacenter(const int ibin) const
-{
-  double etacenter = get_etacenter(ibin);
-  double theta = 2 * atan(exp(-etacenter));
-  return theta;
-}
-
 void RawTowerGeomContainer_Cylinderv1::set_etabounds(const int ibin,
                                                      const std::pair<double, double>& bounds)
 {

--- a/offline/packages/CaloBase/RawTowerGeomContainer_Cylinderv1.h
+++ b/offline/packages/CaloBase/RawTowerGeomContainer_Cylinderv1.h
@@ -54,9 +54,6 @@ class RawTowerGeomContainer_Cylinderv1 : public RawTowerGeomContainerv1
   get_etacenter(const int ibin) const;
 
   double
-  get_thetacenter(const int ibin) const;
-
-  double
   get_phicenter(const int ibin) const;
 
   int get_etabin(const double eta) const;

--- a/offline/packages/CaloBase/RawTowerGeomv1.cc
+++ b/offline/packages/CaloBase/RawTowerGeomv1.cc
@@ -3,38 +3,27 @@
 #include <cmath>
 #include <iostream>
 
-using namespace std;
-
-RawTowerGeomv1::RawTowerGeomv1()
-  : _towerid(~0)
-  , _center_x(0)
-  , _center_y(0)
-  , _center_z(0)
-{
-}
-
 RawTowerGeomv1::RawTowerGeomv1(RawTowerDefs::keytype id)
   : _towerid(id)
-  , _center_x(0)
-  , _center_y(0)
-  , _center_z(0)
-{
-}
+{}
 
 double RawTowerGeomv1::get_center_radius() const
 {
-  return sqrt(_center_x * _center_x +
+  return std::sqrt(_center_x * _center_x +
               _center_y * _center_y);
+}
+
+double RawTowerGeomv1::get_theta() const
+{
+  double radius = sqrt(_center_x * _center_x + _center_y * _center_y);
+  double theta = atan2(radius, _center_z);
+  return theta;
 }
 
 double RawTowerGeomv1::get_eta() const
 {
-  double eta;
-  double radius;
-  double theta;
-  radius = sqrt(_center_x * _center_x + _center_y * _center_y);
-  theta = atan2(radius, _center_z);
-  eta = -log(tan(theta / 2.));
+  double theta = get_theta();
+  double eta = -log(tan(theta / 2.));
 
   return eta;
 }

--- a/offline/packages/CaloBase/RawTowerGeomv1.h
+++ b/offline/packages/CaloBase/RawTowerGeomv1.h
@@ -5,12 +5,13 @@
 
 #include "RawTowerDefs.h"
 
+#include <cmath>
 #include <iostream>
 
 class RawTowerGeomv1 : public RawTowerGeom
 {
  public:
-  RawTowerGeomv1();
+  RawTowerGeomv1() {}
   RawTowerGeomv1(RawTowerDefs::keytype id);
   virtual ~RawTowerGeomv1() {}
 
@@ -47,13 +48,14 @@ class RawTowerGeomv1 : public RawTowerGeom
   double get_center_radius() const;
   double get_eta() const;
   double get_phi() const;
+  double get_theta() const;
 
  protected:
-  RawTowerDefs::keytype _towerid;
-
-  double _center_x;
-  double _center_y;
-  double _center_z;
+  RawTowerDefs::keytype _towerid = ~0; // 0xFFFFFF.. independant of type
+ 
+  double _center_x = NAN;
+  double _center_y = NAN;
+  double _center_z = NAN;
   ClassDef(RawTowerGeomv1, 4)
 };
 

--- a/offline/packages/CaloBase/RawTowerGeomv3.cc
+++ b/offline/packages/CaloBase/RawTowerGeomv3.cc
@@ -3,46 +3,27 @@
 #include <cmath>
 #include <iostream>
 
-using namespace std;
-
-RawTowerGeomv3::RawTowerGeomv3()
-  : _towerid(~0)
-  , _center_x(0)
-  , _center_y(0)
-  , _center_z(0)
-  , _size_x(0)
-  , _size_y(0)
-  , _size_z(0)
-  , _tower_type(-1)
-{
-}
-
 RawTowerGeomv3::RawTowerGeomv3(RawTowerDefs::keytype id)
   : _towerid(id)
-  , _center_x(0)
-  , _center_y(0)
-  , _center_z(0)
-  , _size_x(0)
-  , _size_y(0)
-  , _size_z(0)
-  , _tower_type(-1)
-{
-}
+{}
 
 double RawTowerGeomv3::get_center_radius() const
 {
-  return sqrt(_center_x * _center_x +
+  return std::sqrt(_center_x * _center_x +
               _center_y * _center_y);
+}
+
+double RawTowerGeomv3::get_theta() const
+{
+  double radius = sqrt(_center_x * _center_x + _center_y * _center_y);
+  double theta = atan2(radius, _center_z);
+  return theta;
 }
 
 double RawTowerGeomv3::get_eta() const
 {
-  double eta;
-  double radius;
-  double theta;
-  radius = sqrt(_center_x * _center_x + _center_y * _center_y);
-  theta = atan2(radius, _center_z);
-  eta = -log(tan(theta / 2.));
+  double theta = get_theta();
+  double eta = -log(tan(theta / 2.));
   return eta;
 }
 

--- a/offline/packages/CaloBase/RawTowerGeomv3.h
+++ b/offline/packages/CaloBase/RawTowerGeomv3.h
@@ -5,12 +5,13 @@
 
 #include "RawTowerDefs.h"
 
+#include <cmath>
 #include <iostream>
 
 class RawTowerGeomv3 : public RawTowerGeom
 {
  public:
-  RawTowerGeomv3();
+  RawTowerGeomv3(){}
   RawTowerGeomv3(RawTowerDefs::keytype id);
   virtual ~RawTowerGeomv3() {}
 
@@ -68,26 +69,23 @@ class RawTowerGeomv3 : public RawTowerGeom
   double get_center_radius() const;
   double get_eta() const;
   double get_phi() const;
+  double get_theta() const;
 
-  void set_tower_type(int tt)
-  {
-    _tower_type = tt;
-    return;
-  }
+  void set_tower_type(int tt) {_tower_type = tt;}
   int get_tower_type() const { return _tower_type; }
 
  protected:
-  RawTowerDefs::keytype _towerid;
+  RawTowerDefs::keytype _towerid = ~0; // complement = 0xFFFFF... independent of integer type (32/64/... bits)
 
-  double _center_x;
-  double _center_y;
-  double _center_z;
+  double _center_x = NAN;
+  double _center_y = NAN;
+  double _center_z =NAN;
 
-  double _size_x;
-  double _size_y;
-  double _size_z;
+  double _size_x = NAN;
+  double _size_y = NAN;
+  double _size_z = NAN;
 
-  int _tower_type;
+  int _tower_type = -1;
 
   ClassDef(RawTowerGeomv3, 4)
 };


### PR DESCRIPTION
This PR adds get_theta() methods to the calorimeter geometries we use. It's needed to create parametrizations for eic-smear which use theta, not eta