### PR TITLE
switch from ogzBuffer to opsBuffer

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllRolloverFileOutStream.cc
+++ b/offline/framework/fun4allraw/Fun4AllRolloverFileOutStream.cc
@@ -4,7 +4,7 @@
 
 #include <Event/Event.h>
 #include <Event/oBuffer.h>  // for oBuffer
-#include <Event/ogzBuffer.h>
+#include <Event/ospBuffer.h>
 
 #include <phool/phool.h>
 
@@ -76,9 +76,7 @@ int Fun4AllRolloverFileOutStream::WriteEventOut(Event *evt)
       cout << "Fun4AllRolloverFileOutStream: opening new file " << outfilename << endl;
     }
     MyManager()->SetOutfileName(outfilename);
-    // compression level 6 is best compromize between speed and compression
-    // max is 9 which is much slower but only squeezes out a few more bytes
-    SetoBuffer(new ogzBuffer(OutFileDescriptor(), xb(), LENGTH, 6, irun, iSeq()));
+    SetoBuffer(new ospBuffer(OutFileDescriptor(), xb(), LENGTH, irun, iSeq()));
     delete[] outfilename;
   }
 

--- a/offline/framework/phoolraw/PHRawOManager.cc
+++ b/offline/framework/phoolraw/PHRawOManager.cc
@@ -16,7 +16,7 @@
 
 #include <Event/EventTypes.h>
 #include <Event/oBuffer.h>
-#include <Event/ogzBuffer.h>
+#include <Event/ospBuffer.h>
 #include <Event/phenixTypes.h>
 
 #include <fcntl.h>
@@ -109,30 +109,7 @@ bool PHRawOManager::setFile(const string& setFile, const int setRun, const int s
     return false;
   }
   memBuffer = new PHDWORD[bufferSize];
-  if (compressionLevel == 0)
-  {
-    int status = 0;
-    fileBuffer = new oBuffer(filedesc, memBuffer, bufferSize, status, runNumber);
-    if (status > 0)
-    {
-      PHMessage("PHRawOManager::setFile", PHError, "could not open file");
-      return false;
-    }
-  }
-  else if (1 <= compressionLevel && compressionLevel <= 9)
-  {
-    int status = 0;
-    fileBuffer = new ogzBuffer(filedesc, memBuffer, bufferSize, status, runNumber, compressionLevel);
-    if (status > 0)
-    {
-      PHMessage("PHRawOManager::setFile", PHError, "could not open file");
-      return false;
-    }
-  }
-  else
-  {
-    PHMessage("PHRawOManager::setFile", PHWarning, "illegal compression level, no compression done");
-  }
+  fileBuffer = new ospBuffer(filedesc, memBuffer, bufferSize, runNumber);
 
   return true;
 }

--- a/offline/framework/phoolraw/configure.ac
+++ b/offline/framework/phoolraw/configure.ac
@@ -9,7 +9,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   treat warnings as errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR switches our raw data buffers from ogzBuffer to ospBuffer (in offline/framework/phoolraw and fun4allraw). That also fixes the recent crash of the builds. Right now this is not in the build, once this PR is through and we sorted out the jenkins failures those packages will go back into the build

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

