### PR TITLE
Set Acts Vertex Finder to use SvtxVertexMap

### DIFF
--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -289,11 +289,7 @@ void PHActsTracks::createNodes(PHCompositeNode *topNode)
 
 int PHActsTracks::getNodes(PHCompositeNode *topNode)
 {
-  std::string mapName = "SvtxVertexMap";
-  if(m_secondFit)
-    mapName = "SvtxVertexMapActs";
-
-  m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, mapName.c_str());
+  m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
   if (!m_vertexMap)
     {
       std::cout << PHWHERE << "SvtxVertexMap not found on node tree. Exiting."

--- a/offline/packages/trackreco/PHActsTracks.cc
+++ b/offline/packages/trackreco/PHActsTracks.cc
@@ -122,12 +122,11 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
 
     Acts::Vector3D vertex = {vertX, vertY, vertZ};
     
-    if(Verbosity() > 4)
+    if(Verbosity() > 2)
       {
-	std::cout << "Vertex estimate : ("; 
-	for(int i = 0; i < vertex.size(); i++)
-	  std::cout<<vertex(i)<<", ";
-	std::cout << ")" << std::endl;
+	std::cout << "Vertex estimate :"
+		  << vertex.transpose()
+		  <<std::endl;
       }
 
     /// Get the necessary parameters and values for the TrackParameters
@@ -138,10 +137,17 @@ int PHActsTracks::process_event(PHCompositeNode *topNode)
     /// just set to 10 ns for now. Time isn't needed by Acts, only if TOF is present
     const double trackTime = 10 * Acts::UnitConstants::ns;
 
-    Acts::Vector4D seed4Vec(track->get_x()  * Acts::UnitConstants::cm,
-			    track->get_y()  * Acts::UnitConstants::cm,
-			    track->get_z()  * Acts::UnitConstants::cm,
-			    trackTime);
+    double trackX = track->get_x()  * Acts::UnitConstants::cm;
+    double trackY = track->get_y()  * Acts::UnitConstants::cm;
+    double trackZ = track->get_z()  * Acts::UnitConstants::cm;
+    if(m_secondFit && svtxVertex){
+      trackX = vertX;
+      trackY = vertY;
+      trackZ = vertZ;
+
+    }
+
+    Acts::Vector4D seed4Vec(trackX, trackY, trackZ, trackTime);
     
     if(m_truthTrackSeeding)
       {

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -620,8 +620,11 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
   /// vertex fitting in PHActsVertexFinder
   track->set_dca3d_xy(dca3Dxy / Acts::UnitConstants::cm);
   track->set_dca3d_z(dca3Dz / Acts::UnitConstants::cm);
-  track->set_dca3d_xy_error(sqrt(dca3DxyCov) / Acts::UnitConstants::cm);
-  track->set_dca3d_z_error(sqrt(dca3DzCov) / Acts::UnitConstants::cm);
+
+  /// The covariance that goes into the rotater is already in sphenix
+  /// units, so we don't need to convert back
+  track->set_dca3d_xy_error(sqrt(dca3DxyCov));
+  track->set_dca3d_z_error(sqrt(dca3DzCov));
   
   // Also need to update the state list and cluster ID list for all measurements associated with the acts track  
   // loop over acts track states, copy over to SvtxTrackStates, and add to SvtxTrack

--- a/offline/packages/trackreco/PHActsVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsVertexFinder.cc
@@ -93,7 +93,10 @@ int PHActsVertexFinder::Process(PHCompositeNode *topNode)
       delete track;
     }
 
-  m_svtxVertexMapActs = dynamic_cast<SvtxVertexMap*>(m_svtxVertexMap->CloneMe());
+  for(auto [key, svtxVertex] : *m_svtxVertexMap)
+    { 
+      m_svtxVertexMapActs->insert(dynamic_cast<SvtxVertex*>(svtxVertex->CloneMe()));
+    }
 
   if(Verbosity() > 0)
     std::cout << "Finished PHActsVertexFinder::process_event" << std::endl;

--- a/offline/packages/trackreco/PHActsVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsVertexFinder.cc
@@ -313,6 +313,8 @@ void PHActsVertexFinder::fillVertexMap(VertexVector& vertices,
 	  const auto trackKey = keyMap.find(originalParams)->second;
 	  svtxVertex->insert_track(trackKey);
 
+	  const auto svtxTrack = m_svtxTrackMap->find(trackKey)->second;
+	  svtxTrack->set_vertex_id(key);
 	  updateTrackDCA(trackKey, Acts::Vector3D(vertexX,
 						  vertexY,
 						  vertexZ));
@@ -328,6 +330,17 @@ void PHActsVertexFinder::fillVertexMap(VertexVector& vertices,
       ++key;
     }
       
+
+
+  if(Verbosity() > 2)
+    {
+      std::cout << "Identify vertices in vertex map" << std::endl;
+      for(auto& [key, vert] : *m_svtxVertexMap)
+	{
+	  vert->identify();
+	}
+    }
+
   return;
 }
 

--- a/offline/packages/trackreco/PHActsVertexFinder.h
+++ b/offline/packages/trackreco/PHActsVertexFinder.h
@@ -79,7 +79,12 @@ class PHActsVertexFinder: public PHInitVertexing
   /// Maximum number of vertices that the Acts finder is allowed
   /// to find
   int m_maxVertices = 20;
+
+  int m_goodFits = 0;
+  int m_totalFits = 0;
+
   SvtxVertexMap *m_svtxVertexMap = nullptr;
+  SvtxVertexMap *m_svtxVertexMapActs = nullptr;
   ActsTrackingGeometry *m_tGeometry = nullptr;
   SvtxTrackMap *m_svtxTrackMap = nullptr;
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This PR switches the ActsVertexFinder to use the SvtxVertexMap only, and then creates an SvtxVertexMapActs as a clone of the original vertex map. It also resets the track seed position to the vertex for the second fit pass

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

