### PR TITLE
fix sync object read for filelists

### DIFF
--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -639,7 +639,11 @@ int Fun4AllDstInputManager::HasSyncObject() const
   {
     return m_HaveSyncObject;
   }
-  cout << PHWHERE << "HasSyncObject() not initialized check the calling order" << endl;
-  gSystem->Exit(1);
-  exit(1);
+  if (IsOpen())
+  {
+    cout << PHWHERE << "HasSyncObject() not initialized check the calling order" << endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
+  return 0;
 }

--- a/offline/framework/fun4all/Fun4AllSyncManager.cc
+++ b/offline/framework/fun4all/Fun4AllSyncManager.cc
@@ -98,6 +98,8 @@ int Fun4AllSyncManager::run(const int nevnts)
     int hassync = 0;
     for (vector<Fun4AllInputManager *>::iterator iter = m_InManager.begin(); iter != m_InManager.end(); ++iter)
     {
+      m_iretInManager[iman] = (*iter)->run(1);
+      iret += m_iretInManager[iman];
       // one can run DSTs without sync object via the DST input manager
       // this only poses a problem if one runs two of them and expects the syncing to work
       // or mix DSTs with sync object and without
@@ -121,8 +123,6 @@ int Fun4AllSyncManager::run(const int nevnts)
           }
         }
       }
-      m_iretInManager[iman] = (*iter)->run(1);
-      iret += m_iretInManager[iman];
       if (!ifirst)
       {
         if (!m_iretInManager[iman])
@@ -463,13 +463,15 @@ void Fun4AllSyncManager::CurrentEvent(const int evt)
 
 void Fun4AllSyncManager::PrintSyncProblem() const
 {
-  cout << "Bad use of Fun4AllDstInputManager which might lead to event mixing" << endl;
-  cout << "If you insist to run this do the following in your macro: " << endl;
+  cout << "Bad use of Fun4AllDstInputManager for file(s) which do not have a synchronization object" << endl;
+  cout << "This works for single streams but if you run with multiple input streams this might lead to event mixing" << endl;
+  cout << "If you insist to run this (you take full responsibility), change the following in your macro: " << endl;
   for (auto iter = m_InManager.begin(); iter != m_InManager.end(); ++iter)
   {
     if ((*iter)->HasSyncObject() < 0)
     {
-      cout << "Change Fun4AllDstInputManager with name " << (*iter)->Name() << " from Fun4AllDstInputManager to Fun4AllNoSyncDstInputManager" << endl;
+      cout << "File " << (*iter)->FileName() << " does not contain a sync object" << endl;
+      cout << "Change its Fun4AllDstInputManager with name " << (*iter)->Name() << " from Fun4AllDstInputManager to Fun4AllNoSyncDstInputManager" << endl;
     }
   }
   return;


### PR DESCRIPTION
Ejiro found a problem when using file lists. For file lists the first event has to be processed for the input manager to actually open the file and figure out if a sync object exists or not. Now the run(1) is called in the Fun4AllSyncManager before the sync object consistency is checked. This forces the input managers to open the first file