### PR TITLE
Electron drift speedup

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -281,7 +281,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
   double ecollectedhits = 0.0;
   int ncollectedhits = 0;
   double ihit = 0;
-  int dump_interval = 5000;  // dump temp_hitsetcontainer to the node tree after every this many g4hits
+  int dump_interval = 5000;  // dump temp_hitsetcontainer to the node tree after this many g4hits
   int dump_counter = 0;
   for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
   {
@@ -300,9 +300,11 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
     unsigned int n_electrons = gsl_ran_poisson(RandomGenerator.get(), eion * electrons_per_gev);
     count_electrons += n_electrons;
 
+    /*
     if(count_g4hits%50000 == 0)
       std::cout << " g4hit->size() " << g4hit->size() << " count_g4hits " << count_g4hits << " remaining " << 
 	g4hit->size() - count_g4hits << " count_electrons " << count_electrons << std::endl;
+    */
 
     if (Verbosity() > 100)
       std::cout << "  new hit with t0, " << t0 << " g4hitid " << hiter->first
@@ -440,7 +442,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
     }  // end loop over electrons for this g4hit
 
     // Dump the temp_hitsetcontainer to the node tree and reset it 
-    //    - after every dump_interval g4hits
+    //    - after every "dump_interval" g4hits
     //    - if this is the last g4hit
     if( dump_counter >= dump_interval || count_g4hits == g4hit->size() )
       {

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -219,7 +219,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
   dtrans = new TH1F("difftrans", "transversal diffusion", 100, diffusion_trans - diffusion_trans / 2., diffusion_trans + diffusion_trans / 2.);
   se->registerHisto(dtrans);
 
-  do_ElectronDriftQAHistos = true;  // Whether or not to produce an ElectronDriftQA.root file with useful info
+  do_ElectronDriftQAHistos = false;  // Whether or not to produce an ElectronDriftQA.root file with useful info
   if (do_ElectronDriftQAHistos)
   {
     hitmapstart = new TH2F("hitmapstart", "g4hit starting X-Y locations", 1560, -78, 78, 1560, -78, 78);
@@ -274,12 +274,20 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
 
   PHG4HitContainer::ConstIterator hiter;
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
+  //std::cout << "g4hits size " << g4hit->size() << std::endl;
+  int count_g4hits = 0;
+  int count_electrons = 0;
 
   double ecollectedhits = 0.0;
   int ncollectedhits = 0;
   double ihit = 0;
+  int dump_interval = 5000;  // dump temp_hitsetcontainer to the node tree after every this many g4hits
+  int dump_counter = 0;
   for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
   {
+    count_g4hits++;
+    dump_counter++;
+
     const double t0 = fmax(hiter->second->get_t(0), hiter->second->get_t(1));
     if (t0 > max_time)
     {
@@ -290,6 +298,12 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
     // Instead, use a temporary map to accumulate the charge from all drifted electrons, then copy to the node tree later
     double eion = hiter->second->get_eion();
     unsigned int n_electrons = gsl_ran_poisson(RandomGenerator.get(), eion * electrons_per_gev);
+    count_electrons += n_electrons;
+
+    if(count_g4hits%50000 == 0)
+      std::cout << " g4hit->size() " << g4hit->size() << " count_g4hits " << count_g4hits << " remaining " << 
+	g4hit->size() - count_g4hits << " count_electrons " << count_electrons << std::endl;
+
     if (Verbosity() > 100)
       std::cout << "  new hit with t0, " << t0 << " g4hitid " << hiter->first
                 << " eion " << eion << " n_electrons " << n_electrons
@@ -425,79 +439,90 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       MapToPadPlane(x_final, y_final, z_final, hiter, ntpad, nthit);
     }  // end loop over electrons for this g4hit
 
-    // transfer the hits from temp_hitsetcontainer to hitsetcontainer on the node tree
-    double eg4hit = 0.0;
-    TrkrHitSetContainer::ConstRange temp_hitset_range = temp_hitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
-    for (TrkrHitSetContainer::ConstIterator temp_hitset_iter = temp_hitset_range.first;
-         temp_hitset_iter != temp_hitset_range.second;
-         ++temp_hitset_iter)
-    {
-      // we have an itrator to one TrkrHitSet for the Tpc from the temp_hitsetcontainer
-      TrkrDefs::hitsetkey node_hitsetkey = temp_hitset_iter->first;
-      const unsigned int layer = TrkrDefs::getLayer(node_hitsetkey);
-      const int sector = TpcDefs::getSectorId(node_hitsetkey);
-      const int side = TpcDefs::getSide(node_hitsetkey);
-      if (Verbosity() > 100)
-        std::cout << "PHG4TpcElectronDrift: temp_hitset with key: " << node_hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << std::endl;
-
-      // find or add this hitset on the node tree
-      TrkrHitSetContainer::Iterator node_hitsetit = hitsetcontainer->findOrAddHitSet(node_hitsetkey);
-
-      // get all of the hits from the temporary hitset
-      TrkrHitSet::ConstRange temp_hit_range = temp_hitset_iter->second->getHits();
-      for (TrkrHitSet::ConstIterator temp_hit_iter = temp_hit_range.first;
-           temp_hit_iter != temp_hit_range.second;
-           ++temp_hit_iter)
+    // Dump the temp_hitsetcontainer to the node tree and reset it 
+    //    - after every dump_interval g4hits
+    //    - if this is the last g4hit
+    if( dump_counter >= dump_interval || count_g4hits == g4hit->size() )
       {
-        TrkrDefs::hitkey temp_hitkey = temp_hit_iter->first;
-        TrkrHit *temp_tpchit = temp_hit_iter->second;
-        if (Verbosity() > 100 && layer == print_layer)
-        {
-          std::cout << "      temp_hitkey " << temp_hitkey << " l;ayer " << layer << " pad " << TpcDefs::getPad(temp_hitkey)
-                    << " z bin " << TpcDefs::getTBin(temp_hitkey)
-                    << "  energy " << temp_tpchit->getEnergy() << " eg4hit " << eg4hit << std::endl;
+	//std::cout << " dump_counter " << dump_counter << " count_g4hits " << count_g4hits << std::endl; 
 
-          eg4hit += temp_tpchit->getEnergy();
-          ecollectedhits += temp_tpchit->getEnergy();
-          ncollectedhits++;
-        }
+	double eg4hit = 0.0;
+	TrkrHitSetContainer::ConstRange temp_hitset_range = temp_hitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
+	for (TrkrHitSetContainer::ConstIterator temp_hitset_iter = temp_hitset_range.first;
+	     temp_hitset_iter != temp_hitset_range.second;
+	     ++temp_hitset_iter)
+	  {
+	    // we have an itrator to one TrkrHitSet for the Tpc from the temp_hitsetcontainer
+	    TrkrDefs::hitsetkey node_hitsetkey = temp_hitset_iter->first;
+	    const unsigned int layer = TrkrDefs::getLayer(node_hitsetkey);
+	    const int sector = TpcDefs::getSectorId(node_hitsetkey);
+	    const int side = TpcDefs::getSide(node_hitsetkey);
+	    if (Verbosity() > 100)
+	      std::cout << "PHG4TpcElectronDrift: temp_hitset with key: " << node_hitsetkey << " in layer " << layer << " with sector " << sector << " side " << side << std::endl;
+	    
+	    // find or add this hitset on the node tree
+	    TrkrHitSetContainer::Iterator node_hitsetit = hitsetcontainer->findOrAddHitSet(node_hitsetkey);
+	    
+	    // get all of the hits from the temporary hitset
+	    TrkrHitSet::ConstRange temp_hit_range = temp_hitset_iter->second->getHits();
+	    for (TrkrHitSet::ConstIterator temp_hit_iter = temp_hit_range.first;
+		 temp_hit_iter != temp_hit_range.second;
+		 ++temp_hit_iter)
+	      {
+		TrkrDefs::hitkey temp_hitkey = temp_hit_iter->first;
+		TrkrHit *temp_tpchit = temp_hit_iter->second;
+		if (Verbosity() > 100 && layer == print_layer)
+		  {
+		    std::cout << "      temp_hitkey " << temp_hitkey << " l;ayer " << layer << " pad " << TpcDefs::getPad(temp_hitkey)
+			      << " z bin " << TpcDefs::getTBin(temp_hitkey)
+			      << "  energy " << temp_tpchit->getEnergy() << " eg4hit " << eg4hit << std::endl;
+		    
+		    eg4hit += temp_tpchit->getEnergy();
+		    ecollectedhits += temp_tpchit->getEnergy();
+		    ncollectedhits++;
+		  }
+		
+		// find or add this hit to the node tree
+		TrkrHit *node_hit = node_hitsetit->second->getHit(temp_hitkey);
+		if (!node_hit)
+		  {
+		    // Otherwise, create a new one
+		    node_hit = new TpcHit();
+		    node_hitsetit->second->addHitSpecificKey(temp_hitkey, node_hit);
+		    
+		    // Add the hit-g4hit association
+		    // no need to check for duplicates, since the hit is new
+		    hittruthassoc->addAssoc(node_hitsetkey, temp_hitkey, hiter->first);
+		  }
+		else
+		  {
+		    // Add the hit-g4hit association
+		    // TODO: check if duplication can happen
+		    hittruthassoc->findOrAddAssoc(node_hitsetkey, temp_hitkey, hiter->first);
+		  }
+		
+		// Either way, add the energy to it
+		node_hit->addEnergy(temp_tpchit->getEnergy());
+		
+	      }  // end loop over temp hits
+	    
+	    if (Verbosity() > 100 && layer == print_layer)
+	      std::cout << "  ihit " << ihit << " collected energy = " << eg4hit << std::endl;
+	    
+	    
+	  }  // end loop over temp hitsets
+	
+	// erase all entries in the temp hitsetcontainer
+	temp_hitsetcontainer->Reset();
 
-        // find or add this hit to the node tree
-        TrkrHit *node_hit = node_hitsetit->second->getHit(temp_hitkey);
-        if (!node_hit)
-        {
-          // Otherwise, create a new one
-          node_hit = new TpcHit();
-          node_hitsetit->second->addHitSpecificKey(temp_hitkey, node_hit);
-
-          // Add the hit-g4hit association
-          // no need to check for duplicates, since the hit is new
-          hittruthassoc->addAssoc(node_hitsetkey, temp_hitkey, hiter->first);
-        }
-        else
-        {
-          // Add the hit-g4hit association
-          // TODO: check if duplication can happen
-          hittruthassoc->findOrAddAssoc(node_hitsetkey, temp_hitkey, hiter->first);
-        }
-
-        // Either way, add the energy to it
-        node_hit->addEnergy(temp_tpchit->getEnergy());
-
-      }  // end loop over temp hits
-
-      if (Verbosity() > 100 && layer == print_layer)
-        std::cout << "  ihit " << ihit << " collected energy = " << eg4hit << std::endl;
-
-    }  // end loop over temp hitsets
-
-    // erase all entries in the temp hitsetcontainer
-    temp_hitsetcontainer->Reset();
-
+	// reset the dump counter
+	dump_counter = 0;
+      }  // end copy of temp hitsetcontainer to node tree hitsetcontainer
+    
     ++ihit;
 
   }  // end loop over g4hits
-
+  
   if (Verbosity() > 2)
   {
     std::cout << "From PHG4TpcElectronDrift: hitsetcontainer printout at end:" << std::endl;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The observed slowness of PHG4TpcElectronDrift when running the MDC is addressed. It was due to the overhead of searching the TrkrHitsSetContainer to check if a new hitset and/or hit was already present on the node tree. The new hitsets were previously buffered in a temporary TrkrHitSetContainer for one g4hit worth of electrons. The map search time increases quadratically with the number of g4hits, and becomes unacceptable for events with several million g4hits. This PR increases the number of g4hits buffered in the temporary TrkrHitSetContainer to 5000, which appears to be about optimum. This reduces the number of times the full map on the node tree has to be searched. The time used by PHG4TpcElectronDrift for a test event decreased from about 240 minutes to 24 minutes. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

