### PR TITLE
Pileup input managers

### DIFF
--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -161,12 +161,11 @@ int Fun4AllDstPileupInputManager::run(const int nevents)
     if( result != 0 ) return result;
   }
 
-
-  /* create internal dst node if not already there
-   * this usually happen in fileopen however, when the file is not oppened during first event, for instance because background rate is too low,
+  /*
+   * assign/create relevant dst nodes if not already there
+   * this normally happens in ::fileopen however, when the file is not oppened during first event, for instance because background rate is too low,
    * this can cause fun4all server to bark with "Someone changed the number of Output Nodes on the fly"
    */
-
   if( !m_dstNode )
   {
     auto se = Fun4AllServer::instance();

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -472,7 +472,7 @@ void Fun4AllDstPileupInputManager::load_nodes(PHCompositeNode *dstNode)
 }
 
 //_____________________________________________________________________________
-void Fun4AllDstPileupInputManager::copy_background_event(PHCompositeNode *dstNode, double delta_t)
+void Fun4AllDstPileupInputManager::copy_background_event(PHCompositeNode *dstNode, double delta_t) const
 {
   // copy PHHepMCGenEventMap
   const auto map = findNode::getClass<PHHepMCGenEventMap>(dstNode, "PHHepMCGenEventMap");

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -161,6 +161,23 @@ int Fun4AllDstPileupInputManager::run(const int nevents)
     if( result != 0 ) return result;
   }
 
+
+  /* create internal dst node if not already there
+   * this usually happen in fileopen however, when the file is not oppened during first event, for instance because background rate is too low,
+   * this can cause fun4all server to bark with "Someone changed the number of Output Nodes on the fly"
+   */
+
+  if( !m_dstNode )
+  {
+    auto se = Fun4AllServer::instance();
+    m_dstNode = se->getNode(InputNode(), TopNodeName());
+  }
+
+  if (!m_dstNodeInternal)
+  {
+    m_dstNodeInternal.reset(new PHCompositeNode("DST_INTERNAL"));
+  }
+
   // create merger node
   Fun4AllDstPileupMerger merger;
   merger.load_nodes(m_dstNode);

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -4,21 +4,11 @@
  */
 
 #include "Fun4AllDstPileupInputManager.h"
-
-#include "PHG4Hit.h"  // for PHG4Hit
-#include "PHG4HitContainer.h"
-#include "PHG4Hitv1.h"
-#include "PHG4Particle.h"  // for PHG4Particle
-#include "PHG4Particlev3.h"
-#include "PHG4TruthInfoContainer.h"
-#include "PHG4VtxPoint.h"  // for PHG4VtxPoint
-#include "PHG4VtxPointv1.h"
+#include "Fun4AllDstPileupMerger.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
 
-#include <ffaobjects/EventHeader.h>
-#include <ffaobjects/EventHeaderv1.h>
 #include <ffaobjects/RunHeader.h>
 
 #include <frog/FROG.h>
@@ -51,49 +41,6 @@
 #include <iostream>  // for operator<<, basic_ostream, endl
 #include <iterator>  // for reverse_iterator, operator!=
 #include <utility>   // for pair
-
-// convenient aliases for deep copying nodes
-namespace
-{
-  using PHG4Particle_t = PHG4Particlev3;
-  using PHG4VtxPoint_t = PHG4VtxPointv1;
-  using PHG4Hit_t = PHG4Hitv1;
-
-  //! utility class to find all PHG4Hit container nodes from the DST node
-  class FindG4HitContainer : public PHNodeOperation
-  {
-   public:
-    //! container map alias
-    using ContainerMap = std::map<std::string, PHG4HitContainer *>;
-
-    //! get container map
-    const ContainerMap &containers() const
-    {
-      return m_containers;
-    }
-
-   protected:
-    //! iterator action
-    void perform(PHNode *node) override
-    {
-      // check type name. Only load PHIODataNode
-      if (node->getType() != "PHIODataNode") return;
-
-      // cast to IODataNode and check data
-      auto ionode = static_cast<PHIODataNode<TObject> *>(node);
-      auto data = dynamic_cast<PHG4HitContainer *>(ionode->getData());
-      if (data)
-      {
-        m_containers.insert(std::make_pair(node->getName(), data));
-      }
-    }
-
-   private:
-    //! container map
-    ContainerMap m_containers;
-  };
-
-}  // namespace
 
 //_____________________________________________________________________________
 Fun4AllDstPileupInputManager::Fun4AllDstPileupInputManager(const std::string &name, const std::string &nodename, const std::string &topnodename)
@@ -274,7 +221,9 @@ readagain:
 
   // load relevant DST nodes to internal pointers
   std::cout << "Fun4AllDstPileupInputManager::run - loaded event " << m_ievent_thisfile - 1 << std::endl;
-  load_nodes(m_dstNode);
+
+  Fun4AllDstPileupMerger merger;
+  merger.load_nodes(m_dstNode);
 
   // generate background collisions
   const double mu = m_collision_rate*m_time_between_crossings*1e-9;
@@ -295,7 +244,7 @@ readagain:
 
       // merge
       std::cout << "Fun4AllDstPileupInputManager::run - merged background event " << ievent_thisfile << " time: " << crossing_time << std::endl;
-      copy_background_event(m_dstNodeInternal.get(), crossing_time);
+      merger.copy_background_event(m_dstNodeInternal.get(), crossing_time);
 
       ++neventsbackground;
       ++ievent_thisfile;
@@ -444,260 +393,3 @@ int Fun4AllDstPileupInputManager::PushBackEvents(const int i)
   return -1;
 }
 
