### PR TITLE
Adding true DCA calculations to KFParticle output (nTuple only)

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
@@ -150,8 +150,9 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, const KFPa
     }
   }
 
-  //I used to need to copy this track map to avoid crashes with truth matching
+  //When you build the daughter track, the track vanishes from the original track map, making a clone fixes this
   SvtxTrackMap* originalTrackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  SvtxTrackMap* originalTrackMap_copy = dynamic_cast<SvtxTrackMap*>(originalTrackMap->CloneMe());
   KFParticle* daughterArray = &daughters[0];
 
   for (unsigned int k = 0; k < daughters.size(); ++k)
@@ -163,8 +164,7 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, const KFPa
     }
     else
     {
-      //m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap_copy);
-      m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap);
+      m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap_copy);
     }
 
     m_recoTrackMap->insert(m_recoTrack);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
@@ -150,9 +150,7 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, const KFPa
     }
   }
 
-  //When you build the daughter track, the track vanishes from the original track map, making a clone fixes this
   SvtxTrackMap* originalTrackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
-  SvtxTrackMap* originalTrackMap_copy = dynamic_cast<SvtxTrackMap*>(originalTrackMap->CloneMe());
   KFParticle* daughterArray = &daughters[0];
 
   for (unsigned int k = 0; k < daughters.size(); ++k)
@@ -164,11 +162,10 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, const KFPa
     }
     else
     {
-      m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap_copy);
+      m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap);
     }
 
     m_recoTrackMap->insert(m_recoTrack);
-    m_recoTrack->Reset();
   }
 }
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -65,7 +65,7 @@ void KFParticle_eventReconstruction::createDecay(PHCompositeNode* topNode, std::
                                                  std::vector<std::vector<KFParticle>>& selectedIntermediates,
                                                  int& nPVs, int& multiplicity)
 {
-  KFParticle::SetField(+1.5e0);
+  KFParticle::SetField(-1.4e0);
 
   std::vector<KFParticle> primaryVertices = makeAllPrimaryVertices(topNode);
   std::vector<KFParticle> daughterParticles = makeAllDaughterParticles(topNode);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -65,7 +65,7 @@ void KFParticle_eventReconstruction::createDecay(PHCompositeNode* topNode, std::
                                                  std::vector<std::vector<KFParticle>>& selectedIntermediates,
                                                  int& nPVs, int& multiplicity)
 {
-  KFParticle::SetField(-1.5e0);
+  KFParticle::SetField(+1.5e0);
 
   std::vector<KFParticle> primaryVertices = makeAllPrimaryVertices(topNode);
   std::vector<KFParticle> daughterParticles = makeAllDaughterParticles(topNode);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -12,6 +12,8 @@
 
 #include <TTree.h>
 
+#include <cmath>
+
 KFParticle_Tools kfpTupleTools;
 KFParticle_truthAndDetTools kfpTruthAndDetTools;
 
@@ -68,6 +70,8 @@ void KFParticle_nTuple::initializeBranches()
     m_tree->Branch(TString(mother_name) + "_FDchi2", &m_calculated_mother_fdchi2, TString(mother_name) + "_FDchi2/F");
     m_tree->Branch(TString(mother_name) + "_IP", &m_calculated_mother_ip, TString(mother_name) + "_IP/F");
     m_tree->Branch(TString(mother_name) + "_IPchi2", &m_calculated_mother_ipchi2, TString(mother_name) + "_IPchi2/F");
+    m_tree->Branch(TString(mother_name) + "_IPErr", &m_calculated_mother_ip_err, TString(mother_name) + "_IPErr/F");
+    m_tree->Branch(TString(mother_name) + "_IP_xy", &m_calculated_mother_ip_xy, TString(mother_name) + "_IP_xy/F");
   }
   m_tree->Branch(TString(mother_name) + "_x", &m_calculated_mother_x, TString(mother_name) + "_x/F");
   m_tree->Branch(TString(mother_name) + "_y", &m_calculated_mother_y, TString(mother_name) + "_y/F");
@@ -114,6 +118,8 @@ void KFParticle_nTuple::initializeBranches()
       m_tree->Branch(TString(intermediate_name) + "_decayLengthErr", &m_calculated_intermediate_decaylength_err[i], TString(intermediate_name) + "_decayLengthErr/F");
       m_tree->Branch(TString(intermediate_name) + "_IP", &m_calculated_intermediate_ip[i], TString(intermediate_name) + "_IP/F");
       m_tree->Branch(TString(intermediate_name) + "_IPchi2", &m_calculated_intermediate_ipchi2[i], TString(intermediate_name) + "_IPchi2/F");
+      m_tree->Branch(TString(intermediate_name) + "_IPErr", &m_calculated_intermediate_ip_err[i], TString(intermediate_name) + "_IPErr/F");
+      m_tree->Branch(TString(intermediate_name) + "_IP_xy", &m_calculated_intermediate_ip_xy[i], TString(intermediate_name) + "_IP_xy/F");
       m_tree->Branch(TString(intermediate_name) + "_x", &m_calculated_intermediate_x[i], TString(intermediate_name) + "_x/F");
       m_tree->Branch(TString(intermediate_name) + "_y", &m_calculated_intermediate_y[i], TString(intermediate_name) + "_y/F");
       m_tree->Branch(TString(intermediate_name) + "_z", &m_calculated_intermediate_z[i], TString(intermediate_name) + "_z/F");
@@ -145,6 +151,8 @@ void KFParticle_nTuple::initializeBranches()
     m_tree->Branch(TString(daughter_number) + "_mass", &m_calculated_daughter_mass[i], TString(daughter_number) + "_mass/F");
     m_tree->Branch(TString(daughter_number) + "_IP", &m_calculated_daughter_ip[i], TString(daughter_number) + "_IP/F");
     m_tree->Branch(TString(daughter_number) + "_IPchi2", &m_calculated_daughter_ipchi2[i], TString(daughter_number) + "_IPchi2/F");
+    m_tree->Branch(TString(daughter_number) + "_IPErr", &m_calculated_daughter_ip_err[i], TString(daughter_number) + "_IPErr/F");
+    m_tree->Branch(TString(daughter_number) + "_IP_xy", &m_calculated_daughter_ip_xy[i], TString(daughter_number) + "_IP_xy/F");
     m_tree->Branch(TString(daughter_number) + "_x", &m_calculated_daughter_x[i], TString(daughter_number) + "_x/F");
     m_tree->Branch(TString(daughter_number) + "_y", &m_calculated_daughter_y[i], TString(daughter_number) + "_y/F");
     m_tree->Branch(TString(daughter_number) + "_z", &m_calculated_daughter_z[i], TString(daughter_number) + "_z/F");
@@ -215,6 +223,8 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
                                    std::vector<KFParticle> intermediates,
                                    int nPVs, int multiplicity)
 {
+  const float speedOfLight = 2.99792458e-2; //c in cm/ps
+
   KFPVertex kfpVertex;  // = new KFPVertex;
   kfpVertex.SetXYZ(vertex.Parameters());
   kfpVertex.SetCovarianceMatrix(vertex.CovarianceMatrix());
@@ -225,6 +235,8 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     m_calculated_mother_fdchi2 = kfpTupleTools.flightDistanceChi2(motherParticle, kfpVertex);
     m_calculated_mother_ip = motherParticle.GetDistanceFromVertex(vertex);
     m_calculated_mother_ipchi2 = motherParticle.GetDeviationFromVertex(vertex);
+    m_calculated_mother_ip_err = m_calculated_mother_ip/sqrt(m_calculated_mother_ipchi2);
+    m_calculated_mother_ip_xy = motherParticle.GetDistanceFromVertexXY(vertex);
   }
   m_calculated_mother_x = motherParticle.GetX();
   m_calculated_mother_y = motherParticle.GetY();
