### PR TITLE
Z vertex fitter

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -199,7 +199,7 @@ class PHActsSiliconSeeding : public SubsysReco
 
   int m_event = 0;
 
-  double m_maxSeedPCA = 0.03;
+  double m_maxSeedPCA = 0.01;
   
   const static unsigned int m_nInttLayers = 4;
   const double m_nInttLayerRadii[m_nInttLayers] = 

--- a/offline/packages/trackreco/PHActsVertexFitter.cc
+++ b/offline/packages/trackreco/PHActsVertexFitter.cc
@@ -7,27 +7,26 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
-#include <trackbase_historic/SvtxVertexMap.h>
-#include <trackbase_historic/SvtxVertex.h>
-#include <trackbase_historic/SvtxVertex_v1.h>
-#include <trackbase_historic/SvtxVertexMap_v1.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxVertex.h>
+#include <trackbase_historic/SvtxVertexMap.h>
+#include <trackbase_historic/SvtxVertexMap_v1.h>
+#include <trackbase_historic/SvtxVertex_v1.h>
 
 /// Tracking includes
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
-#include <trackbase_historic/SvtxVertexMap.h>
 #include <trackbase_historic/SvtxVertex.h>
+#include <trackbase_historic/SvtxVertexMap.h>
 
 #include <ActsExamples/Plugins/BField/BFieldOptions.hpp>
 #include <ActsExamples/Plugins/BField/ScalableBField.hpp>
 
+#include <Acts/EventData/TrackParameters.hpp>
 #include <Acts/MagneticField/ConstantBField.hpp>
 #include <Acts/MagneticField/InterpolatedBFieldMap.hpp>
 #include <Acts/MagneticField/SharedBField.hpp>
-#include <Acts/EventData/TrackParameters.hpp>
-#include <Acts/MagneticField/ConstantBField.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Propagator/Propagator.hpp>
 #include <Acts/Surfaces/PerigeeSurface.hpp>
@@ -40,15 +39,16 @@
 
 #include <iostream>
 
-PHActsVertexFitter::PHActsVertexFitter(const std::string& name) 
-: SubsysReco(name)
+PHActsVertexFitter::PHActsVertexFitter(const std::string &name)
+  : SubsysReco(name)
   , m_actsFitResults(nullptr)
   , m_tGeometry(nullptr)
