### PR TITLE
Reject outlier clusters

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -50,8 +50,7 @@ PHSiliconTpcTrackMatching::~PHSiliconTpcTrackMatching()
 int PHSiliconTpcTrackMatching::Setup(PHCompositeNode *topNode)
 {
   // put these in the output file
-  cout << PHWHERE << " p0 " << _par0 << " p1 " << _par1 << " p2 " 
-       << _par2 << " Search windows: phi " << _phi_search_win << " eta " 
+  cout << PHWHERE "_is_ca_seeder " << _is_ca_seeder << " Search windows: phi " << _phi_search_win << " eta " 
        << _eta_search_win << endl;
 
   // corrects the PHTpcTracker phi bias

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
@@ -52,7 +52,7 @@ PHTpcTrackSeedVertexAssoc::~PHTpcTrackSeedVertexAssoc()
 int PHTpcTrackSeedVertexAssoc::Setup(PHCompositeNode *topNode)
 {
   std::cout << PHWHERE << " Parameters: _reject_xy_outliers " << _reject_xy_outliers << " _xy_residual_cut " << _xy_residual_cut
-	    << " _reject_z_outliers " << _reject_z_outliers << " _z_residual_cut " << _z_residual_cut
+	    << " _reject_z_outliers " << _reject_z_outliers << " _z_residual_cut " << _z_residual_cut  << " _refit " << _refit
 	    << std::endl; 
 
   int ret = PHTrackPropagating::Setup(topNode);

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
@@ -301,7 +301,6 @@ int PHTpcTrackSeedVertexAssoc::Process()
 	  for(unsigned int i = 1; i < cpoints.size(); ++i)
 	    {
 	      double res_squared =  residuals[i]*residuals[i];
-	      //if(sqrt(res_squared) < 0.06)  // about 3.5-4 sigma
 	      if(sqrt(res_squared) < _xy_residual_cut)  
 		{
 		  circle_rms_squared += res_squared;
@@ -359,7 +358,7 @@ int PHTpcTrackSeedVertexAssoc::Process()
 		  double y = clusters[i]->getY();	  
 		  cpoints.push_back(make_pair(x, y));
 		}
-	      double R, X0, Y0;
+
 	      CircleFitByTaubin(cpoints, R, X0, Y0);
 	      if(Verbosity() > 2) 
 		std::cout << " after bad xy cluster removal, re-fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
@@ -252,21 +252,25 @@ int PHTpcTrackSeedVertexAssoc::Process()
 	      continue;
 	    }
 
-	  // refit the line
-	  points.clear();
-	  r_vertex = sqrt(vertex->get_x()*vertex->get_x() + vertex->get_y()*vertex->get_y());
-	  z_vertex = vertex->get_z();
-	  points.push_back(make_pair(r_vertex, z_vertex));
-	  for (unsigned int i=0; i<clusters.size(); ++i)
+	  //optionally refit the line
+	  if(_refit)
 	    {
-	      double r = sqrt(pow(clusters[i]->getX(),2) + pow(clusters[i]->getY(), 2));
-	      double z = clusters[i]->getZ();	      
-	      points.push_back(make_pair(r,z));
+	      // refit the line
+	      points.clear();
+	      r_vertex = sqrt(vertex->get_x()*vertex->get_x() + vertex->get_y()*vertex->get_y());
+	      z_vertex = vertex->get_z();
+	      points.push_back(make_pair(r_vertex, z_vertex));
+	      for (unsigned int i=0; i<clusters.size(); ++i)
+		{
+		  double r = sqrt(pow(clusters[i]->getX(),2) + pow(clusters[i]->getY(), 2));
+		  double z = clusters[i]->getZ();	      
+		  points.push_back(make_pair(r,z));
+		}
+	      
+	      line_fit(points, A, B);
+	      if(Verbosity() > 2) 
+		std::cout << "       After bad cluster removal, re-fitted line including vertex has A " << A << " B " << B << std::endl;      	  
 	    }
-	  
-	  line_fit(points, A, B);
-	  if(Verbosity() > 2) 
-	    std::cout << "       After bad cluster removal, re-fitted line including vertex has A " << A << " B " << B << std::endl;      	  
 
 	  bad_clusters.clear();
 	}
@@ -344,21 +348,24 @@ int PHTpcTrackSeedVertexAssoc::Process()
 	      continue;
 	    }
 
-	  // refit the circle
-	  cpoints.clear();
-	  cpoints.push_back(std::make_pair(x_vertex, y_vertex));
-	  for (unsigned int i=0; i<clusters.size(); ++i)
+	  if(_refit)
 	    {
-	      double x = clusters[i]->getX();
-	      double y = clusters[i]->getY();	  
-	      cpoints.push_back(make_pair(x, y));
+	      // refit the circle
+	      cpoints.clear();
+	      cpoints.push_back(std::make_pair(x_vertex, y_vertex));
+	      for (unsigned int i=0; i<clusters.size(); ++i)
+		{
+		  double x = clusters[i]->getX();
+		  double y = clusters[i]->getY();	  
+		  cpoints.push_back(make_pair(x, y));
+		}
+	      double R, X0, Y0;
+	      CircleFitByTaubin(cpoints, R, X0, Y0);
+	      if(Verbosity() > 2) 
+		std::cout << " after bad xy cluster removal, re-fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
 	    }
-	  double R, X0, Y0;
-	  CircleFitByTaubin(cpoints, R, X0, Y0);
-	  if(Verbosity() > 2) 
-	    std::cout << " after bad xy cluster removal, re-fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
 	}
