### PR TITLE
compiler check needs to use *g++ for daily build and jenkins/user to …

### DIFF
--- a/generators/PHPythia8/configure.ac
+++ b/generators/PHPythia8/configure.ac
@@ -14,7 +14,7 @@ dnl specific flags
   clang++)
    CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-c11-extensions"
   ;;
-  g++)
+  *g++)
    CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror -pedantic "
   ;;
  esac

--- a/offline/QA/modules/configure.ac
+++ b/offline/QA/modules/configure.ac
@@ -12,7 +12,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/offline/database/pdbcal/pg/configure.ac
+++ b/offline/database/pdbcal/pg/configure.ac
@@ -15,7 +15,7 @@ case $CXX in
 dnl odbc++ has issues
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations -Wno-overloaded-virtual"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations"
  ;;
 esac

--- a/offline/framework/frog/configure.ac
+++ b/offline/framework/frog/configure.ac
@@ -14,7 +14,7 @@ case $CXX in
 dnl odbc++ uses auto_ptr
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wno-deprecated-declarations"
  ;;
 esac

--- a/offline/packages/CaloBase/configure.ac
+++ b/offline/packages/CaloBase/configure.ac
@@ -9,7 +9,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall  -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
  ;;
 esac

--- a/offline/packages/CaloReco/configure.ac
+++ b/offline/packages/CaloReco/configure.ac
@@ -9,7 +9,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-c11-extensions"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/offline/packages/ClusterIso/configure.ac
+++ b/offline/packages/ClusterIso/configure.ac
@@ -11,7 +11,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/offline/packages/KFParticle_sPHENIX/configure.ac
+++ b/offline/packages/KFParticle_sPHENIX/configure.ac
@@ -11,7 +11,7 @@ case $CXX in
   clang++)
    CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-macro-redefined"
   ;;
-  g++)
+  *g++)
    CXXFLAGS="$CXXFLAGS -Wall -Werror"
   ;;
 esac

--- a/offline/packages/NodeDump/configure.ac
+++ b/offline/packages/NodeDump/configure.ac
@@ -10,7 +10,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/offline/packages/PHTpcTracker/configure.ac
+++ b/offline/packages/PHTpcTracker/configure.ac
@@ -10,7 +10,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/offline/packages/jetbackground/configure.ac
+++ b/offline/packages/jetbackground/configure.ac
@@ -12,7 +12,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
    CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
   else

--- a/offline/packages/particleflow/configure.ac
+++ b/offline/packages/particleflow/configure.ac
@@ -10,7 +10,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/offline/packages/trackreco/configure.ac
+++ b/offline/packages/trackreco/configure.ac
@@ -11,7 +11,7 @@ dnl case $CXX in
 dnl  clang++)
 dnl   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 dnl  ;;
-dnl  g++)
+dnl  *g++)
 dnl   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 dnl  ;;
 dnl esac

--- a/offline/packages/trigger/configure.ac
+++ b/offline/packages/trigger/configure.ac
@@ -12,7 +12,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall  -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/EICPhysicsList/configure.ac
+++ b/simulation/g4simulation/EICPhysicsList/configure.ac
@@ -12,7 +12,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-final-dtor-non-final-class"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4bbc/configure.ac
+++ b/simulation/g4simulation/g4bbc/configure.ac
@@ -11,7 +11,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4calo/configure.ac
+++ b/simulation/g4simulation/g4calo/configure.ac
@@ -11,7 +11,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4decayer/configure.ac
+++ b/simulation/g4simulation/g4decayer/configure.ac
@@ -14,7 +14,7 @@ dnl case $CXX in
 dnl  clang++)
 dnl   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 dnl  ;;
-dnl  g++)
+dnl  *g++)
 dnl   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 dnl  ;;
 dnl esac
@@ -26,7 +26,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-shadow"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4detectors/configure.ac
+++ b/simulation/g4simulation/g4detectors/configure.ac
@@ -9,7 +9,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template -Wno-tautological-overlap-compare"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4epd/configure.ac
+++ b/simulation/g4simulation/g4epd/configure.ac
@@ -10,7 +10,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4eval/configure.ac
+++ b/simulation/g4simulation/g4eval/configure.ac
@@ -8,10 +8,10 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-maybe-uninitialized"
  ;;
 esac
 

--- a/simulation/g4simulation/g4histos/configure.ac
+++ b/simulation/g4simulation/g4histos/configure.ac
@@ -12,7 +12,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4intt/configure.ac
+++ b/simulation/g4simulation/g4intt/configure.ac
@@ -9,7 +9,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-range-loop-construct"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4jets/configure.ac
+++ b/simulation/g4simulation/g4jets/configure.ac
@@ -12,7 +12,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
    CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
   else

--- a/simulation/g4simulation/g4main/configure.ac
+++ b/simulation/g4simulation/g4main/configure.ac
@@ -12,7 +12,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4micromegas/configure.ac
+++ b/simulation/g4simulation/g4micromegas/configure.ac
@@ -10,7 +10,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4mvtx/configure.ac
+++ b/simulation/g4simulation/g4mvtx/configure.ac
@@ -10,7 +10,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4tpc/configure.ac
+++ b/simulation/g4simulation/g4tpc/configure.ac
@@ -9,7 +9,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-misleading-indentation"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4trackfastsim/configure.ac
+++ b/simulation/g4simulation/g4trackfastsim/configure.ac
@@ -12,7 +12,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4vertex/configure.ac
+++ b/simulation/g4simulation/g4vertex/configure.ac
@@ -12,7 +12,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac


### PR DESCRIPTION
…behave identically

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR changes the check for the CXX compiler. It used to be g++ for g++ but the new gcc-8.3 compiler comes with the full path /cvmfs/..../g++ which does not match this. The build cron uses a special setup where g++ is passed down as the compiler. The result was that jenkins and user builds missed the g++ settings which typically add -Werror, so code passed jenkins and bombed out in the daily builds. This PR uses now *g++ which matches both. It has to come after the entry for clang++ since *g++ also matches clang++
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