@@ -255,6 +267,9 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     motherParticle.SetProductionVertex(vertex);
     motherParticle.GetLifeTime(m_calculated_mother_decaytime, m_calculated_mother_decaytime_err);
     motherParticle.GetDecayLength(m_calculated_mother_decaylength, m_calculated_mother_decaylength_err);
+
+    m_calculated_mother_decaytime /= speedOfLight;
+    m_calculated_mother_decaytime_err /= speedOfLight; 
   }
 
   if (m_has_intermediates_nTuple)
@@ -265,6 +280,8 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     {
       m_calculated_intermediate_ip[i] = intermediateArray[i].GetDistanceFromVertex(vertex);
       m_calculated_intermediate_ipchi2[i] = intermediateArray[i].GetDeviationFromVertex(vertex);
+      m_calculated_intermediate_ip_err[i] = m_calculated_intermediate_ip[i]/sqrt(m_calculated_intermediate_ipchi2[i]);
+      m_calculated_intermediate_ip_xy[i] = intermediateArray[i].GetDistanceFromVertexXY(vertex);
       m_calculated_intermediate_x[i] = intermediateArray[i].GetX();
       m_calculated_intermediate_y[i] = intermediateArray[i].GetY();
       m_calculated_intermediate_z[i] = intermediateArray[i].GetZ();
@@ -292,6 +309,9 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
       intermediateArray[i].SetProductionVertex(motherParticle);
       intermediateArray[i].GetLifeTime(m_calculated_intermediate_decaytime[i], m_calculated_intermediate_decaytime_err[i]);
       intermediateArray[i].GetDecayLength(m_calculated_intermediate_decaylength[i], m_calculated_intermediate_decaylength_err[i]);
+
+      m_calculated_intermediate_decaytime[i] /= speedOfLight;
+      m_calculated_intermediate_decaytime_err[i] /= speedOfLight;
     }
   }
 
