### PR TITLE
Remove g4cout

### DIFF
--- a/simulation/g4simulation/g4decayer/G4Pythia6Decayer.cc
+++ b/simulation/g4simulation/g4decayer/G4Pythia6Decayer.cc
@@ -45,7 +45,6 @@
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Track.hh>
 #include <Geant4/G4VExtDecayer.hh>  // for G4VExtDecayer
-#include <Geant4/G4ios.hh>          // for G4cout, G4endl
 
 #include <CLHEP/Vector/LorentzVector.h>
 
@@ -575,7 +574,7 @@ G4DecayProducts* G4Pythia6Decayer::ImportDecayProducts(const G4Track& track)
 
   if (fVerboseLevel > 0)
   {
-    G4cout << "nofParticles: " << nofParticles << G4endl;
+    std::cout << "nofParticles: " << nofParticles << std::endl;
   }
 
   // convert decay products Pythia6Particle type
@@ -598,7 +597,7 @@ G4DecayProducts* G4Pythia6Decayer::ImportDecayProducts(const G4Track& track)
 
       if (fVerboseLevel > 0)
       {
-        G4cout << "  " << i << "th particle PDG: " << pdg << "   ";
+        std::cout << "  " << i << "th particle PDG: " << pdg << "   ";
       }
 
       // create G4DynamicParticle
@@ -608,9 +607,9 @@ G4DecayProducts* G4Pythia6Decayer::ImportDecayProducts(const G4Track& track)
       {
         if (fVerboseLevel > 0)
         {
-          G4cout << "  G4 particle name: "
+          std::cout << "  G4 particle name: "
                  << dynamicParticle->GetDefinition()->GetParticleName()
-                 << G4endl;
+                 << std::endl;
         }
 
         // add dynamicParticle to decayProducts
@@ -622,7 +621,7 @@ G4DecayProducts* G4Pythia6Decayer::ImportDecayProducts(const G4Track& track)
   }
   if (fVerboseLevel > 0)
   {
-    G4cout << "nofParticles for tracking: " << counter << G4endl;
+    std::cout << "nofParticles for tracking: " << counter << std::endl;
   }
 
   return decayProducts;

--- a/simulation/g4simulation/g4decayer/P6DExtDecayerPhysics.cc
+++ b/simulation/g4simulation/g4decayer/P6DExtDecayerPhysics.cc
@@ -42,7 +42,6 @@
 #include <Geant4/G4VPhysicsConstructor.hh>
 #include <Geant4/G4VProcess.hh>  // for G4VProcess
 #include <Geant4/G4Version.hh>
-#include <Geant4/G4ios.hh>  // for G4cout, G4endl
 
 #include <ostream>  // for operator<<, basic_ostream
 #include <string>   // for operator<<
@@ -100,9 +99,9 @@ void P6DExtDecayerPhysics::ConstructProcess()
 
     if (verboseLevel > 1)
     {
-      G4cout << "Setting ext decayer for: "
+      std::cout << "Setting ext decayer for: "
              << aParticleIterator->value()->GetParticleName()
-             << G4endl;
+             << std::endl;
     }
 
     G4ProcessVector* processVector = pmanager->GetProcessList();
@@ -138,7 +137,7 @@ void P6DExtDecayerPhysics::ConstructProcess()
   }
   if (verboseLevel > 0)
   {
-    G4cout << "External decayer physics constructed." << G4endl;
+    std::cout << "External decayer physics constructed." << std::endl;
   }
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4RICHSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4RICHSteppingAction.cc
@@ -37,7 +37,6 @@
 #include <Geant4/G4VProcess.hh>               // for G4VProcess
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
-#include <Geant4/G4ios.hh>                    // for G4endl
 #include <Geant4/globals.hh>                  // for G4Exception, G4Exceptio...
 
 #include <cassert>                           // for assert
