### PR TITLE
Add additional track sources to event evaluator

### DIFF
--- a/simulation/g4simulation/g4eval/EventEvaluator.cc
+++ b/simulation/g4simulation/g4eval/EventEvaluator.cc
@@ -188,6 +188,7 @@ EventEvaluator::EventEvaluator(const string& name, const string& filename)
   , _track_py(0)
   , _track_pz(0)
   , _track_trueID(0)
+  , _track_source(0)
   , _nProjections(0)
   , _track_ProjTrackID(0)
   , _track_ProjLayer(0)
@@ -313,6 +314,7 @@ EventEvaluator::EventEvaluator(const string& name, const string& filename)
   _track_px = new float[_maxNTracks];
   _track_py= new float[_maxNTracks];
   _track_pz = new float[_maxNTracks];
+  _track_source = new unsigned short[_maxNTracks];
   _track_ProjTrackID = new float[_maxNProjections];
   _track_ProjLayer = new int[_maxNProjections];
   _track_TLP_x = new float[_maxNProjections];
@@ -357,6 +359,7 @@ int EventEvaluator::Init(PHCompositeNode* topNode)
     _event_tree->Branch("tracks_py", _track_py, "tracks_py[nTracks]/F");
     _event_tree->Branch("tracks_pz", _track_pz, "tracks_pz[nTracks]/F");
     _event_tree->Branch("tracks_trueID", _track_trueID, "tracks_trueID[nTracks]/F");
+    _event_tree->Branch("tracks_source", _track_source, "tracks_source[nTracks]/s");
   }
   if(_do_PROJECTIONS){
     _event_tree->Branch("nProjections", &_nProjections, "nProjections/I");
@@ -1575,85 +1578,97 @@ void EventEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
   if(_do_TRACKS){
     _nTracks = 0;
     _nProjections = 0;
-    SvtxTrackMap* trackmap = findNode::getClass<SvtxTrackMap>(topNode, "TrackMap");
-    if (trackmap)
-    {
-      if (Verbosity() > 0){ cout << "saving tracks" << endl;}
-      for (SvtxTrackMap::ConstIter track_itr = trackmap->begin(); track_itr != trackmap->end(); track_itr++)
+    // Loop over track maps, identifiy each source.
+    // Although this configuration is fixed here, it doesn't require multiple sources.
+    // It will only store them if they're available.
+    std::vector<std::pair<std::string, TrackSource_t>> trackMapInfo = {
+        {"TrackMap", TrackSource_t::all},
+        {"TrackMapInner", TrackSource_t::inner}
+    };
+    for (const auto & trackMapInfo : trackMapInfo) {
+      SvtxTrackMap* trackmap = findNode::getClass<SvtxTrackMap>(topNode, trackMapInfo.first);
+      if (trackmap)
       {
-        SvtxTrack_FastSim* track = dynamic_cast<SvtxTrack_FastSim*>(track_itr->second);
-        if (track)
+        int nTracksInASource = 0;
+        if (Verbosity() > 0){ cout << "saving tracks for track map: " << trackMapInfo.first << endl;}
+        for (SvtxTrackMap::ConstIter track_itr = trackmap->begin(); track_itr != trackmap->end(); track_itr++)
         {
-          _track_ID[_nTracks] = track->get_id();
-          _track_px[_nTracks] = track->get_px();
-          _track_py[_nTracks] = track->get_py();
-          _track_pz[_nTracks] = track->get_pz();
-          _track_trueID[_nTracks] = track->get_truth_track_id();
-          if(_do_PROJECTIONS){
-            // find projections
-            for (SvtxTrack::ConstStateIter trkstates = track->begin_states(); trkstates != track->end_states(); ++trkstates)
-            {
-              if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " processing " << trkstates->second->get_name() << endl;}
-              string trackStateName = trkstates->second->get_name();
-              if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " found " << trkstates->second->get_name() << endl;}
-              int trackStateIndex = GetProjectionIndex(trackStateName);
-              if (trackStateIndex > -1)
+          SvtxTrack_FastSim* track = dynamic_cast<SvtxTrack_FastSim*>(track_itr->second);
+          if (track)
+          {
+            _track_ID[_nTracks] = track->get_id();
+            _track_px[_nTracks] = track->get_px();
+            _track_py[_nTracks] = track->get_py();
+            _track_pz[_nTracks] = track->get_pz();
+            _track_trueID[_nTracks] = track->get_truth_track_id();
+            _track_source[_nTracks] = static_cast<unsigned short>(trackMapInfo.second);
+            if(_do_PROJECTIONS){
+              // find projections
+              for (SvtxTrack::ConstStateIter trkstates = track->begin_states(); trkstates != track->end_states(); ++trkstates)
               {
-                // save true projection info to given branch
-                _track_TLP_true_x[_nProjections] = trkstates->second->get_pos(0);
-                _track_TLP_true_y[_nProjections] = trkstates->second->get_pos(1);
-                _track_TLP_true_z[_nProjections] = trkstates->second->get_pos(2);
-                _track_TLP_true_t[_nProjections] = trkstates->first;
-                _track_ProjLayer[_nProjections] = trackStateIndex;
-                _track_ProjTrackID[_nProjections] = _nTracks;
-
-                string nodename = "G4HIT_" + trkstates->second->get_name();
-                PHG4HitContainer* hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
-                if (hits)
+                if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " processing " << trkstates->second->get_name() << endl;}
+                string trackStateName = trkstates->second->get_name();
+                if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " found " << trkstates->second->get_name() << endl;}
+                int trackStateIndex = GetProjectionIndex(trackStateName);
+                if (trackStateIndex > -1)
                 {
-                  if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " number of hits: " << hits->size() << endl;}
-                  PHG4HitContainer::ConstRange hit_range = hits->getHits();
-                  for (PHG4HitContainer::ConstIterator hit_iter = hit_range.first; hit_iter != hit_range.second; hit_iter++)
+                  // save true projection info to given branch
+                  _track_TLP_true_x[_nProjections] = trkstates->second->get_pos(0);
+                  _track_TLP_true_y[_nProjections] = trkstates->second->get_pos(1);
+                  _track_TLP_true_z[_nProjections] = trkstates->second->get_pos(2);
+                  _track_TLP_true_t[_nProjections] = trkstates->first;
+                  _track_ProjLayer[_nProjections] = trackStateIndex;
+                  _track_ProjTrackID[_nProjections] = _nTracks;
+
+                  string nodename = "G4HIT_" + trkstates->second->get_name();
+                  PHG4HitContainer* hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
+                  if (hits)
                   {
-                    if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " checking hit id " << hit_iter->second->get_trkid() << " against " << track->get_truth_track_id() << endl;}
-                    if (hit_iter->second->get_trkid() - track->get_truth_track_id() == 0)
+                    if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " number of hits: " << hits->size() << endl;}
+                    PHG4HitContainer::ConstRange hit_range = hits->getHits();
+                    for (PHG4HitContainer::ConstIterator hit_iter = hit_range.first; hit_iter != hit_range.second; hit_iter++)
                     {
-                      if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " found hit with id " << hit_iter->second->get_trkid() << endl;}
-                      // save reco projection info to given branch
-                      _track_TLP_x[_nProjections] = hit_iter->second->get_x(0);
-                      _track_TLP_y[_nProjections] = hit_iter->second->get_y(0);
-                      _track_TLP_z[_nProjections] = hit_iter->second->get_z(0);
-                      _track_TLP_t[_nProjections] = hit_iter->second->get_t(0);
+                      if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " checking hit id " << hit_iter->second->get_trkid() << " against " << track->get_truth_track_id() << endl;}
+                      if (hit_iter->second->get_trkid() - track->get_truth_track_id() == 0)
+                      {
+                        if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " found hit with id " << hit_iter->second->get_trkid() << endl;}
+                        // save reco projection info to given branch
+                        _track_TLP_x[_nProjections] = hit_iter->second->get_x(0);
+                        _track_TLP_y[_nProjections] = hit_iter->second->get_y(0);
+                        _track_TLP_z[_nProjections] = hit_iter->second->get_z(0);
+                        _track_TLP_t[_nProjections] = hit_iter->second->get_t(0);
+                      }
                     }
                   }
+                  else
+                  {
+                    if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " could not find " << nodename << endl;}
+                    continue;
+                  }
+                  _nProjections++;
                 }