@@ -321,6 +341,8 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     m_calculated_daughter_mass[i] = daughterArray[i].GetMass();
     m_calculated_daughter_ip[i] = daughterArray[i].GetDistanceFromVertex(vertex);
     m_calculated_daughter_ipchi2[i] = daughterArray[i].GetDeviationFromVertex(vertex);
+    m_calculated_daughter_ip_err[i] = m_calculated_daughter_ip[i]/sqrt(m_calculated_daughter_ipchi2[i]);
+    m_calculated_daughter_ip_xy[i] = daughterArray[i].GetDistanceFromVertexXY(vertex);
     m_calculated_daughter_x[i] = daughterArray[i].GetX();
     m_calculated_daughter_y[i] = daughterArray[i].GetY();
     m_calculated_daughter_z[i] = daughterArray[i].GetZ();
@@ -344,7 +366,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     //m_calculated_daughter_cov[i]          = &daughterArray[i].CovarianceMatrix()[0];
     for (int j = 0; j < 21; ++j) m_calculated_daughter_cov[i][j] = daughterArray[i].GetCovariance(j);
 
-    if (m_truth_matching) kfpTruthAndDetTools.fillTruthBranch(topNode, m_tree, daughterArray[i], i);
+    if (m_truth_matching) kfpTruthAndDetTools.fillTruthBranch(topNode, m_tree, daughterArray[i], i, vertex);
     if (m_detector_info) kfpTruthAndDetTools.fillDetectorBranch(topNode, m_tree, daughterArray[i], i);
   }
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -175,7 +175,7 @@ void KFParticle_nTuple::initializeBranches()
     m_tree->Branch(TString(daughter_number) + "_PDG_ID", &m_calculated_daughter_pdgID[i], TString(daughter_number) + "_PDG_ID/I");
     m_tree->Branch(TString(daughter_number) + "_Covariance", &m_calculated_daughter_cov[i], TString(daughter_number) + "_Covariance[21]/F", 21);
 
-    if (m_truth_matching) kfpTruthAndDetTools.initializeTruthBranches(m_tree, i);
+    if (m_truth_matching) kfpTruthAndDetTools.initializeTruthBranches(m_tree, i, m_constrain_to_vertex_nTuple);
     if (m_detector_info) kfpTruthAndDetTools.initializeDetectorBranches(m_tree, i);
   }
 
@@ -366,7 +366,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     //m_calculated_daughter_cov[i]          = &daughterArray[i].CovarianceMatrix()[0];
     for (int j = 0; j < 21; ++j) m_calculated_daughter_cov[i][j] = daughterArray[i].GetCovariance(j);
 
-    if (m_truth_matching) kfpTruthAndDetTools.fillTruthBranch(topNode, m_tree, daughterArray[i], i, vertex);
+    if (m_truth_matching) kfpTruthAndDetTools.fillTruthBranch(topNode, m_tree, daughterArray[i], i, vertex, m_constrain_to_vertex_nTuple);
     if (m_detector_info) kfpTruthAndDetTools.fillDetectorBranch(topNode, m_tree, daughterArray[i], i);
   }
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -58,7 +58,9 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools
   float m_calculated_mother_dira = -1;
   float m_calculated_mother_fdchi2 = -1;
   float m_calculated_mother_ip = -1;
+  float m_calculated_mother_ip_xy = -1;
   float m_calculated_mother_ipchi2 = -1;
+  float m_calculated_mother_ip_err = -1;
   float m_calculated_mother_x = -1;
   float m_calculated_mother_y = -1;
   float m_calculated_mother_z = -1;
@@ -90,7 +92,9 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools
   float m_calculated_intermediate_decaylength[max_intermediates] = {0};
   float m_calculated_intermediate_decaylength_err[max_intermediates] = {0};
   float m_calculated_intermediate_ip[max_intermediates] = {0};
+  float m_calculated_intermediate_ip_xy[max_intermediates] = {0};
   float m_calculated_intermediate_ipchi2[max_intermediates] = {0};
+  float m_calculated_intermediate_ip_err[max_intermediates] = {0};
   float m_calculated_intermediate_x[max_intermediates] = {0};
   float m_calculated_intermediate_y[max_intermediates] = {0};
   float m_calculated_intermediate_z[max_intermediates] = {0};
@@ -117,7 +121,9 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools
   static const int max_tracks = 20;
   float m_calculated_daughter_mass[max_tracks] = {0};
   float m_calculated_daughter_ip[max_tracks] = {0};
+  float m_calculated_daughter_ip_xy[max_tracks] = {0};
   float m_calculated_daughter_ipchi2[max_tracks] = {0};
