### PR TITLE
Spacecharge reconstruction

### DIFF
--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -134,6 +134,202 @@ namespace
 
   }
 
+  /// Micromegas geometry
+  /// TODO: should get those numbers from actual geometry configuration
+  // fully equiped sector
+  static constexpr double isec_ref = 3;
+  static constexpr double phi_ref = isec_ref*M_PI/6 + M_PI/12;
+
+  // radius of the micromegas layer
+  static constexpr double r_ref = 82;
+
+  // z extrapolation window
+  static constexpr double zextrap_min = 48;
+  static constexpr double zextrap_max = 58;
+
+  // Micromegas acceptance in incomplete sectors
+  static constexpr double zref = 33.25;
+  static constexpr double length = 50 - 5;
+  static constexpr double zref_min = zref - length/2;
+  static constexpr double zref_max = zref + length/2;
+
+  //____________________________________________________________________________________
+  /// z extrapolation
+  /**
+   * interpolate between micromegas in the fully equiped sector
+   */
+  void extrapolate_z( TH3* hin )
+  {
+    if( !hin ) return;
+
+    // get reference phi bin
+    const int phibin_ref = hin->GetXaxis()->FindBin( phi_ref );
+
+    // loop over radial bins
+    for( int ir = 0; ir < hin->GetYaxis()->GetNbins(); ++ir )
+    {
+
+      // get current radius
+      const auto r = hin->GetYaxis()->GetBinCenter( ir+1 );
+
+      // get z integration window for reference
+      const auto zextrap_min_loc = zextrap_min * r/r_ref;
+      const auto zextrap_max_loc = zextrap_max * r/r_ref;
+
+      // get corresponding bins
+      const int zbin_min[2] = { hin->GetZaxis()->FindBin( -zextrap_max_loc ), hin->GetZaxis()->FindBin( zextrap_min_loc ) };
+      const int zbin_max[2] = { hin->GetZaxis()->FindBin( -zextrap_min_loc ), hin->GetZaxis()->FindBin( zextrap_max_loc ) };
+
+      for( int isign = 0; isign < 2; ++isign )
+      {
+        // adjust z positions
+        const auto z_min = hin->GetZaxis()->GetBinCenter( zbin_min[isign] );
+        const auto z_max = hin->GetZaxis()->GetBinCenter( zbin_max[isign] );
+
+        // get reference
+        const auto content_min = hin->GetBinContent( phibin_ref, ir+1, zbin_min[isign] );
+        const auto content_max = hin->GetBinContent( phibin_ref, ir+1, zbin_max[isign] );
+        const auto error_min = hin->GetBinError( phibin_ref, ir+1, zbin_min[isign] );
+        const auto error_max = hin->GetBinError( phibin_ref, ir+1, zbin_max[isign] );
+
+        // loop over z bins
+        for( int iz = zbin_min[isign]+1; iz < zbin_max[isign]; ++iz )
+        {
+
+          const auto z = hin->GetZaxis()->GetBinCenter( iz );
+
+          // interpolate
+          const auto alpha_min = (z_max-z)/(z_max-z_min);
+          const auto alpha_max = (z-z_min)/(z_max-z_min);
+
+          const auto content = alpha_min*content_min + alpha_max*content_max;
+          const auto error = std::sqrt(square( alpha_min * error_min ) + square( alpha_max*error_max));
+
+          hin->SetBinContent( phibin_ref, ir+1, iz, content );
+          hin->SetBinError( phibin_ref, ir+1, iz, error );
+        }
+      }
+    }
+  }
+
+  //____________________________________________________________________________________
+  /// first phi extrapolation
+  /**
+   * copy the full z dependence of reference sector to all other sectors, separately for positive and negative z,
+   * normalized by the measurement from provided micromegas, at the appropriate z
+   */
+  void extrapolate_phi1( TH3* hin )
+  {
+    if( !hin ) return;
+
+    // get reference phi bin
+    const int phibin_ref = hin->GetXaxis()->FindBin( phi_ref );
+
+    // loop over sectors
+    for( int isec = 0; isec < 12; ++isec )
+    {
+
+      // skip reference sector
+      if( isec == isec_ref ) continue;
+
+      // get relevant phi and corresponding bin
+      const double phi = isec*M_PI/6 + M_PI/12;
+      const int phibin = hin->GetXaxis()->FindBin( phi );
+
+      // loop over radial bins
+      for( int ir = 0; ir < hin->GetYaxis()->GetNbins(); ++ir )
+      {
+
+        // get current radius
+        const auto r = hin->GetYaxis()->GetBinCenter( ir+1 );
+
+        // get z integration window for reference
+        const auto zref_min_loc = zref_min * r/r_ref;
+        const auto zref_max_loc = zref_max * r/r_ref;
+
+        // get corresponding bins
+        const int zbin_ref_neg[2] = { hin->GetZaxis()->FindBin( -zref_max_loc ), hin->GetZaxis()->FindBin( -zref_min_loc ) };
+        const int zbin_ref_pos[2] = { hin->GetZaxis()->FindBin( zref_min_loc ), hin->GetZaxis()->FindBin( zref_max_loc ) };
+
+        // loop over z bins
+        for( int iz = 0; iz < hin->GetZaxis()->GetNbins(); ++iz )
+        {
+          const auto content_ref = hin->GetBinContent( phibin_ref, ir+1, iz+1 );
+          const auto error_ref = hin->GetBinError( phibin_ref, ir+1, iz+1 );
+
+          #if true
+          // calculate scale factor
+          const auto z = hin->GetZaxis()->GetBinCenter( iz+1 );
+          const auto norm_ref = hin->Integral( phibin_ref, phibin_ref, ir+1, ir+1, (z>0) ? zbin_ref_pos[0]:zbin_ref_neg[0], (z>0) ? zbin_ref_pos[1]:zbin_ref_neg[1] );
+          const auto norm_loc = hin->Integral( phibin, phibin, ir+1, ir+1, (z>0) ? zbin_ref_pos[0]:zbin_ref_neg[0], (z>0) ? zbin_ref_pos[1]:zbin_ref_neg[1] );
+          const auto scale = (norm_ref == 0) ? 1:norm_loc/norm_ref;
+
+          #else
+          const auto scale = 1;
+          #endif
+
+          // assign to output histogram
+          hin->SetBinContent( phibin, ir+1, iz+1, content_ref*scale );
+          hin->SetBinError( phibin, ir+1, iz+1, error_ref*scale );
+        }
+      }
+    }
+  }
+
+  //_______________________________________________
+  /// second phi extrapolation
+  /**
+   * for each r, z and phi bin, linearly extrapolate between neighbor phi sector measurements
+   */
+  void extrapolate_phi2( TH3* hin )
+  {
+    if( !hin ) return;
+
+    for( int iphi = 0; iphi < hin->GetXaxis()->GetNbins(); ++iphi )
+    {
+
+      // find nearest sector phi bins
+      const auto phi = hin->GetXaxis()->GetBinCenter( iphi+1 );
+      const int isec = std::floor( (phi - M_PI/12)/(M_PI/6) );
+      double phi_min =  isec*M_PI/6 + M_PI/12;
+      double phi_max =  phi_min + M_PI/6;
+
+      if( phi_min < 0 ) phi_min += 2*M_PI;
+      if( phi_max >= 2*M_PI ) phi_max -= 2*M_PI;
+
+      const auto phibin_min = hin->GetXaxis()->FindBin( phi_min );
+      if( phibin_min == iphi+1 ) continue;
+
+      const auto phibin_max = hin->GetXaxis()->FindBin( phi_max );
+      if( phibin_max == iphi+1 ) continue;
+
+      // loop over radial bins
+      for( int ir = 0; ir < hin->GetYaxis()->GetNbins(); ++ir )
+      {
+
+        // loop over z bins
+        for( int iz = 0; iz < hin->GetZaxis()->GetNbins(); ++iz )
+        {
+          const auto content_min = hin->GetBinContent( phibin_min, ir+1, iz+1 );
+          const auto content_max = hin->GetBinContent( phibin_max, ir+1, iz+1 );
+          const auto error_min = hin->GetBinError( phibin_min, ir+1, iz+1 );
+          const auto error_max = hin->GetBinError( phibin_max, ir+1, iz+1 );
+
+          // perform linear extrapolation
+          const auto alpha_min = (phi_max-phi)/(phi_max-phi_min);
+          const auto alpha_max = (phi-phi_min)/(phi_max-phi_min);
+
+          const auto content = alpha_min*content_min + alpha_max*content_max;
+          const auto error = std::sqrt(square( alpha_min * error_min ) + square( alpha_max*error_max));
+
+          hin->SetBinContent( iphi+1, ir+1, iz+1, content );
+          hin->SetBinError( iphi+1, ir+1, iz+1, error );
+        }
+
+      }
+    }
+  }
+
 }
 
 //_____________________________________________________________________
