### PR TITLE
Truth Initial Vertexing with Acts Silicon Seeding

### DIFF
--- a/offline/packages/trackreco/PHTruthVertexing.cc
+++ b/offline/packages/trackreco/PHTruthVertexing.cc
@@ -145,8 +145,13 @@ void PHTruthVertexing::assignStubsVertices(PHCompositeNode *topNode)
       return;
     }
 
-  for(const auto& [trackKey, track] : *trackMap)
+  for(SvtxTrackMap::Iter iter = trackMap->begin();
+      iter != trackMap->end();
+      ++iter)
     {
+      auto trackKey = iter->first;
+      auto track = iter->second;
+
       if(Verbosity() > 3)
 	track->identify();
       
@@ -159,8 +164,12 @@ void PHTruthVertexing::assignStubsVertices(PHCompositeNode *topNode)
       double dz = 9999.;
       int trackVertexId = 9999;
       
-      for(const auto& [vertexKey, vertex] : *_vertex_map)
+      for(SvtxVertexMap::Iter viter = _vertex_map->begin();
+	  viter != _vertex_map->end();
+	  ++viter)
 	{
+	  auto vertexKey = viter->first;
+	  auto vertex = viter->second;
 	  if(Verbosity() > 3)
 	    vertex->identify();
 	  

--- a/offline/packages/trackreco/PHTruthVertexing.cc
+++ b/offline/packages/trackreco/PHTruthVertexing.cc
@@ -3,7 +3,8 @@
 #include <trackbase_historic/SvtxVertexMap.h>
 #include <trackbase_historic/SvtxVertex.h>     // for SvtxVertex
 #include <trackbase_historic/SvtxVertex_v1.h>
-
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxTrackMap.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <g4main/PHG4VtxPoint.h>
 
@@ -124,10 +125,68 @@ int PHTruthVertexing::Process(PHCompositeNode* topNode)
       
     }
   
-  if (Verbosity() > 0)
-    _vertex_map->identify();
-
+  if (Verbosity() > 0) 
+      _vertex_map->identify();
+   
+  if(_acts_silicon)
+    assignStubsVertices(topNode);
+    
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void PHTruthVertexing::assignStubsVertices(PHCompositeNode *topNode)
+{
+  SvtxTrackMap * trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxSiliconTrackMap");
+  if(!trackMap)
+    {
+      std::cout << PHWHERE 
+		<< "Can't find silicon stub track map. Exiting" 
+		<< std::endl;
+      return;
+    }
+
+  for(const auto& [trackKey, track] : *trackMap)
+    {
+      if(Verbosity() > 3)
+	track->identify();
+      
+      const double trackX = track->get_x();
+      const double trackY = track->get_y();
+      const double trackZ = track->get_z();
+      
+      double dx = 9999.;
+      double dy = 9999.;
+      double dz = 9999.;
+      int trackVertexId = 9999;
+      
+      for(const auto& [vertexKey, vertex] : *_vertex_map)
+	{
+	  if(Verbosity() > 3)
+	    vertex->identify();
+	  
+	  const double vertexX = vertex->get_x();
+	  const double vertexY = vertex->get_y();
+	  const double vertexZ = vertex->get_z();
+	  
+	  if( fabs(trackX - vertexX) < dx &&
+	       fabs(trackY - vertexY) < dy &&
+	       fabs(trackZ - vertexZ) < dz )
+	    {
+	      dx = fabs(trackX - vertexX);
+	      dy = fabs(trackY - vertexY);
+	      dz = fabs(trackZ - vertexZ);
+	      trackVertexId = vertexKey;
+	    }
+
+	}
+
+      track->set_vertex_id(trackVertexId);
+      auto vertex = _vertex_map->find(trackVertexId)->second;
+      vertex->insert_track(trackKey);
+      
+    }
+
+
 }
 
 int PHTruthVertexing::GetNodes(PHCompositeNode* topNode)

--- a/offline/packages/trackreco/PHTruthVertexing.h
+++ b/offline/packages/trackreco/PHTruthVertexing.h
@@ -61,12 +61,15 @@ class PHTruthVertexing : public PHInitVertexing
   /// fetch node pointers
   int GetNodes(PHCompositeNode *topNode);
 
+  void assignStubsVertices(PHCompositeNode *topNode);
+
   PHG4TruthInfoContainer *_g4truth_container;
 
   /// manually assigned vertex error (standard dev), cm
   std::vector<float> _vertex_error;
 
   bool _embed_only;
+  bool _acts_silicon = true;
 
   gsl_rng *m_RandomGenerator;
 };

--- a/offline/packages/trackreco/PHTruthVertexing.h
+++ b/offline/packages/trackreco/PHTruthVertexing.h
@@ -43,7 +43,10 @@ class PHTruthVertexing : public PHInitVertexing
   {
     return _vertex_error;
   }
-
+  void set_acts_silicon(bool acts_silicon)
+  {
+    _acts_silicon = acts_silicon;
+  }
   void set_embed_only(bool embed_only)
   {
     _embed_only = embed_only;
@@ -69,7 +72,7 @@ class PHTruthVertexing : public PHInitVertexing
   std::vector<float> _vertex_error;
 
   bool _embed_only;
-  bool _acts_silicon = true;
+  bool _acts_silicon = false;
 
   gsl_rng *m_RandomGenerator;
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [X] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds functionality for the truth vertexing module to be run following the Acts reconstructed silicon seeder. Currently we see that the performance (DCA, efficiency, etc.) degrades considerably when using the Acts reconstructed initial vertex finder. This needs to be understood, but for the time being (to get people going on their own sims) this PR modifies the truth vertexing to be able to run with the Acts silicon seeder. This improves the performance considerably.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

This is associated with [this](https://github.com/sPHENIX-Collaboration/macros/pull/363) PR in the macros repo.