### PR TITLE
Intt projection update

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -55,7 +55,7 @@ int PHActsSiliconSeeding::Init(PHCompositeNode *topNode)
   h_nMvtxHits = new TH1I("nMvtxHits",";N_{MVTX}",6,0,6);
   h_nInttHits = new TH1I("nInttHits",";N_{INTT}",80,0,80);
   h_nHits = new TH2I("nHits",";N_{MVTX};N_{INTT}",10,0,10,80,0,80);
-  h_nSeeds = new TH1I("nSeeds",";N_{Seeds}",200,0,200);
+  h_nSeeds = new TH1I("nSeeds",";N_{Seeds}",400,0,400);
   h_nInputMeas = new TH1I("nInputMeas",";N_{Meas}",2000,0,2000);
   h_nInputMvtxMeas = new TH1I("nInputMvtxMeas",";N_{meas}^{mvtx}",150,0,150);
   h_nInputInttMeas = new TH1I("nInputInttMeas",";N_{meas}^{intt}",150,0,150);
@@ -358,8 +358,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findInttMatches(
 				      const double B,
 				      const double m)
 {
-  std::vector<TrkrDefs::cluskey> additionalClusters;
-  
+
   double xProj[m_nInttLayers];
   double yProj[m_nInttLayers];
   double zProj[m_nInttLayers];
@@ -432,7 +431,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findInttMatches(
 	}
     }
 
-  additionalClusters = matchInttClusters(xProj, yProj, zProj);
+  auto additionalClusters = matchInttClusters(xProj, yProj, zProj);
 
   return additionalClusters;
 }
@@ -478,12 +477,15 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 		    inttClusR);
 
       if(Verbosity() > 2)
-	std::cout << "Checking INTT cluster with " << cluster->getX()
+	std::cout << "Checking INTT cluster with position " << cluster->getX()
 		  << ", " << cluster->getY() << ", " << cluster->getZ()
 		  << std::endl << " with projections rphi "
-		  << projRphi << " and clus rphi " << inttClusRphi
-		  << " and proj z " << zProj[projLayer] << " and clus z "
-		  << inttClusZ << " in layer " << projLayer << std::endl;
+		  << projRphi << " and inttclus rphi " << inttClusRphi
+		  << " and proj z " << zProj[projLayer] << " and inttclus z "
+		  << inttClusZ << " in layer " << projLayer 
+		  << " with search windows " << m_rPhiSearchWin 
+		  << " in rphi and strip z spacing " << stripZSpacing 
+		  << std::endl;
 
       h_resids->Fill(zProj[projLayer] - inttClusZ,
 		     projRphi - inttClusRphi);

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -490,8 +490,10 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
       h_resids->Fill(zProj[projLayer] - inttClusZ,
 		     projRphi - inttClusRphi);
 
+      /// Z strip spacing is the entire strip, so because we use fabs
+      /// we divide by two
       if(fabs(projRphi - inttClusRphi) < m_rPhiSearchWin and
-	 fabs(zProj[projLayer] - inttClusZ) < stripZSpacing)
+	 fabs(zProj[projLayer] - inttClusZ) < stripZSpacing / 2.)
 	{
 	  matchedClusters.push_back(cluskey);
 

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -140,6 +140,16 @@ class PHActsSiliconSeeding : public SubsysReco
 				double& yplus,
 				double& xminus,
 				double& yminus);
+  void createSvtxTrack(const double x,
+		       const double y,
+		       const double z,
+		       const double px,
+		       const double py,
+		       const double pz,
+		       const int charge,
+		       const std::vector<TrkrCluster*> clusters);
+  std::map<const unsigned int, std::vector<TrkrCluster*>>
+    makePossibleStubs(std::vector<TrkrCluster*> allClusters);
 
   double normPhi2Pi(const double phi);
 
@@ -200,6 +210,7 @@ class PHActsSiliconSeeding : public SubsysReco
   TH1 *h_nInttHits = nullptr;
   TH2 *h_nHits = nullptr;
   TH1 *h_nSeeds = nullptr;
+  TH1 *h_nTotSeeds = nullptr;
   TH1 *h_nInputMeas = nullptr;
   TH1 *h_nInputMvtxMeas = nullptr;
   TH1 *h_nInputInttMeas = nullptr;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -189,7 +189,7 @@ class PHActsSiliconSeeding : public SubsysReco
     {7.188, 7.732, 9.680,10.262}; /// cm
   
   /// Search window for phi to match intt clusters in cm
