### PR TITLE
more tracking fixes

### DIFF
--- a/offline/packages/trackbase_historic/SvtxTrack.h
+++ b/offline/packages/trackbase_historic/SvtxTrack.h
@@ -52,10 +52,12 @@ class SvtxTrack : public PHObject
   using PHObject::CopyFrom;
   
   //! copy content from base class
-  virtual void CopyFrom( const SvtxTrack& ) {}
+  virtual void CopyFrom( const SvtxTrack& ) 
+  {}
 
   //! copy content from base class
-  virtual void CopyFrom( SvtxTrack* ) {}
+  virtual void CopyFrom( SvtxTrack* ) 
+  {}
 
   //
   // basic track information ---------------------------------------------------
@@ -238,7 +240,7 @@ class SvtxTrack : public PHObject
   virtual unsigned int get_truth_track_id() const { return UINT_MAX; }
   virtual void set_truth_track_id(unsigned int truthTrackId) {}
   virtual void set_num_measurements(int nmeas) {}
-  virtual unsigned int get_num_measurements() { return 0; }
+  virtual unsigned int get_num_measurements() const { return 0; }
 
   //SvtxTrack_FastSim_v1
   typedef std::map<int, std::set<PHG4HitDefs::keytype> > HitIdMap;

--- a/offline/packages/trackbase_historic/SvtxTrack.h
+++ b/offline/packages/trackbase_historic/SvtxTrack.h
@@ -48,8 +48,13 @@ class SvtxTrack : public PHObject
   virtual int isValid() const { return 0; }
   virtual PHObject* CloneMe() const { return nullptr; }
 
-  // copy content from base class
+  //! import PHObject CopyFrom, in order to avoid clang warning
+  using PHObject::CopyFrom;
+  
+  //! copy content from base class
   virtual void CopyFrom( const SvtxTrack& ) {}
+
+  //! copy content from base class
   virtual void CopyFrom( SvtxTrack* ) {}
 
   //

--- a/offline/packages/trackbase_historic/SvtxTrack.h
+++ b/offline/packages/trackbase_historic/SvtxTrack.h
@@ -37,7 +37,7 @@ class SvtxTrack : public PHObject
     HCALOUT = 3
   };
 
-  virtual ~SvtxTrack() {}
+  virtual ~SvtxTrack() = default;
 
   // The "standard PHObject response" functions...
   virtual void identify(std::ostream& os = std::cout) const
@@ -47,6 +47,10 @@ class SvtxTrack : public PHObject
   virtual void Reset() {}
   virtual int isValid() const { return 0; }
   virtual PHObject* CloneMe() const { return nullptr; }
+
+  // copy content from base class
+  virtual void CopyFrom( const SvtxTrack& ) {}
+  virtual void CopyFrom( SvtxTrack* ) {}
 
   //
   // basic track information ---------------------------------------------------

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim.cc
@@ -13,16 +13,19 @@
 #include <map>          // for _Rb_tree_const_iterator
 #include <ostream>      // for operator<<, basic_ostream, basic_ostream<>::_...
 
-using namespace std;
+SvtxTrack_FastSim::SvtxTrack_FastSim(const SvtxTrack& source)
+{ SvtxTrack_FastSim::CopyFrom( source ); }
 
-SvtxTrack_FastSim::SvtxTrack_FastSim()
-  : _truth_track_id(UINT_MAX)
-  , _nmeas(0)
+void SvtxTrack_FastSim::CopyFrom( const SvtxTrack& source )
 {
-}
+  
+  // parent class method
+  SvtxTrack_v1::CopyFrom( source );
+  
+  // additional members
+  _truth_track_id = source.get_truth_track_id();
+  _nmeas = source.get_num_measurements();
 
-SvtxTrack_FastSim::~SvtxTrack_FastSim()
-{
 }
 
 void SvtxTrack_FastSim::identify(std::ostream& os) const
@@ -32,14 +35,14 @@ void SvtxTrack_FastSim::identify(std::ostream& os) const
   os << "id: " << get_id() << " ";
   os << "charge: " << get_charge() << " ";
   os << "chisq: " << get_chisq() << " ndf:" << get_ndf() << " ";
-  os << endl;
+  os << std::endl;
 
   os << "(px,py,pz) = ("
      << get_px() << ","
      << get_py() << ","
-     << get_pz() << ")" << endl;
+     << get_pz() << ")" << std::endl;
 
-  os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << endl;
+  os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << std::endl;
 
   if (!empty_clusters())
   {
@@ -51,7 +54,7 @@ void SvtxTrack_FastSim::identify(std::ostream& os) const
       unsigned int cluster_id = *iter;
       os << cluster_id << " ";
     }
-    os << endl;
+    os << std::endl;
   }
 
   return;

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim.h
@@ -12,12 +12,25 @@
 
 #include <iostream>        // for cout, ostream
 
