### PR TITLE
Apply beam crossing angle to any event generator

### DIFF
--- a/generators/PHPythia6/PHPythia6.cc
+++ b/generators/PHPythia6/PHPythia6.cc
@@ -1,31 +1,31 @@
 #include "PHPythia6.h"
 #include "PHPy6GenTrigger.h"
 
-#include <phhepmc/PHHepMCGenHelper.h>    // for PHHepMCGenHelper
+#include <phhepmc/PHHepMCGenHelper.h>  // for PHHepMCGenHelper
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>          // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHRandomSeed.h>
-#include <phool/phool.h>                 // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
-#include <Rtypes.h>                      // for Int_t Float_t
+#include <Rtypes.h>  // for Int_t Float_t
 
 #include <HepMC/GenEvent.h>
-#include <HepMC/HEPEVT_Wrapper.h>        // for HEPEVT_Wrappe
-#include <HepMC/IO_BaseClass.h>          // for IO_BaseClass
+#include <HepMC/HEPEVT_Wrapper.h>  // for HEPEVT_Wrappe
+#include <HepMC/IO_BaseClass.h>    // for IO_BaseClass
 #include <HepMC/IO_GenEvent.h>
 #include <HepMC/IO_HEPEVT.h>
-#include <HepMC/PdfInfo.h>               // for PdfInfo
+#include <HepMC/PdfInfo.h>  // for PdfInfo
 #include <HepMC/PythiaWrapper.h>
-#include <HepMC/PythiaWrapper6_4.h>      // for (anonymous), pypars, pydat1
-#include <HepMC/Units.h>                 // for GEV, MM
+#include <HepMC/PythiaWrapper6_4.h>  // for (anonymous), pypars, pydat1
+#include <HepMC/Units.h>             // for GEV, MM
 
-#include <algorithm>                     // for transform
-#include <cctype>                       // for tolower
-#include <cmath>                        // for fmod
-#include <cstdlib>                      // for exit, abs
-#include <iostream>                      // for operator<<, endl, basic_ostream
+#include <algorithm>  // for transform
+#include <cctype>     // for tolower
+#include <cmath>      // for fmod
+#include <cstdlib>    // for exit, abs
+#include <iostream>   // for operator<<, endl, basic_ostream
 #include <sstream>
 
 class PHHepMCGenEvent;
@@ -46,13 +46,13 @@ PHPythia6::PHPythia6(const std::string &name)
   , _triggersOR(true)
   , _triggersAND(false)
 {
-  hepmc_helper.set_embedding_id(1);  // default embedding ID to 1
+  PHHepMCGenHelper::set_embedding_id(1);  // default embedding ID to 1
 }
 
 int PHPythia6::Init(PHCompositeNode *topNode)
 {
   /* Create node tree */
-  CreateNodeTree(topNode);
+  create_node_tree(topNode);
 
   /* event numbering will start from 1 */
   _eventcount = 0;
@@ -81,7 +81,7 @@ int PHPythia6::Init(PHCompositeNode *topNode)
     exit(2);
   }
   // print out seed so we can make this is reproducible
-  cout << "PHPythia6 random seed: " << fSeed << endl;
+  if (Verbosity()) cout << "PHPythia6 random seed: " << fSeed << endl;
 
   /* read pythia configuration and initialize */
   if (!_configFile.empty()) ReadConfig(_configFile);
@@ -440,7 +440,7 @@ int PHPythia6::process_event(PHCompositeNode *topNode)
 
   /* pass HepMC to PHNode*/
 
