### PR TITLE
Tune Initial Vertexing

### DIFF
--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -74,8 +74,8 @@ int PHActsInitialVertexFinder::Process(PHCompositeNode *topNode)
 
   fillVertexMap(vertices, keyMap);
 
-  /// Need to check that silicon stubs which were skipped over
-  /// still have a vertex associated to them
+  /// Need to check that silicon stubs which may have been
+  /// skipped over still have a vertex association
   checkTrackVertexAssociation();
 
   for(auto track : trackPointers)
@@ -299,7 +299,14 @@ VertexVector PHActsInitialVertexFinder::findVertices(TrackParamVec& tracks)
       
       /// Setup vertex finder now
       typename VertexFitter::Config vertexFitterConfig;
+
+      /// Vertex fitter seems to have no performance difference when
+      /// iterating once vs. default of 5 times. Additionally, iterating
+      /// more than once causes vertices with low numbers of tracks to
+      /// fail fitting, causing an error to be thrown and 0 vertices 
+      /// returned
       vertexFitterConfig.maxIterations = 1;
+
       VertexFitter vertexFitter(std::move(vertexFitterConfig));
       
       typename Linearizer::Config linearizerConfig(bField, propagator);
@@ -320,7 +327,6 @@ VertexVector PHActsInitialVertexFinder::findVertices(TrackParamVec& tracks)
 						 std::move(seeder), ipEst);
       finderConfig.maxVertices = m_maxVertices;
       finderConfig.reassignTracksAfterFirstFit = true;
-      finderConfig.maximumChi2cutForSeeding = 10.;
       VertexFinder finder(finderConfig, std::move(logger));
 
       typename VertexFinder::State state(m_tGeometry->magFieldContext);

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -272,7 +272,6 @@ VertexVector PHActsInitialVertexFinder::findVertices(TrackParamVec& tracks)
       
       using Stepper = Acts::EigenStepper<MagneticField>;
       using Propagator = Acts::Propagator<Stepper>;
-      using PropagatorOptions = Acts::PropagatorOptions<>;
       using TrackParameters = Acts::BoundTrackParameters;
       using Linearizer = Acts::HelicalTrackLinearizer<Propagator>;
       using VertexFitter = 
@@ -300,6 +299,7 @@ VertexVector PHActsInitialVertexFinder::findVertices(TrackParamVec& tracks)
       
       /// Setup vertex finder now
       typename VertexFitter::Config vertexFitterConfig;
+      vertexFitterConfig.maxIterations = 1;
       VertexFitter vertexFitter(std::move(vertexFitterConfig));
       
       typename Linearizer::Config linearizerConfig(bField, propagator);
@@ -384,10 +384,6 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
 	  track->identify();
 	}
 
