### PR TITLE
svtxtrack fastsim

### DIFF
--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -26,6 +26,7 @@ pkginclude_HEADERS = \
   SvtxTrack_v2.h \
   SvtxTrack_FastSim.h \
   SvtxTrack_FastSim_v1.h \
+  SvtxTrack_FastSim_v2.h \
   SvtxTrackMap.h \
   SvtxTrackMap_v1.h \
   SvtxTrackState.h \
@@ -43,6 +44,7 @@ ROOTDICTS = \
   SvtxTrack_v2_Dict.cc \
   SvtxTrack_FastSim_Dict.cc \
   SvtxTrack_FastSim_v1_Dict.cc \
+  SvtxTrack_FastSim_v2_Dict.cc \
   SvtxTrackMap_Dict.cc \
   SvtxTrackMap_v1_Dict.cc \
   SvtxVertex_Dict.cc \
@@ -59,6 +61,7 @@ nobase_dist_pcm_DATA = \
   SvtxTrack_v2_Dict_rdict.pcm \
   SvtxTrack_FastSim_Dict_rdict.pcm \
   SvtxTrack_FastSim_v1_Dict_rdict.pcm \
+  SvtxTrack_FastSim_v2_Dict_rdict.pcm \
   SvtxTrackMap_Dict_rdict.pcm \
   SvtxTrackMap_v1_Dict_rdict.pcm \
   SvtxVertex_Dict_rdict.pcm \
@@ -75,6 +78,7 @@ libtrackbase_historic_io_la_SOURCES = \
   SvtxTrack_v2.cc \
   SvtxTrack_FastSim.cc \
   SvtxTrack_FastSim_v1.cc \
