### PR TITLE
Master fix clustercontainers

### DIFF
--- a/offline/QA/modules/QAG4SimulationIntt.cc
+++ b/offline/QA/modules/QAG4SimulationIntt.cc
@@ -11,7 +11,7 @@
 
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>  // for getTrkrId, getHit...
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase/TrkrHitSet.h>

--- a/offline/QA/modules/QAG4SimulationMicromegas.cc
+++ b/offline/QA/modules/QAG4SimulationMicromegas.cc
@@ -11,7 +11,7 @@
 
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>  // for getTrkrId, getHit...
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase/TrkrHitSet.h>

--- a/offline/QA/modules/QAG4SimulationMvtx.cc
+++ b/offline/QA/modules/QAG4SimulationMvtx.cc
@@ -11,7 +11,7 @@
 
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>  // for getTrkrId, getHit...
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase/TrkrHitSet.h>

--- a/offline/QA/modules/QAG4SimulationTpc.cc
+++ b/offline/QA/modules/QAG4SimulationTpc.cc
@@ -13,7 +13,7 @@
 
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>  // for getTrkrId
 #include <trackbase/TrkrHitTruthAssoc.h>
 

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -12,7 +12,7 @@
 
 #include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>  // for cluskey, getLayer
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase_historic/SvtxTrack.h>

--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -2,7 +2,7 @@
 #include "CylinderGeomIntt.h"
 #include "InttDefs.h"
 
-#include <trackbase/TrkrClusterContainerv2.h>
+#include <trackbase/TrkrClusterContainerv3.h>
 #include <trackbase/TrkrClusterv2.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHitSet.h>
@@ -126,7 +126,7 @@ int InttClusterizer::InitRun(PHCompositeNode* topNode)
 	dstNode->addNode(DetNode);
       }
     
-    trkrclusters = new TrkrClusterContainerv2;
+    trkrclusters = new TrkrClusterContainerv3;
     PHIODataNode<PHObject> *TrkrClusterContainerNode =
       new PHIODataNode<PHObject>(trkrclusters, "TRKR_CLUSTER", "PHObject");
     DetNode->addNode(TrkrClusterContainerNode);

--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -8,7 +8,7 @@
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitv2.h>
 #include <trackbase/TrkrHitSetContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssocv3.h>
 
 #include <g4detectors/PHG4CylinderGeom.h>
 #include <g4detectors/PHG4CylinderGeomContainer.h>
@@ -132,7 +132,7 @@ int InttClusterizer::InitRun(PHCompositeNode* topNode)
     DetNode->addNode(TrkrClusterContainerNode);
   }
 
-  TrkrClusterHitAssoc *clusterhitassoc = findNode::getClass<TrkrClusterHitAssoc>(topNode,"TRKR_CLUSTERHITASSOC");
+  auto clusterhitassoc = findNode::getClass<TrkrClusterHitAssoc>(topNode,"TRKR_CLUSTERHITASSOC");
   if(!clusterhitassoc)
     {
       PHNodeIterator dstiter(dstNode);
@@ -144,7 +144,7 @@ int InttClusterizer::InitRun(PHCompositeNode* topNode)
 	  dstNode->addNode(DetNode);
 	}
 
-      clusterhitassoc = new TrkrClusterHitAssocv2();
+      clusterhitassoc = new TrkrClusterHitAssocv3;
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(clusterhitassoc, "TRKR_CLUSTERHITASSOC", "PHObject");
       DetNode->addNode(newNode);
     }

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -16,7 +16,7 @@
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrHitSetContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssocv3.h>
 
 #include <Acts/Utilities/Units.hpp>
 #include <Acts/Surfaces/Surface.hpp>
@@ -95,7 +95,7 @@ int MicromegasClusterizer::InitRun(PHCompositeNode *topNode)
       dstNode->addNode(trkrNode);
     }
 
