### PR TITLE
Acts Silicon Seeding Improvements

### DIFF
--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -95,6 +95,11 @@ int PHActsInitialVertexFinder::ResetEvent(PHCompositeNode *topNode)
 
 int PHActsInitialVertexFinder::End(PHCompositeNode *topNode)
 {
+
+  std::cout << "Acts IVF succeeded " << m_successFits 
+	    << " out of " << m_totVertexFits << " total fits"
+	    << std::endl;
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -166,9 +171,11 @@ void PHActsInitialVertexFinder::fillVertexMap(VertexVector& vertices,
 
 VertexVector PHActsInitialVertexFinder::findVertices(TrackParamVec& tracks)
 {
+
+  m_totVertexFits++;
+
   /// Determine the input mag field type from the initial geometry
   /// and run the vertex finding with the determined mag field
-
   return std::visit([tracks, this](auto &inputField) {
       /// Setup aliases
       using InputMagneticField = 
@@ -237,6 +244,8 @@ VertexVector PHActsInitialVertexFinder::findVertices(TrackParamVec& tracks)
 
       if(result.ok())
 	{
+	  m_successFits++;
+
 	  auto vertexCollection = *result;
 	  
 	  if(Verbosity() > 1)
@@ -324,7 +333,7 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
 int PHActsInitialVertexFinder::getNodes(PHCompositeNode *topNode)
 {
 
-  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxSiliconTrackMap");
+  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
   if(!m_trackMap)
     {
       std::cout << PHWHERE << "No SvtxTrackMap on node tree, bailing."

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -261,11 +261,18 @@ VertexVector PHActsInitialVertexFinder::findVertices(TrackParamVec& tracks)
 	}
       else
 	{
-	  if(Verbosity() > 1)
+	  if(Verbosity() > 0)
 	    {
-	      std::cout << "Acts vertex finder returned error: " 
+	      std::cout << "Acts initial vertex finder returned error: " 
 			<< result.error().message() << std::endl;
-	    }	  
+	      std::cout << "Track positions IVF used are : " << std::endl;
+	      for(const auto track : tracks)
+		{
+		  const auto position = track->position(m_tGeometry->geoContext);
+		  std::cout << "(" << position(0) << ", " << position(1)
+			    << ", " << position(2) << std::endl;
+		}
+	    }
 	}
     
       return vertexVector;

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -333,7 +333,7 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
 int PHActsInitialVertexFinder::getNodes(PHCompositeNode *topNode)
 {
 
-  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxSiliconTrackMap");
   if(!m_trackMap)
     {
       std::cout << PHWHERE << "No SvtxTrackMap on node tree, bailing."

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.h
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.h
@@ -46,11 +46,13 @@ class PHActsInitialVertexFinder: public PHInitVertexing
   
   TrackParamVec getTrackPointers(InitKeyMap& keyMap);
   VertexVector findVertices(TrackParamVec& tracks);
-void fillVertexMap(VertexVector& vertices, InitKeyMap& keyMap);
+  void fillVertexMap(VertexVector& vertices, InitKeyMap& keyMap);
   
   int m_maxVertices = 10;
   int m_event = 0;
-  
+  unsigned int m_totVertexFits = 0;
+  unsigned int m_successFits = 0;
+
   SvtxTrackMap *m_trackMap = nullptr;
   SvtxVertexMap *m_vertexMap = nullptr;
   ActsTrackingGeometry *m_tGeometry = nullptr;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -87,6 +87,9 @@ class PHActsSiliconSeeding : public SubsysReco
   /// Output some diagnostic histograms
   void seedAnalysis(bool seedAnalysis)
     { m_seedAnalysis = seedAnalysis; }
+  
+  void secondFit(bool secondFit)
+    { m_secondFit = secondFit; }
    
  private:
 

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -113,8 +113,9 @@ class PHActsSiliconSeeding : public SubsysReco
   /// Perform circle/line fits with the final MVTX seed to get
   /// initial point and momentum estimates for stub matching
   int circleFitSeed(std::vector<TrkrCluster*>& clusters,
-		     double& x, double& y, double& z,
-		     double& px, double& py, double& pz);
+		    double& x, double& y, double& z,
+		    double& px, double& py, double& pz,
+		    bool secondPass);
   void circleFitByTaubin(const std::vector<TrkrCluster*>& clusters,
 			 double& R, double& X0, double& Y0);
   void lineFit(const std::vector<TrkrCluster*>& clusters,
@@ -199,7 +200,7 @@ class PHActsSiliconSeeding : public SubsysReco
 
   int m_event = 0;
 
-  double m_maxSeedPCA = 0.01;
+  double m_maxSeedPCA = 0.03;
   
   const static unsigned int m_nInttLayers = 4;
   const double m_nInttLayerRadii[m_nInttLayers] = 
@@ -217,6 +218,7 @@ class PHActsSiliconSeeding : public SubsysReco
   TH1 *h_nInttHits = nullptr;
   TH2 *h_nHits = nullptr;
   TH1 *h_nSeeds = nullptr;
+  TH1 *h_nActsSeeds = nullptr;
   TH1 *h_nTotSeeds = nullptr;
   TH1 *h_nInputMeas = nullptr;
   TH1 *h_nInputMvtxMeas = nullptr;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -88,9 +88,6 @@ class PHActsSiliconSeeding : public SubsysReco
   void seedAnalysis(bool seedAnalysis)
     { m_seedAnalysis = seedAnalysis; }
   
-  void secondFit(bool secondFit)
-    { m_secondFit = secondFit; }
-   
  private:
 
   int getNodes(PHCompositeNode *topNode);
@@ -117,8 +114,8 @@ class PHActsSiliconSeeding : public SubsysReco
   /// initial point and momentum estimates for stub matching
   int circleFitSeed(std::vector<TrkrCluster*>& clusters,
 		    double& x, double& y, double& z,
-		    double& px, double& py, double& pz,
-		    bool secondPass);
+		    double& px, double& py, double& pz);
+
   void circleFitByTaubin(const std::vector<TrkrCluster*>& clusters,
 			 double& R, double& X0, double& Y0);
   void lineFit(const std::vector<TrkrCluster*>& clusters,
@@ -203,7 +200,8 @@ class PHActsSiliconSeeding : public SubsysReco
 
   int m_event = 0;
 
-  double m_maxSeedPCA = 0.01;
+  /// Maximum allowed transverse PCA for seed, cm
+  double m_maxSeedPCA = 0.1;
   
   const static unsigned int m_nInttLayers = 4;
   const double m_nInttLayerRadii[m_nInttLayers] = 
@@ -214,10 +212,6 @@ class PHActsSiliconSeeding : public SubsysReco
 
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;
-
-  /// Whether or not to run a second circle fit after
-  /// INTT clusters are matched
-  bool m_secondFit = false;
 
   int m_nBadUpdates = 0;
   int m_nBadInitialFits = 0;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -200,7 +200,7 @@ class PHActsSiliconSeeding : public SubsysReco
 
   int m_event = 0;
 
-  double m_maxSeedPCA = 0.03;
+  double m_maxSeedPCA = 0.01;
   
   const static unsigned int m_nInttLayers = 4;
   const double m_nInttLayerRadii[m_nInttLayers] = 
@@ -212,6 +212,13 @@ class PHActsSiliconSeeding : public SubsysReco
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;
 
+  /// Whether or not to run a second circle fit after
+  /// INTT clusters are matched
+  bool m_secondFit = false;
+
+  int m_nBadUpdates = 0;
+  int m_nBadInitialFits = 0;
+  
   bool m_seedAnalysis = false;
   TFile *m_file = nullptr;
   TH1 *h_nMvtxHits = nullptr;


### PR DESCRIPTION

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR updates the seeding code with some diagnostic verbosity statements and histograms. It also adds a second circle fit iteration after the INTT clusters are added to the track stubs to improve the momentum magnitude estimate. The efficiency and overall performance of the seeder, as it is in the state of this PR, will be discussed at the tracking meeting tomorrow, linked [here](https://indico.bnl.gov/event/10465/).

## TODOs (if applicable)

## Links to other PRs in macros and calibration repositories (if applicable)

