### PR TITLE
Fix trkr hit set container

### DIFF
--- a/offline/packages/trackbase/TrkrCluster.h
+++ b/offline/packages/trackbase/TrkrCluster.h
@@ -83,7 +83,7 @@ class TrkrCluster : public PHObject
   virtual void setSubSurfKey(TrkrDefs::subsurfkey id) {}
 
  protected:
-  TrkrCluster() {}
+  TrkrCluster() = default;
   ClassDef(TrkrCluster, 1)
 };
 

--- a/offline/packages/trackbase/TrkrClusterContainer.h
+++ b/offline/packages/trackbase/TrkrClusterContainer.h
@@ -34,9 +34,6 @@ class TrkrClusterContainer : public PHObject
   using ConstRange = std::pair<ConstIterator, ConstIterator>;
   //@}
 
-  //! constructor
-  TrkrClusterContainer() = default;
-
   //! reset method
   virtual void Reset() {}
 
@@ -72,6 +69,10 @@ class TrkrClusterContainer : public PHObject
 
   //! total number of clusters
   virtual unsigned int size() const { return 0; }
+
+  protected:
+  //! constructor
+  TrkrClusterContainer() = default;
 
   private:
 

--- a/offline/packages/trackbase/TrkrClusterHitAssoc.h
+++ b/offline/packages/trackbase/TrkrClusterHitAssoc.h
@@ -29,8 +29,6 @@ public:
   using ConstIterator = Map::const_iterator;
   using ConstRange = std::pair<Map::const_iterator, Map::const_iterator>;
   
-  TrkrClusterHitAssoc() = default;
-
   virtual void Reset() = 0;
 
   virtual void identify(std::ostream &os = std::cout) const = 0;
@@ -54,6 +52,9 @@ public:
   virtual ConstRange getHits(TrkrDefs::cluskey) = 0;
 
   virtual unsigned int size() const {return 0;}
+
+protected:
+  TrkrClusterHitAssoc() = default;
 
 private:
 

--- a/offline/packages/trackbase/TrkrHitSet.h
+++ b/offline/packages/trackbase/TrkrHitSet.h
@@ -34,9 +34,6 @@ class TrkrHitSet : public PHObject
   using ConstIterator = Map::const_iterator;
   using ConstRange = std::pair<ConstIterator, ConstIterator>;
 
-  //! ctor
-  TrkrHitSet() = default;
-
   //! TObject functions
   virtual void identify(std::ostream& os = std::cout) const
   {
@@ -109,6 +106,12 @@ class TrkrHitSet : public PHObject
     return 0;
   }
 
+  protected:
+
+  //! ctor, not to be called
+  TrkrHitSet() = default;
+
+private:
   ClassDef(TrkrHitSet, 1);
 };
 

--- a/offline/packages/trackbase/TrkrHitSetContainer.h
+++ b/offline/packages/trackbase/TrkrHitSetContainer.h
@@ -30,9 +30,6 @@ class TrkrHitSetContainer : public PHObject
   using Range = std::pair<Iterator, Iterator>;
   using ConstRange = std::pair<ConstIterator, ConstIterator>;
 
-  //! ctor
-  TrkrHitSetContainer() = default;
-  
   //! dtir
   virtual ~TrkrHitSetContainer() = default;
 
@@ -72,8 +69,12 @@ class TrkrHitSetContainer : public PHObject
   virtual TrkrHitSet *findHitSet(TrkrDefs::hitsetkey)
   { return nullptr; }
 
-  unsigned int size() const
+  virtual unsigned int size() const
   { return 0; }
+
+  protected:
+  //! ctor
+  TrkrHitSetContainer() = default;
 
   private:
 

--- a/offline/packages/trackbase/TrkrHitTruthAssoc.h
+++ b/offline/packages/trackbase/TrkrHitTruthAssoc.h
@@ -34,9 +34,6 @@ class TrkrHitTruthAssoc : public PHObject
   using Range = std::pair<Iterator, Iterator>;
   using ConstRange = std::pair<ConstIterator, ConstIterator>;
 
-  //! ctor                                                                                                                                                                                                  
-  TrkrHitTruthAssoc() = default;  
-  
   virtual void Reset() 
   {}
 
@@ -72,8 +69,12 @@ class TrkrHitTruthAssoc : public PHObject
   virtual void getG4Hits(const TrkrDefs::hitsetkey hitsetkey, const unsigned int hidx, MMap &temp_map) const
   {}
 
+  protected:
+  //! ctor
+  TrkrHitTruthAssoc() = default;
+
   private:
-  
+
   ClassDef(TrkrHitTruthAssoc, 1);
 
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
The TrkrHitSetContainer base class size() method was not virtual which prevented the derived classes from implementing it. There is a way to use the override keyword without triggering warnings from the ClassDef macro by using the ClassDefOverride macro instead
[https://root-forum.cern.ch/t/annoying-warnings-using-c-11-14/20891/2]. This turns the problem around since now one gets warnings from PHObject. If we ever do this it needs to be implemented all at one
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

