### PR TITLE
Implementing beam bunch z dependent of collision vertex and momentum tilt (Crab cavity kick)

### DIFF
--- a/generators/phhepmc/PHHepMCGenHelper.cc
+++ b/generators/phhepmc/PHHepMCGenHelper.cc
@@ -363,40 +363,40 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
              << "cos_rotation_center_angle_to_z = " << cos_rotation_center_angle_to_z
              << endl;
       }
-      else
+    }
+    else
+    {
+      // need a rotation
+      CLHEP::Hep3Vector rotation_axis = beamCenterDiffAxis.cross(z_axis);
+      const double rotation_angle_to_z = -acos(cos_rotation_center_angle_to_z);
+      const CLHEP::HepRotation rotation(rotation_axis, rotation_angle_to_z);
+
+      const HepMC::FourVector init_4vertex = genevent->get_collision_vertex();
+      CLHEP::Hep3Vector init_3vertex(
+          init_4vertex.x(),
+          init_4vertex.y(),
+          init_4vertex.z());
+
+      CLHEP::Hep3Vector final_3vertex = rotation * init_3vertex;
+
+      genevent->set_collision_vertex(HepMC::FourVector(
+          final_3vertex.x(),
+          final_3vertex.y(),
+          final_3vertex.z(),
+          init_4vertex.t()));
+
+      if (m_verbosity)
       {
-        // need a rotation
-        CLHEP::Hep3Vector rotation_axis = beamCenterDiffAxis.cross(z_axis);
-        const double rotation_angle_to_z = -acos(cos_rotation_center_angle_to_z);
-        const CLHEP::HepRotation rotation(rotation_axis, rotation_angle_to_z);
-
-        const HepMC::FourVector init_4vertex = genevent->get_collision_vertex();
-        CLHEP::Hep3Vector init_3vertex(
-            init_4vertex.x(),
-            init_4vertex.y(),
-            init_4vertex.z());
-
-        CLHEP::Hep3Vector final_3vertex = rotation * init_3vertex;
-
-        genevent->set_collision_vertex(HepMC::FourVector(
-            final_3vertex.x(),
-            final_3vertex.y(),
-            final_3vertex.z(),
-            init_4vertex.t()));
-
-        if (m_verbosity)
-        {
-          cout << __PRETTY_FUNCTION__
-               << ": collision longitudinal axis is rotated: "
-               << "cos_rotation_center_angle_to_z = " << cos_rotation_center_angle_to_z << ", "
-               << "rotation_axis = " << rotation_axis << ", "
-               << "init_3vertex = " << init_3vertex << ", "
-               << "final_3vertex = " << final_3vertex << ", "
-               << endl;
-        }
+        cout << __PRETTY_FUNCTION__
+             << ": collision longitudinal axis is rotated: "
+             << "cos_rotation_center_angle_to_z = " << cos_rotation_center_angle_to_z << ", "
+             << "rotation_axis = " << rotation_axis << ", "
+             << "init_3vertex = " << init_3vertex << ", "
+             << "final_3vertex = " << final_3vertex << ", "
+             << endl;
       }
     }
