### PR TITLE
TPC propagator cluster getter fix, and small ALICE KF update

### DIFF
--- a/offline/packages/trackreco/ALICEKF.cc
+++ b/offline/packages/trackreco/ALICEKF.cc
@@ -9,7 +9,7 @@
 #include "TFile.h"
 #include "TNtuple.h"
 
-#define _DEBUG_
+//#define _DEBUG_
 
 #if defined(_DEBUG_)
 #define LogDebug(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << exp

--- a/offline/packages/trackreco/ALICEKF.h
+++ b/offline/packages/trackreco/ALICEKF.h
@@ -4,6 +4,7 @@
 #include <trackbase_historic/SvtxTrack_v2.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrCluster.h>
 #include <phfield/PHField.h>
 #include <phfield/PHFieldUtility.h>
 
@@ -39,6 +40,14 @@ class ALICEKF
   bool checknan(double val, const std::string &msg, int num);
   double get_Bz(double x, double y, double z);
   void CircleFitByTaubin(std::vector<std::pair<double,double>> pts, double &R, double &X0, double &Y0);
+  void useConstBField(bool opt) {_use_const_field = opt;}
+  void useFixedClusterError(bool opt) {_use_fixed_clus_error = opt;}
+  void setFixedClusterError(int i,double val) {_fixed_clus_error.at(i)=val;}
+  double getClusterError(TrkrCluster* c, int i, int j);
+  void line_fit(std::vector<std::pair<double,double>> pts, double& a, double& b);
+  void line_fit_clusters(std::vector<TrkrCluster*> cls, double& a, double& b);
+  std::vector<double> GetCircleClusterResiduals(std::vector<std::pair<double,double>> pts, double R, double X0, double Y0);
+  std::vector<double> GetLineClusterResiduals(std::vector<std::pair<double,double>> pts, double A, double B); 
   private:
   PHField* _B;
   size_t _min_clusters_per_track = 20;
@@ -49,6 +58,8 @@ class ALICEKF
   double _fieldDir = -1;
   double _max_sin_phi = 1.;
   bool _use_const_field = false;
+  bool _use_fixed_clus_error = true;
+  std::array<double,3> _fixed_clus_error = {.1,.1,.1};
 };
 
 #endif

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -18,6 +18,7 @@
 
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrDefs.h>
 
 #include <g4detectors/PHG4CylinderCellGeom.h>