-    trkrClusterHitAssoc = new TrkrClusterHitAssocv2();
+    trkrClusterHitAssoc = new TrkrClusterHitAssocv3;
     PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(trkrClusterHitAssoc, "TRKR_CLUSTERHITASSOC", "PHObject");
     trkrNode->addNode(newNode);
   }

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -10,7 +10,7 @@
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4detectors/PHG4CylinderGeom.h>           // for PHG4CylinderGeom
 
-#include <trackbase/TrkrClusterContainerv2.h>        // for TrkrCluster
+#include <trackbase/TrkrClusterContainerv3.h>        // for TrkrCluster
 #include <trackbase/TrkrClusterv2.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHitSet.h>
@@ -78,7 +78,7 @@ int MicromegasClusterizer::InitRun(PHCompositeNode *topNode)
       dstNode->addNode(trkrNode);
     }
 
-    trkrClusterContainer = new TrkrClusterContainerv2;
+    trkrClusterContainer = new TrkrClusterContainerv3;
     auto TrkrClusterContainerNode = new PHIODataNode<PHObject>(trkrClusterContainer, "TRKR_CLUSTER", "PHObject");
     trkrNode->addNode(TrkrClusterContainerNode);
   }

--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -17,7 +17,7 @@
 #include <trackbase/TrkrHitv2.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssocv3.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>                     // for SubsysReco
@@ -138,7 +138,7 @@ int MvtxClusterizer::InitRun(PHCompositeNode *topNode)
     DetNode->addNode(TrkrClusterContainerNode);
   }
 
-  TrkrClusterHitAssoc *clusterhitassoc = findNode::getClass<TrkrClusterHitAssoc>(topNode,"TRKR_CLUSTERHITASSOC");
+  auto clusterhitassoc = findNode::getClass<TrkrClusterHitAssoc>(topNode,"TRKR_CLUSTERHITASSOC");
   if(!clusterhitassoc)
     {
       PHNodeIterator dstiter(dstNode);
@@ -150,7 +150,7 @@ int MvtxClusterizer::InitRun(PHCompositeNode *topNode)
 	  dstNode->addNode(DetNode);
 	}
 
-      clusterhitassoc = new TrkrClusterHitAssocv2();
+      clusterhitassoc = new TrkrClusterHitAssocv3;
       PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(clusterhitassoc, "TRKR_CLUSTERHITASSOC", "PHObject");
       DetNode->addNode(newNode);
     }

--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -11,7 +11,7 @@
 #include <g4detectors/PHG4CylinderGeom.h>
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
-#include <trackbase/TrkrClusterContainerv2.h>
+#include <trackbase/TrkrClusterContainerv3.h>
 #include <trackbase/TrkrClusterv2.h>
 #include <trackbase/TrkrDefs.h>                     // for hitkey, getLayer
 #include <trackbase/TrkrHitv2.h>
@@ -132,7 +132,7 @@ int MvtxClusterizer::InitRun(PHCompositeNode *topNode)
 	dstNode->addNode(DetNode);
       }
 
-    trkrclusters = new TrkrClusterContainerv2;
+    trkrclusters = new TrkrClusterContainerv3;
     PHIODataNode<PHObject> *TrkrClusterContainerNode =
       new PHIODataNode<PHObject>(trkrclusters, "TRKR_CLUSTER", "PHObject");
     DetNode->addNode(TrkrClusterContainerNode);

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -4,7 +4,7 @@
 
 #include <trackbase/TrkrClusterContainerv2.h>
 #include <trackbase/TrkrClusterv2.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssocv3.h>
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
 #include <trackbase/TrkrHitv2.h>
 #include <trackbase/TrkrHitSet.h>
@@ -671,7 +671,7 @@ int TpcClusterizer::InitRun(PHCompositeNode *topNode)
     DetNode->addNode(TrkrClusterContainerNode);
   }
 
-  TrkrClusterHitAssoc *clusterhitassoc = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
+  auto clusterhitassoc = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
   if (!clusterhitassoc)
   {
     PHNodeIterator dstiter(dstNode);
@@ -683,7 +683,7 @@ int TpcClusterizer::InitRun(PHCompositeNode *topNode)
       dstNode->addNode(DetNode);
     }
 