-      
+
       double pt_track = _tracklet_tpc->get_pt();
       if(Verbosity() > 5)
 	{

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
@@ -433,8 +433,9 @@ int PHTpcTrackSeedVertexAssoc::Process()
 
   bad_clusters_per_track_z /= bad_clusters_per_track_z_wt;
   bad_clusters_per_track_xy /= bad_clusters_per_track_xy_wt;
-  std::cout << "Bad clusters per track:  z:  wt " << bad_clusters_per_track_z_wt << " bad clusters "  << bad_clusters_per_track_z 
-	    << " xy: wt " << bad_clusters_per_track_xy_wt << " bad clusters "  << bad_clusters_per_track_xy << std::endl;
+  if(Verbosity() > 0)
+    std::cout << "Bad clusters per track:  z:  wt " << bad_clusters_per_track_z_wt << " bad clusters "  << bad_clusters_per_track_z 
+	      << " xy: wt " << bad_clusters_per_track_xy_wt << " bad clusters "  << bad_clusters_per_track_xy << std::endl;
 
   if(_reject_z_outliers && Verbosity() > 5)
     {

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -31,8 +31,11 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
   }
   void set_field(const std::string &field) { _field = field;}
 
-  void reject_xy_outliers(bool reject){_reject_xy_outliers = reject;}  
-  void reject_z_outliers(bool reject){_reject_z_outliers = reject;}
+  void reject_xy_outliers(const bool reject){_reject_xy_outliers = reject;}  
+  void reject_z_outliers(const bool reject){_reject_z_outliers = reject;}
+
+  void set_xy_residual_cut(const double cut){_xy_residual_cut = cut;}
+  void set_z_residual_cut(const double cut){_z_residual_cut = cut;}
 
  protected:
   int Setup(PHCompositeNode* topNode) override;
@@ -64,6 +67,10 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
 
   bool _reject_xy_outliers = false;
   bool _reject_z_outliers = false;
+
+  double _xy_residual_cut = 0.06;
+  double _z_residual_cut = 0.15;
+
 
   std::string _field;
   int _fieldDir = -1;

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -23,14 +23,6 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
 
   virtual ~PHTpcTrackSeedVertexAssoc();
 
-  void set_field_dir(const double rescale)
-  {
-    _fieldDir = -1;
-    if(rescale > 0)
-      _fieldDir = 1;     
-  }
-  void set_field(const std::string &field) { _field = field;}
-
   void reject_xy_outliers(const bool reject){_reject_xy_outliers = reject;}  
   void reject_z_outliers(const bool reject){_reject_z_outliers = reject;}
 
@@ -70,13 +62,9 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
   bool _reject_z_outliers = false;
   bool _refit  = false;
 
-  double _xy_residual_cut = 0.06;
-  double _z_residual_cut = 0.15;
-
-
-  std::string _field;
-  int _fieldDir = -1;
+  double _xy_residual_cut = 0.08;
+  double _z_residual_cut = 0.22;
 
 };
 
-#endif // PHTRUTHSILICONASSOCIATION_H
+#endif // PHTRACKSEEDVERTEXASSOCIATION_H

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -36,6 +36,7 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
 
   void set_xy_residual_cut(const double cut){_xy_residual_cut = cut;}
   void set_z_residual_cut(const double cut){_z_residual_cut = cut;}
+  void set_refit(const bool refit) {_refit = refit;}
 
  protected:
   int Setup(PHCompositeNode* topNode) override;
@@ -67,6 +68,7 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
 
   bool _reject_xy_outliers = false;
   bool _reject_z_outliers = false;
+  bool _refit  = false;
 
   double _xy_residual_cut = 0.06;
   double _z_residual_cut = 0.15;

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -31,6 +31,9 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
   }
   void set_field(const std::string &field) { _field = field;}
 
+  void reject_xy_outliers(bool reject){_reject_xy_outliers = reject;}  
+  void reject_z_outliers(bool reject){_reject_z_outliers = reject;}
+
  protected:
   int Setup(PHCompositeNode* topNode) override;
 
@@ -45,6 +48,9 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
   void  line_fit_clusters(std::vector<TrkrCluster*> clusters, double &a, double &b);
   void  line_fit(std::vector<std::pair<double,double>> points, double &a, double &b);
   void CircleFitByTaubin (std::vector<std::pair<double,double>> points, double &R, double &X0, double &Y0);
+  std::vector<double> GetCircleClusterResiduals(std::vector<std::pair<double,double>> points, double R, double X0, double Y0);
+  std::vector<double> GetLineClusterResiduals(std::vector<std::pair<double,double>> points, double A, double B);
+  std::vector<TrkrCluster*> getTrackClusters(SvtxTrack *_tracklet_tpc);
 						    
   std::string _track_map_name_silicon;
 
@@ -55,6 +61,9 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
   unsigned int _max_tpc_layer = 54;
 
   double _z_proj= 0;
+
+  bool _reject_xy_outliers = false;
+  bool _reject_z_outliers = false;
 
   std::string _field;
   int _fieldDir = -1;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Adds the option in PHTpcSeedVertexAssoc to reject outlying clusters in xy or z, using the fitted helix. They are set to false by default. Enabling the rejection in xy improves tracking efficiency in central Au+Au events with 50 kHz pileup to 71% from 66%. It also improves the pT resolution significantly. I think that both of these occur because the ACTS track fit is improved by the outlier rejection. The silicon TPC matching is not affected. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

