### PR TITLE
Reject Geant4 tracks during filling of truth container

### DIFF
--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -355,6 +355,13 @@ void PHG4TruthInfoContainer::delete_particle(Iterator piter)
   return;
 }
 
+void PHG4TruthInfoContainer::delete_particle(int trackid)
+{
+  Iterator it = particlemap.find(trackid);
+  if (it != particlemap.end())
+    delete_particle(it);
+}
+
 void PHG4TruthInfoContainer::delete_vtx(VtxIterator viter)
 {
   delete viter->second;

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -172,6 +172,10 @@ PHG4TruthInfoContainer::AddParticle(G4Track* track)
   ti->set_name(def->GetParticleName());
   ti->set_e(track->GetTotalEnergy() / GeV);
 
+  // Add new vertex and let the track know about it
+  ConstVtxIterator vtxiter = AddVertex(track);
+  ti->set_vtx_id(vtxiter->first);
+
   return particlemap.insert(std::make_pair(trackid, ti)).first;
 }
 

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -15,14 +15,28 @@
 #include <boost/tuple/tuple.hpp>
 
 #include <limits>
+#include <set>
 #include <string>
 
 using namespace std;
 
+namespace {
+  /// A helper container to hold unique vertex positions
+  ///{@
+  struct VtxPos
+  {
+    double x, y, z; int vtxindex;
+    bool operator< (const VtxPos& b) const { return std::tie(z, y, x) < std::tie(b.z, b.y, b.x); }
+  };
+
+  std::set<VtxPos> vtxset;
+  ///@}
+}
+
+
 PHG4TruthInfoContainer::PHG4TruthInfoContainer()
   : particlemap()
   , vtxmap()
-  , vtxset()
   , particle_embed_flags()
   , vertex_embed_flags()
 {

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -369,6 +369,13 @@ void PHG4TruthInfoContainer::delete_vtx(VtxIterator viter)
   return;
 }
 
