### PR TITLE
Overload equality operators for PHG4TruthInfoContainer and PHG4Shower

### DIFF
--- a/simulation/g4simulation/g4main/PHG4Shower.h
+++ b/simulation/g4simulation/g4main/PHG4Shower.h
@@ -88,6 +88,7 @@ class PHG4Shower : public PHObject
   virtual ParticleIdConstIter end_g4particle_id() const { return ParticleIdSet().end(); }
   virtual size_t remove_g4particle_id(int id) { return 0; }
   virtual void clear_g4particle_id() {}
+  virtual const ParticleIdSet& g4particle_ids() const = 0;
 
   virtual bool empty_g4vertex_id() const { return true; }
   virtual size_t size_g4vertex_id() const { return 0; }
@@ -98,6 +99,7 @@ class PHG4Shower : public PHObject
   virtual VertexIdConstIter end_g4vertex_id() const { return VertexIdSet().end(); }
   virtual size_t remove_g4vertex_id(int id) { return 0; }
   virtual void clear_g4vertex_id() {}
+  virtual const VertexIdSet& g4vertex_ids() const = 0;
 
   virtual bool empty_g4hit_id() const { return true; }
   virtual size_t size_g4hit_id() const { return 0; }
@@ -111,6 +113,7 @@ class PHG4Shower : public PHObject
   virtual size_t remove_g4hit_id(int volume, PHG4HitDefs::keytype id) { return 0; }
   virtual size_t remove_g4hit_volume(int volume) { return 0; }
   virtual void clear_g4hit_id() {}
+  virtual const HitIdMap& g4hit_ids() const = 0;
 
  protected:
   PHG4Shower() {}

--- a/simulation/g4simulation/g4main/PHG4Shower.h
+++ b/simulation/g4simulation/g4main/PHG4Shower.h
@@ -122,4 +122,26 @@ class PHG4Shower : public PHObject
   ClassDef(PHG4Shower, 1);
 };
 
+
+/**
+ * Equality operators for PHG4TruthInfoContainer. Note that the comparison is
+ * performed only on the publicly accessible members.
+ */
+///@{
+inline bool operator==(const PHG4Shower& lhs, const PHG4Shower& rhs)
+{
+  return lhs.get_id()                 == rhs.get_id()                 &&
+         lhs.get_parent_particle_id() == rhs.get_parent_particle_id() &&
+         lhs.get_parent_shower_id()   == rhs.get_parent_shower_id()   &&
+         lhs.get_x()                  == rhs.get_x()                  &&
+         lhs.get_y()                  == rhs.get_y()                  &&
+         lhs.get_z()                  == rhs.get_z()                  &&
+         lhs.g4particle_ids()         == rhs.g4particle_ids()         &&
+         lhs.g4vertex_ids()           == rhs.g4vertex_ids()           &&
+         lhs.g4hit_ids()              == rhs.g4hit_ids();
+}
+
+inline bool operator!=(const PHG4Shower& lhs, const PHG4Shower& rhs) { return !(lhs == rhs); }
+///@}
+
 #endif

--- a/simulation/g4simulation/g4main/PHG4Showerv1.h
+++ b/simulation/g4simulation/g4main/PHG4Showerv1.h
@@ -78,6 +78,7 @@ class PHG4Showerv1 : public PHG4Shower
   PHG4Shower::ParticleIdConstIter end_g4particle_id() const { return _g4particle_ids.end(); }
   size_t remove_g4particle_id(int id) { return _g4particle_ids.erase(id); }
   void clear_g4particle_id() { return _g4particle_ids.clear(); }
+  const ParticleIdSet& g4particle_ids() const { return _g4particle_ids; }
 
   bool empty_g4vertex_id() const { return _g4vertex_ids.empty(); }
   size_t size_g4vertex_id() const { return _g4vertex_ids.size(); }
@@ -88,6 +89,7 @@ class PHG4Showerv1 : public PHG4Shower
   PHG4Shower::VertexIdConstIter end_g4vertex_id() const { return _g4vertex_ids.end(); }
   size_t remove_g4vertex_id(int id) { return _g4vertex_ids.erase(id); }
   void clear_g4vertex_id() { return _g4vertex_ids.clear(); }
+  const VertexIdSet& g4vertex_ids() const { return _g4vertex_ids; }
 
   bool empty_g4hit_id() const { return _g4hit_ids.empty(); }
   size_t size_g4hit_id() const { return _g4hit_ids.size(); }
@@ -101,6 +103,7 @@ class PHG4Showerv1 : public PHG4Shower
   size_t remove_g4hit_id(int volume, PHG4HitDefs::keytype id) { return _g4hit_ids[volume].erase(id); }
   size_t remove_g4hit_volume(int volume) { return _g4hit_ids.erase(volume); }
   void clear_g4hit_id() { return _g4hit_ids.clear(); }
+  const HitIdMap& g4hit_ids() const { return _g4hit_ids; }
 
  private:
   unsigned int covar_index(unsigned int i, unsigned int j) const;

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -347,3 +347,18 @@ int PHG4TruthInfoContainer::GetPrimaryVertexIndex() const
 
   return vtx_id_for_highest_embedding_ID;
 }
+
+bool operator==(const PHG4TruthInfoContainer::Map::value_type& lhs, const PHG4TruthInfoContainer::Map::value_type& rhs)
+{
+  return *lhs.second == *rhs.second;
+}
+
+bool operator==(const PHG4TruthInfoContainer::VtxMap::value_type& lhs, const PHG4TruthInfoContainer::VtxMap::value_type& rhs)
+{
+  return *lhs.second == *rhs.second;
+}
+
+bool operator==(const PHG4TruthInfoContainer::ShowerMap::value_type& lhs, const PHG4TruthInfoContainer::ShowerMap::value_type& rhs)
+{
+  return *lhs.second == *rhs.second;
+}

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -229,4 +229,30 @@ class PHG4TruthInfoContainer : public PHObject
   ClassDef(PHG4TruthInfoContainer, 1)
 };
 
+
+/**
+ * Equality operators for the types used in the publicly accessible internal
+ * containers of PHG4TruthInfoContainer.
+ */
+///@{
+bool operator==(const PHG4TruthInfoContainer::Map::value_type& lhs, const PHG4TruthInfoContainer::Map::value_type& rhs);
+bool operator==(const PHG4TruthInfoContainer::VtxMap::value_type& lhs, const PHG4TruthInfoContainer::VtxMap::value_type& rhs);
+bool operator==(const PHG4TruthInfoContainer::ShowerMap::value_type& lhs, const PHG4TruthInfoContainer::ShowerMap::value_type& rhs);
+///@}
+
+/**
+ * Equality operators for PHG4TruthInfoContainer. Note that the comparison is
+ * performed only on the publicly accessible internal containers, i.e.
+ * PHG4TruthInfoContainer::particlemap, PHG4TruthInfoContainer::vtxmap, and
+ * PHG4TruthInfoContainer::showermap.
+ */
+///@{
+inline bool operator==(const PHG4TruthInfoContainer& lhs, const PHG4TruthInfoContainer& rhs)
+{
+  return lhs.GetMap() == rhs.GetMap() && lhs.GetVtxMap() == rhs.GetVtxMap() && lhs.GetShowerMap() == rhs.GetShowerMap();
+}
+
+inline bool operator!=(const PHG4TruthInfoContainer& lhs, const PHG4TruthInfoContainer& rhs) { return !(lhs == rhs); }
+///@}
+
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

The equality operators for the truth container will help to streamline the comparison of the created output data during refactoring

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