+  float m_calculated_daughter_ip_err[max_tracks] = {0};
   float m_calculated_daughter_x[max_tracks] = {0};
   float m_calculated_daughter_y[max_tracks] = {0};
   float m_calculated_daughter_z[max_tracks] = {0};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -126,7 +126,7 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
       if (m_verbosity > 0)
       {
         printParticles(mother[i], vertex[i], daughters[i], intermediates[i], nPVs, multiplicity);
-        if (m_save_dst) printNode(topNode);
+        if (m_save_dst && m_verbosity > 1) printNode(topNode);
       }
     }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -39,7 +39,6 @@ std::map<std::string, particle_pair> particleList = kfp_list.getParticleList();
 /// KFParticle constructor
 KFParticle_sPHENIX::KFParticle_sPHENIX()
   : SubsysReco("KFPARTICLE")
-  , m_verbosity(0)
   , m_has_intermediates_sPHENIX(false)
   , m_constrain_to_vertex_sPHENIX(false)
   , m_require_mva(false)
@@ -52,7 +51,6 @@ KFParticle_sPHENIX::KFParticle_sPHENIX()
 
 KFParticle_sPHENIX::KFParticle_sPHENIX(const std::string &name)
   : SubsysReco(name)
-  , m_verbosity(0)
   , m_has_intermediates_sPHENIX(false)
   , m_constrain_to_vertex_sPHENIX(false)
   , m_require_mva(false)
@@ -68,7 +66,7 @@ int KFParticle_sPHENIX::Init(PHCompositeNode *topNode)
   if (m_save_output)
   {
     m_outfile = new TFile(m_outfile_name.c_str(), "RECREATE");
-    if (m_verbosity > 0) std::cout << "Output nTuple: " << m_outfile_name << std::endl;
+    if (Verbosity() >= VERBOSITY_SOME) std::cout << "Output nTuple: " << m_outfile_name << std::endl;
     initializeBranches();
   }
 
@@ -101,14 +99,14 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
   SvtxVertexMap *check_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, m_vtx_map_node_name);
   if (check_vertexmap->size() == 0)
   {
-    if (m_verbosity > 0) std::cout << "KFParticle: Event skipped as there are no vertices" << std::endl;
+    if (Verbosity() >= VERBOSITY_SOME) std::cout << "KFParticle: Event skipped as there are no vertices" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   SvtxTrackMap *check_trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name);
   if (check_trackmap->size() == 0)
   {
-    if (m_verbosity > 0) std::cout << "KFParticle: Event skipped as there are no tracks" << std::endl;
+    if (Verbosity() >= VERBOSITY_SOME) std::cout << "KFParticle: Event skipped as there are no tracks" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -123,9 +121,12 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
       if (m_save_output) fillBranch(topNode, mother[i], vertex[i], daughters[i], intermediates[i], nPVs, multiplicity);
       if (m_save_dst) fillParticleNode(topNode, mother[i], daughters[i], intermediates[i]);
 
-      if (m_verbosity > 0)
+      if (Verbosity() >= VERBOSITY_SOME)
       {
         printParticles(mother[i], vertex[i], daughters[i], intermediates[i], nPVs, multiplicity);
+      }
+      if (Verbosity() >= VERBOSITY_MORE)
+      {
         if (m_save_dst) printNode(topNode);
       }
     }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -126,7 +126,10 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
       if (m_verbosity > 0)
       {
         printParticles(mother[i], vertex[i], daughters[i], intermediates[i], nPVs, multiplicity);
-        if (m_save_dst && m_verbosity > 1) printNode(topNode);
+      }
+      if (m_verbosity > 1) 
+      {
+        if (m_save_dst) printNode(topNode);
       }
     }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -126,9 +126,6 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
       if (m_verbosity > 0)
       {
         printParticles(mother[i], vertex[i], daughters[i], intermediates[i], nPVs, multiplicity);
-      }
-      if (m_verbosity > 1) 
-      {
         if (m_save_dst) printNode(topNode);
       }
     }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -192,8 +192,6 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMVACutValue(float cut_value) { m_mva_cut_value = cut_value; }
 
-  void Verbosity(int verbosity) { m_verbosity = verbosity; }
-
   void saveDST(bool save) { m_save_dst = save; }
 
   void saveTrackContainer(bool save) { m_write_track_container = save; }
@@ -217,7 +215,6 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
   void setTrackMapNodeName(const std::string& trk_map_node_name) { m_trk_map_node_name = trk_map_node_name; }
 
  private:
-  bool m_verbosity;
   bool m_has_intermediates_sPHENIX;
   bool m_constrain_to_vertex_sPHENIX;
   bool m_require_mva;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -7,6 +7,7 @@
 #include <tpc/TpcDefs.h>
 
 #include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxVertexMap.h>
 
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
@@ -15,6 +16,7 @@
 #include <g4eval/SvtxClusterEval.h>
 #include <g4eval/SvtxEvalStack.h>
 #include <g4eval/SvtxTruthEval.h>
+#include <g4eval/SvtxVertexEval.h>
 
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
@@ -56,6 +58,20 @@ SvtxTrack *KFParticle_truthAndDetTools::getTrack(unsigned int track_id, SvtxTrac
   return matched_track;
 }
 
