### PR TITLE
Tpc seed vtx assoc

### DIFF
--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -61,6 +61,7 @@ pkginclude_HEADERS = \
   PHSiliconTruthTrackSeeding.h \
   PHTpcClusterMover.h \
   PHTpcResiduals.h \
+  PHTpcTrackSeedVertexAssoc.h \
   PHTrackPropagating.h \
   PHTrackSeeding.h \
   PHTrackFitting.h \
@@ -169,7 +170,8 @@ libtrack_reco_la_SOURCES = \
   PHGenFitTrkProp.cc \
   PHGenFitTrkFitter.cc \
   PHGenFitTrackProjection.cc \
-  PHRaveVertexing.cc 
+  PHRaveVertexing.cc \
+  PHTpcTrackSeedVertexAssoc.cc
 
 libtrack_reco_io_la_LIBADD = \
   -lphool \

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -90,11 +90,28 @@ int PHSiliconTpcTrackMatching::Process()
   // We will have to expand the number of tracks whenever we find multiple matches to the silicon
 
   if(Verbosity() > 0)
-    cout << PHWHERE << " TPC track map size " << _track_map->size() << " Silicon track map size " << _track_map->size() << endl;
+    cout << PHWHERE << " TPC track map size " << _track_map->size() << " Silicon track map size " << _track_map_silicon->size() << endl;
 
- // We remember the original size of the TPC track map here
+  if(Verbosity() > 2)
+    {
+      // list silicon tracks
+      for (auto phtrk_iter_si = _track_map_silicon->begin();
+	   phtrk_iter_si != _track_map_silicon->end(); 
+	   ++phtrk_iter_si)
+	{
+	  _tracklet_si = phtrk_iter_si->second;	  
+	  
+	  double si_phi = atan2(_tracklet_si->get_py(), _tracklet_si->get_px());
+	  double si_eta = _tracklet_si->get_eta();
+	  
+	  cout << " Si track " << _tracklet_si->get_id()  << " si_phi " << si_phi  << " si_eta " << si_eta << endl;
+	}  
+    }
+  
+  
+  // We remember the original size of the TPC track map here
   const unsigned int original_track_map_lastkey = _track_map->end()->first;
