### PR TITLE
Tune silicon tpc matcher

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -118,7 +118,7 @@ int PHSiliconTpcTrackMatching::Process()
 
       double tpc_phi = atan2(_tracklet_tpc->get_py(), _tracklet_tpc->get_px());
       double tpc_eta = _tracklet_tpc->get_eta();
-      //double tpc_pt = sqrt( pow(_tracklet_tpc->get_px(),2) + pow(_tracklet_tpc->get_py(),2) );
+      double tpc_pt = sqrt( pow(_tracklet_tpc->get_px(),2) + pow(_tracklet_tpc->get_py(),2) );
 
       // phi correction for PHTpcTracker tracklets is charge dependent
       double sign_phi_correction = _tracklet_tpc->get_charge();
@@ -169,7 +169,7 @@ int PHSiliconTpcTrackMatching::Process()
 
 	  double si_phi = atan2(_tracklet_si->get_py(), _tracklet_si->get_px());
 	  double si_eta = _tracklet_si->get_eta();
-	  double si_pt = sqrt(pow(_tracklet_si->get_px(), 2) + pow(_tracklet_si->get_py(), 2) );
+	  //double si_pt = sqrt(pow(_tracklet_si->get_px(), 2) + pow(_tracklet_si->get_py(), 2) );
 
 	  if(Verbosity() >= 2)
 	    {
@@ -190,15 +190,22 @@ int PHSiliconTpcTrackMatching::Process()
 	  else
 	    {
 	      // PHTpcTracker
-	      double si_pt = sqrt( pow(_tracklet_si->get_px(),2) + pow(_tracklet_si->get_py(),2) );
-	      double phi_search_win_lo = fdphi->Eval(si_pt) * sign_phi_correction -  _phi_search_win * mag;
-	      double phi_search_win_hi = fdphi->Eval(si_pt) * sign_phi_correction +  _phi_search_win * mag;
+	      //double si_pt = sqrt( pow(_tracklet_si->get_px(),2) + pow(_tracklet_si->get_py(),2) );
+	      double phi_search_win_lo = fdphi->Eval(tpc_pt) * sign_phi_correction -  _phi_search_win * mag;
+	      double phi_search_win_hi = fdphi->Eval(tpc_pt) * sign_phi_correction +  _phi_search_win * mag;
 
 	      if(Verbosity() > 10) 
 		cout << " phi_search_win_lo " << phi_search_win_lo << " phi_search_win_hi " << phi_search_win_hi << endl;
 
 	      if(  (tpc_phi - si_phi) > phi_search_win_lo && (tpc_phi - si_phi) < phi_search_win_hi) phi_match = true;	      
 	    }
+
+	  /*
+	  // temporary for debugging!
+	  if(_test_windows)
+	    cout << " Try_silicon:  pt " << tpc_pt << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi-si_phi  
+		 << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " deta " << tpc_eta-si_eta << endl;
+	  */	  
 	  
 	  if(eta_match && phi_match)
 	    {
@@ -210,8 +217,9 @@ int PHSiliconTpcTrackMatching::Process()
 		       << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " eta_match " << eta_match << endl;
 		}
 
+	      // temporary!
 	      if(_test_windows)
-		cout << " Try_silicon:  pt " << si_pt << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi-si_phi  
+		cout << " Try_silicon:  pt " << tpc_pt << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi-si_phi  
 		     << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " deta " << tpc_eta-si_eta << endl;
 
 	      si_matches.insert(_tracklet_si->get_id());
@@ -249,7 +257,11 @@ int PHSiliconTpcTrackMatching::Process()
 	    }
 	  else
 	    {
-	      std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId << " associated with TPC tracklet " << _tracklet_tpc->get_id() << std::endl; 
+	      std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId 
+			<< " associated with TPC tracklet " << _tracklet_tpc->get_id() 
+			<< " si tracklet " << _tracklet_si->get_id()
+			<< " set vertex to (0,0,0)"
+			<< std::endl; 
 	      std::cout << " ---------- Silicon track --------------" << std::endl;
 	      _tracklet_si->identify();
 	      std::cout << " ---------- TPC track -----------------" << std::endl;
@@ -300,7 +312,11 @@ int PHSiliconTpcTrackMatching::Process()
 		}
 	      else
 		{
-		  std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId << " associated with TPC tracklet " << _tracklet_tpc->get_id() << std::endl; 
+		  std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId 
+			    << " associated with TPC tracklet " << _tracklet_tpc->get_id() 
+			    << " si tracklet " << _tracklet_si->get_id()
+			    << " set vertex to (0,0,0)"
+			    << std::endl; 
 		  std::cout << " ---------- Silicon track --------------" << std::endl;
 		  _tracklet_si->identify();
 		  std::cout << " ---------- TPC track -----------------" << std::endl;

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -134,10 +134,10 @@ int PHSiliconTpcTrackMatching::Process()
       // hard code this here for now
       // this factor will increase the window size at low pT
       // otherwise the matching efficiency drops off at low pT
-      // not well optimized yet - smaller may work
+      // it would be better if this was a smooth function
       double mag = 1.0;
-      //if(tpc_pt < 5) mag = 2.0;
-      //if(tpc_pt < 2) mag = 4.0;
+      if(tpc_pt < 6.0) mag = 2;
+      if(tpc_pt < 2.0)  mag = 4.0;
 
       if(Verbosity() > 3)
 	{

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -137,7 +137,7 @@ int PHSiliconTpcTrackMatching::Process()
       // it would be better if this was a smooth function
       double mag = 1.0;
       if(tpc_pt < 6.0) mag = 2;
-      if(tpc_pt < 2.0)  mag = 4.0;
+      if(tpc_pt < 3.0)  mag = 4.0;
 
       if(Verbosity() > 3)
 	{

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -103,7 +103,7 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 
       if(g4particle_vec.size() < 1) continue;
 
-      bool test_phi_matching = true;   // normally false
+      bool test_phi_matching = false;   // normally false
       if(test_phi_matching)
 	{
 	  // for getting the pT dependence of dphi  to eliminate the bias in phi from PHTpcTracker


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR significantly optimizes the search windows in PHSiliconTpcTrackMatching for high occupancy events. The MVTX matching efficiency after the optimization is ~ 93% above pT = 1 GeV/c. The matching efficiency at low pT is greatly improved over the previous tune. The new silicon matching efficiency vs pT is shown in the attached figure.
[MVTX_assoc_MB_pileup.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/5955386/MVTX_assoc_MB_pileup.pdf)


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

