### PR TITLE
Another fix about Micromegas in Tracking QA

### DIFF
--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -673,6 +673,7 @@ int QAG4SimulationTracking::load_nodes(PHCompositeNode *topNode)
   m_g4hits_tpc = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_TPC");
   m_g4hits_intt = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_INTT");
   m_g4hits_mvtx = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_MVTX");
+  m_g4hits_micromegas = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_MICROMEGAS");
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -718,6 +719,10 @@ QAG4SimulationTracking::G4HitSet QAG4SimulationTracking::find_g4hits(TrkrDefs::c
 
       case TrkrDefs::tpcId:
         if (m_g4hits_tpc) g4hit = m_g4hits_tpc->findHit(g4hit_key);
+        break;
+
+      case TrkrDefs::micromegasId:
+        if (m_g4hits_micromegas) g4hit = m_g4hits_micromegas->findHit(g4hit_key);
         break;
 
       default:

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -82,6 +82,7 @@ class QAG4SimulationTracking : public SubsysReco
   PHG4HitContainer *m_g4hits_tpc = nullptr;
   PHG4HitContainer *m_g4hits_intt = nullptr;
   PHG4HitContainer *m_g4hits_mvtx = nullptr;
+  PHG4HitContainer *m_g4hits_micromegas = nullptr;
 };
 
 #endif  // QA_QAG4SimulationTracking_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

In order to also get the number of micromegas clusters per layer per truth track (histogram named nClus_layerGen one must also get the micromegas G4Hit node, and look there to find G4Hits associated to tracks. 

After the patch, said histogram looks like this: 
![Screenshot_20210501_074833](https://user-images.githubusercontent.com/22907496/116784478-a7d8ac80-aa51-11eb-8ee6-564edfb6a35e.png)

The last two layers are the micromegas ones

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