@@ -108,7 +107,7 @@ void PHG4RICHSteppingAction::UserSteppingAction(const G4Step* aStep)
           G4ExceptionDescription ed;
           ed << "EicRichGemTbSteppingAction::UserSteppingAction(): "
              << "No reallocation step after reflection!"
-             << G4endl;
+             << std::endl;
           G4Exception("EicRichGemTbSteppingAction::UserSteppingAction()", "EicRichGemTbExpl01",
                       FatalException, ed,
                       "Something is wrong with the surface normal or geometry");

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
@@ -27,7 +27,6 @@
 #include <Geant4/G4Transform3D.hh>    // for G4Transform3D, G4RotateX3D
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4Types.hh>              // for G4int
-#include <Geant4/G4ios.hh>    // for G4cout, G4endl
 #include <Geant4/globals.hh>  // for G4Exception
 
 #include <algorithm>  // for max
@@ -139,7 +138,7 @@ void PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *WorldLog)
     std::string msg = "Can not find definition of material ";
     msg += geom.get_material();
 
-    G4cout << "PHG4SectorConstructor::Construct_Sectors - ERROR -" << msg << ". Print all available materials:" << G4endl;
+    std::cout << "PHG4SectorConstructor::Construct_Sectors - ERROR -" << msg << ". Print all available materials:" << std::endl;
 
     for (G4MaterialTable::const_iterator it =
              (G4Material::GetMaterialTable())->begin();
@@ -216,14 +215,14 @@ void PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *WorldLog)
   m_DisplayAction->AddVolume(DetectorLog_Det, "DetectorBox");
   if (Verbosity() > 1)
   {
-    G4cout << "PHG4SectorConstructor::Construct_Sectors::" << name_base
+    std::cout << "PHG4SectorConstructor::Construct_Sectors::" << name_base
 	   << " - total thickness = " << geom.get_total_thickness() / cm << " cm"
-	   << G4endl;
-    G4cout << "PHG4SectorConstructor::Construct_Sectors::" << name_base << " - "
-	   << map_log_vol.size() << " logical volume constructed" << G4endl;
-    G4cout << "PHG4SectorConstructor::Construct_Sectors::" << name_base << " - "
+	   << std::endl;
+    std::cout << "PHG4SectorConstructor::Construct_Sectors::" << name_base << " - "
+	   << map_log_vol.size() << " logical volume constructed" << std::endl;
+    std::cout << "PHG4SectorConstructor::Construct_Sectors::" << name_base << " - "
 	   << map_phy_vol.size() << " physical volume constructed; "
-	   << map_active_phy_vol.size() << " is active." << G4endl;
+	   << map_active_phy_vol.size() << " is active." << std::endl;
   }
 }
 