+SvtxVertex *KFParticle_truthAndDetTools::getVertex(unsigned int vertex_id, SvtxVertexMap *vertexmap)
+{
+  SvtxVertex *matched_vertex = NULL;
+
+  for (SvtxVertexMap::Iter iter = vertexmap->begin();
+       iter != vertexmap->end();
+       ++iter)
+  {
+    if (iter->first == vertex_id) matched_vertex = iter->second;
+  }
+
+  return matched_vertex;
+}
+
 void KFParticle_truthAndDetTools::initializeTruthBranches(TTree *m_tree, int daughter_id)
 {
   std::string daughter_number = "track_" + std::to_string(daughter_id + 1);
@@ -63,6 +79,8 @@ void KFParticle_truthAndDetTools::initializeTruthBranches(TTree *m_tree, int dau
   m_tree->Branch(TString(daughter_number) + "_true_vertex_x", &m_true_daughter_vertex_x[daughter_id], TString(daughter_number) + "_true_vertex_x/F");
   m_tree->Branch(TString(daughter_number) + "_true_vertex_y", &m_true_daughter_vertex_y[daughter_id], TString(daughter_number) + "_true_vertex_y/F");
   m_tree->Branch(TString(daughter_number) + "_true_vertex_z", &m_true_daughter_vertex_z[daughter_id], TString(daughter_number) + "_true_vertex_z/F");
+  m_tree->Branch(TString(daughter_number) + "_true_IP", &m_true_daughter_ip[daughter_id], TString(daughter_number) + "_true_IP/F");
+  m_tree->Branch(TString(daughter_number) + "_true_IP_xy", &m_true_daughter_ip_xy[daughter_id], TString(daughter_number) + "_true_IP_xy/F");
   m_tree->Branch(TString(daughter_number) + "_true_px", &m_true_daughter_px[daughter_id], TString(daughter_number) + "_true_px/F");
   m_tree->Branch(TString(daughter_number) + "_true_py", &m_true_daughter_py[daughter_id], TString(daughter_number) + "_true_py/F");
   m_tree->Branch(TString(daughter_number) + "_true_pz", &m_true_daughter_pz[daughter_id], TString(daughter_number) + "_true_pz/F");
@@ -71,7 +89,7 @@ void KFParticle_truthAndDetTools::initializeTruthBranches(TTree *m_tree, int dau
   m_tree->Branch(TString(daughter_number) + "_true_ID", &m_true_daughter_id[daughter_id], TString(daughter_number) + "_true_ID/I");
 }
 
-void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTree *m_tree, KFParticle daughter, int daughter_id)
+void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTree *m_tree, KFParticle daughter, int daughter_id, KFParticle vertex)
 {
   float true_px, true_py, true_pz, true_p, true_pt;
 
@@ -81,12 +99,12 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
     //trackeval = m_svtx_evalstack->get_track_eval();
     clustereval = m_svtx_evalstack->get_cluster_eval();
     trutheval = m_svtx_evalstack->get_truth_eval();
-    //vertexeval = m_svtx_evalstack->get_vertex_eval();
+    vertexeval = m_svtx_evalstack->get_vertex_eval();
   }
-  m_svtx_evalstack->next_event(topNode);
+  //m_svtx_evalstack->next_event(topNode);
 
   PHNodeIterator nodeIter(topNode);
