### PR TITLE
Crystal phparameter

### DIFF
--- a/offline/packages/NodeDump/macro/run_dump.C
+++ b/offline/packages/NodeDump/macro/run_dump.C
@@ -1,10 +1,17 @@
+#ifndef MACRO_RUNDUMP_C
+#define MACRO_RUNDUMP_C
+
+
+#include <nodedump/Dumper.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libphnodedump.so)
+
 void run_dump(const char *infile, const int evts=100)
 {
-  gSystem->Load("libg4hough.so");
-  gSystem->Load("libphnodedump.so");
-  gSystem->Load("libg4vertex_io.so");
-  gSystem->Load("libg4bbc_io.so");
-  
+  gSystem->Load("libg4dst.so");
   Fun4AllServer* se = Fun4AllServer::instance();
 
   Dumper *dmp = new Dumper();
@@ -20,3 +27,5 @@ void run_dump(const char *infile, const int evts=100)
   se->End();
   delete se;
 }
+
+#endif

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
@@ -5,6 +5,8 @@
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4Subsystem.h>
 
+#include <phool/recoConsts.h>
+
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4Element.hh>  // for G4Element
@@ -91,11 +93,13 @@ void PHG4CrystalCalorimeterDetector::ConstructMe(G4LogicalVolume* logicWorld)
     exit(1);
   }
 
+
   /* Read parameters for detector construction and mappign from file */
   ParseParametersFromTable();
 
   /* Create the cone envelope = 'world volume' for the crystal calorimeter */
-  G4Material* Air = G4Material::GetMaterial("G4_AIR");
+   recoConsts *rc = recoConsts::instance();
+   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
   G4VSolid* eemc_envelope_solid = new G4Cons("eemc_envelope_solid",
                                              _rMin1, _rMax1,
@@ -103,7 +107,7 @@ void PHG4CrystalCalorimeterDetector::ConstructMe(G4LogicalVolume* logicWorld)
                                              _dZ / 2.,
                                              _sPhi, _dPhi);
 
-  G4LogicalVolume* eemc_envelope_log = new G4LogicalVolume(eemc_envelope_solid, Air, G4String("eemc_envelope"), 0, 0, 0);
+  G4LogicalVolume* eemc_envelope_log = new G4LogicalVolume(eemc_envelope_solid, WorldMaterial, G4String("eemc_envelope"), 0, 0, 0);
 
   GetDisplayAction()->AddVolume(eemc_envelope_log, "Envelope");
   /* Define rotation attributes for envelope cone */
@@ -147,7 +151,8 @@ PHG4CrystalCalorimeterDetector::ConstructTower()
   G4double tower_dz = _crystal_dz;
 
   /* create logical volume for single tower */
-  G4Material* material_air = G4Material::GetMaterial("G4_AIR");
+   recoConsts *rc = recoConsts::instance();
+   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
   G4VSolid* single_tower_solid = new G4Box(G4String("single_tower_solid"),
                                            tower_dx / 2.0,
@@ -155,7 +160,7 @@ PHG4CrystalCalorimeterDetector::ConstructTower()
                                            tower_dz / 2.0);
 
   G4LogicalVolume* single_tower_logic = new G4LogicalVolume(single_tower_solid,
-                                                            material_air,
+                                                            WorldMaterial,
                                                             "single_tower_logic",
                                                             0, 0, 0);
 

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
@@ -65,23 +65,14 @@ PHG4CrystalCalorimeterDetector::PHG4CrystalCalorimeterDetector(PHG4Subsystem* su
 //_______________________________________________________________________
 int PHG4CrystalCalorimeterDetector::IsInCrystalCalorimeter(G4VPhysicalVolume* volume) const
 {
-  if (volume->GetName().find(_towerlogicnameprefix) != string::npos)
+  if (m_ActiveVolumeSet.find(volume) != m_ActiveVolumeSet.end())
   {
-    if (volume->GetName().find("crystal") != string::npos)
-    {
-      return 1;
-    }
-    /* only record energy in actual absorber- drop energy lost in air gaps inside envelope */
-    else if (volume->GetName().find("absorber") != string::npos)
-    {
-      return -1;
-    }
-    else if (volume->GetName().find("envelope") != string::npos)
-    {
-      return 0;
-    }
+    return 1;
   }
-
+  if ( m_PassiveVolumeSet.find(volume) != m_PassiveVolumeSet.end())
+  {
+    return -1;
+  }
   return 0;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
@@ -240,8 +240,6 @@ PHG4CrystalCalorimeterDetector::ConstructTower()
                     0, 0, OverlapCheck());
   m_PassiveVolumeSet.insert(physvol);
   /* Place crystal in logical tower volume */
-  // ostringstream name_crystal;
-  // name_crystal.str("");
   string name_crystal =  _towerlogicnameprefix + "_single_crystal";
 
   physvol = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
@@ -38,7 +38,6 @@ using namespace std;
 //_______________________________________________________________________
 PHG4CrystalCalorimeterDetector::PHG4CrystalCalorimeterDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters *parameters, const std::string& dnam)
   : PHG4Detector(subsys, Node, dnam)
-  , m_Params(parameters)
   , _place_in_x(0.0 * mm)
   , _place_in_y(0.0 * mm)
   , _place_in_z(-1080.0 * mm)
@@ -62,21 +61,30 @@ PHG4CrystalCalorimeterDetector::PHG4CrystalCalorimeterDetector(PHG4Subsystem* su
   , _blackhole(0)
   , _superdetector("NONE")
   , _mapping_tower_file("")
+  , m_Params(parameters)
   , m_DisplayAction(dynamic_cast<PHG4CrystalCalorimeterDisplayAction*>(subsys->GetDisplayAction()))
   , _towerlogicnameprefix("CrystalCalorimeterTower")
+  , m_IsActive(m_Params->get_int_param("active"))
+  , m_AbsorberActive(m_Params->get_int_param("absorberactive"))
 {
 }
 
 //_______________________________________________________________________
 int PHG4CrystalCalorimeterDetector::IsInCrystalCalorimeter(G4VPhysicalVolume* volume) const
 {
+  if (m_IsActive)
+  {
   if (m_ActiveVolumeSet.find(volume) != m_ActiveVolumeSet.end())
   {
     return 1;
   }
+  }
+  if (m_AbsorberActive)
+  {
   if ( m_PassiveVolumeSet.find(volume) != m_PassiveVolumeSet.end())
   {
     return -1;
+  }
   }
   return 0;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
@@ -1,6 +1,8 @@
 #include "PHG4CrystalCalorimeterDetector.h"
 #include "PHG4CrystalCalorimeterDisplayAction.h"
 
+#include <phparameter/PHParameters.h>
+
 #include <g4main/PHG4Detector.h>       // for PHG4Detector
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4Subsystem.h>
@@ -34,8 +36,9 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4CrystalCalorimeterDetector::PHG4CrystalCalorimeterDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam)
+PHG4CrystalCalorimeterDetector::PHG4CrystalCalorimeterDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters *parameters, const std::string& dnam)
   : PHG4Detector(subsys, Node, dnam)
+  , m_Params(parameters)
   , _place_in_x(0.0 * mm)
   , _place_in_y(0.0 * mm)
   , _place_in_z(-1080.0 * mm)
@@ -94,7 +97,7 @@ void PHG4CrystalCalorimeterDetector::ConstructMe(G4LogicalVolume* logicWorld)
   }
 
 