-                else
-                {
-                  if (Verbosity() > 1){ cout << __PRETTY_FUNCTION__ << " could not find " << nodename << endl;}
-                  continue;
-                }
-                _nProjections++;
               }
             }
+            _nTracks++;
+            nTracksInASource++;
           }
-          _nTracks++;
-        }
-        else
-        {
-          if (Verbosity() > 0)  //Verbosity()
+          else
           {
-            cout << "PHG4TrackFastSimEval::fill_track_tree - ignore track that is not a SvtxTrack_FastSim:";
-            track_itr->second->identify();
+            if (Verbosity() > 0)  //Verbosity()
+            {
+              cout << "PHG4TrackFastSimEval::fill_track_tree - ignore track that is not a SvtxTrack_FastSim:";
+              track_itr->second->identify();
+            }
+            continue;
           }
-          continue;
         }
+        if (Verbosity() > 0){ cout << "saved\t" << nTracksInASource << "\ttracks from track map " << trackMapInfo.first << ". Total saved tracks: " << _nTracks << endl;}
       }
-      if (Verbosity() > 0){ cout << "saved\t" << _nTracks << "\ttracks" << endl;}
-    }
-    else
-    {
-      if (Verbosity() > 0){ cout << PHWHERE << "SvtxTrackMap node with name TrackMap not found on node tree" << endl;}
-      return;
+      else
+      {
+        if (Verbosity() > 0){ cout << PHWHERE << "SvtxTrackMap node with name '" << trackMapInfo.first << "' not found on node tree" << endl;}
+        return;
+      }
     }
   }
   //------------------------
@@ -2043,6 +2058,7 @@ void EventEvaluator::resetBuffer()
       _track_px[itrk] = 0;
       _track_py[itrk] = 0;
       _track_pz[itrk] = 0;
+      _track_source[itrk] = 0;
     }
     if(_do_PROJECTIONS){
       _nProjections = 0;

--- a/simulation/g4simulation/g4eval/EventEvaluator.h
+++ b/simulation/g4simulation/g4eval/EventEvaluator.h
@@ -29,6 +29,11 @@ class TTree;  //Added by Barak
 class EventEvaluator : public SubsysReco
 {
  public:
+  enum class TrackSource_t: unsigned short {
+      all = 0,
+      inner = 1
+  };
+
   EventEvaluator(const std::string& name = "EventEvaluator",
                  const std::string& filename = "g4eval_cemc.root");
   virtual ~EventEvaluator(){};
@@ -209,6 +214,7 @@ private:
   float* _track_py;
   float* _track_pz;
   float* _track_trueID;
+  unsigned short* _track_source;
 
   int _nProjections;
   float* _track_ProjTrackID;


### PR DESCRIPTION
This enables storing the tracking output from multiple sources of tracks
in the event evaluator (say, running the tracking twice with different
parameters). The tracks are stored in one collection, and then
differentiated by a source ID. The user then needs to differentiate the
sources. However, if there is only one collection of tracks, then the
source can be ignored

@FriederikeBock 

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