-    clusterhitassoc = new TrkrClusterHitAssocv2();
+    clusterhitassoc = new TrkrClusterHitAssocv3;
     PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(clusterhitassoc, "TRKR_CLUSTERHITASSOC", "PHObject");
     DetNode->addNode(newNode);
   }

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -2,7 +2,7 @@
 
 #include "TpcDefs.h"
 
-#include <trackbase/TrkrClusterContainerv2.h>
+#include <trackbase/TrkrClusterContainerv3.h>
 #include <trackbase/TrkrClusterv2.h>
 #include <trackbase/TrkrClusterHitAssocv3.h>
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
@@ -665,7 +665,7 @@ int TpcClusterizer::InitRun(PHCompositeNode *topNode)
       dstNode->addNode(DetNode);
     }
 
-    trkrclusters = new TrkrClusterContainerv2;
+    trkrclusters = new TrkrClusterContainerv3;
     PHIODataNode<PHObject> *TrkrClusterContainerNode =
         new PHIODataNode<PHObject>(trkrclusters, "TRKR_CLUSTER", "PHObject");
     DetNode->addNode(TrkrClusterContainerNode);

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -30,6 +30,7 @@ pkginclude_HEADERS = \
   TrkrClusterHitAssoc.h \
   TrkrClusterHitAssocv1.h \
   TrkrClusterHitAssocv2.h \
+  TrkrClusterHitAssocv3.h \
   TrkrDefs.h \
   TrkrHit.h \
   TrkrHitv1.h \
@@ -50,6 +51,7 @@ ROOTDICTS = \
   TrkrClusterHitAssoc_Dict.cc \
   TrkrClusterHitAssocv1_Dict.cc \
   TrkrClusterHitAssocv2_Dict.cc \
+  TrkrClusterHitAssocv3_Dict.cc \
   TrkrHit_Dict.cc \
   TrkrHitv1_Dict.cc \
   TrkrHitv2_Dict.cc \
@@ -70,6 +72,7 @@ nobase_dist_pcm_DATA = \
   TrkrClusterHitAssoc_Dict_rdict.pcm \
   TrkrClusterHitAssocv1_Dict_rdict.pcm \
   TrkrClusterHitAssocv2_Dict_rdict.pcm \
+  TrkrClusterHitAssocv3_Dict_rdict.pcm \
   TrkrHit_Dict_rdict.pcm \
   TrkrHitv1_Dict_rdict.pcm \
   TrkrHitv2_Dict_rdict.pcm \
@@ -89,6 +92,7 @@ libtrack_io_la_SOURCES = \
   TrkrClusterContainerv2.cc \
   TrkrClusterHitAssocv1.cc \
   TrkrClusterHitAssocv2.cc \
+  TrkrClusterHitAssocv3.cc \
   TrkrDefs.cc \
   TrkrHitTruthAssoc.cc \
   TrkrHitSet.cc \

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -27,6 +27,7 @@ pkginclude_HEADERS = \
   TrkrClusterContainer.h \
   TrkrClusterContainerv1.h \
   TrkrClusterContainerv2.h \
+  TrkrClusterContainerv3.h \
   TrkrClusterHitAssoc.h \
   TrkrClusterHitAssocv1.h \
   TrkrClusterHitAssocv2.h \
@@ -48,6 +49,7 @@ ROOTDICTS = \
   TrkrClusterContainer_Dict.cc \
   TrkrClusterContainerv1_Dict.cc \
   TrkrClusterContainerv2_Dict.cc \
+  TrkrClusterContainerv3_Dict.cc \
   TrkrClusterHitAssoc_Dict.cc \
   TrkrClusterHitAssocv1_Dict.cc \
   TrkrClusterHitAssocv2_Dict.cc \
@@ -69,6 +71,7 @@ nobase_dist_pcm_DATA = \
   TrkrClusterContainer_Dict_rdict.pcm \
   TrkrClusterContainerv1_Dict_rdict.pcm \
   TrkrClusterContainerv2_Dict_rdict.pcm \
