### PR TITLE
Switch Seeding to MVTX

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -20,6 +20,9 @@
 
 #include <string>
 #include <map>
+#include <TFile.h>
+#include <TH1.h>
+#include <TH2.h>
 
 class PHCompositeNode;
 class SvtxTrackMap;
@@ -53,6 +56,7 @@ struct SpacePoint {
 
 };
 
+/// This is needed by the Acts seedfinder 
 inline bool operator==(SpacePoint a, SpacePoint b) {
   return (a.m_hitId == b.m_hitId);
 }
@@ -80,6 +84,9 @@ class PHActsSiliconSeeding : public SubsysReco
   void useTruthClusters(bool useTruthClusters)
     { m_useTruthClusters = useTruthClusters; }
 
+  void seedAnalysis(bool seedAnalysis)
+    { m_seedAnalysis = seedAnalysis;}
+  
  private:
 
   int getNodes(PHCompositeNode *topNode);
@@ -136,12 +143,12 @@ class PHActsSiliconSeeding : public SubsysReco
 
   /// Limiting location of measurements (e.g. detector constraints)
   float m_rMax = 250.;
-  float m_rMin = 20.;
+  float m_rMin = 23.;
   float m_zMax = 500.;
   float m_zMin = -500.;
  
   /// max distance between two measurements in one seed
-  float m_deltaRMax = 50;
+  float m_deltaRMax = 40;
   
   /// Cot of maximum theta angle. Equivalent to eta=1.1 here
   float m_cotThetaMax = 1.335647;
@@ -157,6 +164,16 @@ class PHActsSiliconSeeding : public SubsysReco
 
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;
+
+  bool m_seedAnalysis = true;
+  TFile *m_file = nullptr;
+  TH1 *h_nMvtxHits = nullptr;
+  TH1 *h_nInttHits = nullptr;
+  TH2 *h_nHits = nullptr;
+  TH1 *h_nSeeds = nullptr;
+  TH1 *h_nInputMeas = nullptr;
+  TH1 *h_nInputMvtxMeas = nullptr;
+  TH1 *h_nInputInttMeas = nullptr;
 
 };
 

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -107,7 +107,7 @@ class PHActsSiliconSeeding : public SubsysReco
 			    const SourceLink& sl);
   
   /// Get all space points for the seeder
-  std::vector<const SpacePoint*> getSpacePoints();
+  std::vector<const SpacePoint*> getMvtxSpacePoints();
 
   /// Perform circle/line fits with the final seed to get
   /// initial point and momentum estimates for stub matching
@@ -127,7 +127,12 @@ class PHActsSiliconSeeding : public SubsysReco
 			const std::vector<TrkrCluster*>& clusters,
 			const double R,
 			const double X0,
-			const double Y0);
+			const double Y0,
+			const double B,
+			const double m);
+  std::vector<TrkrDefs::cluskey> matchInttClusters(const double xProj[],
+						   const double yProj[],
+						   const double zProj[]);
   void circleCircleIntersection(const double layerRadius, 
 				const double circRadius,
 				const double circX0,
@@ -183,6 +188,10 @@ class PHActsSiliconSeeding : public SubsysReco
   const double m_nInttLayerRadii[m_nInttLayers] = 
     {7.188, 7.732, 9.680,10.262}; /// cm
   
+  /// Search windows for phi and z to match intt clusters in cm
+  double m_rPhiSearchWin = 0.025;
+  double m_zSearchWin = 0.01;
+
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;
 
@@ -195,6 +204,9 @@ class PHActsSiliconSeeding : public SubsysReco
   TH1 *h_nInputMeas = nullptr;
   TH1 *h_nInputMvtxMeas = nullptr;
   TH1 *h_nInputInttMeas = nullptr;
+  TH2 *h_hits = nullptr;
+  TH2 *h_zhits = nullptr;
+  TH2 *h_resids = nullptr;
 
 };
 

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -189,8 +189,8 @@ class PHActsSiliconSeeding : public SubsysReco
     {7.188, 7.732, 9.680,10.262}; /// cm
   
   /// Search windows for phi and z to match intt clusters in cm
-  double m_rPhiSearchWin = 0.1;
-  double m_zSearchWin = 0.01;
+  double m_rPhiSearchWin = 0.2;
+  double m_zSearchWin = 0.2;
 
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -111,7 +111,7 @@ class PHActsSiliconSeeding : public SubsysReco
 
   /// Perform circle/line fits with the final seed to get
   /// initial point and momentum estimates for stub matching