-  PHHepMCGenEvent *success = hepmc_helper.insert_event(evt);
+  PHHepMCGenEvent *success = PHHepMCGenHelper::insert_event(evt);
   if (!success)
   {
     cout << "PHPythia6::process_event - Failed to add event to HepMC record!" << endl;
@@ -450,13 +450,6 @@ int PHPythia6::process_event(PHCompositeNode *topNode)
   if (Verbosity() > 2) cout << "PHPythia6::process_event - FINISHED WHOLE EVENT" << endl;
 
   ++_eventcount;
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int PHPythia6::CreateNodeTree(PHCompositeNode *topNode)
-{
-  hepmc_helper.create_node_tree(topNode);
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/generators/PHPythia6/PHPythia6.h
+++ b/generators/PHPythia6/PHPythia6.h
@@ -11,7 +11,7 @@
 class PHCompositeNode;
 class PHPy6GenTrigger;
 
-class PHPythia6 : public SubsysReco
+class PHPythia6 : public SubsysReco, public PHHepMCGenHelper
 {
  public:
   PHPythia6(const std::string &name = "PHPythia6");
@@ -51,45 +51,8 @@ class PHPythia6 : public SubsysReco
   void set_trigger_OR() { _triggersOR = true; }  // default true
   void set_trigger_AND() { _triggersAND = true; }
 
-  //! toss a new vertex according to a Uniform or Gaus distribution
-  void set_vertex_distribution_function(PHHepMCGenHelper::VTXFUNC x, PHHepMCGenHelper::VTXFUNC y, PHHepMCGenHelper::VTXFUNC z, PHHepMCGenHelper::VTXFUNC t)
-  {
-    hepmc_helper.set_vertex_distribution_function(x, y, z, t);
-  }
-
-  //! set the mean value of the vertex distribution, use PHENIX units of cm, ns
-  void set_vertex_distribution_mean(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_mean(x, y, z, t);
-  }
-
-  //! set the width of the vertex distribution function about the mean, use PHENIX units of cm, ns
-  void set_vertex_distribution_width(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_width(x, y, z, t);
-  }
-  //
-  //! reuse vertex from another PHHepMCGenEvent with embedding_id = src_embedding_id Additional smearing and shift possible with set_vertex_distribution_*()
-  void set_reuse_vertex(int src_embedding_id)
-  {
-    hepmc_helper.set_reuse_vertex(src_embedding_id);
-  }
-
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  int get_embedding_id() const { return hepmc_helper.get_embedding_id(); }
-  //
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  void set_embedding_id(int id) { hepmc_helper.set_embedding_id(id); }
-
  private:
   int ReadConfig(const std::string &cfg_file = "");
-  int CreateNodeTree(PHCompositeNode *topNode);
 
   /** Certain Pythia switches and parameters only accept integer values
    * This function checks if input values are integers and
@@ -122,8 +85,6 @@ class PHPythia6 : public SubsysReco
    * definition needed to use pythia wrapper headers from HepMC
    */
   void initPythia();
-  //! helper for insert HepMC event to DST node and add vertex smearing
-  PHHepMCGenHelper hepmc_helper;
 };
 
 #endif /* PHPYTHIA6_PHPYTHIA6_H */

--- a/generators/PHPythia8/PHPythia8.cc
+++ b/generators/PHPythia8/PHPythia8.cc
@@ -64,7 +64,7 @@ PHPythia8::PHPythia8(const std::string &name)
   m_Pythia8ToHepMC->set_store_pdf(true);
   m_Pythia8ToHepMC->set_store_xsec(true);
 
-  m_HepMC_Helper.set_embedding_id(1);  // default embedding ID to 1
+  PHHepMCGenHelper::set_embedding_id(1);  // default embedding ID to 1
 }
 
 PHPythia8::~PHPythia8()
@@ -238,7 +238,7 @@ int PHPythia8::process_event(PHCompositeNode *topNode)
   m_Pythia8ToHepMC->fill_next_event(*m_Pythia8, genevent, m_EventCount);
 
   /* pass HepMC to PHNode*/
-  PHHepMCGenEvent *success = m_HepMC_Helper.insert_event(genevent);
+  PHHepMCGenEvent *success = PHHepMCGenHelper::insert_event(genevent);
   if (!success)
   {
     cout << "PHPythia8::process_event - Failed to add event to HepMC record!" << endl;
@@ -268,7 +268,7 @@ int PHPythia8::process_event(PHCompositeNode *topNode)
 int PHPythia8::create_node_tree(PHCompositeNode *topNode)
 {
   // HepMC IO
-  m_HepMC_Helper.create_node_tree(topNode);
+  PHHepMCGenHelper::create_node_tree(topNode);
 
   PHNodeIterator iter(topNode);
   PHCompositeNode *sumNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
@@ -282,7 +282,7 @@ int PHPythia8::create_node_tree(PHCompositeNode *topNode)
     m_IntegralNode = findNode::getClass<PHGenIntegral>(sumNode, "PHGenIntegral");
     if (!m_IntegralNode)
     {
-      m_IntegralNode = new PHGenIntegralv1("PHPythia8 with embedding ID of " + std::to_string(m_HepMC_Helper.get_embedding_id()));
+      m_IntegralNode = new PHGenIntegralv1("PHPythia8 with embedding ID of " + std::to_string(PHHepMCGenHelper::get_embedding_id()));
       PHIODataNode<PHObject> *newmapnode = new PHIODataNode<PHObject>(m_IntegralNode, "PHGenIntegral", "PHObject");
       sumNode->addNode(newmapnode);
     }

--- a/generators/PHPythia8/PHPythia8.h
+++ b/generators/PHPythia8/PHPythia8.h
@@ -23,7 +23,7 @@ namespace Pythia8
   class Pythia;
 }
 
-class PHPythia8 : public SubsysReco
+class PHPythia8 : public SubsysReco, public PHHepMCGenHelper
 {
  public:
   PHPythia8(const std::string &name = "PHPythia8");
@@ -66,47 +66,11 @@ class PHPythia8 : public SubsysReco
     set_vertex_distribution_width(beamXsigma, beamYsigma, beamZsigma, 0);
   }
 
-  //! toss a new vertex according to a Uniform or Gaus distribution
-  void set_vertex_distribution_function(PHHepMCGenHelper::VTXFUNC x, PHHepMCGenHelper::VTXFUNC y, PHHepMCGenHelper::VTXFUNC z, PHHepMCGenHelper::VTXFUNC t)
-  {
-    m_HepMC_Helper.set_vertex_distribution_function(x, y, z, t);
-  }
-
-  //! set the mean value of the vertex distribution, use PHENIX units of cm, ns
-  void set_vertex_distribution_mean(const double x, const double y, const double z, const double t)
-  {
-    m_HepMC_Helper.set_vertex_distribution_mean(x, y, z, t);
-  }
-
-  //! set the width of the vertex distribution function about the mean, use PHENIX units of cm, ns
-  void set_vertex_distribution_width(const double x, const double y, const double z, const double t)
-  {
-    m_HepMC_Helper.set_vertex_distribution_width(x, y, z, t);
-  }
-  //
-  //! reuse vertex from another PHHepMCGenEvent with embedding_id = src_embedding_id Additional smearing and shift possible with set_vertex_distribution_*()
-  void set_reuse_vertex(int src_embedding_id)
-  {
-    m_HepMC_Helper.set_reuse_vertex(src_embedding_id);
-  }
-
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  int get_embedding_id() const { return m_HepMC_Helper.get_embedding_id(); }
-  //
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  void set_embedding_id(int id) { m_HepMC_Helper.set_embedding_id(id); }
-  //! whether to store the integrated luminosity and other event statistics to the TOP/RUN/PHGenIntegral node
   void save_integrated_luminosity(const bool b) { m_SaveIntegratedLuminosityFlag = b; }
 
  private:
   int read_config(const std::string &cfg_file);
-  int create_node_tree(PHCompositeNode *topNode);
+  int create_node_tree(PHCompositeNode *topNode) final;
   double percent_diff(const double a, const double b) { return fabs((a - b) / a); }
   int m_EventCount;
 
@@ -123,9 +87,6 @@ class PHPythia8 : public SubsysReco
 
   // HepMC
   HepMC::Pythia8ToHepMC *m_Pythia8ToHepMC;
-
-  //! helper for insert HepMC event to DST node and add vertex smearing
-  PHHepMCGenHelper m_HepMC_Helper;
 
   //! whether to store the integrated luminosity and other event statistics to the TOP/RUN/PHGenIntegral node
   bool m_SaveIntegratedLuminosityFlag;

--- a/generators/PHSartre/PHSartre.cc
+++ b/generators/PHSartre/PHSartre.cc
@@ -68,7 +68,7 @@ PHSartre::PHSartre(const std::string &name)
   //
   _sartre = new Sartre();
 
-  hepmc_helper.set_embedding_id(1);  // default embedding ID to 1
+  PHHepMCGenHelper::set_embedding_id(1);  // default embedding ID to 1
 }
 
 PHSartre::~PHSartre()
@@ -458,7 +458,7 @@ int PHSartre::process_event(PHCompositeNode *topNode)
 
   // pass HepMC to PHNode
 
-  PHHepMCGenEvent *success = hepmc_helper.insert_event(genevent);
+  PHHepMCGenEvent *success = PHHepMCGenHelper::insert_event(genevent);
   if (!success)
   {
     cout << "PHSartre::process_event - Failed to add event to HepMC record!" << endl;
@@ -473,12 +473,7 @@ int PHSartre::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHSartre::create_node_tree(PHCompositeNode *topNode)
-{
-  hepmc_helper.create_node_tree(topNode);
 
-  return Fun4AllReturnCodes::EVENT_OK;
-}
 
 int PHSartre::ResetEvent(PHCompositeNode *topNode)
 {
@@ -494,7 +489,7 @@ void PHSartre::register_trigger(PHSartreGenTrigger *theTrigger)
 // UPC only
 void PHSartre::randomlyReverseBeams(Event *myEvent)
 {
-  if (gsl_rng_uniform(hepmc_helper.get_random_generator()) > 0.5)
+  if (gsl_rng_uniform(PHHepMCGenHelper::get_random_generator()) > 0.5)
   {
     for (unsigned int i = 0; i < myEvent->particles.size(); i++)
       myEvent->particles.at(i).p.RotateX(M_PI);

--- a/generators/PHSartre/PHSartre.h
+++ b/generators/PHSartre/PHSartre.h
@@ -16,7 +16,7 @@ class EventGeneratorSettings;
 class PHSartreGenTrigger;
 class TGenPhaseSpace;
 
-class PHSartre : public SubsysReco
+class PHSartre : public SubsysReco, public PHHepMCGenHelper
 {
  public:
   PHSartre(const std::string &name = "PHSartre");
@@ -61,44 +61,7 @@ class PHSartre : public SubsysReco
     set_vertex_distribution_width(beamXsigma, beamYsigma, beamZsigma, 0);
   }
 
-  //! toss a new vertex according to a Uniform or Gaus distribution
-  void set_vertex_distribution_function(PHHepMCGenHelper::VTXFUNC x, PHHepMCGenHelper::VTXFUNC y, PHHepMCGenHelper::VTXFUNC z, PHHepMCGenHelper::VTXFUNC t)
-  {
-    hepmc_helper.set_vertex_distribution_function(x, y, z, t);
-  }
-
-  //! set the mean value of the vertex distribution, use PHENIX units of cm, ns
-  void set_vertex_distribution_mean(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_mean(x, y, z, t);
-  }
-
-  //! set the width of the vertex distribution function about the mean, use PHENIX units of cm, ns
-  void set_vertex_distribution_width(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_width(x, y, z, t);
-  }
-  //
-  //! reuse vertex from another PHHepMCGenEvent with embedding_id = src_embedding_id Additional smearing and shift possible with set_vertex_distribution_*()
-  void set_reuse_vertex(int src_embedding_id)
-  {
-    hepmc_helper.set_reuse_vertex(src_embedding_id);
-  }
-
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  int get_embedding_id() const { return hepmc_helper.get_embedding_id(); }
-  //
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  void set_embedding_id(int id) { hepmc_helper.set_embedding_id(id); }
-
  private:
-  int create_node_tree(PHCompositeNode *topNode);
   double percent_diff(const double a, const double b) { return fabs((a - b) / a); }
   void randomlyReverseBeams(Event *myEvent);
   void ReverseBeams(Event *myEvent);
@@ -121,9 +84,6 @@ class PHSartre : public SubsysReco
   int daughterID;
   double daughterMasses[2];
   bool doPerformDecay;
-
-  //! helper for insert HepMC event to DST node and add vertex smearing
-  PHHepMCGenHelper hepmc_helper;
 };
 
 #endif /* __PHSARTRE_H__ */

--- a/generators/phhepmc/Fun4AllHepMCInputManager.h
+++ b/generators/phhepmc/Fun4AllHepMCInputManager.h
@@ -10,7 +10,7 @@
 
 #include <fstream>
 #include <string>
-#include <utility>                                  // for swap
+#include <utility>  // for swap
 #include <vector>
 
 class PHCompositeNode;
@@ -23,8 +23,7 @@ namespace HepMC
   class GenEvent;
 }  // namespace HepMC
 
-
-class Fun4AllHepMCInputManager : public Fun4AllInputManager
+class Fun4AllHepMCInputManager : public Fun4AllInputManager, public PHHepMCGenHelper
 {
  public:
   Fun4AllHepMCInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
@@ -34,7 +33,7 @@ class Fun4AllHepMCInputManager : public Fun4AllInputManager
   virtual int run(const int nevents = 0);
   virtual int ResetEvent();
   void ReadOscar(const int i) { m_ReadOscarFlag = i; }
-  int ReadOscar() const { return m_ReadOscarFlag;}
+  int ReadOscar() const { return m_ReadOscarFlag; }
   virtual void Print(const std::string &what = "ALL") const;
   virtual int PushBackEvents(const int i);
 
@@ -45,47 +44,8 @@ class Fun4AllHepMCInputManager : public Fun4AllInputManager
   int NoSyncPushBackEvents(const int nevt) { return PushBackEvents(nevt); }
   HepMC::GenEvent *ConvertFromOscar();
 
-  //! toss a new vertex according to a Uniform or Gaus distribution
-  void set_vertex_distribution_function(PHHepMCGenHelper::VTXFUNC x, PHHepMCGenHelper::VTXFUNC y, PHHepMCGenHelper::VTXFUNC z, PHHepMCGenHelper::VTXFUNC t)
-  {
-    hepmc_helper.set_vertex_distribution_function(x, y, z, t);
-  }
-
-  //! set the mean value of the vertex distribution, use PHENIX units of cm, ns
-  void set_vertex_distribution_mean(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_mean(x, y, z, t);
-  }
-
-  //! set the width of the vertex distribution function about the mean, use PHENIX units of cm, ns
-  void set_vertex_distribution_width(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_width(x, y, z, t);
-  }
-  //
-  //! reuse vertex from another PHHepMCGenEvent with embedding_id = src_embedding_id Additional smearing and shift possible with set_vertex_distribution_*()
-  void set_reuse_vertex(int src_embedding_id)
-  {
-    hepmc_helper.set_reuse_vertex(src_embedding_id);
-  }
-
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  int get_embedding_id() const { return hepmc_helper.get_embedding_id(); }
-  //
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  void set_embedding_id(int id) { hepmc_helper.set_embedding_id(id); }
-
-  virtual int SkipForThisManager(const int nevents) {return PushBackEvents(-nevents);}
-  int MyCurrentEvent(const unsigned int index=0) const;
-// copy helper settings from another HepMC Input Manager
-  void CopyHelperSettings(Fun4AllHepMCInputManager *source);
-  PHHepMCGenHelper &get_helper() {return hepmc_helper;}
+  virtual int SkipForThisManager(const int nevents) { return PushBackEvents(-nevents); }
+  int MyCurrentEvent(const unsigned int index = 0) const;
 
  protected:
   HepMC::GenEvent *evt = nullptr;
@@ -94,19 +54,11 @@ class Fun4AllHepMCInputManager : public Fun4AllInputManager
   int events_thisfile = 0;
   int m_EventPushedBackFlag = 0;
 
-
   HepMC::IO_GenEvent *ascii_in = nullptr;
-
-
-  //! helper for insert HepMC event to DST node and add vertex smearing
-  PHHepMCGenHelper hepmc_helper;
-
 
   std::string m_HepMCTmpFile;
 
-private:
-
-
+ private:
   PHCompositeNode *topNode = nullptr;
 
   // some pointers for use in decompression handling
@@ -123,7 +75,6 @@ private:
 
   std::string filename;
   std::string topNodeName;
-
 };
 
 #endif /* PHHEPMC_FUN4ALLHEPMCINPUTMANAGER_H */

--- a/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
@@ -27,7 +27,7 @@ Fun4AllHepMCPileupInputManager::Fun4AllHepMCPileupInputManager(
   Repeat(1);
 
   //! If set_embedding_id(i) with a negative number or 0, the pile up event will be inserted with increasing positive embedding_id. This is the default operation mode.
-  hepmc_helper.set_embedding_id(-1);
+  PHHepMCGenHelper::set_embedding_id(-1);
 
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
   unsigned int seed = PHRandomSeed();  // fixed seed is handled in this funtcion
@@ -226,7 +226,7 @@ int Fun4AllHepMCPileupInputManager::PushBackEvents(const int i)
     }
     m_EventPushedBackFlag = -1;
     HepMC::IO_GenEvent ascii_io(m_HepMCTmpFile, std::ios::out);
-    PHHepMCGenEventMap *geneventmap = hepmc_helper.get_geneventmap();
+    PHHepMCGenEventMap *geneventmap = PHHepMCGenHelper::get_geneventmap();
     for (auto iter = geneventmap->begin(); iter != geneventmap->end(); ++iter)
     {
       if (m_EventNumberMap.find((iter->second)->getEvent()->event_number()) != m_EventNumberMap.end())
@@ -242,24 +242,24 @@ int Fun4AllHepMCPileupInputManager::PushBackEvents(const int i)
 }
 int Fun4AllHepMCPileupInputManager::InsertEvent(HepMC::GenEvent *evt, const double crossing_time)
 {
-  PHHepMCGenEventMap *geneventmap = hepmc_helper.get_geneventmap();
+  PHHepMCGenEventMap *geneventmap = PHHepMCGenHelper::get_geneventmap();
   PHHepMCGenEvent *genevent = nullptr;
-  if (hepmc_helper.get_embedding_id() > 0)
+  if (PHHepMCGenHelper::get_embedding_id() > 0)
   {
     //! If set_embedding_id(i) with a positive number, the pile up event will be inserted with increasing positive embedding_id. This would be a strange way to use pile up.
 
-    genevent = geneventmap->insert_active_event();
+    genevent = geneventmap->insert_active_event(get_PHHepMCGenEvent_template() );
   }
   else
   {
     //! If set_embedding_id(i) with a negative number or 0, the pile up event will be inserted with increasing positive embedding_id. This is the default operation mode.
 
-    genevent = geneventmap->insert_background_event();
+    genevent = geneventmap->insert_background_event(get_PHHepMCGenEvent_template() );
   }
   assert(genevent);
   assert(evt);
   genevent->addEvent(evt);
-  hepmc_helper.move_vertex(genevent);
+  PHHepMCGenHelper::move_vertex(genevent);
   // place to the crossing center in time
   genevent->moveVertex(0, 0, 0, crossing_time);
   return 0;

--- a/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
@@ -259,7 +259,7 @@ int Fun4AllHepMCPileupInputManager::InsertEvent(HepMC::GenEvent *evt, const doub
   assert(genevent);
   assert(evt);
   genevent->addEvent(evt);
-  PHHepMCGenHelper::move_vertex(genevent);
+  PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(genevent);
   // place to the crossing center in time
   genevent->moveVertex(0, 0, 0, crossing_time);
   return 0;

--- a/generators/phhepmc/Fun4AllOscarInputManager.cc
+++ b/generators/phhepmc/Fun4AllOscarInputManager.cc
@@ -1,27 +1,27 @@
 #include "Fun4AllOscarInputManager.h"
 
-#include "PHHepMCGenEvent.h"                              // for PHHepMCGenE...
+#include "PHHepMCGenEvent.h"  // for PHHepMCGenE...
 #include "PHHepMCGenEventMap.h"
 
 #include <frog/FROG.h>
 
-#include <fun4all/Fun4AllInputManager.h>                  // for Fun4AllInpu...
+#include <fun4all/Fun4AllInputManager.h>  // for Fun4AllInpu...
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllSyncManager.h>
 
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>
 #include <phool/getClass.h>
 #include <phool/recoConsts.h>
-#include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>                           // for PHIODataNode
-#include <phool/PHNodeIterator.h>                         // for PHNodeIterator
-#include <phool/PHObject.h>
 
 #include <HepMC/GenEvent.h>
-#include <HepMC/GenParticle.h>                            // for GenParticle
-#include <HepMC/GenVertex.h>                              // for GenVertex
-#include <HepMC/SimpleVector.h>                           // for FourVector
-#include <HepMC/Units.h>                                  // for GEV, MM
+#include <HepMC/GenParticle.h>   // for GenParticle
+#include <HepMC/GenVertex.h>     // for GenVertex
+#include <HepMC/SimpleVector.h>  // for FourVector
+#include <HepMC/Units.h>         // for GEV, MM
 
 #include <TPRegexp.h>
 #include <TString.h>
@@ -33,11 +33,10 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <map>                                            // for _Rb_tree_it...
+#include <map>  // for _Rb_tree_it...
 #include <sstream>
-#include <utility>                                        // for swap, pair
-#include <vector>                                         // for vector
-
+#include <utility>  // for swap, pair
+#include <vector>   // for vector
 
 using namespace std;
 
@@ -70,7 +69,7 @@ Fun4AllOscarInputManager::Fun4AllOscarInputManager(const string &name, const str
     dstNode->addNode(newmapnode);
   }
 
-  hepmc_helper.set_geneventmap(geneventmap);
+  PHHepMCGenHelper::set_geneventmap(geneventmap);
 }
 
 Fun4AllOscarInputManager::~Fun4AllOscarInputManager()
@@ -248,7 +247,7 @@ int Fun4AllOscarInputManager::PushBackEvents(const int i)
     std::string theLine;
     while (getline(theOscarFile, theLine))
     {
-      if (theLine.compare(0,1,"#") == 0) continue;
+      if (theLine.compare(0, 1, "#") == 0) continue;
       vector<double> theInfo;
       double number = NAN;
       for (istringstream numbers_iss(theLine); numbers_iss >> number;)
@@ -290,7 +289,7 @@ int Fun4AllOscarInputManager::ConvertFromOscar()
   //Grab New Event From Oscar
   string theLine;
   vector<vector<double> > theEventVec;
-//  vector<HepMC::FourVector> theVtxVec;
+  //  vector<HepMC::FourVector> theVtxVec;
   if (isCompressed)
   {
     // while(getline(unzipstream, theLine))
@@ -324,7 +323,7 @@ int Fun4AllOscarInputManager::ConvertFromOscar()
   {
     while (getline(theOscarFile, theLine))
     {
-      if (theLine.compare(0,1,"#") == 0) continue;
+      if (theLine.compare(0, 1, "#") == 0) continue;
       vector<double> theInfo;  //format: N,pid,px,py,pz,E,mass,xvtx,yvtx,zvtx,?
       double number = NAN;
       for (istringstream numbers_iss(theLine); numbers_iss >> number;)
@@ -416,13 +415,13 @@ int Fun4AllOscarInputManager::ConvertFromOscar()
   if (Verbosity() > 3) cout << "Adding Event to phhepmcgenevt" << endl;
 
   PHHepMCGenEventMap::Iter ievt =
-      hepmc_helper.get_geneventmap()->find(hepmc_helper.get_embedding_id());
-  if (ievt != hepmc_helper.get_geneventmap()->end())
+      PHHepMCGenHelper::get_geneventmap()->find(PHHepMCGenHelper::get_embedding_id());
+  if (ievt != PHHepMCGenHelper::get_geneventmap()->end())
   {
     // override existing event
     ievt->second->addEvent(evt);
   }
   else
-    hepmc_helper.insert_event(evt);
+    PHHepMCGenHelper::insert_event(evt);
   return 0;
 }

--- a/generators/phhepmc/Fun4AllOscarInputManager.h
+++ b/generators/phhepmc/Fun4AllOscarInputManager.h
@@ -4,7 +4,7 @@
 #include "PHHepMCGenHelper.h"
 
 #include <fun4all/Fun4AllInputManager.h>
-#include <fun4all/Fun4AllReturnCodes.h>   // for SYNC_NOOBJECT, SYNC_OK
+#include <fun4all/Fun4AllReturnCodes.h>  // for SYNC_NOOBJECT, SYNC_OK
 
 #include <fstream>
 #include <string>
@@ -18,7 +18,7 @@ namespace HepMC
 class PHCompositeNode;
 class SyncObject;
 
-class Fun4AllOscarInputManager : public Fun4AllInputManager
+class Fun4AllOscarInputManager : public Fun4AllInputManager, public PHHepMCGenHelper
 {
  public:
   Fun4AllOscarInputManager(const std::string &name = "DUMMY", const std::string &topnodename = "TOP");
@@ -38,42 +38,6 @@ class Fun4AllOscarInputManager : public Fun4AllInputManager
   int NoSyncPushBackEvents(const int nevt) { return PushBackEvents(nevt); }
   int ConvertFromOscar();
 
-  //! toss a new vertex according to a Uniform or Gaus distribution
-  void set_vertex_distribution_function(PHHepMCGenHelper::VTXFUNC x, PHHepMCGenHelper::VTXFUNC y, PHHepMCGenHelper::VTXFUNC z, PHHepMCGenHelper::VTXFUNC t)
-  {
-    hepmc_helper.set_vertex_distribution_function(x, y, z, t);
-  }
-
-  //! set the mean value of the vertex distribution, use PHENIX units of cm, ns
-  void set_vertex_distribution_mean(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_mean(x, y, z, t);
-  }
-
-  //! set the width of the vertex distribution function about the mean, use PHENIX units of cm, ns
-  void set_vertex_distribution_width(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_width(x, y, z, t);
-  }
-  //
-  //! reuse vertex from another PHHepMCGenEvent with embedding_id = src_embedding_id Additional smearing and shift possible with set_vertex_distribution_*()
-  void set_reuse_vertex(int src_embedding_id)
-  {
-    hepmc_helper.set_reuse_vertex(src_embedding_id);
-  }
-
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  int get_embedding_id() const { return hepmc_helper.get_embedding_id(); }
-  //
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  void set_embedding_id(int id) { hepmc_helper.set_embedding_id(id); }
-
  protected:
   int events_total;
   int events_thisfile;
@@ -89,8 +53,6 @@ class Fun4AllOscarInputManager : public Fun4AllInputManager
   std::istream *unzipstream;  // feed into HepMc
   std::ifstream theOscarFile;
 
-  //! helper for insert HepMC event to DST node and add vertex smearing
-  PHHepMCGenHelper hepmc_helper;
   bool isCompressed;
 };
 

--- a/generators/phhepmc/Makefile.am
+++ b/generators/phhepmc/Makefile.am
@@ -23,6 +23,7 @@ pkginclude_HEADERS = \
   PHGenIntegral.h \
   PHGenIntegralv1.h \
   PHHepMCGenEvent.h \
+  PHHepMCGenEventv1.h \
   PHHepMCGenEventMap.h \
   PHHepMCGenHelper.h
 
@@ -45,6 +46,7 @@ ROOT_DICTS = \
   PHGenIntegralv1_Dict.cc \
   PHHepMC_io_Dict.cc \
   PHHepMCGenEvent_Dict.cc \
+  PHHepMCGenEventv1_Dict.cc \
   PHHepMCGenEventMap_Dict.cc
 
 pcmdir = $(libdir)
@@ -53,6 +55,7 @@ nobase_dist_pcm_DATA = \
   PHGenIntegralv1_Dict_rdict.pcm \
   PHHepMC_io_Dict_rdict.pcm \
   PHHepMCGenEvent_Dict_rdict.pcm \
+  PHHepMCGenEventv1_Dict_rdict.pcm \
   PHHepMCGenEventMap_Dict_rdict.pcm
 
 libphhepmc_la_SOURCES = \
@@ -67,6 +70,7 @@ libphhepmc_la_SOURCES = \
 libphhepmc_io_la_SOURCES = \
   $(ROOT_DICTS) \
   PHHepMCGenEvent.cc \
+  PHHepMCGenEventv1.cc \
   PHHepMCGenEventMap.cc \
   PHGenIntegral.cc \
   PHGenIntegralv1.cc

--- a/generators/phhepmc/Makefile.am
+++ b/generators/phhepmc/Makefile.am
@@ -78,7 +78,8 @@ libphhepmc_io_la_LDFLAGS = \
 
 libphhepmc_io_la_LIBADD = \
   -lphool \
-  -lHepMC
+  -lHepMC \
+  -lCLHEP
 
 BUILT_SOURCES = \
   testexternals.cc

--- a/generators/phhepmc/PHHepMCGenEvent.cc
+++ b/generators/phhepmc/PHHepMCGenEvent.cc
@@ -27,7 +27,8 @@ PHHepMCGenEvent::PHHepMCGenEvent(const PHHepMCGenEvent& event)
   , _collisionVertex(event.get_collision_vertex())
   , _theEvt(nullptr)
 {
-  _theEvt = new HepMC::GenEvent(*event.getEvent());
+  if (event.getEvent())
+    _theEvt = new HepMC::GenEvent(*event.getEvent());
   return;
 }
 

--- a/generators/phhepmc/PHHepMCGenEvent.cc
+++ b/generators/phhepmc/PHHepMCGenEvent.cc
@@ -17,7 +17,6 @@ PHHepMCGenEvent::PHHepMCGenEvent()
   : _embedding_id(0)
   , _isSimulated(false)
   , _collisionVertex(0, 0, 0, 0)
-  , m_rotation_angle(0)
   , _theEvt(nullptr)
 {
 }
@@ -26,9 +25,6 @@ PHHepMCGenEvent::PHHepMCGenEvent(const PHHepMCGenEvent& event)
   : _embedding_id(event.get_embedding_id())
   , _isSimulated(event.is_simulated())
   , _collisionVertex(event.get_collision_vertex())
-  , m_boost_beta_vector(event.get_boost_beta_vector())
-  , m_rotation_vector(event.get_rotation_vector())
-  , m_rotation_angle(event.get_rotation_angle())
   , _theEvt(nullptr)
 {
   _theEvt = new HepMC::GenEvent(*event.getEvent());
@@ -128,17 +124,13 @@ int PHHepMCGenEvent::vertexSize(void) const
 //_____________________________________________________________________________
 void PHHepMCGenEvent::identify(std::ostream& os) const
 {
-  os << "identify yourself: PHHepMCGenEvent Object, " << endl;
+  os << "identify yourself: PHHepMCGenEvent Object";
+  os << ", No of Particles: " << size();
+  os << ", No of Vertices:  " << vertexSize() << endl;
   os << " embedding_id = " << _embedding_id << endl;
   os << " isSimulated = " << _isSimulated << endl;
   os << " collisionVertex = (" << _collisionVertex.x() << "," << _collisionVertex.y() << "," << _collisionVertex.z() << ") cm, " << _collisionVertex.t() << " ns" << endl;
-  os << " m_boost_beta_vector = (" << m_boost_beta_vector.x() << "," << m_boost_beta_vector.y() << "," << m_boost_beta_vector.z() << ") " << endl;
-  os << " m_rotation_vector = (" << m_rotation_vector.x() << "," << m_rotation_vector.y() << "," << m_rotation_vector.z() << ") by " << m_rotation_angle << " rad" << endl;
 
-  os << ", No of Particles: " << size();
-  os << ", No of Vertices:  " << vertexSize();
-
-  os << endl;
   return;
 }
 
@@ -150,18 +142,4 @@ void PHHepMCGenEvent::print(std::ostream& out) const
 void PHHepMCGenEvent::PrintEvent()
 {
   _theEvt->print();
-}
-
-CLHEP::HepLorentzRotation PHHepMCGenEvent::get_LorentzRotation_EvtGen2Lab() const
-{
-  CLHEP::HepBoost boost(m_boost_beta_vector.x(), m_boost_beta_vector.y(), m_boost_beta_vector.z());
-  CLHEP::Hep3Vector axis(m_rotation_vector.x(), m_rotation_vector.y(), m_rotation_vector.z());
-  CLHEP::HepRotation rotation(axis, m_rotation_angle);
-
-  return CLHEP::HepLorentzRotation(boost, rotation);
-}
-
-CLHEP::HepLorentzRotation PHHepMCGenEvent::get_LorentzRotation_Lab2EvtGen() const
-{
-  return get_LorentzRotation_EvtGen2Lab().inverse();
 }

--- a/generators/phhepmc/PHHepMCGenEvent.cc
+++ b/generators/phhepmc/PHHepMCGenEvent.cc
@@ -3,8 +3,13 @@
 #include <HepMC/GenEvent.h>
 #include <HepMC/SimpleVector.h>  // for FourVector
 
+#include <CLHEP/Vector/Boost.h>
+#include <CLHEP/Vector/LorentzRotation.h>
+#include <CLHEP/Vector/LorentzVector.h>
+#include <CLHEP/Vector/Rotation.h>
+
 #include <sstream>
-#include <utility>               // for swap
+#include <utility>  // for swap
 
 using namespace std;
 
@@ -12,6 +17,7 @@ PHHepMCGenEvent::PHHepMCGenEvent()
   : _embedding_id(0)
   , _isSimulated(false)
   , _collisionVertex(0, 0, 0, 0)
+  , m_rotation_angle(0)
   , _theEvt(nullptr)
 {
 }
@@ -20,6 +26,9 @@ PHHepMCGenEvent::PHHepMCGenEvent(const PHHepMCGenEvent& event)
   : _embedding_id(event.get_embedding_id())
   , _isSimulated(event.is_simulated())
   , _collisionVertex(event.get_collision_vertex())
+  , m_boost_beta_vector(event.get_boost_beta_vector())
+  , m_rotation_vector(event.get_rotation_vector())
+  , m_rotation_angle(event.get_rotation_angle())
   , _theEvt(nullptr)
 {
   _theEvt = new HepMC::GenEvent(*event.getEvent());
@@ -65,8 +74,8 @@ const HepMC::GenEvent* PHHepMCGenEvent::getEvent() const
 
 bool PHHepMCGenEvent::addEvent(HepMC::GenEvent* evt)
 {
-// clean up old event if it exists,
-// no check needed, one can delete null pointers
+  // clean up old event if it exists,
+  // no check needed, one can delete null pointers
   delete _theEvt;
 
   _theEvt = evt;
@@ -119,12 +128,16 @@ int PHHepMCGenEvent::vertexSize(void) const
 //_____________________________________________________________________________
 void PHHepMCGenEvent::identify(std::ostream& os) const
 {
-  os << "identify yourself: PHHepMCGenEvent Object, ";
-  os << " embedding_id = " << _embedding_id;
-  os << " isSimulated = " << _isSimulated;
-  os << " collisionVertex = (" << _collisionVertex.x() << "," << _collisionVertex.y() << "," << _collisionVertex.z() << ") cm, " << _collisionVertex.t() << " ns";
+  os << "identify yourself: PHHepMCGenEvent Object, " << endl;
+  os << " embedding_id = " << _embedding_id << endl;
+  os << " isSimulated = " << _isSimulated << endl;
+  os << " collisionVertex = (" << _collisionVertex.x() << "," << _collisionVertex.y() << "," << _collisionVertex.z() << ") cm, " << _collisionVertex.t() << " ns" << endl;
+  os << " m_boost_beta_vector = (" << m_boost_beta_vector.x() << "," << m_boost_beta_vector.y() << "," << m_boost_beta_vector.z() << ") " << endl;
+  os << " m_rotation_vector = (" << m_rotation_vector.x() << "," << m_rotation_vector.y() << "," << m_rotation_vector.z() << ") by " << m_rotation_angle << " rad" << endl;
+
   os << ", No of Particles: " << size();
   os << ", No of Vertices:  " << vertexSize();
+
   os << endl;
   return;
 }
@@ -137,4 +150,18 @@ void PHHepMCGenEvent::print(std::ostream& out) const
 void PHHepMCGenEvent::PrintEvent()
 {
   _theEvt->print();
+}
+
+CLHEP::HepLorentzRotation PHHepMCGenEvent::get_LorentzRotation_EvtGen2Lab() const
+{
+  CLHEP::HepBoost boost(m_boost_beta_vector.x(), m_boost_beta_vector.y(), m_boost_beta_vector.z());
+  CLHEP::Hep3Vector axis(m_rotation_vector.x(), m_rotation_vector.y(), m_rotation_vector.z());
+  CLHEP::HepRotation rotation(axis, m_rotation_angle);
+
+  return CLHEP::HepLorentzRotation(boost, rotation);
+}
+
+CLHEP::HepLorentzRotation PHHepMCGenEvent::get_LorentzRotation_Lab2EvtGen() const
+{
+  return get_LorentzRotation_EvtGen2Lab().inverse();
 }

--- a/generators/phhepmc/PHHepMCGenEvent.h
+++ b/generators/phhepmc/PHHepMCGenEvent.h
@@ -6,8 +6,9 @@
 #include <phool/phool.h>
 
 #include <HepMC/SimpleVector.h>
+#include <CLHEP/Vector/LorentzRotation.h>
 
-#include <iostream>                // for cout, ostream
+#include <iostream>  // for cout, ostream
 
 namespace HepMC
 {
@@ -58,6 +59,30 @@ class PHHepMCGenEvent : public PHObject
   //! collision vertex position in the Hall coordinate system, use PHENIX units of cm, ns
   void set_collision_vertex(const HepMC::FourVector& v) { _collisionVertex = v; }
 
+  //! boost beta vector for Lorentz Transform, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  const HepMC::ThreeVector& get_boost_beta_vector() const { return m_boost_beta_vector; }
+
+  //! boost beta vector for Lorentz Transform, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  void set_boost_beta_vector(const HepMC::ThreeVector& v) { m_boost_beta_vector = v; }
+
+  //! rotation axis vector, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  const HepMC::ThreeVector& get_rotation_vector() const { return m_rotation_vector; }
+
+  //! rotation axis vector, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  void set_rotation_vector(const HepMC::ThreeVector& v) { m_rotation_vector = v; }
+
+  //! rotation angle, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  double get_rotation_angle() const { return m_rotation_angle; }
+
+  //! rotation angle, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  void set_rotation_angle(const double a) { m_rotation_angle = a; }
+
+  //!LorentzRotation to translate from hepmc event frame to lab frame
+  CLHEP::HepLorentzRotation get_LorentzRotation_EvtGen2Lab() const;
+
+  //!LorentzRotation to translate from lab frame to hepmc event frame
+  CLHEP::HepLorentzRotation get_LorentzRotation_Lab2EvtGen() const;
+
   //! host an HepMC event
   bool addEvent(HepMC::GenEvent* evt);
   bool addEvent(HepMC::GenEvent& evt);
@@ -88,10 +113,19 @@ class PHHepMCGenEvent : public PHObject
   //! collision vertex position in the Hall coordinate system, use PHENIX units of cm, ns
   HepMC::FourVector _collisionVertex;
 
+  //! boost beta vector for Lorentz Transform, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  HepMC::ThreeVector m_boost_beta_vector;
+
+  //! rotation axis vector, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  HepMC::ThreeVector m_rotation_vector;
+
+  //! rotation angle, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  double m_rotation_angle;
+
   //! The HEP MC record from event generator. Note the units are recorded in GenEvent
   HepMC::GenEvent* _theEvt;
 
-  ClassDef(PHHepMCGenEvent, 5)
+  ClassDef(PHHepMCGenEvent, 6)
 };
 
 #endif  // PHHEPMC_PHHEPMCEVENT_H

--- a/generators/phhepmc/PHHepMCGenEvent.h
+++ b/generators/phhepmc/PHHepMCGenEvent.h
@@ -5,8 +5,8 @@
 
 #include <phool/phool.h>
 
-#include <HepMC/SimpleVector.h>
 #include <CLHEP/Vector/LorentzRotation.h>
+#include <HepMC/SimpleVector.h>
 
 #include <iostream>  // for cout, ostream
 
@@ -28,12 +28,12 @@ class PHHepMCGenEvent : public PHObject
   virtual void Reset();
   virtual int isValid() const
   {
-    PHOOL_VIRTUAL_WARNING;
-    return 0;
+    return (getEvent() != nullptr) ? 1 : 0;
   }
-  PHObject* CloneMe() const { return new PHHepMCGenEvent(*this); }
-  virtual HepMC::GenEvent* getEvent();
-  virtual const HepMC::GenEvent* getEvent() const;
+  virtual PHObject* CloneMe() const { return new PHHepMCGenEvent(*this); }
+
+  HepMC::GenEvent* getEvent();
+  const HepMC::GenEvent* getEvent() const;
 
   //! embedding ID for the event
   //! positive ID is the embedded event of interest, e.g. jetty event from pythia
@@ -60,28 +60,42 @@ class PHHepMCGenEvent : public PHObject
   void set_collision_vertex(const HepMC::FourVector& v) { _collisionVertex = v; }
 
   //! boost beta vector for Lorentz Transform, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  const HepMC::ThreeVector& get_boost_beta_vector() const { return m_boost_beta_vector; }
+  virtual const HepMC::ThreeVector& get_boost_beta_vector() const
+  {
+    PHOOL_VIRTUAL_WARNING;
+    static HepMC::ThreeVector dummy_vec(0, 0, 0);
+    return dummy_vec;
+  }
 
   //! boost beta vector for Lorentz Transform, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  void set_boost_beta_vector(const HepMC::ThreeVector& v) { m_boost_beta_vector = v; }
+  virtual void set_boost_beta_vector(const HepMC::ThreeVector& v) { PHOOL_VIRTUAL_WARNING; }
 
   //! rotation axis vector, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  const HepMC::ThreeVector& get_rotation_vector() const { return m_rotation_vector; }
+  virtual const HepMC::ThreeVector& get_rotation_vector() const
+  {
+    PHOOL_VIRTUAL_WARNING;
+    static HepMC::ThreeVector dummy_vec(0, 0, 1);
+    return dummy_vec;
+  }
 
   //! rotation axis vector, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  void set_rotation_vector(const HepMC::ThreeVector& v) { m_rotation_vector = v; }
+  virtual void set_rotation_vector(const HepMC::ThreeVector& v) { PHOOL_VIRTUAL_WARNING; }
 
   //! rotation angle, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  double get_rotation_angle() const { return m_rotation_angle; }
+  virtual double get_rotation_angle() const
+  {
+    PHOOL_VIRTUAL_WARNING;
+    return 0;
+  }
 
   //! rotation angle, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  void set_rotation_angle(const double a) { m_rotation_angle = a; }
+  virtual void set_rotation_angle(const double a) { PHOOL_VIRTUAL_WARNING; }
 
   //!LorentzRotation to translate from hepmc event frame to lab frame
-  CLHEP::HepLorentzRotation get_LorentzRotation_EvtGen2Lab() const;
+  virtual CLHEP::HepLorentzRotation get_LorentzRotation_EvtGen2Lab() const { return CLHEP::HepLorentzRotation::IDENTITY; }
 
   //!LorentzRotation to translate from lab frame to hepmc event frame
-  CLHEP::HepLorentzRotation get_LorentzRotation_Lab2EvtGen() const;
+  virtual CLHEP::HepLorentzRotation get_LorentzRotation_Lab2EvtGen() const { return CLHEP::HepLorentzRotation::IDENTITY; }
 
   //! host an HepMC event
   bool addEvent(HepMC::GenEvent* evt);
@@ -96,7 +110,7 @@ class PHHepMCGenEvent : public PHObject
   virtual int size(void) const;
   virtual int vertexSize(void) const;
 
-  virtual void print(std::ostream& os = std::cout) const;
+  void print(std::ostream& os = std::cout) const;
 
   void PrintEvent();
 
@@ -113,19 +127,10 @@ class PHHepMCGenEvent : public PHObject
   //! collision vertex position in the Hall coordinate system, use PHENIX units of cm, ns
   HepMC::FourVector _collisionVertex;
 
-  //! boost beta vector for Lorentz Transform, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  HepMC::ThreeVector m_boost_beta_vector;
-
-  //! rotation axis vector, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  HepMC::ThreeVector m_rotation_vector;
-
-  //! rotation angle, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  double m_rotation_angle;
-
   //! The HEP MC record from event generator. Note the units are recorded in GenEvent
   HepMC::GenEvent* _theEvt;
 
-  ClassDef(PHHepMCGenEvent, 6)
+  ClassDef(PHHepMCGenEvent, 5)
 };
 
 #endif  // PHHEPMC_PHHEPMCEVENT_H

--- a/generators/phhepmc/PHHepMCGenEventv1.cc
+++ b/generators/phhepmc/PHHepMCGenEventv1.cc
@@ -64,6 +64,16 @@ void PHHepMCGenEventv1::identify(std::ostream& os) const
   os << " m_boost_beta_vector = (" << m_boost_beta_vector.x() << "," << m_boost_beta_vector.y() << "," << m_boost_beta_vector.z() << ") " << endl;
   os << " m_rotation_vector = (" << m_rotation_vector.x() << "," << m_rotation_vector.y() << "," << m_rotation_vector.z() << ") by " << m_rotation_angle << " rad" << endl;
 
+  static const CLHEP::HepLorentzVector zp_lightcone(0, 0, 1, 1);
+  static const CLHEP::HepLorentzVector zm_lightcone(0, 0, -1, 1);
+
+  os << " HepMC Frame light cone along +z axis translate to lab at : "
+     << (get_LorentzRotation_EvtGen2Lab() * zp_lightcone)
+     << endl;
+  os << " HepMC Frame light cone along -z axis translate to lab at : "
+     << (get_LorentzRotation_EvtGen2Lab() * zm_lightcone)
+     << endl;
+
   return;
 }
 

--- a/generators/phhepmc/PHHepMCGenEventv1.cc
+++ b/generators/phhepmc/PHHepMCGenEventv1.cc
@@ -67,10 +67,10 @@ void PHHepMCGenEventv1::identify(std::ostream& os) const
   static const CLHEP::HepLorentzVector zp_lightcone(0, 0, 1, 1);
   static const CLHEP::HepLorentzVector zm_lightcone(0, 0, -1, 1);
 
-  os << " HepMC Frame light cone along +z axis translate to lab at : "
+  os << " HepMC Frame unit light cone vector along +z axis "<<zp_lightcone<<" translate to lab at : "
      << (get_LorentzRotation_EvtGen2Lab() * zp_lightcone)
      << endl;
-  os << " HepMC Frame light cone along -z axis translate to lab at : "
+  os << " HepMC Frame unit light cone vector along -z axis  "<<zm_lightcone<<" translate to lab at : "
      << (get_LorentzRotation_EvtGen2Lab() * zm_lightcone)
      << endl;
 

--- a/generators/phhepmc/PHHepMCGenEventv1.cc
+++ b/generators/phhepmc/PHHepMCGenEventv1.cc
@@ -1,0 +1,82 @@
+#include "PHHepMCGenEventv1.h"
+
+#include <HepMC/GenEvent.h>
+#include <HepMC/SimpleVector.h>  // for FourVector
+
+#include <CLHEP/Vector/Boost.h>
+#include <CLHEP/Vector/LorentzRotation.h>
+#include <CLHEP/Vector/LorentzVector.h>
+#include <CLHEP/Vector/Rotation.h>
+
+#include <sstream>
+#include <utility>  // for swap
+
+using namespace std;
+
+PHHepMCGenEventv1::PHHepMCGenEventv1()
+  : m_boost_beta_vector(0, 0, 0)
+  , m_rotation_vector(0, 0, 1)
+  , m_rotation_angle(0)
+{
+}
+
+PHHepMCGenEventv1::PHHepMCGenEventv1(const PHHepMCGenEventv1& event)
+  : PHHepMCGenEvent(event)
+  , m_boost_beta_vector(event.get_boost_beta_vector())
+  , m_rotation_vector(event.get_rotation_vector())
+  , m_rotation_angle(event.get_rotation_angle())
+{
+  return;
+}
+
+PHHepMCGenEventv1& PHHepMCGenEventv1::operator=(const PHHepMCGenEventv1& event)
+{
+  if (&event == this) return *this;
+
+  Reset();
+
+  _embedding_id = event.get_embedding_id();
+  _isSimulated = event.is_simulated();
+  _theEvt = new HepMC::GenEvent(*event.getEvent());
+
+  return *this;
+}
+
+PHHepMCGenEventv1::~PHHepMCGenEventv1()
+{
+}
+
+void PHHepMCGenEventv1::Reset()
+{
+  PHHepMCGenEvent::Reset();
+
+  m_boost_beta_vector.set(0, 0, 0);
+  m_rotation_vector.set(0, 0, 1);
+  m_rotation_angle = 0;
+}
+
+//_____________________________________________________________________________
+void PHHepMCGenEventv1::identify(std::ostream& os) const
+{
+  PHHepMCGenEvent::identify(os);
+
+  os << " collisionVertex = (" << _collisionVertex.x() << "," << _collisionVertex.y() << "," << _collisionVertex.z() << ") cm, " << _collisionVertex.t() << " ns" << endl;
+  os << " m_boost_beta_vector = (" << m_boost_beta_vector.x() << "," << m_boost_beta_vector.y() << "," << m_boost_beta_vector.z() << ") " << endl;
+  os << " m_rotation_vector = (" << m_rotation_vector.x() << "," << m_rotation_vector.y() << "," << m_rotation_vector.z() << ") by " << m_rotation_angle << " rad" << endl;
+
+  return;
+}
+
+CLHEP::HepLorentzRotation PHHepMCGenEventv1::get_LorentzRotation_EvtGen2Lab() const
+{
+  CLHEP::HepBoost boost(m_boost_beta_vector.x(), m_boost_beta_vector.y(), m_boost_beta_vector.z());
+  CLHEP::Hep3Vector axis(m_rotation_vector.x(), m_rotation_vector.y(), m_rotation_vector.z());
+  CLHEP::HepRotation rotation(axis, m_rotation_angle);
+
+  return CLHEP::HepLorentzRotation(boost, rotation);
+}
+
+CLHEP::HepLorentzRotation PHHepMCGenEventv1::get_LorentzRotation_Lab2EvtGen() const
+{
+  return get_LorentzRotation_EvtGen2Lab().inverse();
+}

--- a/generators/phhepmc/PHHepMCGenEventv1.cc
+++ b/generators/phhepmc/PHHepMCGenEventv1.cc
@@ -60,7 +60,6 @@ void PHHepMCGenEventv1::identify(std::ostream& os) const
 {
   PHHepMCGenEvent::identify(os);
 
-  os << " collisionVertex = (" << _collisionVertex.x() << "," << _collisionVertex.y() << "," << _collisionVertex.z() << ") cm, " << _collisionVertex.t() << " ns" << endl;
   os << " m_boost_beta_vector = (" << m_boost_beta_vector.x() << "," << m_boost_beta_vector.y() << "," << m_boost_beta_vector.z() << ") " << endl;
   os << " m_rotation_vector = (" << m_rotation_vector.x() << "," << m_rotation_vector.y() << "," << m_rotation_vector.z() << ") by " << m_rotation_angle << " rad" << endl;
 

--- a/generators/phhepmc/PHHepMCGenEventv1.h
+++ b/generators/phhepmc/PHHepMCGenEventv1.h
@@ -46,9 +46,6 @@ class PHHepMCGenEventv1 : public PHHepMCGenEvent
   CLHEP::HepLorentzRotation get_LorentzRotation_Lab2EvtGen() const final;
 
  protected:
-  //! collision vertex position in the Hall coordinate system, use PHENIX units of cm, ns
-  HepMC::FourVector _collisionVertex;
-
   //! boost beta vector for Lorentz Transform, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
   HepMC::ThreeVector m_boost_beta_vector;
 

--- a/generators/phhepmc/PHHepMCGenEventv1.h
+++ b/generators/phhepmc/PHHepMCGenEventv1.h
@@ -1,0 +1,64 @@
+#ifndef PHHEPMC_PHHEPMCEVENTv1_H
+#define PHHEPMC_PHHEPMCEVENTv1_H
+
+#include "PHHepMCGenEvent.h"
+
+class PHHepMCGenEventv1 : public PHHepMCGenEvent
+{
+ public:
+  PHHepMCGenEventv1();
+
+  PHHepMCGenEventv1(const PHHepMCGenEventv1& event);
+  PHHepMCGenEventv1& operator=(const PHHepMCGenEventv1& event);
+  virtual ~PHHepMCGenEventv1();
+
+  virtual void identify(std::ostream& os = std::cout) const;
+  virtual void Reset();
+  virtual int isValid() const
+  {
+    PHOOL_VIRTUAL_WARNING;
+    return 0;
+  }
+  PHObject* CloneMe() const { return new PHHepMCGenEventv1(*this); }
+
+  //! boost beta vector for Lorentz Transform, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  const HepMC::ThreeVector& get_boost_beta_vector() const final { return m_boost_beta_vector; }
+
+  //! boost beta vector for Lorentz Transform, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  void set_boost_beta_vector(const HepMC::ThreeVector& v) final { m_boost_beta_vector = v; }
+
+  //! rotation axis vector, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  const HepMC::ThreeVector& get_rotation_vector() const final { return m_rotation_vector; }
+
+  //! rotation axis vector, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  void set_rotation_vector(const HepMC::ThreeVector& v) final { m_rotation_vector = v; }
+
+  //! rotation angle, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  double get_rotation_angle() const final { return m_rotation_angle; }
+
+  //! rotation angle, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  void set_rotation_angle(const double a) final { m_rotation_angle = a; }
+
+  //!LorentzRotation to translate from hepmc event frame to lab frame
+  CLHEP::HepLorentzRotation get_LorentzRotation_EvtGen2Lab() const final;
+
+  //!LorentzRotation to translate from lab frame to hepmc event frame
+  CLHEP::HepLorentzRotation get_LorentzRotation_Lab2EvtGen() const final;
+
+ protected:
+  //! collision vertex position in the Hall coordinate system, use PHENIX units of cm, ns
+  HepMC::FourVector _collisionVertex;
+
+  //! boost beta vector for Lorentz Transform, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  HepMC::ThreeVector m_boost_beta_vector;
+
+  //! rotation axis vector, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  HepMC::ThreeVector m_rotation_vector;
+
+  //! rotation angle, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
+  double m_rotation_angle;
+
+  ClassDef(PHHepMCGenEventv1, 1)
+};
+
+#endif  // PHHEPMC_PHHEPMCEVENTv1_H

--- a/generators/phhepmc/PHHepMCGenEventv1LinkDef.h
+++ b/generators/phhepmc/PHHepMCGenEventv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHHepMCGenEventv1 + ;
+
+#endif

--- a/generators/phhepmc/PHHepMCGenHelper.cc
+++ b/generators/phhepmc/PHHepMCGenHelper.cc
@@ -160,6 +160,11 @@ void PHHepMCGenHelper::move_vertex(PHHepMCGenEvent *genevent)
 //! move vertex in translation,boost,rotation according to vertex settings
 void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *genevent)
 {
+  if (m_verbosity)
+  {
+    Print();
+  }
+
   assert(genevent);
 
   move_vertex(genevent);

--- a/generators/phhepmc/PHHepMCGenHelper.cc
+++ b/generators/phhepmc/PHHepMCGenHelper.cc
@@ -210,9 +210,9 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
   auto smear_beam_divergence = [&, this](
                                    const CLHEP::Hep3Vector &beam_center,
-                                   const std::pair<double, double> &divergence_xy) {
-    const double &x_divergence = divergence_xy.first;
-    const double &y_divergence = divergence_xy.second;
+                                   const std::pair<double, double> &divergence_hv) {
+    const double &x_divergence = divergence_hv.first;
+    const double &y_divergence = divergence_hv.second;
 
     // y direction in accelerator
     static const CLHEP::Hep3Vector accelerator_plane(0, 1, 0);
@@ -224,8 +224,8 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
     return y_smear_out_accelerator_plane * x_smear_in_accelerator_plane * beam_center;
   };
 
-  CLHEP::Hep3Vector beamA_vec = smear_beam_divergence(beamA_center, m_beam_angular_divergence_xy.first);
-  CLHEP::Hep3Vector beamB_vec = smear_beam_divergence(beamB_center, m_beam_angular_divergence_xy.second);
+  CLHEP::Hep3Vector beamA_vec = smear_beam_divergence(beamA_center, m_beam_angular_divergence_hv.first);
+  CLHEP::Hep3Vector beamB_vec = smear_beam_divergence(beamB_center, m_beam_angular_divergence_hv.second);
 
   if (m_verbosity)
   {
@@ -432,10 +432,10 @@ void PHHepMCGenHelper::Print(const std::string &what) const
   cout << "Beam direction: B  theta-phi = " << m_beam_direction_theta_phi.second.first
        << ", " << m_beam_direction_theta_phi.second.second << endl;
 
-  cout << "Beam divergence: A X-Y = " << m_beam_angular_divergence_xy.first.first
-       << ", " << m_beam_angular_divergence_xy.first.second << endl;
-  cout << "Beam divergence: B X-Y = " << m_beam_angular_divergence_xy.second.first
-       << ", " << m_beam_angular_divergence_xy.second.second << endl;
+  cout << "Beam divergence: A X-Y = " << m_beam_angular_divergence_hv.first.first
+       << ", " << m_beam_angular_divergence_hv.first.second << endl;
+  cout << "Beam divergence: B X-Y = " << m_beam_angular_divergence_hv.second.first
+       << ", " << m_beam_angular_divergence_hv.second.second << endl;
 
   return;
 }

--- a/generators/phhepmc/PHHepMCGenHelper.cc
+++ b/generators/phhepmc/PHHepMCGenHelper.cc
@@ -186,6 +186,16 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
   CLHEP::Hep3Vector beamA_center = pair2Hep3Vector(m_beam_direction_theta_phi.first);
   CLHEP::Hep3Vector beamB_center = pair2Hep3Vector(m_beam_direction_theta_phi.second);
 
+  if (m_verbosity)
+  {
+    cout << __PRETTY_FUNCTION__ << ": " << endl;
+    cout << "beamA_center = " << beamA_center << endl;
+    cout << "beamB_center = " << beamB_center << endl;
+  }
+
+  assert(fabs(beamB_center.mag2() - 1) < CLHEP::Hep3Vector::getTolerance());
+  assert(fabs(beamB_center.mag2() - 1) < CLHEP::Hep3Vector::getTolerance());
+
   if (beamA_center.dot(beamB_center) > -0.5)
   {
     cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - WARNING -"
@@ -217,6 +227,16 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
   CLHEP::Hep3Vector beamA_vec = smear_beam_divergence(beamA_center, m_beam_angular_divergence_xy.first);
   CLHEP::Hep3Vector beamB_vec = smear_beam_divergence(beamB_center, m_beam_angular_divergence_xy.second);
 
+  if (m_verbosity)
+  {
+    cout << __PRETTY_FUNCTION__ << ": " << endl;
+    cout << "beamA_vec = " << beamA_vec << endl;
+    cout << "beamB_vec = " << beamB_vec << endl;
+  }
+
+  assert(fabs(beamA_vec.mag2() - 1) < CLHEP::Hep3Vector::getTolerance());
+  assert(fabs(beamB_vec.mag2() - 1) < CLHEP::Hep3Vector::getTolerance());
+
   // apply minimal beam energy shift rotation and boost
   CLHEP::Hep3Vector boost_axis = beamA_vec + beamB_vec;
   if (boost_axis.mag2() > CLHEP::Hep3Vector::getTolerance())
@@ -226,25 +246,48 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
     // split the boost to half for each beam for minimal beam  energy shift
     genevent->set_boost_beta_vector(-0.5 * boost_axis);
 
+    if (m_verbosity)
+    {
+      cout << __PRETTY_FUNCTION__ << ": non-zero boost " << endl;
+    }
   }  //    if (cos_rotation_angle> CLHEP::Hep3Vector::getTolerance())
   else
   {
     genevent->set_boost_beta_vector(CLHEP::Hep3Vector(0, 0, 0));
+    if (m_verbosity)
+    {
+      cout << __PRETTY_FUNCTION__ << ": zero boost " << endl;
+    }
   }
 
   //rotation to collision to along z-axis with beamA pointing to +z
   double cos_rotation_angle_to_z = (beamA_vec - beamB_vec).dot(z_axis);
+  if (m_verbosity)
+  {
+    cout << __PRETTY_FUNCTION__ << ": check rotation ";
+    cout << "cos_rotation_angle_to_z= " << cos_rotation_angle_to_z << endl;
+  }
+
   if (1 - cos_rotation_angle_to_z < CLHEP::Hep3Vector::getTolerance())
   {
     //no rotation
     genevent->set_rotation_vector(z_axis);
     genevent->set_rotation_angle(0);
+
+    if (m_verbosity)
+    {
+      cout << __PRETTY_FUNCTION__ << ": no rotation " << endl;
+    }
   }
-  if (cos_rotation_angle_to_z + 1 < CLHEP::Hep3Vector::getTolerance())
+  else if (cos_rotation_angle_to_z + 1 < CLHEP::Hep3Vector::getTolerance())
   {
     // you got beam flipped
     genevent->set_rotation_vector(CLHEP::Hep3Vector(0, 1, 0));
     genevent->set_rotation_angle(M_PI);
+    if (m_verbosity)
+    {
+      cout << __PRETTY_FUNCTION__ << ": reverse beam direction " << endl;
+    }
   }
   else
   {
@@ -255,7 +298,17 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
     genevent->set_rotation_vector(rotation_axis);
     genevent->set_rotation_angle(rotation_angle_to_z);
 
+    if (m_verbosity)
+    {
+      cout << __PRETTY_FUNCTION__ << ": has rotation " << endl;
+    }
   }  //  if (boost_axis.mag2() > CLHEP::Hep3Vector::getTolerance())
+
+  if (m_verbosity)
+  {
+    cout << __PRETTY_FUNCTION__ << ": final boost rotation " << endl;
+    genevent->identify();
+  }
 }
 
 void PHHepMCGenHelper::set_vertex_distribution_function(VTXFUNC x, VTXFUNC y, VTXFUNC z, VTXFUNC t)

--- a/generators/phhepmc/PHHepMCGenHelper.cc
+++ b/generators/phhepmc/PHHepMCGenHelper.cc
@@ -244,7 +244,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
     //non-zero boost
 
     // split the boost to half for each beam for minimal beam  energy shift
-    genevent->set_boost_beta_vector(-0.5 * boost_axis);
+    genevent->set_boost_beta_vector(0.5 * boost_axis);
 
     if (m_verbosity)
     {
@@ -261,7 +261,23 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
   }
 
   //rotation to collision to along z-axis with beamA pointing to +z
-  double cos_rotation_angle_to_z = (beamA_vec - beamB_vec).dot(z_axis);
+  CLHEP::Hep3Vector beamDiffAxis = (beamA_vec - beamB_vec);
+  if (beamDiffAxis.mag2() <CLHEP::Hep3Vector::getTolerance())
+  {
+    cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - Fatal error -"
+         << "Beam A and Beam B are too close to each other in direction "
+         << "Please double check beam direction and divergence setting. "
+         << "beamA_vec = " << beamA_vec << ","
+         << "beamB_vec = " << beamB_vec << ","
+         << " Current setting:";
+
+    Print();
+
+    exit(1);
+  }
+
+  beamDiffAxis = beamDiffAxis / beamDiffAxis.mag();
+  double cos_rotation_angle_to_z = beamDiffAxis.dot(z_axis);
   if (m_verbosity)
   {
     cout << __PRETTY_FUNCTION__ << ": check rotation ";
@@ -293,7 +309,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
   {
     // need a rotation
     CLHEP::Hep3Vector rotation_axis = (beamA_vec - beamB_vec).cross(z_axis);
-    const double rotation_angle_to_z = acos(cos_rotation_angle_to_z);
+    const double rotation_angle_to_z = -acos(cos_rotation_angle_to_z);
 
     genevent->set_rotation_vector(rotation_axis);
     genevent->set_rotation_angle(rotation_angle_to_z);

--- a/generators/phhepmc/PHHepMCGenHelper.cc
+++ b/generators/phhepmc/PHHepMCGenHelper.cc
@@ -193,14 +193,14 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
     Print();
   }
 
-  // y direction in accelerator
-  static const CLHEP::Hep3Vector accelerator_plane(0, 1, 0);
-
-  auto smear_beam_divergence = [accelerator_plane](
+  auto smear_beam_divergence = [&, this](
                                    const CLHEP::Hep3Vector &beam_center,
                                    const std::pair<double, double> &divergence_xy) {
     const double &x_divergence = divergence_xy.first;
     const double &y_divergence = divergence_xy.second;
+
+    // y direction in accelerator
+    static const CLHEP::Hep3Vector accelerator_plane(0, 1, 0);
 
     CLHEP::Hep3Vector beam_direction(beam_center);
     CLHEP::HepRotation x_smear_in_accelerator_plane(accelerator_plane, smear(0, x_divergence, Gaus));

--- a/generators/phhepmc/PHHepMCGenHelper.cc
+++ b/generators/phhepmc/PHHepMCGenHelper.cc
@@ -107,6 +107,9 @@ void PHHepMCGenHelper::move_vertex(PHHepMCGenEvent *genevent)
   assert(genevent);
 
   assert(_vertex_width_x >= 0);
+  assert(_vertex_width_y >= 0);
+  assert(_vertex_width_z >= 0);
+  assert(_vertex_width_t >= 0);
 
   if (_reuse_vertex)
   {

--- a/generators/phhepmc/PHHepMCGenHelper.h
+++ b/generators/phhepmc/PHHepMCGenHelper.h
@@ -13,7 +13,9 @@
 
 #include <gsl/gsl_rng.h>
 
+#include <cmath>
 #include <string>
+#include <utility>
 
 class PHCompositeNode;
 class PHHepMCGenEvent;
@@ -23,7 +25,6 @@ namespace HepMC
 {
   class GenEvent;
 }
-
 
 /*!
  * \brief PHHepMCGenHelper provides service of DST upload of HepMC subevent, vertex assignment and random generator
@@ -101,6 +102,34 @@ class PHHepMCGenHelper
     _geneventmap = geneventmap;
   }
 
+  //! Beam angle in lab polar coordinate.
+  //! @param[in] beamA_theta beamA, in pair of Theta-Phi. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! @param[in] beamA_phi beamA, in pair of Theta-Phi. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! @param[in] beamB_theta  beamB, in pair of Theta-Phi. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  //! @param[in] beamB_phi  beamB, in pair of Theta-Phi. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  void set_beam_direction_theta_phi(
+      const double beamA_theta,
+      const double beamA_phi,
+      const double beamB_theta,
+      const double beamB_phi)
+  {
+    m_beam_direction_theta_phi = {{beamA_theta, beamA_phi}, {beamB_theta, beamB_phi}};
+  }
+
+  //! Beam angle divergence in accelerator beam coordinate.
+  //! @param[in] beamA_divergence_x beamA, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! @param[in] beamA_divergence_y beamA, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! @param[in] beamB_divergence_x beamB, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  //! @param[in] beamB_divergence_y beamB, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  void set_beam_angular_divergence_xy(
+      const double beamA_divergence_x,
+      const double beamA_divergence_y,
+      const double beamB_divergence_x,
+      const double beamB_divergence_y)
+  {
+    m_beam_angular_divergence_xy = {{beamA_divergence_x, beamA_divergence_y}, {beamB_divergence_x, beamB_divergence_y}};
+  }
+
   void CopySettings(PHHepMCGenHelper &helper);
 
   void Print(const std::string &what = "ALL") const;
@@ -124,6 +153,22 @@ class PHHepMCGenHelper
   double _vertex_width_y;
   double _vertex_width_z;
   double _vertex_width_t;
+
+  //! Beam angle in lab polar coordinate.
+  //! First element is beamA, in pair of Theta-Phi. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! Second element is beamB, in pair of Theta-Phi. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  std::pair<std::pair<double, double>, std::pair<double, double>> m_beam_direction_theta_phi = {
+      {0, 0},    //+z beam
+      {M_PI, 0}  //-z beam
+  };
+
+  //! Beam angle divergence in accelerator beam coordinate.
+  //! First element is beamA, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! Second element is beamB, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  std::pair<std::pair<double, double>, std::pair<double, double>> m_beam_angular_divergence_xy = {
+      {0, 0},  //+z beam
+      {0, 0}   //-z beam
+  };
 
   //! positive ID is the embedded event of interest, e.g. jetty event from pythia
   //! negative IDs are backgrounds, .e.g out of time pile up collisions

--- a/generators/phhepmc/PHHepMCGenHelper.h
+++ b/generators/phhepmc/PHHepMCGenHelper.h
@@ -82,7 +82,10 @@ class PHHepMCGenHelper
   //! send HepMC::GenEvent to DST tree. This function takes ownership of evt
   PHHepMCGenEvent *insert_event(HepMC::GenEvent *evt);
 
-  //! move vertex according to vertex settings
+  //! Record the translation,boost,rotation for HepMC frame to lab frame according to collision settings
+  void HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *genevent);
+
+  //! move vertex in translation according to vertex settings
   void move_vertex(PHHepMCGenEvent *genevent);
 
   const PHHepMCGenEventMap *get_geneventmap() const

--- a/generators/phhepmc/PHHepMCGenHelper.h
+++ b/generators/phhepmc/PHHepMCGenHelper.h
@@ -76,6 +76,9 @@ class PHHepMCGenHelper
   //! init interface nodes
   int create_node_tree(PHCompositeNode *topNode);
 
+  //! choice of reference version of the PHHepMCGenEvent
+  const PHHepMCGenEvent * get_PHHepMCGenEvent_template() const;
+
   //! send HepMC::GenEvent to DST tree. This function takes ownership of evt
   PHHepMCGenEvent *insert_event(HepMC::GenEvent *evt);
 
@@ -131,6 +134,12 @@ class PHHepMCGenHelper
   }
 
   void CopySettings(PHHepMCGenHelper &helper);
+
+  //! copy setting to helper_dest
+  void CopySettings(PHHepMCGenHelper * helper_dest) ;
+
+  //! copy setting from helper_src
+  void CopyHelperSettings(PHHepMCGenHelper * helper_src) ;
 
   void Print(const std::string &what = "ALL") const;
 

--- a/generators/phhepmc/PHHepMCGenHelper.h
+++ b/generators/phhepmc/PHHepMCGenHelper.h
@@ -123,17 +123,17 @@ class PHHepMCGenHelper
   }
 
   //! Beam angle divergence in accelerator beam coordinate.
-  //! @param[in] beamA_divergence_x beamA, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to +z direction in the HepMC event generator's coordinate
-  //! @param[in] beamA_divergence_y beamA, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to +z direction in the HepMC event generator's coordinate
-  //! @param[in] beamB_divergence_x beamB, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to -z direction in the HepMC event generator's coordinate
-  //! @param[in] beamB_divergence_y beamB, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to -z direction in the HepMC event generator's coordinate
-  void set_beam_angular_divergence_xy(
-      const double beamA_divergence_x,
-      const double beamA_divergence_y,
-      const double beamB_divergence_x,
-      const double beamB_divergence_y)
+  //! @param[in] beamA_divergence_h beamA, horizontal divergence Gaussian Sigma. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! @param[in] beamA_divergence_v beamA, vertical divergence Gaussian Sigma. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! @param[in] beamB_divergence_h beamB, horizontal divergence Gaussian Sigma. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  //! @param[in] beamB_divergence_v beamB, vertical divergence Gaussian Sigma. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  void set_beam_angular_divergence_hv(
+      const double beamA_divergence_h,
+      const double beamA_divergence_v,
+      const double beamB_divergence_h,
+      const double beamB_divergence_v)
   {
-    m_beam_angular_divergence_xy = {{beamA_divergence_x, beamA_divergence_y}, {beamB_divergence_x, beamB_divergence_y}};
+    m_beam_angular_divergence_hv = {{beamA_divergence_h, beamA_divergence_v}, {beamB_divergence_h, beamB_divergence_v}};
   }
 
   void CopySettings(PHHepMCGenHelper &helper);
@@ -179,9 +179,9 @@ class PHHepMCGenHelper
   };
 
   //! Beam angle divergence in accelerator beam coordinate.
-  //! First element is beamA, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to +z direction in the HepMC event generator's coordinate
-  //! Second element is beamB, in pair of Gaussian Sigma_X Sigma_Y. BeamA is aimed to -z direction in the HepMC event generator's coordinate
-  std::pair<std::pair<double, double>, std::pair<double, double>> m_beam_angular_divergence_xy = {
+  //! First element is beamA, in pair of Gaussian Sigma_H Sigma_V. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! Second element is beamB, in pair of Gaussian Sigma_H Sigma_V. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  std::pair<std::pair<double, double>, std::pair<double, double>> m_beam_angular_divergence_hv = {
       {0, 0},  //+z beam
       {0, 0}   //-z beam
   };

--- a/generators/phhepmc/PHHepMCGenHelper.h
+++ b/generators/phhepmc/PHHepMCGenHelper.h
@@ -146,6 +146,10 @@ class PHHepMCGenHelper
 
   void Print(const std::string &what = "ALL") const;
 
+  void PHHepMCGenHelper_Verbosity(int v) {m_verbosity = v;}
+
+  int PHHepMCGenHelper_Verbosity() {return m_verbosity;}
+
  private:
   gsl_rng *RandomGenerator;
 
@@ -195,6 +199,9 @@ class PHHepMCGenHelper
 
   //! pointer to the output container
   PHHepMCGenEventMap *_geneventmap;
+
+  //!verbosity
+  int m_verbosity = 0;
 };
 
 #endif /* PHHEPMC_PHHEPMCGENHELPER_H */

--- a/generators/phhepmc/PHHepMCGenHelper.h
+++ b/generators/phhepmc/PHHepMCGenHelper.h
@@ -74,7 +74,7 @@ class PHHepMCGenHelper
 
   //
   //! init interface nodes
-  int create_node_tree(PHCompositeNode *topNode);
+  virtual int create_node_tree(PHCompositeNode *topNode);
 
   //! choice of reference version of the PHHepMCGenEvent
   const PHHepMCGenEvent * get_PHHepMCGenEvent_template() const;

--- a/generators/sHEPGen/sHEPGen.C
+++ b/generators/sHEPGen/sHEPGen.C
@@ -3,8 +3,8 @@
 #include <phhepmc/PHHepMCGenEvent.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHIODataNode.h>
 #include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHRandomSeed.h>
 
@@ -18,30 +18,28 @@ using namespace std;
 
 typedef PHIODataNode<PHObject> PHObjectNode_t;
 
-
-sHEPGen::sHEPGen(const std::string &name):
-  SubsysReco(name),
-  _eventcount(0),
-  _p_electron_lab(-20),
-  _p_hadron_lab(250),
-  _p4_electron_lab(nullptr),
-  _p4_hadron_lab(nullptr),
-  _p4_hadron_lab_invert(nullptr),
-  _p4_electron_prest(nullptr),
-  _p4_hadron_prest(nullptr),
-  _hgenManager(NULL),
-  _datacardFile("hepgen_dvcs.data")
+sHEPGen::sHEPGen(const std::string &name)
+  : SubsysReco(name)
+  , _eventcount(0)
+  , _p_electron_lab(-20)
+  , _p_hadron_lab(250)
+  , _p4_electron_lab(nullptr)
+  , _p4_hadron_lab(nullptr)
+  , _p4_hadron_lab_invert(nullptr)
+  , _p4_electron_prest(nullptr)
+  , _p4_hadron_prest(nullptr)
+  , _hgenManager(NULL)
+  , _datacardFile("hepgen_dvcs.data")
 {
-  hepmc_helper.set_embedding_id(1); // default embedding ID to 1
-
+  PHHepMCGenHelper::set_embedding_id(1);  // default embedding ID to 1
 }
 
-sHEPGen::~sHEPGen() {
-
+sHEPGen::~sHEPGen()
+{
 }
 
-int sHEPGen::Init(PHCompositeNode *topNode) {
-
+int sHEPGen::Init(PHCompositeNode *topNode)
+{
   printlogo();
 
   /* electron and proton mass */
@@ -49,50 +47,50 @@ int sHEPGen::Init(PHCompositeNode *topNode) {
   double mass_p = 9.382720e-1;
 
   /* 4-Vectors of colliding electron and proton in laboratory frame */
-  _p4_electron_lab = new HLorentzVector( 0.,
-                                         0.,
-                                         _p_electron_lab,
-                                         sqrt(_p_electron_lab*_p_electron_lab+mass_e*mass_e) );
+  _p4_electron_lab = new HLorentzVector(0.,
+                                        0.,
+                                        _p_electron_lab,
+                                        sqrt(_p_electron_lab * _p_electron_lab + mass_e * mass_e));
 
-  _p4_hadron_lab = new HLorentzVector( 0.,
-                                       0.,
-                                       _p_hadron_lab,
-                                       sqrt(_p_hadron_lab*_p_hadron_lab+mass_p*mass_p) );
+  _p4_hadron_lab = new HLorentzVector(0.,
+                                      0.,
+                                      _p_hadron_lab,
+                                      sqrt(_p_hadron_lab * _p_hadron_lab + mass_p * mass_p));
 
   /* The current version of HEPGen supports only a "Fixed Target" mode, i.e.
      the target (proton) is assumed at rest. Therefore, need to boost collision
      from the laboratory frame to the proton-at-rest frame. */
-  _p4_hadron_lab_invert = new HLorentzVector( 0.,
-                                              0.,
-                                              -1 * _p_hadron_lab,
-                                              sqrt(_p_hadron_lab*_p_hadron_lab+mass_p*mass_p) );
+  _p4_hadron_lab_invert = new HLorentzVector(0.,
+                                             0.,
+                                             -1 * _p_hadron_lab,
+                                             sqrt(_p_hadron_lab * _p_hadron_lab + mass_p * mass_p));
 
   /* 4-Vectors of colliding electron and proton in proton-at-rest frame */
-  _p4_electron_prest = new HLorentzVector( *_p4_electron_lab );
-  _p4_electron_prest->boost(sqrt(_p4_hadron_lab_invert->getQuare()),*_p4_hadron_lab_invert);
+  _p4_electron_prest = new HLorentzVector(*_p4_electron_lab);
+  _p4_electron_prest->boost(sqrt(_p4_hadron_lab_invert->getQuare()), *_p4_hadron_lab_invert);
 
-  _p4_hadron_prest = new HLorentzVector( *_p4_hadron_lab );
-  _p4_hadron_prest->boost(sqrt(_p4_hadron_lab_invert->getQuare()),*_p4_hadron_lab_invert);
+  _p4_hadron_prest = new HLorentzVector(*_p4_hadron_lab);
+  _p4_hadron_prest->boost(sqrt(_p4_hadron_lab_invert->getQuare()), *_p4_hadron_lab_invert);
 
-  if ( verbosity > 2 )
-    {
-      cout << "Electron and proton in laboratory frame:" << endl;
-      _p4_electron_lab->print();
-      _p4_hadron_lab->print();
+  if (verbosity > 2)
+  {
+    cout << "Electron and proton in laboratory frame:" << endl;
+    _p4_electron_lab->print();
+    _p4_hadron_lab->print();
 
-      cout << "Electron and proton in proton-at-rest frame:" << endl;
-      _p4_electron_prest->print();
-      _p4_hadron_prest->print();
-    }
+    cout << "Electron and proton in proton-at-rest frame:" << endl;
+    _p4_electron_prest->print();
+    _p4_hadron_prest->print();
+  }
 
   /* flip sign of electron momentum z-component for HEPGen */
-  HVector3 flip_pz( _p4_electron_prest->getVector() );
-  flip_pz.setZ( flip_pz.Z() * -1 );
-  _p4_electron_prest->setVector( flip_pz );
+  HVector3 flip_pz(_p4_electron_prest->getVector());
+  flip_pz.setZ(flip_pz.Z() * -1);
+  _p4_electron_prest->setVector(flip_pz);
 
   /* get instance of HepGenManager */
   _hgenManager = HGenManager::getInstance();
-  _hgenManager->loadSettings( _datacardFile );
+  _hgenManager->loadSettings(_datacardFile);
   _hgenManager->setupGenerator();
 
   /* set beam parameters */
@@ -103,10 +101,10 @@ int sHEPGen::Init(PHCompositeNode *topNode) {
 
   /* set random seed */
   unsigned int seed = PHRandomSeed();
-  _hgenManager->setSeed ( seed );
+  _hgenManager->setSeed(seed);
 
   /* enable detailed event record printput for debugging */
-  if ( verbosity > 2 )
+  if (verbosity > 2)
     _hgenManager->enableDebug();
 
   create_node_tree(topNode);
@@ -116,33 +114,30 @@ int sHEPGen::Init(PHCompositeNode *topNode) {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int sHEPGen::End(PHCompositeNode *topNode) {
-
+int sHEPGen::End(PHCompositeNode *topNode)
+{
   cout << "Reached the sHEPGen::End()" << endl;
 
   //-* dump out closing info (cross-sections, etc)
 
   if (verbosity > 1) cout << "sHEPGen::End - I'm here!" << endl;
 
-
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-
-int sHEPGen::process_event(PHCompositeNode *topNode) {
-
+int sHEPGen::process_event(PHCompositeNode *topNode)
+{
   if (verbosity > 1) cout << "sHEPGen::process_event - event: " << _eventcount << endl;
 
   _hgenManager->oneShot();
 
-  if ( verbosity > 2 )
+  if (verbosity > 2)
     _hgenManager->getEvent()->printDebug();
 
   HEvent *evt_mc = _hgenManager->getEvent();
 
   /* Create HepMC GenEvent */
-  HepMC::GenEvent* evt = new HepMC::GenEvent();
+  HepMC::GenEvent *evt = new HepMC::GenEvent();
 
   /* define the units (Pythia uses GeV and mm) */
   evt->use_units(HepMC::Units::GEV, HepMC::Units::MM);
@@ -152,12 +147,12 @@ int sHEPGen::process_event(PHCompositeNode *topNode) {
 
   /* Set the PDF information */
   HepMC::PdfInfo pdfinfo;
-  pdfinfo.set_scalePDF( evt_mc->getQsq() );
-  pdfinfo.set_x2( evt_mc->getXbj() );
-  evt->set_pdf_info( pdfinfo );
+  pdfinfo.set_scalePDF(evt_mc->getQsq());
+  pdfinfo.set_x2(evt_mc->getXbj());
+  evt->set_pdf_info(pdfinfo);
 
   /* Set additional event parameters */
-  evt->set_event_scale( evt_mc->getQsq() );
+  evt->set_event_scale(evt_mc->getQsq());
 
   /* Event kinematics */
   /* @TODO How can we store this information in HepMC record? */
@@ -172,63 +167,65 @@ int sHEPGen::process_event(PHCompositeNode *topNode) {
 
   /* Create single HepMC vertex for event */
   /* @TODO: Implement multiple vertices e.g. for decay particles */
-  HepMC::GenVertex* hepmcvtx = new HepMC::GenVertex( HepMC::FourVector( 0,
-                                                                        0,
-                                                                        0,
-                                                                        0 )
-                                                     );
+  HepMC::GenVertex *hepmcvtx = new HepMC::GenVertex(HepMC::FourVector(0,
+                                                                      0,
+                                                                      0,
+                                                                      0));
 
   /* Create HepMC particle records */
-  HEventData* edata = evt_mc->getStruct();
-  for ( unsigned p = 0; p < edata->listOfParticles.size(); p++ )
+  HEventData *edata = evt_mc->getStruct();
+  for (unsigned p = 0; p < edata->listOfParticles.size(); p++)
+  {
+    if (verbosity > 4)
     {
-      if (verbosity > 4)
-        {
-          cout << "______new particle_______" << endl;
-          cout << "Index:  " << p+1 << endl;
-          cout << "PID: " << edata->listOfParticles.at(p)->getParticleType() << " -- " << (edata->listOfParticles.at(p) == &(edata->incBeamParticle)) << endl;
-          cout << "Particle aux flag: " << edata->listOfParticles.at(p)->getParticleAuxFlag() << endl;
-          cout << "Particle origin: " << edata->listOfParticles.at(p)->getParticleOrigin() << endl;
-          cout << "Particle daughter1: " << edata->listOfParticles.at(p)->getParticleDaughter1() << endl;
-          cout << "Particle daughter2: " << edata->listOfParticles.at(p)->getParticleDaughter2() << endl;
-        }
-
-      HLorentzVector v4_particle_p = edata->listOfParticles.at(p)->getVector();
-
-      /* flip z axis component of particle momentum: sPHENIX EIC detector coordinate system uses
-         electron flying in 'negative z' direction */
-      HVector3 flip_pz( v4_particle_p.getVector() );
-      flip_pz.setZ( flip_pz.Z() * -1 );
-      v4_particle_p.setVector( flip_pz );
-
-      /* Boost particle from proton-at-rest frame to laboratory frame */
-      HLorentzVector v4_particle_p_lab( v4_particle_p );
-
-      v4_particle_p_lab.boost(sqrt(_p4_hadron_lab->getQuare()),*_p4_hadron_lab);
-
-      if ( verbosity > 2 )
-        {
-          cout << "EVENT RECORD particle: " << edata->listOfParticles.at(p)->getParticleType()
-               << " (status: " << edata->listOfParticles.at(p)->getParticleAuxFlag() << ")" << endl;
-          cout << " --> PROTON REST frame: "; v4_particle_p.print();
-          cout << " --> LABORATORY  frame: "; v4_particle_p_lab.print();
-        }
-
-      HepMC::GenParticle *particle_hepmc = new HepMC::GenParticle( HepMC::FourVector(v4_particle_p_lab.getVector().X(),
-                                                                                     v4_particle_p_lab.getVector().Y(),
-                                                                                     v4_particle_p_lab.getVector().Z(),
-                                                                                     v4_particle_p_lab.getEnergy()),
-                                                                   edata->listOfParticles.at(p)->getParticleType() );
-      particle_hepmc->set_status( edata->listOfParticles.at(p)->getParticleAuxFlag() );
-      hepmcvtx->add_particle_out( particle_hepmc );
+      cout << "______new particle_______" << endl;
+      cout << "Index:  " << p + 1 << endl;
+      cout << "PID: " << edata->listOfParticles.at(p)->getParticleType() << " -- " << (edata->listOfParticles.at(p) == &(edata->incBeamParticle)) << endl;
+      cout << "Particle aux flag: " << edata->listOfParticles.at(p)->getParticleAuxFlag() << endl;
+      cout << "Particle origin: " << edata->listOfParticles.at(p)->getParticleOrigin() << endl;
+      cout << "Particle daughter1: " << edata->listOfParticles.at(p)->getParticleDaughter1() << endl;
+      cout << "Particle daughter2: " << edata->listOfParticles.at(p)->getParticleDaughter2() << endl;
     }
 
+    HLorentzVector v4_particle_p = edata->listOfParticles.at(p)->getVector();
+
+    /* flip z axis component of particle momentum: sPHENIX EIC detector coordinate system uses
+         electron flying in 'negative z' direction */
+    HVector3 flip_pz(v4_particle_p.getVector());
+    flip_pz.setZ(flip_pz.Z() * -1);
+    v4_particle_p.setVector(flip_pz);
+
+    /* Boost particle from proton-at-rest frame to laboratory frame */
+    HLorentzVector v4_particle_p_lab(v4_particle_p);
+
+    v4_particle_p_lab.boost(sqrt(_p4_hadron_lab->getQuare()), *_p4_hadron_lab);
+
+    if (verbosity > 2)
+    {
+      cout << "EVENT RECORD particle: " << edata->listOfParticles.at(p)->getParticleType()
+           << " (status: " << edata->listOfParticles.at(p)->getParticleAuxFlag() << ")" << endl;
+      cout << " --> PROTON REST frame: ";
+      v4_particle_p.print();
+      cout << " --> LABORATORY  frame: ";
+      v4_particle_p_lab.print();
+    }
+
+    HepMC::GenParticle *particle_hepmc = new HepMC::GenParticle(HepMC::FourVector(v4_particle_p_lab.getVector().X(),
+                                                                                  v4_particle_p_lab.getVector().Y(),
+                                                                                  v4_particle_p_lab.getVector().Z(),
+                                                                                  v4_particle_p_lab.getEnergy()),
+                                                                edata->listOfParticles.at(p)->getParticleType());
+    particle_hepmc->set_status(edata->listOfParticles.at(p)->getParticleAuxFlag());
+    hepmcvtx->add_particle_out(particle_hepmc);
+  }
+
   /* Add vertex to event */
-  evt->add_vertex( hepmcvtx );
+  evt->add_vertex(hepmcvtx);
 
   /* pass HepMC to PHNode */
-  PHHepMCGenEvent * success = hepmc_helper . insert_event(evt);
-  if (!success) {
+  PHHepMCGenEvent *success = PHHepMCGenHelper::insert_event(evt);
+  if (!success)
+  {
     cout << "sHEPGen::process_event - Failed to add event to HepMC record!" << endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
@@ -241,20 +238,12 @@ int sHEPGen::process_event(PHCompositeNode *topNode) {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-
-int sHEPGen::create_node_tree(PHCompositeNode *topNode) {
-
-  hepmc_helper.create_node_tree(topNode);
-
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-
-void sHEPGen::printlogo() {
-
-  cout << endl <<  endl;
-  for ( int i = 0; i < hepconst::logolength; i++ )
+void sHEPGen::printlogo()
+{
+  cout << endl
+       << endl;
+  for (int i = 0; i < hepconst::logolength; i++)
     cout << hepconst::logo[i] << endl;
-  cout << endl <<  endl;
-
+  cout << endl
+       << endl;
 }

--- a/generators/sHEPGen/sHEPGen.h
+++ b/generators/sHEPGen/sHEPGen.h
@@ -17,15 +17,14 @@ class PHHepMCGenEvent;
 class HGenManager;
 class HLorentzVector;
 
-namespace HepMC {
+namespace HepMC
+{
   class GenEvent;
 };
 
-
-class sHEPGen: public SubsysReco {
-
-public:
-
+class sHEPGen : public SubsysReco, public PHHepMCGenHelper
+{
+ public:
   sHEPGen(const std::string &name = "sHEPGen");
   virtual ~sHEPGen();
 
@@ -33,73 +32,37 @@ public:
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
-  void set_datacard_file( const char* cfg_file ) {
-    if ( cfg_file ) _datacardFile = cfg_file;
+  void set_datacard_file(const char *cfg_file)
+  {
+    if (cfg_file) _datacardFile = cfg_file;
   }
 
-  void set_momentum_electron( double emom ) {
+  void set_momentum_electron(double emom)
+  {
     _p_electron_lab = emom;
   }
 
-  void set_momentum_hadron( double hmom ) {
+  void set_momentum_hadron(double hmom)
+  {
     _p_hadron_lab = hmom;
   }
 
   void beam_vertex_parameters(double beamX,
-            double beamY,
-            double beamZ,
-            double beamXsigma,
-            double beamYsigma,
-            double beamZsigma) {
-
+                              double beamY,
+                              double beamZ,
+                              double beamXsigma,
+                              double beamYsigma,
+                              double beamZsigma)
+  {
     set_vertex_distribution_mean(beamX, beamY, beamZ, 0);
     set_vertex_distribution_width(beamXsigma, beamYsigma, beamZsigma, 0);
   }
 
-  //! toss a new vertex according to a Uniform or Gaus distribution
-  void set_vertex_distribution_function(PHHepMCGenHelper::VTXFUNC x, PHHepMCGenHelper::VTXFUNC y, PHHepMCGenHelper::VTXFUNC z, PHHepMCGenHelper::VTXFUNC t)
-  {
-    hepmc_helper.set_vertex_distribution_function(x, y, z, t);
-  }
-
-  //! set the mean value of the vertex distribution, use PHENIX units of cm, ns
-  void set_vertex_distribution_mean(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_mean(x, y, z, t);
-  }
-
-  //! set the width of the vertex distribution function about the mean, use PHENIX units of cm, ns
-  void set_vertex_distribution_width(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_width(x, y, z, t);
-  }
-  //
-  //! reuse vertex from another PHHepMCGenEvent with embedding_id = src_embedding_id Additional smearing and shift possible with set_vertex_distribution_*()
-  void set_reuse_vertex(int src_embedding_id)
-  {
-    hepmc_helper.set_reuse_vertex(src_embedding_id);
-  }
-
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  int get_embedding_id() const { return hepmc_helper.get_embedding_id(); }
-  //
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  void set_embedding_id(int id) { hepmc_helper.set_embedding_id(id); }
-private:
-
+ private:
   /** Print HEPGen++ logo to screen
    */
   void printlogo();
 
-  /** Create node tree
-   */
-  int create_node_tree(PHCompositeNode *topNode);
 
   int _eventcount;
 
@@ -113,13 +76,9 @@ private:
   HLorentzVector *_p4_hadron_prest;
 
   // HEPGen++
-  HGenManager* _hgenManager;
+  HGenManager *_hgenManager;
 
   std::string _datacardFile;
-
-  //! helper for insert HepMC event to DST node and add vertex smearing
-  PHHepMCGenHelper hepmc_helper;
 };
 
-#endif  /* __SHEPGEN_H__ */
-
+#endif /* __SHEPGEN_H__ */

--- a/offline/packages/NodeDump/Makefile.am
+++ b/offline/packages/NodeDump/Makefile.am
@@ -60,6 +60,7 @@ libphnodedump_la_LIBADD = \
   -lSubsysReco \
   -ltrackbase_historic_io \
   -ltrack_io \
+  -lphhepmc_io\
   -lvararray
 
 

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -182,12 +182,24 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
       continue;
     }
 
+    if (Verbosity())
+    {
+      cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found PHHepMCGenEvent:" << endl;
+      genevt->identify();
+    }
+
     HepMC::GenEvent *evt = genevt->getEvent();
     if (!evt)
     {
       cout << PHWHERE << " no evt pointer under HEPMC Node found:";
       genevt->identify();
       return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+    if (Verbosity())
+    {
+      cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found HepMC::GenEvent:" << endl;
+      evt->print();
     }
 
     genevt->is_simulated(true);
@@ -228,6 +240,12 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
          v != evt->vertices_end();
          ++v)
     {
+      if (Verbosity() > 1)
+      {
+        cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found vertex:" << endl;
+        (*v)->print();
+      }
+
       finalstateparticles.clear();
       for (HepMC::GenVertex::particle_iterator p =
                (*v)->particles_begin(HepMC::children);
@@ -235,7 +253,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
       {
         if (Verbosity() > 1)
         {
-          cout << __PRETTY_FUNCTION__ << " : " << __LINE__ << endl;
+          cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found particle:" << endl;
           (*p)->print();
           cout << "end vertex " << (*p)->end_vertex() << endl;
         }

--- a/simulation/g4simulation/g4main/ReadEICFiles.cc
+++ b/simulation/g4simulation/g4main/ReadEICFiles.cc
@@ -50,7 +50,7 @@ ReadEICFiles::ReadEICFiles(const string &name)
   , GenEvent(nullptr)
   , _node_name("PHHepMCGenEvent")
 {
-  hepmc_helper.set_embedding_id(1);  // default embedding ID to 1
+  PHHepMCGenHelper::set_embedding_id(1);  // default embedding ID to 1
   return;
 }
 
@@ -326,7 +326,7 @@ int ReadEICFiles::process_event(PHCompositeNode *topNode)
   evt->set_beam_particles(hepmc_beam1, hepmc_beam2);
 
   /* pass HepMC to PHNode*/
-  PHHepMCGenEvent *success = hepmc_helper.insert_event(evt);
+  PHHepMCGenEvent *success = PHHepMCGenHelper::insert_event(evt);
   if (Verbosity() > 1)
   {
     cout << __PRETTY_FUNCTION__ << " : " << __LINE__ << endl;
@@ -347,7 +347,7 @@ int ReadEICFiles::process_event(PHCompositeNode *topNode)
 
 int ReadEICFiles::CreateNodeTree(PHCompositeNode *topNode)
 {
-  hepmc_helper.create_node_tree(topNode);
+  PHHepMCGenHelper::create_node_tree(topNode);
 
   PHNodeIterator iter(topNode);
   // Looking for the DST node

--- a/simulation/g4simulation/g4main/ReadEICFiles.h
+++ b/simulation/g4simulation/g4main/ReadEICFiles.h
@@ -17,7 +17,7 @@ namespace erhic
 class EventMC;
 }
 
-class ReadEICFiles : public SubsysReco
+class ReadEICFiles : public SubsysReco, public PHHepMCGenHelper
 {
  public:
   ReadEICFiles(const std::string &name = "EICReader");
@@ -33,41 +33,6 @@ class ReadEICFiles : public SubsysReco
   void SetFirstEntry(int e) { entry = e; }
   /** Set name of output node */
   void SetNodeName(const std::string &s) { _node_name = s; }
-  //! toss a new vertex according to a Uniform or Gaus distribution
-  void set_vertex_distribution_function(PHHepMCGenHelper::VTXFUNC x, PHHepMCGenHelper::VTXFUNC y, PHHepMCGenHelper::VTXFUNC z, PHHepMCGenHelper::VTXFUNC t)
-  {
-    hepmc_helper.set_vertex_distribution_function(x, y, z, t);
-  }
-
-  //! set the mean value of the vertex distribution, use PHENIX units of cm, ns
-  void set_vertex_distribution_mean(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_mean(x, y, z, t);
-  }
-
-  //! set the width of the vertex distribution function about the mean, use PHENIX units of cm, ns
-  void set_vertex_distribution_width(const double x, const double y, const double z, const double t)
-  {
-    hepmc_helper.set_vertex_distribution_width(x, y, z, t);
-  }
-  //
-  //! reuse vertex from another PHHepMCGenEvent with embedding_id = src_embedding_id Additional smearing and shift possible with set_vertex_distribution_*()
-  void set_reuse_vertex(int src_embedding_id)
-  {
-    hepmc_helper.set_reuse_vertex(src_embedding_id);
-  }
-
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  int get_embedding_id() const { return hepmc_helper.get_embedding_id(); }
-  //
-  //! embedding ID for the event
-  //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-  //! negative IDs are backgrounds, .e.g out of time pile up collisions
-  //! Usually, ID = 0 means the primary Au+Au collision background
-  void set_embedding_id(int id) { hepmc_helper.set_embedding_id(id); }
 
  private:
   /** Get tree from input file */
@@ -105,8 +70,6 @@ class ReadEICFiles : public SubsysReco
   // output
   std::string _node_name;
 
-  //! helper for insert HepMC event to DST node and add vertex smearing
-  PHHepMCGenHelper hepmc_helper;
 };
 
 #endif /* READEICFILES_H__ */


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## Introduction

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Both sPHENIX and EIC are expected to run with a beam crossing angle, 2mrad for sPHENIX and 25mrad for EIC. This is in principal supported in our current event generator setup, as the reference frame for the event generator is detached from the lab frame which is used in the Geant4 simulation and reconstruction. This pull request further introduce the machinery to easily using the beam parameters

* Support inputs via user macro for beam angle, divergence, vertex shift in space time
* calculate the boost-rotation-shift that is used to translate a head-on-collision event generator's record to the lab frame and use in Geant4 simulation inputs
* Apply the boost-rotation-shift from event generator to G4 simulation input 
* Record keeping to allow analysis to reverse the translation from lab to event generator frame

The beam parameter interface is applicable to HepMC input, Pythia6/8, Sartre, any EIC-smear events.

## How it is done

* The Geant4 simulation use an uniform interface of HepMC records as input. A new version of the container class `PHHepMCGenEventv1` add record of the boost rotation necessary to generate the `HepLorentzRotation` to translate head on collision to lab frame
* Macro interface to calculate boost rotation with beam parameters:  `void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *genevent)`
* Apply boost-rotation-shift at HepMC input to G4 simulation at `HepMCNodeReader::process_event(PHCompositeNode *topNode)`
* Update event generator so they can directly use setter functions of `PHHepMCGenHelper`


## Caveats

* Beam energy is not smeared, which is expected to be small comparing to the experimental sensitivity
* With the boost to introduce crossing angle, the beam energy is slightly increased at O(x-iing angle^2) order, 8x10^-5 for EIC, which is expected to be small comparing to the experimental sensitivity. The boost is designed so it split the increase evenly to both beams and therefore minimal overall change in sqrt-s.  
* The boost is calculated assuming beam particle on light cone. For non-relativistic beam though, the final beam angle will be off from the expected beam center, which require manually calculate the Lorentz-Rotation matrix
* No correlation between smearing in beam position and beam angle, which should also be small at IP focusing point


## Verifications


### Emulation of the beam

With a dummy HepMC record of head-on electron - proton beam at 20x275 GeV/c and no interaction, verify the beam angle is reproduced in the lab/Geant4 frame: 

HepMC record:
```
GenVertex:       -1 ID:    0 (X,cT):0
 O: 2         3       11 +0.00e+00,+0.00e+00,-2.00e+01,+2.00e+01   1
              4     2212 +0.00e+00,+0.00e+00,+2.75e+02,+2.75e+02   1
```

HepMC input setting
```c++

    INPUTMANAGER::HepMCInputManager->set_beam_direction_theta_phi(25e-3,0,M_PI ,0); //25mrad x-ing of EIC
    INPUTMANAGER::HepMCInputManager->set_beam_angular_divergence_hv(
        132e-6, 253e-6,// proton beam divergence at high divergence tune, EIC CDR Table 3.12
        220e-6, 220e-6//max electron beam divergence
    );
    
```

Output proton beam's horizontal angle, reproducing the parameter in EIC CDR: 

![xing6](https://user-images.githubusercontent.com/7947083/109033352-8f849400-7694-11eb-856d-eb81af0278c5.png)


### DIS events

With the example head-on Pythia6 DIS config at Q^2 > 400 GeV/c, apply the EIC beam parameter to translate the event to lab frame with 25 mrad xing: 

Generator file with head-on 10x250 ep collision: https://github.com/eic/fun4all_calibrations/blob/master/Generators/phpythia6_ep_MinPartonP20GeV.cfg

Beam setting on top of the [default macro](https://github.com/eic/fun4all_macros/blob/master/detectors/EICDetector/Fun4All_G4_EICDetector.C): 
```c++

    INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep_MinPartonP20GeV.cfg");
    INPUTGENERATOR::Pythia6->set_beam_direction_theta_phi(25e-3,0,M_PI ,0); //25mrad x-ing of EIC
    INPUTGENERATOR::Pythia6->set_beam_angular_divergence_hv(
        132e-6, 253e-6,// proton beam divergence at high divergence tune, EIC CDR Table 3.12
        220e-6, 220e-6//max electron beam divergence
    );

```

Reproduce with https://github.com/blackcathj/macros/pull/new/beam-xing-event-display 

Event displays showing beam remnants going down the hadron beam pipe:

![xing5](https://user-images.githubusercontent.com/7947083/109033411-9f03dd00-7694-11eb-846b-f97e083c4efa.png)
![xing2](https://user-images.githubusercontent.com/7947083/109033454-a9be7200-7694-11eb-8a5f-4c80e6695769.png)
![xing3](https://user-images.githubusercontent.com/7947083/109033457-aa570880-7694-11eb-8803-ce63723ad433.png)



## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Introduce expected beam parameter to default macros

## Links to other PRs in macros and calibration repositories (if applicable)

No changes in other repo at the moment