### PR TITLE
use TDatabasePDG instead of G4ParticleTable to get charge from PID

### DIFF
--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -30,8 +30,8 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
-#include <Geant4/G4ParticleDefinition.hh>
-#include <Geant4/G4ParticleTable.hh>
+#include <TDatabasePDG.h>
+#include <TParticlePDG.h>
 
 #include <cstdlib>   // for exit
 #include <iostream>  // for operator<<, endl
@@ -128,12 +128,11 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
      * having the proper track charge is necessary for the ACTS fit to work properly
      * with normal tracking, it is set by the track seeding. Here we get it from the G4Particle
      * unfortunately, particle charge is not stored into PHG4Particle.
-     * we need to retrieve it from geant4 particle table
+     * we need to retrieve it from TParticlePDG instead
      */
     {
-      const auto particleTable = G4ParticleTable::GetParticleTable();
-      const auto particledef = particleTable->FindParticle(g4particle->get_pid());
-      if( particledef ) svtx_track->set_charge(particledef->GetPDGCharge());
+      const auto particle = TDatabasePDG::Instance()->GetParticle(g4particle->get_pid());
+      if( particle ) svtx_track->set_charge(particle->Charge());
     }
 
     // Smear the truth values out by 5% so that the seed momentum and

--- a/offline/packages/trackreco/configure.ac
+++ b/offline/packages/trackreco/configure.ac
@@ -5,6 +5,17 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
+dnl leaving this here in case we want to play with different compiler 
+dnl specific flags
+dnl case $CXX in
+dnl  clang++)
+dnl   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+dnl  ;;
+dnl  g++)
+dnl   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+dnl  ;;
+dnl esac
+
 if test $ac_cv_prog_gxx = yes; then
      CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
@@ -20,11 +31,7 @@ case $CXX in
 dnl ACTS needs at least gcc 6
   AM_CONDITIONAL([MAKE_ACTS],test `g++ -dumpversion | awk '{print $1>=6.0?"1":"0"}'` = 1)
  ;;
- clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template"
- ;;
 esac
-
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 

--- a/offline/packages/trackreco/configure.ac
+++ b/offline/packages/trackreco/configure.ac
@@ -13,15 +13,15 @@ AM_CONDITIONAL([MAKE_ACTS],false)
 dnl gcc 8.3 creates warning in boost header, needs -Wno-class-memaccess
 dnl need to check for *g++ since $CXX contains full path to g++
 case $CXX in
- clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template"
- ;;
  *g++)
   if test `g++ -dumpversion | awk '{print $1>=8.3?"1":"0"}'` = 1; then
      CXXFLAGS="$CXXFLAGS -Wno-class-memaccess -Wno-unused-local-typedefs -Wno-sign-compare -Wno-switch -Wno-unused-function -Wno-unused-value"
   fi
 dnl ACTS needs at least gcc 6
   AM_CONDITIONAL([MAKE_ACTS],test `g++ -dumpversion | awk '{print $1>=6.0?"1":"0"}'` = 1)
+ ;;
+ clang++)
+   CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template"
  ;;
 esac
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

Using G4ParticleTable to get particle charge from pid might result in a crash of the macro, because G4ParticleTable might not be initialized at the time of the first call. This happens for instance when running reconstruction only modules on DSTs containing G4Hits.

Instead of figuring out what needs to be initialized to prevent the crash, use TDatabasePDG instead of G4ParticleTable to get charge from PID, as done in e.g. QA/modules/QAG4SimulationTracking.cc

At the same time, reverted the changes to configure.ac about warning suppression, since they have become (hopefully) unnecessary here.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

