### PR TITLE
Added some breaks when we return a nullptr instead of a truth particle

### DIFF
--- a/simulation/g4simulation/g4eval/EventEvaluator.cc
+++ b/simulation/g4simulation/g4eval/EventEvaluator.cc
@@ -709,6 +709,7 @@ void EventEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
               int mcSteps = 0;
               while(g4particleMother->get_parent_id()!=0){
                 g4particleMother = truthinfocontainerHits->GetParticle(g4particleMother->get_parent_id());
+                if (g4particleMother == NULL) break;
                 mcSteps+=1;
               }
               if(mcSteps<=_depth_MCstack){
@@ -718,6 +719,7 @@ void EventEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                 int mcSteps2 = 0;
                 while(g4particleMother2->get_parent_id()!=0 && (mcSteps2<(mcSteps-_depth_MCstack+1))){
                   g4particleMother2 = truthinfocontainerHits->GetParticle(g4particleMother2->get_parent_id());
+                  if (g4particleMother2 == NULL) break;
                   mcSteps2+=1;
                 }
                 _hits_trueID[_nHitsLayers] = g4particleMother2->get_parent_id();
@@ -1676,6 +1678,7 @@ void EventEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         if(g4particle->get_parent_id()!=0){
           while(g4particleMother->get_parent_id()!=0){
             g4particleMother = truthinfocontainer->GetParticle(g4particleMother->get_parent_id());
+            if (g4particleMother == NULL) break;
             mcSteps+=1;
           }
         }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Occasionally the parent association of a truth particle would return a null pointer in the EventEvaluator. The next access would then cause a crash. I added a check for null pointers and break the while loop if this happens. I assume this happens because the truth particle is actually a noise hit but more hunting would need to be performed to confirm this.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