+  TrkrClusterContainerv3_Dict_rdict.pcm \
   TrkrClusterHitAssoc_Dict_rdict.pcm \
   TrkrClusterHitAssocv1_Dict_rdict.pcm \
   TrkrClusterHitAssocv2_Dict_rdict.pcm \
@@ -90,6 +93,7 @@ libtrack_io_la_SOURCES = \
   TrkrClusterContainer.cc \
   TrkrClusterContainerv1.cc \
   TrkrClusterContainerv2.cc \
+  TrkrClusterContainerv3.cc \
   TrkrClusterHitAssocv1.cc \
   TrkrClusterHitAssocv2.cc \
   TrkrClusterHitAssocv3.cc \

--- a/offline/packages/trackbase/TrkrClusterContainerv1.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv1.cc
@@ -6,7 +6,7 @@
  */
 #include "TrkrClusterContainerv1.h"
 #include "TrkrCluster.h"
-#include "TrkrClusterv1.h"
+#include "TrkrClusterv2.h"
 
 #include <cstdlib>
 
@@ -69,7 +69,7 @@ TrkrClusterContainerv1::findOrAddCluster(TrkrDefs::cluskey key)
   if (it == m_clusmap.end()|| (key < it->first ))
   {
     // add new cluster and set its key
-    it = m_clusmap.insert(it, std::make_pair(key, new TrkrClusterv1()));
+    it = m_clusmap.insert(it, std::make_pair(key, new TrkrClusterv2()));
     it->second->setClusKey(key);
   }
   return it;

--- a/offline/packages/trackbase/TrkrClusterContainerv2.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv2.cc
@@ -6,7 +6,7 @@
  */
 #include "TrkrClusterContainerv2.h"
 #include "TrkrCluster.h"
-#include "TrkrClusterv1.h"
+#include "TrkrClusterv2.h"
 #include "TrkrDefs.h"
 
 #include <cstdlib>
@@ -195,7 +195,7 @@ TrkrClusterContainerv2::findOrAddCluster(TrkrDefs::cluskey key)
     if( it == m_clusmap[layer][sector][side].end() || (key < it->first) )
     {
       // add new cluster and set its key
-      it = m_clusmap[layer][sector][side].insert(it, std::make_pair(key, new TrkrClusterv1()));
+      it = m_clusmap[layer][sector][side].insert(it, std::make_pair(key, new TrkrClusterv2()));
       it->second->setClusKey( key );
     }
     return it;

