### PR TITLE
Add constituent tracing for truth-based fast tracking tracks

### DIFF
--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -22,6 +22,7 @@ pkginclude_HEADERS = \
   SvtxTrack.h \
   SvtxTrack_v1.h \
   SvtxTrack_FastSim.h \
+  SvtxTrack_FastSim_v1.h \
   SvtxTrackMap.h \
   SvtxTrackMap_v1.h \
   SvtxTrackState.h \
@@ -37,6 +38,7 @@ ROOTDICTS = \
   SvtxTrackState_v1_Dict.cc \
   SvtxTrack_v1_Dict.cc \
   SvtxTrack_FastSim_Dict.cc \
+  SvtxTrack_FastSim_v1_Dict.cc \
   SvtxTrackMap_Dict.cc \
   SvtxTrackMap_v1_Dict.cc \
   SvtxVertex_Dict.cc \
@@ -51,6 +53,7 @@ nobase_dist_pcm_DATA = \
   SvtxTrackState_v1_Dict_rdict.pcm \
   SvtxTrack_v1_Dict_rdict.pcm \
   SvtxTrack_FastSim_Dict_rdict.pcm \
+  SvtxTrack_FastSim_v1_Dict_rdict.pcm \
   SvtxTrackMap_Dict_rdict.pcm \
   SvtxTrackMap_v1_Dict_rdict.pcm \
   SvtxVertex_Dict_rdict.pcm \
@@ -64,6 +67,7 @@ libtrackbase_historic_io_la_SOURCES = \
   SvtxTrackState_v1.cc \
   SvtxTrack_v1.cc \
   SvtxTrack_FastSim.cc \
+  SvtxTrack_FastSim_v1.cc \
   SvtxTrackMap_v1.cc \
   SvtxVertex_v1.cc \
   SvtxVertexMap_v1.cc

--- a/offline/packages/trackbase_historic/SvtxTrack.h
+++ b/offline/packages/trackbase_historic/SvtxTrack.h
@@ -5,6 +5,7 @@
 
 #include <trackbase/TrkrDefs.h>
 
+#include <g4main/PHG4HitDefs.h>
 #include <phool/PHObject.h>
 
 #include <limits.h>
@@ -56,9 +57,6 @@ class SvtxTrack : public PHObject
 
   virtual unsigned int get_vertex_id() const { return UINT_MAX; }
   virtual void set_vertex_id(unsigned int vertex_id) {}
-
-  virtual unsigned int get_truth_track_id() const { return UINT_MAX; }
-  virtual void set_truth_track_id(unsigned int truthTrackId) {}
 
   virtual bool get_positive_charge() const { return false; }
   virtual void set_positive_charge(bool ispos) {}
@@ -216,6 +214,39 @@ class SvtxTrack : public PHObject
 
   virtual float get_cal_cluster_e(CAL_LAYER layer) const { return 0.; }
   virtual void set_cal_cluster_e(CAL_LAYER layer, float e) {}
