### PR TITLE
Fix silicon seed PCA requirement

### DIFF
--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -274,14 +274,16 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
     {
       if(Verbosity() > 1)
 	{
-	  std::cout << "Adding track seed to vertex finder " << std::endl;
+	  std::cout << "Adding track seed to vertex finder " 
+		    << std::endl;
 	  track->identify();
 	}
 
-      const Acts::Vector4D stubVec(track->get_x() * Acts::UnitConstants::cm,
-				   track->get_y() * Acts::UnitConstants::cm,
-				   track->get_z() * Acts::UnitConstants::cm,
-				   10 * Acts::UnitConstants::ns);
+      const Acts::Vector4D stubVec(
+                  track->get_x() * Acts::UnitConstants::cm,
+		  track->get_y() * Acts::UnitConstants::cm,
+		  track->get_z() * Acts::UnitConstants::cm,
+		  10 * Acts::UnitConstants::ns);
      
       const Acts::Vector3D stubMom(track->get_px(),
 				   track->get_py(),
@@ -354,7 +356,7 @@ int PHActsInitialVertexFinder::createNodes(PHCompositeNode *topNode)
   if (!dstNode)
   {
     std::cerr << "DST Node missing, quitting" << std::endl;
-    throw std::runtime_error("failed to find DST node in PHActsSourceLinks::createNodes");
+    throw std::runtime_error("failed to find DST node in PHActsInitialVertexFinder::createNodes");
   }
 
   /// Get the tracking subnode

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -361,9 +361,11 @@ int PHActsSiliconSeeding::circleFitSeed(std::vector<TrkrCluster*>& clusters,
 
   findRoot(R, X0, Y0, x, y);
 
-  /// If the min x or y initial position was found to be greater 
-  /// than 10 cm that means it is a bad seed
-  if(fabs(x) > 10. or fabs(y) > 10.)
+  /// If the xy position is O(100s) microns, the initial vertex 
+  /// finder will throw an eigen stepper error trying to propagate 
+  /// from the PCA. These  are likely bad seeds anyway since the 
+  /// MVTX has position resolution O(5) microns. Units are cm
+  if(fabs(x) > 0.01 or fabs(y) > 0.01)
     {
       x = NAN;
       y = NAN;
@@ -1067,7 +1069,7 @@ int PHActsSiliconSeeding::createNodes(PHCompositeNode *topNode)
   if (!dstNode)
   {
     std::cerr << "DST node is missing, quitting" << std::endl;
-    throw std::runtime_error("Failed to find DST node in PHActsTracks::createNodes");
+    throw std::runtime_error("Failed to find DST node in PHActsSiliconSeeding::createNodes");
   }
   
   PHCompositeNode *svtxNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SVTX"));

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -365,7 +365,7 @@ int PHActsSiliconSeeding::circleFitSeed(std::vector<TrkrCluster*>& clusters,
   /// finder will throw an eigen stepper error trying to propagate 
   /// from the PCA. These  are likely bad seeds anyway since the 
   /// MVTX has position resolution O(5) microns. Units are cm
-  if(fabs(x) > 0.01 or fabs(y) > 0.01)
+  if(fabs(x) > m_maxSeedPCA or fabs(y) > m_maxSeedPCA)
     {
       x = NAN;
       y = NAN;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -84,9 +84,10 @@ class PHActsSiliconSeeding : public SubsysReco
   void useTruthClusters(bool useTruthClusters)
     { m_useTruthClusters = useTruthClusters; }
 
+  /// Output some diagnostic histograms
   void seedAnalysis(bool seedAnalysis)
     { m_seedAnalysis = seedAnalysis; }
- 
+   
  private:
 
   int getNodes(PHCompositeNode *topNode);
@@ -198,6 +199,8 @@ class PHActsSiliconSeeding : public SubsysReco
 
   int m_event = 0;
 
+  double m_maxSeedPCA = 0.03;
+  
   const static unsigned int m_nInttLayers = 4;
   const double m_nInttLayerRadii[m_nInttLayers] = 
     {7.188, 7.732, 9.680,10.262}; /// cm

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -114,7 +114,7 @@ int PHActsTrkFitter::Process()
   
   m_event++;
 
-  auto logLevel = Acts::Logging::INFO;
+  auto logLevel = Acts::Logging::FATAL;
 
   if (Verbosity() > 1)
   {


### PR DESCRIPTION

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the 2nd last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR changes the x-y PCA selection for the acts silicon seeds to less than 1 mm. The initial vertex finder was crashing due to the Acts stepper trying to propagate seeds that had a bad starting point - adding this criteria removes a higher fraction of bad seeds and allows the vertex finder to run without getting stuck trying to propagate something to a large x-y position.

Now, if a seed is bad, the acts track fitter just returns a bad track fit after the silicon seed is matched to the tpc seed (and then moves on to the next track).

## Links to other PRs in macros and calibration repositories (if applicable)

This PR accompanies a macros [PR](https://github.com/sPHENIX-Collaboration/macros/pull/351) which provides a flag to run the acts silicon seeder. It is not turned on by default since we haven't robustly tested it to determine things like efficiencies. 
