### PR TITLE
FastSim Exception in TrackEval + Custom TrackNodeName Functions

### DIFF
--- a/simulation/g4simulation/g4eval/BaseTruthEval.cc
+++ b/simulation/g4simulation/g4eval/BaseTruthEval.cc
@@ -528,6 +528,11 @@ PHG4Particle* BaseTruthEval::get_primary_particle(PHG4Hit* g4hit)
   return primary;
 }
 
+PHG4Particle* BaseTruthEval::get_particle(const int trackid)
+{
+  return m_TruthInfo->GetParticle(trackid);
+}
+
 bool BaseTruthEval::is_g4hit_from_primary_shower(PHG4Hit* g4hit, PHG4Shower* shower)
 {
   if (!has_reduced_node_pointers())

--- a/simulation/g4simulation/g4eval/BaseTruthEval.h
+++ b/simulation/g4simulation/g4eval/BaseTruthEval.h
@@ -82,6 +82,9 @@ class BaseTruthEval
   /// which primary particle resulted in this truth hit?
   PHG4Particle* get_primary_particle(PHG4Hit* g4hit);
 
+  /// which is the particle associated with this track ID?
+  PHG4Particle* get_particle(const int trackid); 
+
   /// is this truth hit inside this shower?
   bool is_g4hit_from_primary_shower(PHG4Hit* g4hit, PHG4Shower* shower);
 

--- a/simulation/g4simulation/g4eval/JetRecoEval.cc
+++ b/simulation/g4simulation/g4eval/JetRecoEval.cc
@@ -470,7 +470,7 @@ std::set<PHG4Particle*> JetRecoEval::all_truth_particles(Jet* recojet)
     {
       if (!_trackmap)
       {
-        cout << PHWHERE << "ERROR: can't find SvtxTrackMap" << endl;
+        cout << PHWHERE << "ERROR: can't find TrackMap" << endl;
         exit(-1);
       }
 

--- a/simulation/g4simulation/g4eval/JetRecoEval.cc
+++ b/simulation/g4simulation/g4eval/JetRecoEval.cc
@@ -100,6 +100,12 @@ void JetRecoEval::next_event(PHCompositeNode* topNode)
   get_node_pointers(topNode);
 }
 
+void JetRecoEval:: set_track_nodename (const string & name) 
+{
+  m_TrackNodeName = name;
+  _jettrutheval.set_track_nodename (name);
+}
+
 std::set<PHG4Shower*> JetRecoEval::all_truth_showers(Jet* recojet)
 {
   if (_strict)
@@ -1073,7 +1079,6 @@ float JetRecoEval::get_energy_contribution(Jet* recojet, Jet* truthjet)
   float energy_contribution = 0.0;
 
   std::set<PHG4Particle*> truthjetcomp = get_truth_eval()->all_truth_particles(truthjet);
-
   // loop over all truthjet constituents
   for (std::set<PHG4Particle*>::iterator iter = truthjetcomp.begin();
        iter != truthjetcomp.end();

--- a/simulation/g4simulation/g4eval/JetRecoEval.h
+++ b/simulation/g4simulation/g4eval/JetRecoEval.h
@@ -121,7 +121,7 @@ class JetRecoEval
   /// what was the energy contribution to this reconstructed jet from a particular source
   float get_energy_contribution(Jet* recojet, Jet::SRC src);
 
-  void set_track_nodename(const std::string& name) { m_TrackNodeName = name; }
+  void set_track_nodename(const std::string& name);
 
   // ---full sim node required--------------------------------------------------
 

--- a/simulation/g4simulation/g4eval/JetTruthEval.h
+++ b/simulation/g4simulation/g4eval/JetTruthEval.h
@@ -75,6 +75,12 @@ class JetTruthEval
     _eemcevalstack.set_verbosity(verbosity);
   }
 
+  //set track node name
+  void set_track_nodename(const std::string& name)
+  {
+    _svtxevalstack.set_track_nodename(name);
+  }
+
   /// get a copy of the lower level eval and its memory cache
   SvtxEvalStack* get_svtx_eval_stack() { return &_svtxevalstack; }
 

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -209,17 +209,7 @@ PHG4Particle* SvtxTrackEval::max_truth_particle_by_nclusters(SvtxTrack* track)
   {
     // exception for fast sim track
     unsigned int track_id = fastsim_track -> get_truth_track_id();
-
-    //g4_hit->track_id->(check if matches track)->get_truth_particle
-    std::set<PHG4Hit*> truth_hits = get_truth_eval()->all_truth_hits();
-    for(std::set<PHG4Hit*>::iterator iter = truth_hits.begin();
-        iter != truth_hits.begin();
-        ++iter)
-    {
-      PHG4Hit* hit_candidate = *iter; 
-      if (hit_candidate->get_trkid()==track_id)
-        max_particle = get_truth_eval()->get_particle(hit_candidate);
-    }
+    max_particle = get_truth_eval()->get_particle(track_id);
   }
   else
   {

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -1056,6 +1056,11 @@ PHG4Particle* SvtxTruthEval::get_primary_particle(PHG4Particle* particle)
   return _basetrutheval.get_primary_particle(particle);
 }
 
+PHG4Particle* SvtxTruthEval::get_particle(const int trackid)
+{
+  return _basetrutheval.get_particle(trackid);
+}
+
 bool SvtxTruthEval::is_g4hit_from_particle(PHG4Hit* g4hit, PHG4Particle* particle)
 {
   return _basetrutheval.is_g4hit_from_particle(g4hit, particle);

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -49,7 +49,7 @@ class SvtxTruthEval
   bool is_primary(PHG4Particle* particle);
   PHG4Particle* get_primary_particle(PHG4Hit* g4hit);
   PHG4Particle* get_primary_particle(PHG4Particle* particle);
-  PHG4Particle* get_particle(const int trackid);
+  PHG4Particle* get_particle(const int trackid); 
 
   std::map<unsigned int, std::shared_ptr<TrkrCluster> > all_truth_clusters(PHG4Particle* particle);
 

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -49,6 +49,7 @@ class SvtxTruthEval
   bool is_primary(PHG4Particle* particle);
   PHG4Particle* get_primary_particle(PHG4Hit* g4hit);
   PHG4Particle* get_primary_particle(PHG4Particle* particle);
+  PHG4Particle* get_particle(const int trackid);
 
   std::map<unsigned int, std::shared_ptr<TrkrCluster> > all_truth_clusters(PHG4Particle* particle);
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Added PHG4FastSim exceptions needed in jet truth-reco matching.
Added Ability to name TrackNodeName to support changes ("SvtxTrackMap" -> "TrackMap"). Call it in jet analysis module.
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

