### PR TITLE
Add acts vertexing to SvtxEvaluator

### DIFF
--- a/offline/packages/trackreco/PHActsVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsVertexFinder.cc
@@ -293,12 +293,6 @@ void PHActsVertexFinder::fillVertexMap(VertexVector& vertices,
       svtxVertex->set_t0(vertex.time());
       svtxVertex->set_id(key);
 
-      // add tracks
-      for(int itrack=0; itrack < numTracks; ++itrack)
-	{   
-	  svtxVertex->insert_track(itrack);
-	}   
-
      m_svtxVertexMap->insert(svtxVertex);
 
       ++key;

--- a/offline/packages/trackreco/PHActsVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsVertexFinder.cc
@@ -264,23 +264,29 @@ void PHActsVertexFinder::fillVertexMap(VertexVector& vertices)
 
       /// Fill SvtxVertexMap
       auto svtxVertex = new SvtxVertex_v1();
-      svtxVertex->set_x(vertex.position().x());
-      svtxVertex->set_y(vertex.position().y());
-      svtxVertex->set_z(vertex.position().z());
+      svtxVertex->set_x(vertex.position().x()*0.1);  // convert to cm
+      svtxVertex->set_y(vertex.position().y()*0.1);
+      svtxVertex->set_z(vertex.position().z()*0.1);
       for(int i = 0; i < 3; ++i) 
 	{
 	  for(int j = 0; j < 3; ++j)
 	    {
 	      svtxVertex->set_error(i, j,
-				    vertex.covariance()(i,j));
+				    vertex.covariance()(i,j)*0.01);  // squared, right??
 	    }
 	}
       svtxVertex->set_chisq(chi2);
       svtxVertex->set_ndof(ndf);
       svtxVertex->set_t0(vertex.time());
       svtxVertex->set_id(key);
-      
-      m_svtxVertexMap->insert(svtxVertex);
+
+      // add tracks
+      for(int itrack=0; itrack < numTracks; ++itrack)
+	{   
+	  svtxVertex->insert_track(itrack);
+	}   
+
+     m_svtxVertexMap->insert(svtxVertex);
 
       ++key;
     }

--- a/simulation/g4simulation/g4eval/SvtxEvalStack.h
+++ b/simulation/g4simulation/g4eval/SvtxEvalStack.h
@@ -26,6 +26,7 @@ class SvtxEvalStack
   void set_strict(bool strict) { _vertexeval.set_strict(strict); }
   //void set_over_write_vertexmap(bool over_write) {_vertexeval.set_over_write_vertexmap(over_write);}
   void set_use_initial_vertex(bool use_init_vtx) { _vertexeval.set_use_initial_vertex(use_init_vtx); }
+  void set_use_acts_vertex(bool use_acts_vtx) { _vertexeval.set_use_initial_vertex(use_acts_vtx); }
   void set_verbosity(int verbosity) { _vertexeval.set_verbosity(verbosity); }
 
   SvtxVertexEval* get_vertex_eval() { return &_vertexeval; }

--- a/simulation/g4simulation/g4eval/SvtxEvalStack.h
+++ b/simulation/g4simulation/g4eval/SvtxEvalStack.h
@@ -26,7 +26,7 @@ class SvtxEvalStack
   void set_strict(bool strict) { _vertexeval.set_strict(strict); }
   //void set_over_write_vertexmap(bool over_write) {_vertexeval.set_over_write_vertexmap(over_write);}
   void set_use_initial_vertex(bool use_init_vtx) { _vertexeval.set_use_initial_vertex(use_init_vtx); }
-  void set_use_acts_vertex(bool use_acts_vtx) { _vertexeval.set_use_acts_vertex(use_acts_vtx); }
+  void set_use_genfit_vertex(bool use_genfit_vtx) { _vertexeval.set_use_genfit_vertex(use_genfit_vtx); }
   void set_verbosity(int verbosity) { _vertexeval.set_verbosity(verbosity); }
 
   SvtxVertexEval* get_vertex_eval() { return &_vertexeval; }

--- a/simulation/g4simulation/g4eval/SvtxEvalStack.h
+++ b/simulation/g4simulation/g4eval/SvtxEvalStack.h
@@ -26,7 +26,7 @@ class SvtxEvalStack
   void set_strict(bool strict) { _vertexeval.set_strict(strict); }
   //void set_over_write_vertexmap(bool over_write) {_vertexeval.set_over_write_vertexmap(over_write);}
   void set_use_initial_vertex(bool use_init_vtx) { _vertexeval.set_use_initial_vertex(use_init_vtx); }