-  }
+  }  //  if (not _reuse_vertex)
 
   if (m_verbosity)
   {

--- a/generators/phhepmc/PHHepMCGenHelper.cc
+++ b/generators/phhepmc/PHHepMCGenHelper.cc
@@ -348,7 +348,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
   {
     // the final longitudinal vertex smear axis
     CLHEP::Hep3Vector beamCenterDiffAxis = (beamA_center - beamB_center);
-    beamCenterDiffAxis = beamCenterDiffAxis / beamDiffAxis.mag();
+    beamCenterDiffAxis = beamCenterDiffAxis / beamCenterDiffAxis.mag();
 
     double cos_rotation_center_angle_to_z = beamCenterDiffAxis.dot(z_axis);
 

--- a/generators/phhepmc/PHHepMCGenHelper.h
+++ b/generators/phhepmc/PHHepMCGenHelper.h
@@ -77,7 +77,7 @@ class PHHepMCGenHelper
   virtual int create_node_tree(PHCompositeNode *topNode);
 
   //! choice of reference version of the PHHepMCGenEvent
-  const PHHepMCGenEvent * get_PHHepMCGenEvent_template() const;
+  const PHHepMCGenEvent *get_PHHepMCGenEvent_template() const;
 
   //! send HepMC::GenEvent to DST tree. This function takes ownership of evt
   PHHepMCGenEvent *insert_event(HepMC::GenEvent *evt);
@@ -136,19 +136,34 @@ class PHHepMCGenHelper
     m_beam_angular_divergence_hv = {{beamA_divergence_h, beamA_divergence_v}, {beamB_divergence_h, beamB_divergence_v}};
   }
 
+  //! Central beam angle shift as linear function of longitudinal vertex position, d_shift/dz,
+  //! which is used to represent leading order effect of crab cavity momentum kick on the beam bunch
+  //! @param[in] beamA_h beamA, horizontal angle dh/dz. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! @param[in] beamA_v beamA, vertical angle dv/dz. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! @param[in] beamB_h beamB, horizontal angle dh/dz. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  //! @param[in] beamB_v beamB, vertical angle dv/dz. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  void set_beam_angular_z_coefficient_hv(
+      const double beamA_h,
+      const double beamA_v,
+      const double beamB_h,
+      const double beamB_v)
+  {
+    m_beam_angular_z_coefficient_hv = {{beamA_h, beamA_v}, {beamB_h, beamB_v}};
+  }
+
   void CopySettings(PHHepMCGenHelper &helper);
 
   //! copy setting to helper_dest
-  void CopySettings(PHHepMCGenHelper * helper_dest) ;
+  void CopySettings(PHHepMCGenHelper *helper_dest);
 
   //! copy setting from helper_src
-  void CopyHelperSettings(PHHepMCGenHelper * helper_src) ;
+  void CopyHelperSettings(PHHepMCGenHelper *helper_src);
 
   void Print(const std::string &what = "ALL") const;
 
-  void PHHepMCGenHelper_Verbosity(int v) {m_verbosity = v;}
+  void PHHepMCGenHelper_Verbosity(int v) { m_verbosity = v; }
 
-  int PHHepMCGenHelper_Verbosity() {return m_verbosity;}
+  int PHHepMCGenHelper_Verbosity() { return m_verbosity; }
 
  private:
   gsl_rng *RandomGenerator;
@@ -182,6 +197,15 @@ class PHHepMCGenHelper
   //! First element is beamA, in pair of Gaussian Sigma_H Sigma_V. BeamA is aimed to +z direction in the HepMC event generator's coordinate
   //! Second element is beamB, in pair of Gaussian Sigma_H Sigma_V. BeamA is aimed to -z direction in the HepMC event generator's coordinate
   std::pair<std::pair<double, double>, std::pair<double, double>> m_beam_angular_divergence_hv = {
+      {0, 0},  //+z beam
+      {0, 0}   //-z beam
+  };
+
+  //! Central beam angle shift as linear function of longitudinal vertex position, d_shift/dz,
+  //! which is used to represent leading order effect of crab cavity momentum kick on the beam bunch
+  //! First element is beamA, in pair of dh/dz, dv/dz. BeamA is aimed to +z direction in the HepMC event generator's coordinate
+  //! Second element is beamB, in pair of dh/dz, dv/dz. BeamA is aimed to -z direction in the HepMC event generator's coordinate
+  std::pair<std::pair<double, double>, std::pair<double, double>> m_beam_angular_z_coefficient_hv = {
       {0, 0},  //+z beam
       {0, 0}   //-z beam
   };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Following https://github.com/sPHENIX-Collaboration/coresoftware/pull/1087, this pull request implement two vertex-z dependency for any HepMC-based event generators:
* The average collision axis would be rotated from z-axis, when e.g. one beam is off z-axis in the EIC case. At approximation of the lateral beam width is the same between two beams, the collision axis is implemented in the middle between two beams. 
* The crab cavity rotate beam bunch to increase collision overlap between two bunches. It induces a bunch z dependence of the average lateral momentum in the crossing plane, $p_x(z)$. In the leading order, this is implemented as a linear correlation between average beam angle and the longitudinal collision vertex, on top of the beam angle divergence smearing. 

### Verification

With the following test parameters for the EIC beam, verifying tilt of the collision vertex, px(z) for and each of the beam: https://github.com/blackcathj/macros/blob/beam-xing-detector-check/detectors/EICDetector/Plot.ipynb

#### Input configuration

