### PR TITLE
Trap vertex error

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -250,7 +250,11 @@ int PHSiliconTpcTrackMatching::Process()
 	  else
 	    {
 	      std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId << " associated with TPC tracklet " << _tracklet_tpc->get_id() << std::endl; 
+	      std::cout << " ---------- Silicon track --------------" << std::endl;
+	      _tracklet_si->identify();
+	      std::cout << " ---------- TPC track -----------------" << std::endl;
 	      _tracklet_tpc->identify();
+
 	      _tracklet_tpc->set_x(0.0);
 	      _tracklet_tpc->set_y(0.0);
 	      _tracklet_tpc->set_z(0.0);
@@ -297,7 +301,11 @@ int PHSiliconTpcTrackMatching::Process()
 	      else
 		{
 		  std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId << " associated with TPC tracklet " << _tracklet_tpc->get_id() << std::endl; 
+		  std::cout << " ---------- Silicon track --------------" << std::endl;
+		  _tracklet_si->identify();
+		  std::cout << " ---------- TPC track -----------------" << std::endl;
 		  _tracklet_tpc->identify();
+
 		  _tracklet_tpc->set_x(0.0);
 		  _tracklet_tpc->set_y(0.0);
 		  _tracklet_tpc->set_z(0.0);
@@ -340,6 +348,9 @@ int PHSiliconTpcTrackMatching::Process()
 	      else
 		{
 		  std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId << " associated with TPC tracklet " << _tracklet_tpc->get_id() << std::endl; 
+		  std::cout << " ---------- Silicon track --------------" << std::endl;
+		  _tracklet_si->identify();
+		  std::cout << " ---------- TPC track -----------------" << std::endl;
 		  _tracklet_tpc->identify();
 		  newTrack->set_x(0.0);
 		  newTrack->set_y(0.0);

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -241,11 +241,22 @@ int PHSiliconTpcTrackMatching::Process()
 	  
 	  // set the track position to the vertex position
 	  const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);      
-	  _tracklet_tpc->set_x(svtxVertex->get_x());
-	  _tracklet_tpc->set_y(svtxVertex->get_y());
-	  _tracklet_tpc->set_z(svtxVertex->get_z());
+	  if(svtxVertex)
+	    {
+	      _tracklet_tpc->set_x(svtxVertex->get_x());
+	      _tracklet_tpc->set_y(svtxVertex->get_y());
+	      _tracklet_tpc->set_z(svtxVertex->get_z());
+	    }
+	  else
+	    {
+	      std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId << " associated with TPC tracklet " << _tracklet_tpc->get_id() << std::endl; 
+	      _tracklet_tpc->identify();
+	      _tracklet_tpc->set_x(0.0);
+	      _tracklet_tpc->set_y(0.0);
+	      _tracklet_tpc->set_z(0.0);
+	    }
 	}
- 
+
       // Add the silicon clusters to the track
       unsigned int isi = 0;
       for(auto si_it = si_matches.begin(); si_it != si_matches.end(); ++si_it)
@@ -277,10 +288,20 @@ int PHSiliconTpcTrackMatching::Process()
 
 	      // set the track position to the vertex position
 	      const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);      
-	      _tracklet_tpc->set_x(svtxVertex->get_x());
-	      _tracklet_tpc->set_y(svtxVertex->get_y());
-	      _tracklet_tpc->set_z(svtxVertex->get_z());
-	      
+	      if(svtxVertex)
+		{
+		  _tracklet_tpc->set_x(svtxVertex->get_x());
+		  _tracklet_tpc->set_y(svtxVertex->get_y());
+		  _tracklet_tpc->set_z(svtxVertex->get_z());
+		}
+	      else
+		{
+		  std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId << " associated with TPC tracklet " << _tracklet_tpc->get_id() << std::endl; 
+		  _tracklet_tpc->identify();
+		  _tracklet_tpc->set_x(0.0);
+		  _tracklet_tpc->set_y(0.0);
+		  _tracklet_tpc->set_z(0.0);
+		}
 	      for(auto clus_iter=si_clusters.begin(); clus_iter != si_clusters.end(); ++clus_iter)
 		{
 		  if(Verbosity() >= 1) cout << "   inserting si cluster key " << *clus_iter << " into exisiting TPC track " << _tracklet_tpc->get_id() << endl;
@@ -310,10 +331,21 @@ int PHSiliconTpcTrackMatching::Process()
 
 	      // set the track position to the vertex position
 	      const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);      
-	      newTrack->set_x(svtxVertex->get_x());
-	      newTrack->set_y(svtxVertex->get_y());
-	      newTrack->set_z(svtxVertex->get_z());
-	      
+	      if(svtxVertex)
+		{
+		  newTrack->set_x(svtxVertex->get_x());
+		  newTrack->set_y(svtxVertex->get_y());
+		  newTrack->set_z(svtxVertex->get_z());
+		}
+	      else
+		{
+		  std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId << " associated with TPC tracklet " << _tracklet_tpc->get_id() << std::endl; 
+		  _tracklet_tpc->identify();
+		  newTrack->set_x(0.0);
+		  newTrack->set_y(0.0);
+		  newTrack->set_z(0.0);
+		}
+		      
 	      newTrack->set_charge(_tracklet_tpc->get_charge());
 	      newTrack->set_px(_tracklet_tpc->get_px());
 	      newTrack->set_py(_tracklet_tpc->get_py());


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
There is a newly observed, extremely rare, failure to find a valid vertex pointer in PHSiliconTpcTrackMatching. It causes a segfault. This PR traps the error and prints out some diagnostic information. The combined track vertex is then set to (0,0,0), which effectively throws the track away.

## TODOs (if applicable)
Use the diagnostic information generated to find the problem.

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

