### PR TITLE
Branchwarning

### DIFF
--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -504,12 +504,17 @@ readnextsync:
 
 int Fun4AllDstInputManager::BranchSelect(const string &branch, const int iflag)
 {
-  int myflag = iflag;
+  if (IsOpen())
+  {
+    cout << "BranchSelect(\"" << branch << "\", " << iflag
+	 << ") : Input branches can only selected for reading before fileopen is called proceeding without input branch selection" << endl;
+    return -1;
+  }
   // if iflag > 0 the branch is set to read
   // if iflag = 0, the branch is set to NOT read
   // if iflag < 0 the branchname is erased from our internal branch read map
   // this does not have any effect on phool yet
-  if (myflag < 0)
+  if (iflag < 0)
   {
     map<const string, int>::iterator branchiter;
     branchiter = branchread.find(branch);
@@ -519,14 +524,14 @@ int Fun4AllDstInputManager::BranchSelect(const string &branch, const int iflag)
     }
     return 0;
   }
-
-  if (myflag > 0)
+  int readit = 0;
+  if (iflag > 0)
   {
     if (Verbosity() > 1)
     {
       cout << "Setting Root Tree Branch: " << branch << " to read" << endl;
     }
-    myflag = 1;
+    readit = 1;
   }
   else
   {
@@ -535,7 +540,7 @@ int Fun4AllDstInputManager::BranchSelect(const string &branch, const int iflag)
       cout << "Setting Root Tree Branch: " << branch << " to NOT read" << endl;
     }
   }
-  branchread[branch] = myflag;
+  branchread[branch] = iflag;
   return 0;
 }
 

--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -540,7 +540,7 @@ int Fun4AllDstInputManager::BranchSelect(const string &branch, const int iflag)
       cout << "Setting Root Tree Branch: " << branch << " to NOT read" << endl;
     }
   }
-  branchread[branch] = iflag;
+  branchread[branch] = readit;
   return 0;
 }
 

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -30,7 +30,7 @@ class Fun4AllInputManager : public Fun4AllBase
   virtual int GetSyncObject(SyncObject ** /*mastersync*/) { return 0; }
   virtual int SyncIt(const SyncObject * /*mastersync*/) { return Fun4AllReturnCodes::SYNC_FAIL; }
   virtual int BranchSelect(const std::string & /*branch*/, const int /*iflag*/) { return -1; }
-  virtual int setBranches() { return -1; }
+  virtual int setBranches() { return -1; } // publich bc needed by the sync manager
   virtual void Print(const std::string &what = "ALL") const;
   virtual int PushBackEvents(const int /*nevt*/) { return -1; }
   // so people can use the skip they are used to instead of PushBackEvents

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -342,13 +342,12 @@ bool PHNodeIOManager::readEventFromFile(size_t requestedEvent)
   return true;
 }
 
-int PHNodeIOManager::readSpecific(size_t requestedEvent, const char* objectName)
+int PHNodeIOManager::readSpecific(size_t requestedEvent, const std::string &objectName)
 {
   // objectName should be one of the valid branch name of the "T" TTree, and
   // should be one of the branches selected by selectObjectToRead() method.
   // No wildcard allowed for the moment.
-  string name = objectName;
-  map<string, TBranch*>::const_iterator p = fBranches.find(name);
+  map<string, TBranch*>::const_iterator p = fBranches.find(objectName);
 
   if (p != fBranches.end())
   {
@@ -518,7 +517,7 @@ PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
   return topNode;
 }
 
-void PHNodeIOManager::selectObjectToRead(const char* objectName, bool readit)
+void PHNodeIOManager::selectObjectToRead(const std::string &objectName, bool readit)
 {
   objectToRead[objectName] = readit;
 
@@ -536,10 +535,9 @@ void PHNodeIOManager::selectObjectToRead(const char* objectName, bool readit)
   return;
 }
 
-bool PHNodeIOManager::isSelected(const char* objectName)
+bool PHNodeIOManager::isSelected(const std::string &objectName)
 {
-  string name = objectName;
-  map<string, TBranch*>::const_iterator p = fBranches.find(name);
+  map<string, TBranch*>::const_iterator p = fBranches.find(objectName);
 
   if (p != fBranches.end())
   {

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -35,9 +35,9 @@ class PHNodeIOManager : public PHIOManager
   bool setFile(const std::string &, const std::string &, const PHAccessType = PHReadOnly);
   PHCompositeNode *read(PHCompositeNode * = nullptr, size_t = 0);
   bool read(size_t requestedEvent);
-  int readSpecific(size_t requestedEvent, const char *objectName);
-  void selectObjectToRead(const char *objectName, bool readit);
-  bool isSelected(const char *objectName);
+  int readSpecific(size_t requestedEvent, const std::string &objectName);
+  void selectObjectToRead(const std::string &objectName, bool readit);
+  bool isSelected(const std::string &objectName);
   int isFunctional() const { return isFunctionalFlag; }
   bool SetCompressionLevel(const int level);
   double GetBytesWritten();

--- a/offline/framework/phool/PHTimer.cc
+++ b/offline/framework/phool/PHTimer.cc
@@ -22,7 +22,7 @@ PHTimer::Frequency PHTimer::_frequency = PHTimer::Frequency();
 const double PHTimer::_twopower32 = pow(2, 32);
 
 //______________________________________________________________________
-void PHTimer::Frequency::set_cpu_freq(const char* path)
+void PHTimer::Frequency::set_cpu_freq(const std::string &path)
 {
   // Set the default to 2 GHz
   _frequency = 2e9;

--- a/offline/framework/phool/PHTimer.h
+++ b/offline/framework/phool/PHTimer.h
@@ -183,7 +183,7 @@ class PHTimer
     double _period;
 
     //! read pc frequency from cpuinfo place
-    void set_cpu_freq(const char* cpuinfopath = "/proc/cpuinfo");
+    void set_cpu_freq(const std::string &cpuinfopath = "/proc/cpuinfo");
   };
 
   //! used to store high precision time using two integers


### PR DESCRIPTION
I revived the selection of branches for reading so one reads only the data which is needed. This selection needs to be applied before a file is opened to have an effect. There is now a warning message saying so if the order is reversed. I did not make this fatal since the reading still works (you just read more bytes than you have to).
Also - replaced a few more const char * interfaces by const std::string &