-  /* Read parameters for detector construction and mappign from file */
+  /* Read parameters for detector construction and mapping from file */
   ParseParametersFromTable();
 
   /* Create the cone envelope = 'world volume' for the crystal calorimeter */
@@ -170,7 +173,7 @@ PHG4CrystalCalorimeterDetector::ConstructTower()
                                       _crystal_dy / 2.0,
                                       _crystal_dz / 2.0);
 
-  /* create geometry volume for frame (carbon fober shell) inside single_tower */
+  /* create geometry volume for frame (carbon fiber shell) inside single_tower */
   G4VSolid* Carbon_hunk_solid = new G4Box(G4String("Carbon_hunk_solid"),
                                           tower_dx / 2.0,
                                           tower_dy / 2.0,

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
@@ -122,12 +122,12 @@ void PHG4CrystalCalorimeterDetector::ConstructMe(G4LogicalVolume* logicWorld)
   eemc_rotm.rotateZ(_rot_in_z);
 
   /* Place envelope cone in simulation */
-  ostringstream name_envelope;
-  name_envelope.str("");
-  name_envelope << _towerlogicnameprefix << "_envelope" << endl;
+//  ostringstream name_envelope;
+//  name_envelope.str("");
+  string name_envelope = _towerlogicnameprefix + "_envelope";
 
   new G4PVPlacement(G4Transform3D(eemc_rotm, G4ThreeVector(_place_in_x, _place_in_y, _place_in_z)),
-                    eemc_envelope_log, name_envelope.str().c_str(), logicWorld, 0, false, OverlapCheck());
+                    eemc_envelope_log, name_envelope, logicWorld, 0, false, OverlapCheck());
 
   /* Construct single calorimeter tower */
   G4LogicalVolume* singletower = ConstructTower();
@@ -222,27 +222,27 @@ PHG4CrystalCalorimeterDetector::ConstructTower()
   GetDisplayAction()->AddVolume(logic_shell, "CarbonShell");
 
   /* Place structural frame in logical tower volume */
-  ostringstream name_shell;
-  name_shell.str("");
-  name_shell << _towerlogicnameprefix << "_single_absorber" << endl;
-
-  new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
+  // ostringstream name_shell;
+  // name_shell.str("");
+  // name_shell << _towerlogicnameprefix << "_single_absorber";
+  string name_shell =  _towerlogicnameprefix + "_single_absorber";
+  G4VPhysicalVolume *physvol = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
                     logic_shell,
-                    name_shell.str().c_str(),
+                    name_shell,
                     single_tower_logic,
                     0, 0, OverlapCheck());
-
+  m_PassiveVolumeSet.insert(physvol);
   /* Place crystal in logical tower volume */
-  ostringstream name_crystal;
-  name_crystal.str("");
-  name_crystal << _towerlogicnameprefix << "_single_crystal" << endl;
+  // ostringstream name_crystal;
+  // name_crystal.str("");
+  string name_crystal =  _towerlogicnameprefix + "_single_crystal";
 
-  new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
+  physvol = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
                     logic_crystal,
-                    name_crystal.str().c_str(),
+                    name_crystal,
                     single_tower_logic,
                     0, 0, OverlapCheck());
-
+  m_ActiveVolumeSet.insert(physvol);
   if (Verbosity() > 0)
   {
     cout << "PHG4CrystalCalorimeterDetector: Building logical volume for single tower done." << endl;

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.cc
@@ -16,7 +16,7 @@
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
-#include <Geant4/G4String.hh>                     // for G4String
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
@@ -36,7 +36,7 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4CrystalCalorimeterDetector::PHG4CrystalCalorimeterDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters *parameters, const std::string& dnam)
+PHG4CrystalCalorimeterDetector::PHG4CrystalCalorimeterDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam)
   : PHG4Detector(subsys, Node, dnam)
   , _place_in_x(0.0 * mm)
   , _place_in_y(0.0 * mm)
@@ -74,17 +74,17 @@ int PHG4CrystalCalorimeterDetector::IsInCrystalCalorimeter(G4VPhysicalVolume* vo
 {
   if (m_IsActive)
   {
-  if (m_ActiveVolumeSet.find(volume) != m_ActiveVolumeSet.end())
-  {
-    return 1;
-  }
+    if (m_ActiveVolumeSet.find(volume) != m_ActiveVolumeSet.end())
+    {
+      return 1;
+    }
   }
   if (m_AbsorberActive)
   {
-  if ( m_PassiveVolumeSet.find(volume) != m_PassiveVolumeSet.end())
-  {
-    return -1;
-  }
+    if (m_PassiveVolumeSet.find(volume) != m_PassiveVolumeSet.end())
+    {
+      return -1;
+    }
   }
   return 0;
 }
@@ -104,13 +104,12 @@ void PHG4CrystalCalorimeterDetector::ConstructMe(G4LogicalVolume* logicWorld)
     exit(1);
   }
 
-
   /* Read parameters for detector construction and mapping from file */
   ParseParametersFromTable();
 
   /* Create the cone envelope = 'world volume' for the crystal calorimeter */
-   recoConsts *rc = recoConsts::instance();
-   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
+  recoConsts* rc = recoConsts::instance();
+  G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
   G4VSolid* eemc_envelope_solid = new G4Cons("eemc_envelope_solid",
                                              _rMin1, _rMax1,
@@ -128,8 +127,8 @@ void PHG4CrystalCalorimeterDetector::ConstructMe(G4LogicalVolume* logicWorld)
   eemc_rotm.rotateZ(_rot_in_z);
 
   /* Place envelope cone in simulation */
-//  ostringstream name_envelope;
-//  name_envelope.str("");
+  //  ostringstream name_envelope;
+  //  name_envelope.str("");
   string name_envelope = _towerlogicnameprefix + "_envelope";
 
   new G4PVPlacement(G4Transform3D(eemc_rotm, G4ThreeVector(_place_in_x, _place_in_y, _place_in_z)),
@@ -162,8 +161,8 @@ PHG4CrystalCalorimeterDetector::ConstructTower()
   G4double tower_dz = _crystal_dz;
 
   /* create logical volume for single tower */
-   recoConsts *rc = recoConsts::instance();
-   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
+  recoConsts* rc = recoConsts::instance();
+  G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
   G4VSolid* single_tower_solid = new G4Box(G4String("single_tower_solid"),
                                            tower_dx / 2.0,
@@ -232,21 +231,21 @@ PHG4CrystalCalorimeterDetector::ConstructTower()
   // ostringstream name_shell;
   // name_shell.str("");
   // name_shell << _towerlogicnameprefix << "_single_absorber";
-  string name_shell =  _towerlogicnameprefix + "_single_absorber";
-  G4VPhysicalVolume *physvol = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
-                    logic_shell,
-                    name_shell,
-                    single_tower_logic,
-                    0, 0, OverlapCheck());
+  string name_shell = _towerlogicnameprefix + "_single_absorber";
+  G4VPhysicalVolume* physvol = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
+                                                 logic_shell,
+                                                 name_shell,
+                                                 single_tower_logic,
+                                                 0, 0, OverlapCheck());
   m_PassiveVolumeSet.insert(physvol);
   /* Place crystal in logical tower volume */
-  string name_crystal =  _towerlogicnameprefix + "_single_crystal";
+  string name_crystal = _towerlogicnameprefix + "_single_crystal";
 
   physvol = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
-                    logic_crystal,
-                    name_crystal,
-                    single_tower_logic,
-                    0, 0, OverlapCheck());
+                              logic_crystal,
+                              name_crystal,
+                              single_tower_logic,
+                              0, 0, OverlapCheck());
   m_ActiveVolumeSet.insert(physvol);
   if (Verbosity() > 0)
   {

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
@@ -144,7 +144,7 @@ class PHG4CrystalCalorimeterDetector : public PHG4Detector
   };
   PHParameters *m_Params = nullptr;
 
