### PR TITLE
Fail safe for IVF in single particle sims

### DIFF
--- a/offline/packages/trackreco/PHActsInitialVertexFinder.h
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.h
@@ -47,6 +47,7 @@ class PHActsInitialVertexFinder: public PHInitVertexing
   TrackParamVec getTrackPointers(InitKeyMap& keyMap);
   VertexVector findVertices(TrackParamVec& tracks);
   void fillVertexMap(VertexVector& vertices, InitKeyMap& keyMap);
+  void createDummyVertex();
   
   int m_maxVertices = 10;
   int m_event = 0;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -53,8 +53,11 @@ int PHActsSiliconSeeding::Init(PHCompositeNode *topNode)
 
   if(m_seedAnalysis)
     {
-      createHistograms();
+      
+      m_file = new TFile("seedingOutfile.root","recreate");
     }
+  createHistograms();
+    
   
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -1186,7 +1189,6 @@ void PHActsSiliconSeeding::writeHistograms()
 
 void PHActsSiliconSeeding::createHistograms()
 {
-  m_file = new TFile("seedingOutfile.root","recreate");
   h_nMvtxHits = new TH1I("nMvtxHits",";N_{MVTX}",6,0,6);
   h_nInttHits = new TH1I("nInttHits",";N_{INTT}",80,0,80);
   h_nHits = new TH2I("nHits",";N_{MVTX};N_{INTT}",10,0,10,

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -51,7 +51,10 @@ int PHActsSiliconSeeding::Init(PHCompositeNode *topNode)
   m_seedFinderCfg.seedFilter = std::make_unique<Acts::SeedFilter<SpacePoint>>(
      Acts::SeedFilter<SpacePoint>(sfCfg));
 
-  createHistograms();
+  if(m_seedAnalysis)
+    {
+      createHistograms();
+    }
   
   return Fun4AllReturnCodes::EVENT_OK;
 }


### PR DESCRIPTION

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

The Acts initial vertex finder fails when there is only a single track in the event, which is not ideal for single particle simulations. Jenkins pulled this up after making the Acts silicon seeder + IVF default. This PR creates a catch for this by creating a single vertex at (0,0,0) with a large covariance so that the rest of the track fitting can be run without seg faulting.

## TODOs (if applicable)

It remains to be investigated the performance of the IVF in low track situations, which will inevitably come up in p+p collisions. At some point we will need to understand the validity of the IVF and when it fails in low track situations, and create a more permanent solution for these cases.

## Links to other PRs in macros and calibration repositories (if applicable)

Macros [PR](https://github.com/sPHENIX-Collaboration/macros/pull/359) making Acts silicon seeder default.