+
+  //
+  // truth track interface ---------------------------------------------------
+  //
+
+  //SvtxTrack_FastSim
+  virtual unsigned int get_truth_track_id() const { return UINT_MAX; }
+  virtual void set_truth_track_id(unsigned int truthTrackId) {}
+  virtual void set_num_measurements(int nmeas) {}
+  virtual unsigned int get_num_measurements() { return 0; }
+
+  //SvtxTrack_FastSim_v1
+  typedef std::map<int, std::set<PHG4HitDefs::keytype> > HitIdMap;
+  typedef HitIdMap::iterator HitIdIter;
+  typedef HitIdMap::const_iterator HitIdConstIter;
+
+  virtual bool empty_g4hit_id() const { return true; }
+  virtual size_t size_g4hit_id() const { return 0; }
+  virtual void add_g4hit_id(int volume, PHG4HitDefs::keytype id) {}
+  virtual HitIdIter begin_g4hit_id() { return HitIdMap().end(); }
+  virtual HitIdConstIter begin_g4hit_id() const { return HitIdMap().end(); }
+  virtual HitIdIter find_g4hit_id(int volume) { return HitIdMap().end(); }
+  virtual HitIdConstIter find_g4hit_id(int volume) const { return HitIdMap().end(); }
+  virtual HitIdIter end_g4hit_id() { return HitIdMap().end(); }
+  virtual HitIdConstIter end_g4hit_id() const { return HitIdMap().end(); }
+  virtual size_t remove_g4hit_id(int volume, PHG4HitDefs::keytype id) { return 0; }
+  virtual size_t remove_g4hit_volume(int volume) { return 0; }
+  virtual void clear_g4hit_id() {}
+  virtual const HitIdMap& g4hit_ids() const
+  {
+    static const HitIdMap map;
+    return map;
+  };
 
  protected:
   SvtxTrack() {}

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim.cc
@@ -28,7 +28,7 @@ SvtxTrack_FastSim::~SvtxTrack_FastSim()
 void SvtxTrack_FastSim::identify(std::ostream& os) const
 {
   os << "SvtxTrack_FastSim Object ";
-  os << "truth_track_id:" << get_truth_track_id() << endl;
+  os << "truth_track_id:" << get_truth_track_id();
   os << "id: " << get_id() << " ";
   os << "charge: " << get_charge() << " ";
   os << "chisq: " << get_chisq() << " ndf:" << get_ndf() << " ";
@@ -51,8 +51,8 @@ void SvtxTrack_FastSim::identify(std::ostream& os) const
       unsigned int cluster_id = *iter;
       os << cluster_id << " ";
     }
+    os << endl;
   }
-  os << endl;
 
   return;
 }

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.cc
@@ -1,0 +1,49 @@
+/*
+ * SvtxTrack_FastSim_v1.C
+ *
+ *  Created on: Jul 28, 2016
+ *      Author: yuhw
+ */
+
+#include "SvtxTrack_FastSim_v1.h"
+
+#include "SvtxTrack.h"  // for SvtxTrack::ConstClusterIter, SvtxTrack
+
+#include <climits>
+#include <map>          // for _Rb_tree_const_iterator
+#include <ostream>      // for operator<<, basic_ostream, basic_ostream<>::_...
+
+using namespace std;
+
+SvtxTrack_FastSim_v1::SvtxTrack_FastSim_v1()
+{
+}
+
+SvtxTrack_FastSim_v1::~SvtxTrack_FastSim_v1()
+{
+}
+
+void SvtxTrack_FastSim_v1::identify(std::ostream& os) const
+{
+  SvtxTrack_FastSim::identify(os);
+
+  os << "G4Hit IDs" << endl;
+  for (std::map<int, std::set<PHG4HitDefs::keytype> >::const_iterator iter =
+           _g4hit_ids.begin();
+       iter != _g4hit_ids.end(); ++iter)
+  {
+    for (std::set<PHG4HitDefs::keytype>::const_iterator jter =
+             iter->second.begin();
+         jter != iter->second.end(); ++jter)
+    {
+      os << *jter << " ";
+    }
+  }
+  os << endl;
+  return;
+}
+
+int SvtxTrack_FastSim_v1::isValid() const
+{
+  return 1;
+}

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.cc
@@ -10,8 +10,8 @@
 #include "SvtxTrack.h"  // for SvtxTrack::ConstClusterIter, SvtxTrack
 
 #include <climits>
-#include <map>          // for _Rb_tree_const_iterator
-#include <ostream>      // for operator<<, basic_ostream, basic_ostream<>::_...
+#include <map>      // for _Rb_tree_const_iterator
+#include <ostream>  // for operator<<, basic_ostream, basic_ostream<>::_...
 
 using namespace std;
 