@@ -440,13 +636,13 @@ void TpcSpaceChargeReconstruction::calculate_distortions( PHCompositeNode* topNo
 {
 
   // create output histograms
-  auto hentries = new TH3F( "hentries_rec", "hentries_rec", m_phibins, m_phimin, m_phimax, m_rbins, m_rmin, m_rmax, m_zbins, m_zmin, m_zmax );
-  auto hphi = new TH3F( "hDistortionP_rec", "hDistortionP_rec", m_phibins, m_phimin, m_phimax, m_rbins, m_rmin, m_rmax, m_zbins, m_zmin, m_zmax );
-  auto hz = new TH3F( "hDistortionZ_rec", "hDistortionZ_rec", m_phibins, m_phimin, m_phimax, m_rbins, m_rmin, m_rmax, m_zbins, m_zmin, m_zmax );
-  auto hr = new TH3F( "hDistortionR_rec", "hDistortionR_rec", m_phibins, m_phimin, m_phimax, m_rbins, m_rmin, m_rmax, m_zbins, m_zmin, m_zmax );
+  auto hentries( new TH3F( "hentries_rec", "hentries_rec", m_phibins, m_phimin, m_phimax, m_rbins, m_rmin, m_rmax, m_zbins, m_zmin, m_zmax ) );
+  auto hphi( new TH3F( "hDistortionP_rec", "hDistortionP_rec", m_phibins, m_phimin, m_phimax, m_rbins, m_rmin, m_rmax, m_zbins, m_zmin, m_zmax ) );
+  auto hz( new TH3F( "hDistortionZ_rec", "hDistortionZ_rec", m_phibins, m_phimin, m_phimax, m_rbins, m_rmin, m_rmax, m_zbins, m_zmin, m_zmax ) );
+  auto hr( new TH3F( "hDistortionR_rec", "hDistortionR_rec", m_phibins, m_phimin, m_phimax, m_rbins, m_rmin, m_rmax, m_zbins, m_zmin, m_zmax ) );
 
   // set axis labels
-  for( auto h:{ hentries, hphi, hz, hr } )
+  for( const auto& h:{ hentries, hphi, hz, hr } )
   {
     h->GetXaxis()->SetTitle( "#phi (rad)" );
     h->GetYaxis()->SetTitle( "r (cm)" );
@@ -503,14 +699,28 @@ void TpcSpaceChargeReconstruction::calculate_distortions( PHCompositeNode* topNo
   std::unique_ptr<TFile> outputfile( TFile::Open( m_outputfile.c_str(), "RECREATE" ) );
   outputfile->cd();
 
-  // save histograms
+  // when using migromegas, one needs to extrapolate to the rest of the acceptance
+  if( m_use_micromegas )
+  {
+    for( const auto& h: {hentries, hphi, hr, hz} )
+    {
+      if( !h ) continue;
+      extrapolate_z(h);
+      extrapolate_phi1(h);
+      extrapolate_phi2(h);
+    }
+  }
+
+  // write source histograms
   for( const auto& h: { hentries, hphi, hr, hz } ) { h->Write(); }
 
-  // also create and write histograms suitable for space charge correction
+  // create and write histograms suitable for space charge reconstruction
   create_histogram( hentries, "hentries" )->Write();
   create_histogram( hphi, "hIntDistortionP" )->Write();
   create_histogram( hr, "hIntDistortionR" )->Write();
   create_histogram( hz, "hIntDistortionZ" )->Write();
+
+  // close output file
   outputfile->Close();
 
 }

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -139,7 +139,8 @@ namespace
 //_____________________________________________________________________
 TpcSpaceChargeReconstruction::TpcSpaceChargeReconstruction( const std::string& name ):
   SubsysReco( name)
-{}
+  , PHParameterInterface(name)
+{ InitializeParameters(); }
 
 //_____________________________________________________________________
 void TpcSpaceChargeReconstruction::set_grid_dimensions( int phibins, int rbins, int zbins )
@@ -167,6 +168,15 @@ int TpcSpaceChargeReconstruction::Init(PHCompositeNode* topNode )
 //_____________________________________________________________________
 int TpcSpaceChargeReconstruction::InitRun(PHCompositeNode* )
 {
+
+  // load parameters
+  UpdateParametersWithMacro();
+  m_max_talpha = get_double_param( "spacecharge_max_talpha" );
+  m_max_drphi = get_double_param( "spacecharge_max_drphi" );
+  m_max_tbeta = get_double_param( "spacecharge_max_tbeta" );
+  m_max_dz = get_double_param( "spacecharge_max_dz" );
+
+  // print
   std::cout
     << "TpcSpaceChargeReconstruction::InitRun\n"
     << " m_outputfile: " << m_outputfile << "\n"
@@ -175,7 +185,12 @@ int TpcSpaceChargeReconstruction::InitRun(PHCompositeNode* )
     << " m_rbins: " << m_rbins << "\n"
     << " m_zbins: " << m_zbins << "\n"
     << " m_totalbins: " << m_totalbins << "\n"
+    << " m_max_talpha: " << m_max_talpha << "\n"
+    << " m_max_drphi: " << m_max_drphi << "\n"
+    << " m_max_tbeta: " << m_max_tbeta << "\n"
+    << " m_max_dz: " << m_max_dz << "\n"
     << std::endl;
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -195,6 +210,16 @@ int TpcSpaceChargeReconstruction::End(PHCompositeNode* topNode )
 {
   calculate_distortions( topNode );
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//___________________________________________________________________________
+void TpcSpaceChargeReconstruction::SetDefaultParameters()
+{
+  // residual cuts
+  set_default_double_param( "spacecharge_max_talpha", 0.6 );
+  set_default_double_param( "spacecharge_max_drphi", 0.5 );
+  set_default_double_param( "spacecharge_max_tbeta", 1.5 );
+  set_default_double_param( "spacecharge_max_dz", 0.5 );
 }
 
 //_____________________________________________________________________
@@ -377,15 +402,11 @@ void TpcSpaceChargeReconstruction::process_track( SvtxTrack* track )
     }
 
     // check against limits
-    static constexpr float max_talpha = 0.6;
-    static constexpr float max_residual_drphi = 0.5;
-    if( std::abs( talpha ) > max_talpha ) continue;
-    if( std::abs( drp ) > max_residual_drphi ) continue;
+    if( std::abs( talpha ) > m_max_talpha ) continue;
+    if( std::abs( drp ) > m_max_drphi ) continue;
 
-    static constexpr float max_tbeta = 1.5;
-    static constexpr float max_residual_dz = 0.5;
-    if( std::abs( tbeta ) > max_tbeta ) continue;
-    if( std::abs( dz ) > max_residual_dz ) continue;
+    if( std::abs( tbeta ) > m_max_tbeta ) continue;
+    if( std::abs( dz ) > m_max_dz ) continue;
 
     // get cell
     const auto i = get_cell( cluster );

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
@@ -162,6 +162,15 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
   /// keep track of how many clusters are used per cell
   std::vector<int> m_cluster_count;
 
+  ///@name counters
+  //@{
+  int m_total_tracks = 0;
+  int m_accepted_tracks = 0;
+
+  int m_total_clusters = 0;
+  int m_accepted_clusters = 0;
+  //@}
+  
   ///@name nodes
   //@{
   SvtxTrackMap* m_track_map = nullptr;

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
@@ -6,7 +6,7 @@
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  */
 #include <fun4all/SubsysReco.h>
-#include <trackbase/TrkrDefs.h>
+#include <phparameter/PHParameterInterface.h>
 
 #include <Eigen/Core>
 #include <Eigen/Dense>
@@ -33,7 +33,7 @@ class TrkrClusterContainer;
  The inversion is performed in TpcSpaceChargeReconstruction::calculate_distortions
  */
 
-class TpcSpaceChargeReconstruction: public SubsysReco
+class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterface
 {
   public:
 
@@ -64,16 +64,19 @@ class TpcSpaceChargeReconstruction: public SubsysReco
   //@}
 
   /// global initialization
-  virtual int Init(PHCompositeNode*);
+  int Init(PHCompositeNode*) override;
 
   /// run initialization
-  virtual int InitRun(PHCompositeNode*);
+  int InitRun(PHCompositeNode*) override;
 
   /// event processing
-  virtual int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   /// end of processing
-  virtual int End(PHCompositeNode*);
+  int End(PHCompositeNode*) override;
+
+  //! parameters
+  void SetDefaultParameters() override;
 
   private:
 
@@ -116,21 +119,32 @@ class TpcSpaceChargeReconstruction: public SubsysReco
 
   // TODO: could try to get the r and z range from TPC geometry
   // r range
-  float m_rmin = 20;
-  float m_rmax = 78;
+  static constexpr float m_rmin = 20;
+  static constexpr float m_rmax = 78;
 
   // z range
-  float m_zmin = -105.5;
-  float m_zmax = 105.5;
+  static constexpr float m_zmin = -105.5;
+  static constexpr float m_zmax = 105.5;
 
   //@}
 
-  ///@name grid size
+  //!@name grid size
   //@{
   int m_phibins = 36;
   int m_rbins = 16;
   int m_zbins = 80;
   int m_totalbins = m_phibins*m_rbins*m_zbins;
+  //@}
+
+  //!@name selection parameters
+  //@{
+  // residual cuts in r, phi plane
+  float m_max_talpha = 0.6;
+  float m_max_drphi = 0.5;
+
+  // residual cuts in r, z plane
+  float m_max_tbeta = 1.5;
+  float m_max_dz = 0.5;
   //@}
 
   // shortcut for relevant eigen matrices

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
@@ -16,6 +16,7 @@
 // forward declaration
 class SvtxTrack;
 class SvtxTrackMap;
+class TH3;
 class TrkrCluster;
 class TrkrClusterContainer;
 
@@ -75,7 +76,7 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
   /// end of processing
   int End(PHCompositeNode*) override;
 
-  //! parameters
+  /// parameters
   void SetDefaultParameters() override;
 
   private:
@@ -128,7 +129,7 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
 
   //@}
 
-  //!@name grid size
+  ///@name grid size
   //@{
   int m_phibins = 36;
   int m_rbins = 16;
@@ -136,7 +137,7 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
   int m_totalbins = m_phibins*m_rbins*m_zbins;
   //@}
 
-  //!@name selection parameters
+  ///@name selection parameters
   //@{
   // residual cuts in r, phi plane
   float m_max_talpha = 0.6;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR updates the space charge reconstruction code to align with latest results presented at collaboration meeting: 
- allows to configure maximum residuals and local track angles from steering macro
- properly account from track errors when forming the residual-based chisquare used for the distortion reconstruction
- when micromegas are used, extrapolate the reconstructed distortions to regions of the TPC acceptance that are not covered with Micromegas. Right now this extrapolation uses a number of hard coded numbers, from our "baseline" micromegas configuration. This will be updated and made more flexible once we converge on a setup for the Micromegas modules (both number of modules and position)

Remark: in principle this PR could be 'rebased' rather than 'merged' on top of current master

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

