### PR TITLE
Sync fix

### DIFF
--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -133,7 +133,7 @@ int Fun4AllDstInputManager::fileopen(const string &filenam)
     events_thisfile = 0;
     setBranches();                // set branch selections
     AddToFileOpened(FileName());  // add file to the list of files which were opened
-// check if our input file has a sync object or not
+                                  // check if our input file has a sync object or not
     if (IManager->NodeExist(syncdefs::SYNCNODENAME))
     {
       m_HaveSyncObject = 1;
@@ -507,7 +507,7 @@ int Fun4AllDstInputManager::BranchSelect(const string &branch, const int iflag)
   if (IsOpen())
   {
     cout << "BranchSelect(\"" << branch << "\", " << iflag
-	 << ") : Input branches can only selected for reading before fileopen is called proceeding without input branch selection" << endl;
+         << ") : Input branches can only selected for reading before fileopen is called proceeding without input branch selection" << endl;
     return -1;
   }
   // if iflag > 0 the branch is set to read

--- a/offline/framework/fun4all/Fun4AllDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.h
@@ -27,26 +27,28 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
   virtual int setSyncBranches(PHNodeIOManager *IManager);
   void Print(const std::string &what = "ALL") const;
   int PushBackEvents(const int i);
+  virtual int HasSyncObject() const;
 
  protected:
   int ReadNextEventSyncObject();
   void ReadRunTTree(const int i) { m_ReadRunTTree = i; }
 
  private:
-  int m_ReadRunTTree;
-  int events_total;
-  int events_thisfile;
-  int events_skipped_during_sync;
+  int m_ReadRunTTree = 1;
+  int events_total = 0;
+  int events_thisfile = 0;
+  int events_skipped_during_sync = 0;
+  int m_HaveSyncObject = 0;
   std::string fullfilename;
-  std::string RunNode;
+  std::string RunNode = "RUN";
   std::map<const std::string, int> branchread;
   std::string syncbranchname;
-  PHCompositeNode *dstNode;
-  PHCompositeNode *runNode;
-  PHCompositeNode *runNodeCopy;
-  PHCompositeNode *runNodeSum;
-  PHNodeIOManager *IManager;
-  SyncObject *syncobject;
+  PHCompositeNode *dstNode = nullptr;
+  PHCompositeNode *runNode = nullptr;
+  PHCompositeNode *runNodeCopy = nullptr;
+  PHCompositeNode *runNodeSum = nullptr;
+  PHNodeIOManager *IManager = nullptr;
+  SyncObject *syncobject = nullptr;
 };
 
 #endif /* __FUN4ALLDSTINPUTMANAGER_H__ */

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -30,7 +30,7 @@ class Fun4AllInputManager : public Fun4AllBase
   virtual int GetSyncObject(SyncObject ** /*mastersync*/) { return 0; }
   virtual int SyncIt(const SyncObject * /*mastersync*/) { return Fun4AllReturnCodes::SYNC_FAIL; }
   virtual int BranchSelect(const std::string & /*branch*/, const int /*iflag*/) { return -1; }
-  virtual int setBranches() { return -1; } // publich bc needed by the sync manager
+  virtual int setBranches() { return -1; }  // publich bc needed by the sync manager
   virtual void Print(const std::string &what = "ALL") const;
   virtual int PushBackEvents(const int /*nevt*/) { return -1; }
   // so people can use the skip they are used to instead of PushBackEvents
@@ -55,7 +55,7 @@ class Fun4AllInputManager : public Fun4AllBase
   bool FileListEmpty() const { return m_FileList.empty(); }
   virtual int IsOpen() const { return m_IsOpen; }
   virtual int SkipForThisManager(const int nevents) { return 0; }
-  virtual int  HasSyncObject() const {return 0;}
+  virtual int HasSyncObject() const { return 0; }
 
  protected:
   Fun4AllInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -55,6 +55,7 @@ class Fun4AllInputManager : public Fun4AllBase
   bool FileListEmpty() const { return m_FileList.empty(); }
   virtual int IsOpen() const { return m_IsOpen; }
   virtual int SkipForThisManager(const int nevents) { return 0; }
