### PR TITLE
Changes to enable second pass tracking

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -86,6 +86,8 @@ class MakeActsGeometry : public SubsysReco
   double getSurfStepPhi() {return m_surfStepPhi;}
   double getSurfStepZ() {return m_surfStepZ;}
 
+  void add_fake_surfaces(bool add){fake_surfaces = add;}
+
  private:
   /// Main function to build all acts geometry for use in the fitting modules
   int buildAllGeometry(PHCompositeNode *topNode);
@@ -218,7 +220,7 @@ class MakeActsGeometry : public SubsysReco
   double m_magFieldRescale = -1.;
 
   bool m_buildMMs = false;
-
+  bool fake_surfaces = true;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -878,9 +878,6 @@ int PHActsTrkFitter::getNodes(PHCompositeNode* topNode)
 		<< std::endl;
       return Fun4AllReturnCodes::ABORTEVENT;
     }
-  std::cout << "Grabbing map"<<std::endl;
-  for(const auto& [key,track] : *m_trackMap)
-    track->identify();
 
   return Fun4AllReturnCodes::EVENT_OK;
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR enables a second pass of the tracking to be run on the output file from a first pass. Because we are not able to write out Acts surface objects, we have to make the clusterSurfaceMaps in the second pass by running MakeActsGeometry in that pass too. These changes are required so that the fake surfaces for the TPC and Micromegas are not added to the geometry a second time, before the clusterSurfaceMaps are made in the second pass.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

