### PR TITLE
use lower_bound rather than find to check existence of cluster in map

### DIFF
--- a/offline/packages/trackbase/TrkrClusterContainer.cc
+++ b/offline/packages/trackbase/TrkrClusterContainer.cc
@@ -95,13 +95,12 @@ TrkrClusterContainer::getClusters(void) const
 TrkrClusterContainer::Iterator
 TrkrClusterContainer::findOrAddCluster(TrkrDefs::cluskey key)
 {
-  TrkrClusterContainer::Iterator it = m_clusmap.find(key);
-  if (it == m_clusmap.end())
+  auto it = m_clusmap.lower_bound( key );
+  if (it == m_clusmap.end()|| (key < it->first ))
   {
     // add new cluster and set its key
-    auto ret = m_clusmap.insert(std::make_pair(key, new TrkrClusterv1()));
-    (ret.first->second)->setClusKey(key);
-    it = ret.first;
+    it = m_clusmap.insert(it, std::make_pair(key, new TrkrClusterv1()));
+    it->second->setClusKey(key);
   }
   return it;
 }


### PR DESCRIPTION
This speeds up FindOrAdd by a factor two when inserting clusters, by not parsing the map twice.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