@@ -79,12 +80,18 @@ int PHSimpleKFProp::Setup(PHCompositeNode* topNode)
   int ret = get_nodes(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
   fitter = std::make_shared<ALICEKF>(topNode,_cluster_map,_fieldDir,_min_clusters_per_track,_max_sin_phi,Verbosity());
+  fitter->useConstBField(_use_const_field);
+  fitter->useFixedClusterError(_use_fixed_clus_err);
+  fitter->setFixedClusterError(0,_fixed_clus_err.at(0));
+  fitter->setFixedClusterError(1,_fixed_clus_err.at(1));
+  fitter->setFixedClusterError(2,_fixed_clus_err.at(2));
   _field_map = PHFieldUtility::GetFieldMapNode(nullptr,topNode);
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 double PHSimpleKFProp::get_Bz(double x, double y, double z)
 {
+  if(_use_const_field) return 1.4;
   double p[4] = {x*cm,y*cm,z*cm,0.*cm};
   double bfield[3];
   _field_map->GetFieldValue(p,bfield);
@@ -212,25 +219,31 @@ void PHSimpleKFProp::PrepareKDTrees()
     std::cout << "WARNING: (tracking.PHTpcTrackerUtil.convert_clusters_to_hits) cluster map is not provided" << endl;
     return;
   }
-  TrkrClusterContainer::ConstRange clusrange = _cluster_map->getClusters();
-  for (TrkrClusterContainer::ConstIterator it = clusrange.first; it != clusrange.second; ++it)
+  auto hitsetrange = _hitsets->getHitSets(TrkrDefs::TrkrId::tpcId);
+  for (auto hitsetitr = hitsetrange.first;
+       hitsetitr != hitsetrange.second;
+       ++hitsetitr)
   {
-    TrkrDefs::cluskey cluskey = it->first;
-    TrkrCluster* cluster = it->second;
-    int layer = TrkrDefs::getLayer(cluskey);
-    std::vector<double> kdhit(4);
-    kdhit[0] = cluster->getPosition(0);
-    kdhit[1] = cluster->getPosition(1);
-    kdhit[2] = cluster->getPosition(2);
-    uint64_t key = cluster->getClusKey();
-    std::memcpy(&kdhit[3], &key, sizeof(key));
+    auto range = _cluster_map->getClusters(hitsetitr->first);
+    for( auto it = range.first; it != range.second; ++it )
+    {
+      TrkrDefs::cluskey cluskey = it->first;
+      TrkrCluster* cluster = it->second;
+      int layer = TrkrDefs::getLayer(cluskey);
+      std::vector<double> kdhit(4);
+      kdhit[0] = cluster->getPosition(0);
+      kdhit[1] = cluster->getPosition(1);
+      kdhit[2] = cluster->getPosition(2);
+      uint64_t key = cluster->getClusKey();
+      std::memcpy(&kdhit[3], &key, sizeof(key));
     
-    //      HINT: way to get original uint64_t value from double:
-    //
-    //      LOG_DEBUG("tracking.PHTpcTrackerUtil.convert_clusters_to_hits")
-    //        << "orig: " << cluster->getClusKey() << ", readback: " << (*((int64_t*)&kdhit[3]));
+      //      HINT: way to get original uint64_t value from double:
+      //
+      //      LOG_DEBUG("tracking.PHTpcTrackerUtil.convert_clusters_to_hits")
+      //        << "orig: " << cluster->getClusKey() << ", readback: " << (*((int64_t*)&kdhit[3]));
 
-    kdhits[layer].push_back(kdhit);
+      kdhits[layer].push_back(kdhit);
+    }
   }
   _ptclouds.resize(kdhits.size());
   _kdtrees.resize(kdhits.size());

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -53,6 +53,9 @@ class PHSimpleKFProp : public PHTrackPropagating
       _fieldDir = -1;
   }
   void set_max_window(double s){_max_dist = s;}
+  void useConstBField(bool opt){_use_const_field = opt;}
+  void useFixedClusterError(bool opt){_use_fixed_clus_err = opt;}
+  void setFixedClusterError(int i, double val){_fixed_clus_err.at(i) = val;}
  protected:
   /// setup interface for trackers, called in InitRun, setup things like pointers to nodes.
   /// overrided in derived classes
@@ -130,6 +133,7 @@ class PHSimpleKFProp : public PHTrackPropagating
   std::vector<std::shared_ptr<KDPointCloud<double>>> _ptclouds;
   std::vector<std::shared_ptr<nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Simple_Adaptor<double, KDPointCloud<double>>,
                                                 KDPointCloud<double>,3>>> _kdtrees;
+  
   std::shared_ptr<ALICEKF> fitter;
   double get_Bz(double x, double y, double z);
   void publishSeeds(std::vector<SvtxTrack_v2>);
@@ -139,6 +143,9 @@ class PHSimpleKFProp : public PHTrackPropagating
   void line_fit(std::vector<std::pair<double,double>> points, double &A, double &B);
   void line_fit_clusters(std::vector<TrkrCluster*> clusters, double &A, double &B);
   void CircleFitByTaubin(std::vector<std::pair<double,double>> points, double &R, double &X0, double &Y0);
+  bool _use_const_field = false;
+  bool _use_fixed_clus_err = false;
+  std::array<double,3> _fixed_clus_err = {.1,.1,.1};
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Fixed bug where PHSimpleKFProp uses an antiquated version of getClusters(). Also updated ALICE KF to include constant-field and fixed-cluster-error options.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

