### PR TITLE
Small fixes

### DIFF
--- a/offline/packages/CaloReco/BEmcRec.cc
+++ b/offline/packages/CaloReco/BEmcRec.cc
@@ -220,7 +220,7 @@ void BEmcRec::Tower2Global(float E, float xC, float yC,
   int ix = xC + 0.5;  // tower #
   if (ix < 0 || ix >= fNx)
   {
-    cout << "Error in BEmcRec::Tower2Global: wrong input x: " << ix << endl;
+    cout << m_ThisName << " Error in BEmcRec::Tower2Global: wrong input x: " << ix << endl;
     return;
   }
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -581,7 +581,7 @@ void MakeActsGeometry::buildActsSurfaces()
   makeGeometry(argc, arg, m_detector);
 
   for(int i=0; i<argc; i++)
-    delete arg[i];
+    free(arg[i]);
 
 }
 

--- a/simulation/g4simulation/g4histos/G4VtxNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4VtxNtuple.cc
@@ -4,7 +4,7 @@
 #include <g4main/PHG4VtxPoint.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
-#include <fun4all/SubsysReco.h>           // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/getClass.h>
 
@@ -13,27 +13,24 @@
 #include <TNtuple.h>
 
 #include <sstream>
-#include <utility>                        // for pair
+#include <utility>  // for pair
 
 using namespace std;
 
 G4VtxNtuple::G4VtxNtuple(const std::string &name, const std::string &filename)
   : SubsysReco(name)
   , m_FileName(filename)
-  , ntup(nullptr)
 {
 }
 
 G4VtxNtuple::~G4VtxNtuple()
 {
-  //  delete ntup;
   delete hm;
 }
 
 int G4VtxNtuple::Init(PHCompositeNode *)
 {
   hm = new Fun4AllHistoManager(Name());
-//  outfile = new TFile(m_FileName.c_str(), "RECREATE");
   ntup = new TNtuple("vtxntup", "G4Vtxs", "vx:vy:vz");
   hm->registerHisto(ntup);
   return 0;
@@ -44,8 +41,8 @@ int G4VtxNtuple::process_event(PHCompositeNode *topNode)
   PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
   if (truthinfo)
   {
-  PHG4VtxPoint *gvertex = truthinfo->GetPrimaryVtx(truthinfo->GetPrimaryVertexIndex());
-  ntup->Fill(gvertex->get_x(),gvertex->get_y(),gvertex->get_z());
+    PHG4VtxPoint *gvertex = truthinfo->GetPrimaryVtx(truthinfo->GetPrimaryVertexIndex());
+    ntup->Fill(gvertex->get_x(), gvertex->get_y(), gvertex->get_z());
   }
   return 0;
 }
@@ -55,4 +52,3 @@ int G4VtxNtuple::End(PHCompositeNode *topNode)
   hm->dumpHistos(m_FileName, "RECREATE");
   return 0;
 }
-

--- a/simulation/g4simulation/g4histos/G4VtxNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4VtxNtuple.cc
@@ -1,0 +1,58 @@
+#include "G4VtxNtuple.h"
+
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4VtxPoint.h>
+
+#include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/SubsysReco.h>           // for SubsysReco
+
+#include <phool/getClass.h>
+
+#include <TFile.h>
+#include <TH1.h>
+#include <TNtuple.h>
+
+#include <sstream>
+#include <utility>                        // for pair
+
+using namespace std;
+
+G4VtxNtuple::G4VtxNtuple(const std::string &name, const std::string &filename)
+  : SubsysReco(name)
+  , m_FileName(filename)
+  , ntup(nullptr)
+{
+}
+
+G4VtxNtuple::~G4VtxNtuple()
+{
+  //  delete ntup;
+  delete hm;
+}
+
+int G4VtxNtuple::Init(PHCompositeNode *)
+{
+  hm = new Fun4AllHistoManager(Name());
+//  outfile = new TFile(m_FileName.c_str(), "RECREATE");
+  ntup = new TNtuple("vtxntup", "G4Vtxs", "vx:vy:vz");
+  hm->registerHisto(ntup);
+  return 0;
+}
+
+int G4VtxNtuple::process_event(PHCompositeNode *topNode)
+{
+  PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  if (truthinfo)
+  {
+  PHG4VtxPoint *gvertex = truthinfo->GetPrimaryVtx(truthinfo->GetPrimaryVertexIndex());
+  ntup->Fill(gvertex->get_x(),gvertex->get_y(),gvertex->get_z());
+  }
+  return 0;
+}
+
+int G4VtxNtuple::End(PHCompositeNode *topNode)
+{
+  hm->dumpHistos(m_FileName, "RECREATE");
+  return 0;
+}
+

--- a/simulation/g4simulation/g4histos/G4VtxNtuple.h
+++ b/simulation/g4simulation/g4histos/G4VtxNtuple.h
@@ -1,0 +1,42 @@
+#ifndef G4HISTOS_G4VTXNTUPLE_H
+#define G4HISTOS_G4VTXNTUPLE_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+// Forward declerations
+class Fun4AllHistoManager;
+class PHCompositeNode;
+class TFile;
+class TH1;
+class TNtuple;
+
+class G4VtxNtuple : public SubsysReco
+{
+ public:
+  //! constructor
+  G4VtxNtuple(const std::string &name = "G4VtxNtuple", const std::string &filename = "G4VtxNtuple.root");
+
+  //! destructor
+  virtual ~G4VtxNtuple();
+
+  //! full initialization
+  int Init(PHCompositeNode *);
+
+  //! event processing method
+  int process_event(PHCompositeNode *);
+
+  //! end of run method
+  int End(PHCompositeNode *);
+
+ protected:
+  std::string m_FileName;
+  Fun4AllHistoManager *hm;
+  TNtuple *ntup;
+};
+
+#endif

--- a/simulation/g4simulation/g4histos/G4VtxNtuple.h
+++ b/simulation/g4simulation/g4histos/G4VtxNtuple.h
@@ -35,8 +35,8 @@ class G4VtxNtuple : public SubsysReco
 
  protected:
   std::string m_FileName;
-  Fun4AllHistoManager *hm;
-  TNtuple *ntup;
+  Fun4AllHistoManager *hm = nullptr;
+  TNtuple *ntup = nullptr;
 };
 
 #endif

--- a/simulation/g4simulation/g4histos/Makefile.am
+++ b/simulation/g4simulation/g4histos/Makefile.am
@@ -35,7 +35,8 @@ pkginclude_HEADERS = \
   G4HitTTree.h \
   G4RawTowerTTree.h \
   G4SnglNtuple.h \
-  G4SnglTree.h
+  G4SnglTree.h \
+  G4VtxNtuple.h
 
 ROOTDICTS = \
   G4RootHitContainer_Dict.cc \
@@ -74,7 +75,8 @@ libg4histos_la_SOURCES = \
   G4ScintillatorTowerTTree.cc \
   G4SnglNtuple.cc \
   G4SnglTree.cc \
-  G4TowerNtuple.cc
+  G4TowerNtuple.cc \
+  G4VtxNtuple.cc
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h


### PR DESCRIPTION
This PR adds a few small things:
In MakeActsGeometry a string is copied by strdup(argstr[i].c_str()); the memory needs to be free'd, not deleted
Added a small ntuple to dump the vtx distribution (to verify that we use the CAD vertex distribution)
Print out the module name for the x out of bounds message in BEmcRec so we know which one throws the error