+  virtual int  HasSyncObject() const {return 0;}
 
  protected:
   Fun4AllInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");

--- a/offline/framework/fun4all/Fun4AllNoSyncDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllNoSyncDstInputManager.h
@@ -31,6 +31,7 @@ class Fun4AllNoSyncDstInputManager : public Fun4AllDstInputManager
   int NoRunTTree();
 
   int SkipForThisManager(const int nevents) { return PushBackEvents(nevents); }
+  int  HasSyncObject() const {return 0;}
 };
 
-#endif /* __FUN4ALLNOSYNCDSTINPUTMANAGER_H__ */
+#endif // FUN4ALL_FUN4ALLNOSYNCDSTINPUTMANAGER_H

--- a/offline/framework/fun4all/Fun4AllNoSyncDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllNoSyncDstInputManager.h
@@ -31,7 +31,7 @@ class Fun4AllNoSyncDstInputManager : public Fun4AllDstInputManager
   int NoRunTTree();
 
   int SkipForThisManager(const int nevents) { return PushBackEvents(nevents); }
-  int  HasSyncObject() const {return 0;}
+  int HasSyncObject() const { return 0; }
 };
 
-#endif // FUN4ALL_FUN4ALLNOSYNCDSTINPUTMANAGER_H
+#endif  // FUN4ALL_FUN4ALLNOSYNCDSTINPUTMANAGER_H

--- a/offline/framework/fun4all/Fun4AllSyncManager.cc
+++ b/offline/framework/fun4all/Fun4AllSyncManager.cc
@@ -8,6 +8,8 @@
 
 #include <phool/phool.h>  // for PHWHERE
 
+#include <TSystem.h>
+
 #include <cstdlib>
 #include <iostream>  // for operator<<, endl, basic_ostream
 #include <list>      // for list<>::const_iterator, _List_con...
@@ -19,13 +21,6 @@ using namespace std;
 
 Fun4AllSyncManager::Fun4AllSyncManager(const string &name)
   : Fun4AllBase(name)
-  , m_PrdfSegment(0)
-  , m_PrdfEvents(0)
-  , m_EventsTotal(0)
-  , m_CurrentRun(0)
-  , m_CurrentEvent(0)
-  , m_Repeat(0)
-  , m_MasterSync(nullptr)
 {
   return;
 }