@@ -282,15 +281,15 @@ PHG4SectorConstructor::RegisterLogicalVolume(G4LogicalVolume *v)
 {
   if (!v)
   {
-    G4cout
+    std::cout
         << "PHG4SectorConstructor::RegisterVolume - Error - invalid volume!"
-        << G4endl;
+        << std::endl;
     return v;
   }
   if (map_log_vol.find(v->GetName()) != map_log_vol.end())
   {
-    G4cout << "PHG4SectorConstructor::RegisterVolume - Warning - replacing "
-           << v->GetName() << G4endl;
+    std::cout << "PHG4SectorConstructor::RegisterVolume - Warning - replacing "
+           << v->GetName() << std::endl;
   }
 
   map_log_vol[v->GetName()] = v;
@@ -304,9 +303,9 @@ PHG4SectorConstructor::RegisterPhysicalVolume(G4PVPlacement *v,
 {
   if (!v)
   {
-    G4cout
+    std::cout
         << "PHG4SectorConstructor::RegisterPhysicalVolume - Error - invalid volume!"
-        << G4endl;
+        << std::endl;
     return v;
   }
 
@@ -314,9 +313,9 @@ PHG4SectorConstructor::RegisterPhysicalVolume(G4PVPlacement *v,
 
   if (map_phy_vol.find(id) != map_phy_vol.end())
   {
-    G4cout
+    std::cout
         << "PHG4SectorConstructor::RegisterPhysicalVolume - Warning - replacing "
-        << v->GetName() << "[" << v->GetCopyNo() << "]" << G4endl;
+        << v->GetName() << "[" << v->GetCopyNo() << "]" << std::endl;
   }
 
   map_phy_vol[id] = v;

--- a/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4mRICHDetector.cc
@@ -40,7 +40,6 @@
 #include <Geant4/G4Types.hh>                    // for G4double, G4int
 #include <Geant4/G4VPhysicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4ios.hh>  // for G4cout, G4endl
 
 #include <algorithm>  // for fill, max
 #include <cmath>      // for floor, sqrt, acos, asin
@@ -254,7 +253,7 @@ G4double PHG4mRICHDetector::LensPar::GetSagita(G4double r)
 
   if (ArgSqrt < 0.0)
   {
-    G4cout << "UltraFresnelLensParameterisation::Sagita: Square Root of <0 !" << G4endl;
+    std::cout << "UltraFresnelLensParameterisation::Sagita: Square Root of <0 !" << std::endl;
   }
 
   G4double Sagita_value = Curvature * std::pow(r, 2) / (1.0 + std::sqrt(ArgSqrt)) + TotAspher;

--- a/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.cc
+++ b/simulation/g4simulation/g4detectors/ePHENIXRICHConstruction.cc
@@ -36,7 +36,6 @@
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4Types.hh>                    // for G4double, G4int
 #include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
-#include <Geant4/G4ios.hh>              // for G4cout, G4endl
 
 #include <cassert>
 #include <cmath>
@@ -66,14 +65,14 @@ G4LogicalVolume *ePHENIXRICHConstruction::RegisterLogicalVolume(G4LogicalVolume 
 {
   if (!v)
   {
-    G4cout << "ePHENIXRICHConstruction::RegisterVolume - Error - invalid volume!"
-           << G4endl;
+    std::cout << "ePHENIXRICHConstruction::RegisterVolume - Error - invalid volume!"
+           << std::endl;
     return v;
   }
   if (map_log_vol.find(v->GetName()) != map_log_vol.end())
   {
-    G4cout << "ePHENIXRICHConstruction::RegisterVolume - Warning - replacing "
-           << v->GetName() << G4endl;
+    std::cout << "ePHENIXRICHConstruction::RegisterVolume - Warning - replacing "
+           << v->GetName() << std::endl;
   }
 
   map_log_vol[v->GetName()] = v;
@@ -85,8 +84,8 @@ G4PVPlacement *ePHENIXRICHConstruction::RegisterPhysicalVolume(G4PVPlacement *v)
 {
   if (!v)
   {
-    G4cout << "ePHENIXRICHConstruction::RegisterPhysicalVolume - Error - invalid volume!"
-           << G4endl;
+    std::cout << "ePHENIXRICHConstruction::RegisterPhysicalVolume - Error - invalid volume!"
+           << std::endl;
     return v;
   }
 
@@ -94,8 +93,8 @@ G4PVPlacement *ePHENIXRICHConstruction::RegisterPhysicalVolume(G4PVPlacement *v)
 
   if (map_phy_vol.find(id) != map_phy_vol.end())
   {
-    G4cout << "ePHENIXRICHConstruction::RegisterPhysicalVolume - Warning - replacing "
-           << v->GetName() << "[" << v->GetCopyNo() << "]" << G4endl;
+    std::cout << "ePHENIXRICHConstruction::RegisterPhysicalVolume - Warning - replacing "
+           << v->GetName() << "[" << v->GetCopyNo() << "]" << std::endl;
   }
 
   map_phy_vol[id] = v;
@@ -259,10 +258,10 @@ ePHENIXRICHConstruction::Construct_RICH(G4LogicalVolume *WorldLog)
   GetDisplayAction()->AddVolume(RICHHBDLog, "HBD");
 
 // if you want this printout - put some verbosity around it
-  // G4cout << "ePHENIXRICHConstruction::Construct_RICH - " << map_log_vol.size()
-  //        << " logical volume constructed" << G4endl;
-  // G4cout << "ePHENIXRICHConstruction::Construct_RICH - " << map_phy_vol.size()
-  //        << " physical volume constructed" << G4endl;
+  // std::cout << "ePHENIXRICHConstruction::Construct_RICH - " << map_log_vol.size()
+  //        << " logical volume constructed" << std::endl;
+  // std::cout << "ePHENIXRICHConstruction::Construct_RICH - " << map_phy_vol.size()
+  //        << " physical volume constructed" << std::endl;
 
   return WorldLog;
 }

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWrite.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWrite.cc
@@ -112,7 +112,7 @@ void PHG4GDMLWrite::UserinfoWrite(xercesc::DOMElement* gdmlElement)
 {
   if(auxList.size()>0)
   {
-    G4cout << "PHG4GDML: Writing userinfo..." << G4endl;
+    std::cout << "PHG4GDML: Writing userinfo..." << std::endl;
 
     userinfoElement = NewElement("userinfo");
     gdmlElement->appendChild(userinfoElement);
@@ -172,8 +172,8 @@ G4Transform3D PHG4GDMLWrite::Write(const G4String& fname,
    SchemaLocation = setSchemaLocation;
    addPointerToName = refs;
 
-   if (depth==0) { G4cout << "PHG4GDML: Writing '" << fname << "'..." << G4endl; }
-   else   { G4cout << "PHG4GDML: Writing module '" << fname << "'..." << G4endl; }
+   if (depth==0) { std::cout << "PHG4GDML: Writing '" << fname << "'..." << std::endl; }
+   else   { std::cout << "PHG4GDML: Writing module '" << fname << "'..." << std::endl; }
 
    if (FileExists(fname))
    {
@@ -246,20 +246,20 @@ G4Transform3D PHG4GDMLWrite::Write(const G4String& fname,
    catch (const xercesc::XMLException& toCatch)
    {
       char* message = xercesc::XMLString::transcode(toCatch.getMessage());
-      G4cout << "PHG4GDML: Exception message is: " << message << G4endl;
+      std::cout << "PHG4GDML: Exception message is: " << message << std::endl;
       xercesc::XMLString::release(&message);
       return G4Transform3D::Identity;
    }
    catch (const xercesc::DOMException& toCatch)
    {
       char* message = xercesc::XMLString::transcode(toCatch.msg);
-      G4cout << "PHG4GDML: Exception message is: " << message << G4endl;
+      std::cout << "PHG4GDML: Exception message is: " << message << std::endl;
       xercesc::XMLString::release(&message);
       return G4Transform3D::Identity;
    }
    catch (...)
    {
-      G4cout << "PHG4GDML: Unexpected Exception!" << G4endl;
+      std::cout << "PHG4GDML: Unexpected Exception!" << std::endl;
       return G4Transform3D::Identity;
    }
 
@@ -268,11 +268,11 @@ G4Transform3D PHG4GDMLWrite::Write(const G4String& fname,
 
    if (depth==0)
    {
-     G4cout << "PHG4GDML: Writing '" << fname << "' done !" << G4endl;
+     std::cout << "PHG4GDML: Writing '" << fname << "' done !" << std::endl;
    }
    else
    {
-     G4cout << "PHG4GDML: Writing module '" << fname << "' done !" << G4endl;
+     std::cout << "PHG4GDML: Writing module '" << fname << "' done !" << std::endl;
    }
 
    return R;
@@ -287,7 +287,7 @@ void PHG4GDMLWrite::AddModule(const G4VPhysicalVolume* const physvol)
      return;
    }
    G4String fname = GenerateName(physvol->GetName(),physvol);
-   G4cout << "PHG4GDML: Adding module '" << fname << "'..." << G4endl;
+   std::cout << "PHG4GDML: Adding module '" << fname << "'..." << std::endl;
 
    if (dynamic_cast<const G4PVDivision*>(physvol))
    {

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteDefine.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteDefine.cc
@@ -130,7 +130,7 @@ Position_vectorWrite(xercesc::DOMElement* element, const G4String& tag,
 
 void PHG4GDMLWriteDefine::DefineWrite(xercesc::DOMElement* element)
 {
-   G4cout << "PHG4GDML: Writing definitions..." << G4endl;
+  std::cout << "PHG4GDML: Writing definitions..." << std::endl;
 
    defineElement = NewElement("define");
    element->appendChild(defineElement);

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteMaterials.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteMaterials.cc
@@ -274,7 +274,7 @@ void PHG4GDMLWriteMaterials::PropertyWrite(xercesc::DOMElement* matElement,
 
 void PHG4GDMLWriteMaterials::MaterialsWrite(xercesc::DOMElement* element)
 {
-   G4cout << "G4GDML: Writing materials..." << G4endl;
+  std::cout << "G4GDML: Writing materials..." << std::endl;
 
    materialsElement = NewElement("materials");
    element->appendChild(materialsElement);

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteSetup.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteSetup.cc
@@ -47,7 +47,7 @@ PHG4GDMLWriteSetup::~PHG4GDMLWriteSetup()
 void PHG4GDMLWriteSetup::SetupWrite(xercesc::DOMElement* gdmlElement,
                                   const G4LogicalVolume* const logvol)
 {
-   G4cout << "G4GDML: Writing setup..." << G4endl;
+  std::cout << "G4GDML: Writing setup..." << std::endl;
 
    const G4String worldref = GenerateName(logvol->GetName(),logvol);
 

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteSolids.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteSolids.cc
@@ -1018,7 +1018,7 @@ OpticalSurfaceWrite(xercesc::DOMElement* solElement,
 
 void PHG4GDMLWriteSolids::SolidsWrite(xercesc::DOMElement* gdmlElement)
 {
-   G4cout << "PHG4GDML: Writing solids..." << G4endl;
+  std::cout << "PHG4GDML: Writing solids..." << std::endl;
 
    solidsElement = NewElement("solids");
    gdmlElement->appendChild(solidsElement);

--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteStructure.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteStructure.cc
@@ -364,7 +364,7 @@ PHG4GDMLWriteStructure::GetBorderSurface(const G4VPhysicalVolume* const pvol)
 
 void PHG4GDMLWriteStructure::SurfacesWrite()
 {
-   G4cout << "PHG4GDML: Writing surfaces..." << G4endl;
+   std::cout << "PHG4GDML: Writing surfaces..." << std::endl;
 
    std::vector<xercesc::DOMElement*>::const_iterator pos;
    for (pos = skinElementVec.begin(); pos != skinElementVec.end(); ++pos)
@@ -379,7 +379,7 @@ void PHG4GDMLWriteStructure::SurfacesWrite()
 
 void PHG4GDMLWriteStructure::StructureWrite(xercesc::DOMElement* gdmlElement)
 {
-   G4cout << "PHG4GDML: Writing structure..." << G4endl;
+  std::cout << "PHG4GDML: Writing structure..." << std::endl;
 
    structureElement = NewElement("structure");
    gdmlElement->appendChild(structureElement);

--- a/simulation/g4simulation/g4main/G4TBMagneticFieldSetup.cc
+++ b/simulation/g4simulation/g4main/G4TBMagneticFieldSetup.cc
@@ -52,7 +52,6 @@
 #include <Geant4/G4TransportationManager.hh>
 #include <Geant4/G4Types.hh>  // for G4double, G4int
 #include <Geant4/G4UniformMagField.hh>
-#include <Geant4/G4ios.hh>  // for G4cout, G4endl
 
 #include <cassert>
 #include <cstdlib>  // for exit, size_t
@@ -258,10 +257,10 @@ void G4TBMagneticFieldSetup::SetStepper()
 
   if (verbosity > 0)
   {
-    G4cout << " ---------- G4TBMagneticFieldSetup::SetStepper() -----------" << G4endl;
-    G4cout << "  " << message.str() << endl;
-    G4cout << "  Minimum step size: " << fMinStep / mm << " mm" << G4endl;
-    G4cout << " -----------------------------------------------------------" << G4endl;
+    std::cout << " ---------- G4TBMagneticFieldSetup::SetStepper() -----------" << std::endl;
+    std::cout << "  " << message.str() << endl;
+    std::cout << "  Minimum step size: " << fMinStep / mm << " mm" << std::endl;
+    std::cout << " -----------------------------------------------------------" << std::endl;
   }
 
   if (!fStepper)

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -501,7 +501,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
     // }
   }
   G4ProcessManager *pmanager = G4OpticalPhoton::OpticalPhoton()->GetProcessManager();
-  // G4cout << " AddDiscreteProcess to OpticalPhoton " << G4endl;
+  // std::cout << " AddDiscreteProcess to OpticalPhoton " << std::endl;
   pmanager->AddDiscreteProcess(new G4OpAbsorption());
   pmanager->AddDiscreteProcess(new G4OpRayleigh());
   pmanager->AddDiscreteProcess(new G4OpMieHG());

--- a/simulation/g4simulation/g4main/PHG4RegionInformation.cc
+++ b/simulation/g4simulation/g4main/PHG4RegionInformation.cc
@@ -40,11 +40,11 @@ PHG4RegionInformation::PHG4RegionInformation()
 
 void PHG4RegionInformation::Print() const
 {
- G4cout << "I'm ";
- if(isWorld) { G4cout << "World."; }
- else if(isTracker) { G4cout << "Tracker."; }
- else if(isCalorimeter) { G4cout << "Calorimeter."; }
- else { G4cout << "unknown."; }
- G4cout << G4endl;
+ std::cout << "I'm ";
+ if(isWorld) { std::cout << "World."; }
+ else if(isTracker) { std::cout << "Tracker."; }
+ else if(isCalorimeter) { std::cout << "Calorimeter."; }
+ else { std::cout << "unknown."; }
+ std::cout << std::endl;
 }
 

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
@@ -4,8 +4,8 @@
 #define G4MAIN_PHG4TRACKUSERINFOV1_H
 
 #include <Geant4/G4VUserTrackInformation.hh>
-#include <Geant4/G4ios.hh>                    // for G4cout
 
+#include <iostream>
 #include <ostream>                            // for operator<<, basic_ostre...
 
 class PHG4Shower;
@@ -34,12 +34,12 @@ class PHG4TrackUserInfoV1 : public G4VUserTrackInformation
 
   void Print() const
   {
-    G4cout << "PHG4TrackUserInfoV1: " << std::endl;
-    G4cout << "   UserTrackId = " << usertrackid << std::endl;
-    G4cout << "   UserParentId = " << userparentid << std::endl;
-    G4cout << "   UserPrimaryId = " << userprimaryid << std::endl;
-    G4cout << "   Wanted = " << wanted << std::endl;
-    G4cout << "   Keep = " << keep << std::endl;
+    std::cout << "PHG4TrackUserInfoV1: " << std::endl;
+    std::cout << "   UserTrackId = " << usertrackid << std::endl;
+    std::cout << "   UserParentId = " << userparentid << std::endl;
+    std::cout << "   UserPrimaryId = " << userprimaryid << std::endl;
+    std::cout << "   Wanted = " << wanted << std::endl;
+    std::cout << "   Keep = " << keep << std::endl;
   }
 
   void SetUserTrackId(const int val) { usertrackid = val; }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR replaces all uses of G4cout and G4endl by std::cout/std::endl. Trying to hunt down the use of an uninitialized variable in the G4 Streambuf which turns out to be likely caused by the static instantiation of this in G4ios.hh where the buffer which keeps the printout is not initialized. Anyway - we should have only one way to print stuff out. If it turns out that we need to use G4cout in multithreading we change it but having a mix is just bad

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

