### PR TITLE
PHHybridSeeding silicon matching improvements

### DIFF
--- a/offline/packages/trackreco/PHHybridSeeding.cc
+++ b/offline/packages/trackreco/PHHybridSeeding.cc
@@ -266,11 +266,6 @@ int PHHybridSeeding::Process(PHCompositeNode *topNode)
   for(auto clist : clusterLists)
   {
     if(clist.size()>1 && TrkrDefs::getLayer(clist[0])<TrkrDefs::getLayer(clist[1])) std::reverse(clist.begin(),clist.end());
-    cout << "track cluster layers: " << endl;
-    for(auto cluster : clist)
-    {
-      cout << (int)TrkrDefs::getLayer(cluster) << endl;
-    }
   }
   vector<SvtxTrack_v1> seeds = ALICEKalmanFilter(clusterLists,true);
   if(Verbosity()>0) cout << "nseeds: " << seeds.size() << "\n";

--- a/offline/packages/trackreco/PHHybridSeeding.h
+++ b/offline/packages/trackreco/PHHybridSeeding.h
@@ -71,6 +71,12 @@ class PHHybridSeeding : public PHTrackSeeding
   void setSearchAngle(float a1, float a2) {_search_angle1 = a1; _search_angle2 = a2;}
   void setMinTrackSize(size_t n1, size_t n2) {_min_track_size1 = n1; _min_track_size2 = n2;}
   void setNThreads(size_t n) {_nthreads = n;} 
+  void set_field_dir(const double rescale)
+  {
+    _fieldDir = -1;
+    if(rescale > 0)
+      _fieldDir = 1;
+  }
 
  protected:
   virtual int Setup(PHCompositeNode *topNode);

--- a/offline/packages/trackreco/PHHybridSeeding.h
+++ b/offline/packages/trackreco/PHHybridSeeding.h
@@ -63,20 +63,18 @@ class PHHybridSeeding : public PHTrackSeeding
   
   void set_field_dir(const double rescale)
   {
-    _fieldDir = -1;
     if(rescale > 0)
-      _fieldDir = 1;     
+      _fieldDir = 1;
+    else
+    {
+      _fieldDir = -1;
+      _Bz = -1*_Bz;
+    }  
   }
   void setSearchRadius(float r1, float r2) {_search_radius1 = r1; _search_radius2 = r2;}
   void setSearchAngle(float a1, float a2) {_search_angle1 = a1; _search_angle2 = a2;}
   void setMinTrackSize(size_t n1, size_t n2) {_min_track_size1 = n1; _min_track_size2 = n2;}
   void setNThreads(size_t n) {_nthreads = n;} 
-  void set_field_dir(const double rescale)
-  {
-    _fieldDir = -1;
-    if(rescale > 0)
-      _fieldDir = 1;
-  }
 
  protected:
   virtual int Setup(PHCompositeNode *topNode);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

The TPC-to-silicon matching (PHSiliconTpcTrackMatching) expects momentum estimates at the vertex, while the old PHHybridSeeding was providing these estimates at the position of the innermost cluster. In this PR, PHHybridSeeding now provides these estimates at the vertex, significantly improving the ease of matching.

Other changes:
- Reverse cluster chain output from seeding core if it's arranged inside-out
- Fixed TPC tracklet charge assignment by flipping Bz when the parameter _fieldDir is negative
- Minor fixes to KF internals, improving numerical stability

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

