### PR TITLE
Fix to KFParticle DST output

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
@@ -150,8 +150,9 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, const KFPa
     }
   }
 
-  //I used to need to copy this track map to avoid crashes with truth matching
+  //When you build the daughter track, the track vanishes from the original track map, making a clone fixes this
   SvtxTrackMap* originalTrackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  SvtxTrackMap* originalTrackMap_copy = dynamic_cast<SvtxTrackMap*>(originalTrackMap->CloneMe());
   KFParticle* daughterArray = &daughters[0];
 
   for (unsigned int k = 0; k < daughters.size(); ++k)
@@ -163,8 +164,7 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, const KFPa
     }
     else
     {
-      //m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap_copy);
-      m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap);
+      m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap_copy);
     }
 
     m_recoTrackMap->insert(m_recoTrack);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
@@ -150,9 +150,7 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, const KFPa
     }
   }
 
-  //When you build the daughter track, the track vanishes from the original track map, making a clone fixes this
   SvtxTrackMap* originalTrackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
-  SvtxTrackMap* originalTrackMap_copy = dynamic_cast<SvtxTrackMap*>(originalTrackMap->CloneMe());
   KFParticle* daughterArray = &daughters[0];
 
   for (unsigned int k = 0; k < daughters.size(); ++k)
@@ -164,11 +162,10 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, const KFPa
     }
     else
     {
-      m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap_copy);
+      m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap);
     }
 
     m_recoTrackMap->insert(m_recoTrack);
-    m_recoTrack->Reset();
   }
 }
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -126,7 +126,7 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
       if (m_verbosity > 0)
       {
         printParticles(mother[i], vertex[i], daughters[i], intermediates[i], nPVs, multiplicity);
-        if (m_save_dst) printNode(topNode);
+        if (m_save_dst && m_verbosity > 1) printNode(topNode);
       }
     }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -39,7 +39,6 @@ std::map<std::string, particle_pair> particleList = kfp_list.getParticleList();
 /// KFParticle constructor
 KFParticle_sPHENIX::KFParticle_sPHENIX()
   : SubsysReco("KFPARTICLE")
-  , m_verbosity(0)
   , m_has_intermediates_sPHENIX(false)
   , m_constrain_to_vertex_sPHENIX(false)
   , m_require_mva(false)
@@ -52,7 +51,6 @@ KFParticle_sPHENIX::KFParticle_sPHENIX()
 
 KFParticle_sPHENIX::KFParticle_sPHENIX(const std::string &name)
   : SubsysReco(name)
-  , m_verbosity(0)
   , m_has_intermediates_sPHENIX(false)
   , m_constrain_to_vertex_sPHENIX(false)
   , m_require_mva(false)
@@ -68,7 +66,7 @@ int KFParticle_sPHENIX::Init(PHCompositeNode *topNode)
   if (m_save_output)
   {
     m_outfile = new TFile(m_outfile_name.c_str(), "RECREATE");
-    if (m_verbosity > 0) std::cout << "Output nTuple: " << m_outfile_name << std::endl;
+    if (Verbosity() >= VERBOSITY_SOME) std::cout << "Output nTuple: " << m_outfile_name << std::endl;
     initializeBranches();
   }
 
@@ -101,14 +99,14 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
   SvtxVertexMap *check_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, m_vtx_map_node_name);
   if (check_vertexmap->size() == 0)
   {
-    if (m_verbosity > 0) std::cout << "KFParticle: Event skipped as there are no vertices" << std::endl;
+    if (Verbosity() >= VERBOSITY_SOME) std::cout << "KFParticle: Event skipped as there are no vertices" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   SvtxTrackMap *check_trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name);
   if (check_trackmap->size() == 0)
   {
-    if (m_verbosity > 0) std::cout << "KFParticle: Event skipped as there are no tracks" << std::endl;
+    if (Verbosity() >= VERBOSITY_SOME) std::cout << "KFParticle: Event skipped as there are no tracks" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -123,9 +121,12 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
       if (m_save_output) fillBranch(topNode, mother[i], vertex[i], daughters[i], intermediates[i], nPVs, multiplicity);
       if (m_save_dst) fillParticleNode(topNode, mother[i], daughters[i], intermediates[i]);
 
-      if (m_verbosity > 0)
+      if (Verbosity() >= VERBOSITY_SOME)
       {
         printParticles(mother[i], vertex[i], daughters[i], intermediates[i], nPVs, multiplicity);
+      }
+      if (Verbosity() >= VERBOSITY_MORE)
+      {
         if (m_save_dst) printNode(topNode);
       }
     }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -126,7 +126,10 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
       if (m_verbosity > 0)
       {
         printParticles(mother[i], vertex[i], daughters[i], intermediates[i], nPVs, multiplicity);
-        if (m_save_dst && m_verbosity > 1) printNode(topNode);
+      }
+      if (m_verbosity > 1) 
+      {
+        if (m_save_dst) printNode(topNode);
       }
     }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -126,9 +126,6 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
       if (m_verbosity > 0)
       {
         printParticles(mother[i], vertex[i], daughters[i], intermediates[i], nPVs, multiplicity);
-      }
-      if (m_verbosity > 1) 
-      {
         if (m_save_dst) printNode(topNode);
       }
     }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -192,8 +192,6 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMVACutValue(float cut_value) { m_mva_cut_value = cut_value; }
 
-  void Verbosity(int verbosity) { m_verbosity = verbosity; }
-
   void saveDST(bool save) { m_save_dst = save; }
 
   void saveTrackContainer(bool save) { m_write_track_container = save; }
@@ -217,7 +215,6 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
   void setTrackMapNodeName(const std::string& trk_map_node_name) { m_trk_map_node_name = trk_map_node_name; }
 
  private:
-  bool m_verbosity;
   bool m_has_intermediates_sPHENIX;
   bool m_constrain_to_vertex_sPHENIX;
   bool m_require_mva;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I noticed when generating MDC data that when creating a track map for the loose reconstruction, the tracks used disappear from the original track map rather than being copied from them. I cloned the original track map then made the new container from there which keeps the original tracks in place. This might be related to the crash from jet truth matching which could be trying to access the missing tracks.

I also increased the verbosity level for the DST class as it mostly duplicates the basic reconstruction output and would thus be annoying for most users.
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

Run a slow valgrind test after this patch to see if it fixes the conflict with the jet truth matching

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