+void PHG4TruthInfoContainer::delete_vtx(int vtxid)
+{
+  VtxIterator it = vtxmap.find(vtxid);
+  if (it != vtxmap.end())
+    delete_vtx(it);
+}
+
 void PHG4TruthInfoContainer::delete_shower(ShowerIterator siter)
 {
   delete siter->second;

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -1,8 +1,15 @@
 #include "PHG4TruthInfoContainer.h"
 
 #include "PHG4Particle.h"
+#include "PHG4Particlev2.h"
+#include "PHG4Particlev3.h"
 #include "PHG4Shower.h"
 #include "PHG4VtxPoint.h"
+
+#include <Geant4/G4ParticleDefinition.hh>
+#include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4ThreeVector.hh>
+#include <Geant4/G4Track.hh>
 
 #include <boost/tuple/tuple.hpp>
 
@@ -113,6 +120,56 @@ PHG4TruthInfoContainer::AddParticle(const int trackid, PHG4Particle* newparticle
        << " parent ID " << newparticle->get_parent_id()
        << std::endl;
   return particlemap.end();
+}
+
+PHG4TruthInfoContainer::ConstIterator
+PHG4TruthInfoContainer::AddParticle(G4Track* track)
+{
+  int trackid = 0;
+  if (track->GetParentID())
+  {
+    // secondaries get negative user ids and increment downward between geant subevents
+    trackid = mintrkindex() - 1;
+  }
+  else
+  {
+    // primaries get positive user ids and increment upward between geant subevents
+    trackid = maxtrkindex() + 1;
+  }
+
+  // determine the momentum vector
+  G4ParticleDefinition* def = track->GetDefinition();
+  int pdgid = def->GetPDGEncoding();
+  double m = def->GetPDGMass();
+  double ke = track->GetVertexKineticEnergy();
+  double ptot = sqrt(ke * ke + 2.0 * m * ke);
+  G4ThreeVector pdir = track->GetVertexMomentumDirection();
+  pdir *= ptot;
+  PHG4Particle* ti = nullptr;
+  // create a new particle -----------------------------------------------------
+  if (def->IsGeneralIon())  // for ions save a and z in v3 of phg4particle
+  {
+    ti = new PHG4Particlev3();
+    ti->set_A(def->GetAtomicMass());
+    ti->set_Z(def->GetAtomicNumber());
+  }
+  else
+  {
+    ti = new PHG4Particlev2;
+  }
+  ti->set_px(pdir[0] / GeV);
+  ti->set_py(pdir[1] / GeV);
+  ti->set_pz(pdir[2] / GeV);
+  ti->set_track_id(trackid);
+
+  ti->set_parent_id(track->GetParentID());
+  ti->set_primary_id(trackid);
+
+  ti->set_pid(pdgid);
+  ti->set_name(def->GetParticleName());
+  ti->set_e(track->GetTotalEnergy() / GeV);
+
+  return particlemap.insert(std::make_pair(trackid, ti)).first;
 }
 
 PHG4Particle* PHG4TruthInfoContainer::GetParticle(const int trackid)

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -111,6 +111,7 @@ class PHG4TruthInfoContainer : public PHObject
   ConstVtxIterator AddVertex(const int vtxid, PHG4VtxPoint* vertex);
   ConstVtxIterator AddVertex(const G4Track* track);
   void delete_vtx(VtxIterator viter);
+  void delete_vtx(int vtxid);
 
   PHG4VtxPoint* GetVtx(const int vtxid);
   PHG4VtxPoint* GetPrimaryVtx(const int vtxid);

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <iterator>  // for distance
 #include <map>
+#include <set>
 #include <utility>
 
 class PHG4Shower;
@@ -107,6 +108,7 @@ class PHG4TruthInfoContainer : public PHObject
 
   //! Add a vertex and return an iterator to the user
   ConstVtxIterator AddVertex(const int vtxid, PHG4VtxPoint* vertex);
+  ConstVtxIterator AddVertex(const G4Track* track);
   void delete_vtx(VtxIterator viter);
 
   PHG4VtxPoint* GetVtx(const int vtxid);
@@ -219,6 +221,17 @@ class PHG4TruthInfoContainer : public PHObject
   /// -M+1
   /// -M   secondary vertex id => vertex*
   VtxMap vtxmap;
+
+  /// A helper container to hold unique vertex positions
+  ///{@
+  struct VtxPos
+  {
+    double x, y, z; int vtxindex;
+    bool operator< (const PHG4TruthInfoContainer::VtxPos& b) const { return std::tie(z, y, x) < std::tie(b.z, b.y, b.x); }
+  };
+
+  std::set<VtxPos> vtxset; //!
+  ///@}
 
   /// shower map
   /// showers encapsulate the secondaries and hits from a primary particle

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -49,6 +49,7 @@ class PHG4TruthInfoContainer : public PHObject
   ConstIterator AddParticle(const int particleid, PHG4Particle* newparticle);
   ConstIterator AddParticle(G4Track* track);
   void delete_particle(Iterator piter);
+  void delete_particle(int trackid);
 
   PHG4Particle* GetParticle(const int trackid);
   PHG4Particle* GetPrimaryParticle(const int trackid);

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -13,6 +13,7 @@
 class PHG4Shower;
 class PHG4Particle;
 class PHG4VtxPoint;
+class G4Track;
 
 class PHG4TruthInfoContainer : public PHObject
 {
@@ -45,6 +46,7 @@ class PHG4TruthInfoContainer : public PHObject
 
   //! Add a particle that the user has created
   ConstIterator AddParticle(const int particleid, PHG4Particle* newparticle);
+  ConstIterator AddParticle(G4Track* track);
   void delete_particle(Iterator piter);
 
   PHG4Particle* GetParticle(const int trackid);

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -8,7 +8,6 @@
 #include <iostream>
 #include <iterator>  // for distance
 #include <map>
-#include <set>
 #include <utility>
 
 class PHG4Shower;
@@ -223,17 +222,6 @@ class PHG4TruthInfoContainer : public PHObject
   /// -M+1
   /// -M   secondary vertex id => vertex*
   VtxMap vtxmap;
-
-  /// A helper container to hold unique vertex positions
-  ///{@
-  struct VtxPos
-  {
-    double x, y, z; int vtxindex;
-    bool operator< (const PHG4TruthInfoContainer::VtxPos& b) const { return std::tie(z, y, x) < std::tie(b.z, b.y, b.x); }
-  };
-
-  std::set<VtxPos> vtxset; //!
-  ///@}
 
   /// shower map
   /// showers encapsulate the secondaries and hits from a primary particle

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -13,7 +13,6 @@
 class PHG4Shower;
 class PHG4Particle;
 class PHG4VtxPoint;
-class G4Track;
 
 class PHG4TruthInfoContainer : public PHObject
 {
@@ -46,7 +45,6 @@ class PHG4TruthInfoContainer : public PHObject
 
   //! Add a particle that the user has created
   ConstIterator AddParticle(const int particleid, PHG4Particle* newparticle);
-  ConstIterator AddParticle(G4Track* track);
   void delete_particle(Iterator piter);
   void delete_particle(int trackid);
 
@@ -108,7 +106,6 @@ class PHG4TruthInfoContainer : public PHObject
 
   //! Add a vertex and return an iterator to the user
   ConstVtxIterator AddVertex(const int vtxid, PHG4VtxPoint* vertex);
-  ConstVtxIterator AddVertex(const G4Track* track);
   void delete_vtx(VtxIterator viter);
   void delete_vtx(int vtxid);
 

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -27,6 +27,8 @@ using namespace std;
 PHG4TruthTrackingAction::PHG4TruthTrackingAction(PHG4TruthEventAction* eventAction)
   : m_EventAction(eventAction)
   , m_TruthInfoList(nullptr)
+  , m_G4ParticleStack()
+  , m_CurrG4Particle()
 {
 }
 
@@ -34,6 +36,10 @@ void PHG4TruthTrackingAction::PreUserTrackingAction(const G4Track* track)
 {
   // insert particle into the output
   PHG4Particle* ti = (*m_TruthInfoList->AddParticle(const_cast<G4Track*>(track))).second;
+
+  // Negative G4 track id values indicate unwanted tracks to be deleted
+  // Initially all tracks except primary ones flagged as unwanted
+  int track_id_g4 = track->GetTrackID() * (track->GetParentID() ? -1 : +1);
   int trackid = ti->get_track_id();
 
   // add the user id to the geant4 user info
@@ -62,6 +68,8 @@ void PHG4TruthTrackingAction::PreUserTrackingAction(const G4Track* track)
   }
 
   int vtxindex = ti->get_vtx_id();
+
+  m_CurrG4Particle = {track_id_g4, trackid, vtxindex};
 
   // create or add to a new shower object --------------------------------------
   if (!track->GetParentID())
@@ -138,6 +146,45 @@ void PHG4TruthTrackingAction::PostUserTrackingAction(const G4Track* track)
       m_EventAction->AddTrackidToWritelist(trackid);
     }
   }
+
+  UpdateG4ParticleStack(track);
+}
+
+/**
+ * Updates the stack of parent particles and removes unwanted ones from the
+ * truth info container.
+ */
+void PHG4TruthTrackingAction::UpdateG4ParticleStack(const G4Track* track)
+{
+  while (!m_G4ParticleStack.empty())
+  {
+    if ( std::abs(m_G4ParticleStack.back().g4track_id) == track->GetParentID() )
+    {
+      break;
+    }
+    else
+    {
+      if (m_G4ParticleStack.back().g4track_id < 0)
+      {
+        m_TruthInfoList->delete_particle( m_G4ParticleStack.back().particle_id );
+      }
+      m_G4ParticleStack.pop_back();
+    }
+  }
+
+  m_G4ParticleStack.push_back(m_CurrG4Particle);
+
+  // Change sign of G4 track id of all upstream tracks in the stack to positive
+  // in order to keep the track
+  PHG4TrackUserInfoV1* p = dynamic_cast<PHG4TrackUserInfoV1*>(track->GetUserInformation());
+  bool keep_curr_track = p && p->GetKeep() ? true : false;
+
+  auto stack_iter = m_G4ParticleStack.rbegin();
+  while (keep_curr_track && stack_iter != m_G4ParticleStack.rend() && stack_iter->g4track_id < 0)
+  {
+    stack_iter->g4track_id *= -1;
+    ++stack_iter;
+  }
 }
 
 void PHG4TruthTrackingAction::SetInterfacePointers(PHCompositeNode* topNode)