@@ -27,19 +27,18 @@ void SvtxTrack_FastSim_v1::identify(std::ostream& os) const
 {
   SvtxTrack_FastSim::identify(os);
 
-  os << "G4Hit IDs" << endl;
+  os << "G4Hit IDs:" << endl;
   for (std::map<int, std::set<PHG4HitDefs::keytype> >::const_iterator iter =
            _g4hit_ids.begin();
        iter != _g4hit_ids.end(); ++iter)
   {
-    for (std::set<PHG4HitDefs::keytype>::const_iterator jter =
-             iter->second.begin();
-         jter != iter->second.end(); ++jter)
+    os << "\thit container ID" << iter->first << " with hits: ";
+    for (std::set<PHG4HitDefs::keytype>::const_iterator jter = iter->second.begin(); jter != iter->second.end(); ++jter)
     {
       os << *jter << " ";
     }
+    os << endl;
   }
-  os << endl;
   return;
 }
 

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.h
@@ -1,0 +1,43 @@
+/*
+ * SvtxTrack_FastSim_v1.h
+ */
+
+#ifndef TRACKBASEHISTORIC_SVTXTRACKFASTSIMV1_H
+#define TRACKBASEHISTORIC_SVTXTRACKFASTSIMV1_H
+
+#include "SvtxTrack_FastSim.h"
+
+// SvtxTrack_FastSim with recording of associated G4hits
+class SvtxTrack_FastSim_v1 : public SvtxTrack_FastSim
+{
+ public:
+  SvtxTrack_FastSim_v1();
+  virtual ~SvtxTrack_FastSim_v1();
+
+  // The "standard PHObject response" functions...
+  void identify(std::ostream& os = std::cout) const;
+  void Reset() { *this = SvtxTrack_FastSim_v1(); }
+  int isValid() const;
+  PHObject* CloneMe() const { return new SvtxTrack_FastSim_v1(*this); }
+
+  bool empty_g4hit_id() const { return _g4hit_ids.empty(); }
+  size_t size_g4hit_id() const { return _g4hit_ids.size(); }
+  void add_g4hit_id(int volume, PHG4HitDefs::keytype id) { _g4hit_ids[volume].insert(id); }
+  SvtxTrack::HitIdIter begin_g4hit_id() { return _g4hit_ids.begin(); }
+  SvtxTrack::HitIdConstIter begin_g4hit_id() const { return _g4hit_ids.begin(); }
+  SvtxTrack::HitIdIter find_g4hit_id(int volume) { return _g4hit_ids.find(volume); }
+  SvtxTrack::HitIdConstIter find_g4hit_id(int volume) const { return _g4hit_ids.find(volume); }
+  SvtxTrack::HitIdIter end_g4hit_id() { return _g4hit_ids.end(); }
+  SvtxTrack::HitIdConstIter end_g4hit_id() const { return _g4hit_ids.end(); }
+  size_t remove_g4hit_id(int volume, PHG4HitDefs::keytype id) { return _g4hit_ids[volume].erase(id); }
+  size_t remove_g4hit_volume(int volume) { return _g4hit_ids.erase(volume); }
+  void clear_g4hit_id() { return _g4hit_ids.clear(); }
+  const HitIdMap& g4hit_ids() const { return _g4hit_ids; }
+
+ private:
+  HitIdMap _g4hit_ids;  //< contained hit ids
+
+  ClassDef(SvtxTrack_FastSim_v1, 1)
+};
+
+#endif /* __SVTXTRACK_FAST_SIMV1_H__ */

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxTrack_FastSim_v1 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxTrack_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v1.h
@@ -7,10 +7,10 @@
 #include <trackbase/TrkrDefs.h>
 
 #include <cmath>
-#include <cstddef>              // for size_t
+#include <cstddef>  // for size_t
 #include <iostream>
 #include <map>
-#include <utility>               // for pair
+#include <utility>  // for pair
 
 class PHObject;
 
@@ -155,9 +155,9 @@ class SvtxTrack_v1 : public SvtxTrack
   ConstClusterKeyIter find_cluster_key(TrkrDefs::cluskey clusterid) const { return _cluster_keys.find(clusterid); }
   ConstClusterKeyIter begin_cluster_keys() const { return _cluster_keys.begin(); }
   ConstClusterKeyIter end_cluster_keys() const { return _cluster_keys.end(); }
-  ClusterKeyIter find_cluster_key(TrkrDefs::cluskey clusterid) { return _cluster_keys.find(clusterid); }
+  ClusterKeyIter find_cluster_keys(unsigned int clusterid) { return _cluster_keys.find(clusterid); }
   ClusterKeyIter begin_cluster_keys() { return _cluster_keys.begin(); }
-  ClusterKeyIter end_cluster_keys()  { return _cluster_keys.end(); }
+  ClusterKeyIter end_cluster_keys() { return _cluster_keys.end(); }
 
   //
   // calo projection methods ---------------------------------------------------
