### PR TITLE
Fixing valgrind issues

### DIFF
--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -133,6 +133,7 @@ class PHSimpleKFProp : public PHTrackPropagating
   std::shared_ptr<ALICEKF> fitter;
   double get_Bz(double x, double y, double z);
   void publishSeeds(std::vector<SvtxTrack_v1>);
+  void publishSeeds(std::vector<SvtxTrack>);
   void MoveToVertex();
   void MoveToFirstTPCCluster();
   void line_fit(std::vector<std::pair<double,double>> points, double &A, double &B);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Fixing valgrind issues involving PHSimpleKFProp and SvtxTrackMap::erase. The propagator resets and rebuilds the track map rather than modifying in-place, which should be more reliable. 
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