A preliminary EIC beam configuration used in this test. Please note specific numbers need further validation. 
```c++

  //! apply EIC beam parameter to any HepMC generator following EIC CDR,
  //! including in-time collision's space time shift, beam crossing angle and angular divergence
  //! \param[in] HepMCGen any HepMC generator, e.g. Fun4AllHepMCInputManager, Fun4AllHepMCPileupInputManager, PHPythia8, PHPythia6, PHSartre, ReadEICFiles
  void ApplyEICBeamParameter(PHHepMCGenHelper *HepMCGen)
  {
    if (HepMCGen == nullptr)
    {
      std::cout << "ApplyEICBeamParameter(): Fatal Error - null input pointer HepMCGen" << std::endl;
      exit(1);
    }

    //25mrad x-ing as in EIC CDR
    const double EIC_hadron_crossing_angle = 25e-3;

    HepMCGen->set_beam_direction_theta_phi(
        EIC_hadron_crossing_angle,  // beamA_theta
        0,                          // beamA_phi
        M_PI,                       // beamB_theta
        0                           // beamB_phi
    );
    HepMCGen->set_beam_angular_divergence_hv(
        119e-6, 119e-6,  // proton beam divergence horizontal & vertical, as in EIC CDR Table 1.1
        211e-6, 152e-6   // electron beam divergence horizontal & vertical, as in EIC CDR Table 1.1
    );

    // angular kick within a bunch as result of crab cavity
    // using an naive assumption of transfer matrix from the cavity to IP,
    // which is NOT yet validated with accelerator optics simulations!
    const double z_hadron_cavity = 52e2;  // CDR Fig 3.3
    const double z_e_cavity = 38e2;       // CDR Fig 3.2
    HepMCGen->set_beam_angular_z_coefficient_hv(
        -EIC_hadron_crossing_angle / 2. / z_hadron_cavity, 0,
        -EIC_hadron_crossing_angle / 2. / z_e_cavity, 0);

    // calculate beam sigma width at IP  as in EIC CDR table 1.1
    const double sigma_p_h = sqrt(80 * 11.3e-7);
    const double sigma_p_v = sqrt(7.2 * 1.0e-7);
    const double sigma_p_l = 6;
    const double sigma_e_h = sqrt(45 * 20.0e-7);
    const double sigma_e_v = sqrt(5.6 * 1.3e-7);
    const double sigma_e_l = 2;

    // combine two beam gives the collision sigma in z
    const double collision_sigma_z = sqrt(sigma_p_l * sigma_p_l + sigma_e_l * sigma_e_l) / 2;
    const double collision_sigma_t = collision_sigma_z / 29.9792;  // speed of light in cm/ns

    HepMCGen->set_vertex_distribution_width(
        sigma_p_h * sigma_e_h / sqrt(sigma_p_h * sigma_p_h + sigma_e_h * sigma_e_h),  //x
        sigma_p_v * sigma_e_v / sqrt(sigma_p_v * sigma_p_v + sigma_e_v * sigma_e_v),  //y
        collision_sigma_z,                                                            //z
        collision_sigma_t);                                                           //t
    HepMCGen->set_vertex_distribution_function(
        PHHepMCGenHelper::Gaus,   //x
        PHHepMCGenHelper::Gaus,   //y
        PHHepMCGenHelper::Gaus,   //z
        PHHepMCGenHelper::Gaus);  //t
  }
```
A test HepMC event with head-on collision of electron and proton at 20x275 GeV but without interaction 


#### Collision vertex x is correlated with z at half beam angle

![image](https://user-images.githubusercontent.com/7947083/111042376-18c4f600-840b-11eb-95d7-0dd71ef8302c.png)

#### beam angle correlated with z for the proton beam

Centered at 25 mrad with an input -2.4urad/cm

![image](https://user-images.githubusercontent.com/7947083/111043389-452f4100-8410-11eb-881b-b2bbd9dc4984.png)


#### beam angle correlated with z for the electron beam

Plotted as pi-angle so center at 0. This reverses an input tilt of -3.4urad/cm

![image](https://user-images.githubusercontent.com/7947083/111043417-64c66980-8410-11eb-8621-36c4d2b1271f.png)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Update macro PR https://github.com/sPHENIX-Collaboration/macros/pull/381 and obtain validated beam parameters. 


## Links to other PRs in macros and calibration repositories (if applicable)

https://github.com/sPHENIX-Collaboration/macros/pull/381