@@ -202,7 +202,6 @@ class SvtxTrack_v1 : public SvtxTrack
   float _dca3d_z_error;
 
   // extended track information (primary tracks only)
-
 
   // track state information
   StateMap _states;  //< path length => state object

--- a/simulation/g4simulation/g4trackfastsim/Makefile.am
+++ b/simulation/g4simulation/g4trackfastsim/Makefile.am
@@ -23,7 +23,8 @@ libg4trackfastsim_la_LIBADD = \
   -lPHGenFit \
   -lphgeom \
   -lphg4hit \
-  -ltrackbase_historic_io
+  -ltrackbase_historic_io \
+  -lphparameter
 
 pkginclude_HEADERS = \
   PHG4TrackFastSim.h \

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -579,16 +579,21 @@ int PHG4TrackFastSim::CreateNodes(PHCompositeNode* topNode)
   //	if (Verbosity() > 0)
   //		cout << _clustermap_out_name <<" node added" << endl;
 
-  m_SvtxTrackMapOut = new SvtxTrackMap_v1;
-
-  PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(m_SvtxTrackMapOut, m_TrackmapOutNodeName, "PHObject");
-  tb_node->addNode(tracks_node);
-  if (Verbosity() > 0)
+  m_SvtxTrackMapOut = findNode::getClass<SvtxTrackMap>(topNode, m_TrackmapOutNodeName);
+  if (!m_SvtxTrackMapOut)
   {
-    cout << m_TrackmapOutNodeName << " node added" << endl;
+    m_SvtxTrackMapOut = new SvtxTrackMap_v1;
+
+    PHIODataNode<PHObject>* tracks_node = new PHIODataNode<PHObject>(m_SvtxTrackMapOut, m_TrackmapOutNodeName, "PHObject");
+    tb_node->addNode(tracks_node);
+    if (Verbosity() > 0)
+    {
+      cout << m_TrackmapOutNodeName << " node added" << endl;
+    }
   }
 