+  SvtxTrack_FastSim_v2.cc \
   SvtxTrackMap.cc \
   SvtxTrackMap_v1.cc \
   SvtxVertex.cc \

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim.cc
@@ -30,6 +30,8 @@ void SvtxTrack_FastSim::CopyFrom( const SvtxTrack& source )
 
 void SvtxTrack_FastSim::identify(std::ostream& os) const
 {
+  SvtxTrack_v1::identify( os );
+
   os << "SvtxTrack_FastSim Object ";
   os << "truth_track_id:" << get_truth_track_id();
   os << "id: " << get_id() << " ";

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim.h
@@ -15,11 +15,10 @@
 class SvtxTrack_FastSim: public SvtxTrack_v1
 {
  public:
-  
+
   //* constructor
-  SvtxTrack_FastSim()
-  {}
-  
+  SvtxTrack_FastSim() = default;
+
   //* destructor
   virtual ~SvtxTrack_FastSim() = default;
 
@@ -30,16 +29,6 @@ class SvtxTrack_FastSim: public SvtxTrack_v1
   virtual void CopyFrom( const SvtxTrack& );
   virtual void CopyFrom( SvtxTrack* source )
   { CopyFrom( *source ); }
-  
-  unsigned int get_truth_track_id() const
-  {
-    return _truth_track_id;
-  }
-
-  void set_truth_track_id(unsigned int truthTrackId)
-  {
-    _truth_track_id = truthTrackId;
-  }
 
   // The "standard PHObject response" functions...
   void identify(std::ostream& os = std::cout) const;
@@ -47,13 +36,29 @@ class SvtxTrack_FastSim: public SvtxTrack_v1
   int isValid() const;
   PHObject* CloneMe() const { return new SvtxTrack_FastSim(*this); }
 
-  void set_num_measurements(int nmeas) 
-  { _nmeas = nmeas; }
-  
-  unsigned int get_num_measurements() const 
+  //!@name accessors
+  //@{
+
+  unsigned int get_truth_track_id() const
+  { return _truth_track_id; }
+
+  unsigned int get_num_measurements() const
   { return _nmeas; }
 
- private:
+  //@}
+
+  //!@name modifiers
+  //@{
+
+  void set_truth_track_id(unsigned int truthTrackId)
+  { _truth_track_id = truthTrackId; }
+
+  void set_num_measurements(int nmeas)
+  { _nmeas = nmeas; }
+
+  //@}
+
+  private:
   unsigned int _truth_track_id = UINT_MAX;
   unsigned int _nmeas = 0;
 

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.cc
@@ -29,6 +29,7 @@ void SvtxTrack_FastSim_v1::identify(std::ostream& os) const
 {
   SvtxTrack_FastSim::identify(os);
 
+  os << "SvtxTrack_FastSim_v1 Object ";
   os << "G4Hit IDs:" << std::endl;
   for( const auto& pair:_g4hit_ids )
   {

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.h
@@ -8,16 +8,16 @@
 #include "SvtxTrack_FastSim.h"
 
 // SvtxTrack_FastSim with recording of associated G4hits
-class SvtxTrack_FastSim_v1 : public SvtxTrack_FastSim
+class SvtxTrack_FastSim_v1 final: public SvtxTrack_FastSim
 {
  public:
-  
+
   //* constructor
-  SvtxTrack_FastSim_v1() {}
-  
+  SvtxTrack_FastSim_v1() = default;
+
   //* base class copy constructor
   SvtxTrack_FastSim_v1( const SvtxTrack& );
-  
+
   //* destructor
   virtual ~SvtxTrack_FastSim_v1() = default;
 
@@ -25,29 +25,71 @@ class SvtxTrack_FastSim_v1 : public SvtxTrack_FastSim
   virtual void CopyFrom( const SvtxTrack& );
   virtual void CopyFrom( SvtxTrack* source )
   { CopyFrom( *source ); }
-  
+
   // The "standard PHObject response" functions...
   void identify(std::ostream& os = std::cout) const;
-  void Reset() { *this = SvtxTrack_FastSim_v1(); }
+  void Reset() 
+  { *this = SvtxTrack_FastSim_v1(); }
+  
   int isValid() const;
-  PHObject* CloneMe() const { return new SvtxTrack_FastSim_v1(*this); }
+  
+  PHObject* CloneMe() const 
+  { return new SvtxTrack_FastSim_v1(*this); }
 
-  bool empty_g4hit_id() const { return _g4hit_ids.empty(); }
-  size_t size_g4hit_id() const { return _g4hit_ids.size(); }
-  void add_g4hit_id(int volume, PHG4HitDefs::keytype id) { _g4hit_ids[volume].insert(id); }
-  SvtxTrack::HitIdIter begin_g4hit_id() { return _g4hit_ids.begin(); }
-  SvtxTrack::HitIdConstIter begin_g4hit_id() const { return _g4hit_ids.begin(); }
-  SvtxTrack::HitIdIter find_g4hit_id(int volume) { return _g4hit_ids.find(volume); }
-  SvtxTrack::HitIdConstIter find_g4hit_id(int volume) const { return _g4hit_ids.find(volume); }
-  SvtxTrack::HitIdIter end_g4hit_id() { return _g4hit_ids.end(); }
-  SvtxTrack::HitIdConstIter end_g4hit_id() const { return _g4hit_ids.end(); }
-  size_t remove_g4hit_id(int volume, PHG4HitDefs::keytype id) { return _g4hit_ids[volume].erase(id); }
-  size_t remove_g4hit_volume(int volume) { return _g4hit_ids.erase(volume); }
-  void clear_g4hit_id() { return _g4hit_ids.clear(); }
-  const HitIdMap& g4hit_ids() const { return _g4hit_ids; }
+
+  //!@name accessors
+  //@{
+
+  const HitIdMap& g4hit_ids() const
+  { return _g4hit_ids; }
+
+  bool empty_g4hit_id() const
+  { return _g4hit_ids.empty(); }
+
+  size_t size_g4hit_id() const
+  { return _g4hit_ids.size(); }
+
+  SvtxTrack::HitIdConstIter begin_g4hit_id() const
+  { return _g4hit_ids.begin(); }
+
+  SvtxTrack::HitIdConstIter end_g4hit_id() const
+  { return _g4hit_ids.end(); }
+
+  SvtxTrack::HitIdConstIter find_g4hit_id(int volume) const
+  { return _g4hit_ids.find(volume); }
+
+  //@}
+
+
+  //!@name modifiers
+  //@{
+
+  void add_g4hit_id(int volume, PHG4HitDefs::keytype id)
+  { _g4hit_ids[volume].insert(id); }
+
+  size_t remove_g4hit_id(int volume, PHG4HitDefs::keytype id)
+  { return _g4hit_ids[volume].erase(id); }
+
+  size_t remove_g4hit_volume(int volume)
+  { return _g4hit_ids.erase(volume); }
+
+  SvtxTrack::HitIdIter begin_g4hit_id()
+  { return _g4hit_ids.begin(); }
+
+  SvtxTrack::HitIdIter end_g4hit_id()
+  { return _g4hit_ids.end(); }
+
+  SvtxTrack::HitIdIter find_g4hit_id(int volume)
+  { return _g4hit_ids.find(volume); }
+
+  void clear_g4hit_id()
+  { return _g4hit_ids.clear(); }
+
+  //@}
 
  private:
-  HitIdMap _g4hit_ids;  //< contained hit ids
+
+  HitIdMap _g4hit_ids;
 
   ClassDef(SvtxTrack_FastSim_v1, 1)
 };

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v2.cc
@@ -1,0 +1,51 @@
+/*
+ * SvtxTrack_FastSim_v2.C
+ *
+ *  Created on: Jul 28, 2016
+ *      Author: yuhw
+ */
+
+#include "SvtxTrack_FastSim_v2.h"
+
+#include "SvtxTrack.h"  // for SvtxTrack::ConstClusterIter, SvtxTrack
+
+#include <map>      // for _Rb_tree_const_iterator
+#include <ostream>  // for operator<<, basic_ostream, basic_ostream<>::_...
+
+SvtxTrack_FastSim_v2::SvtxTrack_FastSim_v2(const SvtxTrack& source)
+{ SvtxTrack_FastSim_v2::CopyFrom( source ); }
+
+void SvtxTrack_FastSim_v2::CopyFrom( const SvtxTrack& source )
+{
+  // parent class method
+  SvtxTrack_v2::CopyFrom( source );
+
+  // additional members
+  _truth_track_id = source.get_truth_track_id();
+  _nmeas = source.get_num_measurements();
+  _g4hit_ids = source.g4hit_ids();
+}
+
+void SvtxTrack_FastSim_v2::identify(std::ostream& os) const
+{
+  SvtxTrack_v2::identify(os);
+
+  os << "SvtxTrack_FastSim_v2 Object ";
+  os << "_truth_Track_id: " << _truth_track_id << std::endl;
+  os << "_nmeas: " << _nmeas << std::endl;
+
+  os << "G4Hit IDs:" << std::endl;
+  for( const auto& pair:_g4hit_ids )
+  {
+    os << "\thit container ID" << pair.first << " with hits: ";
+    for( const auto& hitid:pair.second )
+    { os << hitid << " "; }
+    os << std::endl;
+  }
+  return;
+}
+
+int SvtxTrack_FastSim_v2::isValid() const
+{
+  return 1;
+}

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v2.h
@@ -1,0 +1,109 @@
+/*
+ * SvtxTrack_FastSim_v2.h
+ */
+
+#ifndef TRACKBASEHISTORIC_SVTXTRACKFASTSIMV2_H
+#define TRACKBASEHISTORIC_SVTXTRACKFASTSIMV2_H
+
+#include "SvtxTrack_v2.h"
+
+// SvtxTrack_FastSim with recording of associated G4hits
+class SvtxTrack_FastSim_v2 final: public SvtxTrack_v2
+{
+ public:
+
+  //* constructor
+  SvtxTrack_FastSim_v2() = default;
+
+  //* base class copy constructor
+  SvtxTrack_FastSim_v2( const SvtxTrack& );
+
+  //* destructor
+  virtual ~SvtxTrack_FastSim_v2() = default;
+
+  // copy content from base class
+  virtual void CopyFrom( const SvtxTrack& );
+  virtual void CopyFrom( SvtxTrack* source )
+  { CopyFrom( *source ); }
+
+  // The "standard PHObject response" functions...
+  void identify(std::ostream& os = std::cout) const;
+  void Reset() { *this = SvtxTrack_FastSim_v2(); }
+  int isValid() const;
+
+  PHObject* CloneMe() const
+  { return new SvtxTrack_FastSim_v2(*this); }
+
+  //!@name accessors
+  //@{
+
+  unsigned int get_truth_track_id() const
+  { return _truth_track_id; }
+
+  unsigned int get_num_measurements() const
+  { return _nmeas; }
+
+  const HitIdMap& g4hit_ids() const
+  { return _g4hit_ids; }
+
+  bool empty_g4hit_id() const
+  { return _g4hit_ids.empty(); }
+
+  size_t size_g4hit_id() const
+  { return _g4hit_ids.size(); }
+
+  SvtxTrack::HitIdConstIter begin_g4hit_id() const
+  { return _g4hit_ids.begin(); }
+
+  SvtxTrack::HitIdConstIter end_g4hit_id() const
+  { return _g4hit_ids.end(); }
+
+  SvtxTrack::HitIdConstIter find_g4hit_id(int volume) const
+  { return _g4hit_ids.find(volume); }
+
+  //@}
+
+
+  //!@name modifiers
+  //@{
+
+  void set_truth_track_id(unsigned int truthTrackId)
+  { _truth_track_id = truthTrackId; }
+
+  void set_num_measurements(int nmeas)
+  { _nmeas = nmeas; }
+
+  void add_g4hit_id(int volume, PHG4HitDefs::keytype id)
+  { _g4hit_ids[volume].insert(id); }
+
+  size_t remove_g4hit_id(int volume, PHG4HitDefs::keytype id)
+  { return _g4hit_ids[volume].erase(id); }
+
+  size_t remove_g4hit_volume(int volume)
+  { return _g4hit_ids.erase(volume); }
+
+  SvtxTrack::HitIdIter begin_g4hit_id()
+  { return _g4hit_ids.begin(); }
+
+  SvtxTrack::HitIdIter end_g4hit_id()
+  { return _g4hit_ids.end(); }
+
+  SvtxTrack::HitIdIter find_g4hit_id(int volume)
+  { return _g4hit_ids.find(volume); }
+
+  void clear_g4hit_id()
+  { return _g4hit_ids.clear(); }
+
+  //@}
+
+ private:
+
+  unsigned int _truth_track_id = UINT_MAX;
+  unsigned int _nmeas = 0;
+
+  HitIdMap _g4hit_ids;
+
+  ClassDef(SvtxTrack_FastSim_v2, 1)
+};
+
+#endif /* __SVTXTRACK_FAST_SIMV1_H__ */

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v2LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxTrack_FastSim_v2 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.h
@@ -14,7 +14,7 @@
 
 class PHObject;
 
-class SvtxTrack_v2 final : public SvtxTrack
+class SvtxTrack_v2: public SvtxTrack
 {
  public:
   SvtxTrack_v2();

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -4,7 +4,7 @@
 
 #include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTra...
 #include <trackbase_historic/SvtxTrackMap.h>  // for SvtxTrackMap, Svtx...
-#include <trackbase_historic/SvtxTrack_FastSim.h>
+#include <trackbase_historic/SvtxTrack_FastSim_v2.h>
 #include <trackbase_historic/SvtxVertexMap.h>
 
 #include <trackbase/TrkrCluster.h>
@@ -262,8 +262,7 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
     if (layers.size() >=  _min_clusters_per_track)
     {
 
-      std::unique_ptr<SvtxTrack_FastSim> svtx_track(new SvtxTrack_FastSim());
-
+      auto svtx_track = std::make_unique<SvtxTrack_FastSim_v2>();
       svtx_track->set_id(_track_map->size());
       svtx_track->set_truth_track_id(trk_clusters_itr->first);
 

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -4,7 +4,7 @@
 
 #include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTra...
 #include <trackbase_historic/SvtxTrackMap.h>  // for SvtxTrackMap, Svtx...
-#include <trackbase_historic/SvtxTrack_FastSim.h>
+#include <trackbase_historic/SvtxTrack_FastSim_v2.h>
 
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
@@ -118,7 +118,7 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
     if(ClusterKeyList.size()< _min_clusters_per_track)
       continue;
 
-    auto svtx_track = std::make_unique<SvtxTrack_FastSim>();
+    auto svtx_track = std::make_unique<SvtxTrack_FastSim_v2>();
     svtx_track->set_id(_track_map->size());
     svtx_track->set_truth_track_id(gtrackID);
     ///g4 vertex id starts at 1, svtx vertex map starts at 0


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR creates a new SvtxTrack_FastSim_v2 class that 
- inherits from SvtxTrack_v2
- implements the additional functionalities of both SvtxTrack_FastSim and SvtxTrack_FastSim_v1
This new class is now the one constructed in trackreco/PHSiliconTruthTrackSeeding and trackreco/PHTruthTrackSeeding.
This allows to fully run ACTS on top of these modules, and in particular properly store and retrieve the newly introduced 6x6 ACTS covariance matrix. This in turn should allow to run ACTS final vertex fit. 

Classes SvtxTrack_FastSim_v1 and SvtxTrack_FastSim_v2 are marked as "final" because future versions of SvtxTrack_FastSim will have to inherit not from the previous version but from whatever latest version of FvtxTrack_vXXX there is, in order not to introduce regressions in the tracking chain. 


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