-  void set_use_acts_vertex(bool use_acts_vtx) { _vertexeval.set_use_initial_vertex(use_acts_vtx); }
+  void set_use_acts_vertex(bool use_acts_vtx) { _vertexeval.set_use_acts_vertex(use_acts_vtx); }
   void set_verbosity(int verbosity) { _vertexeval.set_verbosity(verbosity); }
 
   SvtxVertexEval* get_vertex_eval() { return &_vertexeval; }

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -67,7 +67,6 @@ SvtxEvaluator::SvtxEvaluator(const string& name, const string& filename, const s
   , m_fSeed(NAN)
   , _svtxevalstack(nullptr)
   , _strict(false)
-  , _use_initial_vertex(false)
   , _errors(0)
   , _do_info_eval(true)
   , _do_vertex_eval(true)
@@ -248,7 +247,8 @@ int SvtxEvaluator::process_event(PHCompositeNode* topNode)
     _svtxevalstack->set_strict(_strict);
     _svtxevalstack->set_verbosity(Verbosity());
     _svtxevalstack->set_use_initial_vertex(_use_initial_vertex);
-    _svtxevalstack->set_use_acts_vertex(_use_acts_vertex);
+    _svtxevalstack->set_use_genfit_vertex(_use_genfit_vertex);
+    _svtxevalstack->next_event(topNode);
   }
   else
   {
@@ -387,10 +387,11 @@ void SvtxEvaluator::printInputInfo(PHCompositeNode* topNode)
     SvtxVertexMap* vertexmap = nullptr;
     if(_use_initial_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
-    else if (_use_acts_vertex)
-      vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
-    else
+    else if (_use_genfit_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");
+    else
+      vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
+
     if (vertexmap)
     {
       unsigned int ivertex = 0;
@@ -443,10 +444,11 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode* topNode)
     SvtxVertexMap* vertexmap = nullptr;
     if(_use_initial_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
-    else if (_use_acts_vertex)
-      vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
-    else
+    else if (_use_genfit_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");
+    else
+      vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
+
     if (vertexmap)
     {
       if (!vertexmap->empty())
@@ -939,10 +941,11 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
     SvtxVertexMap* vertexmap = nullptr;
     if(_use_initial_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
-    else if (_use_acts_vertex)
-      vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
-    else
+    else if (_use_genfit_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");
+    else
+      vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
+
     PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
 
     if (vertexmap && truthinfo)
@@ -1018,6 +1021,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       {
         const int point_id = iter->first;
         int gembed = truthinfo->isEmbededVtx(point_id);
+
         if (_scan_for_embedded && gembed <= 0) continue;
 
         auto search = embedvtxid_found.find(gembed);

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -247,6 +247,7 @@ int SvtxEvaluator::process_event(PHCompositeNode* topNode)
     _svtxevalstack->set_strict(_strict);
     _svtxevalstack->set_verbosity(Verbosity());
     _svtxevalstack->set_use_initial_vertex(_use_initial_vertex);
+    _svtxevalstack->set_use_acts_vertex(_use_acts_vertex);
   }
   else
   {
@@ -385,6 +386,8 @@ void SvtxEvaluator::printInputInfo(PHCompositeNode* topNode)
     SvtxVertexMap* vertexmap = nullptr;
     if(_use_initial_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+    else if (_use_acts_vertex)
+      vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
     else
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");
     if (vertexmap)
@@ -439,6 +442,8 @@ void SvtxEvaluator::printOutputInfo(PHCompositeNode* topNode)
     SvtxVertexMap* vertexmap = nullptr;
     if(_use_initial_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+    else if (_use_acts_vertex)
+      vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
     else
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");
     if (vertexmap)
@@ -933,6 +938,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
     SvtxVertexMap* vertexmap = nullptr;
     if(_use_initial_vertex)
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+    else if (_use_acts_vertex)
+      vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
     else
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");
     PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -224,6 +224,7 @@ int SvtxEvaluator::process_event(PHCompositeNode* topNode)
   {
     cout << "SvtxEvaluator::process_event - Event = " << _ievent << endl;
   }
+
   recoConsts *rc = recoConsts::instance();
   if (rc->FlagExist("RANDOMSEED"))
   {
@@ -943,6 +944,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
     else
       vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");
     PHG4TruthInfoContainer* truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+
     if (vertexmap && truthinfo)
     {
       const auto prange = truthinfo->GetPrimaryParticleRange();
@@ -1047,7 +1049,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       for (SvtxVertexMap::Iter iter = vertexmap->begin();
            iter != vertexmap->end();
            ++iter)
-      {
+       {
         SvtxVertex* vertex = iter->second;
         PHG4VtxPoint* point = vertexeval->max_truth_point_by_ntracks(vertex);
         float vx = vertex->get_x();
@@ -1140,6 +1142,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
             gnembed = (float) ngembed;
             //        nfromtruth = vertexeval->get_ntracks_contribution(vertex,point);
           }
+
+	  std::cout << " adding vertex data " << std::endl;
 
           float vertex_data[] = {(float) _ievent,m_fSeed,
                                  vx,

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -45,7 +45,7 @@ class SvtxEvaluator : public SubsysReco
 
   void set_strict(bool b) { _strict = b; }
   void set_use_initial_vertex(bool use_init_vtx) {_use_initial_vertex = use_init_vtx;}
-  void set_use_acts_vertex(bool use_acts_vtx) {_use_acts_vertex = use_acts_vtx;}
+  void set_use_genfit_vertex(bool use_genfit_vtx) {_use_genfit_vertex = use_genfit_vtx;}
   void do_info_eval(bool b) { _do_info_eval = b; }
   void do_vertex_eval(bool b) { _do_vertex_eval = b; }
   void do_gpoint_eval(bool b) { _do_gpoint_eval = b; }
@@ -74,8 +74,8 @@ class SvtxEvaluator : public SubsysReco
   // evaluator output ntuples
 
   bool _strict;
-  bool _use_initial_vertex;
-  bool _use_acts_vertex = true;
+  bool _use_initial_vertex = false;
+  bool _use_genfit_vertex = false;
   unsigned int _errors;
 
   bool _do_info_eval;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -75,7 +75,7 @@ class SvtxEvaluator : public SubsysReco
 
   bool _strict;
   bool _use_initial_vertex;
-  bool _use_acts_vertex = false;
+  bool _use_acts_vertex = true;
   unsigned int _errors;
 
   bool _do_info_eval;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -45,6 +45,7 @@ class SvtxEvaluator : public SubsysReco
 
   void set_strict(bool b) { _strict = b; }
   void set_use_initial_vertex(bool use_init_vtx) {_use_initial_vertex = use_init_vtx;}
+  void set_use_acts_vertex(bool use_acts_vtx) {_use_acts_vertex = use_acts_vtx;}
   void do_info_eval(bool b) { _do_info_eval = b; }
   void do_vertex_eval(bool b) { _do_vertex_eval = b; }
   void do_gpoint_eval(bool b) { _do_gpoint_eval = b; }
@@ -74,6 +75,7 @@ class SvtxEvaluator : public SubsysReco
 
   bool _strict;
   bool _use_initial_vertex;
+  bool _use_acts_vertex = false;
   unsigned int _errors;
 
   bool _do_info_eval;

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.cc
@@ -407,6 +407,10 @@ void SvtxVertexEval::get_node_pointers(PHCompositeNode* topNode)
   {
     _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");  // always there, initial vertices
   }
+  else if (_use_acts_vertex)
+    {
+    _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
+    }
   else
   {
     _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");  // Rave vertices

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.cc
@@ -228,7 +228,6 @@ PHG4VtxPoint* SvtxVertexEval::max_truth_point_by_ntracks(SvtxVertex* vertex)
       max_point = candidate;
     }
   }
-  //std::cout << PHWHERE << " max_point " << max_point->get_id() << " max_ntracks " << max_ntracks << std::endl;
 
   if (_do_cache) _cache_max_truth_point_by_ntracks.insert(make_pair(vertex, max_point));
 

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.cc
@@ -27,13 +27,11 @@ SvtxVertexEval::SvtxVertexEval(PHCompositeNode* topNode)
   , _trackmap(nullptr)
   , _truthinfo(nullptr)
   , _strict(false)
-  , _use_initial_vertex(false)
   , _verbosity(0)
   , _errors(0)
   , _do_cache(true)
 {
   set_track_nodename("SvtxTrackMap");
-  get_node_pointers(topNode);
 }
 
 SvtxVertexEval::~SvtxVertexEval()
@@ -230,6 +228,7 @@ PHG4VtxPoint* SvtxVertexEval::max_truth_point_by_ntracks(SvtxVertex* vertex)
       max_point = candidate;
     }
   }
+  //std::cout << PHWHERE << " max_point " << max_point->get_id() << " max_ntracks " << max_ntracks << std::endl;
 
   if (_do_cache) _cache_max_truth_point_by_ntracks.insert(make_pair(vertex, max_point));
 
@@ -410,14 +409,16 @@ void SvtxVertexEval::get_node_pointers(PHCompositeNode* topNode)
   {
     _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");  // always there, initial vertices
   }
-  else if (_use_acts_vertex)
+  else if (_use_genfit_vertex)
     {
-      _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
+      _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");  // Rave vertices
     }
   else
   {
-    _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapRefit");  // Rave vertices
+    _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
   }
+  if(!_vertexmap)
+    std::cout << PHWHERE << "Did not find_vertexmap on node tree" << endl;
 
   _trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_TrackNodeName);
 
@@ -431,17 +432,26 @@ bool SvtxVertexEval::has_node_pointers()
   if (_strict)
     assert(_vertexmap);
   else if (!_vertexmap)
-    return false;
+    {
+      std::cout << PHWHERE << " did not find _vertexmap " << std::endl;
+      return false;
+    }
 
   if (_strict)
     assert(_trackmap);
   else if (!_trackmap)
-    return false;
+    {
+      std::cout << PHWHERE << " did not find _trackmap " << std::endl;
+      return false;
+    }
 
   if (_strict)
     assert(_truthinfo);
   else if (!_truthinfo)
-    return false;
+    {
+      std::cout << PHWHERE << " did not find _truthinfo " << std::endl;
+      return false;
+    }
 
   return true;
 }

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.cc
@@ -8,6 +8,8 @@
 #include <trackbase_historic/SvtxVertexMap.h>
 
 #include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4VtxPoint.h>
 
 #include <phool/getClass.h>
 
@@ -161,6 +163,7 @@ std::set<PHG4VtxPoint*> SvtxVertexEval::all_truth_points(SvtxVertex* vertex)
        iter != particles.end();
        ++iter)
   {
+
     PHG4Particle* particle = *iter;
     PHG4VtxPoint* point = get_truth_eval()->get_vertex(particle);
 
@@ -409,7 +412,7 @@ void SvtxVertexEval::get_node_pointers(PHCompositeNode* topNode)
   }
   else if (_use_acts_vertex)
     {
-    _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
+      _vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");  // Acts vertices
     }
   else
   {

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.h
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.h
@@ -81,7 +81,7 @@ class SvtxVertexEval
 
   bool _strict;
   bool _use_initial_vertex;
-  bool _use_acts_vertex;
+  bool _use_acts_vertex = true;
   int _verbosity;
   unsigned int _errors;
 

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.h
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.h
@@ -66,6 +66,7 @@ class SvtxVertexEval
   unsigned int get_errors() { return _errors + _trackeval.get_errors(); }
 
   void set_use_initial_vertex(bool use_init_vertex) { _use_initial_vertex = use_init_vertex; }
+  void set_use_acts_vertex(bool use_acts_vertex) { _use_acts_vertex = use_acts_vertex; }
 
   void set_track_nodename(const std::string& name);
 
@@ -80,6 +81,7 @@ class SvtxVertexEval
 
   bool _strict;
   bool _use_initial_vertex;
+  bool _use_acts_vertex;
   int _verbosity;
   unsigned int _errors;
 

--- a/simulation/g4simulation/g4eval/SvtxVertexEval.h
+++ b/simulation/g4simulation/g4eval/SvtxVertexEval.h
@@ -66,7 +66,7 @@ class SvtxVertexEval
   unsigned int get_errors() { return _errors + _trackeval.get_errors(); }
 
   void set_use_initial_vertex(bool use_init_vertex) { _use_initial_vertex = use_init_vertex; }
-  void set_use_acts_vertex(bool use_acts_vertex) { _use_acts_vertex = use_acts_vertex; }
+  void set_use_genfit_vertex(bool use_genfit_vertex) { _use_genfit_vertex = use_genfit_vertex; }
 
   void set_track_nodename(const std::string& name);
 
@@ -80,8 +80,8 @@ class SvtxVertexEval
   PHG4TruthInfoContainer* _truthinfo;
 
   bool _strict;
-  bool _use_initial_vertex;
-  bool _use_acts_vertex = true;
+  bool _use_initial_vertex = false;
+  bool _use_genfit_vertex = false;
   int _verbosity;
   unsigned int _errors;
 


### PR DESCRIPTION
This PR updates SvtxEvaluator to use SvtxVertexMapActs by default. This is the vertex map made from the final Acts fitted tracks by PHActsVertexing. A switch is provided to allow the use of SvtxVertexMapRefit, which is filled by Rave when Genfit tracking is run. Note that the Acts vertexing handles multiple vertices, while Rave (as now configured) only handles one vertex. 