--- a/offline/packages/trackbase/TrkrClusterContainerv2.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv2.cc
@@ -192,7 +192,7 @@ TrkrClusterContainerv2::findOrAddCluster(TrkrDefs::cluskey key)
   if( layer < max_layer && sector < max_phisegment && side < max_zsegment )
   {
     auto it = m_clusmap[layer][sector][side].lower_bound(key);
-    if( it == m_clusmap[layer][sector][side].end() || (it->first < key) )
+    if( it == m_clusmap[layer][sector][side].end() || (key < it->first) )
     {
       // add new cluster and set its key
       it = m_clusmap[layer][sector][side].insert(it, std::make_pair(key, new TrkrClusterv1()));

--- a/offline/packages/trackbase/TrkrClusterContainerv3.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.cc
@@ -1,0 +1,163 @@
+/**
+ * @file trackbase/TrkrClusterContainerv3.cc
+ * @author D. McGlinchey, Hugo Pereira Da Costa
+ * @date June 2018
+ * @brief Implementation of TrkrClusterContainerv3
+ */
+#include "TrkrClusterContainerv3.h"
+#include "TrkrCluster.h"
+#include "TrkrClusterv2.h"
+#include "TrkrDefs.h"
+
+#include <cstdlib>
+
+namespace
+{
+  TrkrClusterContainer::Map dummy_map;
+}
+
+//_________________________________________________________________
+void TrkrClusterContainerv3::Reset()
+{
+  // delete all clusters
+  for( const auto& map_pair:m_clusmap )
+    for( const auto& pair:map_pair.second )
+  { delete pair.second; }
+
+  // clear the maps
+  m_clusmap.clear();
+}
+
+//_________________________________________________________________
+void TrkrClusterContainerv3::identify(std::ostream& os) const
+{
+  os << "-----TrkrClusterContainerv3-----" << std::endl;
+  os << "Number of clusters: " << size() << std::endl;
+
+  for( const auto& map_pair:m_clusmap )
+  {
+
+    const unsigned int layer = TrkrDefs::getLayer(map_pair.first);
+    std::cout << "layer: " << layer << " hitsetkey: " << map_pair.first << std::endl;
+
+    for( const auto& pair:map_pair.second )
+    {
+      int layer = TrkrDefs::getLayer(pair.first);
+      os << "clus key " << pair.first  << " layer " << layer << std::endl;
+      (pair.second)->identify();
+    }
+  }
+
+  os << "------------------------------" << std::endl;
+}
+
+//_________________________________________________________________
+void TrkrClusterContainerv3::removeCluster(TrkrDefs::cluskey key)
+{
+  // get hitset key from cluster
+  const TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey( key );
+  
+  // find relevant cluster map if any and remove corresponding cluster
+  auto iter = m_clusmap.find( hitsetkey );
+  if( iter != m_clusmap.end() ) iter->second.erase( key );
+}
+  
+//_________________________________________________________________
+void TrkrClusterContainerv3::removeCluster(TrkrCluster *clus)
+{ removeCluster( clus->getClusKey() ); }
+
+//_________________________________________________________________
+TrkrClusterContainerv3::ConstIterator
+TrkrClusterContainerv3::addCluster(TrkrCluster* newclus)
+{ return addClusterSpecifyKey(newclus->getClusKey(), newclus); }
+
+//_________________________________________________________________
+TrkrClusterContainerv3::ConstIterator
+TrkrClusterContainerv3::addClusterSpecifyKey(const TrkrDefs::cluskey key, TrkrCluster* newclus)
+{
+  // get hitsetkey from cluster
+  const TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey( key );
+
+  // find relevant cluster map or create one if not found
+  Map& map = m_clusmap[hitsetkey];
+  const auto ret = map.insert(std::make_pair(key, newclus));
+  if ( !ret.second )
+  {
+    std::cout << "TrkrClusterContainerv3::AddClusterSpecifyKey: duplicate key: " << key << " exiting now" << std::endl;
+    exit(1);
+  } else {
+    ret.first->second->setClusKey( key );
+    return ret.first;
+  }
+}
+
+//_________________________________________________________________
+TrkrClusterContainerv3::ConstRange
+TrkrClusterContainerv3::getClusters(TrkrDefs::hitsetkey hitsetkey) const
+{
+  // find relevant association map
+  const auto iter = m_clusmap.find(hitsetkey);
+  if( iter != m_clusmap.end() ) 
+  {
+    return std::make_pair( iter->second.cbegin(), iter->second.cend() );
+  } else { 
+    return std::make_pair( dummy_map.cbegin(), dummy_map.cend() );
+  }
+}
+
+//_________________________________________________________________
+TrkrClusterContainerv3::Map*
+TrkrClusterContainerv3::getClusterMap(TrkrDefs::hitsetkey hitsetkey)
+{ return &m_clusmap[hitsetkey]; }
+  
+//_________________________________________________________________
+TrkrClusterContainerv3::Iterator
+TrkrClusterContainerv3::findOrAddCluster(TrkrDefs::cluskey key)
+{
+  // get hitsetkey from cluster
+  const TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey( key );
+
+  // find relevant cluster map or create one if not found
+  Map& map = m_clusmap[hitsetkey];
+  auto it = map.lower_bound(key);
+  if( it == map.end() || (key<it->first) )
+  {
+    // add new cluster and set its key
+    it = map.insert(it, std::make_pair(key, new TrkrClusterv2()));
+    it->second->setClusKey( key );
+  }
+  
+  return it;
+}
+
+//_________________________________________________________________
+TrkrCluster* TrkrClusterContainerv3::findCluster(TrkrDefs::cluskey key) const
+{
+  
+  // get hitsetkey from cluster
+  const TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey( key );
+
+  const auto map_iter = m_clusmap.find(hitsetkey);
+  if( map_iter != m_clusmap.end() ) 
+  {
+    const auto clus_iter = map_iter->second.find( key );
+    if( clus_iter !=  map_iter->second.end() )
+    { 
+      return clus_iter->second;
+    } else {
+      return nullptr;
+    }
+  } else {
+    return nullptr;
+  }
+}
+
+//_________________________________________________________________
+unsigned int TrkrClusterContainerv3::size(void) const
+{
+  unsigned int size = 0;
+  for( const auto& map_pair:m_clusmap )
+  { size += map_pair.second.size(); }
+  
+  return size;
+}

--- a/offline/packages/trackbase/TrkrClusterContainerv3.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.h
@@ -1,0 +1,56 @@
+#ifndef TRACKBASE_TRKRCLUSTERCONTAINERV3_H
+#define TRACKBASE_TRKRCLUSTERCONTAINERV3_H
+
+/**
+ * @file trackbase/TrkrClusterContainerv3.h
+ * @author D. McGlinchey, Hugo Pereira Da Costa
+ * @date June 2018
+ * @brief Cluster container object
+ */
+
+#include "TrkrClusterContainer.h"
+
+#include <phool/PHObject.h>
+
+class TrkrCluster;
+
+/**
+ * @brief Cluster container object
+ */
+class TrkrClusterContainerv3 : public TrkrClusterContainer
+{
+  public:
+
+  TrkrClusterContainerv3() = default;
+
+  virtual void Reset();
+
+  virtual void identify(std::ostream &os = std::cout) const;
+
+  virtual ConstIterator addCluster(TrkrCluster*);
+
+  virtual ConstIterator addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster*);
+
+  virtual void removeCluster(TrkrDefs::cluskey);
+
+  virtual void removeCluster(TrkrCluster*);
+
+  virtual Iterator findOrAddCluster(TrkrDefs::cluskey);
+
+  virtual ConstRange getClusters(TrkrDefs::hitsetkey) const;
+
+  virtual Map* getClusterMap(TrkrDefs::hitsetkey);
+
+  virtual TrkrCluster* findCluster(TrkrDefs::cluskey) const;
+
+  virtual unsigned int size(void) const;
+
+  private:
+  
+  std::map<TrkrDefs::hitsetkey, Map> m_clusmap;
+
+  ClassDef(TrkrClusterContainerv3, 1)
+
+};
+
+#endif //TRACKBASE_TrkrClusterContainerv3_H

--- a/offline/packages/trackbase/TrkrClusterContainerv3LinkDef.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TrkrClusterContainerv3+;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase/TrkrClusterHitAssocv3.cc
+++ b/offline/packages/trackbase/TrkrClusterHitAssocv3.cc
@@ -1,0 +1,84 @@
+/**
+ * @file trackbase/TrkrClusterHitAssocv3.cc
+ * @author D. McGlinchey
+ * @date June 2018
+ * @brief TrkrClusterHitAssoc implementation
+ */
+
+#include "TrkrClusterHitAssocv3.h"
+#include "TrkrDefs.h"
+
+#include <ostream>  // for operator<<, endl, basic_ostream, ostream, basic_o...
+
+namespace
+{
+  TrkrClusterHitAssocv3::Map dummy_map;
+}
+
+//_________________________________________________________________________
+void TrkrClusterHitAssocv3::Reset()
+{ m_map.clear(); }
+
+//_________________________________________________________________________
+void TrkrClusterHitAssocv3::identify(std::ostream &os) const
+{
+  std::multimap<TrkrDefs::cluskey, TrkrDefs::hitkey>::const_iterator iter;
+  os << "-----TrkrClusterHitAssocv3-----" << std::endl;
+  os << "Number of associations: " << size() << std::endl;
+  for( const auto& map_pair:m_map )
+  {
+    for( const auto& pair:map_pair.second )
+    {
+      os << "clus key " << pair.first << std::dec
+        << " layer " << (unsigned int) TrkrDefs::getLayer(pair.first)
+        << " hit key: " << pair.second << std::endl;
+    }
+  }
+  os << "------------------------------" << std::endl;
+
+  return;
+
+}
+
+//_________________________________________________________________________
+void TrkrClusterHitAssocv3::addAssoc(TrkrDefs::cluskey ckey, unsigned int hidx)
+{ 
+  // get hitset key from cluster
+  const TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey( ckey );
+  
+  // find relevant association map, create one if not found
+  Map& clusterMap = m_map[hitsetkey];
+  
+  // insert association
+  clusterMap.insert(std::make_pair(ckey, hidx));
+}
+
+//_________________________________________________________________________
+TrkrClusterHitAssocv3::Map* TrkrClusterHitAssocv3::getClusterMap(TrkrDefs::hitsetkey hitsetkey)
+{
+  // find relevant association map, create one if not found, and return adress
+  return &m_map[hitsetkey];
+}
+
+//_________________________________________________________________________
+TrkrClusterHitAssocv3::ConstRange TrkrClusterHitAssocv3::getHits(TrkrDefs::cluskey ckey)
+{
+  // get hitset key from cluster
+  const TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey( ckey );
+
+  // find relevant association map, create one if not found
+  const Map& clusterMap = m_map[hitsetkey];
+  
+  // return range matching cluster key
+  return std::make_pair( clusterMap.lower_bound(ckey), clusterMap.upper_bound(ckey) );
+}
+
+//_________________________________________________________________________
+unsigned int TrkrClusterHitAssocv3::size(void) const
+{  
+  unsigned int size = 0;
+  for( const auto& map_pair:m_map )
+  { size += map_pair.second.size(); }
+
+  return size;
+}

--- a/offline/packages/trackbase/TrkrClusterHitAssocv3.cc
+++ b/offline/packages/trackbase/TrkrClusterHitAssocv3.cc
@@ -42,13 +42,13 @@ void TrkrClusterHitAssocv3::identify(std::ostream &os) const
 
 //_________________________________________________________________________
 void TrkrClusterHitAssocv3::addAssoc(TrkrDefs::cluskey ckey, unsigned int hidx)
-{ 
+{
   // get hitset key from cluster
   const TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey( ckey );
-  
+
   // find relevant association map, create one if not found
   Map& clusterMap = m_map[hitsetkey];
-  
+
   // insert association
   clusterMap.insert(std::make_pair(ckey, hidx));
 }
@@ -67,15 +67,18 @@ TrkrClusterHitAssocv3::ConstRange TrkrClusterHitAssocv3::getHits(TrkrDefs::clusk
   const TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey( ckey );
 
   // find relevant association map, create one if not found
-  const Map& clusterMap = m_map[hitsetkey];
-  
-  // return range matching cluster key
-  return std::make_pair( clusterMap.lower_bound(ckey), clusterMap.upper_bound(ckey) );
+  const auto iter = m_map.find(hitsetkey);
+  if( iter != m_map.end() )
+  {
+    return std::make_pair( iter->second.lower_bound(ckey), iter->second.upper_bound(ckey) );
+  } else {
+    return std::make_pair( dummy_map.cbegin(), dummy_map.cend() );
+  }
 }
 
 //_________________________________________________________________________
 unsigned int TrkrClusterHitAssocv3::size(void) const
-{  
+{
   unsigned int size = 0;
   for( const auto& map_pair:m_map )
   { size += map_pair.second.size(); }

--- a/offline/packages/trackbase/TrkrClusterHitAssocv3.h
+++ b/offline/packages/trackbase/TrkrClusterHitAssocv3.h
@@ -1,0 +1,50 @@
+#ifndef TRACKBASE_TRKRCLUSTERHITASSOCV3_H
+#define TRACKBASE_TRKRCLUSTERHITASSOCV3_H
+/**
+
+ * @file trackbase/TrkrClusterHitAssocv3.h
+ * @author D. McGlinchey
+ * @date June 2018
+ * @brief Version 3 of class for associating clusters to the hits that went into them
+ */
+
+#include "TrkrDefs.h"
+#include "TrkrClusterHitAssoc.h"
+
+#include <phool/PHObject.h>
+
+#include <iostream>          // for cout, ostream
+#include <map>
+#include <utility>           // for pair
+
+/**
+ * @brief Class for associating clusters to the hits that went into them
+ *
+ * Store the associations between clusters and the hits that went into them.
+ */
+class TrkrClusterHitAssocv3 : public TrkrClusterHitAssoc
+{
+  public:
+
+  TrkrClusterHitAssocv3() = default;
+
+  virtual void Reset();
+
+  virtual void identify(std::ostream &os = std::cout) const;
+
+  virtual void addAssoc(TrkrDefs::cluskey, unsigned int);
+
+  virtual Map* getClusterMap(TrkrDefs::hitsetkey);
+
+  virtual ConstRange getHits(TrkrDefs::cluskey);
+
+  virtual unsigned int size(void) const;
+
+private:
+
+  std::map<TrkrDefs::hitsetkey, Map> m_map;
+
+  ClassDef(TrkrClusterHitAssocv3, 1);
+};
+
+#endif // TRACKBASE_TRKRCLUSTERHITASSOC_H

--- a/offline/packages/trackbase/TrkrClusterHitAssocv3LinkDef.h
+++ b/offline/packages/trackbase/TrkrClusterHitAssocv3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TrkrClusterHitAssocv3+;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -17,8 +17,8 @@
 
 #include <trackbase/TrkrCluster.h>  // for TrkrCluster
 #include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>  // for getLayer, clu...
-#include <trackbase/TrkrClusterHitAssocv2.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
 

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -9,7 +9,7 @@
 
 #include <trackbase/TrkrClusterv2.h>
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase/TrkrHitSet.h>

--- a/offline/packages/trackreco/PHTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTrackSeeding.cc
@@ -7,7 +7,7 @@
 #include <trackbase_historic/SvtxVertexMap.h>
 
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrHitSetContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>

--- a/offline/packages/trackreco/PHTruthClustering.cc
+++ b/offline/packages/trackreco/PHTruthClustering.cc
@@ -5,7 +5,7 @@
 #include <trackbase_historic/SvtxVertex_v1.h>
 
 
-#include <trackbase/TrkrClusterContainerv2.h>
+#include <trackbase/TrkrClusterContainerv3.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrClusterv2.h>
 
@@ -1104,7 +1104,7 @@ int PHTruthClustering::GetNodes(PHCompositeNode* topNode)
       dstNode->addNode(DetNode);
     }
 
-    trkrclusters = new TrkrClusterContainerv2;
+    trkrclusters = new TrkrClusterContainerv3;
     PHIODataNode<PHObject> *TrkrClusterContainerNode =
         new PHIODataNode<PHObject>(trkrclusters, "TRKR_CLUSTER_TRUTH", "PHObject");
     DetNode->addNode(TrkrClusterContainerNode);

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -6,7 +6,7 @@
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -17,7 +17,7 @@
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
 
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This is the second PR that addresses issues in the TrkrClusterContainer and TrkrClusterHitAssoc. 
It introduces TrkrClusterContainerv3 and TrkrClusterHitAssocv3
Both use a map, with hitsetid as a key, to store the detector specific cluster (and cluster-to-hit association) maps, instead of fixed size 3D array. This fixed the various out-of-bound isses reported with the v2. 
I have not noticed any significant slowdown when accessing these maps instead of the fix-sized arrays, mostly because the number of hitsetids (as opposed to hits or clusters) is reasonably small. 


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

