### PR TITLE
Fix fermi

### DIFF
--- a/generators/phhepmc/PHHepMC_ioLinkDef.h
+++ b/generators/phhepmc/PHHepMC_ioLinkDef.h
@@ -4,9 +4,9 @@
 #include <HepMC/GenParticle.h>
 #include <HepMC/GenVertex.h>
 #include <HepMC/HeavyIon.h>
-
 #include <HepMC/PdfInfo.h>
 #include <HepMC/Polarization.h>
+#include <HepMC/SimpleVector.h>
 #include <HepMC/WeightContainer.h>
 
 #ifdef __CINT__

--- a/offline/framework/ffamodules/Makefile.am
+++ b/offline/framework/ffamodules/Makefile.am
@@ -15,7 +15,7 @@ AM_LDFLAGS = \
 libffamodules_la_LIBADD = \
   -lfun4all \
   -lffaobjects \
-  -lphhepmc \
+  -lphhepmc_io \
   -lSubsysReco
 
 


### PR DESCRIPTION
This PR backs out the last change for the fermi motion afterburner. It modified the hepmc record which then crashed the readback for some unknown reason. If this change is put back - the readback has to be tested. It was a nightmare to find this