### PR TITLE
Acts vertexing

### DIFF
--- a/offline/packages/trackreco/PHActsVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsVertexFinder.cc
@@ -44,6 +44,7 @@
 PHActsVertexFinder::PHActsVertexFinder(const std::string &name)
   : PHInitVertexing(name)
   , m_actsFitResults(nullptr)
+  , m_actsVertexMap(nullptr)
 {
 }
 

--- a/offline/packages/trackreco/PHActsVertexFinder.h
+++ b/offline/packages/trackreco/PHActsVertexFinder.h
@@ -6,6 +6,9 @@
 
 #include <trackbase/TrkrDefs.h>
 
+#include <Acts/Utilities/Result.hpp>
+#include <Acts/Vertexing/Vertex.hpp>
+
 #include <ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp>
 
 class PHCompositeNode;
@@ -18,33 +21,39 @@ namespace Acts
 }
 
 using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
+using VertexVector = std::vector<Acts::Vertex<Acts::BoundTrackParameters>>;
+using TrackPtrVector = std::vector<const Acts::BoundTrackParameters*>;
+using VertexMap = std::map<unsigned int, Acts::Vertex<Acts::BoundTrackParameters>>;
 
 
 class PHActsVertexFinder: public PHInitVertexing 
 {
   
  public:
-  PHActsVertexFinder(const std::string &name);
+  PHActsVertexFinder(const std::string &name = "PHActsVertexFinder");
   virtual ~PHActsVertexFinder() {}
-
-
+  void setMaxVertices(int maxVertices)
+  { m_maxVertices = maxVertices; }
 
  protected:
   int Setup(PHCompositeNode *topNode) override;
   int Process(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
+
  private:
   
   int createNodes(PHCompositeNode *topNode);
   int getNodes(PHCompositeNode *topNode);
   std::vector<const Acts::BoundTrackParameters*> getTracks();
   std::map<const unsigned int, Trajectory> *m_actsFitResults;
-
-  int m_event;
-  int m_maxVertices;
-  ActsTrackingGeometry *m_tGeometry;
+  VertexVector findVertices(TrackPtrVector& tracks);
+  void fillVertexMap(VertexVector& vertices);
   
-  
+  int m_event = 0;
+  int m_maxVertices = 15;
+  VertexMap *m_vertexMap = nullptr;
+  ActsTrackingGeometry *m_tGeometry = nullptr;
+    
 };
 
 #endif // TRACKRECO_PHACTSVERTEXFINDER_H

--- a/offline/packages/trackreco/PHActsVertexFinder.h
+++ b/offline/packages/trackreco/PHActsVertexFinder.h
@@ -14,6 +14,8 @@
 class PHCompositeNode;
 class SvtxTrack;
 class SvtxTrackMap;
+class SvtxVertexMap;
+class SvtxVertex;
 
 namespace Acts
 {
@@ -38,6 +40,7 @@ class PHActsVertexFinder: public PHInitVertexing
  protected:
   int Setup(PHCompositeNode *topNode) override;
   int Process(PHCompositeNode *topNode) override;
+  int ResetEvent(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 
  private:
@@ -45,14 +48,16 @@ class PHActsVertexFinder: public PHInitVertexing
   int createNodes(PHCompositeNode *topNode);
   int getNodes(PHCompositeNode *topNode);
   std::vector<const Acts::BoundTrackParameters*> getTracks();
-  std::map<const unsigned int, Trajectory> *m_actsFitResults;
   VertexVector findVertices(TrackPtrVector& tracks);
   void fillVertexMap(VertexVector& vertices);
   
+  std::map<const unsigned int, Trajectory> *m_actsFitResults;
   int m_event = 0;
   int m_maxVertices = 15;
-  VertexMap *m_vertexMap = nullptr;
+  VertexMap *m_actsVertexMap = nullptr;
+  SvtxVertexMap *m_svtxVertexMap = nullptr;
   ActsTrackingGeometry *m_tGeometry = nullptr;
+  bool m_addActsVertexNode = false;
     
 };
 

--- a/offline/packages/trackreco/PHActsVertexFinder.h
+++ b/offline/packages/trackreco/PHActsVertexFinder.h
@@ -28,14 +28,20 @@ using TrackPtrVector = std::vector<const Acts::BoundTrackParameters*>;
 using VertexMap = std::map<unsigned int, Acts::Vertex<Acts::BoundTrackParameters>>;
 
 
+/**
+ * This class calls the Acts::IterativeVertexFinder which takes a 
+ * list of tracks and returns a list of vertices that are found.
+ */
 class PHActsVertexFinder: public PHInitVertexing 
 {
   
  public:
   PHActsVertexFinder(const std::string &name = "PHActsVertexFinder");
+
   virtual ~PHActsVertexFinder() {}
+
   void setMaxVertices(int maxVertices)
-  { m_maxVertices = maxVertices; }
+    { m_maxVertices = maxVertices; }
 
  protected:
   int Setup(PHCompositeNode *topNode) override;
@@ -47,16 +53,31 @@ class PHActsVertexFinder: public PHInitVertexing
   
   int createNodes(PHCompositeNode *topNode);
   int getNodes(PHCompositeNode *topNode);
+
+  /// Get list of tracks from PHActsTrkFitter to vertex fit
   std::vector<const Acts::BoundTrackParameters*> getTracks();
+
+  /// Call acts vertex finder
   VertexVector findVertices(TrackPtrVector& tracks);
+
+  /// Fill maps with relevant vertex information 
   void fillVertexMap(VertexVector& vertices);
   
+  /// The acts trajectories from PHActsTrkFitter
   std::map<const unsigned int, Trajectory> *m_actsFitResults;
+
+  /// An Acts vertex object map
+  VertexMap *m_actsVertexMap;
+
   int m_event = 0;
-  int m_maxVertices = 15;
-  VertexMap *m_actsVertexMap = nullptr;
+  /// Maximum number of vertices that the Acts finder is allowed
+  /// to find
+  int m_maxVertices = 20;
   SvtxVertexMap *m_svtxVertexMap = nullptr;
   ActsTrackingGeometry *m_tGeometry = nullptr;
+
+  /// Boolean to place m_actsVertexMap on node tree
+  /// False by default since Svtx objects are still the default
   bool m_addActsVertexNode = false;
     
 };

--- a/offline/packages/trackreco/PHActsVertexFitter.cc
+++ b/offline/packages/trackreco/PHActsVertexFitter.cc
@@ -112,8 +112,8 @@ int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
 				    m_tGeometry->magFieldContext);
       
       /// Call the fitter and get the result
-      auto fitRes = fitter.fit(tracks,linearizer,
-      		       vfOptions, state);
+      auto fitRes = fitter.fit(tracks, linearizer,
+			       vfOptions, state);
 
       if(fitRes.ok())
 	{
@@ -158,26 +158,22 @@ std::vector<const Acts::BoundTrackParameters*> PHActsVertexFitter::getTracks()
  
   std::vector<const Acts::BoundTrackParameters*> trackPtrs;
 
-  std::map<const unsigned int, Trajectory>::iterator trackIter;
-
-  for (trackIter = m_actsFitResults->begin();
-       trackIter != m_actsFitResults->end();
-       ++trackIter)
-  {
-    const Trajectory traj = trackIter->second;
-    const auto &[trackTips, mj] = traj.trajectory();
-    
-    for(const size_t &trackTip : trackTips)
-      {
-	if(traj.hasTrackParameters(trackTip))
-	  {
-	    const Acts::BoundTrackParameters *param = new Acts::BoundTrackParameters(traj.trackParameters(trackTip));
-	 
-	    trackPtrs.push_back(param);
-	  }
-
-      }
-  }
+  for(const auto &[key, traj] : *m_actsFitResults)
+    {
+      const auto &[trackTips, mj] = traj.trajectory();
+      
+      for(const size_t &trackTip : trackTips)
+	{
+	  if(traj.hasTrackParameters(trackTip))
+	    {
+	      const auto param = 
+		new Acts::BoundTrackParameters(traj.trackParameters(trackTip));
+	      
+	      trackPtrs.push_back(param);
+	    }
+	  
+	}
+    }
   
   if(Verbosity() > 3)
     {
@@ -188,7 +184,7 @@ std::vector<const Acts::BoundTrackParameters*> PHActsVertexFitter::getTracks()
       for(std::vector<const Acts::BoundTrackParameters*>::iterator it = trackPtrs.begin();
 	  it != trackPtrs.end(); ++it)
 	{
-	  const Acts::BoundTrackParameters* param = *it;
+	  const auto param = *it;
 	  std::cout << "Track position: (" 
 		    << param->position(m_tGeometry->geoContext)(0)
 		    <<", " << param->position(m_tGeometry->geoContext)(1) << ", "


### PR DESCRIPTION
This PR puts the Acts vertex finder in a usable state. The vertex finder takes a list of tracks and returns a list of vertices. A new `SvtxVertexMap` with the name `SvtxVertexMapActs` is put on the node tree, so that analyzers can use this vertex map or one created by e.g. rave. 

Only vertices that have at least 3 tracks and chi2/ndf < 100 are added to the map. These are very basic quality cuts so that users have the option to identify vertices that they may or may not want to use.