-  PHG4CrystalCalorimeterDisplayAction *m_DisplayAction;
+  PHG4CrystalCalorimeterDisplayAction *m_DisplayAction = nullptr;
 
   std::string _towerlogicnameprefix;
 
@@ -152,6 +152,11 @@ class PHG4CrystalCalorimeterDetector : public PHG4Detector
   std::map<std::string, towerposition> _map_tower;
   std::set<G4VPhysicalVolume*> m_ActiveVolumeSet;
   std::set<G4VPhysicalVolume*> m_PassiveVolumeSet;
+  // since getting parameters is a map search we do not want to
+  // do this in every step, the parameters used are cached
+  // in the following variables
+  int m_IsActive;
+  int m_AbsorberActive;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
@@ -150,8 +150,8 @@ class PHG4CrystalCalorimeterDetector : public PHG4Detector
 
   std::map<std::string, G4double> _map_global_parameter;
   std::map<std::string, towerposition> _map_tower;
-  std::set<G4VPhysicalVolume*> m_ActiveVolumeSet;
-  std::set<G4VPhysicalVolume*> m_PassiveVolumeSet;
+  std::set<G4VPhysicalVolume *> m_ActiveVolumeSet;
+  std::set<G4VPhysicalVolume *> m_PassiveVolumeSet;
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
@@ -17,6 +17,7 @@ class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4CrystalCalorimeterDisplayAction;
 class PHG4Subsystem;
