### PR TITLE
Minor change to KFParticle

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
@@ -52,9 +52,15 @@ int KFParticle_DST::createParticleNode(PHCompositeNode* topNode)
     baseName = m_container_name;
 
   //Cant have forward slashes in DST or else you make a subdirectory on save!!!
-  std::string fwd_slsh = "/", undrscr = "_";
+  std::string fwd_slsh = "/";
+  std::string open_bracket = "(";
+  std::string close_bracket = ")";
+  std::string undrscr = "_";
+  std::string nothing = "";
   size_t pos;
   while ((pos = baseName.find(fwd_slsh)) != std::string::npos) baseName.replace(pos, 1, undrscr);
+  while ((pos = baseName.find(open_bracket)) != std::string::npos) baseName.replace(pos, 1, undrscr);
+  while ((pos = baseName.find(close_bracket)) != std::string::npos) baseName.replace(pos, 1, nothing);
 
   trackNodeName = baseName + "_SvtxTrackMap";
   particleNodeName = baseName + "_KFParticle_Container";
@@ -112,12 +118,15 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, const KFPa
     baseName = m_container_name;
 
   //Cant have forward slashes in DST or else you make a subdirectory on save!!!
-  std::string fwd_slsh = "/", undrscr = "_";
+  std::string fwd_slsh = "/";
+  std::string open_bracket = "(";
+  std::string close_bracket = ")";
+  std::string undrscr = "_";
+  std::string nothing = "";
   size_t pos;
-  while ((pos = baseName.find(fwd_slsh)) != std::string::npos)
-  {
-   baseName.replace(pos, 1, undrscr);
-  }
+  while ((pos = baseName.find(fwd_slsh)) != std::string::npos) baseName.replace(pos, 1, undrscr);
+  while ((pos = baseName.find(open_bracket)) != std::string::npos) baseName.replace(pos, 1, undrscr);
+  while ((pos = baseName.find(close_bracket)) != std::string::npos) baseName.replace(pos, 1, nothing);
 
   trackNodeName = baseName + "_SvtxTrackMap";
 