-{}
+{
+}
 
 int PHActsVertexFitter::Init(PHCompositeNode *topNode)
 {
-  if(Verbosity() > 1)
+  if (Verbosity() > 1)
     std::cout << "PHActsVertexFitter::Init" << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -56,7 +56,7 @@ int PHActsVertexFitter::Init(PHCompositeNode *topNode)
 
 int PHActsVertexFitter::End(PHCompositeNode *topNode)
 {
-  if(Verbosity() > 1)
+  if (Verbosity() > 1)
     std::cout << "PHActsVertexFitter::End " << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -64,354 +64,342 @@ int PHActsVertexFitter::End(PHCompositeNode *topNode)
 int PHActsVertexFitter::ResetEvent(PHCompositeNode *topNode)
 {
   m_actsVertexMap->clear();
-  
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int PHActsVertexFitter::InitRun(PHCompositeNode *topNode)
 {
-  if(getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+  if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
     return Fun4AllReturnCodes::ABORTRUN;
 
-  if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+  if (createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
     return Fun4AllReturnCodes::ABORTRUN;
-  
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
 {
   auto logLevel = Acts::Logging::FATAL;
-  if(Verbosity() > 0)
-    {
-      std::cout << "Beginning PHActsVertexFitter::process_event number " 
-		<< m_event << std::endl;
-      if(Verbosity() > 5)
-	logLevel = Acts::Logging::VERBOSE;
-    }
-  
+  if (Verbosity() > 0)
+  {
+    std::cout << "Beginning PHActsVertexFitter::process_event number "
+              << m_event << std::endl;
+    if (Verbosity() > 5)
+      logLevel = Acts::Logging::VERBOSE;
+  }
+
   const auto vertexTrackMap = getTracks();
 
-  for(const auto& [vertexId, trackVec] : vertexTrackMap)
-    {
-      const auto vertex = fitVertex(trackVec, logLevel);
+  for (const auto &[vertexId, trackVec] : vertexTrackMap)
+  {
+    const auto vertex = fitVertex(trackVec, logLevel);
 
-      createActsSvtxVertex(vertexId, vertex);
-      
-      if(m_updateSvtxVertexMap)
-	updateSvtxVertex(vertexId, vertex);
-    }
-  
-  if(Verbosity() > 1)
-    std::cout << "Finished PHActsVertexFitter::process_event" 
-	      << std::endl;
+    createActsSvtxVertex(vertexId, vertex);
+
+    if (m_updateSvtxVertexMap)
+      updateSvtxVertex(vertexId, vertex);
+  }
+
+  if (Verbosity() > 1)
+    std::cout << "Finished PHActsVertexFitter::process_event"
+              << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 void PHActsVertexFitter::updateSvtxVertex(const unsigned int vertexId,
-					  ActsVertex vertex)
+                                          ActsVertex vertex)
 {
   auto svtxVertex = m_vertexMap->get(vertexId);
 
-  if(Verbosity() > 1)
+  if (Verbosity() > 1)
     std::cout << "Updating SvtxVertex id " << vertexId << std::endl;
 
   svtxVertex->set_x(vertex.position().x() / Acts::UnitConstants::cm);
   svtxVertex->set_y(vertex.position().y() / Acts::UnitConstants::cm);
   svtxVertex->set_z(vertex.position().z() / Acts::UnitConstants::cm);
-  
-  for(int i = 0; i < 3; ++i) 
-    {
-      for(int j = 0; j < 3; ++j)
-	{
-	  svtxVertex->set_error(i, j,
-		      vertex.covariance()(i,j) / Acts::UnitConstants::cm2); 
-	}
-    }
 
-  const auto &[chi2,ndf] = vertex.fitQuality();
+  for (int i = 0; i < 3; ++i)
+  {
+    for (int j = 0; j < 3; ++j)
+    {
+      svtxVertex->set_error(i, j,
+                            vertex.covariance()(i, j) / Acts::UnitConstants::cm2);
+    }
+  }
+
+  const auto &[chi2, ndf] = vertex.fitQuality();
   svtxVertex->set_ndof(ndf);
   svtxVertex->set_chisq(chi2);
   svtxVertex->set_t0(vertex.time());
-
 }
 
-void PHActsVertexFitter::createActsSvtxVertex(const unsigned int vertexId, 
-					      ActsVertex vertex)
+void PHActsVertexFitter::createActsSvtxVertex(const unsigned int vertexId,
+                                              ActsVertex vertex)
 {
-  
 #if __cplusplus < 201402L
   auto svtxVertex = boost::make_unique<SvtxVertex_v1>();
 #else
   auto svtxVertex = std::make_unique<SvtxVertex_v1>();
 #endif
-  
-  if(Verbosity() > 2)
-    {
-      std::cout << "Creating vertex for id " << vertexId
-		 << std::endl;
-    }
+
+  if (Verbosity() > 2)
+  {
+    std::cout << "Creating vertex for id " << vertexId
+              << std::endl;
+  }
 
   svtxVertex->set_x(vertex.position().x() / Acts::UnitConstants::cm);
   svtxVertex->set_y(vertex.position().y() / Acts::UnitConstants::cm);
   svtxVertex->set_z(vertex.position().z() / Acts::UnitConstants::cm);
 
-  for(int i = 0; i < 3; ++i) 
+  for (int i = 0; i < 3; ++i)
+  {
+    for (int j = 0; j < 3; ++j)
     {
-      for(int j = 0; j < 3; ++j)
-	{
-	  svtxVertex->set_error(i, j,
-		      vertex.covariance()(i,j) / Acts::UnitConstants::cm2); 
-	}
+      svtxVertex->set_error(i, j,
+                            vertex.covariance()(i, j) / Acts::UnitConstants::cm2);
     }
+  }
 
-  const auto &[chi2,ndf] = vertex.fitQuality();
+  const auto &[chi2, ndf] = vertex.fitQuality();
   svtxVertex->set_ndof(ndf);
   svtxVertex->set_chisq(chi2);
   svtxVertex->set_t0(vertex.time());
   svtxVertex->set_id(vertexId);
 
   m_actsVertexMap->insert(svtxVertex.release());
-
 }
 
 ActsVertex PHActsVertexFitter::fitVertex(BoundTrackParamVec tracks, Acts::Logging::Level logLevel) const
 {
-  
-  /// Determine the input mag field type from the initial 
+  /// Determine the input mag field type from the initial
   /// geometry created in MakeActsGeometry
-  return std::visit([tracks, logLevel, this](auto& inputField) {
+  return std::visit([tracks, logLevel, this](auto &inputField) {
+    /// Setup aliases
+    using InputMagneticField =
+        typename std::decay_t<decltype(inputField)>::element_type;
+    using MagneticField = Acts::SharedBField<InputMagneticField>;
+    using Stepper = Acts::EigenStepper<MagneticField>;
+    using Propagator = Acts::Propagator<Stepper>;
+    using PropagatorOptions = Acts::PropagatorOptions<>;
+    using TrackParameters = Acts::BoundTrackParameters;
+    using Linearizer = Acts::HelicalTrackLinearizer<Propagator>;
+    using VertexFitter =
+        Acts::FullBilloirVertexFitter<TrackParameters, Linearizer>;
+    using VertexFitterOptions = Acts::VertexingOptions<TrackParameters>;
 
-      /// Setup aliases
-      using InputMagneticField = 
-	typename std::decay_t<decltype(inputField)>::element_type;
-      using MagneticField = Acts::SharedBField<InputMagneticField>;
-      using Stepper = Acts::EigenStepper<MagneticField>;
-      using Propagator = Acts::Propagator<Stepper>;
-      using PropagatorOptions = Acts::PropagatorOptions<>;
-      using TrackParameters = Acts::BoundTrackParameters;
-      using Linearizer = Acts::HelicalTrackLinearizer<Propagator>;
-      using VertexFitter =
-	Acts::FullBilloirVertexFitter<TrackParameters, Linearizer>;
-      using VertexFitterOptions = Acts::VertexingOptions<TrackParameters>;
+    auto logger = Acts::getDefaultLogger("PHActsVertexFitter",
+                                         logLevel);
 
-      auto logger = Acts::getDefaultLogger("PHActsVertexFitter", 
-					   logLevel);
+    /// Create necessary templated inputs for Acts vertex fitter
+    MagneticField bField(inputField);
+    auto propagator = std::make_shared<Propagator>(Stepper(bField));
+    PropagatorOptions propagatorOpts(m_tGeometry->geoContext,
+                                     m_tGeometry->magFieldContext,
+                                     Acts::LoggerWrapper(*logger));
 
-      /// Create necessary templated inputs for Acts vertex fitter
-      MagneticField bField(inputField);
-      auto propagator = std::make_shared<Propagator>(Stepper(bField));
-      PropagatorOptions propagatorOpts(m_tGeometry->geoContext,
-				       m_tGeometry->magFieldContext,
-				       Acts::LoggerWrapper(*logger));
-      
-      typename VertexFitter::Config vertexFitterCfg;
-      VertexFitter fitter(vertexFitterCfg);
-      typename VertexFitter::State state(m_tGeometry->magFieldContext);
-    
-      typename Linearizer::Config linConfig(bField, propagator);
-      Linearizer linearizer(linConfig);
+    typename VertexFitter::Config vertexFitterCfg;
+    VertexFitter fitter(vertexFitterCfg);
+    typename VertexFitter::State state(m_tGeometry->magFieldContext);
 
-      /// Can add a vertex fitting constraint as an option, if desired
-      VertexFitterOptions vfOptions(m_tGeometry->geoContext,
-				    m_tGeometry->magFieldContext);
-      
-      /// Call the fitter and get the result
-      auto fitRes = fitter.fit(tracks, linearizer,
-			       vfOptions, state);
+    typename Linearizer::Config linConfig(bField, propagator);
+    Linearizer linearizer(linConfig);
 
-      Acts::Vertex<TrackParameters> fittedVertex;
+    /// Can add a vertex fitting constraint as an option, if desired
+    VertexFitterOptions vfOptions(m_tGeometry->geoContext,
+                                  m_tGeometry->magFieldContext);
 
-      if(fitRes.ok())
-	{
-	  fittedVertex = *fitRes;
-	  if(Verbosity() > 3)
-	    {
-	      std::cout << "Fitted vertex position "
-			<< fittedVertex.position().x() 
-			<< ", " 
-			<< fittedVertex.position().y() 
-			<< ", "
-			<< fittedVertex.position().z() 
-			<< std::endl;
-	    }
-	}
-      else
-	{
-	  if(Verbosity() > 3)
-	    {
-	      std::cout << "Acts vertex fit error: " 
-			<< fitRes.error().message()
-			<< std::endl;
-	    }
-	}
+    /// Call the fitter and get the result
+    auto fitRes = fitter.fit(tracks, linearizer,
+                             vfOptions, state);
 
-      return fittedVertex;
+    Acts::Vertex<TrackParameters> fittedVertex;
+
+    if (fitRes.ok())
+    {
+      fittedVertex = *fitRes;
+      if (Verbosity() > 3)
+      {
+        std::cout << "Fitted vertex position "
+                  << fittedVertex.position().x()
+                  << ", "
+                  << fittedVertex.position().y()
+                  << ", "
+                  << fittedVertex.position().z()
+                  << std::endl;
+      }
     }
-    , m_tGeometry->magField
-    ); /// end std::visit call
+    else
+    {
+      if (Verbosity() > 3)
+      {
+        std::cout << "Acts vertex fit error: "
+                  << fitRes.error().message()
+                  << std::endl;
+      }
+    }
+
+    return fittedVertex;
+  },
+                    m_tGeometry->magField);  /// end std::visit call
 }
 
 VertexTrackMap PHActsVertexFitter::getTracks()
 {
- 
   VertexTrackMap trackPtrs;
 
-  for(const auto &[key, track] : *m_trackMap)
-    {
-      const unsigned int vertexId = track->get_vertex_id();    
-      const auto trackParam = makeTrackParam(track);
-      auto trackVecPos = trackPtrs.find(vertexId);
+  for (const auto &[key, track] : *m_trackMap)
+  {
+    const unsigned int vertexId = track->get_vertex_id();
+    const auto trackParam = makeTrackParam(track);
+    auto trackVecPos = trackPtrs.find(vertexId);
 
-      if(trackVecPos == trackPtrs.end())
-	{
-	  BoundTrackParamVec trackVec;
-	  
-	  trackVec.push_back(trackParam);
-	  auto pair = std::make_pair(vertexId, trackVec);
-	  trackPtrs.insert(pair);
-	} 
-      else
-	{
-	  trackVecPos->second.push_back(trackParam);
-	}
-    }
-  
-  if(Verbosity() > 3)
+    if (trackVecPos == trackPtrs.end())
     {
-      for(const auto& [vertexId, trackVec] : trackPtrs)
-	{
-	  std::cout << "Fitting vertexId : " << vertexId 
-		    << " with the following number of tracks "
-		    << trackVec.size()
-		    << std::endl;
-      
-	  for(const auto param : trackVec)
-	    {
-	      std::cout << "Track position: (" 
-			<< param->position(m_tGeometry->geoContext)(0)
-			<<", " << param->position(m_tGeometry->geoContext)(1) << ", "
-			<< param->position(m_tGeometry->geoContext)(2) << ")" 
-			<< std::endl;
-	    }	  
-	}
+      BoundTrackParamVec trackVec;
+
+      trackVec.push_back(trackParam);
+      auto pair = std::make_pair(vertexId, trackVec);
+      trackPtrs.insert(pair);
     }
+    else
+    {
+      trackVecPos->second.push_back(trackParam);
+    }
+  }
+
+  if (Verbosity() > 3)
+  {
+    for (const auto &[vertexId, trackVec] : trackPtrs)
+    {
+      std::cout << "Fitting vertexId : " << vertexId
+                << " with the following number of tracks "
+                << trackVec.size()
+                << std::endl;
+
+      for (const auto param : trackVec)
+      {
+        std::cout << "Track position: ("
+                  << param->position(m_tGeometry->geoContext)(0)
+                  << ", " << param->position(m_tGeometry->geoContext)(1) << ", "
+                  << param->position(m_tGeometry->geoContext)(2) << ")"
+                  << std::endl;
+      }
+    }
+  }
 
   return trackPtrs;
-
 }
 
-const Acts::BoundTrackParameters* PHActsVertexFitter::makeTrackParam(const SvtxTrack *track) const 
+const Acts::BoundTrackParameters *PHActsVertexFitter::makeTrackParam(const SvtxTrack *track) const
 {
   const Acts::Vector4D trackPos(
-		       track->get_x() * Acts::UnitConstants::cm,
-		       track->get_y() * Acts::UnitConstants::cm,
-		       track->get_z() * Acts::UnitConstants::cm,
-		       10 * Acts::UnitConstants::ns);
-  
+      track->get_x() * Acts::UnitConstants::cm,
+      track->get_y() * Acts::UnitConstants::cm,
+      track->get_z() * Acts::UnitConstants::cm,
+      10 * Acts::UnitConstants::ns);
+
   const Acts::Vector3D trackMom(track->get_px(),
-				track->get_py(),
-				track->get_pz());
- 
+                                track->get_py(),
+                                track->get_pz());
+
   const int trackQ = track->get_charge() * Acts::UnitConstants::e;
   const double p = track->get_p();
   Acts::BoundSymMatrix cov;
-  
-  for(int i = 0; i < 6; ++i)
+
+  for (int i = 0; i < 6; ++i)
+  {
+    for (int j = 0; j < 6; ++j)
     {
-      for(int j = 0; j < 6; ++j)
-	{
-	  cov(i,j) = track->get_error(i,j);
-	}
+      cov(i, j) = track->get_error(i, j);
     }
+  }
 
   auto perigee = Acts::Surface::makeShared<Acts::PerigeeSurface>(
-       Acts::Vector3D(track->get_x() * Acts::UnitConstants::cm,
-		      track->get_y() * Acts::UnitConstants::cm,
-		      track->get_z() * Acts::UnitConstants::cm));
+      Acts::Vector3D(track->get_x() * Acts::UnitConstants::cm,
+                     track->get_y() * Acts::UnitConstants::cm,
+                     track->get_z() * Acts::UnitConstants::cm));
 
   const auto param = new Acts::BoundTrackParameters(
-			 perigee, m_tGeometry->geoContext,
-			 trackPos, trackMom, p, trackQ, cov);
+      perigee, m_tGeometry->geoContext,
+      trackPos, trackMom, p, trackQ, cov);
 
   return param;
-  
 }
 
 int PHActsVertexFitter::getNodes(PHCompositeNode *topNode)
 {
   m_actsFitResults = findNode::getClass<std::map<const unsigned int, Trajectory>>(topNode, "ActsFitResults");
-  if(!m_actsFitResults)
-    {
-      std::cout << PHWHERE << "Acts Trajectories not found on node tree, exiting."
-		<< std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-
-    }
+  if (!m_actsFitResults)
+  {
+    std::cout << PHWHERE << "Acts Trajectories not found on node tree, exiting."
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   m_trackMap = findNode::getClass<SvtxTrackMap>(topNode,
-						"SvtxTrackMap");
-  if(!m_trackMap)
-    {
-      std::cout << PHWHERE << "No SvtxTrackMap on node tree. Bailing." 
-		<< std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+                                                "SvtxTrackMap");
+  if (!m_trackMap)
+  {
+    std::cout << PHWHERE << "No SvtxTrackMap on node tree. Bailing."
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode,
-						  "SvtxVertexMap");
-  if(!m_vertexMap)
-    {
-      std::cout << PHWHERE << "No SvtxVertexMap on node tree, bailing"
-		<< std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+                                                  "SvtxVertexMap");
+  if (!m_vertexMap)
+  {
+    std::cout << PHWHERE << "No SvtxVertexMap on node tree, bailing"
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   m_tGeometry = findNode::getClass<ActsTrackingGeometry>(topNode, "ActsTrackingGeometry");
-  if(!m_tGeometry)
-    {
-      std::cout << PHWHERE << "ActsTrackingGeometry not on node tree. Exiting"
-		<< std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+  if (!m_tGeometry)
+  {
+    std::cout << PHWHERE << "ActsTrackingGeometry not on node tree. Exiting"
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
-
 }
 
 int PHActsVertexFitter::createNodes(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
-  
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   if (!dstNode)
-    {
-      std::cerr << "DST node is missing, quitting" << std::endl;
-      throw std::runtime_error("Failed to find DST node in PHActsTracks::createNodes");
-    }
-  
-  PHCompositeNode *svtxNode = 
-    dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SVTX"));
-  
-  if (!svtxNode)
-    {
-      svtxNode = new PHCompositeNode("SVTX");
-      dstNode->addNode(svtxNode);
-    }
+  {
+    std::cerr << "DST node is missing, quitting" << std::endl;
+    throw std::runtime_error("Failed to find DST node in PHActsTracks::createNodes");
+  }
 
-  m_actsVertexMap = 
-    findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");
-  if(!m_actsVertexMap)
-    {
-      m_actsVertexMap = new SvtxVertexMap_v1;
-      PHIODataNode<PHObject> *node = 
-	new PHIODataNode<PHObject>(m_actsVertexMap,
-				   "SvtxVertexMapActs", "PHObject");
-      svtxNode->addNode(node);
-    }
+  PHCompositeNode *svtxNode =
+      dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SVTX"));
+
+  if (!svtxNode)
+  {
+    svtxNode = new PHCompositeNode("SVTX");
+    dstNode->addNode(svtxNode);
+  }
+
+  m_actsVertexMap =
+      findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");
+  if (!m_actsVertexMap)
+  {
+    m_actsVertexMap = new SvtxVertexMap_v1;
+    PHIODataNode<PHObject> *node =
+        new PHIODataNode<PHObject>(m_actsVertexMap,
+                                   "SvtxVertexMapActs", "PHObject");
+    svtxNode->addNode(node);
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
-
 }

--- a/offline/packages/trackreco/PHActsVertexFitter.cc
+++ b/offline/packages/trackreco/PHActsVertexFitter.cc
@@ -7,6 +7,13 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
+#include <trackbase_historic/SvtxVertexMap.h>
+#include <trackbase_historic/SvtxVertex.h>
+#include <trackbase_historic/SvtxVertex_v1.h>
+#include <trackbase_historic/SvtxVertexMap_v1.h>
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+
 /// Tracking includes
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
@@ -29,7 +36,6 @@
 #include <Acts/Vertexing/FullBilloirVertexFitter.hpp>
 #include <Acts/Vertexing/HelicalTrackLinearizer.hpp>
 #include <Acts/Vertexing/LinearizedTrack.hpp>
-#include <Acts/Vertexing/Vertex.hpp>
 #include <Acts/Vertexing/VertexingOptions.hpp>
 
 #include <iostream>
@@ -57,28 +63,120 @@ int PHActsVertexFitter::End(PHCompositeNode *topNode)
     std::cout << "PHActsVertexFitter::End " << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
-
+int PHActsVertexFitter::ResetEvent(PHCompositeNode *topNode)
+{
+  m_actsVertexMap->clear();
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
 int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
 {
-
+  
   if(getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
     return Fun4AllReturnCodes::ABORTRUN;
 
-  auto logLevel = Acts::Logging::INFO;
-  if(Verbosity() > 1)
+  if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+    return Fun4AllReturnCodes::ABORTRUN;
+  
+  auto logLevel = Acts::Logging::FATAL;
+  if(Verbosity() > 0)
     {
       std::cout << "Beginning PHActsVertexFitter::process_event number " 
 		<< m_event << std::endl;
-      logLevel = Acts::Logging::VERBOSE;
+      if(Verbosity() > 5)
+	logLevel = Acts::Logging::VERBOSE;
     }
   
-  std::vector<const Acts::BoundTrackParameters*> tracks = getTracks();
-  
-  auto logger = Acts::getDefaultLogger("PHActsVertexFitter", logLevel);
+  const auto vertexTrackMap = getTracks();
 
-  /// Determine the input mag field type from the initial geometry created in
-  /// MakeActsGeometry
-  std::visit([&](auto& inputField) {
+  for(const auto& [vertexId, trackVec] : vertexTrackMap)
+    {
+      std::cout<< "Fitting"<<std::endl;
+      const auto vertex = fitVertex(trackVec, logLevel);
+      std::cout <<"Updating"<<std::endl;
+      createActsSvtxVertex(vertexId, vertex);
+      
+      if(m_updateSvtxVertexMap)
+	updateSvtxVertex(vertexId, vertex);
+    }
+  
+  if(Verbosity() > 1)
+    std::cout << "Finished PHActsVertexFitter::process_event" 
+	      << std::endl;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void PHActsVertexFitter::updateSvtxVertex(const unsigned int vertexId,
+					  ActsVertex vertex)
+{
+  auto svtxVertex = m_vertexMap->get(vertexId);
+
+  svtxVertex->set_x(vertex.position().x() / Acts::UnitConstants::cm);
+  svtxVertex->set_y(vertex.position().y() / Acts::UnitConstants::cm);
+  svtxVertex->set_z(vertex.position().z() / Acts::UnitConstants::cm);
+  
+  for(int i = 0; i < 3; ++i) 
+    {
+      for(int j = 0; j < 3; ++j)
+	{
+	  svtxVertex->set_error(i, j,
+		      vertex.covariance()(i,j) / Acts::UnitConstants::cm2); 
+	}
+    }
+
+  const auto &[chi2,ndf] = vertex.fitQuality();
+  svtxVertex->set_ndof(ndf);
+  svtxVertex->set_chisq(chi2);
+  svtxVertex->set_t0(vertex.time());
+
+}
+
+void PHActsVertexFitter::createActsSvtxVertex(const unsigned int vertexId, 
+					      ActsVertex vertex)
+{
+  
+#if __cplusplus < 201402L
+  auto svtxVertex = boost::make_unique<SvtxVertex_v1>();
+#else
+  auto svtxVertex = std::make_unique<SvtxVertex_v1>();
+#endif
+  
+  if(Verbosity() > 2)
+    {
+      std::cout << "Creating vertex for id " << vertexId
+		 << std::endl;
+    }
+
+  svtxVertex->set_x(vertex.position().x() / Acts::UnitConstants::cm);
+  svtxVertex->set_y(vertex.position().y() / Acts::UnitConstants::cm);
+  svtxVertex->set_z(vertex.position().z() / Acts::UnitConstants::cm);
+  std::cout <<" covariance"<<std::endl;
+  for(int i = 0; i < 3; ++i) 
+    {
+      for(int j = 0; j < 3; ++j)
+	{
+	  svtxVertex->set_error(i, j,
+		      vertex.covariance()(i,j) / Acts::UnitConstants::cm2); 
+	}
+    }
+  std::cout<<"other vert things"<<std::endl;
+  const auto &[chi2,ndf] = vertex.fitQuality();
+  svtxVertex->set_ndof(ndf);
+  svtxVertex->set_chisq(chi2);
+  svtxVertex->set_t0(vertex.time());
+  svtxVertex->set_id(vertexId);
+  std::cout << "add to map"<<std::endl;
+  m_actsVertexMap->insert(svtxVertex.release());
+  std::cout << "returning"<<std::endl;
+}
+
+ActsVertex PHActsVertexFitter::fitVertex(BoundTrackParamVec tracks, Acts::Logging::Level logLevel) const
+{
+  
+  /// Determine the input mag field type from the initial 
+  /// geometry created in MakeActsGeometry
+  return std::visit([tracks, logLevel, this](auto& inputField) {
 
       /// Setup aliases
       using InputMagneticField = 
@@ -92,9 +190,12 @@ int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
       using VertexFitter =
 	Acts::FullBilloirVertexFitter<TrackParameters, Linearizer>;
       using VertexFitterOptions = Acts::VertexingOptions<TrackParameters>;
-      
+
+      auto logger = Acts::getDefaultLogger("PHActsVertexFitter", 
+					   logLevel);
+
       /// Create necessary templated inputs for Acts vertex fitter
-      MagneticField bField(std::move(inputField));
+      MagneticField bField(inputField);
       auto propagator = std::make_shared<Propagator>(Stepper(bField));
       PropagatorOptions propagatorOpts(m_tGeometry->geoContext,
 				       m_tGeometry->magFieldContext,
@@ -115,9 +216,10 @@ int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
       auto fitRes = fitter.fit(tracks, linearizer,
 			       vfOptions, state);
 
+      Acts::Vertex<TrackParameters> fittedVertex;
+
       if(fitRes.ok())
 	{
-	  Acts::Vertex<TrackParameters> fittedVertex;
 	  fittedVertex = *fitRes;
 	  if(Verbosity() > 3)
 	    {
@@ -140,63 +242,100 @@ int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
 			<< std::endl;
 	    }
 	}
-      
+
+      return fittedVertex;
     }
     , m_tGeometry->magField
     ); /// end std::visit call
-
-  if(Verbosity() > 1)
-    std::cout << "Finished PHActsVertexFitter::process_event" 
-	      << std::endl;
-
-  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 
-std::vector<const Acts::BoundTrackParameters*> PHActsVertexFitter::getTracks()
+VertexTrackMap PHActsVertexFitter::getTracks()
 {
  
-  std::vector<const Acts::BoundTrackParameters*> trackPtrs;
+  VertexTrackMap trackPtrs;
 
-  for(const auto &[key, traj] : *m_actsFitResults)
+  for(const auto &[key, track] : *m_trackMap)
     {
-      const auto &[trackTips, mj] = traj.trajectory();
-      
-      for(const size_t &trackTip : trackTips)
+      const unsigned int vertexId = track->get_vertex_id();
+    
+      const auto trackParam = makeTrackParam(track);
+
+      auto trackVecPos = trackPtrs.find(vertexId);
+      if(trackVecPos == trackPtrs.end())
 	{
-	  if(traj.hasTrackParameters(trackTip))
-	    {
-	      const auto param = 
-		new Acts::BoundTrackParameters(traj.trackParameters(trackTip));
-	      
-	      trackPtrs.push_back(param);
-	    }
+	  BoundTrackParamVec trackVec;
 	  
+	  trackVec.push_back(trackParam);
+	  auto pair = std::make_pair(vertexId, trackVec);
+	  trackPtrs.insert(pair);
+	} 
+      else
+	{
+	  trackVecPos->second.push_back(trackParam);
 	}
     }
   
   if(Verbosity() > 3)
     {
-      std::cout << "Fitting a vertex for the following number of tracks "
-		<< trackPtrs.size()
-		<< std::endl;
-      
-      for(std::vector<const Acts::BoundTrackParameters*>::iterator it = trackPtrs.begin();
-	  it != trackPtrs.end(); ++it)
+      for(const auto& [vertexId, trackVec] : trackPtrs)
 	{
-	  const auto param = *it;
-	  std::cout << "Track position: (" 
-		    << param->position(m_tGeometry->geoContext)(0)
-		    <<", " << param->position(m_tGeometry->geoContext)(1) << ", "
-		    << param->position(m_tGeometry->geoContext)(2) << ")" 
+	  std::cout << "Fitting vertexId : " << vertexId 
+		    << " with the following number of tracks "
+		    << trackVec.size()
 		    << std::endl;
-
-	}
       
+	  for(const auto param : trackVec)
+	    {
+	      std::cout << "Track position: (" 
+			<< param->position(m_tGeometry->geoContext)(0)
+			<<", " << param->position(m_tGeometry->geoContext)(1) << ", "
+			<< param->position(m_tGeometry->geoContext)(2) << ")" 
+			<< std::endl;
+
+	    }	  
+	}
     }
 
   return trackPtrs;
 
+}
+
+const Acts::BoundTrackParameters* PHActsVertexFitter::makeTrackParam(const SvtxTrack *track) const 
+{
+
+  const Acts::Vector4D trackPos(
+		       track->get_x() * Acts::UnitConstants::cm,
+		       track->get_y() * Acts::UnitConstants::cm,
+		       track->get_z() * Acts::UnitConstants::cm,
+		       10 * Acts::UnitConstants::ns);
+  
+  const Acts::Vector3D trackMom(track->get_px(),
+				track->get_py(),
+				track->get_pz());
+  const int trackQ = track->get_charge() * Acts::UnitConstants::e;
+  const double p = track->get_p();
+  Acts::BoundSymMatrix cov;
+  
+  for(int i = 0; i < 6; ++i)
+    {
+      for(int j = 0; j < 6; ++j)
+	{
+	  cov(i,j) = track->get_error(i,j);
+	}
+    }
+
+  auto perigee = Acts::Surface::makeShared<Acts::PerigeeSurface>(
+       Acts::Vector3D(track->get_x() * Acts::UnitConstants::cm,
+		      track->get_y() * Acts::UnitConstants::cm,
+		      track->get_z() * Acts::UnitConstants::cm));
+
+  const auto param = new Acts::BoundTrackParameters(
+			 perigee, m_tGeometry->geoContext,
+			 trackPos, trackMom, p, trackQ, cov);
+
+  return param;
+  
 }
 
 int PHActsVertexFitter::getNodes(PHCompositeNode *topNode)
@@ -210,6 +349,23 @@ int PHActsVertexFitter::getNodes(PHCompositeNode *topNode)
 
     }
 
+  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode,
+						"SvtxTrackMap");
+  if(!m_trackMap)
+    {
+      std::cout << PHWHERE << "No SvtxTrackMap on node tree. Bailing." 
+		<< std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+  m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode,
+						  "SvtxVertexMap");
+  if(!m_vertexMap)
+    {
+      std::cout << PHWHERE << "No SvtxVertexMap on node tree, bailing"
+		<< std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
 
   m_tGeometry = findNode::getClass<ActsTrackingGeometry>(topNode, "ActsTrackingGeometry");
   if(!m_tGeometry)
@@ -217,6 +373,43 @@ int PHActsVertexFitter::getNodes(PHCompositeNode *topNode)
       std::cout << PHWHERE << "ActsTrackingGeometry not on node tree. Exiting"
 		<< std::endl;
       return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+
+}
+
+
+int PHActsVertexFitter::createNodes(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+  
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+
+  if (!dstNode)
+    {
+      std::cerr << "DST node is missing, quitting" << std::endl;
+      throw std::runtime_error("Failed to find DST node in PHActsTracks::createNodes");
+    }
+  
+  PHCompositeNode *svtxNode = 
+    dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SVTX"));
+  
+  if (!svtxNode)
+    {
+      svtxNode = new PHCompositeNode("SVTX");
+      dstNode->addNode(svtxNode);
+    }
+
+  m_actsVertexMap = 
+    findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");
+  if(!m_actsVertexMap)
+    {
+      m_actsVertexMap = new SvtxVertexMap_v1;
+      PHIODataNode<PHObject> *node = 
+	new PHIODataNode<PHObject>(m_actsVertexMap,
+				   "SvtxVertexMapActs", "PHObject");
+      svtxNode->addNode(node);
     }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trackreco/PHActsVertexFitter.h
+++ b/offline/packages/trackreco/PHActsVertexFitter.h
@@ -27,6 +27,12 @@ using VertexTrackMap = std::map<const unsigned int,
 
 using ActsVertex = const Acts::Vertex<Acts::BoundTrackParameters>;
 
+
+/**
+ * This class runs the Acts vertex fitter on the final tracks. It is
+ * required that the tracks already have an identified vertexId associated
+ * to them, i.e. that vertex finding has already been performed
+ */
 class PHActsVertexFitter : public SubsysReco
 {
  public:
@@ -34,35 +40,47 @@ class PHActsVertexFitter : public SubsysReco
   virtual ~PHActsVertexFitter(){}
   int process_event(PHCompositeNode *topNode);
   int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
   int ResetEvent(PHCompositeNode *topNode);
   int End (PHCompositeNode *topNode);
 
+  void updateSvtxVertexMap(bool updateSvtxVertexMap)
+    { m_updateSvtxVertexMap = updateSvtxVertexMap; }
 
  private:
   
   int getNodes(PHCompositeNode *topNode);
   int createNodes(PHCompositeNode *topNode);
   
+  /// Get the tracks with their associated vertex Ids
   VertexTrackMap getTracks();  
-  const Acts::BoundTrackParameters* makeTrackParam(const SvtxTrack* track) const;
-  ActsVertex fitVertex(BoundTrackParamVec tracks, 
-			 Acts::Logging::Level logLevel) const;
-  std::map<const unsigned int, Trajectory> *m_actsFitResults;
 
+  /// Turn the SvtxTrack object into an Acts::TrackParameters object
+  const Acts::BoundTrackParameters* makeTrackParam(const SvtxTrack* track) const;
+
+  /// Run the Acts vertex fitter
+  ActsVertex fitVertex(BoundTrackParamVec tracks, 
+		       Acts::Logging::Level logLevel) const;
+
+  /// Runs Acts vertex fitter
   void fitVertices(std::vector<const Acts::BoundTrackParameters*> tracks);
   
+  /// Update SvtxVertex or create new SvtxVertexMap
   void createActsSvtxVertex(const unsigned int,
 			    ActsVertex vertex);
   void updateSvtxVertex(const unsigned int,
 			ActsVertex vertex);
  
-  int m_event;
+  int m_event = 0;
+
+  std::map<const unsigned int, Trajectory> *m_actsFitResults;
   ActsTrackingGeometry *m_tGeometry;
+  SvtxTrackMap *m_trackMap = nullptr;
+  SvtxVertexMap *m_vertexMap = nullptr;
+  SvtxVertexMap *m_actsVertexMap = nullptr;
 
-  SvtxTrackMap *m_trackMap;
-  SvtxVertexMap *m_vertexMap;
-  SvtxVertexMap *m_actsVertexMap;
-
+  /// Option to update the default SvtxVertexMap. A new SvtxVertexMap
+  /// called SvtxVertexMapActs is created by default in the module
   bool m_updateSvtxVertexMap = false;
 };
 

--- a/offline/packages/trackreco/PHActsVertexFitter.h
+++ b/offline/packages/trackreco/PHActsVertexFitter.h
@@ -4,11 +4,15 @@
 #include <fun4all/SubsysReco.h>
 #include "ActsTrackingGeometry.h"
 
+#include <Acts/Vertexing/Vertex.hpp>
+
 #include <ActsExamples/EventData/TrkrClusterMultiTrajectory.hpp>
 
 class PHCompositeNode;
 class SvtxTrack;
 class SvtxTrackMap;
+class SvtxVertex;
+class SvtxVertexMap;
 
 namespace Acts
 {
@@ -17,6 +21,12 @@ namespace Acts
 
 using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
 
+using BoundTrackParamVec = std::vector<const Acts::BoundTrackParameters*>;
+using VertexTrackMap = std::map<const unsigned int, 
+                                BoundTrackParamVec>;
+
+using ActsVertex = const Acts::Vertex<Acts::BoundTrackParameters>;
+
 class PHActsVertexFitter : public SubsysReco
 {
  public:
@@ -24,17 +34,36 @@ class PHActsVertexFitter : public SubsysReco
   virtual ~PHActsVertexFitter(){}
   int process_event(PHCompositeNode *topNode);
   int Init(PHCompositeNode *topNode);
+  int ResetEvent(PHCompositeNode *topNode);
   int End (PHCompositeNode *topNode);
 
 
  private:
   
   int getNodes(PHCompositeNode *topNode);
-  std::vector<const Acts::BoundTrackParameters*> getTracks();  
+  int createNodes(PHCompositeNode *topNode);
+  
+  VertexTrackMap getTracks();  
+  const Acts::BoundTrackParameters* makeTrackParam(const SvtxTrack* track) const;
+  ActsVertex fitVertex(BoundTrackParamVec tracks, 
+			 Acts::Logging::Level logLevel) const;
   std::map<const unsigned int, Trajectory> *m_actsFitResults;
 
+  void fitVertices(std::vector<const Acts::BoundTrackParameters*> tracks);
+  
+  void createActsSvtxVertex(const unsigned int,
+			    ActsVertex vertex);
+  void updateSvtxVertex(const unsigned int,
+			ActsVertex vertex);
+ 
   int m_event;
   ActsTrackingGeometry *m_tGeometry;
+
+  SvtxTrackMap *m_trackMap;
+  SvtxVertexMap *m_vertexMap;
+  SvtxVertexMap *m_actsVertexMap;
+
+  bool m_updateSvtxVertexMap = false;
 };
 
 #endif //TRACKRECO_PHACTSVERTEXFITTER_H 

--- a/offline/packages/trackreco/PHActsVertexFitter.h
+++ b/offline/packages/trackreco/PHActsVertexFitter.h
@@ -21,12 +21,11 @@ namespace Acts
 
 using Trajectory = ActsExamples::TrkrClusterMultiTrajectory;
 
-using BoundTrackParamVec = std::vector<const Acts::BoundTrackParameters*>;
-using VertexTrackMap = std::map<const unsigned int, 
+using BoundTrackParamVec = std::vector<const Acts::BoundTrackParameters *>;
+using VertexTrackMap = std::map<const unsigned int,
                                 BoundTrackParamVec>;
 
 using ActsVertex = const Acts::Vertex<Acts::BoundTrackParameters>;
-
 
 /**
  * This class runs the Acts vertex fitter on the final tracks. It is
@@ -36,41 +35,42 @@ using ActsVertex = const Acts::Vertex<Acts::BoundTrackParameters>;
 class PHActsVertexFitter : public SubsysReco
 {
  public:
-  PHActsVertexFitter(const std::string& name = "PHActsVertexFitter");
-  virtual ~PHActsVertexFitter(){}
+  PHActsVertexFitter(const std::string &name = "PHActsVertexFitter");
+  virtual ~PHActsVertexFitter() {}
   int process_event(PHCompositeNode *topNode);
   int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);
   int ResetEvent(PHCompositeNode *topNode);
-  int End (PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
 
   void updateSvtxVertexMap(bool updateSvtxVertexMap)
-    { m_updateSvtxVertexMap = updateSvtxVertexMap; }
+  {
+    m_updateSvtxVertexMap = updateSvtxVertexMap;
+  }
 
  private:
-  
   int getNodes(PHCompositeNode *topNode);
   int createNodes(PHCompositeNode *topNode);
-  
+
   /// Get the tracks with their associated vertex Ids
-  VertexTrackMap getTracks();  
+  VertexTrackMap getTracks();
 
   /// Turn the SvtxTrack object into an Acts::TrackParameters object
-  const Acts::BoundTrackParameters* makeTrackParam(const SvtxTrack* track) const;
+  const Acts::BoundTrackParameters *makeTrackParam(const SvtxTrack *track) const;
 
   /// Run the Acts vertex fitter
-  ActsVertex fitVertex(BoundTrackParamVec tracks, 
-		       Acts::Logging::Level logLevel) const;
+  ActsVertex fitVertex(BoundTrackParamVec tracks,
+                       Acts::Logging::Level logLevel) const;
 
   /// Runs Acts vertex fitter
-  void fitVertices(std::vector<const Acts::BoundTrackParameters*> tracks);
-  
+  void fitVertices(std::vector<const Acts::BoundTrackParameters *> tracks);
+
   /// Update SvtxVertex or create new SvtxVertexMap
   void createActsSvtxVertex(const unsigned int,
-			    ActsVertex vertex);
+                            ActsVertex vertex);
   void updateSvtxVertex(const unsigned int,
-			ActsVertex vertex);
- 
+                        ActsVertex vertex);
+
   int m_event = 0;
 
   std::map<const unsigned int, Trajectory> *m_actsFitResults;
@@ -84,4 +84,4 @@ class PHActsVertexFitter : public SubsysReco
   bool m_updateSvtxVertexMap = false;
 };
 
-#endif //TRACKRECO_PHACTSVERTEXFITTER_H 
+#endif  //TRACKRECO_PHACTSVERTEXFITTER_H


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR updates the z vertex fitting module to work with the SvtxVertexMap and run the final vertex fitting over tracks that have already been assigned to a found vertex. In the initial vertex finding, silicon stubs are associated to a vertex so the finding does not necessarily need to be performed again. This module can then act as a final vertex fitter and could be used in place of the IVF if desired. It needed to be updated to pull from the SvtxTrackMap and to take into account the already associated vertices from the IVF.

Note that it does not need to be included in the macros since the finder+fitter tool could also be used as a final vertex finder+fitter (i.e. this is an additional tool that could be used). However, to be used with the updated track fitting procedure including the silicon seeding, the vertex fitter needed to be updated.
