### PR TITLE
fix vertex node access

### DIFF
--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -283,19 +283,18 @@ void PHActsTracks::createNodes(PHCompositeNode *topNode)
 
 int PHActsTracks::getNodes(PHCompositeNode *topNode)
 {
-  m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+  std::string mapName = "SvtxVertexMap";
+  if(m_secondFit)
+    mapName = "SvtxVertexMapActs";
+
+  m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, mapName.c_str());
   if (!m_vertexMap)
     {
-      /// Check the Acts vertex map node
-      m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMapActs");
-      if(!m_vertexMap)
-	{
-
-	  std::cout << PHWHERE << "SvtxVertexMap not found on node tree. Exiting."
-		    << std::endl;
-	  
-	  return Fun4AllReturnCodes::ABORTEVENT;
-	}
+      std::cout << PHWHERE << "SvtxVertexMap not found on node tree. Exiting."
+		<< std::endl;
+      
+      return Fun4AllReturnCodes::ABORTEVENT;
+	
     }
 
   m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");

--- a/offline/packages/trackreco/PHActsTracks.h
+++ b/offline/packages/trackreco/PHActsTracks.h
@@ -58,6 +58,9 @@ class PHActsTracks : public SubsysReco
   void setTruthTrackSeeding(bool truthTrackSeeding)
   { m_truthTrackSeeding = truthTrackSeeding;}
 
+  void setSecondFit(bool secondFit)
+  { m_secondFit = secondFit;}
+
  private:
   /** 
    * Member functions
@@ -97,6 +100,9 @@ class PHActsTracks : public SubsysReco
   ActsTrackingGeometry *m_tGeometry;
 
   bool m_truthTrackSeeding = false;
+  
+  /// Boolean for running the second fit pass
+  bool m_secondFit = false;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I inadvertently added a bug into the vertex node accessing when trying to make the QA happy. This PR fixes that so that the second track fit pass actually access the final vertexing map `SvtxTrackMapActs` instead of the default `SvtxVertexMap`.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

Macros [PR](https://github.com/sPHENIX-Collaboration/macros/pull/366)