-  PHNode *findNode = dynamic_cast<PHNode *>(nodeIter.findFirst("SvtxTrackMap"));
+  PHNode *findNode = dynamic_cast<PHNode*>(nodeIter.findFirst("SvtxTrackMap"));
   if (findNode)
   {
     dst_trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
@@ -94,6 +112,15 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
   else
   {
     std::cout << "KFParticle truth matching: SvtxTrackMap does not exist" << std::endl;
+  }
+  findNode = dynamic_cast<PHNode*>(nodeIter.findFirst("SvtxVertexMap"));
+  if (findNode)
+  {
+    dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+  }
+  else
+  {
+    std::cout << "KFParticle truth matching: SvtxVertexMap does not exist" << std::endl;
   }
 
   m_svtx_evalstack->next_event(topNode);
@@ -120,6 +147,51 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
   m_true_daughter_vertex_x[daughter_id] = g4vertex_point->get_x();
   m_true_daughter_vertex_y[daughter_id] = g4vertex_point->get_y();
   m_true_daughter_vertex_z[daughter_id] = g4vertex_point->get_z();
+
+  //Calculate true DCA
+  SvtxVertex* recoVertex = getVertex(vertex.Id(), dst_vertexmap);
+  PHG4VtxPoint* truePoint = vertexeval->max_truth_point_by_ntracks(recoVertex);
+
+  KFParticle trueKFParticleVertex;
+
+  float f_vertexParameters[6] = {0};
+
+  if (truePoint == NULL)
+  {
+    std::cout << "KFParticle Truth Matching: This event has no PHG4VtxPoint information!\n";
+    std::cout << "Your truth track DCA will be measured wrt a reconstructed vertex!" << std::endl; 
+
+    f_vertexParameters[0] = recoVertex->get_x();
+    f_vertexParameters[1] = recoVertex->get_y();
+    f_vertexParameters[2] = recoVertex->get_z();
+  }
+  else
+  {
+    f_vertexParameters[0] = truePoint->get_x();
+    f_vertexParameters[1] = truePoint->get_y();
+    f_vertexParameters[2] = truePoint->get_z();
+  }
+
+  float f_vertexCovariance[21] = {0};
+
+  trueKFParticleVertex.Create(f_vertexParameters, f_vertexCovariance, 0, -1);
+
+  KFParticle trueKFParticle;
+
+  float f_trackParameters[6] = {m_true_daughter_vertex_x[daughter_id],
+                                m_true_daughter_vertex_y[daughter_id],
+                                m_true_daughter_vertex_z[daughter_id],
+                                true_px,
+                                true_py,
+                                true_pz};
+
+  float f_trackCovariance[21] = {0};
+
+  trueKFParticle.Create(f_trackParameters, f_trackCovariance, 1, -1);
+
+  m_true_daughter_ip[daughter_id] = trueKFParticle.GetDistanceFromVertex(trueKFParticleVertex);
+  m_true_daughter_ip_xy[daughter_id] = trueKFParticle.GetDistanceFromVertexXY(trueKFParticleVertex);
+
 }
 
 void KFParticle_truthAndDetTools::initializeDetectorBranches(TTree *m_tree, int daughter_id)
