### PR TITLE
Project tracks with CEMC position recalibrated clusters

### DIFF
--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -345,6 +345,14 @@ int PHActsTrackProjection::setCaloContainerNodes(PHCompositeNode *topNode,
   m_clusterContainer = findNode::getClass<RawClusterContainer>
     (topNode, clusterNodeName.c_str());
 
+  if(m_useCemcPosRecalib and 
+     m_caloNames.at(caloLayer).compare("CEMC") == 0) 
+    {
+      std::string nodeName = "CLUSTER_POS_COR_" + m_caloNames.at(caloLayer);
+      m_clusterContainer = findNode::getClass<RawClusterContainer>
+	(topNode, nodeName.c_str());
+    }
+  
   if(!m_towerGeomContainer or !m_towerContainer or !m_clusterContainer)
     {
       std::cout << PHWHERE 

--- a/offline/packages/trackreco/PHActsTrackProjection.h
+++ b/offline/packages/trackreco/PHActsTrackProjection.h
@@ -102,6 +102,8 @@ class PHActsTrackProjection : public SubsysReco
   RawTowerContainer *m_towerContainer = nullptr;
   RawClusterContainer *m_clusterContainer = nullptr;
 
+  bool m_useCemcPosRecalib = false;
+
   int m_event = 0;
 };
 

--- a/offline/packages/trackreco/PHGenFitTrackProjection.cc
+++ b/offline/packages/trackreco/PHGenFitTrackProjection.cc
@@ -178,6 +178,7 @@ int PHGenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 		string towernodename = "TOWER_CALIB_" + _cal_names[i];
 		RawTowerContainer *towerList = findNode::getClass<RawTowerContainer>(
 				topNode, towernodename.c_str());
+	         
 		if (!towerList) {
 			cerr << PHWHERE << " ERROR: Can't find node " << towernodename
 					<< endl;
@@ -188,6 +189,16 @@ int PHGenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 		string clusternodename = "CLUSTER_" + _cal_names[i];
 		RawClusterContainer *clusterList = findNode::getClass<
 				RawClusterContainer>(topNode, clusternodename.c_str());
+
+		if(_use_poscalib_cemc and 
+		   _cal_names[i].compare("CEMC") == 0) {
+		  std::string nodeName = "CLUSTER_POS_COR_" + _cal_names[i];
+		  clusterList = findNode::getClass<RawClusterContainer>(	                             topNode, nodeName.c_str());
+
+		  std::cout << "Grabbing CEMC position recalib clusters"
+			    << std::endl;
+		}
+
 		if (!clusterList) {
 			cerr << PHWHERE << " ERROR: Can't find node " << clusternodename
 					<< endl;

--- a/offline/packages/trackreco/PHGenFitTrackProjection.cc
+++ b/offline/packages/trackreco/PHGenFitTrackProjection.cc
@@ -194,9 +194,10 @@ int PHGenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 		   _cal_names[i].compare("CEMC") == 0) {
 		  std::string nodeName = "CLUSTER_POS_COR_" + _cal_names[i];
 		  clusterList = findNode::getClass<RawClusterContainer>(	                             topNode, nodeName.c_str());
-
-		  std::cout << "Grabbing CEMC position recalib clusters"
-			    << std::endl;
+		  
+		  if(Verbosity() > 1)
+		    std::cout << "Grabbing CEMC position recalib clusters"
+			      << std::endl;
 		}
 
 		if (!clusterList) {

--- a/offline/packages/trackreco/PHGenFitTrackProjection.h
+++ b/offline/packages/trackreco/PHGenFitTrackProjection.h
@@ -39,19 +39,24 @@ class PHGenFitTrackProjection : public SubsysReco
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
-	int get_pid_guess() const {
-		return _pid_guess;
-	}
-
-	void set_pid_guess(int pidGuess) {
-		_pid_guess = pidGuess;
-	}
-
+  int get_pid_guess() const {
+    return _pid_guess;
+  }
+  
+  void set_pid_guess(int pidGuess) {
+    _pid_guess = pidGuess;
+  }
+  
+  void use_poscalib_cemc_clusters(bool calib) {
+    _use_poscalib_cemc = calib;
+  }
 
  private:
 
   PHGenFit::Fitter * _fitter;
   int _pid_guess;
+
+  bool _use_poscalib_cemc = false;
 
   int _num_cal_layers;
   std::vector<SvtxTrack::CAL_LAYER> _cal_types;


### PR DESCRIPTION
This PR adds a flag to the track projection modules to use the cemc position recalibrated cluster information rather than the raw cluster information. It is turned off by default to maintain the current configuration, but users can set it in their tracking macro.