-  int circleFitSeed(const std::vector<TrkrCluster*>& clusters,
+  int circleFitSeed(std::vector<TrkrCluster*>& clusters,
 		     double& x, double& y, double& z,
 		     double& px, double& py, double& pz);
   void circleFitByTaubin(const std::vector<TrkrCluster*>& clusters,
@@ -189,7 +189,7 @@ class PHActsSiliconSeeding : public SubsysReco
     {7.188, 7.732, 9.680,10.262}; /// cm
   
   /// Search windows for phi and z to match intt clusters in cm
-  double m_rPhiSearchWin = 0.025;
+  double m_rPhiSearchWin = 0.1;
   double m_zSearchWin = 0.01;
 
   /// Whether or not to use truth clusters in hit lookup
@@ -206,6 +206,8 @@ class PHActsSiliconSeeding : public SubsysReco
   TH1 *h_nInputInttMeas = nullptr;
   TH2 *h_hits = nullptr;
   TH2 *h_zhits = nullptr;
+  TH2 *h_projHits = nullptr;
+  TH2 *h_zprojHits = nullptr;
   TH2 *h_resids = nullptr;
 
 };

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -61,13 +61,11 @@ inline bool operator==(SpacePoint a, SpacePoint b) {
   return (a.m_hitId == b.m_hitId);
 }
 
-
 using SpacePointPtr = std::unique_ptr<SpacePoint>;
 using GridSeeds = std::vector<std::vector<Acts::Seed<SpacePoint>>>;
 
-
 /**
- * This class runs the Acts seeder over the silicon measurements
+ * This class runs the Acts seeder over the MVTX measurements
  * to create track stubs for the rest of the stub matching pattern
  * recognition
  */
@@ -85,8 +83,11 @@ class PHActsSiliconSeeding : public SubsysReco
     { m_useTruthClusters = useTruthClusters; }
 
   void seedAnalysis(bool seedAnalysis)
-    { m_seedAnalysis = seedAnalysis;}
+    { m_seedAnalysis = seedAnalysis; }
   
+  void projectToIntt(bool projectToIntt)
+    { m_projectToIntt = projectToIntt; }
+
  private:
 
   int getNodes(PHCompositeNode *topNode);
@@ -194,8 +195,10 @@ class PHActsSiliconSeeding : public SubsysReco
 
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;
+  
+  bool m_projectToIntt = false;
 
-  bool m_seedAnalysis = true;
+  bool m_seedAnalysis = false;
   TFile *m_file = nullptr;
   TH1 *h_nMvtxHits = nullptr;
   TH1 *h_nInttHits = nullptr;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -122,6 +122,21 @@ class PHActsSiliconSeeding : public SubsysReco
 		double& x, double& y);
   int getCharge(const std::vector<TrkrCluster*>& clusters,
 		const double circPhi);
+
+  std::vector<TrkrDefs::cluskey> findInttMatches(
+			const std::vector<TrkrCluster*>& clusters,
+			const double R,
+			const double X0,
+			const double Y0);
+  void circleCircleIntersection(const double layerRadius, 
+				const double circRadius,
+				const double circX0,
+				const double circY0,
+				double& xplus,
+				double& yplus,
+				double& xminus,
+				double& yminus);
+
   double normPhi2Pi(const double phi);
 
   std::map<unsigned int, SourceLink> *m_sourceLinks;
@@ -139,16 +154,18 @@ class PHActsSiliconSeeding : public SubsysReco
   float m_minSeedPt = 100;
 
   /// How many seeds a given hit can be the middle hit of the seed
+  /// MVTX can only have the middle layer be the middle hit
   int m_maxSeedsPerSpM = 1;
 
   /// Limiting location of measurements (e.g. detector constraints)
-  float m_rMax = 250.;
+  /// We limit to the MVTX
+  float m_rMax = 50.;
   float m_rMin = 23.;
-  float m_zMax = 500.;
-  float m_zMin = -500.;
+  float m_zMax = 300.;
+  float m_zMin = -300.;
  
   /// max distance between two measurements in one seed
-  float m_deltaRMax = 40;
+  float m_deltaRMax = 15;
   
   /// Cot of maximum theta angle. Equivalent to eta=1.1 here
   float m_cotThetaMax = 1.335647;
@@ -162,6 +179,10 @@ class PHActsSiliconSeeding : public SubsysReco
 
   int m_event = 0;
 
+  const static unsigned int m_nInttLayers = 4;
+  const double m_nInttLayerRadii[m_nInttLayers] = 
+    {7.188, 7.732, 9.680,10.262}; /// cm
+  
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;
 


### PR DESCRIPTION
This PR switches the seeding to only include the MVTX rather than the entire silicon. This reduces the number of duplicate seeds significantly. Additionally, this PR adds an option to project the circle fit that is performed on the MVTX seed to the INTT to find potential matching clusters.

The rphi projection looks as expected but the z projection is quite large, perhaps due to fitting a line to only 3 points introducing a large enough error in the slope that the z projection can be quite bad. A future PR will add a module that tries running the Acts track projection scheme over the MVTX seeds to see if it performs better.