@@ -163,7 +235,7 @@ void KFParticle_truthAndDetTools::fillDetectorBranch(PHCompositeNode *topNode,
 {
   PHNodeIterator nodeIter(topNode);
 
-  PHNode *findNode = dynamic_cast<PHNode *>(nodeIter.findFirst("SvtxTrackMap"));
+  PHNode *findNode = dynamic_cast<PHNode*>(nodeIter.findFirst("SvtxTrackMap"));
   if (findNode)
   {
     dst_trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
@@ -173,7 +245,7 @@ void KFParticle_truthAndDetTools::fillDetectorBranch(PHCompositeNode *topNode,
     std::cout << "KFParticle detector info: SvtxTrackMap does not exist" << std::endl;
   }
 
-  findNode = dynamic_cast<PHNode *>(nodeIter.findFirst("TRKR_CLUSTER"));
+  findNode = dynamic_cast<PHNode*>(nodeIter.findFirst("TRKR_CLUSTER"));
   if (findNode)
   {
     dst_clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -72,24 +72,24 @@ SvtxVertex *KFParticle_truthAndDetTools::getVertex(unsigned int vertex_id, SvtxV
   return matched_vertex;
 }
 
-void KFParticle_truthAndDetTools::initializeTruthBranches(TTree *m_tree, int daughter_id)
+void KFParticle_truthAndDetTools::initializeTruthBranches(TTree *m_tree, int daughter_id, bool m_constrain_to_vertex_truthMatch)
 {
   std::string daughter_number = "track_" + std::to_string(daughter_id + 1);
 
   m_tree->Branch(TString(daughter_number) + "_true_vertex_x", &m_true_daughter_vertex_x[daughter_id], TString(daughter_number) + "_true_vertex_x/F");
   m_tree->Branch(TString(daughter_number) + "_true_vertex_y", &m_true_daughter_vertex_y[daughter_id], TString(daughter_number) + "_true_vertex_y/F");
   m_tree->Branch(TString(daughter_number) + "_true_vertex_z", &m_true_daughter_vertex_z[daughter_id], TString(daughter_number) + "_true_vertex_z/F");
-  m_tree->Branch(TString(daughter_number) + "_true_IP", &m_true_daughter_ip[daughter_id], TString(daughter_number) + "_true_IP/F");
-  m_tree->Branch(TString(daughter_number) + "_true_IP_xy", &m_true_daughter_ip_xy[daughter_id], TString(daughter_number) + "_true_IP_xy/F");
+  if (m_constrain_to_vertex_truthMatch) m_tree->Branch(TString(daughter_number) + "_true_IP", &m_true_daughter_ip[daughter_id], TString(daughter_number) + "_true_IP/F");
+  if (m_constrain_to_vertex_truthMatch) m_tree->Branch(TString(daughter_number) + "_true_IP_xy", &m_true_daughter_ip_xy[daughter_id], TString(daughter_number) + "_true_IP_xy/F");
   m_tree->Branch(TString(daughter_number) + "_true_px", &m_true_daughter_px[daughter_id], TString(daughter_number) + "_true_px/F");
   m_tree->Branch(TString(daughter_number) + "_true_py", &m_true_daughter_py[daughter_id], TString(daughter_number) + "_true_py/F");
   m_tree->Branch(TString(daughter_number) + "_true_pz", &m_true_daughter_pz[daughter_id], TString(daughter_number) + "_true_pz/F");
   m_tree->Branch(TString(daughter_number) + "_true_p", &m_true_daughter_p[daughter_id], TString(daughter_number) + "_true_p/F");
-  m_tree->Branch(TString(daughter_number) + "_true_pt", &m_true_daughter_pt[daughter_id], TString(daughter_number) + "_true_pt/F");
+  m_tree->Branch(TString(daughter_number) + "_true_pT", &m_true_daughter_pt[daughter_id], TString(daughter_number) + "_true_pT/F");
   m_tree->Branch(TString(daughter_number) + "_true_ID", &m_true_daughter_id[daughter_id], TString(daughter_number) + "_true_ID/I");
 }
 
-void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTree *m_tree, KFParticle daughter, int daughter_id, KFParticle vertex)
+void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTree *m_tree, KFParticle daughter, int daughter_id, KFParticle vertex, bool m_constrain_to_vertex_truthMatch)
 {
   float true_px, true_py, true_pz, true_p, true_pt;
 
@@ -148,50 +148,53 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
   m_true_daughter_vertex_y[daughter_id] = g4vertex_point->get_y();
   m_true_daughter_vertex_z[daughter_id] = g4vertex_point->get_z();
 
-  //Calculate true DCA
-  SvtxVertex* recoVertex = getVertex(vertex.Id(), dst_vertexmap);
-  PHG4VtxPoint* truePoint = vertexeval->max_truth_point_by_ntracks(recoVertex);
-
-  KFParticle trueKFParticleVertex;
-
-  float f_vertexParameters[6] = {0};
-
-  if (truePoint == NULL)
+  if (m_constrain_to_vertex_truthMatch)  
   {
-    std::cout << "KFParticle Truth Matching: This event has no PHG4VtxPoint information!\n";
-    std::cout << "Your truth track DCA will be measured wrt a reconstructed vertex!" << std::endl; 
+    //Calculate true DCA
+    SvtxVertex* recoVertex = getVertex(vertex.Id(), dst_vertexmap);
+    PHG4VtxPoint* truePoint = vertexeval->max_truth_point_by_ntracks(recoVertex);
 
-    f_vertexParameters[0] = recoVertex->get_x();
-    f_vertexParameters[1] = recoVertex->get_y();
-    f_vertexParameters[2] = recoVertex->get_z();
+    KFParticle trueKFParticleVertex;
+
+    float f_vertexParameters[6] = {0};
+
+    if (truePoint == NULL)
+    {
+      std::cout << "KFParticle Truth Matching: This event has no PHG4VtxPoint information!\n";
+      std::cout << "Your truth track DCA will be measured wrt a reconstructed vertex!" << std::endl; 
+
+      f_vertexParameters[0] = recoVertex->get_x(); 
+      f_vertexParameters[1] = recoVertex->get_y();
+      f_vertexParameters[2] = recoVertex->get_z();
+    }
+    else
+    {
+      f_vertexParameters[0] = truePoint->get_x();
+      f_vertexParameters[1] = truePoint->get_y();
+      f_vertexParameters[2] = truePoint->get_z();
+    }
+
+    float f_vertexCovariance[21] = {0};
+
+    trueKFParticleVertex.Create(f_vertexParameters, f_vertexCovariance, 0, -1);
+
+    KFParticle trueKFParticle;
+
+    float f_trackParameters[6] = {m_true_daughter_vertex_x[daughter_id],
+                                  m_true_daughter_vertex_y[daughter_id],
+                                  m_true_daughter_vertex_z[daughter_id],
+                                  true_px,
+                                  true_py,
+                                  true_pz};
+
+    float f_trackCovariance[21] = {0};
+
+    trueKFParticle.Create(f_trackParameters, f_trackCovariance, 1, -1);
+
+    m_true_daughter_ip[daughter_id] = trueKFParticle.GetDistanceFromVertex(trueKFParticleVertex);
+    m_true_daughter_ip_xy[daughter_id] = trueKFParticle.GetDistanceFromVertexXY(trueKFParticleVertex);
+
   }
-  else
-  {
-    f_vertexParameters[0] = truePoint->get_x();
-    f_vertexParameters[1] = truePoint->get_y();
-    f_vertexParameters[2] = truePoint->get_z();
-  }
-
-  float f_vertexCovariance[21] = {0};
-
-  trueKFParticleVertex.Create(f_vertexParameters, f_vertexCovariance, 0, -1);
-
-  KFParticle trueKFParticle;
-
-  float f_trackParameters[6] = {m_true_daughter_vertex_x[daughter_id],
-                                m_true_daughter_vertex_y[daughter_id],
-                                m_true_daughter_vertex_z[daughter_id],
-                                true_px,
-                                true_py,
-                                true_pz};
-
-  float f_trackCovariance[21] = {0};
-
-  trueKFParticle.Create(f_trackParameters, f_trackCovariance, 1, -1);
-
-  m_true_daughter_ip[daughter_id] = trueKFParticle.GetDistanceFromVertex(trueKFParticleVertex);
-  m_true_daughter_ip_xy[daughter_id] = trueKFParticle.GetDistanceFromVertexXY(trueKFParticleVertex);
-
 }
 
 void KFParticle_truthAndDetTools::initializeDetectorBranches(TTree *m_tree, int daughter_id)

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
@@ -14,7 +14,9 @@ class SvtxEvalStack;
 class SvtxTrackMap;
 class SvtxTrack;
 class SvtxTruthEval;
+class SvtxVertexMap;
 class SvtxVertex;
+class SvtxVertexEval;
 class TrkrClusterContainer;
 
 class TTree;
@@ -28,8 +30,9 @@ class KFParticle_truthAndDetTools
   virtual ~KFParticle_truthAndDetTools();  //Destructor
 
   SvtxTrack *getTrack(unsigned int track_id, SvtxTrackMap *trackmap);
+  SvtxVertex *getVertex(unsigned int vertex_id, SvtxVertexMap *vertexmap);
   void initializeTruthBranches(TTree *m_tree, int daughter_id);
-  void fillTruthBranch(PHCompositeNode *topNode, TTree *m_tree, KFParticle daughter, int daughter_id);
+  void fillTruthBranch(PHCompositeNode *topNode, TTree *m_tree, KFParticle daughter, int daughter_id, KFParticle vertex);
 
   void initializeDetectorBranches(TTree *m_tree, int daughter_id);
   void initializeSubDetectorBranches(TTree *m_tree, std::string detectorName, int daughter_id);
@@ -39,12 +42,15 @@ class KFParticle_truthAndDetTools
   SvtxEvalStack *m_svtx_evalstack = nullptr;
   SvtxClusterEval *clustereval = nullptr;
   SvtxTruthEval *trutheval = nullptr;
+  SvtxVertexEval *vertexeval = nullptr;
 
   SvtxTrackMap *dst_trackmap = nullptr;
   SvtxTrack *track = nullptr;
 
   PHG4Particle *g4particle = nullptr;
   PHG4VtxPoint *g4vertex_point = nullptr;
+
+  SvtxVertexMap *dst_vertexmap = nullptr;
   SvtxVertex *vertex = nullptr;
 
   TrkrClusterContainer *dst_clustermap = nullptr;
@@ -55,6 +61,8 @@ class KFParticle_truthAndDetTools
   float m_true_daughter_vertex_x[max_tracks] = {0};
   float m_true_daughter_vertex_y[max_tracks] = {0};
   float m_true_daughter_vertex_z[max_tracks] = {0};
+  float m_true_daughter_ip[max_tracks] = {0};
+  float m_true_daughter_ip_xy[max_tracks] = {0};
   float m_true_daughter_px[max_tracks] = {0};
   float m_true_daughter_py[max_tracks] = {0};
   float m_true_daughter_pz[max_tracks] = {0};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
@@ -31,8 +31,8 @@ class KFParticle_truthAndDetTools
 
   SvtxTrack *getTrack(unsigned int track_id, SvtxTrackMap *trackmap);
   SvtxVertex *getVertex(unsigned int vertex_id, SvtxVertexMap *vertexmap);
-  void initializeTruthBranches(TTree *m_tree, int daughter_id);
-  void fillTruthBranch(PHCompositeNode *topNode, TTree *m_tree, KFParticle daughter, int daughter_id, KFParticle vertex);
+  void initializeTruthBranches(TTree *m_tree, int daughter_id, bool m_constrain_to_vertex_truthMatch);
+  void fillTruthBranch(PHCompositeNode *topNode, TTree *m_tree, KFParticle daughter, int daughter_id, KFParticle vertex, bool m_constrain_to_vertex_truthMatch);
 
   void initializeDetectorBranches(TTree *m_tree, int daughter_id);
   void initializeSubDetectorBranches(TTree *m_tree, std::string detectorName, int daughter_id);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
A request was made to calculate the true DCA in the nTuple output. This is calculated from the true track parameters and the VtxPoint, if it exists. If the true VtxPoint does not exist then the true DCA is calculated wrt to the reconstructed vertex and a warning is given.

I also added some new DCA branches in the nTuple: DCA_xy and DCA error to aid in resolution studies. Please note that the DCA_xy error is not calculated. I also changed the units of the decay time from ctau to ps.

Lastly, the magnetic field was set to negative 1.5T. I changed this to positive 1.5T which matches our magnetic field map plot but I should check that there isn't a flip in the sign somewhere.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR introduces a new feature to the nTuple output of KFParticle if truth matching is enabled. This will not impact the MDC production but is wanted for user analysis.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