-  if (m_DoVertexingFlag)
+  m_SvtxVertexMap = findNode::getClass<SvtxVertexMap_v1>(topNode, "SvtxVertexMap");
+  if (not m_SvtxVertexMap)
   {
     m_SvtxVertexMap = new SvtxVertexMap_v1;
     PHIODataNode<PHObject>* vertexes_node = new PHIODataNode<PHObject>(m_SvtxVertexMap, "SvtxVertexMap", "PHObject");

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -35,6 +35,7 @@ class SvtxTrackMap;
 class SvtxVertexMap;
 class PHCompositeNode;
 class PHG4TruthInfoContainer;
+class PHParameters;
 
 namespace PHGenFit
 {
@@ -271,6 +272,8 @@ class PHG4TrackFastSim : public SubsysReco
   bool FillSvtxVertexMap(const std::vector<genfit::GFRaveVertex*>& rave_vertices,
                          const GenFitTrackMap& gf_tracks);
 
+ protected:
+
   // Pointers first
   //! random generator that conform with sPHENIX standard
   gsl_rng* m_RandomGenerator;
@@ -337,6 +340,8 @@ class PHG4TrackFastSim : public SubsysReco
   int m_PrimaryTrackingFlag;
 
   bool m_DoVertexingFlag;
+
+  PHParameters * m_Parameter = nullptr;
 };
 
 #endif /*__PHG4TrackFastSim_H__*/

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <memory>
 
 class PHG4Hit;
 class PHG4HitContainer;
@@ -248,6 +249,7 @@ class PHG4TrackFastSim : public SubsysReco
 	 */
   int PseudoPatternRecognition(const PHG4Particle* particle,
                                std::vector<PHGenFit::Measurement*>& meas_out,
+                               SvtxTrack* track_out,
                                TVector3& seed_pos,
                                TVector3& seed_mom,
                                TMatrixDSym& seed_cov,
@@ -262,9 +264,9 @@ class PHG4TrackFastSim : public SubsysReco
   /*!
 	 * Make SvtxTrack from PHGenFit::Track
 	 */
-  SvtxTrack* MakeSvtxTrack(const PHGenFit::Track* phgf_track_in,
-                           const unsigned int truth_track_id = UINT_MAX,
-                           const unsigned int nmeas = 0, const TVector3& vtx = TVector3(0.0, 0.0, 0.0));
+  bool MakeSvtxTrack(SvtxTrack* track_out, const PHGenFit::Track* phgf_track_in,
+                     const unsigned int truth_track_id = UINT_MAX,
+                     const unsigned int nmeas = 0, const TVector3& vtx = TVector3(0.0, 0.0, 0.0));
 
   /*
   * Fill SvtxVertexMap from GFRaveVertexes and Tracks
@@ -273,7 +275,6 @@ class PHG4TrackFastSim : public SubsysReco
                          const GenFitTrackMap& gf_tracks);
 
  protected:
-
   // Pointers first
   //! random generator that conform with sPHENIX standard
   gsl_rng* m_RandomGenerator;
@@ -341,7 +342,7 @@ class PHG4TrackFastSim : public SubsysReco
 
   bool m_DoVertexingFlag;
 
-  PHParameters * m_Parameter = nullptr;
+  PHParameters* m_Parameter = nullptr;
 };
 
 #endif /*__PHG4TrackFastSim_H__*/

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -19,6 +19,9 @@
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <g4main/PHG4VtxPoint.h>
 
+#include <pdbcalbase/PdbParameterMap.h>
+#include <phparameter/PHParameters.h>
+
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/PHTFileServer.h>
 #include <fun4all/SubsysReco.h>  // for SubsysReco
@@ -71,58 +74,6 @@ PHG4TrackFastSimEval::PHG4TrackFastSimEval(const string &name, const string &fil
 //----------------------------------------------------------------------------//
 int PHG4TrackFastSimEval::Init(PHCompositeNode *topNode)
 {
-  cout << PHWHERE << " Openning file " << m_OutFileName << endl;
-  PHTFileServer::get().open(m_OutFileName, "RECREATE");
-
-  // create TTree
-  m_TracksEvalTree = new TTree("tracks", "FastSim Eval => tracks");
-  m_TracksEvalTree->Branch("event", &m_TTree_Event, "event/I");
-  m_TracksEvalTree->Branch("gtrackID", &m_TTree_gTrackID, "gtrackID/I");
-  m_TracksEvalTree->Branch("gflavor", &m_TTree_gFlavor, "gflavor/I");
-  m_TracksEvalTree->Branch("gpx", &m_TTree_gpx, "gpx/F");
-  m_TracksEvalTree->Branch("gpy", &m_TTree_gpy, "gpy/F");
-  m_TracksEvalTree->Branch("gpz", &m_TTree_gpz, "gpz/F");
-  m_TracksEvalTree->Branch("gvx", &m_TTree_gvx, "gvx/F");
-  m_TracksEvalTree->Branch("gvy", &m_TTree_gvy, "gvy/F");
-  m_TracksEvalTree->Branch("gvz", &m_TTree_gvz, "gvz/F");
-  m_TracksEvalTree->Branch("gvt", &m_TTree_gvt, "gvt/F");
-  m_TracksEvalTree->Branch("trackID", &m_TTree_TrackID, "trackID/I");
-  m_TracksEvalTree->Branch("charge", &m_TTree_Charge, "charge/I");
-  m_TracksEvalTree->Branch("nhits", &m_TTree_nHits, "nhits/I");
-  m_TracksEvalTree->Branch("px", &m_TTree_px, "px/F");
-  m_TracksEvalTree->Branch("py", &m_TTree_py, "py/F");
-  m_TracksEvalTree->Branch("pz", &m_TTree_pz, "pz/F");
-  m_TracksEvalTree->Branch("pcax", &m_TTree_pcax, "pcax/F");
-  m_TracksEvalTree->Branch("pcay", &m_TTree_pcay, "pcay/F");
-  m_TracksEvalTree->Branch("pcaz", &m_TTree_pcaz, "pcaz/F");
-  m_TracksEvalTree->Branch("dca2d", &m_TTree_dca2d, "dca2d/F");
-
-  m_H2D_DeltaMomVsTruthEta = new TH2D("DeltaMomVsTruthEta",
-                                      "#frac{#Delta p}{truth p} vs. truth #eta", 54, -4.5, +4.5, 1000, -1,
-                                      1);
-
-  m_H2D_DeltaMomVsTruthMom = new TH2D("DeltaMomVsTruthMom",
-                                      "#frac{#Delta p}{truth p} vs. truth p", 41, -0.5, 40.5, 1000, -1,
-                                      1);
-
-  // create TTree - vertex
-  m_VertexEvalTree = new TTree("vertex", "FastSim Eval => vertces");
-  m_VertexEvalTree->Branch("event", &m_TTree_Event, "event/I");
-  m_VertexEvalTree->Branch("gvx", &m_TTree_gvx, "gvx/F");
-  m_VertexEvalTree->Branch("gvy", &m_TTree_gvy, "gvy/F");
-  m_VertexEvalTree->Branch("gvz", &m_TTree_gvz, "gvz/F");
-  m_VertexEvalTree->Branch("gvt", &m_TTree_gvt, "gvt/F");
-  m_VertexEvalTree->Branch("vx", &m_TTree_vx, "vx/F");
-  m_VertexEvalTree->Branch("vy", &m_TTree_vy, "vy/F");
-  m_VertexEvalTree->Branch("vz", &m_TTree_vz, "vz/F");
-  m_VertexEvalTree->Branch("deltavx", &m_TTree_DeltaVx, "deltavx/F");
-  m_VertexEvalTree->Branch("deltavy", &m_TTree_DeltaVy, "deltavy/F");
-  m_VertexEvalTree->Branch("deltavz", &m_TTree_DeltaVz, "deltavz/F");
-  m_VertexEvalTree->Branch("gID", &m_TTree_gTrackID, "gID/I");
-  m_VertexEvalTree->Branch("ID", &m_TTree_TrackID, "ID/I");
-  m_VertexEvalTree->Branch("ntracks", &m_TTree_nTracks, "ntracks/I");
-  m_VertexEvalTree->Branch("n_from_truth", &m_TTree_nFromTruth, "n_from_truth/I");
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -177,6 +128,95 @@ int PHG4TrackFastSimEval::InitRun(PHCompositeNode *topNode)
       cout << "InitRun: could not find " << nodename << endl;
     }
   }
+
+  if (Verbosity())
+    cout << PHWHERE << " Openning file " << m_OutFileName << endl;
+  PHTFileServer::get().open(m_OutFileName, "RECREATE");
+
+  // create TTree
+  m_TracksEvalTree = new TTree("tracks", "FastSim Eval => tracks");
+  m_TracksEvalTree->Branch("event", &m_TTree_Event, "event/I");
+  m_TracksEvalTree->Branch("gtrackID", &m_TTree_gTrackID, "gtrackID/I");
+  m_TracksEvalTree->Branch("gflavor", &m_TTree_gFlavor, "gflavor/I");
+  m_TracksEvalTree->Branch("gpx", &m_TTree_gpx, "gpx/F");
+  m_TracksEvalTree->Branch("gpy", &m_TTree_gpy, "gpy/F");
+  m_TracksEvalTree->Branch("gpz", &m_TTree_gpz, "gpz/F");
+  m_TracksEvalTree->Branch("gvx", &m_TTree_gvx, "gvx/F");
+  m_TracksEvalTree->Branch("gvy", &m_TTree_gvy, "gvy/F");
+  m_TracksEvalTree->Branch("gvz", &m_TTree_gvz, "gvz/F");
+  m_TracksEvalTree->Branch("gvt", &m_TTree_gvt, "gvt/F");
+  m_TracksEvalTree->Branch("trackID", &m_TTree_TrackID, "trackID/I");
+  m_TracksEvalTree->Branch("charge", &m_TTree_Charge, "charge/I");
+  m_TracksEvalTree->Branch("nhits", &m_TTree_nHits, "nhits/I");
+  m_TracksEvalTree->Branch("px", &m_TTree_px, "px/F");
+  m_TracksEvalTree->Branch("py", &m_TTree_py, "py/F");
+  m_TracksEvalTree->Branch("pz", &m_TTree_pz, "pz/F");
+  m_TracksEvalTree->Branch("pcax", &m_TTree_pcax, "pcax/F");
+  m_TracksEvalTree->Branch("pcay", &m_TTree_pcay, "pcay/F");
+  m_TracksEvalTree->Branch("pcaz", &m_TTree_pcaz, "pcaz/F");
+  m_TracksEvalTree->Branch("dca2d", &m_TTree_dca2d, "dca2d/F");
+
+  // next a stat. on hits
+  PHParameters PHG4TrackFastSim_Parameter("PHG4TrackFastSim");
+
+  PdbParameterMap *nodeparams = findNode::getClass<PdbParameterMap>(topNode,
+                                                                    "PHG4TrackFastSim_Parameter");
+  if (not nodeparams)
+  {
+    cout << __PRETTY_FUNCTION__ << " : Warning, missing PHG4TrackFastSim_Parameter node and skip saving hits"
+         << endl;
+  }
+  else
+  {
+    PHG4TrackFastSim_Parameter.FillFrom(nodeparams);
+    if (Verbosity())
+    {
+      cout << __PRETTY_FUNCTION__ << " PHG4TrackFastSim_Parameter : ";
+      PHG4TrackFastSim_Parameter.Print();
+    }
+
+    auto range = PHG4TrackFastSim_Parameter.get_all_int_params();
+    for (auto iter = range.first; iter != range.second; ++iter)
+    {
+      const string &phg4hit_node_name = iter->first;
+      const int &phg4hit_node_id = iter->second;
+
+      cout << __PRETTY_FUNCTION__ << " Prepare PHG4Hit node name " << phg4hit_node_name
+           << " with ID = " << phg4hit_node_id << endl;
+
+      string branch_name = string("nHit_") + phg4hit_node_name;
+      m_TracksEvalTree->Branch(branch_name.c_str(),
+                               &m_TTree_HitContainerID_nHits_map[phg4hit_node_id],
+                               (branch_name + "/I").c_str());
+    }
+  }
+
+  m_H2D_DeltaMomVsTruthEta = new TH2D("DeltaMomVsTruthEta",
+                                      "#frac{#Delta p}{truth p} vs. truth #eta", 54, -4.5, +4.5, 1000, -1,
+                                      1);
+
+  m_H2D_DeltaMomVsTruthMom = new TH2D("DeltaMomVsTruthMom",
+                                      "#frac{#Delta p}{truth p} vs. truth p", 41, -0.5, 40.5, 1000, -1,
+                                      1);
+
+  // create TTree - vertex
+  m_VertexEvalTree = new TTree("vertex", "FastSim Eval => vertces");
+  m_VertexEvalTree->Branch("event", &m_TTree_Event, "event/I");
+  m_VertexEvalTree->Branch("gvx", &m_TTree_gvx, "gvx/F");
+  m_VertexEvalTree->Branch("gvy", &m_TTree_gvy, "gvy/F");
+  m_VertexEvalTree->Branch("gvz", &m_TTree_gvz, "gvz/F");
+  m_VertexEvalTree->Branch("gvt", &m_TTree_gvt, "gvt/F");
+  m_VertexEvalTree->Branch("vx", &m_TTree_vx, "vx/F");
+  m_VertexEvalTree->Branch("vy", &m_TTree_vy, "vy/F");
+  m_VertexEvalTree->Branch("vz", &m_TTree_vz, "vz/F");
+  m_VertexEvalTree->Branch("deltavx", &m_TTree_DeltaVx, "deltavx/F");
+  m_VertexEvalTree->Branch("deltavy", &m_TTree_DeltaVy, "deltavy/F");
+  m_VertexEvalTree->Branch("deltavz", &m_TTree_DeltaVz, "deltavz/F");
+  m_VertexEvalTree->Branch("gID", &m_TTree_gTrackID, "gID/I");
+  m_VertexEvalTree->Branch("ID", &m_TTree_TrackID, "ID/I");
+  m_VertexEvalTree->Branch("ntracks", &m_TTree_nTracks, "ntracks/I");
+  m_VertexEvalTree->Branch("n_from_truth", &m_TTree_nFromTruth, "n_from_truth/I");
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -243,12 +283,10 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
 
   PHG4TruthInfoContainer::ConstRange range =
       m_TruthInfoContainer->GetPrimaryParticleRange();
-  //std::cout << "A2" << std::endl;
   for (PHG4TruthInfoContainer::ConstIterator truth_itr = range.first;
        truth_itr != range.second; ++truth_itr)
   {
     reset_variables();
-    //std::cout << "A1" << std::endl;
     m_TTree_Event = m_EventCounter;
 
     PHG4Particle *g4particle = truth_itr->second;
@@ -257,7 +295,6 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
       LogDebug("");
       continue;
     }
-    //std::cout << "B1" << std::endl;
 
     SvtxTrack_FastSim *track = nullptr;
 
@@ -377,13 +414,24 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
             }
           }
         }
