### PR TITLE
Add options to run initial vertex finder by itself

### DIFF
--- a/offline/packages/trackreco/PHActsInitialVertexFinder.h
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.h
@@ -31,8 +31,17 @@ class PHActsInitialVertexFinder: public PHInitVertexing
   PHActsInitialVertexFinder(const std::string& name="PHActsInitialVertexFinder");
   virtual ~PHActsInitialVertexFinder() {}
 
-  void setMaxVertices(int maxVertices)
+  void setMaxVertices(const int maxVertices)
   { m_maxVertices = maxVertices;}
+
+  void setSvtxVertexMapName(const std::string& name)
+  { m_svtxVertexMapName = name; }
+  
+  void setSvtxTrackMapName(const std::string& name)
+  { m_svtxTrackMapName = name; }
+
+  void setInitialVertexer(const bool initial)
+  { m_initial = initial; }
 
  protected:
   int Setup(PHCompositeNode *topNode) override;
@@ -54,6 +63,10 @@ class PHActsInitialVertexFinder: public PHInitVertexing
   int m_event = 0;
   unsigned int m_totVertexFits = 0;
   unsigned int m_successFits = 0;
+
+  std::string m_svtxTrackMapName = "SvtxSiliconTrackMap";
+  std::string m_svtxVertexMapName = "SvtxVertexMap";
+  bool m_initial = true;
 
   SvtxTrackMap *m_trackMap = nullptr;
   SvtxVertexMap *m_vertexMap = nullptr;


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds functionality to the so-called InitialVertexFinder to run with an arbitrary trackmap and vertex map. This will allow users to run this module individually on whatever track map and vertex map that they want to. Note that the name `PHActsInitialVertexFinder` is only because the class is intended to slot in with the initial silicon seeder - all it does is take a generic `SvtxTrackMap` and convert the tracks to Acts track parameters, run the Acts vertex finder on them, then create an `SvtxVertexMap` with the output name. The module defaults to the setup for running after the silicon seeder, so users who want to use it need to add the following to their macro:

```
   PHActsInitialVertexFinder *f = new PHActsInitialVertexFinder("MyVertexFinder");
    f->setSvtxTrackMapName("WhateverTrackMapNameYouWantToReadFrom");
    f->setSvtxVertexMapName("WhateverVertexMapNameYouWantToWriteTo");
    f->setInitialVertexer(false);
    f->Verbosity(0);
    se->registerSubsystem(f);
```

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

