### PR TITLE
Fix other instance of track.release memory leak

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -432,7 +432,7 @@ int PHSiliconTpcTrackMatching::Process()
 		  newTrack->identify();
 		}
 
-	      _track_map->insert(newTrack.release());
+	      _track_map->insert(newTrack.get());
 	 
 	    }
 	  


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This fixes a memory leak issue that was identified by valgrind also in PHActsSiliconSeeding. The same code is here, so we fix it to get rid of a mem leak in this module also.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

