### PR TITLE
Headreco

### DIFF
--- a/generators/FermiMotionAfterburner/FermiMotion.cc
+++ b/generators/FermiMotionAfterburner/FermiMotion.cc
@@ -20,6 +20,7 @@
 #include <CLHEP/Vector/LorentzVector.h>
 
 #include <cmath>
+#include <cstdlib>  // for exit
 #include <iostream>
 
 //____________________________________________________________________________..
@@ -83,7 +84,7 @@ int FermiMotion(HepMC::GenEvent *event, gsl_rng *RandomGenerator)
   //find ploss
   //std::cout<<"getting b"<<std::endl;
   HepMC::HeavyIon *hi = event->heavy_ion();
-  if (! hi)
+  if (!hi)
   {
     std::cout << PHWHERE << ": Fermi Motion Afterburner needs the Heavy Ion Event Info, GenEvent::heavy_ion() returns NULL" << std::endl;
     exit(1);
@@ -100,16 +101,15 @@ int FermiMotion(HepMC::GenEvent *event, gsl_rng *RandomGenerator)
     float p_x = (*p)->momentum().px();
     float p_y = (*p)->momentum().py();
     if (!(p_x == 0 && p_y == 0)) continue;
-    
+
     if (id == 2112)
     {
       if (pnl > gsl_rng_uniform_pos(RandomGenerator))
       {
         //remove particle here
         delete ((*p)->production_vertex())->remove_particle(*p);
-	p = prev;
-	continue;
-        
+        p = prev;
+        continue;
       }
     }
 
@@ -124,7 +124,6 @@ int FermiMotion(HepMC::GenEvent *event, gsl_rng *RandomGenerator)
     v->add_particle_in(*p);
     v->add_particle_out(n);
     event->add_vertex(v);
-    
   }
 
   return 0;

--- a/generators/flowAfterburner/flowAfterburner.cc
+++ b/generators/flowAfterburner/flowAfterburner.cc
@@ -31,6 +31,7 @@
 #include <CLHEP/Vector/LorentzVector.h>
 
 #include <cmath>
+#include <cstdlib>  // for exit
 #include <iostream>
 #include <map>  // for map
 
