### PR TITLE
Directed fitter fixes

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -805,8 +805,15 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
 							    "SvtxSiliconMMTrackMap");
       if(!m_directedTrackMap)
 	{
+	  std::cout <<"In here"<<std::endl;
+	  for(const auto& [key, track] : *m_trackMap)
+	    track->identify();
 	  /// Copy this trackmap, then use it for the rest of processing
 	  m_directedTrackMap = (SvtxTrackMap*)(m_trackMap->CloneMe());
+
+	  std::cout << "Directed map"<<std::endl;
+	  for(const auto& [key, track] : *m_directedTrackMap)
+	    track->identify();
 	  PHIODataNode<PHObject> *trackNode = 
 	    new PHIODataNode<PHObject>(m_directedTrackMap,"SvtxSiliconMMTrackMap","PHObject");
 	  svtxNode->addNode(trackNode);
@@ -815,7 +822,12 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
       /// Run the rest of the module with this track map
       m_trackMap = findNode::getClass<SvtxTrackMap>(topNode,
 						    "SvtxSiliconMMTrackMap");
-      
+      std::cout << "Reg map 2"<<std::endl;
+      for(const auto& [key, track] : *m_trackMap)
+	track->identify();
+      std::cout << "Directed map 2"<<std::endl;
+      for(const auto& [key, track] : *m_directedTrackMap)
+	track->identify();
     }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -297,7 +297,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	  getTrackFitResult(fitOutput, track);
 
 	}
-      else
+      else if (!m_fitSiliconMMs)
 	{
 	  /// Track fit failed, get rid of the track from the map
 	  badTracks.push_back(trackKey);

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -15,6 +15,7 @@
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackState_v1.h>
 #include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxTrackMap_v1.h>
 #include <trackbase_historic/SvtxVertexMap.h>
 #include <trackbase_historic/SvtxVertex.h>
 #include <micromegas/MicromegasDefs.h>
@@ -73,11 +74,11 @@ int PHActsTrkFitter::Setup(PHCompositeNode* topNode)
 {
   if(Verbosity() > 1)
     std::cout << "Setup PHActsTrkFitter" << std::endl;
-  
-  if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
-    return Fun4AllReturnCodes::ABORTEVENT;
 
   if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+    return Fun4AllReturnCodes::ABORTEVENT;
+  
+  if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
     return Fun4AllReturnCodes::ABORTEVENT;
 
   m_fitCfg.fit = ActsExamples::TrkrClusterFittingAlgorithm::makeFitterFunction(
@@ -797,6 +798,25 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
     svtxNode = new PHCompositeNode("SVTX");
     dstNode->addNode(svtxNode);
   }
+
+  if(m_fitSiliconMMs)
+    {
+      m_directedTrackMap = findNode::getClass<SvtxTrackMap>(topNode,
+							    "SvtxSiliconMMTrackMap");
+      if(!m_directedTrackMap)
+	{
+	  /// Copy this trackmap, then use it for the rest of processing
+	  m_directedTrackMap = (SvtxTrackMap*)(m_trackMap->CloneMe());
+	  PHIODataNode<PHObject> *trackNode = 
+	    new PHIODataNode<PHObject>(m_directedTrackMap,"SvtxSiliconMMTrackMap","PHObject");
+	  svtxNode->addNode(trackNode);
+	}
+      
+      /// Run the rest of the module with this track map
+      m_trackMap = findNode::getClass<SvtxTrackMap>(topNode,
+						    "SvtxSiliconMMTrackMap");
+      
+    }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -136,7 +136,7 @@ class PHActsTrkFitter : public PHTrackFitting
   ActsExamples::TrkrClusterFittingAlgorithm::Config m_fitCfg;
 
   /// TrackMap containing SvtxTracks
-  SvtxTrackMap *m_trackMap;
+  SvtxTrackMap *m_trackMap, *m_directedTrackMap;
   SvtxVertexMap *m_vertexMap;
   TrkrClusterContainer *m_clusterContainer;
   ActsSurfaceMaps *m_surfMaps;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -8,7 +8,8 @@
 #ifndef TRACKRECO_ACTSTRKFITTER_H
 #define TRACKRECO_ACTSTRKFITTER_H
 
-#include "PHTrackFitting.h"
+#include <fun4all/SubsysReco.h>
+
 #include <trackbase/ActsTrackingGeometry.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/ActsSurfaceMaps.h>
@@ -55,7 +56,7 @@ using Measurement = Acts::Measurement<ActsExamples::TrkrClusterSourceLink,
 using SurfacePtrVec = std::vector<const Acts::Surface*>;
 using SourceLinkVec = std::vector<SourceLink>;
 
-class PHActsTrkFitter : public PHTrackFitting
+class PHActsTrkFitter : public SubsysReco
 {
  public:
   /// Default constructor
@@ -68,10 +69,10 @@ class PHActsTrkFitter : public PHTrackFitting
   int End(PHCompositeNode *topNode);
 
   /// Get and create nodes
-  int Setup(PHCompositeNode* topNode);
+  int InitRun(PHCompositeNode* topNode);
 
   /// Process each event by calling the fitter
-  int Process();
+  int process_event(PHCompositeNode *topNode);
 
   int ResetEvent(PHCompositeNode *topNode);
 

--- a/offline/packages/trackreco/PHTpcResiduals.cc
+++ b/offline/packages/trackreco/PHTpcResiduals.cc
@@ -463,9 +463,6 @@ void PHTpcResiduals::calculateTpcResiduals(
   const auto globStateY = globalStatePos.y() / Acts::UnitConstants::cm;
   const auto globStateZ = stateZ;
 
-  std::cout << "Track param raw position is : (" << globStateX 
-	    << ", " << globStateY << ", " << globStateZ << std::endl;
-
   stateR = sqrt(pow(globStateX, 2) +
 		pow(globStateY, 2) );
   

--- a/offline/packages/trackreco/PHTpcResiduals.cc
+++ b/offline/packages/trackreco/PHTpcResiduals.cc
@@ -751,11 +751,11 @@ int PHTpcResiduals::getNodes(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxSiliconMMTrackMap");
   
   if (!m_trackMap)
     {
-      std::cout << PHWHERE << "SvtxTrackMap not on node tree. Exiting."
+      std::cout << PHWHERE << "SvtxSiliconMMTrackMap not on node tree. Exiting."
 		<< std::endl;
       return Fun4AllReturnCodes::ABORTEVENT;
     }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR creates a new `SvtxTrackMap` for the results of the silicon+MM track fitting and has the TPC residual calculation module grab that instead. This leaves the original track map alone and then allows us to work with a single silicon+MM track fit map. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

