### PR TITLE
fixed a bug in distortion extrapolation procedure

### DIFF
--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -120,22 +120,15 @@ void TpcSpaceChargeReconstructionHelper::extrapolate_phi1( TH3* hin )
       std::tie( zref_min_loc, zref_max_loc ) = get_zref_range( r );
 
       // get corresponding bins
-      const int zbin_min[2] = { hin->GetZaxis()->FindBin( -zref_max_loc ), hin->GetZaxis()->FindBin( zref_min_loc ) };
-      const int zbin_max[2] = { hin->GetZaxis()->FindBin( -zref_min_loc ), hin->GetZaxis()->FindBin( zref_max_loc ) };
+      const std::array<int,2> zbin_min = {{ hin->GetZaxis()->FindBin( -zref_max_loc ), hin->GetZaxis()->FindBin( zref_min_loc ) }};
+      const std::array<int,2> zbin_max = {{ hin->GetZaxis()->FindBin( -zref_min_loc ), hin->GetZaxis()->FindBin( zref_max_loc ) }};
 
       // get corresponding normalizations
-      const double norm[2] =
-      {
-        hin->Integral( phibin, phibin, ir+1, ir+1, zbin_min[0], zbin_max[0] )/(zbin_max[0]-zbin_min[0]+1),
-        hin->Integral( phibin, phibin, ir+1, ir+1, zbin_min[1], zbin_max[1] )/(zbin_max[1]-zbin_min[1]+1)
-      };
-
-      // get corresponding normalizations
-      const double norm_ref[2] =
-      {
-        hin->Integral( phibin_ref, phibin_ref, ir+1, ir+1, zbin_min[0], zbin_max[0] )/(zbin_max[0]-zbin_min[0]+1),
-        hin->Integral( phibin_ref, phibin_ref, ir+1, ir+1, zbin_min[1], zbin_max[1] )/(zbin_max[1]-zbin_min[1]+1)
-      };
+      const std::array<double,2> scale_factor =
+      {{
+        hin->Integral( phibin, phibin, ir+1, ir+1, zbin_min[0], zbin_max[0] )/hin->Integral( phibin_ref, phibin_ref, ir+1, ir+1, zbin_min[0], zbin_max[0] ),
+        hin->Integral( phibin, phibin, ir+1, ir+1, zbin_min[1], zbin_max[1] )/hin->Integral( phibin_ref, phibin_ref, ir+1, ir+1, zbin_min[1], zbin_max[1] )
+      }};
 
       // loop over z bins
       for( int iz = 0; iz < hin->GetZaxis()->GetNbins(); ++iz )
@@ -145,7 +138,7 @@ void TpcSpaceChargeReconstructionHelper::extrapolate_phi1( TH3* hin )
 
         // calculate scale factor
         const auto z = hin->GetZaxis()->GetBinCenter( iz+1 );
-        const auto scale = (z > 0) ? (norm[1]/norm_ref[1]) : (norm[0]/norm_ref[0]);
+        const auto scale = (z > 0) ? scale_factor[1]:scale_factor[0];
 
         // assign to output histogram
         hin->SetBinContent( phibin, ir+1, iz+1, content_ref*scale );

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
@@ -16,13 +16,16 @@ class TpcSpaceChargeReconstructionHelper
 {
 
   public:
-    
+
   /// z extrapolation
   /**
    * interpolate between micromegas in the fully equiped sector
    */
   static void extrapolate_z( TH3* hin );
-   
+
+  /// get reference z range used for phi extrapolation normalization at a given radius
+  static std::tuple<double, double> get_zref_range( double r );
+
   /// first phi extrapolation
   /**
    * copy the full z dependence of reference sector to all other sectors, separately for positive and negative z,
@@ -53,7 +56,7 @@ class TpcSpaceChargeReconstructionHelper
    * in which case the "guarding bins" would be unnecessary. Should check if it leads to a significant deterioration of the momentum resolution
    */
   static TH3* copy_histogram( TH3* hin, const TString& name );
-    
+
 };
 
 #endif


### PR DESCRIPTION
- more static helper method
- fix a bug in the extrapolation procedure along phi, due to recalculating the (z-integrated) normalization factor, while filling the histogram along z.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