+      }  // find projections
+
+      // find number of hits
+      for (const auto &g4hit_id_hitset : track->g4hit_ids())
+      {
+        const int &g4hit_id = g4hit_id_hitset.first;
+        const set<PHG4HitDefs::keytype> &g4hit_set = g4hit_id_hitset.second;
+        //
+        auto nhit_iter = m_TTree_HitContainerID_nHits_map.find(g4hit_id);
+        assert(nhit_iter != m_TTree_HitContainerID_nHits_map.end());
+        //
+        nhit_iter->second = g4hit_set.size();
       }
-    }
-    //std::cout << "B3" << std::endl;
+
+    }  //     if (track)
 
     m_TracksEvalTree->Fill();
-  }
-  //std::cout << "A3" << std::endl;
+  }  // PHG4TruthInfoContainer::ConstRange range =   m_TruthInfoContainer->GetPrimaryParticleRange();
 
   return;
 }

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
@@ -110,6 +110,8 @@ class PHG4TrackFastSimEval : public SubsysReco
   float m_TTree_pcaz;
   float m_TTree_dca2d;
 
+  std::map<int, int> m_TTree_HitContainerID_nHits_map;
+
   //vertex
   float m_TTree_vx;
   float m_TTree_vy;
@@ -134,6 +136,7 @@ class PHG4TrackFastSimEval : public SubsysReco
   // hits on reference cylinders and planes
   std::vector<std::vector<float>> m_TTree_ref_vec;
   std::vector<std::vector<float>> m_TTree_ref_p_vec;