-class SvtxTrack_FastSim : public SvtxTrack_v1
+class SvtxTrack_FastSim: public SvtxTrack_v1
 {
  public:
-  SvtxTrack_FastSim();
-  virtual ~SvtxTrack_FastSim();
+  
+  //* constructor
+  SvtxTrack_FastSim()
+  {}
+  
+  //* destructor
+  virtual ~SvtxTrack_FastSim() = default;
 
+  //* base class copy constructor
+  SvtxTrack_FastSim( const SvtxTrack& );
+
+  // copy content from base class
+  virtual void CopyFrom( const SvtxTrack& );
+  virtual void CopyFrom( SvtxTrack* source )
+  { CopyFrom( *source ); }
+  
   unsigned int get_truth_track_id() const
   {
     return _truth_track_id;
@@ -34,12 +47,15 @@ class SvtxTrack_FastSim : public SvtxTrack_v1
   int isValid() const;
   PHObject* CloneMe() const { return new SvtxTrack_FastSim(*this); }
 
-  void set_num_measurements(int nmeas) { _nmeas = nmeas; }
-  unsigned int get_num_measurements() { return _nmeas; }
+  void set_num_measurements(int nmeas) 
+  { _nmeas = nmeas; }
+  
+  unsigned int get_num_measurements() const 
+  { return _nmeas; }
 
  private:
-  unsigned int _truth_track_id;
-  unsigned int _nmeas;
+  unsigned int _truth_track_id = UINT_MAX;
+  unsigned int _nmeas = 0;
 
   ClassDef(SvtxTrack_FastSim, 1)
 };

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.cc
@@ -13,31 +13,29 @@
 #include <map>      // for _Rb_tree_const_iterator
 #include <ostream>  // for operator<<, basic_ostream, basic_ostream<>::_...
 
-using namespace std;
+SvtxTrack_FastSim_v1::SvtxTrack_FastSim_v1(const SvtxTrack& source)
+{ SvtxTrack_FastSim_v1::CopyFrom( source ); }
 
-SvtxTrack_FastSim_v1::SvtxTrack_FastSim_v1()
+void SvtxTrack_FastSim_v1::CopyFrom( const SvtxTrack& source )
 {
-}
-
-SvtxTrack_FastSim_v1::~SvtxTrack_FastSim_v1()
-{
+  // parent class method
+  SvtxTrack_FastSim::CopyFrom( source );
+  
+  // additional members
+  _g4hit_ids = source.g4hit_ids();
 }
 
 void SvtxTrack_FastSim_v1::identify(std::ostream& os) const
 {
   SvtxTrack_FastSim::identify(os);
 
-  os << "G4Hit IDs:" << endl;
-  for (std::map<int, std::set<PHG4HitDefs::keytype> >::const_iterator iter =
-           _g4hit_ids.begin();
-       iter != _g4hit_ids.end(); ++iter)
+  os << "G4Hit IDs:" << std::endl;
+  for( const auto& pair:_g4hit_ids )
   {
-    os << "\thit container ID" << iter->first << " with hits: ";
-    for (std::set<PHG4HitDefs::keytype>::const_iterator jter = iter->second.begin(); jter != iter->second.end(); ++jter)
-    {
-      os << *jter << " ";
-    }
-    os << endl;
+    os << "\thit container ID" << pair.first << " with hits: ";
+    for( const auto& hitid:pair.second )
+    { os << hitid << " "; }
+    os << std::endl;
   }
   return;
 }

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.h
@@ -11,9 +11,21 @@
 class SvtxTrack_FastSim_v1 : public SvtxTrack_FastSim
 {
  public:
-  SvtxTrack_FastSim_v1();
-  virtual ~SvtxTrack_FastSim_v1();
+  
+  //* constructor
+  SvtxTrack_FastSim_v1() {}
+  
+  //* base class copy constructor
+  SvtxTrack_FastSim_v1( const SvtxTrack& );
+  
+  //* destructor
+  virtual ~SvtxTrack_FastSim_v1() = default;
 
+  // copy content from base class
+  virtual void CopyFrom( const SvtxTrack& );
+  virtual void CopyFrom( SvtxTrack* source )
+  { CopyFrom( *source ); }
+  
   // The "standard PHObject response" functions...
   void identify(std::ostream& os = std::cout) const;
   void Reset() { *this = SvtxTrack_FastSim_v1(); }

--- a/offline/packages/trackbase_historic/SvtxTrack_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v1.cc
@@ -10,95 +10,60 @@
 #include <map>
 #include <vector>                // for vector
 
-
-using namespace std;
-
 SvtxTrack_v1::SvtxTrack_v1()
-  : _track_id(UINT_MAX)
-  , _vertex_id(UINT_MAX)
-  , _is_positive_charge(false)
-  , _chisq(NAN)
-  , _ndf(0)
-  , _dca(NAN)
-  , _dca_error(NAN)
-  , _dca2d(NAN)
-  , _dca2d_error(NAN)
-  , _dca3d_xy(NAN)
-  , _dca3d_xy_error(NAN)
-  , _dca3d_z(NAN)
-  , _dca3d_z_error(NAN)
-  , _states()
-  , _cluster_ids()
-  , _cluster_keys()
-  , _cal_dphi()
-  , _cal_deta()
-  , _cal_energy_3x3()
-  , _cal_energy_5x5()
-  , _cal_cluster_id()
-  , _cal_cluster_key()
-  , _cal_cluster_e()
 {
   // always include the pca point
-  _states.insert(make_pair(0.0, new SvtxTrackState_v1(0.0)));
+  _states.insert(std::make_pair(0.0, new SvtxTrackState_v1(0.0)));
 }
 
-SvtxTrack_v1::SvtxTrack_v1(const SvtxTrack_v1& track)
+SvtxTrack_v1::SvtxTrack_v1(const SvtxTrack& source)
+{ SvtxTrack_v1::CopyFrom( source ); }
+
+SvtxTrack_v1::SvtxTrack_v1(const SvtxTrack_v1& source)
+{ SvtxTrack_v1::CopyFrom( source ); }
+
+SvtxTrack_v1& SvtxTrack_v1::operator=(const SvtxTrack_v1& source)
+{ if( this != &source ) CopyFrom( source ); return *this; }
+
+SvtxTrack_v1::~SvtxTrack_v1()
 {
-  *this = track;
-  return;
+  clear_states();
 }
 
-SvtxTrack_v1& SvtxTrack_v1::operator=(const SvtxTrack_v1& track)
+void SvtxTrack_v1::CopyFrom( const SvtxTrack& source )
 {
-  _track_id = track.get_id();
-  _vertex_id = track.get_vertex_id();
-  _is_positive_charge = track.get_positive_charge();
-  _chisq = track.get_chisq();
-  _ndf = track.get_ndf();
-  _dca = track.get_dca();
-  _dca_error = track.get_dca_error();
-  _dca2d = track.get_dca2d();
-  _dca2d_error = track.get_dca2d_error();
-  _dca3d_xy = track.get_dca3d_xy();
-  _dca3d_xy_error = track.get_dca3d_xy_error();
-  _dca3d_z = track.get_dca3d_z();
-  _dca3d_z_error = track.get_dca3d_z_error();
 
+  // parent class method
+  SvtxTrack::CopyFrom( source );
+
+  _track_id = source.get_id();
+  _vertex_id = source.get_vertex_id();
+  _is_positive_charge = source.get_positive_charge();
+  _chisq = source.get_chisq();
+  _ndf = source.get_ndf();
+  _dca = source.get_dca();
+  _dca_error = source.get_dca_error();
+  _dca2d = source.get_dca2d();
+  _dca2d_error = source.get_dca2d_error();
+  _dca3d_xy = source.get_dca3d_xy();
+  _dca3d_xy_error = source.get_dca3d_xy_error();
+  _dca3d_z = source.get_dca3d_z();
+  _dca3d_z_error = source.get_dca3d_z_error();
+  
   // copy the states over into new state objects stored here
   clear_states();
-  for (ConstStateIter iter = track.begin_states();
-       iter != track.end_states();
-       ++iter)
-  {
-    SvtxTrackState* state = dynamic_cast< SvtxTrackState*> (iter->second->CloneMe());
-    _states.insert(make_pair(state->get_pathlength(), state));
-  }
+  for( auto iter = source.begin_states(); iter != source.end_states(); ++iter )
+  { _states.insert( std::make_pair(iter->first, static_cast<SvtxTrackState*>(iter->second->CloneMe() ) ) ); }
 
   // copy over cluster ID set
   _cluster_ids.clear();
-  for (ConstClusterIter iter = track.begin_clusters();
-       iter != track.end_clusters();
-       ++iter)
-  {
-    _cluster_ids.insert(*iter);
-  }
-
+  std::copy( source.begin_clusters(), source.end_clusters(), std::inserter( _cluster_ids, _cluster_ids.begin() ) );
+  
   // copy over cluster key set
   _cluster_keys.clear();
-  for (ConstClusterKeyIter iter = track.begin_cluster_keys();
-       iter != track.end_cluster_keys();
-       ++iter)
-  {
-    _cluster_keys.insert(*iter);
-  }
+  std::copy( source.begin_cluster_keys(), source.end_cluster_keys(), std::inserter( _cluster_keys, _cluster_keys.begin() ) );
 
   // copy over calorimeter projections
-  std::vector<CAL_LAYER> types;
-  types.push_back(SvtxTrack::PRES);
-  types.push_back(SvtxTrack::CEMC);
-  types.push_back(SvtxTrack::HCALIN);
-  types.push_back(SvtxTrack::HCALOUT);
-
   _cal_dphi.clear();
   _cal_deta.clear();
   _cal_energy_3x3.clear();
@@ -107,24 +72,19 @@ SvtxTrack_v1& SvtxTrack_v1::operator=(const SvtxTrack_v1& track)
   _cal_cluster_key.clear();
   _cal_cluster_e.clear();
 
-  for (unsigned int i = 0; i < types.size(); ++i)
+  for( const auto& type: { SvtxTrack::PRES, SvtxTrack::CEMC, SvtxTrack::HCALIN, SvtxTrack::HCALOUT } )
   {
-    if (!isnan(track.get_cal_dphi(types[i]))) set_cal_dphi(types[i], track.get_cal_dphi(types[i]));
-    if (!isnan(track.get_cal_deta(types[i]))) set_cal_deta(types[i], track.get_cal_deta(types[i]));
-    if (!isnan(track.get_cal_energy_3x3(types[i]))) set_cal_energy_3x3(types[i], track.get_cal_energy_3x3(types[i]));
-    if (!isnan(track.get_cal_energy_5x5(types[i]))) set_cal_energy_5x5(types[i], track.get_cal_energy_5x5(types[i]));
-    if (track.get_cal_cluster_id(types[i]) != UINT_MAX) set_cal_cluster_id(types[i], track.get_cal_cluster_id(types[i]));
-    if (track.get_cal_cluster_key(types[i]) != UINT_MAX) set_cal_cluster_key(types[i], track.get_cal_cluster_key(types[i]));
-    if (!isnan(track.get_cal_cluster_e(types[i]))) set_cal_cluster_e(types[i], track.get_cal_cluster_e(types[i]));
+    if(!isnan(source.get_cal_dphi(type))) set_cal_dphi(type, source.get_cal_dphi(type));
+    if(!isnan(source.get_cal_deta(type))) set_cal_deta(type, source.get_cal_deta(type));
+    if(!isnan(source.get_cal_energy_3x3(type))) set_cal_energy_3x3(type, source.get_cal_energy_3x3(type));
+    if(!isnan(source.get_cal_energy_5x5(type))) set_cal_energy_5x5(type, source.get_cal_energy_5x5(type));
+    if(source.get_cal_cluster_id(type) != UINT_MAX) set_cal_cluster_id(type, source.get_cal_cluster_id(type));
+    if(source.get_cal_cluster_key(type) != UINT_MAX) set_cal_cluster_key(type, source.get_cal_cluster_key(type));
+    if(!isnan(source.get_cal_cluster_e(type))) set_cal_cluster_e(type, source.get_cal_cluster_e(type));
   }
 
-  return *this;
 }
 
-SvtxTrack_v1::~SvtxTrack_v1()
-{
-  clear_states();
-}
 
 void SvtxTrack_v1::identify(std::ostream& os) const
 {
@@ -133,14 +93,14 @@ void SvtxTrack_v1::identify(std::ostream& os) const
   os << "vertex id: " << get_vertex_id() << " ";
   os << "charge: " << get_charge() << " ";
   os << "chisq: " << get_chisq() << " ndf:" << get_ndf() << " ";
-  os << endl;
+  os << std::endl;
 
   os << "(px,py,pz) = ("
      << get_px() << ","
      << get_py() << ","
-     << get_pz() << ")" << endl;
+     << get_pz() << ")" << std::endl;
 
-  os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << endl;
+  os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << std::endl;
 
   if ( _cluster_ids.size() > 0 || _cluster_keys.size() > 0 )
   {
@@ -163,20 +123,19 @@ void SvtxTrack_v1::identify(std::ostream& os) const
     }
   }
   else
-    os << " track has no clusters " << endl;
+    os << " track has no clusters " << std::endl;
   
-  os << endl;
+  os << std::endl;
 
   return;
 }
 
 void SvtxTrack_v1::clear_states()
 {
-  while(_states.begin() != _states.end())
-  {
-    delete _states.begin()->second;
-    _states.erase(_states.begin());
-  }
+  for( const auto& pair:_states )
+  { delete pair.second; }
+  
+  _states.clear();
 }
 
 int SvtxTrack_v1::isValid() const
@@ -200,8 +159,10 @@ SvtxTrackState* SvtxTrack_v1::get_state(float pathlength)
 
 SvtxTrackState* SvtxTrack_v1::insert_state(const SvtxTrackState* state)
 {
-  _states.insert(make_pair(state->get_pathlength(), dynamic_cast< SvtxTrackState*> (state->CloneMe())));
-  return _states[state->get_pathlength()];
+  const auto copy =  static_cast<SvtxTrackState*> (state->CloneMe());
+  const auto [iterator, inserted] = _states.insert(std::make_pair(state->get_pathlength(),copy));
+  if( !inserted ) delete copy;
+  return iterator->second;  
 }
 
 size_t SvtxTrack_v1::erase_state(float pathlength)

--- a/offline/packages/trackbase_historic/SvtxTrack_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v1.cc
@@ -19,6 +19,8 @@ SvtxTrack_v1::SvtxTrack_v1()
 SvtxTrack_v1::SvtxTrack_v1(const SvtxTrack& source)
 { SvtxTrack_v1::CopyFrom( source ); }
 
+// have to suppress uninitMenberVar from cppcheck since it triggers many false positive
+// cppcheck-suppress uninitMemberVar
 SvtxTrack_v1::SvtxTrack_v1(const SvtxTrack_v1& source)
 { SvtxTrack_v1::CopyFrom( source ); }
 

--- a/offline/packages/trackbase_historic/SvtxTrack_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v1.h
@@ -18,8 +18,16 @@ class SvtxTrack_v1 : public SvtxTrack
 {
  public:
   SvtxTrack_v1();
+  
+  //* base class copy constructor
+  SvtxTrack_v1( const SvtxTrack& );
+  
+  //* copy constructor
   SvtxTrack_v1(const SvtxTrack_v1& track);
+
+  //* assignment operator
   SvtxTrack_v1& operator=(const SvtxTrack_v1& track);
+  
   virtual ~SvtxTrack_v1();
 
   // The "standard PHObject response" functions...
@@ -27,6 +35,11 @@ class SvtxTrack_v1 : public SvtxTrack
   void Reset() { *this = SvtxTrack_v1(); }
   int isValid() const;
   PHObject* CloneMe() const { return new SvtxTrack_v1(*this); }
+  
+  // copy content from base class
+  virtual void CopyFrom( const SvtxTrack& );
+  virtual void CopyFrom( SvtxTrack* source )
+  { CopyFrom( *source ); }
 
   //
   // basic track information ---------------------------------------------------
@@ -185,21 +198,21 @@ class SvtxTrack_v1 : public SvtxTrack
 
  private:
   // track information
-  unsigned int _track_id;
-  unsigned int _vertex_id;
-  bool _is_positive_charge;
-  float _chisq;
-  unsigned int _ndf;
+  unsigned int _track_id = UINT_MAX;
+  unsigned int _vertex_id = UINT_MAX;
+  bool _is_positive_charge = false;
+  float _chisq = NAN;
+  unsigned int _ndf = 0;
 
   // extended track information (non-primary tracks only)
-  float _dca;
-  float _dca_error;
-  float _dca2d;
-  float _dca2d_error;
-  float _dca3d_xy;
-  float _dca3d_xy_error;
-  float _dca3d_z;
-  float _dca3d_z_error;
+  float _dca = NAN;
+  float _dca_error = NAN;
+  float _dca2d = NAN;
+  float _dca2d_error = NAN;
+  float _dca3d_xy = NAN;
+  float _dca3d_xy_error = NAN;
+  float _dca3d_z = NAN;
+  float _dca3d_z_error = NAN;
 
   // extended track information (primary tracks only)
 

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.cc
@@ -22,10 +22,10 @@ SvtxTrack_v2::SvtxTrack_v2()
 }
 
 SvtxTrack_v2::SvtxTrack_v2(const SvtxTrack& source)
-{ if( this != &source ) CopyFrom( source ); }
+{ SvtxTrack_v2::CopyFrom( source ); }
 
 SvtxTrack_v2::SvtxTrack_v2(const SvtxTrack_v2& source)
-{ if( this != &source ) CopyFrom( source ); }
+{ SvtxTrack_v2::CopyFrom( source ); }
 
 SvtxTrack_v2& SvtxTrack_v2::operator=(const SvtxTrack_v2& source)
 { if( this != &source ) CopyFrom( source ); return *this; }

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.cc
@@ -24,6 +24,8 @@ SvtxTrack_v2::SvtxTrack_v2()
 SvtxTrack_v2::SvtxTrack_v2(const SvtxTrack& source)
 { SvtxTrack_v2::CopyFrom( source ); }
 
+// have to suppress uninitMenberVar from cppcheck since it triggers many false positive
+// cppcheck-suppress uninitMemberVar
 SvtxTrack_v2::SvtxTrack_v2(const SvtxTrack_v2& source)
 { SvtxTrack_v2::CopyFrom( source ); }
 

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.cc
@@ -14,7 +14,7 @@ SvtxTrack_v2::SvtxTrack_v2()
 {
   for(int i = 0; i < 6; i++)
     for(int j = 0; j < 6; j++)
-      _acts_trajectory_covariance[i][j] = NAN;
+  { _acts_trajectory_covariance[i][j] = NAN; }
 
   // always include the pca point
   _states.insert( std::make_pair(0, new SvtxTrackState_v1(0)));
@@ -36,6 +36,9 @@ SvtxTrack_v2::~SvtxTrack_v2()
 void SvtxTrack_v2::CopyFrom( const SvtxTrack& source )
 {
 
+  // parent class method
+  SvtxTrack::CopyFrom( source );
+  
   // copy acts covariance 
   for( int i = 0; i<6; ++i )
     for( int j = 0; j<6; ++j )

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.cc
@@ -28,7 +28,7 @@ SvtxTrack_v2::SvtxTrack_v2(const SvtxTrack_v2& source)
 { if( this != &source ) CopyFrom( source ); }
 
 SvtxTrack_v2& SvtxTrack_v2::operator=(const SvtxTrack_v2& source)
-{ CopyFrom( source ); return *this; }
+{ if( this != &source ) CopyFrom( source ); return *this; }
 
 SvtxTrack_v2::~SvtxTrack_v2()
 { clear_states(); }

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.cc
@@ -10,98 +10,65 @@
 #include <map>
 #include <vector>                // for vector
 
-
-using namespace std;
-
 SvtxTrack_v2::SvtxTrack_v2()
-  : _track_id(UINT_MAX)
-  , _vertex_id(UINT_MAX)
-  , _is_positive_charge(false)
-  , _chisq(NAN)
-  , _ndf(0)
-  , _dca(NAN)
-  , _dca_error(NAN)
-  , _dca2d(NAN)
-  , _dca2d_error(NAN)
-  , _dca3d_xy(NAN)
-  , _dca3d_xy_error(NAN)
-  , _dca3d_z(NAN)
-  , _dca3d_z_error(NAN)
-  , _states()
-  , _cluster_ids()
-  , _cluster_keys()
-  , _cal_dphi()
-  , _cal_deta()
-  , _cal_energy_3x3()
-  , _cal_energy_5x5()
-  , _cal_cluster_id()
-  , _cal_cluster_key()
-  , _cal_cluster_e()
 {
   for(int i = 0; i < 6; i++)
     for(int j = 0; j < 6; j++)
       _acts_trajectory_covariance[i][j] = NAN;
+
   // always include the pca point
-  _states.insert(make_pair(0.0, new SvtxTrackState_v1(0.0)));
+  _states.insert( std::make_pair(0, new SvtxTrackState_v1(0)));
+
 }
 
-SvtxTrack_v2::SvtxTrack_v2(const SvtxTrack_v2& track)
-{
-  *this = track;
-  return;
-}
+SvtxTrack_v2::SvtxTrack_v2(const SvtxTrack& source)
+{ if( this != &source ) CopyFrom( source ); }
 
-SvtxTrack_v2& SvtxTrack_v2::operator=(const SvtxTrack_v2& track)
-{
-  _track_id = track.get_id();
-  _vertex_id = track.get_vertex_id();
-  _is_positive_charge = track.get_positive_charge();
-  _chisq = track.get_chisq();
-  _ndf = track.get_ndf();
-  _dca = track.get_dca();
-  _dca_error = track.get_dca_error();
-  _dca2d = track.get_dca2d();
-  _dca2d_error = track.get_dca2d_error();
-  _dca3d_xy = track.get_dca3d_xy();
-  _dca3d_xy_error = track.get_dca3d_xy_error();
-  _dca3d_z = track.get_dca3d_z();
-  _dca3d_z_error = track.get_dca3d_z_error();
+SvtxTrack_v2::SvtxTrack_v2(const SvtxTrack_v2& source)
+{ if( this != &source ) CopyFrom( source ); }
 
+SvtxTrack_v2& SvtxTrack_v2::operator=(const SvtxTrack_v2& source)
+{ CopyFrom( source ); return *this; }
+
+SvtxTrack_v2::~SvtxTrack_v2()
+{ clear_states(); }
+
+void SvtxTrack_v2::CopyFrom( const SvtxTrack& source )
+{
+
+  // copy acts covariance 
+  for( int i = 0; i<6; ++i )
+    for( int j = 0; j<6; ++j )
+  { set_acts_covariance( i, j, source.get_acts_covariance( i, j ) ); }
+
+  _track_id = source.get_id();
+  _vertex_id = source.get_vertex_id();
+  _is_positive_charge = source.get_positive_charge();
+  _chisq = source.get_chisq();
+  _ndf = source.get_ndf();
+  _dca = source.get_dca();
+  _dca_error = source.get_dca_error();
+  _dca2d = source.get_dca2d();
+  _dca2d_error = source.get_dca2d_error();
+  _dca3d_xy = source.get_dca3d_xy();
+  _dca3d_xy_error = source.get_dca3d_xy_error();
+  _dca3d_z = source.get_dca3d_z();
+  _dca3d_z_error = source.get_dca3d_z_error();
+  
   // copy the states over into new state objects stored here
   clear_states();
-  for (ConstStateIter iter = track.begin_states();
-       iter != track.end_states();
-       ++iter)
-  {
-    SvtxTrackState* state = dynamic_cast< SvtxTrackState*> (iter->second->CloneMe());
-    _states.insert(make_pair(state->get_pathlength(), state));
-  }
+  for( auto iter = source.begin_states(); iter != source.end_states(); ++iter )
+  { _states.insert( std::make_pair(iter->first, static_cast<SvtxTrackState*>(iter->second->CloneMe() ) ) ); }
 
   // copy over cluster ID set
   _cluster_ids.clear();
-  for (ConstClusterIter iter = track.begin_clusters();
-       iter != track.end_clusters();
-       ++iter)
-  {
-    _cluster_ids.insert(*iter);
-  }
-
+  std::copy( source.begin_clusters(), source.end_clusters(), std::inserter( _cluster_ids, _cluster_ids.begin() ) );
+  
   // copy over cluster key set
   _cluster_keys.clear();
-  for (ConstClusterKeyIter iter = track.begin_cluster_keys();
-       iter != track.end_cluster_keys();
-       ++iter)
-  {
-    _cluster_keys.insert(*iter);
-  }
+  std::copy( source.begin_cluster_keys(), source.end_cluster_keys(), std::inserter( _cluster_keys, _cluster_keys.begin() ) );
 
   // copy over calorimeter projections
-  std::vector<CAL_LAYER> types;
-  types.push_back(SvtxTrack::PRES);
-  types.push_back(SvtxTrack::CEMC);
-  types.push_back(SvtxTrack::HCALIN);
-  types.push_back(SvtxTrack::HCALOUT);
-
   _cal_dphi.clear();
   _cal_deta.clear();
   _cal_energy_3x3.clear();
@@ -110,23 +77,17 @@ SvtxTrack_v2& SvtxTrack_v2::operator=(const SvtxTrack_v2& track)
   _cal_cluster_key.clear();
   _cal_cluster_e.clear();
 
-  for (unsigned int i = 0; i < types.size(); ++i)
+  for( const auto& type: { SvtxTrack::PRES, SvtxTrack::CEMC, SvtxTrack::HCALIN, SvtxTrack::HCALOUT } )
   {
-    if (!isnan(track.get_cal_dphi(types[i]))) set_cal_dphi(types[i], track.get_cal_dphi(types[i]));
-    if (!isnan(track.get_cal_deta(types[i]))) set_cal_deta(types[i], track.get_cal_deta(types[i]));
-    if (!isnan(track.get_cal_energy_3x3(types[i]))) set_cal_energy_3x3(types[i], track.get_cal_energy_3x3(types[i]));
-    if (!isnan(track.get_cal_energy_5x5(types[i]))) set_cal_energy_5x5(types[i], track.get_cal_energy_5x5(types[i]));
-    if (track.get_cal_cluster_id(types[i]) != UINT_MAX) set_cal_cluster_id(types[i], track.get_cal_cluster_id(types[i]));
-    if (track.get_cal_cluster_key(types[i]) != UINT_MAX) set_cal_cluster_key(types[i], track.get_cal_cluster_key(types[i]));
-    if (!isnan(track.get_cal_cluster_e(types[i]))) set_cal_cluster_e(types[i], track.get_cal_cluster_e(types[i]));
+    if(!isnan(source.get_cal_dphi(type))) set_cal_dphi(type, source.get_cal_dphi(type));
+    if(!isnan(source.get_cal_deta(type))) set_cal_deta(type, source.get_cal_deta(type));
+    if(!isnan(source.get_cal_energy_3x3(type))) set_cal_energy_3x3(type, source.get_cal_energy_3x3(type));
+    if(!isnan(source.get_cal_energy_5x5(type))) set_cal_energy_5x5(type, source.get_cal_energy_5x5(type));
+    if(source.get_cal_cluster_id(type) != UINT_MAX) set_cal_cluster_id(type, source.get_cal_cluster_id(type));
+    if(source.get_cal_cluster_key(type) != UINT_MAX) set_cal_cluster_key(type, source.get_cal_cluster_key(type));
+    if(!isnan(source.get_cal_cluster_e(type))) set_cal_cluster_e(type, source.get_cal_cluster_e(type));
   }
 
-  return *this;
-}
-
-SvtxTrack_v2::~SvtxTrack_v2()
-{
-  clear_states();
 }
 
 void SvtxTrack_v2::identify(std::ostream& os) const
@@ -136,14 +97,14 @@ void SvtxTrack_v2::identify(std::ostream& os) const
   os << "vertex id: " << get_vertex_id() << " ";
   os << "charge: " << get_charge() << " ";
   os << "chisq: " << get_chisq() << " ndf:" << get_ndf() << " ";
-  os << endl;
+  os << std::endl;
 
   os << "(px,py,pz) = ("
      << get_px() << ","
      << get_py() << ","
-     << get_pz() << ")" << endl;
+     << get_pz() << ")" << std::endl;
 
-  os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << endl;
+  os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << std::endl;
 
   if ( _cluster_ids.size() > 0 || _cluster_keys.size() > 0 )
   {
@@ -166,20 +127,19 @@ void SvtxTrack_v2::identify(std::ostream& os) const
     }
   }
   else
-    os << " track has no clusters " << endl;
+    os << " track has no clusters " << std::endl;
   
-  os << endl;
+  os << std::endl;
 
   return;
 }
 
 void SvtxTrack_v2::clear_states()
 {
-  while(_states.begin() != _states.end())
-  {
-    delete _states.begin()->second;
-    _states.erase(_states.begin());
-  }
+  for( const auto& pair:_states )
+  { delete pair.second; }
+  
+  _states.clear();
 }
 
 int SvtxTrack_v2::isValid() const
@@ -189,22 +149,22 @@ int SvtxTrack_v2::isValid() const
 
 const SvtxTrackState* SvtxTrack_v2::get_state(float pathlength) const
 {
-  ConstStateIter iter = _states.find(pathlength);
-  if (iter == _states.end()) return nullptr;
-  return iter->second;
+  const auto iter = _states.find(pathlength);
+  return (iter == _states.end()) ? nullptr:iter->second;
 }
 
 SvtxTrackState* SvtxTrack_v2::get_state(float pathlength)
 {
-  StateIter iter = _states.find(pathlength);
-  if (iter == _states.end()) return nullptr;
-  return iter->second;
+  const auto iter = _states.find(pathlength);
+  return (iter == _states.end()) ? nullptr:iter->second;
 }
 
 SvtxTrackState* SvtxTrack_v2::insert_state(const SvtxTrackState* state)
 {
-  _states.insert(make_pair(state->get_pathlength(), dynamic_cast< SvtxTrackState*> (state->CloneMe())));
-  return _states[state->get_pathlength()];
+  const auto copy =  static_cast<SvtxTrackState*> (state->CloneMe());
+  const auto [iterator, inserted] = _states.insert(std::make_pair(state->get_pathlength(),copy));
+  if( !inserted ) delete copy;
+  return iterator->second;  
 }
 
 size_t SvtxTrack_v2::erase_state(float pathlength)
@@ -248,14 +208,14 @@ float SvtxTrack_v2::get_cal_energy_5x5(SvtxTrack::CAL_LAYER layer) const
 unsigned int SvtxTrack_v2::get_cal_cluster_id(SvtxTrack::CAL_LAYER layer) const
 {
   std::map<SvtxTrack::CAL_LAYER, int>::const_iterator citer = _cal_cluster_id.find(layer);
-  if (citer == _cal_cluster_id.end()) return -9999;
+  if (citer == _cal_cluster_id.end()) return UINT_MAX;
   return citer->second;
 }
 
 TrkrDefs::cluskey SvtxTrack_v2::get_cal_cluster_key(SvtxTrack::CAL_LAYER layer) const
 {
   std::map<SvtxTrack::CAL_LAYER, TrkrDefs::cluskey>::const_iterator citer = _cal_cluster_key.find(layer);
-  if (citer == _cal_cluster_key.end()) return -9999;
+  if (citer == _cal_cluster_key.end()) return UINT_MAX;
   return citer->second;
 }
 

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.h
@@ -203,7 +203,9 @@ class SvtxTrack_v2 final : public SvtxTrack
 
  private:
 
-  float _acts_trajectory_covariance[6][6];
+  //! acts covariance matrix
+  float _acts_trajectory_covariance[6][6] = {};
+
   // track information
   unsigned int _track_id = UINT_MAX;
   unsigned int _vertex_id = UINT_MAX;

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.h
@@ -14,7 +14,7 @@
 
 class PHObject;
 
-class SvtxTrack_v2 : public SvtxTrack
+class SvtxTrack_v2 final : public SvtxTrack
 {
  public:
   SvtxTrack_v2();

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.h
@@ -18,8 +18,17 @@ class SvtxTrack_v2 : public SvtxTrack
 {
  public:
   SvtxTrack_v2();
-  SvtxTrack_v2(const SvtxTrack_v2& track);
+  
+  //* base class copy constructor
+  SvtxTrack_v2( const SvtxTrack& );
+  
+  //* copy constructor
+  SvtxTrack_v2(const SvtxTrack_v2& );
+  
+  //* assignment operator
   SvtxTrack_v2& operator=(const SvtxTrack_v2& track);
+
+  //* destructor
   virtual ~SvtxTrack_v2(); 
 
   // The "standard PHObject response" functions...
@@ -27,6 +36,11 @@ class SvtxTrack_v2 : public SvtxTrack
   void Reset() { *this = SvtxTrack_v2(); }
   int isValid() const;
   PHObject* CloneMe() const { return new SvtxTrack_v2(*this); }
+
+  // copy content from base class
+  virtual void CopyFrom( const SvtxTrack& );
+  virtual void CopyFrom( SvtxTrack* source )
+  { CopyFrom( *source ); }
 
   //
   // basic track information ---------------------------------------------------
@@ -191,21 +205,21 @@ class SvtxTrack_v2 : public SvtxTrack
 
   float _acts_trajectory_covariance[6][6];
   // track information
-  unsigned int _track_id;
-  unsigned int _vertex_id;
-  bool _is_positive_charge;
-  float _chisq;
-  unsigned int _ndf;
+  unsigned int _track_id = UINT_MAX;
+  unsigned int _vertex_id = UINT_MAX;
+  bool _is_positive_charge = false;
+  float _chisq = NAN;
+  unsigned int _ndf = 0;
 
   // extended track information (non-primary tracks only)
-  float _dca;
-  float _dca_error;
-  float _dca2d;
-  float _dca2d_error;
-  float _dca3d_xy;
-  float _dca3d_xy_error;
-  float _dca3d_z;
-  float _dca3d_z_error;
+  float _dca = NAN;
+  float _dca_error = NAN;
+  float _dca2d = NAN;
+  float _dca2d_error = NAN;
+  float _dca3d_xy = NAN;
+  float _dca3d_xy_error = NAN;
+  float _dca3d_z = NAN;
+  float _dca3d_z_error = NAN;
 
   // extended track information (primary tracks only)
 

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -118,7 +118,7 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
     if(ClusterKeyList.size()< _min_clusters_per_track)
       continue;
 
-    std::unique_ptr<SvtxTrack_FastSim> svtx_track(new SvtxTrack_FastSim());
+    auto svtx_track = std::make_unique<SvtxTrack_FastSim>();
     svtx_track->set_id(_track_map->size());
     svtx_track->set_truth_track_id(gtrackID);
     ///g4 vertex id starts at 1, svtx vertex map starts at 0


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
In order to fix GenFit track fitting with both truth or full track finding, one must make it agnostic to the version of the SvtxTrk object provided by the track finding. To achieve this one introduces a CopyFrom to the lastest SvtxTrk object that takes the base class as constructor, and makes use of it inside the GenFitTrackFitter.

CopyFrom method should also be implemented for the other older SvtxTrack objects. This will be the subject for another PR.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