+class PHParameters;
 
 /**
  * \file ${file_name}
@@ -28,7 +29,7 @@ class PHG4CrystalCalorimeterDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4CrystalCalorimeterDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam);
+  PHG4CrystalCalorimeterDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
   virtual ~PHG4CrystalCalorimeterDetector() {}
@@ -141,6 +142,7 @@ class PHG4CrystalCalorimeterDetector : public PHG4Detector
     G4double y;
     G4double z;
   };
+  PHParameters *m_Params = nullptr;
 
   PHG4CrystalCalorimeterDisplayAction *m_DisplayAction;
 

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterDetector.h
@@ -9,6 +9,7 @@
 #include <Geant4/G4Types.hh>
 
 #include <map>
+#include <set>
 #include <string>
 
 class G4LogicalVolume;
@@ -147,6 +148,8 @@ class PHG4CrystalCalorimeterDetector : public PHG4Detector
 
   std::map<std::string, G4double> _map_global_parameter;
   std::map<std::string, towerposition> _map_tower;
+  std::set<G4VPhysicalVolume*> m_ActiveVolumeSet;
+  std::set<G4VPhysicalVolume*> m_PassiveVolumeSet;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
@@ -40,6 +40,8 @@
 #include <boost/lexical_cast.hpp>
 #endif
 
+#include <TSystem.h>
+
 #include <iostream>
 #include <string>                              // for basic_string, string
 
@@ -298,19 +300,20 @@ void PHG4CrystalCalorimeterSteppingAction::SetInterfacePointers(PHCompositeNode*
   }
 
   //now look for the map and grab a pointer to it.
-  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
-  absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename);
+  absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename);
 
   // if we do not find the node it's messed up.
   if (!hits_)
   {
-    std::cout << "PHG4CrystalCalorimeterSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+    std::cout << "PHG4CrystalCalorimeterSteppingAction::SetInterfacePointers - unable to find " << hitnodename << std::endl;
+    gSystem->Exit(1);
   }
   if (!absorberhits_)
   {
     if (Verbosity() > 0)
     {
-      cout << "PHG4CrystalCalorimeterSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
+      cout << "PHG4CrystalCalorimeterSteppingAction::SetInterfacePointers - unable to find " << absorbernodename << endl;
     }
   }
 }

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSteppingAction.cc
@@ -4,8 +4,8 @@
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
 #include <g4main/PHG4Shower.h>
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 
@@ -14,17 +14,17 @@
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fAtRest...
-#include <Geant4/G4String.hh>                  // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRest...
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>         // for G4VPhysicalVolume
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <boost/tokenizer.hpp>
 // this is an ugly hack, the gcc optimizer has a bug which
@@ -43,7 +43,7 @@
 #include <TSystem.h>
 
 #include <iostream>
-#include <string>                              // for basic_string, string
+#include <string>  // for basic_string, string
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
@@ -4,6 +4,8 @@
 #include "PHG4CrystalCalorimeterSteppingAction.h"
 #include "PHG4ProjCrystalCalorimeterDetector.h"
 
+#include <phparameter/PHParameters.h>
+
 #include <g4main/PHG4DisplayAction.h>              // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4SteppingAction.h>             // for PHG4SteppingAction
@@ -26,9 +28,6 @@ using namespace std;
 //_______________________________________________________________________
 PHG4CrystalCalorimeterSubsystem::PHG4CrystalCalorimeterSubsystem(const std::string& name, const int lyr)
   : PHG4DetectorSubsystem(name, lyr)
-  , m_Detector(nullptr)
-  , m_SteppingAction(nullptr)
-  , m_DisplayAction(nullptr)
   , active(1)
   , mappingfile_("")
   , mappingfile_4x4_construct_("")
@@ -45,7 +44,7 @@ PHG4CrystalCalorimeterSubsystem::~PHG4CrystalCalorimeterSubsystem()
 }
 
 //_______________________________________________________________________
-int PHG4CrystalCalorimeterSubsystem::InitSubsystem(PHCompositeNode* topNode)
+int PHG4CrystalCalorimeterSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
 {
   PHNodeIterator iter(topNode);
   PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
@@ -77,8 +76,8 @@ int PHG4CrystalCalorimeterSubsystem::InitSubsystem(PHCompositeNode* topNode)
   m_Detector->SetAbsorberActive(active);
   m_Detector->OverlapCheck(CheckOverlap());
   m_Detector->SuperDetector(SuperDetector());
-
-  if (active)
+  GetParams()->Print();
+  if (GetParams()->get_int_param("active"))
   {
     // create hit output node
     string nodename = "G4HIT_";
@@ -99,6 +98,8 @@ int PHG4CrystalCalorimeterSubsystem::InitSubsystem(PHCompositeNode* topNode)
       dstNode->addNode(hitNode);
     }
 
+    if (GetParams()->get_int_param("absorberactive"))
+    {
     string absnodename = "G4HIT_ABSORBER_";
     if (SuperDetector() != "NONE")
     {
@@ -116,7 +117,7 @@ int PHG4CrystalCalorimeterSubsystem::InitSubsystem(PHCompositeNode* topNode)
       PHIODataNode<PHObject>* abshitNode = new PHIODataNode<PHObject>(absorber_hits, absnodename, "PHObject");
       dstNode->addNode(abshitNode);
     }
-
+    }
     // create stepping action
     m_SteppingAction = new PHG4CrystalCalorimeterSteppingAction(m_Detector);
   }

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
@@ -25,7 +25,7 @@ using namespace std;
 
 //_______________________________________________________________________
 PHG4CrystalCalorimeterSubsystem::PHG4CrystalCalorimeterSubsystem(const std::string& name, const int lyr)
-  : PHG4Subsystem(name)
+  : PHG4DetectorSubsystem(name)
   , m_Detector(nullptr)
   , m_SteppingAction(nullptr)
   , m_DisplayAction(nullptr)
@@ -35,6 +35,7 @@ PHG4CrystalCalorimeterSubsystem::PHG4CrystalCalorimeterSubsystem(const std::stri
   , mappingfile_4x4_construct_("")
   , projective_(false)
 {
+  InitializeParameters();
 }
 
 //_______________________________________________________________________
@@ -44,7 +45,7 @@ PHG4CrystalCalorimeterSubsystem::~PHG4CrystalCalorimeterSubsystem()
 }
 
 //_______________________________________________________________________
-int PHG4CrystalCalorimeterSubsystem::Init(PHCompositeNode* topNode)
+int PHG4CrystalCalorimeterSubsystem::InitSubsystem(PHCompositeNode* topNode)
 {
   PHNodeIterator iter(topNode);
   PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
@@ -123,4 +124,12 @@ int PHG4CrystalCalorimeterSubsystem::process_event(PHCompositeNode* topNode)
 PHG4Detector* PHG4CrystalCalorimeterSubsystem::GetDetector(void) const
 {
   return m_Detector;
+}
+
+void PHG4CrystalCalorimeterSubsystem::SetDefaultParameters()
+{
+  set_default_double_param("place_x", 0.);
+  set_default_double_param("place_y", 0.);
+  set_default_double_param("place_z", -108.);
+  return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
@@ -6,19 +6,19 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4DisplayAction.h>              // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>             // for PHG4SteppingAction
-#include <g4main/PHG4Subsystem.h>                  // for PHG4Subsystem
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
+#include <g4main/PHG4Subsystem.h>       // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>                    // for PHIODataNode
-#include <phool/PHNode.h>                          // for PHNode
-#include <phool/PHNodeIterator.h>                  // for PHNodeIterator
-#include <phool/PHObject.h>                        // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
-#include <iostream>                                // for operator<<, ostrin...
+#include <iostream>  // for operator<<, ostrin...
 #include <sstream>
 
 class PHG4Detector;
@@ -96,23 +96,23 @@ int PHG4CrystalCalorimeterSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
 
     if (GetParams()->get_int_param("absorberactive"))
     {
-    string absnodename = "G4HIT_ABSORBER_";
-    if (SuperDetector() != "NONE")
-    {
-      absnodename += SuperDetector();
-    }
-    else
-    {
-      absnodename += Name();
-    }
+      string absnodename = "G4HIT_ABSORBER_";
+      if (SuperDetector() != "NONE")
+      {
+        absnodename += SuperDetector();
+      }
+      else
+      {
+        absnodename += Name();
+      }
 
-    PHG4HitContainer* absorber_hits = findNode::getClass<PHG4HitContainer>(topNode, absnodename);
-    if (!absorber_hits)
-    {
-      absorber_hits = new PHG4HitContainer(absnodename);
-      PHIODataNode<PHObject>* abshitNode = new PHIODataNode<PHObject>(absorber_hits, absnodename, "PHObject");
-      dstNode->addNode(abshitNode);
-    }
+      PHG4HitContainer* absorber_hits = findNode::getClass<PHG4HitContainer>(topNode, absnodename);
+      if (!absorber_hits)
+      {
+        absorber_hits = new PHG4HitContainer(absnodename);
+        PHIODataNode<PHObject>* abshitNode = new PHIODataNode<PHObject>(absorber_hits, absnodename, "PHObject");
+        dstNode->addNode(abshitNode);
+      }
     }
     // create stepping action
     m_SteppingAction = new PHG4CrystalCalorimeterSteppingAction(m_Detector);

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
@@ -25,16 +25,16 @@ using namespace std;
 
 //_______________________________________________________________________
 PHG4CrystalCalorimeterSubsystem::PHG4CrystalCalorimeterSubsystem(const std::string& name, const int lyr)
-  : PHG4DetectorSubsystem(name)
+  : PHG4DetectorSubsystem(name, lyr)
   , m_Detector(nullptr)
   , m_SteppingAction(nullptr)
   , m_DisplayAction(nullptr)
   , active(1)
-  , detector_type(name)
   , mappingfile_("")
   , mappingfile_4x4_construct_("")
   , projective_(false)
 {
+  detector_type = name + to_string(lyr);
   InitializeParameters();
 }
 
@@ -81,25 +81,39 @@ int PHG4CrystalCalorimeterSubsystem::InitSubsystem(PHCompositeNode* topNode)
   if (active)
   {
     // create hit output node
-    ostringstream nodename;
-    nodename << "G4HIT_" << detector_type;
+    string nodename = "G4HIT_";
+    if (SuperDetector() != "NONE")
+    {
+      nodename += SuperDetector();
+    }
+    else
+    {
+      nodename += Name();
+    }
 
-    PHG4HitContainer* crystal_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str().c_str());
+    PHG4HitContainer* crystal_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
     if (!crystal_hits)
     {
-      crystal_hits = new PHG4HitContainer(nodename.str());
-      PHIODataNode<PHObject>* hitNode = new PHIODataNode<PHObject>(crystal_hits, nodename.str().c_str(), "PHObject");
+      crystal_hits = new PHG4HitContainer(nodename);
+      PHIODataNode<PHObject>* hitNode = new PHIODataNode<PHObject>(crystal_hits, nodename, "PHObject");
       dstNode->addNode(hitNode);
     }
 
-    ostringstream absnodename;
-    absnodename << "G4HIT_ABSORBER_" << detector_type;
+    string absnodename = "G4HIT_ABSORBER_";
+    if (SuperDetector() != "NONE")
+    {
+      absnodename += SuperDetector();
+    }
+    else
+    {
+      absnodename += Name();
+    }
 
-    PHG4HitContainer* absorber_hits = findNode::getClass<PHG4HitContainer>(topNode, absnodename.str().c_str());
+    PHG4HitContainer* absorber_hits = findNode::getClass<PHG4HitContainer>(topNode, absnodename);
     if (!absorber_hits)
     {
-      absorber_hits = new PHG4HitContainer(absnodename.str());
-      PHIODataNode<PHObject>* abshitNode = new PHIODataNode<PHObject>(absorber_hits, absnodename.str().c_str(), "PHObject");
+      absorber_hits = new PHG4HitContainer(absnodename);
+      PHIODataNode<PHObject>* abshitNode = new PHIODataNode<PHObject>(absorber_hits, absnodename, "PHObject");
       dstNode->addNode(abshitNode);
     }
 

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
@@ -28,12 +28,10 @@ using namespace std;
 //_______________________________________________________________________
 PHG4CrystalCalorimeterSubsystem::PHG4CrystalCalorimeterSubsystem(const std::string& name, const int lyr)
   : PHG4DetectorSubsystem(name, lyr)
-  , active(1)
   , mappingfile_("")
   , mappingfile_4x4_construct_("")
   , projective_(false)
 {
-  detector_type = name + to_string(lyr);
   InitializeParameters();
 }
 
@@ -72,8 +70,6 @@ int PHG4CrystalCalorimeterSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
     m_Detector->SetTowerMappingFile(mappingfile_);
   }
 
-  m_Detector->SetActive(active);
-  m_Detector->SetAbsorberActive(active);
   m_Detector->OverlapCheck(CheckOverlap());
   m_Detector->SuperDetector(SuperDetector());
   GetParams()->Print();

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
@@ -59,7 +59,7 @@ int PHG4CrystalCalorimeterSubsystem::InitSubsystem(PHCompositeNode* topNode)
     {
       cout << "PHG4CrystalCalorimeterSubsystem::InitRun - use PHG4ProjCrystalCalorimeterDetector" << endl;
     }
-    m_Detector = new PHG4ProjCrystalCalorimeterDetector(this, topNode, Name());
+    m_Detector = new PHG4ProjCrystalCalorimeterDetector(this, topNode, GetParams(), Name());
     m_Detector->SetTowerMappingFile(mappingfile_);
     m_Detector->SetSupermoduleGeometry(mappingfile_4x4_construct_);
   }
@@ -69,7 +69,7 @@ int PHG4CrystalCalorimeterSubsystem::InitSubsystem(PHCompositeNode* topNode)
     {
       cout << "PHG4CrystalCalorimeterSubsystem::InitRun - use PHG4CrystalCalorimeterDetector" << endl;
     }
-    m_Detector = new PHG4CrystalCalorimeterDetector(this, topNode, Name());
+    m_Detector = new PHG4CrystalCalorimeterDetector(this, topNode, GetParams(), Name());
     m_Detector->SetTowerMappingFile(mappingfile_);
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.cc
@@ -76,6 +76,7 @@ int PHG4CrystalCalorimeterSubsystem::InitSubsystem(PHCompositeNode* topNode)
   m_Detector->SetActive(active);
   m_Detector->SetAbsorberActive(active);
   m_Detector->OverlapCheck(CheckOverlap());
+  m_Detector->SuperDetector(SuperDetector());
 
   if (active)
   {

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.h
@@ -5,7 +5,7 @@
 
 #include "PHG4DetectorSubsystem.h"
 
-#include <string>                  // for string
+#include <string>  // for string
 
 class PHCompositeNode;
 class PHG4CrystalCalorimeterDetector;
@@ -66,11 +66,10 @@ class PHG4CrystalCalorimeterSubsystem : public PHG4DetectorSubsystem
   //  };
 
  private:
-
   //! set detector specific parameters and their defaults
   /*! called by PHG4DetectorSubsystem */
   void SetDefaultParameters() override;
