### PR TITLE
Silicon Stub Association

### DIFF
--- a/offline/packages/trackreco/PHTruthVertexing.cc
+++ b/offline/packages/trackreco/PHTruthVertexing.cc
@@ -154,13 +154,9 @@ void PHTruthVertexing::assignStubsVertices(PHCompositeNode *topNode)
 
       if(Verbosity() > 3)
 	track->identify();
-      
-      const double trackX = track->get_x();
-      const double trackY = track->get_y();
+    
       const double trackZ = track->get_z();
       
-      double dx = 9999.;
-      double dy = 9999.;
       double dz = 9999.;
       int trackVertexId = 9999;
       
@@ -173,16 +169,10 @@ void PHTruthVertexing::assignStubsVertices(PHCompositeNode *topNode)
 	  if(Verbosity() > 3)
 	    vertex->identify();
 	  
-	  const double vertexX = vertex->get_x();
-	  const double vertexY = vertex->get_y();
 	  const double vertexZ = vertex->get_z();
 	  
-	  if( fabs(trackX - vertexX) < dx &&
-	       fabs(trackY - vertexY) < dy &&
-	       fabs(trackZ - vertexZ) < dz )
+	  if( fabs(trackZ - vertexZ) < dz )
 	    {
-	      dx = fabs(trackX - vertexX);
-	      dy = fabs(trackY - vertexY);
 	      dz = fabs(trackZ - vertexZ);
 	      trackVertexId = vertexKey;
 	    }

--- a/simulation/g4simulation/g4main/PHG4Particlev2.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.cc
@@ -53,6 +53,8 @@ void PHG4Particlev2::identify(std::ostream &os) const
      << ", px: " << fpx
      << ", py: " << fpy
      << ", pz: " << fpz
+     << ", phi: " << atan2(fpy,fpx)
+     << ", eta: " << -1*log(tan(0.5*acos(fpz/sqrt(fpx*fpx+fpy*fpy+fpz*fpz))))
      << ", e: " << fe << endl;
   return;
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR fixes a bug in the silicon stub association with the truth vertex when there are multiple vertices in an event. It also adds a phi/eta printout to the G4particle class, which can be useful for debugging sometimes.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

