### PR TITLE
Cluster

### DIFF
--- a/offline/packages/CaloReco/BEmcCluster.cc
+++ b/offline/packages/CaloReco/BEmcCluster.cc
@@ -133,7 +133,7 @@ float EmcCluster::GetECoreCorrected()
   float ecore, ecorecorr;
   ecore = GetECore();
   fOwner->Momenta(&fHitList, e, x, y, xx, yy, xy);
-  fOwner->CorrectECore(ecore, x, y, &ecorecorr);
+  fOwner->CorrectECore(ecore, x, y, ecorecorr);
   return ecorecorr;
 }
 

--- a/offline/packages/CaloReco/BEmcRec.h
+++ b/offline/packages/CaloReco/BEmcRec.h
@@ -85,8 +85,8 @@ class BEmcRec
   virtual float PredictEnergyParam(float, float, float);
 
   // Calorimeter specific functions to be specified in respective inherited object
-  virtual void CorrectEnergy(float energy, float x, float y, float *ecorr) { *ecorr = energy; }
-  virtual void CorrectECore(float ecore, float x, float y, float *ecorecorr) { *ecorecorr = ecore; }
+  virtual void CorrectEnergy(float energy, float x, float y, float &ecorr) { ecorr = energy; }
+  virtual void CorrectECore(float ecore, float x, float y, float &ecorecorr) { ecorecorr = ecore; }
   virtual void CorrectPosition(float energy, float x, float y, float &xcorr, float &ycorr)
   {
     xcorr = x;

--- a/offline/packages/CaloReco/BEmcRecCEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecCEMC.cc
@@ -244,7 +244,7 @@ void BEmcRecCEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, floa
 }
 
 void BEmcRecCEMC::CorrectEnergy(float Energy, float x, float y,
-                                float* Ecorr)
+                                float& Ecorr)
 {
   // Corrects the EM Shower Energy for attenuation in fibers and
   // long energy leakage
@@ -266,10 +266,10 @@ void BEmcRecCEMC::CorrectEnergy(float Energy, float x, float y,
   corr = leak*att;
   *Ecorr = Energy/corr;
   */
-  *Ecorr = Energy;
+  Ecorr = Energy;
 }
 
-void BEmcRecCEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
+void BEmcRecCEMC::CorrectECore(float Ecore, float x, float y, float& Ecorr)
 {
   // Corrects the EM Shower Core Energy for attenuation in fibers,
   // long energy leakage and angle dependance
@@ -277,7 +277,7 @@ void BEmcRecCEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
   // (x,y) - impact position (cm) in Sector frame
 
   const float c0 = 0.950;  // For no threshold
-  *Ecorr = Ecore / c0;
+  Ecorr = Ecore / c0;
 }
 
 void BEmcRecCEMC::CorrectPosition(float Energy, float x, float y,
@@ -346,6 +346,8 @@ void BEmcRecCEMC::CorrectPosition(float Energy, float x, float y,
   //  dx = 0;
 
   xc = x0 - dx;
+  while (xc < -0.5) xc += float(fNx);
+  while (xc >= fNx - 0.5) xc -= float(fNx);
 
   y0 = y + yZero;
   iy0 = EmcCluster::lowint(y0 + 0.5);

--- a/offline/packages/CaloReco/BEmcRecCEMC.h
+++ b/offline/packages/CaloReco/BEmcRecCEMC.h
@@ -14,8 +14,8 @@ class BEmcRecCEMC : public BEmcRec
  public:
   BEmcRecCEMC();
   virtual ~BEmcRecCEMC();
-  void CorrectEnergy(float energy, float x, float y, float *ecorr) override;
-  void CorrectECore(float ecore, float x, float y, float *ecorecorr) override;
+  void CorrectEnergy(float energy, float x, float y, float &ecorr) override;
+  void CorrectECore(float ecore, float x, float y, float &ecorecorr) override;
   void CorrectPosition(float energy, float x, float y, float &xcorr, float &ycorr) override;
   void CorrectShowerDepth(float energy, float x, float y, float z, float &xc, float &yc, float &zc) override;
 

--- a/offline/packages/CaloReco/BEmcRecEEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecEEMC.cc
@@ -69,19 +69,19 @@ void BEmcRecEEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, floa
 }
 
 void BEmcRecEEMC::CorrectEnergy(float Energy, float x, float y,
-                                float* Ecorr)
+                                float& Ecorr)
 {
-  *Ecorr = Energy;
+  Ecorr = Energy;
 }
 
-void BEmcRecEEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
+void BEmcRecEEMC::CorrectECore(float Ecore, float x, float y, float& Ecorr)
 {
   // Corrects the EM Shower Core Energy for attenuation in fibers,
   // long energy leakage and angle dependance
   //
   // (x,y) - shower CG in tower units (not projected anywhere!)
 
-  *Ecorr = Ecore;
+  Ecorr = Ecore;
 }
 
 float BEmcRecEEMC::GetImpactAngle(float e, float x, float y)

--- a/offline/packages/CaloReco/BEmcRecEEMC.h
+++ b/offline/packages/CaloReco/BEmcRecEEMC.h
@@ -14,8 +14,8 @@ class BEmcRecEEMC : public BEmcRec
  public:
   BEmcRecEEMC();
   virtual ~BEmcRecEEMC();
-  void CorrectEnergy(float energy, float x, float y, float *ecorr) override;
-  void CorrectECore(float ecore, float x, float y, float *ecorecorr) override;
+  void CorrectEnergy(float energy, float x, float y, float &ecorr) override;
+  void CorrectECore(float ecore, float x, float y, float &ecorecorr) override;
   void CorrectPosition(float energy, float x, float y, float &xcorr, float &ycorr) override;
   void CorrectShowerDepth(float energy, float x, float y, float z, float &xc, float &yc, float &zc) override;
   static float GetImpactAngle(float e, float x, float y);

--- a/offline/packages/CaloReco/BEmcRecFEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecFEMC.cc
@@ -72,9 +72,9 @@ void BEmcRecFEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, floa
 }
 
 void BEmcRecFEMC::CorrectEnergy(float Energy, float x, float y,
-                                float* Ecorr)
+                                float& Ecorr)
 {
-  *Ecorr = Energy;
+  Ecorr = Energy;
 }
 
 float BEmcRecFEMC::GetImpactAngle(float e, float x, float y)
