### PR TITLE
reduce chatter of pileupmanager

### DIFF
--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -198,7 +198,10 @@ int Fun4AllDstPileupInputManager::run(const int nevents)
       if( result != 0 ) return result;
 
       // merge
-      std::cout << "Fun4AllDstPileupInputManager::run - merged background event " << m_ievent_thisfile << " time: " << crossing_time << std::endl;
+      if (Verbosity() > 0)
+      {
+	std::cout << "Fun4AllDstPileupInputManager::run - merged background event " << m_ievent_thisfile << " time: " << crossing_time << std::endl;
+      }
       merger.copy_background_event(m_dstNodeInternal.get(), crossing_time);
 
     }

--- a/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.cc
@@ -221,7 +221,10 @@ readagain:
   }
 
   // load relevant DST nodes to internal pointers
-  std::cout << "Fun4AllSingleDstPileupInputManager::run - loaded event " << m_ievent_thisfile - 1 << std::endl;
+  if (Verbosity() > 0)
+  {
+    std::cout << "Fun4AllSingleDstPileupInputManager::run - loaded event " << m_ievent_thisfile - 1 << std::endl;
+  }
 
   Fun4AllDstPileupMerger merger;
   merger.load_nodes(m_dstNode);
@@ -244,7 +247,11 @@ readagain:
       if(!m_IManager_background->read(m_dstNodeInternal.get(), ievent_thisfile) ) break;
 
       // merge
-      std::cout << "Fun4AllSingleDstPileupInputManager::run - merged background event " << ievent_thisfile << " time: " << crossing_time << std::endl;
+
+      if (Verbosity() > 0)
+      {
+	std::cout << "Fun4AllSingleDstPileupInputManager::run - merged background event " << ievent_thisfile << " time: " << crossing_time << std::endl;
+      }
       merger.copy_background_event(m_dstNodeInternal.get(), crossing_time);
 
       ++neventsbackground;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

I see some evidence that the chattering of the pileup manager in pp which goes into the logs impacts gpfs performance. This puts the cout's behind a verbosity check (>0)
## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