-  
+
   //  GeometryConfiguration current_geom_config_;
 
   /** Pointer to the Geant4 implementation of the detector

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.h
@@ -84,9 +84,6 @@ class PHG4CrystalCalorimeterSubsystem : public PHG4DetectorSubsystem
   /*! derives from PHG4DisplayAction */
   PHG4DisplayAction *m_DisplayAction = nullptr;
 
-  int active;
-
-  std::string detector_type;
   std::string mappingfile_;
   std::string mappingfile_4x4_construct_;
 

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.h
@@ -3,7 +3,7 @@
 #ifndef G4DETECTORS_PHG4CRYSTALCALORIMETERSUBSYSTEM_H
 #define G4DETECTORS_PHG4CRYSTALCALORIMETERSUBSYSTEM_H
 
-#include <g4main/PHG4Subsystem.h>
+#include "PHG4DetectorSubsystem.h"
 
 #include <string>                  // for string
 
@@ -13,7 +13,7 @@ class PHG4Detector;
 class PHG4DisplayAction;
 class PHG4SteppingAction;
 
-class PHG4CrystalCalorimeterSubsystem : public PHG4Subsystem
+class PHG4CrystalCalorimeterSubsystem : public PHG4DetectorSubsystem
 {
  public:
   /** Constructor
@@ -29,17 +29,17 @@ class PHG4CrystalCalorimeterSubsystem : public PHG4Subsystem
      Creates the stepping action and place it on the node tree, under "ACTIONS" node
      Creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int Init(PHCompositeNode *);
+  int InitSubsystem(PHCompositeNode *) override;
 
   /** Event processing
    */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   /** Accessors (reimplemented)
    */
-  PHG4Detector *GetDetector(void) const;
-  PHG4SteppingAction *GetSteppingAction() const { return m_SteppingAction; }
-  PHG4DisplayAction *GetDisplayAction() const { return m_DisplayAction; }
+  PHG4Detector *GetDetector(void) const override;
+  PHG4SteppingAction *GetSteppingAction() const override { return m_SteppingAction; }
+  PHG4DisplayAction *GetDisplayAction() const override { return m_DisplayAction; }
 
   /** Set mapping file for calorimeter towers
    */
@@ -66,6 +66,11 @@ class PHG4CrystalCalorimeterSubsystem : public PHG4Subsystem
   //  };
 
  private:
+
+  //! set detector specific parameters and their defaults
+  /*! called by PHG4DetectorSubsystem */
+  void SetDefaultParameters() override;
+  
   //  GeometryConfiguration current_geom_config_;
 
   /** Pointer to the Geant4 implementation of the detector

--- a/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CrystalCalorimeterSubsystem.h
@@ -29,7 +29,7 @@ class PHG4CrystalCalorimeterSubsystem : public PHG4DetectorSubsystem
      Creates the stepping action and place it on the node tree, under "ACTIONS" node
      Creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitSubsystem(PHCompositeNode *) override;
+  int InitRunSubsystem(PHCompositeNode *) override;
 
   /** Event processing
    */
@@ -75,14 +75,14 @@ class PHG4CrystalCalorimeterSubsystem : public PHG4DetectorSubsystem
 
   /** Pointer to the Geant4 implementation of the detector
    */
-  PHG4CrystalCalorimeterDetector *m_Detector;
+  PHG4CrystalCalorimeterDetector *m_Detector = nullptr;
 
   /** Stepping action
    */
-  PHG4SteppingAction *m_SteppingAction;
+  PHG4SteppingAction *m_SteppingAction = nullptr;
   //! display attribute setting
   /*! derives from PHG4DisplayAction */
-  PHG4DisplayAction *m_DisplayAction;
+  PHG4DisplayAction *m_DisplayAction = nullptr;
 
   int active;
 

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
@@ -5,6 +5,8 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <phool/recoConsts.h>
+
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4Element.hh>  // for G4Element
 #include <Geant4/G4GenericTrap.hh>
@@ -95,7 +97,8 @@ void PHG4ProjCrystalCalorimeterDetector::ConstructMe(G4LogicalVolume *logicWorld
 
   /* Create the cone envelope = 'world volume' for the crystal calorimeter */
   //G4Material* Air = G4Material::GetMaterial("G4_AIR");
-  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
+   recoConsts *rc = recoConsts::instance();
+   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
   G4VSolid *ecal_envelope_cone = new G4Cons("eEcal_envelope_solid",
                                             _rMin1, _rMax1,
@@ -103,7 +106,7 @@ void PHG4ProjCrystalCalorimeterDetector::ConstructMe(G4LogicalVolume *logicWorld
                                             _dZ / 2.,
                                             _sPhi, _dPhi);
 
-  G4LogicalVolume *ecal_envelope_log = new G4LogicalVolume(ecal_envelope_cone, Air, G4String("eEcal_envelope"), 0, 0, 0);
+  G4LogicalVolume *ecal_envelope_log = new G4LogicalVolume(ecal_envelope_cone, WorldMaterial, G4String("eEcal_envelope"), 0, 0, 0);
   GetDisplayAction()->AddVolume(ecal_envelope_log, "Envelope");
   /* Define rotation attributes for envelope cone */
   G4RotationMatrix ecal_rotm;
@@ -154,7 +157,10 @@ int PHG4ProjCrystalCalorimeterDetector::Fill4x4Unit(G4LogicalVolume *crystal_log
 
   //Air
   //G4Material* Air = G4Material::GetMaterial("G4_AIR");
-  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
+   recoConsts *rc = recoConsts::instance();
+   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
+
+//  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
 
   //*************************************
   //**********Build First Crystal********
@@ -214,7 +220,7 @@ int PHG4ProjCrystalCalorimeterDetector::Fill4x4Unit(G4LogicalVolume *crystal_log
                                          TwoByTwo_dz);  //Half length in z
 
   G4LogicalVolume *Two_by_Two_logic = new G4LogicalVolume(Two_by_Two_solid,
-                                                          Air,
+                                                          WorldMaterial,
                                                           "2_by_2_unit",
                                                           0, 0, 0);
 
@@ -549,7 +555,9 @@ int PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal
 
   //Air
   //G4Material* Air = G4Material::GetMaterial("G4_AIR");
-  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
+   recoConsts *rc = recoConsts::instance();
+   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
+//  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
 
   //*************************************
   //**********Build First Crystal********
@@ -609,7 +617,7 @@ int PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal
                                          TwoByTwo_dz);  //Half length in z
 
   G4LogicalVolume *Two_by_Two_logic = new G4LogicalVolume(Two_by_Two_solid,
-                                                          Air,
+                                                          WorldMaterial,
                                                           "2_by_2_unit",
                                                           0, 0, 0);
 
@@ -1162,10 +1170,12 @@ int PHG4ProjCrystalCalorimeterDetector::ConstructProjectiveCrystals(G4LogicalVol
                                       dz);  //Half length in z
 
   //G4Material* Air = G4Material::GetMaterial("G4_AIR");
-  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
+//  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
+   recoConsts *rc = recoConsts::instance();
+   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
   G4LogicalVolume *crystal_logic = new G4LogicalVolume(crystal_solid,
-                                                       Air,
+                                                       WorldMaterial,
                                                        "eEcal_crystal_unit",
                                                        0, 0, 0);
 
@@ -1179,7 +1189,7 @@ int PHG4ProjCrystalCalorimeterDetector::ConstructProjectiveCrystals(G4LogicalVol
                                      dz);          //Half length in z
 
   G4LogicalVolume *twelve_logic = new G4LogicalVolume(twelve_solid,
-                                                      Air,
+                                                      WorldMaterial,
                                                       "12_unit",
                                                       0, 0, 0);
 
@@ -1193,7 +1203,7 @@ int PHG4ProjCrystalCalorimeterDetector::ConstructProjectiveCrystals(G4LogicalVol
                                         dz);          //Half length in z
 
   G4LogicalVolume *twentytwo_logic = new G4LogicalVolume(twentytwo_solid,
-                                                         Air,
+                                                         WorldMaterial,
                                                          "22_unit",
                                                          0, 0, 0);
 
@@ -1251,7 +1261,7 @@ int PHG4ProjCrystalCalorimeterDetector::ConstructProjectiveCrystals(G4LogicalVol
                                                                Crystal_Center);
 
   G4LogicalVolume *thirtytwo_logic = new G4LogicalVolume(thirtytwo_solid,
-                                                         Air,
+                                                         WorldMaterial,
                                                          "32_unit",
                                                          0, 0, 0);
 

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
@@ -3,6 +3,8 @@
 #include "PHG4CrystalCalorimeterDetector.h"
 #include "PHG4CrystalCalorimeterDisplayAction.h"
 
+#include <phparameter/PHParameters.h>
+
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4Element.hh>  // for G4Element
 #include <Geant4/G4GenericTrap.hh>
@@ -44,9 +46,12 @@ PHG4ProjCrystalCalorimeterDetector::PHG4ProjCrystalCalorimeterDetector(PHG4Subsy
   , _dx_back(48.97454545455 * mm)
   , _dy_back(48.97454545455 * mm)
   , _dz_crystal(90.000 * mm)
+  , m_Params(parameters)
   , _crystallogicnameprefix("eEcalCrystal")
   , _4x4_construct_file("")
   , _overlapcheck_local(false)
+  , m_IsActive(m_Params->get_int_param("active"))
+  , m_AbsorberActive(m_Params->get_int_param("absorberactive"))
 {
 }
 
@@ -56,15 +61,20 @@ int PHG4ProjCrystalCalorimeterDetector::IsInCrystalCalorimeter(G4VPhysicalVolume
   // if hit is in absorber material
   //  bool isinabsorber = false;
 
+  if (m_IsActive)
+  {
   if (volume->GetName().find(_crystallogicnameprefix) != string::npos)
   {
     return 1;
   }
-  else if (volume->GetName().find("arbon") != string::npos)
+  }
+  if (m_AbsorberActive)
+  {
+  if (volume->GetName().find("arbon") != string::npos)
   {
     return -1;
   }
-
+  }
   return 0;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
@@ -21,7 +21,7 @@
 #include <Geant4/G4Transform3D.hh>  // for G4Transform3D
 #include <Geant4/G4Trd.hh>
 #include <Geant4/G4TwoVector.hh>
-#include <Geant4/G4Types.hh>                      // for G4double, G4int
+#include <Geant4/G4Types.hh>            // for G4double, G4int
 #include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 
 #include <cstdlib>
@@ -35,7 +35,7 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4ProjCrystalCalorimeterDetector::PHG4ProjCrystalCalorimeterDetector(PHG4Subsystem *subsys, PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam)
+PHG4ProjCrystalCalorimeterDetector::PHG4ProjCrystalCalorimeterDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
   : PHG4CrystalCalorimeterDetector(subsys, Node, parameters, dnam)
   , m_Params(parameters)
   ,
@@ -97,8 +97,8 @@ void PHG4ProjCrystalCalorimeterDetector::ConstructMe(G4LogicalVolume *logicWorld
 
   /* Create the cone envelope = 'world volume' for the crystal calorimeter */
   //G4Material* Air = G4Material::GetMaterial("G4_AIR");
-   recoConsts *rc = recoConsts::instance();
-   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
+  recoConsts *rc = recoConsts::instance();
+  G4Material *WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
   G4VSolid *ecal_envelope_cone = new G4Cons("eEcal_envelope_solid",
                                             _rMin1, _rMax1,
@@ -157,10 +157,10 @@ int PHG4ProjCrystalCalorimeterDetector::Fill4x4Unit(G4LogicalVolume *crystal_log
 
   //Air
   //G4Material* Air = G4Material::GetMaterial("G4_AIR");
-   recoConsts *rc = recoConsts::instance();
-   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
+  recoConsts *rc = recoConsts::instance();
+  G4Material *WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
-//  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
+  //  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
 
   //*************************************
   //**********Build First Crystal********
@@ -314,12 +314,12 @@ int PHG4ProjCrystalCalorimeterDetector::Fill4x4Unit(G4LogicalVolume *crystal_log
       crystal_name << _crystallogicnameprefix << "_j_" << j_idx << "_k_" << k_idx;
 
       G4VPhysicalVolume *physvol = new G4PVPlacement(Rot, Crystal_Center,
-                        crystal_logic_small,
-                        crystal_name.str().c_str(),
-                        Two_by_Two_logic,
-                        0, 0, _overlapcheck_local);
+                                                     crystal_logic_small,
+                                                     crystal_name.str().c_str(),
+                                                     Two_by_Two_logic,
+                                                     0, 0, _overlapcheck_local);
 
-       m_ActiveVolumeSet.insert(physvol);
+      m_ActiveVolumeSet.insert(physvol);
       j_idx = k_idx = 0;
       x_cent = y_cent = z_cent = rot_x = rot_y = rot_z = 0.0;
     }
@@ -523,10 +523,10 @@ int PHG4ProjCrystalCalorimeterDetector::Fill4x4Unit(G4LogicalVolume *crystal_log
   Rot_5->rotateZ(0 * rad);
 
   G4VPhysicalVolume *physvol = new G4PVPlacement(Rot_5, Carbon_Center,
-                    Carbon_Shell_logic,
-                    "Carbon_Fiber_Shell",
-                    crystal_logic,
-                    0, 0, _overlapcheck_local);
+                                                 Carbon_Shell_logic,
+                                                 "Carbon_Fiber_Shell",
+                                                 crystal_logic,
+                                                 0, 0, _overlapcheck_local);
 
   m_PassiveVolumeSet.insert(physvol);
   //***********************************
@@ -555,9 +555,9 @@ int PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal
 
   //Air
   //G4Material* Air = G4Material::GetMaterial("G4_AIR");
-   recoConsts *rc = recoConsts::instance();
-   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
-//  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
+  recoConsts *rc = recoConsts::instance();
+  G4Material *WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
+  //  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
 
   //*************************************
   //**********Build First Crystal********
@@ -711,11 +711,11 @@ int PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal
       crystal_name << _crystallogicnameprefix << "_j_" << j_idx << "_k_" << k_idx;
 
       G4VPhysicalVolume *physvol = new G4PVPlacement(Rot, Crystal_Center,
-                        crystal_logic_small,
-                        crystal_name.str().c_str(),
-                        Two_by_Two_logic,
-                        0, 0, _overlapcheck_local);
-       m_ActiveVolumeSet.insert(physvol);
+                                                     crystal_logic_small,
+                                                     crystal_name.str().c_str(),
+                                                     Two_by_Two_logic,
+                                                     0, 0, _overlapcheck_local);
+      m_ActiveVolumeSet.insert(physvol);
 
       j_idx = k_idx = 0;
       x_cent = y_cent = z_cent = rot_z = 0.0;
@@ -873,10 +873,10 @@ int PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal
     Rot_5->rotateZ(0 * rad);
 
     G4VPhysicalVolume *physvol = new G4PVPlacement(Rot_5, Carbon_Center,
-                      Carbon_Shell_logic,
-                      "Carbon_Fiber_Shell",
-                      crystal_logic,
-                      0, 0, _overlapcheck_local);
+                                                   Carbon_Shell_logic,
+                                                   "Carbon_Fiber_Shell",
+                                                   crystal_logic,
+                                                   0, 0, _overlapcheck_local);
     m_PassiveVolumeSet.insert(physvol);
   }
   else if (ident == 22)
@@ -967,12 +967,11 @@ int PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal
     Rot_5->rotateZ(0 * rad);
 
     G4VPhysicalVolume *physvol = new G4PVPlacement(Rot_5, Carbon_Center,
-                      Carbon_Shell_logic,
-                      "Carbon_Fiber_Shell",
-                      crystal_logic,
-                      0, 0, _overlapcheck_local);
+                                                   Carbon_Shell_logic,
+                                                   "Carbon_Fiber_Shell",
+                                                   crystal_logic,
+                                                   0, 0, _overlapcheck_local);
     m_PassiveVolumeSet.insert(physvol);
-
   }
   else if (ident == 32)
   {
@@ -1124,12 +1123,11 @@ int PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal
     Rot_5->rotateZ(0 * rad);
 
     G4VPhysicalVolume *physvol = new G4PVPlacement(Rot_5, Carbon_Center,
-                      Carbon_Shell_logic,
-                      "Carbon_Fiber_Shell",
-                      crystal_logic,
-                      0, 0, _overlapcheck_local);
+                                                   Carbon_Shell_logic,
+                                                   "Carbon_Fiber_Shell",
+                                                   crystal_logic,
+                                                   0, 0, _overlapcheck_local);
     m_PassiveVolumeSet.insert(physvol);
-
   }
   else
   {
@@ -1170,9 +1168,9 @@ int PHG4ProjCrystalCalorimeterDetector::ConstructProjectiveCrystals(G4LogicalVol
                                       dz);  //Half length in z
 
   //G4Material* Air = G4Material::GetMaterial("G4_AIR");
-//  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
-   recoConsts *rc = recoConsts::instance();
-   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
+  //  G4Material *Air = G4Material::GetMaterial("G4_Galactic");
+  recoConsts *rc = recoConsts::instance();
+  G4Material *WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
   G4LogicalVolume *crystal_logic = new G4LogicalVolume(crystal_solid,
                                                        WorldMaterial,

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
@@ -35,6 +35,7 @@ using namespace std;
 //_______________________________________________________________________
 PHG4ProjCrystalCalorimeterDetector::PHG4ProjCrystalCalorimeterDetector(PHG4Subsystem *subsys, PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam)
   : PHG4CrystalCalorimeterDetector(subsys, Node, parameters, dnam)
+  , m_Params(parameters)
   ,
   //  _dx_front(50.19*mm),		//****************************************************************//
   //  _dy_front(50.19*mm),		//****************************************************************//
@@ -46,7 +47,6 @@ PHG4ProjCrystalCalorimeterDetector::PHG4ProjCrystalCalorimeterDetector(PHG4Subsy
   , _dx_back(48.97454545455 * mm)
   , _dy_back(48.97454545455 * mm)
   , _dz_crystal(90.000 * mm)
-  , m_Params(parameters)
   , _crystallogicnameprefix("eEcalCrystal")
   , _4x4_construct_file("")
   , _overlapcheck_local(false)
@@ -70,7 +70,7 @@ int PHG4ProjCrystalCalorimeterDetector::IsInCrystalCalorimeter(G4VPhysicalVolume
   }
   if (m_AbsorberActive)
   {
-    if (volume->GetName().find("arbon") != string::npos)
+    if (m_PassiveVolumeSet.find(volume) != m_PassiveVolumeSet.end())
     {
       return -1;
     }
@@ -516,12 +516,13 @@ int PHG4ProjCrystalCalorimeterDetector::Fill4x4Unit(G4LogicalVolume *crystal_log
   Rot_5->rotateY(0 * rad);
   Rot_5->rotateZ(0 * rad);
 
-  new G4PVPlacement(Rot_5, Carbon_Center,
+  G4VPhysicalVolume *physvol = new G4PVPlacement(Rot_5, Carbon_Center,
                     Carbon_Shell_logic,
                     "Carbon_Fiber_Shell",
                     crystal_logic,
                     0, 0, _overlapcheck_local);
 
+  m_PassiveVolumeSet.insert(physvol);
   //***********************************
   //All done! Return to parent function
   //***********************************
@@ -863,11 +864,12 @@ int PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal
     Rot_5->rotateY(0 * rad);
     Rot_5->rotateZ(0 * rad);
 
-    new G4PVPlacement(Rot_5, Carbon_Center,
+    G4VPhysicalVolume *physvol = new G4PVPlacement(Rot_5, Carbon_Center,
                       Carbon_Shell_logic,
                       "Carbon_Fiber_Shell",
                       crystal_logic,
                       0, 0, _overlapcheck_local);
+    m_PassiveVolumeSet.insert(physvol);
   }
   else if (ident == 22)
   {
@@ -956,11 +958,13 @@ int PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal
     Rot_5->rotateY(0 * rad);
     Rot_5->rotateZ(0 * rad);
 
-    new G4PVPlacement(Rot_5, Carbon_Center,
+    G4VPhysicalVolume *physvol = new G4PVPlacement(Rot_5, Carbon_Center,
                       Carbon_Shell_logic,
                       "Carbon_Fiber_Shell",
                       crystal_logic,
                       0, 0, _overlapcheck_local);
+    m_PassiveVolumeSet.insert(physvol);
+
   }
   else if (ident == 32)
   {
@@ -1111,11 +1115,13 @@ int PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal
     Rot_5->rotateY(0 * rad);
     Rot_5->rotateZ(0 * rad);
 
-    new G4PVPlacement(Rot_5, Carbon_Center,
+    G4VPhysicalVolume *physvol = new G4PVPlacement(Rot_5, Carbon_Center,
                       Carbon_Shell_logic,
                       "Carbon_Fiber_Shell",
                       crystal_logic,
                       0, 0, _overlapcheck_local);
+    m_PassiveVolumeSet.insert(physvol);
+
   }
   else
   {

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
@@ -63,17 +63,17 @@ int PHG4ProjCrystalCalorimeterDetector::IsInCrystalCalorimeter(G4VPhysicalVolume
 
   if (m_IsActive)
   {
-  if (volume->GetName().find(_crystallogicnameprefix) != string::npos)
-  {
-    return 1;
-  }
+    if (m_ActiveVolumeSet.find(volume) != m_ActiveVolumeSet.end())
+    {
+      return 1;
+    }
   }
   if (m_AbsorberActive)
   {
-  if (volume->GetName().find("arbon") != string::npos)
-  {
-    return -1;
-  }
+    if (volume->GetName().find("arbon") != string::npos)
+    {
+      return -1;
+    }
   }
   return 0;
 }
@@ -307,12 +307,13 @@ int PHG4ProjCrystalCalorimeterDetector::Fill4x4Unit(G4LogicalVolume *crystal_log
       crystal_name.str("");
       crystal_name << _crystallogicnameprefix << "_j_" << j_idx << "_k_" << k_idx;
 
-      new G4PVPlacement(Rot, Crystal_Center,
+      G4VPhysicalVolume *physvol = new G4PVPlacement(Rot, Crystal_Center,
                         crystal_logic_small,
                         crystal_name.str().c_str(),
                         Two_by_Two_logic,
                         0, 0, _overlapcheck_local);
 
+       m_ActiveVolumeSet.insert(physvol);
       j_idx = k_idx = 0;
       x_cent = y_cent = z_cent = rot_x = rot_y = rot_z = 0.0;
     }
@@ -700,11 +701,12 @@ int PHG4ProjCrystalCalorimeterDetector::FillSpecialUnit(G4LogicalVolume *crystal
       crystal_name.str("");
       crystal_name << _crystallogicnameprefix << "_j_" << j_idx << "_k_" << k_idx;
 
-      new G4PVPlacement(Rot, Crystal_Center,
+      G4VPhysicalVolume *physvol = new G4PVPlacement(Rot, Crystal_Center,
                         crystal_logic_small,
                         crystal_name.str().c_str(),
                         Two_by_Two_logic,
                         0, 0, _overlapcheck_local);
+       m_ActiveVolumeSet.insert(physvol);
 
       j_idx = k_idx = 0;
       x_cent = y_cent = z_cent = rot_z = 0.0;

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.cc
@@ -31,8 +31,8 @@ class PHCompositeNode;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4ProjCrystalCalorimeterDetector::PHG4ProjCrystalCalorimeterDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam)
-  : PHG4CrystalCalorimeterDetector(subsys, Node, dnam)
+PHG4ProjCrystalCalorimeterDetector::PHG4ProjCrystalCalorimeterDetector(PHG4Subsystem *subsys, PHCompositeNode *Node,  PHParameters *parameters, const std::string &dnam)
+  : PHG4CrystalCalorimeterDetector(subsys, Node, parameters, dnam)
   ,
   //  _dx_front(50.19*mm),		//****************************************************************//
   //  _dy_front(50.19*mm),		//****************************************************************//

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
@@ -81,6 +81,8 @@ class PHG4ProjCrystalCalorimeterDetector : public PHG4CrystalCalorimeterDetector
   std::string _4x4_construct_file;
 
   bool _overlapcheck_local;
+  std::set<G4VPhysicalVolume*> m_ActiveVolumeSet;
+  std::set<G4VPhysicalVolume*> m_PassiveVolumeSet;
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
@@ -81,6 +81,11 @@ class PHG4ProjCrystalCalorimeterDetector : public PHG4CrystalCalorimeterDetector
   std::string _4x4_construct_file;
 
   bool _overlapcheck_local;
+  // since getting parameters is a map search we do not want to
+  // do this in every step, the parameters used are cached
+  // in the following variables
+  int m_IsActive;
+  int m_AbsorberActive;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
@@ -13,6 +13,7 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
 class PHG4Subsystem;
+class PHParameters;
 
 /**
  * \file ${file_name}
@@ -24,7 +25,7 @@ class PHG4ProjCrystalCalorimeterDetector : public PHG4CrystalCalorimeterDetector
 {
  public:
   //! constructor
-  PHG4ProjCrystalCalorimeterDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam);
+  PHG4ProjCrystalCalorimeterDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters *parameters, const std::string& dnam);
 
   //! destructor
   virtual ~PHG4ProjCrystalCalorimeterDetector(){}
@@ -67,6 +68,7 @@ class PHG4ProjCrystalCalorimeterDetector : public PHG4CrystalCalorimeterDetector
   int ConstructProjectiveCrystals(G4LogicalVolume* envelope);
   int Fill4x4Unit(G4LogicalVolume* crystal_logic);
   int FillSpecialUnit(G4LogicalVolume* crystal_logic, G4int ident);
+  PHParameters *m_Params = nullptr;
 
   /* crystal geometry */
   G4double _dx_front;

--- a/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ProjCrystalCalorimeterDetector.h
@@ -25,10 +25,10 @@ class PHG4ProjCrystalCalorimeterDetector : public PHG4CrystalCalorimeterDetector
 {
  public:
   //! constructor
-  PHG4ProjCrystalCalorimeterDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters *parameters, const std::string& dnam);
+  PHG4ProjCrystalCalorimeterDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam);
 
   //! destructor
-  virtual ~PHG4ProjCrystalCalorimeterDetector(){}
+  virtual ~PHG4ProjCrystalCalorimeterDetector() {}
 
   //! construct
   virtual void ConstructMe(G4LogicalVolume* world);
@@ -68,7 +68,7 @@ class PHG4ProjCrystalCalorimeterDetector : public PHG4CrystalCalorimeterDetector
   int ConstructProjectiveCrystals(G4LogicalVolume* envelope);
   int Fill4x4Unit(G4LogicalVolume* crystal_logic);
   int FillSpecialUnit(G4LogicalVolume* crystal_logic, G4int ident);
-  PHParameters *m_Params = nullptr;
+  PHParameters* m_Params = nullptr;
 
   /* crystal geometry */
   G4double _dx_front;


### PR DESCRIPTION
This PR modernizes the crystal calorimeter. Instead of string parsing it compares the actual volume, so volumes from other subsystems which match the string compare are not picked up anymore.
The projective calorimeter cheated - it was surrounded by vacuum. This is now replaced with the world material which leads to significantly higher number of hits in the crystals and the absorbers (if the world is filled with air). Given that it was initially air which was exchanged by vacuum later I guess someone "tuned" this