-
+  
   // loop over the original TPC tracks
   for (auto phtrk_iter = _track_map->begin();
        phtrk_iter != _track_map->end(); 
@@ -280,7 +297,7 @@ int PHSiliconTpcTrackMatching::Process()
 	  // get the si tracklet for this id
 	  _tracklet_si = _track_map_silicon->get(*si_it);
 
-	  if(Verbosity() > 3)
+	  if(Verbosity() > 0)
 	    cout << "   isi = " << isi << " si tracklet " << _tracklet_si->get_id() << " was matched to TPC tracklet " << _tracklet_tpc->get_id() << endl;
 
 	  // get the silicon clusters

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -75,7 +75,7 @@ class PHSiliconTpcTrackMatching : public PHTrackPropagating
   double _collision_rate = 50e3;  // input rate for phi correction
   double _reference_collision_rate = 50e3;  // reference rate for phi correction
 
-  bool _is_ca_seeder = false;
+  bool _is_ca_seeder = true;
   bool _sc_calib_flag = false;
   bool _test_windows = false;
 

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
@@ -1,0 +1,304 @@
+#include "PHTpcTrackSeedVertexAssoc.h"
+
+#include "AssocInfoContainer.h"
+
+/// Tracking includes
+#include <trackbase/TrkrDefs.h>                // for cluskey, getTrkrId, tpcId
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrCluster.h>
+#include <trackbase_historic/SvtxTrack_v1.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxVertex.h>     // for SvtxVertex
+#include <trackbase_historic/SvtxVertexMap.h>
+
+#include <g4main/PHG4Hit.h>  // for PHG4Hit
+#include <g4main/PHG4Particle.h>  // for PHG4Particle
+#include <g4main/PHG4HitDefs.h>  // for keytype
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#if __cplusplus < 201402L
+#include <boost/make_unique.hpp>
+#endif
+
+#include <TF1.h>
+
+#include <climits>                            // for UINT_MAX
+#include <iostream>                            // for operator<<, basic_ostream
+#include <cmath>                              // for fabs, sqrt
+#include <set>                                 // for _Rb_tree_const_iterator
+#include <utility>                             // for pair
+#include <memory>
+using namespace std;
+
+//____________________________________________________________________________..
+PHTpcTrackSeedVertexAssoc::PHTpcTrackSeedVertexAssoc(const std::string &name):
+ PHTrackPropagating(name)
+ , _track_map_name_silicon("SvtxSiliconTrackMap")
+{
+  //cout << "PHTpcTrackSeedVertexAssoc::PHTpcTrackSeedVertexAssoc(const std::string &name) Calling ctor" << endl;
+}
+
+//____________________________________________________________________________..
+PHTpcTrackSeedVertexAssoc::~PHTpcTrackSeedVertexAssoc()
+{
+
+}
+
+//____________________________________________________________________________..
+int PHTpcTrackSeedVertexAssoc::Setup(PHCompositeNode *topNode)
+{
+  // put these in the output file
+  cout << PHWHERE << " p0 " << _par0 << " p1 " << _par1 << " p2 " 
+       << _par2 << " Search windows: phi " << _phi_search_win << " eta " 
+       << _eta_search_win << endl;
+
+  // corrects the PHTpcTracker phi bias
+  fdphi = new TF1("f1", "[0] + [1]/x^[2]");
+  fdphi->SetParameter(0, _par0);
+  fdphi->SetParameter(1, _par1);
+  fdphi->SetParameter(2, _par2);
+
+  // corrects the space charge distortion phi bias
+  if(!_is_ca_seeder)
+    {
+      // PHTpcTracker correction is opposite in sign
+      // and different in magnitude - why?
+      _parsc0 *= -1.0 * 0.7;
+      _parsc1 *= -1.0 * 0.7;
+    }
+  fscdphi = new TF1("f2","[0] + [1]*x^2");
+  fscdphi->SetParameter(0, _parsc0 * _collision_rate / _reference_collision_rate);
+  fscdphi->SetParameter(1, _parsc1 * _collision_rate / _reference_collision_rate);
+
+  int ret = PHTrackPropagating::Setup(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  return ret;
+}
+
+//____________________________________________________________________________..
+int PHTpcTrackSeedVertexAssoc::Process()
+{
+  // _track_map contains the TPC seed track stubs
+  // We want to associate these TPC track seeds with a collision vertex
+  // Then we add the collision vertex position as the track seed position
+
+  // All we need is to project the TPC clusters in Z to the beam line.
+
+
+  if(Verbosity() > 0)
+    cout << PHWHERE << " TPC track map size " << _track_map->size()  << endl;
+  /*
+ // We remember the original size of the TPC track map here
+  const unsigned int original_track_map_lastkey = _track_map->end()->first;
+  */
+
+  // loop over the TPC track seeds
+  for (auto phtrk_iter = _track_map->begin();
+       phtrk_iter != _track_map->end(); 
+       ++phtrk_iter)
+    {
+      /*
+      // we may add tracks to the map, so we stop at the last original track
+      if(phtrk_iter->first >= original_track_map_lastkey)  break;
+      */      
+      _tracklet_tpc = phtrk_iter->second;
+      
+      if (Verbosity() >= 1)
+	{
+	  std::cout
+	    << __LINE__
+	    << ": Processing seed itrack: " << phtrk_iter->first
+	    << ": nhits: " << _tracklet_tpc-> size_cluster_keys()
+	    << ": Total tracks: " << _track_map->size()
+	    << ": phi: " << _tracklet_tpc->get_phi()
+	    << endl;
+	}
+
+      // get the tpc track seed cluster positions in z and r
+
+      // Get the outermost TPC clusters for this tracklet
+      std::map<unsigned int, TrkrCluster*> tpc_clusters_map;
+      std::vector<TrkrCluster*> clusters;
+      
+      for (SvtxTrack::ConstClusterKeyIter key_iter = _tracklet_tpc->begin_cluster_keys();
+	   key_iter != _tracklet_tpc->end_cluster_keys();
+	   ++key_iter)
+	{
+	  TrkrDefs::cluskey cluster_key = *key_iter;
+	  unsigned int layer = TrkrDefs::getLayer(cluster_key);
+
+	  if(layer < _min_tpc_layer) continue;
+	  if(layer >= _max_tpc_layer) continue;
+
+	  // get the cluster
+	  TrkrCluster *tpc_clus =  _cluster_map->findCluster(cluster_key);
+
+	  tpc_clusters_map.insert(std::make_pair(layer, tpc_clus));
+	  clusters.push_back(tpc_clus);
+
+	  if(Verbosity() > 10) 
+	    std::cout << "  TPC cluster in layer " << layer << " with position " << tpc_clus->getX() 
+		      << "  " << tpc_clus->getY() << "  " << tpc_clus->getZ() << " outer_clusters.size() " << tpc_clusters_map.size() << std::endl;
+	}
+
+
+      // need at least 3 clusters to fit a circle
+      if(tpc_clusters_map.size() < 3)
+	{
+	  if(Verbosity() > 3) std::cout << PHWHERE << "  -- skip this tpc tracklet, not enough outer clusters " << std::endl; 
+	  continue;  // skip to the next TPC tracklet
+	}
+
+      /*
+      // fit a circle to the clusters
+      double R, X0, Y0;
+      CircleFitByTaubin(clusters, R, X0, Y0);
+      if(Verbosity() > 10) std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
+
+      // toss tracks for which the fitted circle could not have come from the vertex
+      if(R < 40.0) continue;
+      */
+
+      // get the straight line representing the z trajectory in the form of z vs radius
+      double A = 0; double B = 0;
+      line_fit(clusters, A, B);
+      if(Verbosity() > 10) std::cout << " Fitted line has A " << A << " B " << B << std::endl;
+
+      // Project this TPC tracklet  to the beam line and store the projections
+      //bool skip_tracklet = false;
+      // z projection is unique
+      _z_proj = B;
+      
+      // Find the nearest collision vertex
+      // if find multiple close matches, duplicate the track?
+
+      int trackVertexId = 9999;
+      double dz = 9999.;	  
+      for(SvtxVertexMap::Iter viter = _vertex_map->begin();
+	  viter != _vertex_map->end();
+	  ++viter)
+	{
+	  /*
+	  const double trackX = track->get_x();
+	  const double trackY = track->get_y();
+	  const double trackZ = track->get_z();
+	  double dx = 9999.;
+	  double dy = 9999.;
+	  */
+
+	  auto vertexKey = viter->first;
+	  auto vertex = viter->second;
+	  if(Verbosity() > 100)
+	    vertex->identify();
+
+	  /*	  
+	  const double vertexX = vertex->get_x();
+	  const double vertexY = vertex->get_y();
+	  */
+	  const double vertexZ = vertex->get_z();
+	  
+	  if( 
+	     //fabs(trackX - vertexX) < dx &&
+	     //fabs(trackY - vertexY) < dy &&
+	      fabs(_z_proj - vertexZ) < dz )
+	    {
+	      //dx = fabs(trackX - vertexX);
+	      //dy = fabs(trackY - vertexY);
+	      dz = fabs(_z_proj - vertexZ);
+	      trackVertexId = vertexKey;
+	    }	  
+	}  // end loop over collision vertices
+
+      _tracklet_tpc->set_vertex_id(trackVertexId);
+      auto vertex = _vertex_map->find(trackVertexId)->second;
+      vertex->insert_track(phtrk_iter->first);
+
+      // set the track position to the vertex position
+      _tracklet_tpc->set_x(vertex->get_x());
+      _tracklet_tpc->set_y(vertex->get_y());
+      _tracklet_tpc->set_z(vertex->get_z());
+
+      if(Verbosity() > 1)
+	{
+	  std::cout << "TPC seed track " << phtrk_iter->first << " matched to vertex " << trackVertexId << endl; 
+	} 
+    }  // end loop over TPC track seeds
+  
+
+
+  // what next?
+  // Done for now?
+  // call Acts track fitter next for TPC tracklets only?
+
+
+
+  if(Verbosity() > 0)  
+    cout << " Final track map size " << _track_map->size() << endl;
+  
+  if (Verbosity() >= 1)
+    cout << "PHTpcTrackSeedVertexAssoc::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;  
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHTpcTrackSeedVertexAssoc::End()
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int  PHTpcTrackSeedVertexAssoc::GetNodes(PHCompositeNode* topNode)
+{
+  //---------------------------------
+  // Get additional objects off the Node Tree
+  //---------------------------------
+  /*
+  _track_map_silicon = findNode::getClass<SvtxTrackMap>(topNode,  "SvtxSiliconTrackMap");
+  if (!_track_map_silicon)
+  {
+    cerr << PHWHERE << " ERROR: Can't find SvtxSiliconTrackMap: " << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  */  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+void  PHTpcTrackSeedVertexAssoc::line_fit(std::vector<TrkrCluster*> clusters, double &a, double &b)
+{
+  // copied from: https://www.bragitoff.com
+  // we want to fit z vs radius
+  
+   double xsum=0,x2sum=0,ysum=0,xysum=0;                //variables for sums/sigma of xi,yi,xi^2,xiyi etc
+   for (unsigned int i=0; i<clusters.size(); ++i)
+    {
+      double z = clusters[i]->getZ();
+      double r = sqrt(pow(clusters[i]->getX(),2) + pow(clusters[i]->getY(), 2));
+
+      xsum=xsum+r;                        //calculate sigma(xi)
+      ysum=ysum+z;                        //calculate sigma(yi)
+      x2sum=x2sum+pow(r,2);                //calculate sigma(x^2i)
+      xysum=xysum+r*z;                    //calculate sigma(xi*yi)
+    }
+   a=(clusters.size()*xysum-xsum*ysum)/(clusters.size()*x2sum-xsum*xsum);            //calculate slope
+   b=(x2sum*ysum-xsum*xysum)/(x2sum*clusters.size()-xsum*xsum);            //calculate intercept
+
+   if(Verbosity() > 10)
+     {
+       for (unsigned int i=0;i<clusters.size(); ++i)
+	 {
+	   double r = sqrt(pow(clusters[i]->getX(),2) + pow(clusters[i]->getY(), 2));
+	   double z_fit = a * r + b;                    //to calculate y(fitted) at given x points
+	   std::cout << " r " << r << " z " << clusters[i]->getZ() << " z_fit " << z_fit << std::endl; 
+	 } 
+     }
+
+    return;
+}   

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
@@ -186,32 +186,15 @@ int PHTpcTrackSeedVertexAssoc::Process()
 	  viter != _vertex_map->end();
 	  ++viter)
 	{
-	  /*
-	  const double trackX = track->get_x();
-	  const double trackY = track->get_y();
-	  const double trackZ = track->get_z();
-	  double dx = 9999.;
-	  double dy = 9999.;
-	  */
-
 	  auto vertexKey = viter->first;
 	  auto vertex = viter->second;
 	  if(Verbosity() > 100)
 	    vertex->identify();
 
-	  /*	  
-	  const double vertexX = vertex->get_x();
-	  const double vertexY = vertex->get_y();
-	  */
 	  const double vertexZ = vertex->get_z();
 	  
-	  if( 
-	     //fabs(trackX - vertexX) < dx &&
-	     //fabs(trackY - vertexY) < dy &&
-	      fabs(_z_proj - vertexZ) < dz )
+	  if(fabs(_z_proj - vertexZ) < dz )
 	    {
-	      //dx = fabs(trackX - vertexX);
-	      //dy = fabs(trackY - vertexY);
 	      dz = fabs(_z_proj - vertexZ);
 	      trackVertexId = vertexKey;
 	    }	  
@@ -239,7 +222,6 @@ int PHTpcTrackSeedVertexAssoc::Process()
       double r_vertex = sqrt(vertex->get_x()*vertex->get_x() + vertex->get_y()*vertex->get_y());
       double z_vertex = vertex->get_z();
       points.push_back(make_pair(r_vertex, z_vertex));
-
       for (unsigned int i=0; i<clusters.size(); ++i)
 	{
 	  double z = clusters[i]->getZ();
@@ -249,7 +231,8 @@ int PHTpcTrackSeedVertexAssoc::Process()
 	}
       
       line_fit(points, A, B);
-      if(Verbosity() > 5) std::cout << " Fitted line including vertex has A " << A << " B " << B << std::endl;      
+      if(Verbosity() > 5) 
+	std::cout << " Fitted line including vertex has A " << A << " B " << B << std::endl;      
 
       // extract the track theta
       double track_angle = atan(A);  // referenced to 90 degrees
@@ -278,7 +261,8 @@ int PHTpcTrackSeedVertexAssoc::Process()
 	}
       double R, X0, Y0;
       CircleFitByTaubin(cpoints, R, X0, Y0);
-      if(Verbosity() > 5) std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
+      if(Verbosity() > 5) 
+	std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
 
       //  could take new pT from radius of circle - we choose to keep the seed pT
 
@@ -287,10 +271,9 @@ int PHTpcTrackSeedVertexAssoc::Process()
       double dx = X0 - x_vertex;
       double dy = Y0 - y_vertex;
       double phi= atan2(dy,dx);
-      std::cout << "x_vertex " << x_vertex << " y_vertex " << y_vertex << " X0 " << X0 << " Y0 " << Y0 << " angle " << phi * 180 / 3.14159 << std::endl; 
+      //std::cout << "x_vertex " << x_vertex << " y_vertex " << y_vertex << " X0 " << X0 << " Y0 " << Y0 << " angle " << phi * 180 / 3.14159 << std::endl; 
       // convert to the angle of the tangent to the circle
       // we need to know if the track proceeds clockwise or CCW around the circle
-      int charge = _tracklet_tpc->get_charge();
       double dx0 = cpoints[0].first - X0;
       double dy0 = cpoints[0].second - Y0;
       double phi0 = atan2(dy0, dx0);
@@ -298,26 +281,26 @@ int PHTpcTrackSeedVertexAssoc::Process()
       double dy1 = cpoints[1].second - Y0;
       double phi1 = atan2(dy1, dx1);
       double dphi = phi1 - phi0;
-      std::cout << " charge " << charge << " phi0 " << phi0*180.0 / M_PI << " phi1 " << phi1*180.0 / M_PI << " dphi " << dphi*180.0 / M_PI << std::endl;
-      //if(phi0 < 0.0) phi0 += 2.0 * M_PI;
-      //if(phi1 < 0.0) phi1 += 2.0 * M_PI;
-      //std::cout << " now: charge " << charge << " phi0 " << phi0*180.0 / M_PI << " phi1 " << phi1*180.0 / M_PI << " dphi " << dphi*180.0 / M_PI << std::endl;
-      // check to make sure we did not cross +/- pi
-      //if(dphi > 2.0 * M_PI) dphi -= 2.0*M_PI;
-      //if(dphi < -2.0 * M_PI) dphi += 2.0*M_PI;
-      std::cout << " charge " << charge << " phi0 " << phi0*180.0 / M_PI << " phi1 " << phi1*180.0 / M_PI << " dphi " << dphi*180.0 / M_PI << std::endl;
+
+      if(Verbosity() > 5) 
+	{
+	  int charge = _tracklet_tpc->get_charge();   // needed for diagnostic output only
+	  std::cout << " charge " << charge << " phi0 " << phi0*180.0 / M_PI << " phi1 " << phi1*180.0 / M_PI << " dphi " << dphi*180.0 / M_PI << std::endl;
+	}
 
       // whether we add or subtract 90 degrees depends on the track propagation direction determined above
       if(dphi < 0)
 	phi += M_PI / 2.0;  
       else
 	phi -= M_PI / 2.0;  
-      //std::cout << " input track phi " << _tracklet_tpc->get_phi() * 180.0 / M_PI << " new phi " << phi * 180 / M_PI << " charge " << charge << std::endl;  
+      if(Verbosity() > 5) 
+	std::cout << " input track phi " << _tracklet_tpc->get_phi() * 180.0 / M_PI << " new phi " << phi * 180 / M_PI << std::endl;  
 
       // update px, py of track
       double px_new = pt_track * cos(phi);
       double py_new = pt_track * sin(phi);
-      std::cout << " input track px " << _tracklet_tpc->get_px()  << " new px " << px_new << " input py " << _tracklet_tpc->get_py() << " new py " << py_new << std::endl;
+      if(Verbosity() > 5)
+	std::cout << " input track px " << _tracklet_tpc->get_px()  << " new px " << px_new << " input py " << _tracklet_tpc->get_py() << " new py " << py_new << std::endl;
 
       // update track on node tree
       _tracklet_tpc->set_px(px_new);

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
@@ -51,28 +51,6 @@ PHTpcTrackSeedVertexAssoc::~PHTpcTrackSeedVertexAssoc()
 //____________________________________________________________________________..
 int PHTpcTrackSeedVertexAssoc::Setup(PHCompositeNode *topNode)
 {
-  // put these in the output file
-  cout << PHWHERE << " p0 " << _par0 << " p1 " << _par1 << " p2 " 
-       << _par2 << " Search windows: phi " << _phi_search_win << " eta " 
-       << _eta_search_win << endl;
-
-  // corrects the PHTpcTracker phi bias
-  fdphi = new TF1("f1", "[0] + [1]/x^[2]");
-  fdphi->SetParameter(0, _par0);
-  fdphi->SetParameter(1, _par1);
-  fdphi->SetParameter(2, _par2);
-
-  // corrects the space charge distortion phi bias
-  if(!_is_ca_seeder)
-    {
-      // PHTpcTracker correction is opposite in sign
-      // and different in magnitude - why?
-      _parsc0 *= -1.0 * 0.7;
-      _parsc1 *= -1.0 * 0.7;
-    }
-  fscdphi = new TF1("f2","[0] + [1]*x^2");
-  fscdphi->SetParameter(0, _parsc0 * _collision_rate / _reference_collision_rate);
-  fscdphi->SetParameter(1, _parsc1 * _collision_rate / _reference_collision_rate);
 
   int ret = PHTrackPropagating::Setup(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
@@ -89,26 +67,18 @@ int PHTpcTrackSeedVertexAssoc::Process()
   // _track_map contains the TPC seed track stubs
   // We want to associate these TPC track seeds with a collision vertex
   // Then we add the collision vertex position as the track seed position
-
   // All we need is to project the TPC clusters in Z to the beam line.
 
 
   if(Verbosity() > 0)
     cout << PHWHERE << " TPC track map size " << _track_map->size()  << endl;
-  /*
- // We remember the original size of the TPC track map here
-  const unsigned int original_track_map_lastkey = _track_map->end()->first;
-  */
 
   // loop over the TPC track seeds
   for (auto phtrk_iter = _track_map->begin();
        phtrk_iter != _track_map->end(); 
        ++phtrk_iter)
     {
-      /*
-      // we may add tracks to the map, so we stop at the last original track
-      if(phtrk_iter->first >= original_track_map_lastkey)  break;
-      */      
+
       _tracklet_tpc = phtrk_iter->second;
       
       if (Verbosity() >= 1)
@@ -156,16 +126,6 @@ int PHTpcTrackSeedVertexAssoc::Process()
 	  if(Verbosity() > 3) std::cout << PHWHERE << "  -- skip this tpc tracklet, not enough clusters " << std::endl; 
 	  continue;  // skip to the next TPC tracklet
 	}
-
-      /*
-      // fit a circle to the clusters
-      double R, X0, Y0;
-      CircleFitByTaubin(clusters, R, X0, Y0);
-      if(Verbosity() > 10) std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
-
-      // toss tracks for which the fitted circle could not have come from the vertex
-      if(R < 40.0) continue;
-      */
 
       // get the straight line representing the z trajectory in the form of z vs radius
       double A = 0; double B = 0;
@@ -343,14 +303,7 @@ int  PHTpcTrackSeedVertexAssoc::GetNodes(PHCompositeNode* topNode)
   //---------------------------------
   // Get additional objects off the Node Tree
   //---------------------------------
-  /*
-  _track_map_silicon = findNode::getClass<SvtxTrackMap>(topNode,  "SvtxSiliconTrackMap");
-  if (!_track_map_silicon)
-  {
-    cerr << PHWHERE << " ERROR: Can't find SvtxSiliconTrackMap: " << endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-  */  
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -363,8 +316,6 @@ void  PHTpcTrackSeedVertexAssoc::line_fit(std::vector<std::pair<double,double>> 
    double xsum=0,x2sum=0,ysum=0,xysum=0;                //variables for sums/sigma of xi,yi,xi^2,xiyi etc
    for (unsigned int i=0; i<points.size(); ++i)
     {
-      //double z = clusters[i]->getZ();
-      //double r = sqrt(pow(clusters[i]->getX(),2) + pow(clusters[i]->getY(), 2));
       double r = points[i].first;
       double z = points[i].second;
 

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -52,7 +52,8 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
 
   int GetNodes(PHCompositeNode* topNode);
 
-  void  line_fit(std::vector<TrkrCluster*> clusters, double &a, double &b);
+  void  line_fit_clusters(std::vector<TrkrCluster*> clusters, double &a, double &b);
+  void  line_fit(std::vector<std::pair<double,double>> points, double &a, double &b);
 
   std::string _track_map_name_silicon;
 

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -54,7 +54,8 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
 
   void  line_fit_clusters(std::vector<TrkrCluster*> clusters, double &a, double &b);
   void  line_fit(std::vector<std::pair<double,double>> points, double &a, double &b);
-
+  void CircleFitByTaubin (std::vector<std::pair<double,double>> points, double &R, double &X0, double &Y0);
+						    
   std::string _track_map_name_silicon;
 
   // default values, can be replaced from the macro

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -1,0 +1,96 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef PHTPCTRACKSEEDVERTEXASSOC_H
+#define PHTPCTRACKSEEDVERTEXASSOC_H
+
+#include <trackreco/PHTrackPropagating.h>
+
+#include <string>
+#include <vector>
+
+class PHCompositeNode;
+class SvtxTrackMap;
+class SvtxTrack;
+class TrkrCluster;
+class TF1;
+
+
+class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
+{
+ public:
+
+  PHTpcTrackSeedVertexAssoc(const std::string &name = "PHTpcTrackSeedVertexAssoc");
+
+  virtual ~PHTpcTrackSeedVertexAssoc();
+
+  void set_track_map_name_silicon(const std::string &map_name) { _track_map_name_silicon = map_name; }
+  void set_phi_search_window(const double win){_phi_search_win = win;}
+  void set_eta_search_window(const double win){_eta_search_win = win;}
+  void set_search_par_values(const double p0, const double p1, const double p2){_par0 = p0; _par1 = p1; _par2 = p2; }
+  void set_seeder(const bool is_ca_seeder){_is_ca_seeder = is_ca_seeder;}
+
+  void set_field_dir(const double rescale)
+  {
+    _fieldDir = -1;
+    if(rescale > 0)
+      _fieldDir = 1;     
+  }
+  void set_field(const std::string &field) { _field = field;}
+
+  void set_test_windows_printout(const bool test){_test_windows = test ;}
+  void set_sc_calib_mode(const bool flag){_sc_calib_flag = flag;}
+  void set_collision_rate(const double rate){_collision_rate = rate;}
+
+ protected:
+  int Setup(PHCompositeNode* topNode) override;
+
+  int Process() override;
+
+  int End() override;
+  
+ private:
+
+  int GetNodes(PHCompositeNode* topNode);
+
+  void  line_fit(std::vector<TrkrCluster*> clusters, double &a, double &b);
+
+  std::string _track_map_name_silicon;
+
+  // default values, can be replaced from the macro
+  double _phi_search_win = 0.01;
+  double _eta_search_win = 0.004;
+  
+  SvtxTrackMap *_track_map_silicon{nullptr};
+  SvtxTrack *_tracklet_tpc{nullptr};
+  SvtxTrack *_tracklet_si{nullptr};
+
+  // correction function for PHTpcTracker track phi bias
+  TF1 *fdphi{nullptr};
+  // default values, can be replaced from the macro
+  double _par0 =  -0.000650;
+  double _par1 =  0.13373;
+  double _par2 =  0.98298;
+
+  // correction factor for TPC tracklet phi offset due to space charge in TPC
+  TF1 *fscdphi{nullptr};
+  double _parsc0 =  0.0366293;
+  double _parsc1 =   -0.0133073;
+
+  double _collision_rate = 50e3;  // input rate for phi correction
+  double _reference_collision_rate = 50e3;  // reference rate for phi correction
+
+  bool _is_ca_seeder = false;
+  bool _sc_calib_flag = false;
+  bool _test_windows = false;
+
+  unsigned int _min_tpc_layer = 7;
+  unsigned int _max_tpc_layer = 47;
+
+  double _z_proj= 0;
+
+  std::string _field;
+  int _fieldDir = -1;
+
+};
+
+#endif // PHTRUTHSILICONASSOCIATION_H

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -49,7 +49,6 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
   std::string _track_map_name_silicon;
 
   
-  SvtxTrackMap *_track_map_silicon{nullptr};
   SvtxTrack *_tracklet_tpc{nullptr};
 
   unsigned int _min_tpc_layer = 7;

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -23,12 +23,6 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
 
   virtual ~PHTpcTrackSeedVertexAssoc();
 
-  void set_track_map_name_silicon(const std::string &map_name) { _track_map_name_silicon = map_name; }
-  void set_phi_search_window(const double win){_phi_search_win = win;}
-  void set_eta_search_window(const double win){_eta_search_win = win;}
-  void set_search_par_values(const double p0, const double p1, const double p2){_par0 = p0; _par1 = p1; _par2 = p2; }
-  void set_seeder(const bool is_ca_seeder){_is_ca_seeder = is_ca_seeder;}
-
   void set_field_dir(const double rescale)
   {
     _fieldDir = -1;
@@ -36,10 +30,6 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
       _fieldDir = 1;     
   }
   void set_field(const std::string &field) { _field = field;}
-
-  void set_test_windows_printout(const bool test){_test_windows = test ;}
-  void set_sc_calib_mode(const bool flag){_sc_calib_flag = flag;}
-  void set_collision_rate(const double rate){_collision_rate = rate;}
 
  protected:
   int Setup(PHCompositeNode* topNode) override;
@@ -58,32 +48,9 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
 						    
   std::string _track_map_name_silicon;
 
-  // default values, can be replaced from the macro
-  double _phi_search_win = 0.01;
-  double _eta_search_win = 0.004;
   
   SvtxTrackMap *_track_map_silicon{nullptr};
   SvtxTrack *_tracklet_tpc{nullptr};
-  SvtxTrack *_tracklet_si{nullptr};
-
-  // correction function for PHTpcTracker track phi bias
-  TF1 *fdphi{nullptr};
-  // default values, can be replaced from the macro
-  double _par0 =  -0.000650;
-  double _par1 =  0.13373;
-  double _par2 =  0.98298;
-
-  // correction factor for TPC tracklet phi offset due to space charge in TPC
-  TF1 *fscdphi{nullptr};
-  double _parsc0 =  0.0366293;
-  double _parsc1 =   -0.0133073;
-
-  double _collision_rate = 50e3;  // input rate for phi correction
-  double _reference_collision_rate = 50e3;  // reference rate for phi correction
-
-  bool _is_ca_seeder = false;
-  bool _sc_calib_flag = false;
-  bool _test_windows = false;
 
   unsigned int _min_tpc_layer = 7;
   unsigned int _max_tpc_layer = 54;

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -86,7 +86,7 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
   bool _test_windows = false;
 
   unsigned int _min_tpc_layer = 7;
-  unsigned int _max_tpc_layer = 47;
+  unsigned int _max_tpc_layer = 54;
 
   double _z_proj= 0;
 

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -99,7 +99,7 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
       
       // identify the best truth track match(es) for this seed track       
       std::vector<PHG4Particle*> g4particle_vec = getG4PrimaryParticle(_tracklet);
-      //std::cout << " g4particle_vec.size() " << g4particle_vec.size() << std::endl;
+      if(Verbosity() > 0)  std::cout << " g4particle_vec.size() " << g4particle_vec.size() << std::endl;
 
       if(g4particle_vec.size() < 1) continue;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds a module that runs after the TPC track seeding. The module is completely agnostic about which seeder is used, it just takes the pT estimate and the list of TPC clusters. It fits a straight line to the clusters in z vs radius and associates the track with a collision vertex, and determines eta from the fit. It fits a circle to the clusters in x vs y and assigns a phi angle at the vertex. The revised track position and track momentum components are updated in the track. Both overall tracking efficiency and MVTX associated track efficiency are significantly improved in central events. These plots show before (blue) and after (red) tracking efficiency and MVTX association efficiency:
[central_phtpctracker_vtxassoc_eff.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/6043520/central_phtpctracker_vtxassoc_eff.pdf)
[central_phtpctracker_vtxassoc_mvtxassoceff.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/6043525/central_phtpctracker_vtxassoc_mvtxassoceff.pdf)


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