-//_____________________________________________________________________________
-void Fun4AllDstPileupInputManager::load_nodes(PHCompositeNode *dstNode)
-{
-  // hep mc
-  m_geneventmap = findNode::getClass<PHHepMCGenEventMap>(dstNode, "PHHepMCGenEventMap");
-  if (!m_geneventmap)
-  {
-    std::cout << "Fun4AllDstPileupInputManager::load_nodes - creating PHHepMCGenEventMap" << std::endl;
-    m_geneventmap = new PHHepMCGenEventMap();
-    dstNode->addNode(new PHIODataNode<PHObject>(m_geneventmap, "PHHepMCGenEventMap", "PHObject"));
-  }
-
-  // find all G4Hit containers under dstNode
-  FindG4HitContainer nodeFinder;
-  PHNodeIterator(dstNode).forEach(nodeFinder);
-  m_g4hitscontainers = nodeFinder.containers();
-
-  // g4 truth info
-  m_g4truthinfo = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
-  if (!m_g4truthinfo)
-  {
-    std::cout << "Fun4AllDstPileupInputManager::load_nodes - creating node G4TruthInfo" << std::endl;
-    m_g4truthinfo = new PHG4TruthInfoContainer();
-    dstNode->addNode(new PHIODataNode<PHObject>(m_g4truthinfo, "G4TruthInfo", "PHObject"));
-  }
-}
-
-//_____________________________________________________________________________
-void Fun4AllDstPileupInputManager::copy_background_event(PHCompositeNode *dstNode, double delta_t) const
-{
-  // copy PHHepMCGenEventMap
-  const auto map = findNode::getClass<PHHepMCGenEventMap>(dstNode, "PHHepMCGenEventMap");
-
-  // keep track of new embed id, after insertion as background event
-  int new_embed_id = 0;
-
-  if (map && m_geneventmap)
-  {
-    if (map->size() != 1)
-    {
-      std::cout << "Fun4AllDstPileupInputManager::copy_background_event - cannot merge events that contain more than one PHHepMCGenEventMap" << std::endl;
-      return;
-    }
-
-    // get event and insert in new map
-    auto genevent = map->get_map().begin()->second;
-    auto newevent = m_geneventmap->insert_background_event(genevent);
-
-    /*
-     * this hack prevents a crash when writting out
-     * it boils down to root trying to write deleted items from the HepMC::GenEvent copy if the source has been deleted
-     * it does not happen if the source gets written while the copy is deleted
-     */
-    newevent->getEvent()->swap(*genevent->getEvent());
-
-    // shift vertex time and store new embed id
-    newevent->moveVertex(0, 0, 0, delta_t);
-    new_embed_id = newevent->get_embedding_id();
-  }
-
-  // copy truth container
-  // keep track of the correspondance between source index and destination index for vertices, tracks and showers
-  using ConversionMap = std::map<int, int>;
-  ConversionMap vtxid_map;
-  ConversionMap trkid_map;
-
-  const auto container = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
-  if (container && m_g4truthinfo)
-  {
-    {
-      // primary vertices
-      auto key = m_g4truthinfo->maxvtxindex();
-      const auto range = container->GetPrimaryVtxRange();
-      for (auto iter = range.first; iter != range.second; ++iter)
-      {
-        // clone vertex, insert in map, and add index conversion
-        const auto &sourceVertex = iter->second;
-        auto newVertex = new PHG4VtxPoint_t(sourceVertex);
-        newVertex->set_t(sourceVertex->get_t() + delta_t);
-        m_g4truthinfo->AddVertex(++key, newVertex);
-        vtxid_map.insert(std::make_pair(sourceVertex->get_id(), key));
-      }
-    }
-
-    {
-      // secondary vertices
-      auto key = m_g4truthinfo->minvtxindex();
-      const auto range = container->GetSecondaryVtxRange();
-
-      // loop from last to first to preserve order with respect to the original event
-      for (
-          auto iter = std::reverse_iterator<PHG4TruthInfoContainer::ConstVtxIterator>(range.second);
-          iter != std::reverse_iterator<PHG4TruthInfoContainer::ConstVtxIterator>(range.first);
-          ++iter)
-      {
-        // clone vertex, shift time, insert in map, and add index conversion
-        const auto &sourceVertex = iter->second;
-        auto newVertex = new PHG4VtxPoint_t(sourceVertex);
-        newVertex->set_t(sourceVertex->get_t() + delta_t);
-        m_g4truthinfo->AddVertex(--key, newVertex);
-        vtxid_map.insert(std::make_pair(sourceVertex->get_id(), key));
-      }
-    }
-
-    {
-      // primary particles
-      auto key = m_g4truthinfo->maxtrkindex();
-      const auto range = container->GetPrimaryParticleRange();
-      for (auto iter = range.first; iter != range.second; ++iter)
-      {
-        const auto &source = iter->second;
-        auto dest = new PHG4Particle_t(source);
-        m_g4truthinfo->AddParticle(++key, dest);
-        dest->set_track_id(key);
-
-        // set parent to zero
-        dest->set_parent_id(0);
-
-        // set primary to itself
-        dest->set_primary_id(dest->get_track_id());
-
-        // update vertex
-        const auto keyiter = vtxid_map.find(source->get_vtx_id());
-        if (keyiter != vtxid_map.end())
-          dest->set_vtx_id(keyiter->second);
-        else
-          std::cout << "Fun4AllDstPileupInputManager::copy_background_event - vertex id " << source->get_vtx_id() << " not found in map" << std::endl;
-
-        // insert in map
-        trkid_map.insert(std::make_pair(source->get_track_id(), dest->get_track_id()));
-      }
-    }
-
-    {
-      // secondary particles
-      auto key = m_g4truthinfo->mintrkindex();
-      const auto range = container->GetSecondaryParticleRange();
-
-      /*
-       * loop from last to first to preserve order with respect to the original event
-       * also this ensures that for a given particle its parent has already been converted and thus found in the map
-       */
-      for (
-          auto iter = std::reverse_iterator<PHG4TruthInfoContainer::ConstIterator>(range.second);
-          iter != std::reverse_iterator<PHG4TruthInfoContainer::ConstIterator>(range.first);
-          ++iter)
-      {
-        const auto &source = iter->second;
-        auto dest = new PHG4Particle_t(source);
-        m_g4truthinfo->AddParticle(--key, dest);
-        dest->set_track_id(key);
-
-        // update parent id
-        auto keyiter = trkid_map.find(source->get_parent_id());
-        if (keyiter != trkid_map.end())
-          dest->set_parent_id(keyiter->second);
-        else
-          std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " << source->get_parent_id() << " not found in map" << std::endl;
-
-        // update primary id
-        keyiter = trkid_map.find(source->get_primary_id());
-        if (keyiter != trkid_map.end())
-          dest->set_primary_id(keyiter->second);
-        else
-          std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " << source->get_primary_id() << " not found in map" << std::endl;
-
-        // update vertex
-        keyiter = vtxid_map.find(source->get_vtx_id());
-        if (keyiter != vtxid_map.end())
-          dest->set_vtx_id(keyiter->second);
-        else
-          std::cout << "Fun4AllDstPileupInputManager::copy_background_event - vertex id " << source->get_vtx_id() << " not found in map" << std::endl;
-
-        // insert in map
-        trkid_map.insert(std::make_pair(source->get_track_id(), dest->get_track_id()));
-      }
-    }
-
-    // vertex embed flags
-    /* embed flag is stored only for primary vertices, consistently with PHG4TruthEventAction */
-    for (const auto &pair : vtxid_map)
-    {
-      if (pair.first > 0) m_g4truthinfo->AddEmbededVtxId(pair.second, new_embed_id);
-    }
-
-    // track embed flags
-    /* embed flag is stored only for primary tracks, consistently with PHG4TruthEventAction */
-    for (const auto &pair : trkid_map)
-    {
-      if (pair.first > 0) m_g4truthinfo->AddEmbededTrkId(pair.second, new_embed_id);
-    }
-  }
-
-  // copy g4hits
-  // loop over registered maps
-  for (const auto &pair : m_g4hitscontainers)
-  {
-    // check destination node
-    if (!pair.second)
-    {
-      std::cout << "Fun4AllDstPileupInputManager::copy_background_event - invalid destination container " << pair.first << std::endl;
-      continue;
-    }
-
-    // find source node
-    auto container = findNode::getClass<PHG4HitContainer>(dstNode, pair.first);
-    if (!container)
-    {
-      std::cout << "Fun4AllDstPileupInputManager::copy_background_event - invalid source container " << pair.first << std::endl;
-      continue;
-    }
-
-    {
-      // hits
-      const auto range = container->getHits();
-      for (auto iter = range.first; iter != range.second; ++iter)
-      {
-        // clone hit
-        const auto &sourceHit = iter->second;
-        auto newHit = new PHG4Hit_t(sourceHit);
-
-        // shift time
-        newHit->set_t(0, sourceHit->get_t(0) + delta_t);
-        newHit->set_t(1, sourceHit->get_t(1) + delta_t);
-
-        // update track id
-        const auto keyiter = trkid_map.find(sourceHit->get_trkid());
-        if (keyiter != trkid_map.end())
-          newHit->set_trkid(keyiter->second);
-        else
-          std::cout << "Fun4AllDstPileupInputManager::copy_background_event - track id " << sourceHit->get_trkid() << " not found in map" << std::endl;
-
-        /*
-         * reset shower ids
-         * it was decided that showers from the background events will not be copied to the merged event
-         * as such we just reset the hits shower id
-         */
-        newHit->set_shower_id(INT_MIN);
-
-        /*
-         * this will generate a new key for the hit and assign it to the hit
-         * this ensures that there is no conflict with the hits from the 'main' event
-         */
-        pair.second->AddHit(newHit->get_detid(), newHit);
-      }
-    }
-
-    {
-      // layers
-      const auto range = container->getLayers();
-      for (auto iter = range.first; iter != range.second; ++iter)
-      {
-        pair.second->AddLayer(*iter);
-      }
-    }
-  }
-}

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -1,0 +1,385 @@
+/*!
+ * \file Fun4AllDstPileupInputManager.cc
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include "Fun4AllDstPileupInputManager.h"
+#include "Fun4AllDstPileupMerger.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <ffaobjects/RunHeader.h>
+
+#include <frog/FROG.h>
+
+#include <phhepmc/PHHepMCGenEvent.h>  // for PHHepMCGenEvent
+#include <phhepmc/PHHepMCGenEventMap.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>  // for PHIODataNode
+#include <phool/PHNode.h>        // for PHNode
+#include <phool/PHNodeIOManager.h>
+#include <phool/PHNodeIntegrate.h>
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHNodeOperation.h>
+#include <phool/PHObject.h>  // for PHObject
+#include <phool/PHRandomSeed.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE, PHReadOnly, PHRunTree
+
+#include <TSystem.h>
+
+#include <HepMC/GenEvent.h>
+
+#include <gsl/gsl_randist.h>
+
+#include <cassert>
+#include <climits>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>  // for operator<<, basic_ostream, endl
+#include <iterator>  // for reverse_iterator, operator!=
+#include <utility>   // for pair
+
+//_____________________________________________________________________________
+Fun4AllDstPileupInputManager::Fun4AllDstPileupInputManager(const std::string &name, const std::string &nodename, const std::string &topnodename)
+  : Fun4AllInputManager(name, nodename, topnodename)
+{
+  // initialize random generator
+  const uint seed = PHRandomSeed();
+  m_rng.reset( gsl_rng_alloc(gsl_rng_mt19937) );
+  gsl_rng_set( m_rng.get(), seed );
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::fileopen(const std::string &filenam)
+{
+  /*
+  this is largely copied from fun4all/Fun4AllDstInputManager::fileopen
+  with additional code to handle the background IManager
+  */
+
+  auto se = Fun4AllServer::instance();
+  if (IsOpen())
+  {
+    std::cout << "Closing currently open file "
+              << FileName()
+              << " and opening " << filenam << std::endl;
+    fileclose();
+  }
+  FileName(filenam);
+  FROG frog;
+  m_fullfilename = frog.location(FileName());
+  if (Verbosity() > 0)
+  {
+    std::cout << Name() << ": opening file " << m_fullfilename << std::endl;
+  }
+  // sanity check - the IManager must be nullptr when this method is executed
+  // if not something is very very wrong and we must not continue
+  assert( !m_IManager );
+
+  // first read the runnode if not disabled
+  if (m_ReadRunTTree)
+  {
+    m_IManager.reset(new PHNodeIOManager(m_fullfilename, PHReadOnly, PHRunTree));
+    if (m_IManager->isFunctional())
+    {
+      m_runNode = se->getNode(m_RunNode, TopNodeName());
+      m_IManager->read(m_runNode);
+
+      // get the current run number
+      auto runheader = findNode::getClass<RunHeader>(m_runNode, "RunHeader");
+      if (runheader)
+      {
+        SetRunNumber(runheader->get_RunNumber());
+      }
+      // delete our internal copy of the runnode when opening subsequent files
+      assert( !m_runNodeCopy );
+      m_runNodeCopy.reset(new PHCompositeNode("RUNNODECOPY"));
+      if (!m_runNodeSum)
+      {
+        m_runNodeSum.reset(new PHCompositeNode("RUNNODESUM"));
+      }
+
+      {
+        // read run node using temporary node iomanager
+        PHNodeIOManager(m_fullfilename, PHReadOnly, PHRunTree).read(m_runNodeCopy.get());
+      }
+
+      PHNodeIntegrate integrate;
+      integrate.RunNode(m_runNode);
+      integrate.RunSumNode(m_runNodeSum.get());
+      // run recursively over internal run node copy and integrate objects
+      PHNodeIterator mainIter(m_runNodeCopy.get());
+      mainIter.forEach(integrate);
+      // we do not need to keep the internal copy, keeping it would crate
+      // problems in case a subsequent file does not contain all the
+      // runwise objects from the previous file. Keeping this copy would then
+      // integrate the missing object again with the old copy
+      m_runNodeCopy.reset();
+    }
+    // DLW: move the delete outside the if block to cover the case where isFunctional() fails
+    m_IManager.reset();
+  }
+
+  // create internal dst node
+  if (!m_dstNodeInternal)
+  {
+    m_dstNodeInternal.reset(new PHCompositeNode("DST_INTERNAL"));
+  }
+
+  // update dst node from fun4all server
+  m_dstNode = se->getNode(InputNode(), TopNodeName());
+
+  // open file in both active and background input manager
+  m_IManager.reset(new PHNodeIOManager(m_fullfilename, PHReadOnly));
+  if (m_IManager->isFunctional())
+  {
+    IsOpen(1);
+    m_ievent_thisfile = 0;
+    setBranches();                // set branch selections
+    AddToFileOpened(FileName());  // add file to the list of files which were opened
+    return 0;
+  }
+  else
+  {
+    std::cout << PHWHERE << ": " << Name() << " Could not open file " << FileName() << std::endl;
+    m_IManager.reset();
+    return -1;
+  }
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::run(const int nevents)
+{
+
+  if( nevents == 0 ) return runOne( nevents );
+  else if( nevents > 1 )
+  {
+    const auto result = runOne( nevents-1 );
+    if( result != 0 ) return result;
+  }
+
+  // create merger node
+  Fun4AllDstPileupMerger merger;
+  merger.load_nodes(m_dstNode);
+
+  // generate background collisions
+  const double mu = m_collision_rate*m_time_between_crossings*1e-9;
+
+  const int min_crossing = m_tmin/m_time_between_crossings;
+  const int max_crossing = m_tmax/m_time_between_crossings;
+  for( int icrossing = min_crossing; icrossing <= max_crossing; ++icrossing )
+  {
+    const double crossing_time = m_time_between_crossings * icrossing;
+    const int ncollisions = gsl_ran_poisson(m_rng.get(), mu);
+    for (int icollision = 0; icollision < ncollisions; ++icollision)
+    {
+
+      // read one event
+      const auto result = runOne( 1 );
+      if( result != 0 ) return result;
+
+      // merge
+      std::cout << "Fun4AllDstPileupInputManager::run - merged background event " << m_ievent_thisfile << " time: " << crossing_time << std::endl;
+      merger.copy_background_event(m_dstNodeInternal.get(), crossing_time);
+
+    }
+  }
+
+  return 0;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::fileclose()
+{
+  if (!IsOpen())
+  {
+    std::cout << Name() << ": fileclose: No Input file open" << std::endl;
+    return -1;
+  }
+  m_IManager.reset();
+  IsOpen(0);
+  UpdateFileList();
+  return 0;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::BranchSelect(const std::string &branch, const int iflag)
+{
+  int myflag = iflag;
+  // if iflag > 0 the branch is set to read
+  // if iflag = 0, the branch is set to NOT read
+  // if iflag < 0 the branchname is erased from our internal branch read map
+  // this does not have any effect on phool yet
+  if (myflag < 0)
+  {
+    std::map<const std::string, int>::iterator branchiter;
+    branchiter = m_branchread.find(branch);
+    if (branchiter != m_branchread.end())
+    {
+      m_branchread.erase(branchiter);
+    }
+    return 0;
+  }
+
+  if (myflag > 0)
+  {
+    if (Verbosity() > 1)
+    {
+      std::cout << "Setting Root Tree Branch: " << branch << " to read" << std::endl;
+    }
+    myflag = 1;
+  }
+  else
+  {
+    if (Verbosity() > 1)
+    {
+      std::cout << "Setting Root Tree Branch: " << branch << " to NOT read" << std::endl;
+    }
+  }
+  m_branchread[branch] = myflag;
+  return 0;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::setBranches()
+{
+  if (m_IManager)
+  {
+    if (!m_branchread.empty())
+    {
+      std::map<const std::string, int>::const_iterator branchiter;
+      for (branchiter = m_branchread.begin(); branchiter != m_branchread.end(); ++branchiter)
+      {
+        m_IManager->selectObjectToRead(branchiter->first.c_str(), branchiter->second);
+        if (Verbosity() > 0)
+        {
+          std::cout << branchiter->first << " set to " << branchiter->second << std::endl;
+        }
+      }
+    }
+  }
+  else
+  {
+    std::cout << PHWHERE << " " << Name() << ": You can only call this function after a file has been opened" << std::endl;
+    std::cout << "Do not worry, the branches will be set as soon as you open a file" << std::endl;
+    return -1;
+  }
+  return 0;
+}
+
+//_____________________________________________________________________________
+void Fun4AllDstPileupInputManager::Print(const std::string &what) const
+{
+  if (what == "ALL" || what == "BRANCH")
+  {
+    // loop over the map and print out the content (name and location in memory)
+    std::cout << "--------------------------------------" << std::endl
+              << std::endl;
+    std::cout << "List of selected branches in Fun4AllDstPileupInputManager " << Name() << ":" << std::endl;
+
+    std::map<const std::string, int>::const_iterator iter;
+    for (iter = m_branchread.begin(); iter != m_branchread.end(); ++iter)
+    {
+      std::cout << iter->first << " is switched ";
+      if (iter->second)
+      {
+        std::cout << "ON";
+      }
+      else
+      {
+        std::cout << "OFF";
+      }
+      std::cout << std::endl;
+    }
+  }
+  if ((what == "ALL" || what == "PHOOL") && m_IManager)
+  {
+    // loop over the map and print out the content (name and location in memory)
+    std::cout << "--------------------------------------" << std::endl
+              << std::endl;
+    std::cout << "PHNodeIOManager print in Fun4AllDstPileupInputManager " << Name() << ":" << std::endl;
+    m_IManager->print();
+  }
+  Fun4AllInputManager::Print(what);
+  return;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::PushBackEvents(const int i)
+{
+  if (m_IManager)
+  {
+    unsigned EventOnDst = m_IManager->getEventNumber();
+    EventOnDst -= static_cast<unsigned>(i);
+    m_ievent_thisfile -= i;
+    m_ievent_total -= i;
+    m_IManager->setEventNumber(EventOnDst);
+    return 0;
+  }
+  std::cout << PHWHERE << Name() << ": could not push back events, Imanager is NULL"
+            << " probably the dst is not open yet (you need to call fileopen or run 1 event for lists)" << std::endl;
+  return -1;
+}
+
+//_____________________________________________________________________________
+int Fun4AllDstPileupInputManager::runOne(const int nevents)
+{
+  if (!IsOpen())
+  {
+    if (FileListEmpty())
+    {
+      if (Verbosity() > 0)
+      {
+        std::cout << Name() << ": No Input file open" << std::endl;
+      }
+      return -1;
+    }
+    else
+    {
+      if (OpenNextFile())
+      {
+        std::cout << Name() << ": No Input file from filelist opened" << std::endl;
+        return -1;
+      }
+    }
+  }
+  if (Verbosity() > 3)
+  {
+    std::cout << "Getting Event from " << Name() << std::endl;
+  }
+
+readagain:
+
+  // read main event to dstNode
+  auto dummy = m_IManager->read(m_dstNodeInternal.get());
+  int ncount = 0;
+  while (dummy)
+  {
+    ++ncount;
+    if (nevents > 0 && ncount >= nevents)
+    {
+      break;
+    }
+    dummy = m_IManager->read(m_dstNodeInternal.get());
+  }
+  if (!dummy)
+  {
+    fileclose();
+    if (!OpenNextFile())
+    {
+      goto readagain;
+    }
+    return -1;
+  }
+  m_ievent_total += ncount;
+  m_ievent_thisfile += ncount;
+  // check if the local SubsysReco discards this event
+  if (RejectEvent() != Fun4AllReturnCodes::EVENT_OK)
+  {
+    goto readagain;
+  }
+  return 0;
+}

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -447,15 +447,6 @@ int Fun4AllDstPileupInputManager::PushBackEvents(const int i)
 //_____________________________________________________________________________
 void Fun4AllDstPileupInputManager::load_nodes(PHCompositeNode *dstNode)
 {
-  // event header
-  m_eventheader = findNode::getClass<EventHeader>(dstNode, "EventHeader");
-  if (!m_eventheader)
-  {
-    std::cout << "Fun4AllDstPileupInputManager::load_nodes - creating EventHeader" << std::endl;
-    m_eventheader = new EventHeaderv1();
-    dstNode->addNode(new PHIODataNode<PHObject>(m_eventheader, "EventHeader", "PHObject"));
-  }
-
   // hep mc
   m_geneventmap = findNode::getClass<PHHepMCGenEventMap>(dstNode, "PHHepMCGenEventMap");
   if (!m_geneventmap)

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -32,10 +32,15 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   int fileopen(const std::string &filenam) override;
   int fileclose() override;
   int run(const int nevents = 0) override;
-  int BranchSelect(const std::string &branch, const int iflag);
-  int setBranches();
+  int BranchSelect(const std::string &branch, const int iflag) override;
+  int setBranches() override;
   void Print(const std::string &what = "ALL") const override;
   int PushBackEvents(const int i) override;
+
+  // disable synchronization
+  int SyncIt(const SyncObject* /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_OK; }
+  int GetSyncObject(SyncObject** /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
+  int NoSyncPushBackEvents(const int nevt) override { return PushBackEvents(nevt); }
 
   /// collision rate in Hz
   void setCollisionRate(double Hz)

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -21,7 +21,6 @@
 #include <string>
 #include <vector>  // for vector
 
-class EventHeader;
 class PHG4HitContainer;
 class PHG4TruthInfoContainer;
 class PHHepMCGenEventMap;
@@ -102,9 +101,6 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
 
   //! max integration time for pileup in the TPC (ns)
   double m_tmax = 13500;
-
-  //! event header
-  EventHeader *m_eventheader = nullptr;
 
   //! hepmc
   PHHepMCGenEventMap *m_geneventmap = nullptr;

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -37,7 +37,7 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   void Print(const std::string &what = "ALL") const override;
   int PushBackEvents(const int i) override;
 
-  // disable synchronization
+  // Effectivly turn off the synchronization checking (copy from Fun4AllNoSyncDstInputManager)
   int SyncIt(const SyncObject* /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_OK; }
   int GetSyncObject(SyncObject** /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
   int NoSyncPushBackEvents(const int nevt) override { return PushBackEvents(nevt); }

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -57,10 +57,6 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
     m_tmax = tmax;
   }
 
-  //! obsolete. Does nothing, kept for backward API compatibility.
-  void generateBunchCrossingList( int nevents, float collision_rate )
-  {}
-
  private:
 
   //! loads one event on internal DST node

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -21,10 +21,6 @@
 #include <string>
 #include <vector>  // for vector
 
-class PHG4HitContainer;
-class PHG4TruthInfoContainer;
-class PHHepMCGenEventMap;
-
 /*!
  * dedicated input manager that merges single events into "merged" events, containing a trigger event
  * and a number of time-shifted pile-up events corresponding to a given pile-up rate
@@ -61,11 +57,6 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   {}
 
  private:
-  //! load nodes
-  void load_nodes(PHCompositeNode *);
-
-  //! copy background event
-  void copy_background_event(PHCompositeNode *, double delta_t) const;
 
   //!@name event counters
   //@{
@@ -113,15 +104,6 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
 
   //! max integration time for pileup in the TPC (ns)
   double m_tmax = 13500;
-
-  //! hepmc
-  PHHepMCGenEventMap *m_geneventmap = nullptr;
-
-  //! maps g4hit containers to node names
-  std::map<std::string, PHG4HitContainer *> m_g4hitscontainers;
-
-  //! truth information
-  PHG4TruthInfoContainer *m_g4truthinfo = nullptr;
 
   //! random generator
   class Deleter

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -65,7 +65,7 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   void load_nodes(PHCompositeNode *);
 
   //! copy background event
-  void copy_background_event(PHCompositeNode *, double delta_t);
+  void copy_background_event(PHCompositeNode *, double delta_t) const;
 
   //!@name event counters
   //@{

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -25,6 +25,10 @@ class PHG4HitContainer;
 class PHG4TruthInfoContainer;
 class PHHepMCGenEventMap;
 
+/*!
+ * dedicated input manager that merges single events into "merged" events, containing a trigger event
+ * and a number of time-shifted pile-up events corresponding to a given pile-up rate
+*/
 class Fun4AllDstPileupInputManager : public Fun4AllInputManager
 {
  public:
@@ -36,6 +40,14 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   int setBranches();
   void Print(const std::string &what = "ALL") const override;
   int PushBackEvents(const int i) override;
+
+  /// collision rate in Hz
+  void setCollisionRate(double Hz)
+  { m_collision_rate = Hz; }
+
+  /// time between bunch crossing in ns
+  void setTimeBetweenCrossings(double nsec)
+  { m_time_between_crossings = nsec; }
 
   //! set time window for pileup events (ns)
   void setPileupTimeWindow(double tmin, double tmax)
@@ -91,7 +103,7 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   std::unique_ptr<PHNodeIOManager> m_IManager_background;
 
   //! time between crossings. This is a RHIC constant (ns)
-  static constexpr double m_time_between_crossings = 106;
+  double m_time_between_crossings = 106;
 
   //! collision rate (Hz)
   double m_collision_rate = 5e4;

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -1,0 +1,117 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4MAIN_FUN4ALLDSTPILEUPINPUTMANAGER_H
+#define G4MAIN_FUN4ALLDSTPILEUPINPUTMANAGER_H
+
+/*!
+ * \file Fun4AllDstPileupInputManager.h
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include <fun4all/Fun4AllInputManager.h>
+
+#include <phool/PHCompositeNode.h>  // for PHCompositeNode
+#include <phool/PHNodeIOManager.h>  // for PHNodeIOManager
+
+#include <gsl/gsl_rng.h>
+
+#include <cstdint>  // for int64_t
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>  // for vector
+
+/*!
+ * dedicated input manager that merges single events into "merged" events, containing a trigger event
+ * and a number of time-shifted pile-up events corresponding to a given pile-up rate
+*/
+class Fun4AllDstPileupInputManager : public Fun4AllInputManager
+{
+ public:
+  Fun4AllDstPileupInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
+  int fileopen(const std::string &filenam) override;
+  int fileclose() override;
+  int run(const int nevents = 0) override;
+  int BranchSelect(const std::string &branch, const int iflag);
+  int setBranches();
+  void Print(const std::string &what = "ALL") const override;
+  int PushBackEvents(const int i) override;
+
+  /// collision rate in Hz
+  void setCollisionRate(double Hz)
+  { m_collision_rate = Hz; }
+
+  /// time between bunch crossing in ns
+  void setTimeBetweenCrossings(double nsec)
+  { m_time_between_crossings = nsec; }
+
+  //! set time window for pileup events (ns)
+  void setPileupTimeWindow(double tmin, double tmax)
+  {
+    m_tmin = tmin;
+    m_tmax = tmax;
+  }
+
+  //! obsolete. Does nothing, kept for backward API compatibility.
+  void generateBunchCrossingList( int nevents, float collision_rate )
+  {}
+
+ private:
+
+  //! loads one event on internal DST node
+  int runOne(const int nevents = 0);
+
+  //!@name event counters
+  //@{
+  bool m_ReadRunTTree = true;
+  int m_ievent_total = 0;
+  int m_ievent_thisfile = 0;
+  //@}
+
+  std::string m_fullfilename;
+  std::string m_RunNode = "RUN";
+  std::map<const std::string, int> m_branchread;
+
+  //! dst node from TopNode
+  PHCompositeNode *m_dstNode = nullptr;
+
+  //! run node from TopNode
+  PHCompositeNode *m_runNode = nullptr;
+
+  //! internal dst node to copy background events
+  std::unique_ptr<PHCompositeNode> m_dstNodeInternal;
+
+  //!@name internal runnodes to perform the summation over multiple runs
+  //@{
+  std::unique_ptr<PHCompositeNode> m_runNodeCopy;
+  std::unique_ptr<PHCompositeNode> m_runNodeSum;
+  //@}
+
+  //! input manager for active (trigger) events
+  /*! corresponding nodes are copied directly to the topNode */
+  std::unique_ptr<PHNodeIOManager> m_IManager;
+
+  //! time between crossings. This is a RHIC constant (ns)
+  double m_time_between_crossings = 106;
+
+  //! collision rate (Hz)
+  double m_collision_rate = 5e4;
+
+  //! min integration time for pileup in the TPC (ns)
+  double m_tmin = -13500;
+
+  //! max integration time for pileup in the TPC (ns)
+  double m_tmax = 13500;
+
+  //! random generator
+  class Deleter
+  {
+    public:
+    void operator() (gsl_rng* rng) const { gsl_rng_free(rng); }
+  };
+
+  std::unique_ptr<gsl_rng, Deleter> m_rng;
+
+};
+
+#endif /* __Fun4AllDstPileupInputManager_H__ */

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -1,7 +1,7 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef FUN4ALL_FUN4ALLDSTPILEUPINPUTMANAGER_H
-#define FUN4ALL_FUN4ALLDSTPILEUPINPUTMANAGER_H
+#ifndef G4MAIN_FUN4ALLDSTPILEUPINPUTMANAGER_H
+#define G4MAIN_FUN4ALLDSTPILEUPINPUTMANAGER_H
 
 /*!
  * \file Fun4AllDstPileupInputManager.h
@@ -25,22 +25,18 @@ class EventHeader;
 class PHG4HitContainer;
 class PHG4TruthInfoContainer;
 class PHHepMCGenEventMap;
-class SyncObject;
 
 class Fun4AllDstPileupInputManager : public Fun4AllInputManager
 {
  public:
   Fun4AllDstPileupInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
-  int fileopen(const std::string &filenam);
-  int fileclose();
-  int run(const int nevents = 0);
-  int GetSyncObject(SyncObject **mastersync);
-  int SyncIt(const SyncObject *mastersync);
+  int fileopen(const std::string &filenam) override;
+  int fileclose() override;
+  int run(const int nevents = 0) override;
   int BranchSelect(const std::string &branch, const int iflag);
   int setBranches();
-  virtual int setSyncBranches(PHNodeIOManager *IManager);
-  void Print(const std::string &what = "ALL") const;
-  int PushBackEvents(const int i);
+  void Print(const std::string &what = "ALL") const override;
+  int PushBackEvents(const int i) override;
 
   //! set time window for pileup events (ns)
   void setPileupTimeWindow(double tmin, double tmax)
@@ -53,11 +49,6 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   void generateBunchCrossingList( int nevents, float collision_rate )
   {}
 
-
- protected:
-  int ReadNextEventSyncObject();
-  void ReadRunTTree(const int i) { m_ReadRunTTree = i; }
-
  private:
   //! load nodes
   void load_nodes(PHCompositeNode *);
@@ -67,17 +58,15 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
 
   //!@name event counters
   //@{
-  int m_ReadRunTTree = 1;
+  bool m_ReadRunTTree = true;
   int m_ievent_total = 0;
   int m_ievent_thisfile = 0;
-  int m_events_skipped_during_sync = 0;
   int m_events_accepted = 0;
   //@}
 
   std::string m_fullfilename;
   std::string m_RunNode = "RUN";
   std::map<const std::string, int> m_branchread;
-  std::string m_syncbranchname;
 
   //! dst node from TopNode
   PHCompositeNode *m_dstNode = nullptr;
@@ -101,9 +90,6 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   //! input manager for background (pileup) events
   /*! corresponding nodes are copied to the internal dst node, then merged to the top node */
   std::unique_ptr<PHNodeIOManager> m_IManager_background;
-
-  //! synchronization object
-  SyncObject *m_syncobject = nullptr;
 
   //! time between crossings. This is a RHIC constant (ns)
   static constexpr double m_time_between_crossings = 106;

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
@@ -1,0 +1,328 @@
+/*!
+ * \file Fun4AllDstPileupInputMerger.h
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include "Fun4AllDstPileupMerger.h"
+
+#include "PHG4Hit.h"  // for PHG4Hit
+#include "PHG4HitContainer.h"
+#include "PHG4Hitv1.h"
+#include "PHG4Particle.h"  // for PHG4Particle
+#include "PHG4Particlev3.h"
+#include "PHG4TruthInfoContainer.h"
+#include "PHG4VtxPoint.h"  // for PHG4VtxPoint
+#include "PHG4VtxPointv1.h"
+
+#include <phhepmc/PHHepMCGenEvent.h>  // for PHHepMCGenEvent
+#include <phhepmc/PHHepMCGenEventMap.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHNodeOperation.h>
+#include <phool/getClass.h>
+
+#include <HepMC/GenEvent.h>
+
+#include <iostream>
+
+
+// convenient aliases for deep copying nodes
+namespace
+{
+  using PHG4Particle_t = PHG4Particlev3;
+  using PHG4VtxPoint_t = PHG4VtxPointv1;
+  using PHG4Hit_t = PHG4Hitv1;
+
+  //! utility class to find all PHG4Hit container nodes from the DST node
+  class FindG4HitContainer : public PHNodeOperation
+  {
+   public:
+    //! container map alias
+    using ContainerMap = std::map<std::string, PHG4HitContainer *>;
+
+    //! get container map
+    const ContainerMap &containers() const
+    {
+      return m_containers;
+    }
+
+   protected:
+    //! iterator action
+    void perform(PHNode *node) override
+    {
+      // check type name. Only load PHIODataNode
+      if (node->getType() != "PHIODataNode") return;
+
+      // cast to IODataNode and check data
+      auto ionode = static_cast<PHIODataNode<TObject> *>(node);
+      auto data = dynamic_cast<PHG4HitContainer *>(ionode->getData());
+      if (data)
+      {
+        m_containers.insert(std::make_pair(node->getName(), data));
+      }
+    }
+
+   private:
+    //! container map
+    ContainerMap m_containers;
+  };
+
+}  // namespace
+
+//_____________________________________________________________________________
+void Fun4AllDstPileupMerger::load_nodes(PHCompositeNode *dstNode)
+{
+  // hep mc
+  m_geneventmap = findNode::getClass<PHHepMCGenEventMap>(dstNode, "PHHepMCGenEventMap");
+  if (!m_geneventmap)
+  {
+    std::cout << "Fun4AllDstPileupMerger::load_nodes - creating PHHepMCGenEventMap" << std::endl;
+    m_geneventmap = new PHHepMCGenEventMap();
+    dstNode->addNode(new PHIODataNode<PHObject>(m_geneventmap, "PHHepMCGenEventMap", "PHObject"));
+  }
+
+  // find all G4Hit containers under dstNode
+  FindG4HitContainer nodeFinder;
+  PHNodeIterator(dstNode).forEach(nodeFinder);
+  m_g4hitscontainers = nodeFinder.containers();
+
+  // g4 truth info
+  m_g4truthinfo = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
+  if (!m_g4truthinfo)
+  {
+    std::cout << "Fun4AllDstPileupMerger::load_nodes - creating node G4TruthInfo" << std::endl;
+    m_g4truthinfo = new PHG4TruthInfoContainer();
+    dstNode->addNode(new PHIODataNode<PHObject>(m_g4truthinfo, "G4TruthInfo", "PHObject"));
+  }
+}
+
+//_____________________________________________________________________________
+void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, double delta_t) const
+{
+  // copy PHHepMCGenEventMap
+  const auto map = findNode::getClass<PHHepMCGenEventMap>(dstNode, "PHHepMCGenEventMap");
+
+  // keep track of new embed id, after insertion as background event
+  int new_embed_id = 0;
+
+  if (map && m_geneventmap)
+  {
+    if (map->size() != 1)
+    {
+      std::cout << "Fun4AllDstPileupMerger::copy_background_event - cannot merge events that contain more than one PHHepMCGenEventMap" << std::endl;
+      return;
+    }
+
+    // get event and insert in new map
+    auto genevent = map->get_map().begin()->second;
+    auto newevent = m_geneventmap->insert_background_event(genevent);
+
+    /*
+     * this hack prevents a crash when writting out
+     * it boils down to root trying to write deleted items from the HepMC::GenEvent copy if the source has been deleted
+     * it does not happen if the source gets written while the copy is deleted
+     */
+    newevent->getEvent()->swap(*genevent->getEvent());
+
+    // shift vertex time and store new embed id
+    newevent->moveVertex(0, 0, 0, delta_t);
+    new_embed_id = newevent->get_embedding_id();
+  }
+
+  // copy truth container
+  // keep track of the correspondance between source index and destination index for vertices, tracks and showers
+  using ConversionMap = std::map<int, int>;
+  ConversionMap vtxid_map;
+  ConversionMap trkid_map;
+
+  const auto container = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
+  if (container && m_g4truthinfo)
+  {
+    {
+      // primary vertices
+      auto key = m_g4truthinfo->maxvtxindex();
+      const auto range = container->GetPrimaryVtxRange();
+      for (auto iter = range.first; iter != range.second; ++iter)
+      {
+        // clone vertex, insert in map, and add index conversion
+        const auto &sourceVertex = iter->second;
+        auto newVertex = new PHG4VtxPoint_t(sourceVertex);
+        newVertex->set_t(sourceVertex->get_t() + delta_t);
+        m_g4truthinfo->AddVertex(++key, newVertex);
+        vtxid_map.insert(std::make_pair(sourceVertex->get_id(), key));
+      }
+    }
+
+    {
+      // secondary vertices
+      auto key = m_g4truthinfo->minvtxindex();
+      const auto range = container->GetSecondaryVtxRange();
+
+      // loop from last to first to preserve order with respect to the original event
+      for (
+          auto iter = std::reverse_iterator<PHG4TruthInfoContainer::ConstVtxIterator>(range.second);
+          iter != std::reverse_iterator<PHG4TruthInfoContainer::ConstVtxIterator>(range.first);
+          ++iter)
+      {
+        // clone vertex, shift time, insert in map, and add index conversion
+        const auto &sourceVertex = iter->second;
+        auto newVertex = new PHG4VtxPoint_t(sourceVertex);
+        newVertex->set_t(sourceVertex->get_t() + delta_t);
+        m_g4truthinfo->AddVertex(--key, newVertex);
+        vtxid_map.insert(std::make_pair(sourceVertex->get_id(), key));
+      }
+    }
+
+    {
+      // primary particles
+      auto key = m_g4truthinfo->maxtrkindex();
+      const auto range = container->GetPrimaryParticleRange();
+      for (auto iter = range.first; iter != range.second; ++iter)
+      {
+        const auto &source = iter->second;
+        auto dest = new PHG4Particle_t(source);
+        m_g4truthinfo->AddParticle(++key, dest);
+        dest->set_track_id(key);
+
+        // set parent to zero
+        dest->set_parent_id(0);
+
+        // set primary to itself
+        dest->set_primary_id(dest->get_track_id());
+
+        // update vertex
+        const auto keyiter = vtxid_map.find(source->get_vtx_id());
+        if (keyiter != vtxid_map.end())
+          dest->set_vtx_id(keyiter->second);
+        else
+          std::cout << "Fun4AllDstPileupMerger::copy_background_event - vertex id " << source->get_vtx_id() << " not found in map" << std::endl;
+
+        // insert in map
+        trkid_map.insert(std::make_pair(source->get_track_id(), dest->get_track_id()));
+      }
+    }
+
+    {
+      // secondary particles
+      auto key = m_g4truthinfo->mintrkindex();
+      const auto range = container->GetSecondaryParticleRange();
+
+      /*
+       * loop from last to first to preserve order with respect to the original event
+       * also this ensures that for a given particle its parent has already been converted and thus found in the map
+       */
+      for (
+          auto iter = std::reverse_iterator<PHG4TruthInfoContainer::ConstIterator>(range.second);
+          iter != std::reverse_iterator<PHG4TruthInfoContainer::ConstIterator>(range.first);
+          ++iter)
+      {
+        const auto &source = iter->second;
+        auto dest = new PHG4Particle_t(source);
+        m_g4truthinfo->AddParticle(--key, dest);
+        dest->set_track_id(key);
+
+        // update parent id
+        auto keyiter = trkid_map.find(source->get_parent_id());
+        if (keyiter != trkid_map.end())
+          dest->set_parent_id(keyiter->second);
+        else
+          std::cout << "Fun4AllDstPileupMerger::copy_background_event - track id " << source->get_parent_id() << " not found in map" << std::endl;
+
+        // update primary id
+        keyiter = trkid_map.find(source->get_primary_id());
+        if (keyiter != trkid_map.end())
+          dest->set_primary_id(keyiter->second);
+        else
+          std::cout << "Fun4AllDstPileupMerger::copy_background_event - track id " << source->get_primary_id() << " not found in map" << std::endl;
+
+        // update vertex
+        keyiter = vtxid_map.find(source->get_vtx_id());
+        if (keyiter != vtxid_map.end())
+          dest->set_vtx_id(keyiter->second);
+        else
+          std::cout << "Fun4AllDstPileupMerger::copy_background_event - vertex id " << source->get_vtx_id() << " not found in map" << std::endl;
+
+        // insert in map
+        trkid_map.insert(std::make_pair(source->get_track_id(), dest->get_track_id()));
+      }
+    }
+
+    // vertex embed flags
+    /* embed flag is stored only for primary vertices, consistently with PHG4TruthEventAction */
+    for (const auto &pair : vtxid_map)
+    {
+      if (pair.first > 0) m_g4truthinfo->AddEmbededVtxId(pair.second, new_embed_id);
+    }
+
+    // track embed flags
+    /* embed flag is stored only for primary tracks, consistently with PHG4TruthEventAction */
+    for (const auto &pair : trkid_map)
+    {
+      if (pair.first > 0) m_g4truthinfo->AddEmbededTrkId(pair.second, new_embed_id);
+    }
+  }
+
+  // copy g4hits
+  // loop over registered maps
+  for (const auto &pair : m_g4hitscontainers)
+  {
+    // check destination node
+    if (!pair.second)
+    {
+      std::cout << "Fun4AllDstPileupMerger::copy_background_event - invalid destination container " << pair.first << std::endl;
+      continue;
+    }
+
+    // find source node
+    auto container = findNode::getClass<PHG4HitContainer>(dstNode, pair.first);
+    if (!container)
+    {
+      std::cout << "Fun4AllDstPileupMerger::copy_background_event - invalid source container " << pair.first << std::endl;
+      continue;
+    }
+
+    {
+      // hits
+      const auto range = container->getHits();
+      for (auto iter = range.first; iter != range.second; ++iter)
+      {
+        // clone hit
+        const auto &sourceHit = iter->second;
+        auto newHit = new PHG4Hit_t(sourceHit);
+
+        // shift time
+        newHit->set_t(0, sourceHit->get_t(0) + delta_t);
+        newHit->set_t(1, sourceHit->get_t(1) + delta_t);
+
+        // update track id
+        const auto keyiter = trkid_map.find(sourceHit->get_trkid());
+        if (keyiter != trkid_map.end())
+          newHit->set_trkid(keyiter->second);
+        else
+          std::cout << "Fun4AllDstPileupMerger::copy_background_event - track id " << sourceHit->get_trkid() << " not found in map" << std::endl;
+
+        /*
+         * reset shower ids
+         * it was decided that showers from the background events will not be copied to the merged event
+         * as such we just reset the hits shower id
+         */
+        newHit->set_shower_id(INT_MIN);
+
+        /*
+         * this will generate a new key for the hit and assign it to the hit
+         * this ensures that there is no conflict with the hits from the 'main' event
+         */
+        pair.second->AddHit(newHit->get_detid(), newHit);
+      }
+    }
+
+    {
+      // layers
+      const auto range = container->getLayers();
+      for (auto iter = range.first; iter != range.second; ++iter)
+      {
+        pair.second->AddLayer(*iter);
+      }
+    }
+  }
+}

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
@@ -103,7 +103,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
   const auto map = findNode::getClass<PHHepMCGenEventMap>(dstNode, "PHHepMCGenEventMap");
 
   // keep track of new embed id, after insertion as background event
-  int new_embed_id = 0;
+  int new_embed_id = -1;
 
   if (map && m_geneventmap)
   {

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.h
@@ -20,7 +20,7 @@ class PHHepMCGenEventMap;
  * in order to generate full pileup events from raw events
  * it is used internally by Fun4AllDstPileupInputManager and Fun4AllSingleDstPileupInputManager
  */
-class Fun4AllDstPileupMerger
+class Fun4AllDstPileupMerger final
 {
 
   public:

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.h
@@ -1,0 +1,53 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4MAIN_Fun4AllDstPileupMerger_H
+#define G4MAIN_Fun4AllDstPileupMerger_H
+
+/*!
+ * \file Fun4AllDstPileupMerger.h
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include <map>
+
+class PHCompositeNode;
+class PHG4HitContainer;
+class PHG4TruthInfoContainer;
+class PHHepMCGenEventMap;
+
+/*!
+ * utility class that can merge the relevant nodes together, once time shifted
+ * in order to generate full pileup events from raw events
+ * it is used internally by Fun4AllDstPileupInputManager and Fun4AllSingleDstPileupInputManager
+ */
+class Fun4AllDstPileupMerger
+{
+
+  public:
+
+  //! constructor
+  Fun4AllDstPileupMerger() = default;
+
+  //! destructor
+  ~Fun4AllDstPileupMerger() = default;
+
+  //! load destination nodes from composite
+  void load_nodes(PHCompositeNode*);
+
+  //! time-shift and copy content of source nodes to destination
+  void copy_background_event(PHCompositeNode *, double delta_t) const;
+
+  private:
+
+  //! hepmc
+  PHHepMCGenEventMap *m_geneventmap = nullptr;
+
+  //! maps g4hit containers to node names
+  std::map<std::string, PHG4HitContainer *> m_g4hitscontainers;
+
+  //! truth information
+  PHG4TruthInfoContainer *m_g4truthinfo = nullptr;
+
+};
+
+#endif

--- a/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.cc
@@ -155,6 +155,9 @@ int Fun4AllSingleDstPileupInputManager::fileopen(const std::string &filenam)
 //_____________________________________________________________________________
 int Fun4AllSingleDstPileupInputManager::run(const int nevents)
 {
+
+  std::cout << "Fun4AllSingleDstPileupInputManager::run - events: " << nevents << std::endl;
+
   if (!IsOpen())
   {
     if (FileListEmpty())
@@ -251,9 +254,6 @@ readagain:
     }
   }
 
-  // update event counter
-  ++m_events_accepted;
-
   // jump event counter to the last background accepted event
   if( neventsbackground > 0 ) PushBackEvents( -neventsbackground );
   return 0;
@@ -323,6 +323,10 @@ int Fun4AllSingleDstPileupInputManager::setBranches()
       for (branchiter = m_branchread.begin(); branchiter != m_branchread.end(); ++branchiter)
       {
         m_IManager->selectObjectToRead(branchiter->first.c_str(), branchiter->second);
+        if( m_IManager_background )
+        {
+          m_IManager_background->selectObjectToRead(branchiter->first.c_str(), branchiter->second);
+        }
         if (Verbosity() > 0)
         {
           std::cout << branchiter->first << " set to " << branchiter->second << std::endl;

--- a/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.cc
@@ -1,9 +1,9 @@
 /*!
- * \file Fun4AllDstPileupInputManager.cc
+ * \file Fun4AllSingleDstPileupInputManager.cc
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  */
 
-#include "Fun4AllDstPileupInputManager.h"
+#include "Fun4AllSingleDstPileupInputManager.h"
 #include "Fun4AllDstPileupMerger.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -43,7 +43,7 @@
 #include <utility>   // for pair
 
 //_____________________________________________________________________________
-Fun4AllDstPileupInputManager::Fun4AllDstPileupInputManager(const std::string &name, const std::string &nodename, const std::string &topnodename)
+Fun4AllSingleDstPileupInputManager::Fun4AllSingleDstPileupInputManager(const std::string &name, const std::string &nodename, const std::string &topnodename)
   : Fun4AllInputManager(name, nodename, topnodename)
 {
   // initialize random generator
@@ -53,7 +53,7 @@ Fun4AllDstPileupInputManager::Fun4AllDstPileupInputManager(const std::string &na
 }
 
 //_____________________________________________________________________________
-int Fun4AllDstPileupInputManager::fileopen(const std::string &filenam)
+int Fun4AllSingleDstPileupInputManager::fileopen(const std::string &filenam)
 {
   /*
   this is largely copied from fun4all/Fun4AllDstInputManager::fileopen
@@ -153,7 +153,7 @@ int Fun4AllDstPileupInputManager::fileopen(const std::string &filenam)
 }
 
 //_____________________________________________________________________________
-int Fun4AllDstPileupInputManager::run(const int nevents)
+int Fun4AllSingleDstPileupInputManager::run(const int nevents)
 {
   if (!IsOpen())
   {
@@ -215,12 +215,12 @@ readagain:
   // check if the local SubsysReco discards this event
   if (RejectEvent() != Fun4AllReturnCodes::EVENT_OK)
   {
-    std::cout << "Fun4AllDstPileupInputManager::run - skipped event " << m_ievent_thisfile - 1 << std::endl;
+    std::cout << "Fun4AllSingleDstPileupInputManager::run - skipped event " << m_ievent_thisfile - 1 << std::endl;
     goto readagain;
   }
 
   // load relevant DST nodes to internal pointers
-  std::cout << "Fun4AllDstPileupInputManager::run - loaded event " << m_ievent_thisfile - 1 << std::endl;
+  std::cout << "Fun4AllSingleDstPileupInputManager::run - loaded event " << m_ievent_thisfile - 1 << std::endl;
 
   Fun4AllDstPileupMerger merger;
   merger.load_nodes(m_dstNode);
@@ -243,7 +243,7 @@ readagain:
       if(!m_IManager_background->read(m_dstNodeInternal.get(), ievent_thisfile) ) break;
 
       // merge
-      std::cout << "Fun4AllDstPileupInputManager::run - merged background event " << ievent_thisfile << " time: " << crossing_time << std::endl;
+      std::cout << "Fun4AllSingleDstPileupInputManager::run - merged background event " << ievent_thisfile << " time: " << crossing_time << std::endl;
       merger.copy_background_event(m_dstNodeInternal.get(), crossing_time);
 
       ++neventsbackground;
@@ -260,7 +260,7 @@ readagain:
 }
 
 //_____________________________________________________________________________
-int Fun4AllDstPileupInputManager::fileclose()
+int Fun4AllSingleDstPileupInputManager::fileclose()
 {
   if (!IsOpen())
   {
@@ -275,7 +275,7 @@ int Fun4AllDstPileupInputManager::fileclose()
 }
 
 //_____________________________________________________________________________
-int Fun4AllDstPileupInputManager::BranchSelect(const std::string &branch, const int iflag)
+int Fun4AllSingleDstPileupInputManager::BranchSelect(const std::string &branch, const int iflag)
 {
   int myflag = iflag;
   // if iflag > 0 the branch is set to read
@@ -313,7 +313,7 @@ int Fun4AllDstPileupInputManager::BranchSelect(const std::string &branch, const 
 }
 
 //_____________________________________________________________________________
-int Fun4AllDstPileupInputManager::setBranches()
+int Fun4AllSingleDstPileupInputManager::setBranches()
 {
   if (m_IManager)
   {
@@ -340,14 +340,14 @@ int Fun4AllDstPileupInputManager::setBranches()
 }
 
 //_____________________________________________________________________________
-void Fun4AllDstPileupInputManager::Print(const std::string &what) const
+void Fun4AllSingleDstPileupInputManager::Print(const std::string &what) const
 {
   if (what == "ALL" || what == "BRANCH")
   {
     // loop over the map and print out the content (name and location in memory)
     std::cout << "--------------------------------------" << std::endl
               << std::endl;
-    std::cout << "List of selected branches in Fun4AllDstPileupInputManager " << Name() << ":" << std::endl;
+    std::cout << "List of selected branches in Fun4AllSingleDstPileupInputManager " << Name() << ":" << std::endl;
 
     std::map<const std::string, int>::const_iterator iter;
     for (iter = m_branchread.begin(); iter != m_branchread.end(); ++iter)
@@ -369,7 +369,7 @@ void Fun4AllDstPileupInputManager::Print(const std::string &what) const
     // loop over the map and print out the content (name and location in memory)
     std::cout << "--------------------------------------" << std::endl
               << std::endl;
-    std::cout << "PHNodeIOManager print in Fun4AllDstPileupInputManager " << Name() << ":" << std::endl;
+    std::cout << "PHNodeIOManager print in Fun4AllSingleDstPileupInputManager " << Name() << ":" << std::endl;
     m_IManager->print();
   }
   Fun4AllInputManager::Print(what);
@@ -377,7 +377,7 @@ void Fun4AllDstPileupInputManager::Print(const std::string &what) const
 }
 
 //_____________________________________________________________________________
-int Fun4AllDstPileupInputManager::PushBackEvents(const int i)
+int Fun4AllSingleDstPileupInputManager::PushBackEvents(const int i)
 {
   if (m_IManager)
   {

--- a/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.cc
@@ -156,8 +156,6 @@ int Fun4AllSingleDstPileupInputManager::fileopen(const std::string &filenam)
 int Fun4AllSingleDstPileupInputManager::run(const int nevents)
 {
 
-  std::cout << "Fun4AllSingleDstPileupInputManager::run - events: " << nevents << std::endl;
-
   if (!IsOpen())
   {
     if (FileListEmpty())

--- a/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
@@ -57,10 +57,6 @@ class Fun4AllSingleDstPileupInputManager : public Fun4AllInputManager
     m_tmax = tmax;
   }
 
-  //! obsolete. Does nothing, kept for backward API compatibility.
-  void generateBunchCrossingList( int nevents, float collision_rate )
-  {}
-
  private:
 
   //!@name event counters

--- a/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
@@ -63,7 +63,6 @@ class Fun4AllSingleDstPileupInputManager : public Fun4AllInputManager
   bool m_ReadRunTTree = true;
   int m_ievent_total = 0;
   int m_ievent_thisfile = 0;
-  int m_events_accepted = 0;
   //@}
 
   std::string m_fullfilename;

--- a/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
@@ -37,6 +37,11 @@ class Fun4AllSingleDstPileupInputManager : public Fun4AllInputManager
   void Print(const std::string &what = "ALL") const override;
   int PushBackEvents(const int i) override;
 
+  // Effectivly turn off the synchronization checking (copy from Fun4AllNoSyncDstInputManager)
+  int SyncIt(const SyncObject* /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_OK; }
+  int GetSyncObject(SyncObject** /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
+  int NoSyncPushBackEvents(const int nevt) override { return PushBackEvents(nevt); }
+
   /// collision rate in Hz
   void setCollisionRate(double Hz)
   { m_collision_rate = Hz; }

--- a/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
@@ -1,10 +1,10 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef G4MAIN_FUN4ALLDSTPILEUPINPUTMANAGER_H
-#define G4MAIN_FUN4ALLDSTPILEUPINPUTMANAGER_H
+#ifndef G4MAIN_FUN4ALLSINGLEDSTPILEUPINPUTMANAGER_H
+#define G4MAIN_FUN4ALLSINGLEDSTPILEUPINPUTMANAGER_H
 
 /*!
- * \file Fun4AllDstPileupInputManager.h
+ * \file Fun4AllSingleDstPileupInputManager.h
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  */
 
@@ -25,15 +25,15 @@
  * dedicated input manager that merges single events into "merged" events, containing a trigger event
  * and a number of time-shifted pile-up events corresponding to a given pile-up rate
 */
-class Fun4AllDstPileupInputManager : public Fun4AllInputManager
+class Fun4AllSingleDstPileupInputManager : public Fun4AllInputManager
 {
  public:
-  Fun4AllDstPileupInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
+  Fun4AllSingleDstPileupInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
   int fileopen(const std::string &filenam) override;
   int fileclose() override;
   int run(const int nevents = 0) override;
-  int BranchSelect(const std::string &branch, const int iflag);
-  int setBranches();
+  int BranchSelect(const std::string &branch, const int iflag) override;
+  int setBranches() override;
   void Print(const std::string &what = "ALL") const override;
   int PushBackEvents(const int i) override;
 
@@ -116,4 +116,4 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
 
 };
 
-#endif /* __Fun4AllDstPileupInputManager_H__ */
+#endif /* __Fun4AllSingleDstPileupInputManager_H__ */

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -134,7 +134,7 @@ libg4testbench_la_SOURCES = \
   Fun4AllMessenger.cc \
   G4TBMagneticFieldSetup.cc \
   G4TBFieldMessenger.cc \
-  Fun4AllDstPileupInputManager.cc \
+  Fun4AllSingleDstPileupInputManager.cc \
   Fun4AllDstPileupMerger.cc \
   HepMCNodeReader.cc \
   PHG4ConsistencyCheck.cc \
@@ -182,7 +182,7 @@ libg4testbench_la_SOURCES = \
 
 pkginclude_HEADERS = \
   EicEventHeader.h \
-  Fun4AllDstPileupInputManager.h \
+  Fun4AllSingleDstPileupInputManager.h \
   HepMCNodeReader.h \
   PHBBox.h \
   PHG4ColorDefs.h \

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -134,8 +134,9 @@ libg4testbench_la_SOURCES = \
   Fun4AllMessenger.cc \
   G4TBMagneticFieldSetup.cc \
   G4TBFieldMessenger.cc \
-  Fun4AllSingleDstPileupInputManager.cc \
+  Fun4AllDstPileupInputManager.cc \
   Fun4AllDstPileupMerger.cc \
+  Fun4AllSingleDstPileupInputManager.cc \
   HepMCNodeReader.cc \
   PHG4ConsistencyCheck.cc \
   PHG4DisplayAction.cc \
@@ -182,6 +183,8 @@ libg4testbench_la_SOURCES = \
 
 pkginclude_HEADERS = \
   EicEventHeader.h \
+  Fun4AllDstPileupInputManager.h \
+  Fun4AllDstPileupMerger.h \
   Fun4AllSingleDstPileupInputManager.h \
   HepMCNodeReader.h \
   PHBBox.h \

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -135,6 +135,7 @@ libg4testbench_la_SOURCES = \
   G4TBMagneticFieldSetup.cc \
   G4TBFieldMessenger.cc \
   Fun4AllDstPileupInputManager.cc \
+  Fun4AllDstPileupMerger.cc \
   HepMCNodeReader.cc \
   PHG4ConsistencyCheck.cc \
   PHG4DisplayAction.cc \
@@ -257,4 +258,4 @@ testexternals.cc:
 
 
 clean-local:
-	rm -f *Dict* $(BUILT_SOURCES) *.pcm 
+	rm -f *Dict* $(BUILT_SOURCES) *.pcm


### PR DESCRIPTION
This PR:
- modifies the existing DSTPileUpInputManager so that pileup event times are generated on the fly rather than pregenerated, or read from external files. This allows to properly merge signal and pileup events with the right (flat) time distribution, while ensuring that there is no overlap between merged events. This also prevents a bias identified by Dennis (and Jin) in merging pile-up events when reading the time sequence from a predefined set and then adding cuts on event time differences to avoid overlapping merged events. The possibility to read a predefined time sequence will be re-added later.
- renames the existing DSTPileUpInputManager to SingleDSTPileUpInputManager, to indicate that both the signal and the pileup events are read from the same DST
- moves the pile-up event merging code to a separate utility class
- introduces a new DSTPileUpInputManager, similar to HepMCPileupInputManager that allows to merge several events from a separate background file, in the form of pile-up, while the signal is handled separately by a dedicated DstInputManager

This code has been checked to produce the proper (flat) pile-up time distributions, and the right pile-up multiplicity (1.35 pile-up event for 50kHz collision rate and in the TPC time window of +/- 13.5us), but of course another pair of eyes is welcome