@@ -154,5 +201,14 @@ void PHG4TruthTrackingAction::SetInterfacePointers(PHCompositeNode* topNode)
 
 int PHG4TruthTrackingAction::ResetEvent(PHCompositeNode*)
 {
+  while (!m_G4ParticleStack.empty())
+  {
+    if ( m_G4ParticleStack.back().g4track_id < 0)
+    {
+      m_TruthInfoList->delete_particle( m_G4ParticleStack.back().particle_id );
+    }
+    m_G4ParticleStack.pop_back();
+  }
+
   return 0;
 }

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -32,9 +32,6 @@ PHG4TruthTrackingAction::PHG4TruthTrackingAction(PHG4TruthEventAction* eventActi
 
 void PHG4TruthTrackingAction::PreUserTrackingAction(const G4Track* track)
 {
-  // create a new vertex object ------------------------------------------------
-  int vtxindex = m_TruthInfoList->AddVertex(track);
-
   // insert particle into the output
   PHG4Particle* ti = (*m_TruthInfoList->AddParticle(const_cast<G4Track*>(track))).second;
   int trackid = ti->get_track_id();
@@ -63,6 +60,8 @@ void PHG4TruthTrackingAction::PreUserTrackingAction(const G4Track* track)
     PHG4UserPrimaryParticleInformation* userdata = static_cast<PHG4UserPrimaryParticleInformation*>(track->GetDynamicParticle()->GetPrimaryParticle()->GetUserInformation());
     if (userdata) ti->set_barcode(userdata->get_user_barcode());
   }
+
+  int vtxindex = ti->get_vtx_id();
 
   // create or add to a new shower object --------------------------------------
   if (!track->GetParentID())

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
@@ -7,8 +7,6 @@
 
 #include <Geant4/G4ThreeVector.hh>
 
-#include <map>
-
 class G4Track;
 class PHCompositeNode;
 class PHG4TruthInfoContainer;
@@ -34,8 +32,6 @@ class PHG4TruthTrackingAction : public PHG4TrackingAction
   int ResetEvent(PHCompositeNode*);
 
  private:
-  std::map<G4ThreeVector, int> m_VertexMap;
-
   //! pointer to the "owning" event action
   PHG4TruthEventAction* m_EventAction;
 

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
@@ -7,10 +7,13 @@
 
 #include <Geant4/G4ThreeVector.hh>
 
+#include <vector>
+
 class G4Track;
 class PHCompositeNode;
 class PHG4TruthInfoContainer;
 class PHG4TruthEventAction;
+class PHG4Particle;
 
 class PHG4TruthTrackingAction : public PHG4TrackingAction
 {
@@ -37,6 +40,16 @@ class PHG4TruthTrackingAction : public PHG4TrackingAction
 
   //! pointer to truth information container
   PHG4TruthInfoContainer* m_TruthInfoList;
+
+  /// Machinery to keep track of upstream particles while adding Geant4 tracks
+  /// to the truth info container
+  ///@{
+  void UpdateG4ParticleStack(const G4Track*);
+
+  struct G4ParticleInfo { int g4track_id, particle_id, vertex_id; };
+  std::vector<G4ParticleInfo> m_G4ParticleStack;
+  G4ParticleInfo m_CurrG4Particle;
+  ///@}
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
@@ -7,6 +7,7 @@
 
 #include <Geant4/G4ThreeVector.hh>
 
+#include <map>
 #include <vector>
 
 class G4Track;
@@ -14,6 +15,7 @@ class PHCompositeNode;
 class PHG4TruthInfoContainer;
 class PHG4TruthEventAction;
 class PHG4Particle;
+class PHG4VtxPoint;
 
 class PHG4TruthTrackingAction : public PHG4TrackingAction
 {
@@ -35,11 +37,16 @@ class PHG4TruthTrackingAction : public PHG4TrackingAction
   int ResetEvent(PHCompositeNode*);
 
  private:
+  std::map<G4ThreeVector, int> m_VertexMap;
+
   //! pointer to the "owning" event action
   PHG4TruthEventAction* m_EventAction;
 
   //! pointer to truth information container
   PHG4TruthInfoContainer* m_TruthInfoList;
+
+  PHG4Particle* AddParticle(PHG4TruthInfoContainer&, G4Track&);
+  PHG4VtxPoint* AddVertex(PHG4TruthInfoContainer&, const G4Track&);
 
   /// Machinery to keep track of upstream particles while adding Geant4 tracks
   /// to the truth info container


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

As discussed in my talk (see https://plexoos.github.io/pub-docs/sphenix-simu-mem/s2.html) this implements a stack of Geant4 tracks. This stack is used to remove particles from the output truth container as Geant4 provides them instead of collecting all particles and deleting selected ones at the end of event. This approach helps to reduce the maximum amount of memory allocated by simulation jobs.

Previously unsuccessful PR #1081

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