@@ -100,8 +95,32 @@ int Fun4AllSyncManager::run(const int nevnts)
   {
     unsigned iman = 0;
     int ifirst = 0;
+    int hassync = 0;
     for (vector<Fun4AllInputManager *>::iterator iter = m_InManager.begin(); iter != m_InManager.end(); ++iter)
     {
+// one can run DSTs without sync object via the DST input manager
+// this only poses a problem if one runs two of them and expects the syncing to work
+// or mix DSTs with sync object and without
+      if (! hassync && (*iter)->HasSyncObject()) // only update if hassync is 0 and input mgr is non zero
+      {
+	hassync = (*iter)->HasSyncObject();
+      }
+      else
+      {
+	if ((*iter)->HasSyncObject()) // if zero (no syncing) no need to go further
+	{
+          if (hassync != (*iter)->HasSyncObject() ) // we have sync and no sync mixed
+	  {
+	    PrintSyncProblem();
+	    gSystem->Exit(1);
+	  }
+	  else if (hassync < 0) // we have more than one nosync input
+	  {
+	    PrintSyncProblem();
+	    gSystem->Exit(1);
+	  }
+	}
+      }
       m_iretInManager[iman] = (*iter)->run(1);
       iret += m_iretInManager[iman];
       if (!ifirst)
@@ -439,5 +458,19 @@ void Fun4AllSyncManager::CurrentEvent(const int evt)
   m_CurrentEvent = evt;
   Fun4AllServer *se = Fun4AllServer::instance();
   se->EventNumber(evt);
+  return;
+}
+
+void Fun4AllSyncManager::PrintSyncProblem() const
+{
+  cout << "Bad use of Fun4AllDstInputManager which might lead to event mixing" << endl;
+  cout << "If you insist to run this do the following in your macro: " << endl;
+  for (auto iter = m_InManager.begin(); iter != m_InManager.end(); ++iter)
+  {
+    if ((*iter)->HasSyncObject() < 0)
+    {
+      cout << "Change Fun4AllDstInputManager with name " << (*iter)->Name() << " from Fun4AllDstInputManager to Fun4AllNoSyncDstInputManager" << endl;
+    }
+  }
   return;
 }

--- a/offline/framework/fun4all/Fun4AllSyncManager.cc
+++ b/offline/framework/fun4all/Fun4AllSyncManager.cc
@@ -98,28 +98,28 @@ int Fun4AllSyncManager::run(const int nevnts)
     int hassync = 0;
     for (vector<Fun4AllInputManager *>::iterator iter = m_InManager.begin(); iter != m_InManager.end(); ++iter)
     {
-// one can run DSTs without sync object via the DST input manager
-// this only poses a problem if one runs two of them and expects the syncing to work
-// or mix DSTs with sync object and without
-      if (! hassync && (*iter)->HasSyncObject()) // only update if hassync is 0 and input mgr is non zero
+      // one can run DSTs without sync object via the DST input manager
+      // this only poses a problem if one runs two of them and expects the syncing to work
+      // or mix DSTs with sync object and without
+      if (!hassync && (*iter)->HasSyncObject())  // only update if hassync is 0 and input mgr is non zero
       {
-	hassync = (*iter)->HasSyncObject();
+        hassync = (*iter)->HasSyncObject();
       }
       else
       {
-	if ((*iter)->HasSyncObject()) // if zero (no syncing) no need to go further
-	{
-          if (hassync != (*iter)->HasSyncObject() ) // we have sync and no sync mixed
-	  {
-	    PrintSyncProblem();
-	    gSystem->Exit(1);
-	  }
-	  else if (hassync < 0) // we have more than one nosync input
-	  {
-	    PrintSyncProblem();
-	    gSystem->Exit(1);
-	  }
-	}
+        if ((*iter)->HasSyncObject())  // if zero (no syncing) no need to go further
+        {
+          if (hassync != (*iter)->HasSyncObject())  // we have sync and no sync mixed
+          {
+            PrintSyncProblem();
+            gSystem->Exit(1);
+          }
+          else if (hassync < 0)  // we have more than one nosync input
+          {
+            PrintSyncProblem();
+            gSystem->Exit(1);
+          }
+        }
       }
       m_iretInManager[iman] = (*iter)->run(1);
       iret += m_iretInManager[iman];

--- a/offline/framework/fun4all/Fun4AllSyncManager.h
+++ b/offline/framework/fun4all/Fun4AllSyncManager.h
@@ -55,14 +55,15 @@ class Fun4AllSyncManager : public Fun4AllBase
   const std::vector<Fun4AllInputManager *> GetInputManagers() const { return m_InManager; }
 
  private:
+  void PrintSyncProblem() const;
   int CheckSync(unsigned i);
-  int m_PrdfSegment;
-  int m_PrdfEvents;
-  int m_EventsTotal;
-  int m_CurrentRun;
-  int m_CurrentEvent;
-  int m_Repeat;
-  SyncObject *m_MasterSync;
+  int m_PrdfSegment = 0;
+  int m_PrdfEvents = 0;
+  int m_EventsTotal = 0;
+  int m_CurrentRun = 0;
+  int m_CurrentEvent = 0;
+  int m_Repeat = 0;
+  SyncObject *m_MasterSync = nullptr;
   std::vector<Fun4AllInputManager *> m_InManager;
   std::vector<int> m_iretInManager;
 };

--- a/offline/framework/fun4allraw/Fun4AllPrdfInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllPrdfInputManager.h
@@ -26,6 +26,7 @@ class Fun4AllPrdfInputManager : public Fun4AllInputManager
   int PushBackEvents(const int i);
   int GetSyncObject(SyncObject **mastersync);
   int SyncIt(const SyncObject *mastersync);
+  int HasSyncObject() const {return 1;}
 
  private:
   int m_Segment;


### PR DESCRIPTION
This PR adds a safety belt when a DST input manager is used for a file without sync object. This is no problem for single files but reading 2 files where the no sync file is read second fell through the cracks. Now the sync manager checks if there is only one input manager running a no sync file and no other input mgr which supports synchronization.