### PR TITLE
protect against nan scale factors

### DIFF
--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -124,10 +124,11 @@ void TpcSpaceChargeReconstructionHelper::extrapolate_phi1( TH3* hin )
       const std::array<int,2> zbin_max = {{ hin->GetZaxis()->FindBin( -zref_min_loc ), hin->GetZaxis()->FindBin( zref_max_loc ) }};
 
       // get corresponding normalizations
+      auto safe_ratio = []( double numerator, double denominator ) -> double { return denominator == 0 ? 1. : numerator / denominator; };
       const std::array<double,2> scale_factor =
       {{
-        hin->Integral( phibin, phibin, ir+1, ir+1, zbin_min[0], zbin_max[0] )/hin->Integral( phibin_ref, phibin_ref, ir+1, ir+1, zbin_min[0], zbin_max[0] ),
-        hin->Integral( phibin, phibin, ir+1, ir+1, zbin_min[1], zbin_max[1] )/hin->Integral( phibin_ref, phibin_ref, ir+1, ir+1, zbin_min[1], zbin_max[1] )
+        safe_ratio( hin->Integral( phibin, phibin, ir+1, ir+1, zbin_min[0], zbin_max[0] ), hin->Integral( phibin_ref, phibin_ref, ir+1, ir+1, zbin_min[0], zbin_max[0] ) ),
+        safe_ratio( hin->Integral( phibin, phibin, ir+1, ir+1, zbin_min[1], zbin_max[1] ), hin->Integral( phibin_ref, phibin_ref, ir+1, ir+1, zbin_min[1], zbin_max[1] ) )
       }};
 
       // loop over z bins
@@ -142,7 +143,7 @@ void TpcSpaceChargeReconstructionHelper::extrapolate_phi1( TH3* hin )
 
         // assign to output histogram
         hin->SetBinContent( phibin, ir+1, iz+1, content_ref*scale );
-        hin->SetBinError( phibin, ir+1, iz+1, error_ref*scale );
+        hin->SetBinError( phibin, ir+1, iz+1, error_ref*std::abs(scale) );
       }
     }
   }


### PR DESCRIPTION
- prevent nan scale factors
- make sure bin error is always positive
This has no impact on using the reconstructed map since region of the acceptance where nan scale factors occur correspond to places where there is no measurement (typically r < 30cm), but can prevent plotting the distortion map for cross-checks (root doesn't like nans)

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

