### PR TITLE
New micromegas geometry

### DIFF
--- a/offline/QA/modules/QAG4SimulationMicromegas.h
+++ b/offline/QA/modules/QAG4SimulationMicromegas.h
@@ -9,6 +9,7 @@
 #include <string>
 
 class PHCompositeNode;
+class PHG4CylinderGeomContainer;
 class PHG4Hit;
 class PHG4HitContainer;
 class TrkrClusterContainer;
@@ -42,6 +43,9 @@ class QAG4SimulationMicromegas : public SubsysReco
 
   /// true if histograms are initialized
   bool m_initialized = false;
+
+  //! micromegas geometry
+  PHG4CylinderGeomContainer* m_micromegas_geonode = nullptr;
 
   /// cluster map
   TrkrClusterContainer* m_cluster_map = nullptr;

--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -16,9 +16,9 @@ namespace
   // convenient square function
   template<class T>
     inline constexpr T square( const T& x ) { return x*x; }
-  
+
   //! radius
-  template<class T> 
+  template<class T>
     inline constexpr T get_r( T x, T y ) { return std::sqrt( square(x) + square(y) ); }
 
   // bind angle to [-M_PI,+M_PI[. This is useful to avoid edge effects when making the difference between two angles
@@ -35,76 +35,77 @@ namespace
     out << "(" << position[0] << ", " << position[1] << ", " << position[2] << ")";
     return out;
   }
-  
+
 }
 
 //________________________________________________________________________________
 TVector3 CylinderGeomMicromegas::get_local_from_world_coords( uint tileid, const TVector3& world_coordinates ) const
 {
   assert( tileid < m_tiles.size() );
- 
+
   // store world coordinates in array
   std::array<double,3> master;
   world_coordinates.GetXYZ( &master[0] );
-    
+
   // convert to local coordinate
   std::array<double,3> local;
   transformation_matrix(tileid).MasterToLocal( &master[0], &local[0] );
-   
+
   return TVector3( &local[0] );
-  
+
 }
 
 //________________________________________________________________________________
 TVector3 CylinderGeomMicromegas::get_world_from_local_coords( uint tileid, const TVector3& local_coordinates ) const
 {
   assert( tileid < m_tiles.size() );
- 
+
   // store world coordinates in array
   std::array<double,3> local;
   local_coordinates.GetXYZ( &local[0] );
-    
+
   // convert to local coordinate
   std::array<double,3> master;
   transformation_matrix(tileid).LocalToMaster( &local[0], &master[0] );
-   
-  return TVector3( &master[0] );
-  
-}
 
-//________________________________________________________________________________
-TVector3 CylinderGeomMicromegas::get_local_from_world_vect( uint tileid, const TVector3& world_vect ) const
-{
-  assert( tileid < m_tiles.size() );
- 
-  // store world vect in array
-  std::array<double,3> master;
-  world_vect.GetXYZ( &master[0] );
-    
-  // convert to local coordinate
-  std::array<double,3> local;
-  transformation_matrix(tileid).MasterToLocalVect( &master[0], &local[0] );
-   
-  return TVector3( &local[0] );
-  
+  return TVector3( &master[0] );
+
 }
 
 //________________________________________________________________________________
 TVector3 CylinderGeomMicromegas::get_world_from_local_vect( uint tileid, const TVector3& local_vect ) const
 {
   assert( tileid < m_tiles.size() );
- 
+
   // store world vect in array
   std::array<double,3> local;
   local_vect.GetXYZ( &local[0] );
-    
+
   // convert to local coordinate
   std::array<double,3> master;
   transformation_matrix(tileid).LocalToMasterVect( &local[0], &master[0] );
-   
+
   return TVector3( &master[0] );
-  
+
 }