@@ -297,7 +298,7 @@ int flowAfterburner(HepMC::GenEvent *event,
 {
   algorithm = algorithms[algorithmName];
   HepMC::HeavyIon *hi = event->heavy_ion();
-  if (! hi)
+  if (!hi)
   {
     std::cout << PHWHERE << ": Flow Afterburner needs the Heavy Ion Event Info, GenEvent::heavy_ion() returns NULL" << std::endl;
     exit(1);

--- a/generators/flowAfterburner/flowAfterburner.h
+++ b/generators/flowAfterburner/flowAfterburner.h
@@ -5,11 +5,11 @@
 
 namespace CLHEP
 {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 namespace HepMC
 {
-class GenEvent;
+  class GenEvent;
 }
 
 enum flowAfterburnerAlgorithm

--- a/offline/framework/ffamodules/HeadReco.cc
+++ b/offline/framework/ffamodules/HeadReco.cc
@@ -1,0 +1,127 @@
+#include "HeadReco.h"
+
+#include <ffaobjects/EventHeader.h>
+#include <ffaobjects/EventHeaderv1.h>
+#include <ffaobjects/RunHeader.h>
+#include <ffaobjects/RunHeaderv1.h>
+#include <ffaobjects/FlagSave.h>
+#include <ffaobjects/FlagSavev1.h>
+
+#include <phhepmc/PHHepMCGenEvent.h>
+#include <phhepmc/PHHepMCGenEventMap.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>          // for PHIODataNode
+#include <phool/PHNode.h>                // for PHNode
+#include <phool/PHNodeIterator.h>        // for PHNodeIterator
+#include <phool/PHObject.h>              // for PHObject
+#include <phool/phool.h>
+#include <phool/recoConsts.h>
+
+#include <TSystem.h>
+
+#include <HepMC/GenEvent.h>
+#include <HepMC/HeavyIon.h>              // for HeavyIon
+
+#include <cstdlib>
+#include <iostream>
+
+using namespace std;
+
+HeadReco::HeadReco(const std::string &name):
+  SubsysReco(name)
+{}	   
+
+// the nodes need to be created here since at least one input manager uses
+// the event header. Creating them in InitRun() will be too late
+int HeadReco::Init(PHCompositeNode *topNode)
+{
+  
+PHNodeIterator iter(topNode);
+PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *> (iter.findFirst("PHCompositeNode","RUN"));
+RunHeader *runheader = new RunHeaderv1();
+PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(runheader,"RunHeader","PHObject");
+runNode->addNode(newNode);
+
+
+FlagSave *flgsv = new FlagSavev1();
+newNode = new PHIODataNode<PHObject>(flgsv, "Flags", "PHObject");
+runNode->addNode(newNode);
+
+PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *> (iter.findFirst("PHCompositeNode","DST"));
+EventHeader *eventheader = new EventHeaderv1();
+newNode = new PHIODataNode<PHObject>(eventheader,"EventHeader","PHObject");
+dstNode->addNode(newNode);
+
+return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int HeadReco::InitRun(PHCompositeNode *topNode)
+{
+recoConsts *rc = recoConsts::instance();
+RunHeader *runheader = findNode::getClass<RunHeader>(topNode,"RunHeader");
+runheader->set_RunNumber(rc->get_IntFlag("RUNNUMBER"));
+return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int
+HeadReco::process_event(PHCompositeNode *topNode)
+{
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  EventHeader *evtheader = findNode::getClass<EventHeader>(topNode,"EventHeader");
+  PHHepMCGenEventMap *genevtmap = findNode::getClass<PHHepMCGenEventMap>(topNode, "PHHepMCGenEventMap");
+
+  if (genevtmap)
+  {
+  for (PHHepMCGenEventMap::ReverseIter iter = genevtmap->rbegin(); iter != genevtmap->rend(); ++iter)
+  {
+  PHHepMCGenEvent *genevt = iter->second;
+  int embed_flag = genevt->get_embedding_id();
+  if (embed_flag == 0) // should be foreground event
+  {
+
+  HepMC::GenEvent *hepmcevt = genevt->getEvent();
+
+  if (hepmcevt)
+  {
+  HepMC::HeavyIon *hi = hepmcevt->heavy_ion();
+  if (hi)
+  {
+  evtheader->set_ImpactParameter(hi->impact_parameter());
+  evtheader->set_EventPlaneAngle(hi->event_plane_angle());
+  evtheader->set_eccentricity(hi->eccentricity());
+  evtheader->set_ncoll(hi->Ncoll());
+  evtheader->set_npart(hi->Npart_targ()+hi->Npart_proj());
+  }
+  }
+  }
+  }
+  }
+  evtheader->set_RunNumber(se->RunNumber());
+  evtheader->set_EvtSequence(se->EventNumber());
+  if (Verbosity() > 0)
+  {
+  evtheader->identify();
+  }
+
+return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int HeadReco::EndRun(const int runno)
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  FlagSave* flagsave = findNode::getClass<FlagSave>(se->topNode(), "Flags");
+  if (flagsave)
+    {
+      recoConsts *rc = recoConsts::instance();
+      cout << "Saving recoConst Flags: " << endl;
+      flagsave->FillFromPHFlag(rc);
+      flagsave->identify();
+    }
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/framework/ffamodules/HeadReco.cc
+++ b/offline/framework/ffamodules/HeadReco.cc
@@ -2,10 +2,10 @@
 
 #include <ffaobjects/EventHeader.h>
 #include <ffaobjects/EventHeaderv1.h>
-#include <ffaobjects/RunHeader.h>
-#include <ffaobjects/RunHeaderv1.h>
 #include <ffaobjects/FlagSave.h>
 #include <ffaobjects/FlagSavev1.h>
+#include <ffaobjects/RunHeader.h>
+#include <ffaobjects/RunHeaderv1.h>
 
 #include <phhepmc/PHHepMCGenEvent.h>
 #include <phhepmc/PHHepMCGenEventMap.h>
@@ -13,115 +13,111 @@
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
 
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>          // for PHIODataNode
-#include <phool/PHNode.h>                // for PHNode
-#include <phool/PHNodeIterator.h>        // for PHNodeIterator
-#include <phool/PHObject.h>              // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
+#include <phool/getClass.h>
 #include <phool/phool.h>
 #include <phool/recoConsts.h>
 
 #include <TSystem.h>
 
 #include <HepMC/GenEvent.h>
-#include <HepMC/HeavyIon.h>              // for HeavyIon
+#include <HepMC/HeavyIon.h>  // for HeavyIon
 
 #include <cstdlib>
 #include <iostream>
 
 using namespace std;
 
-HeadReco::HeadReco(const std::string &name):
-  SubsysReco(name)
-{}	   
+HeadReco::HeadReco(const std::string &name)
+  : SubsysReco(name)
+{
+}
 
 // the nodes need to be created here since at least one input manager uses
 // the event header. Creating them in InitRun() will be too late
 int HeadReco::Init(PHCompositeNode *topNode)
 {
-  
-PHNodeIterator iter(topNode);
-PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *> (iter.findFirst("PHCompositeNode","RUN"));
-RunHeader *runheader = new RunHeaderv1();
-PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(runheader,"RunHeader","PHObject");
-runNode->addNode(newNode);
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+  RunHeader *runheader = new RunHeaderv1();
+  PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(runheader, "RunHeader", "PHObject");
+  runNode->addNode(newNode);
 
+  FlagSave *flgsv = new FlagSavev1();
+  newNode = new PHIODataNode<PHObject>(flgsv, "Flags", "PHObject");
+  runNode->addNode(newNode);
 
-FlagSave *flgsv = new FlagSavev1();
-newNode = new PHIODataNode<PHObject>(flgsv, "Flags", "PHObject");
-runNode->addNode(newNode);
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  EventHeader *eventheader = new EventHeaderv1();
+  newNode = new PHIODataNode<PHObject>(eventheader, "EventHeader", "PHObject");
+  dstNode->addNode(newNode);
 
-PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *> (iter.findFirst("PHCompositeNode","DST"));
-EventHeader *eventheader = new EventHeaderv1();
-newNode = new PHIODataNode<PHObject>(eventheader,"EventHeader","PHObject");
-dstNode->addNode(newNode);
-
-return Fun4AllReturnCodes::EVENT_OK;
+  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int HeadReco::InitRun(PHCompositeNode *topNode)
 {
-recoConsts *rc = recoConsts::instance();
-RunHeader *runheader = findNode::getClass<RunHeader>(topNode,"RunHeader");
-runheader->set_RunNumber(rc->get_IntFlag("RUNNUMBER"));
-return Fun4AllReturnCodes::EVENT_OK;
+  recoConsts *rc = recoConsts::instance();
+  RunHeader *runheader = findNode::getClass<RunHeader>(topNode, "RunHeader");
+  runheader->set_RunNumber(rc->get_IntFlag("RUNNUMBER"));
+  return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int
-HeadReco::process_event(PHCompositeNode *topNode)
+int HeadReco::process_event(PHCompositeNode *topNode)
 {
-
   Fun4AllServer *se = Fun4AllServer::instance();
-  EventHeader *evtheader = findNode::getClass<EventHeader>(topNode,"EventHeader");
+  EventHeader *evtheader = findNode::getClass<EventHeader>(topNode, "EventHeader");
   PHHepMCGenEventMap *genevtmap = findNode::getClass<PHHepMCGenEventMap>(topNode, "PHHepMCGenEventMap");
 
   if (genevtmap)
   {
-  for (PHHepMCGenEventMap::ReverseIter iter = genevtmap->rbegin(); iter != genevtmap->rend(); ++iter)
-  {
-  PHHepMCGenEvent *genevt = iter->second;
-  int embed_flag = genevt->get_embedding_id();
-  if (embed_flag == 0) // should be foreground event
-  {
+    for (PHHepMCGenEventMap::ReverseIter iter = genevtmap->rbegin(); iter != genevtmap->rend(); ++iter)
+    {
+      PHHepMCGenEvent *genevt = iter->second;
+      int embed_flag = genevt->get_embedding_id();
+      if (embed_flag == 0)  // should be foreground event
+      {
+        HepMC::GenEvent *hepmcevt = genevt->getEvent();
 
-  HepMC::GenEvent *hepmcevt = genevt->getEvent();
-
-  if (hepmcevt)
-  {
-  HepMC::HeavyIon *hi = hepmcevt->heavy_ion();
-  if (hi)
-  {
-  evtheader->set_ImpactParameter(hi->impact_parameter());
-  evtheader->set_EventPlaneAngle(hi->event_plane_angle());
-  evtheader->set_eccentricity(hi->eccentricity());
-  evtheader->set_ncoll(hi->Ncoll());
-  evtheader->set_npart(hi->Npart_targ()+hi->Npart_proj());
-  }
-  }
-  }
-  }
+        if (hepmcevt)
+        {
+          HepMC::HeavyIon *hi = hepmcevt->heavy_ion();
+          if (hi)
+          {
+            evtheader->set_ImpactParameter(hi->impact_parameter());
+            evtheader->set_EventPlaneAngle(hi->event_plane_angle());
+            evtheader->set_eccentricity(hi->eccentricity());
+            evtheader->set_ncoll(hi->Ncoll());
+            evtheader->set_npart(hi->Npart_targ() + hi->Npart_proj());
+          }
+        }
+      }
+    }
   }
   evtheader->set_RunNumber(se->RunNumber());
   evtheader->set_EvtSequence(se->EventNumber());
   if (Verbosity() > 0)
   {
-  evtheader->identify();
+    evtheader->identify();
   }
 
-return Fun4AllReturnCodes::EVENT_OK;
+  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int HeadReco::EndRun(const int runno)
 {
   Fun4AllServer *se = Fun4AllServer::instance();
-  FlagSave* flagsave = findNode::getClass<FlagSave>(se->topNode(), "Flags");
+  FlagSave *flagsave = findNode::getClass<FlagSave>(se->topNode(), "Flags");
   if (flagsave)
-    {
-      recoConsts *rc = recoConsts::instance();
-      cout << "Saving recoConst Flags: " << endl;
-      flagsave->FillFromPHFlag(rc);
-      flagsave->identify();
-    }
+  {
+    recoConsts *rc = recoConsts::instance();
+    cout << "Saving recoConst Flags: " << endl;
+    flagsave->FillFromPHFlag(rc);
+    flagsave->identify();
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/framework/ffamodules/HeadReco.h
+++ b/offline/framework/ffamodules/HeadReco.h
@@ -1,0 +1,26 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef FFAMODULES_HEADRECO_H
+#define FFAMODULES_HEADRECO_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>                // for string
+
+class PHCompositeNode;
+
+class HeadReco: public SubsysReco
+{
+ public:
+  HeadReco(const std::string &name="HeadReco");
+  virtual ~HeadReco(){}
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int EndRun(const int runno);
+
+ protected:
+
+};
+
+#endif

--- a/offline/framework/ffamodules/HeadReco.h
+++ b/offline/framework/ffamodules/HeadReco.h
@@ -5,22 +5,21 @@
 
 #include <fun4all/SubsysReco.h>
 
-#include <string>                // for string
+#include <string>  // for string
 
 class PHCompositeNode;
 
-class HeadReco: public SubsysReco
+class HeadReco : public SubsysReco
 {
  public:
-  HeadReco(const std::string &name="HeadReco");
-  virtual ~HeadReco(){}
+  HeadReco(const std::string &name = "HeadReco");
+  virtual ~HeadReco() {}
   int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
   int EndRun(const int runno);
 
  protected:
-
 };
 
 #endif

--- a/offline/framework/ffamodules/Makefile.am
+++ b/offline/framework/ffamodules/Makefile.am
@@ -15,13 +15,16 @@ AM_LDFLAGS = \
 libffamodules_la_LIBADD = \
   -lfun4all \
   -lffaobjects \
+  -lphhepmc \
   -lSubsysReco
 
 
 pkginclude_HEADERS = \
+  HeadReco.h \
   SyncReco.h
 
 libffamodules_la_SOURCES = \
+  HeadReco.cc \
   SyncReco.cc
 
 BUILT_SOURCES = testexternals.cc

--- a/offline/framework/ffaobjects/EventHeader.cc
+++ b/offline/framework/ffaobjects/EventHeader.cc
@@ -2,29 +2,26 @@
 #include <iostream>
 
 /// Clear Event
-void
-EventHeader::Reset()
+void EventHeader::Reset()
 {
   std::cout << __PRETTY_FUNCTION__
-      << "ERROR Reset() not implemented by daughter class" << std::endl;
+            << "ERROR Reset() not implemented by daughter class" << std::endl;
   return;
 }
 
 /** identify Function from PHObject
  @param os Output Stream
  */
-void
-EventHeader::identify(std::ostream& os) const
+void EventHeader::identify(std::ostream& os) const
 {
   os << "identify yourself: virtual EventHeader Object" << std::endl;
   return;
 }
 
 /// isValid returns non zero if object contains valid data
-int
-EventHeader::isValid() const
+int EventHeader::isValid() const
 {
   std::cout << __PRETTY_FUNCTION__ << "isValid not implemented by daughter class"
-      << std::endl;
+            << std::endl;
   return 0;
 }

--- a/offline/framework/ffaobjects/EventHeader.h
+++ b/offline/framework/ffaobjects/EventHeader.h
@@ -5,7 +5,7 @@
 
 #include <phool/PHObject.h>
 
-#include <ctime>
+#include <cmath>
 #include <iostream>          // for cout, ostream
 
 //! base class for EventHeaders
@@ -39,21 +39,37 @@ class EventHeader: public PHObject
   virtual void set_EvtSequence(const int /*ival*/) {return;}
 
   /// get Event Type (Data,rejected,EOR,BOR,...)
-  virtual int get_EvtType() const {return -9999;}
+  virtual int get_EvtType() const {return get_intval("type");}
   /// set Event Type (Data,rejected,EOR,BOR,...)
-  virtual void set_EvtType(const int /*ival*/) {return;}
+  virtual void set_EvtType(const int ival) {set_intval("type",ival);}
 
-  /// get ATP TimeStamp (unix time, convert with ctime()
-  virtual time_t get_TimeStamp() const {return 0;}
-  
-  /// set TimeStamp
-  virtual void set_TimeStamp(const time_t /*evttime*/) {return;}
-
-  //! bunch crossing
-  virtual void set_BunchCrossing( int64_t ) {}
   
   //! bunch crossing
-  virtual int64_t get_BunchCrossing() const {return 0;}
+  virtual void set_BunchCrossing( int64_t bcr ) {set_intval("bcr",bcr);}
+  
+  //! bunch crossing
+  virtual int64_t get_BunchCrossing() const {return get_intval("bcr");}
+
+  virtual void set_floatval(const std::string &name, const float fval) {return;}
+  virtual float get_floatval(const std::string &name) const {return NAN;}
+
+  virtual void set_intval(const std::string &name, const int64_t ival) {return;}
+  virtual int64_t get_intval(const std::string &name) const {return -999999;}
+
+  void set_ImpactParameter(const double rval) {set_floatval("bimp",rval);}
+  float get_ImpactParameter() const {return get_floatval("bimp");}
+
+  void set_EventPlaneAngle(const double rval) {set_floatval("rplane",rval);}
+  float get_EventPlaneAngle() const {return get_floatval("rplane");}
+
+  void set_eccentricity(const double rval) {set_floatval("ecc",rval);}
+  float get_eccentricity() const {return get_floatval("ecc");}
+
+  void set_ncoll(const int ival) {set_intval("ncoll",ival);}
+  int get_ncoll() const {return get_intval("ncoll");}
+
+  void set_npart(const int ival) {set_intval("npart",ival);}
+  int get_npart() const {return get_intval("npart");}
 
   private: // prevent doc++ from showing ClassDef
   ClassDef(EventHeader,1)

--- a/offline/framework/ffaobjects/EventHeader.h
+++ b/offline/framework/ffaobjects/EventHeader.h
@@ -6,13 +6,13 @@
 #include <phool/PHObject.h>
 
 #include <cmath>
-#include <iostream>          // for cout, ostream
+#include <cstdint>   // for int64_t
+#include <iostream>  // for cout, ostream
 
 //! base class for EventHeaders
-class EventHeader: public PHObject
+class EventHeader : public PHObject
 {
  public:
-
   /// dtor
   virtual ~EventHeader() = default;
 
@@ -23,60 +23,55 @@ class EventHeader: public PHObject
    * identify Function from PHObject
    * @param os Output Stream 
    */
-  virtual void identify(std::ostream& os = std::cout) const;
+  virtual void identify(std::ostream &os = std::cout) const;
 
   /// isValid returns non zero if object contains valid data
   virtual int isValid() const;
 
   /// get Run Number
-  virtual int get_RunNumber() const {return -9999;}
+  virtual int get_RunNumber() const { return 0; }
   /// set Run Number
-  virtual void set_RunNumber(const int run) {return;}
+  virtual void set_RunNumber(const int run) { return; }
 
   /// get Event Number
-  virtual int get_EvtSequence() const {return -9999;}
+  virtual int get_EvtSequence() const { return 0; }
   /// set Event Number
-  virtual void set_EvtSequence(const int /*ival*/) {return;}
+  virtual void set_EvtSequence(const int /*ival*/) { return; }
+
+  //! bunch crossing
+  virtual void set_BunchCrossing(int64_t bcr) { set_intval("bcr", bcr); }
+
+  //! bunch crossing
+  virtual int64_t get_BunchCrossing() const { return get_intval("bcr"); }
+
+  virtual void set_floatval(const std::string &name, const float fval) { return; }
+  virtual float get_floatval(const std::string &name) const { return NAN; }
+
+  virtual void set_intval(const std::string &name, const int64_t ival) { return; }
+  virtual int64_t get_intval(const std::string &name) const { return -999999; }
 
   /// get Event Type (Data,rejected,EOR,BOR,...)
-  virtual int get_EvtType() const {return get_intval("type");}
+  int get_EvtType() const { return get_intval("type"); }
   /// set Event Type (Data,rejected,EOR,BOR,...)
-  virtual void set_EvtType(const int ival) {set_intval("type",ival);}
+  void set_EvtType(const int ival) { set_intval("type", ival); }
 
-  
-  //! bunch crossing
-  virtual void set_BunchCrossing( int64_t bcr ) {set_intval("bcr",bcr);}
-  
-  //! bunch crossing
-  virtual int64_t get_BunchCrossing() const {return get_intval("bcr");}
+  void set_ImpactParameter(const double rval) { set_floatval("bimp", rval); }
+  float get_ImpactParameter() const { return get_floatval("bimp"); }
 
-  virtual void set_floatval(const std::string &name, const float fval) {return;}
-  virtual float get_floatval(const std::string &name) const {return NAN;}
+  void set_EventPlaneAngle(const double rval) { set_floatval("rplane", rval); }
+  float get_EventPlaneAngle() const { return get_floatval("rplane"); }
 
-  virtual void set_intval(const std::string &name, const int64_t ival) {return;}
-  virtual int64_t get_intval(const std::string &name) const {return -999999;}
+  void set_eccentricity(const double rval) { set_floatval("ecc", rval); }
+  float get_eccentricity() const { return get_floatval("ecc"); }
 
-  void set_ImpactParameter(const double rval) {set_floatval("bimp",rval);}
-  float get_ImpactParameter() const {return get_floatval("bimp");}
+  void set_ncoll(const int ival) { set_intval("ncoll", ival); }
+  int get_ncoll() const { return get_intval("ncoll"); }
 
-  void set_EventPlaneAngle(const double rval) {set_floatval("rplane",rval);}
-  float get_EventPlaneAngle() const {return get_floatval("rplane");}
+  void set_npart(const int ival) { set_intval("npart", ival); }
+  int get_npart() const { return get_intval("npart"); }
 
-  void set_eccentricity(const double rval) {set_floatval("ecc",rval);}
-  float get_eccentricity() const {return get_floatval("ecc");}
-
-  void set_ncoll(const int ival) {set_intval("ncoll",ival);}
-  int get_ncoll() const {return get_intval("ncoll");}
-
-  void set_npart(const int ival) {set_intval("npart",ival);}
-  int get_npart() const {return get_intval("npart");}
-
-  private: // prevent doc++ from showing ClassDef
-  ClassDef(EventHeader,1)
-
+ private:  // prevent doc++ from showing ClassDef
+  ClassDef(EventHeader, 1)
 };
 
 #endif
-
-
-

--- a/offline/framework/ffaobjects/EventHeader.h
+++ b/offline/framework/ffaobjects/EventHeader.h
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <cstdint>   // for int64_t
+#include <ctime>
 #include <iostream>  // for cout, ostream
 
 //! base class for EventHeaders
@@ -69,6 +70,9 @@ class EventHeader : public PHObject
 
   void set_npart(const int ival) { set_intval("npart", ival); }
   int get_npart() const { return get_intval("npart"); }
+
+  void set_TimeStamp(const time_t tval) {set_intval("time",tval);}
+  time_t get_TimeStamp() const {return get_intval("time");}
 
  private:  // prevent doc++ from showing ClassDef
   ClassDef(EventHeader, 1)

--- a/offline/framework/ffaobjects/EventHeaderLinkDef.h
+++ b/offline/framework/ffaobjects/EventHeaderLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class EventHeader+;
+#pragma link C++ class EventHeader + ;
 
 #endif

--- a/offline/framework/ffaobjects/EventHeaderv1.cc
+++ b/offline/framework/ffaobjects/EventHeaderv1.cc
@@ -4,18 +4,12 @@
 
 using namespace std;
 
-EventHeaderv1::EventHeaderv1()
-{
-  Reset();
-  return;
-}
-
 void EventHeaderv1::Reset()
 {
   RunNumber = 0;
-  TimeStamp = 0;
-  EvtSequence = -999999;
-  EvtType = -999999;
+  EvtSequence = 0;
+  m_IntEventProperties.clear();
+  m_FloatEventProperties.clear();
   return;
 }
 
@@ -24,15 +18,53 @@ void EventHeaderv1::identify(ostream& out) const
   out << "identify yourself: I am an EventHeaderv1 Object" << endl;
   out << "Run Number: " << RunNumber 
       << ", Event no: " << EvtSequence 
-      << ", Type: " << EvtType 
-      << ", DAQ arrival time: " << ctime(&TimeStamp)
       << endl;
-
+  auto iter = m_IntEventProperties.begin();
+  while(iter !=  m_IntEventProperties.end())
+  {
+    out << iter->first << ": " << iter->second << endl;
+    ++iter;
+  }
+  auto iterf = m_FloatEventProperties.begin();
+  while(iterf !=  m_FloatEventProperties.end())
+  {
+    out << iterf->first << ": " << iterf->second << endl;
+    ++iterf;
+  }
   return;
 }
 
 int EventHeaderv1::isValid() const
 {
-  return((TimeStamp) ? 1:0); // return 1 if TimeStamp is not zero
+  return((RunNumber) ? 1:0); // return 1 if runnumber is not zero
 }
 
+void EventHeaderv1::set_floatval(const std::string &name, const float fval)
+{
+  m_FloatEventProperties[name] = fval;
+}
+
+float EventHeaderv1::get_floatval(const std::string &name) const
+{
+  std::map<std::string, float>::const_iterator iter = m_FloatEventProperties.find(name);
+  if (iter != m_FloatEventProperties.end())
+  {
+    return iter->second;
+  }
+  return NAN;
+}
+
+void EventHeaderv1::set_intval(const std::string &name, const int64_t ival)
+{
+  m_IntEventProperties[name] = ival;
+}
+
+int64_t EventHeaderv1::get_intval(const std::string &name) const
+{
+  auto iter = m_IntEventProperties.find(name);
+  if (iter != m_IntEventProperties.end())
+  {
+    return iter->second;
+  }
+  return -999999;
+}

--- a/offline/framework/ffaobjects/EventHeaderv1.cc
+++ b/offline/framework/ffaobjects/EventHeaderv1.cc
@@ -13,20 +13,20 @@ void EventHeaderv1::Reset()
   return;
 }
 
-void EventHeaderv1::identify(ostream& out) const
+void EventHeaderv1::identify(ostream &out) const
 {
   out << "identify yourself: I am an EventHeaderv1 Object" << endl;
-  out << "Run Number: " << RunNumber 
-      << ", Event no: " << EvtSequence 
+  out << "Run Number: " << RunNumber
+      << ", Event no: " << EvtSequence
       << endl;
   auto iter = m_IntEventProperties.begin();
-  while(iter !=  m_IntEventProperties.end())
+  while (iter != m_IntEventProperties.end())
   {
     out << iter->first << ": " << iter->second << endl;
     ++iter;
   }
   auto iterf = m_FloatEventProperties.begin();
-  while(iterf !=  m_FloatEventProperties.end())
+  while (iterf != m_FloatEventProperties.end())
   {
     out << iterf->first << ": " << iterf->second << endl;
     ++iterf;
@@ -36,7 +36,7 @@ void EventHeaderv1::identify(ostream& out) const
 
 int EventHeaderv1::isValid() const
 {
-  return((RunNumber) ? 1:0); // return 1 if runnumber is not zero
+  return ((RunNumber) ? 1 : 0);  // return 1 if runnumber is not zero
 }
 
 void EventHeaderv1::set_floatval(const std::string &name, const float fval)

--- a/offline/framework/ffaobjects/EventHeaderv1.cc
+++ b/offline/framework/ffaobjects/EventHeaderv1.cc
@@ -2,8 +2,6 @@
 
 #include <iostream>
 
-using namespace std;
-
 void EventHeaderv1::Reset()
 {
   RunNumber = 0;
@@ -13,22 +11,22 @@ void EventHeaderv1::Reset()
   return;
 }
 
-void EventHeaderv1::identify(ostream &out) const
+void EventHeaderv1::identify(std::ostream &out) const
 {
-  out << "identify yourself: I am an EventHeaderv1 Object" << endl;
+  out << "identify yourself: I am an EventHeaderv1 Object" << std::endl;
   out << "Run Number: " << RunNumber
       << ", Event no: " << EvtSequence
-      << endl;
+      << std::endl;
   auto iter = m_IntEventProperties.begin();
   while (iter != m_IntEventProperties.end())
   {
-    out << iter->first << ": " << iter->second << endl;
+    out << iter->first << ": " << iter->second << std::endl;
     ++iter;
   }
   auto iterf = m_FloatEventProperties.begin();
   while (iterf != m_FloatEventProperties.end())
   {
-    out << iterf->first << ": " << iterf->second << endl;
+    out << iterf->first << ": " << iterf->second << std::endl;
     ++iterf;
   }
   return;

--- a/offline/framework/ffaobjects/EventHeaderv1.h
+++ b/offline/framework/ffaobjects/EventHeaderv1.h
@@ -7,6 +7,8 @@
 
 #include <ctime>         // for time_t
 #include <iostream>       // for cout, ostream
+#include <map>
+#include <string>
 
 class PHObject;
 
@@ -16,52 +18,57 @@ class EventHeaderv1: public EventHeader
  public:
 
   /// ctor
-  EventHeaderv1();
+  EventHeaderv1() = default;
   /// dtor
-  virtual ~EventHeaderv1() {}
+  virtual ~EventHeaderv1() = default;
 
-  PHObject *CloneMe() const { return new EventHeaderv1(*this); }
+  PHObject *CloneMe() const override { return new EventHeaderv1(*this); }
 
   ///  Clear Event
-  void Reset();
+  void Reset() override;
 
   /** identify Function from PHObject
       @param os Output Stream 
    */
-  void identify(std::ostream& os = std::cout) const;
+  void identify(std::ostream& os = std::cout) const override;
 
   /// isValid returns non zero if object contains valid data
-  int isValid() const;
+  int isValid() const override;
 
   /// get Run Number
-  int get_RunNumber() const {return RunNumber;}
+  int get_RunNumber() const override {return RunNumber;}
   /// set Run Number
-  void set_RunNumber(const int run) {RunNumber=run; return;}
+  void set_RunNumber(const int run) override {RunNumber=run;}
 
   /// get Event Number
-  int get_EvtSequence() const {return EvtSequence;}
+  int get_EvtSequence() const override {return EvtSequence;}
   /// set Event Number
-  void set_EvtSequence(const int evtno) {EvtSequence=evtno; return;}
+  void set_EvtSequence(const int evtno) override {EvtSequence=evtno;}
 
-  /// get Event Type (Data,rejected,EOR,BOR,...)
-  int get_EvtType() const {return EvtType;}
-  /// set Event Type (Data,rejected,EOR,BOR,...)
-  void set_EvtType(const int ival) {EvtType = ival; return;}
+  void set_floatval(const std::string &name, const float fval) override;
+  float get_floatval(const std::string &name) const override;
 
-  /// get ATP TimeStamp (unix time, convert with ctime() to date string 
-  time_t  get_TimeStamp() const {return TimeStamp;}
-  /// set ATP TimeStamp
-  void set_TimeStamp(const time_t evttime) {TimeStamp = evttime; return;}
+  void set_intval(const std::string &name, const int64_t ival) override;
+  int64_t get_intval(const std::string &name) const override;
 
- protected:
+ private:
 
-  int RunNumber;  // Run number
-  int EvtSequence;  // Event number
-  int EvtType;      // Data type (Data,Rejected,Scaler,PPG ...)
-  time_t TimeStamp;  // TimeStamp of Evt from ATP in Ticks 
+  int RunNumber = 0;  // Run number
+  int EvtSequence = 0;  // Event number
+  std::map<std::string, int64_t> m_IntEventProperties;
+  std::map<std::string, float> m_FloatEventProperties;
 
- private: // prevent doc++ from showing ClassDef
-  ClassDef(EventHeaderv1,1)
+// rootcling and clang complain about inconsistent overrides in the ClassDef
+// this can be supressed with ignoring -Winconsistent-missing-override
+// this pragma is not known to gcc, so we need an #ifdef __clang__ here
+#pragma GCC diagnostic push
+#if defined(__clang__)
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+#endif
+
+  ClassDef(EventHeaderv1,2)
+
+#pragma GCC diagnostic pop
 };
 
 #endif

--- a/offline/framework/ffaobjects/EventHeaderv1.h
+++ b/offline/framework/ffaobjects/EventHeaderv1.h
@@ -5,18 +5,17 @@
 
 #include "EventHeader.h"
 
-#include <ctime>         // for time_t
-#include <iostream>       // for cout, ostream
+#include <ctime>     // for time_t
+#include <iostream>  // for cout, ostream
 #include <map>
 #include <string>
 
 class PHObject;
 
 //! simple event header with ID and time
-class EventHeaderv1: public EventHeader
+class EventHeaderv1 : public EventHeader
 {
  public:
-
   /// ctor
   EventHeaderv1() = default;
   /// dtor
@@ -30,20 +29,20 @@ class EventHeaderv1: public EventHeader
   /** identify Function from PHObject
       @param os Output Stream 
    */
-  void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
   /// isValid returns non zero if object contains valid data
   int isValid() const override;
 
   /// get Run Number
-  int get_RunNumber() const override {return RunNumber;}
+  int get_RunNumber() const override { return RunNumber; }
   /// set Run Number
-  void set_RunNumber(const int run) override {RunNumber=run;}
+  void set_RunNumber(const int run) override { RunNumber = run; }
 
   /// get Event Number
-  int get_EvtSequence() const override {return EvtSequence;}
+  int get_EvtSequence() const override { return EvtSequence; }
   /// set Event Number
-  void set_EvtSequence(const int evtno) override {EvtSequence=evtno;}
+  void set_EvtSequence(const int evtno) override { EvtSequence = evtno; }
 
   void set_floatval(const std::string &name, const float fval) override;
   float get_floatval(const std::string &name) const override;
@@ -52,8 +51,7 @@ class EventHeaderv1: public EventHeader
   int64_t get_intval(const std::string &name) const override;
 
  private:
-
-  int RunNumber = 0;  // Run number
+  int RunNumber = 0;    // Run number
   int EvtSequence = 0;  // Event number
   std::map<std::string, int64_t> m_IntEventProperties;
   std::map<std::string, float> m_FloatEventProperties;
@@ -66,7 +64,7 @@ class EventHeaderv1: public EventHeader
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #endif
 
-  ClassDef(EventHeaderv1,2)
+  ClassDef(EventHeaderv1, 2)
 
 #pragma GCC diagnostic pop
 };

--- a/offline/framework/ffaobjects/EventHeaderv1LinkDef.h
+++ b/offline/framework/ffaobjects/EventHeaderv1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class EventHeaderv1+;
+#pragma link C++ class EventHeaderv1 + ;
 
 #endif

--- a/offline/framework/ffaobjects/EventHeaderv2.cc
+++ b/offline/framework/ffaobjects/EventHeaderv2.cc
@@ -3,19 +3,18 @@
 #include <iostream>
 
 void EventHeaderv2::Reset()
-{ 
+{
   EventHeaderv1::Reset();
-  m_bunchCrossing = 0; 
+  m_bunchCrossing = 0;
 }
 
 void EventHeaderv2::identify(std::ostream& out) const
 {
   out << "identify yourself: I am an EventHeaderv2 Object" << std::endl;
-  out 
-    << "Run Number: " << get_RunNumber() 
-    << ", Event no: " << get_EvtSequence() 
-    << ", Type: " << get_EvtType() 
-    << ", bunch crossing: " << m_bunchCrossing
-    << std::endl;
+  out
+      << "Run Number: " << get_RunNumber()
+      << ", Event no: " << get_EvtSequence()
+      << ", Type: " << get_EvtType()
+      << ", bunch crossing: " << m_bunchCrossing
+      << std::endl;
 }
-

--- a/offline/framework/ffaobjects/EventHeaderv2.cc
+++ b/offline/framework/ffaobjects/EventHeaderv2.cc
@@ -11,12 +11,10 @@ void EventHeaderv2::Reset()
 void EventHeaderv2::identify(std::ostream& out) const
 {
   out << "identify yourself: I am an EventHeaderv2 Object" << std::endl;
-  const auto timestamp( get_TimeStamp() );
   out 
     << "Run Number: " << get_RunNumber() 
     << ", Event no: " << get_EvtSequence() 
     << ", Type: " << get_EvtType() 
-    << ", DAQ arrival time: " << ctime(&timestamp)
     << ", bunch crossing: " << m_bunchCrossing
     << std::endl;
 }

--- a/offline/framework/ffaobjects/EventHeaderv2.h
+++ b/offline/framework/ffaobjects/EventHeaderv2.h
@@ -12,6 +12,8 @@
 
 #include <ctime>         // for time_t
 #include <iostream>       // for cout, ostream
+#include <map>
+#include <string>
 
 class PHObject;
 
@@ -27,32 +29,39 @@ class EventHeaderv2: public EventHeaderv1
   virtual ~EventHeaderv2() = default;
 
   //! clone
-  PHObject *CloneMe() const 
+  PHObject *CloneMe() const  override
   { return new EventHeaderv2(*this); }
 
   ///  Clear Event
-  void Reset();
+  void Reset() override;
 
   /*!
    * identify Function from PHObject
    * @param os Output Stream 
    */
-  virtual void identify(std::ostream& os = std::cout) const;
+  virtual void identify(std::ostream& os = std::cout) const override;
 
   //! bunch crossing
-  void set_BunchCrossing( int64_t value ) 
+  void set_BunchCrossing( int64_t value )  override
   { m_bunchCrossing = value; }
   
   //! bunch crossing
-  int64_t get_BunchCrossing() const
+  int64_t get_BunchCrossing() const override
   { return m_bunchCrossing; }
   
   private: 
 
   //! bunch crossing id
   int64_t m_bunchCrossing = 0;
-
-  ClassDef(EventHeaderv2,1)
+// rootcling and clang complain about inconsistent overrides in the ClassDef
+// this can be supressed with ignoring -Winconsistent-missing-override
+// this pragma is not known to gcc, so we need an #ifdef __clang__ here
+#pragma GCC diagnostic push
+#if defined(__clang__)
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+#endif
+  ClassDef(EventHeaderv2,2)
+#pragma GCC diagnostic pop
 };
 
 #endif

--- a/offline/framework/ffaobjects/EventHeaderv2.h
+++ b/offline/framework/ffaobjects/EventHeaderv2.h
@@ -10,18 +10,17 @@
 
 #include "EventHeaderv1.h"
 
-#include <ctime>         // for time_t
-#include <iostream>       // for cout, ostream
+#include <ctime>     // for time_t
+#include <iostream>  // for cout, ostream
 #include <map>
 #include <string>
 
 class PHObject;
 
 //! simple event header with ID and time
-class EventHeaderv2: public EventHeaderv1
+class EventHeaderv2 : public EventHeaderv1
 {
  public:
-
   //! ctor
   EventHeaderv2() = default;
 
@@ -29,8 +28,10 @@ class EventHeaderv2: public EventHeaderv1
   virtual ~EventHeaderv2() = default;
 
   //! clone
-  PHObject *CloneMe() const  override
-  { return new EventHeaderv2(*this); }
+  PHObject* CloneMe() const override
+  {
+    return new EventHeaderv2(*this);
+  }
 
   ///  Clear Event
   void Reset() override;
@@ -42,15 +43,18 @@ class EventHeaderv2: public EventHeaderv1
   virtual void identify(std::ostream& os = std::cout) const override;
 
   //! bunch crossing
-  void set_BunchCrossing( int64_t value )  override
-  { m_bunchCrossing = value; }
-  
+  void set_BunchCrossing(int64_t value) override
+  {
+    m_bunchCrossing = value;
+  }
+
   //! bunch crossing
   int64_t get_BunchCrossing() const override
-  { return m_bunchCrossing; }
-  
-  private: 
+  {
+    return m_bunchCrossing;
+  }
 
+ private:
   //! bunch crossing id
   int64_t m_bunchCrossing = 0;
 // rootcling and clang complain about inconsistent overrides in the ClassDef
@@ -60,7 +64,7 @@ class EventHeaderv2: public EventHeaderv1
 #if defined(__clang__)
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #endif
-  ClassDef(EventHeaderv2,2)
+  ClassDef(EventHeaderv2, 2)
 #pragma GCC diagnostic pop
 };
 

--- a/offline/framework/ffaobjects/EventHeaderv2LinkDef.h
+++ b/offline/framework/ffaobjects/EventHeaderv2LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class EventHeaderv2+;
+#pragma link C++ class EventHeaderv2 + ;
 
 #endif

--- a/offline/framework/ffaobjects/FlagSave.h
+++ b/offline/framework/ffaobjects/FlagSave.h
@@ -9,42 +9,40 @@
 class PHFlag;
 
 ///
-class FlagSave: public PHObject
+class FlagSave : public PHObject
 {
  public:
-
   /// dtor
   virtual ~FlagSave() {}
 
   /// Clear Flag
   virtual void Reset()
-    {
-      std::cout << PHWHERE << "ERROR Reset() not implemented by daughter class" << std::endl;
-      return;
-    }
+  {
+    std::cout << PHWHERE << "ERROR Reset() not implemented by daughter class" << std::endl;
+    return;
+  }
 
   /** identify Function from PHObject
       @param os Output Stream 
    */
   virtual void identify(std::ostream& os = std::cout) const
-    {
-      os << "identify yourself: virtual FlagSave Object" << std::endl;
-      return;
-    }
+  {
+    os << "identify yourself: virtual FlagSave Object" << std::endl;
+    return;
+  }
 
   /// isValid returns non zero if object contains valid data
   virtual int isValid() const
-    {
-      std::cout << PHWHERE << "isValid not implemented by daughter class" << std::endl;
-      return 0;
-    }
+  {
+    std::cout << PHWHERE << "isValid not implemented by daughter class" << std::endl;
+    return 0;
+  }
 
-  virtual int FillFromPHFlag(const PHFlag* /*flags*/) {return -1;}
-  virtual int PutFlagsBack(PHFlag* /*flags*/) {return -1;}
+  virtual int FillFromPHFlag(const PHFlag* /*flags*/) { return -1; }
+  virtual int PutFlagsBack(PHFlag* /*flags*/) { return -1; }
 
  private:
-  ClassDef(FlagSave,1)
-
+  ClassDef(FlagSave, 1)
 };
 
 #endif

--- a/offline/framework/ffaobjects/FlagSaveLinkDef.h
+++ b/offline/framework/ffaobjects/FlagSaveLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class FlagSave+;
+#pragma link C++ class FlagSave + ;
 
 #endif

--- a/offline/framework/ffaobjects/FlagSavev1.cc
+++ b/offline/framework/ffaobjects/FlagSavev1.cc
@@ -6,8 +6,6 @@
 
 class PHObject;
 
-using namespace std;
-
 PHObject *
 FlagSavev1::CloneMe() const
 {
@@ -33,9 +31,9 @@ int FlagSavev1::isValid() const
   return 1;
 }
 
-void FlagSavev1::identify(ostream &out) const
+void FlagSavev1::identify(std::ostream &out) const
 {
-  out << "identify yourself: I am an FlagSavev1 Object" << endl;
+  out << "identify yourself: I am an FlagSavev1 Object" << std::endl;
   PrintIntFlag(out);
   PrintDoubleFlag(out);
   PrintFloatFlag(out);
@@ -63,8 +61,8 @@ int FlagSavev1::PutFlagsBack(PHFlag *flags)
 
 int FlagSavev1::FillIntFromPHFlag(const PHFlag *flags)
 {
-  map<string, int>::const_iterator iter;
-  const map<string, int> *intm = flags->IntMap();
+  std::map<std::string, int>::const_iterator iter;
+  const std::map<std::string, int> *intm = flags->IntMap();
   for (iter = intm->begin(); iter != intm->end(); ++iter)
   {
     intflag[iter->first] = iter->second;
@@ -74,8 +72,8 @@ int FlagSavev1::FillIntFromPHFlag(const PHFlag *flags)
 
 int FlagSavev1::FillDoubleFromPHFlag(const PHFlag *flags)
 {
-  map<string, double>::const_iterator iter;
-  const map<string, double> *intm = flags->DoubleMap();
+  std::map<std::string, double>::const_iterator iter;
+  const std::map<std::string, double> *intm = flags->DoubleMap();
   for (iter = intm->begin(); iter != intm->end(); ++iter)
   {
     doubleflag[iter->first] = iter->second;
@@ -85,8 +83,8 @@ int FlagSavev1::FillDoubleFromPHFlag(const PHFlag *flags)
 
 int FlagSavev1::FillFloatFromPHFlag(const PHFlag *flags)
 {
-  map<string, float>::const_iterator iter;
-  const map<string, float> *intm = flags->FloatMap();
+  std::map<std::string, float>::const_iterator iter;
+  const std::map<std::string, float> *intm = flags->FloatMap();
   for (iter = intm->begin(); iter != intm->end(); ++iter)
   {
     floatflag[iter->first] = iter->second;
@@ -96,11 +94,11 @@ int FlagSavev1::FillFloatFromPHFlag(const PHFlag *flags)
 
 int FlagSavev1::FillCharFromPHFlag(const PHFlag *flags)
 {
-  map<string, string>::const_iterator iter;
-  const map<string, string> *intm = flags->CharMap();
+  std::map<std::string, std::string>::const_iterator iter;
+  const std::map<std::string, std::string> *intm = flags->CharMap();
   for (iter = intm->begin(); iter != intm->end(); ++iter)
   {
-    string input(iter->second);
+    std::string input(iter->second);
     stringflag[iter->first] = input;
   }
   return 0;
@@ -108,7 +106,7 @@ int FlagSavev1::FillCharFromPHFlag(const PHFlag *flags)
 
 int FlagSavev1::PutIntToPHFlag(PHFlag *flags)
 {
-  map<string, int>::const_iterator iter;
+  std::map<std::string, int>::const_iterator iter;
   for (iter = intflag.begin(); iter != intflag.end(); ++iter)
   {
     flags->set_IntFlag(iter->first, iter->second);
@@ -118,7 +116,7 @@ int FlagSavev1::PutIntToPHFlag(PHFlag *flags)
 
 int FlagSavev1::PutDoubleToPHFlag(PHFlag *flags)
 {
-  map<string, double>::const_iterator iter;
+  std::map<std::string, double>::const_iterator iter;
   for (iter = doubleflag.begin(); iter != doubleflag.end(); ++iter)
   {
     flags->set_DoubleFlag(iter->first, iter->second);
@@ -128,7 +126,7 @@ int FlagSavev1::PutDoubleToPHFlag(PHFlag *flags)
 
 int FlagSavev1::PutFloatToPHFlag(PHFlag *flags)
 {
-  map<string, float>::const_iterator iter;
+  std::map<std::string, float>::const_iterator iter;
   for (iter = floatflag.begin(); iter != floatflag.end(); ++iter)
   {
     flags->set_FloatFlag(iter->first, iter->second);
@@ -138,7 +136,7 @@ int FlagSavev1::PutFloatToPHFlag(PHFlag *flags)
 
 int FlagSavev1::PutCharToPHFlag(PHFlag *flags)
 {
-  map<string, string>::const_iterator iter;
+  std::map<std::string, std::string>::const_iterator iter;
   for (iter = stringflag.begin(); iter != stringflag.end(); ++iter)
   {
     flags->set_CharFlag(iter->first, iter->second);
@@ -152,11 +150,11 @@ void FlagSavev1::PrintIntFlag(std::ostream &os) const
   {
     return;
   }
-  map<string, int>::const_iterator iter;
-  os << "Int Flags: " << endl;
+  std::map<std::string, int>::const_iterator iter;
+  os << "Int Flags: " << std::endl;
   for (iter = intflag.begin(); iter != intflag.end(); ++iter)
   {
-    os << iter->first << ": " << iter->second << endl;
+    os << iter->first << ": " << iter->second << std::endl;
   }
   return;
 }
@@ -167,11 +165,11 @@ void FlagSavev1::PrintDoubleFlag(std::ostream &os) const
   {
     return;
   }
-  map<string, double>::const_iterator iter;
-  os << "Double Flags: " << endl;
+  std::map<std::string, double>::const_iterator iter;
+  os << "Double Flags: " << std::endl;
   for (iter = doubleflag.begin(); iter != doubleflag.end(); ++iter)
   {
-    os << iter->first << ": " << iter->second << endl;
+    os << iter->first << ": " << iter->second << std::endl;
   }
   return;
 }
@@ -182,11 +180,11 @@ void FlagSavev1::PrintFloatFlag(std::ostream &os) const
   {
     return;
   }
-  map<string, float>::const_iterator iter;
-  os << "Float Flags: " << endl;
+  std::map<std::string, float>::const_iterator iter;
+  os << "Float Flags: " << std::endl;
   for (iter = floatflag.begin(); iter != floatflag.end(); ++iter)
   {
-    os << iter->first << ": " << iter->second << endl;
+    os << iter->first << ": " << iter->second << std::endl;
   }
   return;
 }
@@ -197,11 +195,11 @@ void FlagSavev1::PrintStringFlag(std::ostream &os) const
   {
     return;
   }
-  map<string, string>::const_iterator iter;
-  os << "String Flags: " << endl;
+  std::map<std::string, std::string>::const_iterator iter;
+  os << "String Flags: " << std::endl;
   for (iter = stringflag.begin(); iter != stringflag.end(); ++iter)
   {
-    os << iter->first << ": " << iter->second << endl;
+    os << iter->first << ": " << iter->second << std::endl;
   }
   return;
 }

--- a/offline/framework/ffaobjects/FlagSavev1.cc
+++ b/offline/framework/ffaobjects/FlagSavev1.cc
@@ -2,16 +2,16 @@
 
 #include <phool/PHFlag.h>
 
-#include <utility>         // for pair
+#include <utility>  // for pair
 
 class PHObject;
 
 using namespace std;
 
-PHObject * 
+PHObject *
 FlagSavev1::CloneMe() const
 {
-  FlagSavev1 * ret = new FlagSavev1();
+  FlagSavev1 *ret = new FlagSavev1();
 
   ret->intflag = this->intflag;
   ret->doubleflag = this->doubleflag;
@@ -21,32 +21,29 @@ FlagSavev1::CloneMe() const
   return ret;
 }
 
-int
-FlagSavev1::isValid() const
+int FlagSavev1::isValid() const
 {
   if (intflag.empty() &&
       doubleflag.empty() &&
       floatflag.empty() &&
       stringflag.empty())
-    {
-      return 0;
-    }
+  {
+    return 0;
+  }
   return 1;
 }
 
-void 
-FlagSavev1::identify(ostream& out) const
+void FlagSavev1::identify(ostream &out) const
 {
   out << "identify yourself: I am an FlagSavev1 Object" << endl;
-  PrintIntFlag(out) ;
+  PrintIntFlag(out);
   PrintDoubleFlag(out);
   PrintFloatFlag(out);
   PrintStringFlag(out);
-  return ;
+  return;
 }
 
-int
-FlagSavev1::FillFromPHFlag(const PHFlag *flags)
+int FlagSavev1::FillFromPHFlag(const PHFlag *flags)
 {
   int iret = FillIntFromPHFlag(flags);
   iret += FillDoubleFromPHFlag(flags);
@@ -55,170 +52,156 @@ FlagSavev1::FillFromPHFlag(const PHFlag *flags)
   return iret;
 }
 
-int
-FlagSavev1::PutFlagsBack(PHFlag *flags)
+int FlagSavev1::PutFlagsBack(PHFlag *flags)
 {
   int iret = PutIntToPHFlag(flags);
   iret += PutDoubleToPHFlag(flags);
   iret += PutFloatToPHFlag(flags);
   iret += PutCharToPHFlag(flags);
- return iret;
+  return iret;
 }
 
-
-int
-FlagSavev1::FillIntFromPHFlag(const PHFlag *flags)
+int FlagSavev1::FillIntFromPHFlag(const PHFlag *flags)
 {
   map<string, int>::const_iterator iter;
   const map<string, int> *intm = flags->IntMap();
   for (iter = intm->begin(); iter != intm->end(); ++iter)
-    {
-      intflag[iter->first] = iter->second;
-    }
+  {
+    intflag[iter->first] = iter->second;
+  }
   return 0;
 }
 
-int
-FlagSavev1::FillDoubleFromPHFlag(const PHFlag *flags)
+int FlagSavev1::FillDoubleFromPHFlag(const PHFlag *flags)
 {
   map<string, double>::const_iterator iter;
   const map<string, double> *intm = flags->DoubleMap();
   for (iter = intm->begin(); iter != intm->end(); ++iter)
-    {
-      doubleflag[iter->first] = iter->second;
-    }
+  {
+    doubleflag[iter->first] = iter->second;
+  }
   return 0;
 }
 
-int
-FlagSavev1::FillFloatFromPHFlag(const PHFlag *flags)
+int FlagSavev1::FillFloatFromPHFlag(const PHFlag *flags)
 {
   map<string, float>::const_iterator iter;
   const map<string, float> *intm = flags->FloatMap();
   for (iter = intm->begin(); iter != intm->end(); ++iter)
-    {
-      floatflag[iter->first] = iter->second;
-    }
+  {
+    floatflag[iter->first] = iter->second;
+  }
   return 0;
 }
 
-int
-FlagSavev1::FillCharFromPHFlag(const PHFlag *flags)
+int FlagSavev1::FillCharFromPHFlag(const PHFlag *flags)
 {
   map<string, string>::const_iterator iter;
   const map<string, string> *intm = flags->CharMap();
   for (iter = intm->begin(); iter != intm->end(); ++iter)
-    {
-      string input(iter->second);
-      stringflag[iter->first] = input;
-    }
+  {
+    string input(iter->second);
+    stringflag[iter->first] = input;
+  }
   return 0;
 }
 
-int
-FlagSavev1::PutIntToPHFlag(PHFlag *flags)
+int FlagSavev1::PutIntToPHFlag(PHFlag *flags)
 {
   map<string, int>::const_iterator iter;
   for (iter = intflag.begin(); iter != intflag.end(); ++iter)
-    {
-      flags->set_IntFlag(iter->first,iter->second);
-    }
+  {
+    flags->set_IntFlag(iter->first, iter->second);
+  }
   return 0;
 }
 
-int
-FlagSavev1::PutDoubleToPHFlag(PHFlag *flags)
+int FlagSavev1::PutDoubleToPHFlag(PHFlag *flags)
 {
   map<string, double>::const_iterator iter;
   for (iter = doubleflag.begin(); iter != doubleflag.end(); ++iter)
-    {
-      flags->set_DoubleFlag(iter->first,iter->second);
-    }
+  {
+    flags->set_DoubleFlag(iter->first, iter->second);
+  }
   return 0;
 }
 
-int
-FlagSavev1::PutFloatToPHFlag(PHFlag *flags)
+int FlagSavev1::PutFloatToPHFlag(PHFlag *flags)
 {
   map<string, float>::const_iterator iter;
   for (iter = floatflag.begin(); iter != floatflag.end(); ++iter)
-    {
-      flags->set_FloatFlag(iter->first,iter->second);
-    }
+  {
+    flags->set_FloatFlag(iter->first, iter->second);
+  }
   return 0;
 }
 
-int
-FlagSavev1::PutCharToPHFlag(PHFlag *flags)
+int FlagSavev1::PutCharToPHFlag(PHFlag *flags)
 {
   map<string, string>::const_iterator iter;
   for (iter = stringflag.begin(); iter != stringflag.end(); ++iter)
-    {
-      flags->set_CharFlag(iter->first,iter->second);
-    }
+  {
+    flags->set_CharFlag(iter->first, iter->second);
+  }
   return 0;
 }
 
-void
-FlagSavev1::PrintIntFlag(std::ostream& os) const
+void FlagSavev1::PrintIntFlag(std::ostream &os) const
 {
   if (intflag.empty())
-    {
-      return ;
-    }
+  {
+    return;
+  }
   map<string, int>::const_iterator iter;
   os << "Int Flags: " << endl;
   for (iter = intflag.begin(); iter != intflag.end(); ++iter)
-    {
-      os << iter->first << ": " << iter->second << endl;
-    }
-  return ;
+  {
+    os << iter->first << ": " << iter->second << endl;
+  }
+  return;
 }
 
-void
-FlagSavev1::PrintDoubleFlag(std::ostream& os) const
+void FlagSavev1::PrintDoubleFlag(std::ostream &os) const
 {
   if (doubleflag.empty())
-    {
-      return ;
-    }
+  {
+    return;
+  }
   map<string, double>::const_iterator iter;
   os << "Double Flags: " << endl;
   for (iter = doubleflag.begin(); iter != doubleflag.end(); ++iter)
-    {
-      os << iter->first << ": " << iter->second << endl;
-    }
-  return ;
+  {
+    os << iter->first << ": " << iter->second << endl;
+  }
+  return;
 }
 
-void
-FlagSavev1::PrintFloatFlag(std::ostream& os) const
+void FlagSavev1::PrintFloatFlag(std::ostream &os) const
 {
   if (floatflag.empty())
-    {
-      return ;
-    }
+  {
+    return;
+  }
   map<string, float>::const_iterator iter;
   os << "Float Flags: " << endl;
   for (iter = floatflag.begin(); iter != floatflag.end(); ++iter)
-    {
-      os << iter->first << ": " << iter->second << endl;
-    }
-  return ;
+  {
+    os << iter->first << ": " << iter->second << endl;
+  }
+  return;
 }
 
-void
-FlagSavev1::PrintStringFlag(std::ostream& os) const
+void FlagSavev1::PrintStringFlag(std::ostream &os) const
 {
   if (stringflag.empty())
-    {
-      return ;
-    }
+  {
+    return;
+  }
   map<string, string>::const_iterator iter;
   os << "String Flags: " << endl;
-    for (iter = stringflag.begin(); iter != stringflag.end(); ++iter)
-      {
-        os << iter->first << ": " << iter->second << endl;
-      }
-    return ;
+  for (iter = stringflag.begin(); iter != stringflag.end(); ++iter)
+  {
+    os << iter->first << ": " << iter->second << endl;
   }
+  return;
+}

--- a/offline/framework/ffaobjects/FlagSavev1.h
+++ b/offline/framework/ffaobjects/FlagSavev1.h
@@ -13,10 +13,9 @@ class PHFlag;
 class PHObject;
 
 ///
-class FlagSavev1: public FlagSave
+class FlagSavev1 : public FlagSave
 {
  public:
-
   /// ctor
   FlagSavev1() = default;
   /// dtor
@@ -25,16 +24,16 @@ class FlagSavev1: public FlagSave
   PHObject *CloneMe() const override;
 
   ///  Clear Event
-  void Reset()  override {}
+  void Reset() override {}
   int isValid() const override;
 
   /** identify Function from PHObject
       @param os Output Stream 
    */
-  void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
-  int  FillFromPHFlag(const PHFlag *flags) override;
-  int  PutFlagsBack(PHFlag *flags) override;
+  int FillFromPHFlag(const PHFlag *flags) override;
+  int PutFlagsBack(PHFlag *flags) override;
 
  private:
   int FillIntFromPHFlag(const PHFlag *flags);
@@ -47,10 +46,10 @@ class FlagSavev1: public FlagSave
   int PutFloatToPHFlag(PHFlag *flags);
   int PutCharToPHFlag(PHFlag *flags);
 
-  void PrintIntFlag(std::ostream& os) const;
-  void PrintDoubleFlag(std::ostream& os) const;
-  void PrintFloatFlag(std::ostream& os) const ;
-  void PrintStringFlag(std::ostream& os) const;
+  void PrintIntFlag(std::ostream &os) const;
+  void PrintDoubleFlag(std::ostream &os) const;
+  void PrintFloatFlag(std::ostream &os) const;
+  void PrintStringFlag(std::ostream &os) const;
 
   std::map<std::string, int> intflag;
   std::map<std::string, double> doubleflag;
@@ -64,7 +63,7 @@ class FlagSavev1: public FlagSave
 #if defined(__clang__)
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #endif
-  ClassDef(FlagSavev1,1)
+  ClassDef(FlagSavev1, 1)
 #pragma GCC diagnostic pop
 };
 

--- a/offline/framework/ffaobjects/FlagSavev1.h
+++ b/offline/framework/ffaobjects/FlagSavev1.h
@@ -18,25 +18,25 @@ class FlagSavev1: public FlagSave
  public:
 
   /// ctor
-  FlagSavev1() {}
+  FlagSavev1() = default;
   /// dtor
-  virtual ~FlagSavev1() {}
+  virtual ~FlagSavev1() = default;
 
-  PHObject *CloneMe() const;
+  PHObject *CloneMe() const override;
 
   ///  Clear Event
-  void Reset() {}
-  int isValid() const;
+  void Reset()  override {}
+  int isValid() const override;
 
   /** identify Function from PHObject
       @param os Output Stream 
    */
-  void identify(std::ostream& os = std::cout) const;
+  void identify(std::ostream& os = std::cout) const override;
 
-  int  FillFromPHFlag(const PHFlag *flags);
-  int  PutFlagsBack(PHFlag *flags);
+  int  FillFromPHFlag(const PHFlag *flags) override;
+  int  PutFlagsBack(PHFlag *flags) override;
 
- protected:
+ private:
   int FillIntFromPHFlag(const PHFlag *flags);
   int FillDoubleFromPHFlag(const PHFlag *flags);
   int FillFloatFromPHFlag(const PHFlag *flags);
@@ -57,8 +57,15 @@ class FlagSavev1: public FlagSave
   std::map<std::string, float> floatflag;
   std::map<std::string, std::string> stringflag;
 
- private: // prevent doc++ from showing ClassDef
+// rootcling and clang complain about inconsistent overrides in the ClassDef
+// this can be supressed with ignoring -Winconsistent-missing-override
+// this pragma is not known to gcc, so we need an #ifdef __clang__ here
+#pragma GCC diagnostic push
+#if defined(__clang__)
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+#endif
   ClassDef(FlagSavev1,1)
+#pragma GCC diagnostic pop
 };
 
 #endif

--- a/offline/framework/ffaobjects/FlagSavev1LinkDef.h
+++ b/offline/framework/ffaobjects/FlagSavev1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class FlagSavev1+;
+#pragma link C++ class FlagSavev1 + ;
 
 #endif

--- a/offline/framework/ffaobjects/Makefile.am
+++ b/offline/framework/ffaobjects/Makefile.am
@@ -19,6 +19,7 @@ ROOTDICTS = \
   FlagSave_Dict.cc \
   FlagSavev1_Dict.cc \
   RunHeader_Dict.cc \
+  RunHeaderv1_Dict.cc \
   SyncObject_Dict.cc \
   SyncObjectv1_Dict.cc \
   EventHeader_Dict.cc \
@@ -30,6 +31,7 @@ nobase_dist_pcm_DATA = \
   FlagSave_Dict_rdict.pcm \
   FlagSavev1_Dict_rdict.pcm \
   RunHeader_Dict_rdict.pcm \
+  RunHeaderv1_Dict_rdict.pcm \
   SyncObject_Dict_rdict.pcm \
   SyncObjectv1_Dict_rdict.pcm \
   EventHeader_Dict_rdict.pcm \
@@ -40,6 +42,7 @@ pkginclude_HEADERS = \
   FlagSave.h \
   FlagSavev1.h \
   RunHeader.h \
+  RunHeaderv1.h \
   SyncDefs.h \
   SyncObject.h \
   SyncObjectv1.h \
@@ -51,6 +54,7 @@ libffaobjects_la_SOURCES = \
   $(ROOTDICTS) \
   FlagSavev1.cc \
   RunHeader.cc \
+  RunHeaderv1.cc \
   SyncObject.cc \
   SyncObjectv1.cc \
   EventHeader.cc \

--- a/offline/framework/ffaobjects/RunHeader.cc
+++ b/offline/framework/ffaobjects/RunHeader.cc
@@ -10,71 +10,64 @@ using namespace std;
 
 static int nowarning = 0;
 
-PHObject *
+PHObject*
 RunHeader::CloneMe() const
 {
   cout << "RunHeader::CloneMe() is not implemented in daugther class" << endl;
   return nullptr;
 }
 
-void
-RunHeader::Reset()
+void RunHeader::Reset()
 {
   cout << PHWHERE << "ERROR Reset() not implemented by daughter class" << endl;
-  return ;
+  return;
 }
 
-void
-RunHeader::identify(ostream& os) const
+void RunHeader::identify(ostream& os) const
 {
   os << "identify yourself: virtual RunHeader Object" << endl;
-  return ;
+  return;
 }
 
-int
-RunHeader::isValid() const
+int RunHeader::isValid() const
 {
   cout << PHWHERE << "isValid not implemented by daughter class" << endl;
   return 0;
 }
 
-int
-RunHeader::get_RunNumber() const
+int RunHeader::get_RunNumber() const
 {
   warning("get_RunNumber()");
   return -9999;
 }
 
-void
-RunHeader::set_RunNumber(const int /*run*/)
+void RunHeader::set_RunNumber(const int /*run*/)
 {
   warning("set_RunNumber(const int run)");
-  return ;
+  return;
 }
 
-// 
-void
-RunHeader::NoWarning(const int i)
+//
+void RunHeader::NoWarning(const int i)
 {
   if (i > 0)
-    {
-      cout << "RunHeader: switching virtual warnings OFF" << endl;
-      nowarning = i;
-    }
+  {
+    cout << "RunHeader: switching virtual warnings OFF" << endl;
+    nowarning = i;
+  }
   else
-    {
-      cout << "RunHeader: switching virtual warnings ON" << endl;
-      nowarning = 0;
-    }
-  return ;
+  {
+    cout << "RunHeader: switching virtual warnings ON" << endl;
+    nowarning = 0;
+  }
+  return;
 }
 
-void
-RunHeader::warning(const std::string &funcname) const
+void RunHeader::warning(const std::string& funcname) const
 {
-  if (! nowarning)
-    {
-      cout << "Using virtual function RunHeader::" << funcname << endl;
-    }
-  return ;
+  if (!nowarning)
+  {
+    cout << "Using virtual function RunHeader::" << funcname << endl;
+  }
+  return;
 }

--- a/offline/framework/ffaobjects/RunHeader.cc
+++ b/offline/framework/ffaobjects/RunHeader.cc
@@ -52,48 +52,6 @@ RunHeader::set_RunNumber(const int /*run*/)
   return ;
 }
 
-double
-RunHeader::get_Bfield() const
-{
-  warning("get_Bfield()");
-  return -9999.9;
-}
-
-void
-RunHeader::set_Bfield(const double /*rval*/)
-{
-  warning("set_Bfield(const double rval)");
-  return;
-}
-
-time_t
-RunHeader::get_TimeStart() const
-{
-  warning("get_TimeStart()");
-  return 0;
-}
-
-void
-RunHeader::set_TimeStart(const time_t /*ival*/)
-{
-  warning("set_TimeStart(const time_t ival)");
-  return;
-}
-
-time_t
-RunHeader::get_TimeStop() const
-{
-  warning("get_TimeStop()");
-  return 0;
-}
-
-void
-RunHeader::set_TimeStop(const time_t /*ival*/)
-{
-  warning("set_TimeStop(const time_t ival)");
-  return;
-}
-
 // 
 void
 RunHeader::NoWarning(const int i)
@@ -112,7 +70,7 @@ RunHeader::NoWarning(const int i)
 }
 
 void
-RunHeader::warning(const char *funcname) const
+RunHeader::warning(const std::string &funcname) const
 {
   if (! nowarning)
     {

--- a/offline/framework/ffaobjects/RunHeader.cc
+++ b/offline/framework/ffaobjects/RunHeader.cc
@@ -6,32 +6,30 @@
 
 class PHObject;
 
-using namespace std;
-
 static int nowarning = 0;
 
 PHObject*
 RunHeader::CloneMe() const
 {
-  cout << "RunHeader::CloneMe() is not implemented in daugther class" << endl;
+  std::cout << "RunHeader::CloneMe() is not implemented in daugther class" << std::endl;
   return nullptr;
 }
 
 void RunHeader::Reset()
 {
-  cout << PHWHERE << "ERROR Reset() not implemented by daughter class" << endl;
+  std::cout << PHWHERE << "ERROR Reset() not implemented by daughter class" << std::endl;
   return;
 }
 
-void RunHeader::identify(ostream& os) const
+void RunHeader::identify(std::ostream& os) const
 {
-  os << "identify yourself: virtual RunHeader Object" << endl;
+  os << "identify yourself: virtual RunHeader Object" << std::endl;
   return;
 }
 
 int RunHeader::isValid() const
 {
-  cout << PHWHERE << "isValid not implemented by daughter class" << endl;
+  std::cout << PHWHERE << "isValid not implemented by daughter class" << std::endl;
   return 0;
 }
 
@@ -52,12 +50,12 @@ void RunHeader::NoWarning(const int i)
 {
   if (i > 0)
   {
-    cout << "RunHeader: switching virtual warnings OFF" << endl;
+    std::cout << "RunHeader: switching virtual warnings OFF" << std::endl;
     nowarning = i;
   }
   else
   {
-    cout << "RunHeader: switching virtual warnings ON" << endl;
+    std::cout << "RunHeader: switching virtual warnings ON" << std::endl;
     nowarning = 0;
   }
   return;
@@ -67,7 +65,7 @@ void RunHeader::warning(const std::string& funcname) const
 {
   if (!nowarning)
   {
-    cout << "Using virtual function RunHeader::" << funcname << endl;
+    std::cout << "Using virtual function RunHeader::" << funcname << std::endl;
   }
   return;
 }

--- a/offline/framework/ffaobjects/RunHeader.h
+++ b/offline/framework/ffaobjects/RunHeader.h
@@ -9,14 +9,13 @@
 #include <iostream>
 
 ///
-class RunHeader: public PHObject
+class RunHeader : public PHObject
 {
  public:
-
   /// dtor
   virtual ~RunHeader() {}
 
-  virtual PHObject* CloneMe() const;
+  virtual PHObject *CloneMe() const;
 
   /// Clear Event
   virtual void Reset();
@@ -24,7 +23,7 @@ class RunHeader: public PHObject
   /** identify Function from PHObject
       @param os Output Stream 
    */
-  virtual void identify(std::ostream& os = std::cout) const;
+  virtual void identify(std::ostream &os = std::cout) const;
 
   /// isValid returns non zero if object contains valid data
   virtual int isValid() const;
@@ -34,20 +33,19 @@ class RunHeader: public PHObject
   /// set Run Number
   virtual void set_RunNumber(const int run);
 
-  virtual void set_floatval(const std::string &name, const float fval) {return;}
-  virtual float get_floatval(const std::string &name) const {return NAN;}
+  virtual void set_floatval(const std::string &name, const float fval) { return; }
+  virtual float get_floatval(const std::string &name) const { return NAN; }
 
-  virtual void set_intval(const std::string &name, const int ival) {return;}
-  virtual int get_intval(const std::string &name) const {return -999999;}
+  virtual void set_intval(const std::string &name, const int ival) { return; }
+  virtual int get_intval(const std::string &name) const { return -999999; }
 
   /// switches off the pesky virtual warning messages
   void NoWarning(const int i = 1);
 
  private:
   void warning(const std::string &func) const;
-  
-  ClassDef(RunHeader,1)
 
+  ClassDef(RunHeader, 1)
 };
 
 #endif

--- a/offline/framework/ffaobjects/RunHeader.h
+++ b/offline/framework/ffaobjects/RunHeader.h
@@ -5,7 +5,7 @@
 
 #include <phool/PHObject.h>
 
-#include <ctime>
+#include <cmath>
 #include <iostream>
 
 ///
@@ -34,29 +34,18 @@ class RunHeader: public PHObject
   /// set Run Number
   virtual void set_RunNumber(const int run);
 
-  /// get BField (deprecated in v2)
-  virtual double get_Bfield() const;
-  /// set Bfield (deprecated in v2)
-  virtual void set_Bfield(const double rval);
+  virtual void set_floatval(const std::string &name, const float fval) {return;}
+  virtual float get_floatval(const std::string &name) const {return NAN;}
 
-  /// get Start Time of run (in unix ticks, use ctime to convert to date string)
-  virtual time_t get_TimeStart() const;
-  /// set Start Time
-  virtual void set_TimeStart(const time_t ival);
-
-  /// get Time of End Run (in unix ticks)
-  virtual time_t get_TimeStop() const;
-  /// set Time of End Run
-  virtual void set_TimeStop(const time_t ival);
-
+  virtual void set_intval(const std::string &name, const int ival) {return;}
+  virtual int get_intval(const std::string &name) const {return -999999;}
 
   /// switches off the pesky virtual warning messages
-  virtual void NoWarning(const int i = 1);
+  void NoWarning(const int i = 1);
 
- protected:
-  void warning(const char *func) const;
+ private:
+  void warning(const std::string &func) const;
   
- private: // prevent doc++ from showing ClassDef
   ClassDef(RunHeader,1)
 
 };

--- a/offline/framework/ffaobjects/RunHeaderLinkDef.h
+++ b/offline/framework/ffaobjects/RunHeaderLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class RunHeader+;
+#pragma link C++ class RunHeader + ;
 
 #endif

--- a/offline/framework/ffaobjects/RunHeaderv1.cc
+++ b/offline/framework/ffaobjects/RunHeaderv1.cc
@@ -2,13 +2,6 @@
 
 using namespace std;
 
-RunHeaderv1::RunHeaderv1()
-  : RunNumber(0)
-  , TimeStart(0)
-  , TimeStop(0)
-  , Bfield(-99999.)
-{}
-
 void RunHeaderv1::Reset()
 {
   // we don't want to reset the run header for each event
@@ -20,36 +13,52 @@ void RunHeaderv1::identify(ostream& out) const
 {
   out << "identify yourself: I am an RunHeaderv1 Object" << endl;
   out << "Run no: " << RunNumber << endl;
-  out << "Started at: " << ctime(&TimeStart);
-  out << "Ended at:   " << ctime(&TimeStop); 
-  out << "B field was " << Bfield << endl;
+  auto iter = m_IntRunProperties.begin();
+  while(iter !=  m_IntRunProperties.end())
+  {
+    out << iter->first << ": " << iter->second << endl;
+    ++iter;
+  }
+  auto iterf = m_FloatRunProperties.begin();
+  while(iterf !=  m_FloatRunProperties.end())
+  {
+    out << iterf->first << ": " << iterf->second << endl;
+    ++iterf;
+  }
   return;
 }
 
 int RunHeaderv1::isValid() const
 {
-  return((TimeStart) ? 1:0); // return 1 if TimeStart not zero
+  return((RunNumber) ? 1:0); // return 1 if runnumber not zero
 }
 
-// this is now cheating, we set the begin run time to the
-// time of the event with earliest time until we get it from the data base
-void RunHeaderv1::set_TimeStart(time_t start)
+void RunHeaderv1::set_floatval(const std::string &name, const float fval)
 {
-  if (!TimeStart || TimeStart > start)
-    {
-      TimeStart = start;
-    }
-  return;
+  m_FloatRunProperties[name] = fval;
 }
 
-// some more cheating, get the oldest event in fragment
-// until we get it from the db
-void RunHeaderv1::set_TimeStop(time_t stop)
+float RunHeaderv1::get_floatval(const std::string &name) const
 {
-  if (TimeStop < stop)
-    {
-      TimeStop = stop;
-    }
-  return;
+  std::map<std::string, float>::const_iterator iter = m_FloatRunProperties.find(name);
+  if (iter != m_FloatRunProperties.end())
+  {
+    return iter->second;
+  }
+  return NAN;
 }
 
+void RunHeaderv1::set_intval(const std::string &name, const int ival)
+{
+  m_IntRunProperties[name] = ival;
+}
+
+int RunHeaderv1::get_intval(const std::string &name) const
+{
+  std::map<std::string, int>::const_iterator iter = m_IntRunProperties.find(name);
+  if (iter != m_IntRunProperties.end())
+  {
+    return iter->second;
+  }
+  return -999999;
+}

--- a/offline/framework/ffaobjects/RunHeaderv1.cc
+++ b/offline/framework/ffaobjects/RunHeaderv1.cc
@@ -9,18 +9,18 @@ void RunHeaderv1::Reset()
   return;
 }
 
-void RunHeaderv1::identify(ostream& out) const
+void RunHeaderv1::identify(ostream &out) const
 {
   out << "identify yourself: I am an RunHeaderv1 Object" << endl;
   out << "Run no: " << RunNumber << endl;
   auto iter = m_IntRunProperties.begin();
-  while(iter !=  m_IntRunProperties.end())
+  while (iter != m_IntRunProperties.end())
   {
     out << iter->first << ": " << iter->second << endl;
     ++iter;
   }
   auto iterf = m_FloatRunProperties.begin();
-  while(iterf !=  m_FloatRunProperties.end())
+  while (iterf != m_FloatRunProperties.end())
   {
     out << iterf->first << ": " << iterf->second << endl;
     ++iterf;
@@ -30,7 +30,7 @@ void RunHeaderv1::identify(ostream& out) const
 
 int RunHeaderv1::isValid() const
 {
-  return((RunNumber) ? 1:0); // return 1 if runnumber not zero
+  return ((RunNumber) ? 1 : 0);  // return 1 if runnumber not zero
 }
 
 void RunHeaderv1::set_floatval(const std::string &name, const float fval)

--- a/offline/framework/ffaobjects/RunHeaderv1.cc
+++ b/offline/framework/ffaobjects/RunHeaderv1.cc
@@ -1,28 +1,19 @@
 #include "RunHeaderv1.h"
 
-using namespace std;
-
-void RunHeaderv1::Reset()
+void RunHeaderv1::identify(std::ostream &out) const
 {
-  // we don't want to reset the run header for each event
-  // so just return here
-  return;
-}
-
-void RunHeaderv1::identify(ostream &out) const
-{
-  out << "identify yourself: I am an RunHeaderv1 Object" << endl;
-  out << "Run no: " << RunNumber << endl;
+  out << "identify yourself: I am an RunHeaderv1 Object" << std::endl;
+  out << "Run no: " << RunNumber << std::endl;
   auto iter = m_IntRunProperties.begin();
   while (iter != m_IntRunProperties.end())
   {
-    out << iter->first << ": " << iter->second << endl;
+    out << iter->first << ": " << iter->second << std::endl;
     ++iter;
   }
   auto iterf = m_FloatRunProperties.begin();
   while (iterf != m_FloatRunProperties.end())
   {
-    out << iterf->first << ": " << iterf->second << endl;
+    out << iterf->first << ": " << iterf->second << std::endl;
     ++iterf;
   }
   return;

--- a/offline/framework/ffaobjects/RunHeaderv1.h
+++ b/offline/framework/ffaobjects/RunHeaderv1.h
@@ -9,31 +9,33 @@
 #include <map>
 #include <string>
 
-
-class RunHeaderv1: public RunHeader
+class RunHeaderv1 : public RunHeader
 {
  public:
   RunHeaderv1() = default;
   virtual ~RunHeaderv1() = default;
 
   void Reset() override;
-  void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
   int isValid() const override;
 
-   int get_RunNumber() const override {return RunNumber;}
-   void set_RunNumber(const int run) override {RunNumber= run; return;}
+  int get_RunNumber() const override { return RunNumber; }
+  void set_RunNumber(const int run) override
+  {
+    RunNumber = run;
+    return;
+  }
 
   void set_floatval(const std::string &name, const float fval) override;
   float get_floatval(const std::string &name) const override;
 
   void set_intval(const std::string &name, const int ival) override;
   int get_intval(const std::string &name) const override;
-  
 
  private:
-   int RunNumber = 0;
-   std::map<std::string, int> m_IntRunProperties;
-   std::map<std::string, float> m_FloatRunProperties;
+  int RunNumber = 0;
+  std::map<std::string, int> m_IntRunProperties;
+  std::map<std::string, float> m_FloatRunProperties;
 
 // rootcling and clang complain about inconsistent overrides in the ClassDef
 // this can be supressed with ignoring -Winconsistent-missing-override
@@ -42,9 +44,8 @@ class RunHeaderv1: public RunHeader
 #if defined(__clang__)
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #endif
-   ClassDef(RunHeaderv1,1)
+  ClassDef(RunHeaderv1, 1)
 #pragma GCC diagnostic pop
 };
 
 #endif /* __RUNHEADERV1_H */
-

--- a/offline/framework/ffaobjects/RunHeaderv1.h
+++ b/offline/framework/ffaobjects/RunHeaderv1.h
@@ -48,4 +48,4 @@ class RunHeaderv1 : public RunHeader
 #pragma GCC diagnostic pop
 };
 
-#endif /* __RUNHEADERV1_H */
+#endif /* FFAOBJECTS_RUNHEADERV1_H */

--- a/offline/framework/ffaobjects/RunHeaderv1.h
+++ b/offline/framework/ffaobjects/RunHeaderv1.h
@@ -15,7 +15,7 @@ class RunHeaderv1 : public RunHeader
   RunHeaderv1() = default;
   virtual ~RunHeaderv1() = default;
 
-  void Reset() override;
+  void Reset() override {return;}
   void identify(std::ostream &os = std::cout) const override;
   int isValid() const override;
 

--- a/offline/framework/ffaobjects/RunHeaderv1.h
+++ b/offline/framework/ffaobjects/RunHeaderv1.h
@@ -6,39 +6,44 @@
 #include "RunHeader.h"
 
 #include <iostream>
-#include <ctime>
+#include <map>
+#include <string>
 
 
 class RunHeaderv1: public RunHeader
 {
  public:
-  RunHeaderv1();
-  virtual ~RunHeaderv1() {}
+  RunHeaderv1() = default;
+  virtual ~RunHeaderv1() = default;
 
-  void Reset();
-  void identify(std::ostream& os = std::cout) const;
-  int isValid() const;
+  void Reset() override;
+  void identify(std::ostream& os = std::cout) const override;
+  int isValid() const override;
 
-   int get_RunNumber() const {return RunNumber;}
-   void set_RunNumber(const int run) {RunNumber= run; return;}
+   int get_RunNumber() const override {return RunNumber;}
+   void set_RunNumber(const int run) override {RunNumber= run; return;}
 
-   double get_Bfield() const {return Bfield;}
-   void set_Bfield(const double rval) {Bfield = rval; return;}
+  void set_floatval(const std::string &name, const float fval) override;
+  float get_floatval(const std::string &name) const override;
 
-   time_t get_TimeStart() const {return 0;}
-   void set_TimeStart(const time_t start);
+  void set_intval(const std::string &name, const int ival) override;
+  int get_intval(const std::string &name) const override;
+  
 
-   time_t get_TimeStop() const {return 0;}
-   void set_TimeStop(const time_t stop);
+ private:
+   int RunNumber = 0;
+   std::map<std::string, int> m_IntRunProperties;
+   std::map<std::string, float> m_FloatRunProperties;
 
- protected:
-   int RunNumber;
-   time_t TimeStart;
-   time_t TimeStop;
-   double Bfield;
-
+// rootcling and clang complain about inconsistent overrides in the ClassDef
+// this can be supressed with ignoring -Winconsistent-missing-override
+// this pragma is not known to gcc, so we need an #ifdef __clang__ here
+#pragma GCC diagnostic push
+#if defined(__clang__)
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+#endif
    ClassDef(RunHeaderv1,1)
-
+#pragma GCC diagnostic pop
 };
 
 #endif /* __RUNHEADERV1_H */

--- a/offline/framework/ffaobjects/RunHeaderv1LinkDef.h
+++ b/offline/framework/ffaobjects/RunHeaderv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class RunHeaderv1+;
+
+#endif

--- a/offline/framework/ffaobjects/RunHeaderv1LinkDef.h
+++ b/offline/framework/ffaobjects/RunHeaderv1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class RunHeaderv1+;
+#pragma link C++ class RunHeaderv1 + ;
 
 #endif

--- a/offline/framework/ffaobjects/SyncDefs.h
+++ b/offline/framework/ffaobjects/SyncDefs.h
@@ -7,10 +7,10 @@
 
 namespace syncdefs
 {
-// __attribute__((unused)) prevents compiler from flagging variable as unused
-  static const int NUM_SYNC_VARS __attribute__((unused)) =4;
-  static const char *SYNCVARS[] __attribute__((unused)) = { "eventcounter", "eventnumber", "runnumber", "segmentnumber"};
+  // __attribute__((unused)) prevents compiler from flagging variable as unused
+  static const int NUM_SYNC_VARS __attribute__((unused)) = 4;
+  static const char *SYNCVARS[] __attribute__((unused)) = {"eventcounter", "eventnumber", "runnumber", "segmentnumber"};
   static const std::string SYNCNODENAME __attribute__((unused)) = "Sync";
-}
+}  // namespace syncdefs
 
 #endif

--- a/offline/framework/ffaobjects/SyncObject.cc
+++ b/offline/framework/ffaobjects/SyncObject.cc
@@ -11,13 +11,13 @@ using namespace std;
 void SyncObject::Reset()
 {
   cout << PHWHERE << "ERROR Reset() not implemented by daughter class" << endl;
-  return ;
+  return;
 }
 
 void SyncObject::identify(ostream& os) const
 {
   os << "identify yourself: virtual SyncObject Object" << endl;
-  return ;
+  return;
 }
 
 int SyncObject::isValid() const
@@ -36,26 +36,26 @@ SyncObject::CloneMe() const
 SyncObject&
 SyncObject::operator=(const SyncObject& source)
 {
-  if ( this != &source )
-    {
-      EventCounter(source.EventCounter());
-      EventNumber(source.EventNumber());
-      RunNumber(source.RunNumber());
-      SegmentNumber(source.SegmentNumber());
-    }
+  if (this != &source)
+  {
+    EventCounter(source.EventCounter());
+    EventNumber(source.EventNumber());
+    RunNumber(source.RunNumber());
+    SegmentNumber(source.SegmentNumber());
+  }
   return *this;
 }
 
-int SyncObject::Different(const SyncObject *other) const
+int SyncObject::Different(const SyncObject* other) const
 {
   int iret = 0;
   if (EventNumber() != other->EventNumber())
-    {
-      iret += 0x1;
-    }
+  {
+    iret += 0x1;
+  }
   if (RunNumber() != other->RunNumber())
-    {
-      iret |= 0x2;
-    }
+  {
+    iret |= 0x2;
+  }
   return iret;
 }

--- a/offline/framework/ffaobjects/SyncObject.cc
+++ b/offline/framework/ffaobjects/SyncObject.cc
@@ -6,30 +6,28 @@
 
 class PHObject;
 
-using namespace std;
-
 void SyncObject::Reset()
 {
-  cout << PHWHERE << "ERROR Reset() not implemented by daughter class" << endl;
+  std::cout << PHWHERE << "ERROR Reset() not implemented by daughter class" << std::endl;
   return;
 }
 
-void SyncObject::identify(ostream& os) const
+void SyncObject::identify(std::ostream& os) const
 {
-  os << "identify yourself: virtual SyncObject Object" << endl;
+  os << "identify yourself: virtual SyncObject Object" << std::endl;
   return;
 }
 
 int SyncObject::isValid() const
 {
-  cout << PHWHERE << "isValid not implemented by daughter class" << endl;
+  std::cout << PHWHERE << "isValid not implemented by daughter class" << std::endl;
   return 0;
 }
 
 PHObject*
 SyncObject::CloneMe() const
 {
-  cout << "SyncObject::CloneMe() not implemented by daughter class" << endl;
+  std::cout << "SyncObject::CloneMe() not implemented by daughter class" << std::endl;
   return nullptr;
 }
 

--- a/offline/framework/ffaobjects/SyncObject.h
+++ b/offline/framework/ffaobjects/SyncObject.h
@@ -8,10 +8,9 @@
 #include <iostream>
 
 ///
-class SyncObject: public PHObject
+class SyncObject : public PHObject
 {
  public:
-
   /// dtor
   virtual ~SyncObject() {}
 
@@ -23,46 +22,43 @@ class SyncObject: public PHObject
    */
   virtual void identify(std::ostream& os = std::cout) const;
 
-
   /// isValid returns non zero if object contains valid data
   virtual int isValid() const;
 
   virtual PHObject* CloneMe() const;
-  virtual SyncObject& operator=(const SyncObject &source);
-  virtual int Different(const SyncObject *other) const;
+  virtual SyncObject& operator=(const SyncObject& source);
+  virtual int Different(const SyncObject* other) const;
 
   /// set Event Counter
-  virtual void EventCounter(const int /*ival*/) {return;}
+  virtual void EventCounter(const int /*ival*/) { return; }
 
   /// set Event Number
-  virtual void EventNumber(const int /*ival*/) {return;}
-
+  virtual void EventNumber(const int /*ival*/) { return; }
 
   /// set Segment Number
-  virtual void SegmentNumber(const int /*ival*/) {return;}
+  virtual void SegmentNumber(const int /*ival*/) { return; }
 
   /// set Run Number
-  virtual void RunNumber(const int /*ival*/) {return;}
+  virtual void RunNumber(const int /*ival*/) { return; }
 
  protected:
   /// get Event Number
-  virtual int EventNumber() const {return -9999;}
+  virtual int EventNumber() const { return -9999; }
   /// get Event Counter
-  virtual int EventCounter() const {return -9999;}
+  virtual int EventCounter() const { return -9999; }
   /// get Run Number
-  virtual int RunNumber() const {return -9999;}
+  virtual int RunNumber() const { return -9999; }
   /// get Segment Number
-  virtual int SegmentNumber() const {return -9999;}
+  virtual int SegmentNumber() const { return -9999; }
 
- private: // prevent doc++ from showing ClassDef
+ private:  // prevent doc++ from showing ClassDef
   friend class SyncObjectv1;
   friend class Fun4AllDstInputManager;
   friend class Fun4AllDstPileupInputManager;
   friend class DumpSyncObject;
   friend class SegmentSelect;
 
-  ClassDef(SyncObject,1)
-
+  ClassDef(SyncObject, 1)
 };
 
 #endif

--- a/offline/framework/ffaobjects/SyncObjectLinkDef.h
+++ b/offline/framework/ffaobjects/SyncObjectLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class SyncObject+;
+#pragma link C++ class SyncObject + ;
 
 #endif

--- a/offline/framework/ffaobjects/SyncObjectv1.cc
+++ b/offline/framework/ffaobjects/SyncObjectv1.cc
@@ -1,16 +1,5 @@
 #include "SyncObjectv1.h"
 
-using namespace std;
-
-SyncObjectv1::SyncObjectv1():
-  eventcounter(0),
-  eventnumber(-999999),
-  runnumber(-999999),
-  segmentnumber(-999999)
-{
-  return;
-}
-
 SyncObjectv1::SyncObjectv1(const SyncObject& source)
 {
   EventCounter(source.EventCounter());
@@ -21,21 +10,21 @@ SyncObjectv1::SyncObjectv1(const SyncObject& source)
 
 void SyncObjectv1::Reset()
 {
-  eventnumber = -999999;
-  runnumber = -999999;
+  eventnumber = 0;
+  runnumber = 0;
   eventcounter = 0;
   segmentnumber = -999999;
   return;
 }
 
-void SyncObjectv1::identify(ostream& out) const
+void SyncObjectv1::identify(std::ostream& out) const
 {
-  out << "identify yourself: I am an SyncObjectv1 Object" << endl;
+  out << "identify yourself: I am an SyncObjectv1 Object" << std::endl;
   out << "Event no: " <<  eventnumber
       << ", Counter: " << eventcounter
       << ", Segment Number: " << segmentnumber
       << ", Run Number: " << runnumber
-      << endl;
+      << std::endl;
 
   return;
 }
@@ -44,4 +33,3 @@ int SyncObjectv1::isValid() const
 {
   return((eventcounter) ? 1:0); // return 1 if eventcounter is not zero
 }
-

--- a/offline/framework/ffaobjects/SyncObjectv1.cc
+++ b/offline/framework/ffaobjects/SyncObjectv1.cc
@@ -20,7 +20,7 @@ void SyncObjectv1::Reset()
 void SyncObjectv1::identify(std::ostream& out) const
 {
   out << "identify yourself: I am an SyncObjectv1 Object" << std::endl;
-  out << "Event no: " <<  eventnumber
+  out << "Event no: " << eventnumber
       << ", Counter: " << eventcounter
       << ", Segment Number: " << segmentnumber
       << ", Run Number: " << runnumber
@@ -31,5 +31,5 @@ void SyncObjectv1::identify(std::ostream& out) const
 
 int SyncObjectv1::isValid() const
 {
-  return((eventcounter) ? 1:0); // return 1 if eventcounter is not zero
+  return ((eventcounter) ? 1 : 0);  // return 1 if eventcounter is not zero
 }

--- a/offline/framework/ffaobjects/SyncObjectv1.h
+++ b/offline/framework/ffaobjects/SyncObjectv1.h
@@ -14,51 +14,59 @@ class SyncObjectv1: public SyncObject
  public:
 
   /// ctor
-  SyncObjectv1();
-  SyncObjectv1(const SyncObject&);
+  SyncObjectv1() = default;
+  explicit SyncObjectv1(const SyncObject& source);
 
-  PHObject *CloneMe() const {return new SyncObjectv1(*this);}
+  PHObject *CloneMe() const override {return new SyncObjectv1(*this);}
   /// dtor
-  virtual ~SyncObjectv1() {}
+  virtual ~SyncObjectv1() = default;
 
   ///  Clear Event
-  void Reset();
+  void Reset() override;
 
   /** identify Function from PHObject
       @param os Output Stream 
    */
-  void identify(std::ostream& os = std::cout) const;
+  void identify(std::ostream& os = std::cout) const override;
 
   /// isValid returns non zero if object contains valid data
-  int isValid() const;
+  int isValid() const override;
 
   /// set Event Counter
-  void EventCounter(const int ival) {eventcounter = ival;}
+  void EventCounter(const int ival) override {eventcounter = ival;}
 
   /// set Event Number
-  void EventNumber(const int ival) {eventnumber = ival;}
+  void EventNumber(const int ival) override {eventnumber = ival;}
 
   /// set Run Number
-  void RunNumber(const int ival) {runnumber = ival;}
+  void RunNumber(const int ival) override {runnumber = ival;}
 
   /// set Segment Number
-  void SegmentNumber(const int ival) {segmentnumber = ival;}
+  void SegmentNumber(const int ival) override {segmentnumber = ival;}
 
  protected:
   /// get Event Counter
-  int EventCounter() const {return eventcounter;}
+  int EventCounter() const override {return eventcounter;}
   /// get Event Number
-  int EventNumber() const {return eventnumber;}
+  int EventNumber() const override {return eventnumber;}
   /// get Run Number
-  int RunNumber() const {return runnumber;}
+  int RunNumber() const override {return runnumber;}
 
 private:
-  int eventcounter;      // running counter
-  int eventnumber;  // Event number
-  int runnumber;  // Run number
-  int segmentnumber; // segment number
+  int eventcounter = 0;      // running counter
+  int eventnumber = 0;  // Event number
+  int runnumber = 0;  // Run number
+  int segmentnumber = -999999; // segment number
 
+// rootcling and clang complain about inconsistent overrides in the ClassDef
+// this can be supressed with ignoring -Winconsistent-missing-override
+// this pragma is not known to gcc, so we need an #ifdef __clang__ here
+#pragma GCC diagnostic push
+#if defined(__clang__)
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+#endif
   ClassDef(SyncObjectv1,1)
+#pragma GCC diagnostic pop
 };
 
 #endif

--- a/offline/framework/ffaobjects/SyncObjectv1.h
+++ b/offline/framework/ffaobjects/SyncObjectv1.h
@@ -9,15 +9,14 @@
 
 class PHObject;
 
-class SyncObjectv1: public SyncObject
+class SyncObjectv1 : public SyncObject
 {
  public:
-
   /// ctor
   SyncObjectv1() = default;
   explicit SyncObjectv1(const SyncObject& source);
 
-  PHObject *CloneMe() const override {return new SyncObjectv1(*this);}
+  PHObject* CloneMe() const override { return new SyncObjectv1(*this); }
   /// dtor
   virtual ~SyncObjectv1() = default;
 
@@ -33,30 +32,30 @@ class SyncObjectv1: public SyncObject
   int isValid() const override;
 
   /// set Event Counter
-  void EventCounter(const int ival) override {eventcounter = ival;}
+  void EventCounter(const int ival) override { eventcounter = ival; }
 
   /// set Event Number
-  void EventNumber(const int ival) override {eventnumber = ival;}
+  void EventNumber(const int ival) override { eventnumber = ival; }
 
   /// set Run Number
-  void RunNumber(const int ival) override {runnumber = ival;}
+  void RunNumber(const int ival) override { runnumber = ival; }
 
   /// set Segment Number
-  void SegmentNumber(const int ival) override {segmentnumber = ival;}
+  void SegmentNumber(const int ival) override { segmentnumber = ival; }
 
  protected:
   /// get Event Counter
-  int EventCounter() const override {return eventcounter;}
+  int EventCounter() const override { return eventcounter; }
   /// get Event Number
-  int EventNumber() const override {return eventnumber;}
+  int EventNumber() const override { return eventnumber; }
   /// get Run Number
-  int RunNumber() const override {return runnumber;}
+  int RunNumber() const override { return runnumber; }
 
-private:
-  int eventcounter = 0;      // running counter
-  int eventnumber = 0;  // Event number
-  int runnumber = 0;  // Run number
-  int segmentnumber = -999999; // segment number
+ private:
+  int eventcounter = 0;         // running counter
+  int eventnumber = 0;          // Event number
+  int runnumber = 0;            // Run number
+  int segmentnumber = -999999;  // segment number
 
 // rootcling and clang complain about inconsistent overrides in the ClassDef
 // this can be supressed with ignoring -Winconsistent-missing-override
@@ -65,7 +64,7 @@ private:
 #if defined(__clang__)
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #endif
-  ClassDef(SyncObjectv1,1)
+  ClassDef(SyncObjectv1, 1)
 #pragma GCC diagnostic pop
 };
 

--- a/offline/framework/ffaobjects/SyncObjectv1LinkDef.h
+++ b/offline/framework/ffaobjects/SyncObjectv1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class SyncObjectv1+;
+#pragma link C++ class SyncObjectv1 + ;
 
 #endif

--- a/offline/packages/NodeDump/DumpEventHeader.cc
+++ b/offline/packages/NodeDump/DumpEventHeader.cc
@@ -9,11 +9,9 @@
 #include <ostream>
 #include <string>
 
-using namespace std;
-
 typedef PHIODataNode<EventHeader> MyNode_t;
 
-DumpEventHeader::DumpEventHeader(const string &NodeName)
+DumpEventHeader::DumpEventHeader(const std::string &NodeName)
   : DumpObject(NodeName)
 {
   return;
@@ -29,17 +27,18 @@ int DumpEventHeader::process_Node(PHNode *myNode)
   }
   if (eventheader)
   {
-    *fout << "EventHeader->isValid(): " << eventheader->isValid() << endl;
+    *fout << "EventHeader->isValid(): " << eventheader->isValid() << std::endl;
     if (eventheader->isValid())
     {
-      *fout << "get_EvtSequence(): " << eventheader->get_EvtSequence() << endl;
-      *fout << "get_EvtType(): " << eventheader->get_EvtType() << endl;
-      *fout << "get_BunchCrossing(): " << eventheader->get_BunchCrossing() << endl;
-      *fout << "get_ncoll(): " << eventheader->get_ncoll() << endl;
-      *fout << "get_npart(): " << eventheader->get_npart() << endl;
-      *fout << "get_ImpactParameter(): " << eventheader->get_ImpactParameter() << endl;
-      *fout << "get_EventPlaneAngle(): " << eventheader->get_EventPlaneAngle() << endl;
-      *fout << "get_eccentricity(): " << eventheader->get_eccentricity() << endl;
+      *fout << "get_EvtSequence(): " << eventheader->get_EvtSequence() << std::endl;
+      *fout << "get_EvtType(): " << eventheader->get_EvtType() << std::endl;
+      *fout << "get_BunchCrossing(): " << eventheader->get_BunchCrossing() << std::endl;
+      *fout << "get_ncoll(): " << eventheader->get_ncoll() << std::endl;
+      *fout << "get_npart(): " << eventheader->get_npart() << std::endl;
+      *fout << "get_TimeStamp(): " << eventheader->get_TimeStamp() << std::endl;
+      *fout << "get_ImpactParameter(): " << eventheader->get_ImpactParameter() << std::endl;
+      *fout << "get_EventPlaneAngle(): " << eventheader->get_EventPlaneAngle() << std::endl;
+      *fout << "get_eccentricity(): " << eventheader->get_eccentricity() << std::endl;
     }
   }
   return 0;

--- a/offline/packages/NodeDump/DumpEventHeader.cc
+++ b/offline/packages/NodeDump/DumpEventHeader.cc
@@ -1,0 +1,46 @@
+#include "DumpEventHeader.h"
+
+#include "DumpObject.h"
+
+#include <ffaobjects/EventHeader.h>
+
+#include <phool/PHIODataNode.h>
+
+#include <ostream>
+#include <string>
+
+using namespace std;
+
+typedef PHIODataNode<EventHeader> MyNode_t;
+
+DumpEventHeader::DumpEventHeader(const string &NodeName)
+  : DumpObject(NodeName)
+{
+  return;
+}
+
+int DumpEventHeader::process_Node(PHNode *myNode)
+{
+  EventHeader *eventheader = 0;
+  MyNode_t *thisNode = static_cast<MyNode_t *>(myNode);
+  if (thisNode)
+  {
+    eventheader = thisNode->getData();
+  }
+  if (eventheader)
+  {
+    *fout << "EventHeader->isValid(): " << eventheader->isValid() << endl;
+    if (eventheader->isValid())
+    {
+      *fout << "get_EvtSequence(): " << eventheader->get_EvtSequence() << endl;
+      *fout << "get_EvtType(): " << eventheader->get_EvtType() << endl;
+      *fout << "get_BunchCrossing(): " << eventheader->get_BunchCrossing() << endl;
+      *fout << "get_ncoll(): " << eventheader->get_ncoll() << endl;
+      *fout << "get_npart(): " << eventheader->get_npart() << endl;
+      *fout << "get_ImpactParameter(): " << eventheader->get_ImpactParameter() << endl;
+      *fout << "get_EventPlaneAngle(): " << eventheader->get_EventPlaneAngle() << endl;
+      *fout << "get_eccentricity(): " << eventheader->get_eccentricity() << endl;
+    }
+  }
+  return 0;
+}

--- a/offline/packages/NodeDump/DumpEventHeader.h
+++ b/offline/packages/NodeDump/DumpEventHeader.h
@@ -1,0 +1,21 @@
+#ifndef NODEDUMP_DUMPEVENTHEADER_H
+#define NODEDUMP_DUMPEVENTHEADER_H
+
+#include <DumpObject.h>
+
+#include <string>
+
+class PHNode;
+
+class DumpEventHeader : public DumpObject
+{
+ public:
+  DumpEventHeader(const std::string &NodeName);
+  virtual ~DumpEventHeader() {}
+
+ protected:
+  int process_Node(PHNode *mynode);
+  int node_written;
+};
+
+#endif

--- a/offline/packages/NodeDump/DumpEventHeader.h
+++ b/offline/packages/NodeDump/DumpEventHeader.h
@@ -15,7 +15,6 @@ class DumpEventHeader : public DumpObject
 
  protected:
   int process_Node(PHNode *mynode);
-  int node_written;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpRunHeader.cc
+++ b/offline/packages/NodeDump/DumpRunHeader.cc
@@ -9,15 +9,12 @@
 #include <ostream>
 #include <string>
 
-using namespace std;
-
 typedef PHIODataNode<RunHeader> MyNode_t;
 
-DumpRunHeader::DumpRunHeader(const string &NodeName)
+DumpRunHeader::DumpRunHeader(const std::string &NodeName)
   : DumpObject(NodeName)
 {
   WriteRunEvent(0);  // do not write info for each event
-  node_written = 0;  // write runwise nodes only once
   return;
 }
 
@@ -31,10 +28,10 @@ int DumpRunHeader::process_Node(PHNode *myNode)
   }
   if (!node_written && runheader)
   {
-    *fout << "RunHeader->isValid(): " << runheader->isValid() << endl;
+    *fout << "RunHeader->isValid(): " << runheader->isValid() << std::endl;
     if (runheader->isValid())
     {
-      *fout << "get_RunNumber(): " << runheader->get_RunNumber() << endl;
+      *fout << "get_RunNumber(): " << runheader->get_RunNumber() << std::endl;
       node_written = 1;
     }
   }

--- a/offline/packages/NodeDump/DumpRunHeader.cc
+++ b/offline/packages/NodeDump/DumpRunHeader.cc
@@ -35,8 +35,6 @@ int DumpRunHeader::process_Node(PHNode *myNode)
     if (runheader->isValid())
     {
       *fout << "get_RunNumber(): " << runheader->get_RunNumber() << endl;
-      *fout << "get_TimeStart(): " << (int) runheader->get_TimeStart() << endl;
-      *fout << "get_TimeStop(): " << (int) runheader->get_TimeStop() << endl;
       node_written = 1;
     }
   }

--- a/offline/packages/NodeDump/DumpRunHeader.h
+++ b/offline/packages/NodeDump/DumpRunHeader.h
@@ -15,7 +15,7 @@ class DumpRunHeader : public DumpObject
 
  protected:
   int process_Node(PHNode *mynode);
-  int node_written;
+  int node_written = 0;
 };
 
 #endif

--- a/offline/packages/NodeDump/Dumper.cc
+++ b/offline/packages/NodeDump/Dumper.cc
@@ -9,9 +9,7 @@
 
 #include <vector>
 
-using namespace std;
-
-Dumper::Dumper(const string &name)
+Dumper::Dumper(const std::string &name)
   : SubsysReco(name)
 {
   nodedump = new PHNodeDump();
@@ -41,10 +39,10 @@ int Dumper::process_event(PHCompositeNode *topNode)
 int Dumper::End(PHCompositeNode *topNode)
 {
   PHNodeIterator nodeiter(topNode);
-  vector<string> DumpNodeList;
+  std::vector<std::string> DumpNodeList;
   DumpNodeList.push_back("RUN");
   DumpNodeList.push_back("PAR");
-  for (vector<string>::const_iterator iter = DumpNodeList.begin();
+  for (std::vector<std::string>::const_iterator iter = DumpNodeList.begin();
        iter != DumpNodeList.end(); ++iter)
   {
     if (nodeiter.cd(*iter))
@@ -57,7 +55,7 @@ int Dumper::End(PHCompositeNode *topNode)
   return 0;
 }
 
-void Dumper::SetOutDir(const string &outdir)
+void Dumper::SetOutDir(const std::string &outdir)
 {
   nodedump->SetOutDir(outdir);
   return;
@@ -69,12 +67,12 @@ void Dumper::SetPrecision(const int digits)
   return;
 }
 
-int Dumper::AddIgnore(const string &name)
+int Dumper::AddIgnore(const std::string &name)
 {
   return nodedump->AddIgnore(name);
 }
 
-int Dumper::Select(const string &name)
+int Dumper::Select(const std::string &name)
 {
   return nodedump->Select(name);
 }

--- a/offline/packages/NodeDump/Makefile.am
+++ b/offline/packages/NodeDump/Makefile.am
@@ -16,6 +16,7 @@ libphnodedump_la_SOURCES = \
   Dumper.cc \
   DumpBbcVertexMap.cc \
   DumpCaloTriggerInfo.cc \
+  DumpEventHeader.cc \
   DumpGlobalVertexMap.cc \
   DumpJetMap.cc \
   DumpPdbParameterMap.cc \

--- a/offline/packages/NodeDump/PHNodeDump.cc
+++ b/offline/packages/NodeDump/PHNodeDump.cc
@@ -3,6 +3,7 @@
 
 #include "DumpBbcVertexMap.h"
 #include "DumpCaloTriggerInfo.h"
+#include "DumpEventHeader.h"
 #include "DumpGlobalVertexMap.h"
 #include "DumpJetMap.h"
 #include "DumpPHG4BlockCellGeomContainer.h"
@@ -174,6 +175,10 @@ int PHNodeDump::AddDumpObject(const string &NodeName, PHNode *node)
       else if (tmp->InheritsFrom("CaloTriggerInfo"))
       {
         newdump = new DumpCaloTriggerInfo(NodeName);
+      }
+      else if (tmp->InheritsFrom("EventHeader"))
+      {
+        newdump = new DumpEventHeader(NodeName);
       }
       else if (tmp->InheritsFrom("GlobalVertexMap"))
       {

--- a/offline/packages/PHField/PHField2D.cc
+++ b/offline/packages/PHField/PHField2D.cc
@@ -16,12 +16,10 @@
 #include <cstdlib>
 #include <iostream>
 #include <iterator>
-#include <memory>
 #include <set>
 #include <utility>
 
 using namespace std;
-using namespace CLHEP;  // units
 
 PHField2D::PHField2D(const string &filename, const int verb, const float magfield_rescale)
   : PHField(verb)

--- a/offline/packages/PHField/PHFieldBeast.h
+++ b/offline/packages/PHField/PHFieldBeast.h
@@ -3,9 +3,7 @@
 
 #include "PHField.h"
 
-#include <map>
 #include <string>
-#include <vector>
 
 class BeastMagneticField;
 

--- a/offline/packages/PHField/PHFieldCleo.cc
+++ b/offline/packages/PHField/PHFieldCleo.cc
@@ -1,13 +1,14 @@
 #include "PHFieldCleo.h"
 
-#include <BeastMagneticField.h>
-
 #include <Geant4/G4SystemOfUnits.hh>
 
 #include <TSystem.h>
 
+#include <cmath>                        // for modf, fabs, isfinite, NAN
+#include <cstdlib>                     // for exit
 #include <fstream>
 #include <iostream>
+#include <memory>                       // for allocator_traits<>::value_type
 
 using namespace std;
 

--- a/offline/packages/PHField/PHFieldConfigv1.cc
+++ b/offline/packages/PHField/PHFieldConfigv1.cc
@@ -12,10 +12,6 @@
 
 #include <iostream>
 
-class PHObject;
-
-using namespace std;
-
 PHFieldConfigv1::PHFieldConfigv1(FieldConfigTypes field_config,
                                  const std::string& filename,
                                  double magfield_rescale)
@@ -41,7 +37,7 @@ void PHFieldConfigv1::identify(std::ostream& os) const
   {
     os << "Empty";
   }
-  os << endl;
+  os << std::endl;
 }
 
 /// isValid returns non zero if object contains valid data

--- a/offline/packages/PHField/PHFieldConfigv2.cc
+++ b/offline/packages/PHField/PHFieldConfigv2.cc
@@ -13,10 +13,6 @@
 #include <iostream>
 #include <string>
 
-class PHObject;
-
-using namespace std;
-
 PHFieldConfigv2::PHFieldConfigv2(
     double field_mag_x,
     double field_mag_y,
@@ -46,5 +42,5 @@ void PHFieldConfigv2::identify(std::ostream& os) const
   {
     os << "Empty";
   }
-  os << endl;
+  os << std::endl;
 }

--- a/offline/packages/PHField/PHFieldUtility.cc
+++ b/offline/packages/PHField/PHFieldUtility.cc
@@ -10,20 +10,21 @@
 #include "PHFieldConfigv1.h"
 #include "PHFieldUniform.h"
 
+#include <fun4all/Fun4AllServer.h>
+
 #include <phool/PHCompositeNode.h>
 #include <phool/PHDataNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>
 #include <phool/getClass.h>
-
-#include <fun4all/Fun4AllServer.h>
+#include <phool/phool.h>            // for PHWHERE
 
 #include <TSystem.h>
 
+#include <cstdlib>                 // for getenv
 #include <cassert>
 #include <iostream>
-#include <stdexcept>
 
 using namespace std;
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
@@ -37,13 +37,6 @@ using namespace std;
 PHG4HcalSteppingAction::PHG4HcalSteppingAction(PHG4HcalDetector* detector)
   : PHG4SteppingAction(detector->GetName())
   , detector_(detector)
-  , m_HitContainer(nullptr)
-  , m_AbsorberHits(nullptr)
-  , m_SaveHitContainer(nullptr)
-  , m_Hit(nullptr)
-  , zmin(NAN)
-  , zmax(NAN)
-  , light_scint_model_(true)
 {
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.h
@@ -5,6 +5,8 @@
 
 #include <g4main/PHG4SteppingAction.h>
 
+#include <cmath>
+
 class G4Step;
 class PHCompositeNode;
 class PHG4HcalDetector;
@@ -40,15 +42,15 @@ class PHG4HcalSteppingAction : public PHG4SteppingAction
   PHG4HcalDetector* detector_;
 
   //! pointer to hit container
-  PHG4HitContainer* m_HitContainer;
-  PHG4HitContainer* m_AbsorberHits;
-  PHG4HitContainer* m_SaveHitContainer;
-  PHG4Hit* m_Hit;
-  PHG4Shower* m_SaveShower;
-  float zmin;
-  float zmax;
+  PHG4HitContainer* m_HitContainer = nullptr;
+  PHG4HitContainer* m_AbsorberHits = nullptr;
+  PHG4HitContainer* m_SaveHitContainer = nullptr;
+  PHG4Hit* m_Hit = nullptr;
+  PHG4Shower* m_SaveShower = nullptr;
+  float zmin = NAN;
+  float zmax = NAN;
 
-  bool light_scint_model_;
+  bool light_scint_model_ = true;
 };
 
 #endif  // PHG4VHcalSteppingAction_h

--- a/simulation/g4simulation/g4histos/G4CellNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4CellNtuple.cc
@@ -2,6 +2,7 @@
 
 #include <g4detectors/PHG4Cell.h>
 #include <g4detectors/PHG4CellContainer.h>
+#include <g4detectors/PHG4CellDefs.h>  // for get_phibin
 #include <g4detectors/PHG4CylinderCellGeom.h>
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
 

--- a/simulation/g4simulation/g4histos/G4VtxNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4VtxNtuple.cc
@@ -8,12 +8,9 @@
 
 #include <phool/getClass.h>
 
-#include <TFile.h>
-#include <TH1.h>
 #include <TNtuple.h>
 
 #include <sstream>
-#include <utility>  // for pair
 
 using namespace std;
 

--- a/simulation/g4simulation/g4histos/G4VtxNtuple.h
+++ b/simulation/g4simulation/g4histos/G4VtxNtuple.h
@@ -3,16 +3,11 @@
 
 #include <fun4all/SubsysReco.h>
 
-#include <map>
-#include <set>
 #include <string>
-#include <vector>
 
 // Forward declerations
 class Fun4AllHistoManager;
 class PHCompositeNode;
-class TFile;
-class TH1;
 class TNtuple;
 
 class G4VtxNtuple : public SubsysReco

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -18,7 +18,7 @@
 #include <fun4all/Fun4AllServer.h>
 
 #include <ffaobjects/EventHeader.h>
-#include <ffaobjects/EventHeaderv2.h>
+#include <ffaobjects/EventHeaderv1.h>
 #include <ffaobjects/RunHeader.h>
 #include <ffaobjects/SyncDefs.h>
 #include <ffaobjects/SyncObject.h>
@@ -787,7 +787,7 @@ void Fun4AllDstPileupInputManager::load_nodes(PHCompositeNode *dstNode)
   if (!m_eventheader)
   {
     std::cout << "Fun4AllDstPileupInputManager::load_nodes - creating EventHeader" << std::endl;
-    m_eventheader = new EventHeaderv2();
+    m_eventheader = new EventHeaderv1();
     dstNode->addNode(new PHIODataNode<PHObject>(m_eventheader, "EventHeader", "PHObject"));
   }
 


### PR DESCRIPTION
This PR adds the new reconstruction module for the headers (event, run, flags). The Event Header now contains the hepmc heavy ion entries (ncoll, npart, eccentricity, b, rplane angle), the old atp timestamps were removed. The RunHeader contains only the run number so far. The rc flags are now being saved - adding a readback and update at some point in the future is needed. Some cleanup of includes 