@@ -94,20 +94,20 @@ float BEmcRecFEMC::GetImpactAngle(float e, float x, float y)
   return 0;
 }
 
-void BEmcRecFEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
+void BEmcRecFEMC::CorrectECore(float Ecore, float x, float y, float& Ecorr)
 {
   // Corrects the EM Shower Core Energy for attenuation in fibers,
   // long energy leakage and angle dependance
   //
   // (x,y) - shower CG in tower units (not projected anywhere!)
 
-  //  *Ecorr = Ecore;
+  //  Ecorr = Ecore;
   float ec, ec2, corr;
   const float par1 = 0.938;
   const float par2 = 0.50;
   const float par3 = 0.067;
 
-  *Ecorr = Ecore;
+  Ecorr = Ecore;
   if (Ecore < 0.01) return;
 
   float xA, yA, zA;
@@ -118,7 +118,7 @@ void BEmcRecFEMC::CorrectECore(float Ecore, float x, float y, float* Ecorr)
 
   //  CorrectEnergy( ec, x, y, &ec2);
   ec2 = ec;  // !!!!! CorrectEnergy must be implemented
-  *Ecorr = ec2;
+  Ecorr = ec2;
 }
 
 void BEmcRecFEMC::CorrectPosition(float Energy, float x, float y,

--- a/offline/packages/CaloReco/BEmcRecFEMC.h
+++ b/offline/packages/CaloReco/BEmcRecFEMC.h
@@ -14,8 +14,8 @@ class BEmcRecFEMC : public BEmcRec
  public:
   BEmcRecFEMC();
   virtual ~BEmcRecFEMC();
-  void CorrectEnergy(float energy, float x, float y, float *ecorr) override;
-  void CorrectECore(float ecore, float x, float y, float *ecorecorr) override;
+  void CorrectEnergy(float energy, float x, float y, float &ecorr) override;
+  void CorrectECore(float ecore, float x, float y, float &ecorecorr) override;
   void CorrectPosition(float energy, float x, float y, float &xcorr, float &ycorr) override;
   void CorrectShowerDepth(float energy, float x, float y, float z, float &xc, float &yc, float &zc) override;
   static float GetImpactAngle(float e, float x, float y);


### PR DESCRIPTION
1. Small correction in BEmcCEMC::CorrectPosition to avoid potential problem when the correction moves the measurement from N-1 tower to 0th tower in cylindrical geometry
2. A minor code polishing: switch from pointer argument to a reference argument in Energy correction functions of BEmcRec
No impact when running Fun4All_sPHENIX expected. 