-      /// IVF dislikes large x-y position tracks, so skip them
-      if(fabs(track->get_x()) > 0.05 or fabs(track->get_y()) > 0.05)
-	continue;
-      
       const Acts::Vector4D stubVec(
                   track->get_x() * Acts::UnitConstants::cm,
 		  track->get_y() * Acts::UnitConstants::cm,

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -74,6 +74,10 @@ int PHActsInitialVertexFinder::Process(PHCompositeNode *topNode)
 
   fillVertexMap(vertices, keyMap);
 
+  /// Need to check that silicon stubs which were skipped over
+  /// still have a vertex associated to them
+  checkTrackVertexAssociation();
+
   for(auto track : trackPointers)
     {
       delete track;
@@ -103,6 +107,38 @@ int PHActsInitialVertexFinder::End(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+void PHActsInitialVertexFinder::checkTrackVertexAssociation()
+{
+  
+  for(auto& [trackKey, track] : *m_trackMap)
+    {
+      /// If the track wasn't already given a vertex ID, it wasn't 
+      /// included in the initial vertex finding due to Acts not liking
+      /// tracks with large transverse position. So find the closest
+      /// z vertex to it and assign it
+      if(track->get_vertex_id() != UINT_MAX)
+	continue;
+
+      const auto trackZ = track->get_z();
+      
+      double closestVertZ = 9999;
+      int vertId = -1;
+      for(auto& [vertexKey, vertex] : *m_vertexMap)
+	{
+	  double dz = fabs(trackZ - vertex->get_z());
+
+	  if(dz < closestVertZ) 
+	    {
+	      vertId = vertexKey;
+	      closestVertZ = dz;
+	    }
+
+	}
+      track->set_vertex_id(vertId);	
+
+    }
+
+}
 void PHActsInitialVertexFinder::fillVertexMap(VertexVector& vertices,
 					      InitKeyMap& keyMap)
 {
@@ -113,6 +149,9 @@ void PHActsInitialVertexFinder::fillVertexMap(VertexVector& vertices,
   if(vertices.size() == 0)
     {
       createDummyVertex();
+      if(Verbosity() > 1)
+	std::cout << "No vertices found. Adding a dummy vertex"
+		  << std::endl;
       return;
     }
     
@@ -161,7 +200,7 @@ void PHActsInitialVertexFinder::fillVertexMap(VertexVector& vertices,
 	  /// Give the track the appropriate vertex id
 	  const auto svtxTrack = m_trackMap->find(trackKey)->second;
 	  
-	  if(Verbosity() > 1)
+	  if(Verbosity() > 3)
 	    {   
 	      svtxTrack->identify();
 	      std::cout << "Updating track key " << trackKey << " with vertex "
@@ -281,6 +320,7 @@ VertexVector PHActsInitialVertexFinder::findVertices(TrackParamVec& tracks)
 						 std::move(seeder), ipEst);
       finderConfig.maxVertices = m_maxVertices;
       finderConfig.reassignTracksAfterFirstFit = true;
+      finderConfig.maximumChi2cutForSeeding = 10.;
       VertexFinder finder(finderConfig, std::move(logger));
 
       typename VertexFinder::State state(m_tGeometry->magFieldContext);
@@ -337,13 +377,17 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
 
   for(auto& [key,track] : *m_trackMap)
     {
-      if(Verbosity() > 1)
+      if(Verbosity() > 3)
 	{
 	  std::cout << "Adding track seed to vertex finder " 
 		    << std::endl;
 	  track->identify();
 	}
 
+      /// IVF dislikes large x-y position tracks, so skip them
+      if(fabs(track->get_x()) > 0.05 or fabs(track->get_y()) > 0.05)
+	continue;
+      
       const Acts::Vector4D stubVec(
                   track->get_x() * Acts::UnitConstants::cm,
 		  track->get_y() * Acts::UnitConstants::cm,
@@ -359,7 +403,7 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
       /// Make a dummy loose covariance matrix for Acts
       Acts::BoundSymMatrix cov;
       
-      cov << 100 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
+      cov << 1000 * Acts::UnitConstants::um, 0., 0., 0., 0., 0.,
            0., 1000 * Acts::UnitConstants::um, 0., 0., 0., 0.,
            0., 0., 0.05, 0., 0., 0.,
            0., 0., 0., 0.05, 0., 0.,

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.h
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.h
@@ -48,8 +48,9 @@ class PHActsInitialVertexFinder: public PHInitVertexing
   VertexVector findVertices(TrackParamVec& tracks);
   void fillVertexMap(VertexVector& vertices, InitKeyMap& keyMap);
   void createDummyVertex();
+  void checkTrackVertexAssociation();
   
-  int m_maxVertices = 10;
+  int m_maxVertices = 5;
   int m_event = 0;
   unsigned int m_totVertexFits = 0;
   unsigned int m_successFits = 0;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -119,7 +119,7 @@ int SvtxEvaluator::Init(PHCompositeNode* topNode)
                                                  "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
 
   if (_do_vertex_eval) _ntp_vertex = new TNtuple("ntp_vertex", "vertex => max truth",
-                                                 "event:seed:vx:vy:vz:ntracks:"
+                                                 "event:seed:vx:vy:vz:ntracks:chi2:ndof:"
                                                  "gvx:gvy:gvz:gvt:gembed:gntracks:gntracksmaps:"
                                                  "gnembed:nfromtruth:"
                                                  "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
@@ -1060,6 +1060,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         float vy = vertex->get_y();
         float vz = vertex->get_z();
         float ntracks = vertex->size_tracks();
+	float chi2 = vertex->get_chisq();
+	float ndof = vertex->get_ndof();
         float gvx = NAN;
         float gvy = NAN;
         float gvz = NAN;
@@ -1090,6 +1092,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                                vy,
                                vz,
                                ntracks,
+			       chi2,
+			       ndof,
                                gvx,
                                gvy,
                                gvz,


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR tunes the initial vertex finder to be used in both embedded and low occupancy events. It now works with very high efficiency for any number of track events greater than 2. I will make a macros PR to introduce it later, after the full reconstruction chain can be tested with it.

It also adds the vertex chi2 and NDF to the `ntp_vertex` tuple in the SvtxEvaluator.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

