### PR TITLE
KFParticle: 2 fixes (ghosts and resonance/track bug)

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -60,6 +60,7 @@ std::map<std::string, particle_pair> particleMasses = kfp_particleList.getPartic
 KFParticle_Tools::KFParticle_Tools()
   : m_daughter_name{"pion", "pion", "pion", "pion"}
   , m_daughter_charge{1, -1, 1, -1}
+  , m_num_tracks(2)
   , m_min_mass(0)
   , m_max_mass(1e1)
   , m_track_pt(0.25)
@@ -443,9 +444,18 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
   bool daughterMassCheck = true;
   float unique_vertexID = 0;
 
+  //Figure out if the decay has reco. tracks mixed with resonances
+  int num_tracks_used_by_intermediates = 0;
+  for (int i = 0; i < m_num_intermediate_states; ++i) num_tracks_used_by_intermediates += m_num_tracks_from_intermediate[i];
+  int num_remaining_tracks = m_num_tracks - num_tracks_used_by_intermediates;
+
   for (int i = 0; i < nTracks; ++i)
   {
     float daughterMass = constrainMass ? particleMasses.find(daughterOrder[i].c_str())->second.second : vDaughters[i].GetMass();
+    if (num_remaining_tracks > 0 && i >= m_num_intermediate_states) 
+    { 
+      daughterMass = particleMasses.find(daughterOrder[i].c_str())->second.second;
+    }
     inputTracks[i].Create(vDaughters[i].Parameters(),
                           vDaughters[i].CovarianceMatrix(),
                           (Int_t) vDaughters[i].GetQ(),

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -94,6 +94,7 @@ class KFParticle_Tools : public KFParticle_particleList, protected KFParticle_MV
   int m_num_tracks_from_intermediate[max_tracks] = {0};
   std::string m_daughter_name[max_tracks];
   int m_daughter_charge[max_tracks] = {0};
+  int m_num_tracks = -1;
   std::string m_intermediate_name[max_tracks];
   float m_min_mass = -1;
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.h
@@ -80,7 +80,7 @@ class KFParticle_eventReconstruction : public KFParticle_Tools
  protected:
   //static const int max_tracks = 99;
   bool m_has_intermediates;
-  int m_num_tracks = -1;
+  //int m_num_tracks = -1;
   std::string m_daughter_name_evt[max_tracks];
   int m_daughter_charge_evt[max_tracks] = {0};
   int m_intermediate_charge[max_tracks] = {0};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_particleList.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_particleList.cc
@@ -66,7 +66,11 @@ std::map<std::string, particle_pair> KFParticle_particleList::getParticleList()
   //Leptons
   //particleMasses["electron"] = std::make_pair(11, kfpDatabase.GetMass(11));
   particleMasses["electron"] = std::make_pair(11, 0.000511);
+  particleMasses["e+"] = std::make_pair(11, 0.000511);
+  particleMasses["e-"] = std::make_pair(11, 0.000511);
   particleMasses["muon"] = std::make_pair(13, kfpDatabase.GetMass(13));
+  particleMasses["mu+"] = std::make_pair(13, kfpDatabase.GetMass(13));
+  particleMasses["mu-"] = std::make_pair(13, kfpDatabase.GetMass(13));
   particleMasses["tau"] = std::make_pair(15, 1.77686);
 
   //Gauge bosons and Higgs
@@ -131,7 +135,11 @@ std::map<std::string, particle_pair> KFParticle_particleList::getParticleList()
 
   //B-hadrons
   particleMasses["B+"] = std::make_pair(521, 5.279);
+  particleMasses["Bp"] = std::make_pair(521, 5.279);
+  particleMasses["Bplus"] = std::make_pair(521, 5.279);
   particleMasses["B-"] = std::make_pair(521, 5.279);
+  particleMasses["Bm"] = std::make_pair(521, 5.279);
+  particleMasses["Bminus"] = std::make_pair(521, 5.279);
   particleMasses["B0"] = std::make_pair(511, 5.279);
   particleMasses["Bs0"] = std::make_pair(531, 5.366);
   particleMasses["Bc+"] = std::make_pair(541, 6.2749);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -154,21 +154,21 @@ void KFParticle_sPHENIX::printParticles(KFParticle motherParticle,
   std::cout << "\n---------------KFParticle candidate information---------------" << std::endl;
 
   std::cout << "Mother information:" << std::endl;
-  kfpTupleTools_Top.identify(motherParticle);
+  identify(motherParticle);
 
   if (m_has_intermediates_sPHENIX)
   {
     std::cout << "Intermediate state information:" << std::endl;
     for (unsigned int i = 0; i < intermediateParticles.size(); i++)
     {
-      kfpTupleTools_Top.identify(intermediateParticles[i]);
+      identify(intermediateParticles[i]);
     }
   }
 
   std::cout << "Final track information:" << std::endl;
   for (unsigned int i = 0; i < daughterParticles.size(); i++)
   {
-    kfpTupleTools_Top.identify(daughterParticles[i]);
+    identify(daughterParticles[i]);
   }
 
   if (m_constrain_to_vertex_sPHENIX)

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -166,7 +166,7 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
 
     if (truePoint == NULL)
     {
-      std::cout << "KFParticle Truth Matching: This event has no PHG4VtxPoint information!\n";
+      std::cout << "KFParticle truth matching: This event has no PHG4VtxPoint information!\n";
       std::cout << "Your truth track DCA will be measured wrt a reconstructed vertex!" << std::endl; 
 
       f_vertexParameters[0] = recoVertex->get_x(); 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -130,9 +130,11 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
   TrkrDefs::cluskey clusKey = *track->begin_cluster_keys();
   g4particle = clustereval->max_truth_particle_by_cluster_energy(clusKey);
 
-  true_px = (Float_t) g4particle->get_px();
-  true_py = (Float_t) g4particle->get_py();
-  true_pz = (Float_t) g4particle->get_pz();
+  bool isParticleValid = g4particle == nullptr ? 0 : 1;
+  
+  true_px = isParticleValid ? (Float_t) g4particle->get_px() : 0.;
+  true_py = isParticleValid ? (Float_t) g4particle->get_py() : 0.;
+  true_pz = isParticleValid ? (Float_t) g4particle->get_pz() : 0.;
   true_p = sqrt(pow(true_px, 2) + pow(true_py, 2) + pow(true_pz, 2));
   true_pt = sqrt(pow(true_px, 2) + pow(true_py, 2));
 
@@ -141,12 +143,16 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
   m_true_daughter_pz[daughter_id] = true_pz;
   m_true_daughter_p[daughter_id] = true_p;
   m_true_daughter_pt[daughter_id] = true_pt;
-  m_true_daughter_id[daughter_id] = g4particle->get_pid();
+  m_true_daughter_id[daughter_id] = isParticleValid ? g4particle->get_pid() : 0;
 
-  g4vertex_point = trutheval->get_vertex(g4particle);
-  m_true_daughter_vertex_x[daughter_id] = g4vertex_point->get_x();
-  m_true_daughter_vertex_y[daughter_id] = g4vertex_point->get_y();
-  m_true_daughter_vertex_z[daughter_id] = g4vertex_point->get_z();
+  if (isParticleValid)
+  {
+    g4vertex_point = trutheval->get_vertex(g4particle);
+  }
+
+  m_true_daughter_vertex_x[daughter_id] = isParticleValid ? g4vertex_point->get_x() : 0.;
+  m_true_daughter_vertex_y[daughter_id] = isParticleValid ? g4vertex_point->get_y() : 0.;
+  m_true_daughter_vertex_z[daughter_id] = isParticleValid ? g4vertex_point->get_z() : 0.;
 
   if (m_constrain_to_vertex_truthMatch)  
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Occasionally we can reconstruct tracks from noise hits. When we try to truth match these tracks we get a null pointer and KFParticle crashes. I've added a check for this null pointer and set the truth variables to 0.

I found a bug in KFParticle reconstruction that affects analysis where a mother decays to a resonance and reconstructed tracks AND the resonance mass was not constrained (such as B+ -> D0 pi+ where the D0 mass was not fixed to the PDG mass). This would cause all the tracks to have no mass and no PID (see https://indico.bnl.gov/event/10855/contributions/45863/attachments/32826/52483/MDC1_C_Dean_20210222.pdf). This PR now fixes that and a small issue where tracks used by resonance weren't properly removed from the good track list.

I also added a few more particle names to the particleList class

## TODOs (if applicable)

Add mother truth information to the nTuple output

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

