### PR TITLE
Handle in extreme rare cases, noise hits can make a track with no `maxtruthparticle` matched

### DIFF
--- a/simulation/g4simulation/g4eval/JetRecoEval.cc
+++ b/simulation/g4simulation/g4eval/JetRecoEval.cc
@@ -1117,17 +1117,12 @@ float JetRecoEval::get_energy_contribution(Jet* recojet, Jet* truthjet)
 
         PHG4Particle* maxtruthparticle = get_svtx_eval_stack()->get_track_eval()->max_truth_particle_by_nclusters(track);
 
-        if (_strict)
+        if (maxtruthparticle == nullptr)
         {
-          assert(maxtruthparticle);
+          // in extreme rare cases, noise hits can make a track with no maxtruthparticle matched
+          energy = 0;
         }
-        else if (!maxtruthparticle)
-        {
-          ++_errors;
-          continue;
-        }
-
-        if (maxtruthparticle->get_track_id() == truthparticle->get_track_id())
+        else if (maxtruthparticle->get_track_id() == truthparticle->get_track_id())
         {
           energy = track->get_p();
         }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Thanks to @cdean-github , who during the HF MDC1 test production found rare cases where 
```c++
maxtruthparticle = get_svtx_eval_stack()->get_track_eval()->max_truth_particle_by_nclusters(track);
```` 
would return `nullptr`. In extremes rare cases, noise hits in tracker could make a track and has no truth particle matching. Such case previously generates an `assert` error in the strict mode. This PR allow such case and handle it in the jeteval.  

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

