### PR TITLE
Update eventcounter

### DIFF
--- a/generators/FermiMotionAfterburner/FermiMotion.cc
+++ b/generators/FermiMotionAfterburner/FermiMotion.cc
@@ -92,7 +92,6 @@ int FermiMotion(HepMC::GenEvent *event, gsl_rng *RandomGenerator)
   double pnl = ploss(b);
   //now loop over all particles and find spectator neutrons
 
-  std::cout << "looping over particles" << std::endl;
   for (HepMC::GenEvent::particle_const_iterator p = event->particles_begin(), prev = event->particles_end(); p != event->particles_end(); prev = p, ++p)
   {
     int id = (*p)->pdg_id();

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -1467,13 +1467,14 @@ int Fun4AllServer::run(const int nevnts, const bool require_nevents)
 int Fun4AllServer::skip(const int nevnts)
 {
   int iret = 0;
-  if (nevnts > 0)  // do not execute for nevnts == 0
+  if (nevnts > 0)  // do not execute for nevnts <= 0
   {
     vector<Fun4AllSyncManager *>::const_iterator iter;
     for (iter = SyncManagers.begin(); iter != SyncManagers.end(); ++iter)
     {
       iret += (*iter)->skip(nevnts);
     }
+    eventcounter += nevnts; // update event counter so it reflects the number of events in the input
   }
   return iret;
 }


### PR DESCRIPTION
This PR updates the event counter in Fun4All with the number of skipped events. This counter should now accurately reflect the events in the input file. This is needed when an input file is processed in multiple batches where we skip events at the beginning.