### PR TITLE
KFParticle: Added truth PV info and fixed DIRA bug

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -112,9 +112,13 @@ class KFParticle_Tools : public KFParticle_particleList, protected KFParticle_MV
 
   float m_max_mass = -1;
 
-  float m_min_lifetime = -1;
+  float m_min_decayTime = -1;
 
-  float m_max_lifetime = -1;
+  float m_max_decayTime = -1;
+
+  float m_min_decayLength = -1;
+
+  float m_max_decayLength = -1;
 
   float m_track_pt = -1;
 
@@ -156,6 +160,7 @@ class KFParticle_Tools : public KFParticle_particleList, protected KFParticle_MV
   void removeDuplicates(std::vector<int> &v);
   void removeDuplicates(std::vector<std::vector<int>> &v);
   void removeDuplicates(std::vector<std::vector<std::string>> &v);
+
 };
 
 #endif  //KFPARTICLESPHENIX_KFPARTICLETOOLS_H

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -473,10 +473,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
 
     m_calculated_mother_decaytime /= speedOfLight;
     m_calculated_mother_decaytime_err /= speedOfLight; 
-  }
 
-  if (m_constrain_to_vertex_nTuple)
-  {
     m_calculated_vertex_x = vertex.GetX();
     m_calculated_vertex_y = vertex.GetY();
     m_calculated_vertex_z = vertex.GetZ();

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -64,14 +64,6 @@ KFParticle_sPHENIX::KFParticle_sPHENIX(const std::string &name)
 
 int KFParticle_sPHENIX::Init(PHCompositeNode *topNode)
 {
-/*
-  if (m_save_output)
-  {
-    m_outfile = new TFile(m_outfile_name.c_str(), "RECREATE");
-    if (Verbosity() >= VERBOSITY_SOME) std::cout << "Output nTuple: " << m_outfile_name << std::endl;
-    initializeBranches();
-  }
-*/
   if (m_save_output && Verbosity() >= VERBOSITY_SOME) std::cout << "Output nTuple: " << m_outfile_name << std::endl;
 
   if (m_save_dst) createParticleNode(topNode);
@@ -149,7 +141,7 @@ int KFParticle_sPHENIX::End(PHCompositeNode *topNode)
 {
   std::cout << "KFParticle_sPHENIX object " << Name() << " finished. Number of canadidates: " << candidateCounter << std::endl;  
 
-  if (m_save_output)
+  if (m_save_output && candidateCounter != 0)
   {
     m_outfile->Write();
     m_outfile->Close();

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -134,9 +134,21 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMaximumMass(float max_mass) { m_max_mass = max_mass; }
 
-  void setMinimumLifetime(float min_lifetime) { m_min_lifetime = min_lifetime; }
+  //void setMinimumLifetime(float min_lifetime) { m_min_lifetime = min_lifetime; }
 
-  void setMaximumLifetime(float max_lifetime) { m_max_lifetime = max_lifetime; }
+  //void setMaximumLifetime(float max_lifetime) { m_max_lifetime = max_lifetime; }
+
+  void setDecayTimeRange(float min_decayTime, float max_decayTime)
+  {
+    m_min_decayTime = min_decayTime; 
+    m_max_decayTime = max_decayTime; 
+  }
+
+  void setDecayLengthRange(float min_decayLength, float max_decayLength)
+  {
+    m_min_decayLength = min_decayLength; 
+    m_max_decayLength = max_decayLength; 
+  }
 
   void setMinimumTrackPT(float pt) { m_track_pt = pt; }
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -85,6 +85,12 @@ void KFParticle_truthAndDetTools::initializeTruthBranches(TTree *m_tree, int dau
   m_tree->Branch(TString(daughter_number) + "_true_p", &m_true_daughter_p[daughter_id], TString(daughter_number) + "_true_p/F");
   m_tree->Branch(TString(daughter_number) + "_true_pT", &m_true_daughter_pt[daughter_id], TString(daughter_number) + "_true_pT/F");
   m_tree->Branch(TString(daughter_number) + "_true_ID", &m_true_daughter_id[daughter_id], TString(daughter_number) + "_true_ID/I");
+  if (m_constrain_to_vertex_truthMatch)
+  {
+    m_tree->Branch(TString(daughter_number) + "_true_PV_x", &m_true_daughter_pv_x[daughter_id], TString(daughter_number) + "_true_pv_x/F");
+    m_tree->Branch(TString(daughter_number) + "_true_PV_y", &m_true_daughter_pv_y[daughter_id], TString(daughter_number) + "_true_pv_y/F");
+    m_tree->Branch(TString(daughter_number) + "_true_PV_z", &m_true_daughter_pv_z[daughter_id], TString(daughter_number) + "_true_pv_x/F");
+  }
 }
 
 void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTree *m_tree, KFParticle daughter, int daughter_id, KFParticle vertex, bool m_constrain_to_vertex_truthMatch)
@@ -197,6 +203,10 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
 
     m_true_daughter_ip[daughter_id] = trueKFParticle.GetDistanceFromVertex(trueKFParticleVertex);
     m_true_daughter_ip_xy[daughter_id] = trueKFParticle.GetDistanceFromVertexXY(trueKFParticleVertex);
+
+    m_true_daughter_pv_x[daughter_id] = truePoint == NULL ? -99. : truePoint->get_x();
+    m_true_daughter_pv_y[daughter_id] = truePoint == NULL ? -99. : truePoint->get_y();
+    m_true_daughter_pv_z[daughter_id] = truePoint == NULL ? -99. : truePoint->get_z();
 
   }
 }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
@@ -69,6 +69,9 @@ class KFParticle_truthAndDetTools
   float m_true_daughter_p[max_tracks] = {0};
   float m_true_daughter_pt[max_tracks] = {0};
   int m_true_daughter_id[max_tracks] = {0};
+  float m_true_daughter_pv_x[max_tracks] = {0};
+  float m_true_daughter_pv_y[max_tracks] = {0};
+  float m_true_daughter_pv_z[max_tracks] = {0};
 
   std::vector<float> detector_local_x[max_tracks];  // 7 subdetector including outer and inner hcal plus 4th tracker
   std::vector<float> detector_local_y[max_tracks];


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

A user requested the true PV info for each track which has been added to the nTuple

I improved the mother/PV selection to work on the lower IP chi2 for each mother

I fixed a bug in the DIRA. I had taken the absolute value which allowed the momentum and flight vectors to point in opposite directions. This led to strange effects in distributions such as the decay time and decay length.

[comment]: <> (Please tell us something about this pull request)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

## TODOs (if applicable)

Discuss with HFTG about adding calo information to selection and where this should go.

Figure out mother truth matching

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