+
+//________________________________________________________________________________
+TVector3 CylinderGeomMicromegas::get_local_from_world_vect( uint tileid, const TVector3& world_vect ) const
+{
+  assert( tileid < m_tiles.size() );
+
+  // store world vect in array
+  std::array<double,3> master;
+  world_vect.GetXYZ( &master[0] );
+
+  // convert to local coordinate
+  std::array<double,3> local;
+  transformation_matrix(tileid).MasterToLocalVect( &master[0], &local[0] );
+
+  return TVector3( &local[0] );
+
+}
+
 //________________________________________________________________________________
 int CylinderGeomMicromegas::find_tile_cylindrical( const TVector3& world_coordinates ) const
 {
@@ -134,22 +135,22 @@ int CylinderGeomMicromegas::find_tile_planar( const TVector3& world_coordinates 
 
   for( size_t itile = 0; itile < m_tiles.size(); ++itile )
   {
-    
+
     // get local coordinates
     const auto local_coordinates = get_local_from_world_coords( itile, world_coordinates );
-    
+
     // store tile struct locally
     const auto& tile = m_tiles.at(itile);
-    
+
     // check azimuth
     if( std::abs( local_coordinates.x() ) > tile.m_sizePhi*reference_radius/2 ) continue;
-    
+
     // check against thickness
     if( std::abs( local_coordinates.y() ) > m_thickness/2 ) continue;
-    
+
     // check z extend
     if( std::abs( local_coordinates.z() ) > tile.m_sizeZ/2 ) continue;
-    
+
     return itile;
   }
 
@@ -159,24 +160,33 @@ int CylinderGeomMicromegas::find_tile_planar( const TVector3& world_coordinates 
 //________________________________________________________________________________
 void CylinderGeomMicromegas::convert_to_planar( uint tileid, PHG4Hit* hit ) const
 {
-//   // same treatment is applied to both coordinates of the G4Hit
-//   for( int i = 0; i < 2; ++i )
-//   {
-//     
-//     const TVector3 world_coordinate( hit->get_x(i), hit->get_y(i), hit->get_z(i) );
-//     const TVector3 world_direction( hit->get_px(i), hi->get_py(i), hit->get_pz(i) );
-//     
-//     // get coordinate radius, and compare to reference radius. This will be use to offset local position along y in local space
-//     const delta_radius = get_r( world_coordinates.x(), world_coordinates.y() ) - m_radius;
-//     
-//     // convert position and direction to local coordinates
-//     
-//     
-//   }
-//   
-//   
-//   
-//   
+  // same treatment is applied to both coordinates of the G4Hit
+  for( int i = 0; i < 2; ++i )
+  {
+
+    const TVector3 world_coordinates( hit->get_x(i), hit->get_y(i), hit->get_z(i) );
+    const TVector3 world_direction( hit->get_px(i), hit->get_py(i), hit->get_pz(i) );
+
+    // get coordinate radius, and compare to reference radius. This will be use to offset local position along y in local space
+    const double delta_radius = get_r( world_coordinates.x(), world_coordinates.y() ) - m_radius;
+
+    // convert position and direction to local coordinates
+    const auto local_coordinates = get_local_from_world_coords( tileid, world_coordinates );
+    const auto local_direction = get_local_from_world_vect( tileid, world_direction );
+
+    // propagate along local_direction to the rigth y
+    const double delta_y = delta_radius - local_coordinates.y();
+    TVector3 new_local_coordinates(
+      local_coordinates.x() + delta_y*local_direction.x()/local_direction.y(),
+      local_coordinates.y() + delta_y,
+      local_coordinates.z() + delta_y*local_direction.z()/local_direction.y() );
+
+    // convert back to world coordinate and assign to g4hit
+    const auto new_world_coordinates = get_world_from_local_coords( tileid, new_local_coordinates );
+    hit->set_x(i, new_world_coordinates.x() );
+    hit->set_y(i, new_world_coordinates.y() );
+    hit->set_z(i, new_world_coordinates.z() );
+  }
 }
 
 //________________________________________________________________________________
@@ -301,17 +311,17 @@ TGeoHMatrix CylinderGeomMicromegas::transformation_matrix( uint tileid ) const
 {
   assert( tileid < m_tiles.size() );
   const auto& tile = m_tiles[tileid];
-  
+
   // local to master transformation matrix
   TGeoHMatrix matrix;
-  
+
   // rotate around z axis
   matrix.RotateZ( tile.m_centerPhi*180./M_PI - 90 );
-  
+
   // translate to tile center
   matrix.SetDx( m_radius*std::cos( tile.m_centerPhi ) );
   matrix.SetDy( m_radius*std::sin( tile.m_centerPhi ) );
   matrix.SetDz( tile.m_centerZ );
-  
-  return matrix;    
+
+  return matrix;
 }

--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -160,12 +160,15 @@ int CylinderGeomMicromegas::find_tile_planar( const TVector3& world_coordinates 
 //________________________________________________________________________________
 void CylinderGeomMicromegas::convert_to_planar( uint tileid, PHG4Hit* hit ) const
 {
-  // same treatment is applied to both coordinates of the G4Hit
+  
+  // get extrapolation direction based on in and out G4Hit positions
+  const TVector3 world_direction( hit->get_x(1)-hit->get_x(0), hit->get_y(1)-hit->get_y(0), hit->get_z(1)-hit->get_z(0) );
+
+  // same treatment is applied to both coordinates of the G4Hit 
   for( int i = 0; i < 2; ++i )
   {
 
     const TVector3 world_coordinates( hit->get_x(i), hit->get_y(i), hit->get_z(i) );
-    const TVector3 world_direction( hit->get_px(i), hit->get_py(i), hit->get_pz(i) );
 
     // get coordinate radius, and compare to reference radius. This will be use to offset local position along y in local space
     const double delta_radius = get_r( world_coordinates.x(), world_coordinates.y() ) - m_radius;
@@ -190,11 +193,17 @@ void CylinderGeomMicromegas::convert_to_planar( uint tileid, PHG4Hit* hit ) cons
 }
 
 //________________________________________________________________________________
-int CylinderGeomMicromegas::find_strip( uint tileid, const TVector3& world_coordinates ) const
+int CylinderGeomMicromegas::find_strip_from_world_coords( uint tileid, const TVector3& world_coordinates ) const
 {
   // convert to local coordinates
   const auto local_coordinates = get_local_from_world_coords( tileid, world_coordinates );
-  
+  return find_strip_from_local_coords( tileid, local_coordinates );
+}
+
+//________________________________________________________________________________
+int CylinderGeomMicromegas::find_strip_from_local_coords( uint tileid, const TVector3& local_coordinates ) const
+{
+
   // check against thickness
   if( std::abs( local_coordinates.y() ) > m_thickness/2 ) return -1;
 

--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -30,12 +30,6 @@ namespace
     else return angle;
   }
 
-  inline std::ostream& operator << (std::ostream& out, std::array<double,3> position)
-  {
-    out << "(" << position[0] << ", " << position[1] << ", " << position[2] << ")";
-    return out;
-  }
-
 }
 
 //________________________________________________________________________________

--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -246,7 +246,7 @@ uint CylinderGeomMicromegas::get_strip_count( uint tileid ) const
   switch( m_segmentation_type )
   {
     case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
-    return std::floor( m_tiles[tileid].m_sizePhi*m_radius/m_pitch );
+    return std::floor( m_tiles[tileid].m_sizePhi*reference_radius/m_pitch );
 
     case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
     return std::floor( m_tiles[tileid].m_sizeZ/m_pitch );
@@ -267,10 +267,10 @@ TVector3 CylinderGeomMicromegas::get_local_coordinates( uint tileid, uint stripn
   switch( m_segmentation_type )
   {
     case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
-    return TVector3( (0.5+stripnum)*m_pitch - m_radius*tile.m_sizePhi/2, 0, 0 );
+    return TVector3( (0.5+stripnum)*m_pitch - tile.m_sizePhi*reference_radius/2, 0, 0 );
     
     case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
-    return TVector3( 0, 0, (0.5+stripnum)*m_pitch - m_radius*tile.m_sizeZ/2 );
+    return TVector3( 0, 0, (0.5+stripnum)*m_pitch - tile.m_sizeZ/2 );
   }
   
   // unreachable

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -67,6 +67,8 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! print information about this layer
   virtual void identify(std::ostream&) const;
 
+  static constexpr double reference_radius = 82;
+
   //@}
 
   //!@name modifiers

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -101,8 +101,11 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! get number of strips
   uint get_strip_count( uint tileid ) const;
 
-  //! get world location for a given tile and strip
-  TVector3 get_world_coordinate( uint tileid, uint stripnum ) const;
+  //! get local coordinates for a given tile and strip
+  TVector3 get_local_coordinates( uint tileid, uint stripnum ) const;
+
+  //! get world coordinates for a given tile and strip
+  TVector3 get_world_coordinates( uint tileid, uint stripnum ) const;
 
   //! print information about this layer
   virtual void identify(std::ostream&) const;

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -49,8 +49,29 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! drift direction
   MicromegasDefs::DriftDirection get_drift_direction() const {return m_drift_direction;}
 
-  //! get tile for a given world location
-  int find_tile( const TVector3& ) const;
+  //! convert position to coordinate in local (planar) tile reference
+  /** 
+   * each (planar) tile has a local ref system defined as:
+   * - z axis same as phenix, 
+   * - y axis perpendicular to the surface, outward, 
+   * - x axis perpendicular to y and z to have a direct ref. system
+   **/
+  TVector3 get_local_from_world_coords( uint tileid, const TVector3& ) const;
+  
+  //! convert position in local (planar) tile reference to world coordinate
+  /** 
+   * each (planar) tile has a local ref system defined as:
+   * - z axis same as phenix, 
+   * - y axis perpendicular to the surface, outward, 
+   * - x axis perpendicular to y and z to have a direct ref. system
+   **/
+  TVector3 get_world_from_local_coords( uint tileid, const TVector3& ) const;
+
+  //! get tile for a given world location assuming tiles are portion of cylinder centered around tile center
+  int find_tile_cylindrical( const TVector3& ) const;
+
+  //! get tile for a given world location assuming tiles are planes centered on tile center and tengent to local cylinder
+  int find_tile_planar( const TVector3& ) const;
 
   //! get number of tiles
   size_t get_tiles_count() const { return m_tiles.size(); }

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -20,6 +20,7 @@
 #include <iostream>
 
 class TVector3;
+class PHG4Hit;
 
 class CylinderGeomMicromegas : public PHG4CylinderGeom
 {
@@ -49,23 +50,31 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! drift direction
   MicromegasDefs::DriftDirection get_drift_direction() const {return m_drift_direction;}
 
-  //! convert position to coordinate in local (planar) tile reference
+  //! convert world to local position coordinates in (planar) tile reference frame
   /** 
    * each (planar) tile has a local ref system defined as:
+   * - origin at center of the tile
    * - z axis same as phenix, 
    * - y axis perpendicular to the surface, outward, 
-   * - x axis perpendicular to y and z to have a direct ref. system
+   * - x axis perpendicular to y and z to have a direct ref. frame
    **/
   TVector3 get_local_from_world_coords( uint tileid, const TVector3& ) const;
   
-  //! convert position in local (planar) tile reference to world coordinate
+  //! convert local to world position coordinates in (planar) tile reference frame
   /** 
    * each (planar) tile has a local ref system defined as:
+   * - origin at center of the tile
    * - z axis same as phenix, 
    * - y axis perpendicular to the surface, outward, 
    * - x axis perpendicular to y and z to have a direct ref. system
    **/
   TVector3 get_world_from_local_coords( uint tileid, const TVector3& ) const;
+
+  //! convert world to local direction coordinates in (planar) tile reference frame
+  TVector3 get_local_from_world_vect( uint tileid, const TVector3& ) const;
+  
+  //! convert local to world direction coordinates in (planar) tile reference frame
+  TVector3 get_world_from_local_vect( uint tileid, const TVector3& ) const;
 
   //! get tile for a given world location assuming tiles are portion of cylinder centered around tile center
   int find_tile_cylindrical( const TVector3& ) const;
@@ -76,6 +85,13 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! get number of tiles
   size_t get_tiles_count() const { return m_tiles.size(); }
 
+  //! convert g4hit coordinates from cylinder Micromegas to planar
+  /** 
+    * this assumes that Micromegas Geant4 implementation are cylinders, while actual tiles are planes
+    * one must then 'drift' the g4hit along its momentum from its radius to the releval "y" in local coordinates
+    */
+  void convert_to_planar( uint tileid, PHG4Hit* ) const;
+  
   //! get strip for a give world location and tile
   int find_strip( uint tileid, const TVector3& ) const;
 

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -93,7 +93,10 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   void convert_to_planar( uint tileid, PHG4Hit* ) const;
 
   //! get strip for a give world location and tile
-  int find_strip( uint tileid, const TVector3& ) const;
+  int find_strip_from_world_coords( uint tileid, const TVector3& ) const;
+
+  //! get strip for a give world location and tile
+  int find_strip_from_local_coords( uint tileid, const TVector3& ) const;
 
   //! get strip length for a given tile
   double get_strip_length( uint tileid ) const;

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -51,28 +51,28 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   MicromegasDefs::DriftDirection get_drift_direction() const {return m_drift_direction;}
 
   //! convert world to local position coordinates in (planar) tile reference frame
-  /** 
+  /**
    * each (planar) tile has a local ref system defined as:
    * - origin at center of the tile
-   * - z axis same as phenix, 
-   * - y axis perpendicular to the surface, outward, 
+   * - z axis same as phenix,
+   * - y axis perpendicular to the surface, outward,
    * - x axis perpendicular to y and z to have a direct ref. frame
    **/
   TVector3 get_local_from_world_coords( uint tileid, const TVector3& ) const;
-  
+
+  //! convert world to local direction coordinates in (planar) tile reference frame
+  TVector3 get_local_from_world_vect( uint tileid, const TVector3& ) const;
+
   //! convert local to world position coordinates in (planar) tile reference frame
-  /** 
+  /**
    * each (planar) tile has a local ref system defined as:
    * - origin at center of the tile
-   * - z axis same as phenix, 
-   * - y axis perpendicular to the surface, outward, 
+   * - z axis same as phenix,
+   * - y axis perpendicular to the surface, outward,
    * - x axis perpendicular to y and z to have a direct ref. system
    **/
   TVector3 get_world_from_local_coords( uint tileid, const TVector3& ) const;
 
-  //! convert world to local direction coordinates in (planar) tile reference frame
-  TVector3 get_local_from_world_vect( uint tileid, const TVector3& ) const;
-  
   //! convert local to world direction coordinates in (planar) tile reference frame
   TVector3 get_world_from_local_vect( uint tileid, const TVector3& ) const;
 
@@ -86,12 +86,12 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   size_t get_tiles_count() const { return m_tiles.size(); }
 
   //! convert g4hit coordinates from cylinder Micromegas to planar
-  /** 
+  /**
     * this assumes that Micromegas Geant4 implementation are cylinders, while actual tiles are planes
     * one must then 'drift' the g4hit along its momentum from its radius to the releval "y" in local coordinates
     */
   void convert_to_planar( uint tileid, PHG4Hit* ) const;
-  
+
   //! get strip for a give world location and tile
   int find_strip( uint tileid, const TVector3& ) const;
 
@@ -123,7 +123,7 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
 
   //! tiles
   void set_tiles( const MicromegasTile::List& tiles ) {m_tiles = tiles;}
-  
+
   //! segmentation
   void set_segmentation_type( MicromegasDefs::SegmentationType value ) {m_segmentation_type = value;}
 
@@ -138,7 +138,7 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
 
   // get local to master transformation matrix for a given tile
   TGeoHMatrix transformation_matrix( uint tileid ) const;
-  
+
   //! layer id
   int m_layer = 0;
 

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -49,6 +49,9 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! get tile for a given world location
   int find_tile( const TVector3& ) const;
 
+  //! get number of tiles
+  size_t get_tiles_count() const { return m_tiles.size(); }
+  
   //! get tile and strip for a give world location
   std::pair<int,int> find_strip( const TVector3& ) const;
 

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -110,6 +110,13 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! get world coordinates for a given tile and strip
   TVector3 get_world_coordinates( uint tileid, uint stripnum ) const;
 
+  //! get phi angle at center of tile
+  double get_center_phi( uint tileid ) const
+  {
+    assert( tileid < m_tiles.size() );
+    return m_tiles[tileid].m_centerPhi;
+  }
+
   //! print information about this layer
   virtual void identify(std::ostream&) const;
 

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -11,7 +11,10 @@
 
 #include "MicromegasDefs.h"
 #include "MicromegasTile.h"
+
 #include <g4detectors/PHG4CylinderGeom.h>
+
+#include <TGeoMatrix.h>
 
 #include <cmath>
 #include <iostream>
@@ -51,9 +54,6 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
 
   //! get number of tiles
   size_t get_tiles_count() const { return m_tiles.size(); }
-  
-  //! get tile and strip for a give world location
-  std::pair<int,int> find_strip( const TVector3& ) const;
 
   //! get strip for a give world location and tile
   int find_strip( uint tileid, const TVector3& ) const;
@@ -70,6 +70,7 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! print information about this layer
   virtual void identify(std::ostream&) const;
 
+  /// reference radius used in macro to convert tile size in azimuth into a angle range (cm)
   static constexpr double reference_radius = 82;
 
   //@}
@@ -85,7 +86,7 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
 
   //! tiles
   void set_tiles( const MicromegasTile::List& tiles ) {m_tiles = tiles;}
-
+  
   //! segmentation
   void set_segmentation_type( MicromegasDefs::SegmentationType value ) {m_segmentation_type = value;}
 
@@ -98,6 +99,9 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   // check if hit radius matches this cylinder
   bool check_radius( const TVector3& ) const;
 
+  // get local to master transformation matrix for a given tile
+  TGeoHMatrix transformation_matrix( uint tileid ) const;
+  
   //! layer id
   int m_layer = 0;
 

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -329,14 +329,13 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
       Acts::Vector3D center = surface->center(m_tGeometry->geoContext) / Acts::UnitConstants::cm;
       Acts::Vector3D normal = surface->normal(m_tGeometry->geoContext);
 
-      double surfRadius = sqrt(center[0]*center[0] + center[1]*center[1]);
-      double surfPhiCenter = atan2(center[1], center[0]);
+      double surfRadius = std::sqrt( square(center[0]) + square(center[1]) );
+      double surfPhiCenter = std::atan2(center[1], center[0]);
       double surfRphiCenter = surfPhiCenter * surfRadius;
       double surfZCenter = center[2];
 
-      double clusRadius = sqrt(cluster->getX() * cluster->getX()
-			       + cluster->getY() * cluster->getY());
-      double clusphi = atan2(cluster->getY(), cluster->getX());
+      double clusRadius = std::sqrt( square(cluster->getX()) + square(cluster->getY()) );
+      double clusphi = std::atan2(cluster->getY(), cluster->getX());
       double rClusPhi = clusRadius * clusphi;
       double zMm = globalPos(2);
       auto vecResult = surface->globalToLocal(m_tGeometry->geoContext,
@@ -363,7 +362,7 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
 
       // rotate and save
       matrix_t rotation = matrix_t::Identity();
-      const double phi = std::atan2(world_coordinates.y(), world_coordinates.x());
+      const double phi = layergeom->get_center_phi( tileid );
       const double cosphi = std::cos(phi);
       const double sinphi = std::sin(phi);
       rotation(0,0) = cosphi;

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -238,7 +238,7 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
         const double weight = double(hit->getAdc()) - pedestal;
 
         // get strip world coordinate and update relevant sums
-        const auto strip_world_coordinate = layergeom->get_world_coordinate( tileid, strip );
+        const auto strip_world_coordinate = layergeom->get_world_coordinates( tileid, strip );
         world_coordinates += strip_world_coordinate*weight;
         switch( segmentation_type )
         {

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -147,7 +147,6 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
      */
     const auto segmentation_type = layergeom->get_segmentation_type();
     const double thickness = layergeom->get_thickness();
-    const double radius = layergeom->get_radius();
     const double pitch = layergeom->get_pitch();
     const double strip_length = layergeom->get_strip_length( tileid );
 
@@ -211,7 +210,7 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
       auto cluster = std::make_unique<TrkrClusterv2>();
       cluster->setClusKey(cluster_key);
 
-      TVector3 world_coordinates;
+      TVector3 local_coordinates;
       double weight_sum = 0;
 
       // needed for proper error calculation
@@ -237,25 +236,23 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
         static constexpr double pedestal = 74.6;
         const double weight = double(hit->getAdc()) - pedestal;
 
-        // get strip world coordinate and update relevant sums
-        const auto strip_world_coordinate = layergeom->get_world_coordinates( tileid, strip );
-        world_coordinates += strip_world_coordinate*weight;
+        // get strip local coordinate and update relevant sums
+        const auto strip_local_coordinate = layergeom->get_local_coordinates( tileid, strip );
+        local_coordinates += strip_local_coordinate*weight;
         switch( segmentation_type )
         {
           case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
           {
 
-            const auto rphi = radius*std::atan2( strip_world_coordinate.y(), strip_world_coordinate.x() );
-            coord_sum += rphi*weight;
-            coordsquare_sum += square(rphi)*weight;
+            coord_sum += strip_local_coordinate.x()*weight;
+            coordsquare_sum += square(strip_local_coordinate.x())*weight;
             break;
           }
 
           case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
           {
-            const auto z = strip_world_coordinate.z();
-            coord_sum += z*weight;
-            coordsquare_sum += square(z)*weight;
+            coord_sum += strip_local_coordinate.z()*weight;
+            coordsquare_sum += square(strip_local_coordinate.z())*weight;
             break;
           }
         }
@@ -265,12 +262,18 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
       }
 
       // cluster position
-      cluster->setPosition( 0, world_coordinates.x()/weight_sum );
-      cluster->setPosition( 1, world_coordinates.y()/weight_sum );
-      cluster->setPosition( 2, world_coordinates.z()/weight_sum );
+      const auto world_coordinates = layergeom->get_world_from_local_coords( tileid, local_coordinates*(1./weight_sum) );
+      cluster->setX( world_coordinates.x() );
+      cluster->setY( world_coordinates.y() );
+      cluster->setZ( world_coordinates.z() );
       cluster->setGlobal();
 
       // dimension and error in r, rphi and z coordinates
+      /*
+       * NOTE: this is not quite correct. One should calculate them in the tile reference frame (easy)
+       * then convert them back to global frame using tile proper rotation matrix.
+       * probably it is enough to use the phi angle of the tile, not that of the cluster
+       */
       static const float invsqrt12 = 1./std::sqrt(12);
       static constexpr float error_scale_phi = 1.6;
       static constexpr float error_scale_z = 0.8;

--- a/offline/packages/micromegas/MicromegasTile.h
+++ b/offline/packages/micromegas/MicromegasTile.h
@@ -24,11 +24,10 @@ class MicromegasTile: public PHObject
   using List = std::vector<MicromegasTile>;
 
   //! default constructor
-  MicromegasTile()
-  {}
+  MicromegasTile() = default;
 
-// ROOT wants a virtual dtor
-  virtual ~MicromegasTile() {}
+  //! destructor
+  virtual ~MicromegasTile() = default;
 
   //! constructor
   MicromegasTile( std::array<double, 4> values )

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -22,18 +22,17 @@
 #include <trackbase_historic/SvtxVertex.h>          // for SvtxVertex
 #include <trackbase_historic/SvtxVertexMap.h>       // for SvtxVertexMap
 
-#include <micromegas/MicromegasDefs.h>
-#include <mvtx/MvtxDefs.h>
-
 #include <intt/InttDefs.h>
+#include <intt/CylinderGeomIntt.h>
+
+#include <micromegas/MicromegasDefs.h>
+#include <micromegas/CylinderGeomMicromegas.h>
+
+#include <mvtx/MvtxDefs.h>
+#include <mvtx/CylinderGeom_Mvtx.h>
 
 #include <g4detectors/PHG4CylinderGeom.h>           // for PHG4CylinderGeom
 #include <g4detectors/PHG4CylinderGeomContainer.h>
-
-//
-#include <intt/CylinderGeomIntt.h>
-
-#include <mvtx/CylinderGeom_Mvtx.h>
 
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4Particlev2.h>
@@ -832,11 +831,14 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
     return nullptr;
   }
 
-  PHG4CylinderGeomContainer* geom_container_intt = findNode::getClass<
-      PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
+  auto geom_container_intt = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
+  assert( geom_container_intt );
+  
+  auto geom_container_mvtx = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
+  assert( geom_container_mvtx );
 
-  PHG4CylinderGeomContainer* geom_container_mvtx = findNode::getClass<
-      PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
+  auto geom_container_micromegas = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS_FULL");
+  assert( geom_container_micromegas );
 
   // prepare seed
   TVector3 seed_mom(100, 0, 0);
@@ -955,13 +957,6 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
     if(Verbosity() > 10) cout << "    Layer " << layer_out << " cluster " << cluster_key << " radius " << r << endl;
   }
 
-  /* 
-  need to store micromegas separately before adding them to the track. 
-  this is because they only measure one coordinate. One needs to add the other coordinate for each cluster
-  in order to facilitate the fit, event if the uncertainty on that quantity remains large
-  */
-  std::map<TrkrDefs::cluskey, TrkrCluster*> clusters_mm;
-  
   for (auto iter = m_r_cluster_id.begin();
        iter != m_r_cluster_id.end();
        ++iter)
@@ -994,52 +989,62 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
     seed_mom.SetPhi(pos.Phi());
     seed_mom.SetTheta(pos.Theta());
 
-    //TODO use u, v explicitly?
+    // by default assume normal to local surface is along cluster azimuthal position
     TVector3 n(cluster->getPosition(0), cluster->getPosition(1), 0);
 
-    //------------------------------
-    // new
-
-    // Replace n for the silicon subsystems
-
-    // get the trkrid
-    unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
-
-    if(trkrid == TrkrDefs::mvtxId)
+    // replace normal by proper vector for specified subsystems
+    switch( TrkrDefs::getTrkrId(cluster_key) )
+    {
+      
+      case TrkrDefs::mvtxId:
       {
-  int stave_index = MvtxDefs::getStaveId(cluster_key);
-  int chip_index = MvtxDefs::getChipId(cluster_key);
+        int stave_index = MvtxDefs::getStaveId(cluster_key);
+        int chip_index = MvtxDefs::getChipId(cluster_key);
+        
+        double ladder_location[3] = {0.0, 0.0, 0.0};
+        auto geom = static_cast<CylinderGeom_Mvtx*>(geom_container_mvtx->GetLayerGeom(layer));
+        // returns the center of the sensor in world coordinates - used to get the ladder phi location
+        geom->find_sensor_center(stave_index, 0,
+          0, chip_index, ladder_location);
 
-  double ladder_location[3] = {0.0, 0.0, 0.0};
-  auto geom = dynamic_cast<CylinderGeom_Mvtx*>(geom_container_mvtx->GetLayerGeom(layer));
-  // returns the center of the sensor in world coordinates - used to get the ladder phi location
-  geom->find_sensor_center(stave_index, 0,
-         0, chip_index, ladder_location);
-
-  //cout << " MVTX stave phi tilt = " <<  geom->get_stave_phi_tilt()
-  //   << " seg.X " << ladder_location[0] << " seg.Y " << ladder_location[1] << " seg.Z " << ladder_location[2] << endl;
-  n.SetXYZ(ladder_location[0], ladder_location[1], 0);
-  n.RotateZ(geom->get_stave_phi_tilt());
+        //cout << " MVTX stave phi tilt = " <<  geom->get_stave_phi_tilt()
+        //   << " seg.X " << ladder_location[0] << " seg.Y " << ladder_location[1] << " seg.Z " << ladder_location[2] << endl;
+        n.SetXYZ(ladder_location[0], ladder_location[1], 0);
+        n.RotateZ(geom->get_stave_phi_tilt());
+        break;
       }
-    else if(trkrid == TrkrDefs::inttId)
+      
+      case TrkrDefs::inttId:
       {
-  auto geom = dynamic_cast<CylinderGeomIntt*>(geom_container_intt->GetLayerGeom(layer));
-  double hit_location[3] = {0.0, 0.0, 0.0};
-  geom->find_segment_center(InttDefs::getLadderZId(cluster_key),
+        auto geom = static_cast<CylinderGeomIntt*>(geom_container_intt->GetLayerGeom(layer));
+        double hit_location[3] = {0.0, 0.0, 0.0};
+        geom->find_segment_center(InttDefs::getLadderZId(cluster_key),
           InttDefs::getLadderPhiId(cluster_key), hit_location);
-
-  //cout << " Intt strip phi tilt = " <<  geom->get_strip_phi_tilt()
-  //   << " seg.X " << hit_location[0] << " seg.Y " << hit_location[1] << " seg.Z " << hit_location[2] << endl;
-  n.SetXYZ(hit_location[0], hit_location[1], 0);
-  n.RotateZ(geom->get_strip_phi_tilt());
-      } else if( trkrid == TrkrDefs::micromegasId ) {
-  clusters_mm.insert( std::make_pair( cluster_key, cluster ) );
-  continue;
+        
+        //cout << " Intt strip phi tilt = " <<  geom->get_strip_phi_tilt()
+        //   << " seg.X " << hit_location[0] << " seg.Y " << hit_location[1] << " seg.Z " << hit_location[2] << endl;
+        n.SetXYZ(hit_location[0], hit_location[1], 0);
+        n.RotateZ(geom->get_strip_phi_tilt());
+        break;
       }
 
-    auto meas = new PHGenFit::PlanarMeasurement(pos, n,
-                  cluster->getRPhiError(), cluster->getZError());
+      case TrkrDefs::micromegasId:
+      {
+        // get geometry
+        auto geom = static_cast<CylinderGeomMicromegas*>(geom_container_micromegas->GetLayerGeom(layer));
+        const auto tileid = MicromegasDefs::getTileId( cluster_key );
+        
+        // in local coordinate, n is along y axis
+        // convert to global coordinates
+        n = geom->get_world_from_local_vect( tileid, TVector3( 0, 1, 0 ) );
+      }
+      
+      default: break;
+    }
     
+    // create measurement
+    auto meas = new PHGenFit::PlanarMeasurement(pos, n, cluster->getRPhiError(), cluster->getZError());
+
     if(Verbosity() > 10)
     {
       cout << "Add meas layer " << layer << " cluskey " << cluster_key
@@ -1053,76 +1058,7 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
     measurements.push_back(meas);
   }
 
-  // special handling of the micromegas clusters
-  {
-    bool has_phi = false;
-    bool has_z = false;
-    float phi = 0;
-    float z = 0;
-    
-    // first loop to store precise z and rphi coordinates
-    for( const auto& pair:clusters_mm )
-    {
-      const auto& cluster = pair.second;
-      const auto segmentationType(MicromegasDefs::getSegmentationType(pair.first));
-      switch( segmentationType )
-      {
-        case MicromegasDefs::SegmentationType::SEGMENTATION_PHI: 
-        if( !has_phi )
-        { 
-          has_phi = true; 
-          phi = std::atan2( cluster->getY(), cluster->getX() );
-        }
-        break;
-        case MicromegasDefs::SegmentationType::SEGMENTATION_Z: 
-        if( !has_z )
-        { 
-          has_z = true; 
-          z = cluster->getZ();
-        }
-        break;
-      }
-      
-      if( has_phi && has_z ) break;
-    }
-        
-    // second loop to update the coordinate that is not measured and add measurement to track
-    for( const auto& pair:clusters_mm )
-    {
-      
-      // keep cluster
-      const auto& cluster = pair.second;
-      
-      // update the coordinate that is not measured
-      const auto segmentationType(MicromegasDefs::getSegmentationType(pair.first));
-      switch( segmentationType )
-      {
-        case MicromegasDefs::SegmentationType::SEGMENTATION_PHI: 
-        if( has_z ) cluster->setZ(z);
-        break;
-        case MicromegasDefs::SegmentationType::SEGMENTATION_Z: 
-        if( has_phi )
-        { 
-          const auto radius = std::sqrt( square(cluster->getX()) + square(cluster->getY()) );
-          cluster->setX(radius*std::cos(phi));
-          cluster->setY(radius*std::sin(phi));
-        }
-        break;
-      }
-        
-      // create measurement
-      TVector3 pos(cluster->getPosition(0), cluster->getPosition(1), cluster->getPosition(2));
-      seed_mom.SetPhi(pos.Phi());
-      seed_mom.SetTheta(pos.Theta());
-      
-      TVector3 n(cluster->getPosition(0), cluster->getPosition(1), 0);
-      auto meas = new PHGenFit::PlanarMeasurement(pos, n, cluster->getRPhiError(), cluster->getZError());
-      measurements.push_back(meas);
-      
-    }
-  
-  }
-  
+
   /*!
    * mu+:	-13
    * mu-:	13

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -90,13 +90,6 @@ namespace
       + (gaus(xloc+pitch, sigma) - gaus(xloc, sigma))*square(sigma)/pitch;
   }
 
-
-  inline std::ostream& operator << (std::ostream& out, const TVector3& position)
-  {
-    out << "(" << position.x() << ", " << position.y() << ", " << position.z() << ")";
-    return out;
-  }
-
 }
 
 //___________________________________________________________________________

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -67,11 +67,6 @@ namespace
     else return angle;
   }
 
-  // local version of std::clamp, which is only available for c++17
-  template<class T>
-    constexpr const T& clamp( const T& v, const T& lo, const T& hi )
-  { return (v < lo) ? lo : (hi < v) ? hi : v; }
-
   // this corresponds to integrating a gaussian centered on zero and of width sigma from xloc - pitch/2 to xloc+pitch/2
   template<class T>
     inline T get_rectangular_fraction( const T& xloc, const T& sigma, const T& pitch )
@@ -94,13 +89,13 @@ namespace
       + (gaus(xloc+pitch, sigma) - gaus(xloc, sigma))*square(sigma)/pitch;
   }
 
-  
+
   inline std::ostream& operator << (std::ostream& out, const TVector3& position)
   {
     out << "(" << position.x() << ", " << position.y() << ", " << position.z() << ")";
     return out;
   }
-  
+
 }
 
 //___________________________________________________________________________
@@ -478,9 +473,9 @@ void PHG4MicromegasHitReco::setup_tiles(PHCompositeNode* topNode)
     /* they correspond to 256 channels along the phi direction, and 256 along the z direction, assuming 25x50 tiles */
     cylinder->set_pitch( is_first ? 25./256 : 50./256 );
     
-    if( Verbosity() )
+    // if( Verbosity() )
     { cylinder->identify( std::cout ); }
-    
+
   }
 }
 
@@ -519,8 +514,9 @@ PHG4MicromegasHitReco::charge_list_t PHG4MicromegasHitReco::distribute_charge(
 
   // find relevant strip indices
   const auto strip_count = layergeom->get_strip_count( tileid );
-  const auto stripnum_min = clamp<int>( stripnum - 5.*sigma/pitch - 1, 0, strip_count );
-  const auto stripnum_max = clamp<int>( stripnum + 5*sigma/pitch + 1, 0, strip_count );
+  const int nstrips = 5.*sigma/pitch + 1;
+  const auto stripnum_min = std::clamp<int>( stripnum - nstrips, 0, strip_count );
+  const auto stripnum_max = std::clamp<int>( stripnum + nstrips, 0, strip_count );
 
   // prepare charge list
   charge_list_t charge_list;
@@ -532,7 +528,7 @@ PHG4MicromegasHitReco::charge_list_t PHG4MicromegasHitReco::distribute_charge(
   for( int strip = stripnum_min; strip <= stripnum_max; ++strip )
   {
     // get strip center
-    const TVector3 strip_location = layergeom->get_world_coordinate( tileid, strip );
+    const TVector3 strip_location = layergeom->get_world_coordinates( tileid, strip );
     const auto phi_strip = std::atan2( strip_location.y(), strip_location.x() );
 
     // find relevant strip coordinate with respect to location

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -18,6 +18,7 @@
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4HitContainer.h>
 
 #include <phparameter/PHParameterInterface.h>       // for PHParameterInterface
@@ -227,16 +228,27 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
     auto layergeom = dynamic_cast<CylinderGeomMicromegas*>(geonode->GetLayerGeom(layer));
     assert( layergeom );
 
-    /* 
-     * get the radius of the detector mesh. It depends on the drift direction 
+    /*
+     * get the position of the detector mesh in local coordinates
+     * in local coordinate the mesh is a plane perpendicular to the y axis
+     * Its position along z depends on the drift direction
      * it is used to calculate the drift distance of the primary electrons, and the
      * corresponding transverse diffusion
      */
-    const auto mesh_radius = layergeom->get_drift_direction() == MicromegasDefs::DriftDirection::OUTWARD ?
-      (layergeom->get_radius() + layergeom->get_thickness()/2): 
-      (layergeom->get_radius() - layergeom->get_thickness()/2);
-        
-    // get corresponding hits
+    const auto mesh_local_y = layergeom->get_drift_direction() == MicromegasDefs::DriftDirection::OUTWARD ? 
+      layergeom->get_thickness()/2:
+      -layergeom->get_thickness()/2;
+    
+//     /*
+//      * get the radius of the detector mesh. It depends on the drift direction
+//      * it is used to calculate the drift distance of the primary electrons, and the
+//      * corresponding transverse diffusion
+//      */
+//       const auto mesh_radius = layergeom->get_drift_direction() == MicromegasDefs::DriftDirection::OUTWARD ?
+//       (layergeom->get_radius() + layergeom->get_thickness()/2):
+//       (layergeom->get_radius() - layergeom->get_thickness()/2);
+
+    // get hits
     const PHG4HitContainer::ConstRange g4hit_range = g4hitcontainer->getHits(layer);
 
     // loop over hits
@@ -259,13 +271,33 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
        * at this point we do not check the strip validity.
        * This will be done when actually distributing electrons along the G4Hit track segment
        */
-      const auto world_mid = (world_in+world_out)*0.5;
-      const int tileid = layergeom->find_tile_cylindrical( world_mid );
-      // const int tileid = layergeom->find_tile( world_mid );
+      const int tileid = layergeom->find_tile_cylindrical( (world_in+world_out)*0.5 );
       if( tileid < 0 ) continue;
 
+      /*
+       * in geant4 hits are generated on a cylinder located at layergeom->get_radius()
+       * the actual micromegas tiles however are plane surfaces, tengent to said cylinder
+       * one must convert the g4hit in and out positions from the cylinder back to the actual 
+       * micromegas surface
+       */ 
+      
+      // make a local copy of the g4hit
+      PHG4Hitv1 g4hit_copy( g4hit );
+      
+      /*
+       * move hit coordinates to plane, 
+       * update world coordinates
+       * get corresponding local coordinates
+       */
+      layergeom->convert_to_planar( tileid, &g4hit_copy );
+      world_in.SetXYZ( g4hit_copy.get_x(0), g4hit_copy.get_y(0), g4hit_copy.get_z(0) );
+      world_out.SetXYZ( g4hit_copy.get_x(1), g4hit_copy.get_y(1), g4hit_copy.get_z(1) );
+
+      const auto local_in = layergeom->get_local_from_world_coords( tileid, world_in );
+      const auto local_out = layergeom->get_local_from_world_coords( tileid, world_out );
+      
       // number of primary elections
-      const auto nprimary = get_primary_electrons( g4hit );
+      const auto nprimary = get_primary_electrons( &g4hit_copy );
       if( !nprimary ) continue;
 
       // create hitset
@@ -280,33 +312,25 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
       for( uint ie = 0; ie < nprimary; ++ie )
       {
         // put the electron at a random position along the g4hit path
+        // in local reference frame, drift occurs along the y axis, from local y to mesh_local_y
         const auto t = gsl_ran_flat(m_rng.get(), 0.0, 1.0);
-        auto world =  world_in*t + world_out*(1.0-t);
+        auto local = local_in*t + local_out*(1.0-t);
         
         if( m_diffusion_trans > 0 )
         {
           // add transeverse diffusion
           // first convert to polar coordinates
-          const double radius = std::sqrt(square(world.x())+square(world.y()));
-          const double phi = std::atan2(world.y(),world.x());
-          const double drift_distance = std::abs(radius - mesh_radius);
+          const double y = local.y();
+          const double drift_distance = std::abs(y - mesh_local_y);
           const double diffusion = gsl_ran_gaussian(m_rng.get(), m_diffusion_trans*std::sqrt(drift_distance));
           const double diffusion_angle = gsl_ran_flat(m_rng.get(), -M_PI, M_PI);
-                    
-          /*
-           * diffusion happens in the phi,z plane (plane perpendicular to the radius direction)
-           * with a magnitude 'diffusion' and an angle 'diffusion angle'
-           * rotate back to cartesian coordinates
-           */
-          const auto sphi = std::sin(phi);
-          const auto cphi = std::cos(phi);
-          const auto salpha = std::sin(diffusion_angle);
-          const auto calpha = std::cos(diffusion_angle);
-          world += TVector3(-sphi*calpha*diffusion, cphi*calpha*diffusion, salpha*diffusion); 
+
+          // diffusion occurs in x,z plane with a magnitude 'diffusion' and an angle 'diffusion angle'
+          local += TVector3( diffusion*std::cos(diffusion_angle), 0, diffusion*std::sin(diffusion_angle) );
         }
         
         // distribute charge among adjacent strips
-        const auto fractions = distribute_charge( layergeom, tileid, world, m_cloud_sigma );
+        const auto fractions = distribute_charge( layergeom, tileid, local, m_cloud_sigma );
 
         // make sure fractions adds up to unity
         if( Verbosity() > 0 )
@@ -357,6 +381,7 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
       }
 
     }
+    
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -498,19 +523,18 @@ uint PHG4MicromegasHitReco::get_single_electron_amplification() const
 PHG4MicromegasHitReco::charge_list_t PHG4MicromegasHitReco::distribute_charge(
   CylinderGeomMicromegas* layergeom,
   uint tileid,
-  const TVector3& location,
+  const TVector3& local_coords,
   double sigma ) const
 {
 
   // find tile and strip matching center position
-  auto stripnum = layergeom->find_strip( tileid, location );
+  auto stripnum = layergeom->find_strip_from_local_coords( tileid, local_coords );
 
   // check tile and strip
   if( stripnum < 0 ) return charge_list_t();
 
   // store pitch and radius
   const auto pitch = layergeom->get_pitch();
-  const auto radius = layergeom->get_radius();
 
   // find relevant strip indices
   const auto strip_count = layergeom->get_strip_count( tileid );
@@ -521,20 +545,20 @@ PHG4MicromegasHitReco::charge_list_t PHG4MicromegasHitReco::distribute_charge(
   // prepare charge list
   charge_list_t charge_list;
 
-  // store azimuthal angle
-  const auto phi = std::atan2( location.y(), location.x() );
-
   // loop over strips
   for( int strip = stripnum_min; strip <= stripnum_max; ++strip )
   {
     // get strip center
-    const TVector3 strip_location = layergeom->get_world_coordinates( tileid, strip );
-    const auto phi_strip = std::atan2( strip_location.y(), strip_location.x() );
+    const TVector3 strip_location = layergeom->get_local_coordinates( tileid, strip );
 
-    // find relevant strip coordinate with respect to location
+    /* 
+     * find relevant strip coordinate with respect to location
+     * in local coordinate, phi segmented view has strips along z and measures along x
+     * in local coordinate, z segmented view has strips along phi and measures along z
+     */
     const auto xloc = layergeom->get_segmentation_type() == MicromegasDefs::SegmentationType::SEGMENTATION_PHI ?
-      radius * bind_angle( phi_strip - phi ):
-      strip_location.z() - location.z();
+      strip_location.x() - local_coords.x():
+      strip_location.z() - local_coords.z();
 
     // calculate charge fraction
     const auto fraction = m_zigzag_strips ?

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -94,6 +94,13 @@ namespace
       + (gaus(xloc+pitch, sigma) - gaus(xloc, sigma))*square(sigma)/pitch;
   }
 
+  
+  inline std::ostream& operator << (std::ostream& out, const TVector3& position)
+  {
+    out << "(" << position.x() << ", " << position.y() << ", " << position.z() << ")";
+    return out;
+  }
+  
 }
 
 //___________________________________________________________________________
@@ -258,7 +265,8 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
        * This will be done when actually distributing electrons along the G4Hit track segment
        */
       const auto world_mid = (world_in+world_out)*0.5;
-      const int tileid = layergeom->find_tile( world_mid );
+      const int tileid = layergeom->find_tile_cylindrical( world_mid );
+      // const int tileid = layergeom->find_tile( world_mid );
       if( tileid < 0 ) continue;
 
       // number of primary elections
@@ -443,7 +451,6 @@ void PHG4MicromegasHitReco::setup_tiles(PHCompositeNode* topNode)
   PHG4CylinderGeomContainer::ConstRange range = geonode_full->get_begin_end();
   for( auto iter = range.first; iter != range.second; ++iter )
   {
-    std::cout << "PHG4MicromegasHitReco::setup_tiles - processing layer " << iter->first << std::endl;
     auto cylinder = static_cast<CylinderGeomMicromegas*>(iter->second);
 
     // assign tiles
@@ -470,7 +477,10 @@ void PHG4MicromegasHitReco::setup_tiles(PHCompositeNode* topNode)
     // pitch
     /* they correspond to 256 channels along the phi direction, and 256 along the z direction, assuming 25x50 tiles */
     cylinder->set_pitch( is_first ? 25./256 : 50./256 );
-    cylinder->identify( std::cout );
+    
+    if( Verbosity() )
+    { cylinder->identify( std::cout ); }
+    
   }
 }
 

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
@@ -73,7 +73,7 @@ class PHG4MicromegasHitReco : public SubsysReco, public PHParameterInterface
   using charge_list_t = std::vector<charge_pair_t>;
 
   //! distribute a Gaussian charge across adjacent strips
-  charge_list_t distribute_charge( CylinderGeomMicromegas*, uint tileid, const TVector3& position, double sigma ) const;
+  charge_list_t distribute_charge( CylinderGeomMicromegas*, uint tileid, const TVector3& local_position, double sigma ) const;
 
   //! detector name
   std::string m_detector;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This is the first of two PR that implements new micromegas geometry, consisting of planar tiles located around the TPC instead of portions of cylinders. Rather than using polar coordinates to find fired strips, cluster positions etc. one now use a local reference frame for each micromegas, and convert (world_to_local, local_to_world) to and from this frame to do all the position handling.

The Geant4 micromegas implementation is unchanged: two cylinders that cover the full TPC acceptance. 
G4Hits generated with those are 'translated' to the planar implementation in G4HitReco

Genfit and QA evaluators are modified to properly handle this geometry change. 
ACTS is slightly more broken than before with this change, but was broken already anyway.

The second PR will address ACTS necessary changes to accomodate this new geometry. It will be pushed after this one is merged. 

To illustrate the geometry change:
![image](https://user-images.githubusercontent.com/22907496/117883977-53aba480-b269-11eb-8c00-ed893e4e42b9.png)
left is before
right is after. It is closer to reality


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