@@ -177,9 +186,14 @@ void KFParticle_DST::fillParticleNode_Particle(PHCompositeNode* topNode, const K
 
   //Cant have forward slashes in DST or else you make a subdirectory on save!!!
   std::string fwd_slsh = "/";
+  std::string open_bracket = "(";
+  std::string close_bracket = ")";
   std::string undrscr = "_";
+  std::string nothing = "";
   size_t pos;
   while ((pos = baseName.find(fwd_slsh)) != std::string::npos) baseName.replace(pos, 1, undrscr);
+  while ((pos = baseName.find(open_bracket)) != std::string::npos) baseName.replace(pos, 1, undrscr);
+  while ((pos = baseName.find(close_bracket)) != std::string::npos) baseName.replace(pos, 1, nothing);
 
   particleNodeName = baseName + "_KFParticle_Container";
 
@@ -236,9 +250,15 @@ void KFParticle_DST::printNode(PHCompositeNode* topNode)
     baseName = m_container_name;
 
   //Cant have forward slashes in DST or else you make a subdirectory on save!!!
-  std::string fwd_slsh = "/", undrscr = "_";
+  std::string fwd_slsh = "/";
+  std::string open_bracket = "(";
+  std::string close_bracket = ")";
+  std::string undrscr = "_";
+  std::string nothing = "";
   size_t pos;
   while ((pos = baseName.find(fwd_slsh)) != std::string::npos) baseName.replace(pos, 1, undrscr);
+  while ((pos = baseName.find(open_bracket)) != std::string::npos) baseName.replace(pos, 1, undrscr);
+  while ((pos = baseName.find(close_bracket)) != std::string::npos) baseName.replace(pos, 1, nothing);
 
   if (m_write_track_container)
   {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -47,9 +47,14 @@ void KFParticle_nTuple::initializeBranches()
     mother_name = m_mother_name;
 
   std::string fwd_slsh = "/";
+  std::string open_bracket = "(";
+  std::string close_bracket = ")";
   std::string undrscr = "_";
+  std::string nothing = "";
   size_t pos;
   while ((pos = mother_name.find(fwd_slsh)) != std::string::npos) mother_name.replace(pos, 1, undrscr);
+  while ((pos = mother_name.find(open_bracket)) != std::string::npos) mother_name.replace(pos, 1, undrscr);
+  while ((pos = mother_name.find(close_bracket)) != std::string::npos) mother_name.replace(pos, 1, nothing);
 
   m_tree->Branch(TString(mother_name) + "_mass", &m_calculated_mother_mass, TString(mother_name) + "_mass/F");
   m_tree->Branch(TString(mother_name) + "_massErr", &m_calculated_mother_mass_err, TString(mother_name) + "_massErr/F");
@@ -98,6 +103,8 @@ void KFParticle_nTuple::initializeBranches()
 
       //Note, TBranch will not allow the leaf to contain a forward slash as it is used to define the branch type. Causes problems with J/psi
       while ((pos = intermediate_name.find(fwd_slsh)) != std::string::npos) intermediate_name.replace(pos, 1, undrscr);
+      while ((pos = intermediate_name.find(open_bracket)) != std::string::npos) intermediate_name.replace(pos, 1, undrscr);
+      while ((pos = mother_name.find(close_bracket)) != std::string::npos) mother_name.replace(pos, 1, nothing);
 
       m_tree->Branch(TString(intermediate_name) + "_mass", &m_calculated_intermediate_mass[i], TString(intermediate_name) + "_mass/F");
       m_tree->Branch(TString(intermediate_name) + "_massErr", &m_calculated_intermediate_mass_err[i], TString(intermediate_name) + "_massErr/F");

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_particleList.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_particleList.cc
@@ -64,7 +64,8 @@ std::map<std::string, particle_pair> KFParticle_particleList::getParticleList()
   std::map<std::string, particle_pair> particleMasses;
 
   //Leptons
-  particleMasses["electron"] = std::make_pair(11, kfpDatabase.GetMass(11));
+  //particleMasses["electron"] = std::make_pair(11, kfpDatabase.GetMass(11));
+  particleMasses["electron"] = std::make_pair(11, 0.000511);
   particleMasses["muon"] = std::make_pair(13, kfpDatabase.GetMass(13));
   particleMasses["tau"] = std::make_pair(15, 1.77686);
 
@@ -120,6 +121,7 @@ std::map<std::string, particle_pair> KFParticle_particleList::getParticleList()
   particleMasses["Ds*+"] = std::make_pair(433, 2.11220);
   particleMasses["Ds*-"] = std::make_pair(433, 2.11220);
   particleMasses["Lc+"] = std::make_pair(4122, 2.28646);
+  particleMasses["Lambdac"] = std::make_pair(4122, 2.28646);
   particleMasses["Lambdac+"] = std::make_pair(4122, 2.28646);
   particleMasses["Xic0"] = std::make_pair(4132, 2.47090);
   particleMasses["Xic+"] = std::make_pair(4232, 2.46794);
@@ -152,6 +154,7 @@ std::map<std::string, particle_pair> KFParticle_particleList::getParticleList()
   particleMasses["X(3872)"] = std::make_pair(0, 3.87169);
   particleMasses["chic1(3872)"] = std::make_pair(0, 3.87169);
   //b-bbar
+  particleMasses["Upsilon"] = std::make_pair(553, 9.46030);
   particleMasses["Upsilon(1S)"] = std::make_pair(553, 9.46030);
   particleMasses["Upsilon(2S)"] = std::make_pair(100553, 10.02326);
   particleMasses["Upsilon(3S)"] = std::make_pair(200553, 10.3552);


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

When testing KFParticle I noticed ROOT can't interpret branch names with parenthesis. If they appear in either the nTuple or DST output, they are now removed.

I also changed the electron mass assignment to a coded double rather than looking up the KFParticle database. It can return a low mass which confuses the daughter mass check in KFParticle_Tools

## TODOs (if applicable)

Nothing to do in KFParticle. I'm working on a Lambda_c generator for now which can be used to test KFParticle as well (and other parts of our software...)

## Links to other PRs in macros and calibration repositories (if applicable)
PR in macros to run KFParticle: https://github.com/sPHENIX-Collaboration/macros/pull/353
KFParticle will still work without this macro, you just wont be able to read branches with () such as X(3872), psi(2S), Upsilon(1S) etc