-  double m_rPhiSearchWin = 0.2;
+  double m_rPhiSearchWin = 0.1;
 
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -25,6 +25,7 @@
 #include <TH2.h>
 
 class PHCompositeNode;
+class PHG4CylinderGeomContainer;
 class SvtxTrackMap;
 class SvtxVertexMap;
 class TrkrCluster;
@@ -84,10 +85,7 @@ class PHActsSiliconSeeding : public SubsysReco
 
   void seedAnalysis(bool seedAnalysis)
     { m_seedAnalysis = seedAnalysis; }
-  
-  void projectToIntt(bool projectToIntt)
-    { m_projectToIntt = projectToIntt; }
-
+ 
  private:
 
   int getNodes(PHCompositeNode *topNode);
@@ -150,6 +148,7 @@ class PHActsSiliconSeeding : public SubsysReco
   SvtxTrackMap *m_trackMap = nullptr;
   CluskeyBimap *m_hitIdCluskey;
   TrkrClusterContainer *m_clusterMap = nullptr;
+  PHG4CylinderGeomContainer *m_geomContainerIntt = nullptr;
   
   /// Configuration classes for Acts seeding
   Acts::SeedfinderConfig<SpacePoint> m_seedFinderCfg;
@@ -189,16 +188,13 @@ class PHActsSiliconSeeding : public SubsysReco
   const double m_nInttLayerRadii[m_nInttLayers] = 
     {7.188, 7.732, 9.680,10.262}; /// cm
   
-  /// Search windows for phi and z to match intt clusters in cm
+  /// Search window for phi to match intt clusters in cm
   double m_rPhiSearchWin = 0.2;
-  double m_zSearchWin = 0.2;
 
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;
-  
-  bool m_projectToIntt = false;
 
-  bool m_seedAnalysis = false;
+  bool m_seedAnalysis = true;
   TFile *m_file = nullptr;
   TH1 *h_nMvtxHits = nullptr;
   TH1 *h_nInttHits = nullptr;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -68,7 +68,8 @@ using GridSeeds = std::vector<std::vector<Acts::Seed<SpacePoint>>>;
 /**
  * This class runs the Acts seeder over the MVTX measurements
  * to create track stubs for the rest of the stub matching pattern
- * recognition
+ * recognition. The module also projects the MVTX stubs to the INTT
+ * to find possible matches in the INTT to the MVTX triplet.
  */
 class PHActsSiliconSeeding : public SubsysReco
 {
@@ -108,7 +109,7 @@ class PHActsSiliconSeeding : public SubsysReco
   /// Get all space points for the seeder
   std::vector<const SpacePoint*> getMvtxSpacePoints();
 
-  /// Perform circle/line fits with the final seed to get
+  /// Perform circle/line fits with the final MVTX seed to get
   /// initial point and momentum estimates for stub matching
   int circleFitSeed(std::vector<TrkrCluster*>& clusters,
 		     double& x, double& y, double& z,
@@ -122,6 +123,8 @@ class PHActsSiliconSeeding : public SubsysReco
   int getCharge(const std::vector<TrkrCluster*>& clusters,
 		const double circPhi);
 
+  /// Projects circle fit to INTT radii to find possible INTT clusters
+  /// belonging to MVTX track stub
   std::vector<TrkrDefs::cluskey> findInttMatches(
 			const std::vector<TrkrCluster*>& clusters,
 			const double R,
@@ -150,7 +153,8 @@ class PHActsSiliconSeeding : public SubsysReco
 		       const std::vector<TrkrCluster*> clusters);
   std::map<const unsigned int, std::vector<TrkrCluster*>>
     makePossibleStubs(std::vector<TrkrCluster*> allClusters);
-
+  void createHistograms();
+  void writeHistograms();
   double normPhi2Pi(const double phi);
 
   std::map<unsigned int, SourceLink> *m_sourceLinks;
@@ -204,7 +208,7 @@ class PHActsSiliconSeeding : public SubsysReco
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;
 
-  bool m_seedAnalysis = true;
+  bool m_seedAnalysis = false;
   TFile *m_file = nullptr;
   TH1 *h_nMvtxHits = nullptr;
   TH1 *h_nInttHits = nullptr;


### PR DESCRIPTION
This PR changes the projection of the MVTX triplets to the INTT in a couple of ways:

1. The z matching window is changed from some arbitrary length to the INTT strip z length
2. The hits in the INTT that are potential matches are collected
3. These hits are then combinatorially combined with the MVTX triplet with the assumption of 2 INTT hits per track

Initial performance evaluation for the full Acts silicon seeder is/was shown in the December 15, 2020 sPHENIX simulations meeting.