### PR TITLE
Modify PHTrackSeeding

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -1011,6 +1011,14 @@ int PHCASeeding::Setup(PHCompositeNode *topNode)
   if(Verbosity()>0) cout << "Called Setup" << endl;
   if(Verbosity()>0) cout << "topNode:" << topNode << endl;
   PHTrackSeeding::Setup(topNode);
+
+  _vertex_map = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+  if (!_vertex_map)
+  {
+    cerr << PHWHERE << " ERROR: Can't find SvtxVertexMap." << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
   InitializeGeometry(topNode);
  #if __cplusplus < 201402L
   t_fill = boost::make_unique<PHTimer>("t_fill");

--- a/offline/packages/trackreco/PHHybridSeeding.cc
+++ b/offline/packages/trackreco/PHHybridSeeding.cc
@@ -323,6 +323,14 @@ int PHHybridSeeding::Setup(PHCompositeNode *topNode)
   if(Verbosity()>0) cout << "Called Setup" << endl;
   if(Verbosity()>0) cout << "topNode:" << topNode << endl;
   PHTrackSeeding::Setup(topNode);
+
+  _vertex_map = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+  if (!_vertex_map)
+    {
+      cerr << PHWHERE << " ERROR: Can't find SvtxVertexMap." << endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  
   InitializeGeometry(topNode);
   fitter = std::make_shared<ALICEKF>(topNode,_cluster_map,_fieldDir,_min_fit_track_size,_max_sin_phi,Verbosity()); 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -7,7 +7,7 @@
 #include <trackbase_historic/SvtxTrack_FastSim.h>
 #include <trackbase_historic/SvtxVertexMap.h>
 
-#include <trackbase/TrkrCluster.h>
+#include <trackbase/TrkrClusterv2.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssocv2.h>
 #include <trackbase/TrkrDefs.h>

--- a/offline/packages/trackreco/PHTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTrackSeeding.cc
@@ -131,13 +131,6 @@ int PHTrackSeeding::GetNodes(PHCompositeNode* topNode)
     cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTERHITASSOC" << endl;
   }
 
-  _vertex_map = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
-  if (!_vertex_map)
-  {
-    cerr << PHWHERE << " ERROR: Can't find SvtxVertexMap." << endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
- 
  _track_map = findNode::getClass<SvtxTrackMap>(topNode, _track_map_name);
   if (!_track_map)
   {

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -23,6 +23,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4HitDefs.h>  // for keytype
 #include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4VtxPoint.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -112,7 +113,7 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
     for(unsigned int layer = _min_layer;layer < _max_layer;layer++){
       TrkrDefs::cluskey cluskey = _clustereval->best_cluster_by_nhit(gtrackID, layer);
-      if(cluskey!=0)
+      if(cluskey!=0) 
 	ClusterKeyList.push_back(cluskey);
     }
     if(ClusterKeyList.size()< _min_clusters_per_track)
@@ -122,6 +123,7 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
     svtx_track->set_id(_track_map->size());
     svtx_track->set_truth_track_id(gtrackID);
     ///g4 vertex id starts at 1, svtx vertex map starts at 0
+    // This is te truth particle vertex, and does not necessarily give the ID in the vertex map
     svtx_track->set_vertex_id(vertexID-1);
     
     // set track charge
@@ -146,6 +148,12 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
     svtx_track->set_px(g4particle->get_px() * (1 + random));
     svtx_track->set_py(g4particle->get_py() * (1 + random));
     svtx_track->set_pz(g4particle->get_pz() * (1 + random));
+
+    // assign the track position using the truth vertex for this track
+    auto g4vertex = _g4truth_container->GetVtx(vertexID);
+    svtx_track->set_x(g4vertex->get_x() * (1 + random));
+    svtx_track->set_y(g4vertex->get_y() * (1 + random));
+    svtx_track->set_z(g4vertex->get_z() * (1 + random));
       
     for (TrkrDefs::cluskey cluskey : ClusterKeyList){
       svtx_track->insert_cluster_key(cluskey);
@@ -158,7 +166,7 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
   
   if (Verbosity() >= 5)
   {
-    cout << "Loop over SvtxTrackMap entries " << endl;
+    cout << "Loop over TrackMap " << _track_map_name << " entries " << endl;
     for (SvtxTrackMap::Iter iter = _track_map->begin();
          iter != _track_map->end(); ++iter)
     {
@@ -169,7 +177,9 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
       cout << "Track ID: " << svtx_track->get_id() << ", Dummy Track pT: "
            << svtx_track->get_pt() << ", Truth Track/Particle ID: "
-           << svtx_track->get_truth_track_id() << endl;
+           << svtx_track->get_truth_track_id() 
+	   << " (X,Y,Z) " << svtx_track->get_x() << ", " << svtx_track->get_y() << ", " << svtx_track->get_z()  
+	   << endl;
       cout << " nhits: " << svtx_track->size_cluster_keys()<< endl;
       //Print associated clusters;
       for (SvtxTrack::ConstClusterKeyIter iter_clus =


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR just removes the requirement from PHTrackSeeding (the seeding base class) that the SvtxVertexMap be present during instantiation. Now the derived classes get a pointer to SvtxVertexMap as needed. This was needed to allow the reorganization of the G4_Tracking.C macro. It should be transparent to users.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