+
 };
 
 #endif  //* G4TRACKFASTSIM_PHG4TRACKFASTSIMEVAL_H *//


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Following request by @FriederikeBock to introduce the constituent tracing for truth-based fast tracking tracks. 

- New version of `SvtxTrack_FastSim_v1` that associate truth-based fast tracking tracks to its constituent `PHG4Hit`s and containers. The format follow that of `PHG4Shower`
- Record the association in `PHG4TrackFastSim`
- Update the example evaluation analysis module `PHG4TrackFastSimEval` to output number of hit per PHG4HitContainer per track. Example output fast tracking ntuple from the default `Fun4All_G4_EICDetector.C` macro: 

```
root [10] tracks->Show(11)
======> EVENT:11
 event           = 3
 gtrackID        = 2
 gflavor         = -211
 gpx             = -1.93761
 gpy             = 10.1213
 gpz             = 29.2271
 gvx             = 0
 gvy             = 0
 gvz             = -3.13484
 gvt             = 0
 trackID         = 0
 charge          = -1
 nhits           = 0
 px              = -1.89241
 py              = 9.91173
 pz              = 28.6046
 pcax            = -0.0022374
 pcay            = -0.00645765
 pcaz            = -3.13613
 dca2d           = -0.00325268
 nHit_G4HIT_EGEM_0 = 1
 nHit_G4HIT_EGEM_1 = 1
 nHit_G4HIT_EGEM_2 = 1
 nHit_G4HIT_EGEM_3 = 1
 nHit_G4HIT_FGEM_2 = 1
 nHit_G4HIT_FGEM_3 = 1
 nHit_G4HIT_FGEM_4 = 1
 nHit_G4HIT_FST_0 = 1
 nHit_G4HIT_FST_1 = 0
 nHit_G4HIT_FST_2 = 0
 nHit_G4HIT_FST_3 = 0
 nHit_G4HIT_FST_4 = 0
```


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

