### PR TITLE
Fix Acts Initial Vertex Finder Issues

### DIFF
--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -7,7 +7,7 @@
 #include <phool/PHObject.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
-#include <phool/recoConsts.h>
+#include <phool/PHRandomSeed.h>
 
 #if __cplusplus < 201402L
 #include <boost/make_unique.hpp>
@@ -61,6 +61,8 @@ int PHActsInitialVertexFinder::Setup(PHCompositeNode *topNode)
   if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
     return Fun4AllReturnCodes::ABORTEVENT;
   
+  m_seed = PHRandomSeed();
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -405,15 +407,9 @@ std::vector<SvtxTrack*> PHActsInitialVertexFinder::sortTracks()
   /// a centroid based on which they are closest to, and then iterate
   /// to update clusters and centroids
   
-  recoConsts *rc = recoConsts::instance();
-
   std::random_device seed;
-  std::mt19937 random_number_generator(seed());  
-  if(rc->FlagExist("RANDOMSEED"))
-    {
-      auto sphenixSeed = rc->get_IntFlag("RANDOMSEED");
-      random_number_generator.seed(sphenixSeed);
-    }
+  std::mt19937 random_number_generator;  
+  random_number_generator.seed(m_seed);
 
   std::vector<float> centroids(m_nCentroids);
   std::uniform_int_distribution<int> indices(0,m_trackMap->size() - 1);

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -7,6 +7,7 @@
 #include <phool/PHObject.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
+#include <phool/recoConsts.h>
 
 #if __cplusplus < 201402L
 #include <boost/make_unique.hpp>
@@ -69,20 +70,31 @@ int PHActsInitialVertexFinder::Process(PHCompositeNode *topNode)
     std::cout << "PHActsInitialVertexFinder processing event " 
 	      << m_event << std::endl;
 
-  InitKeyMap keyMap;
-  auto trackPointers = getTrackPointers(keyMap);
 
-  auto vertices = findVertices(trackPointers);
-
-  fillVertexMap(vertices, keyMap);
-
-  /// Need to check that silicon stubs which may have been
-  /// skipped over still have a vertex association
-  checkTrackVertexAssociation();
-
-  for(auto track : trackPointers)
+  if(m_trackMap->size() == 0)
     {
-      delete track;
+      std::cout << PHWHERE 
+		<< "No silicon track seeds found. Can't run initial vertexing, setting dummy vertex of (0,0,0)" 
+		<< std::endl;
+      createDummyVertex();
+    }
+  else
+    {
+      InitKeyMap keyMap;
+      auto trackPointers = getTrackPointers(keyMap);
+      
+      auto vertices = findVertices(trackPointers);
+      
+      fillVertexMap(vertices, keyMap);
+      
+      /// Need to check that silicon stubs which may have been
+      /// skipped over still have a vertex association
+      checkTrackVertexAssociation();
+      
+      for(auto track : trackPointers)
+	{
+	  delete track;
+	}
     }
 
   if(Verbosity() > 0)
@@ -393,9 +405,17 @@ std::vector<SvtxTrack*> PHActsInitialVertexFinder::sortTracks()
   /// a centroid based on which they are closest to, and then iterate
   /// to update clusters and centroids
   
-  std::vector<float> centroids(m_nCentroids);
+  recoConsts *rc = recoConsts::instance();
+
   std::random_device seed;
-  std::mt19937 random_number_generator(seed());
+  std::mt19937 random_number_generator(seed());  
+  if(rc->FlagExist("RANDOMSEED"))
+    {
+      auto sphenixSeed = rc->get_IntFlag("RANDOMSEED");
+      random_number_generator.seed(sphenixSeed);
+    }
+
+  std::vector<float> centroids(m_nCentroids);
   std::uniform_int_distribution<int> indices(0,m_trackMap->size() - 1);
   std::vector<int> usedIndices;
 
@@ -591,6 +611,14 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
 {
   TrackParamVec tracks;
 
+  /// If there are fewer tracks than centroids, just one with 1 centroid
+  /// Otherwise algorithm does not converge. nCentroids should only be
+  /// a handful, so this only affects small nTrack events.
+  if(m_trackMap->size() < m_nCentroids) 
+    {
+      m_nCentroids = 1;
+    }
+  
   auto sortedTracks = sortTracks();
 
   for(const auto& track : sortedTracks)

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.h
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.h
@@ -99,6 +99,8 @@ class PHActsInitialVertexFinder: public PHInitVertexing
   unsigned int m_totVertexFits = 0;
   unsigned int m_successFits = 0;
 
+  unsigned int m_seed = 0;
+
   std::string m_svtxTrackMapName = "SvtxSiliconTrackMap";
   std::string m_svtxVertexMapName = "SvtxVertexMap";
 


### PR DESCRIPTION
Add catch for nTracks < nCentroids

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR fixes a few issues in the Acts::IVF:

1. It adds a catch for the case where there are no silicon seeds produced. In this case, the IVF returns a dummy vertex of (0,0,0)
2.  It adds a catch for the case where the number of silicon tracks is less than the number of centroids in the initial silicon stub cleaning algorithm. In this case, the number of centroids is just set to 1. This only occurs when there are a small number of tracks (i.e. less than 5).
3. It updates the random number generator used in the centroid clustering algorithm to use that of the `RANDOMSEED` flag, so that results are reproducible if a random seed is set at the top most macro level.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

