### PR TITLE
need to use LIBADD when libs dependency affects build order

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/Makefile.am
+++ b/offline/packages/KFParticle_sPHENIX/Makefile.am
@@ -6,7 +6,8 @@ lib_LTLIBRARIES = \
 
 AM_LDFLAGS = \
   -L$(libdir) \
-  -L$(OFFLINE_MAIN)/lib
+  -L$(OFFLINE_MAIN)/lib \
+  `root-config --libs`
 
 AM_CPPFLAGS = \
   -I$(includedir) \
@@ -48,17 +49,11 @@ libkfparticle_sphenix_la_SOURCES = \
   KFParticle_eventReconstruction.cc \
   KFParticle_sPHENIX.cc
 
-libkfparticle_sphenix_io_la_LDFLAGS = \
-  -L$(libdir) \
-  -L$(OFFLINE_MAIN)/lib \
+libkfparticle_sphenix_io_la_LIBADD = \
   -lKFParticle \
   -lphool
 
-libkfparticle_sphenix_la_LDFLAGS = \
-  -L$(libdir) \
-  -L$(OFFLINE_MAIN)/lib \
-  -L$(ROOTSYS)/lib \
-  `root-config --libs` \
+libkfparticle_sphenix_la_LIBADD = \
   libkfparticle_sphenix_io.la \
   -lcalo_io \
   -lfun4all \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <This PR fixes a race condition in the KFParticle_sPHENIX package. The io lib was added under LDADD which is basically reserved for library paths. Libraries are added via LIBADD. Then they are build in the proper order so dependencies among them are satisfied> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

